### PR TITLE
feat(workflow): graph-edit turn snapshot, realtime signal, cas surfacing, run node

### DIFF
--- a/packages/lib/src/realtime/events.ts
+++ b/packages/lib/src/realtime/events.ts
@@ -504,6 +504,19 @@ export interface TableViewChangedEvent {
   data: { tableId?: string; kind: 'created' | 'updated' | 'defaultChanged' | 'deleted' }
 }
 
+/**
+ * A workflow's DRAFT graph changed server-side outside the canvas's own save
+ * path (today: the graph-edit ops — Kopilot mutations and the turn-revert
+ * lifecycle). Refresh signal only: an open builder refetches the draft; the
+ * payload carries nothing the client applies directly. `nodeIds` scopes which
+ * nodes the mutation touched (for focus/highlight), `reason` distinguishes an
+ * agent edit from platform machinery (e.g. a turn revert).
+ */
+export interface WorkflowDraftUpdatedEvent {
+  event: 'workflow:draft-updated'
+  data: { workflowAppId: string; nodeIds?: string[]; reason: 'kopilot' | 'system' }
+}
+
 // ════════════════════════════════════════════════════════════════════════════
 // Workflow approval events (per-assignee user channel)
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/lib/src/realtime/index.ts
+++ b/packages/lib/src/realtime/index.ts
@@ -48,6 +48,7 @@ export type {
   ThreadMeta,
   ThreadUpdatedEvent,
   VisibilityChangedEvent,
+  WorkflowDraftUpdatedEvent,
 } from './events'
 export { shapeMailEventForLens } from './mail-event-shaping'
 export {
@@ -73,6 +74,7 @@ export {
   publishThreadCreated,
   publishThreadDeleted,
   publishThreadUpdated,
+  publishWorkflowDraftUpdated,
 } from './publish-helpers'
 export { RealtimeService } from './realtime-service'
 export {

--- a/packages/lib/src/realtime/publish-helpers.ts
+++ b/packages/lib/src/realtime/publish-helpers.ts
@@ -16,6 +16,7 @@ import type {
   ParticipantMeta,
   ThreadCreatedEvent,
   ThreadMeta,
+  WorkflowDraftUpdatedEvent,
 } from './events'
 import { shapeMailEventForLens } from './mail-event-shaping'
 import type { RealtimeService } from './realtime-service'
@@ -730,6 +731,37 @@ export async function publishTableViewChanged(
       rooms.orgPresence(organizationId),
       'tableView:changed',
       { tableId: args.tableId, kind: args.kind },
+      options
+    )
+    .catch(() => {})
+}
+
+/**
+ * Publish `workflow:draft-updated` on the org channel. Fires AFTER a
+ * successful graph-edit persist (Kopilot mutations, turn revert) so an open
+ * builder canvas refetches the draft. Signal only — clients never apply the
+ * payload directly (`feedback_builder_ui_refresh_via_realtime`). The canvas's
+ * own save path must NOT emit this: it would invalidate the author's in-flight
+ * editing.
+ *
+ * Fire-and-forget: errors are swallowed so a Pusher hiccup never blocks the
+ * underlying draft write.
+ */
+export async function publishWorkflowDraftUpdated(
+  realtimeService: RealtimeService,
+  organizationId: string,
+  args: WorkflowDraftUpdatedEvent['data'],
+  options?: { excludeSocketId?: string }
+) {
+  await realtimeService
+    .publish(
+      rooms.orgPresence(organizationId),
+      'workflow:draft-updated',
+      {
+        workflowAppId: args.workflowAppId,
+        ...(args.nodeIds ? { nodeIds: args.nodeIds } : {}),
+        reason: args.reason,
+      },
       options
     )
     .catch(() => {})

--- a/packages/lib/src/workflows/graph-edit/__tests__/run-node.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/run-node.test.ts
@@ -1,0 +1,201 @@
+// packages/lib/src/workflows/graph-edit/__tests__/run-node.test.ts
+
+/**
+ * `runNode` (`03-graph-edit-service.md` §8): refuses a config-invalid node
+ * with the tier-2 issues as the error, runs a valid node through the existing
+ * `WorkflowExecutionService.runSingleNode` path against the DRAFT workflow
+ * row, and returns a SUMMARY (status, outputs, error) — never the raw
+ * execution dump. The executor is mocked; what's under test is the wrapper's
+ * gating, input mapping and summarization.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NotFoundError, UnprocessableEntityError } from '../../../errors'
+
+// The execution service constructs the whole engine off its constructor —
+// replaced so none of that module graph loads (run-node lazy-imports it).
+const runSingleNode = vi.fn()
+vi.mock('../../workflow-execution-service', () => ({
+  WorkflowExecutionService: class {
+    runSingleNode(...args: unknown[]) {
+      return runSingleNode(...args)
+    }
+  },
+}))
+
+const { runNode } = await import('../run-node')
+
+import type { DraftGraph, GraphNode } from '../types'
+
+const ORG = 'org_1'
+const APP = 'wfapp_1'
+const WAIT_ID = 'wait-aaaaaaaaaaaaaaaaaaaaa'
+const ANSWER_ID = 'answer-aaaaaaaaaaaaaaaaaaaaa'
+
+function waitNode(): GraphNode {
+  return {
+    id: WAIT_ID,
+    type: 'standard',
+    position: { x: 100, y: 200 },
+    data: {
+      id: WAIT_ID,
+      type: 'wait',
+      title: 'Wait A Bit',
+      waitType: 'duration',
+      durationAmount: 5,
+      isDurationConstant: true,
+      durationUnit: 'seconds',
+    },
+  }
+}
+
+/** A fresh answer node is NOT config-valid — `text` is required by the validator. */
+function answerNode(): GraphNode {
+  return {
+    id: ANSWER_ID,
+    type: 'standard',
+    position: { x: 300, y: 200 },
+    data: { id: ANSWER_ID, type: 'answer', title: 'Send Answer', text: '' },
+  }
+}
+
+function makeDb(graph: DraftGraph, opts: { noDraft?: boolean } = {}) {
+  const app = {
+    id: APP,
+    name: 'My Flow',
+    organizationId: ORG,
+    draftWorkflow: opts.noDraft
+      ? null
+      : {
+          id: 'wf_draft',
+          name: 'My Flow (Draft)',
+          graph,
+          triggerType: 'scheduled',
+          entityDefinitionId: null,
+          organizationId: ORG,
+          version: 3,
+        },
+  }
+  const db = { query: { WorkflowApp: { findFirst: vi.fn(async () => app) } } }
+  return db as unknown as import('@auxx/database').Database
+}
+
+const scope = { workflowAppId: APP, organizationId: ORG, userId: 'user_1' }
+
+beforeEach(() => {
+  runSingleNode.mockReset()
+  runSingleNode.mockResolvedValue({
+    id: 'exec_1',
+    status: 'succeeded',
+    outputs: { paused_at: '2026-08-14T00:00:00.000Z' },
+    error: null,
+    elapsedTime: 0.42,
+    processData: { internal: 'raw engine dump' },
+    executionMetadata: null,
+  })
+})
+
+describe('runNode', () => {
+  it('refuses a config-invalid node with the tier-2 issues as the error', async () => {
+    const result = await runNode(makeDb({ nodes: [answerNode()], edges: [] }), {
+      ...scope,
+      nodeId: 'Send Answer',
+    })
+    expect(result.isErr()).toBe(true)
+    const error = result._unsafeUnwrapErr()
+    expect(error).toBeInstanceOf(UnprocessableEntityError)
+    expect(error.message).toContain('text')
+    expect(error.message).toContain('not config-valid')
+    expect(runSingleNode).not.toHaveBeenCalled()
+  })
+
+  it('runs a valid node against the DRAFT row and maps the input record', async () => {
+    const result = await runNode(makeDb({ nodes: [waitNode()], edges: [] }), {
+      ...scope,
+      nodeId: 'Wait A Bit',
+      input: { 'trigger.subject': 'hello' },
+    })
+    expect(result.isOk()).toBe(true)
+
+    expect(runSingleNode).toHaveBeenCalledTimes(1)
+    expect(runSingleNode.mock.calls[0]?.[0]).toEqual({
+      workflowAppId: APP,
+      workflowId: 'wf_draft', // the draft Workflow row, never a published one
+      nodeId: WAIT_ID,
+      inputs: [{ variableId: 'trigger.subject', value: 'hello' }],
+      userId: 'user_1',
+      organizationId: ORG,
+    })
+  })
+
+  it('summarizes the result — status/outputs/error only, never the raw dump', async () => {
+    const result = await runNode(makeDb({ nodes: [waitNode()], edges: [] }), {
+      ...scope,
+      nodeId: WAIT_ID,
+    })
+    const summary = result._unsafeUnwrap()
+    expect(summary).toEqual({
+      status: 'succeeded',
+      outputs: { paused_at: '2026-08-14T00:00:00.000Z' },
+      error: null,
+      elapsedTime: 0.42,
+    })
+    expect(summary).not.toHaveProperty('processData')
+    expect(summary).not.toHaveProperty('executionMetadata')
+  })
+
+  it('surfaces a failed run with its per-field validation errors', async () => {
+    runSingleNode.mockResolvedValue({
+      id: 'exec_2',
+      status: 'failed',
+      outputs: null,
+      error: 'Validation failed',
+      elapsedTime: 0.1,
+      executionMetadata: {
+        validationError: { fields: [{ field: 'to', message: 'Recipient is required' }] },
+      },
+    })
+    const result = await runNode(makeDb({ nodes: [waitNode()], edges: [] }), {
+      ...scope,
+      nodeId: WAIT_ID,
+    })
+    const summary = result._unsafeUnwrap()
+    expect(summary.status).toBe('failed')
+    expect(summary.error).toBe('Validation failed')
+    expect(summary.validationErrors).toEqual([{ field: 'to', message: 'Recipient is required' }])
+  })
+
+  it('errors when the app has no draft, and on an unresolvable node ref', async () => {
+    const noDraft = await runNode(makeDb({ nodes: [], edges: [] }, { noDraft: true }), {
+      ...scope,
+      nodeId: WAIT_ID,
+    })
+    expect(noDraft.isErr()).toBe(true)
+    expect(noDraft._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+
+    const badRef = await runNode(makeDb({ nodes: [waitNode()], edges: [] }), {
+      ...scope,
+      nodeId: 'No Such Node',
+    })
+    expect(badRef.isErr()).toBe(true)
+    expect(runSingleNode).not.toHaveBeenCalled()
+  })
+
+  it('maps executor throws to typed AuxxErrors, never a bare throw', async () => {
+    runSingleNode.mockRejectedValue(new Error('Node not found in workflow'))
+    const result = await runNode(makeDb({ nodes: [waitNode()], edges: [] }), {
+      ...scope,
+      nodeId: WAIT_ID,
+    })
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+
+    runSingleNode.mockRejectedValue(new Error('boom'))
+    const crashed = await runNode(makeDb({ nodes: [waitNode()], edges: [] }), {
+      ...scope,
+      nodeId: WAIT_ID,
+    })
+    expect(crashed._unsafeUnwrapErr()).toBeInstanceOf(UnprocessableEntityError)
+    expect(crashed._unsafeUnwrapErr().message).toContain('boom')
+  })
+})

--- a/packages/lib/src/workflows/graph-edit/__tests__/turn-lifecycle.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/turn-lifecycle.test.ts
@@ -1,0 +1,325 @@
+// packages/lib/src/workflows/graph-edit/__tests__/turn-lifecycle.test.ts
+
+/**
+ * Turn snapshot / revert + realtime signal + CAS surfacing
+ * (`03-graph-edit-service.md` §7, `07-remaining-mechanics.md` §6): first
+ * mutation of a turn captures the pre-edit graph, a second mutation of the
+ * SAME turn does not overwrite it, a failed turn's revert restores the exact
+ * prior graph, a PRIOR turn's stale snapshot is rejected, the
+ * `workflow:draft-updated` signal fires after a successful persist (and never
+ * on a rejected mutation), and a hash-CAS conflict surfaces as a typed,
+ * actionable `ConflictError` — never a generic 500, never a silent overwrite.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ConflictError, NotFoundError, UnprocessableEntityError } from '../../../errors'
+import { hashWorkflowGraph } from '../../graph-hash'
+
+// Partial mock — the cache barrel is imported by half of lib; replacing it
+// wholesale dies at collection. Only the read the graph-edit path makes is stubbed.
+const getCachedResources = vi.fn()
+vi.mock('../../../cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../cache')>()),
+  getCachedResources: (...args: unknown[]) => getCachedResources(...args),
+}))
+
+// The persist seam writes through WorkflowService.update (lazy-imported in
+// persist.ts) — replaced so no engine/queue module graph loads.
+const serviceUpdate = vi.fn()
+vi.mock('../../workflow-service', () => ({
+  WorkflowService: class {
+    update(...args: unknown[]) {
+      return serviceUpdate(...args)
+    }
+  },
+}))
+
+const mailGuard = vi.fn(async (..._args: unknown[]) => {})
+vi.mock('../../mail-trigger-guard', () => ({
+  assertMailTriggerNotPersonal: (...args: unknown[]) => mailGuard(...args),
+}))
+
+// In-memory Redis fake — the snapshot slot. Partial mock: the barrel is
+// imported by other lib modules (credential-lock), so only the data helpers
+// the snapshot uses are stubbed.
+const redisStore = new Map<string, unknown>()
+vi.mock('@auxx/redis', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/redis')>()),
+  getRedisData: vi.fn(async (key: string) => redisStore.get(key) ?? null),
+  setRedisData: vi.fn(async (key: string, data: unknown) => {
+    redisStore.set(key, data)
+    return 'OK'
+  }),
+  deleteRedisData: vi.fn(async (key: string) => {
+    const had = redisStore.delete(key)
+    return had ? 1 : 0
+  }),
+}))
+
+// The realtime barrel is lazy-imported inside publishDraftUpdatedSignal —
+// replaced wholesale so none of its module graph loads at collection.
+const publishWorkflowDraftUpdated = vi.fn(async (..._args: unknown[]) => {})
+vi.mock('../../../realtime', () => ({
+  getRealtimeService: () => ({ tag: 'realtime-service' }),
+  publishWorkflowDraftUpdated: (...args: unknown[]) => publishWorkflowDraftUpdated(...args),
+}))
+
+const { addNode } = await import('../ops')
+const { finalizeWorkflowTurn, readWorkflowTurnSnapshot, revertWorkflowTurn } = await import(
+  '../turn-snapshot'
+)
+
+import type { DraftGraph, GraphNode } from '../types'
+
+const ORG = 'org_1'
+const APP = 'wfapp_1'
+const TURN_A = 'turn_aaaa'
+const TURN_B = 'turn_bbbb'
+const TRIGGER_ID = 'scheduled-aaaaaaaaaaaaaaaaaaaaa'
+
+function triggerNode(): GraphNode {
+  return {
+    id: TRIGGER_ID,
+    type: 'standard',
+    position: { x: 100, y: 200 },
+    width: 244,
+    height: 100,
+    data: {
+      id: TRIGGER_ID,
+      type: 'scheduled',
+      title: 'Every Morning',
+      config: {
+        triggerInterval: 'days',
+        timeBetweenTriggers: { days: 1, isConstant: true },
+        timezone: 'UTC',
+      },
+      isEnabled: true,
+    },
+  }
+}
+
+function baseGraph(): DraftGraph {
+  return { nodes: [triggerNode()], edges: [] }
+}
+
+/** In-memory WorkflowApp row + db stub for `loadDraftContext`. */
+function makeDb(graph: DraftGraph, triggerType: string | null = 'scheduled') {
+  const app = {
+    id: APP,
+    name: 'My Flow',
+    organizationId: ORG,
+    draftWorkflow: {
+      id: 'wf_draft',
+      name: 'My Flow (Draft)',
+      graph,
+      triggerType,
+      entityDefinitionId: null,
+      organizationId: ORG,
+      version: 3,
+    },
+  }
+  const db = { query: { WorkflowApp: { findFirst: vi.fn(async () => app) } } }
+  return db as unknown as import('@auxx/database').Database
+}
+
+const scope = (turnId?: string) => ({
+  workflowAppId: APP,
+  organizationId: ORG,
+  ...(turnId ? { turnId } : {}),
+})
+
+const addWait = (db: import('@auxx/database').Database, turnId?: string, title = 'Wait A Bit') =>
+  addNode(db, { ...scope(turnId), type: 'wait', title, after: 'Every Morning' })
+
+beforeEach(() => {
+  redisStore.clear()
+  getCachedResources.mockReset()
+  getCachedResources.mockResolvedValue([])
+  mailGuard.mockReset()
+  mailGuard.mockResolvedValue(undefined)
+  publishWorkflowDraftUpdated.mockReset()
+  serviceUpdate.mockReset()
+  serviceUpdate.mockImplementation(async (_org: string, input: Record<string, unknown>) => ({
+    graphHash: 'hash-after',
+    triggerType: input.triggerType ?? null,
+    entityDefinitionId: input.entityDefinitionId ?? null,
+  }))
+})
+
+describe('turn snapshot capture', () => {
+  it('captures the PRE-edit graph on the first mutation of a turn', async () => {
+    const graph = baseGraph()
+    const result = await addWait(makeDb(graph), TURN_A)
+    expect(result.isOk()).toBe(true)
+
+    const snapshot = await readWorkflowTurnSnapshot(APP, TURN_A)
+    expect(snapshot).not.toBeNull()
+    expect(snapshot?.turnId).toBe(TURN_A)
+    expect(snapshot?.triggerType).toBe('scheduled')
+    // The snapshot is the graph BEFORE the mutation — one node, no wait.
+    expect(snapshot?.graph.nodes.map((n) => n.id)).toEqual([TRIGGER_ID])
+    expect(snapshot?.graph.edges).toEqual([])
+  })
+
+  it('does NOT overwrite the snapshot on a second mutation of the same turn', async () => {
+    await addWait(makeDb(baseGraph()), TURN_A)
+    const first = await readWorkflowTurnSnapshot(APP, TURN_A)
+
+    // Second mutation of the SAME turn, on the now-grown draft.
+    const grown = (serviceUpdate.mock.calls.at(-1)?.[1] as { graph: DraftGraph }).graph
+    const result = await addNode(makeDb(grown), {
+      ...scope(TURN_A),
+      type: 'wait',
+      title: 'Wait Again',
+      after: 'Wait A Bit',
+    })
+    expect(result.isOk()).toBe(true)
+
+    const second = await readWorkflowTurnSnapshot(APP, TURN_A)
+    expect(second).toEqual(first) // still the turn's ORIGINAL pre-edit graph
+    expect(second?.graph.nodes).toHaveLength(1)
+  })
+
+  it('takes no snapshot without a turnId, and none when the mutation is rejected', async () => {
+    await addWait(makeDb(baseGraph()))
+    expect(redisStore.size).toBe(0)
+    serviceUpdate.mockClear()
+
+    // Blocked by the mail-trigger guard → applied: false, nothing persisted,
+    // and the turn must NOT be marked as having written anything.
+    mailGuard.mockRejectedValue(new UnprocessableEntityError('personal channel'))
+    const rejected = await addWait(makeDb(baseGraph()), TURN_A)
+    expect(rejected.isOk()).toBe(true)
+    expect(rejected._unsafeUnwrap().applied).toBe(false)
+    expect(await readWorkflowTurnSnapshot(APP, TURN_A)).toBeNull()
+    expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe('revert / finalize lifecycle', () => {
+  it('a failed turn restores the exact prior graph through the persist seam', async () => {
+    const graph = baseGraph()
+    await addWait(makeDb(graph), TURN_A)
+    serviceUpdate.mockClear()
+    publishWorkflowDraftUpdated.mockClear()
+
+    // The draft now holds the mutated graph; revert must write back the original.
+    const mutated = { ...baseGraph(), nodes: [...baseGraph().nodes] }
+    mutated.nodes.push({
+      id: 'wait-zzzzzzzzzzzzzzzzzzzzz',
+      type: 'standard',
+      position: { x: 500, y: 200 },
+      data: { id: 'wait-zzzzzzzzzzzzzzzzzzzzz', type: 'wait', title: 'Wait A Bit' },
+    })
+    const db = makeDb(mutated)
+
+    const reverted = await revertWorkflowTurn(db, scope(), TURN_A)
+    expect(reverted.isOk()).toBe(true)
+
+    const input = serviceUpdate.mock.calls.at(-1)?.[1] as Record<string, unknown>
+    const written = input.graph as DraftGraph
+    expect(written.nodes.map((n) => n.id)).toEqual([TRIGGER_ID])
+    expect(written.edges).toEqual([])
+    // CAS token from the CURRENT draft — a write racing the revert 409s.
+    expect(input.expectedGraphHash).toBe(hashWorkflowGraph(mutated))
+
+    // Snapshot consumed; the refresh signal fired as machinery, not an edit.
+    expect(await readWorkflowTurnSnapshot(APP, TURN_A)).toBeNull()
+    expect(publishWorkflowDraftUpdated).toHaveBeenCalledTimes(1)
+    expect(publishWorkflowDraftUpdated.mock.calls[0]?.[2]).toEqual({
+      workflowAppId: APP,
+      reason: 'system',
+    })
+  })
+
+  it('rejects a stale snapshot from a PRIOR turn — never restores it', async () => {
+    await addWait(makeDb(baseGraph()), TURN_A)
+    // A newer turn supersedes the slot.
+    await addWait(makeDb(baseGraph()), TURN_B, 'Wait Later')
+    serviceUpdate.mockClear()
+
+    const reverted = await revertWorkflowTurn(makeDb(baseGraph()), scope(), TURN_A)
+    expect(reverted.isErr()).toBe(true)
+    expect(reverted._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+    expect(serviceUpdate).not.toHaveBeenCalled()
+    // Turn B's snapshot is untouched.
+    expect((await readWorkflowTurnSnapshot(APP, TURN_B))?.turnId).toBe(TURN_B)
+  })
+
+  it('reverting a turn that never wrote reports there is nothing to revert', async () => {
+    const reverted = await revertWorkflowTurn(makeDb(baseGraph()), scope(), TURN_A)
+    expect(reverted.isErr()).toBe(true)
+    expect(reverted._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+    expect(reverted._unsafeUnwrapErr().message).toContain('never wrote')
+  })
+
+  it('finalize discards only the OWN turn snapshot, never a fresher one', async () => {
+    await addWait(makeDb(baseGraph()), TURN_B)
+    await finalizeWorkflowTurn(APP, TURN_A) // stale finalize — must be a no-op
+    expect((await readWorkflowTurnSnapshot(APP, TURN_B))?.turnId).toBe(TURN_B)
+
+    await finalizeWorkflowTurn(APP, TURN_B)
+    expect(await readWorkflowTurnSnapshot(APP, TURN_B)).toBeNull()
+  })
+})
+
+describe('workflow:draft-updated signal', () => {
+  it('fires AFTER a successful persist with the event shape', async () => {
+    const result = await addWait(makeDb(baseGraph()), TURN_A)
+    expect(result.isOk()).toBe(true)
+
+    expect(publishWorkflowDraftUpdated).toHaveBeenCalledTimes(1)
+    const [, organizationId, data] = publishWorkflowDraftUpdated.mock.calls[0] ?? []
+    expect(organizationId).toBe(ORG)
+    const addedId = result._unsafeUnwrap().node?.id
+    expect(data).toEqual({ workflowAppId: APP, nodeIds: [addedId], reason: 'kopilot' })
+    // The persist happened BEFORE the signal.
+    expect(serviceUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it("reports reason 'system' for non-turn callers", async () => {
+    await addWait(makeDb(baseGraph()))
+    expect(publishWorkflowDraftUpdated.mock.calls[0]?.[2]).toMatchObject({ reason: 'system' })
+  })
+
+  it('does NOT fire when the mutation is rejected before persisting', async () => {
+    mailGuard.mockRejectedValue(new UnprocessableEntityError('personal channel'))
+    const rejected = await addWait(makeDb(baseGraph()), TURN_A)
+    expect(rejected._unsafeUnwrap().applied).toBe(false)
+    expect(publishWorkflowDraftUpdated).not.toHaveBeenCalled()
+
+    publishWorkflowDraftUpdated.mockClear()
+    mailGuard.mockResolvedValue(undefined)
+    const badRef = await addNode(makeDb(baseGraph()), {
+      ...scope(TURN_A),
+      type: 'wait',
+      after: 'No Such Node',
+    })
+    expect(badRef.isErr()).toBe(true)
+    expect(publishWorkflowDraftUpdated).not.toHaveBeenCalled()
+  })
+})
+
+describe('hash-CAS surfacing (07 §6)', () => {
+  it('sends the loaded graph hash as the CAS token — never an unconditional write', async () => {
+    const graph = baseGraph()
+    await addWait(makeDb(graph))
+    const input = serviceUpdate.mock.calls.at(-1)?.[1] as Record<string, unknown>
+    expect(input.expectedGraphHash).toBe(hashWorkflowGraph(graph))
+  })
+
+  it('surfaces a concurrent-save conflict as a typed, actionable ConflictError', async () => {
+    serviceUpdate.mockRejectedValue(
+      new ConflictError('The draft of workflow "My Flow" changed while you were editing.')
+    )
+    const result = await addWait(makeDb(baseGraph()), TURN_A)
+    expect(result.isErr()).toBe(true)
+    const error = result._unsafeUnwrapErr()
+    expect(error).toBeInstanceOf(ConflictError)
+    expect(error.statusCode).toBe(409)
+    expect(error.message).toMatch(/re-read/i)
+    expect(error.message).toMatch(/retry/i)
+    // No refresh signal for a write that never landed.
+    expect(publishWorkflowDraftUpdated).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/workflows/graph-edit/index.ts
+++ b/packages/lib/src/workflows/graph-edit/index.ts
@@ -12,8 +12,9 @@
  *
  * Surface: §2 reference resolution (`refs.ts`), §3 normalization
  * (`normalize/`), §1 operations (`ops.ts` writes + `read.ts` reads), §4
- * layout/placement, §5 validation. The Redis turn snapshot, realtime event
- * and `runNode` land in the next slice and wrap `persistDraft`.
+ * layout/placement, §5 validation, §7 turn snapshot/revert
+ * (`turn-snapshot.ts`) + the `workflow:draft-updated` refresh signal wired
+ * around `persistDraft`, §8 single-node runs (`run-node.ts`).
  */
 
 export {
@@ -49,6 +50,7 @@ export {
   type DisconnectNodesInput,
   deleteNodes,
   disconnectNodes,
+  type GraphMutationScope,
   type ReplaceGraphEdgeSpec,
   type ReplaceGraphInput,
   type ReplaceGraphNodeSpec,
@@ -63,6 +65,7 @@ export {
   type PersistDraftInput,
   type PersistDraftOutcome,
   persistDraft,
+  publishDraftUpdatedSignal,
 } from './persist'
 export {
   DEFAULT_NODE_SIZE,
@@ -95,6 +98,18 @@ export {
   nodeTitle,
   resolveNodeRef,
 } from './refs'
+export {
+  type RunNodeInput,
+  type RunNodeSummary,
+  runNode,
+} from './run-node'
+export {
+  captureWorkflowTurnSnapshot,
+  finalizeWorkflowTurn,
+  readWorkflowTurnSnapshot,
+  revertWorkflowTurn,
+  type WorkflowPreTurnSnapshot,
+} from './turn-snapshot'
 export type {
   DraftGraph,
   DraftSummary,

--- a/packages/lib/src/workflows/graph-edit/ops.ts
+++ b/packages/lib/src/workflows/graph-edit/ops.ts
@@ -20,7 +20,7 @@ import type { Database } from '@auxx/database'
 import { incrementTitle } from '@auxx/utils'
 import { generateId } from '@auxx/utils/generateId'
 import { err, ok, type Result } from 'neverthrow'
-import { AuxxError, BadRequestError, NotFoundError } from '../../errors'
+import { AuxxError, BadRequestError, ConflictError, NotFoundError } from '../../errors'
 import { LOOP_HANDLES } from '../../workflow-engine/catalog/nodes/loop'
 import { getAuthorableManifests, getManifest } from '../../workflow-engine/catalog/registry'
 import { resolveGraphOutputs } from '../../workflow-engine/catalog/resolve-outputs'
@@ -34,7 +34,7 @@ import { normalizeFriendlyRefs, type ResourceAliasIndex } from './normalize/frie
 import { normalizeAiPromptConfig } from './normalize/prompt'
 import { checkVariableRefsAgainstOutputs } from './normalize/ref-check'
 import { buildResourceAliasIndex, normalizeResourceConfig } from './normalize/resource-refs'
-import { persistDraft } from './persist'
+import { persistDraft, publishDraftUpdatedSignal } from './persist'
 import {
   DEFAULT_NODE_SIZE,
   findNearestEmptySpace,
@@ -51,8 +51,20 @@ import {
   renderFriendlyOutputs,
 } from './read'
 import { describeNode, formatNodeRef, resolveNodeRef } from './refs'
+import { captureWorkflowTurnSnapshot } from './turn-snapshot'
 import type { DraftGraph, GraphEdge, GraphMutationResult, GraphNode, Issue, Point } from './types'
 import { isTriggerNode, nodeType, validateGraphStructure, validateNodeConfigs } from './validate'
+
+/**
+ * Scope every MUTATION takes — `GraphEditScope` plus the optional turn id.
+ * With `turnId`, the pipeline captures the pre-edit graph before the turn's
+ * first write (`turn-snapshot.ts`) so the turn lifecycle can revert on
+ * failure; without it (non-turn callers: system paths, scripts) no snapshot
+ * is taken and the write is plain.
+ */
+export interface GraphMutationScope extends GraphEditScope {
+  turnId?: string
+}
 
 /** The plan a specific mutation hands the shared pipeline. */
 interface MutationPlan {
@@ -76,11 +88,14 @@ interface MutationPlan {
  * The shared mutation pipeline. Blocking tiers (normalize errors, structural
  * errors, the mail-trigger guard) return `applied: false` with the original
  * graph untouched; everything else persists through the one seam
- * (`persistDraft`) and reports.
+ * (`persistDraft`) and reports. The turn snapshot is captured immediately
+ * before the persist (first write of a turn only) and the
+ * `workflow:draft-updated` signal fires immediately after a successful one —
+ * ALL the snapshot/realtime wiring lives here, not in the individual ops.
  */
 async function runGraphMutation(
   db: Database,
-  scope: GraphEditScope,
+  scope: GraphMutationScope,
   build: (
     ctx: DraftContext,
     aliases: ResourceAliasIndex
@@ -131,6 +146,16 @@ async function runGraphMutation(
     issues.push(...checkVariableRefsAgainstOutputs({ graph, outputs: outputsMap }).issues)
   }
 
+  // Pre-turn snapshot — captured only now that the write is certain to be
+  // attempted, so a rejected mutation never marks the turn as "wrote
+  // something". Idempotent per turn: only the FIRST write captures.
+  if (scope.turnId !== undefined) {
+    await captureWorkflowTurnSnapshot(scope.workflowAppId, scope.turnId, {
+      graph: ctx.graph,
+      triggerType: ctx.triggerType,
+    })
+  }
+
   const persisted = await persistDraft(db, scope, {
     graph,
     ...(ctx.graphHash !== undefined ? { expectedGraphHash: ctx.graphHash } : {}),
@@ -140,7 +165,38 @@ async function runGraphMutation(
     ...(plan.variables !== undefined ? { variables: plan.variables as never } : {}),
     ...(plan.icon !== undefined ? { icon: plan.icon } : {}),
   })
-  if (persisted.isErr()) return err(persisted.error)
+  if (persisted.isErr()) {
+    // Hash-CAS conflict (`07-remaining-mechanics.md` §6): a concurrent save
+    // landed between load and write. Surface it typed and actionable — the
+    // caller re-reads the draft and retries; never a silent overwrite, never
+    // a generic 500.
+    if (persisted.error instanceof ConflictError) {
+      return err(
+        new ConflictError(
+          'The workflow draft changed while this edit was being prepared — another save ' +
+            'landed first. Re-read the draft and retry the operation on the fresh graph. ' +
+            'Nothing was overwritten.'
+        )
+      )
+    }
+    return err(persisted.error)
+  }
+
+  // Refresh signal AFTER the successful persist — open canvases refetch.
+  await publishDraftUpdatedSignal(scope.organizationId, {
+    workflowAppId: scope.workflowAppId,
+    ...(plan.touchedNodeId || plan.newNodeIds?.size
+      ? {
+          nodeIds: [
+            ...new Set([
+              ...(plan.touchedNodeId ? [plan.touchedNodeId] : []),
+              ...(plan.newNodeIds ?? []),
+            ]),
+          ],
+        }
+      : {}),
+    reason: scope.turnId !== undefined ? 'kopilot' : 'system',
+  })
 
   const touched = plan.touchedNodeId
     ? graph.nodes.find((n) => n.id === plan.touchedNodeId)
@@ -263,7 +319,7 @@ function resizeContainer(node: GraphNode, size: { width: number; height: number 
 }
 
 /** Input for {@link addNode}. */
-export interface AddNodeInput extends GraphEditScope {
+export interface AddNodeInput extends GraphMutationScope {
   /** Authorable node type (`data.type`), e.g. `'find'`. */
   type: string
   /** Friendly config — `{{Title.path}}` refs, resource slugs, plain prompts. */
@@ -419,7 +475,7 @@ export async function addNode(
 }
 
 /** Input for {@link updateNode}. */
-export interface UpdateNodeInput extends GraphEditScope {
+export interface UpdateNodeInput extends GraphMutationScope {
   /** Node title or id. */
   ref: string
   /** Friendly config, shallow-merged over the node's current data. */
@@ -464,7 +520,7 @@ export async function updateNode(
 }
 
 /** Input for {@link deleteNodes}. */
-export interface DeleteNodesInput extends GraphEditScope {
+export interface DeleteNodesInput extends GraphMutationScope {
   /** Node titles or ids. */
   refs: string[]
   /** Bridge each deleted node's incoming edges to its downstream targets. */
@@ -558,7 +614,7 @@ export async function deleteNodes(
 }
 
 /** Input for {@link connectNodes}. */
-export interface ConnectNodesInput extends GraphEditScope {
+export interface ConnectNodesInput extends GraphMutationScope {
   from: string
   to: string
   /** Branch of `from` to leave on — resolved through the manifest's branches. */
@@ -612,7 +668,7 @@ export async function connectNodes(
 }
 
 /** Input for {@link disconnectNodes}. */
-export interface DisconnectNodesInput extends GraphEditScope {
+export interface DisconnectNodesInput extends GraphMutationScope {
   from: string
   to: string
 }
@@ -648,7 +704,7 @@ export async function disconnectNodes(
 }
 
 /** Input for {@link setTrigger}. */
-export interface SetTriggerInput extends GraphEditScope {
+export interface SetTriggerInput extends GraphMutationScope {
   /** In-graph trigger NODE type: manual, scheduled, resource-trigger, message-received. */
   triggerType: string
   /** Friendly trigger config (e.g. `{ operation: 'created', resourceType: 'ticket' }`). */
@@ -778,7 +834,7 @@ export interface ReplaceGraphEdgeSpec {
 }
 
 /** Input for {@link replaceGraph}. */
-export interface ReplaceGraphInput extends GraphEditScope {
+export interface ReplaceGraphInput extends GraphMutationScope {
   nodes: ReplaceGraphNodeSpec[]
   edges: ReplaceGraphEdgeSpec[]
 }
@@ -927,7 +983,7 @@ export async function replaceGraph(
 }
 
 /** Input for {@link applyTemplate}. */
-export interface ApplyTemplateInput extends GraphEditScope {
+export interface ApplyTemplateInput extends GraphMutationScope {
   /** File template id (`file:<slug>`) or DB template row id. */
   templateId: string
   /** Stamped onto cloned graph metadata by the template transformer. */

--- a/packages/lib/src/workflows/graph-edit/persist.ts
+++ b/packages/lib/src/workflows/graph-edit/persist.ts
@@ -17,9 +17,11 @@
  * so a mutation that adds/edits/removes a trigger node can never leave
  * `Workflow.triggerType`/`entityDefinitionId` stale.
  *
- * NEXT-SLICE SEAM: the Redis turn snapshot wraps this function BEFORE the
- * write and the `workflow:draft-updated` realtime event fires AFTER it —
- * both belong in a wrapper around `persistDraft`, not inside it.
+ * THE SEAM: the Redis turn snapshot (`turn-snapshot.ts`) is captured BEFORE
+ * this write and the `workflow:draft-updated` realtime signal
+ * ({@link publishDraftUpdatedSignal}) fires AFTER it — both wrap `persistDraft`
+ * in the mutation pipeline (`ops.ts` `runGraphMutation`) and the turn-revert
+ * path, never inside it, so non-pipeline callers keep a bare persist.
  */
 
 import type { Database } from '@auxx/database'
@@ -129,5 +131,27 @@ export async function persistDraft(
     const message = error instanceof Error ? error.message : String(error)
     if (message === 'Workflow not found') return err(new NotFoundError('Workflow not found'))
     return err(new UnprocessableEntityError(`Failed to save the workflow draft: ${message}`))
+  }
+}
+
+/**
+ * Fire the `workflow:draft-updated` refresh signal on the org channel AFTER a
+ * successful persist. Signal only — open canvases refetch the draft; nothing
+ * in the payload is applied directly. Fire-and-forget: a realtime hiccup never
+ * fails the mutation that already persisted.
+ *
+ * The realtime barrel is lazy-imported on purpose: statically importing it
+ * breaks `vi.mock` at collection as the module graph grows
+ * (`project_realtime_barrel_import_cycle`).
+ */
+export async function publishDraftUpdatedSignal(
+  organizationId: string,
+  data: { workflowAppId: string; nodeIds?: string[]; reason: 'kopilot' | 'system' }
+): Promise<void> {
+  try {
+    const { getRealtimeService, publishWorkflowDraftUpdated } = await import('../../realtime')
+    await publishWorkflowDraftUpdated(getRealtimeService(), organizationId, data)
+  } catch {
+    // Fire-and-forget — the draft write already succeeded.
   }
 }

--- a/packages/lib/src/workflows/graph-edit/run-node.ts
+++ b/packages/lib/src/workflows/graph-edit/run-node.ts
@@ -1,0 +1,147 @@
+// packages/lib/src/workflows/graph-edit/run-node.ts
+
+/**
+ * Single-node run for the graph-edit module (`03-graph-edit-service.md` §8) —
+ * SERVER-ONLY, and deliberately in its own file: the execution service pulls
+ * the whole engine module graph (bullmq, processors), which must not ride
+ * along with the rest of graph-edit in tests.
+ *
+ * Wraps the EXISTING `WorkflowExecutionService.runSingleNode` path — the same
+ * one the node panel's "Run" button uses — over the DRAFT graph only. One run
+ * per call; the result is SUMMARIZED (status, outputs, error), never the raw
+ * execution dump. There is NO full-workflow trigger API here at all — not
+ * gated, absent — so a later refactor cannot quietly widen it.
+ *
+ * SAFETY: single-node runs are unconditionally debug/dry runs since #1555
+ * (`single-node-executor.ts:88-95` forces `setDebugMode(true)`) — a panel
+ * "Run" previously emailed a real customer; side-effecting nodes now simulate,
+ * and `ResumeOptions.debug` keeps a paused test run from resuming as
+ * production. That is the strongest safety property this wrapper inherits.
+ *
+ * `runSingleNode` does NOT run upstream nodes — the caller supplies every
+ * input variable value explicitly (`07-remaining-mechanics.md` §4), so
+ * `input` values are synthesized test data, not live upstream output.
+ *
+ * No permission checks live here (house rule). The capability layer must
+ * apply all four guards the tRPC procedure applies:
+ * `permissionProcedure(workflowsView)`, `notDemo`,
+ * `assertEditInstance('workflow', workflowAppId)`, and
+ * `assertWorkflowAppNotSystemOwned`.
+ */
+
+import type { Database } from '@auxx/database'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError, NotFoundError, UnprocessableEntityError } from '../../errors'
+import { type GraphEditScope, loadDraftContext } from './read'
+import { resolveNodeRef } from './refs'
+import type { GraphNode, Issue } from './types'
+import { validateNodeConfigs } from './validate'
+
+/** Input for {@link runNode}. */
+export interface RunNodeInput extends GraphEditScope {
+  /** Node reference — title or id, resolved like every other op's `ref`. */
+  nodeId: string
+  /**
+   * Input variable values keyed by variable id (the `{{…}}` names the node
+   * consumes). Upstream nodes are NOT executed — omitted inputs are simply
+   * undefined at run time.
+   */
+  input?: Record<string, unknown>
+  /** User the run executes as (recorded on the execution row). */
+  userId: string
+}
+
+/** The summarized outcome of a single-node run — never the raw execution dump. */
+export interface RunNodeSummary {
+  status: 'succeeded' | 'failed'
+  /** The node's output variables (what downstream `{{Node.x}}` refs would see). */
+  outputs: Record<string, unknown>
+  error: string | null
+  /** Seconds the node took to run. */
+  elapsedTime: number | null
+  /** Per-field messages when the node's own validation rejected the inputs. */
+  validationErrors?: Array<{ field: string; message: string }>
+}
+
+/**
+ * Run one draft node in isolation as a debug/dry run and summarize the result.
+ * The node must be config-valid first (tier-2 validation — the manifest's own
+ * validator); a config-invalid node is refused with the issues as the error,
+ * because running it would only produce a less actionable failure.
+ */
+export async function runNode(
+  db: Database,
+  params: RunNodeInput
+): Promise<Result<RunNodeSummary, AuxxError>> {
+  const loaded = await loadDraftContext(db, params)
+  if (loaded.isErr()) return err(loaded.error)
+  const ctx = loaded.value
+
+  const draftWorkflowId = ctx.draftRow?.id
+  if (typeof draftWorkflowId !== 'string') {
+    return err(new NotFoundError('The workflow has no draft to run a node from.'))
+  }
+
+  const resolved = resolveNodeRef(ctx.graph.nodes, params.nodeId)
+  if (resolved.isErr()) return err(resolved.error)
+  const node = resolved.value.node as GraphNode
+
+  // Tier-2 config validation, scoped to this node — a run needs a valid
+  // config even though a draft legitimately persists without one.
+  const configIssues = validateNodeConfigs({ nodes: [node], edges: [] })
+  const blocking = configIssues.filter((issue) => issue.severity === 'error')
+  if (blocking.length > 0) {
+    return err(
+      new UnprocessableEntityError(
+        `Node "${issueRef(blocking[0]) ?? params.nodeId}" is not config-valid — fix these before running:\n` +
+          blocking
+            .map((issue) => `- ${issue.field ? `${issue.field}: ` : ''}${issue.message}`)
+            .join('\n')
+      )
+    )
+  }
+
+  // Lazy import — the execution service constructs and initializes the
+  // WorkflowEngine off its constructor; that module graph must not load at
+  // import time (`project_workflow_engine_import_cycle`).
+  const { WorkflowExecutionService } = await import('../workflow-execution-service')
+
+  try {
+    const execution = await new WorkflowExecutionService(db).runSingleNode({
+      workflowAppId: params.workflowAppId,
+      workflowId: draftWorkflowId,
+      nodeId: node.id,
+      inputs: Object.entries(params.input ?? {}).map(([variableId, value]) => ({
+        variableId,
+        value,
+      })),
+      userId: params.userId,
+      organizationId: params.organizationId,
+    })
+
+    const metadata = execution.executionMetadata as
+      | { validationError?: { fields?: Array<{ field: string; message: string }> } }
+      | null
+      | undefined
+    const validationErrors = metadata?.validationError?.fields
+    return ok({
+      status: execution.status === 'succeeded' ? 'succeeded' : 'failed',
+      outputs: (execution.outputs ?? {}) as Record<string, unknown>,
+      error: execution.error ?? null,
+      elapsedTime: execution.elapsedTime ?? null,
+      ...(validationErrors && validationErrors.length > 0 ? { validationErrors } : {}),
+    })
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    const message = error instanceof Error ? error.message : String(error)
+    if (message === 'Workflow not found' || message === 'Node not found in workflow') {
+      return err(new NotFoundError(message))
+    }
+    return err(new UnprocessableEntityError(`Node run failed: ${message}`))
+  }
+}
+
+/** The node ref an issue names, if any. */
+function issueRef(issue: Issue | undefined): string | undefined {
+  return issue?.nodeRef
+}

--- a/packages/lib/src/workflows/graph-edit/turn-snapshot.ts
+++ b/packages/lib/src/workflows/graph-edit/turn-snapshot.ts
@@ -1,0 +1,166 @@
+// packages/lib/src/workflows/graph-edit/turn-snapshot.ts
+
+/**
+ * Per-turn pre-edit snapshot of the draft graph — SERVER-ONLY (Redis + the
+ * persist seam). Mirrors `kb/kopilot-snapshot.ts` (`03-graph-edit-service.md`
+ * §7): the FIRST mutation of a turn stores the pre-edit graph under
+ * `(workflowAppId, turnId)` with a 24h TTL; the turn lifecycle finalizes
+ * (discards) on success and reverts (restores the exact prior graph through
+ * `persistDraft`) on failure.
+ *
+ * One slot per workflow app — each new turn overwrites the prior turn's
+ * snapshot, and the slot naturally expires via Redis TTL. `readWorkflowTurnSnapshot`
+ * returning null for a turn id IS the "did this turn write anything" record:
+ * a turn whose mutations all rejected never captured, so there is nothing to
+ * revert. The turn id must be CHECKED, never assumed — a fresher turn's
+ * snapshot in the slot means the asking turn was superseded, and restoring it
+ * would roll the draft back past edits the asking turn never made.
+ *
+ * No permission checks live here (house rule): the capability layer asserts
+ * `assertEditInstance('workflow', workflowAppId)` +
+ * `assertWorkflowAppNotSystemOwned` before calling in.
+ */
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { deleteRedisData, getRedisData, setRedisData } from '@auxx/redis'
+import { err, type Result } from 'neverthrow'
+import { type AuxxError, NotFoundError } from '../../errors'
+import { type PersistDraftOutcome, persistDraft, publishDraftUpdatedSignal } from './persist'
+import { type GraphEditScope, loadDraftContext } from './read'
+import type { DraftGraph } from './types'
+
+const logger = createScopedLogger('workflow-turn-snapshot')
+
+const TTL_SECONDS = 24 * 60 * 60
+
+/**
+ * Pre-turn snapshot captured before a turn's first draft write. Backs the
+ * revert-on-failure path and a per-turn Undo affordance.
+ */
+export interface WorkflowPreTurnSnapshot {
+  turnId: string
+  /** The draft graph exactly as stored BEFORE the turn's first write. */
+  graph: DraftGraph
+  /** The draft row's trigger type column at capture time (persist fallback). */
+  triggerType: string | null
+  capturedAt: number
+}
+
+const snapshotKey = (workflowAppId: string): string => `workflow:graph:${workflowAppId}:preturn`
+
+/**
+ * Capture the pre-edit graph for a turn — called from the mutation pipeline
+ * BEFORE its write. Idempotent per turn: if the slot already holds THIS
+ * turn's snapshot, it is left untouched (a second mutation in the same turn
+ * must not bump the snapshot — that would defeat whole-turn revert/Undo). A
+ * snapshot from a PRIOR turn is overwritten: the new turn supersedes it.
+ *
+ * Returns whether a snapshot was written (false = same-turn no-op).
+ */
+export async function captureWorkflowTurnSnapshot(
+  workflowAppId: string,
+  turnId: string,
+  data: { graph: DraftGraph; triggerType?: string | null }
+): Promise<boolean> {
+  const existing = (await getRedisData(
+    snapshotKey(workflowAppId)
+  )) as WorkflowPreTurnSnapshot | null
+  if (existing?.turnId === turnId) return false
+
+  const snapshot: WorkflowPreTurnSnapshot = {
+    turnId,
+    graph: data.graph,
+    triggerType: data.triggerType ?? null,
+    capturedAt: Date.now(),
+  }
+  await setRedisData(snapshotKey(workflowAppId), snapshot, TTL_SECONDS)
+  return true
+}
+
+/**
+ * Read the current snapshot for a workflow app. Pass `expectedTurnId` to
+ * verify ownership — the call returns null when the stored snapshot belongs
+ * to a different (newer) turn, which is how a stale caller detects it was
+ * superseded. Null also means "this turn never wrote anything" — the two are
+ * deliberately indistinguishable; neither has anything to revert.
+ */
+export async function readWorkflowTurnSnapshot(
+  workflowAppId: string,
+  expectedTurnId?: string
+): Promise<WorkflowPreTurnSnapshot | null> {
+  const raw = (await getRedisData(snapshotKey(workflowAppId))) as WorkflowPreTurnSnapshot | null
+  if (!raw) return null
+  if (expectedTurnId && raw.turnId !== expectedTurnId) return null
+  return raw
+}
+
+/**
+ * Discard the turn's snapshot — the SUCCESS half of the turn lifecycle.
+ * Deletes only when the slot still belongs to `turnId`: a stale finalize from
+ * a prior turn must never clear a fresher turn's snapshot. Best-effort — a
+ * leftover snapshot expires via TTL, and the turn-id check in the revert path
+ * refuses it anyway.
+ */
+export async function finalizeWorkflowTurn(workflowAppId: string, turnId: string): Promise<void> {
+  try {
+    const existing = (await getRedisData(
+      snapshotKey(workflowAppId)
+    )) as WorkflowPreTurnSnapshot | null
+    if (existing?.turnId !== turnId) return
+    await deleteRedisData(snapshotKey(workflowAppId))
+  } catch (error) {
+    logger.warn('Failed to finalize workflow turn snapshot', {
+      workflowAppId,
+      turnId,
+      error: (error as Error).message,
+    })
+  }
+}
+
+/**
+ * Restore the exact pre-turn graph — the FAILURE half of the turn lifecycle.
+ * The stored snapshot must belong to `turnId`: a snapshot from a prior turn
+ * is REJECTED, never restored (restoring it would roll back edits this turn
+ * never made), and no snapshot means the turn never wrote — also nothing to
+ * revert.
+ *
+ * The restore goes through `persistDraft`, so trigger-column re-derivation,
+ * the mail-trigger guard and the hash-CAS all run: a write that landed
+ * between the failure and this revert surfaces as a `ConflictError` instead
+ * of being clobbered. On success the snapshot is discarded and the
+ * `workflow:draft-updated` signal fires (reason `system`) so open canvases
+ * refetch.
+ */
+export async function revertWorkflowTurn(
+  db: Database,
+  scope: GraphEditScope,
+  turnId: string
+): Promise<Result<PersistDraftOutcome, AuxxError>> {
+  const snapshot = await readWorkflowTurnSnapshot(scope.workflowAppId, turnId)
+  if (!snapshot) {
+    return err(
+      new NotFoundError(
+        `No snapshot for turn "${turnId}" — either the turn never wrote to the draft, ` +
+          'or a later turn superseded it. Nothing was reverted.'
+      )
+    )
+  }
+
+  const loaded = await loadDraftContext(db, scope)
+  if (loaded.isErr()) return err(loaded.error)
+
+  const persisted = await persistDraft(db, scope, {
+    graph: snapshot.graph,
+    fallbackTriggerType: snapshot.triggerType,
+    ...(loaded.value.graphHash !== undefined ? { expectedGraphHash: loaded.value.graphHash } : {}),
+  })
+  if (persisted.isErr()) return persisted
+
+  await finalizeWorkflowTurn(scope.workflowAppId, turnId)
+  await publishDraftUpdatedSignal(scope.organizationId, {
+    workflowAppId: scope.workflowAppId,
+    reason: 'system',
+  })
+  return persisted
+}


### PR DESCRIPTION
Phase 3 slice 5 (final) of the workflow graph-edit service — `plans/kopilot/workflow/03-graph-edit-service.md` §7 (remainder) + §8, wired around the `persistDraft` seam #1604 built for exactly this.

## Turn snapshot / undo lifecycle (`graph-edit/turn-snapshot.ts`)

Mirrors `kb/kopilot-snapshot.ts`, including its reasoning about why the turn id must be **checked, never assumed**:

- **Capture**: the FIRST mutation of a turn stores the pre-edit graph in Redis under `workflow:graph:<workflowAppId>:preturn` with a 24h TTL. One slot per workflow app — a new turn overwrites a prior turn's snapshot; a second mutation of the SAME turn is a no-op (bumping it would defeat whole-turn revert). Capture happens in the shared pipeline immediately before the persist, so a rejected mutation never marks the turn as having written anything — `readWorkflowTurnSnapshot(id, turnId)` returning null IS the "did this turn write" record.
- **`finalizeWorkflowTurn` (success)**: discards the snapshot, but only when the slot still belongs to that turn — a stale finalize can't clear a fresher turn's snapshot.
- **`revertWorkflowTurn` (failure)**: restores the exact pre-turn graph through `persistDraft`, so trigger-column re-derivation, `assertMailTriggerNotPersonal` and the hash-CAS all run on the restore (a write racing the revert 409s instead of being clobbered). A snapshot from a **prior turn is rejected, never restored**. On success the snapshot is consumed and the refresh signal fires with `reason: 'system'`.

## Realtime refresh signal

- `WorkflowDraftUpdatedEvent` in `realtime/events.ts`, modeled on `procedure:updated`:
  ```ts
  { event: 'workflow:draft-updated',
    data: { workflowAppId: string; nodeIds?: string[]; reason: 'kopilot' | 'system' } }
  ```
- `publishWorkflowDraftUpdated` in `publish-helpers.ts` (org channel, fire-and-forget), fired AFTER a successful persist from `runGraphMutation` and from the revert path. Signal only — clients refetch, nothing in the payload is applied. The realtime barrel is **lazy-imported** inside `publishDraftUpdatedSignal` (`persist.ts`) per `project_realtime_barrel_import_cycle`. No web/client subscriber in this PR — that's Phase 4.

## Wiring (`ops.ts`)

`GraphMutationScope extends GraphEditScope { turnId?: string }` — all 8 op inputs extend it, so `turnId` threads through with zero per-op changes and ALL snapshot/realtime wiring lives in the one shared pipeline around `persistDraft`. Non-turn callers omit `turnId`: no snapshot, `reason: 'system'`.

## Hash-CAS surfacing (`07-remaining-mechanics.md` §6)

`WorkflowService.update`'s CAS already throws `ConflictError`; the pipeline now re-surfaces it as a typed, actionable 409 — "the draft changed while this edit was being prepared … re-read the draft and retry … nothing was overwritten" — never a generic 500, never a silent overwrite (every pipeline write sends `expectedGraphHash` from the loaded draft; pinned by test).

## `runNode` (`graph-edit/run-node.ts`, §8)

Wraps the EXISTING `WorkflowExecutionService.runSingleNode` path over the **draft graph only**:

- Node must be config-valid first (tier-2 `validateNodeConfigs` scoped to the node); refused with the issues as an `UnprocessableEntityError` otherwise.
- One run per call; result **summarized** — `{ status, outputs, error, elapsedTime, validationErrors? }` — never `processData`/`executionMetadata` raw dumps.
- **No full-workflow trigger API exists here** — not gated, absent.
- Safety: single-node runs are unconditionally debug/dry runs since #1555 (`single-node-executor.ts:88-95` forces `setDebugMode(true)`); side-effecting nodes simulate. Cited in the JSDoc.
- Own file so the engine's module graph only loads at call time (lazy import); the rest of graph-edit stays importable in tests.

No permission checks in lib (house rule) — the Phase-4 capability layer applies the four guards the tRPC procedure applies today.

## Tests (18 new)

`__tests__/turn-lifecycle.test.ts` (12): first-write capture, same-turn no-overwrite, no-snapshot-on-reject/no-turnId, exact-graph revert through the seam with CAS token, prior-turn stale snapshot rejected, revert-with-nothing-written, turn-scoped finalize, event shape + ordering after persist, `reason` derivation, no event on rejected mutations, CAS token pinning, typed `ConflictError` surfacing.
`__tests__/run-node.test.ts` (6): config-invalid refusal, draft-row targeting + input mapping, summarization (raw dump excluded), failed-run validation errors, no-draft/bad-ref errors, executor-throw mapping to typed AuxxErrors.

## Verification

- `node scripts/ci/typecheck-ratchet.js --package lib` — no new type errors (29 total, baseline 29)
- `pnpm exec vitest run src/workflows src/workflow-engine src/realtime` — 80 files, 1415 tests, all passing
- `biome check --write` on touched dirs — clean
- `apps/web` untouched; no `client.ts` / package export changes