### PR TITLE
fix(channels): let the polling scanner drive webhook-mode backfills to completion

### DIFF
--- a/packages/lib/src/jobs/polling/polling-sync-scanner-job.ts
+++ b/packages/lib/src/jobs/polling/polling-sync-scanner-job.ts
@@ -62,22 +62,34 @@ export const pollingSyncScannerJob = async (ctx: JobContext<PollingSyncScannerJo
           eq(schema.Integration.enabled, true),
           inArray(schema.Integration.provider, ['google', 'outlook', 'imap']),
           isNull(schema.Integration.deletedAt),
-          // Effective polling mode, mirroring resolveEffectiveSyncMode: explicit
-          // 'polling', or anything-but-'webhook' when the provider's auto mode
-          // resolves to polling.
+          // Two selection arms (FAILED is the relaunch job's; active stages skip):
           or(
-            eq(schema.Integration.syncMode, 'polling'),
+            // 1. An in-flight two-phase pipeline is driven to completion REGARDLESS of
+            //    sync mode. Webhook-mode channels enter these stages too — the Outlook
+            //    arm-on-connect flow kicks messageListFetchJob for the initial backfill
+            //    (webhook-push-migration plan Phase 2.4), and only this scanner advances
+            //    MESSAGES_IMPORT_PENDING → messagesImportJob. Excluding webhook rows here
+            //    stranded that backfill at MESSAGES_IMPORT_PENDING forever with zero
+            //    messages imported. Draining ends at IDLE, which the arm below ignores
+            //    for webhook rows — so this never turns into periodic polling.
+            inArray(schema.Integration.syncStage, [
+              'MESSAGE_LIST_FETCH_PENDING',
+              'MESSAGES_IMPORT_PENDING',
+            ]),
+            // 2. New cycles (from IDLE) start ONLY for effective polling mode, mirroring
+            //    resolveEffectiveSyncMode: explicit 'polling', or anything-but-'webhook'
+            //    when the provider's auto mode resolves to polling.
             and(
-              ne(schema.Integration.syncMode, 'webhook'),
-              inArray(schema.Integration.provider, [...autoPollingProviders])
+              eq(schema.Integration.syncStage, 'IDLE'),
+              or(
+                eq(schema.Integration.syncMode, 'polling'),
+                and(
+                  ne(schema.Integration.syncMode, 'webhook'),
+                  inArray(schema.Integration.provider, [...autoPollingProviders])
+                )
+              )
             )
           ),
-          // Actionable stages only (FAILED is the relaunch job's; active stages skip)
-          inArray(schema.Integration.syncStage, [
-            'IDLE',
-            'MESSAGE_LIST_FETCH_PENDING',
-            'MESSAGES_IMPORT_PENDING',
-          ]),
           // Not throttled
           or(
             isNull(schema.Integration.throttleRetryAfter),


### PR DESCRIPTION
## Summary

Follow-up to #1585. A freshly connected Outlook channel armed correctly but its initial backfill stalled at `MESSAGES_IMPORT_PENDING` with 0 messages imported.

Root cause: the two-phase backfill is **scanner-driven** — `messageListFetchJob` fills the Redis import cache and parks the row at `MESSAGES_IMPORT_PENDING`; only `pollingSyncScannerJob` advances it by enqueueing `messagesImportJob` (and re-enqueueing between batches). The scanner's WHERE selected effective-polling rows only, which worked while Outlook was forced to `syncMode: 'polling'` — but arm-on-connect now leaves Outlook on `'auto'` (→ webhook), making the mid-backfill row invisible to the scanner.

Fix: the scanner selects any row with an in-flight two-phase pipeline (`MESSAGE_LIST_FETCH_PENDING` / `MESSAGES_IMPORT_PENDING`) **regardless of sync mode**, and starts new cycles from `IDLE` only for effective polling mode. A webhook channel's backfill therefore drains to `IDLE` and drops back out of scanner scope — push remains the only ongoing door, no periodic polling is introduced.

The stale-check job already had no mode filter, so crash recovery of active stages was consistent all along. Known remaining edge (unchanged behavior): a webhook-mode backfill that goes terminally `FAILED` is not relaunched by `pollingRelaunchFailedJob` (it skips non-polling rows) — recovery there is reconnect, same as before.

## Test plan
- [x] biome + jobs suites (83 tests) + scoped tsc clean
- [ ] dev: reconnected Outlook channel's stalled backfill resumes on the next scanner tick and drains to IDLE with `initialBackfillCompletedAt` stamped