### PR TITLE
feat(workflow): let knowledge retrieval search knowledge bases

### DIFF
--- a/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/index.ts
+++ b/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/index.ts
@@ -10,8 +10,9 @@ export {
   knowledgeRetrievalNodeDataSchema,
 } from './schema'
 export type {
-  DatasetEntry,
   KnowledgeRetrievalNode as KnowledgeRetrievalNodeType,
   KnowledgeRetrievalNodeData,
+  KnowledgeSourceRow,
   SearchType,
 } from './types'
+export { sourceFieldKey, sourceRawId } from './types'

--- a/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/node.tsx
+++ b/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/node.tsx
@@ -17,8 +17,8 @@ import type { KnowledgeRetrievalNodeData } from './types'
 export const KnowledgeRetrievalNode = memo<NodeProps<KnowledgeRetrievalNodeData>>(
   ({ id, data, selected }) => {
     const hasQuery = !!data.query
-    const datasetCount = data.datasets?.length ?? 0
-    const hasDatasets = datasetCount > 0
+    const sourceCount = data.sources?.length ?? 0
+    const hasSources = sourceCount > 0
 
     // Check if query is in variable mode
     const isQueryVariable =
@@ -39,7 +39,7 @@ export const KnowledgeRetrievalNode = memo<NodeProps<KnowledgeRetrievalNodeData>
         <NodeTargetHandle id={id} data={{ ...data, selected }} handleId='target' />
         <div className='space-y-1 pb-2'>
           <div className='relative px-2'>
-            {hasQuery || hasDatasets ? (
+            {hasQuery || hasSources ? (
               <div className='space-y-1 mt-1'>
                 {/* Query */}
                 {hasQuery && (
@@ -55,12 +55,12 @@ export const KnowledgeRetrievalNode = memo<NodeProps<KnowledgeRetrievalNodeData>
                   </div>
                 )}
 
-                {/* Datasets */}
-                {hasDatasets && (
+                {/* Knowledge sources */}
+                {hasSources && (
                   <div className='flex items-center gap-1 text-xs text-muted-foreground'>
-                    <span>Datasets:</span>
+                    <span>Knowledge:</span>
                     <span className='font-mono text-primary-600'>
-                      {datasetCount} {datasetCount === 1 ? 'dataset' : 'datasets'}
+                      {sourceCount} {sourceCount === 1 ? 'source' : 'sources'}
                     </span>
                   </div>
                 )}

--- a/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/output-variables.ts
+++ b/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/output-variables.ts
@@ -76,6 +76,42 @@ export function getKnowledgeRetrievalOutputVariables(
             label: 'Search Type',
             description: 'Type of search that found this result',
           },
+          source: {
+            type: BaseType.STRING,
+            label: 'Source',
+            description: "'kb' for a knowledge-base article, 'rag' for an uploaded document",
+          },
+          articleId: {
+            type: BaseType.STRING,
+            label: 'Article ID',
+            description: 'ID of the KB article (KB results only)',
+          },
+          articleSlug: {
+            type: BaseType.STRING,
+            label: 'Article Slug',
+            description: 'Slug of the KB article (KB results only)',
+          },
+          articleSlugPath: {
+            type: BaseType.STRING,
+            label: 'Article Slug Path',
+            description: 'Full slug path of the KB article within its KB (KB results only)',
+          },
+          kbId: {
+            type: BaseType.STRING,
+            label: 'Knowledge Base ID',
+            description: 'ID of the knowledge base (KB results only)',
+          },
+          kbSlug: {
+            type: BaseType.STRING,
+            label: 'Knowledge Base Slug',
+            description: 'Slug of the knowledge base (KB results only)',
+          },
+          docSlug: {
+            type: BaseType.STRING,
+            label: 'Doc Slug',
+            description:
+              'kbSlug/articleSlugPath — cite as [Title](auxx://doc/<docSlug>) (KB results only)',
+          },
         },
       },
     }),

--- a/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/panel.tsx
@@ -3,9 +3,16 @@
 'use client'
 
 import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
 import { InputGroup, InputGroupAddon } from '@auxx/ui/components/input-group'
+import { Switch } from '@auxx/ui/components/switch'
 import { produce } from 'immer'
-import { Plus, Trash2 } from 'lucide-react'
+import { BookOpen, Database, Plus, Trash2 } from 'lucide-react'
 import type React from 'react'
 import { memo, useCallback } from 'react'
 import { useNodeCrud, useReadOnly } from '~/components/workflow/hooks'
@@ -21,7 +28,12 @@ import { OutputVariablesDisplay } from '~/components/workflow/ui/output-variable
 import Section from '~/components/workflow/ui/section'
 import { BasePanel } from '../../shared/base/base-panel'
 import { getKnowledgeRetrievalOutputVariables } from './output-variables'
-import type { KnowledgeRetrievalNodeData } from './types'
+import {
+  type KnowledgeRetrievalNodeData,
+  type KnowledgeSourceRow,
+  sourceFieldKey,
+  sourceRawId,
+} from './types'
 
 interface KnowledgeRetrievalPanelProps {
   nodeId: string
@@ -46,7 +58,7 @@ const KnowledgeRetrievalPanelComponent: React.FC<KnowledgeRetrievalPanelProps> =
   const { inputs: nodeData, setInputs } = useNodeCrud<KnowledgeRetrievalNodeData>(nodeId, data)
   const { isReadOnly } = useReadOnly()
 
-  const datasets = nodeData.datasets || []
+  const sources = nodeData.sources || []
 
   /**
    * Generic handler for string field changes
@@ -92,33 +104,18 @@ const KnowledgeRetrievalPanelComponent: React.FC<KnowledgeRetrievalPanelProps> =
   )
 
   /**
-   * Add a new dataset entry
+   * Add a source row. Kind is chosen up front and stored — see
+   * {@link KnowledgeSourceRow}.
    */
-  const handleAddDataset = useCallback(() => {
-    if (isReadOnly) return
-
-    const newData = produce(nodeData, (draft) => {
-      if (!draft.datasets) draft.datasets = []
-      draft.datasets.push({ datasetId: '' })
-    })
-    setInputs(newData)
-  }, [nodeData, setInputs, isReadOnly])
-
-  /**
-   * Remove a dataset entry
-   */
-  const handleRemoveDataset = useCallback(
-    (index: number) => {
+  const handleAddSource = useCallback(
+    (kind: KnowledgeSourceRow['kind']) => {
       if (isReadOnly) return
 
       const newData = produce(nodeData, (draft) => {
-        if (draft.datasets) {
-          draft.datasets.splice(index, 1)
-        }
-        // Clean up field modes for removed index
-        if (draft.fieldModes) {
-          delete draft.fieldModes[`datasets.${index}.datasetId`]
-        }
+        if (!draft.sources) draft.sources = []
+        draft.sources.push(
+          kind === 'kb' ? { kind: 'kb', knowledgeBaseId: '' } : { kind: 'dataset', datasetId: '' }
+        )
       })
       setInputs(newData)
     },
@@ -126,17 +123,76 @@ const KnowledgeRetrievalPanelComponent: React.FC<KnowledgeRetrievalPanelProps> =
   )
 
   /**
-   * Update a dataset entry
+   * Remove a source row.
+   *
+   * The `fieldModes` keys are positional (`sources.<i>.…`), so removing a row
+   * shifts every later row's key. Deleting only the removed index — which is
+   * what this used to do — left rows after it reading the wrong mode: remove
+   * row 0 of three and rows 1–2 silently inherit each other's constant/variable
+   * setting. Rebuild the whole `sources.*` block instead.
    */
-  const handleDatasetChange = useCallback(
-    (index: number, datasetId: VarEditorValue, isConstantMode: boolean) => {
+  const handleRemoveSource = useCallback(
+    (index: number) => {
+      if (isReadOnly) return
+
       const newData = produce(nodeData, (draft) => {
-        if (!draft.datasets) draft.datasets = []
-        const entry = draft.datasets[index] ?? { datasetId: '' }
-        entry.datasetId = varEditorText(datasetId)
-        draft.datasets[index] = entry
+        if (!draft.sources) return
+        // Capture each row's mode by its CURRENT index before the splice.
+        const modes = draft.sources.map((row, i) => draft.fieldModes?.[sourceFieldKey(row, i)])
+
+        draft.sources.splice(index, 1)
+        modes.splice(index, 1)
+
+        if (draft.fieldModes) {
+          for (const key of Object.keys(draft.fieldModes)) {
+            if (key.startsWith('sources.')) delete draft.fieldModes[key]
+          }
+        } else {
+          draft.fieldModes = {}
+        }
+        draft.sources.forEach((row, i) => {
+          const mode = modes[i]
+          if (mode !== undefined) draft.fieldModes![sourceFieldKey(row, i)] = mode
+        })
+      })
+      setInputs(newData)
+    },
+    [nodeData, setInputs, isReadOnly]
+  )
+
+  /**
+   * Update a source row's id, keeping its stored kind.
+   */
+  const handleSourceChange = useCallback(
+    (index: number, value: VarEditorValue, isConstantMode: boolean) => {
+      const newData = produce(nodeData, (draft) => {
+        if (!draft.sources) return
+        const row = draft.sources[index]
+        if (!row) return
+
+        const id = varEditorText(value)
+        if (row.kind === 'kb') {
+          row.knowledgeBaseId = id
+        } else {
+          row.datasetId = id
+        }
         if (!draft.fieldModes) draft.fieldModes = {}
-        draft.fieldModes[`datasets.${index}.datasetId`] = isConstantMode
+        draft.fieldModes[sourceFieldKey(row, index)] = isConstantMode
+      })
+      setInputs(newData)
+    },
+    [nodeData, setInputs]
+  )
+
+  /**
+   * Toggle a plain boolean setting (no variable binding).
+   */
+  const handleToggleChange = useCallback(
+    (field: 'dedupePerDocument', checked: boolean) => {
+      const newData = produce(nodeData, (draft) => {
+        draft[field] = checked
+        if (!draft.fieldModes) draft.fieldModes = {}
+        draft.fieldModes[field] = true
       })
       setInputs(newData)
     },
@@ -167,38 +223,50 @@ const KnowledgeRetrievalPanelComponent: React.FC<KnowledgeRetrievalPanelProps> =
         </VarEditorField>
       </Section>
 
-      {/* Datasets Section */}
+      {/* Knowledge Section */}
       <Section
-        title='Datasets'
-        description='Select one or more datasets to search across'
+        title='Knowledge'
+        description='Select the knowledge bases and datasets to search across'
         isRequired
         initialOpen
         actions={
           !isReadOnly && (
-            <Button variant='ghost' size='xs' onClick={handleAddDataset}>
-              <Plus /> Add
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant='ghost' size='xs'>
+                  <Plus /> Add
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align='end'>
+                <DropdownMenuItem onClick={() => handleAddSource('kb')}>
+                  <BookOpen /> Knowledge base
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => handleAddSource('dataset')}>
+                  <Database /> Dataset
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )
         }>
         <div className='space-y-4'>
-          {datasets.length > 0 && (
+          {sources.length > 0 && (
             <div className='space-y-2'>
-              {datasets.map((entry, index) => {
-                const fieldKey = `datasets.${index}.datasetId`
-                const isConstantMode = nodeData.fieldModes?.[fieldKey] ?? true
+              {sources.map((row, index) => {
+                const isKb = row.kind === 'kb'
+                const isConstantMode = nodeData.fieldModes?.[sourceFieldKey(row, index)] ?? true
 
                 return (
                   <InputGroup key={index} className='flex items-center gap-2 ps-1 rounded-2xl'>
                     <VarEditor
                       nodeId={nodeId}
-                      value={entry.datasetId}
-                      onChange={(v, m) => handleDatasetChange(index, v, m)}
+                      value={sourceRawId(row)}
+                      onChange={(v, m) => handleSourceChange(index, v, m)}
                       varType={BaseType.RELATION}
-                      fieldOptions={{ fieldReference: 'dataset' }}
-                      allowedTypes={['dataset' as BaseType, BaseType.STRING]}
+                      fieldOptions={{ fieldReference: isKb ? 'kb' : 'dataset' }}
+                      allowedTypes={[(isKb ? 'kb' : 'dataset') as BaseType, BaseType.STRING]}
                       mode={VAR_MODE.PICKER}
-                      placeholder='Select dataset'
-                      placeholderConstant='Select dataset'
+                      placeholder={isKb ? 'Select knowledge base' : 'Select dataset'}
+                      placeholderConstant={isKb ? 'Select knowledge base' : 'Select dataset'}
                       allowConstant
                       hideClearButton
                       isConstantMode={isConstantMode}
@@ -209,7 +277,7 @@ const KnowledgeRetrievalPanelComponent: React.FC<KnowledgeRetrievalPanelProps> =
                         <Button
                           size='icon-xs'
                           variant='destructive-hover'
-                          onClick={() => handleRemoveDataset(index)}>
+                          onClick={() => handleRemoveSource(index)}>
                           <Trash2 />
                         </Button>
                       </InputGroupAddon>
@@ -220,9 +288,9 @@ const KnowledgeRetrievalPanelComponent: React.FC<KnowledgeRetrievalPanelProps> =
             </div>
           )}
 
-          {datasets.length === 0 && (
+          {sources.length === 0 && (
             <div className='text-sm text-muted-foreground text-center py-4'>
-              No datasets selected. Click the + button to add datasets to search.
+              No knowledge selected. Use Add to search a knowledge base or a dataset.
             </div>
           )}
         </div>
@@ -259,7 +327,7 @@ const KnowledgeRetrievalPanelComponent: React.FC<KnowledgeRetrievalPanelProps> =
 
           <VarEditorFieldRow
             title='Limit'
-            description='Maximum number of results to return (1-100)'
+            description='Maximum number of results to return (1-25). Knowledge passages are prose — a large limit makes a large prompt if these results feed an AI or Answer node.'
             type={BaseType.NUMBER}
             onClear={
               nodeData.limit != null && nodeData.limit !== ''
@@ -283,7 +351,7 @@ const KnowledgeRetrievalPanelComponent: React.FC<KnowledgeRetrievalPanelProps> =
 
           <VarEditorFieldRow
             title='Similarity Threshold'
-            description='Minimum similarity score for vector search (0.0-1.0)'
+            description='Minimum similarity score for vector search (0.0-1.0). Leave empty to use the search default.'
             type={BaseType.NUMBER}
             onClear={
               nodeData.similarityThreshold != null && nodeData.similarityThreshold !== ''
@@ -302,11 +370,22 @@ const KnowledgeRetrievalPanelComponent: React.FC<KnowledgeRetrievalPanelProps> =
               varType={BaseType.NUMBER}
               allowedTypes={[BaseType.NUMBER]}
               mode={VAR_MODE.PICKER}
-              placeholder='0.7'
-              placeholderConstant='0.7'
+              placeholder='0.4'
+              placeholderConstant='0.4'
               allowConstant
               isConstantMode={nodeData.fieldModes?.['similarityThreshold'] ?? true}
               hideClearButton
+            />
+          </VarEditorFieldRow>
+
+          <VarEditorFieldRow
+            title='One result per document'
+            description='Return the single best passage from each article or document instead of every matching segment.'
+            type={BaseType.BOOLEAN}>
+            <Switch
+              checked={nodeData.dedupePerDocument === true}
+              onCheckedChange={(checked) => handleToggleChange('dedupePerDocument', checked)}
+              disabled={isReadOnly}
             />
           </VarEditorFieldRow>
         </VarEditorField>

--- a/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/schema.ts
@@ -7,14 +7,16 @@ import { NodeType } from '~/components/workflow/types/node-types'
 import { extractVarIdsFromString } from '~/components/workflow/ui/input-editor/tiptap-converters'
 import { isNodeVariable, isVariableMode } from '~/components/workflow/utils/variable-utils'
 import { getKnowledgeRetrievalOutputVariables } from './output-variables'
-import type { KnowledgeRetrievalNodeData } from './types'
+import { type KnowledgeRetrievalNodeData, sourceFieldKey, sourceRawId } from './types'
 
 /**
- * Dataset entry schema
+ * Knowledge source row schema — a discriminated union so a row's kind survives
+ * a variable-bound id (the engine schema is widened identically).
  */
-const datasetEntrySchema = z.object({
-  datasetId: z.string(),
-})
+const sourceRowSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('dataset'), datasetId: z.string() }),
+  z.object({ kind: z.literal('kb'), knowledgeBaseId: z.string() }),
+])
 
 /**
  * Zod schema for Knowledge Retrieval node data validation
@@ -32,13 +34,15 @@ export const knowledgeRetrievalNodeDataSchema = baseNodeDataSchema.extend({
   // Query input
   query: z.string().optional(),
 
-  // Dataset selection
-  datasets: z.array(datasetEntrySchema).optional(),
+  // Knowledge selection — knowledge bases and/or RAG datasets
+  sources: z.array(sourceRowSchema).optional(),
 
   // Search configuration
   searchType: z.union([z.enum(['vector', 'text', 'hybrid']), z.string()]).optional(),
-  limit: z.union([z.number().min(1).max(100), z.string()]).optional(),
+  limit: z.union([z.number().min(1).max(25), z.string()]).optional(),
   similarityThreshold: z.union([z.number().min(0).max(1), z.string()]).optional(),
+  dedupePerDocument: z.union([z.boolean(), z.string()]).optional(),
+  recordIds: z.union([z.array(z.string()), z.string()]).optional(),
 
   // Field modes
   fieldModes: z.record(z.string(), z.boolean()).optional(),
@@ -49,16 +53,21 @@ export const knowledgeRetrievalNodeDataSchema = baseNodeDataSchema.extend({
  */
 export const knowledgeRetrievalDefaultData: Partial<KnowledgeRetrievalNodeData> = {
   title: 'Knowledge Retrieval',
-  desc: 'Search datasets for relevant content',
+  desc: 'Search knowledge bases and datasets for relevant content',
   searchType: 'hybrid',
   limit: 20,
-  similarityThreshold: 0.7,
-  datasets: [],
+  // similarityThreshold deliberately unset (K7) — the vector lane's own 0.4
+  // floor is a better default than the 0.7 this used to ship.
+  // New nodes get one-passage-per-article; existing nodes keep raw segments
+  // because the schema default is false.
+  dedupePerDocument: true,
+  sources: [],
   fieldModes: {
     query: false, // Default to variable mode for query
     searchType: true, // Default to constant mode
     limit: true,
     similarityThreshold: true,
+    dedupePerDocument: true,
   },
 }
 
@@ -80,15 +89,15 @@ export function extractKnowledgeRetrievalVariables(
     }
   }
 
-  // Extract from datasets (each entry can be a variable)
-  if (data.datasets && Array.isArray(data.datasets)) {
-    data.datasets.forEach((entry, index) => {
-      const fieldKey = `datasets.${index}.datasetId`
-      if (entry.datasetId && isVariableMode(fieldModes, fieldKey)) {
-        if (isNodeVariable(entry.datasetId)) {
-          variableIds.add(entry.datasetId)
+  // Extract from sources (each row's id can be a variable)
+  if (data.sources && Array.isArray(data.sources)) {
+    data.sources.forEach((row, index) => {
+      const rawId = sourceRawId(row)
+      if (rawId && isVariableMode(fieldModes, sourceFieldKey(row, index))) {
+        if (isNodeVariable(rawId)) {
+          variableIds.add(rawId)
         } else {
-          extractVarIdsFromString(entry.datasetId).forEach((id) => variableIds.add(id))
+          extractVarIdsFromString(rawId).forEach((id) => variableIds.add(id))
         }
       }
     })

--- a/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/types.ts
@@ -8,11 +8,24 @@ import type { BaseNodeData, SpecificNode } from '~/components/workflow/types/nod
 export type SearchType = 'vector' | 'text' | 'hybrid'
 
 /**
- * Dataset selection entry
+ * One selected knowledge source.
+ *
+ * The row's `kind` is STORED, not inferred from which id field is populated —
+ * a row whose id is variable-bound still has to know which picker it renders
+ * and which resolver arm it belongs to.
  */
-export interface DatasetEntry {
-  /** Dataset ID (from picker or variable) */
-  datasetId: string
+export type KnowledgeSourceRow =
+  | { kind: 'dataset'; datasetId: string }
+  | { kind: 'kb'; knowledgeBaseId: string }
+
+/** The `fieldModes` key for a row's id field — kind-dependent. */
+export function sourceFieldKey(row: KnowledgeSourceRow, index: number): string {
+  return row.kind === 'kb' ? `sources.${index}.knowledgeBaseId` : `sources.${index}.datasetId`
+}
+
+/** The raw (possibly variable-reference) id a row carries. */
+export function sourceRawId(row: KnowledgeSourceRow): string {
+  return row.kind === 'kb' ? row.knowledgeBaseId : row.datasetId
 }
 
 /**
@@ -30,9 +43,9 @@ export interface KnowledgeRetrievalNodeData extends BaseNodeData {
   /** Search query text (from variable or constant) */
   query?: string
 
-  // === Dataset Selection ===
-  /** Array of datasets to search across */
-  datasets?: DatasetEntry[]
+  // === Knowledge Selection ===
+  /** Knowledge bases and/or RAG datasets to search across */
+  sources?: KnowledgeSourceRow[]
 
   // === Search Configuration ===
   /**
@@ -40,13 +53,26 @@ export interface KnowledgeRetrievalNodeData extends BaseNodeData {
    * A variable reference string when bound to a variable.
    */
   searchType?: SearchType | string
-  /** Maximum number of results to return (default: 20). A string when bound to a variable. */
+  /** Maximum number of results to return (default: 20, max 25). A string when bound. */
   limit?: number | string
   /**
-   * Minimum similarity threshold for vector search (default: 0.7, range: 0-1).
+   * Minimum similarity threshold for vector search (range: 0-1).
+   * **No default** — unset lets the vector lane's own 0.4 floor apply, which is
+   * what the `search_knowledge` agent path gets over identical content.
    * A string when bound to a variable.
    */
   similarityThreshold?: number | string
+  /**
+   * Return one best passage per article/document instead of raw segments.
+   * Schema default false (existing nodes keep their behaviour); `defaultData`
+   * sets it true so new nodes get the good behaviour.
+   */
+  dedupePerDocument?: boolean | string
+  /**
+   * Keep only segments whose `metadata.links[]` include one of these record
+   * ids — "search knowledge relevant to *this* contact/order".
+   */
+  recordIds?: string[] | string
 
   /** Track constant/variable mode per field */
   fieldModes?: Record<string, boolean>

--- a/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/__tests__/search-knowledge-capabilities.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/knowledge/tools/__tests__/search-knowledge-capabilities.test.ts
@@ -4,8 +4,12 @@
 // instance access — KB-backed datasets by `canViewInstance('kb', kbId)`,
 // standalone RAG datasets by `canViewInstance('dataset', id)`. Silent filter:
 // an empty set is a normal empty result, never a 403. Absent capabilities ⇒
-// unrestricted AND zero extra queries (the un-threaded workflow AI node must
-// issue exactly the same SQL it does today).
+// unrestricted AND zero extra queries — for the headless construction sites
+// that legitimately pass `undefined` (master-Kopilot job runs, pre-setup
+// drafts). The tool spells this as `'unrestricted'` when calling the shared
+// resolver, whose `capabilities` parameter is required. NOTE: the workflow AI
+// node is NOT one of those callers any more — `ai-v2.ts` threads a real
+// CapabilityView.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 

--- a/packages/lib/src/data-migrations/migrations/087-knowledge-retrieval-sources.test.ts
+++ b/packages/lib/src/data-migrations/migrations/087-knowledge-retrieval-sources.test.ts
@@ -1,0 +1,142 @@
+// packages/lib/src/data-migrations/migrations/087-knowledge-retrieval-sources.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { rewriteGraph, rewriteKnowledgeRetrievalNode } from './087-knowledge-retrieval-sources'
+
+describe('rewriteKnowledgeRetrievalNode — reshape', () => {
+  it('maps datasets[] to dataset-kind sources[] and drops the old key', () => {
+    const data: Record<string, unknown> = {
+      type: 'knowledge-retrieval',
+      datasets: [{ datasetId: 'ds_1' }, { datasetId: 'ds_2' }],
+    }
+    expect(rewriteKnowledgeRetrievalNode(data)).toBe(true)
+    expect(data.sources).toEqual([
+      { kind: 'dataset', datasetId: 'ds_1' },
+      { kind: 'dataset', datasetId: 'ds_2' },
+    ])
+    expect(data.datasets).toBeUndefined()
+  })
+
+  it('renames the positional fieldModes keys, preserving index and value', () => {
+    const data: Record<string, unknown> = {
+      type: 'knowledge-retrieval',
+      datasets: [{ datasetId: 'ds_1' }, { datasetId: '{{find_1.record}}' }],
+      fieldModes: {
+        query: false,
+        'datasets.0.datasetId': true,
+        'datasets.1.datasetId': false,
+      },
+    }
+    rewriteKnowledgeRetrievalNode(data)
+    expect(data.fieldModes).toEqual({
+      query: false,
+      'sources.0.datasetId': true,
+      'sources.1.datasetId': false,
+    })
+  })
+
+  it('keeps a variable-bound dataset id verbatim', () => {
+    const data: Record<string, unknown> = {
+      type: 'knowledge-retrieval',
+      datasets: [{ datasetId: '{{find_1.record}}' }],
+    }
+    rewriteKnowledgeRetrievalNode(data)
+    expect(data.sources).toEqual([{ kind: 'dataset', datasetId: '{{find_1.record}}' }])
+  })
+
+  it('handles an empty datasets array', () => {
+    const data: Record<string, unknown> = { type: 'knowledge-retrieval', datasets: [] }
+    expect(rewriteKnowledgeRetrievalNode(data)).toBe(true)
+    expect(data.sources).toEqual([])
+  })
+
+  it('leaves other node types alone', () => {
+    const data: Record<string, unknown> = { type: 'find', datasets: [{ datasetId: 'ds_1' }] }
+    expect(rewriteKnowledgeRetrievalNode(data)).toBe(false)
+    expect(data.datasets).toEqual([{ datasetId: 'ds_1' }])
+  })
+})
+
+describe('rewriteKnowledgeRetrievalNode — limit clamp (K9)', () => {
+  it('clamps a literal limit above the ceiling', () => {
+    const data: Record<string, unknown> = { type: 'knowledge-retrieval', limit: 100 }
+    expect(rewriteKnowledgeRetrievalNode(data)).toBe(true)
+    expect(data.limit).toBe(25)
+  })
+
+  it('leaves a limit at or below the ceiling untouched', () => {
+    const data: Record<string, unknown> = { type: 'knowledge-retrieval', limit: 20 }
+    expect(rewriteKnowledgeRetrievalNode(data)).toBe(false)
+    expect(data.limit).toBe(20)
+  })
+
+  it('leaves a variable-bound limit alone — it is range-checked at run time', () => {
+    const data: Record<string, unknown> = {
+      type: 'knowledge-retrieval',
+      limit: '{{trigger_1.limit}}',
+    }
+    expect(rewriteKnowledgeRetrievalNode(data)).toBe(false)
+    expect(data.limit).toBe('{{trigger_1.limit}}')
+  })
+
+  it('clamps even when the node ALREADY carries sources — the guards are independent', () => {
+    // The reshape is skipped for an already-migrated node; if the clamp rode
+    // that branch, a stored limit of 100 would survive and fail the node's own
+    // configSchema.
+    const data: Record<string, unknown> = {
+      type: 'knowledge-retrieval',
+      sources: [{ kind: 'kb', knowledgeBaseId: 'kb_1' }],
+      limit: 100,
+    }
+    expect(rewriteKnowledgeRetrievalNode(data)).toBe(true)
+    expect(data.limit).toBe(25)
+    expect(data.sources).toEqual([{ kind: 'kb', knowledgeBaseId: 'kb_1' }])
+  })
+})
+
+describe('rewriteKnowledgeRetrievalNode — idempotency', () => {
+  it('a second pass changes nothing', () => {
+    const data: Record<string, unknown> = {
+      type: 'knowledge-retrieval',
+      datasets: [{ datasetId: 'ds_1' }],
+      limit: 100,
+      fieldModes: { 'datasets.0.datasetId': true },
+    }
+    expect(rewriteKnowledgeRetrievalNode(data)).toBe(true)
+    const afterFirst = JSON.parse(JSON.stringify(data))
+    expect(rewriteKnowledgeRetrievalNode(data)).toBe(false)
+    expect(data).toEqual(afterFirst)
+  })
+
+  it('does not resurrect datasets on a node that never had them', () => {
+    const data: Record<string, unknown> = {
+      type: 'knowledge-retrieval',
+      sources: [{ kind: 'kb', knowledgeBaseId: 'kb_1' }],
+    }
+    expect(rewriteKnowledgeRetrievalNode(data)).toBe(false)
+    expect(data.datasets).toBeUndefined()
+  })
+})
+
+describe('rewriteGraph', () => {
+  it('counts only the nodes it touched', () => {
+    const graph = {
+      nodes: [
+        { data: { type: 'knowledge-retrieval', datasets: [{ datasetId: 'ds_1' }] } },
+        { data: { type: 'find', resourceType: 'contact' } },
+        { data: { type: 'knowledge-retrieval', limit: 100 } },
+        { data: { type: 'knowledge-retrieval', sources: [], limit: 5 } },
+      ],
+    }
+    expect(rewriteGraph(graph)).toBe(2)
+  })
+
+  it('tolerates a graph with no nodes array', () => {
+    expect(rewriteGraph({})).toBe(0)
+    expect(rewriteGraph({ nodes: [] })).toBe(0)
+  })
+
+  it('skips nodes with no data', () => {
+    expect(rewriteGraph({ nodes: [{}, { data: undefined }] })).toBe(0)
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/087-knowledge-retrieval-sources.ts
+++ b/packages/lib/src/data-migrations/migrations/087-knowledge-retrieval-sources.ts
@@ -1,0 +1,195 @@
+// packages/lib/src/data-migrations/migrations/087-knowledge-retrieval-sources.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { asc, eq, gt } from 'drizzle-orm'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-087')
+
+/** Rows scanned per page (draft + every published version are separate rows). */
+const BATCH_SIZE = 200
+
+/** Must track `MAX_LIMIT` in `workflow-engine/nodes/dataset/knowledge-retrieval.ts`. */
+const MAX_LIMIT = 25
+
+interface GraphNode {
+  data?: Record<string, unknown>
+}
+
+interface Graph {
+  nodes?: GraphNode[]
+}
+
+/**
+ * Rewrite one `knowledge-retrieval` node's data in place.
+ *
+ * Two independent changes, each separately guarded — a graph may already carry
+ * `sources` (re-run, or authored after this shipped) and still hold a `limit`
+ * above the new ceiling, so the clamp must NOT ride the reshape branch.
+ *
+ * Returns true if anything changed.
+ *
+ * Exported for the unit test — pure, no DB.
+ */
+export function rewriteKnowledgeRetrievalNode(data: Record<string, unknown>): boolean {
+  if (data.type !== 'knowledge-retrieval') return false
+  let touched = false
+
+  // 1. datasets: [{ datasetId }] → sources: [{ kind: 'dataset', datasetId }]
+  if (data.sources === undefined && Array.isArray(data.datasets)) {
+    const rows = data.datasets as Array<{ datasetId?: unknown } | null>
+    data.sources = rows
+      .filter((r): r is { datasetId?: unknown } => Boolean(r))
+      .map((r) => ({
+        kind: 'dataset' as const,
+        datasetId: typeof r.datasetId === 'string' ? r.datasetId : '',
+      }))
+    delete data.datasets
+    touched = true
+
+    // `fieldModes` keys are positional and kind-dependent:
+    // `datasets.<i>.datasetId` → `sources.<i>.datasetId`. Index and field name
+    // are unchanged for the dataset kind, so this is a pure prefix rename.
+    const modes = data.fieldModes
+    if (modes && typeof modes === 'object') {
+      const m = modes as Record<string, unknown>
+      for (const key of Object.keys(m)) {
+        if (!key.startsWith('datasets.')) continue
+        m[`sources.${key.slice('datasets.'.length)}`] = m[key]
+        delete m[key]
+      }
+    }
+  }
+
+  // 2. Clamp `limit` to the new ceiling (K9). A stored value above it stops
+  //    parsing the node's own configSchema, which fails the defaults-parse test
+  //    and the node's validation at runtime. Only literal numbers are clamped —
+  //    a string is a variable reference, range-checked at run time.
+  if (typeof data.limit === 'number' && data.limit > MAX_LIMIT) {
+    data.limit = MAX_LIMIT
+    touched = true
+  }
+
+  return touched
+}
+
+/** Rewrite every knowledge-retrieval node in a graph; returns nodes touched. */
+export function rewriteGraph(graph: Graph): number {
+  if (!Array.isArray(graph.nodes)) return 0
+  let touched = 0
+  for (const node of graph.nodes) {
+    if (!node?.data || typeof node.data !== 'object') continue
+    if (rewriteKnowledgeRetrievalNode(node.data)) touched++
+  }
+  return touched
+}
+
+/**
+ * Reshape `knowledge-retrieval` nodes: `datasets[]` → `sources[]`, and clamp
+ * `limit` to 25.
+ *
+ * Before this, the node could only search RAG datasets — KB articles live in
+ * managed datasets that every picker hides, so a workflow could not search the
+ * knowledge base at all. `sources[]` is a union of `kb` and `dataset` rows.
+ *
+ * Two tables carry graphs that need it:
+ *  - `Workflow.graph` — drafts + published versions.
+ *  - `WorkflowTemplate.graph` — admin-created templates (bundled file templates
+ *    are JSON in the repo, merged at read time, never written to the DB).
+ *
+ * `WorkflowRun.graph` is deliberately EXCLUDED — historical run snapshots are
+ * immutable evidence and nothing re-executes them.
+ *
+ * Idempotent: a node already carrying `sources` skips the reshape, and the
+ * clamp is a no-op once applied.
+ */
+export const migration087KnowledgeRetrievalSources: DataMigrationDef = {
+  id: '087-knowledge-retrieval-sources',
+  description:
+    'Reshape knowledge-retrieval nodes from datasets[] to sources[] (kb | dataset) and clamp limit to 25',
+
+  async run(db: Database): Promise<void> {
+    let workflowsRewritten = 0
+    let templatesRewritten = 0
+    let nodesRewritten = 0
+
+    // --- Workflow.graph (nullable — tolerate it) ---
+    let cursor = ''
+    for (;;) {
+      const rows = await db
+        .select({ id: schema.Workflow.id, graph: schema.Workflow.graph })
+        .from(schema.Workflow)
+        .where(gt(schema.Workflow.id, cursor))
+        .orderBy(asc(schema.Workflow.id))
+        .limit(BATCH_SIZE)
+
+      if (rows.length === 0) break
+
+      for (const row of rows) {
+        cursor = row.id
+        if (!row.graph || typeof row.graph !== 'object') continue
+
+        const graph = row.graph as unknown as Graph
+        const touched = rewriteGraph(graph)
+        if (touched === 0) continue
+
+        await db
+          .update(schema.Workflow)
+          // biome-ignore lint/suspicious/noExplicitAny: jsonb column round-trip
+          .set({ graph: graph as any, updatedAt: new Date() })
+          .where(eq(schema.Workflow.id, row.id))
+
+        workflowsRewritten++
+        nodesRewritten += touched
+        logger.info('Reshaped knowledge-retrieval nodes', { workflowId: row.id, touched })
+      }
+
+      if (rows.length < BATCH_SIZE) break
+    }
+
+    // --- WorkflowTemplate.graph ---
+    cursor = ''
+    for (;;) {
+      const rows = await db
+        .select({ id: schema.WorkflowTemplate.id, graph: schema.WorkflowTemplate.graph })
+        .from(schema.WorkflowTemplate)
+        .where(gt(schema.WorkflowTemplate.id, cursor))
+        .orderBy(asc(schema.WorkflowTemplate.id))
+        .limit(BATCH_SIZE)
+
+      if (rows.length === 0) break
+
+      for (const row of rows) {
+        cursor = row.id
+        if (!row.graph || typeof row.graph !== 'object') continue
+
+        const graph = row.graph as unknown as Graph
+        const touched = rewriteGraph(graph)
+        if (touched === 0) continue
+
+        await db
+          .update(schema.WorkflowTemplate)
+          // biome-ignore lint/suspicious/noExplicitAny: jsonb column round-trip
+          .set({ graph: graph as any, updatedAt: new Date() })
+          .where(eq(schema.WorkflowTemplate.id, row.id))
+
+        templatesRewritten++
+        nodesRewritten += touched
+        logger.info('Reshaped knowledge-retrieval nodes in template', {
+          templateId: row.id,
+          touched,
+        })
+      }
+
+      if (rows.length < BATCH_SIZE) break
+    }
+
+    logger.info('knowledge-retrieval sources migration done', {
+      workflowsRewritten,
+      templatesRewritten,
+      nodesRewritten,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -51,6 +51,7 @@ import { migration083FindManyPluralToIdRefs } from './migrations/083-find-many-p
 import { migration084PrimaryEmailUnique } from './migrations/084-primary-email-unique'
 import { migration085MultiEmailWebsiteFlip } from './migrations/085-multi-email-website-flip'
 import { migration086MultiPhoneFlip } from './migrations/086-multi-phone-flip'
+import { migration087KnowledgeRetrievalSources } from './migrations/087-knowledge-retrieval-sources'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -128,6 +129,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration084PrimaryEmailUnique,
     migration085MultiEmailWebsiteFlip,
     migration086MultiPhoneFlip,
+    migration087KnowledgeRetrievalSources,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/datasets/__tests__/resolve-knowledge-targets.test.ts
+++ b/packages/lib/src/datasets/__tests__/resolve-knowledge-targets.test.ts
@@ -36,6 +36,8 @@ interface FakeRows {
   kbDatasetIds?: string[]
   /** `selectDistinct({ sourceId }).from(ArticlePlacement)`. */
   placementSourceIds?: string[]
+  /** `selectDistinct({ homeKnowledgeBaseId }).from(ArticlePlacement).innerJoin(Article)`. */
+  placementHomeKbIds?: string[]
   /** `select({ ownedKnowledgeBaseId }).from(KnowledgeSource)`. */
   ownedKbIds?: string[]
   /** `select({ id, datasetId }).from(KnowledgeBase)` — the access-filter map. */
@@ -55,8 +57,17 @@ function makeDb(rows: FakeRows, log: string[] = []) {
       let result: unknown[]
 
       if (table === schema.ArticlePlacement) {
-        tag = 'placements'
-        result = (rows.placementSourceIds ?? []).map((sourceId) => ({ sourceId }))
+        // Two distinct reads hit this table — the home-KB join (arm 1) and the
+        // source-link scan (arm 2) — told apart by the selected column.
+        if (has('homeKnowledgeBaseId')) {
+          tag = 'placement-home-kbs'
+          result = (rows.placementHomeKbIds ?? []).map((homeKnowledgeBaseId) => ({
+            homeKnowledgeBaseId,
+          }))
+        } else {
+          tag = 'placements'
+          result = (rows.placementSourceIds ?? []).map((sourceId) => ({ sourceId }))
+        }
       } else if (table === schema.KnowledgeSource) {
         tag = 'sources'
         result = (rows.ownedKbIds ?? []).map((ownedKnowledgeBaseId) => ({ ownedKnowledgeBaseId }))
@@ -79,7 +90,13 @@ function makeDb(rows: FakeRows, log: string[] = []) {
         p.limit = () => Promise.resolve(result.slice(0, 1))
         return p
       }
-      return { where }
+      // `innerJoin` returns the same builder — the fake's rows already stand in
+      // for the joined shape.
+      const node: { where: typeof where; innerJoin: () => typeof node } = {
+        where,
+        innerJoin: () => node,
+      }
+      return node
     },
   })
 
@@ -155,6 +172,49 @@ describe('resolveKnowledgeDatasetIds — target routing', () => {
     expect(log).toContain('placements:distinct')
     expect(log).toContain('sources')
     expect(ids).toEqual([KB_DATASET, OWNED_KB_DATASET])
+  })
+
+  it('federates to the HOME KB of a hand-authored article linked in (§5c gap)', async () => {
+    // KB-B is the target. An article authored in KB-A is *placed* into KB-B
+    // with linkedFromSourceId = null, so arm 2 sees nothing — but its
+    // embeddings live in KB-A's dataset, which arm 1 must pull in.
+    const { ids, log } = await resolve(
+      {
+        kbDatasetIds: [KB_DATASET, 'ds_kb_a'],
+        placementHomeKbIds: ['kb_a'],
+        placementSourceIds: [],
+      },
+      {
+        organizationId: ORG,
+        targets: [{ kind: 'kb', knowledgeBaseId: KB_ID }],
+        capabilities: 'unrestricted',
+        knowledgeScope: null,
+      }
+    )
+    expect(log).toContain('placement-home-kbs:distinct')
+    expect(log).not.toContain('sources') // no source chain involved at all
+    expect(ids).toEqual([KB_DATASET, 'ds_kb_a'])
+  })
+
+  it('does not re-query the target KB when every article is natively authored', async () => {
+    // Arm 1 returns the target KB's own id; its dataset is already collected,
+    // so there must be no second KnowledgeBase lookup for it.
+    const { ids, log } = await resolve(
+      {
+        kbDatasetIds: [KB_DATASET],
+        placementHomeKbIds: [KB_ID],
+        placementSourceIds: [],
+      },
+      {
+        organizationId: ORG,
+        targets: [{ kind: 'kb', knowledgeBaseId: KB_ID }],
+        capabilities: 'unrestricted',
+        knowledgeScope: null,
+      }
+    )
+    expect(ids).toEqual([KB_DATASET])
+    // exactly one kb-datasets read: the target KB's own row
+    expect(log.filter((q) => q === 'kb-datasets')).toHaveLength(1)
   })
 
   it('skips the federation queries entirely when a KB has no linked sources', async () => {

--- a/packages/lib/src/datasets/resolve-knowledge-targets.ts
+++ b/packages/lib/src/datasets/resolve-knowledge-targets.ts
@@ -272,9 +272,23 @@ async function filterAccessibleDatasetIds(
 /**
  * Datasets backing knowledge bases.
  *
- * With a `knowledgeBaseId`, federates: a source linked into this KB embeds its
- * content once in its own hidden KB's dataset, so those datasets are included
- * here. Search stays embed-once.
+ * With a `knowledgeBaseId`, **federates two ways**, because a `Document` lives
+ * in its article's *home* KB's dataset — not in the dataset of every KB the
+ * article is placed into:
+ *
+ *  1. **Home-KB federation** — every article placed in this KB contributes its
+ *     home KB's dataset. This is what makes a KB-scoped search find a
+ *     hand-authored article linked in from another KB (KB guide §2's documented
+ *     "search federation gap": such a placement has `linkedFromSourceId = null`,
+ *     so arm 2 never saw it).
+ *  2. **Source federation** — a source linked into this KB embeds its content
+ *     once in its own hidden KB's dataset.
+ *
+ * Arm 1 very likely *subsumes* arm 2 (a source's articles should have the
+ * source-owned KB as their home), but that is unverified against real
+ * source-linked data, so both run and their results union. If subsumption is
+ * ever confirmed, arm 2 is the one to delete. Search stays embed-once either
+ * way — the union is over datasets, and duplicates collapse.
  */
 async function collectManagedDatasetIds(
   db: Database,
@@ -298,16 +312,37 @@ async function collectManagedDatasetIds(
     if (!kb) return []
     const datasetIds = kb.datasetId ? [kb.datasetId] : []
 
-    const linkRows = await db
-      .selectDistinct({ sourceId: schema.ArticlePlacement.linkedFromSourceId })
-      .from(schema.ArticlePlacement)
-      .where(
-        and(
-          eq(schema.ArticlePlacement.knowledgeBaseId, knowledgeBaseId),
-          eq(schema.ArticlePlacement.organizationId, organizationId),
-          isNotNull(schema.ArticlePlacement.linkedFromSourceId)
-        )
-      )
+    const [homeRows, linkRows] = await Promise.all([
+      // Arm 1 — home KBs of every article placed here. `homeKnowledgeBaseId` is
+      // notNull, so there is no null arm. This KB's own id comes back for
+      // natively-authored articles; harmless, its dataset is already in the set.
+      db
+        .selectDistinct({ homeKnowledgeBaseId: schema.Article.homeKnowledgeBaseId })
+        .from(schema.ArticlePlacement)
+        .innerJoin(schema.Article, eq(schema.Article.id, schema.ArticlePlacement.articleId))
+        .where(
+          and(
+            eq(schema.ArticlePlacement.knowledgeBaseId, knowledgeBaseId),
+            eq(schema.ArticlePlacement.organizationId, organizationId)
+          )
+        ),
+      // Arm 2 — sources linked into this KB.
+      db
+        .selectDistinct({ sourceId: schema.ArticlePlacement.linkedFromSourceId })
+        .from(schema.ArticlePlacement)
+        .where(
+          and(
+            eq(schema.ArticlePlacement.knowledgeBaseId, knowledgeBaseId),
+            eq(schema.ArticlePlacement.organizationId, organizationId),
+            isNotNull(schema.ArticlePlacement.linkedFromSourceId)
+          )
+        ),
+    ])
+
+    const federatedKbIds = new Set(
+      homeRows.map((r) => r.homeKnowledgeBaseId).filter((id): id is string => Boolean(id))
+    )
+
     const sourceIds = linkRows.map((r) => r.sourceId).filter((id): id is string => Boolean(id))
     if (sourceIds.length > 0) {
       const sources = await db
@@ -319,16 +354,22 @@ async function collectManagedDatasetIds(
             eq(schema.KnowledgeSource.organizationId, organizationId)
           )
         )
-      const ownedKbIds = sources.map((s) => s.ownedKnowledgeBaseId)
-      if (ownedKbIds.length > 0) {
-        const ownedKbs = await db
-          .select({ datasetId: schema.KnowledgeBase.datasetId })
-          .from(schema.KnowledgeBase)
-          .where(inArray(schema.KnowledgeBase.id, ownedKbIds))
-        datasetIds.push(
-          ...ownedKbs.map((k) => k.datasetId).filter((id): id is string => Boolean(id))
-        )
+      for (const s of sources) {
+        if (s.ownedKnowledgeBaseId) federatedKbIds.add(s.ownedKnowledgeBaseId)
       }
+    }
+
+    // The target KB's own dataset is already collected above.
+    federatedKbIds.delete(knowledgeBaseId)
+
+    if (federatedKbIds.size > 0) {
+      const federatedKbs = await db
+        .select({ datasetId: schema.KnowledgeBase.datasetId })
+        .from(schema.KnowledgeBase)
+        .where(inArray(schema.KnowledgeBase.id, [...federatedKbIds]))
+      datasetIds.push(
+        ...federatedKbs.map((k) => k.datasetId).filter((id): id is string => Boolean(id))
+      )
     }
     return [...new Set(datasetIds)]
   }

--- a/packages/lib/src/workflow-engine/nodes/dataset/dataset-node-config.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/dataset/dataset-node-config.test.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/workflow-engine/nodes/dataset/dataset-node-config.test.ts
 
+import { ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ExecutionContextManager } from '../../core/execution-context'
 import type { PauseReason, WorkflowNode } from '../../core/types'
@@ -20,6 +21,26 @@ const queueAdd = vi.fn()
 vi.mock('../../../jobs/queues', () => ({
   getQueue: () => ({ add: (...args: unknown[]) => queueAdd(...args) }),
   Queues: { workflowDelayQueue: 'workflow-delay' },
+}))
+
+/**
+ * Knowledge-retrieval now resolves its sources through the shared resolver on
+ * the workflow author's authority (K5). These stand in for the access layer so
+ * the tests stay about config binding and source routing; the resolver's own
+ * behaviour is covered in `datasets/__tests__/resolve-knowledge-targets.test.ts`.
+ */
+const resolveKnowledgeDatasetIds = vi.fn()
+vi.mock('../../../datasets/resolve-knowledge-targets', () => ({
+  resolveKnowledgeDatasetIds: (...args: unknown[]) => resolveKnowledgeDatasetIds(...args),
+}))
+vi.mock('../../../permissions/capabilities/get-capabilities', () => ({
+  getCapabilities: async () => ({ canViewInstance: () => true }),
+}))
+// Partial-mock: a wholesale replacement of the org-cache barrel dies at
+// COLLECTION as the import graph grows.
+vi.mock('../../../cache/org-cache-helpers', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getCachedMembers: async () => [{ userId: 'test-user', status: 'ACTIVE' }],
 }))
 
 /**
@@ -151,20 +172,25 @@ describe('ChunkerProcessor config binding', () => {
 describe('KnowledgeRetrievalProcessor config binding', () => {
   let processor: KnowledgeRetrievalProcessor
 
+  /** The targets the processor handed the resolver on the last call. */
+  const lastTargets = () => resolveKnowledgeDatasetIds.mock.calls.at(-1)?.[1].targets
+
   beforeEach(() => {
     processor = new KnowledgeRetrievalProcessor()
+    resolveKnowledgeDatasetIds.mockReset()
+    resolveKnowledgeDatasetIds.mockResolvedValue(ok(['ds_resolved']))
   })
 
   it('accepts variable-bound search settings and resolves them', async () => {
     const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
       query: 'trigger_1.question',
-      datasets: [{ datasetId: 'ds_123' }],
+      sources: [{ kind: 'dataset', datasetId: 'ds_123' }],
       searchType: 'settings_1.mode',
       limit: 'settings_1.limit',
       similarityThreshold: 'settings_1.threshold',
       fieldModes: {
         query: false,
-        'datasets.0.datasetId': true,
+        'sources.0.datasetId': true,
         searchType: false,
         limit: false,
         similarityThreshold: false,
@@ -189,10 +215,10 @@ describe('KnowledgeRetrievalProcessor config binding', () => {
   it('resolves search settings delivered as interpolated strings', async () => {
     const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
       query: 'a question',
-      datasets: [{ datasetId: 'ds_123' }],
+      sources: [{ kind: 'dataset', datasetId: 'ds_123' }],
       searchType: '{{settings_1.mode}}',
       limit: '{{settings_1.limit}}',
-      fieldModes: { query: true, 'datasets.0.datasetId': true, searchType: false, limit: false },
+      fieldModes: { query: true, 'sources.0.datasetId': true, searchType: false, limit: false },
     })
 
     const preprocessed = await processor.preprocessNode(
@@ -207,9 +233,9 @@ describe('KnowledgeRetrievalProcessor config binding', () => {
   it('falls back to defaults when a bound setting resolves out of range', async () => {
     const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
       query: 'a question',
-      datasets: [{ datasetId: 'ds_123' }],
+      sources: [{ kind: 'dataset', datasetId: 'ds_123' }],
       limit: 'settings_1.limit',
-      fieldModes: { query: true, 'datasets.0.datasetId': true, limit: false },
+      fieldModes: { query: true, 'sources.0.datasetId': true, limit: false },
     })
 
     const preprocessed = await processor.preprocessNode(
@@ -220,12 +246,25 @@ describe('KnowledgeRetrievalProcessor config binding', () => {
     expect(preprocessed.inputs.limit).toBe(20)
   })
 
+  it('rejects a literal limit above the ceiling (K9 — was 100, now 25)', async () => {
+    const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
+      query: 'a question',
+      sources: [{ kind: 'dataset', datasetId: 'ds_123' }],
+      limit: 100,
+      fieldModes: { query: true, 'sources.0.datasetId': true, limit: true },
+    })
+
+    await expect(processor.preprocessNode(node, createContext())).rejects.toThrow(
+      /Invalid Knowledge Retrieval configuration/
+    )
+  })
+
   it('declares bound search settings as required variables', () => {
     const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
       query: 'trigger_1.question',
-      datasets: [{ datasetId: 'ds_123' }],
+      sources: [{ kind: 'dataset', datasetId: 'ds_123' }],
       limit: 'settings_1.limit',
-      fieldModes: { query: false, 'datasets.0.datasetId': true, limit: false },
+      fieldModes: { query: false, 'sources.0.datasetId': true, limit: false },
     })
 
     // @ts-expect-error - exercising the protected contract directly
@@ -237,13 +276,13 @@ describe('KnowledgeRetrievalProcessor config binding', () => {
   it('still accepts literal constants', async () => {
     const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
       query: 'a question',
-      datasets: [{ datasetId: 'ds_123' }],
+      sources: [{ kind: 'dataset', datasetId: 'ds_123' }],
       searchType: 'hybrid',
       limit: 20,
       similarityThreshold: 0.7,
       fieldModes: {
         query: true,
-        'datasets.0.datasetId': true,
+        'sources.0.datasetId': true,
         searchType: true,
         limit: true,
         similarityThreshold: true,
@@ -255,6 +294,168 @@ describe('KnowledgeRetrievalProcessor config binding', () => {
     expect(preprocessed.inputs.searchType).toBe('hybrid')
     expect(preprocessed.inputs.limit).toBe(20)
     expect(preprocessed.inputs.similarityThreshold).toBe(0.7)
+  })
+
+  it('leaves similarityThreshold undefined when unset (K7 — no node default)', async () => {
+    const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
+      query: 'a question',
+      sources: [{ kind: 'dataset', datasetId: 'ds_123' }],
+      fieldModes: { query: true, 'sources.0.datasetId': true },
+    })
+
+    const preprocessed = await processor.preprocessNode(node, createContext())
+
+    // Not 0.7 — omitted, so the vector lane's own 0.4 floor applies.
+    expect(preprocessed.inputs.similarityThreshold).toBeUndefined()
+  })
+})
+
+describe('KnowledgeRetrievalProcessor source routing', () => {
+  let processor: KnowledgeRetrievalProcessor
+
+  const lastTargets = () => resolveKnowledgeDatasetIds.mock.calls.at(-1)?.[1].targets
+
+  beforeEach(() => {
+    processor = new KnowledgeRetrievalProcessor()
+    resolveKnowledgeDatasetIds.mockReset()
+    resolveKnowledgeDatasetIds.mockResolvedValue(ok(['ds_resolved']))
+  })
+
+  it('routes a kb row to a kb target', async () => {
+    const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
+      query: 'a question',
+      sources: [{ kind: 'kb', knowledgeBaseId: 'kb_1' }],
+      fieldModes: { query: true, 'sources.0.knowledgeBaseId': true },
+    })
+
+    await processor.preprocessNode(node, createContext())
+
+    expect(lastTargets()).toEqual([{ kind: 'kb', knowledgeBaseId: 'kb_1' }])
+  })
+
+  it('routes a mixed kb + dataset config, preserving order and kind', async () => {
+    const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
+      query: 'a question',
+      sources: [
+        { kind: 'kb', knowledgeBaseId: 'kb_1' },
+        { kind: 'dataset', datasetId: 'ds_1' },
+      ],
+      fieldModes: {
+        query: true,
+        'sources.0.knowledgeBaseId': true,
+        'sources.1.datasetId': true,
+      },
+    })
+
+    await processor.preprocessNode(node, createContext())
+
+    expect(lastTargets()).toEqual([
+      { kind: 'kb', knowledgeBaseId: 'kb_1' },
+      { kind: 'dataset', datasetId: 'ds_1' },
+    ])
+  })
+
+  it('resolves a variable-bound KB id', async () => {
+    const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
+      query: 'a question',
+      sources: [{ kind: 'kb', knowledgeBaseId: 'find_1.record' }],
+      fieldModes: { query: true, 'sources.0.knowledgeBaseId': false },
+    })
+
+    await processor.preprocessNode(node, createContext({ 'find_1.record': 'kb_from_var' }))
+
+    expect(lastTargets()).toEqual([{ kind: 'kb', knowledgeBaseId: 'kb_from_var' }])
+  })
+
+  it('a bound id resolving to nothing contributes nothing — siblings still search', async () => {
+    const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
+      query: 'a question',
+      sources: [
+        { kind: 'kb', knowledgeBaseId: 'find_1.missing' },
+        { kind: 'dataset', datasetId: 'ds_1' },
+      ],
+      fieldModes: {
+        query: true,
+        'sources.0.knowledgeBaseId': false,
+        'sources.1.datasetId': true,
+      },
+    })
+
+    await processor.preprocessNode(node, createContext())
+
+    expect(lastTargets()).toEqual([{ kind: 'dataset', datasetId: 'ds_1' }])
+  })
+
+  it('errors when EVERY row resolves to nothing, never falling through to an unscoped search', async () => {
+    const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
+      query: 'a question',
+      sources: [{ kind: 'kb', knowledgeBaseId: 'find_1.missing' }],
+      fieldModes: { query: true, 'sources.0.knowledgeBaseId': false },
+    })
+
+    await expect(processor.preprocessNode(node, createContext())).rejects.toThrow(
+      /No valid knowledge sources/
+    )
+    expect(resolveKnowledgeDatasetIds).not.toHaveBeenCalled()
+  })
+
+  it('errors when the resolver returns an empty set — access denied is not "search everything"', async () => {
+    resolveKnowledgeDatasetIds.mockResolvedValue(ok([]))
+
+    const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
+      query: 'a question',
+      sources: [{ kind: 'kb', knowledgeBaseId: 'kb_1' }],
+      fieldModes: { query: true, 'sources.0.knowledgeBaseId': true },
+    })
+
+    await expect(processor.preprocessNode(node, createContext())).rejects.toThrow(
+      /No accessible knowledge sources/
+    )
+  })
+
+  it('passes an explicit null knowledgeScope (K6) — there is no agent here', async () => {
+    const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
+      query: 'a question',
+      sources: [{ kind: 'kb', knowledgeBaseId: 'kb_1' }],
+      fieldModes: { query: true, 'sources.0.knowledgeBaseId': true },
+    })
+
+    await processor.preprocessNode(node, createContext())
+
+    const args = resolveKnowledgeDatasetIds.mock.calls.at(-1)?.[1]
+    expect(args.knowledgeScope).toBeNull()
+    expect(args.capabilities).toBeDefined()
+    expect(args.capabilities).not.toBe('unrestricted')
+  })
+
+  it('refuses to run without a user rather than resolving unrestricted (K5)', async () => {
+    const context = new ExecutionContextManager('test-workflow', 'test-run', 'test-org')
+    context.setVariable('sys.organizationId', 'test-org')
+    // sys.userId deliberately absent
+
+    const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
+      query: 'a question',
+      sources: [{ kind: 'kb', knowledgeBaseId: 'kb_1' }],
+      fieldModes: { query: true, 'sources.0.knowledgeBaseId': true },
+    })
+
+    await expect(processor.preprocessNode(node, context)).rejects.toThrow(
+      /will not run unrestricted/
+    )
+    expect(resolveKnowledgeDatasetIds).not.toHaveBeenCalled()
+  })
+
+  it('declares a bound source id as a required variable', () => {
+    const node = createNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL, {
+      query: 'a question',
+      sources: [{ kind: 'kb', knowledgeBaseId: 'find_1.record' }],
+      fieldModes: { query: true, 'sources.0.knowledgeBaseId': false },
+    })
+
+    // @ts-expect-error - exercising the protected contract directly
+    const required = processor.extractRequiredVariables(node) as string[]
+
+    expect(required).toContain('find_1.record')
   })
 })
 

--- a/packages/lib/src/workflow-engine/nodes/dataset/knowledge-retrieval-output.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/dataset/knowledge-retrieval-output.test.ts
@@ -1,0 +1,333 @@
+// packages/lib/src/workflow-engine/nodes/dataset/knowledge-retrieval-output.test.ts
+//
+// The retrieval node's OUTPUT contract (plan 12 §7) plus the two post-filters
+// that shape it: `dedupePerDocument` (K8) and `recordIds`.
+//
+// Covers the KB-provenance fields that make a downstream `answer`/`ai` node able
+// to cite an article (`docSlug` → `[Title](auxx://doc/<docSlug>)`) and a `crud`
+// node able to link a reply back to it (`articleId`).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ExecutionContextManager } from '../../core/execution-context'
+import type { WorkflowNode } from '../../core/types'
+import { WorkflowNodeType } from '../../core/types'
+
+const search = vi.fn()
+vi.mock('../../../datasets/services/search.service', () => ({
+  SearchService: { search: (...args: unknown[]) => search(...args) },
+}))
+
+import { KnowledgeRetrievalProcessor } from './knowledge-retrieval'
+
+/** A KB-sourced segment, metadata shaped as `KBSyncService` writes it. */
+function kbHit(
+  overrides: {
+    id?: string
+    articleId?: string
+    documentId?: string
+    score?: number
+    recordId?: string
+  } = {}
+) {
+  const {
+    id = 'seg_1',
+    articleId = 'art_1',
+    documentId = 'doc_1',
+    score = 0.9,
+    recordId,
+  } = overrides
+  return {
+    segment: {
+      id,
+      content: 'Refunds are issued within 5-7 business days.',
+      position: 0,
+      metadata: {
+        source: 'kb',
+        articleId,
+        articleSlug: 'refund-policy',
+        articleSlugPath: 'policies/refund-policy',
+        kbId: 'kb_1',
+        kbSlug: 'help',
+        ...(recordId ? { links: [{ recordId }] } : {}),
+      },
+      document: {
+        id: documentId,
+        title: 'Refund policy',
+        filename: 'refund-policy.md',
+        dataset: { id: 'ds_kb', name: 'Help Center' },
+      },
+    },
+    score,
+    rank: 1,
+    searchType: 'hybrid',
+  }
+}
+
+/** A standalone RAG segment — no KB metadata at all. */
+function ragHit(overrides: { id?: string; documentId?: string; score?: number } = {}) {
+  const { id = 'seg_r', documentId = 'doc_r', score = 0.8 } = overrides
+  return {
+    segment: {
+      id,
+      content: 'Uploaded handbook text.',
+      position: 3,
+      metadata: {},
+      document: {
+        id: documentId,
+        title: 'Handbook',
+        filename: 'handbook.pdf',
+        dataset: { id: 'ds_rag', name: 'Uploads' },
+      },
+    },
+    score,
+    rank: 2,
+    searchType: 'vector',
+  }
+}
+
+function respond(results: unknown[]) {
+  search.mockResolvedValue({
+    results,
+    total: results.length,
+    responseTime: 12,
+    hasMore: false,
+    query: 'refunds',
+    searchType: 'hybrid',
+  })
+}
+
+function node(): WorkflowNode {
+  return {
+    id: 'n1',
+    workflowId: 'wf',
+    nodeId: 'n1',
+    type: WorkflowNodeType.KNOWLEDGE_RETRIEVAL,
+    name: 'Search Knowledge',
+    description: '',
+    data: { id: 'n1', type: 'knowledge-retrieval', title: 'Search' },
+    metadata: {},
+  } as unknown as WorkflowNode
+}
+
+interface RunOutput {
+  results: Array<Record<string, unknown>>
+  total: number
+  success: boolean
+  error?: string
+}
+
+/** Drive executeNode directly with a preprocessed payload. */
+async function run(inputs: Record<string, unknown>): Promise<{ output: RunOutput }> {
+  const processor = new KnowledgeRetrievalProcessor()
+  const context = new ExecutionContextManager('wf', 'run', 'org')
+  // @ts-expect-error - exercising the protected contract directly
+  const result = await processor.executeNode(node(), context, {
+    inputs: {
+      query: 'refunds',
+      datasetIds: ['ds_kb'],
+      searchType: 'hybrid',
+      limit: 10,
+      organizationId: 'org',
+      userId: 'user',
+      ...inputs,
+    },
+    metadata: {},
+  })
+  const output = result.output as RunOutput | undefined
+  // A thrown search surfaces as the node's error output, never as a bare
+  // undefined — assert rather than optional-chain so a regression is loud.
+  if (!output) throw new Error(`executeNode returned no output: ${JSON.stringify(result)}`)
+  return { output }
+}
+
+/** The `SearchQuery` the node built on the last call. */
+function lastQuery(): Record<string, unknown> {
+  const call = search.mock.calls.at(-1)
+  if (!call) throw new Error('SearchService.search was never called')
+  return call[0] as Record<string, unknown>
+}
+
+/** First result, asserted present. */
+function first(output: RunOutput): Record<string, unknown> {
+  const item = output.results[0]
+  if (!item) throw new Error('expected at least one result')
+  return item
+}
+
+beforeEach(() => {
+  search.mockReset()
+})
+
+describe('KB provenance on results (§7)', () => {
+  it('labels a KB hit and builds docSlug from kbSlug + articleSlugPath', async () => {
+    respond([kbHit()])
+    const { output } = await run({})
+
+    expect(first(output)).toMatchObject({
+      source: 'kb',
+      articleId: 'art_1',
+      articleSlug: 'refund-policy',
+      articleSlugPath: 'policies/refund-policy',
+      kbId: 'kb_1',
+      kbSlug: 'help',
+      docSlug: 'help/policies/refund-policy',
+    })
+  })
+
+  it('labels a RAG hit and omits every article field', async () => {
+    respond([ragHit()])
+    const { output } = await run({})
+
+    const item = first(output)
+    expect(item.source).toBe('rag')
+    expect(item).not.toHaveProperty('articleId')
+    expect(item).not.toHaveProperty('docSlug')
+    expect(item).not.toHaveProperty('kbId')
+  })
+
+  it('omits docSlug when the KB metadata is partial', async () => {
+    const hit = kbHit()
+    // biome-ignore lint/performance/noDelete: modelling a partial metadata row
+    delete (hit.segment.metadata as Record<string, unknown>).kbSlug
+    respond([hit])
+
+    const { output } = await run({})
+    expect(first(output).source).toBe('kb')
+    expect(first(output)).not.toHaveProperty('docSlug')
+  })
+
+  it('keeps the pre-existing fields untouched', async () => {
+    respond([kbHit()])
+    const { output } = await run({})
+
+    expect(first(output)).toMatchObject({
+      content: 'Refunds are issued within 5-7 business days.',
+      score: 0.9,
+      rank: 1,
+      segmentId: 'seg_1',
+      documentId: 'doc_1',
+      documentTitle: 'Refund policy',
+      datasetId: 'ds_kb',
+      datasetName: 'Help Center',
+      position: 0,
+      searchType: 'hybrid',
+    })
+  })
+})
+
+describe('search query construction', () => {
+  it('always requests metadata — the vector lane gates provenance on it', async () => {
+    respond([kbHit()])
+    await run({})
+
+    expect(lastQuery()).toMatchObject({ includeMetadata: true })
+  })
+
+  it('omits similarityThreshold when unset (K7) so the lane default applies', async () => {
+    respond([kbHit()])
+    await run({ similarityThreshold: undefined })
+
+    expect(lastQuery()).not.toHaveProperty('similarityThreshold')
+  })
+
+  it('passes similarityThreshold through when the author set one', async () => {
+    respond([kbHit()])
+    await run({ similarityThreshold: 0.55 })
+
+    expect(lastQuery()).toMatchObject({ similarityThreshold: 0.55 })
+  })
+
+  it('does not over-fetch when nothing will post-filter', async () => {
+    respond([kbHit()])
+    await run({ limit: 10 })
+
+    expect(lastQuery()).toMatchObject({ limit: 10 })
+  })
+
+  it('over-fetches when a post-filter will cut the list', async () => {
+    respond([kbHit()])
+    await run({ limit: 10, dedupePerDocument: true })
+
+    // max(10*3, 15) capped at 50
+    expect(lastQuery()).toMatchObject({ limit: 30 })
+  })
+})
+
+describe('dedupePerDocument (K8)', () => {
+  it('keeps only the best passage per article', async () => {
+    respond([
+      kbHit({ id: 'seg_1', articleId: 'art_1', score: 0.9 }),
+      kbHit({ id: 'seg_2', articleId: 'art_1', score: 0.8 }),
+      kbHit({ id: 'seg_3', articleId: 'art_2', score: 0.7 }),
+    ])
+
+    const { output } = await run({ dedupePerDocument: true })
+
+    expect(output.results.map((r) => r.segmentId)).toEqual(['seg_1', 'seg_3'])
+  })
+
+  it('falls back to documentId for RAG segments, which carry no articleId', async () => {
+    respond([
+      ragHit({ id: 'seg_a', documentId: 'doc_1', score: 0.9 }),
+      ragHit({ id: 'seg_b', documentId: 'doc_1', score: 0.8 }),
+      ragHit({ id: 'seg_c', documentId: 'doc_2', score: 0.7 }),
+    ])
+
+    const { output } = await run({ dedupePerDocument: true })
+
+    expect(output.results.map((r) => r.segmentId)).toEqual(['seg_a', 'seg_c'])
+  })
+
+  it('returns raw segments when off — existing nodes keep their behaviour', async () => {
+    respond([
+      kbHit({ id: 'seg_1', articleId: 'art_1' }),
+      kbHit({ id: 'seg_2', articleId: 'art_1' }),
+    ])
+
+    const { output } = await run({ dedupePerDocument: false })
+
+    expect(output.results).toHaveLength(2)
+  })
+
+  it('trims to the requested limit after deduping', async () => {
+    respond([
+      kbHit({ id: 'seg_1', articleId: 'art_1' }),
+      kbHit({ id: 'seg_2', articleId: 'art_2' }),
+      kbHit({ id: 'seg_3', articleId: 'art_3' }),
+    ])
+
+    const { output } = await run({ limit: 2, dedupePerDocument: true })
+
+    expect(output.results.map((r) => r.segmentId)).toEqual(['seg_1', 'seg_2'])
+  })
+})
+
+describe('recordIds filter', () => {
+  it('keeps only segments linked to one of the given records', async () => {
+    respond([
+      kbHit({ id: 'seg_1', articleId: 'art_1', recordId: 'rec_1' }),
+      kbHit({ id: 'seg_2', articleId: 'art_2', recordId: 'rec_2' }),
+      kbHit({ id: 'seg_3', articleId: 'art_3' }), // no links at all
+    ])
+
+    const { output } = await run({ recordIds: ['rec_2'] })
+
+    expect(output.results.map((r) => r.segmentId)).toEqual(['seg_2'])
+  })
+
+  it('drops segments with no links when a filter is active', async () => {
+    respond([ragHit({ id: 'seg_r' })])
+
+    const { output } = await run({ recordIds: ['rec_1'] })
+
+    expect(output.results).toHaveLength(0)
+  })
+
+  it('is inert when no records are given', async () => {
+    respond([kbHit({ id: 'seg_1' }), ragHit({ id: 'seg_r' })])
+
+    const { output } = await run({ recordIds: [] })
+
+    expect(output.results).toHaveLength(2)
+  })
+})

--- a/packages/lib/src/workflow-engine/nodes/dataset/knowledge-retrieval.ts
+++ b/packages/lib/src/workflow-engine/nodes/dataset/knowledge-retrieval.ts
@@ -1,7 +1,10 @@
 // packages/lib/src/workflow-engine/nodes/dataset/knowledge-retrieval.ts
 
+import { database as db } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { z } from 'zod'
+import type { KnowledgeTarget } from '../../../datasets/resolve-knowledge-targets'
+import { resolveKnowledgeDatasetIds } from '../../../datasets/resolve-knowledge-targets'
 import { SearchService } from '../../../datasets/services/search.service'
 import type { SearchQuery, SearchResult, SearchType } from '../../../datasets/types/search.types'
 import type { ExecutionContextManager } from '../../core/execution-context'
@@ -19,10 +22,22 @@ import { resolveEnumConfig, resolveNumberConfig, variableBound } from './config-
 const logger = createScopedLogger('knowledge-retrieval-processor')
 
 /**
- * Dataset entry configuration
+ * One selected knowledge source. The row's `kind` is stored, never inferred, so
+ * a row whose id is variable-bound still knows which picker and which resolver
+ * arm it belongs to.
  */
-interface DatasetEntry {
-  datasetId: string
+export type KnowledgeSourceRow =
+  | { kind: 'dataset'; datasetId: string }
+  | { kind: 'kb'; knowledgeBaseId: string }
+
+/** The `fieldModes` key for a row's id field — kind-dependent. */
+function sourceFieldKey(row: KnowledgeSourceRow, index: number): string {
+  return row.kind === 'kb' ? `sources.${index}.knowledgeBaseId` : `sources.${index}.datasetId`
+}
+
+/** The raw (possibly variable-reference) id a row carries. */
+function sourceRawId(row: KnowledgeSourceRow): string {
+  return row.kind === 'kb' ? row.knowledgeBaseId : row.datasetId
 }
 
 /**
@@ -35,14 +50,18 @@ interface KnowledgeRetrievalConfig {
   // Query input
   query?: string
 
-  // Dataset selection
-  datasets?: DatasetEntry[]
+  // Knowledge selection — knowledge bases and/or RAG datasets
+  sources?: KnowledgeSourceRow[]
 
   // Search configuration
   // Each carries a variable reference string when bound to a variable
   searchType?: SearchType | string
   limit?: number | string
   similarityThreshold?: number | string
+  /** One best passage per article/document (K8). Schema default false. */
+  dedupePerDocument?: boolean | string
+  /** Keep only segments whose `metadata.links[]` include one of these records. */
+  recordIds?: string[] | string
 
   // Field modes tracking (constant vs variable)
   fieldModes?: Record<string, boolean>
@@ -63,6 +82,50 @@ interface KnowledgeRetrievalResultItem {
   datasetName: string
   position: number
   searchType: string
+
+  // === KB provenance (additive; absent on RAG segments) ===
+  /** `'kb'` for a knowledge-base article, `'rag'` for an uploaded document. */
+  source: 'kb' | 'rag'
+  articleId?: string
+  articleSlug?: string
+  articleSlugPath?: string
+  kbId?: string
+  kbSlug?: string
+  /** `<kbSlug>/<articleSlugPath>` — cite as `[Title](auxx://doc/<docSlug>)`. */
+  docSlug?: string
+}
+
+/** Segment metadata written by `KBSyncService` for KB-sourced segments. */
+interface SegmentMeta {
+  source?: string
+  articleId?: string
+  articleSlug?: string
+  articleSlugPath?: string
+  kbId?: string
+  kbSlug?: string
+  links?: Array<{ recordId?: string }>
+}
+
+/**
+ * Read a segment's metadata.
+ *
+ * ⚠ The two search lanes populate this from DIFFERENT columns — the vector lane
+ * from `DocumentSegment.searchMetadata`, the full-text lane from
+ * `DocumentSegment.metadata` — and hybrid mixes both, so the same article can
+ * come back with metadata sourced from either.
+ *
+ * They agree structurally, not by coincidence: `metadata` is written at chunk
+ * time from `KBSyncService`'s `baseMetadata`, and `searchMetadata` is derived
+ * from it at embed time (`embedding-processor.ts` spreads `segment.metadata`
+ * LAST over its own derived keys, so KB fields cannot be clobbered, and
+ * `postgresql.ts` writes that object to `searchMetadata`). A segment that was
+ * chunked but never embedded has a null `searchMetadata`, but it also has
+ * `indexStatus != 'INDEXED'` and the vector SQL requires INDEXED — so it can
+ * only ever come back through the full-text lane, which reads the populated
+ * column. There is no shape where a KB hit arrives unlabelled.
+ */
+function readSegmentMeta(result: SearchResult): SegmentMeta {
+  return ((result.segment.metadata as SegmentMeta | null) ?? {}) as SegmentMeta
 }
 
 /**
@@ -82,9 +145,10 @@ interface KnowledgeRetrievalOutput {
 /**
  * Validation schema for Knowledge Retrieval configuration
  */
-const datasetEntrySchema = z.object({
-  datasetId: z.string(),
-})
+const sourceRowSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('dataset'), datasetId: z.string() }),
+  z.object({ kind: z.literal('kb'), knowledgeBaseId: z.string() }),
+])
 
 /** Search types the retrieval node knows how to dispatch */
 const SEARCH_TYPES = ['vector', 'text', 'hybrid'] as const
@@ -92,7 +156,36 @@ const SEARCH_TYPES = ['vector', 'text', 'hybrid'] as const
 /** Defaults applied when a search-configuration field is unset or unresolvable */
 const DEFAULT_SEARCH_TYPE: SearchType = 'hybrid'
 const DEFAULT_LIMIT = 20
-const DEFAULT_SIMILARITY_THRESHOLD = 0.7
+
+/**
+ * Upper bound on `limit` (K9).
+ *
+ * Was 100. Chunks default to 1000 chars and this node deliberately does NOT
+ * truncate `results[].content` (a downstream `ai`/`answer` node consumes it),
+ * so a 100-result run put ~25k tokens into the next prompt. 25 sits just above
+ * the node's default of 20, bounding the worst case to the same order as the
+ * default rather than 5x it. With `dedupePerDocument` on, 100 would mean 100
+ * distinct articles — that is re-ranking territory, and re-ranking is out of
+ * scope (it is accepted by `VectorSearchOptions` and silently ignored).
+ */
+const MAX_LIMIT = 25
+
+/**
+ * Over-fetch multiplier when results are post-filtered, mirroring
+ * `search_knowledge`: dedupe and `recordIds` both cut the raw segment list, so
+ * it must be several times the requested page to survive the cuts.
+ */
+const OVERFETCH_MIN = 15
+const OVERFETCH_MAX = 50
+
+// NOTE — `similarityThreshold` deliberately has NO node-level default (K7).
+// It used to default to 0.7 while the vector lane's own floor is 0.4 (chosen
+// deliberately — see the comment in `search/vector-search.ts`), so pointing the
+// node at a knowledge base gave materially worse recall than the
+// `search_knowledge` path over identical content, which passes nothing. Leaving
+// it unset lets the lane default apply and makes the two agree. This is an
+// observable change for existing nodes: they return more results, at lower
+// scores.
 
 /**
  * Validation schema for Knowledge Retrieval configuration
@@ -107,10 +200,12 @@ const knowledgeRetrievalConfigSchema = z.object({
   title: z.string().optional().default('Knowledge Retrieval'),
   desc: z.string().optional(),
   query: z.string().optional(),
-  datasets: z.array(datasetEntrySchema).optional(),
+  sources: z.array(sourceRowSchema).optional(),
   searchType: variableBound(z.enum(SEARCH_TYPES)).optional(),
-  limit: variableBound(z.number().min(1).max(100)).optional(),
+  limit: variableBound(z.number().min(1).max(MAX_LIMIT)).optional(),
   similarityThreshold: variableBound(z.number().min(0).max(1)).optional(),
+  dedupePerDocument: z.union([z.boolean(), z.string()]).optional(),
+  recordIds: z.union([z.array(z.string()), z.string()]).optional(),
   fieldModes: z.record(z.string(), z.boolean()).optional(),
 })
 
@@ -178,41 +273,62 @@ export class KnowledgeRetrievalProcessor extends BaseNodeProcessor {
       })
     }
 
-    // === Resolve datasets ===
-    if (!config.datasets || config.datasets.length === 0) {
-      throw this.createProcessingError('At least one dataset must be selected', node, { config })
+    // === Resolve knowledge sources ===
+    if (!config.sources || config.sources.length === 0) {
+      throw this.createProcessingError('At least one knowledge source must be selected', node, {
+        config,
+      })
     }
 
-    const resolvedDatasetIds: string[] = []
+    // Each row resolves independently and FAILS CLOSED (K3): a variable-bound id
+    // that resolves to nothing contributes nothing while its siblings still
+    // search. Only an empty set after resolution is an error.
+    const targets: KnowledgeTarget[] = []
 
-    for (let i = 0; i < config.datasets.length; i++) {
-      const entry = config.datasets[i]
-      if (!entry?.datasetId) continue
+    for (let i = 0; i < config.sources.length; i++) {
+      const row = config.sources[i]
+      const rawId = row ? sourceRawId(row) : ''
+      if (!row || !rawId) continue
 
-      const fieldKey = `datasets.${i}.datasetId`
+      const fieldKey = sourceFieldKey(row, i)
       const isConstantMode = config.fieldModes?.[fieldKey] !== false // Default to constant mode
 
-      let resolvedDatasetId: string | undefined
+      let resolvedId: string | undefined
 
       if (isConstantMode) {
-        resolvedDatasetId = entry.datasetId
+        resolvedId = rawId
       } else {
-        // Variable mode - use extractIdFromValue which handles ResourceReference objects
-        resolvedDatasetId = await this.extractIdFromValue(entry.datasetId, contextManager)
-        this.extractVariableIds(entry.datasetId).forEach((v) => usedVariables.add(v))
-        if (entry.datasetId.includes('.')) {
-          usedVariables.add(entry.datasetId)
+        // Variable mode — extractIdFromValue unwraps ResourceReference objects,
+        // so `{{find_1.record}}` pointing at a KB works with no extra handling.
+        resolvedId = await this.extractIdFromValue(rawId, contextManager)
+        this.extractVariableIds(rawId).forEach((v) => usedVariables.add(v))
+        if (rawId.includes('.')) {
+          usedVariables.add(rawId)
+        }
+        // `resolveVariableValue` echoes the reference back when the variable is
+        // missing, so an unresolved binding arrives here as its own path string.
+        // Drop it rather than sending a variable path to the resolver as an id:
+        // it would cost a roundtrip, resolve to nothing anyway, and make the
+        // node's `targets` telemetry lie about what it searched.
+        if (resolvedId === rawId) {
+          contextManager.log('WARN', node.name, 'Knowledge source variable did not resolve', {
+            reference: rawId,
+          })
+          resolvedId = undefined
         }
       }
 
-      if (resolvedDatasetId) {
-        resolvedDatasetIds.push(resolvedDatasetId)
-      }
+      if (!resolvedId) continue
+      targets.push(
+        row.kind === 'kb'
+          ? { kind: 'kb', knowledgeBaseId: resolvedId }
+          : { kind: 'dataset', datasetId: resolvedId }
+      )
     }
 
-    if (resolvedDatasetIds.length === 0) {
-      throw this.createProcessingError('No valid dataset IDs after resolution', node, {
-        originalDatasets: config.datasets,
+    if (targets.length === 0) {
+      throw this.createProcessingError('No valid knowledge sources after resolution', node, {
+        originalSources: config.sources,
       })
     }
 
@@ -230,17 +346,27 @@ export class KnowledgeRetrievalProcessor extends BaseNodeProcessor {
 
     let resolvedLimit = DEFAULT_LIMIT
     const limitValue = await resolveNumberConfig(config.limit, resolveValue)
-    if (limitValue !== undefined && limitValue >= 1 && limitValue <= 100) {
+    if (limitValue !== undefined && limitValue >= 1 && limitValue <= MAX_LIMIT) {
       resolvedLimit = Math.floor(limitValue)
     }
     extractVariableRefs(config.limit).forEach((v) => usedVariables.add(v))
 
-    let resolvedSimilarityThreshold = DEFAULT_SIMILARITY_THRESHOLD
+    // K7 — no node default. `undefined` lets the vector lane's own 0.4 apply.
+    let resolvedSimilarityThreshold: number | undefined
     const thresholdValue = await resolveNumberConfig(config.similarityThreshold, resolveValue)
     if (thresholdValue !== undefined && thresholdValue >= 0 && thresholdValue <= 1) {
       resolvedSimilarityThreshold = thresholdValue
     }
     extractVariableRefs(config.similarityThreshold).forEach((v) => usedVariables.add(v))
+
+    const dedupePerDocument = await this.resolveBooleanConfig(
+      config.dedupePerDocument,
+      resolveValue
+    )
+    extractVariableRefs(config.dedupePerDocument).forEach((v) => usedVariables.add(v))
+
+    const recordIds = await this.resolveRecordIds(config.recordIds, resolveValue)
+    extractVariableRefs(config.recordIds).forEach((v) => usedVariables.add(v))
 
     // Get organization and user IDs from context
     const organizationId = (await contextManager.getVariable('sys.organizationId')) as string
@@ -250,6 +376,72 @@ export class KnowledgeRetrievalProcessor extends BaseNodeProcessor {
       throw this.createProcessingError('Organization ID not available in execution context', node)
     }
 
+    // === K5 — resolve on the workflow author's authority ===
+    //
+    // `SearchService.search` has NO ACL of its own: `getAccessibleDatasets`
+    // filters on organizationId + status only, takes a `userId` and never uses
+    // it. Everything below this line is what stands between a workflow and
+    // every dataset in the org, so it must never be skipped.
+    //
+    // `sys.userId` is the workflow's `createdById` on every production trigger.
+    // A non-member composes to an EMPTY capability set and reads deny rather
+    // than running unrestricted — the correct outcome, so the only addition is
+    // a loud diagnostic. Workflows are not permission principals yet; when they
+    // become one, this is the single site to change.
+    if (!userId) {
+      throw this.createProcessingError(
+        'No user in execution context — knowledge retrieval cannot resolve access and will not run unrestricted',
+        node
+      )
+    }
+
+    // Lazy imports — keeps module load light and avoids dragging the org cache
+    // into modules that never take this path (mirrors `ai-v2.ts`).
+    const [{ getCapabilities }, { getCachedMembers }] = await Promise.all([
+      import('../../../permissions/capabilities/get-capabilities'),
+      import('../../../cache/org-cache-helpers'),
+    ])
+
+    const capabilities = await getCapabilities(userId, organizationId)
+    const principalMember = (await getCachedMembers(organizationId)).find(
+      (m) => m.userId === userId
+    )
+    if (!principalMember || principalMember.status !== 'ACTIVE') {
+      contextManager.log(
+        'WARN',
+        node.name,
+        'Knowledge retrieval principal is not an active member — every source will deny',
+        { userId }
+      )
+    }
+
+    const resolved = await resolveKnowledgeDatasetIds(db, {
+      organizationId,
+      targets,
+      capabilities,
+      // K6 — there is no agent here, so no `Agent.knowledge` scope to resolve.
+      // Explicit `null` (the unrestricted arm) so this reads as a decision.
+      knowledgeScope: null,
+    })
+    if (resolved.isErr()) {
+      throw this.createProcessingError(
+        `Failed to resolve knowledge sources: ${resolved.error.message}`,
+        node
+      )
+    }
+    const resolvedDatasetIds = resolved.value
+
+    // Fails closed: inaccessible or unresolvable sources contribute nothing,
+    // and an empty set errors exactly as an empty selection does — it must
+    // never fall through to an unscoped search.
+    if (resolvedDatasetIds.length === 0) {
+      throw this.createProcessingError(
+        'No accessible knowledge sources — check the selected knowledge bases/datasets and the workflow author’s access',
+        node,
+        { targetCount: targets.length }
+      )
+    }
+
     return {
       inputs: {
         query: resolvedQuery,
@@ -257,20 +449,51 @@ export class KnowledgeRetrievalProcessor extends BaseNodeProcessor {
         searchType: resolvedSearchType,
         limit: resolvedLimit,
         similarityThreshold: resolvedSimilarityThreshold,
+        dedupePerDocument,
+        recordIds,
         organizationId,
         userId,
         variablesUsed: Array.from(usedVariables),
       },
       metadata: {
         nodeType: 'knowledge-retrieval',
+        sourceCount: targets.length,
         datasetCount: resolvedDatasetIds.length,
         searchType: resolvedSearchType,
         limit: resolvedLimit,
         similarityThreshold: resolvedSimilarityThreshold,
+        dedupePerDocument,
         variableCount: usedVariables.size,
         preprocessingComplete: true,
       },
     }
+  }
+
+  /** Resolve a bindable boolean — literal, or a variable reference to resolve. */
+  private async resolveBooleanConfig(
+    raw: boolean | string | undefined,
+    resolveValue: (raw: string) => Promise<unknown>
+  ): Promise<boolean> {
+    if (typeof raw === 'boolean') return raw
+    if (typeof raw !== 'string' || raw.length === 0) return false
+    const value = await resolveValue(raw)
+    if (typeof value === 'boolean') return value
+    if (typeof value === 'string') return value === 'true'
+    return false
+  }
+
+  /** Resolve a bindable record-id list — a literal array, or a bound value. */
+  private async resolveRecordIds(
+    raw: string[] | string | undefined,
+    resolveValue: (raw: string) => Promise<unknown>
+  ): Promise<string[]> {
+    if (Array.isArray(raw)) return raw.filter((id) => typeof id === 'string' && id.length > 0)
+    if (typeof raw !== 'string' || raw.length === 0) return []
+    const value = await resolveValue(raw)
+    if (Array.isArray(value)) {
+      return value.filter((id): id is string => typeof id === 'string' && id.length > 0)
+    }
+    return typeof value === 'string' && value.length > 0 ? [value] : []
   }
 
   /**
@@ -305,13 +528,28 @@ export class KnowledgeRetrievalProcessor extends BaseNodeProcessor {
         throw this.createExecutionError('Preprocessed data is required', node)
       }
 
-      // Build search query
+      const recordIds: string[] = inputs.recordIds ?? []
+      const dedupePerDocument: boolean = inputs.dedupePerDocument === true
+      const needsPostFilter = dedupePerDocument || recordIds.length > 0
+
+      // Over-fetch only when something downstream will cut the list, so an
+      // unfiltered run issues exactly the query it always did.
+      const fetchLimit = needsPostFilter
+        ? Math.min(Math.max(inputs.limit * 3, OVERFETCH_MIN), OVERFETCH_MAX)
+        : inputs.limit
+
+      // Build search query. `similarityThreshold` is omitted when unset (K7) so
+      // the vector lane's own default applies.
       const searchQuery: SearchQuery = {
         query: inputs.query,
         datasetIds: inputs.datasetIds,
         searchType: inputs.searchType,
-        limit: inputs.limit,
-        similarityThreshold: inputs.similarityThreshold,
+        limit: fetchLimit,
+        // Required for KB provenance — the vector lane gates metadata on it.
+        includeMetadata: true,
+        ...(inputs.similarityThreshold !== undefined
+          ? { similarityThreshold: inputs.similarityThreshold }
+          : {}),
       }
 
       // Execute search
@@ -321,20 +559,62 @@ export class KnowledgeRetrievalProcessor extends BaseNodeProcessor {
         inputs.userId
       )
 
-      // Transform results to flattened format for easier downstream access
-      const transformedResults: KnowledgeRetrievalResultItem[] = searchResponse.results.map(
-        (result: SearchResult) => ({
-          content: result.segment.content,
-          score: result.score,
-          rank: result.rank,
-          segmentId: result.segment.id,
-          documentId: result.segment.document.id,
-          documentTitle: result.segment.document.title || result.segment.document.filename,
-          datasetId: result.segment.document.dataset.id,
-          datasetName: result.segment.document.dataset.name,
-          position: result.segment.position,
-          searchType: result.searchType,
+      let results = searchResponse.results
+
+      if (recordIds.length > 0) {
+        results = results.filter((result: SearchResult) => {
+          const links = readSegmentMeta(result).links
+          if (!links || links.length === 0) return false
+          return links.some((l) => l.recordId && recordIds.includes(l.recordId))
         })
+      }
+
+      if (dedupePerDocument) {
+        // Results arrive score-sorted, so the first segment seen for a source
+        // is its best passage. Without this one long article can occupy every
+        // slot and crowd out other relevant sources.
+        const seen = new Set<string>()
+        results = results.filter((result: SearchResult) => {
+          const key =
+            readSegmentMeta(result).articleId ?? result.segment.document.id ?? result.segment.id
+          if (seen.has(key)) return false
+          seen.add(key)
+          return true
+        })
+      }
+
+      if (needsPostFilter) results = results.slice(0, inputs.limit)
+
+      // Transform results to flattened format for easier downstream access
+      const transformedResults: KnowledgeRetrievalResultItem[] = results.map(
+        (result: SearchResult) => {
+          const meta = readSegmentMeta(result)
+          const isKb = meta.source === 'kb'
+          const docSlug =
+            isKb && meta.kbSlug && meta.articleSlugPath
+              ? `${meta.kbSlug}/${meta.articleSlugPath}`
+              : undefined
+
+          return {
+            content: result.segment.content,
+            score: result.score,
+            rank: result.rank,
+            segmentId: result.segment.id,
+            documentId: result.segment.document.id,
+            documentTitle: result.segment.document.title || result.segment.document.filename,
+            datasetId: result.segment.document.dataset.id,
+            datasetName: result.segment.document.dataset.name,
+            position: result.segment.position,
+            searchType: result.searchType,
+            source: isKb ? ('kb' as const) : ('rag' as const),
+            ...(meta.articleId ? { articleId: meta.articleId } : {}),
+            ...(meta.articleSlug ? { articleSlug: meta.articleSlug } : {}),
+            ...(meta.articleSlugPath ? { articleSlugPath: meta.articleSlugPath } : {}),
+            ...(meta.kbId ? { kbId: meta.kbId } : {}),
+            ...(meta.kbSlug ? { kbSlug: meta.kbSlug } : {}),
+            ...(docSlug ? { docSlug } : {}),
+          }
+        }
       )
 
       // Build output
@@ -429,14 +709,15 @@ export class KnowledgeRetrievalProcessor extends BaseNodeProcessor {
       }
     }
 
-    // Extract from datasets (each entry can be a variable)
-    if (config.datasets && Array.isArray(config.datasets)) {
-      config.datasets.forEach((entry, index) => {
-        const fieldKey = `datasets.${index}.datasetId`
-        if (entry.datasetId && config.fieldModes?.[fieldKey] === false) {
-          this.extractVariableIds(entry.datasetId).forEach((v) => variables.add(v))
-          if (entry.datasetId.includes('.')) {
-            variables.add(entry.datasetId)
+    // Extract from sources (each row's id can be a variable)
+    if (config.sources && Array.isArray(config.sources)) {
+      config.sources.forEach((row, index) => {
+        const rawId = sourceRawId(row)
+        const fieldKey = sourceFieldKey(row, index)
+        if (rawId && config.fieldModes?.[fieldKey] === false) {
+          this.extractVariableIds(rawId).forEach((v) => variables.add(v))
+          if (rawId.includes('.')) {
+            variables.add(rawId)
           }
         }
       })
@@ -447,6 +728,8 @@ export class KnowledgeRetrievalProcessor extends BaseNodeProcessor {
     extractVariableRefs(config.searchType).forEach((v) => variables.add(v))
     extractVariableRefs(config.limit).forEach((v) => variables.add(v))
     extractVariableRefs(config.similarityThreshold).forEach((v) => variables.add(v))
+    extractVariableRefs(config.dedupePerDocument).forEach((v) => variables.add(v))
+    extractVariableRefs(config.recordIds).forEach((v) => variables.add(v))
 
     return Array.from(variables)
   }
@@ -473,14 +756,25 @@ export class KnowledgeRetrievalProcessor extends BaseNodeProcessor {
       errors.push('Query is required')
     }
 
-    if (!config.datasets || config.datasets.length === 0) {
-      errors.push('At least one dataset must be selected')
+    if (!config.sources || config.sources.length === 0) {
+      errors.push('At least one knowledge source must be selected')
     }
+
+    // K3 — a variable-bound source id cannot be checked at author time. Warn;
+    // the runtime resolution fails closed. Do NOT add a "helpful" author-time
+    // lookup here: a bound id would fail it anyway.
+    config.sources?.forEach((row, index) => {
+      if (config.fieldModes?.[sourceFieldKey(row, index)] === false) {
+        warnings.push(
+          `Source ${index + 1} is bound to a variable — it cannot be verified until the workflow runs`
+        )
+      }
+    })
 
     // Validate literal ranges only — a bound field holds a variable reference
     // whose value is not known until the run, and is range-checked there
-    if (typeof config.limit === 'number' && (config.limit < 1 || config.limit > 100)) {
-      errors.push('Limit must be between 1 and 100')
+    if (typeof config.limit === 'number' && (config.limit < 1 || config.limit > MAX_LIMIT)) {
+      errors.push(`Limit must be between 1 and ${MAX_LIMIT}`)
     }
 
     if (

--- a/packages/lib/src/workflows/templates/kb-auto-responder.template.json
+++ b/packages/lib/src/workflows/templates/kb-auto-responder.template.json
@@ -71,15 +71,17 @@
           "title": "Search Knowledge Base",
           "desc": "Search KB for articles relevant to the customer's question",
           "query": "{{trigger_1.message.subject}} {{trigger_1.message.body}}",
-          "datasets": [],
+          "sources": [{ "kind": "kb", "knowledgeBaseId": "" }],
           "searchType": "hybrid",
           "limit": 5,
-          "similarityThreshold": 0.7,
+          "dedupePerDocument": true,
           "fieldModes": {
             "query": false,
             "searchType": true,
             "limit": true,
-            "similarityThreshold": true
+            "similarityThreshold": true,
+            "dedupePerDocument": true,
+            "sources.0.knowledgeBaseId": true
           }
         },
         "width": 244,


### PR DESCRIPTION
PR 2 of 3 from `plans/kopilot/workflow/12-knowledge-retrieval-sources.md`. Builds on #1639.

## The bug

A workflow **cannot search the knowledge base.** `knowledge-retrieval` takes `datasets: [{ datasetId }]`, but KB articles are embedded into their home KB's **managed** dataset, and managed datasets are deliberately hidden from every dataset picker. So the bundled `kb-auto-responder` template ships `"datasets": []` to be filled from a list that can never contain a KB — **a knowledge-base auto-responder that structurally cannot work.**

## K2 — `datasets[]` → `sources[]`

```ts
type KnowledgeSourceRow =
  | { kind: 'dataset'; datasetId: string }
  | { kind: 'kb'; knowledgeBaseId: string }
```

The row's kind is **stored, not inferred** from which id field is populated — a row whose id is variable-bound still has to know which picker it renders and which resolver arm it belongs to. No implicit "all knowledge bases": that silently widens as KBs are added.

## K5 — this is where the access hole actually closes

#1639 moved the fail-open into one explicit `capabilities ?? 'unrestricted'` line. **This PR is what makes the clamp real**: the node resolves on the workflow author's authority via `getCapabilities(sys.userId, organizationId)`.

That matters because **`SearchService.search` has no ACL of its own** — `getAccessibleDatasets` filters on `organizationId` and `status` only, and takes a `userId` it never uses. This chain is the only thing standing between a workflow and every dataset in the org. It fails closed three ways:

| Situation | Behaviour |
|---|---|
| No user in execution context | Refuses to run — never resolves unrestricted |
| One row unresolvable/inaccessible | Contributes nothing; siblings still search |
| Every row resolves to nothing | Errors — never falls through to an unscoped search |

## Also in this slice

- **K6** — explicit `null` `knowledgeScope`. No agent here, so the call site reads as a decision rather than an omission.
- **K7** — `similarityThreshold` loses its 0.7 default. The vector lane's own floor is 0.4, so the node gave materially worse recall than the `search_knowledge` path over identical content. ⚠ **Observable change**: existing nodes return more results, at lower scores.
- **K8** — `dedupePerDocument`, one best passage per article. Schema default false (existing nodes keep raw segments), `defaultData` true (new nodes get the good behaviour).
- **K9** — `limit` ceiling 100 → **25**. Chunks default to 1000 chars and the node deliberately does *not* truncate content, so 100 results was ~25k tokens into a downstream `ai`/`answer` node.
- **§7 output** — `source`, `articleId`, `articleSlug`, `articleSlugPath`, `kbId`, `kbSlug`, `docSlug` (all additive), plus `includeMetadata: true` and a `recordIds` post-filter. `docSlug` is what lets a downstream node cite `[Title](auxx://doc/<docSlug>)`.
- **Panel** — kind-aware add menu and picker. Plus a pre-existing bug: removing a row deleted only that index's `fieldModes` key without reindexing, so removing row 0 of three left rows 1–2 reading each other's constant/variable settings.
- **Migration `087`** (not `084` — `084`–`086` landed since the plan was written) over `Workflow.graph` and `WorkflowTemplate.graph`. `WorkflowRun.graph` deliberately excluded: run snapshots are immutable evidence.

## Federation gap fix (§5c) — own commit

A `Document` lives in its article's **home** KB's dataset, but federation only followed *source-linked* placements (`linkedFromSourceId`). A hand-authored article linked KB-A → KB-B has that field null, so its embeddings sit in KB-A's dataset and a KB-B-scoped search never looked there. Now unions home-KB datasets too.

**Added alongside the source path, not replacing it.** The home-KB union very likely subsumes the two-hop source chain, but that is unverified against real source-linked data, and swapping out a working security-relevant path on an unverified subsumption is the wrong trade.

## Two plan corrections found while implementing

**§7's metadata-invariant claim was wrong about the mechanism.** The plan said `kb-sync-service` writes the same object to both `metadata` and `searchMetadata`, and asked for a test pinning that. It doesn't: `searchMetadata` is **derived from** `metadata` at embed time (`embedding-processor.ts` spreads `segment.metadata` last, `postgresql.ts` writes the result). The invariant is structural rather than a coincidence of two writes — stronger than assumed, and the requested test would have been testing a spread. Tested the output mapping instead, and corrected the code comment. (No gap for unembedded segments either: they can't reach the vector lane, which requires `indexStatus = 'INDEXED'`.)

**K3 was only accidentally true.** `extractIdFromValue` echoes the reference path back when a variable is missing, so an unresolved binding reached the resolver as a literal id like `find_1.missing`. It failed closed at the DB, but cost a roundtrip and made the node's `targets` telemetry lie. Dropped explicitly now, with a WARN.

## Testing

47 new tests — migration rewriter (incl. the independent-guards case), output contract, dedupe, `recordIds`, source routing, the three fail-closed paths, federation. lib ratchet 29/29, web ratchet 0/0, 1445 lib + 111 web workflow tests green.

## Before merging

**Migration `087` clamps stored `limit` values and I could not verify the blast radius** — it needs a dev DB query. Expected to be zero (default is 20, raising it is manual) and the migration doesn't assume that, but worth a check against dev first.
