### PR TITLE
feat(workflow): per-field update modes for multi-value scalar fields in crud/find nodes

### DIFF
--- a/apps/web/src/components/workflow/nodes/core/crud/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/crud/panel.tsx
@@ -252,7 +252,11 @@ const CrudPanelComponent: React.FC<CrudPanelProps> = ({ nodeId, data }) => {
         field.type === BaseType.RELATION &&
         field.relationship &&
         isMultiRelationship(field.relationship.relationshipType)
-      const showUpdateMode = nodeData.mode === 'update' && (isMultiRelation || isMultiSelect)
+      // Multi-value scalar fields (`options.multi` on EMAIL/URL/PHONE/…) get the
+      // same update-mode badge as multi relations / multi-selects.
+      const isMultiScalar = field.options?.multi === true
+      const showUpdateMode =
+        nodeData.mode === 'update' && (isMultiRelation || isMultiSelect || isMultiScalar)
       const currentUpdateMode = nodeData.fieldUpdateModes?.[field.key] ?? RelationUpdateMode.REPLACE
 
       // Determine allowed types for type filtering

--- a/packages/lib/src/workflow-engine/catalog/nodes/crud.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/crud.ts
@@ -53,7 +53,9 @@ export interface CrudNodeData extends BaseNodeData {
   resourceId?: string // For update/delete operations (VarEditor input)
   data: Record<string, any> // Field values
   fieldModes?: Record<string, boolean> // Track constant/variable mode per field
-  fieldUpdateModes?: Record<string, RelationUpdateMode> // Relation update mode per multi-relation field
+  // Update mode per multi-value field — multi-relation, MULTI_SELECT, and
+  // multi-value scalars (`options.multi` on EMAIL/URL/PHONE/…). Default: replace.
+  fieldUpdateModes?: Record<string, RelationUpdateMode>
   fieldUpdateModeVars?: Record<string, string> // Dynamic mode variable per field
 
   // Error handling configuration
@@ -208,7 +210,7 @@ export const validateCrudNodeConfig = (data: CrudNodeData): NodeValidationResult
     })
   }
 
-  // Validate relation update modes
+  // Validate per-field update modes (multi-relation, MULTI_SELECT, multi-value scalar)
   if (data.fieldUpdateModes) {
     for (const [fieldKey, mode] of Object.entries(data.fieldUpdateModes)) {
       // Dynamic mode requires a mode variable

--- a/packages/lib/src/workflow-engine/core/__tests__/interpolate-multi-scalar.test.ts
+++ b/packages/lib/src/workflow-engine/core/__tests__/interpolate-multi-scalar.test.ts
@@ -1,0 +1,118 @@
+// packages/lib/src/workflow-engine/core/__tests__/interpolate-multi-scalar.test.ts
+//
+// Multi-value scalar fields (`options.multi` on EMAIL/URL/PHONE/…) resolve as
+// arrays through the record-field lane (plan 04-multi-email B4):
+//   1. Exact `{{path}}` resolution keeps the ARRAY shape — the server-side
+//      output resolution a downstream multi-field write consumes.
+//   2. String interpolation is a SCALAR context — the array interpolates as the
+//      primary (first) value via `primaryValue`, never a joined list (a
+//      send-email recipient of "a@x.com, b@x.com" is not an address).
+//   3. Genuine array variables (tags, actionsPerformed, …) keep joining.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ExecutionContextManager } from '../execution-context'
+
+vi.mock('../../../cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../cache')>()),
+  getCachedResourceFields: vi.fn(async (_organizationId: string, resourceType: string) =>
+    resourceType === 'def_contact'
+      ? [
+          {
+            id: 'cf_email',
+            key: 'email',
+            label: 'Email',
+            type: 'string',
+            fieldType: 'EMAIL',
+            options: { multi: true },
+            capabilities: {},
+          },
+          {
+            id: 'cf_name',
+            key: 'name',
+            label: 'Name',
+            type: 'string',
+            fieldType: 'TEXT',
+            capabilities: {},
+          },
+        ]
+      : []
+  ),
+}))
+
+vi.mock('../../../field-values/field-value-queries', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../field-values/field-value-queries')>()),
+  batchGetValues: vi.fn(async (_ctx: unknown, params: any) => {
+    const fieldRef = params.fieldReferences[0] as string
+    if (fieldRef.includes('cf_email')) {
+      return {
+        values: [
+          {
+            recordId: params.recordIds[0],
+            fieldRef,
+            value: [
+              { type: 'text', value: 'primary@x.com' },
+              { type: 'text', value: 'alias@x.com' },
+            ],
+            fieldType: 'EMAIL',
+            fieldOptions: { multi: true },
+          },
+        ],
+      }
+    }
+    return {
+      values: [
+        {
+          recordId: params.recordIds[0],
+          fieldRef,
+          value: { type: 'text', value: 'Ada' },
+          fieldType: 'TEXT',
+        },
+      ],
+    }
+  }),
+}))
+
+describe('multi-value scalar fields in variable resolution', () => {
+  let contextManager: ExecutionContextManager
+
+  beforeEach(() => {
+    contextManager = new ExecutionContextManager(
+      'test-workflow',
+      'test-exec',
+      'org_test',
+      'user_test',
+      'test@example.com',
+      'Test User',
+      'Test Org',
+      'test-org'
+    )
+    // A record-shaped value, exactly what find/crud store for entity results.
+    contextManager.setVariable('find1.contact', { id: 'rec_1', entityDefinitionId: 'def_contact' })
+  })
+
+  it('exact path resolution returns the ARRAY shape for a multi field', async () => {
+    const value = await contextManager.resolveVariablePath('find1.contact.email')
+    expect(value).toEqual(['primary@x.com', 'alias@x.com'])
+  })
+
+  it('string interpolation substitutes the PRIMARY value, not a joined list', async () => {
+    const text = await contextManager.interpolateVariables('To: {{find1.contact.email}}')
+    expect(text).toBe('To: primary@x.com')
+  })
+
+  it('single-value fields interpolate unchanged', async () => {
+    const text = await contextManager.interpolateVariables('Hi {{find1.contact.name}}')
+    expect(text).toBe('Hi Ada')
+  })
+
+  it('genuine array variables still join — the unwrap is field-scoped', async () => {
+    contextManager.setVariable('n1.actionsPerformed', ['tagged', 'assigned'])
+    const text = await contextManager.interpolateVariables('Did: {{n1.actionsPerformed}}')
+    expect(text).toBe('Did: tagged, assigned')
+  })
+
+  it('an explicit index accessor bypasses the primary unwrap', async () => {
+    const text = await contextManager.interpolateVariables('Alt: {{find1.contact.email[1]}}')
+    expect(text).toBe('Alt: alias@x.com')
+  })
+})

--- a/packages/lib/src/workflow-engine/core/execution-context.ts
+++ b/packages/lib/src/workflow-engine/core/execution-context.ts
@@ -29,6 +29,7 @@ import {
 } from '../../field-values/field-value-helpers'
 import { batchGetValues } from '../../field-values/field-value-queries'
 import { formatToDisplayValue, formatToRawValue } from '../../field-values/formatter'
+import { primaryValue } from '../../field-values/primary-value'
 import { getFieldOutputKey, type ResourceField } from '../../resources/registry/field-types'
 import { fetchResourceWithRelationships } from '../../resources/resource-fetcher'
 import { type PathSegment, parseVariablePath } from '../catalog/variable-inference'
@@ -709,6 +710,36 @@ export class ExecutionContextManager implements ContextManager {
   }
 
   /**
+   * True when `path`'s terminal segment names a multi-value SCALAR field
+   * (`options.multi` on EMAIL/URL/PHONE/…) on a record — the case where an
+   * array-shaped resolution represents "several values of one scalar field"
+   * rather than a genuine list variable. Used by `interpolateVariables` to
+   * substitute the primary (first) value into string templates.
+   *
+   * Resolves the parent path to classify the terminal key against the field
+   * registry; both hops are cache-hits after the value resolution that
+   * preceded this call (lazyLoadCache / recordFieldCache / org cache).
+   */
+  private async isMultiValueScalarFieldPath(path: string): Promise<boolean> {
+    const segments = parseVariablePath(path)
+    if (segments.length < 2) return false
+    const last = segments[segments.length - 1]!
+    // An explicit accessor (`email[1]`) never resolves to the whole array.
+    if (last.index !== undefined) return false
+
+    const parentPath = path.split('.').slice(0, -1).join('.')
+    // A stored ResourceReference classifies without a load; otherwise resolve
+    // the parent (cache-hit) and classify the loaded shape.
+    const identity =
+      this.identityOf(this.context.variables[parentPath]) ??
+      this.identityOf(await this.resolveVariablePath(parentPath))
+    if (!identity) return false
+
+    const field = await this.findResourceField(identity.resourceType, last.key)
+    return field != null && field.type !== BaseType.RELATION && field.options?.multi === true
+  }
+
+  /**
    * Interpolate variables in a string
    * NOW ASYNC to support lazy loading
    * Example: "Hello {{webhook-123.body.name}}" → "Hello John"
@@ -730,7 +761,16 @@ export class ExecutionContextManager implements ContextManager {
       const path = match[1]?.trim()
       if (!path) continue
 
-      const value = await this.resolveVariablePath(path)
+      let value = await this.resolveVariablePath(path)
+
+      // A multi-value scalar field (`options.multi` on EMAIL/URL/PHONE/…)
+      // resolves as an array, and a string template is a scalar context — it
+      // interpolates as the primary (first) value, never a joined list (a
+      // send-email recipient of "a@x.com, b@x.com" is not an address). Genuine
+      // array variables (tags, actionsPerformed, …) keep joining below.
+      if (Array.isArray(value) && (await this.isMultiValueScalarFieldPath(path))) {
+        value = primaryValue(value)
+      }
 
       if (value === undefined || value === null) {
         this.log('WARN', undefined, `Variable not found during interpolation: ${path}`)

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/crud-multi-scalar-modes.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/crud-multi-scalar-modes.test.ts
@@ -1,0 +1,277 @@
+// packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/crud-multi-scalar-modes.test.ts
+//
+// Multi-value SCALAR fields (`options.multi` on EMAIL/URL/PHONE/…) ride the same
+// per-field update-mode system as multi-relation and MULTI_SELECT (plan
+// 04-multi-email B4). The two guarantees pinned here:
+//   1. `preprocessNode` wraps a multi-scalar update value with
+//      `{ values, updateMode }` — default mode `replace` (locked) — so the
+//      executor can never treat it as a bare whole-value set.
+//   2. `executeEntityOperation` honors the mode: `add`/`remove` route through the
+//      row-level `FieldValueService.addValues`/`removeValues` primitives and the
+//      field NEVER reaches the whole-field `updateValues` set (no alias-list
+//      wipe); `replace` stays a whole-field set of the parsed array.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NodeData, WorkflowNode } from '../../../core/types'
+import { BaseType, WorkflowNodeType } from '../../../core/types'
+import { CrudNodeProcessor } from '../crud'
+
+const spies = vi.hoisted(() => ({
+  updateValues: vi.fn(),
+  addValues: vi.fn(),
+  removeValues: vi.fn(),
+  addRelationValues: vi.fn(),
+  removeRelationValues: vi.fn(),
+}))
+
+/** Contact-shaped resource: one multi EMAIL field, one plain TEXT field. */
+const contactResource = {
+  id: 'contact',
+  entityDefinitionId: 'def_contact',
+  fields: [
+    {
+      id: 'cf_email',
+      key: 'primary_email',
+      label: 'Email',
+      type: BaseType.STRING,
+      fieldType: 'EMAIL',
+      options: { multi: true },
+    },
+    {
+      id: 'cf_first_name',
+      key: 'first_name',
+      label: 'First name',
+      type: BaseType.STRING,
+      fieldType: 'TEXT',
+    },
+  ],
+}
+
+vi.mock('../../../../cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../cache')>()),
+  findCachedResource: vi.fn(async (_organizationId: string, resourceType: string) =>
+    resourceType === 'contact' ? contactResource : null
+  ),
+}))
+
+// Class stubs, not `vi.fn().mockImplementation(arrow)` — the executor calls
+// `new UnifiedCrudHandler(...)` and an arrow implementation is not constructable.
+vi.mock('../../../../resources/crud', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../resources/crud')>()),
+  UnifiedCrudHandler: class {
+    updateValues = spies.updateValues
+  },
+}))
+
+vi.mock('../../../../field-values/field-value-service', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../field-values/field-value-service')>()),
+  FieldValueService: class {
+    addValues = spies.addValues
+    removeValues = spies.removeValues
+    addRelationValues = spies.addRelationValues
+    removeRelationValues = spies.removeRelationValues
+  },
+}))
+
+const crudNode = (nodeId: string, data: Partial<NodeData>): WorkflowNode => ({
+  id: nodeId,
+  workflowId: 'workflow_1',
+  nodeId,
+  name: nodeId,
+  type: WorkflowNodeType.CRUD,
+  data: { id: nodeId, type: WorkflowNodeType.CRUD, title: nodeId, ...data },
+  metadata: { position: { x: 0, y: 0 } },
+})
+
+describe('CrudNodeProcessor — multi-value scalar update modes', () => {
+  let processor: CrudNodeProcessor
+  let contextManager: any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    spies.updateValues.mockResolvedValue({ entityInstance: { id: 'rec_1' }, id: 'rec_1' })
+    spies.addValues.mockResolvedValue([])
+    spies.removeValues.mockResolvedValue(undefined)
+
+    processor = new CrudNodeProcessor()
+    contextManager = {
+      getVariable: vi.fn((path: string) => {
+        if (path === 'sys.organizationId') return 'org_test'
+        if (path === 'sys.userId') return 'user_test'
+        return undefined
+      }),
+      resolveVariablePath: vi.fn(async (path: string) => {
+        if (path === 'find1.contact.email') return ['a@x.com', 'b@x.com']
+        if (path === 'trigger.mode') return 'ADD'
+        return undefined
+      }),
+      interpolateVariables: vi.fn(async (text: string) => text),
+      setNodeVariable: vi.fn(),
+      log: vi.fn(),
+    }
+  })
+
+  describe('preprocessNode', () => {
+    it('wraps a multi-scalar update with values + the locked default mode (replace)', async () => {
+      const node = crudNode('n1', {
+        resourceType: 'contact',
+        mode: 'update',
+        resourceId: 'rec_1',
+        data: { primary_email: 'new@x.com', first_name: 'Bob' },
+      })
+
+      const result = await processor.preprocessNode(node, contextManager)
+
+      expect(result.inputs.data.primary_email).toEqual({
+        values: ['new@x.com'],
+        updateMode: 'replace',
+        fieldType: 'EMAIL',
+      })
+      // Plain scalar fields stay untouched — no wrapper.
+      expect(result.inputs.data.first_name).toBe('Bob')
+    })
+
+    it('honors an explicit add mode from fieldUpdateModes', async () => {
+      const node = crudNode('n2', {
+        resourceType: 'contact',
+        mode: 'update',
+        resourceId: 'rec_1',
+        data: { primary_email: 'alias@x.com' },
+        fieldUpdateModes: { primary_email: 'add' },
+      })
+
+      const result = await processor.preprocessNode(node, contextManager)
+
+      expect(result.inputs.data.primary_email).toEqual({
+        values: ['alias@x.com'],
+        updateMode: 'add',
+        fieldType: 'EMAIL',
+      })
+    })
+
+    it('keeps the array shape when a variable resolves to multiple values', async () => {
+      const node = crudNode('n3', {
+        resourceType: 'contact',
+        mode: 'update',
+        resourceId: 'rec_1',
+        data: { primary_email: '{{find1.contact.email}}' },
+      })
+
+      const result = await processor.preprocessNode(node, contextManager)
+
+      expect(result.inputs.data.primary_email).toEqual({
+        values: ['a@x.com', 'b@x.com'],
+        updateMode: 'replace',
+        fieldType: 'EMAIL',
+      })
+    })
+
+    it('parses a JSON-stringified array (frontend idiom shared with MULTI_SELECT)', async () => {
+      const node = crudNode('n4', {
+        resourceType: 'contact',
+        mode: 'update',
+        resourceId: 'rec_1',
+        data: { primary_email: '["a@x.com","b@x.com"]' },
+      })
+
+      const result = await processor.preprocessNode(node, contextManager)
+
+      expect(result.inputs.data.primary_email).toEqual({
+        values: ['a@x.com', 'b@x.com'],
+        updateMode: 'replace',
+        fieldType: 'EMAIL',
+      })
+    })
+
+    it('resolves a dynamic mode variable to a runtime mode', async () => {
+      const node = crudNode('n5', {
+        resourceType: 'contact',
+        mode: 'update',
+        resourceId: 'rec_1',
+        data: { primary_email: 'alias@x.com' },
+        fieldUpdateModes: { primary_email: 'dynamic' },
+        fieldUpdateModeVars: { primary_email: '{{trigger.mode}}' },
+      })
+
+      const result = await processor.preprocessNode(node, contextManager)
+
+      expect(result.inputs.data.primary_email).toMatchObject({ updateMode: 'add' })
+      expect(result.inputs.fieldUpdateModes).toEqual({ primary_email: 'add' })
+    })
+
+    it('does not wrap on create — create passes the raw value through', async () => {
+      const node = crudNode('n6', {
+        resourceType: 'contact',
+        mode: 'create',
+        data: { primary_email: 'new@x.com' },
+      })
+
+      const result = await processor.preprocessNode(node, contextManager)
+
+      expect(result.inputs.data.primary_email).toBe('new@x.com')
+    })
+
+    it('leaves an empty value on the plain lane (no-write, never a list wipe)', async () => {
+      const node = crudNode('n7', {
+        resourceType: 'contact',
+        mode: 'update',
+        resourceId: 'rec_1',
+        data: { primary_email: '' },
+      })
+
+      const result = await processor.preprocessNode(node, contextManager)
+
+      // Empty strings are dropped by the existing cleanup — the key is absent,
+      // so the executor writes nothing for this field.
+      expect(result.inputs.data).not.toHaveProperty('primary_email')
+    })
+  })
+
+  describe('executeEntityOperation — mode honored, no list wipe', () => {
+    const execute = (data: Record<string, unknown>) =>
+      (processor as any).executeEntityOperation(
+        contactResource,
+        'update',
+        'rec_1',
+        data,
+        contextManager
+      )
+
+    it('add mode appends via addValues and never reaches the whole-field set', async () => {
+      await execute({
+        primary_email: { values: ['alias@x.com'], updateMode: 'add', fieldType: 'EMAIL' },
+        first_name: 'Bob',
+      })
+
+      expect(spies.addValues).toHaveBeenCalledWith(
+        expect.objectContaining({ fieldId: 'cf_email', values: ['alias@x.com'] })
+      )
+      expect(spies.removeValues).not.toHaveBeenCalled()
+      // The whole-field update carries ONLY the plain field — the multi scalar
+      // must not ride the DELETE-all-then-INSERT set path (list wipe).
+      expect(spies.updateValues).toHaveBeenCalledWith('rec_1', { cf_first_name: 'Bob' })
+    })
+
+    it('remove mode deletes the named values via removeValues', async () => {
+      await execute({
+        primary_email: { values: ['alias@x.com'], updateMode: 'remove', fieldType: 'EMAIL' },
+      })
+
+      expect(spies.removeValues).toHaveBeenCalledWith(
+        expect.objectContaining({ fieldId: 'cf_email', values: ['alias@x.com'] })
+      )
+      expect(spies.addValues).not.toHaveBeenCalled()
+      expect(spies.updateValues).toHaveBeenCalledWith('rec_1', {})
+    })
+
+    it('replace mode is a whole-field set of the parsed array', async () => {
+      await execute({
+        primary_email: { values: ['only@x.com'], updateMode: 'replace', fieldType: 'EMAIL' },
+      })
+
+      expect(spies.updateValues).toHaveBeenCalledWith('rec_1', { cf_email: ['only@x.com'] })
+      expect(spies.addValues).not.toHaveBeenCalled()
+      expect(spies.removeValues).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/find-multi-scalar-exists.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/find-multi-scalar-exists.test.ts
@@ -1,0 +1,90 @@
+// packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/find-multi-scalar-exists.test.ts
+//
+// The find node's custom-entity lane compiles field conditions with
+// `entityConditionBuilder` into EXISTS subqueries over FieldValue rows
+// (`executeCustomEntityQuery` → `buildGroupedQuery`). A multi-value scalar
+// field (`options.multi` on EMAIL/URL/PHONE) stores one row PER value, so
+// "email is X" matches a record when ANY of its rows — primary or alias —
+// equals X. Plan 04-multi-email B4 pins that semantics here: the compiled
+// predicate is a row-level EXISTS with no primary/sortKey restriction.
+
+import { PgDialect, pgTable, text } from 'drizzle-orm/pg-core'
+import { describe, expect, it } from 'vitest'
+import type { ConditionGroup } from '../../../../resources/query-builder/base-condition-builder'
+import {
+  type EntityQueryContext,
+  entityConditionBuilder,
+} from '../../../../resources/query-builder/entity-condition-builder'
+import { BaseType } from '../../../../resources/types'
+
+// The builder only touches `outerTable.id` (the correlation column); the
+// FieldValue side is raw SQL. A minimal real pgTable keeps the rendered SQL
+// honest — the package-level schema proxy would render the column as nothing
+// (project_drizzle_columns_undefined_in_vitest).
+const EntityInstance = pgTable('EntityInstance', {
+  id: text('id').primaryKey(),
+})
+
+/** Contact-shaped context: a multi EMAIL custom field stored in FieldValue. */
+const context: EntityQueryContext = {
+  fields: [
+    {
+      id: 'cf_email_1',
+      key: 'primary_email',
+      label: 'Email',
+      type: BaseType.STRING,
+      fieldType: 'EMAIL',
+      options: { multi: true },
+      capabilities: { filterable: true, sortable: true },
+    } as any,
+  ],
+  outerTable: EntityInstance as any,
+}
+
+const dialect = new PgDialect()
+const compile = (groups: ConditionGroup[]) => {
+  const clause = entityConditionBuilder.buildGroupedQuery(groups, context)
+  expect(clause).toBeDefined()
+  return dialect.sqlToQuery(clause!)
+}
+
+const group = (operator: string, value?: unknown): ConditionGroup[] => [
+  {
+    id: 'g1',
+    logicalOperator: 'AND',
+    conditions: [{ id: 'c1', fieldId: 'primary_email', operator, value } as any],
+  },
+]
+
+describe('find node — multi-scalar EMAIL conditions compile to any-row EXISTS', () => {
+  it("'is X' is a bare EXISTS over FieldValue rows — an alias row matches", () => {
+    const q = compile(group('is', 'alias@x.com'))
+
+    // Row-level EXISTS correlated on the entity, equality on the typed column.
+    expect(q.sql).toMatch(/EXISTS \(\s*SELECT 1 FROM "FieldValue"/i)
+    expect(q.sql).toContain('"FieldValue"."entityId" = "EntityInstance"."id"')
+    expect(q.sql).toContain('"FieldValue"."valueText" =')
+    expect(q.params).toContain('cf_email_1')
+    expect(q.params).toContain('alias@x.com')
+
+    // No primary-row restriction: nothing pins the subquery to the first row,
+    // so ANY alias row satisfies the predicate.
+    expect(q.sql).not.toMatch(/sortKey/i)
+    expect(q.sql).not.toMatch(/LIMIT/i)
+  })
+
+  it("'is not X' stays NULL-correct — unset records match, any-row inequality otherwise", () => {
+    const q = compile(group('is not', 'alias@x.com'))
+
+    expect(q.sql).toMatch(/NOT EXISTS/i)
+    expect(q.sql).toMatch(/OR EXISTS/i)
+    expect(q.params).toContain('alias@x.com')
+  })
+
+  it("'not empty' is EXISTS over any row of the field", () => {
+    const q = compile(group('not empty'))
+
+    expect(q.sql).toMatch(/EXISTS \(\s*SELECT 1 FROM "FieldValue"/i)
+    expect(q.params).toContain('cf_email_1')
+  })
+})

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/crud.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/crud.ts
@@ -195,6 +195,37 @@ export class CrudNodeProcessor extends BaseNodeProcessor {
           }
           resolvedData[key] = { values, updateMode, fieldType: 'MULTI_SELECT' }
         }
+        // Handle multi-value SCALAR fields (`options.multi` on EMAIL/URL/PHONE/…) with
+        // update modes — the same per-field system multi-relation and MULTI_SELECT use.
+        // A scalar write on a multi field must never be a bare whole-value set: replace
+        // (the locked default) stays a whole-field set of the parsed values, add/remove
+        // become row-level value ops in executeEntityOperation. An empty/null resolved
+        // value stays on the plain lane below, where the existing empty-string cleanup
+        // makes it a no-write instead of a list wipe.
+        else if (
+          field?.options?.multi &&
+          config.mode === 'update' &&
+          resolvedValue != null &&
+          resolvedValue !== ''
+        ) {
+          const updateMode = resolvedFieldUpdateModes[key] ?? RelationUpdateMode.REPLACE
+          let values: unknown[]
+          if (Array.isArray(resolvedValue)) {
+            values = resolvedValue
+          } else if (typeof resolvedValue === 'string') {
+            // A variable may hand back a JSON-stringified array (frontend idiom shared
+            // with MULTI_SELECT); a plain scalar (an email is never valid JSON) wraps.
+            try {
+              const parsed = JSON.parse(resolvedValue)
+              values = Array.isArray(parsed) ? parsed : [parsed]
+            } catch {
+              values = [resolvedValue]
+            }
+          } else {
+            values = [resolvedValue]
+          }
+          resolvedData[key] = { values, updateMode, fieldType: field.fieldType }
+        }
         // Transform RELATION fields: extract ID and wrap with update mode
         else if (field?.type === BaseType.RELATION) {
           const isMulti = isMultiRelationship(field.relationship?.relationshipType)
@@ -788,7 +819,8 @@ export class CrudNodeProcessor extends BaseNodeProcessor {
           throw new Error('Resource ID required for update operation')
         }
 
-        // Separate mode-aware fields (relations + multi-select) from regular fields
+        // Separate mode-aware fields (relations, multi-select, multi-value scalars)
+        // from regular fields
         const regularData: Record<string, any> = {}
         const modeAwareRelations: Array<{
           fieldId: string
@@ -823,9 +855,12 @@ export class CrudNodeProcessor extends BaseNodeProcessor {
               updateMode: RelationUpdateModeType
               fieldType?: string
             }
+            const modeField = resource.fields.find((f) => f.id === fieldId || f.key === fieldId)
 
-            if (fieldType === 'MULTI_SELECT') {
-              // MULTI_SELECT field with update mode
+            if (fieldType === 'MULTI_SELECT' || modeField?.options?.multi) {
+              // MULTI_SELECT or multi-value scalar (`options.multi`) with update mode:
+              // add/remove route through the row-level addValues/removeValues primitives
+              // (they support both kinds), replace stays a whole-field set.
               if (
                 updateMode === RelationUpdateMode.ADD ||
                 updateMode === RelationUpdateMode.REMOVE


### PR DESCRIPTION
Implements item **B4** (workflow CRUD + Find nodes) of `plans/custom-field/multi/04-multi-email-implementation-plan.md`, plus its B6 test slice. Unblocked by the catalog migration (#1584).

## CRUD node — multi-scalar fields join the per-field update-mode system

A multi-value SCALAR field (`options.multi` on EMAIL/URL/PHONE/…) now rides the same `fieldUpdateModes` system multi-relation and MULTI_SELECT already use — a scalar write on a multi field is never a bare whole-value set anymore.

- **`preprocessNode`** (`nodes/action-nodes/crud.ts`): a multi-scalar update value is wrapped as `{ values, updateMode, fieldType }`. Default mode: **`replace`** (locked). Accepts a plain scalar, an array from an upstream variable, or a JSON-stringified array (the MULTI_SELECT idiom); `dynamic` resolves through `fieldUpdateModeVars` like relations do. Empty/null values stay on the plain lane where the existing empty-string cleanup makes them a no-write (never a list wipe).
- **`executeEntityOperation`**: `add`/`remove` route through the row-level `FieldValueService.addValues`/`removeValues` primitives (which already support `options.multi` scalars); `replace` stays a whole-field set of the parsed array. The dispatch re-derives multi-ness from the resource's field defs, so a wrapper can never fall into the relation lane.
- **Catalog** (`catalog/nodes/crud.ts`): `fieldUpdateModes` already accepted any field key with the shared `relationUpdateModeSchema`, and the dynamic-mode validation is field-agnostic — comments updated to name the multi-scalar case; no schema change needed.
- **Panel** (`apps/web/.../nodes/core/crud/panel.tsx`): fields with `options.multi` show the same update-mode badge (`RelationUpdateModeButton`) multi relations and multi-selects get, update mode only.

## Find node

- **EXISTS alias match**: condition builders already compile custom-field conditions to row-level `EXISTS` subqueries over `FieldValue` — "email is X" matches ANY alias row. Pinned by tests (bare EXISTS, no sortKey/primary restriction; `is not` stays NULL-correct; `not empty` = any row).
- **Output shape (#1579 parity)**: verified the server-side resolution returns the ARRAY shape for a multi field — `batchGetValues` → `isArrayReturnFieldType(options.multi)` → `cachedToFriendlyValue` preserves arrays; no fix needed. Pinned by test.
- **Scalar interpolation** (`core/execution-context.ts`): `interpolateVariables` now substitutes the **primary** (first) value via `primaryValue` when the resolved value is an array AND the path's terminal segment names a multi-value scalar field — so `{{find.record.email}}` into a send-email recipient yields one address, not `"a@x.com, b@x.com"`. Genuine array variables (tags, `actionsPerformed`, …) keep joining; explicit index accessors (`email[1]`) bypass the unwrap.

## B6 tests

- `crud-multi-scalar-modes.test.ts` — locked default `replace`; `add` mode appends via `addValues` and the field never reaches the whole-field set (no alias-list wipe); `remove`/`replace`/`dynamic`; JSON-array parsing; create passes raw; empty value is a no-write.
- `find-multi-scalar-exists.test.ts` — EXISTS any-row alias match pins.
- `interpolate-multi-scalar.test.ts` — exact-path resolution keeps the array shape; string interpolation yields the primary; plain arrays still join; index accessor honored.

## Verification

- `vitest`: 3 new files (18 tests) green; full `workflow-engine` node/core/catalog + query-builder suites green (560 tests); template-resolution + variable-generators golden green.
- `tsc --noEmit` scoped: `packages/lib` clean (only pre-existing `scripts/*` noise), `apps/web` crud panel clean (remaining 12 errors are the documented pre-existing noise), `@auxx/workflow-nodes` clean.
- Biome clean on all changed files.