### PR TITLE
feat(kopilot): workflow-builder capability — graph tools, authoring guard, per-turn undo

### DIFF
--- a/packages/lib/src/agents/builtin-app.ts
+++ b/packages/lib/src/agents/builtin-app.ts
@@ -189,6 +189,22 @@ export const BUILTIN_TOOLSETS: ReadonlyArray<CachedAgentToolset> = [
     subGroupIconId: 'workflow',
     subGroupColor: 'indigo',
   },
+  {
+    // The Kopilot workflow-builder graph tools (`capabilities/workflow-builder/`).
+    // Builder-surface only — every tool in the set declares `surfaces: ['builder']`,
+    // so chat/email catalogs drop the whole toolset. NOT the AI node's runtime
+    // toolset (`workflow.variable` above): a runtime AI node must never inherit
+    // graph-editing tools.
+    slug: 'workflow.builder',
+    subGroup: 'Workflow',
+    name: 'Workflow — Builder',
+    shortLabel: 'Builder',
+    iconKey: 'workflow',
+    color: 'indigo',
+    isDefault: false,
+    isPopular: false,
+    description: 'Read, build, and edit the open workflow draft on the builder page.',
+  },
 ]
 
 /** Lookup helper — fast path for tag-side code that already has a slug. */

--- a/packages/lib/src/ai/kopilot/__tests__/tool-slug-coverage.test.ts
+++ b/packages/lib/src/ai/kopilot/__tests__/tool-slug-coverage.test.ts
@@ -30,6 +30,7 @@ const KNOWN_SLUGS = new Set<string>([
   'auxx:docs',
   'auxx:actors',
   'workflow.variable',
+  'workflow.builder',
 ])
 
 const ALWAYS_ON_TOOLS = new Set<string>([

--- a/packages/lib/src/ai/kopilot/capabilities/__tests__/tool-permission-declarations.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/__tests__/tool-permission-declarations.test.ts
@@ -80,6 +80,7 @@ import { createRecordViewCapabilities } from '../record-views'
 import { createCapabilityRegistry } from '../registry'
 import { createTaskCapabilities } from '../tasks'
 import { createNativeWorkflowCapabilities } from '../workflow'
+import { createWorkflowBuilderCapabilities } from '../workflow-builder'
 
 const ORG = 'org-1'
 
@@ -116,6 +117,7 @@ async function collectNativeCapabilities(): Promise<PageCapability[]> {
     createLearnedKbCapabilities(getDeps),
     createRecordViewCapabilities(getDeps),
     createNativeWorkflowCapabilities(getDeps),
+    createWorkflowBuilderCapabilities(getDeps),
     createSuggestRepliesGlobalCapability(getDeps),
     await createAgentsBuilderCapabilities(getDeps, ORG),
   ]
@@ -179,6 +181,12 @@ const NO_AUTHORIZATION_REQUIRED: readonly string[] = [
   'assign_variable',
   'suggest_replies',
   'search_docs',
+  // workflow.builder discovery — static product data (the node-type registry
+  // and the public template gallery), identical for every org. Everything that
+  // touches the workflow itself routes through `resolveWorkflowAuthoring`.
+  'list_node_types',
+  'describe_node_type',
+  'find_workflow_templates',
 ]
 
 const AREA_SLUGS = new Set<string>(Object.values(Area))

--- a/packages/lib/src/ai/kopilot/capabilities/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/index.ts
@@ -26,3 +26,8 @@ export {
   WORKFLOW_AI_NODE_PAGE,
   WORKFLOW_NATIVE_TOOLSET_SLUG,
 } from './workflow'
+export {
+  createWorkflowBuilderCapabilities,
+  WORKFLOW_BUILDER_PAGE,
+  WORKFLOW_BUILDER_TOOLSET_SLUG,
+} from './workflow-builder'

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/client.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/client.ts
@@ -1,0 +1,23 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/client.ts
+
+/**
+ * Client-safe constants for the workflow-builder Kopilot capability. NO
+ * `'use client'` directive on purpose — a directive here would turn these
+ * exports into proxy stubs for server importers (constants-only modules must
+ * stay directive-free).
+ */
+
+/**
+ * Page identifier for the workflow BUILDER surface — the docked Kopilot chat
+ * on `/app/workflows/[id]`. Deliberately distinct from `workflow.ai-node`
+ * (`capabilities/workflow/`), the toolset an AI node uses at runtime inside a
+ * run: separate directory, separate page key, so a runtime AI node can never
+ * inherit graph-editing tools.
+ */
+export const WORKFLOW_BUILDER_PAGE = 'workflow.builder'
+
+/**
+ * Toolset slug grouping the graph-editing tools. `<page>.<group>` shape,
+ * matching `workflow.variable` (the AI node's native toolset).
+ */
+export const WORKFLOW_BUILDER_TOOLSET_SLUG = 'workflow.builder'

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/index.ts
@@ -1,0 +1,142 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/index.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { findRef } from '../../context-refs'
+import { buildWorkflowBuilderPromptSection } from '../../prompts/sections/workflow-builder'
+import type { GetToolDeps, PageCapability } from '../types'
+import { WORKFLOW_BUILDER_PAGE } from './client'
+import { createAddNodeTool } from './tools/add-node'
+import { createApplyTemplateTool } from './tools/apply-template'
+import { createConnectNodesTool } from './tools/connect-nodes'
+import { createDeleteNodesTool } from './tools/delete-nodes'
+import { createDescribeNodeTypeTool } from './tools/describe-node-type'
+import { createDisconnectNodesTool } from './tools/disconnect-nodes'
+import { createFindWorkflowTemplatesTool } from './tools/find-workflow-templates'
+import { createGetNodeTool } from './tools/get-node'
+import { createGetWorkflowTool } from './tools/get-workflow'
+import { createListNodeTypesTool } from './tools/list-node-types'
+import { createReplaceGraphTool } from './tools/replace-graph'
+import { createRunNodeTool } from './tools/run-node'
+import { createSetTriggerTool } from './tools/set-trigger'
+import { createUpdateNodeTool } from './tools/update-node'
+import { createValidateWorkflowTool } from './tools/validate-workflow'
+
+export { WORKFLOW_BUILDER_PAGE, WORKFLOW_BUILDER_TOOLSET_SLUG } from './client'
+export {
+  DIRTY_CANVAS_ERROR,
+  NO_WORKFLOW_REF_ERROR,
+  resolveWorkflowAuthoring,
+  type WorkflowAuthoringTier,
+} from './tools/workflow-authoring-guard'
+
+const logger = createScopedLogger('workflow-builder-capability')
+
+/**
+ * The graph mutation tools — the "read, build, and edit" bullet is only honest
+ * while at least one of these survived runtime filtering.
+ */
+const WRITE_TOOL_NAMES = [
+  'add_node',
+  'update_node',
+  'delete_nodes',
+  'connect_nodes',
+  'disconnect_nodes',
+  'set_trigger',
+  'replace_graph',
+  'apply_template',
+]
+
+/**
+ * Page capability for the workflow builder (`plans/kopilot/workflow/04`).
+ * Mounts on `/app/workflows/[id]`; the docked chat there passes
+ * `page='workflow.builder'` and the `workflow` session ref, so every tool
+ * resolves the workflow from `findRef(ctx, 'workflow')` without taking a
+ * workflowId argument. Thin wrappers over `workflows/graph-edit/` — permission
+ * checks live HERE (`resolveWorkflowAuthoring`), never in graph-edit.
+ *
+ * No `publish`, `enable`, or `delete_workflow` tools — those stay with the
+ * user. No full-workflow execution tool exists at all (absent, not gated).
+ */
+export function createWorkflowBuilderCapabilities(getDeps: GetToolDeps): PageCapability {
+  return {
+    page: WORKFLOW_BUILDER_PAGE,
+    tools: [
+      // Discovery (progressive disclosure — the prompt carries no node list).
+      createListNodeTypesTool(getDeps),
+      createDescribeNodeTypeTool(getDeps),
+      createFindWorkflowTemplatesTool(getDeps),
+      // Read
+      createGetWorkflowTool(getDeps),
+      createGetNodeTool(getDeps),
+      // Write
+      createAddNodeTool(getDeps),
+      createUpdateNodeTool(getDeps),
+      createDeleteNodesTool(getDeps),
+      createConnectNodesTool(getDeps),
+      createDisconnectNodesTool(getDeps),
+      createSetTriggerTool(getDeps),
+      createReplaceGraphTool(getDeps),
+      createApplyTemplateTool(getDeps),
+      // Verify
+      createValidateWorkflowTool(getDeps),
+      createRunNodeTool(getDeps),
+    ],
+    systemPromptAddition: buildWorkflowBuilderPromptSection(),
+    capabilities: ({ toolNames }) =>
+      WRITE_TOOL_NAMES.some((name) => toolNames.has(name))
+        ? ['Read, build, and edit the workflow open in this builder']
+        : ['Read the workflow open in this builder'],
+    lifecycle: {
+      // A workflow turn is a turn-scoped transaction against the open draft:
+      // the first mutation captures a pre-turn snapshot in Redis
+      // (`graph-edit/turn-snapshot.ts`, inside `runGraphMutation`); turn end
+      // must keep it (completed — it backs the per-turn Undo card, KB parity)
+      // or revert (restore the pre-turn graph, guarded by `expectedTurnId`).
+      // The snapshot keyed by `(workflowAppId, turnId)` IS the "did THIS turn
+      // write" record: `readWorkflowTurnSnapshot` with the turn id returns
+      // null unless this turn wrote, which also stops a prior turn's
+      // still-pending snapshot (24h TTL) from being touched here.
+      async onTurnEnd(outcome, { turnId }) {
+        const { db, sessionContext, organizationId } = getDeps()
+        const workflowAppId = findRef(sessionContext, 'workflow')?.id
+        if (!workflowAppId) return
+        // Lazy import — turn-snapshot pulls @auxx/redis and (via the revert
+        // path) the persist seam; neither belongs in this capability's
+        // import-time graph, and the laziness keeps tests free to mock the
+        // graph-edit module wholesale.
+        const { readWorkflowTurnSnapshot, revertWorkflowTurn } = await import(
+          '../../../../workflows/graph-edit/turn-snapshot'
+        )
+        const snapshot = await readWorkflowTurnSnapshot(workflowAppId, turnId)
+        if (!snapshot) return
+        try {
+          if (outcome === 'completed') {
+            // Deliberately NOT `finalizeWorkflowTurn` (a discard): the snapshot
+            // is KEPT so the Undo card can call `revertWorkflowTurn` after a
+            // successful turn. Cleanup = next turn's capture, the TTL, or a
+            // manual canvas save clearing it (`clearWorkflowTurnSnapshot`).
+            return
+          }
+          // `expectedTurnId` (the third argument) is load-bearing: it rejects
+          // a stale prior-turn snapshot so a later failed turn can never roll
+          // back a workflow it didn't touch.
+          const reverted = await revertWorkflowTurn(db, { workflowAppId, organizationId }, turnId)
+          if (reverted.isErr()) {
+            logger.error('Kopilot workflow turn revert failed', {
+              workflowAppId,
+              turnId,
+              error: reverted.error.message,
+            })
+          }
+        } catch (err) {
+          logger.error('Kopilot turn-end workflow lifecycle failed', {
+            workflowAppId,
+            turnId,
+            outcome,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
+      },
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/lifecycle.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/lifecycle.test.ts
@@ -1,0 +1,94 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/lifecycle.test.ts
+//
+// Turn-end lifecycle (04 §4, reconciled against KB's actual Undo semantics):
+// a COMPLETED turn KEEPS its snapshot — that is what makes the per-turn Undo
+// card (`revertWorkflowTurn`) work after success — while a failed turn reverts,
+// guarded by `expectedTurnId` so a later failed turn can never roll back a
+// workflow it didn't touch.
+
+import { err, ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NotFoundError } from '../../../../../../errors'
+import type { GetToolDeps, ToolDeps } from '../../../types'
+
+const readWorkflowTurnSnapshot = vi.fn()
+const revertWorkflowTurn = vi.fn()
+const finalizeWorkflowTurn = vi.fn()
+vi.mock('../../../../../../workflows/graph-edit/turn-snapshot', () => ({
+  readWorkflowTurnSnapshot: (...a: unknown[]) => readWorkflowTurnSnapshot(...a),
+  revertWorkflowTurn: (...a: unknown[]) => revertWorkflowTurn(...a),
+  finalizeWorkflowTurn: (...a: unknown[]) => finalizeWorkflowTurn(...a),
+}))
+
+import { createWorkflowBuilderCapabilities } from '../../index'
+
+const ORG = 'org-1'
+const WF = 'wfapp-1'
+const TURN = 'turn-1'
+
+let refs: Array<Record<string, unknown>> = [{ kind: 'workflow', id: WF }]
+const db = { tag: 'db' }
+
+const getDeps: GetToolDeps = () =>
+  ({
+    db,
+    sessionContext: { page: 'workflow.builder', references: refs },
+    organizationId: ORG,
+    userId: 'member-1',
+    sessionId: 's-1',
+    capabilities: undefined,
+  }) as unknown as ToolDeps
+
+function lifecycle() {
+  const capability = createWorkflowBuilderCapabilities(getDeps)
+  if (!capability.lifecycle?.onTurnEnd) throw new Error('lifecycle missing')
+  return capability.lifecycle.onTurnEnd.bind(capability.lifecycle)
+}
+
+beforeEach(() => {
+  refs = [{ kind: 'workflow', id: WF }]
+  readWorkflowTurnSnapshot
+    .mockReset()
+    .mockResolvedValue({ turnId: TURN, graph: { nodes: [], edges: [] }, capturedAt: 1 })
+  revertWorkflowTurn.mockReset().mockResolvedValue(ok({ graphHash: 'h' }))
+  finalizeWorkflowTurn.mockReset().mockResolvedValue(undefined)
+})
+
+describe('workflow.builder onTurnEnd', () => {
+  it('completed ⇒ the snapshot is KEPT for Undo — neither reverted nor finalized (discarded)', async () => {
+    await lifecycle()('completed', { turnId: TURN })
+    expect(readWorkflowTurnSnapshot).toHaveBeenCalledWith(WF, TURN)
+    expect(revertWorkflowTurn).not.toHaveBeenCalled()
+    expect(finalizeWorkflowTurn).not.toHaveBeenCalled()
+  })
+
+  it('error ⇒ reverts, threading the turn id as expectedTurnId', async () => {
+    await lifecycle()('error', { turnId: TURN })
+    expect(revertWorkflowTurn).toHaveBeenCalledTimes(1)
+    expect(revertWorkflowTurn).toHaveBeenCalledWith(
+      db,
+      { workflowAppId: WF, organizationId: ORG },
+      TURN
+    )
+  })
+
+  it('error on a turn that never wrote (or was superseded) ⇒ nothing reverted', async () => {
+    // The turn-checked read returning null IS the "did this turn write" record —
+    // a stale prior-turn snapshot answers null for this turn id too.
+    readWorkflowTurnSnapshot.mockResolvedValue(null)
+    await lifecycle()('error', { turnId: 'turn-2' })
+    expect(readWorkflowTurnSnapshot).toHaveBeenCalledWith(WF, 'turn-2')
+    expect(revertWorkflowTurn).not.toHaveBeenCalled()
+  })
+
+  it('a failed revert is swallowed and logged — turn end must not throw', async () => {
+    revertWorkflowTurn.mockResolvedValue(err(new NotFoundError('superseded')))
+    await expect(lifecycle()('error', { turnId: TURN })).resolves.toBeUndefined()
+  })
+
+  it('no workflow ref ⇒ no snapshot read at all', async () => {
+    refs = []
+    await lifecycle()('completed', { turnId: TURN })
+    expect(readWorkflowTurnSnapshot).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
@@ -1,0 +1,367 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
+//
+// Security property, asserted by ENUMERATING the registered `workflow.builder`
+// capability set (the agents-builder pattern): every tool that touches the
+// workflow routes through `resolveWorkflowAuthoring` before it does anything
+// else — fail-closed on absent capabilities, area rung, org scope, per-workflow
+// instance rung, system-owned lockdown, and (for mutations) the dirty gate.
+//
+// The args passed on denial cases are deliberately empty/garbage: the guard
+// must run BEFORE argument validation, so a denial must surface even for a
+// call the tool would otherwise reject on shape.
+
+import { err, ok, type Result } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { type AuxxError, BadRequestError, ForbiddenError } from '../../../../../../errors'
+import type { GraphMutationResult } from '../../../../../../workflows/graph-edit/types'
+import type { AgentToolDefinition, AgentToolResult } from '../../../../../agent-framework/types'
+import type { GetToolDeps, ToolDeps } from '../../../types'
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const assertNotSystemOwned = vi.fn(async (..._args: unknown[]) => {})
+vi.mock('../../../../../../workflows/workflow-app-access-guard', () => ({
+  assertWorkflowAppNotSystemOwned: (...args: unknown[]) => assertNotSystemOwned(...args),
+}))
+
+const APPLIED: GraphMutationResult = {
+  applied: true,
+  node: {
+    ref: 'Wait A Bit',
+    id: 'wait-1',
+    type: 'wait',
+    title: 'Wait A Bit',
+    position: { x: 10, y: 20 },
+    config: { waitFor: '10m' },
+  },
+  outputs: [{ id: 'Wait A Bit.done', label: 'Done', type: 'boolean' }] as never,
+  issues: [],
+  graphSummary: { nodeCount: 2, edgeCount: 1, nodes: [], edges: [], triggerType: 'manual' },
+}
+
+const opMock = vi.fn(
+  async (..._args: unknown[]): Promise<Result<GraphMutationResult, AuxxError>> => ok(APPLIED)
+)
+const readDraftMock = vi.fn(async (..._args: unknown[]) =>
+  ok({
+    workflowAppId: 'wfapp-1',
+    name: 'My Flow',
+    triggerType: 'manual',
+    nodes: [],
+    edges: [],
+    outputs: {},
+    issues: [],
+    graphSummary: { nodeCount: 0, edgeCount: 0, nodes: [], edges: [], triggerType: 'manual' },
+  })
+)
+vi.mock('../../../../../../workflows/graph-edit', () => ({
+  addNode: (...a: unknown[]) => opMock(...a),
+  updateNode: (...a: unknown[]) => opMock(...a),
+  deleteNodes: (...a: unknown[]) => opMock(...a),
+  connectNodes: (...a: unknown[]) => opMock(...a),
+  disconnectNodes: (...a: unknown[]) => opMock(...a),
+  setTrigger: (...a: unknown[]) => opMock(...a),
+  replaceGraph: (...a: unknown[]) => opMock(...a),
+  applyTemplate: (...a: unknown[]) => opMock(...a),
+  readDraft: (...a: unknown[]) => readDraftMock(...a),
+  validateWorkflow: vi.fn(async () =>
+    ok({ publishable: true, publishErrors: [], publishWarnings: [], issues: [] })
+  ),
+}))
+
+const runNodeMock = vi.fn(async (..._args: unknown[]) =>
+  ok({ status: 'succeeded' as const, outputs: { done: true }, error: null, elapsedTime: 0.1 })
+)
+vi.mock('../../../../../../workflows/graph-edit/run-node', () => ({
+  runNode: (...a: unknown[]) => runNodeMock(...a),
+}))
+
+vi.mock('../../../../../../workflows/graph-edit/turn-snapshot', () => ({
+  readWorkflowTurnSnapshot: vi.fn(async () => null),
+  revertWorkflowTurn: vi.fn(async () => ok({ graphHash: 'h' })),
+}))
+
+vi.mock('../../../../../../demo', () => ({
+  DemoGuard: { requireNotDemo: vi.fn(async () => {}) },
+}))
+
+vi.mock('@auxx/services/workflow-templates', () => ({
+  getAllTemplates: vi.fn(async () => ok([])),
+}))
+
+import { createWorkflowBuilderCapabilities } from '../../index'
+import { DIRTY_CANVAS_ERROR, NO_WORKFLOW_REF_ERROR } from '../workflow-authoring-guard'
+
+// ── Fixture ──────────────────────────────────────────────────────────────────
+
+const ORG = 'org-1'
+const WF = 'wfapp-1'
+
+type CapsStub = {
+  can: ReturnType<typeof vi.fn>
+  canViewInstance: ReturnType<typeof vi.fn>
+  assertEditInstance: ReturnType<typeof vi.fn>
+}
+
+function makeCaps(): CapsStub {
+  return {
+    can: vi.fn(() => true),
+    canViewInstance: vi.fn(() => true),
+    assertEditInstance: vi.fn(() => {}),
+  }
+}
+
+/** Rows the guard's org-scope select resolves. */
+let appRows: Array<{ id: string }> = [{ id: WF }]
+const db = {
+  select: () => ({
+    from: () => ({ where: () => ({ limit: async () => appRows }) }),
+  }),
+}
+
+let caps: CapsStub | undefined
+let refs: Array<Record<string, unknown>> = [{ kind: 'workflow', id: WF }]
+
+const getDeps: GetToolDeps = () =>
+  ({
+    db,
+    sessionContext: { page: 'workflow.builder', references: refs },
+    organizationId: ORG,
+    userId: 'member-1',
+    sessionId: 's-1',
+    capabilities: caps,
+  }) as unknown as ToolDeps
+
+const agentDeps = {
+  organizationId: ORG,
+  userId: 'member-1',
+  sessionId: 's-1',
+  turnId: 'turn-1',
+} as Parameters<AgentToolDefinition['execute']>[1]
+
+function tools(): AgentToolDefinition[] {
+  return createWorkflowBuilderCapabilities(getDeps).tools
+}
+
+function tool(name: string): AgentToolDefinition {
+  const found = tools().find((t) => t.name === name)
+  if (!found) throw new Error(`tool ${name} not registered`)
+  return found
+}
+
+/** Minimal shape-valid args so success-path tests get past arg validation. */
+const VALID_ARGS: Record<string, Record<string, unknown>> = {
+  get_workflow: {},
+  get_node: { ref: 'Wait A Bit' },
+  validate_workflow: {},
+  add_node: { type: 'wait' },
+  update_node: { ref: 'Wait A Bit', config: { waitFor: '5m' } },
+  delete_nodes: { refs: ['Wait A Bit'] },
+  connect_nodes: { from: 'A', to: 'B' },
+  disconnect_nodes: { from: 'A', to: 'B' },
+  set_trigger: { triggerType: 'manual' },
+  replace_graph: { nodes: [{ type: 'wait' }], edges: [] },
+  apply_template: { templateId: 'file:x' },
+  run_node: { ref: 'Wait A Bit' },
+}
+
+function run(t: AgentToolDefinition, args: Record<string, unknown> = {}): Promise<AgentToolResult> {
+  return t.execute(args as never, agentDeps) as Promise<AgentToolResult>
+}
+
+const MUTATION_TOOLS = [
+  'add_node',
+  'update_node',
+  'delete_nodes',
+  'connect_nodes',
+  'disconnect_nodes',
+  'set_trigger',
+  'replace_graph',
+  'apply_template',
+] as const
+const VIEW_TOOLS = ['get_workflow', 'get_node', 'validate_workflow'] as const
+const GUARDED = [...VIEW_TOOLS, ...MUTATION_TOOLS, 'run_node'] as const
+const DISCOVERY = ['list_node_types', 'describe_node_type', 'find_workflow_templates'] as const
+
+beforeEach(() => {
+  caps = makeCaps()
+  refs = [{ kind: 'workflow', id: WF }]
+  appRows = [{ id: WF }]
+  assertNotSystemOwned.mockReset().mockResolvedValue(undefined)
+  opMock.mockClear()
+  readDraftMock.mockClear()
+  runNodeMock.mockClear()
+})
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('workflow.builder tool registry', () => {
+  it('registers exactly the specced tool set — no publish/enable/delete_workflow, no run-workflow', () => {
+    const names = tools().map((t) => t.name)
+    expect(names.sort()).toEqual([...GUARDED, ...DISCOVERY].sort())
+    for (const forbidden of [
+      'publish_workflow',
+      'enable_workflow',
+      'delete_workflow',
+      'run_workflow',
+    ]) {
+      expect(names).not.toContain(forbidden)
+    }
+  })
+
+  it('every tool is builder-surface only and carries the toolset slug', () => {
+    for (const t of tools()) {
+      expect(t.surfaces, t.name).toEqual(['builder'])
+      expect(t.toolsetSlug, t.name).toBe('workflow.builder')
+      expect(t.permission, t.name).toBeDefined()
+    }
+  })
+
+  it('run_node requires approval', () => {
+    expect(tool('run_node').requiresApproval).toBe(true)
+  })
+})
+
+describe('workflow.builder authorization enumeration', () => {
+  it('every guarded tool refuses without a workflow ref (bad context, not a throw)', async () => {
+    refs = []
+    for (const name of GUARDED) {
+      const result = await run(tool(name))
+      expect(result.success, name).toBe(false)
+      expect(result.error, name).toBe(NO_WORKFLOW_REF_ERROR)
+    }
+    expect(opMock).not.toHaveBeenCalled()
+  })
+
+  it('FAIL CLOSED: every guarded tool throws ForbiddenError when capabilities are absent', async () => {
+    caps = undefined
+    for (const name of GUARDED) {
+      await expect(run(tool(name)), name).rejects.toThrow(ForbiddenError)
+    }
+    expect(opMock).not.toHaveBeenCalled()
+  })
+
+  it('every guarded tool throws ForbiddenError without the workflows area rung', async () => {
+    caps!.can.mockReturnValue(false)
+    for (const name of GUARDED) {
+      await expect(run(tool(name)), name).rejects.toThrow(ForbiddenError)
+    }
+    expect(opMock).not.toHaveBeenCalled()
+  })
+
+  it('a crafted foreign-org ref reads as "not in this workspace" — silent for reads, thrown for writes', async () => {
+    appRows = [] // the org-scoped select finds nothing
+    for (const name of VIEW_TOOLS) {
+      const result = await run(tool(name), VALID_ARGS[name])
+      expect(result.success, name).toBe(false)
+      expect(result.error, name).toMatch(/not found in this workspace/i)
+    }
+    for (const name of [...MUTATION_TOOLS, 'run_node']) {
+      await expect(run(tool(name), VALID_ARGS[name]), name).rejects.toThrow(ForbiddenError)
+    }
+    expect(opMock).not.toHaveBeenCalled()
+    expect(runNodeMock).not.toHaveBeenCalled()
+  })
+
+  it('per-workflow instance rung: reads filter silently, writes throw', async () => {
+    caps!.canViewInstance.mockReturnValue(false)
+    const read = await run(tool('get_workflow'))
+    expect(read.success).toBe(false)
+    expect(read.error).toMatch(/not found/i)
+
+    caps!.assertEditInstance.mockImplementation(() => {
+      throw new ForbiddenError('nope')
+    })
+    await expect(run(tool('add_node'), VALID_ARGS.add_node)).rejects.toThrow(ForbiddenError)
+    expect(caps!.assertEditInstance).toHaveBeenCalledWith('workflow', WF)
+  })
+
+  it('system-owned workflows stay blind on reads and forbidden on writes', async () => {
+    assertNotSystemOwned.mockRejectedValue(new ForbiddenError('system-owned'))
+    const read = await run(tool('get_workflow'))
+    expect(read.success).toBe(false)
+    expect(read.error).toMatch(/not found/i)
+    await expect(run(tool('add_node'), VALID_ARGS.add_node)).rejects.toThrow(ForbiddenError)
+  })
+})
+
+describe('dirty gate', () => {
+  it('every mutation refuses while the chip reports unsaved canvas changes', async () => {
+    refs = [{ kind: 'workflow', id: WF, isDirty: true }]
+    for (const name of MUTATION_TOOLS) {
+      const result = await run(tool(name), VALID_ARGS[name])
+      expect(result.success, name).toBe(false)
+      expect(result.error, name).toBe(DIRTY_CANVAS_ERROR)
+    }
+    expect(opMock).not.toHaveBeenCalled()
+  })
+
+  it('reads and run_node still work while dirty', async () => {
+    refs = [{ kind: 'workflow', id: WF, isDirty: true }]
+    expect((await run(tool('get_workflow'))).success).toBe(true)
+    expect((await run(tool('run_node'), VALID_ARGS.run_node)).success).toBe(true)
+  })
+
+  it('tolerates the flag being absent — mutations proceed', async () => {
+    refs = [{ kind: 'workflow', id: WF }]
+    const result = await run(tool('add_node'), VALID_ARGS.add_node)
+    expect(result.success).toBe(true)
+    expect(opMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('turn scoping', () => {
+  it('a mutation without a turnId is refused — no snapshot means no Undo', async () => {
+    const noTurn = { ...agentDeps, turnId: undefined } as typeof agentDeps
+    const result = (await tool('add_node').execute(
+      VALID_ARGS.add_node as never,
+      noTurn
+    )) as AgentToolResult
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/turnId/)
+    expect(opMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('discovery tools', () => {
+  it('list_node_types works without any workflow context and flags authorable types', async () => {
+    refs = []
+    caps = undefined
+    const result = await run(tool('list_node_types'))
+    expect(result.success).toBe(true)
+    const types = (result.output as { types: Array<{ type: string; authorable: boolean }> }).types
+    expect(types.length).toBeGreaterThan(10)
+    expect(types.every((t) => typeof t.authorable === 'boolean')).toBe(true)
+  })
+
+  it('describe_node_type returns the agent-facing schema and connection rules', async () => {
+    const result = await run(tool('describe_node_type'), { type: 'wait' })
+    expect(result.success).toBe(true)
+    const out = result.output as Record<string, unknown>
+    expect(out.type).toBe('wait')
+    expect(out.configSchema).toBeTruthy()
+    expect(out.connection).toBeTruthy()
+  })
+
+  it('describe_node_type refuses an unknown type honestly, naming it', async () => {
+    const result = await run(tool('describe_node_type'), { type: 'quantum-blockchain' })
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('quantum-blockchain')
+  })
+})
+
+describe('non-authorable / unknown types surface graph-edit’s honest refusal verbatim', () => {
+  it('add_node passes the authorable-set error through, never substituting a type', async () => {
+    opMock.mockResolvedValueOnce(
+      err(
+        new BadRequestError(
+          'Node type "webhook-endpoint" cannot be authored here. Authorable types: ai, wait.'
+        )
+      )
+    )
+    const result = await run(tool('add_node'), { type: 'webhook-endpoint' })
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('webhook-endpoint')
+    expect(result.error).toContain('Authorable types')
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/write-tools.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/write-tools.test.ts
@@ -1,0 +1,219 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/write-tools.test.ts
+//
+// The write-tool contract (D12): every mutation threads the Kopilot `turnId`
+// into the graph-edit scope (the snapshot lifecycle keys on it), returns the
+// touched node with `{{Title.path}}`-rendered outputs and issues (coordinates
+// stripped), surfaces blocked edits and CAS conflicts as actionable tool
+// errors, and `run_node` says loudly that the run was simulated.
+
+import { err, ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ConflictError } from '../../../../../../errors'
+import type { GraphMutationResult } from '../../../../../../workflows/graph-edit/types'
+import type { AgentToolDefinition, AgentToolResult } from '../../../../../agent-framework/types'
+import type { GetToolDeps, ToolDeps } from '../../../types'
+
+const assertNotSystemOwned = vi.fn(async (..._args: unknown[]) => {})
+vi.mock('../../../../../../workflows/workflow-app-access-guard', () => ({
+  assertWorkflowAppNotSystemOwned: (...args: unknown[]) => assertNotSystemOwned(...args),
+}))
+
+const addNodeMock = vi.fn()
+const connectNodesMock = vi.fn()
+vi.mock('../../../../../../workflows/graph-edit', () => ({
+  addNode: (...a: unknown[]) => addNodeMock(...a),
+  connectNodes: (...a: unknown[]) => connectNodesMock(...a),
+}))
+
+const runNodeMock = vi.fn()
+vi.mock('../../../../../../workflows/graph-edit/run-node', () => ({
+  runNode: (...a: unknown[]) => runNodeMock(...a),
+}))
+
+const requireNotDemo = vi.fn(async (..._args: unknown[]) => {})
+vi.mock('../../../../../../demo', () => ({
+  DemoGuard: { requireNotDemo: (...a: unknown[]) => requireNotDemo(...a) },
+}))
+
+import { createAddNodeTool } from '../add-node'
+import { createConnectNodesTool } from '../connect-nodes'
+import { createRunNodeTool } from '../run-node'
+
+const ORG = 'org-1'
+const WF = 'wfapp-1'
+const TURN = 'turn-42'
+
+const db = {
+  select: () => ({ from: () => ({ where: () => ({ limit: async () => [{ id: WF }] }) }) }),
+}
+
+const getDeps: GetToolDeps = () =>
+  ({
+    db,
+    sessionContext: {
+      page: 'workflow.builder',
+      references: [{ kind: 'workflow', id: WF }],
+    },
+    organizationId: ORG,
+    userId: 'member-1',
+    sessionId: 's-1',
+    capabilities: {
+      can: () => true,
+      canViewInstance: () => true,
+      assertEditInstance: () => {},
+    },
+  }) as unknown as ToolDeps
+
+const agentDeps = {
+  organizationId: ORG,
+  userId: 'member-1',
+  sessionId: 's-1',
+  turnId: TURN,
+} as Parameters<AgentToolDefinition['execute']>[1]
+
+const APPLIED: GraphMutationResult = {
+  applied: true,
+  node: {
+    ref: 'HTTP Request',
+    id: 'http-abc',
+    type: 'http',
+    title: 'HTTP Request',
+    position: { x: 500, y: 250 },
+    config: { url: 'https://example.com', method: 'POST' },
+  },
+  outputs: [
+    { id: 'HTTP Request.response.body', label: 'Response body', type: 'object' },
+    { id: 'HTTP Request.response.status', label: 'Status', type: 'number' },
+  ] as never,
+  issues: [{ severity: 'warning', message: 'No trigger yet' }],
+  graphSummary: { nodeCount: 3, edgeCount: 2, nodes: [], edges: [], triggerType: null },
+}
+
+beforeEach(() => {
+  assertNotSystemOwned.mockReset().mockResolvedValue(undefined)
+  addNodeMock.mockReset().mockResolvedValue(ok(APPLIED))
+  connectNodesMock.mockReset().mockResolvedValue(ok(APPLIED))
+  runNodeMock
+    .mockReset()
+    .mockResolvedValue(
+      ok({ status: 'succeeded', outputs: { body: '{}' }, error: null, elapsedTime: 0.4 })
+    )
+  requireNotDemo.mockClear()
+})
+
+function run(t: AgentToolDefinition, args: Record<string, unknown>): Promise<AgentToolResult> {
+  return t.execute(args as never, agentDeps) as Promise<AgentToolResult>
+}
+
+describe('add_node', () => {
+  it('threads the turnId + scope into graph-edit and returns {{Title.path}} outputs, no coordinates', async () => {
+    const result = await run(createAddNodeTool(getDeps), {
+      type: 'http',
+      title: 'HTTP Request',
+      after: 'Every Morning',
+      config: { url: 'https://example.com' },
+    })
+    expect(result.success).toBe(true)
+
+    // The scope carries the snapshot lifecycle's turn id — non-negotiable.
+    const input = addNodeMock.mock.calls[0]?.[1] as Record<string, unknown>
+    expect(input).toMatchObject({
+      workflowAppId: WF,
+      organizationId: ORG,
+      turnId: TURN,
+      type: 'http',
+      title: 'HTTP Request',
+      after: 'Every Morning',
+    })
+
+    const output = result.output as {
+      summary: string
+      node: Record<string, unknown>
+      outputs: Array<{ ref: string }>
+      issues: unknown[]
+    }
+    expect(output.summary).toBe('Added HTTP Request')
+    // graph-edit already rendered refs friendly — the tool wraps, never re-renders.
+    expect(output.outputs.map((o) => o.ref)).toEqual([
+      '{{HTTP Request.response.body}}',
+      '{{HTTP Request.response.status}}',
+    ])
+    expect(output.node).not.toHaveProperty('position')
+    expect(output.issues).toHaveLength(1)
+  })
+
+  it('digest carries the completed-action label', async () => {
+    const tool = createAddNodeTool(getDeps)
+    const result = await run(tool, { type: 'http' })
+    const digest = tool.buildDigest?.(result.output) as { label: string; nodeCount?: number }
+    expect(digest.label).toBe('Added HTTP Request')
+    expect(digest.nodeCount).toBe(3)
+  })
+
+  it('a blocked edit comes back as a tool error listing the blocking issues, draft untouched', async () => {
+    addNodeMock.mockResolvedValue(
+      ok({
+        applied: false,
+        issues: [{ severity: 'error', nodeRef: 'HTTP Request', message: 'url is not valid' }],
+        graphSummary: { nodeCount: 2, edgeCount: 1, nodes: [], edges: [], triggerType: null },
+      } satisfies GraphMutationResult)
+    )
+    const result = await run(createAddNodeTool(getDeps), { type: 'http' })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/NOT applied/)
+    expect(result.error).toContain('url is not valid')
+    expect((result.output as { applied: boolean }).applied).toBe(false)
+  })
+
+  it('a CAS conflict surfaces graph-edit’s actionable retry message', async () => {
+    addNodeMock.mockResolvedValue(
+      err(new ConflictError('The workflow draft changed — re-read the draft and retry.'))
+    )
+    const result = await run(createAddNodeTool(getDeps), { type: 'http' })
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/re-read/i)
+  })
+})
+
+describe('connect_nodes', () => {
+  it('summarizes as "Connected A → B [branch]"', async () => {
+    const result = await run(createConnectNodesTool(getDeps), {
+      from: 'Find Contact',
+      to: 'Send Email',
+      branch: 'Found',
+    })
+    expect(result.success).toBe(true)
+    expect((result.output as { summary: string }).summary).toBe(
+      'Connected Find Contact → Send Email [Found]'
+    )
+    expect(connectNodesMock.mock.calls[0]?.[1]).toMatchObject({
+      from: 'Find Contact',
+      to: 'Send Email',
+      branch: 'Found',
+      turnId: TURN,
+    })
+  })
+})
+
+describe('run_node', () => {
+  it('is approval-gated, demo-blocked, and SAYS the run is simulated', async () => {
+    const tool = createRunNodeTool(getDeps)
+    expect(tool.requiresApproval).toBe(true)
+
+    const result = await run(tool, { ref: 'Send Email', input: { 'Find Contact.email': 'a@b.co' } })
+    expect(requireNotDemo).toHaveBeenCalledWith(ORG, 'run workflow nodes', false)
+    expect(result.success).toBe(true)
+    const output = result.output as { simulated: boolean; note: string; status: string }
+    expect(output.simulated).toBe(true)
+    expect(output.note).toMatch(/SIMULATED/i)
+    expect(output.status).toBe('succeeded')
+
+    expect(runNodeMock.mock.calls[0]?.[1]).toMatchObject({
+      workflowAppId: WF,
+      organizationId: ORG,
+      nodeId: 'Send Email',
+      userId: 'member-1',
+      input: { 'Find Contact.email': 'a@b.co' },
+    })
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/add-node.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/add-node.ts
@@ -1,0 +1,71 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/add-node.ts
+
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import { buildWorkflowEditDigest } from '../../../digests'
+import type { GetToolDeps } from '../../types'
+import {
+  digestLabelFromOutput,
+  mutationToToolResult,
+  workflowToolPermission,
+} from './graph-tool-helpers'
+import { optionalRecord, optionalString, resolveWorkflowWrite } from './write-tool-helpers'
+
+/**
+ * Add one node to the open workflow's draft. Thin wrapper over graph-edit
+ * `addNode` — placement, branch resolution, containment, normalization and
+ * validation all live there. Non-authorable types are refused by graph-edit
+ * with an honest error naming the type and the authorable set.
+ */
+export function createAddNodeTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'add_node',
+    permission: workflowToolPermission('edit'),
+    displayName: 'Add workflow node',
+    toolsetSlug: 'workflow.builder',
+    surfaces: ['builder'],
+    description:
+      'Add one node to the open workflow draft. Connect it with `after` (predecessor title) and optionally `branch` (branch NAME of the predecessor); place it inside a loop with `inside` (loop title). Do not send coordinates — layout is automatic. The result returns the node, its resolved outputs (wire `{{Title.path}}` refs from these), and any issues.',
+    parameters: {
+      type: 'object',
+      properties: {
+        type: { type: 'string', description: "Authorable node type (e.g. 'http', 'find')." },
+        title: { type: 'string', description: 'Node title — unique, human-readable.' },
+        config: {
+          type: 'object',
+          description:
+            'Friendly config per describe_node_type — `{{Title.path}}` refs, resource slugs, plain prompts.',
+        },
+        after: { type: 'string', description: 'Predecessor node (title) to connect from.' },
+        branch: { type: 'string', description: 'Branch NAME of `after` to leave on.' },
+        inside: { type: 'string', description: 'Loop node (title) to place this node inside.' },
+      },
+      required: ['type'],
+      additionalProperties: false,
+    },
+    summary: (args) => `Add node: ${typeof args.type === 'string' ? args.type : 'node'}`,
+    buildDigest: (output) =>
+      buildWorkflowEditDigest(digestLabelFromOutput(output, 'Added node'), output),
+    execute: async (args, agentDeps) => {
+      const write = await resolveWorkflowWrite(getDeps, agentDeps)
+      if (!write.ok) return { success: false, output: null, error: write.error }
+      const type = typeof args.type === 'string' ? args.type : ''
+      if (!type) return { success: false, output: null, error: 'type is required.' }
+
+      const { db } = getDeps()
+      // Lazy import — see get-workflow.ts.
+      const { addNode } = await import('../../../../../workflows/graph-edit')
+      const result = await addNode(db, {
+        ...write.scope,
+        type,
+        ...(optionalString(args.title) ? { title: optionalString(args.title) } : {}),
+        ...(optionalRecord(args.config) ? { config: optionalRecord(args.config) } : {}),
+        ...(optionalString(args.after) ? { after: optionalString(args.after) } : {}),
+        ...(optionalString(args.branch) ? { branch: optionalString(args.branch) } : {}),
+        ...(optionalString(args.inside) ? { inside: optionalString(args.inside) } : {}),
+      })
+      return mutationToToolResult(result, (value) =>
+        value.applied ? `Added ${value.node?.title ?? type}` : `Add ${type} blocked`
+      )
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/apply-template.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/apply-template.ts
@@ -1,0 +1,63 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/apply-template.ts
+
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import { buildWorkflowEditDigest } from '../../../digests'
+import type { GetToolDeps } from '../../types'
+import {
+  digestLabelFromOutput,
+  mutationToToolResult,
+  workflowToolPermission,
+} from './graph-tool-helpers'
+import { resolveWorkflowWrite } from './write-tool-helpers'
+
+/**
+ * Install a curated template into an EMPTY draft — the same
+ * create-from-template path the router uses (fresh node ids, refs rewritten,
+ * org-resolved slugs, derived trigger columns).
+ */
+export function createApplyTemplateTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'apply_template',
+    permission: workflowToolPermission('edit'),
+    displayName: 'Apply workflow template',
+    toolsetSlug: 'workflow.builder',
+    surfaces: ['builder'],
+    description:
+      'Install a workflow template into the open EMPTY draft (it refuses when nodes exist). Find template ids with find_workflow_templates — never invent one. Curated templates may contain node types you cannot author; those install fine but stay read-only to you.',
+    parameters: {
+      type: 'object',
+      properties: {
+        templateId: {
+          type: 'string',
+          description: 'Template id from find_workflow_templates.',
+        },
+      },
+      required: ['templateId'],
+      additionalProperties: false,
+    },
+    summary: (args) =>
+      `Apply template ${typeof args.templateId === 'string' ? args.templateId : ''}`,
+    buildDigest: (output) =>
+      buildWorkflowEditDigest(digestLabelFromOutput(output, 'Applied template'), output),
+    execute: async (args, agentDeps) => {
+      const write = await resolveWorkflowWrite(getDeps, agentDeps)
+      if (!write.ok) return { success: false, output: null, error: write.error }
+      const templateId = typeof args.templateId === 'string' ? args.templateId.trim() : ''
+      if (!templateId) return { success: false, output: null, error: 'templateId is required.' }
+
+      const { db } = getDeps()
+      // Lazy import — see get-workflow.ts.
+      const { applyTemplate } = await import('../../../../../workflows/graph-edit')
+      const result = await applyTemplate(db, {
+        ...write.scope,
+        templateId,
+        userId: agentDeps.userId,
+      })
+      return mutationToToolResult(result, (value) =>
+        value.applied
+          ? `Applied template (${value.graphSummary.nodeCount} nodes)`
+          : 'Apply template blocked'
+      )
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/connect-nodes.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/connect-nodes.ts
@@ -1,0 +1,60 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/connect-nodes.ts
+
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import { buildWorkflowEditDigest } from '../../../digests'
+import type { GetToolDeps } from '../../types'
+import {
+  digestLabelFromOutput,
+  mutationToToolResult,
+  workflowToolPermission,
+} from './graph-tool-helpers'
+import { optionalString, resolveWorkflowWrite } from './write-tool-helpers'
+
+/** Connect two nodes — branch handles resolved by NAME through the manifest. */
+export function createConnectNodesTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'connect_nodes',
+    permission: workflowToolPermission('edit'),
+    displayName: 'Connect workflow nodes',
+    toolsetSlug: 'workflow.builder',
+    surfaces: ['builder'],
+    description:
+      'Connect two nodes of the open workflow draft. For a branching source (if-else etc.), pass the branch NAME. Connecting a loop child back to its own loop wires the loop-back edge automatically.',
+    parameters: {
+      type: 'object',
+      properties: {
+        from: { type: 'string', description: 'Source node title.' },
+        to: { type: 'string', description: 'Target node title.' },
+        branch: { type: 'string', description: 'Branch NAME of `from` to leave on.' },
+      },
+      required: ['from', 'to'],
+      additionalProperties: false,
+    },
+    summary: (args) => `Connect ${args.from ?? ''} → ${args.to ?? ''}`,
+    buildDigest: (output) =>
+      buildWorkflowEditDigest(digestLabelFromOutput(output, 'Connected nodes'), output),
+    execute: async (args, agentDeps) => {
+      const write = await resolveWorkflowWrite(getDeps, agentDeps)
+      if (!write.ok) return { success: false, output: null, error: write.error }
+      const from = typeof args.from === 'string' ? args.from.trim() : ''
+      const to = typeof args.to === 'string' ? args.to.trim() : ''
+      if (!from || !to) return { success: false, output: null, error: 'from and to are required.' }
+
+      const branch = optionalString(args.branch)
+      const { db } = getDeps()
+      // Lazy import — see get-workflow.ts.
+      const { connectNodes } = await import('../../../../../workflows/graph-edit')
+      const result = await connectNodes(db, {
+        ...write.scope,
+        from,
+        to,
+        ...(branch ? { branch } : {}),
+      })
+      return mutationToToolResult(result, (value) =>
+        value.applied
+          ? `Connected ${from} → ${to}${branch ? ` [${branch}]` : ''}`
+          : `Connect ${from} → ${to} blocked`
+      )
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/delete-nodes.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/delete-nodes.ts
@@ -1,0 +1,67 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/delete-nodes.ts
+
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import { buildWorkflowEditDigest } from '../../../digests'
+import type { GetToolDeps } from '../../types'
+import {
+  digestLabelFromOutput,
+  mutationToToolResult,
+  workflowToolPermission,
+} from './graph-tool-helpers'
+import { resolveWorkflowWrite } from './write-tool-helpers'
+
+/** Delete nodes (a loop container takes its children with it — canvas parity). */
+export function createDeleteNodesTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'delete_nodes',
+    permission: workflowToolPermission('edit'),
+    displayName: 'Delete workflow nodes',
+    toolsetSlug: 'workflow.builder',
+    surfaces: ['builder'],
+    description:
+      'Delete nodes from the open workflow draft by title. Deleting a loop deletes its contained nodes too. Pass reconnect: true to bridge each deleted node’s predecessors to its successors.',
+    parameters: {
+      type: 'object',
+      properties: {
+        refs: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Node titles (or refs) to delete.',
+        },
+        reconnect: {
+          type: 'boolean',
+          description: 'Bridge surviving predecessors to surviving successors.',
+        },
+      },
+      required: ['refs'],
+      additionalProperties: false,
+    },
+    summary: (args) => `Delete ${Array.isArray(args.refs) ? args.refs.length : 0} node(s)`,
+    buildDigest: (output) =>
+      buildWorkflowEditDigest(digestLabelFromOutput(output, 'Deleted nodes'), output),
+    execute: async (args, agentDeps) => {
+      const write = await resolveWorkflowWrite(getDeps, agentDeps)
+      if (!write.ok) return { success: false, output: null, error: write.error }
+      const refs = Array.isArray(args.refs)
+        ? args.refs.filter((r): r is string => typeof r === 'string' && r.trim() !== '')
+        : []
+      if (refs.length === 0) {
+        return { success: false, output: null, error: 'refs must name at least one node.' }
+      }
+
+      const { db } = getDeps()
+      // Lazy import — see get-workflow.ts.
+      const { deleteNodes } = await import('../../../../../workflows/graph-edit')
+      const result = await deleteNodes(db, {
+        ...write.scope,
+        refs,
+        ...(args.reconnect === true ? { reconnect: true } : {}),
+      })
+      return mutationToToolResult(result, (value) =>
+        value.applied
+          ? `Deleted ${refs.length === 1 ? refs[0] : `${refs.length} nodes`}`
+          : 'Delete blocked'
+      )
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/describe-node-type.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/describe-node-type.ts
@@ -1,0 +1,105 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/describe-node-type.ts
+
+import { z } from 'zod'
+import { getManifest } from '../../../../../workflow-engine/catalog/registry'
+import type { NodeManifest } from '../../../../../workflow-engine/catalog/types'
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import type { GetToolDeps } from '../../types'
+
+/** Agent-facing config schema as JSON Schema — `agentSchema ?? configSchema`. */
+function configJsonSchema(manifest: NodeManifest<unknown>): Record<string, unknown> {
+  const source = manifest.agentSchema ?? manifest.configSchema
+  try {
+    const raw = z.toJSONSchema(source as z.ZodType, { unrepresentable: 'any' }) as Record<
+      string,
+      unknown
+    >
+    delete raw.$schema
+    return raw
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Full agent-facing description of one node type (04 §1): the config schema
+ * the write tools accept, connection/branch rules, the manifest's usage
+ * guidance and worked examples. Static product data — no authorization gate.
+ */
+export function createDescribeNodeTypeTool(getDeps: GetToolDeps): AgentToolDefinition {
+  void getDeps
+  return {
+    name: 'describe_node_type',
+    permission: {
+      target: 'none',
+      note: 'Static node-type manifest (schema, connection rules, usage docs) — identical for every org, no workspace data.',
+    },
+    displayName: 'Describe node type',
+    toolsetSlug: 'workflow.builder',
+    surfaces: ['builder'],
+    idempotent: true,
+    description:
+      'Get one node type in full: the config schema add_node/update_node accept, its connection and branch rules, usage guidance, and worked config examples. Always call this before configuring an unfamiliar type.',
+    parameters: {
+      type: 'object',
+      properties: {
+        type: { type: 'string', description: "Node type id from list_node_types (e.g. 'http')." },
+      },
+      required: ['type'],
+      additionalProperties: false,
+    },
+    execute: async (args) => {
+      const type = typeof args.type === 'string' ? args.type : ''
+      const manifest = getManifest(type)
+      if (!manifest) {
+        return {
+          success: false,
+          output: null,
+          error: `Node type "${type}" does not exist. Call list_node_types for the catalog.`,
+        }
+      }
+
+      // Branch names for the default config — branch handles can be config-
+      // dependent (if-else cases), so this is a starting point; every mutation
+      // result reflects the node's actual branches.
+      let branches: Array<{ name: string; kind: string }> | undefined
+      try {
+        branches = manifest.connection.branches?.(manifest.defaultData()).map((b) => ({
+          name: b.name,
+          kind: b.kind,
+        }))
+      } catch {
+        branches = undefined
+      }
+
+      const connection = {
+        canConnect: manifest.connection.canConnect !== false,
+        ...(manifest.connection.maxIncomingConnections !== undefined
+          ? { maxIncomingConnections: manifest.connection.maxIncomingConnections }
+          : {}),
+        ...(manifest.connection.maxOutgoingConnections !== undefined
+          ? { maxOutgoingConnections: manifest.connection.maxOutgoingConnections }
+          : {}),
+        ...(branches && branches.length > 0 ? { branches } : {}),
+      }
+
+      return {
+        success: true,
+        output: {
+          type: manifest.id,
+          displayName: manifest.displayName,
+          description: manifest.description,
+          category: manifest.category,
+          ...(manifest.triggerType ? { isTrigger: true } : {}),
+          authorable: manifest.agent?.authorable === true,
+          configSchema: configJsonSchema(manifest),
+          connection,
+          ...(manifest.agent?.usage ? { usage: manifest.agent.usage } : {}),
+          ...(manifest.agent?.examples?.length ? { examples: manifest.agent.examples } : {}),
+          outputsNote:
+            'Outputs depend on configuration — every add_node/update_node result (and get_node) returns this node’s resolved outputs; wire references from those.',
+        },
+      }
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/disconnect-nodes.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/disconnect-nodes.ts
@@ -1,0 +1,51 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/disconnect-nodes.ts
+
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import { buildWorkflowEditDigest } from '../../../digests'
+import type { GetToolDeps } from '../../types'
+import {
+  digestLabelFromOutput,
+  mutationToToolResult,
+  workflowToolPermission,
+} from './graph-tool-helpers'
+import { resolveWorkflowWrite } from './write-tool-helpers'
+
+/** Remove every edge between two nodes (all branches). */
+export function createDisconnectNodesTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'disconnect_nodes',
+    permission: workflowToolPermission('edit'),
+    displayName: 'Disconnect workflow nodes',
+    toolsetSlug: 'workflow.builder',
+    surfaces: ['builder'],
+    description:
+      'Remove every connection from one node to another in the open workflow draft (all branches).',
+    parameters: {
+      type: 'object',
+      properties: {
+        from: { type: 'string', description: 'Source node title.' },
+        to: { type: 'string', description: 'Target node title.' },
+      },
+      required: ['from', 'to'],
+      additionalProperties: false,
+    },
+    summary: (args) => `Disconnect ${args.from ?? ''} → ${args.to ?? ''}`,
+    buildDigest: (output) =>
+      buildWorkflowEditDigest(digestLabelFromOutput(output, 'Disconnected nodes'), output),
+    execute: async (args, agentDeps) => {
+      const write = await resolveWorkflowWrite(getDeps, agentDeps)
+      if (!write.ok) return { success: false, output: null, error: write.error }
+      const from = typeof args.from === 'string' ? args.from.trim() : ''
+      const to = typeof args.to === 'string' ? args.to.trim() : ''
+      if (!from || !to) return { success: false, output: null, error: 'from and to are required.' }
+
+      const { db } = getDeps()
+      // Lazy import — see get-workflow.ts.
+      const { disconnectNodes } = await import('../../../../../workflows/graph-edit')
+      const result = await disconnectNodes(db, { ...write.scope, from, to })
+      return mutationToToolResult(result, (value) =>
+        value.applied ? `Disconnected ${from} → ${to}` : `Disconnect ${from} → ${to} blocked`
+      )
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/find-workflow-templates.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/find-workflow-templates.ts
@@ -1,0 +1,83 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/find-workflow-templates.ts
+
+import { listFileTemplates } from '../../../../../workflows/templates'
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import type { GetToolDeps } from '../../types'
+
+const RESULT_LIMIT = 20
+
+/**
+ * Greenfield discovery (D13): search the public workflow templates — bundled
+ * file templates merged with admin-curated DB rows, the same set the template
+ * gallery lists — and hand back compact rows `apply_template` accepts.
+ * Public product data (status `public` only), so no authorization gate.
+ */
+export function createFindWorkflowTemplatesTool(getDeps: GetToolDeps): AgentToolDefinition {
+  void getDeps
+  return {
+    name: 'find_workflow_templates',
+    permission: {
+      target: 'none',
+      note: 'Public workflow-template gallery (bundled file templates + admin-curated public rows) — the same protectedProcedure-only list every member sees; no org data.',
+    },
+    displayName: 'Find workflow templates',
+    toolsetSlug: 'workflow.builder',
+    surfaces: ['builder'],
+    idempotent: true,
+    description:
+      'Search the public workflow template gallery by keyword. Returns template ids for apply_template (empty draft only) plus name, description, categories, and trigger type. Call with no query to browse.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Keyword search over name + description.' },
+      },
+      additionalProperties: false,
+    },
+    execute: async (args) => {
+      const query = typeof args.query === 'string' ? args.query.trim() : ''
+      const search = query || undefined
+
+      const fileItems = listFileTemplates({ ...(search ? { search } : {}), status: 'public' })
+
+      // Lazy import — @auxx/services pulls its own module graph; keep it off
+      // this capability's import time (same rule as graph-edit's applyTemplate).
+      let dbItems: Array<{
+        id: string
+        name: string
+        description: string
+        categories: string[]
+        triggerType: string | null
+      }> = []
+      try {
+        const { getAllTemplates } = await import('@auxx/services/workflow-templates')
+        const result = await getAllTemplates({
+          ...(search ? { search } : {}),
+          status: 'public',
+          limit: RESULT_LIMIT,
+        })
+        if (result.isOk()) dbItems = result.value as typeof dbItems
+      } catch {
+        // Template DB unavailable — file templates still answer.
+      }
+
+      const templates = [...fileItems, ...dbItems].slice(0, RESULT_LIMIT).map((t) => ({
+        templateId: t.id,
+        name: t.name,
+        description: t.description,
+        categories: t.categories ?? [],
+        triggerType: t.triggerType ?? null,
+      }))
+
+      if (templates.length === 0) {
+        return {
+          success: false,
+          output: null,
+          error: query
+            ? `No public templates match "${query}". Try a broader keyword, or build the workflow incrementally with add_node.`
+            : 'No public templates available.',
+        }
+      }
+      return { success: true, output: { templates } }
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/get-node.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/get-node.ts
@@ -1,0 +1,71 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/get-node.ts
+
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import type { GetToolDeps } from '../../types'
+import { projectNode, projectOutputs, workflowToolPermission } from './graph-tool-helpers'
+import { resolveWorkflowAuthoring } from './workflow-authoring-guard'
+
+/**
+ * One node in full: the agent-facing config (friendly `{{Title.path}}` refs,
+ * rendered by graph-edit), its resolved outputs, and its issues.
+ */
+export function createGetNodeTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'get_node',
+    permission: workflowToolPermission('view'),
+    displayName: 'Get node',
+    toolsetSlug: 'workflow.builder',
+    surfaces: ['builder'],
+    idempotent: true,
+    description:
+      'Read one node of the open workflow in full: complete config, resolved outputs (wire references from these), and its current issues. Address it by title or ref from get_workflow.',
+    parameters: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Node title (or ref/id) as returned by the tools.' },
+      },
+      required: ['ref'],
+      additionalProperties: false,
+    },
+    execute: async (args, agentDeps) => {
+      const auth = await resolveWorkflowAuthoring(getDeps, agentDeps, 'view')
+      if (!auth.ok) return { success: false, output: null, error: auth.error }
+      const ref = typeof args.ref === 'string' ? args.ref.trim() : ''
+      if (!ref) return { success: false, output: null, error: 'ref is required.' }
+
+      const { db } = getDeps()
+      // Lazy import — see get-workflow.ts.
+      const { readDraft } = await import('../../../../../workflows/graph-edit')
+      const result = await readDraft(db, {
+        workflowAppId: auth.workflowAppId,
+        organizationId: agentDeps.organizationId,
+      })
+      if (result.isErr()) {
+        return { success: false, output: null, error: result.error.message }
+      }
+      const draft = result.value
+
+      const lowered = ref.toLowerCase()
+      const node = draft.nodes.find(
+        (n) => n.ref === ref || n.id === ref || n.title.toLowerCase() === lowered
+      )
+      if (!node) {
+        const available = draft.nodes.map((n) => n.ref).join(', ')
+        return {
+          success: false,
+          output: null,
+          error: `No node "${ref}" in this workflow. Nodes: ${available || '(none)'}.`,
+        }
+      }
+
+      return {
+        success: true,
+        output: {
+          node: projectNode(node),
+          outputs: projectOutputs(draft.outputs[node.ref]),
+          issues: draft.issues.filter((issue) => issue.nodeRef === node.ref),
+        },
+      }
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/get-workflow.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/get-workflow.ts
@@ -1,0 +1,77 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/get-workflow.ts
+
+import type { EdgeSummary } from '../../../../../workflows/graph-edit/types'
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import type { GetToolDeps } from '../../types'
+import { projectOutputs, workflowToolPermission } from './graph-tool-helpers'
+import { resolveWorkflowAuthoring } from './workflow-authoring-guard'
+
+const CONFIG_SUMMARY_MAX = 140
+
+/** One-line config summary — bodies stay behind `get_node` (04 §1). */
+function summarizeConfig(config: Record<string, unknown>): string {
+  const line = JSON.stringify(config) ?? '{}'
+  return line.length > CONFIG_SUMMARY_MAX ? `${line.slice(0, CONFIG_SUMMARY_MAX - 1)}…` : line
+}
+
+/** `Title → Title [branch]` — the spec's edge rendering. */
+function renderEdge(edge: EdgeSummary): string {
+  return `${edge.from} → ${edge.to}${edge.branch ? ` [${edge.branch}]` : ''}${
+    edge.isLoopBack ? ' [loop-back]' : ''
+  }`
+}
+
+/**
+ * The whole draft, compact: trigger, per-node summaries (one-line config,
+ * resolved output refs), edges as `Title → Title [branch]`, current issues.
+ * Config BODIES are deliberately omitted — `get_node` fetches those.
+ */
+export function createGetWorkflowTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'get_workflow',
+    permission: workflowToolPermission('view'),
+    displayName: 'Get workflow',
+    toolsetSlug: 'workflow.builder',
+    surfaces: ['builder'],
+    idempotent: true,
+    description:
+      'Read the open workflow draft: trigger, every node (type, title, one-line config summary, resolved output refs), edges, and current issues. Use get_node for a node’s full config.',
+    parameters: { type: 'object', properties: {}, additionalProperties: false },
+    execute: async (_args, agentDeps) => {
+      const auth = await resolveWorkflowAuthoring(getDeps, agentDeps, 'view')
+      if (!auth.ok) return { success: false, output: null, error: auth.error }
+
+      const { db } = getDeps()
+      // Lazy import — the graph-edit barrel reads the org cache at import
+      // time; keeping it out of the capability's import graph keeps tests
+      // free to mock the module wholesale.
+      const { readDraft } = await import('../../../../../workflows/graph-edit')
+      const result = await readDraft(db, {
+        workflowAppId: auth.workflowAppId,
+        organizationId: agentDeps.organizationId,
+      })
+      if (result.isErr()) {
+        return { success: false, output: null, error: result.error.message }
+      }
+      const draft = result.value
+      return {
+        success: true,
+        output: {
+          name: draft.name,
+          triggerType: draft.triggerType ?? null,
+          nodeCount: draft.graphSummary.nodeCount,
+          nodes: draft.nodes.map((node) => ({
+            ref: node.ref,
+            type: node.type,
+            title: node.title,
+            ...(node.inside ? { inside: node.inside } : {}),
+            config: summarizeConfig(node.config),
+            outputs: projectOutputs(draft.outputs[node.ref]).map((o) => o.ref),
+          })),
+          edges: draft.edges.map(renderEdge),
+          issues: draft.issues,
+        },
+      }
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/graph-tool-helpers.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/graph-tool-helpers.ts
@@ -1,0 +1,132 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/graph-tool-helpers.ts
+
+import type { Result } from 'neverthrow'
+import type { AuxxError } from '../../../../../errors'
+import type { UnifiedVariable } from '../../../../../workflow-engine/types/unified-variable'
+import type {
+  GraphMutationResult,
+  Issue,
+  NodeSummary,
+} from '../../../../../workflows/graph-edit/types'
+import type { AgentToolPermission } from '../../../../agent-framework/tool-permission'
+import type { AgentToolResult } from '../../../../agent-framework/types'
+
+/**
+ * Shared `permission` declaration for the guarded workflow-builder tools —
+ * every one routes through `resolveWorkflowAuthoring` before doing anything
+ * else. `level` narrows per tool (view for reads, edit for mutations +
+ * `run_node`, matching the tRPC ladder).
+ */
+export function workflowToolPermission(level: 'view' | 'edit'): AgentToolPermission {
+  return {
+    target: 'instance',
+    keys: ['workflow'],
+    level,
+    enforcement: 'enforced',
+    note:
+      'resolveWorkflowAuthoring — fail-closed on absent capabilities, PermissionKey.workflowsView ' +
+      'area rung, org-scope check on the session workflow ref, ' +
+      `${level === 'view' ? 'canViewInstance (silent read filter)' : 'assertEditInstance'} ` +
+      'per workflow, and assertWorkflowAppNotSystemOwned. Proven behaviourally by ' +
+      'workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts.',
+  }
+}
+
+// NOTE: every tool in this capability writes `toolsetSlug: 'workflow.builder'`
+// and `surfaces: ['builder']` as LITERALS (not a shared spread) on purpose —
+// the `tool-slug-coverage` anti-drift test is a static text scan over each
+// factory's `return {` window and cannot see through a spread. Builder-only:
+// graph editing has no meaning on chat/email, and a runtime AI node must never
+// inherit these tools.
+
+/** A node summary for the model: everything but canvas coordinates. */
+export type ProjectedNode = Omit<NodeSummary, 'position'>
+
+/** One resolved output, compact: the wireable ref plus label + type. */
+export interface ProjectedOutput {
+  /** Echo this back verbatim inside a config to wire the value. */
+  ref: string
+  label: string
+  type: string
+}
+
+/** Strip canvas coordinates — the model must never see or send positions. */
+export function projectNode(node: NodeSummary): ProjectedNode {
+  const { position: _position, ...rest } = node
+  return rest
+}
+
+/**
+ * Compact a node's resolved outputs (already friendly-rendered by graph-edit —
+ * ids are `Title.path`; NOT re-rendered here) into `{{Title.path}}` refs.
+ */
+export function projectOutputs(outputs: unknown[] | undefined): ProjectedOutput[] {
+  if (!Array.isArray(outputs)) return []
+  return (outputs as UnifiedVariable[]).map((v) => ({
+    ref: `{{${v.id}}}`,
+    label: v.label,
+    type: String(v.type),
+  }))
+}
+
+/** The projected success output every graph mutation tool returns. */
+export interface ProjectedMutation {
+  applied: boolean
+  /** Human line for the status pill — also what `buildDigest` picks up. */
+  summary: string
+  node?: ProjectedNode
+  outputs?: ProjectedOutput[]
+  issues: Issue[]
+  graphSummary: GraphMutationResult['graphSummary']
+}
+
+/**
+ * Convert a graph-edit mutation `Result` into an `AgentToolResult` (D12: the
+ * touched node, its resolved outputs, and issues ride every write).
+ *
+ * - `err(AuxxError)` → tool error with the actionable message (ConflictError's
+ *   re-read-and-retry text included) — returned, not thrown, so the model can
+ *   recover in-turn.
+ * - `applied: false` → tool error carrying the blocking issues; the draft is
+ *   untouched.
+ * - `applied: true` → success, coordinates stripped, outputs compacted.
+ *
+ * `summarize` names the completed action for the status pill — e.g.
+ * "Added HTTP Request".
+ */
+export function mutationToToolResult(
+  result: Result<GraphMutationResult, AuxxError>,
+  summarize: (value: GraphMutationResult) => string
+): AgentToolResult {
+  if (result.isErr()) {
+    return { success: false, output: null, error: result.error.message }
+  }
+  const value = result.value
+  const projected: ProjectedMutation = {
+    applied: value.applied,
+    summary: summarize(value),
+    ...(value.node ? { node: projectNode(value.node) } : {}),
+    ...(value.outputs ? { outputs: projectOutputs(value.outputs) } : {}),
+    issues: value.issues,
+    graphSummary: value.graphSummary,
+  }
+  if (!value.applied) {
+    const blocking = value.issues.filter((issue) => issue.severity === 'error')
+    return {
+      success: false,
+      output: projected,
+      error:
+        'The edit was NOT applied — blocking issues:\n' +
+        (blocking.length > 0 ? blocking : value.issues)
+          .map((issue) => `- ${issue.nodeRef ? `${issue.nodeRef}: ` : ''}${issue.message}`)
+          .join('\n'),
+    }
+  }
+  return { success: true, output: projected }
+}
+
+/** The `summary` string off a projected mutation output, for `buildDigest`. */
+export function digestLabelFromOutput(output: unknown, fallback: string): string {
+  const summary = (output as { summary?: unknown } | null)?.summary
+  return typeof summary === 'string' && summary.length > 0 ? summary : fallback
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/list-node-types.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/list-node-types.ts
@@ -1,0 +1,60 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/list-node-types.ts
+
+import { listManifests } from '../../../../../workflow-engine/catalog/registry'
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import type { GetToolDeps } from '../../types'
+
+/**
+ * Compact node-type catalog — progressive disclosure (04 §1): this is the only
+ * node list in the prompt path; `describe_node_type` carries the schemas.
+ * Static product data, identical for every org, so no authorization gate.
+ */
+export function createListNodeTypesTool(getDeps: GetToolDeps): AgentToolDefinition {
+  void getDeps
+  return {
+    name: 'list_node_types',
+    permission: {
+      target: 'none',
+      note: 'Static node-type catalog (the registry manifest list) — identical for every org, no workspace data.',
+    },
+    displayName: 'List node types',
+    toolsetSlug: 'workflow.builder',
+    surfaces: ['builder'],
+    idempotent: true,
+    description:
+      'List the workflow node types: id, display name, one-line description, category, whether it is a trigger, and whether you may author it. Call describe_node_type before configuring one.',
+    parameters: {
+      type: 'object',
+      properties: {
+        category: {
+          type: 'string',
+          description:
+            "Optional category filter (e.g. 'trigger', 'action', 'condition', 'flow_control', 'ai').",
+        },
+      },
+      additionalProperties: false,
+    },
+    execute: async (args) => {
+      const category = typeof args.category === 'string' ? args.category : undefined
+      const types = listManifests()
+        .filter((m) => !category || m.category === category)
+        .map((m) => ({
+          type: m.id,
+          displayName: m.displayName,
+          description: m.description,
+          category: m.category,
+          ...(m.triggerType ? { isTrigger: true } : {}),
+          authorable: m.agent?.authorable === true,
+        }))
+        .sort((a, b) => a.type.localeCompare(b.type))
+      if (types.length === 0) {
+        return {
+          success: false,
+          output: null,
+          error: `No node types in category "${category}". Call list_node_types without a filter to see all categories.`,
+        }
+      }
+      return { success: true, output: { types } }
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/replace-graph.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/replace-graph.ts
@@ -1,0 +1,91 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/replace-graph.ts
+
+import type {
+  ReplaceGraphEdgeSpec,
+  ReplaceGraphNodeSpec,
+} from '../../../../../workflows/graph-edit/ops'
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import { buildWorkflowEditDigest } from '../../../digests'
+import type { GetToolDeps } from '../../types'
+import {
+  digestLabelFromOutput,
+  mutationToToolResult,
+  workflowToolPermission,
+} from './graph-tool-helpers'
+import { resolveWorkflowWrite } from './write-tool-helpers'
+
+/**
+ * Author a whole graph at once. Graph-edit restricts this to EMPTY drafts
+ * (decision 2026-08-13) — the tool surfaces that refusal honestly rather than
+ * flattening an existing graph.
+ */
+export function createReplaceGraphTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'replace_graph',
+    permission: workflowToolPermission('edit'),
+    displayName: 'Build workflow graph',
+    toolsetSlug: 'workflow.builder',
+    surfaces: ['builder'],
+    description:
+      'Author a whole workflow graph in one call — ONLY on an empty draft (it refuses when nodes exist; edit incrementally instead). Nodes are referenced by title in edges and configs; positions are laid out automatically.',
+    parameters: {
+      type: 'object',
+      properties: {
+        nodes: {
+          type: 'array',
+          description: 'Nodes to create.',
+          items: {
+            type: 'object',
+            properties: {
+              type: { type: 'string', description: 'Authorable node type.' },
+              title: { type: 'string' },
+              config: { type: 'object', description: 'Friendly config per describe_node_type.' },
+              inside: { type: 'string', description: 'Title of the loop this node lives inside.' },
+            },
+            required: ['type'],
+            additionalProperties: false,
+          },
+        },
+        edges: {
+          type: 'array',
+          description: 'Connections between the new nodes, by title.',
+          items: {
+            type: 'object',
+            properties: {
+              from: { type: 'string' },
+              to: { type: 'string' },
+              branch: { type: 'string', description: 'Branch NAME of `from`.' },
+            },
+            required: ['from', 'to'],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ['nodes', 'edges'],
+      additionalProperties: false,
+    },
+    summary: (args) => `Build graph: ${Array.isArray(args.nodes) ? args.nodes.length : 0} node(s)`,
+    buildDigest: (output) =>
+      buildWorkflowEditDigest(digestLabelFromOutput(output, 'Built workflow graph'), output),
+    execute: async (args, agentDeps) => {
+      const write = await resolveWorkflowWrite(getDeps, agentDeps)
+      if (!write.ok) return { success: false, output: null, error: write.error }
+
+      const nodes = Array.isArray(args.nodes) ? (args.nodes as ReplaceGraphNodeSpec[]) : []
+      const edges = Array.isArray(args.edges) ? (args.edges as ReplaceGraphEdgeSpec[]) : []
+      if (nodes.length === 0) {
+        return { success: false, output: null, error: 'nodes must contain at least one node.' }
+      }
+
+      const { db } = getDeps()
+      // Lazy import — see get-workflow.ts.
+      const { replaceGraph } = await import('../../../../../workflows/graph-edit')
+      const result = await replaceGraph(db, { ...write.scope, nodes, edges })
+      return mutationToToolResult(result, (value) =>
+        value.applied
+          ? `Built graph with ${value.graphSummary.nodeCount} nodes`
+          : 'Build graph blocked'
+      )
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/run-node.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/run-node.ts
@@ -1,0 +1,100 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/run-node.ts
+
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import type { GetToolDeps } from '../../types'
+import { workflowToolPermission } from './graph-tool-helpers'
+import { resolveWorkflowAuthoring } from './workflow-authoring-guard'
+
+/**
+ * The message the model must relay: since #1555 single-node runs are
+ * UNCONDITIONALLY debug/dry runs — side-effecting nodes simulate.
+ */
+export const SIMULATED_RUN_NOTE =
+  'This was a SIMULATED debug run — side-effecting nodes (email, webhooks, record writes) did not perform real actions. Tell the user the result is from a simulation.'
+
+/**
+ * Run ONE draft node in isolation (D8) — approval-gated so the user sees a
+ * run coming, even though the execution is unconditionally simulated. There
+ * is NO full-workflow execution tool at all, deliberately.
+ *
+ * Guard tier mirrors the tRPC `runSingleNode` procedure exactly: workflowsView
+ * area + per-workflow EDIT instance + not-system-owned + the demo-org block.
+ */
+export function createRunNodeTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'run_node',
+    permission: workflowToolPermission('edit'),
+    displayName: 'Run workflow node',
+    toolsetSlug: 'workflow.builder',
+    surfaces: ['builder'],
+    requiresApproval: true,
+    description:
+      'Run ONE node of the open workflow draft as a SIMULATED debug run (side-effecting nodes do not send email, call webhooks, or write records). Upstream nodes are NOT executed — supply every input value the node consumes via `input`, keyed by the `{{…}}` reference it reads. Always tell the user the run was simulated.',
+    parameters: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Node title (or ref) to run.' },
+        input: {
+          type: 'object',
+          description:
+            'Test values for the node’s input references, keyed by reference (e.g. { "Find Contact.record.email": "a@b.co" }). Omitted inputs are undefined at run time.',
+        },
+      },
+      required: ['ref'],
+      additionalProperties: false,
+    },
+    summary: (args) => `Run node: ${typeof args.ref === 'string' ? args.ref : ''} (simulated)`,
+    buildDigest: (output) => {
+      const out = (output ?? {}) as { status?: string; error?: string | null }
+      return {
+        label: `Simulated run ${out.status === 'succeeded' ? 'succeeded' : 'failed'}`,
+        simulated: true,
+        ...(out.error ? { error: String(out.error).slice(0, 200) } : {}),
+      }
+    },
+    execute: async (args, agentDeps) => {
+      const auth = await resolveWorkflowAuthoring(getDeps, agentDeps, 'edit')
+      if (!auth.ok) return { success: false, output: null, error: auth.error }
+      const ref = typeof args.ref === 'string' ? args.ref.trim() : ''
+      if (!ref) return { success: false, output: null, error: 'ref is required.' }
+
+      // Demo-org block — parity with the tRPC procedure's `notDemo` middleware.
+      // Lazy: DemoGuard rides the permissions/billing module graph.
+      const { DemoGuard } = await import('../../../../../demo')
+      await DemoGuard.requireNotDemo(agentDeps.organizationId, 'run workflow nodes', false)
+
+      const input =
+        args.input && typeof args.input === 'object' && !Array.isArray(args.input)
+          ? (args.input as Record<string, unknown>)
+          : undefined
+
+      const { db } = getDeps()
+      // Lazy import — run-node pulls the execution service's engine module
+      // graph; it must never load at import time (see graph-edit/run-node.ts).
+      const { runNode } = await import('../../../../../workflows/graph-edit/run-node')
+      const result = await runNode(db, {
+        workflowAppId: auth.workflowAppId,
+        organizationId: agentDeps.organizationId,
+        nodeId: ref,
+        ...(input ? { input } : {}),
+        userId: agentDeps.userId,
+      })
+      if (result.isErr()) {
+        return { success: false, output: null, error: result.error.message }
+      }
+      const summary = result.value
+      return {
+        success: true,
+        output: {
+          simulated: true,
+          note: SIMULATED_RUN_NOTE,
+          status: summary.status,
+          outputs: summary.outputs,
+          error: summary.error,
+          elapsedTime: summary.elapsedTime,
+          ...(summary.validationErrors ? { validationErrors: summary.validationErrors } : {}),
+        },
+      }
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/set-trigger.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/set-trigger.ts
@@ -1,0 +1,69 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/set-trigger.ts
+
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import { buildWorkflowEditDigest } from '../../../digests'
+import type { GetToolDeps } from '../../types'
+import {
+  digestLabelFromOutput,
+  mutationToToolResult,
+  workflowToolPermission,
+} from './graph-tool-helpers'
+import { optionalRecord, resolveWorkflowWrite } from './write-tool-helpers'
+
+/**
+ * Set the workflow's trigger — in-graph trigger types only. Retypes an
+ * existing trigger node IN PLACE (same id, outgoing edges kept) so downstream
+ * `{{Trigger.x}}` refs survive; creates one when the graph has none.
+ */
+export function createSetTriggerTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'set_trigger',
+    permission: workflowToolPermission('edit'),
+    displayName: 'Set workflow trigger',
+    toolsetSlug: 'workflow.builder',
+    surfaces: ['builder'],
+    description:
+      "Set the open workflow's trigger (what starts it). An existing trigger node is retyped in place — its title, position, and outgoing connections survive; with no trigger yet, one is created. In-graph trigger types only (e.g. 'manual', 'scheduled', 'resource-trigger', 'message-received').",
+    parameters: {
+      type: 'object',
+      properties: {
+        triggerType: {
+          type: 'string',
+          description: "Trigger NODE type (e.g. 'resource-trigger').",
+        },
+        config: {
+          type: 'object',
+          description:
+            "Friendly trigger config (e.g. { operation: 'created', resourceType: 'ticket' }).",
+        },
+      },
+      required: ['triggerType'],
+      additionalProperties: false,
+    },
+    summary: (args) =>
+      `Set trigger: ${typeof args.triggerType === 'string' ? args.triggerType : ''}`,
+    buildDigest: (output) =>
+      buildWorkflowEditDigest(digestLabelFromOutput(output, 'Set trigger'), output),
+    execute: async (args, agentDeps) => {
+      const write = await resolveWorkflowWrite(getDeps, agentDeps)
+      if (!write.ok) return { success: false, output: null, error: write.error }
+      const triggerType = typeof args.triggerType === 'string' ? args.triggerType.trim() : ''
+      if (!triggerType) return { success: false, output: null, error: 'triggerType is required.' }
+
+      const config = optionalRecord(args.config)
+      const { db } = getDeps()
+      // Lazy import — see get-workflow.ts.
+      const { setTrigger } = await import('../../../../../workflows/graph-edit')
+      const result = await setTrigger(db, {
+        ...write.scope,
+        triggerType,
+        ...(config ? { config } : {}),
+      })
+      return mutationToToolResult(result, (value) =>
+        value.applied
+          ? `Set trigger to ${value.node?.title ?? triggerType}`
+          : `Set trigger ${triggerType} blocked`
+      )
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/update-node.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/update-node.ts
@@ -1,0 +1,56 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/update-node.ts
+
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import { buildWorkflowEditDigest } from '../../../digests'
+import type { GetToolDeps } from '../../types'
+import {
+  digestLabelFromOutput,
+  mutationToToolResult,
+  workflowToolPermission,
+} from './graph-tool-helpers'
+import { optionalRecord, resolveWorkflowWrite } from './write-tool-helpers'
+
+/** Shallow-merge a friendly config into one node. */
+export function createUpdateNodeTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'update_node',
+    permission: workflowToolPermission('edit'),
+    displayName: 'Update workflow node',
+    toolsetSlug: 'workflow.builder',
+    surfaces: ['builder'],
+    description:
+      'Update one node of the open workflow draft: the config is shallow-merged over its current data. Pass only the fields you want to change. Use get_node first to see the current config; the result returns the node, its resolved outputs, and any issues.',
+    parameters: {
+      type: 'object',
+      properties: {
+        ref: { type: 'string', description: 'Node title (or ref) to update.' },
+        config: {
+          type: 'object',
+          description: 'Friendly config fields to merge — `{{Title.path}}` refs welcome.',
+        },
+      },
+      required: ['ref', 'config'],
+      additionalProperties: false,
+    },
+    summary: (args) => `Update node: ${typeof args.ref === 'string' ? args.ref : ''}`,
+    buildDigest: (output) =>
+      buildWorkflowEditDigest(digestLabelFromOutput(output, 'Updated node'), output),
+    execute: async (args, agentDeps) => {
+      const write = await resolveWorkflowWrite(getDeps, agentDeps)
+      if (!write.ok) return { success: false, output: null, error: write.error }
+      const ref = typeof args.ref === 'string' ? args.ref.trim() : ''
+      const config = optionalRecord(args.config)
+      if (!ref || !config) {
+        return { success: false, output: null, error: 'ref and config are required.' }
+      }
+
+      const { db } = getDeps()
+      // Lazy import — see get-workflow.ts.
+      const { updateNode } = await import('../../../../../workflows/graph-edit')
+      const result = await updateNode(db, { ...write.scope, ref, config })
+      return mutationToToolResult(result, (value) =>
+        value.applied ? `Updated ${value.node?.title ?? ref}` : `Update ${ref} blocked`
+      )
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/validate-workflow.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/validate-workflow.ts
@@ -1,0 +1,50 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/validate-workflow.ts
+
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import type { GetToolDeps } from '../../types'
+import { workflowToolPermission } from './graph-tool-helpers'
+import { resolveWorkflowAuthoring } from './workflow-authoring-guard'
+
+/**
+ * The publish gate without publishing: the three validation tiers plus the
+ * REAL `validateDraftWorkflowForPublish` verdict. Publishing itself stays the
+ * user's action — no publish tool exists.
+ */
+export function createValidateWorkflowTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'validate_workflow',
+    permission: workflowToolPermission('view'),
+    displayName: 'Validate workflow',
+    toolsetSlug: 'workflow.builder',
+    surfaces: ['builder'],
+    idempotent: true,
+    description:
+      'Check whether the open workflow draft would pass the publish gate — without publishing (publishing stays the user’s action). Returns publishability, publish errors/warnings, and the structural/config/reference issues.',
+    parameters: { type: 'object', properties: {}, additionalProperties: false },
+    execute: async (_args, agentDeps) => {
+      const auth = await resolveWorkflowAuthoring(getDeps, agentDeps, 'view')
+      if (!auth.ok) return { success: false, output: null, error: auth.error }
+
+      const { db } = getDeps()
+      // Lazy import — see get-workflow.ts.
+      const { validateWorkflow } = await import('../../../../../workflows/graph-edit')
+      const result = await validateWorkflow(db, {
+        workflowAppId: auth.workflowAppId,
+        organizationId: agentDeps.organizationId,
+      })
+      if (result.isErr()) {
+        return { success: false, output: null, error: result.error.message }
+      }
+      const report = result.value
+      return {
+        success: true,
+        output: {
+          publishable: report.publishable,
+          publishErrors: report.publishErrors,
+          publishWarnings: report.publishWarnings,
+          issues: report.issues,
+        },
+      }
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/workflow-authoring-guard.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/workflow-authoring-guard.ts
@@ -1,0 +1,157 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/workflow-authoring-guard.ts
+
+import { schema } from '@auxx/database'
+import { and, eq } from 'drizzle-orm'
+import { ForbiddenError } from '../../../../../errors'
+import { PermissionKey } from '../../../../../permissions/capabilities/registry'
+import { assertWorkflowAppNotSystemOwned } from '../../../../../workflows/workflow-app-access-guard'
+import type { AgentDeps } from '../../../../agent-framework/types'
+import { findRef } from '../../../context-refs'
+import type { GetToolDeps } from '../../types'
+
+/**
+ * Refusal text for "this tool ran without a builder session". Shared so the
+ * enumeration test can assert on the *authorization* path without matching a
+ * per-tool message.
+ */
+export const NO_WORKFLOW_REF_ERROR =
+  'No workflow in session context — this tool only runs on the workflow builder page.'
+
+/**
+ * Silent-read refusal (`kb-access.ts` semantics): a workflow the principal may
+ * not view — foreign org, instance-restricted, or system-owned — reads as "not
+ * found", never as a 403 that confirms it exists.
+ */
+export const WORKFLOW_NOT_FOUND_ERROR = 'Workflow not found in this workspace.'
+
+/**
+ * The dirty-canvas refusal (Phase 3 §7). Actionable: the model relays it and
+ * the user saves or discards, then retries.
+ */
+export const DIRTY_CANVAS_ERROR =
+  'The canvas has unsaved changes, so editing the stored draft now would conflict with what the ' +
+  'user sees. Ask the user to save (or discard) their canvas changes first, then retry.'
+
+export type WorkflowAuthoringResolution =
+  | { ok: true; workflowAppId: string }
+  | { ok: false; error: string }
+
+/**
+ * Which access rung a workflow-builder tool needs. Mirrors the tRPC ladder in
+ * `apps/web/src/server/api/routers/workflow.ts` exactly: the AREA key is
+ * `workflowsView` everywhere (workflows are an instance-access resource — the
+ * per-workflow rung is what varies), and the instance rung is `view` for reads
+ * vs `edit` for every draft mutation and `runSingleNode`. No default on
+ * purpose — a shared gate with a hardcoded tier is how a Kopilot tool ends up
+ * cheaper than the router it mirrors.
+ */
+export type WorkflowAuthoringTier = 'view' | 'edit'
+
+/**
+ * **The** authorization gate for every graph tool in the `workflow.builder`
+ * capability set.
+ *
+ * Threat model (same as `agent-authoring-guard.ts`): these tools run BELOW the
+ * tRPC routers, reached through `POST /api/kopilot/stream` — a route that
+ * authenticates the session but takes `page` and `context` straight off the
+ * request body. Any authenticated member could POST `page: 'workflow.builder'`
+ * with a crafted `workflow` ref, so each tool re-asserts:
+ *
+ * 1. **Fail closed on absent capabilities** (07 §5). The documented lib-wide
+ *    convention is `capabilities === undefined ⇒ unrestricted` (the workflow AI
+ *    node is the un-threaded caller) — for graph WRITES that default is wrong,
+ *    and this capability is only ever mounted on a real user session, so a
+ *    missing view is refused outright rather than waved through.
+ * 2. **The area rung** — `PermissionKey.workflowsView`, exact parity with the
+ *    router base (`permissionProcedure(workflowsView)` everywhere the instance
+ *    rung varies).
+ * 3. **Org scope** — the workflow id arrives in client-supplied session refs;
+ *    a foreign id must read as "not in this workspace", never leak existence.
+ * 4. **Per-workflow instance rung** — `canViewInstance` (silent) for reads,
+ *    `assertEditInstance` (throws `ForbiddenError`) for writes; plan 30's
+ *    per-workflow `ResourceAccess` rows.
+ * 5. **`assertWorkflowAppNotSystemOwned`** — every workflow router procedure
+ *    applies it (sequences compile to hidden system-owned apps), so the
+ *    capability must too. Reads stay blind to such rows (silent not-found).
+ * 6. **The dirty gate** (mutations only, LAST so a permission denial is never
+ *    masked): the builder chip contributes `{ id, isDirty }`; a mutation
+ *    refuses while `isDirty` with an actionable message. The flag is advisory
+ *    and may be absent — the hash-CAS inside graph-edit is the real guard.
+ *
+ * Authorization failures **throw `ForbiddenError`** (auditable; the engine
+ * turns it into a `tool-call-failed` event). Bad-context conditions — missing
+ * ref, silent read filtering, the dirty gate — come back `{ ok: false }` so
+ * the model gets a plain, actionable tool error.
+ */
+export async function resolveWorkflowAuthoring(
+  getDeps: GetToolDeps,
+  agentDeps: AgentDeps,
+  tier: WorkflowAuthoringTier,
+  opts: { mutation?: boolean } = {}
+): Promise<WorkflowAuthoringResolution> {
+  const { db, sessionContext, capabilities } = getDeps()
+  const workflowRef = findRef(sessionContext, 'workflow')
+  if (!workflowRef?.id) {
+    return { ok: false, error: NO_WORKFLOW_REF_ERROR }
+  }
+  const workflowAppId = workflowRef.id
+  const organizationId = agentDeps.organizationId
+
+  // (1) Fail closed — see the docblock. Deliberately opposite the lib-wide
+  // `undefined ⇒ unrestricted` convention, so it is stated loudly here.
+  if (!capabilities) {
+    throw new ForbiddenError(
+      'This session carries no permission context — workflow editing is unavailable.'
+    )
+  }
+
+  // (2) Area rung.
+  if (!capabilities.can(PermissionKey.workflowsView)) {
+    throw new ForbiddenError('You don’t have permission to work with workflows.')
+  }
+
+  // (3) Org scope. The id comes from client-supplied session refs — verify it
+  // belongs to THIS org before any instance assert, so a foreign id reads as
+  // "not in this workspace" rather than leaking that it exists elsewhere.
+  const [row] = await db
+    .select({ id: schema.WorkflowApp.id })
+    .from(schema.WorkflowApp)
+    .where(
+      and(
+        eq(schema.WorkflowApp.id, workflowAppId),
+        eq(schema.WorkflowApp.organizationId, organizationId)
+      )
+    )
+    .limit(1)
+  if (!row) {
+    if (tier === 'view') return { ok: false, error: WORKFLOW_NOT_FOUND_ERROR }
+    throw new ForbiddenError(WORKFLOW_NOT_FOUND_ERROR)
+  }
+
+  // (4) Per-workflow instance rung. Reads filter silently; writes throw.
+  if (tier === 'view') {
+    if (!capabilities.canViewInstance('workflow', workflowAppId)) {
+      return { ok: false, error: WORKFLOW_NOT_FOUND_ERROR }
+    }
+  } else {
+    capabilities.assertEditInstance('workflow', workflowAppId)
+  }
+
+  // (5) System-owned lockdown — reads stay blind, writes get the guard's own
+  // ForbiddenError verbatim.
+  try {
+    await assertWorkflowAppNotSystemOwned(db, { workflowAppId, organizationId })
+  } catch (error) {
+    if (tier === 'view' && error instanceof ForbiddenError) {
+      return { ok: false, error: WORKFLOW_NOT_FOUND_ERROR }
+    }
+    throw error
+  }
+
+  // (6) Dirty gate — advisory, mutations only, after every real check.
+  if (opts.mutation && workflowRef.isDirty === true) {
+    return { ok: false, error: DIRTY_CANVAS_ERROR }
+  }
+
+  return { ok: true, workflowAppId }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/write-tool-helpers.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/write-tool-helpers.ts
@@ -1,0 +1,50 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/write-tool-helpers.ts
+
+import type { GraphMutationScope } from '../../../../../workflows/graph-edit'
+import type { AgentDeps } from '../../../../agent-framework/types'
+import type { GetToolDeps } from '../../types'
+import { resolveWorkflowAuthoring } from './workflow-authoring-guard'
+
+/** What a write tool needs to call a graph-edit mutation. */
+export type WriteResolution = { ok: true; scope: GraphMutationScope } | { ok: false; error: string }
+
+/**
+ * Shared preamble of every graph mutation tool: the edit-tier guard (incl. the
+ * dirty gate) plus the turn id the snapshot lifecycle keys on. A write without
+ * a `turnId` would take no pre-turn snapshot — no Undo, no revert-on-failure —
+ * so it is refused outright (KB `runBlockCrudOp` parity).
+ */
+export async function resolveWorkflowWrite(
+  getDeps: GetToolDeps,
+  agentDeps: AgentDeps
+): Promise<WriteResolution> {
+  const auth = await resolveWorkflowAuthoring(getDeps, agentDeps, 'edit', { mutation: true })
+  if (!auth.ok) return auth
+  const turnId = agentDeps.turnId
+  if (!turnId) {
+    return {
+      ok: false,
+      error: 'No turnId on agent deps — cannot scope kopilot workflow writes.',
+    }
+  }
+  return {
+    ok: true,
+    scope: {
+      workflowAppId: auth.workflowAppId,
+      organizationId: agentDeps.organizationId,
+      turnId,
+    },
+  }
+}
+
+/** Optional-string arg helper — trims, empty → undefined. */
+export function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined
+}
+
+/** Optional plain-object arg helper. */
+export function optionalRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}

--- a/packages/lib/src/ai/kopilot/context-refs.ts
+++ b/packages/lib/src/ai/kopilot/context-refs.ts
@@ -37,6 +37,9 @@ const ARG_TO_REF_KIND: Record<string, SessionRefKind> = {
   articleId: 'article',
   knowledgeBaseId: 'kb',
   actorId: 'actor',
+  // Unlike `record`, a workflow chip has no ambiguity — the builder page has
+  // exactly one open workflow — so binding it is always right (04 §2).
+  workflowId: 'workflow',
 }
 
 /**

--- a/packages/lib/src/ai/kopilot/digests.ts
+++ b/packages/lib/src/ai/kopilot/digests.ts
@@ -36,3 +36,40 @@ export function takeSample<T>(items: readonly T[] | undefined, n = DIGEST_SAMPLE
   if (!items || !Array.isArray(items)) return []
   return items.slice(0, n)
 }
+
+/**
+ * Shared digest shape for the workflow-builder graph tools' status pills.
+ * `label` is the human line ("Added HTTP Request", "Connected Find Contact →
+ * Send Email"); the counts let the card flag a blocked edit or open issues
+ * without storing the whole graph summary.
+ */
+export const WorkflowEditDigest = z.object({
+  label: z.string(),
+  /** False when blocking issues rejected the edit and the draft is untouched. */
+  applied: z.boolean().optional(),
+  issueCount: z.number().optional(),
+  nodeCount: z.number().optional(),
+})
+export type WorkflowEditDigest = z.infer<typeof WorkflowEditDigest>
+
+/**
+ * Build a {@link WorkflowEditDigest} from a graph tool's output. `label` should
+ * name the completed action with the touched node's friendly title(s) — e.g.
+ * "Added HTTP Request" — falling back to the verb alone when the output carries
+ * no node. Pure + deterministic (persisted on the tool-call part).
+ */
+export function buildWorkflowEditDigest(label: string, output: unknown): WorkflowEditDigest {
+  const out = (output ?? {}) as {
+    applied?: boolean
+    issues?: unknown[]
+    graphSummary?: { nodeCount?: number }
+  }
+  return {
+    label,
+    ...(typeof out.applied === 'boolean' ? { applied: out.applied } : {}),
+    ...(Array.isArray(out.issues) ? { issueCount: out.issues.length } : {}),
+    ...(typeof out.graphSummary?.nodeCount === 'number'
+      ? { nodeCount: out.graphSummary.nodeCount }
+      : {}),
+  }
+}

--- a/packages/lib/src/ai/kopilot/index.ts
+++ b/packages/lib/src/ai/kopilot/index.ts
@@ -19,9 +19,12 @@ export {
   createSuggestRepliesGlobalCapability,
   createTaskCapabilities,
   createToolDepsFactory,
+  createWorkflowBuilderCapabilities,
   KB_PAGE,
   RECORDS_PAGE,
   WORKFLOW_AI_NODE_PAGE,
+  WORKFLOW_BUILDER_PAGE,
+  WORKFLOW_BUILDER_TOOLSET_SLUG,
   WORKFLOW_NATIVE_TOOLSET_SLUG,
 } from './capabilities'
 export { applyContextDefaults, findAllRefs, findRef } from './context-refs'

--- a/packages/lib/src/ai/kopilot/prompts/sections/active-refs.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/active-refs.ts
@@ -13,6 +13,7 @@ const REF_KIND_LABEL: Record<SessionRefKind, string> = {
   article: 'article',
   actor: 'actor',
   agent: 'agent',
+  workflow: 'workflow',
 }
 
 export const activeRefs: PromptSection = {

--- a/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
@@ -1,0 +1,52 @@
+// packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
+
+/**
+ * System-prompt section for the `workflow.builder` capability
+ * (plans/kopilot/workflow/04 §3). Delivered through the capability's
+ * `systemPromptAddition` — NOT the master prompt-section registry — so it only
+ * renders when the workflow-builder tools are actually mounted. Teaches only
+ * what the tools cannot express: the reference grammar, the upstream rule,
+ * loop/branch wiring, and where edits commit. Follows the KB section's
+ * register: worked examples, explicit "never invent ids".
+ */
+
+/** Build the workflow-builder prompt addition. Static — no per-org content. */
+export function buildWorkflowBuilderPromptSection(): string {
+  return [
+    // What the surface is + where edits go.
+    "You can read and edit the workflow open in this builder. All edits go to the DRAFT — publishing is the user's action, in the editor. After editing, say what you changed and that they can review and publish; never imply the workflow is live. This page is scoped to exactly ONE workflow (the one in the active references). If asked to build or edit a different workflow — or several — say honestly that you can only work on the open one and the user should open the other workflow's builder.",
+
+    // Reference grammar.
+    "Reference grammar: values flow between nodes as `{{Node Title.output}}` — e.g. `{{Find Contact.record.email}}`. Every mutation and `get_workflow`/`get_node` returns each node's resolved outputs; wire references ONLY from those. Never invent an output name, never guess a path, and never write a raw node id inside `{{…}}` — always the node's title exactly as the tools return it.",
+
+    // Upstream rule.
+    'Upstream rule: a node can only reference outputs of nodes UPSTREAM of it (connected before it in the graph). If a value is needed further along, move the node or add an edge so the producer runs first.',
+
+    // Loops.
+    "Loops: nodes go inside a loop via `add_node`'s `inside` parameter, not by drawing an edge into the container. Loop item references are NODE-SCOPED ONLY: `{{Loop Title.item}}`, `{{Loop Title.index}}`, `{{Loop Title.count}}` (using the loop node's own title). Never write bare `{{item}}` or `{{index}}` (one global slot — clobbered by nested loops) and never `{{loop.index}}` (builder-only vocabulary the engine does not write).",
+
+    // Branches.
+    'Branches: an `if-else` (and other branching nodes) is wired by branch NAME via the `branch` parameter on `connect_nodes` / `add_node` — e.g. `connect_nodes(from: "Check Priority", branch: "High", to: "Post To Webhook")`. Branch names come from the node\'s outputs/`describe_node_type`; never invent handle ids.',
+
+    // Workflow shape.
+    'Workflow shape: a FINISHED workflow has exactly one trigger; while building incrementally, having no trigger yet is fine (it reports as a warning, not an error). Graphs read left to right; parallel branches stack vertically.',
+
+    // Positions.
+    'Positions: do not send coordinates — layout is automatic and existing nodes never move. Only pass `position` if the user explicitly asks for a specific placement.',
+
+    // Verification + simulation.
+    'Verifying: `validate_workflow` runs the real publish gate without publishing — use it after a batch of edits. `run_node` executes ONE node as a SIMULATED debug run (side-effecting nodes do not send email, call webhooks, etc.); you supply its input values — upstream nodes are not executed. Say clearly in your reply that the run was simulated.',
+
+    // Worked examples.
+    [
+      'Worked examples:',
+      '  - add_node(type: "http", title: "Post To Webhook", after: "Check Priority", branch: "High", config: { url: "https://example.com/hook", method: "POST" })',
+      '  - update_node(ref: "Send Email", config: { subject: "Order {{Find Order.record.number}} update" })',
+      '  - add_node(type: "crud", title: "Create Task", inside: "For Each Line Item", config: { … "{{For Each Line Item.item.name}}" … })',
+      '  - connect_nodes(from: "Summarize Email", to: "Save Summary")',
+    ].join('\n'),
+
+    // Honesty rules.
+    'Never invent node ids, output names, template ids, or node types — use `list_node_types` / `describe_node_type` / `find_workflow_templates` and the refs the tools return. If a requested node type is not authorable, say so plainly and name the type; do not silently substitute another type. If an edit is refused because the canvas has unsaved changes, ask the user to save (or discard) their canvas changes and then retry.',
+  ].join('\n\n')
+}

--- a/packages/lib/src/ai/kopilot/types.ts
+++ b/packages/lib/src/ai/kopilot/types.ts
@@ -15,6 +15,7 @@ export type SessionRefKind =
   | 'article' // article id
   | 'actor' // `user:<id>` or `group:<id>`
   | 'agent' // user-authored agent id — present on the builder page
+  | 'workflow' // WorkflowApp id — present on the workflow builder page
 
 /**
  * A single thing the user has in focus this turn — either because a page
@@ -33,6 +34,14 @@ export interface SessionRef {
    * precedence (mention wins over surface).
    */
   origin: 'surface' | 'mention'
+  /**
+   * ADVISORY dirty flag contributed by the `workflow` builder chip: the open
+   * canvas has unsaved changes, so the DB draft the graph-edit tools would
+   * mutate is stale relative to what the user sees. Workflow mutations refuse
+   * while it is true. Tolerate absence — the chip is a courtesy; the hash-CAS
+   * inside graph-edit is the real concurrency guard.
+   */
+  isDirty?: boolean
 }
 
 /** Open-ended UI context bag. Known fields provide autocomplete; any key is valid. */

--- a/packages/lib/src/workflows/graph-edit/__tests__/turn-lifecycle.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/turn-lifecycle.test.ts
@@ -5,7 +5,9 @@
  * (`03-graph-edit-service.md` §7, `07-remaining-mechanics.md` §6): first
  * mutation of a turn captures the pre-edit graph, a second mutation of the
  * SAME turn does not overwrite it, a failed turn's revert restores the exact
- * prior graph, a PRIOR turn's stale snapshot is rejected, the
+ * prior graph, a PRIOR turn's stale snapshot is rejected (NOTE: a COMPLETED
+ * turn deliberately keeps its snapshot for the per-turn Undo card — the
+ * capability lifecycle never calls `finalizeWorkflowTurn` on success), the
  * `workflow:draft-updated` signal fires after a successful persist (and never
  * on a rejected mutation), and a hash-CAS conflict surfaces as a typed,
  * actionable `ConflictError` — never a generic 500, never a silent overwrite.

--- a/packages/lib/src/workflows/graph-edit/index.ts
+++ b/packages/lib/src/workflows/graph-edit/index.ts
@@ -105,6 +105,7 @@ export {
 } from './run-node'
 export {
   captureWorkflowTurnSnapshot,
+  clearWorkflowTurnSnapshot,
   finalizeWorkflowTurn,
   readWorkflowTurnSnapshot,
   revertWorkflowTurn,

--- a/packages/lib/src/workflows/graph-edit/persist.ts
+++ b/packages/lib/src/workflows/graph-edit/persist.ts
@@ -113,6 +113,10 @@ export async function persistDraft(
       graph: graph as WorkflowUpdateInput['graph'],
       triggerType: triggerType as WorkflowTriggerType | undefined,
       entityDefinitionId,
+      // The agent's own writes must not wipe the pre-turn Undo snapshot the
+      // mutation pipeline captured just before this persist. Manual canvas
+      // saves (which don't go through this seam) DO clear it.
+      preserveTurnSnapshot: true,
       ...(input.expectedGraphHash !== undefined
         ? { expectedGraphHash: input.expectedGraphHash }
         : {}),

--- a/packages/lib/src/workflows/graph-edit/turn-snapshot.ts
+++ b/packages/lib/src/workflows/graph-edit/turn-snapshot.ts
@@ -4,9 +4,13 @@
  * Per-turn pre-edit snapshot of the draft graph — SERVER-ONLY (Redis + the
  * persist seam). Mirrors `kb/kopilot-snapshot.ts` (`03-graph-edit-service.md`
  * §7): the FIRST mutation of a turn stores the pre-edit graph under
- * `(workflowAppId, turnId)` with a 24h TTL; the turn lifecycle finalizes
- * (discards) on success and reverts (restores the exact prior graph through
- * `persistDraft`) on failure.
+ * `(workflowAppId, turnId)` with a 24h TTL. On turn FAILURE the lifecycle
+ * reverts (restores the exact prior graph through `persistDraft`). On turn
+ * SUCCESS the snapshot is deliberately KEPT — it backs the per-turn Undo card
+ * (KB parity: `finalizeKopilotKbTurn` keeps its snapshot too, so
+ * `revertWorkflowTurn` stays reachable after a completed turn). Cleanup is the
+ * next turn's capture overwriting the slot, the TTL, or a manual draft save
+ * clearing it via {@link clearWorkflowTurnSnapshot}.
  *
  * One slot per workflow app — each new turn overwrites the prior turn's
  * snapshot, and the slot naturally expires via Redis TTL. `readWorkflowTurnSnapshot`
@@ -96,8 +100,12 @@ export async function readWorkflowTurnSnapshot(
 }
 
 /**
- * Discard the turn's snapshot — the SUCCESS half of the turn lifecycle.
- * Deletes only when the slot still belongs to `turnId`: a stale finalize from
+ * Discard the turn's snapshot, turn-checked. NOT called on turn success — a
+ * completed turn keeps its snapshot so the per-turn Undo card can still call
+ * {@link revertWorkflowTurn} (KB parity; see the module docblock). Callers:
+ * the revert path (after a successful restore there is nothing left to undo)
+ * and any future cleanup that must not clobber a fresher turn's slot.
+ * Deletes only when the slot still belongs to `turnId`: a stale call from
  * a prior turn must never clear a fresher turn's snapshot. Best-effort — a
  * leftover snapshot expires via TTL, and the turn-id check in the revert path
  * refuses it anyway.
@@ -119,7 +127,27 @@ export async function finalizeWorkflowTurn(workflowAppId: string, turnId: string
 }
 
 /**
- * Restore the exact pre-turn graph — the FAILURE half of the turn lifecycle.
+ * Delete the snapshot unconditionally (no turn check). The workflow twin of
+ * KB's `clearKopilotSnapshot`: called from non-Kopilot write paths — a manual
+ * canvas save through `WorkflowService.update` — so a stale Undo can never
+ * roll the draft back over edits the user made by hand after the turn.
+ * Best-effort: a clear that fails only leaves a snapshot the TTL expires.
+ */
+export async function clearWorkflowTurnSnapshot(workflowAppId: string): Promise<void> {
+  try {
+    await deleteRedisData(snapshotKey(workflowAppId))
+  } catch (error) {
+    logger.warn('Failed to clear workflow turn snapshot', {
+      workflowAppId,
+      error: (error as Error).message,
+    })
+  }
+}
+
+/**
+ * Restore the exact pre-turn graph — the FAILURE half of the turn lifecycle,
+ * and the Undo card's server piece after a COMPLETED turn (the snapshot
+ * survives success precisely so this stays callable).
  * The stored snapshot must belong to `turnId`: a snapshot from a prior turn
  * is REJECTED, never restored (restoring it would roll back edits this turn
  * never made), and no snapshot means the turn never wrote — also nothing to

--- a/packages/lib/src/workflows/types.ts
+++ b/packages/lib/src/workflows/types.ts
@@ -77,6 +77,15 @@ export interface WorkflowUpdateInput {
    * When absent, the write is unconditional (template install / system paths).
    */
   expectedGraphHash?: string
+  /**
+   * Keep the Kopilot per-turn Undo snapshot (`graph-edit/turn-snapshot.ts`)
+   * across this write. Set ONLY by the graph-edit persist seam — the agent's
+   * own writes must not wipe the snapshot they just captured. Every other
+   * graph write (a manual canvas save) clears it, so a stale Undo can never
+   * roll the draft back over the user's own edits (KB
+   * `bypassSnapshotClear` parity).
+   */
+  preserveTurnSnapshot?: boolean
 
   // Access settings
   webEnabled?: boolean

--- a/packages/lib/src/workflows/workflow-service.ts
+++ b/packages/lib/src/workflows/workflow-service.ts
@@ -406,6 +406,7 @@ export class WorkflowService {
         envVars,
         variables,
         expectedGraphHash,
+        preserveTurnSnapshot,
         webEnabled,
         apiEnabled,
         accessMode,
@@ -584,6 +585,20 @@ export class WorkflowService {
       })
 
       logger.info('Workflow app updated successfully', { workflowAppId: id, organizationId })
+
+      // A non-Kopilot graph write invalidates the per-turn Undo snapshot (KB
+      // parity: KBService clears on every manual save unless the agent path
+      // bypasses). Only the graph-edit persist seam sets `preserveTurnSnapshot`.
+      // Best-effort + lazy — the snapshot module pulls @auxx/redis, which must
+      // not become an import-time dependency of every WorkflowService caller.
+      if (graph !== undefined && !preserveTurnSnapshot) {
+        try {
+          const { clearWorkflowTurnSnapshot } = await import('./graph-edit/turn-snapshot')
+          await clearWorkflowTurnSnapshot(id)
+        } catch {
+          // A leftover snapshot expires via TTL; never fail the save over it.
+        }
+      }
 
       await onCacheEvent('workflow.updated', { orgId: organizationId })
 


### PR DESCRIPTION
Phase 4a of the Kopilot workflow-builder project: the entire lib side of the `workflow.builder` capability. Exposes the Phase 3 headless graph-edit service (#1601–#1606) as Kopilot tools on the workflow builder page. Modeled on `agents-builder` (guard, read→edit contract, builder-only surface), with the turn-snapshot/Undo lifecycle lifted from KB. No web changes here — the context chip, `workflow:draft-updated` subscriber, and Undo card ship in the next PR.

## Tools (`ai/kopilot/capabilities/workflow-builder/`, page + toolset slug `workflow.builder`)

- **Discovery** (no auth — static product data): `list_node_types(category?)`, `describe_node_type(type)` (`agentSchema ?? configSchema` as JSON Schema, connection/branch rules, `manifest.agent.usage` + examples), `find_workflow_templates(query)` (bundled file templates + admin-curated public DB rows).
- **Read** (view tier, silent filtering): `get_workflow()` (trigger, one-line config summaries, output refs, edges as `Title → Title [branch]`, issues — no config bodies), `get_node(ref)` (full friendly config + resolved outputs + issues).
- **Write** (edit tier + dirty gate + turnId): `add_node`, `update_node`, `delete_nodes`, `connect_nodes`, `disconnect_nodes`, `set_trigger`, `replace_graph` (empty-draft-only — surfaces graph-edit's refusal honestly), `apply_template` (empty-draft-only). Each returns the touched node (coordinates stripped), its resolved outputs as `{{Title.path}}` refs (rendered by graph-edit, never re-rendered), issues, and a graph summary. Blocked edits and CAS conflicts come back as actionable tool errors.
- **Verify**: `validate_workflow()` (the real publish gate, without publishing), `run_node(ref, input?)` (`requiresApproval`, demo-blocked, and the output says loudly the run is SIMULATED — #1555 made single-node runs unconditionally debug/dry).
- **Absent by design**: no `publish`, `enable`, `delete_workflow`; no full-workflow execution tool at all.

Non-authorable / unknown node types get graph-edit's honest refusal naming the type and the authorable set — never a silent substitution. (Note: all 22 currently migrated manifests declare `authorable: true`, so today this only fires for unknown types.)

## Guard (`resolveWorkflowAuthoring`, mirroring `agent-authoring-guard.ts`)

`POST /api/kopilot/stream` takes `page` + `context` off the body, so any member can claim the builder page with a crafted `workflow` ref. Every guarded tool asserts, in order:

1. **Fail closed on absent capabilities** (07 §5 — deliberately opposite the lib-wide `undefined ⇒ unrestricted` convention).
2. Area rung `PermissionKey.workflowsView` (router parity — the workflow router's base is `permissionProcedure(workflowsView)` everywhere; the instance rung is what varies).
3. Org scope on the client-supplied ref (foreign id reads as "not in this workspace").
4. Per-workflow instance rung: `canViewInstance` (silent not-found) for reads, `assertEditInstance` (throws `ForbiddenError`) for writes — `run_node` is edit-tier, matching tRPC `runSingleNode`.
5. `assertWorkflowAppNotSystemOwned` (reads stay blind to system-owned rows).
6. **Dirty gate** (mutations only, last so it never masks a denial): the chip's advisory `SessionRef.isDirty` refuses mutations with an actionable "save your canvas changes" message; absent flag tolerated — the hash-CAS inside graph-edit is the real guard. Reads and `run_node` work regardless.

Writes additionally refuse without an `agentDeps.turnId` (KB parity) — a write without a turn id would take no snapshot, so no Undo and no revert-on-failure.

## Undo / finalize reconciliation (04 §4 vs slice-5 `finalizeWorkflowTurn`)

04 said finalize "keeps the snapshot for Undo", but slice 5 shipped `finalizeWorkflowTurn` as a turn-checked **discard** — calling it on success would make post-turn Undo impossible. KB's actual end-to-end semantics: `finalizeKopilotKbTurn` keeps the snapshot (it only releases the editor lock), and the Undo card calls a tRPC mutation → `revertKopilotKbTurn(expectedTurnId)`; manual saves clear the snapshot via `KBService` unless the agent path bypasses. This PR matches that:

- `onTurnEnd(completed)` deliberately does **not** call `finalizeWorkflowTurn` — the snapshot is kept (next turn's capture overwrites it; 24h TTL; manual saves clear it). `onTurnEnd(error)` calls `revertWorkflowTurn(db, scope, turnId)`, whose `expectedTurnId` check rejects stale prior-turn snapshots.
- `finalizeWorkflowTurn` keeps its discard semantics (used after a successful revert); docblocks updated to state the new lifecycle.
- New `clearWorkflowTurnSnapshot(workflowAppId)` (KB `clearKopilotSnapshot` twin) + `WorkflowUpdateInput.preserveTurnSnapshot`: `WorkflowService.update` clears the snapshot on every non-Kopilot graph write (manual canvas save), and only the graph-edit persist seam sets the bypass — so a stale Undo can never roll the draft back over the user's own hand edits. (Publish/version-restore don't touch the draft graph, so they're unaffected.)
- **What the web Undo card calls (next PR):** a `workflow.revertKopilotTurn` tRPC mutation mirroring `kb.revertKopilotTurn` — assert `assertEditInstance('workflow', id)` + `assertWorkflowAppNotSystemOwned`, then `revertWorkflowTurn(db, { workflowAppId, organizationId }, turnId)`; a review query can use `readWorkflowTurnSnapshot(workflowAppId, turnId?)`. Both are exported from `workflows/graph-edit`.

## Context, prompt, registration

- New `SessionRefKind` `'workflow'` + advisory `SessionRef.isDirty`; `workflowId` added to `applyContextDefaults` binding pre-fill (unlike `record`, a builder page has exactly one open workflow).
- Prompt section `prompts/sections/workflow-builder.ts`, delivered via the capability's `systemPromptAddition` (KB register: worked examples, "never invent ids"): `{{Node Title.output}}` grammar, upstream rule, node-scoped loop refs only (`{{Loop Title.item}}` — never bare `{{item}}`/`{{loop.index}}`, 09 §5), branches by name, "a FINISHED workflow has exactly one trigger; building with none is fine (warning)", publishing is the user's, no coordinates, multi-workflow honest refusal.
- `BUILTIN_TOOLSETS` entry `workflow.builder` ("Workflow — Builder"); every tool declares `surfaces: ['builder']` + `toolsetSlug: 'workflow.builder'` so chat/email catalogs drop the set and a runtime AI node (page `workflow.ai-node`) can never inherit graph-editing tools.
- Exported through `capabilities/index.ts` + `ai/kopilot/index.ts`; the stream-route `registry.register(createWorkflowBuilderCapabilities(getToolDeps))` for `page === 'workflow.builder'` lands with the web PR. (04 said "register in domain-config.ts", but capability registration actually lives in the stream route's registry — domain-config only fans out lifecycles.)
- Status-pill digests: `buildWorkflowEditDigest` in `kopilot/digests.ts`; labels like "Added HTTP Request", "Connected Find Contact → Send Email [Found]".

## Tests

28 new tests across three files (guard enumeration incl. fail-closed / crafted-ref / instance-rung / system-owned / dirty-gate / turnId scoping; write-tool contract incl. turnId threading, `{{Title.path}}` outputs, coordinate stripping, blocked-edit + CAS surfacing, digests; lifecycle keep-on-complete / revert-on-error / stale-turn rejection; run_node simulated messaging). `tool-permission-declarations` enumeration extended with the new factory; the three discovery tools pinned in `NO_AUTHORIZATION_REQUIRED`.

- `node scripts/ci/typecheck-ratchet.js --package lib` — no new errors (29/29 baseline)
- `pnpm exec vitest run src/ai src/workflows src/workflow-engine` — all green
- biome clean on touched paths
