### PR TITLE
feat(workflow): variable chip editing with explorer and array access menu

### DIFF
--- a/apps/web/src/components/editor/extensions/variable-node-view.tsx
+++ b/apps/web/src/components/editor/extensions/variable-node-view.tsx
@@ -5,16 +5,22 @@ import type { NodeViewProps } from '@tiptap/react'
 import { NodeViewWrapper } from '@tiptap/react'
 import type React from 'react'
 import { useCallback } from 'react'
+import type { AllowedVarType } from '~/components/workflow/types'
+import { VariablePicker } from '~/components/workflow/ui/variables/variable-picker'
 import VariableTag from '~/components/workflow/ui/variables/variable-tag'
-import {
-  VariableTagContextMenu,
-  VariableTagDropdown,
-} from '~/components/workflow/ui/variables/variable-tag-context-menu'
+import { VariableTagContextMenu } from '~/components/workflow/ui/variables/variable-tag-context-menu'
 
 /**
- * React component for rendering variable nodes in TipTap editor
- * Fetches variable data from the UnifiedVariable store using the ID
- * Supports click selection and right-click context menu for array accessor editing
+ * React component for rendering variable nodes in TipTap editor.
+ *
+ * Gesture split, matching the picker-mode chip in `var-editor.tsx`:
+ * - **left-click** → the variable explorer, pre-navigated to this variable's own
+ *   path, so a chip can be re-pointed without deleting and retyping `{`
+ * - **right-click** → array access for every array in the path
+ *
+ * The node's field type contract arrives through `editor.storage.expectedTypes`
+ * — a NodeView only receives `node`/`getPos`/`editor`/`selected`, so editor
+ * storage is the only channel (same one `nodeId` already uses).
  */
 const VariableNodeView: React.FC<NodeViewProps> = ({ node, getPos, editor, selected }) => {
   const { variableId } = node.attrs
@@ -33,7 +39,12 @@ const VariableNodeView: React.FC<NodeViewProps> = ({ node, getPos, editor, selec
     [getPos, editor]
   )
 
-  // Handle variable ID change from context menu (e.g., array accessor update)
+  // Handle variable ID change from the context menu (array accessor) or the
+  // explorer (a different variable entirely).
+  //
+  // `setNodeMarkup` keeps the node type, so ProseMirror reuses the node view and
+  // React re-renders this component in place rather than remounting it — which
+  // is what lets the context menu stay open across several accessor edits.
   const handleVariableIdChange = useCallback(
     (newId: string) => {
       if (getPos && editor) {
@@ -46,6 +57,8 @@ const VariableNodeView: React.FC<NodeViewProps> = ({ node, getPos, editor, selec
     [getPos, editor, node.attrs]
   )
 
+  const allowedTypes = (editor.storage.expectedTypes ?? []) as AllowedVarType[]
+
   return (
     <NodeViewWrapper
       as='span'
@@ -56,17 +69,28 @@ const VariableNodeView: React.FC<NodeViewProps> = ({ node, getPos, editor, selec
       tabIndex={0}
       role='button'
       aria-selected={selected}>
-      <VariableTagDropdown variableId={variableId} onVariableIdChange={handleVariableIdChange}>
-        <VariableTagContextMenu variableId={variableId} onVariableIdChange={handleVariableIdChange}>
-          <VariableTag
+      <VariablePicker
+        nodeId={editor.storage.nodeId}
+        value={variableId}
+        allowedTypes={allowedTypes}
+        onVariableSelect={(variable) => handleVariableIdChange(variable.id)}>
+        {/* A stable element for `PopoverTrigger asChild` — the context menu
+            renders a bare fragment when the path holds no arrays, and cloning
+            props onto a fragment would drop the trigger's handlers. */}
+        <span className='inline-flex'>
+          <VariableTagContextMenu
             variableId={variableId}
-            nodeId={editor.storage.nodeId}
-            isShort
-            selected={selected}
-            onVariableIdChange={handleVariableIdChange}
-          />
-        </VariableTagContextMenu>
-      </VariableTagDropdown>
+            onVariableIdChange={handleVariableIdChange}>
+            <VariableTag
+              variableId={variableId}
+              nodeId={editor.storage.nodeId}
+              isShort
+              selected={selected}
+              onVariableIdChange={handleVariableIdChange}
+            />
+          </VariableTagContextMenu>
+        </span>
+      </VariablePicker>
     </NodeViewWrapper>
   )
 }

--- a/apps/web/src/components/workflow/ui/input-editor/hooks/use-workflow-variable-editor.tsx
+++ b/apps/web/src/components/workflow/ui/input-editor/hooks/use-workflow-variable-editor.tsx
@@ -352,12 +352,21 @@ export function useWorkflowVariableEditor({
     },
   })
 
-  // Store nodeId in editor storage for variable-node access
+  // Store nodeId + the field's type contract in editor storage. A NodeView only
+  // receives `node`/`getPos`/`editor`/`selected`, so this is the only channel by
+  // which the variable chip can learn what types its field accepts.
+  //
+  // Keyed on the joined types rather than the array identity — callers build
+  // `expectedTypes` inline, so a reference dep would re-fire every render.
+  const expectedTypesKey = expectedTypes.join('|')
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on expectedTypesKey, not the unstable array
   useEffect(() => {
     if (editor && nodeId !== undefined) {
       editor.storage.nodeId = nodeId
+      editor.storage.expectedTypes = expectedTypes
     }
-  }, [editor, nodeId])
+  }, [editor, nodeId, expectedTypesKey])
 
   // Insert a variable at trigger position
   const insertVariable = useCallback(

--- a/apps/web/src/components/workflow/ui/input-editor/var-editor.tsx
+++ b/apps/web/src/components/workflow/ui/input-editor/var-editor.tsx
@@ -11,10 +11,7 @@ import { InlinePickerPopover } from '~/components/editor/inline-picker'
 import { Tooltip } from '~/components/global/tooltip'
 import { type UnifiedVariable, VAR_MODE } from '~/components/workflow/types'
 import { VariablePicker } from '~/components/workflow/ui/variables/variable-picker'
-import {
-  VariableTagContextMenu,
-  VariableTagDropdown,
-} from '~/components/workflow/ui/variables/variable-tag-context-menu'
+import { VariableTagContextMenu } from '~/components/workflow/ui/variables/variable-tag-context-menu'
 import { containsVariableReference } from '~/components/workflow/utils/variable-utils'
 import { VariableExplorerEnhanced } from '../variables/variable-explorer-enhanced'
 import VariableTag from '../variables/variable-tag'
@@ -182,11 +179,17 @@ const VarEditor: React.FC<VarEditorProps> = React.memo(
       }
     }, [value])
 
+    // `finalAllowedTypes` is rebuilt on every render, so key the effect on its
+    // contents — not the array identity — or it re-fires continuously.
+    const allowedTypesKey = finalAllowedTypes.join('|')
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on allowedTypesKey, not the unstable array
     useEffect(() => {
       if (editor && nodeId !== undefined) {
         editor.storage.nodeId = nodeId
+        editor.storage.expectedTypes = finalAllowedTypes
       }
-    }, [editor, nodeId])
+    }, [editor, nodeId, allowedTypesKey])
 
     // Handle component unmount - flush any pending changes
     React.useEffect(() => {
@@ -266,20 +269,16 @@ const VarEditor: React.FC<VarEditorProps> = React.memo(
             popoverHeight={500}>
             <div className='w-full h-8 flex items-center'>
               {textValue ? (
-                <VariableTagDropdown
+                <VariableTagContextMenu
                   variableId={textValue}
                   onVariableIdChange={handleVariableIdChange}>
-                  <VariableTagContextMenu
+                  <VariableTag
                     variableId={textValue}
-                    onVariableIdChange={handleVariableIdChange}>
-                    <VariableTag
-                      variableId={textValue}
-                      nodeId={nodeId}
-                      isShort
-                      onVariableIdChange={handleVariableIdChange}
-                    />
-                  </VariableTagContextMenu>
-                </VariableTagDropdown>
+                    nodeId={nodeId}
+                    isShort
+                    onVariableIdChange={handleVariableIdChange}
+                  />
+                </VariableTagContextMenu>
               ) : (
                 <span className='text-sm text-primary-400 truncate pointer-events-none'>
                   {placeholder}

--- a/apps/web/src/components/workflow/ui/variables/use-variable-array-segments.ts
+++ b/apps/web/src/components/workflow/ui/variables/use-variable-array-segments.ts
@@ -1,0 +1,105 @@
+// apps/web/src/components/workflow/ui/variables/use-variable-array-segments.ts
+
+'use client'
+
+import { BaseType, type UnifiedVariable } from '@auxx/lib/workflow-engine/client'
+import { useMemo } from 'react'
+import { useVarStore } from '~/components/workflow/store/use-var-store'
+
+/** Matches ONE trailing `[<int>|*]` bracket on a single dot-segment. */
+const SEGMENT_BRACKET_RE = /^(.*)\[(-?\d+|\*)\]$/
+
+/** One array in a variable's path whose access the user can change. */
+export interface VariableArraySegment {
+  /** The variable id up to and including this segment's key, bracket excluded. */
+  basePath: string
+  /** The raw path key — frequently a CUID, never render this. */
+  key: string
+  /** Display label resolved from the variable store, falling back to {@link key}. */
+  label: string
+  /** Current accessor, or `null` when the segment carries no bracket (the array itself). */
+  accessor: string | null
+  /** Zero-based position among this id's array segments, in path order. */
+  ordinal: number
+  /** Whether this is the last segment of the path. */
+  isTerminal: boolean
+}
+
+/**
+ * Collect the array segments of a variable id that the user can re-access.
+ *
+ * Deliberately store-aware rather than a regex over the id, for two reasons:
+ *
+ * 1. **Bare arrays are invisible to a regex.** A terminal segment can be
+ *    `ARRAY`-typed with no bracket — `find_1.<cuid>` feeding a List node's
+ *    Input List — and that is exactly the chip a user wants to switch to
+ *    "first item". Only the resolved variable's `type` reveals it.
+ * 2. **Raw keys are not display names.** A findMany output is keyed on
+ *    `resource.id`, so the key is a CUID (`find_1.mzxt3cxyzhm3cbtgcbpmeir1`)
+ *    while the variable's `label` is `Vendors`. Resolving `basePath` through the
+ *    store is what `buildVariableLabelPath` already does for the chip itself.
+ *
+ * Consequence worth knowing: because eligibility is type-based and not
+ * bracket-based, stripping a bracket (choosing "the whole list") keeps the
+ * segment in this list. A bracket-based test would return an empty list and
+ * unmount the menu mid-interaction.
+ */
+export function useVariableArraySegments(variableId: string): VariableArraySegment[] {
+  const variableIndex = useVarStore((state) => state.variableIndex)
+
+  return useMemo(() => {
+    if (!variableId) return []
+
+    // Mirrors `getVariableById`: the store only ever indexes the `[*]` form, so
+    // an id carrying a numeric accessor has to be normalised before lookup.
+    const resolve = (id: string): UnifiedVariable | undefined =>
+      variableIndex.get(id) ?? variableIndex.get(id.replace(/\[-?\d+\]/g, '[*]'))
+
+    const parts = variableId.split('.')
+    const segments: VariableArraySegment[] = []
+
+    // Start at 1 — the first segment is the node/`env`/`sys` prefix, never an array.
+    for (let i = 1; i < parts.length; i++) {
+      const raw = parts[i]
+      if (raw === undefined) continue
+
+      const bracket = raw.match(SEGMENT_BRACKET_RE)
+      const key = bracket ? bracket[1]! : raw
+      const accessor = bracket ? bracket[2]! : null
+      const basePath = [...parts.slice(0, i), key].join('.')
+
+      const variable = resolve(basePath)
+      // A bracket proves it is an array. Without one, only the store can say.
+      if (!bracket && variable?.type !== BaseType.ARRAY) continue
+
+      segments.push({
+        basePath,
+        key,
+        label: variable?.label || key,
+        accessor,
+        ordinal: segments.length,
+        isTerminal: i === parts.length - 1,
+      })
+    }
+
+    return segments
+  }, [variableId, variableIndex])
+}
+
+/** Human-readable label for an accessor, including the bracket-less array itself. */
+export function getAccessorLabel(accessor: string | null): string {
+  if (accessor === null) return 'The whole list'
+  if (accessor === '*') return 'All items'
+  const index = Number.parseInt(accessor, 10)
+  if (index === 0) return 'First item'
+  if (index === -1) return 'Last item'
+  if (index < -1) return `${ordinalLabel(Math.abs(index))} to last`
+  return `${ordinalLabel(index + 1)} item`
+}
+
+/** Ordinal suffix for a number (1st, 2nd, 3rd, …). */
+function ordinalLabel(n: number): string {
+  const suffixes = ['th', 'st', 'nd', 'rd']
+  const v = n % 100
+  return `${n}${suffixes[(v - 20) % 10] || suffixes[v] || suffixes[0]}`
+}

--- a/apps/web/src/components/workflow/ui/variables/variable-explorer-enhanced.tsx
+++ b/apps/web/src/components/workflow/ui/variables/variable-explorer-enhanced.tsx
@@ -17,7 +17,7 @@ import { Kbd } from '@auxx/ui/components/kbd'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
 import { useStore } from '@xyflow/react'
-import { ChevronLeft, ChevronRight, Copy, Search } from 'lucide-react'
+import { Check, ChevronLeft, ChevronRight, Copy, Search } from 'lucide-react'
 import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { TooltipExplanation } from '~/components/global/tooltip'
@@ -358,10 +358,27 @@ export const VariableExplorerEnhanced: React.FC<VariableExplorerEnhancedProps> =
   // Build navigation stack from variable ID path
   const buildNavigationStack = useCallback(
     (variableId: string, allVariables: UnifiedVariable[]): NavigationItem[] => {
-      const pathParts = variableId.split('.')
+      // The store only ever indexes the `[*]` form. A chip carrying `[0]`/`[-1]`
+      // — which is exactly the array case worth drilling into — would miss every
+      // intermediate lookup below and silently land back at root.
+      const pathParts = variableId.replace(/\[-?\d+\]/g, '[*]').split('.')
       const stack: NavigationItem[] = []
 
-      for (let i = 0; i < pathParts.length - 1; i++) {
+      // The first segment is the node id, but groups are keyed `node-<nodeId>`
+      // and variable ids never equal a bare node id, so looking it up in
+      // `allVariables` always missed: the breadcrumb started mid-path and one
+      // "back" jumped past the node straight to root.
+      const rootGroup = groups.find((g) => g.id === `node-${pathParts[0]}`)
+      if (rootGroup) {
+        stack.push({
+          id: rootGroup.id,
+          label: rootGroup.name,
+          type: 'group',
+          icon: rootGroup.icon,
+        })
+      }
+
+      for (let i = 1; i < pathParts.length - 1; i++) {
         const currentId = pathParts.slice(0, i + 1).join('.')
         const variable = allVariables.find((v) => v.id === currentId)
 
@@ -376,7 +393,14 @@ export const VariableExplorerEnhanced: React.FC<VariableExplorerEnhancedProps> =
 
       return stack
     },
-    []
+    [groups]
+  )
+
+  // Current value marker. Normalised so a chip on `[0]` still matches the `[*]`
+  // id the explorer lists.
+  const normalizedSelected = useMemo(
+    () => selected?.replace(/\[-?\d+\]/g, '[*]') ?? null,
+    [selected]
   )
 
   /**
@@ -617,7 +641,7 @@ export const VariableExplorerEnhanced: React.FC<VariableExplorerEnhancedProps> =
                     navigateInto(item)
                   }}
                   onCopy={copyVariable}
-                  isSelected={selectedVariables.includes(item.id)}
+                  isSelected={normalizedSelected === item.id || selectedVariables.includes(item.id)}
                   isHighlighted={selectedItemId === item.id}
                   showPath={!!search}
                   labelPath={
@@ -731,6 +755,11 @@ const VariableCommandItem: React.FC<VariableCommandItemProps> = ({
             )}>
             {isGroup ? (item as VariableGroup).name : (item as UnifiedVariable).label}
           </code>
+
+          {/* Current value marker — this is the variable the chip already points at. */}
+          {isSelected && !isGroup && (
+            <Check className='size-3.5 shrink-0 text-info' strokeWidth={3} />
+          )}
 
           {/* Show label path in search mode */}
           {showPath && labelPath && (

--- a/apps/web/src/components/workflow/ui/variables/variable-tag-context-menu.tsx
+++ b/apps/web/src/components/workflow/ui/variables/variable-tag-context-menu.tsx
@@ -2,59 +2,61 @@
 
 'use client'
 
+import { setSegmentAccessor } from '@auxx/lib/workflow-engine/client'
 import {
   ContextMenu,
-  ContextMenuCheckboxItem,
   ContextMenuContent,
+  ContextMenuItem,
   ContextMenuLabel,
-  ContextMenuSeparator,
   ContextMenuTrigger,
 } from '@auxx/ui/components/context-menu'
 import { Input } from '@auxx/ui/components/input'
-import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
-import { Check } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { Check, ChevronDown, ChevronRight } from 'lucide-react'
+import { Fragment, useState } from 'react'
 import {
-  type ArraySegmentInfo,
-  getArrayAccessorMenuLabel,
-  parseArraySegmentsFromId,
-  replaceArrayAccessor,
-} from '~/components/workflow/utils/variable-utils'
+  getAccessorLabel,
+  useVariableArraySegments,
+  type VariableArraySegment,
+} from './use-variable-array-segments'
 
-/** Standard accessor options shown in the menu */
-const STANDARD_ACCESSORS = [
-  { value: '*', label: 'All items' },
-  { value: '0', label: 'First item' },
-  { value: '-1', label: 'Last item' },
-] as const
+/**
+ * Accessor options offered for a segment.
+ *
+ * `null` (the array itself) is offered **only on a terminal segment** —
+ * stripping a bracket mid-path leaves `orders.sku`, i.e. dotting into an array.
+ *
+ * A terminal segment deliberately does NOT offer `[*]`. At the end of a path a
+ * wildcard returns the array unmapped (`ExecutionContextManager.walkProjection`
+ * returns `items` when nothing follows), so `X` and `X[*]` are the same value —
+ * but `X` is declared `ARRAY` while `X[*]` is the item's shape, and the item
+ * shape is the wrong answer for every array-accepting input. Offering both
+ * would be two identical-looking options where one silently mistypes.
+ */
+function accessorOptions(segment: VariableArraySegment): (string | null)[] {
+  return segment.isTerminal ? [null, '0', '-1'] : ['*', '0', '-1']
+}
 
-// ---------------------------------------------------------------------------
-// Shared props
-// ---------------------------------------------------------------------------
-
-type ArrayAccessorMenuProps = {
+type VariableTagContextMenuProps = {
   variableId: string
   onVariableIdChange?: (newId: string) => void
   children: React.ReactNode
 }
 
-// ---------------------------------------------------------------------------
-// Right-click context menu variant
-// ---------------------------------------------------------------------------
-
 /**
- * Context menu wrapper for variable tags that contain array segments.
- * Right-click shows accessor options per array segment in the variable path.
+ * Right-click menu for changing how each array in a variable's path is accessed.
+ *
+ * Renders nothing when the path has no arrays — the chip falls through to the
+ * browser's own menu rather than showing an empty or disabled panel.
  */
 export function VariableTagContextMenu({
   variableId,
   onVariableIdChange,
   children,
-}: ArrayAccessorMenuProps) {
-  const arraySegments = useMemo(() => parseArraySegmentsFromId(variableId), [variableId])
+}: VariableTagContextMenuProps) {
+  const segments = useVariableArraySegments(variableId)
 
-  if (arraySegments.length === 0 || !onVariableIdChange) {
+  if (segments.length === 0 || !onVariableIdChange) {
     return <>{children}</>
   }
 
@@ -63,80 +65,146 @@ export function VariableTagContextMenu({
       <ContextMenuTrigger asChild>
         <span className='inline-flex'>{children}</span>
       </ContextMenuTrigger>
-      <ContextMenuContent className='w-56'>
-        <div onClick={(e) => e.stopPropagation()}>
-          {arraySegments.map((seg, i) => (
-            <ContextMenuSegmentSection
-              key={`${seg.path}-${i}`}
-              segment={seg}
-              variableId={variableId}
-              onVariableIdChange={onVariableIdChange}
-              showSeparator={i < arraySegments.length - 1}
-            />
-          ))}
-        </div>
+      <ContextMenuContent
+        className='w-64'
+        // Radix portals this content to `document.body`, but React synthetic
+        // events propagate along the REACT tree — where it is still a descendant
+        // of whatever wraps the chip. Every consumer wraps the chip in a
+        // `PopoverTrigger` (the variable explorer), so without this, clicking any
+        // row in here bubbles out and toggles that popover open on top of us.
+        onClick={(e) => e.stopPropagation()}>
+        <ArrayAccessPanel
+          segments={segments}
+          variableId={variableId}
+          onVariableIdChange={onVariableIdChange}
+        />
       </ContextMenuContent>
     </ContextMenu>
   )
 }
 
-/** Context menu section for a single array segment */
-function ContextMenuSegmentSection({
+/**
+ * Inline accordion over the path's arrays.
+ *
+ * Every array is listed by name with its current selection; clicking one expands
+ * its options in place below it, one at a time. A single array is always
+ * expanded, so the common case stays one click deep.
+ *
+ * The menu deliberately stays open across selections — with several arrays in a
+ * path you routinely set two accessors in one visit. That is what every
+ * `onSelect`'s `preventDefault` buys.
+ */
+function ArrayAccessPanel({
+  segments,
+  variableId,
+  onVariableIdChange,
+}: {
+  segments: VariableArraySegment[]
+  variableId: string
+  onVariableIdChange: (newId: string) => void
+}) {
+  const isSingle = segments.length === 1
+  // Keyed on `ordinal`, never `basePath`: editing one accessor rewrites the ids
+  // of every segment after it, so a basePath key would collapse or jump the
+  // accordion on each selection.
+  const [expandedOrdinal, setExpandedOrdinal] = useState<number | null>(0)
+
+  return (
+    <>
+      <ContextMenuLabel className='text-xs text-muted-foreground'>Array access</ContextMenuLabel>
+
+      {segments.map((segment) => {
+        const isExpanded = isSingle || expandedOrdinal === segment.ordinal
+
+        return (
+          <Fragment key={segment.ordinal}>
+            {isSingle ? (
+              <ContextMenuLabel className='flex items-center justify-between gap-2 font-medium'>
+                <span className='truncate'>{segment.label}</span>
+                <span className='shrink-0 text-xs text-muted-foreground'>
+                  {getAccessorLabel(segment.accessor)}
+                </span>
+              </ContextMenuLabel>
+            ) : (
+              <ContextMenuItem
+                onSelect={(e) => {
+                  e.preventDefault()
+                  setExpandedOrdinal(isExpanded ? null : segment.ordinal)
+                }}>
+                <div className='flex w-full items-center gap-2'>
+                  {isExpanded ? (
+                    <ChevronDown className='size-3.5 shrink-0 opacity-60' />
+                  ) : (
+                    <ChevronRight className='size-3.5 shrink-0 opacity-60' />
+                  )}
+                  <span className='truncate font-medium'>{segment.label}</span>
+                  <span className='ml-auto shrink-0 text-xs text-muted-foreground'>
+                    {getAccessorLabel(segment.accessor)}
+                  </span>
+                </div>
+              </ContextMenuItem>
+            )}
+
+            {isExpanded && (
+              <SegmentOptions
+                segment={segment}
+                variableId={variableId}
+                onVariableIdChange={onVariableIdChange}
+                indented={!isSingle}
+              />
+            )}
+          </Fragment>
+        )
+      })}
+    </>
+  )
+}
+
+/** The expanded option list for one array segment. */
+function SegmentOptions({
   segment,
   variableId,
   onVariableIdChange,
-  showSeparator,
+  indented,
 }: {
-  segment: ArraySegmentInfo
+  segment: VariableArraySegment
   variableId: string
   onVariableIdChange: (newId: string) => void
-  showSeparator: boolean
+  indented: boolean
 }) {
   const [showCustomIndex, setShowCustomIndex] = useState(false)
   const [customIndex, setCustomIndex] = useState('')
 
-  const isCustomAccessor =
-    segment.accessor !== '*' && segment.accessor !== '0' && segment.accessor !== '-1'
+  const options = accessorOptions(segment)
+  const isCustom = segment.accessor !== null && !options.includes(segment.accessor)
 
-  const handleSelect = (newAccessor: string) => {
+  const select = (accessor: string | null) => {
     setShowCustomIndex(false)
     setCustomIndex('')
-    const newId = replaceArrayAccessor(variableId, segment.path, newAccessor)
-    onVariableIdChange(newId)
+    onVariableIdChange(setSegmentAccessor(variableId, segment.basePath, accessor))
   }
 
-  const handleCustomSubmit = () => {
+  const submitCustom = () => {
     const parsed = Number.parseInt(customIndex, 10)
-    if (!Number.isNaN(parsed)) {
-      handleSelect(String(parsed))
-    }
+    if (!Number.isNaN(parsed)) select(String(parsed))
   }
 
   return (
-    <>
-      <ContextMenuLabel className='text-xs text-muted-foreground'>
-        "{segment.label}" access
-      </ContextMenuLabel>
-
-      {STANDARD_ACCESSORS.map((opt) => (
-        <ContextMenuCheckboxItem
-          key={opt.value}
-          multi={false}
-          checked={segment.accessor === opt.value}
-          onSelect={(e) => {
-            e.preventDefault()
-            handleSelect(opt.value)
-          }}>
-          {opt.label}
-          <span className='ml-auto text-xs text-muted-foreground'>[{opt.value}]</span>
-        </ContextMenuCheckboxItem>
+    <div className={cn(indented && 'ml-3 border-l pl-1')}>
+      {options.map((accessor) => (
+        <OptionRow
+          key={accessor ?? 'bare'}
+          checked={segment.accessor === accessor}
+          onSelect={() => select(accessor)}
+          hint={accessor === null ? undefined : `[${accessor}]`}>
+          {getAccessorLabel(accessor)}
+        </OptionRow>
       ))}
 
-      {isCustomAccessor && (
-        <ContextMenuCheckboxItem multi={false} checked>
-          {getArrayAccessorMenuLabel(segment.accessor)}
-          <span className='ml-auto text-xs text-muted-foreground'>[{segment.accessor}]</span>
-        </ContextMenuCheckboxItem>
+      {isCustom && (
+        <OptionRow checked hint={`[${segment.accessor}]`}>
+          {getAccessorLabel(segment.accessor)}
+        </OptionRow>
       )}
 
       {showCustomIndex ? (
@@ -149,8 +217,9 @@ function ContextMenuSegmentSection({
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 e.preventDefault()
-                handleCustomSubmit()
+                submitCustom()
               }
+              // The menu's typeahead would otherwise swallow the digits.
               e.stopPropagation()
             }}
             className='h-7 text-xs'
@@ -158,179 +227,48 @@ function ContextMenuSegmentSection({
           />
         </div>
       ) : (
-        <ContextMenuCheckboxItem
-          multi={false}
-          checked={false}
-          onSelect={(e) => {
-            e.preventDefault()
-            setShowCustomIndex(true)
-          }}>
+        <OptionRow checked={false} onSelect={() => setShowCustomIndex(true)}>
           Specific index...
-        </ContextMenuCheckboxItem>
+        </OptionRow>
       )}
-
-      {showSeparator && <ContextMenuSeparator />}
-    </>
+    </div>
   )
 }
-
-// ---------------------------------------------------------------------------
-// Left-click dropdown variant
-// ---------------------------------------------------------------------------
 
 /**
- * Dropdown (popover) wrapper for variable tags that contain array segments.
- * Left-click shows accessor options per array segment in the variable path.
+ * One selectable accessor. `preventDefault` is what keeps the menu open after a
+ * selection — without it Radix dismisses on every activation.
  */
-export function VariableTagDropdown({
-  variableId,
-  onVariableIdChange,
-  children,
-}: ArrayAccessorMenuProps) {
-  const [open, setOpen] = useState(false)
-  const arraySegments = useMemo(() => parseArraySegmentsFromId(variableId), [variableId])
-
-  if (arraySegments.length === 0 || !onVariableIdChange) {
-    return <>{children}</>
-  }
-
-  const handleChange = (newId: string) => {
-    onVariableIdChange(newId)
-    setOpen(false)
-  }
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <span className='inline-flex cursor-pointer'>{children}</span>
-      </PopoverTrigger>
-      <PopoverContent
-        side='bottom'
-        align='start'
-        className='w-56 p-1'
-        onOpenAutoFocus={(e) => e.preventDefault()}>
-        {arraySegments.map((seg, i) => (
-          <DropdownSegmentSection
-            key={`${seg.path}-${i}`}
-            segment={seg}
-            variableId={variableId}
-            onVariableIdChange={handleChange}
-            showSeparator={i < arraySegments.length - 1}
-          />
-        ))}
-      </PopoverContent>
-    </Popover>
-  )
-}
-
-/** Dropdown section for a single array segment */
-function DropdownSegmentSection({
-  segment,
-  variableId,
-  onVariableIdChange,
-  showSeparator,
-}: {
-  segment: ArraySegmentInfo
-  variableId: string
-  onVariableIdChange: (newId: string) => void
-  showSeparator: boolean
-}) {
-  const [showCustomIndex, setShowCustomIndex] = useState(false)
-  const [customIndex, setCustomIndex] = useState('')
-
-  const isCustomAccessor =
-    segment.accessor !== '*' && segment.accessor !== '0' && segment.accessor !== '-1'
-
-  const handleSelect = (newAccessor: string) => {
-    setShowCustomIndex(false)
-    setCustomIndex('')
-    const newId = replaceArrayAccessor(variableId, segment.path, newAccessor)
-    onVariableIdChange(newId)
-  }
-
-  const handleCustomSubmit = () => {
-    const parsed = Number.parseInt(customIndex, 10)
-    if (!Number.isNaN(parsed)) {
-      handleSelect(String(parsed))
-    }
-  }
-
-  return (
-    <>
-      <div className='px-2 py-1.5 text-xs font-semibold text-muted-foreground'>
-        "{segment.label}" access
-      </div>
-
-      {STANDARD_ACCESSORS.map((opt) => (
-        <DropdownCheckItem
-          key={opt.value}
-          checked={segment.accessor === opt.value}
-          onSelect={() => handleSelect(opt.value)}>
-          {opt.label}
-          <span className='ml-auto text-xs text-muted-foreground'>[{opt.value}]</span>
-        </DropdownCheckItem>
-      ))}
-
-      {isCustomAccessor && (
-        <DropdownCheckItem checked>
-          {getArrayAccessorMenuLabel(segment.accessor)}
-          <span className='ml-auto text-xs text-muted-foreground'>[{segment.accessor}]</span>
-        </DropdownCheckItem>
-      )}
-
-      {showCustomIndex ? (
-        <div className='px-2 py-1.5'>
-          <Input
-            type='number'
-            placeholder='Enter index...'
-            value={customIndex}
-            onChange={(e) => setCustomIndex(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault()
-                handleCustomSubmit()
-              }
-              e.stopPropagation()
-            }}
-            className='h-7 text-xs'
-            autoFocus
-          />
-        </div>
-      ) : (
-        <DropdownCheckItem checked={false} onSelect={() => setShowCustomIndex(true)}>
-          Specific index...
-        </DropdownCheckItem>
-      )}
-
-      {showSeparator && <div className='-mx-1 my-1 h-px bg-border' />}
-    </>
-  )
-}
-
-/** Simple check item for the dropdown variant — mirrors ContextMenuCheckboxItem with multi=false */
-function DropdownCheckItem({
+function OptionRow({
   checked,
   onSelect,
+  hint,
   children,
 }: {
   checked?: boolean
   onSelect?: () => void
+  hint?: string
   children: React.ReactNode
 }) {
   return (
-    <button
-      type='button'
-      className={cn(
-        'relative flex w-full cursor-default select-none items-center justify-between rounded-full px-2 py-1 text-sm outline-hidden transition-colors',
-        'hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground'
-      )}
-      onClick={onSelect}>
-      <div className='flex items-center gap-2'>{children}</div>
-      {checked && (
-        <div className='flex size-4 items-center justify-center rounded-full border border-blue-800 bg-info'>
-          <Check className='size-2.5! text-white' strokeWidth={4} />
-        </div>
-      )}
-    </button>
+    <ContextMenuItem
+      onSelect={(e) => {
+        e.preventDefault()
+        onSelect?.()
+      }}>
+      <div className='flex w-full items-center gap-2'>
+        <span className='truncate'>{children}</span>
+        {hint && <span className='ml-auto text-xs text-muted-foreground'>{hint}</span>}
+        {checked && (
+          <div
+            className={cn(
+              'flex size-4 shrink-0 items-center justify-center rounded-full border border-blue-800 bg-info',
+              !hint && 'ml-auto'
+            )}>
+            <Check className='size-2.5! text-white' strokeWidth={4} />
+          </div>
+        )}
+      </div>
+    </ContextMenuItem>
   )
 }

--- a/apps/web/src/components/workflow/utils/variable-utils.ts
+++ b/apps/web/src/components/workflow/utils/variable-utils.ts
@@ -41,8 +41,8 @@ export {
   parseArraySegmentsFromId,
   parseResourceFieldFromVariableId,
   preserveArrayStructure,
-  replaceArrayAccessor,
   resolveFieldPath,
+  setSegmentAccessor,
   VARIABLE_PATTERN,
 } from '@auxx/lib/workflow-engine/client'
 
@@ -340,6 +340,15 @@ export function hasCompatibleChildPath(
         return true
       }
     }
+  }
+
+  // Arrays hold their child shape under `items`, not `properties`. Without this
+  // branch an array-of-objects is reported as having no compatible descendant,
+  // so a typed field renders it non-selectable AND non-navigable — you could
+  // never drill into `find_1.<cuid>` to reach `[*].email` on a STRING field.
+  // `isNavigableVariable` has always honoured `items`; this keeps the two in step.
+  if (variable.items) {
+    return hasCompatibleChildPath(variable.items, allowedTypes)
   }
 
   return false

--- a/packages/lib/src/workflow-engine/catalog/variable-inference.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/variable-inference.test.ts
@@ -1,7 +1,11 @@
 // packages/lib/src/workflow-engine/catalog/variable-inference.test.ts
 
 import { describe, expect, it } from 'vitest'
-import { parseVariablePath } from './variable-inference'
+import {
+  parseArraySegmentsFromId,
+  parseVariablePath,
+  setSegmentAccessor,
+} from './variable-inference'
 
 /**
  * Unit tests for the segment-walk resolver's parser (see
@@ -93,5 +97,87 @@ describe('parseVariablePath', () => {
       { key: 'items', index: 0 },
       { key: 'name' },
     ])
+  })
+})
+
+describe('parseArraySegmentsFromId', () => {
+  it('reports basePath and ordinal for each bracketed segment', () => {
+    expect(parseArraySegmentsFromId('nodeId.message.to[*].items[0].name')).toEqual([
+      {
+        path: 'to',
+        accessor: '*',
+        fullSegment: 'to[*]',
+        label: 'to',
+        basePath: 'nodeId.message.to',
+        ordinal: 0,
+      },
+      {
+        path: 'items',
+        accessor: '0',
+        fullSegment: 'items[0]',
+        label: 'items',
+        basePath: 'nodeId.message.to[*].items',
+        ordinal: 1,
+      },
+    ])
+  })
+
+  it('distinguishes two same-named arrays by basePath', () => {
+    const [first, second] = parseArraySegmentsFromId('n.items[*].items[0]')
+
+    expect(first?.path).toBe('items')
+    expect(second?.path).toBe('items')
+    // The bare key is ambiguous; the basePath is not. This is what makes
+    // `setSegmentAccessor` able to address the second one.
+    expect(first?.basePath).toBe('n.items')
+    expect(second?.basePath).toBe('n.items[*].items')
+  })
+
+  it('finds nothing in a bare array path (needs the store — see useVariableArraySegments)', () => {
+    expect(parseArraySegmentsFromId('find_1.mzxt3cxyzhm3cbtgcbpmeir1')).toEqual([])
+  })
+
+  it('handles a multi-word key', () => {
+    const [segment] = parseArraySegmentsFromId('find_1.knowledge bases[*].title')
+    expect(segment?.path).toBe('knowledge bases')
+    expect(segment?.basePath).toBe('find_1.knowledge bases')
+  })
+})
+
+describe('setSegmentAccessor', () => {
+  it('swaps an existing accessor', () => {
+    expect(setSegmentAccessor('nodeId.msg.to[*].name', 'nodeId.msg.to', '0')).toBe(
+      'nodeId.msg.to[0].name'
+    )
+  })
+
+  it('adds a bracket to a bare array', () => {
+    expect(setSegmentAccessor('find_1.orders', 'find_1.orders', '-1')).toBe('find_1.orders[-1]')
+  })
+
+  it('strips the bracket when passed null', () => {
+    expect(setSegmentAccessor('find_1.orders[*]', 'find_1.orders', null)).toBe('find_1.orders')
+  })
+
+  it('edits the addressed segment when two arrays share a name', () => {
+    // The old name-keyed implementation used a non-global regex on the bare key,
+    // so editing the second `items` rewrote the first.
+    expect(setSegmentAccessor('n.items[*].items[0]', 'n.items[*].items', '*')).toBe(
+      'n.items[*].items[*]'
+    )
+    expect(setSegmentAccessor('n.items[*].items[0]', 'n.items', '0')).toBe('n.items[0].items[0]')
+  })
+
+  it('preserves the tail after the edited segment', () => {
+    expect(
+      setSegmentAccessor('find_1.cuid[*].contact_employer.company_name', 'find_1.cuid', '-1')
+    ).toBe('find_1.cuid[-1].contact_employer.company_name')
+  })
+
+  it('leaves the id alone when basePath is not a segment-boundary prefix', () => {
+    // "find_1.ord" is a prefix of "find_1.orders" but not a whole segment —
+    // rewriting there would corrupt the key into "find_1.ord[0]ers".
+    expect(setSegmentAccessor('find_1.orders[*]', 'find_1.ord', '0')).toBe('find_1.orders[*]')
+    expect(setSegmentAccessor('find_1.orders[*]', 'other.path', '0')).toBe('find_1.orders[*]')
   })
 })

--- a/packages/lib/src/workflow-engine/catalog/variable-inference.ts
+++ b/packages/lib/src/workflow-engine/catalog/variable-inference.ts
@@ -24,8 +24,27 @@ export interface ArraySegmentInfo {
   accessor: string
   /** The full segment string (e.g., "to[*]") */
   fullSegment: string
-  /** Human-readable label for the property */
+  /**
+   * Human-readable label for the property.
+   *
+   * This module is pure — it has no access to the variable store — so this
+   * falls back to the raw key. A raw key is frequently a CUID (a findMany
+   * output is keyed on `resource.id`, see `generateFindNodeVariablesFromFields`),
+   * so **UI must not render this directly**. Resolve `basePath` through the
+   * store and use the resolved `variable.label`, exactly as
+   * {@link buildVariableLabelPath} does.
+   */
   label: string
+  /**
+   * The variable id up to and including this segment's key, bracket excluded
+   * (e.g. `find_1.orders` for `find_1.orders[*].sku`). Unique within an id by
+   * construction, which makes it the stable handle for
+   * {@link setSegmentAccessor} — the bare key is not, because one path can
+   * nest two arrays of the same name (`items[*].items[0]`).
+   */
+  basePath: string
+  /** Zero-based position among the array segments of this id, in path order. */
+  ordinal: number
 }
 
 /** Pattern matching array bracket notation in variable IDs */
@@ -79,11 +98,20 @@ export function parseVariablePath(path: string): PathSegment[] {
 }
 
 /**
- * Parse all array segments from a variable ID
+ * Parse all **bracketed** array segments from a variable ID.
+ *
+ * Only finds segments that already carry a `[…]`. A bare array — a terminal
+ * segment whose variable is `ARRAY`-typed but has no bracket, e.g. `find_1.orders`
+ * feeding a List node — is invisible here, because deciding that requires the
+ * variable store. UI that needs both walks the path against the store instead
+ * (see `useVariableArraySegments` in apps/web).
+ *
  * @example
  * parseArraySegmentsFromId("nodeId.message.to[*].items[0].name")
- * // → [{ path: "to", accessor: "*", fullSegment: "to[*]", label: "to" },
- * //    { path: "items", accessor: "0", fullSegment: "items[0]", label: "items" }]
+ * // → [{ path: "to",    accessor: "*", fullSegment: "to[*]",
+ * //      label: "to",    basePath: "nodeId.message.to",          ordinal: 0 },
+ * //    { path: "items", accessor: "0", fullSegment: "items[0]",
+ * //      label: "items", basePath: "nodeId.message.to[*].items", ordinal: 1 }]
  */
 export function parseArraySegmentsFromId(variableId: string): ArraySegmentInfo[] {
   const segments: ArraySegmentInfo[] = []
@@ -92,30 +120,54 @@ export function parseArraySegmentsFromId(variableId: string): ArraySegmentInfo[]
   // Reset lastIndex for global regex
   ARRAY_SEGMENT_PATTERN.lastIndex = 0
   while ((match = ARRAY_SEGMENT_PATTERN.exec(variableId)) !== null) {
+    const key = match[1]!
     segments.push({
-      path: match[1]!,
+      path: key,
       accessor: match[2]!,
       fullSegment: match[0],
-      label: match[1]!,
+      label: key,
+      basePath: variableId.slice(0, match.index + key.length),
+      ordinal: segments.length,
     })
   }
   return segments
 }
 
 /**
- * Replace the accessor for a specific array segment in a variable ID
+ * Set, swap, or strip the array accessor on one segment of a variable ID.
+ *
+ * Addressed by `basePath` (the id up to and including the segment's key,
+ * bracket excluded) rather than by the bare key, so a path that nests two
+ * arrays of the same name edits the intended one:
+ * `setSegmentAccessor("n.items[*].items[0]", "n.items[*].items", "*")` touches
+ * the second `items`, not the first.
+ *
+ * Passing `null` removes the bracket entirely, yielding the array itself —
+ * which is a different declared type from `[*]` (`ARRAY` vs the item's shape)
+ * and what array-accepting inputs such as the List node's Input List want. Only
+ * meaningful on a terminal segment: stripping a bracket mid-path leaves
+ * `orders.sku`, i.e. dotting into an array.
+ *
  * @example
- * replaceArrayAccessor("nodeId.msg.to[*].name", "to", "0")
- * // → "nodeId.msg.to[0].name"
+ * setSegmentAccessor("nodeId.msg.to[*].name", "nodeId.msg.to", "0")  // → "nodeId.msg.to[0].name"
+ * setSegmentAccessor("find_1.orders[*]",      "find_1.orders",      null) // → "find_1.orders"
+ * setSegmentAccessor("find_1.orders",         "find_1.orders",      "-1") // → "find_1.orders[-1]"
  */
-export function replaceArrayAccessor(
+export function setSegmentAccessor(
   variableId: string,
-  segmentPath: string,
-  newAccessor: string
+  basePath: string,
+  accessor: string | null
 ): string {
-  // Match the specific segment[accessor] and replace the accessor
-  const pattern = new RegExp(`(${escapeRegExp(segmentPath)})\\[(-?\\d+|\\*)\\]`)
-  return variableId.replace(pattern, `$1[${newAccessor}]`)
+  if (!variableId.startsWith(basePath)) return variableId
+
+  const rest = variableId.slice(basePath.length)
+  const existing = rest.match(/^\[(-?\d+|\*)\]/)
+  // A `basePath` must land on a segment boundary — anything else is a caller
+  // bug (a truncated prefix), and rewriting there would corrupt the key.
+  if (!existing && rest !== '' && !rest.startsWith('.')) return variableId
+
+  const tail = existing ? rest.slice(existing[0].length) : rest
+  return `${basePath}${accessor === null ? '' : `[${accessor}]`}${tail}`
 }
 
 /**
@@ -142,11 +194,6 @@ function ordinal(n: number): string {
   const s = ['th', 'st', 'nd', 'rd']
   const v = n % 100
   return `${n}${s[(v - 20) % 10] || s[v] || s[0]}`
-}
-
-/** Escape special regex characters in a string */
-function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 /**

--- a/packages/lib/src/workflow-engine/client.ts
+++ b/packages/lib/src/workflow-engine/client.ts
@@ -394,8 +394,8 @@ export {
   parseArraySegmentsFromId,
   parseResourceFieldFromVariableId,
   preserveArrayStructure,
-  replaceArrayAccessor,
   resolveFieldPath,
+  setSegmentAccessor,
   VARIABLE_PATTERN,
 } from './catalog/variable-inference'
 export type {


### PR DESCRIPTION
Editing an existing variable chip meant deleting it and retyping `{`. The only in-place edit was array accessors, reachable on both left- and right-click, and that menu showed raw CUIDs where a resource name belongs.

## Gesture split

Applied to both the tiptap chip and the picker-mode chip:

| gesture | surface |
|---|---|
| left-click | variable explorer, pre-navigated to the chip's own path |
| right-click | array access for every array in the path |
| right-click, no arrays | nothing — the browser's own menu fires |

`VariableTagDropdown` is deleted. It was a Popover nested inside a Popover trigger, which is what made the two collide in `var-editor`; a ContextMenu nested there is fine, as `variable-input` has been demonstrating all along.

Array access is an inline accordion — every array listed by resolved name with its current selection, click one to expand its options in place. The menu stays open across selections, since a multi-array path routinely needs two accessors set in one visit.

## Fixes along the way

- **Accessor menu showed a raw CUID.** findMany output is keyed on `resource.id` since #1599, so the path key is a cuid while the label is `Contacts`. Now resolved through the var store, the same way `buildVariableLabelPath` already does for the chip itself.
- **`replaceArrayAccessor` edited the wrong segment.** Keyed on the bare name via a non-global regex, so in `items[*].items[0]` both rows addressed the first. Replaced by `setSegmentAccessor`, addressed by `basePath` and able to add/strip a bracket rather than only swap one.
- **Bare `ARRAY`-typed segments had no accessor UI**, which is the case that matters for array-accepting inputs (List node, Dataset, AI/HTTP file). Eligibility is type-based via a store walk now, not bracket-based.
- **Explorer drill-down failed on any numeric accessor** — the store only indexes the `[*]` form.
- **Explorer breadcrumb omitted the node group** (groups are keyed `node-<id>`), so "back" jumped past the node to root.
- **`isSelected` was passed and destructured but never rendered** — there was no current-value marker.
- **`hasCompatibleChildPath` recursed `properties` but never `items`**, so a typed field could not navigate into an array of objects.

## Terminal segments offer the array, not `[*]`

A trailing wildcard returns the array unmapped (`walkProjection` returns `items` when nothing follows), so `X` and `X[*]` are the same value — but `X` is declared `ARRAY` while `X[*]` is the item shape, which is wrong for every array-accepting input. Offering both would be two identical-looking options where one silently mistypes.

## Verification

Unit tests cover `parseArraySegmentsFromId` (basePath/ordinal, same-named arrays, multi-word keys) and `setSegmentAccessor` (swap, add, strip, positional addressing, non-boundary prefixes).

Exercised live against a findMany Contact workflow:

- accessor menu reads `Contacts · Last item` (was `"mzxt3cxyzhm3cbtgcbpmeir1" access`)
- menu stays open while the chip id rewrites `[-1]` → `[0]`, header updating in place
- two-array path renders the accordion with `Contacts` and `Work Order list`, single-expand
- left-click opens the explorer at `All Variables › Find › Contact` with one check on the chip's current value, resolved through a `[-1]` accessor

## Not included

The `allowedTypes` **hint**. The plumbing ships — `editor.storage.expectedTypes` is populated and the explorer filters on it — but the accessor options don't yet mark a choice that would break the field's type contract. Switching a List node input from the whole array to `[0]` still changes `ARRAY` → `OBJECT` with no visual signal, since `useVariable`'s `isValid` is availability-only.