### PR TITLE
feat(workflow): absorb server trigger branches into shared catalog derivation

### DIFF
--- a/packages/lib/src/workflow-engine/catalog/derive-trigger-server.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/derive-trigger-server.test.ts
@@ -1,0 +1,109 @@
+// packages/lib/src/workflow-engine/catalog/derive-trigger-server.test.ts
+
+import { err, ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { WorkflowTriggerType } from '../core/types'
+
+// Leaf-module mock (not a shared barrel — safe to replace wholesale): keeps
+// `@auxx/database` out of the test process.
+const resolveActiveInstallationId = vi.fn()
+vi.mock('../../apps/installations/resolve-active-installation', () => ({
+  resolveActiveInstallationId: (...args: unknown[]) => resolveActiveInstallationId(...args),
+}))
+
+const { deriveTriggerLinkColumns } = await import('./derive-trigger-server')
+
+const ALL_CLEAR = {
+  triggerAppId: null,
+  triggerTriggerId: null,
+  triggerInstallationId: null,
+  triggerConnectionId: null,
+  triggerWebhookEndpointId: null,
+  triggerTopic: null,
+}
+
+const appNode = {
+  data: {
+    type: 'someapp:new-row',
+    appId: 'app_1',
+    triggerId: 'order-created',
+    connectionId: 'conn_1',
+    installationId: 'inst_stored',
+  },
+}
+
+/**
+ * Pins the column updates `workflow-service.update` used to build inline —
+ * behavior-preserving move, so every arm must write (or withhold) exactly the
+ * same keys the service did.
+ */
+describe('deriveTriggerLinkColumns', () => {
+  beforeEach(() => {
+    resolveActiveInstallationId.mockReset()
+  })
+
+  it('returns {} (leave columns alone) when there is nothing to derive', async () => {
+    expect(await deriveTriggerLinkColumns('org_1', undefined, [appNode])).toEqual({})
+    // App trigger whose node is missing — the service wrote no updates here.
+    expect(await deriveTriggerLinkColumns('org_1', WorkflowTriggerType.APP_TRIGGER, [])).toEqual({})
+    expect(resolveActiveInstallationId).not.toHaveBeenCalled()
+  })
+
+  it('writes the app columns with the installation resolved at save time', async () => {
+    resolveActiveInstallationId.mockResolvedValue(ok('inst_active'))
+
+    const result = await deriveTriggerLinkColumns('org_1', WorkflowTriggerType.APP_TRIGGER, [
+      appNode,
+    ])
+
+    expect(resolveActiveInstallationId).toHaveBeenCalledWith('app_1', 'org_1')
+    expect(result).toEqual({
+      triggerAppId: 'app_1',
+      triggerTriggerId: 'order-created',
+      triggerConnectionId: 'conn_1',
+      triggerInstallationId: 'inst_active',
+    })
+    // The webhook columns are NOT cleared on the app arm — preserved verbatim.
+    expect('triggerWebhookEndpointId' in result).toBe(false)
+    expect('triggerTopic' in result).toBe(false)
+  })
+
+  it('falls back to the node-stored installationId when resolution fails', async () => {
+    resolveActiveInstallationId.mockResolvedValue(err(new Error('not installed')))
+
+    const result = await deriveTriggerLinkColumns(
+      'org_1',
+      WorkflowTriggerType.APP_POLLING_TRIGGER,
+      [appNode]
+    )
+    expect(result.triggerInstallationId).toBe('inst_stored')
+
+    // Legacy node without a stored installationId → explicit null.
+    const bare = await deriveTriggerLinkColumns('org_1', WorkflowTriggerType.APP_TRIGGER, [
+      { data: { appId: 'app_1', triggerId: 'order-created' } },
+    ])
+    expect(bare.triggerInstallationId).toBeNull()
+  })
+
+  it('persists (webhookEndpointId, topic) and clears the app columns for webhook-endpoint', async () => {
+    const result = await deriveTriggerLinkColumns('org_1', WorkflowTriggerType.WEBHOOK_ENDPOINT, [
+      { data: { webhookEndpointId: 'whep_1', topic: 'orders/create' } },
+    ])
+    expect(result).toEqual({
+      ...ALL_CLEAR,
+      triggerWebhookEndpointId: 'whep_1',
+      triggerTopic: 'orders/create',
+    })
+    expect(resolveActiveInstallationId).not.toHaveBeenCalled()
+  })
+
+  it('clears all six columns when switching to any other trigger type', async () => {
+    expect(
+      await deriveTriggerLinkColumns('org_1', WorkflowTriggerType.SCHEDULED, [appNode])
+    ).toEqual(ALL_CLEAR)
+    // Webhook-endpoint without a posted graph falls through to the clear arm.
+    expect(
+      await deriveTriggerLinkColumns('org_1', WorkflowTriggerType.WEBHOOK_ENDPOINT, undefined)
+    ).toEqual(ALL_CLEAR)
+  })
+})

--- a/packages/lib/src/workflow-engine/catalog/derive-trigger-server.ts
+++ b/packages/lib/src/workflow-engine/catalog/derive-trigger-server.ts
@@ -1,0 +1,105 @@
+// packages/lib/src/workflow-engine/catalog/derive-trigger-server.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { resolveActiveInstallationId } from '../../apps/installations/resolve-active-installation'
+import { deriveTriggerLinks, type TriggerDerivationNode } from './derive-trigger'
+
+const logger = createScopedLogger('derive-trigger-server')
+
+/**
+ * The app/webhook trigger columns on `Workflow` (and their `AgentTrigger`
+ * mirrors). A key that is absent means "leave the stored value alone"; `null`
+ * is an explicit clear — the same contract `workflow-service.update` builds
+ * its `workflowUpdates` object with.
+ */
+export interface TriggerLinkColumnUpdates {
+  triggerAppId?: string | null
+  triggerTriggerId?: string | null
+  triggerInstallationId?: string | null
+  triggerConnectionId?: string | null
+  triggerWebhookEndpointId?: string | null
+  triggerTopic?: string | null
+}
+
+/**
+ * Server-side composition over {@link deriveTriggerLinks}: derive the six
+ * app/webhook trigger-link columns from the graph, resolving
+ * `triggerInstallationId` at save time. THE one implementation of the
+ * branches `workflow-service.update` used to inline (HANDOFF item 5) —
+ * Phase 3's graph-edit service calls this on every trigger-touching mutation.
+ *
+ * SERVER-ONLY leaf module (same rule as `build-output-context.ts` /
+ * `resolve-outputs.ts`): it reaches the DB through
+ * `resolveActiveInstallationId`, so it must never be exported from
+ * `client.ts` or the `workflow-engine` index barrel. `organizationId` first,
+ * no `db` param: the only read goes through `resolveActiveInstallationId`,
+ * which owns its own DB access — there is no query here to run against a
+ * caller-supplied `db`.
+ *
+ * `triggerType` is the type being WRITTEN (the save path trusts the posted
+ * value; a future full server derivation needs the catalog to cover webhook /
+ * app trigger types first — see `05-resource-model.md` §4a.8 step 5). This
+ * function cannot fail: an unresolvable installation falls back to the
+ * node's stored `installationId` with a warning, because writing `null`
+ * would silently disable dispatch (the trigger filter matches on exact
+ * equality).
+ *
+ * Returns `{}` when there is nothing to write — the caller must then leave
+ * the stored columns untouched.
+ */
+export async function deriveTriggerLinkColumns(
+  organizationId: string,
+  triggerType: string | null | undefined,
+  nodes: readonly TriggerDerivationNode[] | null | undefined
+): Promise<TriggerLinkColumnUpdates> {
+  const links = deriveTriggerLinks(triggerType, nodes)
+
+  switch (links.kind) {
+    case 'none':
+      return {}
+
+    case 'clear':
+      return {
+        triggerAppId: null,
+        triggerTriggerId: null,
+        triggerInstallationId: null,
+        triggerConnectionId: null,
+        triggerWebhookEndpointId: null,
+        triggerTopic: null,
+      }
+
+    case 'webhook-endpoint':
+      // No installation/connection to resolve — the user owns the endpoint.
+      return {
+        triggerAppId: null,
+        triggerTriggerId: null,
+        triggerInstallationId: null,
+        triggerConnectionId: null,
+        triggerWebhookEndpointId: links.webhookEndpointId,
+        triggerTopic: links.topic,
+      }
+
+    case 'app-trigger': {
+      // Resolve triggerInstallationId at save time — fall back to the stored
+      // value for legacy nodes that still carry installationId.
+      let triggerInstallationId: string | null
+      const instResult = await resolveActiveInstallationId(links.appId, organizationId)
+      if (instResult.isOk()) {
+        triggerInstallationId = instResult.value
+      } else {
+        triggerInstallationId = links.storedInstallationId
+        logger.warn('Could not resolve triggerInstallationId, using stored value', {
+          appId: links.appId,
+          organizationId,
+          storedInstallationId: links.storedInstallationId,
+        })
+      }
+      return {
+        triggerAppId: links.appId,
+        triggerTriggerId: links.triggerId,
+        triggerConnectionId: links.connectionId,
+        triggerInstallationId,
+      }
+    }
+  }
+}

--- a/packages/lib/src/workflow-engine/catalog/derive-trigger.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/derive-trigger.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from 'vitest'
 import { WorkflowTriggerType } from '../core/types'
-import { deriveTriggerColumns } from './derive-trigger'
+import { deriveTriggerColumns, deriveTriggerLinks } from './derive-trigger'
 
 /**
  * The trigger-columns derivation moved from `use-workflow-save.ts` (browser)
@@ -69,5 +69,98 @@ describe('deriveTriggerColumns', () => {
         nodeType === 'someapp:new-row' ? WorkflowTriggerType.APP_TRIGGER : undefined,
     })
     expect(result.triggerType).toBe(WorkflowTriggerType.APP_TRIGGER)
+  })
+})
+
+/**
+ * The app/webhook trigger-column branches moved out of
+ * `workflow-service.update` — these pin the branch behavior it inlined,
+ * including the "no updates at all" (`none`) arms a naive rewrite would
+ * collapse into clears.
+ */
+describe('deriveTriggerLinks', () => {
+  const appNode = {
+    data: {
+      type: 'someapp:new-row',
+      appId: 'app_1',
+      triggerId: 'order-created',
+      connectionId: 'conn_1',
+      installationId: 'inst_stored',
+    },
+  }
+
+  it('returns none without a trigger type — the caller leaves the columns alone', () => {
+    expect(deriveTriggerLinks(undefined, [appNode])).toEqual({ kind: 'none' })
+    expect(deriveTriggerLinks(null, [appNode])).toEqual({ kind: 'none' })
+  })
+
+  it('extracts the app trigger fields from the node carrying appId + triggerId', () => {
+    expect(
+      deriveTriggerLinks(WorkflowTriggerType.APP_TRIGGER, [{ data: { type: 'note' } }, appNode])
+    ).toEqual({
+      kind: 'app-trigger',
+      appId: 'app_1',
+      triggerId: 'order-created',
+      connectionId: 'conn_1',
+      storedInstallationId: 'inst_stored',
+    })
+    expect(deriveTriggerLinks(WorkflowTriggerType.APP_POLLING_TRIGGER, [appNode]).kind).toBe(
+      'app-trigger'
+    )
+  })
+
+  it('nulls missing connection/installation on an app trigger node', () => {
+    const result = deriveTriggerLinks(WorkflowTriggerType.APP_TRIGGER, [
+      { data: { appId: 'app_1', triggerId: 'order-created' } },
+    ])
+    expect(result).toEqual({
+      kind: 'app-trigger',
+      appId: 'app_1',
+      triggerId: 'order-created',
+      connectionId: null,
+      storedInstallationId: null,
+    })
+  })
+
+  it('returns none for an app trigger whose node is missing — never a clear', () => {
+    // A node needs BOTH appId and triggerId to count.
+    expect(
+      deriveTriggerLinks(WorkflowTriggerType.APP_TRIGGER, [{ data: { appId: 'app_1' } }])
+    ).toEqual({ kind: 'none' })
+    expect(deriveTriggerLinks(WorkflowTriggerType.APP_TRIGGER, [])).toEqual({ kind: 'none' })
+    // No graph posted at all.
+    expect(deriveTriggerLinks(WorkflowTriggerType.APP_TRIGGER, undefined)).toEqual({ kind: 'none' })
+  })
+
+  it('extracts (webhookEndpointId, topic) for a webhook-endpoint trigger', () => {
+    const result = deriveTriggerLinks(WorkflowTriggerType.WEBHOOK_ENDPOINT, [
+      { data: { type: 'webhook-trigger', webhookEndpointId: 'whep_1', topic: 'orders/create' } },
+    ])
+    expect(result).toEqual({
+      kind: 'webhook-endpoint',
+      webhookEndpointId: 'whep_1',
+      topic: 'orders/create',
+    })
+  })
+
+  it('writes explicit nulls when the webhook-endpoint node is missing from the graph', () => {
+    expect(
+      deriveTriggerLinks(WorkflowTriggerType.WEBHOOK_ENDPOINT, [{ data: { type: 'note' } }])
+    ).toEqual({ kind: 'webhook-endpoint', webhookEndpointId: null, topic: null })
+  })
+
+  it('falls back to clear for a webhook-endpoint trigger without a posted graph', () => {
+    // Preserved quirk: without `graph.nodes` the original branch chain fell
+    // through to the clear arm, nulling the webhook columns too.
+    expect(deriveTriggerLinks(WorkflowTriggerType.WEBHOOK_ENDPOINT, undefined)).toEqual({
+      kind: 'clear',
+    })
+  })
+
+  it('clears the link columns when switching to any other trigger type', () => {
+    expect(deriveTriggerLinks(WorkflowTriggerType.SCHEDULED, [appNode])).toEqual({ kind: 'clear' })
+    expect(deriveTriggerLinks(WorkflowTriggerType.MESSAGE_RECEIVED, undefined)).toEqual({
+      kind: 'clear',
+    })
   })
 })

--- a/packages/lib/src/workflow-engine/catalog/derive-trigger.ts
+++ b/packages/lib/src/workflow-engine/catalog/derive-trigger.ts
@@ -20,6 +20,86 @@ export interface TriggerDerivationNode {
   } | null
 }
 
+/** The two dynamic app trigger types whose link columns come off the app trigger node. */
+const APP_TRIGGER_TYPES: readonly string[] = [
+  WorkflowTriggerType.APP_TRIGGER,
+  WorkflowTriggerType.APP_POLLING_TRIGGER,
+]
+
+/**
+ * What `deriveTriggerLinks` found in the graph for the app/webhook trigger
+ * columns (`Workflow.triggerAppId` / `triggerTriggerId` / `triggerConnectionId`
+ * / `triggerInstallationId` / `triggerWebhookEndpointId` / `triggerTopic`):
+ *
+ * - `none` — nothing to write; the caller leaves the columns untouched. This
+ *   covers "no trigger type", "app trigger but no graph posted", and "app
+ *   trigger whose node is missing" — all preserved verbatim from the
+ *   `workflow-service.update` branches this replaced.
+ * - `app-trigger` — the app trigger node's fields; `triggerInstallationId` is
+ *   NOT part of this result because it is resolved server-side at save time
+ *   (`resolveActiveInstallationId`), with `storedInstallationId` as the legacy
+ *   fallback.
+ * - `webhook-endpoint` — `(webhookEndpointId, topic)` off the trigger node
+ *   (explicit `null`s when the node is missing); the app columns clear.
+ * - `clear` — the trigger switched to a non-app, non-webhook type: all six
+ *   columns clear.
+ */
+export type DerivedTriggerLinks =
+  | { kind: 'none' }
+  | { kind: 'clear' }
+  | {
+      kind: 'app-trigger'
+      appId: string
+      triggerId: string
+      connectionId: string | null
+      /** The node's stored `installationId` — fallback when resolution fails. */
+      storedInstallationId: string | null
+    }
+  | { kind: 'webhook-endpoint'; webhookEndpointId: string | null; topic: string | null }
+
+/**
+ * Pure graph-side half of the app/webhook trigger-column derivation — the
+ * server-side branches `workflow-service.update` used to inline (HANDOFF item
+ * 5). Unlike {@link deriveTriggerColumns}, `triggerType` is an INPUT here, not
+ * derived: the save path trusts the caller-posted type, and the catalog cannot
+ * yet resolve webhook / webhook-endpoint / app trigger types itself (they are
+ * `NOT_YET_MIGRATED`).
+ *
+ * The server-side composition that resolves the installation id lives in
+ * `derive-trigger-server.ts` (server-only leaf module — do not fold it in
+ * here, this file is exported through `client.ts` and runs in the browser).
+ */
+export function deriveTriggerLinks(
+  triggerType: string | null | undefined,
+  nodes: readonly TriggerDerivationNode[] | null | undefined
+): DerivedTriggerLinks {
+  if (!triggerType) return { kind: 'none' }
+
+  if (APP_TRIGGER_TYPES.includes(triggerType)) {
+    if (!nodes) return { kind: 'none' }
+    const triggerNode = nodes.find((n) => n.data?.triggerId && n.data?.appId)
+    if (!triggerNode?.data) return { kind: 'none' }
+    return {
+      kind: 'app-trigger',
+      appId: triggerNode.data.appId,
+      triggerId: triggerNode.data.triggerId,
+      connectionId: triggerNode.data.connectionId || null,
+      storedInstallationId: triggerNode.data.installationId || null,
+    }
+  }
+
+  if (triggerType === WorkflowTriggerType.WEBHOOK_ENDPOINT && nodes) {
+    const triggerNode = nodes.find((n) => n.data?.webhookEndpointId)
+    return {
+      kind: 'webhook-endpoint',
+      webhookEndpointId: triggerNode?.data?.webhookEndpointId || null,
+      topic: triggerNode?.data?.topic || null,
+    }
+  }
+
+  return { kind: 'clear' }
+}
+
 export interface DerivedTriggerColumns {
   /** Undefined ⇒ no trigger node found — the caller keeps its previous value. */
   triggerType?: WorkflowTriggerType

--- a/packages/lib/src/workflow-engine/client.ts
+++ b/packages/lib/src/workflow-engine/client.ts
@@ -77,9 +77,14 @@ export * from './utils/terminal-nodes'
 // NOTE: `catalog/build-output-context` and `catalog/resolve-outputs` are
 // SERVER-ONLY (they import the org cache, which pulls in bullmq) and must
 // never be exported here — import them via their own subpaths instead.
+// NOTE: `catalog/derive-trigger-server` (the composition resolving
+// `triggerInstallationId`) is SERVER-ONLY for the same reason — import it
+// via a relative path (lib) or its own subpath, never from here.
 export {
   type DerivedTriggerColumns,
+  type DerivedTriggerLinks,
   deriveTriggerColumns,
+  deriveTriggerLinks,
   type TriggerDerivationNode,
 } from './catalog/derive-trigger'
 export {

--- a/packages/lib/src/workflows/workflow-service.ts
+++ b/packages/lib/src/workflows/workflow-service.ts
@@ -9,6 +9,8 @@ import { canonicalizeEntityDefinitionId, getCachedResources } from '../cache/org
 import { getCachedWorkflowAppsList } from '../cache/workflow-app-queries'
 import { ConflictError, NotFoundError } from '../errors'
 import { getQueue, Queues } from '../jobs/queues'
+import type { TriggerDerivationNode } from '../workflow-engine/catalog/derive-trigger'
+import { deriveTriggerLinkColumns } from '../workflow-engine/catalog/derive-trigger-server'
 import { WorkflowEngine } from '../workflow-engine/core/workflow-engine'
 import { hashWorkflowGraph } from './graph-hash'
 import { assertMailTriggerNotPersonal } from './mail-trigger-guard'
@@ -509,63 +511,19 @@ export class WorkflowService {
           if (basicUpdateData.entityDefinitionId !== undefined)
             workflowUpdates.entityDefinitionId = basicUpdateData.entityDefinitionId
 
-          // Extract app trigger fields from graph's trigger node for both app trigger types
-          const isAppTrigger =
-            basicUpdateData.triggerType === 'app-trigger' ||
-            basicUpdateData.triggerType === 'app-polling-trigger'
-          if (isAppTrigger && graph?.nodes) {
-            const triggerNode = (graph.nodes as any[]).find(
-              (n: any) => n.data?.triggerId && n.data?.appId
+          // App/webhook trigger-link columns (app trigger fields incl. the
+          // save-time installation resolution, webhook-endpoint columns,
+          // explicit clear on trigger switch) are derived by the catalog's
+          // server-side composition — one implementation shared with future
+          // server-side graph mutations. `{}` means leave the columns alone.
+          Object.assign(
+            workflowUpdates,
+            await deriveTriggerLinkColumns(
+              organizationId,
+              basicUpdateData.triggerType,
+              graph?.nodes as TriggerDerivationNode[] | undefined
             )
-            if (triggerNode?.data) {
-              workflowUpdates.triggerAppId = triggerNode.data.appId || null
-              workflowUpdates.triggerTriggerId = triggerNode.data.triggerId || null
-              workflowUpdates.triggerConnectionId = triggerNode.data.connectionId || null
-
-              // Resolve triggerInstallationId at save time — fail hard if app not installed
-              // (writing null would silently disable dispatch since the filter matches on exact equality)
-              if (triggerNode.data.appId) {
-                const { resolveActiveInstallationId } = await import(
-                  '../apps/installations/resolve-active-installation'
-                )
-                const instResult = await resolveActiveInstallationId(
-                  triggerNode.data.appId,
-                  organizationId
-                )
-                if (instResult.isOk()) {
-                  workflowUpdates.triggerInstallationId = instResult.value
-                } else {
-                  // Fallback to stored value for legacy nodes that still have installationId
-                  workflowUpdates.triggerInstallationId = triggerNode.data.installationId || null
-                  logger.warn('Could not resolve triggerInstallationId, using stored value', {
-                    appId: triggerNode.data.appId,
-                    organizationId,
-                    storedInstallationId: triggerNode.data.installationId,
-                  })
-                }
-              } else {
-                workflowUpdates.triggerInstallationId = triggerNode.data.installationId || null
-              }
-            }
-          } else if (basicUpdateData.triggerType === 'webhook-endpoint' && graph?.nodes) {
-            // Webhook-endpoint trigger: persist (webhookEndpointId, topic) from the trigger
-            // node into the dedicated column; no installation/connection to resolve.
-            const triggerNode = (graph.nodes as any[]).find((n: any) => n.data?.webhookEndpointId)
-            workflowUpdates.triggerAppId = null
-            workflowUpdates.triggerTriggerId = null
-            workflowUpdates.triggerInstallationId = null
-            workflowUpdates.triggerConnectionId = null
-            workflowUpdates.triggerWebhookEndpointId = triggerNode?.data?.webhookEndpointId || null
-            workflowUpdates.triggerTopic = triggerNode?.data?.topic || null
-          } else if (basicUpdateData.triggerType && !isAppTrigger) {
-            // Clear app + webhook trigger fields when switching to another trigger
-            workflowUpdates.triggerAppId = null
-            workflowUpdates.triggerTriggerId = null
-            workflowUpdates.triggerInstallationId = null
-            workflowUpdates.triggerConnectionId = null
-            workflowUpdates.triggerWebhookEndpointId = null
-            workflowUpdates.triggerTopic = null
-          }
+          )
 
           if (graph) workflowUpdates.graph = graph as any
           if (envVars) workflowUpdates.envVars = envVars as any


### PR DESCRIPTION
Phase-3 prep debt (HANDOFF item 5, deferred out of #1571 and again out of #1578's step 5): the three server-side trigger branches inlined in `WorkflowService.update` — webhook-endpoint columns, explicit clear on trigger switch, and the save-time `resolveActiveInstallationId` — now live in the catalog's trigger-column derivation, so all trigger columns are derived in ONE place callable from both the browser save path and Phase 3's graph-edit service.

## What moved where

**`catalog/derive-trigger.ts` (pure, browser-safe, exported via `client.ts`)** gains `deriveTriggerLinks(triggerType, nodes)` — the graph-side half of the branches, returning a discriminated union (`none` / `app-trigger` / `webhook-endpoint` / `clear`). Every arm of the old branch chain is preserved verbatim, including three quirks a naive rewrite would flatten:

- an app trigger with no posted graph, or whose node is missing, writes **nothing** (`none`), never a clear
- a `webhook-endpoint` trigger with no posted graph falls through to the **clear** arm, nulling the webhook columns too
- `triggerType` is an **input**, not derived — the save path trusts the posted value, and the catalog still cannot resolve webhook / app trigger types (`NOT_YET_MIGRATED`), which is exactly why publish-time re-derivation (05 §4a.8 step 5) stays deferred

**`catalog/derive-trigger-server.ts` (new SERVER-ONLY leaf module, same rule as `build-output-context.ts` / `resolve-outputs.ts`)**: `deriveTriggerLinkColumns(organizationId, triggerType, nodes)` composes the pure derivation with the save-time installation resolution (resolved id, else fallback to the node's stored `installationId` + the same warn log) and maps each arm to the exact `workflowUpdates` keys the service wrote — `{}` means "leave the columns alone". Not exported from `client.ts` or the `workflow-engine` index barrel (known cycle); no `@auxx/lib` subpath entry needed since its only caller is lib-internal (`generate:exports` produced zero `package.json` churn).

**`workflow-service.ts`**: the ~57-line inline branch chain becomes one `Object.assign(workflowUpdates, await deriveTriggerLinkColumns(...))`. The dynamic import of `resolve-active-installation` becomes a static import in the leaf module (that file only imports `@auxx/database` — no cycle).

## What stayed / deliberate non-changes

- **Behavior-preserving throughout** — browser save path untouched (`use-workflow-save.ts` still calls `deriveTriggerColumns` with its registry-backed resolver); the update path writes byte-identical column sets.
- One dead arm dropped, not moved: the old `else { triggerInstallationId = installationId || null }` for a falsy `appId` could never fire — the node predicate (`data.triggerId && data.appId`) guarantees `appId` is truthy.
- `deriveTriggerLinkColumns` returns a plain promise, not `Result` — it cannot fail by design (resolution failure falls back + warns, because writing `null` silently disables dispatch).
- The warn log moves from scope `workflow-service` to `derive-trigger-server`; message and fields unchanged.
- Publish still copies draft columns (step 5 of 05 §4a.8 remains deferred), and `createForResource`'s hand-built columns (writer #5) remain — both tracked in the plan docs, out of scope here.

## Verification

- `derive-trigger.test.ts` extended (8 new cases pinning every arm incl. the none-vs-clear distinctions); new `derive-trigger-server.test.ts` (5 cases, leaf-module mock of `resolveActiveInstallationId`, keeps `@auxx/database` out of the test process)
- lib typecheck ratchet: 29/29 (no new errors); web untouched
- `vitest run src/workflow-engine` — 1085 passed (63 files); `vitest run src/workflows` — 155 passed
- biome error-clean on touched dirs; `pnpm --filter @auxx/lib build` green, zero exports codegen churn
