### PR TITLE
feat(workflow): let message triggers decide on own-address mail

### DIFF
--- a/apps/web/src/components/workflow/nodes/core/message-received/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/message-received/panel.tsx
@@ -213,6 +213,13 @@ const MessageReceivedPanelComponent: React.FC<MessageReceivedPanelProps> = ({ no
     setNodeData(newData)
   }
 
+  const setOwnAddress = (value: 'exclude' | 'include') => {
+    const newData = produce(nodeData, (draft) => {
+      draft.ownAddress = value
+    })
+    setNodeData(newData)
+  }
+
   return (
     <BasePanel nodeId={nodeId} data={data}>
       <Section
@@ -321,6 +328,33 @@ const MessageReceivedPanelComponent: React.FC<MessageReceivedPanelProps> = ({ no
           </Select>
           <p className='text-xs text-muted-foreground'>
             Bounce and delivery-failure emails never trigger workflows, regardless of this setting.
+          </p>
+        </div>
+      </Section>
+
+      <Section
+        title='Mail from your own channels'
+        description='Controls whether mail sent from one of your connected channel addresses — a teammate writing in from their own mailbox, or a reply arriving on a second channel — can start this workflow.'
+        initialOpen={false}>
+        <div className='space-y-2'>
+          <Select
+            value={nodeData.ownAddress ?? 'include'}
+            onValueChange={(value: 'exclude' | 'include') => setOwnAddress(value)}
+            disabled={isReadOnly}>
+            <SelectTrigger className='w-full'>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value='include'>
+                Also trigger on mail from your own channel addresses
+              </SelectItem>
+              <SelectItem value='exclude'>
+                Skip mail sent from your own channel addresses
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <p className='text-xs text-muted-foreground'>
+            Copies of mail this workflow sent never trigger it again, regardless of this setting.
           </p>
         </div>
       </Section>

--- a/packages/lib/src/channels/__tests__/own-addresses.test.ts
+++ b/packages/lib/src/channels/__tests__/own-addresses.test.ts
@@ -93,4 +93,48 @@ describe('buildOrgOwnEmailAddressSet', () => {
     const set = buildOrgOwnEmailAddressSet([channel({ email: null, metadata: null })])
     expect(set).toEqual(new Set())
   })
+
+  // `excludeInboxIds` exists for message DIRECTION at the SES door: a personal
+  // mailbox's address belongs to a human who also writes mail by hand, so mail
+  // from one arriving at a shared channel is inbound there, not the org
+  // replying to itself. Ingest's `fromOwnAddress` signal passes no exclusions —
+  // it wants the full "is the sender one of ours" answer.
+  describe('excludeInboxIds', () => {
+    it('drops a channel whose inbox is excluded, aliases included', () => {
+      const set = buildOrgOwnEmailAddressSet(
+        [
+          channel({ id: 'shared', email: 'support@company.com', inboxId: 'ibx_shared' }),
+          channel({
+            id: 'personal',
+            email: 'alice@company.com',
+            inboxId: 'ibx_personal',
+            metadata: { userEmails: ['alice.alias@company.com'] },
+          }),
+        ],
+        { excludeInboxIds: new Set(['ibx_personal']) }
+      )
+      expect(set).toEqual(new Set(['support@company.com']))
+    })
+
+    it('keeps every channel when no exclusions are passed', () => {
+      const channels = [
+        channel({ id: 'shared', email: 'support@company.com', inboxId: 'ibx_shared' }),
+        channel({ id: 'personal', email: 'alice@company.com', inboxId: 'ibx_personal' }),
+      ]
+      expect(buildOrgOwnEmailAddressSet(channels)).toEqual(
+        new Set(['support@company.com', 'alice@company.com'])
+      )
+      expect(buildOrgOwnEmailAddressSet(channels, {})).toEqual(
+        new Set(['support@company.com', 'alice@company.com'])
+      )
+    })
+
+    it('keeps an unlinked channel (null inboxId) regardless of the exclusion set', () => {
+      const set = buildOrgOwnEmailAddressSet(
+        [channel({ email: 'orphan@company.com', inboxId: null })],
+        { excludeInboxIds: new Set(['ibx_personal']) }
+      )
+      expect(set).toEqual(new Set(['orphan@company.com']))
+    })
+  })
 })

--- a/packages/lib/src/channels/cache.ts
+++ b/packages/lib/src/channels/cache.ts
@@ -38,16 +38,25 @@ export async function getOrgChannelBidirectionalSyncMap(
 }
 
 /**
- * Org-wide "us" address set — see `buildOrgOwnEmailAddressSet`. Convenience
- * wrapper for callers that don't already hold the `channels` cache rows (e.g.
- * the SES inbound processor, which has no other reason to read this cache).
- * Ingest's own publish gate (`store-message.ts`) reads the `channels` cache
- * directly instead of going through this wrapper, to keep its cache
- * dependency to a single mockable call on the hot path.
+ * Org-wide "us" address set for message DIRECTION — see
+ * `buildOrgOwnEmailAddressSet`. Convenience wrapper for callers that don't
+ * already hold the `channels` cache rows (currently only the SES inbound
+ * processor, which has no other reason to read this cache). Ingest stamps
+ * `fromOwnAddress` from the same builder but reads the `channels` cache
+ * directly, to keep its cache dependency to a single mockable call on the hot
+ * path.
+ *
+ * Personal-inbox channels are EXCLUDED: their addresses belong to a human who
+ * also writes mail by hand, so a message from one arriving at a shared channel
+ * is inbound on that channel, not the org replying to itself.
  */
 export async function getOrgOwnEmailAddresses(organizationId: string): Promise<Set<string>> {
-  const channels = await getOrgCache().get(organizationId, 'channels')
-  return buildOrgOwnEmailAddressSet(channels)
+  const [channels, inboxes] = await Promise.all([
+    getOrgCache().get(organizationId, 'channels'),
+    getOrgCache().get(organizationId, 'inboxes'),
+  ])
+  const personalInboxIds = new Set(inboxes.filter((inbox) => inbox.isPersonal).map((i) => i.id))
+  return buildOrgOwnEmailAddressSet(channels, { excludeInboxIds: personalInboxIds })
 }
 
 /**

--- a/packages/lib/src/channels/own-addresses.ts
+++ b/packages/lib/src/channels/own-addresses.ts
@@ -7,11 +7,22 @@ import type { CachedChannel } from '../cache/providers/channels-provider'
  * primary `email` plus its provider-reported aliases — Outlook
  * `metadata.emailAliases` and Gmail send-as `metadata.userEmails`
  * (`fetchAllUserEmails()`, persisted on the integration). This is the "us"
- * set for the ingest own-address loop guard
- * (`plans/workflow/2026-08-12-message-trigger-scoping-and-send-safety.md`
- * §6 #1): an inbound message whose `From` address is in this set is our own
- * outbound mail echoing back through a different door (a second connected
- * channel, the SES forwarding alias, ...), not real inbound mail.
+ * set: an inbound message whose `From` address is in it was sent from a
+ * mailbox this org has connected.
+ *
+ * Two consumers, two readings — the set answers "is the sender one of ours",
+ * which is NOT the same question as "is this a loop":
+ *  - `store-message.ts` stamps `fromOwnAddress` on the `message:received`
+ *    event and lets each workflow's trigger decide (default: fire). A
+ *    teammate mailing the shared inbox from their own connected mailbox is in
+ *    this set and is perfectly real mail, so membership alone must never
+ *    suppress anything. The loop guard proper is `ownEcho`, which resolves
+ *    `X-AuxxAi-Message-Id` to a row we actually sent.
+ *  - `inbound-email-processor.ts` uses it for SES message DIRECTION, and
+ *    passes `excludeInboxIds` covering the org's personal inboxes: mail from
+ *    a teammate's personal mailbox arriving at a shared channel through the
+ *    forwarding alias is inbound ON THAT CHANNEL, and marking it outbound
+ *    renders it as an org reply in the thread.
  *
  * The SES forwarding address needs no special case — it is itself an
  * `Integration.email` row (provider `email`, `metadata.systemManaged: true`,
@@ -23,9 +34,13 @@ import type { CachedChannel } from '../cache/providers/channels-provider'
  * control the cache-vs-query decision (see `getOrgOwnEmailAddresses` in
  * `./cache.ts` for the cache-backed convenience wrapper).
  */
-export function buildOrgOwnEmailAddressSet(channels: readonly CachedChannel[]): Set<string> {
+export function buildOrgOwnEmailAddressSet(
+  channels: readonly CachedChannel[],
+  options?: { excludeInboxIds?: ReadonlySet<string> }
+): Set<string> {
   const addresses = new Set<string>()
   for (const channel of channels) {
+    if (channel.inboxId && options?.excludeInboxIds?.has(channel.inboxId)) continue
     if (channel.email) addresses.add(channel.email.trim().toLowerCase())
     const metadata = channel.metadata as Record<string, unknown> | null
     addAliasArray(addresses, metadata?.emailAliases) // Outlook proxy addresses

--- a/packages/lib/src/email/inbound/inbound-email-processor.ts
+++ b/packages/lib/src/email/inbound/inbound-email-processor.ts
@@ -127,10 +127,12 @@ export class InboundEmailProcessor {
 
     // Loop-guard plan §6 #2 — SES used to hardcode `isInbound: true` with no
     // sender check at all, so a reply sent on the Gmail or Outlook channel
-    // that re-arrived through this org's forwarding alias published
-    // `message:received` for its own outbound mail. Consult the same
-    // org-wide own-address set the ingest publish gate uses
-    // (`buildOrgOwnEmailAddressSet` / `store-message.ts`) instead.
+    // that re-arrived through this org's forwarding alias was stored as fresh
+    // inbound mail. Consult the org's own-address set instead. This is a
+    // DIRECTION decision, not a loop verdict: `getOrgOwnEmailAddresses`
+    // excludes personal-inbox channels, because a teammate mailing the shared
+    // inbox from their own connected mailbox is genuinely inbound here and
+    // marking it outbound renders it as an org reply in the thread.
     const fromAddress = parsedEmail.from.address.trim().toLowerCase()
     const ownAddresses = await getOrgOwnEmailAddresses(organizationId)
     const isInbound = !ownAddresses.has(fromAddress)

--- a/packages/lib/src/events/handlers/trigger-message-workflows.test.ts
+++ b/packages/lib/src/events/handlers/trigger-message-workflows.test.ts
@@ -38,7 +38,11 @@ const INT_B = 'int_b'
 /** A published workflow app with a MESSAGE_RECEIVED trigger node, optionally channel-scoped. */
 function app(
   id: string,
-  overrides: { channelIds?: string[]; machineMail?: 'include' | 'exclude' } = {}
+  overrides: {
+    channelIds?: string[]
+    machineMail?: 'include' | 'exclude'
+    ownAddress?: 'include' | 'exclude'
+  } = {}
 ) {
   return {
     id: `app_${id}`,
@@ -53,6 +57,7 @@ function app(
               type: 'message-received',
               ...(overrides.channelIds !== undefined && { channelIds: overrides.channelIds }),
               ...(overrides.machineMail !== undefined && { machineMail: overrides.machineMail }),
+              ...(overrides.ownAddress !== undefined && { ownAddress: overrides.ownAddress }),
             },
           },
         ],
@@ -177,6 +182,87 @@ describe('triggerMessageWorkflows — channel scope (§4)', () => {
     expect(h.getQueueAdd).toHaveBeenCalledWith(
       'executeMessageTrigger',
       expect.objectContaining({ workflowAppId: 'app_scoped-opted-in' })
+    )
+  })
+})
+
+// The loop guards moved off the publish site and onto the dispatcher: ingest
+// now always publishes and attaches signals, so this handler is where a loop
+// actually stops. `ownEcho` is hard (proof the message is a copy of one we
+// sent); `fromOwnAddress` is the author's call and defaults to firing.
+describe('triggerMessageWorkflows — loop signals', () => {
+  it('never dispatches for a proven echo of our own sent mail', async () => {
+    h.getCachedWorkflowAppsByTrigger.mockResolvedValue([app('unscoped')])
+
+    await triggerMessageWorkflows(event({ ownEcho: { sentMessageId: 'm_sent_1' } }))
+
+    expect(h.getQueueAdd).not.toHaveBeenCalled()
+    expect(h.loadProcessedMessage).not.toHaveBeenCalled()
+  })
+
+  it('skips an echo even for a workflow that opted into own-address mail', async () => {
+    h.getCachedWorkflowAppsByTrigger.mockResolvedValue([app('opted-in', { ownAddress: 'include' })])
+
+    await triggerMessageWorkflows(
+      event({ ownEcho: { sentMessageId: 'm_sent_1' }, fromOwnAddress: true })
+    )
+
+    expect(h.getQueueAdd).not.toHaveBeenCalled()
+  })
+
+  it('dispatches own-address mail by default — a teammate writing in is real mail', async () => {
+    h.getCachedWorkflowAppsByTrigger.mockResolvedValue([app('unscoped')])
+
+    await triggerMessageWorkflows(event({ fromOwnAddress: true }))
+
+    expect(h.getQueueAdd).toHaveBeenCalledTimes(1)
+    expect(h.getQueueAdd).toHaveBeenCalledWith(
+      'executeMessageTrigger',
+      expect.objectContaining({ workflowAppId: 'app_unscoped' })
+    )
+  })
+
+  it("dispatches own-address mail for a trigger with an explicit 'include'", async () => {
+    h.getCachedWorkflowAppsByTrigger.mockResolvedValue([app('opted-in', { ownAddress: 'include' })])
+
+    await triggerMessageWorkflows(event({ fromOwnAddress: true }))
+
+    expect(h.getQueueAdd).toHaveBeenCalledTimes(1)
+  })
+
+  it("skips a trigger that opted out with ownAddress: 'exclude'", async () => {
+    h.getCachedWorkflowAppsByTrigger.mockResolvedValue([
+      app('opted-out', { ownAddress: 'exclude' }),
+    ])
+
+    await triggerMessageWorkflows(event({ fromOwnAddress: true }))
+
+    expect(h.getQueueAdd).not.toHaveBeenCalled()
+    expect(h.loadProcessedMessage).not.toHaveBeenCalled()
+  })
+
+  it("still dispatches an 'exclude' trigger for mail that is NOT own-address", async () => {
+    h.getCachedWorkflowAppsByTrigger.mockResolvedValue([
+      app('opted-out', { ownAddress: 'exclude' }),
+    ])
+
+    await triggerMessageWorkflows(event())
+
+    expect(h.getQueueAdd).toHaveBeenCalledTimes(1)
+  })
+
+  it('filters per workflow — one opted out, one on the default', async () => {
+    h.getCachedWorkflowAppsByTrigger.mockResolvedValue([
+      app('opted-out', { ownAddress: 'exclude' }),
+      app('default'),
+    ])
+
+    await triggerMessageWorkflows(event({ fromOwnAddress: true }))
+
+    expect(h.getQueueAdd).toHaveBeenCalledTimes(1)
+    expect(h.getQueueAdd).toHaveBeenCalledWith(
+      'executeMessageTrigger',
+      expect.objectContaining({ workflowAppId: 'app_default' })
     )
   })
 })

--- a/packages/lib/src/events/handlers/trigger-message-workflows.ts
+++ b/packages/lib/src/events/handlers/trigger-message-workflows.ts
@@ -28,6 +28,26 @@ function includesSoftMachineMail(publishedWorkflow: CachedPublishedWorkflow): bo
 }
 
 /**
+ * Read the message-received trigger node's own-address opt-out off the
+ * published workflow graph. Default `'include'` — mail sent from one of the
+ * org's own connected channel addresses DOES start a workflow, because at the
+ * address level a teammate mailing the shared inbox from their own connected
+ * mailbox is indistinguishable from a cross-channel echo, and the former is
+ * real mail that should be automated. A workflow that genuinely must ignore
+ * its own org's mail sets `ownAddress: 'exclude'`. The proven-echo case
+ * (`ownEcho`) is not covered by this toggle — it is always skipped.
+ * Returns `true` when the workflow should be dispatched for own-address mail.
+ */
+function includesOwnAddressMail(publishedWorkflow: CachedPublishedWorkflow): boolean {
+  const nodes = (publishedWorkflow.graph as { nodes?: any[] } | null | undefined)?.nodes
+  if (!Array.isArray(nodes)) return true
+  const triggerNode = nodes.find(
+    (node) => (node?.data?.type ?? node?.type) === WorkflowNodeType.MESSAGE_RECEIVED
+  )
+  return (triggerNode?.data?.ownAddress ?? 'include') === 'include'
+}
+
+/**
  * Read the message-received trigger node's channel scope off the published
  * workflow graph (message-trigger-scoping plan §4). `data.channelIds` is a
  * `string[]` of `Integration.id`s the builder's channel/inbox scope picker
@@ -65,9 +85,31 @@ function matchesChannelScope(
  */
 export const triggerMessageWorkflows = async ({ data: event }: { data: AuxxEvent }) => {
   if (event.type !== 'message:received') return
-  const { messageId, organizationId, threadId, machineMail, integrationId, inboxId } = (
-    event as MessageReceivedEvent
-  ).data
+  const {
+    messageId,
+    organizationId,
+    threadId,
+    machineMail,
+    integrationId,
+    inboxId,
+    ownEcho,
+    fromOwnAddress,
+  } = (event as MessageReceivedEvent).data
+
+  // Proven self-send — the inbound copy's `X-AuxxAi-Message-Id` resolved to a
+  // message THIS org sent (`store-message.ts`). Hard, no per-trigger opt-in:
+  // it is a literal duplicate of our own outbound mail, so there is no
+  // workflow for which running on it is correct. This is the only remaining
+  // unconditional loop guard on the dispatch path — the address-level signal
+  // below is the workflow author's call.
+  if (ownEcho) {
+    logger.info('Skipping MESSAGE_RECEIVED workflows — message is an echo of our own sent mail', {
+      messageId,
+      organizationId,
+      sentMessageId: ownEcho.sentMessageId,
+    })
+    return
+  }
 
   // Hard-tier machine mail (bounces/NDRs) is loop-forming — never dispatch any
   // workflow. There is nothing sensible for an Answer node to say to a daemon.
@@ -122,6 +164,25 @@ export const triggerMessageWorkflows = async ({ data: event }: { data: AuxxEvent
       })
       return
     }
+  }
+
+  // Own-address mail: the sender is one of the org's connected channel
+  // addresses. Opt-OUT (default include), the inverse of machineMail above —
+  // most such mail is a teammate writing to the shared inbox, which should
+  // automate normally. Only a workflow that would loop on its org's own mail
+  // sets `ownAddress: 'exclude'`.
+  if (fromOwnAddress) {
+    matchingWorkflows = matchingWorkflows.filter((workflow) => {
+      const includes = includesOwnAddressMail(workflow.publishedWorkflow)
+      if (!includes) {
+        logger.info('Skipping MESSAGE_RECEIVED workflow — opted out of own-address mail', {
+          messageId,
+          organizationId,
+          workflowAppId: workflow.workflowApp.id,
+        })
+      }
+      return includes
+    })
   }
 
   // Channel scope (§4): a workflow whose trigger is restricted to specific

--- a/packages/lib/src/events/types.ts
+++ b/packages/lib/src/events/types.ts
@@ -191,6 +191,21 @@ export type MessageReceivedEvent = AuxxEventGeneric<
      * mail) — excluded from workflows by default, per-trigger opt-in. The same object
      * is persisted at `Message.metadata.machineMail`. */
     machineMail?: { tier: 'hard' | 'soft'; reason: string }
+    /** Set when this inbound row is PROVEN to be a copy of a message we sent —
+     * its `X-AuxxAi-Message-Id` header resolved to a `Message` row in this org
+     * carrying a `sendToken`. The hard tier of the loop guard: the workflow
+     * dispatcher and mail classification both skip it unconditionally, because
+     * a literal duplicate of our own outbound mail is not a new event. Carries
+     * the id of the row we sent, for log correlation. */
+    ownEcho?: { sentMessageId: string }
+    /** Set when the sender address is one of the org's connected channel
+     * addresses (`buildOrgOwnEmailAddressSet` — every non-deleted channel's
+     * email plus provider aliases, personal mailboxes included). Descriptive,
+     * NOT a verdict: a teammate mailing the shared inbox from their connected
+     * mailbox looks identical to a cross-channel echo at the address level, so
+     * the trigger decides via `MessageReceivedNodeData.ownAddress` (default
+     * `'include'` — it fires). The proven case is `ownEcho` above. */
+    fromOwnAddress?: true
   }
 >
 export type MessageSentEvent = AuxxEventGeneric<

--- a/packages/lib/src/ingest/__tests__/store-message-echoed-message-id-guard.test.ts
+++ b/packages/lib/src/ingest/__tests__/store-message-echoed-message-id-guard.test.ts
@@ -248,60 +248,74 @@ beforeEach(() => {
   }
 })
 
-describe('storeMessage — X-AuxxAi-Message-Id echo guard (§6 supplement)', () => {
-  it('suppresses when the header resolves to a sent message in this org', async () => {
+/**
+ * `ownEcho` is the HARD loop signal: the header resolved to a row this org
+ * actually sent, so the message is a literal copy of our own outbound mail.
+ * The publish still happens (timeline, filters, bounce ingest and signals all
+ * describe the message as it exists) — the dispatcher and mail classification
+ * are what skip on the flag.
+ */
+describe('storeMessage — X-AuxxAi-Message-Id echo signal', () => {
+  const publishedData = () => (h.published[0] as any)?.data
+
+  it('flags ownEcho when the header resolves to a sent message in this org', async () => {
     h.messageRows = [{ id: 'm_sent_1', organizationId: ORG, sendToken: 'tok_1' }]
 
     await storeMessage(ctx(), messageData({ echoedMessageId: 'm_sent_1' }))
 
-    expect(h.published).toEqual([])
+    expect(h.published).toHaveLength(1)
+    expect(publishedData()).toMatchObject({ ownEcho: { sentMessageId: 'm_sent_1' } })
   })
 
-  it('logs the suppression with a reason', async () => {
+  it('logs the signal with the resolved sent-message id', async () => {
     h.messageRows = [{ id: 'm_sent_1', organizationId: ORG, sendToken: 'tok_1' }]
     const c = ctx()
 
     await storeMessage(c, messageData({ echoedMessageId: 'm_sent_1' }))
 
     expect(c.logger.info).toHaveBeenCalledWith(
-      expect.stringContaining('X-AuxxAi-Message-Id'),
+      expect.stringContaining('loop signals attached'),
       expect.objectContaining({ echoedMessageId: 'm_sent_1', sentMessageId: 'm_sent_1' })
     )
   })
 
-  it('does NOT suppress when the header is absent', async () => {
+  it('does NOT flag when the header is absent', async () => {
     h.messageRows = [{ id: 'm_sent_1', organizationId: ORG, sendToken: 'tok_1' }]
 
     await storeMessage(ctx(), messageData())
 
     expect(h.published).toHaveLength(1)
+    expect(publishedData().ownEcho).toBeUndefined()
   })
 
-  it('does NOT suppress when the id is unknown (no matching row)', async () => {
+  it('does NOT flag when the id is unknown (no matching row)', async () => {
     h.messageRows = [{ id: 'm_sent_1', organizationId: ORG, sendToken: 'tok_1' }]
 
     await storeMessage(ctx(), messageData({ echoedMessageId: 'm_unknown' }))
 
     expect(h.published).toHaveLength(1)
+    expect(publishedData().ownEcho).toBeUndefined()
   })
 
-  it('does NOT suppress a match belonging to a different org', async () => {
+  it('does NOT flag a match belonging to a different org', async () => {
     h.messageRows = [{ id: 'm_sent_1', organizationId: OTHER_ORG, sendToken: 'tok_1' }]
 
     await storeMessage(ctx(), messageData({ echoedMessageId: 'm_sent_1' }))
 
     expect(h.published).toHaveLength(1)
+    expect(publishedData().ownEcho).toBeUndefined()
   })
 
-  it('does NOT suppress when sendToken is null (not a message we sent)', async () => {
+  it('does NOT flag when sendToken is null (not a message we sent)', async () => {
     h.messageRows = [{ id: 'm_sent_1', organizationId: ORG, sendToken: null }]
 
     await storeMessage(ctx(), messageData({ echoedMessageId: 'm_sent_1' }))
 
     expect(h.published).toHaveLength(1)
+    expect(publishedData().ownEcho).toBeUndefined()
   })
 
-  it('does not run the header lookup at all when own-address suppression already fired', async () => {
+  it('carries both signals when the sender is also one of our addresses', async () => {
     h.senderIdentifier = 'shopify-demo@mail.auxx.ai'
     h.cachedChannels = [
       { id: 'int_ses', email: 'shopify-demo@mail.auxx.ai', metadata: { systemManaged: true } },
@@ -311,13 +325,21 @@ describe('storeMessage — X-AuxxAi-Message-Id echo guard (§6 supplement)', () 
 
     await storeMessage(c, messageData({ echoedMessageId: 'm_sent_1' }))
 
-    expect(h.published).toEqual([])
-    expect(c.db.query.Message.findFirst).not.toHaveBeenCalled()
+    expect(h.published).toHaveLength(1)
+    expect(publishedData()).toMatchObject({
+      fromOwnAddress: true,
+      ownEcho: { sentMessageId: 'm_sent_1' },
+    })
+    // The two signals are independent now — an own-address sender no longer
+    // short-circuits the header lookup, because each drives a different gate.
+    expect(c.db.query.Message.findFirst).toHaveBeenCalled()
   })
 
-  it('publishes for a genuinely external sender carrying no header at all', async () => {
+  it('publishes unflagged for a genuinely external sender carrying no header at all', async () => {
     await storeMessage(ctx(), messageData())
 
     expect(h.published).toHaveLength(1)
+    expect(publishedData().ownEcho).toBeUndefined()
+    expect(publishedData().fromOwnAddress).toBeUndefined()
   })
 })

--- a/packages/lib/src/ingest/__tests__/store-message-own-address-guard.test.ts
+++ b/packages/lib/src/ingest/__tests__/store-message-own-address-guard.test.ts
@@ -14,7 +14,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const h = vi.hoisted(() => ({
-  cachedChannels: [] as Array<{ id: string; email: string | null; metadata: unknown }>,
+  cachedChannels: [] as Array<{
+    id: string
+    email: string | null
+    metadata: unknown
+    inboxId?: string | null
+  }>,
   published: [] as Array<{ type: string; data: Record<string, unknown> }>,
   senderIdentifier: 'sender@example.com',
   threadRow: {} as Record<string, unknown>,
@@ -192,8 +197,17 @@ beforeEach(() => {
   }
 })
 
-describe('storeMessage — org-wide own-address loop guard (§6 #1)', () => {
-  it('suppresses the publish when From matches a channel primary email', async () => {
+/**
+ * Own-address mail is FLAGGED, never suppressed. The address level cannot tell
+ * a cross-channel echo from a teammate writing in off their own connected
+ * mailbox, so the publish always happens and `fromOwnAddress` lets each
+ * workflow trigger decide (`trigger-message-workflows.ts`, default: fire). The
+ * hard loop guard is `ownEcho` — see the sibling echoed-message-id suite.
+ */
+describe('storeMessage — own-address signal on message:received', () => {
+  const publishedData = () => (h.published[0] as any)?.data
+
+  it('flags fromOwnAddress when From matches a channel primary email', async () => {
     h.senderIdentifier = 'shopify-demo@mail.auxx.ai'
     h.cachedChannels = [
       { id: 'int_ses', email: 'shopify-demo@mail.auxx.ai', metadata: { systemManaged: true } },
@@ -202,14 +216,16 @@ describe('storeMessage — org-wide own-address loop guard (§6 #1)', () => {
 
     await storeMessage(c, messageData())
 
-    expect(h.published).toEqual([])
+    expect(h.published).toHaveLength(1)
+    expect(publishedData()).toMatchObject({ fromOwnAddress: true })
+    expect(publishedData().ownEcho).toBeUndefined()
     expect(c.logger.info).toHaveBeenCalledWith(
-      expect.stringContaining('Suppressing message:received publish'),
-      expect.objectContaining({ from: 'shopify-demo@mail.auxx.ai' })
+      expect.stringContaining('Publishing message:received with loop signals attached'),
+      expect.objectContaining({ fromOwnAddress: true, from: 'shopify-demo@mail.auxx.ai' })
     )
   })
 
-  it('suppresses the publish when From matches an Outlook alias (metadata.emailAliases)', async () => {
+  it('flags fromOwnAddress when From matches an Outlook alias (metadata.emailAliases)', async () => {
     h.senderIdentifier = 'alias@outlook.example.com'
     h.cachedChannels = [
       {
@@ -221,10 +237,11 @@ describe('storeMessage — org-wide own-address loop guard (§6 #1)', () => {
 
     await storeMessage(ctx(), messageData())
 
-    expect(h.published).toEqual([])
+    expect(h.published).toHaveLength(1)
+    expect(publishedData()).toMatchObject({ fromOwnAddress: true })
   })
 
-  it('suppresses the publish when From matches a Gmail send-as alias (metadata.userEmails)', async () => {
+  it('flags fromOwnAddress when From matches a Gmail send-as alias (metadata.userEmails)', async () => {
     h.senderIdentifier = 'sendas@gmail.example.com'
     h.cachedChannels = [
       {
@@ -236,7 +253,8 @@ describe('storeMessage — org-wide own-address loop guard (§6 #1)', () => {
 
     await storeMessage(ctx(), messageData())
 
-    expect(h.published).toEqual([])
+    expect(h.published).toHaveLength(1)
+    expect(publishedData()).toMatchObject({ fromOwnAddress: true })
   })
 
   it('matches case-insensitively', async () => {
@@ -245,10 +263,24 @@ describe('storeMessage — org-wide own-address loop guard (§6 #1)', () => {
 
     await storeMessage(ctx(), messageData())
 
-    expect(h.published).toEqual([])
+    expect(h.published).toHaveLength(1)
+    expect(publishedData()).toMatchObject({ fromOwnAddress: true })
   })
 
-  it('publishes for a genuinely external sender, carrying integrationId + inboxId', async () => {
+  it('flags a teammate mailing in from a personal channel — publish is never suppressed', async () => {
+    h.senderIdentifier = 'alice@company.com'
+    h.cachedChannels = [
+      { id: 'int_support', email: 'support@company.com', metadata: null },
+      { id: 'int_alice', email: 'alice@company.com', metadata: null, inboxId: 'inbox_personal' },
+    ]
+
+    await storeMessage(ctx(), messageData())
+
+    expect(h.published).toHaveLength(1)
+    expect(publishedData()).toMatchObject({ from: 'alice@company.com', fromOwnAddress: true })
+  })
+
+  it('publishes for a genuinely external sender, carrying integrationId + inboxId and no signals', async () => {
     h.senderIdentifier = 'customer@external.com'
     h.cachedChannels = [{ id: 'int_ses', email: 'shopify-demo@mail.auxx.ai', metadata: null }]
 
@@ -263,18 +295,21 @@ describe('storeMessage — org-wide own-address loop guard (§6 #1)', () => {
         inboxId: INBOX_ID,
       }),
     })
+    expect(publishedData().fromOwnAddress).toBeUndefined()
+    expect(publishedData().ownEcho).toBeUndefined()
   })
 
-  it('publishes when the org has no configured channels (empty own-address set)', async () => {
+  it('publishes unflagged when the org has no configured channels (empty own-address set)', async () => {
     h.senderIdentifier = 'customer@external.com'
     h.cachedChannels = []
 
     await storeMessage(ctx(), messageData())
 
     expect(h.published).toHaveLength(1)
+    expect(publishedData().fromOwnAddress).toBeUndefined()
   })
 
-  it('does not suppress a DIFFERENT channel that merely shares no aliases with the sender', async () => {
+  it('does not flag a DIFFERENT channel that merely shares no aliases with the sender', async () => {
     h.senderIdentifier = 'customer@external.com'
     h.cachedChannels = [
       {
@@ -288,5 +323,6 @@ describe('storeMessage — org-wide own-address loop guard (§6 #1)', () => {
     await storeMessage(ctx(), messageData())
 
     expect(h.published).toHaveLength(1)
+    expect(publishedData().fromOwnAddress).toBeUndefined()
   })
 })

--- a/packages/lib/src/ingest/store-message.ts
+++ b/packages/lib/src/ingest/store-message.ts
@@ -871,32 +871,46 @@ export async function storeMessage(
     //    branches (see `sync-messages.ts` / `outlook-provider.ts`); live
     //    webhook ingest (SES inbound, OpenPhone/Facebook/Instagram routes)
     //    never touches sync mode, so it stays `false` and always fires.
-    //  - not one of the org's own addresses (loop-guard plan §6 #1): a
-    //    single-channel echo is already `isInbound: false` per-provider, but
-    //    a reply sent on one channel can re-arrive `isInbound: true` on a
-    //    DIFFERENT channel — a second connected mailbox, or the SES
-    //    forwarding alias. `ownAddresses` is the ORG-WIDE union (every
-    //    non-deleted Integration's email + aliases — see
-    //    `buildOrgOwnEmailAddressSet`), not just this integration's, so it
-    //    catches that case too. Hard guard, no toggle: there is no legitimate
-    //    reason to fire any of the five `message:received` subscribers off
-    //    the org's own outbound mail.
-    //  - not an echo of our own sent mail via `X-AuxxAi-Message-Id` (loop-guard
-    //    plan §6 supplement): complementary to the own-address check above,
-    //    not a replacement — that check catches it while `From` is still one
-    //    of our addresses; this catches it when an intermediate forwarder
-    //    REWROTE `From` to something unrecognizable, which is exactly where
-    //    the own-address check fails. Gmail, SES, and Outlook all stamp the
-    //    header on send now (see `channel-provider.interface.ts:50-56`), so
-    //    an inbound copy that carries it back resolves to the `Message` row
-    //    we sent. Suppress-only: no merge, no thread grafting, no
-    //    reconciliation. This is a PLAIN org-scoped existence check on the
-    //    primary key — it does not reuse or relax Strategy 0's
-    //    integration-scoped reconciliation predicate
-    //    (`message-reconciler.service.ts`, a security guard against a forged
-    //    header grafting inbound mail onto an arbitrary row). One indexed
-    //    lookup, and only when the header is present — the common case has
-    //    no header and costs nothing here.
+    // Loop signals ride ALONG on the event rather than vetoing the publish.
+    // They used to suppress it outright, which took out the four subscribers
+    // that have nothing to do with loops (timeline, mail filters, bounce
+    // ingest, signals) as collateral — and, worse, the own-address arm could
+    // not tell a cross-channel echo from a teammate mailing the shared inbox
+    // off their own connected mailbox, so real human mail vanished. Two
+    // signals now, mirroring `machineMail`'s hard/soft split:
+    //  - `ownEcho` (HARD, no toggle): the inbound copy carries
+    //    `X-AuxxAi-Message-Id` resolving to a `Message` row in THIS org with a
+    //    `sendToken` — proof it is a copy of mail we sent, not an inference
+    //    from an address. Gmail, Outlook, SES and (as of this change) IMAP/SMTP
+    //    all stamp it on send, see `channel-provider.interface.ts:50-56`.
+    //    Read-only: no merge, no thread grafting, no reconciliation. A PLAIN
+    //    org-scoped existence check on the primary key — it deliberately does
+    //    not reuse or relax Strategy 0's integration-scoped reconciliation
+    //    predicate (`message-reconciler.service.ts`, a security guard against
+    //    a forged header grafting inbound mail onto an arbitrary row). One
+    //    indexed lookup, and only when the header is present — the common case
+    //    has no header and costs nothing here.
+    //  - `fromOwnAddress` (SOFT, per-trigger): the sender is one of the org's
+    //    connected channel addresses. Genuinely ambiguous, so the trigger
+    //    decides (`MessageReceivedNodeData.ownAddress`, default `'include'`).
+    // Both are computed only for a message that is already publishing, so the
+    // remaining gates below are unchanged:
+    //  - inbound only: `storeMessage` is never on the compose/send path (that's
+    //    `MessageComposerService.createPendingMessage`); the only outbound
+    //    traffic here is provider sync echoing our own sent mail, so gating on
+    //    `isInbound` fully covers "a workflow that sends mail must not
+    //    re-trigger itself" for the SINGLE-channel case.
+    //  - genuinely NEW row only: every dedup/reconciliation branch above
+    //    (internetMessageId match, `reconcileMessage` match, duplicate-key
+    //    catch) returns early with `isNew: false` — this line only runs on
+    //    the fresh-insert path, so re-ingest of an already-stored message
+    //    never re-emits.
+    //  - `!ctx.isInitialSync`: a first-connect Gmail/Outlook backfill must not
+    //    fire thousands of workflow runs. Gmail/Outlook set this via
+    //    `MessageStorageService.setInitialSyncMode` on their backfill
+    //    branches (see `sync-messages.ts` / `outlook-provider.ts`); live
+    //    webhook ingest (SES inbound, OpenPhone/Facebook/Instagram routes)
+    //    never touches sync mode, so it stays `false` and always fires.
     // Best-effort — `publisher.publishLater` swallows its own errors and
     // never throws, so this can't fail message ingestion.
     if (messageData.isInbound && !ctx.isInitialSync) {
@@ -904,15 +918,10 @@ export async function storeMessage(
       const ownAddresses = buildOrgOwnEmailAddressSet(
         await getOrgCache().get(messageData.organizationId, 'channels')
       )
+      const fromOwnAddress = !!fromAddress && ownAddresses.has(fromAddress)
 
-      let suppressReason: { message: string; fields: Record<string, unknown> } | null = null
-      if (fromAddress && ownAddresses.has(fromAddress)) {
-        suppressReason = {
-          message:
-            "Suppressing message:received publish — sender is one of the org's own channel addresses (cross-channel echo)",
-          fields: { from: fromAddress },
-        }
-      } else if (messageData.echoedMessageId) {
+      let ownEcho: { sentMessageId: string } | null = null
+      if (messageData.echoedMessageId) {
         const echoedSentMessage = await ctx.db.query.Message.findFirst({
           where: (messages, { eq, and, isNotNull }) =>
             and(
@@ -922,45 +931,42 @@ export async function storeMessage(
             ),
           columns: { id: true },
         })
-        if (echoedSentMessage) {
-          suppressReason = {
-            message:
-              'Suppressing message:received publish — inbound carries X-AuxxAi-Message-Id resolving to our own sent message in this org (cross-channel echo via forwarder)',
-            fields: {
-              echoedMessageId: messageData.echoedMessageId,
-              sentMessageId: echoedSentMessage.id,
-            },
-          }
-        }
+        if (echoedSentMessage) ownEcho = { sentMessageId: echoedSentMessage.id }
       }
 
-      if (suppressReason) {
-        ctx.logger.info(suppressReason.message, {
+      if (ownEcho || fromOwnAddress) {
+        ctx.logger.info('Publishing message:received with loop signals attached', {
           messageId: messageRecord.id,
           organizationId: messageData.organizationId,
           integrationId: messageData.integrationId,
           threadId: thread.id,
-          ...suppressReason.fields,
+          ...(fromOwnAddress && { fromOwnAddress: true, from: fromAddress }),
+          ...(ownEcho && {
+            echoedMessageId: messageData.echoedMessageId,
+            sentMessageId: ownEcho.sentMessageId,
+          }),
         })
-      } else {
-        await publisher.publishLater({
-          type: 'message:received',
-          data: {
-            messageId: messageRecord.id,
-            organizationId: messageData.organizationId,
-            ...(senderParticipant.entityInstanceId && {
-              recordId: toRecordId('contact', senderParticipant.entityInstanceId),
-            }),
-            threadId: thread.id,
-            integrationId: messageData.integrationId,
-            ...(inboxIdForChannel && { inboxId: inboxIdForChannel }),
-            subject: messageData.subject ?? undefined,
-            from: senderParticipant.identifier,
-            snippet: messageData.snippet ?? undefined,
-            ...(machineMailResult && { machineMail: machineMailResult }),
-          },
-        } as MessageReceivedEvent)
       }
+
+      await publisher.publishLater({
+        type: 'message:received',
+        data: {
+          messageId: messageRecord.id,
+          organizationId: messageData.organizationId,
+          ...(senderParticipant.entityInstanceId && {
+            recordId: toRecordId('contact', senderParticipant.entityInstanceId),
+          }),
+          threadId: thread.id,
+          integrationId: messageData.integrationId,
+          ...(inboxIdForChannel && { inboxId: inboxIdForChannel }),
+          subject: messageData.subject ?? undefined,
+          from: senderParticipant.identifier,
+          snippet: messageData.snippet ?? undefined,
+          ...(machineMailResult && { machineMail: machineMailResult }),
+          ...(ownEcho && { ownEcho }),
+          ...(fromOwnAddress && { fromOwnAddress: true as const }),
+        },
+      } as MessageReceivedEvent)
     }
 
     ctx.logger.info('Message stored successfully (Revised Schema v2)', {

--- a/packages/lib/src/mail-classification/enqueue.test.ts
+++ b/packages/lib/src/mail-classification/enqueue.test.ts
@@ -82,6 +82,20 @@ describe('enqueueMailClassification', () => {
     expect(h.add).not.toHaveBeenCalled()
   })
 
+  // Ingest publishes `message:received` for a proven echo of our own sent mail
+  // rather than suppressing it, so the four subscribers that describe the
+  // message as it exists keep working. Classification is the one that opts out:
+  // it would spend a model call tagging our own text.
+  it('never queues a proven echo of our own sent mail', async () => {
+    await enqueueMailClassification(event({ ownEcho: { sentMessageId: 'm_sent_1' } }))
+    expect(h.add).not.toHaveBeenCalled()
+  })
+
+  it('DOES queue own-address mail — a teammate writing in is classifiable', async () => {
+    await enqueueMailClassification(event({ fromOwnAddress: true }))
+    expect(h.add).toHaveBeenCalledTimes(1)
+  })
+
   it('swallows an enqueue failure rather than failing the fan-out', async () => {
     h.add.mockRejectedValue(new Error('redis down'))
     await expect(enqueueMailClassification(event())).resolves.toBeUndefined()

--- a/packages/lib/src/mail-classification/enqueue.ts
+++ b/packages/lib/src/mail-classification/enqueue.ts
@@ -35,12 +35,18 @@ const logger = createScopedLogger('mail-classification')
 export const enqueueMailClassification = async ({ data: event }: { data: AuxxEvent }) => {
   if (event.type !== 'message:received') return
 
-  const { organizationId, messageId, threadId, machineMail, from } = (event as MessageReceivedEvent)
-    .data
+  const { organizationId, messageId, threadId, machineMail, from, ownEcho } = (
+    event as MessageReceivedEvent
+  ).data
 
   // Payload-only exits 1 and 2 (§3.1). Everything past here costs a queue write,
-  // so the two free checks happen on this side of it.
+  // so the free checks happen on this side of it.
   if (machineMail?.tier === 'hard') return
+  // A proven copy of mail this org sent (`store-message.ts`'s `ownEcho`) is our
+  // own text coming back — classifying it burns a model call to tag ourselves.
+  // The only other subscriber that opts out; timeline, filters, bounce ingest
+  // and signals all describe the message as it exists and run normally.
+  if (ownEcho) return
   if (!threadId) return
 
   const data: MailClassificationJobData = {

--- a/packages/lib/src/providers/imap/__tests__/imap-send-message.test.ts
+++ b/packages/lib/src/providers/imap/__tests__/imap-send-message.test.ts
@@ -1,0 +1,110 @@
+// packages/lib/src/providers/imap/__tests__/imap-send-message.test.ts
+//
+// SMTP was the one outbound email door that never stamped
+// `X-AuxxAi-Message-Id` (Gmail `create-message.ts`, Outlook `outlook-provider.ts`
+// and SES `email-forwarding-provider.ts` all did), so an inbound copy of an
+// IMAP channel's send arriving on another channel carried nothing tying it back
+// to the row we sent. That header is what `store-message.ts` resolves into the
+// `ownEcho` signal — the ONLY unconditional loop guard on the dispatch path —
+// so without it IMAP orgs had no cross-channel echo detection at all.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({ sendMail: vi.fn() }))
+
+vi.mock('nodemailer', () => ({
+  createTransport: () => ({ sendMail: h.sendMail, verify: vi.fn(), close: vi.fn() }),
+}))
+
+import { ImapSmtpSendService } from '../imap-send-message'
+
+const CREDENTIALS = {
+  smtp: {
+    host: 'smtp.example.com',
+    port: 587,
+    secure: false,
+    username: 'user',
+    password: 'pass',
+    allowUnauthorizedCerts: false,
+  },
+} as never
+
+async function service() {
+  const svc = new ImapSmtpSendService()
+  await svc.initialize(CREDENTIALS)
+  return svc
+}
+
+/** The `headers` object handed to nodemailer on the most recent send. */
+const sentHeaders = () => h.sendMail.mock.calls.at(-1)?.[0]?.headers ?? {}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.sendMail.mockResolvedValue({ messageId: '<smtp-generated@example.com>' })
+})
+
+describe('ImapSmtpSendService — X-AuxxAi-Message-Id', () => {
+  it('stamps our own Message.id when internalMessageId is provided', async () => {
+    const svc = await service()
+
+    await svc.sendMessage({
+      from: 'support@company.com',
+      to: 'customer@external.com',
+      subject: 'Re: order',
+      text: 'body',
+      internalMessageId: 'msg_abc123',
+    } as never)
+
+    expect(sentHeaders()['X-AuxxAi-Message-Id']).toBe('msg_abc123')
+  })
+
+  it('omits the header entirely when there is no internalMessageId', async () => {
+    const svc = await service()
+
+    await svc.sendMessage({
+      from: 'support@company.com',
+      to: 'customer@external.com',
+      subject: 'Re: order',
+      text: 'body',
+    } as never)
+
+    expect(sentHeaders()).not.toHaveProperty('X-AuxxAi-Message-Id')
+  })
+
+  it('stamps it alongside the RFC 3834 automated-send headers', async () => {
+    const svc = await service()
+
+    await svc.sendMessage({
+      from: 'support@company.com',
+      to: 'customer@external.com',
+      subject: 'Re: order',
+      text: 'body',
+      internalMessageId: 'msg_abc123',
+      automated: true,
+    } as never)
+
+    expect(sentHeaders()).toMatchObject({
+      'X-AuxxAi-Message-Id': 'msg_abc123',
+      'Auto-Submitted': 'auto-replied',
+      'X-Auto-Response-Suppress': 'All',
+    })
+  })
+
+  it('does not disturb the Message-ID header', async () => {
+    const svc = await service()
+
+    await svc.sendMessage({
+      from: 'support@company.com',
+      to: 'customer@external.com',
+      subject: 'Re: order',
+      text: 'body',
+      messageId: '<ours@company.com>',
+      internalMessageId: 'msg_abc123',
+    } as never)
+
+    expect(sentHeaders()).toMatchObject({
+      'Message-ID': '<ours@company.com>',
+      'X-AuxxAi-Message-Id': 'msg_abc123',
+    })
+  })
+})

--- a/packages/lib/src/providers/imap/imap-send-message.ts
+++ b/packages/lib/src/providers/imap/imap-send-message.ts
@@ -54,6 +54,14 @@ export class ImapSmtpSendService {
         references: options.references,
         headers: {
           ...(options.messageId ? { 'Message-ID': options.messageId } : {}),
+          // Our own `Message.id`, so an inbound copy of this send arriving on
+          // another channel resolves back to the row we sent and is recognised
+          // as an echo (`store-message.ts`'s `ownEcho`). Gmail, Outlook and SES
+          // stamp the same header — SMTP was the one door that didn't, leaving
+          // IMAP channels with no cross-channel echo detection at all.
+          ...(options.internalMessageId
+            ? { 'X-AuxxAi-Message-Id': options.internalMessageId }
+            : {}),
           // RFC 3834 loop prevention for automated sends (machine-mail plan Phase 2)
           ...(options.automated
             ? { 'Auto-Submitted': 'auto-replied', 'X-Auto-Response-Suppress': 'All' }

--- a/packages/lib/src/workflow-engine/catalog/nodes/message-received.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/message-received.ts
@@ -41,6 +41,19 @@ export interface MessageReceivedNodeData extends BaseNodeData {
    */
   machineMail?: 'exclude' | 'include'
   /**
+   * Mail sent from one of the org's own connected channel addresses (any
+   * channel's email or provider alias, personal mailboxes included).
+   * `'include'` — the default when absent — fires the workflow: at the address
+   * level a teammate mailing the shared inbox off their own connected mailbox
+   * is indistinguishable from a cross-channel echo, and that mail should
+   * automate like any other. `'exclude'` skips it, for a workflow that would
+   * otherwise act on its own org's mail. Read off the published graph by the
+   * `triggerMessageWorkflows` dispatcher. A PROVEN echo of a message this org
+   * sent (`X-AuxxAi-Message-Id` resolving to our own row) is always skipped,
+   * regardless of this setting.
+   */
+  ownAddress?: 'exclude' | 'include'
+  /**
    * Content conditions, replaces the deleted "Message Filters" UI. Evaluated
    * by the engine with the shared `evaluateConditionsWithDiagnostics` against
    * message-resolvable fields (from/to/subject/body/hasAttachments).
@@ -67,6 +80,7 @@ export const messageReceivedNodeDataSchema = z.object({
   variables: z.array(z.any()).optional(),
   channelIds: z.array(z.string()).optional(),
   machineMail: z.enum(['exclude', 'include']).optional(),
+  ownAddress: z.enum(['exclude', 'include']).optional(),
   conditions: conditionGroupsSchema.optional(),
 
   // Other node data properties
@@ -280,7 +294,10 @@ export const messageReceivedManifest: NodeManifest<MessageReceivedNodeData> = {
       'warning; relay it and push toward scoping). `conditions` filter on message content ' +
       '(from/to/subject/body/hasAttachments, shared ConditionGroup dialect, fail-closed); channel ' +
       "scoping lives ONLY in `channelIds`. `machineMail: 'include'` opts into soft machine mail " +
-      '(out-of-office, list mail); bounces are always skipped.',
+      '(out-of-office, list mail); bounces are always skipped. ' +
+      "`ownAddress: 'exclude'` stops the workflow firing on mail sent from the org's own connected " +
+      'channel addresses — leave it unset (defaults to include) unless the user says this workflow ' +
+      "must ignore their own team's mail; echoes of mail this org sent are always skipped anyway.",
     examples: [
       {
         description: 'Fire on support-inbox mail that mentions a refund',

--- a/packages/lib/src/workflow-engine/nodes/trigger-nodes/message-received.ts
+++ b/packages/lib/src/workflow-engine/nodes/trigger-nodes/message-received.ts
@@ -30,11 +30,13 @@ import { BaseNodeProcessor } from '../base-node'
  *
  * `machineMail` is likewise a dispatcher gate: `'exclude'` (default when
  * absent) skips soft machine mail, hard-tier machine mail (bounces/NDRs) is
- * always skipped regardless.
+ * always skipped regardless. So is `ownAddress`: `'include'` (default when
+ * absent) fires on mail from the org's own channel addresses, `'exclude'`
+ * skips it; a proven echo of mail this org sent is always skipped regardless.
  */
 export type MessageReceivedTriggerConfig = Pick<
   MessageReceivedNodeData,
-  'conditions' | 'machineMail'
+  'conditions' | 'machineMail' | 'ownAddress'
 >
 
 /** Output shape for the `message.attachments` node variable. */


### PR DESCRIPTION
## Why

#1555's own-address loop guard vetoed the `message:received` publish outright whenever the sender matched one of the org's channel addresses. Two problems, both hit in normal use:

- **An address-level match cannot tell a cross-channel echo from a teammate mailing the shared inbox** off their own connected mailbox. Personal channels are in the `channels` cache too, so that mail — real human inbound — vanished silently.
- **Vetoing the publish took out all five subscribers, not just workflows.** A loop is a workflow concern; timeline, mail filters, bounce ingest and signals were collateral damage.

## What

Ingest always publishes now, attaching two signals split by strength of evidence, mirroring `machineMail`'s hard/soft shape:

| Signal | Evidence | Gate | Toggle |
|---|---|---|---|
| `ownEcho: { sentMessageId }` | `X-AuxxAi-Message-Id` resolves to a `Message` row in this org with a `sendToken` — proof it's a copy of mail we sent | hard block | none |
| `fromOwnAddress: true` | Sender ∈ the org's channel addresses — ambiguous | per-trigger | `ownAddress: 'include' \| 'exclude'`, default `include` |

The dispatcher (`trigger-message-workflows.ts`) is now where a loop actually stops. Only `enqueueMailClassification` also opts out, and only on `ownEcho` — a model call spent tagging our own text. `apply-mail-filters`, `create-timeline-event`, `ingest-bounce-message` and `derive-message-signals` run unconditionally; signals were already protected by `sender.isInternal`.

**Prerequisite shipped with it:** SMTP/IMAP sends never stamped `X-AuxxAi-Message-Id` (Gmail, Outlook and SES all do), so `ownEcho` — now the only unconditional guard on the dispatch path — was blind on IMAP channels, where address matching had been doing all the work.

**Also fixes SES message direction**, which reads the same address set for a different question. `getOrgOwnEmailAddresses` now excludes personal-inbox channels, so mail from a teammate's personal mailbox arriving at a shared channel through the forwarding alias is stored inbound instead of rendering as an org reply in the thread.

## Residual risk, accepted deliberately

A cross-channel echo whose header an intermediate forwarder **strips** now reaches the workflow and can draw one automated reply before `assertAlternation` (`message-sender.service.ts:632`) kills it on the next hop. `ownAddress: 'exclude'` is the escape hatch. The trade: one potential extra send in a rare forwarder case, versus teammates, personal mailboxes and cross-channel human mail all working normally.

## Testing

- The two ingest suites asserted the suppression, so they pinned the behavior being removed — both now assert the publish carries the signal instead.
- New coverage: dispatcher gates (`ownEcho` never dispatches, `fromOwnAddress` defaults to firing, `exclude` skips), the `excludeInboxIds` option, and the IMAP header (there were no IMAP tests at all before).
- 1569 tests pass across 98 files in the affected surface; `packages/lib` and `apps/web` typecheck clean for the touched files; Biome clean.