### PR TITLE
feat(records): flip contact phone to multi-value

### DIFF
--- a/packages/lib/src/data-migrations/migrations/085-multi-email-website-flip.test.ts
+++ b/packages/lib/src/data-migrations/migrations/085-multi-email-website-flip.test.ts
@@ -52,7 +52,10 @@ describe('mergeMultiIntoOptions', () => {
 })
 
 describe('MULTI_FLIP_SYSTEM_ATTRIBUTES', () => {
-  it('flips EMAIL + WEBSITE only — phone waits on the E.164 plan', () => {
+  // Phone is flipped by migration 086, not by extending this list: 085 has
+  // already run everywhere, and a data migration is applied once — a new
+  // attribute added here would silently no-op for every existing org.
+  it('flips EMAIL + WEBSITE only', () => {
     expect([...MULTI_FLIP_SYSTEM_ATTRIBUTES]).toEqual(['primary_email', 'company_website'])
     expect(MULTI_FLIP_SYSTEM_ATTRIBUTES).not.toContain('phone')
   })

--- a/packages/lib/src/data-migrations/migrations/086-multi-phone-flip.test.ts
+++ b/packages/lib/src/data-migrations/migrations/086-multi-phone-flip.test.ts
@@ -1,0 +1,56 @@
+// packages/lib/src/data-migrations/migrations/086-multi-phone-flip.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { CONTACT_FIELDS } from '../../resources/registry/resources/contact-fields'
+import { MULTI_FLIP_SYSTEM_ATTRIBUTES } from './085-multi-email-website-flip'
+import {
+  MULTI_PHONE_ENTITY_TYPE,
+  MULTI_PHONE_SYSTEM_ATTRIBUTE,
+  migration086MultiPhoneFlip,
+} from './086-multi-phone-flip'
+
+/**
+ * The merge logic itself is 085's (`mergeMultiIntoOptions`, covered there); 086
+ * reuses it verbatim. What's worth pinning here is the pairing between the
+ * migration and the registry — the flip only works when BOTH sides agree, and a
+ * one-sided change is exactly the failure mode that leaves newly seeded orgs
+ * multi-value while existing orgs stay scalar (or vice versa).
+ */
+describe('migration086MultiPhoneFlip', () => {
+  const phoneField = CONTACT_FIELDS.phone
+
+  it('targets the seeded contact phone system attribute', () => {
+    expect(MULTI_PHONE_SYSTEM_ATTRIBUTE).toBe('phone')
+    expect(MULTI_PHONE_SYSTEM_ATTRIBUTE).toBe(phoneField?.systemAttribute)
+  })
+
+  it('matches the registry — the field it flips is declared multi', () => {
+    expect(phoneField?.options).toMatchObject({ multi: true })
+  })
+
+  it('does not re-flip what 085 already handled', () => {
+    expect(MULTI_FLIP_SYSTEM_ATTRIBUTES).not.toContain(MULTI_PHONE_SYSTEM_ATTRIBUTE)
+  })
+
+  it('arms no uniqueness gate — phone is deliberately non-unique', () => {
+    expect(phoneField?.capabilities?.unique).toBeUndefined()
+  })
+
+  it('is registered with the id its filename claims', () => {
+    expect(migration086MultiPhoneFlip.id).toBe('086-multi-phone-flip')
+  })
+
+  /**
+   * Load-bearing: `phone` is a generic attribute name that ORG-CREATED defs
+   * reuse (dev DB carries it on `leads` and `vendors`). Those defs are in no
+   * field registry, so flipping them would make existing orgs multi-value while
+   * newly created ones stay scalar. The `entityType` join is the only thing
+   * keeping the migration to the seeded contact field — dropping it silently
+   * widens the blast radius, which no other assertion here would catch.
+   */
+  it('is scoped to the seeded contact def, not every def using the name', () => {
+    expect(MULTI_PHONE_ENTITY_TYPE).toBe('contact')
+    expect(migration086MultiPhoneFlip.run.toString()).toContain('EntityDefinition')
+    expect(migration086MultiPhoneFlip.run.toString()).toContain('entityType')
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/086-multi-phone-flip.ts
+++ b/packages/lib/src/data-migrations/migrations/086-multi-phone-flip.ts
@@ -1,0 +1,113 @@
+// packages/lib/src/data-migrations/migrations/086-multi-phone-flip.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { sql } from 'drizzle-orm'
+import type { DataMigrationDef } from '../types'
+import { mergeMultiIntoOptions } from './085-multi-email-website-flip'
+
+const logger = createScopedLogger('migration-086')
+
+/**
+ * The seeded system attribute this migration flips to multi-value storage.
+ *
+ * Split out from 085's list rather than folded into it: 085 has already run on
+ * every environment, and a data migration is applied once — extending its
+ * attribute list would silently no-op for existing orgs.
+ */
+export const MULTI_PHONE_SYSTEM_ATTRIBUTE = 'phone'
+
+/**
+ * The seeded `EntityDefinition.entityType` this migration is scoped to.
+ *
+ * Unlike 085's `primary_email` / `company_website`, the attribute name `phone`
+ * is generic enough that ORG-CREATED definitions use it too — a dev-DB check
+ * found `leads` and `vendors` defs carrying `systemAttribute = 'phone'`. Those
+ * are user-created (`entityType IS NULL`) and appear in no field registry, so
+ * flipping them would leave existing orgs multi-value while any newly created
+ * such def stays scalar — a permanent divergence, and exactly the mismatch this
+ * migration exists to prevent. `entityType` is the seeder's own key
+ * (`create-entity-defs.ts` writes it from `SYSTEM_ENTITIES`) and is the same
+ * key `FIELD_REGISTRY` uses to decide the field is `CONTACT_FIELDS.phone`.
+ */
+export const MULTI_PHONE_ENTITY_TYPE = 'contact'
+
+/**
+ * Flip contact `phone` to multi-value storage (`options.multi`) on existing
+ * orgs — the last single-value identity field, held back until E.164
+ * normalization landed (PR #1629).
+ *
+ * Mechanically identical to {@link migration085MultiEmailWebsiteFlip}; see that
+ * file for why the registry flag alone is not enough (`create-fields.ts`
+ * inserts and never updates, so existing orgs keep `multi` unset and their
+ * fields stay single-value), why options are merged rather than clobbered, and
+ * why the org cache flush is this migration's responsibility.
+ *
+ * **Scoped to the system field ON THE CONTACT DEF.** Matched on
+ * `systemAttribute = 'phone'` AND `EntityDefinition.entityType = 'contact'` —
+ * see {@link MULTI_PHONE_ENTITY_TYPE} for why the attribute alone is too broad
+ * here (it is not, for 085's attributes). Org-created PHONE_INTL fields carry a
+ * NULL `systemAttribute` and are untouched either way.
+ *
+ * **No value reshape, and none is needed.** A multi field with one stored row
+ * is already the valid one-element state. The prod audit
+ * (`plans/records/phone-e164-normalization-plan.md` §5, run 2026-08-14: 498
+ * rows / 103 distinct) found 36 distinct values that fail `isValid()` and
+ * **zero that renormalize to a different string** — a renormalize pass would be
+ * a pure no-op. Those invalid values are seed-generator junk from before #1629;
+ * they read fine and only reject if someone edits that contact's phone.
+ *
+ * **Deliberately no uniqueness pass.** `primary_email` needed migration 084 to
+ * set `isUnique` because addresses identify one contact. Phone numbers do not —
+ * households and companies share a line — so `CONTACT_FIELDS.phone` carries no
+ * `unique` capability and this migration arms no gate.
+ *
+ * Idempotent: the `WHERE` only matches rows whose options don't carry
+ * `multi: true` yet.
+ */
+export const migration086MultiPhoneFlip: DataMigrationDef = {
+  id: '086-multi-phone-flip',
+  description: 'Flip contact phone to multi-value (options.multi)',
+  async run(db: Database): Promise<void> {
+    const pending = await db.execute<{
+      id: string
+      organizationId: string
+      options: unknown
+    }>(sql`
+      SELECT cf."id", cf."organizationId", cf."options"
+      FROM "CustomField" cf
+      JOIN "EntityDefinition" ed ON ed."id" = cf."entityDefinitionId"
+      WHERE cf."systemAttribute" = ${MULTI_PHONE_SYSTEM_ATTRIBUTE}
+        AND ed."entityType" = ${MULTI_PHONE_ENTITY_TYPE}
+        AND (cf."options" IS NULL OR cf."options"->>'multi' IS DISTINCT FROM 'true')
+    `)
+
+    for (const row of pending.rows) {
+      const merged = mergeMultiIntoOptions(row.options)
+      await db.execute(sql`
+        UPDATE "CustomField"
+        SET "options" = ${JSON.stringify(merged)}::jsonb, "updatedAt" = now()
+        WHERE "id" = ${row.id}
+      `)
+    }
+
+    const organizationIds = [...new Set(pending.rows.map((r) => r.organizationId))]
+
+    if (organizationIds.length > 0) {
+      // Lazy so the data-migration graph does not pull the cache barrel (and its
+      // Redis client) into every migration run.
+      const { getOrgCache } = await import('../../cache')
+      const cache = getOrgCache()
+      await Promise.all(
+        organizationIds.map((organizationId) =>
+          cache.invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+        )
+      )
+    }
+
+    logger.info('contact phone is now multi-value', {
+      fieldsUpdated: pending.rows.length,
+      organizationsAffected: organizationIds.length,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -50,6 +50,7 @@ import { migration082InteractionFieldsParticipantResolution } from './migrations
 import { migration083FindManyPluralToIdRefs } from './migrations/083-find-many-plural-to-id-refs'
 import { migration084PrimaryEmailUnique } from './migrations/084-primary-email-unique'
 import { migration085MultiEmailWebsiteFlip } from './migrations/085-multi-email-website-flip'
+import { migration086MultiPhoneFlip } from './migrations/086-multi-phone-flip'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -126,6 +127,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration083FindManyPluralToIdRefs,
     migration084PrimaryEmailUnique,
     migration085MultiEmailWebsiteFlip,
+    migration086MultiPhoneFlip,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/resources/registry/resources/contact-fields.ts
+++ b/packages/lib/src/resources/registry/resources/contact-fields.ts
@@ -141,7 +141,7 @@ export const CONTACT_FIELDS: Record<string, ResourceField> = {
     isIdentifier: true,
     // Multi-value: a contact can hold up to MAX_MULTI_VALUES addresses; the
     // first (by sortKey) is the primary. Existing orgs are caught up by data
-    // migration 085. Phone stays single until the E.164 plan lands.
+    // migration 085.
     options: { multi: true },
     capabilities: {
       filterable: true,
@@ -172,6 +172,12 @@ export const CONTACT_FIELDS: Record<string, ResourceField> = {
     systemSortOrder: 'a3',
     dbColumn: 'phone',
     nullable: true,
+    // Multi-value: a contact can hold up to MAX_MULTI_VALUES numbers; the first
+    // (by sortKey) is the primary and is what outbound SMS/voice dials. Existing
+    // orgs are caught up by data migration 086. Unlike `primaryEmail` this field
+    // is deliberately NOT unique — households and companies legitimately share a
+    // line, and arming the uniqueness gate here would 409 ordinary ingest writes.
+    options: { multi: true },
     capabilities: {
       filterable: true,
       sortable: false,


### PR DESCRIPTION
Contact `phone` was the last single-value identity field, held back until E.164 normalization landed (#1629). This flips it.

## Prod audit (the thing that was blocking this)

Ran `plans/records/phone-e164-normalization-plan.md` §5 against prod. **No reshape migration needed** — same conclusion as dev:

- 500 rows / 104 distinct `PHONE_INTL` values
- 36 distinct values fail `isValid()` — 35 are the old arithmetic-seeder pattern (`+1AAAAAA####`), plus `+15101112222`
- **Zero renormalize to a different string**, so a renormalize pass would be a pure no-op
- Per-org spread confirms it's all seed/demo data (two demo orgs hold 35 each, every other org holds exactly 1) — no real customer number affected

**One genuine prod defect found and cleared separately:** 2 rows stored the literal `{"status":"aborted"}` as a phone value — the `z.NEVER`-in-a-bare-transform bug writing its abort marker as data. Both contacts had it as their only phone row, so the rows were deleted. Verified 0 aborted markers remain anywhere in `FieldValue`. The write path rejects properly since #1629 so it can't recur for phone, but **boolean/date still carry that `z.NEVER` bug** and deserve the same sweep.

## Changes

| File | Change |
|---|---|
| `resources/registry/resources/contact-fields.ts` | `options: { multi: true }` on `CONTACT_FIELDS.phone` |
| `data-migrations/migrations/086-multi-phone-flip.ts` | NEW — flips seeded contact `phone`, reusing 085's `mergeMultiIntoOptions`, then invalidates `customFields`/`resources` per org |
| `data-migrations/registry.ts` | registered |
| `086-multi-phone-flip.test.ts` | NEW — 6 tests |
| `085-…flip.test.ts` | reworded the phone assertion so it reads as "086 owns this" |

## Two decisions worth reviewing

**Scoped to the contact def, not just the attribute.** Unlike 085's `primary_email`/`company_website`, the name `phone` is generic enough that org-created defs reuse it — dev carries it on `leads` (type `PHONE`) and `vendors`. My first version flipped those too, which would have left existing orgs multi-value while any newly created such def stayed scalar. Now joined to `EntityDefinition.entityType = 'contact'` (the seeder's own key from `create-entity-defs.ts`; NULL on user-created defs), and pinned by a test.

**Deliberately not unique.** `primaryEmail` carries `unique: true` + migration 084; phone gets no equivalent. Households and companies legitimately share a line, and arming `checkUniqueValueTyped` here would 409 ordinary ingest writes.

## Why there's no UI in this PR

The email rollout built the multi-value machinery type-generically with phone in mind. `get-input-component.tsx:77` already routes `PHONE_INTL` through `ScalarOrMultiValueInput`, so the panel/cell editor swaps to the value-list picker the moment `options.multi` is set. The picker (`isValidMultiValue`, `formatValueForDisplay`), `renderPhoneValue`'s chip branch, `hydrate-field-values`, import (`phone:split`), `normalizeForLookup` and the connector sink all carry working PHONE branches already.

## Testing

- `packages/lib` data-migrations: 227 passed · `resources`/`field-values`/`seed`: 593 passed
- `apps/web` fields/pickers/dynamic-table/records/custom-fields/resources: 333 passed
- `packages/lib` scoped tsc: no new errors · Biome clean
- Local DB: 086 applied — `entityType='contact'` 30/30 multi, `leads` 0/2, `vendors` 0/1

**Not browser-verified yet.** The email flip's two bugs (#1627, #1628) were both found that way rather than by tests, so that pass is still worth doing before this is trusted in prod.

## Deploy

`pnpm db:migrate` is not needed (no schema change). Run data migration 086 via `packages/lib/scripts/run-pending-data-migrations.ts`.

## Follow-up, deliberately not here

`RecipientInput` is email-only — it hardcodes `isValidEmail`, `IdentifierType.EMAIL` and `'primary_email'`, yet serves the phone channels (`sms`/`openphone`/`whatsapp` are all `recipientModel: 'phone'` + `newOutbound: true`). Typing a number into an SMS composer's To field is rejected as "Invalid Email" **today** — a pre-existing bug, not one this flip introduces. Its own PR.