### PR TITLE
fix(channels): route channel webhook callbacks through ngrok in dev

### DIFF
--- a/packages/lib/scripts/probe-outlook-subscription.ts
+++ b/packages/lib/scripts/probe-outlook-subscription.ts
@@ -61,7 +61,9 @@ if (!integ) {
   process.exit(1)
 }
 
-const notificationUrl = urlArg ?? `${WEBAPP_URL}/api/outlook/webhook`
+// Same NGROK_URL-first convention as the runtime arming path (webhook-callback-base.ts) —
+// Graph rejects http:// notification URLs, so localhost can never pass validation.
+const notificationUrl = urlArg ?? `${process.env.NGROK_URL || WEBAPP_URL}/api/outlook/webhook`
 
 console.log('\n=== Phase 0 — Outlook subscription scope probe ===')
 console.log('integration :', integ.id, `(${integ.email ?? 'no email on row'})`)

--- a/packages/lib/src/jobs/maintenance/webhook-renewal-job.ts
+++ b/packages/lib/src/jobs/maintenance/webhook-renewal-job.ts
@@ -1,10 +1,10 @@
 // packages/lib/src/jobs/maintenance/webhook-renewal-job.ts
 
-import { WEBAPP_URL } from '@auxx/config/server'
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq, isNull } from 'drizzle-orm'
 import { ProviderRegistryService } from '../../providers/provider-registry-service'
+import { providerWebhookCallbackUrl } from '../../providers/webhook-callback-base'
 import type { JobContext } from '../types'
 
 const logger = createScopedLogger('webhook-renewal-job')
@@ -71,9 +71,10 @@ export const webhookRenewalJob = async (
       const providerRegistry = new ProviderRegistryService(organizationId)
       const emailProvider = await providerRegistry.getProvider(integrationId)
 
-      // Build callback URL (same logic as WebhookManagerService). Google uses the Pub/Sub
-      // topic from env and ignores callbackUrl; Outlook uses it for the Graph subscription.
-      const callbackUrl = `${WEBAPP_URL}/api/${provider}/webhook`
+      // Build callback URL (same helper as WebhookManagerService, NGROK_URL-aware in dev).
+      // Google uses the Pub/Sub topic from env and ignores callbackUrl; Outlook uses it for
+      // the Graph subscription.
+      const callbackUrl = providerWebhookCallbackUrl(provider)
 
       await emailProvider.setupWebhook(callbackUrl)
       result.webhookRenewed = true

--- a/packages/lib/src/providers/outlook/__tests__/arm-subscription.test.ts
+++ b/packages/lib/src/providers/outlook/__tests__/arm-subscription.test.ts
@@ -128,7 +128,9 @@ describe('armOutlookSubscription', () => {
     await armOutlookSubscription({ integrationId: 'int-1', organizationId: 'org-1', seedSince })
 
     expect(syncMessages).toHaveBeenCalledWith(seedSince)
-    expect(setupWebhook).toHaveBeenCalledWith('http://localhost:3000/api/outlook/webhook')
+    // Base varies by env (NGROK_URL in dev shells falls through webhook-callback-base) —
+    // the contract under test is the route path, not the origin.
+    expect(setupWebhook).toHaveBeenCalledWith(expect.stringMatching(/\/api\/outlook\/webhook$/))
 
     const [seedCallOrder] = syncMessages.mock.invocationCallOrder
     const [armCallOrder] = setupWebhook.mock.invocationCallOrder

--- a/packages/lib/src/providers/outlook/outlook-subscription.ts
+++ b/packages/lib/src/providers/outlook/outlook-subscription.ts
@@ -1,9 +1,9 @@
 // packages/lib/src/providers/outlook/outlook-subscription.ts
 
-import { WEBAPP_URL } from '@auxx/config/server'
 import { database as db, schema } from '@auxx/database'
 import { and, eq } from 'drizzle-orm'
 import { ProviderRegistryService } from '../provider-registry-service'
+import { providerWebhookCallbackUrl } from '../webhook-callback-base'
 
 /**
  * Arm (or re-arm) an Outlook channel's Graph change-notification subscription — the single
@@ -77,7 +77,7 @@ export async function armOutlookSubscription(args: {
     await provider.syncMessages(seedSince ?? new Date())
   }
 
-  await provider.setupWebhook(`${WEBAPP_URL}/api/outlook/webhook`)
+  await provider.setupWebhook(providerWebhookCallbackUrl('outlook'))
 
   // First successful arm clears a latched Sync Error card — nothing else does.
   await db

--- a/packages/lib/src/providers/webhook-callback-base.ts
+++ b/packages/lib/src/providers/webhook-callback-base.ts
@@ -1,0 +1,20 @@
+// packages/lib/src/providers/webhook-callback-base.ts
+
+import { WEBAPP_URL } from '@auxx/config/server'
+
+/**
+ * Public base URL external services deliver channel webhooks to.
+ *
+ * In dev, `NGROK_URL` points callbacks at the tunnel — the same convention every OAuth
+ * redirect base uses (`process.env.NGROK_URL || WEBAPP_URL`); providers like Microsoft
+ * Graph reject non-HTTPS notification URLs outright, so localhost can never receive them.
+ * In production `NGROK_URL` is unset and the public `WEBAPP_URL` applies. Server-side only.
+ */
+export function webhookCallbackBase(): string {
+  return process.env.NGROK_URL || WEBAPP_URL
+}
+
+/** Callback URL for a provider's inbound webhook route (e.g. `/api/outlook/webhook`). */
+export function providerWebhookCallbackUrl(providerType: string): string {
+  return `${webhookCallbackBase()}/api/${providerType}/webhook`
+}

--- a/packages/lib/src/providers/webhook-manager-service.ts
+++ b/packages/lib/src/providers/webhook-manager-service.ts
@@ -1,11 +1,11 @@
 // packages/lib/src/providers/webhook-manager-service.ts
-import { WEBAPP_URL } from '@auxx/config/server'
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
 import type { ProviderRegistryService } from './provider-registry-service'
 import { resolveEffectiveSyncMode } from './sync-mode-resolver'
 import type { ChannelProviderType } from './types'
+import { providerWebhookCallbackUrl } from './webhook-callback-base'
 
 const logger = createScopedLogger('webhook-manager-service')
 
@@ -36,9 +36,8 @@ export class WebhookManagerService {
    */
   async setupWebhooks(integrationType: ChannelProviderType, integrationId?: string): Promise<void> {
     try {
-      // Build callback URL based on environment and provider type
-      const baseUrl = WEBAPP_URL
-      const callbackUrl = `${baseUrl}/api/${integrationType}/webhook`
+      // Build callback URL based on environment and provider type (NGROK_URL-aware in dev)
+      const callbackUrl = providerWebhookCallbackUrl(integrationType)
 
       if (integrationId) {
         logger.info(`Registering webhook for specific integration`, {
@@ -268,8 +267,7 @@ export class WebhookManagerService {
    * Build callback URL for a specific provider type
    */
   private buildCallbackUrl(providerType: ChannelProviderType): string {
-    const baseUrl = WEBAPP_URL
-    return `${baseUrl}/api/${providerType}/webhook`
+    return providerWebhookCallbackUrl(providerType)
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #1585. Dev arming failed with `NotificationUrl scheme='http' is not supported` — Graph refuses non-HTTPS notification URLs, and `WEBAPP_URL` is `http://localhost:3000` locally, so the provisioning hook always fell back to polling in dev.

Adopts the existing repo convention (`process.env.NGROK_URL || WEBAPP_URL`, same as every OAuth redirect base) via a shared `providerWebhookCallbackUrl` helper, used by:
- `armOutlookSubscription`
- `WebhookManagerService` (`setupWebhooks` + `buildCallbackUrl`)
- `webhookRenewalJob`
- the phase 0 probe script's default URL

No-op in production, where `NGROK_URL` is unset. Also makes the arm-subscription test assert the route path instead of the origin (vitest inherits the shell's `NGROK_URL`).

## Test plan
- [x] outlook provider suites: 58/58 pass
- [x] biome clean on all changed files
- [ ] dev: reconnect an Outlook channel with `NGROK_URL` set → subscription arms, `syncMode` returns to `auto`