### PR TITLE
fix(records): multi-value-safe display recalc and extension lookup parse

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "package": "pnpm build && node scripts/package.mjs",
     "preview": "vite preview",
+    "test": "vitest run",
     "clean": "rm -rf dist node_modules .turbo *.tsbuildinfo *.zip"
   },
   "dependencies": {
@@ -39,6 +40,7 @@
     "postcss": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/apps/extension/src/iframe/routes/root/lookups.test.ts
+++ b/apps/extension/src/iframe/routes/root/lookups.test.ts
@@ -1,0 +1,146 @@
+// apps/extension/src/iframe/routes/root/lookups.test.ts
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ParsedPerson } from '../../../lib/parsers/types'
+import { lookupByField } from '../../trpc'
+import { findExistingInEntity } from './lookups'
+
+/**
+ * Regression guard for the multi-value email rollout: once contact
+ * `primary_email` is `options.multi`, `EntityInstance.secondaryDisplayValue`
+ * may surface as a `string[]`. The lookup schema must tolerate that shape —
+ * a failed Zod parse is swallowed by lookups.ts as "no match", and the user
+ * saves a duplicate contact.
+ */
+
+function trpcQueryResponse(payload: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ result: { data: { json: payload } } }),
+  } as Response
+}
+
+function stubFetch(payload: unknown) {
+  const fetchMock = vi.fn(async () => trpcQueryResponse(payload))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+const person: ParsedPerson = {
+  externalId: 'linkedin:jane-doe',
+  primaryEmail: 'jane@example.com',
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('lookupByField parse', () => {
+  it('survives an array subtitle (multi-value email display column)', async () => {
+    stubFetch({
+      items: [
+        {
+          recordId: 'contact:inst-1',
+          displayName: 'Jane Doe',
+          secondaryDisplayValue: ['jane@example.com', 'jd@alias.com'],
+          avatarUrl: null,
+        },
+      ],
+      hasMore: false,
+    })
+
+    const result = await lookupByField({
+      entityDefinitionId: 'contact',
+      candidates: [{ systemAttribute: 'primary_email', value: 'jane@example.com' }],
+    })
+
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0]?.secondaryDisplayValue).toEqual(['jane@example.com', 'jd@alias.com'])
+  })
+
+  it('still accepts a scalar subtitle', async () => {
+    stubFetch({
+      items: [
+        {
+          recordId: 'contact:inst-1',
+          displayName: 'Jane Doe',
+          secondaryDisplayValue: 'jane@example.com',
+          avatarUrl: null,
+        },
+      ],
+      hasMore: false,
+    })
+
+    const result = await lookupByField({
+      entityDefinitionId: 'contact',
+      candidates: [{ systemAttribute: 'primary_email', value: 'jane@example.com' }],
+    })
+
+    expect(result.items[0]?.secondaryDisplayValue).toBe('jane@example.com')
+  })
+})
+
+describe('findExistingInEntity', () => {
+  it('returns the match (not "no match") when the subtitle is an array, normalized to the primary', async () => {
+    stubFetch({
+      items: [
+        {
+          recordId: 'contact:inst-1',
+          displayName: 'Jane Doe',
+          secondaryDisplayValue: ['jane@example.com', 'jd@alias.com'],
+          avatarUrl: null,
+        },
+      ],
+      hasMore: false,
+    })
+
+    const matches = await findExistingInEntity('contact', person, null)
+
+    // The pre-loosening behavior: Zod parse failure → catch → [] → the user
+    // is offered Save and creates a duplicate. This must stay a real match.
+    expect(matches).toHaveLength(1)
+    expect(matches[0]).toEqual({
+      recordId: 'contact:inst-1',
+      entityType: 'contact',
+      displayName: 'Jane Doe',
+      secondaryDisplayValue: 'jane@example.com',
+      avatarUrl: null,
+    })
+  })
+
+  it('passes scalar subtitles through unchanged', async () => {
+    stubFetch({
+      items: [
+        {
+          recordId: 'contact:inst-2',
+          displayName: 'John Doe',
+          secondaryDisplayValue: 'john@example.com',
+          avatarUrl: null,
+        },
+      ],
+      hasMore: false,
+    })
+
+    const matches = await findExistingInEntity('contact', person, null)
+    expect(matches[0]?.secondaryDisplayValue).toBe('john@example.com')
+  })
+
+  it('normalizes an empty array subtitle to null', async () => {
+    stubFetch({
+      items: [
+        {
+          recordId: 'contact:inst-3',
+          displayName: 'Empty Subtitle',
+          secondaryDisplayValue: [],
+          avatarUrl: null,
+        },
+      ],
+      hasMore: false,
+    })
+
+    const matches = await findExistingInEntity('contact', person, null)
+    expect(matches).toHaveLength(1)
+    expect(matches[0]?.secondaryDisplayValue).toBeNull()
+  })
+})

--- a/apps/extension/src/iframe/routes/root/lookups.ts
+++ b/apps/extension/src/iframe/routes/root/lookups.ts
@@ -20,6 +20,15 @@ import type { EntityType, ExistingMatch, GenericPage } from './types'
  */
 const LOOKUP_LIMIT = 5
 
+/**
+ * Multi-value display fields surface the subtitle as an array (first value
+ * is the primary). Normalize to the primary so `ExistingMatch` and the
+ * views stay scalar.
+ */
+function primarySubtitle(value: string | string[] | null): string | null {
+  return Array.isArray(value) ? (value[0] ?? null) : value
+}
+
 async function findExistingByPerson(person: ParsedPerson): Promise<ExistingMatch[]> {
   const candidates: LookupByFieldCandidate[] = [
     { systemAttribute: 'external_id', value: person.externalId },
@@ -37,7 +46,7 @@ async function findExistingByPerson(person: ParsedPerson): Promise<ExistingMatch
       recordId: item.recordId,
       entityType: 'contact',
       displayName: item.displayName,
-      secondaryDisplayValue: item.secondaryDisplayValue,
+      secondaryDisplayValue: primarySubtitle(item.secondaryDisplayValue),
       avatarUrl: item.avatarUrl,
     }))
   } catch {
@@ -62,7 +71,7 @@ async function findExistingByCompany(company: ParsedCompany): Promise<ExistingMa
       recordId: item.recordId,
       entityType: 'company',
       displayName: item.displayName,
-      secondaryDisplayValue: item.secondaryDisplayValue,
+      secondaryDisplayValue: primarySubtitle(item.secondaryDisplayValue),
       avatarUrl: item.avatarUrl,
     }))
   } catch {

--- a/apps/extension/src/iframe/trpc.ts
+++ b/apps/extension/src/iframe/trpc.ts
@@ -237,7 +237,11 @@ const LookupByFieldOutputSchema = z.object({
       // render an avatar + name + subtitle for each "similar found" row
       // without an N+1 record.getById fan-out.
       displayName: z.string().nullable(),
-      secondaryDisplayValue: z.string().nullable(),
+      // Forward-compat: multi-value display fields (`options.multi` email)
+      // may surface the subtitle as an array. A strict `z.string()` here
+      // would fail the whole parse, which lookups.ts swallows as "no match"
+      // — and the user saves a duplicate contact.
+      secondaryDisplayValue: z.union([z.string(), z.array(z.string())]).nullable(),
       avatarUrl: z.string().nullable(),
     })
   ),

--- a/apps/extension/vitest.config.ts
+++ b/apps/extension/vitest.config.ts
@@ -1,0 +1,18 @@
+// apps/extension/vitest.config.ts
+
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  root: __dirname,
+  define: {
+    // Injected by vite.config.ts at build time; pin a stable value for tests.
+    __AUXX_WEBAPP_URL__: JSON.stringify('http://localhost:3000'),
+  },
+  test: {
+    name: 'extension',
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.ts'],
+    exclude: ['node_modules/**', 'dist/**', '**/*.config.*'],
+  },
+})

--- a/packages/lib/src/field-values/display-field-service.test.ts
+++ b/packages/lib/src/field-values/display-field-service.test.ts
@@ -1,0 +1,161 @@
+// packages/lib/src/field-values/display-field-service.test.ts
+
+import type { Database } from '@auxx/database'
+import type { TypedFieldValue } from '@auxx/types'
+import { ok } from 'neverthrow'
+
+// Mock the cache barrel WHOLESALE, listing every name the static import
+// graph of display-field-service pulls (helpers, mutations, queries,
+// timeline-snapshot, resolvers). Do NOT partial-mock via `importOriginal`
+// here: loading the real barrel inside the factory walks its own import
+// graph before the mock exists, and modules loaded during that walk capture
+// the REAL `getCachedResource` — the mock then silently never applies.
+vi.mock('../cache', () => ({
+  getCachedResource: vi.fn(),
+  findCachedResource: vi.fn(),
+  getCachedEntityDefId: vi.fn(),
+  getOrgCache: vi.fn(),
+  getCachedResourceFields: vi.fn(),
+  getCachedFieldMap: vi.fn(),
+  getAllCachedCustomFields: vi.fn(),
+  requireCachedEntityDefId: vi.fn(),
+  getCachedAgents: vi.fn(),
+  getCachedGroups: vi.fn(),
+  getCachedMembersByUserIds: vi.fn(),
+  getCachedResources: vi.fn(),
+  getCachedAgentsByUserIds: vi.fn(),
+}))
+
+vi.mock('@auxx/services/entity-instances', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/services/entity-instances')>()),
+  batchUpdateDisplayValues: vi.fn(),
+  clearDisplayValues: vi.fn(),
+}))
+
+// The searchText refresh runs raw SQL against the db — out of scope here.
+vi.mock('./search-text', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./search-text')>()),
+  updateSearchTextForEntityDefinition: vi.fn(),
+}))
+
+import { batchUpdateDisplayValues } from '@auxx/services/entity-instances'
+import { getCachedResource } from '../cache'
+import { DisplayFieldService } from './display-field-service'
+import { FieldValueService } from './field-value-service'
+
+const mockedGetCachedResource = vi.mocked(getCachedResource)
+const mockedBatchUpdate = vi.mocked(batchUpdateDisplayValues)
+
+const ORG_ID = 'org-1'
+const EMAIL_FIELD_ID = 'field-email'
+
+const emailField = {
+  id: EMAIL_FIELD_ID,
+  fieldType: 'EMAIL',
+  options: { multi: true },
+} as any
+
+const contactResource = {
+  id: 'contact',
+  type: 'custom',
+  fields: [emailField],
+  display: {
+    primaryDisplayField: null,
+    secondaryDisplayField: { id: EMAIL_FIELD_ID },
+    avatarField: null,
+  },
+} as any
+
+const email = (id: string, value: string): TypedFieldValue => ({ id, type: 'text', value }) as any
+
+function createService(instances: Array<{ id: string }>) {
+  const db = {
+    query: {
+      EntityInstance: {
+        findMany: vi.fn().mockResolvedValue(instances),
+      },
+    },
+  } as unknown as Database
+  return new DisplayFieldService(ORG_ID, db)
+}
+
+describe('DisplayFieldService.computeDisplayValue (via recalculateDisplayField)', () => {
+  beforeEach(() => {
+    mockedGetCachedResource.mockResolvedValue(contactResource)
+    mockedBatchUpdate.mockImplementation(async ({ updates }) => ok({ updated: updates.size }))
+  })
+
+  it('renders the primary (first) value as the subtitle for a multi email field', async () => {
+    const service = createService([{ id: 'inst-1' }])
+    vi.spyOn(FieldValueService.prototype, 'batchGetValues').mockResolvedValue({
+      values: [
+        {
+          recordId: 'contact:inst-1',
+          fieldRef: `contact:${EMAIL_FIELD_ID}`,
+          value: [email('v1', 'primary@example.com'), email('v2', 'alias@example.com')],
+        } as any,
+      ],
+    })
+
+    const result = await service.recalculateDisplayField('contact', 'secondary')
+
+    expect(mockedBatchUpdate).toHaveBeenCalledTimes(1)
+    const { updates, column } = mockedBatchUpdate.mock.calls[0]?.[0] as {
+      updates: Map<string, string | null>
+      column: string
+    }
+    expect(column).toBe('secondaryDisplayValue')
+    // Pre-fix behavior: the `typeof === 'string'` guard nulled the array and
+    // the batch recalc WIPED the subtitle. It must be the primary value.
+    expect(updates.get('inst-1')).toBe('primary@example.com')
+    expect(result).toEqual({ displayFieldType: 'secondary', processed: 1, updated: 1 })
+  })
+
+  it('does not null subtitles across a batch recalc mixing multi, single and empty values', async () => {
+    const service = createService([{ id: 'inst-1' }, { id: 'inst-2' }, { id: 'inst-3' }])
+    vi.spyOn(FieldValueService.prototype, 'batchGetValues').mockResolvedValue({
+      values: [
+        {
+          recordId: 'contact:inst-1',
+          fieldRef: `contact:${EMAIL_FIELD_ID}`,
+          value: [email('v1', 'a@example.com'), email('v2', 'b@example.com')],
+        } as any,
+        {
+          recordId: 'contact:inst-2',
+          fieldRef: `contact:${EMAIL_FIELD_ID}`,
+          value: email('v3', 'single@example.com'),
+        } as any,
+        // inst-3 has no value row at all — its subtitle legitimately clears.
+      ],
+    })
+
+    await service.recalculateDisplayField('contact', 'secondary')
+
+    const { updates } = mockedBatchUpdate.mock.calls[0]?.[0] as {
+      updates: Map<string, string | null>
+    }
+    expect(updates.get('inst-1')).toBe('a@example.com')
+    expect(updates.get('inst-2')).toBe('single@example.com')
+    expect(updates.get('inst-3')).toBeNull()
+  })
+
+  it('nulls the subtitle for an empty array value', async () => {
+    const service = createService([{ id: 'inst-1' }])
+    vi.spyOn(FieldValueService.prototype, 'batchGetValues').mockResolvedValue({
+      values: [
+        {
+          recordId: 'contact:inst-1',
+          fieldRef: `contact:${EMAIL_FIELD_ID}`,
+          value: [],
+        } as any,
+      ],
+    })
+
+    await service.recalculateDisplayField('contact', 'secondary')
+
+    const { updates } = mockedBatchUpdate.mock.calls[0]?.[0] as {
+      updates: Map<string, string | null>
+    }
+    expect(updates.get('inst-1')).toBeNull()
+  })
+})

--- a/packages/lib/src/field-values/display-field-service.ts
+++ b/packages/lib/src/field-values/display-field-service.ts
@@ -18,6 +18,7 @@ import {
 import { batchGetRelatedDisplayNames } from './field-value-helpers'
 import { FieldValueService } from './field-value-service'
 import { formatToDisplayValue } from './formatter'
+import { primaryValue } from './primary-value'
 import { updateSearchTextForEntityDefinition } from './search-text'
 
 const BATCH_SIZE = 100
@@ -280,8 +281,15 @@ export class DisplayFieldService {
     // Use fieldType from ResourceField (properly typed FieldType enum)
     const fieldType = field.fieldType ?? 'TEXT'
 
+    // Multi-value fields (`options.multi`) read back as arrays ordered by
+    // sortKey — the subtitle shows the primary (first) value, never a joined
+    // array. Without the unwrap the string guard below nulls every array and
+    // a batch recalc wipes subtitles for multi-value display fields.
+    const single = primaryValue(typedValue)
+    if (!single) return null
+
     // Use centralized formatter with properly typed options
-    const displayValue = formatToDisplayValue(typedValue, fieldType, field.options)
+    const displayValue = formatToDisplayValue(single, fieldType, field.options)
 
     return typeof displayValue === 'string' ? displayValue : null
   }

--- a/packages/lib/src/field-values/timeline-snapshot.test.ts
+++ b/packages/lib/src/field-values/timeline-snapshot.test.ts
@@ -1,0 +1,91 @@
+// packages/lib/src/field-values/timeline-snapshot.test.ts
+
+import type { Database } from '@auxx/database'
+import type { TypedFieldValue } from '@auxx/types/field-value'
+import { TIMELINE_SNAPSHOT_ARRAY_LIMIT } from '../timeline/field-change-snapshot'
+import { resolveFieldChangeSnapshotPair, type SnapshotContext } from './timeline-snapshot'
+import type { CachedField } from './types'
+
+/**
+ * A7 verification (multi-value email plan): `buildSnapshotValue` already
+ * branches on `Array.isArray` — adds/removes on a multi field must produce
+ * timeline entries carrying ARRAY old/new snapshots, sliced to
+ * `TIMELINE_SNAPSHOT_ARRAY_LIMIT`. EMAIL values carry no relationship/actor
+ * refs, so the resolver never touches the db or org cache here.
+ */
+
+const ctx: SnapshotContext = {
+  db: {} as Database,
+  organizationId: 'org-1',
+}
+
+const emailField = {
+  id: 'field-email',
+  type: 'EMAIL',
+  options: { multi: true },
+} as CachedField
+
+const email = (id: string, value: string): TypedFieldValue =>
+  ({ id, type: 'text', value }) as TypedFieldValue
+
+describe('resolveFieldChangeSnapshotPair — multi-value EMAIL field', () => {
+  it('an add produces array old/new snapshots (new includes the added value)', async () => {
+    const oldValue = [email('v1', 'a@example.com')]
+    const newValue = [email('v1', 'a@example.com'), email('v2', 'b@example.com')]
+
+    const { oldDisplay, newDisplay } = await resolveFieldChangeSnapshotPair(
+      ctx,
+      emailField,
+      oldValue,
+      newValue
+    )
+
+    expect(oldDisplay).toEqual([{ fieldType: 'EMAIL', text: 'a@example.com' }])
+    expect(newDisplay).toEqual([
+      { fieldType: 'EMAIL', text: 'a@example.com' },
+      { fieldType: 'EMAIL', text: 'b@example.com' },
+    ])
+  })
+
+  it('a remove produces array old/new snapshots (old keeps the removed value)', async () => {
+    const oldValue = [email('v1', 'a@example.com'), email('v2', 'b@example.com')]
+    const newValue = [email('v1', 'a@example.com')]
+
+    const { oldDisplay, newDisplay } = await resolveFieldChangeSnapshotPair(
+      ctx,
+      emailField,
+      oldValue,
+      newValue
+    )
+
+    expect(oldDisplay).toEqual([
+      { fieldType: 'EMAIL', text: 'a@example.com' },
+      { fieldType: 'EMAIL', text: 'b@example.com' },
+    ])
+    expect(newDisplay).toEqual([{ fieldType: 'EMAIL', text: 'a@example.com' }])
+  })
+
+  it('clearing the field snapshots array → null (and vice versa on first write)', async () => {
+    const values = [email('v1', 'a@example.com')]
+
+    const cleared = await resolveFieldChangeSnapshotPair(ctx, emailField, values, [])
+    expect(cleared.oldDisplay).toEqual([{ fieldType: 'EMAIL', text: 'a@example.com' }])
+    expect(cleared.newDisplay).toBeNull()
+
+    const firstWrite = await resolveFieldChangeSnapshotPair(ctx, emailField, null, values)
+    expect(firstWrite.oldDisplay).toBeNull()
+    expect(firstWrite.newDisplay).toEqual([{ fieldType: 'EMAIL', text: 'a@example.com' }])
+  })
+
+  it('slices oversized arrays to TIMELINE_SNAPSHOT_ARRAY_LIMIT', async () => {
+    const values = Array.from({ length: TIMELINE_SNAPSHOT_ARRAY_LIMIT + 5 }, (_, i) =>
+      email(`v${i}`, `user${i}@example.com`)
+    )
+
+    const { newDisplay } = await resolveFieldChangeSnapshotPair(ctx, emailField, null, values)
+
+    expect(Array.isArray(newDisplay)).toBe(true)
+    expect(newDisplay).toHaveLength(TIMELINE_SNAPSHOT_ARRAY_LIMIT)
+    expect((newDisplay as Array<{ text: string }>)[0]?.text).toBe('user0@example.com')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -649,6 +649,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/homepage:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     projects: [
       './apps/api/vitest.config.ts',
+      './apps/extension/vitest.config.ts',
       './apps/worker/vitest.config.ts',
       './apps/web/vitest.config.ts',
       './apps/kb/vitest.config.ts',


### PR DESCRIPTION
Part of the multi-value email rollout (`plans/custom-field/multi/04-multi-email-implementation-plan.md`), lane 3 (Display) — item A2's `display-field-service` half, the extension zod loosening, and the A7 verification test. The `field-value-helpers.ts` twin fix (`maybeUpdateDisplayValue`) lands in a parallel PR.

## A2 — batch display recalc must not wipe multi-value subtitles

`DisplayFieldService.computeDisplayValue` guarded on `typeof displayValue === 'string'`, so an `options.multi` field value (an array) was nulled — a batch recalc would WIPE `secondaryDisplayValue` for every contact once `primary_email` flips multi (contact's secondary display field IS `primaryEmail`; company's IS `website`). The value is now unwrapped with `primaryValue()` before formatting, so the subtitle is the primary (first) value.

Tests: multi email → subtitle = primary; batch mixing multi/single/empty values does not null populated subtitles; empty array → null.

## A2 — extension forward-compat: array subtitle must not read as "no match"

`apps/extension/src/iframe/trpc.ts` hard-zod'ed `secondaryDisplayValue: z.string().nullable()`; a stray array failed the whole parse and `lookups.ts` swallowed it as "no match" → the user saves a duplicate contact. The schema is loosened to `z.union([z.string(), z.array(z.string())]).nullable()`, and `lookups.ts` normalizes an array subtitle to its primary so `ExistingMatch` and the views stay scalar.

Tests: added a vitest project for `apps/extension` (registered in the root `vitest.config.ts`); explicit regression tests that the lookup parse survives an array subtitle and `findExistingInEntity` returns the match instead of `[]`.

## A7 — timeline snapshot (verify only)

`buildSnapshotValue` already handles arrays (EMAIL/URL case + `TIMELINE_SNAPSHOT_ARRAY_LIMIT`); added the plan's verification test that adds/removes on a multi field produce timeline entries with array old/new, plus the slice bound.

## Verification

- `packages/lib`: `vitest run src/field-values` — 14 files / 100 tests green
- `apps/extension`: `vitest run` — 5 tests green; `tsc --noEmit` clean
- `packages/lib` `tsc --noEmit`: zero errors under `src/` (pre-existing `scripts/*` + `vitest.integration.config.ts` errors untouched)
- Biome clean on all changed files

Test-authoring note: partial-mocking the `../cache` barrel via `importOriginal` does NOT work for `display-field-service` — loading the real barrel inside the factory walks its own import graph before the mock exists and the mock silently never applies; the test mocks the barrel wholesale (documented in the test).