### PR TITLE
fix(records): keep multi-value email/url table cells array-shaped

### DIFF
--- a/apps/web/src/components/resources/hooks/use-create-record.ts
+++ b/apps/web/src/components/resources/hooks/use-create-record.ts
@@ -62,9 +62,11 @@ export function useCreateRecord(opts: UseCreateRecordOptions): {
   const createMutation = api.record.create.useMutation()
   const createManyMutation = api.record.createMany.useMutation()
 
-  /** Resolve each input value's `fieldType` from the resource store so the seed
-   *  builds typed field values. Keys may be systemAttribute, ResourceFieldId, or
-   *  a bare field UUID — resolve via the systemAttribute map, then by ref. */
+  /** Resolve each input value's `fieldType` + `fieldOptions` from the resource
+   *  store so the seed builds typed field values. Keys may be systemAttribute,
+   *  ResourceFieldId, or a bare field UUID — resolve via the systemAttribute
+   *  map, then by ref. `fieldOptions` (options.multi, actor.multiple) keeps the
+   *  seeded shape array-stable for multi-value scalar fields. */
   const toSeedValues = useCallback(
     (values: Record<string, unknown>): SeedFieldValue[] => {
       const store = useResourceStore.getState()
@@ -73,7 +75,12 @@ export function useCreateRecord(opts: UseCreateRecordOptions): {
         const field =
           store.getFieldByRef(ref) ??
           store.getFieldByRef(toResourceFieldId(entityDefinitionId, fieldId))
-        return { fieldId, value, fieldType: field?.fieldType as FieldType | undefined }
+        return {
+          fieldId,
+          value,
+          fieldType: field?.fieldType as FieldType | undefined,
+          fieldOptions: field?.options as SeedFieldValue['fieldOptions'],
+        }
       })
     },
     [entityDefinitionId]

--- a/apps/web/src/components/resources/hooks/use-seed-created-record.test.ts
+++ b/apps/web/src/components/resources/hooks/use-seed-created-record.test.ts
@@ -1,0 +1,91 @@
+// apps/web/src/components/resources/hooks/use-seed-created-record.test.ts
+//
+// Regression: the create-dialog optimistic seed used to convert a multi-email
+// array through the scalar converter branch — `String(array)` — so the records
+// table rendered "a@x.io,b@y.io" in ONE CopyableLinkCell right after create,
+// and the joined string survived every list refetch (the fetch queue skips
+// keys that already hold a value) until a full page reload. With
+// `fieldOptions` threaded through (the #1623 third-param pattern) the seed
+// stores the same ordered TypedFieldValueInput[] shape `fieldValue.batchGet`
+// delivers.
+
+import type { RecordId } from '@auxx/lib/resources/client'
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { buildFieldValueKey, useFieldValueStore } from '../store/field-value-store'
+import { useSeedCreatedRecord } from './use-seed-created-record'
+
+const DEF_ID = 'cmdefcontact1234567890abcd'
+const EMAIL_FIELD = `${DEF_ID}:cmfldemail1234567890abcd`
+const NOTES_FIELD = `${DEF_ID}:cmfldnotes1234567890abcd`
+
+const recordId = `${DEF_ID}:rec1` as RecordId
+
+const instance = {
+  id: 'rec1',
+  displayName: 'Anna Multimail',
+  secondaryDisplayValue: null,
+  avatarUrl: null,
+  createdAt: '2026-08-14T00:00:00.000Z',
+  updatedAt: '2026-08-14T00:00:00.000Z',
+}
+
+function seed(
+  values: Parameters<ReturnType<typeof useSeedCreatedRecord>['seedCreatedRecord']>[0]['values']
+) {
+  const { result } = renderHook(() => useSeedCreatedRecord())
+  result.current.seedCreatedRecord({
+    entityDefinitionId: DEF_ID,
+    recordId,
+    instance,
+    values,
+  })
+}
+
+beforeEach(() => {
+  useFieldValueStore.getState().clearAll()
+})
+
+describe('useSeedCreatedRecord — options.multi fields', () => {
+  it('seeds a multi EMAIL array as TypedFieldValueInput[] (primary first), not a comma string', () => {
+    seed([
+      {
+        fieldId: EMAIL_FIELD,
+        value: ['anna.work@corp.io', 'anna@example.com'],
+        fieldType: 'EMAIL',
+        fieldOptions: { multi: true },
+      },
+    ])
+
+    const value = useFieldValueStore.getState().values[buildFieldValueKey(recordId, EMAIL_FIELD)]
+    expect(value).toEqual([
+      { type: 'text', value: 'anna.work@corp.io' },
+      { type: 'text', value: 'anna@example.com' },
+    ])
+    // The old bug: String(['a','b']) => 'a,b' stored as ONE text value.
+    expect(JSON.stringify(value)).not.toContain('anna.work@corp.io,anna@example.com')
+  })
+
+  it('normalizes a scalar on a multi field to a one-element array (stable shape)', () => {
+    seed([
+      {
+        fieldId: EMAIL_FIELD,
+        value: 'anna.work@corp.io',
+        fieldType: 'EMAIL',
+        fieldOptions: { multi: true },
+      },
+    ])
+
+    expect(useFieldValueStore.getState().values[buildFieldValueKey(recordId, EMAIL_FIELD)]).toEqual(
+      [{ type: 'text', value: 'anna.work@corp.io' }]
+    )
+  })
+
+  it('keeps single-value fields scalar-shaped', () => {
+    seed([{ fieldId: NOTES_FIELD, value: 'hello', fieldType: 'TEXT', fieldOptions: {} }])
+
+    expect(useFieldValueStore.getState().values[buildFieldValueKey(recordId, NOTES_FIELD)]).toEqual(
+      { type: 'text', value: 'hello' }
+    )
+  })
+})

--- a/apps/web/src/components/resources/hooks/use-seed-created-record.ts
+++ b/apps/web/src/components/resources/hooks/use-seed-created-record.ts
@@ -1,7 +1,11 @@
 // apps/web/src/components/resources/hooks/use-seed-created-record.ts
 
 import type { FieldType } from '@auxx/database/types'
-import { formatToTypedInput } from '@auxx/lib/field-values/client'
+import {
+  type FieldOptions,
+  formatToTypedInput,
+  isArrayReturnFieldType,
+} from '@auxx/lib/field-values/client'
 import type { RecordId } from '@auxx/lib/resources/client'
 import { useCallback } from 'react'
 import {
@@ -32,6 +36,14 @@ export interface SeedFieldValue {
   fieldId: string
   value: unknown
   fieldType?: FieldType
+  /**
+   * Field options (`options.multi`, `actor.multiple`, …). Without them a
+   * multi-value scalar field (EMAIL/URL/PHONE with `options.multi`) seeds
+   * through the scalar converter branch, which joins the array into ONE
+   * comma string (`String(array)`) — the table cell then renders
+   * "a@x.io,b@y.io" in a single chip until a full page reload.
+   */
+  fieldOptions?: FieldOptions
 }
 
 /**
@@ -81,15 +93,24 @@ export function useSeedCreatedRecord() {
       if (listKey) recordStore.appendCreatedRecord(listKey, instance.id)
 
       const resourceState = useResourceStore.getState()
-      const entries = values.map(({ fieldId, value, fieldType }) => {
+      const entries = values.map(({ fieldId, value, fieldType, fieldOptions }) => {
         const resourceFieldId = (resolveSystemAttributeForRecord(
           resourceState,
           fieldId,
           recordId
         ) ?? fieldId) as FieldReference
+        // Stable array shape for array-return fields (options.multi scalars,
+        // multi ACTOR): normalize a scalar to a one-element array so the seeded
+        // shape matches what `fieldValue.batchGet` delivers on refetch — cell
+        // renderers branch on Array.isArray. `fieldOptions` also routes arrays
+        // through the per-item converter instead of `String(array)`.
+        const isArrayReturn = fieldType ? isArrayReturnFieldType(fieldType, fieldOptions) : false
+        const normalized = isArrayReturn && value != null && !Array.isArray(value) ? [value] : value
         return {
           key: buildFieldValueKey(recordId, resourceFieldId),
-          value: fieldType ? formatToTypedInput(value, fieldType) : value,
+          value: fieldType
+            ? formatToTypedInput(normalized, fieldType, { fieldOptions })
+            : normalized,
         }
       })
       useFieldValueStore.getState().setValues(entries)

--- a/apps/web/src/components/resources/store/hydrate-field-values.test.ts
+++ b/apps/web/src/components/resources/store/hydrate-field-values.test.ts
@@ -1,0 +1,115 @@
+// apps/web/src/components/resources/store/hydrate-field-values.test.ts
+//
+// Multi-value (options.multi) shape guards for the record-data → field-value
+// store bridge. Record-row data carries at most the denormalized PRIMARY value
+// for a multi scalar field (e.g. contact `email` via `dbColumn`), so hydration
+// must NOT seed a scalar there: the fetch queue and cell hooks skip keys that
+// already hold a value, so a seeded scalar blocks the authoritative
+// `fieldValue.batchGet` array and the table cell shows only the primary until
+// something else overwrites the key.
+
+import type { Resource, ResourceField } from '@auxx/lib/resources/client'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { buildFieldValueKey, useFieldValueStore } from './field-value-store'
+import { hydrateFieldValues, hydrateMultipleRecords } from './hydrate-field-values'
+
+const DEF_ID = 'cmdefcontact1234567890abcd'
+
+const multiEmailField = {
+  id: 'cmfldemail1234567890abcd',
+  resourceFieldId: `${DEF_ID}:cmfldemail1234567890abcd`,
+  key: 'primaryEmail',
+  label: 'Email',
+  type: 'email',
+  fieldType: 'EMAIL',
+  isSystem: true,
+  systemAttribute: 'primary_email',
+  dbColumn: 'email',
+  options: { multi: true },
+} as unknown as ResourceField
+
+const notesField = {
+  id: 'cmfldnotes1234567890abcd',
+  resourceFieldId: `${DEF_ID}:cmfldnotes1234567890abcd`,
+  key: 'notes',
+  label: 'Notes',
+  type: 'text',
+  fieldType: 'TEXT',
+  options: {},
+} as unknown as ResourceField
+
+const resource = {
+  id: DEF_ID,
+  entityDefinitionId: DEF_ID,
+  entityType: 'contact',
+  apiSlug: 'contacts',
+  fields: [multiEmailField, notesField],
+} as unknown as Resource
+
+const recordId = `${DEF_ID}:rec1` as Parameters<typeof hydrateFieldValues>[0]['recordId']
+const emailKey = buildFieldValueKey(recordId, multiEmailField.resourceFieldId!)
+const notesKey = buildFieldValueKey(recordId, notesField.resourceFieldId!)
+
+beforeEach(() => {
+  useFieldValueStore.getState().clearAll()
+})
+
+describe('hydrateFieldValues — options.multi fields', () => {
+  it('does NOT seed a scalar for a multi field (leaves the key to batchGet)', () => {
+    hydrateFieldValues({
+      resource,
+      recordId,
+      recordData: { email: 'anna.work@corp.io', notes: 'hello' },
+    })
+
+    const values = useFieldValueStore.getState().values
+    // The multi email key must stay unset — a seeded scalar would block the
+    // batch fetch (keys with values are skipped) and pin the cell to the
+    // primary value only.
+    expect(emailKey in values).toBe(false)
+    // Single-value fields still hydrate as before.
+    expect(values[notesKey]).toEqual({ type: 'text', value: 'hello' })
+  })
+
+  it('seeds an ordered array when record data carries the full array', () => {
+    hydrateFieldValues({
+      resource,
+      recordId,
+      recordData: { email: ['anna.work@corp.io', 'anna@example.com'] },
+    })
+
+    expect(useFieldValueStore.getState().values[emailKey]).toEqual([
+      { type: 'text', value: 'anna.work@corp.io' },
+      { type: 'text', value: 'anna@example.com' },
+    ])
+  })
+
+  it('never stores the String(array) comma join', () => {
+    hydrateFieldValues({
+      resource,
+      recordId,
+      recordData: { email: ['a@x.io', 'b@y.io'] },
+    })
+
+    const value = useFieldValueStore.getState().values[emailKey]
+    expect(JSON.stringify(value)).not.toContain('a@x.io,b@y.io')
+  })
+})
+
+describe('hydrateMultipleRecords — options.multi fields', () => {
+  it('applies the same scalar skip + array pass-through per record', () => {
+    const otherRecordId = `${DEF_ID}:rec2` as typeof recordId
+    hydrateMultipleRecords(resource, [
+      { recordId, data: { email: 'primary.only@corp.io', notes: 'a' } },
+      { recordId: otherRecordId, data: { email: ['x@x.io', 'y@y.io'] } },
+    ])
+
+    const values = useFieldValueStore.getState().values
+    expect(emailKey in values).toBe(false)
+    expect(values[notesKey]).toEqual({ type: 'text', value: 'a' })
+    expect(values[buildFieldValueKey(otherRecordId, multiEmailField.resourceFieldId!)]).toEqual([
+      { type: 'text', value: 'x@x.io' },
+      { type: 'text', value: 'y@y.io' },
+    ])
+  })
+})

--- a/apps/web/src/components/resources/store/hydrate-field-values.ts
+++ b/apps/web/src/components/resources/store/hydrate-field-values.ts
@@ -34,6 +34,30 @@ function getRelatedEntityDefinitionId(field: ResourceField): string | undefined 
   }
 }
 
+/**
+ * Convert one field's record-row value to the typed store shape, or `undefined`
+ * to skip seeding the key entirely.
+ *
+ * `options.multi` scalar fields (EMAIL/URL/PHONE with `multi: true`) get
+ * special handling: record-row data carries at most the denormalized PRIMARY
+ * value (e.g. contact `email` via `dbColumn`), never the full FieldValue row
+ * set. Seeding that scalar would (a) store a scalar where every other feed
+ * stores an array and (b) block the authoritative `fieldValue.batchGet` fetch —
+ * the fetch queue and cell hooks skip keys that already hold a value — so the
+ * table cell would show only the primary until something else overwrote the
+ * key. Skipping leaves the key `undefined`, and autoFetch delivers the full
+ * ordered array. A genuine array in record data (a feed that does carry every
+ * value) still hydrates, through the per-item converter via `fieldOptions`.
+ */
+function toHydratedTypedValue(field: ResourceField, rawValue: unknown): StoredFieldValue | null {
+  if (field.options?.multi && !Array.isArray(rawValue)) return null
+  return formatToTypedInput(rawValue, field.fieldType as FieldType, {
+    selectOptions: field.options?.options,
+    relatedEntityDefinitionId: getRelatedEntityDefinitionId(field),
+    fieldOptions: field.options,
+  }) as StoredFieldValue | null
+}
+
 interface HydrationOptions {
   resource: Resource
   /** RecordId in format "entityDefinitionId:entityInstanceId" */
@@ -88,16 +112,14 @@ export function hydrateFieldValues({
       })
     }
 
-    // Convert to TypedFieldValue using the converter
-    const typedValue = formatToTypedInput(rawValue, field.fieldType as FieldType, {
-      selectOptions: field.options?.options,
-      relatedEntityDefinitionId: getRelatedEntityDefinitionId(field),
-    })
+    // Convert to TypedFieldValue using the converter (multi-aware — see
+    // toHydratedTypedValue for why a scalar on an options.multi field skips).
+    const typedValue = toHydratedTypedValue(field, rawValue)
 
     if (typedValue !== null) {
       // Use field identity (resourceFieldId or id) for store key — must match what cells read
       const storeKey = buildFieldValueKey(recordId, field.resourceFieldId ?? field.id)
-      entries.push({ key: storeKey, value: typedValue as StoredFieldValue })
+      entries.push({ key: storeKey, value: typedValue })
     }
   }
 
@@ -141,17 +163,14 @@ export function hydrateMultipleRecords(
         })
       }
 
-      const typedValue = formatToTypedInput(rawValue, field.fieldType as FieldType, {
-        selectOptions: field.options?.options,
-        relatedEntityDefinitionId: getRelatedEntityDefinitionId(field),
-      })
+      const typedValue = toHydratedTypedValue(field, rawValue)
 
       if (typedValue !== null) {
         const storeKey = buildFieldValueKey(
           getNormalizedRecordId(record.recordId),
           field.resourceFieldId ?? field.id
         )
-        allEntries.push({ key: storeKey, value: typedValue as StoredFieldValue })
+        allEntries.push({ key: storeKey, value: typedValue })
       }
     }
   }


### PR DESCRIPTION
## Problem

Multi-value email/website fields (`options.multi`, shipped in the multi-email plan) render correctly in the record drawer and create-dialog picker, but the records TABLE Email cell broke two ways:

1. **Right after create (optimistic path):** the cell rendered the comma-joined string `anna.work@corp.io,anna@example.com` inside ONE `CopyableLinkCell`.
2. **After a list refetch:** the cell stayed wrong (joined string / primary-only) until a full page reload — refetching the list never repaired it.

## Root cause

The server list pipeline is NOT the flattener. Traced end-to-end: `record.listFiltered` returns ids only; row hydration (`record.getByIds` → `RecordPickerService.fetchEntityInstancesByIds`) carries no field values for EntityInstance-backed defs; cell values come exclusively from `fieldValue.batchGet`, whose fold (`fetchFieldValueResults` in `packages/lib/src/field-values/field-value-queries.ts`) is already multi-aware — rows ordered by `sortKey`, folded to an array when `isArrayReturnFieldType(fieldType, options)`. Verified live: a clean reload renders two chips.

The scalar reaches `renderEmailValue` from **client-side store seeding paths that bypass the multi-aware shaping**, combined with the fetch-queue's skip rule (`field-value-fetch-queue.ts` skips any key that already holds a value, and the cell hooks dedupe per mount) — so a wrongly-shaped seeded value is **permanent until page reload**:

- **Bug 2 (proven live):** `use-seed-created-record.ts` called `formatToTypedInput(value, fieldType)` with **no third param**. For a multi EMAIL array the text converter's scalar branch does `String(['a','b'])` → one `{type:'text', value:'a,b'}` row — the comma string in one chip. This is the same missing-`fieldOptions` bug #1623 fixed in `use-save-field-value.ts`.
- **Bug 1:** the same poisoned value survives every "clean refetch" — `refresh()` invalidates the id list, but nothing overwrites the field-value store, and the batch fetch queue skips populated keys. Additionally, the generic record-data → store bridge (`hydrate-field-values.ts`) read a multi field via its `dbColumn` alias (contact `primaryEmail` has `dbColumn: 'email'`) and would seed the **denormalized primary as a scalar** whenever a record-data feed carries that key — blocking the authoritative `batchGet` array, i.e. "only the primary shows until the drawer's fetch overwrites the key".

## Fix (all in apps/web — no server change needed)

- `use-seed-created-record.ts`: `SeedFieldValue` gains `fieldOptions`; the seed normalizes scalars on array-return fields to one-element arrays and converts with `formatToTypedInput(value, fieldType, { fieldOptions })` — the seeded shape now matches what `fieldValue.batchGet` delivers (ordered `TypedFieldValueInput[]`, primary first).
- `use-create-record.ts`: threads `field?.options` from the resource store into the seed values.
- `hydrate-field-values.ts`: shared `toHydratedTypedValue` — for `options.multi` fields a **scalar** in record data is skipped (leaves the key `undefined` so autoFetch delivers the full ordered array); a genuine **array** hydrates through the per-item converter via `fieldOptions`. Single-value fields unchanged.

Result: contact with 2 emails renders TWO chips via `ItemsCellView` (primary first) right after create, after any list refetch, and after reload.

## Not changed (noted per review guidance)

`packages/lib/src/resources/resource-fetcher.ts` also flattens via `extractFieldValueScalar` (~:215, ~:616) — that is the workflow/record-rules **variable fetcher**, not a feed for the web table, and record-rules snapshots deliberately want the primary scalar. Left as a scalar-only consumer.

## Tests

- `use-seed-created-record.test.ts` (3): multi EMAIL array seeds as `TypedFieldValueInput[]` primary-first (never the `String(array)` comma join); scalar on a multi field normalizes to a one-element array; single-value fields stay scalar.
- `hydrate-field-values.test.ts` (4): scalar on a multi field is NOT seeded (both `hydrateFieldValues` and `hydrateMultipleRecords`); full arrays hydrate ordered; single-value fields hydrate as before.
- Full `src/components/resources` + `cell-renderers` suites: 15 files / 113 tests green.
- `apps/web` scoped `tsc --noEmit`: no errors in changed files (only known pre-existing noise in unrelated files).

Live repro before the fix (fresh `/demo` org): create contact with 2 emails → table cell shows `anna.work@corp.io,anna@example.com` in one chip; list refresh does not repair it; reload shows two chips (server path healthy).