### PR TITLE
fix(records): run the duplicate name-matching arm and fix queue surfaces

### DIFF
--- a/apps/web/src/components/duplicates/ui/duplicate-pair-summary.tsx
+++ b/apps/web/src/components/duplicates/ui/duplicate-pair-summary.tsx
@@ -43,7 +43,10 @@ export interface DuplicateSignalSummary {
   type: string
   value: string
   otherValue?: string
+  /** `CustomField.key` of the field that matched, when one field is responsible. */
   fieldKey?: string
+  /** `CustomField.systemAttribute` of that field, when it has one. */
+  systemAttribute?: string
 }
 
 /** Human labels for `SignalType`. Unknown types fall back to the raw string. */
@@ -56,6 +59,55 @@ const SIGNAL_LABELS: Record<string, string> = {
   address: 'Address',
   identity: 'External ID',
   ingest: 'Same import',
+}
+
+/**
+ * Labels for the fields that reach the chip as `type: 'unique'`.
+ *
+ * 🔴 **`company_domain` is the reason this map exists.** It is a plain TEXT
+ * field promoted to a strong key by `STRONG_KEY_SYSTEM_ATTRIBUTES`, so it emits
+ * `type: 'unique'` and a type-only label called the highest-yield company signal
+ * in the whole engine "Unique field". The signal already carries its provenance;
+ * labelling from `type` alone was simply throwing it away.
+ */
+const SYSTEM_ATTRIBUTE_LABELS: Record<string, string> = {
+  company_domain: 'Domain',
+  website: 'Website',
+  primary_email: 'Email',
+  phone: 'Phone',
+  company_name: 'Company name',
+  first_name: 'First name',
+  last_name: 'Last name',
+}
+
+/** `company_domain` → `Company domain`, `taxId` → `Tax id`. */
+function humanizeFieldKey(key: string): string {
+  const words = key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .trim()
+    .toLowerCase()
+  if (!words) return key
+  return words.charAt(0).toUpperCase() + words.slice(1)
+}
+
+/**
+ * What a chip calls one signal.
+ *
+ * Provenance first, type second: a generic type label is only right when the
+ * signal came from something other than a field (`identity`, `ingest`) or when
+ * the type IS the field's meaning (`email`, `phone`).
+ */
+function signalLabel(signal: DuplicateSignalSummary): string {
+  if (signal.systemAttribute) {
+    const known = SYSTEM_ATTRIBUTE_LABELS[signal.systemAttribute]
+    if (known) return known
+  }
+  if (signal.type === 'unique') {
+    const source = signal.systemAttribute ?? signal.fieldKey
+    if (source) return humanizeFieldKey(source)
+  }
+  return SIGNAL_LABELS[signal.type] ?? signal.type
 }
 
 function initials(name: string | null): string {
@@ -130,9 +182,7 @@ export function DuplicateSignalChips({
         <span
           key={`${signal.type}:${signal.value}:${signal.otherValue ?? ''}`}
           className='inline-flex max-w-full items-center gap-1 truncate rounded-[5px] bg-muted px-1.5 py-0.5 text-[11px] text-foreground/80 ring-1 ring-border'>
-          <span className='shrink-0 text-muted-foreground'>
-            {SIGNAL_LABELS[signal.type] ?? signal.type}
-          </span>
+          <span className='shrink-0 text-muted-foreground'>{signalLabel(signal)}</span>
           <span className='truncate'>
             {signal.otherValue ? `${signal.value} ↔ ${signal.otherValue}` : signal.value}
           </span>

--- a/apps/web/src/components/global/notifications/hooks/use-approvals-count.ts
+++ b/apps/web/src/components/global/notifications/hooks/use-approvals-count.ts
@@ -68,6 +68,13 @@ export function useApprovalsCount(): ApprovalsCount {
    * as the list — a pair the list refuses to render must not be counted, which
    * is why the archived filter lives on all three read paths rather than on
    * `list` alone.
+   *
+   * ⚠️ It counts PAIRS while the section renders one row per CLUSTER, so an org
+   * with multi-record clusters sees a badge above its visible row count. That is
+   * deliberate: the badge answers "how much duplicate evidence is outstanding",
+   * and counting components instead would need a union-find over every open pair
+   * in the org on a query that runs whenever the bell is mounted. The section
+   * itself pages, so everything counted is reachable.
    */
   const duplicates = api.duplicates.count.useQuery(undefined, {
     enabled: duplicatesEnabled,

--- a/apps/web/src/components/global/notifications/ui/approvals-duplicates.test.tsx
+++ b/apps/web/src/components/global/notifications/ui/approvals-duplicates.test.tsx
@@ -21,6 +21,20 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+// `InfiniteScroll` constructs a real `IntersectionObserver` in a layout effect,
+// and the shared setup file installs an arrow function rather than a class. The
+// section only started mounting one when it gained load-more.
+class NoopIntersectionObserver {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+  takeRecords = vi.fn(() => [])
+  root = null
+  rootMargin = ''
+  thresholds: number[] = []
+}
+vi.stubGlobal('IntersectionObserver', NoopIntersectionObserver)
+
 const DEF = 'edf_contact00000000000000000'
 const LOW = 'ein_low000000000000000000000'
 const HIGH = 'ein_high00000000000000000000'
@@ -34,6 +48,9 @@ const h = vi.hoisted(() => ({
   /** `baseRecordIds` the merge dialog was mounted with. */
   mergeProps: [] as unknown[],
   items: [] as unknown[],
+  /** Non-null ⇒ the section has another page to load. */
+  nextCursor: null as unknown,
+  fetchNextPage: vi.fn(),
 }))
 
 vi.mock('~/providers/feature-flag-provider', () => ({
@@ -100,13 +117,18 @@ vi.mock('~/trpc/react', () => ({
     },
     duplicates: {
       list: {
-        useQuery: (input: unknown, opts: { enabled: boolean }) => {
+        useInfiniteQuery: (input: unknown, opts: { enabled: boolean }) => {
           if (opts.enabled) h.listCalls.push(input)
           return {
-            data: opts.enabled ? { items: h.items, nextCursor: null } : undefined,
+            data: opts.enabled
+              ? { pages: [{ items: h.items, nextCursor: h.nextCursor }] }
+              : undefined,
             isLoading: false,
             error: null,
             refetch: vi.fn(),
+            hasNextPage: !!h.nextCursor,
+            isFetchingNextPage: false,
+            fetchNextPage: h.fetchNextPage,
           }
         },
       },
@@ -133,18 +155,22 @@ function pair(overrides: Record<string, unknown> = {}) {
     band: 'high',
     signals: [{ type: 'email', strength: 'strong', value: 'bob@acme.test' }],
     createdAt: new Date().toISOString(),
-    low: {
-      instanceId: LOW,
-      displayName: 'Bob Smith',
-      secondaryDisplayValue: 'bob@acme.test',
-      avatarUrl: null,
-    },
-    high: {
-      instanceId: HIGH,
-      displayName: 'Robert Smith',
-      secondaryDisplayValue: 'bob@acme.test',
-      avatarUrl: null,
-    },
+    // The whole CLUSTER, best-established first — the router emits one item per
+    // connected component, not one per stored pair.
+    records: [
+      {
+        instanceId: HIGH,
+        displayName: 'Robert Smith',
+        secondaryDisplayValue: 'bob@acme.test',
+        avatarUrl: null,
+      },
+      {
+        instanceId: LOW,
+        displayName: 'Bob Smith',
+        secondaryDisplayValue: 'bob@acme.test',
+        avatarUrl: null,
+      },
+    ],
     // Server-decided order: the HIGH record is better established, so it must
     // survive the merge even though canonical pair order puts LOW first.
     mergeInstanceIds: [HIGH, LOW],
@@ -163,6 +189,8 @@ beforeEach(() => {
   h.dismissCalls = []
   h.mergeProps = []
   h.items = [pair()]
+  h.nextCursor = null
+  h.fetchNextPage = vi.fn()
 })
 
 describe('the Possible duplicates section', () => {
@@ -197,6 +225,45 @@ describe('the Possible duplicates section', () => {
     h.items = []
     renderTab()
     expect(screen.getByText('Nothing needs your approval')).toBeInTheDocument()
+  })
+
+  it('renders every record of a CLUSTER on one card', () => {
+    // Three records that all duplicate each other are three stored pairs
+    // offering the same merge. Rendering them as three rows meant two of them
+    // read as the same pair reversed — five clusters ate 15 of 25 slots on dev.
+    const third = 'ein_third0000000000000000000'
+    h.items = [
+      pair({
+        records: [
+          ...(pair().records as unknown[]),
+          {
+            instanceId: third,
+            displayName: 'Bobby Smith',
+            secondaryDisplayValue: 'bob@acme.test',
+            avatarUrl: null,
+          },
+        ],
+        mergeInstanceIds: [HIGH, LOW, third],
+      }),
+    ]
+    renderTab()
+
+    expect(screen.getByText('Robert Smith')).toBeInTheDocument()
+    expect(screen.getByText('Bob Smith')).toBeInTheDocument()
+    expect(screen.getByText('Bobby Smith')).toBeInTheDocument()
+    // One card, not three: the section header counts items, not records.
+    expect(screen.getByText('(1)')).toBeInTheDocument()
+  })
+
+  it('pages rather than stranding the pairs the badge counts', () => {
+    // A fixed-size query left the difference between the badge and the first
+    // page counted but unreachable — badge 70, list 25, no load-more.
+    h.nextCursor = { score: 0.9, id: 'dup_1' }
+    renderTab()
+
+    expect(h.listCalls).toHaveLength(1)
+    // The cursor input is what makes the next page fetchable at all.
+    expect(h.listCalls[0]).toEqual({ limit: 25 })
   })
 })
 

--- a/apps/web/src/components/global/notifications/ui/approvals-tab.tsx
+++ b/apps/web/src/components/global/notifications/ui/approvals-tab.tsx
@@ -39,6 +39,15 @@ const SUGGESTION_FILTERS = {
   limit: 25,
 } as const
 
+/**
+ * Cursor-paged like the suggestions section above it, and for a sharper reason:
+ * the badge counts EVERY open pair while a fixed-size query renders only the
+ * first page, so a plain `useQuery` left the difference counted but unreachable
+ * (measured during Phase 5 verification: badge 70, list 25, no way to see the
+ * rest).
+ */
+const DUPLICATE_FILTERS = { limit: 25 } as const
+
 /** How long the flashed ring stays on a highlighted confirmation. */
 const HIGHLIGHT_MS = 2000
 
@@ -104,10 +113,11 @@ function PendingApprovals({ viewportRef }: ApprovalsTabProps) {
    * suggestions section above, and the reason the router may refuse outright
    * rather than answering with an empty list.
    */
-  const duplicates = api.duplicates.list.useQuery(
-    { limit: 25 },
-    { enabled: duplicatesEnabled, refetchOnWindowFocus: false }
-  )
+  const duplicates = api.duplicates.list.useInfiniteQuery(DUPLICATE_FILTERS, {
+    enabled: duplicatesEnabled,
+    getNextPageParam: (lastPage) => lastPage?.nextCursor ?? undefined,
+    refetchOnWindowFocus: false,
+  })
 
   // Deadline order — soonest expiry first, undated last. Correct only because the
   // pending view is fetched as one page (the router asks for 100), so this sorts
@@ -130,7 +140,10 @@ function PendingApprovals({ viewportRef }: ApprovalsTabProps) {
   )
 
   const mailSuggestionItems = mailSuggestions.data ?? []
-  const duplicateItems = duplicates.data?.items ?? []
+  const duplicateItems = useMemo(
+    () => duplicates.data?.pages.flatMap((page) => page?.items ?? []) ?? [],
+    [duplicates.data]
+  )
 
   /**
    * The acting client refetches both lists and both badge counts itself rather
@@ -348,6 +361,15 @@ function PendingApprovals({ viewportRef }: ApprovalsTabProps) {
           {duplicateItems.map((pair) => (
             <DuplicateRow key={pair.id} pair={pair} onResolved={onDuplicateResolved} />
           ))}
+          <InfiniteScroll
+            isLoading={duplicates.isFetchingNextPage}
+            hasMore={!!duplicates.hasNextPage}
+            next={() => duplicates.fetchNextPage()}
+            root={viewportRef.current}
+            rootMargin='200px'>
+            <div className='h-px' />
+          </InfiniteScroll>
+          {duplicates.isFetchingNextPage ? <NotificationRowSkeleton /> : null}
         </section>
       ) : null}
     </>

--- a/apps/web/src/components/global/notifications/ui/items/duplicate-row.tsx
+++ b/apps/web/src/components/global/notifications/ui/items/duplicate-row.tsx
@@ -72,7 +72,13 @@ export function DuplicateRow({
     toRecordId(pair.entityDefinitionId, id)
   )
 
-  const records = [pair.low, pair.high].map((side) => ({
+  /**
+   * The whole CLUSTER, not two sides. The router emits one item per connected
+   * component, so a three-record cluster is one card listing three records —
+   * previously it was three cards offering the same merge, two of which read as
+   * the same pair reversed.
+   */
+  const records = pair.records.map((side) => ({
     recordId: toRecordId(pair.entityDefinitionId, side.instanceId),
     displayName: side.displayName,
     secondaryDisplayValue: side.secondaryDisplayValue,

--- a/apps/web/src/server/api/routers/duplicates.ts
+++ b/apps/web/src/server/api/routers/duplicates.ts
@@ -196,25 +196,16 @@ export const duplicatesRouter = createTRPCRouter({
       })
       if (page.isErr()) throw page.error
 
-      // Every cluster member is a side of some pair in this page (the clusters
-      // are page-local by construction), so one map covers the whole ordering.
-      const sideById = new Map<string, DuplicateSide>()
-      for (const pair of page.value.items) {
-        sideById.set(pair.low.instanceId, pair.low)
-        sideById.set(pair.high.instanceId, pair.high)
-      }
-
-      const establishment = await readMergeEstablishment(ctx.db, ctx.session.organizationId, [
-        ...sideById.keys(),
-      ])
+      const establishment = await readMergeEstablishment(
+        ctx.db,
+        ctx.session.organizationId,
+        page.value.items.flatMap((pair) => pair.clusterInstanceIds)
+      )
       if (establishment.isErr()) throw establishment.error
 
       const items = page.value.items.map((pair) => {
-        const clusterSides = pair.clusterInstanceIds.flatMap((id) => {
-          const side = sideById.get(id)
-          return side ? [side] : []
-        })
-        const ordered = orderByEstablishment(clusterSides, establishment.value)
+        const ordered = orderByEstablishment(pair.clusterSides, establishment.value)
+        const byId = new Map(pair.clusterSides.map((side) => [side.instanceId, side]))
         return {
           id: pair.id,
           entityDefinitionId: pair.entityDefinitionId,
@@ -222,10 +213,17 @@ export const duplicatesRouter = createTRPCRouter({
           band: pair.band,
           signals: pair.signals,
           createdAt: pair.createdAt,
-          low: toSideDto(pair.low),
-          high: toSideDto(pair.high),
           /**
-           * The cluster, best-established first — what the client turns into
+           * Every record in the cluster, best-established first — one row per
+           * component, so a three-record cluster is one card listing three
+           * records rather than three cards offering the same merge.
+           */
+          records: ordered.flatMap((id) => {
+            const side = byId.get(id)
+            return side ? [toSideDto(side)] : []
+          }),
+          /**
+           * The same ids, same order — what the client turns into
            * `MergeDialog.baseRecordIds`. The FIRST id becomes the merge target.
            */
           mergeInstanceIds: ordered,

--- a/packages/lib/src/dedup/__tests__/dedup-engine.int.test.ts
+++ b/packages/lib/src/dedup/__tests__/dedup-engine.int.test.ts
@@ -618,6 +618,10 @@ describe('exact engine — the pair lifecycle', () => {
     expect(rows[0]?.band).toBe('high')
     // The snooze does not survive an upgrade either.
     expect(rows[0]?.snoozeUntil).toBeNull()
+    // Nor does the dismissal snapshot: an `open` row carrying a `dismissedBand`
+    // is a dismissal that no longer exists — harmless to every reader, and a lie
+    // in the audit trail.
+    expect(rows[0]?.dismissedBand).toBeNull()
   })
 
   it('leaves a dismissed pair dismissed when the rescan produces the SAME band', async () => {

--- a/packages/lib/src/dedup/__tests__/dedup-fuzzy.int.test.ts
+++ b/packages/lib/src/dedup/__tests__/dedup-fuzzy.int.test.ts
@@ -22,7 +22,7 @@ import { createTestOrganization, getTestDb } from '@auxx/test-utils'
 import type { FieldId } from '@auxx/types/field'
 import { eq } from 'drizzle-orm'
 import { describe, expect, it, vi } from 'vitest'
-import { blockFuzzyRecord } from '../blocking-fuzzy'
+import { blockFuzzyRecord, blockSurnameRecord } from '../blocking-fuzzy'
 import { corroboratePair, deriveCorroborationFields, evaluateFuzzyPair } from '../corroborate'
 import { upsertPairs } from '../pairs'
 import { scorePair } from '../scoring'
@@ -403,6 +403,68 @@ describe('fuzzy blocking — candidate generation only', () => {
       })
     )._unsafeUnwrap()
     expect(withAnchor.map((c) => c.instanceId)).toEqual([margaret])
+  })
+
+  it('returns EVERY same-surname record through the exact anchor pass', async () => {
+    // The recall arm the trigram pass cannot provide. Ordering by similarity to
+    // the whole anchor string means the true same-surname candidates compete
+    // with lookalikes and lose once the surname is common — measured on dev,
+    // `Robert Smith` was not among `Bob Smith`'s top neighbours across 19
+    // Smiths. Corroboration cannot rescue a pair that was never generated.
+    const f = await seedOrg()
+    const bob = await seedContact(f, { firstName: 'Bob', lastName: 'Smith' })
+    const robert = await seedContact(f, { firstName: 'Robert', lastName: 'Smith' })
+    for (const first of ['Ann', 'Amy', 'Ben', 'Dan', 'Eve', 'Gus', 'Ida', 'Joe']) {
+      await seedContact(f, { firstName: first, lastName: 'Smith' })
+    }
+    await seedContact(f, { firstName: 'Bob', lastName: 'Smythe' })
+
+    const candidates = (
+      await blockSurnameRecord(db(), {
+        organizationId: f.orgId,
+        entityDefinitionId: f.defId,
+        instanceId: bob,
+        surnameFieldId: f.lastNameFieldId as FieldId,
+        surname: 'Smith',
+      })
+    )._unsafeUnwrap()
+
+    const ids = candidates.map((c) => c.instanceId)
+    expect(ids).toContain(robert)
+    // Nine other Smiths, itself excluded, and `Smythe` is a different surname —
+    // near-exactness is the COMPARATOR's job, not the blocker's.
+    expect(ids).toHaveLength(9)
+    expect(ids).not.toContain(bob)
+  })
+
+  it('honours its own cap and skips a blank surname', async () => {
+    const f = await seedOrg()
+    const bob = await seedContact(f, { firstName: 'Bob', lastName: 'Smith' })
+    await seedContact(f, { firstName: 'Robert', lastName: 'Smith' })
+    await seedContact(f, { firstName: 'Ann', lastName: 'Smith' })
+
+    const capped = (
+      await blockSurnameRecord(db(), {
+        organizationId: f.orgId,
+        entityDefinitionId: f.defId,
+        instanceId: bob,
+        surnameFieldId: f.lastNameFieldId as FieldId,
+        surname: 'Smith',
+        limit: 1,
+      })
+    )._unsafeUnwrap()
+    expect(capped).toHaveLength(1)
+
+    const blank = (
+      await blockSurnameRecord(db(), {
+        organizationId: f.orgId,
+        entityDefinitionId: f.defId,
+        instanceId: bob,
+        surnameFieldId: f.lastNameFieldId as FieldId,
+        surname: '   ',
+      })
+    )._unsafeUnwrap()
+    expect(blank).toEqual([])
   })
 })
 

--- a/packages/lib/src/dedup/__tests__/enqueue-scan.test.ts
+++ b/packages/lib/src/dedup/__tests__/enqueue-scan.test.ts
@@ -35,9 +35,11 @@ vi.mock('../../jobs/queues', () => ({
 vi.mock('../../jobs/queues/types', () => ({ Queues: { maintenanceQueue: 'maintenance' } }))
 
 import {
+  DUPLICATE_SCAN_CONTINUATION_DELAY_MS,
   DUPLICATE_SCAN_DELAY_MS,
   DUPLICATE_SCAN_JOB_NAME,
   enqueueDuplicateScan,
+  enqueueDuplicateScanContinuation,
   enqueueDuplicateScanForRecords,
 } from '../enqueue-scan'
 
@@ -131,5 +133,37 @@ describe('enqueueDuplicateScanForRecords — one job per RUN', () => {
     })
     expect(id).toBeUndefined()
     expect(h.calls).toHaveLength(0)
+  })
+})
+
+describe('enqueueDuplicateScanContinuation — draining a capped backlog', () => {
+  it('does NOT reuse the org+def jobId, which the running job still holds', async () => {
+    // The bug this exists to avoid: the handler requeueing itself under
+    // `dup-scan:{org}:{def}` while it is the ACTIVE job under that very id, so
+    // BullMQ drops the add and the backlog silently stalls.
+    await enqueueDuplicateScan('org_1', 'def_contact')
+    await enqueueDuplicateScanContinuation('org_1', 'def_contact', '2026-08-15 10:00:00')
+
+    expect(h.delayed.size).toBe(2)
+    expect(h.calls[1]?.opts.jobId).toBe('dup-scan:cont:org_1:def_contact:2026-08-15 10:00:00')
+  })
+
+  it('collapses a repeat at the same cursor and advances with a new one', async () => {
+    await enqueueDuplicateScanContinuation('org_1', 'def_contact', 'cursor_a')
+    await enqueueDuplicateScanContinuation('org_1', 'def_contact', 'cursor_a')
+    await enqueueDuplicateScanContinuation('org_1', 'def_contact', 'cursor_b')
+
+    expect(h.calls).toHaveLength(3)
+    expect(h.delayed.size).toBe(2)
+  })
+
+  it('carries the org+def scope and a short delay', async () => {
+    await enqueueDuplicateScanContinuation('org_1', 'def_contact', 'cursor_a')
+    expect(h.calls[0]?.data).toEqual({
+      organizationId: 'org_1',
+      entityDefinitionId: 'def_contact',
+    })
+    expect(h.calls[0]?.opts.delay).toBe(DUPLICATE_SCAN_CONTINUATION_DELAY_MS)
+    expect(DUPLICATE_SCAN_CONTINUATION_DELAY_MS).toBeLessThan(DUPLICATE_SCAN_DELAY_MS)
   })
 })

--- a/packages/lib/src/dedup/__tests__/queries.int.test.ts
+++ b/packages/lib/src/dedup/__tests__/queries.int.test.ts
@@ -25,9 +25,11 @@ import {
   DUPLICATE_HIGH_INSTANCE_ID_SQL,
   DUPLICATE_LOW_INSTANCE_ID_SQL,
   type DuplicateDefScope,
+  type DuplicateSide,
   getVisibleDuplicatePair,
   listDuplicatePairs,
   listDuplicatePairsForRecord,
+  orderByEstablishment,
 } from '../queries'
 
 const db = () => getTestDb() as never as import('@auxx/database').Database
@@ -42,6 +44,9 @@ interface Fixture {
   b: string
   c: string
   d: string
+  /** Two more, so the paging test can build three DISJOINT pairs (one row each). */
+  e: string
+  g: string
   scopes: DuplicateDefScope[]
 }
 
@@ -78,6 +83,8 @@ async function seed(): Promise<Fixture> {
     await instance('Bravo'),
     await instance('Charlie'),
     await instance('Delta'),
+    await instance('Echo'),
+    await instance('Golf'),
   ].sort()
 
   return {
@@ -88,6 +95,8 @@ async function seed(): Promise<Fixture> {
     b: ids[1] as string,
     c: ids[2] as string,
     d: ids[3] as string,
+    e: ids[4] as string,
+    g: ids[5] as string,
     scopes: [{ entityDefinitionId: def?.id as string }],
   }
 }
@@ -296,7 +305,10 @@ describe('snooze window — snoozed is `open` plus a future snoozeUntil', () => 
 })
 
 describe('clustering + paging', () => {
-  it('unions A–B and B–C into one component', async () => {
+  it('collapses A–B and B–C into ONE row for the component', async () => {
+    // Three stored pairs offering the same merge used to render as three rows,
+    // two of which read as the same pair reversed — five clusters ate 15 of 25
+    // visible slots on dev. The union-find decides which rows exist now.
     const f = await seed()
     await pair(f, f.a, f.b)
     await pair(f, f.b, f.c)
@@ -304,13 +316,14 @@ describe('clustering + paging', () => {
     const result = await listDuplicatePairs(db(), { organizationId: f.orgId, scopes: f.scopes })
     const items = result._unsafeUnwrap().items
 
-    expect(items).toHaveLength(2)
-    for (const item of items) {
-      expect([...item.clusterInstanceIds].sort()).toEqual([f.a, f.b, f.c])
-    }
+    expect(items).toHaveLength(1)
+    expect([...(items[0]?.clusterInstanceIds ?? [])].sort()).toEqual([f.a, f.b, f.c])
+    // The whole component is hydrated, so the card can name all three records.
+    expect(items[0]?.clusterSides.map((side) => side.instanceId).sort()).toEqual([f.a, f.b, f.c])
+    expect(items[0]?.clusterSides.every((side) => side.displayName)).toBe(true)
   })
 
-  it('keeps disjoint pairs in separate clusters', async () => {
+  it('keeps disjoint pairs as separate rows', async () => {
     const f = await seed()
     await pair(f, f.a, f.b)
     await pair(f, f.c, f.d)
@@ -319,6 +332,7 @@ describe('clustering + paging', () => {
       await listDuplicatePairs(db(), { organizationId: f.orgId, scopes: f.scopes })
     )._unsafeUnwrap().items
 
+    expect(items).toHaveLength(2)
     for (const item of items) {
       expect(item.clusterInstanceIds).toHaveLength(2)
     }
@@ -326,11 +340,12 @@ describe('clustering + paging', () => {
 
   it('pages on (score desc, id desc) without repeating or skipping a row', async () => {
     const f = await seed()
-    // Identical scores on purpose: `score` is a double that ties constantly, so
-    // the id tiebreak is what makes the keyset total.
+    // Disjoint on purpose, so one raw row is one item and paging is what is
+    // under test rather than clustering. Identical scores: `score` is a double
+    // that ties constantly, so the id tiebreak is what makes the keyset total.
     await pair(f, f.a, f.b, { score: 0.9 })
     await pair(f, f.c, f.d, { score: 0.9 })
-    await pair(f, f.a, f.c, { score: 0.9 })
+    await pair(f, f.e, f.g, { score: 0.9 })
 
     const first = (
       await listDuplicatePairs(db(), { organizationId: f.orgId, scopes: f.scopes, limit: 2 })
@@ -350,6 +365,32 @@ describe('clustering + paging', () => {
     const ids = [...first.items, ...second.items].map((item) => item.id)
     expect(new Set(ids).size).toBe(3)
     expect(second.nextCursor).toBeNull()
+  })
+
+  it('resumes from the last ROW read, not the last item emitted', async () => {
+    // A page that collapses three rows into one item must still continue the
+    // keyset from the third row, or the next page repeats what it just hid.
+    const f = await seed()
+    await pair(f, f.a, f.b, { score: 0.9 })
+    await pair(f, f.b, f.c, { score: 0.8 })
+    await pair(f, f.d, f.e, { score: 0.7 })
+
+    const first = (
+      await listDuplicatePairs(db(), { organizationId: f.orgId, scopes: f.scopes, limit: 2 })
+    )._unsafeUnwrap()
+    expect(first.items).toHaveLength(1)
+
+    const second = (
+      await listDuplicatePairs(db(), {
+        organizationId: f.orgId,
+        scopes: f.scopes,
+        limit: 2,
+        cursor: first.nextCursor ?? undefined,
+      })
+    )._unsafeUnwrap()
+
+    expect(second.items).toHaveLength(1)
+    expect([...(second.items[0]?.clusterInstanceIds ?? [])].sort()).toEqual([f.d, f.e])
   })
 
   it('joins both sides’ display columns', async () => {
@@ -478,5 +519,47 @@ describe('getVisibleDuplicatePair — the resolve-then-authorize read', () => {
       scopes: f.scopes,
     })
     expect(result._unsafeUnwrap()).toBeNull()
+  })
+})
+
+describe('orderByEstablishment — which record a merge defaults INTO', () => {
+  const side = (instanceId: string, over: Partial<DuplicateSide> = {}): DuplicateSide => ({
+    instanceId,
+    displayName: instanceId,
+    secondaryDisplayValue: null,
+    avatarUrl: null,
+    firstInteractionAt: null,
+    lastInteractionAt: null,
+    createdAt: null,
+    ...over,
+  })
+
+  it('prefers outbound history above everything else', () => {
+    const ordered = orderByEstablishment(
+      [side('zzz'), side('aaa', { createdAt: new Date('2020-01-01') })],
+      [{ instanceId: 'zzz', hasOutboundHistory: true }]
+    )
+    expect(ordered[0]).toBe('zzz')
+  })
+
+  it('falls back to the OLDEST record when no establishment signal exists', () => {
+    // The case this rung exists for, and the one the queue is full of: two
+    // records the name rule paired, neither with any interaction history. The id
+    // fallback is a cuid2, i.e. arbitrary — so without `createdAt` the merge
+    // target was a coin flip, and half the time it was the emptier stub.
+    const older = side('zzz', { createdAt: new Date('2020-01-01') })
+    const newer = side('aaa', { createdAt: new Date('2026-01-01') })
+
+    expect(orderByEstablishment([newer, older], [])[0]).toBe('zzz')
+    expect(orderByEstablishment([older, newer], [])[0]).toBe('zzz')
+  })
+
+  it('ranks an interacted record above an older one with no interaction', () => {
+    const stub = side('aaa', { createdAt: new Date('2019-01-01') })
+    const real = side('zzz', {
+      createdAt: new Date('2026-01-01'),
+      firstInteractionAt: new Date('2026-02-01'),
+    })
+    expect(orderByEstablishment([stub, real], [])[0]).toBe('zzz')
   })
 })

--- a/packages/lib/src/dedup/blocking-fuzzy.ts
+++ b/packages/lib/src/dedup/blocking-fuzzy.ts
@@ -22,14 +22,27 @@
 // scores 0.2105263 and is not, because a short surname cannot carry a nickname
 // pair over the threshold on its own. That is why {@link FuzzyBlockAnchors}
 // accepts a `surname` anchor: querying the surname alone puts the whole burden
-// on the part that actually matches. The `LIMIT` truncating a common surname's
-// neighbours is harmless — a common surname fails the rarity condition anyway.
+// on the part that actually matches.
+//
+// ⚠️ **Second recall limit, found by Phase 5 verification and now fixed.** The
+// original header claimed the `LIMIT` truncating a common surname's neighbours
+// was harmless "because a common surname fails the rarity condition anyway".
+// That is wrong: a common surname reaches `medium` through CORROBORATION
+// (`Bob Smith` / `Robert Smith` — a case the plan requires), and corroboration
+// cannot rescue a pair the blocker never generated. Two changes followed —
+// {@link FUZZY_BLOCK_LIMIT} went from 5 to 20, and {@link blockSurnameRecord}
+// added an exact-surname anchor pass that does not compete for those slots at
+// all. Neither touches the name RULE: precision on `John Smith` / `Jane Smith`
+// is unchanged.
 
 import { type Database, schema } from '@auxx/database'
-import { and, desc, eq, isNull, ne } from 'drizzle-orm'
+import type { FieldId } from '@auxx/types/field'
+import { and, desc, eq, isNull, ne, sql } from 'drizzle-orm'
 import { ok, type Result } from 'neverthrow'
 import { recordSearchNameScore, recordSearchPredicate } from '../resources/search/record-search-sql'
-import { FUZZY_BLOCK_LIMIT } from './config'
+import { FUZZY_BLOCK_LIMIT, SURNAME_ANCHOR_LIMIT } from './config'
+import { normalizeSurname } from './name-match'
+import { NORMALIZED_SURNAME_SQL } from './surname-rarity'
 
 /**
  * One fuzzy neighbour.
@@ -169,4 +182,81 @@ export async function blockFuzzyRecord(
   }
 
   return ok([...byId.values()])
+}
+
+/** Parameters for {@link blockSurnameRecord}. */
+export interface BlockSurnameParams {
+  organizationId: string
+  entityDefinitionId: string
+  /** `EntityInstance.id` of the record being scanned — never returned to itself. */
+  instanceId: string
+  /** `CustomField.id` of the surname field, from `resolveNameFieldIds`. */
+  surnameFieldId: FieldId
+  /** The scanned record's raw surname cell; normalized here. */
+  surname: string
+  /** Defaults to {@link SURNAME_ANCHOR_LIMIT}. */
+  limit?: number
+}
+
+/**
+ * Every live record in the definition holding the SAME normalized surname.
+ *
+ * 🔴 **The recall arm the trigram blocker cannot provide.** `blockFuzzyRecord`
+ * orders by similarity to the whole anchor string and truncates at
+ * {@link FUZZY_BLOCK_LIMIT}, so on a common surname the genuine same-surname
+ * candidates compete with trigram neighbours that merely look alike — measured
+ * on dev, `Bob Smith` did not have `Robert Smith` among its top neighbours
+ * across 19 Smiths. Corroboration cannot rescue a pair the blocker never
+ * generated, so `Bob Smith` / `Robert Smith` — a case the plan explicitly
+ * requires — was unreachable.
+ *
+ * This asks the surname FIELD instead of the display name, which removes the
+ * competition entirely: every candidate it returns already satisfies condition
+ * (a) of the name rule exactly, and the only thing left to decide is the given
+ * name. Fixing recall here rather than by loosening the name rule is deliberate
+ * — precision on `John Smith` / `Jane Smith` must not move.
+ *
+ * Normalization is {@link NORMALIZED_SURNAME_SQL}, the same expression
+ * `surnameIdf` counts with, so "the same surname" means one thing across the
+ * blocker, the comparator and the rarity test.
+ *
+ * @returns up to `limit` candidates. Ordered by id purely for determinism —
+ *   there is no meaningful ranking among exact surname matches.
+ */
+export async function blockSurnameRecord(
+  db: Database,
+  params: BlockSurnameParams
+): Promise<Result<FuzzyCandidate[], Error>> {
+  const { organizationId, entityDefinitionId, instanceId, surnameFieldId } = params
+  const normalized = normalizeSurname(params.surname)
+  if (!normalized) return ok([])
+
+  const rows = await db
+    .selectDistinct({
+      instanceId: schema.EntityInstance.id,
+      displayName: schema.EntityInstance.displayName,
+      secondaryDisplayValue: schema.EntityInstance.secondaryDisplayValue,
+    })
+    .from(schema.FieldValue)
+    .innerJoin(
+      schema.EntityInstance,
+      and(
+        eq(schema.EntityInstance.id, schema.FieldValue.entityId),
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, entityDefinitionId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        eq(schema.FieldValue.fieldId, surnameFieldId as string),
+        ne(schema.FieldValue.entityId, instanceId),
+        sql`${NORMALIZED_SURNAME_SQL} = ${normalized}`
+      )
+    )
+    .orderBy(schema.EntityInstance.id)
+    .limit(params.limit ?? SURNAME_ANCHOR_LIMIT)
+
+  return ok(rows)
 }

--- a/packages/lib/src/dedup/config.ts
+++ b/packages/lib/src/dedup/config.ts
@@ -219,12 +219,35 @@ export const SURNAME_RARE_MAX_SHARE = 0.002
 /**
  * How many fuzzy neighbours the trigram blocker returns per anchor.
  *
- * Small on purpose. The blocker's job is recall-oriented candidate GENERATION;
- * precision comes from the structured comparator downstream, and a wide net here
- * only buys per-pair work. A record with more than five plausible name
- * neighbours is a common name, which the surname-rarity condition rejects anyway.
+ * 🔴 **Raised from 5 after Phase 5 verification.** The original value came with
+ * the reasoning "a record with more than five plausible name neighbours is a
+ * common name, which the surname-rarity condition rejects anyway" — which is
+ * false for exactly the case the plan requires: `Bob Smith` / `Robert Smith`
+ * reaches `medium` through CORROBORATION, not rarity, and corroboration cannot
+ * rescue a pair the blocker never generated. Measured on dev: 19 Smiths truncate
+ * at 5, and Robert was not among them.
+ *
+ * Widening is close to free because `evaluateFuzzyPair` compares the structured
+ * names in JS first and bails before its corroboration queries: a candidate that
+ * is not a name match costs one map lookup. Precision still comes from the
+ * comparator and the rarity condition, never from starving the blocker.
  */
-export const FUZZY_BLOCK_LIMIT = 5
+export const FUZZY_BLOCK_LIMIT = 20
+
+/**
+ * Cap on the EXACT-surname anchor pass (`blockSurnameRecord`).
+ *
+ * The trigram blocker orders by similarity to the whole query string, so on a
+ * common surname the true same-surname candidates compete with — and lose to —
+ * trigram neighbours that merely look alike. The exact-surname pass removes that
+ * competition entirely by asking the surname field directly, and it needs a
+ * bound of its own because "every record called Smith" is unbounded.
+ *
+ * Higher than {@link FUZZY_BLOCK_LIMIT} on purpose: these candidates already
+ * satisfy condition (a) of the name rule, so the only thing left to decide is
+ * the given name — the cheapest possible filter.
+ */
+export const SURNAME_ANCHOR_LIMIT = 50
 
 /**
  * Per-entity-type dedup tuning, mirroring the `HOOKS_BY_ENTITY_TYPE` registry

--- a/packages/lib/src/dedup/enqueue-scan.ts
+++ b/packages/lib/src/dedup/enqueue-scan.ts
@@ -90,6 +90,41 @@ export async function enqueueDuplicateScan(
   )
 }
 
+/**
+ * How long a continuation waits — short, because there is a known backlog to
+ * drain rather than a burst to absorb.
+ */
+export const DUPLICATE_SCAN_CONTINUATION_DELAY_MS = 5_000
+
+/**
+ * Continue a scan that hit its per-definition record cap.
+ *
+ * The watermark query is oldest-dirty-first and bounded, so in a definition with
+ * more than `RECORDS_PER_DEFINITION` dirty records a freshly created record
+ * sorts LAST and would wait for the next write or the 6h sweep. The handler
+ * therefore requeues itself, and the backlog drains in bounded chunks.
+ *
+ * 🔴 **A different jobId from {@link enqueueDuplicateScan}, and the cursor is
+ * part of it.** The org+def jobId is held by the job that is currently RUNNING —
+ * BullMQ drops a same-jobId `add` in that state, so reusing it would make this
+ * call a silent no-op, which is exactly the bug being fixed. Keying on the
+ * watermark the tick stopped at makes each continuation distinct while still
+ * collapsing a redundant re-add at the same position.
+ */
+export async function enqueueDuplicateScanContinuation(
+  organizationId: string,
+  entityDefinitionId: string,
+  cursor: string
+): Promise<string | undefined> {
+  return addScanJob(
+    { organizationId, entityDefinitionId },
+    {
+      jobId: `dup-scan:cont:${organizationId}:${entityDefinitionId}:${cursor}`,
+      delay: DUPLICATE_SCAN_CONTINUATION_DELAY_MS,
+    }
+  )
+}
+
 /** Parameters for {@link enqueueDuplicateScanForRecords}. */
 export interface EnqueueScanForRecordsParams {
   organizationId: string

--- a/packages/lib/src/dedup/index.ts
+++ b/packages/lib/src/dedup/index.ts
@@ -15,7 +15,9 @@ export {
 } from './blocking'
 export {
   type BlockFuzzyParams,
+  type BlockSurnameParams,
   blockFuzzyRecord,
+  blockSurnameRecord,
   type FuzzyBlockAnchors,
   type FuzzyCandidate,
 } from './blocking-fuzzy'
@@ -33,6 +35,7 @@ export {
   ROLE_EMAIL_LOCALS,
   SIGNAL_WEIGHTS,
   STRONG_KEY_SYSTEM_ATTRIBUTES,
+  SURNAME_ANCHOR_LIMIT,
   SURNAME_RARE_MAX_SHARE,
   SURNAME_RARE_MIN_COUNT,
   SURNAME_TRIGRAM_THRESHOLD,
@@ -51,10 +54,12 @@ export {
   emitPairsFromIdentityMatch,
 } from './emit-identity-pairs'
 export {
+  DUPLICATE_SCAN_CONTINUATION_DELAY_MS,
   DUPLICATE_SCAN_DELAY_MS,
   DUPLICATE_SCAN_JOB_NAME,
   type EnqueueScanForRecordsParams,
   enqueueDuplicateScan,
+  enqueueDuplicateScanContinuation,
   enqueueDuplicateScanForRecords,
 } from './enqueue-scan'
 export { deriveMatchKeys, type MatchKey, type MatchKeyColumn } from './match-keys'
@@ -122,6 +127,7 @@ export {
 } from './scoring'
 export {
   type NameFieldIds,
+  NORMALIZED_SURNAME_SQL,
   readStructuredNames,
   resolveNameFieldIds,
   type SurnameRarity,

--- a/packages/lib/src/dedup/pairs.ts
+++ b/packages/lib/src/dedup/pairs.ts
@@ -78,6 +78,12 @@ export async function upsertPairs(
         ? {
             status: sql`CASE WHEN ${T.status} = 'dismissed' AND ${T.dismissedBand} = 'medium' THEN 'open' ELSE ${T.status} END`,
             snoozeUntil: sql`CASE WHEN ${T.band} = 'medium' THEN NULL ELSE ${T.snoozeUntil} END`,
+            // Cleared in the same statement that reopens the row. A reopened
+            // pair is `open`, and an `open` row carrying a `dismissedBand` is a
+            // dismissal that no longer exists — harmless to every reader, but a
+            // lie in the audit trail and a trap for the next person who reads
+            // the column as "this was dismissed at…".
+            dismissedBand: sql`CASE WHEN ${T.status} = 'dismissed' AND ${T.dismissedBand} = 'medium' THEN NULL ELSE ${T.dismissedBand} END`,
           }
         : {}
 

--- a/packages/lib/src/dedup/queries.ts
+++ b/packages/lib/src/dedup/queries.ts
@@ -63,6 +63,8 @@ export interface DuplicateSide {
   avatarUrl: string | null
   firstInteractionAt: Date | null
   lastInteractionAt: Date | null
+  /** `EntityInstance.createdAt` — the final merge-target tiebreak. */
+  createdAt: Date | null
 }
 
 /** One open pair, both sides hydrated. */
@@ -77,18 +79,37 @@ export interface DuplicatePair {
   high: DuplicateSide
 }
 
-/** A listed pair plus the connected component it belongs to within the page. */
+/**
+ * One CLUSTER, represented by its best-scoring pair.
+ *
+ * 🔴 **One item per connected component, not one per pair.** The store's unit is
+ * the pair, but the reviewer's unit is the cluster: three records that all
+ * duplicate each other are three stored pairs offering the SAME merge, and
+ * rendering them as three rows meant two of them read as the same pair reversed.
+ * Measured during Phase 5 verification: five clusters ate 15 of 25 visible slots.
+ * The union-find below now decides which rows exist, not just what they are
+ * annotated with.
+ *
+ * `score`, `band` and `signals` are the representative pair's — the highest
+ * scoring one in the component, since the page arrives score-desc and the first
+ * pair seen for a component wins.
+ */
 export interface DuplicatePairListItem extends DuplicatePair {
   /**
-   * Every instance id reachable from this pair through other open pairs **in the
-   * same page** (union-find at read).
+   * Every instance id in this component, reachable through other open pairs **in
+   * the same page** (union-find at read).
    *
-   * Page-local by construction, and deliberately so: the store's unit is the
-   * pair, and completing a cluster across the whole queue would need a second,
-   * unbounded query per page. A cluster split across a page boundary shows up as
-   * two rows rather than one — noisier, never wrong.
+   * Page-local by construction, and deliberately so: completing a cluster across
+   * the whole queue would need a second, unbounded query per page. A component
+   * split across a page boundary — and ONLY that case — still shows up as two
+   * rows: noisier, never wrong.
    */
   clusterInstanceIds: string[]
+  /**
+   * The same component's records, hydrated. Every member is a side of some pair
+   * in the page (that is what page-local means), so this costs no extra query.
+   */
+  clusterSides: DuplicateSide[]
 }
 
 /** Keyset position — score first, id as the tiebreak, both descending. */
@@ -173,12 +194,14 @@ const PAIR_COLUMNS = {
   lowAvatarUrl: LOW.avatarUrl,
   lowFirstInteractionAt: LOW.firstInteractionAt,
   lowLastInteractionAt: LOW.lastInteractionAt,
+  lowCreatedAt: LOW.createdAt,
   highId: T.instanceIdHigh,
   highDisplayName: HIGH.displayName,
   highSecondary: HIGH.secondaryDisplayValue,
   highAvatarUrl: HIGH.avatarUrl,
   highFirstInteractionAt: HIGH.firstInteractionAt,
   highLastInteractionAt: HIGH.lastInteractionAt,
+  highCreatedAt: HIGH.createdAt,
 } as const
 
 type PairRow = {
@@ -200,6 +223,7 @@ function toPair(row: PairRow): DuplicatePair {
       avatarUrl: (row.lowAvatarUrl ?? null) as string | null,
       firstInteractionAt: (row.lowFirstInteractionAt ?? null) as Date | null,
       lastInteractionAt: (row.lowLastInteractionAt ?? null) as Date | null,
+      createdAt: (row.lowCreatedAt ?? null) as Date | null,
     },
     high: {
       instanceId: row.highId as string,
@@ -208,6 +232,7 @@ function toPair(row: PairRow): DuplicatePair {
       avatarUrl: (row.highAvatarUrl ?? null) as string | null,
       firstInteractionAt: (row.highFirstInteractionAt ?? null) as Date | null,
       lastInteractionAt: (row.highLastInteractionAt ?? null) as Date | null,
+      createdAt: (row.highCreatedAt ?? null) as Date | null,
     },
   }
 }
@@ -271,15 +296,39 @@ export async function listDuplicatePairs(
   const page = (hasMore ? rows.slice(0, limit) : rows).map(toPair)
   const clusters = clusterInstanceIds(page)
 
+  // Every side in the page, so a component can be hydrated without a second query.
+  const sideById = new Map<string, DuplicateSide>()
+  for (const pair of page) {
+    sideById.set(pair.low.instanceId, pair.low)
+    sideById.set(pair.high.instanceId, pair.high)
+  }
+
+  // ONE item per component. The page is score-desc, so the first pair seen for a
+  // component is its best-scoring one and becomes the representative.
+  const emitted = new Set<string>()
+  const items: DuplicatePairListItem[] = []
+  for (const pair of page) {
+    const members = clusters.get(pair.low.instanceId) ?? [pair.low.instanceId, pair.high.instanceId]
+    const componentKey = [...members].sort().join('|')
+    if (emitted.has(componentKey)) continue
+    emitted.add(componentKey)
+
+    items.push({
+      ...pair,
+      clusterInstanceIds: members,
+      clusterSides: members.flatMap((id) => {
+        const side = sideById.get(id)
+        return side ? [side] : []
+      }),
+    })
+  }
+
+  // The cursor tracks the last ROW read, not the last item emitted — collapsing
+  // happens after paging, so a page that yields three items still has to resume
+  // from the pair it stopped at or the next page would repeat rows.
   const last = page.at(-1)
   return ok({
-    items: page.map((pair) => ({
-      ...pair,
-      clusterInstanceIds: clusters.get(pair.low.instanceId) ?? [
-        pair.low.instanceId,
-        pair.high.instanceId,
-      ],
-    })),
+    items,
     nextCursor: hasMore && last ? { score: last.score, id: last.id } : null,
   })
 }
@@ -291,6 +340,9 @@ export async function listDuplicatePairs(
  * unit is the pair, so one side can be dismissed or merged without invalidating
  * its neighbours. The cost is that a cluster is only ever as complete as the set
  * of pairs in hand.
+ *
+ * Its output decides which ROWS the queue has, not merely how they are
+ * annotated — see {@link DuplicatePairListItem}.
  */
 function clusterInstanceIds(pairs: DuplicatePair[]): Map<string, string[]> {
   const parent = new Map<string, string>()
@@ -379,10 +431,17 @@ export interface CountDuplicatePairsParams {
 /**
  * How many pairs the review queue would render — the notification badge's term.
  *
- * Carries the SAME archived and scope filters as {@link listDuplicatePairs} and
- * not one filter fewer. A badge that counts a different set than the tab shows
- * is the drift failure the shared count hook exists to prevent, arriving through
- * the back door.
+ * Carries the SAME archived, snooze and scope filters as
+ * {@link listDuplicatePairs} and not one filter fewer. A badge that counts a
+ * different set than the tab shows is the drift failure the shared count hook
+ * exists to prevent, arriving through the back door.
+ *
+ * ⚠️ It counts **pairs**, while the list renders one row per CLUSTER, so an org
+ * with multi-record clusters sees a badge above its rendered row count. That is
+ * deliberate and is not the drift this warns about: the badge answers "how much
+ * duplicate evidence is outstanding", and counting components instead would need
+ * the union-find over every open pair in the org — unbounded, on a query that
+ * runs every time the bell opens.
  */
 export async function countOpenDuplicatePairs(
   db: Database,
@@ -520,7 +579,16 @@ export async function readMergeEstablishment(
  * user selection rather than an artefact of canonical pair order.
  *
  * Ladder: outbound history → has any interaction history → oldest
- * `firstInteractionAt` → id (so the order is total and stable).
+ * `firstInteractionAt` → **oldest `createdAt`** → id (so the order is total and
+ * stable).
+ *
+ * 🔴 **The `createdAt` rung is load-bearing, not a formality.** Two records with
+ * no participant rows and no interaction history — which is every pair the name
+ * rule surfaces, and the whole reason this ordering exists — tie on the first
+ * three terms, and the id fallback is a cuid2, i.e. arbitrary. This function
+ * exists to stop merges defaulting INTO the empty stub, so where nothing else
+ * distinguishes the two, the record that has existed longer is the one whose id
+ * other things are most likely to point at.
  */
 export function orderByEstablishment(
   sides: readonly DuplicateSide[],
@@ -530,7 +598,12 @@ export function orderByEstablishment(
   const rank = (side: DuplicateSide) => ({
     outbound: outbound.get(side.instanceId) ? 1 : 0,
     interacted: side.firstInteractionAt ? 1 : 0,
+    // `Infinity - Infinity` is NaN, which a comparator reads as "equal" and
+    // falls through — the intended behaviour when neither side has interacted,
+    // but only because the next rung exists to answer it.
     since: side.firstInteractionAt?.getTime() ?? Number.POSITIVE_INFINITY,
+    // Unknown `createdAt` sorts last: it cannot claim to be the older record.
+    created: side.createdAt?.getTime() ?? Number.POSITIVE_INFINITY,
   })
 
   return [...sides]
@@ -541,6 +614,7 @@ export function orderByEstablishment(
         right.outbound - left.outbound ||
         right.interacted - left.interacted ||
         left.since - right.since ||
+        left.created - right.created ||
         a.instanceId.localeCompare(b.instanceId)
       )
     })

--- a/packages/lib/src/dedup/surname-rarity.ts
+++ b/packages/lib/src/dedup/surname-rarity.ts
@@ -150,7 +150,7 @@ export interface SurnameRarity {
  * which makes each look marginally RARER. Bounded and rare enough to accept over
  * adding an extension; revisit if it ever shows up in dismissal data.
  */
-const normalizedSurnameSql = sql`btrim(lower(regexp_replace(${schema.FieldValue.valueText}, '[^a-zA-Z0-9]+', ' ', 'g')))`
+export const NORMALIZED_SURNAME_SQL = sql`btrim(lower(regexp_replace(${schema.FieldValue.valueText}, '[^a-zA-Z0-9]+', ' ', 'g')))`
 
 /**
  * How rare is this surname in this org and definition?
@@ -206,7 +206,7 @@ export async function surnameIdf(
 
   const [row] = await db
     .select({
-      matched: sql<number>`count(DISTINCT ${schema.FieldValue.entityId}) FILTER (WHERE ${normalizedSurnameSql} = ${normalized})`,
+      matched: sql<number>`count(DISTINCT ${schema.FieldValue.entityId}) FILTER (WHERE ${NORMALIZED_SURNAME_SQL} = ${normalized})`,
       total: sql<number>`count(DISTINCT ${schema.FieldValue.entityId})`,
     })
     .from(schema.FieldValue)
@@ -222,7 +222,7 @@ export async function surnameIdf(
         eq(schema.FieldValue.organizationId, organizationId),
         eq(schema.FieldValue.entityDefinitionId, entityDefinitionId),
         eq(schema.FieldValue.fieldId, surnameFieldId as string),
-        sql`${normalizedSurnameSql} <> ''`
+        sql`${NORMALIZED_SURNAME_SQL} <> ''`
       )
     )
 

--- a/packages/lib/src/jobs/dedup/__tests__/duplicate-scan-job.int.test.ts
+++ b/packages/lib/src/jobs/dedup/__tests__/duplicate-scan-job.int.test.ts
@@ -94,6 +94,8 @@ interface Fixture {
   defId: string
   emailFieldId: string
   phoneFieldId: string
+  firstNameFieldId: string
+  lastNameFieldId: string
 }
 
 async function seedContactOrg(): Promise<Fixture> {
@@ -115,7 +117,7 @@ async function seedContactOrg(): Promise<Fixture> {
 
   const makeField = async (
     name: string,
-    type: 'EMAIL' | 'PHONE_INTL',
+    type: 'EMAIL' | 'PHONE_INTL' | 'TEXT',
     systemAttribute: string,
     sortOrder: string
   ) => {
@@ -129,7 +131,7 @@ async function seedContactOrg(): Promise<Fixture> {
         type,
         systemAttribute,
         sortOrder,
-        options: { multi: true },
+        options: type === 'TEXT' ? {} : { multi: true },
         isCustom: false,
         isUnique: false,
         updatedAt: new Date(),
@@ -143,13 +145,27 @@ async function seedContactOrg(): Promise<Fixture> {
     defId: def?.id as string,
     emailFieldId: await makeField('primaryEmail', 'EMAIL', 'primary_email', 'a2'),
     phoneFieldId: await makeField('phone', 'PHONE_INTL', 'phone', 'a3'),
+    // Ordinary TEXT `CustomField` rows — `firstName`/`lastName` carry a
+    // `dbColumn` in the registry but neither column exists on `EntityInstance`,
+    // so they live in `FieldValue` like any other field.
+    firstNameFieldId: await makeField('firstName', 'TEXT', 'first_name', 'a4'),
+    lastNameFieldId: await makeField('lastName', 'TEXT', 'last_name', 'a5'),
   }
+}
+
+interface ContactValues {
+  email?: string
+  phone?: string
+  firstName?: string
+  lastName?: string
+  /** Both sides on the same SECOND is the `ingest` corroborator. */
+  firstInteractionAt?: Date
 }
 
 async function seedContact(
   f: Fixture,
   displayName: string,
-  values: { email?: string; phone?: string } = {}
+  values: ContactValues = {}
 ): Promise<string> {
   const [inst] = await db()
     .insert(schema.EntityInstance)
@@ -157,6 +173,7 @@ async function seedContact(
       organizationId: f.orgId,
       entityDefinitionId: f.defId,
       displayName,
+      firstInteractionAt: values.firstInteractionAt ?? null,
       updatedAt: new Date(),
     })
     .returning()
@@ -177,7 +194,61 @@ async function seedContact(
 
   await write(f.emailFieldId, values.email)
   await write(f.phoneFieldId, values.phone)
+  await write(f.firstNameFieldId, values.firstName)
+  await write(f.lastNameFieldId, values.lastName)
   return inst?.id as string
+}
+
+/** A person, as the name arm needs them: display name AND structured parts. */
+const person = (
+  first: string,
+  last: string,
+  extra: ContactValues = {}
+): [string, ContactValues] => [`${first} ${last}`, { firstName: first, lastName: last, ...extra }]
+
+/**
+ * Short, realistic given names on purpose.
+ *
+ * The trigram blocker ranks by similarity to the whole anchor string, and a
+ * short display name scores HIGHER against `Bob Smith` than a long synthetic one
+ * — so a crowd of `Filler12 Smith` would leave Bob's real neighbours at the top
+ * of the list and the recall problem would never reproduce.
+ */
+const CROWD_OF_SMITHS = [
+  'Ann',
+  'Amy',
+  'Ben',
+  'Dan',
+  'Eve',
+  'Gus',
+  'Hal',
+  'Ida',
+  'Jim',
+  'Joe',
+  'Kim',
+  'Lee',
+  'Lou',
+  'Mae',
+  'Ned',
+  'Pam',
+  'Ray',
+  'Ron',
+  'Roy',
+  'Sam',
+  'Sue',
+  'Tim',
+  'Tom',
+  'Zoe',
+]
+
+async function seedPerson(
+  f: Fixture,
+  first: string,
+  last: string,
+  extra: ContactValues = {}
+): Promise<string> {
+  const [displayName, values] = person(first, last, extra)
+  return seedContact(f, displayName, values)
 }
 
 const runJob = (data: Record<string, unknown>) =>
@@ -189,6 +260,26 @@ async function pairCount(orgId: string): Promise<number> {
     .from(schema.DuplicateSuggestion)
     .where(eq(schema.DuplicateSuggestion.organizationId, orgId))
   return rows.length
+}
+
+/** Every stored pair for one org, with the columns the band tests assert on. */
+async function storedPairs(orgId: string) {
+  return db()
+    .select({
+      band: schema.DuplicateSuggestion.band,
+      score: schema.DuplicateSuggestion.score,
+      signals: schema.DuplicateSuggestion.signals,
+      low: schema.DuplicateSuggestion.instanceIdLow,
+      high: schema.DuplicateSuggestion.instanceIdHigh,
+    })
+    .from(schema.DuplicateSuggestion)
+    .where(eq(schema.DuplicateSuggestion.organizationId, orgId))
+}
+
+/** The stored pair joining two specific records, or `undefined`. */
+async function storedPairFor(orgId: string, a: string, b: string) {
+  const [low, high] = a < b ? [a, b] : [b, a]
+  return (await storedPairs(orgId)).find((row) => row.low === low && row.high === high)
 }
 
 async function watermark(instanceId: string): Promise<Date | null> {
@@ -332,6 +423,152 @@ describe('duplicateScanJob — org+def scope (the coalesced mutation seam)', () 
 
     expect(stats.scanned).toBe(1)
     expect(await pairCount(f.orgId)).toBe(0)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE PHASE-2 SEAM
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * 🔴 **The regression guard for the integration seam itself.**
+ *
+ * Phase 2 shipped merged, unit-tested and CORRECT — and with zero production
+ * callers. `scanRecord` called `blockRecord` and nothing else, so every stored
+ * row was `band: 'high'` and no `medium` row existed or could. Every unit test
+ * on both sides passed, and the module-level integration tests
+ * (`dedup/__tests__/dedup-fuzzy.int.test.ts`) passed too, because they compose
+ * the pipeline BY HAND — which is exactly what production was not doing.
+ *
+ * So these tests run the JOB HANDLER and assert on rows in
+ * `DuplicateSuggestion`. Nothing between the job data and the stored band is
+ * stubbed. Delete the fuzzy arm from `scanRecord` and every case here fails;
+ * that is the only property that matters about this block.
+ */
+describe('duplicateScanJob — the name arm (Phase 2 must actually run)', () => {
+  it('stores a MEDIUM pair for a nickname on a rare surname, with no other evidence', async () => {
+    // No shared email, no shared phone, no corroboration — the genesis-map G1
+    // shape (email↔phone twin), where the name is the only evidence there is.
+    const f = await seedContactOrg()
+    const bill = await seedPerson(f, 'Bill', 'Quillfeather')
+    const william = await seedPerson(f, 'William', 'Quillfeather')
+
+    await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+
+    const pair = await storedPairFor(f.orgId, bill, william)
+    expect(pair).toBeDefined()
+    expect(pair?.band).toBe('medium')
+    const signals = (pair?.signals ?? []) as Array<Record<string, unknown>>
+    expect(signals.some((s) => s.type === 'name')).toBe(true)
+    // The blocker's similarity number must never reach storage: full-name
+    // trigram ranks `john smith`/`jane smith` ABOVE every true nickname pair.
+    expect(signals.every((s) => s.similarity === undefined)).toBe(true)
+  })
+
+  it('recovers peggy / margaret, which only the nickname dictionary can do', async () => {
+    // Zero shared trigrams — no string metric reaches this pair, ever.
+    const f = await seedContactOrg()
+    const peggy = await seedPerson(f, 'Peggy', 'Quillfeather')
+    const margaret = await seedPerson(f, 'Margaret', 'Quillfeather')
+
+    await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+
+    expect((await storedPairFor(f.orgId, peggy, margaret))?.band).toBe('medium')
+  })
+
+  it('does NOT pair john smith with jane smith', async () => {
+    // The regression test for the whole name rule. Raw `displayName` trigram
+    // scores this pair 0.4666667 — higher than bill/william (0.4210526) — so a
+    // scorer that ranked on similarity would lead the queue with siblings and
+    // spouses. It fails given-name equivalence AND surname rarity.
+    const f = await seedContactOrg()
+    await seedPerson(f, 'John', 'Smith')
+    await seedPerson(f, 'Jane', 'Smith')
+    for (let i = 0; i < 4; i++) await seedPerson(f, `Filler${i}`, 'Smith')
+
+    await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+
+    expect(await pairCount(f.orgId)).toBe(0)
+  })
+
+  it('does NOT pair john / jane even when the surname is rare', async () => {
+    // Rarity alone must never suggest: with a rare surname, the GIVEN-NAME
+    // condition is the only thing left that can reject this pair, so this is
+    // where a loosened name rule would show up first.
+    const f = await seedContactOrg()
+    await seedPerson(f, 'John', 'Quillfeather')
+    await seedPerson(f, 'Jane', 'Quillfeather')
+
+    await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+
+    expect(await pairCount(f.orgId)).toBe(0)
+  })
+
+  it('reaches bob smith / robert smith through corroboration, past a crowd of Smiths', async () => {
+    // Two fixes meet here. (1) The nickname is a dictionary hit but `smith` is
+    // common, so the pair only reaches `medium` with a corroborating signal —
+    // here a shared `firstInteractionAt` second. (2) The blocker has to GENERATE
+    // the pair at all: the trigram pass is per-anchor capped and truncates
+    // against a crowd of Smiths, which is why the exact-surname anchor pass
+    // exists. Corroboration cannot rescue a pair that was never generated.
+    const f = await seedContactOrg()
+    const sameSecond = new Date('2026-03-01T10:00:00.000Z')
+    for (const given of CROWD_OF_SMITHS) await seedPerson(f, given, 'Smith')
+    const bob = await seedPerson(f, 'Bob', 'Smith', { firstInteractionAt: sameSecond })
+    const robert = await seedPerson(f, 'Robert', 'Smith', { firstInteractionAt: sameSecond })
+
+    await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+
+    const pair = await storedPairFor(f.orgId, bob, robert)
+    expect(pair).toBeDefined()
+    expect(pair?.band).toBe('medium')
+    const types = ((pair?.signals ?? []) as Array<Record<string, unknown>>).map((s) => s.type)
+    expect(types).toContain('name')
+    expect(types).toContain('ingest')
+  })
+
+  it('drops bob / robert on a common surname when nothing corroborates', async () => {
+    const f = await seedContactOrg()
+    for (const given of CROWD_OF_SMITHS) await seedPerson(f, given, 'Smith')
+    const bob = await seedPerson(f, 'Bob', 'Smith')
+    const robert = await seedPerson(f, 'Robert', 'Smith')
+
+    await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+
+    expect(await storedPairFor(f.orgId, bob, robert)).toBeUndefined()
+  })
+
+  it('keeps a pair HIGH when the exact and name arms both fire on it', async () => {
+    // The merge step in `scanRecord`. Both arms produce the same canonical pair,
+    // and `upsertPairs` keeps the last writer — so without merging, a `high`
+    // exact pair is silently rewritten as `medium` by the name arm.
+    const f = await seedContactOrg()
+    const a = await seedPerson(f, 'Bill', 'Quillfeather', { phone: '+12133734253' })
+    const b = await seedPerson(f, 'William', 'Quillfeather', { phone: '+12133734253' })
+
+    await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+
+    const pair = await storedPairFor(f.orgId, a, b)
+    expect(pair?.band).toBe('high')
+    const types = ((pair?.signals ?? []) as Array<Record<string, unknown>>).map((s) => s.type)
+    expect(types).toContain('phone')
+    expect(types).toContain('name')
+  })
+
+  it('runs no name arm for a definition with no surname field', async () => {
+    // Companies have no `firstName`/`lastName`, so the whole arm is skipped
+    // rather than half-run — and the exact keys keep working untouched.
+    const f = await seedContactOrg()
+    await db()
+      .delete(schema.CustomField)
+      .where(eq(schema.CustomField.id, f.lastNameFieldId as string))
+    const a = await seedContact(f, 'Bill Quillfeather', { firstName: 'Bill' })
+    const b = await seedContact(f, 'William Quillfeather', { firstName: 'William' })
+
+    const stats = await runJob({ organizationId: f.orgId, entityDefinitionId: f.defId })
+
+    expect(stats.scanned).toBe(2)
+    expect(await storedPairFor(f.orgId, a, b)).toBeUndefined()
   })
 })
 

--- a/packages/lib/src/jobs/dedup/duplicate-scan-job.ts
+++ b/packages/lib/src/jobs/dedup/duplicate-scan-job.ts
@@ -12,12 +12,32 @@ import { parseRecordId, type RecordId } from '@auxx/types/resource'
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm'
 import { getCachedResourceFields } from '../../cache'
 import { blockIdentity, blockOrgKey, blockRecord } from '../../dedup/blocking'
+import { blockFuzzyRecord, blockSurnameRecord } from '../../dedup/blocking-fuzzy'
 import { DEDUP_V1_ALLOWLIST, getDedupConfig } from '../../dedup/config'
+import {
+  type CorroborationFields,
+  deriveCorroborationFields,
+  evaluateFuzzyPair,
+} from '../../dedup/corroborate'
+import { enqueueDuplicateScanContinuation } from '../../dedup/enqueue-scan'
 import { deriveMatchKeys, type MatchKey } from '../../dedup/match-keys'
+import { normalizeSurname } from '../../dedup/name-match'
 import { rescoreOpenPairsForRecord, upsertPairs } from '../../dedup/pairs'
 import type { ScoredPair } from '../../dedup/scoring'
-import { scoreBlockGroup, scoreIdentityGroup, scoreRecordMatches } from '../../dedup/scoring'
-import type { DedupConfig } from '../../dedup/types'
+import {
+  scoreBlockGroup,
+  scoreIdentityGroup,
+  scorePair,
+  toCandidatePair,
+} from '../../dedup/scoring'
+import {
+  type NameFieldIds,
+  readStructuredNames,
+  resolveNameFieldIds,
+  type SurnameRarity,
+  surnameIdf,
+} from '../../dedup/surname-rarity'
+import type { CandidatePair, DedupConfig, Signal } from '../../dedup/types'
 import { FeaturePermissionService } from '../../permissions/feature-permission-service'
 import { FeatureKey } from '../../permissions/types'
 import type { JobContext } from '../types'
@@ -78,10 +98,13 @@ interface ScanTarget {
  * Duplicate scan — block, score and store `DuplicateSuggestion` pairs for every
  * dirty record in scope.
  *
- * Per record: `deriveMatchKeys` → `blockRecord` → `scoreRecordMatches` →
- * `upsertPairs` → `rescoreOpenPairsForRecord` → stamp `lastDuplicateScanAt`.
- * The rescore step is not optional: without it the store is upsert-only and a
- * corrected email leaves its duplicate suggestion standing forever.
+ * Per record, BOTH arms (see `scanRecord`): the exact arm `deriveMatchKeys` →
+ * `blockRecord`, and the Phase-2 arm `blockFuzzyRecord` + `blockSurnameRecord` →
+ * `readStructuredNames` → `evaluateFuzzyPair`. Their pairs are merged onto the
+ * canonical key, then `scorePair` → `upsertPairs` → `rescoreOpenPairsForRecord`
+ * → stamp `lastDuplicateScanAt`. The rescore step is not optional: without it
+ * the store is upsert-only and a corrected email leaves its duplicate suggestion
+ * standing forever.
  *
  * Never throws — a scan failure must not fail whatever enqueued it. Per-record
  * failures are logged and skipped so one garbage row cannot take down the tick.
@@ -262,6 +285,14 @@ interface DirtyRecord {
    * dirty and the next tick picks it up.
    */
   dirtyAt: string
+  /**
+   * The record's own trigram anchors, projected here rather than re-read per
+   * record inside `blockFuzzyRecord`: the fuzzy arm needs them for EVERY dirty
+   * record, and they cost nothing extra on a query that is already reading the
+   * row.
+   */
+  displayName: string | null
+  secondaryDisplayValue: string | null
 }
 
 async function scanDefinition(args: {
@@ -293,13 +324,27 @@ async function scanDefinition(args: {
     ? await selectLiveRecords(organizationId, entityDefinitionId, instanceIds)
     : await selectDirtyRecords(organizationId, entityDefinitionId, RECORDS_PER_DEFINITION)
 
+  // Resolved ONCE per definition, not per record: the name field ids and the
+  // corroboration field split are stable for the whole scan, and surname rarity
+  // is an aggregate over the definition that a per-pair call would repeat for
+  // every neighbour of every record.
+  const fuzzy = await buildFuzzyContext(target, config, fields)
+
   const counts: ScanCounts = { definitions: 1, scanned: 0, upserted: 0, closed: 0 }
 
   for (const record of dirty) {
     try {
       accumulate(
         counts,
-        await scanRecord({ organizationId, entityDefinitionId, config, keys, record, dryRun })
+        await scanRecord({
+          organizationId,
+          entityDefinitionId,
+          config,
+          keys,
+          fuzzy,
+          record,
+          dryRun,
+        })
       )
     } catch (error) {
       logger.error('Record scan threw', {
@@ -319,18 +364,113 @@ async function scanDefinition(args: {
     accumulate(counts, await runOrgPasses({ organizationId, entityDefinitionId, config, keys }))
   }
 
+  // The watermark query is oldest-dirty-first and capped, so in a definition
+  // with more than RECORDS_PER_DEFINITION dirty records a freshly created record
+  // sorts LAST and would wait for the next trigger or the 6h sweep. Requeue
+  // ourselves instead: the next tick starts from the new watermark, so the
+  // backlog drains in bounded chunks rather than stalling.
+  if (!dryRun && !instanceIds && dirty.length >= RECORDS_PER_DEFINITION) {
+    const cursor = dirty.at(-1)?.dirtyAt ?? ''
+    await enqueueDuplicateScanContinuation(organizationId, entityDefinitionId, cursor).catch(
+      (error: unknown) => {
+        logger.warn('Failed to requeue a capped scan', {
+          organizationId,
+          entityDefinitionId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    )
+  }
+
   return counts
 }
 
+/**
+ * The per-definition state the Phase-2 (fuzzy / name) arm needs, or `null` when
+ * this definition has no person-name shape.
+ *
+ * Companies resolve to `null` — `DedupConfig` carries no
+ * `surnameSystemAttribute` for them — so they keep exactly the exact-key
+ * behaviour they had. The structured comparator is about people; there is no
+ * `firstName`/`lastName` on a company to compare.
+ */
+interface FuzzyContext {
+  corroboration: CorroborationFields
+  nameFields: NameFieldIds & { surnameFieldId: FieldIdString }
+  /**
+   * normalized surname → rarity, memoized for the whole definition scan.
+   *
+   * `surnameIdf` is an aggregate over the definition's surname values, and a
+   * scan commonly walks several records sharing one surname. Resolving it per
+   * pair would repeat that aggregate for every neighbour of every record.
+   */
+  rarityBySurname: Map<string, SurnameRarity>
+}
+
+/** `CustomField.id` as `surname-rarity` brands it. */
+type FieldIdString = NonNullable<NameFieldIds['surnameFieldId']>
+
+async function buildFuzzyContext(
+  target: ScanTarget,
+  config: DedupConfig,
+  fields: Awaited<ReturnType<typeof getCachedResourceFields>>
+): Promise<FuzzyContext | null> {
+  if (!config.surnameSystemAttribute) return null
+
+  const resolved = await resolveNameFieldIds(
+    database,
+    target.organizationId,
+    target.entityDefinitionId,
+    { givenName: config.givenNameSystemAttribute, surname: config.surnameSystemAttribute }
+  )
+  if (resolved.isErr()) {
+    logger.warn('Could not resolve name fields — fuzzy arm disabled for this definition', {
+      organizationId: target.organizationId,
+      entityDefinitionId: target.entityDefinitionId,
+      error: resolved.error.message,
+    })
+    return null
+  }
+
+  const surnameFieldId = resolved.value.surnameFieldId
+  // No surname field ⇒ condition (a) of the name rule can never hold, so the
+  // whole arm is dead weight for this definition.
+  if (!surnameFieldId) return null
+
+  return {
+    corroboration: deriveCorroborationFields(fields),
+    nameFields: { ...resolved.value, surnameFieldId },
+    rarityBySurname: new Map(),
+  }
+}
+
+/**
+ * Block, score and store one record's pairs — **both arms**.
+ *
+ * ```text
+ * exact:  deriveMatchKeys → blockRecord            → toCandidatePair ┐
+ * fuzzy:  blockFuzzyRecord + blockSurnameRecord                     ├→ merge
+ *         → readStructuredNames → evaluateFuzzyPair                 ┘
+ *                    → scorePair → upsertPairs → rescoreOpenPairsForRecord
+ * ```
+ *
+ * 🔴 **The two arms MERGE before scoring, and that is not cosmetic.**
+ * `upsertPairs` dedupes by the conflict key and keeps the last writer, so a pair
+ * found by both arms would be stored with whichever arm happened to be scored
+ * last — a `high` exact pair silently rewritten as `medium`. Merging the signal
+ * sets first also produces the richer "matched on:" chips a reviewer actually
+ * wants: an email match AND a name match on one card, not one of the two.
+ */
 async function scanRecord(args: {
   organizationId: string
   entityDefinitionId: string
   config: DedupConfig
   keys: MatchKey[]
+  fuzzy: FuzzyContext | null
   record: DirtyRecord
   dryRun: boolean
 }): Promise<ScanCounts> {
-  const { organizationId, entityDefinitionId, config, keys, record, dryRun } = args
+  const { organizationId, entityDefinitionId, config, keys, fuzzy, record, dryRun } = args
   const db = database
 
   const matches = await blockRecord(db, {
@@ -350,11 +490,23 @@ async function scanRecord(args: {
     return NO_WORK
   }
 
-  const scored = scoreRecordMatches({
-    organizationId,
-    entityDefinitionId,
-    instanceId: record.id,
-    matches: matches.value,
+  const exact = matches.value.flatMap((match) => {
+    const pair = toCandidatePair({
+      organizationId,
+      entityDefinitionId,
+      instanceId: record.id,
+      match,
+    })
+    return pair ? [pair] : []
+  })
+
+  const fuzzyPairs = fuzzy
+    ? await fuzzyPairsForRecord({ organizationId, entityDefinitionId, fuzzy, record })
+    : []
+
+  const scored = mergeCandidatePairs([...exact, ...fuzzyPairs]).flatMap((pair) => {
+    const result = scorePair(pair)
+    return result ? [result] : []
   })
 
   if (dryRun) {
@@ -392,6 +544,199 @@ async function scanRecord(args: {
     upserted: upserted.isOk() ? upserted.value : 0,
     closed: closed.isOk() ? closed.value : 0,
   }
+}
+
+/** Stable identity for a signal, so the same evidence is never carried twice. */
+const signalKey = (s: Signal) =>
+  `${s.type}|${s.strength}|${s.fieldKey ?? ''}|${s.value}|${s.otherValue ?? ''}`
+
+/**
+ * Fold every candidate pair for one record onto its canonical key, unioning the
+ * signal sets.
+ *
+ * Two arms can produce the same pair — two contacts who share a phone number
+ * usually share a name too — and storage holds ONE row per canonical pair. See
+ * the `scanRecord` docstring for why keeping the last writer instead would
+ * silently downgrade a `high` pair.
+ */
+function mergeCandidatePairs(pairs: CandidatePair[]): CandidatePair[] {
+  const byKey = new Map<string, CandidatePair>()
+  for (const pair of pairs) {
+    const key = `${pair.instanceIdLow}|${pair.instanceIdHigh}`
+    const existing = byKey.get(key)
+    if (!existing) {
+      byKey.set(key, { ...pair, signals: [...pair.signals] })
+      continue
+    }
+    const seen = new Set(existing.signals.map(signalKey))
+    for (const signal of pair.signals) {
+      if (seen.has(signalKey(signal))) continue
+      seen.add(signalKey(signal))
+      existing.signals.push(signal)
+    }
+  }
+  return [...byKey.values()]
+}
+
+/**
+ * The Phase-2 arm for one record: name neighbours → structured comparison →
+ * corroboration → the name-alone rule.
+ *
+ * 🔴 **This is the seam Phase 5 verification found missing.** The modules below
+ * were merged, unit-tested and correct, and had ZERO production callers — so
+ * every stored row was `band: 'high'` and the work-address / name-variant
+ * duplicates the feature exists to catch were invisible. Nothing here
+ * re-implements them; it calls them in the documented order.
+ *
+ * Two candidate sources, not one:
+ *  - `blockFuzzyRecord` — trigram neighbours off the displayName index, which is
+ *    what catches a MISSPELLED surname;
+ *  - `blockSurnameRecord` — an exact match on the surname field, which is what
+ *    catches a nickname behind a COMMON surname. The trigram pass truncates
+ *    against 19 Smiths, so `Bob Smith` / `Robert Smith` is unreachable without
+ *    it (measured), and corroboration cannot rescue a pair that was never
+ *    generated.
+ *
+ * A record with no surname returns nothing: condition (a) of the name rule
+ * cannot hold, and neither can the reversed-order fallback, since that compares
+ * this record's `lastName` against the other's `firstName`.
+ *
+ * ⚠️ **One accepted asymmetry.** `rescoreOpenPairsForRecord` treats a record's
+ * fresh set as a complete statement about every pair it belongs to, which is
+ * exactly true for exact blocking (scanning A finds B iff scanning B finds A).
+ * The name arm is symmetric on an exact surname match, but on a TYPO'd one the
+ * two sides resolve rarity for different normalized surnames — `smiht` can be
+ * rare where `smith` is common — so scanning one side may create a pair the
+ * other side's scan then closes. It settles after both have been scanned (each
+ * runs only while dirty, so there is no loop), and it fails toward dropping a
+ * borderline pair rather than keeping one. Not worth a second rarity lookup per
+ * pair to close.
+ */
+async function fuzzyPairsForRecord(args: {
+  organizationId: string
+  entityDefinitionId: string
+  fuzzy: FuzzyContext
+  record: DirtyRecord
+}): Promise<CandidatePair[]> {
+  const { organizationId, entityDefinitionId, fuzzy, record } = args
+  const db = database
+
+  const ownNames = await readStructuredNames(db, organizationId, [record.id], fuzzy.nameFields)
+  if (ownNames.isErr()) return []
+  const own = ownNames.value.get(record.id)
+  if (!own?.lastName) return []
+
+  const [neighbours, sameSurname] = await Promise.all([
+    blockFuzzyRecord(db, {
+      organizationId,
+      entityDefinitionId,
+      instanceId: record.id,
+      anchors: {
+        displayName: record.displayName,
+        secondaryDisplayValue: record.secondaryDisplayValue,
+        surname: own.lastName,
+      },
+    }),
+    blockSurnameRecord(db, {
+      organizationId,
+      entityDefinitionId,
+      instanceId: record.id,
+      surnameFieldId: fuzzy.nameFields.surnameFieldId,
+      surname: own.lastName,
+    }),
+  ])
+
+  const candidateIds = [
+    ...new Set([
+      ...(neighbours.isOk() ? neighbours.value : []).map((c) => c.instanceId),
+      ...(sameSurname.isOk() ? sameSurname.value : []).map((c) => c.instanceId),
+    ]),
+  ].filter((id) => id !== record.id)
+  if (candidateIds.length === 0) return []
+
+  // One query for the whole candidate set, not one per candidate.
+  const names = await readStructuredNames(db, organizationId, candidateIds, fuzzy.nameFields)
+  if (names.isErr()) return []
+
+  const rarity = await resolveSurnameRarity(fuzzy, organizationId, entityDefinitionId, own.lastName)
+
+  const pairs: CandidatePair[] = []
+  for (const otherId of candidateIds) {
+    const other = names.value.get(otherId)
+    if (!other) continue
+
+    // Canonical order is a STORAGE invariant, so the pair is oriented here and
+    // `evaluateFuzzyPair` is handed the two names already on that axis — the
+    // signals it returns need no re-orientation downstream.
+    const swap = record.id > otherId
+    const instanceIdLow = swap ? otherId : record.id
+    const instanceIdHigh = swap ? record.id : otherId
+
+    const signals = await evaluateFuzzyPair(db, {
+      organizationId,
+      entityDefinitionId,
+      instanceIdLow,
+      instanceIdHigh,
+      fields: fuzzy.corroboration,
+      nameLow: swap ? other : own,
+      nameHigh: swap ? own : other,
+      surnameFieldId: fuzzy.nameFields.surnameFieldId,
+      surnameRarity: rarity,
+    })
+    if (signals.isErr()) {
+      logger.warn('Fuzzy pair evaluation failed', {
+        organizationId,
+        entityDefinitionId,
+        instanceIdLow,
+        instanceIdHigh,
+        error: signals.error.message,
+      })
+      continue
+    }
+    if (signals.value.length === 0) continue
+
+    pairs.push({
+      organizationId,
+      entityDefinitionId,
+      instanceIdLow,
+      instanceIdHigh,
+      signals: signals.value,
+    })
+  }
+
+  return pairs
+}
+
+/**
+ * Surname rarity for the SCANNED record, memoized per definition scan.
+ *
+ * Keyed on the scanned record's surname rather than the pair's because
+ * condition (a) already requires the two surnames to be equal or within a typo
+ * of each other — and because a scan walks many records that share one surname,
+ * which is exactly the case a per-pair aggregate would pay for repeatedly.
+ */
+async function resolveSurnameRarity(
+  fuzzy: FuzzyContext,
+  organizationId: string,
+  entityDefinitionId: string,
+  surname: string
+): Promise<SurnameRarity | undefined> {
+  const key = normalizeSurname(surname)
+  if (!key) return undefined
+
+  const cached = fuzzy.rarityBySurname.get(key)
+  if (cached) return cached
+
+  const computed = await surnameIdf(database, organizationId, entityDefinitionId, surname, {
+    surnameFieldId: fuzzy.nameFields.surnameFieldId,
+  })
+  // Undefined, not a fabricated `rare: false`: `evaluateFuzzyPair` resolves its
+  // own rarity when none is supplied, so a transient failure here degrades to an
+  // extra query rather than to a silently suppressed suggestion.
+  if (computed.isErr()) return undefined
+
+  fuzzy.rarityBySurname.set(key, computed.value)
+  return computed.value
 }
 
 async function runOrgPasses(args: {
@@ -478,7 +823,9 @@ async function selectDirtyRecords(
   limit: number
 ): Promise<DirtyRecord[]> {
   const result = await database.execute(sql`
-    SELECT ei."id" AS "id", ${DIRTY_AT}::text AS "dirtyAt"
+    SELECT ei."id" AS "id", ${DIRTY_AT}::text AS "dirtyAt",
+           ei."displayName" AS "displayName",
+           ei."secondaryDisplayValue" AS "secondaryDisplayValue"
     FROM "EntityInstance" ei
     ${FIELD_VALUE_LATERAL}
     WHERE ei."organizationId" = ${organizationId}
@@ -513,7 +860,9 @@ async function selectLiveRecords(
   )
 
   const result = await database.execute(sql`
-    SELECT ei."id" AS "id", ${DIRTY_AT}::text AS "dirtyAt"
+    SELECT ei."id" AS "id", ${DIRTY_AT}::text AS "dirtyAt",
+           ei."displayName" AS "displayName",
+           ei."secondaryDisplayValue" AS "secondaryDisplayValue"
     FROM "EntityInstance" ei
     ${FIELD_VALUE_LATERAL}
     WHERE ei."organizationId" = ${organizationId}
@@ -528,7 +877,13 @@ function toDirtyRecords(result: unknown): DirtyRecord[] {
   const rows = ((result as { rows?: unknown[] })?.rows ?? []) as Array<Record<string, unknown>>
   return rows
     .filter((row) => row.id != null && row.dirtyAt != null)
-    .map((row) => ({ id: String(row.id), dirtyAt: String(row.dirtyAt) }))
+    .map((row) => ({
+      id: String(row.id),
+      dirtyAt: String(row.dirtyAt),
+      displayName: row.displayName == null ? null : String(row.displayName),
+      secondaryDisplayValue:
+        row.secondaryDisplayValue == null ? null : String(row.secondaryDisplayValue),
+    }))
 }
 
 /**


### PR DESCRIPTION
Phase 2 name matching shipped as dead code. The modules merged, were correct
and were unit-tested, but `scanRecord` only ever called `blockRecord` — so
every stored suggestion was `band: 'high'` and no `medium` row could exist.
The work/personal-address and name-variant duplicates the feature was designed
around were invisible.

`scanRecord` now runs both arms and MERGES them onto the canonical key before
scoring. The merge is load-bearing: `upsertPairs` dedupes by conflict key
keeping the last writer, so an unmerged `high` exact pair would be silently
rewritten as `medium`. Per-definition state resolves once per definition, and
definitions with no surname field skip the arm.

The regression guard is a job-level DB-backed test, not a module test — module
tests all passed while the wiring did not exist. Verified by disabling the arm:
the four positive cases fail and the four negatives stay green.

Blocker recall: an exact-surname anchor pass (`blockSurnameRecord`) alongside
the trigram anchor. Raising `FUZZY_BLOCK_LIMIT` alone does not fix
Bob/Robert — with the anchor disabled it still fails at a limit of 20, because
~24 same-surname neighbours crowd out the match. The name rule is untouched, so
precision on `John Smith`/`Jane Smith` does not move.

Surfaces: the queue paginates by cursor instead of silently truncating at 25;
clusters collapse to one row per connected component instead of N rows all
offering the same merge; the `company_domain` chip reads "Domain" rather than
"Unique field".

Also: merge-target defaulting tie-breaks on oldest `createdAt` so a merge with
no establishment signals stops landing on the emptiest record; reopen clears
`dismissedBand`; the scan self-requeues when it hits the per-definition cap,
keyed on the stopping watermark rather than the org+def jobId the running job
already holds.

---
Found by Phase 5 browser verification, not by tests — the entire Phase 2 module suite was green while the capability was unreachable in production.

**Root cause was process:** Phase 1 wiring and Phase 2 modules were built in parallel with deliberately disjoint file sets. The job was off-limits to the name agent, and the name modules did not exist when the job was written, so the integration seam belonged to neither side.

**Accepted tradeoffs, documented in code:**
- `duplicates.count` counts *pairs* while the list renders *clusters*, so the badge can exceed visible rows. Counting components needs an unbounded union-find on a query that runs whenever the bell mounts.
- On a typo'd surname the two sides resolve rarity for different normalized surnames, so one side's scan can create a pair the other's rescore closes. It settles once both are scanned and fails toward dropping a borderline pair.

Needs Phase 5 browser re-verification after merge. Plan: `plans/records/duplicate-suggestion-plan-v2.md` (local-only — `/plans` is gitignored).