### PR TITLE
feat(workflow): one-call form-input authoring via add_node inputFor

### DIFF
--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/add-node.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/add-node.ts
@@ -12,9 +12,9 @@ import { optionalRecord, optionalString, resolveWorkflowWrite } from './write-to
 
 /**
  * Add one node to the open workflow's draft. Thin wrapper over graph-edit
- * `addNode` — placement, branch resolution, containment, normalization and
- * validation all live there. Non-authorable types are refused by graph-edit
- * with an honest error naming the type and the authorable set.
+ * `addNode` — placement, branch resolution, containment, input wiring,
+ * normalization and validation all live there. Non-authorable types are refused
+ * by graph-edit with an honest error naming the type and the authorable set.
  */
 export function createAddNodeTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
@@ -23,7 +23,7 @@ export function createAddNodeTool(getDeps: GetToolDeps): AgentToolDefinition {
     displayName: 'Add workflow node',
     surfaces: ['builder'],
     description:
-      'Add one node to the open workflow draft. Connect it with `after` (predecessor title) and optionally `branch` (branch NAME of the predecessor); place it inside a loop with `inside` (loop title). Do not send coordinates — layout is automatic. The result returns the node, its resolved outputs (wire `{{Title.path}}` refs from these), and any issues.',
+      'Add one node to the open workflow draft. Connect it with `after` (predecessor title) and optionally `branch` (branch NAME of the predecessor); place it inside a loop with `inside` (loop title); attach an input node (form-input) to a trigger’s run form with `inputFor` (trigger title). Do not send coordinates — layout is automatic. The result returns the node, its resolved outputs (wire `{{Title.path}}` refs from these), and any issues.',
     parameters: {
       type: 'object',
       properties: {
@@ -42,6 +42,11 @@ export function createAddNodeTool(getDeps: GetToolDeps): AgentToolDefinition {
         after: { type: 'string', description: 'Predecessor node (title) to connect from.' },
         branch: { type: 'string', description: 'Branch NAME of `after` to leave on.' },
         inside: { type: 'string', description: 'Loop node (title) to place this node inside.' },
+        inputFor: {
+          type: 'string',
+          description:
+            'Trigger node (title) whose RUN FORM this node adds a field to — for input node types (form-input) only. The edge runs backwards into the trigger, so this replaces the old two-step of add_node followed by connect_nodes FROM the field TO the trigger. Cannot be combined with `after` or `inside`.',
+        },
       },
       required: ['type'],
       additionalProperties: false,
@@ -70,6 +75,7 @@ export function createAddNodeTool(getDeps: GetToolDeps): AgentToolDefinition {
         ...(optionalString(args.after) ? { after: optionalString(args.after) } : {}),
         ...(optionalString(args.branch) ? { branch: optionalString(args.branch) } : {}),
         ...(optionalString(args.inside) ? { inside: optionalString(args.inside) } : {}),
+        ...(optionalString(args.inputFor) ? { inputFor: optionalString(args.inputFor) } : {}),
       })
       return mutationToToolResult(result, (value) =>
         value.applied ? `Added ${value.node?.title ?? type}` : `Add ${type} blocked`

--- a/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
@@ -53,6 +53,7 @@ export function buildWorkflowBuilderPromptSection(): string {
       '  - update_node(ref: "Send Email", config: { subject: "Order {{Find Order.record.number}} update" })',
       '  - get_node(ref: "AI Agent") → update_node(ref: "AI Agent", expectedConfigHash: "<returned configHash>", patches: [{ op: "set", path: ["model", "completion_params", "temperature"], value: 0.2 }])',
       '  - add_node(type: "crud", title: "Create Task", inside: "For Each Line Item", config: { … "{{For Each Line Item.item.name}}" … })',
+      '  - add_node(type: "form-input", title: "Ticket Subject", description: "The subject the agent types when starting the workflow", inputFor: "Manual Trigger", config: { label: "Subject", inputType: "string", required: true })',
       '  - connect_nodes(from: "Summarize Email", to: "Save Summary")',
     ].join('\n'),
 

--- a/packages/lib/src/workflow-engine/catalog/nodes/form-input.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/form-input.ts
@@ -465,9 +465,12 @@ export const formInputManifest: NodeManifest<FormInputNodeData> = {
     authorable: true,
     usage:
       'Declares ONE field on a manual trigger’s run form. This node never runs on its own — ' +
-      'it only has an effect once it is connected to a `manual` trigger, so always follow it ' +
-      'with connect_nodes FROM the form-input node TO the trigger (the edge runs backwards, ' +
-      'into the trigger). A form-input node that is not connected to a trigger does nothing. ' +
+      'it only has an effect once it is attached to a `manual` trigger, so add it with ' +
+      'add_node({ type: "form-input", inputFor: "<trigger title>" }), which creates the field ' +
+      'and wires it onto that trigger’s run form in ONE call (the edge runs backwards, into ' +
+      'the trigger). Use connect_nodes FROM the form-input node TO the trigger only to attach a ' +
+      'form-input that already exists and is not wired up. A form-input node that is not ' +
+      'attached to a trigger does nothing. ' +
       '`label` is what the person filling the form sees and is required. `inputType` is one of ' +
       'string, number, boolean, email, url, phone, date, datetime, time, enum, file, currency, ' +
       'address, tags, array — it decides both the form control and the variables the node ' +
@@ -479,7 +482,7 @@ export const formInputManifest: NodeManifest<FormInputNodeData> = {
       '`multiline` / `minLength` / `maxLength`.',
     examples: [
       {
-        description: 'A required single-line text field (connect it to the manual trigger next)',
+        description: 'A required single-line text field (add it with inputFor: the trigger title)',
         config: {
           title: 'Ticket Subject',
           label: 'Subject',

--- a/packages/lib/src/workflows/graph-edit/__tests__/input-wiring.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/input-wiring.test.ts
@@ -1,14 +1,17 @@
 // packages/lib/src/workflows/graph-edit/__tests__/input-wiring.test.ts
 
 /**
- * Input wiring (`plans/kopilot/workflow/15-form-input-migration.md` §2/§4a/§5):
+ * Input wiring (`plans/kopilot/workflow/15-form-input-migration.md` §2/§4/§5):
  * a `form-input` node attaches to a `manual` trigger with a BACKWARDS edge on
  * two non-standard handles (`input-output` → `input`). Three structural rules
  * used to reject that shape outright, which made every workflow containing a
  * form-input node — and `apply_template('manual-ticket-triage')` — un-editable.
  *
  * These tests pin BOTH directions: the wiring validates and round-trips, and
- * the rules it excepts still fire for everything else.
+ * the rules it excepts still fire for everything else. §4b adds the one-call
+ * authoring path — `addNode({ inputFor })` — where the writer must produce
+ * exactly the graph shape the first block accepts, place the field in the
+ * trigger's input column, and give it a run-form `position`.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -38,8 +41,12 @@ vi.mock('../../mail-trigger-guard', () => ({
   assertMailTriggerNotPersonal: (...args: unknown[]) => mailGuard(...args),
 }))
 
-const { applyTemplate, connectNodes, deleteNodes, disconnectNodes } = await import('../ops')
+const { addNode, applyTemplate, connectNodes, deleteNodes, disconnectNodes } = await import(
+  '../ops'
+)
+const { runNode } = await import('../run-node')
 
+import { BadRequestError } from '../../../errors'
 import { manualManifest } from '../../../workflow-engine/catalog/nodes/manual'
 import { staticOutputContext } from '../../../workflow-engine/catalog/output-context'
 // The SHIPPED template, loaded rather than re-typed, so this test cannot drift
@@ -363,6 +370,167 @@ describe('edge handle resolution (§4a)', () => {
     const typeOf = (id: string) => persisted.nodes.find((n) => n.id === id)?.data?.type
     expect(inputEdges.map((e) => typeOf(e.source))).toEqual(['form-input', 'form-input'])
     expect(inputEdges.map((e) => typeOf(e.target))).toEqual(['manual', 'manual'])
+  })
+})
+
+describe('addNode({ inputFor }) (§4b)', () => {
+  const scope = { workflowAppId: APP, organizationId: ORG }
+
+  /** A graph with just the trigger and one downstream node. */
+  function triggerGraph(): DraftGraph {
+    return {
+      nodes: [manualNode(), waitNode()],
+      edges: [edge(MANUAL_ID, 'source', WAIT_ID)],
+    }
+  }
+
+  /** The node the last persist added (the one not present in `before`). */
+  function addedNode(before: DraftGraph): GraphNode {
+    const known = new Set(before.nodes.map((n) => n.id))
+    const node = persistedGraph().nodes.find((n) => !known.has(n.id))
+    expect(node).toBeDefined()
+    return node as GraphNode
+  }
+
+  it('creates the field, wires it on the input handles and validates clean', async () => {
+    const graph = triggerGraph()
+    const result = await addNode(makeDb(graph), {
+      ...scope,
+      type: 'form-input',
+      title: 'Ticket Subject',
+      inputFor: 'Manual Trigger',
+      config: { label: 'Subject', inputType: 'string', required: true },
+    })
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().applied).toBe(true)
+
+    const persisted = persistedGraph()
+    const created = addedNode(graph)
+    expect(created.data?.type).toBe('form-input')
+    expect(created.data?.label).toBe('Subject')
+
+    const wired = persisted.edges.find((e) => e.source === created.id)
+    expect(wired?.target).toBe(MANUAL_ID)
+    expect(wired?.sourceHandle).toBe('input-output')
+    expect(wired?.targetHandle).toBe('input')
+
+    // Canvas parity, and the graph the writer produced is one the validator accepts.
+    expect(persisted.nodes.find((n) => n.id === MANUAL_ID)?.data?.inputNodes).toEqual([created.id])
+    expect(errors(validateGraphStructure(persisted))).toEqual([])
+  })
+
+  it('stacks a second field left of the trigger with an ordered run-form position', async () => {
+    const first = triggerGraph()
+    const firstResult = await addNode(makeDb(first), {
+      ...scope,
+      type: 'form-input',
+      title: 'Ticket Subject',
+      inputFor: 'Manual Trigger',
+      config: { label: 'Subject' },
+    })
+    expect(firstResult._unsafeUnwrap().applied).toBe(true)
+    const afterFirst = persistedGraph()
+    const subject = addedNode(first)
+
+    const secondResult = await addNode(makeDb(afterFirst), {
+      ...scope,
+      type: 'form-input',
+      title: 'Ticket Body',
+      inputFor: 'Manual Trigger',
+      config: { label: 'Body' },
+    })
+    expect(secondResult._unsafeUnwrap().applied).toBe(true)
+    const afterSecond = persistedGraph()
+    const body = addedNode(afterFirst)
+
+    // Own column, 300px left of the trigger; stacked 100px apart.
+    expect(subject.position).toEqual({ x: 100 - 300, y: 300 })
+    expect(body.position).toEqual({ x: 100 - 300, y: 400 })
+
+    // Fractional run-form order — distinct, and sorting them reproduces the
+    // order they were added in (the connected-inputs editor sorts on this).
+    const subjectPosition = subject.data?.position as string
+    const bodyPosition = body.data?.position as string
+    expect(typeof subjectPosition).toBe('string')
+    expect(typeof bodyPosition).toBe('string')
+    expect(subjectPosition).not.toEqual(bodyPosition)
+    expect(subjectPosition.localeCompare(bodyPosition)).toBeLessThan(0)
+
+    expect(afterSecond.nodes.find((n) => n.id === MANUAL_ID)?.data?.inputNodes).toEqual([
+      subject.id,
+      body.id,
+    ])
+    expect(errors(validateGraphStructure(afterSecond))).toEqual([])
+  })
+
+  it('keeps a `position` the caller set explicitly', async () => {
+    const graph = triggerGraph()
+    const result = await addNode(makeDb(graph), {
+      ...scope,
+      type: 'form-input',
+      title: 'Ticket Subject',
+      inputFor: 'Manual Trigger',
+      config: { label: 'Subject', position: 'a5' },
+    })
+    expect(result._unsafeUnwrap().applied).toBe(true)
+    expect(addedNode(graph).data?.position).toBe('a5')
+  })
+
+  it('refuses a target that does not accept input nodes', async () => {
+    const result = await addNode(makeDb(triggerGraph()), {
+      ...scope,
+      type: 'form-input',
+      inputFor: 'Cool Down',
+      config: { label: 'Subject' },
+    })
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+    expect(result._unsafeUnwrapErr().message).toMatch(/does not take input nodes/)
+    expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('refuses a node type that is not an input node', async () => {
+    const result = await addNode(makeDb(triggerGraph()), {
+      ...scope,
+      type: 'wait',
+      inputFor: 'Manual Trigger',
+    })
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+    expect(result._unsafeUnwrapErr().message).toMatch(/is not an input node/)
+    expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('refuses `inputFor` combined with `after`', async () => {
+    const result = await addNode(makeDb(triggerGraph()), {
+      ...scope,
+      type: 'form-input',
+      inputFor: 'Manual Trigger',
+      after: 'Manual Trigger',
+      config: { label: 'Subject' },
+    })
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+    expect(result._unsafeUnwrapErr().message).toMatch(/cannot be combined/)
+    expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe('runNode refusal for canRunSingle: false (§4)', () => {
+  it('refuses to run a form-input node instead of handing it to the engine', async () => {
+    const graph: DraftGraph = {
+      nodes: [formInputNode(), manualNode([FORM_ID]), waitNode()],
+      edges: [inputEdge(FORM_ID, MANUAL_ID), edge(MANUAL_ID, 'source', WAIT_ID)],
+    }
+    const result = await runNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      nodeId: 'Ticket Subject',
+      userId: 'user_1',
+    })
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+    expect(result._unsafeUnwrapErr().message).toMatch(/cannot be run on its own/)
   })
 })
 

--- a/packages/lib/src/workflows/graph-edit/ops.ts
+++ b/packages/lib/src/workflows/graph-edit/ops.ts
@@ -17,14 +17,14 @@
  */
 
 import type { Database } from '@auxx/database'
-import { incrementTitle } from '@auxx/utils'
+import { incrementTitle, nextKeyAfter } from '@auxx/utils'
 import { generateId } from '@auxx/utils/generateId'
 import { err, ok, type Result } from 'neverthrow'
 import { AuxxError, BadRequestError, ConflictError, NotFoundError } from '../../errors'
 import { LOOP_HANDLES } from '../../workflow-engine/catalog/nodes/loop'
 import { getAuthorableManifests, getManifest } from '../../workflow-engine/catalog/registry'
 import { resolveGraphOutputs } from '../../workflow-engine/catalog/resolve-outputs'
-import type { NodeManifest } from '../../workflow-engine/catalog/types'
+import { NodeCategory, type NodeManifest } from '../../workflow-engine/catalog/types'
 import type { UnifiedVariable } from '../../workflow-engine/types/unified-variable'
 import { assertMailTriggerNotPersonal } from '../mail-trigger-guard'
 import { calculateContainerSize, getLayoutByDagre, getLayoutForChildNodes } from './layout'
@@ -40,6 +40,7 @@ import {
   DEFAULT_NODE_SIZE,
   findNearestEmptySpace,
   placeAfter,
+  placeAsInput,
   placeInside,
   placeStandalone,
 } from './place-node'
@@ -330,6 +331,53 @@ function updateInputNodes(
   })
 }
 
+/**
+ * The nodes already wired into `targetId` on the input handle, in graph order.
+ * Read off the EDGES rather than `data.inputNodes` — the edge is the contract
+ * the validator and the engine both judge, the list is cosmetic parity.
+ */
+function wiredInputNodes(nodes: GraphNode[], edges: GraphEdge[], targetId: string): GraphNode[] {
+  const sources = new Set(
+    edges
+      .filter(
+        (e) =>
+          e.target === targetId &&
+          (e.targetHandle ?? 'target') === INPUT_WIRING_HANDLES.targetHandle
+      )
+      .map((e) => e.source)
+  )
+  return nodes.filter((n) => sources.has(n.id))
+}
+
+/**
+ * The next run-form `position` for a field joining `existingInputs` — the
+ * fractional index (`generateKeyBetween`) that orders fields on the manual
+ * trigger's form, NOT a canvas coordinate. Without it every agent-created field
+ * lands `position: undefined` and the connected-inputs editor sorts them
+ * unstably (its comparator returns 0 for two undefineds).
+ *
+ * `nextKeyAfter` rather than the strict `generateKeyBetween`: a legacy or
+ * hand-edited node can carry a corrupt key, and the strict call throws on one,
+ * which would poison every later insert into the same form.
+ */
+function nextInputPosition(existingInputs: GraphNode[]): string {
+  const positions = existingInputs
+    .map((n) => n.data?.position)
+    .filter((p): p is string => typeof p === 'string' && p !== '')
+    .sort((a, b) => a.localeCompare(b))
+  return nextKeyAfter(positions.at(-1) ?? null)
+}
+
+/**
+ * Whether a node type's config schema declares the run-form `position` key, so
+ * only types that order themselves on a form get one assigned. Read off the
+ * manifest's own schema — never a node-type string match.
+ */
+function declaresRunFormPosition(manifest: NodeManifest<any>): boolean {
+  const shape = (manifest.configSchema as unknown as { shape?: Record<string, unknown> }).shape
+  return typeof shape === 'object' && shape !== null && 'position' in shape
+}
+
 /** Fresh node data — NodeFactory parity (defaults under config, identity on top). */
 function buildNodeData(
   manifest: NodeManifest<any>,
@@ -386,6 +434,14 @@ export interface AddNodeInput extends GraphMutationScope {
   branch?: string
   /** Loop container to place the node inside (title or id). */
   inside?: string
+  /**
+   * Node whose run form this node adds a field to (title or id) — the BACKWARDS
+   * input wiring (`form-input --input-output--> manual --input`). Mutually
+   * exclusive with `after`/`inside`: `after` connects FROM the anchor TO the new
+   * node, which is the wrong direction for an input, and an input node is never
+   * a loop child.
+   */
+  inputFor?: string
   /** Explicit canvas position — omitted, the §4 placement rules decide. */
   position?: Point
 }
@@ -396,7 +452,10 @@ export interface AddNodeInput extends GraphMutationScope {
  * written on the branch handle resolved through
  * `manifest.connection.branches`. With `inside`, the node is contained in the
  * loop (top-level `parentId`, parent-relative position, loop-start edge for
- * the first child, container resized to fit). Existing nodes never move.
+ * the first child, container resized to fit). With `inputFor`, an INPUT-category
+ * node attaches to a node that declares `acceptsInputNodes` — the edge runs
+ * backwards on the input handles, the node lands in the target's input column
+ * and gets the next run-form `position`. Existing nodes never move.
  */
 export async function addNode(
   db: Database,
@@ -408,6 +467,51 @@ export async function addNode(
     const manifest = manifestResult.value
 
     const { nodes, edges } = ctx.graph
+
+    // Input wiring is its own attachment mode — the edge runs backwards, so
+    // combining it with a forward `after` (or with loop containment) describes
+    // no graph the canvas can draw.
+    if (params.inputFor !== undefined && params.after !== undefined) {
+      return err(
+        new BadRequestError(
+          '`inputFor` and `after` cannot be combined — `after` connects FROM a predecessor TO the ' +
+            'new node, while `inputFor` attaches the new node BACKWARDS onto the run form of the ' +
+            'node it names. Pick one.'
+        )
+      )
+    }
+    if (params.inputFor !== undefined && params.inside !== undefined) {
+      return err(
+        new BadRequestError(
+          '`inputFor` and `inside` cannot be combined — an input node declares a field on a ' +
+            "trigger's run form and is never a loop body node."
+        )
+      )
+    }
+
+    // Resolve the input-wiring target: it must DECLARE that it accepts inputs.
+    // (The other half of the rule — that the node being added is an INPUT-
+    // category type — is checked below, once the node exists, through the same
+    // `isInputNodePair` the validator judges the persisted graph with.)
+    let inputTarget: GraphNode | undefined
+    if (params.inputFor !== undefined) {
+      const resolved = resolveNodeRef(nodes, params.inputFor)
+      if (resolved.isErr()) return err(resolved.error)
+      inputTarget = resolved.value.node as GraphNode
+      if (getManifest(nodeType(inputTarget))?.connection.acceptsInputNodes !== true) {
+        const accepting = getAuthorableManifests()
+          .filter((m) => m.connection.acceptsInputNodes === true)
+          .map((m) => m.id)
+          .sort()
+          .join(', ')
+        return err(
+          new BadRequestError(
+            `Node ${describeNode(inputTarget)} does not take input nodes — only a node with a run ` +
+              `form does. Node types that accept inputs: ${accepting || 'none'}.`
+          )
+        )
+      }
+    }
 
     // Resolve containment and/or the predecessor connection.
     let parentId: string | undefined
@@ -458,12 +562,20 @@ export async function addNode(
         : manifest.displayName)
     const title = uniqueTitle(baseTitle, nodes)
 
+    // The fields already on the target's run form — both the placement stack
+    // and the fractional `position` order are derived from them.
+    const existingInputs = inputTarget
+      ? wiredInputNodes(nodes as GraphNode[], edges, inputTarget.id)
+      : []
+
     // §4 placement — existing nodes never move; only the new node is placed.
     const parent = parentId ? nodes.find((n) => n.id === parentId) : undefined
     let position = params.position
     let resizedParent: GraphNode | undefined
     if (!position) {
-      if (parent) {
+      if (inputTarget) {
+        position = placeAsInput(inputTarget, existingInputs)
+      } else if (parent) {
         const children = nodes.filter((n) => n.parentId === parent.id)
         const anchor = connection ? nodes.find((n) => n.id === connection.sourceNodeId) : undefined
         if (anchor && anchor.id !== parent.id) {
@@ -491,6 +603,13 @@ export async function addNode(
       }
     }
 
+    // Run-form order: the field joins the end of the target's form unless the
+    // caller pinned a `position` itself.
+    const runFormPosition =
+      inputTarget && normalized.config.position === undefined && declaresRunFormPosition(manifest)
+        ? { position: nextInputPosition(existingInputs) }
+        : {}
+
     const newNode: GraphNode = {
       id: nodeId,
       type: params.type === 'note' ? 'note' : 'standard',
@@ -499,23 +618,57 @@ export async function addNode(
       width: DEFAULT_NODE_SIZE.width,
       height: DEFAULT_NODE_SIZE.height,
       selected: false,
-      data: buildNodeData(manifest, nodeId, normalized.config, {
-        title,
-        ...(parentId ? { loopId: parentId } : {}),
-      }),
+      data: buildNodeData(
+        manifest,
+        nodeId,
+        { ...normalized.config, ...runFormPosition },
+        {
+          title,
+          ...(parentId ? { loopId: parentId } : {}),
+        }
+      ),
+    }
+
+    // The other half of the input-wiring rule, asked of the real node through
+    // the one predicate `validateGraphStructure` uses — so this can never mint
+    // an edge the validator would then reject.
+    if (inputTarget && !isInputNodePair(newNode, inputTarget)) {
+      const inputTypes = getAuthorableManifests()
+        .filter((m) => m.category === NodeCategory.INPUT)
+        .map((m) => m.id)
+        .sort()
+        .join(', ')
+      return err(
+        new BadRequestError(
+          `Node type "${params.type}" is not an input node, so it cannot be attached to the run ` +
+            `form of ${describeNode(inputTarget)}. Use \`inputFor\` only for input node types: ` +
+            `${inputTypes || 'none'}. To connect "${params.type}" downstream of a node, use \`after\`.`
+        )
+      )
     }
 
     const newEdges: GraphEdge[] = []
-    if (connection) {
+    if (inputTarget) {
+      const handles = resolveEdgeHandles(newNode, inputTarget, 'source')
+      newEdges.push(makeEdge(nodeId, handles.sourceHandle, inputTarget.id, handles.targetHandle))
+    } else if (connection) {
       newEdges.push(makeEdge(connection.sourceNodeId, connection.sourceHandle, nodeId, 'target'))
     } else if (parent && nodes.every((n) => n.parentId !== parent.id)) {
       // First child of a loop: the canvas wires loop-start → first body node.
       newEdges.push(makeEdge(parent.id, LOOP_HANDLES.LOOP_START, nodeId, 'target'))
     }
 
-    const nextNodes = nodes.map((n) =>
+    let nextNodes = nodes.map((n) =>
       resizedParent && n.id === resizedParent.id ? resizedParent : n
     )
+    if (inputTarget) {
+      // Canvas parity: the target lists the input nodes wired into it.
+      nextNodes = updateInputNodes(
+        nextNodes as GraphNode[],
+        (current) => (current.includes(nodeId) ? current : [...current, nodeId]),
+        { onlyNodeId: inputTarget.id }
+      )
+    }
     return ok({
       graph: {
         nodes: [...nextNodes, newNode],

--- a/packages/lib/src/workflows/graph-edit/place-node.ts
+++ b/packages/lib/src/workflows/graph-edit/place-node.ts
@@ -19,6 +19,9 @@
  *   below the lowest sibling, so branch targets stack downward.
  * - `inside`: grid position within the container bounds (parent-relative
  *   coordinates), with a container-resize suggestion when the child overflows.
+ * - `inputFor`: its own column to the LEFT of the node it feeds, existing
+ *   inputs stacked downward (the input wiring runs backwards, so an input node
+ *   is the one thing that never lands right of its anchor).
  * - no anchor: to the right of the whole graph.
  */
 
@@ -142,6 +145,40 @@ export function placeAfter(
     y: lowestBottom + NODE_ADDITION_CONFIG.VERTICAL_SPACING,
   }
   return findNearestEmptySpace(preferred, size, nodes, 'vertical')
+}
+
+/**
+ * Geometry of the input column, read off the shipped `manual-ticket-triage`
+ * template: the manual trigger sits at `(100, 300)` and its two form-inputs at
+ * `(-200, 225)` and `(-200, 325)` — one column 300px left, fields 100px apart.
+ */
+const INPUT_COLUMN = { OFFSET_X: 300, STACK_SPACING: 100 }
+
+/**
+ * Position for an input node attaching to `target` (`form-input → manual`):
+ * its own column `INPUT_COLUMN.OFFSET_X` to the LEFT of the target, the first
+ * field vertically centered on it and every later field stacked
+ * `INPUT_COLUMN.STACK_SPACING` below the lowest existing one.
+ *
+ * `existingInputs` are the nodes ALREADY wired into `target` on the input
+ * handle. They never move (the §4 placement invariant), so the stack grows
+ * downward from wherever it currently ends rather than re-centering — which is
+ * also why this deliberately skips `findNearestEmptySpace`: the 100px step is
+ * the rule, and the collision search (padding 20 against a 100px default
+ * footprint) would push every second field out of the column it belongs to.
+ */
+export function placeAsInput(
+  target: GraphNode,
+  existingInputs: GraphNode[],
+  size: Size = DEFAULT_NODE_SIZE
+): Point {
+  const x = target.position.x - INPUT_COLUMN.OFFSET_X
+  if (existingInputs.length === 0) {
+    const targetHeight = target.height || LAYOUT_SPACING.DEFAULT_NODE_HEIGHT
+    return { x, y: target.position.y + (targetHeight - size.height) / 2 }
+  }
+  const lowest = Math.max(...existingInputs.map((n) => n.position.y))
+  return { x, y: lowest + INPUT_COLUMN.STACK_SPACING }
 }
 
 /** What `placeInside` decides: a parent-relative position plus a resize ask. */

--- a/packages/lib/src/workflows/graph-edit/run-node.ts
+++ b/packages/lib/src/workflows/graph-edit/run-node.ts
@@ -31,11 +31,12 @@
 
 import type { Database } from '@auxx/database'
 import { err, ok, type Result } from 'neverthrow'
-import { AuxxError, NotFoundError, UnprocessableEntityError } from '../../errors'
+import { AuxxError, BadRequestError, NotFoundError, UnprocessableEntityError } from '../../errors'
+import { getManifest } from '../../workflow-engine/catalog/registry'
 import { type GraphEditScope, loadDraftContext } from './read'
-import { resolveNodeRef } from './refs'
+import { describeNode, resolveNodeRef } from './refs'
 import type { GraphNode, Issue } from './types'
-import { validateNodeConfigs } from './validate'
+import { nodeType, validateNodeConfigs } from './validate'
 
 /** Input for {@link runNode}. */
 export interface RunNodeInput extends GraphEditScope {
@@ -85,6 +86,20 @@ export async function runNode(
   const resolved = resolveNodeRef(ctx.graph.nodes, params.nodeId)
   if (resolved.isErr()) return err(resolved.error)
   const node = resolved.value.node as GraphNode
+
+  // Nodes the manifest declares un-runnable in isolation (triggers, and
+  // `form-input`, which never executes at all — `NON_EXECUTABLE_NODE_TYPES`)
+  // are refused HERE. Sent on, they reach the engine, get skipped, and come
+  // back as a meaningless "succeeded" with no outputs.
+  const manifest = getManifest(nodeType(node))
+  if (manifest?.connection.canRunSingle === false) {
+    return err(
+      new BadRequestError(
+        `Node ${describeNode(node)} is a "${nodeType(node)}" node, which cannot be run on its own — ` +
+          'it has no standalone execution. Run a node downstream of it instead.'
+      )
+    )
+  }
 
   // Tier-2 config validation, scoped to this node — a run needs a valid
   // config even though a draft legitimately persists without one.


### PR DESCRIPTION
Follow-up to #1649 (plan §7 PR 3). Kopilot could already create a `form-input` node and then wire it with `connect_nodes`; this makes it **one call**, and gives the field the run-form ordering key the two-step never set.

## `add_node({ inputFor })`

Resolves a target whose manifest sets `connection.acceptsInputNodes`, checks the new node is `NodeCategory.INPUT` through **the same `isInputNodePair` the validator judges persisted graphs with** — no second copy of the wiring rule — mints the edge through `resolveEdgeHandles`, appends to `data.inputNodes`, places the node in the trigger's input column, and assigns the next run-form `position`.

Mutually exclusive with `after` (which connects in the opposite direction: FROM a predecessor TO the new node) and with `inside` (an input node is never a loop child). Both combinations are 400s.

## Three choices worth reviewing

- **`position` uses `nextKeyAfter`, not the strict `generateKeyBetween`.** The strict call *throws* on a corrupt existing key, which would poison every later insert into the same form. `nextKeyAfter` is that call with a tolerant fallback.
- **Existing inputs are read off the EDGES, not `data.inputNodes`.** The edge is what the validator and the engine judge; the list is cosmetic parity (and was append-only with no pruning until #1649).
- **Whether a type gets a `position` is read off the manifest's own `configSchema`**, never a `'form-input'` string match. Degrades to "no position" if a manifest's schema isn't a plain object.

## A placement tension worth naming

`placeAsInput` puts the field 300px left of the target, stacking 100px — derived from the shipped `manual-ticket-triage` template.

But that template's two fields sit centred as a **pair** around the trigger (y 225/325 for a trigger at y 300), which is only reachable by **moving the first field when the second arrives**. The graph-edit placement invariant is that existing nodes never move. So the first field is centred on the target and later ones stack downward: two agent-added fields land at y 300 and y 400, not 225/325. The tension is documented on the function.

## Behaviour changes

- **`add_node` gains `inputFor`.** The two-step still works for attaching an *existing* unwired node. `form-input`'s `agent.usage` and the workflow-builder prompt now teach the one-call path, so model behaviour on "add a subject field to the manual trigger" changes.
- **Agent-created form fields now get a fractional `position`.** Previously every one landed `undefined` and `connected-inputs-editor.tsx` sorted them unstably (its comparator returns 0 for two undefineds). An explicit `config.position` is never overwritten.
- **`run_node` now refuses `canRunSingle: false` types** with a 400 naming the node, instead of handing them to the engine, which skips them as `NON_EXECUTABLE_NODE_TYPES` and returns a meaningless success with no outputs. **This affects every trigger, not just `form-input`.**

## Verification

```
lib   src/workflows src/workflow-engine src/ai/kopilot   150 files, 2049 tests passed
web   src/components/workflow                             19 files,  135 tests passed
ratchet lib   no new type errors (29 total, baseline 29)
ratchet web   no new type errors (0 total, baseline 0)
```

7 new tests covering: the one-call path produces a graph with zero blocking issues; two successive calls stack positions and produce distinct, correctly-ordered fractional keys; a target without `acceptsInputNodes` 400s; a non-INPUT node type 400s; `inputFor` + `after` 400s; an explicit `config.position` survives; `runNode` refuses a `canRunSingle: false` node.

## Not in scope

`webhook` / `webhook-endpoint` (the remaining tracker entries). `branch` passed alongside `inputFor` is ignored rather than rejected, matching how `branch` without `after` already behaves.
