### PR TITLE
fix(workflow): match resource triggers on both entity keyspaces

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -155,6 +155,7 @@
     "react-resizable-panels": "^2.1.7",
     "react-select": "^5.10.0",
     "recharts": "^2.15.4",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "server-only": "catalog:",
     "sharp": "catalog:",

--- a/apps/web/src/components/workflow/hooks/use-workflow-save.ts
+++ b/apps/web/src/components/workflow/hooks/use-workflow-save.ts
@@ -151,7 +151,11 @@ export const useWorkflowSave = () => {
         resolveTriggerType: (nodeType) => unifiedNodeRegistry.getDefinition(nodeType)?.triggerType,
       })
       const triggerType = derived.triggerType ?? workflow.triggerType
-      const entityDefinitionId = derived.entityDefinitionId
+      // `null`, not `undefined` — the service only writes the column when the
+      // key is not `undefined`, so posting `undefined` for a graph that no
+      // longer has a resource trigger left the OLD entity id on the row next
+      // to the new trigger type. `null` is the explicit clear.
+      const entityDefinitionId = derived.entityDefinitionId ?? null
 
       payload.graph = { nodes: cleanNodes, edges: cleanEdges, viewport: { x, y, zoom } }
       payload.triggerType = triggerType

--- a/apps/web/src/components/workflow/nodes/core/ai/trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/core/ai/trace-renderer.tsx
@@ -4,6 +4,7 @@
 
 import { Sparkles, TriangleAlert } from 'lucide-react'
 import Markdown from 'react-markdown'
+import remarkBreaks from 'remark-breaks'
 import remarkGfm from 'remark-gfm'
 import { BlockCard } from '~/components/kopilot/ui/blocks/block-card'
 import { CollapsedJson, FieldRows } from '~/components/workflow/nodes/shared/trace-primitives'
@@ -71,7 +72,9 @@ export function AiTraceRenderer({ execution }: TraceRendererProps) {
         ) : (
           outputs.text && (
             <div className='prose prose-sm dark:prose-invert max-w-none text-sm'>
-              <Markdown remarkPlugins={[remarkGfm]}>{outputs.text}</Markdown>
+              {/* remarkBreaks: single newlines are soft breaks in markdown and
+                  would collapse to spaces — see the End trace renderer. */}
+              <Markdown remarkPlugins={[remarkGfm, remarkBreaks]}>{outputs.text}</Markdown>
             </div>
           )
         )}

--- a/apps/web/src/components/workflow/nodes/core/end/trace-renderer.tsx
+++ b/apps/web/src/components/workflow/nodes/core/end/trace-renderer.tsx
@@ -6,6 +6,7 @@ import type { ContentSegment, WorkflowFileData } from '@auxx/lib/workflow-engine
 import { Badge } from '@auxx/ui/components/badge'
 import { Flag, Paperclip } from 'lucide-react'
 import Markdown from 'react-markdown'
+import remarkBreaks from 'remark-breaks'
 import remarkGfm from 'remark-gfm'
 import { BlockCard } from '~/components/kopilot/ui/blocks/block-card'
 import { TraceRawJson } from '~/components/workflow/panels/run/components/trace-render-boundary'
@@ -55,9 +56,15 @@ export function EndTraceRenderer({ execution }: TraceRendererProps) {
       secondaryText={badge}
       hasFooter={false}>
       <div className='space-y-2 p-1'>
+        {/* `remarkBreaks` renders a single newline as a <br>. Without it the
+            markdown soft break survives into the DOM as a literal "\n" that
+            `white-space: normal` collapses to a space, so a multi-line
+            completion message reads as one run-on line — while the same text in
+            the Outputs tab (a <pre>) and in the share view
+            (`whitespace-pre-wrap`) shows its line breaks. */}
         {outputs.message && (
           <div className='prose prose-sm dark:prose-invert max-w-none text-sm'>
-            <Markdown remarkPlugins={[remarkGfm]}>{outputs.message}</Markdown>
+            <Markdown remarkPlugins={[remarkGfm, remarkBreaks]}>{outputs.message}</Markdown>
           </div>
         )}
         {files.length > 0 && (

--- a/packages/lib/src/cache/accessor-map.ts
+++ b/packages/lib/src/cache/accessor-map.ts
@@ -100,7 +100,10 @@ export interface CustomFieldGroupAccessor extends ArrayAccessor<CustomFieldEntit
 /** WorkflowApps accessor — ArrayAccessor + trigger matching + list view sugar methods */
 export interface WorkflowAppsAccessor extends ArrayAccessor<CachedWorkflowApp> {
   /** Find enabled apps matching trigger criteria */
-  byTrigger(triggerType: string, entityDefinitionId?: string): Promise<CachedWorkflowApp[]>
+  byTrigger(
+    triggerType: string,
+    entityDefinitionIds?: readonly string[]
+  ): Promise<CachedWorkflowApp[]>
   /** Find enabled app by ID */
   byAppId(workflowAppId: string): Promise<CachedWorkflowApp | null>
   /** Find enabled apps matching app trigger fields */

--- a/packages/lib/src/cache/canonicalize-entity-definition-id.test.ts
+++ b/packages/lib/src/cache/canonicalize-entity-definition-id.test.ts
@@ -1,0 +1,60 @@
+// packages/lib/src/cache/canonicalize-entity-definition-id.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { canonicalizeEntityDefinitionId } from './org-cache-helpers'
+
+const ORG = 'org_1'
+const TICKET_DEF = 'i5aezsg4bc6n8gof2uan3wcf'
+
+/**
+ * The entityDefs cache maps entityType → id for EVERY EntityDefinition row
+ * (`entity-defs-provider.ts`), which in a real org includes `thread` and
+ * `article`. That is the whole point of these tests: the cache resolving a
+ * value must NOT be what decides whether it gets rewritten.
+ */
+const ENTITY_DEFS: Record<string, string> = {
+  ticket: TICKET_DEF,
+  contact: 'mzxt3cxyzhm3cbtgcbpmeir1',
+  thread: 'thread_def_cuid',
+  article: 'article_def_cuid',
+}
+
+const get = vi.fn(async () => ENTITY_DEFS)
+
+vi.mock('./singletons', () => ({
+  getOrgCache: () => ({ get }),
+}))
+
+describe('canonicalizeEntityDefinitionId', () => {
+  beforeEach(() => {
+    get.mockClear()
+  })
+
+  it.each(['ticket', 'contact'])('resolves the tier-B slug %s to the org id', async (slug) => {
+    expect(await canonicalizeEntityDefinitionId(ORG, slug)).toBe(ENTITY_DEFS[slug])
+  })
+
+  it.each([
+    'thread',
+    'article',
+  ])('leaves the tier-A slug %s alone even though the cache resolves it', async (slug) => {
+    // Regression guard for the trap that broke earlier attempts at this fix:
+    // `thread`/`article` have EntityDefinition rows in every org, but they are
+    // table-backed system resources whose ids stay slug-keyed everywhere
+    // (`thread:<id>` RecordIds), because canonicalization is gated on
+    // `isEntityDefinitionType`. Normalizing on "the cache resolved it" would
+    // rewrite them and break every reference that works today.
+    expect(await canonicalizeEntityDefinitionId(ORG, slug)).toBe(slug)
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  it('passes a CUID through untouched without reading the cache', async () => {
+    expect(await canonicalizeEntityDefinitionId(ORG, TICKET_DEF)).toBe(TICKET_DEF)
+    expect(get).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the slug when the org has no definition for it', async () => {
+    get.mockResolvedValueOnce({})
+    expect(await canonicalizeEntityDefinitionId(ORG, 'ticket')).toBe('ticket')
+  })
+})

--- a/packages/lib/src/cache/index.ts
+++ b/packages/lib/src/cache/index.ts
@@ -51,6 +51,7 @@ export {
 export type { CacheEvent } from './invalidation-graph'
 // ── Cache Helpers ──
 export {
+  canonicalizeEntityDefinitionId,
   findCachedResource,
   getAllCachedAgents,
   getAllCachedCustomFields,

--- a/packages/lib/src/cache/org-cache-helpers.ts
+++ b/packages/lib/src/cache/org-cache-helpers.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/cache/org-cache-helpers.ts
 
 import type { CustomFieldEntity } from '@auxx/database/types'
+import { isEntityDefinitionType } from '@auxx/types/resource'
 import type { KbCatalogEntry } from '../kb/catalog/kb-catalog'
 import type { CachedMailFilter } from '../mail-filters/types'
 import type { CachedPermissionProfile } from '../permissions/profiles/types'
@@ -136,6 +137,33 @@ export async function getCachedEntityDefId(
 ): Promise<string | undefined> {
   const entityDefs = await getOrgCache().get(orgId, 'entityDefs')
   return entityDefs[entityType]
+}
+
+/**
+ * Normalize an `entityDefinitionId` value to the org's EntityDefinition id,
+ * tolerating either keyspace this column is written in.
+ *
+ * Values arrive in two forms: the per-org CUID (what the resource picker,
+ * `toCustomResourceBase` and `toRecordId` write) and, for the legacy
+ * `ticket:*` / `contact:*` event family, the bare entityType slug — those
+ * events are the only ones whose payload omits the definition id. Every
+ * consumer compares with strict equality, so an unnormalized slug matches
+ * nothing and the trigger silently never fires.
+ *
+ * The gate is `isEntityDefinitionType`, **not** "the entityDefs cache resolved
+ * it": `thread` and `article` have an EntityDefinition row in every org but are
+ * table-backed system resources that stay slug-keyed everywhere (`thread:<id>`
+ * RecordIds), because canonicalization is gated on the same predicate.
+ * Resolving those would break references that work today.
+ *
+ * A CUID, a tier-A slug, or an unresolvable value is returned unchanged.
+ */
+export async function canonicalizeEntityDefinitionId(
+  orgId: string,
+  value: string
+): Promise<string> {
+  if (!isEntityDefinitionType(value)) return value
+  return (await getCachedEntityDefId(orgId, value)) ?? value
 }
 
 /**

--- a/packages/lib/src/cache/providers/workflow-apps-provider.ts
+++ b/packages/lib/src/cache/providers/workflow-apps-provider.ts
@@ -150,16 +150,24 @@ export const workflowAppsProvider = {
 
     return Object.assign(accessor, {
       /** Find enabled apps matching trigger criteria */
+      /**
+       * `entityDefinitionIds` is a set, not a single value: the column holds the
+       * org's EntityDefinition CUID on some rows and the bare entityType slug on
+       * others, and a workflow saved either way must keep firing. Callers pass
+       * every accepted form — see `ResourceTriggerMatch.matchIds`.
+       */
       async byTrigger(
         triggerType: string,
-        entityDefinitionId?: string
+        entityDefinitionIds?: readonly string[]
       ): Promise<CachedWorkflowApp[]> {
         const data = await dataFn()
         return data.filter(
           (app) =>
             app.enabled &&
             app.publishedWorkflow?.triggerType === triggerType &&
-            (!entityDefinitionId || app.publishedWorkflow.entityDefinitionId === entityDefinitionId)
+            (!entityDefinitionIds?.length ||
+              (app.publishedWorkflow.entityDefinitionId !== null &&
+                entityDefinitionIds.includes(app.publishedWorkflow.entityDefinitionId)))
         )
       },
 

--- a/packages/lib/src/cache/workflow-app-queries.ts
+++ b/packages/lib/src/cache/workflow-app-queries.ts
@@ -16,15 +16,18 @@ export async function getCachedWorkflowApp(
 
 /**
  * Get all enabled workflow apps matching trigger criteria from cache.
+ *
+ * `entityDefinitionIds` accepts every form the stored column may hold for the
+ * same entity (CUID and entityType slug) — pass `ResourceTriggerMatch.matchIds`.
  */
 export async function getCachedWorkflowAppsByTrigger(params: {
   organizationId: string
   triggerType: string
-  entityDefinitionId?: string
+  entityDefinitionIds?: readonly string[]
 }): Promise<CachedWorkflowApp[]> {
   return getOrgCache()
     .from(params.organizationId, 'workflowApps')
-    .byTrigger(params.triggerType, params.entityDefinitionId)
+    .byTrigger(params.triggerType, params.entityDefinitionIds)
 }
 
 /**

--- a/packages/lib/src/events/handlers/handle-record-rules.ts
+++ b/packages/lib/src/events/handlers/handle-record-rules.ts
@@ -7,31 +7,30 @@
 import { createScopedLogger } from '@auxx/logger'
 import { parseRecordId } from '@auxx/types/resource'
 import type { AuxxEvent } from '../types'
-import { getEventRecordId, getResourceTriggerMatch } from './trigger-resource-workflows'
+import { getEventRecordId, resolveResourceTriggerMatch } from './trigger-resource-workflows'
 
 const logger = createScopedLogger('record-rules-lifecycle')
 
 export const handleRecordRules = async ({ data: event }: { data: AuxxEvent }) => {
   try {
-    const match = getResourceTriggerMatch(event)
-    if (!match || match.triggerType === 'updated') {
-      if (!match) logger.debug('No resource trigger match — skipping', { eventType: event.type })
-      return
-    }
-
     const organizationId = event.data.organizationId
     if (!organizationId) {
       logger.debug('Event has no organizationId — skipping', { eventType: event.type })
       return
     }
 
-    const { getCachedRecordRules, getCachedEntityDefId } = await import('../../cache')
-
     // Legacy-shape events carry an entityType ('ticket'/'contact') where modern
-    // events carry the real definition id — normalize via the entityDefs cache.
-    const entityDefinitionId =
-      (await getCachedEntityDefId(organizationId, match.entityDefinitionId)) ??
-      match.entityDefinitionId
+    // events carry the real definition id; the shared resolver normalizes it.
+    const match = await resolveResourceTriggerMatch(event, organizationId)
+    if (!match || match.triggerType === 'updated') {
+      if (!match) logger.debug('No resource trigger match — skipping', { eventType: event.type })
+      return
+    }
+    // Canonical id for the work below; `matchIds` for filtering stored rows,
+    // which may be keyed by either form.
+    const { entityDefinitionId, matchIds } = match
+
+    const { getCachedRecordRules } = await import('../../cache')
 
     const on = match.triggerType === 'created' ? 'created' : 'deleted'
     const allRules = await getCachedRecordRules(organizationId)
@@ -40,7 +39,7 @@ export const handleRecordRules = async ({ data: event }: { data: AuxxEvent }) =>
         rule.enabled &&
         rule.fieldId === null &&
         rule.on === on &&
-        rule.entityDefinitionId === entityDefinitionId
+        matchIds.includes(rule.entityDefinitionId)
     )
     logger.debug('Lifecycle event matched against cached rules', {
       eventType: event.type,

--- a/packages/lib/src/events/handlers/resolve-resource-trigger-match.test.ts
+++ b/packages/lib/src/events/handlers/resolve-resource-trigger-match.test.ts
@@ -1,0 +1,134 @@
+// packages/lib/src/events/handlers/resolve-resource-trigger-match.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const hoisted = vi.hoisted(() => ({
+  getCachedEntityDefId: vi.fn<(orgId: string, slug: string) => Promise<string | undefined>>(),
+}))
+
+vi.mock('../../cache', () => ({
+  getCachedWorkflowAppsByTrigger: vi.fn(async () => []),
+  // Re-implement the real helper's gate over a mocked cache read so the test
+  // exercises the tier rule rather than the cache plumbing.
+  canonicalizeEntityDefinitionId: async (orgId: string, value: string) => {
+    const { isEntityDefinitionType } = await import('@auxx/types/resource')
+    if (!isEntityDefinitionType(value)) return value
+    return (await hoisted.getCachedEntityDefId(orgId, value)) ?? value
+  },
+}))
+
+const ORG = 'org_1'
+const TICKET_DEF = 'i5aezsg4bc6n8gof2uan3wcf'
+
+// Every org has a `thread` EntityDefinition row, so the cache DOES resolve it —
+// the gate is what must keep it slug-keyed.
+const CACHE: Record<string, string> = {
+  ticket: TICKET_DEF,
+  contact: 'mzxt3cxyzhm3cbtgcbpmeir1',
+  thread: 'thread_def_cuid',
+  article: 'article_def_cuid',
+}
+
+const event = (type: string, data: Record<string, unknown> = {}) =>
+  ({ type, data: { organizationId: ORG, ...data } }) as never
+
+describe('resolveResourceTriggerMatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hoisted.getCachedEntityDefId.mockImplementation(async (_orgId, slug) => CACHE[slug])
+  })
+
+  it('normalizes the legacy ticket slug to the org EntityDefinition id', async () => {
+    const { resolveResourceTriggerMatch } = await import('./trigger-resource-workflows')
+
+    const match = await resolveResourceTriggerMatch(
+      event('ticket:created', { ticketId: 't1' }),
+      ORG
+    )
+
+    // The picker stores the CUID; without this the strict compare in
+    // `byTrigger` / `trigger-agents` never matches and the trigger is dead.
+    expect(match?.entityDefinitionId).toBe(TICKET_DEF)
+  })
+
+  it('keeps the slug in matchIds so slug-keyed rows still fire', async () => {
+    const { resolveResourceTriggerMatch } = await import('./trigger-resource-workflows')
+
+    const match = await resolveResourceTriggerMatch(
+      event('contact:created', { contactId: 'c1' }),
+      ORG
+    )
+
+    // Regression: normalizing ONLY the event side broke a real workflow whose
+    // column held 'contact' — the picker writes
+    // `resource.entityDefinitionId || resourceType`, so both forms exist in
+    // production. Filtering must accept either.
+    expect(match?.matchIds).toEqual(['mzxt3cxyzhm3cbtgcbpmeir1', 'contact'])
+  })
+
+  it('collapses matchIds when there is nothing to normalize', async () => {
+    const { resolveResourceTriggerMatch } = await import('./trigger-resource-workflows')
+
+    const match = await resolveResourceTriggerMatch(
+      event('entity:created', { entityDefinitionId: 'custom_def_cuid' }),
+      ORG
+    )
+
+    expect(match?.matchIds).toEqual(['custom_def_cuid'])
+  })
+
+  it('normalizes contact events too', async () => {
+    const { resolveResourceTriggerMatch } = await import('./trigger-resource-workflows')
+
+    const match = await resolveResourceTriggerMatch(
+      event('contact:deleted', { contactId: 'c1' }),
+      ORG
+    )
+
+    expect(match?.entityDefinitionId).toBe('mzxt3cxyzhm3cbtgcbpmeir1')
+  })
+
+  it('leaves a modern payload entityDefinitionId untouched', async () => {
+    const { resolveResourceTriggerMatch } = await import('./trigger-resource-workflows')
+
+    const match = await resolveResourceTriggerMatch(
+      event('entity:created', { entityDefinitionId: 'custom_def_cuid' }),
+      ORG
+    )
+
+    expect(match?.entityDefinitionId).toBe('custom_def_cuid')
+    expect(hoisted.getCachedEntityDefId).not.toHaveBeenCalled()
+  })
+
+  it('returns null for an event that is not a resource CRUD trigger', async () => {
+    const { resolveResourceTriggerMatch } = await import('./trigger-resource-workflows')
+
+    expect(await resolveResourceTriggerMatch(event('integration:connected'), ORG)).toBeNull()
+  })
+
+  it('falls back to the slug when the org has no definition for it', async () => {
+    hoisted.getCachedEntityDefId.mockResolvedValue(undefined)
+    const { resolveResourceTriggerMatch } = await import('./trigger-resource-workflows')
+
+    const match = await resolveResourceTriggerMatch(
+      event('ticket:created', { ticketId: 't1' }),
+      ORG
+    )
+
+    expect(match?.entityDefinitionId).toBe('ticket')
+  })
+
+  it('leaves a tier-A slug alone even when the org has a definition row for it', async () => {
+    const { resolveResourceTriggerMatch } = await import('./trigger-resource-workflows')
+
+    // `thread` reaches this path only via a hand-written event today, but the
+    // gate is what keeps it slug-keyed — see the dedicated unit test in
+    // `cache/canonicalize-entity-definition-id.test.ts`.
+    const match = await resolveResourceTriggerMatch(
+      event('entity:created', { entityDefinitionId: 'thread' }),
+      ORG
+    )
+
+    expect(match?.entityDefinitionId).toBe('thread')
+  })
+})

--- a/packages/lib/src/events/handlers/trigger-agents.ts
+++ b/packages/lib/src/events/handlers/trigger-agents.ts
@@ -10,8 +10,8 @@ import { parseRecordId } from '../../resources/resource-id'
 import type { AuxxEvent } from '../types'
 import {
   getEventRecordId,
-  getResourceTriggerMatch,
   type ResourceFetcher,
+  resolveResourceTriggerMatch,
 } from './trigger-resource-workflows'
 
 const logger = createScopedLogger('trigger-agents')
@@ -22,7 +22,7 @@ const logger = createScopedLogger('trigger-agents')
  * and enqueue an autonomous agent run for each.
  *
  * Two independent branches:
- *   1. CRUD: reuse `getResourceTriggerMatch` and match by `{triggerType, entityDefinitionId}`.
+ *   1. CRUD: reuse `resolveResourceTriggerMatch` and match by `{triggerType, entityDefinitionId}`.
  *   2. Direct: match by `eventType` literal.
  *
  * The two branches are independent; one event may match both kinds of
@@ -50,8 +50,10 @@ export const dispatchAgentTriggers = async (event: AuxxEvent, fetchResource: Res
   const queue = getQueue(Queues.scheduledTriggerQueue)
   let totalFired = 0
 
-  // CRUD branch
-  const match = getResourceTriggerMatch(event)
+  // CRUD branch. Normalized to the org's EntityDefinition id before the strict
+  // compare below — agent triggers store the picker's CUID, while `ticket:*` /
+  // `contact:*` events report the slug (see `resolveResourceTriggerMatch`).
+  const match = await resolveResourceTriggerMatch(event, organizationId)
   if (match) {
     const crudMatches: Array<{
       agentId: string
@@ -62,7 +64,10 @@ export const dispatchAgentTriggers = async (event: AuxxEvent, fetchResource: Res
       for (const trigger of agent.triggers) {
         if (trigger.kind !== 'event' || !trigger.enabled) continue
         if (trigger.triggerType !== match.triggerType) continue
-        if (trigger.entityDefinitionId !== match.entityDefinitionId) continue
+        // `matchIds`, not the canonical id — agent triggers store the CUID on
+        // some rows and the bare slug on others.
+        if (!trigger.entityDefinitionId || !match.matchIds.includes(trigger.entityDefinitionId))
+          continue
         crudMatches.push({
           agentId: agent.id,
           triggerId: trigger.id,

--- a/packages/lib/src/events/handlers/trigger-resource-workflows.ts
+++ b/packages/lib/src/events/handlers/trigger-resource-workflows.ts
@@ -2,7 +2,7 @@
 
 import { createScopedLogger } from '@auxx/logger'
 import { type RecordId, toRecordId } from '@auxx/types/resource'
-import { getCachedWorkflowAppsByTrigger } from '../../cache'
+import { canonicalizeEntityDefinitionId, getCachedWorkflowAppsByTrigger } from '../../cache'
 import { getQueue } from '../../jobs/queues'
 import { Queues } from '../../jobs/queues/types'
 import { fetchResourceById, getRecordIdField } from '../../resources/resource-fetcher'
@@ -14,12 +14,34 @@ export type ResourceTriggerType = 'created' | 'updated' | 'deleted'
 
 export type ResourceTriggerMatch = {
   triggerType: ResourceTriggerType
+  /**
+   * The canonical form — the org's EntityDefinition id where one exists. Use it
+   * for work that needs a single answer (RecordIds, record-rule dispatch).
+   * Do NOT filter stored trigger rows with it; use {@link matchIds}.
+   */
   entityDefinitionId: string
+  /**
+   * Every form a stored trigger row may legitimately hold for this entity:
+   * the canonical id AND the bare entityType slug. Both are in production —
+   * the resource picker writes `resource.entityDefinitionId || resourceType`,
+   * which is the CUID for some paths and the slug for others, and a workflow
+   * saved either way must keep firing. Filter with `matchIds.includes(...)`.
+   */
+  matchIds: readonly string[]
 }
+
+/** What the event alone can say, before the org's definition ids are known. */
+export type RawResourceTriggerMatch = Pick<
+  ResourceTriggerMatch,
+  'triggerType' | 'entityDefinitionId'
+>
 
 /**
  * Resolve which resource CRUD trigger this event maps to. Shared with the
  * agent-trigger dispatcher (see `./trigger-agents.ts`).
+ *
+ * Prefer {@link resolveResourceTriggerMatch} — this reports the legacy family
+ * under its slug, which is only one of the two forms stored triggers use.
  *
  * Modern-shape events (emitted from unified-handler-mutations) carry
  * `entityDefinitionId` directly in the payload — including custom-entity
@@ -28,7 +50,7 @@ export type ResourceTriggerMatch = {
  *
  * Returns null when the event is not a resource CRUD trigger.
  */
-export function getResourceTriggerMatch(event: AuxxEvent): ResourceTriggerMatch | null {
+export function getResourceTriggerMatch(event: AuxxEvent): RawResourceTriggerMatch | null {
   const payload = event.data as Record<string, unknown>
   const payloadEntityDefinitionId =
     typeof payload.entityDefinitionId === 'string' ? payload.entityDefinitionId : undefined
@@ -76,6 +98,48 @@ export function getResourceTriggerMatch(event: AuxxEvent): ResourceTriggerMatch 
 }
 
 /**
+ * Resolve an event to its resource-trigger criteria **in the keyspace triggers
+ * are actually stored in** — the org's EntityDefinition id.
+ *
+ * `getResourceTriggerMatch` reports the legacy `ticket:*`/`contact:*` family
+ * under its slug, because those are the only events whose payload omits
+ * `entityDefinitionId` (`publishEvent`'s perspective branch in
+ * `resources/crud/unified-handler-mutations.ts`). Every writer stores the CUID —
+ * the resource picker via `toCustomResourceBase`, agent triggers, and
+ * `toRecordId(entityDef.id, …)` — and every consumer compares with strict
+ * equality, so an unnormalized slug matches nothing and the trigger silently
+ * never fires.
+ *
+ * `canonicalizeEntityDefinitionId` carries the tier gate — it deliberately
+ * leaves `thread`/`article` alone; see its docblock.
+ *
+ * Both forms are returned, and **filtering must use `matchIds`, not
+ * `entityDefinitionId`**: the column holds the CUID on some rows and the slug on
+ * others (the picker writes `resource.entityDefinitionId || resourceType`), and
+ * normalizing only the event side turns a working slug-keyed trigger into a
+ * dead one. Canonicalizing on save fixes a row the next time it is saved; it
+ * cannot fix the rows already out there.
+ *
+ * The value written as an execution-context key must come from the matched
+ * workflow's OWN stored id, not from here — that is what its graph declared its
+ * `{{node.<id>.field}}` paths against.
+ */
+export async function resolveResourceTriggerMatch(
+  event: AuxxEvent,
+  organizationId: string
+): Promise<ResourceTriggerMatch | null> {
+  const raw = getResourceTriggerMatch(event)
+  if (!raw) return null
+  const canonical = await canonicalizeEntityDefinitionId(organizationId, raw.entityDefinitionId)
+  return {
+    triggerType: raw.triggerType,
+    entityDefinitionId: canonical,
+    matchIds:
+      canonical === raw.entityDefinitionId ? [canonical] : [canonical, raw.entityDefinitionId],
+  }
+}
+
+/**
  * Resolve the RecordId for the event's subject resource.
  *
  * Modern-shape events already carry `recordId`. Legacy events don't —
@@ -115,18 +179,11 @@ export const dispatchResourceWorkflows = async (
   event: AuxxEvent,
   fetchResource: ResourceFetcher
 ) => {
-  // 1. Map event to workflow trigger criteria
-  const match = getResourceTriggerMatch(event)
-  if (!match) {
-    logger.debug('No workflow trigger mapping for event', { eventType: event.type })
-    return
-  }
-  const { triggerType, entityDefinitionId } = match
-
   // A handful of payloads (`integration:connection_failed`) fire before a
   // session is resolved and carry no org id. None of them map to a resource
   // trigger, so this is unreachable today — but workflow lookup is org-scoped
-  // and must never run unscoped.
+  // and must never run unscoped, and the entity normalization below is
+  // per-org, so the check comes first.
   const organizationId = event.data.organizationId
   if (!organizationId) {
     logger.debug('Event has no organizationId; skipping workflow dispatch', {
@@ -135,11 +192,20 @@ export const dispatchResourceWorkflows = async (
     return
   }
 
-  // 2. Query workflows via org cache
+  // 1. Map event to workflow trigger criteria — see `resolveResourceTriggerMatch`.
+  const match = await resolveResourceTriggerMatch(event, organizationId)
+  if (!match) {
+    logger.debug('No workflow trigger mapping for event', { eventType: event.type })
+    return
+  }
+  const { triggerType, entityDefinitionId, matchIds } = match
+
+  // 2. Query workflows via org cache. Match on EVERY form the column may hold —
+  //    a workflow saved with the bare slug must keep firing (see `matchIds`).
   const matchingApps = await getCachedWorkflowAppsByTrigger({
     organizationId,
     triggerType,
-    entityDefinitionId,
+    entityDefinitionIds: matchIds,
   })
 
   const matchingWorkflows = matchingApps
@@ -181,7 +247,12 @@ export const dispatchResourceWorkflows = async (
       workflowAppId: workflow.workflowApp.id,
       workflowId: workflow.publishedWorkflow.id,
       organizationId: event.data.organizationId,
-      entityDefinitionId,
+      // The workflow's OWN stored id, not the event's — the job keys the
+      // trigger's output under this (`resource-trigger-job.ts`), and the graph
+      // declared its `{{node.<id>.field}}` paths against whatever this row
+      // holds. Sending the canonical id to a slug-keyed workflow would fire it
+      // with unresolvable variables.
+      entityDefinitionId: workflow.publishedWorkflow.entityDefinitionId ?? entityDefinitionId,
       resourceData,
       triggerType,
       triggeredAt: new Date().toISOString(),

--- a/packages/lib/src/workflows/create-from-template.ts
+++ b/packages/lib/src/workflows/create-from-template.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/workflows/create-from-template.ts
 
+import { deriveTriggerColumns } from '../workflow-engine/catalog/derive-trigger'
 import { TemplateGraphTransformer } from './template-graph-transformer'
 import {
   checkEntityReadiness,
@@ -72,10 +73,30 @@ export async function buildTemplateWorkflowData(
     )
   }
 
+  // Derive the entity scoping from the RESOLVED graph rather than carrying the
+  // template's own value across orgs: `resolveEntityRefsInGraph` has just
+  // rewritten the graph's entity refs into this org's ids, so anything the
+  // template row held is either an authoring-org id or stale. `triggerType`
+  // still falls back — templates may use trigger types the catalog cannot see
+  // yet (webhook, app triggers), for which the derivation returns nothing.
+  //
+  // NOTE: `resolveEntityRefsInGraph` currently only rewrites `crud`/`find`
+  // nodes, so a template carrying a `resource-trigger` would still install with
+  // an unresolved ref — no template does today (see 05-resource-model.md §4a.5).
+  const derived = deriveTriggerColumns(
+    ((transformed.graph as { nodes?: unknown[] }).nodes ?? []) as Parameters<
+      typeof deriveTriggerColumns
+    >[0]
+  )
+
   return {
     graph: transformed.graph,
-    triggerType: transformed.triggerType as WorkflowTriggerType | undefined,
-    entityDefinitionId: transformed.entityDefinitionId,
+    triggerType: (derived.triggerType ?? transformed.triggerType) as
+      | WorkflowTriggerType
+      | undefined,
+    entityDefinitionId: derived.entityDefinitionId?.startsWith('@')
+      ? undefined
+      : derived.entityDefinitionId,
     envVars: transformed.envVars,
     variables: transformed.variables,
     // Use the template icon as a fallback when the user didn't choose one

--- a/packages/lib/src/workflows/workflow-service.ts
+++ b/packages/lib/src/workflows/workflow-service.ts
@@ -5,7 +5,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { generateId } from '@auxx/utils/generateId'
 import { and, desc, eq, inArray, sql } from 'drizzle-orm'
 import { onCacheEvent } from '../cache/invalidate'
-import { getCachedResources } from '../cache/org-cache-helpers'
+import { canonicalizeEntityDefinitionId, getCachedResources } from '../cache/org-cache-helpers'
 import { getCachedWorkflowAppsList } from '../cache/workflow-app-queries'
 import { ConflictError, NotFoundError } from '../errors'
 import { getQueue, Queues } from '../jobs/queues'
@@ -192,6 +192,13 @@ export class WorkflowService {
       variables,
     } = input
     const finalTriggerType = triggerType || WorkflowTriggerType.MESSAGE_RECEIVED
+    // This column is written by a dozen callers (builder save, template install,
+    // seed, duplicate, the REST door) and read with strict equality by every
+    // dispatcher. Canonicalize on the way in so the row only ever holds one
+    // keyspace — see `canonicalizeEntityDefinitionId` for the tier-A gate.
+    const finalEntityDefinitionId = entityDefinitionId
+      ? await canonicalizeEntityDefinitionId(organizationId, entityDefinitionId)
+      : entityDefinitionId
 
     logger.info('Creating workflow app', { organizationId, userId, name })
 
@@ -222,7 +229,7 @@ export class WorkflowService {
             name: `${name} (Draft)`,
             description,
             triggerType: finalTriggerType,
-            entityDefinitionId,
+            entityDefinitionId: finalEntityDefinitionId,
             enabled: false, // Draft is always disabled
             organizationId,
             createdById: userId,
@@ -405,6 +412,16 @@ export class WorkflowService {
         rateLimit,
         ...basicUpdateData
       } = updateData
+
+      // Same canonicalization as `create` — one keyspace in the column.
+      // `null` is the explicit clear (the builder posts it when the graph has
+      // no resource trigger); `undefined` still means "leave alone".
+      if (basicUpdateData.entityDefinitionId) {
+        basicUpdateData.entityDefinitionId = await canonicalizeEntityDefinitionId(
+          organizationId,
+          basicUpdateData.entityDefinitionId
+        )
+      }
 
       const result = await this.db.transaction(async (tx: Transaction) => {
         // Update WorkflowApp fields (including share settings)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,7 +539,7 @@ importers:
     devDependencies:
       '@opennextjs/aws':
         specifier: 3.9.15
-        version: 3.9.15(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 3.9.15(next@16.2.10(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.2.1
@@ -739,7 +739,7 @@ importers:
     devDependencies:
       '@opennextjs/aws':
         specifier: 3.9.15
-        version: 3.9.15(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 3.9.15(next@16.2.10(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.1
@@ -1295,6 +1295,9 @@ importers:
       recharts:
         specifier: ^2.15.4
         version: 2.15.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -1367,7 +1370,7 @@ importers:
         version: 15.5.12
       '@opennextjs/aws':
         specifier: 3.9.15
-        version: 3.9.15(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+        version: 3.9.15(next@16.2.10(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@tailwindcss/container-queries':
         specifier: ^0.1.1
         version: 0.1.1(tailwindcss@4.2.1)
@@ -12280,6 +12283,9 @@ packages:
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
+
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
@@ -13783,6 +13789,9 @@ packages:
 
   relay-runtime@12.0.0:
     resolution: {integrity: sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==}
+
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
 
   remark-directive@3.0.1:
     resolution: {integrity: sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==}
@@ -18895,7 +18904,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@opennextjs/aws@3.9.15(next@16.2.10(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@opennextjs/aws@3.9.15(next@16.2.10(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@aws-sdk/client-cloudfront': 3.398.0
@@ -26168,6 +26177,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
+
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -28046,6 +28060,12 @@ snapshots:
       invariant: 2.2.4
     transitivePeerDependencies:
       - encoding
+
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
+      unified: 11.0.5
 
   remark-directive@3.0.1:
     dependencies:


### PR DESCRIPTION
## The bug

A resource trigger on **Ticket** or **Contact** never fired. Custom entities were fine.

`Workflow.entityDefinitionId` and `AgentTrigger.entityDefinitionId` hold **two forms** — the org's EntityDefinition CUID *and* the bare entityType slug. The resource-trigger panel writes `currentResourceData?.entityDefinitionId || resourceType`, so which one lands depends on whether the picker had the resolved resource in hand at write time. Both are in production.

The `ticket:*` / `contact:*` events are the only ones whose payload omits the definition id (`publishEvent`'s perspective branch), so `getResourceTriggerMatch` reports them under the slug. Every consumer then compared with strict equality:

```
saved trigger:  "i5aezsg4bc6n8gof2uan3wcf"
event reports:  "contact"
compare:        false  →  nothing runs, no error, no log line saying why
```

Custom entities were unaffected — their `entity:*` events carry the real id.

## Why "just normalize it" doesn't work

Normalizing the event side alone is a swap, not a fix — it makes CUID-keyed rows fire and kills slug-keyed ones. That was confirmed the hard way against a live workflow whose column held `'contact'`.

So `resolveResourceTriggerMatch` returns both:

- `entityDefinitionId` — canonical, for work needing one answer (RecordIds, record-rule dispatch)
- `matchIds` — every accepted form, and **this is what filters stored rows**

`byTrigger` now takes a list; `trigger-agents` and `handle-record-rules` use `matchIds.includes(...)`. The latter also drops its inline duplicate of the normalization, which was the only place in the codebase that had it.

## Two traps worth flagging in review

**The variable key.** The same value is the execution-context key (`resource-trigger-job.ts:87` → `{ [entityDefinitionId]: resourceData }`). Fixing only the match makes the trigger fire with every `{{node.<id>.field}}` unresolvable. The job now receives the matched workflow's **own stored id** — what its graph declared against.

**Tier A resolves too.** `thread` and `article` have an `EntityDefinition` row in every org (29/29 in dev) but are **not** in `ENTITY_DEFINITION_TYPES`, and their RecordIds stay slug-keyed. So the gate is `isEntityDefinitionType`, **never** "the entityDefs cache resolved it" — the cache resolves `thread` happily, and using that would break the triggers that work today. `canonicalize-entity-definition-id.test.ts` pins exactly this.

## Also included

One-keyspace hygiene, not live bugs:

- canonicalize on write in `WorkflowService.create` / `.update`
- the builder posts `null` instead of `undefined` when a graph has no resource trigger, so switching trigger types **clears** the old scoping instead of leaving it stranded next to the new `triggerType` (the service only writes the column when the key is not `undefined`)
- template install derives its entity from the **resolved** graph rather than copying the template row's own value (latent — `WorkflowTemplate` has no such column and no template carries a resource-trigger node)

## Migration

**None.** Both forms are valid at rest now, so there is no broken state to repair. A tidy-up migration is optional later; `matchIds` should stay either way, since any path that doesn't go through `WorkflowService` can still write a slug.

## Second commit — unrelated, small

`fix(workflow): render newlines in the trace preview`. A multi-line completion message rendered as one run-on line in a node's Preview tab: `react-markdown` treats a single `\n` as a soft break, which survives into the DOM and gets collapsed by `white-space: normal`. The Outputs tab (a `<pre>`) and the share view (`whitespace-pre-wrap`) both showed it correctly. Adds `remark-breaks` to the end and ai trace renderers. Happy to split this out if you'd rather.

## Verification

- ticket/contact triggers confirmed firing end-to-end on a real contact create; the run's inputs land under the key the graph declares
- `vitest src/events src/cache src/workflows src/workflow-engine` — 1327 passed
- `vitest src/components/workflow` (web) — 96 passed
- typecheck ratchet: lib 29/29, web 1/1
- trace preview verified in-browser: `<p>Contact created:<br>First name: …</p>`

## Not in scope

Publish-time re-derivation. `WorkflowVersionService.publish` still copies the draft's columns rather than re-deriving from the graph it publishes — doing that properly needs `deriveTriggerColumns` to cover webhook / webhook-endpoint / app triggers server-side first, otherwise a half-blind derivation would overwrite correct columns for those types.
