### PR TITLE
fix(billing): hide custom-pricing plans on shopify-billed orgs

### DIFF
--- a/apps/web/src/components/subscriptions/horizontal-plan-card.tsx
+++ b/apps/web/src/components/subscriptions/horizontal-plan-card.tsx
@@ -196,11 +196,9 @@ export function HorizontalPlanCard({
       {/* Right Section: CTA */}
       <div className='flex items-center md:w-1/6 justify-end'>
         {cta.action === 'contact' ? (
-          <Button
-            className='w-full md:w-auto'
-            variant={btnVariant}
-            onClick={() => router.push('/contact-sales')}>
-            Contact Sales
+          // See plan-card.tsx — /contact-sales is not a route; it bounced to /app.
+          <Button className='w-full md:w-auto' variant={btnVariant} asChild>
+            <a href='mailto:sales@auxx.ai'>Contact Sales</a>
           </Button>
         ) : cta.action === 'current' ? (
           <Button className='w-full md:w-auto' disabled>

--- a/apps/web/src/components/subscriptions/plan-card.tsx
+++ b/apps/web/src/components/subscriptions/plan-card.tsx
@@ -232,11 +232,11 @@ export function PlanCard({
 
         <CardFooter className='flex flex-col gap-2 p-3 pt-0'>
           {cta.action === 'contact' ? (
-            <Button
-              variant={btnVariant}
-              className='w-full'
-              onClick={() => router.push('/contact-sales')}>
-              Contact Sales
+            // There is no /contact-sales route, and `contact-sales` isn't in the proxy's
+            // KNOWN_ROUTE_PREFIXES — pushing it bounced the merchant to /app. Mail sales
+            // instead, matching subscription-ended.tsx and the homepage.
+            <Button variant={btnVariant} className='w-full' asChild>
+              <a href='mailto:sales@auxx.ai'>Contact Sales</a>
             </Button>
           ) : cta.action === 'current' ? (
             <Button className='w-full' disabled>

--- a/apps/web/src/components/subscriptions/plan-comparison.tsx
+++ b/apps/web/src/components/subscriptions/plan-comparison.tsx
@@ -3,6 +3,7 @@
 
 import { PermissionKey } from '@auxx/lib/permissions/client'
 import { Skeleton } from '@auxx/ui/components/skeleton'
+import { cn } from '@auxx/ui/lib/utils'
 import { useEffect, useState } from 'react'
 import { useUser } from '~/hooks/use-user'
 import { useRequireCapability } from '~/providers/capabilities-provider'
@@ -57,9 +58,21 @@ export function PlanComparison({
 
   const [billingCycle, setBillingCycle] = useState<'MONTHLY' | 'ANNUAL'>('MONTHLY')
 
+  const dehydratedSubscription = useDehydratedSubscription()
+
   // Shopify is monthly-only (per-seat is billed as usage, which can't ride an annual cycle).
   // Default a missing capability to `true` (Stripe/unknown → annual offered). See plan 15.
-  const annualBillingCycle = useDehydratedSubscription()?.capabilities.annualBillingCycle ?? true
+  const annualBillingCycle = dehydratedSubscription?.capabilities.annualBillingCycle ?? true
+
+  // Shopify App Store rules 1.2.1 / 1.2.3 forbid advertising a plan that can't be billed
+  // through Shopify or that tells the merchant to contact support, so the Enterprise
+  // ("Custom" / "Contact Sales") card must not render on a Shopify-billed org. Fall back to
+  // the *provider* rather than to `true` — a cache blob written before `customPricingPlans`
+  // existed would otherwise fail open and keep showing the card. No subscription row at all
+  // → `undefined !== 'shopify'` → true → Stripe default. See plan v3/04.
+  const customPricingPlans =
+    dehydratedSubscription?.capabilities.customPricingPlans ??
+    dehydratedSubscription?.billingProvider !== 'shopify'
 
   const [initialCycleSet, setInitialCycleSet] = useState(false) // Flag to set default only once
 
@@ -96,18 +109,28 @@ export function PlanComparison({
     }
   }, [subscription, subscriptionLoading, initialCycleSet, annualBillingCycle]) // Dependencies
 
-  // Filter out internal plans (e.g. Demo), then separate free and paid.
+  // Filter out internal plans (e.g. Demo) and — on providers that can't bill them —
+  // custom-priced plans, then separate free and paid. A custom-priced plan is still shown
+  // when it IS the current plan, so an org parked on Enterprise by an admin billing
+  // override doesn't lose its own card.
   // `Plan.features` is a jsonb column, so it arrives as `unknown` — narrow it
   // here rather than trusting the shape all the way down into the cards.
   const availablePlans: Plan[] =
     plans
       ?.filter((plan) => plan.hierarchyLevel >= 0)
+      .filter(
+        (plan) => customPricingPlans || !plan.isCustomPricing || plan.id === subscription?.planId
+      )
       .map((plan) => ({
         ...plan,
         features: Array.isArray(plan.features) ? (plan.features as string[]) : [],
       })) ?? []
   const paidPlans = availablePlans.filter((plan) => !plan.isFree)
   const freePlan = availablePlans.find((plan) => plan.isFree)
+
+  // Track the rendered card count — with Enterprise filtered out, two cards in a
+  // three-column track sit left-stranded. Static class strings so Tailwind can see them.
+  const paidGridCols = paidPlans.length >= 3 ? 'md:grid-cols-2 lg:grid-cols-3' : 'md:grid-cols-2'
 
   return (
     <div className={inDialog ? '' : 'p-6'}>
@@ -140,7 +163,7 @@ export function PlanComparison({
       ) : (
         <>
           {/* Paid Plans Grid */}
-          <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 pt-6'>
+          <div className={cn('grid grid-cols-1 gap-4 pt-6', paidGridCols)}>
             {paidPlans.map((plan) => (
               <PlanCard
                 key={plan.id}

--- a/packages/billing/src/providers/shopify/provider.ts
+++ b/packages/billing/src/providers/shopify/provider.ts
@@ -40,6 +40,7 @@ export class ShopifyBillingProvider implements BillingProvider {
     prorationPreview: false, // Shopify prorates but does not preview
     arbitraryBillingCycles: false, // Monthly only — per-seat is billed as usage, which can't ride an annual cycle (plan 14 §6 Q3)
     annualBillingCycle: false, // Usage charges must be tied to a monthly cycle; annual is Stripe-only
+    customPricingPlans: false, // App Store 1.2.1/1.2.3 — no off-platform or "Contact Sales" plans (plan v3/04)
     trialWithoutPaymentMethod: true, // Per-plan trial in Partner Dashboard
     immediateCancellation: false, // Cancellations land at end of cycle
     scheduledDowngrade: true, // Downgrade-to-free is a scheduled cancel

--- a/packages/billing/src/providers/stripe.ts
+++ b/packages/billing/src/providers/stripe.ts
@@ -29,6 +29,7 @@ export class StripeBillingProvider implements BillingProvider {
     prorationPreview: true,
     arbitraryBillingCycles: true,
     annualBillingCycle: true,
+    customPricingPlans: true,
     trialWithoutPaymentMethod: true,
     immediateCancellation: true,
     scheduledDowngrade: true,

--- a/packages/billing/src/providers/types.ts
+++ b/packages/billing/src/providers/types.ts
@@ -13,6 +13,13 @@ export interface BillingCapabilities {
   arbitraryBillingCycles: boolean
   /** Whether annual billing is offered. Shopify is monthly-only (usage charges can't ride an annual cycle). */
   annualBillingCycle: boolean
+  /**
+   * Whether custom-priced ("Contact Sales") plans may be advertised to the merchant.
+   * Shopify App Store rules 1.2.1 / 1.2.3 forbid offering a plan that can't be billed
+   * through Shopify or that requires contacting support. See
+   * plans/billing/v3/04-hide-custom-pricing-plans-on-shopify.md.
+   */
+  customPricingPlans: boolean
   trialWithoutPaymentMethod: boolean
   immediateCancellation: boolean
   scheduledDowngrade: boolean

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -715,7 +715,14 @@ export const ORG_CACHE_KEY_CONFIG: Record<
 
   // Business data (24h TTL, all invalidated via cache events)
   features: { prefix: 'org:features', ttlSeconds: THIRTY_DAYS },
-  subscription: { prefix: 'org:subscription', ttlSeconds: ONE_DAY },
+  // v2: + `capabilities.customPricingPlans`, which `PlanComparison` reads to hide the
+  // Enterprise ("Contact Sales") card on Shopify-billed orgs — App Store rules 1.2.1 /
+  // 1.2.3. `capabilities` is baked into the blob at compute time
+  // (`subscription-provider.ts`), so a v1 blob has no such key and the read would
+  // resolve `undefined` → the Stripe default → **the card stays visible for up to the
+  // ONE_DAY TTL**, i.e. straight through the review window. Moving the keyspace makes
+  // that impossible. See plans/billing/v3/04-hide-custom-pricing-plans-on-shopify.md.
+  subscription: { prefix: 'org:subscription:v2', ttlSeconds: ONE_DAY },
   // v2: + disabledAt/disabledReason, which `protectedProcedure` now reads to lock
   // members out of an admin-suspended org. The shape is still parseable by both
   // sides, which is exactly why the bump is load-bearing: a v1 blob has no


### PR DESCRIPTION
Shopify App Review (round 2) flagged the Enterprise **"Custom" / "Contact Sales"** card in Settings → Billing → *Choose Your Plan* on a Shopify-billed org.

## Why it's a real violation, not cosmetics

| Rule | Verbatim | How the card breaks it |
| --- | --- | --- |
| **1.2.1** | "Apps that use off-platform billing cannot be distributed through the Shopify App store. Your app must use Shopify App Pricing or the Shopify Billing API for any app charges." | Enterprise has `shopifyPlanHandle: null` — no Shopify price, so it can only ever be paid off-platform. Advertising it in-app offers an off-platform billing route. |
| **1.2.3** | "Your app must allow merchants to upgrade and downgrade their pricing plan **without having to contact your support team**…" | "Contact Sales" is literally the forbidden affordance, rendered next to the self-serve plans. |

Same class of finding as #718 (*hide cancel-subscription dialog for Shopify-billed orgs*).

The **purchase path was already safe** — `ShopifyBillingProvider.createSubscription` throws `PLAN_NOT_AVAILABLE` for any plan with a null `shopifyPlanHandle`. Only the *advertisement* was wrong, so this is pure UI gating with no billing-logic risk.

## The change

New `customPricingPlans` capability on `BillingCapabilities` — `true` on Stripe, `false` on Shopify. `PlanComparison` filters `isCustomPricing` plans out when it's false, sitting next to the existing `hierarchyLevel >= 0` Demo filter. All live mounts (settings, expired-org reactivation) funnel through that one component.

**Current-plan escape hatch:** a custom-priced plan is still shown when it IS the current plan, so an org parked on Enterprise by an admin billing override (`adminOverrideAt`) doesn't lose its own card.

## The part that would have shipped a second rejection

`capabilities` is **baked into the Redis blob at compute time** (`subscription-provider.ts:21,40`), and `org:subscription` was unversioned with a 24h TTL. A pre-deploy blob has no `customPricingPlans` key, so the conventional `?? true` fallback would resolve `undefined` → the Stripe default → **Enterprise stays visible on Shopify for a full day after deploy**, i.e. straight through the review window.

Two mitigations, both applied:
1. Bumped the prefix to `org:subscription:v2` so every blob recomputes with the field present (precedent: `org:agents:v4`). Orphaned keys expire on their own TTL.
2. Failed the client fallback closed — `?? sub?.billingProvider !== 'shopify'` instead of `?? true`.

## Second defect found while tracing

Both cards did `router.push('/contact-sales')`. That route **doesn't exist**, and `contact-sales` isn't in the proxy's `KNOWN_ROUTE_PREFIXES`, so the proxy treated it as an org handle and **silently bounced the merchant to `/app`**. Broken on Stripe too, and a finding in its own right if a reviewer clicked it. Now `mailto:sales@auxx.ai`, matching `subscription-ended.tsx` and the homepage.

Grid columns now follow the rendered card count, so two cards don't sit left-stranded in a three-column track.

## Deliberately not in scope

- **`apps/homepage` still shows Enterprise / Contact Sales.** Marketing site, outside the embedded app surface, and normal for App Store listings. A decision, not an oversight — revisit only if written reviewer feedback names it.
- **Enterprise plan row is not deleted.** Still valid for Stripe orgs and admin-override customers. This is a per-provider gate, not a removal.
- **`getPlanCta`'s `'contact'` branch left in place** — unreachable on Shopify now, still correct for Stripe.

## Verification

- `packages/billing` tsc clean; `apps/web` tsc clean across all touched files
- 88/88 `@auxx/billing` tests pass
- Biome clean on all 7 files
- No schema change, no migration, no new tRPC procedure

**Not verified from the repo** — that post-deploy a Shopify org's dehydrated `capabilities.customPricingPlans` reads `false` on first paint. Worth eyeballing on `auxxai.myshopify.com` before resubmitting.

Plan doc: `plans/billing/v3/04-hide-custom-pricing-plans-on-shopify.md`