### PR TITLE
feat(records): array-aware email uniqueness, value cap, lookup-core extraction

### DIFF
--- a/apps/api/src/routes/entities/find-by-value.ts
+++ b/apps/api/src/routes/entities/find-by-value.ts
@@ -8,9 +8,9 @@
  * key resolves "customer #456" only within the bound store (parent §8).
  */
 
-import { database, schema } from '@auxx/database'
+import { database } from '@auxx/database'
 import { getCachedEntityDefId } from '@auxx/lib/cache'
-import { and, eq, type SQL } from 'drizzle-orm'
+import { type LookupCandidate, lookupEntitiesByFieldValue } from '@auxx/lib/resources'
 import { Hono } from 'hono'
 import { z } from 'zod'
 import { verifyCallbackAuth } from '../../lib/callback-auth'
@@ -25,22 +25,6 @@ const FindByValueSchema = z.object({
   fieldKey: z.string().min(1),
   value: z.string(),
 })
-
-/** Match `value` against the FieldValue column for the field's type. */
-function valueCondition(fieldType: string, value: string): SQL | null {
-  switch (fieldType) {
-    case 'NUMBER':
-    case 'CURRENCY': {
-      const n = Number(value)
-      return Number.isFinite(n) ? eq(schema.FieldValue.valueNumber, n) : null
-    }
-    case 'CHECKBOX':
-      return eq(schema.FieldValue.valueBoolean, value === 'true')
-    default:
-      // TEXT, EMAIL, URL, PHONE_INTL, NAME, … all live in valueText.
-      return eq(schema.FieldValue.valueText, value)
-  }
-}
 
 findByValue.post('/find-by-value', async (c) => {
   const auth = verifyCallbackAuth(c, 'entities')
@@ -73,31 +57,29 @@ findByValue.post('/find-by-value', async (c) => {
   )
   if (!field) return c.json(errorResponse('FORBIDDEN', `Field not owned: ${fieldKey}`), 403)
 
-  const condition = valueCondition(field.type, value)
-  if (!condition) return c.json({ entity: null })
+  // The SDK sends strings; `createTypedValueInput` does `Boolean('false') ===
+  // true`, so coerce checkbox values here (matching this route's historical
+  // `value === 'true'` behavior).
+  const candidateValue: unknown = field.type === 'CHECKBOX' ? value === 'true' : value
 
-  const row = await database
-    .select({
-      instanceId: schema.EntityInstance.id,
-      displayName: schema.EntityInstance.displayName,
-    })
-    .from(schema.FieldValue)
-    .innerJoin(schema.EntityInstance, eq(schema.EntityInstance.id, schema.FieldValue.entityId))
-    .where(
-      and(
-        eq(schema.FieldValue.organizationId, auth.organizationId),
-        eq(schema.FieldValue.fieldId, field.id),
-        condition
-      )
-    )
-    .limit(1)
+  // Shared lookup core: column-aware typed match + write-path normalization
+  // (EMAIL lowercased, URL protocol-prefixed, PHONE E.164 — a raw `eq` on
+  // valueText could never match those), deterministic ordering. Keeps
+  // include-archived, matching the historical behavior of this route.
+  const result = await lookupEntitiesByFieldValue(database, {
+    organizationId: auth.organizationId,
+    entityDefinitionId: defId,
+    candidates: [{ fieldId: field.id, value: candidateValue } as LookupCandidate],
+    limit: 1,
+  })
+  if (result.isErr()) return c.json({ entity: null })
 
-  const hit = row[0]
+  const hit = result.value.items[0]
   if (!hit) return c.json({ entity: null })
 
   return c.json({
     entity: {
-      recordId: `${defId}:${hit.instanceId}`,
+      recordId: hit.recordId,
       displayName: hit.displayName,
     },
   })

--- a/packages/lib/src/custom-fields/__tests__/check-unique-value-typed.test.ts
+++ b/packages/lib/src/custom-fields/__tests__/check-unique-value-typed.test.ts
@@ -1,0 +1,87 @@
+// packages/lib/src/custom-fields/__tests__/check-unique-value-typed.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { UniqueValueConflictError } from '../../errors'
+import { checkUniqueValueTyped } from '../check-unique-value-typed'
+
+/**
+ * Minimal fake Drizzle db: every builder step chains, `.limit()` returns a
+ * thenable resolving to `rows` so `await query` works. `selectCalls` counts
+ * how many queries were issued (one per array element).
+ */
+function buildFakeDb(rows: Array<{ entityId: string; displayName: string | null }>) {
+  const state = { selectCalls: 0 }
+  const chain: Record<string, unknown> = {}
+  chain.from = () => chain
+  chain.innerJoin = () => chain
+  chain.where = () => chain
+  chain.limit = () => Promise.resolve(rows)
+  const db = {
+    select: () => {
+      state.selectCalls++
+      return chain
+    },
+  }
+  return { db: db as never, state }
+}
+
+const baseInput = {
+  fieldId: 'field-email-1',
+  organizationId: 'org-1',
+  modelType: 'ENTITY' as never,
+  entityDefinitionId: 'def-contact',
+  excludeEntityId: 'inst-self',
+}
+
+describe('checkUniqueValueTyped — array-aware (panel/bulk-edit door)', () => {
+  it('returns true for null without querying', async () => {
+    const { db, state } = buildFakeDb([{ entityId: 'x', displayName: null }])
+    await expect(checkUniqueValueTyped({ ...baseInput, value: null }, db)).resolves.toBe(true)
+    expect(state.selectCalls).toBe(0)
+  })
+
+  it('checks every element of an array input (one query per element)', async () => {
+    const { db, state } = buildFakeDb([])
+    const result = await checkUniqueValueTyped(
+      {
+        ...baseInput,
+        value: [
+          { type: 'text', value: 'a@x.com' },
+          { type: 'text', value: 'b@x.com' },
+        ],
+      },
+      db
+    )
+    expect(result).toBe(true)
+    expect(state.selectCalls).toBe(2)
+  })
+
+  it('rejects an array containing a value claimed by another record', async () => {
+    const { db } = buildFakeDb([{ entityId: 'inst-other', displayName: 'Jane Roe' }])
+    const promise = checkUniqueValueTyped(
+      { ...baseInput, value: [{ type: 'text', value: 'claimed@x.com' }] },
+      db
+    )
+    await expect(promise).rejects.toThrow(UniqueValueConflictError)
+    await promise.catch((e: UniqueValueConflictError) => {
+      expect(e.conflictingValue).toBe('claimed@x.com')
+      expect(e.existingEntityId).toBe('inst-other')
+      expect(e.fieldId).toBe('field-email-1')
+      expect(e.statusCode).toBe(409)
+      expect(e.message).toContain('Jane Roe')
+    })
+  })
+
+  it('rejects a scalar duplicate with the structured error', async () => {
+    const { db } = buildFakeDb([{ entityId: 'inst-other', displayName: null }])
+    await expect(
+      checkUniqueValueTyped({ ...baseInput, value: { type: 'text', value: 'dup@x.com' } }, db)
+    ).rejects.toThrow(UniqueValueConflictError)
+  })
+
+  it('empty array passes without querying', async () => {
+    const { db, state } = buildFakeDb([{ entityId: 'x', displayName: null }])
+    await expect(checkUniqueValueTyped({ ...baseInput, value: [] }, db)).resolves.toBe(true)
+    expect(state.selectCalls).toBe(0)
+  })
+})

--- a/packages/lib/src/custom-fields/check-unique-value-typed.ts
+++ b/packages/lib/src/custom-fields/check-unique-value-typed.ts
@@ -3,7 +3,8 @@
 import type { ModelType } from '@auxx/database'
 import { type Database, database, schema, type Transaction } from '@auxx/database'
 import type { TypedFieldValueInput } from '@auxx/types'
-import { and, eq, ne, sql } from 'drizzle-orm'
+import { and, eq, isNull, ne, sql } from 'drizzle-orm'
+import { UniqueValueConflictError } from '../errors'
 import { parseRecordId } from '../resources/resource-id'
 
 /**
@@ -22,8 +23,13 @@ export interface CheckUniqueValueTypedInput {
  * Check if a typed field value is unique within its scope.
  * Uses the new FieldValue table with typed columns.
  *
+ * Array inputs (multi-value fields, `options.multi`) are checked PER VALUE —
+ * every element must be unique org-wide. Archived records are excluded (merge
+ * archives sources whose FieldValue rows survive; counting them would
+ * false-conflict edits of the surviving record).
+ *
  * @param input - Check parameters
- * @returns True if value is unique, throws error if not
+ * @returns True if value is unique, throws {@link UniqueValueConflictError} if not
  */
 export async function checkUniqueValueTyped(
   input: CheckUniqueValueTypedInput,
@@ -36,8 +42,13 @@ export async function checkUniqueValueTyped(
     return true
   }
 
-  // For arrays, we don't support uniqueness checking on multi-value fields
+  // Multi-value fields: every element must individually pass. This is the
+  // panel/bulk-edit door's ONLY uniqueness gate for arrays — returning true
+  // here would let a claimed email in via `fieldValue.set`.
   if (Array.isArray(value)) {
+    for (const element of value) {
+      await checkUniqueValueTyped({ ...input, value: element }, db)
+    }
     return true
   }
 
@@ -82,16 +93,22 @@ export async function checkUniqueValueTyped(
     return true
   }
 
-  // Query for existing values with the same value
+  // Query for existing values with the same value. The EntityInstance join
+  // excludes archived records from the check.
   const query = db
-    .select({ entityId: schema.FieldValue.entityId })
+    .select({
+      entityId: schema.FieldValue.entityId,
+      displayName: schema.EntityInstance.displayName,
+    })
     .from(schema.FieldValue)
     .innerJoin(schema.CustomField, eq(schema.CustomField.id, schema.FieldValue.fieldId))
+    .innerJoin(schema.EntityInstance, eq(schema.EntityInstance.id, schema.FieldValue.entityId))
     .where(
       and(
         eq(schema.FieldValue.fieldId, fieldId),
         eq(schema.FieldValue.organizationId, organizationId),
         eq(schema.CustomField.modelType, modelType),
+        isNull(schema.EntityInstance.archivedAt),
         entityDefinitionId
           ? eq(schema.CustomField.entityDefinitionId, entityDefinitionId)
           : undefined,
@@ -103,8 +120,23 @@ export async function checkUniqueValueTyped(
 
   const result = await query
 
-  if (result.length > 0) {
-    throw new Error('Value already exists')
+  const existing = result[0]
+  if (existing) {
+    const conflictingValue =
+      value.type === 'option'
+        ? value.optionId
+        : value.type === 'relationship'
+          ? value.recordId
+          : 'value' in value
+            ? String(value.value)
+            : JSON.stringify(value)
+    const owner = existing.displayName ? ` on "${existing.displayName}"` : ''
+    throw new UniqueValueConflictError({
+      message: `Value already exists${owner}: ${conflictingValue}`,
+      conflictingValue,
+      fieldId,
+      existingEntityId: existing.entityId,
+    })
   }
 
   return true

--- a/packages/lib/src/data-migrations/migrations/084-primary-email-unique.ts
+++ b/packages/lib/src/data-migrations/migrations/084-primary-email-unique.ts
@@ -1,0 +1,71 @@
+// packages/lib/src/data-migrations/migrations/084-primary-email-unique.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { sql } from 'drizzle-orm'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-084')
+
+/**
+ * Mark the seeded contact `primary_email` field `isUnique` on existing orgs.
+ *
+ * **Why the registry flag alone is not enough.** `CONTACT_FIELDS.primaryEmail`
+ * gained `capabilities.unique: true`, and the entity seeder maps that onto
+ * `CustomField.isUnique` (`entity-seeder/utils.ts` → `mapCapabilities`) — but
+ * only for orgs seeded AFTER the change. `create-fields.ts` inserts and never
+ * updates, so existing orgs keep `isUnique = false` and the
+ * `FieldValueService` uniqueness gate (`checkUniqueValueTyped`, keyed off
+ * `field.isUnique`) never fires for them. That gate is the ONLY uniqueness
+ * door for panel/bulk-edit writes (`fieldValue.set` / `applyBulk`), which
+ * never run contact hooks — without this flip those orgs can claim another
+ * contact's email through the panel. Same mechanism as migration 078.
+ *
+ * **Scoped to the system field.** Matched on
+ * `systemAttribute = 'primary_email'`, the seeded identity of this field on
+ * every org's `contact` def. Org-created EMAIL fields carry a NULL
+ * `systemAttribute` and are untouched.
+ *
+ * **Pre-existing duplicates are left in place.** The gate is write-time only;
+ * a duplicate pair created before this flip keeps both rows until one is
+ * edited (at which point the edit conflicts). The dedup plan owns cleanup.
+ *
+ * **Cache clear is required and is ours.** The data-migration runner does not
+ * invalidate org caches, and `customFields` / `resources` are cached per org.
+ * Without the flush, orgs holding a warm blob keep serving `isUnique: false`
+ * (and the write gate keeps not firing) until the key expires.
+ *
+ * Idempotent: the `WHERE` only matches rows still at `false`.
+ */
+export const migration084PrimaryEmailUnique: DataMigrationDef = {
+  id: '084-primary-email-unique',
+  description: 'Mark the seeded contact primary_email field isUnique (arms the write gate)',
+  async run(db: Database): Promise<void> {
+    const result = await db.execute<{ organizationId: string }>(sql`
+      UPDATE "CustomField"
+      SET "isUnique" = true, "updatedAt" = now()
+      WHERE "systemAttribute" = 'primary_email'
+        AND "isUnique" = false
+      RETURNING "organizationId"
+    `)
+
+    const organizationIds = [...new Set(result.rows.map((r) => r.organizationId))]
+
+    if (organizationIds.length > 0) {
+      // Lazy so the data-migration graph does not pull the cache barrel (and its
+      // Redis client) into every migration run.
+      const { getOrgCache } = await import('../../cache')
+      const cache = getOrgCache()
+      await Promise.all(
+        organizationIds.map((organizationId) =>
+          cache.invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+        )
+      )
+    }
+
+    logger.info('primary_email is now isUnique', {
+      fieldsUpdated: result.rows.length,
+      organizationsAffected: organizationIds.length,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -48,6 +48,7 @@ import { migration080OutlookWebhookCutover } from './migrations/080-outlook-webh
 import { migration081BackfillInteractionFields } from './migrations/081-backfill-interaction-fields'
 import { migration082InteractionFieldsParticipantResolution } from './migrations/082-interaction-fields-participant-resolution'
 import { migration083FindManyPluralToIdRefs } from './migrations/083-find-many-plural-to-id-refs'
+import { migration084PrimaryEmailUnique } from './migrations/084-primary-email-unique'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -122,6 +123,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration081BackfillInteractionFields,
     migration082InteractionFieldsParticipantResolution,
     migration083FindManyPluralToIdRefs,
+    migration084PrimaryEmailUnique,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/field-values/__tests__/multi-value-cap.test.ts
+++ b/packages/lib/src/field-values/__tests__/multi-value-cap.test.ts
@@ -1,0 +1,56 @@
+// packages/lib/src/field-values/__tests__/multi-value-cap.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { BadRequestError } from '../../errors'
+import { type FieldValueContext, validateAndConvertValue } from '../field-value-helpers'
+import { FieldValueValidator } from '../field-value-validator'
+import { MAX_MULTI_VALUES } from '../primary-value'
+import type { CachedField } from '../types'
+
+const ctx = {
+  db: {} as never,
+  organizationId: 'org-1',
+  fieldCache: new Map(),
+  batchRelationshipValidationCache: new Map(),
+  validator: new FieldValueValidator(),
+} as unknown as FieldValueContext
+
+const multiEmailField = {
+  id: 'field-email-1',
+  type: 'EMAIL',
+  options: { multi: true },
+} as unknown as CachedField
+
+const emails = (n: number) => Array.from({ length: n }, (_, i) => `user${i}@example.com`)
+
+describe('validateAndConvertValue — MAX_MULTI_VALUES cap', () => {
+  it(`accepts exactly ${MAX_MULTI_VALUES} values`, async () => {
+    const result = await validateAndConvertValue(
+      ctx,
+      emails(MAX_MULTI_VALUES),
+      'EMAIL',
+      multiEmailField
+    )
+    expect(Array.isArray(result)).toBe(true)
+    expect((result as unknown[]).length).toBe(MAX_MULTI_VALUES)
+  })
+
+  it(`rejects the ${MAX_MULTI_VALUES + 1}th value`, async () => {
+    await expect(
+      validateAndConvertValue(ctx, emails(MAX_MULTI_VALUES + 1), 'EMAIL', multiEmailField)
+    ).rejects.toThrow(BadRequestError)
+  })
+
+  it('normalizes (lowercases) each array element on the way through', async () => {
+    const result = await validateAndConvertValue(
+      ctx,
+      ['Alice@Example.COM', 'BOB@X.io'],
+      'EMAIL',
+      multiEmailField
+    )
+    expect(result).toEqual([
+      { type: 'text', value: 'alice@example.com' },
+      { type: 'text', value: 'bob@x.io' },
+    ])
+  })
+})

--- a/packages/lib/src/field-values/field-value-helpers.ts
+++ b/packages/lib/src/field-values/field-value-helpers.ts
@@ -42,6 +42,7 @@ import { isRecordId, parseRecordId, toRecordId } from '../resources/resource-id'
 import { cascadeDependentDisplayNames, getDisplayFieldDeps } from './display-field-deps'
 import { FieldValueValidator, fieldValueSchemas } from './field-value-validator'
 import { formatToDisplayValue } from './formatter'
+import { MAX_MULTI_VALUES, primaryValue } from './primary-value'
 import type { InverseFieldInfo } from './relationship-sync'
 import { isSearchTextIndexedFieldType, updateSearchText } from './search-text'
 import { toFieldType } from './stored-field-type'
@@ -605,6 +606,13 @@ export async function validateAndConvertValue(
       }
     }
 
+    // Value cap: bounds the multi-value injection vector and the UI.
+    if (converted.length > MAX_MULTI_VALUES) {
+      throw new BadRequestError(
+        `Field ${field.id} accepts at most ${MAX_MULTI_VALUES} values; received ${converted.length}`
+      )
+    }
+
     return converted.length > 0 ? converted : null
   }
 
@@ -1131,12 +1139,16 @@ export async function maybeUpdateDisplayValue(
         }
       }
     } else {
-      // Use centralized formatter for display value computation
-      displayValue = formatToDisplayValue(
-        typedValue,
-        toFieldType(field.type),
-        field.options as any
-      ) as string | null
+      // Use centralized formatter for display value computation. Multi-value
+      // fields render their PRIMARY (first) value — `formatToDisplayValue`
+      // maps over arrays, and writing that array into the display column
+      // would corrupt `displayName`/`secondaryDisplayValue`.
+      const primaryTyped = primaryValue(typedValue)
+      displayValue = primaryTyped
+        ? (formatToDisplayValue(primaryTyped, toFieldType(field.type), field.options as any) as
+            | string
+            | null)
+        : null
     }
   }
 

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -76,6 +76,7 @@ import {
 } from './field-value-helpers'
 import { getValue } from './field-value-queries'
 import { formatToTypedInput } from './formatter'
+import { MAX_MULTI_VALUES } from './primary-value'
 import {
   type BulkRelationshipUpdate,
   batchGetExistingRelatedIds,
@@ -1394,6 +1395,14 @@ export async function addValues(
       return existingRows.map((r) => rowToTypedValue(r, fieldType))
     }
 
+    // Value cap: existing rows + surviving (deduped) additions must fit.
+    if (existingRows.length + survivors.length > MAX_MULTI_VALUES) {
+      throw new BadRequestError(
+        `Field ${fieldId} accepts at most ${MAX_MULTI_VALUES} values; ` +
+          `record has ${existingRows.length} and ${survivors.length} more were submitted`
+      )
+    }
+
     // Generate sortKeys appended after the current max.
     // `nextKeyAfter` tolerates a corrupt last-row sortKey by degrading to 'a0'.
     let prevKey: string | null =
@@ -1667,6 +1676,15 @@ export async function addValuesBulk(
         if (seen.has(key) || localSeen.has(key)) {
           skippedCount++
           continue
+        }
+        // Value cap: adding this value would push the record past the cap.
+        // Throwing aborts the whole transaction — a partial bulk add on some
+        // records but not others would be harder to reason about than a rerun.
+        if (existing.length + insertedTyped.length + 1 > MAX_MULTI_VALUES) {
+          throw new BadRequestError(
+            `Field ${fieldId} accepts at most ${MAX_MULTI_VALUES} values; ` +
+              `record ${entityId} would exceed the cap`
+          )
         }
         localSeen.add(key)
         const sortKey = nextKeyAfter(prevKey)

--- a/packages/lib/src/import/fields/suggest-resolution-type.ts
+++ b/packages/lib/src/import/fields/suggest-resolution-type.ts
@@ -47,7 +47,11 @@ export function suggestResolutionType(field: ImportableField): ResolutionType {
     case 'phone':
       return 'phone:value'
 
+    // URL fields keep scheme/path — `domain:value` strips them, so the value
+    // could never round-trip against the write path's `https://host/...` form.
     case 'url':
+      return 'url:value'
+
     case 'domain':
       return 'domain:value'
 
@@ -123,6 +127,8 @@ export function getValidResolutionTypes(fieldType: string): ResolutionType[] {
       return ['phone:value', 'text:value']
 
     case 'url':
+      return ['url:value', 'domain:value', 'text:value']
+
     case 'domain':
       return ['domain:value', 'text:value']
 

--- a/packages/lib/src/import/planning/find-existing-record.ts
+++ b/packages/lib/src/import/planning/find-existing-record.ts
@@ -3,10 +3,11 @@
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { getValueType } from '@auxx/types'
 import { and, eq, ilike } from 'drizzle-orm'
 import type { PgTableWithColumns } from 'drizzle-orm/pg-core'
 import type { Resource, ResourceField } from '../../resources'
+import { lookupEntitiesByFieldValue } from '../../resources/lookup'
+import { parseRecordId } from '../../resources/resource-id'
 import { BaseType } from '../../workflow-engine/core/types'
 
 const logger = createScopedLogger('find-existing-record')
@@ -82,8 +83,8 @@ export function createFindExistingRecord(options: FindExistingRecordOptions) {
     if (resource.type === 'custom' && resource.entityDefinitionId) {
       const result = await findInCustomEntity(
         db,
-        resource.entityDefinitionId,
         organizationId,
+        resource.entityDefinitionId,
         identifierField,
         value
       )
@@ -133,52 +134,44 @@ async function findInSystemTable(
 }
 
 /**
- * Find a record in a custom entity by unique field value.
- * Queries FieldValue table using typed columns to find the entityId.
+ * Find a record in a custom entity by identifier field value.
+ *
+ * Routes through the shared lookup core so the comparison mirrors write-path
+ * normalization (EMAIL lowercased, URL protocol-prefixed, PHONE E.164 —
+ * previously the raw CSV cell was compared against the normalized stored value
+ * and could never match a `Foo@Bar.com` cell, the historic "uniqueness breaks
+ * imports" root cause). Archived records are excluded — an import must never
+ * resolve a row to a merged-away/archived record — and matching is
+ * deterministic (entityId, sortKey ordering).
  */
 async function findInCustomEntity(
   db: Database,
-  entityDefinitionId: string,
   organizationId: string,
+  entityDefinitionId: string,
   identifierField: ResourceField,
   value: string
 ): Promise<string | null> {
   if (!identifierField.id) return null
 
-  // Determine which typed column to query based on field type
-  const dbFieldType = identifierField.fieldType || 'TEXT'
-  const valueType = getValueType(dbFieldType)
+  const result = await lookupEntitiesByFieldValue(db, {
+    organizationId,
+    entityDefinitionId,
+    candidates: [{ fieldId: identifierField.id, value }],
+    limit: 1,
+    excludeArchived: true,
+  })
 
-  // Build the value comparison based on type
-  let valueComparison
-  switch (valueType) {
-    case 'text':
-      valueComparison = eq(schema.FieldValue.valueText, value)
-      break
-    case 'number':
-      valueComparison = eq(schema.FieldValue.valueNumber, parseFloat(value))
-      break
-    case 'option':
-      valueComparison = eq(schema.FieldValue.optionId, value)
-      break
-    default:
-      // For other types, use text column
-      valueComparison = eq(schema.FieldValue.valueText, value)
+  if (result.isErr()) {
+    // Sole candidate uncoercible (e.g. malformed email cell) — no match.
+    logger.debug('Identifier value not coercible for lookup', {
+      entityDefinitionId,
+      identifierField: identifierField.key,
+      value,
+    })
+    return null
   }
 
-  const result = await db
-    .select({ entityId: schema.FieldValue.entityId })
-    .from(schema.FieldValue)
-    .innerJoin(schema.EntityInstance, eq(schema.FieldValue.entityId, schema.EntityInstance.id))
-    .where(
-      and(
-        eq(schema.EntityInstance.entityDefinitionId, entityDefinitionId),
-        eq(schema.FieldValue.organizationId, organizationId),
-        eq(schema.FieldValue.fieldId, identifierField.id),
-        valueComparison
-      )
-    )
-    .limit(1)
-
-  return result[0]?.entityId ?? null
+  const match = result.value.items[0]
+  if (!match) return null
+  return parseRecordId(match.recordId).entityInstanceId
 }

--- a/packages/lib/src/import/resolution/__tests__/resolve-relation-lookups.test.ts
+++ b/packages/lib/src/import/resolution/__tests__/resolve-relation-lookups.test.ts
@@ -1,0 +1,123 @@
+// packages/lib/src/import/resolution/__tests__/resolve-relation-lookups.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BaseType } from '../../../resources/types'
+
+// Mock the cache barrel WHOLESALE (partial-mocking it via importOriginal walks
+// its real import graph before the mock exists).
+vi.mock('../../../cache', () => ({
+  getCachedResource: vi.fn(),
+}))
+
+const { getCachedResource } = await import('../../../cache')
+const { resolveRelationLookups } = await import('../resolve-relation-lookups')
+
+const getCachedResourceMock = vi.mocked(getCachedResource)
+
+const companyResource = {
+  type: 'custom',
+  id: 'company',
+  entityDefinitionId: 'def-company',
+  organizationId: 'org-1',
+  fields: [
+    { key: 'website', id: 'field-web-1', type: BaseType.URL },
+    { key: 'email', id: 'field-email-1', type: BaseType.EMAIL },
+  ],
+  display: { primaryDisplayField: { name: 'name' } },
+} as never
+
+const userSystemResource = {
+  type: 'system',
+  id: 'user',
+  dbName: 'User',
+  fields: [{ key: 'email', dbColumn: 'email', type: BaseType.EMAIL }],
+  display: { primaryDisplayField: { id: 'email' } },
+} as never
+
+/** Fake db: FieldValue-lane select chain is thenable and resolves `rows`. */
+function buildFakeDb(rows: Array<Record<string, unknown>>) {
+  const chain: Record<string, unknown> = {}
+  chain.from = () => chain
+  chain.innerJoin = () => chain
+  chain.where = () => chain
+  // biome-ignore lint/suspicious/noThenProperty: deliberately thenable — the query builder is awaited directly
+  chain.then = (resolve: (v: unknown) => void) => Promise.resolve(rows).then(resolve)
+  const execute = vi.fn(async () => ({ rows: [] }))
+  const db = {
+    select: () => chain,
+    execute,
+    query: { EntityInstance: { findMany: vi.fn(async () => []) } },
+  }
+  return { db: db as never, execute }
+}
+
+function lookup(searchValue: string, matchField: string, hash = `h-${searchValue}`) {
+  return {
+    hash,
+    jobPropertyId: 'jp-1',
+    entityDefinitionId: 'company',
+    matchField,
+    searchValue,
+  }
+}
+
+beforeEach(() => {
+  getCachedResourceMock.mockReset()
+  getCachedResourceMock.mockResolvedValue(companyResource)
+})
+
+describe('resolveRelationLookups', () => {
+  it('matches a URL relation cell against the write-normalized stored value', async () => {
+    // Stored: write-path shape. CSV cell: bare mixed-case host — lowercase-only
+    // normalization could never match this.
+    const { db } = buildFakeDb([
+      { entityId: 'rec-1', valueText: 'https://acme.com', valueNumber: null, optionId: null },
+    ])
+    const results = await resolveRelationLookups(db, 'org-1', [lookup('ACME.com', 'website')])
+    expect(results).toHaveLength(1)
+    expect(results[0]!.recordId).toBe('rec-1')
+    expect(results[0]!.error).toBeUndefined()
+  })
+
+  it('errors on ambiguity instead of last-write-wins', async () => {
+    const { db } = buildFakeDb([
+      { entityId: 'rec-1', valueText: 'shared@x.com', valueNumber: null, optionId: null },
+      { entityId: 'rec-2', valueText: 'shared@x.com', valueNumber: null, optionId: null },
+    ])
+    const results = await resolveRelationLookups(db, 'org-1', [lookup('shared@x.com', 'email')])
+    expect(results[0]!.recordId).toBeNull()
+    expect(results[0]!.error).toContain('Ambiguous match')
+  })
+
+  it('still resolves a unique match normally', async () => {
+    const { db } = buildFakeDb([
+      { entityId: 'rec-1', valueText: 'solo@x.com', valueNumber: null, optionId: null },
+    ])
+    const results = await resolveRelationLookups(db, 'org-1', [lookup('Solo@X.com', 'email')])
+    expect(results[0]!.recordId).toBe('rec-1')
+  })
+
+  it('reports no-match for unmatched values', async () => {
+    const { db } = buildFakeDb([])
+    const results = await resolveRelationLookups(db, 'org-1', [lookup('ghost@x.com', 'email')])
+    expect(results[0]!.recordId).toBeNull()
+    expect(results[0]!.error).toContain('No match found')
+  })
+
+  it('rejects an unknown/unsafe matchField on system resources without touching sql.raw', async () => {
+    getCachedResourceMock.mockResolvedValue(userSystemResource)
+    const { db, execute } = buildFakeDb([])
+    const results = await resolveRelationLookups(db, 'org-1', [
+      lookup('x@y.com', '"email" OR 1=1 --'),
+    ])
+    expect(execute).not.toHaveBeenCalled()
+    expect(results[0]!.recordId).toBeNull()
+  })
+
+  it('allows a registered system-resource matchField through the gate', async () => {
+    getCachedResourceMock.mockResolvedValue(userSystemResource)
+    const { db, execute } = buildFakeDb([])
+    await resolveRelationLookups(db, 'org-1', [lookup('x@y.com', 'email')])
+    expect(execute).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/lib/src/import/resolution/resolve-relation-lookups.ts
+++ b/packages/lib/src/import/resolution/resolve-relation-lookups.ts
@@ -5,6 +5,7 @@ import { schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq, inArray, isNull, type SQL, sql } from 'drizzle-orm'
 import { getCachedResource } from '../../cache'
+import { normalizeForLookup } from '../../field-values/normalize-for-lookup'
 import type { CustomResource, Resource, SystemResource } from '../../resources/registry/types'
 import { BaseType } from '../../resources/types'
 
@@ -135,7 +136,8 @@ async function resolveLookupsForTable(
   const results: RelationLookupResult[] = []
 
   for (const [matchField, fieldLookups] of byMatchField) {
-    const searchValues = fieldLookups.map((l) => l.searchValue.toLowerCase().trim())
+    const fieldType = resource.fields.find((f) => f.key === matchField)?.type
+    const searchValues = fieldLookups.map((l) => normalizeSearchValue(l.searchValue, fieldType))
 
     // Query records matching any of the search values
     const records = await queryRecordsByField(
@@ -146,26 +148,37 @@ async function resolveLookupsForTable(
       searchValues
     )
 
-    // Build lookup map: normalizedSearchValue -> recordId
-    const recordMap = new Map<string, string>()
+    // Build lookup map: normalizedSearchValue -> recordIds. A value carried by
+    // MORE than one record is an ambiguity — resolved as a row error below,
+    // never last-write-wins (silently linking to an arbitrary record).
+    const recordMap = new Map<string, Set<string>>()
     for (const record of records) {
       const fieldValue = record[matchField]
       if (fieldValue != null) {
         const normalizedKey = String(fieldValue).toLowerCase().trim()
-        recordMap.set(normalizedKey, record.id)
+        const ids = recordMap.get(normalizedKey) ?? new Set<string>()
+        ids.add(record.id)
+        recordMap.set(normalizedKey, ids)
       }
     }
 
     // Map results
-    for (const lookup of fieldLookups) {
-      const normalizedSearch = lookup.searchValue.toLowerCase().trim()
-      const recordId = recordMap.get(normalizedSearch) ?? null
+    for (let i = 0; i < fieldLookups.length; i++) {
+      const lookup = fieldLookups[i]!
+      const matched = recordMap.get(searchValues[i]!)
 
-      if (recordId) {
+      if (matched && matched.size > 1) {
         results.push({
           hash: lookup.hash,
           jobPropertyId: lookup.jobPropertyId,
-          recordId,
+          recordId: null,
+          error: `Ambiguous match for "${lookup.searchValue}": ${matched.size} records share this value`,
+        })
+      } else if (matched && matched.size === 1) {
+        results.push({
+          hash: lookup.hash,
+          jobPropertyId: lookup.jobPropertyId,
+          recordId: [...matched][0]!,
         })
       } else if (lookup.createIfNotFound) {
         results.push({
@@ -189,6 +202,30 @@ async function resolveLookupsForTable(
 }
 
 /**
+ * Normalize a relation search value to write-path shape so it can match stored
+ * values: EMAIL lowercased, URL `https://`-prefixed + lowercased, PHONE E.164.
+ * Lowercase-only normalization can never match a stored URL/phone — the write
+ * path stores `https://acme.com` and `+15551234567`. Falls back to
+ * lowercase+trim when the value doesn't parse (it then simply finds no match)
+ * or when the field type carries no normalization.
+ */
+function normalizeSearchValue(rawValue: string, fieldType: BaseType | undefined): string {
+  const fallback = rawValue.toLowerCase().trim()
+  const dbType =
+    fieldType === BaseType.EMAIL
+      ? ('EMAIL' as const)
+      : fieldType === BaseType.URL
+        ? ('URL' as const)
+        : fieldType === BaseType.PHONE
+          ? ('PHONE_INTL' as const)
+          : null
+  if (!dbType) return fallback
+  const normalized = normalizeForLookup(dbType, rawValue)
+  // The SQL side compares LOWER(column) — keep the key lowercase.
+  return typeof normalized === 'string' ? normalized.toLowerCase() : fallback
+}
+
+/**
  * Query records by field value using IN clause for batch efficiency.
  * Uses cached resource data from ResourceRegistryService.
  */
@@ -206,9 +243,12 @@ async function queryRecordsByField(
   if (resource.type === 'system') {
     return querySystemResource(db, organizationId, resource, matchField, searchValues)
   } else {
-    return queryCustomEntity(db, resource, matchField, searchValues)
+    return queryCustomEntity(db, organizationId, resource, matchField, searchValues)
   }
 }
+
+/** Conservative SQL-identifier shape for interpolated column names. */
+const SAFE_SQL_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/
 
 /**
  * Query system resource (contact, ticket, etc.)
@@ -224,6 +264,20 @@ async function querySystemResource(
   // Use raw SQL query for flexibility with dynamic table/column names
   // This avoids TypeScript issues with dynamic schema access
   const tableName = resource.dbName
+
+  // `matchField` is mapping-supplied and reaches `sql.raw` — gate it against
+  // the resource's registered fields (plus identifier shape) so a crafted
+  // mapping cannot inject SQL through the column position.
+  const isKnownField =
+    matchField === 'id' ||
+    resource.fields.some((f) => f.key === matchField || f.dbColumn === matchField)
+  if (!isKnownField || !SAFE_SQL_IDENTIFIER.test(matchField)) {
+    logger.warn('Rejected unsafe or unknown matchField for system resource lookup', {
+      resourceId: resource.id,
+      matchField,
+    })
+    return []
+  }
 
   // Build the SQL query with proper escaping
   const results = await db.execute<{ id: string; [key: string]: unknown }>(
@@ -243,6 +297,7 @@ async function querySystemResource(
  */
 async function queryCustomEntity(
   db: Database,
+  organizationId: string,
   resource: CustomResource,
   matchField: string,
   searchValues: string[]
@@ -253,6 +308,7 @@ async function queryCustomEntity(
   if (matchField === 'id') {
     const instances = await db.query.EntityInstance.findMany({
       where: and(
+        eq(schema.EntityInstance.organizationId, organizationId),
         eq(schema.EntityInstance.entityDefinitionId, entityDefinitionId),
         inArray(schema.EntityInstance.id, searchValues),
         isNull(schema.EntityInstance.archivedAt)
@@ -304,7 +360,10 @@ async function queryCustomEntity(
     return []
   }
 
-  // Query with type-appropriate condition using FieldValue typed columns
+  // Query with type-appropriate condition using FieldValue typed columns.
+  // The organizationId predicate is load-bearing: FieldValue.fieldId alone
+  // does scope to one org's CustomField row, but belt-and-braces here keeps
+  // the query index-friendly and future-proof against shared field ids.
   const results = await db
     .select({
       entityId: schema.FieldValue.entityId,
@@ -320,7 +379,13 @@ async function queryCustomEntity(
         isNull(schema.EntityInstance.archivedAt)
       )
     )
-    .where(and(eq(schema.FieldValue.fieldId, field.id), matchCondition))
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, field.id),
+        matchCondition
+      )
+    )
 
   return results.map((r) => {
     // Extract the appropriate value based on column type

--- a/packages/lib/src/import/resolution/resolver-registry.ts
+++ b/packages/lib/src/import/resolution/resolver-registry.ts
@@ -21,6 +21,7 @@ import {
 } from './resolvers/relation'
 import { resolveSelectCreate, resolveSelectValue } from './resolvers/select'
 import { resolveTextCuid, resolveTextValue } from './resolvers/text'
+import { resolveUrl } from './resolvers/url'
 
 /** Resolver function type */
 type ResolverFn = (rawValue: string, config: ResolutionConfig) => ResolvedValue
@@ -45,6 +46,7 @@ const RESOLVER_REGISTRY: Record<ResolutionType, ResolverFn> = {
   'relation:match': resolveRelationMatch,
   'relation:create': resolveRelationCreate,
   'domain:value': resolveDomain,
+  'url:value': resolveUrl,
   'array:split': resolveArraySplit,
 }
 

--- a/packages/lib/src/import/resolution/resolvers/__tests__/url.test.ts
+++ b/packages/lib/src/import/resolution/resolvers/__tests__/url.test.ts
@@ -1,0 +1,41 @@
+// packages/lib/src/import/resolution/resolvers/__tests__/url.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { fieldValueSchemas } from '../../../../field-values/field-value-validator'
+import { resolveUrl } from '../url'
+
+const config = {} as never
+
+describe('resolveUrl (url:value)', () => {
+  it('preserves scheme and path (unlike domain:value)', () => {
+    const result = resolveUrl('https://acme.com/pricing?x=1', config)
+    expect(result).toEqual({ type: 'value', value: 'https://acme.com/pricing?x=1' })
+  })
+
+  it('prefixes https:// and lowercases, matching the write path', () => {
+    const result = resolveUrl('Acme.COM/Pricing', config)
+    expect(result.type).toBe('value')
+    expect(result.value).toBe('https://acme.com/pricing')
+  })
+
+  it('round-trips: resolver output is byte-identical to the write-path normalization', () => {
+    const raw = 'WWW.Example.com/Path'
+    const resolved = resolveUrl(raw, config)
+    const written = fieldValueSchemas.url.safeParse(raw)
+    expect(written.success).toBe(true)
+    expect(resolved.value).toBe(written.success ? written.data : undefined)
+    // And a re-import of the stored value is a no-op transform.
+    const reResolved = resolveUrl(String(resolved.value), config)
+    expect(reResolved.value).toBe(resolved.value)
+  })
+
+  it('returns null for a blank cell', () => {
+    expect(resolveUrl('   ', config)).toEqual({ type: 'value', value: null })
+  })
+
+  it('errors on an unparseable URL', () => {
+    const result = resolveUrl('ht tp://not a url', config)
+    expect(result.type).toBe('error')
+    expect(result.error).toContain('Invalid URL')
+  })
+})

--- a/packages/lib/src/import/resolution/resolvers/index.ts
+++ b/packages/lib/src/import/resolution/resolvers/index.ts
@@ -24,3 +24,4 @@ export {
 } from './relation'
 export { resolveSelectCreate, resolveSelectValue } from './select'
 export { resolveTextCuid, resolveTextValue } from './text'
+export { resolveUrl } from './url'

--- a/packages/lib/src/import/resolution/resolvers/url.ts
+++ b/packages/lib/src/import/resolution/resolvers/url.ts
@@ -1,0 +1,28 @@
+// packages/lib/src/import/resolution/resolvers/url.ts
+
+import { fieldValueSchemas } from '../../../field-values/field-value-validator'
+import type { ResolutionConfig, ResolvedValue } from '../../types/resolution'
+
+/**
+ * Resolve and validate a URL, preserving scheme and path.
+ *
+ * Reuses the write path's zod schema (`fieldValueSchemas.url`: trim, lowercase,
+ * `https://`-prefix when no protocol) so an imported URL lands byte-identical to
+ * a hand-typed one and round-trips through export → import losslessly. This is
+ * deliberately NOT `domain:value`, which strips scheme/path/`www.` — the lossy
+ * mapping URL fields historically got.
+ */
+export function resolveUrl(rawValue: string, _config: ResolutionConfig): ResolvedValue {
+  const trimmed = rawValue.trim()
+
+  if (!trimmed) {
+    return { type: 'value', value: null }
+  }
+
+  const parsed = fieldValueSchemas.url.safeParse(trimmed)
+  if (!parsed.success) {
+    return { type: 'error', error: `Invalid URL: ${rawValue}` }
+  }
+
+  return { type: 'value', value: parsed.data }
+}

--- a/packages/lib/src/import/types/resolution.ts
+++ b/packages/lib/src/import/types/resolution.ts
@@ -22,6 +22,7 @@ export type ResolutionType =
   | 'relation:match' // Match related record by a field value (e.g., name, email)
   | 'relation:create' // Match or create related record if not found
   | 'domain:value' // Parse domain
+  | 'url:value' // URL validation (scheme/path preserved — write-path normalized)
   | 'array:split' // Split to array
 
 /** Configuration for resolution */

--- a/packages/lib/src/resources/crud/unified-handler.ts
+++ b/packages/lib/src/resources/crud/unified-handler.ts
@@ -3,29 +3,19 @@
 import type { Database } from '@auxx/database'
 import { database as defaultDatabase, schema } from '@auxx/database'
 import type { Rung } from '@auxx/database/enums'
-import type { FieldType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { checkUniqueValue } from '@auxx/services/custom-fields'
 import { getEntityInstance, listEntityInstances } from '@auxx/services/entity-instances'
 import { ModelTypes } from '@auxx/types/custom-field'
-import type { FieldId } from '@auxx/types/field'
-import { createTypedValueInput } from '@auxx/types/field-value'
 import { isEntityDefinitionType } from '@auxx/types/resource'
 import type { SystemAttribute } from '@auxx/types/system-attribute'
-import { type AnyColumn, and, eq, type SQL } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import type { Result } from 'neverthrow'
-import {
-  findCachedResource,
-  getCachedCustomFields,
-  getCachedFieldMap,
-  getCachedResources,
-} from '../../cache'
+import { findCachedResource, getCachedCustomFields, getCachedResources } from '../../cache'
 import { type ConditionGroup, resolveConditionContext } from '../../conditions'
-import { BadRequestError, ForbiddenError } from '../../errors'
+import { ForbiddenError, UniqueValueConflictError } from '../../errors'
 import { publisher } from '../../events/publisher'
 import { FieldValueService } from '../../field-values'
-import { normalizeForLookup } from '../../field-values/normalize-for-lookup'
-import { typedColumnMatch } from '../../field-values/typed-column-match'
 import { upsertRecordIdentity } from '../../identity'
 import { systemTableVisibilityScope } from '../../permissions/capabilities/article-visibility-scope'
 import type { CapabilityView } from '../../permissions/capabilities/capability-view'
@@ -39,6 +29,12 @@ import {
 import { buildDefIdToSlug } from '../../permissions/capabilities/resolve-capability-inputs'
 import { resolveResourceAccessGrantees } from '../../resource-access/grantee-resolution'
 import { getCommonHooks, getSystemHooks } from '../hooks'
+import {
+  type LookupByFieldResult,
+  type LookupCandidate,
+  lookupEntitiesByFieldValue,
+  parseExternalIdentity,
+} from '../lookup'
 import { RecordPickerService } from '../picker'
 import { isMailLensTableId, MAIL_LENS_REFUSAL } from '../picker/mail-lens-tables'
 import type { RecordPickerItem } from '../picker/types'
@@ -76,62 +72,13 @@ import {
   resolveEntityIdFromCache,
 } from './unified-handler-queries'
 
-/** Inferred type for CustomField select (not exported from schema) */
-type CustomFieldEntity = typeof schema.CustomField.$inferSelect
 type EntityInstanceEntity = typeof schema.EntityInstance.$inferSelect
 
 const lookupLogger = createScopedLogger('unified-handler-lookup')
 
-/**
- * Parse an `external_id` value (`"<source>:<value>"`, e.g. `"gmail:jane@x.com"`,
- * `"website:acme.com"`) into a `RecordIdentity` `(source, externalId)`. The
- * `external_id` array attribute is retired; app-less external ids now live in
- * the identity index, so both the extension dedupe lookup and its create-write
- * route through this. Returns `null` for unprefixed / malformed values.
- */
-function parseExternalIdentity(raw: unknown): { source: string; externalId: string } | null {
-  if (typeof raw !== 'string') return null
-  const idx = raw.indexOf(':')
-  if (idx <= 0 || idx >= raw.length - 1) return null
-  return { source: raw.slice(0, idx), externalId: raw.slice(idx + 1) }
-}
-
-/**
- * Candidate for `lookupByField` — one field reference + value to try. Two shapes,
- * resolved through the same `customFields` org-cache:
- *  - `{ systemAttribute }` → matched by `CustomField.systemAttribute` (system
- *    fields / legacy callers: extension, `record.lookupByField`, `findByField`).
- *  - `{ fieldId }` → matched by `CustomField.id` directly — the only path that
- *    resolves connector-provisioned custom fields, whose `systemAttribute` is null.
- */
-export type LookupCandidate =
-  | { systemAttribute: string; value: unknown }
-  | { fieldId: FieldId; value: unknown }
-
-/**
- * Single match returned by `lookupByField`. `matchedBy` echoes the candidate that
- * hit this record (its `systemAttribute` or `fieldId`), useful when callers want
- * to know whether dedup succeeded via externalId vs. primary_email. The
- * denormalized display columns from EntityInstance ride along so list-style
- * consumers (e.g. the extension's "N similar found" view) can render an avatar +
- * name + subtitle without a second round-trip.
- */
-export type LookupMatch = {
-  recordId: RecordId
-  matchedBy: { systemAttribute?: string; fieldId?: FieldId; value: unknown }
-  displayName: string | null
-  secondaryDisplayValue: string | null
-  avatarUrl: string | null
-}
-
-/**
- * Result envelope for `lookupByField`. `hasMore` is set when the server
- * found more than `limit` distinct records across the candidate list.
- */
-export type LookupByFieldResult = {
-  items: LookupMatch[]
-  hasMore: boolean
-}
+// Lookup core extracted to `../lookup` — re-exported here so existing importers
+// of the crud barrel keep working.
+export type { LookupByFieldResult, LookupCandidate, LookupMatch } from '../lookup'
 
 /**
  * Helper to unwrap neverthrow Result and throw on error.
@@ -588,49 +535,15 @@ export class UnifiedCrudHandler {
   }
 
   /**
-   * Build a typed equality condition on the right FieldValue column for a
-   * given field + raw value. Returns `null` when the value can't be
-   * coerced / normalized (uncoercible inputs like `Number('foo')` leak
-   * through `createTypedValueInput` as NaN and would silently match zero
-   * rows — gate explicitly instead).
-   */
-  private buildLookupCondition(field: CustomFieldEntity, rawValue: unknown): SQL | null {
-    const normalized = normalizeForLookup(field.type as FieldType, rawValue)
-    if (normalized === null || normalized === undefined) return null
-
-    const typedInput = createTypedValueInput(field.type, normalized)
-    if (typedInput === null) return null
-
-    // `createTypedValueInput` does `Number(raw)` / `new Date(raw)` without
-    // validating the result — gate explicitly.
-    if (typedInput.type === 'number' && !Number.isFinite(typedInput.value)) return null
-    if (typedInput.type === 'date' && Number.isNaN(new Date(typedInput.value).getTime())) {
-      return null
-    }
-
-    const { column, value } = typedColumnMatch(typedInput)
-    return eq(schema.FieldValue[column] as AnyColumn, value as string | number | boolean)
-  }
-
-  /**
    * Lookup record IDs by one or more `(systemAttribute, value)` candidates,
-   * tried in priority order. Column-aware (routes through `typedColumnMatch`)
-   * and value-normalizing (mirrors write-path formatting). Deduplicates hits
-   * across candidates by recordId; the earliest-priority candidate wins
-   * attribution.
-   *
-   * Candidate failure handling: a candidate whose field doesn't exist OR
-   * whose value can't be coerced / normalized is **skipped with a warning
-   * log**, not thrown. Only throws `BadRequestError` when ALL candidates
-   * fail — otherwise one garbage input would take down a best-effort
-   * fallback chain (e.g. externalId → email).
+   * tried in priority order. Thin wrapper over
+   * {@link lookupEntitiesByFieldValue} — see its docs for candidate handling,
+   * normalization and determinism.
    *
    * Does not filter on archived records: re-capture of an archived contact
    * should link to the same row rather than create a duplicate. Callers
-   * needing only-active records should post-filter via `record.getById`.
-   *
-   * Does not filter on `capabilities.hidden`: the extension is a system
-   * integration and is allowed to address hidden fields (externalId).
+   * needing only-active records should post-filter via `record.getById` (or
+   * use the core with `excludeArchived`).
    */
   async lookupByField(params: {
     entityDefinitionId: string
@@ -638,163 +551,21 @@ export class UnifiedCrudHandler {
     limit: number
   }): Promise<LookupByFieldResult> {
     // Read enforcement (§5.1): arm 4 yields no matches without a query; the two
-    // middle arms narrow both lookup queries below (both inner-join
+    // middle arms narrow both lookup queries in the core (both inner-join
     // EntityInstance, so the predicate correlates directly).
     const lookupScope = await this.recordScope(params.entityDefinitionId)
     if (lookupScope.arm === 'none') return { items: [], hasMore: false }
     const entityDef = await this.resolveEntityDefinition(params.entityDefinitionId)
-    const seen = new Set<RecordId>()
-    const items: LookupMatch[] = []
-    let hasMore = false
-    let anyValid = false
-    const skipped: Array<{ candidate: LookupCandidate; reason: string }> = []
 
-    // `{ fieldId }` candidates resolve through the same `customFields` cache
-    // `getFieldBySystemAttribute` reads — fetched once here, not per candidate.
-    // Keyed by `CustomField.id` (every DB-backed field, incl. system fields whose
-    // ResourceFieldId carries the UUID); a systemAttribute fallback covers the
-    // pure-static-field edge so a `{ fieldId }` candidate never silently misses.
-    const hasFieldIdCandidate = params.candidates.some((c) => 'fieldId' in c)
-    const fieldMap = hasFieldIdCandidate
-      ? await getCachedFieldMap(this.organizationId, entityDef.id)
-      : null
-    const resolveByFieldId = (fieldId: FieldId): CustomFieldEntity | null => {
-      const byId = fieldMap!.get(fieldId)
-      if (byId) return byId
-      for (const f of fieldMap!.values()) if (f.systemAttribute === fieldId) return f
-      return null
-    }
-
-    for (const candidate of params.candidates) {
-      if (items.length >= params.limit) break
-
-      // `external_id` is retired as a FieldValue attribute — resolve it against
-      // the `RecordIdentity` index instead (app-less link, source-scoped).
-      if ('systemAttribute' in candidate && candidate.systemAttribute === 'external_id') {
-        const parsed = parseExternalIdentity(candidate.value)
-        if (!parsed) {
-          skipped.push({ candidate, reason: 'unparseable external_id' })
-          continue
-        }
-        anyValid = true
-        const remaining = params.limit - items.length
-        const rows = await this.db
-          .select({
-            entityId: schema.RecordIdentity.entityInstanceId,
-            displayName: schema.EntityInstance.displayName,
-            secondaryDisplayValue: schema.EntityInstance.secondaryDisplayValue,
-            avatarUrl: schema.EntityInstance.avatarUrl,
-          })
-          .from(schema.RecordIdentity)
-          .innerJoin(
-            schema.EntityInstance,
-            eq(schema.EntityInstance.id, schema.RecordIdentity.entityInstanceId)
-          )
-          .where(
-            and(
-              eq(schema.RecordIdentity.organizationId, this.organizationId),
-              eq(schema.RecordIdentity.entityDefinitionId, entityDef.id),
-              eq(schema.RecordIdentity.source, parsed.source),
-              eq(schema.RecordIdentity.externalId, parsed.externalId),
-              lookupScope.where
-            )
-          )
-          .limit(remaining + 1)
-        for (const row of rows) {
-          const recordId = toRecordId(entityDef.id, row.entityId)
-          if (seen.has(recordId)) continue
-          if (items.length >= params.limit) {
-            hasMore = true
-            break
-          }
-          seen.add(recordId)
-          items.push({
-            recordId,
-            matchedBy: { systemAttribute: candidate.systemAttribute, value: candidate.value },
-            displayName: row.displayName,
-            secondaryDisplayValue: row.secondaryDisplayValue,
-            avatarUrl: row.avatarUrl,
-          })
-        }
-        continue
-      }
-
-      const field =
-        'fieldId' in candidate
-          ? resolveByFieldId(candidate.fieldId)
-          : await this.getFieldBySystemAttribute(entityDef.id, candidate.systemAttribute)
-      if (!field) {
-        skipped.push({ candidate, reason: 'field not found' })
-        continue
-      }
-
-      const condition = this.buildLookupCondition(field, candidate.value)
-      if (condition === null) {
-        skipped.push({ candidate, reason: 'uncoercible value' })
-        continue
-      }
-      anyValid = true
-
-      // Fetch `remaining + 1` to detect hasMore. DISTINCT ON collapses
-      // duplicate FieldValue rows on the same entity (e.g. belt-and-braces
-      // against two rows with the same externalId after mode:'add' dedup).
-      // Inner-join EntityInstance so each match carries the denormalized
-      // displayName / secondaryDisplayValue / avatarUrl columns that the
-      // FieldValueService write path keeps in sync.
-      const remaining = params.limit - items.length
-      const rows = await this.db
-        .selectDistinctOn([schema.FieldValue.entityId], {
-          entityId: schema.FieldValue.entityId,
-          displayName: schema.EntityInstance.displayName,
-          secondaryDisplayValue: schema.EntityInstance.secondaryDisplayValue,
-          avatarUrl: schema.EntityInstance.avatarUrl,
-        })
-        .from(schema.FieldValue)
-        .innerJoin(schema.EntityInstance, eq(schema.EntityInstance.id, schema.FieldValue.entityId))
-        .where(
-          and(
-            eq(schema.FieldValue.fieldId, field.id),
-            eq(schema.FieldValue.organizationId, this.organizationId),
-            condition,
-            lookupScope.where
-          )
-        )
-        .limit(remaining + 1)
-
-      for (const row of rows) {
-        const recordId = toRecordId(entityDef.id, row.entityId)
-        if (seen.has(recordId)) continue
-        if (items.length >= params.limit) {
-          hasMore = true
-          break
-        }
-        seen.add(recordId)
-        items.push({
-          recordId,
-          matchedBy:
-            'fieldId' in candidate
-              ? { fieldId: candidate.fieldId, value: candidate.value }
-              : { systemAttribute: candidate.systemAttribute, value: candidate.value },
-          displayName: row.displayName,
-          secondaryDisplayValue: row.secondaryDisplayValue,
-          avatarUrl: row.avatarUrl,
-        })
-      }
-    }
-
-    if (!anyValid && params.candidates.length > 0) {
-      throw new BadRequestError(
-        `lookupByField: no candidate was valid. Skipped: ${JSON.stringify(skipped)}`
-      )
-    }
-    if (skipped.length > 0) {
-      lookupLogger.warn('lookupByField: skipped candidates', {
-        entityDef: entityDef.id,
-        skipped,
-      })
-    }
-
-    return { items, hasMore }
+    const result = await lookupEntitiesByFieldValue(this.db, {
+      organizationId: this.organizationId,
+      entityDefinitionId: entityDef.id,
+      candidates: params.candidates,
+      limit: params.limit,
+      scopeWhere: lookupScope.where,
+    })
+    if (result.isErr()) throw result.error
+    return result.value
   }
 
   /**
@@ -1556,17 +1327,31 @@ export class UnifiedCrudHandler {
       const value = values[field.id]
       if (value === undefined || value === null || value === '') continue
 
-      const result = await checkUniqueValue({
-        fieldId: field.id,
-        value,
-        organizationId: this.organizationId,
-        modelType: ModelTypes.ENTITY,
-        entityDefinitionId,
-        excludeEntityId,
-      })
+      // Multi-value fields (`options.multi`) arrive as arrays — check each
+      // value individually; passing the array through would silently pass
+      // (`normalizeValueForComparison` can't stringify it).
+      const candidates = Array.isArray(value) ? value : [value]
+      for (const candidate of candidates) {
+        if (candidate === undefined || candidate === null || candidate === '') continue
 
-      if (result.isErr()) {
-        throw new Error(`${field.name} must be unique: value already exists`)
+        const result = await checkUniqueValue({
+          fieldId: field.id,
+          value: candidate,
+          organizationId: this.organizationId,
+          modelType: ModelTypes.ENTITY,
+          entityDefinitionId,
+          excludeEntityId,
+        })
+
+        if (result.isErr()) {
+          const violation = result.error
+          throw new UniqueValueConflictError({
+            message: `${field.name} must be unique: value already exists`,
+            conflictingValue: typeof candidate === 'string' ? candidate : String(candidate),
+            fieldId: field.id,
+            existingEntityId: violation.existingEntityId,
+          })
+        }
       }
     }
   }

--- a/packages/lib/src/resources/hooks/__tests__/contact-hooks.test.ts
+++ b/packages/lib/src/resources/hooks/__tests__/contact-hooks.test.ts
@@ -1,0 +1,141 @@
+// packages/lib/src/resources/hooks/__tests__/contact-hooks.test.ts
+
+import { err, ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BadRequestError, UniqueValueConflictError } from '../../../errors'
+import { CONTACT_HOOKS } from '../contact-hooks'
+import type { SystemHookContext } from '../types'
+
+vi.mock('@auxx/services/custom-fields', () => ({
+  checkUniqueValue: vi.fn(),
+}))
+
+const { checkUniqueValue } = await import('@auxx/services/custom-fields')
+const checkUniqueValueMock = vi.mocked(checkUniqueValue)
+
+const FIELD_ID = 'field-email-1'
+
+function buildContext(
+  value: unknown,
+  overrides: Partial<SystemHookContext> = {}
+): SystemHookContext {
+  return {
+    operation: 'update',
+    entityDef: { id: 'def-contact', entityType: 'contact' },
+    field: { id: FIELD_ID, type: 'EMAIL', systemAttribute: 'primary_email' },
+    values: { [FIELD_ID]: value },
+    existingInstance: undefined,
+    organizationId: 'org-1',
+    userId: 'user-1',
+    allFields: [],
+    ...overrides,
+  } as unknown as SystemHookContext
+}
+
+/** Run the three primary_email hooks in registration order, chaining values. */
+async function runEmailHooks(ctx: SystemHookContext): Promise<Record<string, unknown>> {
+  let values = ctx.values
+  for (const hook of CONTACT_HOOKS.primary_email!) {
+    values = await hook({ ...ctx, values })
+  }
+  return values
+}
+
+beforeEach(() => {
+  checkUniqueValueMock.mockReset()
+  checkUniqueValueMock.mockResolvedValue(ok(null))
+})
+
+describe('primary_email hooks — array writes', () => {
+  it('validates and lowercases every value of an array write', async () => {
+    const result = await runEmailHooks(buildContext(['  Alice@Example.COM ', 'BOB@x.io']))
+    expect(result[FIELD_ID]).toEqual(['alice@example.com', 'bob@x.io'])
+  })
+
+  it('rejects an array containing one invalid email', async () => {
+    await expect(
+      runEmailHooks(buildContext(['valid@example.com', 'not-an-email']))
+    ).rejects.toThrow(BadRequestError)
+  })
+
+  it('collapses in-record case-variant duplicates (first occurrence wins)', async () => {
+    const result = await runEmailHooks(buildContext(['A@x.com', 'a@X.COM', 'b@x.com', 'B@X.com ']))
+    expect(result[FIELD_ID]).toEqual(['a@x.com', 'b@x.com'])
+  })
+
+  it('checks uniqueness once per surviving value with excludeEntityId = self', async () => {
+    await runEmailHooks(
+      buildContext(['a@x.com', 'b@x.com'], {
+        existingInstance: { id: 'inst-self' } as never,
+      })
+    )
+    expect(checkUniqueValueMock).toHaveBeenCalledTimes(2)
+    expect(checkUniqueValueMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fieldId: FIELD_ID,
+        value: 'a@x.com',
+        organizationId: 'org-1',
+        excludeEntityId: 'inst-self',
+      })
+    )
+    expect(checkUniqueValueMock).toHaveBeenCalledWith(
+      expect.objectContaining({ value: 'b@x.com', excludeEntityId: 'inst-self' })
+    )
+  })
+
+  it('throws UniqueValueConflictError carrying the offending value and existing record', async () => {
+    checkUniqueValueMock.mockImplementation(async (input) =>
+      input.value === 'claimed@x.com'
+        ? err({
+            code: 'UNIQUE_VIOLATION',
+            message: 'A record with this value already exists',
+            fieldId: FIELD_ID,
+            existingEntityId: 'inst-other',
+            existingDisplayName: 'Jane Roe',
+          })
+        : ok(null)
+    )
+
+    const promise = runEmailHooks(buildContext(['fresh@x.com', 'Claimed@X.com']))
+    await expect(promise).rejects.toThrow(UniqueValueConflictError)
+    await promise.catch((e: UniqueValueConflictError) => {
+      expect(e.conflictingValue).toBe('claimed@x.com')
+      expect(e.fieldId).toBe(FIELD_ID)
+      expect(e.existingEntityId).toBe('inst-other')
+      expect(e.message).toContain('Jane Roe')
+      expect(e.message).toContain('claimed@x.com')
+    })
+  })
+})
+
+describe('primary_email hooks — scalar writes (existing behavior)', () => {
+  it('lowercases and trims a scalar value', async () => {
+    const result = await runEmailHooks(buildContext(' Carol@Example.com '))
+    expect(result[FIELD_ID]).toBe('carol@example.com')
+  })
+
+  it('rejects an invalid scalar email', async () => {
+    await expect(runEmailHooks(buildContext('nope'))).rejects.toThrow(BadRequestError)
+  })
+
+  it('passes through null / undefined without querying uniqueness', async () => {
+    const result = await runEmailHooks(buildContext(null))
+    expect(result[FIELD_ID]).toBeNull()
+    expect(checkUniqueValueMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a scalar email claimed by another contact', async () => {
+    checkUniqueValueMock.mockResolvedValue(
+      err({
+        code: 'UNIQUE_VIOLATION',
+        message: 'A record with this value already exists',
+        fieldId: FIELD_ID,
+        existingEntityId: 'inst-other',
+        existingDisplayName: null,
+      })
+    )
+    await expect(runEmailHooks(buildContext('claimed@x.com'))).rejects.toThrow(
+      UniqueValueConflictError
+    )
+  })
+})

--- a/packages/lib/src/resources/hooks/contact-hooks.ts
+++ b/packages/lib/src/resources/hooks/contact-hooks.ts
@@ -3,18 +3,27 @@
 import { checkUniqueValue } from '@auxx/services/custom-fields'
 import { ModelTypes } from '@auxx/types/custom-field'
 import { formatEmail, isValidEmail } from '@auxx/utils/email'
-import { BadRequestError, ConflictError } from '../../errors'
+import { BadRequestError, UniqueValueConflictError } from '../../errors'
 import type { SystemHook, SystemHookRegistry } from './types'
 
 /**
- * Validate email format for primary_email field
+ * Read the submitted email value(s) as a flat list of string candidates.
+ * Multi-value writes (`options.multi`) arrive as arrays; single writes as a
+ * scalar. Non-string / empty entries are passed through untouched here — the
+ * typed write path's zod validation is the authority on those.
+ */
+function emailCandidates(value: unknown): string[] {
+  const list = Array.isArray(value) ? value : [value]
+  return list.filter((v): v is string => typeof v === 'string' && v.length > 0)
+}
+
+/**
+ * Validate email format for primary_email field — every value of an array write.
  */
 const validateEmailFormat: SystemHook = async ({ field, values }) => {
-  const email = values[field.id]
-
-  if (email && typeof email === 'string') {
+  for (const email of emailCandidates(values[field.id])) {
     if (!isValidEmail(email)) {
-      throw new BadRequestError('Invalid email format')
+      throw new BadRequestError(`Invalid email format: ${email}`)
     }
   }
 
@@ -25,9 +34,28 @@ const validateEmailFormat: SystemHook = async ({ field, values }) => {
  * Normalize email to lowercase and trim. Deliberately NOT normalizeEmail — that
  * canonicalizes Gmail plus-aliases/dots for comparison and must not rewrite the
  * stored address (a+x@gmail.com is the address the customer actually uses).
+ *
+ * Lowercasing here is load-bearing: `normalizeForLookup` assumes stored values
+ * are write-normalized. Array writes additionally get an in-record
+ * case-insensitive dedupe (first occurrence wins, order preserved) — nothing
+ * downstream dedupes case-variants of the same address.
  */
 const normalizeEmailValue: SystemHook = async ({ field, values }) => {
   const email = values[field.id]
+
+  if (Array.isArray(email)) {
+    const seen = new Set<string>()
+    const normalized: unknown[] = []
+    for (const v of email) {
+      const formatted = typeof v === 'string' && v ? formatEmail(v) : v
+      if (typeof formatted === 'string') {
+        if (seen.has(formatted)) continue
+        seen.add(formatted)
+      }
+      normalized.push(formatted)
+    }
+    return { ...values, [field.id]: normalized }
+  }
 
   if (email && typeof email === 'string') {
     return {
@@ -40,8 +68,13 @@ const normalizeEmailValue: SystemHook = async ({ field, values }) => {
 }
 
 /**
- * Check email uniqueness for contact entities
- * Ensures no duplicate email addresses exist in the organization
+ * Check email uniqueness for contact entities — per value, org-wide.
+ *
+ * Every submitted value (array or scalar) must be unique across ALL contacts'
+ * email rows in the org, excluding the record being written and excluding
+ * archived records (merge archives sources whose FieldValue rows survive — see
+ * `checkUniqueValue`). Throws `UniqueValueConflictError` carrying the offending
+ * value so per-value writers (import, connector sink) can drop just that value.
  */
 const checkEmailUniqueness: SystemHook = async ({
   field,
@@ -50,25 +83,26 @@ const checkEmailUniqueness: SystemHook = async ({
   organizationId,
   existingInstance,
 }) => {
-  const email = values[field.id]
+  for (const email of emailCandidates(values[field.id])) {
+    const result = await checkUniqueValue({
+      fieldId: field.id,
+      value: email,
+      organizationId,
+      modelType: ModelTypes.ENTITY,
+      entityDefinitionId: entityDef.id,
+      excludeEntityId: existingInstance?.id,
+    })
 
-  // Skip if no email value provided
-  if (!email || typeof email !== 'string') {
-    return values
-  }
-
-  // Check uniqueness using checkUniqueValue
-  const result = await checkUniqueValue({
-    fieldId: field.id,
-    value: email,
-    organizationId,
-    modelType: ModelTypes.ENTITY,
-    entityDefinitionId: entityDef.id,
-    excludeEntityId: existingInstance?.id,
-  })
-
-  if (result.isErr()) {
-    throw new ConflictError(`Email address already exists: ${email}`)
+    if (result.isErr()) {
+      const violation = result.error
+      const owner = violation.existingDisplayName ? ` on "${violation.existingDisplayName}"` : ''
+      throw new UniqueValueConflictError({
+        message: `Email address already exists${owner}: ${email}`,
+        conflictingValue: email,
+        fieldId: field.id,
+        existingEntityId: violation.existingEntityId,
+      })
+    }
   }
 
   return values

--- a/packages/lib/src/resources/index.ts
+++ b/packages/lib/src/resources/index.ts
@@ -44,6 +44,9 @@ export {
   defDeniedRecordIds,
 } from './crud/record-row-access'
 export { listAll } from './crud/unified-handler-queries'
+// Field-value lookup core (extracted from UnifiedCrudHandler.lookupByField)
+export type { LookupEntitiesByFieldValueParams } from './lookup'
+export { buildLookupCondition, lookupEntitiesByFieldValue } from './lookup'
 export type { MergeEntitiesInput, MergeEntitiesResult } from './merge'
 // Merge service (server-side)
 export { EntityMergeService } from './merge'

--- a/packages/lib/src/resources/lookup/__tests__/lookup-entities-by-field-value.test.ts
+++ b/packages/lib/src/resources/lookup/__tests__/lookup-entities-by-field-value.test.ts
@@ -1,0 +1,211 @@
+// packages/lib/src/resources/lookup/__tests__/lookup-entities-by-field-value.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BadRequestError } from '../../../errors'
+
+// Mock the cache barrel WHOLESALE (partial-mocking it via importOriginal walks
+// its real import graph before the mock exists and modules capture the real
+// functions — see the field-values test suite note).
+vi.mock('../../../cache', () => ({
+  getCachedFieldMap: vi.fn(),
+}))
+
+const { getCachedFieldMap } = await import('../../../cache')
+const { lookupEntitiesByFieldValue } = await import('../lookup-entities-by-field-value')
+
+const getCachedFieldMapMock = vi.mocked(getCachedFieldMap)
+
+const EMAIL_FIELD = {
+  id: 'field-email-1',
+  type: 'EMAIL',
+  systemAttribute: 'primary_email',
+} as never
+
+/**
+ * Fake db capturing FieldValue-lane queries. `selectDistinctOn` (the
+ * FieldValue query) resolves `rows`; `select` (the RecordIdentity lane)
+ * resolves `identityRows`.
+ */
+function buildFakeDb(
+  rows: Array<{
+    entityId: string
+    displayName: string | null
+    secondaryDisplayValue: string | null
+    avatarUrl: string | null
+  }>,
+  identityRows: Array<{
+    entityId: string
+    displayName: string | null
+    secondaryDisplayValue: string | null
+    avatarUrl: string | null
+  }> = []
+) {
+  const state = { distinctCalls: 0, selectCalls: 0 }
+  const makeChain = (result: unknown[]) => {
+    const chain: Record<string, unknown> = {}
+    chain.from = () => chain
+    chain.innerJoin = () => chain
+    chain.where = () => chain
+    chain.orderBy = () => chain
+    chain.limit = () => Promise.resolve(result)
+    return chain
+  }
+  const db = {
+    selectDistinctOn: () => {
+      state.distinctCalls++
+      return makeChain(rows)
+    },
+    select: () => {
+      state.selectCalls++
+      return makeChain(identityRows)
+    },
+  }
+  return { db: db as never, state }
+}
+
+const baseParams = {
+  organizationId: 'org-1',
+  entityDefinitionId: 'def-contact',
+  limit: 5,
+}
+
+beforeEach(() => {
+  getCachedFieldMapMock.mockReset()
+  getCachedFieldMapMock.mockResolvedValue(new Map([['field-email-1', EMAIL_FIELD]]))
+})
+
+describe('lookupEntitiesByFieldValue', () => {
+  it('matches by systemAttribute and echoes matchedBy', async () => {
+    const { db } = buildFakeDb([
+      {
+        entityId: 'inst-1',
+        displayName: 'Jane',
+        secondaryDisplayValue: 'jane@x.com',
+        avatarUrl: null,
+      },
+    ])
+    const result = await lookupEntitiesByFieldValue(db, {
+      ...baseParams,
+      candidates: [{ systemAttribute: 'primary_email', value: 'Jane@X.com' }],
+    })
+    expect(result.isOk()).toBe(true)
+    const { items, hasMore } = result._unsafeUnwrap()
+    expect(hasMore).toBe(false)
+    expect(items).toHaveLength(1)
+    expect(items[0]!.recordId).toBe('def-contact:inst-1')
+    expect(items[0]!.matchedBy).toEqual({ systemAttribute: 'primary_email', value: 'Jane@X.com' })
+    expect(items[0]!.displayName).toBe('Jane')
+  })
+
+  it('resolves { fieldId } candidates through the field map', async () => {
+    const { db, state } = buildFakeDb([
+      { entityId: 'inst-2', displayName: null, secondaryDisplayValue: null, avatarUrl: null },
+    ])
+    const result = await lookupEntitiesByFieldValue(db, {
+      ...baseParams,
+      candidates: [{ fieldId: 'field-email-1' as never, value: 'a@x.com' }],
+    })
+    expect(result._unsafeUnwrap().items[0]!.recordId).toBe('def-contact:inst-2')
+    expect(state.distinctCalls).toBe(1)
+  })
+
+  it('skips an uncoercible candidate without querying, errs when ALL are invalid', async () => {
+    const { db, state } = buildFakeDb([])
+    const result = await lookupEntitiesByFieldValue(db, {
+      ...baseParams,
+      candidates: [{ systemAttribute: 'primary_email', value: 'not-an-email' }],
+    })
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+    expect(state.distinctCalls).toBe(0)
+  })
+
+  it('skips invalid candidates but still runs valid ones (best-effort chain)', async () => {
+    const { db, state } = buildFakeDb([
+      { entityId: 'inst-3', displayName: null, secondaryDisplayValue: null, avatarUrl: null },
+    ])
+    const result = await lookupEntitiesByFieldValue(db, {
+      ...baseParams,
+      candidates: [
+        { systemAttribute: 'primary_email', value: 'garbage' },
+        { systemAttribute: 'primary_email', value: 'ok@x.com' },
+      ],
+    })
+    expect(result._unsafeUnwrap().items).toHaveLength(1)
+    expect(state.distinctCalls).toBe(1)
+  })
+
+  it('skips a candidate whose field does not exist', async () => {
+    const { db, state } = buildFakeDb([])
+    const result = await lookupEntitiesByFieldValue(db, {
+      ...baseParams,
+      candidates: [
+        { systemAttribute: 'no_such_field', value: 'x' },
+        { systemAttribute: 'primary_email', value: 'ok@x.com' },
+      ],
+    })
+    expect(result.isOk()).toBe(true)
+    expect(state.distinctCalls).toBe(1)
+  })
+
+  it('dedupes across candidates by recordId (earliest candidate wins attribution)', async () => {
+    const { db } = buildFakeDb([
+      { entityId: 'inst-1', displayName: null, secondaryDisplayValue: null, avatarUrl: null },
+    ])
+    const result = await lookupEntitiesByFieldValue(db, {
+      ...baseParams,
+      candidates: [
+        { systemAttribute: 'primary_email', value: 'a@x.com' },
+        { systemAttribute: 'primary_email', value: 'b@x.com' },
+      ],
+    })
+    const { items } = result._unsafeUnwrap()
+    expect(items).toHaveLength(1)
+    expect(items[0]!.matchedBy.value).toBe('a@x.com')
+  })
+
+  it('sets hasMore when matches exceed limit', async () => {
+    const rows = Array.from({ length: 3 }, (_, i) => ({
+      entityId: `inst-${i}`,
+      displayName: null,
+      secondaryDisplayValue: null,
+      avatarUrl: null,
+    }))
+    const { db } = buildFakeDb(rows)
+    const result = await lookupEntitiesByFieldValue(db, {
+      ...baseParams,
+      limit: 2,
+      candidates: [{ systemAttribute: 'primary_email', value: 'a@x.com' }],
+    })
+    const { items, hasMore } = result._unsafeUnwrap()
+    expect(items).toHaveLength(2)
+    expect(hasMore).toBe(true)
+  })
+
+  it('routes external_id candidates through the RecordIdentity lane', async () => {
+    const { db, state } = buildFakeDb(
+      [],
+      [{ entityId: 'inst-9', displayName: 'Ext', secondaryDisplayValue: null, avatarUrl: null }]
+    )
+    const result = await lookupEntitiesByFieldValue(db, {
+      ...baseParams,
+      candidates: [{ systemAttribute: 'external_id', value: 'gmail:jane@x.com' }],
+    })
+    const { items } = result._unsafeUnwrap()
+    expect(items[0]!.recordId).toBe('def-contact:inst-9')
+    expect(state.selectCalls).toBe(1)
+    expect(state.distinctCalls).toBe(0)
+  })
+
+  it('accepts the excludeArchived option (import-planning path)', async () => {
+    const { db } = buildFakeDb([
+      { entityId: 'inst-1', displayName: null, secondaryDisplayValue: null, avatarUrl: null },
+    ])
+    const result = await lookupEntitiesByFieldValue(db, {
+      ...baseParams,
+      excludeArchived: true,
+      candidates: [{ systemAttribute: 'primary_email', value: 'a@x.com' }],
+    })
+    expect(result.isOk()).toBe(true)
+  })
+})

--- a/packages/lib/src/resources/lookup/index.ts
+++ b/packages/lib/src/resources/lookup/index.ts
@@ -1,0 +1,13 @@
+// packages/lib/src/resources/lookup/index.ts
+
+export type {
+  LookupByFieldResult,
+  LookupCandidate,
+  LookupEntitiesByFieldValueParams,
+  LookupMatch,
+} from './lookup-entities-by-field-value'
+export {
+  buildLookupCondition,
+  lookupEntitiesByFieldValue,
+  parseExternalIdentity,
+} from './lookup-entities-by-field-value'

--- a/packages/lib/src/resources/lookup/lookup-entities-by-field-value.ts
+++ b/packages/lib/src/resources/lookup/lookup-entities-by-field-value.ts
@@ -1,0 +1,317 @@
+// packages/lib/src/resources/lookup/lookup-entities-by-field-value.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import type { FieldType } from '@auxx/database/types'
+import { createScopedLogger } from '@auxx/logger'
+import type { FieldId } from '@auxx/types/field'
+import { createTypedValueInput } from '@auxx/types/field-value'
+import { type AnyColumn, and, asc, eq, isNull, type SQL } from 'drizzle-orm'
+import { err, ok, type Result } from 'neverthrow'
+import { getCachedFieldMap } from '../../cache'
+import { BadRequestError } from '../../errors'
+import { normalizeForLookup } from '../../field-values/normalize-for-lookup'
+import { typedColumnMatch } from '../../field-values/typed-column-match'
+import { type RecordId, toRecordId } from '../resource-id'
+
+const logger = createScopedLogger('lookup-entities-by-field-value')
+
+type CustomFieldEntity = typeof schema.CustomField.$inferSelect
+
+/**
+ * Candidate for a field-value lookup — one field reference + value to try. Two
+ * shapes, resolved through the same `customFields` org-cache:
+ *  - `{ systemAttribute }` → matched by `CustomField.systemAttribute` (system
+ *    fields / legacy callers: extension, `record.lookupByField`, `findByField`).
+ *  - `{ fieldId }` → matched by `CustomField.id` directly — the only path that
+ *    resolves connector-provisioned custom fields, whose `systemAttribute` is null.
+ */
+export type LookupCandidate =
+  | { systemAttribute: string; value: unknown }
+  | { fieldId: FieldId; value: unknown }
+
+/**
+ * Single match returned by the lookup. `matchedBy` echoes the candidate that
+ * hit this record (its `systemAttribute` or `fieldId`), useful when callers want
+ * to know whether dedup succeeded via externalId vs. primary_email. The
+ * denormalized display columns from EntityInstance ride along so list-style
+ * consumers (e.g. the extension's "N similar found" view) can render an avatar +
+ * name + subtitle without a second round-trip.
+ */
+export type LookupMatch = {
+  recordId: RecordId
+  matchedBy: { systemAttribute?: string; fieldId?: FieldId; value: unknown }
+  displayName: string | null
+  secondaryDisplayValue: string | null
+  avatarUrl: string | null
+}
+
+/**
+ * Result envelope. `hasMore` is set when the lookup found more than `limit`
+ * distinct records across the candidate list.
+ */
+export type LookupByFieldResult = {
+  items: LookupMatch[]
+  hasMore: boolean
+}
+
+/** Parameters for {@link lookupEntitiesByFieldValue}. */
+export interface LookupEntitiesByFieldValueParams {
+  organizationId: string
+  /**
+   * CANONICAL `EntityDefinition.id` — used to key the field cache, the
+   * `RecordIdentity` index and the returned `RecordId`s. Callers resolving from
+   * a slug must canonicalize first.
+   */
+  entityDefinitionId: string
+  candidates: LookupCandidate[]
+  limit: number
+  /**
+   * Extra SQL predicate on `EntityInstance` (permission record-scope). The
+   * caller resolves its visibility arm; `arm: 'none'` must short-circuit to an
+   * empty result WITHOUT calling this function.
+   */
+  scopeWhere?: SQL
+  /**
+   * Exclude archived records. Default `false` — include-archived is the
+   * dedupe-correct default (re-capture of an archived contact should link to
+   * the same row rather than create a duplicate). Import planning and other
+   * "active records only" callers opt in.
+   */
+  excludeArchived?: boolean
+}
+
+/**
+ * Parse an `external_id` value (`"<source>:<value>"`, e.g. `"gmail:jane@x.com"`,
+ * `"website:acme.com"`) into a `RecordIdentity` `(source, externalId)`. The
+ * `external_id` array attribute is retired; app-less external ids now live in
+ * the identity index, so both the extension dedupe lookup and its create-write
+ * route through this. Returns `null` for unprefixed / malformed values.
+ */
+export function parseExternalIdentity(raw: unknown): { source: string; externalId: string } | null {
+  if (typeof raw !== 'string') return null
+  const idx = raw.indexOf(':')
+  if (idx <= 0 || idx >= raw.length - 1) return null
+  return { source: raw.slice(0, idx), externalId: raw.slice(idx + 1) }
+}
+
+/**
+ * Build a typed equality condition on the right FieldValue column for a
+ * given field + raw value. Returns `null` when the value can't be
+ * coerced / normalized (uncoercible inputs like `Number('foo')` leak
+ * through `createTypedValueInput` as NaN and would silently match zero
+ * rows — gate explicitly instead).
+ */
+export function buildLookupCondition(field: CustomFieldEntity, rawValue: unknown): SQL | null {
+  const normalized = normalizeForLookup(field.type as FieldType, rawValue)
+  if (normalized === null || normalized === undefined) return null
+
+  const typedInput = createTypedValueInput(field.type, normalized)
+  if (typedInput === null) return null
+
+  // `createTypedValueInput` does `Number(raw)` / `new Date(raw)` without
+  // validating the result — gate explicitly.
+  if (typedInput.type === 'number' && !Number.isFinite(typedInput.value)) return null
+  if (typedInput.type === 'date' && Number.isNaN(new Date(typedInput.value).getTime())) {
+    return null
+  }
+
+  const { column, value } = typedColumnMatch(typedInput)
+  return eq(schema.FieldValue[column] as AnyColumn, value as string | number | boolean)
+}
+
+/**
+ * Lookup record IDs by one or more `(systemAttribute, value)` /
+ * `(fieldId, value)` candidates, tried in priority order. Column-aware (routes
+ * through `typedColumnMatch`) and value-normalizing (mirrors write-path
+ * formatting: EMAIL lowercased, URL protocol-prefixed, PHONE E.164).
+ * Deduplicates hits across candidates by recordId; the earliest-priority
+ * candidate wins attribution. Row-level `eq()` on the typed column +
+ * `DISTINCT ON (entityId)` — multi-value fields match on ANY value row.
+ * Ordering is deterministic (entityId, then sortKey).
+ *
+ * Candidate failure handling: a candidate whose field doesn't exist OR whose
+ * value can't be coerced / normalized is **skipped with a warning log**, not
+ * an error. Only returns `err(BadRequestError)` when ALL candidates fail —
+ * otherwise one garbage input would take down a best-effort fallback chain
+ * (e.g. externalId → email).
+ *
+ * Does not filter on `capabilities.hidden`: the extension is a system
+ * integration and is allowed to address hidden fields (externalId).
+ */
+export async function lookupEntitiesByFieldValue(
+  db: Database,
+  params: LookupEntitiesByFieldValueParams
+): Promise<Result<LookupByFieldResult, Error>> {
+  const { organizationId, entityDefinitionId, candidates, limit } = params
+  const archivedFilter = params.excludeArchived
+    ? isNull(schema.EntityInstance.archivedAt)
+    : undefined
+
+  const seen = new Set<RecordId>()
+  const items: LookupMatch[] = []
+  let hasMore = false
+  let anyValid = false
+  const skipped: Array<{ candidate: LookupCandidate; reason: string }> = []
+
+  // Candidates resolve through the same `customFields` cache the crud handler
+  // reads — fetched once here, not per candidate. Keyed by `CustomField.id`
+  // (every DB-backed field, incl. system fields whose ResourceFieldId carries
+  // the UUID); a systemAttribute fallback covers the pure-static-field edge so
+  // a `{ fieldId }` candidate never silently misses.
+  const fieldMap = await getCachedFieldMap(organizationId, entityDefinitionId)
+  const resolveField = (candidate: LookupCandidate): CustomFieldEntity | null => {
+    if ('fieldId' in candidate) {
+      const byId = fieldMap.get(candidate.fieldId)
+      if (byId) return byId
+      for (const f of fieldMap.values()) if (f.systemAttribute === candidate.fieldId) return f
+      return null
+    }
+    for (const f of fieldMap.values()) {
+      if (f.systemAttribute === candidate.systemAttribute) return f
+    }
+    return null
+  }
+
+  for (const candidate of candidates) {
+    if (items.length >= limit) break
+
+    // `external_id` is retired as a FieldValue attribute — resolve it against
+    // the `RecordIdentity` index instead (app-less link, source-scoped).
+    if ('systemAttribute' in candidate && candidate.systemAttribute === 'external_id') {
+      const parsed = parseExternalIdentity(candidate.value)
+      if (!parsed) {
+        skipped.push({ candidate, reason: 'unparseable external_id' })
+        continue
+      }
+      anyValid = true
+      const remaining = limit - items.length
+      const rows = await db
+        .select({
+          entityId: schema.RecordIdentity.entityInstanceId,
+          displayName: schema.EntityInstance.displayName,
+          secondaryDisplayValue: schema.EntityInstance.secondaryDisplayValue,
+          avatarUrl: schema.EntityInstance.avatarUrl,
+        })
+        .from(schema.RecordIdentity)
+        .innerJoin(
+          schema.EntityInstance,
+          eq(schema.EntityInstance.id, schema.RecordIdentity.entityInstanceId)
+        )
+        .where(
+          and(
+            eq(schema.RecordIdentity.organizationId, organizationId),
+            eq(schema.RecordIdentity.entityDefinitionId, entityDefinitionId),
+            eq(schema.RecordIdentity.source, parsed.source),
+            eq(schema.RecordIdentity.externalId, parsed.externalId),
+            archivedFilter,
+            params.scopeWhere
+          )
+        )
+        .orderBy(asc(schema.RecordIdentity.entityInstanceId))
+        .limit(remaining + 1)
+      for (const row of rows) {
+        const recordId = toRecordId(entityDefinitionId, row.entityId)
+        if (seen.has(recordId)) continue
+        if (items.length >= limit) {
+          hasMore = true
+          break
+        }
+        seen.add(recordId)
+        items.push({
+          recordId,
+          matchedBy: { systemAttribute: candidate.systemAttribute, value: candidate.value },
+          displayName: row.displayName,
+          secondaryDisplayValue: row.secondaryDisplayValue,
+          avatarUrl: row.avatarUrl,
+        })
+      }
+      continue
+    }
+
+    const field = resolveField(candidate)
+    if (!field) {
+      skipped.push({ candidate, reason: 'field not found' })
+      continue
+    }
+
+    const condition = buildLookupCondition(field, candidate.value)
+    if (condition === null) {
+      skipped.push({ candidate, reason: 'uncoercible value' })
+      continue
+    }
+    anyValid = true
+
+    // Fetch `remaining + 1` to detect hasMore. DISTINCT ON collapses
+    // duplicate FieldValue rows on the same entity (e.g. belt-and-braces
+    // against two rows with the same externalId after mode:'add' dedup).
+    // Inner-join EntityInstance so each match carries the denormalized
+    // displayName / secondaryDisplayValue / avatarUrl columns that the
+    // FieldValueService write path keeps in sync. DISTINCT ON requires the
+    // ORDER BY to lead with entityId; sortKey second keeps the picked row
+    // (and thus result order) deterministic.
+    const remaining = limit - items.length
+    const rows = await db
+      .selectDistinctOn([schema.FieldValue.entityId], {
+        entityId: schema.FieldValue.entityId,
+        displayName: schema.EntityInstance.displayName,
+        secondaryDisplayValue: schema.EntityInstance.secondaryDisplayValue,
+        avatarUrl: schema.EntityInstance.avatarUrl,
+      })
+      .from(schema.FieldValue)
+      .innerJoin(
+        schema.EntityInstance,
+        and(
+          eq(schema.EntityInstance.id, schema.FieldValue.entityId),
+          eq(schema.EntityInstance.organizationId, organizationId)
+        )
+      )
+      .where(
+        and(
+          eq(schema.FieldValue.fieldId, field.id),
+          eq(schema.FieldValue.organizationId, organizationId),
+          condition,
+          archivedFilter,
+          params.scopeWhere
+        )
+      )
+      .orderBy(asc(schema.FieldValue.entityId), asc(schema.FieldValue.sortKey))
+      .limit(remaining + 1)
+
+    for (const row of rows) {
+      const recordId = toRecordId(entityDefinitionId, row.entityId)
+      if (seen.has(recordId)) continue
+      if (items.length >= limit) {
+        hasMore = true
+        break
+      }
+      seen.add(recordId)
+      items.push({
+        recordId,
+        matchedBy:
+          'fieldId' in candidate
+            ? { fieldId: candidate.fieldId, value: candidate.value }
+            : { systemAttribute: candidate.systemAttribute, value: candidate.value },
+        displayName: row.displayName,
+        secondaryDisplayValue: row.secondaryDisplayValue,
+        avatarUrl: row.avatarUrl,
+      })
+    }
+  }
+
+  if (!anyValid && candidates.length > 0) {
+    return err(
+      new BadRequestError(
+        `lookupEntitiesByFieldValue: no candidate was valid. Skipped: ${JSON.stringify(skipped)}`
+      )
+    )
+  }
+  if (skipped.length > 0) {
+    logger.warn('lookupEntitiesByFieldValue: skipped candidates', {
+      entityDef: entityDefinitionId,
+      skipped,
+    })
+  }
+
+  return ok({ items, hasMore })
+}

--- a/packages/lib/src/resources/registry/resources/contact-fields.ts
+++ b/packages/lib/src/resources/registry/resources/contact-fields.ts
@@ -145,6 +145,11 @@ export const CONTACT_FIELDS: Record<string, ResourceField> = {
       creatable: true,
       updatable: true,
       configurable: false,
+      // Org-wide per-value uniqueness. `isUnique` on the seeded CustomField row
+      // arms the FieldValueService gate (`checkUniqueValueTyped`) — the ONLY
+      // uniqueness door for panel/bulk-edit writes, which never run contact
+      // hooks. Existing orgs are caught up by data migration 084.
+      unique: true,
     },
     placeholder: 'Enter email address',
     validation: {

--- a/packages/seed/src/domains/crm.domain.ts
+++ b/packages/seed/src/domains/crm.domain.ts
@@ -702,6 +702,10 @@ export class CrmDomain {
     // Re-seeding must not double up contacts: generated emails are deterministic by
     // index and persona emails are fixed, so skip any whose primary_email already
     // exists on the org (the historical duplicate-contact source).
+    // Keys mirror the contact-hook write normalization (`formatEmail`: trim +
+    // lowercase) so this dedupe can never disagree with the org-wide per-value
+    // uniqueness gate the hooks enforce.
+    const emailKey = (email: string): string => email.trim().toLowerCase()
     const existingEmailRows = await db
       .select({ valueText: schema.FieldValue.valueText })
       .from(schema.FieldValue)
@@ -711,12 +715,18 @@ export class CrmDomain {
       )
     const existingEmails = new Set(
       existingEmailRows
-        .map((row: any) => row.valueText?.toLowerCase())
+        .map((row: any) => (row.valueText ? emailKey(row.valueText) : undefined))
         .filter((email: string | undefined) => !!email)
     )
-    const newContactValues = contactValues.filter(
-      (value) => !existingEmails.has(value.primary_email.toLowerCase())
-    )
+    // Also dedupe within the batch itself — with primary_email unique org-wide,
+    // a second in-batch duplicate would otherwise fail its create.
+    const batchEmails = new Set<string>()
+    const newContactValues = contactValues.filter((value) => {
+      const key = emailKey(value.primary_email)
+      if (existingEmails.has(key) || batchEmails.has(key)) return false
+      batchEmails.add(key)
+      return true
+    })
     const skippedCount = contactValues.length - newContactValues.length
     if (skippedCount > 0) {
       console.log(`  ↩️  Skipped ${skippedCount} contacts whose email already exists in the org`)

--- a/packages/services/src/custom-fields/check-unique-value.ts
+++ b/packages/services/src/custom-fields/check-unique-value.ts
@@ -1,7 +1,7 @@
 // packages/services/src/custom-fields/check-unique-value.ts
 
 import { database, schema } from '@auxx/database'
-import { and, eq, ne, or, sql } from 'drizzle-orm'
+import { and, eq, isNull, ne, or, sql } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 
 /**
@@ -28,6 +28,8 @@ export interface UniqueViolation {
   message: string
   fieldId: string
   existingEntityId: string
+  /** Display name of the existing record (free — the check already joins EntityInstance). */
+  existingDisplayName: string | null
 }
 
 /**
@@ -74,8 +76,6 @@ export async function checkUniqueValue(
     return ok(null)
   }
 
-  let existingEntityId: string | null = null
-
   // Build the value match condition - check text and number columns
   // (unique fields are typically TEXT, EMAIL, NUMBER, etc.)
   const valueMatchCondition = or(
@@ -90,8 +90,15 @@ export async function checkUniqueValue(
   // The entityDefinitionId filter scopes to the correct entity type.
   const effectiveEntityDefId = entityDefinitionId ?? modelType
 
+  // Archived records are excluded: merge archives sources but their FieldValue
+  // rows survive, so post-merge the same value legitimately exists on the target
+  // AND the archived source. Counting the archived row would false-conflict any
+  // future edit of the surviving record.
   const result = await database
-    .select({ entityId: schema.FieldValue.entityId })
+    .select({
+      entityId: schema.FieldValue.entityId,
+      displayName: schema.EntityInstance.displayName,
+    })
     .from(schema.FieldValue)
     .innerJoin(schema.EntityInstance, eq(schema.FieldValue.entityId, schema.EntityInstance.id))
     .where(
@@ -99,20 +106,22 @@ export async function checkUniqueValue(
         eq(schema.FieldValue.fieldId, fieldId),
         eq(schema.FieldValue.organizationId, organizationId),
         eq(schema.EntityInstance.entityDefinitionId, effectiveEntityDefId),
+        isNull(schema.EntityInstance.archivedAt),
         valueMatchCondition,
         excludeEntityId ? ne(schema.FieldValue.entityId, excludeEntityId) : sql`true`
       )
     )
     .limit(1)
 
-  existingEntityId = result[0]?.entityId ?? null
+  const existing = result[0]
 
-  if (existingEntityId) {
+  if (existing) {
     return err({
       code: 'UNIQUE_VIOLATION',
       message: 'A record with this value already exists',
       fieldId,
-      existingEntityId,
+      existingEntityId: existing.entityId,
+      existingDisplayName: existing.displayName ?? null,
     })
   }
 


### PR DESCRIPTION
Critical-path lane of `plans/custom-field/multi/04-multi-email-implementation-plan.md` — items **A1, A5, A6, the A2 fix in `field-value-helpers.ts`**, and the A8 tests covering them.

## A1 — array-aware contact email hooks + per-value uniqueness (security control)
- `contact-hooks.ts`: all three `primary_email` hooks are array-aware — every value validated (`isValidEmail`) and lowercased (`formatEmail`), in-record case-insensitive dedupe (first occurrence wins), per-value org-wide uniqueness with `excludeEntityId` self. Conflicts throw `UniqueValueConflictError` (structured: `conflictingValue`/`fieldId`/`existingEntityId`), message names the existing contact.
- `services/check-unique-value.ts`: uniqueness query now excludes archived records (`isNull(EntityInstance.archivedAt)`) — merge archives sources whose FieldValue rows survive; also returns `existingDisplayName` for free (the join already existed).
- **All-doors fix (locked decision):** `checkUniqueValueTyped` is now array-aware (per-element checks; previously `return true` for arrays — the panel-door hole), archived-excluding, and throws `UniqueValueConflictError` instead of bare `Error`. Seeded `primaryEmail` gets `capabilities.unique: true` in the registry so the existing `FieldValueService` gate fires for new orgs; **data migration `084-primary-email-unique`** flips `isUnique` on existing orgs' rows and invalidates the `customFields`/`resources` org caches (modeled on 078 — the data-migration runner does not flush caches itself).
- `validateUniqueFields` (unified-handler): array-aware for org-created unique EMAIL/URL fields; throws the structured conflict error (409) instead of a bare `Error` (500).
- Seed writer (`crm.domain.ts`): dedupe keys mirror `formatEmail` (trim+lowercase) and the batch now dedupes within itself, so re-seeds can't trip the new uniqueness gate.

## A5 — value cap
`MAX_MULTI_VALUES` (10) enforced in `validateAndConvertValue` and on the `addValues` / `addValuesBulk` paths (`BadRequestError`; bulk throws and rolls the tx back rather than partially applying).

## A2 (partial — helpers file only)
`maybeUpdateDisplayValue` generic branch takes `primaryValue(typedValue)` before `formatToDisplayValue` — an array can no longer be written into `displayName`/`secondaryDisplayValue`. (The `display-field-service.ts` twin fix is in the display lane's PR.)

## A6 — lookup-core retrofit
- New `packages/lib/src/resources/lookup/lookup-entities-by-field-value.ts` (lib-module-guide shape: `db`-first async fn, neverthrow `Result`): extracted from `UnifiedCrudHandler.lookupByField`. `recordScope` parameterized as `scopeWhere`, new `excludeArchived` option (default keeps today's include-archived behavior — the extension's lookup semantics are unchanged), `matchedBy` preserved, plus deterministic ordering (`entityId, sortKey` — DISTINCT ON previously had no ORDER BY at all) and an `EntityInstance.organizationId` join predicate. `lookupByField` is now a thin wrapper; types re-exported so existing importers keep working.
- `import/planning/find-existing-record.ts` (custom-entity path): migrated onto the core → write-path-normalized comparison (the historic **"uniqueness breaks imports"** root cause: raw CSV cell vs normalized stored value), archived excluded, org scope, deterministic.
- `import/resolution/resolve-relation-lookups.ts`: added missing `organizationId` predicate on FieldValue (+ id-branch), gated the `sql.raw` interpolation of mapping-supplied `matchField` (identifier shape + membership in the resource's registered fields), replaced last-write-wins `recordMap` with an explicit **ambiguity error**, and added URL-prefix/E.164 normalization of search values (`normalizeForLookup`).
- New `url:value` resolver (write-path `fieldValueSchemas.url` parity — scheme/path preserved); `suggestResolutionType` maps `url` → `url:value` (`domain` unchanged; `domain:value` remains offered as an alternative). Diff in `resolver-registry.ts` kept minimal for the split-resolvers rebase.
- Extra callers: `apps/api/find-by-value.ts` migrated onto the core (fixes its bare-`eq` normalization bug; CHECKBOX coercion preserved). `ingest/contacts/find-or-create*.ts` already route through `handler.findByField` → `lookupByField` and inherit the core automatically — no change needed.

## Tests (A8 subset — 37 new, all passing)
Hooks (array lowercase/validate, in-record dedupe, per-value conflict error shape, excludeEntityId threading); panel door (`checkUniqueValueTyped` array rejection, per-element queries, structured 409); cap (11th value rejected, exactly-10 accepted); lookup core (normalization skip/err semantics, matchedBy, cross-candidate dedupe, hasMore, RecordIdentity lane, excludeArchived); `url:value` round-trip vs the write path; relation lookups (URL cell matches write-normalized stored value, ambiguity = error, matchField injection gated).

## Verified
- `packages/lib` scoped `tsc --noEmit` clean (ignoring pre-existing `scripts/*` + integration-config errors); `@auxx/api`, `@auxx/services`, `@auxx/seed` typecheck clean.
- `vitest run` over `field-values`, `resources`, `import`, `custom-fields`, `data-migrations`: all pass (one pre-existing slow-import flake in `076-mail-category-rework.test.ts` under a fully parallel run; passes in isolation).
- Biome clean on changed files.

## Deviations from the plan's claims
- `apps/api/find-contact-by-email.ts` / `find-contact-by-phone.ts` are **already fixed on main** (ORDER BY `asc(sortKey)` + `archivedAt` filter present) — the plan's claim is stale. Left un-migrated deliberately: their documented tie-break ("most-primary row wins across contacts") isn't expressible through the core's per-entity DISTINCT ON shape.
- Data migration instead of an entity migration for the `isUnique` flip: capability-column flips on seeded fields are established as pure data migrations (078 is the exact precedent, including the cache invalidation).
- In-record dedupe implemented in `normalizeEmailValue` (post-lowercase) rather than `checkEmailUniqueness` — same hook chain, simpler per-value loop.

## Follow-ups (deliberately deferred)
- `data-connectors/sinks/entity-sink.ts:160` migration onto the lookup core — owned by the connector lane (B1); noted here per the plan.
- Panel-door whole-array `set` does not dedupe in-record case-variants (hooks only run on the crud door); the picker UI (C3) and/or a `setValueWithType` dedupe can close this later.
- Pre-existing duplicate emails on existing orgs are left in place by migration 084 (write-time gate only); cleanup belongs to the dedup plan.