### PR TITLE
fix(connectors): drop format-rejected values instead of failing the record

### DIFF
--- a/packages/lib/src/data-connectors/sinks/entity-sink-row-level.test.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink-row-level.test.ts
@@ -7,6 +7,12 @@
 // array-shaped match candidate FAILS the record instead of creating a silent
 // duplicate, and in-slice two-source dedupe (first wins field writes, the
 // second still binds).
+//
+// The trailing PHONE block covers the E.164 interaction (the Shopify `phone`
+// binding rides this path): a differently-FORMATTED source number must compare
+// equal to the stored E.164 row rather than appending a duplicate every sync,
+// and a number the write path refuses must cost the value, never the record —
+// on the scalar path as well as the multi one.
 
 import { toResourceFieldId } from '@auxx/types/field'
 import { stableHash } from '@auxx/utils/hash'
@@ -476,5 +482,154 @@ describe('entitySink row-level multi-field writes (B1)', () => {
     })
     expect(ctx.counters.skipped).toBe(1)
     expect(ctx.counters.failed).toBe(0)
+  })
+})
+
+// ── PHONE / E.164 ────────────────────────────────────────────────────────────
+// The Shopify customer stream binds `phone` with no `mergeStrategy`, so it
+// defaults to `overwrite` and rides exactly the path above once contact `phone`
+// flips to `options.multi`. What differs from EMAIL is normalization: the write
+// path rewrites the value (E.164) instead of just lowercasing it, and it
+// REJECTS what it cannot parse.
+
+const PHONE_KEY = 'phone'
+const PHONE_UUID = 'field-phone-uuid'
+const PHONE_REF = toResourceFieldId(DEF_ID, PHONE_KEY)
+
+function phoneField(over: Record<string, unknown> = {}) {
+  return {
+    id: PHONE_UUID,
+    type: 'PHONE_INTL',
+    modelType: 'contact',
+    systemAttribute: PHONE_KEY,
+    options: { multi: true },
+    isUnique: false,
+    ...over,
+  }
+}
+
+function phoneMapping(): DecodedMapping {
+  return mapping({
+    fieldMappings: [
+      {
+        id: 'fm-phone',
+        targetFieldRef: PHONE_REF,
+        expression: '{phone}',
+        sourceFields: { phone: 'phone' },
+      },
+    ],
+  } as never)
+}
+
+function phoneRecord(phone: unknown): ProjectedRecord {
+  return {
+    externalId: 'shopify-cust-1',
+    displayName: 'Jane',
+    fields: { [PHONE_REF]: phone },
+    identityCandidates: [],
+    pendingRelations: [],
+  } as unknown as ProjectedRecord
+}
+
+/** Point the field lookups at the phone field; `multi: false` exercises the scalar path. */
+function usePhoneField(multi: boolean) {
+  resolveConnectorFieldRef.mockImplementation(async (ref: string) =>
+    ref === PHONE_REF ? PHONE_REF : null
+  )
+  buildWriteKeyToFieldId.mockResolvedValue(
+    new Map([
+      [PHONE_KEY, PHONE_UUID],
+      [PHONE_UUID, PHONE_UUID],
+    ])
+  )
+  getCachedFieldMap.mockResolvedValue(
+    new Map([[PHONE_UUID, phoneField({ options: multi ? { multi: true } : {} })]])
+  )
+}
+
+describe('entitySink — PHONE_INTL values (E.164)', () => {
+  beforeEach(async () => {
+    // The shared stub lowercases; PHONE_INTL is normalized (and validated) by
+    // `formatPhoneNumber`, which is what `validateSingleValue` calls for this
+    // type. Model that faithfully, throwing like the real validator does.
+    const { formatPhoneNumber } = await import('@auxx/utils')
+    const helpers = await import('../../field-values/field-value-helpers')
+    vi.mocked(helpers.validateAndConvertValue).mockImplementation(
+      async (_ctx: unknown, value: unknown) => {
+        const normalized = formatPhoneNumber(String(value).trim())
+        if (!normalized) throw new Error('Invalid phone number')
+        return { type: 'text', value: normalized } as never
+      }
+    )
+  })
+
+  it('a differently-formatted source number matches the stored E.164 row — no duplicate append', async () => {
+    // The every-sync-duplicates regression: Shopify sends `(415) 555-1234`,
+    // storage holds `+14155551234`. Comparing raw source against stored would
+    // see a diff forever and append an alias on every run.
+    usePhoneField(true)
+    findItem.mockResolvedValue(boundItem())
+    const { db, updateCalls } = makeDb([row('r1', 'a0', '+14155551234', null)])
+    const ctx = makeCtx({ db: db as never })
+
+    await entitySink.upsertRecord(ctx, phoneMapping(), phoneRecord('(415) 555-1234'))
+
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(update.mock.calls[0]?.[1]).toEqual({}) // no whole-field set
+    expect(updateCalls).toHaveLength(0) // no row update, no append, no re-stamp
+    expect(ctx.counters.failed).toBe(0)
+  })
+
+  it('normalizes a changed source number into the connector row (E.164, not the raw string)', async () => {
+    usePhoneField(true)
+    findItem.mockResolvedValue(boundItem())
+    const { db, updateCalls } = makeDb([row('r1', 'a0', '+14155551234', 'dc1')])
+    const ctx = makeCtx({ db: db as never })
+
+    await entitySink.upsertRecord(ctx, phoneMapping(), phoneRecord('212-555-0100'))
+
+    expect(updateCalls).toHaveLength(1)
+    expect(updateCalls[0]).toMatchObject({ valueText: '+12125550100' })
+  })
+
+  it('an unparseable number on a MULTI field drops the value, never the record', async () => {
+    usePhoneField(true)
+    findItem.mockResolvedValue(boundItem())
+    const { db, updateCalls } = makeDb([row('r1', 'a0', '+14155551234', 'dc1')])
+    const ctx = makeCtx({ db: db as never })
+
+    await entitySink.upsertRecord(ctx, phoneMapping(), phoneRecord('not a phone'))
+
+    expect(updateCalls).toHaveLength(0)
+    expect(ctx.counters.failed).toBe(0)
+    expect(upsertItem).toHaveBeenCalledTimes(1) // the record still syncs + binds
+  })
+
+  it('an unparseable number on a SCALAR field drops the value, never the record', async () => {
+    // Without the write-set pre-flight this throws inside `handler.update`,
+    // where the catch only special-cases UniqueValueConflictError — the whole
+    // customer would fail to sync over one bad phone number.
+    usePhoneField(false)
+    findItem.mockResolvedValue(boundItem())
+    const { db } = makeDb([])
+    const ctx = makeCtx({ db: db as never })
+
+    await entitySink.upsertRecord(ctx, phoneMapping(), phoneRecord('not a phone'))
+
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(update.mock.calls[0]?.[1]).toEqual({}) // phone dropped from the write set
+    expect(ctx.counters.failed).toBe(0)
+    expect(ctx.counters.errorSample).toHaveLength(0)
+  })
+
+  it('a valid number still reaches the write set on a SCALAR field', async () => {
+    usePhoneField(false)
+    findItem.mockResolvedValue(boundItem())
+    const { db } = makeDb([])
+    const ctx = makeCtx({ db: db as never })
+
+    await entitySink.upsertRecord(ctx, phoneMapping(), phoneRecord('+14155551234'))
+
+    expect(update.mock.calls[0]?.[1]).toEqual({ [PHONE_KEY]: '+14155551234' })
   })
 })

--- a/packages/lib/src/data-connectors/sinks/entity-sink.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink.ts
@@ -17,6 +17,7 @@ import { and, eq, inArray, isNull, ne, or } from 'drizzle-orm'
 import { resolveConnectorFieldRef } from '../../agents/bindings/resolve'
 import { getCachedFieldMap } from '../../cache'
 import { UniqueValueConflictError } from '../../errors'
+import { fieldValueSchemas } from '../../field-values/field-value-validator'
 import { upsertRecordIdentity } from '../../identity'
 import type { ManifestFieldChange } from '../../record-rules/sync-manifest-types'
 import { toRecordId } from '../../resources/resource-id'
@@ -66,6 +67,43 @@ function rawOf(v: TypedFieldValue | TypedFieldValue[] | undefined): unknown {
 
 function isBlank(value: unknown): boolean {
   return value === undefined || value === null || value === ''
+}
+
+/**
+ * Format-validated scalar field types: the write path normalizes these through a
+ * zod schema that REJECTS unparseable input (`fieldValueSchemas`), and the
+ * rejection surfaces as a bare `Error` from `validateSingleValue` — no field
+ * identity, so the write-time catch cannot attribute it and fails the whole
+ * record.
+ */
+const FORMAT_VALIDATED_TYPES: Record<string, keyof typeof fieldValueSchemas> = {
+  EMAIL: 'email',
+  URL: 'url',
+  PHONE_INTL: 'phone',
+}
+
+/**
+ * Would this scalar value be REJECTED by the write path's format validation?
+ *
+ * Providers send free-form contact data — a Shopify customer's `phone` is not
+ * guaranteed to be a dialable number, and E.164 normalization refuses what it
+ * can't parse. Without this pre-flight the throw happens inside
+ * `handler.update`, where the catch can only special-case
+ * `UniqueValueConflictError`; everything else costs the ENTIRE record (no
+ * contact created or updated, just a `failed` counter). Dropping the one value
+ * instead mirrors what the row-level multi path already does per value, and
+ * keeps the sync green.
+ *
+ * Scoped to the three format-validated types on purpose: it is a pure zod parse
+ * (no ctx, no DB), unlike the relation/file validators.
+ */
+function rejectsFormat(fieldType: string | undefined, value: unknown): boolean {
+  // Arrays have their own guards on both paths (a connector cannot source one);
+  // never let `String([…])` decide a drop here.
+  if (!fieldType || isBlank(value) || Array.isArray(value)) return false
+  const schemaKey = FORMAT_VALIDATED_TYPES[fieldType]
+  if (!schemaKey) return false
+  return !fieldValueSchemas[schemaKey].safeParse(value).success
 }
 
 /**
@@ -340,6 +378,21 @@ async function buildWriteSet(
     const isMulti =
       !identityRefs.has(rawRef) &&
       (fieldRow?.options as { multi?: boolean } | null | undefined)?.multi === true
+
+    // Pre-flight the format-validated types (EMAIL/URL/PHONE_INTL): a value the
+    // write path would refuse costs the WHOLE record if it throws inside
+    // `handler.update`. Drop the one value and keep syncing — the multi path
+    // below reaches the same outcome per value (`row-level-writes.ts`), so the
+    // record's fate no longer depends on whether the field happens to be multi.
+    if (rejectsFormat(fieldRow?.type, value)) {
+      logger.warn('source value rejected by field format validation — value dropped', {
+        mappingId: mapping.row.id,
+        externalId: record.externalId,
+        field: rawRef,
+        fieldType: fieldRow?.type,
+      })
+      continue
+    }
 
     if (isMulti && strategy !== 'manual_review') {
       // Never write null/empty over a multi field: a source key present-but-null


### PR DESCRIPTION
Follow-up to #1629, and the Shopify-connector verification for the multi-phone flip.

## The live bug

Since E.164 normalization landed, the write path **rejects** phone numbers it can't parse. On the scalar path that throw happens inside `handler.update`, where the catch (`entity-sink.ts:947`) only special-cases `UniqueValueConflictError` — everything else increments `failed` and skips the record.

So one unparseable phone number on a Shopify customer meant **the whole contact never synced**, not just a missing phone. Providers send free-form contact data; Shopify's `phone` is not guaranteed to be dialable.

## The fix

Pre-flight EMAIL/URL/PHONE_INTL values against their write-path zod schema while building the write set, and drop the offending value with a log. The row-level multi path already does exactly this per value, so a record's fate no longer depends on whether the target field happens to be multi.

Scoped to those three types on purpose — it's a pure zod parse (no ctx, no DB), unlike the relation/file validators. Arrays bail out early; both paths already guard those separately.

## Why the field-level error couldn't just be caught

`validateSingleValue` throws a bare `new Error(message)` with no field identity (`field-value-helpers.ts:647`), so the write-time catch cannot attribute the failure to a key the way `dropConflictingKey` does for unique conflicts. Pre-flight is the only place the field is still known.

## Shopify connector verification

This was the open pre-flip question. Findings:

- **The connector needs no change.** The sink's row-level path is generic on `options.multi`, read from the CustomField row at runtime (`entity-sink.ts:342`, `:570`). Shopify's `{ sourceFieldKey: 'phone', targetKey: 'phone' }` binding carries no `mergeStrategy`, so it defaults to `overwrite` and will divert to the row-level own-row upsert the moment phone flips — the same path `primary_email` proves today.
- **Normalization was already handled.** `row-level-writes.ts` runs the source value through `validateAndConvertValue` *before* comparing it to stored rows, so `(415) 555-1234` normalizes to `+14155551234` and compares equal. Without that it would append a duplicate alias every single sync. Now pinned by a test.
- Dev shows zero phone-related connector errors across all runs (`errorSample` scan).

## Tests

Five new cases in the row-level sink slice: formatted-vs-stored E.164 equality (no duplicate append), changed number normalizes into the connector's own row, unparseable number drops the value on the multi path, same on the scalar path, valid number still reaches the write set.

Verified the scalar case actually fails without the guard. `packages/lib/src/data-connectors` 360 passed; `tsc --noEmit` clean under `src/`.
