### PR TITLE
feat(kopilot): add safe deep node config patches

### DIFF
--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
@@ -31,6 +31,7 @@ const APPLIED: GraphMutationResult = {
     id: 'wait-1',
     type: 'wait',
     title: 'Wait A Bit',
+    configHash: 'config-hash-1',
     position: { x: 10, y: 20 },
     config: { waitFor: '10m' },
   },

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/write-tools.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/write-tools.test.ts
@@ -20,9 +20,13 @@ vi.mock('../../../../../../workflows/workflow-app-access-guard', () => ({
 
 const addNodeMock = vi.fn()
 const connectNodesMock = vi.fn()
+const updateNodeMock = vi.fn()
+const readDraftMock = vi.fn()
 vi.mock('../../../../../../workflows/graph-edit', () => ({
   addNode: (...a: unknown[]) => addNodeMock(...a),
   connectNodes: (...a: unknown[]) => connectNodesMock(...a),
+  updateNode: (...a: unknown[]) => updateNodeMock(...a),
+  readDraft: (...a: unknown[]) => readDraftMock(...a),
 }))
 
 const runNodeMock = vi.fn()
@@ -37,7 +41,9 @@ vi.mock('../../../../../../demo', () => ({
 
 import { createAddNodeTool } from '../add-node'
 import { createConnectNodesTool } from '../connect-nodes'
+import { createGetNodeTool } from '../get-node'
 import { createRunNodeTool } from '../run-node'
+import { createUpdateNodeTool } from '../update-node'
 
 const ORG = 'org-1'
 const WF = 'wfapp-1'
@@ -78,6 +84,7 @@ const APPLIED: GraphMutationResult = {
     id: 'http-abc',
     type: 'http',
     title: 'HTTP Request',
+    configHash: 'config-hash-1',
     position: { x: 500, y: 250 },
     config: { url: 'https://example.com', method: 'POST' },
   },
@@ -93,6 +100,19 @@ beforeEach(() => {
   assertNotSystemOwned.mockReset().mockResolvedValue(undefined)
   addNodeMock.mockReset().mockResolvedValue(ok(APPLIED))
   connectNodesMock.mockReset().mockResolvedValue(ok(APPLIED))
+  updateNodeMock.mockReset().mockResolvedValue(ok(APPLIED))
+  readDraftMock.mockReset().mockResolvedValue(
+    ok({
+      workflowAppId: WF,
+      name: 'My Flow',
+      triggerType: 'manual',
+      nodes: [APPLIED.node],
+      edges: [],
+      outputs: { 'HTTP Request': APPLIED.outputs },
+      issues: [],
+      graphSummary: APPLIED.graphSummary,
+    })
+  )
   runNodeMock
     .mockReset()
     .mockResolvedValue(
@@ -174,6 +194,48 @@ describe('add_node', () => {
     const result = await run(createAddNodeTool(getDeps), { type: 'http' })
     expect(result.success).toBe(false)
     expect(result.error).toMatch(/re-read/i)
+  })
+})
+
+describe('get_node / update_node deep patches', () => {
+  it('returns configHash and threads guarded patches into graph-edit', async () => {
+    const read = await run(createGetNodeTool(getDeps), { ref: 'HTTP Request' })
+    expect(read.success).toBe(true)
+    expect((read.output as { node: { configHash: string } }).node.configHash).toBe('config-hash-1')
+
+    const patches = [{ op: 'set', path: ['body', 'data', 0, 'value'], value: 'updated' }]
+    const updated = await run(createUpdateNodeTool(getDeps), {
+      ref: 'HTTP Request',
+      expectedConfigHash: 'config-hash-1',
+      patches,
+    })
+    expect(updated.success).toBe(true)
+    expect(updateNodeMock.mock.calls[0]?.[1]).toMatchObject({
+      workflowAppId: WF,
+      organizationId: ORG,
+      turnId: TURN,
+      ref: 'HTTP Request',
+      expectedConfigHash: 'config-hash-1',
+      patches,
+    })
+  })
+
+  it('requires exactly one update mode and a hash for patches', async () => {
+    const both = await run(createUpdateNodeTool(getDeps), {
+      ref: 'HTTP Request',
+      config: { method: 'POST' },
+      patches: [{ op: 'set', path: ['method'], value: 'POST' }],
+    })
+    expect(both.success).toBe(false)
+    expect(both.error).toContain('exactly one')
+
+    const unhashed = await run(createUpdateNodeTool(getDeps), {
+      ref: 'HTTP Request',
+      patches: [{ op: 'set', path: ['method'], value: 'POST' }],
+    })
+    expect(unhashed.success).toBe(false)
+    expect(unhashed.error).toContain('expectedConfigHash')
+    expect(updateNodeMock).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/get-node.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/get-node.ts
@@ -17,7 +17,7 @@ export function createGetNodeTool(getDeps: GetToolDeps): AgentToolDefinition {
     surfaces: ['builder'],
     idempotent: true,
     description:
-      'Read one node of the open workflow in full: complete config, resolved outputs (wire references from these), and its current issues. Address it by title or ref from get_workflow.',
+      'Read one node of the open workflow in full: complete config, configHash for guarded patches, resolved outputs (wire references from these), and its current issues. Address it by title or ref from get_workflow.',
     parameters: {
       type: 'object',
       properties: {

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/update-node.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/update-node.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/update-node.ts
 
+import type { ConfigPatch } from '../../../../../workflows/graph-edit'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import { buildWorkflowEditDigest } from '../../../digests'
 import type { GetToolDeps } from '../../types'
@@ -10,7 +11,7 @@ import {
 } from './graph-tool-helpers'
 import { optionalRecord, resolveWorkflowWrite } from './write-tool-helpers'
 
-/** Shallow-merge a friendly config into one node. */
+/** Shallow-merge top-level fields or apply stale-safe deep config patches. */
 export function createUpdateNodeTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'update_node',
@@ -18,17 +19,59 @@ export function createUpdateNodeTool(getDeps: GetToolDeps): AgentToolDefinition 
     displayName: 'Update workflow node',
     surfaces: ['builder'],
     description:
-      'Update one node of the open workflow draft: the config is shallow-merged over its current data. Pass only the fields you want to change. Use get_node first to see the current config; the result returns the node, its resolved outputs, and any issues.',
+      'Update one node of the open workflow draft. Use `config` for a legacy top-level shallow merge, or `patches` plus the configHash from get_node for atomic deep set/unset edits that preserve nested siblings. Pass exactly one mode. Patch paths are arrays of field names and numeric array indexes.',
     parameters: {
       type: 'object',
       properties: {
         ref: { type: 'string', description: 'Node title (or ref) to update.' },
         config: {
           type: 'object',
-          description: 'Friendly config fields to merge — `{{Title.path}}` refs welcome.',
+          description:
+            'Top-level friendly config fields to shallow-merge; {{Title.path}} refs welcome.',
+        },
+        expectedConfigHash: {
+          type: 'string',
+          description: 'Opaque configHash from get_node; required with patches.',
+        },
+        patches: {
+          type: 'array',
+          minItems: 1,
+          description:
+            'Atomic deep edits to the complete friendly config returned by get_node. Every parent must exist; set may create the final object field.',
+          items: {
+            oneOf: [
+              {
+                type: 'object',
+                properties: {
+                  op: { const: 'set' },
+                  path: {
+                    type: 'array',
+                    minItems: 1,
+                    items: { oneOf: [{ type: 'string' }, { type: 'integer', minimum: 0 }] },
+                  },
+                  value: {},
+                },
+                required: ['op', 'path', 'value'],
+                additionalProperties: false,
+              },
+              {
+                type: 'object',
+                properties: {
+                  op: { const: 'unset' },
+                  path: {
+                    type: 'array',
+                    minItems: 1,
+                    items: { oneOf: [{ type: 'string' }, { type: 'integer', minimum: 0 }] },
+                  },
+                },
+                required: ['op', 'path'],
+                additionalProperties: false,
+              },
+            ],
+          },
         },
       },
-      required: ['ref', 'config'],
+      required: ['ref'],
       additionalProperties: false,
     },
     summary: (args) => `Update node: ${typeof args.ref === 'string' ? args.ref : ''}`,
@@ -38,15 +81,55 @@ export function createUpdateNodeTool(getDeps: GetToolDeps): AgentToolDefinition 
       const write = await resolveWorkflowWrite(getDeps, agentDeps)
       if (!write.ok) return { success: false, output: null, error: write.error }
       const ref = typeof args.ref === 'string' ? args.ref.trim() : ''
-      const config = optionalRecord(args.config)
-      if (!ref || !config) {
-        return { success: false, output: null, error: 'ref and config are required.' }
+      if (!ref) return { success: false, output: null, error: 'ref is required.' }
+
+      const hasConfig = args.config !== undefined
+      const hasPatches = args.patches !== undefined
+      if (hasConfig === hasPatches) {
+        return {
+          success: false,
+          output: null,
+          error: 'Pass exactly one of config or patches.',
+        }
+      }
+      const config = hasConfig ? optionalRecord(args.config) : undefined
+      if (hasConfig && !config) {
+        return { success: false, output: null, error: 'config must be an object.' }
+      }
+      const patches =
+        hasPatches && Array.isArray(args.patches) ? (args.patches as ConfigPatch[]) : []
+      const expectedConfigHash =
+        typeof args.expectedConfigHash === 'string' ? args.expectedConfigHash.trim() : ''
+      if (hasPatches && (patches.length === 0 || !expectedConfigHash)) {
+        return {
+          success: false,
+          output: null,
+          error: 'patches must be non-empty and expectedConfigHash is required.',
+        }
+      }
+      if (hasConfig && args.expectedConfigHash !== undefined) {
+        return {
+          success: false,
+          output: null,
+          error: 'expectedConfigHash is only used with patches.',
+        }
       }
 
       const { db } = getDeps()
       // Lazy import — see get-workflow.ts.
       const { updateNode } = await import('../../../../../workflows/graph-edit')
-      const result = await updateNode(db, { ...write.scope, ref, config })
+      const result = hasPatches
+        ? await updateNode(db, {
+            ...write.scope,
+            ref,
+            patches,
+            expectedConfigHash,
+          })
+        : await updateNode(db, {
+            ...write.scope,
+            ref,
+            config: config!,
+          })
       return mutationToToolResult(result, (value) =>
         value.applied ? `Updated ${value.node?.title ?? ref}` : `Update ${ref} blocked`
       )

--- a/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
@@ -37,6 +37,9 @@ export function buildWorkflowBuilderPromptSection(): string {
     // Canvas readability.
     'Every node you add needs a concise `description` that explains why it exists in the user’s terms. This appears under the node title on the canvas.',
 
+    // Safe nested edits.
+    'Nested config edits: call `get_node` immediately before editing, then use `update_node` with its `configHash` and `patches`. Paths are segment arrays, for example `["model", "completion_params", "temperature"]`; use numeric segments for arrays. Prefer patches over resending a nested object. If the hash is stale, re-read and retry. Use legacy `config` only for top-level fields such as `title`.',
+
     // Verification + simulation.
     'Verifying: `validate_workflow` runs the real publish gate without publishing — use it after a batch of edits. `run_node` executes ONE node as a SIMULATED debug run (side-effecting nodes do not send email, call webhooks, etc.); you supply its input values — upstream nodes are not executed. Say clearly in your reply that the run was simulated.',
 
@@ -45,6 +48,7 @@ export function buildWorkflowBuilderPromptSection(): string {
       'Worked examples:',
       '  - add_node(type: "http", title: "Post To Webhook", description: "Notify the fulfillment system about high-priority orders", after: "Check Priority", branch: "High", config: { url: "https://example.com/hook", method: "POST" })',
       '  - update_node(ref: "Send Email", config: { subject: "Order {{Find Order.record.number}} update" })',
+      '  - get_node(ref: "AI Agent") → update_node(ref: "AI Agent", expectedConfigHash: "<returned configHash>", patches: [{ op: "set", path: ["model", "completion_params", "temperature"], value: 0.2 }])',
       '  - add_node(type: "crud", title: "Create Task", inside: "For Each Line Item", config: { … "{{For Each Line Item.item.name}}" … })',
       '  - connect_nodes(from: "Summarize Email", to: "Save Summary")',
     ].join('\n'),

--- a/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
@@ -46,8 +46,9 @@ const {
   setTrigger,
   updateNode,
 } = await import('../ops')
-const { readDraft } = await import('../read')
+const { buildNodeSummary, readDraft } = await import('../read')
 
+import { hashWorkflowGraph } from '../../graph-hash'
 import type { DraftGraph, GraphEdge, GraphNode } from '../types'
 
 const ORG = 'org_1'
@@ -670,6 +671,104 @@ describe('updateNode / disconnectNodes', () => {
     const loop = persistedGraph().nodes.find((n) => n.id === LOOP_ID)
     expect(loop?.data?.title).toBe('Every Morning')
     expect(loop?.data?.desc).toBe('Every Morning')
+  })
+
+  it('deep-patches nested config atomically, preserves siblings, and durably unsets fields', async () => {
+    const trigger = triggerNode()
+    const graph: DraftGraph = { nodes: [trigger], edges: [] }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'Every Morning',
+      expectedConfigHash: hashWorkflowGraph(trigger.data),
+      patches: [
+        {
+          op: 'set',
+          path: ['config', 'timeBetweenTriggers', 'days'],
+          value: 2,
+        },
+        { op: 'unset', path: ['config', 'timezone'] },
+      ],
+    })
+
+    expect(result.isOk()).toBe(true)
+    const persisted = persistedGraph().nodes[0]
+    expect(persisted?.data?.config).toEqual({
+      triggerInterval: 'days',
+      timeBetweenTriggers: { days: 2, isConstant: true },
+    })
+    expect(result._unsafeUnwrap().node?.configHash).not.toBe(hashWorkflowGraph(trigger.data))
+  })
+
+  it('patches an array entry without replacing its siblings', async () => {
+    const conditional = ifElseNode()
+    conditional.data._targetBranches = [{ id: 'true', name: 'IF', type: 'default' }]
+    const graph: DraftGraph = { nodes: [triggerNode(), conditional], edges: [] }
+    const configHash = buildNodeSummary(graph, conditional).configHash
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'Check Priority',
+      expectedConfigHash: configHash,
+      patches: [{ op: 'set', path: ['cases', 0, 'logical_operator'], value: 'or' }],
+    })
+
+    expect(result.isOk()).toBe(true)
+    const persisted = persistedGraph().nodes.find((node) => node.id === IFELSE_ID)
+    expect(persisted?.data?.cases).toEqual([
+      { id: 'c1', case_id: 'true', logical_operator: 'or', conditions: [] },
+    ])
+    expect(result._unsafeUnwrap().node?.configHash).not.toBe(configHash)
+  })
+
+  it('adds a dynamic dotted key while re-normalizing the complete friendly config', async () => {
+    const crudId = 'crud-aaaaaaaaaaaaaaaaaaaaa'
+    const crud: GraphNode = {
+      id: crudId,
+      type: 'standard',
+      position: { x: 500, y: 200 },
+      data: {
+        id: crudId,
+        type: 'crud',
+        title: 'Create Ticket',
+        resourceType: TICKET_ID,
+        mode: 'create',
+        data: { subject: 'Original' },
+        error_strategy: 'fail',
+        default_values: [],
+      },
+    }
+    const graph: DraftGraph = { nodes: [triggerNode(), crud], edges: [] }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'Create Ticket',
+      expectedConfigHash: hashWorkflowGraph(crud.data),
+      patches: [{ op: 'set', path: ['data', 'customer.email'], value: 'person@example.com' }],
+    })
+
+    expect(result.isOk()).toBe(true)
+    const persisted = persistedGraph().nodes.find((node) => node.id === crudId)
+    expect(persisted?.data?.resourceType).toBe(TICKET_ID)
+    expect(persisted?.data?.data).toEqual({
+      subject: 'Original',
+      'customer.email': 'person@example.com',
+    })
+  })
+
+  it('rejects a patch based on a stale get_node configHash without persisting', async () => {
+    const graph: DraftGraph = { nodes: [triggerNode(), loopNode()], edges: [] }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'For each order',
+      expectedConfigHash: 'stale',
+      patches: [{ op: 'set', path: ['maxIterations'], value: 5 }],
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('Re-read the node')
+    expect(serviceUpdate).not.toHaveBeenCalled()
   })
 
   it('disconnectNodes removes the edge and errors when none exists', async () => {

--- a/packages/lib/src/workflows/graph-edit/__tests__/patch-config.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/patch-config.test.ts
@@ -1,0 +1,61 @@
+// packages/lib/src/workflows/graph-edit/__tests__/patch-config.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { applyConfigPatches } from '../patch-config'
+
+describe('applyConfigPatches', () => {
+  it('sets nested objects, dynamic dotted keys, and array leaves without losing siblings', () => {
+    const original = {
+      model: { completion_params: { temperature: 0.7, max_tokens: 500 } },
+      schema: { properties: {} as Record<string, unknown> },
+      cases: [{ id: 'case-1', logical_operator: 'and' }],
+    }
+    const result = applyConfigPatches(original, [
+      { op: 'set', path: ['model', 'completion_params', 'temperature'], value: 0.2 },
+      { op: 'set', path: ['schema', 'properties', 'order.total'], value: { type: 'number' } },
+      { op: 'set', path: ['cases', 0, 'logical_operator'], value: 'or' },
+    ])
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toEqual({
+      model: { completion_params: { temperature: 0.2, max_tokens: 500 } },
+      schema: { properties: { 'order.total': { type: 'number' } } },
+      cases: [{ id: 'case-1', logical_operator: 'or' }],
+    })
+    expect(original.model.completion_params.temperature).toBe(0.7)
+  })
+
+  it('creates and removes optional object fields in one atomic patch set', () => {
+    const result = applyConfigPatches({ authorization: { type: 'bearer' } }, [
+      { op: 'set', path: ['authorization', 'token'], value: 'secret' },
+      { op: 'unset', path: ['authorization', 'token'] },
+    ])
+
+    expect(result._unsafeUnwrap()).toEqual({ authorization: { type: 'bearer' } })
+  })
+
+  it.each([
+    [{ op: 'set', path: ['missing', 'child'], value: true }],
+    [{ op: 'set', path: ['items', 1], value: 'b' }],
+    [{ op: 'unset', path: ['items', 0] }],
+    [{ op: 'set', path: ['__proto__', 'polluted'], value: true }],
+    [{ op: 'set', path: ['_targetBranches'], value: [] }],
+    [{ op: 'set', path: ['id'], value: 'evil' }],
+  ])('rejects unsafe or ambiguous path operations: %j', (patch) => {
+    const result = applyConfigPatches({ items: ['a'] }, [patch] as Parameters<
+      typeof applyConfigPatches
+    >[1])
+    expect(result.isErr()).toBe(true)
+  })
+
+  it('does not mutate the input when a later patch fails', () => {
+    const original = { nested: { value: 1 } }
+    const result = applyConfigPatches(original, [
+      { op: 'set', path: ['nested', 'value'], value: 2 },
+      { op: 'set', path: ['nested', 'missing', 'value'], value: 3 },
+    ])
+
+    expect(result.isErr()).toBe(true)
+    expect(original).toEqual({ nested: { value: 1 } })
+  })
+})

--- a/packages/lib/src/workflows/graph-edit/index.ts
+++ b/packages/lib/src/workflows/graph-edit/index.ts
@@ -61,6 +61,11 @@ export {
   updateNode,
 } from './ops'
 export {
+  applyConfigPatches,
+  type ConfigPatch,
+  type ConfigPathSegment,
+} from './patch-config'
+export {
   cleanGraphForSave,
   type PersistDraftInput,
   type PersistDraftOutcome,
@@ -82,6 +87,7 @@ export {
   buildNodeSummary,
   type DraftContext,
   type GraphEditScope,
+  hashNodeConfig,
   loadDraftContext,
   readDraft,
   renderFriendlyOutputs,

--- a/packages/lib/src/workflows/graph-edit/ops.ts
+++ b/packages/lib/src/workflows/graph-edit/ops.ts
@@ -34,6 +34,7 @@ import { normalizeFriendlyRefs, type ResourceAliasIndex } from './normalize/frie
 import { normalizeAiPromptConfig } from './normalize/prompt'
 import { checkVariableRefsAgainstOutputs } from './normalize/ref-check'
 import { buildResourceAliasIndex, normalizeResourceConfig } from './normalize/resource-refs'
+import { applyConfigPatches, type ConfigPatch } from './patch-config'
 import { persistDraft, publishDraftUpdatedSignal } from './persist'
 import {
   DEFAULT_NODE_SIZE,
@@ -47,6 +48,7 @@ import {
   buildNodeSummary,
   type DraftContext,
   type GraphEditScope,
+  hashNodeConfig,
   loadDraftContext,
   renderFriendlyOutputs,
 } from './read'
@@ -476,17 +478,32 @@ export async function addNode(
   })
 }
 
-/** Input for {@link updateNode}. */
-export interface UpdateNodeInput extends GraphMutationScope {
+interface UpdateNodeBaseInput extends GraphMutationScope {
   /** Node title or id. */
   ref: string
-  /** Friendly config, shallow-merged over the node's current data. */
-  config: Record<string, unknown>
 }
 
+/** Input for {@link updateNode}: a legacy shallow merge or guarded deep patches. */
+export type UpdateNodeInput = UpdateNodeBaseInput &
+  (
+    | {
+        /** Friendly config, shallow-merged over the node's current data. */
+        config: Record<string, unknown>
+        patches?: never
+        expectedConfigHash?: never
+      }
+    | {
+        /** Atomic edits against the complete friendly config returned by `get_node`. */
+        patches: ConfigPatch[]
+        /** `configHash` from the same `get_node` result used to choose the patch paths. */
+        expectedConfigHash: string
+        config?: never
+      }
+  )
+
 /**
- * Shallow-merge a friendly config into one node's data. `id` and `type` are
- * identity and cannot be changed here (use `setTrigger`/delete + add).
+ * Update one node using either the legacy top-level merge or atomic, stale-safe
+ * deep patches. `id`, `type`, and derived keys cannot be patched.
  */
 export async function updateNode(
   db: Database,
@@ -500,18 +517,50 @@ export async function updateNode(
     const manifestResult = requireAuthorableManifest(type)
     if (manifestResult.isErr()) return err(manifestResult.error)
 
-    const normalized = await normalizeConfig(
-      ctx.organizationId,
-      ctx.graph.nodes,
-      aliases,
-      type,
-      params.config
-    )
-    const { id: _id, type: _type, ...mergeable } = normalized.config
+    let nextData: Record<string, unknown>
+    let normalized: Awaited<ReturnType<typeof normalizeConfig>>
 
-    const nextNodes = ctx.graph.nodes.map((n) =>
-      n.id === node.id ? { ...n, data: { ...n.data, ...mergeable } } : n
-    )
+    if ('patches' in params) {
+      const actualConfigHash = hashNodeConfig((node.data ?? {}) as Record<string, unknown>)
+      if (params.expectedConfigHash !== actualConfigHash) {
+        return err(
+          new ConflictError(
+            'This node changed after get_node returned it. Re-read the node and retry the ' +
+              'patches with its new configHash. Nothing was overwritten.'
+          )
+        )
+      }
+
+      const currentFriendly = buildNodeSummary(ctx.graph, node, aliases).config
+      const patched = applyConfigPatches(currentFriendly, params.patches)
+      if (patched.isErr()) return err(patched.error)
+      normalized = await normalizeConfig(
+        ctx.organizationId,
+        ctx.graph.nodes,
+        aliases,
+        type,
+        patched.value
+      )
+      const { id: _id, type: _type, ...replacement } = normalized.config
+
+      // Remove every previous agent-visible top-level key first. This makes an
+      // `unset` durable while retaining identity, title, canvas, and derived data.
+      nextData = { ...(node.data as Record<string, unknown>) }
+      for (const key of Object.keys(currentFriendly)) delete nextData[key]
+      nextData = { ...nextData, ...replacement }
+    } else {
+      normalized = await normalizeConfig(
+        ctx.organizationId,
+        ctx.graph.nodes,
+        aliases,
+        type,
+        params.config
+      )
+      const { id: _id, type: _type, ...mergeable } = normalized.config
+      nextData = { ...(node.data as Record<string, unknown>), ...mergeable }
+    }
+
+    const nextNodes = ctx.graph.nodes.map((n) => (n.id === node.id ? { ...n, data: nextData } : n))
     return ok({
       graph: { ...ctx.graph, nodes: nextNodes },
       touchedNodeId: node.id,

--- a/packages/lib/src/workflows/graph-edit/patch-config.ts
+++ b/packages/lib/src/workflows/graph-edit/patch-config.ts
@@ -1,0 +1,147 @@
+// packages/lib/src/workflows/graph-edit/patch-config.ts
+
+import { err, ok, type Result } from 'neverthrow'
+import { BadRequestError } from '../../errors'
+
+/** One unambiguous segment in an agent-visible node config path. */
+export type ConfigPathSegment = string | number
+
+/** Atomic deep edits accepted by `updateNode`. */
+export type ConfigPatch =
+  | { op: 'set'; path: ConfigPathSegment[]; value: unknown }
+  | { op: 'unset'; path: ConfigPathSegment[] }
+
+const FORBIDDEN_SEGMENTS = new Set(['__proto__', 'prototype', 'constructor'])
+const FORBIDDEN_ROOT_KEYS = new Set(['id', 'type'])
+
+function own(record: object, key: PropertyKey): boolean {
+  return Object.hasOwn(record, key)
+}
+
+function validatePath(path: ConfigPathSegment[]): Result<void, BadRequestError> {
+  if (path.length === 0) return err(new BadRequestError('Patch path cannot be empty.'))
+
+  for (const segment of path) {
+    if (typeof segment !== 'string' && typeof segment !== 'number') {
+      return err(new BadRequestError('Patch path segments must be field names or array indexes.'))
+    }
+    if (typeof segment === 'number') {
+      if (!Number.isInteger(segment) || segment < 0) {
+        return err(new BadRequestError(`Array index must be a non-negative integer: ${segment}`))
+      }
+      continue
+    }
+    if (!segment) return err(new BadRequestError('Patch path segments cannot be empty.'))
+    if (FORBIDDEN_SEGMENTS.has(segment)) {
+      return err(new BadRequestError(`Patch path segment "${segment}" is not allowed.`))
+    }
+  }
+
+  const root = path[0]
+  if (typeof root !== 'string') {
+    return err(new BadRequestError('Patch paths must start with a config field name.'))
+  }
+  if (FORBIDDEN_ROOT_KEYS.has(root) || root.startsWith('_')) {
+    return err(new BadRequestError(`Config field "${root}" cannot be patched.`))
+  }
+  return ok(undefined)
+}
+
+function descend(
+  current: unknown,
+  segment: ConfigPathSegment,
+  path: ConfigPathSegment[]
+): Result<unknown, BadRequestError> {
+  const label = JSON.stringify(path)
+  if (Array.isArray(current)) {
+    if (typeof segment !== 'number') {
+      return err(new BadRequestError(`Expected an array index at ${label}.`))
+    }
+    if (segment >= current.length) {
+      return err(new BadRequestError(`Array index ${segment} is out of bounds at ${label}.`))
+    }
+    return ok(current[segment])
+  }
+  if (!current || typeof current !== 'object') {
+    return err(new BadRequestError(`Patch parent does not exist at ${label}.`))
+  }
+  if (typeof segment !== 'string') {
+    return err(new BadRequestError(`Expected an object field at ${label}.`))
+  }
+  if (!own(current, segment)) {
+    return err(new BadRequestError(`Patch parent does not exist at ${label}.`))
+  }
+  return ok((current as Record<string, unknown>)[segment])
+}
+
+/**
+ * Apply config patches to a clone. Parents must exist; `set` may create its
+ * final object key, while arrays are replacement-only and never sparse.
+ */
+export function applyConfigPatches(
+  config: Record<string, unknown>,
+  patches: ConfigPatch[]
+): Result<Record<string, unknown>, BadRequestError> {
+  if (patches.length === 0) {
+    return err(new BadRequestError('At least one config patch is required.'))
+  }
+
+  const next = structuredClone(config)
+  for (const patch of patches) {
+    if (
+      !patch ||
+      typeof patch !== 'object' ||
+      (patch.op !== 'set' && patch.op !== 'unset') ||
+      !Array.isArray(patch.path) ||
+      (patch.op === 'set' && (!Object.hasOwn(patch, 'value') || patch.value === undefined))
+    ) {
+      return err(new BadRequestError('Each config patch must be a valid set or unset operation.'))
+    }
+    const valid = validatePath(patch.path)
+    if (valid.isErr()) return err(valid.error)
+
+    let parent: unknown = next
+    for (let index = 0; index < patch.path.length - 1; index += 1) {
+      const resolved = descend(parent, patch.path[index]!, patch.path.slice(0, index + 1))
+      if (resolved.isErr()) return err(resolved.error)
+      parent = resolved.value
+    }
+
+    const leaf = patch.path.at(-1)!
+    const label = JSON.stringify(patch.path)
+    if (Array.isArray(parent)) {
+      if (typeof leaf !== 'number') {
+        return err(new BadRequestError(`Expected an array index at ${label}.`))
+      }
+      if (leaf >= parent.length) {
+        return err(new BadRequestError(`Array index ${leaf} is out of bounds at ${label}.`))
+      }
+      if (patch.op === 'unset') {
+        return err(
+          new BadRequestError(
+            `Array entries cannot be unset at ${label}; replace the containing array instead.`
+          )
+        )
+      }
+      parent[leaf] = structuredClone(patch.value)
+      continue
+    }
+
+    if (!parent || typeof parent !== 'object') {
+      return err(new BadRequestError(`Patch parent does not exist at ${label}.`))
+    }
+    if (typeof leaf !== 'string') {
+      return err(new BadRequestError(`Expected an object field at ${label}.`))
+    }
+    const record = parent as Record<string, unknown>
+    if (patch.op === 'unset') {
+      if (!own(record, leaf)) {
+        return err(new BadRequestError(`Cannot unset missing config field at ${label}.`))
+      }
+      delete record[leaf]
+    } else {
+      record[leaf] = structuredClone(patch.value)
+    }
+  }
+  return ok(next)
+}

--- a/packages/lib/src/workflows/graph-edit/read.ts
+++ b/packages/lib/src/workflows/graph-edit/read.ts
@@ -116,6 +116,13 @@ const NON_CONFIG_KEYS = new Set([
   'outputVariables',
 ])
 
+/** Hash durable node data only; `_` keys are regenerated and stripped on save. */
+export function hashNodeConfig(data: Record<string, unknown>): string {
+  return hashWorkflowGraph(
+    Object.fromEntries(Object.entries(data).filter(([key]) => !key.startsWith('_')))
+  )
+}
+
 /** One node's summary: friendly ref + friendly-rendered config. */
 export function buildNodeSummary(
   graph: DraftGraph,
@@ -133,6 +140,7 @@ export function buildNodeSummary(
     id: node.id,
     type: nodeType(node),
     title: typeof node.data?.title === 'string' ? node.data.title : '',
+    configHash: hashNodeConfig((node.data ?? {}) as Record<string, unknown>),
     ...(container ? { inside: formatNodeRef(graph.nodes, container) } : {}),
     position: node.position ?? { x: 0, y: 0 },
     config: renderPersistedRefs(config, { nodes: graph.nodes, resourceAliases: aliases }),

--- a/packages/lib/src/workflows/graph-edit/types.ts
+++ b/packages/lib/src/workflows/graph-edit/types.ts
@@ -112,6 +112,8 @@ export interface NodeSummary {
   id: string
   type: string
   title: string
+  /** Opaque token guarding deep patches against a stale `get_node` snapshot. */
+  configHash: string
   /** Friendly ref of the loop container this node lives inside, if any. */
   inside?: string
   position: Point


### PR DESCRIPTION
## Summary

- add atomic deep set/unset patches to update_node while retaining legacy top-level config merges
- return an opaque configHash and reject patches based on stale node snapshots
- preserve nested siblings and run complete friendly reference, resource, and prompt normalization
- reject unsafe prototype, identity, derived, sparse-array, and array-unset paths

## Verification

- pnpm --filter @auxx/lib test --run src/workflows/graph-edit/__tests__ src/ai/kopilot/capabilities/workflow-builder/tools/__tests__ (160 tests passed)
- Biome check passed on all touched files
- git diff --check passed
- scoped lib typecheck reported only existing unrelated script and Vitest/Vite configuration errors