### PR TITLE
fix(workflow): resolve tier-a find fields under their declared keys

### DIFF
--- a/packages/lib/src/resources/registry/index.ts
+++ b/packages/lib/src/resources/registry/index.ts
@@ -170,7 +170,6 @@ export type {
   ResourceTableDefinition,
 } from './field-types'
 export { getFieldOutputKey } from './field-types'
-
 // Re-export option helpers
 export {
   type FieldOptionItem,
@@ -180,6 +179,8 @@ export {
   isValidOptionValue,
   labelToValue,
 } from './option-helpers'
+// Re-export the tier-A output-shape helper (§10b step 4)
+export { toOutputShape } from './output-shape'
 
 // export * from './enum-values'
 

--- a/packages/lib/src/resources/registry/output-shape.test.ts
+++ b/packages/lib/src/resources/registry/output-shape.test.ts
@@ -1,0 +1,144 @@
+// packages/lib/src/resources/registry/output-shape.test.ts
+// §10b step 4: pins `toOutputShape`'s merged-shape contract in isolation —
+// see `../../workflow-engine/parity/find.resolvability.test.ts` for the
+// end-to-end proof against a real FindProcessor run.
+
+import { describe, expect, it } from 'vitest'
+import { BaseType } from '../types'
+import type { ResourceField } from './field-types'
+import { toOutputShape } from './output-shape'
+
+const capabilities = {
+  filterable: true,
+  sortable: true,
+  creatable: false,
+  updatable: false,
+  configurable: false,
+}
+
+function field(overrides: Partial<ResourceField>): ResourceField {
+  return {
+    id: 'f' as ResourceField['id'],
+    key: 'f',
+    label: 'F',
+    type: BaseType.STRING,
+    capabilities,
+    ...overrides,
+  }
+}
+
+describe('toOutputShape', () => {
+  it('aliases a field whose output key differs from its dbColumn', () => {
+    const statusField = field({
+      key: 'status',
+      systemAttribute: 'thread_status' as ResourceField['systemAttribute'],
+      dbColumn: 'status',
+    })
+    const row = { id: 't1', status: 'OPEN' }
+
+    expect(toOutputShape(row, [statusField])).toEqual({
+      id: 't1',
+      status: 'OPEN',
+      thread_status: 'OPEN',
+    })
+  })
+
+  it('preserves the raw camelCase key alongside the alias (merged, not replaced)', () => {
+    const assigneeField = field({
+      key: 'assignee',
+      systemAttribute: 'assignee_id' as ResourceField['systemAttribute'],
+      dbColumn: 'assigneeId',
+    })
+    const row = { assigneeId: 'usr_1' }
+
+    const shaped = toOutputShape(row, [assigneeField])
+    // Raw column keeps working (back-compat for hand-typed `{{…}}` refs)...
+    expect(shaped.assigneeId).toBe('usr_1')
+    // ...and the declared systemAttribute path starts working too.
+    expect(shaped.assignee_id).toBe('usr_1')
+  })
+
+  it('skips RELATION-type fields even when they have a dbColumn', () => {
+    const inboxField = field({
+      key: 'inbox',
+      type: BaseType.RELATION,
+      systemAttribute: 'inbox_id' as ResourceField['systemAttribute'],
+      dbColumn: 'inboxId',
+    })
+    const row = { inboxId: 'inbox_1' }
+
+    const shaped = toOutputShape(row, [inboxField])
+    expect(shaped).toEqual({ inboxId: 'inbox_1' })
+    expect(shaped).not.toHaveProperty('inbox_id')
+  })
+
+  it('skips fields with no dbColumn (FieldValue-backed / virtual query fields)', () => {
+    const virtualField = field({
+      key: 'from',
+      systemAttribute: 'from' as ResourceField['systemAttribute'],
+      dbColumn: undefined,
+    })
+    const row = { subject: 'hello' }
+
+    expect(toOutputShape(row, [virtualField])).toEqual({ subject: 'hello' })
+  })
+
+  it('does not clobber the row when the output key already equals the column name', () => {
+    const idField = field({
+      key: 'id',
+      systemAttribute: 'id' as ResourceField['systemAttribute'],
+      dbColumn: 'id',
+    })
+    const row = { id: 't1' }
+
+    // A spy-free way to prove no clobber: the merged object is deep-equal to
+    // the original, i.e. no `aliases.id` overwrite occurred (harmless here
+    // since the values are identical, but the point is the alias is never
+    // even computed for an identity mapping).
+    expect(toOutputShape(row, [idField])).toEqual({ id: 't1' })
+  })
+
+  it('skips a field whose dbColumn is absent from the row entirely', () => {
+    const missingColumnField = field({
+      key: 'closedAt',
+      systemAttribute: 'closed_at' as ResourceField['systemAttribute'],
+      dbColumn: 'closedAt',
+    })
+    const row = { id: 't1' } // no `closedAt` key selected on this row
+
+    const shaped = toOutputShape(row, [missingColumnField])
+    expect(shaped).toEqual({ id: 't1' })
+    expect(shaped).not.toHaveProperty('closed_at')
+  })
+
+  it('merges multiple field aliases at once and returns a NEW object (non-mutating)', () => {
+    const fields = [
+      field({
+        key: 'status',
+        systemAttribute: 'thread_status' as ResourceField['systemAttribute'],
+        dbColumn: 'status',
+      }),
+      field({
+        key: 'messageCount',
+        systemAttribute: 'message_count' as ResourceField['systemAttribute'],
+        dbColumn: 'messageCount',
+      }),
+    ]
+    const row = { id: 't1', status: 'OPEN', messageCount: 3 }
+
+    const shaped = toOutputShape(row, fields)
+    expect(shaped).toEqual({
+      id: 't1',
+      status: 'OPEN',
+      messageCount: 3,
+      thread_status: 'OPEN',
+      message_count: 3,
+    })
+    expect(shaped).not.toBe(row)
+  })
+
+  it('returns the row untouched (still a merge) when fields is empty', () => {
+    const row = { id: 't1', status: 'OPEN' }
+    expect(toOutputShape(row, [])).toEqual(row)
+  })
+})

--- a/packages/lib/src/resources/registry/output-shape.ts
+++ b/packages/lib/src/resources/registry/output-shape.ts
@@ -1,0 +1,56 @@
+// packages/lib/src/resources/registry/output-shape.ts
+
+import { BaseType } from '../types'
+import { getFieldOutputKey, type ResourceField } from './field-types'
+
+/**
+ * Re-key a raw tier-A (static system table) row by each field's advertised
+ * output key ({@link getFieldOutputKey}), MERGED on top of the raw row rather
+ * than replacing it.
+ *
+ * Interim fix for §3.2 / §10b step 4
+ * (`plans/kopilot/workflow/10-variable-resolution-deep-dive.md`): `find.ts`
+ * stores tier-A results as raw Drizzle rows, keyed by camelCase DB columns
+ * (`status`, `assigneeId`, `messageCount`, …). The builder's variable picker
+ * advertises tier-A fields by `getFieldOutputKey` (`thread_status`,
+ * `assignee_id`, `message_count`, …), which almost never equals the column
+ * name — so nearly every advertised field path resolved to `undefined`.
+ * Tier-A resolution is exact-match plain-object navigation with no key
+ * tolerance, by design (§2 of the doc above); the fix is the STORED SHAPE,
+ * not the resolver.
+ *
+ * Merged, not replaced: `{ ...row, ...aliases }`. Existing hand-typed
+ * `{{find_1.thread.status}}` refs (raw camelCase columns) keep resolving —
+ * production workflows may already use them — while the declared
+ * `{{find_1.thread.thread_status}}` path starts resolving too. A field whose
+ * output key already equals its column name is skipped, so it never clobbers
+ * the raw value with an identical alias.
+ *
+ * RELATION fields are skipped: tier A never stores a `ResourceReference`, so
+ * there is no lazy-load lane to expand a relation through — aliasing a
+ * relation's output key to its (non-scalar) raw column would resolve to the
+ * wrong shape, not the missing one. Those paths stay pinned broken in
+ * `known-broken.ts`; the real fix is §10b proposal #1 (ResourceReference
+ * unification for tier A).
+ *
+ * Pure: fields in, object out. No DB/cache access.
+ */
+export function toOutputShape(
+  row: Record<string, unknown>,
+  fields: ResourceField[]
+): Record<string, unknown> {
+  const aliases: Record<string, unknown> = {}
+
+  for (const field of fields) {
+    if (field.type === BaseType.RELATION) continue
+    if (!field.dbColumn) continue
+    if (!(field.dbColumn in row)) continue
+
+    const outputKey = getFieldOutputKey(field)
+    if (outputKey === field.dbColumn) continue
+
+    aliases[outputKey] = row[field.dbColumn]
+  }
+
+  return { ...row, ...aliases }
+}

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/find.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/find.ts
@@ -27,6 +27,7 @@ import {
   isValidOperatorForField,
   RESOURCE_FIELD_REGISTRY,
   setEntityVariables,
+  toOutputShape,
 } from '../../../resources/registry'
 import type { TableId } from '../../../resources/registry/field-registry'
 import { getFieldOutputKey, type ResourceField } from '../../../resources/registry/field-types'
@@ -649,6 +650,30 @@ export class FindProcessor extends BaseNodeProcessor {
           result = queryResult.results
           resultCount = queryResult.results ? 1 : 0
         }
+      }
+
+      // Tier-A (static system table — thread/message/kb/…) results are raw
+      // Drizzle rows keyed by camelCase DB columns (`status`, `assigneeId`,
+      // `messageCount`, …), while the builder advertises fields by
+      // `getFieldOutputKey` (`thread_status`, `assignee_id`, …) — see §3.2/
+      // §10b step 4 of the variable-resolution deep dive. Merge in the
+      // declared aliases here, at write time, for BOTH find modes: the raw
+      // camelCase columns keep resolving (back-compat for hand-typed refs),
+      // and the declared systemAttribute paths start resolving too. A
+      // findMany item benefits the same way once assigned to `loop.item`.
+      // The custom-entity lanes (ResourceReference-backed) are untouched —
+      // they're correct today. Doing this BEFORE `outputData` is built below
+      // means the run trace shows the identical merged shape the written
+      // variable resolves to, not the raw row underneath — deliberate, since
+      // the trace already keys on the same identity as the variable (see the
+      // output-keying comment below); a findOne miss (`null`/`undefined`)
+      // passes through untouched.
+      if (!isCustomResourceId(resourceType)) {
+        result = Array.isArray(result)
+          ? result.map((row) => toOutputShape(row, resource.fields))
+          : result
+            ? toOutputShape(result, resource.fields)
+            : result
       }
 
       contextManager.log(

--- a/packages/lib/src/workflow-engine/parity/find.resolvability.test.ts
+++ b/packages/lib/src/workflow-engine/parity/find.resolvability.test.ts
@@ -292,6 +292,34 @@ describe('Find node resolvability', () => {
     )
     expect(declared.length).toBeGreaterThan(5)
     await assertResolvability(ctx, written, declared, 'find.findOne.thread')
+
+    // §10b step 4 (toOutputShape) — the declared systemAttribute paths now
+    // resolve to the FIXTURE ROW'S ACTUAL VALUES, not just "not undefined".
+    // Was: `resolveNestedObject` read `row['thread_status']`, which never
+    // existed on the raw Drizzle row (`row.status` did) — every one of these
+    // interpolated to empty string. `THREAD_ROW` in `fixtures.ts` pins the
+    // exact camelCase-vs-systemAttribute divergence this proves fixed.
+    expect(await ctx.resolveVariablePath(`${nodeId}.thread.thread_status`)).toBe('OPEN')
+    expect(await ctx.resolveVariablePath(`${nodeId}.thread.assignee_id`)).toBe(
+      'usr_parity_assignee'
+    )
+    expect(await ctx.resolveVariablePath(`${nodeId}.thread.message_count`)).toBe(3)
+    expect(await ctx.resolveVariablePath(`${nodeId}.thread.last_message_at`)).toEqual(
+      THREAD_ROW.lastMessageAt
+    )
+    expect(await ctx.resolveVariablePath(`${nodeId}.thread.first_message_at`)).toEqual(
+      THREAD_ROW.firstMessageAt
+    )
+    expect(await ctx.resolveVariablePath(`${nodeId}.thread.created_at`)).toEqual(
+      THREAD_ROW.createdAt
+    )
+    // `external_id` is `null` on the fixture row (a present, resolvable
+    // `null` — not the absent-key `undefined` the bug used to produce).
+    expect(await ctx.resolveVariablePath(`${nodeId}.thread.external_id`)).toBeNull()
+    // The raw camelCase column keeps resolving too — hand-typed refs in
+    // existing workflows must not break (the merged-shape back-compat
+    // guarantee `toOutputShape`'s docblock promises).
+    expect(await ctx.resolveVariablePath(`${nodeId}.thread.status`)).toBe('OPEN')
   })
 
   it('findMany (custom entity Vendor) — declared ⊆ resolvable, written ⊆ declared, labels present', async () => {
@@ -349,6 +377,17 @@ describe('Find node resolvability', () => {
     )
     expect(declared.length).toBeGreaterThan(5)
     await assertResolvability(ctx, written, declared, 'find.findMany.thread')
+
+    // §10b step 4 — findMany items get the SAME merged shape as findOne, so
+    // `loop.item.<systemAttribute>` starts working too. Assert the actual
+    // per-item values, not just "the array is defined".
+    expect(await ctx.resolveVariablePath(`${nodeId}.threads[*].thread_status`)).toEqual([
+      'OPEN',
+      'OPEN',
+    ])
+    expect(await ctx.resolveVariablePath(`${nodeId}.threads[0].thread_status`)).toBe('OPEN')
+    expect(await ctx.resolveVariablePath(`${nodeId}.threads[1].subject`)).toBe(THREAD_ROW_2.subject)
+    expect(await ctx.resolveVariablePath(`${nodeId}.threads[*].message_count`)).toEqual([3, 3])
   })
 
   // §11-segment-walk-resolver §8 additions — the deliberate behavior changes

--- a/packages/lib/src/workflow-engine/parity/known-broken.ts
+++ b/packages/lib/src/workflow-engine/parity/known-broken.ts
@@ -29,6 +29,10 @@
  * a fixed bug forces its own pin's removal instead of quietly rotting.
  */
 
+import { RESOURCE_FIELD_REGISTRY } from '../../resources/registry/field-registry'
+import { getFieldOutputKey } from '../../resources/registry/field-types'
+import { BaseType } from '../../resources/types'
+
 /** One pin: a predicate over the id/key, plus why it's pinned and where the fix lives. */
 interface Pin {
   test: (id: string) => boolean
@@ -45,30 +49,44 @@ function findPin(pins: Pin[], id: string): string | undefined {
 // =============================================================================
 
 /**
- * Tier-A (`thread`) findOne/findMany declared field paths, EXCEPT the two
- * coincidental matches (`id`, `subject`, whose `systemAttribute` string
- * happens to equal the raw Drizzle column name).
+ * Tier-A (`thread`) findOne/findMany declared field paths that are STILL
+ * broken after §10b step 4 (`toOutputShape`, `resources/registry/output-shape.ts`)
+ * — everything else in this family was retired by that fix.
  *
  * §3.2 (`plans/kopilot/workflow/10-variable-resolution-deep-dive.md`): the
  * palette advertises tier-A fields by `systemAttribute` (`thread_status`,
- * `assignee_id`, `message_count`, `last_message_at`, …), but find.ts stores
- * the RAW Drizzle row (camelCase columns: `status`, `assigneeId`,
- * `messageCount`, `lastMessageAt`, …) and tier-A resolution has no key
- * mapping — `resolveNestedObject` looks for `row['thread_status']`, which
- * doesn't exist. Confirmed by the real `RESOURCE_FIELD_REGISTRY.thread`
- * entries (`thread-fields.ts`): `status.systemAttribute === 'thread_status'`
- * but `status.dbColumn === 'status'`; same divergence for `assignee`,
- * `messageCount`, `lastMessageAt`, `firstMessageAt`, `closedAt`, `externalId`.
+ * `assignee_id`, `message_count`, `last_message_at`, …), but find.ts used to
+ * store the RAW Drizzle row (camelCase columns: `status`, `assigneeId`,
+ * `messageCount`, `lastMessageAt`, …) with no key mapping at all —
+ * `resolveNestedObject` looked for `row['thread_status']`, which never
+ * existed. `toOutputShape` now merges `getFieldOutputKey(field) →
+ * row[field.dbColumn]` aliases into the row at write time for every field
+ * that HAS a `dbColumn`, which retires every scalar in this family whose
+ * declared key differs from its column (`external_id`, `thread_status`,
+ * `message_count`, `first_message_at`, `last_message_at`, `closed_at`,
+ * `created_at`, `assignee_id`; `id`/`subject` already matched coincidentally
+ * and were never broken).
  *
- * Tier-A RELATION fields (`inbox`, `ticket`, `messages`, `tags`) are broken
- * for the compounding, structural reason in §3.4: tier A never stores a
- * `ResourceReference`, so there is no lazy-load lane to expand them through
- * at all — the raw row simply has no property by that name.
+ * Two field shapes remain genuinely unresolvable, both because
+ * `toOutputShape` only aliases a field that HAS a `dbColumn` — a field
+ * without one was never a candidate for this fix:
  *
- * Fix pointer: §10b step 4 — `toOutputShape(row, fields)` re-keys the row by
- * `getFieldOutputKey` at write time (the cheap, do-now fix); the full fix
- * (§10b proposal #1) unifies tier A onto the same `ResourceReference` lane
- * tier B/C already uses, which would additionally fix the relation fields.
+ * - **RELATION fields** (`inbox`, `ticket`, `messages`, `tags`): tier A never
+ *   stores a `ResourceReference`, so there is no lazy-load lane to expand
+ *   them through at all (§3.4) — the raw row simply has no property by that
+ *   name, and aliasing a nonexistent scalar column wouldn't help even if one
+ *   existed. Fix pointer: §10b proposal #1 (ResourceReference unification for
+ *   tier A).
+ * - **Scalar fields with NO `dbColumn`** (`readStatus`, the `visit*`
+ *   chat-capture fields, and the mail-builder's virtual query-only fields
+ *   `from`/`to`/`body`/`freeText`/`hasAttachments`/`hasDraft`/`sent`): these
+ *   are FieldValue-backed or cross-table-join-resolved, never present on the
+ *   raw `schema.Thread` row `find.ts` selects — there is no column for
+ *   `toOutputShape` to alias FROM. Same fix pointer as RELATION (proposal #1
+ *   would read these through the FieldValue/join lane instead of the raw row).
+ *
+ * Derived directly from the real `RESOURCE_FIELD_REGISTRY.thread` registry
+ * (not hand-copied), so a future field addition can't silently drift this set.
  *
  * findMany items go through the SAME per-element `resolveNestedObject` inside
  * the array-map branch of `resolveVariablePath` — the array itself is always
@@ -77,6 +95,12 @@ function findPin(pins: Pin[], id: string): string | undefined {
  * `harness.ts`'s `assertDeclaredResolvable`) — otherwise this whole family
  * would silently pass for findMany while genuinely broken.
  */
+const THREAD_STILL_BROKEN_OUTPUT_KEYS = new Set(
+  Object.values(RESOURCE_FIELD_REGISTRY.thread ?? {})
+    .filter((field) => field.type === BaseType.RELATION || !field.dbColumn)
+    .map((field) => getFieldOutputKey(field))
+)
+
 const TIER_A_FIELD_PATH_RE = /^[^.]+\.(thread|threads\[\*\])\.(.+)$/
 
 function tierAFieldPathPin(id: string): string | undefined {
@@ -84,12 +108,13 @@ function tierAFieldPathPin(id: string): string | undefined {
   if (!match) return undefined
   const rest = match[2]!
   const firstSegment = rest.split('.')[0]!.replace(/\[\*\]$/, '')
-  if (firstSegment === 'id' || firstSegment === 'subject') return undefined
+  if (!THREAD_STILL_BROKEN_OUTPUT_KEYS.has(firstSegment)) return undefined
   return (
-    '§3.2/§3.4: tier-A (thread) stores the raw Drizzle row, not a ResourceReference — ' +
-    'nested field access has no systemAttribute→dbColumn mapping (scalars) and no lazy-load ' +
-    'lane at all (relations). Fix: §10b step 4 (toOutputShape) for scalars, proposal #1 ' +
-    '(ResourceReference unification) for relations.'
+    '§3.2/§3.4, fixed by §10b step 4 (toOutputShape) for every scalar WITH a dbColumn — ' +
+    'this key is one of the two shapes toOutputShape cannot fix: a RELATION field (tier A ' +
+    'never stores a ResourceReference, so there is no lazy-load lane at all) or a scalar with ' +
+    'no dbColumn at all (FieldValue-backed or cross-table-join-resolved, never on the raw row). ' +
+    'Fix pointer: §10b proposal #1 (ResourceReference unification for tier A).'
   )
 }
 


### PR DESCRIPTION
§10b step 4 of the variable-resolution sequence — fixes deep-dive §3.2, the previously-undocumented P1: **nearly every advertised tier-A (thread/message/kb) find field path has interpolated to empty string since the beginning**, because find stores raw Drizzle rows (camelCase columns) while the builder advertises `getFieldOutputKey` paths (`thread_status`, `assignee_id`, …), and plain-object resolution is exact-match by design.

## Fix

`toOutputShape(row, fields)` — a pure write-time translator (`resources/registry/output-shape.ts`, 8 unit tests) applied **once** in find.ts for tier-A results only:

- **Merged shape**: raw row spread + `getFieldOutputKey(field) → row[field.dbColumn]` aliases. Hand-typed raw-column refs (`{{find.thread.status}}`) keep working; declared paths (`{{find.thread.thread_status}}`) start resolving — including through `loop.item` over a tier-A findMany.
- Relation fields and dbColumn-less fields skipped (their resolvability-suite pins stay, re-pointed at the planned ResourceReference unification).
- Applied before the trace is built → the run trace shows the identical merged shape the variables resolve to (the existing "trace keys like the variable" invariant).
- Custom-entity lanes untouched (ResourceReference-backed, already correct). Resolver untouched — the fix is the stored shape, not new key tolerance.

## Pin flip (the suite doing its job)

The tier-A known-broken pins flip per the self-retiring contract: retired scalars get **value-level positive assertions** (`thread_status → 'OPEN'`, `message_count → 3`, `external_id → null` present-but-null, raw `status` back-compat, `threads[*].thread_status`). The still-broken set is now **derived from `RESOURCE_FIELD_REGISTRY.thread`** instead of hand-listed — relation fields plus dbColumn-less scalars (`readStatus`, `visit*`, virtual query-only fields) remain pinned with their own documented reasons.

## Verification

- Resolvability suite: 45/45; `output-shape` unit tests: 8/8
- `packages/lib` `src/workflow-engine src/resources`: 1,451 tests green
- typecheck ratchets: lib 29/29, web 1/1 — no new errors
- `apps/web` workflow suite: 100/100; biome clean