### PR TITLE
fix(field-values): make boolean and date schemas actually reject

### DIFF
--- a/packages/lib/src/field-values/__tests__/schema-rejection.test.ts
+++ b/packages/lib/src/field-values/__tests__/schema-rejection.test.ts
@@ -1,0 +1,114 @@
+// packages/lib/src/field-values/__tests__/schema-rejection.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { normalizeSettingValue } from '../../settings/normalize-setting-value'
+import { fieldValueSchemas } from '../field-value-validator'
+
+/**
+ * Guards the `z.NEVER` failure mode that put `{"status":"aborted"}` into
+ * production `FieldValue` rows.
+ *
+ * Under zod 4, `z.NEVER` is the `{status:'aborted'}` sentinel. Returning it
+ * from a bare `.transform((v) => …)` — without reporting an issue — does NOT
+ * fail the parse: `safeParse` comes back `success: true` with the sentinel
+ * OBJECT as `data`. `validateSingleValue` validates by trusting
+ * `result.success`, so the object flowed straight into storage. On `valueText`
+ * (a text column) node-postgres serialized it and the literal string landed in
+ * the DB; that is how two contacts ended up with a phone number of
+ * `{"status":"aborted"}`.
+ *
+ * The correct form is `.transform((v, ctx) => { ctx.addIssue(…); return z.NEVER })`,
+ * or a `.pipe()` that rejects the sentinel downstream (what saves `number`).
+ */
+
+/** Sentinel shape zod returns for `z.NEVER` — never a legitimate parse result here. */
+function isAbortSentinel(value: unknown): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    !(value instanceof Date) &&
+    'status' in value &&
+    (value as { status: unknown }).status === 'aborted'
+  )
+}
+
+/**
+ * Inputs chosen to be invalid for every scalar schema. Object/array shapes are
+ * excluded — the JSON schemas legitimately accept objects, and this sweep is
+ * about scalar coercion.
+ */
+const BAD_INPUTS: unknown[] = ['banana', '', '   ', Number.NaN, {}, [], null, undefined]
+
+describe('no fieldValueSchemas entry fails open with the abort sentinel', () => {
+  // Iterating the registry (rather than listing types) is the point: a schema
+  // added later with a bare `z.NEVER` transform fails here without anyone
+  // remembering this rule.
+  const entries = Object.entries(fieldValueSchemas)
+
+  it('covers every exported schema', () => {
+    expect(entries.length).toBeGreaterThan(5)
+  })
+
+  it.each(entries)('%s never returns sentinel data with success:true', (_name, schema) => {
+    for (const input of BAD_INPUTS) {
+      const result = schema.safeParse(input)
+      if (result.success) {
+        expect(isAbortSentinel(result.data)).toBe(false)
+      }
+    }
+  })
+})
+
+describe('booleanSchema rejects instead of aborting', () => {
+  it.each([['banana'], [{}], [[]], [Number.NaN]])('rejects %s', (input) => {
+    expect(fieldValueSchemas.boolean.safeParse(input).success).toBe(false)
+  })
+
+  it('still coerces the accepted truthy/falsy spellings', () => {
+    for (const [input, expected] of [
+      [true, true],
+      [false, false],
+      ['true', true],
+      ['false', false],
+      ['1', true],
+      ['0', false],
+      [1, true],
+      [0, false],
+    ] as const) {
+      const result = fieldValueSchemas.boolean.safeParse(input)
+      expect(result.success && result.data).toBe(expected)
+    }
+  })
+})
+
+describe('dateSchema rejects instead of aborting', () => {
+  it.each([['banana'], [{}], [Number.NaN]])('rejects %s', (input) => {
+    expect(fieldValueSchemas.date.safeParse(input).success).toBe(false)
+  })
+
+  it('still accepts parseable dates', () => {
+    expect(fieldValueSchemas.date.safeParse('2026-08-14').success).toBe(true)
+    const asDate = fieldValueSchemas.date.safeParse(new Date('2026-08-14T00:00:00.000Z'))
+    expect(asDate.success && asDate.data).toBe('2026-08-14T00:00:00.000Z')
+  })
+})
+
+/**
+ * The one path where the sentinel could be stored SILENTLY rather than blowing
+ * up: settings persist to a `jsonb` column, so an object is perfectly
+ * storable. On the `FieldValue` side CHECKBOX/DATE land in typed
+ * `valueBoolean`/`valueDate` columns and Postgres rejects the sentinel outright.
+ */
+describe('normalizeSettingValue CHECKBOX no longer stores the sentinel', () => {
+  const config = { fieldType: 'CHECKBOX' } as Parameters<typeof normalizeSettingValue>[1]
+
+  it('throws on a non-boolean value', () => {
+    expect(() => normalizeSettingValue('some.flag', config, 'banana' as never)).toThrow()
+  })
+
+  it('still accepts real booleans', () => {
+    expect(normalizeSettingValue('some.flag', config, true as never)).toBe(true)
+    expect(normalizeSettingValue('some.flag', config, false as never)).toBe(false)
+  })
+})

--- a/packages/lib/src/field-values/field-value-validator.ts
+++ b/packages/lib/src/field-values/field-value-validator.ts
@@ -35,17 +35,26 @@ const numberSchema = z
   })
   .pipe(z.number().finite())
 
-const booleanSchema = z.unknown().transform((v) => {
+// `ctx.addIssue` is load-bearing here, exactly as it is on `phone` below: a bare
+// transform that returns `z.NEVER` does NOT fail the parse — see the comment on
+// `phone` for the full mechanism. `numberSchema` above gets away with the bare
+// form only because its `.pipe(z.number().finite())` rejects the sentinel
+// downstream; these two have no pipe, so they must report the issue themselves.
+const booleanSchema = z.unknown().transform((v, ctx) => {
   if (typeof v === 'boolean') return v
   if (v === 'true' || v === '1' || v === 1) return true
   if (v === 'false' || v === '0' || v === 0) return false
+  ctx.addIssue({ code: 'custom', message: 'Invalid boolean value' })
   return z.NEVER
 })
 
-const dateSchema = z.unknown().transform((v) => {
+const dateSchema = z.unknown().transform((v, ctx) => {
   if (v instanceof Date) return v.toISOString()
   const date = new Date(String(v))
-  if (Number.isNaN(date.getTime())) return z.NEVER
+  if (Number.isNaN(date.getTime())) {
+    ctx.addIssue({ code: 'custom', message: 'Invalid date value' })
+    return z.NEVER
+  }
   return date.toISOString()
 })
 


### PR DESCRIPTION
Closes the last two schemas carrying the `z.NEVER` fail-open defect — the one that put two `{"status":"aborted"}` phone numbers into production.

## The defect

`booleanSchema` and `dateSchema` "rejected" by returning `z.NEVER` from a bare `.transform((v) => …)`. Under zod 4 that sentinel, with no issue reported, makes the parse **succeed** with `{status:'aborted'}` as `data`.

`validateSingleValue` (`field-value-helpers.ts:642`) validates by trusting `result.success`, so the sentinel object flowed straight into storage. On `valueText` node-postgres serialized it and the literal string landed in the DB — that is how two contacts ended up with a phone number of `{"status":"aborted"}`.

Phone was fixed in #1629. These were the last two: `number` is saved only by its `.pipe(z.number().finite())`, email/url by their pipes.

## Why this wasn't the connector's fault

Worth recording, since that was the first hypothesis: of the two corrupted prod rows, only one was connector-managed — the other had `managedByConnectorId` NULL. Two different doors producing the same artifact is the tell that the defect is central. Every write door (connector sink, import, panel, ingest, Kopilot, API) funnels through `validateSingleValue`, so fixing it connector-side would have left the rest open.

(#1632's "drop format-rejected values instead of failing the record" is how the connector *reacts* to a rejection, and it only helps because #1629 made phone actually reject. Complementary, not a substitute.)

## Exposure — narrower than phone's, and prod is clean

Audited prod: **0 sentinels** in `FieldValue` or in `OrganizationSetting`/`UserSetting`/`AppSetting`.

| Consumer | Lands in | Result before this PR |
|---|---|---|
| `validateSingleValue` CHECKBOX/DATE/DATETIME/TIME | typed `valueBoolean`/`valueDate` | Postgres rejects outright (`invalid input syntax`, verified) — a 500 where a 400 belonged, no corruption |
| `normalizeSettingValue` CHECKBOX | settings `value jsonb` | stores the object **silently** — the one real corruption path, zero instances found |

So this is a latent footgun rather than an active incident. Fixing it because it's six lines, not because anything is on fire.

## The meta-test

`__tests__/schema-rejection.test.ts` iterates **every** export of `fieldValueSchemas` with known-bad inputs and asserts none returns sentinel-shaped `data` with `success: true`. Iterating the registry rather than listing types is the point — a schema added later with a bare `z.NEVER` transform fails without anyone remembering the rule. It also pins that boolean still coerces its accepted spellings (`'true'`/`'1'`/`1`/…) and that date still accepts parseable input, so the fix can't have tightened things too far.

## Testing

- **Verified red before green**: reverted each schema in turn and confirmed the meta-test fails on exactly that row (`boolean` → 6 failures, `date` → 4), so it isn't vacuous.
- Full `packages/lib` suite: **8841 passed, 0 failed**. 4 suites fail to *collect* on `src/threads` / `src/connections` — the known pre-existing `@auxx/redis` full-replacement-mock issue, reproduced independently of this change.
- `packages/lib` scoped tsc clean, Biome clean.