### PR TITLE
refactor(workflow): split parity extractor into honest halves

### DIFF
--- a/apps/web/src/components/workflow/parity/builder-declared-keys.ts
+++ b/apps/web/src/components/workflow/parity/builder-declared-keys.ts
@@ -1,0 +1,47 @@
+// apps/web/src/components/workflow/parity/builder-declared-keys.ts
+
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { BUILDER_ROOT, ENGINE_ROOT, stripComments } from './monorepo-paths'
+
+/**
+ * Property names declared for a builder node's data shape — the BUILDER half
+ * of the config-keys assertion, split out of the deleted `engine-contract.ts`
+ * (node-catalog Phase 1 exit criterion). Unlike that file's engine-side
+ * scraping (now `engine-write-scrape.ts`), this reader has nothing to do with
+ * processor internals — it is a declared-shape reader, and it stays textual
+ * for a reason unrelated to that migration: TypeScript interfaces have no
+ * runtime representation, so there is no way to `Object.keys()` a `type` at
+ * test time.
+ *
+ * The zod schema alone is NOT the builder's writable surface, migrated node
+ * types included. Several nodes declare only a handful of keys in zod while
+ * the panel writes the full TypeScript interface — `format`'s manifest schema
+ * (`catalog/nodes/format.ts`) has four keys, its `FormatNodeData` interface has
+ * eighteen `*Config` objects that the panel and validator both use. Reading the
+ * interface keeps the config-key assertion pointed at genuine name-mismatches
+ * (`data.assigneeId` vs `data.assignee`) rather than at zod schemas that are
+ * merely incomplete — which is a different bug, and not this suite's.
+ *
+ * Deliberately a flat property-line scan rather than a parse: it over-collects
+ * slightly (nested object types in the same file contribute their keys too),
+ * and over-collecting only makes this assertion more conservative.
+ */
+export function builderDeclaredKeys(builderDir: string): Set<string> {
+  const keys = new Set<string>()
+
+  // Migrated node types (node-catalog Phase 1) declare their data interface in
+  // the lib catalog; the web types.ts shrinks to a `type: NodeType` narrowing
+  // wrapper over it. Read the catalog file first when it exists — it IS the
+  // builder declaration for those types.
+  const catalogPath = join(ENGINE_ROOT, 'catalog/nodes', `${builderDir.replace(/^core\//, '')}.ts`)
+  const paths = [catalogPath, join(BUILDER_ROOT, builderDir, 'types.ts')]
+  for (const path of paths) {
+    if (!existsSync(path)) continue
+    const source = stripComments(readFileSync(path, 'utf8'))
+    for (const m of source.matchAll(/^\s+(\w+)\??\s*:/gm)) {
+      keys.add(m[1] as string)
+    }
+  }
+  return keys
+}

--- a/apps/web/src/components/workflow/parity/builder-engine-parity.test.ts
+++ b/apps/web/src/components/workflow/parity/builder-engine-parity.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, it } from 'vitest'
 import type { UnifiedVariable } from '~/components/workflow/types/variable-types'
+import { builderDeclaredKeys } from './builder-declared-keys'
 import { BUILDER_RENDERED_HANDLES } from './builder-rendered-handles'
 import {
   EXTRACTION_BLIND_SPOTS,
@@ -13,12 +14,11 @@ import {
 } from './contract-drift-allowlist'
 import {
   advertisedPath,
-  builderDeclaredKeys,
   isPathWritten,
   isWriteAdvertised,
   readEngineContracts,
   readEngineRoutedHandleLiterals,
-} from './engine-contract'
+} from './engine-write-scrape'
 import { BUILDER_NODE_DEFINITIONS, CONFIG_VARIANTS } from './node-definitions'
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -56,10 +56,12 @@ import { BUILDER_NODE_DEFINITIONS, CONFIG_VARIANTS } from './node-definitions'
 //      until a lib-side handle manifest exists).
 //
 // This half lives in `apps/web` and not beside the engine because the
-// declarations it reads are here: `nodes/core/*/schema.ts`. `packages/lib` is
-// dependency tier 3 and must never import from tier 5. The engine's side is
-// therefore read STATICALLY — see `engine-contract.ts` for exactly what that
-// extraction can and cannot see.
+// declarations it reads are here: `nodes/core/*/schema.ts` (and, for the 22
+// wave-1 migrated types, `packages/lib/src/workflow-engine/catalog/nodes/`).
+// `packages/lib` is dependency tier 3 and must never import from tier 5. The
+// engine's side is therefore read STATICALLY — see `engine-write-scrape.ts`
+// for exactly what that extraction can and cannot see, and why manifests
+// (builder-declared contract) don't make it go away.
 //
 // The OPERATOR third of the suite lives in `packages/lib`, where both sides
 // already are: `src/workflow-engine/nodes/condition-nodes/operator-parity.test.ts`.
@@ -188,8 +190,8 @@ function assertAgainstAllowlist(
 // ═══════════════════════════════════════════════════════════════════════════
 // 0. THE READER ITSELF
 //
-// The parity assertions are only as good as what `engine-contract.ts` can see,
-// and a blind spot there does not fail — it MIS-CLASSIFIES, which is worse. The
+// The parity assertions are only as good as what `engine-write-scrape.ts` can
+// see, and a blind spot there does not fail — it MIS-CLASSIFIES, which is worse. The
 // reader shipped blind to `setNodeVariables` (the bulk writer, execution-context
 // .ts:282) and so reported four nodes as "advertises but never writes" when they
 // publish everything correctly. That reads as a burn-down item and sends someone

--- a/apps/web/src/components/workflow/parity/builder-rendered-handles.ts
+++ b/apps/web/src/components/workflow/parity/builder-rendered-handles.ts
@@ -4,7 +4,7 @@ import { NodeType } from '~/components/workflow/types/node-types'
 
 /**
  * The handles each builder node's UI actually renders — the builder half of the
- * HANDLE contract, beside the engine half `engine-contract.ts` extracts
+ * HANDLE contract, beside the engine half `engine-write-scrape.ts` extracts
  * (`outputHandles` per processor, plus `readEngineRoutedHandleLiterals` for the
  * core's own edge lookups).
  *

--- a/apps/web/src/components/workflow/parity/contract-drift-allowlist.ts
+++ b/apps/web/src/components/workflow/parity/contract-drift-allowlist.ts
@@ -345,7 +345,7 @@ export const EXTRACTION_BLIND_SPOTS: Record<string, string> = {
 
   // ── Handle the reader can see but production can never emit ───────────────
   'handle:if-else.true':
-    "Dead arm, not drift: `outputHandle = conditionResult ? 'true' : 'false'` (if-else.ts:181) runs only when matchedCaseId is null, and buildExecutionResult is only ever called with (true, case_id, …) on a match (if-else.ts:138) or (false, null, …) on none (if-else.ts:150) — so the 'true' literal is unreachable. Production emits case ids and 'false', both rendered. The reachability hole in the reader's net (engine-contract.ts header) seen from the other side: it proves a write EXISTS, never that it runs.",
+    "Dead arm, not drift: `outputHandle = conditionResult ? 'true' : 'false'` (if-else.ts:181) runs only when matchedCaseId is null, and buildExecutionResult is only ever called with (true, case_id, …) on a match (if-else.ts:138) or (false, null, …) on none (if-else.ts:150) — so the 'true' literal is unreachable. Production emits case ids and 'false', both rendered. The reachability hole in the reader's net (engine-write-scrape.ts header) seen from the other side: it proves a write EXISTS, never that it runs.",
 
   // ── Internal bookkeeping, deliberately not picker material ────────────────
   'written:ai._resolvedPromptVars':

--- a/apps/web/src/components/workflow/parity/engine-write-scrape.ts
+++ b/apps/web/src/components/workflow/parity/engine-write-scrape.ts
@@ -1,16 +1,41 @@
-// apps/web/src/components/workflow/parity/engine-contract.ts
+// apps/web/src/components/workflow/parity/engine-write-scrape.ts
 
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { WorkflowNodeType } from '@auxx/lib/workflow-engine/client'
+import { ENGINE_ROOT, listSources, stripComments } from './monorepo-paths'
 
 /**
- * Static reader for the workflow ENGINE's side of the builder↔engine contract.
+ * Static reader for the workflow ENGINE's side of the builder↔engine contract —
+ * the successor to `engine-contract.ts` (deleted; node-catalog Phase 1 exit
+ * criterion, `plans/kopilot/workflow/01-node-catalog.md`).
  *
- * The engine lives in `packages/lib` (tier 3) and the builder's declarations in
- * `apps/web` (tier 5). lib must never import upward, so the parity test lives
- * here — and here we cannot *execute* a processor (they pull in bullmq, redis,
- * the database and live AI providers). What we can do is read their source.
+ * Phase 1 gave every builder node type (wave 1: 22 types) a manifest in
+ * `packages/lib/src/workflow-engine/catalog/`, so `builder-declared-keys.ts`
+ * (formerly this file's `builderDeclaredKeys`) now reads the catalog file
+ * instead of scraping `nodes/core/<type>/schema.ts`'s source text — that half
+ * of the old extractor is genuinely gone.
+ *
+ * This half is not, and manifests are not the reason why. A `NodeManifest`
+ * (`catalog/types.ts`) is the BUILDER's declared contract — `configSchema`,
+ * `defaultData`, `validate`, `resolveOutputs`, `connection` — it says nothing
+ * about what a processor's `setNodeVariable` calls actually write, what
+ * `node.data` keys it actually reads, or what `outputHandle` values it can
+ * actually emit at runtime. Those are ENGINE (`packages/lib`) processor
+ * internals, and the engine lives at dependency tier 3 while the builder's
+ * declarations live in `apps/web` at tier 5 — lib must never import upward, so
+ * the parity test lives here, and here we cannot *execute* a processor (they
+ * pull in bullmq, redis, the database and live AI providers). What we can do
+ * is read their source, same as before.
+ *
+ * **This is expected to shrink, not stay forever.** The planned replacement is
+ * the "resolvability suite" — `plans/kopilot/workflow/10-variable-resolution-deep-dive.md`
+ * §10b step 2, sequenced as the next item after this file's introduction —
+ * which executes real processors against fixtures instead of reading their
+ * source text (`find-output-keying.test.ts` already does this for one
+ * processor; that is the shape the suite generalizes). When it lands, the
+ * assertions this file powers move to it and this file's scanning apparatus
+ * goes with `engine-contract.ts` did.
  *
  * ── WHAT THIS EXTRACTION SEES ───────────────────────────────────────────────
  *  - `contextManager.setNodeVariable(<any>, '<literal>', ...)` and the bulk
@@ -118,68 +143,17 @@ import { fileURLToPath } from 'node:url'
  * was real drift hidden that way for the whole first pass of the burn-down.
  */
 
-/** Walk up from this file until the monorepo root (the one with `packages/lib`). */
-function repoRoot(): string {
-  let dir = dirname(fileURLToPath(import.meta.url))
-  while (!existsSync(join(dir, 'packages', 'lib', 'package.json'))) {
-    const parent = dirname(dir)
-    if (parent === dir) throw new Error('could not locate the monorepo root')
-    dir = parent
-  }
-  return dir
-}
-
-const ENGINE_ROOT = join(repoRoot(), 'packages/lib/src/workflow-engine')
-const BUILDER_ROOT = join(repoRoot(), 'apps/web/src/components/workflow/nodes')
-
-function listSources(dir: string, out: string[] = []): string[] {
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry)
-    if (statSync(full).isDirectory()) listSources(full, out)
-    else if (full.endsWith('.ts') && !/\.(test|spec)\.ts$/.test(full)) out.push(full)
-  }
-  return out
-}
-
 /**
- * Strip comments before scanning.
- *
- * Not cosmetic: `form-input-processor.ts` documents `setNodeVariable(` inside a
- * JSDoc block, and without this the scanner reads the prose that follows it as
- * an argument list.
- *
- * Offsets are preserved (comments are blanked, not removed) because the
- * `else`-block analysis below compares call-site offsets against block spans.
+ * `readonly type = WorkflowNodeType.X` / `WorkflowActionType.X` in a processor
+ * file all resolve through the SAME merged const at runtime —
+ * `WorkflowNodeType` is `{ ...WorkflowTriggerType, ...WorkflowActionType }`
+ * (`core/types.ts`), and the two source enums share no member names — so one
+ * imported lookup table replaces what `engine-contract.ts` used to get by
+ * regex-parsing `core/types.ts`'s enum bodies as text (`parseEnum`). This is a
+ * real category-(a) win: `apps/web` (tier 5) can import this const directly
+ * from the client-safe barrel, no text-scraping needed for it.
  */
-function stripComments(source: string): string {
-  const blank = (text: string) => text.replace(/[^\n]/g, ' ')
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, blank)
-    .replace(/(^|[^:])\/\/[^\n]*/g, (_m, lead: string) => lead + blank(_m.slice(lead.length)))
-}
-
-/** Parse `enum X { A = 'a', ... }` out of a source file: member name -> value. */
-function parseEnum(source: string, name: string): Record<string, string> {
-  const start = source.indexOf(`enum ${name} {`)
-  if (start === -1) throw new Error(`enum ${name} not found in core/types.ts`)
-  const end = source.indexOf('\n}', start)
-  const body = source.slice(start, end)
-  return Object.fromEntries(
-    Array.from(body.matchAll(/(\w+)\s*=\s*'([^']*)'/g), (m) => [m[1] as string, m[2] as string])
-  )
-}
-
-const CORE_TYPES = stripComments(readFileSync(join(ENGINE_ROOT, 'core/types.ts'), 'utf8'))
-
-/**
- * `WorkflowNodeType` is not an enum — it is `{ ...WorkflowTriggerType,
- * ...WorkflowActionType }`, so a member reference has to be resolved against
- * both. `WorkflowActionType` is kept separate as well because several dataset
- * processors declare `readonly type = WorkflowActionType.X`.
- */
-const ACTION_TYPE_VALUES = parseEnum(CORE_TYPES, 'WorkflowActionType')
-const TRIGGER_TYPE_VALUES = parseEnum(CORE_TYPES, 'WorkflowTriggerType')
-const NODE_TYPE_VALUES = { ...TRIGGER_TYPE_VALUES, ...ACTION_TYPE_VALUES }
+const NODE_TYPE_VALUES: Record<string, string> = WorkflowNodeType
 
 /**
  * Engine files whose `setNodeVariable` calls target a node type OTHER than the
@@ -679,8 +653,9 @@ function scanFile(path: string): FileFacts {
       nodeTypeValues.push(m[3])
       continue
     }
-    const table = m[1] === 'WorkflowActionType' ? ACTION_TYPE_VALUES : NODE_TYPE_VALUES
-    const value = table[m[2] as string]
+    // `m[1]` (`WorkflowNodeType` vs `WorkflowActionType`) no longer changes
+    // which table is consulted — see `NODE_TYPE_VALUES` above.
+    const value = NODE_TYPE_VALUES[m[2] as string]
     if (value) nodeTypeValues.push(value)
   }
 
@@ -1039,41 +1014,6 @@ export function readEngineRoutedHandleLiterals(): Array<{ handle: string; file: 
     }
   }
   return lookups
-}
-
-/**
- * Property names declared in a builder node's `types.ts`.
- *
- * The zod schema alone is NOT the builder's writable surface. Several nodes
- * declare only a handful of keys in zod while the panel writes the full
- * TypeScript interface — `format`'s schema has four keys, its `FormatNodeData`
- * has eighteen `*Config` objects that the panel and validator both use. Reading
- * the interface keeps the config-key assertion pointed at genuine
- * name-mismatches (`data.assigneeId` vs `data.assignee`) rather than at zod
- * schemas that are merely incomplete — which is a different bug, and not this
- * suite's.
- *
- * Deliberately a flat property-line scan rather than a parse: it over-collects
- * slightly (nested object types in the same file contribute their keys too),
- * and over-collecting only makes this assertion more conservative.
- */
-export function builderDeclaredKeys(builderDir: string): Set<string> {
-  const keys = new Set<string>()
-
-  // Migrated node types (node-catalog Phase 1) declare their data interface in
-  // the lib catalog; the web types.ts shrinks to a `type: NodeType` narrowing
-  // wrapper over it. Read the catalog file first when it exists — it IS the
-  // builder declaration for those types.
-  const catalogPath = join(ENGINE_ROOT, 'catalog/nodes', `${builderDir.replace(/^core\//, '')}.ts`)
-  const paths = [catalogPath, join(BUILDER_ROOT, builderDir, 'types.ts')]
-  for (const path of paths) {
-    if (!existsSync(path)) continue
-    const source = stripComments(readFileSync(path, 'utf8'))
-    for (const m of source.matchAll(/^\s+(\w+)\??\s*:/gm)) {
-      keys.add(m[1] as string)
-    }
-  }
-  return keys
 }
 
 /**

--- a/apps/web/src/components/workflow/parity/monorepo-paths.ts
+++ b/apps/web/src/components/workflow/parity/monorepo-paths.ts
@@ -1,0 +1,57 @@
+// apps/web/src/components/workflow/parity/monorepo-paths.ts
+
+import { existsSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Shared filesystem plumbing for the parity suite's static readers
+ * (`engine-write-scrape.ts`, `builder-declared-keys.ts`) — both need to locate
+ * the monorepo root and read/strip source files, and neither should carry its
+ * own copy of that logic. Split out of `engine-contract.ts` when it was
+ * deleted (node-catalog Phase 1 exit criterion) so the two readers it used to
+ * house — one genuinely ENGINE-side, one BUILDER-side — don't depend on each
+ * other just to find a path.
+ */
+
+/** Walk up from this file until the monorepo root (the one with `packages/lib`). */
+export function repoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url))
+  while (!existsSync(join(dir, 'packages', 'lib', 'package.json'))) {
+    const parent = dirname(dir)
+    if (parent === dir) throw new Error('could not locate the monorepo root')
+    dir = parent
+  }
+  return dir
+}
+
+export const ENGINE_ROOT = join(repoRoot(), 'packages/lib/src/workflow-engine')
+export const BUILDER_ROOT = join(repoRoot(), 'apps/web/src/components/workflow/nodes')
+
+/** List every non-test `.ts` source file under `dir`, recursively. */
+export function listSources(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) listSources(full, out)
+    else if (full.endsWith('.ts') && !/\.(test|spec)\.ts$/.test(full)) out.push(full)
+  }
+  return out
+}
+
+/**
+ * Strip comments before scanning.
+ *
+ * Not cosmetic: `form-input-processor.ts` documents `setNodeVariable(` inside a
+ * JSDoc block, and without this a caller's scanner reads the prose that
+ * follows it as an argument list.
+ *
+ * Offsets are preserved (comments are blanked, not removed) so callers doing
+ * offset-based structural analysis (e.g. `engine-write-scrape.ts`'s
+ * `else`-block spans) stay aligned with the original source.
+ */
+export function stripComments(source: string): string {
+  const blank = (text: string) => text.replace(/[^\n]/g, ' ')
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, blank)
+    .replace(/(^|[^:])\/\/[^\n]*/g, (_m, lead: string) => lead + blank(_m.slice(lead.length)))
+}


### PR DESCRIPTION
Executes the node-catalog Phase 1 exit criterion (`01-node-catalog.md`: "delete `engine-contract.ts`, re-point the parity suite at the manifests") — **with a corrected premise**, discovered during implementation and worth recording:

## The premise was ~85% wrong

Analysis of all 1,118 lines showed only a small fraction of `engine-contract.ts` read the builder's contract. **~950 lines scrape ENGINE processor source** — `setNodeVariable` writes, `node.data` reads, `outputHandle` emissions. A `NodeManifest` cannot replace that: it's the builder's *declared* contract (schema/defaults/validate/resolveOutputs/connection) and says nothing about what a processor actually writes at runtime. And the processors can't be executed from a web test process (they import bullmq/redis/DB via the processor registry). The scraper's genuine retirement path is the planned **resolvability suite** (deep-dive §10b step 2), which executes processors against fixtures — `find-output-keying.test.ts` is the existing single-processor example of that shape.

## What this PR does

- **Deletes `engine-contract.ts`**, splitting it into honest, separately-documented pieces:
  - `engine-write-scrape.ts` — the engine-side scraper, functionally unchanged, header documents why manifests don't obsolete it and names the resolvability suite as its retirement path
  - `builder-declared-keys.ts` — the declared-shape reader, **now catalog-first for migrated types** (this half genuinely moved to the catalog). Stays textual because TS interfaces aren't runtime-reflectable, and zod schemas are deliberately narrower than the data interfaces (format: 4-key schema vs 18-field interface)
  - `monorepo-paths.ts` — shared path/source helpers
- **The one true manifest win**: ~46 lines of regex-parsing enum bodies out of `core/types.ts` source replaced by importing `WorkflowNodeType` from `@auxx/lib/workflow-engine/client`.
- `builder-engine-parity.test.ts` re-pointed (imports + doc comments only); filename references updated in `contract-drift-allowlist.ts` and `builder-rendered-handles.ts`.

## Guarantees

- **Zero assertions changed** — every test asserts identically; the reverse "written ⊆ advertised" drift-catcher (which caught the real crud drift fixed in #1584) runs unmodified.
- **Zero allowlist entries added or removed.**
- No engine/lib files touched.

## Verification

- `apps/web` vitest `src/components/workflow`: 100/100 (25/25 in `parity/`)
- typecheck ratchet web: 1/1 baseline, no new errors
- biome: clean