### PR TITLE
feat(workflow): graph-edit refs and friendly normalization layer

### DIFF
--- a/packages/lib/src/workflows/graph-edit/__tests__/friendly-refs.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/friendly-refs.test.ts
@@ -1,0 +1,198 @@
+// packages/lib/src/workflows/graph-edit/__tests__/friendly-refs.test.ts
+
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeFriendlyRefs,
+  type ResourceAliasIndex,
+  renderPersistedRefs,
+} from '../normalize/friendly-refs'
+import type { NodeMeta } from '../types'
+
+const TICKET_ID = 'i5aezsg4bc6n8gof2uan3wcf'
+
+const node = (id: string, title: string, data: Record<string, unknown> = {}): NodeMeta => ({
+  id,
+  type: 'standard',
+  data: { id, type: 'find', title, ...data },
+})
+
+const NODES: NodeMeta[] = [
+  node('n1aaaaaaaaaaaaaaaaaaaa', 'Find Contact'),
+  node('n2aaaaaaaaaaaaaaaaaaaa', 'Find Tickets', { resourceType: TICKET_ID }),
+  node('n3aaaaaaaaaaaaaaaaaaaa', 'Find Mr. Smith'),
+  node('d1aaaaaaaaaaaaaaaaaaaa', 'Send Reply'),
+  node('d2aaaaaaaaaaaaaaaaaaaa', 'Send Reply'),
+]
+
+/** Tier-B ticket aliases, as `buildResourceAliasIndex` would produce them. */
+const ALIASES: ResourceAliasIndex = {
+  aliasToId: new Map(
+    [TICKET_ID, 'ticket', 'tickets'].map((alias) => [alias.toLowerCase(), TICKET_ID])
+  ),
+  idToSlug: new Map([[TICKET_ID, 'ticket']]),
+}
+
+describe('normalizeFriendlyRefs', () => {
+  it('rewrites {{Title.path}} spans to {{nodeId.path}}', () => {
+    const { data, issues } = normalizeFriendlyRefs(
+      { text: 'Email: {{Find Contact.email}}' },
+      { nodes: NODES }
+    )
+    expect(data.text).toBe('Email: {{n1aaaaaaaaaaaaaaaaaaaa.email}}')
+    expect(issues).toEqual([])
+  })
+
+  it('resolves a title containing a dot via longest-prefix', () => {
+    const { data, issues } = normalizeFriendlyRefs(
+      { text: '{{Find Mr. Smith.email}}' },
+      { nodes: NODES }
+    )
+    expect(data.text).toBe('{{n3aaaaaaaaaaaaaaaaaaaa.email}}')
+    expect(issues).toEqual([])
+  })
+
+  it('rewrites gated bare refs (if-else variableId shape)', () => {
+    const { data, issues } = normalizeFriendlyRefs(
+      { cases: [{ conditions: [{ variableId: 'Find Contact.email', value: 1 }] }] },
+      { nodes: NODES }
+    )
+    expect((data.cases[0]!.conditions[0] as { variableId: string }).variableId).toBe(
+      'n1aaaaaaaaaaaaaaaaaaaa.email'
+    )
+    expect(issues).toEqual([])
+  })
+
+  it('leaves prose alone, even when it starts with a node title and a dot', () => {
+    const { data, issues } = normalizeFriendlyRefs(
+      { note: 'Find Contact. Thanks.' },
+      { nodes: NODES }
+    )
+    expect(data.note).toBe('Find Contact. Thanks.')
+    expect(issues).toEqual([])
+  })
+
+  it('errors on an ambiguous title, listing candidates with ids, and leaves the value verbatim', () => {
+    const { data, issues } = normalizeFriendlyRefs(
+      { text: '{{Send Reply.status}}' },
+      { nodes: NODES }
+    )
+    expect(data.text).toBe('{{Send Reply.status}}')
+    expect(issues).toHaveLength(1)
+    expect(issues[0]).toMatchObject({ severity: 'error', ref: 'Send Reply.status' })
+    expect(issues[0]!.message).toContain('d1aaaaaaaaaaaaaaaaaaaa')
+    expect(issues[0]!.message).toContain('d2aaaaaaaaaaaaaaaaaaaa')
+  })
+
+  it('errors on an unknown span ref — never a silent drop', () => {
+    const { data, issues } = normalizeFriendlyRefs({ text: '{{Ghost Node.x}}' }, { nodes: NODES })
+    expect(data.text).toBe('{{Ghost Node.x}}')
+    expect(issues).toHaveLength(1)
+    expect(issues[0]!.severity).toBe('error')
+    expect(issues[0]!.message).toContain('Ghost Node.x')
+  })
+
+  it('leaves env./sys. refs untouched', () => {
+    const { data, issues } = normalizeFriendlyRefs(
+      { text: '{{env.THRESHOLD}} {{sys.userId}}' },
+      { nodes: NODES }
+    )
+    expect(data.text).toBe('{{env.THRESHOLD}} {{sys.userId}}')
+    expect(issues).toEqual([])
+  })
+
+  it('aliases the resource segment to the canonical id ({{Find Tickets.ticket.subject}})', () => {
+    const { data, issues } = normalizeFriendlyRefs(
+      { text: '{{Find Tickets.ticket.subject}}' },
+      { nodes: NODES, resourceAliases: ALIASES }
+    )
+    expect(data.text).toBe(`{{n2aaaaaaaaaaaaaaaaaaaa.${TICKET_ID}.subject}}`)
+    expect(issues).toEqual([])
+  })
+
+  it('aliases the plural form with a bracket accessor', () => {
+    const { data } = normalizeFriendlyRefs(
+      { text: '{{Find Tickets.tickets[*].subject}}' },
+      { nodes: NODES, resourceAliases: ALIASES }
+    )
+    expect(data.text).toBe(`{{n2aaaaaaaaaaaaaaaaaaaa.${TICKET_ID}[*].subject}}`)
+  })
+
+  it('aliases even when the node still holds the slug in resourceType (pre-canonicalization)', () => {
+    const nodes = [node('n9aaaaaaaaaaaaaaaaaaaa', 'Find Slug', { resourceType: 'ticket' })]
+    const { data } = normalizeFriendlyRefs(
+      { text: '{{Find Slug.ticket.subject}}' },
+      { nodes, resourceAliases: ALIASES }
+    )
+    expect(data.text).toBe(`{{n9aaaaaaaaaaaaaaaaaaaa.${TICKET_ID}.subject}}`)
+  })
+
+  it('does not touch non-resource segments after the node ref', () => {
+    const { data } = normalizeFriendlyRefs(
+      { text: '{{Find Tickets.count}}' },
+      { nodes: NODES, resourceAliases: ALIASES }
+    )
+    expect(data.text).toBe('{{n2aaaaaaaaaaaaaaaaaaaa.count}}')
+  })
+
+  it('never mutates the input', () => {
+    const input = { text: '{{Find Contact.email}}' }
+    normalizeFriendlyRefs(input, { nodes: NODES })
+    expect(input.text).toBe('{{Find Contact.email}}')
+  })
+})
+
+describe('renderPersistedRefs', () => {
+  it('renders {{nodeId.path}} back as {{Title.path}}', () => {
+    const data = renderPersistedRefs(
+      { text: 'Email: {{n1aaaaaaaaaaaaaaaaaaaa.email}}' },
+      { nodes: NODES }
+    )
+    expect(data.text).toBe('Email: {{Find Contact.email}}')
+  })
+
+  it('renders the resource segment back as its slug', () => {
+    const data = renderPersistedRefs(
+      { text: `{{n2aaaaaaaaaaaaaaaaaaaa.${TICKET_ID}.subject}}` },
+      { nodes: NODES, resourceAliases: ALIASES }
+    )
+    expect(data.text).toBe('{{Find Tickets.ticket.subject}}')
+  })
+
+  it('keeps the id for duplicated titles — the only rendering that round-trips', () => {
+    const data = renderPersistedRefs(
+      { text: '{{d1aaaaaaaaaaaaaaaaaaaa.status}}' },
+      { nodes: NODES }
+    )
+    expect(data.text).toBe('{{d1aaaaaaaaaaaaaaaaaaaa.status}}')
+  })
+
+  it('renders bare id refs (variableId shape)', () => {
+    const data = renderPersistedRefs(
+      { variableId: 'n1aaaaaaaaaaaaaaaaaaaa.email' },
+      { nodes: NODES }
+    )
+    expect(data.variableId).toBe('Find Contact.email')
+  })
+})
+
+describe('round trip', () => {
+  it.each([
+    ['{{Find Contact.email}}', {}],
+    ['{{Find Mr. Smith.email}}', {}],
+    ['{{Find Tickets.ticket.subject}}', { resourceAliases: ALIASES }],
+    ['{{Find Tickets.ticket.attachments.values[*].name}}', { resourceAliases: ALIASES }],
+    ['{{d1aaaaaaaaaaaaaaaaaaaa.status}}', {}],
+  ])('%s survives friendly → persisted → friendly', (text, extra) => {
+    const params = { nodes: NODES, ...extra }
+    const { data: persisted, issues } = normalizeFriendlyRefs({ text }, params)
+    expect(issues).toEqual([])
+    const { data: rePersisted, issues: reIssues } = normalizeFriendlyRefs(
+      renderPersistedRefs(persisted, params),
+      params
+    )
+    expect(reIssues).toEqual([])
+    // Friendly rendering is stable and re-normalizes to the identical persisted form.
+    expect(renderPersistedRefs(persisted, params)).toEqual({ text })
+    expect(rePersisted).toEqual(persisted)
+  })
+})

--- a/packages/lib/src/workflows/graph-edit/__tests__/normalize.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/normalize.test.ts
@@ -1,0 +1,290 @@
+// packages/lib/src/workflows/graph-edit/__tests__/normalize.test.ts
+
+/**
+ * Golden friendly → persisted normalization for a representative set of
+ * migrated node types (`03-graph-edit-service.md` §3/§9): ai prompts, if-else
+ * bare refs, resource slug → CUID resolution, and after/branch → edge wiring
+ * through `manifest.connection.branches`.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+// Partial mock — the cache barrel is imported by half of lib; replacing it
+// wholesale dies at collection. Only the one read resource-refs makes is stubbed.
+const getCachedResources = vi.fn()
+vi.mock('../../../cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../cache')>()),
+  getCachedResources: (...args: unknown[]) => getCachedResources(...args),
+}))
+
+const { resolveConnectionSpec } = await import('../normalize/connection')
+const { normalizeFriendlyRefs } = await import('../normalize/friendly-refs')
+const { normalizeAiPromptConfig } = await import('../normalize/prompt')
+const { buildResourceAliasIndex, normalizeResourceConfig, resolveResourceRef } = await import(
+  '../normalize/resource-refs'
+)
+
+import type { NodeMeta } from '../types'
+
+const ORG = 'org_1'
+const TICKET_ID = 'i5aezsg4bc6n8gof2uan3wcf'
+const ORDERS_ID = 'xhahogeml2s9utggipn2jr1i'
+
+/** Minimal `Resource` fixtures — one tier-A system row, one tier B, one tier C. */
+const RESOURCES = [
+  {
+    id: 'thread',
+    type: 'system',
+    label: 'Thread',
+    plural: 'Threads',
+    apiSlug: 'threads',
+    entityType: 'thread',
+    entityDefinitionId: 'thread',
+    isVisible: true,
+    fields: [],
+  },
+  {
+    id: TICKET_ID,
+    type: 'custom',
+    label: 'Ticket',
+    plural: 'Tickets',
+    apiSlug: 'tickets',
+    entityType: 'ticket',
+    entityDefinitionId: TICKET_ID,
+    isVisible: true,
+    fields: [],
+  },
+  {
+    id: ORDERS_ID,
+    type: 'custom',
+    label: 'Order',
+    plural: 'Orders',
+    apiSlug: 'orders',
+    entityType: 'order',
+    entityDefinitionId: ORDERS_ID,
+    isVisible: true,
+    fields: [],
+  },
+]
+
+const withResources = () => {
+  getCachedResources.mockReset()
+  getCachedResources.mockResolvedValue(RESOURCES)
+}
+
+const node = (id: string, title: string, data: Record<string, unknown> = {}): NodeMeta => ({
+  id,
+  type: 'standard',
+  data: { id, title, type: 'find', ...data },
+})
+
+describe('normalizeAiPromptConfig (golden)', () => {
+  it('converts a friendly `prompt` string into a prompt_template Tiptap entry', () => {
+    // Refs are normalized first (normalizeFriendlyRefs), then the prompt pass
+    // turns each {{…}} span into a variable-node chip via textToDoc.
+    const nodes = [node('n1aaaaaaaaaaaaaaaaaaaa', 'Find Contact')]
+    const { data: withRefs } = normalizeFriendlyRefs(
+      { prompt: 'Summarize {{Find Contact.body}} briefly' },
+      { nodes }
+    )
+    const config = normalizeAiPromptConfig('ai', withRefs)
+
+    expect(config).toEqual({
+      prompt_template: [
+        {
+          role: 'system',
+          json: {
+            type: 'doc',
+            content: [
+              {
+                type: 'paragraph',
+                content: [
+                  { type: 'text', text: 'Summarize ' },
+                  {
+                    type: 'variable-node',
+                    attrs: { variableId: 'n1aaaaaaaaaaaaaaaaaaaa.body' },
+                  },
+                  { type: 'text', text: ' briefly' },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    })
+  })
+
+  it('converts legacy { role, text } entries and bare strings; keeps Tiptap docs untouched', () => {
+    const doc = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'kept' }] }],
+    }
+    const config = normalizeAiPromptConfig('ai', {
+      prompt_template: [
+        'be brief',
+        { role: 'user', text: 'hi {{env.NAME}}' },
+        { role: 'user', json: doc },
+      ],
+    })
+
+    const entries = config.prompt_template as Array<{ role: string; json: unknown }>
+    expect(entries).toHaveLength(3)
+    expect(entries[0]).toMatchObject({ role: 'system' })
+    expect(entries[1]).toMatchObject({ role: 'user' })
+    expect(JSON.stringify(entries[1]!.json)).toContain('env.NAME')
+    expect(entries[2]!.json).toEqual(doc)
+  })
+
+  it('is a no-op for non-ai node types', () => {
+    const config = { prompt: 'plain {{x.y}}' }
+    expect(normalizeAiPromptConfig('answer', config)).toBe(config)
+  })
+})
+
+describe('resolveResourceRef', () => {
+  it('leaves tier-A system slugs alone (thread) without reading the cache', async () => {
+    withResources()
+    const result = await resolveResourceRef(ORG, 'thread')
+    expect(result._unsafeUnwrap()).toBe('thread')
+    expect(getCachedResources).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    'ticket',
+    'tickets',
+    'Ticket',
+  ])('resolves the tier-B alias %s to the org EntityDefinition CUID', async (alias) => {
+    withResources()
+    expect((await resolveResourceRef(ORG, alias))._unsafeUnwrap()).toBe(TICKET_ID)
+  })
+
+  it('resolves a tier-C custom apiSlug to its CUID', async () => {
+    withResources()
+    expect((await resolveResourceRef(ORG, 'orders'))._unsafeUnwrap()).toBe(ORDERS_ID)
+  })
+
+  it('passes an already-canonical CUID through', async () => {
+    withResources()
+    expect((await resolveResourceRef(ORG, TICKET_ID))._unsafeUnwrap()).toBe(TICKET_ID)
+  })
+
+  it('errors on an unknown slug with a did-you-mean candidate — never persists it', async () => {
+    withResources()
+    const result = await resolveResourceRef(ORG, 'tickett')
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('ticket')
+  })
+})
+
+describe('normalizeResourceConfig (golden: find)', () => {
+  it('rewrites resourceType slug → CUID and leaves the rest of the config alone', async () => {
+    withResources()
+    const { config, issues } = await normalizeResourceConfig(ORG, 'find', {
+      resourceType: 'ticket',
+      mode: 'findOne',
+    })
+    expect(config).toEqual({ resourceType: TICKET_ID, mode: 'findOne' })
+    expect(issues).toEqual([])
+  })
+
+  it('reports an unresolvable resource as an error issue carrying the field', async () => {
+    withResources()
+    const { config, issues } = await normalizeResourceConfig(ORG, 'find', {
+      resourceType: 'no-such-thing',
+    })
+    expect(config.resourceType).toBe('no-such-thing')
+    expect(issues).toHaveLength(1)
+    expect(issues[0]).toMatchObject({ severity: 'error', field: 'resourceType' })
+  })
+
+  it('skips node types without resource keys', async () => {
+    withResources()
+    const input = { text: 'hello' }
+    const { config, issues } = await normalizeResourceConfig(ORG, 'wait', input)
+    expect(config).toBe(input)
+    expect(issues).toEqual([])
+  })
+})
+
+describe('buildResourceAliasIndex', () => {
+  it('indexes tier B/C aliases only, both directions', async () => {
+    withResources()
+    const index = await buildResourceAliasIndex(ORG)
+    expect(index.aliasToId.get('ticket')).toBe(TICKET_ID)
+    expect(index.aliasToId.get('tickets')).toBe(TICKET_ID)
+    expect(index.aliasToId.get('orders')).toBe(ORDERS_ID)
+    expect(index.idToSlug.get(TICKET_ID)).toBe('ticket')
+    // Tier A never enters the index — its canonical id IS the slug.
+    expect(index.aliasToId.has('thread')).toBe(false)
+    expect(index.idToSlug.has('thread')).toBe(false)
+  })
+})
+
+describe('resolveConnectionSpec', () => {
+  const ifElse = node('if1aaaaaaaaaaaaaaaaaaa', 'Route It', {
+    type: 'if-else',
+    cases: [{ case_id: 'case-a', logical_operator: 'and', conditions: [] }],
+  })
+  const wait = node('w1aaaaaaaaaaaaaaaaaaaa', 'Wait A Bit', { type: 'wait' })
+  const http = node('h1aaaaaaaaaaaaaaaaaaaa', 'Call API', {
+    type: 'http',
+    error_strategy: 'fail',
+  })
+  const nodes = [ifElse, wait, http]
+
+  it('connects after a branchless node on the default source handle', () => {
+    expect(resolveConnectionSpec(nodes, { after: 'Wait A Bit' })._unsafeUnwrap()).toEqual({
+      sourceNodeId: 'w1aaaaaaaaaaaaaaaaaaaa',
+      sourceHandle: 'source',
+    })
+  })
+
+  it('resolves a branch by display name through manifest.connection.branches', () => {
+    expect(
+      resolveConnectionSpec(nodes, { after: 'Route It', branch: 'else' })._unsafeUnwrap()
+    ).toEqual({ sourceNodeId: 'if1aaaaaaaaaaaaaaaaaaa', sourceHandle: 'false' })
+    expect(
+      resolveConnectionSpec(nodes, { after: 'Route It', branch: 'IF' })._unsafeUnwrap()
+    ).toEqual({ sourceNodeId: 'if1aaaaaaaaaaaaaaaaaaa', sourceHandle: 'case-a' })
+  })
+
+  it('resolves a branch by handle id', () => {
+    expect(
+      resolveConnectionSpec(nodes, { after: 'Call API', branch: 'fail' })._unsafeUnwrap()
+    ).toEqual({ sourceNodeId: 'h1aaaaaaaaaaaaaaaaaaaa', sourceHandle: 'fail' })
+  })
+
+  it('uses the single default branch when none is specified (http)', () => {
+    expect(resolveConnectionSpec(nodes, { after: 'Call API' })._unsafeUnwrap()).toEqual({
+      sourceNodeId: 'h1aaaaaaaaaaaaaaaaaaaa',
+      sourceHandle: 'source',
+    })
+  })
+
+  it('errors when a multi-branch node gets no branch, naming every branch', () => {
+    const result = resolveConnectionSpec(nodes, { after: 'Route It' })
+    expect(result.isErr()).toBe(true)
+    const message = result._unsafeUnwrapErr().message
+    expect(message).toContain('case-a')
+    expect(message).toContain('false')
+  })
+
+  it('errors on an unknown branch, naming the candidates', () => {
+    const result = resolveConnectionSpec(nodes, { after: 'Route It', branch: 'no match' })
+    expect(result.isErr()).toBe(true)
+    const message = result._unsafeUnwrapErr().message
+    expect(message).toContain('No branch "no match"')
+    expect(message).toContain('IF')
+    expect(message).toContain('ELSE')
+  })
+
+  it('errors when a branch is named on a branchless node', () => {
+    const result = resolveConnectionSpec(nodes, { after: 'Wait A Bit', branch: 'fail' })
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('has no branches')
+  })
+
+  it('propagates node-ref resolution errors (unknown after)', () => {
+    expect(resolveConnectionSpec(nodes, { after: 'Ghost' }).isErr()).toBe(true)
+  })
+})

--- a/packages/lib/src/workflows/graph-edit/__tests__/ref-check.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/ref-check.test.ts
@@ -1,0 +1,186 @@
+// packages/lib/src/workflows/graph-edit/__tests__/ref-check.test.ts
+
+/**
+ * Dangling-ref and non-upstream-ref errors naming candidates
+ * (`03-graph-edit-service.md` §9), including the collection-shape correction:
+ * `{{X.attachments[*]}}` comes back WITH the suggested `.values[*]` form.
+ * Upstream reachability comes from the catalog's `buildUpstreamMap`.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { BaseType } from '../../../workflow-engine/core/types'
+import type { UnifiedVariable } from '../../../workflow-engine/types/unified-variable'
+import type { NodeMeta, WorkflowOutputGraph } from '../types'
+
+// ref-check statically imports the catalog's server-side resolve-outputs, whose
+// cache read must not hit a real backend if the composed helper is ever used.
+const getCachedResources = vi.fn().mockResolvedValue([])
+vi.mock('../../../cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../cache')>()),
+  getCachedResources: (...args: unknown[]) => getCachedResources(...args),
+}))
+
+const { checkVariableRefsAgainstOutputs } = await import('../normalize/ref-check')
+
+const TICKET_ID = 'i5aezsg4bc6n8gof2uan3wcf'
+const FIND = 'find1aaaaaaaaaaaaaaaaa'
+const CONSUMER = 'ai1aaaaaaaaaaaaaaaaaaa'
+const STRAY = 'strayaaaaaaaaaaaaaaaaa'
+
+const variable = (
+  id: string,
+  type: BaseType,
+  extra: Partial<UnifiedVariable> = {}
+): UnifiedVariable => ({
+  id,
+  label: id.split('.').pop() ?? id,
+  type,
+  category: 'node',
+  ...extra,
+})
+
+/** Declared find outputs: scalar, entity object with fields, a has-many wrapper, an open object. */
+const FIND_OUTPUTS: UnifiedVariable[] = [
+  variable(`${FIND}.count`, BaseType.NUMBER),
+  variable(`${FIND}.${TICKET_ID}`, BaseType.OBJECT, {
+    properties: {
+      subject: variable(`${FIND}.${TICKET_ID}.subject`, BaseType.STRING),
+      email: variable(`${FIND}.${TICKET_ID}.email`, BaseType.EMAIL),
+      record: variable(`${FIND}.${TICKET_ID}.record`, BaseType.OBJECT),
+      attachments: variable(`${FIND}.${TICKET_ID}.attachments`, BaseType.OBJECT, {
+        properties: {
+          values: variable(`${FIND}.${TICKET_ID}.attachments.values`, BaseType.ARRAY, {
+            items: variable(`${FIND}.${TICKET_ID}.attachments.values[*]`, BaseType.OBJECT, {
+              properties: {
+                name: variable(`${FIND}.${TICKET_ID}.attachments.values[*].name`, BaseType.STRING),
+              },
+            }),
+          }),
+          count: variable(`${FIND}.${TICKET_ID}.attachments.count`, BaseType.NUMBER),
+          isEmpty: variable(`${FIND}.${TICKET_ID}.attachments.isEmpty`, BaseType.BOOLEAN),
+          first: variable(`${FIND}.${TICKET_ID}.attachments.first`, BaseType.OBJECT),
+          last: variable(`${FIND}.${TICKET_ID}.attachments.last`, BaseType.OBJECT),
+        },
+      }),
+    },
+  }),
+]
+
+/** A consumer with no catalog manifest, so the generic {{…}} walk extracts its refs. */
+const consumerNode = (refs: string[]): NodeMeta => ({
+  id: CONSUMER,
+  type: 'standard',
+  data: { id: CONSUMER, type: 'custom-consumer', title: 'Draft Reply', text: refs.join(' ') },
+})
+
+const graphWith = (consumer: NodeMeta): WorkflowOutputGraph => ({
+  nodes: [
+    { id: FIND, type: 'standard', data: { id: FIND, type: 'custom-find', title: 'Find Contact' } },
+    consumer,
+    { id: STRAY, type: 'standard', data: { id: STRAY, type: 'custom-x', title: 'Stray Step' } },
+  ],
+  edges: [{ id: 'e1', source: FIND, target: CONSUMER }],
+})
+
+const check = (refs: string[]) =>
+  checkVariableRefsAgainstOutputs({
+    graph: graphWith(consumerNode(refs.map((r) => `{{${r}}}`))),
+    outputs: new Map([[FIND, FIND_OUTPUTS]]),
+  })
+
+describe('checkVariableRefsAgainstOutputs', () => {
+  it('accepts declared paths, numeric accessors, open-object depth, env/sys refs', () => {
+    const { issues } = check([
+      `${FIND}.count`,
+      `${FIND}.${TICKET_ID}.subject`,
+      `${FIND}.${TICKET_ID}.attachments.values[0].name`,
+      `${FIND}.${TICKET_ID}.attachments.first`,
+      `${FIND}.${TICKET_ID}.record.arbitrary.deep.path`,
+      'env.THRESHOLD',
+      'sys.userId',
+    ])
+    expect(issues).toEqual([])
+  })
+
+  it('reports a typo with did-you-mean candidates from the declared siblings', () => {
+    const { issues } = check([`${FIND}.${TICKET_ID}.emial`])
+    expect(issues).toHaveLength(1)
+    expect(issues[0]).toMatchObject({
+      severity: 'error',
+      nodeRef: 'Draft Reply',
+      ref: `${FIND}.${TICKET_ID}.emial`,
+      suggestion: `${FIND}.${TICKET_ID}.email`,
+    })
+    expect(issues[0]!.message).toContain('No output "emial" on node Find Contact')
+    expect(issues[0]!.message).toContain('did you mean "email"')
+  })
+
+  it('corrects a bare-array collection ref with the .values[*] form instead of rejecting it', () => {
+    const { issues, corrections } = check([`${FIND}.${TICKET_ID}.attachments[*].name`])
+    expect(issues).toHaveLength(1)
+    expect(issues[0]).toMatchObject({
+      severity: 'error',
+      suggestion: `${FIND}.${TICKET_ID}.attachments.values[*].name`,
+    })
+    expect(issues[0]!.message).toContain('.count')
+    expect(corrections).toEqual([
+      {
+        nodeId: CONSUMER,
+        from: `${FIND}.${TICKET_ID}.attachments[*].name`,
+        to: `${FIND}.${TICKET_ID}.attachments.values[*].name`,
+      },
+    ])
+  })
+
+  it('preserves the original numeric accessor in a collection correction', () => {
+    const { corrections } = check([`${FIND}.${TICKET_ID}.attachments[0].name`])
+    expect(corrections[0]?.to).toBe(`${FIND}.${TICKET_ID}.attachments.values[0].name`)
+  })
+
+  it('reports a ref to an unknown node with candidates', () => {
+    const { issues } = check(['ghostnode.total'])
+    expect(issues).toHaveLength(1)
+    expect(issues[0]!.severity).toBe('error')
+    expect(issues[0]!.message).toContain('unknown node "ghostnode"')
+  })
+
+  it('reports a ref to a node that exists but is not upstream, naming both nodes', () => {
+    const { issues } = check([`${STRAY}.result`])
+    expect(issues).toHaveLength(1)
+    expect(issues[0]!.severity).toBe('error')
+    expect(issues[0]!.message).toContain('Stray Step')
+    expect(issues[0]!.message).toContain('not upstream')
+    expect(issues[0]!.message).toContain('Draft Reply')
+  })
+
+  it('reports a self-reference', () => {
+    const { issues } = check([`${CONSUMER}.text`])
+    expect(issues).toHaveLength(1)
+    expect(issues[0]!.message).toContain('own output')
+  })
+
+  it('skips path validation for nodes with no declared outputs (not-yet-migrated)', () => {
+    const graph = graphWith(consumerNode([`{{${FIND}.anything.at.all}}`]))
+    const { issues } = checkVariableRefsAgainstOutputs({ graph, outputs: new Map() })
+    expect(issues).toEqual([])
+  })
+
+  it('allows loop children to read their container via parentId ancestry', () => {
+    const loopId = 'loop1aaaaaaaaaaaaaaaaa'
+    const child: NodeMeta = {
+      id: CONSUMER,
+      type: 'standard',
+      parentId: loopId,
+      data: { id: CONSUMER, type: 'custom-consumer', title: 'Child', text: `{{${loopId}.item}}` },
+    }
+    const graph: WorkflowOutputGraph = {
+      nodes: [
+        { id: loopId, type: 'loop', data: { id: loopId, type: 'loop', title: 'For Each' } },
+        child,
+      ],
+      edges: [],
+    }
+    const { issues } = checkVariableRefsAgainstOutputs({ graph, outputs: new Map() })
+    expect(issues).toEqual([])
+  })
+})

--- a/packages/lib/src/workflows/graph-edit/__tests__/refs.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/refs.test.ts
@@ -1,0 +1,125 @@
+// packages/lib/src/workflows/graph-edit/__tests__/refs.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { formatNodeRef, isIdShaped, matchNodeRefPrefix, resolveNodeRef } from '../refs'
+import type { NodeMeta } from '../types'
+
+const node = (id: string, title: string, data: Record<string, unknown> = {}): NodeMeta => ({
+  id,
+  type: 'standard',
+  data: { id, type: 'find', title, ...data },
+})
+
+const NODES: NodeMeta[] = [
+  node('n1aaaaaaaaaaaaaaaaaaaa', 'Find Contact'),
+  node('n2aaaaaaaaaaaaaaaaaaaa', 'Find Tickets'),
+  node('n3aaaaaaaaaaaaaaaaaaaa', 'Find Mr. Smith'),
+  node('d1aaaaaaaaaaaaaaaaaaaa', 'Send Reply'),
+  node('d2aaaaaaaaaaaaaaaaaaaa', 'Send Reply'),
+]
+
+describe('resolveNodeRef', () => {
+  it('resolves an exact title match case-insensitively', () => {
+    const result = resolveNodeRef(NODES, 'find contact')
+    expect(result._unsafeUnwrap()).toMatchObject({
+      node: { id: 'n1aaaaaaaaaaaaaaaaaaaa' },
+      matchedBy: 'title',
+    })
+  })
+
+  it('errors on an ambiguous title, listing every candidate with its id', () => {
+    const result = resolveNodeRef(NODES, 'Send Reply')
+    expect(result.isErr()).toBe(true)
+    const message = result._unsafeUnwrapErr().message
+    expect(message).toContain('ambiguous')
+    expect(message).toContain('d1aaaaaaaaaaaaaaaaaaaa')
+    expect(message).toContain('d2aaaaaaaaaaaaaaaaaaaa')
+  })
+
+  it('falls back to an exact id match when no title matches', () => {
+    const result = resolveNodeRef(NODES, 'n2aaaaaaaaaaaaaaaaaaaa')
+    expect(result._unsafeUnwrap()).toMatchObject({
+      node: { id: 'n2aaaaaaaaaaaaaaaaaaaa' },
+      matchedBy: 'id',
+    })
+  })
+
+  it('returns an actionable not-found error naming close candidates', () => {
+    const result = resolveNodeRef(NODES, 'Find Contct')
+    expect(result.isErr()).toBe(true)
+    const message = result._unsafeUnwrapErr().message
+    expect(message).toContain('No node matches "Find Contct"')
+    expect(message).toContain('Find Contact')
+  })
+
+  it('notes when an id-shaped ref matches no node', () => {
+    const result = resolveNodeRef(NODES, 'zzzzzzzzzzzzzzzzzzzzzzzz')
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('No node has this id either')
+  })
+
+  it('rejects an empty ref', () => {
+    expect(resolveNodeRef(NODES, '  ').isErr()).toBe(true)
+  })
+})
+
+describe('matchNodeRefPrefix', () => {
+  it('matches a title head and returns the path remainder', () => {
+    const match = matchNodeRefPrefix(NODES, 'Find Contact.email')._unsafeUnwrap()
+    expect(match).toMatchObject({ node: { id: 'n1aaaaaaaaaaaaaaaaaaaa' }, rest: 'email' })
+  })
+
+  it('matches a title containing a dot via longest-prefix', () => {
+    const match = matchNodeRefPrefix(NODES, 'Find Mr. Smith.email')._unsafeUnwrap()
+    expect(match).toMatchObject({ node: { id: 'n3aaaaaaaaaaaaaaaaaaaa' }, rest: 'email' })
+  })
+
+  it('matches an id head', () => {
+    const match = matchNodeRefPrefix(NODES, 'n2aaaaaaaaaaaaaaaaaaaa.tickets[*]')._unsafeUnwrap()
+    expect(match).toMatchObject({ node: { id: 'n2aaaaaaaaaaaaaaaaaaaa' }, rest: 'tickets[*]' })
+  })
+
+  it('keeps a bracket remainder attached to the ref head', () => {
+    const withBracket = [...NODES, node('n4aaaaaaaaaaaaaaaaaaaa', 'Orders')]
+    const match = matchNodeRefPrefix(withBracket, 'Orders[0].total')._unsafeUnwrap()
+    expect(match).toMatchObject({ node: { id: 'n4aaaaaaaaaaaaaaaaaaaa' }, rest: '[0].total' })
+  })
+
+  it('errors on an ambiguous title head instead of guessing', () => {
+    const result = matchNodeRefPrefix(NODES, 'Send Reply.status')
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('ambiguous')
+  })
+
+  it('returns null for prose that merely starts with a title', () => {
+    expect(matchNodeRefPrefix(NODES, 'Find Contact. Thanks.')._unsafeUnwrap()).toBeNull()
+  })
+
+  it('returns null for non-refs (env/prose)', () => {
+    expect(matchNodeRefPrefix(NODES, 'no such thing.here')._unsafeUnwrap()).toBeNull()
+  })
+})
+
+describe('formatNodeRef', () => {
+  it('renders a unique title', () => {
+    expect(formatNodeRef(NODES, 'n1aaaaaaaaaaaaaaaaaaaa')).toBe('Find Contact')
+  })
+
+  it('keeps the id when the title is duplicated — the only rendering that round-trips', () => {
+    expect(formatNodeRef(NODES, 'd1aaaaaaaaaaaaaaaaaaaa')).toBe('d1aaaaaaaaaaaaaaaaaaaa')
+  })
+
+  it('passes unknown ids through', () => {
+    expect(formatNodeRef(NODES, 'ghost')).toBe('ghost')
+  })
+})
+
+describe('isIdShaped', () => {
+  it.each(['V1StGXR8_Z5jdHi6B-myT', 'i5aezsg4bc6n8gof2uan3wcf'])('accepts %s', (id) => {
+    expect(isIdShaped(id)).toBe(true)
+  })
+
+  it.each(['Find Contact', 'short', 'has.dot.aaaaaaaaaaaaaa'])('rejects %s', (ref) => {
+    expect(isIdShaped(ref)).toBe(false)
+  })
+})

--- a/packages/lib/src/workflows/graph-edit/index.ts
+++ b/packages/lib/src/workflows/graph-edit/index.ts
@@ -1,0 +1,59 @@
+// packages/lib/src/workflows/graph-edit/index.ts
+
+/**
+ * Headless graph-edit module (`plans/kopilot/workflow/03-graph-edit-service.md`)
+ * — friendly input in, validated graph + resolved outputs out. SERVER-ONLY
+ * entrypoint: `resource-refs.ts` and `ref-check.ts` read the org cache, so this
+ * barrel must never be exported through a client bundle (same rule as the
+ * catalog's `build-output-context.ts`/`resolve-outputs.ts` leaf subpaths).
+ * The pure pieces (`refs.ts`, `normalize/friendly-refs.ts`,
+ * `normalize/prompt.ts`, `normalize/connection.ts`) are browser-safe and can
+ * grow a dedicated client surface when a UI consumer appears.
+ *
+ * This file exports the §2 (reference resolution) + §3 (friendly → persisted
+ * normalization) surface; the mutation ops, pipeline and layout land in their
+ * own slices and extend these exports.
+ */
+
+export {
+  type ConnectionSpec,
+  resolveConnectionSpec,
+} from './normalize/connection'
+export {
+  type FriendlyRefsResult,
+  normalizeFriendlyRefs,
+  type ResourceAliasIndex,
+  renderPersistedRefs,
+} from './normalize/friendly-refs'
+export { normalizeAiPromptConfig } from './normalize/prompt'
+export {
+  checkGraphRefs,
+  checkVariableRefsAgainstOutputs,
+  type RefCheckResult,
+} from './normalize/ref-check'
+export {
+  buildResourceAliasIndex,
+  normalizeResourceConfig,
+  RESOURCE_CONFIG_KEYS,
+  resolveResourceRef,
+} from './normalize/resource-refs'
+export {
+  closestMatches,
+  describeNode,
+  formatNodeRef,
+  isIdShaped,
+  matchNodeRefPrefix,
+  type NodeRefPrefixMatch,
+  nodeTitle,
+  resolveNodeRef,
+} from './refs'
+export type {
+  EdgeMeta,
+  Issue,
+  IssueSeverity,
+  NodeMeta,
+  NodeRef,
+  RefCorrection,
+  ResolvedNodeRef,
+  WorkflowOutputGraph,
+} from './types'

--- a/packages/lib/src/workflows/graph-edit/normalize/connection.ts
+++ b/packages/lib/src/workflows/graph-edit/normalize/connection.ts
@@ -1,0 +1,98 @@
+// packages/lib/src/workflows/graph-edit/normalize/connection.ts
+
+/**
+ * Friendly connection resolution (`03-graph-edit-service.md` §3 rows 6–7) —
+ * pure, browser-safe.
+ *
+ * `after: "<title-or-id>"` names the predecessor node; `branch: "no match"`
+ * names one of its outgoing branches. The branch id is resolved through
+ * `manifest.connection.branches(config)` from the catalog registry — the
+ * single source for the handle ids the canvas renders and the processors
+ * emit — NEVER string-matched locally, so a rename of a branch-derivation rule
+ * can't silently detach agent-authored edges.
+ */
+
+import { err, ok, type Result } from 'neverthrow'
+import { type AuxxError, BadRequestError } from '../../../errors'
+import { getManifest } from '../../../workflow-engine/catalog/registry'
+import type { NodeBranch } from '../../../workflow-engine/catalog/types'
+import { describeNode, resolveNodeRef } from '../refs'
+import type { NodeMeta } from '../types'
+
+/** The default source handle for a node with no branch handles. */
+const DEFAULT_SOURCE_HANDLE = 'source'
+
+/** A resolved `after`/`branch` pair, ready to become an edge. */
+export interface ConnectionSpec {
+  sourceNodeId: string
+  sourceHandle: string
+}
+
+/** `Name (id)` / `id` — the candidate format branch errors use. */
+function describeBranch(branch: NodeBranch): string {
+  return branch.name ? `"${branch.name}" (${branch.id})` : `"${branch.id}"`
+}
+
+/**
+ * Resolve `after` (node title or id) and optional `branch` (branch name or
+ * handle id, case-insensitive) to the edge source the mutation should write.
+ *
+ * - No branch given: nodes without branch handles connect on the default
+ *   `source` handle; nodes with exactly one `default`-kind branch use it;
+ *   nodes with several (if-else cases, classifier categories) are an error
+ *   naming every branch — never a guess.
+ * - Branch given: matched against `manifest.connection.branches(config)` by
+ *   name then id; no match is an error naming the candidates.
+ */
+export function resolveConnectionSpec(
+  nodes: NodeMeta[],
+  params: { after: string; branch?: string }
+): Result<ConnectionSpec, AuxxError> {
+  const resolved = resolveNodeRef(nodes, params.after)
+  if (resolved.isErr()) return err(resolved.error)
+  const source = resolved.value.node
+
+  const nodeType: string | undefined = source.data?.type ?? source.type
+  const manifest = nodeType ? getManifest(nodeType) : undefined
+  const branches = manifest?.connection.branches?.(source.data) ?? []
+
+  const branchRef = params.branch?.trim()
+  if (!branchRef) {
+    if (branches.length === 0) {
+      return ok({ sourceNodeId: source.id, sourceHandle: DEFAULT_SOURCE_HANDLE })
+    }
+    const defaults = branches.filter((b) => b.kind === 'default')
+    if (defaults.length === 1) {
+      return ok({ sourceNodeId: source.id, sourceHandle: defaults[0]!.id })
+    }
+    return err(
+      new BadRequestError(
+        `Node ${describeNode(source)} has ${branches.length} branches — specify one: ` +
+          `${branches.map(describeBranch).join(', ')}.`
+      )
+    )
+  }
+
+  if (branches.length === 0) {
+    return err(
+      new BadRequestError(
+        `Node ${describeNode(source)} has no branches — omit "branch" to connect its output.`
+      )
+    )
+  }
+
+  const needle = branchRef.toLowerCase()
+  const match =
+    branches.find((b) => b.name.toLowerCase() === needle) ??
+    branches.find((b) => b.id.toLowerCase() === needle)
+  if (!match) {
+    return err(
+      new BadRequestError(
+        `No branch "${branchRef}" on node ${describeNode(source)}. Available branches: ` +
+          `${branches.map(describeBranch).join(', ')}.`
+      )
+    )
+  }
+
+  return ok({ sourceNodeId: source.id, sourceHandle: match.id })
+}

--- a/packages/lib/src/workflows/graph-edit/normalize/friendly-refs.ts
+++ b/packages/lib/src/workflows/graph-edit/normalize/friendly-refs.ts
@@ -1,0 +1,236 @@
+// packages/lib/src/workflows/graph-edit/normalize/friendly-refs.ts
+
+/**
+ * Friendly ↔ persisted variable-reference rewriting (`03-graph-edit-service.md`
+ * §3, rows 1 and 3) — pure, browser-safe.
+ *
+ * Friendly → persisted: `{{Find Contact.email}}` → `{{<nodeId>.email}}`, and
+ * the resource segment one level deeper: `{{Find Tickets.ticket.subject}}` →
+ * `{{<nodeId>.<entityDefId>.subject}}` — the same rewrite
+ * `TemplateGraphTransformer.cloneGraph` does for template node ids and
+ * `resolveEntityRefsInGraph` does for `@entity:` tokens, applied to titles and
+ * resource slugs so a model never types a raw id.
+ *
+ * Persisted → friendly: the exact reverse, so everything returned to a caller
+ * renders refs as `{{Title.path}}` (and resource slugs) — a model that has
+ * never seen a raw id cannot invent one.
+ *
+ * The friendly direction deliberately does NOT reuse
+ * `rewriteVariableRefs` (`../../variable-ref-rewriter`): that walker applies
+ * one strictness to `{{…}}` spans and bare strings alike, while friendly input
+ * needs two regimes — spans are always refs (an unresolvable one is an ERROR,
+ * never a silent drop), bare strings are only *possibly* refs (prose that
+ * happens to start like a title must pass through untouched). The reverse
+ * direction has no such split and reuses the shared walker via the same
+ * traversal contract. Both directions share `firstPathSegment` and the
+ * `VARIABLE_PATTERN` span grammar rather than re-deriving them.
+ */
+
+import { VARIABLE_PATTERN } from '../../../workflow-engine/catalog/variable-inference'
+import { firstPathSegment, rewriteVariableRefs } from '../../variable-ref-rewriter'
+import { formatNodeRef, matchNodeRefPrefix, nodeTitle } from '../refs'
+import type { Issue, NodeMeta } from '../types'
+
+/**
+ * Per-org resource alias lookup for the resource path segment (tier B/C only —
+ * tier-A slugs ARE their canonical id and never appear here). Built server-side
+ * by `buildResourceAliasIndex` (`resource-refs.ts`); consumed by the pure
+ * rewriters so they stay browser-safe.
+ */
+export interface ResourceAliasIndex {
+  /** lowercased alias (id, entityType, apiSlug, label, plural) → canonical resource id */
+  aliasToId: Map<string, string>
+  /** canonical resource id → the slug rendered back to the model (entityType ?? apiSlug) */
+  idToSlug: Map<string, string>
+}
+
+/** First-segment prefixes that are never node refs. */
+const RESERVED_PREFIXES = new Set(['env', 'sys'])
+
+/** Result of a friendly-ref rewrite pass. */
+export interface FriendlyRefsResult<T> {
+  data: T
+  issues: Issue[]
+}
+
+/** The canonical resource id a node's `resourceType` config resolves to, if tier B/C. */
+function canonicalResourceIdFor(
+  node: NodeMeta,
+  aliases: ResourceAliasIndex | undefined
+): string | undefined {
+  if (!aliases) return undefined
+  const resourceType = node.data?.resourceType
+  if (typeof resourceType !== 'string' || !resourceType) return undefined
+  if (aliases.idToSlug.has(resourceType)) return resourceType
+  return aliases.aliasToId.get(resourceType.toLowerCase())
+}
+
+/** Join a resolved head onto a path remainder (`''`, `.x…` via caller, or `[0]…`). */
+function joinHead(head: string, rest: string): string {
+  if (!rest) return head
+  return rest.startsWith('[') ? `${head}${rest}` : `${head}.${rest}`
+}
+
+/**
+ * Rewrite the resource segment at the head of `rest` to `canonicalId` when it
+ * is an alias of that same resource (never a guess across resources).
+ */
+function aliasResourceSegment(
+  rest: string,
+  canonicalId: string | undefined,
+  aliases: ResourceAliasIndex | undefined
+): string {
+  if (!rest || !canonicalId || !aliases) return rest
+  const segment = firstPathSegment(rest)
+  if (!segment || segment === canonicalId) return rest
+  if (aliases.aliasToId.get(segment.toLowerCase()) !== canonicalId) return rest
+  return canonicalId + rest.slice(segment.length)
+}
+
+interface WalkOptions {
+  /** Rewrite one `{{…}}` span's inner path. Unresolvable refs report an issue. */
+  mapSpanPath: (path: string) => string
+  /** Rewrite one bare string that *may* be a ref (already gated). */
+  mapBarePath: (path: string) => string
+  /** Gate for bare strings: first path segment must be in this set. */
+  bareGate: Set<string>
+}
+
+/** Depth-first walk over node data, string values only, keys untouched. */
+function walk(value: unknown, options: WalkOptions): unknown {
+  if (typeof value === 'string') {
+    if (value.includes('{{')) {
+      return value.replace(VARIABLE_PATTERN, (_full, inner: string) => {
+        return `{{${options.mapSpanPath(inner)}}}`
+      })
+    }
+    if (options.bareGate.has(firstPathSegment(value))) {
+      return options.mapBarePath(value)
+    }
+    return value
+  }
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) value[i] = walk(value[i], options)
+    return value
+  }
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    for (const key of Object.keys(record)) {
+      record[key] = walk(record[key], options)
+    }
+    return record
+  }
+  return value
+}
+
+/**
+ * Friendly → persisted: rewrite every `{{Title.path}}` span and every gated
+ * bare title/id reference in `data` to `{{<nodeId>.path}}`, aliasing the
+ * resource path segment to the source node's canonical resource id where
+ * applicable. Returns a deep clone; `data` is never mutated.
+ *
+ * Every span whose head resolves to nothing — and every ambiguous title —
+ * comes back as an ERROR issue naming candidates; the value itself is left
+ * verbatim so the caller can refuse to persist. Bare strings that fail to
+ * resolve stay untouched *without* an issue (they may be prose); the
+ * post-mutation reference check (`ref-check.ts`) is the net under those.
+ */
+export function normalizeFriendlyRefs<T>(
+  data: T,
+  params: { nodes: NodeMeta[]; resourceAliases?: ResourceAliasIndex }
+): FriendlyRefsResult<T> {
+  const { nodes, resourceAliases } = params
+  const issues: Issue[] = []
+
+  const bareGate = new Set<string>()
+  for (const node of nodes) {
+    bareGate.add(node.id)
+    const title = nodeTitle(node)
+    if (title) bareGate.add(firstPathSegment(title))
+  }
+
+  const mapPath = (path: string, strict: boolean): string => {
+    const trimmed = path.trim()
+    if (!trimmed || RESERVED_PREFIXES.has(firstPathSegment(trimmed))) return path
+
+    const match = matchNodeRefPrefix(nodes, trimmed)
+    if (match.isErr()) {
+      issues.push({ severity: 'error', ref: trimmed, message: match.error.message })
+      return path
+    }
+    if (match.value === null) {
+      if (strict) {
+        // Head matches no title and no id — try resolveNodeRef purely for its
+        // actionable candidate list (it cannot succeed where the prefix
+        // matcher found nothing at any boundary).
+        const titles = nodes.map(nodeTitle).filter(Boolean)
+        issues.push({
+          severity: 'error',
+          ref: trimmed,
+          message:
+            `Unknown node reference in "{{${trimmed}}}" — no node title or id matches its start.` +
+            (titles.length > 0
+              ? ` Available nodes: ${titles.map((t) => `"${t}"`).join(', ')}.`
+              : ''),
+        })
+      }
+      return path
+    }
+
+    const { node, rest } = match.value
+    const aliasedRest = aliasResourceSegment(
+      rest,
+      canonicalResourceIdFor(node, resourceAliases),
+      resourceAliases
+    )
+    return joinHead(node.id, aliasedRest)
+  }
+
+  const cloned = structuredClone(data)
+  const result = walk(cloned, {
+    mapSpanPath: (path) => mapPath(path, true),
+    mapBarePath: (path) => mapPath(path, false),
+    bareGate,
+  }) as T
+  return { data: result, issues }
+}
+
+/**
+ * Persisted → friendly: render every `{{<nodeId>.path}}` span and bare id ref
+ * as `{{Title.path}}` (title only when unique — a duplicated title keeps the
+ * id, the only rendering that round-trips), and the canonical resource segment
+ * back to its slug. Returns a deep clone; infallible — unknown ids pass
+ * through unchanged.
+ *
+ * Reuses the shared `rewriteVariableRefs` walker: in this direction spans and
+ * bare strings need the same treatment (an id head either resolves or is left
+ * alone), which is exactly that walker's contract.
+ */
+export function renderPersistedRefs<T>(
+  data: T,
+  params: { nodes: NodeMeta[]; resourceAliases?: ResourceAliasIndex }
+): T {
+  const { nodes, resourceAliases } = params
+  const nodeIds = new Set(nodes.map((n) => n.id))
+  const nodeById = new Map(nodes.map((n) => [n.id, n]))
+
+  const mapPath = (path: string): string => {
+    const trimmed = path.trim()
+    const head = firstPathSegment(trimmed)
+    const node = nodeById.get(head)
+    if (!node) return path
+
+    let rest = trimmed.slice(head.length).replace(/^\./, '')
+    const canonicalId = canonicalResourceIdFor(node, resourceAliases)
+    if (rest && canonicalId && resourceAliases) {
+      const segment = firstPathSegment(rest)
+      if (segment === canonicalId) {
+        const slug = resourceAliases.idToSlug.get(canonicalId)
+        if (slug) rest = slug + rest.slice(segment.length)
+      }
+    }
+    return joinHead(formatNodeRef(nodes, node.id), rest)
+  }
+
+  return rewriteVariableRefs(structuredClone(data), nodeIds, mapPath)
+}

--- a/packages/lib/src/workflows/graph-edit/normalize/prompt.ts
+++ b/packages/lib/src/workflows/graph-edit/normalize/prompt.ts
@@ -1,0 +1,78 @@
+// packages/lib/src/workflows/graph-edit/normalize/prompt.ts
+
+/**
+ * Prompt normalization for ai-style nodes (`03-graph-edit-service.md` §3
+ * row 4) — pure, browser-safe.
+ *
+ * The `ai` node persists `prompt_template: Array<{ role, json: TiptapDoc }>`;
+ * a model authors plain strings with `{{…}}` refs. This converts the friendly
+ * forms through the EXISTING machinery — `textToDoc({ parseVariables: true })`
+ * via `normalizeTemplateGraph` (`../../normalize-template-graph`), the same
+ * pass template install already runs — rather than re-implementing the
+ * string → Tiptap conversion.
+ *
+ * Only `ai` is touched: `information-extractor`, `answer` and
+ * `text-classifier` use plain `{{variable}}` strings by design
+ * (`normalize-template-graph.ts` documents the same boundary).
+ */
+
+import { normalizeTemplateGraph } from '../../normalize-template-graph'
+
+/** Friendly prompt entry shapes accepted from an agent. */
+type FriendlyPromptEntry = string | { role?: string; text?: string; json?: unknown }
+
+/**
+ * Normalize an `ai` node config's prompt to the persisted
+ * `prompt_template: [{ role, json }]` shape. Accepted friendly forms:
+ *
+ * - `prompt: "Summarize {{Find Contact.body}}"` → a single system entry
+ * - `prompt_template: ["...", { role, text }, { role, json }]` — bare strings
+ *   become system entries, `{ role, text }` entries convert, Tiptap-doc
+ *   entries pass through untouched (idempotent).
+ *
+ * Variable refs inside the text should already be in persisted `{{nodeId.…}}`
+ * form (run `normalizeFriendlyRefs` first) — `textToDoc` turns each `{{…}}`
+ * span into a `variable-node` chip verbatim.
+ *
+ * Non-`ai` node types and configs without prompt keys pass through unchanged.
+ * Returns a clone; `config` is never mutated.
+ */
+export function normalizeAiPromptConfig<T extends Record<string, unknown>>(
+  nodeType: string,
+  config: T
+): T {
+  if (nodeType !== 'ai') return config
+  const hasFriendlyPrompt = typeof config.prompt === 'string'
+  if (!hasFriendlyPrompt && !Array.isArray(config.prompt_template)) return config
+
+  const friendlyEntries: FriendlyPromptEntry[] = hasFriendlyPrompt
+    ? [{ role: 'system', text: config.prompt as string }]
+    : (config.prompt_template as FriendlyPromptEntry[])
+
+  // Bare strings → { role: 'system', text } so `normalizeTemplateGraph` (which
+  // reads `entry.text`) sees them; everything else passes through for it to
+  // convert-or-keep.
+  const prepared = friendlyEntries.map((entry) =>
+    typeof entry === 'string' ? { role: 'system', text: entry } : entry
+  )
+
+  // Reuse the template-install pass verbatim by wrapping the prompt as a
+  // one-node graph — it converts `{ role, text }` via
+  // `textToDoc({ parseVariables: true })` and leaves Tiptap docs untouched.
+  const normalized = normalizeTemplateGraph({
+    nodes: [
+      {
+        id: 'n',
+        type: 'standard',
+        position: { x: 0, y: 0 },
+        data: { type: 'ai', prompt_template: prepared },
+      },
+    ],
+    edges: [],
+  })
+
+  const result: Record<string, unknown> = { ...config }
+  delete result.prompt
+  result.prompt_template = normalized.nodes[0]!.data.prompt_template
+  return result as T
+}

--- a/packages/lib/src/workflows/graph-edit/normalize/ref-check.ts
+++ b/packages/lib/src/workflows/graph-edit/normalize/ref-check.ts
@@ -1,0 +1,332 @@
+// packages/lib/src/workflows/graph-edit/normalize/ref-check.ts
+
+/**
+ * Reference validation against resolved outputs (`03-graph-edit-service.md`
+ * §3 last rows + §5 tier 3): every `{{…}}` ref in a graph either resolves
+ * against the declared output tree of an upstream node, or comes back as an
+ * ERROR naming candidates — never a silent drop, never silently persisted
+ * (this codebase already has a scar from a condition builder that dropped
+ * unmatched clauses and failed open).
+ *
+ * Collection shapes get a *correction with a suggestion*, not a bare
+ * rejection: `has_many`/`many_to_many` relations expand to a wrapper
+ * (`.values[*]`, `.count`, `.isEmpty`, `.first`, `.last`), so the
+ * `{{X.attachments[*]}}` a model writes every time is answered with the
+ * `{{X.attachments.values[*]}}` form it should have used.
+ *
+ * `checkVariableRefsAgainstOutputs` is pure (outputs supplied);
+ * `checkGraphRefs` composes it with the catalog's server-side
+ * `resolveGraphOutputs` and is therefore SERVER-ONLY.
+ */
+
+import { err, ok, type Result } from 'neverthrow'
+import { buildUpstreamMap } from '../../../workflow-engine/catalog/graph-vars'
+import { getManifest } from '../../../workflow-engine/catalog/registry'
+import { resolveGraphOutputs } from '../../../workflow-engine/catalog/resolve-outputs'
+import type { UnifiedVariable } from '../../../workflow-engine/types/unified-variable'
+import { firstPathSegment, rewriteVariableRefs } from '../../variable-ref-rewriter'
+import { closestMatches, formatNodeRef, nodeTitle } from '../refs'
+import type { Issue, NodeMeta, RefCorrection, WorkflowOutputGraph } from '../types'
+
+/** What a reference check returns: findings plus machine-applicable fixes. */
+export interface RefCheckResult {
+  issues: Issue[]
+  corrections: RefCorrection[]
+}
+
+/** First-segment prefixes that are never node refs and are skipped entirely. */
+const RESERVED_PREFIXES = new Set(['env', 'sys'])
+
+/** Numeric accessors resolve against the declared `[*]` item — normalize for matching. */
+function normalizeIndices(path: string): string {
+  return path.replace(/\[-?\d+\]/g, '[*]')
+}
+
+/** Flatten a declared output tree into id → variable (walking properties/items). */
+function indexTree(variables: UnifiedVariable[], into: Map<string, UnifiedVariable>): void {
+  for (const variable of variables) {
+    into.set(variable.id, variable)
+    if (variable.properties) indexTree(Object.values(variable.properties), into)
+    if (variable.items) indexTree([variable.items], into)
+  }
+}
+
+/** Whether a declared variable's shape is open (no declared children to check against). */
+function isOpenShape(variable: UnifiedVariable): boolean {
+  const hasProperties = !!variable.properties && Object.keys(variable.properties).length > 0
+  return !hasProperties && !variable.items
+}
+
+/** All prefixes of a normalized path, longest first (bracket-stripped variants included). */
+function pathPrefixes(path: string): string[] {
+  const prefixes: string[] = []
+  let current = path
+  const pushBracketStripped = (value: string) => {
+    if (/\[\*\]$/.test(value)) prefixes.push(value.replace(/\[\*\]$/, ''))
+  }
+  pushBracketStripped(current)
+  while (true) {
+    const dot = current.lastIndexOf('.')
+    if (dot <= 0) break
+    current = current.slice(0, dot)
+    prefixes.push(current)
+    pushBracketStripped(current)
+  }
+  return prefixes
+}
+
+/** Whether a normalized path resolves against the declared id index. */
+function pathResolves(candidate: string, idMap: Map<string, UnifiedVariable>): boolean {
+  if (idMap.has(candidate)) return true
+  for (const prefix of pathPrefixes(candidate)) {
+    const variable = idMap.get(prefix)
+    if (!variable) continue
+    // Longest declared prefix decides: an open shape (e.g. a bare `record`
+    // object) accepts any deeper path — the runtime navigates raw JSON there;
+    // a declared shape with children means the next segment simply missed.
+    return isOpenShape(variable)
+  }
+  return false
+}
+
+/** The deepest declared prefix of a path, for candidate naming. */
+function deepestDeclaredPrefix(
+  candidate: string,
+  idMap: Map<string, UnifiedVariable>
+): { prefix: string; variable: UnifiedVariable } | null {
+  for (const prefix of pathPrefixes(candidate)) {
+    const variable = idMap.get(prefix)
+    if (variable) return { prefix, variable }
+  }
+  return null
+}
+
+/**
+ * Collection-shape correction: try inserting `.values` before bracket
+ * accessors (each one alone, then all at once) and return the first variant
+ * that resolves. Applied to the raw path so the original accessor (`[0]`,
+ * `[-1]`) is preserved in the suggestion.
+ */
+function collectionCorrection(rawPath: string, idMap: Map<string, UnifiedVariable>): string | null {
+  const bracketOffsets: number[] = []
+  for (const match of rawPath.matchAll(/\[(?:\*|-?\d+)\]/g)) {
+    // Skip brackets already preceded by `.values`.
+    if (!rawPath.slice(0, match.index).endsWith('.values')) bracketOffsets.push(match.index)
+  }
+  if (bracketOffsets.length === 0) return null
+
+  const variants: string[] = bracketOffsets.map(
+    (offset) => `${rawPath.slice(0, offset)}.values${rawPath.slice(offset)}`
+  )
+  if (bracketOffsets.length > 1) {
+    let combined = ''
+    let last = 0
+    for (const offset of bracketOffsets) {
+      combined += `${rawPath.slice(last, offset)}.values`
+      last = offset
+    }
+    variants.push(combined + rawPath.slice(last))
+  }
+
+  for (const variant of variants) {
+    if (pathResolves(normalizeIndices(variant), idMap)) return variant
+  }
+  return null
+}
+
+/** Extract every variable ref a node reads: manifest extractor first, generic walk otherwise. */
+function extractNodeRefs(node: NodeMeta, nodeIds: Set<string>): string[] {
+  const manifest = getManifest(node.data?.type ?? node.type)
+  if (manifest?.extractVariables) {
+    try {
+      return manifest.extractVariables(node.data)
+    } catch {
+      // Fall through to the generic walk — a half-configured node must not
+      // crash the check.
+    }
+  }
+  const refs = new Set<string>()
+  rewriteVariableRefs(structuredClone(node.data), nodeIds, (path) => {
+    const trimmed = path.trim()
+    if (trimmed) refs.add(trimmed)
+    return path
+  })
+  return Array.from(refs)
+}
+
+/** Container ancestry (`parentId` chain + `data.loopId`) — loop children may read their container. */
+function containerAncestors(node: NodeMeta, nodeById: Map<string, NodeMeta>): Set<string> {
+  const ancestors = new Set<string>()
+  const loopId = node.data?.loopId
+  if (typeof loopId === 'string') ancestors.add(loopId)
+  let current: NodeMeta | undefined = node
+  while (current?.parentId && !ancestors.has(current.parentId)) {
+    ancestors.add(current.parentId)
+    current = nodeById.get(current.parentId)
+  }
+  return ancestors
+}
+
+/**
+ * Validate every variable reference in `graph` against the supplied declared
+ * outputs (`resolveGraphOutputs` shape). Pure — no cache, no db.
+ *
+ * Checks per ref, in order:
+ * 1. the referenced node exists (else: error naming closest titles/ids);
+ * 2. it is upstream of the consumer, or a container ancestor (else: error —
+ *    the ref a model gets wrong constantly is one that *exists* but is not
+ *    reachable);
+ * 3. the path resolves in the declared output tree — numeric accessors match
+ *    their `[*]` declaration, undeclared-child ("open") objects accept any
+ *    deeper path, collection misuse gets a `.values[*]` suggestion, anything
+ *    else gets "did you mean" candidates from the declared siblings.
+ *
+ * Nodes whose declared outputs are empty (not-yet-migrated types) skip check 3
+ * — an empty declaration proves nothing either way.
+ */
+export function checkVariableRefsAgainstOutputs(params: {
+  graph: WorkflowOutputGraph
+  outputs: Map<string, UnifiedVariable[]>
+}): RefCheckResult {
+  const { graph, outputs } = params
+  const issues: Issue[] = []
+  const corrections: RefCorrection[] = []
+
+  const nodeIds = new Set(graph.nodes.map((n) => n.id))
+  const nodeById = new Map(graph.nodes.map((n) => [n.id, n]))
+  const upstreamMap = buildUpstreamMap(graph.edges, graph.nodes)
+
+  const idMapByNode = new Map<string, Map<string, UnifiedVariable>>()
+  const declaredIdMap = (nodeId: string): Map<string, UnifiedVariable> => {
+    let idMap = idMapByNode.get(nodeId)
+    if (!idMap) {
+      idMap = new Map()
+      indexTree(outputs.get(nodeId) ?? [], idMap)
+      idMapByNode.set(nodeId, idMap)
+    }
+    return idMap
+  }
+
+  for (const consumer of graph.nodes) {
+    const consumerRef = formatNodeRef(graph.nodes, consumer.id)
+    const upstream = upstreamMap.get(consumer.id) ?? new Set<string>()
+    const containers = containerAncestors(consumer, nodeById)
+
+    for (const rawPath of extractNodeRefs(consumer, nodeIds)) {
+      const head = firstPathSegment(rawPath)
+      if (!head || RESERVED_PREFIXES.has(head)) continue
+      // A head-only string carries no output path to validate — and bare
+      // node-id strings in node data (`data.id`, loop ids, …) are data, not
+      // references, so treating them as refs would flood every node with
+      // self-reference noise.
+      if (rawPath === head) continue
+
+      const source = nodeById.get(head)
+      if (!source) {
+        const titles = graph.nodes.map(nodeTitle).filter(Boolean)
+        const near = closestMatches(head, [...titles, ...nodeIds])
+        issues.push({
+          severity: 'error',
+          nodeRef: consumerRef,
+          ref: rawPath,
+          message:
+            `Reference "{{${rawPath}}}" points at unknown node "${head}".` +
+            (near.length > 0 ? ` Did you mean ${near.map((t) => `"${t}"`).join(' or ')}?` : ''),
+        })
+        continue
+      }
+
+      if (source.id !== consumer.id && !upstream.has(source.id) && !containers.has(source.id)) {
+        issues.push({
+          severity: 'error',
+          nodeRef: consumerRef,
+          ref: rawPath,
+          message:
+            `Reference "{{${rawPath}}}" reads node ${formatNodeRef(graph.nodes, source.id)}, ` +
+            `which is not upstream of ${consumerRef} — a node can only read outputs of nodes ` +
+            'that run before it. Connect them, or reference an upstream node instead.',
+        })
+        continue
+      }
+      if (source.id === consumer.id) {
+        issues.push({
+          severity: 'error',
+          nodeRef: consumerRef,
+          ref: rawPath,
+          message: `Reference "{{${rawPath}}}" reads the node's own output — a node cannot reference itself.`,
+        })
+        continue
+      }
+
+      const idMap = declaredIdMap(source.id)
+      if (idMap.size === 0) continue // nothing declared (not-yet-migrated) — unverifiable
+
+      const candidate = normalizeIndices(rawPath)
+      if (pathResolves(candidate, idMap)) continue
+
+      const corrected = collectionCorrection(rawPath, idMap)
+      if (corrected) {
+        issues.push({
+          severity: 'error',
+          nodeRef: consumerRef,
+          ref: rawPath,
+          suggestion: corrected,
+          message:
+            `"{{${rawPath}}}" — this field is a collection wrapper, not a bare array. ` +
+            `Use "{{${corrected}}}" (collections also expose .count, .isEmpty, .first, .last).`,
+        })
+        corrections.push({ nodeId: consumer.id, from: rawPath, to: corrected })
+        continue
+      }
+
+      const declared = deepestDeclaredPrefix(candidate, idMap)
+      const parentPrefix = declared?.prefix ?? head
+      const parent = declared?.variable
+      const available = parent?.properties
+        ? Object.keys(parent.properties)
+        : Array.from(idMap.keys())
+            .filter((id) => id.startsWith(`${head}.`) && !id.slice(head.length + 1).includes('.'))
+            .map((id) => id.slice(head.length + 1))
+      const missing = candidate.slice(parentPrefix.length).replace(/^\./, '')
+      const missingSegment = firstPathSegment(missing) || missing
+      const near = closestMatches(missingSegment, available)
+      issues.push({
+        severity: 'error',
+        nodeRef: consumerRef,
+        ref: rawPath,
+        ...(near.length === 1
+          ? {
+              suggestion:
+                parentPrefix +
+                (parentPrefix ? '.' : '') +
+                near[0] +
+                missing.slice(missingSegment.length),
+            }
+          : {}),
+        message:
+          `No output "${missingSegment}" on node ${formatNodeRef(graph.nodes, source.id)}` +
+          (near.length > 0
+            ? `; did you mean ${near.map((n) => `"${n}"`).join(' or ')}?`
+            : available.length > 0
+              ? `. Available: ${available.slice(0, 8).join(', ')}${available.length > 8 ? ', …' : ''}.`
+              : '.'),
+      })
+    }
+  }
+
+  return { issues, corrections }
+}
+
+/**
+ * SERVER-ONLY convenience: resolve the graph's declared outputs through the
+ * catalog (`resolveGraphOutputs`, org-cache-backed) and run
+ * {@link checkVariableRefsAgainstOutputs} over them.
+ */
+export async function checkGraphRefs(
+  orgId: string,
+  params: { graph: WorkflowOutputGraph }
+): Promise<Result<RefCheckResult, Error>> {
+  const outputs = await resolveGraphOutputs(orgId, { graph: params.graph })
+  if (outputs.isErr()) return err(outputs.error)
+  return ok(checkVariableRefsAgainstOutputs({ graph: params.graph, outputs: outputs.value }))
+}

--- a/packages/lib/src/workflows/graph-edit/normalize/resource-refs.ts
+++ b/packages/lib/src/workflows/graph-edit/normalize/resource-refs.ts
@@ -1,0 +1,169 @@
+// packages/lib/src/workflows/graph-edit/normalize/resource-refs.ts
+
+/**
+ * Resource-reference normalization (`03-graph-edit-service.md` §3 row 2) —
+ * SERVER-ONLY (reads the org cache; never export through a client barrel).
+ *
+ * `ResourcePicker` writes `resource.id`, which for every `ENTITY_DEFINITION_TYPES`
+ * member (tier B) and every user-created entity (tier C) is a per-org
+ * EntityDefinition CUID — and both the variable picker and the runtime build
+ * paths from it. An agent that writes the bare slug produces a graph whose
+ * picker and runtime disagree, so slug → CUID resolution is a CORRECTNESS
+ * requirement, not ergonomics (`05-resource-model.md` §2–3). Tier-A slugs
+ * (`thread`, `message`, `kb`, …) ARE their canonical id and are left alone —
+ * the same gate as `canonicalizeEntityDefinitionId`, and the same trap: the
+ * entityDefs cache resolves `thread` to a def id that nothing else uses, so
+ * "the cache resolved it" is never the gate.
+ *
+ * The convention this copies is the template dialect's `@entity:<slug>`
+ * resolution (`template-resolution.ts`), which resolves slugs to the same
+ * canonical values at install time.
+ */
+
+import { err, ok, type Result } from 'neverthrow'
+import { getCachedResources } from '../../../cache'
+import { type AuxxError, BadRequestError, NotFoundError } from '../../../errors'
+import type { Resource } from '../../../resources/registry/types'
+import { isSystemResourceId } from '../../../resources/registry/types'
+import { closestMatches } from '../refs'
+import type { Issue } from '../types'
+import type { ResourceAliasIndex } from './friendly-refs'
+
+/**
+ * Which config keys hold a resource identifier, per node type. The plan's
+ * `resourceRef` manifest marker (01 §6) has not shipped, so the map lives here
+ * until it does — keep it in sync with the crud/find/resource-trigger
+ * manifests.
+ */
+export const RESOURCE_CONFIG_KEYS: Readonly<Record<string, readonly string[]>> = {
+  find: ['resourceType'],
+  crud: ['resourceType'],
+  'resource-trigger': ['resourceType', 'entityDefinitionId'],
+}
+
+/** The alias strings a resource answers to, for matching and error candidates. */
+function resourceAliases(resource: Resource): string[] {
+  return [resource.entityType, resource.apiSlug, resource.label, resource.plural].filter(
+    (alias): alias is string => typeof alias === 'string' && alias !== ''
+  )
+}
+
+/**
+ * Resolve a friendly resource reference (slug, apiSlug, label, plural, or an
+ * already-canonical id) to the value `find`/`crud`/`resource-trigger` configs
+ * must persist: the bare slug for tier-A system resources, the org's
+ * EntityDefinition CUID for tiers B/C. Unresolvable input is an error naming
+ * the closest candidates — never passed through for the runtime to choke on.
+ */
+export async function resolveResourceRef(
+  orgId: string,
+  value: string
+): Promise<Result<string, AuxxError>> {
+  const trimmed = value.trim()
+  if (!trimmed) return err(new BadRequestError('Resource reference is empty'))
+
+  // Tier A: table-backed system resources stay slug-keyed everywhere.
+  if (isSystemResourceId(trimmed)) return ok(trimmed)
+
+  const resources = await getCachedResources(orgId)
+
+  const byId = resources.find((r) => r.id === trimmed)
+  if (byId) return ok(byId.id)
+
+  const needle = trimmed.toLowerCase()
+  const strong = resources.filter(
+    (r) => r.entityType?.toLowerCase() === needle || r.apiSlug.toLowerCase() === needle
+  )
+  const matches =
+    strong.length > 0
+      ? strong
+      : resources.filter(
+          (r) => r.label.toLowerCase() === needle || r.plural.toLowerCase() === needle
+        )
+
+  if (matches.length === 1) return ok(matches[0]!.id)
+  if (matches.length > 1) {
+    return err(
+      new BadRequestError(
+        `Resource reference "${trimmed}" is ambiguous — it matches: ` +
+          `${matches.map((r) => `"${r.label}" (${r.apiSlug})`).join(', ')}. Use the apiSlug.`
+      )
+    )
+  }
+
+  const allAliases = resources.flatMap(resourceAliases)
+  const near = closestMatches(trimmed, allAliases)
+  const available = resources
+    .filter((r) => r.isVisible)
+    .map((r) => r.apiSlug)
+    .slice(0, 15)
+  const hint =
+    near.length > 0
+      ? ` Did you mean ${near.map((a) => `"${a}"`).join(' or ')}?`
+      : available.length > 0
+        ? ` Available resources: ${available.join(', ')}.`
+        : ''
+  return err(new NotFoundError(`Unknown resource "${trimmed}".${hint}`))
+}
+
+/**
+ * Build the per-org alias index the pure ref rewriters
+ * (`friendly-refs.ts`) consume for the resource path segment. Tier B/C only:
+ * a tier-A resource's canonical id IS its slug, so it needs no aliasing in
+ * either direction. Aliases that collide across resources are dropped —
+ * an ambiguous alias must never silently pick a resource.
+ */
+export async function buildResourceAliasIndex(orgId: string): Promise<ResourceAliasIndex> {
+  const resources = await getCachedResources(orgId)
+  const aliasToId = new Map<string, string>()
+  const idToSlug = new Map<string, string>()
+  const ambiguous = new Set<string>()
+
+  for (const resource of resources) {
+    if (resource.type !== 'custom') continue
+    idToSlug.set(resource.id, resource.entityType ?? resource.apiSlug)
+    for (const alias of [resource.id, ...resourceAliases(resource)]) {
+      const key = alias.toLowerCase()
+      if (ambiguous.has(key)) continue
+      const existing = aliasToId.get(key)
+      if (existing && existing !== resource.id) {
+        aliasToId.delete(key)
+        ambiguous.add(key)
+        continue
+      }
+      aliasToId.set(key, resource.id)
+    }
+  }
+
+  return { aliasToId, idToSlug }
+}
+
+/**
+ * Normalize every resource-holding config key of one node config
+ * (per {@link RESOURCE_CONFIG_KEYS}). Unresolvable values stay verbatim and
+ * come back as ERROR issues carrying the field name — the caller refuses to
+ * persist on error severity. Node types without resource keys pass through
+ * untouched. Returns a shallow clone; `config` is never mutated.
+ */
+export async function normalizeResourceConfig<T extends Record<string, unknown>>(
+  orgId: string,
+  nodeType: string,
+  config: T
+): Promise<{ config: T; issues: Issue[] }> {
+  const keys = RESOURCE_CONFIG_KEYS[nodeType]
+  if (!keys) return { config, issues: [] }
+
+  const next: Record<string, unknown> = { ...config }
+  const issues: Issue[] = []
+  for (const key of keys) {
+    const value = next[key]
+    if (typeof value !== 'string' || !value.trim()) continue
+    const resolved = await resolveResourceRef(orgId, value)
+    if (resolved.isOk()) {
+      next[key] = resolved.value
+    } else {
+      issues.push({ severity: 'error', field: key, message: resolved.error.message })
+    }
+  }
+  return { config: next as T, issues }
+}

--- a/packages/lib/src/workflows/graph-edit/refs.ts
+++ b/packages/lib/src/workflows/graph-edit/refs.ts
@@ -1,0 +1,212 @@
+// packages/lib/src/workflows/graph-edit/refs.ts
+
+/**
+ * Node reference resolution (`03-graph-edit-service.md` §2) — pure, browser-safe.
+ *
+ * Tools accept a `ref` that is a node **title** or a node id. Titles are what
+ * the model sees and what the user talks about; ids are nanoids it would have
+ * to copy correctly every time. Resolution rules:
+ *
+ * - Exact title match, case-insensitive → that node.
+ * - Multiple title matches → error listing candidates with ids. Never guess —
+ *   the canvas does not enforce title uniqueness, so ambiguity is the common
+ *   error path, not an edge case.
+ * - No title match → exact id match.
+ * - Otherwise → actionable NotFound error naming the closest candidates.
+ */
+
+import { err, ok, type Result } from 'neverthrow'
+import { type AuxxError, BadRequestError, NotFoundError } from '../../errors'
+import type { NodeMeta, ResolvedNodeRef } from './types'
+
+/** A node's display title (`data.title`), or '' when unset. */
+export function nodeTitle(node: NodeMeta): string {
+  const title = node.data?.title
+  return typeof title === 'string' ? title : ''
+}
+
+/** `"Title" (id)` — the candidate format every ambiguity/not-found error uses. */
+export function describeNode(node: NodeMeta): string {
+  const title = nodeTitle(node)
+  return title ? `"${title}" (${node.id})` : `(${node.id})`
+}
+
+/**
+ * Whether a string is shaped like a generated node id (nanoid / cuid2 — 16+
+ * url-safe chars, no dots or spaces). Only used to phrase errors; resolution
+ * itself always tries an exact id match regardless of shape.
+ */
+export function isIdShaped(ref: string): boolean {
+  return /^[A-Za-z0-9_-]{16,}$/.test(ref)
+}
+
+/** Levenshtein edit distance — small inputs only (variable segments, titles). */
+function editDistance(a: string, b: string): number {
+  const rows = a.length + 1
+  const cols = b.length + 1
+  const dist: number[] = Array.from({ length: cols }, (_, j) => j)
+  for (let i = 1; i < rows; i++) {
+    let prevDiagonal = dist[0]!
+    dist[0] = i
+    for (let j = 1; j < cols; j++) {
+      const current = dist[j]!
+      dist[j] = Math.min(
+        current + 1,
+        dist[j - 1]! + 1,
+        prevDiagonal + (a[i - 1] === b[j - 1] ? 0 : 1)
+      )
+      prevDiagonal = current
+    }
+  }
+  return dist[cols - 1]!
+}
+
+/**
+ * The candidates closest to `input` by case-insensitive edit distance, nearest
+ * first. Only near misses qualify (distance ≤ max(2, ⌊len/3⌋)) — a "did you
+ * mean" that suggests something unrelated is worse than none.
+ */
+export function closestMatches(input: string, candidates: string[], limit = 3): string[] {
+  const needle = input.toLowerCase()
+  const maxDistance = Math.max(2, Math.floor(needle.length / 3))
+  return candidates
+    .map((candidate) => ({ candidate, distance: editDistance(needle, candidate.toLowerCase()) }))
+    .filter(({ distance }) => distance <= maxDistance)
+    .sort((a, b) => a.distance - b.distance)
+    .slice(0, limit)
+    .map(({ candidate }) => candidate)
+}
+
+/** All nodes whose title equals `ref` case-insensitively. */
+function titleMatches(nodes: NodeMeta[], ref: string): NodeMeta[] {
+  const needle = ref.toLowerCase()
+  return nodes.filter((n) => {
+    const title = nodeTitle(n)
+    return title !== '' && title.toLowerCase() === needle
+  })
+}
+
+function ambiguityError(ref: string, matches: NodeMeta[]): AuxxError {
+  return new BadRequestError(
+    `Node reference "${ref}" is ambiguous — ${matches.length} nodes share this title: ` +
+      `${matches.map(describeNode).join(', ')}. Use the node id instead.`
+  )
+}
+
+function notFoundError(nodes: NodeMeta[], ref: string): AuxxError {
+  const titles = nodes.map(nodeTitle).filter((t) => t !== '')
+  const near = closestMatches(ref, titles)
+  const candidates = (near.length > 0 ? near : titles.slice(0, 10)).map((title) => {
+    const match = nodes.find((n) => nodeTitle(n) === title)
+    return match ? describeNode(match) : `"${title}"`
+  })
+  const hint =
+    candidates.length > 0
+      ? near.length > 0
+        ? ` Did you mean ${candidates.join(' or ')}?`
+        : ` Available nodes: ${candidates.join(', ')}.`
+      : ' The graph has no nodes.'
+  const idNote = isIdShaped(ref) ? ' (No node has this id either.)' : ''
+  return new NotFoundError(`No node matches "${ref}".${idNote}${hint}`)
+}
+
+/**
+ * Resolve a node reference (title or id) to a node. Title match wins; an
+ * ambiguous title is an error listing every candidate with its id — never a
+ * guess.
+ */
+export function resolveNodeRef(nodes: NodeMeta[], ref: string): Result<ResolvedNodeRef, AuxxError> {
+  const trimmed = ref.trim()
+  if (!trimmed) return err(new BadRequestError('Node reference is empty'))
+
+  const byTitle = titleMatches(nodes, trimmed)
+  if (byTitle.length === 1) return ok({ node: byTitle[0]!, matchedBy: 'title' })
+  if (byTitle.length > 1) return err(ambiguityError(trimmed, byTitle))
+
+  const byId = nodes.find((n) => n.id === trimmed)
+  if (byId) return ok({ node: byId, matchedBy: 'id' })
+
+  return err(notFoundError(nodes, trimmed))
+}
+
+/** A node-ref prefix match inside a variable path. */
+export interface NodeRefPrefixMatch extends ResolvedNodeRef {
+  /** The path remainder after the matched ref, leading `.` stripped (`''` for a bare ref). */
+  rest: string
+}
+
+/** Boundary offsets a node ref may end at: end of string, each `.`, the first `[`. */
+function prefixBoundaries(path: string): number[] {
+  const boundaries = new Set<number>([path.length])
+  for (let i = 0; i < path.length; i++) {
+    if (path[i] === '.') boundaries.add(i)
+    if (path[i] === '[') {
+      boundaries.add(i)
+      break // a `[` always ends the ref — titles never contain brackets in refs
+    }
+  }
+  return Array.from(boundaries).sort((a, b) => b - a)
+}
+
+/**
+ * Match the node reference at the head of a variable path — the parser behind
+ * `{{Find Contact.email}}` → node + `email`.
+ *
+ * Titles may contain `.`, so the first segment alone can't identify the ref.
+ * Every prefix ending at a `.` (or the first `[`, or end-of-string) is tried
+ * longest-first: the longest case-insensitive title match wins, an ambiguous
+ * title at that boundary errors, and with no title match anywhere the first
+ * segment is tried as an exact node id. `ok(null)` means "not a node ref at
+ * all" (prose, `env.X`, `sys.Y`) — the caller decides whether that's an error.
+ */
+export function matchNodeRefPrefix(
+  nodes: NodeMeta[],
+  path: string
+): Result<NodeRefPrefixMatch | null, AuxxError> {
+  const trimmed = path.trim()
+  if (!trimmed) return ok(null)
+
+  for (const boundary of prefixBoundaries(trimmed)) {
+    const candidate = trimmed.slice(0, boundary)
+    // Prose guard: a matched title followed by `.` and whitespace (or a bare
+    // trailing `.`) is a sentence, not a ref — skip the boundary so "Find
+    // Contact. Thanks." in a gated bare string is never rewritten.
+    if (boundary < trimmed.length) {
+      const after = trimmed.slice(boundary + (trimmed[boundary] === '.' ? 1 : 0))
+      if (!after || /^\s/.test(after)) continue
+    }
+    const matches = titleMatches(nodes, candidate)
+    if (matches.length > 1) return err(ambiguityError(candidate, matches))
+    if (matches.length === 1) {
+      const rest = trimmed.slice(boundary).replace(/^\./, '')
+      return ok({ node: matches[0]!, matchedBy: 'title', rest })
+    }
+  }
+
+  const firstSegmentEnd = Math.min(
+    ...[trimmed.indexOf('.'), trimmed.indexOf('[')].filter((i) => i >= 0),
+    trimmed.length
+  )
+  const firstSegment = trimmed.slice(0, firstSegmentEnd)
+  const byId = nodes.find((n) => n.id === firstSegment)
+  if (byId) {
+    const rest = trimmed.slice(firstSegmentEnd).replace(/^\./, '')
+    return ok({ node: byId, matchedBy: 'id', rest })
+  }
+
+  return ok(null)
+}
+
+/**
+ * Render a node id as the friendly ref the model should see: the title when it
+ * is unique in the graph (case-insensitively), the raw id otherwise — a
+ * duplicated title would round-trip into an ambiguity error, so the id is the
+ * only honest rendering. Unknown ids pass through unchanged.
+ */
+export function formatNodeRef(nodes: NodeMeta[], nodeId: string): string {
+  const node = nodes.find((n) => n.id === nodeId)
+  if (!node) return nodeId
+  const title = nodeTitle(node)
+  if (!title) return nodeId
+  return titleMatches(nodes, title).length === 1 ? title : nodeId
+}

--- a/packages/lib/src/workflows/graph-edit/types.ts
+++ b/packages/lib/src/workflows/graph-edit/types.ts
@@ -1,0 +1,66 @@
+// packages/lib/src/workflows/graph-edit/types.ts
+
+/**
+ * Shared types for the headless graph-edit module — the friendly-input layer
+ * agent tools and other headless callers use to edit a workflow draft.
+ *
+ * Graph shapes are REUSED from the catalog rather than re-declared:
+ * `NodeMeta`/`EdgeMeta` (`workflow-engine/catalog/graph-vars.ts`) are the
+ * structural node/edge representation React Flow nodes, engine nodes and
+ * agent-authored graphs all satisfy, and `WorkflowOutputGraph`
+ * (`workflow-engine/catalog/resolve-outputs.ts`) is the persisted-graph shape
+ * output resolution reads. Type-only re-exports keep this file browser-safe
+ * even though `resolve-outputs.ts` itself is server-only.
+ */
+
+import type { EdgeMeta, NodeMeta } from '../../workflow-engine/catalog/graph-vars'
+import type { WorkflowOutputGraph } from '../../workflow-engine/catalog/resolve-outputs'
+
+export type { EdgeMeta, NodeMeta, WorkflowOutputGraph }
+
+/** How loud an issue is. Blocking-vs-non-blocking is pipeline policy, not encoded here. */
+export type IssueSeverity = 'error' | 'warning' | 'info'
+
+/**
+ * One validation/normalization finding, returned alongside (never instead of)
+ * the operation result. The shape from `03-graph-edit-service.md` §5, plus two
+ * optional machine-readable fields so a caller can auto-apply corrections.
+ */
+export interface Issue {
+  severity: IssueSeverity
+  /**
+   * Friendly reference to the node the issue is about — the title when unique,
+   * the node id otherwise (`formatNodeRef`). Never a raw id when a unique
+   * title exists, so a model can echo it back as a valid ref.
+   */
+  nodeRef?: string
+  /** Config field the issue is about (e.g. `resourceType`, `prompt_template.0.role`). */
+  field?: string
+  /** The offending variable reference, verbatim, when the issue is about one. */
+  ref?: string
+  message: string
+  /** Machine-usable corrected form (e.g. `att.values[*].name` for `att[*].name`). */
+  suggestion?: string
+}
+
+/**
+ * A node reference as tools accept it: a node *title* (matched exactly,
+ * case-insensitively) or a node id. See `refs.ts` for resolution rules.
+ */
+export type NodeRef = string
+
+/** A successfully resolved node reference. */
+export interface ResolvedNodeRef {
+  node: NodeMeta
+  matchedBy: 'title' | 'id'
+}
+
+/** A ref-level correction the caller may apply verbatim (`from` → `to`). */
+export interface RefCorrection {
+  /** Node whose data holds the reference. */
+  nodeId: string
+  /** The reference as written (the raw path inside `{{…}}`, or the bare ref). */
+  from: string
+  /** The corrected reference. */
+  to: string
+}


### PR DESCRIPTION
Phase 3 §2 + §3 of the graph-edit service plan: the foundation of the headless graph-edit module, `packages/lib/src/workflows/graph-edit/` (functional + neverthrow per `docs/lib-module-guide.md`). Scope-fenced: no layout, no mutation ops/pipeline — those are parallel slices; `index.ts` exports only this surface.

## Layout

```
packages/lib/src/workflows/graph-edit/
  types.ts                 Issue { severity, nodeRef, field, message } (+ ref/suggestion), ref types;
                           graph types REUSED from the catalog (NodeMeta/EdgeMeta from graph-vars.ts,
                           WorkflowOutputGraph from resolve-outputs.ts — type-only, browser-safe)
  refs.ts                  §2 node-ref resolution (pure): exact ci title match wins; ambiguity errors
                           listing candidates with ids; id fallback; actionable NotFound with did-you-mean;
                           longest-prefix matcher for refs at the head of a variable path (titles with dots)
  normalize/
    friendly-refs.ts       {{Title.path}} ⇄ {{nodeId.path}} + resource-segment aliasing (pure)
    resource-refs.ts       slug → per-org EntityDefinition CUID (SERVER-ONLY, org cache)
    prompt.ts              plain prompt string → { role, json: TiptapDoc } (pure)
    connection.ts          after/branch → { sourceNodeId, sourceHandle } (pure)
    ref-check.ts           refs vs resolved outputs: dangling / non-upstream / collection corrections
  __tests__/               73 tests: golden normalization, ref round-trips, dangling/non-upstream errors
  index.ts                 explicit named exports (server entrypoint — see below)
```

## Normalization table → machinery reused

| Friendly input | Persisted | Reuses |
|---|---|---|
| `{{Find Contact.email}}` | `{{<nodeId>.email}}` | same ref-rewrite family as `TemplateGraphTransformer.cloneGraph` / #1600's paste rewriting; shares `firstPathSegment` + the `VARIABLE_PATTERN` span grammar (`catalog/variable-inference.ts`). The friendly direction has its own 2-regime walker (spans strict → errors; bare strings lenient → prose-safe); the reverse direction reuses `rewriteVariableRefs` directly |
| `resource: "ticket"` | the org's EntityDefinition CUID for tiers B/C, slug untouched for tier A | `getCachedResources`-backed resolution copying `findCachedResource`'s id/entityType/apiSlug matching (+ ci label/plural); tier gate is `isSystemResourceId`, mirroring `canonicalizeEntityDefinitionId`'s "never gate on the cache resolving it" rule (thread/article trap) |
| `{{Find Tickets.ticket.subject}}` | `{{<nodeId>.<cuid>.subject}}` | same mechanism as the title↔id rewrite, one level deeper; `buildResourceAliasIndex` (tier B/C only) feeds the pure rewriter, and the reverse pass renders the CUID back as the slug |
| `prompt: "Summarize {{Find.body}}"` on `ai` | `prompt_template: [{ role, json: TiptapDoc }]` | `normalizeTemplateGraph` → `textToDoc({ parseVariables: true })`, called verbatim via a one-node wrapper graph — zero re-implementation. Only `ai` is touched (extractor/answer/classifier keep plain strings by design) |
| `after: "Find Contact"` | edge source on the default handle | `resolveNodeRef` + `manifest.connection` from `getManifest` — `source` for branchless nodes, the single `default` branch otherwise (http/crud) |
| `branch: "no match"` | `sourceHandle` = the branch id | `manifest.connection.branches(config)` from the catalog registry, matched by display name then handle id — never string-matched locally; unknown/omitted branch errors name every branch |
| `{{X.attachments[*]}}` | error WITH `suggestion: X.attachments.values[*]` + a machine-applicable correction entry | validated against the declared output tree from `resolveGraphOutputs` (`catalog/resolve-outputs.ts`); numeric accessors normalize to the declared `[*]`, open-shaped objects accept deeper paths |
| `{{Find.emial}}` | error: `No output "emial" on node Find Contact; did you mean "email"?` | did-you-mean over the declared siblings (edit distance); upstream reachability via the catalog's `buildUpstreamMap`, with `parentId`/`loopId` container ancestry allowed |

Every unresolved reference is an error with candidates — nothing is silently dropped or silently persisted; ambiguous titles list every candidate with its id (never guess).

## Server/client boundary

The module's entrypoint is SERVER-ONLY (`resource-refs.ts` + `ref-check.ts` read the org cache) — same rule as the catalog's `build-output-context`/`resolve-outputs` leaf subpaths: never route through `workflow-engine/client.ts`. `refs.ts`, `friendly-refs.ts`, `prompt.ts`, `connection.ts` are pure and can grow a client surface when a UI consumer appears. No `package.json` exports touched (codegen'd from consumer imports; no external consumer yet).

## Notes for the follow-up slices

- The plan's `resourceRef` manifest marker (01 §6) has NOT shipped — `RESOURCE_CONFIG_KEYS` in `resource-refs.ts` hardcodes find/crud/resource-trigger until it does.
- `checkVariableRefsAgainstOutputs` is pure (outputs supplied) so the pipeline can run it post-apply without a second cache read; `checkGraphRefs(orgId, { graph })` is the composed server helper.
- Corrections come back machine-readable (`{ nodeId, from, to }`) so the ops slice can choose auto-apply vs report.

## Verification

- `node scripts/ci/typecheck-ratchet.js --package lib` — no new errors (29 total, baseline 29)
- `cd packages/lib && pnpm exec vitest run src/workflows src/workflow-engine` — 70 files, 1300/1300 passed (includes the 73 new graph-edit tests)
- `pnpm exec biome check --write packages/lib/src/workflows/graph-edit` — clean
