### PR TITLE
fix(records): close org-wide email uniqueness bypass on fieldValue service doors

### DIFF
--- a/apps/web/src/components/fields/property-provider.tsx
+++ b/apps/web/src/components/fields/property-provider.tsx
@@ -409,11 +409,16 @@ export function PropertyProvider({
       setCurrentValue(newValue)
       setIsDirty(false)
 
-      // Use async save path
+      // Use async save path. Only advance serverValue on success — a failed
+      // save rolls the store back, and advancing here would make the next
+      // commit's "did it change" diff compare against a value the server
+      // never accepted.
       const result = await storeSaveAsync(recordId, field.id, newValue, field.fieldType, {
         fieldOptions: field.options,
       })
-      setServerValue(newValue)
+      if (result?.success) {
+        setServerValue(newValue)
+      }
       return result
     },
     [recordId, serverValue, storeSaveAsync, field.id, field.fieldType, field.options]

--- a/apps/web/src/components/resources/hooks/use-save-field-value.ts
+++ b/apps/web/src/components/resources/hooks/use-save-field-value.ts
@@ -412,42 +412,52 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
         })
       }
 
-      // try {
-      const result = await setMutateAsync({
-        recordId: normalizedRecordId,
-        fieldId,
-        value,
-        ...(ai ? { ai: true } : {}),
-      })
+      try {
+        const result = await setMutateAsync({
+          recordId: normalizedRecordId,
+          fieldId,
+          value,
+          ...(ai ? { ai: true } : {}),
+        })
 
-      // Check if stale (a newer mutation was fired)
-      const store = useFieldValueStore.getState()
-      if (prep.mutationVersion < store.getMutationVersion(prep.key)) {
-        return { success: true }
+        // Check if stale (a newer mutation was fired)
+        const store = useFieldValueStore.getState()
+        if (prep.mutationVersion < store.getMutationVersion(prep.key)) {
+          return { success: true }
+        }
+
+        // Apply server result
+        const firstValueId = result?.values?.[0]?.id
+        handleMutationSuccess(
+          prep.key,
+          prep.mutationVersion,
+          result,
+          fieldType,
+          saveOpts?.fieldOptions
+        )
+        onSuccess?.()
+        return { success: true, id: firstValueId }
+      } catch (error: unknown) {
+        // Check if superseded — a newer mutation owns the store state now.
+        const store = useFieldValueStore.getState()
+        if (prep.mutationVersion < store.getMutationVersion(prep.key)) {
+          return undefined
+        }
+
+        // Roll back the optimistic value and surface the server error
+        // (e.g. a uniqueness conflict on a multi-value EMAIL field) —
+        // without this the UI silently keeps a value the server rejected.
+        handleMutationError(
+          prep.key,
+          prep.mutationVersion,
+          prep,
+          normalizedRecordId,
+          syncInverseCache,
+          error,
+          ai
+        )
+        return { success: false }
       }
-
-      // Apply server result
-      const firstValueId = result?.values?.[0]?.id
-      handleMutationSuccess(
-        prep.key,
-        prep.mutationVersion,
-        result,
-        fieldType,
-        saveOpts?.fieldOptions
-      )
-      onSuccess?.()
-      return { success: true, id: firstValueId }
-      // } catch (error: unknown) {
-      //   console.log('ON ERROR ASYNC:', { error })
-      //   // Check if superseded
-      //   const store = useFieldValueStore.getState()
-      //   if (prep.mutationVersion < store.getMutationVersion(prep.key)) {
-      //     return undefined
-      //   }
-
-      //   handleMutationError(prep.key, prep.mutationVersion, prep, recordId, syncInverseCache, error)
-      //   return undefined
-      // }
     },
     [setMutateAsync, onSuccess, getFieldMetadata, syncInverseCache]
   )

--- a/packages/lib/src/custom-fields/__tests__/check-unique-value-typed.test.ts
+++ b/packages/lib/src/custom-fields/__tests__/check-unique-value-typed.test.ts
@@ -28,8 +28,6 @@ function buildFakeDb(rows: Array<{ entityId: string; displayName: string | null 
 const baseInput = {
   fieldId: 'field-email-1',
   organizationId: 'org-1',
-  modelType: 'ENTITY' as never,
-  entityDefinitionId: 'def-contact',
   excludeEntityId: 'inst-self',
 }
 

--- a/packages/lib/src/custom-fields/check-unique-value-typed.ts
+++ b/packages/lib/src/custom-fields/check-unique-value-typed.ts
@@ -1,6 +1,5 @@
 // packages/lib/src/custom-fields/check-unique-value-typed.ts
 
-import type { ModelType } from '@auxx/database'
 import { type Database, database, schema, type Transaction } from '@auxx/database'
 import type { TypedFieldValueInput } from '@auxx/types'
 import { and, eq, isNull, ne, sql } from 'drizzle-orm'
@@ -8,14 +7,20 @@ import { UniqueValueConflictError } from '../errors'
 import { parseRecordId } from '../resources/resource-id'
 
 /**
- * Input for checking if a value is unique for a field
+ * Input for checking if a value is unique for a field.
+ *
+ * `FieldValue.fieldId` is an FK to `CustomField.id` (a primary key), so
+ * `fieldId` + `organizationId` alone pin the exact field. The check
+ * deliberately takes NO `modelType`/`entityDefinitionId` scope: seeded
+ * system fields carry their entity type as `CustomField.modelType`
+ * (e.g. `'contact'`) while callers deriving a scope from the record's
+ * def id get `'entity'` — a mismatched predicate silently emptied the
+ * query and let duplicates through the `fieldValue.set` door.
  */
 export interface CheckUniqueValueTypedInput {
   fieldId: string
   value: TypedFieldValueInput | TypedFieldValueInput[] | null
   organizationId: string
-  modelType: ModelType
-  entityDefinitionId?: string | null
   excludeEntityId?: string
 }
 
@@ -35,7 +40,7 @@ export async function checkUniqueValueTyped(
   input: CheckUniqueValueTypedInput,
   db: Database | Transaction = database
 ): Promise<boolean> {
-  const { fieldId, value, organizationId, modelType, entityDefinitionId, excludeEntityId } = input
+  const { fieldId, value, organizationId, excludeEntityId } = input
 
   // Null values are always allowed (no uniqueness constraint)
   if (value === null) {
@@ -94,24 +99,21 @@ export async function checkUniqueValueTyped(
   }
 
   // Query for existing values with the same value. The EntityInstance join
-  // excludes archived records from the check.
+  // excludes archived records from the check. No CustomField join: fieldId
+  // is the CustomField PK, so any extra modelType/entityDefinitionId
+  // predicate can only wrongly EXCLUDE the conflicting row (fail open).
   const query = db
     .select({
       entityId: schema.FieldValue.entityId,
       displayName: schema.EntityInstance.displayName,
     })
     .from(schema.FieldValue)
-    .innerJoin(schema.CustomField, eq(schema.CustomField.id, schema.FieldValue.fieldId))
     .innerJoin(schema.EntityInstance, eq(schema.EntityInstance.id, schema.FieldValue.entityId))
     .where(
       and(
         eq(schema.FieldValue.fieldId, fieldId),
         eq(schema.FieldValue.organizationId, organizationId),
-        eq(schema.CustomField.modelType, modelType),
         isNull(schema.EntityInstance.archivedAt),
-        entityDefinitionId
-          ? eq(schema.CustomField.entityDefinitionId, entityDefinitionId)
-          : undefined,
         excludeEntityId ? ne(schema.FieldValue.entityId, excludeEntityId) : undefined,
         valueCondition
       )

--- a/packages/lib/src/data-connectors/sinks/row-level-writes.ts
+++ b/packages/lib/src/data-connectors/sinks/row-level-writes.ts
@@ -210,8 +210,6 @@ export async function planRowLevelWrites(
             fieldId: w.fieldUuid,
             value: typed,
             organizationId: ctx.orgId,
-            modelType: w.field.modelType as never,
-            entityDefinitionId,
             excludeEntityId: instanceId,
           },
           ctx.db

--- a/packages/lib/src/field-values/__tests__/email-uniqueness-doors.int.test.ts
+++ b/packages/lib/src/field-values/__tests__/email-uniqueness-doors.int.test.ts
@@ -1,0 +1,393 @@
+// packages/lib/src/field-values/__tests__/email-uniqueness-doors.int.test.ts
+//
+// DB-backed behavior tests (vitest.integration.config.ts → auxx_test database) for
+// org-wide per-value uniqueness on multi-value EMAIL fields at the FieldValueService
+// layer — the panel door (`fieldValue.set` → setValueWithBuiltIn) and its siblings
+// (addValue / addValues / addValuesBulk).
+//
+// Why integration and not unit: the regression these tests pin was invisible to
+// predicate-blind fake-db unit tests. The seeded contact `primaryEmail` CustomField
+// row carries `modelType='contact'` (entity-seeder `create-fields.ts` writes
+// `modelType: entityType`), while the old gate derived `getModelType(defId)` →
+// `'entity'` for any CUID def — the `eq(CustomField.modelType, …)` predicate then
+// emptied the join and the uniqueness check silently PASSED. Only real SQL against
+// rows shaped exactly like the seeder's exposes that. The CustomField fixture here
+// deliberately mirrors the seeder (modelType 'contact', isUnique true,
+// systemAttribute 'primary_email', options.multi).
+//
+// The org cache barrel is mocked wholesale (deterministic, no Redis): field lookups
+// read straight from the test DB.
+
+import { type Database, schema } from '@auxx/database'
+import { createTestOrganization, getTestDb } from '@auxx/test-utils'
+import type { RecordId } from '@auxx/types/resource'
+import { and, asc, eq } from 'drizzle-orm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { UniqueValueConflictError } from '../../errors'
+import { createFieldValueContext, type FieldValueContext } from '../field-value-helpers'
+import {
+  addValue,
+  addValues,
+  addValuesBulk,
+  setValue,
+  setValueWithBuiltIn,
+} from '../field-value-mutations'
+
+const db = () => getTestDb() as unknown as Database
+
+// ── Org-cache mock (wholesale — DB-backed, no Redis, no providers) ──────────
+
+vi.mock('../../cache', () => {
+  const tdb = () => getTestDb() as never as Database
+
+  const fieldsForOrg = async (orgId: string) => {
+    return await tdb()
+      .select()
+      .from(schema.CustomField)
+      .where(eq(schema.CustomField.organizationId, orgId))
+  }
+
+  const resourceFor = async (orgId: string, defId: string) => {
+    const [def] = await tdb()
+      .select()
+      .from(schema.EntityDefinition)
+      .where(
+        and(
+          eq(schema.EntityDefinition.id, defId),
+          eq(schema.EntityDefinition.organizationId, orgId)
+        )
+      )
+    if (!def) return null
+    return {
+      id: def.id,
+      entityDefinitionId: def.id,
+      apiSlug: def.apiSlug,
+      entityType: def.entityType,
+      display: { primaryDisplayField: null, secondaryDisplayField: null, avatarField: null },
+    }
+  }
+
+  return {
+    getOrgCache: () => ({
+      from: (orgId: string, _key: string) => ({
+        all: async () => {
+          const fields = await fieldsForOrg(orgId)
+          const grouped: Record<string, unknown[]> = {}
+          for (const f of fields) {
+            const defId = f.entityDefinitionId ?? '_'
+            grouped[defId] = grouped[defId] ?? []
+            grouped[defId]!.push(f)
+          }
+          return grouped
+        },
+        byId: async (fieldId: string) => {
+          const fields = await fieldsForOrg(orgId)
+          return fields.find((f) => f.id === fieldId) ?? null
+        },
+        bySystemAttribute: async (attr: string) => {
+          const fields = await fieldsForOrg(orgId)
+          return fields.find((f) => f.systemAttribute === attr) ?? null
+        },
+      }),
+    }),
+    getCachedResource: async (orgId: string, defId: string) => resourceFor(orgId, defId),
+    findCachedResource: async (orgId: string, defId: string) => resourceFor(orgId, defId),
+    getCachedResources: async () => [],
+    getCachedFieldMap: async (orgId: string, _defId: string) => {
+      const fields = await fieldsForOrg(orgId)
+      return new Map(fields.map((f) => [f.id, f]))
+    },
+    getCachedEntityDefId: async (_orgId: string, slugOrId: string) => slugOrId,
+    requireCachedEntityDefId: async (_orgId: string, slugOrId: string) => slugOrId,
+    getAllCachedCustomFields: async (orgId: string) => fieldsForOrg(orgId),
+    getCachedResourceFields: async () => [],
+    getCachedUserInstanceGrants: async () => [],
+    getCachedMembersByUserIds: async () => [],
+    getCachedAgentsByUserIds: async () => [],
+  }
+})
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+interface Fixture {
+  orgId: string
+  defId: string
+  emailFieldId: string
+  ctx: FieldValueContext
+}
+
+/** Mirror of what `EntitySeeder` produces for the contact def + primaryEmail. */
+async function seedContactOrg(): Promise<Fixture> {
+  const org = await createTestOrganization()
+  const orgId = org.id
+
+  const [def] = await db()
+    .insert(schema.EntityDefinition)
+    .values({
+      organizationId: orgId,
+      entityType: 'contact',
+      apiSlug: 'contacts',
+      singular: 'contact',
+      plural: 'contacts',
+      updatedAt: new Date(),
+    })
+    .returning()
+
+  const [emailField] = await db()
+    .insert(schema.CustomField)
+    .values({
+      organizationId: orgId,
+      entityDefinitionId: def!.id,
+      // Load-bearing: the seeder writes the ENTITY TYPE here, not 'entity'.
+      // The old gate filtered on getModelType(defId) === 'entity' and never
+      // matched this row — that mismatch IS the uniqueness bypass under test.
+      modelType: 'contact',
+      name: 'Email',
+      type: 'EMAIL',
+      systemAttribute: 'primary_email',
+      sortOrder: 'a2',
+      options: { multi: true },
+      isCustom: false,
+      isUnique: true,
+      updatedAt: new Date(),
+    })
+    .returning()
+
+  // No userId → field-change post-hooks and trigger publishes stay off.
+  const ctx = createFieldValueContext(orgId, undefined, db())
+  return { orgId, defId: def!.id, emailFieldId: emailField!.id, ctx }
+}
+
+async function seedContact(f: Fixture, displayName: string, emails: string[] = []) {
+  const [inst] = await db()
+    .insert(schema.EntityInstance)
+    .values({
+      organizationId: f.orgId,
+      entityDefinitionId: f.defId,
+      displayName,
+      updatedAt: new Date(),
+    })
+    .returning()
+
+  let sortKey = 'a0'
+  for (const email of emails) {
+    await db().insert(schema.FieldValue).values({
+      organizationId: f.orgId,
+      entityId: inst!.id,
+      entityDefinitionId: f.defId,
+      fieldId: f.emailFieldId,
+      valueText: email,
+      sortKey,
+    })
+    sortKey = `${sortKey}V` // strictly ascending fractional-ish keys
+  }
+  return inst!
+}
+
+const recordIdOf = (f: Fixture, instId: string) => `${f.defId}:${instId}` as RecordId
+
+async function emailsOf(f: Fixture, instId: string): Promise<string[]> {
+  const rows = await db()
+    .select()
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.entityId, instId),
+        eq(schema.FieldValue.fieldId, f.emailFieldId),
+        eq(schema.FieldValue.organizationId, f.orgId)
+      )
+    )
+    .orderBy(asc(schema.FieldValue.sortKey))
+  return rows.map((r) => r.valueText!).filter((v) => v !== null)
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('multi-value EMAIL uniqueness — service-layer doors', () => {
+  let f: Fixture
+
+  beforeEach(async () => {
+    f = await seedContactOrg()
+  })
+
+  describe('setValueWithBuiltIn (the fieldValue.set panel door)', () => {
+    it('rejects a whole-array set containing an email claimed by another contact', async () => {
+      const anna = await seedContact(f, 'Anna Multitest', ['anna.work@corp.io', 'anna@example.com'])
+      const bob = await seedContact(f, 'Bob', ['bob@example.com'])
+
+      const promise = setValueWithBuiltIn(f.ctx, {
+        recordId: recordIdOf(f, bob.id),
+        fieldId: f.emailFieldId,
+        value: ['bob-new@example.com', 'anna.work@corp.io'],
+        publishEvents: false,
+      })
+
+      await expect(promise).rejects.toThrow(UniqueValueConflictError)
+      await promise.catch((e: UniqueValueConflictError) => {
+        expect(e.conflictingValue).toBe('anna.work@corp.io')
+        expect(e.existingEntityId).toBe(anna.id)
+      })
+
+      // The conflict must abort BEFORE the destructive delete+insert:
+      // Bob keeps exactly his prior values.
+      expect(await emailsOf(f, bob.id)).toEqual(['bob@example.com'])
+      expect(await emailsOf(f, anna.id)).toEqual(['anna.work@corp.io', 'anna@example.com'])
+    })
+
+    it('allows a record to re-set (reorder) its OWN values', async () => {
+      const anna = await seedContact(f, 'Anna', ['anna.work@corp.io', 'anna@example.com'])
+
+      await setValueWithBuiltIn(f.ctx, {
+        recordId: recordIdOf(f, anna.id),
+        fieldId: f.emailFieldId,
+        value: ['anna@example.com', 'anna.work@corp.io'],
+        publishEvents: false,
+      })
+
+      expect(await emailsOf(f, anna.id)).toEqual(['anna@example.com', 'anna.work@corp.io'])
+    })
+
+    it('does not conflict with emails held only by an ARCHIVED contact', async () => {
+      const ghost = await seedContact(f, 'Ghost', ['ghost@example.com'])
+      await db()
+        .update(schema.EntityInstance)
+        .set({ archivedAt: new Date() })
+        .where(eq(schema.EntityInstance.id, ghost.id))
+      const bob = await seedContact(f, 'Bob')
+
+      await setValueWithBuiltIn(f.ctx, {
+        recordId: recordIdOf(f, bob.id),
+        fieldId: f.emailFieldId,
+        value: ['ghost@example.com'],
+        publishEvents: false,
+      })
+
+      expect(await emailsOf(f, bob.id)).toEqual(['ghost@example.com'])
+    })
+  })
+
+  describe('addValue (the fieldValue.add door)', () => {
+    it('rejects appending an email claimed by another contact', async () => {
+      const anna = await seedContact(f, 'Anna', ['anna.work@corp.io'])
+      const bob = await seedContact(f, 'Bob', ['bob@example.com'])
+
+      const promise = addValue(f.ctx, {
+        recordId: recordIdOf(f, bob.id),
+        fieldId: f.emailFieldId,
+        fieldType: 'EMAIL',
+        value: { type: 'text', value: 'anna.work@corp.io' },
+      })
+
+      await expect(promise).rejects.toThrow(UniqueValueConflictError)
+      await promise.catch((e: UniqueValueConflictError) => {
+        expect(e.conflictingValue).toBe('anna.work@corp.io')
+        expect(e.existingEntityId).toBe(anna.id)
+      })
+      expect(await emailsOf(f, bob.id)).toEqual(['bob@example.com'])
+    })
+
+    it('still appends a fresh email', async () => {
+      const bob = await seedContact(f, 'Bob', ['bob@example.com'])
+      await addValue(f.ctx, {
+        recordId: recordIdOf(f, bob.id),
+        fieldId: f.emailFieldId,
+        fieldType: 'EMAIL',
+        value: { type: 'text', value: 'bob-alt@example.com' },
+      })
+      expect(await emailsOf(f, bob.id)).toEqual(['bob@example.com', 'bob-alt@example.com'])
+    })
+  })
+
+  describe('addValues (fieldValue.set mode "add" / applyBulk per-record add)', () => {
+    it('rejects a batch containing an email claimed by another contact', async () => {
+      await seedContact(f, 'Anna', ['anna.work@corp.io'])
+      const bob = await seedContact(f, 'Bob', ['bob@example.com'])
+
+      await expect(
+        addValues(f.ctx, {
+          recordId: recordIdOf(f, bob.id),
+          fieldId: f.emailFieldId,
+          values: ['bob-new@example.com', 'anna.work@corp.io'],
+          skipPublishEvents: true,
+        })
+      ).rejects.toThrow(UniqueValueConflictError)
+
+      // Transactional: the fresh sibling value must not have landed either.
+      expect(await emailsOf(f, bob.id)).toEqual(['bob@example.com'])
+    })
+
+    it('re-adding a record`s own email is a dedup no-op, not a conflict', async () => {
+      const anna = await seedContact(f, 'Anna', ['anna.work@corp.io'])
+      const result = await addValues(f.ctx, {
+        recordId: recordIdOf(f, anna.id),
+        fieldId: f.emailFieldId,
+        values: ['anna.work@corp.io'],
+        skipPublishEvents: true,
+      })
+      expect(result.map((v) => ('value' in v ? v.value : null))).toEqual(['anna.work@corp.io'])
+      expect(await emailsOf(f, anna.id)).toEqual(['anna.work@corp.io'])
+    })
+  })
+
+  describe('addValuesBulk (applyBulk uniform add)', () => {
+    it('rejects when the added email is claimed by a record outside the batch', async () => {
+      await seedContact(f, 'Anna', ['anna.work@corp.io'])
+      const bob = await seedContact(f, 'Bob')
+      const cara = await seedContact(f, 'Cara')
+
+      await expect(
+        addValuesBulk(f.ctx, {
+          recordIds: [recordIdOf(f, bob.id), recordIdOf(f, cara.id)],
+          fieldId: f.emailFieldId,
+          values: ['anna.work@corp.io'],
+        })
+      ).rejects.toThrow(UniqueValueConflictError)
+
+      expect(await emailsOf(f, bob.id)).toEqual([])
+      expect(await emailsOf(f, cara.id)).toEqual([])
+    })
+
+    it('rejects handing the SAME new email to two records in one batch', async () => {
+      const bob = await seedContact(f, 'Bob')
+      const cara = await seedContact(f, 'Cara')
+
+      await expect(
+        addValuesBulk(f.ctx, {
+          recordIds: [recordIdOf(f, bob.id), recordIdOf(f, cara.id)],
+          fieldId: f.emailFieldId,
+          values: ['fresh@example.com'],
+        })
+      ).rejects.toThrow(UniqueValueConflictError)
+
+      expect(await emailsOf(f, bob.id)).toEqual([])
+      expect(await emailsOf(f, cara.id)).toEqual([])
+    })
+
+    it('allows a unique value landing on exactly one record', async () => {
+      const bob = await seedContact(f, 'Bob')
+      const res = await addValuesBulk(f.ctx, {
+        recordIds: [recordIdOf(f, bob.id)],
+        fieldId: f.emailFieldId,
+        values: ['fresh@example.com'],
+      })
+      expect(res.inserted).toBe(1)
+      expect(await emailsOf(f, bob.id)).toEqual(['fresh@example.com'])
+    })
+  })
+
+  describe('setValue (low-level service door)', () => {
+    it('rejects a whole-array set containing a claimed email', async () => {
+      await seedContact(f, 'Anna', ['anna.work@corp.io'])
+      const bob = await seedContact(f, 'Bob', ['bob@example.com'])
+
+      await expect(
+        setValue(f.ctx, {
+          recordId: recordIdOf(f, bob.id),
+          fieldId: f.emailFieldId,
+          value: ['anna.work@corp.io'],
+        })
+      ).rejects.toThrow(UniqueValueConflictError)
+      expect(await emailsOf(f, bob.id)).toEqual(['bob@example.com'])
+    })
+  })
+})

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -36,7 +36,7 @@ import {
   isBuiltInField,
 } from '../custom-fields/built-in-fields'
 import { checkUniqueValueTyped } from '../custom-fields/check-unique-value-typed'
-import { BadRequestError, NotFoundError } from '../errors'
+import { BadRequestError, NotFoundError, UniqueValueConflictError } from '../errors'
 import {
   collectTriggeredFields,
   deduplicateBySystemAttribute,
@@ -353,6 +353,21 @@ export async function setValue(
     return []
   }
 
+  // Uniqueness gate — setValue writes through setMultiValue/setSingleValue
+  // directly (it does NOT route through setValueWithType), so it needs its
+  // own check before any row is touched.
+  if (field.isUnique) {
+    await checkUniqueValueTyped(
+      {
+        fieldId,
+        value: typedInput,
+        organizationId: ctx.organizationId,
+        excludeEntityId: parseRecordId(recordId).entityInstanceId,
+      },
+      ctx.db
+    )
+  }
+
   // 3. Determine strategy and execute
   let result: TypedFieldValue[]
 
@@ -424,6 +439,23 @@ export async function setValueWithType(
         )
       }
     }
+  }
+
+  // Uniqueness gate — THE gate for every set-shaped write (panel writes via
+  // setValueWithBuiltIn, setValuesForEntity/setBulkValues/applyBulk fan-outs,
+  // and direct service calls). Array values are checked per element,
+  // org-wide, excluding this record's own rows. Runs BEFORE the destructive
+  // delete below so a conflict leaves the record's existing values untouched.
+  if (field.isUnique && value !== null) {
+    await checkUniqueValueTyped(
+      {
+        fieldId,
+        value,
+        organizationId: ctx.organizationId,
+        excludeEntityId: entityInstanceId,
+      },
+      ctx.db
+    )
   }
 
   // Delete existing values for this entityInstanceId + fieldId
@@ -555,6 +587,22 @@ export async function addValue(
   // Parse RecordId to get entityInstanceId for DB queries
   const { entityInstanceId } = parseRecordId(recordId)
 
+  // Uniqueness gate — the `fieldValue.add` door appends a single value and
+  // must not be able to claim one held by another record (org-wide,
+  // excluding this record's own rows).
+  const field = await getField(ctx, fieldId)
+  if (field.isUnique) {
+    await checkUniqueValueTyped(
+      {
+        fieldId,
+        value,
+        organizationId: ctx.organizationId,
+        excludeEntityId: entityInstanceId,
+      },
+      ctx.db
+    )
+  }
+
   // Get existing values to determine sortKey position
   const existing = await ctx.db
     .select({ sortKey: schema.FieldValue.sortKey })
@@ -612,7 +660,6 @@ export async function addValue(
   const typedResult = rowToTypedValue(inserted as unknown as FieldValueRow, fieldType)
 
   // Update display value if this is a display field (e.g., avatar for FILE fields)
-  const field = await getField(ctx, fieldId)
   await maybeUpdateDisplayValue(ctx, recordId, field, value)
 
   // Re-read full field value and publish (multi-value — send complete array)
@@ -1358,6 +1405,13 @@ function buildMatchInClause(
  * `db.transaction(...)`, which is a `PgTransaction` and is not assignable to the
  * pooled `Database`.
  */
+/** Human-readable form of a typed input for uniqueness-conflict errors. */
+function typedInputDisplay(v: TypedFieldValueInput): string {
+  if (v.type === 'option') return v.optionId
+  if (v.type === 'relationship') return v.recordId
+  return 'value' in v ? String(v.value) : JSON.stringify(v)
+}
+
 async function acquireFieldValueLock(
   tx: Pick<FieldValueContext['db'], 'execute'>,
   entityId: string,
@@ -1486,6 +1540,22 @@ export async function addValues(
 
     if (survivors.length === 0) {
       return existingRows.map((r) => rowToTypedValue(r, fieldType))
+    }
+
+    // Uniqueness gate — appended values must not be claimed by another
+    // record org-wide. Checked on survivors (post-dedup) inside the lock so
+    // the check and the insert are atomic; own-record duplicates were
+    // already dropped by the dedup above.
+    if (field.isUnique) {
+      await checkUniqueValueTyped(
+        {
+          fieldId,
+          value: survivors,
+          organizationId: ctx.organizationId,
+          excludeEntityId: entityInstanceId,
+        },
+        txCtx.db
+      )
     }
 
     // Value cap: existing rows + surviving (deduped) additions must fit.
@@ -1753,6 +1823,10 @@ export async function addValuesBulk(
     }
 
     const insertRows: ReturnType<typeof buildFieldValueRow>[] = []
+    // Unique fields: one value can only land on ONE record in the whole
+    // batch — the per-entity org-wide check below can't see sibling inserts
+    // (they all flush in one statement at the end of the tx).
+    const batchClaims = new Map<string, string>()
     for (const entityId of entityIds) {
       const existing = existingByEntity.get(entityId) ?? []
       oldRowsByEntity.set(entityId, existing)
@@ -1782,6 +1856,19 @@ export async function addValuesBulk(
               `record ${entityId} would exceed the cap`
           )
         }
+        if (field.isUnique) {
+          const claimedBy = batchClaims.get(key)
+          if (claimedBy !== undefined && claimedBy !== entityId) {
+            const display = typedInputDisplay(typedInputs[i]!)
+            throw new UniqueValueConflictError({
+              message: `Value already added to another record in this batch: ${display}`,
+              conflictingValue: display,
+              fieldId,
+              existingEntityId: claimedBy,
+            })
+          }
+          batchClaims.set(key, entityId)
+        }
         localSeen.add(key)
         const sortKey = nextKeyAfter(prevKey)
         prevKey = sortKey
@@ -1797,6 +1884,20 @@ export async function addValuesBulk(
         )
         insertedTyped.push(typedInputs[i]!)
         insertedCount++
+      }
+      // Uniqueness gate — values this entity would actually insert must not
+      // be claimed by any OTHER record org-wide (archived excluded). Runs
+      // inside the tx/locks so check and insert are atomic.
+      if (field.isUnique && insertedTyped.length > 0) {
+        await checkUniqueValueTyped(
+          {
+            fieldId,
+            value: insertedTyped,
+            organizationId: ctx.organizationId,
+            excludeEntityId: entityId,
+          },
+          tx as unknown as Database
+        )
       }
       if (insertedTyped.length > 0) {
         insertedTypedByEntity.set(entityId, insertedTyped)
@@ -2148,20 +2249,9 @@ export async function setValueWithBuiltIn(
     return { state: 'complete', performedAt: new Date().toISOString(), values: [] }
   }
 
-  // 4. Check uniqueness if applicable (if field has unique constraint)
-  if (field.isUnique && typedValue !== null) {
-    await checkUniqueValueTyped(
-      {
-        fieldId,
-        value: typedValue,
-        organizationId: ctx.organizationId,
-        modelType,
-        entityDefinitionId: field.entityDefinitionId,
-        excludeEntityId: entityInstanceId,
-      },
-      ctx.db
-    )
-  }
+  // 4. Uniqueness is enforced inside setValueWithType (step 6) — one gate
+  // site, running just before the destructive delete, so hook-transformed
+  // values are what get checked and a conflict leaves existing rows intact.
 
   // 6. Set the value
   const result = await setValueWithType(ctx, {

--- a/packages/lib/vitest.integration.config.ts
+++ b/packages/lib/vitest.integration.config.ts
@@ -13,6 +13,7 @@
 import path from 'node:path'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
+import { auxxSourceAlias } from '../../vitest.alias'
 
 export default defineConfig({
   plugins: [tsconfigPaths()],
@@ -33,15 +34,12 @@ export default defineConfig({
   },
 
   resolve: {
+    // The shared source-alias map covers every @auxx/* workspace package (see
+    // vitest.alias.ts) — a hand-picked subset here left `@auxx/types` and
+    // `@auxx/services` resolving to a `dist/` that a fresh checkout does not
+    // have. `@auxx/test-utils` is not part of the shared map, so it stays.
     alias: {
-      '@auxx/database': path.resolve(__dirname, '../database/src'),
-      '@auxx/credentials/store': path.resolve(__dirname, '../credentials/src/store'),
-      '@auxx/credentials/crypto': path.resolve(__dirname, '../credentials/src/crypto'),
-      '@auxx/lib': path.resolve(__dirname, './src'),
-      '@auxx/utils': path.resolve(__dirname, '../utils/src'),
-      '@auxx/logger': path.resolve(__dirname, '../logger/src'),
-      '@auxx/config': path.resolve(__dirname, '../config/src'),
-      '@auxx/workflow-nodes': path.resolve(__dirname, '../workflow-nodes/src'),
+      ...auxxSourceAlias,
       '@auxx/test-utils': path.resolve(__dirname, '../test-utils/src'),
       '~/': path.resolve(__dirname, './src/'),
     },


### PR DESCRIPTION
## Security-relevant fix: uniqueness bypass on the `fieldValue.set` door

**Repro (confirmed by live browser verification):** with contact Anna holding `anna.work@corp.io` on the seeded multi-value Email field (`isUnique`), editing Bob's Email in the record panel and adding `anna.work@corp.io` SUCCEEDED — the whole-array save via tRPC `fieldValue.set` persisted the duplicate. The CREATE door (contact hooks in `UnifiedCrudHandler`) correctly rejected; the FieldValueService-side gate did not.

### Root cause (plan hypothesis 2)

The gate DID fire, but `checkUniqueValueTyped` passed wrongly. The entity-seeder writes the **entity type** into the seeded CustomField row (`create-fields.ts`: `modelType: entityType` → `'contact'`), while the gate derived its scope with `getModelType(entityDefinitionId)` → `'entity'` for any CUID def. The check's `eq(CustomField.modelType, …)` predicate therefore matched **zero rows** — the query came back empty and the check silently passed. Custom (user-created) unique fields get `modelType: 'entity'`, which is why the gate always worked in tests and for custom fields, and only seeded system fields (contact email!) were bypassed. Predicate-blind fake-db unit tests could never see this.

### Fix

- `checkUniqueValueTyped` no longer takes/filters `modelType`/`entityDefinitionId` at all. `FieldValue.fieldId` is an FK to `CustomField.id` (a PK), so `fieldId + organizationId` already pin the exact field — the extra predicates could only wrongly EXCLUDE the conflicting row (fail open). The `EntityInstance` join (archived exclusion + owner display name) stays.
- The set-door gate moved from `setValueWithBuiltIn` into **`setValueWithType`**, running **before** the destructive delete+insert — one gate site covering `setValueWithBuiltIn` (the `fieldValue.set` panel door), `setValuesForEntity`/`setBulkValues`/`applyBulk` set-mode fan-outs, and direct `service.setValueWithType` calls. A conflict now aborts with the record's existing values untouched.

### Sibling doors — audited, and they were OPEN too

| door | route | pre-fix state | fix |
|---|---|---|---|
| `addValue` | tRPC `fieldValue.add` | **no uniqueness gate at all** | org-wide check before insert |
| `addValues` | tRPC `fieldValue.set` `mode:'add'`, `applyBulk` per-record add | only in-record dedup | org-wide check on post-dedup survivors, inside the advisory-lock tx |
| `addValuesBulk` | `applyBulk` uniform add | only in-record dedup | per-entity org-wide check inside the tx + intra-batch claim tracking (same value cannot land on two records in one batch) |
| `setValue` | `service.setValue` (identity-field writers) | no gate (writes via setSingleValue/setMultiValue, bypassing setValueWithType) | own gate before any row is touched |

All throw `UniqueValueConflictError` (409) carrying `conflictingValue` + `existingEntityId`; own-record re-sets and archived-record duplicates do NOT conflict (pinned by tests).

### Client fix

`use-save-field-value.ts` `saveFieldValueAsync` had its try/catch **commented out** (debug leftover from Jan 2026, `4f03edc0f`) — a failed save surfaced no `toastError` and never rolled back the optimistic value. Restored: rollback + toast on error, `{ success: false }` return; `property-provider.commitValueAsync` now only advances its `serverValue` on success. (The panel's fire-and-forget `saveFieldValue` path already had rollback+toast — it showed nothing during repro only because the server never errored.)

### Tests (failing-test-first)

New DB-backed integration suite `packages/lib/src/field-values/__tests__/email-uniqueness-doors.int.test.ts` (11 tests) with a CustomField fixture mirroring the seeder exactly (`modelType: 'contact'`, `isUnique`, `options.multi`). Verified **red on unfixed origin/main: 6/11 fail** — the panel-door repro plus every sibling door accepts the duplicate — and **green on this branch: 11/11**.

Also updated the predicate-args in the existing unit test, and `vitest.integration.config.ts` now uses the shared `auxxSourceAlias` map (the hand-picked subset left `@auxx/types`/`@auxx/services` resolving to a `dist/` a fresh checkout doesn't have).

Full verification: lib unit (116 ✓), lib integration (104 ✓), data-connectors (355 ✓), web pickers/fields (122 ✓), scoped `tsc` for lib + web clean vs main baseline, biome clean.