### PR TITLE
docs(channels): outlook push architecture + relaunch failed webhook backfills

### DIFF
--- a/docs/channels-mail-architecture-guide.md
+++ b/docs/channels-mail-architecture-guide.md
@@ -55,7 +55,8 @@ machinery rather than a bespoke ACL.
   Gmail (Pub/Sub push) → /api/google/webhook   ┐
   Outlook (Graph sub)  → /api/outlook/webhook  │
   Gmail/Outlook/IMAP   → polling scanner       ┼─▶ provider.importMessages
-   (poll fallback)        → list-fetch → import│      → MessageData[]
+   (fallback + initial    → list-fetch → import│      → MessageData[]
+    backfill)                                  │
   forward@mail.auxx.ai → SES → SQS → worker    │            │
   FB / IG / OpenPhone  → /api/<provider>/…     ┘            ▼
                                                  batchStoreMessages → storeMessage
@@ -216,7 +217,13 @@ then runs a **post-connect hook**:
 
 `channels/provisioning-hook.ts` (Gmail/Outlook) — resolve a fresh access token, fetch the account
 email, discover Outlook aliases, create-or-relink the `Integration`, link it to an inbox, seed sync
-state, and arm the Gmail watch / kick polling.
+state, and arm the push door: Gmail watch, or the Outlook Graph subscription via
+`armOutlookSubscription` (which first seeds `metadata.graphDeltaLink` with a `since = now` delta
+walk so push only ever sees future mail, then arms; on failure the row is stamped
+`syncMode: 'polling'` — **not** `'auto'`, which would resolve straight back to webhook and the
+polling scanner would skip it). A new channel then still kicks the polling pipeline once for its
+initial history backfill (§8). Reconnects re-arm without re-backfilling; the *silent* token-refresh
+reconnect path never reaches this hook, so `recoverChannel` re-arms too.
 `channels/social-provisioning-hook.ts` (Facebook/Instagram) and
 `channels/openphone-provisioning-hook.ts` do the equivalent for their platforms;
 `channels/register-hooks.ts` wires them up.
@@ -273,25 +280,57 @@ don't "consistency-fix" one against the other.
 | Provider | Endpoint | Verification |
 | --- | --- | --- |
 | Gmail | `apps/web/src/app/api/google/webhook/route.ts` | Pub/Sub push JWT — JWKS from `googleapis.com/oauth2/v3/certs`, RS256, audience = `WEBAPP_URL` \| the Pub/Sub subscriber audience \| the configured service-account email |
-| Outlook | `apps/web/src/app/api/outlook/webhook/route.ts` | Graph `?validationToken=` handshake (answered **before** anything else, on both GET and POST) + `clientState` check against the stored webhook secret |
+| Outlook | `apps/web/src/app/api/outlook/webhook/route.ts` + `…/webhook/lifecycle/route.ts` | Graph `?validationToken=` handshake (answered **before** anything else, on both GET and POST, on both routes) + `clientState` timing-safe check against the per-integration secret in `metadata.outlookSubscription`; unverifiable notifications are **dropped, never thrown** (a 500 makes Graph retry a notification we will never accept) |
 | Facebook / Instagram | `api/{facebook,instagram}/webhook/route.ts` | `hub.challenge` subscribe handshake + `X-Hub-Signature-256` |
 | OpenPhone | `api/openphone/webhook/route.ts` | `x-openphone-signature` verified against the integration's credential secret (`@auxx/lib/webhooks`) |
 
 Gmail push carries a `historyId`, not the mail — the handler resolves the channel and runs an
-incremental history sync from `Integration.lastHistoryId`. Webhook lifetime is managed by
-`providers/webhook-manager-service.ts` (Gmail watches expire and must be re-armed).
+incremental history sync from `Integration.lastHistoryId`.
+
+**Outlook push is the live inbound door** (plans/outlook/webhook-push-migration.md, shipped
+2026-08-13 as #1585/#1586/#1587) and is shaped by Graph's **3-second ack rule**: a slow endpoint
+gets marked slow/drop and mail is silently lost. So the route only validates → resolves the
+channel by the **indexed `Integration.webhookRouteKey` column** (the Graph subscription id;
+never the old jsonb scan) → enqueues `outlookPushSyncJob` → `202`. The job debounces bursts into
+one delta walk per 15s window (jobId coalescing) and takes a **per-integration Redis lock** — the
+only thing serializing `metadata.graphDeltaLink`, whose hold-on-retriable-failure safety two
+concurrent walks would silently defeat. The lifecycle route handles `reauthorizationRequired`
+(PATCH renews *and* reauthorizes — never pair with `/reauthorize`), `subscriptionRemoved`
+(clear state → re-arm → catch-up sync) and `missed` (delta resync).
+
+**Webhook lifetime.** Gmail watches and Outlook subscriptions (max just under 7 days; armed for
+6d20h) are renewed by `webhookRenewalScannerJob` (15 min, 24h buffer, reads
+`metadata.outlookSubscription.expiresAt`). The hourly `outlookSubscriptionHealthJob` is the
+backstop that replaces running polling in parallel: it re-arms dead/expired subscriptions, and
+for a stored-but-silent one (stale `lastSyncedAt`) it first `GET`s the subscription — a quiet
+mailbox is not a dead one, never re-arm on staleness alone. Repeated arm failures flip
+`syncStatus` to `FAILED`; the first successful arm is the only thing that un-fails it.
+
+**Dev:** Graph rejects `http://` notification URLs, so callbacks are built via
+`providers/webhook-callback-base.ts` (`NGROK_URL || WEBAPP_URL` — the same convention as the
+OAuth redirect bases). Arming in dev requires the tunnel.
 
 ---
 
 ## 8. Inbound Door 2 — Two-Phase Polling
 
-The polling pipeline is the fallback for Gmail (missing Pub/Sub env), the default for IMAP, and
-the recovery path for everything. All jobs run on the `polling-sync` queue
-(`apps/worker/.../polling-sync-worker.ts`, concurrency 10, 5 min lock).
+The polling pipeline is the fallback for Gmail (missing Pub/Sub env) and for Outlook when
+subscription arming fails (the provisioning hook stamps `syncMode: 'polling'`), the default for
+IMAP, and the **one-shot initial backfill** for every new channel — a webhook-mode Outlook
+channel runs this pipeline exactly once at connect to import its history, then never again
+(push is the ongoing door; the health job is the recovery path). All jobs run on the
+`polling-sync` queue (`apps/worker/.../polling-sync-worker.ts`, concurrency 10, 5 min lock).
+
+**The pipeline is scanner-driven, and the scanner has two selection arms** (#1587): any row with
+an in-flight pipeline (`MESSAGE_LIST_FETCH_PENDING` / `MESSAGES_IMPORT_PENDING`) is driven to
+completion **regardless of sync mode** — only the scanner advances those stages, so excluding
+webhook rows stranded their initial backfill forever — while *new* cycles (from `IDLE`) start
+only for effective polling mode.
 
 ```
-  pollingSyncScannerJob        every ~5 min — find polling-mode channels needing work
-        │                       (enabled, not requiresReauth, past pollingIntervalMs,
+  pollingSyncScannerJob        every ~5 min — drive in-flight pipelines (any mode) +
+        │                       start IDLE cycles (polling mode only; enabled, not
+        │                       requiresReauth, past pollingIntervalMs,
         │                        30s CLAIM_COOLDOWN_MS against double-enqueue)
         ├─▶ messageListFetchJob      PHASE 1 — discover ids
         │     provider.fetchMessageIds() → ids into the Redis import cache
@@ -303,10 +342,26 @@ the recovery path for everything. All jobs run on the `polling-sync` queue
               stage: MESSAGES_IMPORT → …
 ```
 
+**The backfill trigger cutoff.** Historical mail must not fire `message:received` subscribers
+(workflows, billed classification, bounce ingest, timeline), and "which code path ingested it"
+was never a safe gate — the polling backfill routes through `importMessages`, which is also the
+live import path. So suppression is **received-time based**: the provisioning hook stamps
+`metadata.backfillCutoffAt` at connect (the *same* epoch the Outlook delta cursor is seeded
+from), the provider sets it on the ingest ctx, and `storeMessage` suppresses the publish for
+inbound mail received before it — regardless of walker — until `messagesImportJob`'s first
+drain-to-IDLE stamps `metadata.initialBackfillCompletedAt`. Overlap mail (received ≥ cutoff)
+fires exactly once via the fresh-insert-only gate, whichever walker wins. Built as a shared
+ingest mechanism (`ctx.backfillCutoffAt`); only Outlook wires it so far — Gmail's polling path
+still has the walker-based hole (separate ticket).
+
 **Self-healing.** `pollingStaleCheckJob` (~15 min) resets channels stuck in an active stage past
 15 min — preserving the Redis import cache so recovery resumes importing rather than re-listing
-against an already-advanced cursor. `pollingRelaunchFailedJob` (~30 min) resets `FAILED` polling
-channels, skipping `requiresReauth` and rows still inside `throttleRetryAfter`.
+against an already-advanced cursor; it has no sync-mode filter, so it covers a webhook channel's
+backfill too. `pollingRelaunchFailedJob` (~30 min) resets `FAILED` channels, skipping
+`requiresReauth` and rows still inside `throttleRetryAfter`; it relaunches effective-polling rows
+plus webhook-mode rows **only while their initial backfill is incomplete** (`backfillCutoffAt`
+stamped, `initialBackfillCompletedAt` not) — an arm-failure `FAILED` from the health job is
+deliberately not "fixed" by re-running list-fetch.
 
 **IMAP is special**: full sync uses windowed UID scanning with durable per-folder checkpoints
 (`Label.syncCheckpoint`) and enqueues *self-contained* `imapImportBatchJob`s instead of using the
@@ -619,6 +674,20 @@ components in `~/components/mail` (thread list/display/composer, chat panel, sea
 23. **Bulk/system writes bypass the per-write fan-out.** If an automation needs to react to synced
     mail-adjacent records, that's the sync-change manifest — see
     `entity-events-architecture-guide.md` §8.
+24. **The Outlook delta cursor is serialized only by `outlookPushSyncJob`'s Redis lock.** The 15s
+    jobId debounce is not a concurrency guard; a second walk from the same `graphDeltaLink`
+    silently defeats the hold-cursor-on-retriable-failure safety. Never call
+    `syncMessages('outlook', …)` from a new concurrent path without going through the job.
+25. **Never gate historical-mail suppression on the ingest walker.** Use the received-time cutoff
+    (`metadata.backfillCutoffAt` / `initialBackfillCompletedAt`, `ctx.backfillCutoffAt`) — the
+    `isInitialSync` flag is a property of which code path ran, and the polling backfill shares its
+    import path with live sync.
+26. **`Integration.webhookRouteKey` is the inbound routing key** (unique per provider among live
+    rows). It is a column, so `metadata: null` does NOT clear it — every teardown path
+    (`removeWebhook`, `revokeAccess`, lifecycle `subscriptionRemoved`) must null it explicitly.
+27. **Outlook webhook callbacks must be HTTPS.** Build them via
+    `providers/webhook-callback-base.ts` (`NGROK_URL || WEBAPP_URL`), never from `WEBAPP_URL`
+    directly — Graph rejects `http://` and dev arming silently falls back to polling.
 
 ---
 
@@ -631,17 +700,21 @@ components in `~/components/mail` (thread list/display/composer, chat panel, sea
 
 **Providers** — `packages/lib/src/providers/`: `channel-provider.interface.ts`,
 `provider-registry-service.ts`, `provider-capabilities.ts`, `sync-mode-resolver.ts`,
-`auth-error-handler.ts`, `webhook-manager-service.ts`, and the per-provider dirs
-(`google/`, `outlook/`, `imap/`, `email/`, `mailgun/`, `facebook/`, `instagram/`, `openphone/`,
-`chat/`).
+`auth-error-handler.ts`, `webhook-manager-service.ts`, `webhook-callback-base.ts`, and the
+per-provider dirs (`google/`, `outlook/` (incl. `outlook-subscription.ts` — arm/seed), `imap/`,
+`email/`, `mailgun/`, `facebook/`, `instagram/`, `openphone/`, `chat/`).
 
 **Inbound** — `packages/lib/src/ingest/` (`batch-store-messages.ts`, `store-message.ts`,
 `context.ts`, `threads/resolve-thread.ts`, `filtering/`, `reconciliation/`, `contacts/`,
 `companies/`), `packages/lib/src/email/inbound/`, `apps/worker/src/inbound-email/`,
-`apps/web/src/app/api/{google,outlook,facebook,instagram,openphone}/webhook/route.ts`.
+`apps/web/src/app/api/{google,outlook,facebook,instagram,openphone}/webhook/route.ts` (+
+`outlook/webhook/lifecycle/route.ts`, `outlook/webhook/shared.ts`).
 
-**Sync jobs** — `packages/lib/src/jobs/polling/`, `packages/lib/src/jobs/messages/`,
-`packages/lib/src/sync-core/`, `apps/worker/src/workers/worker-definitions/{polling-sync,
+**Sync jobs** — `packages/lib/src/jobs/polling/`, `packages/lib/src/jobs/messages/`
+(incl. `outlook-push-sync-job.ts`), `packages/lib/src/jobs/maintenance/`
+(`webhook-renewal-scanner-job.ts`, `webhook-renewal-job.ts`,
+`outlook-subscription-health-job.ts`), `packages/lib/src/sync-core/`,
+`apps/worker/src/workers/worker-definitions/{polling-sync,
 message-sync,message-processing,email}-worker.ts`.
 
 **Outbound** — `packages/lib/src/messages/` (`message-composer.service.ts`,

--- a/docs/today-architecture-guide.md
+++ b/docs/today-architecture-guide.md
@@ -1,15 +1,20 @@
 # Today Architecture Guide
 
-Today is a daily-triage home tab: a headless AI agent watches CRM entities
-(deals/leads/tickets) that have gone quiet, proposes a bundle of next actions
-per entity, and the account owner triages each bundle with a single Yes/No.
-Covers the scanner, the headless agent run, the bundle data model, apply-time
-execution, and the frontend. Verified against the implementation on
-**2026-07-09**. Feature-flagged (`FeatureKey.todayInbox`, default **off**) —
-nothing here runs for an org unless the flag is enabled.
+"Today" is the AI-suggestion triage lane: headless AI runs propose bundles of
+next actions, and the owner triages each bundle with a single Yes/No in the
+**Approvals tab of the notification side panel** (there is no Today page —
+see §7). Two producers mint bundles: the stale-entity scanner (deals/leads/
+tickets gone quiet) and the learned-KB extraction job (resolved threads —
+see §4b). Covers the scanner, both headless runs, the bundle data model,
+apply-time execution, and the frontend. Verified against the implementation on
+**2026-08-13**. The suggestion lane is feature-flagged (`FeatureKey.todayInbox`,
+default **off**); learned extraction has its own flag (`FeatureKey.learnedMemory`).
+The Approvals tab itself and its workflow-confirmation / access-request /
+mail-suggestion sections are **not** gated on either.
 
-Ground-truth plan (matches shipped code closely):
-`plans/follow-up/phases/phase-3e-today-ui.md`, with sibling phases
+Ground-truth plans:
+`plans/today/README.md` (the fold-into-approvals-tab move, shipped 2026-07-28)
+on top of `plans/follow-up/phases/phase-3e-today-ui.md`, with sibling phases
 `phase-3a-capture-mode.md` (engine capture mode), `phase-3b-headless-runner.md`,
 `phase-3c-suggestion-table.md` (`AiSuggestion` design), `phase-3d-event-triggers.md`
 (**not yet built** — see §6), `phase-4-override.md`, `phase-5-spawn.md`,
@@ -41,7 +46,7 @@ in-row countdown with an `Undo`.
 
 | Table | File | Role |
 | --- | --- | --- |
-| `AiSuggestion` | `ai-suggestion.ts` | One bundle of `ProposedAction[]` per entity per triage cycle. `entityInstanceId`/`entityDefinitionId` (denormalized), `threadId?` (context only), `ownerUserId` (snapshotted at creation — reassignment doesn't re-route), `bundle` (jsonb: `{ actions, summary, modelId, headlessTraceId, computedForLatestMessageId? }`), `actionCount` (denormalized), `computedForActivityAt` (drives FRESH→STALE), `triggerSource` (`'event'\|'stale_scan'\|'manual'\|'override'`), `status` (`FRESH → APPROVED\|PARTIALLY_APPROVED\|REJECTED\|STALE`), `outcomes` (jsonb `ActionOutcome[]`, populated on approve), `decidedById`/`decidedAt`. Partial unique index `(organizationId, entityInstanceId) WHERE status='FRESH'` — enforces **one active bundle per entity**; the scanner relies on the resulting unique-violation as a no-op signal. |
+| `AiSuggestion` | `ai-suggestion.ts` | One bundle of `ProposedAction[]` per entity per triage cycle. `entityInstanceId`/`entityDefinitionId` (denormalized), `threadId?` (context only), `ownerUserId` (snapshotted at creation — reassignment doesn't re-route), `bundle` (jsonb: `{ actions, summary, modelId, headlessTraceId, computedForLatestMessageId? }`), `actionCount` (denormalized), `computedForActivityAt` (drives FRESH→STALE), `triggerSource` (`'event'\|'stale_scan'\|'manual'\|'override'\|'learned-extraction'`), `status` (`FRESH → APPROVED\|PARTIALLY_APPROVED\|REJECTED\|STALE`), `outcomes` (jsonb `ActionOutcome[]`, populated on approve), `decidedById`/`decidedAt`. **Two** partial unique indexes: `AiSuggestion_org_entity_active_key` on `(organizationId, entityInstanceId) WHERE status='FRESH' AND "triggerSource" <> 'learned-extraction'` — one active bundle per entity for scanner-produced bundles (the scanner relies on the unique-violation as a no-op signal) — and `AiSuggestion_org_thread_learned_active_key` on `(organizationId, threadId) WHERE status='FRESH' AND "triggerSource" = 'learned-extraction'` — learned bundles dedupe **per thread** instead. |
 | `SuggestionDismissal` | `suggestion-dismissal.ts` | Per-user, per-entity skip record from Reject/Snooze. `dismissedAtActivity` (entity's `lastActivityAt` at dismissal time) + optional `snoozeUntil`. The scanner's candidate query excludes an entity while `dismissedAtActivity >= entity.lastActivityAt` — so the dismissal naturally expires once new activity lands, independent of `snoozeUntil`. Unique per `(organizationId, userId, entityInstanceId)` — upserted on repeat dismissal. Dismissal is **per-user**, not org-wide. |
 | `ScheduledMessage` (extended) | `scheduled-message.ts` | Reused, not a new table. Today-specific columns: `source` (`USER_SCHEDULED\|AI_SUGGESTED\|AUTO_REPLY`), `approvedById` (who clicked Yes), `cancelledAt`/`cancelledById`, `aiSuggestionId` (FK back to the originating bundle). Indexed `(organizationId, source, approvedById, status)` for the pending-sends pill. |
 | — | — | No new tables for entity data itself — Today reads `EntityInstance` (+ two new columns, below), `Draft`, and the existing field-value system. |
@@ -126,6 +131,43 @@ separate `kind` discriminator, callers branch on which field is set.
 
 ---
 
+## 4b. The second producer — learned-KB extraction (`packages/lib/src/approvals/learned-extraction-runner.ts`)
+
+`runLearnedExtraction` mints bundles too — same capture machinery
+(`resolveCaptureRunPrincipal`, `mergeActions`/`parseFinalText`), different
+trigger, scope, and flag. When a thread resolves (archive path in
+`threads/thread-mutation.service.ts`) or a member explicitly asks ("remember
+this thread", `thread` router → `force: true` + `requestedByUserId`),
+`enqueueLearnedExtraction` queues a run on its **own** queue
+(`Queues.learnedExtractionQueue`, own worker definition) with a stable
+per-thread jobId that collapses archive→reopen→archive bursts; forced runs get
+a unique jobId and no delay.
+
+The job (`jobs/approvals/learned-extraction-job.ts`) gates on
+`FeatureKey.learnedMemory`, then on row-local noise gates
+(`learned-extraction-gates.ts`: thread `ARCHIVED`, not merged, ≥2 messages,
+`learnedExtractedAt < lastMessageAt` so a reopen with no new conversation is a
+no-op), a **human-authored-outbound** check (`hasHumanOutbound` over a 20-send
+sample — agents must not learn from their own replies; provider-synced sends
+count as human), and a fixed-window daily cap
+(`LEARNED_EXTRACTION_DAILY_LIMIT = 100`/org — forced runs count toward the
+window but are never blocked by it). The runner feeds the KB catalog plus a
+capped transcript (30 messages, 2k chars each) to the engine, which proposes
+`upsert_learned_article` writes in capture mode ("one living article per
+topic; when in doubt, save nothing"). A non-noop result lands via
+`createBundleFromHeadlessRun` with `triggerSource: 'learned-extraction'`,
+deduped per-thread by the second partial unique index (§2), and
+`Thread.learnedExtractedAt` is stamped.
+
+Display note: learned bundles are ordinary `AiSuggestion` rows, so they render
+in the same **Suggestions** section — which the client gates on
+`FeatureKey.todayInbox`. A learned bundle is therefore only *visible* when
+`todayInbox` is also on, even though its producer is gated on `learnedMemory`.
+`SuggestionRow` branches on `toolName === 'upsert_learned_article'` to render
+`LearnedArticlePreview` for these actions.
+
+---
+
 ## 5. Apply-time — approving a bundle (`packages/lib/src/approvals/actions-service.ts`)
 
 `approveBundle` is the all-or-nothing execution path, invoked from
@@ -185,28 +227,33 @@ avoid name collisions as the two evolve independently.
 | Procedure | Purpose |
 | --- | --- |
 | `list` | Paginated bundles (`ownerScope`: `mine`\|`mine_and_unassigned`\|`all`; default status filter `['FRESH']`; cursor = base64 `createdAt\|id`). |
+| `count` | Open-bundle count for the bell/tab badge (`countBundles`) — so the badge never pages the list. |
 | `get` | Single bundle by id. |
-| `approve` | Runs `approveBundle`; maps `ConflictError` → tRPC `CONFLICT`. |
+| `approve` | Runs `approveBundle`; maps `ConflictError` → tRPC `CONFLICT` and `ForbiddenError` → `FORBIDDEN` (a permission-blocked action leaves the bundle `FRESH`). |
 | `reject` | Runs `rejectBundle`. |
 | `snooze` | Runs `snoozeBundle`. |
 | `cancelPendingSend` | Runs `cancelPendingSend`. |
-| `listPending` | `ScheduledMessage` rows where `source='AI_SUGGESTED', status='PENDING'`, optionally scoped to the caller (`mineOnly`, default true). |
+| `listPending` | `ScheduledMessage` rows where `source='AI_SUGGESTED', status='PENDING'` (`mineOnly`, default true). **Effectively dead** — its consumer was the deleted `/app/today/pending` page; the countdown now reads `findScheduledSend` in-row. No web caller remains. |
 
 ### Known gaps vs. the plan epic
-- **`phase-3d-event-triggers.md` (reactive triggers) was never built.** The
-  scanner (`triggerSource: 'stale_scan'`) is the only thing that calls
-  `runHeadlessSuggestion` today — `'event'` and `'manual'` are valid
-  `triggerSource` values in the type system but nothing produces them yet.
-  Bundles are compute-on-a-5-minute-poll only, not reactive to inbound
-  messages.
+- **`phase-3d-event-triggers.md` (generic reactive triggers) was never built.**
+  The scanner (`triggerSource: 'stale_scan'`) is still the only caller of
+  `runHeadlessSuggestion`; `'event'` and `'manual'` remain valid
+  `triggerSource` values nothing produces. Entity bundles are
+  compute-on-a-5-minute-poll only, not reactive to inbound messages. (The
+  learned-extraction lane, §4b, IS event-driven — thread archive — but it is
+  its own runner and `triggerSource`, not the 3d design.)
 - **`phase-6-polish.md`'s ranking model was never built** — `listBundles`
-  is recency-sorted, not the planned SLA/value/confidence score.
-- **Snooze has no frontend affordance** — the mutation and schema support
-  exist, but `BundleCard` (§7) only renders Yes/No; there's no snooze UI
-  wired up yet.
+  is recency-sorted (`createdAt desc, id desc`), not the planned
+  SLA/value/confidence score.
 - **Reject doesn't clean up soft-tool side effects** — a Draft created
   during headless capture survives a Reject and sits in the org's normal
   Drafts tab (explicitly deferred, not a bug).
+- **`plans/today/06-router-merge.md` (fold `approval` + `approvals` into one
+  router) is planned, not built** — both stay registered separately in
+  `root.ts`.
+- Closed gaps: snooze now **has** a frontend affordance (the `SuggestionRow`
+  overflow menu, §7); the badge no longer pages the list (`approvals.count`).
 
 ---
 
@@ -302,9 +349,30 @@ node, message, timestamps, and the decision comment `Textarea`. Approve has
 no confirm; **Deny does** — it stops a live run with no undo. A past-expiry
 request disables both actions.
 
+### Badge & realtime
+`useApprovalsCount` (`hooks/use-approvals-count.ts`) is the **single** badge
+source: `approval.getPendingCount` + `approvals.count` (gated on `todayInbox`)
++ `useMailSuggestionsCount()` (deliberately ungated). Errors are surfaced
+separately so a failed load renders `!` rather than a silent `0`. Both
+consumers — the sidebar bell (`notification-trigger.tsx`, total = unread +
+approvals) and the tab badge (`notification-panel.tsx`) — read this one hook
+and must not drift (the hook's own comment says so).
+
+Freshness is split by lane. Confirmations/access requests are push-fresh:
+`'approval'` and `'approval:resolved'` publish on the **assignee's user room**
+(`realtime/events.ts`, `publish-helpers.ts`), and
+`hooks/use-notification-subscription.ts` invalidates all four queries
+(`approval.getPendingCount`, `approval.list`, `approvals.count`,
+`approvals.list`); `'approval'` also pulses the bell (+ optional sound).
+Suggestion bundles and mail suggestions publish **nothing** — those lanes are
+refetch-driven (window-focus refetch on the counts, mutation invalidation, and
+a fresh fetch when the panel opens).
+
 Panel state (`open`, `mode`, `highlightApprovalId`) lives in
 `notification-panel-store.ts`; `openApprovals(id?)` is how the kbar action
-and `APPROVAL` notification rows jump to the tab. Only `width` is persisted.
+(`nav.approvals`, `components/kbar/actions/navigation.ts`) and `APPROVAL`
+notification rows jump to the tab — there is no URL for it. Only `width` is
+persisted.
 
 ---
 
@@ -319,17 +387,30 @@ email (soft call, real `Draft` created) + a follow-up task (captured,
 `createBundleFromHeadlessRun` inserts a `FRESH` `AiSuggestion` →
 `EntityInstance.lastSuggestionScanAt` bumped either way.
 
-**Owner approves from Today**
-`TodayPage` renders the card → click **Yes** → `approvalsRouter.approve` →
-staleness re-check passes → topo-sort → soft action promotes the Draft to a
-`ScheduledMessage` (send in 5 min, cancellable) → captured action's
-`create_task` tool runs for real, referencing the promoted message's id if
-chained → bundle marked `APPROVED` with per-action outcomes.
+**Owner approves from the Approvals tab**
+The panel's Suggestions section renders the bundle as a `SuggestionRow` →
+click **Approve** → `approvalsRouter.approve` → staleness re-check passes →
+topo-sort → soft action promotes the Draft to a `ScheduledMessage` (send in
+5 min, cancellable) → captured action's `create_task` tool runs for real,
+referencing the promoted message's id if chained → bundle marked `APPROVED`
+with per-action outcomes.
 
 **Owner cancels an AI-drafted send**
-`/app/today/pending` shows the countdown row → **Cancel** before the 5-minute
-buffer elapses → `ScheduledMessage` flips to `CANCELLED`, BullMQ job removed
-(best-effort) → row disappears from the pending list.
+The approved row flips in place to a `Sending in Nm Ns` countdown → **Undo**
+before the 5-minute buffer elapses → `approvals.cancelPendingSend` flips the
+`ScheduledMessage` to `CANCELLED`, BullMQ job removed (best-effort; the send
+job re-checks status at fire time) → the countdown clears. If the send already
+flipped to `PROCESSING`, a `send_in_flight` conflict surfaces as "Send in
+flight, can't cancel."
+
+**A thread resolves and teaches the AI Memory (§4b)**
+Thread archived → `enqueueLearnedExtraction` (stable per-thread jobId) →
+job passes the `learnedMemory` flag, noise gates, human-outbound check, and
+daily cap → `runLearnedExtraction` proposes `upsert_learned_article` writes in
+capture mode → `[summary]` result lands as a `FRESH` bundle with
+`triggerSource: 'learned-extraction'` (per-thread dedupe) →
+`Thread.learnedExtractedAt` stamped → the bundle renders in the Suggestions
+section with `LearnedArticlePreview`; Approve executes the article upserts.
 
 **Owner rejects instead**
 Click **No** → bundle flips to `REJECTED`, nothing executes; if the reject
@@ -343,16 +424,19 @@ point.
 
 | Concern | Path |
 | --- | --- |
-| Schema | `packages/database/src/db/schema/{ai-suggestion,suggestion-dismissal,scheduled-message}.ts`, `EntityInstance.lastSuggestionScanAt` |
+| Schema | `packages/database/src/db/schema/{ai-suggestion,suggestion-dismissal,scheduled-message}.ts`, `EntityInstance.lastSuggestionScanAt`, `Thread.learnedExtractedAt` |
 | Scanner job | `packages/lib/src/jobs/approvals/next-action-stale-scanner-job.ts` |
 | Staleness config | `packages/lib/src/work-items/stale-defaults.ts` |
 | Headless agent | `packages/lib/src/approvals/headless-runner.ts` |
-| Bundle CRUD | `packages/lib/src/approvals/bundle-service.ts` |
+| Learned extraction | `packages/lib/src/approvals/learned-extraction-runner.ts`, `packages/lib/src/jobs/approvals/{learned-extraction-job,learned-extraction-gates}.ts`, `apps/worker/src/workers/worker-definitions/learned-extraction-worker.ts` |
+| Bundle CRUD | `packages/lib/src/approvals/bundle-service.ts` (`createBundleFromHeadlessRun`, `listBundles`, `countBundles`, `markStaleBundles`) |
 | Apply / reject / snooze / cancel | `packages/lib/src/approvals/actions-service.ts` |
 | Types | `packages/lib/src/approvals/types.ts` (`ProposedAction`, `ActionOutcome`, `StoredBundle`) |
 | Capture-mode engine | `packages/lib/src/ai/agent-framework/capture-mode.ts`, `types.ts` (`approvalMode`, `captureMint`, `capturedActions`) |
-| tRPC | `apps/web/src/server/api/routers/approvals.ts` |
-| Frontend | `apps/web/src/components/today/` (`today-page.tsx`, `pending-page.tsx`, `bundle-card.tsx`) |
-| Routes | `apps/web/src/app/(protected)/app/today/{page.tsx,pending/page.tsx}` |
-| Feature flag | `packages/lib/src/permissions/types.ts` (`FeatureKey.todayInbox`) |
-| Plans (ground truth) | `plans/follow-up/phases/phase-3{a,b,c,d,e}-*.md`, `phase-4-override.md`, `phase-5-spawn.md`, `phase-6-polish.md` |
+| tRPC | `apps/web/src/server/api/routers/approvals.ts` (bundles), `approval.ts` (confirmations + access requests), `mail-suggestions.ts` (mail lane) |
+| Frontend | `apps/web/src/components/global/notifications/` — `ui/approvals-tab.tsx`, `ui/items/{suggestion,confirmation,access-request,mail-suggestion,decided}-row.tsx`, `hooks/use-approvals-count.ts`, `notification-panel.tsx`, `notification-panel-store.ts` |
+| Entry points | notification bell (`notification-trigger.tsx`) + kbar `nav.approvals` (`apps/web/src/components/kbar/actions/navigation.ts`) — no URL/route |
+| Realtime | `packages/lib/src/realtime/events.ts` (`approval`, `approval:resolved`), `publish-helpers.ts`, `apps/web/src/components/global/notifications/hooks/use-notification-subscription.ts` |
+| Feature flags | `packages/lib/src/permissions/types.ts` (`FeatureKey.todayInbox`, `FeatureKey.learnedMemory`) |
+| Mail-suggestions lane | `docs/mail-suggestions-architecture-guide.md` |
+| Plans (ground truth) | `plans/today/README.md` (+ `plans/today/06-router-merge.md`, planned), `plans/follow-up/phases/phase-3{a,b,c,d,e}-*.md`, `phase-4-override.md`, `phase-5-spawn.md`, `phase-6-polish.md` |

--- a/packages/lib/src/jobs/polling/polling-relaunch-failed-job.ts
+++ b/packages/lib/src/jobs/polling/polling-relaunch-failed-job.ts
@@ -28,6 +28,7 @@ export const pollingRelaunchFailedJob = async (_ctx: JobContext<PollingRelaunchF
       id: schema.Integration.id,
       provider: schema.Integration.provider,
       syncMode: schema.Integration.syncMode,
+      metadata: schema.Integration.metadata,
       requiresReauth: schema.Credential.requiresReauth,
       throttleRetryAfter: schema.Integration.throttleRetryAfter,
     })
@@ -45,13 +46,25 @@ export const pollingRelaunchFailedJob = async (_ctx: JobContext<PollingRelaunchF
   let relaunchedCount = 0
 
   for (const integration of failedIntegrations) {
-    // Only relaunch polling-mode integrations
     const effectiveMode = resolveEffectiveSyncMode({
       syncMode: integration.syncMode,
       provider: integration.provider,
     })
 
-    if (effectiveMode !== 'polling') continue
+    // Relaunch polling-mode rows, plus webhook-mode rows whose INITIAL BACKFILL died —
+    // the two-phase pipeline is their only way to get history, and the scanner (which
+    // drives in-flight pipelines regardless of mode) can't act on a FAILED stage. The
+    // incomplete-backfill predicate is what keeps this narrow: an arm-failure FAILED
+    // stamped by outlookSubscriptionHealthJob has a completed backfill, and re-running
+    // list-fetch would not fix a subscription problem. (Gmail webhook rows never carry
+    // backfillCutoffAt today, so their behavior is unchanged until they adopt the
+    // received-time cutoff mechanism.)
+    if (effectiveMode !== 'polling') {
+      const metadata = integration.metadata as Record<string, unknown> | null
+      const backfillIncomplete =
+        !!metadata?.backfillCutoffAt && !metadata?.initialBackfillCompletedAt
+      if (!backfillIncomplete) continue
+    }
 
     // Skip channels needing re-authentication
     if (integration.requiresReauth) continue


### PR DESCRIPTION
## Summary

Two commits:

**1. Architecture guide updates**
- `docs/channels-mail-architecture-guide.md` — Outlook is now Inbound Door 1 (Graph webhook push, #1585–#1587): arm-on-connect via `armOutlookSubscription` (seed-then-arm, polling fallback stamp), the 3-second-ack validate→enqueue→202 route shape with the per-integration Redis cursor lock, the lifecycle route, renewal scanner + hourly `outlookSubscriptionHealthJob` (quiet ≠ dead), the received-time backfill trigger cutoff, the polling scanner's two selection arms, `webhookRouteKey` routing, and the `NGROK_URL || WEBAPP_URL` dev callback convention. New invariants 24–27; key-files updated.
- `docs/today-architecture-guide.md` — catches the guide up to #1584 (learned-KB extraction as the second bundle producer, approvals-tab fold-in, per-thread learned dedupe index).

**2. Relaunch decision for failed webhook backfills** (the last open behavioral question from the migration)
`pollingRelaunchFailedJob` now also relaunches webhook-mode rows **while their initial backfill is incomplete** (`backfillCutoffAt` stamped, `initialBackfillCompletedAt` not) — previously a terminally FAILED backfill on a webhook Outlook channel stayed FAILED until manual reconnect. Deliberately narrow: an arm-failure FAILED from the health job (completed backfill) is untouched, and Gmail webhook rows (no cutoff stamp yet) are unchanged.

## Test plan
- [x] jobs suites (83 tests) pass, biome clean