### PR TITLE
fix(web): clear the apps/web typecheck baseline

### DIFF
--- a/apps/web/src/app/api/kopilot/stream/route.ts
+++ b/apps/web/src/app/api/kopilot/stream/route.ts
@@ -8,6 +8,7 @@ import {
   resolveAgentKnowledgeScope,
 } from '@auxx/lib/agents'
 import {
+  type AgentDomainConfig,
   AgentEngine,
   type AgentEngineConfig,
   type AgentEvent,
@@ -936,7 +937,18 @@ async function runInProcessPath(params: {
     userId,
     sessionId,
     db,
-    domainConfig,
+    // The engine treats domain state as opaque `Record<string, unknown>`, but
+    // `AgentDomainConfig` is contravariant in its state generic (`buildMessages`
+    // and friends take `AgentState<T>` as a parameter) — so the concrete
+    // `AgentDomainConfig<KopilotDomainState>` is not assignable to the default.
+    // Widen at this single boundary, the same conversion `buildChatEngineConfig`
+    // and `buildEffectiveAgentRuntime` already perform — this call site was
+    // simply the one that never got it.
+    //
+    // Kept local rather than relaxing `AgentEngineConfig.domainConfig` itself to
+    // `AgentDomainConfig<any>`: that would push an `any` into a widely-exported
+    // interface to spare three call sites a cast.
+    domainConfig: domainConfig as unknown as AgentDomainConfig,
     callModel,
     signal: request.signal,
     maxTotalIterations: 100,

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,6 +2,24 @@
   "extends": "@auxx/typescript-config/nextjs.json",
   "compilerOptions": {
     "incremental": true,
+    // Turn OFF the declaration emit inherited from `base.json`. That base is
+    // shared with the packages, which are consumed through `dist/` and genuinely
+    // need it; `apps/web` is a leaf Next.js app that already sets `noEmit: true`
+    // and has zero inbound project references, so it never emits a `.d.ts` at all.
+    //
+    // Leaving it on is not free: tsc still computes declaration-emit diagnostics
+    // for output it never writes, and `apps/web` carries ~220 of them (TS2883 /
+    // TS4023 / TS4058 — "inferred type cannot be named without a reference to
+    // …", mostly tRPC inference in `src/trpc/*` and the API routers).
+    //
+    // Those were invisible until 2026-08 because declaration diagnostics are only
+    // computed when tsc actually emits, and tsc skips emit when the program has a
+    // semantic error — so the single baselined TS2322 in
+    // `api/kopilot/stream/route.ts` was suppressing all of them. Fixing that one
+    // error surfaced the lot. See `scripts/ci/typecheck-baseline.json`.
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
     "moduleResolution": "Bundler",
     "paths": {
       "~/*": ["./src/*"]

--- a/scripts/ci/typecheck-baseline.json
+++ b/scripts/ci/typecheck-baseline.json
@@ -9,8 +9,6 @@
       "scripts/verify-learned-kb.ts::TS2339": 3,
       "vitest.integration.config.ts::TS2769": 1
     },
-    "web": {
-      "src/app/api/kopilot/stream/route.ts::TS2322": 1
-    }
+    "web": {}
   }
 }


### PR DESCRIPTION
Takes `apps/web` from **1 baselined type error to 0**, cold.

## The one-line fix

`AgentDomainConfig<T>` is **contravariant** in `T` — `buildMessages`, `applyContext` and `onToolResult` all take `AgentState<T>` as a *parameter* — so a concrete `AgentDomainConfig<KopilotDomainState>` is not assignable to the `Record<string, unknown>` default that `AgentEngineConfig.domainConfig` declares.

Two call sites already widen at that boundary:

- `packages/lib/src/chat/agent/build-chat-engine-config.ts:227`
- `packages/lib/src/ai/agent-framework/effective-runtime.ts:332`

The kopilot stream route never did. That's the single `TS2322` the web baseline has been carrying.

## Why it isn't a one-line change

That error was **load-bearing**.

Declaration-emit diagnostics are only computed when tsc actually emits, and tsc skips emit when the program has a semantic error. So the single `TS2322` was suppressing declaration checking for the entire app. Removing it surfaces **~220 latent errors** across ~59 file/code groups:

| Where | Codes |
|---|---|
| `src/trpc/vanilla.ts`, `react.tsx`, `server.ts` | TS2883 ×53, TS4023 ×10, TS7056 ×2 |
| `src/server/api/routers/*` (billing, comment, file, folder, kb, record, recording, segment, thread, data-connectors) | TS2883, TS4023 |
| `src/test/mocks.ts`, `src/test/utils.tsx` | TS2883 ×18 |
| `src/components/apps/runtime/component-registry.tsx`, `src/components/fields/displays/display-field.tsx`, … | TS4023, TS4058 |

All of the form *"inferred type cannot be named without a reference to …"*, nearly all of it tRPC inference.

Verified by isolation — pristine `HEAD` + cold cache → 1 error; apply only the cast + cold cache → 220.

## Why turning declaration emit off is correct, not a suppression

`apps/web` is a **leaf Next.js app**:

- it already sets `noEmit: true`, so it never emits a `.d.ts` at all;
- **zero inbound project references** — no tsconfig in the repo has a `"path"` to `apps/web`.

It inherits `composite` / `declaration` / `declarationMap` from `packages/typescript-config/base.json`, which is shared with the packages — those are consumed through `dist/` and genuinely need it. The app was paying for portability checks on an artifact that is never produced.

So the three flags are turned off for `apps/web` specifically, with the mechanism documented inline in the tsconfig so nobody re-enables it and rediscovers this the hard way.

## Rejected alternative

Widening `AgentEngineConfig.domainConfig` to `AgentDomainConfig<any>` removes the need for a cast at all three sites — but it pushes an `any` into a widely-exported interface to save three casts. Kept the cast local, consistent with the two existing sites.

## Testing

- `node scripts/ci/typecheck-ratchet.js --package web` → `no new type errors (0 total, baseline 0)`, run cold (`tsconfig.tsbuildinfo` deleted) with the CI prep steps (`@auxx/chat build`, `next typegen`).
- Baseline re-recorded: `"web": {}`.
- Biome clean on all three changed files.
- No runtime behaviour change — one type assertion and a compiler-options change.