### PR TITLE
chore(workflow): retire eight never-implemented node types

### DIFF
--- a/apps/web/src/components/workflow/nodes/core/resource-trigger/node.tsx
+++ b/apps/web/src/components/workflow/nodes/core/resource-trigger/node.tsx
@@ -17,9 +17,11 @@ interface ResourceTriggerNodeProps extends NodeProps {
 /**
  * Resource Trigger Node Component
  *
- * This is a shared component used by all resource trigger nodes
- * (contact-created-trigger, ticket-updated-trigger, etc.)
- * The specific resource type and operation are determined by the node type
+ * The single node type behind every resource trigger — the resource and the
+ * operation come from its config, not from the node type. (The six legacy
+ * per-resource types it used to also serve, `contact-created-trigger` …
+ * `ticket-deleted-trigger`, were retired: never implemented, no persisted
+ * graphs.)
  */
 const ResourceTriggerNodeComponent: FC<ResourceTriggerNodeProps> = ({ id, data, selected }) => {
   // console.log('Rendering ResourceTriggerNode:', id, data, selected)

--- a/apps/web/src/components/workflow/types/node-types.ts
+++ b/apps/web/src/components/workflow/types/node-types.ts
@@ -13,18 +13,8 @@ export enum NodeType {
   MANUAL = 'manual',
   RESOURCE_TRIGGER = 'resource-trigger', // Unified resource trigger
 
-  // Resource trigger nodes (legacy - kept for backwards compatibility)
-  CONTACT_CREATED_TRIGGER = 'contact-created-trigger',
-  CONTACT_UPDATED_TRIGGER = 'contact-updated-trigger',
-  CONTACT_DELETED_TRIGGER = 'contact-deleted-trigger',
-  TICKET_CREATED_TRIGGER = 'ticket-created-trigger',
-  TICKET_UPDATED_TRIGGER = 'ticket-updated-trigger',
-  TICKET_DELETED_TRIGGER = 'ticket-deleted-trigger',
-
   // Input nodes
   FORM_INPUT = 'form-input',
-  NUMBER_INPUT = 'number-input',
-  FILE_UPLOAD = 'file-upload',
 
   // Condition nodes
   IF_ELSE = 'if-else',
@@ -78,15 +68,7 @@ export function getNodeTypeDisplayName(type: NodeType): string {
     [NodeType.SCHEDULED]: 'Scheduled Trigger',
     [NodeType.MANUAL]: 'Manual Trigger',
     [NodeType.RESOURCE_TRIGGER]: 'Resource',
-    [NodeType.CONTACT_CREATED_TRIGGER]: 'Contact Created',
-    [NodeType.CONTACT_UPDATED_TRIGGER]: 'Contact Updated',
-    [NodeType.CONTACT_DELETED_TRIGGER]: 'Contact Deleted',
-    [NodeType.TICKET_CREATED_TRIGGER]: 'Ticket Created',
-    [NodeType.TICKET_UPDATED_TRIGGER]: 'Ticket Updated',
-    [NodeType.TICKET_DELETED_TRIGGER]: 'Ticket Deleted',
     [NodeType.FORM_INPUT]: 'Form Input',
-    [NodeType.NUMBER_INPUT]: 'Number Input',
-    [NodeType.FILE_UPLOAD]: 'File Upload',
     [NodeType.IF_ELSE]: 'IF/ELSE',
     [NodeType.ANSWER]: 'Answer',
     [NodeType.AI]: 'AI',

--- a/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
+++ b/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
@@ -5,12 +5,17 @@
  * `apps/web/src/components/workflow/nodes/core/<type>/schema.ts` and have no
  * catalog manifest yet.
  *
- * This list is the migration tracker and it may ONLY SHRINK: migrating a type
- * means registering its manifest in `registry.ts` and deleting its entry
- * here. The catalog coverage test (apps/web parity suite) asserts that every
- * builder `NodeType` value is in exactly one of {registered manifests, this
- * list} — so adding a node type, migrating one, or retiring one is always an
- * explicit edit here, never silent.
+ * This list is the migration tracker and it may ONLY SHRINK, for one of two
+ * reasons:
+ *  - **Migrated** — register its manifest in `registry.ts`, delete its entry here.
+ *  - **Retired** — the type is gone; delete its entry here AND its member from
+ *    the builder's `NodeType` enum, in the SAME change. The coverage test
+ *    asserts exact set equality between `NodeType` and {manifests ∪ this list}
+ *    in both directions, so a half-done retirement fails the build.
+ *
+ * The catalog coverage test (apps/web parity suite) is what makes adding a node
+ * type, migrating one, or retiring one always an explicit edit here, never
+ * silent.
  *
  * Values are the persisted `data.type` strings (the builder's `NodeType` enum
  * values), listed in the enum's order.
@@ -23,17 +28,15 @@ export const NOT_YET_MIGRATED: readonly string[] = [
   // 'scheduled' — migrated (catalog/nodes/scheduled.ts)
   // 'manual' — migrated (catalog/nodes/manual.ts)
   // 'resource-trigger' — migrated (catalog/nodes/resource-trigger.ts)
-  // Legacy per-resource triggers (kept for backwards compatibility)
-  'contact-created-trigger',
-  'contact-updated-trigger',
-  'contact-deleted-trigger',
-  'ticket-created-trigger',
-  'ticket-updated-trigger',
-  'ticket-deleted-trigger',
+  // The six legacy per-resource triggers ('contact-created-trigger' …
+  // 'ticket-deleted-trigger') were RETIRED, not migrated: they never had a
+  // schema, definition or processor, only enum members and a publish-time
+  // normalization shim for old graphs that do not exist.
   // Input nodes
   'form-input',
-  'number-input',
-  'file-upload',
+  // 'number-input' / 'file-upload' — RETIRED alongside the legacy triggers.
+  // Neither was ever implemented; file-upload behaviour is 'form-input' with
+  // `inputType: 'file'`.
   // Condition nodes
   // 'if-else' — migrated (catalog/nodes/if-else.ts)
   // Action nodes

--- a/packages/lib/src/workflow-engine/core/types.ts
+++ b/packages/lib/src/workflow-engine/core/types.ts
@@ -242,15 +242,11 @@ export function isActionNodeType(type: WorkflowNodeType): type is WorkflowAction
 /**
  * Node types that are UI-only and should not be validated/executed by the workflow engine.
  * These nodes are configuration or annotation nodes that don't have processors.
- * - Input nodes (form-input, file-upload, number-input) configure manual trigger inputs
+ * - `form-input` configures manual trigger inputs (file inputs are this node
+ *   with `inputType: 'file'` — there is no separate upload node type)
  * - Note nodes are visual annotations
  */
-export const NON_EXECUTABLE_NODE_TYPES = [
-  'form-input',
-  'file-upload',
-  'number-input',
-  'note',
-] as const
+export const NON_EXECUTABLE_NODE_TYPES = ['form-input', 'note'] as const
 
 export type NonExecutableNodeType = (typeof NON_EXECUTABLE_NODE_TYPES)[number]
 

--- a/packages/lib/src/workflow-engine/core/validation.ts
+++ b/packages/lib/src/workflow-engine/core/validation.ts
@@ -69,8 +69,8 @@ export async function validateWorkflow(
   }
 
   // Find truly orphaned nodes (no incoming connections and not an entry point)
-  // Exclude non-executable nodes (form-input, file-upload, number-input, note)
-  // since they're source/annotation nodes that don't require incoming connections
+  // Exclude non-executable nodes (form-input, note) since they're
+  // source/annotation nodes that don't require incoming connections
   const orphanedNodes = workflow.nodes.filter(
     (node) =>
       node !== entryNode && !referencedNodes.has(node.nodeId) && !isNonExecutableNodeType(node.type)

--- a/packages/lib/src/workflows/workflow-version-service.ts
+++ b/packages/lib/src/workflows/workflow-version-service.ts
@@ -17,16 +17,6 @@ import { WorkflowTriggerType, type WorkflowVersion } from './types'
 
 const logger = createScopedLogger('workflow-version-service')
 
-/** Legacy resource trigger node types that map to the unified resource-trigger. */
-const LEGACY_RESOURCE_TRIGGER_TYPES = new Set([
-  'contact-created-trigger',
-  'contact-updated-trigger',
-  'contact-deleted-trigger',
-  'ticket-created-trigger',
-  'ticket-updated-trigger',
-  'ticket-deleted-trigger',
-])
-
 /**
  * Convert a stored workflow (DB row) into the workflow-engine format used for
  * publish-time validation.
@@ -46,11 +36,6 @@ function toEngineFormat(dbWorkflow: any): EngineWorkflow {
       engineType = node.data?.config?.polling
         ? WorkflowNodeType.APP_POLLING_TRIGGER
         : WorkflowNodeType.APP_TRIGGER
-    }
-
-    // Normalize legacy resource trigger types to the unified resource-trigger.
-    if (typeof engineType === 'string' && LEGACY_RESOURCE_TRIGGER_TYPES.has(engineType)) {
-      engineType = WorkflowNodeType.RESOURCE_TRIGGER
     }
 
     return {


### PR DESCRIPTION
Net −32 lines. Deletions only, no behaviour change.

## What

`NOT_YET_MIGRATED` read as **15 outstanding node-catalog migrations**. Auditing it for the next migration step turned up that eight of those were never node types at all: `number-input`, `file-upload`, and the six legacy `contact/ticket-*-trigger` types existed **only as members of the builder's `NodeType` enum** — no directory, no `schema.ts`, no `NodeDefinition`, no processor.

They sat on the tracker because `catalog-coverage.test.ts` requires every enum value to appear in exactly one of {registered manifests, that list}. So they read as pending work forever while being nothing at all.

Tracker goes **15 → 7**.

## The two live shims that made this look risky

Both were protecting data that doesn't exist — Markus confirmed there are no old graphs:

- **`NON_EXECUTABLE_NODE_TYPES`** (`workflow-engine/core/types.ts`) listed `number-input` and `file-upload`. That entry is what made the engine *skip* them rather than fail to find a processor. File-upload behaviour is actually `form-input` with `inputType: 'file'` — the standalone node type was superseded and never built.
- **`LEGACY_RESOURCE_TRIGGER_TYPES`** (`workflows/workflow-version-service.ts`) normalized the six legacy triggers to `resource-trigger` during publish-time validation, purely so old persisted graphs stayed publishable.

## `form-input` is deliberately NOT retired

It's on the same tracker list and looks superficially similar, but it is fully live:

- node + panel + schema + types + output-variables in `nodes/inputs/form-input/`, registered in `nodes/inputs/index.ts`
- engine processor: `workflow-engine/nodes/form-input/form-input-processor.ts`
- input validator: `workflow-engine/validation/form-input-validator.ts`
- powers **public web forms** — `api/workflows/shared/[shareToken]/run/route.ts` validates submissions against its configs; `files/sessions/route.ts` gates uploads on `type === 'form-input' && inputType === 'file'`
- shipped in `manual-ticket-triage.template.json`, and **6 workflow rows + 1 template carry it in dev data**

It stays on the tracker as a genuine pending migration. Worth knowing it lives in `nodes/inputs/`, **not** `nodes/core/` — it is the sole occupant of that directory and is easy to miss when auditing.

## Verification before deleting

- **Zero** references to any of the eight enum members anywhere outside the enum itself.
- **Zero** quoted-string references outside the four definition sites changed here.
- **Zero rows** carrying any of the eight in `Workflow.graph` or `WorkflowTemplate.graph`. Only `form-input` appears (6 workflows, 1 template), and it stays.

## Files

| File | Change |
|---|---|
| `types/node-types.ts` | 8 enum members + their `getNodeTypeDisplayName` entries |
| `catalog/not-yet-migrated.ts` | 8 entries; docblock now covers *retired* as well as *migrated* |
| `workflow-engine/core/types.ts` | 2 entries from `NON_EXECUTABLE_NODE_TYPES` |
| `workflows/workflow-version-service.ts` | `LEGACY_RESOURCE_TRIGGER_TYPES` + its normalization branch |
| `workflow-engine/core/validation.ts` | stale comment |
| `nodes/core/resource-trigger/node.tsx` | stale doc comment |

The enum and the tracker are **coupled**: `catalog-coverage.test.ts:34` asserts exact set equality in both directions, so a tracker entry can only be dropped in the same change that drops its enum member. That test passing is the proof this is complete, and the tracker's docblock now says so explicitly rather than only describing the *migrate* path.

## Testing

- `catalog-coverage.test.ts` green — enum and tracker agree.
- lib: 1418 tests across `workflow-engine` + `workflows`. web: 111 across `components/workflow`.
- Typecheck: `apps/web` at its unchanged 10-error baseline; `packages/lib` src clean.
- Biome clean.

**Note on a flake seen while verifying** (pre-existing, not from this PR): `workflows/__tests__/workflow-draft-cas.test.ts` can time out in a large parallel run — it takes ~6.3s standalone because it connects to live Redis, against the 5s default. The full suite passes at `--testTimeout=30000`, and `workflow-service.ts` (what that test exercises) has no reference to `workflow-version-service.ts` (the only file touched here in that package).