### PR TITLE
feat(connectors): row-level sink semantics for multi-value fields (B1)

### DIFF
--- a/apps/web/src/components/data-connectors/ui/merge-strategy-toggle.tsx
+++ b/apps/web/src/components/data-connectors/ui/merge-strategy-toggle.tsx
@@ -22,13 +22,15 @@ const MERGE_STRATEGIES: Array<{
     value: 'overwrite',
     label: 'Always update',
     variant: 'default',
-    description: 'Always replace the current value with the latest synced value.',
+    description:
+      'Always keep this field at the latest synced value. On a multi-value field only the synced value is updated — other values are kept.',
   },
   {
     value: 'fill_blank',
     label: 'Only if empty',
     variant: 'sky',
-    description: 'Only fill this in when the field is empty; never replace an existing value.',
+    description:
+      'Only fill this in when the field is empty; never replace an existing value. On a multi-value field, only when the list is empty.',
   },
   {
     value: 'connector_owned_only',

--- a/apps/web/src/components/dynamic-table/components/custom-field-cell.tsx
+++ b/apps/web/src/components/dynamic-table/components/custom-field-cell.tsx
@@ -114,7 +114,11 @@ export const CustomFieldCell = memo(function CustomFieldCell({
     <div className='relative h-full w-full'>
       {content}
       <div className='absolute top-0.5 right-0.5 z-10 opacity-60'>
-        <ConnectorLockBadge connectorId={managedConnectorId} mode='contributing' />
+        <ConnectorLockBadge
+          connectorId={managedConnectorId}
+          mode='contributing'
+          multi={(options as { multi?: boolean } | null | undefined)?.multi === true}
+        />
       </div>
     </div>
   )

--- a/apps/web/src/components/fields/connector-lock-badge.tsx
+++ b/apps/web/src/components/fields/connector-lock-badge.tsx
@@ -16,6 +16,12 @@ interface ConnectorLockBadgeProps {
    * overwritten on the next sync.
    */
   mode: 'owned' | 'contributing'
+  /**
+   * The field is multi-value (`options.multi`): the connector owns only its own
+   * row, so the contributing copy softens to "Some values synced by <connector>"
+   * (the badge stays cell-grained in v1 — no per-chip badges).
+   */
+  multi?: boolean
   className?: string
 }
 
@@ -30,7 +36,12 @@ interface ConnectorLockBadgeProps {
  * The connector name resolves from the org-scoped connector list (deduped).
  * Renders a generic label until the name loads / if it can't be resolved.
  */
-export function ConnectorLockBadge({ connectorId, mode, className }: ConnectorLockBadgeProps) {
+export function ConnectorLockBadge({
+  connectorId,
+  mode,
+  multi,
+  className,
+}: ConnectorLockBadgeProps) {
   const name = useConnectorName(connectorId)
   const who = name ?? 'a data connector'
 
@@ -38,7 +49,9 @@ export function ConnectorLockBadge({ connectorId, mode, className }: ConnectorLo
   const content =
     mode === 'owned'
       ? `Managed by ${who}`
-      : `Synced by ${who} — may be overwritten on the next sync`
+      : multi
+        ? `Some values synced by ${who} — other values are kept`
+        : `Synced by ${who} — may be overwritten on the next sync`
 
   return (
     <Tooltip content={content} side='top'>

--- a/apps/web/src/components/fields/property-row.tsx
+++ b/apps/web/src/components/fields/property-row.tsx
@@ -129,6 +129,7 @@ function PropertyRow({
                 <ConnectorLockBadge
                   connectorId={managedConnectorId}
                   mode='contributing'
+                  multi={(field.options as { multi?: boolean } | null | undefined)?.multi === true}
                   className='ms-1'
                 />
               )

--- a/packages/lib/src/data-connectors/map-record.test.ts
+++ b/packages/lib/src/data-connectors/map-record.test.ts
@@ -402,4 +402,50 @@ describe('mapRecord', () => {
     // entirely, never evaluated against the (irrelevant) source subtree.
     expect(writes[0]?.projected?.fields).toEqual({ 'def1:total': '49.99' })
   })
+
+  it('drops an array-shaped source value (no write) instead of evaluating it to null', () => {
+    // A provider `emails[]` field on a scalar mapping: the CALC evaluator would
+    // flatten it to null and the write path would CLEAR the target field. The
+    // guard turns it into a no-write — the key is absent from the projection.
+    const m = mapping({
+      fieldMappings: [
+        {
+          id: 'e1',
+          targetFieldRef: toResourceFieldId('def1', 'email'),
+          expression: '{emails}',
+          sourceFields: { emails: 'emails' },
+        },
+        {
+          id: 'e2',
+          targetFieldRef: toResourceFieldId('def1', 'name'),
+          expression: '{name}',
+          sourceFields: { name: 'name' },
+        },
+      ],
+    })
+
+    const writes = mapRecord([m], source({ emails: ['a@x.com', 'b@x.com'], name: 'Jane' }))
+
+    expect(writes[0]?.projected?.fields).toEqual({ 'def1:name': 'Jane' })
+    expect(writes[0]?.projected?.fields).not.toHaveProperty('def1:email')
+  })
+
+  it('drops the degenerate whole-subtree `{source}` binding when the subtree is an array', () => {
+    const m = mapping({
+      id: 'tags',
+      rootPath: 'meta',
+      fieldMappings: [
+        {
+          id: 'e1',
+          targetFieldRef: toResourceFieldId('def1', 'tags'),
+          expression: '{source}',
+          sourceFields: {},
+        },
+      ],
+    })
+
+    const writes = mapRecord([m], source({ meta: ['red', 'blue'] }))
+
+    expect(writes[0]?.projected?.fields).toEqual({})
+  })
 })

--- a/packages/lib/src/data-connectors/map-record.ts
+++ b/packages/lib/src/data-connectors/map-record.ts
@@ -7,12 +7,18 @@
 // linkMode (upsert writes / reference registers a pending relation on the parent)
 // and wires embedded relationships as pending relations on the parent's item.
 
+import { createScopedLogger } from '@auxx/logger'
 import { evaluateCalcExpression } from '@auxx/utils/calc-expression'
 import type { ConnectorRecord } from './connectors/types'
 import type { DecodedMapping } from './service'
 import type { ProjectedRecord } from './sinks/types'
 import type { FieldMapping } from './types'
 import { parseUpstreamUpdatedAt } from './watermark'
+
+const logger = createScopedLogger('data-connector-map-record')
+
+/** `mappingId:targetFieldRef` pairs already warned about an array-shaped source. */
+const warnedArraySources = new Set<string>()
 
 /** One mapping's projection result for a single source record. */
 export interface MappedWrite {
@@ -109,17 +115,62 @@ function evaluateFieldValue(fm: FieldMapping, subtree: unknown): unknown {
 }
 
 /**
+ * Whether any of a binding's resolved SOURCE values is array-shaped (a provider
+ * `emails[]` field mapped onto a scalar binding). Connectors cannot source arrays
+ * (B1): `extractValue` inside the CALC evaluator flattens them to `null`, which the
+ * write path would treat as "clear the field" — so an array-shaped source must
+ * become a NO-WRITE, never a destructive null. Mirrors `evaluateFieldValue`'s own
+ * placeholder resolution, including the degenerate whole-subtree `{source}` case.
+ */
+function hasArrayShapedSource(fm: FieldMapping, subtree: unknown): boolean {
+  const subtreeObj =
+    subtree && typeof subtree === 'object' ? (subtree as Record<string, unknown>) : null
+  const sourceFields = Object.entries(fm.sourceFields ?? {})
+  for (const [, sourcePath] of sourceFields) {
+    const v =
+      subtreeObj && !sourcePath.includes('.') && !sourcePath.includes('[')
+        ? subtreeObj[sourcePath]
+        : getByPath(subtree, sourcePath)
+    if (Array.isArray(v)) return true
+  }
+  return sourceFields.length === 0 && fm.expression.trim() === '{source}' && Array.isArray(subtree)
+}
+
+/**
  * Evaluate one mapping's CALC field expressions against a subtree, keyed by each
- * binding's `targetFieldRef`. Unassigned drafts (no target) are skipped.
+ * binding's `targetFieldRef`. Unassigned drafts (no target) are skipped. An
+ * array-shaped source value (or an array-shaped evaluation result) drops the key
+ * entirely — no write — with one warning per (mapping, field): multi-value
+ * SOURCING is out of scope, and the alternative is `null` clearing the target.
  */
 function evaluateFields(mapping: DecodedMapping, subtree: unknown): Record<string, unknown> {
+  const warnArraySkip = (targetFieldRef: string) => {
+    const warnKey = `${mapping.row.id}:${targetFieldRef}`
+    if (warnedArraySources.has(warnKey)) return
+    warnedArraySources.add(warnKey)
+    logger.warn('array-shaped source value on a scalar mapping — field skipped, not written', {
+      mappingId: mapping.row.id,
+      targetFieldRef,
+    })
+  }
+
   const out: Record<string, unknown> = {}
   for (const fm of mapping.fieldMappings) {
     if (fm.targetFieldRef == null) continue // unassigned draft — projected nowhere
     // connectionMetaKey bindings read connection metadata, not the source subtree —
     // the sink injects their value before the write set is built (entity-sink.ts).
     if (fm.connectionMetaKey != null) continue
-    out[fm.targetFieldRef] = evaluateFieldValue(fm, subtree)
+    if (hasArrayShapedSource(fm, subtree)) {
+      warnArraySkip(fm.targetFieldRef)
+      continue
+    }
+    const value = evaluateFieldValue(fm, subtree)
+    if (Array.isArray(value)) {
+      // Belt-and-braces: a CALC result that still comes back array-shaped.
+      warnArraySkip(fm.targetFieldRef)
+      continue
+    }
+    out[fm.targetFieldRef] = value
   }
   return out
 }

--- a/packages/lib/src/data-connectors/sinks/entity-sink-identity.test.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink-identity.test.ts
@@ -215,18 +215,19 @@ describe('entitySink identity write-ownership rule', () => {
   it('does not stamp contributing provenance on the identity field', async () => {
     // A mapping whose only written field is identity-flagged means
     // stampContributingProvenance's stampable-key list is empty — it returns
-    // before ever calling buildWriteKeyToFieldId (no false "synced by
-    // connector" badge over a value that may be chat-verified).
+    // before ever touching the DB (no false "synced by connector" badge over a
+    // value that may be chat-verified). The stamp is the only `db.update` in
+    // this flow, so a spied db proves it never fires.
     findItem.mockResolvedValue(null)
     create.mockResolvedValue({ instance: { id: 'inst1' } })
     const ctx = makeCtx()
+    const dbUpdate = vi.fn()
+    ctx.db = { update: dbUpdate } as never
 
     await entitySink.upsertRecord(ctx, mapping(), record())
 
-    // buildWriteKeyToFieldId is called once by mirrorIdentityWrites's sibling
-    // resolution path is getCachedFieldMap, not this — so any call here would
-    // only come from stampContributingProvenance, which must not fire.
-    expect(buildWriteKeyToFieldId).not.toHaveBeenCalled()
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(dbUpdate).not.toHaveBeenCalled()
   })
 
   it('excludes the identity ref from drift detection (drift-exempt)', async () => {

--- a/packages/lib/src/data-connectors/sinks/entity-sink-row-level.test.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink-row-level.test.ts
@@ -1,0 +1,480 @@
+// packages/lib/src/data-connectors/sinks/entity-sink-row-level.test.ts
+// B1 row-level semantics for multi-value (`options.multi`) target fields + the
+// B6 sink test slice: own-row in-place update (alias + primary intact), never
+// re-stamp a user-owned value, fill_blank only on an empty list, source null
+// never clears the list, drifted-forever regression (alias must not defeat the
+// content-hash skip), per-value uniqueness conflicts keep the sync green, an
+// array-shaped match candidate FAILS the record instead of creating a silent
+// duplicate, and in-slice two-source dedupe (first wins field writes, the
+// second still binds).
+
+import { toResourceFieldId } from '@auxx/types/field'
+import { stableHash } from '@auxx/utils/hash'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeSyncCtx } from '../__test-helpers'
+import type { DecodedMapping } from '../service'
+import type { ProjectedRecord, SyncCtx } from './types'
+
+const findItem = vi.fn()
+const findItemByDef = vi.fn()
+const touchItem = vi.fn()
+const upsertItem = vi.fn()
+vi.mock('../service', () => ({
+  findItem: (...a: unknown[]) => findItem(...a),
+  findItemByDef: (...a: unknown[]) => findItemByDef(...a),
+  touchItem: (...a: unknown[]) => touchItem(...a),
+  upsertItem: (...a: unknown[]) => upsertItem(...a),
+  listItemsForMapping: vi.fn(),
+  markItemArchived: vi.fn(),
+  setItemPendingRelations: vi.fn(),
+}))
+
+const resolveConnectorFieldRef = vi.fn()
+vi.mock('../../agents/bindings/resolve', () => ({
+  resolveConnectorFieldRef: (...a: unknown[]) => resolveConnectorFieldRef(...a),
+}))
+const buildWriteKeyToFieldId = vi.fn()
+vi.mock('../field-id-resolver', () => ({
+  buildWriteKeyToFieldId: (...a: unknown[]) => buildWriteKeyToFieldId(...a),
+}))
+
+const getCachedFieldMap = vi.fn()
+const getCachedResource = vi.fn()
+vi.mock('../../cache', () => ({
+  getCachedFieldMap: (...a: unknown[]) => getCachedFieldMap(...a),
+  getCachedResource: (...a: unknown[]) => getCachedResource(...a),
+}))
+
+vi.mock('../../identity', () => ({ upsertRecordIdentity: vi.fn() }))
+
+// Lazy-imported field-value helpers (row-level path only) — tiny stand-ins so the
+// real field-values graph never loads under the test collector.
+const maybeUpdateDisplayValue = vi.fn()
+const updateSearchText = vi.fn()
+vi.mock('../../field-values/field-value-helpers', () => ({
+  createFieldValueContext: vi.fn(() => ({})),
+  validateAndConvertValue: vi.fn(async (_ctx: unknown, value: unknown) => ({
+    type: 'text',
+    value: String(value).trim().toLowerCase(),
+  })),
+  maybeUpdateDisplayValue: (...a: unknown[]) => maybeUpdateDisplayValue(...a),
+}))
+vi.mock('../../field-values/field-value-mutations', () => ({
+  buildFieldValueRow: (params: {
+    organizationId: string
+    entityId: string
+    entityDefinitionId: string
+    fieldId: string
+    value: { value: string }
+    sortKey: string
+  }) => ({
+    organizationId: params.organizationId,
+    entityId: params.entityId,
+    entityDefinitionId: params.entityDefinitionId,
+    fieldId: params.fieldId,
+    sortKey: params.sortKey,
+    valueText: params.value.value,
+    valueNumber: null,
+    valueBoolean: null,
+    valueDate: null,
+    valueJson: null,
+    optionId: null,
+    relatedEntityId: null,
+    relatedEntityDefinitionId: null,
+    actorId: null,
+  }),
+}))
+vi.mock('../../field-values/search-text', () => ({
+  updateSearchText: (...a: unknown[]) => updateSearchText(...a),
+}))
+const checkUniqueValueTyped = vi.fn()
+vi.mock('../../custom-fields/check-unique-value-typed', () => ({
+  checkUniqueValueTyped: (...a: unknown[]) => checkUniqueValueTyped(...a),
+}))
+
+import { UniqueValueConflictError } from '../../errors'
+import { entitySink } from './entity-sink'
+
+const DEF_ID = 'def_contact'
+const EMAIL_KEY = 'primary_email'
+const EMAIL_UUID = 'field-email-uuid'
+const EMAIL_REF = toResourceFieldId(DEF_ID, EMAIL_KEY)
+
+function emailField(over: Record<string, unknown> = {}) {
+  return {
+    id: EMAIL_UUID,
+    type: 'EMAIL',
+    modelType: 'contact',
+    systemAttribute: EMAIL_KEY,
+    options: { multi: true },
+    isUnique: false,
+    ...over,
+  }
+}
+
+function mapping(over: Partial<DecodedMapping> = {}): DecodedMapping {
+  return {
+    row: { id: 'm1' },
+    rootPath: '',
+    linkMode: 'upsert',
+    targetMode: 'contributing',
+    entityDefinitionId: DEF_ID,
+    parentMappingId: null,
+    relationshipFieldKey: null,
+    orphanBehavior: 'ignore',
+    fieldMappings: [
+      {
+        id: 'fm1',
+        targetFieldRef: EMAIL_REF,
+        expression: '{email}',
+        sourceFields: { email: 'email' },
+        identityRole: { kind: 'match', normalize: 'email' },
+      },
+    ],
+    ...over,
+  } as unknown as DecodedMapping
+}
+
+function record(email: unknown, over: Partial<ProjectedRecord> = {}): ProjectedRecord {
+  return {
+    externalId: 'c1',
+    displayName: 'Jane',
+    fields: { [EMAIL_REF]: email },
+    identityCandidates: [{ targetFieldRef: EMAIL_REF, value: email, normalize: 'email' }],
+    pendingRelations: [],
+    ...over,
+  }
+}
+
+interface FvRow {
+  id: string
+  sortKey: string
+  valueText: string
+  managedByConnectorId: string | null
+}
+function row(id: string, sortKey: string, valueText: string, marker: string | null): FvRow {
+  return { id, sortKey, valueText, managedByConnectorId: marker }
+}
+
+/** Chainable db stub: FieldValue row reads + recorded `update().set()` calls. */
+function makeDb(rows: FvRow[] = []) {
+  const updateCalls: Array<Record<string, unknown>> = []
+  const selectDistinct = vi.fn()
+  const db = {
+    select: vi.fn(() => ({
+      from: () => ({ where: () => ({ orderBy: async () => rows }) }),
+    })),
+    selectDistinct,
+    update: vi.fn(() => ({
+      set: (vals: Record<string, unknown>) => ({
+        where: async () => {
+          updateCalls.push(vals)
+        },
+      }),
+    })),
+  }
+  return { db, updateCalls, selectDistinct }
+}
+
+const create = vi.fn()
+const update = vi.fn().mockResolvedValue(undefined)
+const getFieldValues = vi.fn()
+const lookupByField = vi.fn()
+
+function makeCtx(over: Partial<SyncCtx> = {}): SyncCtx {
+  return makeSyncCtx({
+    crud: { update, create, getFieldValues, lookupByField } as never,
+    ownedCrud: { update, create, getFieldValues, lookupByField } as never,
+    ...over,
+  })
+}
+
+/** The bound item every "existing instance" test starts from. */
+function boundItem(over: Record<string, unknown> = {}) {
+  return {
+    id: 'item1',
+    entityInstanceId: 'inst1',
+    contentHash: 'stale',
+    pendingRelations: [],
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  findItem.mockReset()
+  findItem.mockResolvedValue(null)
+  findItemByDef.mockReset()
+  findItemByDef.mockResolvedValue(null)
+  touchItem.mockReset()
+  upsertItem.mockReset()
+  update.mockReset()
+  update.mockResolvedValue(undefined)
+  create.mockReset()
+  create.mockResolvedValue({ instance: { id: 'created1' } })
+  getFieldValues.mockReset()
+  getFieldValues.mockResolvedValue(new Map())
+  lookupByField.mockReset()
+  lookupByField.mockResolvedValue({ items: [], hasMore: false })
+  resolveConnectorFieldRef.mockReset()
+  resolveConnectorFieldRef.mockImplementation(async (ref: string) =>
+    ref === EMAIL_REF ? EMAIL_REF : null
+  )
+  buildWriteKeyToFieldId.mockReset()
+  buildWriteKeyToFieldId.mockResolvedValue(
+    new Map([
+      [EMAIL_KEY, EMAIL_UUID],
+      [EMAIL_UUID, EMAIL_UUID],
+    ])
+  )
+  getCachedFieldMap.mockReset()
+  getCachedFieldMap.mockResolvedValue(new Map([[EMAIL_UUID, emailField()]]))
+  getCachedResource.mockReset()
+  getCachedResource.mockResolvedValue(null)
+  maybeUpdateDisplayValue.mockReset()
+  updateSearchText.mockReset()
+  checkUniqueValueTyped.mockReset()
+  checkUniqueValueTyped.mockResolvedValue(true)
+})
+
+describe('entitySink row-level multi-field writes (B1)', () => {
+  it('resync with a changed source email updates the connector row IN PLACE — alias + primary untouched', async () => {
+    findItem.mockResolvedValue(boundItem())
+    // Connector's row is primary; user alias sits behind it.
+    const { db, updateCalls } = makeDb([
+      row('r1', 'a0', 'old@x.com', 'dc1'),
+      row('r2', 'a1', 'alias@x.com', null),
+    ])
+    const ctx = makeCtx({ db: db as never })
+
+    await entitySink.upsertRecord(ctx, mapping(), record('new@x.com'))
+
+    // No whole-field set: the scalar write set stays empty…
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(update.mock.calls[0]?.[1]).toEqual({})
+    // …and the connector's own row is updated in place (sortKey untouched).
+    expect(updateCalls).toHaveLength(1)
+    expect(updateCalls[0]).toMatchObject({
+      valueText: 'new@x.com',
+      managedByConnectorId: 'dc1',
+    })
+    expect(updateCalls[0]!.sortKey).toBeUndefined()
+    // Primary row changed → display columns follow.
+    expect(maybeUpdateDisplayValue).toHaveBeenCalledTimes(1)
+    expect(ctx.counters.failed).toBe(0)
+    expect(upsertItem).toHaveBeenCalledTimes(1)
+  })
+
+  it('updating a NON-primary own row refreshes search text, not the display columns', async () => {
+    findItem.mockResolvedValue(boundItem())
+    const { db, updateCalls } = makeDb([
+      row('r1', 'a0', 'primary@x.com', null),
+      row('r2', 'a1', 'old@x.com', 'dc1'),
+    ])
+    const ctx = makeCtx({ db: db as never })
+
+    await entitySink.upsertRecord(ctx, mapping(), record('new@x.com'))
+
+    expect(updateCalls[0]).toMatchObject({ valueText: 'new@x.com' })
+    expect(maybeUpdateDisplayValue).not.toHaveBeenCalled()
+    expect(updateSearchText).toHaveBeenCalledTimes(1)
+  })
+
+  it('never re-stamps a user-owned value: incoming value already present on an unmarked row → no write', async () => {
+    findItem.mockResolvedValue(boundItem())
+    const { db, updateCalls } = makeDb([
+      row('r1', 'a0', 'primary@x.com', null),
+      row('r2', 'a1', 'alias@x.com', null),
+    ])
+    const ctx = makeCtx({ db: db as never })
+
+    await entitySink.upsertRecord(ctx, mapping(), record('Alias@X.com')) // case-insensitive match
+
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(update.mock.calls[0]?.[1]).toEqual({})
+    expect(updateCalls).toHaveLength(0) // no row update, no stamp
+  })
+
+  it('appends at the end when the value is new and no connector row exists, stamping ONLY the new row', async () => {
+    findItem.mockResolvedValue(boundItem())
+    const { db, updateCalls } = makeDb([row('r1', 'a0', 'primary@x.com', null)])
+    const ctx = makeCtx({ db: db as never })
+
+    await entitySink.upsertRecord(ctx, mapping(), record('new@x.com'))
+
+    // Append rides the `add` multi-value primitive, never a whole-field set.
+    expect(update).toHaveBeenCalledTimes(2)
+    expect(update.mock.calls[1]?.[1]).toEqual({ [EMAIL_KEY]: ['new@x.com'] })
+    expect(update.mock.calls[1]?.[2]).toEqual({ [EMAIL_KEY]: 'add' })
+    // The stamp UPDATE touches only the marker.
+    expect(updateCalls).toHaveLength(1)
+    expect(updateCalls[0]).toEqual({ managedByConnectorId: 'dc1' })
+  })
+
+  it('fill_blank writes only when the list is empty', async () => {
+    const fillBlank = () =>
+      mapping({
+        fieldMappings: [
+          {
+            id: 'fm1',
+            targetFieldRef: EMAIL_REF,
+            expression: '{email}',
+            sourceFields: { email: 'email' },
+            mergeStrategy: 'fill_blank',
+          },
+        ],
+      } as never)
+
+    // Non-empty list → nothing happens.
+    findItem.mockResolvedValue(boundItem())
+    const nonEmpty = makeDb([row('r1', 'a0', 'primary@x.com', null)])
+    const ctx1 = makeCtx({ db: nonEmpty.db as never })
+    await entitySink.upsertRecord(ctx1, fillBlank(), record('new@x.com'))
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(update.mock.calls[0]?.[1]).toEqual({})
+    expect(nonEmpty.updateCalls).toHaveLength(0)
+
+    update.mockClear()
+
+    // Empty list → append + stamp.
+    const empty = makeDb([])
+    const ctx2 = makeCtx({ db: empty.db as never })
+    await entitySink.upsertRecord(ctx2, fillBlank(), record('new@x.com'))
+    expect(update).toHaveBeenCalledTimes(2)
+    expect(update.mock.calls[1]?.[1]).toEqual({ [EMAIL_KEY]: ['new@x.com'] })
+    expect(empty.updateCalls).toEqual([{ managedByConnectorId: 'dc1' }])
+  })
+
+  it('a source null does NOT clear the list (never write null/empty over a multi field)', async () => {
+    findItem.mockResolvedValue(boundItem())
+    const { db, updateCalls } = makeDb([
+      row('r1', 'a0', 'primary@x.com', null),
+      row('r2', 'a1', 'alias@x.com', 'dc1'),
+    ])
+    const ctx = makeCtx({ db: db as never })
+
+    await entitySink.upsertRecord(
+      ctx,
+      mapping(),
+      record(null, { identityCandidates: [] }) // present-but-null source key
+    )
+
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(update.mock.calls[0]?.[1]).toEqual({}) // key dropped — no null write
+    expect(updateCalls).toHaveLength(0)
+    expect(db.select).not.toHaveBeenCalled() // never even planned a row write
+  })
+
+  it('drifted-forever regression: a user alias on a multi overwrite field does not defeat the content-hash skip', async () => {
+    const rec = record('a@x.com')
+    findItem.mockResolvedValue(
+      boundItem({
+        contentHash: stableHash({ fields: rec.fields, displayName: rec.displayName }),
+      })
+    )
+    const { db, selectDistinct } = makeDb()
+    const ctx = makeCtx({ db: db as never })
+
+    await entitySink.upsertRecord(ctx, mapping(), rec)
+
+    // Multi fields are row-scoped OUT of drift detection → zero drift query,
+    // content-hash skip fires.
+    expect(selectDistinct).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+    expect(touchItem).toHaveBeenCalledTimes(1)
+    expect(ctx.counters.skipped).toBe(1)
+  })
+
+  it('per-value uniqueness pre-flight: a conflicting value is dropped, the sync stays green', async () => {
+    getCachedFieldMap.mockResolvedValue(new Map([[EMAIL_UUID, emailField({ isUnique: true })]]))
+    checkUniqueValueTyped.mockRejectedValue(new Error('Value already exists'))
+    findItem.mockResolvedValue(boundItem())
+    const { db, updateCalls } = makeDb([row('r1', 'a0', 'primary@x.com', null)])
+    const ctx = makeCtx({ db: db as never })
+
+    await entitySink.upsertRecord(ctx, mapping(), record('claimed@x.com'))
+
+    expect(update).toHaveBeenCalledTimes(1) // no append attempted
+    expect(updateCalls).toHaveLength(0)
+    expect(ctx.counters.failed).toBe(0)
+    expect(upsertItem).toHaveBeenCalledTimes(1) // record still binds + hashes
+  })
+
+  it('a UniqueValueConflictError from the write drops the value and retries — record never fails', async () => {
+    // Scalar (non-multi) field: the conflict surfaces from inside handler.update
+    // (A1's pre-hooks). First attempt throws, retry with the key dropped succeeds.
+    getCachedFieldMap.mockResolvedValue(new Map([[EMAIL_UUID, emailField({ options: {} })]]))
+    findItem.mockResolvedValue(boundItem())
+    update.mockRejectedValueOnce(
+      new UniqueValueConflictError({
+        message: 'Email already in use',
+        conflictingValue: 'claimed@x.com',
+        fieldId: EMAIL_UUID,
+      })
+    )
+    const { db } = makeDb()
+    const ctx = makeCtx({ db: db as never })
+
+    await entitySink.upsertRecord(ctx, mapping(), record('claimed@x.com'))
+
+    expect(update).toHaveBeenCalledTimes(2)
+    expect(update.mock.calls[0]?.[1]).toEqual({ [EMAIL_KEY]: 'claimed@x.com' })
+    expect(update.mock.calls[1]?.[1]).toEqual({}) // conflicting key dropped
+    expect(ctx.counters.failed).toBe(0)
+    expect(ctx.counters.updated).toBe(1)
+    expect(upsertItem).toHaveBeenCalledTimes(1)
+  })
+
+  it('array-shaped match candidate: record FAILS visibly — no silent duplicate create', async () => {
+    const { db } = makeDb()
+    const ctx = makeCtx({ db: db as never })
+
+    await entitySink.upsertRecord(ctx, mapping(), record(['a@x.com', 'b@x.com'] as never))
+
+    expect(create).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+    expect(upsertItem).not.toHaveBeenCalled()
+    expect(ctx.counters.failed).toBe(1)
+    expect(ctx.counters.errorSample[0]?.error).toMatch(/array-shaped/)
+  })
+
+  it('two source records matching two aliases of one contact: first wins field writes, second still binds', async () => {
+    // Neither record is bound; both match the same instance by (different) alias.
+    lookupByField.mockImplementation(async (params: { candidates: Array<{ value: string }> }) => ({
+      items: [
+        {
+          recordId: `${DEF_ID}:inst1`,
+          matchedBy: { fieldId: EMAIL_KEY, value: params.candidates[0]!.value },
+          displayName: 'Jane',
+          secondaryDisplayValue: null,
+          avatarUrl: null,
+        },
+      ],
+      hasMore: false,
+    }))
+    const { db, updateCalls } = makeDb([row('r1', 'a0', 'a@x.com', null)])
+    const ctx = makeCtx({ db: db as never })
+
+    const recA = record('a@x.com', { externalId: 'srcA' })
+    const recB = record('b@x.com', { externalId: 'srcB' })
+    await entitySink.upsertRecord(ctx, mapping(), recA)
+    await entitySink.upsertRecord(ctx, mapping(), recB)
+
+    // A won (match-by-alias no-op: matched row IS the value — nothing written).
+    // B lost the slice dedupe: field writes skipped entirely.
+    expect(update).toHaveBeenCalledTimes(1) // A's (empty) scalar write only
+    expect(updateCalls).toHaveLength(0)
+    expect(create).not.toHaveBeenCalled()
+    // BOTH bindings upserted onto the same instance.
+    expect(upsertItem).toHaveBeenCalledTimes(2)
+    expect(upsertItem.mock.calls[0]?.[1]).toMatchObject({
+      externalId: 'srcA',
+      entityInstanceId: 'inst1',
+    })
+    expect(upsertItem.mock.calls[1]?.[1]).toMatchObject({
+      externalId: 'srcB',
+      entityInstanceId: 'inst1',
+    })
+    expect(ctx.counters.skipped).toBe(1)
+    expect(ctx.counters.failed).toBe(0)
+  })
+})

--- a/packages/lib/src/data-connectors/sinks/entity-sink.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink.ts
@@ -16,6 +16,7 @@ import { stableHash } from '@auxx/utils/hash'
 import { and, eq, inArray, isNull, ne, or } from 'drizzle-orm'
 import { resolveConnectorFieldRef } from '../../agents/bindings/resolve'
 import { getCachedFieldMap } from '../../cache'
+import { UniqueValueConflictError } from '../../errors'
 import { upsertRecordIdentity } from '../../identity'
 import type { ManifestFieldChange } from '../../record-rules/sync-manifest-types'
 import { toRecordId } from '../../resources/resource-id'
@@ -32,6 +33,12 @@ import {
   upsertItem,
 } from '../service'
 import type { FieldMergeStrategy } from '../types'
+import {
+  executeRowLevelWrites,
+  planRowLevelWrites,
+  type RowLevelField,
+  type RowLevelWrite,
+} from './row-level-writes'
 import type { EntitySink, ProjectedRecord, SyncCtx } from './types'
 
 const logger = createScopedLogger('data-connector-entity-sink')
@@ -59,6 +66,40 @@ function rawOf(v: TypedFieldValue | TypedFieldValue[] | undefined): unknown {
 
 function isBlank(value: unknown): boolean {
   return value === undefined || value === null || value === ''
+}
+
+/**
+ * Remove the write-set entry carrying a unique-value conflict (B1 per-value
+ * tolerance). Prefers the error's `fieldId` when it names a write-set key, else
+ * scans values (case-insensitively — the hook lowercases before checking). For
+ * an array value only the offending element is removed. Returns the touched key,
+ * or null when nothing matched (the caller then fails the record as before).
+ */
+function dropConflictingKey(
+  writeSet: Record<string, unknown>,
+  error: UniqueValueConflictError
+): string | null {
+  const conflict = String(error.conflictingValue).trim().toLowerCase()
+  const matchesConflict = (v: unknown) => String(v).trim().toLowerCase() === conflict
+
+  if (error.fieldId && error.fieldId in writeSet) {
+    delete writeSet[error.fieldId]
+    return error.fieldId
+  }
+  for (const [key, value] of Object.entries(writeSet)) {
+    if (Array.isArray(value)) {
+      const remaining = value.filter((v) => !matchesConflict(v))
+      if (remaining.length === value.length) continue
+      if (remaining.length === 0) delete writeSet[key]
+      else writeSet[key] = remaining
+      return key
+    }
+    if (matchesConflict(value)) {
+      delete writeSet[key]
+      return key
+    }
+  }
+  return null
 }
 
 /**
@@ -139,15 +180,37 @@ async function resolveFieldRefs(
  * bindings → identityCandidates); each candidate's `targetFieldRef` is resolved
  * to a concrete field id via `refToConcrete`, then keyed by `fieldId` so
  * `lookupByField` matches connector-provisioned fields (systemAttribute null).
+ *
+ * Array-shaped candidate values are DROPPED with a warning (never stringified —
+ * `'a@x,b@x'` can only miss and mint a duplicate). If every configured candidate
+ * was dropped that way, `failed: true` tells the caller to FAIL the record
+ * instead of falling through to create: a visible failure beats a silent
+ * duplicate. `matched` echoes `lookupByField`'s `matchedBy` — which candidate
+ * (field + normalized value) hit — so the write path knows the matched row IS
+ * the incoming value (the match-by-alias natural no-op, B1).
  */
 async function resolveIdentity(
   ctx: SyncCtx,
   mapping: DecodedMapping,
   record: ProjectedRecord,
   refToConcrete: Map<string, ResourceFieldId>
-): Promise<{ instanceId: string | null }> {
+): Promise<{
+  instanceId: string | null
+  matched?: { fieldId?: FieldId; value: unknown }
+  failed?: boolean
+}> {
+  let droppedArrayCandidate = false
   const candidates = record.identityCandidates
     .map((c) => {
+      if (Array.isArray(c.value)) {
+        droppedArrayCandidate = true
+        logger.warn('array-shaped identity match candidate — dropped, never stringified', {
+          mappingId: mapping.row.id,
+          externalId: record.externalId,
+          targetFieldRef: c.targetFieldRef,
+        })
+        return null
+      }
       if (isBlank(c.value)) return null
       const concrete = refToConcrete.get(c.targetFieldRef)
       if (!concrete) return null
@@ -155,7 +218,13 @@ async function resolveIdentity(
     })
     .filter((c): c is { fieldId: FieldId; value: string } => c !== null)
 
-  if (candidates.length === 0) return { instanceId: null } // external-id only → create
+  if (candidates.length === 0) {
+    // All configured match keys degraded to unusable array values → FAIL the
+    // record rather than create a duplicate. External-id-only records (no match
+    // keys at all) keep falling through to create.
+    if (droppedArrayCandidate) return { instanceId: null, failed: true }
+    return { instanceId: null } // external-id only → create
+  }
 
   const { items } = await ctx.crud.lookupByField({
     entityDefinitionId: mapping.entityDefinitionId,
@@ -171,24 +240,32 @@ async function resolveIdentity(
     })
   }
   // recordId is `entityDefId:instanceId`.
-  const recordId = items[0]!.recordId
-  const instanceId = recordId.split(':').slice(1).join(':')
-  return { instanceId }
+  const match = items[0]!
+  const instanceId = match.recordId.split(':').slice(1).join(':')
+  return { instanceId, matched: { fieldId: match.matchedBy.fieldId, value: match.matchedBy.value } }
 }
 
 /**
  * Build the write set from a projected record, applying each field's merge
  * strategy against the current target value. Contributing mode narrows to the
  * mapping's managed (mapped) fields; owned mode writes everything mapped.
+ *
+ * Multi-value (`options.multi`) target fields on an EXISTING instance are
+ * diverted out of the whole-field write set into `rowWrites` — the row-level
+ * own-row-upsert path (B1; see `row-level-writes.ts`). A whole-field `set`
+ * would wipe every row's connector marker and regenerate all sortKeys. On a
+ * CREATE they stay in the write set (a fresh instance has no rows to protect).
  */
 async function buildWriteSet(
   ctx: SyncCtx,
   mapping: DecodedMapping,
   record: ProjectedRecord,
   existingInstanceId: string | null,
-  refToConcrete: Map<string, ResourceFieldId>
+  refToConcrete: Map<string, ResourceFieldId>,
+  matched?: { fieldId?: FieldId; value: unknown }
 ): Promise<{
   writeSet: Record<string, unknown>
+  rowWrites: RowLevelWrite[]
   managedFields: string[]
   identityFieldKeys: string[]
 }> {
@@ -221,6 +298,23 @@ async function buildWriteSet(
   const strategyFor = (key: string): FieldMergeStrategy =>
     identityRefs.has(key) ? 'fill_blank' : (mergeByKey.get(key) ?? 'overwrite')
 
+  // Multi-value fields diverted to the row-level path (existing instances only).
+  const rowWrites: RowLevelWrite[] = []
+
+  // Field metadata: multi-detection + the fill_blank key-space fix. Write-set
+  // keys may be systemAttributes while `getFieldValues` / `FieldValue.fieldId`
+  // key by the CustomField uuid — resolve through the shared write-key map, or a
+  // missed lookup silently turns `fill_blank` into `overwrite`.
+  let keyToId: Map<string, string> | null = null
+  let fieldMap: Map<string, RowLevelField> | null = null
+  if (managedFields.length > 0) {
+    keyToId = await buildWriteKeyToFieldId(ctx.orgId, mapping.entityDefinitionId)
+    fieldMap = (await getCachedFieldMap(ctx.orgId, mapping.entityDefinitionId)) as unknown as Map<
+      string,
+      RowLevelField
+    >
+  }
+
   // Read current values once (only needed for fill_blank / connector_owned_only).
   const needsCurrent = managedFields.some((k) => {
     const strat = strategyFor(k)
@@ -241,6 +335,47 @@ async function buildWriteSet(
     const fieldId = getFieldId(concrete)
     if (identityRefs.has(rawRef)) identityFieldKeys.push(fieldId)
 
+    const fieldUuid = keyToId?.get(fieldId)
+    const fieldRow = fieldUuid ? fieldMap?.get(fieldUuid) : undefined
+    const isMulti =
+      !identityRefs.has(rawRef) &&
+      (fieldRow?.options as { multi?: boolean } | null | undefined)?.multi === true
+
+    if (isMulti && strategy !== 'manual_review') {
+      // Never write null/empty over a multi field: a source key present-but-null
+      // must not clear the row list (B1). Arrays can't be sourced — belt-and-braces
+      // for the map-record guard.
+      if (isBlank(value)) continue
+      if (Array.isArray(value)) {
+        logger.warn('array-shaped value reached a multi field — skipped', {
+          mappingId: mapping.row.id,
+          externalId: record.externalId,
+          field: rawRef,
+        })
+        continue
+      }
+      if (!existingInstanceId) {
+        // Fresh instance: no rows to protect — plain write (becomes the one row).
+        writeSet[fieldId] = value
+        continue
+      }
+      // Row-level own-row upsert for overwrite / connector_owned_only / fill_blank.
+      // Row-marker ownership subsumes the per-field managedFields check.
+      const candidate = record.identityCandidates.find((c) => c.targetFieldRef === rawRef)
+      const knownPresent =
+        matched?.fieldId === fieldId &&
+        normalizeMatch(value, candidate?.normalize) === String(matched.value)
+      rowWrites.push({
+        writeKey: fieldId,
+        fieldUuid: fieldUuid!,
+        field: fieldRow as RowLevelField,
+        value,
+        strategy,
+        knownPresent,
+      })
+      continue
+    }
+
     if (strategy === 'overwrite') {
       writeSet[fieldId] = value
       continue
@@ -253,7 +388,7 @@ async function buildWriteSet(
       continue
     }
     if (strategy === 'fill_blank') {
-      const cur = current ? rawOf(current.get(fieldId)) : undefined
+      const cur = current ? rawOf(current.get(fieldUuid ?? fieldId)) : undefined
       if (isBlank(cur)) writeSet[fieldId] = value
       continue
     }
@@ -267,7 +402,7 @@ async function buildWriteSet(
     }
   }
 
-  return { writeSet, managedFields, identityFieldKeys }
+  return { writeSet, rowWrites, managedFields, identityFieldKeys }
 }
 
 /**
@@ -281,6 +416,12 @@ async function buildWriteSet(
  * systemAttribute). `FieldValue.fieldId` is always the CustomField uuid, so we
  * resolve systemAttribute keys back to their uuid via the cached field map before
  * the batched UPDATE. One UPDATE per upserted contributing record (cold path).
+ *
+ * ROW-ACCURACY: the UPDATE is keyed on `(org, entity, fieldId)` — every row of
+ * the field. That is exact for scalar fields (one row) and for multi fields on a
+ * CREATE (every row on a fresh instance is the connector's). Multi fields on an
+ * UPDATE never reach here: they divert to the row-level path, which stamps only
+ * the specific row it wrote (`row-level-writes.ts`).
  */
 async function stampContributingProvenance(
   ctx: SyncCtx,
@@ -411,12 +552,23 @@ async function computeDriftedInstances(
   // (refs may be the late-bound `@app:` form; system fields key by systemAttribute).
   const connectionId = ctx.connector.credentialId ?? undefined
   const keyToId = await buildWriteKeyToFieldId(ctx.orgId, mapping.entityDefinitionId)
+  const fieldMap = await getCachedFieldMap(ctx.orgId, mapping.entityDefinitionId)
   const fieldIds = new Set<string>()
   for (const ref of overwriteRefs) {
     const concrete = await resolveConnectorFieldRef(ref, ctx.orgId, connectionId)
     if (!concrete) continue
     const uuid = keyToId.get(getFieldId(concrete))
-    if (uuid) fieldIds.add(uuid)
+    if (!uuid) continue
+    // Multi-value (`options.multi`) fields are ROW-SCOPED out of drift detection:
+    // under row-level semantics, unmarked/foreign rows are legitimate (user
+    // aliases, other connectors' rows), so a null-or-foreign marker no longer
+    // signals a hand-edit. Without this, a single user alias makes every bound
+    // record permanently "drifted" and the content-hash skip never fires again.
+    // A user edit of the connector's own row is respected (never re-asserted)
+    // until the SOURCE value changes — consistent with never-touch-other-rows.
+    const field = fieldMap.get(uuid)
+    if ((field?.options as { multi?: boolean } | null | undefined)?.multi === true) continue
+    fieldIds.add(uuid)
   }
   if (fieldIds.size === 0) return new Set()
 
@@ -580,9 +732,38 @@ export const entitySink: EntitySink = {
       )
       instanceId = shared?.entityInstanceId ?? null
     }
+    let matched: { fieldId?: FieldId; value: unknown } | undefined
     if (!instanceId) {
       const resolved = await resolveIdentity(ctx, mapping, record, refToConcrete)
+      if (resolved.failed) {
+        // Every configured match candidate was array-shaped — fail the record
+        // VISIBLY instead of falling through to create a silent duplicate.
+        ctx.counters.failed += 1
+        if (ctx.counters.errorSample.length < 50) {
+          ctx.counters.errorSample.push({
+            externalId: record.externalId,
+            error: 'identity match candidates were array-shaped — record failed, not created',
+            tier: 'invalid',
+          })
+        }
+        return
+      }
       instanceId = resolved.instanceId
+      matched = resolved.matched
+    }
+
+    // 1c. In-slice two-source dedupe (B1, locked): the FIRST source record that
+    //     binds an instance this slice wins its field writes; a later one still
+    //     upserts its DataConnectorItem binding but logs + skips the field writes
+    //     (`managedByConnectorId` cannot tell two bindings of one connector apart,
+    //     so both writing would flip-flop the connector-owned row every run).
+    let lostSliceDedupe = false
+    if (instanceId) {
+      const winners = (ctx.sliceWriteWinners ??= new Map())
+      const winnerKey = `${mapping.row.id}::${instanceId}`
+      const winner = winners.get(winnerKey)
+      if (winner === undefined) winners.set(winnerKey, record.externalId)
+      else if (winner !== record.externalId) lostSliceDedupe = true
     }
 
     // 2. Content hash — skip unchanged + already bound, UNLESS an overwrite cell
@@ -622,14 +803,58 @@ export const entitySink: EntitySink = {
       }
     }
 
-    // 3. Build the write set with per-field merge strategy.
-    const { writeSet, managedFields, identityFieldKeys } = await buildWriteSet(
+    // 2b. Slice-dedupe loser: keep the binding current, skip all field writes.
+    if (lostSliceDedupe && instanceId) {
+      logger.warn(
+        'two source records resolved to one instance in this slice — field writes skipped (first wins)',
+        {
+          mappingId: mapping.row.id,
+          externalId: record.externalId,
+          instanceId,
+          winnerExternalId: ctx.sliceWriteWinners?.get(`${mapping.row.id}::${instanceId}`),
+        }
+      )
+      ctx.counters.skipped += 1
+      await upsertItem(ctx.db, {
+        dataConnectorId: ctx.connector.id,
+        organizationId: ctx.orgId,
+        mappingId: mapping.row.id,
+        externalId: record.externalId,
+        entityDefinitionId: mapping.entityDefinitionId,
+        entityInstanceId: instanceId,
+        contentHash,
+        managedFields: bound?.managedFields ?? [],
+        pendingRelations: mergePending(
+          bound?.pendingRelations ?? [],
+          record.pendingRelations,
+          new Set(bound?.linkedRelations ?? [])
+        ),
+        upstreamUpdatedAt: record.upstreamUpdatedAt ?? null,
+        lastSeenRunId: ctx.runId,
+        mintedInstance: false,
+      })
+      return
+    }
+
+    // 3. Build the write set with per-field merge strategy. Multi fields on an
+    //    existing instance divert to `rowWrites` (row-level own-row upserts).
+    const { writeSet, rowWrites, managedFields, identityFieldKeys } = await buildWriteSet(
       ctx,
       mapping,
       record,
       instanceId,
-      refToConcrete
+      refToConcrete,
+      matched
     )
+
+    // 3b. Plan the row-level writes BEFORE capture/write: the plan's projected
+    //     arrays feed the manifest capture (record rules must see the resulting
+    //     LIST as `n`, not the scalar source value), and its reads must be
+    //     pre-write anyway.
+    const rowPlan =
+      instanceId && rowWrites.length > 0
+        ? await planRowLevelWrites(ctx, mapping.entityDefinitionId, instanceId, rowWrites)
+        : { actions: [], captureSet: {} }
 
     // 4. Write — owned uses the bypass handler; contributing uses the standard
     //    handler and leaves the row pair alone. `justCreated` marks a minted
@@ -639,81 +864,129 @@ export const entitySink: EntitySink = {
     //    (replaces the retired `EntityInstance.integrationSource` stamp).
     const handler = mapping.targetMode === 'owned' ? ctx.ownedCrud : ctx.crud
     let justCreated = false
-    try {
-      if (instanceId) {
-        const recordId = toRecordId(mapping.entityDefinitionId, instanceId)
-        // B2: read pre-write old values for subscribed fields BEFORE the write.
-        //
-        // KNOWN NON-ATOMICITY (F10): capture-read → write → recordChange are three
-        // unlocked steps. A concurrent interactive edit (or sibling stream slice) on
-        // the same subscribed field in that window can yield a manifest transition
-        // that never happened as written. Tolerated: it needs same-field overlap
-        // during an in-flight sync AND an old-value-conditioned rule; fixing it means
-        // pushing capture inside the write's transaction (or RETURNING the prior
-        // value from the write itself).
-        //
-        // KNOWN N+1 (F9): one pre-read per updated record that writes a subscribed
-        // field. Records stream one at a time and the instanceId only exists after
-        // per-record identity resolution, so there is no slice-level id list to batch
-        // against — and the content-hash skip above means only genuinely changed
-        // records pay it.
-        const captured = ctx.manifest?.enabled
-          ? await captureSubscribedChanges(ctx, mapping.entityDefinitionId, instanceId, writeSet)
-          : null
-        await handler.update(recordId, writeSet, undefined, {
-          skipEvents: true,
-        })
-        ctx.counters.updated += 1
-        if (captured) ctx.manifest.recordChange(recordId, captured)
-      } else {
-        const created = await handler.create(mapping.entityDefinitionId, writeSet, {
-          skipEvents: true,
-        })
-        instanceId = created.instance.id
-        justCreated = true
-        ctx.counters.created += 1
-        // B2: lifecycle-created + `set`-transition capture for synced creates.
-        if (ctx.manifest?.enabled) {
+    // Per-value uniqueness tolerance (B1): a `UniqueValueConflictError` thrown from
+    // inside the write (A1's pre-hooks / unique-field validation) fails ONE value,
+    // not the record — drop the conflicting key from the write set and retry, so
+    // the sync stays green instead of the whole record retrying forever.
+    const maxConflictDrops = Object.keys(writeSet).length
+    for (let conflictDrops = 0; ; ) {
+      try {
+        if (instanceId) {
           const recordId = toRecordId(mapping.entityDefinitionId, instanceId)
-          const subs = ctx.manifest.subscriptionsFor(mapping.entityDefinitionId)
-          if (subs) {
-            if (subs.lifecycle.created) {
-              // Thread the raw created values so native entity-trigger lifecycle handlers
-              // (e.g. enrichCompanyOnCreate) can read them on the sync door without a DB
-              // refetch (Phase 9 / Option A). No DB read — writeSet is already in hand.
-              const createdValues = await buildCreatedValues(
+          // B2: read pre-write old values for subscribed fields BEFORE the write.
+          // Row-level fields contribute their PROJECTED resulting array (not the
+          // scalar source value) so `{o, n}` describes the post-write list.
+          //
+          // KNOWN NON-ATOMICITY (F10): capture-read → write → recordChange are three
+          // unlocked steps. A concurrent interactive edit (or sibling stream slice) on
+          // the same subscribed field in that window can yield a manifest transition
+          // that never happened as written. Tolerated: it needs same-field overlap
+          // during an in-flight sync AND an old-value-conditioned rule; fixing it means
+          // pushing capture inside the write's transaction (or RETURNING the prior
+          // value from the write itself).
+          //
+          // KNOWN N+1 (F9): one pre-read per updated record that writes a subscribed
+          // field. Records stream one at a time and the instanceId only exists after
+          // per-record identity resolution, so there is no slice-level id list to batch
+          // against — and the content-hash skip above means only genuinely changed
+          // records pay it.
+          const captured = ctx.manifest?.enabled
+            ? await captureSubscribedChanges(ctx, mapping.entityDefinitionId, instanceId, {
+                ...writeSet,
+                ...rowPlan.captureSet,
+              })
+            : null
+          // Shallow copy per attempt: a conflict retry mutates `writeSet`.
+          await handler.update(recordId, { ...writeSet }, undefined, {
+            skipEvents: true,
+          })
+          ctx.counters.updated += 1
+          if (captured) ctx.manifest.recordChange(recordId, captured)
+        } else {
+          const created = await handler.create(
+            mapping.entityDefinitionId,
+            { ...writeSet },
+            { skipEvents: true }
+          )
+          instanceId = created.instance.id
+          justCreated = true
+          ctx.counters.created += 1
+          // Claim the fresh instance for this slice's two-source dedupe so a later
+          // source record matching it (e.g. by alias) defers its field writes.
+          ;(ctx.sliceWriteWinners ??= new Map()).set(
+            `${mapping.row.id}::${instanceId}`,
+            record.externalId
+          )
+          // B2: lifecycle-created + `set`-transition capture for synced creates.
+          if (ctx.manifest?.enabled) {
+            const recordId = toRecordId(mapping.entityDefinitionId, instanceId)
+            const subs = ctx.manifest.subscriptionsFor(mapping.entityDefinitionId)
+            if (subs) {
+              if (subs.lifecycle.created) {
+                // Thread the raw created values so native entity-trigger lifecycle handlers
+                // (e.g. enrichCompanyOnCreate) can read them on the sync door without a DB
+                // refetch (Phase 9 / Option A). No DB read — writeSet is already in hand.
+                const createdValues = await buildCreatedValues(
+                  ctx,
+                  mapping.entityDefinitionId,
+                  writeSet
+                )
+                ctx.manifest.recordCreated(recordId, createdValues ?? undefined)
+              }
+              const entries = await buildCreateChangeEntries(
                 ctx,
                 mapping.entityDefinitionId,
-                writeSet
+                writeSet,
+                subs.fieldIds
               )
-              ctx.manifest.recordCreated(recordId, createdValues ?? undefined)
+              if (entries) ctx.manifest.recordChange(recordId, entries)
             }
-            const entries = await buildCreateChangeEntries(
-              ctx,
-              mapping.entityDefinitionId,
-              writeSet,
-              subs.fieldIds
-            )
-            if (entries) ctx.manifest.recordChange(recordId, entries)
           }
         }
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      ctx.counters.failed += 1
-      if (ctx.counters.errorSample.length < 50) {
-        ctx.counters.errorSample.push({
+        break
+      } catch (error) {
+        if (error instanceof UniqueValueConflictError && conflictDrops < maxConflictDrops) {
+          const droppedKey = dropConflictingKey(writeSet, error)
+          if (droppedKey) {
+            conflictDrops += 1
+            logger.warn('unique-value conflict — value dropped, record still syncs', {
+              mappingId: mapping.row.id,
+              externalId: record.externalId,
+              field: droppedKey,
+              conflictingValue: error.conflictingValue,
+            })
+            continue
+          }
+        }
+        const message = error instanceof Error ? error.message : String(error)
+        ctx.counters.failed += 1
+        if (ctx.counters.errorSample.length < 50) {
+          ctx.counters.errorSample.push({
+            externalId: record.externalId,
+            error: message,
+            tier: 'rejected', // the entity write itself failed
+          })
+        }
+        logger.warn('upsertRecord failed', {
+          mappingId: mapping.row.id,
           externalId: record.externalId,
           error: message,
-          tier: 'rejected', // the entity write itself failed
         })
+        return
       }
-      logger.warn('upsertRecord failed', {
-        mappingId: mapping.row.id,
-        externalId: record.externalId,
-        error: message,
-      })
-      return
+    }
+
+    // 4a. Execute the planned row-level writes (multi fields): in-place own-row
+    //     updates + end-appends, each stamping only its own row. Per-value
+    //     failures are logged inside — they never fail the record.
+    if (instanceId && rowPlan.actions.length > 0) {
+      await executeRowLevelWrites(
+        ctx,
+        mapping.entityDefinitionId,
+        handler,
+        instanceId,
+        rowPlan.actions
+      )
     }
 
     // 4b. Contributing mode — stamp per-cell provenance on the written values so

--- a/packages/lib/src/data-connectors/sinks/row-level-writes.ts
+++ b/packages/lib/src/data-connectors/sinks/row-level-writes.ts
@@ -1,0 +1,376 @@
+// packages/lib/src/data-connectors/sinks/row-level-writes.ts
+// Row-level write semantics for multi-value (`options.multi`) target fields (B1).
+//
+// A whole-field `set` is DELETE-all-then-INSERT: it wipes every row's
+// `managedByConnectorId` marker (other connectors' included) and regenerates all
+// sortKeys — so for a multi field the sink NEVER sets. Instead each strategy
+// becomes an own-row upsert against the connector's own marked row:
+//   • value already present (any row)      → no-op — and if that row is
+//     user/foreign-owned it is never re-stamped (match-by-alias stays user-owned);
+//   • my marked row exists, value changed  → update that row IN PLACE (sortKey
+//     stays → position stays → the primary stays stable);
+//   • no matching row, no marked row       → append at the END via the `add`
+//     multi-value primitive, then stamp only the appended row;
+//   • `fill_blank`                         → write only when the list is EMPTY.
+// Other rows are never touched and never deleted.
+//
+// Planning (reads + decisions) is split from execution so the caller can feed the
+// PROJECTED resulting array into the sync-change manifest capture BEFORE any write
+// (`{o, n}` must describe the post-write list, not the scalar source value).
+//
+// Field-value helpers are lazy-imported (same rule as the manifest capture in
+// entity-sink) so the sink's mocked unit tests never load that graph.
+
+import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { TypedFieldValueInput } from '@auxx/types'
+import { and, asc, eq, isNull } from 'drizzle-orm'
+import { UniqueValueConflictError } from '../../errors'
+import type { UnifiedCrudHandler } from '../../resources/crud/unified-handler'
+import { toRecordId } from '../../resources/resource-id'
+import type { SyncCtx } from './types'
+
+const logger = createScopedLogger('data-connector-row-level-writes')
+
+/** The typed value columns a FieldValue row stores its scalar in. */
+const VALUE_COLUMNS = [
+  'valueText',
+  'valueNumber',
+  'valueBoolean',
+  'valueDate',
+  'valueJson',
+  'optionId',
+  'relatedEntityId',
+  'actorId',
+] as const
+type ValueColumn = (typeof VALUE_COLUMNS)[number]
+
+type FieldValueInsert = typeof schema.FieldValue.$inferInsert
+type FieldValueRow = typeof schema.FieldValue.$inferSelect
+
+/** Minimal cached CustomField shape the row-level path needs. */
+export interface RowLevelField {
+  id: string
+  type: string
+  modelType: string
+  options?: unknown
+  isUnique?: boolean | null
+}
+
+/** One diverted multi-field write (built by the sink's `buildWriteSet`). */
+export interface RowLevelWrite {
+  /** Concrete write-set key (CustomField uuid OR systemAttribute) — what `handler.update` accepts. */
+  writeKey: string
+  /** The CustomField uuid `FieldValue.fieldId` carries. */
+  fieldUuid: string
+  /** Cached CustomField row (type / options / isUnique / modelType). */
+  field: RowLevelField
+  /** Raw scalar source value. Never null/blank/array — the sink guards before diverting. */
+  value: unknown
+  strategy: 'overwrite' | 'connector_owned_only' | 'fill_blank'
+  /**
+   * The identity lookup matched THIS value on THIS field (`matchedBy` threaded from
+   * `resolveIdentity`) — the matched row IS the incoming value, so the write is a
+   * natural no-op without even reading the rows.
+   */
+  knownPresent?: boolean
+}
+
+export type RowLevelAction =
+  | {
+      kind: 'update'
+      write: RowLevelWrite
+      rowId: string
+      /** The updated row is the field's FIRST row — display columns must follow. */
+      isPrimary: boolean
+      candidate: FieldValueInsert
+      typed: TypedFieldValueInput
+    }
+  | { kind: 'append'; write: RowLevelWrite; column: ValueColumn; flatValue: unknown }
+
+export interface RowLevelPlan {
+  actions: RowLevelAction[]
+  /**
+   * Projected post-write value per writeKey (the full resulting array) — feed this
+   * into the manifest capture so record rules on the field see sane `{o, n}` under
+   * row-level appends/updates. Only fields that will actually write appear.
+   */
+  captureSet: Record<string, unknown>
+}
+
+/** The single populated value column of a candidate insert row. */
+function valueColumnOf(candidate: FieldValueInsert): ValueColumn | null {
+  for (const col of VALUE_COLUMNS) {
+    if (candidate[col] !== null && candidate[col] !== undefined) return col
+  }
+  return null
+}
+
+/** Stored-space equality on one value column. EMAIL compares case-insensitively. */
+function valuesEqual(a: unknown, b: unknown, fieldType: string): boolean {
+  if (a === null || a === undefined || b === null || b === undefined) return a === b
+  if (fieldType === 'EMAIL')
+    return String(a).trim().toLowerCase() === String(b).trim().toLowerCase()
+  if (typeof a === 'object' || typeof b === 'object') return JSON.stringify(a) === JSON.stringify(b)
+  return a === b
+}
+
+/**
+ * Plan the row-level writes for one record: read the field's current rows, decide
+ * per field between no-op / in-place own-row update / append, run the per-value
+ * uniqueness pre-flight, and project the resulting array for manifest capture.
+ * Read-only — call BEFORE the record's write so `o` capture stays pre-write.
+ */
+export async function planRowLevelWrites(
+  ctx: SyncCtx,
+  entityDefinitionId: string,
+  instanceId: string,
+  writes: RowLevelWrite[]
+): Promise<RowLevelPlan> {
+  const actions: RowLevelAction[] = []
+  const captureSet: Record<string, unknown> = {}
+  if (writes.length === 0) return { actions, captureSet }
+
+  const { createFieldValueContext, validateAndConvertValue } = await import(
+    '../../field-values/field-value-helpers'
+  )
+  const { buildFieldValueRow } = await import('../../field-values/field-value-mutations')
+  const fvCtx = createFieldValueContext(ctx.orgId, undefined, ctx.db)
+
+  for (const w of writes) {
+    // Match-by-alias fast path: the identity lookup matched this exact value on
+    // this field, so a row with it already exists — natural no-op, never re-stamped.
+    if (w.knownPresent) continue
+
+    // Normalize through the write path's own validator so the comparison below is
+    // stored-space vs stored-space (email lowercased/trimmed, date → ISO, …).
+    let typed: TypedFieldValueInput | null = null
+    try {
+      const converted = await validateAndConvertValue(
+        fvCtx,
+        w.value,
+        w.field.type as never,
+        w.field as never
+      )
+      typed = Array.isArray(converted) ? (converted[0] ?? null) : converted
+    } catch (error) {
+      logger.warn('row-level value failed validation — dropped', {
+        connectorId: ctx.connector.id,
+        fieldId: w.fieldUuid,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      continue
+    }
+    if (!typed) continue
+
+    const candidate = buildFieldValueRow({
+      organizationId: ctx.orgId,
+      entityId: instanceId,
+      entityDefinitionId,
+      fieldId: w.fieldUuid,
+      value: typed,
+      sortKey: 'a0', // placeholder — never inserted; only the value columns are read
+    })
+    const column = valueColumnOf(candidate)
+    if (!column) continue
+
+    const rows = (await ctx.db
+      .select()
+      .from(schema.FieldValue)
+      .where(
+        and(
+          eq(schema.FieldValue.entityId, instanceId),
+          eq(schema.FieldValue.fieldId, w.fieldUuid),
+          eq(schema.FieldValue.organizationId, ctx.orgId)
+        )
+      )
+      .orderBy(asc(schema.FieldValue.sortKey))) as FieldValueRow[]
+
+    // fill_blank on a multi field: write only when the list is EMPTY.
+    if (w.strategy === 'fill_blank' && rows.length > 0) continue
+
+    const flatValue = candidate[column]
+    if (rows.some((row) => valuesEqual(row[column], flatValue, w.field.type))) {
+      // Value already present — user/foreign-owned rows are never re-stamped;
+      // the connector's own unchanged row needs nothing.
+      continue
+    }
+
+    const myRow = rows.find((row) => row.managedByConnectorId === ctx.connector.id)
+
+    // Per-value uniqueness pre-flight (B1): an org-wide conflict drops THIS value
+    // with a log — never the whole record — so the sync stays green.
+    if (w.field.isUnique) {
+      try {
+        const { checkUniqueValueTyped } = await import(
+          '../../custom-fields/check-unique-value-typed'
+        )
+        await checkUniqueValueTyped(
+          {
+            fieldId: w.fieldUuid,
+            value: typed,
+            organizationId: ctx.orgId,
+            modelType: w.field.modelType as never,
+            entityDefinitionId,
+            excludeEntityId: instanceId,
+          },
+          ctx.db
+        )
+      } catch (error) {
+        logger.warn('row-level value conflicts with another record — dropped, sync stays green', {
+          connectorId: ctx.connector.id,
+          fieldId: w.fieldUuid,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        continue
+      }
+    }
+
+    const flatRows = rows.map((row) => row[column])
+    if (myRow) {
+      const idx = rows.indexOf(myRow)
+      const projected = [...flatRows]
+      projected[idx] = flatValue
+      actions.push({
+        kind: 'update',
+        write: w,
+        rowId: myRow.id,
+        isPrimary: idx === 0,
+        candidate,
+        typed,
+      })
+      captureSet[w.writeKey] = projected
+    } else {
+      actions.push({ kind: 'append', write: w, column, flatValue })
+      captureSet[w.writeKey] = [...flatRows, flatValue]
+    }
+  }
+
+  return { actions, captureSet }
+}
+
+/**
+ * Execute a planned set of row-level writes. In-place updates go straight to the
+ * connector's own FieldValue row (sortKey untouched → primary stable) and keep the
+ * denormalized display/search columns in step; appends route through the standard
+ * handler's `add` mode (dedupe + hooks + cap) and then stamp ONLY the appended row.
+ * Failures are per-value: logged and skipped, never failing the record.
+ */
+export async function executeRowLevelWrites(
+  ctx: SyncCtx,
+  entityDefinitionId: string,
+  handler: UnifiedCrudHandler,
+  instanceId: string,
+  actions: RowLevelAction[]
+): Promise<void> {
+  if (actions.length === 0) return
+  const recordId = toRecordId(entityDefinitionId, instanceId)
+
+  for (const action of actions) {
+    if (action.kind === 'update') {
+      const { candidate } = action
+      await ctx.db
+        .update(schema.FieldValue)
+        .set({
+          valueText: candidate.valueText,
+          valueNumber: candidate.valueNumber,
+          valueBoolean: candidate.valueBoolean,
+          valueDate: candidate.valueDate,
+          valueJson: candidate.valueJson,
+          optionId: candidate.optionId,
+          relatedEntityId: candidate.relatedEntityId,
+          relatedEntityDefinitionId: candidate.relatedEntityDefinitionId,
+          actorId: candidate.actorId,
+          managedByConnectorId: ctx.connector.id,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(schema.FieldValue.id, action.rowId),
+            eq(schema.FieldValue.organizationId, ctx.orgId)
+          )
+        )
+
+      // Display/search upkeep. A direct row update bypasses the service layer, so:
+      // primary row changed → recompute the denormalized display column (subtitle
+      // follows a connector email change); non-primary → refresh search text only
+      // (the display columns still reflect the untouched primary).
+      try {
+        if (action.isPrimary) {
+          const { createFieldValueContext, maybeUpdateDisplayValue } = await import(
+            '../../field-values/field-value-helpers'
+          )
+          const { getCachedResource } = await import('../../cache')
+          const resource = await getCachedResource(ctx.orgId, entityDefinitionId)
+          const entityDefinition = resource
+            ? {
+                id: resource.entityDefinitionId ?? resource.id,
+                primaryDisplayFieldId: resource.display.primaryDisplayField?.id ?? null,
+                secondaryDisplayFieldId: resource.display.secondaryDisplayField?.id ?? null,
+                avatarFieldId: resource.display.avatarField?.id ?? null,
+              }
+            : null
+          await maybeUpdateDisplayValue(
+            createFieldValueContext(ctx.orgId, undefined, ctx.db),
+            recordId,
+            { ...action.write.field, entityDefinition } as never,
+            action.typed
+          )
+        } else {
+          const { updateSearchText } = await import('../../field-values/search-text')
+          await updateSearchText(ctx.db, instanceId, ctx.orgId)
+        }
+      } catch (error) {
+        logger.warn('row-level display/search refresh failed', {
+          connectorId: ctx.connector.id,
+          recordId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+      continue
+    }
+
+    // Append at the end via the multi-value primitive (never a whole-field set):
+    // `add` dedupes, runs hooks and honors the value cap.
+    try {
+      await handler.update(
+        recordId,
+        { [action.write.writeKey]: [action.flatValue] },
+        { [action.write.writeKey]: 'add' },
+        { skipEvents: true }
+      )
+    } catch (error) {
+      if (error instanceof UniqueValueConflictError) {
+        logger.warn('row-level append hit a unique-value conflict — value dropped', {
+          connectorId: ctx.connector.id,
+          recordId,
+          fieldId: action.write.fieldUuid,
+          conflictingValue: error.conflictingValue,
+        })
+      } else {
+        logger.warn('row-level append failed — value skipped', {
+          connectorId: ctx.connector.id,
+          recordId,
+          fieldId: action.write.fieldUuid,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+      continue
+    }
+
+    // Stamp ONLY the appended row (row-accurate provenance). The value was absent
+    // before the append, so the matching unmarked row is exactly the one we wrote.
+    await ctx.db
+      .update(schema.FieldValue)
+      .set({ managedByConnectorId: ctx.connector.id })
+      .where(
+        and(
+          eq(schema.FieldValue.entityId, instanceId),
+          eq(schema.FieldValue.fieldId, action.write.fieldUuid),
+          eq(schema.FieldValue.organizationId, ctx.orgId),
+          eq(schema.FieldValue[action.column], action.flatValue as never),
+          isNull(schema.FieldValue.managedByConnectorId)
+        )
+      )
+  }
+}

--- a/packages/lib/src/data-connectors/sinks/types.ts
+++ b/packages/lib/src/data-connectors/sinks/types.ts
@@ -80,6 +80,16 @@ export interface SyncCtx {
    * Promise so concurrent records share it), never per record.
    */
   driftByMapping?: Map<string, Promise<Set<string>>>
+  /**
+   * In-slice two-source dedupe (B1, locked): `mappingId::instanceId` → the
+   * externalId of the FIRST source record that bound the instance this slice.
+   * `managedByConnectorId` alone cannot tell two bindings of the same connector
+   * apart, so two upstream records matching two aliases of one contact would
+   * flip-flop the connector-owned row every run. Later source records resolving
+   * to an already-claimed instance still upsert their `DataConnectorItem`
+   * binding, but log + skip their field writes.
+   */
+  sliceWriteWinners?: Map<string, string>
 }
 
 /** The entity sink contract (04 §1b). */

--- a/packages/lib/src/field-values/field-value-queries.ts
+++ b/packages/lib/src/field-values/field-value-queries.ts
@@ -756,9 +756,12 @@ async function fetchFieldValueResults(
     const firstRow = fieldRows[0]!
     const aiStatus = (firstRow.aiStatus ?? null) as AiStatus | null
     const aiMetadata = readAiMetadata(firstRow)
-    // Contributing data-connector provenance marker (per-cell). Single marker
-    // per (entity, field), so — like aiStatus — take the first row's value.
-    const managedByConnectorId = firstRow.managedByConnectorId ?? null
+    // Contributing data-connector provenance marker (cell-grained badge). Multi
+    // fields stamp ROW-accurately (the connector's own row may not be first), so
+    // take ANY row's marker — else the badge vanishes whenever the primary row
+    // happens to be user-owned. Scalar fields have one row; same answer.
+    const managedByConnectorId =
+      fieldRows.find((row) => row.managedByConnectorId != null)?.managedByConnectorId ?? null
 
     results.push({
       recordId,


### PR DESCRIPTION
Implements **B1** (connector sink row-level semantics) + its **B6 sink test slice** from
`plans/custom-field/multi/04-multi-email-implementation-plan.md`.

## What changed

### Row-level writes for multi fields (`packages/lib/src/data-connectors/sinks/row-level-writes.ts`, new)
`set` is DELETE-all-then-INSERT (wipes every `managedByConnectorId` marker, regenerates sortKeys), so for `options.multi` target fields on an existing instance the sink never whole-field-sets. `overwrite` / `connector_owned_only` / `fill_blank` become an own-row upsert:
- value already present on ANY row → no-op, never re-stamped (user-owned stays user-owned — the load-bearing rule for match-by-alias, where the matched row IS the incoming value; `matchedBy` is now threaded from `resolveIdentity` into `buildWriteSet` as a `knownPresent` fast path that skips even the row read)
- connector's marked row exists, value changed → **in-place UPDATE** (sortKey untouched → position → primary stable); display columns recomputed when it's the first row, search text refreshed otherwise
- no matching row, no marked row → **append at end** via the `add` multi-value primitive (dedupe + hooks + cap), then stamp only the appended row
- `fill_blank` → only when the list is empty
- creates keep the plain write set (fresh instance, no rows to protect); stamp-all-rows stays accurate there

### The other B1 items (`entity-sink.ts`, `map-record.ts`, `sinks/types.ts`)
- **fill_blank key-space fix**: `current` is keyed by CustomField uuid while `getFieldId` can yield a systemAttribute — now resolved through `buildWriteKeyToFieldId` (a missed lookup used to make `fill_blank` behave as `overwrite`)
- **never-write-null guard**: a source key present-but-null on a multi field is a no-write (previously deleted every row)
- **provenance**: DB stamping is row-accurate (multi updates stamp only the written row); the counterpart read (`field-value-queries.ts` `fieldRows[0]` pick) now takes ANY row with a marker so the badge doesn't vanish when the primary is user-owned
- **per-value uniqueness**: pre-flight via `checkUniqueValueTyped` (gated on `isUnique`) in the row-level planner, plus a catch of `UniqueValueConflictError` around `handler.update`/`create` that drops the conflicting key and retries — the record no longer fails-and-retries-forever; sync stays green
- **drift detector row-scoped**: multi fields are excluded from `computeDriftedInstances` — under row-level semantics unmarked/foreign rows are legitimate (user aliases, other connectors), so a user alias no longer makes every bound record permanently "drifted" (content-hash skip restored)
- **fail-safe guards**: array-shaped raw source value on a scalar mapping ⇒ no write + one warning per (mapping, field) — guarded in `map-record`'s write-set building, NOT in `calc-expression`; array-shaped match candidate ⇒ dropped with a warning (never stringified), and zero usable candidates ⇒ record FAILS visibly instead of falling through to create
- **two-source ambiguity (locked)**: per-slice dedupe on the resolved instance via `ctx.sliceWriteWinners` (fresh per `fetchSlice`, same lifetime as the drift memo) — first source record binding a contact wins its field writes; later ones log + skip but still upsert their `DataConnectorItem` binding
- **manifest capture**: row-level fields feed the PROJECTED resulting array into `captureSubscribedChanges`, so record rules on email see sane `{o, n}` under row-level appends/updates

### UI copy
- `connector-lock-badge.tsx`: new `multi` prop → contributing copy softens to "Some values synced by X — other values are kept" (cell-grained, per the locked v1 decision); `custom-field-cell.tsx` + `property-row.tsx` pass it from field options
- `merge-strategy-toggle.tsx`: multi-aware wording for `overwrite` and `fill_blank`

### Verified, not changed
- `deleteConnector` keeps the now-unowned alias row (markers null via FK, `mintedInstance` gates archive/delete) — locked behavior confirmed in `mutations.ts`
- Stripe template (`templates/defs/stripe.json`) matches on `primary_email` + writes `phone`; the Shopify email match key rides `overwrite` by default (`strategyFor`) — both flows exercise the new row-level rules

## Tests (B6 sink slice)
`sinks/entity-sink-row-level.test.ts` (new, 10 cases): in-place own-row update keeps alias + primary; non-primary update refreshes search only; user-typed value never re-stamped; append stamps only the new row; `fill_blank` only on empty list; source null does not clear the list; drifted-forever regression (alias present → hash skip still fires); per-value pre-flight conflict keeps sync green; `UniqueValueConflictError` from the write drops the value + retries; array match candidate fails the record visibly; two source records matching two aliases → first wins, second still binds. Plus 2 new `map-record` guard tests and an updated assertion in `entity-sink-identity.test.ts` (buildWriteKeyToFieldId is now legitimately called by `buildWriteSet`; the no-stamp assertion moved to a `db.update` spy).

## Verification
- `vitest run src/data-connectors src/field-values`: 44 files / 355 tests + 12 files / 93 tests, all green
- `tsc --noEmit` scoped to `packages/lib`: clean except pre-existing `scripts/*` + `vitest.integration.config.ts` noise
- `tsc --noEmit` scoped to `apps/web`: clean for the four touched files
- Biome on all changed files

## Deviations / notes for other lanes
- **Drift row-scoping = exclusion**: the marker cannot distinguish a hand-edited connector row from a legitimate user alias on a multi field (a user picker `set` wipes all markers anyway), so multi fields never count as drifted. Consequence: a user edit/delete of the connector's row is respected until the source value changes — consistent with never-touch-other-rows, and the alternative (drift when no my-marker row exists) would permanently defeat the hash skip for the very common match-by-alias-user-owned case.
- **Two-source dedupe lives in `entity-sink`** (keyed on `ctx`), not `sink-source-record` — the instance is only known after the sink's identity resolution, and the ctx has exactly per-slice lifetime.
- **Cross-lane observation (A2/C lane)**: `addValues` passes only the appended `survivors` to `maybeUpdateDisplayValue` (`field-value-mutations.ts:1425`) — an append can set the subtitle to the alias, and A2's `values[0]` fix doesn't cover it since the wrong values are passed in. Worth folding into the A2 display pass.
- **Follow-up (per coordination note)**: migrate the sink's `resolveIdentity` onto A6's extracted lookup core once `resources/lookup/` lands — not done here to avoid crossing lanes.