### PR TITLE
fix(records): export current view csv matches the rendered table

### DIFF
--- a/apps/web/src/components/data-export/hooks/use-export-columns.ts
+++ b/apps/web/src/components/data-export/hooks/use-export-columns.ts
@@ -6,16 +6,13 @@ import type { ExportColumn } from '@auxx/lib/export/client'
 import { toResourceFieldId } from '@auxx/types/field'
 import { useMemo } from 'react'
 import { useResourceFields } from '~/components/resources/hooks'
-import {
-  useColumnLabels,
-  useColumnOrder,
-  useColumnVisibility,
-} from '../../dynamic-table/stores/store-selectors'
+import { useTableInstance } from '../../dynamic-table/context/table-instance-context'
+import { useColumnLabels } from '../../dynamic-table/stores/store-selectors'
 import { decodeColumnId, isFieldColumnId } from '../../dynamic-table/utils/column-id'
 
 /** Column snapshots for the two export entry points. */
 export interface UseExportColumnsResult {
-  /** Ordered, visible, field-only columns matching what the table shows. */
+  /** Field columns exactly as the table renders them — same order, same visibility. */
   viewColumns: ExportColumn[]
   /** Every (non-hidden) field on the entity — for a full dump. */
   allColumns: ExportColumn[]
@@ -23,31 +20,34 @@ export interface UseExportColumnsResult {
 
 /**
  * Resolve the column snapshots the exporter sends to the worker. `viewColumns`
- * mirror the active view (order + visibility + label overrides); `allColumns`
- * are all non-hidden fields on the entity. Each `fieldRef` is a `FieldReference`
- * (direct `ResourceFieldId` or a `FieldPath`) — passed verbatim to `batchGetValues`.
+ * come from the rendered table instance (`getVisibleLeafColumns`), so the export
+ * matches what the user sees — including columns the view's saved `columnOrder`
+ * doesn't list, which the table appends in definition order. `allColumns` are all
+ * non-hidden fields on the entity. Each `fieldRef` is a `FieldReference` (direct
+ * `ResourceFieldId` or a `FieldPath`) — passed verbatim to `batchGetValues`.
+ *
+ * Must be used within a `TableInstanceProvider`.
  */
 export function useExportColumns(
   tableId: string,
   entityDefinitionId: string | undefined
 ): UseExportColumnsResult {
-  const columnOrder = useColumnOrder(tableId)
-  const columnVisibility = useColumnVisibility(tableId)
+  const { table } = useTableInstance()
   const columnLabels = useColumnLabels(tableId)
   const { fields } = useResourceFields(entityDefinitionId ?? null)
 
-  const viewColumns = useMemo<ExportColumn[]>(() => {
-    if (!columnOrder) return []
-    return columnOrder
-      .filter((id) => columnVisibility?.[id] !== false)
-      .filter((id) => isFieldColumnId(id))
-      .map((id) => {
-        const decoded = decodeColumnId(id)
-        const fieldRef = decoded.type === 'direct' ? decoded.resourceFieldId : decoded.fieldPath
-        const field = fields.find((f) => f.resourceFieldId === id || f.id === id)
-        return { label: columnLabels[id] ?? field?.label ?? id, fieldRef }
-      })
-  }, [columnOrder, columnVisibility, columnLabels, fields])
+  // Computed per render, not memoized: the table instance is referentially stable
+  // while its column state mutates, so a memo keyed on it would go stale.
+  const viewColumns: ExportColumn[] = table
+    .getVisibleLeafColumns()
+    .map((column) => column.id)
+    .filter((id) => isFieldColumnId(id))
+    .map((id) => {
+      const decoded = decodeColumnId(id)
+      const fieldRef = decoded.type === 'direct' ? decoded.resourceFieldId : decoded.fieldPath
+      const field = fields.find((f) => f.resourceFieldId === id || f.id === id)
+      return { label: columnLabels[id] ?? field?.label ?? id, fieldRef }
+    })
 
   const allColumns = useMemo<ExportColumn[]>(() => {
     if (!entityDefinitionId) return []

--- a/apps/web/src/components/dynamic-table/stores/ui-slice.ts
+++ b/apps/web/src/components/dynamic-table/stores/ui-slice.ts
@@ -2,6 +2,7 @@
 
 import type { CalendarViewConfig, KanbanViewConfig } from '../types'
 import { tableViewPreferenceKey } from '../utils/constants'
+import { toPersonalOverlayConfig } from '../utils/table-view-preference'
 import type { SliceCreator, UISlice } from './store-types'
 import { DEFAULT_UI_CONFIG } from './store-types'
 
@@ -34,7 +35,7 @@ export const createUISlice: SliceCreator<UISlice> = (set, get) => ({
         state.viewPreferences[tableViewPreferenceKey(preference.tableId, preference.tableViewId)] =
           preference
         if (preference.tableViewId) {
-          state.personalConfigs[preference.tableViewId] = { ...preference.config }
+          state.personalConfigs[preference.tableViewId] = toPersonalOverlayConfig(preference.config)
         }
       }
     })

--- a/apps/web/src/components/dynamic-table/utils/table-view-preference.test.ts
+++ b/apps/web/src/components/dynamic-table/utils/table-view-preference.test.ts
@@ -2,7 +2,11 @@
 
 import { tableViewPreferenceConfigSchema } from '@auxx/lib/conditions/client'
 import { describe, expect, it } from 'vitest'
-import { hasPresentationPreference, toTableViewPreferenceConfig } from './table-view-preference'
+import {
+  hasPresentationPreference,
+  toPersonalOverlayConfig,
+  toTableViewPreferenceConfig,
+} from './table-view-preference'
 
 describe('table view preferences', () => {
   it('keeps presentation state and drops transient/shared-view state', () => {
@@ -36,6 +40,20 @@ describe('table view preferences', () => {
     })
 
     expect(hasPresentationPreference(preference)).toBe(false)
+  })
+
+  it('drops empty containers when hydrating a personal overlay', () => {
+    const overlay = toPersonalOverlayConfig({
+      columnVisibility: {},
+      columnOrder: [],
+      columnSizing: { name: 280 },
+      columnPinning: { left: ['_checkbox', 'name'] },
+    })
+
+    expect(overlay).toEqual({
+      columnSizing: { name: 280 },
+      columnPinning: { left: ['_checkbox', 'name'] },
+    })
   })
 
   it('validates only the presentation payload accepted by the router', () => {

--- a/apps/web/src/components/dynamic-table/utils/table-view-preference.ts
+++ b/apps/web/src/components/dynamic-table/utils/table-view-preference.ts
@@ -18,6 +18,25 @@ export function toTableViewPreferenceConfig(
   }
 }
 
+/**
+ * Convert a persisted preference row back into a personal overlay.
+ * `toTableViewPreferenceConfig` coerces untouched keys to empty containers to
+ * satisfy the schema; hydrating those back verbatim would shadow the shared
+ * view's saved config (e.g. an empty `columnOrder` masking the view's real
+ * order), so empty `[]`/`{}` values are dropped.
+ */
+export function toPersonalOverlayConfig(config: TableViewPreferenceConfig): Partial<TableUIConfig> {
+  const overlay: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(config)) {
+    if (value == null) continue
+    if (Array.isArray(value) && value.length === 0) continue
+    if (typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === 0)
+      continue
+    overlay[key] = value
+  }
+  return overlay as Partial<TableUIConfig>
+}
+
 /** Whether an extracted config contains presentation state worth persisting. */
 export function hasPresentationPreference(config: TableViewPreferenceConfig): boolean {
   return (


### PR DESCRIPTION
## Summary

"Export current view as CSV" on records pages errored with **"Nothing to export"** even though the table was full of rows. Two fixes:

### 1. Empty preference overlays no longer shadow the shared view's config

`toTableViewPreferenceConfig` coerces untouched keys to empty containers (`columnOrder: []`, `columnVisibility: {}`) to satisfy the schema when persisting a personal `TableViewPreference` row (e.g. after resizing/pinning a column on a shared view). Hydrating those rows verbatim into `personalConfigs` made the empty containers win over the shared view's saved config in the `??` chains — an empty `columnOrder` masked the view's real order, so `useExportColumns` produced zero columns and the export bailed. It also distorted the rendered table (all columns shown instead of the view's configured set) and could have clobbered the shared view's config on a "save for everyone" merge.

`setViewPreferences` now hydrates through `toPersonalOverlayConfig`, which drops empty `[]`/`{}` values — they are persistence artifacts, never meaningful overrides. Fixing at hydration neutralizes the bad rows already in the DB for every consumer at once.

### 2. "Export current view" exports exactly what's rendered

`viewColumns` now come from the table instance (`getVisibleLeafColumns`) instead of the stored `columnOrder`, so the export matches the on-screen table — same order, same visibility, including columns the saved order never listed (which the table appends in definition order). No server change: the client already sends the full ordered column list on `dataExport.create`. The print wizard's preselected columns benefit the same way.

## Testing

- Added a unit test for `toPersonalOverlayConfig`; existing `table-view-preference` tests pass.
- Verified in the running app: contacts table renders Name, Email, Shopify store, Orders, Phone, First interaction, Last interaction, Long Note, Tags — the `dataExport.create` payload now contains exactly those 9 columns in that order, and the export completes (1,324 records).