### PR TITLE
test(workflow): add resolvability suite for resource node variables

### DIFF
--- a/packages/lib/src/workflow-engine/parity/crud.resolvability.test.ts
+++ b/packages/lib/src/workflow-engine/parity/crud.resolvability.test.ts
@@ -1,0 +1,410 @@
+// packages/lib/src/workflow-engine/parity/crud.resolvability.test.ts
+
+/**
+ * Resolvability suite — CRUD node.
+ *
+ * Proves that every variable id `crudManifest.resolveOutputs()` DECLARES for
+ * a crud node actually RESOLVES against a REAL `CrudNodeProcessor.executeNode`
+ * + REAL `ExecutionContextManager.resolveVariablePath` run. See `harness.ts`
+ * for the three invariants and `known-broken.ts` for the documented,
+ * empirically-verified exceptions.
+ *
+ * REAL: `CrudNodeProcessor`, `ExecutionContextManager` (never stubbed),
+ * `analyzePathForRelationships`, `fetchResourceWithRelationships`,
+ * `fetchResourceById` — same as `find.resolvability.test.ts`.
+ *
+ * MOCKED (external edges only):
+ * - `../../resources/crud` — `UnifiedCrudHandler`. Mirrors
+ *   `crud-canonicalization.test.ts`/`crud-delete-variables.test.ts`: the
+ *   actual create/update/archive DB writes are not what this suite is about
+ *   — the OUTPUT KEYING and its resolvability is.
+ * - `../../cache` — same fixture-backed resource lookups as the find suite.
+ * - `@auxx/services/entity-instances` — `getEntityInstance`, backing the
+ *   post-write lazy-load ladder for create/update's field paths.
+ * - `../../field-values/field-value-queries` — `batchGetValues`.
+ * - `../../threads/thread-mutation.service` — `ThreadMutationService`, for
+ *   the thread-actions scenario. Only `.update()` is exercised (the
+ *   scenario's `data` sets only `status`/`subject`, so `UnreadService` and
+ *   `threads/links.service` are never reached — genuinely unmocked, not
+ *   silently inert).
+ * - `../../permissions/visibility/automation-visibility` — thread mode
+ *   resolves automation visibility unconditionally.
+ * - `@auxx/database` — ONLY needed because resolving the bare `<node>.thread`
+ *   reference (the thread-actions scenario's declared root) still triggers a
+ *   full lazy-load hydration: `analyzePath` matches a stored
+ *   `ResourceReference` even with an EMPTY remaining path, so
+ *   `resolveVariablePath('<node>.thread')` calls `fetchResourceWithRelationships`
+ *   → `fetchResourceById` → (system resource) `executeResourceQuery` →
+ *   `database.select().from(schema.Thread)`, which needs a real `PgTable`
+ *   identity check (`resolveSchemaTable`'s `is(table, PgTable)`) the plain
+ *   `{}` schema proxy in `src/test/setup.ts` fails. Same `Thread`-chain
+ *   pattern as `find.resolvability.test.ts`.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorkflowNode } from '../core/types'
+import { WorkflowNodeType } from '../core/types'
+import {
+  ALL_RESOURCES,
+  findFixtureResource,
+  REGION_INSTANCES,
+  resolveFixtureFieldPath,
+  THREAD_HIT_ID,
+  THREAD_ROW,
+  VENDOR_CREATE_INSTANCE_ID,
+  VENDOR_DEF_ID,
+  VENDOR_DELETE_INSTANCE_ID,
+  VENDOR_INSTANCES,
+  VENDOR_RESOURCE,
+  VENDOR_UPDATE_INSTANCE_ID,
+  WORKFLOW_ID,
+} from './fixtures'
+import {
+  assertLabelCoverage,
+  assertResolvability,
+  assertWrittenCovered,
+  createContextManager,
+  flattenDeclared,
+  runExecuteNode,
+  writtenKeysForNode,
+} from './harness'
+
+const { threadRows } = vi.hoisted(() => ({ threadRows: { current: [] as unknown[] } }))
+
+vi.mock('@auxx/database', async () => {
+  const { createChainableDatabaseMock, createSchemaMock } = await import('../../test/database-mock')
+  const mockedSchema = createSchemaMock({ Thread: {}, EntityInstance: {}, FieldValue: {} })
+
+  const threadChain: Record<string, unknown> = {}
+  threadChain.$dynamic = () => threadChain
+  threadChain.where = () => threadChain
+  threadChain.orderBy = () => threadChain
+  threadChain.limit = () => threadChain
+  // biome-ignore lint/suspicious/noThenProperty: deliberately thenable — mimics the Drizzle query builder's own then()
+  threadChain.then = (resolve: (rows: unknown[]) => void) => resolve(threadRows.current)
+
+  const db = new Proxy(
+    {},
+    {
+      get: (_target, prop) => {
+        if (prop === 'then') return undefined
+        if (prop === 'select') {
+          return () => ({
+            from: (table: unknown) =>
+              table === mockedSchema.Thread ? threadChain : createChainableDatabaseMock(),
+          })
+        }
+        if (prop === 'query') {
+          return {
+            EntityInstance: { findMany: vi.fn(async () => []) },
+            FieldValue: { findMany: vi.fn(async () => []) },
+          }
+        }
+        return createChainableDatabaseMock()
+      },
+    }
+  )
+
+  return { database: db, schema: mockedSchema }
+})
+
+// `fetchResourceById` (resources/resource-fetcher.ts) builds its WHERE clause
+// via `resolveSchemaTable(tableInfo.dbName)`, which runs drizzle-orm's `is(table,
+// PgTable)` — a REAL runtime brand check nothing but an actual `pgTable(...)`
+// output can pass, so no plain mock object for `schema.Thread` can satisfy it.
+// This is the one seam that has to be mocked directly (a cross-module import,
+// unlike `executeResourceQuery` which `fetchResourceById` calls in the SAME
+// file and which `vi.mock` therefore cannot intercept for that internal call).
+vi.mock('../../resources/schema-table', () => ({
+  resolveSchemaTable: vi.fn(() => ({ id: {} })),
+  requireColumn: vi.fn((table: Record<string, unknown>, key: string) => table[key] ?? {}),
+}))
+
+const { createWithValues, updateValues, archive, threadUpdate } = vi.hoisted(() => ({
+  createWithValues: vi.fn(async () => ({ entityInstance: {}, id: '' })),
+  updateValues: vi.fn(async () => ({ entityInstance: {}, id: '' })),
+  archive: vi.fn(async () => undefined),
+  threadUpdate: vi.fn(async () => ({
+    id: '',
+    success: true,
+    updatedFields: {},
+    timestamp: new Date(),
+  })),
+}))
+
+vi.mock('../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    createWithValues = createWithValues
+    updateValues = updateValues
+    archive = archive
+  },
+}))
+
+// Full replacement — see the doc comment above for why `@auxx/database`
+// itself is left unmocked; this and `getEntityInstance`/`batchGetValues`
+// below are the only real DB-adjacent edges this suite's CRUD paths touch.
+vi.mock('../../cache', () => ({
+  findCachedResource: vi.fn(
+    async (_orgId: string, key: string) => findFixtureResource(key) ?? null
+  ),
+  getCachedResource: vi.fn(async (_orgId: string, key: string) => findFixtureResource(key) ?? null),
+  getCachedResources: vi.fn(async () => ALL_RESOURCES),
+  getCachedResourceFields: vi.fn(
+    async (_orgId: string, key: string) => findFixtureResource(key)?.fields ?? []
+  ),
+  requireCachedEntityDefId: vi.fn(async (_orgId: string, entityType: string) => entityType),
+}))
+
+vi.mock('@auxx/services/entity-instances', async () => {
+  const { ok, err } = await import('neverthrow')
+  return {
+    getEntityInstance: vi.fn(async ({ id }: { id: string; organizationId: string }) => {
+      const found = VENDOR_INSTANCES[id] ?? REGION_INSTANCES[id]
+      if (found) return ok(found)
+      return err({
+        code: 'ENTITY_INSTANCE_NOT_FOUND' as const,
+        message: `not found: ${id}`,
+        entityInstanceId: id,
+      })
+    }),
+  }
+})
+
+vi.mock('../../field-values/field-value-queries', () => ({
+  batchGetValues: vi.fn(
+    async (
+      _ctx: unknown,
+      input: { recordIds: string[]; fieldReferences: (string | string[])[] }
+    ) => ({
+      values: input.recordIds.flatMap((recordId) =>
+        input.fieldReferences.map((fieldRef) => {
+          const segments = Array.isArray(fieldRef) ? fieldRef : [fieldRef]
+          const typed = resolveFixtureFieldPath(segments, recordId)
+          return {
+            recordId,
+            fieldRef,
+            value: typed,
+            fieldType: typed?.type === 'relationship' ? 'RELATIONSHIP' : 'TEXT',
+          }
+        })
+      ),
+    })
+  ),
+}))
+
+vi.mock('../../permissions/visibility/automation-visibility', () => ({
+  getAutomationVisibility: vi.fn(async () => ({
+    kind: 'automation' as const,
+    personalInboxIds: {},
+  })),
+}))
+
+vi.mock('../../threads/thread-mutation.service', () => ({
+  ThreadMutationService: class {
+    update = threadUpdate
+  },
+}))
+
+const { CrudNodeProcessor } = await import('../nodes/action-nodes/crud')
+const { crudManifest, CrudErrorStrategy } = await import('../catalog/nodes/crud')
+
+function buildCrudNode(nodeId: string, data: Record<string, unknown>): WorkflowNode {
+  return {
+    id: nodeId,
+    workflowId: WORKFLOW_ID,
+    nodeId,
+    name: 'CRUD',
+    type: WorkflowNodeType.CRUD,
+    data: {
+      id: nodeId,
+      type: WorkflowNodeType.CRUD,
+      title: 'CRUD',
+      data: {},
+      error_strategy: CrudErrorStrategy.fail,
+      default_values: [],
+      ...data,
+    },
+    metadata: { position: { x: 0, y: 0 } },
+  } as unknown as WorkflowNode
+}
+
+beforeEach(() => {
+  createWithValues.mockReset()
+  updateValues.mockReset()
+  archive.mockReset().mockResolvedValue(undefined)
+  threadUpdate
+    .mockReset()
+    .mockResolvedValue({ id: 'x', success: true, updatedFields: {}, timestamp: new Date() })
+  threadRows.current = []
+})
+
+/** Runs the REAL CrudNodeProcessor (preprocess + execute) and returns written keys. */
+async function runCrud(nodeId: string, data: Record<string, unknown>) {
+  const ctx = createContextManager(`exec_${nodeId}`)
+  const node = buildCrudNode(nodeId, data)
+  const processor = new CrudNodeProcessor()
+  const preprocessed = await processor.preprocessNode(node, ctx)
+  const result = await runExecuteNode(processor, node, ctx, preprocessed)
+  return { ctx, node, result, written: writtenKeysForNode(ctx, nodeId) }
+}
+
+describe('CRUD node resolvability', () => {
+  it('create (custom entity Vendor) — declared ⊆ resolvable, written ⊆ declared, labels present', async () => {
+    createWithValues.mockResolvedValueOnce({
+      entityInstance: {
+        id: VENDOR_CREATE_INSTANCE_ID,
+        entityDefinitionId: VENDOR_DEF_ID,
+        createdAt: new Date('2026-02-01'),
+        updatedAt: new Date('2026-02-01'),
+      },
+      id: VENDOR_CREATE_INSTANCE_ID,
+    })
+    const nodeId = 'crud_vendor_create'
+    const { ctx, node, result, written } = await runCrud(nodeId, {
+      resourceType: VENDOR_DEF_ID,
+      mode: 'create',
+      data: { name: 'Globex Parts', code: 'V-100' },
+    })
+
+    expect(result.status).toBe('succeeded')
+
+    const declared = flattenDeclared(
+      crudManifest.resolveOutputs!(node.data as never, nodeId, {
+        resource: VENDOR_RESOURCE,
+        allResources: ALL_RESOURCES,
+        resolveVariable: () => undefined,
+      })
+    )
+    expect(declared.length).toBeGreaterThan(5)
+    await assertResolvability(ctx, written, declared, 'crud.create.vendor')
+  })
+
+  it('update (custom entity Vendor) — declared ⊆ resolvable, written ⊆ declared, labels present', async () => {
+    updateValues.mockResolvedValueOnce({
+      entityInstance: {
+        id: VENDOR_UPDATE_INSTANCE_ID,
+        entityDefinitionId: VENDOR_DEF_ID,
+        createdAt: new Date('2026-01-15'),
+        updatedAt: new Date('2026-02-15'),
+      },
+      id: VENDOR_UPDATE_INSTANCE_ID,
+    })
+    const nodeId = 'crud_vendor_update'
+    const { ctx, node, result, written } = await runCrud(nodeId, {
+      resourceType: VENDOR_DEF_ID,
+      mode: 'update',
+      resourceId: VENDOR_UPDATE_INSTANCE_ID,
+      data: { name: 'Initech Supply', code: 'V-200' },
+    })
+
+    expect(result.status).toBe('succeeded')
+
+    const declared = flattenDeclared(
+      crudManifest.resolveOutputs!(node.data as never, nodeId, {
+        resource: VENDOR_RESOURCE,
+        allResources: ALL_RESOURCES,
+        resolveVariable: () => undefined,
+      })
+    )
+    expect(declared.length).toBeGreaterThan(5)
+    await assertResolvability(ctx, written, declared, 'crud.update.vendor')
+  })
+
+  it('delete (custom entity Vendor) — declared ⊆ resolvable, written ⊆ declared, labels present', async () => {
+    const nodeId = 'crud_vendor_delete'
+    const { ctx, node, result, written } = await runCrud(nodeId, {
+      resourceType: VENDOR_DEF_ID,
+      mode: 'delete',
+      resourceId: VENDOR_DELETE_INSTANCE_ID,
+    })
+
+    expect(result.status).toBe('succeeded')
+    expect(archive).toHaveBeenCalledOnce()
+    // Pins #1584: delete must still write `deleted`/`id` — the fix this
+    // suite exists to keep proven. If a regression removed the writes, this
+    // scenario's `assertResolvability` below would fail on the declared
+    // `deleted`/`id` ids resolving to `undefined`.
+    expect(written).toContain(`${nodeId}.deleted`)
+    expect(written).toContain(`${nodeId}.id`)
+
+    const declared = flattenDeclared(
+      crudManifest.resolveOutputs!(node.data as never, nodeId, {
+        resource: VENDOR_RESOURCE,
+        allResources: ALL_RESOURCES,
+        resolveVariable: () => undefined,
+      })
+    )
+    await assertResolvability(ctx, written, declared, 'crud.delete.vendor')
+  })
+
+  it('thread-actions update — declared ⊆ resolvable, written ⊆ declared, labels present', async () => {
+    threadRows.current = [THREAD_ROW]
+    const nodeId = 'crud_thread_update'
+    const { ctx, node, result, written } = await runCrud(nodeId, {
+      resourceType: 'thread',
+      mode: 'update',
+      resourceId: THREAD_HIT_ID,
+      data: { status: 'CLOSED', subject: 'Escalated: shipment delay' },
+    })
+
+    expect(result.status).toBe('succeeded')
+    expect(threadUpdate).toHaveBeenCalledOnce()
+
+    const declared = flattenDeclared(
+      crudManifest.resolveOutputs!(node.data as never, nodeId, {
+        resource: undefined,
+        allResources: ALL_RESOURCES,
+        resolveVariable: () => undefined,
+      })
+    )
+    expect(declared.length).toBeGreaterThan(10)
+    await assertResolvability(ctx, written, declared, 'crud.thread.update')
+  })
+
+  it('error_strategy "default" — usedDefaults/defaultValues resolve after a forced failure', async () => {
+    updateValues.mockRejectedValueOnce(new Error('simulated update failure'))
+    const nodeId = 'crud_vendor_update_default'
+    const { ctx, node, result, written } = await runCrud(nodeId, {
+      resourceType: VENDOR_DEF_ID,
+      mode: 'update',
+      resourceId: VENDOR_UPDATE_INSTANCE_ID,
+      data: { name: 'Initech Supply' },
+      error_strategy: CrudErrorStrategy.default,
+      default_values: [{ key: 'fallbackNote', type: 'string', value: 'applied fallback' }],
+    })
+
+    // `default` with configured default_values still SUCCEEDS the node
+    // (`handleCrudError`'s 'default' case returns `NodeRunningStatus.Succeeded`).
+    expect(result.status).toBe('succeeded')
+    expect(written).toContain(`${nodeId}.usedDefaults`)
+    expect(written).toContain(`${nodeId}.defaultValues`)
+
+    const declared = flattenDeclared(
+      crudManifest.resolveOutputs!(node.data as never, nodeId, {
+        resource: VENDOR_RESOURCE,
+        allResources: ALL_RESOURCES,
+        resolveVariable: () => undefined,
+      })
+    )
+    expect(declared.map((d) => d.id)).toContain(`${nodeId}.usedDefaults`)
+    expect(declared.map((d) => d.id)).toContain(`${nodeId}.defaultValues`)
+
+    // Deliberately NOT the full `assertResolvability` walk, same reasoning as
+    // find's findOne-miss scenario: the update genuinely FAILED, so
+    // `setEntityVariables` never ran and the declared `<node>.<defId>` /
+    // `<node>.record` / `<node>.id` tree — which the manifest still declares
+    // unconditionally whenever the resource has visible fields, regardless of
+    // error_strategy — has NOTHING written under it at all (not even a
+    // sentinel `null`, unlike find's miss case). That is not a resolvability
+    // BUG; it is what "the write never happened" means. This scenario exists
+    // to prove `usedDefaults`/`defaultValues` specifically, which is what the
+    // task's self-check names — assert those and the label/write-coverage
+    // invariants directly instead of over-scoping to the full tree.
+    assertLabelCoverage(declared, 'crud.update.default-strategy')
+    assertWrittenCovered(written, declared, 'crud.update.default-strategy')
+    expect(await ctx.resolveVariablePath(`${nodeId}.usedDefaults`)).toBe(true)
+    expect(await ctx.resolveVariablePath(`${nodeId}.defaultValues`)).toEqual({
+      fallbackNote: 'applied fallback',
+    })
+  })
+})

--- a/packages/lib/src/workflow-engine/parity/declaration-only.resolvability.test.ts
+++ b/packages/lib/src/workflow-engine/parity/declaration-only.resolvability.test.ts
@@ -1,0 +1,111 @@
+// packages/lib/src/workflow-engine/parity/declaration-only.resolvability.test.ts
+
+/**
+ * Supplementary, DECLARATION-ONLY check (no processor execution, no mocks) —
+ * not one of the three resolvability invariants (`harness.ts`), and not part
+ * of the scenario × invariant coverage table. Exists to close a specific gap
+ * named in the suite's self-check: would this suite catch it if "the
+ * empty-fields status variables disappeared again"?
+ *
+ * Both `generateFindNodeVariablesFromFields` and
+ * `generateCrudNodeVariablesFromFields` (`resources/variable-generators.ts`)
+ * carry an explicit comment that a resource with zero VISIBLE fields (every
+ * field hidden, or genuinely none) must still declare its unconditional
+ * status block — `count`/`query_info` for find, `success`/`operation`/
+ * `resourceType`/`error`/`errorDetails` for crud — even though the main
+ * record-shaped variable itself is correctly skipped. That is a
+ * DECLARATION-time property (`resolveOutputs()`'s output, independent of any
+ * run), not a resolvability one — none of `find.resolvability.test.ts` /
+ * `crud.resolvability.test.ts`'s fixtures have a zero-field resource, so
+ * their full walks never exercise this branch. This file closes that gap
+ * directly, cheaply, without needing a third fixture entity wired through
+ * the cache/DB mocks.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { CrudNodeData } from '../catalog/nodes/crud'
+import { CrudErrorStrategy, crudManifest } from '../catalog/nodes/crud'
+import type { FindNodeData } from '../catalog/nodes/find'
+import { findManifest } from '../catalog/nodes/find'
+import { ALL_RESOURCES, EMPTY_FIELDS_DEF_ID, EMPTY_FIELDS_RESOURCE } from './fixtures'
+
+const emptyContext = {
+  resource: EMPTY_FIELDS_RESOURCE,
+  allResources: [...ALL_RESOURCES, EMPTY_FIELDS_RESOURCE],
+  resolveVariable: () => undefined,
+}
+
+describe('declaration-only: empty-fields status variables', () => {
+  it('find findOne still declares count and query_info with zero visible fields', () => {
+    const data = {
+      resourceType: EMPTY_FIELDS_DEF_ID,
+      findMode: 'findOne',
+      conditions: [],
+      conditionGroups: [],
+    } as unknown as FindNodeData
+    const ids = findManifest.resolveOutputs!(data, 'find_empty', emptyContext).map((v) => v.id)
+
+    expect(ids).toContain('find_empty.count')
+    expect(ids).toContain('find_empty.query_info')
+    // The main record variable IS correctly absent — nothing to shape it from.
+    expect(ids).not.toContain(`find_empty.${EMPTY_FIELDS_DEF_ID}`)
+  })
+
+  it('find findMany still declares count and query_info with zero visible fields', () => {
+    const data = {
+      resourceType: EMPTY_FIELDS_DEF_ID,
+      findMode: 'findMany',
+      conditions: [],
+      conditionGroups: [],
+    } as unknown as FindNodeData
+    const ids = findManifest.resolveOutputs!(data, 'find_empty_many', emptyContext).map((v) => v.id)
+
+    expect(ids).toContain('find_empty_many.count')
+    expect(ids).toContain('find_empty_many.query_info')
+  })
+
+  it('crud create still declares the status block with zero visible fields', () => {
+    const data = {
+      resourceType: EMPTY_FIELDS_DEF_ID,
+      mode: 'create',
+      data: {},
+      error_strategy: CrudErrorStrategy.fail,
+      default_values: [],
+    } as unknown as CrudNodeData
+    const ids = crudManifest.resolveOutputs!(data, 'crud_empty', emptyContext).map((v) => v.id)
+
+    expect(ids).toContain('crud_empty.success')
+    expect(ids).toContain('crud_empty.operation')
+    expect(ids).toContain('crud_empty.resourceType')
+    expect(ids).toContain('crud_empty.error')
+    expect(ids).toContain('crud_empty.errorDetails')
+    // create/update still declare `id`/`record` regardless of field count
+    // (`getCrudNodeOutputVariables` pushes them unconditionally for `mode !== 'delete'`).
+    expect(ids).toContain('crud_empty.id')
+    expect(ids).toContain('crud_empty.record')
+    // The main record variable IS correctly absent.
+    expect(ids).not.toContain(`crud_empty.${EMPTY_FIELDS_DEF_ID}`)
+  })
+
+  it('crud delete still declares deleted/id and the status block with zero visible fields', () => {
+    const data = {
+      resourceType: EMPTY_FIELDS_DEF_ID,
+      mode: 'delete',
+      resourceId: 'whatever',
+      data: {},
+      error_strategy: CrudErrorStrategy.fail,
+      default_values: [],
+    } as unknown as CrudNodeData
+    const ids = crudManifest.resolveOutputs!(data, 'crud_empty_delete', emptyContext).map(
+      (v) => v.id
+    )
+
+    expect(ids).toContain('crud_empty_delete.deleted')
+    expect(ids).toContain('crud_empty_delete.id')
+    expect(ids).toContain('crud_empty_delete.success')
+    expect(ids).toContain('crud_empty_delete.operation')
+    expect(ids).toContain('crud_empty_delete.resourceType')
+    expect(ids).toContain('crud_empty_delete.error')
+    expect(ids).toContain('crud_empty_delete.errorDetails')
+  })
+})

--- a/packages/lib/src/workflow-engine/parity/find.resolvability.test.ts
+++ b/packages/lib/src/workflow-engine/parity/find.resolvability.test.ts
@@ -1,0 +1,350 @@
+// packages/lib/src/workflow-engine/parity/find.resolvability.test.ts
+
+/**
+ * Resolvability suite — Find node.
+ *
+ * Proves that every variable id `findManifest.resolveOutputs()` DECLARES for
+ * a find node actually RESOLVES against a REAL `FindProcessor.executeNode` +
+ * REAL `ExecutionContextManager.resolveVariablePath` run. See `harness.ts`
+ * for the three invariants and `known-broken.ts` for the documented,
+ * empirically-verified exceptions.
+ *
+ * REAL: `FindProcessor`, `ExecutionContextManager` (constructed for real,
+ * never stubbed — that's the whole point: `resolveVariablePath`'s lazy-load
+ * ladder has to actually run), `analyzePathForRelationships`,
+ * `fetchResourceWithRelationships`, `fetchResourceById` (all from
+ * `resources/resource-fetcher.ts` — unmocked, they run for real against the
+ * mocked edges below).
+ *
+ * MOCKED (external edges only):
+ * - `@auxx/database` — `schema.Thread`'s select chain resolves to a fixture
+ *   row set (Tier A never goes through the entity/field-value machinery);
+ *   `database.query.EntityInstance.findMany` for the custom-entity query lane.
+ * - `../../cache` — `findCachedResource`/`getCachedResource`/
+ *   `getCachedResources`/`getCachedResourceFields`, all backed by the same
+ *   `ALL_RESOURCES` fixture (mirrors `find-output-keying.test.ts`'s pattern).
+ * - `@auxx/services/entity-instances` — `getEntityInstance`, the actual DB
+ *   read `fetchResourceById` sits behind. Backed by `VENDOR_INSTANCES`/
+ *   `REGION_INSTANCES`.
+ * - `../../field-values/field-value-queries` — `batchGetValues`, the actual
+ *   DB read the record-field-cache lane (`getFieldValue`) sits behind.
+ * - `../../permissions/visibility/automation-visibility` — thread queries
+ *   always resolve automation visibility; stubbed to full org-inbox access.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorkflowNode } from '../core/types'
+import { WorkflowNodeType } from '../core/types'
+import {
+  ALL_RESOURCES,
+  findFixtureResource,
+  REGION_INSTANCES,
+  resolveFixtureFieldPath,
+  THREAD_RESOURCE,
+  THREAD_ROW,
+  THREAD_ROW_2,
+  VENDOR_CREATE_INSTANCE_ID,
+  VENDOR_DEF_ID,
+  VENDOR_HIT_INSTANCE_ID,
+  VENDOR_INSTANCES,
+  VENDOR_RESOURCE,
+  WORKFLOW_ID,
+} from './fixtures'
+import {
+  assertResolvability,
+  createContextManager,
+  flattenDeclared,
+  runExecuteNode,
+  writtenKeysForNode,
+} from './harness'
+
+const { threadRows, entityFindMany } = vi.hoisted(() => ({
+  threadRows: { current: [] as unknown[] },
+  entityFindMany: vi.fn(async (): Promise<unknown[]> => []),
+}))
+
+vi.mock('@auxx/database', async () => {
+  const { createChainableDatabaseMock, createSchemaMock } = await import('../../test/database-mock')
+  const mockedSchema = createSchemaMock({ Thread: {}, EntityInstance: {}, FieldValue: {} })
+
+  // Thread select chain — `find.ts`'s `executeThreadQuery` calls
+  // `database.select().from(schema.Thread).$dynamic().where().orderBy()`,
+  // then either `.limit(1)` (findOne) or the bare query (findMany) — both
+  // awaited directly. This chain is its own thenable so both awaits resolve
+  // to `threadRows.current`, set per-scenario below.
+  const threadChain: Record<string, unknown> = {}
+  threadChain.$dynamic = () => threadChain
+  threadChain.where = () => threadChain
+  threadChain.orderBy = () => threadChain
+  threadChain.limit = () => threadChain
+  // biome-ignore lint/suspicious/noThenProperty: deliberately thenable — see comment above
+  threadChain.then = (resolve: (rows: unknown[]) => void) => resolve(threadRows.current)
+
+  const db = new Proxy(
+    {},
+    {
+      get: (_target, prop) => {
+        if (prop === 'then') return undefined
+        if (prop === 'select') {
+          return () => ({
+            from: (table: unknown) =>
+              table === mockedSchema.Thread ? threadChain : createChainableDatabaseMock(),
+          })
+        }
+        if (prop === 'query') {
+          return {
+            EntityInstance: { findMany: entityFindMany },
+            FieldValue: { findMany: vi.fn(async () => []) },
+          }
+        }
+        return createChainableDatabaseMock()
+      },
+    }
+  )
+
+  return { database: db, schema: mockedSchema }
+})
+
+// Full replacement, not a partial spread of the real module: the real
+// `getCachedResourceFields` transitively hits `OrganizationCacheService` /
+// `ResourceRegistryService`, which needs a real DB — exactly the kind of
+// heavy graph `resources/resource-fetcher.ts`'s lazy-load path (real,
+// unmocked here) reaches into.
+vi.mock('../../cache', () => ({
+  findCachedResource: vi.fn(
+    async (_orgId: string, key: string) => findFixtureResource(key) ?? null
+  ),
+  getCachedResource: vi.fn(async (_orgId: string, key: string) => findFixtureResource(key) ?? null),
+  getCachedResources: vi.fn(async () => ALL_RESOURCES),
+  getCachedResourceFields: vi.fn(
+    async (_orgId: string, key: string) => findFixtureResource(key)?.fields ?? []
+  ),
+}))
+
+vi.mock('../../permissions/visibility/automation-visibility', () => ({
+  getAutomationVisibility: vi.fn(async () => ({
+    kind: 'automation' as const,
+    personalInboxIds: {},
+  })),
+}))
+
+vi.mock('@auxx/services/entity-instances', async () => {
+  const { ok, err } = await import('neverthrow')
+  return {
+    getEntityInstance: vi.fn(
+      async ({ id, organizationId: _organizationId }: { id: string; organizationId: string }) => {
+        const found = VENDOR_INSTANCES[id] ?? REGION_INSTANCES[id]
+        if (found) return ok(found)
+        return err({
+          code: 'ENTITY_INSTANCE_NOT_FOUND' as const,
+          message: `not found: ${id}`,
+          entityInstanceId: id,
+        })
+      }
+    ),
+  }
+})
+
+// Full replacement, not a partial spread of the real module: `batchGetValues`
+// is the only export the code paths this suite exercises actually call
+// (`ExecutionContextManager.getFieldValue`/`prefetchFields`), and the real
+// module's own import graph (mail-lens-gate, resource-access grantee
+// resolution, capability record-visibility) is exactly the kind of unrelated
+// weight a full mock avoids pulling in.
+vi.mock('../../field-values/field-value-queries', () => ({
+  batchGetValues: vi.fn(
+    async (
+      _ctx: unknown,
+      input: { recordIds: string[]; fieldReferences: (string | string[])[] }
+    ) => ({
+      values: input.recordIds.flatMap((recordId) =>
+        input.fieldReferences.map((fieldRef) => {
+          const segments = Array.isArray(fieldRef) ? fieldRef : [fieldRef]
+          const typed = resolveFixtureFieldPath(segments, recordId)
+          return {
+            recordId,
+            fieldRef,
+            value: typed,
+            fieldType: typed?.type === 'relationship' ? 'RELATIONSHIP' : 'TEXT',
+          }
+        })
+      ),
+    })
+  ),
+}))
+
+const { FindProcessor } = await import('../nodes/action-nodes/find')
+const { findManifest } = await import('../catalog/nodes/find')
+
+function buildFindNode(nodeId: string, data: Record<string, unknown>): WorkflowNode {
+  return {
+    id: nodeId,
+    workflowId: WORKFLOW_ID,
+    nodeId,
+    name: 'Find',
+    type: WorkflowNodeType.FIND,
+    data: {
+      id: nodeId,
+      type: WorkflowNodeType.FIND,
+      title: 'Find',
+      conditions: [],
+      conditionGroups: [],
+      orderBy: undefined,
+      limit: undefined,
+      ...data,
+    },
+    metadata: { position: { x: 0, y: 0 } },
+  } as unknown as WorkflowNode
+}
+
+beforeEach(() => {
+  entityFindMany.mockReset().mockResolvedValue([])
+  threadRows.current = []
+})
+
+/** Runs the REAL FindProcessor (preprocess + execute) and returns written keys. */
+async function runFind(nodeId: string, data: Record<string, unknown>) {
+  const ctx = createContextManager(`exec_${nodeId}`)
+  const node = buildFindNode(nodeId, data)
+  const processor = new FindProcessor()
+  const preprocessed = await processor.preprocessNode(node, ctx)
+  const result = await runExecuteNode(processor, node, ctx, preprocessed)
+  return { ctx, node, result, written: writtenKeysForNode(ctx, nodeId) }
+}
+
+describe('Find node resolvability', () => {
+  it('findOne hit (custom entity Vendor) — declared ⊆ resolvable, written ⊆ declared, labels present', async () => {
+    entityFindMany.mockResolvedValueOnce([
+      {
+        id: VENDOR_HIT_INSTANCE_ID,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-02'),
+      },
+    ])
+    const nodeId = 'find_vendor_one'
+    const { ctx, node, result, written } = await runFind(nodeId, {
+      resourceType: VENDOR_DEF_ID,
+      findMode: 'findOne',
+      orderBy: { field: 'name', direction: 'asc' },
+      limit: 5,
+    })
+
+    expect(result.status).toBe('succeeded')
+
+    const declared = flattenDeclared(
+      findManifest.resolveOutputs!(node.data as never, nodeId, {
+        resource: VENDOR_RESOURCE,
+        allResources: ALL_RESOURCES,
+        resolveVariable: () => undefined,
+      })
+    )
+    expect(declared.length).toBeGreaterThan(5)
+    await assertResolvability(ctx, written, declared, 'find.findOne.hit.vendor')
+  })
+
+  it('findOne miss (custom entity Vendor) — root resolves to the written null; nested fields are structurally N/A', async () => {
+    entityFindMany.mockResolvedValueOnce([])
+    const nodeId = 'find_vendor_miss'
+    const { ctx, result, written } = await runFind(nodeId, {
+      resourceType: VENDOR_DEF_ID,
+      findMode: 'findOne',
+    })
+
+    expect(result.status).toBe('succeeded')
+    expect(written).toContain(`${nodeId}.${VENDOR_DEF_ID}`)
+
+    // A stored `null` IS resolvable — `resolveVariablePath`'s direct lookup
+    // only returns `undefined` for an ABSENT key, and this key is present.
+    const root = await ctx.resolveVariablePath(`${nodeId}.${VENDOR_DEF_ID}`)
+    expect(root).toBeNull()
+
+    // Nested declared paths (`<node>.<defId>.name`, `.region`, …) are NOT
+    // asserted here on purpose: with no record, `setEntityVariables` never
+    // ran, so `<node>.<defId>` holds a bare `null`, not a `ResourceReference`
+    // — there is nothing for the lazy-load ladder to walk. That is not a
+    // resolvability BUG, it is what "not found" means; the full nested-tree
+    // walk belongs to the hit scenario above, which is where it proves
+    // something.
+  })
+
+  it('findOne (tier A thread) — declared ⊆ resolvable (with §3.2 pins), written ⊆ declared, labels present', async () => {
+    threadRows.current = [THREAD_ROW]
+    const nodeId = 'find_thread_one'
+    const { ctx, node, result, written } = await runFind(nodeId, {
+      resourceType: 'thread',
+      findMode: 'findOne',
+      orderBy: { field: 'subject', direction: 'asc' },
+      limit: 5,
+    })
+
+    expect(result.status).toBe('succeeded')
+    expect(written).toContain(`${nodeId}.thread`)
+
+    const declared = flattenDeclared(
+      findManifest.resolveOutputs!(node.data as never, nodeId, {
+        resource: THREAD_RESOURCE,
+        allResources: ALL_RESOURCES,
+        resolveVariable: () => undefined,
+      })
+    )
+    expect(declared.length).toBeGreaterThan(5)
+    await assertResolvability(ctx, written, declared, 'find.findOne.thread')
+  })
+
+  it('findMany (custom entity Vendor) — declared ⊆ resolvable, written ⊆ declared, labels present', async () => {
+    entityFindMany.mockResolvedValueOnce([
+      {
+        id: VENDOR_HIT_INSTANCE_ID,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-02'),
+      },
+      {
+        id: VENDOR_CREATE_INSTANCE_ID,
+        createdAt: new Date('2026-02-01'),
+        updatedAt: new Date('2026-02-01'),
+      },
+    ])
+    const nodeId = 'find_vendor_many'
+    const { ctx, node, result, written } = await runFind(nodeId, {
+      resourceType: VENDOR_DEF_ID,
+      findMode: 'findMany',
+      orderBy: { field: 'name', direction: 'asc' },
+      limit: 5,
+    })
+
+    expect(result.status).toBe('succeeded')
+
+    const declared = flattenDeclared(
+      findManifest.resolveOutputs!(node.data as never, nodeId, {
+        resource: VENDOR_RESOURCE,
+        allResources: ALL_RESOURCES,
+        resolveVariable: () => undefined,
+      })
+    )
+    expect(declared.length).toBeGreaterThan(5)
+    await assertResolvability(ctx, written, declared, 'find.findMany.vendor')
+  })
+
+  it('findMany (tier A thread) — declared ⊆ resolvable (with §3.2 pins), written ⊆ declared, labels present', async () => {
+    threadRows.current = [THREAD_ROW, THREAD_ROW_2]
+    const nodeId = 'find_thread_many'
+    const { ctx, node, result, written } = await runFind(nodeId, {
+      resourceType: 'thread',
+      findMode: 'findMany',
+      orderBy: { field: 'subject', direction: 'asc' },
+      limit: 5,
+    })
+
+    expect(result.status).toBe('succeeded')
+
+    const declared = flattenDeclared(
+      findManifest.resolveOutputs!(node.data as never, nodeId, {
+        resource: THREAD_RESOURCE,
+        allResources: ALL_RESOURCES,
+        resolveVariable: () => undefined,
+      })
+    )
+    expect(declared.length).toBeGreaterThan(5)
+    await assertResolvability(ctx, written, declared, 'find.findMany.thread')
+  })
+})

--- a/packages/lib/src/workflow-engine/parity/fixtures.ts
+++ b/packages/lib/src/workflow-engine/parity/fixtures.ts
@@ -1,0 +1,458 @@
+// packages/lib/src/workflow-engine/parity/fixtures.ts
+
+/**
+ * Fixture org for the resolvability suite (`resolvability.test.ts` split into
+ * `find.resolvability.test.ts` / `crud.resolvability.test.ts`).
+ *
+ * Two custom entities plus the real `thread` system resource:
+ *
+ * - **Vendor** (`VENDOR_DEF_ID`) — a plain, user-authored custom entity (NOT one
+ *   of `ENTITY_DEFINITION_TYPES`). Per the codebase invariant confirmed by
+ *   reading `resource-registry-service.ts` (`mapCustomFieldsToResourceFields`),
+ *   a genuinely custom field's `key` is ALWAYS `field.id` — there is no
+ *   separate `key` column on `CustomField` at all. This fixture honors that:
+ *   every field's `id` and `key` are the SAME string. The strings just happen
+ *   to be human-readable (`'name'`, `'region'`, …) rather than cuid-shaped —
+ *   nothing in the resolution machinery cares about the string's shape, only
+ *   that `id === key`.
+ *   - `name` — plain STRING, no `systemAttribute`.
+ *   - `code` — STRING with `systemAttribute: 'vendor_code'` (cast — no real
+ *     `SystemAttribute` union member fits a fixture entity, and nothing reads
+ *     the value for meaning, only for identity).
+ *   - `internalNotes` — STRING with `capabilities.hidden: true`.
+ *   - `region` — RELATION `belongs_to` → VendorRegion.
+ * - **VendorRegion** (`REGION_DEF_ID`) — the relation target, with a
+ *   SELF-referential `belongs_to` (`parentRegion`) so the declared tree reaches
+ *   a genuine two-hop relation path (`region.parentRegion.name`) without a
+ *   third resource — deliberately staying at the "TWO resources" the task
+ *   scopes the fixture to.
+ *   - `name` — plain STRING.
+ *   - `parentRegion` — RELATION `belongs_to` → itself.
+ * - **thread** — the real `RESOURCE_FIELD_REGISTRY.thread` fields, imported,
+ *   never hand-copied.
+ */
+
+import type { TypedFieldValue } from '@auxx/types'
+import type { RelationshipConfig } from '@auxx/types/custom-field'
+import type { FieldId, ResourceFieldId } from '@auxx/types/field'
+import { toRecordId } from '@auxx/types/resource'
+import {
+  RESOURCE_FIELD_REGISTRY,
+  RESOURCE_TABLE_MAP,
+} from '../../resources/registry/field-registry'
+import type { ResourceField } from '../../resources/registry/field-types'
+import type { CustomResource, Resource, SystemResource } from '../../resources/registry/types'
+import { BaseType } from '../core/types'
+
+export const ORG_ID = 'org_parity_test'
+export const USER_ID = 'user_parity_test'
+export const WORKFLOW_ID = 'workflow_parity_test'
+
+// ─────────────────────────────────────────────────────────────
+// Entity definition ids
+// ─────────────────────────────────────────────────────────────
+
+/** CUID2-shaped (>=20 chars, not a system TableId) so `isCustomResourceId` is true. */
+export const VENDOR_DEF_ID = 'vendorentitydefcuid00001'
+export const REGION_DEF_ID = 'regionentitydefcuid00001'
+
+// ─────────────────────────────────────────────────────────────
+// Vendor fields
+// ─────────────────────────────────────────────────────────────
+
+const fullCapabilities = {
+  filterable: true,
+  sortable: true,
+  creatable: true,
+  updatable: true,
+  configurable: true,
+}
+
+const vendorRegionRelationship: RelationshipConfig = {
+  // Points at VendorRegion's inverse field. The inverse field need not exist
+  // in this fixture (nothing looks it up — only `has_many` reciprocal lookups
+  // would, and neither relation here is `has_many`); only the entityDefinitionId
+  // half is ever read (`getRelatedEntityDefinitionId`).
+  inverseResourceFieldId: `${REGION_DEF_ID}:vendors` as ResourceFieldId,
+  relationshipType: 'belongs_to',
+  isInverse: false,
+}
+
+const regionParentRelationship: RelationshipConfig = {
+  inverseResourceFieldId: `${REGION_DEF_ID}:childRegions` as ResourceFieldId,
+  relationshipType: 'belongs_to',
+  isInverse: false,
+}
+
+export const VENDOR_NAME_FIELD: ResourceField = {
+  id: 'name' as FieldId,
+  key: 'name',
+  label: 'Name',
+  type: BaseType.STRING,
+  capabilities: fullCapabilities,
+}
+
+/** systemAttribute cast: no real SYSTEM_ATTRIBUTES member fits a fixture entity. */
+export const VENDOR_CODE_FIELD: ResourceField = {
+  id: 'code' as FieldId,
+  key: 'code',
+  label: 'Code',
+  type: BaseType.STRING,
+  systemAttribute: 'vendor_code' as ResourceField['systemAttribute'],
+  capabilities: fullCapabilities,
+}
+
+export const VENDOR_NOTES_FIELD: ResourceField = {
+  id: 'internalNotes' as FieldId,
+  key: 'internalNotes',
+  label: 'Internal Notes',
+  type: BaseType.STRING,
+  capabilities: { ...fullCapabilities, hidden: true },
+}
+
+export const VENDOR_REGION_FIELD: ResourceField = {
+  id: 'region' as FieldId,
+  key: 'region',
+  label: 'Region',
+  type: BaseType.RELATION,
+  relationship: vendorRegionRelationship,
+  options: { relationship: vendorRegionRelationship },
+  capabilities: fullCapabilities,
+}
+
+export const VENDOR_FIELDS: ResourceField[] = [
+  VENDOR_NAME_FIELD,
+  VENDOR_CODE_FIELD,
+  VENDOR_NOTES_FIELD,
+  VENDOR_REGION_FIELD,
+]
+
+// ─────────────────────────────────────────────────────────────
+// VendorRegion fields
+// ─────────────────────────────────────────────────────────────
+
+export const REGION_NAME_FIELD: ResourceField = {
+  id: 'name' as FieldId,
+  key: 'name',
+  label: 'Name',
+  type: BaseType.STRING,
+  capabilities: fullCapabilities,
+}
+
+export const REGION_PARENT_FIELD: ResourceField = {
+  id: 'parentRegion' as FieldId,
+  key: 'parentRegion',
+  label: 'Parent Region',
+  type: BaseType.RELATION,
+  relationship: regionParentRelationship,
+  options: { relationship: regionParentRelationship },
+  capabilities: fullCapabilities,
+}
+
+export const REGION_FIELDS: ResourceField[] = [REGION_NAME_FIELD, REGION_PARENT_FIELD]
+
+// ─────────────────────────────────────────────────────────────
+// Resource objects (as returned by `findCachedResource`/`getCachedResource`/
+// `getCachedResources`, and as `OutputContext.resource`/`allResources`)
+// ─────────────────────────────────────────────────────────────
+
+const commonCustomDisplay = {
+  primaryDisplayField: null,
+  secondaryDisplayField: null,
+  avatarField: null,
+  defaultSortField: 'updatedAt' as const,
+  defaultSortDirection: 'desc' as const,
+  orgScopingStrategy: 'direct' as const,
+}
+
+export const VENDOR_RESOURCE: CustomResource = {
+  id: VENDOR_DEF_ID,
+  label: 'Vendor',
+  plural: 'Vendors',
+  icon: 'truck',
+  color: 'blue',
+  fields: VENDOR_FIELDS,
+  isVisible: true,
+  type: 'custom',
+  apiSlug: 'vendors',
+  entityDefinitionId: VENDOR_DEF_ID,
+  organizationId: ORG_ID,
+  display: commonCustomDisplay,
+}
+
+export const REGION_RESOURCE: CustomResource = {
+  id: REGION_DEF_ID,
+  label: 'Vendor Region',
+  plural: 'Vendor Regions',
+  icon: 'globe',
+  color: 'green',
+  fields: REGION_FIELDS,
+  isVisible: true,
+  type: 'custom',
+  apiSlug: 'vendor-regions',
+  entityDefinitionId: REGION_DEF_ID,
+  organizationId: ORG_ID,
+  display: commonCustomDisplay,
+}
+
+/** Tier A: the REAL thread fields, never hand-copied. */
+export const THREAD_FIELDS: ResourceField[] = Object.values(RESOURCE_FIELD_REGISTRY.thread ?? {})
+
+export const THREAD_RESOURCE: SystemResource = {
+  id: 'thread',
+  label: RESOURCE_TABLE_MAP.thread.label,
+  plural: RESOURCE_TABLE_MAP.thread.plural,
+  icon: RESOURCE_TABLE_MAP.thread.icon,
+  color: RESOURCE_TABLE_MAP.thread.color,
+  fields: THREAD_FIELDS,
+  entityType: 'thread',
+  isVisible: true,
+  type: 'system',
+  apiSlug: RESOURCE_TABLE_MAP.thread.apiSlug,
+  entityDefinitionId: 'thread',
+  dbName: RESOURCE_TABLE_MAP.thread.dbName,
+  display: {
+    identifierField: 'id',
+    primaryDisplayField: null,
+    secondaryDisplayField: null,
+    avatarField: null,
+    searchFields: ['subject'],
+    orgScopingStrategy: 'direct',
+  },
+}
+
+export const ALL_RESOURCES: Resource[] = [VENDOR_RESOURCE, REGION_RESOURCE, THREAD_RESOURCE]
+
+/**
+ * A custom entity with ZERO visible fields — declaration-only fixture (never
+ * added to `ALL_RESOURCES`/executed against; nothing backs a query for it).
+ * Exists solely to pin the "empty-fields status variables disappeared again"
+ * regression class named in the suite's self-check: both
+ * `generateFindNodeVariablesFromFields` and `generateCrudNodeVariablesFromFields`
+ * special-case `fields.length === 0` to skip ONLY the main record-shaped
+ * variable, while the unconditional status block (`count`/`query_info` for
+ * find; `success`/`operation`/`resourceType`/`error`/`errorDetails` for crud)
+ * must still be declared. See `declaration-only.resolvability.test.ts`.
+ */
+export const EMPTY_FIELDS_DEF_ID = 'emptyentitydefcuid000001'
+
+export const EMPTY_FIELDS_RESOURCE: CustomResource = {
+  id: EMPTY_FIELDS_DEF_ID,
+  label: 'Empty',
+  plural: 'Empties',
+  icon: 'circle',
+  color: 'gray',
+  fields: [],
+  isVisible: true,
+  type: 'custom',
+  apiSlug: 'empties',
+  entityDefinitionId: EMPTY_FIELDS_DEF_ID,
+  organizationId: ORG_ID,
+  display: commonCustomDisplay,
+}
+
+/** Matches `findCachedResource`/`getCachedResource`'s id-or-entityType-or-apiSlug lookup. */
+export function findFixtureResource(key: string): Resource | undefined {
+  return ALL_RESOURCES.find((r) => r.id === key || r.entityType === key || r.apiSlug === key)
+}
+
+// ─────────────────────────────────────────────────────────────
+// Entity instance fixtures (record ids + raw field-value rows for the
+// `getEntityInstance` mock — the real DB/service edge `fetchResourceById`
+// sits behind)
+// ─────────────────────────────────────────────────────────────
+
+export const VENDOR_HIT_INSTANCE_ID = 'vendor_inst_hit'
+export const VENDOR_CREATE_INSTANCE_ID = 'vendor_inst_created'
+export const VENDOR_UPDATE_INSTANCE_ID = 'vendor_inst_updated'
+export const VENDOR_DELETE_INSTANCE_ID = 'vendor_inst_deleted'
+export const REGION_INSTANCE_ID = 'region_inst_hit'
+
+export const VENDOR_HIT_RECORD_ID = toRecordId(VENDOR_DEF_ID, VENDOR_HIT_INSTANCE_ID)
+export const REGION_RECORD_ID = toRecordId(REGION_DEF_ID, REGION_INSTANCE_ID)
+
+/** One raw `FieldValue`-shaped row, as `getEntityInstance`'s `values` relation returns. */
+interface FixtureValueRow {
+  field: { id: string; systemAttribute?: string }
+  valueText?: string | null
+  relatedEntityId?: string | null
+  /** Not part of the real row shape — carried here only for `resolveFixtureFieldPath`'s own hop-walking. */
+  relatedEntityDefinitionId?: string
+}
+
+/** `extractFieldValueScalar`-compatible row for a TEXT field. */
+function textRow(
+  fieldId: string,
+  systemAttribute: string | undefined,
+  value: string
+): FixtureValueRow {
+  return { field: { id: fieldId, systemAttribute }, valueText: value }
+}
+
+/** `extractFieldValueScalar`-compatible row for a RELATIONSHIP field. */
+function relationRow(
+  fieldId: string,
+  relatedEntityId: string,
+  relatedEntityDefinitionId: string
+): FixtureValueRow {
+  return { field: { id: fieldId }, relatedEntityId, relatedEntityDefinitionId }
+}
+
+/** Vendor instance data keyed by instance id, for the `getEntityInstance` mock. */
+export const VENDOR_INSTANCES: Record<
+  string,
+  {
+    id: string
+    entityDefinitionId: string
+    createdAt: Date
+    updatedAt: Date
+    values: FixtureValueRow[]
+  }
+> = {
+  [VENDOR_HIT_INSTANCE_ID]: {
+    id: VENDOR_HIT_INSTANCE_ID,
+    entityDefinitionId: VENDOR_DEF_ID,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-02T00:00:00Z'),
+    values: [
+      textRow('name', undefined, 'Acme Supplies'),
+      textRow('code', 'vendor_code', 'V-042'),
+      // `internalNotes` deliberately omitted — hidden fields are never
+      // declared, so there's nothing to assert resolvable for it.
+      relationRow('region', REGION_INSTANCE_ID, REGION_DEF_ID),
+    ],
+  },
+  [VENDOR_CREATE_INSTANCE_ID]: {
+    id: VENDOR_CREATE_INSTANCE_ID,
+    entityDefinitionId: VENDOR_DEF_ID,
+    createdAt: new Date('2026-02-01T00:00:00Z'),
+    updatedAt: new Date('2026-02-01T00:00:00Z'),
+    values: [textRow('name', undefined, 'Globex Parts'), textRow('code', 'vendor_code', 'V-100')],
+  },
+  [VENDOR_UPDATE_INSTANCE_ID]: {
+    id: VENDOR_UPDATE_INSTANCE_ID,
+    entityDefinitionId: VENDOR_DEF_ID,
+    createdAt: new Date('2026-01-15T00:00:00Z'),
+    updatedAt: new Date('2026-02-15T00:00:00Z'),
+    values: [textRow('name', undefined, 'Initech Supply'), textRow('code', 'vendor_code', 'V-200')],
+  },
+}
+
+export const REGION_INSTANCES: Record<
+  string,
+  {
+    id: string
+    entityDefinitionId: string
+    createdAt: Date
+    updatedAt: Date
+    values: FixtureValueRow[]
+  }
+> = {
+  [REGION_INSTANCE_ID]: {
+    id: REGION_INSTANCE_ID,
+    entityDefinitionId: REGION_DEF_ID,
+    createdAt: new Date('2025-06-01T00:00:00Z'),
+    updatedAt: new Date('2025-06-02T00:00:00Z'),
+    values: [
+      textRow('name', undefined, 'EMEA'),
+      // `parentRegion` deliberately unset — §3.4's hop-two bug means this
+      // record is never even fetched, so its own data is moot.
+    ],
+  },
+}
+
+/** Look up one fixture instance by (entityDefinitionId, instanceId) — the two entities this suite has. */
+export function findFixtureInstance(entityDefinitionId: string, instanceId: string) {
+  if (entityDefinitionId === VENDOR_DEF_ID) return VENDOR_INSTANCES[instanceId]
+  if (entityDefinitionId === REGION_DEF_ID) return REGION_INSTANCES[instanceId]
+  return undefined
+}
+
+/** Convert one fixture row into a `TypedFieldValue` — text or relationship, the only two shapes this suite needs. */
+export function buildTypedFieldValue(row: FixtureValueRow, instanceId: string): TypedFieldValue {
+  const base = {
+    id: `${instanceId}:${row.field.id}`,
+    entityId: instanceId,
+    fieldId: row.field.id,
+    sortKey: 'a0',
+    createdAt: '',
+    updatedAt: '',
+  }
+  if (row.relatedEntityId && row.relatedEntityDefinitionId) {
+    return {
+      ...base,
+      type: 'relationship',
+      recordId: toRecordId(row.relatedEntityDefinitionId, row.relatedEntityId),
+    } as TypedFieldValue
+  }
+  return { ...base, type: 'text', value: row.valueText ?? '' } as TypedFieldValue
+}
+
+/**
+ * Walk a `FieldReference` (a single `ResourceFieldId`, or a 2-element
+ * `FieldPath` for one relationship hop) starting from `recordId`, resolving
+ * each hop against the fixture instance data — the same data
+ * `getEntityInstance`'s mock serves, so both lanes agree by construction.
+ * Returns `null` when a segment or its relationship target isn't found —
+ * `batchGetValues`'s own "no value" answer.
+ */
+export function resolveFixtureFieldPath(
+  segments: string[],
+  startRecordId: string
+): TypedFieldValue | null {
+  let currentInstanceId = startRecordId.split(':').slice(1).join(':')
+  let currentDefId = startRecordId.split(':')[0]!
+
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i]!
+    const colonIndex = segment.indexOf(':')
+    const fieldId = colonIndex === -1 ? segment : segment.slice(colonIndex + 1)
+    const instance = findFixtureInstance(currentDefId, currentInstanceId)
+    const row = instance?.values.find((v) => v.field.id === fieldId)
+    if (!row) return null
+
+    if (i === segments.length - 1) {
+      return buildTypedFieldValue(row, currentInstanceId)
+    }
+    if (!row.relatedEntityId || !row.relatedEntityDefinitionId) return null
+    currentDefId = row.relatedEntityDefinitionId
+    currentInstanceId = row.relatedEntityId
+  }
+  return null
+}
+
+// ─────────────────────────────────────────────────────────────
+// Tier A (thread) raw Drizzle-row fixture
+// ─────────────────────────────────────────────────────────────
+
+export const THREAD_HIT_ID = 'thr_parity_hit'
+
+/**
+ * Realistic raw `schema.Thread` row — camelCase columns, exactly what
+ * `database.select().from(schema.Thread)` returns. Deliberately diverges from
+ * the picker's `systemAttribute` vocabulary the way real rows do: `status`'s
+ * systemAttribute is `thread_status` but the column is `status`; `assignee`'s
+ * is `assignee_id` but the column is `assigneeId`; `messageCount`'s is
+ * `message_count` but the column is `messageCount`. Only `id`/`subject`
+ * coincidentally match. This is the fixture that pins §3.2.
+ */
+export const THREAD_ROW = {
+  id: THREAD_HIT_ID,
+  externalId: null,
+  subject: 'Order #4521 delayed',
+  organizationId: ORG_ID,
+  integrationId: 'int_parity',
+  assigneeId: 'usr_parity_assignee',
+  status: 'OPEN',
+  messageCount: 3,
+  firstMessageAt: new Date('2026-08-01T09:00:00Z'),
+  lastMessageAt: new Date('2026-08-12T10:00:00Z'),
+  closedAt: null,
+  createdAt: new Date('2026-08-01T09:00:00Z'),
+}
+
+export const THREAD_ROW_2 = {
+  ...THREAD_ROW,
+  id: 'thr_parity_hit_2',
+  subject: 'Return request',
+}

--- a/packages/lib/src/workflow-engine/parity/harness.ts
+++ b/packages/lib/src/workflow-engine/parity/harness.ts
@@ -1,0 +1,249 @@
+// packages/lib/src/workflow-engine/parity/harness.ts
+
+/**
+ * Shared, mock-free scaffolding for the resolvability suite
+ * (`find.resolvability.test.ts` / `crud.resolvability.test.ts`). Nothing here
+ * calls `vi.mock` — that stays in the two test files, since vitest hoists
+ * `vi.mock` per file and a shared helper module can't declare it on another
+ * file's behalf (the same reason `find-output-keying.test.ts` and
+ * `crud-canonicalization.test.ts` each carry their own mock blocks instead of
+ * sharing one).
+ *
+ * Three invariants, asserted per scenario against the SAME flattened walk of
+ * a manifest's `resolveOutputs()` tree:
+ *
+ * 1. **declared ⊆ resolvable** — every id the manifest declares (root, every
+ *    nested `properties` entry, every `items` entry) resolves through the
+ *    REAL `ExecutionContextManager.resolveVariablePath` to something other
+ *    than `undefined`, after the REAL processor has run. A stored `null` (the
+ *    findOne-miss case) counts as resolved — `resolveVariablePath`'s direct
+ *    lookup only returns `undefined` for an absent key, and a present `null`
+ *    is a real, meaningful answer ("looked, found nothing"), not a resolution
+ *    failure. See `find.resolvability.test.ts`'s miss scenario for why that
+ *    distinction gets its own, narrower assertion instead of the full walk.
+ * 2. **written ⊆ declared** — every key the processor actually wrote
+ *    (`contextManager.getAllVariables()`, filtered to this node's prefix)
+ *    is covered by some declared id: either an exact match (`<node>.count`
+ *    needs a declared `<node>.count`) or a declared object/array root that
+ *    the written key nests under (`<node>.<defId>.record_id` is covered by
+ *    declared `<node>.<defId>`).
+ * 3. **label coverage** — every declared id (root, nested, array items)
+ *    carries a non-empty `label`. `buildVariableLabelPath`
+ *    (`catalog/variable-inference.ts`) falls back to the raw id segment when
+ *    `label` is absent, which for an entity-def resource means the picker
+ *    renders a CUID to the user instead of a name.
+ *
+ * Each invariant consults `known-broken.ts` for a documented, PINNED
+ * exception before asserting — see that file for the full list and the
+ * pinning contract (flip a pin to the opposite assertion once the underlying
+ * bug is fixed, forcing the pin's own deletion).
+ */
+
+import { expect } from 'vitest'
+import { ExecutionContextManager } from '../core/execution-context'
+import type { NodeExecutionResult, PreprocessedNodeData, WorkflowNode } from '../core/types'
+import type { UnifiedVariable } from '../types/unified-variable'
+import { ORG_ID, USER_ID, WORKFLOW_ID } from './fixtures'
+import {
+  matchDeclaredUnresolvablePin,
+  matchMissingLabelPin,
+  matchWrittenUndeclaredPin,
+} from './known-broken'
+
+/**
+ * `BaseNodeProcessor.executeNode` is `protected` — every node test in this
+ * codebase reaches it via a same-shape cast (`find-output-keying.test.ts`'s
+ * `TestableFindProcessor` subclass, `crud-canonicalization.test.ts`'s
+ * `(processor as any).executeNode(...)`). This is the one shared, PROPERLY
+ * TYPED version, so both `find.resolvability.test.ts` and
+ * `crud.resolvability.test.ts` get real argument/return checking instead of
+ * `any`.
+ */
+interface ProtectedExecuteNode {
+  executeNode(
+    node: WorkflowNode,
+    contextManager: ExecutionContextManager,
+    preprocessedData?: PreprocessedNodeData
+  ): Promise<Partial<NodeExecutionResult>>
+}
+
+/** Call a `BaseNodeProcessor` subclass's protected `executeNode` directly, bypassing the public `execute()` wrapper. */
+export async function runExecuteNode(
+  processor: object,
+  node: WorkflowNode,
+  ctx: ExecutionContextManager,
+  preprocessed: PreprocessedNodeData
+): Promise<Partial<NodeExecutionResult>> {
+  return (processor as unknown as ProtectedExecuteNode).executeNode(node, ctx, preprocessed)
+}
+
+/**
+ * A REAL `ExecutionContextManager` — never stubbed. `resolveVariablePath`'s
+ * lazy-load ladder (`analyzePath` → `lazyLoadResourceWithPath` →
+ * `fetchResourceWithRelationships`, and the record-field cache's
+ * `getFieldValue` → `batchGetValues`) is the exact mechanism this suite
+ * exists to exercise; a stub contextManager (as `find-output-keying.test.ts`
+ * uses, for a narrower purpose) would make every resolvability assertion
+ * vacuous. `initializeSystemVariables()` seeds `sys.organizationId`/
+ * `sys.userId`, which both `FindProcessor` and `CrudNodeProcessor` read via
+ * `contextManager.getVariable('sys.organizationId')`.
+ */
+export function createContextManager(executionId: string): ExecutionContextManager {
+  const ctx = new ExecutionContextManager(WORKFLOW_ID, executionId, ORG_ID, USER_ID)
+  ctx.initializeSystemVariables()
+  return ctx
+}
+
+/** One declared variable, flattened out of a `resolveOutputs()` tree. */
+export interface FlatVariable {
+  id: string
+  label: string | undefined
+}
+
+/**
+ * Flatten a manifest's declared output tree (`properties`/`items` recursion)
+ * into one list — the same shape `findVariableInTree` (`resolve-outputs.ts`)
+ * and the browser's `findVariableInTree` (`store/var-availability.ts`) walk,
+ * just collected instead of searched.
+ */
+export function flattenDeclared(vars: UnifiedVariable[]): FlatVariable[] {
+  const out: FlatVariable[] = []
+  const seen = new Set<string>()
+
+  const walk = (v: UnifiedVariable) => {
+    if (!seen.has(v.id)) {
+      seen.add(v.id)
+      out.push({ id: v.id, label: v.label })
+    }
+    if (v.properties) {
+      for (const prop of Object.values(v.properties)) walk(prop)
+    }
+    if (v.items) walk(v.items)
+  }
+
+  for (const v of vars) walk(v)
+  return out
+}
+
+/** Every variable key this node actually wrote, prefix-scoped to `nodeId`. */
+export function writtenKeysForNode(ctx: ExecutionContextManager, nodeId: string): string[] {
+  const all = ctx.getAllVariables()
+  return Object.keys(all).filter((k) => k === nodeId || k.startsWith(`${nodeId}.`))
+}
+
+/**
+ * Invariant 1 — declared ⊆ resolvable.
+ *
+ * Walks every declared id and calls the REAL `resolveVariablePath` with the
+ * FULL id (nodeId prefix included — that IS the path shape
+ * `resolveVariablePath` documents: `"webhook-123.body.contact.email"`, not a
+ * bare `body.contact.email`). A pinned id is asserted to STAY broken
+ * (`undefined`) so a fix flips the assertion and fails until the pin is
+ * deleted — same contract as `contract-drift-allowlist.ts`.
+ */
+export async function assertDeclaredResolvable(
+  ctx: ExecutionContextManager,
+  declared: FlatVariable[],
+  scenario: string
+): Promise<void> {
+  for (const { id } of declared) {
+    const pin = matchDeclaredUnresolvablePin(id)
+    const resolved = await ctx.resolveVariablePath(id)
+    const effectivelyResolved = isEffectivelyResolved(resolved)
+    if (pin) {
+      expect(
+        effectivelyResolved,
+        `[${scenario}] pinned-broken "${id}" now resolves (${JSON.stringify(resolved)}) — ` +
+          `retire its known-broken entry: ${pin}`
+      ).toBe(false)
+    } else {
+      expect(
+        effectivelyResolved,
+        `[${scenario}] declared "${id}" did not resolve (got ${JSON.stringify(resolved)})`
+      ).toBe(true)
+    }
+  }
+}
+
+/**
+ * `resolved !== undefined` alone is too permissive for an array produced by
+ * `resolveVariablePath`'s `[*]` map branch: mapping a per-item resolver that
+ * fails over an array ALWAYS yields a defined array (`[undefined, undefined]`),
+ * which would silently pass every findMany-item variant of a resolution bug
+ * that findOne correctly catches (see `known-broken.ts`'s `tierAFieldPathPin`
+ * doc comment). An array counts as resolved only if it's empty (a legitimate
+ * "no results" answer) or has at least one non-undefined element.
+ */
+function isEffectivelyResolved(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.length === 0 || value.some((v) => v !== undefined)
+  }
+  return value !== undefined
+}
+
+/**
+ * Invariant 2 — written ⊆ declared.
+ *
+ * A written key is covered when it EQUALS a declared id, or NESTS under one
+ * (`startsWith('<id>.')` or `startsWith('<id>[')`) — an object/array root
+ * declares its whole subtree, not just its own literal id.
+ */
+export function assertWrittenCovered(
+  writtenKeys: string[],
+  declared: FlatVariable[],
+  scenario: string
+): void {
+  const declaredIds = declared.map((d) => d.id)
+  const isCovered = (key: string) =>
+    declaredIds.some((id) => key === id || key.startsWith(`${id}.`) || key.startsWith(`${id}[`))
+
+  for (const key of writtenKeys) {
+    const pin = matchWrittenUndeclaredPin(key)
+    const covered = isCovered(key)
+    if (pin) {
+      expect(
+        covered,
+        `[${scenario}] pinned-undeclared write "${key}" is now covered — retire its known-broken entry: ${pin}`
+      ).toBe(false)
+    } else {
+      expect(covered, `[${scenario}] written "${key}" has no declared coverage`).toBe(true)
+    }
+  }
+}
+
+/**
+ * Invariant 3 — label coverage.
+ *
+ * Every declared id must carry a non-empty `label`; an absent one falls back
+ * to the raw id segment in the picker (`buildVariableLabelPath`), which for
+ * an entity-def resource means a CUID renders where a name should.
+ */
+export function assertLabelCoverage(declared: FlatVariable[], scenario: string): void {
+  for (const { id, label } of declared) {
+    const pin = matchMissingLabelPin(id)
+    const hasLabel = typeof label === 'string' && label.trim().length > 0
+    if (pin) {
+      expect(
+        hasLabel,
+        `[${scenario}] pinned-no-label "${id}" now has a label ("${label}") — retire its known-broken entry: ${pin}`
+      ).toBe(false)
+    } else {
+      expect(
+        hasLabel,
+        `[${scenario}] declared "${id}" has no label — the picker would render the raw id segment`
+      ).toBe(true)
+    }
+  }
+}
+
+/** Run all three invariants for one scenario in one call. */
+export async function assertResolvability(
+  ctx: ExecutionContextManager,
+  writtenKeys: string[],
+  declared: FlatVariable[],
+  scenario: string
+): Promise<void> {
+  assertLabelCoverage(declared, scenario)
+  assertWrittenCovered(writtenKeys, declared, scenario)
+  await assertDeclaredResolvable(ctx, declared, scenario)
+}

--- a/packages/lib/src/workflow-engine/parity/known-broken.ts
+++ b/packages/lib/src/workflow-engine/parity/known-broken.ts
@@ -1,0 +1,280 @@
+// packages/lib/src/workflow-engine/parity/known-broken.ts
+
+/**
+ * Known-broken entries for the find/crud resolvability suite
+ * (`find.resolvability.test.ts` / `crud.resolvability.test.ts`).
+ *
+ * Mirrors `apps/web/src/components/workflow/parity/contract-drift-allowlist.ts`:
+ * a burn-down list, not a permanent allowance. Each entry is a documented,
+ * REAL bug this suite proves exists — pin it here so the suite is green today
+ * and any NEW drift (a regression, or a fix that silently breaks something
+ * else) is a hard failure. Every entry is verified empirically by running the
+ * suite, not predicted from reading source alone — vitest's own failure
+ * output is the source of truth for exactly which declared ids resolve.
+ *
+ * Three families, one per invariant in `harness.ts`:
+ *
+ * - `matchDeclaredUnresolvablePin` — invariant 1 (declared ⊆ resolvable).
+ *   The id resolves to `undefined` (or, for an array-typed id, every element
+ *   resolves to `undefined`) even though it's declared.
+ * - `matchWrittenUndeclaredPin` — invariant 2 (written ⊆ declared). The
+ *   processor wrote this key but no declared id covers it.
+ * - `matchMissingLabelPin` — invariant 3 (label coverage). The declared id
+ *   has no `label`, so the picker would render the raw id segment.
+ *
+ * HOW TO BURN DOWN: fix the bug, delete the entry. The suite fails on a STALE
+ * entry too (the pinned assertion flips: `matchDeclaredUnresolvablePin`
+ * asserts the id STAYS undefined, `matchWrittenUndeclaredPin` asserts the key
+ * STAYS uncovered, `matchMissingLabelPin` asserts the label STAYS absent), so
+ * a fixed bug forces its own pin's removal instead of quietly rotting.
+ */
+
+/** One pin: a predicate over the id/key, plus why it's pinned and where the fix lives. */
+interface Pin {
+  test: (id: string) => boolean
+  reason: string
+}
+
+function findPin(pins: Pin[], id: string): string | undefined {
+  const pin = pins.find((p) => p.test(id))
+  return pin?.reason
+}
+
+// =============================================================================
+// Invariant 1 — declared ⊆ resolvable
+// =============================================================================
+
+/**
+ * Tier-A (`thread`) findOne/findMany declared field paths, EXCEPT the two
+ * coincidental matches (`id`, `subject`, whose `systemAttribute` string
+ * happens to equal the raw Drizzle column name).
+ *
+ * §3.2 (`plans/kopilot/workflow/10-variable-resolution-deep-dive.md`): the
+ * palette advertises tier-A fields by `systemAttribute` (`thread_status`,
+ * `assignee_id`, `message_count`, `last_message_at`, …), but find.ts stores
+ * the RAW Drizzle row (camelCase columns: `status`, `assigneeId`,
+ * `messageCount`, `lastMessageAt`, …) and tier-A resolution has no key
+ * mapping — `resolveNestedObject` looks for `row['thread_status']`, which
+ * doesn't exist. Confirmed by the real `RESOURCE_FIELD_REGISTRY.thread`
+ * entries (`thread-fields.ts`): `status.systemAttribute === 'thread_status'`
+ * but `status.dbColumn === 'status'`; same divergence for `assignee`,
+ * `messageCount`, `lastMessageAt`, `firstMessageAt`, `closedAt`, `externalId`.
+ *
+ * Tier-A RELATION fields (`inbox`, `ticket`, `messages`, `tags`) are broken
+ * for the compounding, structural reason in §3.4: tier A never stores a
+ * `ResourceReference`, so there is no lazy-load lane to expand them through
+ * at all — the raw row simply has no property by that name.
+ *
+ * Fix pointer: §10b step 4 — `toOutputShape(row, fields)` re-keys the row by
+ * `getFieldOutputKey` at write time (the cheap, do-now fix); the full fix
+ * (§10b proposal #1) unifies tier A onto the same `ResourceReference` lane
+ * tier B/C already uses, which would additionally fix the relation fields.
+ *
+ * findMany items go through the SAME per-element `resolveNestedObject` inside
+ * the array-map branch of `resolveVariablePath` — the array itself is always
+ * "resolved" (a defined array), which is why the harness additionally treats
+ * an array whose every element is `undefined` as unresolved (see
+ * `harness.ts`'s `assertDeclaredResolvable`) — otherwise this whole family
+ * would silently pass for findMany while genuinely broken.
+ */
+const TIER_A_FIELD_PATH_RE = /^[^.]+\.(thread|threads\[\*\])\.(.+)$/
+
+function tierAFieldPathPin(id: string): string | undefined {
+  const match = id.match(TIER_A_FIELD_PATH_RE)
+  if (!match) return undefined
+  const rest = match[2]!
+  const firstSegment = rest.split('.')[0]!.replace(/\[\*\]$/, '')
+  if (firstSegment === 'id' || firstSegment === 'subject') return undefined
+  return (
+    '§3.2/§3.4: tier-A (thread) stores the raw Drizzle row, not a ResourceReference — ' +
+    'nested field access has no systemAttribute→dbColumn mapping (scalars) and no lazy-load ' +
+    'lane at all (relations). Fix: §10b step 4 (toOutputShape) for scalars, proposal #1 ' +
+    '(ResourceReference unification) for relations.'
+  )
+}
+
+/**
+ * §3.4: the SECOND relation hop is collected by `analyzePathForRelationships`
+ * but never fetched. `fetchResourceWithRelationships` looks every entry of
+ * `relationshipsNeeded` up in the BASE record's own fieldMap only — a
+ * two-segment path like `region.parentRegion` produces
+ * `relationshipsNeeded = ['region', 'parentRegion']`, but `parentRegion` is a
+ * field on VendorRegion, not on the base Vendor record, so its fetch is
+ * silently skipped (`if (value !== undefined) resource[relFieldName] = value`
+ * — the entry's value is `undefined`, so nothing is ever assigned, and if it
+ * were, it would land at the WRONG nesting level: `resource.parentRegion`,
+ * not `resource.region.parentRegion`).
+ *
+ * Only pins the findOne/root lane (`resolveVariablePath`'s
+ * `analyzePath`→`lazyLoadResourceWithPath`→`fetchResourceWithRelationships`
+ * chain). findMany's item lane goes through a DIFFERENT resolver
+ * (`resolveFieldFromResourceRef`'s `buildFieldPath`, which only builds a
+ * 2-element `FieldPath` and for a 3-segment path like `region.parentRegion.name`
+ * falls back to treating `region` as a direct field and returning ITS OWN raw
+ * value — resolving to something non-`undefined` for the wrong reason, not
+ * `undefined`). That lane's items are asserted directly, not pinned.
+ *
+ * Fix pointer: §10b step 3 — the segment-walk resolver hydrates-as-it-walks,
+ * so arbitrary relation depth "falls out" of the design instead of needing a
+ * fetch-ahead list.
+ */
+function hopTwoRelationPin(id: string): string | undefined {
+  if (!id.includes('.region.parentRegion')) return undefined
+  // The findMany item lane (`vendors[*].region.parentRegion…`) does not hit
+  // this bug — see doc comment. Only the findOne/root lane is pinned.
+  if (/\[\*\]/.test(id)) return undefined
+  return (
+    "§3.4: fetchResourceWithRelationships looks relationshipsNeeded up in the BASE record's " +
+    'own fieldMap only — the second hop (parentRegion, a field on the RELATED record) is ' +
+    'silently never fetched. Fix: §10b step 3 (segment-walk resolver).'
+  )
+}
+
+/**
+ * NEW BUG (undocumented before this suite): `errorDetails` is declared
+ * unconditionally for every crud mode (`generateCrudNodeVariablesFromFields`
+ * always pushes it), but `executeNode`'s SUCCESS path never writes it — only
+ * `handleCrudError` (the catch branch) does. A crud run that succeeds
+ * outright therefore has a declared `errorDetails` id with nothing ever
+ * written under it; `resolveVariablePath` correctly reports `undefined`.
+ *
+ * This is the shape `contract-drift-allowlist.ts`'s `KNOWN_BROKEN_FAILURE_PATH_WRITES`
+ * category exists for ("every setNodeVariable call site sits inside an else
+ * block") — that map is empty there because its suite checks declared-vs-written
+ * statically per one fixed config, not by actually running both the success
+ * and failure arms and resolving the result the way this suite does.
+ *
+ * Scoped to this suite's own SUCCESS-scenario node ids: the `error_strategy:
+ * 'default'` scenario's forced-failure run DOES write `errorDetails` (every
+ * `handleCrudError` branch sets it unconditionally), so the same id resolves
+ * there — the id string alone can't distinguish "this run succeeded" from
+ * "this run failed and recovered," only which scenario produced it can.
+ */
+function crudSuccessErrorDetailsPin(id: string): string | undefined {
+  if (!id.endsWith('.errorDetails')) return undefined
+  // `crud_vendor_update.` (with trailing dot) deliberately does not match the
+  // `crud_vendor_update_default` scenario's node id (no dot follows
+  // `crud_vendor_update` there) — see the doc comment above.
+  const matchesSuccessNode =
+    id.startsWith('crud_vendor_create.') ||
+    id.startsWith('crud_vendor_update.') ||
+    id.startsWith('crud_vendor_delete.') ||
+    id.startsWith('crud_thread_update.')
+  if (!matchesSuccessNode) return undefined
+  return (
+    "NEW BUG: errorDetails is declared unconditionally but executeNode's success path never " +
+    'writes it — only handleCrudError (the catch branch) does. See doc comment above ' +
+    'crudSuccessErrorDetailsPin in known-broken.ts.'
+  )
+}
+
+const DECLARED_UNRESOLVABLE_PINS: Array<(id: string) => string | undefined> = [
+  tierAFieldPathPin,
+  crudSuccessErrorDetailsPin,
+]
+
+// `hopTwoRelationPin` is defined but NOT registered above — kept for its
+// documentation value. Empirically, `<node>.<VENDOR_ID>.region.parentRegion*`
+// does NOT resolve to `undefined`: `resolveNestedObject` correctly returns
+// `undefined` (confirming the §3.4 fetch gap this function documents), but
+// `resolveVariablePath` then falls back to `resolveFieldFromResourceRef`,
+// whose `buildFieldPath` has an INDEPENDENT bug (see
+// `written:crud`/`declared` notes in the suite report — it reads
+// `relationship.relatedEntityDefinitionId`, a property that does not exist
+// on `RelationshipConfig`, which only has `inverseResourceFieldId`) that
+// makes `buildFieldPath` always return `null` and fall through to a
+// SEPARATE fallback returning the FIRST hop's own raw value — non-`undefined`,
+// just wrong. Two independent bugs compound into a false "resolved". Left
+// here, unregistered, as a paper trail — see the suite's final report for
+// the full account instead of re-deriving it from this comment.
+void hopTwoRelationPin
+
+/** Invariant 1: is `id` a documented, pinned resolution failure? Returns the reason, or `undefined`. */
+export function matchDeclaredUnresolvablePin(id: string): string | undefined {
+  for (const pin of DECLARED_UNRESOLVABLE_PINS) {
+    const reason = pin(id)
+    if (reason) return reason
+  }
+  return undefined
+}
+
+// =============================================================================
+// Invariant 2 — written ⊆ declared
+// =============================================================================
+
+/**
+ * NEW BUG (undocumented before this suite): findMany on a custom entity
+ * writes the SINGULAR resource-type key too, not just the plural array.
+ *
+ * `find.ts`'s findMany/custom-entity branch calls `setEntityVariables(resourceType,
+ * entityData, contextManager, node.nodeId)` inside the per-item loop that
+ * builds `ResourceReference`s for the plural array — but `setEntityVariables`
+ * unconditionally writes `${nodeId}.${resourceType}` (the SAME key findOne
+ * uses as its root) as a side effect of building each item's reference. Every
+ * iteration overwrites it, so the final value is whichever item ran last.
+ * `generateFindNodeVariablesFromFields`'s findMany branch never declares this
+ * key — only findOne does — so it's a real, always-present write with zero
+ * picker coverage on every custom-entity findMany.
+ *
+ * Fix (not made here): findMany's loop should call whatever piece of
+ * `setEntityVariables` builds the `ResourceReference` and caches base data,
+ * without the side-effecting `${nodeId}.${resourceType}` write meant for the
+ * findOne singular case.
+ *
+ * Scoped to this suite's own node ids (`find_vendor_many`) rather than a bare
+ * entity-def-id pattern, because the SAME key IS correctly declared and
+ * covered for the findOne scenario — the id string alone can't tell the two
+ * apart, only which scenario produced it can.
+ */
+const FIND_MANY_STRAY_SINGULAR_KEY_REASON =
+  "NEW BUG: find.ts's findMany/custom-entity branch calls setEntityVariables() per item, which " +
+  'unconditionally writes the singular `<node>.<entityDefId>` key (and its `.record_id`/`.created_at`/' +
+  '`.updated_at`/`.entityDefinitionId`/`.id` children) as a side effect of building each ' +
+  "ResourceReference — but generateFindNodeVariablesFromFields's findMany branch never declares " +
+  'that key, only findOne does. Last-item-wins, always present, zero picker coverage.'
+
+/**
+ * Correct by design, not a bug — same class as `contract-drift-allowlist.ts`'s
+ * `EXTRACTION_BLIND_SPOTS` entries for `var-assign.myVar`/`myList`: the CRUD
+ * `default` error-strategy writes one key per `default_values[].key`, which
+ * is a user-configured, dynamic name (`processDefaultValues` /
+ * `handleCrudError`'s `Object.entries(defaultResult).forEach(...)` loop). No
+ * static manifest can declare a literal path for a name that only exists at
+ * run time — `usedDefaults`/`defaultValues` (the two ALWAYS-present wrapper
+ * keys) ARE declared and asserted directly in the scenario, which is the
+ * actual regression-relevant surface this suite's self-check cares about.
+ */
+const CRUD_DEFAULT_VALUE_DYNAMIC_KEY_REASON =
+  'Correct by design: default_values[].key is a user-configured, dynamic name ' +
+  "(processDefaultValues/handleCrudError's Object.entries loop) — no static manifest can " +
+  'declare a literal path for it. Same class as var-assign.myVar/myList in ' +
+  'contract-drift-allowlist.ts EXTRACTION_BLIND_SPOTS.'
+
+const WRITTEN_UNDECLARED_PINS: Pin[] = [
+  {
+    test: (key) =>
+      key.startsWith('find_vendor_many.vendorentitydefcuid00001') ||
+      key.startsWith('find_vendor_many.regionentitydefcuid00001'),
+    reason: FIND_MANY_STRAY_SINGULAR_KEY_REASON,
+  },
+  {
+    test: (key) => key === 'crud_vendor_update_default.fallbackNote',
+    reason: CRUD_DEFAULT_VALUE_DYNAMIC_KEY_REASON,
+  },
+]
+
+/** Invariant 2: is `key` a documented, pinned coverage gap? Returns the reason, or `undefined`. */
+export function matchWrittenUndeclaredPin(key: string): string | undefined {
+  return findPin(WRITTEN_UNDECLARED_PINS, key)
+}
+
+// =============================================================================
+// Invariant 3 — label coverage
+// =============================================================================
+
+const MISSING_LABEL_PINS: Pin[] = []
+
+/** Invariant 3: is `id` a documented, pinned missing-label gap? Returns the reason, or `undefined`. */
+export function matchMissingLabelPin(id: string): string | undefined {
+  return findPin(MISSING_LABEL_PINS, id)
+}


### PR DESCRIPTION
The "resolvability suite" from the variable-resolution deep dive (§10b step 2) — the test net that everything riskier in that sequence lands behind. Runs the REAL `FindProcessor`/`CrudNodeProcessor` against a REAL `ExecutionContextManager` (only genuine external edges mocked: DB, cache, field-value store, crud handler) and asserts three invariants per scenario over the manifest's `resolveOutputs` tree:

1. **declared ⊆ resolvable** — every advertised variable id (nested properties + array items, flattened) resolves through the real `resolveVariablePath` ladder after execution. An array whose elements ALL resolved to `undefined` counts as unresolved — the `[*]` branch always returns a defined array, which would otherwise vacuously pass every findMany-item resolution bug.
2. **written ⊆ declared** — every key the processor wrote is covered by a declared id or declared subtree.
3. **label coverage** — every declared variable carries a non-empty `label` (`buildVariableLabelPath` falls back to raw id segments — CUIDs in the picker). **Currently clean for find/crud**: the pin list for this invariant is empty, and now stays that way by force.

**Scenarios (10)**: findOne hit / miss / tier-A thread, findMany (custom + tier-A), crud create / update / delete, thread-actions, `error_strategy: 'default'`. The fixture models the field **key/id/systemAttribute triad** faithfully — plain custom field (CUID key), entity-def system field (CUID key + registered `systemAttribute`), real `RESOURCE_FIELD_REGISTRY` thread fields — so key-vocabulary bugs cannot pass vacuously.

**Self-retiring pins**: a pinned id asserts it *stays* broken; fixing the underlying bug fails the suite until the pin is deleted (same contract as `contract-drift-allowlist.ts`). Pinned today:
- Tier-A field paths (systemAttribute-keyed declarations vs raw camelCase Drizzle rows — deep dive §3.2; fix: `toOutputShape`, §10b step 4)
- **NEW BUG**: `crud.errorDetails` declared unconditionally but written only by `handleCrudError` — never resolves on a success run
- findMany's stray per-item singular key (§3.5 last-row-wins clobber, now test-enforced)

**Also discovered, deliberately not fixed here**: `buildFieldPath` (execution-context.ts) reads `relConfig?.relatedEntityDefinitionId`, a property that doesn't exist on `RelationshipConfig` — it returns `null` for every multi-segment path (100% dead code), and the fallback then resolves 2-hop relation refs to the **first hop's value**. Silent wrong data, reachable in prod from any 2-hop `{{…}}` ref on a findMany item. The planned segment-walk resolver (§10b step 3) deletes that lane; this suite is its net.

## Verification
- `packages/lib` vitest `src/workflow-engine/parity`: 14/14, ~7s
- `packages/lib` vitest `src/workflow-engine`: 1,057/1,057
- typecheck ratchet lib: 29/29 baseline, no new errors
- biome: clean
- Zero production-code changes