### PR TITLE
fix(records): re-point participants, threads and connector items on merge

### DIFF
--- a/apps/web/src/components/merge/merge-dialog.tsx
+++ b/apps/web/src/components/merge/merge-dialog.tsx
@@ -16,6 +16,7 @@ import { Kbd } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useRecords, useResource } from '~/components/resources'
+import { useNormalizedDefinitionId } from '~/components/resources/utils/normalize-record-id'
 import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { MergePreviewPanel } from './merge-preview-panel'
@@ -57,12 +58,6 @@ export function MergeDialog({
   // Get resource definition for label and fields
   const { resource } = useResource(entityDefinitionId ?? '')
 
-  // Per-def write gate (Layer 2 × Layer 3) — merge is a record write (`edit`
-  // floor). Central guard covering every merge trigger (records view, ticket
-  // row actions, detail view). The server enforces regardless.
-  const { canEditEntity } = useAccess()
-  const canEdit = entityDefinitionId ? canEditEntity(entityDefinitionId) : false
-
   // State: target and sources (sources = everything except target)
   // Undefined only when opened with an empty `baseRecordIds` — the dialog
   // renders nothing in that case (guard below).
@@ -78,6 +73,18 @@ export function MergeDialog({
     [targetRecordId, sourceRecordIds]
   )
   const { records, isLoading: recordsLoading } = useRecords({ recordIds: allRecordIds })
+
+  // Per-row DELETE gate — merge permanently removes the source records, so the
+  // server asserts the delete verb PER ROW for the target and every source
+  // (`assertCanDeleteRows` in record.merge). Mirror that here from each row's
+  // server-resolved `_access` stamp, with the member's def rung as the
+  // unstamped fallback — the same resolution as `useRecordAccessAt`.
+  const { canDeleteRecordAt, recordDefRung } = useAccess()
+  const normalizedDefId = useNormalizedDefinitionId(entityDefinitionId ?? '')
+  const canDeleteAll = useMemo(() => {
+    const defRung = (normalizedDefId ? recordDefRung(normalizedDefId) : undefined) ?? 'none'
+    return records.every((record) => canDeleteRecordAt(record?._access ?? defRung))
+  }, [records, normalizedDefId, recordDefRung, canDeleteRecordAt])
 
   // Reset state when dialog closes
   useEffect(() => {
@@ -140,7 +147,7 @@ export function MergeDialog({
 
   /** Execute merge */
   const handleMerge = () => {
-    if (sourceRecordIds.length === 0 || !targetRecordId || !canEdit) return
+    if (sourceRecordIds.length === 0 || !targetRecordId || !canDeleteAll) return
 
     mergeMutation.mutate({
       targetRecordId,
@@ -149,7 +156,7 @@ export function MergeDialog({
   }
 
   const resourceLabel = resource?.label ?? 'Record'
-  const canMerge = sourceRecordIds.length > 0 && canEdit
+  const canMerge = sourceRecordIds.length > 0 && canDeleteAll
 
   // Nothing to merge into — every caller mounts this dialog with a selection.
   if (!targetRecordId) return null

--- a/packages/lib/src/resources/merge/merge-service-links.test.ts
+++ b/packages/lib/src/resources/merge/merge-service-links.test.ts
@@ -1,0 +1,65 @@
+// packages/lib/src/resources/merge/merge-service-links.test.ts
+// Merge must re-point mail participant links, thread primaries, and connector
+// item bindings onto the target — archive is a soft delete, so without these
+// blanket UPDATEs the archived source keeps all mail history (participant
+// links only fill when NULL) and every later connector sync rebinds to it.
+// plans/custom-field/multi/04-multi-email-implementation-plan.md D1 + D4.
+
+import { schema } from '@auxx/database'
+import { describe, expect, it, vi } from 'vitest'
+import { BadRequestError } from '../../errors'
+import { EntityMergeService } from './merge-service'
+
+const ORG_ID = 'org1'
+const TARGET_ID = 'target1'
+const SOURCE_A = 'sourceA'
+const SOURCE_B = 'sourceB'
+
+function makeService() {
+  return new EntityMergeService({} as never, ORG_ID, 'user1')
+}
+
+/** Minimal tx double covering only the update chain — the method issues no reads. */
+function buildTx() {
+  const updateWhere = vi.fn().mockResolvedValue(undefined)
+  const set = vi.fn(() => ({ where: updateWhere }))
+  const update = vi.fn(() => ({ set }))
+  return { update, set, updateWhere }
+}
+
+describe('EntityMergeService.redirectMailAndConnectorLinks', () => {
+  it('re-points Participant, ThreadParticipant, Thread.primary and DataConnectorItem rows', async () => {
+    const tx = buildTx()
+    const service = makeService()
+
+    await (service as any).redirectMailAndConnectorLinks(tx, [SOURCE_A, SOURCE_B], TARGET_ID)
+
+    // One blanket UPDATE per table, identified by table reference (columns are
+    // unassertable under the vitest schema mock — see src/test/setup.ts).
+    expect(tx.update).toHaveBeenCalledTimes(4)
+    expect(tx.update).toHaveBeenNthCalledWith(1, schema.Participant)
+    expect(tx.update).toHaveBeenNthCalledWith(2, schema.ThreadParticipant)
+    expect(tx.update).toHaveBeenNthCalledWith(3, schema.Thread)
+    expect(tx.update).toHaveBeenNthCalledWith(4, schema.DataConnectorItem)
+
+    // Participant / ThreadParticipant / DataConnectorItem re-point entityInstanceId;
+    // Thread re-points its denormalized primary link.
+    expect(tx.set).toHaveBeenNthCalledWith(1, { entityInstanceId: TARGET_ID })
+    expect(tx.set).toHaveBeenNthCalledWith(2, { entityInstanceId: TARGET_ID })
+    expect(tx.set).toHaveBeenNthCalledWith(3, { primaryEntityInstanceId: TARGET_ID })
+    expect(tx.set).toHaveBeenNthCalledWith(4, { entityInstanceId: TARGET_ID })
+
+    // Every update chain completes through `.where(...)`.
+    expect(tx.updateWhere).toHaveBeenCalledTimes(4)
+  })
+})
+
+describe('EntityMergeService.validateMergeInput', () => {
+  it('throws AuxxError (not TRPCError) on invalid input', async () => {
+    const service = makeService()
+
+    await expect(
+      service.merge({ targetRecordId: 'def1:target1', sourceRecordIds: [] } as never)
+    ).rejects.toBeInstanceOf(BadRequestError)
+  })
+})

--- a/packages/lib/src/resources/merge/merge-service.ts
+++ b/packages/lib/src/resources/merge/merge-service.ts
@@ -3,9 +3,9 @@
 import { type Database, schema, type Transaction } from '@auxx/database'
 import type { FieldType } from '@auxx/database/types'
 import { getFieldId, isFieldPath, isResourceFieldId, toResourceFieldIds } from '@auxx/types/field'
-import { TRPCError } from '@trpc/server'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { touchEntityActivity } from '../../entity-instances/activity'
+import { BadRequestError, ForbiddenError, NotFoundError } from '../../errors'
 import { formatToRawValue } from '../../field-values/client'
 import { FieldValueService } from '../../field-values/field-value-service'
 import { parseRecordId, type RecordId } from '../resource-id'
@@ -60,15 +60,6 @@ export class EntityMergeService {
           (_rid, idx) => allValues.sources[idx]?.[field.id] ?? null
         )
 
-        // Debug TAGS field merge
-        if (field.type === 'TAGS') {
-          console.log('🏷️  TAGS field merge input:', {
-            fieldId: field.id,
-            targetValue,
-            sourceValues,
-          })
-        }
-
         const result = mergeFieldValue({
           targetValue,
           sourceValues,
@@ -76,29 +67,12 @@ export class EntityMergeService {
           fieldOptions: field.options ?? undefined,
         })
 
-        // Debug TAGS field merge result
-        if (field.type === 'TAGS') {
-          console.log('🏷️  TAGS merge result:', {
-            fieldId: field.id,
-            mergedValue: result.value,
-            wasModified: result.wasModified,
-          })
-        }
-
         if (result.wasModified) {
           mergedValues.push({ fieldId: field.id, value: result.value })
         }
       }
 
       // 4. Apply merged values to target (with explicit conversion back)
-      // Debug TAGS values being applied
-      const tagsMerged = mergedValues.filter((v) =>
-        fields.find((f) => f.id === v.fieldId && f.type === 'TAGS')
-      )
-      if (tagsMerged.length > 0) {
-        console.log('📤 Applying TAGS values:', tagsMerged)
-      }
-
       const fieldsMerged = await this.applyMergedValues(tx, targetRecordId, mergedValues, fields)
 
       // 5. Transfer task references
@@ -122,6 +96,12 @@ export class EntityMergeService {
       // app-less chat visitorId links, which have no FieldValue to carry them)
       // are stranded on the archived source and lost.
       const identitiesRedirected = await this.redirectRecordIdentities(tx, sourceIds, targetId)
+
+      // 6c. Re-point mail links and connector bindings. Archive (step 7) is a
+      // soft delete, so without this the archived source keeps all mail history
+      // (participant links only fill when NULL, so future mail stays on it too)
+      // and every subsequent connector sync rebinds to the archived source.
+      await this.redirectMailAndConnectorLinks(tx, sourceIds, targetId)
 
       // 7. Archive sources
       await this.archiveSourceInstances(tx, sourceIds)
@@ -151,10 +131,7 @@ export class EntityMergeService {
     const { sourceRecordIds, targetRecordId } = input
 
     if (sourceRecordIds.length === 0) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'At least one source entity is required for merge',
-      })
+      throw new BadRequestError('At least one source entity is required for merge')
     }
 
     // All must be same entityDefinitionId
@@ -163,18 +140,12 @@ export class EntityMergeService {
       (rid) => parseRecordId(rid).entityDefinitionId === targetParsed.entityDefinitionId
     )
     if (!allSameType) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'All entities must be of the same type to merge',
-      })
+      throw new BadRequestError('All entities must be of the same type to merge')
     }
 
     // Target cannot be in sources
     if (sourceRecordIds.includes(targetRecordId)) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'Target entity cannot be in the source list',
-      })
+      throw new BadRequestError('Target entity cannot be in the source list')
     }
 
     // Verify all instances exist and belong to organization
@@ -192,24 +163,15 @@ export class EntityMergeService {
       .where(inArray(schema.EntityInstance.id, allIds))
 
     if (instances.length !== allIds.length) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: 'One or more entities not found',
-      })
+      throw new NotFoundError('One or more entities not found')
     }
 
     if (!instances.every((i) => i.organizationId === this.organizationId)) {
-      throw new TRPCError({
-        code: 'FORBIDDEN',
-        message: 'Cannot merge entities from different organizations',
-      })
+      throw new ForbiddenError('Cannot merge entities from different organizations')
     }
 
     if (instances.some((i) => i.archivedAt !== null)) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'Cannot merge archived entities',
-      })
+      throw new BadRequestError('Cannot merge archived entities')
     }
   }
 
@@ -312,19 +274,6 @@ export class EntityMergeService {
         }
       }
       sources.push(source)
-    }
-
-    // Debug logging for TAGS fields
-    const tagsFields = fields.filter((f) => f.type === 'TAGS')
-    if (tagsFields.length > 0) {
-      console.log('📥 Loaded TAGS field values:', {
-        targetRecordId,
-        tagsFields: tagsFields.map((f) => ({
-          fieldId: f.id,
-          targetValue: target[f.id],
-          sourceValues: sources.map((s) => s[f.id]),
-        })),
-      })
     }
 
     return { target, sources }
@@ -615,6 +564,63 @@ export class EntityMergeService {
     }
 
     return idsToUpdate.length
+  }
+
+  // ─────────────────────────────────────────────────────────────────
+  // MAIL & CONNECTOR LINK REDIRECT
+  // ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Re-point mail participant links, thread primaries, and connector item
+   * bindings from the sources to the target. All four are blanket UPDATEs:
+   * none of these columns participates in a unique key
+   * (`Participant` is unique on `(organizationId, identifier, identifierType)`,
+   * `ThreadParticipant` on `(threadId, email)`), and multiple
+   * `DataConnectorItem` rows sharing one instance is the documented shape.
+   */
+  private async redirectMailAndConnectorLinks(
+    tx: Transaction,
+    sourceIds: string[],
+    targetId: string
+  ): Promise<void> {
+    await tx
+      .update(schema.Participant)
+      .set({ entityInstanceId: targetId })
+      .where(
+        and(
+          inArray(schema.Participant.entityInstanceId, sourceIds),
+          eq(schema.Participant.organizationId, this.organizationId)
+        )
+      )
+
+    // ThreadParticipant has no organizationId column — instance ids are
+    // globally unique CUIDs already validated to belong to this org.
+    await tx
+      .update(schema.ThreadParticipant)
+      .set({ entityInstanceId: targetId })
+      .where(inArray(schema.ThreadParticipant.entityInstanceId, sourceIds))
+
+    // `primaryEntityDefinitionId` stays as-is: sources and target are
+    // validated to share the same definition.
+    await tx
+      .update(schema.Thread)
+      .set({ primaryEntityInstanceId: targetId })
+      .where(
+        and(
+          inArray(schema.Thread.primaryEntityInstanceId, sourceIds),
+          eq(schema.Thread.organizationId, this.organizationId)
+        )
+      )
+
+    await tx
+      .update(schema.DataConnectorItem)
+      .set({ entityInstanceId: targetId })
+      .where(
+        and(
+          inArray(schema.DataConnectorItem.entityInstanceId, sourceIds),
+          eq(schema.DataConnectorItem.organizationId, this.organizationId)
+        )
+      )
   }
 
   // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Items D1, D4, D5 of `plans/custom-field/multi/04-multi-email-implementation-plan.md`.

## What was broken

Merging records archives the sources (soft delete), but nothing re-pointed the mail and connector links riding on them:

- **D1 — mail orphaned**: `Participant.entityInstanceId`, `ThreadParticipant.entityInstanceId`, and `Thread.primaryEntityInstanceId` stayed on the archived source. All mail history was lost from the merged contact, and since participant links only fill when NULL, **future** mail kept binding to the archived source too.
- **D4 — connector bindings orphaned**: `DataConnectorItem.entityInstanceId` stayed on the archived source, so external-id reuse rebound every subsequent sync to it and the merged contact silently stopped receiving connector updates.

## The fix

`packages/lib/src/resources/merge/merge-service.ts` — new step 6c inside the merge transaction, sibling of `redirectRecordIdentities`: blanket UPDATEs re-pointing all four columns from each source id to the target. All four are safe blanket updates — none of the columns participates in a unique key, and multiple `DataConnectorItem` rows sharing one instance is the documented shape.

## D5 hygiene (same file / flow)

- Removed the four shipped TAGS debug `console.log` blocks.
- Replaced `TRPCError` throws with the matching `AuxxError` subclasses (`BadRequestError`, `NotFoundError`, `ForbiddenError`) and dropped the `@trpc/server` import — lib code must never throw `TRPCError`. The calling router (`record.merge`) already guards rethrows with `isAuxxError`, so no router change needed.
- `apps/web/src/components/merge/merge-dialog.tsx`: the merge button was gated on `canEditEntity` while the server gates on the **delete** verb per row — edit-but-not-delete users got an enabled button and a server 403. The gate now requires delete on every row (target + sources), resolved from each row's server-side `_access` stamp with the def-rung fallback, mirroring `useRecordAccessAt`.

## Verification

- Tests: new `merge-service-links.test.ts` (asserts the four re-pointing UPDATEs by table ref + the AuxxError throw); existing `merge-service-identity.test.ts` untouched. `vitest run merge-service`: 7/7 passed.
- Typecheck: `packages/lib` and `apps/web` scoped `tsc --noEmit` — no errors in any touched file (remaining errors are pre-existing in unrelated `scripts/` / workflow files).
- Lint: biome clean on all three files.

Out of scope (land later per plan): merge-dialog grant warning (D2), multi-value cap in merge unions (D3), realtime/invalidation rework.