### PR TITLE
fix(records): deterministic primary-value reads via sortkey ordering

### DIFF
--- a/apps/api/src/routes/entities/find-contact-by-email.ts
+++ b/apps/api/src/routes/entities/find-contact-by-email.ts
@@ -4,9 +4,10 @@
  * Lambda SDK callback for `ctx.entities.findContactByEmail`.
  *
  * Authorized via the `entities` callback token scope minted by
- * `prepareLambdaContext` for AI tool invocations. Looks up a contact-kind
- * EntityInstance whose primary EMAIL FieldValue matches (case-insensitive)
- * and returns the auxx recordId (`<defId>:<instId>`) plus display name.
+ * `prepareLambdaContext` for AI tool invocations. Looks up a non-archived
+ * contact-kind EntityInstance with any EMAIL FieldValue matching
+ * (case-insensitive) and returns the auxx recordId (`<defId>:<instId>`)
+ * plus display name. Ties resolve to the first row by ascending sortKey.
  *
  * Used by integrations that don't have a contact-import source path —
  * Slack first, Gmail next. See plans/kopilot/apps/slack-overhaul.md §6.
@@ -14,7 +15,7 @@
 
 import { database, schema } from '@auxx/database'
 import { getCachedCustomFields, getCachedEntityDefId } from '@auxx/lib/cache'
-import { and, eq, inArray, sql } from 'drizzle-orm'
+import { and, asc, eq, inArray, isNull, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { z } from 'zod'
 import { verifyCallbackAuth } from '../../lib/callback-auth'
@@ -61,7 +62,13 @@ findContactByEmail.post('/find-contact-by-email', async (c) => {
       displayName: schema.EntityInstance.displayName,
     })
     .from(schema.FieldValue)
-    .innerJoin(schema.EntityInstance, eq(schema.EntityInstance.id, schema.FieldValue.entityId))
+    .innerJoin(
+      schema.EntityInstance,
+      and(
+        eq(schema.EntityInstance.id, schema.FieldValue.entityId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
     .where(
       and(
         eq(schema.FieldValue.organizationId, auth.organizationId),
@@ -70,6 +77,7 @@ findContactByEmail.post('/find-contact-by-email', async (c) => {
         sql`lower(${schema.FieldValue.valueText}) = ${email}`
       )
     )
+    .orderBy(asc(schema.FieldValue.sortKey), asc(schema.EntityInstance.id))
     .limit(1)
 
   const hit = row[0]

--- a/apps/api/src/routes/entities/find-contact-by-phone.ts
+++ b/apps/api/src/routes/entities/find-contact-by-phone.ts
@@ -5,9 +5,10 @@
  *
  * Authorized via the `entities` callback token scope minted by
  * `prepareLambdaContext` for AI tool invocations. Normalizes the input
- * phone to E.164 (when possible), then looks up a contact-kind
- * EntityInstance whose PHONE-type FieldValue matches (case-insensitive
+ * phone to E.164 (when possible), then looks up a non-archived contact-kind
+ * EntityInstance with any PHONE-type FieldValue matching (case-insensitive
  * exact). Returns the auxx recordId (`<defId>:<instId>`) plus display name.
+ * Ties resolve to the first row by ascending sortKey.
  *
  * Used by integrations whose identity is keyed on a phone number —
  * WhatsApp first, Twilio next. See plans/kopilot/apps/whatsapp-overhaul.md §6.
@@ -15,7 +16,7 @@
 
 import { database, schema } from '@auxx/database'
 import { getCachedCustomFields, getCachedEntityDefId } from '@auxx/lib/cache'
-import { and, eq, inArray, sql } from 'drizzle-orm'
+import { and, asc, eq, inArray, isNull, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { z } from 'zod'
 import { verifyCallbackAuth } from '../../lib/callback-auth'
@@ -81,7 +82,13 @@ findContactByPhone.post('/find-contact-by-phone', async (c) => {
       displayName: schema.EntityInstance.displayName,
     })
     .from(schema.FieldValue)
-    .innerJoin(schema.EntityInstance, eq(schema.EntityInstance.id, schema.FieldValue.entityId))
+    .innerJoin(
+      schema.EntityInstance,
+      and(
+        eq(schema.EntityInstance.id, schema.FieldValue.entityId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
     .where(
       and(
         eq(schema.FieldValue.organizationId, auth.organizationId),
@@ -90,6 +97,7 @@ findContactByPhone.post('/find-contact-by-phone', async (c) => {
         sql`lower(${schema.FieldValue.valueText}) = ${normalized.toLowerCase()}`
       )
     )
+    .orderBy(asc(schema.FieldValue.sortKey), asc(schema.EntityInstance.id))
     .limit(1)
 
   const hit = row[0]

--- a/packages/lib/src/ai/kopilot/capabilities/mail/recipient-resolver.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/recipient-resolver.ts
@@ -3,7 +3,7 @@
 import { schema } from '@auxx/database'
 import type { IdentifierType } from '@auxx/database/types'
 import { isRecordId, parseRecordId, type RecordId } from '@auxx/types/resource'
-import { and, desc, eq, inArray } from 'drizzle-orm'
+import { and, asc, desc, eq, inArray } from 'drizzle-orm'
 import type { IntegrationCatalogEntry } from '../../../../cache/integration-catalog'
 import { getCachedCustomFields } from '../../../../cache/org-cache-helpers'
 import { Result, type TypedResult } from '../../../../result'
@@ -86,6 +86,8 @@ function systemAttributeForChannel(
  * is the canonical place where a contact's email lives — the `Participant`
  * table only has a row when a thread/message has actually been recorded with
  * that contact, which isn't true for brand-new CRM contacts.
+ *
+ * The primary value is the FIRST row by ascending `sortKey`.
  */
 async function lookupIdentifierFromFieldValue(
   ctx: ToolContext,
@@ -105,7 +107,7 @@ async function lookupIdentifierFromFieldValue(
       eq(schema.FieldValue.entityId, entityInstanceId),
       inArray(schema.FieldValue.fieldId, matchingFieldIds)
     ),
-    orderBy: [desc(schema.FieldValue.updatedAt)],
+    orderBy: [asc(schema.FieldValue.sortKey)],
   })
   for (const row of rows) {
     const value = row.valueText?.trim()
@@ -127,8 +129,9 @@ function detectFormat(entry: string): 'recordId' | 'participantId' | 'email' | '
  * identifiers) into concrete `ResolvedRecipient` rows for the given channel.
  *
  * - **recordId**: looks up the contact's participants matching the channel's
- *   `recipientModel`, picks the most recently used (no primary flag exists on
- *   `Participant` today).
+ *   `recipientModel`, prefers the one matching the contact's primary
+ *   identifier (first FieldValue row by sortKey), else the most recently
+ *   used in a stable order (no primary flag exists on `Participant` today).
  * - **participantId**: fetches by id, validates `identifierType` matches the
  *   channel.
  * - **raw**: validated for shape; passed through with no participantId.
@@ -170,7 +173,11 @@ export async function resolveRecipients(
           inArray(schema.Participant.entityInstanceId, instanceIds),
           inArray(schema.Participant.identifierType, acceptableTypes as IdentifierType[])
         ),
-        orderBy: [desc(schema.Participant.lastSentMessageAt), desc(schema.Participant.updatedAt)],
+        orderBy: [
+          desc(schema.Participant.lastSentMessageAt),
+          desc(schema.Participant.updatedAt),
+          asc(schema.Participant.id),
+        ],
       })
     : []
 
@@ -200,7 +207,22 @@ export async function resolveRecipients(
       case 'recordId': {
         const parsed = parseRecordId(entry.value as RecordId)
         const matches = byInstance.get(parsed.entityInstanceId)
-        const pick = matches?.[0]
+        // The contact's primary identifier: first FieldValue row by sortKey.
+        const sysAttr = systemAttributeForChannel(integration)
+        const primaryIdentifier = sysAttr
+          ? await lookupIdentifierFromFieldValue(
+              ctx,
+              parsed.entityDefinitionId,
+              parsed.entityInstanceId,
+              sysAttr.systemAttributes
+            )
+          : undefined
+        // Prefer the participant matching the primary identifier; otherwise
+        // fall back to the stable most-recently-used ordering above.
+        const pick =
+          (primaryIdentifier &&
+            matches?.find((p) => p.identifier.toLowerCase() === primaryIdentifier.toLowerCase())) ||
+          matches?.[0]
         if (pick) {
           resolved.push({
             recordId: entry.value,
@@ -213,31 +235,23 @@ export async function resolveRecipients(
           break
         }
         // Fallback: no Participant row yet (brand-new contact with only the
-        // identifier set as a field value). Read directly from FieldValue via
-        // the contact's primary_email / phone systemAttribute.
-        const sysAttr = systemAttributeForChannel(integration)
-        if (sysAttr) {
-          const identifier = await lookupIdentifierFromFieldValue(
-            ctx,
-            parsed.entityDefinitionId,
-            parsed.entityInstanceId,
-            sysAttr.systemAttributes
-          )
-          if (identifier) {
-            resolved.push({
-              recordId: entry.value,
-              identifier:
-                sysAttr.identifierType === 'EMAIL'
-                  ? identifier.toLowerCase()
-                  : sysAttr.identifierType === 'PHONE'
-                    ? identifier.replace(/[\s().-]/g, '')
-                    : identifier,
-              identifierType: sysAttr.identifierType,
-              role: entry.role,
-              displayName: identifier,
-            })
-            break
-          }
+        // identifier set as a field value). Use the primary identifier read
+        // from FieldValue via the contact's primary_email / phone
+        // systemAttribute above.
+        if (sysAttr && primaryIdentifier) {
+          resolved.push({
+            recordId: entry.value,
+            identifier:
+              sysAttr.identifierType === 'EMAIL'
+                ? primaryIdentifier.toLowerCase()
+                : sysAttr.identifierType === 'PHONE'
+                  ? primaryIdentifier.replace(/[\s().-]/g, '')
+                  : primaryIdentifier,
+            identifierType: sysAttr.identifierType,
+            role: entry.role,
+            displayName: primaryIdentifier,
+          })
+          break
         }
         return Result.error(
           new RecipientResolutionError(

--- a/packages/lib/src/record-rules/snapshot-fetcher.ts
+++ b/packages/lib/src/record-rules/snapshot-fetcher.ts
@@ -33,7 +33,9 @@ export async function fetchResourceSnapshots(
     const rows = await db.query.EntityInstance.findMany({
       where: (t, { and, eq, inArray }) =>
         and(eq(t.organizationId, organizationId), inArray(t.id, chunk)),
-      with: { values: { with: { field: true } } },
+      with: {
+        values: { orderBy: (t, { asc }) => [asc(t.sortKey)], with: { field: true } },
+      },
     })
 
     for (const inst of rows as Array<Record<string, any>>) {
@@ -42,6 +44,8 @@ export async function fetchResourceSnapshots(
         const field = value.field
         if (!field) continue
         const key = field.systemAttribute ?? field.id
+        // First row by ascending sortKey wins — that row is the primary value.
+        if (key in fieldValues) continue
         fieldValues[key] = extractFieldValueScalar(value)
       }
       out.set(toRecordId(inst.entityDefinitionId, inst.id), {

--- a/packages/lib/src/recording/calendar/participant-resolver.ts
+++ b/packages/lib/src/recording/calendar/participant-resolver.ts
@@ -116,7 +116,7 @@ export async function findCompanyByDomain(
           ilike(schema.FieldValue.valueText, `%${normalizedDomain}%`)
         )
       )
-      .orderBy(asc(schema.FieldValue.entityId))
+      .orderBy(asc(schema.FieldValue.sortKey), asc(schema.FieldValue.entityId))
       .limit(1)
 
     return ok(match?.entityId ?? null)
@@ -203,15 +203,22 @@ export async function resolveContactEmails(
         inArray(schema.FieldValue.entityId, entityInstanceIds)
       )
     )
+    .orderBy(asc(schema.FieldValue.sortKey))
 
-  return rows
-    .filter((r) => r.email)
-    .map((r) => ({
-      email: r.email!,
-      name: null,
-      responseStatus: null,
-      organizer: false as const,
-    }))
+  // One attendee per contact: the primary email (first row by sortKey).
+  const seen = new Set<string>()
+  const attendees: Array<{
+    email: string
+    name: null
+    responseStatus: null
+    organizer: false
+  }> = []
+  for (const row of rows) {
+    if (!row.email || seen.has(row.entityId)) continue
+    seen.add(row.entityId)
+    attendees.push({ email: row.email, name: null, responseStatus: null, organizer: false })
+  }
+  return attendees
 }
 
 /**
@@ -276,6 +283,7 @@ async function findContactEntityInstanceIdByEmail(
           isNull(schema.EntityInstance.archivedAt)
         )
       )
+      .orderBy(asc(schema.FieldValue.sortKey), asc(schema.EntityInstance.id))
       .limit(1)
 
     return ok(match?.entityId ?? null)

--- a/packages/sdk/src/server/entities.ts
+++ b/packages/sdk/src/server/entities.ts
@@ -166,12 +166,12 @@ export async function findByIntegrationId(input: {
   return sdkOrThrow().findByIntegrationId(input)
 }
 
-/** Resolve a contact by its primary email. */
+/** Resolve a contact by any of its email addresses (case-insensitive). */
 export async function findContactByEmail(input: { email: string }): Promise<EntityRef | null> {
   return sdkOrThrow().findContactByEmail(input)
 }
 
-/** Resolve a contact by its primary phone (normalized to E.164 server-side). */
+/** Resolve a contact by any of its phone numbers (normalized to E.164 server-side). */
 export async function findContactByPhone(input: { phone: string }): Promise<EntityRef | null> {
   return sdkOrThrow().findContactByPhone(input)
 }

--- a/packages/services/src/field-values/get-existing-value.ts
+++ b/packages/services/src/field-values/get-existing-value.ts
@@ -1,7 +1,7 @@
 // packages/services/src/field-values/get-existing-value.ts
 
 import { database, schema } from '@auxx/database'
-import { and, eq } from 'drizzle-orm'
+import { and, asc, eq } from 'drizzle-orm'
 import { ok } from 'neverthrow'
 import { fromDatabase } from '../shared/utils'
 import type { GetExistingValueInput } from './types'
@@ -40,6 +40,7 @@ export async function getExistingFieldValue(input: GetExistingValueInput) {
           eq(schema.FieldValue.organizationId, organizationId)
         )
       )
+      .orderBy(asc(schema.FieldValue.sortKey))
       .limit(1),
     'get-existing-field-value'
   )


### PR DESCRIPTION
## What

Several field-value read paths did `.limit(1)` (or mapped every row) with no ORDER BY, so which email/phone row "wins" was arbitrary — live non-determinism bugs regardless of the multi-value-email feature. This PR establishes the convention that the **first row by ascending `sortKey` is the primary value**, and makes every remaining pick deterministic. Item A4 of `plans/custom-field/multi/04-multi-email-implementation-plan.md`.

## Changes

- **`packages/services/src/field-values/get-existing-value.ts`** — `.limit(1)` had no ORDER BY; now `orderBy(asc(FieldValue.sortKey))`, so the UPDATE-vs-INSERT check for single-value fields always sees the primary row.
- **`packages/lib/src/ai/kopilot/capabilities/mail/recipient-resolver.ts`** — was the only read ordering `desc(FieldValue.updatedAt)` (contradicting first-is-primary); now `asc(sortKey)`. The recordId→Participant pick is now deterministic: prefer the participant whose identifier matches the contact's primary (first-by-sortKey) FieldValue identifier, else the most-recently-used order with an `asc(id)` tiebreak. The no-participant fallback reuses the already-resolved primary identifier instead of a second query.
- **`packages/lib/src/record-rules/snapshot-fetcher.ts`** — the relational `values` load had no ordering and the loop let the *last* row win, so automation conditions on email could flip between runs; now ordered `asc(sortKey)` with first-row-wins per field key.
- **`packages/lib/src/recording/calendar/participant-resolver.ts`** —
  - `resolveContactEmails` emitted an attendee for *every* email row of a contact; now dedupes per contact, emitting only the primary (first by sortKey).
  - `findContactEntityInstanceIdByEmail` `.limit(1)` now has `orderBy(asc(FieldValue.sortKey), asc(EntityInstance.id))`.
  - `findCompanyByDomain` now leads its existing `asc(entityId)` order with `asc(sortKey)` (a primary-website match beats an alias match).
- **`apps/api/src/routes/entities/find-contact-by-email.ts` / `find-contact-by-phone.ts`** — matching semantics unchanged (still row-level / any-address match), but the `.limit(1)` now has `orderBy(asc(FieldValue.sortKey), asc(EntityInstance.id))`, and **archived records are excluded** via `isNull(EntityInstance.archivedAt)` on the EntityInstance join (mirrors `findCompanyByDomain`).
- **`packages/sdk/src/server/entities.ts`** — docstrings for `findContactByEmail`/`findContactByPhone` corrected from "primary email/phone" to "any of its email addresses / phone numbers", matching what the routes actually do (route file headers updated to match).

## Not changed

No write paths, no helpers, no new files — ORDER BY + archived filters + docstrings only.

## Verification

- Biome lint clean on all seven files.
- `tsc --noEmit` clean for `@auxx/services`, `@auxx/sdk`, `@auxx/api`; `packages/lib` shows only pre-existing errors in `scripts/` / `vitest.integration.config.ts`, none in touched files.
- No existing vitest harness covers these read paths (`handle-sync-record-rules.test.ts` fully mocks `fetchResourceSnapshots`), so no ordering tests were added.