### PR TITLE
feat(records): wire duplicate-scan triggers, sweep and archive cleanup

### DIFF
--- a/apps/worker/src/workers/index.ts
+++ b/apps/worker/src/workers/index.ts
@@ -254,6 +254,32 @@ export async function setupSchedules() {
     }
   )
 
+  // Duplicate-suggestion sweep — every 6 hours. NOT a second job: this invokes
+  // the SAME `duplicateScanJob` the mutation seam and the sync-manifest consumer
+  // enqueue, with no scope, which makes it walk feature-enabled orgs ×
+  // allowlisted definitions by watermark and additionally run the org-level
+  // `blockOrgKey` / `blockIdentity` passes (the only pass that finds a pair where
+  // NEITHER side is dirty).
+  //
+  // Backfill and safety only — the two event doors carry live traffic. What lands
+  // here: newly-enabled orgs (full backfill via NULL watermarks), records dirtied
+  // while a coalesced job was already running (BullMQ only coalesces the DELAYED
+  // state), and any future writer that slips past both doors.
+  await maintenanceQueue.upsertJobScheduler(
+    'duplicateScanJob',
+    { pattern: '0 */6 * * *' },
+    {
+      data: { dryRun: false },
+      opts: {
+        attempts: 2,
+        backoff: { type: 'exponential', delay: 60000 },
+        priority: 8,
+        removeOnComplete: { count: 60 },
+        removeOnFail: { count: 100 },
+      },
+    }
+  )
+
   // Stale PENDING message sweeper — every 5 minutes. The synchronous send path
   // creates a PENDING row then sends/reconciles in-request; a process death
   // between the two strands the row in PENDING forever (retry rejects it, UI

--- a/apps/worker/src/workers/worker-definitions/maintenance-worker.test.ts
+++ b/apps/worker/src/workers/worker-definitions/maintenance-worker.test.ts
@@ -35,6 +35,10 @@ describe('maintenance worker registrations', () => {
     ['mail reclassify apply', 'mailReclassifyApplyJob'],
     ['retroactive mail-filter apply', 'mailFilterRetroactiveApplyJob'],
     ['data migrations', 'dataMigrationsJob'],
+    // Four doors enqueue this one name — the mutation seam, the sync-manifest
+    // consumer, and the 6h scheduler — so a missing registration would silently
+    // disable duplicate detection everywhere at once.
+    ['duplicate scan', 'duplicateScanJob'],
   ])('has a handler for the %s job', (_label, name) => {
     expect(Object.keys(jobMappings)).toContain(name)
   })

--- a/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
@@ -17,6 +17,7 @@ import {
   dataMigrationsJob,
   demoCleanupJob,
   dispatchDigestJob,
+  duplicateScanJob,
   expiredTrialAccountCleanupJob,
   flushUsageEventsJob,
   invoiceDraftsJob,
@@ -291,6 +292,14 @@ export const jobMappings = {
   // from a `subjectKey` we already unsubscribed from, so "Stripe ignored your
   // unsubscribe — 6 more since. Filter it?" is answerable.
   mailUnsubscribeSweepJob,
+
+  // Duplicate-suggestion scan (plans/records/duplicate-suggestion-plan-v2.md §1.4).
+  // ONE handler behind FOUR doors — the coalesced mutation seam
+  // (jobId `dup-scan:{org}:{def}`, 45s delay), the `sync:records:changed`
+  // manifest consumer (jobId `dup-scan:{runId|importRef}`), and the 6h sweep
+  // (no scope) — all resolve their scope from the job data and run the same
+  // watermark-driven pass.
+  duplicateScanJob,
 
   // Signals substrate (plans/signals/01-signal-store.md "Retention" / "Rollups"):
   // nightly high-volume EntitySignal prune (180d) + EntitySignalRollup *Count30d decay sweep.

--- a/packages/lib/src/data-connectors/sinks/entity-sink.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink.ts
@@ -264,23 +264,75 @@ async function resolveIdentity(
     return { instanceId: null } // external-id only → create
   }
 
+  // `limit: 6` rather than 2: one slot decides the match, the rest are the
+  // duplicate SET this lookup just discovered. Capping at 2 made the ambiguity
+  // detectable but unrecordable — we could say "more than one" and nothing else.
   const { items } = await ctx.crud.lookupByField({
     entityDefinitionId: mapping.entityDefinitionId,
     candidates,
-    limit: 2,
+    limit: 6,
   })
   if (items.length === 0) return { instanceId: null }
   if (items.length > 1) {
+    const instanceIds = items.map((i) => i.recordId.split(':').slice(1).join(':'))
     logger.warn('ambiguous identity match — using first', {
       mappingId: mapping.row.id,
       externalId: record.externalId,
       matches: items.length,
+      // The ids, not just the count: the loser of this resolution is a silent
+      // duplicate, and "3 matched" is not something anyone can act on.
+      instanceIds,
     })
+    void captureAmbiguousMatch(ctx, mapping, record, instanceIds)
   }
   // recordId is `entityDefId:instanceId`.
   const match = items[0]!
   const instanceId = match.recordId.split(':').slice(1).join(':')
   return { instanceId, matched: { fieldId: match.matchedBy.fieldId, value: match.matchedBy.value } }
+}
+
+/**
+ * Record the duplicate an ambiguous identity resolution just walked past.
+ *
+ * `resolveIdentity` takes the first match and proceeds — it has to, or a sync
+ * would fail on data the user can only fix by merging. But no scan is guaranteed
+ * to rediscover the loser: neither record need ever go dirty again. This is the
+ * cheapest true positive in the whole dedup feature, because the connector's own
+ * match keys already asserted these records are the same customer.
+ *
+ * Fire-and-forget and non-throwing: a sync must never fail because a suggestion
+ * could not be written. Gated on the plan feature so a connector run for an org
+ * without duplicate detection writes nothing.
+ */
+async function captureAmbiguousMatch(
+  ctx: SyncCtx,
+  mapping: DecodedMapping,
+  record: ProjectedRecord,
+  instanceIds: string[]
+): Promise<void> {
+  try {
+    const { FeaturePermissionService } = await import(
+      '../../permissions/feature-permission-service'
+    )
+    const { FeatureKey } = await import('../../permissions/types')
+    const features = new FeaturePermissionService()
+    if (!(await features.hasAccess(ctx.orgId, FeatureKey.duplicateDetection))) return
+
+    const { emitPairsFromIdentityMatch } = await import('../../dedup/emit-identity-pairs')
+    await emitPairsFromIdentityMatch(ctx.db, {
+      organizationId: ctx.orgId,
+      entityDefinitionId: mapping.entityDefinitionId,
+      instanceIds,
+      source: ctx.connector.type,
+      externalId: record.externalId,
+    })
+  } catch (error) {
+    logger.debug('ambiguous-match duplicate capture failed', {
+      connectorId: ctx.connector.id,
+      externalId: record.externalId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
 }
 
 /**

--- a/packages/lib/src/events/handlers/handle-sync-duplicate-scan.test.ts
+++ b/packages/lib/src/events/handlers/handle-sync-duplicate-scan.test.ts
@@ -1,0 +1,194 @@
+// packages/lib/src/events/handlers/handle-sync-duplicate-scan.test.ts
+//
+// The dedup half of the `sync:records:changed` fan-out. Two claims carry the
+// design and both are asserted here: the handler enqueues ONE scan per run with
+// the manifest's ids, and it NEVER claims the manifest — the claim is the
+// record-rules consumer's once-only latch, and a second claimant would starve it.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SyncChangeManifest } from '../../record-rules/sync-manifest-types'
+import { createChainableDatabaseMock, createSchemaMock } from '../../test/database-mock'
+
+const h = vi.hoisted(() => ({
+  getRunManifest: vi.fn<() => Promise<SyncChangeManifest | null>>(),
+  getImportManifest: vi.fn<() => Promise<SyncChangeManifest | null>>(),
+  claimRunManifestConsumed: vi.fn(async () => true),
+  claimImportManifestConsumed: vi.fn(async () => true),
+  hasAccess: vi.fn(async () => true),
+  enqueueDuplicateScanForRecords: vi.fn<
+    (p: { organizationId: string; recordIds: string[]; scopeKey: string }) => Promise<string>
+  >(async () => 'job_1'),
+  getCachedRecordRules: vi.fn(async () => [] as unknown[]),
+  fireRecordRulesBatch: vi.fn(async () => {}),
+  fetchResourceSnapshots: vi.fn(async () => new Map()),
+  getCachedResourceFields: vi.fn(async () => [] as unknown[]),
+}))
+
+vi.mock('@auxx/database', async () => ({
+  database: createChainableDatabaseMock(),
+  schema: createSchemaMock(),
+}))
+vi.mock('../../data-connectors/service', () => ({
+  getRunManifest: h.getRunManifest,
+  claimRunManifestConsumed: h.claimRunManifestConsumed,
+}))
+vi.mock('../../import', () => ({
+  getImportManifest: h.getImportManifest,
+  claimImportManifestConsumed: h.claimImportManifestConsumed,
+}))
+vi.mock('../../permissions/feature-permission-service', () => ({
+  FeaturePermissionService: class {
+    hasAccess = h.hasAccess
+  },
+}))
+vi.mock('../../dedup/enqueue-scan', () => ({
+  enqueueDuplicateScanForRecords: h.enqueueDuplicateScanForRecords,
+}))
+vi.mock('../../cache', () => ({
+  getCachedRecordRules: h.getCachedRecordRules,
+  getCachedResourceFields: h.getCachedResourceFields,
+}))
+vi.mock('../../record-rules/engine', () => ({ fireRecordRulesBatch: h.fireRecordRulesBatch }))
+vi.mock('../../record-rules/snapshot-fetcher', () => ({
+  fetchResourceSnapshots: h.fetchResourceSnapshots,
+}))
+
+import { handleSyncDuplicateScan } from './handle-sync-duplicate-scan'
+import { handleSyncRecordRules } from './handle-sync-record-rules'
+
+function manifest(over: Partial<SyncChangeManifest> = {}): SyncChangeManifest {
+  return {
+    version: 1,
+    truncated: false,
+    changes: {},
+    createdRecordIds: [],
+    archivedRecordIds: [],
+    ...over,
+  } as SyncChangeManifest
+}
+
+const connectorEvent = (runId = 'run_1') =>
+  ({
+    data: {
+      type: 'sync:records:changed',
+      data: { source: 'connector', organizationId: 'org_1', runId },
+    },
+  }) as never
+
+/** The single enqueue this handler is allowed to make, asserted present. */
+function firstEnqueue() {
+  const call = h.enqueueDuplicateScanForRecords.mock.calls[0]
+  if (!call) throw new Error('enqueueDuplicateScanForRecords was never called')
+  return call[0]
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.hasAccess.mockResolvedValue(true)
+  h.claimRunManifestConsumed.mockResolvedValue(true)
+  h.getCachedRecordRules.mockResolvedValue([])
+})
+
+describe('handleSyncDuplicateScan', () => {
+  it('enqueues exactly one scan carrying the created + changed ids', async () => {
+    h.getRunManifest.mockResolvedValue(
+      manifest({
+        createdRecordIds: ['def_1:a', 'def_1:b'] as never,
+        changes: { 'def_1:c': { f1: { o: 1, n: 2 } } } as never,
+      })
+    )
+
+    await handleSyncDuplicateScan(connectorEvent())
+
+    expect(h.enqueueDuplicateScanForRecords).toHaveBeenCalledTimes(1)
+    const arg = firstEnqueue()
+    expect(arg.organizationId).toBe('org_1')
+    expect(arg.recordIds.sort()).toEqual(['def_1:a', 'def_1:b', 'def_1:c'])
+    // Stable per-RUN id — this is what makes a redelivered event a no-op.
+    expect(arg.scopeKey).toBe('run_1')
+  })
+
+  it('leaves ARCHIVED ids out of scope', async () => {
+    // An archived record is not a duplicate subject, and `archiveEntity` has
+    // already deleted its open pairs.
+    h.getRunManifest.mockResolvedValue(
+      manifest({
+        createdRecordIds: ['def_1:a'] as never,
+        archivedRecordIds: ['def_1:z'] as never,
+      })
+    )
+    await handleSyncDuplicateScan(connectorEvent())
+    const arg = firstEnqueue()
+    expect(arg.recordIds).toEqual(['def_1:a'])
+  })
+
+  it('NEVER claims the manifest', async () => {
+    h.getRunManifest.mockResolvedValue(manifest({ createdRecordIds: ['def_1:a'] as never }))
+    await handleSyncDuplicateScan(connectorEvent())
+    expect(h.claimRunManifestConsumed).not.toHaveBeenCalled()
+    expect(h.claimImportManifestConsumed).not.toHaveBeenCalled()
+  })
+
+  it('leaves the claim available to the record-rules handler', async () => {
+    // The real failure mode this guards: both consumers run off ONE event, and
+    // whichever claims first starves the other. Rules MUST win the claim.
+    h.getRunManifest.mockResolvedValue(
+      manifest({ changes: { 'def_1:c': { f1: { o: 1, n: 2 } } } as never })
+    )
+    h.getCachedRecordRules.mockResolvedValue([
+      {
+        id: 'rule_1',
+        organizationId: 'org_1',
+        entityDefinitionId: 'def_1',
+        fieldId: 'f1',
+        name: 'r',
+        on: 'changed',
+        condition: [],
+        actions: [],
+        enabled: true,
+      },
+    ])
+
+    await handleSyncDuplicateScan(connectorEvent())
+    await handleSyncRecordRules(connectorEvent())
+
+    expect(h.claimRunManifestConsumed).toHaveBeenCalledTimes(1)
+    expect(h.enqueueDuplicateScanForRecords).toHaveBeenCalledTimes(1)
+  })
+
+  it('bails before reading the manifest when the org lacks the feature', async () => {
+    h.hasAccess.mockResolvedValue(false)
+    await handleSyncDuplicateScan(connectorEvent())
+    expect(h.getRunManifest).not.toHaveBeenCalled()
+    expect(h.enqueueDuplicateScanForRecords).not.toHaveBeenCalled()
+  })
+
+  it('enqueues nothing when the manifest touched no records', async () => {
+    h.getRunManifest.mockResolvedValue(manifest())
+    await handleSyncDuplicateScan(connectorEvent())
+    expect(h.enqueueDuplicateScanForRecords).not.toHaveBeenCalled()
+  })
+
+  it('bails on an unresolvable manifest instead of throwing', async () => {
+    h.getRunManifest.mockResolvedValue(null)
+    await expect(handleSyncDuplicateScan(connectorEvent())).resolves.toBeUndefined()
+    expect(h.enqueueDuplicateScanForRecords).not.toHaveBeenCalled()
+  })
+
+  it('resolves an import manifest through the import reader', async () => {
+    h.getImportManifest.mockResolvedValue(manifest({ createdRecordIds: ['def_1:a'] as never }))
+    await handleSyncDuplicateScan({
+      data: {
+        type: 'sync:records:changed',
+        data: { source: 'import', organizationId: 'org_1', importRef: 'imp_7' },
+      },
+    } as never)
+    const arg = firstEnqueue()
+    expect(arg.scopeKey).toBe('imp_7')
+  })
+
+  it('ignores events of other types', async () => {
+    await handleSyncDuplicateScan({ data: { type: 'entity:created', data: {} } } as never)
+    expect(h.getRunManifest).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/events/handlers/handle-sync-duplicate-scan.ts
+++ b/packages/lib/src/events/handlers/handle-sync-duplicate-scan.ts
@@ -1,0 +1,107 @@
+// packages/lib/src/events/handlers/handle-sync-duplicate-scan.ts
+//
+// Dispatch door 3, second consumer: the dedup half of the sync-change manifest.
+// Connector runs and CSV imports write with `skipEvents`, so they never reach the
+// mutation seam that enqueues the coalesced scan — this handler is how their
+// records get scanned with per-run freshness instead of waiting up to 6h for the
+// sweep. One seam covers BOTH writers; `execute-plan-job.ts` stays untouched.
+//
+// Keep top-level imports to types/logger only; lazy-import everything else (the
+// dedup ↔ data-connectors ↔ cache boundaries break vi.mock otherwise, exactly as
+// they do for the record-rules consumer next door).
+
+import { createScopedLogger } from '@auxx/logger'
+import type { SyncChangeManifest } from '../../record-rules/sync-manifest-types'
+import type { AuxxEvent, SyncRecordsChangedEvent } from '../types'
+
+const logger = createScopedLogger('dedup-sync')
+
+/** Resolve the manifest a pointer event refers to (connector run row / import job row). */
+async function resolveManifest(
+  data: SyncRecordsChangedEvent['data']
+): Promise<SyncChangeManifest | null> {
+  const { database } = await import('@auxx/database')
+  if (data.source === 'connector') {
+    if (!data.runId) return null
+    const { getRunManifest } = await import('../../data-connectors/service')
+    return getRunManifest(database, data.runId)
+  }
+  if (!data.importRef) return null
+  const { getImportManifest } = await import('../../import')
+  return getImportManifest(database, data.importRef)
+}
+
+/**
+ * Enqueue ONE duplicate scan for everything a bulk run touched.
+ *
+ * ⚠️ **Never claims the manifest.** `claimManifest` is the record-rules
+ * consumer's once-only latch — rule actions carry no idempotency of their own,
+ * so exactly one claimant may proceed. A second claimant here would win the race
+ * sometimes and STARVE record rules for that run. Dedup needs no latch: the
+ * per-run `jobId` gives at-most-once, and pair upserts conflict on the canonical
+ * pair key, so even a duplicate delivery that slips past the jobId is a no-op
+ * beyond a refreshed `updatedAt`.
+ *
+ * Scope is `createdRecordIds` + every record with captured field changes.
+ * Archived ids are deliberately absent: an archived record is not a duplicate
+ * subject, and `archiveEntity` already deleted its open pairs.
+ */
+export const handleSyncDuplicateScan = async ({ data: event }: { data: AuxxEvent }) => {
+  if (event.type !== 'sync:records:changed') return
+  const data = event.data
+  const { organizationId } = data
+
+  try {
+    // Cheap bail first — an org without the feature must not pay for a manifest
+    // read, and this mirrors the rules handler's zero-rules early return.
+    const { FeaturePermissionService } = await import(
+      '../../permissions/feature-permission-service'
+    )
+    const { FeatureKey } = await import('../../permissions/types')
+    const features = new FeaturePermissionService()
+    if (!(await features.hasAccess(organizationId, FeatureKey.duplicateDetection))) return
+
+    const manifest = await resolveManifest(data)
+    if (!manifest) {
+      logger.warn('sync:records:changed with no resolvable manifest — bailing', {
+        source: data.source,
+        runId: data.runId,
+        importRef: data.importRef,
+      })
+      return
+    }
+
+    const recordIds = [
+      ...new Set<string>([...manifest.createdRecordIds, ...Object.keys(manifest.changes)]),
+    ]
+    if (recordIds.length === 0) return
+
+    // Stable per-RUN id. A re-entered connector finalize re-publishes the pointer
+    // event and BullMQ can redeliver the handler job; both collapse onto this.
+    const scopeKey = data.runId ?? data.importRef
+    if (!scopeKey) {
+      logger.warn('sync:records:changed with neither runId nor importRef — bailing', {
+        organizationId,
+        source: data.source,
+      })
+      return
+    }
+
+    const { enqueueDuplicateScanForRecords } = await import('../../dedup/enqueue-scan')
+    await enqueueDuplicateScanForRecords({ organizationId, recordIds, scopeKey })
+
+    logger.info('duplicate scan enqueued for sync run', {
+      organizationId,
+      source: data.source,
+      scopeKey,
+      records: recordIds.length,
+      truncated: manifest.truncated,
+    })
+  } catch (error) {
+    logger.error('Sync duplicate-scan enqueue failed', {
+      organizationId,
+      runId: data.runId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/packages/lib/src/events/handlers/publish-event-job.ts
+++ b/packages/lib/src/events/handlers/publish-event-job.ts
@@ -19,6 +19,7 @@ import { createTimelineEvent } from './create-timeline-event'
 import { deriveMessageReplySignal, deriveThreadResolvedSignal } from './derive-message-signals'
 import { handleRecordRules } from './handle-record-rules'
 import { handleSignalRecordRules } from './handle-signal-record-rules'
+import { handleSyncDuplicateScan } from './handle-sync-duplicate-scan'
 import { handleSyncRecordRules } from './handle-sync-record-rules'
 import { ingestBounceMessage } from './ingest-bounce-message'
 import { projectSignalToTimeline } from './project-signal-to-timeline'
@@ -187,8 +188,11 @@ export const EventHandlers: IEventsHandlers = {
   // Field trigger events → FIELD TRIGGER HANDLERS
   'field:trigger': [handleFieldTriggerJob],
 
-  // B2 — bulk-writer sync-change manifest → record rules with `source: 'sync'`.
-  'sync:records:changed': [handleSyncRecordRules],
+  // B2 — bulk-writer sync-change manifest → record rules with `source: 'sync'`,
+  // and the duplicate scan for the same run's records. The dedup consumer must
+  // NEVER claim the manifest: the claim is the rules consumer's once-only latch,
+  // and a second claimant would starve it.
+  'sync:records:changed': [handleSyncRecordRules, handleSyncDuplicateScan],
 
   // Integration events → AUDIT LOG (+ analytics)
   'integration:connected': [createAuditLog],

--- a/packages/lib/src/jobs/dedup/__tests__/duplicate-scan-job.int.test.ts
+++ b/packages/lib/src/jobs/dedup/__tests__/duplicate-scan-job.int.test.ts
@@ -1,0 +1,417 @@
+// packages/lib/src/jobs/dedup/__tests__/duplicate-scan-job.int.test.ts
+//
+// DB-backed behavior tests (vitest.integration.config.ts → auxx_test) for the
+// ONE scan job and its three scopes.
+//
+// Why integration and not unit: every claim this job rests on is a PREDICATE
+// claim about SQL, and a chainable mock is predicate-blind.
+//   1. The dirty predicate is `GREATEST(ei."updatedAt", max(fv."updatedAt")) >
+//      "lastDuplicateScanAt"`, resolved through a LATERAL. The whole reason it
+//      is not `updatedAt` alone is that a `skipEvents` writer leaves the
+//      instance row untouched — only real rows can show that the lateral arm
+//      fires.
+//   2. Stamping the watermark must not RE-dirty the record. Drizzle's
+//      `$onUpdate` on `EntityInstance.updatedAt` would do exactly that, which is
+//      why the stamp is raw SQL; a mock would happily "pass" either way.
+//
+// The org cache barrel is mocked wholesale (deterministic, no Redis): field
+// lookups read straight from the test DB. The feature service is mocked so the
+// flag is a test input rather than a Redis-backed plan lookup.
+
+import { schema } from '@auxx/database'
+import { createTestOrganization, getTestDb } from '@auxx/test-utils'
+import { and, eq, sql } from 'drizzle-orm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const db = () => getTestDb() as never as import('@auxx/database').Database
+
+// ── Feature flag as a test input ────────────────────────────────────────────
+
+const flags = vi.hoisted(() => ({ enabled: new Set<string>() }))
+
+vi.mock('../../../permissions/feature-permission-service', () => ({
+  FeaturePermissionService: class {
+    async hasAccess(organizationId: string) {
+      return flags.enabled.has(organizationId)
+    }
+  },
+}))
+
+// ── Org-cache mock (wholesale — DB-backed, no Redis, no providers) ──────────
+
+vi.mock('../../../cache', () => {
+  const tdb = () => getTestDb() as never as import('@auxx/database').Database
+
+  const fieldsForOrg = async (orgId: string) =>
+    await tdb()
+      .select()
+      .from(schema.CustomField)
+      .where(eq(schema.CustomField.organizationId, orgId))
+
+  return {
+    getCachedFieldMap: async (orgId: string) => {
+      const fields = await fieldsForOrg(orgId)
+      return new Map(fields.map((f) => [f.id, f]))
+    },
+    getCachedCustomFields: async (orgId: string) => fieldsForOrg(orgId),
+    getAllCachedCustomFields: async (orgId: string) => fieldsForOrg(orgId),
+    getCachedResource: async () => null,
+    findCachedResource: async () => null,
+    getCachedResources: async () => [],
+    getCachedEntityDefId: async (_orgId: string, slugOrId: string) => slugOrId,
+    // Shaped like `ResourceField` — only what `deriveMatchKeys` reads.
+    getCachedResourceFields: async (orgId: string, defId: string) => {
+      const rows = await tdb()
+        .select()
+        .from(schema.CustomField)
+        .where(
+          and(
+            eq(schema.CustomField.organizationId, orgId),
+            eq(schema.CustomField.entityDefinitionId, defId)
+          )
+        )
+      return rows.map((f) => ({
+        id: f.id,
+        key: f.name,
+        label: f.name,
+        type: 'string',
+        fieldType: f.type,
+        systemAttribute: f.systemAttribute ?? undefined,
+        isUnique: f.isUnique,
+        options: f.options ?? {},
+        capabilities: {},
+      }))
+    },
+  }
+})
+
+import { duplicateScanJob } from '../duplicate-scan-job'
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+interface Fixture {
+  orgId: string
+  defId: string
+  emailFieldId: string
+  phoneFieldId: string
+}
+
+async function seedContactOrg(): Promise<Fixture> {
+  const org = await createTestOrganization()
+  const orgId = org.id
+  flags.enabled.add(orgId)
+
+  const [def] = await db()
+    .insert(schema.EntityDefinition)
+    .values({
+      organizationId: orgId,
+      entityType: 'contact',
+      apiSlug: 'contacts',
+      singular: 'contact',
+      plural: 'contacts',
+      updatedAt: new Date(),
+    })
+    .returning()
+
+  const makeField = async (
+    name: string,
+    type: 'EMAIL' | 'PHONE_INTL',
+    systemAttribute: string,
+    sortOrder: string
+  ) => {
+    const [row] = await db()
+      .insert(schema.CustomField)
+      .values({
+        organizationId: orgId,
+        entityDefinitionId: def?.id as string,
+        modelType: 'contact',
+        name,
+        type,
+        systemAttribute,
+        sortOrder,
+        options: { multi: true },
+        isCustom: false,
+        isUnique: false,
+        updatedAt: new Date(),
+      })
+      .returning()
+    return row?.id as string
+  }
+
+  return {
+    orgId,
+    defId: def?.id as string,
+    emailFieldId: await makeField('primaryEmail', 'EMAIL', 'primary_email', 'a2'),
+    phoneFieldId: await makeField('phone', 'PHONE_INTL', 'phone', 'a3'),
+  }
+}
+
+async function seedContact(
+  f: Fixture,
+  displayName: string,
+  values: { email?: string; phone?: string } = {}
+): Promise<string> {
+  const [inst] = await db()
+    .insert(schema.EntityInstance)
+    .values({
+      organizationId: f.orgId,
+      entityDefinitionId: f.defId,
+      displayName,
+      updatedAt: new Date(),
+    })
+    .returning()
+
+  const write = async (fieldId: string, value?: string) => {
+    if (!value) return
+    await db()
+      .insert(schema.FieldValue)
+      .values({
+        organizationId: f.orgId,
+        entityId: inst?.id as string,
+        entityDefinitionId: f.defId,
+        fieldId,
+        valueText: value,
+        sortKey: 'a0',
+      })
+  }
+
+  await write(f.emailFieldId, values.email)
+  await write(f.phoneFieldId, values.phone)
+  return inst?.id as string
+}
+
+const runJob = (data: Record<string, unknown>) =>
+  duplicateScanJob({ job: { data, id: 'job_test' } } as never)
+
+async function pairCount(orgId: string): Promise<number> {
+  const rows = await db()
+    .select({ id: schema.DuplicateSuggestion.id })
+    .from(schema.DuplicateSuggestion)
+    .where(eq(schema.DuplicateSuggestion.organizationId, orgId))
+  return rows.length
+}
+
+async function watermark(instanceId: string): Promise<Date | null> {
+  const [row] = await db()
+    .select({ at: schema.EntityInstance.lastDuplicateScanAt })
+    .from(schema.EntityInstance)
+    .where(eq(schema.EntityInstance.id, instanceId))
+  return row?.at ?? null
+}
+
+beforeEach(() => {
+  flags.enabled.clear()
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('duplicateScanJob — org+def scope (the coalesced mutation seam)', () => {
+  it('pairs two contacts sharing a phone and stamps both watermarks', async () => {
+    const f = await seedContactOrg()
+    const a = await seedContact(f, 'A', { phone: '+12133734253' })
+    const b = await seedContact(f, 'B', { phone: '+12133734253' })
+
+    const stats = await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+
+    expect(stats.scanned).toBe(2)
+    expect(await pairCount(f.orgId)).toBe(1)
+    expect(await watermark(a)).not.toBeNull()
+    expect(await watermark(b)).not.toBeNull()
+  })
+
+  it('finds NOTHING dirty on an immediate second run', async () => {
+    // The stamp must not re-dirty the record. `EntityInstance.updatedAt` carries
+    // `$onUpdate`, so a Drizzle `.update()` here would bump `updatedAt` in the
+    // same statement and loop the scanner forever.
+    const f = await seedContactOrg()
+    await seedContact(f, 'A', { phone: '+12133734253' })
+    await seedContact(f, 'B', { phone: '+12133734253' })
+
+    await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+    const second = await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+
+    expect(second.scanned).toBe(0)
+  })
+
+  it('picks a record up again once it is dirtied after the stamp', async () => {
+    const f = await seedContactOrg()
+    const a = await seedContact(f, 'A', { phone: '+12133734253' })
+    await seedContact(f, 'B', { phone: '+12133734253' })
+    await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+
+    await db().execute(
+      sql`UPDATE "EntityInstance" SET "updatedAt" = now() + interval '1 second' WHERE "id" = ${a}`
+    )
+
+    const again = await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+    expect(again.scanned).toBe(1)
+  })
+
+  it('finds a `skipEvents` write through the FieldValue lateral', async () => {
+    // THE reason the predicate is not `updatedAt` alone: a connector sync or CSV
+    // import leaves BOTH `EntityInstance.updatedAt` and `lastActivityAt`
+    // untouched. `FieldValue.updatedAt` is the only timestamp that always moves.
+    const f = await seedContactOrg()
+    const a = await seedContact(f, 'A', { email: 'a@example.com' })
+    const b = await seedContact(f, 'B', { email: 'other@example.com' })
+    await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+    expect(await pairCount(f.orgId)).toBe(0)
+
+    // Exactly what a `skipEvents` writer does: the value row moves, the instance
+    // row does not.
+    await db().execute(sql`
+      UPDATE "FieldValue"
+      SET "valueText" = 'a@example.com', "updatedAt" = now() + interval '1 second'
+      WHERE "entityId" = ${b} AND "fieldId" = ${f.emailFieldId}
+    `)
+    const beforeInstanceUpdatedAt = (
+      await db()
+        .select({ at: schema.EntityInstance.updatedAt })
+        .from(schema.EntityInstance)
+        .where(eq(schema.EntityInstance.id, b))
+    )[0]?.at
+
+    const again = await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+
+    expect(again.scanned).toBe(1)
+    expect(await pairCount(f.orgId)).toBe(1)
+    // Sanity: the instance row really was untouched, so `updatedAt` alone could
+    // never have found this record.
+    const afterInstanceUpdatedAt = (
+      await db()
+        .select({ at: schema.EntityInstance.updatedAt })
+        .from(schema.EntityInstance)
+        .where(eq(schema.EntityInstance.id, b))
+    )[0]?.at
+    expect(afterInstanceUpdatedAt?.getTime()).toBe(beforeInstanceUpdatedAt?.getTime())
+    expect(a).toBeTruthy()
+  })
+
+  it('closes a pair whose evidence is gone (rescore-on-change)', async () => {
+    const f = await seedContactOrg()
+    await seedContact(f, 'A', { email: 'same@example.com' })
+    const b = await seedContact(f, 'B', { email: 'same@example.com' })
+    await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+    expect(await pairCount(f.orgId)).toBe(1)
+
+    await db().execute(sql`
+      UPDATE "FieldValue"
+      SET "valueText" = 'corrected@example.com', "updatedAt" = now() + interval '1 second'
+      WHERE "entityId" = ${b} AND "fieldId" = ${f.emailFieldId}
+    `)
+
+    const again = await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+    expect(again.closed).toBe(1)
+    expect(await pairCount(f.orgId)).toBe(0)
+  })
+
+  it('skips an org without the feature flag', async () => {
+    const f = await seedContactOrg()
+    flags.enabled.delete(f.orgId)
+    await seedContact(f, 'A', { phone: '+12133734253' })
+    await seedContact(f, 'B', { phone: '+12133734253' })
+
+    const stats = await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+
+    expect(stats.scanned).toBe(0)
+    expect(await pairCount(f.orgId)).toBe(0)
+  })
+
+  it('never scans an archived record as a subject', async () => {
+    // `EntityInstance_org_def_dup_scan_idx` is PARTIAL on `archivedAt IS NULL`,
+    // so the predicate has to carry it — and it is correct on its own terms.
+    const f = await seedContactOrg()
+    const a = await seedContact(f, 'A', { phone: '+12133734253' })
+    await seedContact(f, 'B', { phone: '+12133734253' })
+    await db()
+      .update(schema.EntityInstance)
+      .set({ archivedAt: new Date() })
+      .where(eq(schema.EntityInstance.id, a))
+
+    const stats = await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+
+    expect(stats.scanned).toBe(1)
+    expect(await pairCount(f.orgId)).toBe(0)
+  })
+})
+
+describe('duplicateScanJob — recordIds scope (the sync-manifest door)', () => {
+  it('scans exactly the manifest ids', async () => {
+    const f = await seedContactOrg()
+    const a = await seedContact(f, 'A', { phone: '+12133734253' })
+    const b = await seedContact(f, 'B', { phone: '+12133734253' })
+    await seedContact(f, 'C', { phone: '+12125551234' })
+
+    const stats = await runJob({
+      organizationId: f.orgId,
+      recordIds: [`${f.defId}:${a}`, `${f.defId}:${b}`],
+    })
+
+    expect(stats.scanned).toBe(2)
+    expect(await pairCount(f.orgId)).toBe(1)
+  })
+
+  it('refuses ids from another organization', async () => {
+    const f = await seedContactOrg()
+    const other = await seedContactOrg()
+    const foreign = await seedContact(other, 'X', { phone: '+12133734253' })
+
+    const stats = await runJob({
+      organizationId: f.orgId,
+      recordIds: [`${other.defId}:${foreign}`],
+    })
+
+    expect(stats.scanned).toBe(0)
+  })
+
+  it('is idempotent — re-running the same manifest writes one pair', async () => {
+    const f = await seedContactOrg()
+    const a = await seedContact(f, 'A', { phone: '+12133734253' })
+    const b = await seedContact(f, 'B', { phone: '+12133734253' })
+    const ids = [`${f.defId}:${a}`, `${f.defId}:${b}`]
+
+    await runJob({ organizationId: f.orgId, recordIds: ids })
+    await runJob({ organizationId: f.orgId, recordIds: ids })
+
+    expect(await pairCount(f.orgId)).toBe(1)
+  })
+})
+
+describe('duplicateScanJob — no scope (the 6h sweep)', () => {
+  it('walks feature-enabled orgs × allowlisted definitions', async () => {
+    const f = await seedContactOrg()
+    await seedContact(f, 'A', { email: 'sweep@example.com' })
+    await seedContact(f, 'B', { email: 'sweep@example.com' })
+
+    const stats = await runJob({ dryRun: false })
+
+    expect(stats.definitions).toBeGreaterThanOrEqual(1)
+    expect(await pairCount(f.orgId)).toBe(1)
+  })
+
+  it('skips a definition whose entityType is not allowlisted', async () => {
+    const f = await seedContactOrg()
+    await db()
+      .update(schema.EntityDefinition)
+      .set({ entityType: 'ticket' })
+      .where(eq(schema.EntityDefinition.id, f.defId))
+    await seedContact(f, 'A', { email: 'sweep@example.com' })
+    await seedContact(f, 'B', { email: 'sweep@example.com' })
+
+    const stats = await runJob({ dryRun: false })
+
+    expect(stats.definitions).toBe(0)
+    expect(await pairCount(f.orgId)).toBe(0)
+  })
+
+  it('dryRun writes no pairs and stamps no watermark', async () => {
+    const f = await seedContactOrg()
+    const a = await seedContact(f, 'A', { email: 'dry@example.com' })
+    await seedContact(f, 'B', { email: 'dry@example.com' })
+
+    await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId, dryRun: true })
+
+    expect(await pairCount(f.orgId)).toBe(0)
+    expect(await watermark(a)).toBeNull()
+  })
+})

--- a/packages/lib/src/jobs/dedup/duplicate-scan-job.ts
+++ b/packages/lib/src/jobs/dedup/duplicate-scan-job.ts
@@ -1,0 +1,548 @@
+// packages/lib/src/jobs/dedup/duplicate-scan-job.ts
+//
+// ONE job, three scopes. Every door into duplicate detection — the interactive
+// mutation seam, the sync-change manifest consumer, and the 6h sweep — enqueues
+// THIS handler; only the job data differs. The handler itself is always
+// watermark-driven, so a coalesced burst and a scheduled backfill run exactly
+// the same code against exactly the same dirty predicate.
+
+import { database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { parseRecordId, type RecordId } from '@auxx/types/resource'
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm'
+import { getCachedResourceFields } from '../../cache'
+import { blockIdentity, blockOrgKey, blockRecord } from '../../dedup/blocking'
+import { DEDUP_V1_ALLOWLIST, getDedupConfig } from '../../dedup/config'
+import { deriveMatchKeys, type MatchKey } from '../../dedup/match-keys'
+import { rescoreOpenPairsForRecord, upsertPairs } from '../../dedup/pairs'
+import type { ScoredPair } from '../../dedup/scoring'
+import { scoreBlockGroup, scoreIdentityGroup, scoreRecordMatches } from '../../dedup/scoring'
+import type { DedupConfig } from '../../dedup/types'
+import { FeaturePermissionService } from '../../permissions/feature-permission-service'
+import { FeatureKey } from '../../permissions/types'
+import type { JobContext } from '../types'
+
+const logger = createScopedLogger('job:duplicate-scan')
+
+/** Max dirty records processed per (org × definition) per tick. */
+const RECORDS_PER_DEFINITION = 500
+
+/**
+ * Dirty-set size above which the org-level passes (`blockOrgKey`,
+ * `blockIdentity`) are cheaper than N per-record lookups and run alongside them.
+ */
+const ORG_PASS_DIRTY_THRESHOLD = 50
+
+/**
+ * Scope of one scan, resolved from the job data — there is no `mode` field,
+ * because the three doors differ only in what they know:
+ *
+ *  - `recordIds` present → scan exactly those records (the sync-manifest door;
+ *    the ids carry their definition, so no watermark query is needed to FIND
+ *    them — though their watermark is still stamped);
+ *  - `organizationId` + `entityDefinitionId` → the watermark query for that
+ *    definition's dirty records (the coalesced mutation-seam door);
+ *  - neither → walk feature-enabled orgs × allowlisted definitions (the 6h
+ *    sweep; also the only path that runs the org-level passes unconditionally).
+ */
+export interface DuplicateScanJobData {
+  organizationId?: string
+  entityDefinitionId?: string
+  /** `RecordId`s (`entityDefinitionId:instanceId`), from a sync-change manifest. */
+  recordIds?: string[]
+  /** Block, score and log — write no pairs and bump no watermark. */
+  dryRun?: boolean
+}
+
+export interface DuplicateScanJobStats {
+  /** (org × definition) pairs actually scanned. */
+  definitions: number
+  /** Records blocked + scored. */
+  scanned: number
+  /** Pairs inserted or refreshed. */
+  upserted: number
+  /** Stale `open` pairs deleted by the rescore arm. */
+  closed: number
+  elapsedMs: number
+}
+
+/** One (org, definition) the scan can run against. */
+interface ScanTarget {
+  organizationId: string
+  entityDefinitionId: string
+  /** `EntityDefinition.entityType` — `null` for org-created definitions (never scanned in v1). */
+  entityType: string | null
+}
+
+/**
+ * Duplicate scan — block, score and store `DuplicateSuggestion` pairs for every
+ * dirty record in scope.
+ *
+ * Per record: `deriveMatchKeys` → `blockRecord` → `scoreRecordMatches` →
+ * `upsertPairs` → `rescoreOpenPairsForRecord` → stamp `lastDuplicateScanAt`.
+ * The rescore step is not optional: without it the store is upsert-only and a
+ * corrected email leaves its duplicate suggestion standing forever.
+ *
+ * Never throws — a scan failure must not fail whatever enqueued it. Per-record
+ * failures are logged and skipped so one garbage row cannot take down the tick.
+ */
+export async function duplicateScanJob(
+  ctx: JobContext<DuplicateScanJobData>
+): Promise<DuplicateScanJobStats> {
+  const data = ctx.job?.data ?? ({} as DuplicateScanJobData)
+  const { organizationId, entityDefinitionId, recordIds, dryRun = false } = data
+  const startedAt = Date.now()
+
+  const stats = { definitions: 0, scanned: 0, upserted: 0, closed: 0 }
+  const featureCache = new Map<string, boolean>()
+
+  logger.info('Starting duplicate scan', {
+    organizationId,
+    entityDefinitionId,
+    recordCount: recordIds?.length,
+    dryRun,
+    jobId: ctx.job?.id,
+  })
+
+  try {
+    if (recordIds && recordIds.length > 0) {
+      // ── Manifest scope ────────────────────────────────────────────────────
+      if (!organizationId) {
+        logger.warn('duplicateScanJob received recordIds with no organizationId — bailing')
+        return { ...stats, elapsedMs: Date.now() - startedAt }
+      }
+      if (!(await isEnabled(organizationId, featureCache))) {
+        return { ...stats, elapsedMs: Date.now() - startedAt }
+      }
+
+      for (const [defId, instanceIds] of groupByDefinition(recordIds)) {
+        const target = await loadTarget(organizationId, defId)
+        if (!target) continue
+        accumulate(stats, await scanDefinition({ target, instanceIds, dryRun }))
+      }
+    } else if (organizationId && entityDefinitionId) {
+      // ── Coalesced mutation-seam scope ─────────────────────────────────────
+      if (!(await isEnabled(organizationId, featureCache))) {
+        return { ...stats, elapsedMs: Date.now() - startedAt }
+      }
+      const target = await loadTarget(organizationId, entityDefinitionId)
+      if (target) accumulate(stats, await scanDefinition({ target, dryRun }))
+    } else {
+      // ── Scheduled sweep ───────────────────────────────────────────────────
+      for (const target of await listSweepTargets(organizationId)) {
+        if (!(await isEnabled(target.organizationId, featureCache))) continue
+        accumulate(stats, await scanDefinition({ target, dryRun, forceOrgPasses: true }))
+      }
+    }
+  } catch (error) {
+    logger.error('Duplicate scan failed', {
+      organizationId,
+      entityDefinitionId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  const result = { ...stats, elapsedMs: Date.now() - startedAt }
+  logger.info('Duplicate scan finished', result)
+  return result
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCOPE RESOLUTION
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Feature check, memoized per tick. `hasAccess` is org-cache-backed, but the
+ * sweep asks the same question once per definition and an org commonly has both
+ * `contact` and `company`.
+ */
+async function isEnabled(organizationId: string, cache: Map<string, boolean>): Promise<boolean> {
+  const cached = cache.get(organizationId)
+  if (cached !== undefined) return cached
+  const features = new FeaturePermissionService()
+  const enabled = await features.hasAccess(organizationId, FeatureKey.duplicateDetection)
+  cache.set(organizationId, enabled)
+  return enabled
+}
+
+/** Group manifest `RecordId`s by their definition — one scan pass per definition. */
+function groupByDefinition(recordIds: string[]): Map<string, string[]> {
+  const byDef = new Map<string, string[]>()
+  for (const raw of recordIds) {
+    const { entityDefinitionId, entityInstanceId } = parseRecordId(raw as RecordId)
+    if (!entityDefinitionId || !entityInstanceId) continue
+    const bucket = byDef.get(entityDefinitionId)
+    if (bucket) bucket.push(entityInstanceId)
+    else byDef.set(entityDefinitionId, [entityInstanceId])
+  }
+  return byDef
+}
+
+async function loadTarget(
+  organizationId: string,
+  entityDefinitionId: string
+): Promise<ScanTarget | null> {
+  const [row] = await database
+    .select({ entityType: schema.EntityDefinition.entityType })
+    .from(schema.EntityDefinition)
+    .where(
+      and(
+        eq(schema.EntityDefinition.id, entityDefinitionId),
+        eq(schema.EntityDefinition.organizationId, organizationId),
+        isNull(schema.EntityDefinition.archivedAt)
+      )
+    )
+    .limit(1)
+
+  if (!row) return null
+  return { organizationId, entityDefinitionId, entityType: row.entityType }
+}
+
+/**
+ * Every (org, definition) the sweep walks: live definitions whose `entityType`
+ * is on the v1 allowlist, in orgs that are not disabled. Feature filtering
+ * happens per org in the caller (the `filterByTodayInboxFlag` pattern) so the
+ * memo can be shared with the other two scopes.
+ */
+async function listSweepTargets(onlyOrganizationId?: string): Promise<ScanTarget[]> {
+  const conditions = [
+    inArray(schema.EntityDefinition.entityType, [...DEDUP_V1_ALLOWLIST]),
+    isNull(schema.EntityDefinition.archivedAt),
+    isNull(schema.Organization.disabledAt),
+  ]
+  if (onlyOrganizationId) {
+    conditions.push(eq(schema.EntityDefinition.organizationId, onlyOrganizationId))
+  }
+
+  return database
+    .select({
+      organizationId: schema.EntityDefinition.organizationId,
+      entityDefinitionId: schema.EntityDefinition.id,
+      entityType: schema.EntityDefinition.entityType,
+    })
+    .from(schema.EntityDefinition)
+    .innerJoin(
+      schema.Organization,
+      eq(schema.Organization.id, schema.EntityDefinition.organizationId)
+    )
+    .where(and(...conditions))
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE SCAN
+// ═══════════════════════════════════════════════════════════════════════════
+
+interface ScanCounts {
+  definitions: number
+  scanned: number
+  upserted: number
+  closed: number
+}
+
+const NO_WORK: ScanCounts = { definitions: 0, scanned: 0, upserted: 0, closed: 0 }
+
+function accumulate(into: ScanCounts, from: ScanCounts): void {
+  into.definitions += from.definitions
+  into.scanned += from.scanned
+  into.upserted += from.upserted
+  into.closed += from.closed
+}
+
+/** One record the scan will process, with the watermark it will be stamped with. */
+interface DirtyRecord {
+  id: string
+  /**
+   * `GREATEST(ei."updatedAt", max(fv."updatedAt"))` as it was OBSERVED — bound
+   * as text, never as a `Date`, so nothing re-interprets a `timestamp without
+   * time zone` in the session timezone on the way back in.
+   *
+   * Stamping the OBSERVED watermark rather than `now()` is what closes the
+   * scan-window race: a write that lands while this record is being blocked
+   * leaves a `FieldValue.updatedAt` newer than the stamp, so the record stays
+   * dirty and the next tick picks it up.
+   */
+  dirtyAt: string
+}
+
+async function scanDefinition(args: {
+  target: ScanTarget
+  /** Explicit records (manifest door). Omitted → the watermark query decides. */
+  instanceIds?: string[]
+  dryRun: boolean
+  /** Scheduled sweep: run the org-level passes regardless of dirty-set size. */
+  forceOrgPasses?: boolean
+}): Promise<ScanCounts> {
+  const { target, instanceIds, dryRun, forceOrgPasses = false } = args
+  const { organizationId, entityDefinitionId } = target
+
+  const config = getDedupConfig(target.entityType)
+  if (!config) return NO_WORK
+
+  const fields = await getCachedResourceFields(organizationId, entityDefinitionId)
+  const keys = deriveMatchKeys(fields, config)
+  if (keys.length === 0) {
+    logger.debug('No strong match keys for definition — skipping', {
+      organizationId,
+      entityDefinitionId,
+      entityType: target.entityType,
+    })
+    return NO_WORK
+  }
+
+  const dirty = instanceIds
+    ? await selectLiveRecords(organizationId, entityDefinitionId, instanceIds)
+    : await selectDirtyRecords(organizationId, entityDefinitionId, RECORDS_PER_DEFINITION)
+
+  const counts: ScanCounts = { definitions: 1, scanned: 0, upserted: 0, closed: 0 }
+
+  for (const record of dirty) {
+    try {
+      accumulate(
+        counts,
+        await scanRecord({ organizationId, entityDefinitionId, config, keys, record, dryRun })
+      )
+    } catch (error) {
+      logger.error('Record scan threw', {
+        organizationId,
+        entityDefinitionId,
+        instanceId: record.id,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  // Org-level passes find pairs where NEITHER side is dirty (a backfill), and
+  // once a definition's dirty set is large they are cheaper than N per-record
+  // lookups. They only UPSERT — rescoring stays a per-record responsibility,
+  // because only the scanned record has a complete fresh pair set.
+  if (!dryRun && (forceOrgPasses || dirty.length >= ORG_PASS_DIRTY_THRESHOLD)) {
+    accumulate(counts, await runOrgPasses({ organizationId, entityDefinitionId, config, keys }))
+  }
+
+  return counts
+}
+
+async function scanRecord(args: {
+  organizationId: string
+  entityDefinitionId: string
+  config: DedupConfig
+  keys: MatchKey[]
+  record: DirtyRecord
+  dryRun: boolean
+}): Promise<ScanCounts> {
+  const { organizationId, entityDefinitionId, config, keys, record, dryRun } = args
+  const db = database
+
+  const matches = await blockRecord(db, {
+    organizationId,
+    entityDefinitionId,
+    instanceId: record.id,
+    keys,
+    blockCap: config.blockCap,
+  })
+  if (matches.isErr()) {
+    logger.warn('Blocking failed for record', {
+      organizationId,
+      entityDefinitionId,
+      instanceId: record.id,
+      error: matches.error.message,
+    })
+    return NO_WORK
+  }
+
+  const scored = scoreRecordMatches({
+    organizationId,
+    entityDefinitionId,
+    instanceId: record.id,
+    matches: matches.value,
+  })
+
+  if (dryRun) {
+    logger.info('dry run — pairs not written', {
+      organizationId,
+      entityDefinitionId,
+      instanceId: record.id,
+      pairs: scored.length,
+    })
+    return { definitions: 0, scanned: 1, upserted: 0, closed: 0 }
+  }
+
+  const upserted = await upsertPairs(db, scored)
+  if (upserted.isErr()) {
+    logger.warn('Pair upsert failed', {
+      organizationId,
+      entityDefinitionId,
+      instanceId: record.id,
+      error: upserted.error.message,
+    })
+  }
+
+  const closed = await rescoreOpenPairsForRecord(db, {
+    organizationId,
+    entityDefinitionId,
+    instanceId: record.id,
+    pairs: scored,
+  })
+
+  await stampWatermark(organizationId, record)
+
+  return {
+    definitions: 0,
+    scanned: 1,
+    upserted: upserted.isOk() ? upserted.value : 0,
+    closed: closed.isOk() ? closed.value : 0,
+  }
+}
+
+async function runOrgPasses(args: {
+  organizationId: string
+  entityDefinitionId: string
+  config: DedupConfig
+  keys: MatchKey[]
+}): Promise<ScanCounts> {
+  const { organizationId, entityDefinitionId, config, keys } = args
+  const db = database
+  const pairs: ScoredPair[] = []
+
+  for (const key of keys) {
+    const groups = await blockOrgKey(db, {
+      organizationId,
+      entityDefinitionId,
+      key,
+      blockCap: config.blockCap,
+    })
+    if (groups.isErr()) continue
+    for (const group of groups.value) {
+      pairs.push(...scoreBlockGroup({ organizationId, entityDefinitionId, group }))
+    }
+  }
+
+  const identities = await blockIdentity(db, {
+    organizationId,
+    entityDefinitionId,
+    blockCap: config.blockCap,
+  })
+  if (identities.isOk()) {
+    for (const group of identities.value) {
+      pairs.push(...scoreIdentityGroup({ organizationId, entityDefinitionId, group }))
+    }
+  }
+
+  if (pairs.length === 0) return NO_WORK
+  const written = await upsertPairs(db, pairs)
+  return {
+    definitions: 0,
+    scanned: 0,
+    upserted: written.isOk() ? written.value : 0,
+    closed: 0,
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE WATERMARK
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * `GREATEST(ei."updatedAt", max(fv."updatedAt"))` — the only dirty predicate
+ * that survives a `skipEvents` writer.
+ *
+ * A connector sync or CSV import leaves BOTH `EntityInstance.updatedAt` and
+ * `lastActivityAt` untouched (`touchEntityActivity` never runs, and the
+ * post-hook gate needs a `userId`), so `FieldValue.updatedAt` is the only
+ * timestamp that always moves. The lateral is a per-row aggregate rather than a
+ * join+GROUP BY so the outer row can be filtered and ordered without collapsing.
+ */
+const DIRTY_AT = sql`GREATEST(ei."updatedAt", COALESCE(fv."maxAt", ei."updatedAt"))`
+
+const FIELD_VALUE_LATERAL = sql`
+  LEFT JOIN LATERAL (
+    SELECT max(v."updatedAt") AS "maxAt"
+    FROM "FieldValue" v
+    WHERE v."entityId" = ei."id" AND v."organizationId" = ei."organizationId"
+  ) fv ON TRUE
+`
+
+/**
+ * The dirty records of one definition, oldest-dirty first.
+ *
+ * ⚠️ `archivedAt IS NULL` is NOT optional. `EntityInstance_org_def_dup_scan_idx`
+ * is a PARTIAL index (`WHERE "archivedAt" IS NULL`); without the matching
+ * predicate the planner cannot use it and this degrades to a full scan of the
+ * org's records. It is also correct on its own terms — an archived record is
+ * never a duplicate subject, and `blockRecord` already refuses to return one as
+ * a candidate.
+ */
+async function selectDirtyRecords(
+  organizationId: string,
+  entityDefinitionId: string,
+  limit: number
+): Promise<DirtyRecord[]> {
+  const result = await database.execute(sql`
+    SELECT ei."id" AS "id", ${DIRTY_AT}::text AS "dirtyAt"
+    FROM "EntityInstance" ei
+    ${FIELD_VALUE_LATERAL}
+    WHERE ei."organizationId" = ${organizationId}
+      AND ei."entityDefinitionId" = ${entityDefinitionId}
+      AND ei."archivedAt" IS NULL
+      AND (ei."lastDuplicateScanAt" IS NULL OR ${DIRTY_AT} > ei."lastDuplicateScanAt")
+    ORDER BY ${DIRTY_AT} ASC
+    LIMIT ${limit}
+  `)
+  return toDirtyRecords(result)
+}
+
+/**
+ * The same projection for an EXPLICIT id set (the manifest door): the ids are
+ * already known to be freshly written, so there is no watermark predicate — only
+ * the org/definition/archived guards, which stop a manifest from steering the
+ * scan at another org's rows.
+ */
+async function selectLiveRecords(
+  organizationId: string,
+  entityDefinitionId: string,
+  instanceIds: string[]
+): Promise<DirtyRecord[]> {
+  if (instanceIds.length === 0) return []
+  const ids = [...new Set(instanceIds)].slice(0, RECORDS_PER_DEFINITION)
+  // One bind per id rather than an array parameter: `= ANY($1::text[])` depends
+  // on the driver serialising a JS array into a Postgres array literal, which
+  // Drizzle's `sql` template does not promise for an interpolated value.
+  const idList = sql.join(
+    ids.map((id) => sql`${id}`),
+    sql`, `
+  )
+
+  const result = await database.execute(sql`
+    SELECT ei."id" AS "id", ${DIRTY_AT}::text AS "dirtyAt"
+    FROM "EntityInstance" ei
+    ${FIELD_VALUE_LATERAL}
+    WHERE ei."organizationId" = ${organizationId}
+      AND ei."entityDefinitionId" = ${entityDefinitionId}
+      AND ei."archivedAt" IS NULL
+      AND ei."id" IN (${idList})
+  `)
+  return toDirtyRecords(result)
+}
+
+function toDirtyRecords(result: unknown): DirtyRecord[] {
+  const rows = ((result as { rows?: unknown[] })?.rows ?? []) as Array<Record<string, unknown>>
+  return rows
+    .filter((row) => row.id != null && row.dirtyAt != null)
+    .map((row) => ({ id: String(row.id), dirtyAt: String(row.dirtyAt) }))
+}
+
+/**
+ * Stamp `lastDuplicateScanAt` with the watermark this scan OBSERVED.
+ *
+ * ⚠️ Raw SQL on purpose. `EntityInstance.updatedAt` carries `$onUpdate`, so a
+ * Drizzle `.update()` would bump `updatedAt` in the same statement — instantly
+ * re-dirtying the record against its own fresh watermark and looping the scanner
+ * forever. This statement touches exactly one column.
+ */
+async function stampWatermark(organizationId: string, record: DirtyRecord): Promise<void> {
+  await database.execute(sql`
+    UPDATE "EntityInstance"
+    SET "lastDuplicateScanAt" = ${record.dirtyAt}::timestamp
+    WHERE "id" = ${record.id} AND "organizationId" = ${organizationId}
+  `)
+}

--- a/packages/lib/src/jobs/index.ts
+++ b/packages/lib/src/jobs/index.ts
@@ -109,6 +109,12 @@ export {
   cleanupOrphanedDataJob,
   reindexDatasetJob,
 } from './datasets/maintenance-jobs'
+// Duplicate detection — ONE job, three scopes (mutation seam, sync manifest, 6h sweep)
+export {
+  type DuplicateScanJobData,
+  type DuplicateScanJobStats,
+  duplicateScanJob,
+} from './dedup/duplicate-scan-job'
 // Documents (money MQ2 PDF render pipeline)
 export {
   type RenderDocumentPdfJobData,

--- a/packages/lib/src/resources/crud/__tests__/archive-duplicate-pair-cleanup.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/archive-duplicate-pair-cleanup.test.ts
@@ -1,0 +1,96 @@
+// packages/lib/src/resources/crud/__tests__/archive-duplicate-pair-cleanup.test.ts
+//
+// One property, and it is a placement property: the archive path's
+// duplicate-pair cleanup sits OUTSIDE the `if (!options.skipEvents)` guard.
+//
+// Pair cleanup is data hygiene, not an event. In this product "delete" IS
+// archive, so the FK cascade essentially never fires for a real record — and the
+// bulk paths (`bulkArchiveEntities`, connector/import archives) are exactly the
+// ones that pass `skipEvents: true`. A cleanup call nested in the event guard
+// would therefore leak `open` pairs on precisely the highest-volume archive path
+// while looking correct on the interactive one.
+//
+// The delete SQL itself (which statuses survive) is pinned against real SQL in
+// `dedup/__tests__/archive-pair-cleanup.int.test.ts` — a fake db is
+// predicate-blind.
+
+import { ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  deleteOpenPairsForRecord: vi.fn(async () => ok(0)),
+  enqueueDuplicateScan: vi.fn(async () => 'job_1'),
+  publish: vi.fn(async () => {}),
+  publishLater: vi.fn(() => {}),
+}))
+
+vi.mock('../../../dedup/pairs', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  deleteOpenPairsForRecord: h.deleteOpenPairsForRecord,
+}))
+vi.mock('../../../dedup/enqueue-scan', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  enqueueDuplicateScan: h.enqueueDuplicateScan,
+}))
+
+vi.mock('@auxx/services/entity-instances', () => ({
+  getEntityInstance: vi.fn(async () => ok({ id: 'inst_1', archivedAt: null })),
+  updateEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+  createEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+  deleteEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+}))
+vi.mock('../../../realtime', () => ({
+  getRealtimeService: () => ({ publish: h.publish }),
+  rooms: { orgRecords: () => 'room' },
+}))
+vi.mock('../../../events/publisher', () => ({
+  publisher: { publishLater: h.publishLater, publish: h.publishLater },
+}))
+
+import { archiveEntity, type MutationContext } from '../unified-handler-mutations'
+
+function ctx(): MutationContext {
+  return {
+    db: {} as never,
+    organizationId: 'org_1',
+    userId: 'user_1',
+    fieldValueService: {} as never,
+    resolveEntityDefinition: async () => ({
+      id: 'def_1',
+      entityType: 'contact',
+      apiSlug: 'contacts',
+    }),
+    getFields: async () => [],
+    runPreHooks: async (_o, _d, values) => values,
+    validateUniqueFields: async () => {},
+    setFieldValues: async () => {},
+  }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('archiveEntity — duplicate-pair cleanup', () => {
+  it('deletes the record’s open pairs on an interactive archive', async () => {
+    await archiveEntity(ctx(), 'def_1:inst_1' as never)
+    expect(h.deleteOpenPairsForRecord).toHaveBeenCalledTimes(1)
+    expect(h.deleteOpenPairsForRecord).toHaveBeenCalledWith({}, 'org_1', 'inst_1')
+  })
+
+  it('still cleans up under skipEvents — this is the bulk-archive path', async () => {
+    await archiveEntity(ctx(), 'def_1:inst_1' as never, { skipEvents: true })
+    expect(h.publish).not.toHaveBeenCalled()
+    expect(h.deleteOpenPairsForRecord).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fail the archive when cleanup throws', async () => {
+    h.deleteOpenPairsForRecord.mockRejectedValueOnce(new Error('boom') as never)
+    await expect(archiveEntity(ctx(), 'def_1:inst_1' as never)).resolves.toMatchObject({
+      id: 'inst_1',
+    })
+  })
+
+  it('does not enqueue a scan — archiving is not a reason to re-scan', async () => {
+    await archiveEntity(ctx(), 'def_1:inst_1' as never)
+    expect(h.enqueueDuplicateScan).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/resources/crud/unified-handler-mutations.ts
+++ b/packages/lib/src/resources/crud/unified-handler-mutations.ts
@@ -13,6 +13,8 @@ import {
 import type { Result } from 'neverthrow'
 import { findCachedResource } from '../../cache'
 import { CommentService } from '../../comments'
+import { enqueueDuplicateScan } from '../../dedup/enqueue-scan'
+import { deleteOpenPairsForRecord } from '../../dedup/pairs'
 import { UnprocessableEntityError } from '../../errors'
 import { publisher } from '../../events/publisher'
 import type { Events } from '../../events/types'
@@ -439,6 +441,13 @@ export async function createEntity(
         { excludeSocketId: ctx.socketId }
       )
       .catch(() => {})
+
+    // Duplicate scan, coalesced per (org, definition). Fire-and-forget: a scan
+    // must never be able to fail a write. NO recordId is passed — the handler is
+    // watermark-driven, so a burst of creates (a first-connect mailbox sync going
+    // through `findOrCreate` fires this seam live, hundreds of times) collapses
+    // onto ONE delayed job under the shared jobId.
+    enqueueDuplicateScan(ctx.organizationId, entityDef.id).catch(() => {})
   }
 
   // Return the fresh instance so callers (e.g. the create_entity tool) have a
@@ -545,6 +554,9 @@ export async function updateEntity(
         { excludeSocketId: ctx.socketId }
       )
       .catch(() => {})
+
+    // Coalesced duplicate scan — see the note on the create path.
+    enqueueDuplicateScan(ctx.organizationId, entityDef.id).catch(() => {})
   }
 
   // Return the fresh instance so callers see the post-update denormalized columns.
@@ -605,6 +617,20 @@ export async function archiveEntity(
         { excludeSocketId: ctx.socketId }
       )
       .catch(() => {})
+  }
+
+  // Duplicate-suggestion cleanup — deliberately OUTSIDE the `skipEvents` guard.
+  // Pair cleanup is data hygiene, not an event: a `skipEvents` bulk archive must
+  // still clean up after itself. Only `open` rows go; `dismissed` carries the
+  // band that governs reopen and `merged` is the audit trail.
+  // (`bulkArchiveEntities` delegates here per record, so it is covered too.)
+  try {
+    await deleteOpenPairsForRecord(ctx.db, ctx.organizationId, entityInstanceId)
+  } catch (error) {
+    logger.warn('Duplicate-pair cleanup failed on archive', {
+      recordId,
+      error: error instanceof Error ? error.message : String(error),
+    })
   }
 
   // Return the instance we already fetched (archivedAt is the only change)
@@ -863,6 +889,9 @@ export async function bulkArchiveEntities(
   let count = 0
   for (const recordId of recordIds) {
     try {
+      // Delegates per record, so `archiveEntity`'s duplicate-pair cleanup covers
+      // the bulk path too — including under `skipEvents`, where it sits outside
+      // the event guard precisely so this loop still cleans up.
       await archiveEntity(ctx, recordId, {
         skipEvents: options.skipEvents,
       })


### PR DESCRIPTION
Makes the dedup engine actually run. One watermark-driven job reached through
four doors, plus archive cleanup.

The scan job resolves its scope from the job data: explicit `recordIds`
(sync-manifest path), org+def (mutation-seam path), or unscoped (the 6h sweep,
which walks feature-enabled orgs x allowlisted defs).

Coalescing is org+def-scoped, not per-record: ingest fires the mutation seam
live even during a first-connect backfill, so a per-record jobId would enqueue
one job per created contact. A stable `dup-scan:{org}:{def}` jobId plus a 45s
delay absorbs any burst source.

The watermark stamp is raw SQL touching exactly one column. `EntityInstance`
carries `$onUpdate` on `updatedAt`, so a Drizzle `.update()` would bump it in
the same statement, instantly re-dirtying the record against its own fresh
watermark and looping the scanner forever. It also writes back the OBSERVED
watermark rather than `now()`, so a FieldValue write landing mid-scan is not
swallowed.

The `sync:records:changed` consumer deliberately does NOT claim the manifest —
`claimManifest` is the record-rules consumer's once-only latch and a second
claimant would starve it. At-most-once comes from the jobId, and pair upserts
are idempotent.

Archiving deletes the record's `open` pairs, leaving `dismissed` (it carries the
band governing reopen) and `merged` (terminal) intact. The call sits outside the
`skipEvents` guard so bulk archives still clean up. No restore hook is needed:
`$onUpdate` re-dirties a restored record and the next scan recreates the pair.

Tests: 21 unit + 13 DB-backed integration.

---
**Stacked on #1640** — base is `feat/dedup-engine`, retarget to `main` once that merges.

This is where the runtime-behaviour change lives: a fire-and-forget enqueue on every record create/update, a second consumer on `sync:records:changed`, a 6h scheduler, and pair cleanup on archive. Reviewed separately from the engine for that reason.

Plan: `plans/records/duplicate-suggestion-plan-v2.md`