### PR TITLE
fix(fields): persist set-as-primary on multi-value fields

### DIFF
--- a/apps/web/src/components/fields/property-provider.test.ts
+++ b/apps/web/src/components/fields/property-provider.test.ts
@@ -1,0 +1,78 @@
+// apps/web/src/components/fields/property-provider.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { hasValueChanged, isOrderSensitive } from './property-provider'
+
+/**
+ * Regression guard for the silently-dropped "set as primary" write.
+ *
+ * `commitValue` skips the mutation entirely when `hasValueChanged` says nothing
+ * changed. That comparison sorted both arrays before diffing, which is right for
+ * MULTI_SELECT/TAGS (an unordered set) but wrong for `options.multi` scalars,
+ * where index 0 IS the primary — the address outbound mail/SMS actually uses.
+ *
+ * The user-visible bug: set-as-primary reordered the picker, then the reorder
+ * was discarded — no request, no DB write, order reverted on reload. Adding and
+ * removing values worked, because those change the array LENGTH. Found in
+ * browser verification of the multi-phone flip; it affected live multi-email too.
+ */
+describe('hasValueChanged — order sensitivity', () => {
+  const a = 'a@x.com'
+  const b = 'b@x.com'
+
+  it('treats a pure reorder as CHANGED when order-sensitive', () => {
+    expect(hasValueChanged([b, a], [a, b], true)).toBe(true)
+  })
+
+  it('treats a pure reorder as unchanged when order-insensitive (sets)', () => {
+    expect(hasValueChanged([b, a], [a, b], false)).toBe(false)
+  })
+
+  it('defaults to order-insensitive so set-valued fields keep their behavior', () => {
+    expect(hasValueChanged([b, a], [a, b])).toBe(false)
+  })
+
+  it('still reports no change for an identical ordered list', () => {
+    expect(hasValueChanged([a, b], [a, b], true)).toBe(false)
+  })
+
+  it('detects add and remove under both modes (length differs)', () => {
+    for (const ordered of [true, false]) {
+      expect(hasValueChanged([a, b], [a], ordered)).toBe(true)
+      expect(hasValueChanged([a], [a, b], ordered)).toBe(true)
+    }
+  })
+
+  it('handles empty and null consistently under both modes', () => {
+    for (const ordered of [true, false]) {
+      expect(hasValueChanged([], [], ordered)).toBe(false)
+      expect(hasValueChanged(null, null, ordered)).toBe(false)
+      expect(hasValueChanged([a], null, ordered)).toBe(true)
+      expect(hasValueChanged(null, [a], ordered)).toBe(true)
+    }
+  })
+
+  it('leaves non-array comparisons untouched by the flag', () => {
+    expect(hasValueChanged('x', 'x', true)).toBe(false)
+    expect(hasValueChanged('x', 'y', true)).toBe(true)
+    expect(hasValueChanged({ a: 1 }, { a: 1 }, true)).toBe(false)
+  })
+})
+
+describe('isOrderSensitive', () => {
+  it('is true only for options.multi scalar fields', () => {
+    expect(isOrderSensitive({ options: { multi: true } })).toBe(true)
+  })
+
+  it('is false for set-valued and plain fields', () => {
+    // MULTI_SELECT/TAGS/RELATIONSHIP arrays carry no meaningful order.
+    expect(isOrderSensitive({ options: { multiple: true } })).toBe(false)
+    expect(isOrderSensitive({ options: {} })).toBe(false)
+    expect(isOrderSensitive({})).toBe(false)
+    expect(isOrderSensitive(undefined)).toBe(false)
+  })
+
+  it('does not treat a truthy non-true multi as order-sensitive', () => {
+    expect(isOrderSensitive({ options: { multi: 'yes' } })).toBe(false)
+  })
+})

--- a/apps/web/src/components/fields/property-provider.tsx
+++ b/apps/web/src/components/fields/property-provider.tsx
@@ -137,6 +137,18 @@ function extractRawValue(val: StoredFieldValue | null | undefined, fieldType: Fi
 }
 
 /**
+ * Whether this field's array values are ORDER-sensitive.
+ *
+ * True only for `options.multi` scalar fields (EMAIL/URL/PHONE), where the list
+ * is ordered and index 0 is the primary — the value outbound mail/SMS actually
+ * uses. Every other array-valued type (MULTI_SELECT, TAGS, RELATIONSHIP, ACTOR)
+ * stores an unordered set, where a reshuffle carries no meaning.
+ */
+export function isOrderSensitive(field: any): boolean {
+  return field?.options?.multi === true
+}
+
+/**
  * Normalize a value for comparison purposes.
  * Treats empty strings, null, and undefined as equivalent "empty" values.
  */
@@ -150,8 +162,12 @@ function normalizeForComparison(val: any): any {
  * Check if a value has changed compared to another value
  * Handles arrays, objects, and primitives
  * Treats empty strings and null/undefined as equivalent (no change)
+ *
+ * @param orderSensitive - When true, arrays that differ only in ORDER count as
+ *   changed. Required for `options.multi` scalar fields (EMAIL/URL/PHONE), where
+ *   position is data: index 0 IS the primary value. See {@link isOrderSensitive}.
  */
-function hasValueChanged(newValue: any, originalVal: any): boolean {
+export function hasValueChanged(newValue: any, originalVal: any, orderSensitive = false): boolean {
   // Normalize both values - empty strings are treated as null
   const normalizedNew = normalizeForComparison(newValue)
   const normalizedOrig = normalizeForComparison(originalVal)
@@ -170,6 +186,13 @@ function hasValueChanged(newValue: any, originalVal: any): boolean {
     if (normalizedNew.length !== normalizedOrig.length) return true
     // Empty arrays are equal
     if (normalizedNew.length === 0) return false
+    // Order-insensitive by default: MULTI_SELECT/TAGS/RELATIONSHIP carry a SET
+    // of values, so a reshuffle is not an edit. Multi-value scalars are the
+    // opposite — set-as-primary reorders the same members, and sorting here
+    // would report "unchanged" and silently drop the write.
+    if (orderSensitive) {
+      return JSON.stringify(normalizedNew) !== JSON.stringify(normalizedOrig)
+    }
     const sortedNew = [...normalizedNew].sort()
     const sortedOrig = [...normalizedOrig].sort()
     return JSON.stringify(sortedNew) !== JSON.stringify(sortedOrig)
@@ -201,6 +224,10 @@ export function PropertyProvider({
   showTitle = true,
   children,
 }: PropertyProviderProps) {
+  // Derived once as a primitive so the commit callbacks depend on a stable
+  // boolean rather than the whole `field` object.
+  const orderSensitive = isOrderSensitive(field)
+
   // ─── Store Integration ───
   // Get value from store using RecordId directly with auto-fetch
   const { value: storeValue, isLoading: storeLoading } = useFieldValue(recordId, field.id, {
@@ -270,7 +297,7 @@ export function PropertyProvider({
   const commitValue = useCallback(
     (newValue: any) => {
       // Check if value actually changed
-      if (!hasValueChanged(newValue, serverValue)) {
+      if (!hasValueChanged(newValue, serverValue, orderSensitive)) {
         setIsDirty(false)
         return
       }
@@ -333,7 +360,16 @@ export function PropertyProvider({
       // Store handles the optimistic update, so also update local serverValue
       setServerValue(newValue)
     },
-    [recordId, serverValue, storeSave, storeSaveMultiple, field.id, field.fieldType, field.options]
+    [
+      recordId,
+      serverValue,
+      storeSave,
+      storeSaveMultiple,
+      field.id,
+      field.fieldType,
+      field.options,
+      orderSensitive,
+    ]
   )
 
   /**
@@ -349,11 +385,11 @@ export function PropertyProvider({
    * Commit current dirty value and close popover.
    */
   const commitAndClose = useCallback(() => {
-    if (isDirty && hasValueChanged(currentValue, serverValue)) {
+    if (isDirty && hasValueChanged(currentValue, serverValue, orderSensitive)) {
       commitValue(currentValue)
     }
     setIsOpen(false)
-  }, [isDirty, currentValue, serverValue, commitValue])
+  }, [isDirty, currentValue, serverValue, commitValue, orderSensitive])
 
   /**
    * Commit explicit value and close popover atomically.
@@ -367,7 +403,7 @@ export function PropertyProvider({
         return
       }
 
-      if (!hasValueChanged(newValue, serverValue)) {
+      if (!hasValueChanged(newValue, serverValue, orderSensitive)) {
         setIsDirty(false)
         setIsOpen(false)
         isOutsideClick.current = false
@@ -384,7 +420,16 @@ export function PropertyProvider({
       storeSave(recordId, field.id, newValue, field.fieldType, { fieldOptions: field.options })
       setServerValue(newValue)
     },
-    [recordId, isSaving, serverValue, storeSave, field.id, field.fieldType, field.options]
+    [
+      recordId,
+      isSaving,
+      serverValue,
+      storeSave,
+      field.id,
+      field.fieldType,
+      field.options,
+      orderSensitive,
+    ]
   )
 
   /**
@@ -400,7 +445,7 @@ export function PropertyProvider({
         !Array.isArray(newValue) &&
         Object.keys(newValue).length === 0
 
-      if (!isEmptyObject && !hasValueChanged(newValue, serverValue)) {
+      if (!isEmptyObject && !hasValueChanged(newValue, serverValue, orderSensitive)) {
         setIsDirty(false)
         return undefined
       }
@@ -421,7 +466,15 @@ export function PropertyProvider({
       }
       return result
     },
-    [recordId, serverValue, storeSaveAsync, field.id, field.fieldType, field.options]
+    [
+      recordId,
+      serverValue,
+      storeSaveAsync,
+      field.id,
+      field.fieldType,
+      field.options,
+      orderSensitive,
+    ]
   )
 
   /**
@@ -444,14 +497,14 @@ export function PropertyProvider({
    * Close the popover (cancels if dirty via Esc key)
    */
   const close = useCallback(() => {
-    if (isDirty && hasValueChanged(currentValue, serverValue)) {
+    if (isDirty && hasValueChanged(currentValue, serverValue, orderSensitive)) {
       // Esc key was pressed while dirty - cancel instead of save
       setCurrentValue(serverValue)
       setIsDirty(false)
     }
     setIsOpen(false)
     isOutsideClick.current = false
-  }, [isDirty, currentValue, serverValue])
+  }, [isDirty, currentValue, serverValue, orderSensitive])
 
   /**
    * Force close the popover


### PR DESCRIPTION
Set-as-primary reordered the picker and then **silently dropped the write** — no request, no DB change, order reverted on reload. Adding and removing values worked, which is exactly what hid it: those change the array *length*.

**This is not phone-specific.** Reproduced on `primary_email`, live in production since #1625, and it would have hit company `website` too. Found while browser-verifying the multi-phone flip (#1634).

## Root cause

`commitValue` skips the mutation entirely when `hasValueChanged` reports no change, and that comparison sorted both arrays before diffing:

```js
const sortedNew  = [...normalizedNew].sort()
const sortedOrig = [...normalizedOrig].sort()
return JSON.stringify(sortedNew) !== JSON.stringify(sortedOrig)
```

Correct for MULTI_SELECT/TAGS/RELATIONSHIP, which carry an unordered **set**. Wrong for `options.multi` scalars (EMAIL/URL/PHONE), where order **is** the data: index 0 is the primary — the address outbound mail/SMS actually uses. A reorder keeps the same members, so it compared equal and the write was discarded at `property-provider.tsx:273`.

That matches the observed pattern exactly:

| Action | Length changes? | Persisted before this PR |
|---|---|---|
| Add a value | yes | ✅ |
| Remove a value | yes | ✅ |
| **Set as primary (reorder)** | **no** | **❌ silently dropped** |

The picker was innocent — `MultiValuePicker.setPrimary` correctly emits `onChange([value, ...rest])`. Worth noting it does *not* call the dedicated `fieldValue.setPrimary` mutation from #1623; the reorder rides the generic whole-array write, which is where it died.

## The fix

An `orderSensitive` flag on `hasValueChanged`, derived once per provider from `field.options.multi` and threaded through all five call sites. Only `options.multi` scalars compare order-sensitively; every other array type keeps its existing set semantics. All three editors (panel, table cell, identity header) share `PropertyProvider`, so one fix covers them.

## Verification

**Browser, end-to-end on a real record:**
- *Before*: real CDP click on "Set as primary" → UI reorders (handler runs) → **zero tRPC requests** with `window.fetch` instrumented → `FieldValue.updatedAt` unchanged → order reverts on reload.
- *After*: `fieldValue.set` fires, the two rows swap `sortKey` (`a0`/`a1`) in the DB, and the new primary survives a full reload.

**Tests:** new `property-provider.test.ts` (10 tests) pins order-sensitivity both ways, plus that add/remove/null/primitive/object comparisons are untouched by the flag. Confirmed **red before green** by reverting the branch — the reorder assertion is the only one that fails, so it isn't vacuous.

`apps/web` fields/dynamic-table/records/resources/pickers suites: 335 passed. Scoped tsc clean, Biome clean.