### PR TITLE
feat(workflow): graph-edit operations, validation pipeline and draft persistence

### DIFF
--- a/apps/web/src/server/api/workflow-template-resolver.ts
+++ b/apps/web/src/server/api/workflow-template-resolver.ts
@@ -1,32 +1,5 @@
 // apps/web/src/server/api/workflow-template-resolver.ts
 
-import { getFileTemplateById, isFileTemplateId, normalizeTemplateGraph } from '@auxx/lib/workflows'
-import { getTemplateById, type WorkflowTemplateDetail } from '@auxx/services/workflow-templates'
-
-/** A resolved template, tagged with its origin so callers can gate edits. */
-export type ResolvedTemplate = WorkflowTemplateDetail & { source: 'file' | 'admin' }
-
-/**
- * Resolve a workflow template by id from either the bundled file registry or the
- * database, with AI-node prompts normalized to the editor's `{ role, json }` shape.
- *
- * File templates (id prefixed `file:`) are normalized at registry load. DB rows
- * are normalized here so legacy `{ role, text }` prompts self-heal on read.
- *
- * @param id - File template id (`file:<slug>`) or DB row id.
- * @returns The resolved template, or null if not found.
- */
-export async function resolveTemplateById(id: string): Promise<ResolvedTemplate | null> {
-  if (isFileTemplateId(id)) {
-    return getFileTemplateById(id) ?? null
-  }
-
-  const result = await getTemplateById(id)
-  if (result.isErr() || !result.value) return null
-
-  return {
-    ...result.value,
-    graph: normalizeTemplateGraph(result.value.graph),
-    source: 'admin',
-  }
-}
+// Moved to lib (graph-edit's `applyTemplate` shares the same file + admin
+// template merge); re-exported here so no server import churns.
+export { type ResolvedTemplate, resolveTemplateById } from '@auxx/lib/workflows'

--- a/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
@@ -1,0 +1,742 @@
+// packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
+
+/**
+ * Operation-layer tests (`03-graph-edit-service.md` §9): branch wiring through
+ * `manifest.connection.branches`, loop containment + the canvas's own
+ * loop-delete behaviour, §4 layout stability, replaceGraph's empty-draft
+ * restriction, the structural-vs-config blocking split, setTrigger's trigger
+ * column re-derivation through the persist seam, and the readDraft shape.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Partial mock — the cache barrel is imported by half of lib; replacing it
+// wholesale dies at collection. Only the read the graph-edit path makes is stubbed.
+const getCachedResources = vi.fn()
+vi.mock('../../../cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../cache')>()),
+  getCachedResources: (...args: unknown[]) => getCachedResources(...args),
+}))
+
+// The persist seam writes through WorkflowService.update (lazy-imported in
+// persist.ts) — replaced so no engine/queue module graph loads and the exact
+// update input (trigger columns!) can be asserted.
+const serviceUpdate = vi.fn()
+vi.mock('../../workflow-service', () => ({
+  WorkflowService: class {
+    update(...args: unknown[]) {
+      return serviceUpdate(...args)
+    }
+  },
+}))
+
+// The blocking mail guard — checked in the pipeline so it reports as an issue.
+const mailGuard = vi.fn(async (..._args: unknown[]) => {})
+vi.mock('../../mail-trigger-guard', () => ({
+  assertMailTriggerNotPersonal: (...args: unknown[]) => mailGuard(...args),
+}))
+
+const {
+  addNode,
+  applyTemplate,
+  connectNodes,
+  deleteNodes,
+  disconnectNodes,
+  replaceGraph,
+  setTrigger,
+  updateNode,
+} = await import('../ops')
+const { readDraft } = await import('../read')
+
+import type { DraftGraph, GraphEdge, GraphNode } from '../types'
+
+const ORG = 'org_1'
+const APP = 'wfapp_1'
+const TICKET_ID = 'i5aezsg4bc6n8gof2uan3wcf'
+
+const RESOURCES = [
+  {
+    id: TICKET_ID,
+    type: 'custom',
+    label: 'Ticket',
+    plural: 'Tickets',
+    apiSlug: 'tickets',
+    entityType: 'ticket',
+    entityDefinitionId: TICKET_ID,
+    isVisible: true,
+    fields: [],
+  },
+]
+
+const TRIGGER_ID = 'scheduled-aaaaaaaaaaaaaaaaaaaaa'
+const IFELSE_ID = 'ifelse-aaaaaaaaaaaaaaaaaaaaa'
+const LOOP_ID = 'loop-aaaaaaaaaaaaaaaaaaaaa'
+
+function triggerNode(): GraphNode {
+  return {
+    id: TRIGGER_ID,
+    type: 'standard',
+    position: { x: 100, y: 200 },
+    width: 244,
+    height: 100,
+    data: {
+      id: TRIGGER_ID,
+      type: 'scheduled',
+      title: 'Every Morning',
+      config: {
+        triggerInterval: 'days',
+        timeBetweenTriggers: { days: 1, isConstant: true },
+        timezone: 'UTC',
+      },
+      isEnabled: true,
+    },
+  }
+}
+
+function ifElseNode(): GraphNode {
+  return {
+    id: IFELSE_ID,
+    type: 'standard',
+    position: { x: 500, y: 200 },
+    width: 244,
+    height: 100,
+    data: {
+      id: IFELSE_ID,
+      type: 'if-else',
+      title: 'Check Priority',
+      cases: [{ id: 'c1', case_id: 'true', logical_operator: 'and', conditions: [] }],
+    },
+  }
+}
+
+function loopNode(): GraphNode {
+  return {
+    id: LOOP_ID,
+    type: 'standard',
+    position: { x: 500, y: 400 },
+    width: 400,
+    height: 300,
+    data: {
+      id: LOOP_ID,
+      type: 'loop',
+      title: 'For each order',
+      itemsSource: '',
+      maxIterations: 100,
+      accumulateResults: true,
+    },
+  }
+}
+
+function edge(
+  source: string,
+  sourceHandle: string,
+  target: string,
+  targetHandle = 'target',
+  data?: GraphEdge['data']
+): GraphEdge {
+  return {
+    id: `${source}-${sourceHandle}-${target}-${targetHandle}`,
+    source,
+    sourceHandle,
+    target,
+    targetHandle,
+    ...(data ? { data } : {}),
+  }
+}
+
+/** In-memory WorkflowApp row + db stub for `loadDraftContext`. */
+function makeDb(graph: DraftGraph, triggerType: string | null = 'scheduled') {
+  const app = {
+    id: APP,
+    name: 'My Flow',
+    organizationId: ORG,
+    draftWorkflow: {
+      id: 'wf_draft',
+      name: 'My Flow (Draft)',
+      graph,
+      triggerType,
+      entityDefinitionId: null,
+      organizationId: ORG,
+      version: 3,
+    },
+  }
+  const db = { query: { WorkflowApp: { findFirst: vi.fn(async () => app) } } }
+  return db as unknown as import('@auxx/database').Database
+}
+
+/** The graph the pipeline persisted (last WorkflowService.update input). */
+function persistedInput(): Record<string, unknown> {
+  const call = serviceUpdate.mock.calls.at(-1)
+  expect(call).toBeDefined()
+  expect(call?.[0]).toBe(ORG)
+  return call?.[1] as Record<string, unknown>
+}
+
+function persistedGraph(): DraftGraph {
+  return persistedInput().graph as DraftGraph
+}
+
+beforeEach(() => {
+  getCachedResources.mockReset()
+  getCachedResources.mockResolvedValue(RESOURCES)
+  mailGuard.mockReset()
+  mailGuard.mockResolvedValue(undefined)
+  serviceUpdate.mockReset()
+  serviceUpdate.mockImplementation(async (_org: string, input: Record<string, unknown>) => ({
+    graphHash: 'hash-after',
+    triggerType: input.triggerType ?? null,
+    entityDefinitionId: input.entityDefinitionId ?? null,
+  }))
+})
+
+describe('addNode — branch wiring (§6)', () => {
+  const base = (): DraftGraph => ({
+    nodes: [triggerNode(), ifElseNode()],
+    edges: [edge(TRIGGER_ID, 'source', IFELSE_ID)],
+  })
+
+  it('resolves a branch NAME to the case handle id from manifest.connection.branches', async () => {
+    const result = await addNode(makeDb(base()), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      type: 'wait',
+      title: 'Then Wait',
+      after: 'Check Priority',
+      branch: 'IF',
+    })
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().applied).toBe(true)
+
+    const graph = persistedGraph()
+    const added = graph.nodes.find((n) => n.data?.title === 'Then Wait')
+    expect(added).toBeDefined()
+    const wired = graph.edges.find((e) => e.target === added?.id)
+    expect(wired?.source).toBe(IFELSE_ID)
+    expect(wired?.sourceHandle).toBe('true') // the case's id, never the display name
+  })
+
+  it("wires the ELSE branch on the reserved 'false' handle", async () => {
+    const result = await addNode(makeDb(base()), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      type: 'wait',
+      after: 'Check Priority',
+      branch: 'ELSE',
+    })
+    expect(result.isOk()).toBe(true)
+    const graph = persistedGraph()
+    const wired = graph.edges.find((e) => e.source === IFELSE_ID && e.sourceHandle === 'false')
+    expect(wired).toBeDefined()
+  })
+
+  it('errors listing every branch when the anchor has several and none was named', async () => {
+    const result = await addNode(makeDb(base()), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      type: 'wait',
+      after: 'Check Priority',
+    })
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('branches')
+    expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe('addNode — layout stability (§4)', () => {
+  it('leaves every existing node position byte-identical', async () => {
+    const graph: DraftGraph = {
+      nodes: [triggerNode(), ifElseNode()],
+      edges: [edge(TRIGGER_ID, 'source', IFELSE_ID)],
+    }
+    const before = JSON.stringify(graph.nodes.map((n) => [n.id, n.position]))
+
+    const result = await addNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      type: 'wait',
+      after: 'Every Morning',
+    })
+    expect(result.isOk()).toBe(true)
+
+    const persisted = persistedGraph()
+    const after = JSON.stringify(
+      persisted.nodes
+        .filter((n) => n.id === TRIGGER_ID || n.id === IFELSE_ID)
+        .map((n) => [n.id, n.position])
+    )
+    expect(after).toBe(before)
+
+    // The anchor already feeds Check Priority, so the new node joins that
+    // column below the existing sibling (branch targets stack downward).
+    const added = persisted.nodes.find((n) => n.id !== TRIGGER_ID && n.id !== IFELSE_ID)
+    expect(added?.position.x).toBe(500)
+    expect(added?.position.y).toBe(350)
+  })
+
+  it('places a first successor one column right of its predecessor, vertically aligned', async () => {
+    const graph: DraftGraph = { nodes: [triggerNode()], edges: [] }
+    const result = await addNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      type: 'wait',
+      after: 'Every Morning',
+    })
+    expect(result.isOk()).toBe(true)
+    const persisted = persistedGraph()
+    const added = persisted.nodes.find((n) => n.id !== TRIGGER_ID)
+    expect(added?.position.x).toBeGreaterThan(100 + 244)
+    expect(added?.position.y).toBe(200)
+  })
+})
+
+describe('loop containment (§6)', () => {
+  it('addNode inside a loop sets parentId/loopId, positions in-container, wires loop-start', async () => {
+    const graph: DraftGraph = {
+      nodes: [triggerNode(), loopNode()],
+      edges: [edge(TRIGGER_ID, 'source', LOOP_ID)],
+    }
+    const result = await addNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      type: 'wait',
+      title: 'Per Order Wait',
+      inside: 'For each order',
+    })
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().applied).toBe(true)
+
+    const persisted = persistedGraph()
+    const child = persisted.nodes.find((n) => n.data?.title === 'Per Order Wait')
+    expect(child?.parentId).toBe(LOOP_ID)
+    expect(child?.extent).toBe('parent')
+    expect(child?.data?.loopId).toBe(LOOP_ID)
+    expect(child?.data?.isInLoop).toBe(true)
+    // Parent-relative position within the container padding.
+    expect(child?.position.x).toBeGreaterThanOrEqual(20)
+    expect(child?.position.y).toBeGreaterThanOrEqual(80)
+    // First body node: the canvas wires loop-start → first child.
+    const loopStart = persisted.edges.find(
+      (e) => e.source === LOOP_ID && e.sourceHandle === 'loop-start'
+    )
+    expect(loopStart?.target).toBe(child?.id)
+    expect(result._unsafeUnwrap().node?.inside).toBe('For each order')
+  })
+
+  it('connectNodes from a loop child to its container writes the loop-back edge', async () => {
+    const childId = 'wait-childaaaaaaaaaaaaaaa'
+    const graph: DraftGraph = {
+      nodes: [
+        triggerNode(),
+        loopNode(),
+        {
+          id: childId,
+          type: 'standard',
+          position: { x: 78, y: 80 },
+          parentId: LOOP_ID,
+          data: { id: childId, type: 'wait', title: 'Per Order Wait', loopId: LOOP_ID },
+        },
+      ],
+      edges: [edge(TRIGGER_ID, 'source', LOOP_ID), edge(LOOP_ID, 'loop-start', childId)],
+    }
+    const result = await connectNodes(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      from: 'Per Order Wait',
+      to: 'For each order',
+    })
+    expect(result.isOk()).toBe(true)
+    const loopBack = persistedGraph().edges.find((e) => e.targetHandle === 'loop-back')
+    expect(loopBack?.source).toBe(childId)
+    expect(loopBack?.target).toBe(LOOP_ID)
+    expect(loopBack?.data?.isLoopBackEdge).toBe(true)
+  })
+
+  it('deleting a loop deletes its children with it (canvas handleDeleteNode behaviour)', async () => {
+    const childId = 'wait-childaaaaaaaaaaaaaaa'
+    const graph: DraftGraph = {
+      nodes: [
+        triggerNode(),
+        loopNode(),
+        {
+          id: childId,
+          type: 'standard',
+          position: { x: 78, y: 80 },
+          parentId: LOOP_ID,
+          data: { id: childId, type: 'wait', title: 'Per Order Wait', loopId: LOOP_ID },
+        },
+      ],
+      edges: [
+        edge(TRIGGER_ID, 'source', LOOP_ID),
+        edge(LOOP_ID, 'loop-start', childId),
+        edge(childId, 'source', LOOP_ID, 'loop-back', { isLoopBackEdge: true }),
+      ],
+    }
+    const result = await deleteNodes(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      refs: ['For each order'],
+    })
+    expect(result.isOk()).toBe(true)
+    const persisted = persistedGraph()
+    // Children are REMOVED with the container — never reparented — and every
+    // touching edge goes with them (use-node-interactions.ts:423-446).
+    expect(persisted.nodes.map((n) => n.id)).toEqual([TRIGGER_ID])
+    expect(persisted.edges).toEqual([])
+  })
+})
+
+describe('deleteNodes — reconnect bridging', () => {
+  it('bridges surviving predecessors to surviving successors on the original handle', async () => {
+    const waitId = 'wait-aaaaaaaaaaaaaaaaaaaa'
+    const endId = 'end-aaaaaaaaaaaaaaaaaaaaa'
+    const graph: DraftGraph = {
+      nodes: [
+        triggerNode(),
+        {
+          id: waitId,
+          type: 'standard',
+          position: { x: 500, y: 200 },
+          data: { id: waitId, type: 'wait', title: 'Cool Down' },
+        },
+        {
+          id: endId,
+          type: 'standard',
+          position: { x: 900, y: 200 },
+          data: { id: endId, type: 'end', title: 'Done' },
+        },
+      ],
+      edges: [edge(TRIGGER_ID, 'source', waitId), edge(waitId, 'source', endId)],
+    }
+    const result = await deleteNodes(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      refs: ['Cool Down'],
+      reconnect: true,
+    })
+    expect(result.isOk()).toBe(true)
+    const persisted = persistedGraph()
+    expect(persisted.edges).toHaveLength(1)
+    expect(persisted.edges[0]).toMatchObject({
+      source: TRIGGER_ID,
+      sourceHandle: 'source',
+      target: endId,
+    })
+  })
+})
+
+describe('structural vs config blocking split (§5)', () => {
+  it('structural: an edge into a trigger rejects WITHOUT persisting', async () => {
+    const graph: DraftGraph = {
+      nodes: [triggerNode(), ifElseNode()],
+      edges: [edge(TRIGGER_ID, 'source', IFELSE_ID)],
+    }
+    const result = await connectNodes(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      from: 'Check Priority',
+      branch: 'IF',
+      to: 'Every Morning',
+    })
+    expect(result.isOk()).toBe(true)
+    const outcome = result._unsafeUnwrap()
+    expect(outcome.applied).toBe(false)
+    expect(outcome.issues.some((i) => i.severity === 'error' && /trigger/i.test(i.message))).toBe(
+      true
+    )
+    expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('structural: a non-loop cycle rejects without persisting', async () => {
+    const aId = 'wait-aaaaaaaaaaaaaaaaaaaa'
+    const bId = 'wait-baaaaaaaaaaaaaaaaaaa'
+    const graph: DraftGraph = {
+      nodes: [
+        triggerNode(),
+        {
+          id: aId,
+          type: 'standard',
+          position: { x: 500, y: 200 },
+          data: { id: aId, type: 'wait', title: 'A' },
+        },
+        {
+          id: bId,
+          type: 'standard',
+          position: { x: 900, y: 200 },
+          data: { id: bId, type: 'wait', title: 'B' },
+        },
+      ],
+      edges: [edge(TRIGGER_ID, 'source', aId), edge(aId, 'source', bId)],
+    }
+    const result = await connectNodes(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      from: 'B',
+      to: 'A',
+    })
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().applied).toBe(false)
+    expect(
+      result._unsafeUnwrap().issues.some((i) => i.severity === 'error' && /cycle/i.test(i.message))
+    ).toBe(true)
+    expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('config: a half-configured node PERSISTS and reports issues', async () => {
+    const graph: DraftGraph = { nodes: [triggerNode()], edges: [] }
+    const result = await addNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      type: 'answer', // fresh answer has no text — invalid config, valid draft
+      after: 'Every Morning',
+    })
+    expect(result.isOk()).toBe(true)
+    const outcome = result._unsafeUnwrap()
+    expect(outcome.applied).toBe(true)
+    expect(serviceUpdate).toHaveBeenCalledTimes(1)
+    expect(outcome.issues.some((i) => i.field === 'text')).toBe(true)
+  })
+
+  it('normalize: an unresolvable {{ref}} rejects without persisting', async () => {
+    const graph: DraftGraph = { nodes: [triggerNode()], edges: [] }
+    const result = await addNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      type: 'wait',
+      after: 'Every Morning',
+      config: { note: 'wait for {{No Such Node.value}}' },
+    })
+    expect(result.isOk()).toBe(true)
+    const outcome = result._unsafeUnwrap()
+    expect(outcome.applied).toBe(false)
+    expect(outcome.issues.some((i) => i.ref === 'No Such Node.value')).toBe(true)
+    expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('mail guard: a personal-channel trigger surfaces as a blocking issue, never swallowed', async () => {
+    const { BadRequestError } = await import('../../../errors')
+    mailGuard.mockRejectedValueOnce(
+      new BadRequestError('Mail triggers cannot be configured on a personal inbox.')
+    )
+    const graph: DraftGraph = { nodes: [triggerNode()], edges: [] }
+    const result = await addNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      type: 'wait',
+      after: 'Every Morning',
+    })
+    expect(result.isOk()).toBe(true)
+    const outcome = result._unsafeUnwrap()
+    expect(outcome.applied).toBe(false)
+    expect(outcome.issues.some((i) => /personal inbox/.test(i.message))).toBe(true)
+    expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe('replaceGraph', () => {
+  it('rejects on a NON-EMPTY draft with an actionable message', async () => {
+    const graph: DraftGraph = { nodes: [triggerNode()], edges: [] }
+    const result = await replaceGraph(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      nodes: [{ type: 'scheduled' }],
+      edges: [],
+    })
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toMatch(/incrementally/i)
+    expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('builds a branched graph on an empty draft with auto-layout and branch handles', async () => {
+    const result = await replaceGraph(makeDb({ nodes: [], edges: [] }, null), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      nodes: [
+        { type: 'scheduled', title: 'Daily' },
+        {
+          type: 'if-else',
+          title: 'Route',
+          config: {
+            cases: [{ id: 'c1', case_id: 'true', logical_operator: 'and', conditions: [] }],
+          },
+        },
+        { type: 'wait', title: 'On Match' },
+        { type: 'wait', title: 'Otherwise' },
+      ],
+      edges: [
+        { from: 'Daily', to: 'Route' },
+        { from: 'Route', to: 'On Match', branch: 'IF' },
+        { from: 'Route', to: 'Otherwise', branch: 'ELSE' },
+      ],
+    })
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().applied).toBe(true)
+
+    const persisted = persistedGraph()
+    expect(persisted.nodes).toHaveLength(4)
+    const handles = persisted.edges
+      .filter((e) => e.source === persisted.nodes[1]?.id)
+      .map((e) => e.sourceHandle)
+      .sort()
+    expect(handles).toEqual(['false', 'true'])
+    // Auto-layout: left-to-right; branch targets share a column, stacked.
+    const [daily, route, onMatch, otherwise] = persisted.nodes
+    expect(daily!.position.x).toBeLessThan(route!.position.x)
+    expect(route!.position.x).toBeLessThan(onMatch!.position.x)
+    expect(onMatch!.position.x).toBe(otherwise!.position.x)
+    expect(onMatch!.position.y).not.toBe(otherwise!.position.y)
+  })
+
+  it('applyTemplate also refuses a non-empty draft', async () => {
+    const graph: DraftGraph = { nodes: [triggerNode()], edges: [] }
+    const result = await applyTemplate(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      userId: 'user_1',
+      templateId: 'file:whatever',
+    })
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toMatch(/EMPTY draft/i)
+    expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe('setTrigger — trigger columns re-derived through the persist seam (§7)', () => {
+  it('retypes the trigger in place and persists derived triggerType/entityDefinitionId', async () => {
+    const graph: DraftGraph = { nodes: [triggerNode()], edges: [] }
+    const result = await setTrigger(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      triggerType: 'resource-trigger',
+      config: { operation: 'created', resourceType: 'ticket', entityDefinitionId: 'ticket' },
+    })
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().applied).toBe(true)
+
+    const input = persistedInput()
+    // deriveTriggerColumns over the new node: operation 'created' + resolved
+    // entity id → Workflow.triggerType/entityDefinitionId are RE-DERIVED, not
+    // carried over from the previous 'scheduled'.
+    expect(input.triggerType).toBe('created')
+    expect(input.entityDefinitionId).toBe(TICKET_ID)
+
+    // Same node id (downstream {{Every Morning.x}} refs survive the retype),
+    // and the friendly resource slug was normalized to the org CUID.
+    const persisted = persistedGraph()
+    expect(persisted.nodes).toHaveLength(1)
+    expect(persisted.nodes[0]?.id).toBe(TRIGGER_ID)
+    expect(persisted.nodes[0]?.data?.type).toBe('resource-trigger')
+    expect(persisted.nodes[0]?.data?.resourceType).toBe(TICKET_ID)
+    expect(persisted.nodes[0]?.data?.entityDefinitionId).toBe(TICKET_ID)
+  })
+
+  it('a graph mutation that does not touch the trigger keeps the previous triggerType', async () => {
+    const graph: DraftGraph = { nodes: [triggerNode()], edges: [] }
+    await addNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      type: 'wait',
+      after: 'Every Morning',
+    })
+    expect(persistedInput().triggerType).toBe('scheduled')
+  })
+})
+
+describe('updateNode / disconnectNodes', () => {
+  it('shallow-merges config and never lets it change id/type', async () => {
+    const graph: DraftGraph = { nodes: [triggerNode(), loopNode()], edges: [] }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'For each order',
+      config: { maxIterations: 5, id: 'evil', type: 'code' },
+    })
+    expect(result.isOk()).toBe(true)
+    const persisted = persistedGraph()
+    const loop = persisted.nodes.find((n) => n.id === LOOP_ID)
+    expect(loop?.data?.maxIterations).toBe(5)
+    expect(loop?.data?.id).toBe(LOOP_ID)
+    expect(loop?.data?.type).toBe('loop')
+  })
+
+  it('a title equal to another node title stays a NAME, never a rewritten ref', async () => {
+    const graph: DraftGraph = { nodes: [triggerNode(), loopNode()], edges: [] }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'For each order',
+      config: { title: 'Every Morning', desc: 'Every Morning' },
+    })
+    expect(result.isOk()).toBe(true)
+    const loop = persistedGraph().nodes.find((n) => n.id === LOOP_ID)
+    expect(loop?.data?.title).toBe('Every Morning')
+    expect(loop?.data?.desc).toBe('Every Morning')
+  })
+
+  it('disconnectNodes removes the edge and errors when none exists', async () => {
+    const graph: DraftGraph = {
+      nodes: [triggerNode(), ifElseNode()],
+      edges: [edge(TRIGGER_ID, 'source', IFELSE_ID)],
+    }
+    const removed = await disconnectNodes(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      from: 'Every Morning',
+      to: 'Check Priority',
+    })
+    expect(removed.isOk()).toBe(true)
+    expect(persistedGraph().edges).toEqual([])
+
+    const missing = await disconnectNodes(makeDb({ nodes: graph.nodes, edges: [] }), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      from: 'Every Morning',
+      to: 'Check Priority',
+    })
+    expect(missing.isErr()).toBe(true)
+  })
+})
+
+describe('readDraft (§1)', () => {
+  it('returns friendly summaries, per-node outputs and issues', async () => {
+    const waitId = 'wait-aaaaaaaaaaaaaaaaaaaa'
+    const graph: DraftGraph = {
+      nodes: [
+        triggerNode(),
+        {
+          id: waitId,
+          type: 'standard',
+          position: { x: 500, y: 200 },
+          data: {
+            id: waitId,
+            type: 'wait',
+            title: 'Cool Down',
+            note: `after {{${TRIGGER_ID}.timestamp}}`,
+          },
+        },
+      ],
+      edges: [edge(TRIGGER_ID, 'source', waitId)],
+    }
+    const result = await readDraft(makeDb(graph), { workflowAppId: APP, organizationId: ORG })
+    expect(result.isOk()).toBe(true)
+    const draft = result._unsafeUnwrap()
+
+    expect(draft.workflowAppId).toBe(APP)
+    expect(draft.name).toBe('My Flow')
+    expect(draft.triggerType).toBe('scheduled')
+    expect(draft.graphSummary.nodeCount).toBe(2)
+    expect(draft.graphSummary.edgeCount).toBe(1)
+    expect(draft.edges).toEqual([{ from: 'Every Morning', to: 'Cool Down' }])
+
+    const wait = draft.nodes.find((n) => n.ref === 'Cool Down')
+    expect(wait?.type).toBe('wait')
+    // Persisted node-id refs render back as {{Title.path}} — never a raw id.
+    expect(wait?.config.note).toBe('after {{Every Morning.timestamp}}')
+    // Bookkeeping keys are withheld from config.
+    expect(wait?.config.id).toBeUndefined()
+    expect(wait?.config.title).toBeUndefined()
+
+    // Outputs keyed by friendly ref.
+    expect(Object.keys(draft.outputs)).toContain('Every Morning')
+    expect(Object.keys(draft.outputs)).toContain('Cool Down')
+  })
+})

--- a/packages/lib/src/workflows/graph-edit/index.ts
+++ b/packages/lib/src/workflows/graph-edit/index.ts
@@ -10,9 +10,10 @@
  * `normalize/prompt.ts`, `normalize/connection.ts`) are browser-safe and can
  * grow a dedicated client surface when a UI consumer appears.
  *
- * This file exports the §2 (reference resolution) + §3 (friendly → persisted
- * normalization) surface; the mutation ops, pipeline and layout land in their
- * own slices and extend these exports.
+ * Surface: §2 reference resolution (`refs.ts`), §3 normalization
+ * (`normalize/`), §1 operations (`ops.ts` writes + `read.ts` reads), §4
+ * layout/placement, §5 validation. The Redis turn snapshot, realtime event
+ * and `runNode` land in the next slice and wrap `persistDraft`.
  */
 
 export {
@@ -38,6 +39,53 @@ export {
   resolveResourceRef,
 } from './normalize/resource-refs'
 export {
+  type AddNodeInput,
+  type ApplyTemplateInput,
+  addNode,
+  applyTemplate,
+  type ConnectNodesInput,
+  connectNodes,
+  type DeleteNodesInput,
+  type DisconnectNodesInput,
+  deleteNodes,
+  disconnectNodes,
+  type ReplaceGraphEdgeSpec,
+  type ReplaceGraphInput,
+  type ReplaceGraphNodeSpec,
+  replaceGraph,
+  type SetTriggerInput,
+  setTrigger,
+  type UpdateNodeInput,
+  updateNode,
+} from './ops'
+export {
+  cleanGraphForSave,
+  type PersistDraftInput,
+  type PersistDraftOutcome,
+  persistDraft,
+} from './persist'
+export {
+  DEFAULT_NODE_SIZE,
+  findNearestEmptySpace,
+  type InsidePlacement,
+  isPositionOccupied,
+  placeAfter,
+  placeInside,
+  placeStandalone,
+  type Size,
+} from './place-node'
+export {
+  buildGraphSummary,
+  buildNodeSummary,
+  type DraftContext,
+  type GraphEditScope,
+  loadDraftContext,
+  readDraft,
+  renderFriendlyOutputs,
+  validateWorkflow,
+  type WorkflowValidationReport,
+} from './read'
+export {
   closestMatches,
   describeNode,
   formatNodeRef,
@@ -48,12 +96,28 @@ export {
   resolveNodeRef,
 } from './refs'
 export type {
+  DraftGraph,
+  DraftSummary,
   EdgeMeta,
+  EdgeSummary,
+  GraphEdge,
+  GraphMutationResult,
+  GraphNode,
+  GraphSummary,
   Issue,
   IssueSeverity,
   NodeMeta,
   NodeRef,
+  NodeSummary,
+  Point,
   RefCorrection,
   ResolvedNodeRef,
   WorkflowOutputGraph,
 } from './types'
+export {
+  hasBlockingIssues,
+  isTriggerNode,
+  nodeType,
+  validateGraphStructure,
+  validateNodeConfigs,
+} from './validate'

--- a/packages/lib/src/workflows/graph-edit/layout.ts
+++ b/packages/lib/src/workflows/graph-edit/layout.ts
@@ -19,8 +19,8 @@ export interface LayoutNode {
   id: string
   parentId?: string
   type?: string
-  width?: number
-  height?: number
+  width?: number | null
+  height?: number | null
   data?: { type?: string }
 }
 

--- a/packages/lib/src/workflows/graph-edit/ops.ts
+++ b/packages/lib/src/workflows/graph-edit/ops.ts
@@ -1,0 +1,992 @@
+// packages/lib/src/workflows/graph-edit/ops.ts
+
+/**
+ * Graph mutations (`03-graph-edit-service.md` §1) — SERVER-ONLY writes.
+ *
+ * Every mutation runs the same pipeline: load draft → resolve refs →
+ * normalize → apply → layout → validate → persist → return
+ * `{ node, outputs, issues, graphSummary }`. Structural errors (and
+ * unresolvable references) REJECT before persisting (`applied: false`);
+ * config and reference issues PERSIST and come back as `issues` — a
+ * half-built workflow is legitimate, mirroring the canvas.
+ *
+ * NO permission checks live here (house rule): callers must assert
+ * `capabilities.assertEditInstance('workflow', workflowAppId)` and
+ * `assertWorkflowAppNotSystemOwned` before calling in. `publish`/`enabled`
+ * are never written by any of these operations.
+ */
+
+import type { Database } from '@auxx/database'
+import { incrementTitle } from '@auxx/utils'
+import { generateId } from '@auxx/utils/generateId'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError, BadRequestError, NotFoundError } from '../../errors'
+import { LOOP_HANDLES } from '../../workflow-engine/catalog/nodes/loop'
+import { getAuthorableManifests, getManifest } from '../../workflow-engine/catalog/registry'
+import { resolveGraphOutputs } from '../../workflow-engine/catalog/resolve-outputs'
+import type { NodeManifest } from '../../workflow-engine/catalog/types'
+import type { UnifiedVariable } from '../../workflow-engine/types/unified-variable'
+import { assertMailTriggerNotPersonal } from '../mail-trigger-guard'
+import { calculateContainerSize, getLayoutByDagre, getLayoutForChildNodes } from './layout'
+import { LAYOUT_SPACING, NODE_ADDITION_CONFIG } from './layout-constants'
+import { resolveConnectionSpec } from './normalize/connection'
+import { normalizeFriendlyRefs, type ResourceAliasIndex } from './normalize/friendly-refs'
+import { normalizeAiPromptConfig } from './normalize/prompt'
+import { checkVariableRefsAgainstOutputs } from './normalize/ref-check'
+import { buildResourceAliasIndex, normalizeResourceConfig } from './normalize/resource-refs'
+import { persistDraft } from './persist'
+import {
+  DEFAULT_NODE_SIZE,
+  findNearestEmptySpace,
+  placeAfter,
+  placeInside,
+  placeStandalone,
+} from './place-node'
+import {
+  buildGraphSummary,
+  buildNodeSummary,
+  type DraftContext,
+  type GraphEditScope,
+  loadDraftContext,
+  renderFriendlyOutputs,
+} from './read'
+import { describeNode, formatNodeRef, resolveNodeRef } from './refs'
+import type { DraftGraph, GraphEdge, GraphMutationResult, GraphNode, Issue, Point } from './types'
+import { isTriggerNode, nodeType, validateGraphStructure, validateNodeConfigs } from './validate'
+
+/** The plan a specific mutation hands the shared pipeline. */
+interface MutationPlan {
+  graph: DraftGraph
+  /** The node the result's `node`/`outputs` describe. */
+  touchedNodeId?: string
+  /** Nodes this mutation introduced/retyped — scope of the authorable check. */
+  newNodeIds?: ReadonlySet<string>
+  /** Normalization findings; `error` severity blocks the persist. */
+  normalizeIssues: Issue[]
+  /** Curated graphs (templates) may carry non-authorable nodes — skip that check. */
+  skipAuthorableCheck?: boolean
+  /** Overrides `ctx.triggerType` as the fallback when the graph derives none. */
+  fallbackTriggerType?: string | null
+  envVars?: unknown[]
+  variables?: unknown[]
+  icon?: { iconId: string; color: string }
+}
+
+/**
+ * The shared mutation pipeline. Blocking tiers (normalize errors, structural
+ * errors, the mail-trigger guard) return `applied: false` with the original
+ * graph untouched; everything else persists through the one seam
+ * (`persistDraft`) and reports.
+ */
+async function runGraphMutation(
+  db: Database,
+  scope: GraphEditScope,
+  build: (
+    ctx: DraftContext,
+    aliases: ResourceAliasIndex
+  ) => Promise<Result<MutationPlan, AuxxError>>
+): Promise<Result<GraphMutationResult, AuxxError>> {
+  const loaded = await loadDraftContext(db, scope)
+  if (loaded.isErr()) return err(loaded.error)
+  const ctx = loaded.value
+  const aliases = await buildResourceAliasIndex(scope.organizationId)
+
+  const planResult = await build(ctx, aliases)
+  if (planResult.isErr()) return err(planResult.error)
+  const plan = planResult.value
+  const { graph } = plan
+
+  const structural = validateGraphStructure(graph, {
+    ...(plan.skipAuthorableCheck ? {} : { newNodeIds: plan.newNodeIds }),
+  })
+  const guardIssues: Issue[] = []
+  const hasBlocking = () =>
+    plan.normalizeIssues.some((i) => i.severity === 'error') ||
+    structural.some((i) => i.severity === 'error') ||
+    guardIssues.length > 0
+  if (!hasBlocking()) {
+    try {
+      // The same blocking guard `WorkflowService.update` runs — checked here so
+      // it reports as a structured issue instead of a bare throw.
+      await assertMailTriggerNotPersonal(db, scope.organizationId, graph)
+    } catch (error) {
+      if (!(error instanceof AuxxError)) throw error
+      guardIssues.push({ severity: 'error', message: error.message })
+    }
+  }
+
+  if (hasBlocking()) {
+    return ok({
+      applied: false,
+      issues: [...plan.normalizeIssues, ...structural, ...guardIssues],
+      graphSummary: buildGraphSummary(ctx.graph, ctx.triggerType),
+    })
+  }
+
+  const issues: Issue[] = [...plan.normalizeIssues, ...structural, ...validateNodeConfigs(graph)]
+  let outputsMap: Map<string, UnifiedVariable[]> | undefined
+  const resolved = await resolveGraphOutputs(scope.organizationId, { graph })
+  if (resolved.isOk()) {
+    outputsMap = resolved.value
+    issues.push(...checkVariableRefsAgainstOutputs({ graph, outputs: outputsMap }).issues)
+  }
+
+  const persisted = await persistDraft(db, scope, {
+    graph,
+    ...(ctx.graphHash !== undefined ? { expectedGraphHash: ctx.graphHash } : {}),
+    fallbackTriggerType:
+      plan.fallbackTriggerType !== undefined ? plan.fallbackTriggerType : ctx.triggerType,
+    ...(plan.envVars !== undefined ? { envVars: plan.envVars as never } : {}),
+    ...(plan.variables !== undefined ? { variables: plan.variables as never } : {}),
+    ...(plan.icon !== undefined ? { icon: plan.icon } : {}),
+  })
+  if (persisted.isErr()) return err(persisted.error)
+
+  const touched = plan.touchedNodeId
+    ? graph.nodes.find((n) => n.id === plan.touchedNodeId)
+    : undefined
+  return ok({
+    applied: true,
+    ...(touched ? { node: buildNodeSummary(graph, touched, aliases) } : {}),
+    ...(touched && outputsMap
+      ? { outputs: renderFriendlyOutputs(graph, outputsMap.get(touched.id) ?? [], aliases) }
+      : {}),
+    issues,
+    graphSummary: buildGraphSummary(graph, persisted.value.triggerType ?? ctx.triggerType),
+  })
+}
+
+/** Top-level prose keys the bare-ref rewriter must never touch — a title set
+ * to another node's exact title is a NAME, not a reference. `{{…}}` spans
+ * inside them still normalize (they re-enter via the span walk below). */
+const PROSE_CONFIG_KEYS = ['title', 'desc', 'description'] as const
+
+/** friendly refs → resource refs → prompt: the §3 normalization chain, in order. */
+async function normalizeConfig(
+  organizationId: string,
+  nodes: GraphNode[],
+  aliases: ResourceAliasIndex,
+  type: string,
+  config: Record<string, unknown>
+): Promise<{ config: Record<string, unknown>; issues: Issue[] }> {
+  const prose: Record<string, unknown> = {}
+  const rest: Record<string, unknown> = { ...config }
+  for (const key of PROSE_CONFIG_KEYS) {
+    if (typeof rest[key] === 'string' && !(rest[key] as string).includes('{{')) {
+      prose[key] = rest[key]
+      delete rest[key]
+    }
+  }
+  const friendly = normalizeFriendlyRefs(rest, { nodes, resourceAliases: aliases })
+  const resource = await normalizeResourceConfig(organizationId, type, friendly.data)
+  return {
+    config: { ...normalizeAiPromptConfig(type, resource.config), ...prose },
+    issues: [...friendly.issues, ...resource.issues],
+  }
+}
+
+/** Manifest for an authorable type, or an actionable error naming the options. */
+function requireAuthorableManifest(type: string): Result<NodeManifest<any>, AuxxError> {
+  const manifest = getManifest(type)
+  if (manifest?.agent?.authorable === true) return ok(manifest)
+  const authorable = getAuthorableManifests()
+    .map((m) => m.id)
+    .sort()
+    .join(', ')
+  return err(
+    new BadRequestError(
+      `Node type "${type}" ${manifest ? 'cannot be authored here' : 'does not exist'}. ` +
+        `Authorable types: ${authorable}.`
+    )
+  )
+}
+
+/** `${source}-${handle}-${target}-${targetHandle}` — the canvas EdgeManager's id format. */
+function makeEdge(
+  source: string,
+  sourceHandle: string,
+  target: string,
+  targetHandle: string,
+  data?: GraphEdge['data']
+): GraphEdge {
+  return {
+    id: `${source}-${sourceHandle}-${target}-${targetHandle}`,
+    source,
+    sourceHandle,
+    target,
+    targetHandle,
+    ...(data ? { data } : {}),
+  }
+}
+
+/** Fresh node data — NodeFactory parity (defaults under config, identity on top). */
+function buildNodeData(
+  manifest: NodeManifest<any>,
+  nodeId: string,
+  config: Record<string, unknown>,
+  extras: { title: string; loopId?: string }
+): Record<string, unknown> {
+  return {
+    id: nodeId,
+    desc: manifest.description,
+    isValid: true,
+    errors: [],
+    disabled: false,
+    selected: false,
+    ...(extras.loopId ? { isInLoop: true, loopId: extras.loopId } : {}),
+    ...(manifest.defaultData() as Record<string, unknown>),
+    ...config,
+    type: manifest.id,
+    title: extras.title,
+  }
+}
+
+/** Unique title (case-sensitive, `incrementTitle` — the canvas's own nudge). */
+function uniqueTitle(base: string, nodes: GraphNode[], excludeNodeId?: string): string {
+  const existing = new Set(
+    nodes
+      .filter((n) => n.id !== excludeNodeId)
+      .map((n) => (typeof n.data?.title === 'string' ? n.data.title : ''))
+      .filter((t) => t.trim())
+  )
+  return incrementTitle(base, existing)
+}
+
+/** Grow a container so a new child fits — parity with `createResizedParentNode`. */
+function resizeContainer(node: GraphNode, size: { width: number; height: number }): GraphNode {
+  return {
+    ...node,
+    width: size.width,
+    height: size.height,
+    data: { ...node.data, width: size.width, height: size.height },
+  }
+}
+
+/** Input for {@link addNode}. */
+export interface AddNodeInput extends GraphEditScope {
+  /** Authorable node type (`data.type`), e.g. `'find'`. */
+  type: string
+  /** Friendly config — `{{Title.path}}` refs, resource slugs, plain prompts. */
+  config?: Record<string, unknown>
+  title?: string
+  /** Predecessor to connect from (node title or id). */
+  after?: string
+  /** Branch of `after` to leave on (name or handle id) — via the manifest's branches. */
+  branch?: string
+  /** Loop container to place the node inside (title or id). */
+  inside?: string
+  /** Explicit canvas position — omitted, the §4 placement rules decide. */
+  position?: Point
+}
+
+/**
+ * Add one node. With `after`, the node lands one column right of its
+ * predecessor (branch targets stack downward) and the connecting edge is
+ * written on the branch handle resolved through
+ * `manifest.connection.branches`. With `inside`, the node is contained in the
+ * loop (top-level `parentId`, parent-relative position, loop-start edge for
+ * the first child, container resized to fit). Existing nodes never move.
+ */
+export async function addNode(
+  db: Database,
+  params: AddNodeInput
+): Promise<Result<GraphMutationResult, AuxxError>> {
+  return runGraphMutation(db, params, async (ctx, aliases) => {
+    const manifestResult = requireAuthorableManifest(params.type)
+    if (manifestResult.isErr()) return err(manifestResult.error)
+    const manifest = manifestResult.value
+
+    const { nodes, edges } = ctx.graph
+
+    // Resolve containment and/or the predecessor connection.
+    let parentId: string | undefined
+    if (params.inside !== undefined) {
+      const inside = resolveNodeRef(nodes, params.inside)
+      if (inside.isErr()) return err(inside.error)
+      if (nodeType(inside.value.node as GraphNode) !== 'loop') {
+        return err(
+          new BadRequestError(
+            `Node ${describeNode(inside.value.node)} is not a loop — only loops contain other nodes.`
+          )
+        )
+      }
+      parentId = inside.value.node.id
+    }
+
+    let connection: { sourceNodeId: string; sourceHandle: string } | undefined
+    if (params.after !== undefined) {
+      const spec = resolveConnectionSpec(nodes, { after: params.after, branch: params.branch })
+      if (spec.isErr()) return err(spec.error)
+      connection = spec.value
+      const anchor = nodes.find((n) => n.id === connection?.sourceNodeId)
+      // Entering a loop through its loop-start handle IS containment; adding
+      // after a loop child stays inside the same container.
+      if (connection.sourceHandle === LOOP_HANDLES.LOOP_START) {
+        parentId ??= connection.sourceNodeId
+      } else {
+        parentId ??=
+          anchor?.parentId ??
+          (typeof anchor?.data?.loopId === 'string' ? anchor.data.loopId : undefined)
+      }
+    }
+
+    const normalized = await normalizeConfig(
+      ctx.organizationId,
+      nodes,
+      aliases,
+      params.type,
+      params.config ?? {}
+    )
+
+    const nodeId = generateId(params.type)
+    const baseTitle =
+      params.title ??
+      (typeof normalized.config.title === 'string' ? normalized.config.title : undefined) ??
+      (typeof manifest.defaultData().title === 'string'
+        ? (manifest.defaultData().title as string)
+        : manifest.displayName)
+    const title = uniqueTitle(baseTitle, nodes)
+
+    // §4 placement — existing nodes never move; only the new node is placed.
+    const parent = parentId ? nodes.find((n) => n.id === parentId) : undefined
+    let position = params.position
+    let resizedParent: GraphNode | undefined
+    if (!position) {
+      if (parent) {
+        const children = nodes.filter((n) => n.parentId === parent.id)
+        const anchor = connection ? nodes.find((n) => n.id === connection.sourceNodeId) : undefined
+        if (anchor && anchor.id !== parent.id) {
+          position = placeAfter(
+            anchor as GraphNode,
+            connection?.sourceHandle ?? 'source',
+            children,
+            edges
+          )
+        } else {
+          const placement = placeInside(parent as GraphNode, children)
+          position = placement.position
+          if (placement.requiresResize && placement.suggestedSize) {
+            resizedParent = resizeContainer(parent as GraphNode, placement.suggestedSize)
+          }
+        }
+      } else if (connection) {
+        const anchor = nodes.find((n) => n.id === connection.sourceNodeId)
+        const topLevel = nodes.filter((n) => !n.parentId)
+        position = anchor
+          ? placeAfter(anchor as GraphNode, connection.sourceHandle, topLevel, edges)
+          : placeStandalone(nodes)
+      } else {
+        position = placeStandalone(nodes)
+      }
+    }
+
+    const newNode: GraphNode = {
+      id: nodeId,
+      type: params.type === 'note' ? 'note' : 'standard',
+      position,
+      ...(parentId ? { parentId, extent: 'parent' } : {}),
+      width: DEFAULT_NODE_SIZE.width,
+      height: DEFAULT_NODE_SIZE.height,
+      selected: false,
+      data: buildNodeData(manifest, nodeId, normalized.config, {
+        title,
+        ...(parentId ? { loopId: parentId } : {}),
+      }),
+    }
+
+    const newEdges: GraphEdge[] = []
+    if (connection) {
+      newEdges.push(makeEdge(connection.sourceNodeId, connection.sourceHandle, nodeId, 'target'))
+    } else if (parent && nodes.every((n) => n.parentId !== parent.id)) {
+      // First child of a loop: the canvas wires loop-start → first body node.
+      newEdges.push(makeEdge(parent.id, LOOP_HANDLES.LOOP_START, nodeId, 'target'))
+    }
+
+    const nextNodes = nodes.map((n) =>
+      resizedParent && n.id === resizedParent.id ? resizedParent : n
+    )
+    return ok({
+      graph: {
+        nodes: [...nextNodes, newNode],
+        edges: [...edges, ...newEdges],
+        ...(ctx.graph.viewport ? { viewport: ctx.graph.viewport } : {}),
+      },
+      touchedNodeId: nodeId,
+      newNodeIds: new Set([nodeId]),
+      normalizeIssues: normalized.issues,
+    })
+  })
+}
+
+/** Input for {@link updateNode}. */
+export interface UpdateNodeInput extends GraphEditScope {
+  /** Node title or id. */
+  ref: string
+  /** Friendly config, shallow-merged over the node's current data. */
+  config: Record<string, unknown>
+}
+
+/**
+ * Shallow-merge a friendly config into one node's data. `id` and `type` are
+ * identity and cannot be changed here (use `setTrigger`/delete + add).
+ */
+export async function updateNode(
+  db: Database,
+  params: UpdateNodeInput
+): Promise<Result<GraphMutationResult, AuxxError>> {
+  return runGraphMutation(db, params, async (ctx, aliases) => {
+    const resolved = resolveNodeRef(ctx.graph.nodes, params.ref)
+    if (resolved.isErr()) return err(resolved.error)
+    const node = resolved.value.node as GraphNode
+    const type = nodeType(node)
+    const manifestResult = requireAuthorableManifest(type)
+    if (manifestResult.isErr()) return err(manifestResult.error)
+
+    const normalized = await normalizeConfig(
+      ctx.organizationId,
+      ctx.graph.nodes,
+      aliases,
+      type,
+      params.config
+    )
+    const { id: _id, type: _type, ...mergeable } = normalized.config
+
+    const nextNodes = ctx.graph.nodes.map((n) =>
+      n.id === node.id ? { ...n, data: { ...n.data, ...mergeable } } : n
+    )
+    return ok({
+      graph: { ...ctx.graph, nodes: nextNodes },
+      touchedNodeId: node.id,
+      newNodeIds: new Set([node.id]),
+      normalizeIssues: normalized.issues,
+    })
+  })
+}
+
+/** Input for {@link deleteNodes}. */
+export interface DeleteNodesInput extends GraphEditScope {
+  /** Node titles or ids. */
+  refs: string[]
+  /** Bridge each deleted node's incoming edges to its downstream targets. */
+  reconnect?: boolean
+}
+
+/**
+ * Delete nodes. Deleting a loop container deletes its children with it and
+ * removes every touching edge — the canvas's own delete behaviour
+ * (`use-node-interactions.ts` `handleDeleteNode` recurses into
+ * `parentId`-children before removing the container; it never reparents).
+ * With `reconnect`, each surviving predecessor is bridged to the deleted
+ * span's surviving successors on the predecessor's own handle.
+ */
+export async function deleteNodes(
+  db: Database,
+  params: DeleteNodesInput
+): Promise<Result<GraphMutationResult, AuxxError>> {
+  return runGraphMutation(db, params, async (ctx) => {
+    if (params.refs.length === 0) return err(new BadRequestError('No node references given'))
+
+    const { nodes, edges } = ctx.graph
+    const toDelete = new Set<string>()
+    for (const ref of params.refs) {
+      const resolved = resolveNodeRef(nodes, ref)
+      if (resolved.isErr()) return err(resolved.error)
+      toDelete.add(resolved.value.node.id)
+    }
+
+    // Canvas parity: children go with their container (recursively, so a
+    // nested loop's body is included too).
+    let grew = true
+    while (grew) {
+      grew = false
+      for (const node of nodes) {
+        if (node.parentId && toDelete.has(node.parentId) && !toDelete.has(node.id)) {
+          toDelete.add(node.id)
+          grew = true
+        }
+      }
+    }
+
+    let bridged: GraphEdge[] = []
+    if (params.reconnect) {
+      // Successors reachable from a deleted node through deleted nodes only,
+      // following forward (non-loop-back) edges.
+      const survivingSuccessors = (start: string): string[] => {
+        const found = new Set<string>()
+        const stack = [start]
+        const visited = new Set<string>()
+        while (stack.length > 0) {
+          const current = stack.pop()
+          if (current === undefined || visited.has(current)) continue
+          visited.add(current)
+          for (const edge of edges) {
+            if (edge.source !== current || edge.data?.isLoopBackEdge) continue
+            if (toDelete.has(edge.target)) stack.push(edge.target)
+            else found.add(edge.target)
+          }
+        }
+        return [...found]
+      }
+      const seen = new Set<string>()
+      for (const edge of edges) {
+        if (edge.data?.isLoopBackEdge) continue
+        if (toDelete.has(edge.source) || !toDelete.has(edge.target)) continue
+        for (const target of survivingSuccessors(edge.target)) {
+          const handle = edge.sourceHandle ?? 'source'
+          const id = `${edge.source}-${handle}-${target}-target`
+          if (seen.has(id) || edges.some((e) => e.id === id)) continue
+          seen.add(id)
+          bridged.push(makeEdge(edge.source, handle, target, 'target'))
+        }
+      }
+      // Never bridge into a deleted node's container boundary handles.
+      bridged = bridged.filter((e) => !toDelete.has(e.source) && !toDelete.has(e.target))
+    }
+
+    return ok({
+      graph: {
+        nodes: nodes.filter((n) => !toDelete.has(n.id)),
+        edges: [
+          ...edges.filter((e) => !toDelete.has(e.source) && !toDelete.has(e.target)),
+          ...bridged,
+        ],
+        ...(ctx.graph.viewport ? { viewport: ctx.graph.viewport } : {}),
+      },
+      normalizeIssues: [],
+    })
+  })
+}
+
+/** Input for {@link connectNodes}. */
+export interface ConnectNodesInput extends GraphEditScope {
+  from: string
+  to: string
+  /** Branch of `from` to leave on — resolved through the manifest's branches. */
+  branch?: string
+}
+
+/**
+ * Connect two nodes. The source handle is resolved through
+ * `manifest.connection.branches(config)` — never string-matched. Connecting a
+ * loop child back to its own container targets the `loop-back` handle and
+ * flags the edge `isLoopBackEdge` (the initializer regenerates the flag from
+ * `parentId` and the handle; both are written so the live graph matches).
+ */
+export async function connectNodes(
+  db: Database,
+  params: ConnectNodesInput
+): Promise<Result<GraphMutationResult, AuxxError>> {
+  return runGraphMutation(db, params, async (ctx) => {
+    const { nodes, edges } = ctx.graph
+    const spec = resolveConnectionSpec(nodes, { after: params.from, branch: params.branch })
+    if (spec.isErr()) return err(spec.error)
+    const target = resolveNodeRef(nodes, params.to)
+    if (target.isErr()) return err(target.error)
+
+    const source = nodes.find((n) => n.id === spec.value.sourceNodeId)
+    const targetNode = target.value.node as GraphNode
+    const isLoopBack =
+      nodeType(targetNode) === 'loop' &&
+      (source?.parentId === targetNode.id || source?.data?.loopId === targetNode.id)
+
+    const edge = isLoopBack
+      ? makeEdge(spec.value.sourceNodeId, spec.value.sourceHandle, targetNode.id, 'loop-back', {
+          isLoopBackEdge: true,
+        })
+      : makeEdge(spec.value.sourceNodeId, spec.value.sourceHandle, targetNode.id, 'target')
+
+    if (edges.some((e) => e.id === edge.id)) {
+      return err(
+        new BadRequestError(
+          `${formatNodeRef(nodes, edge.source)} is already connected to ${formatNodeRef(nodes, edge.target)} on that branch.`
+        )
+      )
+    }
+
+    return ok({
+      graph: { ...ctx.graph, edges: [...edges, edge] },
+      touchedNodeId: targetNode.id,
+      normalizeIssues: [],
+    })
+  })
+}
+
+/** Input for {@link disconnectNodes}. */
+export interface DisconnectNodesInput extends GraphEditScope {
+  from: string
+  to: string
+}
+
+/** Remove every edge between two nodes (all branches). */
+export async function disconnectNodes(
+  db: Database,
+  params: DisconnectNodesInput
+): Promise<Result<GraphMutationResult, AuxxError>> {
+  return runGraphMutation(db, params, async (ctx) => {
+    const { nodes, edges } = ctx.graph
+    const from = resolveNodeRef(nodes, params.from)
+    if (from.isErr()) return err(from.error)
+    const to = resolveNodeRef(nodes, params.to)
+    if (to.isErr()) return err(to.error)
+
+    const remaining = edges.filter(
+      (e) => !(e.source === from.value.node.id && e.target === to.value.node.id)
+    )
+    if (remaining.length === edges.length) {
+      return err(
+        new NotFoundError(
+          `No connection from ${describeNode(from.value.node)} to ${describeNode(to.value.node)}.`
+        )
+      )
+    }
+
+    return ok({
+      graph: { ...ctx.graph, edges: remaining },
+      normalizeIssues: [],
+    })
+  })
+}
+
+/** Input for {@link setTrigger}. */
+export interface SetTriggerInput extends GraphEditScope {
+  /** In-graph trigger NODE type: manual, scheduled, resource-trigger, message-received. */
+  triggerType: string
+  /** Friendly trigger config (e.g. `{ operation: 'created', resourceType: 'ticket' }`). */
+  config?: Record<string, unknown>
+}
+
+/**
+ * Set the workflow's trigger — in-graph triggers only (D11; webhook endpoints
+ * and app triggers stay manual). An existing trigger node is retyped IN PLACE
+ * (same node id, same position, outgoing edges kept) so downstream
+ * `{{Trigger.x}}` refs survive; with no trigger yet, one is created at the
+ * left of the graph. The persist seam re-derives
+ * `Workflow.triggerType`/`entityDefinitionId` from the new node.
+ */
+export async function setTrigger(
+  db: Database,
+  params: SetTriggerInput
+): Promise<Result<GraphMutationResult, AuxxError>> {
+  return runGraphMutation(db, params, async (ctx, aliases) => {
+    const manifestResult = requireAuthorableManifest(params.triggerType)
+    if (manifestResult.isErr()) return err(manifestResult.error)
+    const manifest = manifestResult.value
+    if (!manifest.triggerType) {
+      const triggerTypes = getAuthorableManifests()
+        .filter((m) => m.triggerType)
+        .map((m) => m.id)
+        .sort()
+        .join(', ')
+      return err(
+        new BadRequestError(
+          `"${params.triggerType}" is not a trigger node type. In-graph triggers: ${triggerTypes}.`
+        )
+      )
+    }
+
+    const { nodes, edges } = ctx.graph
+    const triggers = nodes.filter((n) => isTriggerNode(n as GraphNode))
+    if (triggers.length > 1) {
+      return err(
+        new BadRequestError(
+          `The workflow has ${triggers.length} trigger nodes (${triggers
+            .map((t) => describeNode(t))
+            .join(', ')}) — delete the extras first.`
+        )
+      )
+    }
+
+    const normalized = await normalizeConfig(
+      ctx.organizationId,
+      nodes,
+      aliases,
+      params.triggerType,
+      params.config ?? {}
+    )
+    const baseTitle =
+      (typeof normalized.config.title === 'string' ? normalized.config.title : undefined) ??
+      (typeof manifest.defaultData().title === 'string'
+        ? (manifest.defaultData().title as string)
+        : manifest.displayName)
+
+    const existing = triggers[0] as GraphNode | undefined
+    if (existing) {
+      const title = uniqueTitle(baseTitle, nodes as GraphNode[], existing.id)
+      const nextNodes = nodes.map((n) =>
+        n.id === existing.id
+          ? {
+              ...n,
+              type: 'standard',
+              data: buildNodeData(manifest, existing.id, normalized.config, { title }),
+            }
+          : n
+      )
+      return ok({
+        graph: { ...ctx.graph, nodes: nextNodes },
+        touchedNodeId: existing.id,
+        newNodeIds: new Set([existing.id]),
+        normalizeIssues: normalized.issues,
+      })
+    }
+
+    const nodeId = generateId(params.triggerType)
+    const title = uniqueTitle(baseTitle, nodes as GraphNode[])
+    const topLevel = (nodes as GraphNode[]).filter((n) => !n.parentId)
+    const preferred: Point =
+      topLevel.length === 0
+        ? { x: 250, y: 250 }
+        : {
+            x:
+              Math.min(...topLevel.map((n) => n.position.x)) -
+              LAYOUT_SPACING.DEFAULT_NODE_WIDTH -
+              NODE_ADDITION_CONFIG.HORIZONTAL_SPACING,
+            y: topLevel.reduce((sum, n) => sum + n.position.y, 0) / topLevel.length,
+          }
+    const newNode: GraphNode = {
+      id: nodeId,
+      type: 'standard',
+      position: findNearestEmptySpace(preferred, DEFAULT_NODE_SIZE, topLevel, 'down'),
+      width: DEFAULT_NODE_SIZE.width,
+      height: DEFAULT_NODE_SIZE.height,
+      selected: false,
+      data: buildNodeData(manifest, nodeId, normalized.config, { title }),
+    }
+    return ok({
+      graph: { ...ctx.graph, nodes: [...nodes, newNode], edges },
+      touchedNodeId: nodeId,
+      newNodeIds: new Set([nodeId]),
+      normalizeIssues: normalized.issues,
+    })
+  })
+}
+
+/** One node of a {@link replaceGraph} spec. */
+export interface ReplaceGraphNodeSpec {
+  type: string
+  title?: string
+  config?: Record<string, unknown>
+  position?: Point
+  /** Title of the loop (among these specs) this node lives inside. */
+  inside?: string
+}
+
+/** One edge of a {@link replaceGraph} spec — friendly refs by title. */
+export interface ReplaceGraphEdgeSpec {
+  from: string
+  to: string
+  branch?: string
+}
+
+/** Input for {@link replaceGraph}. */
+export interface ReplaceGraphInput extends GraphEditScope {
+  nodes: ReplaceGraphNodeSpec[]
+  edges: ReplaceGraphEdgeSpec[]
+}
+
+/**
+ * Author a whole graph at once — RESTRICTED to EMPTY drafts. A model
+ * re-emitting a graph it partially understands silently drops nodes, and a
+ * full replace is exactly the operation nobody reviews, so a non-empty draft
+ * is refused with instructions to edit incrementally (decision 2026-08-13).
+ * Positions are auto-laid-out with the same dagre pass the canvas's
+ * auto-organize uses; loop children are laid out inside their container.
+ */
+export async function replaceGraph(
+  db: Database,
+  params: ReplaceGraphInput
+): Promise<Result<GraphMutationResult, AuxxError>> {
+  return runGraphMutation(db, params, async (ctx, aliases) => {
+    if (ctx.graph.nodes.length > 0) {
+      return err(
+        new BadRequestError(
+          `The draft already has ${ctx.graph.nodes.length} nodes — replaceGraph only builds onto ` +
+            'an EMPTY draft. Edit incrementally instead (addNode / updateNode / connectNodes / ' +
+            'deleteNodes), or delete the existing nodes explicitly first.'
+        )
+      )
+    }
+    if (params.nodes.length === 0) {
+      return err(new BadRequestError('replaceGraph needs at least one node'))
+    }
+
+    // Pass 1 — mint ids and titles so refs in configs/edges can resolve.
+    const built: GraphNode[] = []
+    for (const spec of params.nodes) {
+      const manifestResult = requireAuthorableManifest(spec.type)
+      if (manifestResult.isErr()) return err(manifestResult.error)
+      const manifest = manifestResult.value
+      const nodeId = generateId(spec.type)
+      const baseTitle =
+        spec.title ??
+        (typeof spec.config?.title === 'string' ? spec.config.title : undefined) ??
+        (typeof manifest.defaultData().title === 'string'
+          ? (manifest.defaultData().title as string)
+          : manifest.displayName)
+      const title = uniqueTitle(baseTitle, built)
+      built.push({
+        id: nodeId,
+        type: spec.type === 'note' ? 'note' : 'standard',
+        position: spec.position ?? { x: 0, y: 0 },
+        width: DEFAULT_NODE_SIZE.width,
+        height: DEFAULT_NODE_SIZE.height,
+        selected: false,
+        data: buildNodeData(manifest, nodeId, {}, { title }),
+      })
+    }
+
+    // Pass 2 — containment, then normalized configs (refs resolve by title).
+    const normalizeIssues: Issue[] = []
+    for (let i = 0; i < params.nodes.length; i++) {
+      const spec = params.nodes[i]
+      const node = built[i]
+      if (!spec || !node) continue
+      if (spec.inside !== undefined) {
+        const inside = resolveNodeRef(built, spec.inside)
+        if (inside.isErr()) return err(inside.error)
+        if (nodeType(inside.value.node as GraphNode) !== 'loop') {
+          return err(
+            new BadRequestError(`"${spec.inside}" is not a loop — only loops contain other nodes.`)
+          )
+        }
+        node.parentId = inside.value.node.id
+        node.extent = 'parent'
+        node.data = { ...node.data, isInLoop: true, loopId: inside.value.node.id }
+      }
+      const manifest = getManifest(spec.type)
+      if (!manifest) continue
+      const normalized = await normalizeConfig(
+        ctx.organizationId,
+        built,
+        aliases,
+        spec.type,
+        spec.config ?? {}
+      )
+      normalizeIssues.push(...normalized.issues)
+      const { id: _id, type: _type, title: _title, ...config } = normalized.config
+      node.data = { ...node.data, ...config }
+    }
+
+    // Pass 3 — edges through the branch resolver, loop-backs detected.
+    const edges: GraphEdge[] = []
+    for (const spec of params.edges) {
+      const from = resolveConnectionSpec(built, { after: spec.from, branch: spec.branch })
+      if (from.isErr()) return err(from.error)
+      const to = resolveNodeRef(built, spec.to)
+      if (to.isErr()) return err(to.error)
+      const source = built.find((n) => n.id === from.value.sourceNodeId)
+      const targetNode = to.value.node as GraphNode
+      const isLoopBack = nodeType(targetNode) === 'loop' && source?.parentId === targetNode.id
+      const edge = isLoopBack
+        ? makeEdge(from.value.sourceNodeId, from.value.sourceHandle, targetNode.id, 'loop-back', {
+            isLoopBackEdge: true,
+          })
+        : makeEdge(from.value.sourceNodeId, from.value.sourceHandle, targetNode.id, 'target')
+      if (!edges.some((e) => e.id === edge.id)) edges.push(edge)
+    }
+
+    // Pass 4 — auto-layout: dagre for the top level (positions from centers,
+    // the canvas auto-organize's math), per-container dagre for loop children,
+    // containers sized to fit.
+    const explicit = new Set(
+      params.nodes.flatMap((spec, i) => (spec.position ? [built[i]?.id ?? ''] : []))
+    )
+    const layout = getLayoutByDagre(built, edges)
+    for (const node of built) {
+      if (node.parentId || explicit.has(node.id)) continue
+      const placed = layout.node(node.id)
+      if (!placed) continue
+      node.position = {
+        x: placed.x - (node.width || DEFAULT_NODE_SIZE.width) / 2,
+        y: placed.y - (node.height || DEFAULT_NODE_SIZE.height) / 2,
+      }
+    }
+    for (const container of built.filter((n) => built.some((c) => c.parentId === n.id))) {
+      const childLayout = getLayoutForChildNodes(container.id, built, edges)
+      const containerPadding = 20
+      for (const child of built) {
+        if (child.parentId !== container.id || explicit.has(child.id)) continue
+        const placed = childLayout.node(child.id)
+        if (!placed) continue
+        child.position = {
+          x: containerPadding + placed.x - (child.width || DEFAULT_NODE_SIZE.width) / 2,
+          y: containerPadding + placed.y - (child.height || DEFAULT_NODE_SIZE.height) / 2,
+        }
+      }
+      const size = calculateContainerSize(container.id, built, childLayout)
+      container.width = Math.max(size.width, container.width || 0)
+      container.height = Math.max(size.height, container.height || 0)
+      container.data = { ...container.data, width: container.width, height: container.height }
+    }
+
+    return ok({
+      graph: { nodes: built, edges, viewport: { x: 0, y: 0, zoom: 1 } },
+      newNodeIds: new Set(built.map((n) => n.id)),
+      normalizeIssues,
+    })
+  })
+}
+
+/** Input for {@link applyTemplate}. */
+export interface ApplyTemplateInput extends GraphEditScope {
+  /** File template id (`file:<slug>`) or DB template row id. */
+  templateId: string
+  /** Stamped onto cloned graph metadata by the template transformer. */
+  userId: string
+}
+
+/**
+ * Install a template into an EMPTY draft, through the same
+ * create-from-template path the router uses (`resolveTemplateById` +
+ * `buildTemplateWorkflowData`): fresh node ids, `{{oldId.x}}` refs rewritten,
+ * app slugs and `@entity:`/`@field:` refs resolved against this org, trigger
+ * columns derived from the resolved graph. Curated templates may contain
+ * non-authorable node types — those install as-is and stay read-only to the
+ * agent.
+ */
+export async function applyTemplate(
+  db: Database,
+  params: ApplyTemplateInput
+): Promise<Result<GraphMutationResult, AuxxError>> {
+  return runGraphMutation(db, params, async (ctx) => {
+    if (ctx.graph.nodes.length > 0) {
+      return err(
+        new BadRequestError(
+          `The draft already has ${ctx.graph.nodes.length} nodes — applyTemplate only installs ` +
+            'into an EMPTY draft. Delete the existing nodes first, or build on them incrementally.'
+        )
+      )
+    }
+
+    // Lazy imports — the template resolver pulls @auxx/services and the
+    // transformer chain; neither belongs in this module's import-time graph.
+    const { resolveTemplateById } = await import('../resolve-template')
+    const { buildTemplateWorkflowData } = await import('../create-from-template')
+
+    const template = await resolveTemplateById(params.templateId)
+    if (!template) return err(new NotFoundError('Template not found'))
+
+    const data = await buildTemplateWorkflowData(
+      params.organizationId,
+      params.userId,
+      // Same cast the create-from-template router applies (workflow.ts:379) —
+      // the template row's jsonb fields are looser than TemplateForCreate.
+      template as import('../create-from-template').TemplateForCreate,
+      false
+    )
+    const graph = data.graph as unknown as Partial<DraftGraph> | undefined
+    return ok({
+      graph: {
+        nodes: Array.isArray(graph?.nodes) ? graph.nodes : [],
+        edges: Array.isArray(graph?.edges) ? graph.edges : [],
+        viewport: graph?.viewport ?? { x: 0, y: 0, zoom: 1 },
+      },
+      // Curated graphs may carry not-yet-migrated types (webhook templates).
+      skipAuthorableCheck: true,
+      normalizeIssues: [],
+      fallbackTriggerType: data.triggerType ?? null,
+      ...(data.envVars !== undefined ? { envVars: data.envVars as unknown[] } : {}),
+      ...(data.variables !== undefined ? { variables: data.variables as unknown[] } : {}),
+      ...(data.icon !== undefined ? { icon: data.icon } : {}),
+    })
+  })
+}

--- a/packages/lib/src/workflows/graph-edit/persist.ts
+++ b/packages/lib/src/workflows/graph-edit/persist.ts
@@ -1,0 +1,133 @@
+// packages/lib/src/workflows/graph-edit/persist.ts
+
+/**
+ * The ONE seam through which every graph mutation writes the draft
+ * (`03-graph-edit-service.md` §7) — SERVER-ONLY.
+ *
+ * Writes go through the existing `WorkflowService.update` path (NOT
+ * `workflow-engine/services/`), so everything it does on save keeps
+ * happening: the blocking `assertMailTriggerNotPersonal`, entity-id
+ * canonicalization, the `deriveTriggerLinkColumns` app/webhook column
+ * derivation, the hash-CAS on `expectedGraphHash`, and cache invalidation.
+ * `publish`, `enabled` and the admin-only field set are never touched here —
+ * those are the user's actions.
+ *
+ * Trigger columns are re-derived on EVERY persist (`deriveTriggerColumns`
+ * over the cleaned nodes — the same derivation `use-workflow-save.ts` runs),
+ * so a mutation that adds/edits/removes a trigger node can never leave
+ * `Workflow.triggerType`/`entityDefinitionId` stale.
+ *
+ * NEXT-SLICE SEAM: the Redis turn snapshot wraps this function BEFORE the
+ * write and the `workflow:draft-updated` realtime event fires AFTER it —
+ * both belong in a wrapper around `persistDraft`, not inside it.
+ */
+
+import type { Database } from '@auxx/database'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError, NotFoundError, UnprocessableEntityError } from '../../errors'
+import { deriveTriggerColumns } from '../../workflow-engine/catalog/derive-trigger'
+import type { WorkflowTriggerType, WorkflowUpdateInput } from '../types'
+import type { GraphEditScope } from './read'
+import type { DraftGraph, GraphEdge, GraphNode } from './types'
+
+/** Strip `_`-prefixed keys — derived state the initializer regenerates on load. */
+function stripDerivedKeys(record: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(record).filter(([key]) => !key.startsWith('_')))
+}
+
+/**
+ * The same cleanup the canvas save applies (`use-workflow-save.ts`
+ * `cleanNodes`/`cleanEdges`): `_`-prefixed keys in node and edge data never
+ * persist. Agent-authored data must not carry them either — manifest
+ * `defaultData` may (if-else ships `_targetBranches`), so cleaning here keeps
+ * that invariant regardless of the mutation.
+ */
+export function cleanGraphForSave(graph: DraftGraph): DraftGraph {
+  const nodes: GraphNode[] = graph.nodes.map((node) => ({
+    ...node,
+    data: stripDerivedKeys((node.data ?? {}) as Record<string, unknown>),
+  }))
+  const edges: GraphEdge[] = graph.edges.map((edge) => {
+    if (!edge.data) return edge
+    const data = stripDerivedKeys(edge.data)
+    return { ...edge, data: Object.keys(data).length > 0 ? data : undefined }
+  })
+  return { nodes, edges, ...(graph.viewport ? { viewport: graph.viewport } : {}) }
+}
+
+/** What a mutation hands the persist seam. */
+export interface PersistDraftInput {
+  graph: DraftGraph
+  /** CAS token from `loadDraftContext` — a concurrent save between load and write 409s. */
+  expectedGraphHash?: string
+  /**
+   * Trigger type to write when the graph derives none (template installs
+   * carrying not-yet-migrated triggers). Ordinary mutations pass the loaded
+   * draft's current type, mirroring the browser save's fallback.
+   */
+  fallbackTriggerType?: string | null
+  envVars?: WorkflowUpdateInput['envVars']
+  variables?: WorkflowUpdateInput['variables']
+  icon?: WorkflowUpdateInput['icon']
+}
+
+/** What the persist wrote — chained into the next mutation's CAS token. */
+export interface PersistDraftOutcome {
+  graphHash: string | null
+  triggerType?: string | null
+  entityDefinitionId?: string | null
+}
+
+/**
+ * Persist a mutated draft graph. Callers must have validated the graph first
+ * (structural errors reject before this runs) and asserted edit access +
+ * `assertWorkflowAppNotSystemOwned` at the capability layer — no permission
+ * checks live in lib.
+ *
+ * `assertMailTriggerNotPersonal` (inside `WorkflowService.update`) and the
+ * hash-CAS surface as `err(AuxxError)` — never swallowed.
+ */
+export async function persistDraft(
+  db: Database,
+  scope: GraphEditScope,
+  input: PersistDraftInput
+): Promise<Result<PersistDraftOutcome, AuxxError>> {
+  const graph = cleanGraphForSave(input.graph)
+
+  // Re-derive the trigger columns from the graph being written — the exact
+  // derivation (and fallbacks) the canvas save posts.
+  const derived = deriveTriggerColumns(graph.nodes)
+  const triggerType = derived.triggerType ?? input.fallbackTriggerType ?? undefined
+  // `null` is the explicit clear: a graph with no resource trigger must not
+  // leave a stale entity id next to the new trigger type.
+  const entityDefinitionId = derived.entityDefinitionId ?? null
+
+  try {
+    // Lazy import — `workflow-service` statically loads the engine + queue
+    // module graph, which must not ride along at import time.
+    const { WorkflowService } = await import('../workflow-service')
+    const updated = await new WorkflowService(db).update(scope.organizationId, {
+      id: scope.workflowAppId,
+      graph: graph as WorkflowUpdateInput['graph'],
+      triggerType: triggerType as WorkflowTriggerType | undefined,
+      entityDefinitionId,
+      ...(input.expectedGraphHash !== undefined
+        ? { expectedGraphHash: input.expectedGraphHash }
+        : {}),
+      ...(input.envVars !== undefined ? { envVars: input.envVars } : {}),
+      ...(input.variables !== undefined ? { variables: input.variables } : {}),
+      ...(input.icon !== undefined ? { icon: input.icon } : {}),
+    })
+    return ok({
+      graphHash: (updated?.graphHash as string | null | undefined) ?? null,
+      triggerType: (updated?.triggerType as string | null | undefined) ?? triggerType ?? null,
+      entityDefinitionId:
+        (updated?.entityDefinitionId as string | null | undefined) ?? entityDefinitionId,
+    })
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    const message = error instanceof Error ? error.message : String(error)
+    if (message === 'Workflow not found') return err(new NotFoundError('Workflow not found'))
+    return err(new UnprocessableEntityError(`Failed to save the workflow draft: ${message}`))
+  }
+}

--- a/packages/lib/src/workflows/graph-edit/place-node.ts
+++ b/packages/lib/src/workflows/graph-edit/place-node.ts
@@ -1,0 +1,250 @@
+// packages/lib/src/workflows/graph-edit/place-node.ts
+
+/**
+ * Incremental node placement (`03-graph-edit-service.md` §4) — pure, no DOM.
+ *
+ * A pared-down port of the pure parts of apps/web's
+ * `components/workflow/utils/node-layout/{collision-detector,position-calculator}.ts`
+ * — the collision search verbatim, the placement rules reduced to what
+ * `addNode` needs. The web files were NOT moved (they also carry lane-shifting
+ * and viewport logic the server must not run): §4's rule is that **existing
+ * nodes never move** on an incremental add, so the collision search only ever
+ * places the NEW node around them.
+ *
+ * Rules implemented:
+ * - `after` with no siblings: one column right of the predecessor, vertically
+ *   aligned to it.
+ * - `after` with siblings (other targets of the same anchor — same handle
+ *   first, any handle otherwise): aligned to the sibling column, stacked
+ *   below the lowest sibling, so branch targets stack downward.
+ * - `inside`: grid position within the container bounds (parent-relative
+ *   coordinates), with a container-resize suggestion when the child overflows.
+ * - no anchor: to the right of the whole graph.
+ */
+
+import { LAYOUT_SPACING, NODE_ADDITION_CONFIG } from './layout-constants'
+import type { GraphEdge, GraphNode, Point } from './types'
+
+/** Width/height pair for the node being placed. */
+export interface Size {
+  width: number
+  height: number
+}
+
+/** The default footprint a node occupies before the canvas measures it. */
+export const DEFAULT_NODE_SIZE: Size = {
+  width: LAYOUT_SPACING.DEFAULT_NODE_WIDTH,
+  height: LAYOUT_SPACING.DEFAULT_NODE_HEIGHT,
+}
+
+interface Bounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+function nodeBounds(node: GraphNode): Bounds {
+  return {
+    x: node.position.x,
+    y: node.position.y,
+    width: node.width || LAYOUT_SPACING.DEFAULT_NODE_WIDTH,
+    height: node.height || LAYOUT_SPACING.DEFAULT_NODE_HEIGHT,
+  }
+}
+
+function boundsOverlap(a: Bounds, b: Bounds): boolean {
+  const padding = NODE_ADDITION_CONFIG.COLLISION_PADDING
+  return !(
+    a.x + a.width + padding <= b.x ||
+    b.x + b.width + padding <= a.x ||
+    a.y + a.height + padding <= b.y ||
+    b.y + b.height + padding <= a.y
+  )
+}
+
+/** Whether a node of `size` at `position` would overlap any of `nodes`. */
+export function isPositionOccupied(position: Point, size: Size, nodes: GraphNode[]): boolean {
+  const candidate: Bounds = { x: position.x, y: position.y, ...size }
+  return nodes.some((node) => boundsOverlap(candidate, nodeBounds(node)))
+}
+
+/**
+ * Nearest collision-free position for a node of `size`, starting from
+ * `preferred` and searching in `direction` — the web collision detector's
+ * linear searches, verbatim. Falls back to far right when nothing frees up.
+ */
+export function findNearestEmptySpace(
+  preferred: Point,
+  size: Size,
+  nodes: GraphNode[],
+  direction: 'right' | 'down' | 'vertical' = 'vertical'
+): Point {
+  if (!isPositionOccupied(preferred, size, nodes)) return preferred
+
+  const increment = NODE_ADDITION_CONFIG.POSITION_SEARCH_INCREMENTS
+  const maxAttempts = NODE_ADDITION_CONFIG.MAX_POSITION_ATTEMPTS
+
+  for (let i = 1; i <= maxAttempts; i++) {
+    const candidates: Point[] =
+      direction === 'right'
+        ? [{ x: preferred.x + i * increment, y: preferred.y }]
+        : direction === 'down'
+          ? [{ x: preferred.x, y: preferred.y + i * increment }]
+          : [
+              { x: preferred.x, y: preferred.y + i * increment },
+              { x: preferred.x, y: preferred.y - i * increment },
+            ]
+    for (const candidate of candidates) {
+      if (!isPositionOccupied(candidate, size, nodes)) return candidate
+    }
+  }
+
+  return { x: preferred.x + NODE_ADDITION_CONFIG.COLLISION_SEARCH_RADIUS, y: preferred.y }
+}
+
+/**
+ * Position for a node added after `anchor`: one column right, vertically
+ * aligned — unless the anchor already feeds other nodes, in which case the new
+ * node joins their column below the lowest one (branch targets stack
+ * downward). Nodes sharing the anchor's coordinate frame only: when the anchor
+ * is a loop child (parent-relative coordinates), pass its siblings as `nodes`.
+ */
+export function placeAfter(
+  anchor: GraphNode,
+  sourceHandle: string,
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+  size: Size = DEFAULT_NODE_SIZE
+): Point {
+  const outgoing = edges.filter((e) => e.source === anchor.id)
+  const sameHandle = outgoing.filter((e) => (e.sourceHandle ?? 'source') === sourceHandle)
+  const siblingEdges = sameHandle.length > 0 ? sameHandle : outgoing
+  const siblings = siblingEdges
+    .map((e) => nodes.find((n) => n.id === e.target))
+    .filter((n): n is GraphNode => n !== undefined && n.id !== anchor.id)
+
+  if (siblings.length === 0) {
+    const anchorWidth = anchor.width || LAYOUT_SPACING.DEFAULT_NODE_WIDTH
+    const preferred: Point = {
+      x: anchor.position.x + anchorWidth + NODE_ADDITION_CONFIG.HORIZONTAL_SPACING,
+      y: anchor.position.y,
+    }
+    return findNearestEmptySpace(preferred, size, nodes, 'right')
+  }
+
+  const columnX = Math.min(...siblings.map((s) => s.position.x))
+  const lowestBottom = Math.max(
+    ...siblings.map((s) => s.position.y + (s.height || LAYOUT_SPACING.DEFAULT_NODE_HEIGHT))
+  )
+  const preferred: Point = {
+    x: columnX,
+    y: lowestBottom + NODE_ADDITION_CONFIG.VERTICAL_SPACING,
+  }
+  return findNearestEmptySpace(preferred, size, nodes, 'vertical')
+}
+
+/** What `placeInside` decides: a parent-relative position plus a resize ask. */
+export interface InsidePlacement {
+  position: Point
+  requiresResize: boolean
+  suggestedSize?: Size
+}
+
+/** Container inner padding — the position-calculator's values, verbatim. */
+const CONTAINER_PADDING = { top: 80, right: 20, bottom: 20, left: 20 }
+const CHILD_SPACING = { horizontal: 20, vertical: 20 }
+
+/**
+ * Position for a node added inside a container: the web position-calculator's
+ * `inside` path, verbatim — first child centered under the header, later
+ * children on the next free grid cell; coordinates are PARENT-RELATIVE (React
+ * Flow child frames). Returns a container-resize suggestion when the child
+ * lands outside the current bounds.
+ */
+export function placeInside(
+  parent: GraphNode,
+  children: GraphNode[],
+  size: Size = DEFAULT_NODE_SIZE
+): InsidePlacement {
+  const parentWidth = parent.width || LAYOUT_SPACING.DEFAULT_NODE_WIDTH
+
+  let position: Point
+  if (children.length === 0) {
+    position = {
+      x: Math.max(CONTAINER_PADDING.left, (parentWidth - size.width) / 2),
+      y: CONTAINER_PADDING.top,
+    }
+  } else {
+    const availableWidth = parentWidth - CONTAINER_PADDING.left - CONTAINER_PADDING.right
+    const maxColumns = Math.max(
+      1,
+      Math.floor(availableWidth / (size.width + CHILD_SPACING.horizontal))
+    )
+    const occupied = new Set(
+      children.map((child) => {
+        const col = Math.floor(
+          (child.position.x - CONTAINER_PADDING.left) / (size.width + CHILD_SPACING.horizontal)
+        )
+        const row = Math.floor(
+          (child.position.y - CONTAINER_PADDING.top) / (size.height + CHILD_SPACING.vertical)
+        )
+        return `${col},${row}`
+      })
+    )
+    let row = 0
+    let col = 0
+    while (occupied.has(`${col},${row}`)) {
+      col++
+      if (col >= maxColumns) {
+        col = 0
+        row++
+      }
+    }
+    position = {
+      x: CONTAINER_PADDING.left + col * (size.width + CHILD_SPACING.horizontal),
+      y: CONTAINER_PADDING.top + row * (size.height + CHILD_SPACING.vertical),
+    }
+  }
+
+  let maxX = position.x + size.width
+  let maxY = position.y + size.height
+  for (const child of children) {
+    maxX = Math.max(maxX, child.position.x + (child.width || LAYOUT_SPACING.DEFAULT_NODE_WIDTH))
+    maxY = Math.max(maxY, child.position.y + (child.height || LAYOUT_SPACING.DEFAULT_NODE_HEIGHT))
+  }
+  const requiredWidth = maxX + CONTAINER_PADDING.right
+  const requiredHeight = maxY + CONTAINER_PADDING.bottom
+  const currentWidth = parent.width || LAYOUT_SPACING.DEFAULT_NODE_WIDTH
+  const currentHeight = parent.height || LAYOUT_SPACING.DEFAULT_NODE_HEIGHT
+  const requiresResize = requiredWidth > currentWidth || requiredHeight > currentHeight
+
+  return {
+    position,
+    requiresResize,
+    ...(requiresResize
+      ? {
+          suggestedSize: {
+            width: Math.max(requiredWidth, currentWidth),
+            height: Math.max(requiredHeight, currentHeight),
+          },
+        }
+      : {}),
+  }
+}
+
+/** Position for a node with no anchor: to the right of the whole graph. */
+export function placeStandalone(nodes: GraphNode[], size: Size = DEFAULT_NODE_SIZE): Point {
+  const topLevel = nodes.filter((n) => !n.parentId)
+  if (topLevel.length === 0) return { x: 250, y: 250 }
+
+  const rightmostX = Math.max(
+    ...topLevel.map((n) => n.position.x + (n.width || LAYOUT_SPACING.DEFAULT_NODE_WIDTH))
+  )
+  const averageY = topLevel.reduce((sum, n) => sum + n.position.y, 0) / topLevel.length
+  const preferred: Point = {
+    x: rightmostX + NODE_ADDITION_CONFIG.HORIZONTAL_SPACING,
+    y: averageY,
+  }
+  return findNearestEmptySpace(preferred, size, topLevel, 'right')
+}

--- a/packages/lib/src/workflows/graph-edit/read.ts
+++ b/packages/lib/src/workflows/graph-edit/read.ts
@@ -1,0 +1,275 @@
+// packages/lib/src/workflows/graph-edit/read.ts
+
+/**
+ * Draft reads for the graph-edit module (`03-graph-edit-service.md` §1) —
+ * SERVER-ONLY (org cache + db). Loads the draft `Workflow` row that
+ * `WorkflowApp.draftWorkflowId` points at and renders it for a headless
+ * caller: friendly refs everywhere (`{{Title.path}}`, resource slugs), never
+ * raw node ids or per-org CUIDs.
+ *
+ * No permission checks live here (house rule): callers must assert edit/view
+ * access (`capabilities.assert*Instance('workflow', id)`) and
+ * `assertWorkflowAppNotSystemOwned` before calling in.
+ */
+
+import { type Database, schema } from '@auxx/database'
+import { and, eq } from 'drizzle-orm'
+import { err, ok, type Result } from 'neverthrow'
+import { type AuxxError, NotFoundError } from '../../errors'
+import { resolveGraphOutputs } from '../../workflow-engine/catalog/resolve-outputs'
+import type { UnifiedVariable } from '../../workflow-engine/types/unified-variable'
+import { hashWorkflowGraph } from '../graph-hash'
+import { type ResourceAliasIndex, renderPersistedRefs } from './normalize/friendly-refs'
+import { checkVariableRefsAgainstOutputs } from './normalize/ref-check'
+import { buildResourceAliasIndex } from './normalize/resource-refs'
+import { formatNodeRef } from './refs'
+import type {
+  DraftGraph,
+  DraftSummary,
+  EdgeSummary,
+  GraphNode,
+  GraphSummary,
+  Issue,
+  NodeSummary,
+} from './types'
+import { nodeType, validateGraphStructure, validateNodeConfigs } from './validate'
+
+/** Everything a mutation or read needs about the loaded draft. */
+export interface DraftContext {
+  workflowAppId: string
+  organizationId: string
+  appName: string
+  /** The raw draft `Workflow` row (null when the app has no draft yet). */
+  draftRow: Record<string, unknown> | null
+  graph: DraftGraph
+  /** CAS token — hash of the stored graph; undefined when there is none yet. */
+  graphHash?: string
+  triggerType?: string | null
+}
+
+/** Scope every operation takes. */
+export interface GraphEditScope {
+  workflowAppId: string
+  organizationId: string
+}
+
+/** Normalize whatever the jsonb column holds into a well-formed graph doc. */
+function toDraftGraph(raw: unknown): DraftGraph {
+  const graph = (raw ?? {}) as Partial<DraftGraph>
+  return {
+    nodes: Array.isArray(graph.nodes) ? graph.nodes : [],
+    edges: Array.isArray(graph.edges) ? graph.edges : [],
+    ...(graph.viewport ? { viewport: graph.viewport } : {}),
+  }
+}
+
+/**
+ * Load the workflow app + its draft graph. A missing draft row is NOT an
+ * error — the app then edits as an empty graph and `WorkflowService.update`
+ * creates the draft on first persist.
+ */
+export async function loadDraftContext(
+  db: Database,
+  params: GraphEditScope
+): Promise<Result<DraftContext, AuxxError>> {
+  const { workflowAppId, organizationId } = params
+  const app = await db.query.WorkflowApp.findFirst({
+    where: and(
+      eq(schema.WorkflowApp.id, workflowAppId),
+      eq(schema.WorkflowApp.organizationId, organizationId)
+    ),
+    with: { draftWorkflow: true },
+  })
+  if (!app) return err(new NotFoundError('Workflow not found'))
+
+  const draftRow = (app.draftWorkflow ?? null) as Record<string, unknown> | null
+  const rawGraph = draftRow?.graph
+  return ok({
+    workflowAppId,
+    organizationId,
+    appName: app.name,
+    draftRow,
+    graph: toDraftGraph(rawGraph),
+    ...(rawGraph ? { graphHash: hashWorkflowGraph(rawGraph) } : {}),
+    triggerType: (draftRow?.triggerType as string | null | undefined) ?? null,
+  })
+}
+
+/** Data keys that are identity/bookkeeping, not config — withheld from summaries. */
+const NON_CONFIG_KEYS = new Set([
+  'id',
+  'type',
+  'title',
+  'desc',
+  'icon',
+  'selected',
+  'isValid',
+  'errors',
+  'disabled',
+  'isInLoop',
+  'loopId',
+  'width',
+  'height',
+  'variables',
+  'outputVariables',
+])
+
+/** One node's summary: friendly ref + friendly-rendered config. */
+export function buildNodeSummary(
+  graph: DraftGraph,
+  node: GraphNode,
+  aliases?: ResourceAliasIndex
+): NodeSummary {
+  const config: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries((node.data ?? {}) as Record<string, unknown>)) {
+    if (key.startsWith('_') || NON_CONFIG_KEYS.has(key)) continue
+    config[key] = value
+  }
+  const container = node.parentId ?? (node.data?.loopId as string | undefined)
+  return {
+    ref: formatNodeRef(graph.nodes, node.id),
+    id: node.id,
+    type: nodeType(node),
+    title: typeof node.data?.title === 'string' ? node.data.title : '',
+    ...(container ? { inside: formatNodeRef(graph.nodes, container) } : {}),
+    position: node.position ?? { x: 0, y: 0 },
+    config: renderPersistedRefs(config, { nodes: graph.nodes, resourceAliases: aliases }),
+  }
+}
+
+/** Compact graph summary with friendly refs. */
+export function buildGraphSummary(graph: DraftGraph, triggerType?: string | null): GraphSummary {
+  const edges: EdgeSummary[] = graph.edges.map((edge) => {
+    const handle = edge.sourceHandle ?? 'source'
+    return {
+      from: formatNodeRef(graph.nodes, edge.source),
+      to: formatNodeRef(graph.nodes, edge.target),
+      ...(handle !== 'source' ? { branch: handle } : {}),
+      ...(edge.data?.isLoopBackEdge || edge.targetHandle === 'loop-back'
+        ? { isLoopBack: true }
+        : {}),
+    }
+  })
+  return {
+    nodeCount: graph.nodes.length,
+    edgeCount: graph.edges.length,
+    nodes: graph.nodes.map((node) => {
+      const container = node.parentId ?? (node.data?.loopId as string | undefined)
+      return {
+        ref: formatNodeRef(graph.nodes, node.id),
+        type: nodeType(node),
+        ...(container ? { inside: formatNodeRef(graph.nodes, container) } : {}),
+      }
+    }),
+    edges,
+    triggerType: triggerType ?? null,
+  }
+}
+
+/** Friendly-render one node's resolved outputs (variable ids become `Title.path`). */
+export function renderFriendlyOutputs(
+  graph: DraftGraph,
+  outputs: UnifiedVariable[],
+  aliases?: ResourceAliasIndex
+): UnifiedVariable[] {
+  return renderPersistedRefs(structuredClone(outputs), {
+    nodes: graph.nodes,
+    resourceAliases: aliases,
+  })
+}
+
+/**
+ * Read the whole draft: graph + trigger + node summaries + resolved outputs +
+ * current issues (`03` §1). The one-stop read a tool's `get_workflow` wraps.
+ */
+export async function readDraft(
+  db: Database,
+  params: GraphEditScope
+): Promise<Result<DraftSummary, AuxxError>> {
+  const loaded = await loadDraftContext(db, params)
+  if (loaded.isErr()) return err(loaded.error)
+  const ctx = loaded.value
+  const aliases = await buildResourceAliasIndex(params.organizationId)
+
+  const issues: Issue[] = [...validateGraphStructure(ctx.graph), ...validateNodeConfigs(ctx.graph)]
+
+  const outputs: Record<string, UnifiedVariable[]> = {}
+  const resolved = await resolveGraphOutputs(params.organizationId, { graph: ctx.graph })
+  if (resolved.isOk()) {
+    issues.push(
+      ...checkVariableRefsAgainstOutputs({ graph: ctx.graph, outputs: resolved.value }).issues
+    )
+    for (const node of ctx.graph.nodes) {
+      outputs[formatNodeRef(ctx.graph.nodes, node.id)] = renderFriendlyOutputs(
+        ctx.graph,
+        resolved.value.get(node.id) ?? [],
+        aliases
+      )
+    }
+  }
+
+  return ok({
+    workflowAppId: ctx.workflowAppId,
+    name: ctx.appName,
+    triggerType: ctx.triggerType,
+    nodes: ctx.graph.nodes.map((node) => buildNodeSummary(ctx.graph, node, aliases)),
+    edges: buildGraphSummary(ctx.graph, ctx.triggerType).edges,
+    outputs,
+    issues,
+    graphSummary: buildGraphSummary(ctx.graph, ctx.triggerType),
+  })
+}
+
+/** What {@link validateWorkflow} reports. */
+export interface WorkflowValidationReport {
+  /** The real publish gate's verdict (`WorkflowEngine.validateWorkflowForPublish`). */
+  publishable: boolean
+  publishErrors: string[]
+  publishWarnings: string[]
+  /** Structural + config + reference issues, same tiers every mutation returns. */
+  issues: Issue[]
+}
+
+/**
+ * Check publishability without publishing: runs the three validation tiers
+ * plus the REAL publish gate over the current draft. Publishing itself stays
+ * the user's action — this only reports.
+ */
+export async function validateWorkflow(
+  db: Database,
+  params: GraphEditScope
+): Promise<Result<WorkflowValidationReport, AuxxError>> {
+  const loaded = await loadDraftContext(db, params)
+  if (loaded.isErr()) return err(loaded.error)
+  const ctx = loaded.value
+
+  const issues: Issue[] = [...validateGraphStructure(ctx.graph), ...validateNodeConfigs(ctx.graph)]
+  const resolved = await resolveGraphOutputs(params.organizationId, { graph: ctx.graph })
+  if (resolved.isOk()) {
+    issues.push(
+      ...checkVariableRefsAgainstOutputs({ graph: ctx.graph, outputs: resolved.value }).issues
+    )
+  }
+
+  if (!ctx.draftRow) {
+    return ok({
+      publishable: false,
+      publishErrors: ['No draft workflow to publish'],
+      publishWarnings: [],
+      issues,
+    })
+  }
+
+  // Lazy import — `workflow-version-service` statically loads `WorkflowEngine`,
+  // whose module graph must not ride along with every graph-edit read (same
+  // rule as the engine's own dynamic loading; see
+  // `project_workflow_engine_import_cycle`).
+  const { validateDraftWorkflowForPublish } = await import('../workflow-version-service')
+  const gate = await validateDraftWorkflowForPublish(ctx.draftRow)
+  return ok({
+    publishable: gate.valid,
+    publishErrors: gate.errors,
+    publishWarnings: gate.warnings ?? [],
+    issues,
+  })
+}

--- a/packages/lib/src/workflows/graph-edit/types.ts
+++ b/packages/lib/src/workflows/graph-edit/types.ts
@@ -64,3 +64,106 @@ export interface RefCorrection {
   /** The corrected reference. */
   to: string
 }
+
+/** Canvas coordinates. */
+export interface Point {
+  x: number
+  y: number
+}
+
+/**
+ * A persisted graph node as the draft `Workflow.graph` column stores it —
+ * `NodeMeta` plus the layout fields the canvas persists. Only the durable
+ * contract (`07-remaining-mechanics.md` §0): `data.type` + config, `position`,
+ * top-level `parentId`; every `_`-prefixed key is derived state and never
+ * authored here.
+ */
+export interface GraphNode extends NodeMeta {
+  position: Point
+  width?: number | null
+  height?: number | null
+  /** React Flow containment clamp — set alongside `parentId` (NodeFactory parity). */
+  extent?: string
+  selected?: boolean
+}
+
+/** A persisted graph edge — `EdgeMeta` plus the target handle and open data. */
+export interface GraphEdge extends EdgeMeta {
+  targetHandle?: string | null
+  data?: { isLoopBackEdge?: boolean; [key: string]: unknown }
+}
+
+/** The draft `Workflow.graph` document. */
+export interface DraftGraph {
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+  viewport?: { x: number; y: number; zoom: number }
+}
+
+/**
+ * One node, rendered for a caller: friendly `ref` (unique title, else id) and
+ * `config` with every variable/resource reference in `{{Title.path}}` / slug
+ * form — a model reading this never sees a raw node id or per-org CUID it
+ * might try to invent.
+ */
+export interface NodeSummary {
+  /** Friendly reference (`formatNodeRef`) — echoing it back is a valid `ref`. */
+  ref: string
+  id: string
+  type: string
+  title: string
+  /** Friendly ref of the loop container this node lives inside, if any. */
+  inside?: string
+  position: Point
+  /** Node config, friendly-rendered, bookkeeping keys stripped. */
+  config: Record<string, unknown>
+}
+
+/** One edge, rendered for a caller with friendly node refs. */
+export interface EdgeSummary {
+  from: string
+  to: string
+  /** Source branch handle when not the default `source`. */
+  branch?: string
+  isLoopBack?: boolean
+}
+
+/** Compact whole-graph shape returned with every operation. */
+export interface GraphSummary {
+  nodeCount: number
+  edgeCount: number
+  nodes: Array<{ ref: string; type: string; inside?: string }>
+  edges: EdgeSummary[]
+  /** The draft row's trigger type column (what the workflow fires on). */
+  triggerType?: string | null
+}
+
+/**
+ * What every graph mutation returns. `applied: false` means blocking issues
+ * (structural, or unresolvable references) prevented the write and the draft
+ * is untouched — the issues say what to fix. `applied: true` may still carry
+ * non-blocking config/reference issues: a half-built workflow is legitimate
+ * and persists, mirroring the canvas.
+ */
+export interface GraphMutationResult {
+  applied: boolean
+  /** The touched node, when the operation targets one. */
+  node?: NodeSummary
+  /** The touched node's resolved outputs, friendly-rendered — wire refs from these. */
+  outputs?: unknown[]
+  issues: Issue[]
+  graphSummary: GraphSummary
+}
+
+/** What `readDraft` returns: the whole draft, friendly-rendered. */
+export interface DraftSummary {
+  workflowAppId: string
+  name: string
+  triggerType?: string | null
+  nodes: NodeSummary[]
+  edges: EdgeSummary[]
+  /** Resolved outputs per node, keyed by friendly ref, friendly-rendered. */
+  outputs: Record<string, unknown[]>
+  issues: Issue[]
+  graphSummary: GraphSummary
+}

--- a/packages/lib/src/workflows/graph-edit/validate.ts
+++ b/packages/lib/src/workflows/graph-edit/validate.ts
@@ -1,0 +1,343 @@
+// packages/lib/src/workflows/graph-edit/validate.ts
+
+/**
+ * Graph validation (`03-graph-edit-service.md` §5), tiers 1 and 2 — pure, no
+ * db/cache. Tier 3 (reference checks) lives in `normalize/ref-check.ts`; the
+ * publish gate wrapper lives in `read.ts` (it loads the draft row).
+ *
+ * Tier 1 (structural, BLOCKING — the pipeline refuses to persist):
+ *   unknown/non-authorable node types among the nodes a mutation introduced,
+ *   edges to missing nodes, invalid source/target handles (checked against
+ *   `manifest.connection.branches(config)` — never string-matched), trigger
+ *   rules, containment integrity, connection limits, and non-loop cycles.
+ *
+ * Tier 2 (config, NON-blocking — a half-configured node persists, mirroring
+ * the canvas): `manifest.configSchema.safeParse` + `manifest.validate`,
+ * reported per field.
+ *
+ * One deliberate softening of §5's "exactly one trigger": ZERO triggers is a
+ * warning, not an error — blocking it would make it impossible to build a
+ * workflow incrementally (the first `addNode` on an empty draft has no
+ * trigger yet). More than one trigger, or an edge INTO a trigger, is a hard
+ * structural error.
+ */
+
+import { getAuthorableManifests, getManifest } from '../../workflow-engine/catalog/registry'
+import { formatNodeRef } from './refs'
+import type { DraftGraph, GraphEdge, GraphNode, Issue } from './types'
+
+/** The persisted node type (`data.type`; `node.type` is the renderer type). */
+export function nodeType(node: GraphNode): string {
+  return (node.data?.type as string | undefined) ?? node.type
+}
+
+/** Whether a node is an in-graph trigger per its catalog manifest. */
+export function isTriggerNode(node: GraphNode): boolean {
+  return getManifest(nodeType(node))?.triggerType !== undefined
+}
+
+/**
+ * Forward edges for cycle detection — loop-back edges and child→own-container
+ * edges excluded, mirroring the catalog's `getForwardEdges`
+ * (`graph-vars.ts`), so an intentional loop never reads as a cycle.
+ */
+function forwardEdges(graph: DraftGraph): GraphEdge[] {
+  const loopIds = new Set(graph.nodes.filter((n) => nodeType(n) === 'loop').map((n) => n.id))
+  return graph.edges.filter((edge) => {
+    if (edge.data?.isLoopBackEdge) return false
+    if (loopIds.has(edge.target)) {
+      const source = graph.nodes.find((n) => n.id === edge.source)
+      if (source?.parentId === edge.target || source?.data?.loopId === edge.target) return false
+    }
+    return true
+  })
+}
+
+/** Node ids left over after Kahn's algorithm — the members of non-loop cycles. */
+function cycleMembers(graph: DraftGraph): string[] {
+  const nodeIds = new Set(graph.nodes.map((n) => n.id))
+  const inDegree = new Map<string, number>()
+  const adjacency = new Map<string, string[]>()
+  for (const id of nodeIds) {
+    inDegree.set(id, 0)
+    adjacency.set(id, [])
+  }
+  for (const edge of forwardEdges(graph)) {
+    if (!nodeIds.has(edge.source) || !nodeIds.has(edge.target)) continue
+    inDegree.set(edge.target, (inDegree.get(edge.target) ?? 0) + 1)
+    adjacency.get(edge.source)?.push(edge.target)
+  }
+  const queue = [...nodeIds].filter((id) => inDegree.get(id) === 0)
+  const seen = new Set<string>()
+  while (queue.length > 0) {
+    const current = queue.shift()
+    if (current === undefined || seen.has(current)) continue
+    seen.add(current)
+    for (const next of adjacency.get(current) ?? []) {
+      const degree = (inDegree.get(next) ?? 1) - 1
+      inDegree.set(next, degree)
+      if (degree === 0) queue.push(next)
+    }
+  }
+  return [...nodeIds].filter((id) => !seen.has(id))
+}
+
+/**
+ * Tier-1 structural validation. Every issue this returns with severity
+ * `error` BLOCKS the mutation.
+ *
+ * `newNodeIds` scopes the authorable-type check to the nodes the mutation
+ * introduced or retyped: a pre-existing not-yet-migrated node (webhook, app
+ * block) must not lock the whole draft against unrelated edits — those get an
+ * `info` note instead.
+ */
+export function validateGraphStructure(
+  graph: DraftGraph,
+  opts: { newNodeIds?: ReadonlySet<string> } = {}
+): Issue[] {
+  const issues: Issue[] = []
+  const nodes = graph.nodes
+  const nodeById = new Map(nodes.map((n) => [n.id, n]))
+  const ref = (id: string) => formatNodeRef(nodes, id)
+  const newNodeIds = opts.newNodeIds ?? new Set<string>()
+  const authorableTypes = () =>
+    getAuthorableManifests()
+      .map((m) => m.id)
+      .sort()
+      .join(', ')
+
+  // Node types — authorable for introduced nodes, informational otherwise.
+  for (const node of nodes) {
+    const type = nodeType(node)
+    const manifest = getManifest(type)
+    if (newNodeIds.has(node.id)) {
+      if (!manifest) {
+        issues.push({
+          severity: 'error',
+          nodeRef: ref(node.id),
+          message: `Unknown node type "${type}". Authorable types: ${authorableTypes()}.`,
+        })
+      } else if (manifest.agent?.authorable !== true) {
+        issues.push({
+          severity: 'error',
+          nodeRef: ref(node.id),
+          message: `Node type "${type}" cannot be authored here. Authorable types: ${authorableTypes()}.`,
+        })
+      }
+    } else if (!manifest) {
+      issues.push({
+        severity: 'info',
+        nodeRef: ref(node.id),
+        message: `Node type "${type}" is not in the catalog — it is read-only to this editor.`,
+      })
+    }
+  }
+
+  // Containment — parentId must name an existing loop node.
+  for (const node of nodes) {
+    if (!node.parentId) continue
+    const parent = nodeById.get(node.parentId)
+    if (!parent) {
+      issues.push({
+        severity: 'error',
+        nodeRef: ref(node.id),
+        message: `Node ${ref(node.id)} has parentId "${node.parentId}", which matches no node.`,
+      })
+    } else if (nodeType(parent) !== 'loop') {
+      issues.push({
+        severity: 'error',
+        nodeRef: ref(node.id),
+        message: `Node ${ref(node.id)} is contained in ${ref(parent.id)}, which is not a loop.`,
+      })
+    }
+  }
+
+  // Edges — endpoints must exist, handles must be ones the manifest declares.
+  for (const edge of graph.edges) {
+    const source = nodeById.get(edge.source)
+    const target = nodeById.get(edge.target)
+    if (!source || !target) {
+      issues.push({
+        severity: 'error',
+        message: `Edge "${edge.id}" connects ${source ? ref(edge.source) : `missing node "${edge.source}"`} → ${
+          target ? ref(edge.target) : `missing node "${edge.target}"`
+        }.`,
+      })
+      continue
+    }
+
+    const sourceManifest = getManifest(nodeType(source))
+    if (sourceManifest) {
+      const branches = sourceManifest.connection.branches?.(source.data) ?? []
+      const handle = edge.sourceHandle ?? 'source'
+      const allowed = branches.length > 0 ? branches.map((b) => b.id) : ['source']
+      if (!allowed.includes(handle)) {
+        issues.push({
+          severity: 'error',
+          nodeRef: ref(source.id),
+          message:
+            `Edge "${edge.id}" leaves ${ref(source.id)} on handle "${handle}", which the node does ` +
+            `not expose. Valid handles: ${allowed.join(', ')}.`,
+        })
+      }
+    }
+
+    const targetHandle = edge.targetHandle ?? 'target'
+    if (targetHandle === 'loop-back') {
+      if (nodeType(target) !== 'loop') {
+        issues.push({
+          severity: 'error',
+          nodeRef: ref(target.id),
+          message: `Edge "${edge.id}" targets handle "loop-back" on ${ref(target.id)}, which is not a loop.`,
+        })
+      }
+    } else if (targetHandle !== 'target') {
+      issues.push({
+        severity: 'error',
+        nodeRef: ref(target.id),
+        message: `Edge "${edge.id}" targets unknown handle "${targetHandle}" on ${ref(target.id)}.`,
+      })
+    }
+  }
+
+  // Connection limits and non-connectable nodes.
+  for (const node of nodes) {
+    const manifest = getManifest(nodeType(node))
+    if (!manifest) continue
+    const incoming = graph.edges.filter((e) => e.target === node.id)
+    const outgoing = graph.edges.filter((e) => e.source === node.id)
+    if (manifest.connection.canConnect === false && incoming.length + outgoing.length > 0) {
+      issues.push({
+        severity: 'error',
+        nodeRef: ref(node.id),
+        message: `Node type "${nodeType(node)}" cannot be connected to other nodes.`,
+      })
+    }
+    const maxIn = manifest.connection.maxIncomingConnections
+    if (maxIn !== undefined && incoming.length > maxIn) {
+      issues.push({
+        severity: 'error',
+        nodeRef: ref(node.id),
+        message: `Node ${ref(node.id)} has ${incoming.length} incoming connections (max ${maxIn}).`,
+      })
+    }
+    const maxOut = manifest.connection.maxOutgoingConnections
+    if (maxOut !== undefined && outgoing.length > maxOut) {
+      issues.push({
+        severity: 'error',
+        nodeRef: ref(node.id),
+        message: `Node ${ref(node.id)} has ${outgoing.length} outgoing connections (max ${maxOut}).`,
+      })
+    }
+  }
+
+  // Trigger rules — at most one; none is a warning (a draft under construction);
+  // an edge INTO a trigger is structural corruption.
+  const triggers = nodes.filter(isTriggerNode)
+  if (triggers.length === 0 && nodes.length > 0) {
+    issues.push({
+      severity: 'warning',
+      message: 'The workflow has no trigger node yet — it cannot run until one is added.',
+    })
+  } else if (triggers.length > 1) {
+    issues.push({
+      severity: 'error',
+      message:
+        `The workflow has ${triggers.length} trigger nodes — only one is allowed: ` +
+        `${triggers.map((t) => ref(t.id)).join(', ')}. Delete the extras or use setTrigger.`,
+    })
+  }
+  for (const trigger of triggers) {
+    if (graph.edges.some((e) => e.target === trigger.id)) {
+      issues.push({
+        severity: 'error',
+        nodeRef: ref(trigger.id),
+        message: `Trigger ${ref(trigger.id)} has incoming connections — triggers start the workflow and take no input.`,
+      })
+    }
+  }
+
+  // Loop structure — at most one loop-start edge per loop (the engine's
+  // validateLoopStructure throws on more); children with none is a warning.
+  for (const loop of nodes.filter((n) => nodeType(n) === 'loop')) {
+    const loopStarts = graph.edges.filter(
+      (e) => e.source === loop.id && e.sourceHandle === 'loop-start'
+    )
+    if (loopStarts.length > 1) {
+      issues.push({
+        severity: 'error',
+        nodeRef: ref(loop.id),
+        message: `Loop ${ref(loop.id)} has ${loopStarts.length} loop-start connections — exactly one is allowed.`,
+      })
+    }
+    const children = nodes.filter((n) => n.parentId === loop.id)
+    if (children.length > 0 && loopStarts.length === 0) {
+      issues.push({
+        severity: 'warning',
+        nodeRef: ref(loop.id),
+        message: `Loop ${ref(loop.id)} has body nodes but no loop-start connection — the body will never run.`,
+      })
+    }
+  }
+
+  // Non-loop cycles.
+  const cyclic = cycleMembers(graph)
+  if (cyclic.length > 0) {
+    issues.push({
+      severity: 'error',
+      message: `The graph has a cycle (outside loop containers) through: ${cyclic
+        .map(ref)
+        .join(', ')}. Remove one of the connections.`,
+    })
+  }
+
+  return issues
+}
+
+/**
+ * Tier-2 config validation — `configSchema.safeParse` plus the manifest's own
+ * `validate`, per node, per field. Never blocks: a half-configured node is a
+ * legitimate draft state. Validator warnings map to `warning` severity.
+ */
+export function validateNodeConfigs(graph: DraftGraph): Issue[] {
+  const issues: Issue[] = []
+  for (const node of graph.nodes) {
+    const manifest = getManifest(nodeType(node))
+    if (!manifest) continue
+    const ref = formatNodeRef(graph.nodes, node.id)
+
+    const parsed = manifest.configSchema.safeParse(node.data)
+    if (!parsed.success) {
+      for (const zodIssue of parsed.error.issues) {
+        issues.push({
+          severity: 'warning',
+          nodeRef: ref,
+          field: zodIssue.path.join('.') || undefined,
+          message: zodIssue.message,
+        })
+      }
+    }
+
+    try {
+      const result = manifest.validate(node.data)
+      if (!result.isValid || result.errors.length > 0) {
+        for (const error of result.errors) {
+          issues.push({
+            severity: error.type === 'warning' ? 'warning' : 'error',
+            nodeRef: ref,
+            field: error.field,
+            message: error.message,
+          })
+        }
+      }
+    } catch {
+      // A validator crashing on half-built data must not take the pipeline down.
+    }
+  }
+  return issues
+}
+
+/** Whether an issue list contains anything the pipeline treats as blocking. */
+export function hasBlockingIssues(issues: Issue[]): boolean {
+  return issues.some((issue) => issue.severity === 'error')
+}

--- a/packages/lib/src/workflows/index.ts
+++ b/packages/lib/src/workflows/index.ts
@@ -6,6 +6,7 @@ export {
   type TemplateWorkflowData,
 } from './create-from-template'
 export { normalizeTemplateGraph } from './normalize-template-graph'
+export { type ResolvedTemplate, resolveTemplateById } from './resolve-template'
 export { type SystemWorkflowRun, startSystemWorkflowRun } from './system-workflow-run'
 export type { WorkflowGraph } from './template-graph-transformer'
 export { TemplateGraphTransformer } from './template-graph-transformer'

--- a/packages/lib/src/workflows/resolve-template.ts
+++ b/packages/lib/src/workflows/resolve-template.ts
@@ -1,0 +1,38 @@
+// packages/lib/src/workflows/resolve-template.ts
+
+import { getTemplateById, type WorkflowTemplateDetail } from '@auxx/services/workflow-templates'
+import { normalizeTemplateGraph } from './normalize-template-graph'
+import { getFileTemplateById, isFileTemplateId } from './templates'
+
+/** A resolved template, tagged with its origin so callers can gate edits. */
+export type ResolvedTemplate = WorkflowTemplateDetail & { source: 'file' | 'admin' }
+
+/**
+ * Resolve a workflow template by id from either the bundled file registry or
+ * the database, with AI-node prompts normalized to the editor's
+ * `{ role, json }` shape. Moved from
+ * `apps/web/src/server/api/workflow-template-resolver.ts` (which re-exports
+ * it) so headless callers — graph-edit's `applyTemplate` — share the same
+ * file + admin merge as the create-from-template router path.
+ *
+ * File templates (id prefixed `file:`) are normalized at registry load. DB
+ * rows are normalized here so legacy `{ role, text }` prompts self-heal on
+ * read.
+ *
+ * @param id - File template id (`file:<slug>`) or DB row id.
+ * @returns The resolved template, or null if not found.
+ */
+export async function resolveTemplateById(id: string): Promise<ResolvedTemplate | null> {
+  if (isFileTemplateId(id)) {
+    return getFileTemplateById(id) ?? null
+  }
+
+  const result = await getTemplateById(id)
+  if (result.isErr() || !result.value) return null
+
+  return {
+    ...result.value,
+    graph: normalizeTemplateGraph(result.value.graph),
+    source: 'admin',
+  }
+}

--- a/packages/lib/src/workflows/workflow-version-service.ts
+++ b/packages/lib/src/workflows/workflow-version-service.ts
@@ -90,13 +90,25 @@ function toEngineFormat(dbWorkflow: any): EngineWorkflow {
 }
 
 /**
+ * Run the real publish gate (`WorkflowEngine.validateWorkflowForPublish`)
+ * against a draft `Workflow` row WITHOUT publishing — the seam graph-edit's
+ * `validateWorkflow` wraps so an agent can check publishability. Non-throwing:
+ * returns the engine's verdict verbatim.
+ */
+export async function validateDraftWorkflowForPublish(
+  draftWorkflow: any
+): Promise<{ valid: boolean; errors: string[]; warnings?: string[] }> {
+  const engine = new WorkflowEngine()
+  await engine.getNodeRegistry().initializeWithDefaults()
+  return await engine.validateWorkflowForPublish(toEngineFormat(draftWorkflow))
+}
+
+/**
  * Validate a draft workflow for publishing. Throws {@link BadRequestError} with
  * the collected validation errors when the workflow is not publishable.
  */
 async function assertDraftIsPublishable(draftWorkflow: any): Promise<void> {
-  const engine = new WorkflowEngine()
-  await engine.getNodeRegistry().initializeWithDefaults()
-  const result = await engine.validateWorkflowForPublish(toEngineFormat(draftWorkflow))
+  const result = await validateDraftWorkflowForPublish(draftWorkflow)
   if (!result.valid) {
     logger.error('Workflow validation failed for publish', {
       workflowId: draftWorkflow?.id,


### PR DESCRIPTION
Phase 3 slice 4 of the workflow graph-edit project (`03-graph-edit-service.md` §1/§5/§6 + the persistence and trigger-re-derivation parts of §7). Builds on the merged foundation PRs #1601 (trigger derivation), #1602 (layout port), #1603 (refs + normalize).

## Operations (`packages/lib/src/workflows/graph-edit/`)

| Op | Behaviour |
|---|---|
| `readDraft` | graph + trigger + friendly node summaries + per-node resolved outputs + current issues |
| `addNode` | friendly config normalized (§3 chain), placed per §4 rules, edge on the branch handle from `manifest.connection.branches` |
| `updateNode` | shallow config merge; `id`/`type` are identity and cannot be changed |
| `deleteNodes` | loop containers take their children with them (canvas parity, see below); optional `reconnect` bridges surviving predecessors → surviving successors on the original handle |
| `connectNodes` / `disconnectNodes` | branch resolved through the manifest — never string-matched; child→own-container connects on `loop-back` with `isLoopBackEdge` |
| `setTrigger` | in-graph triggers only (D11); retypes the existing trigger node IN PLACE (same id, position, outgoing edges) so downstream `{{Trigger.x}}` refs survive |
| `replaceGraph` | **restricted to EMPTY drafts** (owner decision 2026-08-13, no preservation guard); a non-empty draft gets an actionable "edit incrementally" error. Friendly node/edge specs by title; dagre auto-layout, per-container child layout, containers sized to fit |
| `applyTemplate` | wraps the existing create-from-template path (`resolveTemplateById` + `buildTemplateWorkflowData`) — also empty-draft-only; curated templates may carry non-authorable types, so the authorable check is skipped for them |
| `validateWorkflow` | three issue tiers + the REAL publish gate (`WorkflowEngine.validateWorkflowForPublish`, newly exported as `validateDraftWorkflowForPublish`) without publishing |

Everything returned renders refs as `{{Title.path}}` / resource slugs (the foundation's reverse rewriter) — a caller never sees raw node ids or per-org CUIDs.

## Blocking vs non-blocking (§5)

Structural findings **reject before persisting** (`applied: false`, draft untouched): unknown/non-authorable types among the nodes the mutation introduced, edges to missing nodes, invalid source/target handles (checked against `manifest.connection.branches(config)`), >1 trigger, edges INTO a trigger, broken containment, >1 `loop-start`, connection limits, non-loop cycles, and unresolvable `{{refs}}` from the normalizer. Config issues (`configSchema.safeParse` + `manifest.validate`, per field) and reference issues (dangling / non-upstream / collection-shape suggestions via the foundation's ref-check) **persist and come back as `issues`** — a half-built workflow is legitimate, mirroring the canvas.

One deliberate softening of §5's "exactly one trigger": **zero** triggers is a warning, not an error — blocking it would make incremental building impossible (the first `addNode` on an empty draft has no trigger yet). More than one, or an inbound edge into one, is a hard error.

## Loop-delete behaviour — copied from the canvas

`use-node-interactions.ts` `handleDeleteNode` (:407–:492): deleting a loop **recurses into its `parentId`-children and deletes them first, then the container** — it never reparents — and every edge touching a deleted node is removed. `deleteNodes` matches that exactly (recursively, so nested loop bodies go too). Also matched: the canvas's add-inside behaviour (`use-node-addition.ts` :243–:271) — first body node gets the `loop-start` edge; later children get containment + position only.

## Layout on add (§4)

Ported the **pure parts** of web's `utils/node-layout/{collision-detector,position-calculator}.ts` into `graph-edit/place-node.ts` (collision search verbatim; placement reduced to what `addNode` needs): first successor lands one column right of its predecessor, vertically aligned; siblings/branch targets stack downward in the same column; loop children get parent-relative grid positions inside the container (with a container-resize suggestion applied like `createResizedParentNode`). The web files were **not moved** — they also carry lane-shifting/viewport logic the server must not run — so no web shims were needed and web behaviour is unchanged. **Existing nodes never move** on an incremental op (pinned by test).

## Persistence (§7, this slice's share)

One seamed function, `persistDraft` (`persist.ts`): cleans `_`-prefixed derived keys (canvas `cleanNodes`/`cleanEdges` parity — manifest `defaultData` can carry `_targetBranches`), **re-derives `Workflow.triggerType`/`entityDefinitionId` via `deriveTriggerColumns` on every persist** (browser-save parity incl. the `?? null` explicit clear), and writes through the existing `WorkflowService.update` path — so `assertMailTriggerNotPersonal` (also pre-checked in the pipeline so it reports as a structured issue, never swallowed), entity-id canonicalization, #1601's `deriveTriggerLinkColumns`, the `expectedGraphHash` hash-CAS (token from the loaded draft) and cache invalidation all keep happening. `publish`/`enabled`/admin-only fields are never touched. The next slice's Redis turn snapshot + `workflow:draft-updated` realtime event wrap this seam (before/after the write) — called out in the file header.

No permission checks in lib: JSDoc on ops/read/persist states callers must assert `assertEditInstance('workflow', …)` + `assertWorkflowAppNotSystemOwned`.

## Ride-alongs

- `resolveTemplateById` moved from `apps/web/src/server/api/workflow-template-resolver.ts` to lib (`workflows/resolve-template.ts`) so `applyTemplate` shares the file+admin template merge; the web file is a re-export shim (zero behaviour change; router tests that mock the module still pass).
- `workflow-version-service.ts`: publish-gate internals exposed as `validateDraftWorkflowForPublish` (non-throwing); `assertDraftIsPublishable` now calls it.
- `layout.ts` `LayoutNode.width/height` widened to `number | null` (persisted React Flow nodes carry null); math unchanged (`||` fallbacks).
- Prose config keys (`title`/`desc`/`description`) are withheld from the bare-ref rewriter — renaming a node to another node's exact title must stay a NAME, not become a node-id ref (pinned by test).

## Tests (23 new, `graph-edit/__tests__/ops.test.ts`)

Branch wiring through manifest branches (name → handle id, ELSE → `false`, ambiguity error), loop containment (add-inside, loop-back connect, canvas-parity loop delete), reconnect bridging, §4 layout stability (byte-identical positions), replaceGraph/applyTemplate empty-draft rejection, structural-vs-config-vs-normalize blocking split incl. the mail-guard issue, **setTrigger re-derives `Workflow.triggerType`/`entityDefinitionId` through the persist seam** (asserted on the `WorkflowService.update` input), readDraft summary shape with friendly-rendered refs.

## Verification

- `node scripts/ci/typecheck-ratchet.js --package lib` — no new errors (baseline 29)
- `node scripts/ci/typecheck-ratchet.js --package web` — no new errors (baseline 1)
- `packages/lib`: `vitest run src/workflows src/workflow-engine` — 1343 passed
- `apps/web`: `vitest run src/components/workflow` — 101 passed; the three router tests mocking the resolver shim — 131 passed
- biome clean on all touched files