### PR TITLE
feat(records): multi-safe writer sweep for email/phone/website

### DIFF
--- a/apps/api/src/routes/entities/set-values.ts
+++ b/apps/api/src/routes/entities/set-values.ts
@@ -12,6 +12,14 @@
  * App fields are `updatable: false` to block *user* edits (a frontend
  * affordance) — there is no server-side updatable guard on `FieldValueService`,
  * so the owning app writes them directly here, authorized purely by ownership.
+ *
+ * Multi-value note: writes are replace-only (`applyBulk` mode defaults to
+ * `'set'` — a multi-value field's whole stored list is replaced). This is safe
+ * here because only app-OWNED fields are reachable: the seeded multi-capable
+ * fields (contact `primary_email`/`phone`, company `website`) are org-owned
+ * and can never resolve through `resolveOwnedField`. If an app ever needs
+ * append semantics on its own multi field, thread an optional per-key `mode`
+ * through to `applyBulk`'s `BulkValueItem.mode`.
  */
 
 import { getOrgCache } from '@auxx/lib/cache'

--- a/apps/extension/src/iframe/routes/root-route.tsx
+++ b/apps/extension/src/iframe/routes/root-route.tsx
@@ -39,7 +39,7 @@ type Props = {
 }
 
 export function RootRoute({ session }: Props) {
-  const { top: routeTop, push: routePush, replace: routeReplace } = useRouteStack()
+  const { top: routeTop, push: routePush, pop: routePop, replace: routeReplace } = useRouteStack()
   const [phase, setPhase] = useState<Phase>({ kind: 'loading' })
   // Bumped whenever we want to force a re-parse (session change, or the
   // `panelOpened` broadcast from the SW after the user clicks the toolbar
@@ -315,10 +315,33 @@ export function RootRoute({ session }: Props) {
         })
         navigateToDetail('company', created.recordId)
       } catch (err) {
+        // Per-value uniqueness conflict (e.g. the captured email already
+        // belongs to another contact): route into the "N similar found" list
+        // instead of a raw CONFLICT error — the existing record IS the answer.
+        if (isConflictError(err)) {
+          const matches = await lookupMatchesAfterConflict(ready)
+          if (matches.length > 0) {
+            // If the user came via "Add anyway?" (capture sub-view), pop back
+            // so the matches list is what renders.
+            if (routeTop.kind === 'root' && routeTop.view === 'capture') routePop()
+            setPhase({
+              ...ready,
+              savingAs: null,
+              existingMatches: matches,
+              matchesStatus: 'loaded',
+            })
+            return
+          }
+          setPhase({
+            kind: 'error',
+            message: 'A record with these details already exists in Auxx.',
+          })
+          return
+        }
         setPhase({ kind: 'error', message: saveErrorMessage(err) })
       }
     },
-    [phase, navigateToDetail]
+    [phase, navigateToDetail, routeTop, routePop]
   )
 
   return (
@@ -336,4 +359,34 @@ function saveErrorMessage(err: unknown): string {
   }
   if (err instanceof Error) return err.message
   return 'Save failed.'
+}
+
+/** Per-value uniqueness rejection from the server (409 / tRPC CONFLICT). */
+function isConflictError(err: unknown): boolean {
+  return err instanceof TrpcCallError && (err.code === 'CONFLICT' || err.httpStatus === 409)
+}
+
+/**
+ * Re-run the dual-entity dedup lookup after a save conflict. The conflicting
+ * record was not necessarily in the pre-save matches (the save may have raced
+ * a capture on another tab, or the email may belong to a record the
+ * externalId lookup missed) — the email/domain candidates find it row-level.
+ */
+async function lookupMatchesAfterConflict(
+  ready: Extract<Phase, { kind: 'ready' }>
+): Promise<ExistingMatch[]> {
+  const primary = ready.target.entityType
+  const other: EntityType = primary === 'contact' ? 'company' : 'contact'
+  const [primaryHits, otherHits] = await Promise.all([
+    findExistingInEntity(primary, ready.person, ready.company),
+    findExistingInEntity(other, ready.person, ready.company),
+  ])
+  const merged: ExistingMatch[] = []
+  const seen = new Set<string>()
+  for (const m of [...primaryHits, ...otherHits]) {
+    if (seen.has(m.recordId)) continue
+    seen.add(m.recordId)
+    merged.push(m)
+  }
+  return merged
 }

--- a/apps/extension/src/iframe/routes/root/field-values.ts
+++ b/apps/extension/src/iframe/routes/root/field-values.ts
@@ -20,8 +20,13 @@ export function buildContactFieldValues(person: ParsedPerson): Record<string, un
     // column and synthesises the NAME value on read.
     first_name: person.firstName,
     last_name: person.lastName,
-    primary_email: person.primaryEmail,
-    phone: person.phone,
+    // primary_email / phone can be multi-value fields (options.multi). Send
+    // single-element arrays for shape consistency with the multi write path —
+    // the server auto-unwraps length-1 arrays on single-value fields, so this
+    // is safe either way. The extension has no update path (re-capture
+    // short-circuits into the matches list), so create is the only writer.
+    primary_email: person.primaryEmail ? [person.primaryEmail] : undefined,
+    phone: person.phone ? [person.phone] : undefined,
     notes: person.notes,
     // externalId is multi-value (options.multi=true in the registry). Send
     // the capture's identifier as a single-element array so the server

--- a/apps/web/src/components/custom-fields/ui/bulk-edit-field-gate.test.ts
+++ b/apps/web/src/components/custom-fields/ui/bulk-edit-field-gate.test.ts
@@ -1,0 +1,49 @@
+// apps/web/src/components/custom-fields/ui/bulk-edit-field-gate.test.ts
+// B6 (multi-email plan): the bulk editor excludes multi-value EMAIL/URL/PHONE
+// fields (whole-list replace across N records would wipe N alias lists) with a
+// per-record hint, while single-value and non-scalar-multi fields stay editable.
+
+import { describe, expect, it } from 'vitest'
+import { getBulkEditFieldGate } from './bulk-edit-field-gate'
+
+describe('getBulkEditFieldGate', () => {
+  it.each([
+    'EMAIL',
+    'URL',
+    'PHONE',
+    'PHONE_INTL',
+  ])('disables a multi-value %s field with the per-record hint', (fieldType) => {
+    expect(getBulkEditFieldGate({ fieldType, options: { multi: true } }, 1)).toEqual({
+      disabled: true,
+      description: 'Multi-value fields are edited per record',
+    })
+  })
+
+  it('keeps single-value EMAIL editable', () => {
+    expect(getBulkEditFieldGate({ fieldType: 'EMAIL', options: {} }, 3)).toEqual({
+      disabled: false,
+    })
+  })
+
+  it('does not exclude multi TEXT (only EMAIL/URL/PHONE are locked out)', () => {
+    expect(getBulkEditFieldGate({ fieldType: 'TEXT', options: { multi: true } }, 3)).toEqual({
+      disabled: false,
+    })
+  })
+
+  it('disables unique fields only when editing more than one record', () => {
+    expect(getBulkEditFieldGate({ isUnique: true, fieldType: 'TEXT' }, 2)).toEqual({
+      disabled: true,
+      description: 'Unique fields cannot be bulk edited',
+    })
+    expect(getBulkEditFieldGate({ isUnique: true, fieldType: 'TEXT' }, 1)).toEqual({
+      disabled: false,
+    })
+  })
+
+  it('multi EMAIL stays excluded even for a single selected record', () => {
+    expect(getBulkEditFieldGate({ fieldType: 'EMAIL', options: { multi: true } }, 1).disabled).toBe(
+      true
+    )
+  })
+})

--- a/apps/web/src/components/custom-fields/ui/bulk-edit-field-gate.ts
+++ b/apps/web/src/components/custom-fields/ui/bulk-edit-field-gate.ts
@@ -1,0 +1,34 @@
+// apps/web/src/components/custom-fields/ui/bulk-edit-field-gate.ts
+
+/** Field types whose multi-value variants are excluded from bulk edit. */
+const MULTI_VALUE_EXCLUDED_TYPES = new Set(['EMAIL', 'URL', 'PHONE', 'PHONE_INTL'])
+
+export interface BulkEditFieldGate {
+  disabled: boolean
+  /** Hint rendered as the field's description when disabled. */
+  description?: string
+}
+
+/**
+ * Decide whether a field is editable in the bulk-edit dialog.
+ *
+ * - Unique fields are disabled when editing multiple records (a shared value
+ *   would violate uniqueness on all but one).
+ * - Multi-value EMAIL/URL/PHONE fields (`options.multi`) are excluded outright
+ *   (locked decision, multi-email plan): a bulk set is a whole-list replace
+ *   across N records — it would wipe N alias lists, and per-value email
+ *   uniqueness makes the same value succeed on one record and conflict on the
+ *   rest. Edit per record via the picker instead.
+ */
+export function getBulkEditFieldGate(
+  field: { isUnique?: boolean; fieldType?: string; options?: { multi?: boolean } },
+  instanceCount: number
+): BulkEditFieldGate {
+  if (field.isUnique && instanceCount > 1) {
+    return { disabled: true, description: 'Unique fields cannot be bulk edited' }
+  }
+  if (field.options?.multi === true && MULTI_VALUE_EXCLUDED_TYPES.has(field.fieldType ?? '')) {
+    return { disabled: true, description: 'Multi-value fields are edited per record' }
+  }
+  return { disabled: false }
+}

--- a/apps/web/src/components/custom-fields/ui/bulk-update-entity-instance-dialog.tsx
+++ b/apps/web/src/components/custom-fields/ui/bulk-update-entity-instance-dialog.tsx
@@ -21,6 +21,7 @@ import { useFieldValueSyncer } from '~/components/resources/hooks/use-field-valu
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import { useDirtyCheck } from '~/hooks/use-dirty-state'
 import { useUnsavedChangesGuard } from '~/hooks/use-unsaved-changes-guard'
+import { getBulkEditFieldGate } from './bulk-edit-field-gate'
 import { FieldInputRow } from './field-input-row'
 
 interface BulkUpdateEntityInstanceDialogProps {
@@ -234,20 +235,18 @@ export function BulkUpdateEntityInstanceDialog({
 
           <FieldPanel className='p-0' breakpoint='md' resizeId='bulk-update-entity-instance'>
             {editableFields.map((field) => {
-              // Disable unique fields when editing multiple instances (would violate uniqueness)
-              const isUniqueDisabled = field.isUnique && instanceCount > 1
+              // Unique fields can't be bulk edited across >1 record; multi-value
+              // EMAIL/URL/PHONE fields are excluded outright (locked decision,
+              // multi-email plan — see getBulkEditFieldGate).
+              const { disabled, description } = getBulkEditFieldGate(field, instanceCount)
               return (
                 <FieldInputRow
                   key={field.id}
-                  field={
-                    isUniqueDisabled
-                      ? { ...field, description: 'Unique fields cannot be bulk edited' }
-                      : field
-                  }
+                  field={description ? { ...field, description } : field}
                   value={values[field.id] ?? ''}
                   onChange={handleFieldChange}
                   placeholder={getPlaceholder(field.id)}
-                  disabled={isUniqueDisabled}
+                  disabled={disabled}
                 />
               )
             })}

--- a/apps/web/src/server/api/routers/record-rules.ts
+++ b/apps/web/src/server/api/routers/record-rules.ts
@@ -68,7 +68,14 @@ const actionDocSchema = z.object({
 })
 
 const actionSchema = z.discriminatedUnion('type', [
-  z.object({ type: z.literal('set-field'), fieldRef: z.string().min(1), value: z.unknown() }),
+  z.object({
+    type: z.literal('set-field'),
+    fieldRef: z.string().min(1),
+    value: z.unknown(),
+    // Multi-value fields only: 'add' appends instead of replacing the stored
+    // list. No builder UI exposes this yet — default is replace ('set').
+    mode: z.enum(['set', 'add']).optional(),
+  }),
   z.object({ type: z.literal('enqueue-workflow'), workflowAppId: z.string().min(1) }),
   z.object({
     type: z.literal('notify'),

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/bulk-update-entity-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/bulk-update-entity-capabilities.test.ts
@@ -20,7 +20,7 @@
 import type { Rung } from '@auxx/database/enums'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const setBulkValuesSpy = vi.fn()
+const applyBulkSpy = vi.fn()
 /** Stands in for `RecordPickerService.getResourcesByIds` — the `_access` read. */
 const stampedRead = vi.fn<(ids: string[]) => Promise<Record<string, { _access?: Rung }>>>()
 
@@ -38,8 +38,8 @@ vi.mock('../../../../../../cache/org-cache-helpers', () => ({
 
 vi.mock('../../../../../../field-values/field-value-service', () => ({
   FieldValueService: class {
-    async setBulkValues(args: unknown) {
-      return setBulkValuesSpy(args)
+    async applyBulk(args: unknown) {
+      return applyBulkSpy(args)
     }
   },
 }))
@@ -143,8 +143,8 @@ function runTool(recordIds: string[], capabilities?: CapabilityView, approvedRec
 }
 
 beforeEach(() => {
-  setBulkValuesSpy.mockReset()
-  setBulkValuesSpy.mockResolvedValue({ count: 2 })
+  applyBulkSpy.mockReset()
+  applyBulkSpy.mockResolvedValue({ count: 2 })
   stampedRead.mockReset()
   stampedRead.mockResolvedValue({})
 })
@@ -155,7 +155,7 @@ describe('absent capabilities ⇒ unrestricted', () => {
 
     expect(result.success).toBe(true)
     expect(result.output).toMatchObject({ total: 2, approved: 2, updated: 2 })
-    expect(setBulkValuesSpy).toHaveBeenCalledTimes(1)
+    expect(applyBulkSpy).toHaveBeenCalledTimes(1)
     expect(stampedRead).not.toHaveBeenCalled()
   })
 })
@@ -165,7 +165,7 @@ describe('the def gate is the fast path', () => {
     const result = await runTool([OPEN_A, OPEN_B], member(Level.Edit))
 
     expect(result.success).toBe(true)
-    expect(setBulkValuesSpy).toHaveBeenCalledTimes(1)
+    expect(applyBulkSpy).toHaveBeenCalledTimes(1)
     expect(stampedRead).not.toHaveBeenCalled()
   })
 
@@ -187,7 +187,7 @@ describe('the def gate is the fast path', () => {
 
     expect(result.success).toBe(true)
     expect(stampedRead).not.toHaveBeenCalled()
-    expect(setBulkValuesSpy).toHaveBeenCalledWith(expect.objectContaining({ recordIds: [OPEN_A] }))
+    expect(applyBulkSpy).toHaveBeenCalledWith(expect.objectContaining({ recordIds: [OPEN_A] }))
   })
 })
 
@@ -202,7 +202,7 @@ describe('§5.3 — a row the def gate refuses is judged on its own `_access`', 
 
     expect(result.success).toBe(true)
     expect(stampedRead).toHaveBeenCalledWith([CLOSED_A])
-    expect(setBulkValuesSpy).toHaveBeenCalledTimes(1)
+    expect(applyBulkSpy).toHaveBeenCalledTimes(1)
   })
 
   it('only the def-DENIED remainder is stamped in a MIXED batch', async () => {
@@ -226,7 +226,7 @@ describe('§5.3 — a row the def gate refuses is judged on its own `_access`', 
     })
 
     await expect(runTool([CLOSED_A, CLOSED_B], capabilities)).rejects.toBeInstanceOf(ForbiddenError)
-    expect(setBulkValuesSpy).not.toHaveBeenCalled()
+    expect(applyBulkSpy).not.toHaveBeenCalled()
   })
 
   it('a row denied by BOTH routes throws before any write', async () => {
@@ -235,7 +235,7 @@ describe('§5.3 — a row the def gate refuses is judged on its own `_access`', 
     stampedRead.mockResolvedValue({ [CLOSED_A]: stampedAt(capabilities, CLOSED_A, null) })
 
     await expect(runTool([OPEN_A, CLOSED_A], capabilities)).rejects.toBeInstanceOf(ForbiddenError)
-    expect(setBulkValuesSpy).not.toHaveBeenCalled()
+    expect(applyBulkSpy).not.toHaveBeenCalled()
   })
 })
 
@@ -248,7 +248,7 @@ describe('§5.2 — non-enumeration: an id the read path hid DENIES', () => {
     await expect(runTool([CLOSED_A], member(Level.Full, [CLOSED_DEF]))).rejects.toBeInstanceOf(
       ForbiddenError
     )
-    expect(setBulkValuesSpy).not.toHaveBeenCalled()
+    expect(applyBulkSpy).not.toHaveBeenCalled()
   })
 
   it('a row that comes back WITHOUT a stamp is refused', async () => {
@@ -259,7 +259,7 @@ describe('§5.2 — non-enumeration: an id the read path hid DENIES', () => {
     await expect(runTool([CLOSED_A], member(Level.Full, [CLOSED_DEF]))).rejects.toBeInstanceOf(
       ForbiddenError
     )
-    expect(setBulkValuesSpy).not.toHaveBeenCalled()
+    expect(applyBulkSpy).not.toHaveBeenCalled()
   })
 })
 
@@ -283,6 +283,6 @@ describe('a pure AGENT principal behaves exactly as it did under the def loop', 
     stampedRead.mockResolvedValue({ [CLOSED_A]: row })
 
     await expect(runTool([CLOSED_A], capabilities)).rejects.toBeInstanceOf(ForbiddenError)
-    expect(setBulkValuesSpy).not.toHaveBeenCalled()
+    expect(applyBulkSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/mail-lens-write-block.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/mail-lens-write-block.test.ts
@@ -87,7 +87,7 @@ vi.mock('../../../../../../resources/crud/record-row-access', () => ({
 const setBulkValuesSpy = vi.fn(async (_args: unknown) => ({ count: 1 }))
 vi.mock('../../../../../../field-values/field-value-service', () => ({
   FieldValueService: class {
-    async setBulkValues(args: unknown) {
+    async applyBulk(args: unknown) {
       return setBulkValuesSpy(args)
     }
   },
@@ -96,6 +96,7 @@ vi.mock('../../../../../../field-values/field-value-service', () => ({
 vi.mock('../field-label-helpers', () => ({
   validateFieldKeys: () => ({ unknownKeys: [], validIds: ['name'] }),
   formatUnknownFieldsError: () => 'unknown fields',
+  isMultiValueField: () => false,
   resolveFieldLabels: (_r: unknown, ids: string[]) => ids,
 }))
 

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/update-tools-multi-modes.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/update-tools-multi-modes.test.ts
@@ -1,0 +1,187 @@
+// packages/lib/src/ai/kopilot/capabilities/entities/tools/__tests__/update-tools-multi-modes.test.ts
+//
+// B5/B6 (multi-email plan): the Kopilot update tools must never silently wipe a
+// multi-value field's stored list when the model asked to append, and must never
+// route an append at a single-value field (the append primitive throws there).
+//
+//   - `update_entity` accepts `modes: { <fieldId>: 'add' }` → `handler.update`
+//     receives the per-field mode map, but ONLY for fields that are actually
+//     multi-value on the cached resource; everything else stays default replace.
+//   - `bulk_update_entity` accepts `mode: 'add'` per values entry → routed
+//     through `FieldValueService.applyBulk` as `BulkValueItem.mode`, with the
+//     same multi-only guard.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handlerUpdate = vi.fn()
+vi.mock('../../../../../../resources/crud', () => ({
+  UnifiedCrudHandler: class {
+    update = handlerUpdate
+  },
+}))
+
+const applyBulkSpy = vi.fn()
+vi.mock('../../../../../../field-values/field-value-service', () => ({
+  FieldValueService: class {
+    async applyBulk(args: unknown) {
+      return applyBulkSpy(args)
+    }
+  },
+}))
+
+const findCachedResource = vi.fn()
+vi.mock('../../../../../../cache/org-cache-helpers', () => ({
+  findCachedResource: (...args: unknown[]) => findCachedResource(...args),
+  getCachedResources: vi.fn(async () => []),
+  getCachedMembers: vi.fn(async () => []),
+  getCachedGroups: vi.fn(async () => []),
+}))
+
+import type { ToolContext } from '../../../../../agent-framework/tool-context'
+import type { AgentToolResult } from '../../../../../agent-framework/types'
+import { createBulkUpdateEntityTool } from '../bulk-update-entity'
+import { createUpdateEntityTool } from '../update-entity'
+
+const DEF = 'edf_contact00000000000000000'
+const REC = `${DEF}:ins_a00000000000000000000`
+const REC_B = `${DEF}:ins_b00000000000000000000`
+
+/** Cached resource with one multi-value email field and one single-value URL field. */
+const resource = {
+  id: DEF,
+  entityDefinitionId: DEF,
+  label: 'Contact',
+  fields: [
+    {
+      id: 'fld_email',
+      key: 'primary_email',
+      systemAttribute: 'primary_email',
+      label: 'Email',
+      fieldType: 'EMAIL',
+      options: { multi: true },
+      capabilities: {},
+    },
+    {
+      id: 'fld_site',
+      key: 'company_website',
+      systemAttribute: 'company_website',
+      label: 'Website',
+      fieldType: 'URL',
+      options: {},
+      capabilities: {},
+    },
+  ],
+}
+
+const ctx = { organizationId: 'org_1', userId: 'u_1' } as ToolContext
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  findCachedResource.mockResolvedValue(resource)
+  handlerUpdate.mockResolvedValue(undefined)
+  applyBulkSpy.mockResolvedValue({ count: 0, added: 1 })
+})
+
+describe('update_entity — per-field write modes', () => {
+  const tool = createUpdateEntityTool(() => ({ db: {}, capabilities: undefined }) as never)
+
+  it("passes mode 'add' through for a multi-value field", async () => {
+    const result = (await tool.execute(
+      {
+        recordId: REC,
+        values: { primary_email: 'alias@x.com' },
+        modes: { primary_email: 'add' },
+      },
+      ctx
+    )) as AgentToolResult
+
+    expect(result.success).toBe(true)
+    expect(handlerUpdate).toHaveBeenCalledWith(
+      REC,
+      { primary_email: 'alias@x.com' },
+      { primary_email: 'add' }
+    )
+  })
+
+  it("ignores mode 'add' on a single-value field (default replace, no throw)", async () => {
+    const result = (await tool.execute(
+      {
+        recordId: REC,
+        values: { company_website: 'https://x.com' },
+        modes: { company_website: 'add' },
+      },
+      ctx
+    )) as AgentToolResult
+
+    expect(result.success).toBe(true)
+    expect(handlerUpdate).toHaveBeenCalledWith(REC, { company_website: 'https://x.com' }, undefined)
+  })
+
+  it('defaults to replace when no modes are given', async () => {
+    const result = (await tool.execute(
+      { recordId: REC, values: { primary_email: 'a@x.com' } },
+      ctx
+    )) as AgentToolResult
+
+    expect(result.success).toBe(true)
+    expect(handlerUpdate).toHaveBeenCalledWith(REC, { primary_email: 'a@x.com' }, undefined)
+  })
+})
+
+describe('bulk_update_entity — per-entry write modes', () => {
+  const tool = createBulkUpdateEntityTool(() => ({ db: {}, capabilities: undefined }) as never)
+
+  it("routes mode 'add' on a multi-value field through applyBulk as an append", async () => {
+    const result = (await tool.execute(
+      {
+        recordIds: [REC, REC_B],
+        values: [{ fieldId: 'primary_email', value: 'alias@x.com', mode: 'add' }],
+      },
+      ctx
+    )) as AgentToolResult
+
+    expect(result.success).toBe(true)
+    expect(applyBulkSpy).toHaveBeenCalledWith({
+      recordIds: [REC, REC_B],
+      values: [{ fieldId: 'primary_email', value: 'alias@x.com', mode: 'add' }],
+    })
+    // `count` only tallies replace writes — an all-append call still reports
+    // every approved record as updated.
+    expect(result.output).toMatchObject({ updated: 2 })
+  })
+
+  it("downgrades mode 'add' on a single-value field to a replace", async () => {
+    applyBulkSpy.mockResolvedValue({ count: 2 })
+    const result = (await tool.execute(
+      {
+        recordIds: [REC, REC_B],
+        values: [{ fieldId: 'company_website', value: 'https://x.com', mode: 'add' }],
+      },
+      ctx
+    )) as AgentToolResult
+
+    expect(result.success).toBe(true)
+    expect(applyBulkSpy).toHaveBeenCalledWith({
+      recordIds: [REC, REC_B],
+      values: [{ fieldId: 'company_website', value: 'https://x.com', mode: 'set' }],
+    })
+    expect(result.output).toMatchObject({ updated: 2 })
+  })
+
+  it('defaults every entry to replace when no mode is given', async () => {
+    applyBulkSpy.mockResolvedValue({ count: 2 })
+    const result = (await tool.execute(
+      {
+        recordIds: [REC, REC_B],
+        values: [{ fieldId: 'primary_email', value: 'a@x.com' }],
+      },
+      ctx
+    )) as AgentToolResult
+
+    expect(result.success).toBe(true)
+    expect(applyBulkSpy).toHaveBeenCalledWith({
+      recordIds: [REC, REC_B],
+      values: [{ fieldId: 'primary_email', value: 'a@x.com', mode: 'set' }],
+    })
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/bulk-update-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/bulk-update-entity.ts
@@ -25,6 +25,7 @@ const BulkUpdateEntityOutput = z.object({
 
 import {
   formatUnknownFieldsError,
+  isMultiValueField,
   resolveFieldLabels,
   validateFieldKeys,
 } from './field-label-helpers'
@@ -70,6 +71,9 @@ them on update. Ids listed in \`autoFilled\` are also system-managed; don't pass
 
 Use this tool instead of update_entity when updating 2+ records with the same field values.
 
+Multi-value fields (list_entity_fields flags them \`multi: true\`): writing a value REPLACES each
+record's whole stored list. Pass \`"mode": "add"\` on that values entry to append instead.
+
 Example (ids match list_entity_fields output):
   recordIds: ["abc123:def456", "abc123:ghi789"]
   values: [{ "fieldId": "ticket_status", "value": "COMPLETED" }]`,
@@ -95,6 +99,12 @@ Example (ids match list_entity_fields output):
               },
               value: {
                 description: 'The new value for the field (null to clear)',
+              },
+              mode: {
+                type: 'string',
+                enum: ['replace', 'add'],
+                description:
+                  "Write mode for multi-value fields: 'replace' (default) replaces each record's stored list; 'add' appends without touching existing values. Ignored for single-value fields.",
               },
             },
             required: ['fieldId', 'value'],
@@ -152,7 +162,11 @@ Example (ids match list_entity_fields output):
         }
       }
 
-      const values = args.values as Array<{ fieldId: string; value: unknown }>
+      const values = args.values as Array<{
+        fieldId: string
+        value: unknown
+        mode?: 'replace' | 'add'
+      }>
 
       // inputAmendment._approvedRecordIds filters which records to actually update
       const approvedIds = args._approvedRecordIds as string[] | undefined
@@ -259,10 +273,26 @@ Example (ids match list_entity_fields output):
 
       const service = new FieldValueService(agentDeps.organizationId, agentDeps.userId, db)
 
+      // Per-field write modes: `'add'` appends on multi-value fields instead of
+      // replacing each record's stored list (default replace). Guarded on the
+      // field actually being multi — the append primitive throws on
+      // single-value fields, and a model-guessed 'add' on a scalar should just
+      // replace.
+      const addFieldIds = new Set(
+        values
+          .filter((v) => v.mode === 'add' && (!resource || isMultiValueField(resource, v.fieldId)))
+          .map((v) => v.fieldId)
+      )
+      const bulkValues = resolvedPairs.map((p) => ({
+        fieldId: p.fieldId,
+        value: p.value,
+        mode: addFieldIds.has(p.fieldId) ? ('add' as const) : ('set' as const),
+      }))
+
       try {
-        const result = await service.setBulkValues({
+        const result = await service.applyBulk({
           recordIds,
-          values: resolvedPairs,
+          values: bulkValues,
         })
 
         const fieldIds = resolvedPairs.map((v) => v.fieldId)
@@ -272,7 +302,9 @@ Example (ids match list_entity_fields output):
           output: {
             total: allRecordIds.length,
             approved: recordIds.length,
-            updated: result.count,
+            // `count` only tallies replace writes; an all-append call still
+            // touched every approved record.
+            updated: result.count > 0 ? result.count : recordIds.length,
             updatedFields: fieldLabels,
           },
         }

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/field-label-helpers.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/field-label-helpers.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/ai/kopilot/capabilities/entities/tools/field-label-helpers.ts
 
+import { isMultiValueFieldType } from '../../../../../field-values/formatter'
 import { getFieldOutputKey } from '../../../../../resources/registry/field-types'
 import type { Resource } from '../../../../../resources/registry/types'
 
@@ -19,6 +20,24 @@ export function resolveFieldLabels(
     )
     return field?.label ?? id
   })
+}
+
+/**
+ * Whether an LLM-supplied field id names a multi-value field on the resource
+ * (MULTI_SELECT/TAGS/RELATIONSHIP/FILE, multi-ACTOR, or a scalar field with
+ * `options.multi` — e.g. a multi-value email/phone/website). Used to decide
+ * whether an `'add'` write mode may route to the append primitives, which
+ * throw on single-value fields.
+ *
+ * Returns `false` when the resource or field can't be resolved — the caller
+ * then keeps the default replace mode, which is always safe to attempt.
+ */
+export function isMultiValueField(resource: Resource | null | undefined, fieldId: string): boolean {
+  const field = resource?.fields.find(
+    (f) => getFieldOutputKey(f) === fieldId || f.key === fieldId || f.id === fieldId
+  )
+  if (!field?.fieldType) return false
+  return isMultiValueFieldType(field.fieldType, field.options)
 }
 
 /**

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields-output.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields-output.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields-output.ts
 
+import { isMultiValueFieldType } from '../../../../../field-values/formatter'
 import type { ResourceField } from '../../../../../resources/registry/field-types'
 
 const SELECT_TYPES = new Set(['SINGLE_SELECT', 'MULTI_SELECT', 'STATUS'])
@@ -46,6 +47,11 @@ export interface FieldOutput {
   required?: true
   /** Only present when true — absence means "no uniqueness constraint". */
   unique?: true
+  /**
+   * Only present when true — the field stores a LIST of values. Writing it
+   * replaces the whole list; the update tools accept mode `'add'` to append.
+   */
+  multi?: true
   /** Only present when creatable && updatable are both false. */
   readOnly?: true
   /** Only present when creatable && !updatable (e.g. ticket_type). */
@@ -93,6 +99,7 @@ export function formatFieldOutput(field: ResourceField): FieldOutput | null {
 
   if (caps?.required) entry.required = true
   if (caps?.unique) entry.unique = true
+  if (field.fieldType && isMultiValueFieldType(field.fieldType, field.options)) entry.multi = true
 
   const creatable = caps?.creatable ?? true
   const updatable = caps?.updatable ?? true

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/list-entity-fields.ts
@@ -95,6 +95,7 @@ Response shape:
 - fields[]: each entry has \`id\`, \`label\`, \`fieldType\`, plus optional flags:
     required: true       — must be set on create
     unique: true         — duplicates will be rejected
+    multi: true          — stores a LIST of values; a plain write replaces the whole list (update tools accept mode 'add' to append)
     readOnly: true       — can't be set on create or update
     createOnly: true     — set at create, never updated after
     options              — valid values for select / multi-select / status

--- a/packages/lib/src/ai/kopilot/capabilities/entities/tools/update-entity.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/tools/update-entity.ts
@@ -17,6 +17,7 @@ const UpdateEntityOutput = z.object({
 
 import {
   formatUnknownFieldsError,
+  isMultiValueField,
   resolveFieldLabels,
   validateFieldKeys,
 } from './field-label-helpers'
@@ -57,6 +58,10 @@ Each key in \`values\` must be an id from list_entity_fields. Unknown keys are r
 Do NOT include ids flagged \`readOnly: true\` or \`createOnly: true\` — the backend ignores
 them on update. Ids listed in \`autoFilled\` are also system-managed; don't pass them.
 
+Multi-value fields (list_entity_fields flags them): writing a value REPLACES the whole
+stored list. To append without touching existing values, pass \`modes\` with \`"add"\` for
+that field, e.g. modes: { "primary_email": "add" }.
+
 Example (ids match list_entity_fields output):
   recordId: "abc123:def456"
   values: { "company_website": "https://new-site.com" }`,
@@ -73,6 +78,12 @@ Example (ids match list_entity_fields output):
           description:
             'Object mapping field IDs to their new values. Keys MUST be exact ids from the most recent list_entity_fields call (usually systemAttribute, e.g. company_website, ticket_status). Only include fields you want to update.',
           additionalProperties: true,
+        },
+        modes: {
+          type: 'object',
+          description:
+            "Optional per-field write mode, keyed like `values`. Only 'add' is meaningful: on a multi-value field (list_entity_fields flags `multi: true`) it APPENDS the given value(s) instead of replacing the stored list. Omitted fields default to replace. Ignored for single-value fields.",
+          additionalProperties: { type: 'string', enum: ['replace', 'add'] },
         },
       },
       required: ['recordId', 'values'],
@@ -116,7 +127,9 @@ Example (ids match list_entity_fields output):
       // The LLM may nest field values under `values` or flatten them at the top level.
       const values =
         (args.values as Record<string, unknown>) ??
-        Object.fromEntries(Object.entries(args).filter(([k]) => k !== 'recordId' && k !== 'values'))
+        Object.fromEntries(
+          Object.entries(args).filter(([k]) => k !== 'recordId' && k !== 'values' && k !== 'modes')
+        )
 
       if (!values || Object.keys(values).length === 0) {
         return {
@@ -167,8 +180,20 @@ Example (ids match list_entity_fields output):
         { capabilities }
       )
 
+      // Per-field write modes: `'add'` appends on multi-value fields instead of
+      // replacing the stored list (default replace). Guarded on the field
+      // actually being multi — the append primitive throws on single-value
+      // fields, and a model-guessed 'add' on a scalar should just replace.
+      const rawModes = (args.modes ?? {}) as Record<string, unknown>
+      let modes: Record<string, 'set' | 'add' | 'remove'> | undefined
+      for (const [key, mode] of Object.entries(rawModes)) {
+        if (mode !== 'add' || !(key in resolvedValues)) continue
+        if (resource && !isMultiValueField(resource, key)) continue
+        modes = { ...modes, [key]: 'add' }
+      }
+
       try {
-        await handler.update(recordId, resolvedValues)
+        await handler.update(recordId, resolvedValues, modes)
         const fieldIds = Object.keys(resolvedValues)
         const labels = resolveFieldLabels(resource, fieldIds)
         return {

--- a/packages/lib/src/custom-fields/ai.ts
+++ b/packages/lib/src/custom-fields/ai.ts
@@ -23,11 +23,17 @@ export function isAiEligible(type: FieldType): boolean {
 /**
  * Whether a specific field has AI generation turned on. Combines the
  * type-level eligibility gate with the per-field `options.ai.enabled` flag.
+ *
+ * Multi-value scalar fields (`options.multi` — e.g. multi-value email/phone/
+ * website) are NOT AI-generatable: the commit path is a whole-field replace,
+ * so a generated value would wipe the stored alias list. This gates the whole
+ * pipeline (enqueue short-circuit, worker generation, reference resolution).
  */
 export function isAiField(field: CustomFieldEntity): boolean {
   if (!isAiEligible(toFieldType(field.type))) return false
-  const ai = (field.options as { ai?: AiOptions } | null | undefined)?.ai
-  return ai?.enabled === true
+  const options = field.options as { ai?: AiOptions; multi?: boolean } | null | undefined
+  if (options?.multi === true) return false
+  return options?.ai?.enabled === true
 }
 
 /**

--- a/packages/lib/src/field-values/ai-autofill/__tests__/multi-field-gate.test.ts
+++ b/packages/lib/src/field-values/ai-autofill/__tests__/multi-field-gate.test.ts
@@ -1,0 +1,52 @@
+// packages/lib/src/field-values/ai-autofill/__tests__/multi-field-gate.test.ts
+//
+// B5/B6 (multi-email plan): AI autofill is GATED OFF multi-value scalar fields
+// (`options.multi`) — the commit path is a whole-field replace, so a generated
+// value would wipe the stored alias list. `isAiField` gates the whole pipeline
+// (enqueue short-circuit, worker generation, reference resolution);
+// `buildJsonSchema` throws as defense in depth for callers that skip the gate.
+
+import type { CustomFieldEntity } from '@auxx/database/types'
+import { describe, expect, it } from 'vitest'
+import { isAiField } from '../../../custom-fields/ai'
+import { BadRequestError } from '../../../errors'
+import { buildJsonSchema } from '../json-schema-builder'
+
+function field(overrides: Partial<CustomFieldEntity>): CustomFieldEntity {
+  return {
+    id: 'fld_1',
+    type: 'EMAIL',
+    options: {},
+    ...overrides,
+  } as CustomFieldEntity
+}
+
+describe('isAiField — multi-value gate', () => {
+  it('gates an ai-enabled field OFF once it is flagged multi', async () => {
+    const single = field({ options: { ai: { enabled: true } } })
+    const multi = field({ options: { ai: { enabled: true }, multi: true } })
+
+    expect(isAiField(single)).toBe(true)
+    expect(isAiField(multi)).toBe(false)
+  })
+
+  it('keeps MULTI_SELECT eligible — inherently multi via TYPE, not options.multi', async () => {
+    const multiSelect = field({
+      type: 'MULTI_SELECT',
+      options: { ai: { enabled: true }, options: [{ id: 'a', value: 'a', label: 'A' }] },
+    })
+    expect(isAiField(multiSelect)).toBe(true)
+  })
+})
+
+describe('buildJsonSchema — multi-value defense in depth', () => {
+  it('throws for a multi-value scalar field even when a caller skipped the gate', async () => {
+    expect(() => buildJsonSchema(field({ options: { multi: true } }))).toThrow(BadRequestError)
+  })
+
+  it('still builds the scalar schema for single-value fields', async () => {
+    expect(buildJsonSchema(field({}))).toMatchObject({
+      schema: { properties: { value: { type: 'string' } } },
+    })
+  })
+})

--- a/packages/lib/src/field-values/ai-autofill/json-schema-builder.ts
+++ b/packages/lib/src/field-values/ai-autofill/json-schema-builder.ts
@@ -41,6 +41,13 @@ function wrap(valueSchema: JsonSchema, description?: string): JsonSchema {
 export function buildJsonSchema(field: CustomFieldEntity): JsonSchema {
   const options = (field.options ?? {}) as FieldOptions
 
+  // Multi-value scalar fields are gated off autofill entirely (`isAiField`):
+  // the commit path is a whole-field replace, so a generated value would wipe
+  // the stored list. Defense in depth for callers that skipped the gate.
+  if (options.multi === true) {
+    throw new BadRequestError('AI generation is not supported for multi-value fields')
+  }
+
   switch (field.type) {
     case FieldTypeEnum.TEXT:
     case FieldTypeEnum.URL:

--- a/packages/lib/src/ingest/companies/find-or-create.ts
+++ b/packages/lib/src/ingest/companies/find-or-create.ts
@@ -24,10 +24,14 @@ export async function findOrCreateCompanyByDomain(
     return existing.id
   }
 
+  // `company_website` is array-wrapped for shape consistency with multi-value
+  // fields (the write path auto-unwraps length-1 arrays on single-value
+  // fields); `company_domain` stays single-value by design. Create-only: an
+  // existing company is never re-written here.
   const result = await crudHandler.create('company', {
     company_domain: domain,
     company_name: domain,
-    company_website: `https://${domain}`,
+    company_website: [`https://${domain}`],
   })
 
   const createdId = result.instance.id

--- a/packages/lib/src/ingest/contacts/__tests__/find-or-create-from-jwt.test.ts
+++ b/packages/lib/src/ingest/contacts/__tests__/find-or-create-from-jwt.test.ts
@@ -100,7 +100,9 @@ describe('findOrCreateContactFromJwt — chat (app-less) visitor', () => {
     })
 
     expect(create).toHaveBeenCalledWith('contact', {
-      primary_email: 'jane@example.com',
+      // Array-wrapped for multi-value shape consistency; the write path
+      // auto-unwraps length-1 arrays on single-value fields.
+      primary_email: ['jane@example.com'],
       contact_status: 'ACTIVE',
     })
     // No external_id array in the create payload.
@@ -131,7 +133,7 @@ describe('findOrCreateContactFromJwt — chat (app-less) visitor', () => {
     expect(create).toHaveBeenCalledWith('contact', {
       contact_status: 'ACTIVE',
       first_name: 'Jane',
-      primary_email: 'jane@example.com',
+      primary_email: ['jane@example.com'],
     })
     expect(result.resolution).toBe('created')
   })

--- a/packages/lib/src/ingest/contacts/find-or-create-from-jwt.ts
+++ b/packages/lib/src/ingest/contacts/find-or-create-from-jwt.ts
@@ -132,11 +132,13 @@ export async function findOrCreateContactFromJwt(
 
   // Tier 3 — create on first sight. Server-derived identity fields are spread
   // AFTER the caller attribute bag so no attribute can override the signed
-  // JWT email.
+  // JWT email. The email is array-wrapped for shape consistency with
+  // multi-value fields (the write path auto-unwraps length-1 arrays on
+  // single-value fields).
   const { instance } = await handler.create('contact', {
     contact_status: 'ACTIVE',
     ...attributes,
-    ...(email ? { primary_email: email } : {}),
+    ...(email ? { primary_email: [email] } : {}),
   })
   if (!shopify && contactDefId) {
     await mirrorChatLink({ organizationId, contactDefId, contactId: instance.id, userId })

--- a/packages/lib/src/ingest/contacts/find-or-create.ts
+++ b/packages/lib/src/ingest/contacts/find-or-create.ts
@@ -123,7 +123,11 @@ export async function findOrCreateContactForParticipant(
     }
 
     if (participant.identifierType === IdentifierTypeEnum.PHONE) {
-      createValues.phone = participant.identifier
+      // Array-wrapped for shape consistency with multi-value fields
+      // (options.multi) — the write path auto-unwraps length-1 arrays on
+      // single-value fields. Create-only: matched contacts never get their
+      // identifier re-written here (no-append is the locked ingest decision).
+      createValues.phone = [participant.identifier]
     }
 
     let contactId: string
@@ -134,8 +138,14 @@ export async function findOrCreateContactForParticipant(
       const { instance } = await handler.create('contact', createValues)
       contactId = instance.id
     } else {
+      // `findBy` stays scalar (it drives the lookup); the create data gets the
+      // array-wrapped identifier so a fresh contact's email/phone lands in the
+      // multi-value shape (createValues spreads after findBy in findOrCreate).
       const findBy: Record<string, unknown> = { [systemAttr]: participant.identifier }
-      const { instance } = await handler.findOrCreate('contact', findBy, createValues)
+      const { instance } = await handler.findOrCreate('contact', findBy, {
+        ...createValues,
+        [systemAttr]: [participant.identifier],
+      })
       contactId = instance.id
     }
 

--- a/packages/lib/src/participants/__tests__/participant-queries.test.ts
+++ b/packages/lib/src/participants/__tests__/participant-queries.test.ts
@@ -1,0 +1,167 @@
+// packages/lib/src/participants/__tests__/participant-queries.test.ts
+// B6 (multi-email plan): the chat "promote to contact" claimed-email copy must
+// APPEND on a multi-value `primary_email` field (never replace the alias list)
+// and must SURFACE uniqueness conflicts to the clicking user instead of
+// silently promoting with no email.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { UniqueValueConflictError } from '../../errors'
+
+// Partial mock: `@auxx/logger/run-log` imports sink-registration helpers from
+// this barrel at module load, so a full replacement breaks whichever test file
+// happens to load it first.
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+const crudUpdate = vi.fn()
+const findOrCreateContactForParticipant = vi.fn()
+vi.mock('../../ingest', () => ({
+  createIngestContext: vi.fn(async () => ({ crudHandler: { update: crudUpdate } })),
+  extractRegistrableDomain: vi.fn(() => null),
+  findOrCreateContactForParticipant: (...args: unknown[]) =>
+    findOrCreateContactForParticipant(...args),
+  getOwnDomains: vi.fn(async () => new Set<string>()),
+  normalizeDomain: (d: string) => d,
+}))
+
+const getChatThreadMetadata = vi.fn()
+vi.mock('../../chat/metadata', () => ({
+  getChatThreadMetadata: (...args: unknown[]) => getChatThreadMetadata(...args),
+}))
+
+const getCachedEntityDefId = vi.fn()
+const getCachedCustomFields = vi.fn()
+vi.mock('../../cache', () => ({
+  getCachedEntityDefId: (...args: unknown[]) => getCachedEntityDefId(...args),
+  getCachedCustomFields: (...args: unknown[]) => getCachedCustomFields(...args),
+}))
+
+import { ensureContactForParticipant } from '../participant-queries'
+
+const ORG = 'org_1'
+const PARTICIPANT = {
+  id: 'part_1',
+  organizationId: ORG,
+  entityInstanceId: null,
+  isSpammer: false,
+  isInternal: false,
+  identifier: 'visitor_cookie',
+  identifierType: 'CHAT_VISITOR',
+}
+
+/** Minimal `Database` stand-in for the participant read + link-back write. */
+// biome-ignore lint/suspicious/noExplicitAny: test double
+function makeDb(participantRow: unknown): any {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: async () => (participantRow ? [participantRow] : []) }),
+      }),
+    }),
+    update: () => ({ set: () => ({ where: async () => undefined }) }),
+  }
+}
+
+const emailField = (multi: boolean) => ({
+  id: 'fld_email',
+  systemAttribute: 'primary_email',
+  type: 'EMAIL',
+  options: multi ? { multi: true } : {},
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  findOrCreateContactForParticipant.mockResolvedValue('contact_1')
+  crudUpdate.mockResolvedValue(undefined)
+  getCachedEntityDefId.mockResolvedValue('def_contact')
+  getCachedCustomFields.mockResolvedValue([emailField(true)])
+  getChatThreadMetadata.mockResolvedValue({
+    claimedVisitorName: 'Jane Doe',
+    claimedVisitorEmail: 'jane@example.com',
+    visit: null,
+  })
+})
+
+describe('ensureContactForParticipant — claimed email copy', () => {
+  it('APPENDS the claimed email on a multi-value field (mode add, never a replace)', async () => {
+    const result = await ensureContactForParticipant(ORG, 'part_1', makeDb(PARTICIPANT), {
+      sourceThreadId: 'thread_1',
+    })
+
+    expect(result).toEqual({ entityInstanceId: 'contact_1', created: true })
+    // Name attrs and the email ride separate writes; the email write is an
+    // append so an existing contact's alias list is never replaced.
+    expect(crudUpdate).toHaveBeenCalledWith(
+      'contact:contact_1',
+      { primary_email: ['jane@example.com'] },
+      { primary_email: 'add' }
+    )
+    // No write may carry the email as a whole-value set.
+    for (const call of crudUpdate.mock.calls) {
+      const [, values, modes] = call as [string, Record<string, unknown>, unknown]
+      if ('primary_email' in values) {
+        expect(modes).toEqual({ primary_email: 'add' })
+      }
+    }
+  })
+
+  it('keeps the whole-value set while the field is still single-value (pre-flip)', async () => {
+    getCachedCustomFields.mockResolvedValue([emailField(false)])
+
+    await ensureContactForParticipant(ORG, 'part_1', makeDb(PARTICIPANT), {
+      sourceThreadId: 'thread_1',
+    })
+
+    expect(crudUpdate).toHaveBeenCalledWith('contact:contact_1', {
+      primary_email: 'jane@example.com',
+    })
+  })
+
+  it('surfaces a uniqueness conflict on the claimed email to the caller', async () => {
+    crudUpdate.mockImplementation(async (_recordId: string, values: Record<string, unknown>) => {
+      if ('primary_email' in values) {
+        throw new UniqueValueConflictError({
+          message: 'Value already in use',
+          conflictingValue: 'jane@example.com',
+          existingEntityId: 'contact_other',
+        })
+      }
+    })
+
+    await expect(
+      ensureContactForParticipant(ORG, 'part_1', makeDb(PARTICIPANT), {
+        sourceThreadId: 'thread_1',
+      })
+    ).rejects.toBeInstanceOf(UniqueValueConflictError)
+  })
+
+  it('stays best-effort for non-conflict email copy failures', async () => {
+    crudUpdate.mockImplementation(async (_recordId: string, values: Record<string, unknown>) => {
+      if ('primary_email' in values) throw new Error('transient')
+    })
+
+    await expect(
+      ensureContactForParticipant(ORG, 'part_1', makeDb(PARTICIPANT), {
+        sourceThreadId: 'thread_1',
+      })
+    ).resolves.toEqual({ entityInstanceId: 'contact_1', created: true })
+  })
+
+  it('still writes the claimed email when the name/geo copy fails', async () => {
+    crudUpdate.mockImplementation(async (_recordId: string, values: Record<string, unknown>) => {
+      if (!('primary_email' in values)) throw new Error('attrs write failed')
+    })
+
+    await ensureContactForParticipant(ORG, 'part_1', makeDb(PARTICIPANT), {
+      sourceThreadId: 'thread_1',
+    })
+
+    expect(crudUpdate).toHaveBeenCalledWith(
+      'contact:contact_1',
+      { primary_email: ['jane@example.com'] },
+      { primary_email: 'add' }
+    )
+  })
+})

--- a/packages/lib/src/participants/participant-queries.ts
+++ b/packages/lib/src/participants/participant-queries.ts
@@ -4,9 +4,12 @@ import { type Database, database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { toRecordId } from '@auxx/types/resource'
 import { and, eq } from 'drizzle-orm'
+import { getCachedCustomFields, getCachedEntityDefId } from '../cache'
 import { resolveChatAttributes } from '../chat/attribute-resolution'
 import { getChatThreadMetadata } from '../chat/metadata'
-import { BadRequestError, NotFoundError } from '../errors'
+import { BadRequestError, NotFoundError, UniqueValueConflictError } from '../errors'
+import { isMultiValueFieldType } from '../field-values/formatter'
+import { toFieldType } from '../field-values/stored-field-type'
 import {
   createIngestContext,
   extractRegistrableDomain,
@@ -40,6 +43,9 @@ export interface EnsureContactResult {
  *    `Participant.entityInstanceId`, and return it.
  *
  * Throws `NotFoundError` when the participant doesn't belong to `organizationId`.
+ * Throws `UniqueValueConflictError` when the chat visitor's claimed email is
+ * already held by another contact (the contact is still created and linked —
+ * only the email copy is rejected).
  */
 export async function ensureContactForParticipant(
   organizationId: string,
@@ -96,7 +102,10 @@ export async function ensureContactForParticipant(
 
   // Copy the visitor's claimed name/email + last-known geo from the source chat
   // thread onto the freshly created contact. Best-effort — the contact is
-  // already created/linked, so a copy failure must never fail the promotion.
+  // already created/linked, so a copy failure must never fail the promotion —
+  // EXCEPT a `UniqueValueConflictError` on the claimed email, which is rethrown
+  // so the clicking user learns the email belongs to another contact instead of
+  // the promote silently landing without it.
   if (options.sourceThreadId) {
     await copyChatAttributesToContact(
       ingestCtx,
@@ -112,7 +121,14 @@ export async function ensureContactForParticipant(
 /**
  * Project a chat thread's claimed identity + last-known geo onto a contact.
  * Reuses the same `resolveChatAttributes` mapping the JWT path uses (name-split
- * into first/last, geo passthrough). Best-effort: logs and swallows on failure.
+ * into first/last, geo passthrough). Best-effort: logs and swallows on failure —
+ * with one exception: a `UniqueValueConflictError` on the claimed email is
+ * rethrown so the caller can surface it to the clicking user.
+ *
+ * The claimed email is written separately from the other attributes, and on a
+ * multi-value `primary_email` field it APPENDS (`mode: 'add'`) — the promote
+ * target may be an existing contact, and a whole-value set would replace its
+ * alias list.
  */
 async function copyChatAttributesToContact(
   ingestCtx: IngestContext,
@@ -120,6 +136,8 @@ async function copyChatAttributesToContact(
   sourceThreadId: string,
   entityInstanceId: string
 ): Promise<void> {
+  let claimedEmail: string | null = null
+  const attrs: Record<string, unknown> = {}
   try {
     const meta = await getChatThreadMetadata(serviceCtx, sourceThreadId)
     if (!meta) return
@@ -134,19 +152,18 @@ async function copyChatAttributesToContact(
       },
     })
 
-    const attrs: Record<string, unknown> = {
-      ...writes, // { first_name?, last_name?, city?, region?, country?, timezone? }
-      ...(meta.claimedVisitorEmail ? { primary_email: meta.claimedVisitorEmail } : {}),
-    }
+    // { first_name?, last_name?, city?, region?, country?, timezone? }
+    Object.assign(attrs, writes)
+    claimedEmail = meta.claimedVisitorEmail || null
 
     // Drop empties so we never overwrite with blank values.
     for (const [key, value] of Object.entries(attrs)) {
       if (value == null || value === '') delete attrs[key]
     }
 
-    if (Object.keys(attrs).length === 0) return
-
-    await ingestCtx.crudHandler.update(toRecordId('contact', entityInstanceId), attrs)
+    if (Object.keys(attrs).length > 0) {
+      await ingestCtx.crudHandler.update(toRecordId('contact', entityInstanceId), attrs)
+    }
   } catch (err) {
     logger.warn('Failed to copy chat attributes to new contact', {
       sourceThreadId,
@@ -154,4 +171,41 @@ async function copyChatAttributesToContact(
       error: err instanceof Error ? err.message : String(err),
     })
   }
+
+  if (!claimedEmail) return
+  try {
+    const recordId = toRecordId('contact', entityInstanceId)
+    if (await isContactEmailMulti(serviceCtx.organizationId)) {
+      // Append — never replace the contact's alias list.
+      await ingestCtx.crudHandler.update(
+        recordId,
+        { primary_email: [claimedEmail] },
+        { primary_email: 'add' }
+      )
+    } else {
+      await ingestCtx.crudHandler.update(recordId, { primary_email: claimedEmail })
+    }
+  } catch (err) {
+    // Surface uniqueness conflicts (the email belongs to another contact) —
+    // silently promoting with no email hides a real, actionable problem.
+    if (err instanceof UniqueValueConflictError) throw err
+    logger.warn('Failed to copy claimed visitor email to new contact', {
+      sourceThreadId,
+      entityInstanceId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+/** Whether the org's contact `primary_email` field is flagged multi-value (`options.multi`). */
+async function isContactEmailMulti(organizationId: string): Promise<boolean> {
+  const contactDefId = await getCachedEntityDefId(organizationId, 'contact')
+  if (!contactDefId) return false
+  const fields = await getCachedCustomFields(organizationId, contactDefId)
+  const field = fields.find((f) => f.systemAttribute === 'primary_email')
+  if (!field) return false
+  return isMultiValueFieldType(
+    toFieldType(field.type),
+    (field.options ?? undefined) as { multi?: boolean } | undefined
+  )
 }

--- a/packages/lib/src/record-rules/actions.test.ts
+++ b/packages/lib/src/record-rules/actions.test.ts
@@ -43,9 +43,14 @@ const h = vi.hoisted(() => {
       async () => 'user_system_1'
     ),
     sendNotification: vi.fn<(input: any) => Promise<void>>(async () => undefined),
-    crudUpdate: vi.fn<(recordId: string, data: Record<string, unknown>) => Promise<void>>(
-      async () => undefined
-    ),
+    crudUpdate: vi.fn<
+      (
+        recordId: string,
+        data: Record<string, unknown>,
+        modes?: Record<string, 'set' | 'add' | 'remove'>
+      ) => Promise<void>
+    >(async () => undefined),
+    getCachedCustomFields: vi.fn<(orgId: string, defId: string) => Promise<any[]>>(async () => []),
     resolveFieldTokens: vi.fn<(tokens: any[], ctx: any) => Promise<Map<string, any>>>(
       async () => new Map()
     ),
@@ -73,6 +78,7 @@ vi.mock('../users/system-user-service', () => ({
 vi.mock('../cache', () => ({
   getOrgCache: () => ({ get: vi.fn(async () => ({})) }),
   getUserCache: () => ({ get: vi.fn(async () => null) }),
+  getCachedCustomFields: (...args: [string, string]) => h.getCachedCustomFields(...args),
 }))
 vi.mock('../placeholders/resolver', () => ({
   resolveFieldTokens: h.resolveFieldTokens,
@@ -464,5 +470,64 @@ describe("executeRuleAction — 'set-field'", () => {
     )
     expect(result).toBe('skipped')
     expect(h.crudUpdate).not.toHaveBeenCalled()
+  })
+
+  // Multi-value awareness (multi-email plan B5): a scalar-multi field
+  // (options.multi) must never lose its stored list to an unintended append
+  // routing, and `mode: 'add'` must go through the append primitives.
+  it("routes mode 'add' to an append write when the target field is multi-value", async () => {
+    h.select.mockReset()
+    h.getCachedCustomFields.mockResolvedValueOnce([
+      {
+        id: 'fld_email',
+        systemAttribute: 'primary_email',
+        type: 'EMAIL',
+        options: { multi: true },
+      },
+    ])
+    const result = await executeRuleAction(
+      { type: 'set-field', fieldRef: 'primary_email', value: 'a@x.com', mode: 'add' },
+      rule(),
+      baseCtx,
+      null
+    )
+    expect(result).toBe('ok')
+    expect(h.crudUpdate).toHaveBeenCalledWith(
+      'def_contact:contact_1',
+      { primary_email: 'a@x.com' },
+      { primary_email: 'add' }
+    )
+  })
+
+  it("treats mode 'add' on a single-value field as a plain replace (never throws)", async () => {
+    h.select.mockReset()
+    h.getCachedCustomFields.mockResolvedValueOnce([
+      { id: 'fld_email', systemAttribute: 'primary_email', type: 'EMAIL', options: {} },
+    ])
+    const result = await executeRuleAction(
+      { type: 'set-field', fieldRef: 'primary_email', value: 'a@x.com', mode: 'add' },
+      rule(),
+      baseCtx,
+      null
+    )
+    expect(result).toBe('ok')
+    expect(h.crudUpdate).toHaveBeenCalledWith('def_contact:contact_1', {
+      primary_email: 'a@x.com',
+    })
+  })
+
+  it('defaults to replace without a field lookup when no mode is set', async () => {
+    h.select.mockReset()
+    const result = await executeRuleAction(
+      { type: 'set-field', fieldRef: 'primary_email', value: 'a@x.com' },
+      rule(),
+      baseCtx,
+      null
+    )
+    expect(result).toBe('ok')
+    expect(h.getCachedCustomFields).not.toHaveBeenCalled()
+    expect(h.crudUpdate).toHaveBeenCalledWith('def_contact:contact_1', {
+      primary_email: 'a@x.com',
+    })
   })
 })

--- a/packages/lib/src/record-rules/actions.ts
+++ b/packages/lib/src/record-rules/actions.ts
@@ -107,11 +107,36 @@ export async function executeRuleAction(
       ])
       const systemUserId = await SystemUserService.getSystemUserForActions(ctx.organizationId)
       const handler = new UnifiedCrudHandler(ctx.organizationId, systemUserId)
-      await handler.update(toRecordId(ctx.entityDefinitionId, ctx.entityInstanceId), {
-        // fieldRef may be a field row id OR a systemAttribute — the mutation-side
-        // field resolution accepts both.
-        [action.fieldRef]: value,
-      })
+      // Multi-value awareness: `mode: 'add'` appends instead of replacing the
+      // field's stored list, but ONLY when the target field really is multi —
+      // the append primitive throws on single-value fields. Default (`'set'`,
+      // and any 'add' on a single-value field) stays a whole-value replace.
+      let modes: Record<string, 'set' | 'add' | 'remove'> | undefined
+      if (action.mode === 'add') {
+        const { getCachedCustomFields } = await import('../cache')
+        const { isMultiValueFieldType } = await import('../field-values/formatter')
+        const { toFieldType } = await import('../field-values/stored-field-type')
+        const fields = await getCachedCustomFields(ctx.organizationId, ctx.entityDefinitionId)
+        const field = fields.find(
+          (f) => f.id === action.fieldRef || f.systemAttribute === action.fieldRef
+        )
+        if (
+          field &&
+          isMultiValueFieldType(
+            toFieldType(field.type),
+            (field.options ?? undefined) as { multi?: boolean } | undefined
+          )
+        ) {
+          modes = { [action.fieldRef]: 'add' }
+        }
+      }
+      const targetRecordId = toRecordId(ctx.entityDefinitionId, ctx.entityInstanceId)
+      // fieldRef may be a field row id OR a systemAttribute — the mutation-side
+      // field resolution accepts both.
+      const writeValues = { [action.fieldRef]: value }
+      await (modes
+        ? handler.update(targetRecordId, writeValues, modes)
+        : handler.update(targetRecordId, writeValues))
       return 'ok'
     }
 

--- a/packages/lib/src/record-rules/types.ts
+++ b/packages/lib/src/record-rules/types.ts
@@ -43,6 +43,14 @@ export interface SetFieldAction {
    * (string/number/…), written verbatim — hence `unknown` rather than `TiptapDoc | string`.
    */
   value: unknown
+  /**
+   * Write mode for MULTI-VALUE target fields (`options.multi`, MULTI_SELECT, TAGS, …).
+   * `'set'` (default) replaces the field's whole stored list with the resolved value;
+   * `'add'` appends without touching existing values. Ignored (treated as `'set'`) when
+   * the target field is single-value. No builder UI exposes this yet — rules default to
+   * replace, and the executor guards the append routing on the field actually being multi.
+   */
+  mode?: 'set' | 'add'
 }
 
 /** Enqueue a published workflow with the record snapshot as trigger payload. */


### PR DESCRIPTION
Multi-value email/phone/website rollout — B2 remainder + B5 writer sweep + B6 test slice, per `plans/custom-field/multi/04-multi-email-implementation-plan.md`. Every writer below did a whole-value set; each is now multi-safe (append where appending is the semantic, replace-only made explicit and guarded everywhere else).

## B2 remainder

- **Chat participant promote** (`packages/lib/src/participants/participant-queries.ts`): the claimed-visitor-email copy now writes the email separately from name/geo attrs. On a multi `primary_email` field it APPENDS (`crudHandler.update` with `mode: 'add'`) — never replaces the alias list; pre-flip single fields keep today's set. A `UniqueValueConflictError` on the email is rethrown (the participant router already rethrows `AuxxError`s → 409 to the clicking user) instead of the old blanket `logger.warn` silently promoting with no email. Other copy failures stay best-effort.
- **Extension capture shape** (`apps/extension/src/iframe/routes/root/field-values.ts`): `primary_email` + `phone` are sent as single-element arrays (shape parity with the multi write path; server auto-unwraps length-1 on single fields). The extension has no update path — re-capture short-circuits into the matches list — so this is shape-only.
- **Extension conflict UX** (`apps/extension/src/iframe/routes/root-route.tsx`): a save failing with tRPC `CONFLICT`/409 now re-runs the dual-entity dedup lookup and routes into the existing "N similar found" list (popping the "Add anyway?" capture sub-view), never the raw `Save failed (CONFLICT)` string. Fallback when the lookup finds nothing (e.g. no read access): a friendly "already exists" message.

## B5 sweep (per the plan's writer table)

- **Kopilot `update_entity` / `bulk_update_entity`**: both tools expose an append decision — `update_entity` takes `modes: { <fieldId>: 'add' }`, `bulk_update_entity` takes `mode: 'replace' | 'add'` per values entry. Default replace. `'add'` is guarded on the field actually being multi (new `isMultiValueField` helper; the append primitive throws on single-value fields, so a model-guessed 'add' on a scalar degrades to replace). `bulk_update_entity` now routes through `FieldValueService.applyBulk` (mode-aware) instead of `setBulkValues`. `list_entity_fields` now emits `multi: true` per field so the model can discover which fields need the mode.
- **Record-rule `set-field` action**: optional `mode?: 'set' | 'add'` added to the action config (type + router zod — cheap), executor resolves the target field from the org cache and only routes `'add'` to the append path when the field is really multi; otherwise replace. Default (and everything existing) stays replace; no builder UI yet, documented on the type.
- **AI autofill — GATED off multi fields** (the simpler safe option, as the commit path is a whole-field replace): `isAiField` returns false for `options.multi` fields, which gates the whole pipeline (enqueue short-circuit, worker generation, reference resolver); `buildJsonSchema` throws `BadRequestError` as defense in depth. MULTI_SELECT (multi via TYPE, not `options.multi`) stays eligible.
- **Web bulk editor**: multi EMAIL/URL/PHONE(_INTL) fields are disabled in the bulk-edit field list with hint "Multi-value fields are edited per record" (new `getBulkEditFieldGate` helper beside the dialog; also carries the existing unique-field gate). Did not touch `use-save-field-value.ts`.
- **`apps/api` `set-values.ts`**: doc note only — replace-only is safe because only app-OWNED fields are reachable (the three seeded multi-capable fields are org-owned and never resolve through `resolveOwnedField`); pointed at `BulkValueItem.mode` as the future append hook. No schema change (a per-key mode would also touch the public SDK surface — not trivial).
- **Create-only writers**: verified create-safe and array-wrapped for shape — ingest `find-or-create.ts` (phone + the identifier in the `findOrCreate` create data; `findBy` stays scalar for the lookup), `find-or-create-from-jwt.ts` tier-3 create (`primary_email: [email]`; the RESERVED_CLAIMS/spread-order fix was already merged and is untouched), `ingest/companies/find-or-create.ts` (`company_website` wrapped; `company_domain` stays single by design).

## Follow-ups / notes for other lanes

- **`unified-handler.ts` `bulkSetFieldValue` (owned by another agent — not edited here):** it has no mode param and is a whole-value replace; notably it has **no live callers** (only README/blog references and a permissions test). Follow-up for the handler owner: either add a `mode?: 'set' | 'add' | 'remove'` pass-through or a replace-only doc comment (or delete it).
- **Alias appends fire "when email changes" automations** — an appended alias goes through the same field-change events as any email write, so every "when email changes" record rule/workflow fires. Correct by design (plan B5 note), called out here rather than suppressed.
- **Possible overlap with the lookup lane:** `ingest/contacts/find-or-create*.ts` may also be touched by the lookup-call migration; my diffs there are value-shape only (array wraps + comments) as instructed.

## Tests (B6 slice)

- `participants/__tests__/participant-queries.test.ts` — claim appends on multi (mode add, no list replace), pre-flip set unchanged, conflict surfaces (rejects with `UniqueValueConflictError`), non-conflict failures stay best-effort, email still written when attr copy fails.
- `tools/__tests__/update-tools-multi-modes.test.ts` — both Kopilot tools honor `'add'` on multi fields, degrade `'add'` on single fields to replace, default replace; bulk tool reports all approved records updated on an all-append call.
- `record-rules/actions.test.ts` — set-field `mode: 'add'` routes to append only when the field is multi; no mode ⇒ replace with zero cache lookups.
- `ai-autofill/__tests__/multi-field-gate.test.ts` — `isAiField` multi gate (MULTI_SELECT unaffected) + `buildJsonSchema` throw.
- `bulk-edit-field-gate.test.ts` — multi EMAIL/URL/PHONE excluded with the per-record hint (multi TEXT not excluded; unique gate only >1 record).
- Updated: jwt create test (array-wrapped email), `bulk-update-entity-capabilities.test.ts` + `mail-lens-write-block.test.ts` (FieldValueService mock now `applyBulk`).

## Verification

- `pnpm exec biome check --write` clean on all changed files.
- Vitest: kopilot entities suite (11 files/142 tests), record-rules, participants, ingest, field-values, custom-fields slices all green.
- Typecheck: `packages/lib` (scoped, 8GB heap) clean; `apps/api` clean; `apps/extension` (`tsc --noEmit`) clean; `apps/web` scoped tsc — no errors in files touched by this PR.
