### PR TITLE
feat(kopilot): improve workflow builder discovery

### DIFF
--- a/apps/web/src/components/kopilot/ui/blocks/__tests__/summarize-tool-result.test.ts
+++ b/apps/web/src/components/kopilot/ui/blocks/__tests__/summarize-tool-result.test.ts
@@ -1,0 +1,44 @@
+// apps/web/src/components/kopilot/ui/blocks/__tests__/summarize-tool-result.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { summarizeToolResult } from '../summarize-tool-result'
+
+describe('summarizeToolResult workflow digests', () => {
+  it('summarizes discovery counts', () => {
+    expect(
+      summarizeToolResult('list_node_types', null, {
+        label: 'Node types listed',
+        resultCount: 1,
+      }).summary
+    ).toBe('1 node type listed')
+    expect(
+      summarizeToolResult('find_workflow_templates', null, {
+        label: 'Workflow templates found',
+        resultCount: 3,
+      }).summary
+    ).toBe('3 templates found')
+  })
+
+  it('summarizes workflow reads and validation findings', () => {
+    expect(
+      summarizeToolResult('get_workflow', null, {
+        label: 'Workflow loaded',
+        nodeCount: 4,
+      }).summary
+    ).toBe('4 nodes')
+    expect(
+      summarizeToolResult('validate_workflow', null, {
+        label: 'Workflow validated',
+        errorCount: 1,
+        warningCount: 2,
+      }).summary
+    ).toBe('1 error · 2 warnings')
+    expect(
+      summarizeToolResult('validate_workflow', null, {
+        label: 'Workflow validated',
+        errorCount: 0,
+        warningCount: 0,
+      }).summary
+    ).toBe('No issues')
+  })
+})

--- a/apps/web/src/components/kopilot/ui/blocks/summarize-tool-result.ts
+++ b/apps/web/src/components/kopilot/ui/blocks/summarize-tool-result.ts
@@ -109,6 +109,31 @@ function summaryFromDigest(toolName: string, digest: unknown): ToolSummary | nul
       const title = typeof d.title === 'string' ? d.title : ''
       return { summary: title ? `Task created: "${truncate(title, 50)}"` : 'Task created' }
     }
+    case 'list_node_types': {
+      const count = typeof d.resultCount === 'number' ? d.resultCount : 0
+      return { summary: `${count} node type${count === 1 ? '' : 's'} listed` }
+    }
+    case 'find_workflow_templates': {
+      const count = typeof d.resultCount === 'number' ? d.resultCount : 0
+      return { summary: `${count} template${count === 1 ? '' : 's'} found` }
+    }
+    case 'get_workflow': {
+      const count = typeof d.nodeCount === 'number' ? d.nodeCount : 0
+      return { summary: `${count} node${count === 1 ? '' : 's'}` }
+    }
+    case 'validate_workflow': {
+      const errors = typeof d.errorCount === 'number' ? d.errorCount : 0
+      const warnings = typeof d.warningCount === 'number' ? d.warningCount : 0
+      if (errors === 0 && warnings === 0) return { summary: 'No issues' }
+      return {
+        summary: [
+          errors > 0 ? `${errors} error${errors === 1 ? '' : 's'}` : null,
+          warnings > 0 ? `${warnings} warning${warnings === 1 ? '' : 's'}` : null,
+        ]
+          .filter(Boolean)
+          .join(' · '),
+      }
+    }
   }
   return null
 }

--- a/apps/web/src/components/kopilot/ui/messages/tool-status-pill-config.ts
+++ b/apps/web/src/components/kopilot/ui/messages/tool-status-pill-config.ts
@@ -213,6 +213,47 @@ const configs: Record<string, ToolPillConfig> = {
       error: () => ({ label: 'Failed to update records' }),
     },
   },
+  list_node_types: {
+    icon: 'ListTree',
+    labels: {
+      running: (args) => ({
+        label: 'Listing node types',
+        secondary: args.query ? `"${args.query}"` : undefined,
+      }),
+      completed: (_args, summary) => ({ label: 'Node types listed', secondary: summary }),
+      error: () => ({ label: 'Failed to list node types' }),
+    },
+  },
+  find_workflow_templates: {
+    icon: 'Search',
+    labels: {
+      running: (args) => ({
+        label: 'Searching workflow templates',
+        secondary: args.query ? `"${args.query}"` : undefined,
+      }),
+      completed: (_args, summary) => ({
+        label: 'Workflow templates found',
+        secondary: summary,
+      }),
+      error: () => ({ label: 'Failed to find workflow templates' }),
+    },
+  },
+  get_workflow: {
+    icon: 'Workflow',
+    labels: {
+      running: () => ({ label: 'Reading workflow' }),
+      completed: (_args, summary) => ({ label: 'Workflow loaded', secondary: summary }),
+      error: () => ({ label: 'Failed to read workflow' }),
+    },
+  },
+  validate_workflow: {
+    icon: 'BadgeCheck',
+    labels: {
+      running: () => ({ label: 'Validating workflow' }),
+      completed: (_args, summary) => ({ label: 'Workflow validated', secondary: summary }),
+      error: () => ({ label: 'Failed to validate workflow' }),
+    },
+  },
   run_eval_suite: {
     icon: 'FlaskConical',
     labels: {

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
@@ -424,6 +424,60 @@ describe('discovery tools', () => {
     expect(types.every((t) => typeof t.authorable === 'boolean')).toBe(true)
   })
 
+  it('list_node_types searches id, display name, description, and category', async () => {
+    const byId = await run(tool('list_node_types'), { query: 'if-else' })
+    expect(byId.success).toBe(true)
+    expect((byId.output as { types: Array<{ type: string }> }).types.map((t) => t.type)).toEqual([
+      'if-else',
+    ])
+
+    const byDescription = await run(tool('list_node_types'), { query: 'HTTP REQUESTS' })
+    expect(byDescription.success).toBe(true)
+    expect(
+      (byDescription.output as { types: Array<{ type: string }> }).types.map((t) => t.type)
+    ).toContain('http')
+
+    const byCategory = await run(tool('list_node_types'), {
+      category: 'utility',
+      query: 'date',
+    })
+    expect(byCategory.success).toBe(true)
+    expect((byCategory.output as { types: Array<{ type: string }> }).types).toHaveLength(1)
+  })
+
+  it('list_node_types reports an actionable error when filters match nothing', async () => {
+    const result = await run(tool('list_node_types'), { query: 'quantum-blockchain' })
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('quantum-blockchain')
+    expect(result.error).toContain('without filters')
+  })
+
+  it('read and discovery tools build compact count digests', () => {
+    expect(tool('list_node_types').buildDigest?.({ types: [{}, {}] })).toEqual({
+      label: 'Node types listed',
+      resultCount: 2,
+    })
+    expect(tool('find_workflow_templates').buildDigest?.({ templates: [{}] })).toEqual({
+      label: 'Workflow templates found',
+      resultCount: 1,
+    })
+    expect(tool('get_workflow').buildDigest?.({ nodeCount: 4, nodes: [] })).toEqual({
+      label: 'Workflow loaded',
+      nodeCount: 4,
+    })
+    expect(
+      tool('validate_workflow').buildDigest?.({
+        publishErrors: ['Missing trigger'],
+        publishWarnings: ['Unused node'],
+        issues: [
+          { severity: 'error', message: 'Missing trigger' },
+          { severity: 'error', message: 'Broken reference' },
+          { severity: 'warning', message: 'Unused node' },
+        ],
+      })
+    ).toEqual({ label: 'Workflow validated', errorCount: 2, warningCount: 1 })
+  })
+
   it('describe_node_type returns the agent-facing schema and connection rules', async () => {
     const result = await run(tool('describe_node_type'), { type: 'wait' })
     expect(result.success).toBe(true)

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/find-workflow-templates.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/find-workflow-templates.ts
@@ -32,6 +32,13 @@ export function createFindWorkflowTemplatesTool(getDeps: GetToolDeps): AgentTool
       },
       additionalProperties: false,
     },
+    buildDigest: (output) => {
+      const out = (output ?? {}) as { templates?: unknown[] }
+      return {
+        label: 'Workflow templates found',
+        resultCount: Array.isArray(out.templates) ? out.templates.length : 0,
+      }
+    },
     execute: async (args) => {
       const query = typeof args.query === 'string' ? args.query.trim() : ''
       const search = query || undefined

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/get-workflow.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/get-workflow.ts
@@ -36,6 +36,18 @@ export function createGetWorkflowTool(getDeps: GetToolDeps): AgentToolDefinition
     description:
       'Read the open workflow draft: trigger, every node (type, title, one-line config summary, resolved output refs), edges, and current issues. Use get_node for a node’s full config.',
     parameters: { type: 'object', properties: {}, additionalProperties: false },
+    buildDigest: (output) => {
+      const out = (output ?? {}) as { nodeCount?: unknown; nodes?: unknown[] }
+      return {
+        label: 'Workflow loaded',
+        nodeCount:
+          typeof out.nodeCount === 'number'
+            ? out.nodeCount
+            : Array.isArray(out.nodes)
+              ? out.nodes.length
+              : 0,
+      }
+    },
     execute: async (_args, agentDeps) => {
       const auth = await resolveWorkflowAuthoring(getDeps, agentDeps, 'view')
       if (!auth.ok) return { success: false, output: null, error: auth.error }

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/list-node-types.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/list-node-types.ts
@@ -21,7 +21,7 @@ export function createListNodeTypesTool(getDeps: GetToolDeps): AgentToolDefiniti
     surfaces: ['builder'],
     idempotent: true,
     description:
-      'List the workflow node types: id, display name, one-line description, category, whether it is a trigger, and whether you may author it. Call describe_node_type before configuring one.',
+      'List or search workflow node types: id, display name, one-line description, category, whether it is a trigger, and whether you may author it. Call describe_node_type before configuring one.',
     parameters: {
       type: 'object',
       properties: {
@@ -30,13 +30,34 @@ export function createListNodeTypesTool(getDeps: GetToolDeps): AgentToolDefiniti
           description:
             "Optional category filter (e.g. 'trigger', 'action', 'condition', 'flow_control', 'ai').",
         },
+        query: {
+          type: 'string',
+          description:
+            'Optional free-text search over type id, display name, description, and category.',
+        },
       },
       additionalProperties: false,
     },
+    buildDigest: (output) => {
+      const out = (output ?? {}) as { types?: unknown[] }
+      return {
+        label: 'Node types listed',
+        resultCount: Array.isArray(out.types) ? out.types.length : 0,
+      }
+    },
     execute: async (args) => {
       const category = typeof args.category === 'string' ? args.category : undefined
+      const query = typeof args.query === 'string' ? args.query.trim() : ''
+      const normalizedQuery = query.toLowerCase()
       const types = listManifests()
         .filter((m) => !category || m.category === category)
+        .filter(
+          (m) =>
+            !normalizedQuery ||
+            [m.id, m.displayName, m.description, m.category].some((value) =>
+              value.toLowerCase().includes(normalizedQuery)
+            )
+        )
         .map((m) => ({
           type: m.id,
           displayName: m.displayName,
@@ -47,10 +68,14 @@ export function createListNodeTypesTool(getDeps: GetToolDeps): AgentToolDefiniti
         }))
         .sort((a, b) => a.type.localeCompare(b.type))
       if (types.length === 0) {
+        const filter = [
+          ...(query ? [`query "${query}"`] : []),
+          ...(category ? [`category "${category}"`] : []),
+        ].join(' and ')
         return {
           success: false,
           output: null,
-          error: `No node types in category "${category}". Call list_node_types without a filter to see all categories.`,
+          error: `No node types match ${filter || 'the supplied filters'}. Call list_node_types without filters to see the full catalog.`,
         }
       }
       return { success: true, output: { types } }

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/validate-workflow.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/validate-workflow.ts
@@ -5,6 +5,27 @@ import type { GetToolDeps } from '../../types'
 import { workflowToolPermission } from './graph-tool-helpers'
 import { resolveWorkflowAuthoring } from './workflow-authoring-guard'
 
+function countFindings(output: unknown, severity: 'error' | 'warning'): number {
+  const report = (output ?? {}) as {
+    publishErrors?: unknown[]
+    publishWarnings?: unknown[]
+    issues?: Array<{ severity?: unknown; message?: unknown }>
+  }
+  const messages = new Set<string>()
+  const publish = severity === 'error' ? report.publishErrors : report.publishWarnings
+  if (Array.isArray(publish)) {
+    for (const message of publish) messages.add(String(message))
+  }
+  if (Array.isArray(report.issues)) {
+    for (const issue of report.issues) {
+      if (issue.severity === severity && typeof issue.message === 'string') {
+        messages.add(issue.message)
+      }
+    }
+  }
+  return messages.size
+}
+
 /**
  * The publish gate without publishing: the three validation tiers plus the
  * REAL `validateDraftWorkflowForPublish` verdict. Publishing itself stays the
@@ -20,6 +41,11 @@ export function createValidateWorkflowTool(getDeps: GetToolDeps): AgentToolDefin
     description:
       'Check whether the open workflow draft would pass the publish gate — without publishing (publishing stays the user’s action). Returns publishability, publish errors/warnings, and the structural/config/reference issues.',
     parameters: { type: 'object', properties: {}, additionalProperties: false },
+    buildDigest: (output) => ({
+      label: 'Workflow validated',
+      errorCount: countFindings(output, 'error'),
+      warningCount: countFindings(output, 'warning'),
+    }),
     execute: async (_args, agentDeps) => {
       const auth = await resolveWorkflowAuthoring(getDeps, agentDeps, 'view')
       if (!auth.ok) return { success: false, output: null, error: auth.error }

--- a/packages/lib/src/ai/kopilot/prompts/sections/__tests__/workflow-builder.test.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/__tests__/workflow-builder.test.ts
@@ -1,0 +1,15 @@
+// packages/lib/src/ai/kopilot/prompts/sections/__tests__/workflow-builder.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { buildWorkflowBuilderPromptSection } from '../workflow-builder'
+
+describe('buildWorkflowBuilderPromptSection', () => {
+  it('requires the structured workflow completion shape and partial progress', () => {
+    const prompt = buildWorkflowBuilderPromptSection()
+
+    expect(prompt).toContain('`Done`')
+    expect(prompt).toContain('`Still needs your input`')
+    expect(prompt).toContain('`Remaining validation`')
+    expect(prompt).toContain('Apply every safe, unambiguous part before asking')
+  })
+})

--- a/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
@@ -43,6 +43,9 @@ export function buildWorkflowBuilderPromptSection(): string {
     // Verification + simulation.
     'Verifying: `validate_workflow` runs the real publish gate without publishing — use it after a batch of edits. `run_node` executes ONE node as a SIMULATED debug run (side-effecting nodes do not send email, call webhooks, etc.); you supply its input values — upstream nodes are not executed. Say clearly in your reply that the run was simulated.',
 
+    // Completion shape.
+    'After workflow work, close with three compact sections: `Done` (what changed), `Still needs your input` (a numbered list of unresolved choices, or “Nothing”), and `Remaining validation` (the exact errors/warnings from validate_workflow, or “None”). Apply every safe, unambiguous part before asking about the genuinely unresolved parts.',
+
     // Worked examples.
     [
       'Worked examples:',


### PR DESCRIPTION
## Summary
- add free-text node type discovery across ids, names, descriptions, and categories
- add compact read-tool digests and workflow-specific activity chip labels
- require structured workflow completion guidance with partial progress before questions

## Verification
- 25 focused Vitest tests passed
- explicit Biome check passed on all 10 touched files
- git diff --check passed
- scoped lib/web typechecks report only pre-existing errors outside the touched files