### PR TITLE
fix(channels): gmail backfill trigger cutoff + enqueue-based webhook route

### DIFF
--- a/apps/web/src/app/api/google/webhook/route.ts
+++ b/apps/web/src/app/api/google/webhook/route.ts
@@ -1,9 +1,16 @@
 // apps/web/src/app/api/google/webhook/route.ts
+//
+// Google Pub/Sub push endpoint for Gmail watch notifications. Shape: validate → resolve →
+// enqueue → ack, all inside Pub/Sub's ack-deadline window — the same validate/enqueue/ack
+// pattern as the Outlook Graph webhook route (webhook-push-migration plan §6/Ticket 2).
+// Pub/Sub redelivers on a slow or failed ack, and nothing serializes `Integration.lastHistoryId`
+// against a concurrent redelivery, so the actual history sync runs out-of-band in
+// `googlePushSyncJob` on the message-sync queue; this route never syncs inline.
 
 import { WEBAPP_URL } from '@auxx/config/server'
 import { configService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
-import { type ChannelProviderType, MessageService } from '@auxx/lib/email'
+import { enqueueGooglePushSync } from '@auxx/lib/jobs'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq, sql } from 'drizzle-orm'
 import jwt from 'jsonwebtoken'
@@ -153,56 +160,42 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     }
 
     logger.info(
-      `Found integration ${integration.id} for email ${data.emailAddress}. Triggering sync.`
+      `Found integration ${integration.id} for email ${data.emailAddress}. Enqueuing push sync.`
     )
 
-    // 4. Update history ID and trigger sync
+    // 4. Enqueue the sync — never run it inline (plan §2.3/§6). `data.historyId` is advisory
+    // only: `googlePushSyncJob` re-derives everything from the integration's own
+    // `lastHistoryId` at sync time (mirrors how the Outlook push job treats the notification
+    // payload as a trigger, not a cursor). The comparison below is purely a cheap filter to
+    // skip enqueuing on an already-stale/redelivered notification — it does not gate
+    // correctness, since the job's own sync call is the source of truth for the cursor.
     const currentHistoryId = BigInt(data.historyId)
     const lastKnownHistoryId = integration.lastHistoryId
       ? BigInt(integration.lastHistoryId)
       : BigInt(0)
 
-    // Only proceed if the incoming history ID is newer
     if (currentHistoryId > lastKnownHistoryId) {
-      // DON'T update history ID before sync - let syncMessages handle it
-      // Store the target history ID for potential rollback scenarios
-      const targetHistoryId = data.historyId.toString()
-
       logger.debug(
-        `Starting sync for integration ${integration.id} from ${lastKnownHistoryId} to ${targetHistoryId}`
+        `Enqueuing push sync for integration ${integration.id} (notification historyId ${data.historyId}, last known ${lastKnownHistoryId})`
       )
-
-      // Initialize message service for the integration's organization
-      const messageService = new MessageService(integration.organizationId) // Use renamed service
-
-      // Trigger sync for this specific integration.
-      // The provider's syncMessages method will use the current lastHistoryId as startHistoryId
-      // and update it to the latest after successful processing
-      try {
-        await messageService.syncMessages('google' as ChannelProviderType, integration.id)
-        logger.info('Sync initiated successfully via webhook.', { integrationId: integration.id })
-      } catch (syncError) {
-        logger.error('Error during sync initiated by webhook:', {
-          error: syncError,
-          integrationId: integration.id,
-        })
-        // Even if sync fails, acknowledge the Pub/Sub message to prevent retries.
-        // The error is logged, and subsequent syncs (manual or scheduled) can catch up.
-      }
+      await enqueueGooglePushSync({
+        integrationId: integration.id,
+        organizationId: integration.organizationId,
+      })
     } else {
       logger.warn(
-        `Received stale historyId ${data.historyId} (<= ${lastKnownHistoryId}). Skipping sync.`,
+        `Received stale historyId ${data.historyId} (<= ${lastKnownHistoryId}). Skipping enqueue.`,
         { integrationId: integration.id }
       )
     }
 
-    // 5. Acknowledge the Pub/Sub message
-    return NextResponse.json({ success: true, message: 'Webhook processed' }) // Return 200 OK
+    // 5. Acknowledge the Pub/Sub message. Enqueuing durably queues the work, so this is a
+    // real ack, not a "trust me it'll work out" — the actual sync happens out-of-band.
+    return NextResponse.json({ success: true, message: 'Webhook enqueued' }, { status: 202 })
   } catch (error: any) {
+    // An enqueue failing (or any other error above) means the notification was NOT durably
+    // queued — 5xx so Pub/Sub retries, rather than acknowledging work we never acted on.
     logger.error('Error processing Google webhook:', { error: error.message, stack: error.stack })
-    // Return 500 for internal errors, Pub/Sub might retry.
-    // However, if parsing failed, retrying won't help, so maybe return 400 or 200?
-    // Let's return 500 for now to indicate server-side issue.
     return NextResponse.json({ error: 'Internal server error processing webhook' }, { status: 500 })
   }
 }

--- a/apps/worker/src/workers/worker-definitions/message-sync-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/message-sync-worker.ts
@@ -1,4 +1,5 @@
 import {
+  googlePushSyncJob,
   monitorMessageSyncJob,
   outlookPushSyncJob,
   startMessageSyncJob,
@@ -17,6 +18,7 @@ const messageSyncJobMappings = {
   monitorMessageSyncJob,
   threadProviderStatusSyncJob,
   outlookPushSyncJob,
+  googlePushSyncJob,
 }
 
 /**

--- a/packages/lib/src/channels/provisioning-hook.ts
+++ b/packages/lib/src/channels/provisioning-hook.ts
@@ -350,6 +350,25 @@ async function seedSync(args: {
   // Reconnect on a polling channel needs no backfill re-kick — the existing sync state stands.
   if (!isNew) return
 
+  if (provider === 'google') {
+    // Received-time trigger cutoff (webhook-push-migration plan Phase 2.5): the polling
+    // backfill routes through importMessages, which fires message:received per message —
+    // without this stamp a first connect on the polling path (custom OAuth client, missing
+    // Pub/Sub env, watch-arm failure) mass-fires workflows/classification for every
+    // historical email. Outlook stamps earlier (its epoch must match the delta-cursor
+    // seed); Gmail has no cursor-epoch constraint, so stamping here — only when the
+    // polling pipeline will actually run — keeps webhook-mode connects (whose
+    // sync-messages backfill never drains the import cache, so the completion stamp
+    // would never land) free of a permanently-open suppression window.
+    await db
+      .update(schema.Integration)
+      .set({
+        metadata: sql`COALESCE(${schema.Integration.metadata}, '{}'::jsonb) || jsonb_build_object('backfillCutoffAt', ${new Date().toISOString()}::text)`,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.Integration.id, integrationId))
+  }
+
   // Initial polling pipeline — imports history for a new channel regardless of sync mode:
   // Outlook is armed for push above but still backfills; Google with a custom client or on
   // polling mode has no other way to get its history.

--- a/packages/lib/src/jobs/index.ts
+++ b/packages/lib/src/jobs/index.ts
@@ -235,6 +235,12 @@ export {
 } from './mcp/mcp-tools-resync-job'
 // Messages
 export {
+  enqueueGooglePushSync,
+  GOOGLE_PUSH_DEBOUNCE_WINDOW_MS,
+  type GooglePushSyncJobData,
+  googlePushSyncJob,
+} from './messages/google-push-sync-job'
+export {
   MONITOR_RECHECK_DELAY_MS,
   type MonitorMessageSyncJobData,
   monitorMessageSyncJob,

--- a/packages/lib/src/jobs/messages/google-push-sync-job.ts
+++ b/packages/lib/src/jobs/messages/google-push-sync-job.ts
@@ -1,0 +1,159 @@
+// packages/lib/src/jobs/messages/google-push-sync-job.ts
+
+import { database as db, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { getRedisClient } from '@auxx/redis'
+import { eq } from 'drizzle-orm'
+import { type ChannelProviderType, MessageService } from '../../email/message-service'
+import { getQueue, Queues } from '../queues'
+import type { JobContext } from '../types'
+
+const logger = createScopedLogger('job:google-push-sync')
+
+/** Job payload — the one Gmail history cursor lives on the integration, nothing else to pass. */
+export interface GooglePushSyncJobData {
+  integrationId: string
+  organizationId: string
+}
+
+/**
+ * A burst of Pub/Sub notifications for the same mailbox collapses into one history sync per
+ * window: every notification arriving inside a given 15s slice resolves to the same
+ * `googlePushSyncJobId`, so BullMQ's dedupe-by-jobId does the coalescing for free. Defined
+ * locally (not shared with `OUTLOOK_PUSH_DEBOUNCE_WINDOW_MS`) to keep the two provider job
+ * modules independent.
+ */
+export const GOOGLE_PUSH_DEBOUNCE_WINDOW_MS = 15_000
+
+/**
+ * Deterministic jobId for the debounce window containing `at` (defaults to now). Two
+ * notifications landing in the same 15s window produce the same id; BullMQ then rejects the
+ * second `add` as a duplicate instead of queuing a second history sync.
+ */
+export function googlePushSyncJobId(integrationId: string, at: number = Date.now()): string {
+  return `google-push-${integrationId}-${Math.floor(at / GOOGLE_PUSH_DEBOUNCE_WINDOW_MS)}`
+}
+
+/**
+ * Enqueue (or coalesce into) a Google push-sync job. Callers include the webhook route (on a
+ * fresh Pub/Sub history notification) and the job body itself, which re-enqueues into the *next*
+ * window when it loses the per-integration lock (see {@link googlePushSyncJob}).
+ *
+ * "Already exists" from BullMQ means another notification already coalesced into this window —
+ * that is the intended outcome, not a failure, so it is swallowed rather than thrown.
+ */
+export async function enqueueGooglePushSync(
+  data: GooglePushSyncJobData,
+  opts?: { delay?: number }
+): Promise<void> {
+  const delay = opts?.delay
+  const jobId = googlePushSyncJobId(data.integrationId, Date.now() + (delay ?? 0))
+  const queue = getQueue(Queues.messageSyncQueue)
+
+  try {
+    await queue.add('googlePushSyncJob', data, {
+      jobId,
+      delay,
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 30000 },
+      removeOnComplete: { count: 100 },
+      removeOnFail: { count: 200 },
+    })
+  } catch (error: any) {
+    if (error.message?.includes('already exists')) {
+      logger.debug('Google push sync already queued for this debounce window', {
+        integrationId: data.integrationId,
+        jobId,
+      })
+      return
+    }
+    throw error
+  }
+}
+
+/**
+ * Google push-sync job body — what a Pub/Sub Gmail notification enqueues instead of running the
+ * history sync inline.
+ *
+ * Why enqueue instead of sync inline: Pub/Sub redelivers a push notification on a slow or failed
+ * ack, and a full history sync + ingest can run well outside an ack-friendly window on a busy
+ * mailbox — same 3xx/2xx ack-budget shape as Graph's push webhook (webhook-push-migration plan
+ * §2.3/§6), so the route only validates, resolves the integration, and enqueues; this job does
+ * the actual work off the request path.
+ *
+ * Why the per-integration lock: the debounce window (jobId coalescing) only prevents a *burst* of
+ * notifications from enqueuing multiple jobs — it does not stop two already-enqueued jobs from
+ * running concurrently once the message-sync worker's `concurrency: 5` picks them both up (e.g. a
+ * redelivered notification landing while the previous window's job is still mid-sync).
+ * `MessageService.syncMessages` has no guard of its own, and Gmail's history cursor
+ * (`Integration.lastHistoryId`) has the same concurrent-advance race Outlook's `graphDeltaLink`
+ * has — two concurrent syncs from the same stored cursor can race, with one run's advance
+ * silently stepping over the other's unretried batch. The Redis lock is the only thing
+ * serializing that cursor; when it's held, this job re-enqueues into the next debounce window
+ * instead of racing.
+ */
+export const googlePushSyncJob = async (ctx: JobContext<GooglePushSyncJobData>): Promise<void> => {
+  const { integrationId, organizationId } = ctx.job.data
+
+  const [row] = await db
+    .select({
+      id: schema.Integration.id,
+      deletedAt: schema.Integration.deletedAt,
+      enabled: schema.Integration.enabled,
+      requiresReauth: schema.Credential.requiresReauth,
+    })
+    .from(schema.Integration)
+    .leftJoin(schema.Credential, eq(schema.Credential.id, schema.Integration.credentialId))
+    .where(eq(schema.Integration.id, integrationId))
+    .limit(1)
+
+  // Notifications keep arriving for a broken or removed channel — bail before paying for a full
+  // provider init that would only fail anyway.
+  if (!row || row.deletedAt || !row.enabled || row.requiresReauth) {
+    logger.info('Skipping google push sync — integration not eligible', {
+      integrationId,
+      missing: !row,
+      deleted: !!row?.deletedAt,
+      enabled: row?.enabled,
+      requiresReauth: row?.requiresReauth,
+    })
+    return
+  }
+
+  const redis = await getRedisClient()
+  const lockKey = `google-push-sync:${integrationId}`
+  let acquired = false
+
+  if (redis) {
+    acquired = !!(await redis.set(lockKey, String(ctx.job.id ?? '1'), 'PX', 240_000, 'NX'))
+
+    if (!acquired) {
+      const now = Date.now()
+      const nextWindowStart =
+        (Math.floor(now / GOOGLE_PUSH_DEBOUNCE_WINDOW_MS) + 1) * GOOGLE_PUSH_DEBOUNCE_WINDOW_MS
+      const delay = nextWindowStart - now + 1000
+      logger.info('Google push sync lock held — re-enqueuing into next debounce window', {
+        integrationId,
+        delay,
+      })
+      await enqueueGooglePushSync({ integrationId, organizationId }, { delay })
+      return
+    }
+  } else {
+    // Redis down means the whole import pipeline (import cache, cross-job locks) is already
+    // degraded — proceed unlocked rather than dropping the notification entirely.
+    logger.warn('Redis unavailable — running google push sync unlocked', { integrationId })
+  }
+
+  try {
+    // Sync errors are intentionally left to throw — BullMQ retries per this job's `attempts`.
+    await new MessageService(organizationId).syncMessages(
+      'google' as ChannelProviderType,
+      integrationId
+    )
+  } finally {
+    if (acquired && redis) {
+      await redis.del(lockKey)
+    }
+  }
+}

--- a/packages/lib/src/jobs/polling/messages-import-job.ts
+++ b/packages/lib/src/jobs/polling/messages-import-job.ts
@@ -36,7 +36,7 @@ const BASE_THROTTLE_BACKOFF_MS = 30_000
  * Guarded to a no-op unless the row has a cutoff stamp and no completion stamp
  * yet, so ordinary polling cycles (every later IDLE transition) never rewrite
  * it. Provider-agnostic on purpose — only rows a provider has actually stamped
- * `backfillCutoffAt` on (currently just Outlook) ever match.
+ * `backfillCutoffAt` on (Outlook always; Gmail on its polling path) ever match.
  */
 async function stampInitialBackfillCompleted(integrationId: string, now: Date): Promise<void> {
   await db

--- a/packages/lib/src/providers/google/google-provider.ts
+++ b/packages/lib/src/providers/google/google-provider.ts
@@ -173,6 +173,13 @@ export class GoogleProvider
     // Surface the canonical "us" address set to the ingest pipeline so
     // self-addressed mail never produces a contact for the integration owner.
     this.storageService.setOwnEmails(this.userEmails)
+    // Received-time trigger cutoff (webhook-push-migration plan Phase 2.5): while the
+    // initial backfill is incomplete, ingest suppresses message:received for mail
+    // received before the connect epoch — regardless of which walker ingested it.
+    const metadata = (integration.metadata as any) ?? {}
+    const cutoffRaw = metadata.backfillCutoffAt
+    const backfillDone = metadata.initialBackfillCompletedAt
+    this.storageService.setBackfillCutoff(cutoffRaw && !backfillDone ? new Date(cutoffRaw) : null)
     logger.info(`GoogleProvider initialized successfully for integration: ${integrationId}`, {
       userEmailsCount: this.userEmails.length,
     })
@@ -1029,8 +1036,11 @@ export class GoogleProvider
   async importMessages(externalIds: string[]): Promise<{ imported: number; failed: number }> {
     await this.ensureInitialized()
 
-    // On-demand import (not a backfill) — the `message:received` workflow
-    // trigger should fire for these. Explicit reset in case a prior
+    // The two-phase polling backfill routes through this exact method (written
+    // unaware of that — hence this comment's old "not a backfill" framing).
+    // Historical-mail trigger suppression is handled by the received-time cutoff
+    // set in initialize() (webhook-push-migration plan Phase 2.5), not by this
+    // flag, so it always stays false here. Explicit reset in case a prior
     // `syncGmailMessages` call on this provider instance left the shared
     // `storageService`'s flag set (its own `finally` already resets it, but
     // this stays correct even if that invariant changes later).


### PR DESCRIPTION
## Summary

The two Gmail tickets deferred from the Outlook webhook-push migration (#1585–#1588) — Gmail had the same two design flaws in milder form.

**1. Backfill trigger cutoff (the mass-fire bug, Gmail edition).** `GoogleProvider.importMessages` carried the same "on-demand import (not a backfill)" comment Outlook had — written unaware the two-phase polling backfill routes through it with trigger firing enabled. A Gmail channel connecting on the **polling path** (customer's own OAuth client, missing Pub/Sub env, or a watch-arm failure fallback) fired `message:received` for every historical email: workflow runs, billed classification, bounce suppressions, timeline spam. Webhook-mode connects were safe (their backfill goes through `sync-messages.ts`, which suppresses via `isInitialSync`).

Fix reuses the shared received-time cutoff shipped for Outlook: the provisioning hook stamps `metadata.backfillCutoffAt` for `google` exactly at the initial-polling-pipeline kick — the successful webhook branch returns earlier, so webhook connects never get a stamp whose completion marker (`initialBackfillCompletedAt`, written by `messagesImportJob`'s drain-to-IDLE) could never land. `GoogleProvider.initialize()` wires `setBackfillCutoff()` exactly like `OutlookProvider`.

**2. Webhook route: validate → enqueue → ack.** `api/google/webhook/route.ts` awaited the full history sync inside the handler. Pub/Sub redelivers on slow/failed acks, and nothing serialized `Integration.lastHistoryId` against overlapping redelivered syncs — the same concurrent-cursor race the Outlook push job's lock prevents. New `googlePushSyncJob` mirrors `outlookPushSyncJob` (15s jobId debounce window, per-integration Redis `SET NX PX` lock, reauth/disabled fast-skip); the route keeps all Pub/Sub JWT/JWKS verification untouched, keeps the stale-historyId pre-filter as advisory, enqueues, and acks `202` (in Pub/Sub's ack set). `5xx` only when the enqueue itself fails, so Pub/Sub redelivers un-queued work instead of us acking it away.

## Test plan
- [x] lib suites for google providers / jobs / channels: 180 tests pass (incl. `connect-scope.test.ts` over `seedSync`)
- [x] scoped typechecks clean: lib, web (route), worker; biome clean
- [ ] dev: connect a Gmail channel with a custom OAuth client → backfill imports history with zero historical `message:received` firings
- [ ] dev: Gmail watch notification → route acks fast, `googlePushSyncJob` runs the history sync