### PR TITLE
fix(records): normalize phone numbers to E.164 via libphonenumber-js

### DIFF
--- a/packages/lib/src/field-values/__tests__/phone-e164.test.ts
+++ b/packages/lib/src/field-values/__tests__/phone-e164.test.ts
@@ -1,0 +1,53 @@
+// packages/lib/src/field-values/__tests__/phone-e164.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { fieldValueSchemas } from '../field-value-validator'
+import { normalizeForLookup } from '../normalize-for-lookup'
+
+/**
+ * The write path (`fieldValueSchemas.phone`) and the read-side lookup key
+ * (`normalizeForLookup`) share one normalizer by construction — these tests
+ * pin the E.164 behavior and the lockstep between them.
+ */
+describe('phone write-path normalization (E.164)', () => {
+  it('accepts an international number', () => {
+    // The regression test: the previous US-only normalizer rejected every
+    // number that was not 10 digits, or 11 digits starting with 1.
+    const result = fieldValueSchemas.phone.safeParse('+49 30 901820')
+    expect(result.success).toBe(true)
+    expect(result.success && result.data).toBe('+4930901820')
+  })
+
+  it('infers US for national input', () => {
+    const result = fieldValueSchemas.phone.safeParse('(415) 555-1234')
+    expect(result.success && result.data).toBe('+14155551234')
+  })
+
+  it('leaves an already-normalized value unchanged', () => {
+    const result = fieldValueSchemas.phone.safeParse('+14155551234')
+    expect(result.success && result.data).toBe('+14155551234')
+  })
+
+  it('rejects invalid numbers instead of blessing them with a +1', () => {
+    expect(fieldValueSchemas.phone.safeParse('12345').success).toBe(false)
+    expect(fieldValueSchemas.phone.safeParse('0123456789').success).toBe(false)
+    expect(fieldValueSchemas.phone.safeParse('not a phone').success).toBe(false)
+  })
+})
+
+describe('normalizeForLookup PHONE_INTL', () => {
+  it.each([
+    ['(415) 555-1234'],
+    ['415.555.1234'],
+    ['+1 415 555 1234'],
+    ['+49 30 901820'],
+  ])('agrees with the write path for %s', (raw) => {
+    const written = fieldValueSchemas.phone.safeParse(raw)
+    expect(written.success).toBe(true)
+    expect(normalizeForLookup('PHONE_INTL', raw)).toBe(written.success ? written.data : null)
+  })
+
+  it('returns null for a value the write path would reject (skip the candidate)', () => {
+    expect(normalizeForLookup('PHONE_INTL', '12345')).toBeNull()
+  })
+})

--- a/packages/lib/src/field-values/field-value-validator.ts
+++ b/packages/lib/src/field-values/field-value-validator.ts
@@ -70,10 +70,18 @@ export const fieldValueSchemas = {
     })
     .pipe(z.url('Invalid URL format')),
 
-  // PHONE_INTL - format to E.164
-  phone: z.unknown().transform((v) => {
+  // PHONE_INTL - normalize to E.164 via the shared `formatPhoneNumber`
+  //
+  // `ctx.addIssue` is load-bearing: returning `z.NEVER` from a bare transform
+  // does NOT fail the parse — `z.NEVER` is the `{status:'aborted'}` sentinel,
+  // which without a reported issue becomes the parsed DATA (`success: true`),
+  // so an unparseable number reached storage as an object instead of a 400.
+  phone: z.unknown().transform((v, ctx) => {
     const formatted = formatPhoneNumber(String(v).trim())
-    if (!formatted) return z.NEVER
+    if (!formatted) {
+      ctx.addIssue({ code: 'custom', message: 'Invalid phone number' })
+      return z.NEVER
+    }
     return formatted
   }),
 

--- a/packages/lib/src/import/__tests__/split-resolvers.test.ts
+++ b/packages/lib/src/import/__tests__/split-resolvers.test.ts
@@ -58,10 +58,22 @@ describe('resolveEmailSplit', () => {
 })
 
 describe('resolvePhoneSplit', () => {
-  it('normalizes each element', () => {
-    const result = resolvePhoneSplit('+1 (555) 123-4567; 555 987 6543', {})
+  it('normalizes each element to E.164', () => {
+    const result = resolvePhoneSplit('+1 (415) 555-1234; 212 555 0100', {})
     expect(result.type).toBe('value')
-    expect(result.value).toEqual(['+15551234567', '5559876543'])
+    expect(result.value).toEqual(['+14155551234', '+12125550100'])
+  })
+
+  it('mixes international and national elements', () => {
+    const result = resolvePhoneSplit('+49 30 901820, (415) 555-1234', {})
+    expect(result.type).toBe('value')
+    expect(result.value).toEqual(['+4930901820', '+14155551234'])
+  })
+
+  it('drops an invalid element with a warning', () => {
+    const result = resolvePhoneSplit('(415) 555-1234, 12345', {})
+    expect(result.type).toBe('warning')
+    expect(result.value).toEqual(['+14155551234'])
   })
 })
 

--- a/packages/lib/src/import/resolution/resolve-relation-lookups.ts
+++ b/packages/lib/src/import/resolution/resolve-relation-lookups.ts
@@ -205,7 +205,7 @@ async function resolveLookupsForTable(
  * Normalize a relation search value to write-path shape so it can match stored
  * values: EMAIL lowercased, URL `https://`-prefixed + lowercased, PHONE E.164.
  * Lowercase-only normalization can never match a stored URL/phone — the write
- * path stores `https://acme.com` and `+15551234567`. Falls back to
+ * path stores `https://acme.com` and `+14155551234`. Falls back to
  * lowercase+trim when the value doesn't parse (it then simply finds no match)
  * or when the field type carries no normalization.
  */

--- a/packages/lib/src/import/resolution/resolvers/__tests__/phone.test.ts
+++ b/packages/lib/src/import/resolution/resolvers/__tests__/phone.test.ts
@@ -1,0 +1,58 @@
+// packages/lib/src/import/resolution/resolvers/__tests__/phone.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { fieldValueSchemas } from '../../../../field-values/field-value-validator'
+import { normalizeForLookup } from '../../../../field-values/normalize-for-lookup'
+import { resolvePhone } from '../phone'
+
+const config = {} as never
+
+describe('resolvePhone (phone:value)', () => {
+  it('normalizes a US national number to E.164', () => {
+    expect(resolvePhone('(415) 555-1234', config)).toEqual({
+      type: 'value',
+      value: '+14155551234',
+    })
+  })
+
+  it('accepts an international number (the resolver/validator mismatch this fixes)', () => {
+    const raw = '+49 30 901820'
+    const resolved = resolvePhone(raw, config)
+    expect(resolved).toEqual({ type: 'value', value: '+4930901820' })
+    // Previously the resolver emitted `+4930901820` and the write validator then
+    // rejected it mid-import. Both sides must now agree.
+    const written = fieldValueSchemas.phone.safeParse(raw)
+    expect(written.success).toBe(true)
+    expect(written.success ? written.data : null).toBe(resolved.value)
+  })
+
+  it('round-trips: resolver output is byte-identical to the write-path normalization', () => {
+    const raw = '415.555.1234'
+    const resolved = resolvePhone(raw, config)
+    const written = fieldValueSchemas.phone.safeParse(raw)
+    expect(written.success).toBe(true)
+    expect(resolved.value).toBe(written.success ? written.data : undefined)
+    // A re-import of the stored value is a no-op transform.
+    expect(resolvePhone(String(resolved.value), config).value).toBe(resolved.value)
+  })
+
+  it('agrees with read-side lookup normalization', () => {
+    const raw = '(415) 555-1234'
+    expect(normalizeForLookup('PHONE_INTL', raw)).toBe(resolvePhone(raw, config).value)
+  })
+
+  it('returns null for a blank cell', () => {
+    expect(resolvePhone('   ', config)).toEqual({ type: 'value', value: null })
+  })
+
+  it('errors on an unparseable number', () => {
+    const result = resolvePhone('12345', config)
+    expect(result.type).toBe('error')
+    expect(result.error).toContain('Invalid phone number')
+  })
+
+  it('errors on a number the old digit-count check would have accepted', () => {
+    // 7–15 digits passed the old length gate; `isValid()` rejects the prefix.
+    expect(resolvePhone('0123456789', config).type).toBe('error')
+  })
+})

--- a/packages/lib/src/import/resolution/resolvers/phone.ts
+++ b/packages/lib/src/import/resolution/resolvers/phone.ts
@@ -1,10 +1,18 @@
 // packages/lib/src/import/resolution/resolvers/phone.ts
 
+import { formatPhoneNumber } from '@auxx/utils'
 import type { ResolutionConfig, ResolvedValue } from '../../types/resolution'
 
 /**
- * Resolve and normalize phone number.
- * Strips non-numeric characters except leading +.
+ * Resolve and normalize a phone number to E.164.
+ *
+ * Delegates to the shared `formatPhoneNumber` normalizer so the resolver emits
+ * exactly what the write validator (`fieldValueSchemas.phone`) accepts —
+ * previously the resolver's hand-rolled digit logic accepted international
+ * numbers the write path then rejected mid-import.
+ *
+ * Empty cells resolve to `null` (a no-write on update rows); anything the
+ * normalizer can't parse is a row error, never a silent drop.
  */
 export function resolvePhone(rawValue: string, _config: ResolutionConfig): ResolvedValue {
   const trimmed = rawValue.trim()
@@ -13,21 +21,11 @@ export function resolvePhone(rawValue: string, _config: ResolutionConfig): Resol
     return { type: 'value', value: null }
   }
 
-  // Preserve leading + for international numbers
-  const hasPlus = trimmed.startsWith('+')
+  const normalized = formatPhoneNumber(trimmed)
 
-  // Keep only digits
-  const digits = trimmed.replace(/\D/g, '')
-
-  if (digits.length < 7) {
-    return { type: 'error', error: `Phone number too short: ${rawValue}` }
+  if (!normalized) {
+    return { type: 'error', error: `Invalid phone number: ${rawValue}` }
   }
-
-  if (digits.length > 15) {
-    return { type: 'error', error: `Phone number too long: ${rawValue}` }
-  }
-
-  const normalized = hasPlus ? `+${digits}` : digits
 
   return { type: 'value', value: normalized }
 }

--- a/packages/lib/src/ingest/contacts/__tests__/find-or-create-phone.test.ts
+++ b/packages/lib/src/ingest/contacts/__tests__/find-or-create-phone.test.ts
@@ -1,0 +1,103 @@
+// packages/lib/src/ingest/contacts/__tests__/find-or-create-phone.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// --- mocks -----------------------------------------------------------------
+
+// Partial mock: `@auxx/logger/run-log` imports sink-registration helpers from
+// this barrel at module load, so a full replacement breaks whichever test file
+// happens to load it first.
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('../../companies/link-contact', () => ({
+  linkContactToCompanyByDomain: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../../domain/classifier', () => ({
+  getOwnDomains: vi.fn().mockResolvedValue(new Set<string>()),
+}))
+
+vi.mock('../has-sent-to', () => ({
+  hasOrganizationSentToParticipant: vi.fn().mockResolvedValue(true),
+}))
+
+import { findOrCreateContactForParticipant } from '../find-or-create'
+
+const create = vi.fn()
+const findOrCreate = vi.fn()
+const findByField = vi.fn()
+
+function makeCtx() {
+  return {
+    organizationId: 'org_1',
+    db: {} as never,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    crudHandler: { create, findOrCreate, findByField },
+    integrationSettings: { recordCreation: { mode: 'all' } },
+    ownDomainsByOrg: new Map(),
+    companyIdByDomain: new Map(),
+  } as never
+}
+
+function phoneParticipant(identifier: string) {
+  return {
+    id: 'participant_1',
+    identifier,
+    identifierType: 'PHONE',
+    displayName: 'Sender',
+    isInternal: false,
+  } as never
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  create.mockResolvedValue({ instance: { id: 'contact_new' } })
+  findOrCreate.mockResolvedValue({ instance: { id: 'contact_new' } })
+  findByField.mockResolvedValue(null)
+})
+
+describe('findOrCreateContactForParticipant — PHONE identifiers', () => {
+  it('writes a dialable number and dedupes on it', async () => {
+    const contactId = await findOrCreateContactForParticipant(
+      makeCtx(),
+      phoneParticipant('+14155551234'),
+      { isInbound: true, role: 'FROM' as never }
+    )
+
+    expect(contactId).toBe('contact_new')
+    expect(findOrCreate).toHaveBeenCalledWith(
+      'contact',
+      { phone: '+14155551234' },
+      expect.objectContaining({ phone: ['+14155551234'] })
+    )
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it('creates without a phone value for an SMS short code (validator would reject it)', async () => {
+    // Ingest must never throw: a short code is not a dialable number, so the
+    // contact is created with no phone and no identifier-keyed dedupe.
+    const contactId = await findOrCreateContactForParticipant(
+      makeCtx(),
+      phoneParticipant('12345'),
+      { isInbound: true, role: 'FROM' as never }
+    )
+
+    expect(contactId).toBe('contact_new')
+    expect(findOrCreate).not.toHaveBeenCalled()
+    expect(create).toHaveBeenCalledWith('contact', expect.any(Object))
+    expect(create.mock.calls[0]?.[1]).not.toHaveProperty('phone')
+  })
+
+  it('creates without a phone value for an alphanumeric sender id', async () => {
+    const contactId = await findOrCreateContactForParticipant(makeCtx(), phoneParticipant('AUXX'), {
+      isInbound: true,
+      role: 'FROM' as never,
+    })
+
+    expect(contactId).toBe('contact_new')
+    expect(create.mock.calls[0]?.[1]).not.toHaveProperty('phone')
+  })
+})

--- a/packages/lib/src/ingest/contacts/find-or-create.ts
+++ b/packages/lib/src/ingest/contacts/find-or-create.ts
@@ -5,6 +5,7 @@ import {
   ParticipantRole as ParticipantRoleEnum,
 } from '@auxx/database/enums'
 import type { ParticipantEntity as Participant, ParticipantRole } from '@auxx/database/types'
+import { formatPhoneNumber } from '@auxx/utils'
 import { linkContactToCompanyByDomain } from '../companies/link-contact'
 import type { IngestContext } from '../context'
 import { getOwnDomains } from '../domain/classifier'
@@ -68,11 +69,29 @@ export async function findOrCreateContactForParticipant(
     // skip the identifier-keyed lookup and rely on `Participant.entityInstanceId`
     // for dedupe on the caller side.
     const isChatVisitor = participant.identifierType === 'CHAT_VISITOR'
-    const systemAttr = isChatVisitor
-      ? null
-      : participant.identifierType === IdentifierTypeEnum.PHONE
-        ? 'phone'
-        : 'primary_email'
+
+    // A PHONE participant is not guaranteed to carry a dialable number: SMS
+    // short codes (`12345`) and alphanumeric sender IDs (`AUXX`) arrive with
+    // the same identifier type. The write validator normalizes to E.164 and
+    // REJECTS those, so writing one would throw inside ingest. Treat them like
+    // chat visitors — no phone value, no identifier-keyed dedupe.
+    const isAddressablePhone =
+      participant.identifierType !== IdentifierTypeEnum.PHONE ||
+      formatPhoneNumber(participant.identifier) !== null
+
+    if (!isAddressablePhone) {
+      ctx.logger.debug('Participant phone identifier is not a dialable number', {
+        participantId: participant.id,
+        identifier: participant.identifier,
+      })
+    }
+
+    const systemAttr =
+      isChatVisitor || !isAddressablePhone
+        ? null
+        : participant.identifierType === IdentifierTypeEnum.PHONE
+          ? 'phone'
+          : 'primary_email'
 
     // Never auto-create a contact for the integration owner's own addresses.
     // `force` is the documented escape hatch for the user-initiated
@@ -122,7 +141,7 @@ export async function findOrCreateContactForParticipant(
       contact_status: 'ACTIVE',
     }
 
-    if (participant.identifierType === IdentifierTypeEnum.PHONE) {
+    if (participant.identifierType === IdentifierTypeEnum.PHONE && isAddressablePhone) {
       // Array-wrapped for shape consistency with multi-value fields
       // (options.multi) — the write path auto-unwraps length-1 arrays on
       // single-value fields. Create-only: matched contacts never get their

--- a/packages/seed/src/domains/crm.domain.ts
+++ b/packages/seed/src/domains/crm.domain.ts
@@ -17,6 +17,16 @@ interface CompanyRoster {
 }
 
 /**
+ * Assigned NANP area codes used for seeded phone numbers. Curated because the
+ * write validator rejects anything `libphonenumber-js` calls invalid — an
+ * arithmetically generated area code lands on unassigned or service prefixes
+ * roughly half the time. See {@link CrmDomain.generatePhone}.
+ */
+const CRM_SEED_AREA_CODES: readonly number[] = [
+  212, 415, 312, 617, 206, 305, 702, 646, 718, 213, 404, 512, 720, 857,
+]
+
+/**
  * COMPANY_ROSTER is a hand-picked set of recognizable real companies used for
  * demo seeding. Entries are consumed in order — scenarios with `scales.companies = N`
  * take the first N rows. Keep entries distinct by domain.
@@ -1031,13 +1041,24 @@ export class CrmDomain {
     return titles[index % titles.length]!
   }
 
-  /** generatePhone creates realistic phone numbers. */
+  /**
+   * generatePhone creates realistic phone numbers.
+   *
+   * Numbers must be VALID under `libphonenumber-js`, not merely well-shaped:
+   * the write validator (`fieldValueSchemas.phone` → `formatPhoneNumber`) runs
+   * `isValid()`, so an arbitrary `+1<NPA><NXX><line>` is rejected outright.
+   * Hence the curated area codes and the two guards below — the previous
+   * arithmetic generator emitted N11 service codes (`+1211…`) and other
+   * unassigned prefixes for ~46% of seeded contacts.
+   */
   private generatePhone(index: number): string | null {
     if (index % 3 === 0) {
       return null // 33% no phone
     }
-    const areaCode = 200 + (index % 800)
-    const exchange = 200 + (index % 800)
+    const areaCode = CRM_SEED_AREA_CODES[index % CRM_SEED_AREA_CODES.length]!
+    let exchange = 200 + (index % 700)
+    if (exchange % 100 === 11) exchange += 1 // N11 (211, 311, …) are service codes
+    if (exchange === 555) exchange = 556 // 555 is reserved for fictional numbers
     const number = 1000 + (index % 9000)
     return `+1${areaCode}${exchange}${number}`
   }

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -41,7 +41,7 @@ import { generateId } from '@auxx/utils/generateId'
 - `getContactDisplayName` - Get displayable contact name
 - `getInitials` - Get initials from a full name
 - `getInitialsFromName` - Get initials from first/last name
-- `formatPhoneNumber` - Format phone number for display
+- `formatPhoneNumber` - Normalize a phone number to E.164 (null when invalid)
 - `formatStreetAddress` - Format street address
 - `formatCompanyName` - Format company name
 - `formatComplexName` - Format complex name formats

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -177,6 +177,7 @@
     "@auxx/types": "workspace:*",
     "date-fns": "catalog:",
     "date-fns-tz": "^3.2.0",
+    "libphonenumber-js": "catalog:",
     "nanoid": "^5.1.5"
   },
   "devDependencies": {

--- a/packages/utils/src/__tests__/contact.test.ts
+++ b/packages/utils/src/__tests__/contact.test.ts
@@ -1,0 +1,69 @@
+// packages/utils/src/__tests__/contact.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { formatPhoneNumber } from '../contact'
+
+describe('formatPhoneNumber', () => {
+  describe('US national numbers (the default country)', () => {
+    it('normalizes a bare 10-digit number to E.164', () => {
+      expect(formatPhoneNumber('4155551234')).toBe('+14155551234')
+    })
+
+    it('normalizes formatted input', () => {
+      expect(formatPhoneNumber('(415) 555-1234')).toBe('+14155551234')
+      expect(formatPhoneNumber('415.555.1234')).toBe('+14155551234')
+      expect(formatPhoneNumber('415-555-1234 ')).toBe('+14155551234')
+    })
+
+    it('normalizes an 11-digit number that already carries the country code', () => {
+      expect(formatPhoneNumber('14155551234')).toBe('+14155551234')
+      expect(formatPhoneNumber('+1 415 555 1234')).toBe('+14155551234')
+    })
+
+    it('returns already-E.164 values unchanged (migration is a no-op on clean rows)', () => {
+      expect(formatPhoneNumber('+14155551234')).toBe('+14155551234')
+    })
+  })
+
+  describe('international numbers (rejected by the old US-only normalizer)', () => {
+    it('parses a German number without coercing it to US', () => {
+      expect(formatPhoneNumber('+49 30 901820')).toBe('+4930901820')
+    })
+
+    it('parses UK and Australian numbers', () => {
+      expect(formatPhoneNumber('+44 20 7183 8750')).toBe('+442071838750')
+      expect(formatPhoneNumber('+61 2 8015 5555')).toBe('+61280155555')
+    })
+
+    it('honors an explicit default country for national input', () => {
+      expect(formatPhoneNumber('030 901820', 'DE')).toBe('+4930901820')
+    })
+  })
+
+  describe('invalid input', () => {
+    it('returns null for empty input', () => {
+      expect(formatPhoneNumber(null)).toBeNull()
+      expect(formatPhoneNumber('')).toBeNull()
+      expect(formatPhoneNumber('   ')).toBeNull()
+    })
+
+    it('returns null for too-short numbers', () => {
+      expect(formatPhoneNumber('12345')).toBeNull()
+    })
+
+    it('returns null for garbage', () => {
+      expect(formatPhoneNumber('not a phone')).toBeNull()
+      expect(formatPhoneNumber('++++')).toBeNull()
+    })
+
+    it('rejects impossible US numbers the old algorithm blessed with a +1', () => {
+      // 10 digits, so the old normalizer returned `+10123456789`-style junk.
+      expect(formatPhoneNumber('0123456789')).toBeNull()
+      expect(formatPhoneNumber('1111111111')).toBeNull()
+    })
+
+    it('returns null for an unknown country calling code', () => {
+      expect(formatPhoneNumber('+999 1234567')).toBeNull()
+    })
+  })
+})

--- a/packages/utils/src/contact.ts
+++ b/packages/utils/src/contact.ts
@@ -1,3 +1,7 @@
+// packages/utils/src/contact.ts
+
+import { type CountryCode, parsePhoneNumberFromString } from 'libphonenumber-js'
+
 export type ContactName = {
   id?: string
   name?: string | null
@@ -63,20 +67,32 @@ export const getInitialsFromName = (name: string | null, empty: string = 'U'): s
   return name[0]!.charAt(0).toUpperCase()
 }
 
-export const formatPhoneNumber = (phone: string | null): string | null => {
-  if (!phone) return null // Handle empty input
+/**
+ * Normalize a phone number to E.164 (`+4930901820`).
+ *
+ * This is THE phone normalizer — the write-path validator
+ * (`fieldValueSchemas.phone`), read-side `normalizeForLookup` and the import
+ * resolver all funnel through it, so write and lookup normalization can never
+ * drift apart.
+ *
+ * National numbers with no country code are parsed as `defaultCountry`
+ * (US in v1; org-profile-based inference is the v2 lever). Validation uses
+ * `isValid()` — the per-country numbering-plan check, not just a length check —
+ * so impossible numbers are rejected rather than blessed with a `+1`.
+ *
+ * @param phone Raw user/CSV/provider input, any formatting.
+ * @param defaultCountry Country assumed for numbers written without a `+` prefix.
+ * @returns The E.164 string, or `null` when the input is unparseable or invalid.
+ */
+export const formatPhoneNumber = (
+  phone: string | null,
+  defaultCountry: CountryCode = 'US'
+): string | null => {
+  if (!phone) return null
 
-  // Remove all non-numeric characters
-  const digits: string = phone.replace(/\D/g, '')
+  const parsed = parsePhoneNumberFromString(phone.trim(), defaultCountry)
 
-  // Handle different cases
-  if (digits.length === 10) {
-    return `+1${digits}` // Assume US number without country code
-  } else if (digits.length === 11 && digits.startsWith('1')) {
-    return `+${digits}` // Already has country code
-  } else {
-    return null // Invalid number
-  }
+  return parsed?.isValid() ? parsed.number : null
 }
 
 export const formatStreetAddress = (street: string | null): string | null => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2774,6 +2774,9 @@ importers:
       date-fns-tz:
         specifier: ^3.2.0
         version: 3.2.0(date-fns@4.1.0)
+      libphonenumber-js:
+        specifier: 'catalog:'
+        version: 1.12.38
       nanoid:
         specifier: ^5.1.5
         version: 5.1.6


### PR DESCRIPTION
Unblocks the multi-value **phone** flip (`plans/custom-field/multi/04-multi-email-implementation-plan.md` C5). Email + website flipped in #1625; phone was held back because the normalizer would reject international aliases at write. This is that normalizer.

## What was wrong

`formatPhoneNumber` was a hand-rolled US-only digit shuffle — 10 digits got a `+1`, 11 starting with `1` got a `+`, everything else was rejected:

- every international number refused at write time
- `+49 30 901820` → `+14930901820`, a German number silently stamped as US
- the import resolver had its own *third* normalization (7–15 digits, no country inference), so it accepted numbers the write path then rejected mid-import

## What changed

- **`packages/utils/src/contact.ts`** — rewritten on `libphonenumber-js` with `isValid()` and a `defaultCountry = 'US'` param (unused until v2 org-country inference). Signature is unchanged, so `fieldValueSchemas.phone` and `normalizeForLookup` inherit it and write/lookup normalization cannot drift.
- **`import/resolution/resolvers/phone.ts`** — delegates to the shared helper. `phone:split` composes it per element, so multi-value phone cells inherit it too.

## Two things the plan did not know about

**1. The phone schema never actually rejected anything.** Returning `z.NEVER` from a bare `.transform()` does not fail the parse — it is the `{status:'aborted'}` sentinel, and with no issue reported it becomes the parsed *data* with `success: true`. So an unparseable phone was never a 400; `validateAndConvertValue` passed that object on as the column value. Fixed with `ctx.addIssue`.

> The identical bug sits on `booleanSchema` and `dateSchema` in the same file (a bad CHECKBOX setting stores the sentinel via `normalize-setting-value.ts`). **Deliberately not fixed here** — each changes behavior on a different door and deserves its own PR.

**2. Making rejection real broke two feeders, both fixed here:**

- **Ingest** wrote `participant.identifier` straight onto a contact's phone field. SMS short codes (`12345`) and alphanumeric sender ids (`AUXX`) carry `identifierType = PHONE`, so that write would now throw *inside ingest*, which must never throw. They are treated like chat visitors: contact created, no phone value, no identifier-keyed dedupe.
- **The seed generator** built area codes arithmetically (`200 + index % 800`), emitting N11 service codes and unassigned prefixes — **46% of seeded contacts** carried numbers the new validator rejects. Now a curated assigned-area-code list with N11/555 guards (0 invalid over 3000 generated).

## Dev audit — no data migration

287 stored phone values / 107 distinct, **all E.164-shaped, 0 renormalizable**. 35 distinct values are *invalid* (`+1211…`, `+1222…` — exactly the old seeder's junk), but re-running the normalizer changes none of them, so the migration the plan hedged on would be a pure no-op. Skipped.

⚠️ **Prod audit is still outstanding before the phone flip.** Invalid stored values are harmless on read, but editing such a contact's phone now 400s until the number is corrected.

## Tests

31 new/updated across four files: normalizer units (US, international, explicit country, garbage, impossible-US), write-validator + `normalizeForLookup` lockstep, resolver↔validator round-trip parity, the ingest short-code guard, and the corrected `resolvePhoneSplit` expectations.

`packages/utils` 192 passed · `packages/lib` ingest+import+field-values 360 passed · `tsc --noEmit` clean under `src/` for both.
