### PR TITLE
feat(records): duplicate suggestion surfaces, router and merge wire-up

### DIFF
--- a/apps/web/src/components/detail-view/components/detail-view-actions.test.tsx
+++ b/apps/web/src/components/detail-view/components/detail-view-actions.test.tsx
@@ -137,6 +137,12 @@ vi.mock('~/components/permissions/ui/instance-share-dialog', () => ({
 vi.mock('~/components/permissions/ui/instance-share-avatars', () => ({
   InstanceShareAvatars: () => null,
 }))
+// Same reason: it runs its own `duplicates.forRecord` query and renders nothing
+// unless the record has open duplicate pairs. Ungated like the star beside it,
+// so it can only add noise to a test about the write gate.
+vi.mock('~/components/duplicates/ui/duplicate-indicator-button', () => ({
+  DuplicateIndicatorButton: () => null,
+}))
 vi.mock('~/components/sequences/ui/add-to-sequence-dialog', () => ({
   AddToSequenceDialog: () => null,
 }))

--- a/apps/web/src/components/detail-view/components/detail-view-actions.tsx
+++ b/apps/web/src/components/detail-view/components/detail-view-actions.tsx
@@ -6,6 +6,7 @@ import { Button } from '@auxx/ui/components/button'
 import { Kbd } from '@auxx/ui/components/kbd'
 import { Share2 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
+import { DuplicateIndicatorButton } from '~/components/duplicates/ui/duplicate-indicator-button'
 import { FavoriteStarButton } from '~/components/favorites/ui/favorite-star-button'
 import { GranularPermissionsGate } from '~/components/mail-permissions/ui/granular-permissions-gate'
 import { InstanceShareAvatars } from '~/components/permissions/ui/instance-share-avatars'
@@ -117,6 +118,15 @@ export function DetailViewActions({
           />
         </GranularPermissionsGate>
       )}
+
+      {/* Renders nothing unless this record has open duplicate pairs. Same
+          component the drawer header mounts — one affordance, two surfaces,
+          exactly like the star beside it. */}
+      <DuplicateIndicatorButton
+        recordId={recordId}
+        size='icon-xs'
+        className={RECORD_HEADER_GHOST}
+      />
 
       <FavoriteStarButton
         targetType='ENTITY_INSTANCE'

--- a/apps/web/src/components/duplicates/ui/duplicate-indicator-button.tsx
+++ b/apps/web/src/components/duplicates/ui/duplicate-indicator-button.tsx
@@ -1,0 +1,169 @@
+// apps/web/src/components/duplicates/ui/duplicate-indicator-button.tsx
+'use client'
+
+import { FeatureKey } from '@auxx/lib/permissions/client'
+import { type RecordId, toRecordId } from '@auxx/lib/resources/client'
+import { Button, type ButtonProps } from '@auxx/ui/components/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { toastError } from '@auxx/ui/components/toast'
+import { SimpleTooltip } from '@auxx/ui/components/tooltip'
+import { cn } from '@auxx/ui/lib/utils'
+import { CopyCheck } from 'lucide-react'
+import { useState } from 'react'
+import { MergeDialog } from '~/components/merge/merge-dialog'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import { api } from '~/trpc/react'
+import {
+  DuplicateBandBadge,
+  DuplicateRecordCard,
+  DuplicateSignalChips,
+} from './duplicate-pair-summary'
+
+/**
+ * The per-record duplicates affordance, mounted in BOTH record headers
+ * (plan §3.3) — the drawer's icon cluster and the detail page's action cluster,
+ * the same two mount points `FavoriteStarButton` has.
+ *
+ * **It renders NOTHING when the record has no open pairs**, which is nearly
+ * every record. That is the whole design constraint: a header badge that is
+ * present-but-empty on every contact in the org would be pure noise, so the
+ * component's default state is absence, not an empty popover.
+ *
+ * It mounts its OWN `MergeDialog` (the `ticket-row-actions.tsx` precedent).
+ * Neither header owns one any more — merge moved into the shared
+ * `RecordActionsMenu` — so borrowing one would mean threading dialog state up
+ * through two unrelated headers.
+ *
+ * The query is doubly lazy: gated on the plan feature AND on `enabled`, which
+ * the drawer passes as `!!open`. A closed drawer costs the server nothing.
+ */
+export function DuplicateIndicatorButton({
+  recordId,
+  enabled = true,
+  size = 'icon-sm',
+  className,
+}: {
+  recordId: RecordId
+  /** The drawer passes `!!open` — a mounted-but-closed drawer must not query. */
+  enabled?: boolean
+  size?: ButtonProps['size']
+  className?: string
+}) {
+  const { hasAccess } = useFeatureFlags()
+  const featureEnabled = hasAccess(FeatureKey.duplicateDetection)
+  const utils = api.useUtils()
+
+  const [open, setOpen] = useState(false)
+  const [mergeIds, setMergeIds] = useState<RecordId[] | null>(null)
+
+  const pairs = api.duplicates.forRecord.useQuery(
+    { recordId },
+    { enabled: featureEnabled && enabled, refetchOnWindowFocus: false }
+  )
+
+  const dismiss = api.duplicates.dismiss.useMutation({
+    onSuccess: () => {
+      void utils.duplicates.forRecord.invalidate()
+      void utils.duplicates.list.invalidate()
+      void utils.duplicates.count.invalidate()
+    },
+    onError: (error) => toastError({ title: 'Dismiss failed', description: error.message }),
+  })
+
+  const items = pairs.data ?? []
+  // Absence, not an empty state — see the component docstring.
+  if (!featureEnabled || items.length === 0) return null
+
+  const onMergeComplete = () => {
+    setMergeIds(null)
+    setOpen(false)
+    void utils.duplicates.forRecord.invalidate()
+    void utils.duplicates.list.invalidate()
+    void utils.duplicates.count.invalidate()
+  }
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <SimpleTooltip
+          content={`${items.length} possible duplicate${items.length === 1 ? '' : 's'}`}>
+          <PopoverTrigger asChild>
+            <Button
+              type='button'
+              variant='ghost'
+              size={size}
+              aria-label='Possible duplicates'
+              className={cn('relative', className)}>
+              <CopyCheck />
+              {/* Count rides the icon rather than sitting beside it: the header
+                  clusters are fixed-width icon slots in the drawer. */}
+              <span className='-top-0.5 -right-0.5 absolute flex size-3.5 items-center justify-center rounded-full bg-amber-500 text-[9px] font-medium text-white'>
+                {items.length > 9 ? '9+' : items.length}
+              </span>
+            </Button>
+          </PopoverTrigger>
+        </SimpleTooltip>
+
+        <PopoverContent align='end' className='w-80 p-0'>
+          <div className='border-b px-3 py-2 font-medium text-xs uppercase tracking-wide text-muted-foreground'>
+            Possible duplicates
+          </div>
+          <div className='flex max-h-96 flex-col divide-y overflow-y-auto'>
+            {items.map((pair) => (
+              <div key={pair.id} className='flex flex-col gap-2 px-3 py-2.5'>
+                <DuplicateRecordCard
+                  record={{
+                    recordId: toRecordId(pair.entityDefinitionId, pair.other.instanceId),
+                    displayName: pair.other.displayName,
+                    secondaryDisplayValue: pair.other.secondaryDisplayValue,
+                    avatarUrl: pair.other.avatarUrl,
+                  }}
+                />
+                <div className='flex flex-wrap items-center gap-1.5'>
+                  <DuplicateBandBadge band={pair.band} />
+                  <DuplicateSignalChips signals={pair.signals} />
+                </div>
+                <div className='flex items-center justify-end gap-1'>
+                  <Button
+                    variant='ghost'
+                    size='sm'
+                    disabled={dismiss.isPending}
+                    onClick={() => dismiss.mutate({ pairId: pair.id })}>
+                    Dismiss
+                  </Button>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    onClick={() =>
+                      setMergeIds(
+                        pair.mergeInstanceIds.map((id) => toRecordId(pair.entityDefinitionId, id))
+                      )
+                    }>
+                    Review & merge
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {mergeIds ? (
+        <MergeDialog
+          open
+          onOpenChange={(next) => !next && setMergeIds(null)}
+          baseRecordIds={mergeIds}
+          /**
+           * The record whose header this is stays the target, whatever the
+           * establishment ordering says — a merge started FROM a record is a
+           * statement about which one the user is standing on. The ordering
+           * still decides the target for the Approvals-tab entry point, which
+           * has no such anchor.
+           */
+          targetRecordId={recordId}
+          onMergeComplete={onMergeComplete}
+        />
+      ) : null}
+    </>
+  )
+}

--- a/apps/web/src/components/duplicates/ui/duplicate-pair-summary.tsx
+++ b/apps/web/src/components/duplicates/ui/duplicate-pair-summary.tsx
@@ -1,0 +1,170 @@
+// apps/web/src/components/duplicates/ui/duplicate-pair-summary.tsx
+'use client'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
+import { Badge } from '@auxx/ui/components/badge'
+import { cn } from '@auxx/ui/lib/utils'
+
+/**
+ * The pair-rendering vocabulary shared by the Approvals-tab row (§3.2) and the
+ * per-record header popover (§3.3).
+ *
+ * It lives here rather than inside either caller because the two need exactly
+ * the same three things — who the records are, how confident the engine is, and
+ * what matched — while their chrome is entirely different (a `NotificationRow`
+ * card vs. a header popover). Keeping the body in one place is what stops the
+ * two surfaces describing the same pair differently.
+ *
+ * Everything here is presentational: no queries, no mutations, no record
+ * fetching. The pair read already returns both sides' display columns, so
+ * reaching for `RecordBadge` (which resolves its own record) would add one query
+ * per side for data already in hand.
+ */
+
+/** One side of a pair, as the router returns it. */
+export interface DuplicateRecordSummary {
+  recordId: string
+  displayName: string | null
+  secondaryDisplayValue: string | null
+  avatarUrl: string | null
+}
+
+/**
+ * One piece of evidence.
+ *
+ * `value` is the matched value, not just the field — contact `primary_email`,
+ * contact `phone` and company `website` are multi-value, so "matched on: email"
+ * cannot say *which* address, which is precisely the fact a reviewer needs
+ * before merging. `otherValue` is present only when the two sides matched on
+ * DIFFERENT values (a nickname, a trigram-tolerant surname, a domain-shape
+ * variant).
+ */
+export interface DuplicateSignalSummary {
+  type: string
+  value: string
+  otherValue?: string
+  fieldKey?: string
+}
+
+/** Human labels for `SignalType`. Unknown types fall back to the raw string. */
+const SIGNAL_LABELS: Record<string, string> = {
+  email: 'Email',
+  phone: 'Phone',
+  unique: 'Unique field',
+  name: 'Name',
+  company: 'Company',
+  address: 'Address',
+  identity: 'External ID',
+  ingest: 'Same import',
+}
+
+function initials(name: string | null): string {
+  const parts = (name ?? '').trim().split(/\s+/).filter(Boolean)
+  if (parts.length === 0) return '?'
+  return parts
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('')
+}
+
+/**
+ * Confidence, as a badge.
+ *
+ * There is deliberately no `low`: a pair we would not ask a human to look at is
+ * a pair the engine does not store, so the badge only ever has two states and
+ * says which kind of evidence produced it.
+ */
+export function DuplicateBandBadge({ band }: { band: string }) {
+  return (
+    <Badge variant={band === 'high' ? 'amber' : 'secondary'} className='shrink-0 text-[10px]'>
+      {band === 'high' ? 'Likely duplicate' : 'Possible duplicate'}
+    </Badge>
+  )
+}
+
+/** One record: avatar, name, and whatever the definition uses as its subtitle. */
+export function DuplicateRecordCard({
+  record,
+  className,
+}: {
+  record: DuplicateRecordSummary
+  className?: string
+}) {
+  const name = record.displayName?.trim() || 'Untitled'
+  return (
+    <div className={cn('flex min-w-0 items-center gap-2', className)}>
+      <Avatar className='size-6 shrink-0'>
+        {record.avatarUrl ? <AvatarImage src={record.avatarUrl} alt={name} /> : null}
+        <AvatarFallback className='text-[10px] font-medium'>
+          {initials(record.displayName)}
+        </AvatarFallback>
+      </Avatar>
+      <div className='min-w-0'>
+        {/* min-w-0 on the flex child, not just `truncate` on the text: a nowrap
+            string still reports its full min-content width and would blow the
+            row out otherwise. */}
+        <div className='truncate text-sm leading-5'>{name}</div>
+        {record.secondaryDisplayValue ? (
+          <div className='truncate text-muted-foreground text-xs leading-4'>
+            {record.secondaryDisplayValue}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+/** `matched on: Email · bob@acme.com` — one chip per signal. */
+export function DuplicateSignalChips({
+  signals,
+  className,
+}: {
+  signals: DuplicateSignalSummary[]
+  className?: string
+}) {
+  if (signals.length === 0) return null
+  return (
+    <div className={cn('flex flex-wrap items-center gap-1', className)}>
+      <span className='text-muted-foreground text-xs'>matched on:</span>
+      {signals.map((signal) => (
+        <span
+          key={`${signal.type}:${signal.value}:${signal.otherValue ?? ''}`}
+          className='inline-flex max-w-full items-center gap-1 truncate rounded-[5px] bg-muted px-1.5 py-0.5 text-[11px] text-foreground/80 ring-1 ring-border'>
+          <span className='shrink-0 text-muted-foreground'>
+            {SIGNAL_LABELS[signal.type] ?? signal.type}
+          </span>
+          <span className='truncate'>
+            {signal.otherValue ? `${signal.value} ↔ ${signal.otherValue}` : signal.value}
+          </span>
+        </span>
+      ))}
+    </div>
+  )
+}
+
+/** The whole body: both records, the band, and the evidence. */
+export function DuplicatePairSummary({
+  records,
+  band,
+  signals,
+  className,
+}: {
+  records: DuplicateRecordSummary[]
+  band: string
+  signals: DuplicateSignalSummary[]
+  className?: string
+}) {
+  return (
+    <div className={cn('flex flex-col gap-2', className)}>
+      <div className='flex flex-col gap-1.5'>
+        {records.map((record) => (
+          <DuplicateRecordCard key={record.recordId} record={record} />
+        ))}
+      </div>
+      <div className='flex flex-wrap items-center gap-1.5'>
+        <DuplicateBandBadge band={band} />
+        <DuplicateSignalChips signals={signals} />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/global/notifications/hooks/use-approvals-count.test.tsx
+++ b/apps/web/src/components/global/notifications/hooks/use-approvals-count.test.tsx
@@ -1,0 +1,92 @@
+// apps/web/src/components/global/notifications/hooks/use-approvals-count.test.tsx
+//
+// The Approvals badge is ONE hook, read by both the sidebar bell and the panel's
+// tab badge, so the two cannot drift. Duplicates are its fifth term (plan §3.2).
+//
+// What is worth pinning is not the arithmetic but the two ways a new term goes
+// wrong: it is added to one consumer and not the shared hook (covered by there
+// being only one hook), or it is counted for orgs that cannot see the section it
+// belongs to — which would show a bell badge pointing at a tab with nothing in
+// it, and a query the router refuses.
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  duplicatesEnabled: true,
+  suggestionsEnabled: true,
+  /** Whether the duplicates count query was ENABLED. */
+  duplicatesQueried: false,
+  duplicatesError: null as unknown,
+}))
+
+vi.mock('~/providers/feature-flag-provider', () => ({
+  useFeatureFlags: () => ({
+    hasAccess: (key: string) =>
+      key === 'duplicateDetection' ? h.duplicatesEnabled : h.suggestionsEnabled,
+  }),
+}))
+
+vi.mock('~/components/mail-suggestions/hooks/use-mail-suggestions', () => ({
+  useMailSuggestionsCount: () => ({ count: 2, isError: false }),
+}))
+
+vi.mock('~/trpc/react', () => ({
+  api: {
+    approval: {
+      getPendingCount: { useQuery: () => ({ data: 3, error: null }) },
+    },
+    approvals: {
+      count: { useQuery: () => ({ data: { count: 5 }, error: null }) },
+    },
+    duplicates: {
+      count: {
+        useQuery: (_input: unknown, opts: { enabled: boolean }) => {
+          h.duplicatesQueried = opts.enabled
+          return {
+            data: opts.enabled ? { count: 7 } : undefined,
+            error: h.duplicatesError,
+          }
+        },
+      },
+    },
+  },
+}))
+
+import { useApprovalsCount } from './use-approvals-count'
+
+beforeEach(() => {
+  h.duplicatesEnabled = true
+  h.suggestionsEnabled = true
+  h.duplicatesQueried = false
+  h.duplicatesError = null
+})
+
+describe('useApprovalsCount', () => {
+  it('sums all five sources', () => {
+    const { result } = renderHook(() => useApprovalsCount())
+    // confirmations 3 + suggestion bundles 5 + mail suggestions 2 + duplicates 7
+    expect(result.current.count).toBe(17)
+  })
+
+  it('drops the duplicates term — and its query — when the org lacks the feature', () => {
+    h.duplicatesEnabled = false
+    const { result } = renderHook(() => useApprovalsCount())
+
+    expect(result.current.count).toBe(10)
+    expect(h.duplicatesQueried).toBe(false)
+  })
+
+  it('surfaces a duplicates failure rather than reading as "all caught up"', () => {
+    h.duplicatesError = new Error('boom')
+    const { result } = renderHook(() => useApprovalsCount())
+    expect(result.current.isError).toBe(true)
+  })
+
+  it('ignores a duplicates failure the org could never have queried', () => {
+    h.duplicatesEnabled = false
+    h.duplicatesError = new Error('stale')
+    const { result } = renderHook(() => useApprovalsCount())
+    expect(result.current.isError).toBe(false)
+  })
+})

--- a/apps/web/src/components/global/notifications/hooks/use-approvals-count.ts
+++ b/apps/web/src/components/global/notifications/hooks/use-approvals-count.ts
@@ -7,7 +7,10 @@ import { useFeatureFlags } from '~/providers/feature-flag-provider'
 import { api } from '~/trpc/react'
 
 export interface ApprovalsCount {
-  /** Pending workflow confirmations + fresh suggestion bundles + mail suggestions. */
+  /**
+   * Pending workflow confirmations + fresh suggestion bundles + mail
+   * suggestions + open duplicate pairs.
+   */
   count: number
   /**
    * At least one of the two queries failed. A badge that fails to load and a
@@ -22,17 +25,21 @@ export interface ApprovalsCount {
  * The Approvals count, shared by the sidebar bell and the panel's tab badge so
  * the two cannot drift.
  *
- * The suggestion filters MUST match `ApprovalsTab`'s list query — including its
- * `FeatureKey.todayInbox` gate. A badge that counts a different set than the tab
- * renders is a bug, not a tuning knob.
+ * Every term's filters MUST match the corresponding `ApprovalsTab` section —
+ * including its feature gate (`FeatureKey.todayInbox` for suggestions,
+ * `FeatureKey.duplicateDetection` for duplicates). A badge that counts a
+ * different set than the tab renders is a bug, not a tuning knob. **Add new
+ * sources here and nowhere else**: the bell and the tab badge both read this
+ * one hook precisely so they cannot disagree.
  *
- * No `enabled` gate: the bell needs this with the panel closed. Both queries
- * refetch on window focus, which is what keeps the badge honest if the realtime
- * ping is ever missed.
+ * No `enabled` gate beyond the feature flags: the bell needs this with the panel
+ * closed. Every query refetches on window focus, which is what keeps the badge
+ * honest if the realtime ping is ever missed.
  */
 export function useApprovalsCount(): ApprovalsCount {
   const { hasAccess } = useFeatureFlags()
   const suggestionsEnabled = hasAccess(FeatureKey.todayInbox)
+  const duplicatesEnabled = hasAccess(FeatureKey.duplicateDetection)
 
   const confirmations = api.approval.getPendingCount.useQuery(undefined, {
     refetchOnWindowFocus: true,
@@ -51,12 +58,32 @@ export function useApprovalsCount(): ApprovalsCount {
    * suggestions above, a different feature for a different audience.
    */
   const mailSuggestions = useMailSuggestionsCount()
+  /**
+   * The Approvals tab's fifth section (duplicate plan §3.2). Counted here for
+   * the same reason mail suggestions are: the section is a lane of one queue,
+   * not a queue of its own, so a second badge would be two numbers describing
+   * one backlog.
+   *
+   * The count query carries the SAME archived, snooze and record-scope filters
+   * as the list — a pair the list refuses to render must not be counted, which
+   * is why the archived filter lives on all three read paths rather than on
+   * `list` alone.
+   */
+  const duplicates = api.duplicates.count.useQuery(undefined, {
+    enabled: duplicatesEnabled,
+    refetchOnWindowFocus: true,
+  })
 
   return {
-    count: (confirmations.data ?? 0) + (suggestions.data?.count ?? 0) + mailSuggestions.count,
+    count:
+      (confirmations.data ?? 0) +
+      (suggestions.data?.count ?? 0) +
+      mailSuggestions.count +
+      (duplicates.data?.count ?? 0),
     isError:
       !!confirmations.error ||
       (suggestionsEnabled && !!suggestions.error) ||
-      mailSuggestions.isError,
+      mailSuggestions.isError ||
+      (duplicatesEnabled && !!duplicates.error),
   }
 }

--- a/apps/web/src/components/global/notifications/ui/approvals-duplicates.test.tsx
+++ b/apps/web/src/components/global/notifications/ui/approvals-duplicates.test.tsx
@@ -1,0 +1,243 @@
+// apps/web/src/components/global/notifications/ui/approvals-duplicates.test.tsx
+//
+// The Approvals tab's fifth section (duplicate plan §3.2 / §3.6).
+//
+// Four claims, all of which have a cheap way to be wrong:
+//
+//  1. **The section renders, LAST.** The tab is a fixed urgency ladder, and data
+//     hygiene is the least urgent lane in it — a section that drifts up the
+//     order pushes an expiring workflow confirmation below a pair that will
+//     still be a duplicate tomorrow.
+//  2. **The flag OFF means no section AND no query.** Skipping the query is the
+//     half that a "does the section render" assertion alone would miss, and the
+//     router refuses outright rather than answering empty, so a query that ran
+//     anyway would surface as an error state.
+//  3. **Review & merge pre-fills the dialog best-established-first.** The dialog
+//     defaults its target to the FIRST id it is handed, so the order IS the
+//     target choice.
+//  4. **Dismiss resolves the row** through the shared mutation.
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const DEF = 'edf_contact00000000000000000'
+const LOW = 'ein_low000000000000000000000'
+const HIGH = 'ein_high00000000000000000000'
+
+const h = vi.hoisted(() => ({
+  /** Whether `FeatureKey.duplicateDetection` is granted. */
+  duplicatesEnabled: true,
+  /** Inputs the duplicates list query was ENABLED for — a lazy-query probe. */
+  listCalls: [] as unknown[],
+  dismissCalls: [] as unknown[],
+  /** `baseRecordIds` the merge dialog was mounted with. */
+  mergeProps: [] as unknown[],
+  items: [] as unknown[],
+}))
+
+vi.mock('~/providers/feature-flag-provider', () => ({
+  useFeatureFlags: () => ({
+    hasAccess: (key: string) => (key === 'duplicateDetection' ? h.duplicatesEnabled : true),
+  }),
+}))
+
+vi.mock('~/components/mail-suggestions/hooks/use-mail-suggestions', () => ({
+  useMailSuggestions: () => ({
+    data: [],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}))
+
+// The other four sections' rows pull unrelated tRPC/query graphs. Their lists
+// are empty here anyway — mocking them keeps this file about the fifth section.
+vi.mock('./items/access-request-row', () => ({ AccessRequestRow: () => null }))
+vi.mock('./items/confirmation-row', () => ({ ConfirmationRow: () => null }))
+vi.mock('./items/decided-row', () => ({ DecidedRow: () => null }))
+vi.mock('./items/suggestion-row', () => ({ SuggestionRow: () => null }))
+vi.mock('./items/mail-suggestion-row', () => ({ MailSuggestionRow: () => null }))
+
+// A probe, not a stub: what the dialog is HANDED is claim 3.
+vi.mock('~/components/merge/merge-dialog', () => ({
+  MergeDialog: (props: Record<string, unknown>) => {
+    h.mergeProps.push(props)
+    return <div data-testid='merge-dialog' />
+  },
+}))
+
+vi.mock('~/trpc/react', () => ({
+  api: {
+    useUtils: () => ({
+      approval: { list: { invalidate: vi.fn() }, getPendingCount: { invalidate: vi.fn() } },
+      approvals: { list: { invalidate: vi.fn() }, count: { invalidate: vi.fn() } },
+      mailSuggestions: { count: { invalidate: vi.fn() } },
+      duplicates: {
+        list: { invalidate: vi.fn() },
+        count: { invalidate: vi.fn() },
+        forRecord: { invalidate: vi.fn() },
+      },
+    }),
+    approval: {
+      list: {
+        useQuery: () => ({ data: { items: [] }, isLoading: false, error: null, refetch: vi.fn() }),
+        useInfiniteQuery: () => ({ data: undefined, isLoading: false, error: null }),
+      },
+    },
+    approvals: {
+      list: {
+        useInfiniteQuery: () => ({
+          data: undefined,
+          isLoading: false,
+          error: null,
+          refetch: vi.fn(),
+          hasNextPage: false,
+          isFetchingNextPage: false,
+          fetchNextPage: vi.fn(),
+        }),
+      },
+    },
+    duplicates: {
+      list: {
+        useQuery: (input: unknown, opts: { enabled: boolean }) => {
+          if (opts.enabled) h.listCalls.push(input)
+          return {
+            data: opts.enabled ? { items: h.items, nextCursor: null } : undefined,
+            isLoading: false,
+            error: null,
+            refetch: vi.fn(),
+          }
+        },
+      },
+      dismiss: {
+        useMutation: (opts: { onSuccess?: () => void }) => ({
+          mutate: (input: unknown) => {
+            h.dismissCalls.push(input)
+            opts.onSuccess?.()
+          },
+          isPending: false,
+        }),
+      },
+    },
+  },
+}))
+
+import { ApprovalsTab } from './approvals-tab'
+
+function pair(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'dup_1',
+    entityDefinitionId: DEF,
+    score: 0.95,
+    band: 'high',
+    signals: [{ type: 'email', strength: 'strong', value: 'bob@acme.test' }],
+    createdAt: new Date().toISOString(),
+    low: {
+      instanceId: LOW,
+      displayName: 'Bob Smith',
+      secondaryDisplayValue: 'bob@acme.test',
+      avatarUrl: null,
+    },
+    high: {
+      instanceId: HIGH,
+      displayName: 'Robert Smith',
+      secondaryDisplayValue: 'bob@acme.test',
+      avatarUrl: null,
+    },
+    // Server-decided order: the HIGH record is better established, so it must
+    // survive the merge even though canonical pair order puts LOW first.
+    mergeInstanceIds: [HIGH, LOW],
+    ...overrides,
+  }
+}
+
+function renderTab() {
+  const viewportRef = { current: null }
+  return render(<ApprovalsTab viewportRef={viewportRef} />)
+}
+
+beforeEach(() => {
+  h.duplicatesEnabled = true
+  h.listCalls = []
+  h.dismissCalls = []
+  h.mergeProps = []
+  h.items = [pair()]
+})
+
+describe('the Possible duplicates section', () => {
+  it('renders both records and the matched value', () => {
+    renderTab()
+
+    expect(screen.getByText('Possible duplicates')).toBeInTheDocument()
+    expect(screen.getByText('Bob Smith')).toBeInTheDocument()
+    expect(screen.getByText('Robert Smith')).toBeInTheDocument()
+    // The chip names the matched VALUE, not just the field — multi-value email
+    // means "matched on: email" cannot say which address.
+    expect(screen.getAllByText('bob@acme.test').length).toBeGreaterThan(0)
+  })
+
+  it('is hidden AND unqueried when the org lacks the feature', () => {
+    h.duplicatesEnabled = false
+    renderTab()
+
+    expect(screen.queryByText('Possible duplicates')).not.toBeInTheDocument()
+    // The query must be SKIPPED, not merely ignored: the router refuses without
+    // the flag, so a query that ran would produce an error, not an empty list.
+    expect(h.listCalls).toHaveLength(0)
+  })
+
+  it('is hidden when there are no open pairs', () => {
+    h.items = []
+    renderTab()
+    expect(screen.queryByText('Possible duplicates')).not.toBeInTheDocument()
+  })
+
+  it('leaves the all-caught-up state alone when duplicates are the only source', () => {
+    h.items = []
+    renderTab()
+    expect(screen.getByText('Nothing needs your approval')).toBeInTheDocument()
+  })
+})
+
+describe('Review & merge', () => {
+  it('pre-fills the dialog with the cluster, best-established first', async () => {
+    renderTab()
+    await userEvent.click(screen.getByText('Review & merge'))
+
+    expect(screen.getByTestId('merge-dialog')).toBeInTheDocument()
+    const props = h.mergeProps.at(-1) as { baseRecordIds: string[]; targetRecordId?: string }
+    // The dialog defaults its target to the first id, so the ORDER is the
+    // target choice — pair order would have put LOW (an arbitrary cuid sort)
+    // first, which is how "merged into the empty stub" happens.
+    expect(props.baseRecordIds).toEqual([`${DEF}:${HIGH}`, `${DEF}:${LOW}`])
+    // No explicit target from this entry point: the ordering already decided it.
+    expect(props.targetRecordId).toBeUndefined()
+  })
+
+  it('does not mount the dialog until it is asked for', () => {
+    renderTab()
+    expect(screen.queryByTestId('merge-dialog')).not.toBeInTheDocument()
+  })
+})
+
+describe('Dismiss', () => {
+  it('sends the pair id and resolves the row', async () => {
+    renderTab()
+    await userEvent.click(screen.getByText('Dismiss'))
+    expect(h.dismissCalls).toEqual([{ pairId: 'dup_1' }])
+  })
+
+  it('snoozes with a future date rather than dismissing', async () => {
+    renderTab()
+    await userEvent.click(screen.getByLabelText('Duplicate actions'))
+    await userEvent.click(await screen.findByText('Snooze'))
+    await userEvent.click(await screen.findByText('Next week'))
+
+    const call = h.dismissCalls.at(-1) as { pairId: string; snoozeUntil: Date }
+    expect(call.pairId).toBe('dup_1')
+    // Snoozed is `open` plus a FUTURE snoozeUntil — a past date would put the
+    // pair straight back in the queue.
+    expect(call.snoozeUntil.getTime()).toBeGreaterThan(Date.now())
+  })
+})

--- a/apps/web/src/components/global/notifications/ui/approvals-tab.tsx
+++ b/apps/web/src/components/global/notifications/ui/approvals-tab.tsx
@@ -21,6 +21,7 @@ import { useNotificationPanelStore } from '../notification-panel-store'
 import { AccessRequestRow } from './items/access-request-row'
 import { ConfirmationRow } from './items/confirmation-row'
 import { DecidedRow } from './items/decided-row'
+import { DuplicateRow } from './items/duplicate-row'
 import { MailSuggestionRow } from './items/mail-suggestion-row'
 import { SuggestionRow } from './items/suggestion-row'
 import { NotificationRowSkeleton } from './notification-row'
@@ -71,6 +72,7 @@ export function ApprovalsTab({ viewportRef }: ApprovalsTabProps) {
 function PendingApprovals({ viewportRef }: ApprovalsTabProps) {
   const { hasAccess } = useFeatureFlags()
   const suggestionsEnabled = hasAccess(FeatureKey.todayInbox)
+  const duplicatesEnabled = hasAccess(FeatureKey.duplicateDetection)
   const utils = api.useUtils()
   const highlightApprovalId = useNotificationPanelStore((state) => state.highlightApprovalId)
   const clearHighlight = useNotificationPanelStore((state) => state.clearHighlight)
@@ -96,6 +98,16 @@ function PendingApprovals({ viewportRef }: ApprovalsTabProps) {
    * job, so it needs no pagination of its own.
    */
   const mailSuggestions = useMailSuggestions()
+  /**
+   * The fifth source (plan §3.2). Gated on `FeatureKey.duplicateDetection` and
+   * skipped entirely when the org does not have it — the same shape as the
+   * suggestions section above, and the reason the router may refuse outright
+   * rather than answering with an empty list.
+   */
+  const duplicates = api.duplicates.list.useQuery(
+    { limit: 25 },
+    { enabled: duplicatesEnabled, refetchOnWindowFocus: false }
+  )
 
   // Deadline order — soonest expiry first, undated last. Correct only because the
   // pending view is fetched as one page (the router asks for 100), so this sorts
@@ -118,6 +130,7 @@ function PendingApprovals({ viewportRef }: ApprovalsTabProps) {
   )
 
   const mailSuggestionItems = mailSuggestions.data ?? []
+  const duplicateItems = duplicates.data?.items ?? []
 
   /**
    * The acting client refetches both lists and both badge counts itself rather
@@ -142,10 +155,23 @@ function PendingApprovals({ viewportRef }: ApprovalsTabProps) {
     void utils.mailSuggestions.count.invalidate()
   }
 
+  /**
+   * Dismiss, snooze and merge all change what the queue contains, so both the
+   * list and the badge term are refetched by the acting client rather than
+   * waiting for a frame that this feature deliberately does not publish
+   * (realtime is out of v1 — the tab is refetch-driven).
+   */
+  const onDuplicateResolved = () => {
+    void utils.duplicates.list.invalidate()
+    void utils.duplicates.count.invalidate()
+    void utils.duplicates.forRecord.invalidate()
+  }
+
   const isLoading =
     confirmations.isLoading ||
     (suggestionsEnabled && suggestions.isLoading) ||
-    mailSuggestions.isLoading
+    mailSuggestions.isLoading ||
+    (duplicatesEnabled && duplicates.isLoading)
   const highlightIsListed = confirmationItems.some((item) => item.id === highlightApprovalId)
 
   /**
@@ -186,12 +212,16 @@ function PendingApprovals({ viewportRef }: ApprovalsTabProps) {
   // nothing looks identical to both sources erroring, and an approval inbox that
   // quietly claims to be empty is worse than one that admits it is broken.
   const loadError =
-    confirmations.error ?? (suggestionsEnabled ? suggestions.error : null) ?? mailSuggestions.error
+    confirmations.error ??
+    (suggestionsEnabled ? suggestions.error : null) ??
+    mailSuggestions.error ??
+    (duplicatesEnabled ? duplicates.error : null)
   if (
     loadError &&
     !confirmationItems.length &&
     !suggestionItems.length &&
-    !mailSuggestionItems.length
+    !mailSuggestionItems.length &&
+    !duplicateItems.length
   ) {
     return (
       <div className='flex flex-1 items-center justify-center'>
@@ -209,6 +239,7 @@ function PendingApprovals({ viewportRef }: ApprovalsTabProps) {
                 void confirmations.refetch()
                 if (suggestionsEnabled) void suggestions.refetch()
                 void mailSuggestions.refetch()
+                if (duplicatesEnabled) void duplicates.refetch()
               }}>
               Try again
             </Button>
@@ -218,7 +249,12 @@ function PendingApprovals({ viewportRef }: ApprovalsTabProps) {
     )
   }
 
-  if (!confirmationItems.length && !suggestionItems.length && !mailSuggestionItems.length) {
+  if (
+    !confirmationItems.length &&
+    !suggestionItems.length &&
+    !mailSuggestionItems.length &&
+    !duplicateItems.length
+  ) {
     return (
       // flex-1 against the ScrollArea content wrapper's `min-h-full flex
       // flex-col`, so the empty state centres in the whole panel.
@@ -298,6 +334,19 @@ function PendingApprovals({ viewportRef }: ApprovalsTabProps) {
               suggestion={suggestion}
               onResolved={onMailResolved}
             />
+          ))}
+        </section>
+      ) : null}
+
+      {/* Last of all, and the order is deliberate (§3.2): the tab is a fixed
+          urgency ladder, and data hygiene is the least urgent lane in it. A
+          workflow confirmation blocks a live run and expires; a duplicate pair
+          will still be a duplicate tomorrow. */}
+      {duplicateItems.length ? (
+        <section>
+          <SectionHeader label='Possible duplicates' count={duplicateItems.length} />
+          {duplicateItems.map((pair) => (
+            <DuplicateRow key={pair.id} pair={pair} onResolved={onDuplicateResolved} />
           ))}
         </section>
       ) : null}

--- a/apps/web/src/components/global/notifications/ui/items/duplicate-row.tsx
+++ b/apps/web/src/components/global/notifications/ui/items/duplicate-row.tsx
@@ -1,0 +1,156 @@
+// apps/web/src/components/global/notifications/ui/items/duplicate-row.tsx
+'use client'
+
+import { type RecordId, toRecordId } from '@auxx/lib/resources/client'
+import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
+import { toastError } from '@auxx/ui/components/toast'
+import { Clock, CopyCheck, MoreHorizontal } from 'lucide-react'
+import { useState } from 'react'
+import { DuplicatePairSummary } from '~/components/duplicates/ui/duplicate-pair-summary'
+import { BlockCardActionButton } from '~/components/kopilot/ui/blocks/block-card'
+import { MergeDialog } from '~/components/merge/merge-dialog'
+import { api, type RouterOutputs } from '~/trpc/react'
+import { NotificationRow } from '../notification-row'
+
+type DuplicatePairItem = RouterOutputs['duplicates']['list']['items'][number]
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * One duplicate suggestion, triaged inline in the Approvals tab's fifth section
+ * (plan §3.2).
+ *
+ * A sibling of `MailSuggestionRow` rather than a mode of it: like mail
+ * suggestions, **nothing here is backed by a `Notification` row** — the tab
+ * reads source tables directly and `DuplicateSuggestion` is one, so minting a
+ * notification per pair would create two lifecycles over one thing. Unlike
+ * every other row in this tab, the primary action opens a DIALOG rather than
+ * resolving in place: a merge is destructive and irreversible-feeling, so it
+ * gets the full preview surface the merge dialog already provides.
+ *
+ * The row mounts its own `MergeDialog` (the `ticket-row-actions.tsx`
+ * precedent) — the notification panel has no dialog host to borrow.
+ *
+ * Snooze is in the overflow rather than the footer, mirroring `SuggestionRow`:
+ * a snoozed pair is `open` plus a future `snoozeUntil`, so it returns to this
+ * queue on its own with no sweep to un-snooze it.
+ */
+export function DuplicateRow({
+  pair,
+  onResolved,
+}: {
+  pair: DuplicatePairItem
+  onResolved: () => void
+}) {
+  const [mergeOpen, setMergeOpen] = useState(false)
+
+  const dismiss = api.duplicates.dismiss.useMutation({
+    onSuccess: () => onResolved(),
+    onError: (error) => {
+      toastError({ title: 'Dismiss failed', description: error.message })
+      onResolved()
+    },
+  })
+
+  /**
+   * Best-established first, decided server-side (plan §3.4): the dialog defaults
+   * its target to the FIRST id, and in canonical pair order that is whichever
+   * cuid2 sorts lower. Since the target is the record whose id survives, letting
+   * pair order pick it is how "merged into the empty stub" happens.
+   */
+  const mergeRecordIds: RecordId[] = pair.mergeInstanceIds.map((id) =>
+    toRecordId(pair.entityDefinitionId, id)
+  )
+
+  const records = [pair.low, pair.high].map((side) => ({
+    recordId: toRecordId(pair.entityDefinitionId, side.instanceId),
+    displayName: side.displayName,
+    secondaryDisplayValue: side.secondaryDisplayValue,
+    avatarUrl: side.avatarUrl,
+  }))
+
+  const snooze = (ms: number) =>
+    dismiss.mutate({ pairId: pair.id, snoozeUntil: new Date(Date.now() + ms) })
+
+  const overflow = (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        {/* size-7 + rounded-full so the trigger sits level with the h-7 pills. */}
+        <Button
+          variant='ghost'
+          size='icon-sm'
+          className='size-7 rounded-full'
+          aria-label='Duplicate actions'>
+          <MoreHorizontal />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align='end' className='w-56'>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger disabled={dismiss.isPending}>
+            <Clock />
+            Snooze
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className='w-56'>
+            <DropdownMenuLabel className='font-normal text-muted-foreground text-xs'>
+              Hide this pair until:
+            </DropdownMenuLabel>
+            <DropdownMenuItem onSelect={() => snooze(7 * DAY_MS)}>Next week</DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => snooze(30 * DAY_MS)}>Next month</DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+
+  return (
+    <>
+      <NotificationRow
+        id={pair.id}
+        createdAt={new Date(pair.createdAt)}
+        label='Possible duplicate'
+        icon={<CopyCheck className='size-4' />}
+        actions={
+          <>
+            {overflow}
+            <BlockCardActionButton
+              label='Dismiss'
+              disabled={dismiss.isPending}
+              onClick={() => dismiss.mutate({ pairId: pair.id })}
+            />
+            <BlockCardActionButton
+              label='Review & merge'
+              primary
+              disabled={dismiss.isPending}
+              onClick={() => setMergeOpen(true)}
+            />
+          </>
+        }>
+        <DuplicatePairSummary records={records} band={pair.band} signals={pair.signals} />
+      </NotificationRow>
+
+      {mergeOpen ? (
+        <MergeDialog
+          open
+          onOpenChange={setMergeOpen}
+          baseRecordIds={mergeRecordIds}
+          // No `targetRecordId`: the dialog defaults to the first id, which is
+          // already the best-established record. The user can still override.
+          onMergeComplete={() => {
+            setMergeOpen(false)
+            onResolved()
+          }}
+        />
+      ) : null}
+    </>
+  )
+}

--- a/apps/web/src/components/records/record-drawer-request-access.test.tsx
+++ b/apps/web/src/components/records/record-drawer-request-access.test.tsx
@@ -90,6 +90,12 @@ vi.mock('~/components/detail-view/components/app-record-actions', () => ({
 vi.mock('~/components/favorites/ui/favorite-star-button', () => ({
   FavoriteStarButton: () => null,
 }))
+// Runs its own `duplicates.forRecord` query and renders nothing unless the
+// record has open duplicate pairs — orthogonal to the preflight budget this
+// file measures, and it would otherwise count as a query on mount.
+vi.mock('~/components/duplicates/ui/duplicate-indicator-button', () => ({
+  DuplicateIndicatorButton: () => null,
+}))
 vi.mock('~/hooks/use-entity-instance-operations', () => ({
   useEntityInstanceOperations: () => ({
     canEdit: false,

--- a/apps/web/src/components/records/record-drawer.tsx
+++ b/apps/web/src/components/records/record-drawer.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/navigation'
 import * as React from 'react'
 import { BaseEntityDrawer } from '~/components/drawers/base-entity-drawer'
 import { getHeaderActions } from '~/components/drawers/drawer-action-registry'
+import { DuplicateIndicatorButton } from '~/components/duplicates/ui/duplicate-indicator-button'
 import { FavoriteStarButton } from '~/components/favorites/ui/favorite-star-button'
 import { ConnectorSourceBadge } from '~/components/fields/connector-source-badge'
 import { Tooltip } from '~/components/global/tooltip'
@@ -274,6 +275,19 @@ export const RecordDrawer = React.memo(function RecordDrawer({
                 />
               </GranularPermissionsGate>
             )}
+
+            {/* Renders nothing unless this record has open duplicate pairs —
+                the common case is absence, so there is no header cost for the
+                overwhelming majority of records. `enabled={!!open}` keeps a
+                mounted-but-closed drawer from querying at all. */}
+            {recordId ? (
+              <DuplicateIndicatorButton
+                recordId={recordId}
+                enabled={!!open}
+                size='icon-xs'
+                className='rounded-full'
+              />
+            ) : null}
 
             <FavoriteStarButton
               targetType='ENTITY_INSTANCE'

--- a/apps/web/src/server/api/root.ts
+++ b/apps/web/src/server/api/root.ts
@@ -36,6 +36,7 @@ import { datasetRouter } from './routers/dataset'
 import { dispatchRouter } from './routers/dispatch'
 import { documentRouter } from './routers/document'
 import { draftRouter } from './routers/draft'
+import { duplicatesRouter } from './routers/duplicates'
 import { emailTemplateRouter } from './routers/emailTemplate'
 import { entityDefinitionRouter } from './routers/entityDefinition'
 import { entityGroupRouter } from './routers/entityGroup'
@@ -133,6 +134,7 @@ export const appRouter = createTRPCRouter({
   dataset: datasetRouter,
   document: documentRouter,
   draft: draftRouter,
+  duplicates: duplicatesRouter,
   segment: segmentRouter,
   fieldValue: fieldValueRouter,
   file: fileRouter,

--- a/apps/web/src/server/api/routers/duplicates.ts
+++ b/apps/web/src/server/api/routers/duplicates.ts
@@ -1,0 +1,336 @@
+// apps/web/src/server/api/routers/duplicates.ts
+
+import { getCachedResources } from '@auxx/lib/cache'
+import {
+  countOpenDuplicatePairs,
+  DUPLICATE_HIGH_INSTANCE_ID_SQL,
+  DUPLICATE_LOW_INSTANCE_ID_SQL,
+  type DuplicateDefScope,
+  type DuplicateSide,
+  dismissPair,
+  getVisibleDuplicatePair,
+  listDuplicatePairs,
+  listDuplicatePairsForRecord,
+  orderByEstablishment,
+  readMergeEstablishment,
+} from '@auxx/lib/dedup'
+import { BadRequestError, NotFoundError } from '@auxx/lib/errors'
+import {
+  FeatureKey,
+  FeaturePermissionService,
+  recordScopeArmFor,
+  resolveRecordVisibilityScope,
+} from '@auxx/lib/permissions'
+import { isSystemResourceId } from '@auxx/lib/resources'
+import { parseRecordId, type RecordId } from '@auxx/types/resource'
+import { z } from 'zod'
+import { capabilityProcedure, createTRPCRouter } from '../trpc'
+
+/**
+ * tRPC surface for the duplicate review queue
+ * (plans/records/duplicate-suggestion-plan-v2.md §3.1).
+ *
+ * `@auxx/lib/dedup` holds ZERO permission checks by house rule, so **this router
+ * is the only authorization path for the feature.** Two separate gates meet
+ * here and must not be conflated:
+ *
+ * | Gate | What it decides |
+ * | --- | --- |
+ * | `FeatureKey.duplicateDetection` | whether the ORG has the feature at all |
+ * | {@link loadDuplicateScopes} | which records THIS member may see, in SQL |
+ *
+ * The second one is the load-bearing half. A duplicate pair carries the *other*
+ * record's display name, so a pair read without the record-scope predicate
+ * advertises the names of records the viewer cannot open — the visibility leak
+ * named in the plan's Risks section. The predicate is therefore resolved here
+ * and applied inside the query, never as a post-fetch filter, and a pair whose
+ * other side is invisible is dropped outright rather than rendered half-empty.
+ */
+
+/**
+ * Client-facing shape of one side of a pair.
+ *
+ * Instance ids, not `RecordId`s: the brand does not survive serialization, so
+ * the client composes them with `toRecordId(entityDefinitionId, instanceId)`
+ * (the same thing `SuggestionRow` does) rather than casting a plain string back
+ * into a branded type.
+ */
+interface DuplicateSideDto {
+  instanceId: string
+  displayName: string | null
+  secondaryDisplayValue: string | null
+  avatarUrl: string | null
+}
+
+/**
+ * The org must hold the feature. Deliberately a hard refusal rather than an
+ * empty list: the clients already skip these queries when the flag is off (the
+ * Approvals section and the header indicator both gate on `useFeatureFlags`), so
+ * a request arriving here without it is a bug worth seeing, not a state worth
+ * pretending is empty.
+ */
+async function requireDuplicateDetection(organizationId: string): Promise<void> {
+  await new FeaturePermissionService().requireAccess(organizationId, FeatureKey.duplicateDetection)
+}
+
+/**
+ * The definitions this member may read duplicate pairs for, each with the
+ * per-side record-scope predicate it needs.
+ *
+ * Mirrors `UnifiedCrudHandler.recordScope`, with two differences that fall out
+ * of reading PAIRS rather than rows:
+ *
+ * 1. **It resolves every definition at once**, because the queue is not scoped
+ *    to one type. Arms 1 and 4 are decided from the in-memory capability view
+ *    with no I/O, so enumerating the org's definitions costs nothing; only the
+ *    rare `restricted` / `grant-only` definitions reach for grantee resolution
+ *    (itself org-cache-only).
+ * 2. **The scope is resolved TWICE per narrowed definition**, once per side,
+ *    because the two correlate against different join aliases. Resolving with
+ *    the default correlation target would silently point both arms at
+ *    `"EntityInstance"."id"`, which is not in this query's FROM list.
+ *
+ * System-table resources are skipped: they have no `EntityInstance` rows, so no
+ * `DuplicateSuggestion` row can reference them and including them would only
+ * pad the `IN (…)` list with ids that match nothing.
+ */
+async function loadDuplicateScopes(ctx: {
+  session: { organizationId: string; userId: string }
+  capabilities: Parameters<typeof recordScopeArmFor>[0]
+}): Promise<DuplicateDefScope[]> {
+  const { organizationId, userId } = ctx.session
+  const resources = await getCachedResources(organizationId)
+  const scopes: DuplicateDefScope[] = []
+
+  for (const resource of resources) {
+    if (isSystemResourceId(resource.id)) continue
+
+    const arm = recordScopeArmFor(ctx.capabilities, resource.id)
+    // Arm 4 — nothing of this definition is reachable, so it must not appear in
+    // the query at all (not even as a definition id whose rows are then filtered).
+    if (arm === 'none') continue
+    if (arm === 'all') {
+      scopes.push({ entityDefinitionId: resource.entityDefinitionId })
+      continue
+    }
+
+    const [low, high] = await Promise.all([
+      resolveRecordVisibilityScope({
+        organizationId,
+        userId,
+        entityDefinitionId: resource.entityDefinitionId,
+        capabilities: ctx.capabilities,
+        instanceIdColumn: DUPLICATE_LOW_INSTANCE_ID_SQL,
+      }),
+      resolveRecordVisibilityScope({
+        organizationId,
+        userId,
+        entityDefinitionId: resource.entityDefinitionId,
+        capabilities: ctx.capabilities,
+        instanceIdColumn: DUPLICATE_HIGH_INSTANCE_ID_SQL,
+      }),
+    ])
+
+    scopes.push({
+      entityDefinitionId: resource.entityDefinitionId,
+      lowWhere: low.where,
+      highWhere: high.where,
+    })
+  }
+
+  return scopes
+}
+
+function toSideDto(side: DuplicateSide): DuplicateSideDto {
+  return {
+    instanceId: side.instanceId,
+    displayName: side.displayName,
+    secondaryDisplayValue: side.secondaryDisplayValue,
+    avatarUrl: side.avatarUrl,
+  }
+}
+
+/**
+ * `mergeInstanceIds` on every item below is ordered **best-established first**
+ * (plan §3.4).
+ *
+ * `MergeDialog` defaults its target to the first id it is given, and in
+ * canonical pair order that is whichever cuid2 sorts lower — i.e. arbitrary.
+ * Since the merge target is the record whose id survives while the other's dies,
+ * letting pair order pick it is how "merged into the empty stub" happens. The
+ * ordering is decided HERE because the evidence it reads (outbound history,
+ * interaction history) is server-side; `orderByEstablishment` is the pure
+ * comparator over it.
+ *
+ * Scoped to this entry point on purpose: every other `MergeDialog` caller keeps
+ * its own ordering, because elsewhere the first id is a deliberate user
+ * selection rather than an artefact of storage.
+ */
+export const duplicatesRouter = createTRPCRouter({
+  /**
+   * The review queue — the Approvals tab's fifth section.
+   *
+   * Keyset-paged on `(score desc, id desc)`; clusters are computed at read over
+   * the page (see `listDuplicatePairs`).
+   */
+  list: capabilityProcedure
+    .input(
+      z
+        .object({
+          cursor: z.object({ score: z.number(), id: z.string() }).optional(),
+          limit: z.number().int().min(1).max(50).default(25),
+          entityDefinitionId: z.string().optional(),
+        })
+        .default({ limit: 25 })
+    )
+    .query(async ({ ctx, input }) => {
+      await requireDuplicateDetection(ctx.session.organizationId)
+      const scopes = await loadDuplicateScopes(ctx)
+
+      const page = await listDuplicatePairs(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        scopes,
+        cursor: input.cursor,
+        limit: input.limit,
+        entityDefinitionId: input.entityDefinitionId,
+      })
+      if (page.isErr()) throw page.error
+
+      // Every cluster member is a side of some pair in this page (the clusters
+      // are page-local by construction), so one map covers the whole ordering.
+      const sideById = new Map<string, DuplicateSide>()
+      for (const pair of page.value.items) {
+        sideById.set(pair.low.instanceId, pair.low)
+        sideById.set(pair.high.instanceId, pair.high)
+      }
+
+      const establishment = await readMergeEstablishment(ctx.db, ctx.session.organizationId, [
+        ...sideById.keys(),
+      ])
+      if (establishment.isErr()) throw establishment.error
+
+      const items = page.value.items.map((pair) => {
+        const clusterSides = pair.clusterInstanceIds.flatMap((id) => {
+          const side = sideById.get(id)
+          return side ? [side] : []
+        })
+        const ordered = orderByEstablishment(clusterSides, establishment.value)
+        return {
+          id: pair.id,
+          entityDefinitionId: pair.entityDefinitionId,
+          score: pair.score,
+          band: pair.band,
+          signals: pair.signals,
+          createdAt: pair.createdAt,
+          low: toSideDto(pair.low),
+          high: toSideDto(pair.high),
+          /**
+           * The cluster, best-established first — what the client turns into
+           * `MergeDialog.baseRecordIds`. The FIRST id becomes the merge target.
+           */
+          mergeInstanceIds: ordered,
+        }
+      })
+
+      return { items, nextCursor: page.value.nextCursor }
+    }),
+
+  /**
+   * Open pairs touching one record — the drawer / detail-page header indicator.
+   *
+   * Same scope rule as {@link list}, and for a sharper reason: the caller
+   * plainly can see THIS record (they are looking at it), and the other side is
+   * exactly what this read discloses.
+   */
+  forRecord: capabilityProcedure
+    .input(z.object({ recordId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      await requireDuplicateDetection(ctx.session.organizationId)
+      // The brand does not survive the wire, so the zod input is a plain string.
+      // `parseRecordId` does not throw on a malformed id — it yields an empty
+      // instance id — so the shape is checked here rather than relying on a
+      // query for `id = ''` to return nothing.
+      const { entityInstanceId } = parseRecordId(input.recordId as RecordId)
+      if (!entityInstanceId) throw new BadRequestError('Malformed recordId')
+      const scopes = await loadDuplicateScopes(ctx)
+
+      const pairs = await listDuplicatePairsForRecord(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        instanceId: entityInstanceId,
+        scopes,
+      })
+      if (pairs.isErr()) throw pairs.error
+
+      const establishment = await readMergeEstablishment(
+        ctx.db,
+        ctx.session.organizationId,
+        pairs.value.flatMap((pair) => [pair.low.instanceId, pair.high.instanceId])
+      )
+      if (establishment.isErr()) throw establishment.error
+
+      return pairs.value.map((pair) => {
+        const isLow = pair.low.instanceId === entityInstanceId
+        const other = isLow ? pair.high : pair.low
+        const ordered = orderByEstablishment([pair.low, pair.high], establishment.value)
+        return {
+          id: pair.id,
+          entityDefinitionId: pair.entityDefinitionId,
+          score: pair.score,
+          band: pair.band,
+          signals: pair.signals,
+          createdAt: pair.createdAt,
+          other: toSideDto(other),
+          mergeInstanceIds: ordered,
+        }
+      })
+    }),
+
+  /**
+   * The badge term. Carries the SAME archived, snooze and scope filters as
+   * {@link list} — a badge counting a different set than the tab renders is the
+   * drift bug `use-approvals-count.ts` exists to prevent.
+   */
+  count: capabilityProcedure.query(async ({ ctx }) => {
+    await requireDuplicateDetection(ctx.session.organizationId)
+    const scopes = await loadDuplicateScopes(ctx)
+
+    const count = await countOpenDuplicatePairs(ctx.db, {
+      organizationId: ctx.session.organizationId,
+      scopes,
+    })
+    if (count.isErr()) throw count.error
+    return { count: count.value }
+  }),
+
+  /**
+   * Dismiss a pair, or snooze it until a date.
+   *
+   * Resolve-then-authorize: the pair is loaded through the same scoped read the
+   * queue uses, so an id the caller cannot see is a 404 rather than a silent
+   * write. `dismissedBand` is stamped from the row's own stored band inside the
+   * update — never from anything the client sent.
+   */
+  dismiss: capabilityProcedure
+    .input(z.object({ pairId: z.string(), snoozeUntil: z.date().optional() }))
+    .mutation(async ({ ctx, input }) => {
+      await requireDuplicateDetection(ctx.session.organizationId)
+      const scopes = await loadDuplicateScopes(ctx)
+
+      const pair = await getVisibleDuplicatePair(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        pairId: input.pairId,
+        scopes,
+      })
+      if (pair.isErr()) throw pair.error
+      if (!pair.value) throw new NotFoundError('Duplicate suggestion not found')
+
+      const result = await dismissPair(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        pairId: input.pairId,
+        userId: ctx.session.userId,
+        snoozeUntil: input.snoozeUntil,
+      })
+      if (result.isErr()) throw result.error
+      return { dismissed: result.value }
+    }),
+})

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -358,6 +358,12 @@
       "import": "./dist/datasets/types/index.mjs",
       "default": "./src/datasets/types/index.ts"
     },
+    "./dedup": {
+      "types": "./src/dedup/index.ts",
+      "source": "./src/dedup/index.ts",
+      "import": "./dist/dedup/index.mjs",
+      "default": "./src/dedup/index.ts"
+    },
     "./dehydration": {
       "types": "./src/dehydration/index.ts",
       "source": "./src/dehydration/index.ts",

--- a/packages/lib/src/dedup/__tests__/queries.int.test.ts
+++ b/packages/lib/src/dedup/__tests__/queries.int.test.ts
@@ -1,0 +1,482 @@
+// packages/lib/src/dedup/__tests__/queries.int.test.ts
+//
+// DB-backed test (vitest.integration.config.ts → auxx_test) for the read paths
+// behind the duplicate router (plan §3.1 / §3.1a / §3.6).
+//
+// Integration and not unit, for one reason that applies to every case below:
+// **every claim here is a PREDICATE claim.** A fake db records the call and
+// proves nothing about which rows come back — and the two rules these reads
+// exist to enforce (a pair whose other side is invisible is absent; a pair
+// whose either side is archived is absent, on ALL THREE read paths) are exactly
+// the kind that a predicate-blind test passes vacuously.
+//
+// The scope predicates are built by hand here rather than resolved through the
+// permissions module. What is under test is that `queries.ts` APPLIES a
+// caller-supplied predicate to the RIGHT side of the pair, through the join
+// aliases the correlation targets name — not how the router derives it.
+
+import { schema } from '@auxx/database'
+import { createTestOrganization, getTestDb } from '@auxx/test-utils'
+import { eq, sql } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+import { dismissPair } from '../pairs'
+import {
+  countOpenDuplicatePairs,
+  DUPLICATE_HIGH_INSTANCE_ID_SQL,
+  DUPLICATE_LOW_INSTANCE_ID_SQL,
+  type DuplicateDefScope,
+  getVisibleDuplicatePair,
+  listDuplicatePairs,
+  listDuplicatePairsForRecord,
+} from '../queries'
+
+const db = () => getTestDb() as never as import('@auxx/database').Database
+
+interface Fixture {
+  orgId: string
+  /** A real `User.id` — `dismissedByUserId` carries a FK. */
+  userId: string
+  defId: string
+  /** Sorted ascending, so `(a,b)`, `(b,c)`, `(a,c)` are all canonical. */
+  a: string
+  b: string
+  c: string
+  d: string
+  scopes: DuplicateDefScope[]
+}
+
+async function seed(): Promise<Fixture> {
+  const org = await createTestOrganization()
+  const [def] = await db()
+    .insert(schema.EntityDefinition)
+    .values({
+      organizationId: org.id,
+      entityType: 'contact',
+      apiSlug: 'contacts',
+      singular: 'contact',
+      plural: 'contacts',
+      updatedAt: new Date(),
+    })
+    .returning()
+
+  const instance = async (name: string) => {
+    const [row] = await db()
+      .insert(schema.EntityInstance)
+      .values({
+        organizationId: org.id,
+        entityDefinitionId: def?.id as string,
+        displayName: name,
+        secondaryDisplayValue: `${name.toLowerCase()}@acme.test`,
+        updatedAt: new Date(),
+      })
+      .returning()
+    return row?.id as string
+  }
+
+  const ids = [
+    await instance('Alpha'),
+    await instance('Bravo'),
+    await instance('Charlie'),
+    await instance('Delta'),
+  ].sort()
+
+  return {
+    orgId: org.id,
+    userId: org.ownerId,
+    defId: def?.id as string,
+    a: ids[0] as string,
+    b: ids[1] as string,
+    c: ids[2] as string,
+    d: ids[3] as string,
+    scopes: [{ entityDefinitionId: def?.id as string }],
+  }
+}
+
+async function pair(
+  f: Fixture,
+  low: string,
+  high: string,
+  overrides: Record<string, unknown> = {}
+): Promise<string> {
+  const [row] = await db()
+    .insert(schema.DuplicateSuggestion)
+    .values({
+      organizationId: f.orgId,
+      entityDefinitionId: f.defId,
+      instanceIdLow: low,
+      instanceIdHigh: high,
+      score: 0.9,
+      band: 'high',
+      signals: [{ type: 'email', strength: 'strong', value: 'a@acme.test' }],
+      status: 'open',
+      ...overrides,
+    })
+    .returning()
+  return row?.id as string
+}
+
+async function archive(instanceId: string) {
+  await db()
+    .update(schema.EntityInstance)
+    .set({ archivedAt: new Date() })
+    .where(eq(schema.EntityInstance.id, instanceId))
+}
+
+/** A scope that admits only the named instances — one arm per side. */
+function onlyVisible(f: Fixture, visible: string[]): DuplicateDefScope[] {
+  const list = sql.join(
+    visible.map((id) => sql`${id}`),
+    sql`, `
+  )
+  return [
+    {
+      entityDefinitionId: f.defId,
+      lowWhere: sql`${DUPLICATE_LOW_INSTANCE_ID_SQL} IN (${list})`,
+      highWhere: sql`${DUPLICATE_HIGH_INSTANCE_ID_SQL} IN (${list})`,
+    },
+  ]
+}
+
+describe('record scope — a pair whose OTHER side is invisible is absent', () => {
+  it('drops the pair outright rather than rendering half of it', async () => {
+    const f = await seed()
+    await pair(f, f.a, f.b)
+
+    // The viewer can see A but not B. The pair carries B's display NAME, so a
+    // post-fetch filter would already have read it into the process — this is
+    // the visibility leak the predicate exists to close.
+    const visible = await listDuplicatePairs(db(), {
+      organizationId: f.orgId,
+      scopes: onlyVisible(f, [f.a]),
+    })
+
+    expect(visible._unsafeUnwrap().items).toHaveLength(0)
+  })
+
+  it('keeps the pair when BOTH sides pass the scope', async () => {
+    const f = await seed()
+    await pair(f, f.a, f.b)
+
+    const result = await listDuplicatePairs(db(), {
+      organizationId: f.orgId,
+      scopes: onlyVisible(f, [f.a, f.b]),
+    })
+
+    expect(result._unsafeUnwrap().items).toHaveLength(1)
+  })
+
+  it('applies the same rule on forRecord and count', async () => {
+    const f = await seed()
+    await pair(f, f.a, f.b)
+    const scopes = onlyVisible(f, [f.a])
+
+    const forRecord = await listDuplicatePairsForRecord(db(), {
+      organizationId: f.orgId,
+      instanceId: f.a,
+      scopes,
+    })
+    const count = await countOpenDuplicatePairs(db(), { organizationId: f.orgId, scopes })
+
+    expect(forRecord._unsafeUnwrap()).toHaveLength(0)
+    expect(count._unsafeUnwrap()).toBe(0)
+  })
+
+  it('issues no query at all when nothing is reachable', async () => {
+    const f = await seed()
+    await pair(f, f.a, f.b)
+
+    // Arm 4, generalized: an empty scope list is "no reachable rows", which must
+    // short-circuit rather than degrade into an unscoped read.
+    expect(
+      (await listDuplicatePairs(db(), { organizationId: f.orgId, scopes: [] }))._unsafeUnwrap()
+        .items
+    ).toHaveLength(0)
+    expect(
+      (await countOpenDuplicatePairs(db(), { organizationId: f.orgId, scopes: [] }))._unsafeUnwrap()
+    ).toBe(0)
+  })
+
+  it('excludes a definition that is absent from the scope list', async () => {
+    const f = await seed()
+    await pair(f, f.a, f.b)
+
+    const result = await listDuplicatePairs(db(), {
+      organizationId: f.orgId,
+      scopes: [{ entityDefinitionId: 'some-other-def' }],
+    })
+
+    expect(result._unsafeUnwrap().items).toHaveLength(0)
+  })
+})
+
+describe('archived filtering — on ALL THREE read paths (§3.1a rule 1)', () => {
+  it('hides a pair whose LOW side is archived', async () => {
+    const f = await seed()
+    await pair(f, f.a, f.b)
+    await archive(f.a)
+
+    const result = await listDuplicatePairs(db(), { organizationId: f.orgId, scopes: f.scopes })
+    expect(result._unsafeUnwrap().items).toHaveLength(0)
+  })
+
+  it('hides a pair whose HIGH side is archived', async () => {
+    const f = await seed()
+    await pair(f, f.a, f.b)
+    await archive(f.b)
+
+    const result = await listDuplicatePairs(db(), { organizationId: f.orgId, scopes: f.scopes })
+    expect(result._unsafeUnwrap().items).toHaveLength(0)
+  })
+
+  it('count agrees with list — the badge must not drift', async () => {
+    const f = await seed()
+    await pair(f, f.a, f.b)
+    await pair(f, f.c, f.d)
+    await archive(f.c)
+
+    const list = await listDuplicatePairs(db(), { organizationId: f.orgId, scopes: f.scopes })
+    const count = await countOpenDuplicatePairs(db(), {
+      organizationId: f.orgId,
+      scopes: f.scopes,
+    })
+
+    // The whole point of putting the archived filter on `count` too: the badge
+    // would otherwise advertise a pair the list refuses to render.
+    expect(list._unsafeUnwrap().items).toHaveLength(1)
+    expect(count._unsafeUnwrap()).toBe(1)
+  })
+
+  it('hides an archived-side pair from forRecord', async () => {
+    const f = await seed()
+    await pair(f, f.a, f.b)
+    await archive(f.b)
+
+    const result = await listDuplicatePairsForRecord(db(), {
+      organizationId: f.orgId,
+      instanceId: f.a,
+      scopes: f.scopes,
+    })
+    expect(result._unsafeUnwrap()).toHaveLength(0)
+  })
+})
+
+describe('snooze window — snoozed is `open` plus a future snoozeUntil', () => {
+  const HOUR = 60 * 60 * 1000
+
+  it('hides a pair snoozed into the future', async () => {
+    const f = await seed()
+    await pair(f, f.a, f.b, { snoozeUntil: new Date(Date.now() + HOUR) })
+
+    const list = await listDuplicatePairs(db(), { organizationId: f.orgId, scopes: f.scopes })
+    const count = await countOpenDuplicatePairs(db(), {
+      organizationId: f.orgId,
+      scopes: f.scopes,
+    })
+
+    expect(list._unsafeUnwrap().items).toHaveLength(0)
+    expect(count._unsafeUnwrap()).toBe(0)
+  })
+
+  it('returns it again once the snooze has lapsed — no sweep required', async () => {
+    const f = await seed()
+    await pair(f, f.a, f.b, { snoozeUntil: new Date(Date.now() - HOUR) })
+
+    const list = await listDuplicatePairs(db(), { organizationId: f.orgId, scopes: f.scopes })
+    expect(list._unsafeUnwrap().items).toHaveLength(1)
+  })
+
+  it('hides `dismissed` and `merged` from the queue', async () => {
+    const f = await seed()
+    await pair(f, f.a, f.b, { status: 'dismissed', dismissedBand: 'high' })
+    await pair(f, f.c, f.d, { status: 'merged' })
+
+    const list = await listDuplicatePairs(db(), { organizationId: f.orgId, scopes: f.scopes })
+    expect(list._unsafeUnwrap().items).toHaveLength(0)
+  })
+})
+
+describe('clustering + paging', () => {
+  it('unions A–B and B–C into one component', async () => {
+    const f = await seed()
+    await pair(f, f.a, f.b)
+    await pair(f, f.b, f.c)
+
+    const result = await listDuplicatePairs(db(), { organizationId: f.orgId, scopes: f.scopes })
+    const items = result._unsafeUnwrap().items
+
+    expect(items).toHaveLength(2)
+    for (const item of items) {
+      expect([...item.clusterInstanceIds].sort()).toEqual([f.a, f.b, f.c])
+    }
+  })
+
+  it('keeps disjoint pairs in separate clusters', async () => {
+    const f = await seed()
+    await pair(f, f.a, f.b)
+    await pair(f, f.c, f.d)
+
+    const items = (
+      await listDuplicatePairs(db(), { organizationId: f.orgId, scopes: f.scopes })
+    )._unsafeUnwrap().items
+
+    for (const item of items) {
+      expect(item.clusterInstanceIds).toHaveLength(2)
+    }
+  })
+
+  it('pages on (score desc, id desc) without repeating or skipping a row', async () => {
+    const f = await seed()
+    // Identical scores on purpose: `score` is a double that ties constantly, so
+    // the id tiebreak is what makes the keyset total.
+    await pair(f, f.a, f.b, { score: 0.9 })
+    await pair(f, f.c, f.d, { score: 0.9 })
+    await pair(f, f.a, f.c, { score: 0.9 })
+
+    const first = (
+      await listDuplicatePairs(db(), { organizationId: f.orgId, scopes: f.scopes, limit: 2 })
+    )._unsafeUnwrap()
+    expect(first.items).toHaveLength(2)
+    expect(first.nextCursor).not.toBeNull()
+
+    const second = (
+      await listDuplicatePairs(db(), {
+        organizationId: f.orgId,
+        scopes: f.scopes,
+        limit: 2,
+        cursor: first.nextCursor ?? undefined,
+      })
+    )._unsafeUnwrap()
+
+    const ids = [...first.items, ...second.items].map((item) => item.id)
+    expect(new Set(ids).size).toBe(3)
+    expect(second.nextCursor).toBeNull()
+  })
+
+  it('joins both sides’ display columns', async () => {
+    const f = await seed()
+    await pair(f, f.a, f.b)
+
+    const item = (
+      await listDuplicatePairs(db(), { organizationId: f.orgId, scopes: f.scopes })
+    )._unsafeUnwrap().items[0]
+
+    expect(item?.low.displayName).toBeTruthy()
+    expect(item?.high.displayName).toBeTruthy()
+    expect(item?.low.secondaryDisplayValue).toContain('@acme.test')
+  })
+})
+
+describe('dismiss', () => {
+  it('stamps `dismissedBand` from the row’s OWN stored band', async () => {
+    const f = await seed()
+    // A medium pair — if the band came from the caller instead of the row, a
+    // stale client could stamp `high` here and permanently suppress the genuine
+    // upgrade that `upsertPairs` reopens on.
+    const id = await pair(f, f.a, f.b, { band: 'medium', score: 0.6 })
+
+    const result = await dismissPair(db(), {
+      organizationId: f.orgId,
+      pairId: id,
+      userId: f.userId,
+    })
+
+    const [row] = await db()
+      .select()
+      .from(schema.DuplicateSuggestion)
+      .where(eq(schema.DuplicateSuggestion.id, id))
+
+    expect(result._unsafeUnwrap()).toBe(true)
+    expect(row?.status).toBe('dismissed')
+    expect(row?.dismissedBand).toBe('medium')
+    expect(row?.dismissedAt).toBeTruthy()
+  })
+
+  it('snoozing keeps the pair `open` and does NOT stamp a band', async () => {
+    const f = await seed()
+    const id = await pair(f, f.a, f.b, { band: 'medium' })
+    const until = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+
+    await dismissPair(db(), {
+      organizationId: f.orgId,
+      pairId: id,
+      userId: f.userId,
+      snoozeUntil: until,
+    })
+
+    const [row] = await db()
+      .select()
+      .from(schema.DuplicateSuggestion)
+      .where(eq(schema.DuplicateSuggestion.id, id))
+
+    // A snooze is "not now", not a verdict on the evidence — stamping the band
+    // would make the next upgrade un-noticeable for this pair.
+    expect(row?.status).toBe('open')
+    expect(row?.dismissedBand).toBeNull()
+    expect(row?.snoozeUntil?.getTime()).toBe(until.getTime())
+  })
+
+  it('never touches a `merged` row', async () => {
+    const f = await seed()
+    const id = await pair(f, f.a, f.b, { status: 'merged' })
+
+    const result = await dismissPair(db(), {
+      organizationId: f.orgId,
+      pairId: id,
+      userId: f.userId,
+    })
+
+    expect(result._unsafeUnwrap()).toBe(false)
+  })
+
+  it('is org-scoped', async () => {
+    const f = await seed()
+    const other = await seed()
+    const id = await pair(other, other.a, other.b)
+
+    const result = await dismissPair(db(), {
+      organizationId: f.orgId,
+      pairId: id,
+      userId: f.userId,
+    })
+    expect(result._unsafeUnwrap()).toBe(false)
+  })
+})
+
+describe('getVisibleDuplicatePair — the resolve-then-authorize read', () => {
+  it('refuses a pair the caller cannot see both sides of', async () => {
+    const f = await seed()
+    const id = await pair(f, f.a, f.b)
+
+    const result = await getVisibleDuplicatePair(db(), {
+      organizationId: f.orgId,
+      pairId: id,
+      scopes: onlyVisible(f, [f.a]),
+    })
+    expect(result._unsafeUnwrap()).toBeNull()
+  })
+
+  it('returns a dismissed pair — status is deliberately not filtered', async () => {
+    const f = await seed()
+    const id = await pair(f, f.a, f.b, { status: 'dismissed', dismissedBand: 'high' })
+
+    const result = await getVisibleDuplicatePair(db(), {
+      organizationId: f.orgId,
+      pairId: id,
+      scopes: f.scopes,
+    })
+    expect(result._unsafeUnwrap()?.id).toBe(id)
+  })
+
+  it('refuses a pair with an archived side', async () => {
+    const f = await seed()
+    const id = await pair(f, f.a, f.b)
+    await archive(f.b)
+
+    const result = await getVisibleDuplicatePair(db(), {
+      organizationId: f.orgId,
+      pairId: id,
+      scopes: f.scopes,
+    })
+    expect(result._unsafeUnwrap()).toBeNull()
+  })
+})

--- a/packages/lib/src/dedup/index.ts
+++ b/packages/lib/src/dedup/index.ts
@@ -80,13 +80,36 @@ export {
   normalizeGivenName,
 } from './nicknames'
 export {
+  type DismissPairParams,
   deleteOpenPairsForRecord,
+  dismissPair,
   type MergeResolution,
   type RescorePairsParams,
   rescoreOpenPairsForRecord,
   resolveSuggestionsForMerge,
   upsertPairs,
 } from './pairs'
+export {
+  type CountDuplicatePairsParams,
+  countOpenDuplicatePairs,
+  DUPLICATE_HIGH_INSTANCE_ID_SQL,
+  DUPLICATE_LOW_INSTANCE_ID_SQL,
+  type DuplicateCursor,
+  type DuplicateDefScope,
+  type DuplicatePair,
+  type DuplicatePairListItem,
+  type DuplicatePairPage,
+  type DuplicateSide,
+  type GetDuplicatePairParams,
+  getVisibleDuplicatePair,
+  type ListDuplicatePairsParams,
+  type ListPairsForRecordParams,
+  listDuplicatePairs,
+  listDuplicatePairsForRecord,
+  type MergeEstablishment,
+  orderByEstablishment,
+  readMergeEstablishment,
+} from './queries'
 export {
   bandForScore,
   type ScoredPair,

--- a/packages/lib/src/dedup/pairs.ts
+++ b/packages/lib/src/dedup/pairs.ts
@@ -243,6 +243,66 @@ export async function deleteOpenPairsForRecord(
   return ok(rows.length)
 }
 
+/** Parameters for {@link dismissPair}. */
+export interface DismissPairParams {
+  organizationId: string
+  /** `DuplicateSuggestion.id`. The caller must already have proven it is visible. */
+  pairId: string
+  /** Who acted — stamped so the queue can say who buried a pair. */
+  userId: string
+  /**
+   * Present ⇒ SNOOZE instead of dismiss. Snoozed is `open` plus a future
+   * `snoozeUntil`, so the pair returns to the queue on its own with no sweep.
+   */
+  snoozeUntil?: Date
+}
+
+/**
+ * Dismiss or snooze one pair — the only user-facing write on the queue.
+ *
+ * **`dismissedBand` is stamped from the row's OWN stored band**, read inside the
+ * same statement rather than passed in by the caller. That column is what makes
+ * reopen-on-upgrade safe (`upsertPairs`), and a caller-supplied band would let a
+ * stale client snapshot decide whether a future `high` re-match is allowed to
+ * nag — the one field where trusting the client silently breaks the state
+ * machine.
+ *
+ * Snoozing deliberately does NOT stamp `dismissedBand`: a snooze is "not now",
+ * not a decision about the evidence, and stamping it would make the next
+ * band upgrade un-noticeable for that pair.
+ *
+ * `merged` rows are never touched — merge is terminal.
+ *
+ * @returns `true` when a row was written; `false` when the id matched nothing
+ *          eligible (already merged, or not in this org).
+ */
+export async function dismissPair(
+  db: Database,
+  params: DismissPairParams
+): Promise<Result<boolean, Error>> {
+  const { organizationId, pairId, userId, snoozeUntil } = params
+
+  const set = snoozeUntil
+    ? { snoozeUntil, updatedAt: new Date() }
+    : {
+        status: 'dismissed',
+        dismissedByUserId: userId,
+        dismissedAt: new Date(),
+        // `T.band` — the row's stored band, not the caller's idea of it.
+        dismissedBand: sql`${T.band}`,
+        snoozeUntil: null,
+        updatedAt: new Date(),
+      }
+
+  const rows = await db
+    .update(T)
+    .set(set)
+    .where(and(eq(T.organizationId, organizationId), eq(T.id, pairId), ne(T.status, 'merged')))
+    .returning({ id: T.id })
+
+  return ok(rows.length > 0)
+}
+
 /** Outcome of {@link resolveSuggestionsForMerge}. */
 export interface MergeResolution {
   /** Pairs entirely inside the merge set, stamped `merged`. */

--- a/packages/lib/src/dedup/queries.ts
+++ b/packages/lib/src/dedup/queries.ts
@@ -1,0 +1,548 @@
+// packages/lib/src/dedup/queries.ts
+//
+// Reads for the duplicate review queue — the surface half of `pairs.ts`.
+// Functional Drizzle + neverthrow, `db` first, no service class.
+//
+// ZERO permission DECISIONS live here (lib-module-guide §6): the router decides
+// which definitions the caller may read and hands the resolved predicates in as
+// {@link DuplicateDefScope}. But the resulting SQL is applied HERE, because a
+// pair read is the one shape where a post-fetch filter is not equivalent — a
+// pair carries the *other* record's display name, so a row that is later
+// dropped in JS has already been read into the process and, worse, would be
+// trivially re-derivable from a count. Scope lands in the query.
+//
+// **Both sides must survive every filter.** A pair whose other side is invisible
+// or archived is excluded outright rather than rendered half-populated: half a
+// duplicate card is both useless and a leak.
+
+import { type Database, schema } from '@auxx/database'
+import { aliasedTable, and, desc, eq, inArray, isNull, lt, or, type SQL, sql } from 'drizzle-orm'
+import { ok, type Result } from 'neverthrow'
+import type { Band, Signal } from './types'
+
+const T = schema.DuplicateSuggestion
+
+/**
+ * `EntityInstance` under two aliases — the pair's two sides.
+ *
+ * The alias names are load-bearing: the caller-supplied record-scope predicates
+ * ({@link DuplicateDefScope}) correlate against `"dupLow"."id"` / `"dupHigh"."id"`
+ * as RAW identifiers, because a Drizzle `Column` inside an `sql` fragment can be
+ * rewritten to a bare, unqualified name (see `record-visibility-scope.ts`).
+ */
+const LOW = aliasedTable(schema.EntityInstance, 'dupLow')
+const HIGH = aliasedTable(schema.EntityInstance, 'dupHigh')
+
+/** Correlation targets a caller builds its scope predicates against. */
+export const DUPLICATE_LOW_INSTANCE_ID_SQL = sql.raw('"dupLow"."id"')
+export const DUPLICATE_HIGH_INSTANCE_ID_SQL = sql.raw('"dupHigh"."id"')
+
+/**
+ * One definition the caller may read pairs for, with the per-side record-scope
+ * predicate that definition needs.
+ *
+ * A definition the caller can reach NOTHING of (scope arm 4) must simply be
+ * absent from the list — that is the "no reachable rows ⇒ no query" contract the
+ * record lane already states. `lowWhere`/`highWhere` are absent on arm 1, where
+ * the member sees every row and the read must pay nothing.
+ */
+export interface DuplicateDefScope {
+  /** Canonical `EntityDefinition.id` — the keyspace `DuplicateSuggestion` stores. */
+  entityDefinitionId: string
+  /** Narrows the LOW side; built against {@link DUPLICATE_LOW_INSTANCE_ID_SQL}. */
+  lowWhere?: SQL
+  /** Narrows the HIGH side; built against {@link DUPLICATE_HIGH_INSTANCE_ID_SQL}. */
+  highWhere?: SQL
+}
+
+/** Display columns for one side of a pair, joined from `EntityInstance`. */
+export interface DuplicateSide {
+  instanceId: string
+  displayName: string | null
+  secondaryDisplayValue: string | null
+  avatarUrl: string | null
+  firstInteractionAt: Date | null
+  lastInteractionAt: Date | null
+}
+
+/** One open pair, both sides hydrated. */
+export interface DuplicatePair {
+  id: string
+  entityDefinitionId: string
+  score: number
+  band: Band
+  signals: Signal[]
+  createdAt: Date
+  low: DuplicateSide
+  high: DuplicateSide
+}
+
+/** A listed pair plus the connected component it belongs to within the page. */
+export interface DuplicatePairListItem extends DuplicatePair {
+  /**
+   * Every instance id reachable from this pair through other open pairs **in the
+   * same page** (union-find at read).
+   *
+   * Page-local by construction, and deliberately so: the store's unit is the
+   * pair, and completing a cluster across the whole queue would need a second,
+   * unbounded query per page. A cluster split across a page boundary shows up as
+   * two rows rather than one — noisier, never wrong.
+   */
+  clusterInstanceIds: string[]
+}
+
+/** Keyset position — score first, id as the tiebreak, both descending. */
+export interface DuplicateCursor {
+  score: number
+  id: string
+}
+
+const DEFAULT_LIMIT = 25
+
+/**
+ * Snoozed is not a status: it is `open` plus a future `snoozeUntil`, so the pair
+ * returns to the queue on its own with no sweep to un-snooze it.
+ */
+function notSnoozed(now: Date): SQL {
+  return or(isNull(T.snoozeUntil), lt(T.snoozeUntil, now)) as SQL
+}
+
+/**
+ * The caller's record scope, as one predicate.
+ *
+ * Definitions with no per-side narrowing collapse into a single `IN (…)` — the
+ * overwhelmingly common shape, and the one the queue index can serve. Only the
+ * rare restricted / grant-only definitions get their own `AND`ed arm.
+ */
+function buildScopePredicate(scopes: readonly DuplicateDefScope[]): SQL | undefined {
+  const plain: string[] = []
+  const arms: SQL[] = []
+
+  for (const scope of scopes) {
+    if (!scope.lowWhere && !scope.highWhere) {
+      plain.push(scope.entityDefinitionId)
+      continue
+    }
+    arms.push(
+      and(
+        eq(T.entityDefinitionId, scope.entityDefinitionId),
+        scope.lowWhere,
+        scope.highWhere
+      ) as SQL
+    )
+  }
+
+  if (plain.length > 0) arms.unshift(inArray(T.entityDefinitionId, plain))
+  if (arms.length === 0) return undefined
+  return arms.length === 1 ? arms[0] : (or(...arms) as SQL)
+}
+
+/**
+ * The filters EVERY read path shares (§3.1a rule 1).
+ *
+ * `archivedAt IS NULL` on **both** sides is the invariant, not the hygiene.
+ * `deleteOpenPairsForRecord` already removes an archived record's open pairs at
+ * archive time, but write-path hooks in this codebase get bypassed routinely
+ * (`skipEvents`, `bypassFieldGuards`, bulk paths, direct DB writes), so
+ * correctness must not depend on one having run. Applying it on `list` alone —
+ * which is what the plan originally said — would have made `count` (the
+ * notification badge) count pairs the list refuses to render.
+ */
+function openPairFilters(organizationId: string, now: Date, scope: SQL | undefined): SQL {
+  return and(
+    eq(T.organizationId, organizationId),
+    eq(T.status, 'open'),
+    isNull(LOW.archivedAt),
+    isNull(HIGH.archivedAt),
+    notSnoozed(now),
+    scope
+  ) as SQL
+}
+
+/** The projection both list shapes share. */
+const PAIR_COLUMNS = {
+  id: T.id,
+  entityDefinitionId: T.entityDefinitionId,
+  score: T.score,
+  band: T.band,
+  signals: T.signals,
+  createdAt: T.createdAt,
+  lowId: T.instanceIdLow,
+  lowDisplayName: LOW.displayName,
+  lowSecondary: LOW.secondaryDisplayValue,
+  lowAvatarUrl: LOW.avatarUrl,
+  lowFirstInteractionAt: LOW.firstInteractionAt,
+  lowLastInteractionAt: LOW.lastInteractionAt,
+  highId: T.instanceIdHigh,
+  highDisplayName: HIGH.displayName,
+  highSecondary: HIGH.secondaryDisplayValue,
+  highAvatarUrl: HIGH.avatarUrl,
+  highFirstInteractionAt: HIGH.firstInteractionAt,
+  highLastInteractionAt: HIGH.lastInteractionAt,
+} as const
+
+type PairRow = {
+  [K in keyof typeof PAIR_COLUMNS]: unknown
+}
+
+function toPair(row: PairRow): DuplicatePair {
+  return {
+    id: row.id as string,
+    entityDefinitionId: row.entityDefinitionId as string,
+    score: row.score as number,
+    band: row.band as Band,
+    signals: (row.signals ?? []) as Signal[],
+    createdAt: row.createdAt as Date,
+    low: {
+      instanceId: row.lowId as string,
+      displayName: (row.lowDisplayName ?? null) as string | null,
+      secondaryDisplayValue: (row.lowSecondary ?? null) as string | null,
+      avatarUrl: (row.lowAvatarUrl ?? null) as string | null,
+      firstInteractionAt: (row.lowFirstInteractionAt ?? null) as Date | null,
+      lastInteractionAt: (row.lowLastInteractionAt ?? null) as Date | null,
+    },
+    high: {
+      instanceId: row.highId as string,
+      displayName: (row.highDisplayName ?? null) as string | null,
+      secondaryDisplayValue: (row.highSecondary ?? null) as string | null,
+      avatarUrl: (row.highAvatarUrl ?? null) as string | null,
+      firstInteractionAt: (row.highFirstInteractionAt ?? null) as Date | null,
+      lastInteractionAt: (row.highLastInteractionAt ?? null) as Date | null,
+    },
+  }
+}
+
+/** Parameters for {@link listDuplicatePairs}. */
+export interface ListDuplicatePairsParams {
+  organizationId: string
+  /** The definitions the caller may read, with their per-side scope. */
+  scopes: readonly DuplicateDefScope[]
+  cursor?: DuplicateCursor
+  limit?: number
+  /** Narrow to one definition — must already be present in {@link scopes}. */
+  entityDefinitionId?: string
+  /** Injected for tests; defaults to `new Date()`. */
+  now?: Date
+}
+
+/** {@link listDuplicatePairs}'s page. */
+export interface DuplicatePairPage {
+  items: DuplicatePairListItem[]
+  nextCursor: DuplicateCursor | null
+}
+
+/**
+ * The review queue: open, non-snoozed, unarchived pairs the caller can see BOTH
+ * sides of, best-scoring first.
+ *
+ * Ordered `(score desc, id desc)` — the id tiebreak is what makes the keyset
+ * cursor total, since `score` is a `double precision` that ties constantly (every
+ * `high` pair produced by a single strong key scores identically).
+ */
+export async function listDuplicatePairs(
+  db: Database,
+  params: ListDuplicatePairsParams
+): Promise<Result<DuplicatePairPage, Error>> {
+  const { organizationId, cursor, entityDefinitionId } = params
+  const limit = params.limit ?? DEFAULT_LIMIT
+  const now = params.now ?? new Date()
+
+  const scopes = entityDefinitionId
+    ? params.scopes.filter((scope) => scope.entityDefinitionId === entityDefinitionId)
+    : params.scopes
+
+  // Arm 4, generalized: nothing is reachable, so no query is issued at all.
+  if (scopes.length === 0) return ok({ items: [], nextCursor: null })
+
+  const keyset = cursor
+    ? (or(lt(T.score, cursor.score), and(eq(T.score, cursor.score), lt(T.id, cursor.id))) as SQL)
+    : undefined
+
+  const rows = await db
+    .select(PAIR_COLUMNS)
+    .from(T)
+    .innerJoin(LOW, eq(LOW.id, T.instanceIdLow))
+    .innerJoin(HIGH, eq(HIGH.id, T.instanceIdHigh))
+    .where(and(openPairFilters(organizationId, now, buildScopePredicate(scopes)), keyset))
+    .orderBy(desc(T.score), desc(T.id))
+    .limit(limit + 1)
+
+  const hasMore = rows.length > limit
+  const page = (hasMore ? rows.slice(0, limit) : rows).map(toPair)
+  const clusters = clusterInstanceIds(page)
+
+  const last = page.at(-1)
+  return ok({
+    items: page.map((pair) => ({
+      ...pair,
+      clusterInstanceIds: clusters.get(pair.low.instanceId) ?? [
+        pair.low.instanceId,
+        pair.high.instanceId,
+      ],
+    })),
+    nextCursor: hasMore && last ? { score: last.score, id: last.id } : null,
+  })
+}
+
+/**
+ * Union-find over the page's pairs → `instanceId → every id in its component`.
+ *
+ * Clustering lives at READ time by design (see the schema docstring): the stored
+ * unit is the pair, so one side can be dismissed or merged without invalidating
+ * its neighbours. The cost is that a cluster is only ever as complete as the set
+ * of pairs in hand.
+ */
+function clusterInstanceIds(pairs: DuplicatePair[]): Map<string, string[]> {
+  const parent = new Map<string, string>()
+
+  const find = (id: string): string => {
+    let root = parent.get(id) ?? id
+    if (root === id) return id
+    root = find(root)
+    parent.set(id, root)
+    return root
+  }
+  const union = (a: string, b: string) => {
+    const rootA = find(a)
+    const rootB = find(b)
+    if (rootA !== rootB) parent.set(rootA, rootB)
+  }
+
+  for (const pair of pairs) {
+    if (!parent.has(pair.low.instanceId)) parent.set(pair.low.instanceId, pair.low.instanceId)
+    if (!parent.has(pair.high.instanceId)) parent.set(pair.high.instanceId, pair.high.instanceId)
+    union(pair.low.instanceId, pair.high.instanceId)
+  }
+
+  const members = new Map<string, string[]>()
+  for (const id of parent.keys()) {
+    const root = find(id)
+    const bucket = members.get(root)
+    if (bucket) bucket.push(id)
+    else members.set(root, [id])
+  }
+
+  const byInstance = new Map<string, string[]>()
+  for (const id of parent.keys()) byInstance.set(id, members.get(find(id)) ?? [id])
+  return byInstance
+}
+
+/** Parameters for {@link listDuplicatePairsForRecord}. */
+export interface ListPairsForRecordParams {
+  organizationId: string
+  /** `EntityInstance.id` of the record the indicator is mounted on. */
+  instanceId: string
+  scopes: readonly DuplicateDefScope[]
+  limit?: number
+  now?: Date
+}
+
+/**
+ * Open pairs touching one record — the per-record header indicator.
+ *
+ * Same scope and archived rules as {@link listDuplicatePairs}, for the same
+ * reason: the caller may be able to see THIS record and not the other side, and
+ * the other side's name is exactly what this read returns.
+ */
+export async function listDuplicatePairsForRecord(
+  db: Database,
+  params: ListPairsForRecordParams
+): Promise<Result<DuplicatePair[], Error>> {
+  const { organizationId, instanceId, scopes } = params
+  const now = params.now ?? new Date()
+  if (scopes.length === 0) return ok([])
+
+  const rows = await db
+    .select(PAIR_COLUMNS)
+    .from(T)
+    .innerJoin(LOW, eq(LOW.id, T.instanceIdLow))
+    .innerJoin(HIGH, eq(HIGH.id, T.instanceIdHigh))
+    .where(
+      and(
+        openPairFilters(organizationId, now, buildScopePredicate(scopes)),
+        or(eq(T.instanceIdLow, instanceId), eq(T.instanceIdHigh, instanceId))
+      )
+    )
+    .orderBy(desc(T.score), desc(T.id))
+    .limit(params.limit ?? DEFAULT_LIMIT)
+
+  return ok(rows.map(toPair))
+}
+
+/** Parameters for {@link countOpenDuplicatePairs}. */
+export interface CountDuplicatePairsParams {
+  organizationId: string
+  scopes: readonly DuplicateDefScope[]
+  now?: Date
+}
+
+/**
+ * How many pairs the review queue would render — the notification badge's term.
+ *
+ * Carries the SAME archived and scope filters as {@link listDuplicatePairs} and
+ * not one filter fewer. A badge that counts a different set than the tab shows
+ * is the drift failure the shared count hook exists to prevent, arriving through
+ * the back door.
+ */
+export async function countOpenDuplicatePairs(
+  db: Database,
+  params: CountDuplicatePairsParams
+): Promise<Result<number, Error>> {
+  const { organizationId, scopes } = params
+  const now = params.now ?? new Date()
+  if (scopes.length === 0) return ok(0)
+
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(T)
+    .innerJoin(LOW, eq(LOW.id, T.instanceIdLow))
+    .innerJoin(HIGH, eq(HIGH.id, T.instanceIdHigh))
+    .where(openPairFilters(organizationId, now, buildScopePredicate(scopes)))
+
+  return ok(row?.count ?? 0)
+}
+
+/** Parameters for {@link getVisibleDuplicatePair}. */
+export interface GetDuplicatePairParams {
+  organizationId: string
+  pairId: string
+  scopes: readonly DuplicateDefScope[]
+}
+
+/**
+ * One pair by id, subject to the same scope and archived rules — the
+ * resolve-then-authorize read every pair MUTATION goes through.
+ *
+ * Status is deliberately NOT filtered: a caller dismissing an already-dismissed
+ * pair deserves a truthful answer from the router rather than a 404 that blames
+ * the id. Snooze is not filtered either — re-snoozing a snoozed pair is legal.
+ */
+export async function getVisibleDuplicatePair(
+  db: Database,
+  params: GetDuplicatePairParams
+): Promise<Result<DuplicatePair | null, Error>> {
+  const { organizationId, pairId, scopes } = params
+  if (scopes.length === 0) return ok(null)
+
+  const [row] = await db
+    .select(PAIR_COLUMNS)
+    .from(T)
+    .innerJoin(LOW, eq(LOW.id, T.instanceIdLow))
+    .innerJoin(HIGH, eq(HIGH.id, T.instanceIdHigh))
+    .where(
+      and(
+        eq(T.organizationId, organizationId),
+        eq(T.id, pairId),
+        isNull(LOW.archivedAt),
+        isNull(HIGH.archivedAt),
+        buildScopePredicate(scopes)
+      )
+    )
+    .limit(1)
+
+  return ok(row ? toPair(row) : null)
+}
+
+/**
+ * How well established a record is — the input to merge-TARGET defaulting
+ * (plan §3.4).
+ *
+ * `MergeDialog` defaults its target to the first id it is handed, which in
+ * pair order is arbitrary. The surviving record's id is what links and external
+ * references keep pointing at while the archived one's id dies, so "merged into
+ * the empty stub" is a real and irreversible-feeling mistake.
+ *
+ * ⚠ **The plan's middle term — raw interaction COUNT — is deliberately not
+ * here.** There is no interaction counter on `EntityInstance`; computing one
+ * means aggregating `MessageParticipant` per record, which for a page of 25
+ * pairs is 50 correlated aggregates over a contact's entire message history —
+ * far too much for a query that runs every time the notification bell opens.
+ * `firstInteractionAt` (backfilled, indexed, already on the row) answers the
+ * same question well enough: whether the record has any interaction history at
+ * all, and how far back it goes.
+ */
+export interface MergeEstablishment {
+  instanceId: string
+  /**
+   * The org has previously SENT to a participant linked to this record — the
+   * strongest available "this is the address people actually use" evidence.
+   */
+  hasOutboundHistory: boolean
+}
+
+/**
+ * Outbound-history flags for a bounded set of records, in one grouped query.
+ *
+ * Grouped rather than correlated per row so the cost is one index scan over
+ * `Participant_entityInstanceId_idx`, not one per side of every listed pair.
+ * Records with no participant row are simply absent from the result — callers
+ * read a missing entry as `false`.
+ */
+export async function readMergeEstablishment(
+  db: Database,
+  organizationId: string,
+  instanceIds: readonly string[]
+): Promise<Result<MergeEstablishment[], Error>> {
+  const ids = [...new Set(instanceIds)]
+  if (ids.length === 0) return ok([])
+
+  // `inArray`, never `= ANY(${ids}::text[])` in a raw fragment — the latter
+  // silently matches ZERO rows under Drizzle's `sql` template, with no error.
+  const rows = await db
+    .select({
+      instanceId: schema.Participant.entityInstanceId,
+      hasOutboundHistory: sql<boolean>`bool_or(${schema.Participant.hasReceivedMessage})`,
+    })
+    .from(schema.Participant)
+    .where(
+      and(
+        eq(schema.Participant.organizationId, organizationId),
+        inArray(schema.Participant.entityInstanceId, ids)
+      )
+    )
+    .groupBy(schema.Participant.entityInstanceId)
+
+  return ok(
+    rows.flatMap((row) =>
+      row.instanceId
+        ? [{ instanceId: row.instanceId, hasOutboundHistory: Boolean(row.hasOutboundHistory) }]
+        : []
+    )
+  )
+}
+
+/**
+ * Order instance ids **best-established first** — what a merge opened from a
+ * duplicate suggestion hands `MergeDialog` as `baseRecordIds`.
+ *
+ * Scoped to the suggestion entry point on purpose: every other `MergeDialog`
+ * caller keeps its own ordering, because elsewhere the first id is a deliberate
+ * user selection rather than an artefact of canonical pair order.
+ *
+ * Ladder: outbound history → has any interaction history → oldest
+ * `firstInteractionAt` → id (so the order is total and stable).
+ */
+export function orderByEstablishment(
+  sides: readonly DuplicateSide[],
+  establishment: readonly MergeEstablishment[]
+): string[] {
+  const outbound = new Map(establishment.map((row) => [row.instanceId, row.hasOutboundHistory]))
+  const rank = (side: DuplicateSide) => ({
+    outbound: outbound.get(side.instanceId) ? 1 : 0,
+    interacted: side.firstInteractionAt ? 1 : 0,
+    since: side.firstInteractionAt?.getTime() ?? Number.POSITIVE_INFINITY,
+  })
+
+  return [...sides]
+    .sort((a, b) => {
+      const left = rank(a)
+      const right = rank(b)
+      return (
+        right.outbound - left.outbound ||
+        right.interacted - left.interacted ||
+        left.since - right.since ||
+        a.instanceId.localeCompare(b.instanceId)
+      )
+    })
+    .map((side) => side.instanceId)
+}

--- a/packages/lib/src/resources/merge/merge-duplicate-resolution.int.test.ts
+++ b/packages/lib/src/resources/merge/merge-duplicate-resolution.int.test.ts
@@ -1,0 +1,136 @@
+// packages/lib/src/resources/merge/merge-duplicate-resolution.int.test.ts
+//
+// DB-backed test (vitest.integration.config.ts → auxx_test) that the merge
+// service actually RESOLVES its duplicate suggestions (plan §3.4).
+//
+// `resolveSuggestionsForMerge`'s own behaviour — which rows are stamped `merged`
+// and which are deleted — is pinned in `dedup/__tests__/dedup-engine.int.test.ts`.
+// What is under test HERE is the wiring: that `EntityMergeService.merge` calls
+// it, inside the same transaction as the archive, so a merge cannot leave the
+// review queue offering a pair the user just resolved.
+//
+// It runs the real service against real SQL rather than a fake tx because the
+// claim is "the pair is gone from the queue AFTER a merge", and a fake
+// transaction can only show that a function was called.
+
+import { schema } from '@auxx/database'
+import { createTestOrganization, getTestDb } from '@auxx/test-utils'
+import { eq } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+import { toRecordId } from '../resource-id'
+import { EntityMergeService } from './merge-service'
+
+const db = () => getTestDb() as never as import('@auxx/database').Database
+
+async function seed() {
+  const org = await createTestOrganization()
+  const [def] = await db()
+    .insert(schema.EntityDefinition)
+    .values({
+      organizationId: org.id,
+      entityType: 'contact',
+      apiSlug: 'contacts',
+      singular: 'contact',
+      plural: 'contacts',
+      updatedAt: new Date(),
+    })
+    .returning()
+
+  const instance = async (name: string) => {
+    const [row] = await db()
+      .insert(schema.EntityInstance)
+      .values({
+        organizationId: org.id,
+        entityDefinitionId: def?.id as string,
+        displayName: name,
+        updatedAt: new Date(),
+      })
+      .returning()
+    return row?.id as string
+  }
+
+  return {
+    orgId: org.id,
+    userId: org.ownerId,
+    defId: def?.id as string,
+    target: await instance('Target'),
+    source: await instance('Source'),
+    bystander: await instance('Bystander'),
+  }
+}
+
+async function insertPair(orgId: string, defId: string, x: string, y: string): Promise<void> {
+  const [low, high] = [x, y].sort() as [string, string]
+  await db().insert(schema.DuplicateSuggestion).values({
+    organizationId: orgId,
+    entityDefinitionId: defId,
+    instanceIdLow: low,
+    instanceIdHigh: high,
+    score: 0.9,
+    band: 'high',
+    signals: [],
+    status: 'open',
+  })
+}
+
+async function storedPairs(orgId: string) {
+  return db()
+    .select({
+      id: schema.DuplicateSuggestion.id,
+      status: schema.DuplicateSuggestion.status,
+      low: schema.DuplicateSuggestion.instanceIdLow,
+      high: schema.DuplicateSuggestion.instanceIdHigh,
+    })
+    .from(schema.DuplicateSuggestion)
+    .where(eq(schema.DuplicateSuggestion.organizationId, orgId))
+}
+
+describe('EntityMergeService.merge — duplicate suggestion resolution', () => {
+  it('stamps the acted-on pair `merged` and closes the source’s other pairs', async () => {
+    const f = await seed()
+    await insertPair(f.orgId, f.defId, f.target, f.source)
+    await insertPair(f.orgId, f.defId, f.source, f.bystander)
+
+    const service = new EntityMergeService(db(), f.orgId, f.userId)
+    await service.merge({
+      targetRecordId: toRecordId(f.defId, f.target),
+      sourceRecordIds: [toRecordId(f.defId, f.source)],
+    })
+
+    const rows = await storedPairs(f.orgId)
+
+    // The acted-on pair survives as `merged` — terminal, and the audit trail
+    // that this suggestion led somewhere. The bystander pair is DELETED: it was
+    // never acted on, and whether the bystander still duplicates the TARGET is
+    // a fact for the target's next scan to establish, not one to migrate.
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.status).toBe('merged')
+    expect([rows[0]?.low, rows[0]?.high].sort()).toEqual([f.target, f.source].sort())
+  })
+
+  it('leaves pairs that touch neither side alone', async () => {
+    const f = await seed()
+    await insertPair(f.orgId, f.defId, f.target, f.source)
+    // A pair between two records the merge does not involve.
+    const [other] = await db()
+      .insert(schema.EntityInstance)
+      .values({
+        organizationId: f.orgId,
+        entityDefinitionId: f.defId,
+        displayName: 'Other',
+        updatedAt: new Date(),
+      })
+      .returning()
+    await insertPair(f.orgId, f.defId, f.bystander, other?.id as string)
+
+    const service = new EntityMergeService(db(), f.orgId, f.userId)
+    await service.merge({
+      targetRecordId: toRecordId(f.defId, f.target),
+      sourceRecordIds: [toRecordId(f.defId, f.source)],
+    })
+
+    const rows = await storedPairs(f.orgId)
+    expect(rows).toHaveLength(2)
+    expect(rows.filter((row) => row.status === 'open')).toHaveLength(1)
+  })
+})

--- a/packages/lib/src/resources/merge/merge-service.ts
+++ b/packages/lib/src/resources/merge/merge-service.ts
@@ -4,6 +4,7 @@ import { type Database, schema, type Transaction } from '@auxx/database'
 import type { FieldType } from '@auxx/database/types'
 import { getFieldId, isFieldPath, isResourceFieldId, toResourceFieldIds } from '@auxx/types/field'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
+import { resolveSuggestionsForMerge } from '../../dedup/pairs'
 import { touchEntityActivity } from '../../entity-instances/activity'
 import { BadRequestError, ForbiddenError, NotFoundError } from '../../errors'
 import { formatToRawValue } from '../../field-values/client'
@@ -105,6 +106,24 @@ export class EntityMergeService {
 
       // 7. Archive sources
       await this.archiveSourceInstances(tx, sourceIds)
+
+      // 7b. Resolve the duplicate suggestions this merge answers — INSIDE the
+      // transaction, so a rolled-back merge cannot leave the queue reporting a
+      // merge that did not happen. Archive (step 7) is a soft delete, so the
+      // `DuplicateSuggestion` FK cascade never fires and the pairs survive
+      // unless this runs. The pair whose both sides are in the merge set is
+      // stamped `merged` (terminal, and the record that this suggestion led
+      // somewhere); every other open pair touching an archived source is
+      // deleted — its surviving side may still duplicate the TARGET, but that is
+      // a fact for the target's next scan to establish, not one to migrate
+      // blindly.
+      const resolved = await resolveSuggestionsForMerge(
+        tx,
+        this.organizationId,
+        targetId,
+        sourceIds
+      )
+      if (resolved.isErr()) throw resolved.error
 
       // Merge is meaningful activity on the target — surface it for staleness scanners.
       await touchEntityActivity([targetId], this.organizationId, new Date(), tx)


### PR DESCRIPTION
Makes duplicate suggestions visible. Adds `dedup/queries.ts`, the `duplicates`
tRPC router, an Approvals-tab section, a per-record header indicator, and the
merge resolution hook.

Visibility is enforced in SQL, not the router. A pair read without the record
scope predicate advertises the display names of records the viewer cannot see,
so scope is resolved per join alias — twice, once for each side — and a pair
whose other side is invisible is excluded outright rather than rendered as half
a pair.

All three read paths filter `archivedAt IS NULL` on BOTH sides via a shared
`openPairFilters()`. Archived pairs are also deleted at archive time, but that
is hygiene; the read filter is the invariant, since write-path hooks here get
bypassed (`skipEvents`, bulk paths, direct writes). Filtering only `list` would
have let `count` feed the badge from pairs the list refuses to render.

Merge marks the pair `merged` and closes siblings inside the merge transaction.
Merge-target defaulting orders candidates best-established-first — outbound
history, then any interaction, then oldest `firstInteractionAt` — so a merge
does not default into an empty stub. The header indicator keeps its explicit
`targetRecordId` anchor and overrides that ordering.

`dismissedBand` is stamped from the row's own band inside the UPDATE rather than
passed by the caller, so a stale client band cannot corrupt reopen-on-upgrade.
Snooze stamps no band.

The indicator renders nothing when a record has no open pairs, which is nearly
every record.

Tests: 155 unit + 73 DB-backed integration.

---
Completes the duplicate-suggestions feature (Phase 3 of `plans/records/duplicate-suggestion-plan-v2.md`), on top of #1640/#1641. Still dark behind `FeatureKey.duplicateDetection`, which seeds `false` on every tier.

**Known limits, documented in code rather than hidden:**
- Clusters are page-local — a cluster split across a page boundary renders as two rows. Completing them needs a second unbounded query per page.
- Merge-target ranking uses outbound history → any interaction → oldest `firstInteractionAt`. The plan asked for "interaction count" as the middle term; there is no such column, and a real count means ~50 correlated aggregates over full message histories on a query that runs every time the bell opens.

**Not yet verified in a browser** — Phase 5 manual verification is next. Note phone fixtures must be real-shaped E.164 (`+12133734253`); `+1 555-…` is rejected by libphonenumber, so phone blocking silently finds nothing.

**Deploy:** needs `pnpm db:migrate` on prod for migration `0333` (from #1640, still dev-only).