### PR TITLE
fix(records): stamp interactions on participant-linked contacts

### DIFF
--- a/packages/lib/src/data-migrations/migrations/082-interaction-fields-participant-resolution.ts
+++ b/packages/lib/src/data-migrations/migrations/082-interaction-fields-participant-resolution.ts
@@ -1,0 +1,176 @@
+// packages/lib/src/data-migrations/migrations/082-interaction-fields-participant-resolution.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { sql } from 'drizzle-orm'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-082')
+
+/** Participants scanned per statement. */
+const BATCH_SIZE = 1000
+
+/** Log a progress line every N batches so a long run is observable. */
+const LOG_EVERY = 20
+
+/**
+ * Re-run the interaction-fields backfill with the CORRECT target resolution.
+ *
+ * **Why.** Migration 081 resolved stamp targets via thread primaries +
+ * `ThreadEntityLink` — but thread primaries are tickets/quotes, and
+ * `ThreadEntityLink` rows exist only for manual links/merges/workflow nodes, so
+ * contacts and companies (the point of the feature) got nothing. Contacts
+ * attach to mail via `Participant.entityInstanceId`
+ * (Message → MessageParticipant → Participant); the live write sites were
+ * re-aimed the same way in the fix this migration ships with.
+ *
+ * **What counts** (same rules as 081/live): messages with a real `sentAt`,
+ * excluding hard-tier machine mail; only non-internal participants with a
+ * linked contact. Companies then inherit min/max from their linked contacts via
+ * `contact_employer`. 081's ticket/quote stamps are left alone (harmless — no
+ * registry fields on those types) and its participant repair pass was correct
+ * and is not repeated.
+ *
+ * **Idempotent and live-safe.** Pure min/max recompute under the same
+ * first-wins/last-wins guards the live path uses.
+ */
+export const migration082InteractionFieldsParticipantResolution: DataMigrationDef = {
+  id: '082-interaction-fields-participant-resolution',
+  description: 'Backfill contact/company interaction stamps via participant resolution',
+  async run(db: Database): Promise<void> {
+    // ── Pass 1: contacts, batched by participant ───────────────────────────
+    let cursor = ''
+    let scanned = 0
+    let stampedFirst = 0
+    let stampedLast = 0
+    let batches = 0
+
+    for (;;) {
+      const result = await db.execute<{
+        lastId: string | null
+        scanned: number
+        first: number
+        last: number
+      }>(sql`
+        WITH batch AS MATERIALIZED (
+          SELECT id, "entityInstanceId", "organizationId"
+          FROM "Participant"
+          WHERE id > ${cursor}
+            AND "entityInstanceId" IS NOT NULL
+            AND "isInternal" = false
+          ORDER BY id
+          LIMIT ${BATCH_SIZE}
+        ),
+        msgs AS (
+          SELECT
+            b."entityInstanceId" AS contact_id,
+            b."organizationId" AS org_id,
+            m.id AS msg_id,
+            m."sentAt" AS sent_at
+          FROM batch b
+          JOIN "MessageParticipant" mp ON mp."participantId" = b.id
+          JOIN "Message" m ON m.id = mp."messageId"
+          WHERE m."sentAt" IS NOT NULL
+            AND m."machineMailTier" IS DISTINCT FROM 'hard'
+        ),
+        -- Several participants (email + phone identifier, say) can link the
+        -- same contact within one batch: collapse to the single oldest/newest
+        -- candidate per contact before updating, because UPDATE ... FROM
+        -- applies an arbitrary matching row, not the extreme one. Cross-batch
+        -- overlap converges via the monotonic guards.
+        first_targets AS (
+          SELECT DISTINCT ON (contact_id) contact_id, org_id, sent_at, msg_id
+          FROM msgs ORDER BY contact_id, sent_at ASC
+        ),
+        last_targets AS (
+          SELECT DISTINCT ON (contact_id) contact_id, org_id, sent_at, msg_id
+          FROM msgs ORDER BY contact_id, sent_at DESC
+        ),
+        first_upd AS (
+          UPDATE "EntityInstance" ei
+          SET "firstInteractionAt" = t.sent_at, "firstInteractionMessageId" = t.msg_id
+          FROM first_targets t
+          WHERE ei.id = t.contact_id AND ei."organizationId" = t.org_id
+            AND (ei."firstInteractionAt" IS NULL OR ei."firstInteractionAt" > t.sent_at)
+          RETURNING ei.id
+        ),
+        last_upd AS (
+          UPDATE "EntityInstance" ei
+          SET "lastInteractionAt" = t.sent_at, "lastInteractionMessageId" = t.msg_id
+          FROM last_targets t
+          WHERE ei.id = t.contact_id AND ei."organizationId" = t.org_id
+            AND (ei."lastInteractionAt" IS NULL OR ei."lastInteractionAt" < t.sent_at)
+          RETURNING ei.id
+        )
+        SELECT
+          (SELECT max(id) FROM batch) AS "lastId",
+          (SELECT count(*) FROM batch)::int AS "scanned",
+          (SELECT count(*) FROM first_upd)::int AS "first",
+          (SELECT count(*) FROM last_upd)::int AS "last"
+      `)
+
+      const row = result.rows[0]
+      if (!row?.lastId || Number(row.scanned) === 0) break
+
+      cursor = row.lastId
+      scanned += Number(row.scanned)
+      stampedFirst += Number(row.first)
+      stampedLast += Number(row.last)
+      batches += 1
+
+      if (batches % LOG_EVERY === 0) {
+        logger.info('Backfilling contact interaction stamps', { scanned, stampedFirst, cursor })
+      }
+
+      if (Number(row.scanned) < BATCH_SIZE) break
+    }
+
+    logger.info('Contact interaction pass done', { scanned, stampedFirst, stampedLast, batches })
+
+    // ── Pass 2: propagate contact stamps to their linked companies ─────────
+    const companies = await db.execute<{ first: number; last: number }>(sql`
+      WITH links AS (
+        SELECT
+          fv."relatedEntityId" AS company_id,
+          fv."organizationId" AS org_id,
+          c."firstInteractionAt" AS first_at, c."firstInteractionMessageId" AS first_msg_id,
+          c."lastInteractionAt" AS last_at, c."lastInteractionMessageId" AS last_msg_id
+        FROM "FieldValue" fv
+        JOIN "CustomField" cf ON cf.id = fv."fieldId" AND cf."systemAttribute" = 'contact_employer'
+        JOIN "EntityInstance" c ON c.id = fv."entityId"
+        WHERE fv."relatedEntityId" IS NOT NULL
+      ),
+      first_targets AS (
+        SELECT DISTINCT ON (company_id) company_id, org_id, first_at, first_msg_id
+        FROM links WHERE first_at IS NOT NULL ORDER BY company_id, first_at ASC
+      ),
+      last_targets AS (
+        SELECT DISTINCT ON (company_id) company_id, org_id, last_at, last_msg_id
+        FROM links WHERE last_at IS NOT NULL ORDER BY company_id, last_at DESC
+      ),
+      first_upd AS (
+        UPDATE "EntityInstance" ei
+        SET "firstInteractionAt" = t.first_at, "firstInteractionMessageId" = t.first_msg_id
+        FROM first_targets t
+        WHERE ei.id = t.company_id AND ei."organizationId" = t.org_id
+          AND (ei."firstInteractionAt" IS NULL OR ei."firstInteractionAt" > t.first_at)
+        RETURNING ei.id
+      ),
+      last_upd AS (
+        UPDATE "EntityInstance" ei
+        SET "lastInteractionAt" = t.last_at, "lastInteractionMessageId" = t.last_msg_id
+        FROM last_targets t
+        WHERE ei.id = t.company_id AND ei."organizationId" = t.org_id
+          AND (ei."lastInteractionAt" IS NULL OR ei."lastInteractionAt" < t.last_at)
+        RETURNING ei.id
+      )
+      SELECT
+        (SELECT count(*) FROM first_upd)::int AS "first",
+        (SELECT count(*) FROM last_upd)::int AS "last"
+    `)
+    logger.info('Company propagation pass done', {
+      first: Number(companies.rows[0]?.first ?? 0),
+      last: Number(companies.rows[0]?.last ?? 0),
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -46,6 +46,7 @@ import { migration078TicketTypeUpdatable } from './migrations/078-ticket-type-up
 import { migration079EnrichmentFieldsBackendOwned } from './migrations/079-enrichment-fields-backend-owned'
 import { migration080OutlookWebhookCutover } from './migrations/080-outlook-webhook-cutover'
 import { migration081BackfillInteractionFields } from './migrations/081-backfill-interaction-fields'
+import { migration082InteractionFieldsParticipantResolution } from './migrations/082-interaction-fields-participant-resolution'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -118,6 +119,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration079EnrichmentFieldsBackendOwned,
     migration080OutlookWebhookCutover,
     migration081BackfillInteractionFields,
+    migration082InteractionFieldsParticipantResolution,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/entity-instances/__tests__/interaction-touch.test.ts
+++ b/packages/lib/src/entity-instances/__tests__/interaction-touch.test.ts
@@ -26,6 +26,8 @@ const h = vi.hoisted(() => ({
   >(),
   threadPrimary: null as string | null,
   threadLinkIds: [] as string[],
+  /** Pre-shaped resolver rows for the message's participant-linked contacts. */
+  messageContactRows: [] as Array<{ contactId: string | null }>,
   /** contactId → companyId rows behind the `contact_employer` field. */
   employerLinks: [] as Array<{ entityId: string; companyId: string }>,
   employerField: { id: 'cf_employer' } as { id: string } | null,
@@ -84,6 +86,10 @@ vi.mock('@auxx/database', async () => {
         h.selectedTables.push('FieldValue')
         return h.employerLinks.map((l) => ({ companyId: l.companyId }))
       }
+      if (table === schema.MessageParticipant) {
+        h.selectedTables.push('MessageParticipant')
+        return h.messageContactRows
+      }
       return []
     }
     const chain: any = new Proxy(
@@ -102,6 +108,7 @@ vi.mock('@auxx/database', async () => {
 
   const database = {
     select: () => ({ from: (table: unknown) => makeSelectChain(table) }),
+    selectDistinct: () => ({ from: (table: unknown) => makeSelectChain(table) }),
     update: () => ({
       set: (vals: Record<string, unknown>) => ({
         where: (cond: unknown) => {
@@ -136,7 +143,7 @@ vi.mock('@auxx/database', async () => {
   return { database, schema, Database: class {}, Transaction: class {} }
 })
 
-import { touchEntityInteraction, touchInteractionForThreadLinks } from '../activity'
+import { touchEntityInteraction, touchInteractionForMessage } from '../activity'
 
 const ORG = 'org_1'
 
@@ -152,8 +159,9 @@ beforeEach(() => {
   h.entities.clear()
   h.entities.set('contact_1', entityRow())
   h.entities.set('company_1', entityRow())
-  h.threadPrimary = 'contact_1'
+  h.threadPrimary = 'ticket_1'
   h.threadLinkIds = []
+  h.messageContactRows = []
   h.employerLinks = []
   h.employerField = { id: 'cf_employer' }
   h.selectedTables = []
@@ -211,35 +219,41 @@ describe('touchEntityInteraction', () => {
   })
 })
 
-describe('touchInteractionForThreadLinks', () => {
+describe('touchInteractionForMessage', () => {
   const SENT = new Date('2026-05-01T09:00:00Z')
 
-  it('stamps the thread-linked entities AND their linked companies', async () => {
+  it('stamps the participant-linked contacts AND their companies — never the thread links', async () => {
+    // The thread's primary is a ticket; interaction targets come from the
+    // message's own correspondents, so the ticket stays untouched and the
+    // thread tables are never consulted.
+    h.entities.set('ticket_1', entityRow())
+    h.messageContactRows = [{ contactId: 'contact_1' }]
     h.employerLinks = [{ entityId: 'contact_1', companyId: 'company_1' }]
-    await touchInteractionForThreadLinks('t_1', ORG, 'm_x', SENT)
+    await touchInteractionForMessage('m_x', ORG, SENT)
     expect(h.entities.get('contact_1')!.lastInteractionAt).toEqual(SENT)
     expect(h.entities.get('company_1')!.lastInteractionAt).toEqual(SENT)
     expect(h.entities.get('company_1')!.lastInteractionMessageId).toBe('m_x')
+    expect(h.entities.get('ticket_1')!.lastInteractionAt).toBeNull()
+    expect(h.selectedTables).not.toContain('Thread')
+    expect(h.selectedTables).not.toContain('ThreadEntityLink')
   })
 
   it('does not stamp companies with no contact link', async () => {
-    await touchInteractionForThreadLinks('t_1', ORG, 'm_x', SENT)
+    h.messageContactRows = [{ contactId: 'contact_1' }]
+    await touchInteractionForMessage('m_x', ORG, SENT)
     expect(h.entities.get('contact_1')!.lastInteractionAt).toEqual(SENT)
     expect(h.entities.get('company_1')!.lastInteractionAt).toBeNull()
   })
 
-  it('reuses a pre-resolved entity set without re-querying the thread links', async () => {
-    await touchInteractionForThreadLinks('t_1', ORG, 'm_x', SENT, {
-      entityInstanceIds: ['contact_1'],
-    })
-    expect(h.selectedTables).not.toContain('Thread')
-    expect(h.selectedTables).not.toContain('ThreadEntityLink')
+  it('reuses pre-resolved contact ids without querying MessageParticipant', async () => {
+    await touchInteractionForMessage('m_x', ORG, SENT, { contactIds: ['contact_1'] })
+    expect(h.selectedTables).not.toContain('MessageParticipant')
     expect(h.entities.get('contact_1')!.firstInteractionAt).toEqual(SENT)
   })
 
-  it('no-ops when the thread has no linked entities', async () => {
-    h.threadPrimary = null
-    await touchInteractionForThreadLinks('t_1', ORG, 'm_x', SENT)
+  it('no-ops when the message has no participant-linked contacts', async () => {
+    h.messageContactRows = []
+    await touchInteractionForMessage('m_x', ORG, SENT)
     expect(h.updateCalls).toBe(0)
   })
 })

--- a/packages/lib/src/entity-instances/activity.ts
+++ b/packages/lib/src/entity-instances/activity.ts
@@ -171,10 +171,41 @@ export async function touchEntityInteraction(
 }
 
 /**
- * Companies are usually not thread-linked, so interaction stamps propagate from
- * stamped contacts to their linked companies via the `contact_employer` field
- * (maintained by `ingest/companies/link-contact.ts`). Non-contact ids simply have
- * no employer rows and contribute nothing.
+ * Resolve the contacts that were actually ON a message's correspondence: its
+ * non-internal participants' `Participant.entityInstanceId`. This — not thread
+ * links — is how contacts attach to mail (thread primaries are tickets/quotes,
+ * and `ThreadEntityLink` rows exist only for manual links/merges/workflows; a
+ * manually linked record wasn't part of the correspondence and must not get
+ * interaction stamps).
+ */
+export async function resolveMessageContactIds(
+  messageId: string,
+  organizationId: string,
+  tx?: DbOrTx
+): Promise<string[]> {
+  const db = tx ?? database
+  const rows = await db
+    .selectDistinct({ contactId: schema.Participant.entityInstanceId })
+    .from(schema.MessageParticipant)
+    .innerJoin(
+      schema.Participant,
+      eq(schema.Participant.id, schema.MessageParticipant.participantId)
+    )
+    .where(
+      and(
+        eq(schema.MessageParticipant.messageId, messageId),
+        eq(schema.Participant.organizationId, organizationId),
+        eq(schema.Participant.isInternal, false),
+        isNotNull(schema.Participant.entityInstanceId)
+      )
+    )
+  return rows.map((r) => r.contactId).filter((id): id is string => Boolean(id))
+}
+
+/**
+ * Interaction stamps propagate from stamped contacts to their linked companies
+ * via the `contact_employer` field (maintained by
+ * `ingest/companies/link-contact.ts`).
  */
 async function resolveLinkedCompanyIds(
   entityInstanceIds: string[],
@@ -209,37 +240,34 @@ async function resolveLinkedCompanyIds(
 }
 
 /**
- * Stamp first/last interaction for every entity linked to a thread (primary +
- * active secondaries), plus the stamped contacts' linked companies. Call sites:
- * ingest (`store-message.ts`, qualifying messages only) and the sender
- * (`message-sender.service.ts`, successful sends with the reconciler-confirmed
- * `sentAt`) — Auxx-sent mail never reaches ingest's fresh-insert path, and the
- * sync echo early-returns before the ingest touch.
+ * Stamp first/last interaction for the contacts on a message's correspondence
+ * (non-internal participants with a linked contact), plus those contacts'
+ * linked companies. Call sites: ingest (`store-message.ts`, qualifying messages
+ * only) and the sender (`message-sender.service.ts`, successful sends with the
+ * reconciler-confirmed `sentAt`) — Auxx-sent mail never reaches ingest's
+ * fresh-insert path, and the sync echo early-returns before the ingest touch.
  *
- * Pass `opts.entityInstanceIds` when the caller already resolved the thread-link
- * set (e.g. for the activity touch) to avoid re-running the SELECTs.
+ * Pass `opts.contactIds` when the caller already holds the message's resolved
+ * participants (ingest does) to skip the MessageParticipant lookup.
  */
-export async function touchInteractionForThreadLinks(
-  threadId: string,
-  organizationId: string,
+export async function touchInteractionForMessage(
   messageId: string,
+  organizationId: string,
   sentAt: Date,
-  opts?: { entityInstanceIds?: string[]; tx?: DbOrTx }
+  opts?: { contactIds?: string[]; tx?: DbOrTx }
 ): Promise<void> {
   try {
-    const linked =
-      opts?.entityInstanceIds ??
-      (await resolveThreadLinkedEntityIds(threadId, organizationId, opts?.tx))
-    if (linked.length === 0) return
+    const contactIds =
+      opts?.contactIds ?? (await resolveMessageContactIds(messageId, organizationId, opts?.tx))
+    if (contactIds.length === 0) return
 
-    const companyIds = await resolveLinkedCompanyIds(linked, organizationId, opts?.tx)
-    const all = Array.from(new Set([...linked, ...companyIds]))
+    const companyIds = await resolveLinkedCompanyIds(contactIds, organizationId, opts?.tx)
+    const all = Array.from(new Set([...contactIds, ...companyIds]))
     await touchEntityInteraction(all, organizationId, messageId, sentAt, opts?.tx)
   } catch (error) {
     // Same contract as the activity touch: log and swallow.
-    logger.warn('Failed to touch interaction for thread links', {
+    logger.warn('Failed to touch interaction for message', {
       organizationId,
-      threadId,
       messageId,
       error: error instanceof Error ? error.message : error,
     })

--- a/packages/lib/src/entity-instances/index.ts
+++ b/packages/lib/src/entity-instances/index.ts
@@ -8,7 +8,7 @@ export {
   touchActivityForThreadLinks,
   touchEntityActivity,
   touchEntityInteraction,
-  touchInteractionForThreadLinks,
+  touchInteractionForMessage,
 } from './activity'
 export type {
   ContactMetadata,

--- a/packages/lib/src/ingest/__tests__/store-message-backfill-cutoff.test.ts
+++ b/packages/lib/src/ingest/__tests__/store-message-backfill-cutoff.test.ts
@@ -38,7 +38,7 @@ vi.mock('../../entity-instances/activity', () => ({
   touchActivityForThreadLinks: vi.fn(),
   resolveThreadLinkedEntityIds: vi.fn(async () => []),
   touchEntityActivity: vi.fn(),
-  touchInteractionForThreadLinks: vi.fn(),
+  touchInteractionForMessage: vi.fn(),
 }))
 vi.mock('../../events/publisher', () => ({
   publisher: {

--- a/packages/lib/src/ingest/__tests__/store-message-echoed-message-id-guard.test.ts
+++ b/packages/lib/src/ingest/__tests__/store-message-echoed-message-id-guard.test.ts
@@ -85,7 +85,7 @@ vi.mock('../../entity-instances/activity', () => ({
   touchActivityForThreadLinks: vi.fn(),
   resolveThreadLinkedEntityIds: vi.fn(async () => []),
   touchEntityActivity: vi.fn(),
-  touchInteractionForThreadLinks: vi.fn(),
+  touchInteractionForMessage: vi.fn(),
 }))
 vi.mock('../../events/publisher', () => ({
   publisher: {

--- a/packages/lib/src/ingest/__tests__/store-message-inbox-recordid.test.ts
+++ b/packages/lib/src/ingest/__tests__/store-message-inbox-recordid.test.ts
@@ -44,7 +44,7 @@ vi.mock('../../entity-instances/activity', () => ({
   touchActivityForThreadLinks: vi.fn(),
   resolveThreadLinkedEntityIds: vi.fn(async () => []),
   touchEntityActivity: vi.fn(),
-  touchInteractionForThreadLinks: vi.fn(),
+  touchInteractionForMessage: vi.fn(),
 }))
 vi.mock('../../events/publisher', () => ({ publisher: { publishLater: vi.fn() } }))
 vi.mock('../../permissions/visibility/audience', () => ({

--- a/packages/lib/src/ingest/__tests__/store-message-own-address-guard.test.ts
+++ b/packages/lib/src/ingest/__tests__/store-message-own-address-guard.test.ts
@@ -41,7 +41,7 @@ vi.mock('../../entity-instances/activity', () => ({
   touchActivityForThreadLinks: vi.fn(),
   resolveThreadLinkedEntityIds: vi.fn(async () => []),
   touchEntityActivity: vi.fn(),
-  touchInteractionForThreadLinks: vi.fn(),
+  touchInteractionForMessage: vi.fn(),
 }))
 vi.mock('../../events/publisher', () => ({
   publisher: {

--- a/packages/lib/src/ingest/__tests__/store-message.threading.test.ts
+++ b/packages/lib/src/ingest/__tests__/store-message.threading.test.ts
@@ -75,7 +75,7 @@ vi.mock('../../entity-instances/activity', () => ({
   touchActivityForThreadLinks: vi.fn(),
   resolveThreadLinkedEntityIds: vi.fn(async () => []),
   touchEntityActivity: vi.fn(),
-  touchInteractionForThreadLinks: vi.fn(),
+  touchInteractionForMessage: vi.fn(),
 }))
 vi.mock('../../events/publisher', () => ({ publisher: { publishLater: vi.fn() } }))
 vi.mock('../../permissions/visibility/audience', () => ({

--- a/packages/lib/src/ingest/store-message.ts
+++ b/packages/lib/src/ingest/store-message.ts
@@ -14,7 +14,7 @@ import { buildOrgOwnEmailAddressSet } from '../channels/own-addresses'
 import {
   resolveThreadLinkedEntityIds,
   touchEntityActivity,
-  touchInteractionForThreadLinks,
+  touchInteractionForMessage,
 } from '../entity-instances/activity'
 import { publisher } from '../events/publisher'
 import type { MessageReceivedEvent } from '../events/types'
@@ -764,20 +764,27 @@ export async function storeMessage(
     // Advance lastActivityAt for any entity linked to this thread (primary +
     // active secondaries), and stamp first/last interaction for qualifying
     // messages (real correspondence both directions; hard-tier machine mail
-    // never counts — mirrors the contact-graph rule above). The link set is
-    // resolved once and shared. Best-effort; helpers log and swallow.
+    // never counts — mirrors the contact-graph rule above). Interaction targets
+    // are the message's own correspondents — the non-internal participants'
+    // linked contacts, already in hand from processing above — NOT the thread
+    // links (those are tickets/quotes and manual links, which get activity but
+    // never interaction). Best-effort; helpers log and swallow.
     const linkedEntityIds = await resolveThreadLinkedEntityIds(
       thread.id,
       messageData.organizationId
     )
     await touchEntityActivity(linkedEntityIds, messageData.organizationId, messageData.sentAt)
     if (machineMailResult?.tier !== 'hard') {
-      await touchInteractionForThreadLinks(
-        thread.id,
-        messageData.organizationId,
+      const contactIds = Array.from(participantCache.values())
+        .filter((p) => p?.entityInstanceId && !p.isInternal)
+        .map((p) => p.entityInstanceId as string)
+      await touchInteractionForMessage(
         messageRecord.id,
+        messageData.organizationId,
         messageData.sentAt,
-        { entityInstanceIds: linkedEntityIds }
+        {
+          contactIds: Array.from(new Set(contactIds)),
+        }
       )
     }
 

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -8,7 +8,7 @@ import { and, asc, desc, eq, sql } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
 import {
   touchActivityForThreadLinks,
-  touchInteractionForThreadLinks,
+  touchInteractionForMessage,
 } from '../entity-instances/activity'
 import { ForbiddenError, UsageLimitError } from '../errors'
 import { FileService } from '../files/core/file-service'
@@ -403,12 +403,12 @@ export class MessageSenderService {
       // Interaction stamp for Auxx-sent mail: this path never reaches ingest's
       // fresh-insert touch (the sync echo early-returns in storeMessage), so
       // without this the stamps only move when the customer writes. Successful
-      // sends only — a FAILED row is not correspondence (§2.4).
+      // sends only — a FAILED row is not correspondence (§2.4). Targets resolve
+      // from the message's own participants (the composer wrote the links).
       if (sendResult.success) {
-        await touchInteractionForThreadLinks(
-          threadContext.id,
-          this.organizationId,
+        await touchInteractionForMessage(
           composed.id,
+          this.organizationId,
           sendResult.timestamp ?? new Date()
         )
       }
@@ -1557,10 +1557,9 @@ export class MessageSenderService {
     // Interaction stamp — same rationale as the first-send path: Auxx-sent mail
     // never reaches ingest's touch, and only a landed retry is correspondence.
     if (result.success) {
-      await touchInteractionForThreadLinks(
-        threadId,
-        this.organizationId,
+      await touchInteractionForMessage(
         messageId,
+        this.organizationId,
         result.timestamp ?? new Date()
       )
     }


### PR DESCRIPTION
## Summary

Fixes the target-resolution bug in #1590: interaction stamps resolved entities via thread primary + `ThreadEntityLink`, but thread primaries are tickets/quotes and `ThreadEntityLink` rows exist only for manual links, merges, and workflow nodes — so **contacts and companies never got stamped** (verified on dev: migration 081 stamped 33 tickets/quotes and zero of 1,625 contacts). Contacts actually attach to mail via `Participant.entityInstanceId` (`Message → MessageParticipant → Participant`).

## Changes

- `touchInteractionForThreadLinks` → **`touchInteractionForMessage`**: targets are the message's non-internal participants' linked contacts. Ingest passes the contact ids already in hand from participant processing (no extra query); the sender path resolves the composed message's participants via the new `resolveMessageContactIds` (the composer writes the `MessageParticipant` links). Company propagation via employer links unchanged.
- The **activity** touch (`lastActivityAt`) keeps its thread-link resolution — a message is still activity on the linked ticket. Only interaction is re-aimed; manually thread-linked records and internal participants deliberately never get interaction stamps.
- **Migration 082** re-runs the backfill with participant resolution (keyset over `Participant`, min/max per contact, same monotonic guards, company pass). 081's ticket/quote stamps are harmless (no registry fields on those types) and left alone; its participant-repair pass was correct and is not repeated.
- Tests updated: participant-linked contacts get stamped, thread-primary tickets do not, store-message mocks renamed.

## Testing

- 330 tests passing across `entity-instances`, `ingest`, `messages`, `data-migrations` suites (8 reworked interaction-touch tests incl. the ticket-exclusion assertion).
- `packages/lib` scoped `tsc --noEmit`: zero errors in touched files. Biome clean.