### PR TITLE
refactor(knowledge): extract dataset resolution with a required access clamp

### DIFF
--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
@@ -1,11 +1,13 @@
 // packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
 
-import { schema } from '@auxx/database'
-import { and, eq, inArray, isNotNull } from 'drizzle-orm'
 import { z } from 'zod'
 import type { ResolvedKnowledgeScope } from '../../../../../agents/resolve-knowledge-scope'
+import {
+  type KnowledgeSource,
+  knowledgeTargetsForSource,
+  resolveKnowledgeDatasetIds,
+} from '../../../../../datasets/resolve-knowledge-targets'
 import { SearchService } from '../../../../../datasets/services/search.service'
-import type { CapabilityView } from '../../../../../permissions/capabilities/capability-view'
 import { parseStringArg } from '../../../../agent-framework/tool-inputs'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import { takeSample } from '../../../digests'
@@ -54,7 +56,8 @@ const MAX_RESULTS = 10
 const DEFAULT_RESULTS = 5
 const MAX_CONTENT_LENGTH = 1500
 
-type Source = 'kb' | 'rag' | 'both'
+/** Alias, not a copy — the two cannot drift. */
+type Source = KnowledgeSource
 
 /**
  * Unified hybrid search across KB-managed datasets (article embeddings) and
@@ -68,8 +71,9 @@ type Source = 'kb' | 'rag' | 'both'
  *  2. Agent retrieval scope (`knowledgeScope`, permissions v2 §1.2/1.3) —
  *     **relevance-by-design**, not a security boundary of its own: it's the
  *     agent author's choice of which of the org's *otherwise-accessible*
- *     knowledge this agent should draw from. Narrows `resolveDatasetIds`'
- *     dataset set (1a) and, for KB segments, narrows further at the article
+ *     knowledge this agent should draw from. Narrows
+ *     `resolveKnowledgeDatasetIds`' dataset set (1a) and, for KB segments,
+ *     narrows further at the article
  *     level via {@link isSegmentInKnowledgeScope} (1b) — a dataset in scope
  *     can still hold articles the scope excludes.
  *  3. Capability instance-access (`capabilities`, doc-14) — **security**.
@@ -86,7 +90,7 @@ export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefini
       keys: ['kb', 'dataset'],
       level: 'view',
       enforcement: 'enforced',
-      note: 'filterAccessibleDatasetIds → canViewInstance per kb/dataset, intersected with the agent’s knowledgeScope and clamped to PUBLIC articles on a visitor turn.',
+      note: 'resolveKnowledgeDatasetIds → canViewInstance per kb/dataset, intersected with the agent’s knowledgeScope and clamped to PUBLIC articles on a visitor turn.',
     },
     displayName: 'Search knowledge',
     toolsetSlug: 'auxx:knowledge',
@@ -208,16 +212,22 @@ export function createSearchKnowledgeTool(getDeps: GetToolDeps): AgentToolDefini
       const source: Source = isChat ? 'kb' : requestedSource
 
       try {
-        const datasetIds = await resolveDatasetIds({
-          db,
+        const resolved = await resolveKnowledgeDatasetIds(db, {
           organizationId: agentDeps.organizationId,
-          source,
-          knowledgeBaseId,
-          requestedDatasetIds,
+          targets: knowledgeTargetsForSource(source, knowledgeBaseId, requestedDatasetIds),
           publicOnly: isChat,
-          capabilities,
-          knowledgeScope,
+          // `capabilities: undefined` ⇒ unrestricted is the load-bearing
+          // convention for the headless construction sites that legitimately
+          // pass it (master-Kopilot job runs, pre-setup drafts — see
+          // `ToolDeps.capabilities`). Spelling it as `'unrestricted'` here
+          // preserves that exactly while removing the *implicit* fail-open arm
+          // from the resolver, so a new caller can no longer get an unfiltered
+          // retrieval set by forgetting the field.
+          capabilities: capabilities ?? 'unrestricted',
+          knowledgeScope: knowledgeScope ?? null,
         })
+        if (resolved.isErr()) throw resolved.error
+        const datasetIds = resolved.value
 
         if (datasetIds.length === 0) {
           return {
@@ -386,219 +396,4 @@ export function isSegmentInKnowledgeScope(
   if (meta.kbId !== undefined && scope.fullKbIds.has(meta.kbId)) return true
   if (meta.articleId !== undefined && scope.articleIds.has(meta.articleId)) return true
   return false
-}
-
-async function resolveDatasetIds(args: {
-  db: import('@auxx/database').Database
-  organizationId: string
-  source: Source
-  knowledgeBaseId?: string
-  requestedDatasetIds?: string[]
-  /** Chat clamp — restrict managed datasets to PUBLIC knowledge bases. */
-  publicOnly?: boolean
-  /** Resolved instance-access gate for the turn; absent ⇒ unrestricted. */
-  capabilities?: CapabilityView
-  /**
-   * Agent retrieval scope (permissions v2 §1.2/1.3). Intersected with the
-   * collected dataset ids below — narrows, never adds — before the
-   * capability instance-access filter runs. `null`/`undefined` ⇒ unrestricted
-   * and zero added I/O (a plain array filter, no extra query either way).
-   */
-  knowledgeScope?: ResolvedKnowledgeScope | null
-}): Promise<string[]> {
-  const {
-    db,
-    organizationId,
-    source,
-    knowledgeBaseId,
-    requestedDatasetIds,
-    publicOnly,
-    capabilities,
-    knowledgeScope,
-  } = args
-
-  const ids = await collectDatasetIds({
-    db,
-    organizationId,
-    source,
-    knowledgeBaseId,
-    requestedDatasetIds,
-    publicOnly,
-  })
-  // Cheap in-memory intersection, no I/O — runs before the capability filter's
-  // extra KB query so a scope that already narrows to nothing skips it
-  // entirely. Absent scope is a no-op pass-through.
-  const scoped = knowledgeScope ? ids.filter((id) => knowledgeScope.datasetIds.has(id)) : ids
-  return filterAccessibleDatasetIds(db, organizationId, scoped, capabilities)
-}
-
-async function collectDatasetIds(args: {
-  db: import('@auxx/database').Database
-  organizationId: string
-  source: Source
-  knowledgeBaseId?: string
-  requestedDatasetIds?: string[]
-  publicOnly?: boolean
-}): Promise<string[]> {
-  const { db, organizationId, source, knowledgeBaseId, requestedDatasetIds, publicOnly } = args
-
-  if (source === 'kb') {
-    return collectManagedDatasetIds(db, organizationId, knowledgeBaseId, publicOnly)
-  }
-  if (source === 'rag') {
-    const rows = await db
-      .select({ id: schema.Dataset.id })
-      .from(schema.Dataset)
-      .where(
-        and(
-          eq(schema.Dataset.organizationId, organizationId),
-          eq(schema.Dataset.isManaged, false),
-          requestedDatasetIds && requestedDatasetIds.length > 0
-            ? inArray(schema.Dataset.id, requestedDatasetIds)
-            : undefined
-        )
-      )
-    return rows.map((r) => r.id)
-  }
-  // both
-  const [kb, rag] = await Promise.all([
-    collectManagedDatasetIds(db, organizationId, knowledgeBaseId),
-    db
-      .select({ id: schema.Dataset.id })
-      .from(schema.Dataset)
-      .where(
-        and(
-          eq(schema.Dataset.organizationId, organizationId),
-          eq(schema.Dataset.isManaged, false),
-          requestedDatasetIds && requestedDatasetIds.length > 0
-            ? inArray(schema.Dataset.id, requestedDatasetIds)
-            : undefined
-        )
-      )
-      .then((rows) => rows.map((r) => r.id)),
-  ])
-  return [...new Set([...kb, ...rag])]
-}
-
-/**
- * Instance-access read gate for the searchable set (permissions v2 §3.3, doc-11
- * "Read = use in search/agents"). Every branch above funnels through here, so a
- * dataset the principal can't view — or a managed dataset whose backing KB the
- * principal can't view — never reaches `SearchService`.
- *
- * A KB-backed dataset is governed by its **KB** instance grant (that's the
- * container an admin actually shares); only standalone RAG datasets fall back
- * to the `dataset` key. Silent filter: an empty result is a normal empty search,
- * never a 403.
- *
- * Zero extra I/O when `capabilities` is absent — the whole function
- * short-circuits, so the un-threaded workflow AI node issues exactly the same
- * queries it does today.
- */
-async function filterAccessibleDatasetIds(
-  db: import('@auxx/database').Database,
-  organizationId: string,
-  datasetIds: string[],
-  capabilities?: CapabilityView
-): Promise<string[]> {
-  if (!capabilities || datasetIds.length === 0) return datasetIds
-
-  const kbRows = await db
-    .select({ id: schema.KnowledgeBase.id, datasetId: schema.KnowledgeBase.datasetId })
-    .from(schema.KnowledgeBase)
-    .where(eq(schema.KnowledgeBase.organizationId, organizationId))
-
-  const kbIdByDatasetId = new Map<string, string>()
-  for (const row of kbRows) {
-    if (row.datasetId) kbIdByDatasetId.set(row.datasetId, row.id)
-  }
-
-  return datasetIds.filter((datasetId) => {
-    const kbId = kbIdByDatasetId.get(datasetId)
-    return kbId
-      ? capabilities.canViewInstance('kb', kbId)
-      : capabilities.canViewInstance('dataset', datasetId)
-  })
-}
-
-async function collectManagedDatasetIds(
-  db: import('@auxx/database').Database,
-  organizationId: string,
-  knowledgeBaseId?: string,
-  publicOnly?: boolean
-): Promise<string[]> {
-  if (knowledgeBaseId) {
-    const [kb] = await db
-      .select({ datasetId: schema.KnowledgeBase.datasetId })
-      .from(schema.KnowledgeBase)
-      .where(
-        and(
-          eq(schema.KnowledgeBase.id, knowledgeBaseId),
-          eq(schema.KnowledgeBase.organizationId, organizationId),
-          // Chat clamp — an INTERNAL KB id resolves to no datasets.
-          publicOnly ? eq(schema.KnowledgeBase.visibility, 'PUBLIC') : undefined
-        )
-      )
-      .limit(1)
-    if (!kb) return []
-    const datasetIds = kb.datasetId ? [kb.datasetId] : []
-
-    // Federate: a source linked into this KB embeds its content once in its own hidden
-    // KB's dataset, so include those datasets here. Search stays embed-once.
-    const linkRows = await db
-      .selectDistinct({ sourceId: schema.ArticlePlacement.linkedFromSourceId })
-      .from(schema.ArticlePlacement)
-      .where(
-        and(
-          eq(schema.ArticlePlacement.knowledgeBaseId, knowledgeBaseId),
-          eq(schema.ArticlePlacement.organizationId, organizationId),
-          isNotNull(schema.ArticlePlacement.linkedFromSourceId)
-        )
-      )
-    const sourceIds = linkRows.map((r) => r.sourceId).filter((id): id is string => Boolean(id))
-    if (sourceIds.length > 0) {
-      const sources = await db
-        .select({ ownedKnowledgeBaseId: schema.KnowledgeSource.ownedKnowledgeBaseId })
-        .from(schema.KnowledgeSource)
-        .where(
-          and(
-            inArray(schema.KnowledgeSource.id, sourceIds),
-            eq(schema.KnowledgeSource.organizationId, organizationId)
-          )
-        )
-      const ownedKbIds = sources.map((s) => s.ownedKnowledgeBaseId)
-      if (ownedKbIds.length > 0) {
-        const ownedKbs = await db
-          .select({ datasetId: schema.KnowledgeBase.datasetId })
-          .from(schema.KnowledgeBase)
-          .where(inArray(schema.KnowledgeBase.id, ownedKbIds))
-        datasetIds.push(
-          ...ownedKbs.map((k) => k.datasetId).filter((id): id is string => Boolean(id))
-        )
-      }
-    }
-    return [...new Set(datasetIds)]
-  }
-  // Chat clamp — restrict to datasets backing PUBLIC knowledge bases (RAG
-  // datasets are excluded entirely by forcing source='kb' upstream). Internal
-  // callers get every managed dataset.
-  if (publicOnly) {
-    const rows = await db
-      .select({ datasetId: schema.KnowledgeBase.datasetId })
-      .from(schema.KnowledgeBase)
-      .where(
-        and(
-          eq(schema.KnowledgeBase.organizationId, organizationId),
-          eq(schema.KnowledgeBase.visibility, 'PUBLIC')
-        )
-      )
-    return rows.map((r) => r.datasetId).filter((id): id is string => Boolean(id))
-  }
-  const rows = await db
-    .select({ id: schema.Dataset.id })
-    .from(schema.Dataset)
-    .where(
-      and(eq(schema.Dataset.organizationId, organizationId), eq(schema.Dataset.isManaged, true))
-    )
-  return rows.map((r) => r.id)
 }

--- a/packages/lib/src/datasets/__tests__/resolve-knowledge-targets.test.ts
+++ b/packages/lib/src/datasets/__tests__/resolve-knowledge-targets.test.ts
@@ -1,0 +1,322 @@
+// packages/lib/src/datasets/__tests__/resolve-knowledge-targets.test.ts
+//
+// Scope note: the WHERE predicates in this module moved verbatim out of
+// `search-knowledge.ts` and are exercised end-to-end by that tool's existing
+// tests (the extraction's oracle). A fake `db` cannot evaluate drizzle
+// predicates, so simulating `isManaged = false` here would only test the fake.
+//
+// What IS new in this module, and what these tests cover:
+//  - target routing (which tables a target kind reaches, and which it skips)
+//  - `all-managed` subsuming per-KB requests
+//  - the `publicOnly` RAG drop, enforced here rather than trusted to callers
+//  - the in-memory `knowledgeScope` intersection, and that it runs BEFORE the
+//    capability query
+//  - capability keying: KB-backed datasets on the `kb` grant, standalone on
+//    `dataset` — and that `'unrestricted'` issues no extra query
+//  - empty is `ok([])`, never `err`
+
+import { schema } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import type { ResolvedKnowledgeScope } from '../../agents/resolve-knowledge-scope'
+import type { CapabilityView } from '../../permissions/capabilities/capability-view'
+import { knowledgeTargetsForSource, resolveKnowledgeDatasetIds } from '../resolve-knowledge-targets'
+
+const KB_ID = 'kb_1'
+const KB_DATASET = 'ds_kb_1'
+const OWNED_KB_ID = 'kb_source_owned'
+const OWNED_KB_DATASET = 'ds_kb_source_owned'
+const RAG_DATASET = 'ds_rag_1'
+const SOURCE_ID = 'src_1'
+const ORG = 'org_1'
+
+interface FakeRows {
+  /** Rows for `select({ id }).from(Dataset)` — the "all managed"/RAG lists. */
+  datasets?: string[]
+  /** `select({ datasetId }).from(KnowledgeBase)` — single KB, owned KB, or public list. */
+  kbDatasetIds?: string[]
+  /** `selectDistinct({ sourceId }).from(ArticlePlacement)`. */
+  placementSourceIds?: string[]
+  /** `select({ ownedKnowledgeBaseId }).from(KnowledgeSource)`. */
+  ownedKbIds?: string[]
+  /** `select({ id, datasetId }).from(KnowledgeBase)` — the access-filter map. */
+  kbMap?: Array<{ id: string; datasetId: string | null }>
+}
+
+/**
+ * Fake drizzle handle dispatching on the table reference (`src/test/setup.ts`
+ * memoizes the schema proxy, so `table === schema.X` holds) plus the selected
+ * column set. Records every query so a test can assert which roundtrips ran.
+ */
+function makeDb(rows: FakeRows, log: string[] = []) {
+  const build = (cols: Record<string, unknown> | undefined, distinct: boolean) => ({
+    from: (table: unknown) => {
+      const has = (k: string) => Boolean(cols && k in cols)
+      let tag: string
+      let result: unknown[]
+
+      if (table === schema.ArticlePlacement) {
+        tag = 'placements'
+        result = (rows.placementSourceIds ?? []).map((sourceId) => ({ sourceId }))
+      } else if (table === schema.KnowledgeSource) {
+        tag = 'sources'
+        result = (rows.ownedKbIds ?? []).map((ownedKnowledgeBaseId) => ({ ownedKnowledgeBaseId }))
+      } else if (table === schema.Dataset) {
+        tag = 'datasets'
+        result = (rows.datasets ?? []).map((id) => ({ id }))
+      } else if (has('id') && has('datasetId')) {
+        tag = 'kb-map'
+        result = rows.kbMap ?? []
+      } else {
+        tag = 'kb-datasets'
+        result = (rows.kbDatasetIds ?? []).map((datasetId) => ({ datasetId }))
+      }
+
+      log.push(distinct ? `${tag}:distinct` : tag)
+      const where = () => {
+        const p = Promise.resolve(result) as Promise<unknown[]> & {
+          limit: () => Promise<unknown[]>
+        }
+        p.limit = () => Promise.resolve(result.slice(0, 1))
+        return p
+      }
+      return { where }
+    },
+  })
+
+  return {
+    select: (cols?: Record<string, unknown>) => build(cols, false),
+    selectDistinct: (cols?: Record<string, unknown>) => build(cols, true),
+  } as never
+}
+
+/** A `CapabilityView` that answers only `canViewInstance`; nothing else is reached. */
+function capsAllowing(allow: (key: string, id: string) => boolean): CapabilityView {
+  return {
+    canViewInstance: (key: string, instanceId: string) => allow(key, instanceId),
+  } as unknown as CapabilityView
+}
+
+function scope(datasetIds: string[]): ResolvedKnowledgeScope {
+  return {
+    datasetIds: new Set(datasetIds),
+    fullKbIds: new Set<string>(),
+    articleIds: new Set<string>(),
+    excludedArticleIds: new Set<string>(),
+  } as unknown as ResolvedKnowledgeScope
+}
+
+async function resolve(rows: FakeRows, args: Parameters<typeof resolveKnowledgeDatasetIds>[1]) {
+  const log: string[] = []
+  const result = await resolveKnowledgeDatasetIds(makeDb(rows, log), args)
+  if (result.isErr()) throw result.error
+  return { ids: result.value, log }
+}
+
+describe('knowledgeTargetsForSource', () => {
+  it("maps 'kb' with an id to a single kb target, without one to all-managed", () => {
+    expect(knowledgeTargetsForSource('kb', KB_ID)).toEqual([{ kind: 'kb', knowledgeBaseId: KB_ID }])
+    expect(knowledgeTargetsForSource('kb')).toEqual([{ kind: 'all-managed' }])
+  })
+
+  it("maps 'rag' with ids to dataset targets, without them to all-rag", () => {
+    expect(knowledgeTargetsForSource('rag', undefined, ['a', 'b'])).toEqual([
+      { kind: 'dataset', datasetId: 'a' },
+      { kind: 'dataset', datasetId: 'b' },
+    ])
+    expect(knowledgeTargetsForSource('rag')).toEqual([{ kind: 'all-rag' }])
+  })
+
+  it("'both' is the union of the two single-source translations", () => {
+    expect(knowledgeTargetsForSource('both', KB_ID, ['a'])).toEqual([
+      { kind: 'kb', knowledgeBaseId: KB_ID },
+      { kind: 'dataset', datasetId: 'a' },
+    ])
+  })
+})
+
+describe('resolveKnowledgeDatasetIds — target routing', () => {
+  it('a kb target federates through placements → sources → owned KB datasets', async () => {
+    const { ids, log } = await resolve(
+      {
+        kbDatasetIds: [KB_DATASET, OWNED_KB_DATASET],
+        placementSourceIds: [SOURCE_ID],
+        ownedKbIds: [OWNED_KB_ID],
+      },
+      {
+        organizationId: ORG,
+        targets: [{ kind: 'kb', knowledgeBaseId: KB_ID }],
+        capabilities: 'unrestricted',
+        knowledgeScope: null,
+      }
+    )
+
+    // KB row (.limit(1) → first id), then the federation chain, then the owned
+    // KB's dataset — deduped into one set.
+    expect(log).toContain('placements:distinct')
+    expect(log).toContain('sources')
+    expect(ids).toEqual([KB_DATASET, OWNED_KB_DATASET])
+  })
+
+  it('skips the federation queries entirely when a KB has no linked sources', async () => {
+    const { log } = await resolve(
+      { kbDatasetIds: [KB_DATASET], placementSourceIds: [] },
+      {
+        organizationId: ORG,
+        targets: [{ kind: 'kb', knowledgeBaseId: KB_ID }],
+        capabilities: 'unrestricted',
+        knowledgeScope: null,
+      }
+    )
+    expect(log).toContain('placements:distinct')
+    expect(log).not.toContain('sources')
+  })
+
+  it('all-managed subsumes per-KB targets — no federation roundtrips', async () => {
+    const { ids, log } = await resolve(
+      { datasets: [KB_DATASET, OWNED_KB_DATASET] },
+      {
+        organizationId: ORG,
+        targets: [{ kind: 'all-managed' }, { kind: 'kb', knowledgeBaseId: KB_ID }],
+        capabilities: 'unrestricted',
+        knowledgeScope: null,
+      }
+    )
+    expect(ids).toEqual([KB_DATASET, OWNED_KB_DATASET])
+    expect(log).not.toContain('placements:distinct')
+    expect(log).toEqual(['datasets'])
+  })
+
+  it('queries nothing at all when there are no targets', async () => {
+    const { ids, log } = await resolve(
+      {},
+      {
+        organizationId: ORG,
+        targets: [],
+        capabilities: 'unrestricted',
+        knowledgeScope: null,
+      }
+    )
+    expect(ids).toEqual([])
+    expect(log).toEqual([])
+  })
+})
+
+describe('resolveKnowledgeDatasetIds — visitor clamp', () => {
+  it('drops RAG targets under publicOnly instead of trusting the caller', async () => {
+    const { ids, log } = await resolve(
+      { kbDatasetIds: [KB_DATASET], placementSourceIds: [] },
+      {
+        organizationId: ORG,
+        targets: [
+          { kind: 'kb', knowledgeBaseId: KB_ID },
+          { kind: 'dataset', datasetId: RAG_DATASET },
+          { kind: 'all-rag' },
+        ],
+        capabilities: 'unrestricted',
+        publicOnly: true,
+        knowledgeScope: null,
+      }
+    )
+    expect(ids).toEqual([KB_DATASET])
+    // The Dataset table is never reached at all — the drop is structural.
+    expect(log).not.toContain('datasets')
+  })
+})
+
+describe('resolveKnowledgeDatasetIds — knowledgeScope', () => {
+  it('intersects the collected set, and narrows to nothing without the capability query', async () => {
+    const { ids, log } = await resolve(
+      { datasets: [KB_DATASET, RAG_DATASET] },
+      {
+        organizationId: ORG,
+        targets: [{ kind: 'all-managed' }],
+        capabilities: capsAllowing(() => true),
+        knowledgeScope: scope(['ds_unrelated']),
+      }
+    )
+    expect(ids).toEqual([])
+    // Empty after the in-memory intersection ⇒ the kb-map roundtrip is skipped.
+    expect(log).not.toContain('kb-map')
+  })
+
+  it('keeps only the datasets the scope names', async () => {
+    const { ids } = await resolve(
+      { datasets: [KB_DATASET, RAG_DATASET] },
+      {
+        organizationId: ORG,
+        targets: [{ kind: 'all-managed' }],
+        capabilities: 'unrestricted',
+        knowledgeScope: scope([RAG_DATASET]),
+      }
+    )
+    expect(ids).toEqual([RAG_DATASET])
+  })
+})
+
+describe('resolveKnowledgeDatasetIds — capability filter', () => {
+  const rows: FakeRows = {
+    datasets: [KB_DATASET, RAG_DATASET],
+    kbMap: [{ id: KB_ID, datasetId: KB_DATASET }],
+  }
+
+  it('governs a KB-backed dataset by its kb grant', async () => {
+    const { ids } = await resolve(rows, {
+      organizationId: ORG,
+      targets: [{ kind: 'all-managed' }],
+      capabilities: capsAllowing((key, id) => !(key === 'kb' && id === KB_ID)),
+      knowledgeScope: null,
+    })
+    expect(ids).toEqual([RAG_DATASET])
+  })
+
+  it('governs a standalone dataset by its dataset grant', async () => {
+    const { ids } = await resolve(rows, {
+      organizationId: ORG,
+      targets: [{ kind: 'all-managed' }],
+      capabilities: capsAllowing((key, id) => !(key === 'dataset' && id === RAG_DATASET)),
+      knowledgeScope: null,
+    })
+    expect(ids).toEqual([KB_DATASET])
+  })
+
+  it('denying everything is an empty success, never an error', async () => {
+    const { ids } = await resolve(rows, {
+      organizationId: ORG,
+      targets: [{ kind: 'all-managed' }],
+      capabilities: capsAllowing(() => false),
+      knowledgeScope: null,
+    })
+    expect(ids).toEqual([])
+  })
+
+  it("'unrestricted' returns everything and issues no access query", async () => {
+    const { ids, log } = await resolve(rows, {
+      organizationId: ORG,
+      targets: [{ kind: 'all-managed' }],
+      capabilities: 'unrestricted',
+      knowledgeScope: null,
+    })
+    expect(ids).toEqual([KB_DATASET, RAG_DATASET])
+    expect(log).not.toContain('kb-map')
+  })
+})
+
+describe('resolveKnowledgeDatasetIds — failure', () => {
+  it('returns err rather than throwing when the query layer fails', async () => {
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: () => Promise.reject(new Error('connection lost')),
+        }),
+      }),
+    } as never
+
+    const result = await resolveKnowledgeDatasetIds(db, {
+      organizationId: ORG,
+      targets: [{ kind: 'all-managed' }],
+      capabilities: 'unrestricted',
+      knowledgeScope: null,
+    })
+    expect(result.isErr()).toBe(true)
+  })
+})

--- a/packages/lib/src/datasets/index.ts
+++ b/packages/lib/src/datasets/index.ts
@@ -23,6 +23,14 @@ export { PdfExtractor } from './extractors/pdf-extractor'
 export { TextExtractor } from './extractors/text-extractor'
 // Export processors
 export { TextChunker } from './processors/text-chunker'
+// Knowledge target resolution — the access boundary in front of SearchService
+export {
+  type KnowledgeSource,
+  type KnowledgeTarget,
+  knowledgeTargetsForSource,
+  type ResolveKnowledgeTargetsArgs,
+  resolveKnowledgeDatasetIds,
+} from './resolve-knowledge-targets'
 export { FullTextSearchService } from './search/full-text-search'
 export { HybridSearchService } from './search/hybrid-search'
 // Export search services

--- a/packages/lib/src/datasets/resolve-knowledge-targets.ts
+++ b/packages/lib/src/datasets/resolve-knowledge-targets.ts
@@ -1,0 +1,356 @@
+// packages/lib/src/datasets/resolve-knowledge-targets.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, inArray, isNotNull } from 'drizzle-orm'
+import { err, ok, type Result } from 'neverthrow'
+import type { ResolvedKnowledgeScope } from '../agents/resolve-knowledge-scope'
+import { AuxxError } from '../errors'
+import type { CapabilityView } from '../permissions/capabilities/capability-view'
+
+const logger = createScopedLogger('datasets/resolve-knowledge-targets')
+
+/**
+ * One requested search target. A caller states *what* it wants to search; this
+ * module answers *which dataset ids* that resolves to for the acting principal.
+ *
+ * - `dataset` / `kb` — an explicit id. `kb` federates (see
+ *   {@link collectManagedDatasetIds}).
+ * - `all-managed` / `all-rag` — the unscoped "everything of this flavour"
+ *   requests, which is how `search_knowledge`'s `source: kb | rag | both`
+ *   translates when the caller names no id.
+ */
+export type KnowledgeTarget =
+  | { kind: 'dataset'; datasetId: string }
+  | { kind: 'kb'; knowledgeBaseId: string }
+  | { kind: 'all-managed' }
+  | { kind: 'all-rag' }
+
+/** The `kb | rag | both` vocabulary `search_knowledge` exposes to the model. */
+export type KnowledgeSource = 'kb' | 'rag' | 'both'
+
+/**
+ * Translate a `source` + optional ids into targets.
+ *
+ * Lives here rather than at the tool's call site because it is shared
+ * vocabulary: `scripts/debug-search-knowledge.ts` exists to reproduce the
+ * tool's resolution exactly, and it previously drifted by re-implementing it.
+ *
+ * `both` is the union of the two single-source translations, which is what the
+ * previous inline `Promise.all` over the kb and rag branches produced.
+ */
+export function knowledgeTargetsForSource(
+  source: KnowledgeSource,
+  knowledgeBaseId?: string,
+  requestedDatasetIds?: readonly string[]
+): KnowledgeTarget[] {
+  const kb: KnowledgeTarget[] = knowledgeBaseId
+    ? [{ kind: 'kb', knowledgeBaseId }]
+    : [{ kind: 'all-managed' }]
+  const rag: KnowledgeTarget[] =
+    requestedDatasetIds && requestedDatasetIds.length > 0
+      ? requestedDatasetIds.map((datasetId) => ({ kind: 'dataset', datasetId }))
+      : [{ kind: 'all-rag' }]
+
+  if (source === 'kb') return kb
+  if (source === 'rag') return rag
+  return [...kb, ...rag]
+}
+
+export interface ResolveKnowledgeTargetsArgs {
+  organizationId: string
+  targets: readonly KnowledgeTarget[]
+  /**
+   * Per-instance read gate for the acting principal (capability layer v2 §3.3,
+   * doc-11 "Read = use in search/agents").
+   *
+   * 🔴 **REQUIRED, and that is the point.** The extracted original read
+   * `capabilities?: CapabilityView` and short-circuited to "return everything"
+   * when absent — i.e. a caller that forgot the field got an *unfiltered*
+   * retrieval set. That is fail-OPEN on a payload that gets fed straight into a
+   * model prompt, which is the same class of leak that made `renderKbCatalog`'s
+   * `kbAccess` a required union (`kb/catalog/render-kb-catalog.ts`).
+   *
+   * Flipping the short-circuit was not available: `capabilities: undefined` ⇒
+   * unrestricted is a load-bearing convention for headless callers. So the type
+   * forces the distinction instead — **"no viewer"** (`'unrestricted'`, a
+   * deliberate, greppable choice) versus **"a viewer, who may see nothing"**
+   * (a `CapabilityView` that may deny every id, yielding an empty set).
+   */
+  capabilities: CapabilityView | 'unrestricted'
+  /**
+   * Visitor clamp — restrict managed datasets to PUBLIC knowledge bases and
+   * drop RAG entirely. An untrusted external caller must never reach an
+   * INTERNAL KB or any RAG dataset, full stop.
+   *
+   * The RAG drop is enforced *here* rather than trusting each caller to omit
+   * its RAG targets. Today no caller can reach that combination (the tool
+   * forces `source: 'kb'` on a visitor turn), so this changes no behaviour —
+   * it just means a future caller cannot reintroduce the hole by translating
+   * its targets wrong.
+   */
+  publicOnly?: boolean
+  /**
+   * Agent retrieval scope (permissions v2 §1.2/1.3). Intersected with the
+   * collected ids — narrows, never adds. `null` ⇒ unrestricted; pass it
+   * explicitly so the call site reads as a decision rather than an omission.
+   */
+  knowledgeScope: ResolvedKnowledgeScope | null
+}
+
+/**
+ * Resolve search targets to the concrete, access-filtered dataset id set.
+ *
+ * `SearchService.search` has **no ACL of its own** — `getAccessibleDatasets`
+ * filters on `organizationId` and `status = 'ACTIVE'` only, and an empty
+ * `datasetIds` makes it search *every* active dataset in the org, managed KB
+ * datasets included. This function is therefore the access boundary for every
+ * knowledge search, and its callers must treat an empty result as "search
+ * nothing", never as "search everything".
+ *
+ * Narrowing order is load-bearing and preserved from the original:
+ * collect → in-memory `knowledgeScope` intersection (no I/O, so a scope that
+ * narrows to nothing skips the capability query entirely) → capability
+ * instance-access filter.
+ *
+ * An empty result is a normal empty search, never a 403.
+ */
+export async function resolveKnowledgeDatasetIds(
+  db: Database,
+  args: ResolveKnowledgeTargetsArgs
+): Promise<Result<string[], Error>> {
+  const { organizationId, targets, capabilities, publicOnly, knowledgeScope } = args
+
+  try {
+    const collected = await collectDatasetIds(db, organizationId, targets, publicOnly)
+
+    // Cheap in-memory intersection, no I/O — runs before the capability
+    // filter's extra KB query so a scope that already narrows to nothing skips
+    // it entirely. Absent scope is a no-op pass-through.
+    const scoped = knowledgeScope
+      ? collected.filter((id) => knowledgeScope.datasetIds.has(id))
+      : collected
+
+    return ok(await filterAccessibleDatasetIds(db, organizationId, scoped, capabilities))
+  } catch (error) {
+    if (error instanceof AuxxError) return err(error)
+    logger.error('Failed to resolve knowledge dataset ids', { error, organizationId })
+    return err(new AuxxError('Failed to resolve knowledge dataset ids'))
+  }
+}
+
+async function collectDatasetIds(
+  db: Database,
+  organizationId: string,
+  targets: readonly KnowledgeTarget[],
+  publicOnly?: boolean
+): Promise<string[]> {
+  const kbIds: string[] = []
+  const datasetIds: string[] = []
+  let wantsAllManaged = false
+  let wantsAllRag = false
+
+  for (const target of targets) {
+    switch (target.kind) {
+      case 'kb':
+        kbIds.push(target.knowledgeBaseId)
+        break
+      case 'dataset':
+        datasetIds.push(target.datasetId)
+        break
+      case 'all-managed':
+        wantsAllManaged = true
+        break
+      case 'all-rag':
+        wantsAllRag = true
+        break
+      default: {
+        const _exhaustive: never = target
+        return _exhaustive
+      }
+    }
+  }
+
+  // Visitor clamp: RAG datasets are internal uploads with no visibility tier,
+  // so they are unreachable on a public turn regardless of what was requested.
+  if (publicOnly) {
+    datasetIds.length = 0
+    wantsAllRag = false
+  }
+
+  const [managed, rag] = await Promise.all([
+    collectManagedIds(db, organizationId, kbIds, wantsAllManaged, publicOnly),
+    collectRagIds(db, organizationId, datasetIds, wantsAllRag),
+  ])
+
+  return [...new Set([...managed, ...rag])]
+}
+
+async function collectManagedIds(
+  db: Database,
+  organizationId: string,
+  knowledgeBaseIds: readonly string[],
+  wantsAllManaged: boolean,
+  publicOnly?: boolean
+): Promise<string[]> {
+  // "All managed" subsumes any per-KB request, so resolve it alone and skip the
+  // per-KB federation queries entirely.
+  if (wantsAllManaged) {
+    return collectManagedDatasetIds(db, organizationId, undefined, publicOnly)
+  }
+  if (knowledgeBaseIds.length === 0) return []
+
+  const perKb = await Promise.all(
+    knowledgeBaseIds.map((knowledgeBaseId) =>
+      collectManagedDatasetIds(db, organizationId, knowledgeBaseId, publicOnly)
+    )
+  )
+  return perKb.flat()
+}
+
+/**
+ * Standalone RAG datasets. `isManaged = false` is preserved from the original
+ * and is not incidental: it is what stops a caller from reaching a KB's hidden
+ * managed dataset by passing its id as a plain `dataset` target.
+ */
+async function collectRagIds(
+  db: Database,
+  organizationId: string,
+  datasetIds: readonly string[],
+  wantsAllRag: boolean
+): Promise<string[]> {
+  if (!wantsAllRag && datasetIds.length === 0) return []
+
+  const rows = await db
+    .select({ id: schema.Dataset.id })
+    .from(schema.Dataset)
+    .where(
+      and(
+        eq(schema.Dataset.organizationId, organizationId),
+        eq(schema.Dataset.isManaged, false),
+        wantsAllRag ? undefined : inArray(schema.Dataset.id, [...datasetIds])
+      )
+    )
+  return rows.map((r) => r.id)
+}
+
+/**
+ * Instance-access read gate for the searchable set. Every branch above funnels
+ * through here, so a dataset the principal can't view — or a managed dataset
+ * whose backing KB the principal can't view — never reaches `SearchService`.
+ *
+ * A KB-backed dataset is governed by its **KB** instance grant (that's the
+ * container an admin actually shares); only standalone RAG datasets fall back
+ * to the `dataset` key.
+ */
+async function filterAccessibleDatasetIds(
+  db: Database,
+  organizationId: string,
+  datasetIds: string[],
+  capabilities: CapabilityView | 'unrestricted'
+): Promise<string[]> {
+  if (capabilities === 'unrestricted' || datasetIds.length === 0) return datasetIds
+
+  const kbRows = await db
+    .select({ id: schema.KnowledgeBase.id, datasetId: schema.KnowledgeBase.datasetId })
+    .from(schema.KnowledgeBase)
+    .where(eq(schema.KnowledgeBase.organizationId, organizationId))
+
+  const kbIdByDatasetId = new Map<string, string>()
+  for (const row of kbRows) {
+    if (row.datasetId) kbIdByDatasetId.set(row.datasetId, row.id)
+  }
+
+  return datasetIds.filter((datasetId) => {
+    const kbId = kbIdByDatasetId.get(datasetId)
+    return kbId
+      ? capabilities.canViewInstance('kb', kbId)
+      : capabilities.canViewInstance('dataset', datasetId)
+  })
+}
+
+/**
+ * Datasets backing knowledge bases.
+ *
+ * With a `knowledgeBaseId`, federates: a source linked into this KB embeds its
+ * content once in its own hidden KB's dataset, so those datasets are included
+ * here. Search stays embed-once.
+ */
+async function collectManagedDatasetIds(
+  db: Database,
+  organizationId: string,
+  knowledgeBaseId?: string,
+  publicOnly?: boolean
+): Promise<string[]> {
+  if (knowledgeBaseId) {
+    const [kb] = await db
+      .select({ datasetId: schema.KnowledgeBase.datasetId })
+      .from(schema.KnowledgeBase)
+      .where(
+        and(
+          eq(schema.KnowledgeBase.id, knowledgeBaseId),
+          eq(schema.KnowledgeBase.organizationId, organizationId),
+          // Visitor clamp — an INTERNAL KB id resolves to no datasets.
+          publicOnly ? eq(schema.KnowledgeBase.visibility, 'PUBLIC') : undefined
+        )
+      )
+      .limit(1)
+    if (!kb) return []
+    const datasetIds = kb.datasetId ? [kb.datasetId] : []
+
+    const linkRows = await db
+      .selectDistinct({ sourceId: schema.ArticlePlacement.linkedFromSourceId })
+      .from(schema.ArticlePlacement)
+      .where(
+        and(
+          eq(schema.ArticlePlacement.knowledgeBaseId, knowledgeBaseId),
+          eq(schema.ArticlePlacement.organizationId, organizationId),
+          isNotNull(schema.ArticlePlacement.linkedFromSourceId)
+        )
+      )
+    const sourceIds = linkRows.map((r) => r.sourceId).filter((id): id is string => Boolean(id))
+    if (sourceIds.length > 0) {
+      const sources = await db
+        .select({ ownedKnowledgeBaseId: schema.KnowledgeSource.ownedKnowledgeBaseId })
+        .from(schema.KnowledgeSource)
+        .where(
+          and(
+            inArray(schema.KnowledgeSource.id, sourceIds),
+            eq(schema.KnowledgeSource.organizationId, organizationId)
+          )
+        )
+      const ownedKbIds = sources.map((s) => s.ownedKnowledgeBaseId)
+      if (ownedKbIds.length > 0) {
+        const ownedKbs = await db
+          .select({ datasetId: schema.KnowledgeBase.datasetId })
+          .from(schema.KnowledgeBase)
+          .where(inArray(schema.KnowledgeBase.id, ownedKbIds))
+        datasetIds.push(
+          ...ownedKbs.map((k) => k.datasetId).filter((id): id is string => Boolean(id))
+        )
+      }
+    }
+    return [...new Set(datasetIds)]
+  }
+  // Visitor clamp — restrict to datasets backing PUBLIC knowledge bases.
+  // Internal callers get every managed dataset.
+  if (publicOnly) {
+    const rows = await db
+      .select({ datasetId: schema.KnowledgeBase.datasetId })
+      .from(schema.KnowledgeBase)
+      .where(
+        and(
+          eq(schema.KnowledgeBase.organizationId, organizationId),
+          eq(schema.KnowledgeBase.visibility, 'PUBLIC')
+        )
+      )
+    return rows.map((r) => r.datasetId).filter((id): id is string => Boolean(id))
+  }
+  const rows = await db
+    .select({ id: schema.Dataset.id })
+    .from(schema.Dataset)
+    .where(
+      and(eq(schema.Dataset.organizationId, organizationId), eq(schema.Dataset.isManaged, true))
+    )
+  return rows.map((r) => r.id)
+}

--- a/scripts/debug-search-knowledge.ts
+++ b/scripts/debug-search-knowledge.ts
@@ -1,10 +1,12 @@
 // scripts/debug-search-knowledge.ts
 //
-// Debug harness for the kopilot `search_knowledge` tool. Replicates the tool's
-// dataset-resolution logic from
-// packages/lib/src/ai/kopilot/capabilities/knowledge/tools/search-knowledge.ts
-// and calls SearchService directly so we can tweak knobs the tool hardcodes
+// Debug harness for the kopilot `search_knowledge` tool. Shares the tool's
+// dataset resolution (`resolveKnowledgeDatasetIds` in @auxx/lib/datasets) and
+// calls SearchService directly so we can tweak knobs the tool hardcodes
 // (similarity threshold, hybrid weights, search type, includeInactive).
+//
+// Runs unrestricted — no capability view, no knowledge scope — so it shows the
+// full candidate set, not what a given principal would see.
 //
 // Run with:
 //   pnpm dotenv -- npx tsx scripts/debug-search-knowledge.ts <flags>
@@ -30,10 +32,15 @@
 //   --raw-limit N        bypass the 10 cap (sets SearchService limit directly)
 
 import { closePools, database as db, schema } from '@auxx/database'
-import { SearchService } from '@auxx/lib/datasets'
-import { and, eq, inArray } from 'drizzle-orm'
+import {
+  type KnowledgeSource,
+  knowledgeTargetsForSource,
+  resolveKnowledgeDatasetIds,
+  SearchService,
+} from '@auxx/lib/datasets'
+import { eq } from 'drizzle-orm'
 
-type Source = 'kb' | 'rag' | 'both'
+type Source = KnowledgeSource
 
 interface Args {
   org?: string
@@ -203,70 +210,21 @@ async function listDatasets(organizationId: string) {
   }
 }
 
-/** Mirrors resolveDatasetIds() in search-knowledge.ts. */
-async function resolveDatasetIds(args: {
-  organizationId: string
-  source: Source
-  knowledgeBaseId?: string
-  requestedDatasetIds?: string[]
-}): Promise<string[]> {
-  const { organizationId, source, knowledgeBaseId, requestedDatasetIds } = args
-
-  const collectManaged = async () => {
-    if (knowledgeBaseId) {
-      const [kb] = await db
-        .select({ datasetId: schema.KnowledgeBase.datasetId })
-        .from(schema.KnowledgeBase)
-        .where(
-          and(
-            eq(schema.KnowledgeBase.id, knowledgeBaseId),
-            eq(schema.KnowledgeBase.organizationId, organizationId)
-          )
-        )
-        .limit(1)
-      return kb?.datasetId ? [kb.datasetId] : []
-    }
-    const rows = await db
-      .select({ id: schema.Dataset.id })
-      .from(schema.Dataset)
-      .where(
-        and(eq(schema.Dataset.organizationId, organizationId), eq(schema.Dataset.isManaged, true))
-      )
-    return rows.map((r) => r.id)
-  }
-
-  const collectRag = async () => {
-    const rows = await db
-      .select({ id: schema.Dataset.id })
-      .from(schema.Dataset)
-      .where(
-        and(
-          eq(schema.Dataset.organizationId, organizationId),
-          eq(schema.Dataset.isManaged, false),
-          requestedDatasetIds && requestedDatasetIds.length > 0
-            ? inArray(schema.Dataset.id, requestedDatasetIds)
-            : undefined
-        )
-      )
-    return rows.map((r) => r.id)
-  }
-
-  if (source === 'kb') return collectManaged()
-  if (source === 'rag') return collectRag()
-  const [kb, rag] = await Promise.all([collectManaged(), collectRag()])
-  return [...new Set([...kb, ...rag])]
-}
-
 async function runSearch(args: Args) {
   if (!args.org) throw new Error('--org is required for search')
   if (!args.query) throw new Error('--query is required for search')
 
-  const datasetIds = await resolveDatasetIds({
+  // The real resolver the tool uses — this script used to re-implement it and
+  // had already drifted (it never federated source-owned KB datasets).
+  // `'unrestricted'` is the deliberate debug-harness choice: no viewer.
+  const resolved = await resolveKnowledgeDatasetIds(db, {
     organizationId: args.org,
-    source: args.source,
-    knowledgeBaseId: args.kb,
-    requestedDatasetIds: args.datasets,
+    targets: knowledgeTargetsForSource(args.source, args.kb, args.datasets),
+    capabilities: 'unrestricted',
+    knowledgeScope: null,
   })
+  if (resolved.isErr()) throw resolved.error
+  const datasetIds = resolved.value
 
   console.log('---')
   console.log(`org:            ${args.org}`)


### PR DESCRIPTION
PR 1 of 3 from `plans/kopilot/workflow/12-knowledge-retrieval-sources.md`. Pure refactor; lands alone so a regression in it is unambiguous.

## Why

A workflow cannot search the knowledge base. `KnowledgeRetrievalProcessor` takes `datasets: [{ datasetId }]`, but KB articles live in **managed** datasets that every dataset picker deliberately hides — so the bundled `kb-auto-responder` template ships `"datasets": []` to be filled from a list that can never contain a KB. We ship a knowledge-base auto-responder that structurally cannot work.

`search_knowledge` already resolves kb↔rag datasets correctly, but its resolvers are module-private. That privacy had already cost once: `scripts/debug-search-knowledge.ts` duplicated them and **had drifted** — it never federated source-owned KB datasets. The node would have been the second duplication.

## What moved

`resolveDatasetIds` / `collectDatasetIds` / `filterAccessibleDatasetIds` / `collectManagedDatasetIds` → `packages/lib/src/datasets/resolve-knowledge-targets.ts`, behind a `KnowledgeTarget[]` API (`dataset` | `kb` | `all-managed` | `all-rag`) returning `Result<string[], Error>`.

Narrowing order preserved and load-bearing: collect → in-memory `knowledgeScope` intersection (no I/O, so a scope narrowing to nothing skips the capability query) → capability instance-access filter, where a KB-backed dataset is governed by its **`kb`** grant and standalone RAG by **`dataset`**. Empty stays a normal empty search, never a 403.

## K4 — `capabilities` is now required

It was `capabilities?: CapabilityView`, short-circuiting to *return everything* when absent. A caller that forgot the field got an unfiltered retrieval set, fed straight into a model prompt.

Flipping the short-circuit wasn't available: `capabilities: undefined` ⇒ unrestricted is a load-bearing convention for headless callers (master-Kopilot job runs, pre-setup drafts — see `ToolDeps.capabilities`). So the **type** forces the distinction, exactly as `renderKbCatalog`'s `kbAccess` does:

```ts
capabilities: CapabilityView | 'unrestricted'
```

"No viewer" is now a deliberate, greppable token; "a viewer who may see nothing" is a view that denies every id. A new caller can no longer get unfiltered output by forgetting a line.

**Be clear about the scope of this win:** the tool passes `capabilities ?? 'unrestricted'`, which is behaviour-identical — PR 1 promises a pure refactor. The fail-open is now one explicit reviewable line instead of the resolver's default for every future caller. The real clamp lands in PR 2, when the node passes the author's view.

## Two deliberate deviations from plan §5

- **The `source` → targets translation lives in the shared module**, not at the tool's call site. The debug script needs the identical translation; leaving it at the call site would have kept caller 3's duplication alive — the debt this PR exists to pay.
- **`publicOnly` drops RAG targets inside the resolver** rather than trusting each caller to omit them. Unreachable today (a visitor turn forces `source: 'kb'`), so no behaviour change — it means PR 2's node cannot reopen the hole by translating targets wrong.

## Ride-along

`scripts/debug-search-knowledge.ts` now calls the real resolver. This **fixes** its drift (it now federates), and it runs `'unrestricted'` with that stated in the header.

## Testing

- **All 13 existing `search_knowledge` tests pass unmodified** — the oracle. They fake `db` and mock only `SearchService`, so they genuinely exercise the moved code.
- 15 new resolver tests: target routing, KB federation, `all-managed` subsumption, the `publicOnly` RAG drop, scope intersection (incl. skipping the capability query when it narrows to nothing), capability keying both ways, empty-is-ok, and err-not-throw.
- `node scripts/ci/typecheck-ratchet.js --package lib` → 29/29 baseline.
- 59 tests green across `src/datasets` + `src/ai/kopilot/capabilities/knowledge`.

Net −240 lines.

## Note for review

`search-knowledge-capabilities.test.ts`'s header comment ("the un-threaded workflow AI node") is **stale** — `ai-v2.ts` threads capabilities now. Left untouched on purpose: "existing tests pass unmodified" is this PR's proof. Worth fixing in PR 2.
