### PR TITLE
fix(workflow): guard scheduled resolver and isolate resolver crashes

### DIFF
--- a/apps/web/src/components/workflow/store/var-availability.ts
+++ b/apps/web/src/components/workflow/store/var-availability.ts
@@ -35,7 +35,14 @@ export function computeNodeOutputs(
     resolveVariable,
   }
 
-  return nodeDef.outputVariables(data, nodeId, context)
+  // A resolver crash (e.g. a legacy node whose persisted data is missing the
+  // shape the resolver expects) degrades to "no outputs for this node" — one
+  // bad node must not take down the variable picker for the whole graph.
+  try {
+    return nodeDef.outputVariables(data, nodeId, context)
+  } catch {
+    return []
+  }
 }
 
 /**

--- a/packages/lib/src/workflow-engine/catalog/nodes/scheduled.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/scheduled.ts
@@ -158,6 +158,8 @@ export function validateScheduledTriggerData(data: ScheduledTriggerNodeData): No
 export function extractScheduledTriggerVariables(data: ScheduledTriggerNodeData): string[] {
   const variables: string[] = []
   const { config } = data
+  // Legacy/imported rows can lack `config` entirely; nothing to extract.
+  if (!config) return variables
 
   // Extract variables from interval values
   if (config.triggerInterval !== 'custom') {
@@ -215,8 +217,9 @@ function getScheduledTriggerOutputVariables(
     })
   )
 
-  // Schedule configuration
-  if (data.config.triggerInterval === 'custom') {
+  // Schedule configuration. `config` can be absent on legacy/imported rows —
+  // fall through to the interval branch, matching `defaultData()`'s shape.
+  if (data.config?.triggerInterval === 'custom') {
     variables.push(
       createUnifiedOutputVariable({
         nodeId,

--- a/packages/lib/src/workflow-engine/catalog/resolve-outputs.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/resolve-outputs.test.ts
@@ -13,6 +13,24 @@ vi.mock('../../cache', async (importOriginal) => ({
   getCachedResources: (...args: unknown[]) => getCachedResources(...args),
 }))
 
+// Partial mock: a synthetic `__throwing__` type whose resolver always crashes,
+// for the crash-isolation test; every real type passes through untouched.
+vi.mock('./registry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./registry')>()
+  return {
+    ...actual,
+    getManifest: (type: string) =>
+      type === '__throwing__'
+        ? {
+            ...actual.getManifest('wait'),
+            resolveOutputs: () => {
+              throw new Error('boom')
+            },
+          }
+        : actual.getManifest(type),
+  }
+})
+
 const { resolveGraphOutputs, resolveNodeOutputs } = await import('./resolve-outputs')
 
 const noResources = () => {
@@ -209,5 +227,60 @@ describe('resolveNodeOutputs', () => {
 
     await resolveNodeOutputs('org-1', { graph, nodeId: 'n2' })
     expect(getCachedResources).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('resolver crash isolation', () => {
+  it('resolves a scheduled trigger with missing config (legacy rows) without crashing', async () => {
+    noResources()
+    const graph = {
+      nodes: [
+        { id: 's1', type: 'scheduled', data: { id: 's1', type: 'scheduled', title: 'Schedule' } },
+      ],
+      edges: [],
+    }
+
+    const result = await resolveGraphOutputs('org-1', { graph })
+
+    expect(result.isOk()).toBe(true)
+    const ids = (result._unsafeUnwrap().get('s1') ?? []).map((v) => v.id)
+    // No config falls into the interval branch, matching defaultData()'s shape.
+    expect(ids).toEqual([
+      's1.triggered_at',
+      's1.schedule_type',
+      's1.is_test_run',
+      's1.interval_config',
+    ])
+  })
+
+  it('degrades a crashing resolver to empty outputs instead of failing the graph', async () => {
+    noResources()
+    const graph = {
+      nodes: [
+        {
+          id: 'bad',
+          type: '__throwing__',
+          data: { id: 'bad', type: '__throwing__', title: 'Bad' },
+        },
+        varAssignArrayNode('ok', 'items'),
+      ],
+      edges: [],
+    }
+
+    const result = await resolveGraphOutputs('org-1', { graph })
+
+    expect(result.isOk()).toBe(true)
+    const outputs = result._unsafeUnwrap()
+    expect(outputs.get('bad')).toEqual([])
+    expect((outputs.get('ok') ?? []).length).toBeGreaterThan(0)
+  })
+})
+
+describe('scheduled manifest config-less guards', () => {
+  it('extractScheduledTriggerVariables returns [] when config is absent', async () => {
+    const { extractScheduledTriggerVariables } = await import('./nodes/scheduled')
+    expect(
+      extractScheduledTriggerVariables({ id: 's1', type: 'scheduled', title: 'Schedule' } as never)
+    ).toEqual([])
   })
 })

--- a/packages/lib/src/workflow-engine/catalog/resolve-outputs.ts
+++ b/packages/lib/src/workflow-engine/catalog/resolve-outputs.ts
@@ -106,7 +106,14 @@ function resolveInTopoOrder(
     }
 
     const context = buildOutputContextFromResources(allResources, node.data?.resourceType)
-    memo.set(nodeId, manifest.resolveOutputs(node.data, nodeId, { ...context, resolveVariable }))
+    // A resolver crash (e.g. a legacy node whose persisted data is missing the
+    // shape the resolver expects) degrades to "no outputs for this node" — one
+    // bad node must not poison resolution for the whole graph.
+    try {
+      memo.set(nodeId, manifest.resolveOutputs(node.data, nodeId, { ...context, resolveVariable }))
+    } catch {
+      memo.set(nodeId, [])
+    }
   }
 
   return memo


### PR DESCRIPTION
Fixes the `scheduled` output-resolver crash on config-less nodes found during #1604, plus the systemic hardening so no single manifest resolver can take down graph-wide output resolution.

## The bug
`getScheduledTriggerOutputVariables` read `data.config.triggerInterval` unguarded — a scheduled node missing `data.config` (legacy/imported rows, bare test fixtures) threw a `TypeError`. `extractScheduledTriggerVariables` had the same latent pattern. Neither call site caught the throw:
- server: `resolve-outputs.ts` topo walk — one bad node poisoned resolution for the whole graph (readDraft + every Kopilot tool on that workflow)
- web: `var-availability.ts` `computeNodeOutputs` — variable picker computation threw for the whole graph

## The fix
- `scheduled.ts`: `config?.` guard in the resolver (config-less falls into the `interval_config` branch, matching `defaultData()`); early return in the extractor.
- `resolve-outputs.ts` + `var-availability.ts`: resolver calls wrapped so a crash degrades to "no outputs for this node" instead of failing the graph — hardens against the next manifest with this pattern, not just scheduled.

## Tests
3 new in `resolve-outputs.test.ts`: config-less scheduled resolves to its 4 interval-branch outputs; a synthetic always-throwing manifest degrades to `[]` while sibling nodes still resolve; config-less extractor returns `[]`.

Ratchets at baseline (lib 29, web 1); catalog suite 61/61; web store/parity 25/25.