### PR TITLE
fix(workflow): drop server-only catalog exports from client barrel

### DIFF
--- a/apps/web/src/components/workflow/parity/output-resolution-parity.test.ts
+++ b/apps/web/src/components/workflow/parity/output-resolution-parity.test.ts
@@ -1,8 +1,12 @@
 // apps/web/src/components/workflow/parity/output-resolution-parity.test.ts
 
+import { buildOutputContextFromResources } from '@auxx/lib/workflow-engine/catalog/build-output-context'
+import {
+  resolveGraphOutputs,
+  type WorkflowOutputGraph,
+} from '@auxx/lib/workflow-engine/catalog/resolve-outputs'
 import {
   BaseType,
-  buildOutputContextFromResources,
   type EdgeMeta,
   getNodeIdFromVariableId,
   listManifests,
@@ -10,10 +14,8 @@ import {
   type NodeMeta,
   type Resource,
   type ResourceField,
-  resolveGraphOutputs,
   topologicalSort,
   type UnifiedVariable,
-  type WorkflowOutputGraph,
 } from '@auxx/lib/workflow-engine/client'
 import { describe, expect, it, vi } from 'vitest'
 import { NodeType } from '~/components/workflow/types/node-types'

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1336,6 +1336,18 @@
       "import": "./dist/workflow-engine/index.mjs",
       "default": "./src/workflow-engine/index.ts"
     },
+    "./workflow-engine/catalog/build-output-context": {
+      "types": "./src/workflow-engine/catalog/build-output-context.ts",
+      "source": "./src/workflow-engine/catalog/build-output-context.ts",
+      "import": "./dist/workflow-engine/catalog/build-output-context.mjs",
+      "default": "./src/workflow-engine/catalog/build-output-context.ts"
+    },
+    "./workflow-engine/catalog/resolve-outputs": {
+      "types": "./src/workflow-engine/catalog/resolve-outputs.ts",
+      "source": "./src/workflow-engine/catalog/resolve-outputs.ts",
+      "import": "./dist/workflow-engine/catalog/resolve-outputs.mjs",
+      "default": "./src/workflow-engine/catalog/resolve-outputs.ts"
+    },
     "./workflow-engine/client": {
       "types": "./src/workflow-engine/client.ts",
       "source": "./src/workflow-engine/client.ts",

--- a/packages/lib/src/workflow-engine/client.ts
+++ b/packages/lib/src/workflow-engine/client.ts
@@ -74,10 +74,9 @@ export * from './utils/terminal-nodes'
 // The server-safe node contract: manifest types, the registry, the migration
 // tracker, and the pure variable-inference helpers split out of apps/web
 // utils/variable-utils.ts (the store-reading display helpers stayed there).
-export {
-  buildOutputContext,
-  buildOutputContextFromResources,
-} from './catalog/build-output-context'
+// NOTE: `catalog/build-output-context` and `catalog/resolve-outputs` are
+// SERVER-ONLY (they import the org cache, which pulls in bullmq) and must
+// never be exported here — import them via their own subpaths instead.
 export {
   type DerivedTriggerColumns,
   deriveTriggerColumns,
@@ -324,11 +323,6 @@ export {
   getManifest,
   listManifests,
 } from './catalog/registry'
-export {
-  resolveGraphOutputs,
-  resolveNodeOutputs,
-  type WorkflowOutputGraph,
-} from './catalog/resolve-outputs'
 export {
   extractSchemaPropertyPaths,
   generateSampleFromSchema,


### PR DESCRIPTION
## Problem

#1579 exported `catalog/build-output-context` and `catalog/resolve-outputs` from `workflow-engine/client.ts` — the client-safe barrel. Both modules import the org cache (`../../cache`), which pulls the inbox service and BullMQ into the browser bundle. Every page 500'd:

```
Module not found: Can't resolve 'child_process'
  bullmq/dist/esm/classes/child.js
  ← packages/lib/dist/cache/org-cache-helpers.mjs
  ← packages/lib/dist/workflow-engine/catalog/build-output-context.mjs
  ← packages/lib/dist/workflow-engine/client.mjs
```

## Fix

- Remove both export blocks from `client.ts`, with a comment marking the modules server-only so this doesn't regress.
- Give both modules their own subpath exports (`generate:exports` codegen); the parity test — their only consumer — imports the leaf modules directly.
- Deliberately **not** routed through the `@auxx/lib/workflow-engine` server barrel: that statically loads `WorkflowEngine`, which must stay dynamically loaded (known import cycle → `BaseAiNodeProcessor undefined`).

## Verification

- `dist/workflow-engine/client.mjs` after rebuild: zero references to either module
- apps/web workflow suite: 100/100 (incl. 4 output-resolution parity tests)
- typecheck ratchet: lib 29/29 baseline, web 1/1