### PR TITLE
fix(workflow): key findMany output on resource id, not plural label

### DIFF
--- a/packages/lib/src/data-migrations/migrations/083-find-many-plural-to-id-refs.test.ts
+++ b/packages/lib/src/data-migrations/migrations/083-find-many-plural-to-id-refs.test.ts
@@ -1,0 +1,188 @@
+// packages/lib/src/data-migrations/migrations/083-find-many-plural-to-id-refs.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { WorkflowGraph, WorkflowNode } from '../../workflows/template-graph-transformer'
+import {
+  buildOrgResourceMap,
+  buildStaticResourceMap,
+  rewriteFindManyRefsInGraph,
+} from './083-find-many-plural-to-id-refs'
+
+/**
+ * Pure-logic tests only (no DB — see the migration's docblock for why the
+ * plumbing is not exercised here, same reasoning as
+ * `072-mail-filters-limit.test.ts`). `rewriteFindManyRefsInGraph` is the
+ * entire behavior surface: everything DB-shaped in `run()` is fetch-rows /
+ * call-this-function / write-rows-that-changed.
+ */
+
+const VENDOR_DEF_ID = 'vendorentitydefcuid00001'
+
+function node(id: string, data: Record<string, unknown>): WorkflowNode {
+  return { id, type: data.type as string, position: { x: 0, y: 0 }, data }
+}
+
+function graphWith(nodes: WorkflowNode[]): WorkflowGraph {
+  return { nodes, edges: [] }
+}
+
+describe('buildStaticResourceMap', () => {
+  it('maps a static resource by id and apiSlug to the same entry', () => {
+    const map = buildStaticResourceMap()
+    const byId = map.get('thread')
+    const bySlug = map.get('threads')
+
+    expect(byId).toEqual({ id: 'thread', plural: 'Threads' })
+    expect(bySlug).toBe(byId) // same object reference
+  })
+})
+
+describe('buildOrgResourceMap', () => {
+  it('layers EntityDefinition rows over the static map by id, entityType, and apiSlug', () => {
+    const staticMap = buildStaticResourceMap()
+    const orgMap = buildOrgResourceMap(staticMap, [
+      { id: VENDOR_DEF_ID, plural: 'Vendors', entityType: null, apiSlug: 'vendors' },
+      {
+        id: 'entitydefcuidcontact001',
+        plural: 'Contacts',
+        entityType: 'contact',
+        apiSlug: 'contacts',
+      },
+    ])
+
+    expect(orgMap.get(VENDOR_DEF_ID)).toEqual({ id: VENDOR_DEF_ID, plural: 'Vendors' })
+    expect(orgMap.get('vendors')).toEqual({ id: VENDOR_DEF_ID, plural: 'Vendors' })
+    expect(orgMap.get('contact')).toEqual({ id: 'entitydefcuidcontact001', plural: 'Contacts' })
+    expect(orgMap.get('contacts')).toEqual({ id: 'entitydefcuidcontact001', plural: 'Contacts' })
+    // Static entries survive underneath the org layer.
+    expect(orgMap.get('thread')).toEqual({ id: 'thread', plural: 'Threads' })
+  })
+
+  it('does not mutate the static map passed in', () => {
+    const staticMap = buildStaticResourceMap()
+    const sizeBefore = staticMap.size
+    buildOrgResourceMap(staticMap, [
+      { id: VENDOR_DEF_ID, plural: 'Vendors', entityType: null, apiSlug: 'vendors' },
+    ])
+    expect(staticMap.size).toBe(sizeBefore)
+  })
+})
+
+describe('rewriteFindManyRefsInGraph', () => {
+  const resourceMap = buildOrgResourceMap(buildStaticResourceMap(), [
+    { id: VENDOR_DEF_ID, plural: 'Vendors', entityType: null, apiSlug: 'vendors' },
+  ])
+
+  it('rewrites a {{…}} span referencing the legacy plural key onto the canonical id', () => {
+    const findNode = node('find_1', { type: 'find', findMode: 'findMany', resourceType: 'vendors' })
+    const messageNode = node('message_1', {
+      type: 'answer',
+      body: 'First vendor email: {{find_1.vendors[0].email}}',
+    })
+    const graph = graphWith([findNode, messageNode])
+
+    const touched = rewriteFindManyRefsInGraph(graph, resourceMap)
+
+    expect(touched).toBe(1)
+    expect(messageNode.data.body).toBe(`First vendor email: {{find_1.${VENDOR_DEF_ID}[0].email}}`)
+  })
+
+  it('rewrites a bare variable-id reference (e.g. a loop itemsSource) the same way', () => {
+    const findNode = node('find_1', { type: 'find', findMode: 'findMany', resourceType: 'vendors' })
+    const loopNode = node('loop_1', { type: 'loop', itemsSource: 'find_1.vendors' })
+    const graph = graphWith([findNode, loopNode])
+
+    rewriteFindManyRefsInGraph(graph, resourceMap)
+
+    expect(loopNode.data.itemsSource).toBe(`find_1.${VENDOR_DEF_ID}`)
+  })
+
+  it('handles a multi-word plural with a space in the legacy key', () => {
+    const findNode = node('find_1', { type: 'find', findMode: 'findMany', resourceType: 'kb' })
+    const messageNode = node('message_1', {
+      type: 'answer',
+      body: '{{find_1.knowledge bases[*].title}}',
+    })
+    const graph = graphWith([findNode, messageNode])
+
+    rewriteFindManyRefsInGraph(graph, resourceMap)
+
+    expect(messageNode.data.body).toBe('{{find_1.kb[*].title}}')
+  })
+
+  it('never touches an unrelated node whose plural happens to match a different find node id', () => {
+    // Two find nodes on the SAME resource — a ref must only rewrite under its
+    // OWN node id prefix, never a blanket plural-string replace.
+    const findA = node('find_a', { type: 'find', findMode: 'findMany', resourceType: 'vendors' })
+    const findB = node('find_b', { type: 'find', findMode: 'findMany', resourceType: 'vendors' })
+    const messageNode = node('message_1', {
+      type: 'answer',
+      body: '{{find_a.vendors[0].email}} and {{find_b.vendors[0].email}}',
+    })
+    const graph = graphWith([findA, findB, messageNode])
+
+    rewriteFindManyRefsInGraph(graph, resourceMap)
+
+    expect(messageNode.data.body).toBe(
+      `{{find_a.${VENDOR_DEF_ID}[0].email}} and {{find_b.${VENDOR_DEF_ID}[0].email}}`
+    )
+  })
+
+  it('leaves ordinary prose containing the plural word alone', () => {
+    const findNode = node('find_1', { type: 'find', findMode: 'findMany', resourceType: 'vendors' })
+    const messageNode = node('message_1', {
+      type: 'answer',
+      body: 'Thanks for reaching out about our vendors program.',
+    })
+    const graph = graphWith([findNode, messageNode])
+
+    const touched = rewriteFindManyRefsInGraph(graph, resourceMap)
+
+    expect(touched).toBe(0)
+    expect(messageNode.data.body).toBe('Thanks for reaching out about our vendors program.')
+  })
+
+  it('skips a findMany node whose resourceType does not resolve (deleted/unknown entity)', () => {
+    const findNode = node('find_1', {
+      type: 'find',
+      findMode: 'findMany',
+      resourceType: 'entitydefcuidgoneforever',
+    })
+    const messageNode = node('message_1', { type: 'answer', body: '{{find_1.gone[0].x}}' })
+    const graph = graphWith([findNode, messageNode])
+
+    const touched = rewriteFindManyRefsInGraph(graph, resourceMap)
+
+    expect(touched).toBe(0)
+  })
+
+  it('ignores findOne nodes — only findMany keys on the plural', () => {
+    const findNode = node('find_1', { type: 'find', findMode: 'findOne', resourceType: 'vendors' })
+    const messageNode = node('message_1', {
+      type: 'answer',
+      body: `{{find_1.${VENDOR_DEF_ID}.name}}`,
+    })
+    const graph = graphWith([findNode, messageNode])
+
+    const touched = rewriteFindManyRefsInGraph(graph, resourceMap)
+
+    expect(touched).toBe(0)
+  })
+
+  it('is idempotent — a second pass over an already-rewritten graph is a no-op', () => {
+    const findNode = node('find_1', { type: 'find', findMode: 'findMany', resourceType: 'vendors' })
+    const messageNode = node('message_1', { type: 'answer', body: '{{find_1.vendors[0].email}}' })
+    const graph = graphWith([findNode, messageNode])
+
+    const firstPass = rewriteFindManyRefsInGraph(graph, resourceMap)
+    const secondPass = rewriteFindManyRefsInGraph(graph, resourceMap)
+
+    expect(firstPass).toBe(1)
+    expect(secondPass).toBe(0)
+    expect(messageNode.data.body).toBe(`{{find_1.${VENDOR_DEF_ID}[0].email}}`)
+  })
+
+  it('returns 0 for a graph with no nodes', () => {
+    expect(rewriteFindManyRefsInGraph(graphWith([]), resourceMap)).toBe(0)
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/083-find-many-plural-to-id-refs.ts
+++ b/packages/lib/src/data-migrations/migrations/083-find-many-plural-to-id-refs.ts
@@ -1,0 +1,256 @@
+// packages/lib/src/data-migrations/migrations/083-find-many-plural-to-id-refs.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { asc, eq, gt } from 'drizzle-orm'
+import { RESOURCE_TABLE_MAP } from '../../resources/registry'
+import type { WorkflowGraph } from '../../workflows/template-graph-transformer'
+import { rewriteVariableRefs } from '../../workflows/variable-ref-rewriter'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-083')
+
+/** `Workflow` rows scanned per page (draft + every published version are separate rows). */
+const BATCH_SIZE = 200
+
+/** What a findMany node's stored `resourceType` resolves to. */
+interface ResolvedResource {
+  id: string
+  plural: string
+}
+
+/**
+ * Every key a find node's `resourceType` config can be stored under, mapped to
+ * the resource it identifies. Mirrors the three-way match
+ * `resolveCanonicalResource`/`findCachedResource` do at runtime (id | entityType
+ * | apiSlug) — see `find.ts:544-559` and
+ * `plans/kopilot/workflow/10-variable-resolution-deep-dive.md` §1's
+ * "alias-tolerant keying" note.
+ *
+ * Exported for the unit test — pure, no DB.
+ */
+export function buildStaticResourceMap(): Map<string, ResolvedResource> {
+  const map = new Map<string, ResolvedResource>()
+  for (const table of Object.values(RESOURCE_TABLE_MAP)) {
+    const entry: ResolvedResource = { id: table.id, plural: table.plural }
+    map.set(table.id, entry)
+    if (table.apiSlug) map.set(table.apiSlug, entry)
+  }
+  return map
+}
+
+/**
+ * Extend a resource map with one organization's `EntityDefinition` rows —
+ * covers custom entities AND the entity-def-backed system types (contact/
+ * ticket/…, `type: 'custom'` per the deep-dive doc's tier correction, §1).
+ *
+ * Exported for the unit test — pure, no DB (takes already-fetched rows).
+ */
+export function buildOrgResourceMap(
+  staticMap: Map<string, ResolvedResource>,
+  entityDefs: Array<{ id: string; plural: string; entityType: string | null; apiSlug: string }>
+): Map<string, ResolvedResource> {
+  const map = new Map(staticMap)
+  for (const def of entityDefs) {
+    const entry: ResolvedResource = { id: def.id, plural: def.plural }
+    map.set(def.id, entry)
+    if (def.entityType) map.set(def.entityType, entry)
+    if (def.apiSlug) map.set(def.apiSlug, entry)
+  }
+  return map
+}
+
+/**
+ * Rewrite one variable path if it starts with `<findNodeId>.<oldKey>` for one
+ * of `rewrites` — string-prefix match, NOT `firstPathSegment`, because
+ * `oldKey` (a lowercased plural label) can itself contain spaces
+ * ('knowledge bases') that `rewriteVariableRefs`' bare-string node-id gate
+ * doesn't split on. Every `rewrites` entry targets a DIFFERENT node id, so at
+ * most one can ever match a given path — never a blanket plural-string
+ * replace (the design's explicit constraint).
+ */
+function rewritePluralPrefix(
+  path: string,
+  rewrites: Array<{ findNodeId: string; oldKey: string; newKey: string }>
+): string {
+  for (const { findNodeId, oldKey, newKey } of rewrites) {
+    const prefix = `${findNodeId}.${oldKey}`
+    if (path === prefix) return `${findNodeId}.${newKey}`
+    if (path.startsWith(`${prefix}.`) || path.startsWith(`${prefix}[`)) {
+      return `${findNodeId}.${newKey}${path.slice(prefix.length)}`
+    }
+  }
+  return path
+}
+
+/**
+ * Rewrite every findMany node's plural-keyed `{{…}}`/bare variable ref in one
+ * workflow graph onto the canonical `resource.id` key. Mutates `graph` (and
+ * the `node.data` objects inside it) in place and returns the number of nodes
+ * whose data actually changed — `0` means nothing to persist.
+ *
+ * IDEMPOTENT by construction: once a path has been rewritten it starts with
+ * `<findNodeId>.<newKey>`, which no longer matches the `<findNodeId>.<oldKey>`
+ * prefix `rewritePluralPrefix` looks for, so a second pass is a no-op.
+ *
+ * Exported for the unit test — pure, no DB.
+ */
+export function rewriteFindManyRefsInGraph(
+  graph: WorkflowGraph,
+  resourceMap: Map<string, ResolvedResource>
+): number {
+  if (!Array.isArray(graph.nodes) || graph.nodes.length === 0) return 0
+
+  const rewrites: Array<{ findNodeId: string; oldKey: string; newKey: string }> = []
+  for (const node of graph.nodes) {
+    if (node?.data?.type !== 'find' || node.data.findMode !== 'findMany') continue
+    const resourceType = node.data.resourceType
+    if (typeof resourceType !== 'string' || !resourceType) continue
+
+    const resolved = resourceMap.get(resourceType)
+    if (!resolved) continue
+
+    const oldKey = resolved.plural.toLowerCase()
+    const newKey = resolved.id
+    if (oldKey === newKey) continue // nothing to rewrite — same string either way
+
+    rewrites.push({ findNodeId: node.id, oldKey, newKey })
+  }
+
+  if (rewrites.length === 0) return 0
+
+  const nodeIds = new Set(graph.nodes.map((n) => n.id))
+  let touched = 0
+  for (const node of graph.nodes) {
+    if (!node.data || typeof node.data !== 'object') continue
+    const before = JSON.stringify(node.data)
+    rewriteVariableRefs(node.data, nodeIds, (path) => rewritePluralPrefix(path, rewrites))
+    if (JSON.stringify(node.data) !== before) touched++
+  }
+
+  return touched
+}
+
+/**
+ * Rewrite `{{<findNodeId>.<plural>…}}` references (and their bare-string
+ * equivalents) left over from before the findMany id-keying fix onto the
+ * canonical `{{<findNodeId>.<resource.id>…}}` form.
+ *
+ * **Why.** `find.ts`'s findMany lanes used to key their result array on
+ * `resource.plural.toLowerCase()` — a USER-EDITABLE string (entity settings)
+ * — so renaming an entity silently broke every stored `{{node.<plural>…}}`
+ * reference (plans/kopilot/workflow/10-variable-resolution-deep-dive.md §3.1,
+ * the doc's headline bug). The engine fix (§10 option A+C, §10b step 5) now
+ * dual-writes the array under BOTH the canonical `resource.id` key and the
+ * legacy plural key, so nothing is broken by NOT running this migration — but
+ * every graph left un-migrated carries a stale key forever, one entity rename
+ * away from breaking again. This migration is the one-shot cleanup that lets
+ * the legacy dual-write eventually retire.
+ *
+ * **Scope.** Every row in `Workflow` — the draft AND every published version
+ * are independent rows sharing that one table (`WorkflowApp.workflowId` /
+ * `.draftWorkflowId` each point at a `Workflow` row; `packages/database/src/db/
+ * schema/workflow.ts`'s `graph` jsonb column holds the node graph). Workflow
+ * TEMPLATES (`WorkflowTemplate`) are deliberately NOT walked: templates store
+ * `@entity:`/`@field:` placeholder tokens, not literal resource keys — the
+ * literal plural string this migration hunts for can only exist in an
+ * installed, org-owned workflow.
+ *
+ * **Resolution.** Per organization: entity-def-backed resources (custom
+ * entities + contact/ticket/…) come from that org's `EntityDefinition` rows;
+ * static tier-A resources (thread/message/kb/…) come from the global
+ * `RESOURCE_TABLE_MAP` — same three-way match (id | entityType | apiSlug) the
+ * engine uses to canonicalize `resourceType` at runtime, so a node's stored
+ * config (whichever of the three it happens to hold) resolves the same way
+ * here as it would live.
+ *
+ * **Idempotent.** See `rewriteFindManyRefsInGraph`'s docblock — a graph with
+ * nothing left to rewrite is skipped without a write.
+ *
+ * **Self-contained.** Raw Drizzle, no org-cache reads (a migration must not
+ * depend on cache state that may be cold, stale, or shaped differently by the
+ * time this runs) — `EntityDefinition` is read straight from the DB per org,
+ * cached only within this run.
+ */
+export const migration083FindManyPluralToIdRefs: DataMigrationDef = {
+  id: '083-find-many-plural-to-id-refs',
+  description: 'Rewrite findMany {{node.<plural>…}} refs onto the canonical {{node.<id>…}} form',
+  async run(db: Database): Promise<void> {
+    const staticResources = buildStaticResourceMap()
+    const orgResourceMapCache = new Map<string, Map<string, ResolvedResource>>()
+
+    async function getOrgResourceMap(orgId: string): Promise<Map<string, ResolvedResource>> {
+      const cached = orgResourceMapCache.get(orgId)
+      if (cached) return cached
+
+      const defs = await db
+        .select({
+          id: schema.EntityDefinition.id,
+          plural: schema.EntityDefinition.plural,
+          entityType: schema.EntityDefinition.entityType,
+          apiSlug: schema.EntityDefinition.apiSlug,
+        })
+        .from(schema.EntityDefinition)
+        .where(eq(schema.EntityDefinition.organizationId, orgId))
+
+      const map = buildOrgResourceMap(staticResources, defs)
+      orgResourceMapCache.set(orgId, map)
+      return map
+    }
+
+    let cursor = ''
+    let scanned = 0
+    let graphsRewritten = 0
+    let nodesRewritten = 0
+
+    for (;;) {
+      const rows = await db
+        .select({
+          id: schema.Workflow.id,
+          organizationId: schema.Workflow.organizationId,
+          graph: schema.Workflow.graph,
+        })
+        .from(schema.Workflow)
+        .where(gt(schema.Workflow.id, cursor))
+        .orderBy(asc(schema.Workflow.id))
+        .limit(BATCH_SIZE)
+
+      if (rows.length === 0) break
+
+      for (const row of rows) {
+        scanned++
+        cursor = row.id
+
+        if (!row.graph || typeof row.graph !== 'object') continue
+        const graph = row.graph as unknown as WorkflowGraph
+        if (!Array.isArray(graph.nodes) || graph.nodes.length === 0) continue
+
+        const resourceMap = await getOrgResourceMap(row.organizationId)
+        const touched = rewriteFindManyRefsInGraph(graph, resourceMap)
+        if (touched === 0) continue
+
+        await db
+          .update(schema.Workflow)
+          .set({ graph: graph as any, updatedAt: new Date() })
+          .where(eq(schema.Workflow.id, row.id))
+
+        graphsRewritten++
+        nodesRewritten += touched
+        logger.info('Rewrote findMany plural refs', {
+          workflowId: row.id,
+          organizationId: row.organizationId,
+          nodesTouched: touched,
+        })
+      }
+
+      if (rows.length < BATCH_SIZE) break
+    }
+
+    logger.info('findMany plural→id ref migration done', {
+      scanned,
+      graphsRewritten,
+      nodesRewritten,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -47,6 +47,7 @@ import { migration079EnrichmentFieldsBackendOwned } from './migrations/079-enric
 import { migration080OutlookWebhookCutover } from './migrations/080-outlook-webhook-cutover'
 import { migration081BackfillInteractionFields } from './migrations/081-backfill-interaction-fields'
 import { migration082InteractionFieldsParticipantResolution } from './migrations/082-interaction-fields-participant-resolution'
+import { migration083FindManyPluralToIdRefs } from './migrations/083-find-many-plural-to-id-refs'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -120,6 +121,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration080OutlookWebhookCutover,
     migration081BackfillInteractionFields,
     migration082InteractionFieldsParticipantResolution,
+    migration083FindManyPluralToIdRefs,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/resources/__tests__/__snapshots__/variable-generators-golden.test.ts.snap
+++ b/packages/lib/src/resources/__tests__/__snapshots__/variable-generators-golden.test.ts.snap
@@ -173,18 +173,18 @@ exports[`variable-generators golden snapshots (FROZEN — pre-refactor baseline)
   {
     "category": "node",
     "description": "Array of ticket records",
-    "id": "node-2.tickets",
+    "id": "node-2.ticket",
     "items": {
       "category": "node",
       "description": "Ticket record",
-      "id": "node-2.tickets[*]",
+      "id": "node-2.ticket[*]",
       "label": "Ticket",
       "properties": {
         "assignee": {
           "category": "node",
           "description": "Assignee of the resource",
           "fieldReference": "ticket:assignee",
-          "id": "node-2.tickets[*].assignee",
+          "id": "node-2.ticket[*].assignee",
           "label": "Assignee",
           "options": {
             "actor": {
@@ -197,7 +197,7 @@ exports[`variable-generators golden snapshots (FROZEN — pre-refactor baseline)
         "ticket_status": {
           "category": "node",
           "description": "Status of the resource",
-          "id": "node-2.tickets[*].ticket_status",
+          "id": "node-2.ticket[*].ticket_status",
           "label": "Status",
           "options": {
             "options": [
@@ -216,27 +216,27 @@ exports[`variable-generators golden snapshots (FROZEN — pre-refactor baseline)
         "title": {
           "category": "node",
           "description": "Title of the resource",
-          "id": "node-2.tickets[*].title",
+          "id": "node-2.ticket[*].title",
           "label": "Title",
           "type": "string",
         },
         "vendor": {
           "category": "node",
           "fieldReference": "ticket:vendor",
-          "id": "node-2.tickets[*].vendor",
+          "id": "node-2.ticket[*].vendor",
           "label": "Vendor",
           "properties": {
             "name": {
               "category": "node",
               "description": "Name of the resource",
-              "id": "node-2.tickets[*].vendor.name",
+              "id": "node-2.ticket[*].vendor.name",
               "label": "Name",
               "type": "string",
             },
             "referenceId": {
               "category": "node",
               "description": "ID of the related Vendor",
-              "id": "node-2.tickets[*].vendor.referenceId",
+              "id": "node-2.ticket[*].vendor.referenceId",
               "label": "Reference ID",
               "type": "string",
             },

--- a/packages/lib/src/resources/__tests__/variable-generators-golden.test.ts
+++ b/packages/lib/src/resources/__tests__/variable-generators-golden.test.ts
@@ -176,6 +176,14 @@ describe('variable-generators golden snapshots (FROZEN — pre-refactor baseline
     expect(result).toMatchSnapshot()
   })
 
+  // SANCTIONED snapshot change (§10/§10b step 5,
+  // plans/kopilot/workflow/10-variable-resolution-deep-dive.md): the findMany
+  // array/item variable ids now key on `resourceMeta.id` ("node-2.ticket…")
+  // instead of `resourceMeta.plural.toLowerCase()` ("node-2.tickets…") — the
+  // plural is a user-editable string, so keying on it silently broke every
+  // `{{node.<plural>…}}` ref on rename. `label` still reports the plural
+  // ("Tickets") — only the id segment changed. Any OTHER snapshot in this
+  // file changing means something else broke.
   it('generateFindNodeVariablesFromFields — findMany', () => {
     const result = generateFindNodeVariablesFromFields(
       fields,

--- a/packages/lib/src/resources/variable-generators.ts
+++ b/packages/lib/src/resources/variable-generators.ts
@@ -585,12 +585,19 @@ export function generateFindNodeVariablesFromFields(
       })
     )
   } else {
-    // For findMany, create array variable with items
-    const pluralPath = resourceMeta.plural.toLowerCase()
+    // For findMany, create array variable with items. Keyed on the canonical
+    // `resource.id` (was `resourceMeta.plural.toLowerCase()` — see
+    // plans/kopilot/workflow/10-variable-resolution-deep-dive.md §10/§10b
+    // step 5: the plural is user-editable, so keying on it silently broke
+    // every `{{node.<plural>…}}` reference on rename). The engine dual-writes
+    // the array under this id AND the legacy plural key for back-compat; the
+    // picker only ever advertises this id-keyed path going forward. `label`
+    // stays `resourceMeta.plural` on purpose — display names are contract,
+    // the picker must keep showing "Vendors", never a raw CUID.
     const itemVar = createNestedVariable({
       deriveLabel: false,
       nodeId,
-      basePath: `${pluralPath}[*]`,
+      basePath: `${resourceMeta.id}[*]`,
       type: BaseType.OBJECT,
       label: resourceMeta.label,
       description: `${resourceMeta.label} record`,
@@ -599,7 +606,7 @@ export function generateFindNodeVariablesFromFields(
     })
 
     variables.push({
-      id: `${nodeId}.${pluralPath}`,
+      id: `${nodeId}.${resourceMeta.id}`,
       label: resourceMeta.plural,
       type: BaseType.ARRAY,
       category: 'node',

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/find-output-keying.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/find-output-keying.test.ts
@@ -268,20 +268,36 @@ describe('findOne keys the result by the resource id', () => {
   })
 })
 
-describe('findMany keeps keying by the plural name the builder advertises', () => {
-  it('keys a system-resource array by the lowercased plural', async () => {
+describe('findMany dual-writes the canonical id key and a legacy plural alias', () => {
+  /**
+   * Flips the old "findMany keeps keying by the plural name" pin — see
+   * `plans/kopilot/workflow/10-variable-resolution-deep-dive.md` §10/§10b step
+   * 5. The plural is a USER-EDITABLE string (entity settings), so keying
+   * findMany's array by it silently broke every `{{node.<plural>…}}` ref on
+   * rename. The array is now written under the CANONICAL `resource.id` key
+   * (what `generateFindNodeVariablesFromFields` declares going forward) AND
+   * the legacy `resource.plural.toLowerCase()` key — same array reference —
+   * so refs stored before the plural→id DataMigration keep resolving. Retire
+   * the legacy assertions here together with the engine's legacy write once
+   * that migration has run everywhere.
+   */
+  it('keys a system-resource array by the id, plus a legacy plural-keyed alias (same array)', async () => {
     executeResourceQuery.mockResolvedValue([{ id: 'row_1' }, { id: 'row_2' }])
     const { written } = await run('kb', 'findMany')
 
-    // Unchanged, and unchanged deliberately: both sides already agree on the
-    // plural for findMany (`generateFindNodeVariablesFromFields` builds the array
-    // variable id from `plural.toLowerCase()`).
+    expect(written['find_1.kb']).toHaveLength(2)
+    // Legacy alias, multi-word plural — the space is still legal here (it's
+    // the pre-migration back-compat key, never the advertised one).
     expect(written['find_1.knowledge bases']).toHaveLength(2)
+    // Dual-write, not a copy: same array reference on both keys.
+    expect(written['find_1.kb']).toBe(written['find_1.knowledge bases'])
   })
 
-  it('keys a custom-entity array by the lowercased plural', async () => {
+  it('keys a custom-entity array by the id, plus a legacy plural-keyed alias', async () => {
     const { written } = await run('orders', 'findMany')
 
+    expect(written['find_1.entitydefcuidorders000000']).toHaveLength(1)
     expect(written['find_1.orders']).toHaveLength(1)
+    expect(written['find_1.entitydefcuidorders000000']).toBe(written['find_1.orders'])
   })
 })

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/find.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/find.ts
@@ -684,10 +684,12 @@ export class FindProcessor extends BaseNodeProcessor {
 
       // The trace output carries the result under the SAME key the variable does
       // (see the keying note below), so a run trace and a `{{…}}` path never name
-      // the same value differently.
+      // the same value differently. Both find modes now key on the canonical
+      // `resource.id` — see the output-keying comment below for the findMany
+      // dual-write that keeps legacy plural-keyed refs alive alongside it.
       const pluralName = resource.plural.toLowerCase()
       const outputData = {
-        [findMode === 'findOne' ? resourceType : pluralName]: result,
+        [resourceType]: result,
         count: resultCount,
         query_info: {
           resource_type: resourceType,
@@ -702,16 +704,25 @@ export class FindProcessor extends BaseNodeProcessor {
 
       // Output keying — the contract the builder's variable picker advertises:
       //
-      // - `findOne`  → `<node>.<resource.id>`     (`generateFindNodeVariablesFromFields`
-      //                                            uses `resourceMeta.id` as the base path)
-      // - `findMany` → `<node>.<resource.plural>` (same generator, `plural.toLowerCase()`)
+      // - `findOne`  → `<node>.<resource.id>` (`generateFindNodeVariablesFromFields`
+      //                                        uses `resourceMeta.id` as the base path)
+      // - `findMany` → `<node>.<resource.id>` too, as of the plural-rename fix
+      //                (plans/kopilot/workflow/10-variable-resolution-deep-dive.md
+      //                §10 option A+C, §10b step 5). The array is ALSO written
+      //                under the legacy `<node>.<resource.plural.toLowerCase()>`
+      //                key (same array reference) — a back-compat alias for
+      //                `{{…}}` refs stored before the DataMigration rewrites
+      //                stored graphs onto the canonical key. Retire the legacy
+      //                write once that migration has run everywhere.
       //
-      // `findOne` deliberately does NOT key by `resource.label`. A label is
-      // user-editable, so renaming an entity would silently break every workflow
-      // reading its result, and the nine multi-word labels ('Knowledge Base',
-      // 'Work Order', 'Product / Service', …) lowercase into keys no `{{…}}` path
-      // can even address. `resource.id` is stable, addressable, and is already the
-      // key `setResourceVariables`/`setEntityVariables` use for triggers and CRUD.
+      // Neither mode keys by `resource.label`. A label is user-editable, so
+      // renaming an entity would silently break every workflow reading its
+      // result, and the nine multi-word labels ('Knowledge Base', 'Work Order',
+      // 'Product / Service', …) lowercase into keys no `{{…}}` path can even
+      // address (the plural has the same defect — see §10b for why the legacy
+      // key is an alias, not a design). `resource.id` is stable, addressable,
+      // and is already the key `setResourceVariables`/`setEntityVariables` use
+      // for triggers and CRUD.
       //
       // A template addresses a custom entity's result as `{{<node>.@entity:<slug>}}`;
       // `@entity:` refs are rewritten to the installing org's EntityDefinition cuid.
@@ -735,7 +746,14 @@ export class FindProcessor extends BaseNodeProcessor {
         }
       } else {
         if (isCustomResourceId(resourceType) && Array.isArray(result)) {
-          // Store ResourceReferences for each item + cache base entity data
+          // Store ResourceReferences for each item + cache base entity data.
+          // No per-item `setEntityVariables` call here (deliberate removal —
+          // see §3.5/§10c of the deep-dive doc): it used to write
+          // `<node>.<cuid>` + five subkeys per row, last-row-wins, undeclared
+          // and never advertised by the picker. Now that the array itself
+          // lives at `<node>.<resource.id>`, that stray write would clobber
+          // it. Items still resolve lazily through the ref lane —
+          // `cacheRecordBase` below seeds the base record the walker reads.
           const { createResourceReference } = await import('../../types/resource-reference')
           const refs = []
           for (const item of result) {
@@ -746,7 +764,6 @@ export class FindProcessor extends BaseNodeProcessor {
                 createdAt: item.createdAt,
                 updatedAt: item.updatedAt,
               }
-              setEntityVariables(resourceType, entityData, contextManager, node.nodeId)
 
               // Cache base data for recordFieldCache (field values load lazily)
               const recordId = toRecordId(resourceType, item.id)
@@ -754,10 +771,14 @@ export class FindProcessor extends BaseNodeProcessor {
               refs.push(createResourceReference(resourceType as any, item.id, organizationId))
             }
           }
-          // Store ResourceReference array under plural name for downstream consumption
+          // Dual-write: canonical `resource.id` key (the picker's advertised
+          // path going forward) plus the legacy plural-keyed alias, same
+          // array reference — see the output-keying comment above.
+          contextManager.setNodeVariable(node.nodeId, resourceType, refs)
           contextManager.setNodeVariable(node.nodeId, pluralName, refs)
         } else {
-          // System resources
+          // System resources — canonical id key + legacy plural alias.
+          contextManager.setNodeVariable(node.nodeId, resourceType, result)
           contextManager.setNodeVariable(node.nodeId, pluralName, result)
         }
       }

--- a/packages/lib/src/workflow-engine/parity/known-broken.ts
+++ b/packages/lib/src/workflow-engine/parity/known-broken.ts
@@ -101,7 +101,12 @@ const THREAD_STILL_BROKEN_OUTPUT_KEYS = new Set(
     .map((field) => getFieldOutputKey(field))
 )
 
-const TIER_A_FIELD_PATH_RE = /^[^.]+\.(thread|threads\[\*\])\.(.+)$/
+// findOne's root is `<n>.thread`, findMany's is `<n>.thread[*]` — both key on
+// the canonical `resource.id` ('thread') as of §10/§10b step 5; there is no
+// more `threads[*]` shape in the DECLARED tree (the legacy plural write is
+// still resolvable at runtime, it's just not declared — see
+// `FIND_MANY_LEGACY_PLURAL_ALIAS_REASON` below).
+const TIER_A_FIELD_PATH_RE = /^[^.]+\.thread(\[\*\])?\.(.+)$/
 
 function tierAFieldPathPin(id: string): string | undefined {
   const match = id.match(TIER_A_FIELD_PATH_RE)
@@ -183,36 +188,33 @@ export function matchDeclaredUnresolvablePin(id: string): string | undefined {
 // Invariant 2 — written ⊆ declared
 // =============================================================================
 
+// A former `FIND_MANY_STRAY_SINGULAR_KEY` entry lived here (findMany's
+// custom-entity loop called `setEntityVariables()` per item, which
+// unconditionally wrote the singular `<node>.<entityDefId>` key + five
+// subkeys as a side effect of building each `ResourceReference` —
+// last-item-wins, zero picker coverage). RETIRED by the findMany id-keying
+// change (§10/§10b step 5, `10-variable-resolution-deep-dive.md`): the array
+// itself now lives at `<node>.<entityDefId>`, so that stray per-item write
+// would have clobbered it — the fix removes the `setEntityVariables` call
+// from the loop entirely (see `find.ts`'s findMany/custom-entity branch),
+// not just the pin.
+
 /**
- * NEW BUG (undocumented before this suite): findMany on a custom entity
- * writes the SINGULAR resource-type key too, not just the plural array.
- *
- * `find.ts`'s findMany/custom-entity branch calls `setEntityVariables(resourceType,
- * entityData, contextManager, node.nodeId)` inside the per-item loop that
- * builds `ResourceReference`s for the plural array — but `setEntityVariables`
- * unconditionally writes `${nodeId}.${resourceType}` (the SAME key findOne
- * uses as its root) as a side effect of building each item's reference. Every
- * iteration overwrites it, so the final value is whichever item ran last.
- * `generateFindNodeVariablesFromFields`'s findMany branch never declares this
- * key — only findOne does — so it's a real, always-present write with zero
- * picker coverage on every custom-entity findMany.
- *
- * Fix (not made here): findMany's loop should call whatever piece of
- * `setEntityVariables` builds the `ResourceReference` and caches base data,
- * without the side-effecting `${nodeId}.${resourceType}` write meant for the
- * findOne singular case.
- *
- * Scoped to this suite's own node ids (`find_vendor_many`) rather than a bare
- * entity-def-id pattern, because the SAME key IS correctly declared and
- * covered for the findOne scenario — the id string alone can't tell the two
- * apart, only which scenario produced it can.
+ * DELIBERATE, not a bug: findMany dual-writes its result array under BOTH the
+ * canonical `<node>.<resource.id>` key (declared, covered) and the legacy
+ * `<node>.<resource.plural.toLowerCase()>` key — same array reference — so
+ * `{{node.<plural>…}}` refs stored before the plural-rename fix
+ * (§10/§10b step 5) keep resolving until the DataMigration rewrites stored
+ * graphs onto the canonical key. `generateFindNodeVariablesFromFields` only
+ * ever declares the id-keyed path, so the plural key is written-but-
+ * undeclared by design. Retire this pin together with the legacy write in
+ * `find.ts` once the migration has run everywhere.
  */
-const FIND_MANY_STRAY_SINGULAR_KEY_REASON =
-  "NEW BUG: find.ts's findMany/custom-entity branch calls setEntityVariables() per item, which " +
-  'unconditionally writes the singular `<node>.<entityDefId>` key (and its `.record_id`/`.created_at`/' +
-  '`.updated_at`/`.entityDefinitionId`/`.id` children) as a side effect of building each ' +
-  "ResourceReference — but generateFindNodeVariablesFromFields's findMany branch never declares " +
-  'that key, only findOne does. Last-item-wins, always present, zero picker coverage.'
+const FIND_MANY_LEGACY_PLURAL_ALIAS_REASON =
+  'DELIBERATE back-compat alias (§10/§10b step 5): find.ts dual-writes the findMany array under ' +
+  'both the canonical `<node>.<resource.id>` key (declared) and this legacy ' +
+  '`<node>.<resource.plural.toLowerCase()>` key so pre-migration `{{…}}` refs keep resolving. ' +
+  'Retire together with the dual-write once the plural→id DataMigration has run everywhere.'
 
 /**
  * Correct by design, not a bug — same class as `contract-drift-allowlist.ts`'s
@@ -233,10 +235,12 @@ const CRUD_DEFAULT_VALUE_DYNAMIC_KEY_REASON =
 
 const WRITTEN_UNDECLARED_PINS: Pin[] = [
   {
-    test: (key) =>
-      key.startsWith('find_vendor_many.vendorentitydefcuid00001') ||
-      key.startsWith('find_vendor_many.regionentitydefcuid00001'),
-    reason: FIND_MANY_STRAY_SINGULAR_KEY_REASON,
+    test: (key) => key === 'find_vendor_many.vendors',
+    reason: FIND_MANY_LEGACY_PLURAL_ALIAS_REASON,
+  },
+  {
+    test: (key) => key === 'find_thread_many.threads',
+    reason: FIND_MANY_LEGACY_PLURAL_ALIAS_REASON,
   },
   {
     test: (key) => key === 'crud_vendor_update_default.fallbackNote',

--- a/packages/lib/src/workflows/index.ts
+++ b/packages/lib/src/workflows/index.ts
@@ -32,6 +32,7 @@ export {
 } from './templates'
 // Export all types
 export * from './types'
+export { firstPathSegment, rewriteVariableRefs } from './variable-ref-rewriter'
 export {
   assertWorkflowAppNotSystemOwned,
   assertWorkflowRunNotSystemOwned,

--- a/packages/lib/src/workflows/template-resolution.ts
+++ b/packages/lib/src/workflows/template-resolution.ts
@@ -7,6 +7,7 @@ import { getAppCache, getOrgCache } from '../cache/singletons'
 import type { InstallTemplatesResult } from '../entity-templates/template-installer'
 import { getTemplateById as getEntityTemplateById } from '../entity-templates/template-registry'
 import type { WorkflowGraph } from './template-graph-transformer'
+import { firstPathSegment, rewriteVariableRefs } from './variable-ref-rewriter'
 
 export interface ResolvedApp {
   appId: string
@@ -246,9 +247,6 @@ export function resolveFieldsFromInstallerResult(
  */
 const PLACEHOLDER_TOKEN = /@(entity|field):([A-Za-z0-9_-]+)/g
 
-/** A `{{ … }}` variable span. Mirrors the engine's own pattern (`execution-context.ts`). */
-const VARIABLE_SPAN = /\{\{([^}]+)\}\}/g
-
 /** Everything the path rewriter needs to turn a placeholder into a concrete id. */
 interface PlaceholderContext {
   /** `@entity:<slug>` → entityTemplateId */
@@ -285,11 +283,6 @@ function resolveEntityPlaceholder(
   }
 }
 
-/** The first path segment of a variable reference (`find-1.orders[0].x` → `find-1`). */
-function firstPathSegment(path: string): string {
-  return path.trim().split(/[.[]/)[0] ?? ''
-}
-
 /**
  * Rewrite the placeholders inside one variable path (the text between `{{` and `}}`,
  * or a bare variable reference such as a Tiptap `variable-node` `variableId`).
@@ -323,68 +316,6 @@ function rewriteVariablePath(path: string, nodeId: string, ctx: PlaceholderConte
     }
     return fieldId
   })
-}
-
-/**
- * Apply `visit` to every variable path inside a single string, and only there —
- * the text between `{{` and `}}`, or the whole string when it is a bare variable
- * reference starting with a node id in this graph (the same shape
- * `TemplateGraphTransformer.cloneGraph` remaps node ids in, e.g. a Tiptap
- * `variable-node` `attrs.variableId`). Ordinary prose is returned untouched, so an
- * `@` that isn't a placeholder inside a variable reference can never be corrupted.
- */
-function mapStringVariablePaths(
-  value: string,
-  nodeIds: Set<string>,
-  visit: (path: string) => string
-): string {
-  if (!value.includes('@entity:') && !value.includes('@field:')) return value
-
-  if (value.includes('{{')) {
-    return value.replace(VARIABLE_SPAN, (_full, inner: string) => `{{${visit(inner)}}}`)
-  }
-
-  if (nodeIds.has(firstPathSegment(value))) {
-    return visit(value)
-  }
-
-  return value
-}
-
-/**
- * Walk every value under a node's `data` and run `visit` over the variable paths
- * found in each string, substituting whatever it returns.
- *
- * Object *keys* are deliberately left alone — `data` / `fieldModes` /
- * `fieldUpdateModes*` keys are rewritten by the config pass, and `$comment` is
- * template-authoring prose that must never be touched.
- */
-function mapVariablePaths(
-  value: unknown,
-  nodeIds: Set<string>,
-  visit: (path: string) => string
-): unknown {
-  if (typeof value === 'string') {
-    return mapStringVariablePaths(value, nodeIds, visit)
-  }
-
-  if (Array.isArray(value)) {
-    for (let i = 0; i < value.length; i++) {
-      value[i] = mapVariablePaths(value[i], nodeIds, visit)
-    }
-    return value
-  }
-
-  if (value && typeof value === 'object') {
-    const record = value as Record<string, unknown>
-    for (const key of Object.keys(record)) {
-      if (key === '$comment') continue
-      record[key] = mapVariablePaths(record[key], nodeIds, visit)
-    }
-    return record
-  }
-
-  return value
 }
 
 /**
@@ -559,7 +490,7 @@ export function resolveEntityRefsInGraph(
 
   for (const node of graph.nodes) {
     if (!node.data || typeof node.data !== 'object') continue
-    mapVariablePaths(node.data, nodeIds, (path) =>
+    rewriteVariableRefs(node.data, nodeIds, (path) =>
       rewriteVariablePath(path, node.id, placeholderCtx)
     )
   }
@@ -614,7 +545,7 @@ export function extractRequiredEntities(graph: WorkflowGraph): Partial<RequiredE
 
   for (const node of graph.nodes) {
     if (!node.data || typeof node.data !== 'object') continue
-    mapVariablePaths(node.data, nodeIds, (path) => {
+    rewriteVariableRefs(node.data, nodeIds, (path) => {
       let currentSlug = nodeSlugs.get(firstPathSegment(path))
       for (const match of path.matchAll(PLACEHOLDER_TOKEN)) {
         const [, kind, ref] = match as unknown as [string, string, string]

--- a/packages/lib/src/workflows/variable-ref-rewriter.ts
+++ b/packages/lib/src/workflows/variable-ref-rewriter.ts
@@ -1,0 +1,108 @@
+// packages/lib/src/workflows/variable-ref-rewriter.ts
+
+/**
+ * Generic graph-walking variable-reference rewriter.
+ *
+ * Extracted from `template-resolution.ts` (originally `rewriteVariablePath` /
+ * `mapStringVariablePaths` / `mapVariablePaths`, the machinery behind
+ * `@entity:`/`@field:` placeholder resolution at template install). Shared by:
+ *
+ * - Template install (`template-resolution.ts`'s `resolveEntityRefsInGraph`)
+ * - The findMany plural→id `{{…}}` ref DataMigration
+ *   (`plans/kopilot/workflow/10-variable-resolution-deep-dive.md` §10b step 5)
+ * - (future) paste-node ref rewriting — §4/§10b #5 of the same doc
+ *
+ * See that doc for the full identity-model background.
+ */
+
+/** A `{{ … }}` variable span. Mirrors the engine's own pattern (`execution-context.ts`). */
+const VARIABLE_SPAN = /\{\{([^}]+)\}\}/g
+
+/** The first path segment of a variable reference (`find-1.orders[0].x` → `find-1`). */
+export function firstPathSegment(path: string): string {
+  return path.trim().split(/[.[]/)[0] ?? ''
+}
+
+/**
+ * Apply `mapPath` to every variable path inside a single string, and only there —
+ * the text between `{{` and `}}`, or the whole string when it is a bare variable
+ * reference starting with a node id in `nodeIds` (the shape a Tiptap `variable-node`
+ * `attrs.variableId`, or a bare config field like `itemsSource`/`variableId`, stores).
+ * Ordinary prose is returned untouched, so text that merely contains a `.` or a node
+ * id as a substring can never be corrupted.
+ */
+function mapStringVariablePaths(
+  value: string,
+  nodeIds: Set<string>,
+  mapPath: (path: string) => string
+): string {
+  if (value.includes('{{')) {
+    return value.replace(VARIABLE_SPAN, (_full, inner: string) => `{{${mapPath(inner)}}}`)
+  }
+
+  if (nodeIds.has(firstPathSegment(value))) {
+    return mapPath(value)
+  }
+
+  return value
+}
+
+/**
+ * Walk every value under `nodeData` and run `mapPath` over the variable paths found
+ * in each string, substituting whatever it returns.
+ *
+ * Object *keys* are deliberately left alone — callers that also need to rewrite
+ * keys (e.g. `@field:` placeholder keys) do that in a separate pass before calling
+ * this one. `$comment` is template-authoring prose and is never touched.
+ */
+function mapVariablePaths(
+  value: unknown,
+  nodeIds: Set<string>,
+  mapPath: (path: string) => string
+): unknown {
+  if (typeof value === 'string') {
+    return mapStringVariablePaths(value, nodeIds, mapPath)
+  }
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      value[i] = mapVariablePaths(value[i], nodeIds, mapPath)
+    }
+    return value
+  }
+
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    for (const key of Object.keys(record)) {
+      if (key === '$comment') continue
+      record[key] = mapVariablePaths(record[key], nodeIds, mapPath)
+    }
+    return record
+  }
+
+  return value
+}
+
+/**
+ * Rewrite every `{{…}}` variable span and bare variable-id reference inside
+ * `nodeData`, applying `mapPath` to each path string found. Object keys are left
+ * untouched. Mutates `nodeData` in place (arrays/objects) and returns it — callers
+ * that need immutability should clone first, matching the original
+ * `resolveEntityRefsInGraph` contract ("caller should clone first").
+ *
+ * `nodeIds` scopes which bare (non-`{{…}}`) strings are treated as variable
+ * references — a bare string is only rewritten when its first path segment names a
+ * node in `nodeIds`, so ordinary text fields are never touched.
+ *
+ * `mapPath` should be a no-op (return the input unchanged) for any path it doesn't
+ * recognize — it runs over every `{{…}}` span and every node-id-prefixed bare
+ * string in the data, whether or not that specific path is the one the caller
+ * cares about.
+ */
+export function rewriteVariableRefs<T>(
+  nodeData: T,
+  nodeIds: Set<string>,
+  mapPath: (path: string) => string
+): T {
+  return mapVariablePaths(nodeData, nodeIds, mapPath) as T
+}


### PR DESCRIPTION
§10b step 5 — the finale of the variable-resolution sequence, fixing the deep dive's headline bug (§3.1): findMany output keyed on `resource.plural.toLowerCase()`, a **user-editable string**, so renaming an entity's plural silently broke every stored `{{node.<plural>…}}` reference — old refs interpolate to empty string, the trace displays the new key (confirming the wrong thing), and any loop iterating the result degrades its `item` to untyped `ANY`. findOne got this fix in #1551; findMany deliberately didn't, until now.

## Engine — dual-write + a two-birds removal

- The results array lands under **canonical `resource.id`** AND the **legacy plural key** (same array reference; retirement conditions commented inline). Nothing breaks for existing graphs before the migration runs.
- The per-item `setEntityVariables` call in the findMany loop is **removed**: it wrote the undeclared, last-row-wins `<node>.<cuid>` stray key (deep dive §3.5, pinned by the resolvability suite) — which would now collide with the canonical array key. One removal fixes both; items still resolve lazily via `cacheRecordBase` + the walker's ref lane. The suite's stray-key pin retires per its self-retiring contract.
- Trace `outputData` keys on the canonical id for both find modes.

## Declared side

Array/items keyed on `resourceMeta.id`; **`label` stays the plural** — display names are contract (the picker keeps showing "Vendors", never a CUID; the suite's label invariant enforces this). Golden snapshot updated — the one sanctioned change, commented in the test.

## Shared rewriter

`workflows/variable-ref-rewriter.ts` — the template installer's variable-path rewriting machinery, extracted generic (`rewriteVariableRefs`). Template behavior unchanged (37 tests untouched). This is the same tool the paste ref-rewriting fix (§10b step 6) will use.

## DataMigration 083 — written, registered, **NOT yet run**

Rewrites stored `{{<findNode>.<plural>…}}` refs onto the canonical id form: cursor-paginated over every `Workflow` row (drafts + published versions), per-org three-way `resourceType` resolution (id | entityType | apiSlug — the engine's own match), prefix rewrite **scoped per find node** (never a blanket plural replace, boundary-safe against `vendor`/`vendors` collisions), idempotent by construction, templates excluded (`@entity:` tokens, no literal keys). 12 pure-logic unit tests. Run on dev after merge → verify logged rewrite counts → prod; the legacy dual-write + its alias pin retire after it has run everywhere.

## Verification

- Resolvability + parity suites green (stray-key pin retired, legacy-alias pin added, tier-A pattern updated for the new `thread[*]` root)
- `find-output-keying.test.ts` findMany block flipped: asserts canonical + alias dual-write incl. the multi-word `knowledge bases` case
- `packages/lib` engine/resources/workflows/data-migrations: 1,800+ tests green; golden snapshots show only the sanctioned findMany id change
- typecheck ratchets: lib 29/29, web 1/1; `apps/web` workflow suite 100/100; biome clean