### PR TITLE
feat(records): multi-value contracts — primaryValue helper, cap constant, structured conflict error

### DIFF
--- a/packages/lib/src/errors.ts
+++ b/packages/lib/src/errors.ts
@@ -69,6 +69,35 @@ export class ConflictError extends AuxxError {
   public name = AuxxErrorCodes.ConflictError
 }
 
+/**
+ * A unique-value conflict that identifies WHICH value collided. Thrown by
+ * per-value uniqueness checks on multi-value fields (contact email hooks,
+ * `checkUniqueValueTyped`), where callers that write several values in one
+ * operation (connector sink, import) must drop only the offending value and
+ * keep the rest. Serializes as a plain 409 ConflictError over the API.
+ */
+export class UniqueValueConflictError extends ConflictError {
+  public conflictingValue: string
+  public fieldId?: string
+  public existingEntityId?: string
+
+  constructor(params: {
+    message: string
+    conflictingValue: string
+    fieldId?: string
+    existingEntityId?: string
+  }) {
+    super(params.message, {
+      conflictingValue: params.conflictingValue,
+      fieldId: params.fieldId,
+      existingEntityId: params.existingEntityId,
+    })
+    this.conflictingValue = params.conflictingValue
+    this.fieldId = params.fieldId
+    this.existingEntityId = params.existingEntityId
+  }
+}
+
 export class UnprocessableEntityError extends AuxxError {
   public statusCode = 422
   public name = AuxxErrorCodes.UnprocessableEntityError

--- a/packages/lib/src/field-values/client.ts
+++ b/packages/lib/src/field-values/client.ts
@@ -45,6 +45,8 @@ export {
   type SelectFieldOptions,
   type TextFieldOptions,
 } from './formatter'
+// Multi-value scalar helpers (first-is-primary convention)
+export { MAX_MULTI_VALUES, primaryValue } from './primary-value'
 // Relationship utilities
 // Re-export RecordId utilities from resources
 export {

--- a/packages/lib/src/field-values/index.ts
+++ b/packages/lib/src/field-values/index.ts
@@ -118,6 +118,8 @@ export {
 } from './formatter'
 // Read-side value normalization for lookupByField
 export { normalizeForLookup } from './normalize-for-lookup'
+// Multi-value scalar helpers (first-is-primary convention)
+export { MAX_MULTI_VALUES, primaryValue } from './primary-value'
 // Relationship error types
 export {
   createCircularReferenceError,

--- a/packages/lib/src/field-values/primary-value.ts
+++ b/packages/lib/src/field-values/primary-value.ts
@@ -1,0 +1,21 @@
+// packages/lib/src/field-values/primary-value.ts
+
+/**
+ * Maximum number of values a multi-value scalar field (`options.multi`) may hold.
+ * Enforced at the write path (`validateAndConvertValue`, `addValues`) and mirrored
+ * in the UI (picker hides its create row at the cap).
+ */
+export const MAX_MULTI_VALUES = 10
+
+/**
+ * First-is-primary unwrap for multi-value scalar fields.
+ *
+ * Field values on `options.multi` fields read back as arrays ordered by `sortKey`;
+ * by convention the first value is the primary. Single-value fields pass through
+ * unchanged. Use this everywhere a scalar consumer (sequences, compose, documents,
+ * placeholders, connectors) needs one representative value.
+ */
+export function primaryValue<T>(value: T | T[] | null | undefined): T | null {
+  if (value == null) return null
+  return Array.isArray(value) ? (value[0] ?? null) : value
+}


### PR DESCRIPTION
Keel PR for `plans/custom-field/multi/04-multi-email-implementation-plan.md` — the shared contracts every implementation lane codes against, so the lanes can land in parallel:

- **`primaryValue<T>()`** (`@auxx/lib/field-values` + `/client`): first-is-primary unwrap for `options.multi` fields (plan item A3). Retires six local copies in follow-up lane PRs.
- **`MAX_MULTI_VALUES = 10`**: the value cap constant (A5/C3/D3 all reference it).
- **`UniqueValueConflictError extends ConflictError`** (`@auxx/lib/errors`): carries `conflictingValue` / `fieldId` / `existingEntityId` structurally so per-value writers (connector sink B1, import B3) can drop only the offending value instead of failing the record. Serializes as a plain 409 over the API (`name` stays `ConflictError`).

No behavior change — nothing consumes these yet. Typecheck (lib, 8GB heap): clean except known pre-existing `scripts/*` errors. Biome clean.