### PR TITLE
feat(kopilot): add workflow detail editing

### DIFF
--- a/packages/lib/src/ai/kopilot/__tests__/tool-slug-coverage.test.ts
+++ b/packages/lib/src/ai/kopilot/__tests__/tool-slug-coverage.test.ts
@@ -65,6 +65,7 @@ const ALWAYS_ON_TOOLS = new Set<string>([
   'connect_nodes',
   'disconnect_nodes',
   'set_trigger',
+  'set_workflow_details',
   'replace_graph',
   'apply_template',
   'validate_workflow',

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/index.ts
@@ -18,6 +18,7 @@ import { createListNodeTypesTool } from './tools/list-node-types'
 import { createReplaceGraphTool } from './tools/replace-graph'
 import { createRunNodeTool } from './tools/run-node'
 import { createSetTriggerTool } from './tools/set-trigger'
+import { createSetWorkflowDetailsTool } from './tools/set-workflow-details'
 import { createUpdateNodeTool } from './tools/update-node'
 import { createValidateWorkflowTool } from './tools/validate-workflow'
 
@@ -44,6 +45,7 @@ const WRITE_TOOL_NAMES = [
   'set_trigger',
   'replace_graph',
   'apply_template',
+  'set_workflow_details',
 ]
 
 /**
@@ -75,6 +77,7 @@ export function createWorkflowBuilderCapabilities(getDeps: GetToolDeps): PageCap
       createConnectNodesTool(getDeps),
       createDisconnectNodesTool(getDeps),
       createSetTriggerTool(getDeps),
+      createSetWorkflowDetailsTool(getDeps),
       createReplaceGraphTool(getDeps),
       createApplyTemplateTool(getDeps),
       // Verify

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
@@ -76,9 +76,45 @@ vi.mock('../../../../../../workflows/graph-edit/run-node', () => ({
   runNode: (...a: unknown[]) => runNodeMock(...a),
 }))
 
+const captureWorkflowTurnSnapshot = vi.fn(async () => true)
 vi.mock('../../../../../../workflows/graph-edit/turn-snapshot', () => ({
+  captureWorkflowTurnSnapshot,
   readWorkflowTurnSnapshot: vi.fn(async () => null),
   revertWorkflowTurn: vi.fn(async () => ok({ graphHash: 'h' })),
+}))
+
+const loadDraftContext = vi.fn(async () =>
+  ok({
+    workflowAppId: 'wfapp-1',
+    organizationId: 'org-1',
+    appName: 'My Flow',
+    appDescription: 'Original description',
+    draftRow: null,
+    graph: { nodes: [], edges: [] },
+    triggerType: 'manual',
+  })
+)
+vi.mock('../../../../../../workflows/graph-edit/read', () => ({
+  loadDraftContext,
+}))
+
+const updateWorkflowDetails = vi.fn(
+  async (_organizationId: string, _input: Record<string, unknown>) => ({
+    name: 'Renamed workflow',
+    description: 'New description',
+  })
+)
+vi.mock('../../../../../../workflows/workflow-service', () => ({
+  WorkflowService: class {
+    update(organizationId: string, input: Record<string, unknown>) {
+      return updateWorkflowDetails(organizationId, input)
+    }
+  },
+}))
+
+const publishDraftUpdatedSignal = vi.fn(async () => {})
+vi.mock('../../../../../../workflows/graph-edit/persist', () => ({
+  publishDraftUpdatedSignal,
 }))
 
 vi.mock('../../../../../../demo', () => ({
@@ -101,6 +137,7 @@ type CapsStub = {
   can: ReturnType<typeof vi.fn>
   canViewInstance: ReturnType<typeof vi.fn>
   assertEditInstance: ReturnType<typeof vi.fn>
+  assertAdminInstance: ReturnType<typeof vi.fn>
 }
 
 function makeCaps(): CapsStub {
@@ -108,6 +145,7 @@ function makeCaps(): CapsStub {
     can: vi.fn(() => true),
     canViewInstance: vi.fn(() => true),
     assertEditInstance: vi.fn(() => {}),
+    assertAdminInstance: vi.fn(() => {}),
   }
 }
 
@@ -162,6 +200,7 @@ const VALID_ARGS: Record<string, Record<string, unknown>> = {
   set_trigger: { triggerType: 'manual' },
   replace_graph: { nodes: [{ type: 'wait' }], edges: [] },
   apply_template: { templateId: 'file:x' },
+  set_workflow_details: { name: 'Renamed workflow' },
   run_node: { ref: 'Wait A Bit' },
 }
 
@@ -178,6 +217,7 @@ const MUTATION_TOOLS = [
   'set_trigger',
   'replace_graph',
   'apply_template',
+  'set_workflow_details',
 ] as const
 const VIEW_TOOLS = ['get_workflow', 'get_node', 'validate_workflow'] as const
 const GUARDED = [...VIEW_TOOLS, ...MUTATION_TOOLS, 'run_node'] as const
@@ -191,6 +231,10 @@ beforeEach(() => {
   opMock.mockClear()
   readDraftMock.mockClear()
   runNodeMock.mockClear()
+  captureWorkflowTurnSnapshot.mockClear()
+  loadDraftContext.mockClear()
+  updateWorkflowDetails.mockClear()
+  publishDraftUpdatedSignal.mockClear()
 })
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -280,6 +324,45 @@ describe('workflow.builder authorization enumeration', () => {
     })
     await expect(run(tool('add_node'), VALID_ARGS.add_node)).rejects.toThrow(ForbiddenError)
     expect(caps!.assertEditInstance).toHaveBeenCalledWith('workflow', WF)
+  })
+
+  it('workflow details require the admin instance rung', async () => {
+    caps!.assertAdminInstance.mockImplementation(() => {
+      throw new ForbiddenError('admin required')
+    })
+    await expect(
+      run(tool('set_workflow_details'), VALID_ARGS.set_workflow_details)
+    ).rejects.toThrow(ForbiddenError)
+    expect(caps!.assertAdminInstance).toHaveBeenCalledWith('workflow', WF)
+  })
+
+  it('updates workflow details with a turn snapshot and a draft refresh', async () => {
+    const result = await run(tool('set_workflow_details'), {
+      name: 'Renamed workflow',
+      description: 'New description',
+    })
+
+    expect(result).toMatchObject({
+      success: true,
+      output: { name: 'Renamed workflow', description: 'New description' },
+    })
+    expect(caps!.assertAdminInstance).toHaveBeenCalledWith('workflow', WF)
+    expect(captureWorkflowTurnSnapshot).toHaveBeenCalledWith(WF, 'turn-1', {
+      graph: { nodes: [], edges: [] },
+      triggerType: 'manual',
+      name: 'My Flow',
+      description: 'Original description',
+    })
+    expect(updateWorkflowDetails).toHaveBeenCalledWith(ORG, {
+      id: WF,
+      name: 'Renamed workflow',
+      description: 'New description',
+      preserveTurnSnapshot: true,
+    })
+    expect(publishDraftUpdatedSignal).toHaveBeenCalledWith(ORG, {
+      workflowAppId: WF,
+      reason: 'kopilot',
+    })
   })
 
   it('system-owned workflows stay blind on reads and forbidden on writes', async () => {

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/write-tools.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/write-tools.test.ts
@@ -110,6 +110,7 @@ describe('add_node', () => {
     const result = await run(createAddNodeTool(getDeps), {
       type: 'http',
       title: 'HTTP Request',
+      description: 'Notify the order system',
       after: 'Every Morning',
       config: { url: 'https://example.com' },
     })
@@ -124,6 +125,7 @@ describe('add_node', () => {
       type: 'http',
       title: 'HTTP Request',
       after: 'Every Morning',
+      config: { url: 'https://example.com', desc: 'Notify the order system' },
     })
 
     const output = result.output as {

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/add-node.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/add-node.ts
@@ -29,6 +29,11 @@ export function createAddNodeTool(getDeps: GetToolDeps): AgentToolDefinition {
       properties: {
         type: { type: 'string', description: "Authorable node type (e.g. 'http', 'find')." },
         title: { type: 'string', description: 'Node title — unique, human-readable.' },
+        description: {
+          type: 'string',
+          description:
+            'One line explaining why this node exists, in the user’s terms. Shown under the node title on the canvas.',
+        },
         config: {
           type: 'object',
           description:
@@ -49,6 +54,8 @@ export function createAddNodeTool(getDeps: GetToolDeps): AgentToolDefinition {
       if (!write.ok) return { success: false, output: null, error: write.error }
       const type = typeof args.type === 'string' ? args.type : ''
       if (!type) return { success: false, output: null, error: 'type is required.' }
+      const config = optionalRecord(args.config)
+      const description = optionalString(args.description)
 
       const { db } = getDeps()
       // Lazy import — see get-workflow.ts.
@@ -57,7 +64,9 @@ export function createAddNodeTool(getDeps: GetToolDeps): AgentToolDefinition {
         ...write.scope,
         type,
         ...(optionalString(args.title) ? { title: optionalString(args.title) } : {}),
-        ...(optionalRecord(args.config) ? { config: optionalRecord(args.config) } : {}),
+        ...(config || description
+          ? { config: { ...config, ...(description ? { desc: description } : {}) } }
+          : {}),
         ...(optionalString(args.after) ? { after: optionalString(args.after) } : {}),
         ...(optionalString(args.branch) ? { branch: optionalString(args.branch) } : {}),
         ...(optionalString(args.inside) ? { inside: optionalString(args.inside) } : {}),

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/graph-tool-helpers.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/graph-tool-helpers.ts
@@ -17,7 +17,7 @@ import type { AgentToolResult } from '../../../../agent-framework/types'
  * else. `level` narrows per tool (view for reads, edit for mutations +
  * `run_node`, matching the tRPC ladder).
  */
-export function workflowToolPermission(level: 'view' | 'edit'): AgentToolPermission {
+export function workflowToolPermission(level: 'view' | 'edit' | 'admin'): AgentToolPermission {
   return {
     target: 'instance',
     keys: ['workflow'],
@@ -26,7 +26,13 @@ export function workflowToolPermission(level: 'view' | 'edit'): AgentToolPermiss
     note:
       'resolveWorkflowAuthoring — fail-closed on absent capabilities, PermissionKey.workflowsView ' +
       'area rung, org-scope check on the session workflow ref, ' +
-      `${level === 'view' ? 'canViewInstance (silent read filter)' : 'assertEditInstance'} ` +
+      `${
+        level === 'view'
+          ? 'canViewInstance (silent read filter)'
+          : level === 'edit'
+            ? 'assertEditInstance'
+            : 'assertAdminInstance'
+      } ` +
       'per workflow, and assertWorkflowAppNotSystemOwned. Proven behaviourally by ' +
       'workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts.',
   }

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/set-workflow-details.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/set-workflow-details.ts
@@ -1,0 +1,99 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/set-workflow-details.ts
+
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import { buildWorkflowEditDigest } from '../../../digests'
+import type { GetToolDeps } from '../../types'
+import { workflowToolPermission } from './graph-tool-helpers'
+import { resolveWorkflowAdminWrite } from './write-tool-helpers'
+
+/** Update the open workflow's user-facing name and description. */
+export function createSetWorkflowDetailsTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'set_workflow_details',
+    permission: workflowToolPermission('admin'),
+    displayName: 'Set workflow details',
+    surfaces: ['builder'],
+    description:
+      'Update the open workflow’s name and/or description. This is a workflow settings action and requires Full access. The change is included in the current Kopilot turn and is reverted if that turn fails.',
+    parameters: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'New workflow name. Must not be empty.' },
+        description: {
+          type: 'string',
+          description: 'New workflow description. Pass an empty string to clear it.',
+        },
+      },
+      additionalProperties: false,
+    },
+    summary: () => 'Update workflow details',
+    buildDigest: (output) => buildWorkflowEditDigest('Updated workflow details', output),
+    execute: async (args, agentDeps) => {
+      const write = await resolveWorkflowAdminWrite(getDeps, agentDeps)
+      if (!write.ok) return { success: false, output: null, error: write.error }
+
+      const nameValue = typeof args.name === 'string' ? args.name : undefined
+      const descriptionValue = typeof args.description === 'string' ? args.description : undefined
+      if (nameValue === undefined && descriptionValue === undefined) {
+        return { success: false, output: null, error: 'Provide a name and/or description.' }
+      }
+      const name = nameValue?.trim()
+      if (nameValue !== undefined && !name) {
+        return { success: false, output: null, error: 'name must not be empty.' }
+      }
+
+      const { db } = getDeps()
+      // Capture the same pre-turn state as graph mutations before this settings
+      // write, so a failed turn restores both graph and workflow metadata.
+      const { loadDraftContext } = await import('../../../../../workflows/graph-edit/read')
+      const loaded = await loadDraftContext(db, write.scope)
+      if (loaded.isErr()) return { success: false, output: null, error: loaded.error.message }
+      const draft = loaded.value
+
+      const { captureWorkflowTurnSnapshot } = await import(
+        '../../../../../workflows/graph-edit/turn-snapshot'
+      )
+      await captureWorkflowTurnSnapshot(write.scope.workflowAppId, write.scope.turnId!, {
+        graph: draft.graph,
+        triggerType: draft.triggerType,
+        name: draft.appName,
+        description: draft.appDescription,
+      })
+
+      try {
+        const { WorkflowService } = await import('../../../../../workflows/workflow-service')
+        const updated = await new WorkflowService(db).update(write.scope.organizationId, {
+          id: write.scope.workflowAppId,
+          ...(name !== undefined ? { name } : {}),
+          ...(descriptionValue !== undefined ? { description: descriptionValue } : {}),
+          preserveTurnSnapshot: true,
+        })
+        const { publishDraftUpdatedSignal } = await import(
+          '../../../../../workflows/graph-edit/persist'
+        )
+        await publishDraftUpdatedSignal(write.scope.organizationId, {
+          workflowAppId: write.scope.workflowAppId,
+          reason: 'kopilot',
+        })
+        return {
+          success: true,
+          output: {
+            applied: true,
+            summary: 'Updated workflow details',
+            name: updated?.name ?? name ?? draft.appName,
+            description:
+              updated?.description ??
+              (descriptionValue !== undefined ? descriptionValue : draft.appDescription),
+            issues: [],
+          },
+        }
+      } catch (error) {
+        return {
+          success: false,
+          output: null,
+          error: error instanceof Error ? error.message : String(error),
+        }
+      }
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/workflow-authoring-guard.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/workflow-authoring-guard.ts
@@ -45,7 +45,7 @@ export type WorkflowAuthoringResolution =
  * purpose — a shared gate with a hardcoded tier is how a Kopilot tool ends up
  * cheaper than the router it mirrors.
  */
-export type WorkflowAuthoringTier = 'view' | 'edit'
+export type WorkflowAuthoringTier = 'view' | 'edit' | 'admin'
 
 /**
  * **The** authorization gate for every graph tool in the `workflow.builder`
@@ -68,7 +68,7 @@ export type WorkflowAuthoringTier = 'view' | 'edit'
  * 3. **Org scope** — the workflow id arrives in client-supplied session refs;
  *    a foreign id must read as "not in this workspace", never leak existence.
  * 4. **Per-workflow instance rung** — `canViewInstance` (silent) for reads,
- *    `assertEditInstance` (throws `ForbiddenError`) for writes; plan 30's
+ *    `assertEditInstance` / `assertAdminInstance` (throws `ForbiddenError`) for writes; plan 30's
  *    per-workflow `ResourceAccess` rows.
  * 5. **`assertWorkflowAppNotSystemOwned`** — every workflow router procedure
  *    applies it (sequences compile to hidden system-owned apps), so the
@@ -133,8 +133,10 @@ export async function resolveWorkflowAuthoring(
     if (!capabilities.canViewInstance('workflow', workflowAppId)) {
       return { ok: false, error: WORKFLOW_NOT_FOUND_ERROR }
     }
-  } else {
+  } else if (tier === 'edit') {
     capabilities.assertEditInstance('workflow', workflowAppId)
+  } else {
+    capabilities.assertAdminInstance('workflow', workflowAppId)
   }
 
   // (5) System-owned lockdown — reads stay blind, writes get the guard's own

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/write-tool-helpers.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/write-tool-helpers.ts
@@ -38,6 +38,30 @@ export async function resolveWorkflowWrite(
   }
 }
 
+/** Admin-tier variant for workflow settings that are still part of an AI turn. */
+export async function resolveWorkflowAdminWrite(
+  getDeps: GetToolDeps,
+  agentDeps: AgentDeps
+): Promise<WriteResolution> {
+  const auth = await resolveWorkflowAuthoring(getDeps, agentDeps, 'admin', { mutation: true })
+  if (!auth.ok) return auth
+  const turnId = agentDeps.turnId
+  if (!turnId) {
+    return {
+      ok: false,
+      error: 'No turnId on agent deps — cannot scope kopilot workflow writes.',
+    }
+  }
+  return {
+    ok: true,
+    scope: {
+      workflowAppId: auth.workflowAppId,
+      organizationId: agentDeps.organizationId,
+      turnId,
+    },
+  }
+}
+
 /** Optional-string arg helper — trims, empty → undefined. */
 export function optionalString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim() !== '' ? value : undefined

--- a/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
@@ -14,7 +14,7 @@
 export function buildWorkflowBuilderPromptSection(): string {
   return [
     // What the surface is + where edits go.
-    "You can read and edit the workflow open in this builder. All edits go to the DRAFT — publishing is the user's action, in the editor. After editing, say what you changed and that they can review and publish; never imply the workflow is live. This page is scoped to exactly ONE workflow (the one in the active references). If asked to build or edit a different workflow — or several — say honestly that you can only work on the open one and the user should open the other workflow's builder.",
+    "You can read and edit the workflow open in this builder. All edits go to the DRAFT — publishing is the user's action, in the editor. Use set_workflow_details to give a workflow you build a concise, user-facing name and description when you have Full access. After editing, say what you changed and that they can review and publish; never imply the workflow is live. This page is scoped to exactly ONE workflow (the one in the active references). If asked to build or edit a different workflow — or several — say honestly that you can only work on the open one and the user should open the other workflow's builder.",
 
     // Reference grammar.
     "Reference grammar: values flow between nodes as `{{Node Title.output}}` — e.g. `{{Find Contact.record.email}}`. Every mutation and `get_workflow`/`get_node` returns each node's resolved outputs; wire references ONLY from those. Never invent an output name, never guess a path, and never write a raw node id inside `{{…}}` — always the node's title exactly as the tools return it.",
@@ -34,13 +34,16 @@ export function buildWorkflowBuilderPromptSection(): string {
     // Positions.
     'Positions: do not send coordinates — layout is automatic and existing nodes never move. Only pass `position` if the user explicitly asks for a specific placement.',
 
+    // Canvas readability.
+    'Every node you add needs a concise `description` that explains why it exists in the user’s terms. This appears under the node title on the canvas.',
+
     // Verification + simulation.
     'Verifying: `validate_workflow` runs the real publish gate without publishing — use it after a batch of edits. `run_node` executes ONE node as a SIMULATED debug run (side-effecting nodes do not send email, call webhooks, etc.); you supply its input values — upstream nodes are not executed. Say clearly in your reply that the run was simulated.',
 
     // Worked examples.
     [
       'Worked examples:',
-      '  - add_node(type: "http", title: "Post To Webhook", after: "Check Priority", branch: "High", config: { url: "https://example.com/hook", method: "POST" })',
+      '  - add_node(type: "http", title: "Post To Webhook", description: "Notify the fulfillment system about high-priority orders", after: "Check Priority", branch: "High", config: { url: "https://example.com/hook", method: "POST" })',
       '  - update_node(ref: "Send Email", config: { subject: "Order {{Find Order.record.number}} update" })',
       '  - add_node(type: "crud", title: "Create Task", inside: "For Each Line Item", config: { … "{{For Each Line Item.item.name}}" … })',
       '  - connect_nodes(from: "Summarize Email", to: "Save Summary")',

--- a/packages/lib/src/workflows/graph-edit/__tests__/turn-lifecycle.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/turn-lifecycle.test.ts
@@ -110,6 +110,7 @@ function makeDb(graph: DraftGraph, triggerType: string | null = 'scheduled') {
   const app = {
     id: APP,
     name: 'My Flow',
+    description: 'Original description',
     organizationId: ORG,
     draftWorkflow: {
       id: 'wf_draft',
@@ -158,6 +159,8 @@ describe('turn snapshot capture', () => {
     const snapshot = await readWorkflowTurnSnapshot(APP, TURN_A)
     expect(snapshot).not.toBeNull()
     expect(snapshot?.turnId).toBe(TURN_A)
+    expect(snapshot?.name).toBe('My Flow')
+    expect(snapshot?.description).toBe('Original description')
     expect(snapshot?.triggerType).toBe('scheduled')
     // The snapshot is the graph BEFORE the mutation — one node, no wait.
     expect(snapshot?.graph.nodes.map((n) => n.id)).toEqual([TRIGGER_ID])
@@ -223,6 +226,8 @@ describe('revert / finalize lifecycle', () => {
     const written = input.graph as DraftGraph
     expect(written.nodes.map((n) => n.id)).toEqual([TRIGGER_ID])
     expect(written.edges).toEqual([])
+    expect(input.name).toBe('My Flow')
+    expect(input.description).toBe('Original description')
     // CAS token from the CURRENT draft — a write racing the revert 409s.
     expect(input.expectedGraphHash).toBe(hashWorkflowGraph(mutated))
 

--- a/packages/lib/src/workflows/graph-edit/ops.ts
+++ b/packages/lib/src/workflows/graph-edit/ops.ts
@@ -153,6 +153,8 @@ async function runGraphMutation(
     await captureWorkflowTurnSnapshot(scope.workflowAppId, scope.turnId, {
       graph: ctx.graph,
       triggerType: ctx.triggerType,
+      name: ctx.appName,
+      description: ctx.appDescription,
     })
   }
 

--- a/packages/lib/src/workflows/graph-edit/persist.ts
+++ b/packages/lib/src/workflows/graph-edit/persist.ts
@@ -60,6 +60,9 @@ export function cleanGraphForSave(graph: DraftGraph): DraftGraph {
 /** What a mutation hands the persist seam. */
 export interface PersistDraftInput {
   graph: DraftGraph
+  /** Optional WorkflowApp metadata to atomically restore with a failed AI turn. */
+  name?: string
+  description?: string | null
   /** CAS token from `loadDraftContext` — a concurrent save between load and write 409s. */
   expectedGraphHash?: string
   /**
@@ -117,6 +120,8 @@ export async function persistDraft(
       // mutation pipeline captured just before this persist. Manual canvas
       // saves (which don't go through this seam) DO clear it.
       preserveTurnSnapshot: true,
+      ...(input.name !== undefined ? { name: input.name } : {}),
+      ...(input.description !== undefined ? { description: input.description } : {}),
       ...(input.expectedGraphHash !== undefined
         ? { expectedGraphHash: input.expectedGraphHash }
         : {}),

--- a/packages/lib/src/workflows/graph-edit/read.ts
+++ b/packages/lib/src/workflows/graph-edit/read.ts
@@ -39,6 +39,7 @@ export interface DraftContext {
   workflowAppId: string
   organizationId: string
   appName: string
+  appDescription: string | null
   /** The raw draft `Workflow` row (null when the app has no draft yet). */
   draftRow: Record<string, unknown> | null
   graph: DraftGraph
@@ -88,6 +89,7 @@ export async function loadDraftContext(
     workflowAppId,
     organizationId,
     appName: app.name,
+    appDescription: app.description,
     draftRow,
     graph: toDraftGraph(rawGraph),
     ...(rawGraph ? { graphHash: hashWorkflowGraph(rawGraph) } : {}),

--- a/packages/lib/src/workflows/graph-edit/turn-snapshot.ts
+++ b/packages/lib/src/workflows/graph-edit/turn-snapshot.ts
@@ -6,7 +6,7 @@
  * §7): the FIRST mutation of a turn stores the pre-edit graph under
  * `(workflowAppId, turnId)` with a 24h TTL. The snapshot exists ONLY for
  * failed-turn atomicity: on turn FAILURE the lifecycle reverts (restores the
- * exact prior graph through `persistDraft`); on turn SUCCESS it is discarded
+ * exact prior graph and workflow details through `persistDraft`); on turn SUCCESS it is discarded
  * via {@link finalizeWorkflowTurn}. Undo of a completed turn is client-side —
  * the builder's `workflow:draft-updated` subscriber records each Kopilot edit
  * as a normal canvas history entry, so there is no per-turn Undo card and no
@@ -46,6 +46,9 @@ const TTL_SECONDS = 24 * 60 * 60
  */
 export interface WorkflowPreTurnSnapshot {
   turnId: string
+  /** WorkflowApp metadata exactly as stored before the turn's first write. */
+  name: string
+  description: string | null
   /** The draft graph exactly as stored BEFORE the turn's first write. */
   graph: DraftGraph
   /** The draft row's trigger type column at capture time (persist fallback). */
@@ -67,7 +70,12 @@ const snapshotKey = (workflowAppId: string): string => `workflow:graph:${workflo
 export async function captureWorkflowTurnSnapshot(
   workflowAppId: string,
   turnId: string,
-  data: { graph: DraftGraph; triggerType?: string | null }
+  data: {
+    graph: DraftGraph
+    triggerType?: string | null
+    name: string
+    description: string | null
+  }
 ): Promise<boolean> {
   const existing = (await getRedisData(
     snapshotKey(workflowAppId)
@@ -76,6 +84,8 @@ export async function captureWorkflowTurnSnapshot(
 
   const snapshot: WorkflowPreTurnSnapshot = {
     turnId,
+    name: data.name,
+    description: data.description,
     graph: data.graph,
     triggerType: data.triggerType ?? null,
     capturedAt: Date.now(),
@@ -181,6 +191,8 @@ export async function revertWorkflowTurn(
   const persisted = await persistDraft(db, scope, {
     graph: snapshot.graph,
     fallbackTriggerType: snapshot.triggerType,
+    name: snapshot.name,
+    description: snapshot.description,
     ...(loaded.value.graphHash !== undefined ? { expectedGraphHash: loaded.value.graphHash } : {}),
   })
   if (persisted.isErr()) return persisted

--- a/packages/lib/src/workflows/types.ts
+++ b/packages/lib/src/workflows/types.ts
@@ -62,7 +62,7 @@ export interface WorkflowCreateInput {
 export interface WorkflowUpdateInput {
   id: string
   name?: string
-  description?: string
+  description?: string | null
   enabled?: boolean
   triggerType?: WorkflowTriggerType | null
   entityDefinitionId?: string | null // NEW: replaces triggerConfig


### PR DESCRIPTION
## Summary
- add a Full-access Kopilot tool for naming and describing workflows
- include workflow metadata in turn snapshots so failed turns revert it with the graph
- add explicit AI-authored node descriptions that render on the canvas

## Verification
- Focused Vitest suite: 40 tests passed
- Biome check on touched files passed
- @auxx/lib typecheck remains blocked by existing unrelated script/config diagnostics