### PR TITLE
fix(records): hide interaction columns in tables by default

### DIFF
--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -730,7 +730,7 @@ export const ORG_CACHE_KEY_CONFIG: Record<
   // (statics + CustomField rows), so a pre-deploy blob simply lacks the new
   // static fields for up to the ONE_DAY TTL — the bump moves the keyspace so
   // every org recomputes on first read after deploy.
-  resources: { prefix: 'org:resources:v2', ttlSeconds: ONE_DAY },
+  resources: { prefix: 'org:resources:v3', ttlSeconds: ONE_DAY },
   customFields: { prefix: 'org:custom-fields', ttlSeconds: ONE_DAY },
   groups: { prefix: 'org:groups', ttlSeconds: ONE_DAY },
   groupMembers: { prefix: 'org:group-members', ttlSeconds: ONE_DAY },

--- a/packages/lib/src/resources/registry/resources/company-fields.ts
+++ b/packages/lib/src/resources/registry/resources/company-fields.ts
@@ -482,6 +482,7 @@ export const COMPANY_FIELDS: Record<string, ResourceField> = {
     systemSortOrder: 'aCb',
     dbColumn: 'firstInteractionAt',
     nullable: true,
+    showInTable: false,
     capabilities: {
       filterable: true,
       sortable: true,
@@ -504,6 +505,7 @@ export const COMPANY_FIELDS: Record<string, ResourceField> = {
     systemSortOrder: 'aCc',
     dbColumn: 'lastInteractionAt',
     nullable: true,
+    showInTable: false,
     capabilities: {
       filterable: true,
       sortable: true,

--- a/packages/lib/src/resources/registry/resources/contact-fields.ts
+++ b/packages/lib/src/resources/registry/resources/contact-fields.ts
@@ -376,6 +376,7 @@ export const CONTACT_FIELDS: Record<string, ResourceField> = {
     systemSortOrder: 'a7a',
     dbColumn: 'firstInteractionAt',
     nullable: true,
+    showInTable: false,
     capabilities: {
       filterable: true,
       sortable: true,
@@ -397,6 +398,7 @@ export const CONTACT_FIELDS: Record<string, ResourceField> = {
     systemSortOrder: 'a7b',
     dbColumn: 'lastInteractionAt',
     nullable: true,
+    showInTable: false,
     capabilities: {
       filterable: true,
       sortable: true,


### PR DESCRIPTION
Follow-up to #1591 — the `showInTable: false` commit was pushed to that branch after the squash-merge, so it never landed.

Sets `showInTable: false` on the four interaction field blocks (contact + company). The fields stay available via the column manager ("+" add-column list), filters, sorting, the panel, and the drawer card — they just no longer appear as default table columns (registry system fields default to visible via `defaultVisible: field.showInTable ?? field.showInPanel !== false`).

Bumps the org resources cache prefix to `org:resources:v3` so cached merged registries pick up the flag deterministically. No migration — this is a code-level registry default, applies to all orgs (existing and new); user-saved column toggles still win.