### PR TITLE
fix(workflow): paste ref rewriting, output-var labels, declared-var gaps

### DIFF
--- a/apps/web/src/components/workflow/hooks/__tests__/use-node-interactions.paste.test.ts
+++ b/apps/web/src/components/workflow/hooks/__tests__/use-node-interactions.paste.test.ts
@@ -1,0 +1,199 @@
+// apps/web/src/components/workflow/hooks/__tests__/use-node-interactions.paste.test.ts
+//
+// Paste/duplicate builds `idMapping[oldNodeId] = newNodeId` and applies it to
+// node ids and edges, but historically never walked `node.data` — a pasted
+// node's `{{oldNodeId.…}}` refs (and bare variable-id attrs) kept pointing at
+// the ORIGINAL nodes' outputs. Fixed by rewriting each pasted node's `data`
+// with `rewriteVariableRefs` (`@auxx/lib/workflows/variable-ref-rewriter`)
+// after a deep clone. This suite proves: a ref between two pasted nodes gets
+// remapped to the new id regardless of clipboard iteration order, a ref to a
+// node OUTSIDE the paste set is left untouched, and the original nodes' data
+// is never mutated by the paste.
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FlowEdge, FlowNode } from '~/components/workflow/types'
+
+const h = vi.hoisted(() => ({
+  /** The xyflow store's `nodes`/`edges`, and the setters under test. */
+  nodes: [] as FlowNode[],
+  edges: [] as FlowEdge[],
+  setNodes: vi.fn(),
+  setEdges: vi.fn(),
+  /** Clipboard, as populated by a prior `handleCopyNode` (direct references, not clones). */
+  clipboardElements: [] as FlowNode[],
+  /** Sequential, inspectable replacement for `generateId()`. */
+  generateId: vi.fn(),
+}))
+
+vi.mock('@xyflow/react', () => ({
+  getConnectedEdges: vi.fn(() => []),
+  useReactFlow: () => ({ screenToFlowPosition: (p: unknown) => p }),
+  useStoreApi: () => ({
+    getState: () => ({
+      nodes: h.nodes,
+      setNodes: h.setNodes,
+      edges: h.edges,
+      setEdges: h.setEdges,
+    }),
+  }),
+}))
+
+vi.mock('@auxx/ui/components/toast', () => ({
+  toastError: vi.fn(),
+  toastInfo: vi.fn(),
+  toastSuccess: vi.fn(),
+}))
+
+vi.mock('@auxx/utils', () => ({ uniqueBy: (arr: unknown[]) => arr }))
+vi.mock('@auxx/utils/generateId', () => ({ generateId: h.generateId }))
+
+vi.mock('~/components/workflow/hooks', () => ({
+  useHelpline: () => ({ handleSetHelpline: vi.fn(), handleClearHelpline: vi.fn() }),
+  useNodesReadOnly: () => ({ getNodesReadOnly: () => false }),
+  useNodeValidation: () => ({ isValidConnection: vi.fn() }),
+  useSelectionActions: () => ({ selectNode: vi.fn() }),
+  useWorkflowSave: () => ({ debouncedSave: vi.fn() }),
+}))
+
+vi.mock('~/components/workflow/nodes/unified-registry', () => ({
+  ALLOW_TRIGGER_DELETE: true,
+  unifiedNodeRegistry: { isTrigger: () => false },
+}))
+
+vi.mock('~/components/workflow/store/event-bus', () => ({
+  storeEventBus: { emit: vi.fn() },
+}))
+
+vi.mock('~/components/workflow/store/panel-store', () => ({
+  usePanelStore: (selector: (state: unknown) => unknown) =>
+    selector({ closePanel: vi.fn(), isPinned: false }),
+}))
+
+vi.mock('~/components/workflow/store/workflow-store', () => ({
+  useWorkflowStore: {
+    getState: () => ({
+      clipboardElements: h.clipboardElements,
+      setClipboardElements: vi.fn(),
+      setDragging: vi.fn(),
+    }),
+  },
+}))
+
+vi.mock('~/components/workflow/utils', () => ({
+  getNodesConnectedSourceOrTargetHandleIdsMap: vi.fn(),
+}))
+vi.mock('~/components/workflow/utils/edge-utils', () => ({ calculateZIndex: vi.fn(() => 0) }))
+vi.mock('~/components/workflow/utils/layout-constants', () => ({
+  LAYOUT_SPACING: { NODE_HORIZONTAL_PADDING: 0, NODE_VERTICAL_PADDING: 0 },
+}))
+vi.mock('~/components/workflow/utils/node-layout', () => ({ NodeFactory: { createNode: vi.fn() } }))
+// Identity — this suite isn't about title de-duplication.
+vi.mock('~/components/workflow/utils/unique-title-generator', () => ({
+  generateUniqueTitle: (title: string) => title,
+}))
+vi.mock('~/components/workflow/utils/viewport-utils', () => ({ centerOnNode: vi.fn() }))
+
+vi.mock('../use-save-to-history', () => ({
+  useWorkflowHistory: () => ({ saveStateToHistory: vi.fn() }),
+  WorkflowHistoryEvent: { NodePaste: 'NodePaste' },
+}))
+
+import { useNodesInteractions } from '../use-node-interactions'
+
+/** Builds a minimal FlowNode fixture. `data` carries the fields this suite exercises. */
+function buildNode(id: string, data: Record<string, unknown>, position = { x: 0, y: 0 }): FlowNode {
+  return {
+    id,
+    position,
+    selected: true,
+    data: { id, type: 'action', title: `Node ${id}`, ...data },
+  } as unknown as FlowNode
+}
+
+describe('useNodesInteractions — paste rewrites variable references', () => {
+  beforeEach(() => {
+    h.setNodes.mockClear()
+    h.setEdges.mockClear()
+    let counter = 0
+    h.generateId.mockReset().mockImplementation((prefix?: string) => {
+      counter += 1
+      return prefix ? `${prefix}-${counter}` : `new-${counter}`
+    })
+  })
+
+  it('remaps a ref between two pasted nodes, leaves a ref to an unselected node untouched, and never mutates the originals', () => {
+    // Canvas: nodeA -> nodeB (both about to be pasted), plus nodeC, which
+    // stays put and is NOT part of the paste set.
+    const nodeA = buildNode('a1', {
+      config: { note: 'unrelated ref: {{c1.value}}' },
+    })
+    const nodeB = buildNode('b1', {
+      config: {
+        message: 'Value: {{a1.output}}',
+        // Bare (non-`{{…}}`) variable-id reference, the shape a Tiptap
+        // `variable-node`'s `attrs.variableId` stores.
+        bareVar: 'a1.output[0].x',
+      },
+    })
+    const nodeC = buildNode('c1', { config: { note: 'stays on canvas' } })
+
+    // Snapshot the exact objects the paste must not touch.
+    const originalNodeAConfig = { ...((nodeA.data as { config: unknown }).config as object) }
+    const originalNodeBConfig = { ...((nodeB.data as { config: unknown }).config as object) }
+
+    h.nodes = [nodeA, nodeB, nodeC]
+    h.edges = [
+      {
+        id: 'e-a1-b1',
+        source: 'a1',
+        target: 'b1',
+        sourceHandle: 'source',
+        targetHandle: 'target',
+        data: {},
+      } as unknown as FlowEdge,
+    ]
+    // Clipboard holds direct references to the copied nodes (as the real
+    // `handleCopyNode` stores them) — reversed order from canvas, so a naive
+    // single-pass id assignment (old bug shape) would fail to resolve nodeB's
+    // ref to nodeA in time.
+    h.clipboardElements = [nodeB, nodeA]
+
+    const { result } = renderHook(() => useNodesInteractions())
+    result.current.handleNodesPaste()
+
+    expect(h.setNodes).toHaveBeenCalledOnce()
+    const nextNodes = h.setNodes.mock.calls[0]![0] as FlowNode[]
+    const pastedNodes = nextNodes.filter((n) => n.id !== 'a1' && n.id !== 'b1' && n.id !== 'c1')
+    expect(pastedNodes).toHaveLength(2)
+
+    const pastedA = pastedNodes.find((n) => (n.data as { config: any }).config.note)!
+    const pastedB = pastedNodes.find((n) => (n.data as { config: any }).config.message)!
+    expect(pastedA).toBeDefined()
+    expect(pastedB).toBeDefined()
+
+    const newIdA = pastedA.id
+    const newIdB = pastedB.id
+    expect(newIdA).not.toBe('a1')
+    expect(newIdB).not.toBe('b1')
+
+    // The ref to the OTHER pasted node is remapped to its new id.
+    expect((pastedB.data as { config: any }).config.message).toBe(`Value: {{${newIdA}.output}}`)
+    // Bare (non-`{{…}}`) variable-id refs are rewritten the same way.
+    expect((pastedB.data as { config: any }).config.bareVar).toBe(`${newIdA}.output[0].x`)
+    // The ref to c1 — NOT in the paste set — survives untouched.
+    expect((pastedA.data as { config: any }).config.note).toBe('unrelated ref: {{c1.value}}')
+
+    // The pasted edge follows the same id remapping.
+    expect(h.setEdges).toHaveBeenCalledOnce()
+    const nextEdges = h.setEdges.mock.calls[0]![0] as FlowEdge[]
+    const pastedEdge = nextEdges.find((e) => e.id !== 'e-a1-b1')!
+    expect(pastedEdge).toBeDefined()
+    expect(pastedEdge.source).toBe(newIdA)
+    expect(pastedEdge.target).toBe(newIdB)
+
+    // The originals are byte-for-byte unmutated — paste must not corrupt them.
+    expect((nodeA.data as { config: unknown }).config).toEqual(originalNodeAConfig)
+    expect((nodeB.data as { config: unknown }).config).toEqual(originalNodeBConfig)
+  })
+})

--- a/apps/web/src/components/workflow/hooks/use-node-interactions.ts
+++ b/apps/web/src/components/workflow/hooks/use-node-interactions.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/workflow/hooks/use-node-interactions.ts
 
+import { firstPathSegment, rewriteVariableRefs } from '@auxx/lib/workflows/variable-ref-rewriter'
 import { toastError, toastInfo, toastSuccess } from '@auxx/ui/components/toast'
 import { uniqueBy } from '@auxx/utils'
 import { generateId } from '@auxx/utils/generateId'
@@ -269,15 +270,42 @@ export const useNodesInteractions = () => {
       const offsetX = pastePosition.x - minX
       const offsetY = pastePosition.y - minY
 
-      // Create ID mapping for nodes
+      // Create ID mapping for nodes. Assigned in its own pass, up front, so that
+      // every pasted node's new id is known before any node.data gets rewritten —
+      // a pasted node can reference another pasted node regardless of clipboard
+      // iteration order.
       const idMapping: Record<string, string> = {}
+      clipboardElements.forEach((node) => {
+        idMapping[node.id] = generateId()
+      })
+      // The OLD ids being pasted — gates which bare (non-`{{…}}`) strings in
+      // node.data are treated as variable references at all (see
+      // `rewriteVariableRefs`). Refs to nodes outside this set (e.g. an upstream
+      // node that stayed put) are left untouched.
+      const pastedOldNodeIds = new Set(Object.keys(idMapping))
+      const mapVariablePath = (path: string): string => {
+        const segment = firstPathSegment(path)
+        const mappedSegment = idMapping[segment]
+        return mappedSegment ? mappedSegment + path.slice(segment.length) : path
+      }
+
       const nodesToPaste: FlowNode[] = []
 
       // Paste nodes with new IDs
       clipboardElements.forEach((node) => {
-        const nodeData = node.data
-        const newId = generateId()
-        idMapping[node.id] = newId
+        const newId = idMapping[node.id]
+        // Guaranteed present — idMapping was built from this same clipboardElements
+        // list above. Guard only to satisfy noUncheckedIndexedAccess.
+        if (!newId) return
+        // Deep-clone before rewriting: clipboard nodes hold direct references to
+        // the copied nodes' data (see handleCopyNode), and rewriteVariableRefs
+        // mutates in place — without this, pasting would rewrite the ORIGINAL
+        // node's `{{…}}` refs too.
+        const nodeData = rewriteVariableRefs(
+          structuredClone(node.data),
+          pastedOldNodeIds,
+          mapVariablePath
+        )
 
         // Calculate zIndex if node has parentId
         let zIndex = node.zIndex || 0
@@ -323,7 +351,7 @@ export const useNodesInteractions = () => {
       setNodes([...nodes, ...nodesToPaste])
 
       // Handle edges between pasted nodes
-      const clipboardNodeIds = new Set(clipboardElements.map((n) => n.id))
+      const clipboardNodeIds = pastedOldNodeIds
       const edgesToPaste: FlowEdge[] = []
 
       // Find all edges that connect clipboard nodes

--- a/apps/web/src/components/workflow/ui/output-variables/output-variables-display.tsx
+++ b/apps/web/src/components/workflow/ui/output-variables/output-variables-display.tsx
@@ -25,8 +25,12 @@ function unifiedVariableToDisplayVariable(variable: UnifiedVariable): DisplayVar
   // Handle object types with properties - recursively process each property
   if (variable.type === BaseType.OBJECT && variable.properties) {
     displayVar.subItems = Object.entries(variable.properties).map(([key, prop]) => {
-      // Create a child variable with proper label and recursively convert it
-      const childVariable: UnifiedVariable = { ...prop, label: key }
+      // Prefer the property's own label over its record key: for custom-entity
+      // fields the key IS the CustomField CUID (rename-proof by design,
+      // `resource-registry-service.ts` `key: field.id`), so rendering the key
+      // shows an id where a name belongs. The key is only a fallback for
+      // properties that genuinely carry no label.
+      const childVariable: UnifiedVariable = { ...prop, label: prop.label || key }
       return unifiedVariableToDisplayVariable(childVariable)
     })
   }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1395,6 +1395,12 @@
       "source": "./src/workflows/index.ts",
       "import": "./dist/workflows/index.mjs",
       "default": "./src/workflows/index.ts"
+    },
+    "./workflows/variable-ref-rewriter": {
+      "types": "./src/workflows/variable-ref-rewriter.ts",
+      "source": "./src/workflows/variable-ref-rewriter.ts",
+      "import": "./dist/workflows/variable-ref-rewriter.mjs",
+      "default": "./src/workflows/variable-ref-rewriter.ts"
     }
   },
   "scripts": {

--- a/packages/lib/src/conditions/operator-definitions.test.ts
+++ b/packages/lib/src/conditions/operator-definitions.test.ts
@@ -1,0 +1,84 @@
+// packages/lib/src/conditions/operator-definitions.test.ts
+
+import { FieldType, FieldTypeValues } from '@auxx/database/enums'
+import { describe, expect, it, vi } from 'vitest'
+import { BaseType } from '../workflow-engine/core/types'
+import { mapFieldTypeToBaseType as mapFieldTypeToBaseTypeForWorkflow } from '../workflow-engine/utils/field-type-mapper'
+import { mapFieldTypeToBaseType as mapFieldTypeToBaseTypeForConditions } from './operator-definitions'
+
+/**
+ * Two independent `mapFieldTypeToBaseType` copies exist — this one
+ * (`conditions/operator-definitions.ts`) and
+ * `workflow-engine/utils/field-type-mapper.ts`. Both are now exhaustive
+ * switches over every `FieldType` member (a new member fails to compile in
+ * either file, via a `const _exhaustive: never` guard), but they are
+ * deliberately NOT unified: `ADDRESS`, `CALC`, and the unknown/default
+ * fallback diverge on purpose (see the comment above each function). This
+ * table pins those divergences AS divergences — if either function's output
+ * for a shared case ever drifts apart from this table, that's a real
+ * regression; if `ADDRESS`/`CALC`/default ever start agreeing, that's fine,
+ * but this test should be updated deliberately, not by an unrelated change.
+ */
+const EXPECTED: Record<
+  (typeof FieldTypeValues)[number],
+  { workflow: BaseType; conditions: BaseType }
+> = {
+  TEXT: { workflow: BaseType.STRING, conditions: BaseType.STRING },
+  NAME: { workflow: BaseType.STRING, conditions: BaseType.STRING },
+  RICH_TEXT: { workflow: BaseType.STRING, conditions: BaseType.STRING },
+  NUMBER: { workflow: BaseType.NUMBER, conditions: BaseType.NUMBER },
+  EMAIL: { workflow: BaseType.EMAIL, conditions: BaseType.EMAIL },
+  URL: { workflow: BaseType.URL, conditions: BaseType.URL },
+  PHONE_INTL: { workflow: BaseType.PHONE, conditions: BaseType.PHONE },
+  DATE: { workflow: BaseType.DATE, conditions: BaseType.DATE },
+  DATETIME: { workflow: BaseType.DATETIME, conditions: BaseType.DATETIME },
+  TIME: { workflow: BaseType.TIME, conditions: BaseType.TIME },
+  CHECKBOX: { workflow: BaseType.BOOLEAN, conditions: BaseType.BOOLEAN },
+  TAGS: { workflow: BaseType.TAGS, conditions: BaseType.TAGS },
+  SINGLE_SELECT: { workflow: BaseType.ENUM, conditions: BaseType.ENUM },
+  MULTI_SELECT: { workflow: BaseType.ARRAY, conditions: BaseType.ARRAY },
+  // Intentional divergence: free-text address (workflow) vs. structured
+  // address operator set (conditions).
+  ADDRESS: { workflow: BaseType.STRING, conditions: BaseType.ADDRESS },
+  ADDRESS_STRUCT: { workflow: BaseType.ADDRESS, conditions: BaseType.ADDRESS },
+  CURRENCY: { workflow: BaseType.CURRENCY, conditions: BaseType.CURRENCY },
+  FILE: { workflow: BaseType.FILE, conditions: BaseType.FILE },
+  RELATIONSHIP: { workflow: BaseType.RELATION, conditions: BaseType.RELATION },
+  // Intentional divergence: workflow treats an unrecognized CALC as its
+  // generic unknown-type fallback (STRING, with a console warning) because a
+  // CALC field reaching a workflow node is unexpected; conditions maps CALC
+  // to ANY on purpose so every operator stays a candidate for it.
+  CALC: { workflow: BaseType.STRING, conditions: BaseType.ANY },
+  ACTOR: { workflow: BaseType.ACTOR, conditions: BaseType.ACTOR },
+  JSON: { workflow: BaseType.JSON, conditions: BaseType.JSON },
+}
+
+describe('mapFieldTypeToBaseType — workflow vs. conditions', () => {
+  it('covers every FieldType member (guards the pinned table above against enum drift)', () => {
+    expect(Object.keys(EXPECTED).sort()).toEqual([...FieldTypeValues].sort())
+  })
+
+  it.each(FieldTypeValues)('%s', (fieldType) => {
+    const expected = EXPECTED[fieldType]
+    expect(mapFieldTypeToBaseTypeForWorkflow(fieldType)).toBe(expected.workflow)
+    expect(mapFieldTypeToBaseTypeForConditions(fieldType)).toBe(expected.conditions)
+  })
+
+  it('falls back — workflow warns and defaults to STRING, conditions fails open to ANY', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      expect(mapFieldTypeToBaseTypeForWorkflow('NOT_A_REAL_FIELD_TYPE')).toBe(BaseType.STRING)
+      expect(warn).toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
+
+    expect(mapFieldTypeToBaseTypeForConditions('NOT_A_REAL_FIELD_TYPE')).toBe(BaseType.ANY)
+  })
+
+  it('sanity: FieldType is still a real member of the const object used in switches', () => {
+    for (const fieldType of FieldTypeValues) {
+      expect(FieldType).toHaveProperty(fieldType, fieldType)
+    }
+  })
+})

--- a/packages/lib/src/conditions/operator-definitions.ts
+++ b/packages/lib/src/conditions/operator-definitions.ts
@@ -1,6 +1,11 @@
 // packages/lib/src/conditions/operator-definitions.ts
 
 import { FieldType } from '@auxx/database/enums'
+// `FieldType` above is the runtime value map (used as `FieldType.TEXT` etc.
+// throughout this file); the type-level union is imported separately under
+// its own name so `mapFieldTypeToBaseType` below can be typed against it
+// without renaming the ~170 existing `FieldType.<MEMBER>` value references.
+import type { FieldType as FieldTypeValue } from '@auxx/database/types'
 import { BaseType } from '../workflow-engine/core/types'
 
 /**
@@ -856,34 +861,86 @@ export function getOperatorsByCategory(
 /**
  * Maps FieldType to BaseType for fallback operator lookup
  * Used when supportedFieldTypes is not defined on an operator
+ *
+ * The switch is exhaustive over every `FieldType` member (see `_exhaustive`
+ * below): adding a new member to the enum without a case here fails to
+ * compile, instead of silently falling through to the ANY default. NOT
+ * unified with `workflow-engine/utils/field-type-mapper.ts`'s own
+ * `mapFieldTypeToBaseType` on purpose — their `ADDRESS`/`CALC`/default
+ * outputs genuinely diverge:
+ *  - `ADDRESS` maps to `BaseType.ADDRESS` here (vs. STRING there) because
+ *    resource-condition operators key off the structured address operator
+ *    set, not the free-text one.
+ *  - `CALC` maps to `BaseType.ANY` here (calculated fields aren't typically
+ *    filterable, so every operator stays a candidate) rather than STRING.
+ *  - The default/unknown case returns `BaseType.ANY` here, not STRING —
+ *    `getOperatorsForBaseType(ANY)` returns every operator, so this is a
+ *    fail-OPEN default (an unrecognized field type still gets a full
+ *    operator list). Changing this to STRING would silently narrow which
+ *    operators resource conditions offer for any field type this function
+ *    doesn't recognize.
  */
-export function mapFieldTypeToBaseType(fieldType: string): BaseType {
-  const mapping: Record<string, BaseType> = {
-    [FieldType.TEXT]: BaseType.STRING,
-    [FieldType.NAME]: BaseType.STRING,
-    [FieldType.RICH_TEXT]: BaseType.STRING,
-    [FieldType.EMAIL]: BaseType.EMAIL,
-    [FieldType.URL]: BaseType.URL,
-    [FieldType.PHONE_INTL]: BaseType.PHONE,
-    [FieldType.NUMBER]: BaseType.NUMBER,
-    [FieldType.CURRENCY]: BaseType.CURRENCY,
-    [FieldType.CHECKBOX]: BaseType.BOOLEAN,
-    [FieldType.SINGLE_SELECT]: BaseType.ENUM,
-    [FieldType.MULTI_SELECT]: BaseType.ARRAY,
-    [FieldType.TAGS]: BaseType.TAGS,
-    [FieldType.DATE]: BaseType.DATE,
-    [FieldType.DATETIME]: BaseType.DATETIME,
-    [FieldType.TIME]: BaseType.TIME,
-    [FieldType.FILE]: BaseType.FILE,
-    [FieldType.RELATIONSHIP]: BaseType.RELATION,
-    [FieldType.ACTOR]: BaseType.ACTOR,
-    [FieldType.ADDRESS]: BaseType.ADDRESS,
-    [FieldType.ADDRESS_STRUCT]: BaseType.ADDRESS,
-    [FieldType.JSON]: BaseType.JSON,
-    [FieldType.CALC]: BaseType.ANY, // Calculated fields - not typically filterable
+export function mapFieldTypeToBaseType(fieldType: FieldTypeValue | string): BaseType {
+  // Cast only to enable switch-exhaustiveness checking against every real
+  // `FieldType` member below — the parameter still accepts arbitrary strings,
+  // and a genuinely-invalid one still flows to `default` at runtime exactly
+  // as before.
+  const type = fieldType as FieldTypeValue
+  switch (type) {
+    case FieldType.TEXT:
+    case FieldType.NAME:
+    case FieldType.RICH_TEXT:
+      return BaseType.STRING
+    case FieldType.EMAIL:
+      return BaseType.EMAIL
+    case FieldType.URL:
+      return BaseType.URL
+    case FieldType.PHONE_INTL:
+      return BaseType.PHONE
+    case FieldType.NUMBER:
+      return BaseType.NUMBER
+    case FieldType.CURRENCY:
+      return BaseType.CURRENCY
+    case FieldType.CHECKBOX:
+      return BaseType.BOOLEAN
+    case FieldType.SINGLE_SELECT:
+      return BaseType.ENUM
+    case FieldType.MULTI_SELECT:
+      return BaseType.ARRAY
+    case FieldType.TAGS:
+      return BaseType.TAGS
+    case FieldType.DATE:
+      return BaseType.DATE
+    case FieldType.DATETIME:
+      return BaseType.DATETIME
+    case FieldType.TIME:
+      return BaseType.TIME
+    case FieldType.FILE:
+      return BaseType.FILE
+    case FieldType.RELATIONSHIP:
+      return BaseType.RELATION
+    case FieldType.ACTOR:
+      return BaseType.ACTOR
+    case FieldType.ADDRESS:
+      return BaseType.ADDRESS
+    case FieldType.ADDRESS_STRUCT:
+      return BaseType.ADDRESS
+    case FieldType.JSON:
+      return BaseType.JSON
+    case FieldType.CALC:
+      // Calculated fields - not typically filterable
+      return BaseType.ANY
+    default: {
+      // Exhaustiveness guard: once every `FieldType` member has its own case
+      // above, `type` narrows to `never` here. A new enum member added
+      // without a matching case fails this assignment at compile time. Still
+      // reachable at runtime for a raw string that isn't a real FieldType —
+      // same fail-open ANY fallback as before.
+      const _exhaustive: never = type
+      void _exhaustive
+      return BaseType.ANY
+    }
   }
-
-  return mapping[fieldType] ?? BaseType.ANY
 }
 
 /**

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/crud.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/crud.ts
@@ -603,6 +603,12 @@ export class CrudNodeProcessor extends BaseNodeProcessor {
       contextManager.setNodeVariable(node.nodeId, 'resourceType', canonicalResourceType)
       contextManager.setNodeVariable(node.nodeId, 'success', true)
       contextManager.setNodeVariable(node.nodeId, 'error', null)
+      // `generateCrudNodeVariablesFromFields` declares `errorDetails`
+      // unconditionally for every crud mode, but only `handleCrudError` (the
+      // catch branch) used to write it — a run that succeeds outright left it
+      // permanently unresolvable. Write it here, next to `error`, so it
+      // resolves to null on success too.
+      contextManager.setNodeVariable(node.nodeId, 'errorDetails', null)
 
       // Delete: write the variables `generateCrudNodeVariablesFromFields` declares
       // for delete mode (`deleted`, `id`) — the operation returns exactly this shape
@@ -1366,6 +1372,13 @@ export class CrudNodeProcessor extends BaseNodeProcessor {
             },
           }
         }
+        // No default values configured — `usedDefaults`/`defaultValues` are
+        // declared by the builder whenever the strategy is `default`, for
+        // every resource type, same as the branch above. Write them here too
+        // before falling through to `fail`, so they still resolve on this run
+        // instead of being left permanently unresolvable.
+        contextManager.setNodeVariable(node.nodeId, 'usedDefaults', false)
+        contextManager.setNodeVariable(node.nodeId, 'defaultValues', null)
       // Fall through to fail if no defaults configured
       case 'fail':
       default:

--- a/packages/lib/src/workflow-engine/parity/crud.resolvability.test.ts
+++ b/packages/lib/src/workflow-engine/parity/crud.resolvability.test.ts
@@ -277,6 +277,11 @@ describe('CRUD node resolvability', () => {
     )
     expect(declared.length).toBeGreaterThan(5)
     await assertResolvability(ctx, written, declared, 'crud.create.vendor')
+    // Retires the former `crudSuccessErrorDetailsPin` (known-broken.ts):
+    // `errorDetails` is declared unconditionally, and now the success path
+    // writes it to `null` next to `error: null`, same as the failure path
+    // (`handleCrudError`) already did.
+    expect(await ctx.resolveVariablePath(`${nodeId}.errorDetails`)).toBeNull()
   })
 
   it('update (custom entity Vendor) — declared ⊆ resolvable, written ⊆ declared, labels present', async () => {
@@ -308,6 +313,7 @@ describe('CRUD node resolvability', () => {
     )
     expect(declared.length).toBeGreaterThan(5)
     await assertResolvability(ctx, written, declared, 'crud.update.vendor')
+    expect(await ctx.resolveVariablePath(`${nodeId}.errorDetails`)).toBeNull()
   })
 
   it('delete (custom entity Vendor) — declared ⊆ resolvable, written ⊆ declared, labels present', async () => {
@@ -335,6 +341,7 @@ describe('CRUD node resolvability', () => {
       })
     )
     await assertResolvability(ctx, written, declared, 'crud.delete.vendor')
+    expect(await ctx.resolveVariablePath(`${nodeId}.errorDetails`)).toBeNull()
   })
 
   it('thread-actions update — declared ⊆ resolvable, written ⊆ declared, labels present', async () => {
@@ -359,6 +366,7 @@ describe('CRUD node resolvability', () => {
     )
     expect(declared.length).toBeGreaterThan(10)
     await assertResolvability(ctx, written, declared, 'crud.thread.update')
+    expect(await ctx.resolveVariablePath(`${nodeId}.errorDetails`)).toBeNull()
   })
 
   it('error_strategy "default" — usedDefaults/defaultValues resolve after a forced failure', async () => {
@@ -406,5 +414,45 @@ describe('CRUD node resolvability', () => {
     expect(await ctx.resolveVariablePath(`${nodeId}.defaultValues`)).toEqual({
       fallbackNote: 'applied fallback',
     })
+  })
+
+  it('error_strategy "default" with no default_values configured — falls through to fail, but usedDefaults/defaultValues still resolve', async () => {
+    updateValues.mockRejectedValueOnce(new Error('simulated update failure'))
+    const nodeId = 'crud_vendor_update_default_empty'
+    const { ctx, node, result, written } = await runCrud(nodeId, {
+      resourceType: VENDOR_DEF_ID,
+      mode: 'update',
+      resourceId: VENDOR_UPDATE_INSTANCE_ID,
+      data: { name: 'Initech Supply' },
+      error_strategy: CrudErrorStrategy.default,
+      default_values: [],
+    })
+
+    // No default_values configured — `handleCrudError`'s 'default' case falls
+    // through to 'fail' (see the `crud.ts` comment above that fall-through).
+    expect(result.status).toBe('failed')
+    // Both are declared unconditionally whenever error_strategy === 'default',
+    // same as the configured-defaults scenario above — the fall-through must
+    // not leave them permanently unresolvable.
+    expect(written).toContain(`${nodeId}.usedDefaults`)
+    expect(written).toContain(`${nodeId}.defaultValues`)
+
+    const declared = flattenDeclared(
+      crudManifest.resolveOutputs!(node.data as never, nodeId, {
+        resource: VENDOR_RESOURCE,
+        allResources: ALL_RESOURCES,
+        resolveVariable: () => undefined,
+      })
+    )
+    expect(declared.map((d) => d.id)).toContain(`${nodeId}.usedDefaults`)
+    expect(declared.map((d) => d.id)).toContain(`${nodeId}.defaultValues`)
+
+    // Same reasoning as the configured-defaults scenario: the update
+    // genuinely failed, so the full declared tree isn't resolvable — assert
+    // write/label coverage plus the two variables this scenario exists to prove.
+    assertLabelCoverage(declared, 'crud.update.default-strategy-empty')
+    assertWrittenCovered(written, declared, 'crud.update.default-strategy-empty')
+    expect(await ctx.resolveVariablePath(`${nodeId}.usedDefaults`)).toBe(false)
+    expect(await ctx.resolveVariablePath(`${nodeId}.defaultValues`)).toBeNull()
   })
 })

--- a/packages/lib/src/workflow-engine/parity/known-broken.ts
+++ b/packages/lib/src/workflow-engine/parity/known-broken.ts
@@ -123,48 +123,17 @@ function tierAFieldPathPin(id: string): string | undefined {
   )
 }
 
-/**
- * NEW BUG (undocumented before this suite): `errorDetails` is declared
- * unconditionally for every crud mode (`generateCrudNodeVariablesFromFields`
- * always pushes it), but `executeNode`'s SUCCESS path never writes it — only
- * `handleCrudError` (the catch branch) does. A crud run that succeeds
- * outright therefore has a declared `errorDetails` id with nothing ever
- * written under it; `resolveVariablePath` correctly reports `undefined`.
- *
- * This is the shape `contract-drift-allowlist.ts`'s `KNOWN_BROKEN_FAILURE_PATH_WRITES`
- * category exists for ("every setNodeVariable call site sits inside an else
- * block") — that map is empty there because its suite checks declared-vs-written
- * statically per one fixed config, not by actually running both the success
- * and failure arms and resolving the result the way this suite does.
- *
- * Scoped to this suite's own SUCCESS-scenario node ids: the `error_strategy:
- * 'default'` scenario's forced-failure run DOES write `errorDetails` (every
- * `handleCrudError` branch sets it unconditionally), so the same id resolves
- * there — the id string alone can't distinguish "this run succeeded" from
- * "this run failed and recovered," only which scenario produced it can.
- */
-function crudSuccessErrorDetailsPin(id: string): string | undefined {
-  if (!id.endsWith('.errorDetails')) return undefined
-  // `crud_vendor_update.` (with trailing dot) deliberately does not match the
-  // `crud_vendor_update_default` scenario's node id (no dot follows
-  // `crud_vendor_update` there) — see the doc comment above.
-  const matchesSuccessNode =
-    id.startsWith('crud_vendor_create.') ||
-    id.startsWith('crud_vendor_update.') ||
-    id.startsWith('crud_vendor_delete.') ||
-    id.startsWith('crud_thread_update.')
-  if (!matchesSuccessNode) return undefined
-  return (
-    "NEW BUG: errorDetails is declared unconditionally but executeNode's success path never " +
-    'writes it — only handleCrudError (the catch branch) does. See doc comment above ' +
-    'crudSuccessErrorDetailsPin in known-broken.ts.'
-  )
-}
+// A former `crudSuccessErrorDetailsPin` entry lived here: `errorDetails` is
+// declared unconditionally for every crud mode
+// (`generateCrudNodeVariablesFromFields` always pushes it), but `executeNode`'s
+// SUCCESS path never wrote it — only `handleCrudError` (the catch branch) did,
+// so a crud run that succeeded outright left the declared `errorDetails` id
+// with nothing written under it. RETIRED (§10c) by writing `errorDetails: null`
+// next to the existing `error: null` write in `executeNode`'s success path
+// (`action-nodes/crud.ts`) — the id now resolves to `null` on success too,
+// same shape the catch branch already produced on failure.
 
-const DECLARED_UNRESOLVABLE_PINS: Array<(id: string) => string | undefined> = [
-  tierAFieldPathPin,
-  crudSuccessErrorDetailsPin,
-]
+const DECLARED_UNRESOLVABLE_PINS: Array<(id: string) => string | undefined> = [tierAFieldPathPin]
 
 // A former §3.4 hop-two entry lived here (`hopTwoRelationPin`) — defined but
 // deliberately never registered above, since `buildFieldPath`'s independent

--- a/packages/lib/src/workflow-engine/utils/field-type-mapper.ts
+++ b/packages/lib/src/workflow-engine/utils/field-type-mapper.ts
@@ -8,9 +8,23 @@ import { BaseType } from '../types'
  * Map database FieldType to BaseType for workflow operations
  * Used by workflow nodes (CRUD, Find, etc.) to convert custom field types
  * to the workflow type system.
+ *
+ * The switch is exhaustive over every `FieldType` member (see `_exhaustive`
+ * below): adding a new member to the enum without a case here fails to
+ * compile, instead of silently falling through to the STRING default. This
+ * mirrors `conditions/operator-definitions.ts`'s own `mapFieldTypeToBaseType`
+ * — the two are NOT unified (see that file's comment) because their
+ * `CALC`/default behavior is deliberately different: this one only ever runs
+ * against real custom-field types wired into the workflow engine, so an
+ * unrecognized value is a bug worth a console warning.
  */
 export function mapFieldTypeToBaseType(fieldType: FieldType | string): BaseType {
-  switch (fieldType) {
+  // Cast only to enable switch-exhaustiveness checking against every real
+  // `FieldType` member below — the parameter still accepts arbitrary strings,
+  // and a genuinely-invalid one still flows to `default` at runtime exactly
+  // as before.
+  const type = fieldType as FieldType
+  switch (type) {
     case FieldTypeEnum.TEXT:
     case FieldTypeEnum.NAME:
       return BaseType.STRING
@@ -52,9 +66,25 @@ export function mapFieldTypeToBaseType(fieldType: FieldType | string): BaseType 
       return BaseType.ACTOR
     case FieldTypeEnum.JSON:
       return BaseType.JSON
-    default:
+    case FieldTypeEnum.CALC:
+      // CALC was never a distinct case here — it used to fall through to
+      // `default` and hit the same warn+STRING fallback below. Kept as an
+      // explicit case with identical output only so the switch can be
+      // exhaustive; NOT a behavior change (intentionally left un-aligned
+      // with operator-definitions.ts's CALC -> ANY — see module comment).
       console.warn(`Unknown FieldType: ${fieldType}, defaulting to STRING`)
       return BaseType.STRING
+    default: {
+      // Exhaustiveness guard: once every `FieldType` member has its own case
+      // above, `type` narrows to `never` here. A new enum member added
+      // without a matching case fails this assignment at compile time. Still
+      // reachable at runtime for a raw string that isn't a real FieldType
+      // (the `| string` half of the parameter type) — same fallback as before.
+      const _exhaustive: never = type
+      void _exhaustive
+      console.warn(`Unknown FieldType: ${fieldType}, defaulting to STRING`)
+      return BaseType.STRING
+    }
   }
 }
 


### PR DESCRIPTION
Four small, independent fixes closing out the variable-resolution arc (deep-dive §10b step 6 + §4 + HANDOFF item 2b + §10c leftovers), plus a user-reported display bug found during the same session.

## 1. Paste rewrites variable references (§10b step 6)

Pasting nodes remapped ids on nodes and edges but **never walked `node.data`** — a pasted node's `{{oldId.…}}` refs silently kept pointing at the ORIGINAL nodes' outputs. Paste now rewrites each pasted node's data via `rewriteVariableRefs` (#1599's shared rewriter), imported through a **new client-safe leaf subpath** `@auxx/lib/workflows/variable-ref-rewriter` — the workflows barrel is server-only (#1582 lesson applied; the rewriter itself has zero imports). Two subtleties handled: id mapping is built in its own pass so connected nodes remap regardless of clipboard order, and node data is `structuredClone`'d before rewriting because the clipboard **aliases the originals' data** — without the clone, pasting would have corrupted the source nodes. Refs to unselected nodes survive untouched. New test proves all four properties (and was verified red with the fix reverted).

## 2. Output-variables panel shows labels, not CUIDs (user-reported)

Since the initial commit, `output-variables-display.tsx` clobbered every nested property's label with its record key (`{ ...prop, label: key }` — the comment claimed "proper label"). Unnoticed while keys were readable; once the custom-field arc made keys rename-proof CUIDs, the panel showed `y2qpbpcuvn6a…` where "Important documents" belongs — while the correct labels flowed through the pipeline the whole time. The property's own label now wins; the key is fallback only.

## 3. `mapFieldTypeToBaseType` exhaustiveness (HANDOFF 2b)

Both lib copies are now exhaustive switches with `const _exhaustive: never` guards — a new `FieldType` member becomes a **build error in both files** instead of a silent divergence. Per-case outputs byte-identical; the known `ADDRESS`/`CALC`/default divergences are deliberately preserved (conditions fails open to `ANY` on purpose) and pinned as intentional by a full-enum table test (25 cases).

## 4. crud declared-variable gaps (§10c)

- Success runs write `errorDetails: null` next to `error: null` — it was declared unconditionally but only written by `handleCrudError`, permanently unresolvable on success. The resolvability-suite pin retires per its self-retiring contract; all four success scenarios now assert it resolves.
- `error_strategy: 'default'` with empty `default_values` writes `usedDefaults: false` / `defaultValues: null` before its (unchanged) fall-through to fail — the declared pair now resolves on that run. New scenario covers it.

## Verification

- `packages/lib` engine/resources/workflows/conditions: 1,734 tests green (parity suite incl. retired pin)
- `apps/web` workflow suite: 101 tests green (new paste test)
- typecheck ratchets: lib 29/29, web 1/1 — no new errors
- `pnpm --filter @auxx/lib build`: clean; `package.json` diff is exactly the one new leaf subpath export
- biome clean