### PR TITLE
feat(channels): rewrite the quo (openphone) channel against the real api

### DIFF
--- a/apps/docs/content/docs/help/channels/openphone.mdx
+++ b/apps/docs/content/docs/help/channels/openphone.mdx
@@ -1,8 +1,125 @@
 ---
-title: OpenPhone
-description: Connect OpenPhone to Auxx.ai to manage phone and SMS conversations from a unified inbox.
+title: Quo (OpenPhone)
+description: Connect a Quo phone number to Auxx.ai so SMS conversations land in your inbox and you can reply from the platform.
 ---
 
-<Callout type="warn" title="Coming soon">
-  This channel is not yet available. Check back for updates.
+Quo — formerly OpenPhone — is a business phone service. Connect a Quo number to Auxx.ai and text messages sent to it arrive in the inbox you choose, alongside your email channels, so the same team answers them the same way.
+
+<Callout type="info">
+  OpenPhone rebranded to **Quo**, and `openphone.com` now redirects to `quo.com`. You'll still see "OpenPhone" in a few places around the web — it's the same product and the same account.
 </Callout>
+
+## Prerequisites
+
+- A Quo workspace with at least one phone number.
+- Owner or admin access to that workspace — only owners and admins can create an API key.
+- An inbox in Auxx.ai for the conversations to land in.
+
+## 1. Create a Quo API key
+
+1. Sign in to the [Quo dashboard](https://quo.com/).
+2. Go to **Workspace Settings → API**.
+3. Create a new key and give it a name you'll recognize later, e.g. "Auxx.ai".
+4. Copy the key. Quo shows it once — if you lose it, create another.
+
+<Callout type="warn">
+  The key is workspace-wide. Anyone holding it can read and send messages on every number in the workspace, so treat it like a password and revoke it in Quo if it's ever exposed.
+</Callout>
+
+## 2. Connect Quo in Auxx.ai
+
+1. Go to **Settings → Channels**.
+2. Click **New Channel** and select **Quo**.
+3. Paste your API key.
+4. Pick the phone number this channel should answer, from the list of numbers on your workspace.
+5. Choose the inbox its conversations route into.
+
+That's the whole setup. You don't need to configure anything back in the Quo dashboard:
+
+| Step | Who does it |
+|---|---|
+| Reading the numbers on your workspace | Auxx.ai, using your API key |
+| Creating the channel and linking the inbox | Auxx.ai |
+| Registering the webhook that delivers incoming texts | Auxx.ai, automatically |
+| Generating the signing secret that proves messages are genuine | Quo, handed straight to Auxx.ai |
+
+There is no webhook URL to paste and no signing secret to copy across.
+
+## One connection, one channel per number
+
+Your API key represents the **workspace**, not a single number. So you paste it once:
+
+- **The connection** is your Quo workspace. Connect it a single time.
+- **A channel** is one phone number from that workspace, routed into one inbox.
+
+To answer a second number, add another channel against the connection you already have — go to **Settings → Channels → New Channel → Quo** and pick the next number. You don't need a second API key, and each number can route into a different inbox if you want sales and support kept apart.
+
+<Callout type="warn">
+  Because every Quo channel shares one connection, deleting that connection disconnects **all** of them. Remove an individual channel instead if you only want to stop answering one number.
+</Callout>
+
+## Check that your number is allowed to send
+
+Quo restricts messaging per number and per region, and a restricted number will fail at send time — the message simply won't go out. This catches people off guard, because the number receives texts perfectly well.
+
+On one real workspace we tested, of three numbers only the toll-free line was cleared to send SMS to US recipients; the other two were restricted.
+
+Before you rely on a number for replies, open it in the Quo dashboard and confirm messaging is unrestricted for the regions you text. If it isn't, Quo's own registration process is what lifts it — it isn't something Auxx.ai can change.
+
+## What history you get
+
+Connecting a channel brings across recent conversations for that number, most recently active first, so a thread someone replied to yesterday is there even if it started a year ago. It is a bounded catch-up, not a complete archive — very old, long-dormant conversations may not be included.
+
+Two things never come across, because Quo's API doesn't return them for past messages:
+
+- **Attachments on picture messages (MMS).** A message that was nothing but an image backfills with a placeholder and no file.
+- **Voicemail and call recordings.**
+
+This isn't a limit we can work around — Quo only ever hands out media at the moment a message arrives, never afterwards. Anything from before you connected stays viewable in the Quo dashboard.
+
+## How SMS differs from email
+
+Texting isn't email, and the composer changes to match. On a Quo channel you won't see:
+
+| Missing | Why |
+|---|---|
+| Subject line | SMS has no subject. Threads are identified by the person you're texting. |
+| Cc and Bcc | There's no equivalent in SMS. |
+| Drafts | Quo has no drafts — there's nowhere to save one. |
+| Attaching a file to a reply | Quo's send API accepts text only, so outbound picture messages aren't possible. |
+
+Incoming picture messages arrive as messages with any text they carried, but the image itself isn't stored in Auxx.ai yet — open the conversation in Quo to see it.
+
+## Troubleshooting
+
+<Accordions type="single">
+  <Accordion title="No phone numbers appear after I paste the key">
+    The key is probably from a different workspace, or it was revoked. Create a fresh key in **Workspace Settings → API** and try again. If the key is valid but new numbers you've since bought are missing, refresh the number list on the connection.
+  </Accordion>
+  <Accordion title="Incoming texts aren't showing up">
+    Confirm the channel is connected and linked to an inbox in **Settings → Channels**. Then send a test text to the number from a phone that isn't in your workspace — messages you send between your own Quo numbers can behave differently. If it appears in the Quo dashboard but not in Auxx.ai, reconnect the channel so the webhook is registered again.
+  </Accordion>
+  <Accordion title="Replies fail to send">
+    The most common cause is a messaging restriction on the number — see [Check that your number is allowed to send](#check-that-your-number-is-allowed-to-send). Also check the recipient's number is a real mobile line; landlines and short codes can't receive SMS.
+  </Accordion>
+  <Accordion title="A message is empty or shows a placeholder">
+    That's a picture message. Quo doesn't return the image for past messages, so only the placeholder can be shown. The original is still viewable in the Quo dashboard.
+  </Accordion>
+  <Accordion title="I rotated the API key in Quo">
+    Rotating the key breaks every channel on that connection at once. Open the connection in Auxx.ai, paste the new key, and the existing channels and inbox links carry over.
+  </Accordion>
+</Accordions>
+
+## Next steps
+
+<Cards>
+  <Card title="Chat widget" href="/help/channels/chat-widget">
+    Route live website conversations into the same inbox.
+  </Card>
+  <Card title="Connect your first inbox" href="/help/getting-started/connect-inbox">
+    Link a channel to a shared inbox and set who can see it.
+  </Card>
+  <Card title="Gmail channel" href="/help/channels/gmail">
+    Connect an email inbox alongside your phone number.
+  </Card>
+</Cards>

--- a/apps/web/src/app/api/openphone/webhook/route.ts
+++ b/apps/web/src/app/api/openphone/webhook/route.ts
@@ -1,59 +1,77 @@
 // apps/web/src/app/api/openphone/webhook/route.ts
+// Inbound webhook endpoint for Quo (formerly OpenPhone).
+//
+// The provider key stays `openphone` everywhere it is persisted — Integration.provider,
+// Credential.type, and this route path (which `providerWebhookCallbackUrl('openphone')` derives,
+// so renaming it would invalidate every already-registered webhook). The rename is labels-only.
+//
+// Verification: Quo signs as `openphone-signature: hmac;1;<timestamp>;<base64 signature>` —
+// HMAC-SHA256, base64 digest, over `${timestamp}.${rawBody}`, with the signing key base64-DECODED
+// first. The timestamp comes from the header, which `WebhookVerifyPreset.signedPayload` (raw-body
+// only) cannot express, so this call site parses the header and calls `verifyHmacSignature`
+// directly, exactly like the Recall/Svix call site. `openphonePreset` documents the scheme as data.
 
 import { database as db, schema } from '@auxx/database'
 import type { MessageData } from '@auxx/lib/email'
 import { MessageStorageService } from '@auxx/lib/email'
 import type {
   OpenPhoneIntegrationMetadata,
-  OpenPhoneMessageReceivedData,
-  OpenPhoneWebhookEvent,
-} from '@auxx/lib/providers/openphone/types' // Adjust path
-import { openphonePreset, resolveWebhookSecret, verifyWebhook } from '@auxx/lib/webhooks'
+  QuoWebhookEvent,
+  QuoWebhookMessage,
+} from '@auxx/lib/providers/openphone/types'
+import { resolveWebhookSecret, verifyHmacSignature } from '@auxx/lib/webhooks'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq, sql } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 
 const logger = createScopedLogger('openphone-webhook')
 
+/** Quo's signature header. Note: no `x-` prefix — that was the shape we wrongly shipped before. */
+const SIGNATURE_HEADER = 'openphone-signature'
+
+/** Replay window, in seconds. Matches the Recall/Svix call site's tolerance. */
+const TIMESTAMP_TOLERANCE_SEC = 300
+
+/** The events that carry a `phoneNumberId` and therefore resolve to one of our Integrations. */
+type QuoPhoneScopedPayload = { phoneNumberId?: string }
+
 /**
- * Handles incoming OpenPhone webhook events (POST request).
+ * Handles an incoming Quo webhook event (POST).
+ *
+ * Always answers 200 for anything we deliberately do not process — Quo retries on non-2xx, and a
+ * retry loop on an event we will never handle is worse than a dropped one.
  */
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  logger.info('Received OpenPhone webhook event')
   let bodyText: string
-  let payload: OpenPhoneWebhookEvent
+  let payload: QuoWebhookEvent<QuoPhoneScopedPayload>
 
   try {
-    // 1. Read body first for signature verification
+    // 1. Raw body first — the HMAC is computed over these exact bytes, never over re-serialized
+    //    JSON.
     bodyText = await req.text()
     if (!bodyText) {
-      logger.warn('Received empty request body for OpenPhone webhook.')
+      logger.warn('Received empty request body for Quo webhook.')
       return NextResponse.json({ error: 'Bad Request: Empty body' }, { status: 400 })
     }
 
-    // 2. Parse the body (do this *after* reading text for signature)
     payload = JSON.parse(bodyText)
-    logger.debug('Parsed OpenPhone webhook payload', { type: payload?.type, eventId: payload?.id })
+    logger.debug('Parsed Quo webhook payload', { type: payload?.type, eventId: payload?.id })
 
-    // 3. Find the relevant Integration based on webhook data
-    // We need a piece of data that uniquely identifies the integration.
-    // The webhook payload itself doesn't directly contain our integration ID.
-    // It usually contains the phone number ID (`data.phone_number_id` for messages)
-    // that received the event. We use this to look up the integration.
-
-    let phoneNumberId: string | undefined
-    if (payload.type?.startsWith('message.') && payload.data?.phone_number_id) {
-      phoneNumberId = payload.data.phone_number_id
-    } else if (payload.type?.startsWith('call.') && payload.data?.phone_number?.id) {
-      phoneNumberId = payload.data.phone_number.id
-    }
-    // Add other event type checks if needed
+    // 2. Resolve the Integration. Every phone-scoped event — `message.received`,
+    //    `message.delivered`, `call.ringing`, `call.completed`, `call.recording.completed` —
+    //    carries `phoneNumberId` at the same place, so one code path covers all five.
+    const phoneNumberId = payload.data?.object?.phoneNumberId
 
     if (!phoneNumberId) {
-      logger.warn('Could not determine phone_number_id from webhook payload to find integration.', {
+      // `call.summary.completed`, `call.transcript.completed`, `contact.updated` and
+      // `contact.deleted` carry NO `phoneNumberId`, so `metadata->>'phoneNumberId' = …` can never
+      // match them. Do NOT subscribe to those events without first building the lookup they need:
+      // summaries/transcripts require a `callId` → prior-call resolution, and contact events
+      // require a credential-scoped (org-level) resolution rather than a channel-level one.
+      logger.warn('Quo webhook payload carries no phoneNumberId; cannot resolve an integration.', {
         payloadType: payload.type,
+        eventId: payload.id,
       })
-      // Respond OK even if we can't process, to prevent OpenPhone retries for irrelevant events.
       return NextResponse.json({ status: 'success - cannot identify integration' }, { status: 200 })
     }
 
@@ -75,21 +93,20 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       .limit(1)
 
     if (!integration || !integration.metadata) {
-      logger.warn(
-        `No active OpenPhone integration found for phoneNumberId ${phoneNumberId}. Ignoring webhook event.`,
-        { eventType: payload.type }
-      )
-      // Respond OK to acknowledge receipt
+      logger.warn('No active Quo integration found for phoneNumberId. Ignoring webhook event.', {
+        phoneNumberId,
+        eventType: payload.type,
+      })
       return NextResponse.json({ status: 'success - no integration found' }, { status: 200 })
     }
     const metadata = integration.metadata as unknown as OpenPhoneIntegrationMetadata
 
-    // The signing secret lives encrypted on the linked Credential (not in metadata). Reveal it via
-    // the Integration's credentialId — the route is unauthenticated but has the org id in scope.
+    // 3. The signing secret lives encrypted on the linked Credential (Quo mints it and returns it
+    //    from `POST /v1/webhooks/messages` → `data.key`; the provisioning hook writes it there).
     if (!integration.credentialId) {
-      logger.error(
-        `OpenPhone integration ${integration.id} has no linked credential; cannot verify webhook.`
-      )
+      logger.error('Quo integration has no linked credential; cannot verify webhook.', {
+        integrationId: integration.id,
+      })
       return NextResponse.json(
         { error: 'Configuration Error: Missing credential' },
         { status: 500 }
@@ -101,181 +118,242 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       organizationId: integration.organizationId,
       field: 'webhookSigningSecret',
     })
-
-    // 4. Verify Request Signature
-    const signature = req.headers.get('x-openphone-signature')
-    if (!signature) {
-      logger.error('Missing X-Openphone-Signature header. Rejecting request.')
-      return NextResponse.json({ error: 'Forbidden: Missing signature' }, { status: 403 })
-    }
     if (!signingSecret) {
-      logger.error(
-        `Missing webhook signing secret for integration ${integration.id}. Cannot verify signature.`
-      )
+      logger.error('Missing Quo webhook signing secret. Cannot verify signature.', {
+        integrationId: integration.id,
+      })
       return NextResponse.json(
         { error: 'Configuration Error: Missing signing secret' },
         { status: 500 }
       )
     }
 
-    const verified = verifyWebhook(openphonePreset, {
-      rawBody: bodyText, // the raw body text read earlier
-      headers: { 'x-openphone-signature': signature },
+    // 4. Verify the signature.
+    const parsedSignature = parseQuoSignatureHeader(req.headers.get(SIGNATURE_HEADER))
+    if (!parsedSignature) {
+      logger.error('Missing or malformed openphone-signature header. Rejecting request.', {
+        integrationId: integration.id,
+      })
+      return NextResponse.json({ error: 'Forbidden: Missing signature' }, { status: 403 })
+    }
+
+    const { timestamp, signature } = parsedSignature
+    if (!isWithinTolerance(timestamp)) {
+      logger.error('Quo webhook timestamp outside the tolerance window. Rejecting as a replay.', {
+        integrationId: integration.id,
+        timestamp,
+      })
+      return NextResponse.json({ error: 'Forbidden: Stale signature' }, { status: 403 })
+    }
+
+    const verified = verifyHmacSignature({
+      rawBody: bodyText,
+      signature,
       secret: signingSecret,
+      encoding: 'base64',
+      secretEncoding: 'base64',
+      signedPayload: () => `${timestamp}.${bodyText}`,
     })
     if (!verified) {
-      logger.error('Invalid X-Openphone-Signature. Request rejected.', {
+      logger.error('Invalid openphone-signature. Request rejected.', {
         integrationId: integration.id,
       })
       return NextResponse.json({ error: 'Forbidden: Invalid signature' }, { status: 403 })
     }
-    logger.debug('OpenPhone webhook signature verified successfully.')
 
-    // 5. Process Supported Events
-    const storageService = new MessageStorageService()
-
+    // 5. Process the events we subscribe to.
     switch (payload.type) {
-      case 'message.received': {
-        logger.info(`Processing message.received event`, {
+      // `message.received` is inbound; `message.delivered` is the confirmation of an OUTBOUND
+      // message (`direction: 'outgoing'`). Both go through the same store path: `storeMessage`
+      // reconciles an outbound echo against the row our send pipeline already wrote (by
+      // externalId, then by the reconciler's heuristics) and flips `sendStatus` to SENT, so this
+      // both confirms our own sends AND captures messages an agent sent from the Quo app.
+      case 'message.received':
+      case 'message.delivered': {
+        const event = payload as QuoWebhookEvent<QuoWebhookMessage>
+        logger.info('Processing Quo message event', {
+          type: payload.type,
           eventId: payload.id,
           integrationId: integration.id,
         })
-        const messageData = convertOpenPhoneWebhookEventToMessageData(
-          payload.data as OpenPhoneMessageReceivedData,
+
+        const messageData = convertQuoWebhookEventToMessageData(
+          event,
           integration.id,
           integration.organizationId,
-          metadata // Pass metadata for context (e.g., our phone number)
+          metadata
         )
-        if (messageData) {
-          try {
-            await storageService.storeMessage(messageData)
-            logger.info(`Successfully stored OpenPhone message`, {
-              mid: messageData.externalId,
-              integrationId: integration.id,
-            })
-          } catch (storeError: any) {
-            logger.error(`Failed to store OpenPhone message`, {
-              mid: messageData.externalId,
-              integrationId: integration.id,
-              error: storeError.message,
-            })
-            // Decide if we should return 500 to trigger retry
-            // If it's a unique constraint (P2002), message likely processed, return 200.
-            if (
-              storeError &&
-              typeof storeError === 'object' &&
-              (storeError as any).code === 'P2002'
-            ) {
-              logger.warn('Message likely already processed (unique constraint violation).', {
-                mid: messageData.externalId,
-              })
-              // Fall through to return 200 OK
-            } else {
-              // For other errors, maybe return 500?
-              return NextResponse.json({ error: 'Failed to store message' }, { status: 500 })
-            }
-          }
-        } else {
-          logger.warn('Failed to convert message.received event data', { eventId: payload.id })
+        if (!messageData) {
+          logger.warn('Failed to convert Quo message event data', { eventId: payload.id })
+          break
+        }
+
+        const storageService = new MessageStorageService(integration.organizationId)
+        try {
+          await storageService.storeMessage(messageData)
+          logger.info('Stored Quo message', {
+            mid: messageData.externalId,
+            isInbound: messageData.isInbound,
+            integrationId: integration.id,
+          })
+        } catch (storeError) {
+          const message = storeError instanceof Error ? storeError.message : String(storeError)
+          logger.error('Failed to store Quo message', {
+            mid: messageData.externalId,
+            integrationId: integration.id,
+            error: message,
+          })
+          // `storeMessage` is idempotent on `(integrationId, externalId)` and swallows the
+          // duplicate-key case itself, so anything reaching here is a real failure worth a retry.
+          return NextResponse.json({ error: 'Failed to store message' }, { status: 500 })
         }
         break
       }
 
+      // Call events are logged no-ops today. The names below are the real ones — there is no
+      // `call.finished`. Turning any of these into a Message row needs a call-shaped payload
+      // mapper (voicemail/recording `media[]`), which is out of scope here.
       case 'call.ringing':
-        // TODO: Handle incoming call event (e.g., create notification, log event)
-        logger.info(`Received call.ringing event`, { eventId: payload.id, data: payload.data })
+      case 'call.completed':
+      case 'call.recording.completed':
+        logger.info('Received Quo call event (no-op)', {
+          type: payload.type,
+          eventId: payload.id,
+          integrationId: integration.id,
+        })
         break
-
-      case 'call.finished':
-        // TODO: Handle finished call event (e.g., store call log as a Message)
-        logger.info(`Received call.finished event`, { eventId: payload.id, data: payload.data })
-        // Potentially convert payload.data (call object) into a MessageData with MessageType.CALL
-        break
-
-      // Add cases for other events you subscribe to
 
       default:
-        logger.debug(`Ignoring unhandled OpenPhone event type: ${payload.type}`)
+        logger.debug('Ignoring unhandled Quo event type', { type: payload.type })
     }
 
-    // 6. Respond OK
     return NextResponse.json({ status: 'success' }, { status: 200 })
-  } catch (error: any) {
-    logger.error('Error processing OpenPhone webhook:', {
-      error: error.message,
-      stack: error.stack,
+  } catch (error) {
+    logger.error('Error processing Quo webhook:', {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
     })
-    // Return 500 for unexpected internal errors
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
   }
 }
 
 /**
- * Helper function to convert an OpenPhone webhook message event into MessageData.
+ * Parses `hmac;1;<timestamp>;<base64 signature>`. Returns null for a missing, malformed, or
+ * unknown-scheme header so the caller rejects before any crypto runs.
  */
-function convertOpenPhoneWebhookEventToMessageData(
-  messagePayload: OpenPhoneMessageReceivedData,
+function parseQuoSignatureHeader(
+  headerValue: string | null
+): { timestamp: string; signature: string } | null {
+  if (!headerValue) return null
+  const [scheme, version, timestamp, signature] = headerValue.split(';')
+  if (scheme !== 'hmac' || !version || !timestamp || !signature) return null
+  return { timestamp, signature }
+}
+
+/**
+ * Replay guard over the header timestamp.
+ *
+ * Quo's timestamp is an ISO-8601 string on the current apiVersion and epoch milliseconds on
+ * older ones, so both are parsed. If neither parses we SKIP the guard rather than reject: the
+ * timestamp is inside the signed payload, so an unparseable value still cannot be forged — only
+ * un-aged — and rejecting would take the channel down over a format change.
+ */
+function isWithinTolerance(timestamp: string): boolean {
+  const trimmed = timestamp.trim()
+  if (!trimmed) return true
+
+  const numeric = Number(trimmed)
+  let ms: number
+  if (Number.isFinite(numeric)) {
+    // A millisecond timestamp any time after 2001 is >= 1e12; anything smaller is seconds.
+    ms = numeric < 1e12 ? numeric * 1000 : numeric
+  } else {
+    ms = Date.parse(trimmed)
+  }
+  if (!Number.isFinite(ms)) return true
+
+  return Math.abs(Date.now() - ms) <= TIMESTAMP_TOLERANCE_SEC * 1000
+}
+
+/**
+ * Converts a Quo message webhook event into `MessageData`.
+ *
+ * Reads the **webhook** message shape (`body`, `to` as a plain string, `direction: 'incoming'`) —
+ * REST returns `text` and `to[]` instead, which is why the two are separate types with separate
+ * mappers. Identifiers are passed through as raw E.164; the ingest path maps `openphone` to
+ * `IdentifierType.PHONE` and normalizes from there.
+ */
+function convertQuoWebhookEventToMessageData(
+  event: QuoWebhookEvent<QuoWebhookMessage>,
   integrationId: string,
   organizationId: string,
   metadata: OpenPhoneIntegrationMetadata | null
 ): MessageData | null {
-  if (!metadata?.phoneNumber) {
-    logger.error('Cannot convert webhook event, missing integration metadata (phoneNumber).')
+  const message = event.data?.object
+  if (!message?.id) {
+    logger.error('Cannot convert Quo webhook event: no message object on the payload.', {
+      eventId: event.id,
+    })
     return null
   }
+
   try {
-    const externalId = messagePayload.id
-    const externalThreadId = messagePayload.conversation_id
-    const createdTime = new Date(messagePayload.date_created)
+    const isInbound = message.direction === 'incoming'
+    // Quo puts both sides on the payload. `metadata.phoneNumber` is only a fallback for our own
+    // side of the exchange.
+    const ourNumber = metadata?.phoneNumber
+    const fromNumber = message.from || (isInbound ? undefined : ourNumber)
+    const toNumber = message.to || (isInbound ? ourNumber : undefined)
 
-    // Webhook 'message.received' is always inbound
-    const isInbound = true
-    const fromNumber = messagePayload.sender_phone_number
-    const toNumber = metadata.phoneNumber // Our number
-
-    if (!fromNumber) {
-      logger.warn('Missing sender number in message.received webhook', { messageId: externalId })
-      return null // Cannot process without sender
+    if (!fromNumber || !toNumber) {
+      logger.warn('Missing sender or recipient number on Quo message webhook', {
+        messageId: message.id,
+        eventType: event.type,
+      })
+      return null
     }
 
-    const fromParticipant = { identifier: fromNumber }
-    const toParticipant = { identifier: toNumber }
+    const createdTime = new Date(message.createdAt)
+    if (Number.isNaN(createdTime.getTime())) {
+      logger.warn('Unparseable createdAt on Quo message webhook', {
+        messageId: message.id,
+        createdAt: message.createdAt,
+      })
+      return null
+    }
 
-    const messageData: MessageData = {
-      externalId: externalId,
-      externalThreadId: externalThreadId,
-      integrationId: integrationId,
-      // Note: integrationType and messageType removed - derived from Integration.provider
-      organizationId: organizationId,
-      createdTime: createdTime,
-      sentAt: createdTime, // For inbound, sentAt=receivedAt=createdTime
+    return {
+      externalId: message.id,
+      externalThreadId: message.conversationId,
+      integrationId,
+      organizationId,
+      createdTime,
+      sentAt: createdTime,
       receivedAt: createdTime,
-      subject: undefined,
-      from: fromParticipant,
-      to: [toParticipant],
+      subject: undefined, // SMS has no subject.
+      from: { identifier: fromNumber },
+      to: [{ identifier: toNumber }],
       cc: [],
       bcc: [],
       replyTo: [],
-      // OpenPhone has no inbound attachment ingestor, so no MessageAttachment rows
-      // are ever created and `providerAttachments` is never populated. Mirrors
-      // OpenPhoneProvider.convertToMessageData — `hasAttachments` is a workflow
-      // trigger filter, so claiming true fires attachment rules for bytes that were
-      // never fetched. The raw payload (including each attachment's `url`) is
-      // retained in `metadata.openphone_webhook_event_data` for a future backfill.
+      // Quo has no inbound attachment ingestor, so no MessageAttachment rows are ever created
+      // and `providerAttachments` is never populated. `hasAttachments` is a workflow trigger
+      // filter (see workflow-engine/nodes/trigger-nodes/message-received.ts), so claiming true
+      // here fires attachment rules for bytes that were never fetched. The raw payload —
+      // including each entry's `media[].url` — is retained in `metadata.quo_webhook_event` for a
+      // future backfill. Real MMS ingest is a follow-up.
       hasAttachments: false,
-      textPlain: messagePayload.body,
-      snippet: messagePayload.body?.substring(0, 100),
-      isInbound: isInbound,
-      metadata: { openphone_webhook_event_data: messagePayload },
+      textPlain: message.body,
+      snippet: message.body?.substring(0, 100),
+      isInbound,
+      metadata: { quo_webhook_event: event },
       keywords: [],
       labelIds: [],
-    }
-
-    return messageData
-  } catch (error: any) {
-    logger.error('Failed to convert OpenPhone webhook event data', {
-      error: error.message,
-      payload: messagePayload,
+    } satisfies MessageData
+  } catch (error) {
+    logger.error('Failed to convert Quo webhook event data', {
+      error: error instanceof Error ? error.message : String(error),
+      eventId: event.id,
     })
     return null
   }

--- a/apps/web/src/components/channels/ui/channel-gallery-dialog.tsx
+++ b/apps/web/src/components/channels/ui/channel-gallery-dialog.tsx
@@ -17,7 +17,6 @@ import {
   type ConnectFlowDefinition,
   useConnectFlow,
 } from '~/components/apps/hooks/use-connect-flow'
-import { platformScope, platformTarget } from '~/components/connections/ui/connection-targets'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { TemplateGalleryDialog } from '~/components/templates/ui'
@@ -28,6 +27,7 @@ import { CHANNEL_CATALOG, CHANNEL_CATEGORIES, type ChannelCatalogItem } from '..
 import { getIntegrationProviderIcon } from './channel-icon'
 import ImapConnectForm from './imap-connect-form'
 import { InboxDestinationField, useInboxDestination } from './inbox-destination-field'
+import QuoConnectForm from './quo-connect-form'
 
 const DEFAULT_RETURN_TO = '/app/settings/channels'
 const RESIZE_ID = 'channel-connect'
@@ -104,7 +104,7 @@ export function ChannelGalleryDialog({
     { enabled: open && isOAuth && !!selected?.provider, retry: false }
   )
 
-  // Quo (secret connection) rides the shared connect flow, carrying `{ inboxId }` as post-connect.
+  // Platform provider catalog — Quo's row (`openphone`) feeds its dedicated connect form.
   const { data: providers = [] } = api.connections.listProviders.useQuery(undefined, {
     enabled: open && !personalOnly,
   })
@@ -204,24 +204,6 @@ export function ChannelGalleryDialog({
     } catch (error) {
       toastError({
         title: 'Failed to create chat widget',
-        description: error instanceof Error ? error.message : 'Unknown error',
-      })
-    }
-  }
-
-  async function connectPhone(item: ChannelCatalogItem) {
-    const provider = providers.find((p) => p.providerKey === item.providerKey)
-    if (!provider) return
-    try {
-      const inboxId = await inbox.resolve()
-      flow.start({
-        target: platformTarget(provider),
-        scope: platformScope(provider),
-        postConnect: { inboxId },
-      })
-    } catch (error) {
-      toastError({
-        title: 'Could not start connect',
         description: error instanceof Error ? error.message : 'Unknown error',
       })
     }
@@ -373,15 +355,32 @@ export function ChannelGalleryDialog({
     )
   }
 
-  function renderPhoneDetail() {
+  /**
+   * Quo: an API key covers a whole workspace, so the number is a picker rather than a typed
+   * field — which the generic connect form (static `ConnectionVariable.options`) can't express.
+   * The dedicated form owns its own Connect button, like IMAP.
+   */
+  function renderPhoneDetail(item: ChannelCatalogItem, helpers: { close: () => void }) {
+    const provider = providers.find((p) => p.providerKey === item.providerKey)
     return (
-      <div className='flex flex-col gap-3 p-3'>
+      <div className='flex flex-col gap-4 p-3'>
         <FieldPanel orientation='responsive' resizeId={RESIZE_ID} className='p-0'>
           <InboxDestinationField controller={inbox} />
         </FieldPanel>
-        <p className='text-xs text-muted-foreground'>
-          You'll enter your Quo API key and phone number in the next step.
-        </p>
+        {provider ? (
+          <QuoConnectForm
+            provider={provider}
+            inbox={inbox}
+            onSuccess={() => {
+              void utils.channel.list.invalidate()
+              void utils.inbox.settingsList.invalidate()
+              void utils.record.listAll.invalidate()
+              helpers.close()
+            }}
+          />
+        ) : (
+          <p className='text-sm text-muted-foreground'>Loading…</p>
+        )}
       </div>
     )
   }
@@ -412,8 +411,8 @@ export function ChannelGalleryDialog({
       case 'social':
         return !inbox.isValid || !ownClientReady || !prep.data
       case 'chat':
-      case 'phone':
         return !inbox.isValid
+      // 'phone' owns its own Connect button (QuoConnectForm) — no shell footer.
       default:
         return true
     }
@@ -427,9 +426,6 @@ export function ChannelGalleryDialog({
         break
       case 'chat':
         void connectChat()
-        break
-      case 'phone':
-        void connectPhone(item)
         break
     }
   }
@@ -483,7 +479,7 @@ export function ChannelGalleryDialog({
             case 'chat':
               return renderChatDetail()
             case 'phone':
-              return renderPhoneDetail()
+              return renderPhoneDetail(item, helpers)
             case 'imap':
               return renderImapDetail(helpers)
             default:
@@ -491,8 +487,9 @@ export function ChannelGalleryDialog({
           }
         }}
         renderDetailFooter={(item) => {
-          // IMAP owns its own Connect button (inside the embedded form).
-          if (item.kind === 'imap' || item.kind === 'coming-soon') return null
+          // IMAP and Quo own their Connect button (inside their embedded form).
+          if (item.kind === 'imap' || item.kind === 'phone' || item.kind === 'coming-soon')
+            return null
           return (
             <Button
               size='sm'

--- a/apps/web/src/components/channels/ui/quo-connect-form.tsx
+++ b/apps/web/src/components/channels/ui/quo-connect-form.tsx
@@ -1,0 +1,473 @@
+// apps/web/src/components/channels/ui/quo-connect-form.tsx
+'use client'
+
+import { FieldType } from '@auxx/database/enums'
+import type { SelectOption } from '@auxx/types/custom-field'
+import { Alert, AlertDescription, AlertTitle } from '@auxx/ui/components/alert'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { RadioGroup } from '@auxx/ui/components/radio-group'
+import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
+import { toastError } from '@auxx/ui/components/toast'
+import { Phone, TriangleAlert } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import type { ProviderRow } from '~/components/connections/ui/connection-targets'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { BaseType } from '~/components/workflow/types'
+import { api } from '~/trpc/react'
+import type { InboxDestinationController } from './inbox-destination-field'
+
+/** Shared with the gallery so both panels drag their label column together. */
+const RESIZE_ID = 'channel-connect'
+
+/** Full-width control flush to the row label (matches InboxDestinationField). */
+const FIELD_TRIGGER_PROPS = { className: 'w-full ps-0 pe-1' }
+
+/** A number on a Quo workspace (`channel.quoPhoneNumbers` / `channel.quoCachedNumbers`). */
+interface QuoPhoneNumber {
+  id: string
+  number: string
+  name: string | null
+  usRestricted: boolean
+}
+
+interface QuoConnectFormProps {
+  /** The `openphone` platform provider row from `connections.listProviders`. */
+  provider: ProviderRow
+  /** Inbox-destination controller from the detail step — resolved on Connect. */
+  inbox: InboxDestinationController
+  /** Fired after a successful connect (gallery invalidates + closes). */
+  onSuccess: () => void
+}
+
+/**
+ * The number picker, shared by both connect paths.
+ *
+ * Identical markup whether the list came from a pasted key (live fetch) or from
+ * `Credential.metadata.quo` (cached) — the two paths differ only in where the numbers come
+ * from, so the restriction warnings live here rather than being written twice.
+ *
+ * Two different "can't use this" states, deliberately treated differently:
+ *  - **US-restricted** stays SELECTABLE. Such a number still receives messages and still sends
+ *    outside the US; only outbound US SMS fails. Blocking it would be wrong for inbound-only or
+ *    non-US use, so it is flagged, not disabled.
+ *  - **Already connected** is DISABLED. One phone number backs at most one live Integration —
+ *    picking it again would relink the existing channel rather than create a second one.
+ */
+function QuoNumberPicker({
+  numbers,
+  value,
+  onChange,
+  usedIds,
+  disabled,
+}: {
+  numbers: QuoPhoneNumber[]
+  value: string
+  onChange: (phoneNumberId: string) => void
+  /** `phoneNumberId`s that already back a live channel. */
+  usedIds: ReadonlySet<string>
+  disabled?: boolean
+}) {
+  const restricted = numbers.filter((n) => n.usRestricted)
+  const selected = numbers.find((n) => n.id === value) ?? null
+  const allUsed = numbers.every((n) => usedIds.has(n.id))
+
+  return (
+    <>
+      <div className='flex flex-col gap-2'>
+        <p className='text-xs text-muted-foreground'>
+          Choose the number this channel sends and receives from.
+        </p>
+        <RadioGroup value={value} onValueChange={onChange} className='grid gap-2'>
+          {numbers.map((number) => {
+            const used = usedIds.has(number.id)
+            return (
+              <RadioGroupItemCard
+                key={number.id}
+                value={number.id}
+                icon={<Phone />}
+                label={number.number}
+                sublabel={
+                  used ? 'Already connected' : number.usRestricted ? 'US SMS restricted' : undefined
+                }
+                description={number.name ?? undefined}
+                disabled={used || disabled}
+                className={used ? 'opacity-60' : undefined}
+              />
+            )
+          })}
+        </RadioGroup>
+        {allUsed && (
+          // Otherwise every card is disabled and Connect never enables, with nothing saying why.
+          <p className='text-xs text-muted-foreground'>
+            Every number on this workspace already has a channel. Add a number in Quo to connect
+            another.
+          </p>
+        )}
+      </div>
+
+      {restricted.length > 0 && (
+        <Alert variant='warning'>
+          <AlertTitle>
+            <TriangleAlert />
+            Some numbers can't send US SMS
+          </AlertTitle>
+          <AlertDescription className='flex flex-col gap-2'>
+            <p>
+              Quo restricts US messaging on numbers that aren't registered for it. A restricted
+              number still receives messages, but outbound US SMS fails at send time. You can still
+              pick one — for inbound-only or non-US use.
+            </p>
+            <div className='flex flex-wrap gap-1'>
+              {restricted.map((number) => (
+                <Badge key={number.id} variant='amber'>
+                  {number.number}
+                </Badge>
+              ))}
+            </div>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {selected?.usRestricted && (
+        <p className='text-xs text-muted-foreground'>
+          {selected.number} is US-restricted — it can receive messages, but sending to US numbers
+          will fail until you register it in Quo.
+        </p>
+      )}
+    </>
+  )
+}
+
+/**
+ * Shell-free Quo connect form embedded in the channel gallery's detail step.
+ *
+ * One Quo API key covers a whole WORKSPACE with N numbers, so this form has two paths:
+ *
+ *  - **Existing connection** (default whenever the org already has one). The workspace's numbers
+ *    were cached on `Credential.metadata.quo` at connect time, so the picker reads them back via
+ *    `channel.quoCachedNumbers` and `channel.addQuoNumber` hangs a second Integration off the
+ *    SAME credential. Without this path a user adding their second number re-pastes the key, and
+ *    `saveConnection` does not dedupe by providerKey — they would get a second Credential for one
+ *    Quo workspace, which is exactly what the workspace-scoped model exists to prevent.
+ *  - **New API key** (the only path when no connection exists, and the escape hatch to a genuinely
+ *    different workspace). Lists numbers through `channel.quoPhoneNumbers` — a mutation, so the
+ *    key never lands in a URL or a query key — then rides `connections.save`'s `postConnect` into
+ *    the provisioning hook, which caches the list and creates the Integration for the chosen
+ *    number.
+ */
+export default function QuoConnectForm({ provider, inbox, onSuccess }: QuoConnectFormProps) {
+  const [apiKey, setApiKey] = useState('')
+  const [numbers, setNumbers] = useState<QuoPhoneNumber[] | null>(null)
+  const [phoneNumberId, setPhoneNumberId] = useState('')
+  /** Set when the user explicitly opts out of the existing connection. */
+  const [useNewKey, setUseNewKey] = useState(false)
+  /** Empty = "whatever the first Quo connection is" (the only one, in practice). */
+  const [credentialId, setCredentialId] = useState('')
+
+  const quoPhoneNumbers = api.channel.quoPhoneNumbers.useMutation()
+  const saveConnection = api.connections.save.useMutation()
+  const addQuoNumber = api.channel.addQuoNumber.useMutation()
+
+  // Existing Quo workspace connections. `Credential.type` is the providerKey, so 'openphone'
+  // selects them; `kind: ['connection']` excludes app/MCP credentials.
+  const connections = api.connections.list.useQuery({ type: 'openphone', kind: ['connection'] })
+  const quoConnections = connections.data ?? []
+  const hasExisting = quoConnections.length > 0
+  const mode: 'existing' | 'new' = hasExisting && !useNewKey ? 'existing' : 'new'
+  const activeCredentialId = credentialId || quoConnections[0]?.id || ''
+  const activeConnection = quoConnections.find((c) => c.id === activeCredentialId) ?? null
+
+  const cachedNumbers = api.channel.quoCachedNumbers.useQuery(
+    { credentialId: activeCredentialId },
+    { enabled: mode === 'existing' && activeCredentialId.length > 0 }
+  )
+
+  // Numbers that already back a live channel can't become a second one. `channel.list` returns
+  // `Integration.metadata`, which is where the routing identity (`phoneNumberId`) lives. Read on
+  // BOTH paths — "connect a different workspace" is also how someone re-pastes the same key.
+  const channels = api.channel.list.useQuery(undefined)
+  const usedIds = useMemo(
+    () =>
+      new Set(
+        (channels.data?.channels ?? [])
+          .filter((c) => c.provider === 'openphone')
+          .map((c) => (c.metadata as { phoneNumberId?: string } | null)?.phoneNumberId)
+          .filter((id): id is string => !!id)
+      ),
+    [channels.data]
+  )
+
+  const connectionOptions = useMemo<SelectOption[]>(
+    () => quoConnections.map((c) => ({ value: c.id, label: c.name })),
+    [quoConnections]
+  )
+
+  const connecting =
+    (mode === 'existing' ? addQuoNumber.isPending : saveConnection.isPending) || inbox.creating
+
+  /** A key edit invalidates whatever the previous key listed. */
+  function onApiKeyChange(value: string) {
+    setApiKey(value)
+    setNumbers(null)
+    setPhoneNumberId('')
+  }
+
+  /** Switch paths. The pick belongs to one workspace, so it never survives the switch. */
+  function switchTo(next: 'existing' | 'new') {
+    setUseNewKey(next === 'new')
+    setPhoneNumberId('')
+  }
+
+  function onCredentialChange(value: string) {
+    setCredentialId(value)
+    setPhoneNumberId('')
+  }
+
+  /** Validate the pasted key and list its numbers. A bad key rejects — surface and let them retry. */
+  async function findNumbers() {
+    try {
+      const result = await quoPhoneNumbers.mutateAsync({ apiKey: apiKey.trim() })
+      setNumbers(result.numbers)
+      // Preselect when the workspace has exactly one number — there is nothing to choose.
+      setPhoneNumberId(result.numbers.length === 1 ? (result.numbers[0]?.id ?? '') : '')
+    } catch (error) {
+      setNumbers(null)
+      toastError({
+        title: 'Could not read your Quo numbers',
+        description: error instanceof Error ? error.message : 'Check the API key and try again.',
+      })
+    }
+  }
+
+  /** New workspace: create the Credential, and let the post-connect hook provision the channel. */
+  async function connectWithKey() {
+    try {
+      const inboxId = await inbox.resolve()
+      await saveConnection.mutateAsync({
+        // `save` resolves a platform providerKey as the definition id.
+        connectionDefinitionId: provider.providerKey,
+        name: provider.label,
+        values: { apiKey: apiKey.trim() },
+        // Forwarded verbatim to the provisioning hook as `ctx.extra`.
+        postConnect: { inboxId, phoneNumberId },
+      })
+      onSuccess()
+    } catch (error) {
+      toastError({
+        title: 'Connection failed',
+        description: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
+  }
+
+  /** Existing workspace: reuse the credential, add one more Integration for the picked number. */
+  async function connectExisting() {
+    try {
+      const inboxId = await inbox.resolve()
+      await addQuoNumber.mutateAsync({
+        credentialId: activeCredentialId,
+        phoneNumberId,
+        inboxId,
+      })
+      onSuccess()
+    } catch (error) {
+      toastError({
+        title: 'Could not add this number',
+        description: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
+  }
+
+  // Hold the paths back until we know whether a connection exists — rendering the API-key form
+  // first and swapping it for the existing-connection one a tick later reads as a glitch.
+  if (connections.isLoading) {
+    return <p className='text-sm text-muted-foreground'>Loading…</p>
+  }
+
+  if (mode === 'existing') {
+    const cached = cachedNumbers.data?.numbers ?? []
+    const cacheEmpty = cachedNumbers.isSuccess && cached.length === 0
+
+    return (
+      <div className='flex flex-col gap-4'>
+        {connectionOptions.length > 1 ? (
+          <FieldPanel orientation='responsive' resizeId={RESIZE_ID} className='p-0'>
+            <FieldPanelRow title='Quo connection' type={BaseType.STRING} showIcon isRequired>
+              <FieldInputAdapter
+                fieldType={FieldType.SINGLE_SELECT}
+                fieldOptions={{ options: connectionOptions }}
+                value={activeCredentialId}
+                onChange={(v) =>
+                  onCredentialChange(Array.isArray(v) ? (v[0] ?? '') : ((v as string) ?? ''))
+                }
+                placeholder='Choose a connection'
+                triggerProps={FIELD_TRIGGER_PROPS}
+                disabled={connecting}
+              />
+            </FieldPanelRow>
+          </FieldPanel>
+        ) : (
+          <p className='text-xs text-muted-foreground'>
+            Using your existing Quo connection
+            {activeConnection ? ` (${activeConnection.name})` : ''}. One key covers the whole
+            workspace, so there is no key to paste again.
+          </p>
+        )}
+
+        {cachedNumbers.isLoading && (
+          <p className='text-sm text-muted-foreground'>Loading your numbers…</p>
+        )}
+
+        {cacheEmpty && (
+          <Alert variant='warning'>
+            <AlertTitle>
+              <TriangleAlert />
+              No numbers cached for this connection
+            </AlertTitle>
+            <AlertDescription>
+              This connection was made before we started caching its workspace numbers. Paste the
+              API key once more to refresh the list — it will be cached from then on.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {cached.length > 0 && (
+          <QuoNumberPicker
+            numbers={cached}
+            value={phoneNumberId}
+            onChange={setPhoneNumberId}
+            usedIds={usedIds}
+            disabled={connecting}
+          />
+        )}
+
+        {cached.length > 0 && cachedNumbers.data?.fetchedAt && (
+          // The cache refreshes whenever a number is provisioned, so it can lag a number added
+          // in Quo since. Say when it was read rather than leaving a missing number unexplained.
+          <p className='text-xs text-muted-foreground'>
+            Numbers read from Quo on {new Date(cachedNumbers.data.fetchedAt).toLocaleDateString()}.
+            Added a number since? Connect it with your API key.
+          </p>
+        )}
+
+        <div className='flex justify-end gap-2'>
+          <Button
+            type='button'
+            size='sm'
+            variant='ghost'
+            onClick={() => switchTo('new')}
+            disabled={connecting}>
+            {cacheEmpty ? 'Use an API key' : 'Connect a different workspace'}
+          </Button>
+          {!cacheEmpty && (
+            <Button
+              type='button'
+              size='sm'
+              variant='outline'
+              onClick={() => void connectExisting()}
+              disabled={!inbox.isValid || !phoneNumberId || connecting}
+              loading={connecting}
+              loadingText='Connecting…'>
+              Connect
+            </Button>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <FieldPanel orientation='responsive' resizeId={RESIZE_ID} className='p-0'>
+        <FieldPanelRow title='API Key' type={BaseType.STRING} showIcon isRequired>
+          <FieldInputAdapter
+            fieldType={FieldType.TEXT}
+            fieldOptions={{ secret: true }}
+            value={apiKey}
+            onChange={(v) => onApiKeyChange((v as string) ?? '')}
+            placeholder='Your Quo API key'
+            disabled={connecting}
+          />
+        </FieldPanelRow>
+      </FieldPanel>
+
+      <p className='text-xs text-muted-foreground'>
+        Create a key in Quo under Workspace Settings → API (owner or admin only). One key covers
+        your whole workspace — pick which of its numbers this channel uses below.
+      </p>
+
+      {!numbers && (
+        <div className='flex justify-end'>
+          <Button
+            type='button'
+            size='sm'
+            variant='outline'
+            onClick={() => void findNumbers()}
+            disabled={apiKey.trim().length === 0 || quoPhoneNumbers.isPending}
+            loading={quoPhoneNumbers.isPending}
+            loadingText='Checking key…'>
+            Find my numbers
+          </Button>
+        </div>
+      )}
+
+      {numbers?.length === 0 && (
+        <Alert variant='warning'>
+          <AlertTitle>
+            <TriangleAlert />
+            No phone numbers on this workspace
+          </AlertTitle>
+          <AlertDescription>
+            This key is valid but its Quo workspace has no phone numbers. Add one in Quo, then try
+            again.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {!!numbers?.length && (
+        <QuoNumberPicker
+          numbers={numbers}
+          value={phoneNumberId}
+          onChange={setPhoneNumberId}
+          usedIds={usedIds}
+          disabled={connecting}
+        />
+      )}
+
+      <div className='flex justify-end gap-2'>
+        {hasExisting && (
+          <Button
+            type='button'
+            size='sm'
+            variant='ghost'
+            onClick={() => switchTo('existing')}
+            disabled={connecting}>
+            Use your existing connection
+          </Button>
+        )}
+        {!!numbers?.length && (
+          <Button
+            type='button'
+            size='sm'
+            variant='ghost'
+            onClick={() => void findNumbers()}
+            disabled={quoPhoneNumbers.isPending || connecting}>
+            Refresh numbers
+          </Button>
+        )}
+        <Button
+          type='button'
+          size='sm'
+          variant='outline'
+          onClick={() => void connectWithKey()}
+          disabled={!inbox.isValid || !phoneNumberId || connecting}
+          loading={connecting}
+          loadingText='Connecting…'>
+          Connect
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/data-connectors/ui/source-template-dialog.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-template-dialog.tsx
@@ -6,7 +6,7 @@ import { Input } from '@auxx/ui/components/input'
 import { KbdSubmit } from '@auxx/ui/components/kbd'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { toastError } from '@auxx/ui/components/toast'
-import { Boxes, CreditCard, Database, Github, Globe, Plug } from 'lucide-react'
+import { Boxes, CreditCard, Database, Github, Globe, MessageSquare, Plug } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { type ComponentType, useMemo, useState } from 'react'
 import { AppIcon } from '~/components/apps/ui/app-icon'
@@ -38,6 +38,7 @@ const ICONS: Record<string, ComponentType<{ className?: string }>> = {
   'credit-card': CreditCard,
   github: Github,
   database: Database,
+  'message-square': MessageSquare,
 }
 function iconFor(key: string | null | undefined): ComponentType<{ className?: string }> {
   return (key && ICONS[key]) || Boxes

--- a/apps/web/src/components/mail/email-editor/identifier-model.ts
+++ b/apps/web/src/components/mail/email-editor/identifier-model.ts
@@ -1,0 +1,115 @@
+// apps/web/src/components/mail/email-editor/identifier-model.ts
+
+import { IdentifierType } from '@auxx/database/enums'
+import type { IdentifierType as IdentifierTypeType } from '@auxx/database/types'
+import type { PlatformCapabilities } from '@auxx/lib/channels/client'
+import { formatPhoneNumber } from '@auxx/utils'
+
+/** The shape of identifier a channel addresses — `PlatformCapabilities.recipientModel`. */
+export type RecipientModel = PlatformCapabilities['recipientModel']
+
+/**
+ * Everything the recipient input needs to know about ONE identifier shape:
+ * how to validate/normalize a typed value, which `IdentifierType` to commit,
+ * which contact field holds the candidate values, and what to call the thing
+ * in copy.
+ *
+ * Keyed by `recipientModel` so the composer stays capability-driven — the same
+ * switch the agent path uses in
+ * `packages/lib/src/ai/kopilot/capabilities/mail/recipient-resolver.ts`
+ * (`identifierTypesForIntegration` / `systemAttributeForChannel`).
+ */
+export interface IdentifierModelSpec {
+  /** `IdentifierType` committed on every recipient of this model. */
+  identifierType: IdentifierTypeType
+
+  /**
+   * `systemAttribute` candidates on the contact definition, in preference
+   * order. The first one that resolves to a field wins. Mirrors
+   * `systemAttributeForChannel` in the kopilot recipient resolver.
+   */
+  systemAttributes: string[]
+
+  /**
+   * Key on the picker row's raw `data` holding the record's primary value —
+   * the fallback when the field read fails or returns nothing.
+   */
+  rowDataKey: string
+
+  /**
+   * Whether the picker row's `secondaryInfo` (the secondary display field) is
+   * a value of THIS model. True for email — contacts render their address as
+   * the subtitle — and false for everything else, where the subtitle is still
+   * an email and would poison a phone recipient list.
+   */
+  secondaryInfoIsIdentifier: boolean
+
+  /**
+   * Canonical form of a raw typed/stored value, or `null` when it is not a
+   * valid identifier of this model. Doubles as the validator.
+   */
+  normalize: (raw: string) => string | null
+
+  /** Toast copy for an explicit commit (Enter / comma) of an invalid value. */
+  invalidTitle: string
+  invalidDescription: string
+
+  /** Singular/plural noun used in the "which one?" popover. */
+  noun: string
+  nounPlural: string
+}
+
+const EMAIL_RE = /\S+@\S+\.\S+/
+
+const EMAIL_SPEC: IdentifierModelSpec = {
+  identifierType: IdentifierType.EMAIL,
+  systemAttributes: ['primary_email'],
+  rowDataKey: 'email',
+  secondaryInfoIsIdentifier: true,
+  normalize: (raw) => {
+    const trimmed = raw.trim()
+    return trimmed && EMAIL_RE.test(trimmed) ? trimmed.toLowerCase() : null
+  },
+  invalidTitle: 'Invalid Email',
+  invalidDescription: 'Please enter a valid email address.',
+  noun: 'email address',
+  nounPlural: 'email addresses',
+}
+
+const PHONE_SPEC: IdentifierModelSpec = {
+  identifierType: IdentifierType.PHONE,
+  // `phone` is what the contact registry seeds (contact-fields.ts); older /
+  // connector-provisioned orgs can carry `primary_phone`.
+  systemAttributes: ['phone', 'primary_phone'],
+  rowDataKey: 'phone',
+  secondaryInfoIsIdentifier: false,
+  // `formatPhoneNumber` is THE phone normalizer (libphonenumber-backed, E.164
+  // out, `null` for anything unparseable or impossible). Never hand-roll a
+  // second one here — write-path and lookup normalization must not drift.
+  normalize: (raw) => formatPhoneNumber(raw),
+  invalidTitle: 'Invalid Phone Number',
+  invalidDescription: 'Please enter a valid phone number, e.g. +14155551234.',
+  noun: 'phone number',
+  nounPlural: 'phone numbers',
+}
+
+/**
+ * Resolve the identifier spec for a channel's `recipientModel`.
+ *
+ * Defaults to email when the model is absent — every caller without resolved
+ * `PlatformCapabilities` is an email composer. `thread_only` and
+ * `platform_user` never reach here (the composer hides the recipient field for
+ * both); they fall back to email rather than crashing.
+ */
+export function getIdentifierModel(model?: RecipientModel): IdentifierModelSpec {
+  return model === 'phone' ? PHONE_SPEC : EMAIL_SPEC
+}
+
+/**
+ * Dedupe/exclude key for an identifier of this model. Falls back to the
+ * lowercased raw value when normalization fails, so an already-stored value
+ * that no longer parses still matches itself.
+ */
+export function identifierKey(spec: IdentifierModelSpec, value: string): string {
+  return (spec.normalize(value) ?? value.trim()).toLowerCase()
+}

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -1095,6 +1095,7 @@ function ReplyComposeEditorComponent({
                   <span className='w-10 shrink-0 text-sm text-muted-foreground'>To:</span>
                   <RecipientInput
                     ref={toInputRef}
+                    recipientModel={platformCaps?.recipientModel}
                     field='TO'
                     recipients={recipients.TO}
                     onAdd={(r) => upsertRecipient('TO', r)}
@@ -1148,6 +1149,7 @@ function ReplyComposeEditorComponent({
                     <span className='w-10 shrink-0 text-sm text-muted-foreground'>Cc:</span>
                     <RecipientInput
                       ref={ccInputRef}
+                      recipientModel={platformCaps?.recipientModel}
                       field='CC'
                       recipients={recipients.CC}
                       onAdd={(r) => upsertRecipient('CC', r)}
@@ -1181,6 +1183,7 @@ function ReplyComposeEditorComponent({
                     <span className='w-10 shrink-0 text-sm text-muted-foreground'>Bcc:</span>
                     <RecipientInput
                       ref={bccInputRef}
+                      recipientModel={platformCaps?.recipientModel}
                       field='BCC'
                       recipients={recipients.BCC}
                       onAdd={(r) => upsertRecipient('BCC', r)}

--- a/apps/web/src/components/mail/email-editor/recipient-input.test.tsx
+++ b/apps/web/src/components/mail/email-editor/recipient-input.test.tsx
@@ -21,6 +21,7 @@ interface PickerItemStub {
 
 const h = vi.hoisted(() => ({
   batchGet: vi.fn(),
+  toastError: vi.fn(),
   pickerItems: [] as unknown[],
 }))
 
@@ -84,6 +85,8 @@ vi.mock('~/components/resources/utils/resolve-system-attribute', () => ({
   resolveSystemAttributeRef: () => 'contact:field-email',
 }))
 
+vi.mock('@auxx/ui/components/toast', () => ({ toastError: h.toastError }))
+
 vi.mock('~/components/global/tooltip', () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
@@ -137,6 +140,23 @@ function renderInput(
   return { ...utils, onContactSelect }
 }
 
+/** Same render, on a `recipientModel: 'phone'` channel (Quo/SMS). */
+function renderPhoneInput(onAdd = vi.fn(), onContactSelect = vi.fn()) {
+  const utils = render(
+    <RecipientInput
+      recipients={[]}
+      field='TO'
+      onAdd={onAdd}
+      onRemove={vi.fn()}
+      onMoveTo={vi.fn()}
+      onContactSelect={onContactSelect}
+      placeholder='To'
+      recipientModel='phone'
+    />
+  )
+  return { ...utils, onAdd, onContactSelect }
+}
+
 async function openPickerAndPick(name: string) {
   await userEvent.type(screen.getByLabelText('Add recipient'), 'ada')
   await userEvent.click(await screen.findByRole('button', { name }))
@@ -144,6 +164,7 @@ async function openPickerAndPick(name: string) {
 
 beforeEach(() => {
   h.batchGet.mockReset()
+  h.toastError.mockReset()
   h.pickerItems = [ADA]
   Element.prototype.scrollIntoView = vi.fn()
 })
@@ -247,5 +268,77 @@ describe('RecipientInput — contact expansion into N addresses', () => {
         expect.objectContaining({ identifier: 'a@x.com' })
       )
     )
+  })
+})
+
+// Quo (formerly OpenPhone) is the first channel whose recipient is a phone
+// number, not an address. The same input has to accept E.164, reject anything
+// libphonenumber can't parse, commit `PHONE`, and read the contact's
+// multi-value `phone` field instead of `primary_email`.
+describe('RecipientInput — phone recipientModel', () => {
+  /** batchGet payload for a contact whose phone field holds the given numbers. */
+  function phoneValues(numbers: string[]) {
+    return {
+      values: [
+        {
+          recordId: 'contact:c1',
+          fieldRef: 'contact:field-email',
+          fieldType: 'PHONE_INTL',
+          value: numbers.map((value) => ({ type: 'text', value })),
+        },
+      ],
+    }
+  }
+
+  it('commits a typed number as E.164 with identifierType PHONE', async () => {
+    const { onAdd } = renderPhoneInput()
+
+    await userEvent.type(screen.getByLabelText('Add recipient'), '(415) 555-1234{Enter}')
+
+    expect(onAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ identifier: '+14155551234', identifierType: 'PHONE' })
+    )
+    expect(h.toastError).not.toHaveBeenCalled()
+  })
+
+  it('rejects an email address with the phone-specific toast', async () => {
+    const { onAdd } = renderPhoneInput()
+
+    await userEvent.type(screen.getByLabelText('Add recipient'), 'a@x.com{Enter}')
+
+    expect(onAdd).not.toHaveBeenCalled()
+    expect(h.toastError).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Invalid Phone Number' })
+    )
+  })
+
+  it('expands a picked contact into its phone numbers, not its addresses', async () => {
+    h.pickerItems = [{ ...ADA, data: { phone: '+14155551234' } }]
+    h.batchGet.mockResolvedValue(phoneValues(['+14155551234', '+442071838750']))
+    const { onContactSelect } = renderPhoneInput()
+
+    await openPickerAndPick('Ada Lovelace')
+
+    const rowUs = await screen.findByRole('option', { name: /\+14155551234/ })
+    expect(rowUs).toBeVisible()
+    await userEvent.click(screen.getByRole('option', { name: /\+442071838750/ }))
+
+    expect(onContactSelect).toHaveBeenCalledWith({
+      id: 'c1',
+      identifier: '+442071838750',
+      identifierType: 'PHONE',
+      name: 'Ada Lovelace',
+    })
+  })
+
+  it('never falls back to the row secondaryInfo (an email) when the field read fails', async () => {
+    h.pickerItems = [{ ...ADA, data: {} }]
+    h.batchGet.mockRejectedValue(new Error('offline'))
+    const { onContactSelect } = renderPhoneInput()
+
+    await openPickerAndPick('Ada Lovelace')
+
+    await waitFor(() => expect(screen.getByTestId('record-picker')).toBeInTheDocument())
+    expect(onContactSelect).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/components/mail/email-editor/recipient-input.tsx
+++ b/apps/web/src/components/mail/email-editor/recipient-input.tsx
@@ -1,6 +1,5 @@
 // apps/web/src/components/mail/email-editor/recipient-input.tsx
 'use client'
-import { IdentifierType } from '@auxx/database/enums'
 import type { FieldType, IdentifierType as IdentifierTypeType } from '@auxx/database/types'
 import { extractValues } from '@auxx/lib/field-values/client'
 import { getDefinitionId, type RecordPickerItem } from '@auxx/lib/resources/client'
@@ -16,7 +15,7 @@ import {
 import { Popover, PopoverAnchor, PopoverContent } from '@auxx/ui/components/popover'
 import { toastError } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
-import { Copy, Mail, X } from 'lucide-react'
+import { Copy, Mail, Phone, X } from 'lucide-react'
 import type React from 'react'
 import { useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
@@ -27,6 +26,12 @@ import { resolveSystemAttributeRef } from '~/components/resources/utils/resolve-
 import { api } from '~/trpc/react'
 import { toEmailAddressList } from '../email-address-list'
 import { useEditorActiveStateContext } from './editor-active-state-context'
+import {
+  getIdentifierModel,
+  type IdentifierModelSpec,
+  identifierKey,
+  type RecipientModel,
+} from './identifier-model'
 
 export type RecipientField = 'TO' | 'CC' | 'BCC'
 
@@ -39,7 +44,7 @@ interface RecipientState {
 
 /** Imperative handle exposed via ref for parent components */
 export interface RecipientInputHandle {
-  /** Commits any valid email currently typed in the input. Returns true if committed. */
+  /** Commits any valid identifier currently typed in the input. Returns true if committed. */
   commitPendingInput: () => boolean
 }
 
@@ -60,15 +65,28 @@ interface RecipientInputProps {
   disabled?: boolean
   /** className forwarded to popover/dropdown content (e.g. for z-index override) */
   popoverClassName?: string
+  /**
+   * Shape of identifier the selected channel addresses
+   * (`PlatformCapabilities.recipientModel`). Drives validation, the committed
+   * `IdentifierType`, which contact field the picker reads, and the copy.
+   * Absent → email, which is every caller without resolved capabilities.
+   */
+  recipientModel?: RecipientModel
 }
 
 const FIELD_LABELS: Record<RecipientField, string> = { TO: 'To', CC: 'Cc', BCC: 'Bcc' }
 const ALL_FIELDS: RecipientField[] = ['TO', 'CC', 'BCC']
 
-/** The picker row's own single known address (the primary) — the fallback
- *  when the field read fails or returns nothing. */
-function itemFallbackAddresses(item: RecordPickerItem): string[] {
-  const single = toEmailAddressList(item.data?.email)[0] ?? (item.secondaryInfo || undefined)
+/** The picker row's own single known identifier (the primary) — the fallback
+ *  when the field read fails or returns nothing. `toEmailAddressList` is a
+ *  generic system-value normalizer (scalar or sortKey-ordered array); phone is
+ *  multi-value too since #1629. */
+function itemFallbackAddresses(item: RecordPickerItem, spec: IdentifierModelSpec): string[] {
+  const fromRow = toEmailAddressList(item.data?.[spec.rowDataKey])[0]
+  // `secondaryInfo` is the contact's secondary DISPLAY field — an email. It is
+  // only a usable fallback when this channel addresses emails.
+  const single =
+    fromRow ?? (spec.secondaryInfoIsIdentifier ? item.secondaryInfo || undefined : undefined)
   return single ? [single] : []
 }
 
@@ -190,7 +208,10 @@ export function RecipientInput({
   placeholder,
   disabled,
   popoverClassName,
+  recipientModel,
 }: RecipientInputProps) {
+  const spec = useMemo(() => getIdentifierModel(recipientModel), [recipientModel])
+  const IdentifierIcon = recipientModel === 'phone' ? Phone : Mail
   const [inputValue, setInputValue] = useState('')
   const [highlightedIndex, setHighlightedIndex] = useState<number | null>(null)
   const [showPicker, setShowPicker] = useState(false)
@@ -209,17 +230,15 @@ export function RecipientInput({
   const inputRef = useRef<AutosizeInputRef>(null)
   const pickerRef = useRef<HTMLDivElement>(null)
 
-  const isValidEmail = (email: string) => /\S+@\S+\.\S+/.test(email.trim())
-
-  /** Silently commits valid email input. No toast on invalid. Returns true if committed. */
+  /** Silently commits a valid identifier. No toast on invalid. Returns true if committed. */
   const tryCommitInput = (): boolean => {
-    const emailCandidate = inputValue.trim()
-    if (!emailCandidate || !isValidEmail(emailCandidate)) return false
-    const dummyId = `temp_${Date.now()}_${emailCandidate}`
+    const normalized = spec.normalize(inputValue)
+    if (!normalized) return false
+    const dummyId = `temp_${Date.now()}_${normalized}`
     onAdd({
       id: dummyId,
-      identifier: emailCandidate.toLowerCase(),
-      identifierType: IdentifierType.EMAIL,
+      identifier: normalized,
+      identifierType: spec.identifierType,
       name: null,
     })
     setInputValue('')
@@ -227,11 +246,10 @@ export function RecipientInput({
     return true
   }
 
-  /** Commits input with toast error for invalid emails (explicit user action: Enter, comma). */
+  /** Commits input with a toast on invalid input (explicit user action: Enter, comma). */
   const addRecipientFromInput = () => {
-    const emailCandidate = inputValue.trim()
-    if (!isValidEmail(emailCandidate)) {
-      toastError({ title: 'Invalid Email', description: 'Please enter a valid email address.' })
+    if (!spec.normalize(inputValue)) {
+      toastError({ title: spec.invalidTitle, description: spec.invalidDescription })
       return
     }
     tryCommitInput()
@@ -248,30 +266,31 @@ export function RecipientInput({
   const requestedAddressIdsRef = useRef<Set<string>>(new Set())
 
   /**
-   * Fetch the FULL email list for each contact (multi-value `primary_email`
-   * reads back as one row per address, primary first) in one batch read.
-   * Falls back per item to its own row data when the field ref can't resolve
-   * or the read fails.
+   * Fetch the FULL identifier list for each contact (both `primary_email` and
+   * `phone` are multi-value — they read back as one row per value, primary
+   * first) in one batch read. Falls back per item to its own row data when the
+   * field ref can't resolve or the read fails.
    */
   const fetchContactAddresses = useCallback(
     async (items: RecordPickerItem[]): Promise<Map<string, string[]>> => {
       const result = new Map<string, string[]>()
       const fallbackAll = () => {
-        for (const item of items) result.set(item.id, itemFallbackAddresses(item))
+        for (const item of items) result.set(item.id, itemFallbackAddresses(item, spec))
         return result
       }
       try {
         const normalizedToItem = new Map(
           items.map((item) => [getNormalizedRecordId(item.recordId), item] as const)
         )
-        const { systemAttributeMap, systemAttributeByDef, ambiguousSystemAttributes } =
-          useResourceStore.getState()
+        const maps = useResourceStore.getState()
         const [firstRecordId] = normalizedToItem.keys()
+        // First systemAttribute candidate that resolves on this definition wins
+        // (mirrors `systemAttributeForChannel` in the kopilot recipient resolver).
         const ref = firstRecordId
-          ? resolveSystemAttributeRef(
-              { systemAttributeMap, systemAttributeByDef, ambiguousSystemAttributes },
-              'primary_email',
-              getDefinitionId(firstRecordId)
+          ? spec.systemAttributes.reduce<ReturnType<typeof resolveSystemAttributeRef>>(
+              (found, attr) =>
+                found ?? resolveSystemAttributeRef(maps, attr, getDefinitionId(firstRecordId)),
+              undefined
             )
           : undefined
         if (!ref) return fallbackAll()
@@ -286,17 +305,17 @@ export function RecipientInput({
             row.value as TypedFieldValue | TypedFieldValue[] | null,
             row.fieldType as FieldType
           ).filter((v): v is string => typeof v === 'string' && v.length > 0)
-          result.set(item.id, addresses.length > 0 ? addresses : itemFallbackAddresses(item))
+          result.set(item.id, addresses.length > 0 ? addresses : itemFallbackAddresses(item, spec))
         }
         for (const item of items) {
-          if (!result.has(item.id)) result.set(item.id, itemFallbackAddresses(item))
+          if (!result.has(item.id)) result.set(item.id, itemFallbackAddresses(item, spec))
         }
         return result
       } catch {
         return fallbackAll()
       }
     },
-    [batchGetAsync]
+    [batchGetAsync, spec]
   )
 
   /**
@@ -320,20 +339,21 @@ export function RecipientInput({
     [fetchContactAddresses]
   )
 
-  // Lowercased emails of recipients already in this field — used to hide their
-  // matching contacts from the picker. Covers picker/draft/reply/free-typed alike.
-  const excludeEmails = useMemo(
-    () => new Set(recipients.map((r) => r.identifier.toLowerCase())),
-    [recipients]
+  // Normalized identifiers of recipients already in this field — used to hide
+  // their matching contacts from the picker. Covers picker/draft/reply/
+  // free-typed alike.
+  const excludeIdentifiers = useMemo(
+    () => new Set(recipients.map((r) => identifierKey(spec, r.identifier))),
+    [recipients, spec]
   )
 
-  /** Commit one address as a recipient and reset the picker state. */
+  /** Commit one identifier as a recipient and reset the picker state. */
   const commitContactAddress = useCallback(
-    (contactId: string, email: string, name: string | null) => {
+    (contactId: string, address: string, name: string | null) => {
       onContactSelect({
         id: contactId,
-        identifier: email,
-        identifierType: IdentifierType.EMAIL,
+        identifier: spec.normalize(address) ?? address,
+        identifierType: spec.identifierType,
         name,
       })
       setInputValue('')
@@ -341,13 +361,13 @@ export function RecipientInput({
       setPendingContact(null)
       inputRef.current?.focus()
     },
-    [onContactSelect]
+    [onContactSelect, spec]
   )
 
   /**
    * Handle contact selection from RecordPickerContent. A picked contact is
-   * expanded into its N addresses: exactly one address not yet a recipient
-   * commits directly; several swap the popover to a per-address row list.
+   * expanded into its N identifiers: exactly one not yet a recipient commits
+   * directly; several swap the popover to a per-value row list.
    */
   const handleContactPick = useCallback(
     async (item: RecordPickerItem) => {
@@ -361,7 +381,7 @@ export function RecipientInput({
         const known = addresses
         setContactAddresses((prev) => new Map(prev).set(item.id, known))
       }
-      const candidates = addresses.filter((a) => !excludeEmails.has(a.toLowerCase()))
+      const candidates = addresses.filter((a) => !excludeIdentifiers.has(identifierKey(spec, a)))
       if (candidates.length === 0) return
       if (candidates.length === 1) {
         commitContactAddress(item.id, candidates[0]!, name)
@@ -369,22 +389,22 @@ export function RecipientInput({
       }
       setPendingContact({ id: item.id, name, addresses: candidates })
     },
-    [contactAddresses, fetchContactAddresses, excludeEmails, commitContactAddress]
+    [contactAddresses, fetchContactAddresses, excludeIdentifiers, commitContactAddress, spec]
   )
 
   const excludeFilter = useCallback(
     (item: RecordPickerItem) => {
-      // Per-address exclude: once the contact's full list is known (results
-      // prefetch), the contact hides only when EVERY address is a recipient.
+      // Per-value exclude: once the contact's full list is known (results
+      // prefetch), the contact hides only when EVERY identifier is a recipient.
       const known = contactAddresses.get(item.id)
       if (known && known.length > 0) {
-        return known.every((a) => excludeEmails.has(a.toLowerCase()))
+        return known.every((a) => excludeIdentifiers.has(identifierKey(spec, a)))
       }
-      // Unfetched: the only known address is the primary (`secondaryInfo`).
-      const email = item.secondaryInfo?.toLowerCase()
-      return !!email && excludeEmails.has(email)
+      // Unfetched: the only known value is the row's own primary.
+      const [primary] = itemFallbackAddresses(item, spec)
+      return !!primary && excludeIdentifiers.has(identifierKey(spec, primary))
     },
-    [contactAddresses, excludeEmails]
+    [contactAddresses, excludeIdentifiers, spec]
   )
 
   /** Forward a keyboard event to the cmdk Command inside the picker popover */
@@ -412,7 +432,7 @@ export function RecipientInput({
           forwardToPicker(e)
           break
         }
-        // Otherwise commit free-text email
+        // Otherwise commit the free-typed identifier
         if (inputValue.trim()) {
           e.preventDefault()
           addRecipientFromInput()
@@ -534,7 +554,7 @@ export function RecipientInput({
                 if (inputValue.trim().length > 0) setShowPicker(true)
               }}
               onBlur={() => {
-                // Silently commit valid email on blur (no toast for invalid)
+                // Silently commit a valid identifier on blur (no toast for invalid)
                 tryCommitInput()
                 // Delay closing to allow clicking picker items
                 setTimeout(() => setShowPicker(false), 200)
@@ -563,11 +583,11 @@ export function RecipientInput({
           onOpenAutoFocus={(e) => e.preventDefault()}
           onCloseAutoFocus={(e) => e.preventDefault()}>
           {pendingContact ? (
-            <div className='py-1' role='listbox' aria-label='Choose an email address'>
+            <div className='py-1' role='listbox' aria-label={`Choose a ${spec.noun}`}>
               <div className='px-3 py-1.5 text-xs text-muted-foreground'>
                 {pendingContact.name
-                  ? `${pendingContact.name} has ${pendingContact.addresses.length} addresses`
-                  : 'Choose an address'}
+                  ? `${pendingContact.name} has ${pendingContact.addresses.length} ${spec.nounPlural}`
+                  : `Choose a ${spec.noun}`}
               </div>
               {pendingContact.addresses.map((address) => (
                 <button
@@ -579,7 +599,7 @@ export function RecipientInput({
                   onClick={() =>
                     commitContactAddress(pendingContact.id, address, pendingContact.name)
                   }>
-                  <Mail className='size-3.5 text-muted-foreground' />
+                  <IdentifierIcon className='size-3.5 text-muted-foreground' />
                   <span className='truncate'>{address}</span>
                 </button>
               ))}

--- a/apps/web/src/server/api/routers/channel.ts
+++ b/apps/web/src/server/api/routers/channel.ts
@@ -15,6 +15,9 @@ import {
   getProviderType,
   linkChannelToInbox,
   list as listChannels,
+  listQuoPhoneNumbers,
+  provisionQuoChannel,
+  readCachedQuoNumbers,
   recoverChannel,
   requireChannelManageAccess,
   resolveChannelDefinitionId,
@@ -950,6 +953,93 @@ export const channelRouter = createTRPCRouter({
       })
 
       return result.value
+    }),
+
+  /**
+   * Validate a pasted Quo API key and list the phone numbers on its workspace — BEFORE any
+   * Credential exists, so the connect dialog can show the number picker in the same step.
+   *
+   * A mutation, not a query, deliberately: the API key must never land in a URL or a react-query
+   * key. `usRestricted` surfaces `restrictions.messaging.US === 'restricted'` — such a number
+   * cannot send US SMS and would fail at send time with no other signal in the UI.
+   */
+  quoPhoneNumbers: protectedProcedure
+    .input(z.object({ apiKey: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const { userId } = ctx.session
+      const organizationId = getUserOrganizationId(ctx.session)
+      await requirePermission(userId, organizationId, PermissionKey.channelsManage)
+
+      const numbers = await listQuoPhoneNumbers(input.apiKey)
+      return {
+        numbers: numbers.map((n) => ({
+          id: n.id,
+          number: n.number,
+          name: n.name,
+          usRestricted: n.restrictions?.messaging?.US === 'restricted',
+        })),
+      }
+    }),
+
+  /**
+   * List the numbers cached on an EXISTING Quo connection (`Credential.metadata.quo`).
+   *
+   * A query, not a mutation: no secret rides the input, so the credential id is safe in a
+   * react-query key. This is what lets a user add a second number without re-pasting the API
+   * key — re-pasting would mint a second Credential for the same workspace, which is exactly
+   * what the workspace-scoped model exists to prevent.
+   *
+   * A credential with no `quo` bag (saved before the cache landed) returns an EMPTY list, not an
+   * error — the caller falls back to the API-key path. `readCachedQuoNumbers` is org-scoped, so
+   * a foreign credential id reads as empty too.
+   */
+  quoCachedNumbers: protectedProcedure
+    .input(z.object({ credentialId: z.string().min(1) }))
+    .query(async ({ ctx, input }) => {
+      const { userId } = ctx.session
+      const organizationId = getUserOrganizationId(ctx.session)
+      await requirePermission(userId, organizationId, PermissionKey.channelsManage)
+
+      const cached = await readCachedQuoNumbers(input.credentialId, organizationId)
+      return {
+        numbers: cached.phoneNumbers.map((n) => ({
+          id: n.id,
+          number: n.number,
+          name: n.name,
+          usRestricted: n.restrictions?.messaging?.US === 'restricted',
+        })),
+        fetchedAt: cached.fetchedAt,
+      }
+    }),
+
+  /**
+   * Add a second/third phone number as a new channel against an EXISTING Quo connection.
+   *
+   * One connection = one Quo workspace, so the credential is reused rather than re-pasted; the
+   * number is validated against a live `GET /v1/phone-numbers` (never the cached list) and gets
+   * its own Integration + inbox link.
+   */
+  addQuoNumber: protectedProcedure
+    .use(notDemo('add Quo phone numbers'))
+    .input(
+      z.object({
+        credentialId: z.string().min(1),
+        phoneNumberId: z.string().min(1),
+        inboxId: z.string().min(1),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { userId } = ctx.session
+      const organizationId = getUserOrganizationId(ctx.session)
+      await requirePermission(userId, organizationId, PermissionKey.channelsManage)
+
+      return provisionQuoChannel({
+        credentialId: input.credentialId,
+        organizationId,
+        userId,
+        phoneNumberId: input.phoneNumberId,
+        inboxId: input.inboxId,
+      })
     }),
 
   /**

--- a/apps/web/src/server/api/routers/connections.ts
+++ b/apps/web/src/server/api/routers/connections.ts
@@ -95,9 +95,17 @@ export const connectionsRouter = createTRPCRouter({
       // Channels bind a connection credential — flag those rows so the UI can disable delete.
       // Sourced from the `channels` org cache (no extra query); keyed by the credential FK.
       const channels = await getOrgCache().get(organizationId, 'channels')
-      const channelByCred = new Map(
-        channels.flatMap((c) => (c.credentialId ? [[c.credentialId, c] as const] : []))
-      )
+      // One credential can back MANY channels — a Quo (OpenPhone) API key is workspace-scoped
+      // and every phone number on it becomes its own channel. A plain `new Map(...)` keyed by
+      // credentialId silently collapses those to whichever came last, so group instead and
+      // report the count alongside a representative row.
+      const channelsByCred = new Map<string, typeof channels>()
+      for (const c of channels) {
+        if (!c.credentialId) continue
+        const bucket = channelsByCred.get(c.credentialId)
+        if (bucket) bucket.push(c)
+        else channelsByCred.set(c.credentialId, [c])
+      }
 
       // MCP rows are owned by `mcpServerId` (no provider `type`/`providerKey`), so their brand
       // mark lives on the `McpServer` row, not the platform catalog. Source it from the
@@ -107,7 +115,8 @@ export const connectionsRouter = createTRPCRouter({
 
       const now = new Date()
       return result.value.map((record) => {
-        const channel = channelByCred.get(record.id)
+        const boundChannels = channelsByCred.get(record.id)
+        const channel = boundChannels?.[0]
         const mcpServer = record.mcpServerId ? mcpByServer.get(record.mcpServerId) : undefined
         const expired =
           record.consecutiveRefreshFailures >= CONNECTION_CIRCUIT_OPEN_THRESHOLD ||
@@ -144,6 +153,10 @@ export const connectionsRouter = createTRPCRouter({
           // Set when a channel binds this credential — the UI disables delete and shows an "In use"
           // badge. Deleting would orphan the channel (FK is set-null), so block it here too.
           usedByChannel: channel ? { provider: channel.provider, email: channel.email } : null,
+          // How many channels bind this credential. `usedByChannel` names only the first —
+          // a workspace-scoped key (Quo) legitimately backs one channel per phone number, and
+          // the delete guard's message counts all of them.
+          channelCount: boundChannels?.length ?? 0,
         }
       })
     }),
@@ -448,14 +461,24 @@ export const connectionsRouter = createTRPCRouter({
         })
       }
 
-      // A channel binding this credential would be orphaned by the delete (FK is set-null), losing
-      // its only token source. Block it — disconnect the channel first. Sourced from the cache.
+      // Channels binding this credential would be orphaned by the delete (`Integration.credentialId`
+      // is `onDelete: 'set null'`), losing their only token source. Block it — disconnect the
+      // channels first. Sourced from the `channels` org cache, which already excludes soft-deleted
+      // rows, so the count is exactly the live dependents.
+      //
+      // The count is named on purpose: one credential can now back MANY channels (a Quo workspace
+      // key covers every phone number on it, one Integration per number), so "it is in use by a
+      // channel" would understate what the delete is about to break. Generic over providers — the
+      // 1:N case is just where it stops being self-evident.
       const channels = await getOrgCache().get(organizationId, 'channels')
-      if (channels.some((c) => c.credentialId === input.id)) {
+      const dependents = channels.filter((c) => c.credentialId === input.id)
+      if (dependents.length > 0) {
         throw new TRPCError({
           code: 'CONFLICT',
           message:
-            'Cannot delete connection: it is in use by a channel. Disconnect the channel first.',
+            dependents.length === 1
+              ? 'Cannot delete connection: 1 channel depends on it. Disconnect that channel first.'
+              : `Cannot delete connection: ${dependents.length} channels depend on it. Disconnect them first.`,
         })
       }
 

--- a/packages/lib/src/channels/capabilities.ts
+++ b/packages/lib/src/channels/capabilities.ts
@@ -126,7 +126,15 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
     threadReply: true,
     subject: false,
     ccBcc: false,
-    drafts: true,
+    // Quo has no drafts API — the surface is List messages / Send a text /
+    // Get a message by ID, nothing else. Matches `provider-capabilities.ts`
+    // (`canDraft: false`, `createDraft()` returning `{ success: false }`).
+    // LOCAL drafts (our own DB row) are a different mechanism and do NOT read
+    // this flag; this one only advertises server-side draft persistence.
+    drafts: false,
+    // Quo's send schema is `content`/`from`/`to` (+ optional `userId`,
+    // deprecated `phoneNumberId`, `setInboxStatus`) — no media field at all.
+    // Outbound MMS is a platform limitation, not a gap on our side.
     attachments: false,
     recipientModel: 'phone',
   },

--- a/packages/lib/src/channels/index.ts
+++ b/packages/lib/src/channels/index.ts
@@ -30,6 +30,12 @@ export {
   provisionPersonalInbox,
   supportsPersonalChannelConnection,
 } from './personal-connection'
+export {
+  listQuoPhoneNumbers,
+  type ProvisionQuoChannelInput,
+  provisionQuoChannel,
+  readCachedQuoNumbers,
+} from './quo-channel'
 export { type RecoverChannelResult, recoverChannel } from './recover'
 export { registerChannelHooks } from './register-hooks'
 export {

--- a/packages/lib/src/channels/openphone-provisioning-hook.ts
+++ b/packages/lib/src/channels/openphone-provisioning-hook.ts
@@ -1,99 +1,31 @@
 // packages/lib/src/channels/openphone-provisioning-hook.ts
-// Post-connect provisioning for the Quo (OpenPhone) SMS channel — a secret (API-key) connection.
-// The generic `connections.save` path commits a Credential holding the apiKey + webhookSigningSecret
-// (both encrypted) plus the non-secret routing identity (phoneNumberId, phoneNumber) under
-// metadata.connectionVariables, then runs this hook to do the channel-side provisioning that used to
-// live in OpenPhoneService.addIntegration:
-//   gate (admin + channel limit), create-or-relink the Integration row matched by phoneNumberId, copy
-//   the two non-secret identifiers onto Integration.metadata (the shape the provider + webhook route
-//   read), default selective record-creation, and link the default inbox.
+// Post-connect provisioning for the Quo (formerly OpenPhone) SMS channel — a secret (API-key)
+// connection.
 //
-// Secrets stay on the Credential: getChannelTokens resolves apiKey via Integration.credentialId, and the
-// unauthenticated webhook route reveals webhookSigningSecret via the same credentialId — neither is
-// copied into Integration.metadata. There is no token swap (unlike the social hook) — saveConnection
-// already stored apiKey as the credential secret.
+// The connect form collects the API KEY AND NOTHING ELSE (see `connections/providers/defs.ts`):
+// one connection = one Quo WORKSPACE, not one phone number. `connections.save` commits the
+// Credential holding that key (encrypted), then runs this hook, which fetches the workspace's
+// numbers, caches them on `Credential.metadata.quo`, and turns the ONE number the user picked
+// into a channel.
+//
+// The picked `PN…` arrives via `ctx.extra.phoneNumberId` — `connections.save` forwards
+// `input.postConnect` verbatim as `ctx.extra`, the same channel that already carries
+// `pc_inboxId` → `ctx.extra.inboxId`.
+//
+// v1 is deliberately ONE CHANNEL PER CONNECT: auto-creating a channel per number would blow
+// through `assertChannelLimit` on a workspace with many numbers and silently spend the org's
+// plan allowance. Adding a second number is `channel.addQuoNumber` against this same Credential.
+//
+// All the actual work lives in `quo-channel.ts`, shared with that procedure. This hook is only
+// the permission gate + input plumbing.
 
-import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq } from 'drizzle-orm'
-import { onCacheEvent } from '../cache'
 import type { PostConnectHook, PostConnectHookContext } from '../connections/post-connect-hooks'
-import { ForbiddenError } from '../errors'
-import { publisher } from '../events'
-import { InboxService } from '../inboxes/inbox-service'
-import {
-  FeatureKey,
-  FeaturePermissionService,
-  PermissionKey,
-  requirePermission,
-} from '../permissions'
-import { assertSharedConnectInbox } from './connect-inbox'
-import { countBillableChannels } from './list'
+import { BadRequestError } from '../errors'
+import { PermissionKey, requirePermission } from '../permissions'
+import { provisionQuoChannel } from './quo-channel'
 
 const logger = createScopedLogger('openphone-provisioning-hook')
-
-/** The non-secret routing identity carried in Credential metadata.connectionVariables. */
-interface OpenPhoneIdentity {
-  phoneNumberId: string
-  phoneNumber: string
-}
-
-/** Read the saved connection's non-secret connection variables from the Credential row. */
-async function readIdentity(
-  credentialId: string,
-  organizationId: string
-): Promise<OpenPhoneIdentity> {
-  const [credential] = await db
-    .select({ metadata: schema.Credential.metadata })
-    .from(schema.Credential)
-    .where(
-      and(
-        eq(schema.Credential.id, credentialId),
-        eq(schema.Credential.organizationId, organizationId)
-      )
-    )
-    .limit(1)
-  const vars = (credential?.metadata?.connectionVariables ?? {}) as Record<string, unknown>
-  const phoneNumberId = typeof vars.phoneNumberId === 'string' ? vars.phoneNumberId : ''
-  const phoneNumber = typeof vars.phoneNumber === 'string' ? vars.phoneNumber : ''
-  if (!phoneNumberId || !phoneNumber) {
-    throw new Error('Quo connection is missing phoneNumberId / phoneNumber')
-  }
-  return { phoneNumberId, phoneNumber }
-}
-
-/** Enforce the channel feature limit (the bespoke addOpenPhoneIntegration ran this pre-insert). */
-async function assertChannelLimit(organizationId: string): Promise<void> {
-  const limit = await new FeaturePermissionService(db).getLimit(organizationId, FeatureKey.channels)
-  if (typeof limit === 'number' && limit >= 0) {
-    const current = await countBillableChannels(db, organizationId)
-    if (current >= limit) {
-      throw new ForbiddenError(
-        `You have reached your channel limit (${limit}). Upgrade your plan to connect more channels.`
-      )
-    }
-  }
-}
-
-/** Find the existing openphone Integration for this phone number id, if any (jsonb match in memory). */
-async function findExistingChannel(
-  organizationId: string,
-  phoneNumberId: string
-): Promise<string | null> {
-  const rows = await db
-    .select({ id: schema.Integration.id, metadata: schema.Integration.metadata })
-    .from(schema.Integration)
-    .where(
-      and(
-        eq(schema.Integration.organizationId, organizationId),
-        eq(schema.Integration.provider, 'openphone')
-      )
-    )
-  const match = rows.find(
-    (r) => (r.metadata as Record<string, unknown> | null)?.phoneNumberId === phoneNumberId
-  )
-  return match?.id ?? null
-}
 
 /** The Quo (OpenPhone) channel post-connect hook — runs off the secret-save path. */
 export const openphoneProvisioningHook: PostConnectHook = {
@@ -102,83 +34,19 @@ export const openphoneProvisioningHook: PostConnectHook = {
     // Channels require the channels.manage capability (the generic secret-save allows any member).
     await requirePermission(ctx.userId, ctx.organizationId, PermissionKey.channelsManage)
 
-    const identity = await readIdentity(ctx.credentialId, ctx.organizationId)
-    const existingId = await findExistingChannel(ctx.organizationId, identity.phoneNumberId)
-    // Only a brand-new channel counts against the limit; a reconnect relinks in place.
-    if (!existingId) await assertChannelLimit(ctx.organizationId)
-
-    const metadata = { phoneNumberId: identity.phoneNumberId, phoneNumber: identity.phoneNumber }
-    // Channel settings live under `Integration.metadata.settings` — there is no
-    // top-level `settings` column (see channels/settings.ts and the ingest read
-    // in store-message.ts). Default to selective record-creation on first connect.
-    const newChannelMetadata = {
-      ...metadata,
-      settings: { recordCreation: { mode: 'selective' } },
-    }
-    let integrationId: string
-
-    if (existingId) {
-      await db
-        .update(schema.Integration)
-        .set({
-          credentialId: ctx.credentialId,
-          enabled: true,
-          metadata: metadata as any,
-          updatedAt: new Date(),
-        })
-        .where(eq(schema.Integration.id, existingId))
-      integrationId = existingId
-    } else {
-      const [created] = await db
-        .insert(schema.Integration)
-        .values({
-          organizationId: ctx.organizationId,
-          provider: 'openphone',
-          credentialId: ctx.credentialId,
-          enabled: true,
-          metadata: newChannelMetadata,
-          updatedAt: new Date(),
-        })
-        .returning({ id: schema.Integration.id })
-      if (!created) throw new Error('OpenPhone channel insert returned no row')
-      integrationId = created.id
+    const phoneNumberId = ctx.extra?.phoneNumberId
+    if (typeof phoneNumberId !== 'string' || !phoneNumberId) {
+      throw new BadRequestError('Pick a Quo phone number to connect as a channel.')
     }
 
-    // Inbox-first (channels v2): a new channel REQUIRES a validated shared inbox chosen
-    // up-front (forwarded via `pc_inboxId` → `ctx.extra.inboxId`); a reconnect keeps its
-    // existing link and ignores the param.
-    const existingLink = existingId
-      ? await db.query.InboxIntegration.findFirst({
-          where: eq(schema.InboxIntegration.integrationId, integrationId),
-        })
-      : null
-    if (!existingLink) {
-      const recordId = await assertSharedConnectInbox(
-        db,
-        ctx.organizationId,
-        ctx.extra?.inboxId as string | undefined
-      )
-      const inboxService = new InboxService(db, ctx.organizationId, ctx.userId)
-      await inboxService.addIntegration(recordId, integrationId)
-    }
-
-    await onCacheEvent('channel.connected', { orgId: ctx.organizationId })
-
-    await publisher.publishLater({
-      type: 'integration:connected',
-      data: {
-        organizationId: ctx.organizationId,
-        userId: ctx.userId,
-        provider: 'openphone',
-        identifier: identity.phoneNumber,
-        integrationId,
-      },
+    const { integrationId } = await provisionQuoChannel({
+      credentialId: ctx.credentialId,
+      organizationId: ctx.organizationId,
+      userId: ctx.userId,
+      phoneNumberId,
+      inboxId: ctx.extra?.inboxId as string | undefined,
     })
 
-    logger.info('Quo (OpenPhone) channel provisioned', {
-      integrationId,
-      phoneNumberId: identity.phoneNumberId,
-      isNew: !existingId,
-    })
+    logger.info('Quo (OpenPhone) connection provisioned', { integrationId, phoneNumberId })
   },
 }

--- a/packages/lib/src/channels/quo-channel.ts
+++ b/packages/lib/src/channels/quo-channel.ts
@@ -1,0 +1,377 @@
+// packages/lib/src/channels/quo-channel.ts
+// Provisioning for the Quo (formerly OpenPhone) SMS channel.
+//
+// THE MODEL: one connection = one Quo WORKSPACE, not one phone number. Quo scopes the API key
+// and webhooks at the workspace; only the number itself is a sub-resource. So a single
+// Credential holds the API key, and N Integrations hang off it — one per number the user turns
+// into a channel. `Integration.credentialId` is a plain FK on a NON-unique index
+// (`Integration_credentialId_idx`), and `disconnect` soft-deletes the Integration without
+// touching the Credential, so the schema already supports 1:N.
+//
+// This module is the single implementation shared by two callers:
+//   - the post-connect hook (`openphone-provisioning-hook.ts`), which provisions the first
+//     number right after `connections.save` commits the Credential; and
+//   - `channel.addQuoNumber` (tRPC), which adds a second/third number against the SAME
+//     Credential.
+//
+// Style note: this throws `AuxxError` subclasses rather than returning a `Result`. It sits
+// beside `connect-inbox.ts` (`assertSharedConnectInbox`) and both provisioning hooks, all of
+// which are imperative/throwing, and it composes with `InboxService`, which throws too. There
+// are NO permission checks here — the hook and the router assert `channelsManage`.
+
+import { revealSecrets } from '@auxx/credentials/store'
+import { database as db, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNull, sql } from 'drizzle-orm'
+import { onCacheEvent } from '../cache'
+import { BadRequestError, ForbiddenError, NotFoundError } from '../errors'
+import { publisher } from '../events'
+import { InboxService } from '../inboxes/inbox-service'
+import { FeatureKey, FeaturePermissionService } from '../permissions'
+import { listPhoneNumbers, QuoApiError } from '../providers/openphone/api'
+import type {
+  QuoCachedPhoneNumber,
+  QuoCredentialMetadata,
+  QuoPhoneNumber,
+} from '../providers/openphone/types'
+import { assertSharedConnectInbox } from './connect-inbox'
+import { countBillableChannels } from './list'
+
+const logger = createScopedLogger('quo-channel')
+
+/**
+ * Trim a live `GET /v1/phone-numbers` row to what we cache. `users[]` is dropped (member
+ * emails/names we do not need, and the fastest-staling part); `restrictions` is KEPT, because
+ * only a number with `restrictions.messaging.US === 'unrestricted'` can send US SMS — the
+ * others fail at send time with no signal in our UI.
+ */
+function toCachedPhoneNumber(number: QuoPhoneNumber): QuoCachedPhoneNumber {
+  return {
+    id: number.id,
+    number: number.number,
+    name: number.name ?? null,
+    ...(number.restrictions ? { restrictions: number.restrictions } : {}),
+  }
+}
+
+/** Translate a Quo wire failure into the AuxxError the router/hook should surface. */
+function toAuxxError(error: unknown): Error {
+  if (error instanceof QuoApiError) {
+    if (error.status === 401 || error.status === 403) {
+      return new BadRequestError('That API key was rejected by Quo. Check the key and try again.')
+    }
+    return new BadRequestError(`Quo rejected the request: ${error.message}`)
+  }
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+/**
+ * Fetch every phone number on the workspace an API key belongs to, trimmed to the cached
+ * projection. Used both to validate a pasted key before any Credential exists and as the live
+ * fetch inside `provisionQuoChannel`.
+ */
+export async function listQuoPhoneNumbers(apiKey: string): Promise<QuoCachedPhoneNumber[]> {
+  try {
+    const numbers = await listPhoneNumbers(apiKey)
+    return numbers.map(toCachedPhoneNumber)
+  } catch (error) {
+    throw toAuxxError(error)
+  }
+}
+
+/**
+ * Read the cached workspace numbers back off `Credential.metadata.quo`.
+ *
+ * The read counterpart of {@link cachePhoneNumbers} — the "add another number" picker renders
+ * from this instead of re-asking for the API key (which would mint a SECOND Credential for the
+ * same Quo workspace, the exact thing the workspace-scoped model exists to prevent).
+ *
+ * Org-scoped on purpose: `credentialId` arrives from the client, so the org predicate is the
+ * authorization boundary, not a filter. A credential from another org, a missing row, or a
+ * credential saved before this cache existed all read as an EMPTY list — never an error. An
+ * empty list is a legitimate "nothing cached yet" state the caller falls back from, and the
+ * cache is a picker convenience only: `provisionQuoChannel` still validates the chosen number
+ * against a live fetch.
+ */
+export async function readCachedQuoNumbers(
+  credentialId: string,
+  organizationId: string
+): Promise<{ phoneNumbers: QuoCachedPhoneNumber[]; fetchedAt: string | null }> {
+  const [row] = await db
+    .select({ metadata: schema.Credential.metadata })
+    .from(schema.Credential)
+    .where(
+      and(
+        eq(schema.Credential.id, credentialId),
+        eq(schema.Credential.organizationId, organizationId)
+      )
+    )
+    .limit(1)
+
+  const quo = (row?.metadata as { quo?: Partial<QuoCredentialMetadata> } | null)?.quo
+  if (!quo || !Array.isArray(quo.phoneNumbers)) return { phoneNumbers: [], fetchedAt: null }
+  return { phoneNumbers: quo.phoneNumbers, fetchedAt: quo.fetchedAt ?? null }
+}
+
+/** Read the API key out of the Credential's multi-field secret bag (`secrets.fields.apiKey`). */
+async function revealApiKey(credentialId: string, organizationId: string): Promise<string> {
+  const revealed = await revealSecrets<{ fields?: Record<string, string> }>(
+    credentialId,
+    organizationId
+  )
+  const apiKey = revealed.isOk() ? revealed.value.secrets.fields?.apiKey : undefined
+  if (!apiKey) {
+    throw new NotFoundError('This Quo connection has no API key. Reconnect it and try again.')
+  }
+  return apiKey
+}
+
+/**
+ * Cache the workspace's numbers on `Credential.metadata.quo`.
+ *
+ * Deliberately its OWN key, not `metadata.connectionVariables`: that bag is reserved for
+ * user-supplied form values, and `mergeManualConnectionEdit` read-modify-writes it on every
+ * manual reconnect — derived provider state living there would look like a field the user
+ * forgot to re-supply. The jsonb `||` merge keeps every other top-level key intact.
+ *
+ * ⚠️ This cache is a PICKER CONVENIENCE, never a routing authority. Message routing resolves
+ * against `Integration.metadata.phoneNumberId` (what the webhook route matches on). Nothing in
+ * the ingest path may read this list, and channel creation validates the selected number
+ * against a live fetch rather than against this cache.
+ */
+async function cachePhoneNumbers(
+  credentialId: string,
+  organizationId: string,
+  phoneNumbers: QuoCachedPhoneNumber[]
+): Promise<void> {
+  const quo: QuoCredentialMetadata = { phoneNumbers, fetchedAt: new Date().toISOString() }
+  await db
+    .update(schema.Credential)
+    .set({
+      metadata: sql`COALESCE(${schema.Credential.metadata}, '{}'::jsonb) || jsonb_build_object('quo', ${JSON.stringify(quo)}::jsonb)`,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(schema.Credential.id, credentialId),
+        eq(schema.Credential.organizationId, organizationId)
+      )
+    )
+}
+
+/** Enforce the channel feature limit (only a brand-new channel counts). */
+async function assertChannelLimit(organizationId: string): Promise<void> {
+  const limit = await new FeaturePermissionService(db).getLimit(organizationId, FeatureKey.channels)
+  if (typeof limit === 'number' && limit >= 0) {
+    const current = await countBillableChannels(db, organizationId)
+    if (current >= limit) {
+      throw new ForbiddenError(
+        `You have reached your channel limit (${limit}). Upgrade your plan to connect more channels.`
+      )
+    }
+  }
+}
+
+/**
+ * Find the LIVE openphone Integration for this phone number id, if any (jsonb match in memory).
+ *
+ * Soft-deleted rows are excluded on purpose, matching `upsertIntegration` in
+ * `provisioning-hook.ts`: relinking a `deletedAt`-stamped row produces a channel that connects
+ * fine but never appears (the channels cache filters `deletedAt`) and never syncs. Reconnecting
+ * a disconnected number must INSERT a fresh row — the partial unique index is keyed on
+ * `(organizationId, provider, email)` and openphone rows carry a NULL email, so it allows this.
+ */
+async function findExistingChannel(
+  organizationId: string,
+  phoneNumberId: string
+): Promise<{ id: string; metadata: Record<string, unknown> | null } | null> {
+  const rows = await db
+    .select({ id: schema.Integration.id, metadata: schema.Integration.metadata })
+    .from(schema.Integration)
+    .where(
+      and(
+        eq(schema.Integration.organizationId, organizationId),
+        eq(schema.Integration.provider, 'openphone'),
+        isNull(schema.Integration.deletedAt)
+      )
+    )
+  const match = rows.find(
+    (r) => (r.metadata as Record<string, unknown> | null)?.phoneNumberId === phoneNumberId
+  )
+  if (!match) return null
+  return { id: match.id, metadata: (match.metadata as Record<string, unknown> | null) ?? null }
+}
+
+/**
+ * Arm the Quo message webhook for a freshly provisioned channel.
+ *
+ * Goes through the generic seam Gmail/Outlook use — `WebhookManagerService.setupWebhook` →
+ * `provider.setupWebhook(callbackUrl)` — which also honours the sync-mode gate, so this is a
+ * logged no-op until `resolveEffectiveSyncMode` returns `'webhook'` for openphone.
+ *
+ * Failure degrades gracefully: log and leave the channel connected, matching how email
+ * provisioning falls back to polling. A webhook error must never fail the whole connect.
+ */
+export async function armQuoWebhook(integrationId: string, organizationId: string): Promise<void> {
+  try {
+    const { ProviderRegistryService } = await import('../providers/provider-registry-service')
+    const { WebhookManagerService } = await import('../providers/webhook-manager-service')
+    const registry = new ProviderRegistryService(organizationId)
+    await new WebhookManagerService(organizationId, registry).setupWebhooks(
+      'openphone',
+      integrationId
+    )
+  } catch (error) {
+    logger.warn('Quo webhook arming failed — channel stays connected', {
+      integrationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+export interface ProvisionQuoChannelInput {
+  /** The Credential holding the workspace API key. */
+  credentialId: string
+  organizationId: string
+  /** The acting user (permission is asserted by the caller, not here). */
+  userId: string
+  /** The `PN…` id the user picked. Validated against a LIVE fetch, not the cache. */
+  phoneNumberId: string
+  /** Required for a brand-new channel; ignored when relinking an existing one. */
+  inboxId?: string
+}
+
+/**
+ * Create (or relink) the channel for one Quo phone number on an existing workspace connection.
+ *
+ * Steps, in order:
+ *  1. reveal the API key from the Credential;
+ *  2. `GET /v1/phone-numbers` and refresh `Credential.metadata.quo` (so reconnect re-fetches);
+ *  3. validate the selected `PN…` against that LIVE fetch — a stale cache entry must never
+ *     produce a broken channel;
+ *  4. create-or-relink the Integration, copying `{ phoneNumberId, phoneNumber }` from the live
+ *     row onto `Integration.metadata` (the routing identity the webhook route resolves against);
+ *  5. link the destination inbox (new channels only);
+ *  6. arm the webhook, gracefully;
+ *  7. invalidate the channel caches and publish `integration:connected`.
+ */
+export async function provisionQuoChannel(
+  input: ProvisionQuoChannelInput
+): Promise<{ integrationId: string }> {
+  const { credentialId, organizationId, userId, phoneNumberId } = input
+
+  const apiKey = await revealApiKey(credentialId, organizationId)
+  const phoneNumbers = await listQuoPhoneNumbers(apiKey)
+  await cachePhoneNumbers(credentialId, organizationId, phoneNumbers)
+
+  const selected = phoneNumbers.find((n) => n.id === phoneNumberId)
+  if (!selected) {
+    throw new BadRequestError(
+      `Phone number ${phoneNumberId} is not on this Quo workspace. Refresh the list and pick again.`
+    )
+  }
+
+  const existing = await findExistingChannel(organizationId, phoneNumberId)
+  // Only a brand-new channel counts against the limit; a reconnect relinks in place.
+  if (!existing) await assertChannelLimit(organizationId)
+
+  // Inbox-first (channels v2): a new channel REQUIRES a validated shared inbox chosen up-front;
+  // a relink keeps its existing link and ignores the param. Resolved BEFORE the Integration
+  // write so a missing/invalid inbox never leaves a half-provisioned channel behind.
+  const existingLink = existing
+    ? await db.query.InboxIntegration.findFirst({
+        where: eq(schema.InboxIntegration.integrationId, existing.id),
+      })
+    : null
+  const inboxRecordId = existingLink
+    ? null
+    : await assertSharedConnectInbox(db, organizationId, input.inboxId)
+
+  // Routing identity — the shape `OpenPhoneProvider` and the webhook route both read.
+  const identity = { phoneNumberId: selected.id, phoneNumber: selected.number }
+  let integrationId: string
+
+  if (existing) {
+    // MERGE, never replace: `settings`, `webhookId` and `backfillCutoffAt` all live in this
+    // blob, and a reconnect that overwrote it would silently reset the channel's record-creation
+    // mode and re-open the trigger-suppression window.
+    await db
+      .update(schema.Integration)
+      .set({
+        credentialId,
+        enabled: true,
+        metadata: { ...(existing.metadata ?? {}), ...identity } as any,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.Integration.id, existing.id))
+    integrationId = existing.id
+  } else {
+    const connectEpoch = new Date()
+    const [created] = await db
+      .insert(schema.Integration)
+      .values({
+        organizationId,
+        provider: 'openphone',
+        credentialId,
+        enabled: true,
+        metadata: {
+          ...identity,
+          // Channel settings live under `Integration.metadata.settings` — there is no
+          // top-level `settings` column (see channels/settings.ts and the ingest read in
+          // store-message.ts).
+          //
+          // `'all'`, not the `'selective'` this hook used to inherit from email. Selective was
+          // spam hygiene for mail: an inbound-only stranger gets a Participant and a working
+          // thread but NO Contact (ingest/contacts/find-or-create.ts — it only creates when the
+          // participant is an outbound recipient or the org has texted them before). On an SMS
+          // support line that is backwards; someone texting the business cold is exactly who
+          // should get a CRM record.
+          //
+          // TRADEOFF, accepted: under `'all'`, short codes and alphanumeric sender IDs (`12345`,
+          // `AUXX`) fail `isAddressablePhone`, get `systemAttr = null`, and are created with no
+          // identifier-keyed dedupe — i.e. every 2FA/marketing sender becomes an un-dedupable
+          // contact. Sender filtering (channels/settings.ts excluded senders) is the follow-up
+          // mitigation.
+          settings: { recordCreation: { mode: 'all' } },
+          // Received-time trigger cutoff, stamped at the connect epoch — the same stamp
+          // gmail/outlook write in `provisioning-hook.ts`, consumed via `ingest/context.ts` +
+          // `store-message.ts` to suppress `message:received` for pre-cutoff messages. Without
+          // it the Phase 6 backfill mass-fires workflows, AI classification, notifications and
+          // contact creation for every historical conversation at once.
+          backfillCutoffAt: connectEpoch.toISOString(),
+        },
+        updatedAt: connectEpoch,
+      })
+      .returning({ id: schema.Integration.id })
+    if (!created) throw new Error('Quo channel insert returned no row')
+    integrationId = created.id
+  }
+
+  if (inboxRecordId) {
+    await new InboxService(db, organizationId, userId).addIntegration(inboxRecordId, integrationId)
+  }
+
+  // After the Integration row commits and the inbox link lands, before the connected publish.
+  await armQuoWebhook(integrationId, organizationId)
+
+  await onCacheEvent('channel.connected', { orgId: organizationId })
+
+  await publisher.publishLater({
+    type: 'integration:connected',
+    data: {
+      organizationId,
+      userId,
+      provider: 'openphone',
+      identifier: selected.number,
+      integrationId,
+    },
+  })
+
+  logger.info('Quo channel provisioned', {
+    integrationId,
+    phoneNumberId: selected.id,
+    isNew: !existing,
+  })
+
+  return { integrationId }
+}

--- a/packages/lib/src/channels/recover.ts
+++ b/packages/lib/src/channels/recover.ts
@@ -107,6 +107,15 @@ export async function recoverChannel(
     }
   }
 
+  // Same two-path reasoning as Outlook above. Quo webhooks never expire, so this only matters
+  // when the callback URL moved — which is exactly the dev-tunnel case (`NGROK_URL` feeds
+  // `providerWebhookCallbackUrl`), and also covers a webhook deleted on Quo's side. Arming is
+  // delete-then-recreate, so re-running it can never leave two live webhooks for one number.
+  if (channel.provider === 'openphone') {
+    const { armQuoWebhook } = await import('./quo-channel')
+    await armQuoWebhook(channelId, ctx.organizationId)
+  }
+
   // After the metadata write, not before: `toggle`'s own invalidation fires
   // while the stale `auth` block is still on the row, and the cached channel
   // list carries both `metadata` and `enabled`.

--- a/packages/lib/src/connections/providers/defs.ts
+++ b/packages/lib/src/connections/providers/defs.ts
@@ -811,12 +811,28 @@ export const PLATFORM_PROVIDER_DEFS: PlatformProviderDef[] = [
 
   // ────────────────────────────────────────────────────────────────────────
   // Channel API-key providers (secret). The SMS/phone channel (Quo, formerly
-  // OpenPhone) as a per-org connection. All four connect fields are connection
-  // variables: apiKey + webhookSigningSecret are secret (encrypted on the
-  // Credential); phoneNumberId + phoneNumber are non-secret routing identity the
-  // openphone provisioning hook copies onto Integration.metadata. providerKey
-  // stays `openphone` (labels-only rename). (Mailgun is intentionally absent — its
-  // key is a platform env, not a per-org connection.)
+  // OpenPhone) as a per-org connection.
+  //
+  // ONE CONNECTION = ONE QUO WORKSPACE, not one phone number. Quo scopes the API
+  // key and its webhooks at the workspace; only the number itself is a resource
+  // within it. So the form collects the API KEY AND NOTHING ELSE — the connect
+  // flow fetches `GET /v1/phone-numbers` with it, caches the trimmed list on
+  // `Credential.metadata.quo`, and the number is a post-connect selection carried
+  // through `postConnect` → `ctx.extra.phoneNumberId`. N Integrations then hang
+  // off the one Credential, one per number turned into a channel.
+  //
+  // The other three fields this form used to collect are gone:
+  //  - `phoneNumberId` validated `^pnv_.+`, but real Quo ids are `PN…` — the form
+  //    literally could not be submitted, which is why this channel had never been
+  //    connected. It is now picked from the live list after connect.
+  //  - `phoneNumber` is derived from that same list.
+  //  - `webhookSigningSecret` is minted by Quo and returned on webhook creation
+  //    (`POST /v1/webhooks/messages` → `data.key`), which `setupWebhook` persists.
+  //
+  // providerKey stays `openphone` everywhere it is persisted (labels-only rename).
+  // `authApply: BEARER` is verified working — Quo tolerates the `Bearer ` prefix,
+  // and the Quo contacts data-connector binds to this same definition. (Mailgun is
+  // intentionally absent — its key is a platform env, not a per-org connection.)
   // ────────────────────────────────────────────────────────────────────────
   {
     providerKey: 'openphone',
@@ -831,36 +847,9 @@ export const PLATFORM_PROVIDER_DEFS: PlatformProviderDef[] = [
         secret: true,
         required: true,
         placeholder: 'Your Quo API key',
-        description: 'Quo (OpenPhone) API key — Settings → Developer in the Quo dashboard.',
+        description:
+          'Quo API key — Workspace Settings → API in the Quo dashboard (owner/admin only). One key covers every phone number on the workspace.',
         validation: { minLength: 10, message: 'API key must be at least 10 characters.' },
-      },
-      {
-        key: 'phoneNumberId',
-        label: 'Phone Number ID',
-        required: true,
-        placeholder: 'pnv_…',
-        description: 'The phone number ID (starts with pnv_).',
-        validation: { pattern: '^pnv_.+', message: 'Phone number ID must start with pnv_.' },
-      },
-      {
-        key: 'phoneNumber',
-        label: 'Phone Number',
-        required: true,
-        placeholder: '+1234567890',
-        description: 'Your phone number in E.164 format.',
-        validation: {
-          pattern: '^\\+[1-9]\\d{6,14}$',
-          message: 'Use E.164 format, e.g. +1234567890.',
-        },
-      },
-      {
-        key: 'webhookSigningSecret',
-        label: 'Webhook Signing Secret',
-        secret: true,
-        required: true,
-        placeholder: 'Webhook signing secret',
-        description: 'Used to verify webhook requests from Quo.',
-        validation: { minLength: 16, message: 'Signing secret must be at least 16 characters.' },
       },
     ],
     uiMetadata: { icon: 'brand:openphone', category: 'other', brandColor: '#6366f1' },

--- a/packages/lib/src/data-connectors/map-record.test.ts
+++ b/packages/lib/src/data-connectors/map-record.test.ts
@@ -430,6 +430,142 @@ describe('mapRecord', () => {
     expect(writes[0]?.projected?.fields).not.toHaveProperty('def1:email')
   })
 
+  // ── Indexed source paths (`emails[0].value`) ─────────────────────────────────
+
+  it('resolves an INDEXED source path into a labelled array (Quo `emails[0].value`)', () => {
+    // Quo exposes no scalar email/phone — both are arrays of labelled entries, so a
+    // scalar binding has to address one element explicitly. NOTE: this lands the
+    // FIRST entry only. Contact phone is multi-value E.164 since #1629, but the
+    // connector write path is scalar, so a contact with three numbers lands one.
+    const m = mapping({
+      rootPath: 'data[]',
+      targetMode: 'contributing',
+      fieldMappings: [
+        {
+          id: 'e1',
+          targetFieldRef: toResourceFieldId('def1', 'primary_email'),
+          expression: '{defaultFields.emails[0].value}',
+          sourceFields: { 'defaultFields.emails[0].value': 'defaultFields.emails[0].value' },
+        },
+        {
+          id: 'e2',
+          targetFieldRef: toResourceFieldId('def1', 'phone'),
+          expression: '{defaultFields.phoneNumbers[0].value}',
+          sourceFields: {
+            'defaultFields.phoneNumbers[0].value': 'defaultFields.phoneNumbers[0].value',
+          },
+          identityRole: { kind: 'match', normalize: 'phone' },
+        },
+      ],
+    })
+
+    const writes = mapRecord(
+      [m],
+      rawPayload({
+        data: [
+          {
+            id: '69dd3ed96520933f4d16e5f2',
+            defaultFields: {
+              firstName: 'Jane',
+              lastName: 'Doe',
+              emails: [
+                { id: 'e_1', name: 'Work', value: 'jane@acme.com' },
+                { id: 'e_2', name: 'Home', value: 'jane@home.com' },
+              ],
+              phoneNumbers: [{ id: 'p_1', name: 'Mobile', value: '+15551234567' }],
+            },
+          },
+        ],
+      })
+    )
+
+    expect(writes).toHaveLength(1)
+    expect(writes[0]?.projected?.fields).toEqual({
+      'def1:primary_email': 'jane@acme.com',
+      'def1:phone': '+15551234567',
+    })
+    // The indexed path is equally the identity-match value.
+    expect(writes[0]?.projected?.identityCandidates).toEqual([
+      { targetFieldRef: 'def1:phone', value: '+15551234567', normalize: 'phone' },
+    ])
+  })
+
+  it('resolves an indexed path to undefined (no write) when the array is empty or short', () => {
+    const m = mapping({
+      fieldMappings: [
+        {
+          id: 'e1',
+          targetFieldRef: toResourceFieldId('def1', 'email'),
+          expression: '{emails[0].value}',
+          sourceFields: { 'emails[0].value': 'emails[0].value' },
+        },
+        {
+          id: 'e2',
+          targetFieldRef: toResourceFieldId('def1', 'second_phone'),
+          expression: '{phoneNumbers[1].value}',
+          sourceFields: { 'phoneNumbers[1].value': 'phoneNumbers[1].value' },
+        },
+        {
+          id: 'e3',
+          // Not an array at all → undefined, never a partial object.
+          targetFieldRef: toResourceFieldId('def1', 'bogus'),
+          expression: '{company[0].value}',
+          sourceFields: { 'company[0].value': 'company[0].value' },
+        },
+      ],
+    })
+
+    // Quo really does return `emails: []` on most contacts (verified live).
+    const writes = mapRecord(
+      [m],
+      source({ emails: [], phoneNumbers: [{ value: '+15551234567' }], company: 'Acme' })
+    )
+
+    // Blank, not array-shaped — the values evaluate to undefined and the multi-field
+    // write path skips blanks rather than clearing (`entity-sink.ts`).
+    expect(writes[0]?.projected?.fields).toEqual({
+      'def1:email': undefined,
+      'def1:second_phone': undefined,
+      'def1:bogus': undefined,
+    })
+  })
+
+  it('still no-writes a BARE array path — indexing did not weaken the array guard', () => {
+    // The guard that must survive: `emails` (no index) is array-shaped, so the
+    // binding is dropped entirely. Sourcing it would flatten to null and CLEAR the
+    // target. Only the explicitly indexed sibling resolves.
+    const m = mapping({
+      rootPath: 'defaultFields',
+      fieldMappings: [
+        {
+          id: 'bare',
+          targetFieldRef: toResourceFieldId('def1', 'primary_email'),
+          expression: '{emails}',
+          sourceFields: { emails: 'emails' },
+        },
+        {
+          id: 'indexed',
+          targetFieldRef: toResourceFieldId('def1', 'phone'),
+          expression: '{phoneNumbers[0].value}',
+          sourceFields: { 'phoneNumbers[0].value': 'phoneNumbers[0].value' },
+        },
+      ],
+    })
+
+    const writes = mapRecord(
+      [m],
+      source({
+        defaultFields: {
+          emails: [{ value: 'jane@acme.com' }],
+          phoneNumbers: [{ value: '+15551234567' }],
+        },
+      })
+    )
+
+    expect(writes[0]?.projected?.fields).toEqual({ 'def1:phone': '+15551234567' })
+    expect(writes[0]?.projected?.fields).not.toHaveProperty('def1:primary_email')
+  })
+
   it('drops the degenerate whole-subtree `{source}` binding when the subtree is an array', () => {
     const m = mapping({
       id: 'tags',

--- a/packages/lib/src/data-connectors/map-record.ts
+++ b/packages/lib/src/data-connectors/map-record.ts
@@ -48,13 +48,43 @@ export interface MappedWrite {
   } | null
 }
 
-/** Walk a dotted path into a value. '' / undefined → the whole record. */
+/** A path segment carrying an explicit array index — `emails[0]`, or a bare `[0]`. */
+const INDEXED_SEGMENT = /^(.*?)\[(\d+)\]$/
+
+/**
+ * Walk a dotted path into a value. '' / undefined → the whole record.
+ *
+ * A segment may carry an explicit array INDEX (`emails[0]`, or a bare `[0]` to index
+ * the current value): providers that expose a labelled list where the target field is
+ * a scalar — Quo's `defaultFields.emails[0].value` / `phoneNumbers[0].value` — are
+ * addressed this way. Both call sites already route `[`-carrying paths here
+ * ({@link evaluateFieldValue}, {@link hasArrayShapedSource}); this is the parser they
+ * were written against.
+ *
+ * Indexing is deliberately narrow: it resolves ONE element. A non-array at an indexed
+ * segment, or a missing element, resolves `undefined` — never a partial object. And a
+ * BARE array path (`emails`, no index) still resolves the array itself, so
+ * {@link hasArrayShapedSource}'s no-write guard keeps firing on it: sourcing a whole
+ * array into a scalar binding stays out of scope (B1), because the CALC evaluator
+ * flattens it to `null` and a `null` write CLEARS the target.
+ *
+ * `foo[]` (the fan-out selector consumed by {@link extractSubtrees}) has no digits and
+ * so never matches here.
+ */
 function getByPath(obj: unknown, path: string): unknown {
   if (!path) return obj
   let cur: unknown = obj
-  for (const key of path.split('.')) {
-    if (cur === null || cur === undefined || typeof cur !== 'object') return undefined
-    cur = (cur as Record<string, unknown>)[key]
+  for (const segment of path.split('.')) {
+    const indexed = INDEXED_SEGMENT.exec(segment)
+    const key = indexed ? (indexed[1] ?? '') : segment
+    if (key !== '') {
+      if (cur === null || cur === undefined || typeof cur !== 'object') return undefined
+      cur = (cur as Record<string, unknown>)[key]
+    }
+    if (indexed) {
+      if (!Array.isArray(cur)) return undefined
+      cur = cur[Number(indexed[2] ?? '0')]
+    }
   }
   return cur
 }

--- a/packages/lib/src/data-connectors/templates/connector-template-registry.ts
+++ b/packages/lib/src/data-connectors/templates/connector-template-registry.ts
@@ -3,12 +3,75 @@
 // indexes them by id, and validates at import time — mirroring
 // `entity-templates/template-registry.ts`. Templates are open presets: each
 // seeds a normal, fully-editable `generic-rest` connector.
+//
+// ── `defs/quo.json` design notes ─────────────────────────────────────────────
+// Quo (formerly OpenPhone) contacts. JSON carries no comments, so the decisions
+// behind that template live here:
+//
+// • CREDENTIAL SHARING — `connection.providerKey: 'openphone'` binds to the SAME
+//   seeded ConnectionDefinition the SMS channel uses (the key stays `openphone`;
+//   the rename to Quo is labels-only). Connecting Quo once serves both consumers.
+//   `authScheme: 'bearer'` works as-is — verified live that Quo accepts
+//   `Authorization: Bearer <key>`, so this depends on no channel-side change.
+//
+// • TWO WRITERS INTO `@system:contact` — the channel's own ingest also creates
+//   contacts from inbound SMS, so identity matching carries all the weight here.
+//   `match: {normalize:'phone'}` on the phone binding must agree with the ingest
+//   side's `Participant.identifier` E.164 form, or the same person lands twice.
+//   The in-flight `dedup/` + duplicate-suggestion work is exactly this problem —
+//   the two writers should be tested TOGETHER, not in isolation.
+//
+// • FIRST VALUE ONLY — Quo exposes no scalar email/phone; both are arrays of
+//   labelled entries, addressed with `defaultFields.emails[0].value` (the indexed
+//   `getByPath` syntax in `map-record.ts`). Contact phone went multi-value E.164
+//   in #1629 but the connector write path is scalar, so a Quo contact with three
+//   numbers lands ONE. Accepted for v1; the rest are not silently dropped so much
+//   as not yet reachable — landing them needs a multi-value source path.
+//
+// • NO INCREMENTAL / NO BACKFILL WINDOW — verified live that `/v1/contacts`
+//   silently IGNORES `updatedAfter` / `createdAfter` / `since` (unknown params are
+//   ignored, not rejected). There is no delta filter to declare, so every run is a
+//   full snapshot crawl. Do not invent a `sinceParam`: it would be a lie in config
+//   that changes nothing on the wire.
+//
+// • PAGING TERMINATES ON `nextPageToken` ALONE — deliberately no `hasMorePath`.
+//   `totalItems` is PER-PAGE, not a grand total (`?maxResults=2` returns
+//   `totalItems: 2` *with* a next token). `maxResults` hard-caps at 50 (400 above
+//   it), so this is ~2x the requests of a Stripe-sized address book.
+//
+// • NULL SOURCES OVERWRITE — a template binding has no `mergeStrategy` knob, so
+//   contributing writes land on the sink's `overwrite` default. Multi-value fields
+//   (`primary_email`, `phone`) are protected — the sink never writes blank over a
+//   multi field — but a SCALAR target is cleared when Quo's value is null. That is
+//   why `defaultFields.role` → `job_title` is NOT mapped: 24 of 25 live contacts
+//   have `role: null`, so mapping it would blank a human-entered job title on every
+//   run. `Quo Company` is safe by contrast: it is the connector's OWN provisioned
+//   field, so mirroring null is correct rather than destructive. The same hazard
+//   applies on a smaller surface to the name bindings — a Quo contact with neither
+//   name blanks both — which is the price of mapping them at all; revisit if
+//   templates ever gain `mergeStrategy: 'fill_blank'`.
+//
+// • NAMES BIND TO `first_name` / `last_name`, NOT `full_name`. Both are creatable/
+//   updatable system attributes on contact (`resources/registry/resources/
+//   contact-fields.ts`), hidden from the panel in favour of the computed name
+//   field, which they drive. Quo hands us the two halves already split, so binding
+//   them directly is lossless — composing `full_name` and letting the sink split it
+//   back on whitespace would turn "Mary Jo Van Dyke" into first "Mary" /
+//   last "Jo Van Dyke".
+//
+// • `customFields[]` is deliberately unmapped — a typed union needing its own pass.
+// ─────────────────────────────────────────────────────────────────────────────
 
 import githubTemplate from './defs/github.json'
+import quoTemplate from './defs/quo.json'
 import stripeTemplate from './defs/stripe.json'
 import type { ConnectorTemplate, ConnectorTemplateSummary } from './types'
 
-const allTemplates: ConnectorTemplate[] = [stripeTemplate, githubTemplate] as ConnectorTemplate[]
+const allTemplates: ConnectorTemplate[] = [
+  stripeTemplate,
+  githubTemplate,
+  quoTemplate,
+] as ConnectorTemplate[]
 
 /** All templates indexed by id. */
 const templateMap = new Map<string, ConnectorTemplate>()

--- a/packages/lib/src/data-connectors/templates/defs/quo.json
+++ b/packages/lib/src/data-connectors/templates/defs/quo.json
@@ -1,0 +1,131 @@
+{
+  "id": "quo",
+  "name": "Quo Contacts",
+  "description": "Sync your Quo (formerly OpenPhone) address book into contacts. Bind the same Quo API key the SMS channel uses — connect once, both share the credential.",
+  "categories": ["communication", "crm"],
+  "iconKey": "message-square",
+  "requiresConnection": true,
+  "connection": {
+    "providerKey": "openphone",
+    "authScheme": "bearer",
+    "docsUrl": "https://quo.com/docs"
+  },
+  "config": {
+    "endpoint": {
+      "baseUrl": "https://api.quo.com/v1",
+      "auth": "credential"
+    }
+  },
+  "streams": [
+    {
+      "streamKey": "contacts",
+      "syncMode": "snapshot",
+      "requestConfig": {
+        "path": "/contacts",
+        "method": "GET",
+        "pagination": {
+          "kind": "cursor",
+          "cursorFrom": "response",
+          "cursorPath": "nextPageToken",
+          "cursorParam": "pageToken",
+          "recordsPath": "data",
+          "limitParam": "maxResults",
+          "pageSize": 50
+        }
+      },
+      "mappings": [
+        {
+          "rootPath": "data[]",
+          "linkMode": "upsert",
+          "target": { "mode": "contributing", "entityRef": "@system:contact" },
+          "fields": [
+            { "key": "first_name", "source": "defaultFields.firstName" },
+            { "key": "last_name", "source": "defaultFields.lastName" },
+            { "key": "primary_email", "source": "defaultFields.emails[0].value" },
+            {
+              "key": "phone",
+              "source": "defaultFields.phoneNumbers[0].value",
+              "match": { "normalize": "phone" }
+            },
+            {
+              "key": "Quo Company",
+              "source": "defaultFields.company",
+              "provision": { "type": "TEXT" }
+            },
+            {
+              "key": "Quo Contact ID",
+              "source": "id",
+              "provision": { "type": "TEXT", "isHidden": true }
+            }
+          ]
+        }
+      ],
+      "sourceSchema": {
+        "type": "object",
+        "properties": {
+          "totalItems": { "type": "number" },
+          "nextPageToken": { "type": "string" },
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "externalId": { "type": "string" },
+                "source": { "type": "string" },
+                "sourceUrl": { "type": "string" },
+                "createdAt": { "type": "string" },
+                "updatedAt": { "type": "string" },
+                "createdByUserId": { "type": "string" },
+                "defaultFields": {
+                  "type": "object",
+                  "properties": {
+                    "firstName": { "type": "string" },
+                    "lastName": { "type": "string" },
+                    "company": { "type": "string" },
+                    "role": { "type": "string" },
+                    "emails": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string" },
+                          "name": { "type": "string" },
+                          "value": { "type": "string" }
+                        }
+                      }
+                    },
+                    "phoneNumbers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string" },
+                          "name": { "type": "string" },
+                          "value": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                },
+                "customFields": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": { "type": "string" },
+                      "name": { "type": "string" },
+                      "key": { "type": "string" },
+                      "type": { "type": "string" },
+                      "value": {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/lib/src/ingest/store-message.ts
+++ b/packages/lib/src/ingest/store-message.ts
@@ -580,6 +580,14 @@ export async function storeMessage(
       const messageRecords = await tx
         .insert(schema.Message)
         .values({
+          // The idempotency key. Without it every row lands with `externalId = NULL`,
+          // Postgres treats those as distinct in the unique index below, and the
+          // `onConflictDoUpdate` target can never match — so the upsert silently
+          // degrades into an insert. Email masks this because the internetMessageId
+          // reconcile above catches the redelivery first; SMS carries no
+          // Message-ID, so for Quo this is the ONLY dedupe and every webhook retry
+          // or backfill re-run would duplicate the message.
+          externalId: messageData.externalId,
           externalThreadId: messageData.externalThreadId,
           threadId: thread.id,
           organizationId: messageData.organizationId,

--- a/packages/lib/src/jobs/messages/sync-all-messages-job.ts
+++ b/packages/lib/src/jobs/messages/sync-all-messages-job.ts
@@ -91,6 +91,10 @@ export const startMessageSyncJob = async (ctx: JobContext<StartMessageSyncJobDat
         and(
           eq(schema.Integration.organizationId, organizationId),
           eq(schema.Integration.enabled, true),
+          // `openphone` (Quo) stays registered: its `syncMessages` now drives the capped
+          // conversation backfill (enumerate a bounded window → sort by lastActivityAt DESC →
+          // cap at N → one `/v1/messages` call per conversation). The first run performs the
+          // resumable initial backfill; later runs are incremental off `since`.
           inArray(schema.Integration.provider, [
             'google',
             'outlook',

--- a/packages/lib/src/providers/__tests__/provider-capabilities.test.ts
+++ b/packages/lib/src/providers/__tests__/provider-capabilities.test.ts
@@ -251,7 +251,7 @@ describe('Provider Capabilities', () => {
     })
 
     it('OpenPhone should have extended capabilities', () => {
-      expect(openPhoneCapabilities.metadata?.maxMessageLength).toBe(160)
+      expect(openPhoneCapabilities.metadata?.maxMessageLength).toBe(1600) // Quo accepts 1600 chars; 160 is the GSM segment size
       expect(openPhoneCapabilities.metadata?.supportsUnicode).toBe(true)
     })
   })

--- a/packages/lib/src/providers/__tests__/provider-channel.test.ts
+++ b/packages/lib/src/providers/__tests__/provider-channel.test.ts
@@ -175,7 +175,7 @@ describe('Provider Integration Tests', () => {
       expect(openphoneCapabilities.canDraft).toBe(false) // SMS is immediate
       expect(openphoneCapabilities.canApplyLabel).toBe(false) // No labels in SMS
       expect(openphoneCapabilities.canScheduleSend).toBe(true) // Business SMS
-      expect(openphoneCapabilities.metadata?.maxMessageLength).toBe(160)
+      expect(openphoneCapabilities.metadata?.maxMessageLength).toBe(1600) // Quo accepts 1600 chars; 160 is the GSM segment size
       expect(openphoneCapabilities.metadata?.supportsUnicode).toBe(true)
     })
 
@@ -407,7 +407,7 @@ describe('Provider Integration Tests', () => {
       expect(openphoneCaps.canApplyLabel).toBe(false)
       expect(openphoneCaps.canAttachFiles).toBe(false) // SMS limitation
       expect(openphoneCaps.canScheduleSend).toBe(true)
-      expect(openphoneCaps.metadata?.maxMessageLength).toBe(160)
+      expect(openphoneCaps.metadata?.maxMessageLength).toBe(1600) // Quo accepts 1600 chars; 160 is the GSM segment size
       expect(openphoneCaps.metadata?.supportsUnicode).toBe(true)
     })
   })

--- a/packages/lib/src/providers/openphone/__tests__/openphone-provider.test.ts
+++ b/packages/lib/src/providers/openphone/__tests__/openphone-provider.test.ts
@@ -1,0 +1,409 @@
+// packages/lib/src/providers/openphone/__tests__/openphone-provider.test.ts
+//
+// Covers the three things the Quo rewrite can get silently wrong:
+//   1. `setupWebhook` must persist BOTH the webhook id (Integration.metadata) and the signing
+//      key Quo mints (Credential secret field `webhookSigningSecret`) — merged, never clobbering
+//      the stored `apiKey` — and only flip the webhook to `enabled` once both are stored.
+//   2. The capped backfill must sort by `lastActivityAt` DESC. The server orders by `createdAt`
+//      DESC, so an old-but-active conversation is exactly what a naive implementation drops.
+//   3. The REST mapper must read `text` / `to[]` (the webhook says `body` / `to: string`) and
+//      must not ingest a media-only MMS as an empty message.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { OpenPhoneProvider } from '../openphone-provider'
+
+const mocks = vi.hoisted(() => {
+  const updateWhere = vi.fn().mockResolvedValue(undefined)
+  const updateSet = vi.fn().mockReturnValue({ where: updateWhere })
+  const update = vi.fn().mockReturnValue({ set: updateSet })
+  return {
+    update,
+    updateSet,
+    updateWhere,
+    mergeSecretFields: vi.fn(),
+    createMessageWebhook: vi.fn(),
+    updateWebhookStatus: vi.fn(),
+    deleteWebhook: vi.fn(),
+    sendMessage: vi.fn(),
+    listConversations: vi.fn(),
+    listMessages: vi.fn(),
+  }
+})
+
+// Partial mock: the chainable proxy still backs every builder the rest of the module graph
+// touches at import time (see `src/test/database-mock.ts`), and the schema proxy auto-vivifies
+// every table. Only `update` is pinned to a spy so this suite can assert on the jsonb-merge
+// writes without the rest of the import graph dying at collection.
+vi.mock('@auxx/database', async () => {
+  const { createChainableDatabaseMock, createSchemaMock } = await import(
+    '../../../test/database-mock'
+  )
+  const database = new Proxy(createChainableDatabaseMock(), {
+    get: (target: any, prop: string) => {
+      if (prop === 'update') return mocks.update
+      return target[prop]
+    },
+  })
+  return {
+    database,
+    schema: createSchemaMock({
+      Integration: { id: 'Integration.id', metadata: 'Integration.metadata' },
+    }),
+  }
+})
+
+// Partial mock: silence log output without replacing the rest of the barrel.
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('@auxx/credentials/store', () => ({
+  mergeSecretFields: mocks.mergeSecretFields,
+  revealSecrets: vi.fn(),
+}))
+
+// The Quo client is a thin local wrapper around `fetch`; stubbing it is what keeps this suite
+// off the network while still exercising every request shape the provider builds.
+vi.mock('../api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../api')>()),
+  createMessageWebhook: mocks.createMessageWebhook,
+  updateWebhookStatus: mocks.updateWebhookStatus,
+  deleteWebhook: mocks.deleteWebhook,
+  sendMessage: mocks.sendMessage,
+  listConversations: mocks.listConversations,
+  listMessages: mocks.listMessages,
+}))
+
+const CALLBACK_URL = 'https://app.test/api/openphone/webhook'
+const PHONE_NUMBER_ID = 'PN0eLoM7TQ'
+const PHONE_NUMBER = '+18889155797'
+
+function makeProvider(metadata: Record<string, unknown> = {}) {
+  const provider = new OpenPhoneProvider('org_1')
+  const self = provider as any
+  self.integrationId = 'int_1'
+  self.apiKey = 'quo_key'
+  self.credentialId = 'cred_1'
+  self.phoneNumberId = PHONE_NUMBER_ID
+  self.phoneNumber = PHONE_NUMBER
+  self.metadata = { phoneNumberId: PHONE_NUMBER_ID, phoneNumber: PHONE_NUMBER, ...metadata }
+  self.storageService = {
+    setIntegrationSettings: vi.fn(),
+    setBackfillCutoff: vi.fn(),
+    batchStoreMessages: vi.fn().mockResolvedValue(0),
+  }
+  return provider
+}
+
+/** Walks a drizzle `sql\`...\`` template's chunks for an interpolated value. */
+function sqlContains(sqlChunk: any, value: string): boolean {
+  if (!sqlChunk || typeof sqlChunk !== 'object' || !Array.isArray(sqlChunk.queryChunks))
+    return false
+  return sqlChunk.queryChunks.some((chunk: any) => {
+    if (typeof chunk === 'string') return chunk.includes(value)
+    if (chunk && typeof chunk === 'object' && Array.isArray(chunk.value)) {
+      return chunk.value.some((v: unknown) => typeof v === 'string' && v.includes(value))
+    }
+    if (chunk && typeof chunk === 'object' && typeof chunk.value === 'string') {
+      return chunk.value.includes(value)
+    }
+    return false
+  })
+}
+
+function conversation(overrides: Record<string, unknown>) {
+  return {
+    id: 'CN1',
+    phoneNumberId: PHONE_NUMBER_ID,
+    participants: ['+13109531695'],
+    name: null,
+    assignedTo: null,
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:00.000Z',
+    lastActivityAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.mergeSecretFields.mockResolvedValue({ isErr: () => false })
+  mocks.listMessages.mockResolvedValue({ data: [], nextPageToken: null })
+})
+
+describe('OpenPhoneProvider.setupWebhook', () => {
+  it('creates a disabled webhook, persists id + key, then enables it', async () => {
+    const provider = makeProvider()
+    mocks.createMessageWebhook.mockResolvedValue({
+      id: 'WH_new',
+      key: 'c2lnbmluZy1rZXk=',
+      status: 'disabled',
+    })
+
+    await provider.setupWebhook(CALLBACK_URL)
+
+    const body = mocks.createMessageWebhook.mock.calls[0]![1]
+    expect(body.url).toBe(CALLBACK_URL)
+    expect(body.events).toEqual(['message.received', 'message.delivered'])
+    // Per-number, not `["*"]` — one channel owns one webhook.
+    expect(body.resourceIds).toEqual([PHONE_NUMBER_ID])
+    // Created disabled so a half-provisioned channel never receives unverifiable traffic.
+    expect(body.status).toBe('disabled')
+
+    // The signing key is merged onto the Credential's secret bag, keyed exactly as the webhook
+    // route's `resolveWebhookSecret({ kind: 'credentialField', field: 'webhookSigningSecret' })`.
+    expect(mocks.mergeSecretFields).toHaveBeenCalledWith('cred_1', 'org_1', {
+      webhookSigningSecret: 'c2lnbmluZy1rZXk=',
+    })
+    // MERGE, not replace: only the one field is written, so the stored apiKey survives.
+    const mergedFields = mocks.mergeSecretFields.mock.calls[0]![2]
+    expect(Object.keys(mergedFields)).toEqual(['webhookSigningSecret'])
+    expect(mergedFields).not.toHaveProperty('apiKey')
+
+    // The webhook id lands on Integration.metadata as a jsonb merge, not a whole-object replace.
+    expect(mocks.update).toHaveBeenCalledTimes(1)
+    const setArg = mocks.updateSet.mock.calls[0]![0]
+    expect(sqlContains(setArg.metadata, 'WH_new')).toBe(true)
+    expect(sqlContains(setArg.metadata, 'webhookId')).toBe(true)
+
+    // Enabled last, after both id and key are stored.
+    expect(mocks.updateWebhookStatus).toHaveBeenCalledWith('quo_key', 'WH_new', 'enabled')
+    const enableOrder = mocks.updateWebhookStatus.mock.invocationCallOrder[0]!
+    expect(mocks.mergeSecretFields.mock.invocationCallOrder[0]!).toBeLessThan(enableOrder)
+    expect(mocks.update.mock.invocationCallOrder[0]!).toBeLessThan(enableOrder)
+  })
+
+  it('deletes the stored webhook before re-arming so only one stays live', async () => {
+    const provider = makeProvider({ webhookId: 'WH_old' })
+    mocks.deleteWebhook.mockResolvedValue(undefined)
+    mocks.createMessageWebhook.mockResolvedValue({ id: 'WH_new', key: 'a2V5', status: 'disabled' })
+
+    await provider.setupWebhook(CALLBACK_URL)
+
+    expect(mocks.deleteWebhook).toHaveBeenCalledWith('quo_key', 'WH_old')
+    expect(mocks.deleteWebhook.mock.invocationCallOrder[0]!).toBeLessThan(
+      mocks.createMessageWebhook.mock.invocationCallOrder[0]!
+    )
+  })
+
+  it('rolls the webhook back when the signing key cannot be stored', async () => {
+    const provider = makeProvider()
+    mocks.createMessageWebhook.mockResolvedValue({ id: 'WH_orphan', key: 'a2V5' })
+    mocks.mergeSecretFields.mockResolvedValue({
+      isErr: () => true,
+      error: { message: 'credential gone' },
+    })
+
+    await expect(provider.setupWebhook(CALLBACK_URL)).rejects.toThrow(/credential gone/)
+
+    // Never enabled, and torn back down — an orphan live webhook we cannot verify is worse
+    // than no webhook at all.
+    expect(mocks.updateWebhookStatus).not.toHaveBeenCalled()
+    expect(mocks.deleteWebhook).toHaveBeenCalledWith('quo_key', 'WH_orphan')
+  })
+})
+
+describe('OpenPhoneProvider.syncMessages — capped backfill', () => {
+  it('sorts by lastActivityAt DESC (not the server createdAt order) and caps at the limit', async () => {
+    const provider = makeProvider({ backfillConversationLimit: 2 })
+    // Server order is `createdAt` DESC. `CN_old_active` was created first (so it is LAST in the
+    // server's order) but received a message yesterday — the exact row a naive "take the first
+    // N pages" implementation drops.
+    mocks.listConversations.mockResolvedValue({
+      data: [
+        conversation({
+          id: 'CN_new_quiet',
+          createdAt: '2026-08-10T00:00:00.000Z',
+          lastActivityAt: '2026-08-10T00:00:00.000Z',
+          participants: ['+13100000001'],
+        }),
+        conversation({
+          id: 'CN_mid',
+          createdAt: '2026-08-05T00:00:00.000Z',
+          lastActivityAt: '2026-08-12T00:00:00.000Z',
+          participants: ['+13100000002'],
+        }),
+        conversation({
+          id: 'CN_old_active',
+          createdAt: '2025-03-01T00:00:00.000Z',
+          lastActivityAt: '2026-08-14T00:00:00.000Z',
+          participants: ['+13100000003'],
+        }),
+      ],
+      nextPageToken: null,
+    })
+
+    await provider.syncMessages()
+
+    const fetched = mocks.listMessages.mock.calls.map((call) => call[1].participants[0])
+    // Top two by lastActivityAt, most recent first. CN_new_quiet is cut by the cap.
+    expect(fetched).toEqual(['+13100000003', '+13100000002'])
+
+    // The scope params keep each endpoint's own convention: bracketed E.164 on
+    // /v1/conversations, the singular `PN…` id plus bare participants on /v1/messages.
+    expect(mocks.listConversations.mock.calls[0]![1].phoneNumber).toBe(PHONE_NUMBER)
+    expect(mocks.listMessages.mock.calls[0]![1].phoneNumberId).toBe(PHONE_NUMBER_ID)
+  })
+
+  it('stamps initialBackfillCompletedAt on success and lifts the ingest cutoff', async () => {
+    const provider = makeProvider({ backfillConversationLimit: 1 })
+    mocks.listConversations.mockResolvedValue({ data: [conversation({})], nextPageToken: null })
+
+    await provider.syncMessages()
+
+    const metadataWrites = mocks.updateSet.mock.calls
+      .map((call) => call[0].metadata)
+      .filter(Boolean)
+    expect(metadataWrites.some((m: any) => sqlContains(m, 'initialBackfillCompletedAt'))).toBe(true)
+    expect(metadataWrites.some((m: any) => sqlContains(m, 'backfill'))).toBe(true)
+    expect((provider as any).storageService.setBackfillCutoff).toHaveBeenCalledWith(null)
+
+    // lastSyncedAt is only stamped on the success path.
+    expect(mocks.updateSet.mock.calls.some((call) => call[0].lastSyncedAt instanceof Date)).toBe(
+      true
+    )
+  })
+
+  it('does not stamp lastSyncedAt when the run fails', async () => {
+    const provider = makeProvider({ backfillConversationLimit: 1 })
+    mocks.listConversations.mockRejectedValue(new Error('Quo API error (500): boom'))
+
+    await expect(provider.syncMessages()).rejects.toThrow('boom')
+
+    expect(mocks.updateSet.mock.calls.some((call) => call[0].lastSyncedAt instanceof Date)).toBe(
+      false
+    )
+  })
+
+  it('terminates paging on nextPageToken alone (totalItems is per-page)', async () => {
+    const provider = makeProvider({ backfillConversationLimit: 500 })
+    mocks.listConversations
+      .mockResolvedValueOnce({
+        data: [conversation({ id: 'CN1' })],
+        totalItems: 1,
+        nextPageToken: 'page2',
+      })
+      .mockResolvedValueOnce({
+        data: [conversation({ id: 'CN2', participants: ['+13100000009'] })],
+        totalItems: 1,
+        nextPageToken: null,
+      })
+      .mockResolvedValue({ data: [], nextPageToken: null })
+
+    await provider.syncMessages()
+
+    expect(mocks.listConversations.mock.calls[1]![1].pageToken).toBe('page2')
+    expect(mocks.listMessages).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('OpenPhoneProvider REST message mapping', () => {
+  const conv = conversation({ id: 'CNx', participants: ['+13109531695'] })
+
+  function mapOne(message: Record<string, unknown>) {
+    const provider = makeProvider()
+    return (provider as any).mapRestMessageToMessageData(message, conv)
+  }
+
+  it('reads `text` and the `to` ARRAY (the webhook shape would read undefined)', () => {
+    const mapped = mapOne({
+      id: 'AC1',
+      to: ['+13109531695', '+13109531696'],
+      from: PHONE_NUMBER,
+      text: 'hello there',
+      direction: 'outgoing',
+      status: 'delivered',
+      createdAt: '2026-08-15T00:12:25.083Z',
+      phoneNumberId: PHONE_NUMBER_ID,
+      conversationId: 'CNx',
+    })
+
+    expect(mapped.textPlain).toBe('hello there')
+    expect(mapped.to.map((p: any) => p.identifier)).toEqual(['+13109531695', '+13109531696'])
+    expect(mapped.from.identifier).toBe(PHONE_NUMBER)
+    expect(mapped.isInbound).toBe(false)
+    expect(mapped.externalId).toBe('AC1')
+    expect(mapped.externalThreadId).toBe('CNx')
+    expect(mapped.subject).toBeUndefined()
+    // No attachment ingestor and no media on REST — claiming true fires attachment rules for
+    // bytes that were never fetched.
+    expect(mapped.hasAttachments).toBe(false)
+  })
+
+  it('maps `direction: "incoming"` (not "inbound") to isInbound', () => {
+    const mapped = mapOne({
+      id: 'AC2',
+      to: [PHONE_NUMBER],
+      from: '+13109531695',
+      text: 'inbound text',
+      direction: 'incoming',
+      status: 'received',
+      createdAt: '2026-08-15T00:12:25.083Z',
+      phoneNumberId: PHONE_NUMBER_ID,
+      conversationId: 'CNx',
+    })
+
+    expect(mapped.isInbound).toBe(true)
+    expect(mapped.receivedAt.toISOString()).toBe('2026-08-15T00:12:25.083Z')
+  })
+
+  it('placeholders an empty-text message rather than ingesting a blank bubble', () => {
+    const mapped = mapOne({
+      id: 'AC3',
+      to: [PHONE_NUMBER],
+      from: '+13109531695',
+      text: '',
+      direction: 'incoming',
+      status: 'received',
+      createdAt: '2026-08-15T00:12:25.083Z',
+      phoneNumberId: PHONE_NUMBER_ID,
+      conversationId: 'CNx',
+    })
+
+    expect(mapped.textPlain).toBe('[media — not available via backfill]')
+    expect(mapped.snippet).toBe('[media — not available via backfill]')
+  })
+})
+
+describe('OpenPhoneProvider.sendMessage', () => {
+  it('sends `{ content, from, to[] }` and passes multiple recipients through', async () => {
+    const provider = makeProvider()
+    mocks.sendMessage.mockResolvedValue({ id: 'AC_sent' })
+
+    const result = await provider.sendMessage({
+      from: PHONE_NUMBER,
+      to: ['+13100000001', '+13100000002'],
+      text: 'hi',
+    })
+
+    expect(result).toEqual({ id: 'AC_sent', success: true })
+    expect(mocks.sendMessage).toHaveBeenCalledWith('quo_key', {
+      content: 'hi',
+      from: PHONE_NUMBER,
+      to: ['+13100000001', '+13100000002'],
+    })
+  })
+
+  it('truncates explicitly at Quo’s 10-recipient ceiling', async () => {
+    const provider = makeProvider()
+    mocks.sendMessage.mockResolvedValue({ id: 'AC_sent' })
+    const recipients = Array.from({ length: 12 }, (_, i) => `+1310000000${i}`)
+
+    await provider.sendMessage({ from: PHONE_NUMBER, to: recipients, text: 'hi' })
+
+    expect(mocks.sendMessage.mock.calls[0]![1].to).toHaveLength(10)
+  })
+})
+
+describe('OpenPhoneProvider.getThread', () => {
+  it('is a no-op — GET /v1/conversations/{id} does not exist', async () => {
+    const provider = makeProvider()
+    await expect(provider.getThread('CNx')).resolves.toBeNull()
+  })
+})

--- a/packages/lib/src/providers/openphone/api.ts
+++ b/packages/lib/src/providers/openphone/api.ts
@@ -1,0 +1,287 @@
+// packages/lib/src/providers/openphone/api.ts
+// The one place that talks to Quo (formerly OpenPhone) over the wire. Every other file goes
+// through these functions — no hand-rolled fetches.
+//
+// Base is `https://api.quo.com/v1`. The old `api.openphone.co/v3` host does not resolve at all;
+// `api.openphone.com/v1` still aliases but is not what we point at.
+//
+// Auth: `Authorization: <apiKey>` — raw, matching Quo's docs ("does not use a Bearer token").
+// Verified live that a `Bearer ` prefix is also accepted, so either form works; we send the
+// documented one.
+
+import { createScopedLogger } from '@auxx/logger'
+import type {
+  QuoConversation,
+  QuoCreateMessageWebhookInput,
+  QuoPhoneNumber,
+  QuoRestMessage,
+  QuoSendMessageInput,
+  QuoWebhook,
+} from './types'
+
+const logger = createScopedLogger('quo-api')
+
+export const QUO_API_BASE = 'https://api.quo.com/v1'
+
+/**
+ * Quo's documented ceiling is 10 requests/second per API key. We pace at 8 to leave headroom;
+ * measured latency is ~195ms/request, so a serial caller never reaches this anyway — the pacer
+ * matters when a backfill runs a small amount of concurrency.
+ */
+const MAX_REQUESTS_PER_SECOND = 8
+const MIN_INTERVAL_MS = Math.ceil(1000 / MAX_REQUESTS_PER_SECOND)
+const MAX_RETRIES_ON_429 = 3
+
+/** An error carrying the HTTP status plus whatever message Quo returned. */
+export class QuoApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body?: unknown
+  ) {
+    super(message)
+    this.name = 'QuoApiError'
+  }
+}
+
+/**
+ * Per-API-key pacing. The rate limit is per key, not per number, so three channels backfilling
+ * concurrently share one budget — keying the pacer on the key is what keeps them from 429ing
+ * each other.
+ */
+const nextSlotByKey = new Map<string, number>()
+
+async function acquireSlot(apiKey: string): Promise<void> {
+  const now = Date.now()
+  const earliest = nextSlotByKey.get(apiKey) ?? 0
+  const slot = Math.max(now, earliest)
+  nextSlotByKey.set(apiKey, slot + MIN_INTERVAL_MS)
+  const wait = slot - now
+  if (wait > 0) await sleep(wait)
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function buildQuery(query?: QueryValue): string {
+  if (!query) return ''
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null) continue
+    // Repeated bare keys — `/v1/messages` rejects `participants[]=` and `participants[0]=`
+    // in any bracketed form. Callers that need brackets put them in the key themselves.
+    if (Array.isArray(value)) {
+      for (const item of value) params.append(key, String(item))
+    } else {
+      params.append(key, String(value))
+    }
+  }
+  const qs = params.toString()
+  return qs ? `?${qs}` : ''
+}
+
+type QueryValue = Record<string, string | number | boolean | string[] | undefined | null>
+
+/** Issue one paced, retry-on-429 request against the Quo API. */
+async function quoFetch<T>(
+  apiKey: string,
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
+  path: string,
+  opts: { query?: QueryValue; body?: unknown } = {}
+): Promise<T> {
+  const url = `${QUO_API_BASE}${path}${buildQuery(opts.query)}`
+
+  for (let attempt = 0; ; attempt++) {
+    await acquireSlot(apiKey)
+
+    let response: Response
+    try {
+      response = await fetch(url, {
+        method,
+        headers: {
+          Authorization: apiKey,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      logger.error('Quo API network error', { method, path, error: message })
+      throw new QuoApiError(`Failed to reach the Quo API: ${message}`, 0)
+    }
+
+    if (response.status === 429 && attempt < MAX_RETRIES_ON_429) {
+      const retryAfter = Number(response.headers.get('retry-after'))
+      const waitMs = Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : 1000
+      logger.warn('Quo API rate limited; backing off', { method, path, waitMs, attempt })
+      await sleep(waitMs)
+      continue
+    }
+
+    // 204 (webhook delete) has no body.
+    if (response.status === 204) return undefined as T
+
+    const raw = await response.text()
+    let parsed: unknown
+    try {
+      parsed = raw ? JSON.parse(raw) : undefined
+    } catch {
+      parsed = raw
+    }
+
+    if (!response.ok) {
+      const message = extractErrorMessage(parsed) ?? `HTTP error ${response.status}`
+      logger.error('Quo API error', { method, path, status: response.status, message })
+      throw new QuoApiError(
+        `Quo API error (${response.status}): ${message}`,
+        response.status,
+        parsed
+      )
+    }
+
+    return parsed as T
+  }
+}
+
+function extractErrorMessage(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') return typeof body === 'string' ? body : undefined
+  const bag = body as { message?: unknown; error?: unknown }
+  if (typeof bag.message === 'string') return bag.message
+  if (typeof bag.error === 'string') return bag.error
+  if (bag.error && typeof bag.error === 'object') {
+    const inner = (bag.error as { message?: unknown }).message
+    if (typeof inner === 'string') return inner
+  }
+  return undefined
+}
+
+/** Standard Quo list envelope. `totalItems` is per-page — never use it to terminate a loop. */
+interface QuoList<T> {
+  data: T[]
+  totalItems?: number
+  nextPageToken?: string | null
+}
+
+/** `GET /v1/phone-numbers` — every number on the workspace this API key belongs to. */
+export async function listPhoneNumbers(apiKey: string): Promise<QuoPhoneNumber[]> {
+  const result = await quoFetch<QuoList<QuoPhoneNumber>>(apiKey, 'GET', '/phone-numbers')
+  return result.data ?? []
+}
+
+/**
+ * `POST /v1/messages` — send an SMS.
+ * `from` is the E.164 number or `PN…` id; `to` accepts 1–10 recipients.
+ */
+export async function sendMessage(
+  apiKey: string,
+  input: QuoSendMessageInput
+): Promise<QuoRestMessage> {
+  const result = await quoFetch<{ data: QuoRestMessage }>(apiKey, 'POST', '/messages', {
+    body: input,
+  })
+  return result.data
+}
+
+/**
+ * `POST /v1/webhooks/messages` — create a message webhook scoped to specific numbers.
+ * The response carries `key`, the HMAC signing secret; Quo only hands it out here.
+ */
+export async function createMessageWebhook(
+  apiKey: string,
+  input: QuoCreateMessageWebhookInput
+): Promise<QuoWebhook> {
+  const result = await quoFetch<{ data: QuoWebhook }>(apiKey, 'POST', '/webhooks/messages', {
+    body: input,
+  })
+  return result.data
+}
+
+/** `PATCH /v1/webhooks/{id}` — used to flip a freshly created webhook from disabled to enabled. */
+export async function updateWebhookStatus(
+  apiKey: string,
+  webhookId: string,
+  status: 'enabled' | 'disabled'
+): Promise<QuoWebhook> {
+  const result = await quoFetch<{ data: QuoWebhook }>(
+    apiKey,
+    'PATCH',
+    `/webhooks/${encodeURIComponent(webhookId)}`,
+    { body: { status } }
+  )
+  return result.data
+}
+
+/** `DELETE /v1/webhooks/{id}` → 204. */
+export async function deleteWebhook(apiKey: string, webhookId: string): Promise<void> {
+  await quoFetch<void>(apiKey, 'DELETE', `/webhooks/${encodeURIComponent(webhookId)}`)
+}
+
+/** `GET /v1/webhooks` — returns each webhook's `key` in plaintext. */
+export async function listWebhooks(apiKey: string): Promise<QuoWebhook[]> {
+  const result = await quoFetch<QuoList<QuoWebhook>>(apiKey, 'GET', '/webhooks')
+  return result.data ?? []
+}
+
+/**
+ * `GET /v1/conversations` — one page.
+ *
+ * Scope is the bracketed `phoneNumbers[]=+1888…` (E.164, not the `PN…` id — that is the
+ * `/v1/messages` convention). Supports `createdAfter`/`createdBefore`/`updatedAfter`/
+ * `updatedBefore`; unknown params are silently ignored rather than rejected.
+ *
+ * ⚠️ Results are ordered by `createdAt` DESCENDING, **not** by `lastActivityAt`. Never
+ * implement "page until older than the watermark" against activity time.
+ */
+export async function listConversations(
+  apiKey: string,
+  params: {
+    phoneNumber: string
+    maxResults?: number
+    pageToken?: string
+    createdAfter?: string
+    createdBefore?: string
+    updatedAfter?: string
+    updatedBefore?: string
+  }
+): Promise<QuoList<QuoConversation>> {
+  const { phoneNumber, maxResults, ...rest } = params
+  // Spread `rest` BEFORE the explicit keys — spreading it after would re-write `maxResults`
+  // with its own (possibly undefined) value and silently drop the default.
+  return quoFetch<QuoList<QuoConversation>>(apiKey, 'GET', '/conversations', {
+    query: { ...rest, 'phoneNumbers[]': phoneNumber, maxResults: maxResults ?? 50 },
+  })
+}
+
+/**
+ * `GET /v1/messages` — one page of messages for an exact participant set.
+ *
+ * `phoneNumberId` (the `PN…` id, singular) is REQUIRED, and `participants` must be repeated
+ * bare keys — every bracketed form is rejected with `"/participants: Expected array"`. The
+ * match is exact-set, not OR, so this is one call per conversation with no batching.
+ *
+ * Messages come back with `text`/`to[]` (see QuoRestMessage) and NEVER carry media.
+ */
+export async function listMessages(
+  apiKey: string,
+  params: {
+    phoneNumberId: string
+    participants: string[]
+    maxResults?: number
+    pageToken?: string
+    createdAfter?: string
+    createdBefore?: string
+  }
+): Promise<QuoList<QuoRestMessage>> {
+  return quoFetch<QuoList<QuoRestMessage>>(apiKey, 'GET', '/messages', {
+    query: {
+      phoneNumberId: params.phoneNumberId,
+      participants: params.participants,
+      maxResults: params.maxResults ?? 50,
+      pageToken: params.pageToken,
+      createdAfter: params.createdAfter,
+      createdBefore: params.createdBefore,
+    },
+  })
+}

--- a/packages/lib/src/providers/openphone/openphone-provider.ts
+++ b/packages/lib/src/providers/openphone/openphone-provider.ts
@@ -1,57 +1,140 @@
 // packages/lib/src/providers/openphone/openphone-provider.ts
+// The Quo (formerly OpenPhone) SMS channel provider.
+//
+// Every network call goes through `./api` (base `https://api.quo.com/v1`). The old
+// `https://api.openphone.co/v3` host this file used to point at does not resolve at all, so the
+// hand-rolled `apiCall` it carried is gone — there is exactly one wire seam now.
+//
+// The provider key stays `openphone` everywhere it is persisted (IntegrationProviderType,
+// Credential.type, Integration.provider, /api/openphone/webhook). This is a labels-only rename.
 
-import { revealSecrets } from '@auxx/credentials/store'
+import { mergeSecretFields, revealSecrets } from '@auxx/credentials/store'
 import { database as db, schema } from '@auxx/database'
 import { IntegrationProviderType } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import {
   type IntegrationSettings, // Per-integration record-creation/filter settings
   type MessageData,
   MessageStorageService,
   type ParticipantInputData,
-} from '../../email/email-storage' // Adjust path
+} from '../../email/email-storage'
 import type {
   ChannelProvider,
-  MessageStatus, // Note: Most statuses don't map directly to OpenPhone
+  MessageStatus, // Note: Most statuses don't map directly to Quo
   SendMessageOptions,
-} from '../channel-provider.interface' // Adjust path
+} from '../channel-provider.interface'
 import { BaseMessageProvider, type MessageProvider } from '../message-provider-interface'
 import { getProviderCapabilities, type ProviderCapabilities } from '../provider-capabilities'
-import type {
-  OpenPhoneConversation,
-  OpenPhoneIntegrationMetadata,
-  OpenPhoneMessage,
-  OpenPhoneSendMessagePayload,
-} from './types' // Import types
+import {
+  createMessageWebhook,
+  deleteWebhook,
+  listConversations,
+  listMessages,
+  QuoApiError,
+  sendMessage as sendQuoMessage,
+  updateWebhookStatus,
+} from './api'
+import type { OpenPhoneIntegrationMetadata, QuoConversation, QuoRestMessage } from './types'
 
 const logger = createScopedLogger('openphone-provider')
-const OPENPHONE_API_BASE = 'https://api.openphone.co/v3' // Use v3
+
+/** `POST /v1/messages` accepts 1–10 recipients. More than that is truncated, loudly. */
+const MAX_RECIPIENTS_PER_MESSAGE = 10
+
+/** `maxResults` caps at 50 on both list endpoints — there is no larger page size. */
+const CONVERSATION_PAGE_SIZE = 50
+const MESSAGE_PAGE_SIZE = 50
+
+/**
+ * Cap on how many conversations one channel (one number) backfills. Per channel, not per
+ * workspace: a shared cap would starve low-traffic numbers. Overridable per channel via
+ * `Integration.metadata.backfillConversationLimit`.
+ */
+const DEFAULT_BACKFILL_CONVERSATION_LIMIT = 2000
+
+/**
+ * Bound on the per-conversation message walk. One call covers a conversation up to 50 messages;
+ * this caps the pathological long-running thread at 500 rather than letting a single
+ * conversation dominate the run.
+ */
+const MAX_MESSAGE_PAGES_PER_CONVERSATION = 10
+
+/**
+ * The expanding window used to bound enumeration (plan §6.2). `null` means "no lower bound".
+ * Successive windows are enumerated as *rings* (`updatedAfter=w[i]` AND `updatedBefore=w[i-1]`),
+ * so each conversation is fetched exactly once no matter how many windows we walk.
+ */
+const BACKFILL_WINDOW_MONTHS: Array<number | null> = [1, 3, 6, 12, 24, null]
+
+/** Persist backfill progress every N conversations — 80 writes for a 2,000-conversation run. */
+const BACKFILL_PROGRESS_WRITE_EVERY = 25
+
+/**
+ * REST never returns media — not on the list endpoint, not on `GET /v1/messages/{id}`. A
+ * media-only MMS backfills as `text: ""` with *nothing* indicating an attachment ever existed,
+ * so the placeholder can only be generic. Ingesting those silently as empty renders blank
+ * bubbles that are indistinguishable from a bug, which is the worse option.
+ */
+const MEDIA_PLACEHOLDER = '[media — not available via backfill]'
+
+/**
+ * Resumable backfill state, stored on `Integration.metadata.backfill`.
+ *
+ * Deliberately small: the pinned `windowStart` plus a cursor, not the 2,000-entry conversation
+ * list. Resuming re-enumerates the SAME window (bounded, ~80 requests) and re-sorts, then
+ * resumes after `lastConversationId`. A conversation whose activity bumps mid-run may be
+ * re-fetched (harmless — `storeMessage` dedupes on `externalId`) or, if it jumps ahead of the
+ * cursor, skipped — but a bump means a live webhook already delivered that message.
+ */
+interface QuoBackfillState {
+  startedAt: string
+  /** ISO `updatedAfter` bound of the chosen window; `null` = no lower bound (all history). */
+  windowStart: string | null
+  completedConversations: number
+  lastConversationId?: string | null
+  completedAt?: string | null
+}
+
+interface QuoIntegrationMetadata extends OpenPhoneIntegrationMetadata {
+  settings?: IntegrationSettings
+  backfill?: QuoBackfillState
+  backfillConversationLimit?: number
+  backfillCutoffAt?: string
+  initialBackfillCompletedAt?: string
+}
+
+function monthsAgoIso(months: number): string {
+  const date = new Date()
+  date.setMonth(date.getMonth() - months)
+  return date.toISOString()
+}
+
 export class OpenPhoneProvider
   extends BaseMessageProvider
   implements ChannelProvider, MessageProvider
 {
-  private metadata: OpenPhoneIntegrationMetadata | null = null
-  private apiKey: string | null = null // The actual API key
+  private metadata: QuoIntegrationMetadata | null = null
+  private apiKey: string | null = null
+  private credentialId: string | null = null
   private phoneNumberId: string | null = null
-  private phoneNumber: string | null = null // E.164 format
+  private phoneNumber: string | null = null // E.164
   private storageService: MessageStorageService
+
   constructor(organizationId: string) {
     super(IntegrationProviderType.openphone, '', organizationId)
     this.storageService = new MessageStorageService(organizationId)
   }
-  /**
-   * Get provider capabilities for OpenPhone
-   */
+
+  /** Get provider capabilities for Quo. */
   getCapabilities(): ProviderCapabilities {
     return getProviderCapabilities(IntegrationProviderType.openphone)
   }
-  /**
-   * Initializes the provider with data from the integration record.
-   */
+
+  /** Initializes the provider with data from the integration record. */
   async initialize(integrationId: string): Promise<void> {
     logger.info(`Initializing OpenPhoneProvider for integration: ${integrationId}`)
-    ;(this as any).integrationId = integrationId
+    this.integrationId = integrationId
     const [integration] = await db
       .select()
       .from(schema.Integration)
@@ -70,15 +153,14 @@ export class OpenPhoneProvider
     ) {
       this.resetState()
       throw new Error(
-        `Active OpenPhone integration not found, not enabled, or missing metadata for ID: ${integrationId}`
+        `Active Quo integration not found, not enabled, or missing metadata for ID: ${integrationId}`
       )
     }
-    // Get the API key from the linked Credential. As a multi-field secret connection, the apiKey is
-    // stored under the credential's `secrets.fields` bag (not `accessToken`), so read it directly via
-    // the store rather than getChannelTokens (which serves the oauth `accessToken` shape).
+    // The apiKey lives on the linked Credential's multi-field secret bag (`secrets.fields`), not
+    // on `accessToken` — read it through the store rather than getChannelTokens.
     if (!integration.credentialId) {
       this.resetState()
-      throw new Error(`Missing credential for OpenPhone integration ID: ${integrationId}`)
+      throw new Error(`Missing credential for Quo integration ID: ${integrationId}`)
     }
     const revealed = await revealSecrets<{ fields?: Record<string, string> }>(
       integration.credentialId,
@@ -87,46 +169,52 @@ export class OpenPhoneProvider
     const apiKey = revealed.isOk() ? revealed.value.secrets.fields?.apiKey : undefined
     if (!apiKey) {
       this.resetState()
-      throw new Error(`Missing API key for OpenPhone integration ID: ${integrationId}`)
+      throw new Error(`Missing API key for Quo integration ID: ${integrationId}`)
     }
     this.apiKey = apiKey
-    try {
-      this.metadata = integration.metadata as unknown as OpenPhoneIntegrationMetadata
-      this.phoneNumberId = this.metadata.phoneNumberId
-      this.phoneNumber = this.metadata.phoneNumber
-      if (!this.phoneNumberId || !this.phoneNumber) {
-        throw new Error('Essential metadata (phoneNumberId, phoneNumber) missing.')
-      }
-    } catch (e) {
+    this.credentialId = integration.credentialId
+
+    const metadata = integration.metadata as unknown as QuoIntegrationMetadata
+    this.metadata = metadata
+    this.phoneNumberId = metadata.phoneNumberId
+    this.phoneNumber = metadata.phoneNumber
+    if (!this.phoneNumberId || !this.phoneNumber) {
       this.resetState()
-      logger.error('Failed to parse metadata for OpenPhone integration', {
+      logger.error('Quo integration metadata is missing phoneNumberId / phoneNumber', {
         integrationId,
-        metadata: integration.metadata,
-        error: e,
       })
-      throw new Error(`Invalid metadata format for OpenPhone integration ${integrationId}`)
+      throw new Error(`Invalid metadata format for Quo integration ${integrationId}`)
     }
-    // Pass integration settings to storage service (they live in metadata)
-    const settings = (integration.metadata as { settings?: IntegrationSettings }).settings
-    if (settings) {
-      this.storageService.setIntegrationSettings(settings)
-      logger.info('Integration settings loaded for selective mode', {
-        integrationId,
-        hasSettings: true,
-      })
+
+    // Channel settings live under `Integration.metadata.settings`.
+    if (metadata.settings) {
+      this.storageService.setIntegrationSettings(metadata.settings)
     }
+
+    // Received-time trigger cutoff: while the initial backfill is incomplete, ingest suppresses
+    // `message:received` for messages received before the connect epoch. The stamp itself is
+    // written by the provisioning hook; this is the consumption side.
+    this.storageService.setBackfillCutoff(
+      metadata.backfillCutoffAt && !metadata.initialBackfillCompletedAt
+        ? new Date(metadata.backfillCutoffAt)
+        : null
+    )
+
     logger.info(
-      `OpenphoneProvider initialized successfully for Number: ${this.phoneNumber} (ID: ${this.phoneNumberId})`,
+      `OpenPhoneProvider initialized successfully for Number: ${this.phoneNumber} (ID: ${this.phoneNumberId})`,
       { integrationId }
     )
   }
+
   private resetState(): void {
     this.integrationId = null
     this.metadata = null
     this.apiKey = null
+    this.credentialId = null
     this.phoneNumberId = null
     this.phoneNumber = null
   }
+
   private async ensureInitialized(): Promise<void> {
     if (
       !this.integrationId ||
@@ -136,442 +224,689 @@ export class OpenPhoneProvider
       !this.metadata
     ) {
       if (this.integrationId) {
-        logger.warn(`Re-initializing OpenPhone provider for ${this.integrationId}`)
+        logger.warn(`Re-initializing Quo provider for ${this.integrationId}`)
         await this.initialize(this.integrationId)
       } else {
         throw new Error('OpenPhoneProvider not initialized with an integration ID.')
       }
     }
   }
-  /** Makes an authenticated API call to OpenPhone */
-  private async apiCall<T = any>(
-    method: 'GET' | 'POST' | 'PUT' | 'DELETE',
-    endpoint: string, // e.g., /messages
-    payload?: any
-  ): Promise<T> {
-    await this.ensureInitialized()
-    const url = `${OPENPHONE_API_BASE}${endpoint}`
-    const headers: HeadersInit = {
-      Authorization: `Bearer ${this.apiKey}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-      'User-Agent': 'AuxxOpenPhoneProvider/1.0',
-    }
-    const options: RequestInit = {
-      method: method,
-      headers: headers,
-      body: payload ? JSON.stringify(payload) : undefined,
-    }
-    logger.debug(`OpenPhone API Call: ${method} ${url}`, {
-      payload: method !== 'GET' ? payload : undefined,
-    })
-    try {
-      const response = await fetch(url, options)
-      const responseBody = await response.json() // Assume JSON response
-      if (!response.ok) {
-        logger.error(`OpenPhone API Error (${response.status}): ${method} ${url}`, {
-          status: response.status,
-          errorBody: responseBody,
-        })
-        // Attempt to extract a meaningful error message
-        const errorMessage =
-          responseBody?.message || responseBody?.error || `HTTP error ${response.status}`
-        throw new Error(`OpenPhone API Error: ${errorMessage}`)
-      }
-      logger.debug(`OpenPhone API Success: ${method} ${url}`, { status: response.status })
-      return responseBody as T
-    } catch (error: any) {
-      logger.error(`OpenPhone API Fetch Error: ${method} ${url}`, { error: error.message })
-      // Rethrow network or parsing errors
-      throw new Error(`Failed to call OpenPhone API: ${error.message}`)
-    }
-  }
+
+  // -------------------------------------------------------------------------
+  // Outbound
+  // -------------------------------------------------------------------------
+
   /**
-   * Sends an SMS message via OpenPhone.
+   * Sends an SMS via `POST /v1/messages`.
+   *
+   * The wire shape is `{ content, from, to: string[] }` — `from` takes the E.164 number (or the
+   * `PN…` id; `phoneNumberId` is deprecated) and `to` is an ARRAY of 1–10 recipients. Group SMS
+   * therefore works: recipients are passed through rather than truncated to the first one.
    */
-  async sendMessage(options: SendMessageOptions): Promise<{
-    id?: string
-    success: boolean
-  }> {
+  async sendMessage(options: SendMessageOptions): Promise<{ id?: string; success: boolean }> {
     await this.ensureInitialized()
-    // Validate 'to' is a single phone number string
-    const recipientPhoneNumber = Array.isArray(options.to) ? options.to[0] : options.to
-    if (!recipientPhoneNumber || typeof recipientPhoneNumber !== 'string') {
+
+    const requested = (Array.isArray(options.to) ? options.to : [options.to])
+      .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+      .map((value) => value.trim())
+    if (requested.length === 0) {
       throw new Error(
-        "Recipient phone number (E.164 format) is required in 'to' field for OpenPhone messages."
+        "At least one recipient phone number (E.164) is required in 'to' for Quo messages."
       )
     }
     if (!options.text) {
-      throw new Error('Message body (text) is required for OpenPhone SMS.')
+      throw new Error('Message body (text) is required for a Quo SMS.')
     }
-    const payload: OpenPhoneSendMessagePayload = {
-      phone_number_id: this.phoneNumberId!,
-      to: recipientPhoneNumber,
-      body: options.text,
-      // TODO: Handle attachments from options.attachmentIds if needed
-    }
-    try {
-      const response = await this.apiCall<{
-        id: string
-      }>('POST', '/messages', payload)
-      logger.info('OpenPhone SMS sent successfully', {
-        messageId: response.id,
-        to: recipientPhoneNumber,
-      })
-      return { id: response.id, success: true }
-    } catch (error: any) {
-      logger.error('Error sending OpenPhone SMS:', {
-        error: error.message,
-        to: recipientPhoneNumber,
+
+    let recipients = requested
+    if (recipients.length > MAX_RECIPIENTS_PER_MESSAGE) {
+      logger.warn('Quo accepts at most 10 recipients per message — truncating', {
+        requested: recipients.length,
+        kept: MAX_RECIPIENTS_PER_MESSAGE,
         integrationId: this.integrationId,
       })
-      // Don't rethrow sensitive API errors directly to user in tRPC? Maybe.
-      // For now, rethrow to indicate failure clearly.
+      recipients = recipients.slice(0, MAX_RECIPIENTS_PER_MESSAGE)
+    }
+
+    try {
+      const sent = await sendQuoMessage(this.apiKey!, {
+        content: options.text,
+        from: this.phoneNumber!,
+        to: recipients,
+      })
+      logger.info('Quo SMS sent successfully', {
+        messageId: sent.id,
+        recipients: recipients.length,
+        integrationId: this.integrationId,
+      })
+      return { id: sent.id, success: true }
+    } catch (error: any) {
+      logger.error('Error sending Quo SMS', {
+        error: error?.message,
+        recipients: recipients.length,
+        integrationId: this.integrationId,
+      })
       throw error
     }
   }
+
+  // -------------------------------------------------------------------------
+  // Webhooks
+  // -------------------------------------------------------------------------
+
   /**
-   * No-op. Quo (OpenPhone) webhooks are configured manually in the Quo dashboard (the user pastes
-   * the signing secret at connect time); we do not API-create them. Kept to satisfy the
-   * `ChannelProvider` interface.
+   * Arms a `message.received` / `message.delivered` webhook scoped to this channel's number.
+   *
+   * ```
+   * POST /v1/webhooks/messages
+   * { url, events, resourceIds: [PN…], label, status: 'disabled' }
+   *   → { data: { id: 'WH…', key: '<base64 32 bytes>' } }
+   * PATCH /v1/webhooks/{id} { status: 'enabled' }   ← only after id + key are persisted
+   * ```
+   *
+   * Two properties of the create call, both verified live, shape this:
+   * - **Quo mints and returns the signing key** on create, so nobody has to paste it into the
+   *   connect form. It is merged onto the Credential's secret bag as `webhookSigningSecret` —
+   *   exactly the field the webhook route reveals via
+   *   `resolveWebhookSecret({ kind: 'credentialField', field: 'webhookSigningSecret' })`.
+   *   `mergeSecretFields` merges, so the stored `apiKey` is never clobbered.
+   * - **The URL is not reachability-checked**, so there is no ordering dependency on our
+   *   endpoint being live — this works in dev without a tunnel already running.
+   *
+   * Creating `disabled` and enabling last means a half-provisioned channel (webhook created but
+   * the key not yet stored) never receives traffic it could not verify.
+   *
+   * **Idempotency: delete-then-recreate.** Re-arming with a stored `webhookId` deletes the old
+   * webhook first, because (a) the callback URL changes between dev tunnels and Quo documents no
+   * PATCH for `url`, and (b) the alternative — reusing the stored id — would leave a webhook
+   * pointing at a dead URL live on the workspace. Deleting first guarantees at most one live
+   * webhook per number, which is what makes teardown on disconnect unambiguous.
    */
-  async setupWebhook(_callbackUrl: string): Promise<void> {
-    logger.debug('setupWebhook is a no-op for OpenPhone (webhook configured manually in Quo).')
+  async setupWebhook(callbackUrl: string): Promise<void> {
+    await this.ensureInitialized()
+
+    const existingWebhookId = this.metadata?.webhookId
+    if (existingWebhookId) {
+      logger.info('Replacing existing Quo webhook before re-arming', {
+        webhookId: existingWebhookId,
+        integrationId: this.integrationId,
+      })
+      await this.deleteWebhookTolerantly(existingWebhookId)
+    }
+
+    const created = await createMessageWebhook(this.apiKey!, {
+      url: callbackUrl,
+      events: ['message.received', 'message.delivered'],
+      // Per-number rather than `["*"]`: it matches the one-channel-one-webhook model the rest of
+      // the code assumes and makes teardown on disconnect unambiguous.
+      resourceIds: [this.phoneNumberId!],
+      label: `Auxx.ai — ${this.phoneNumber}`,
+      status: 'disabled',
+    })
+
+    try {
+      if (!created.key) {
+        throw new Error('Quo did not return a signing key for the created webhook')
+      }
+      const merged = await mergeSecretFields(this.credentialId!, this.organizationId, {
+        webhookSigningSecret: created.key,
+      })
+      if (merged.isErr()) {
+        throw new Error(`Failed to store the Quo webhook signing secret: ${merged.error.message}`)
+      }
+
+      // jsonb merge, not a whole-object replace — a concurrent write (settings, backfill
+      // progress) must not be wiped by stale in-memory metadata.
+      await db
+        .update(schema.Integration)
+        .set({
+          metadata: sql`COALESCE(${schema.Integration.metadata}, '{}'::jsonb) || jsonb_build_object('webhookId', ${created.id}::text)`,
+        })
+        .where(eq(schema.Integration.id, this.integrationId!))
+      if (this.metadata) this.metadata.webhookId = created.id
+
+      // Only now is the channel able to verify what Quo sends.
+      await updateWebhookStatus(this.apiKey!, created.id, 'enabled')
+
+      logger.info('Quo webhook armed', {
+        webhookId: created.id,
+        phoneNumberId: this.phoneNumberId,
+        integrationId: this.integrationId,
+      })
+    } catch (error: any) {
+      // The webhook exists Quo-side but we could not persist (or enable) it. Leaving it would
+      // orphan a webhook nobody owns, so tear it back down before surfacing the failure.
+      logger.error('Failed to finish arming the Quo webhook — rolling back', {
+        error: error?.message,
+        webhookId: created.id,
+        integrationId: this.integrationId,
+      })
+      await this.deleteWebhookTolerantly(created.id)
+      throw error
+    }
   }
-  /**
-   * Removes the configured webhook via API.
-   */
+
+  /** Removes the configured webhook. `DELETE /v1/webhooks/{id}` → 204. */
   async removeWebhook(): Promise<void> {
     await this.ensureInitialized()
     const webhookId = this.metadata?.webhookId
     if (!webhookId) {
-      logger.warn('No stored OpenPhone webhook ID found to remove.', {
+      logger.warn('No stored Quo webhook ID found to remove.', {
         integrationId: this.integrationId,
       })
-      // Try listing webhooks and finding by URL? Complex. Assume stored ID is needed.
-      return // Nothing to remove if ID isn't known
+      return
     }
+
+    const removed = await this.deleteWebhookTolerantly(webhookId)
+    if (!removed) return // non-404 failure: keep the stored id so a retry can still find it
+
+    await db
+      .update(schema.Integration)
+      .set({
+        metadata: sql`COALESCE(${schema.Integration.metadata}, '{}'::jsonb) - 'webhookId'`,
+      })
+      .where(eq(schema.Integration.id, this.integrationId!))
+      .catch((dbErr) => logger.error('Failed to clear webhookId after webhook delete', { dbErr }))
+    if (this.metadata) this.metadata.webhookId = undefined
+  }
+
+  /**
+   * `DELETE /v1/webhooks/{id}`, treating a 404 as success (already gone). Returns false only
+   * when the webhook may still be live, so callers know not to forget its id.
+   */
+  private async deleteWebhookTolerantly(webhookId: string): Promise<boolean> {
     try {
-      logger.info(`Attempting to delete OpenPhone webhook: ${webhookId}`)
-      await this.apiCall('DELETE', `/webhooks/${webhookId}`)
-      logger.info('OpenPhone webhook deleted successfully.', { webhookId })
-      // Clear stored webhook ID from metadata
-      const updatedMetadata = { ...this.metadata, webhookId: undefined }
-      delete updatedMetadata.webhookId // Explicitly remove the key
-      await db
-        .update(schema.Integration)
-        .set({ metadata: updatedMetadata as any })
-        .where(eq(schema.Integration.id, this.integrationId!))
-      if (this.metadata) {
-        this.metadata.webhookId = undefined
-      } // Update local cache
+      await deleteWebhook(this.apiKey!, webhookId)
+      return true
     } catch (error: any) {
-      // Handle 404 if webhook already deleted
-      if (error.message?.includes('404') || error.message?.includes('not found')) {
-        logger.warn('OpenPhone webhook not found during deletion (might be already deleted).', {
-          webhookId,
-        })
-        // Clear stored ID anyway
-        const updatedMetadata = { ...this.metadata, webhookId: undefined }
-        delete updatedMetadata.webhookId
-        await db
-          .update(schema.Integration)
-          .set({ metadata: updatedMetadata as any })
-          .where(eq(schema.Integration.id, this.integrationId!))
-          .catch((dbErr) => logger.error('Failed to clear webhookId after 404', { dbErr }))
-        if (this.metadata) {
-          this.metadata.webhookId = undefined
-        }
-        return
+      if (error instanceof QuoApiError && error.status === 404) {
+        logger.warn('Quo webhook already gone (404) — treating as deleted', { webhookId })
+        return true
       }
-      logger.error('Error deleting OpenPhone webhook:', {
-        error: error.message,
+      logger.error('Error deleting Quo webhook', {
+        error: error?.message,
         webhookId,
         integrationId: this.integrationId,
       })
-      // Don't necessarily throw during cleanup, but log the error
-      // throw error;
+      return false
     }
   }
+
+  // -------------------------------------------------------------------------
+  // Backfill / sync
+  // -------------------------------------------------------------------------
+
   /**
-   * Synchronizes messages (SMS) from OpenPhone.
+   * Backfills SMS history for this channel's number.
+   *
+   * Two modes, both built on the same ladder — Quo has no "list all messages for this number"
+   * endpoint, so messages can only be reached through their conversation:
+   *
+   * ```
+   * GET /v1/conversations?phoneNumbers[]=+1888…       (E.164, BRACKETED)
+   * GET /v1/messages?phoneNumberId=PN…&participants=… (PN id, REPEATED BARE keys)
+   * ```
+   *
+   * **Initial backfill** (nothing stamped in `metadata.backfill`) uses the bounded
+   * expanding-window algorithm: widen `updatedAfter` through 1/3/6/12/24 months and then "all",
+   * enumerating each step as a *ring* so no conversation is fetched twice, stopping at the first
+   * window holding N candidates and capping enumeration at ~2N rows. Cost is then independent of
+   * workspace size — identical whether the workspace holds 4k conversations or 4M.
+   *
+   * **Incremental** (backfill already completed) passes `since` straight through as
+   * `updatedAfter` / `createdAfter`.
+   *
+   * Traps this respects, all verified live:
+   * - Server order is `createdAt` DESC, **not** `lastActivityAt` — an old-but-active conversation
+   *   sits thousands of rows deep, so the sort by `lastActivityAt` is done client-side and the
+   *   window filter (not the page order) is what bounds the walk.
+   * - `totalItems` is per-page; termination is on `nextPageToken` alone.
+   * - `updatedAt` ≠ `lastActivityAt` — `updatedAfter` also moves on assignment/mute/snooze/read.
+   *   It is a superset trigger: safe as a bound (no false negatives), but a hit does not mean
+   *   there are new messages.
+   * - Unknown query params are silently ignored, so a 200 never proves a filter worked.
+   * - `excludeInactive` is unverified and deliberately unused.
+   *
+   * `lastSyncedAt` is stamped on **success only**. The previous implementation stamped it in the
+   * catch block too, which made a channel that had never ingested anything look healthy.
    */
   async syncMessages(since?: Date): Promise<void> {
     await this.ensureInitialized()
-    logger.info('Starting OpenPhone message sync', {
+
+    const limit = this.backfillConversationLimit()
+    const state = this.metadata?.backfill
+    const isInitialBackfill = !state?.completedAt
+
+    logger.info('Starting Quo message sync', {
       phoneNumber: this.phoneNumber,
+      mode: isInitialBackfill ? 'initial-backfill' : 'incremental',
       since: since?.toISOString(),
+      limit,
       integrationId: this.integrationId,
     })
-    try {
-      let pageToken: string | undefined
-      let hasMore = true
-      let totalMessagesProcessed = 0
-      // OpenPhone Conversation API returns latest message. We might need full history per convo.
-      // Let's start by syncing conversations and storing the latest message.
-      // A separate job might be needed for historical backfill per conversation.
-      while (hasMore) {
-        const params = new URLSearchParams()
-        params.append('limit', '100') // Max limit
-        if (pageToken) {
-          params.append('pageToken', pageToken)
+
+    if (isInitialBackfill) {
+      await this.runInitialBackfill(limit, state)
+    } else {
+      await this.runIncrementalSync(since, limit)
+    }
+
+    await db
+      .update(schema.Integration)
+      .set({ lastSyncedAt: new Date() })
+      .where(eq(schema.Integration.id, this.integrationId!))
+  }
+
+  private backfillConversationLimit(): number {
+    const configured = this.metadata?.backfillConversationLimit
+    return typeof configured === 'number' && configured > 0
+      ? Math.floor(configured)
+      : DEFAULT_BACKFILL_CONVERSATION_LIMIT
+  }
+
+  /** Capped, resumable first-connect backfill (plan §6.2). */
+  private async runInitialBackfill(
+    limit: number,
+    resumeFrom: QuoBackfillState | undefined
+  ): Promise<void> {
+    // A resumed run pins the window it started with, so the candidate set does not drift.
+    const candidates = resumeFrom
+      ? {
+          conversations: await this.enumerateConversations({
+            updatedAfter: resumeFrom.windowStart ?? undefined,
+            maxRows: limit * 2,
+          }),
+          windowStart: resumeFrom.windowStart,
         }
-        // Note: Filtering conversations by date or phoneNumberId is not directly documented for /conversations list.
-        // We might fetch all accessible by the API key and process relevant ones.
-        const endpoint = `/conversations?${params.toString()}`
-        logger.debug(`Fetching conversations page`, {
-          endpoint: endpoint.split('?')[0],
-          pageToken: pageToken,
-        })
-        const response = await this.apiCall<{
-          data: OpenPhoneConversation[]
-          nextPageToken?: string
-        }>('GET', endpoint)
-        const conversations = response.data || []
-        logger.info(`Fetched ${conversations.length} conversations page.`, { pageToken: pageToken })
-        const messagesToStore: MessageData[] = []
-        for (const conversation of conversations) {
-          // Filter conversations related to our integrated phone number ID
-          if (conversation.phone_number_id !== this.phoneNumberId) {
-            logger.debug(
-              `Skipping conversation ${conversation.id} for different phone number ${conversation.phone_number_id}`
-            )
-            continue
-          }
-          // Process the latest message from the conversation list endpoint
-          if (conversation.latest_message) {
-            // Check if latest message is newer than 'since' date if provided
-            const messageDate = new Date(conversation.latest_message.date_created)
-            if (since && messageDate < since) {
-              logger.debug(
-                `Skipping conversation ${conversation.id} as latest message is older than 'since' date.`
-              )
-              continue // Skip if latest message is too old
-            }
-            const converted = this.convertOpenPhoneMessageToMessageData(
-              conversation.latest_message,
-              conversation // Pass full conversation for context if needed
-            )
-            if (converted) {
-              messagesToStore.push(converted)
-            }
-          }
-          // TODO: Optionally fetch full message history for conversation if needed:
-          // GET /conversations/{conversation.id}/messages
-        }
-        if (messagesToStore.length > 0) {
-          const storedCount = await this.storageService.batchStoreMessages(messagesToStore)
-          totalMessagesProcessed += storedCount
-          logger.info(
-            `Stored ${storedCount}/${messagesToStore.length} latest messages from conversations batch.`,
-            { integrationId: this.integrationId }
-          )
-        }
-        pageToken = response.nextPageToken
-        hasMore = !!pageToken
-      } // End pagination loop
-      await db
-        .update(schema.Integration)
-        .set({ lastSyncedAt: new Date() })
-        .where(eq(schema.Integration.id, this.integrationId!))
-      logger.info(
-        `OpenPhone sync completed. Processed latest messages from conversations. Total stored: ${totalMessagesProcessed}.`,
-        { integrationId: this.integrationId }
-      )
-    } catch (error: any) {
-      logger.error('Error syncing messages from OpenPhone:', {
-        error: error.message,
+      : await this.collectBackfillCandidates(limit)
+
+    const windowStart = candidates.windowStart
+    const conversations = sortByLastActivityDesc(candidates.conversations).slice(0, limit)
+
+    let startIndex = 0
+    if (resumeFrom) {
+      const found = resumeFrom.lastConversationId
+        ? conversations.findIndex((c) => c.id === resumeFrom.lastConversationId)
+        : -1
+      startIndex = found >= 0 ? found + 1 : resumeFrom.completedConversations
+      logger.info('Resuming Quo backfill', {
+        startIndex,
+        total: conversations.length,
         integrationId: this.integrationId,
       })
-      await db
-        .update(schema.Integration)
-        .set({ lastSyncedAt: new Date() })
-        .where(eq(schema.Integration.id, this.integrationId!))
-        .catch((updateErr) =>
-          logger.error('Failed to update lastSyncedAt after sync error', { updateErr })
-        )
-      throw error
     }
+
+    const state: QuoBackfillState = {
+      startedAt: resumeFrom?.startedAt ?? new Date().toISOString(),
+      windowStart,
+      completedConversations: startIndex,
+      lastConversationId: resumeFrom?.lastConversationId ?? null,
+    }
+    await this.writeBackfillState(state)
+
+    for (let index = startIndex; index < conversations.length; index++) {
+      const conversation = conversations[index]!
+      await this.ingestConversation(conversation, { isInitialBackfill: true })
+      state.completedConversations = index + 1
+      state.lastConversationId = conversation.id
+      if (state.completedConversations % BACKFILL_PROGRESS_WRITE_EVERY === 0) {
+        await this.writeBackfillState(state)
+      }
+    }
+
+    state.completedAt = new Date().toISOString()
+    await this.writeBackfillState(state)
+    // Lifting the received-time cutoff is the same signal Gmail/Outlook use — once this is
+    // stamped, `message:received` fires normally again for this channel.
+    await db
+      .update(schema.Integration)
+      .set({
+        metadata: sql`COALESCE(${schema.Integration.metadata}, '{}'::jsonb) || jsonb_build_object('initialBackfillCompletedAt', ${state.completedAt}::text)`,
+      })
+      .where(eq(schema.Integration.id, this.integrationId!))
+    this.storageService.setBackfillCutoff(null)
+
+    logger.info('Quo initial backfill complete', {
+      conversations: conversations.length,
+      windowStart,
+      integrationId: this.integrationId,
+    })
   }
-  /** Converts an OpenPhone message object to our standard MessageData format */
-  private convertOpenPhoneMessageToMessageData(
-    message: OpenPhoneMessage,
-    conversation?: OpenPhoneConversation // Optional conversation context
+
+  /** Incremental pass: `since` becomes the `updatedAfter` / `createdAfter` bound. */
+  private async runIncrementalSync(since: Date | undefined, limit: number): Promise<void> {
+    // `updatedAfter` is a superset trigger, so a 24h floor never misses a conversation that
+    // actually received a message; it just over-collects a few that only changed state.
+    const sinceIso = (since ?? new Date(Date.now() - 24 * 60 * 60 * 1000)).toISOString()
+    const conversations = sortByLastActivityDesc(
+      await this.enumerateConversations({ updatedAfter: sinceIso, maxRows: limit * 2 })
+    ).slice(0, limit)
+
+    for (const conversation of conversations) {
+      await this.ingestConversation(conversation, {
+        isInitialBackfill: false,
+        createdAfter: sinceIso,
+      })
+    }
+
+    logger.info('Quo incremental sync complete', {
+      conversations: conversations.length,
+      since: sinceIso,
+      integrationId: this.integrationId,
+    })
+  }
+
+  /**
+   * Step 1 of §6.2 — the bounded expanding window.
+   *
+   * Each step is enumerated as a ring (`updatedAfter = w[i]`, `updatedBefore = w[i-1]`), so
+   * widening never re-fetches what a narrower window already returned. Enumeration stops at the
+   * first window holding `limit` candidates, or at ~2 × `limit` rows, whichever comes first.
+   */
+  private async collectBackfillCandidates(
+    limit: number
+  ): Promise<{ conversations: QuoConversation[]; windowStart: string | null }> {
+    const collected: QuoConversation[] = []
+    const seen = new Set<string>()
+    let previousStart: string | undefined
+    let windowStart: string | null = null
+
+    for (const months of BACKFILL_WINDOW_MONTHS) {
+      const start = months === null ? undefined : monthsAgoIso(months)
+      const ring = await this.enumerateConversations({
+        updatedAfter: start,
+        updatedBefore: previousStart,
+        maxRows: Math.max(1, limit * 2 - collected.length),
+      })
+      for (const conversation of ring) {
+        if (seen.has(conversation.id)) continue
+        seen.add(conversation.id)
+        collected.push(conversation)
+      }
+      previousStart = start
+      windowStart = start ?? null
+      logger.debug('Quo backfill window probe', {
+        windowMonths: months,
+        ringSize: ring.length,
+        collected: collected.length,
+        integrationId: this.integrationId,
+      })
+      if (collected.length >= limit || months === null) break
+    }
+
+    return { conversations: collected, windowStart }
+  }
+
+  /** Pages `/v1/conversations` to exhaustion (or `maxRows`), terminating on `nextPageToken`. */
+  private async enumerateConversations(params: {
+    updatedAfter?: string
+    updatedBefore?: string
+    maxRows: number
+  }): Promise<QuoConversation[]> {
+    const rows: QuoConversation[] = []
+    let pageToken: string | undefined
+
+    do {
+      const page = await listConversations(this.apiKey!, {
+        phoneNumber: this.phoneNumber!,
+        maxResults: CONVERSATION_PAGE_SIZE,
+        pageToken,
+        updatedAfter: params.updatedAfter,
+        updatedBefore: params.updatedBefore,
+      })
+      rows.push(...(page.data ?? []))
+      // `totalItems` is per-page — `nextPageToken` is the only honest terminator.
+      pageToken = page.nextPageToken ?? undefined
+    } while (pageToken && rows.length < params.maxRows)
+
+    return rows
+  }
+
+  /**
+   * Fetches and stores every message in one conversation.
+   *
+   * `/v1/messages` matches the participant set EXACTLY (two `participants=` values return zero
+   * rows), so this is necessarily one call per conversation with no batching.
+   */
+  private async ingestConversation(
+    conversation: QuoConversation,
+    options: { isInitialBackfill: boolean; createdAfter?: string }
+  ): Promise<void> {
+    const participants = (conversation.participants ?? []).filter(Boolean)
+    if (participants.length === 0) {
+      logger.debug('Skipping Quo conversation with no participants', {
+        conversationId: conversation.id,
+      })
+      return
+    }
+
+    const messages: QuoRestMessage[] = []
+    let pageToken: string | undefined
+    let pages = 0
+
+    try {
+      do {
+        const page = await listMessages(this.apiKey!, {
+          phoneNumberId: this.phoneNumberId!,
+          participants,
+          maxResults: MESSAGE_PAGE_SIZE,
+          pageToken,
+          createdAfter: options.createdAfter,
+        })
+        messages.push(...(page.data ?? []))
+        pageToken = page.nextPageToken ?? undefined
+        pages++
+      } while (pageToken && pages < MAX_MESSAGE_PAGES_PER_CONVERSATION)
+    } catch (error: any) {
+      // One bad conversation must not abort the whole run — the cursor still advances, and a
+      // later incremental pass picks the thread up again.
+      logger.error('Failed to fetch Quo messages for a conversation', {
+        error: error?.message,
+        conversationId: conversation.id,
+        integrationId: this.integrationId,
+      })
+      return
+    }
+
+    const mapped = messages
+      .map((message) => this.mapRestMessageToMessageData(message, conversation))
+      .filter((message): message is MessageData => message !== null)
+    if (mapped.length === 0) return
+
+    await this.storageService.batchStoreMessages(mapped, undefined, options.isInitialBackfill)
+  }
+
+  private async writeBackfillState(state: QuoBackfillState): Promise<void> {
+    await db
+      .update(schema.Integration)
+      .set({
+        metadata: sql`COALESCE(${schema.Integration.metadata}, '{}'::jsonb) || jsonb_build_object('backfill', ${JSON.stringify(state)}::jsonb)`,
+      })
+      .where(eq(schema.Integration.id, this.integrationId!))
+    if (this.metadata) this.metadata.backfill = state
+  }
+
+  /**
+   * Maps a **REST** message (`QuoRestMessage`) into `MessageData`.
+   *
+   * Deliberately separate from the webhook mapper in the ingest route: REST says `text` and
+   * `to: string[]`, the webhook says `body` and `to: string`. A shared type/mapper would read
+   * `undefined` on one of the two paths and silently produce empty messages rather than crash.
+   */
+  private mapRestMessageToMessageData(
+    message: QuoRestMessage,
+    conversation: QuoConversation
   ): MessageData | null {
-    if (!this.integrationId || !this.phoneNumberId || !this.phoneNumber || !this.metadata) {
-      logger.error('Cannot convert message, provider state invalid.')
+    if (!this.integrationId || !this.phoneNumber) {
+      logger.error('Cannot convert Quo message, provider state invalid.')
       return null
     }
     try {
-      const externalId = message.id
-      const externalThreadId = message.conversation_id
-      const createdTime = new Date(message.date_created)
-      const sentAt = message.date_sent ? new Date(message.date_sent) : createdTime // Fallback to created time
-      const receivedAt = message.direction === 'inbound' ? createdTime : sentAt // Received = created for inbound
-      const isInbound = message.direction === 'inbound'
-      // Determine participants (phone numbers)
-      let fromNumber = isInbound ? message.sender_phone_number : this.phoneNumber
-      let toNumber = isInbound ? this.phoneNumber : message.recipient_phone_number
-      // Handle cases where numbers might be missing (though unlikely for SMS)
-      if (!fromNumber) {
-        logger.warn(`Missing sender number for message ${externalId}`)
-        fromNumber = 'unknown_sender'
+      const createdTime = new Date(message.createdAt)
+      const isInbound = message.direction === 'incoming'
+      const fromParticipant: ParticipantInputData = {
+        identifier: message.from || (isInbound ? 'unknown_sender' : this.phoneNumber),
       }
-      if (!toNumber) {
-        logger.warn(`Missing recipient number for message ${externalId}`)
-        toNumber = 'unknown_recipient'
-      }
-      // No name info directly on message sender/recipient. The ingest pipeline derives the
-      // IdentifierType from the integration's provider (openphone -> PHONE), so the raw
-      // identifier is all that is passed here.
-      const fromParticipant: ParticipantInputData = { identifier: fromNumber }
-      const toParticipant: ParticipantInputData = { identifier: toNumber }
-      const messageData: MessageData = {
-        externalId: externalId,
-        externalThreadId: externalThreadId,
+      const recipients = (message.to ?? []).filter(Boolean)
+      const toParticipants: ParticipantInputData[] = (
+        recipients.length > 0 ? recipients : [isInbound ? this.phoneNumber : 'unknown_recipient']
+      ).map((identifier) => ({ identifier }))
+
+      // REST gives no media signal whatsoever, so an empty body is the only tell that a
+      // media-only MMS existed. Placeholder rather than a blank bubble.
+      const text = message.text?.trim() ? message.text : MEDIA_PLACEHOLDER
+
+      return {
+        externalId: message.id,
+        externalThreadId: message.conversationId ?? conversation.id,
         integrationId: this.integrationId,
         organizationId: this.organizationId,
-        createdTime: createdTime,
-        sentAt: sentAt,
-        receivedAt: receivedAt,
-        subject: undefined, // No subject for SMS
+        createdTime,
+        sentAt: createdTime,
+        receivedAt: createdTime,
+        subject: undefined, // SMS has no subject
         from: fromParticipant,
-        to: [toParticipant],
+        to: toParticipants,
         cc: [],
         bcc: [],
         replyTo: [],
-        // OpenPhone has no inbound attachment ingestor, so no MessageAttachment
-        // rows are ever created and `providerAttachments` is never populated.
-        // `hasAttachments` is a workflow trigger filter (see
-        // workflow-engine/nodes/trigger-nodes/message-received.ts), so claiming
-        // true here fires attachment rules for bytes that were never fetched.
-        // The raw MMS payload — including each attachment's `url` — is retained
-        // in `metadata.openphone_message` for a future backfill.
+        // REST never returns media, and there is no inbound attachment ingestor for this
+        // provider, so no MessageAttachment rows exist. `hasAttachments` is a workflow trigger
+        // filter — claiming true fires attachment rules for bytes that were never fetched.
         hasAttachments: false,
-        textPlain: message.body,
-        snippet: message.body?.substring(0, 100),
-        isInbound: isInbound,
-        metadata: { openphone_message: message, openphone_conversation: conversation }, // Store raw event
+        textPlain: text,
+        snippet: text.substring(0, 100),
+        isInbound,
+        metadata: { quo_message: message, quo_conversation: conversation },
         keywords: [],
         labelIds: [],
-        // Fields from Message model defaults
-        isFirstInThread: false, // Cannot easily determine from single message
-        isAIGenerated: false, // Assume false
+        isFirstInThread: false,
+        isAIGenerated: false,
         internetMessageId: undefined,
         inReplyTo: undefined,
         references: undefined,
         threadIndex: undefined,
         folderId: undefined,
-        // internetHeaders: undefined,
       }
-      return messageData
     } catch (error: any) {
-      logger.error('Error converting OpenPhone message to MessageData', {
-        error: error.message,
+      logger.error('Error converting Quo REST message to MessageData', {
+        error: error?.message,
         messageId: message?.id,
         integrationId: this.integrationId,
       })
       return null
     }
   }
+
   getProviderName(): string {
     return 'openphone'
   }
-  // --- Methods less applicable to OpenPhone ---
+
+  // --- Methods less applicable to Quo ---
+
   async archive(externalId: string, type: 'message' | 'thread'): Promise<boolean> {
-    logger.warn(`'archive' not supported by OpenPhone provider for ${type} ${externalId}.`)
+    logger.warn(`'archive' not supported by the Quo provider for ${type} ${externalId}.`)
     return false
   }
   async markAsSpam(externalId: string, type: 'message' | 'thread'): Promise<boolean> {
-    logger.warn(
-      `'markAsSpam' not supported by OpenPhone provider for ${type} ${externalId}. Consider blocking contact.`
-    )
+    logger.warn(`'markAsSpam' not supported by the Quo provider for ${type} ${externalId}.`)
     return false
   }
   async trash(externalId: string, type: 'message' | 'thread'): Promise<boolean> {
-    logger.warn(`'trash' not supported by OpenPhone provider for ${type} ${externalId}.`)
+    logger.warn(`'trash' not supported by the Quo provider for ${type} ${externalId}.`)
     return false
   }
   async restore(externalId: string, type: 'message' | 'thread'): Promise<boolean> {
-    logger.warn(`'restore' not supported by OpenPhone provider for ${type} ${externalId}.`)
+    logger.warn(`'restore' not supported by the Quo provider for ${type} ${externalId}.`)
     return false
   }
-  async createDraft(options: SendMessageOptions): Promise<{
-    id: string
-    success: boolean
-  }> {
-    logger.warn("'createDraft' not applicable to OpenPhone provider.")
+  async createDraft(_options: SendMessageOptions): Promise<{ id: string; success: boolean }> {
+    logger.warn("'createDraft' not applicable to the Quo provider — Quo has no drafts API.")
     return { id: '', success: false }
   }
-  async updateDraft(draftId: string, options: Partial<SendMessageOptions>): Promise<boolean> {
-    logger.warn("'updateDraft' not applicable to OpenPhone provider.")
+  async updateDraft(_draftId: string, _options: Partial<SendMessageOptions>): Promise<boolean> {
+    logger.warn("'updateDraft' not applicable to the Quo provider.")
     return false
   }
-  async sendDraft(draftId: string): Promise<{
-    id: string
-    success: boolean
-  }> {
-    logger.warn("'sendDraft' not applicable to OpenPhone provider.")
+  async sendDraft(_draftId: string): Promise<{ id: string; success: boolean }> {
+    logger.warn("'sendDraft' not applicable to the Quo provider.")
     return { id: '', success: false }
   }
   async getLabels(): Promise<any[]> {
-    logger.warn("'getLabels' not applicable to OpenPhone provider.")
+    logger.warn("'getLabels' not applicable to the Quo provider.")
     return []
   }
-  async createLabel(options: any): Promise<any> {
-    logger.warn("'createLabel' not applicable to OpenPhone provider.")
+  async createLabel(_options: any): Promise<any> {
+    logger.warn("'createLabel' not applicable to the Quo provider.")
     throw new Error('Not implemented')
   }
-  async updateLabel(labelId: string, options: any): Promise<boolean> {
-    logger.warn("'updateLabel' not applicable to OpenPhone provider.")
+  async updateLabel(_labelId: string, _options: any): Promise<boolean> {
+    logger.warn("'updateLabel' not applicable to the Quo provider.")
     return false
   }
-  async deleteLabel(labelId: string): Promise<boolean> {
-    logger.warn("'deleteLabel' not applicable to OpenPhone provider.")
+  async deleteLabel(_labelId: string): Promise<boolean> {
+    logger.warn("'deleteLabel' not applicable to the Quo provider.")
     return false
   }
   async addLabel(
-    labelId: string,
+    _labelId: string,
     externalId: string,
     type: 'message' | 'thread'
   ): Promise<boolean> {
-    logger.warn(`'addLabel' not applicable to OpenPhone provider for ${type} ${externalId}.`)
+    logger.warn(`'addLabel' not applicable to the Quo provider for ${type} ${externalId}.`)
     return false
   }
   async removeLabel(
-    labelId: string,
+    _labelId: string,
     externalId: string,
     type: 'message' | 'thread'
   ): Promise<boolean> {
-    logger.warn(`'removeLabel' not applicable to OpenPhone provider for ${type} ${externalId}.`)
+    logger.warn(`'removeLabel' not applicable to the Quo provider for ${type} ${externalId}.`)
     return false
   }
+
+  /**
+   * No-op returning null. `GET /v1/conversations/{id}` **does not exist** on Quo (`Cannot GET`) —
+   * only the list endpoint, which would mean paging the whole address book to find one row. The
+   * conversation is already carried on `MessageData.metadata.quo_conversation` at ingest time,
+   * so nothing needs a live single-conversation read.
+   */
   async getThread(externalThreadId: string): Promise<any> {
-    logger.info(`Getting OpenPhone conversation info for: ${externalThreadId}`)
-    try {
-      // GET /conversations/{conversationId}
-      const conversation = await this.apiCall<OpenPhoneConversation>(
-        'GET',
-        `/conversations/${externalThreadId}`
-      )
-      return conversation
-    } catch (error) {
-      logger.error(`Error getting OpenPhone conversation info for ${externalThreadId}`, { error })
-      throw error
-    }
+    logger.info('getThread is a no-op for Quo — there is no single-conversation endpoint.', {
+      externalThreadId,
+      integrationId: this.integrationId,
+    })
+    return null
   }
-  async updateThreadStatus(externalThreadId: string, status: MessageStatus): Promise<boolean> {
-    logger.warn(
-      `'updateThreadStatus' not supported for OpenPhone conversation ${externalThreadId}.`
-    )
+
+  async updateThreadStatus(externalThreadId: string, _status: MessageStatus): Promise<boolean> {
+    logger.warn(`'updateThreadStatus' not supported for Quo conversation ${externalThreadId}.`)
     return false
   }
-  async moveThread(externalThreadId: string, destinationLabelId: string): Promise<boolean> {
-    logger.warn(`'moveThread' not supported for OpenPhone conversation ${externalThreadId}.`)
+  async moveThread(externalThreadId: string, _destinationLabelId: string): Promise<boolean> {
+    logger.warn(`'moveThread' not supported for Quo conversation ${externalThreadId}.`)
     return false
   }
-  async simulateOperation(operation: string, targetId: string, params?: any): Promise<any> {
-    logger.warn('simulateOperation is not implemented for OpenphoneProvider')
+  async simulateOperation(_operation: string, _targetId: string, _params?: any): Promise<any> {
+    logger.warn('simulateOperation is not implemented for the Quo provider')
     return Promise.resolve({ success: false, message: 'Not implemented' })
   }
+}
+
+/**
+ * Step 2 of §6.2 — REQUIRED. The server orders by `createdAt` DESC, so a conversation opened in
+ * March that received a message yesterday sits thousands of rows deep. Sorting client-side by
+ * `lastActivityAt` is the only way "the N most recently active conversations" means that.
+ */
+function sortByLastActivityDesc(conversations: QuoConversation[]): QuoConversation[] {
+  return [...conversations].sort((a, b) => {
+    const delta = activityMs(b) - activityMs(a)
+    if (delta !== 0) return delta
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+  })
+}
+
+function activityMs(conversation: QuoConversation): number {
+  const value = Date.parse(conversation.lastActivityAt ?? conversation.updatedAt ?? '')
+  return Number.isFinite(value) ? value : 0
 }

--- a/packages/lib/src/providers/openphone/types.ts
+++ b/packages/lib/src/providers/openphone/types.ts
@@ -1,102 +1,240 @@
-// src/lib/providers/openphone/types.ts
+// packages/lib/src/providers/openphone/types.ts
+// Wire shapes for Quo (formerly OpenPhone), https://api.quo.com/v1.
+//
+// The provider key stays `openphone` everywhere it is persisted (IntegrationProviderType,
+// Credential.type, Integration.provider, /api/openphone/webhook) — this is a labels-only
+// rename. New *types* use the `Quo` prefix.
+//
+// ⚠️ REST and webhook return DIFFERENT shapes for the same logical message. Verified live:
+//
+//   |            | webhook (`data.object`) | REST (`GET /v1/messages`) |
+//   | body text  | `body`                  | `text`                    |
+//   | recipient  | `to` (string)           | `to` (string[])           |
+//   | media      | `media: [{url,type}]`   | absent — never returned   |
+//
+// They are therefore two types with two mappers. A single shared type would silently read
+// `undefined` on one of the two paths and produce empty messages rather than a crash.
 
-// Describes the expected structure in the Integration.metadata field. The apiKey +
-// webhookSigningSecret are NOT here — they live encrypted on the Credential (resolved via
-// Integration.credentialId by getChannelTokens / the webhook route). Only non-secret routing
-// identity sits in metadata.
+/**
+ * Describes the expected structure in the Integration.metadata field. The apiKey is NOT here —
+ * it lives encrypted on the Credential (resolved via Integration.credentialId). Only non-secret
+ * routing identity sits in metadata.
+ *
+ * `webhookSigningSecret` is the per-channel key Quo mints when we create the webhook
+ * (`POST /v1/webhooks/messages` → `data.key`); it is written to the Credential secret bag by the
+ * provisioning hook, never here.
+ */
 export interface OpenPhoneIntegrationMetadata {
   phoneNumberId: string
   phoneNumber: string // E.164 format
-  webhookId?: string // ID of the webhook created via API (if applicable)
+  webhookId?: string // ID of the webhook created via API (WH…)
 }
 
-// --- Types based on OpenPhone API Docs ---
+// ---------------------------------------------------------------------------
+// REST resources
+// ---------------------------------------------------------------------------
 
-export interface OpenPhoneConversation {
-  id: string
-  object: 'conversation'
-  phone_number_id: string
-  contact: OpenPhoneContact | null
-  latest_message: OpenPhoneMessage | null
-  unread: boolean
-  last_activity_at: string // ISO 8601 Date string
-  created_at: string // ISO 8601 Date string
+/** A workspace member attached to a phone number. */
+export interface QuoUser {
+  id: string // US…
+  email: string
+  firstName: string | null
+  lastName: string | null
+  role: string
+  groupId?: string | null
 }
 
-export interface OpenPhoneContact {
-  id: string
-  object: 'contact'
+/**
+ * Per-region messaging/calling restrictions. Only a number whose
+ * `messaging.US === 'unrestricted'` can send US SMS — the others fail at send time with no
+ * signal in our UI, which is why we cache this alongside the number.
+ */
+export interface QuoRestrictions {
+  calling?: Record<string, string>
+  messaging?: Record<string, string>
+}
+
+/** `GET /v1/phone-numbers` → `data[]`. */
+export interface QuoPhoneNumber {
+  id: string // PN…
+  number: string // E.164
   name: string | null
-  company_name: string | null
-  // ... other contact fields
+  formattedNumber?: string | null
+  symbol?: string | null
+  groupId?: string | null
+  forward?: string | null
+  portingStatus?: string | null
+  restrictions?: QuoRestrictions
+  users?: QuoUser[]
+  createdAt?: string
+  updatedAt?: string
 }
 
-export interface OpenPhoneMessage {
+/**
+ * The trimmed projection cached on `Credential.metadata.quo.phoneNumbers`. Deliberately drops
+ * `users[]` (member emails/names we do not need, and the part that goes stale fastest) while
+ * keeping `restrictions`, which is the difference between a channel that works and one that
+ * silently cannot send.
+ */
+export interface QuoCachedPhoneNumber {
   id: string
+  number: string
+  name: string | null
+  restrictions?: QuoRestrictions
+}
+
+/** The `Credential.metadata.quo` bag. Derived provider state — NOT `connectionVariables`. */
+export interface QuoCredentialMetadata {
+  phoneNumbers: QuoCachedPhoneNumber[]
+  fetchedAt: string
+}
+
+/** Media on a webhook message/call payload. REST never returns this. */
+export interface QuoMedia {
+  url: string
+  type: string
+  duration?: number
+}
+
+/**
+ * A message as it arrives on a **webhook** (`data.object`). Note `body` (not `text`) and
+ * `to` as a plain string (not an array).
+ */
+export interface QuoWebhookMessage {
+  id: string // AC…
   object: 'message'
-  conversation_id: string
-  phone_number_id: string
-  direction: 'inbound' | 'outbound'
-  sender_phone_number: string | null // E.164 format
-  recipient_phone_number: string | null // E.164 format
-  sender_contact: OpenPhoneContact | null
-  recipient_contact: OpenPhoneContact | null
-  status: 'received' | 'sent' | 'delivered' | 'read' | 'error'
-  type: 'sms' // Assuming only SMS for now
+  from: string
+  to: string
+  direction: 'incoming' | 'outgoing'
   body: string
-  attachments: OpenPhoneAttachment[]
-  date_created: string // ISO 8601 Date string
-  date_sent: string | null // ISO 8601 Date string
-  date_delivered: string | null // ISO 8601 Date string
-  date_read: string | null // ISO 8601 Date string
+  media?: QuoMedia[]
+  status: string
+  createdAt: string
+  updatedAt?: string
+  userId?: string
+  phoneNumberId: string
+  conversationId: string // CN…
 }
 
-export interface OpenPhoneAttachment {
+/**
+ * A message as returned by **REST** (`GET /v1/messages`, `GET /v1/messages/{id}`,
+ * `POST /v1/messages`). Note `text` (not `body`) and `to` as an array. Media is never present.
+ */
+export interface QuoRestMessage {
+  id: string // AC…
+  to: string[]
+  from: string
+  text: string
+  direction: 'incoming' | 'outgoing'
+  status: string
+  createdAt: string
+  updatedAt?: string
+  userId?: string
+  phoneNumberId: string
+  conversationId: string // CN…
+}
+
+/**
+ * A call as it arrives on a webhook. The message shape plus voicemail/recording media.
+ * REST calls carry a different set (`answeredBy`, `callRoute`, `duration`, …) and omit media.
+ */
+export interface QuoWebhookCall {
   id: string
-  object: 'attachment'
-  file_name: string
-  content_type: string
+  object: 'call'
+  from: string
+  to: string
+  direction: 'incoming' | 'outgoing'
+  status: string
+  media?: QuoMedia[]
+  voicemail?: QuoMedia | null
+  answeredAt?: string | null
+  completedAt?: string | null
+  createdAt: string
+  userId?: string
+  phoneNumberId: string
+  conversationId: string
+}
+
+/**
+ * `GET /v1/conversations` → `data[]`. There is **no** `latestMessage` field, and
+ * `GET /v1/conversations/{id}` does not exist — only the list endpoint.
+ */
+export interface QuoConversation {
+  id: string // CN…
+  phoneNumberId: string
+  participants: string[]
+  name: string | null
+  assignedTo: string | null
+  createdAt: string
+  updatedAt: string
+  lastActivityAt: string
+  lastActivityId?: string | null
+  deletedAt?: string | null
+  mutedUntil?: string | null
+  snoozedUntil?: string | null
+}
+
+/** `POST /v1/webhooks/messages` → `data`. The signing `key` comes back on create. */
+export interface QuoWebhook {
+  id: string // WH…
+  key: string // base64 of 32 raw bytes — the HMAC signing key
   url: string
-  size_bytes: number
+  label?: string | null
+  status: 'enabled' | 'disabled'
+  events: string[]
+  resourceIds: string[]
+  createdAt?: string
+  updatedAt?: string
 }
 
-// Type for POST /messages payload
-export interface OpenPhoneSendMessagePayload {
-  phone_number_id: string
-  to: string // E.164 phone number
-  body: string
-  // attachments?: Array<{ url: string }>; // Sending attachments
-}
+// ---------------------------------------------------------------------------
+// Webhook envelope
+// ---------------------------------------------------------------------------
 
-// Type for POST /webhooks payload
-export interface OpenPhoneWebhookPayload {
-  url: string
-  secret: string
-  triggers: Array<'message.received' | 'call.ringing' | 'call.finished' /* Add others */>
-}
-
-export interface OpenPhoneWebhookResponse {
-  id: string
-  object: 'webhook'
-  url: string
-  secret: string // The secret you provided
-  triggers: string[]
-  status: 'active' | 'inactive'
-  date_created: string
-  date_updated: string
-}
-
-// Type for incoming webhook event
-export interface OpenPhoneWebhookEvent<T = any> {
-  id: string // Event ID
+/**
+ * Every Quo webhook shares one envelope; only `data.object` varies.
+ *
+ * Events carrying `phoneNumberId` (resolvable to an Integration): `message.received`,
+ * `message.delivered`, `call.ringing`, `call.completed`, `call.recording.completed`.
+ * Events that do NOT: `call.summary.completed`, `call.transcript.completed`,
+ * `contact.updated`, `contact.deleted` — do not subscribe to these without building a
+ * `callId` → prior-call or credential-scoped lookup first.
+ */
+export interface QuoWebhookEvent<T = unknown> {
+  id: string // EV…
   object: 'event'
-  type: string // e.g., 'message.received'
-  date_created: string
-  data: T // Payload depends on the event type
-  webhook_id: string
-  api_version: string
+  apiVersion: string
+  createdAt: string
+  type: string
+  data: { object: T }
 }
 
-export type OpenPhoneMessageReceivedData = {
-  object: 'message'
-} & OpenPhoneMessage // Reuse the Message type
+/** Convenience alias for the two message events we subscribe to. */
+export type QuoMessageWebhookEvent = QuoWebhookEvent<QuoWebhookMessage>
+
+// ---------------------------------------------------------------------------
+// Request payloads
+// ---------------------------------------------------------------------------
+
+/**
+ * `POST /v1/messages`. `from` is the E.164 number or `PN…` id (`phoneNumberId` is deprecated).
+ * `to` accepts 1–10 recipients. There is no `media`/`attachments` field — outbound MMS is not
+ * supported by Quo.
+ */
+export interface QuoSendMessageInput {
+  content: string
+  from: string
+  to: string[]
+  userId?: string
+  setInboxStatus?: 'done'
+}
+
+/** `POST /v1/webhooks/messages`. */
+export interface QuoCreateMessageWebhookInput {
+  url: string
+  events: Array<'message.received' | 'message.delivered'>
+  resourceIds: string[]
+  label?: string
+  status?: 'enabled' | 'disabled'
+  userId?: string
+}

--- a/packages/lib/src/providers/provider-capabilities.ts
+++ b/packages/lib/src/providers/provider-capabilities.ts
@@ -157,7 +157,9 @@ export const PROVIDER_CAPABILITIES: Record<ChannelProviderType, ProviderCapabili
     canReact: false,
     canShare: false,
     metadata: {
-      maxMessageLength: 160,
+      // Quo accepts up to 1600 characters on `POST /v1/messages` and segments longer SMS
+      // itself; 160 is the per-segment GSM limit, not the API's.
+      maxMessageLength: 1600,
       supportsUnicode: true,
     },
     requiresSubject: false,

--- a/packages/lib/src/providers/sync-mode-resolver.ts
+++ b/packages/lib/src/providers/sync-mode-resolver.ts
@@ -51,6 +51,13 @@ export function resolveEffectiveSyncMode(integration: {
     return 'webhook'
   }
 
+  if (integration.provider === 'openphone') {
+    // Quo (OpenPhone) webhooks need no extra env vars — we create them over the API and Quo
+    // mints the signing key on create. Without this branch the default below returns 'polling'
+    // and `WebhookManagerService.setupWebhook` early-returns, silently no-opping auto-arming.
+    return 'webhook'
+  }
+
   // Default for future providers (IMAP, etc.)
   return 'polling'
 }

--- a/packages/lib/src/utils/rate-limiter/provider-configs.ts
+++ b/packages/lib/src/utils/rate-limiter/provider-configs.ts
@@ -177,23 +177,34 @@ export const ENHANCED_PROVIDER_LIMITS: Partial<
   },
 
   [IntegrationProviderTypeEnum.openphone]: {
-    // OpenPhone API limits
-    requestsPerMinute: 100,
-    requestsPerHour: 1000,
-    concurrentRequests: 5,
+    // Quo (formerly OpenPhone). Documented ceiling: 10 requests/second PER API KEY (429 on
+    // exceed) = 600/min = 36,000/hour. The previous 100/min + 1000/hr numbers were invented and
+    // throttled us 6× / 36× below the real allowance.
+    //
+    // `requestsPerSecond` is the load-bearing knob — `config-manager.ts` derives
+    // `minInterval = 1000 / requestsPerSecond` from it.
+    requestsPerSecond: 10,
+    requestsPerMinute: 600,
+    requestsPerHour: 36000,
+    // Measured latency is ~195ms/request, so a serial caller only reaches ~5 rps; 2 in flight
+    // lands at ~10 rps. The old `5` would overshoot the ceiling and collect 429s.
+    concurrentRequests: 2,
     batchSize: 10,
 
+    // NOTE: the rate limit is per API KEY, not per number — three channels backfilling
+    // concurrently share one budget. The Quo client (`providers/openphone/api.ts`) paces on the
+    // key itself for exactly this reason.
     contexts: {
       messages: {
-        maxRequests: 100,
+        maxRequests: 600,
         perInterval: 60000,
       },
       send: {
-        maxRequests: 30,
+        maxRequests: 600,
         perInterval: 60000,
       },
       calls: {
-        maxRequests: 50,
+        maxRequests: 600,
         perInterval: 60000,
       },
     },

--- a/packages/lib/src/webhooks/inbound/inbound.test.ts
+++ b/packages/lib/src/webhooks/inbound/inbound.test.ts
@@ -3,10 +3,14 @@
 // the same way its provider does, then verified; tampered bodies, wrong secrets, and
 // length mismatches must return false (never throw); the Stripe tolerance window must
 // reject a stale timestamp.
+//
+// Quo (formerly OpenPhone) is NOT dispatched through `verifyWebhook` — its timestamp comes from
+// the header, which `WebhookVerifyPreset.signedPayload` cannot express. Its vectors live in
+// `quo-signature.test.ts`.
 
 import { createHmac } from 'node:crypto'
 import { describe, expect, it } from 'vitest'
-import { fixturePreset, metaPreset, openphonePreset, shopifyPreset, stripePreset } from './presets'
+import { fixturePreset, metaPreset, shopifyPreset, stripePreset } from './presets'
 import {
   timingSafeStringEqual,
   verifyHmacSignature,
@@ -166,17 +170,13 @@ describe('verifyWebhook dispatcher', () => {
     expect(verifyWebhook(metaPreset, { rawBody: 'tampered', headers, secret })).toBe(false)
   })
 
-  it('openphone preset (hmac hex) — length mismatch returns false, not a throw', () => {
-    const secret = 'opsecret'
+  it('length mismatch returns false, not a throw (the old OpenPhone timingSafeEqual bug)', () => {
+    const secret = 'shpss'
     const rawBody = '{"type":"message.received"}'
-    const headers = {
-      'x-openphone-signature': createHmac('sha256', secret).update(rawBody).digest('hex'),
-    }
-    expect(verifyWebhook(openphonePreset, { rawBody, headers, secret })).toBe(true)
     expect(
-      verifyWebhook(openphonePreset, {
+      verifyWebhook(shopifyPreset, {
         rawBody,
-        headers: { 'x-openphone-signature': 'short' },
+        headers: { 'x-shopify-hmac-sha256': 'short' },
         secret,
       })
     ).toBe(false)

--- a/packages/lib/src/webhooks/inbound/presets.ts
+++ b/packages/lib/src/webhooks/inbound/presets.ts
@@ -27,12 +27,21 @@ export const metaPreset: WebhookVerifyPreset = {
   prefix: 'sha256=',
 }
 
-/** OpenPhone webhooks: HMAC-SHA256 hex over the raw body, in `x-openphone-signature`. */
+/**
+ * Quo (formerly OpenPhone) webhooks: HMAC-SHA256 base64 over `${timestamp}.${rawBody}`, with a
+ * base64-decoded signing key, in `openphone-signature` shaped `hmac;1;<timestamp>;<signature>`.
+ * The timestamp comes from the header, which `WebhookVerifyPreset.signedPayload` (raw-body only)
+ * cannot express — so the call site parses the header, builds the signed payload, enforces the
+ * timestamp tolerance, and calls `verifyHmacSignature` directly (`secretEncoding: 'base64'`)
+ * rather than going through `verifyWebhook`. This preset records the scheme as data.
+ *
+ * The provider key stays `openphone` everywhere it is persisted; the rename to Quo is labels-only.
+ */
 export const openphonePreset: WebhookVerifyPreset = {
   scheme: 'hmac',
-  header: 'x-openphone-signature',
+  header: 'openphone-signature',
   algo: 'sha256',
-  encoding: 'hex',
+  encoding: 'base64',
 }
 
 /**

--- a/packages/lib/src/webhooks/inbound/quo-signature.test.ts
+++ b/packages/lib/src/webhooks/inbound/quo-signature.test.ts
@@ -1,0 +1,149 @@
+// packages/lib/src/webhooks/inbound/quo-signature.test.ts
+// Golden-vector tests for the Quo (formerly OpenPhone) webhook signature scheme.
+//
+// Quo signs as `openphone-signature: hmac;1;<timestamp>;<base64 signature>` — HMAC-SHA256,
+// base64 digest, over `${timestamp}.${rawBody}`, with the signing key base64-DECODED first.
+// Four things differ from what we shipped before (hex digest, utf8 key, no timestamp prefix,
+// `x-openphone-signature` header), which is why the channel could never verify a real webhook.
+//
+// These vectors are the regression guard: they prove the unmodified `verifyHmacSignature`
+// primitive covers the scheme (no `HmacVerifyParams` change needed), and they pin the old
+// parameters as failing so a revert cannot pass silently.
+
+import { createHmac, randomBytes } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { openphonePreset } from './presets'
+import { verifyHmacSignature } from './verify'
+
+/** Quo's signing key as it arrives from `POST /v1/webhooks/messages` → `data.key`: base64 of 32 raw bytes. */
+const signingKey = randomBytes(32).toString('base64')
+
+/** A realistic `message.received` envelope — `data.object` nesting, `body`, `direction: incoming`. */
+const rawBody = JSON.stringify({
+  id: 'EVabc123',
+  object: 'event',
+  apiVersion: 'v3',
+  createdAt: '2026-08-14T18:22:11.000Z',
+  type: 'message.received',
+  data: {
+    object: {
+      id: 'ACabc123',
+      object: 'message',
+      from: '+14155550123',
+      to: '+18889155797',
+      direction: 'incoming',
+      body: 'is my order shipped yet?',
+      media: [],
+      status: 'received',
+      createdAt: '2026-08-14T18:22:11.000Z',
+      userId: 'USabc123',
+      phoneNumberId: 'PN0eLoM7TQ',
+      conversationId: 'CNabc123',
+    },
+  },
+})
+
+/** Sign exactly as Quo documents it, and return the full header value. */
+function quoHeader(body: string, timestamp: string, key = signingKey): string {
+  const signature = createHmac('sha256', Buffer.from(key, 'base64'))
+    .update(`${timestamp}.${body}`, 'utf8')
+    .digest('base64')
+  return `hmac;1;${timestamp};${signature}`
+}
+
+/** The verify call exactly as the route makes it, given a parsed header. */
+function verifyAsRoute(body: string, header: string, secret = signingKey): boolean {
+  const [scheme, , timestamp, signature] = header.split(';')
+  if (scheme !== 'hmac' || !timestamp || !signature) return false
+  return verifyHmacSignature({
+    rawBody: body,
+    signature,
+    secret,
+    encoding: 'base64',
+    secretEncoding: 'base64',
+    signedPayload: () => `${timestamp}.${body}`,
+  })
+}
+
+describe('quo webhook signature', () => {
+  const timestamp = '2026-08-14T18:22:11.000Z'
+
+  it('verifies a signature produced by Quo’s documented algorithm', () => {
+    expect(verifyAsRoute(rawBody, quoHeader(rawBody, timestamp))).toBe(true)
+  })
+
+  it('accepts an epoch-millisecond timestamp too (the header value is opaque to the HMAC)', () => {
+    const epochMs = String(Date.parse(timestamp))
+    expect(verifyAsRoute(rawBody, quoHeader(rawBody, epochMs))).toBe(true)
+  })
+
+  it('rejects a tampered body', () => {
+    const header = quoHeader(rawBody, timestamp)
+    const tampered = rawBody.replace('is my order shipped yet?', 'send me a refund')
+    expect(tampered).not.toBe(rawBody)
+    expect(verifyAsRoute(tampered, header)).toBe(false)
+    // Even a single trailing byte must break it — the HMAC is over the raw bytes, never
+    // over re-serialized JSON.
+    expect(verifyAsRoute(`${rawBody} `, header)).toBe(false)
+  })
+
+  it('rejects a swapped timestamp (the timestamp is inside the signed payload)', () => {
+    const header = quoHeader(rawBody, timestamp)
+    const [, version, , signature] = header.split(';')
+    const replayed = `hmac;${version};2026-08-14T19:00:00.000Z;${signature}`
+    expect(verifyAsRoute(rawBody, replayed)).toBe(false)
+  })
+
+  it('rejects a wrong signing key and a malformed header', () => {
+    const header = quoHeader(rawBody, timestamp)
+    expect(verifyAsRoute(rawBody, header, randomBytes(32).toString('base64'))).toBe(false)
+    expect(verifyAsRoute(rawBody, header, '')).toBe(false)
+    // Malformed / unknown-scheme headers never reach the verifier.
+    expect(verifyAsRoute(rawBody, 'hmac;1;only-three-parts')).toBe(false)
+    expect(verifyAsRoute(rawBody, `sha256;1;${timestamp};abc`)).toBe(false)
+    expect(verifyAsRoute(rawBody, '')).toBe(false)
+    // A bare digest with no envelope (what a naive provider might send) is rejected too.
+    expect(verifyAsRoute(rawBody, header.split(';')[3] ?? '')).toBe(false)
+  })
+
+  it('rejects the parameters we shipped before (hex digest, utf8 key, no timestamp prefix)', () => {
+    const header = quoHeader(rawBody, timestamp)
+    const signature = header.split(';')[3] as string
+
+    // What `openphonePreset` used to declare: hex over the bare raw body with a utf8 key.
+    expect(verifyHmacSignature({ rawBody, signature, secret: signingKey, encoding: 'hex' })).toBe(
+      false
+    )
+    // Right encoding, but the key is not base64-decoded.
+    expect(
+      verifyHmacSignature({
+        rawBody,
+        signature,
+        secret: signingKey,
+        encoding: 'base64',
+        signedPayload: () => `${timestamp}.${rawBody}`,
+      })
+    ).toBe(false)
+    // Right key handling, but the timestamp prefix is missing from the signed payload.
+    expect(
+      verifyHmacSignature({
+        rawBody,
+        signature,
+        secret: signingKey,
+        encoding: 'base64',
+        secretEncoding: 'base64',
+      })
+    ).toBe(false)
+  })
+})
+
+describe('openphonePreset', () => {
+  it('documents the Quo scheme as data (the route verifies directly)', () => {
+    expect(openphonePreset).toEqual({
+      scheme: 'hmac',
+      header: 'openphone-signature',
+      algo: 'sha256',
+      encoding: 'base64',
+    })
+  })
+})


### PR DESCRIPTION
Implements `plans/channels/quo-channel-rewrite.md`.

OpenPhone rebranded to **Quo** and moved its API to `https://api.quo.com/v1`. Everything we shipped that talked to it over the wire was written against a shape that does not exist — the old base host does not even resolve — which is why this channel has never been connected in production. The plumbing (provisioning hook, credential split, inbox linking, channel limits, ingest) was sound and is kept; only the wire-facing half is replaced.

**The provider key is unchanged.** `openphone` stays as the enum value, `Credential.type`, `Integration.provider`, and the route path `/api/openphone/webhook`. Labels-only rename — renaming it would change the derived webhook callback URL and invalidate every registered webhook, and the enum codegen is destructive.

## What was broken

| | |
|---|---|
| Base URL | `api.openphone.co/v3` — **DNS failure**, the host does not resolve |
| Connect form | `phoneNumberId` validated `^pnv_.+`; real ids are `PN…`, so **the form could not be submitted** |
| Webhook signature | wrong header, hex instead of base64, utf8 key instead of base64-decoded, and the `hmac;1;<ts>;` prefix never parsed — four independent reasons it could never verify |
| Webhook ingest | read `data.phone_number_id`, always `undefined` → silent 200, message dropped. Looks healthy in logs |
| Send payload | `{phone_number_id, to: "<str>", body}` — wrong on all three fields |
| Polling sync | read `conversation.latest_message` and filtered on `phone_number_id`; **neither field exists** |
| Auto-provisioning | `setupWebhook` was an explicit no-op |

## What changed

**Wire format.** New `providers/openphone/api.ts` is the single typed client — raw `Authorization` header, per-API-key 8 rps pacer with `Retry-After` handling, and both of Quo's parameter conventions encoded (bracketed `phoneNumbers[]=` for conversations, repeated bare `participants=` for messages; the latter rejects brackets in any form).

`types.ts` is rewritten to the real camelCase shapes. **REST and webhook return different shapes for the same logical message** — `body` vs `text`, string vs array `to`, media only on the webhook — so they get separate types and separate mappers. Sharing one would silently read `undefined` on one path and produce empty messages rather than crash.

**Signature verification.** Quo signs `openphone-signature: hmac;1;<ts>;<b64sig>` — HMAC-SHA256, base64 digest, over `${ts}.${rawBody}`, with a base64-decoded key. The route now parses the header and calls `verifyHmacSignature` directly with a replay guard, following the Recall/Svix precedent. `HmacVerifyParams` needed no change.

**Auto-provisioning.** `setupWebhook` creates the webhook `disabled`, persists the id plus the signing key Quo mints on create (merged into the credential secret bag so `apiKey` survives), then enables it — deleting it if either step fails. That minted key is what removes the "Webhook Signing Secret" field from the connect form. Quo webhooks never expire, so no renewal job. `recoverChannel` re-arms Quo too, since reconnect settles through two paths and only the OAuth popup runs the post-connect hook.

**Workspace model.** One connection = one Quo **workspace**, not one number. The form collapses from four fields to the API key alone; the number becomes a picker backed by the list cached on `Credential.metadata.quo`. Adding a second number is a new channel against the *existing* connection, not a re-pasted key. Deleting a credential now blocks with the count of dependent channels — the FK is `onDelete: set null`, and at 1:N the orphaning is no longer self-evident.

**Backfill** is a rewrite, not a repair. Bounded expanding window enumerated as non-overlapping rings, sorted client-side by `lastActivityAt` — the server orders by `createdAt`, so "take the first N" would drop old-but-active threads, exactly the ones a support team cares about. Capped per number, resumable, and cost is independent of workspace size. `backfillCutoffAt` is stamped at connect epoch so a backfill cannot mass-fire `message:received` across years of history.

**Compose.** `recipient-input` is generalized off email onto an identifier model driven by `platformCaps.recipientModel`, so a phone number can actually be entered. `openphone drafts: true → false` — Quo has no drafts API, so the flag offered an affordance that silently fails and fed a false claim into the Kopilot integration catalog.

**Contacts connector.** `getByPath` learns array indexing — both call sites already routed bracketed paths to it, so the syntax was intended and simply never implemented. The array-source guard is intact. `quo.json` binds contacts to `@system:contact` on the same credential the channel uses.

## Bug found and fixed along the way

The `Message` insert never set `externalId`, while the upsert's conflict target is `(integrationId, externalId)`. Every row landed with `externalId = NULL`, Postgres treats those as distinct in a unique index, and the idempotency upsert silently degraded into a plain insert. Email masks this because the `internetMessageId` reconcile catches redelivery first — but **SMS has no Message-ID**, so for Quo that upsert is the only dedupe and every webhook retry or backfill re-run would have duplicated the message. Cross-provider latent bug, not introduced here.

## Where the plan was wrong

- **The contacts connector has no incremental sync.** The plan assumed `updatedAt` on records meant date filtering was available. Tested against a bogus-param control: `/v1/contacts` has no date filter at all and silently ignores unknown params. Declared as a full snapshot crawl rather than putting a fake `sinceParam` in config to recover a version stamp that would then be a lie.
- **The backfill probe as specified isn't achievable.** Quo exposes no count (`totalItems` is per-page), so a probe can't be cheaper than enumerating. Implemented as non-overlapping rings — same total cost, without the 6× redundancy a re-enumerating probe would incur.
- **`role` → `job_title` is deliberately unmapped.** Template bindings have no `mergeStrategy` knob, so scalar targets are *cleared* on a null source, and 24 of 25 live contacts have `role: null` — mapping it would blank a human-entered job title on every run.

## Verification

- `packages/lib` and `apps/web` typecheck clean (pre-existing unrelated errors only)
- **991 tests pass** across webhooks, providers, channels, ingest, jobs, rate-limiter, data-connectors
- Signature verification has a dedicated test that asserts all three *old* parameter sets return `false`, so a revert cannot pass silently
- Verified read-only against a live Quo workspace: phone numbers, conversations, messages, contacts, webhooks, and both endpoints' parameter conventions

⚠️ **Signature verification is proven self-consistent with Quo's documented algorithm, not against a live inbound SMS.** That is the first thing to check on merge: tunnel via `NGROK_URL`, text a connected number, confirm the thread appears.

## Known open

- `saveConnection` has no providerKey dedupe, so "connect a different workspace" with the same key can still mint a duplicate Credential
- The corrected rate-limit config is inert — nothing calls `createThrottler` for this provider; real pacing lives in `api.ts`. Relatedly `config-manager.getLimits(provider, context)` drops `minInterval` on the context branch, affecting every provider
- Inbound media is dropped and group SMS is unverified (the test workspace has zero group conversations) — both per the plan's scope
