### PR TITLE
feat(records): merge-dialog grant warning and multi-value union cap

### DIFF
--- a/apps/web/src/components/merge/grant-count.test.ts
+++ b/apps/web/src/components/merge/grant-count.test.ts
@@ -1,0 +1,41 @@
+// apps/web/src/components/merge/grant-count.test.ts
+
+import { ResourceGranteeType, type Rung } from '@auxx/database/enums'
+import { describe, expect, it } from 'vitest'
+import { countGrantedActors } from './grant-count'
+
+const row = (granteeType: ResourceGranteeType, rung: Rung) => ({ granteeType, rung })
+
+describe('countGrantedActors (merge-dialog grant warning)', () => {
+  it('counts user and group grants', () => {
+    expect(
+      countGrantedActors([
+        row(ResourceGranteeType.user, 'read'),
+        row(ResourceGranteeType.group, 'edit'),
+        row(ResourceGranteeType.user, 'admin'),
+      ])
+    ).toBe(3)
+  })
+
+  it('returns 0 when the target has no grants', () => {
+    expect(countGrantedActors([])).toBe(0)
+  })
+
+  it('excludes the workspace baseline role row — it is a floor, not a share', () => {
+    expect(
+      countGrantedActors([
+        row(ResourceGranteeType.role, 'read'),
+        row(ResourceGranteeType.user, 'read'),
+      ])
+    ).toBe(1)
+  })
+
+  it("excludes 'none' rung rows — a restriction marker never grants access", () => {
+    expect(
+      countGrantedActors([
+        row(ResourceGranteeType.user, 'none'),
+        row(ResourceGranteeType.group, 'read'),
+      ])
+    ).toBe(1)
+  })
+})

--- a/apps/web/src/components/merge/grant-count.ts
+++ b/apps/web/src/components/merge/grant-count.ts
@@ -1,0 +1,17 @@
+// apps/web/src/components/merge/grant-count.ts
+
+import { ResourceGranteeType, type Rung } from '@auxx/database/enums'
+
+/**
+ * Count the grantees that actually HOLD record-level access, from raw
+ * `resourceAccess.forInstance` rows. Two row kinds are NOT grants and are
+ * excluded:
+ * - `role` rows (`role:org_member`) are the workspace baseline/floor, not a
+ *   share with specific people;
+ * - a `none` rung is a RESTRICTION marker — it removes access, never grants it.
+ */
+export function countGrantedActors(
+  rows: Array<{ granteeType: ResourceGranteeType; rung: Rung }>
+): number {
+  return rows.filter((r) => r.granteeType !== ResourceGranteeType.role && r.rung !== 'none').length
+}

--- a/apps/web/src/components/merge/merge-dialog.tsx
+++ b/apps/web/src/components/merge/merge-dialog.tsx
@@ -1,7 +1,9 @@
 // apps/web/src/components/merge/merge-dialog.tsx
 'use client'
 
-import { getDefinitionId, type RecordId } from '@auxx/lib/resources/client'
+import { getDefinitionId, getInstanceId, type RecordId } from '@auxx/lib/resources/client'
+import { toRecordId } from '@auxx/types/resource'
+import { Alert, AlertDescription } from '@auxx/ui/components/alert'
 import { Button } from '@auxx/ui/components/button'
 import {
   Dialog,
@@ -14,11 +16,13 @@ import {
 import { EntityIcon } from '@auxx/ui/components/icons'
 import { Kbd } from '@auxx/ui/components/kbd'
 import { toastError } from '@auxx/ui/components/toast'
+import { Users } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useRecords, useResource } from '~/components/resources'
 import { useNormalizedDefinitionId } from '~/components/resources/utils/normalize-record-id'
 import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
+import { countGrantedActors } from './grant-count'
 import { MergePreviewPanel } from './merge-preview-panel'
 import { MergeSourcePanel } from './merge-source-panel'
 import { MergeTargetPanel } from './merge-target-panel'
@@ -85,6 +89,23 @@ export function MergeDialog({
     const defRung = (normalizedDefId ? recordDefRung(normalizedDefId) : undefined) ?? 'none'
     return records.every((record) => canDeleteRecordAt(record?._access ?? defRung))
   }, [records, normalizedDefId, recordDefRung, canDeleteRecordAt])
+
+  // Grant warning (contacts only): record-level grants on the TARGET widen with
+  // the merge — the grantee's contact lens fans out over the merged threads.
+  // ResourceAccess keys contact grants by the fixed 'contact' slug (the mail
+  // keyspace), and `forInstance` is the same read the share surfaces use — the
+  // server gates it on "may the caller SEE the target", which merging requires
+  // anyway. Source-contact grants stay on the archived sources (nothing
+  // transfers them), so only the target's grants matter here.
+  const isContactMerge = resource?.entityType === 'contact'
+  const { data: targetAccessRows } = api.resourceAccess.forInstance.useQuery(
+    { recordId: targetRecordId ? toRecordId('contact', getInstanceId(targetRecordId)) : '' },
+    { enabled: open && isContactMerge && !!targetRecordId }
+  )
+  const targetGrantCount = useMemo(
+    () => (isContactMerge ? countGrantedActors(targetAccessRows ?? []) : 0),
+    [isContactMerge, targetAccessRows]
+  )
 
   // Reset state when dialog closes
   useEffect(() => {
@@ -168,7 +189,7 @@ export function MergeDialog({
           <DialogTitle>Merge {resourceLabel}s</DialogTitle>
           <DialogDescription>
             Select items to merge into the target {resourceLabel.toLowerCase()}. All data will be
-            combined into the target.
+            combined into the target, and the source records will be permanently archived.
           </DialogDescription>
         </DialogHeader>
 
@@ -218,6 +239,21 @@ export function MergeDialog({
             isLoading={recordsLoading}
           />
         </div>
+
+        {/* Non-blocking notice: merging widens existing record-level grants on
+            the target to cover the merged conversation history. */}
+        {targetGrantCount > 0 && (
+          <Alert variant='warning'>
+            <Users />
+            <AlertDescription>
+              {targetGrantCount === 1
+                ? '1 person has access'
+                : `${targetGrantCount} people have access`}{' '}
+              to this contact&apos;s conversations — merging extends their access to the merged
+              contact&apos;s threads. Sharing on the source contacts is not carried over.
+            </AlertDescription>
+          </Alert>
+        )}
 
         <DialogFooter>
           <Button

--- a/apps/web/src/components/merge/use-merge-preview.ts
+++ b/apps/web/src/components/merge/use-merge-preview.ts
@@ -1,7 +1,7 @@
 // apps/web/src/components/merge/use-merge-preview.ts
 'use client'
 
-import { formatToRawValue } from '@auxx/lib/field-values/client'
+import { type FieldTypeOptions, formatToRawValue } from '@auxx/lib/field-values/client'
 import type { RecordId, ResourceField } from '@auxx/lib/resources/client'
 import { mergeFieldValue } from '@auxx/lib/resources/merge/client'
 import { useMemo } from 'react'
@@ -46,12 +46,18 @@ export function useMergePreview({
       const fieldType = field.fieldType
       if (!fieldType) continue
 
+      // Field options drive the array-return shape: without them a single
+      // stored value on an `options.multi` field unwraps to a scalar here while
+      // the server's batchGetValues hands mergeFieldValue an array — the preview
+      // must merge the same shapes the server writes.
+      const fieldOptions = field.options as FieldTypeOptions | undefined
+
       // Get target value from store (TypedFieldValue format)
       const targetStoreKey = buildFieldValueKey(targetRecordId, field.id)
       const targetStoreValue = storeValues[targetStoreKey]
 
       // EXPLICIT CONVERSION: TypedFieldValue → raw value
-      const targetValue = formatToRawValue(targetStoreValue, fieldType)
+      const targetValue = formatToRawValue(targetStoreValue, fieldType, fieldOptions)
 
       // Get source values from store (TypedFieldValue format)
       const sourceValues = sourceRecordIds.map((recordId) => {
@@ -59,7 +65,7 @@ export function useMergePreview({
         const sourceStoreValue = storeValues[sourceStoreKey]
 
         // EXPLICIT CONVERSION: TypedFieldValue → raw value
-        return formatToRawValue(sourceStoreValue, fieldType)
+        return formatToRawValue(sourceStoreValue, fieldType, fieldOptions)
       })
 
       // Skip fields that have no data in target or any sources

--- a/packages/lib/src/field-values/client.ts
+++ b/packages/lib/src/field-values/client.ts
@@ -34,6 +34,7 @@ export {
   type DateFieldOptions,
   extractValues,
   type FieldOptions,
+  type FieldTypeOptions,
   formatToDisplayValue,
   formatToRawValue,
   formatToTypedInput,

--- a/packages/lib/src/resources/merge/merge.test.ts
+++ b/packages/lib/src/resources/merge/merge.test.ts
@@ -1,0 +1,101 @@
+// packages/lib/src/resources/merge/merge.test.ts
+
+import type { TypedFieldValueInput } from '@auxx/types/field-value'
+import { describe, expect, it } from 'vitest'
+import { formatToRawValue } from '../../field-values/formatter'
+import { MAX_MULTI_VALUES } from '../../field-values/primary-value'
+import { mergeFieldValue } from './client'
+
+const MULTI_EMAIL = { fieldType: 'EMAIL' as const, fieldOptions: { multi: true } }
+
+describe('mergeFieldValue — multi-value union cap (D3)', () => {
+  it('clamps a 2×6 email union to MAX_MULTI_VALUES with target-first preference', () => {
+    const targetValue = Array.from({ length: 6 }, (_, i) => `target${i}@x.com`)
+    const sourceValues = [Array.from({ length: 6 }, (_, i) => `source${i}@x.com`)]
+
+    const result = mergeFieldValue({ targetValue, sourceValues, ...MULTI_EMAIL })
+
+    const merged = result.value as string[]
+    expect(merged).toHaveLength(MAX_MULTI_VALUES)
+    // Target values were pushed first, so the clamp drops SOURCE overflow:
+    // all 6 target values survive, and the target's primary stays index 0.
+    expect(merged.slice(0, 6)).toEqual(targetValue)
+    expect(merged[0]).toBe('target0@x.com')
+    expect(merged.slice(6)).toEqual(sourceValues[0]!.slice(0, 4))
+    expect(result.wasModified).toBe(true)
+  })
+
+  it('clamps after dedupe, not before — duplicates do not eat cap slots', () => {
+    const targetValue = Array.from({ length: 5 }, (_, i) => `target${i}@x.com`)
+    // First 5 source values duplicate the target (different case), then 5 new.
+    const sourceValues = [
+      [
+        ...targetValue.map((v) => v.toUpperCase()),
+        ...Array.from({ length: 5 }, (_, i) => `source${i}@x.com`),
+      ],
+    ]
+
+    const result = mergeFieldValue({ targetValue, sourceValues, ...MULTI_EMAIL })
+
+    const merged = result.value as string[]
+    expect(merged).toHaveLength(MAX_MULTI_VALUES)
+    expect(merged.slice(0, 5)).toEqual(targetValue)
+    expect(merged.slice(5)).toEqual(sourceValues[0]!.slice(5))
+  })
+
+  it('dedupes EMAIL case-insensitively, keeping the target casing', () => {
+    const result = mergeFieldValue({
+      targetValue: ['A@x.com'],
+      sourceValues: [['a@x.com'], ['A@X.COM']],
+      ...MULTI_EMAIL,
+    })
+
+    expect(result.value).toEqual(['A@x.com'])
+    expect(result.wasModified).toBe(false)
+  })
+
+  it('keeps non-EMAIL multi dedupe case-sensitive', () => {
+    const result = mergeFieldValue({
+      targetValue: ['Alpha'],
+      sourceValues: [['alpha']],
+      fieldType: 'TEXT',
+      fieldOptions: { multi: true },
+    })
+
+    expect(result.value).toEqual(['Alpha', 'alpha'])
+    expect(result.wasModified).toBe(true)
+  })
+
+  it('preview parity: scalar-shaped store value merges to the same union as the server array shape', () => {
+    // The server's batchGetValues always hands mergeFieldValue arrays for
+    // options.multi fields; the client store may hold a single TypedFieldValue
+    // for a one-value field. `formatToRawValue` with fieldOptions wraps that
+    // scalar so both paths merge identical shapes.
+    const typed = (value: string): TypedFieldValueInput => ({ type: 'text', value })
+    const fieldOptions = { multi: true }
+
+    const clientTarget = formatToRawValue(typed('primary@x.com'), 'EMAIL', fieldOptions)
+    const serverTarget = formatToRawValue([typed('primary@x.com')], 'EMAIL', fieldOptions)
+    expect(clientTarget).toEqual(serverTarget)
+
+    const sources = [
+      formatToRawValue([typed('alias@x.com'), typed('PRIMARY@x.com')], 'EMAIL', fieldOptions),
+    ]
+
+    const viaClient = mergeFieldValue({
+      targetValue: clientTarget,
+      sourceValues: sources,
+      fieldType: 'EMAIL',
+      fieldOptions,
+    })
+    const viaServer = mergeFieldValue({
+      targetValue: serverTarget,
+      sourceValues: sources,
+      fieldType: 'EMAIL',
+      fieldOptions,
+    })
+
+    expect(viaClient.value).toEqual(['primary@x.com', 'alias@x.com'])
+    expect(viaClient).toEqual(viaServer)
+  })
+})

--- a/packages/lib/src/resources/merge/merge.ts
+++ b/packages/lib/src/resources/merge/merge.ts
@@ -2,6 +2,7 @@
 
 import type { FieldType } from '@auxx/database/types'
 import { type FieldTypeOptions, isMultiValueFieldType } from '../../field-values/formatter'
+import { MAX_MULTI_VALUES } from '../../field-values/primary-value'
 import type { MergeFieldInput, MergeFieldResult } from './types'
 
 /**
@@ -94,10 +95,15 @@ function mergeMultiValue(
     }
   }
 
-  const targetArray = Array.isArray(targetValue) ? targetValue : []
-  const wasModified = uniqueValues.length !== targetArray.length
+  // Clamp to the write-path cap AFTER dedupe. Target values were pushed first,
+  // so the clamp drops source overflow preferentially and the target's primary
+  // stays at index 0.
+  const cappedValues = uniqueValues.slice(0, MAX_MULTI_VALUES)
 
-  return { value: uniqueValues, wasModified }
+  const targetArray = Array.isArray(targetValue) ? targetValue : []
+  const wasModified = cappedValues.length !== targetArray.length
+
+  return { value: cappedValues, wasModified }
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -216,6 +222,12 @@ function hasValue(value: unknown): boolean {
 
 /** Get deduplication key for a value (safer than JSON.stringify) */
 function getDedupeKey(value: unknown, fieldType: FieldType): string {
+  // EMAIL dedupes case-insensitively: the write path lowercases on store, so
+  // `A@x.com` and `a@x.com` are the same address and must collapse to one.
+  if (fieldType === 'EMAIL' && typeof value === 'string') {
+    return `${fieldType}:${value.toLowerCase()}`
+  }
+
   // For primitive values
   if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
     return `${fieldType}:${value}`


### PR DESCRIPTION
Final merge-flow lane of `plans/custom-field/multi/04-multi-email-implementation-plan.md` — items **D2** and **D3** (D1/D4/D5 shipped in #1615).

## D2 — merge-dialog grant warning + copy pass (`apps/web`)

- Contact merges now surface a non-blocking warning when the **target** carries record-level grants: *"N people have access to this contact's conversations — merging extends their access to the merged contact's threads. Sharing on the source contacts is not carried over."*
- Count rides the existing `resourceAccess.forInstance` read (the same endpoint every share surface uses — no new procedure), keyed by the fixed `contact` slug keyspace like `ContactSharedWithCard`, and only issued while the dialog is open on a contact def.
- `countGrantedActors` (new pure helper) excludes `role` rows (workspace baseline, not a share) and `none` rungs (restriction markers, never grants).
- Verified read-only in `merge-service.ts`: **no grant transfer exists anywhere in the merge transaction** — source-contact grants stay on the archived sources, reflected in the notice copy.
- Copy pass: dialog description now states source records are permanently archived.

## D3 — merge unions respect the cap (`packages/lib`)

- `mergeMultiValue` clamps the deduped union to `MAX_MULTI_VALUES` (10). Target values are pushed before sources, so the clamp drops source overflow preferentially and the target's primary stays index 0 (pinned by test).
- `getDedupeKey` lowercases the EMAIL key so `A@x.com` / `a@x.com` collapse — target casing wins (write path lowercases on store anyway). Other types stay case-sensitive.
- Preview parity: `use-merge-preview.ts` now passes `fieldOptions` into `formatToRawValue` (the optional third param from #1623), so a single stored value on an `options.multi` field wraps to the same array shape the server's `batchGetValues` hands `mergeFieldValue` (server side is already always array-shaped for multi fields — verified, no server change needed). `FieldTypeOptions` re-exported from `@auxx/lib/field-values/client` for the cast.

## Tests

- `packages/lib/src/resources/merge/merge.test.ts`: 2×6 email union clamps to 10 target-first; clamp happens AFTER dedupe (duplicates don't eat cap slots); case-insensitive email dedupe keeps target casing; non-EMAIL stays case-sensitive; preview-parity (scalar store shape and server array shape merge to the identical union through the `/client` path).
- `apps/web/src/components/merge/grant-count.test.ts`: counts user/group grants, 0 when unshared, excludes the baseline `role` row and `none`-rung restriction markers.

## Verification

- `vitest run src/resources/merge` (lib): 3 files, 12 tests green.
- `vitest run src/components/merge/grant-count.test.ts` (web): 4 tests green.
- Scoped `tsc --noEmit`: no errors in touched files (lib `src/` clean; web errors are the known pre-existing noise in unrelated files).
- Biome check clean on changed files (one pre-existing `FileValue` unused-interface warning in `merge.ts`, untouched).