### PR TITLE
feat(records): multi-value setPrimary, read rendering and value-list picker

### DIFF
--- a/apps/web/src/components/dynamic-table/components/selectable-table-cell.tsx
+++ b/apps/web/src/components/dynamic-table/components/selectable-table-cell.tsx
@@ -65,7 +65,7 @@ function SelectableTableCellInner<TData>({
   const isSystemColumn = columnId === '_checkbox'
 
   const field = cellSelectionConfig?.getFieldDefinition?.(columnId)
-  const editMode = getEditModeForFieldType(field?.fieldType)
+  const editMode = getEditModeForFieldType(field?.fieldType, field?.options)
   const isInlineEditing = isEditing && editMode === 'inline'
   const isPopoverEditing = isEditing && editMode === 'popover'
 

--- a/apps/web/src/components/dynamic-table/utils/cell-renderers.test.tsx
+++ b/apps/web/src/components/dynamic-table/utils/cell-renderers.test.tsx
@@ -1,0 +1,83 @@
+// apps/web/src/components/dynamic-table/utils/cell-renderers.test.tsx
+//
+// C6 (multi-email plan): the EMAIL/PHONE/URL cell renderers' array branches,
+// and the `unwrapValue` options hop above them — `renderCellValue` must thread
+// `config.options` into `formatToRawValue`, or a multi field whose store value
+// is a SINGLE TypedFieldValue unwraps to a scalar and the array branch never
+// fires (shape flip-flops between one value and two).
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { renderCellValue } from './cell-renderers'
+
+/** TypedFieldValue in store shape (only the fields the converters read). */
+function typed(value: string) {
+  return { id: `fv-${value}`, type: 'text', value }
+}
+
+describe('renderCellValue — EMAIL array branch', () => {
+  it('renders every address of a TypedFieldValue[] as chips (primary first)', () => {
+    render(
+      <>
+        {renderCellValue([typed('a@x.com'), typed('b@x.com')], 'EMAIL', undefined, {
+          options: { multi: true },
+        })}
+      </>
+    )
+    expect(screen.getByText('a@x.com')).toBeInTheDocument()
+    expect(screen.getByText('b@x.com')).toBeInTheDocument()
+  })
+
+  it('the :740 options hop — a SINGLE TypedFieldValue on a multi field still renders through the array branch', () => {
+    const { container } = render(
+      <>{renderCellValue(typed('a@x.com'), 'EMAIL', undefined, { options: { multi: true } })}</>
+    )
+    expect(screen.getByText('a@x.com')).toBeInTheDocument()
+    // The array branch renders ItemsCellView (ExpandableCell mode='items'),
+    // never the scalar branch's mode='horizontal' wrapper.
+    expect(container.querySelector('[data-expand="items"]')).toBeTruthy()
+    expect(container.querySelector('[data-expand="horizontal"]')).toBeNull()
+  })
+
+  it('collapses overflow into +N', () => {
+    const values = ['a@x.com', 'b@x.com', 'c@x.com', 'd@x.com', 'e@x.com'].map(typed)
+    render(<>{renderCellValue(values, 'EMAIL', undefined, { options: { multi: true } })}</>)
+    expect(screen.getByText('a@x.com')).toBeInTheDocument()
+    expect(screen.getByText('c@x.com')).toBeInTheDocument()
+    expect(screen.queryByText('d@x.com')).not.toBeInTheDocument()
+    expect(screen.getByText('+2')).toBeInTheDocument()
+  })
+
+  it('keeps the scalar branch for non-multi fields', () => {
+    render(<>{renderCellValue(typed('a@x.com'), 'EMAIL')}</>)
+    expect(screen.getByText('a@x.com')).toBeInTheDocument()
+  })
+})
+
+describe('renderCellValue — PHONE/URL array branches', () => {
+  it('renders every phone value, display-formatted', () => {
+    render(
+      <>
+        {renderCellValue([typed('+12125551234'), typed('+13105556789')], 'PHONE_INTL', undefined, {
+          options: { multi: true },
+        })}
+      </>
+    )
+    // Formatted display (national grouping) — assert on raw fragments that
+    // survive any format: last four digits of each number.
+    expect(screen.getByText(/1234/)).toBeInTheDocument()
+    expect(screen.getByText(/6789/)).toBeInTheDocument()
+  })
+
+  it('renders every URL value', () => {
+    render(
+      <>
+        {renderCellValue([typed('https://a.com'), typed('https://b.com')], 'URL', undefined, {
+          options: { multi: true },
+        })}
+      </>
+    )
+    expect(screen.getByText('https://a.com')).toBeInTheDocument()
+    expect(screen.getByText('https://b.com')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/dynamic-table/utils/cell-renderers.tsx
+++ b/apps/web/src/components/dynamic-table/utils/cell-renderers.tsx
@@ -356,10 +356,35 @@ export function renderCurrencyValue(
 }
 
 /**
- * Render email value as copyable link
+ * Normalize a multi-value cell value (options.multi EMAIL/URL/PHONE) into a
+ * string list. Returns null for scalar values so callers keep their scalar
+ * rendering path.
+ */
+function toMultiValueList(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null
+  return value.filter((v): v is string => typeof v === 'string' && v !== '')
+}
+
+/**
+ * Render email value as copyable link. Arrays (options.multi fields) render as
+ * a chip list via ItemsCellView — primary first, `+N` overflow.
  */
 export function renderEmailValue(value: unknown): React.ReactNode {
   if (value == null || value === '') return <EmptyCell />
+
+  const values = toMultiValueList(value)
+  if (values) {
+    if (values.length === 0) return <EmptyCell />
+    return (
+      <ItemsCellView
+        items={values.map((email, index) => ({ id: `${index}:${email}`, email }))}
+        renderItem={(item) => (
+          <CopyableLinkCell displayText={item.email} value={item.email} type='email' />
+        )}
+        maxDisplay={3}
+      />
+    )
+  }
 
   const email = String(value)
   return (
@@ -382,8 +407,6 @@ export function renderPhoneValue(
 ): React.ReactNode {
   if (value == null || value === '') return <EmptyCell />
 
-  const phone = String(value)
-
   // Merge column formatting with field options (column takes precedence)
   const opts: PhoneFieldOptions = {
     ...(config?.options as PhoneFieldOptions | undefined),
@@ -394,17 +417,34 @@ export function renderPhoneValue(
   // Use converter for display formatting. `formatToDisplayValue` is typed for
   // the full DB entity, but the PHONE_INTL converter only reads `.value`, so the
   // input shape is sufficient here.
-  const formatted =
+  const formatPhone = (phone: string) =>
     (formatToDisplayValue(
       { type: 'text', value: phone } as TypedFieldValue,
       'PHONE_INTL',
       opts
     ) as string) || phone
 
+  // Multi-value branch (options.multi fields) — chip list, primary first.
+  const values = toMultiValueList(value)
+  if (values) {
+    if (values.length === 0) return <EmptyCell />
+    return (
+      <ItemsCellView
+        items={values.map((phone, index) => ({ id: `${index}:${phone}`, phone }))}
+        renderItem={(item) => (
+          <CopyableLinkCell displayText={formatPhone(item.phone)} value={item.phone} type='phone' />
+        )}
+        maxDisplay={3}
+      />
+    )
+  }
+
+  const phone = String(value)
+
   return (
     <ExpandableCell mode='horizontal'>
       <div>
-        <CopyableLinkCell displayText={formatted} value={phone} type='phone' />
+        <CopyableLinkCell displayText={formatPhone(phone)} value={phone} type='phone' />
       </div>
     </ExpandableCell>
   )
@@ -416,6 +456,25 @@ export function renderPhoneValue(
  */
 export function renderUrlValue(value: unknown, config?: CellConfig): React.ReactNode {
   if (value == null || value === '') return <EmptyCell />
+
+  // Multi-value branch (options.multi fields) — chip list, primary first.
+  const values = toMultiValueList(value)
+  if (values) {
+    if (values.length === 0) return <EmptyCell />
+    return (
+      <ItemsCellView
+        items={values.map((itemUrl, index) => ({ id: `${index}:${itemUrl}`, url: itemUrl }))}
+        renderItem={(item) => (
+          <CopyableLinkCell
+            displayText={item.url}
+            value={item.url.startsWith('http') ? item.url : `https://${item.url}`}
+            type='url'
+          />
+        )}
+        maxDisplay={3}
+      />
+    )
+  }
 
   const url = String(value)
   const href = url.startsWith('http') ? url : `https://${url}`
@@ -737,9 +796,17 @@ function isFieldType(type: string): type is FieldType {
   return (FieldTypeValues as readonly string[]).includes(type)
 }
 
-function unwrapValue(value: unknown, fieldType: string): unknown {
+function unwrapValue(value: unknown, fieldType: string, options?: CellConfig['options']): unknown {
   if (value === null || value === undefined) return null
-  return isFieldType(fieldType) ? formatToRawValue(value, fieldType) : value
+  if (!isFieldType(fieldType)) return value
+  // Thread `multi` through so options.multi fields unwrap to a STABLE array —
+  // without it a single stored value unwraps to a scalar and the renderers'
+  // array branches never fire. Scoped to `multi` so legacy array-return types
+  // (TAGS, SINGLE_SELECT, RELATIONSHIP, …) keep their historic shapes.
+  const fieldOptions = (options as { multi?: boolean } | undefined)?.multi
+    ? { multi: true }
+    : undefined
+  return formatToRawValue(value, fieldType, fieldOptions)
 }
 
 /**
@@ -755,7 +822,7 @@ export function renderCellValue(
   const type = fieldType ?? 'TEXT'
 
   // Extract raw value from TypedFieldValue using centralized formatter
-  const actualValue = unwrapValue(value, type)
+  const actualValue = unwrapValue(value, type, config?.options)
 
   // Get renderer for field type, fallback to TEXT
   const renderer = cellRenderers[type] ?? TEXT_CELL_RENDERER

--- a/apps/web/src/components/fields/displays/display-email.tsx
+++ b/apps/web/src/components/fields/displays/display-email.tsx
@@ -1,15 +1,52 @@
+// apps/web/src/components/fields/displays/display-email.tsx
+
 import { Badge } from '@auxx/ui/components/badge'
 import { Mail } from 'lucide-react'
+import { ItemsListView } from '~/components/ui/items-list-view'
 import { useFieldContext } from './display-field'
 import DisplayWrapper from './display-wrapper'
 import { FieldOptionButton } from './field-option-button'
 
+/** How many chips a multi-value field shows before collapsing into `+N more`. */
+const MULTI_VALUE_MAX_DISPLAY = 3
+
 /**
  * DisplayEmail component
- * Renders an email value
+ * Renders an email value. Multi-value fields (options.multi) render the full
+ * list as chips — primary first, `+N more` overflow — with copy/compose
+ * actions bound to the primary address.
  */
 export function DisplayEmail() {
   const { value } = useFieldContext()
+
+  // Multi-value branch: array of addresses, primary at index 0.
+  if (Array.isArray(value)) {
+    const emails = value.filter((v): v is string => typeof v === 'string' && v !== '')
+    const primary = emails[0] ?? null
+
+    const buttons = primary
+      ? [
+          <FieldOptionButton key='open' label='Email' href={`mailto:${primary}`}>
+            <Mail />
+          </FieldOptionButton>,
+        ]
+      : []
+
+    return (
+      <DisplayWrapper copyValue={primary} buttons={buttons}>
+        <ItemsListView
+          items={emails.map((email, index) => ({ id: `${index}:${email}`, email }))}
+          renderItem={(item) => (
+            <Badge variant='pill' className='focus:ring-0'>
+              {typeof item === 'object' ? (item.email as string) : String(item)}
+            </Badge>
+          )}
+          maxDisplay={MULTI_VALUE_MAX_DISPLAY}
+        />
+      </DisplayWrapper>
+    )
+  }
+
   const email = typeof value === 'string' ? value : ''
 
   const buttons = [

--- a/apps/web/src/components/fields/displays/display-phone.tsx
+++ b/apps/web/src/components/fields/displays/display-phone.tsx
@@ -3,22 +3,58 @@
 import { formatToDisplayValue } from '@auxx/lib/field-values/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { PhoneForwarded } from 'lucide-react'
+import { ItemsListView } from '~/components/ui/items-list-view'
 import { useFieldContext } from './display-field'
 import DisplayWrapper from './display-wrapper'
 import { FieldOptionButton } from './field-option-button'
 
+/** How many chips a multi-value field shows before collapsing into `+N more`. */
+const MULTI_VALUE_MAX_DISPLAY = 3
+
 /**
  * DisplayPhone component
- * Renders a formatted phone number with configurable format
+ * Renders a formatted phone number with configurable format. Multi-value
+ * fields (options.multi) render the full list as chips — primary first,
+ * `+N more` overflow — with copy/call actions bound to the primary number.
  */
 export function DisplayPhone() {
   const { value, field } = useFieldContext()
-  const rawValue = typeof value === 'string' ? value : value ? String(value) : ''
   const options = field.options
+
+  const formatPhone = (raw: string): string =>
+    (formatToDisplayValue({ type: 'text', value: raw }, 'PHONE_INTL', options) as string) || raw
+
+  // Multi-value branch: array of numbers, primary at index 0.
+  if (Array.isArray(value)) {
+    const phones = value.filter((v): v is string => typeof v === 'string' && v !== '')
+    const primary = phones[0] ?? null
+
+    const buttons = primary
+      ? [
+          <FieldOptionButton key='open' label='Call' href={`tel:${primary}`}>
+            <PhoneForwarded />
+          </FieldOptionButton>,
+        ]
+      : []
+
+    return (
+      <DisplayWrapper copyValue={primary} buttons={buttons}>
+        <ItemsListView
+          items={phones.map((phone, index) => ({ id: `${index}:${phone}`, phone }))}
+          renderItem={(item) => (
+            <Badge shape='tag' variant='pill'>
+              {formatPhone(typeof item === 'object' ? (item.phone as string) : String(item))}
+            </Badge>
+          )}
+          maxDisplay={MULTI_VALUE_MAX_DISPLAY}
+        />
+      </DisplayWrapper>
+    )
+  }
+
+  const rawValue = typeof value === 'string' ? value : value ? String(value) : ''
   // Use converter for display formatting
-  const formatted = rawValue
-    ? (formatToDisplayValue({ type: 'text', value: rawValue }, 'PHONE_INTL', options) as string)
-    : ''
+  const formatted = rawValue ? formatPhone(rawValue) : ''
 
   const displayText = formatted || '-'
 

--- a/apps/web/src/components/fields/displays/display-url.tsx
+++ b/apps/web/src/components/fields/displays/display-url.tsx
@@ -8,9 +8,13 @@ import { formatUrlForDisplay, normalizeUrl } from '@auxx/utils'
 import { ExternalLink } from 'lucide-react'
 import { useMemo } from 'react'
 import { VisualIcon } from '~/components/icons/ui/visual-icon'
+import { ItemsListView } from '~/components/ui/items-list-view'
 import { useFieldContext } from './display-field'
 import DisplayWrapper from './display-wrapper'
 import { FieldOptionButton } from './field-option-button'
+
+/** How many chips a multi-value field shows before collapsing into `+N more`. */
+const MULTI_VALUE_MAX_DISPLAY = 3
 
 /**
  * DisplayUrl component
@@ -30,6 +34,42 @@ export function DisplayUrl() {
     if (!normalizedValue) return null
     return formatUrlForDisplay(normalizedValue)
   }, [normalizedValue])
+
+  // Multi-value branch (options.multi): array of URLs, primary at index 0,
+  // chips with `+N more` overflow. Copy/open actions bind to the primary.
+  // Placed after every hook so the early return never skips one.
+  if (Array.isArray(value)) {
+    const urls = value
+      .filter((v): v is string => typeof v === 'string' && v !== '')
+      .map((v) => normalizeUrl(v))
+      .filter((v): v is string => !!v)
+    const primary = urls[0] ?? null
+
+    const buttons = primary
+      ? [
+          <FieldOptionButton key='open' label='Open website' href={primary}>
+            <ExternalLink />
+          </FieldOptionButton>,
+        ]
+      : []
+
+    return (
+      <DisplayWrapper copyValue={primary} buttons={buttons}>
+        <ItemsListView
+          items={urls.map((url, index) => ({ id: `${index}:${url}`, url }))}
+          renderItem={(item) => {
+            const url = typeof item === 'object' ? (item.url as string) : String(item)
+            return (
+              <Badge variant='pill' className='shrink-0'>
+                {formatUrlForDisplay(url)}
+              </Badge>
+            )
+          }}
+          maxDisplay={MULTI_VALUE_MAX_DISPLAY}
+        />
+      </DisplayWrapper>
+    )
+  }
 
   if (!normalizedValue || !displayValue) {
     return (

--- a/apps/web/src/components/fields/inputs/field-input-adapter.tsx
+++ b/apps/web/src/components/fields/inputs/field-input-adapter.tsx
@@ -29,6 +29,7 @@ import {
   StringInput,
 } from '~/components/workflow/nodes/shared/node-inputs'
 import { useAccess } from '~/providers/capabilities-provider'
+import { MultiValueFieldInput } from './multi-value-input-field'
 import { NameFieldInput, type NameValue } from './name-field-input'
 import { getSelectConfig, SelectFieldInput } from './select-input-field'
 
@@ -401,6 +402,25 @@ export function FieldInputAdapter({
       )
 
     case FieldType.EMAIL: {
+      // Multi-value fields (options.multi) edit through the value-list picker —
+      // this is the create-dialog path, so writes land as whole arrays.
+      if (fieldOptions?.multi) {
+        return (
+          <MultiValueFieldInput
+            fieldType={fieldType}
+            value={value}
+            onChange={onChange as (values: string[]) => void}
+            fieldOptions={fieldOptions}
+            placeholder={placeholder}
+            disabled={disabled}
+            triggerProps={triggerProps}
+            open={open}
+            onOpenChange={onOpenChange}
+            shouldPreventDismiss={shouldPreventDismiss}
+          />
+        )
+      }
+
       const emailOpts = fieldOptions?.email
 
       // If email options with participantType exist, use ParticipantPicker
@@ -437,7 +457,25 @@ export function FieldInputAdapter({
       )
     }
 
-    case FieldType.URL:
+    case FieldType.URL: {
+      // Multi-value URL fields (options.multi) — value-list picker, whole-array writes.
+      if (fieldOptions?.multi) {
+        return (
+          <MultiValueFieldInput
+            fieldType={fieldType}
+            value={value}
+            onChange={onChange as (values: string[]) => void}
+            fieldOptions={fieldOptions}
+            placeholder={placeholder}
+            disabled={disabled}
+            triggerProps={triggerProps}
+            open={open}
+            onOpenChange={onOpenChange}
+            shouldPreventDismiss={shouldPreventDismiss}
+          />
+        )
+      }
+
       return (
         <FocusableInputWrapper open={open} onOpenChange={onOpenChange}>
           <StringInput
@@ -448,6 +486,7 @@ export function FieldInputAdapter({
           />
         </FocusableInputWrapper>
       )
+    }
 
     case FieldType.RICH_TEXT:
       return (
@@ -459,12 +498,31 @@ export function FieldInputAdapter({
     // ─────────────────────────────────────────────────────────────────
     // PHONE - uses PhoneInput with focus wrapper
     // ─────────────────────────────────────────────────────────────────
-    case FieldType.PHONE_INTL:
+    case FieldType.PHONE_INTL: {
+      // Multi-value phone fields (options.multi) — value-list picker, whole-array writes.
+      if (fieldOptions?.multi) {
+        return (
+          <MultiValueFieldInput
+            fieldType={fieldType}
+            value={value}
+            onChange={onChange as (values: string[]) => void}
+            fieldOptions={fieldOptions}
+            placeholder={placeholder}
+            disabled={disabled}
+            triggerProps={triggerProps}
+            open={open}
+            onOpenChange={onOpenChange}
+            shouldPreventDismiss={shouldPreventDismiss}
+          />
+        )
+      }
+
       return (
         <FocusableInputWrapper open={open} onOpenChange={onOpenChange}>
           <PhoneInput {...nodeInputProps} />
         </FocusableInputWrapper>
       )
+    }
 
     // ─────────────────────────────────────────────────────────────────
     // NUMBER - uses NumberInput with focus wrapper

--- a/apps/web/src/components/fields/inputs/get-input-component.tsx
+++ b/apps/web/src/components/fields/inputs/get-input-component.tsx
@@ -14,6 +14,7 @@ import { DateInputField } from './date-input-field'
 import { EmailInputField } from './email-input-field'
 import { FileInputField } from './file-input-field'
 import { JsonInputField } from './json-input-field'
+import { MultiValueInputField } from './multi-value-input-field'
 import { NameInputField } from './name-input-field'
 import { NumberInputField } from './number-input-field'
 import { PhoneInputField } from './phone-input-field'
@@ -38,6 +39,16 @@ function AddressStructOrSingleInput() {
 }
 
 /**
+ * EMAIL/URL/PHONE branch on `options.multi`: multi-value fields edit through
+ * the value-list picker (whole-array saves, set-as-primary, remove); scalar
+ * fields keep their single-line inputs.
+ */
+function ScalarOrMultiValueInput({ scalar }: { scalar: ReactNode }) {
+  const { field } = usePropertyContext()
+  return field.options?.multi ? <MultiValueInputField /> : <>{scalar}</>
+}
+
+/**
  * Returns the appropriate input component for a field type.
  * Used by both FieldInput (drawer) and CellFieldEditor (table).
  */
@@ -54,9 +65,9 @@ export function getInputComponentForFieldType(fieldType: FieldType): ReactNode {
     case FieldTypeEnum.TIME:
       return <DateInputField />
     case FieldTypeEnum.EMAIL:
-      return <EmailInputField />
+      return <ScalarOrMultiValueInput scalar={<EmailInputField />} />
     case FieldTypeEnum.URL:
-      return <UrlInputField />
+      return <ScalarOrMultiValueInput scalar={<UrlInputField />} />
     case FieldTypeEnum.CHECKBOX:
       return <CheckboxInputField />
     case FieldTypeEnum.SINGLE_SELECT:
@@ -64,7 +75,7 @@ export function getInputComponentForFieldType(fieldType: FieldType): ReactNode {
     case FieldTypeEnum.TAGS:
       return <SelectInputField />
     case FieldTypeEnum.PHONE_INTL:
-      return <PhoneInputField />
+      return <ScalarOrMultiValueInput scalar={<PhoneInputField />} />
     case FieldTypeEnum.RICH_TEXT:
       return <RichTextInputField />
     case FieldTypeEnum.FILE:

--- a/apps/web/src/components/fields/inputs/multi-value-input-field.test.tsx
+++ b/apps/web/src/components/fields/inputs/multi-value-input-field.test.tsx
@@ -1,0 +1,152 @@
+// apps/web/src/components/fields/inputs/multi-value-input-field.test.tsx
+//
+// C6 (multi-email plan): the two wrappers around MultiValuePicker.
+//
+// - `MultiValueInputField` (panel popover): saves are debounced whole-array
+//   `commitValue` calls, and the pending state MUST flush through the
+//   provider's `onBeforeClose` hook when the popover dismisses — otherwise a
+//   quick edit-then-click-away silently drops the change.
+// - `FieldInputAdapter` multi branch (create dialog path): a multi EMAIL field
+//   routes to `MultiValueFieldInput` and its onChange emits WHOLE ARRAYS —
+//   this is what makes the create dialog write arrays.
+
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+class NoopIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return []
+  }
+}
+
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  global.IntersectionObserver = NoopIntersectionObserver as unknown as typeof IntersectionObserver
+})
+
+// ── panel path: PropertyProvider context is mocked, the picker runs for real ──
+const h = vi.hoisted(() => ({
+  ctx: null as any,
+}))
+
+vi.mock('../property-provider', () => ({
+  usePropertyContext: () => h.ctx,
+}))
+vi.mock('../field-navigation-context', () => ({
+  useFieldNavigationOptional: () => null,
+}))
+
+// Heavy siblings of the adapter's multi branch — not under test here.
+vi.mock('~/components/records/record-editor-dialog', () => ({
+  RecordEditorDialog: () => null,
+}))
+vi.mock('~/components/shared/multi-relation-input', () => ({
+  MultiRelationInput: () => null,
+}))
+vi.mock('~/components/pickers/actor-picker/actor-picker', () => ({
+  ActorPicker: () => null,
+}))
+vi.mock('~/components/pickers/participant-picker', () => ({
+  ParticipantPicker: () => null,
+}))
+vi.mock('~/providers/capabilities-provider', () => ({
+  useAccess: () => ({ canEditEntity: () => true }),
+}))
+
+const { MultiValueInputField } = await import('./multi-value-input-field')
+const { FieldInputAdapter } = await import('./field-input-adapter')
+
+function makePropertyContext(value: unknown) {
+  return {
+    value,
+    field: {
+      id: 'field-email',
+      key: 'primaryEmail',
+      name: 'Email',
+      type: 'string',
+      fieldType: 'EMAIL',
+      options: { multi: true },
+      readOnly: false,
+    },
+    recordId: 'widget:inst-1',
+    commitValue: vi.fn(),
+    close: vi.fn(),
+    onBeforeClose: { current: undefined as (() => void) | undefined },
+  }
+}
+
+describe('MultiValueInputField (panel popover)', () => {
+  it('flushes the pending debounced save through onBeforeClose on dismiss', async () => {
+    h.ctx = makePropertyContext(['a@x.com'])
+    render(<MultiValueInputField />)
+
+    await userEvent.type(screen.getByPlaceholderText('Search or add email...'), 'b@x.com')
+    await userEvent.click(screen.getByText(/^Add "/))
+
+    // Debounced — nothing committed yet.
+    expect(h.ctx.commitValue).not.toHaveBeenCalled()
+
+    // Popover dismiss runs the registered onBeforeClose → immediate flush.
+    act(() => {
+      h.ctx.onBeforeClose.current?.()
+    })
+    expect(h.ctx.commitValue).toHaveBeenCalledTimes(1)
+    expect(h.ctx.commitValue).toHaveBeenCalledWith(['a@x.com', 'b@x.com'])
+  })
+
+  it('commits the whole array after the debounce window without a dismiss', async () => {
+    h.ctx = makePropertyContext(['a@x.com'])
+    render(<MultiValueInputField />)
+
+    await userEvent.type(screen.getByPlaceholderText('Search or add email...'), 'b@x.com')
+    await userEvent.click(screen.getByText(/^Add "/))
+
+    await vi.waitFor(() => {
+      expect(h.ctx.commitValue).toHaveBeenCalledWith(['a@x.com', 'b@x.com'])
+    })
+  })
+
+  it('set-as-primary inside the popover reorders before commit (move-to-front)', async () => {
+    h.ctx = makePropertyContext(['a@x.com', 'b@x.com'])
+    render(<MultiValueInputField />)
+
+    await userEvent.click(screen.getByTitle('Set as primary'))
+    act(() => {
+      h.ctx.onBeforeClose.current?.()
+    })
+    expect(h.ctx.commitValue).toHaveBeenCalledWith(['b@x.com', 'a@x.com'])
+  })
+})
+
+describe('FieldInputAdapter — multi EMAIL branch (create dialog path)', () => {
+  it('routes options.multi EMAIL to the value-list input and writes WHOLE ARRAYS', async () => {
+    const onChange = vi.fn()
+    render(
+      <FieldInputAdapter
+        fieldType='EMAIL'
+        fieldOptions={{ multi: true }}
+        value={['a@x.com']}
+        onChange={onChange}
+      />
+    )
+
+    // Trigger shows the existing value as a chip; open the picker. (The
+    // adapter threads its own placeholder default through to the picker.)
+    await userEvent.click(screen.getByRole('combobox'))
+    await userEvent.type(screen.getByPlaceholderText('Enter value...'), 'b@x.com')
+    await userEvent.click(screen.getByText(/^Add "/))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(['a@x.com', 'b@x.com'])
+  })
+
+  it('keeps the scalar EMAIL branch (plain input) when options.multi is absent', () => {
+    render(<FieldInputAdapter fieldType='EMAIL' value='a@x.com' onChange={vi.fn()} />)
+    // The scalar branch renders a text input, not the picker trigger.
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/fields/inputs/multi-value-input-field.tsx
+++ b/apps/web/src/components/fields/inputs/multi-value-input-field.tsx
@@ -1,0 +1,241 @@
+// apps/web/src/components/fields/inputs/multi-value-input-field.tsx
+'use client'
+
+import type { FieldOptions } from '@auxx/lib/field-values/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { cn } from '@auxx/ui/lib/utils'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { MultiValuePicker } from '~/components/pickers/multi-value-picker'
+import { ItemsListView } from '~/components/ui/items-list-view'
+import { PickerTrigger, type PickerTriggerOptions } from '~/components/ui/picker-trigger'
+import { useFieldNavigationOptional } from '../field-navigation-context'
+import { usePropertyContext } from '../property-provider'
+
+/** Placeholder per field type for the picker's combined filter/entry input. */
+function placeholderFor(fieldType: string): string {
+  switch (fieldType) {
+    case 'EMAIL':
+      return 'Search or add email...'
+    case 'URL':
+      return 'Search or add website...'
+    case 'PHONE_INTL':
+      return 'Search or add phone...'
+    default:
+      return 'Search or add...'
+  }
+}
+
+/** Normalize whatever the store/context holds into a string list. */
+function toValueList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === 'string' && v !== '')
+  }
+  if (typeof value === 'string' && value !== '') return [value]
+  return []
+}
+
+/**
+ * MultiValueInputField
+ * Panel/popover editor for multi-value scalar fields (options.multi
+ * EMAIL/URL/PHONE). Mirrors `SelectInputField`'s save idiom: every picker
+ * change is a whole-array `set`, debounced, with an `onBeforeClose` flush so
+ * dismissing the popover commits the pending state.
+ */
+export function MultiValueInputField() {
+  const { value, field, commitValue, onBeforeClose } = usePropertyContext()
+  const nav = useFieldNavigationOptional()
+  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  const fieldType: string = field?.fieldType || field?.type
+
+  const [localValues, setLocalValues] = useState<string[]>(() => toValueList(value))
+
+  // Ref to track current local value (for the onBeforeClose handler)
+  const localValuesRef = useRef<string[]>(localValues)
+  useEffect(() => {
+    localValuesRef.current = localValues
+  }, [localValues])
+
+  /** Debounced whole-array save — waits for the user to stop editing. */
+  const debouncedSave = useCallback(
+    (newValues: string[]) => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current)
+      }
+      saveTimeoutRef.current = setTimeout(() => {
+        commitValue(newValues)
+      }, 300)
+    },
+    [commitValue]
+  )
+
+  // Flush the pending debounced save when the popover closes
+  useEffect(() => {
+    onBeforeClose.current = () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current)
+        saveTimeoutRef.current = null
+        commitValue(localValuesRef.current)
+      }
+    }
+    return () => {
+      onBeforeClose.current = undefined
+    }
+  }, [onBeforeClose, commitValue])
+
+  // Cleanup timeout on unmount (onBeforeClose already handled the save if needed)
+  useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const handleChange = useCallback(
+    (newValues: string[]) => {
+      setLocalValues(newValues)
+      debouncedSave(newValues)
+    },
+    [debouncedSave]
+  )
+
+  const handleCaptureChange = useCallback(
+    (capturing: boolean) => {
+      nav?.setPopoverCapturing(capturing)
+    },
+    [nav]
+  )
+
+  return (
+    <MultiValuePicker
+      fieldType={fieldType}
+      values={localValues}
+      onChange={handleChange}
+      fieldOptions={field?.options as FieldOptions | undefined}
+      placeholder={placeholderFor(fieldType)}
+      onCaptureChange={handleCaptureChange}
+    />
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────
+// MultiValueFieldInput - Standalone input (used by FieldInputAdapter)
+// ─────────────────────────────────────────────────────────────────
+
+/**
+ * Props for MultiValueFieldInput (standalone usage — create dialog, forms)
+ */
+export interface MultiValueFieldInputProps {
+  /** Field type: EMAIL, URL or PHONE_INTL */
+  fieldType: string
+  /** Current values — primary first. Callers may pass a scalar; it is wrapped. */
+  value: unknown
+  /** Change handler — always receives the full string[] */
+  onChange: (values: string[]) => void
+  /** Field options (multi flag, phoneFormat, …) */
+  fieldOptions?: FieldOptions
+  /** Placeholder text */
+  placeholder?: string
+  /** Disabled state */
+  disabled?: boolean
+  /** Additional className */
+  className?: string
+  /** Trigger customization options */
+  triggerProps?: PickerTriggerOptions
+  /** Controlled open state */
+  open?: boolean
+  /** Callback when open state changes */
+  onOpenChange?: (open: boolean) => void
+  /** Callback to check if a dismiss event should be prevented. Return true to prevent closing. */
+  shouldPreventDismiss?: (target: HTMLElement) => boolean
+}
+
+/**
+ * MultiValueFieldInput
+ * Standalone popover input for multi-value scalar fields — a `PickerTrigger`
+ * showing the current values as chips, opening a `MultiValuePicker`. Form
+ * state is caller-owned (`value`/`onChange`), so writes land as whole arrays
+ * (the create dialog path).
+ */
+export function MultiValueFieldInput({
+  fieldType,
+  value,
+  onChange,
+  fieldOptions,
+  placeholder,
+  disabled = false,
+  className,
+  triggerProps,
+  open: controlledOpen,
+  onOpenChange,
+  shouldPreventDismiss,
+}: MultiValueFieldInputProps) {
+  const values = toValueList(value)
+
+  const [internalOpen, setInternalOpen] = useState(false)
+  const open = controlledOpen ?? internalOpen
+  const setOpen = (newOpen: boolean) => {
+    if (controlledOpen === undefined) {
+      setInternalOpen(newOpen)
+    }
+    onOpenChange?.(newOpen)
+  }
+
+  const handleClearAll = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+      onChange([])
+    },
+    [onChange]
+  )
+
+  const hasValue = values.length > 0
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <PickerTrigger
+          open={open}
+          disabled={disabled}
+          variant={triggerProps?.variant ?? 'transparent'}
+          hasValue={hasValue}
+          placeholder={placeholder ?? placeholderFor(fieldType)}
+          showClear={triggerProps?.showClear ?? true}
+          onClear={handleClearAll}
+          asCombobox
+          className={cn(className, triggerProps?.className)}>
+          <ItemsListView
+            items={values.map((v, index) => ({ id: `${index}:${v}`, value: v }))}
+            renderItem={(item) => (
+              <Badge variant='pill' className='shrink-0'>
+                {typeof item === 'object' ? (item.value as string) : String(item)}
+              </Badge>
+            )}
+            maxDisplay={3}
+            className='flex-1'
+          />
+        </PickerTrigger>
+      </PopoverTrigger>
+      <PopoverContent
+        className='min-w-[var(--radix-popover-trigger-width)] p-0'
+        align='start'
+        onPointerDownOutside={(e) => {
+          if (shouldPreventDismiss?.(e.target as HTMLElement)) e.preventDefault()
+        }}
+        onFocusOutside={(e) => {
+          if (shouldPreventDismiss?.(e.target as HTMLElement)) e.preventDefault()
+        }}>
+        <MultiValuePicker
+          fieldType={fieldType}
+          values={values}
+          onChange={onChange}
+          fieldOptions={fieldOptions}
+          placeholder={placeholder ?? placeholderFor(fieldType)}
+          disabled={disabled}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/web/src/components/fields/property-provider.tsx
+++ b/apps/web/src/components/fields/property-provider.tsx
@@ -326,8 +326,10 @@ export function PropertyProvider({
       setCurrentValue(newValue)
       setIsDirty(false)
 
-      // 2. Fire mutation in BACKGROUND (optimistic + background mutation)
-      storeSave(recordId, field.id, newValue, field.fieldType)
+      // 2. Fire mutation in BACKGROUND (optimistic + background mutation).
+      // `fieldOptions` keeps options.multi fields array-shaped through the
+      // optimistic store write and the post-save shaping.
+      storeSave(recordId, field.id, newValue, field.fieldType, { fieldOptions: field.options })
       // Store handles the optimistic update, so also update local serverValue
       setServerValue(newValue)
     },
@@ -379,10 +381,10 @@ export function PropertyProvider({
       isOutsideClick.current = false
 
       // Fire mutation in background (optimistic + background mutation)
-      storeSave(recordId, field.id, newValue, field.fieldType)
+      storeSave(recordId, field.id, newValue, field.fieldType, { fieldOptions: field.options })
       setServerValue(newValue)
     },
-    [recordId, isSaving, serverValue, storeSave, field.id, field.fieldType]
+    [recordId, isSaving, serverValue, storeSave, field.id, field.fieldType, field.options]
   )
 
   /**
@@ -408,11 +410,13 @@ export function PropertyProvider({
       setIsDirty(false)
 
       // Use async save path
-      const result = await storeSaveAsync(recordId, field.id, newValue, field.fieldType)
+      const result = await storeSaveAsync(recordId, field.id, newValue, field.fieldType, {
+        fieldOptions: field.options,
+      })
       setServerValue(newValue)
       return result
     },
-    [recordId, serverValue, storeSaveAsync, field.id, field.fieldType]
+    [recordId, serverValue, storeSaveAsync, field.id, field.fieldType, field.options]
   )
 
   /**

--- a/apps/web/src/components/fields/utils/edit-mode.ts
+++ b/apps/web/src/components/fields/utils/edit-mode.ts
@@ -14,12 +14,25 @@ const INLINE_EDITABLE_FIELD_TYPES = new Set<string>([
   FieldType.URL,
 ])
 
+/** Options subset that changes the edit-mode answer. */
+interface EditModeFieldOptions {
+  /** Multi-value scalar storage (options.multi) — always edits in a popover. */
+  multi?: boolean
+}
+
 /**
  * Determines the edit mode for a field type
  * - 'inline': Input renders directly in cell (TEXT, NUMBER, CURRENCY, EMAIL, URL)
- * - 'popover': Input renders in popover overlay (all other types)
+ * - 'popover': Input renders in popover overlay (all other types — including
+ *   any scalar type flagged `options.multi`, whose editor is the value-list
+ *   picker rather than a single-line input)
  */
-export function getEditModeForFieldType(fieldType: string | undefined): EditMode {
+export function getEditModeForFieldType(
+  fieldType: string | undefined,
+  options?: EditModeFieldOptions | null
+): EditMode {
   if (!fieldType) return 'popover'
+  // Multi-value scalars leave inline editing — the editor is a list picker.
+  if (options?.multi) return 'popover'
   return INLINE_EDITABLE_FIELD_TYPES.has(fieldType) ? 'inline' : 'popover'
 }

--- a/apps/web/src/components/kopilot/ui/blocks/block-schemas.ts
+++ b/apps/web/src/components/kopilot/ui/blocks/block-schemas.ts
@@ -144,6 +144,8 @@ export const tableCellSchema = z
     href: z.string().optional(),
     type: z.string().optional(),
     actorId: z.string().optional(),
+    /** Per-value list for multi-value email/phone cells — one link per value. */
+    values: z.array(z.string()).optional(),
     tags: z
       .array(
         z.object({

--- a/apps/web/src/components/kopilot/ui/blocks/table-block.tsx
+++ b/apps/web/src/components/kopilot/ui/blocks/table-block.tsx
@@ -22,6 +22,37 @@ import type { BlockRendererProps } from './block-registry'
 import type { TableBlockData, TableCellData, TableColumnData } from './block-schemas'
 import { tableBodyCellClass, tableClass, tableHeaderCellClass, tableRowClass } from './table-styles'
 
+/**
+ * Render an email/phone cell as one link PER value. Prefers the explicit
+ * `values` list; falls back to splitting the joined `text` on commas (safe for
+ * these two types — neither a valid email nor a phone number contains one).
+ */
+function renderLinkedValues(cell: TableCellData, hrefPrefix: 'mailto:' | 'tel:') {
+  const values =
+    cell.values && cell.values.length > 0
+      ? cell.values
+      : cell.text
+          .split(/\s*,\s*/)
+          .map((v) => v.trim())
+          .filter(Boolean)
+  if (values.length === 0) return <>{cell.text}</>
+  return (
+    <span className='inline-flex flex-wrap gap-x-1'>
+      {values.map((value, i) => (
+        <span key={`${value}-${i}`}>
+          <a
+            href={`${hrefPrefix}${value}`}
+            className='text-primary hover:underline'
+            onClick={(e) => e.stopPropagation()}>
+            {value}
+          </a>
+          {i < values.length - 1 && <span className='text-muted-foreground'>,</span>}
+        </span>
+      ))}
+    </span>
+  )
+}
+
 function CellContent({ cell }: { cell: TableCellData }) {
   // Entity record link. Cell ids are model-authored, so a malformed id falls
   // through to the plain-text branch rather than rendering a badge that can
@@ -78,28 +109,17 @@ function CellContent({ cell }: { cell: TableCellData }) {
     }
   }
 
-  // Email — clickable mailto
+  // Email — clickable mailto. Multi-value cells (options.multi fields) carry
+  // `values`; a joined text without it is split on commas as a fallback (a
+  // valid email cannot contain an unquoted comma), so each address links
+  // separately instead of one mailto carrying the whole list.
   if (cell.type === 'email') {
-    return (
-      <a
-        href={`mailto:${cell.text}`}
-        className='text-primary hover:underline'
-        onClick={(e) => e.stopPropagation()}>
-        {cell.text}
-      </a>
-    )
+    return renderLinkedValues(cell, 'mailto:')
   }
 
-  // Phone — clickable tel
+  // Phone — clickable tel, same per-value treatment as email.
   if (cell.type === 'phone') {
-    return (
-      <a
-        href={`tel:${cell.text}`}
-        className='text-primary hover:underline'
-        onClick={(e) => e.stopPropagation()}>
-        {cell.text}
-      </a>
-    )
+    return renderLinkedValues(cell, 'tel:')
   }
 
   // External link

--- a/apps/web/src/components/mail/participant-display.tsx
+++ b/apps/web/src/components/mail/participant-display.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/mail/participant-display.tsx
 'use client'
 
+import { formatToDisplayValue } from '@auxx/lib/field-values/client'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -172,20 +173,12 @@ export const ParticipantDisplay: React.FC<ParticipantDisplayProps> = ({
 }
 
 /**
- * Format phone number for display.
+ * Format phone number for display via the shared PHONE_INTL converter —
+ * one formatter for every surface instead of a local re-implementation.
  */
 function formatPhoneNumber(phone: string): string {
-  if (phone?.startsWith('+')) {
-    const digits = phone.substring(1)
-    if (digits.length >= 10) {
-      const countryCode = digits.slice(0, digits.length - 10)
-      const areaCode = digits.slice(digits.length - 10, digits.length - 7)
-      const firstPart = digits.slice(digits.length - 7, digits.length - 4)
-      const lastPart = digits.slice(digits.length - 4)
-      return `+${countryCode} (${areaCode}) ${firstPart}-${lastPart}`
-    }
-  }
-  return phone
+  if (!phone) return phone
+  return (formatToDisplayValue({ type: 'text', value: phone }, 'PHONE_INTL') as string) || phone
 }
 
 /**

--- a/apps/web/src/components/pickers/multi-value-picker.test.tsx
+++ b/apps/web/src/components/pickers/multi-value-picker.test.tsx
@@ -1,0 +1,132 @@
+// apps/web/src/components/pickers/multi-value-picker.test.tsx
+//
+// C6 (multi-email plan): the tags-style value-list editor. The load-bearing
+// behaviors: the Create row is gated on per-type client validation, hidden for
+// duplicates and at the MAX_MULTI_VALUES cap; a bare row click is a NO-OP (it
+// must never silently retarget outbound mail); set-as-primary is an explicit
+// action that moves the value to index 0; and the panel input flushes its
+// debounced whole-array save when the popover dismisses (`onBeforeClose`).
+
+import { MAX_MULTI_VALUES } from '@auxx/lib/field-values/client'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { MultiValuePicker } from './multi-value-picker'
+
+// cmdk scrolls the selected row into view; jsdom has no scrollIntoView. And
+// base-ui's ScrollArea (inside CommandList) does `new IntersectionObserver`,
+// which the global vi.fn-based mock does not satisfy — use a real class.
+class NoopIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return []
+  }
+}
+
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  global.IntersectionObserver = NoopIntersectionObserver as unknown as typeof IntersectionObserver
+})
+
+function typeInto(input: HTMLElement, text: string) {
+  return userEvent.type(input, text)
+}
+
+describe('MultiValuePicker — Create row gating', () => {
+  it('shows the Add row only once the typed value passes EMAIL validation', async () => {
+    const onChange = vi.fn()
+    render(<MultiValuePicker fieldType='EMAIL' values={['a@x.com']} onChange={onChange} />)
+
+    const input = screen.getByPlaceholderText('Search or add...')
+
+    await typeInto(input, 'not-an-email')
+    expect(screen.queryByText(/^Add "/)).not.toBeInTheDocument()
+
+    await userEvent.clear(input)
+    await typeInto(input, 'b@x.com')
+    expect(screen.getByText(/^Add "/)).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText(/^Add "/))
+    expect(onChange).toHaveBeenCalledWith(['a@x.com', 'b@x.com'])
+  })
+
+  it('hides the Add row when the typed value already exists (case-insensitive)', async () => {
+    render(<MultiValuePicker fieldType='EMAIL' values={['a@x.com']} onChange={vi.fn()} />)
+
+    await typeInto(screen.getByPlaceholderText('Search or add...'), 'A@X.com')
+    expect(screen.queryByText(/^Add "/)).not.toBeInTheDocument()
+  })
+
+  it(`hides the Add row at the ${MAX_MULTI_VALUES}-value cap, even for valid input`, async () => {
+    const values = Array.from({ length: MAX_MULTI_VALUES }, (_, i) => `v${i}@x.com`)
+    render(<MultiValuePicker fieldType='EMAIL' values={values} onChange={vi.fn()} />)
+
+    await typeInto(screen.getByPlaceholderText('Search or add...'), 'new@x.com')
+    expect(screen.queryByText(/^Add "/)).not.toBeInTheDocument()
+  })
+
+  it('lowercases a created email (matches the server hooks)', async () => {
+    const onChange = vi.fn()
+    render(<MultiValuePicker fieldType='EMAIL' values={[]} onChange={onChange} />)
+
+    await typeInto(screen.getByPlaceholderText('Search or add...'), 'New@X.com')
+    await userEvent.click(screen.getByText(/^Add "/))
+    expect(onChange).toHaveBeenCalledWith(['new@x.com'])
+  })
+
+  it('validates URL input before offering the Add row', async () => {
+    const onChange = vi.fn()
+    render(<MultiValuePicker fieldType='URL' values={[]} onChange={onChange} />)
+
+    const input = screen.getByPlaceholderText('Search or add...')
+    await typeInto(input, 'not a url')
+    expect(screen.queryByText(/^Add "/)).not.toBeInTheDocument()
+
+    await userEvent.clear(input)
+    await typeInto(input, 'example.com')
+    expect(screen.getByText(/^Add "/)).toBeInTheDocument()
+  })
+})
+
+describe('MultiValuePicker — rows', () => {
+  it('marks index 0 with the Primary badge', () => {
+    render(
+      <MultiValuePicker fieldType='EMAIL' values={['a@x.com', 'b@x.com']} onChange={vi.fn()} />
+    )
+    expect(screen.getByText('Primary')).toBeInTheDocument()
+    expect(screen.getByText('a@x.com')).toBeInTheDocument()
+    expect(screen.getByText('b@x.com')).toBeInTheDocument()
+  })
+
+  it('a bare row click never fires onChange (must not retarget outbound mail)', async () => {
+    const onChange = vi.fn()
+    render(
+      <MultiValuePicker fieldType='EMAIL' values={['a@x.com', 'b@x.com']} onChange={onChange} />
+    )
+    await userEvent.click(screen.getByText('b@x.com'))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('"Set as primary" moves the value to the front', async () => {
+    const onChange = vi.fn()
+    render(
+      <MultiValuePicker fieldType='EMAIL' values={['a@x.com', 'b@x.com']} onChange={onChange} />
+    )
+    // The primary row has no set-primary action, so there is exactly one.
+    await userEvent.click(screen.getByTitle('Set as primary'))
+    expect(onChange).toHaveBeenCalledWith(['b@x.com', 'a@x.com'])
+  })
+
+  it('"Remove" drops the value from the list', async () => {
+    const onChange = vi.fn()
+    render(
+      <MultiValuePicker fieldType='EMAIL' values={['a@x.com', 'b@x.com']} onChange={onChange} />
+    )
+    const removeButtons = screen.getAllByTitle('Remove')
+    expect(removeButtons).toHaveLength(2)
+    await userEvent.click(removeButtons[1]!)
+    expect(onChange).toHaveBeenCalledWith(['a@x.com'])
+  })
+})

--- a/apps/web/src/components/pickers/multi-value-picker.tsx
+++ b/apps/web/src/components/pickers/multi-value-picker.tsx
@@ -1,0 +1,277 @@
+// apps/web/src/components/pickers/multi-value-picker.tsx
+'use client'
+
+import {
+  type FieldOptions,
+  formatToDisplayValue,
+  MAX_MULTI_VALUES,
+} from '@auxx/lib/field-values/client'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Command,
+  CommandDetailItem,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@auxx/ui/components/command'
+import { cn } from '@auxx/ui/lib/utils'
+import { formatUrlForDisplay, normalizeUrl } from '@auxx/utils'
+import { ArrowUpToLine, Plus, Trash2 } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+/**
+ * Props for the MultiValuePicker component
+ */
+export interface MultiValuePickerProps {
+  /** Field type driving validation + display formatting: EMAIL, URL or PHONE_INTL */
+  fieldType: string
+
+  /** Current value list — primary first (index 0) */
+  values: string[]
+
+  /** Called with the full re-ordered/edited array on every change */
+  onChange: (values: string[]) => void
+
+  /** Field options (phoneFormat, …) for display formatting */
+  fieldOptions?: FieldOptions
+
+  /** Placeholder text for the combined filter/entry input */
+  placeholder?: string
+
+  /** Disabled state */
+  disabled?: boolean
+
+  /** Callback when arrow key capture state changes (for parent navigation) */
+  onCaptureChange?: (capturing: boolean) => void
+
+  /** Additional className for Command wrapper */
+  className?: string
+}
+
+/** Client-side per-type validation gate for the Create row. Server still normalizes. */
+export function isValidMultiValue(fieldType: string, raw: string): boolean {
+  const value = raw.trim()
+  if (!value) return false
+  switch (fieldType) {
+    case 'EMAIL':
+      return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+    case 'URL': {
+      try {
+        const candidate = /^https?:\/\//i.test(value) ? value : `https://${value}`
+        const parsed = new URL(candidate)
+        return parsed.hostname.includes('.')
+      } catch {
+        return false
+      }
+    }
+    case 'PHONE_INTL':
+      return /^[+]?[1-9][\d\s\-().]{7,15}$/.test(value.replace(/\s/g, ''))
+    default:
+      return true
+  }
+}
+
+/** Display-format one value for its row title (raw value stays the stored one). */
+function formatValueForDisplay(
+  fieldType: string,
+  value: string,
+  fieldOptions?: FieldOptions
+): string {
+  if (fieldType === 'PHONE_INTL') {
+    return (
+      (formatToDisplayValue({ type: 'text', value }, 'PHONE_INTL', fieldOptions) as string) || value
+    )
+  }
+  if (fieldType === 'URL') {
+    const normalized = normalizeUrl(value)
+    return normalized ? formatUrlForDisplay(normalized) : value
+  }
+  return value
+}
+
+/** Normalize a typed value before storing — email lowercases (matches the server hooks). */
+function normalizeNewValue(fieldType: string, raw: string): string {
+  const value = raw.trim()
+  return fieldType === 'EMAIL' ? value.toLowerCase() : value
+}
+
+/**
+ * MultiValuePicker
+ * Tags-style value-list editor for multi-value scalar fields (options.multi
+ * EMAIL/URL/PHONE). The `CommandInput` doubles as filter and entry field; a
+ * `Create "«typed»"` row appears for valid, non-duplicate input while under
+ * the value cap. Value rows are `CommandDetailItem`s with `selectionMode='none'`
+ * — a bare row click is deliberately a no-op (it must never silently retarget
+ * outbound mail); explicit hover actions handle set-as-primary and remove.
+ */
+export function MultiValuePicker({
+  fieldType,
+  values,
+  onChange,
+  fieldOptions,
+  placeholder = 'Search or add...',
+  disabled = false,
+  onCaptureChange,
+  className,
+}: MultiValuePickerProps) {
+  // Notify parent about capture state on mount/unmount
+  useEffect(() => {
+    onCaptureChange?.(true)
+    return () => onCaptureChange?.(false)
+  }, [onCaptureChange])
+
+  const [searchValue, setSearchValue] = useState('')
+
+  // Filter values by search (raw + display-formatted, case-insensitive)
+  const filteredValues = useMemo(() => {
+    if (!searchValue.trim()) return values
+    const search = searchValue.toLowerCase()
+    return values.filter(
+      (v) =>
+        v.toLowerCase().includes(search) ||
+        formatValueForDisplay(fieldType, v, fieldOptions).toLowerCase().includes(search)
+    )
+  }, [values, searchValue, fieldType, fieldOptions])
+
+  // Hide the Create row when the typed value already exists (case-insensitive)
+  const searchMatchesExisting = useMemo(() => {
+    const typed = normalizeNewValue(fieldType, searchValue).toLowerCase()
+    if (!typed) return true
+    return values.some((v) => v.toLowerCase() === typed)
+  }, [values, searchValue, fieldType])
+
+  const typedIsValid = useMemo(
+    () => isValidMultiValue(fieldType, searchValue),
+    [fieldType, searchValue]
+  )
+
+  const atCap = values.length >= MAX_MULTI_VALUES
+  const showCreate =
+    !disabled && searchValue.trim() !== '' && typedIsValid && !searchMatchesExisting && !atCap
+
+  /** Append the typed value at the end of the list. */
+  const createValue = useCallback(() => {
+    const newValue = normalizeNewValue(fieldType, searchValue)
+    if (!newValue || !isValidMultiValue(fieldType, newValue)) return
+    if (values.some((v) => v.toLowerCase() === newValue.toLowerCase())) {
+      setSearchValue('')
+      return
+    }
+    if (values.length >= MAX_MULTI_VALUES) return
+    onChange([...values, newValue])
+    setSearchValue('')
+  }, [fieldType, searchValue, values, onChange])
+
+  /** Move a value to the front — index 0 IS the primary. */
+  const setPrimary = useCallback(
+    (value: string) => {
+      const index = values.indexOf(value)
+      if (index <= 0) return
+      onChange([value, ...values.filter((_, i) => i !== index)])
+    },
+    [values, onChange]
+  )
+
+  /** Remove a value from the list. */
+  const removeValue = useCallback(
+    (value: string) => {
+      onChange(values.filter((v) => v !== value))
+    },
+    [values, onChange]
+  )
+
+  return (
+    <Command shouldFilter={false} className={cn('rounded-lg', className)}>
+      <CommandInput
+        placeholder={placeholder}
+        value={searchValue}
+        onValueChange={setSearchValue}
+        disabled={disabled}
+      />
+
+      <CommandList>
+        {/* Create row — inside the list, beside the results it filters. Hidden
+            at the value cap and for invalid/duplicate input. */}
+        {showCreate && (
+          <>
+            <CommandGroup>
+              <CommandItem
+                onSelect={createValue}
+                className='cursor-pointer h-7'
+                disabled={disabled}>
+                <Plus className='text-muted-foreground' />
+                <span>
+                  Add "<span className='font-medium'>{searchValue.trim()}</span>"
+                </span>
+              </CommandItem>
+            </CommandGroup>
+            <div className='-mx-1 h-px bg-border/50' />
+          </>
+        )}
+
+        {filteredValues.length === 0 && !searchValue.trim() && (
+          <CommandEmpty>No values yet. Type to add one.</CommandEmpty>
+        )}
+
+        {filteredValues.length > 0 && (
+          <CommandGroup>
+            {filteredValues.map((value) => {
+              const index = values.indexOf(value)
+              const isPrimary = index === 0
+              return (
+                <CommandDetailItem
+                  key={value}
+                  value={value}
+                  title={formatValueForDisplay(fieldType, value, fieldOptions)}
+                  secondary={
+                    isPrimary ? (
+                      <Badge variant='secondary' className='shrink-0'>
+                        Primary
+                      </Badge>
+                    ) : undefined
+                  }
+                  selectionMode='none'
+                  // A bare click must never retarget outbound mail — actions
+                  // are explicit hover buttons only.
+                  onSelect={() => {}}
+                  disabled={disabled}
+                  actions={
+                    <>
+                      {!isPrimary && (
+                        <Button
+                          variant='ghost'
+                          size='icon-xs'
+                          title='Set as primary'
+                          disabled={disabled}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setPrimary(value)
+                          }}>
+                          <ArrowUpToLine />
+                        </Button>
+                      )}
+                      <Button
+                        variant='destructive-hover'
+                        size='icon-xs'
+                        title='Remove'
+                        disabled={disabled}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          removeValue(value)
+                        }}>
+                        <Trash2 />
+                      </Button>
+                    </>
+                  }
+                />
+              )
+            })}
+          </CommandGroup>
+        )}
+      </CommandList>
+    </Command>
+  )
+}

--- a/apps/web/src/components/records/ui/record-identity-header.test.tsx
+++ b/apps/web/src/components/records/ui/record-identity-header.test.tsx
@@ -303,6 +303,71 @@ describe('RecordIdentityHeader — what it lets you write', () => {
   })
 })
 
+describe('RecordIdentityHeader — multi-value secondary line (options.multi)', () => {
+  // The value-list picker (cmdk + base-ui ScrollArea) needs two jsdom shims.
+  class NoopIntersectionObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return []
+    }
+  }
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+    global.IntersectionObserver = NoopIntersectionObserver as unknown as typeof IntersectionObserver
+  })
+
+  function givenMultiEmailSecondary(emails: string[]) {
+    const secondary = makeField({
+      id: SECONDARY_ID,
+      key: 'primaryEmail',
+      label: 'Email',
+      fieldType: 'EMAIL',
+      options: { multi: true },
+    })
+    h.fields = [secondary]
+    h.secondaryDisplayFieldId = SECONDARY_ID
+    h.values[SECONDARY_ID] = emails.map((value, i) => ({ id: `fv-${i}`, type: 'text', value }))
+  }
+
+  // The heading compresses a multi-value field to primary + `+N` — the full
+  // list is the panel's job, and a three-chip list does not belong in a
+  // text-xs secondary line.
+  it('renders the primary value plus a +N badge, never the full list', () => {
+    givenMultiEmailSecondary(['a@x.com', 'b@x.com', 'c@x.com'])
+
+    render(<RecordIdentityHeader recordId={RECORD_ID} />)
+
+    expect(screen.getByText('a@x.com')).toBeInTheDocument()
+    expect(screen.getByText('+2')).toBeInTheDocument()
+    expect(screen.queryByText('b@x.com')).not.toBeInTheDocument()
+    expect(screen.queryByText('c@x.com')).not.toBeInTheDocument()
+  })
+
+  // Multi leaves inline edit: the answer that routes the heading (and table
+  // cells) to the popover picker instead of a single-line input.
+  it('multi EMAIL answers popover edit mode while scalar EMAIL stays inline', () => {
+    expect(getEditModeForFieldType('EMAIL')).toBe('inline')
+    expect(getEditModeForFieldType('EMAIL', { multi: true })).toBe('popover')
+    expect(getEditModeForFieldType('URL', { multi: true })).toBe('popover')
+    expect(getEditModeForFieldType('PHONE_INTL', { multi: true })).toBe('popover')
+  })
+
+  it('editing routes to the popover value-list picker, outside the heading', async () => {
+    givenMultiEmailSecondary(['a@x.com', 'b@x.com'])
+
+    const { container } = render(<RecordIdentityHeader recordId={RECORD_ID} />)
+
+    await userEvent.click(screen.getByText('a@x.com'))
+
+    // The picker's combined filter/entry input mounts in the popover overlay —
+    // not inline inside the heading.
+    const pickerInput = screen.getByPlaceholderText('Search or add email...')
+    expect(container.contains(pickerInput)).toBe(false)
+  })
+})
+
 describe('RecordIdentityHeader — which editor the field type calls for', () => {
   // §7. Text-like types replace the value in the heading itself; everything else
   // gets the shared field popover, which is why a NAME primary field lands on

--- a/apps/web/src/components/records/ui/record-identity-header.tsx
+++ b/apps/web/src/components/records/ui/record-identity-header.tsx
@@ -2,10 +2,16 @@
 'use client'
 
 import { FieldType } from '@auxx/database/enums'
-import { isValueEmpty } from '@auxx/lib/field-values/client'
+import {
+  type FieldOptions,
+  formatToDisplayValue,
+  isValueEmpty,
+} from '@auxx/lib/field-values/client'
 import type { RecordId } from '@auxx/lib/resources/client'
+import { Badge } from '@auxx/ui/components/badge'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
+import { formatUrlForDisplay, normalizeUrl } from '@auxx/utils'
 import { formatDistanceToNow } from 'date-fns'
 import { type ReactNode, useCallback, useEffect, useMemo, useRef } from 'react'
 import { DisplayField } from '~/components/fields/displays/display-field'
@@ -277,6 +283,46 @@ function HeaderValue({
 }
 
 /**
+ * Compact heading rendering for a multi-value field (options.multi): the
+ * primary value plus a `+N` badge for the rest. The full list is the panel's
+ * job; clicking the heading opens the popover picker.
+ */
+function HeaderMultiValue({
+  values,
+  fieldType,
+  options,
+}: {
+  values: string[]
+  fieldType?: string
+  options?: FieldOptions
+}) {
+  const primary = values[0]!
+  const rest = values.length - 1
+
+  let display = primary
+  if (fieldType === FieldType.PHONE_INTL) {
+    display =
+      (formatToDisplayValue({ type: 'text', value: primary }, 'PHONE_INTL', options ?? undefined) as
+        | string
+        | null) || primary
+  } else if (fieldType === FieldType.URL) {
+    const normalized = normalizeUrl(primary)
+    display = normalized ? formatUrlForDisplay(normalized) : primary
+  }
+
+  return (
+    <span className='flex min-w-0 items-center gap-1.5' data-slot='header-multi-value'>
+      <span className='truncate min-w-0'>{display}</span>
+      {rest > 0 && (
+        <Badge variant='pill' className='shrink-0'>
+          +{rest}
+        </Badge>
+      )}
+    </span>
+  )
+}
+
+/**
  * Value slot inside the provider: resolves the render states (row fallback,
  * skeleton, empty, value) and mounts the editor the field type calls for.
  */
@@ -332,6 +378,14 @@ function HeaderValueInner({
     return <div className={cn(STATIC_VALUE_BOX, className)}>{emptyFallback}</div>
   }
 
+  // Multi-value fields (options.multi) compress to primary + `+N` in the
+  // heading — the full list lives in the panel, and editing routes to the
+  // popover picker (getEditModeForFieldType answers 'popover' for multi).
+  const multiValues =
+    field.options?.multi && Array.isArray(value)
+      ? value.filter((v): v is string => typeof v === 'string' && v !== '')
+      : null
+
   const content = isEmpty ? (
     <div
       className={cn(
@@ -342,6 +396,8 @@ function HeaderValueInner({
       )}>
       {placeholder}
     </div>
+  ) : multiValues && multiValues.length > 0 ? (
+    <HeaderMultiValue values={multiValues} fieldType={field.fieldType} options={field.options} />
   ) : (
     <DisplayField />
   )
@@ -350,7 +406,7 @@ function HeaderValueInner({
     return <div className={cn(STATIC_VALUE_BOX, className)}>{content}</div>
   }
 
-  const editMode = getEditModeForFieldType(field.fieldType)
+  const editMode = getEditModeForFieldType(field.fieldType, field.options)
 
   return (
     // `group/property-row` is what `DisplayWrapper` keys its hover background and

--- a/apps/web/src/components/resources/hooks/use-save-field-value.ts
+++ b/apps/web/src/components/resources/hooks/use-save-field-value.ts
@@ -1,7 +1,11 @@
 // apps/web/src/components/resources/hooks/use-save-field-value.ts
 
 import type { FieldType } from '@auxx/database/types'
-import { formatToTypedInput, isArrayReturnFieldType } from '@auxx/lib/field-values/client'
+import {
+  type FieldOptions,
+  formatToTypedInput,
+  isArrayReturnFieldType,
+} from '@auxx/lib/field-values/client'
 import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
 import {
   getInverseFieldId,
@@ -34,6 +38,14 @@ interface SaveOptions {
    *  BullMQ autofill job; the client keeps an optimistic 'generating' marker
    *  until the realtime socket delivers the final value. */
   ai?: boolean
+  /**
+   * Field options (`options.multi`, `actor.multiple`, …). Without them the
+   * optimistic write and the post-save store shaping treat a multi-value
+   * scalar field (EMAIL/URL/PHONE with `options.multi`) as scalar — the
+   * optimistic store joins the array into one string, and clearing the field
+   * leaves the store scalar-shaped instead of `[]`.
+   */
+  fieldOptions?: FieldOptions
 }
 
 /**
@@ -85,7 +97,8 @@ function prepareOptimisticUpdate(
   value: unknown,
   fieldType: FieldType,
   getFieldMetadata?: (fieldId: FieldId) => FieldMetadata | undefined,
-  ai?: boolean
+  ai?: boolean,
+  fieldOptions?: FieldOptions
 ): OptimisticUpdatePrep {
   const key = buildFieldValueKey(recordId, resolveFieldRef(fieldId, recordId))
   const store = useFieldValueStore.getState()
@@ -114,8 +127,10 @@ function prepareOptimisticUpdate(
     }
   }
 
-  // Optimistic update to store (convert to TypedFieldValue format)
-  const typedValue = fieldType ? formatToTypedInput(value, fieldType) : value
+  // Optimistic update to store (convert to TypedFieldValue format).
+  // `fieldOptions` matters for options.multi scalar fields: without it an
+  // array value would be coerced through the scalar branch (joined string).
+  const typedValue = fieldType ? formatToTypedInput(value, fieldType, { fieldOptions }) : value
 
   store.setValueOptimistic(key, typedValue)
 
@@ -168,7 +183,8 @@ function handleMutationSuccess(
   key: FieldValueKey,
   mutationVersion: number,
   result: { state?: string; values?: Array<{ id?: string }>; jobId?: string } | undefined,
-  fieldType: FieldType
+  fieldType: FieldType,
+  fieldOptions?: FieldOptions
 ): boolean {
   const store = useFieldValueStore.getState()
   const currentVersion = store.getMutationVersion(key)
@@ -187,14 +203,19 @@ function handleMutationSuccess(
   }
 
   if (result?.values && result.values.length > 0) {
-    // Static multi-value types (MULTI_SELECT, TAGS, etc.) always return arrays
-    // For ACTOR fields: if server returned multiple values, it's a multi-select actor field
-    const returnsArray = isArrayReturnFieldType(fieldType) || result.values.length > 1
+    // Static multi-value types (MULTI_SELECT, TAGS, etc.) always return arrays.
+    // `fieldOptions` covers the conditional cases: options.multi scalars and
+    // multi ACTOR fields — without it a one-value multi field would be stored
+    // scalar-shaped. (`length > 1` stays as a fallback for callers that don't
+    // thread options.)
+    const returnsArray = isArrayReturnFieldType(fieldType, fieldOptions) || result.values.length > 1
     const valueToStore = returnsArray ? result.values : result.values[0]
 
     store.setValue(key, valueToStore)
     store.confirmOptimistic(key)
-  } else if (fieldType && isArrayReturnFieldType(fieldType)) {
+  } else if (fieldType && isArrayReturnFieldType(fieldType, fieldOptions)) {
+    // Clearing an array-return field must leave `[]` in the store, not a
+    // stale scalar shape — options.multi fields depend on `fieldOptions` here.
     store.setValue(key, [])
     store.confirmOptimistic(key)
   } else {
@@ -304,7 +325,8 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
         value,
         fieldType,
         getFieldMetadata,
-        ai
+        ai,
+        saveOpts?.fieldOptions
       )
 
       // Sync relationship cache (never for AI requests — stage-1 doesn't
@@ -323,7 +345,15 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
         { recordId: normalizedRecordId, fieldId, value, ...(ai ? { ai: true } : {}) },
         {
           onSuccess: (result) => {
-            if (handleMutationSuccess(prep.key, prep.mutationVersion, result, fieldType)) {
+            if (
+              handleMutationSuccess(
+                prep.key,
+                prep.mutationVersion,
+                result,
+                fieldType,
+                saveOpts?.fieldOptions
+              )
+            ) {
               onSuccess?.()
             }
           },
@@ -368,7 +398,8 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
         value,
         fieldType,
         getFieldMetadata,
-        ai
+        ai,
+        saveOpts?.fieldOptions
       )
 
       // Sync relationship cache
@@ -397,7 +428,13 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
 
       // Apply server result
       const firstValueId = result?.values?.[0]?.id
-      handleMutationSuccess(prep.key, prep.mutationVersion, result, fieldType)
+      handleMutationSuccess(
+        prep.key,
+        prep.mutationVersion,
+        result,
+        fieldType,
+        saveOpts?.fieldOptions
+      )
       onSuccess?.()
       return { success: true, id: firstValueId }
       // } catch (error: unknown) {

--- a/apps/web/src/server/api/routers/fieldValue.ts
+++ b/apps/web/src/server/api/routers/fieldValue.ts
@@ -108,6 +108,45 @@ export const fieldValueRouter = createTRPCRouter({
     }),
 
   /**
+   * Promote one value of a multi-value field to primary (position 0).
+   * Single-row sortKey move — recomputes display columns and publishes the
+   * full array server-side. Gated exactly like `set`.
+   */
+  setPrimary: capabilityProcedure
+    .input(
+      z.object({
+        recordId: z.string(), // RecordId format
+        fieldId: fieldIdSchema,
+        /** FieldValue row id to move to the front. */
+        valueId: z.string(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertFieldValueHostsWritable({
+        db: ctx.db,
+        capabilities: ctx.capabilities,
+        organizationId: ctx.session.organizationId,
+        userId: ctx.session.user.id,
+        hosts: [input.recordId as RecordId],
+      })
+
+      const service = new FieldValueService(
+        ctx.session.organizationId,
+        ctx.session.user.id,
+        ctx.db,
+        ctx.headers.get('x-realtime-socket-id') ?? undefined,
+        { capabilities: ctx.capabilities }
+      )
+
+      const values = await service.setPrimaryValue({
+        recordId: input.recordId as RecordId,
+        fieldId: input.fieldId,
+        valueId: input.valueId,
+      })
+      return { state: 'complete' as const, performedAt: new Date().toISOString(), values }
+    }),
+
+  /**
    * Set values for multiple resources (bulk operation).
    * Expects recordIds in RecordId format.
    */

--- a/packages/lib/src/ai/kopilot/capabilities/entities/format-enriched-fields.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/entities/format-enriched-fields.ts
@@ -12,6 +12,8 @@ export const FormattedFieldSchema = z.object({
   tags: z.array(z.object({ label: z.string(), color: z.string().optional() })).optional(),
   recordId: z.string().optional(),
   recordIds: z.array(z.string()).optional(),
+  /** Per-value list for multi-value email/phone cells — renderers link each value separately. */
+  values: z.array(z.string()).optional(),
 })
 
 /** Maps FieldType → cell type hint for the auxx:table block */
@@ -35,6 +37,8 @@ export interface FormattedField {
   tags?: Array<{ label: string; color?: string }>
   recordId?: string
   recordIds?: string[]
+  /** Per-value list for multi-value email/phone cells — renderers link each value separately. */
+  values?: string[]
 }
 
 /**
@@ -63,6 +67,17 @@ export function formatEnrichedFields(
 
     if (cellType) {
       formatted.type = cellType
+    }
+
+    // Multi-value email/phone (options.multi): the joined `text` would render
+    // as ONE mailto/tel target carrying every address. Carry the per-value
+    // list so the table cell can link each value separately.
+    if (
+      (cellType === 'email' || cellType === 'phone') &&
+      Array.isArray(field.displayValue) &&
+      field.displayValue.length > 1
+    ) {
+      formatted.values = field.displayValue.map(String)
     }
 
     // ACTOR: extract actorId from converter's rawValue

--- a/packages/lib/src/field-values/__tests__/set-primary-value.test.ts
+++ b/packages/lib/src/field-values/__tests__/set-primary-value.test.ts
@@ -1,0 +1,304 @@
+// packages/lib/src/field-values/__tests__/set-primary-value.test.ts
+//
+// C6 (multi-email plan): `setPrimaryValue` promotes one row of a multi-value
+// field to primary via a single-row sortKey UPDATE — no delete/insert — then
+// recomputes display columns (the subtitle must follow the new primary even
+// though no VALUE was written) and publishes the FULL array (a publish entry
+// without a `value` is silently dropped by the realtime layer).
+
+import { buildFieldValueKey, type FieldId } from '@auxx/types/field'
+import { toRecordId } from '@auxx/types/resource'
+
+// ⚠️ Mock the publish-helpers LEAF, not the '../../realtime' barrel — same
+// import-cycle gotcha as batched-realtime-publish.test.ts.
+vi.mock('../../realtime/publish-helpers', () => ({
+  publishFieldValueUpdates: vi.fn(),
+}))
+
+// Mock the cache barrel WHOLESALE (never partial-mock via importOriginal —
+// loading the real barrel inside the factory walks its import graph before the
+// mock exists and modules capture the real fns). The entries cover everything
+// this path can touch: getField's fallback, maybeUpdateDisplayValue's cascade
+// (getCachedResource / getCachedResources via display-field-deps), and the
+// mail gate in getValue (findCachedResource / getCachedUserInstanceGrants).
+vi.mock('../../cache', () => ({
+  getCachedFieldMap: vi.fn(),
+  getCachedResource: vi.fn(),
+  getCachedResources: vi.fn(),
+  getOrgCache: vi.fn(),
+  findCachedResource: vi.fn(),
+  getCachedUserInstanceGrants: vi.fn(),
+}))
+
+import { getCachedResource, getCachedResources, getOrgCache } from '../../cache'
+import { NotFoundError } from '../../errors'
+import { publishFieldValueUpdates } from '../../realtime/publish-helpers'
+import { createFieldValueContext } from '../field-value-helpers'
+import { addValues, setPrimaryValue } from '../field-value-mutations'
+
+const mockedGetCachedResource = getCachedResource as unknown as ReturnType<typeof vi.fn>
+const mockedGetCachedResources = getCachedResources as unknown as ReturnType<typeof vi.fn>
+const mockedGetOrgCache = getOrgCache as unknown as ReturnType<typeof vi.fn>
+const mockedPublish = vi.mocked(publishFieldValueUpdates)
+
+const ORG = 'org-1'
+const FIELD_ID = 'field-email'
+const recordId = toRecordId('widget', 'inst-1')
+
+/**
+ * Chainable fake db. `select()` chains resolve to the next queued result (or
+ * `[]`); `update().set()` chains record their payload into `updates` and
+ * resolve to `[]`; `execute` (raw searchText UPDATE) resolves to `[]`.
+ * No assertion depends on Drizzle column refs (undefined under the vitest
+ * schema mock) — where() args are ignored entirely.
+ */
+function makeFakeDb(
+  selectQueue: unknown[][],
+  updates: Array<Record<string, unknown>>,
+  inserts: Array<Record<string, unknown>[]> = []
+) {
+  function selectChain() {
+    const c: any = {
+      from: () => c,
+      where: () => c,
+      leftJoin: () => c,
+      innerJoin: () => c,
+      limit: () => c,
+      orderBy: () => c,
+      // biome-ignore lint/suspicious/noThenProperty: deliberate thenable — awaited like a Drizzle builder
+      then: (resolve: any, reject: any) =>
+        Promise.resolve(selectQueue.shift() ?? []).then(resolve, reject),
+    }
+    return c
+  }
+  function updateChain() {
+    const c: any = {
+      set: (vals: Record<string, unknown>) => {
+        updates.push(vals)
+        return c
+      },
+      where: () => c,
+      // biome-ignore lint/suspicious/noThenProperty: deliberate thenable — awaited like a Drizzle builder
+      then: (resolve: any, reject: any) => Promise.resolve([]).then(resolve, reject),
+    }
+    return c
+  }
+  function insertChain() {
+    let pending: Record<string, unknown>[] = []
+    let idSeq = 0
+    const c: any = {
+      values: (rows: Record<string, unknown> | Record<string, unknown>[]) => {
+        pending = Array.isArray(rows) ? rows : [rows]
+        inserts.push(pending)
+        return c
+      },
+      onConflictDoUpdate: () => c,
+      returning: () =>
+        Promise.resolve(
+          pending.map((r) => ({
+            id: `fv-new-${idSeq++}`,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            ...r,
+          }))
+        ),
+    }
+    return c
+  }
+  const db: any = {
+    select: () => selectChain(),
+    update: () => updateChain(),
+    insert: () => insertChain(),
+    execute: async () => [],
+  }
+  // addValues wraps its critical section in a transaction; run it on the
+  // same fake so all captures land in the shared arrays.
+  db.transaction = async (fn: (tx: any) => Promise<unknown>) => fn(db)
+  return db
+}
+
+/** Multi-EMAIL field wired as the entity's secondary display field. */
+const FIELD = {
+  id: FIELD_ID,
+  type: 'EMAIL',
+  options: { multi: true },
+  entityDefinitionId: 'widget',
+  entityType: null,
+  isUnique: false,
+  systemAttribute: null,
+  entityDefinition: {
+    id: 'widget',
+    primaryDisplayFieldId: null,
+    secondaryDisplayFieldId: FIELD_ID,
+    avatarFieldId: null,
+  },
+} as any
+
+/** FieldValue row fixture in DB shape (valueText column for EMAIL). */
+function row(id: string, email: string, sortKey: string) {
+  return {
+    id,
+    entityId: 'inst-1',
+    fieldId: FIELD_ID,
+    organizationId: ORG,
+    sortKey,
+    valueText: email,
+    valueNumber: null,
+    valueBoolean: null,
+    valueDate: null,
+    valueJson: null,
+    optionId: null,
+    relatedEntityId: null,
+    relatedEntityDefinitionId: null,
+    actorId: null,
+    aiStatus: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+function makeCtx(db: any) {
+  const ctx = createFieldValueContext(ORG, undefined, db, 'socket-abc')
+  // Pre-seed the per-context field cache so getField never hits the org cache.
+  ctx.fieldCache.set(FIELD_ID, FIELD)
+  return ctx
+}
+
+describe('setPrimaryValue', () => {
+  beforeEach(() => {
+    mockedPublish.mockReset()
+    mockedPublish.mockResolvedValue(undefined)
+    mockedGetCachedResource.mockReset()
+    mockedGetCachedResource.mockResolvedValue(undefined)
+    mockedGetCachedResources.mockReset()
+    mockedGetCachedResources.mockResolvedValue([])
+    mockedGetOrgCache.mockReset()
+    mockedGetOrgCache.mockReturnValue({
+      from: () => ({ all: async () => ({}), byId: async () => undefined }),
+    })
+  })
+
+  it('moves the target row to the front with a single sortKey UPDATE, recomputes the subtitle, and publishes the full array', async () => {
+    const updates: Array<Record<string, unknown>> = []
+    // Query order: (1) existing {id, sortKey} rows, (2) getValue re-read.
+    const db = makeFakeDb(
+      [
+        [
+          { id: 'fv-a', sortKey: 'a0' },
+          { id: 'fv-b', sortKey: 'a1' },
+        ],
+        // Re-read AFTER the move: b now sorts first.
+        [row('fv-b', 'b@x.com', 'Zz'), row('fv-a', 'a@x.com', 'a0')],
+      ],
+      updates
+    )
+    const ctx = makeCtx(db)
+
+    const values = await setPrimaryValue(ctx, { recordId, fieldId: FIELD_ID, valueId: 'fv-b' })
+
+    // Returned array is the re-read, new-primary-first order.
+    expect(values.map((v: any) => v.value)).toEqual(['b@x.com', 'a@x.com'])
+
+    // Single-row move: exactly one FieldValue sortKey write, strictly BEFORE
+    // the old first key under C collation, and no delete/insert.
+    const sortKeyWrites = updates.filter((u) => 'sortKey' in u)
+    expect(sortKeyWrites).toHaveLength(1)
+    expect(typeof sortKeyWrites[0]!.sortKey).toBe('string')
+    expect((sortKeyWrites[0]!.sortKey as string) < 'a0').toBe(true)
+
+    // Subtitle recompute fired even though no VALUE was written — the
+    // secondaryDisplayValue column write is the observable effect.
+    const subtitleWrites = updates.filter((u) => 'secondaryDisplayValue' in u)
+    expect(subtitleWrites).toHaveLength(1)
+
+    // Publishes ONE frame carrying the FULL array (entries without a value
+    // are silently dropped by the realtime layer).
+    expect(mockedPublish).toHaveBeenCalledTimes(1)
+    const [, organizationId, entries, options] = mockedPublish.mock.calls[0]!
+    expect(organizationId).toBe(ORG)
+    expect(options).toEqual({ excludeSocketId: 'socket-abc' })
+    expect(entries).toHaveLength(1)
+    const entry = entries[0]! as any
+    expect(entry.key).toBe(buildFieldValueKey(recordId, FIELD_ID as FieldId))
+    expect(Array.isArray(entry.value)).toBe(true)
+    expect(entry.value.map((v: any) => v.value)).toEqual(['b@x.com', 'a@x.com'])
+  })
+
+  it('is a no-op when the target row is already primary', async () => {
+    const updates: Array<Record<string, unknown>> = []
+    const db = makeFakeDb(
+      [
+        [
+          { id: 'fv-a', sortKey: 'a0' },
+          { id: 'fv-b', sortKey: 'a1' },
+        ],
+        [row('fv-a', 'a@x.com', 'a0'), row('fv-b', 'b@x.com', 'a1')],
+      ],
+      updates
+    )
+    const ctx = makeCtx(db)
+
+    const values = await setPrimaryValue(ctx, { recordId, fieldId: FIELD_ID, valueId: 'fv-a' })
+
+    expect(values.map((v: any) => v.value)).toEqual(['a@x.com', 'b@x.com'])
+    // No writes, no display recompute, no publish.
+    expect(updates).toHaveLength(0)
+    expect(mockedPublish).not.toHaveBeenCalled()
+  })
+
+  it('throws NotFoundError when the value row does not exist on the field', async () => {
+    const db = makeFakeDb([[{ id: 'fv-a', sortKey: 'a0' }]], [])
+    const ctx = makeCtx(db)
+
+    await expect(
+      setPrimaryValue(ctx, { recordId, fieldId: FIELD_ID, valueId: 'fv-missing' })
+    ).rejects.toBeInstanceOf(NotFoundError)
+  })
+})
+
+describe('addValues — display recompute sees the FULL list', () => {
+  beforeEach(() => {
+    mockedPublish.mockReset()
+    mockedPublish.mockResolvedValue(undefined)
+    mockedGetCachedResource.mockReset()
+    mockedGetCachedResource.mockResolvedValue(undefined)
+    mockedGetCachedResources.mockReset()
+    mockedGetCachedResources.mockResolvedValue([])
+    mockedGetOrgCache.mockReset()
+    mockedGetOrgCache.mockReturnValue({
+      from: () => ({ all: async () => ({}), byId: async () => undefined }),
+    })
+  })
+
+  it('appending an alias keeps the subtitle on the primary (recompute from full list, not survivors)', async () => {
+    const updates: Array<Record<string, unknown>> = []
+    const inserts: Array<Record<string, unknown>[]> = []
+    // addValues' in-lock read of existing rows (full row shape).
+    const db = makeFakeDb([[row('fv-a', 'a@x.com', 'a0')]], updates, inserts)
+    const ctx = makeCtx(db)
+
+    const result = await addValues(ctx, {
+      recordId,
+      fieldId: FIELD_ID,
+      values: ['b@x.com'],
+    })
+
+    // Append lands at the END — primary unchanged.
+    expect(result.map((v: any) => v.value)).toEqual(['a@x.com', 'b@x.com'])
+
+    // The display recompute must have run over the FULL list: whatever shape
+    // the formatter currently produces (joined array today, primary-only
+    // scalar once the display-path lane lands), the PRIMARY leads — a
+    // survivors-only recompute would have written the alias instead.
+    const subtitleWrites = updates.filter((u) => 'secondaryDisplayValue' in u)
+    expect(subtitleWrites).toHaveLength(1)
+    const subtitle = subtitleWrites[0]!.secondaryDisplayValue
+    const first = Array.isArray(subtitle) ? subtitle[0] : subtitle
+    expect(String(first).startsWith('a@x.com')).toBe(true)
+
+    // And the realtime frame carries the full post-state array.
+    expect(mockedPublish).toHaveBeenCalledTimes(1)
+    const [, , entries] = mockedPublish.mock.calls[0]!
+    expect((entries[0] as any).value.map((v: any) => v.value)).toEqual(['a@x.com', 'b@x.com'])
+  })
+})

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -36,7 +36,7 @@ import {
   isBuiltInField,
 } from '../custom-fields/built-in-fields'
 import { checkUniqueValueTyped } from '../custom-fields/check-unique-value-typed'
-import { BadRequestError } from '../errors'
+import { BadRequestError, NotFoundError } from '../errors'
 import {
   collectTriggeredFields,
   deduplicateBySystemAttribute,
@@ -103,6 +103,7 @@ import type {
   RemoveRelationValuesBulkInput,
   RemoveRelationValuesInput,
   SetBulkValuesInput,
+  SetPrimaryValueInput,
   SetValueInput,
   SetValueResult,
   SetValuesForEntityInput,
@@ -667,6 +668,98 @@ export async function removeValue(ctx: FieldValueContext, valueId: string): Prom
     const remaining = await getValue(ctx, { recordId, fieldId: row.fieldId })
     await maybeUpdateDisplayValue(ctx, recordId, field, remaining ?? null)
   }
+}
+
+/**
+ * Promote one value of a multi-value field to primary (position 0).
+ *
+ * Move-to-front is a single-row sortKey UPDATE — no delete/insert, so the
+ * row keeps its id, provenance markers and timestamps. The new key is
+ * `generateKeyBetween(null, firstKey)` (strictly before every existing key
+ * under C collation, so the `(entityId, fieldId, sortKey)` unique index
+ * cannot collide); a corrupt legacy first key degrades to `nextKeyAfter(null)`
+ * — the same fallback `addValue`'s 'start' position uses.
+ *
+ * A sortKey-only move never writes a value, so the display-column recompute
+ * (`maybeUpdateDisplayValue` — subtitle follows the new primary) and the
+ * realtime publish of the full array are triggered explicitly here.
+ *
+ * @returns The field's full value array in the new order (primary first).
+ */
+export async function setPrimaryValue(
+  ctx: FieldValueContext,
+  params: SetPrimaryValueInput
+): Promise<TypedFieldValue[]> {
+  const { recordId, fieldId, valueId } = params
+  const { entityInstanceId } = parseRecordId(recordId)
+
+  const field = await getField(ctx, fieldId)
+
+  const existing = await ctx.db
+    .select({ id: schema.FieldValue.id, sortKey: schema.FieldValue.sortKey })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.entityId, entityInstanceId),
+        eq(schema.FieldValue.fieldId, fieldId),
+        eq(schema.FieldValue.organizationId, ctx.organizationId)
+      )
+    )
+    .orderBy(asc(schema.FieldValue.sortKey))
+
+  const targetIndex = existing.findIndex((row) => row.id === valueId)
+  if (targetIndex === -1) {
+    throw new NotFoundError(`Field value ${valueId} not found on field ${fieldId}`)
+  }
+
+  const readValues = async (): Promise<TypedFieldValue[]> => {
+    const full = await getValue(ctx, { recordId, fieldId }, field)
+    return full == null ? [] : Array.isArray(full) ? full : [full]
+  }
+
+  // Already primary — nothing to move, nothing to recompute or publish.
+  if (targetIndex === 0) {
+    return readValues()
+  }
+
+  const firstKey = existing[0]!.sortKey
+  const sortKey = isValidOrderKey(firstKey)
+    ? generateKeyBetween(null, firstKey)
+    : nextKeyAfter(null)
+
+  await ctx.db
+    .update(schema.FieldValue)
+    .set({ sortKey, updatedAt: new Date() })
+    .where(
+      and(
+        eq(schema.FieldValue.id, valueId),
+        eq(schema.FieldValue.organizationId, ctx.organizationId)
+      )
+    )
+
+  const values = await readValues()
+
+  // Recompute display columns — the subtitle must follow the new primary even
+  // though no value changed hands (recompute otherwise keys off value writes).
+  await maybeUpdateDisplayValue(ctx, recordId, field, values)
+
+  // Publish the full array. Entries without a `value` are silently dropped by
+  // the realtime layer, so the re-read array always rides along. Publish under
+  // the field's real EntityDefinition id (alias guard — see setValueWithBuiltIn).
+  const publishRecordId = field.entityDefinitionId
+    ? toRecordId(field.entityDefinitionId, entityInstanceId)
+    : recordId
+  const entry = buildPublishEntry({
+    publishRecordId,
+    fieldId: fieldId as FieldId,
+    field,
+    values,
+  })
+  publishFieldValueUpdates(getRealtimeService(), ctx.organizationId, [entry], {
+    excludeSocketId: ctx.socketId,
+  }).catch(() => {})
+
+  return values
 }
 
 /**
@@ -1420,9 +1513,12 @@ export async function addValues(
     const allTyped = allRows.map((r) => rowToTypedValue(r, fieldType))
 
     // Update display value (safe no-op when the field isn't a display source).
-    // Pass txCtx so the inner update + searchText + cascade writes go through
-    // the active tx, not the pool.
-    await maybeUpdateDisplayValue(txCtx, recordId, field, survivors)
+    // Pass the FULL post-state, not just the appended survivors — an append
+    // lands at the END of the list, and a survivors-only recompute would
+    // overwrite the subtitle with the new alias instead of keeping the
+    // primary (position 0). Pass txCtx so the inner update + searchText +
+    // cascade writes go through the active tx, not the pool.
+    await maybeUpdateDisplayValue(txCtx, recordId, field, allTyped)
 
     // Publish the full post-state. Array-return fields publish arrays;
     // scalar-multi (TEXT/etc. with options.multi) are array-return too.

--- a/packages/lib/src/field-values/field-value-service.ts
+++ b/packages/lib/src/field-values/field-value-service.ts
@@ -27,6 +27,7 @@ import type {
   RemoveRelationValuesBulkInput,
   RemoveRelationValuesInput,
   SetBulkValuesInput,
+  SetPrimaryValueInput,
   SetValueInput,
   SetValueResult,
   SetValuesForEntityInput,
@@ -212,6 +213,15 @@ export class FieldValueService {
     skipPublishEvents?: boolean
   }): Promise<void> {
     return mutations.removeValues(this.ctx, params)
+  }
+
+  /**
+   * Promote one value of a multi-value field to primary (position 0) via a
+   * single-row sortKey move. Recomputes display columns and publishes the
+   * full array. Throws `NotFoundError` if the value row does not exist.
+   */
+  setPrimaryValue(params: SetPrimaryValueInput): Promise<TypedFieldValue[]> {
+    return mutations.setPrimaryValue(this.ctx, params)
   }
 
   /**

--- a/packages/lib/src/field-values/formatter.ts
+++ b/packages/lib/src/field-values/formatter.ts
@@ -113,7 +113,8 @@ export function formatToTypedInput(
  */
 export function formatToRawValue(
   value: TypedFieldValue | TypedFieldValueInput | TypedFieldValue[] | unknown,
-  fieldType: FieldType
+  fieldType: FieldType,
+  fieldOptions?: FieldTypeOptions
 ): unknown {
   const converter = getConverter(fieldType)
 
@@ -124,7 +125,18 @@ export function formatToRawValue(
     return rawValues.filter((v) => v !== null && v !== undefined)
   }
 
-  return converter.toRawValue(value)
+  const raw = converter.toRawValue(value)
+
+  // Stable array shape for array-return fields (options.multi scalars, multi
+  // ACTOR): a single stored value must still unwrap to a one-element array so
+  // downstream array branches (cell renderers, panel displays) always see the
+  // same shape regardless of value count. Callers that omit `fieldOptions`
+  // keep the historic scalar passthrough.
+  if (fieldOptions && isArrayReturnType(fieldType, fieldOptions)) {
+    return raw === null || raw === undefined || raw === '' ? [] : [raw]
+  }
+
+  return raw
 }
 
 /**

--- a/packages/lib/src/field-values/index.ts
+++ b/packages/lib/src/field-values/index.ts
@@ -83,6 +83,7 @@ export {
   removeRelationValuesBulk,
   removeValue,
   setBulkValues,
+  setPrimaryValue,
   setValue,
   setValuesForEntity,
   setValueWithBuiltIn,
@@ -223,6 +224,7 @@ export type {
   RemoveRelationValuesBulkInput,
   RemoveRelationValuesInput,
   SetBulkValuesInput,
+  SetPrimaryValueInput,
   // Existing input types
   SetValueInput,
   // Result types

--- a/packages/lib/src/field-values/types.ts
+++ b/packages/lib/src/field-values/types.ts
@@ -254,6 +254,16 @@ export interface AddValueInput {
   position?: 'start' | 'end' | { after: string }
 }
 
+/**
+ * Input for promoting one value of a multi-value field to primary
+ * (position 0). `valueId` is the FieldValue row id to move to the front.
+ */
+export interface SetPrimaryValueInput {
+  recordId: RecordId
+  fieldId: string
+  valueId: string
+}
+
 /** Input for getting a single field value */
 export interface GetValueInput {
   recordId: RecordId


### PR DESCRIPTION
## Summary

Lane 6 (UI) of `plans/custom-field/multi/04-multi-email-implementation-plan.md` — items **C1**, **C2**, **C3** and their **C6** tests. Everything is gated on `field.options.multi` / array-shaped values and is a no-op for scalar fields; no field is flipped to multi yet.

### C1 — `setPrimary`
- `setPrimaryValue` in `field-value-mutations.ts`: move-to-front via `generateKeyBetween(null, firstKey)` — a **single-row sortKey UPDATE**, no delete/insert (row keeps id/provenance/timestamps), with `addValue`'s `isValidOrderKey` fallback for corrupt legacy keys. The new key sorts strictly before every existing key, so the `(entityId, fieldId, sortKey)` unique index cannot collide.
- After the move: explicit `maybeUpdateDisplayValue` with the re-read array (a sortKey-only move writes no value, so the subtitle recompute is triggered here) and a full-array publish via `buildPublishEntry` (entries without a `value` are dropped by the realtime layer).
- tRPC `fieldValue.setPrimary`, capability-gated exactly like `set`.
- **Scope addition (coordinator, connector lane):** `addValues` now recomputes display columns from the **full post-state** instead of the appended survivors — appending an alias no longer overwrites the subtitle with the alias.

### C2 — read rendering + the plumbing that silently defeats it
- `cell-renderers.tsx`: EMAIL/PHONE/URL renderers get array branches → `ItemsCellView` chips with `maxDisplay=3` / `+N`; `unwrapValue` threads `config.options` into `formatToRawValue` (new optional `fieldOptions` param) so multi fields unwrap to a **stable array** even with one stored value.
- `use-save-field-value.ts`: `SaveOptions.fieldOptions` threaded into the optimistic `formatToTypedInput` and both `isArrayReturnFieldType` calls — clearing a multi field now leaves `[]` in the store, and an optimistic array is no longer joined into one string. `property-provider` passes `field.options` at all three save sites.
- Panel displays `display-email/phone/url`: array branch via `ItemsListView`, primary first, copy/compose/call/open actions bound to the primary (chips + `+N more` stay sane at the ~380px extension embed width).
- `record-identity-header`: multi secondary renders **primary + `+N` badge** (never the full list); `getEditModeForFieldType` gains an options param — `options.multi` ⇒ `popover`, so editing routes to the picker (multi leaves inline edit).
- `mail/participant-display`: local phone formatter retired for `formatToDisplayValue(..., 'PHONE_INTL')`.
- Kopilot `format-enriched-fields`: multi email/phone cells carry a per-value `values` list; the `auxx:table` cell renders one `mailto:`/`tel:` link per value (comma-split fallback for LLM-flattened text — safe for these two types).

### C3 — `MultiValuePicker` (locked editor design)
- New `pickers/multi-value-picker.tsx`, structural sibling of `multi-select-picker.tsx`: `CommandInput` = filter + entry; `Add "«typed»"` row inside the list, gated on per-type client validation (email/URL/phone — server still normalizes), hidden for duplicates and at `MAX_MULTI_VALUES` (imported from `@auxx/lib/field-values/client`). Rows are `CommandDetailItem` `selectionMode='none'` — bare click is a **no-op** (never retargets outbound mail); hover actions = set-as-primary (move-to-front) + remove; `Primary` badge on index 0.
- `fields/inputs/multi-value-input-field.tsx`: panel variant (debounced whole-array `commitValue` + `onBeforeClose` flush, the `select-input-field` idiom) and standalone `MultiValueFieldInput` (PickerTrigger chips) for the create-dialog path.
- Wiring: `get-input-component` routes EMAIL/URL/PHONE through an `options.multi` branch; `edit-mode` answers popover for multi; `FieldInputAdapter` gets multi branches for all three types (create dialog writes whole arrays). Bulk editor deliberately untouched (exclusion is another lane's item).

### C6 tests (this lane's subset)
- lib: setPrimary reorders + recomputes subtitle + publishes the array; already-primary no-op; NotFound; **addValues append keeps the subtitle on the primary**.
- web: picker create-row validation / cap / duplicate-hide / lowercase / no-op row click / set-primary / remove; panel input dismiss-flush + debounce + in-popover reorder; adapter multi EMAIL writes whole arrays (scalar branch unchanged); cell renderer array branches incl. the `:740` options-hop proof (single TypedFieldValue on a multi field renders through the array branch) and `+N` overflow; header primary + `+N` + popover routing.

## Verification
- `packages/lib` + `apps/web` scoped `tsc --noEmit`: clean for all touched files (remaining errors are pre-existing in unrelated files: `scripts/*`, `human/panel.tsx`, `chat.ts`, `logo.tsx`, `command-palette.tsx`).
- Vitest: lib `src/field-values` + `src/resources` (479 tests) green incl. 4 new; web pickers/fields/records/dynamic-table/kopilot suites green incl. 20 new.
- Biome clean on all changed files.