### PR TITLE
fix(chat): block boot attributes from overwriting contact identity fields

### DIFF
--- a/packages/lib/src/chat/attribute-resolution.test.ts
+++ b/packages/lib/src/chat/attribute-resolution.test.ts
@@ -1,0 +1,55 @@
+// packages/lib/src/chat/attribute-resolution.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { resolveChatAttributes } from './attribute-resolution'
+
+describe('resolveChatAttributes — reserved identity claims', () => {
+  it('strips contact identity fields from boot attributes', () => {
+    const { writes } = resolveChatAttributes({
+      bootAttributes: {
+        primary_email: 'attacker@evil.com',
+        phone: '+1555000000',
+        company_website: 'https://evil.com',
+        email: 'attacker@evil.com',
+        plan: 'pro',
+      },
+    })
+
+    expect(writes).not.toHaveProperty('primary_email')
+    expect(writes).not.toHaveProperty('phone')
+    expect(writes).not.toHaveProperty('company_website')
+    expect(writes).not.toHaveProperty('email')
+    expect(writes).toEqual({ plan: 'pro' })
+  })
+
+  it('strips identity fields from every tier, not just boot', () => {
+    const { writes } = resolveChatAttributes({
+      jwtClaims: { primary_email: 'x@y.com', phone: '+1', role: 'admin' },
+      serverAttributes: { company_website: 'https://z.com', city: 'Berlin' },
+      bootAttributes: { primary_email: 'a@b.com' },
+    })
+
+    expect(writes).not.toHaveProperty('primary_email')
+    expect(writes).not.toHaveProperty('phone')
+    expect(writes).not.toHaveProperty('company_website')
+    expect(writes).toEqual({ role: 'admin', city: 'Berlin' })
+  })
+
+  it('strips JWT framing and user_id claims', () => {
+    const { writes } = resolveChatAttributes({
+      jwtClaims: { user_id: 'u1', exp: 1, iat: 1, nbf: 1, iss: 'i', aud: 'a', sub: 's' },
+    })
+
+    expect(writes).toEqual({})
+  })
+
+  it('keeps jwt > server > boot precedence for non-reserved keys', () => {
+    const { writes } = resolveChatAttributes({
+      jwtClaims: { plan: 'enterprise' },
+      serverAttributes: { plan: 'growth', city: 'Berlin' },
+      bootAttributes: { plan: 'free', locale: 'de' },
+    })
+
+    expect(writes).toEqual({ plan: 'enterprise', city: 'Berlin', locale: 'de' })
+  })
+})

--- a/packages/lib/src/chat/attribute-resolution.ts
+++ b/packages/lib/src/chat/attribute-resolution.ts
@@ -1,14 +1,29 @@
 // packages/lib/src/chat/attribute-resolution.ts
 
 /**
- * JWT claim names that are never written as generic Contact attributes.
+ * Claim/attribute names that are never written as generic Contact attributes.
  *
  * - `user_id` is resolved upstream into the Contact's multi-value
  *   `external_id` (as `chat:<user_id>`).
  * - `email` is written to `Contact.primary_email`.
  * - `exp`, `iat`, `nbf`, `iss`, `aud`, `sub` are JWT framing.
+ * - `primary_email`, `phone`, `company_website` are Contact identity fields —
+ *   only server-derived values (e.g. the signed JWT `email` claim) may set
+ *   them, never a spoofable `Auxx.boot()` attribute.
  */
-const RESERVED_CLAIMS = new Set(['user_id', 'email', 'exp', 'iat', 'nbf', 'iss', 'aud', 'sub'])
+const RESERVED_CLAIMS = new Set([
+  'user_id',
+  'email',
+  'exp',
+  'iat',
+  'nbf',
+  'iss',
+  'aud',
+  'sub',
+  'primary_email',
+  'phone',
+  'company_website',
+])
 
 /**
  * Split a display name on the first whitespace.

--- a/packages/lib/src/ingest/contacts/__tests__/find-or-create-from-jwt.test.ts
+++ b/packages/lib/src/ingest/contacts/__tests__/find-or-create-from-jwt.test.ts
@@ -118,6 +118,24 @@ describe('findOrCreateContactFromJwt — chat (app-less) visitor', () => {
     expect(result).toEqual({ contactId: 'new_contact', resolution: 'created' })
   })
 
+  it('never lets a caller attribute override the signed JWT email on create', async () => {
+    const result = await findOrCreateContactFromJwt({
+      organizationId: 'org_1',
+      userId: 'visitor_new',
+      email: 'jane@example.com',
+      // Defense in depth: `primary_email` is already stripped upstream by
+      // resolveChatAttributes, but even a raw bag must not win over the JWT.
+      attributes: { primary_email: 'attacker@evil.com', first_name: 'Jane' },
+    })
+
+    expect(create).toHaveBeenCalledWith('contact', {
+      contact_status: 'ACTIVE',
+      first_name: 'Jane',
+      primary_email: 'jane@example.com',
+    })
+    expect(result.resolution).toBe('created')
+  })
+
   it('email-folds onto an existing contact and mirrors the chat link (no duplicate)', async () => {
     findByField.mockResolvedValueOnce({ id: 'existing_contact' })
 

--- a/packages/lib/src/ingest/contacts/find-or-create-from-jwt.ts
+++ b/packages/lib/src/ingest/contacts/find-or-create-from-jwt.ts
@@ -130,11 +130,13 @@ export async function findOrCreateContactFromJwt(
     }
   }
 
-  // Tier 3 — create on first sight.
+  // Tier 3 — create on first sight. Server-derived identity fields are spread
+  // AFTER the caller attribute bag so no attribute can override the signed
+  // JWT email.
   const { instance } = await handler.create('contact', {
-    ...(email ? { primary_email: email } : {}),
     contact_status: 'ACTIVE',
     ...attributes,
+    ...(email ? { primary_email: email } : {}),
   })
   if (!shopify && contactDefId) {
     await mirrorChatLink({ organizationId, contactDefId, contactId: instance.id, userId })


### PR DESCRIPTION
## Security fix — RESERVED_CLAIMS hole (item B2, ship-now, of `plans/custom-field/multi/04-multi-email-implementation-plan.md`)

### The hole

Client-supplied `Auxx.boot({ attributes })` values flow through `resolveChatAttributes` into the contact write path in `findOrCreateContactFromJwt`. The reserved-claim filter stripped only the literal key `email`, so a boot attribute named `primary_email` (or `phone` / `company_website`) could overwrite a matched contact's stored identity fields. Additionally, on contact create the attribute bag was spread after `primary_email`, so a boot attribute could override even the signed JWT email.

### The fix

- `packages/lib/src/chat/attribute-resolution.ts`: `RESERVED_CLAIMS` now also blocks `primary_email`, `phone`, and `company_website` (stripped from every tier, same as the existing reserved names). Identity fields can only be set by server-derived values (the signed JWT `email` claim).
- `packages/lib/src/ingest/contacts/find-or-create-from-jwt.ts`: create-path spread order fixed — the JWT-derived `primary_email` is now applied after `...attributes`, so no caller attribute can override it (defense in depth on top of the filter).
- Traced the tier-2 UPDATE path (email-fold): the only caller (`apps/api/src/routes/chat/passport.ts`) passes the bag through `resolveChatAttributes` before `findOrCreateContactFromJwt`, so the update path is covered by the filter change. No second path delivers raw boot attributes to the contact write.

Out of scope (deliberately untouched): participant promotion, uniqueness hooks, and the rest of item B2's follow-ups.

### Tests

- New `packages/lib/src/chat/attribute-resolution.test.ts` (pure unit): identity fields stripped from boot attributes and from every tier; JWT framing claims stripped; jwt > server > boot precedence preserved for non-reserved keys.
- Extended `packages/lib/src/ingest/contacts/__tests__/find-or-create-from-jwt.test.ts`: on create, the signed JWT email wins even when the attribute bag contains `primary_email`.

11/11 tests pass; Biome clean; `tsc --noEmit` in `packages/lib` has no errors in touched files (remaining errors are pre-existing in `scripts/`).