### PR TITLE
feat(rate-limiter): shared redis-backed pacer for channels and connectors

### DIFF
--- a/packages/lib/scripts/rearm-quo-webhook.ts
+++ b/packages/lib/scripts/rearm-quo-webhook.ts
@@ -1,0 +1,36 @@
+// packages/lib/scripts/rearm-quo-webhook.ts
+// One-off repair: re-arm the Quo message webhook for a channel whose stored `webhookId` points at
+// a webhook that no longer exists Quo-side (the create-disabled-then-PATCH-enable sequence that
+// shipped in #1646 rolled its own webhook back on every connect).
+import { revealSecrets } from '@auxx/credentials/store'
+import { database as db, schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import { armQuoWebhook } from '../src/channels/quo-channel'
+import { listWebhooks } from '../src/providers/openphone/api'
+
+const [integrationId, organizationId] = process.argv.slice(2)
+if (!integrationId || !organizationId) {
+  console.error('usage: rearm-quo-webhook.ts <integrationId> <organizationId>')
+  process.exit(1)
+}
+
+await armQuoWebhook(integrationId, organizationId)
+
+const [row] = await db
+  .select({ credentialId: schema.Integration.credentialId, metadata: schema.Integration.metadata })
+  .from(schema.Integration)
+  .where(eq(schema.Integration.id, integrationId))
+  .limit(1)
+
+const revealed = await revealSecrets<{ fields?: Record<string, string> }>(
+  row!.credentialId!,
+  organizationId
+)
+const apiKey = revealed.isOk() ? revealed.value.secrets.fields?.apiKey : undefined
+const live = await listWebhooks(apiKey!)
+console.log('stored webhookId:', (row!.metadata as any)?.webhookId)
+console.log(
+  'live webhooks:',
+  live.map((w) => ({ id: w.id, status: w.status, url: w.url, events: w.events }))
+)
+process.exit(0)

--- a/packages/lib/src/connections/transports/__tests__/http-pacing.test.ts
+++ b/packages/lib/src/connections/transports/__tests__/http-pacing.test.ts
@@ -1,0 +1,148 @@
+// packages/lib/src/connections/transports/__tests__/http-pacing.test.ts
+// The transport's PROACTIVE half (the reactive half lives in http.test.ts). Runs over
+// the pacer's in-process fallback — same cursor arithmetic as the Lua path, and it
+// keeps the assertions about the transport rather than about Redis.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('@auxx/redis', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/redis')>()),
+  getRedisClient: async () => null,
+}))
+
+import { resetPacerState } from '../../../utils/rate-limiter/pacer'
+import type { RuntimeConnectionData } from '../../resolve-connection-for-runtime'
+import { httpTransport } from '../http'
+
+const conn = (id: string): RuntimeConnectionData =>
+  ({ id, type: 'api-key', value: 'k', authApply: null }) as unknown as RuntimeConnectionData
+
+function stubFetch(specs: Array<{ status: number; headers?: Record<string, string> }>) {
+  const state = { count: 0 }
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      const spec = specs[Math.min(state.count, specs.length - 1)]!
+      state.count++
+      return new Response('{}', { status: spec.status, headers: spec.headers })
+    })
+  )
+  return state
+}
+
+beforeEach(() => {
+  resetPacerState()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('httpTransport proactive pacing', () => {
+  it('does not pace when the policy declares no rate', async () => {
+    stubFetch([{ status: 200 }])
+
+    const res = await httpTransport.request(conn('c-unpaced'), {
+      method: 'GET',
+      url: 'https://api.example.com/v1',
+    })
+
+    expect(res.rateLimitWaitMs).toBe(0)
+  })
+
+  it('does not pace without a connection — there is nothing to share a budget on', async () => {
+    stubFetch([{ status: 200 }])
+
+    const res = await httpTransport.request(null, {
+      method: 'GET',
+      url: 'https://api.example.com/v1',
+      rateLimit: { rps: 20 },
+    })
+
+    // Falls through to the legacy local floor, which is unset here.
+    expect(res.rateLimitWaitMs).toBe(0)
+  })
+
+  it('reserves a slot per request on the connection cursor, so a second call waits', async () => {
+    stubFetch([{ status: 200 }])
+    const req = {
+      method: 'GET' as const,
+      url: 'https://api.example.com/v1',
+      rateLimit: { rps: 20 }, // 50ms interval
+    }
+
+    const first = await httpTransport.request(conn('c-paced'), req)
+    const second = await httpTransport.request(conn('c-paced'), req)
+
+    expect(first.rateLimitWaitMs).toBe(0)
+    expect(second.rateLimitWaitMs).toBeGreaterThan(0)
+    expect(second.rateLimitWaitMs).toBeLessThanOrEqual(50)
+  })
+
+  it('keeps two different connections on separate budgets', async () => {
+    stubFetch([{ status: 200 }])
+    const req = {
+      method: 'GET' as const,
+      url: 'https://api.example.com/v1',
+      rateLimit: { rps: 20 },
+    }
+
+    await httpTransport.request(conn('c-a'), req)
+    const otherConnection = await httpTransport.request(conn('c-b'), req)
+
+    expect(otherConnection.rateLimitWaitMs).toBe(0)
+  })
+
+  it('reads minDelayMs as a rate when a connection is in scope', async () => {
+    stubFetch([{ status: 200 }])
+    const req = {
+      method: 'GET' as const,
+      url: 'https://api.example.com/v1',
+      rateLimit: { minDelayMs: 40 },
+    }
+
+    const first = await httpTransport.request(conn('c-mindelay'), req)
+    const second = await httpTransport.request(conn('c-mindelay'), req)
+
+    // Paced BEFORE the request, not slept after it — so the first call is free.
+    expect(first.rateLimitWaitMs).toBe(0)
+    expect(second.rateLimitWaitMs).toBeGreaterThan(0)
+    expect(second.rateLimitWaitMs).toBeLessThanOrEqual(40)
+  })
+
+  it('still applies minDelayMs as a local floor when there is no connection', async () => {
+    stubFetch([{ status: 200 }])
+
+    const res = await httpTransport.request(null, {
+      method: 'GET',
+      url: 'https://api.example.com/v1',
+      rateLimit: { minDelayMs: 20 },
+    })
+
+    expect(res.rateLimitWaitMs).toBe(20)
+  })
+
+  it('folds an observed Retry-After onto the shared cursor instead of sleeping twice', async () => {
+    const counter = stubFetch([
+      { status: 429, headers: { 'retry-after': '0.05' } },
+      { status: 200 },
+    ])
+
+    const res = await httpTransport.request(conn('c-429'), {
+      method: 'GET',
+      url: 'https://api.example.com/v1',
+      rateLimit: { rps: 20, maxRetries: 3 },
+    })
+
+    expect(counter.count).toBe(2)
+    expect(res.status).toBe(200)
+    // The 50ms came back through the next reservation, and is still accounted for.
+    expect(res.rateLimitWaitMs).toBeGreaterThan(30)
+    expect(res.rateLimitWaitMs).toBeLessThanOrEqual(60)
+  })
+})

--- a/packages/lib/src/connections/transports/http.ts
+++ b/packages/lib/src/connections/transports/http.ts
@@ -5,9 +5,11 @@
 // consumers previously hand-rolled. Consumers: generic-rest data connectors today;
 // the workflow HTTP node and connection-backed agent tools next.
 
+import { acquireSlot, reportRetryAfter } from '../../utils/rate-limiter/pacer'
+import { connectionQuota, type Quota } from '../../utils/rate-limiter/quota'
 import { applyAuth, type RequestParts } from '../auth-apply'
 import type { RuntimeConnectionData } from '../resolve-connection-for-runtime'
-import type { HttpResponse, HttpTransport, RateLimitPolicy } from './types'
+import type { HttpRequest, HttpResponse, HttpTransport, RateLimitPolicy } from './types'
 
 const DEFAULT_TIMEOUT_MS = 30_000
 const DEFAULT_MAX_RETRIES = 5
@@ -181,6 +183,34 @@ function detectThrottle(
   return { throttled: false }
 }
 
+/**
+ * The shared budget this request paces against, or `undefined` when there is nothing
+ * to share one on.
+ *
+ * An explicit `req.quota` wins. Otherwise a quota is derived from the CONNECTION —
+ * the natural per-account partition for a connector — but only when the policy
+ * actually declares a rate. Without a declared rate, pacing would be a behaviour
+ * change imposed on every consumer of this transport (workflow HTTP nodes, agent
+ * tools), so proactive pacing stays opt-in.
+ */
+function resolveRequestQuota(
+  conn: RuntimeConnectionData | null,
+  req: HttpRequest
+): Quota | undefined {
+  if (req.quota) return req.quota
+  if (!conn?.id) return undefined
+
+  const policy = req.rateLimit
+  const rps =
+    policy?.rps ??
+    (policy?.minDelayMs && policy.minDelayMs > 0 ? 1_000 / policy.minDelayMs : undefined)
+  if (!rps || !Number.isFinite(rps)) return undefined
+
+  // Cap the look-ahead at the transport's own single-wait ceiling: a backlog longer
+  // than that surfaces as a RateLimitError rather than parking a worker indefinitely.
+  return connectionQuota(conn.id, { rps, burstMs: MAX_WAIT_MS })
+}
+
 export const httpTransport: HttpTransport = {
   kind: 'http',
 
@@ -194,9 +224,17 @@ export const httpTransport: HttpTransport = {
 
     const policy = req.rateLimit
     const maxRetries = policy?.maxRetries ?? DEFAULT_MAX_RETRIES
+    const quota = resolveRequestQuota(conn, req)
     let rateLimitWaitMs = 0
 
     for (let attempt = 0; ; attempt++) {
+      // Proactive half: reserve a slot on the connection's SHARED cursor. This is the
+      // cross-request coordination the comment below used to defer to "Steps 3/4" —
+      // it lives in the pacer, which the stateless transport merely calls.
+      if (quota) {
+        rateLimitWaitMs += await acquireSlot(quota, { signal: req.signal })
+      }
+
       // Combine the caller's cancellation with the per-attempt timeout.
       const timeout = AbortSignal.timeout(req.timeoutMs ?? DEFAULT_TIMEOUT_MS)
       const signal = req.signal ? AbortSignal.any([req.signal, timeout]) : timeout
@@ -214,19 +252,25 @@ export const httpTransport: HttpTransport = {
       const throttle = detectThrottle(res.status, respHeaders, text, policy)
       if (throttle.throttled && attempt < maxRetries) {
         const waitMs = Math.min(MAX_WAIT_MS, throttle.waitMs ?? backoffMs(attempt))
+        if (quota) {
+          // Reactive half, shared: push the wait onto the same cursor so EVERY
+          // process on this connection backs off, then loop — the `acquireSlot` at
+          // the top of the next iteration absorbs the wait. Sleeping here as well
+          // would double-count it.
+          await reportRetryAfter(quota, waitMs)
+          continue
+        }
         rateLimitWaitMs += waitMs
         await sleep(waitMs, req.signal)
         continue
       }
 
-      // Inter-page pacing: a configured floor between pages (token-bucket-lite),
-      // applied after the response so a pagination loop paces before the next page.
-      // NOTE: speculative pre-throttling off a usage gauge (e.g. Shopify's
-      // shop-global `X-Shopify-Shop-Api-Call-Limit`) is cross-request coordination
-      // and deliberately does NOT live in this stateless per-request transport — it
-      // belongs in the per-connection throttle layer (sync-core `ThrottleHandle`
-      // over `UniversalThrottler`, keyed by connection), wired in Steps 3/4.
-      const paceMs = policy?.minDelayMs ?? 0
+      // Inter-page pacing with no connection to share a budget on: fall back to a
+      // process-local floor between pages, applied after the response so a
+      // pagination loop paces before the next page. When a quota IS in play the
+      // pre-request reservation above already enforces this rate — across processes,
+      // not just this one — so the local sleep would be a double wait.
+      const paceMs = quota ? 0 : (policy?.minDelayMs ?? 0)
       if (paceMs > 0) {
         rateLimitWaitMs += paceMs
         await sleep(paceMs, req.signal)

--- a/packages/lib/src/connections/transports/types.ts
+++ b/packages/lib/src/connections/transports/types.ts
@@ -5,6 +5,7 @@
 // auth + the wire call. Only the HTTP transport is implemented today; the rest are
 // scaffolded so future consumers can be written against a stable signature.
 
+import type { Quota } from '../../utils/rate-limiter/quota'
 import type { RuntimeConnectionData } from '../resolve-connection-for-runtime'
 
 /** The transport a connection speaks. Mirrors the connection's transport class. */
@@ -33,17 +34,27 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD'
  *  - `backoff-jitter`— `429` with **no** `Retry-After`; exponential backoff with
  *                      jitter (Stripe's explicit recommendation).
  *
- * Scope: this handles a throttle the SERVER signals on a given request (retry THIS
- * request after N). Speculative pacing off a usage gauge (e.g. Shopify's
- * shop-global `X-Shopify-Shop-Api-Call-Limit`) is cross-request coordination that
- * needs shared per-connection state, so it lives in the throttle layer
- * (`UniversalThrottler` keyed by connection), not in this stateless transport.
+ * Proactive pacing is the other half, and it is no longer "elsewhere": set `rps`
+ * (or `minDelayMs`) on a request that carries a connection and the transport reserves
+ * a slot on that connection's SHARED cursor before every attempt, and folds any
+ * observed `Retry-After` back onto the same cursor. See `utils/rate-limiter/pacer`.
  */
 export interface RateLimitPolicy {
   strategy?: 'retry-after' | 'graphql-cost' | 'backoff-jitter'
   /** Max retry attempts on a throttle signal. Default 5. */
   maxRetries?: number
-  /** Floor delay applied AFTER each request (inter-page pacing, token-bucket-lite). */
+  /**
+   * Sustained requests/second for this connection's shared budget. Enables proactive
+   * pacing across every process using the connection. Takes precedence over
+   * `minDelayMs`.
+   */
+  rps?: number
+  /**
+   * Floor delay between requests. With a connection in scope this is read as a rate
+   * (`1000 / minDelayMs`) and enforced as a shared pre-request slot reservation;
+   * without one there is nothing to share a budget on, so it degrades to a
+   * process-local sleep AFTER each request.
+   */
   minDelayMs?: number
 }
 
@@ -63,6 +74,10 @@ export interface HttpRequest {
   timeoutMs?: number
   /** Rate-limit handling. Absent ⇒ the default `429`+`Retry-After` behavior. */
   rateLimit?: RateLimitPolicy
+  /** Explicit shared budget to pace against. Overrides the connection-derived one —
+   *  use it when the upstream meters something other than the connection (a shop
+   *  domain, an API key shared by several connections). */
+  quota?: Quota
   /** Cancels in-flight waits (Retry-After/backoff sleeps) and the fetch. */
   signal?: AbortSignal
 }

--- a/packages/lib/src/data-connectors/slice-orchestrator.ts
+++ b/packages/lib/src/data-connectors/slice-orchestrator.ts
@@ -17,8 +17,9 @@ import type { ResourceFieldId } from '@auxx/types/field'
 import { and, eq, inArray, lt } from 'drizzle-orm'
 import { resolveConnectorFieldRef } from '../agents/bindings/resolve'
 import { reconcileInstallationAppFields } from '../apps/installations/app-field-provisioning'
-import type { ThrottleHandle } from '../sync-core/contracts'
 import { runSyncSlice } from '../sync-core/slice-runner'
+import { createThrottleHandle } from '../sync-core/throttle'
+import { connectionQuota } from '../utils/rate-limiter/quota'
 import { prepareConnectorFetch } from './connector-runtime'
 import { createConnectorStreamSyncSource, type SyncSourceStream } from './connector-sync-source'
 import {
@@ -76,9 +77,18 @@ export const MAX_BACKFILL_RECORDS = 9_000
  */
 export const STALE_RUN_MS = 5 * 60 * 1_000
 
-/** A no-op throttle handle. The DC source does per-request 429 handling in the
- *  transport; the cross-request `connection:operation` throttle threads in later. */
-const NO_THROTTLE: ThrottleHandle = { run: (fn) => fn() }
+/**
+ * The shared budget a connector's slices pace against. Keyed on the bound CREDENTIAL
+ * (falling back to the connector id) so two connectors on one upstream account share
+ * one budget — the same partition `ConnectorStreamSyncSource.throttleKey` declares.
+ *
+ * Per-REQUEST pacing happens in the HTTP transport against this same quota; the
+ * slice-level handle is the coarse outer bound, so a stampede of concurrent slices on
+ * one account can't all start on the same millisecond.
+ */
+function connectorQuota(connector: { id: string; credentialId?: string | null }) {
+  return connectionQuota(connector.credentialId ?? connector.id)
+}
 
 // ── The pinned chain snapshot stored on the run (B2) ────────────────────────────
 
@@ -513,13 +523,14 @@ export async function runBackfillSlice(
       ? { ...SLICE_BUDGET, maxRecords: Math.min(SLICE_BUDGET.maxRecords, run.sampleLimit) }
       : SLICE_BUDGET
 
+  const sliceSignal = signal ?? new AbortController().signal
   const outcome = await runSyncSlice({
     source,
     stateStore: createStreamSyncStateStore(db, streamId),
     ledger: createConnectorRunLedger(db, { id: runId, startedAt: run.startedAt }, streamId),
-    throttle: NO_THROTTLE,
+    throttle: createThrottleHandle(connectorQuota(connector), { signal: sliceSignal }),
     budget,
-    signal: signal ?? new AbortController().signal,
+    signal: sliceSignal,
   })
 
   if (outcome.action === 'reenqueue') {

--- a/packages/lib/src/providers/openphone/__tests__/openphone-provider.test.ts
+++ b/packages/lib/src/providers/openphone/__tests__/openphone-provider.test.ts
@@ -1,9 +1,10 @@
 // packages/lib/src/providers/openphone/__tests__/openphone-provider.test.ts
 //
 // Covers the three things the Quo rewrite can get silently wrong:
-//   1. `setupWebhook` must persist BOTH the webhook id (Integration.metadata) and the signing
-//      key Quo mints (Credential secret field `webhookSigningSecret`) — merged, never clobbering
-//      the stored `apiKey` — and only flip the webhook to `enabled` once both are stored.
+//   1. `setupWebhook` must create the webhook ENABLED (Quo webhooks are immutable — there is no
+//      update call to flip one on later) and persist BOTH the webhook id (Integration.metadata)
+//      and the signing key Quo mints (Credential secret field `webhookSigningSecret`) — merged,
+//      never clobbering the stored `apiKey`.
 //   2. The capped backfill must sort by `lastActivityAt` DESC. The server orders by `createdAt`
 //      DESC, so an old-but-active conversation is exactly what a naive implementation drops.
 //   3. The REST mapper must read `text` / `to[]` (the webhook says `body` / `to: string`) and
@@ -22,7 +23,6 @@ const mocks = vi.hoisted(() => {
     updateWhere,
     mergeSecretFields: vi.fn(),
     createMessageWebhook: vi.fn(),
-    updateWebhookStatus: vi.fn(),
     deleteWebhook: vi.fn(),
     sendMessage: vi.fn(),
     listConversations: vi.fn(),
@@ -73,7 +73,6 @@ vi.mock('@auxx/credentials/store', () => ({
 vi.mock('../api', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../api')>()),
   createMessageWebhook: mocks.createMessageWebhook,
-  updateWebhookStatus: mocks.updateWebhookStatus,
   deleteWebhook: mocks.deleteWebhook,
   sendMessage: mocks.sendMessage,
   listConversations: mocks.listConversations,
@@ -138,12 +137,12 @@ beforeEach(() => {
 })
 
 describe('OpenPhoneProvider.setupWebhook', () => {
-  it('creates a disabled webhook, persists id + key, then enables it', async () => {
+  it('creates an enabled webhook and persists id + key', async () => {
     const provider = makeProvider()
     mocks.createMessageWebhook.mockResolvedValue({
       id: 'WH_new',
       key: 'c2lnbmluZy1rZXk=',
-      status: 'disabled',
+      status: 'enabled',
     })
 
     await provider.setupWebhook(CALLBACK_URL)
@@ -153,8 +152,10 @@ describe('OpenPhoneProvider.setupWebhook', () => {
     expect(body.events).toEqual(['message.received', 'message.delivered'])
     // Per-number, not `["*"]` — one channel owns one webhook.
     expect(body.resourceIds).toEqual([PHONE_NUMBER_ID])
-    // Created disabled so a half-provisioned channel never receives unverifiable traffic.
-    expect(body.status).toBe('disabled')
+    // Created ENABLED, because Quo webhooks are immutable — `/v1/webhooks/{id}` routes only GET
+    // and DELETE, so there is no later call that could flip a `disabled` webhook on. Creating
+    // disabled would arm nothing at all.
+    expect(body.status).toBe('enabled')
 
     // The signing key is merged onto the Credential's secret bag, keyed exactly as the webhook
     // route's `resolveWebhookSecret({ kind: 'credentialField', field: 'webhookSigningSecret' })`.
@@ -172,17 +173,17 @@ describe('OpenPhoneProvider.setupWebhook', () => {
     expect(sqlContains(setArg.metadata, 'WH_new')).toBe(true)
     expect(sqlContains(setArg.metadata, 'webhookId')).toBe(true)
 
-    // Enabled last, after both id and key are stored.
-    expect(mocks.updateWebhookStatus).toHaveBeenCalledWith('quo_key', 'WH_new', 'enabled')
-    const enableOrder = mocks.updateWebhookStatus.mock.invocationCallOrder[0]!
-    expect(mocks.mergeSecretFields.mock.invocationCallOrder[0]!).toBeLessThan(enableOrder)
-    expect(mocks.update.mock.invocationCallOrder[0]!).toBeLessThan(enableOrder)
+    // The key is stored before the id, so the window in which a delivered event cannot be
+    // verified is as short as the API allows.
+    expect(mocks.mergeSecretFields.mock.invocationCallOrder[0]!).toBeLessThan(
+      mocks.update.mock.invocationCallOrder[0]!
+    )
   })
 
   it('deletes the stored webhook before re-arming so only one stays live', async () => {
     const provider = makeProvider({ webhookId: 'WH_old' })
     mocks.deleteWebhook.mockResolvedValue(undefined)
-    mocks.createMessageWebhook.mockResolvedValue({ id: 'WH_new', key: 'a2V5', status: 'disabled' })
+    mocks.createMessageWebhook.mockResolvedValue({ id: 'WH_new', key: 'a2V5', status: 'enabled' })
 
     await provider.setupWebhook(CALLBACK_URL)
 
@@ -202,9 +203,8 @@ describe('OpenPhoneProvider.setupWebhook', () => {
 
     await expect(provider.setupWebhook(CALLBACK_URL)).rejects.toThrow(/credential gone/)
 
-    // Never enabled, and torn back down — an orphan live webhook we cannot verify is worse
-    // than no webhook at all.
-    expect(mocks.updateWebhookStatus).not.toHaveBeenCalled()
+    // Torn back down — a live webhook whose signature we can never verify is worse than no
+    // webhook at all, and Quo offers no way to disable one in place.
     expect(mocks.deleteWebhook).toHaveBeenCalledWith('quo_key', 'WH_orphan')
   })
 })

--- a/packages/lib/src/providers/openphone/api.ts
+++ b/packages/lib/src/providers/openphone/api.ts
@@ -9,7 +9,14 @@
 // Verified live that a `Bearer ` prefix is also accepted, so either form works; we send the
 // documented one.
 
+import { IntegrationProviderType } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
+import { RateLimitError } from '../../errors'
+// Leaf imports, not the `rate-limiter` barrel — the barrel drags in the whole
+// `UniversalThrottler` cluster (queues, circuit breakers, the config manager) that this
+// path has no use for.
+import { pacedFetch } from '../../utils/rate-limiter/paced-fetch'
+import { hashScopeId, type Quota, resolveQuota } from '../../utils/rate-limiter/quota'
 import type {
   QuoConversation,
   QuoCreateMessageWebhookInput,
@@ -23,13 +30,6 @@ const logger = createScopedLogger('quo-api')
 
 export const QUO_API_BASE = 'https://api.quo.com/v1'
 
-/**
- * Quo's documented ceiling is 10 requests/second per API key. We pace at 8 to leave headroom;
- * measured latency is ~195ms/request, so a serial caller never reaches this anyway — the pacer
- * matters when a backfill runs a small amount of concurrency.
- */
-const MAX_REQUESTS_PER_SECOND = 8
-const MIN_INTERVAL_MS = Math.ceil(1000 / MAX_REQUESTS_PER_SECOND)
 const MAX_RETRIES_ON_429 = 3
 
 /** An error carrying the HTTP status plus whatever message Quo returned. */
@@ -45,23 +45,18 @@ export class QuoApiError extends Error {
 }
 
 /**
- * Per-API-key pacing. The rate limit is per key, not per number, so three channels backfilling
- * concurrently share one budget — keying the pacer on the key is what keeps them from 429ing
- * each other.
+ * The quota every call in this file draws from. Quo meters per API KEY, not per number, so
+ * three channels backfilling concurrently share one budget — and so do three *workers*, which
+ * is why this goes through the shared Redis-backed pacer rather than a process-local map.
+ *
+ * The key is hashed, never stored raw: `saveConnection` still has no `providerKey` dedupe, so
+ * two `Credential` rows can hold the same API key. Keying on the key's hash hands that one
+ * workspace one budget; keying on `credentialId` would hand it two and 429 itself.
+ *
+ * The rate comes from `provider-configs.ts` — this file carries no rate constant of its own.
  */
-const nextSlotByKey = new Map<string, number>()
-
-async function acquireSlot(apiKey: string): Promise<void> {
-  const now = Date.now()
-  const earliest = nextSlotByKey.get(apiKey) ?? 0
-  const slot = Math.max(now, earliest)
-  nextSlotByKey.set(apiKey, slot + MIN_INTERVAL_MS)
-  const wait = slot - now
-  if (wait > 0) await sleep(wait)
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+function quotaFor(apiKey: string): Quota {
+  return resolveQuota(IntegrationProviderType.openphone, 'apiKey', hashScopeId(apiKey))
 }
 
 function buildQuery(query?: QueryValue): string {
@@ -86,18 +81,22 @@ type QueryValue = Record<string, string | number | boolean | string[] | undefine
 /** Issue one paced, retry-on-429 request against the Quo API. */
 async function quoFetch<T>(
   apiKey: string,
-  method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
+  method: 'GET' | 'POST' | 'DELETE',
   path: string,
   opts: { query?: QueryValue; body?: unknown } = {}
 ): Promise<T> {
   const url = `${QUO_API_BASE}${path}${buildQuery(opts.query)}`
 
-  for (let attempt = 0; ; attempt++) {
-    await acquireSlot(apiKey)
-
-    let response: Response
-    try {
-      response = await fetch(url, {
+  // `pacedFetch` reserves a slot on the shared cursor before every attempt and, on a 429,
+  // publishes the `Retry-After` back onto that same cursor — so the backoff is observed by
+  // every other worker on this API key, not just this process. It does not sleep the
+  // `Retry-After` itself: the next reservation already lands past it.
+  let response: Response
+  try {
+    ;({ response } = await pacedFetch(
+      quotaFor(apiKey),
+      url,
+      {
         method,
         headers: {
           Authorization: apiKey,
@@ -105,44 +104,45 @@ async function quoFetch<T>(
           Accept: 'application/json',
         },
         body: opts.body === undefined ? undefined : JSON.stringify(opts.body),
-      })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      logger.error('Quo API network error', { method, path, error: message })
-      throw new QuoApiError(`Failed to reach the Quo API: ${message}`, 0)
-    }
-
-    if (response.status === 429 && attempt < MAX_RETRIES_ON_429) {
-      const retryAfter = Number(response.headers.get('retry-after'))
-      const waitMs = Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter * 1000 : 1000
-      logger.warn('Quo API rate limited; backing off', { method, path, waitMs, attempt })
-      await sleep(waitMs)
-      continue
-    }
-
-    // 204 (webhook delete) has no body.
-    if (response.status === 204) return undefined as T
-
-    const raw = await response.text()
-    let parsed: unknown
-    try {
-      parsed = raw ? JSON.parse(raw) : undefined
-    } catch {
-      parsed = raw
-    }
-
-    if (!response.ok) {
-      const message = extractErrorMessage(parsed) ?? `HTTP error ${response.status}`
-      logger.error('Quo API error', { method, path, status: response.status, message })
-      throw new QuoApiError(
-        `Quo API error (${response.status}): ${message}`,
-        response.status,
-        parsed
-      )
-    }
-
-    return parsed as T
+      },
+      {
+        maxRetries: MAX_RETRIES_ON_429,
+        onThrottle: ({ attempt, retryAfterMs }) =>
+          logger.warn('Quo API rate limited; shared cursor pushed forward', {
+            method,
+            path,
+            retryAfterMs,
+            attempt,
+          }),
+      }
+    ))
+  } catch (error) {
+    // A `RateLimitError` means the shared budget is backed up past the burst ceiling — that
+    // is a real rate-limit answer, not a network failure, so it must not be flattened.
+    if (error instanceof QuoApiError || error instanceof RateLimitError) throw error
+    const message = error instanceof Error ? error.message : String(error)
+    logger.error('Quo API network error', { method, path, error: message })
+    throw new QuoApiError(`Failed to reach the Quo API: ${message}`, 0)
   }
+
+  // 204 (webhook delete) has no body.
+  if (response.status === 204) return undefined as T
+
+  const raw = await response.text()
+  let parsed: unknown
+  try {
+    parsed = raw ? JSON.parse(raw) : undefined
+  } catch {
+    parsed = raw
+  }
+
+  if (!response.ok) {
+    const message = extractErrorMessage(parsed) ?? `HTTP error ${response.status}`
+    logger.error('Quo API error', { method, path, status: response.status, message })
+    throw new QuoApiError(`Quo API error (${response.status}): ${message}`, response.status, parsed)
+  }
+
+  return parsed as T
 }
 
 function extractErrorMessage(body: unknown): string | undefined {
@@ -198,22 +198,15 @@ export async function createMessageWebhook(
   return result.data
 }
 
-/** `PATCH /v1/webhooks/{id}` — used to flip a freshly created webhook from disabled to enabled. */
-export async function updateWebhookStatus(
-  apiKey: string,
-  webhookId: string,
-  status: 'enabled' | 'disabled'
-): Promise<QuoWebhook> {
-  const result = await quoFetch<{ data: QuoWebhook }>(
-    apiKey,
-    'PATCH',
-    `/webhooks/${encodeURIComponent(webhookId)}`,
-    { body: { status } }
-  )
-  return result.data
-}
-
-/** `DELETE /v1/webhooks/{id}` → 204. */
+/**
+ * `DELETE /v1/webhooks/{id}` → 204.
+ *
+ * Note there is deliberately no update call here: `/v1/webhooks/{id}` routes only `GET` and
+ * `DELETE`. `PATCH`, `PUT` and `POST` all 404 (`Cannot PATCH /v1/webhooks/…`), and no
+ * `/enable`, `/disable` or `/status` sub-route exists either — probed against the live API.
+ * Quo webhooks are immutable: to change `url`, `events`, `resourceIds` or `status`, delete and
+ * recreate. `setupWebhook` is built around that.
+ */
 export async function deleteWebhook(apiKey: string, webhookId: string): Promise<void> {
   await quoFetch<void>(apiKey, 'DELETE', `/webhooks/${encodeURIComponent(webhookId)}`)
 }

--- a/packages/lib/src/providers/openphone/openphone-provider.ts
+++ b/packages/lib/src/providers/openphone/openphone-provider.ts
@@ -33,7 +33,6 @@ import {
   listMessages,
   QuoApiError,
   sendMessage as sendQuoMessage,
-  updateWebhookStatus,
 } from './api'
 import type { OpenPhoneIntegrationMetadata, QuoConversation, QuoRestMessage } from './types'
 
@@ -299,9 +298,8 @@ export class OpenPhoneProvider
    *
    * ```
    * POST /v1/webhooks/messages
-   * { url, events, resourceIds: [PN…], label, status: 'disabled' }
+   * { url, events, resourceIds: [PN…], label, status: 'enabled' }
    *   → { data: { id: 'WH…', key: '<base64 32 bytes>' } }
-   * PATCH /v1/webhooks/{id} { status: 'enabled' }   ← only after id + key are persisted
    * ```
    *
    * Two properties of the create call, both verified live, shape this:
@@ -313,8 +311,18 @@ export class OpenPhoneProvider
    * - **The URL is not reachability-checked**, so there is no ordering dependency on our
    *   endpoint being live — this works in dev without a tunnel already running.
    *
-   * Creating `disabled` and enabling last means a half-provisioned channel (webhook created but
-   * the key not yet stored) never receives traffic it could not verify.
+   * **Webhooks are immutable — create and delete only.** `/v1/webhooks/{id}` routes `GET` and
+   * `DELETE`; `PATCH`, `PUT` and `POST` all 404 with Express's `Cannot PATCH /v1/webhooks/…`, and
+   * there is no `/enable` sub-route either (probed against the live API). So the
+   * create-`disabled`-then-enable sequence this originally shipped with could never work: the
+   * create succeeded, the enable 404'd, and the rollback tore the webhook straight back down —
+   * a channel that reported connected and received nothing.
+   *
+   * The consequence is an unavoidable window: the webhook is live from the moment it is created,
+   * but its signing key only exists in the create *response*, so it cannot be stored beforehand.
+   * A message landing in the ~200ms before `mergeSecretFields` commits fails verification and is
+   * dropped. There is no API shape that closes this — a dropped inbound SMS during provisioning
+   * is the cheapest of the available failure modes.
    *
    * **Idempotency: delete-then-recreate.** Re-arming with a stored `webhookId` deletes the old
    * webhook first, because (a) the callback URL changes between dev tunnels and Quo documents no
@@ -341,7 +349,7 @@ export class OpenPhoneProvider
       // the code assumes and makes teardown on disconnect unambiguous.
       resourceIds: [this.phoneNumberId!],
       label: `Auxx.ai — ${this.phoneNumber}`,
-      status: 'disabled',
+      status: 'enabled',
     })
 
     try {
@@ -365,17 +373,15 @@ export class OpenPhoneProvider
         .where(eq(schema.Integration.id, this.integrationId!))
       if (this.metadata) this.metadata.webhookId = created.id
 
-      // Only now is the channel able to verify what Quo sends.
-      await updateWebhookStatus(this.apiKey!, created.id, 'enabled')
-
       logger.info('Quo webhook armed', {
         webhookId: created.id,
         phoneNumberId: this.phoneNumberId,
         integrationId: this.integrationId,
       })
     } catch (error: any) {
-      // The webhook exists Quo-side but we could not persist (or enable) it. Leaving it would
-      // orphan a webhook nobody owns, so tear it back down before surfacing the failure.
+      // The webhook is live Quo-side but we could not persist what verifies it. Leaving it would
+      // orphan a webhook nobody owns, delivering traffic we can only reject, so tear it back down
+      // before surfacing the failure.
       logger.error('Failed to finish arming the Quo webhook — rolling back', {
         error: error?.message,
         webhookId: created.id,

--- a/packages/lib/src/sync-core/slice-runner.ts
+++ b/packages/lib/src/sync-core/slice-runner.ts
@@ -42,7 +42,7 @@ export interface RunSliceArgs {
   source: SyncSource
   stateStore: SyncStateStore
   ledger: RunLedger
-  /** Built by the worker via `createThrottleHandle(throttler, source.throttleKey)`. */
+  /** Built by the worker via `createThrottleHandle(quota)`. */
   throttle: ThrottleHandle
   budget: SliceBudget
   signal: AbortSignal

--- a/packages/lib/src/sync-core/throttle.ts
+++ b/packages/lib/src/sync-core/throttle.ts
@@ -1,24 +1,40 @@
 // packages/lib/src/sync-core/throttle.ts
-// Adapter from the shared `UniversalThrottler` to the core's `ThrottleHandle` seam.
-// The core hands a handle to each `fetchSlice`; the source runs every upstream call
-// through it. Keying is `connection:operation` (shared-sync-core-plan §3.3) so two
-// sources on the same upstream account share one rate budget, while distinct API
-// method quotas (e.g. gmail sync vs batch) stay separated.
+// Adapter from the shared pacer to the core's `ThrottleHandle` seam. The core hands a
+// handle to each `fetchSlice`; a source runs upstream work through it.
+//
+// What this delivers, precisely: ONE cost-weighted slot reservation on the quota's
+// shared Redis cursor per `run()` call, slept until due, cross-process. Any 429 that
+// another caller published via `reportRetryAfter` is already folded into that cursor,
+// so the reservation lands past it.
+//
+// What it does NOT deliver, and never did despite the previous doc comment claiming
+// otherwise: a token bucket, a circuit breaker, or a queue. Per-REQUEST pacing for the
+// data-connector path lives in the HTTP transport (`connections/transports/http.ts`),
+// which reserves on the same connection quota — a handle wrapping a whole slice is a
+// far coarser unit than a page fetch.
 
-import type { UniversalThrottler } from '../utils/rate-limiter'
+import { acquireSlot } from '../utils/rate-limiter/pacer'
+import type { Quota } from '../utils/rate-limiter/quota'
 import type { ThrottleHandle } from './contracts'
 
 /**
- * Wrap a `UniversalThrottler` as a `ThrottleHandle` bound to one throttle key.
- * `throttleKey` is the source's `${connectionId}:${operation}` bucket. The handle
- * is per-slice but the underlying throttler (and its Redis-backed token bucket +
- * circuit breaker + cross-run `Retry-After` backoff) is shared process-wide.
+ * Wrap a shared {@link Quota} as a `ThrottleHandle`.
+ *
+ * @param quota - The metered budget this slice's work draws from. Two sources on one
+ *   upstream account must resolve the same quota to share a budget.
+ * @param opts.cost - Quota units one `run()` consumes. Default 1.
+ * @param opts.signal - Cancels the pacing sleep, so an aborted slice never parks.
+ * @throws {import('../errors').RateLimitError} From `run()` when the backlog exceeds
+ *   the quota's burst ceiling — the caller should yield the slice, not spin.
  */
 export function createThrottleHandle(
-  throttler: UniversalThrottler,
-  throttleKey: string
+  quota: Quota,
+  opts: { cost?: number; signal?: AbortSignal } = {}
 ): ThrottleHandle {
   return {
-    run: (fn) => throttler.execute(throttleKey, fn),
+    run: async (fn) => {
+      await acquireSlot(quota, opts)
+      return fn()
+    },
   }
 }

--- a/packages/lib/src/utils/rate-limiter/__tests__/paced-fetch.test.ts
+++ b/packages/lib/src/utils/rate-limiter/__tests__/paced-fetch.test.ts
@@ -1,0 +1,130 @@
+// packages/lib/src/utils/rate-limiter/__tests__/paced-fetch.test.ts
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+// No Redis in this file — `pacedFetch` is exercised over the in-process fallback, which
+// is the same cursor arithmetic and keeps the test about the fetch loop.
+vi.mock('@auxx/redis', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/redis')>()),
+  getRedisClient: async () => null,
+}))
+
+import { pacedFetch, parseRetryAfterMs } from '../paced-fetch'
+import { resetPacerState } from '../pacer'
+import { connectionQuota } from '../quota'
+
+const fetchMock = vi.fn()
+
+function reply(status: number, headers: Record<string, string> = {}): Response {
+  return new Response(status === 204 ? null : '{}', { status, headers })
+}
+
+beforeEach(() => {
+  resetPacerState()
+  fetchMock.mockReset()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('parseRetryAfterMs', () => {
+  it('reads delta-seconds', () => {
+    expect(parseRetryAfterMs('2')).toBe(2_000)
+  })
+
+  it('reads an HTTP-date', () => {
+    const when = new Date(Date.now() + 5_000).toUTCString()
+    const ms = parseRetryAfterMs(when)!
+    expect(ms).toBeGreaterThan(3_000)
+    expect(ms).toBeLessThanOrEqual(5_000)
+  })
+
+  it('returns undefined for absent or junk values', () => {
+    expect(parseRetryAfterMs(null)).toBeUndefined()
+    expect(parseRetryAfterMs('soon')).toBeUndefined()
+  })
+})
+
+describe('pacedFetch', () => {
+  it('returns a non-throttled response on the first attempt', async () => {
+    fetchMock.mockResolvedValue(reply(200))
+
+    const { response, attempts } = await pacedFetch(
+      connectionQuota('ok', { rps: 1000 }),
+      'https://example.test/x'
+    )
+
+    expect(response.status).toBe(200)
+    expect(attempts).toBe(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a 429 and absorbs the Retry-After through the shared cursor', async () => {
+    fetchMock
+      .mockResolvedValueOnce(reply(429, { 'retry-after': '0.05' }))
+      .mockResolvedValueOnce(reply(200))
+
+    const started = Date.now()
+    const { response, attempts, waitedMs } = await pacedFetch(
+      connectionQuota('throttled', { rps: 1000 }),
+      'https://example.test/x'
+    )
+
+    expect(response.status).toBe(200)
+    expect(attempts).toBe(2)
+    // The wait came from the reservation, not a local sleep — so it is REPORTED
+    // (waitedMs) rather than silently spent, and it actually elapsed.
+    expect(waitedMs).toBeGreaterThan(30)
+    expect(Date.now() - started).toBeGreaterThan(30)
+  })
+
+  it('hands back the final throttled response once retries are exhausted', async () => {
+    fetchMock.mockResolvedValue(reply(429, { 'retry-after': '0.01' }))
+
+    const { response, attempts } = await pacedFetch(
+      connectionQuota('exhausted', { rps: 1000 }),
+      'https://example.test/x',
+      {},
+      { maxRetries: 2 }
+    )
+
+    expect(response.status).toBe(429)
+    expect(attempts).toBe(3) // first + 2 retries
+  })
+
+  it('fires onThrottle once per throttled attempt', async () => {
+    fetchMock
+      .mockResolvedValueOnce(reply(429, { 'retry-after': '0.01' }))
+      .mockResolvedValueOnce(reply(200))
+    const onThrottle = vi.fn()
+
+    await pacedFetch(
+      connectionQuota('observed', { rps: 1000 }),
+      'https://example.test/x',
+      {},
+      { onThrottle }
+    )
+
+    expect(onThrottle).toHaveBeenCalledTimes(1)
+    expect(onThrottle).toHaveBeenCalledWith({ attempt: 0, status: 429, retryAfterMs: 10 })
+  })
+
+  it('does not retry a plain error status', async () => {
+    fetchMock.mockResolvedValue(reply(500))
+
+    const { response, attempts } = await pacedFetch(
+      connectionQuota('five-hundred', { rps: 1000 }),
+      'https://example.test/x'
+    )
+
+    expect(response.status).toBe(500)
+    expect(attempts).toBe(1)
+  })
+})

--- a/packages/lib/src/utils/rate-limiter/__tests__/pacer.test.ts
+++ b/packages/lib/src/utils/rate-limiter/__tests__/pacer.test.ts
@@ -1,0 +1,249 @@
+// packages/lib/src/utils/rate-limiter/__tests__/pacer.test.ts
+//
+// The fake Redis below re-implements the two Lua scripts in JS. That verifies our
+// CLIENT layer — arg marshalling, EVALSHA/NOSCRIPT/EVAL, the max-not-add semantics,
+// the burst refusal, the in-process fallback — but it does NOT execute real Lua, so it
+// cannot prove the scripts themselves parse on a live server. Exercising the bodies
+// needs an integration run against a real Redis.
+
+import { createHash } from 'node:crypto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Partial mock: `@auxx/logger/run-log` pulls sink helpers off this barrel at load
+// time, so a full replacement breaks whichever test file loads it first.
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+/** Cursor store shared by the fake client across a test. */
+const store = new Map<string, number>()
+/** Digests the fake server has "cached", so EVALSHA can miss the way Redis does. */
+const cachedShas = new Set<string>()
+
+const calls = { evalsha: 0, eval: 0 }
+
+class NoScriptError extends Error {
+  constructor() {
+    super('NOSCRIPT No matching script. Please use EVAL.')
+  }
+}
+
+/** Interpret whichever of the two scripts was sent. */
+function runBody(script: string, key: string, argv: number[]): unknown {
+  if (script.includes('burst')) {
+    const [now, intervalMs, burst, cost, _ttl] = argv as [number, number, number, number, number]
+    const interval = intervalMs * cost
+    let cursor = store.get(key) ?? 0
+    if (cursor < now) cursor = now
+    const wait = cursor - now
+    if (wait > burst) return [0, wait]
+    store.set(key, Math.floor(cursor + interval))
+    return [1, wait]
+  }
+  // Retry-After push.
+  const [now, retryAfterMs] = argv as [number, number, number]
+  const cursor = store.get(key) ?? 0
+  const target = now + retryAfterMs
+  if (target > cursor) {
+    store.set(key, Math.floor(target))
+    return 1
+  }
+  return 0
+}
+
+/** Mirrors the pacer's digest so EVALSHA and EVAL agree on script identity. */
+function shaOf(script: string): string {
+  return createHash('sha1').update(script).digest('hex')
+}
+
+const scriptForSha = new Map<string, string>()
+
+const redis = {
+  evalsha: vi.fn(async (sha: string, _numKeys: number, key: string, ...argv: number[]) => {
+    calls.evalsha++
+    if (!cachedShas.has(sha)) throw new NoScriptError()
+    return runBody(scriptForSha.get(sha)!, key, argv)
+  }),
+  eval: vi.fn(async (script: string, _numKeys: number, key: string, ...argv: number[]) => {
+    calls.eval++
+    const sha = shaOf(script)
+    cachedShas.add(sha)
+    scriptForSha.set(sha, script)
+    return runBody(script, key, argv)
+  }),
+}
+
+let redisAvailable = true
+// Partial mock — a full replacement of `@auxx/redis` drops `createCredentialLockProvider`
+// et al. and dies at collection time as soon as anything in the graph reaches for them.
+vi.mock('@auxx/redis', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/redis')>()),
+  getRedisClient: async () => (redisAvailable ? redis : null),
+}))
+
+import { RateLimitError } from '../../../errors'
+import { acquireSlot, reportRetryAfter, resetPacerState } from '../pacer'
+import { connectionQuota, type Quota, quotaCursorKey } from '../quota'
+
+/** 1000 rps ⇒ a 1ms interval, so ordering assertions don't cost wall-clock. */
+function fastQuota(scopeId: string, overrides: Partial<Quota> = {}): Quota {
+  return { ...connectionQuota(scopeId, { rps: 1000, burstMs: 5_000 }), ...overrides }
+}
+
+beforeEach(() => {
+  store.clear()
+  cachedShas.clear()
+  scriptForSha.clear()
+  calls.evalsha = 0
+  calls.eval = 0
+  redisAvailable = true
+  resetPacerState()
+  vi.clearAllMocks()
+})
+
+describe('acquireSlot', () => {
+  it('never hands the same slot to two concurrent callers', async () => {
+    const quota = fastQuota('same-key')
+
+    const waits = await Promise.all(Array.from({ length: 8 }, () => acquireSlot(quota)))
+
+    // Each caller reserved a distinct, monotonically later slot — the property a
+    // read-modify-write limiter cannot provide.
+    expect(new Set(waits).size).toBe(waits.length)
+    expect([...waits].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5, 6, 7])
+  })
+
+  it('keeps distinct quotas on separate budgets', async () => {
+    const a = fastQuota('key-a')
+    const b = fastQuota('key-b')
+
+    await Promise.all([acquireSlot(a), acquireSlot(a), acquireSlot(a)])
+    const firstOnB = await acquireSlot(b)
+
+    // B's cursor is untouched by A's three reservations.
+    expect(firstOnB).toBe(0)
+    expect(store.size).toBe(2)
+  })
+
+  it('re-anchors an idle cursor instead of firing a burst of backdated slots', async () => {
+    const quota = fastQuota('idle')
+    const key = quotaCursorKey(quota)
+    // A cursor left far in the past by a long-finished run.
+    store.set(key, Date.now() - 60_000)
+
+    const waited = await acquireSlot(quota)
+
+    expect(waited).toBe(0)
+    // Re-anchored to ~now, not now-60s + interval.
+    expect(store.get(key)!).toBeGreaterThan(Date.now() - 1_000)
+  })
+
+  it('does not consume budget when the reservation is past the burst ceiling', async () => {
+    const quota = fastQuota('burst', { burstMs: 100 })
+    const key = quotaCursorKey(quota)
+    const cursor = Date.now() + 5_000
+    store.set(key, cursor)
+
+    await expect(acquireSlot(quota)).rejects.toBeInstanceOf(RateLimitError)
+
+    // The refusal cost nothing: the cursor is exactly where it was. A post-increment
+    // burst check would have leaked an interval here on every rejected call.
+    expect(store.get(key)).toBe(cursor)
+  })
+
+  it('falls back to EVAL on NOSCRIPT and re-caches the digest', async () => {
+    const quota = fastQuota('noscript')
+
+    await acquireSlot(quota)
+    expect(calls.evalsha).toBe(1) // missed
+    expect(calls.eval).toBe(1) // re-sent the body
+
+    await acquireSlot(quota)
+    expect(calls.evalsha).toBe(2) // hit this time
+    expect(calls.eval).toBe(1) // no second body send
+  })
+
+  it('paces in-process when Redis is unavailable', async () => {
+    redisAvailable = false
+    const quota = fastQuota('offline')
+
+    const waits = await Promise.all([acquireSlot(quota), acquireSlot(quota), acquireSlot(quota)])
+
+    expect(waits).toEqual([0, 1, 2])
+    expect(store.size).toBe(0) // nothing reached Redis
+  })
+
+  it('weights the reservation by cost', async () => {
+    const quota = fastQuota('cost')
+
+    await acquireSlot(quota, { cost: 100 })
+    const second = await acquireSlot(quota)
+
+    // 100 units at a 1ms interval pushes the cursor 100ms out.
+    expect(second).toBeGreaterThanOrEqual(95)
+    expect(second).toBeLessThanOrEqual(100)
+  })
+})
+
+describe('reportRetryAfter', () => {
+  it("delays a different caller's next reservation", async () => {
+    const quota = fastQuota('shared-429')
+
+    // Process A takes a 429 and publishes it.
+    await reportRetryAfter(quota, 150)
+
+    // Process B (same quota, no shared memory) reserves next.
+    const waited = await acquireSlot(quota)
+
+    expect(waited).toBeGreaterThan(100)
+    expect(waited).toBeLessThanOrEqual(150)
+  })
+
+  it('takes the max, never the sum — a smaller Retry-After cannot shorten the cursor', async () => {
+    const quota = fastQuota('max-not-add')
+    const key = quotaCursorKey(quota)
+
+    await reportRetryAfter(quota, 200)
+    const afterLong = store.get(key)!
+
+    await reportRetryAfter(quota, 20)
+    const afterShort = store.get(key)!
+
+    expect(afterShort).toBe(afterLong)
+  })
+
+  it('does not compound repeated reports into a stall', async () => {
+    const quota = fastQuota('compound')
+    const key = quotaCursorKey(quota)
+
+    await reportRetryAfter(quota, 200)
+    await reportRetryAfter(quota, 200)
+    await reportRetryAfter(quota, 200)
+
+    // An additive push would sit ~600ms out; a max sits ~200ms out.
+    expect(store.get(key)! - Date.now()).toBeLessThanOrEqual(200)
+  })
+
+  it('ignores a non-positive Retry-After', async () => {
+    const quota = fastQuota('zero')
+    await reportRetryAfter(quota, 0)
+    expect(store.size).toBe(0)
+  })
+
+  it('backs off in-process when Redis is unavailable', async () => {
+    redisAvailable = false
+    const quota = fastQuota('offline-429')
+
+    await reportRetryAfter(quota, 120)
+    const waited = await acquireSlot(quota)
+
+    expect(waited).toBeGreaterThan(80)
+    expect(waited).toBeLessThanOrEqual(120)
+  })
+})

--- a/packages/lib/src/utils/rate-limiter/__tests__/quota.test.ts
+++ b/packages/lib/src/utils/rate-limiter/__tests__/quota.test.ts
@@ -1,0 +1,92 @@
+// packages/lib/src/utils/rate-limiter/__tests__/quota.test.ts
+
+import { IntegrationProviderType } from '@auxx/database/enums'
+import { describe, expect, it } from 'vitest'
+import { ENHANCED_PROVIDER_LIMITS } from '../provider-configs'
+import {
+  connectionQuota,
+  DEFAULT_BURST_MS,
+  DEFAULT_CONNECTION_RPS,
+  DEFAULT_RPS,
+  hashScopeId,
+  quotaCursorKey,
+  resolveQuota,
+} from '../quota'
+
+describe('hashScopeId', () => {
+  it('is stable and never leaks the secret', () => {
+    const secret = 'op_live_abcdef0123456789'
+    const hashed = hashScopeId(secret)
+
+    expect(hashed).toBe(hashScopeId(secret))
+    expect(hashed).toHaveLength(16)
+    expect(hashed).toMatch(/^[0-9a-f]{16}$/)
+    expect(hashed).not.toContain(secret.slice(0, 8))
+  })
+
+  it('separates different secrets', () => {
+    expect(hashScopeId('a')).not.toBe(hashScopeId('b'))
+  })
+})
+
+describe('resolveQuota', () => {
+  it('reads the rate from provider-configs — the file is load-bearing, not decorative', () => {
+    const declared = ENHANCED_PROVIDER_LIMITS[IntegrationProviderType.openphone]?.requestsPerSecond
+    const quota = resolveQuota(IntegrationProviderType.openphone, 'apiKey', 'abc')
+
+    expect(declared).toBeDefined()
+    expect(quota.rps).toBe(declared)
+    expect(quota.burstMs).toBe(DEFAULT_BURST_MS)
+  })
+
+  it('keeps Quo at the documented headroom value', () => {
+    // The plan's DoD: api.ts carries no rate constant, and this is the single source.
+    expect(resolveQuota(IntegrationProviderType.openphone, 'apiKey', 'x').rps).toBe(8)
+  })
+
+  it('falls back conservatively for a provider with no declared rate', () => {
+    const quota = resolveQuota(IntegrationProviderType.outlook, 'account', 'mbx')
+    expect(quota.rps).toBe(DEFAULT_RPS)
+  })
+
+  it('honors explicit overrides', () => {
+    const quota = resolveQuota(IntegrationProviderType.shopify, 'shop', 'acme.myshopify.com', {
+      rps: 4,
+      burstMs: 1_000,
+    })
+    expect(quota).toMatchObject({ rps: 4, burstMs: 1_000, scope: 'shop' })
+  })
+})
+
+describe('quotaCursorKey', () => {
+  it('partitions on provider + scope + scopeId', () => {
+    const a = resolveQuota(IntegrationProviderType.openphone, 'apiKey', 'one')
+    const b = resolveQuota(IntegrationProviderType.openphone, 'apiKey', 'two')
+    const c = resolveQuota(IntegrationProviderType.shopify, 'shop', 'one')
+
+    expect(quotaCursorKey(a)).toBe('pace:openphone:apiKey:one')
+    expect(new Set([quotaCursorKey(a), quotaCursorKey(b), quotaCursorKey(c)]).size).toBe(3)
+  })
+
+  it('gives two callers on the same metered identity the SAME key', () => {
+    const key = 'op_live_shared'
+    const fromChannelA = resolveQuota(IntegrationProviderType.openphone, 'apiKey', hashScopeId(key))
+    const fromChannelB = resolveQuota(IntegrationProviderType.openphone, 'apiKey', hashScopeId(key))
+
+    expect(quotaCursorKey(fromChannelA)).toBe(quotaCursorKey(fromChannelB))
+  })
+})
+
+describe('connectionQuota', () => {
+  it('defaults to the connection rate and its own namespace', () => {
+    const quota = connectionQuota('conn_1')
+    expect(quota).toEqual({
+      provider: 'connection',
+      scope: 'connection',
+      scopeId: 'conn_1',
+      rps: DEFAULT_CONNECTION_RPS,
+      burstMs: DEFAULT_BURST_MS,
+    })
+    expect(quotaCursorKey(quota)).toBe('pace:connection:connection:conn_1')
+  })
+})

--- a/packages/lib/src/utils/rate-limiter/__tests__/rate-limiter.test.ts
+++ b/packages/lib/src/utils/rate-limiter/__tests__/rate-limiter.test.ts
@@ -643,28 +643,6 @@ describe('UniversalThrottler', () => {
     )
   }, 5000)
 
-  it('should support request coalescing', async () => {
-    const throttler = new UniversalThrottler()
-    await throttler.init()
-
-    const fn = vi.fn(async () => {
-      return 'result'
-    })
-
-    // Make multiple requests for the same key
-    const promises = [
-      throttler.coalesce('key', fn, 100),
-      throttler.coalesce('key', fn, 100),
-      throttler.coalesce('key', fn, 100),
-    ]
-
-    const results = await Promise.all(promises)
-
-    // Function should only be called once
-    expect(fn).toHaveBeenCalledTimes(1)
-    expect(results).toEqual(['result', 'result', 'result'])
-  }, 5000)
-
   it('should collect metrics when enabled', async () => {
     const throttler = new UniversalThrottler({
       metricsEnabled: true,

--- a/packages/lib/src/utils/rate-limiter/config-manager.ts
+++ b/packages/lib/src/utils/rate-limiter/config-manager.ts
@@ -9,7 +9,7 @@ import {
   getDefaultRateLimits,
   getMergedProviderLimits,
 } from './provider-configs'
-import type { EnhancedRateLimits, RateLimiterConfig, ThrottlerConfig } from './types'
+import type { EnhancedRateLimits, ThrottlerConfig } from './types'
 
 /**
  * Configuration manager for rate limiting
@@ -56,9 +56,6 @@ export class RateLimiterConfigManager {
 
     // Outlook overrides
     this.loadOutlookOverrides()
-
-    // Facebook overrides
-    this.loadFacebookOverrides()
 
     // Shopify overrides
     this.loadShopifyOverrides()
@@ -117,14 +114,6 @@ export class RateLimiterConfigManager {
       })
     }
 
-    const outlookRatePerHour = configService.get<string>('OUTLOOK_RATE_LIMIT_PER_HOUR')
-    if (outlookRatePerHour) {
-      outlookConfig.requestsPerHour = parseInt(outlookRatePerHour, 10)
-      this.logger.info('Outlook rate limit per hour overridden', {
-        value: outlookConfig.requestsPerHour,
-      })
-    }
-
     const outlookBatchSize = configService.get<string>('OUTLOOK_BATCH_SIZE')
     if (outlookBatchSize) {
       outlookConfig.batchSize = parseInt(outlookBatchSize, 10)
@@ -132,23 +121,6 @@ export class RateLimiterConfigManager {
     }
 
     this.config.set(IntegrationProviderTypeEnum.outlook, outlookConfig)
-  }
-
-  /**
-   * Load Facebook-specific environment overrides
-   */
-  private loadFacebookOverrides(): void {
-    const facebookConfig = this.config.get(IntegrationProviderTypeEnum.facebook) || {}
-
-    const fbRatePerHour = configService.get<string>('FACEBOOK_RATE_LIMIT_PER_HOUR')
-    if (fbRatePerHour) {
-      facebookConfig.requestsPerHour = parseInt(fbRatePerHour, 10)
-      this.logger.info('Facebook rate limit per hour overridden', {
-        value: facebookConfig.requestsPerHour,
-      })
-    }
-
-    this.config.set(IntegrationProviderTypeEnum.facebook, facebookConfig)
   }
 
   /**
@@ -166,50 +138,6 @@ export class RateLimiterConfigManager {
     }
 
     this.config.set(IntegrationProviderTypeEnum.shopify, shopifyConfig)
-  }
-
-  /**
-   * Get configuration for a specific provider and context
-   * @param providerType - Provider type
-   * @param context - Optional context (e.g., 'sync', 'send', 'batch')
-   * @returns Rate limiter configuration
-   */
-  getConfig(providerType: IntegrationProviderType, context?: string): RateLimiterConfig {
-    // Check if rate limiting is disabled
-    if (!this.isRateLimitingEnabled()) {
-      // Return very high limits when disabled
-      return {
-        maxRequests: 999999,
-        perInterval: 1000,
-        maxConcurrent: 999999,
-        retryConfig: DEFAULT_RETRY_CONFIG,
-        name: `${providerType}${context ? `:${context}` : ''}`,
-      }
-    }
-
-    const providerConfig = this.config.get(providerType)
-
-    // Check for context-specific limits
-    if (context && providerConfig?.contexts?.[context]) {
-      return {
-        ...providerConfig.contexts[context],
-        retryConfig: this.getRetryConfig(providerType),
-        name: `${providerType}:${context}`,
-      }
-    }
-
-    // Return provider defaults
-    const defaultLimits = providerConfig || getDefaultRateLimits()
-    return {
-      maxRequests: defaultLimits.requestsPerMinute || 100,
-      perInterval: 60000,
-      maxConcurrent: defaultLimits.concurrentRequests || 10,
-      minInterval: defaultLimits.requestsPerSecond
-        ? 1000 / defaultLimits.requestsPerSecond
-        : undefined,
-      retryConfig: this.getRetryConfig(providerType),
-      name: providerType,
-    }
   }
 
   /**

--- a/packages/lib/src/utils/rate-limiter/index.ts
+++ b/packages/lib/src/utils/rate-limiter/index.ts
@@ -29,17 +29,35 @@ export {
 } from './config-manager'
 export { checkFixedWindowLimit, type FixedWindowResult } from './fixed-window'
 export { MetricsCollector } from './metrics-collector'
+export {
+  type PacedFetchOptions,
+  type PacedFetchResult,
+  pacedFetch,
+  parseRetryAfterMs,
+} from './paced-fetch'
+// Shared pacer (the cross-process slot cursor)
+export { acquireSlot, reportRetryAfter, resetPacerState } from './pacer'
 export { PriorityQueue } from './priority-queue'
 export {
   DEFAULT_RETRY_CONFIG,
   ENHANCED_PROVIDER_LIMITS,
   GMAIL_QUOTA_COSTS,
-  getContextLimits,
   getDefaultRateLimits,
   getGmailQuotaCost,
   getMergedProviderLimits,
   supportsRateLimiting,
 } from './provider-configs'
+export {
+  connectionQuota,
+  DEFAULT_BURST_MS,
+  DEFAULT_CONNECTION_RPS,
+  DEFAULT_RPS,
+  hashScopeId,
+  type Quota,
+  type QuotaScope,
+  quotaCursorKey,
+  resolveQuota,
+} from './quota'
 export { RedisRateLimiter } from './redis-rate-limiter'
 // Core components
 export { TokenBucket } from './token-bucket'

--- a/packages/lib/src/utils/rate-limiter/paced-fetch.ts
+++ b/packages/lib/src/utils/rate-limiter/paced-fetch.ts
@@ -1,0 +1,90 @@
+// packages/lib/src/utils/rate-limiter/paced-fetch.ts
+// The thin composition providers call: reserve a slot on the shared cursor, fetch,
+// and on a throttle publish the `Retry-After` back onto that same cursor before
+// retrying. Everything interesting lives in `pacer.ts`; this is the two-line loop
+// that stops each new provider from arriving with its own private pacing code.
+
+import { acquireSlot, reportRetryAfter } from './pacer'
+import type { Quota } from './quota'
+
+/** Attempts after the first before the last response is handed back as-is. */
+const DEFAULT_MAX_RETRIES = 3
+
+/** Assumed backoff when a throttling response carries no usable `Retry-After`. */
+const DEFAULT_RETRY_AFTER_MS = 1_000
+
+export interface PacedFetchOptions {
+  /** Retries after the first attempt. Default 3. */
+  maxRetries?: number
+  /** Quota units this call consumes. Default 1. */
+  cost?: number
+  /** Aborts pacing sleeps (the `fetch` itself takes its own signal via `init`). */
+  signal?: AbortSignal
+  /** Statuses treated as throttling. Default `[429]`. */
+  throttleStatuses?: number[]
+  /** Observability hook, fired once per throttled attempt before the retry. */
+  onThrottle?: (info: { attempt: number; status: number; retryAfterMs: number }) => void
+}
+
+export interface PacedFetchResult {
+  response: Response
+  /** Wall-clock slept on pacing across every attempt. */
+  waitedMs: number
+  /** Attempts made, including the one that produced `response`. */
+  attempts: number
+}
+
+/**
+ * Parse a `Retry-After` header (delta-seconds or HTTP-date) to milliseconds.
+ * `undefined` when absent or unparseable.
+ */
+export function parseRetryAfterMs(value: string | null | undefined): number | undefined {
+  if (!value) return undefined
+  const seconds = Number(value)
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1_000)
+  const when = Date.parse(value)
+  if (!Number.isNaN(when)) return Math.max(0, when - Date.now())
+  return undefined
+}
+
+/**
+ * Issue a request paced against a shared {@link Quota}.
+ *
+ * On a throttling status the observed `Retry-After` is pushed onto the shared cursor
+ * and the loop simply retries — it deliberately does NOT sleep here, because the next
+ * `acquireSlot` already reserves a slot past the retry point. Sleeping as well would
+ * double-wait, and the shared push is what makes one process's 429 delay every OTHER
+ * process too.
+ *
+ * The final response is returned regardless of status once retries are exhausted;
+ * callers own their own error mapping.
+ *
+ * @throws {import('../../errors').RateLimitError} When the reservation lands past the
+ *   quota's burst ceiling — i.e. the backlog is longer than the caller agreed to wait.
+ */
+export async function pacedFetch(
+  quota: Quota,
+  input: string | URL,
+  init: RequestInit = {},
+  options: PacedFetchOptions = {}
+): Promise<PacedFetchResult> {
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES
+  const throttleStatuses = options.throttleStatuses ?? [429]
+  let waitedMs = 0
+
+  for (let attempt = 0; ; attempt++) {
+    waitedMs += await acquireSlot(quota, { cost: options.cost, signal: options.signal })
+
+    const response = await fetch(input, init)
+
+    if (throttleStatuses.includes(response.status) && attempt < maxRetries) {
+      const retryAfterMs =
+        parseRetryAfterMs(response.headers.get('retry-after')) ?? DEFAULT_RETRY_AFTER_MS
+      options.onThrottle?.({ attempt, status: response.status, retryAfterMs })
+      await reportRetryAfter(quota, retryAfterMs)
+      continue
+    }
+
+    return { response, waitedMs, attempts: attempt + 1 }
+  }
+}

--- a/packages/lib/src/utils/rate-limiter/pacer.ts
+++ b/packages/lib/src/utils/rate-limiter/pacer.ts
@@ -1,0 +1,285 @@
+// packages/lib/src/utils/rate-limiter/pacer.ts
+// The shared pacer: one Redis cursor per {@link Quota} that every process reserves
+// slots from, so N workers on one API key stay under the configured rate COMBINED.
+//
+// Two ideas carry the whole design:
+//
+//  1. **Pace, don't reject.** A caller reserves the next free slot and sleeps until
+//     it, instead of being refused and recovering through exponential-backoff retry.
+//     That removes the need for a priority queue, a `queue: true` flag on every call,
+//     and a circuit breaker on the common path.
+//  2. **`Retry-After` rides the same cursor.** A 429 seen by ANY process pushes the
+//     shared cursor forward, so every other process's next reservation lands past it
+//     automatically. Proactive pacing and cross-process reactive backoff, one key,
+//     no extra round trip on the hot path.
+//
+// Both operations are single Lua scripts: one round trip, fully atomic. A read-
+// modify-write (GET, compute in JS, SET) cannot provide this — two processes read the
+// same cursor and both admit — which is precisely the guarantee `RedisRateLimiter`
+// fails to deliver despite being "Redis-backed".
+//
+// `now` is passed in by the caller rather than read via `redis.call('TIME')` so the
+// scripts stay deterministic and replica-safe. Clock skew between app processes is the
+// trade; on one container platform it is far below one interval.
+
+import { createHash } from 'node:crypto'
+import { getRedisClient, type RedisClient } from '@auxx/redis'
+import { RateLimitError } from '../../errors'
+import { createScopedLogger } from '../../logger'
+import { type Quota, quotaCursorKey } from './quota'
+
+const logger = createScopedLogger('rate-limiter-pacer')
+
+/**
+ * The cursor TTL must exceed the maximum look-ahead (`burstMs`) with margin — if it
+ * expires mid-flight the cursor evaporates and the limiter silently resets to
+ * unthrottled.
+ */
+const CURSOR_TTL_MARGIN_MS = 60_000
+
+/** Cap on the in-process fallback map, so an unbounded key space can't leak. */
+const MAX_LOCAL_CURSORS = 5_000
+
+/**
+ * Reserve one cost-weighted slot on the shared cursor.
+ *
+ * `KEYS[1]` = cursor key. `ARGV` = now, intervalMs, burstMs, cost, ttlMs.
+ * Returns `{admitted, waitMs}`.
+ *
+ * The burst check runs BEFORE the write, so a refused reservation costs nothing. A
+ * bare `INCRBY` can only check after incrementing, which permanently shifts the cursor
+ * forward every time a caller gives up — and `DECRBY` to compensate reintroduces the
+ * race. Re-anchoring an idle cursor (`cursor < now`) is likewise free and exact here,
+ * where outside a script it is a two-command check-then-set that two processes can
+ * interleave into a backdated slot.
+ *
+ * The cursor is written through `string.format('%d', …)` because Lua's default number
+ * formatting is `%.14g` — a millisecond epoch plus a fraction exceeds 14 significant
+ * digits and would round into scientific notation, silently corrupting the cursor.
+ */
+const RESERVE_SCRIPT = `
+local now      = tonumber(ARGV[1])
+local interval = tonumber(ARGV[2]) * tonumber(ARGV[4])
+local burst    = tonumber(ARGV[3])
+local ttl      = tonumber(ARGV[5])
+local cursor   = tonumber(redis.call('GET', KEYS[1])) or 0
+
+if cursor < now then cursor = now end
+
+local wait = cursor - now
+if wait > burst then
+  return {0, wait}
+end
+
+redis.call('SET', KEYS[1], string.format('%d', math.floor(cursor + interval)), 'PX', ttl)
+return {1, wait}
+`.trim()
+
+/**
+ * Fold an observed `Retry-After` into the shared cursor as a **max**, never an add.
+ *
+ * `KEYS[1]` = cursor key. `ARGV` = now, retryAfterMs, ttlMs. Returns 1 when it moved
+ * the cursor.
+ *
+ * Adding is a correctness bug, not a wart: a blind `INCRBY(key, 2000)` on a cursor
+ * already 5s ahead yields 7s instead of the correct 5s, and repeated 429s compound
+ * that into a stall.
+ */
+const RETRY_AFTER_SCRIPT = `
+local cursor = tonumber(redis.call('GET', KEYS[1])) or 0
+local target = tonumber(ARGV[1]) + tonumber(ARGV[2])
+
+if target > cursor then
+  redis.call('SET', KEYS[1], string.format('%d', math.floor(target)), 'PX', tonumber(ARGV[3]))
+  return 1
+end
+return 0
+`.trim()
+
+/** Memoized `sha1(script)` — the digest is deterministic, this just avoids rehashing. */
+const scriptShas = new Map<string, string>()
+
+/** In-process cursors, used when Redis is unavailable (§ Redis-down behavior). */
+const localCursors = new Map<string, number>()
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (ms <= 0) return Promise.resolve()
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) return reject(signal.reason ?? new Error('aborted'))
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(signal?.reason ?? new Error('aborted'))
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+function isNoScriptError(error: unknown): boolean {
+  return String((error as Error)?.message ?? '').includes('NOSCRIPT')
+}
+
+/**
+ * Run a script by digest, re-sending the body once on `NOSCRIPT`. The body is ~400
+ * bytes; shipping it on every request is pure waste, and `EVAL` re-caches it server
+ * side under the same digest, so the fallback is self-healing.
+ */
+async function runScript(
+  redis: RedisClient,
+  script: string,
+  key: string,
+  argv: (string | number)[]
+): Promise<unknown> {
+  let sha = scriptShas.get(script)
+  if (!sha) {
+    sha = createHash('sha1').update(script).digest('hex')
+    scriptShas.set(script, sha)
+  }
+
+  try {
+    return await redis.evalsha(sha, 1, key, ...argv)
+  } catch (error) {
+    if (!isNoScriptError(error)) throw error
+    return await redis.eval(script, 1, key, ...argv)
+  }
+}
+
+/** Coerce a `{admitted, waitMs}` reply from either provider's array encoding. */
+function readReservation(reply: unknown): { admitted: boolean; waitMs: number } {
+  const pair = Array.isArray(reply) ? reply : []
+  return { admitted: Number(pair[0]) === 1, waitMs: Math.max(0, Number(pair[1]) || 0) }
+}
+
+/** Drop cursors that are already in the past once the map grows too large. */
+function pruneLocalCursors(now: number): void {
+  if (localCursors.size <= MAX_LOCAL_CURSORS) return
+  for (const [key, cursor] of localCursors) {
+    if (cursor <= now) localCursors.delete(key)
+  }
+}
+
+/** The in-process mirror of {@link RESERVE_SCRIPT}. Same arithmetic, one process. */
+function reserveLocally(
+  key: string,
+  now: number,
+  intervalMs: number,
+  burstMs: number
+): { admitted: boolean; waitMs: number } {
+  let cursor = localCursors.get(key) ?? 0
+  if (cursor < now) cursor = now
+
+  const waitMs = cursor - now
+  if (waitMs > burstMs) return { admitted: false, waitMs }
+
+  localCursors.set(key, cursor + intervalMs)
+  pruneLocalCursors(now)
+  return { admitted: true, waitMs }
+}
+
+/** Redis when it's up, `null` otherwise — never throws. */
+async function tryGetRedis(): Promise<RedisClient | null> {
+  try {
+    return (await getRedisClient(false)) ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Reserve the next slot on `quota`'s shared cursor and sleep until it is due.
+ *
+ * @param quota - The metered budget to draw from.
+ * @param opts.cost - Quota units this call consumes (Gmail's `messages.send` is 100,
+ *   not 1). Multiplies the reservation width; defaults to 1.
+ * @param opts.signal - Aborts the sleep, so a cancelled slice never parks.
+ * @returns Milliseconds actually slept — fold this into a run ledger's rate-limit wait.
+ * @throws {RateLimitError} When the next free slot is past `quota.burstMs`. The
+ *   reservation is NOT consumed in that case, so the cursor is unmoved and a later
+ *   caller sees the same budget.
+ *
+ * Degrades to an in-process cursor when Redis is unavailable — i.e. per-process
+ * pacing, which is still correct for a single worker. Explicit, not silently
+ * best-effort.
+ */
+export async function acquireSlot(
+  quota: Quota,
+  opts: { cost?: number; signal?: AbortSignal } = {}
+): Promise<number> {
+  const key = quotaCursorKey(quota)
+  const cost = Math.max(1, Math.round(opts.cost ?? 1))
+  const intervalMs = Math.max(1, Math.ceil(1000 / quota.rps))
+  const ttlMs = quota.burstMs + CURSOR_TTL_MARGIN_MS
+  const now = Date.now()
+
+  let outcome: { admitted: boolean; waitMs: number } | undefined
+  const redis = await tryGetRedis()
+  if (redis) {
+    try {
+      outcome = readReservation(
+        await runScript(redis, RESERVE_SCRIPT, key, [now, intervalMs, quota.burstMs, cost, ttlMs])
+      )
+    } catch (error) {
+      logger.warn('Slot reservation failed in Redis; pacing in-process for this call', {
+        key,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+  outcome ??= reserveLocally(key, now, intervalMs * cost, quota.burstMs)
+
+  if (!outcome.admitted) {
+    throw new RateLimitError(
+      `Rate limit budget exhausted for ${key}: the next slot is ${outcome.waitMs}ms out, ` +
+        `past the ${quota.burstMs}ms burst ceiling`,
+      Math.ceil(outcome.waitMs / 1000)
+    )
+  }
+
+  if (outcome.waitMs > 0) await sleep(outcome.waitMs, opts.signal)
+  return outcome.waitMs
+}
+
+/**
+ * Publish an observed `Retry-After` to every process sharing `quota`.
+ *
+ * Call this the moment a 429 (or a provider-specific throttle signal) is seen, BEFORE
+ * sleeping — the next {@link acquireSlot} on this quota, in this process or any other,
+ * then lands past the retry point on its own. Never-throws: a failed report degrades
+ * to process-local backoff, it must not turn a retryable 429 into a hard failure.
+ *
+ * @param quota - The budget the throttle applies to.
+ * @param retryAfterMs - How far out the upstream says the next attempt may be.
+ */
+export async function reportRetryAfter(quota: Quota, retryAfterMs: number): Promise<void> {
+  if (!(retryAfterMs > 0)) return
+
+  const key = quotaCursorKey(quota)
+  const now = Date.now()
+  // The TTL has to outlive the push itself, not just the burst window.
+  const ttlMs = Math.max(quota.burstMs, retryAfterMs) + CURSOR_TTL_MARGIN_MS
+
+  const redis = await tryGetRedis()
+  if (redis) {
+    try {
+      await runScript(redis, RETRY_AFTER_SCRIPT, key, [now, Math.ceil(retryAfterMs), ttlMs])
+      return
+    } catch (error) {
+      logger.warn('Retry-After report failed in Redis; backing off in-process only', {
+        key,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  const target = now + retryAfterMs
+  if (target > (localCursors.get(key) ?? 0)) localCursors.set(key, target)
+}
+
+/** Test seam — drops the in-process cursors and the memoized script digests. */
+export function resetPacerState(): void {
+  localCursors.clear()
+  scriptShas.clear()
+}

--- a/packages/lib/src/utils/rate-limiter/provider-configs.ts
+++ b/packages/lib/src/utils/rate-limiter/provider-configs.ts
@@ -70,7 +70,6 @@ export const ENHANCED_PROVIDER_LIMITS: Partial<
     // Gmail specific limits (extending existing capabilities)
     requestsPerSecond: 250, // 250 quota units/sec
     requestsPerMinute: 15000, // 15k quota units/min per user
-    burstLimit: 100, // Max burst requests
     concurrentRequests: 50, // Max concurrent API calls
     batchSize: 100, // Max items per batch request
 
@@ -120,8 +119,6 @@ export const ENHANCED_PROVIDER_LIMITS: Partial<
   [IntegrationProviderTypeEnum.outlook]: {
     // Outlook/Microsoft Graph API limits
     requestsPerMinute: 1000, // Conservative estimate
-    requestsPerHour: 10000, // 10k requests per 10 minutes
-    burstLimit: 20,
     concurrentRequests: 10,
     batchSize: 20, // Microsoft Graph batch limit
 
@@ -152,7 +149,6 @@ export const ENHANCED_PROVIDER_LIMITS: Partial<
   [IntegrationProviderTypeEnum.facebook]: {
     // Facebook Graph API limits
     requestsPerMinute: 200,
-    requestsPerHour: 1000,
     concurrentRequests: 5,
     batchSize: 50,
 
@@ -178,43 +174,36 @@ export const ENHANCED_PROVIDER_LIMITS: Partial<
 
   [IntegrationProviderTypeEnum.openphone]: {
     // Quo (formerly OpenPhone). Documented ceiling: 10 requests/second PER API KEY (429 on
-    // exceed) = 600/min = 36,000/hour. The previous 100/min + 1000/hr numbers were invented and
-    // throttled us 6× / 36× below the real allowance.
+    // exceed). The previous 100/min + 1000/hr numbers were invented and throttled us 6× / 36×
+    // below the real allowance.
     //
-    // `requestsPerSecond` is the load-bearing knob — `config-manager.ts` derives
-    // `minInterval = 1000 / requestsPerSecond` from it.
-    requestsPerSecond: 10,
-    requestsPerMinute: 600,
-    requestsPerHour: 36000,
+    // `requestsPerSecond` is the SINGLE SOURCE for the Quo client's pacing — `api.ts` reads it
+    // through `resolveQuota` and carries no rate constant of its own. It is deliberately 8, not
+    // the documented 10: two below the ceiling is the headroom that absorbs clock skew between
+    // workers and a burst that lands on an interval boundary. Measured latency is ~195ms/request,
+    // so a serial caller never reaches this anyway — the pacer matters when a backfill runs a
+    // small amount of concurrency.
+    requestsPerSecond: 8,
+    requestsPerMinute: 480,
     // Measured latency is ~195ms/request, so a serial caller only reaches ~5 rps; 2 in flight
     // lands at ~10 rps. The old `5` would overshoot the ceiling and collect 429s.
     concurrentRequests: 2,
     batchSize: 10,
 
     // NOTE: the rate limit is per API KEY, not per number — three channels backfilling
-    // concurrently share one budget. The Quo client (`providers/openphone/api.ts`) paces on the
-    // key itself for exactly this reason.
-    contexts: {
-      messages: {
-        maxRequests: 600,
-        perInterval: 60000,
-      },
-      send: {
-        maxRequests: 600,
-        perInterval: 60000,
-      },
-      calls: {
-        maxRequests: 600,
-        perInterval: 60000,
-      },
-    },
+    // concurrently share one budget. The Quo client (`providers/openphone/api.ts`) paces on a
+    // hash of the key itself for exactly this reason.
+    //
+    // No `contexts` block: Quo meters one flat per-key rate, and the per-context entries that
+    // used to sit here (600/min for messages/send/calls) were both unread — nothing builds a
+    // `UniversalThrottler` for this provider — and in direct contradiction with the 480/min
+    // that `requestsPerSecond` above now enforces.
   },
 
   [IntegrationProviderTypeEnum.shopify]: {
     // Shopify API limits (REST)
     requestsPerSecond: 2, // 2 requests per second
     requestsPerMinute: 40, // Leaky bucket: 40 requests per minute
-    burstLimit: 40,
     concurrentRequests: 5,
 
     contexts: {
@@ -258,25 +247,6 @@ export function getMergedProviderLimits(providerType: IntegrationProviderType): 
 }
 
 /**
- * Get rate limit configuration for a specific context
- */
-export function getContextLimits(
-  providerType: IntegrationProviderType,
-  context: string
-): {
-  maxRequests: number
-  perInterval: number
-  maxConcurrent?: number
-} | null {
-  const providerLimits = ENHANCED_PROVIDER_LIMITS[providerType]
-  if (!providerLimits?.contexts) {
-    return null
-  }
-
-  return providerLimits.contexts[context] || null
-}
-
-/**
  * Get Gmail quota cost for an operation
  */
 export function getGmailQuotaCost(operation: string): number {
@@ -296,9 +266,7 @@ export function supportsRateLimiting(providerType: IntegrationProviderType): boo
 export function getDefaultRateLimits(): EnhancedRateLimits {
   return {
     requestsPerMinute: 100,
-    requestsPerHour: 1000,
     concurrentRequests: 10,
-    burstLimit: 20,
     batchSize: 10,
   }
 }

--- a/packages/lib/src/utils/rate-limiter/quota.ts
+++ b/packages/lib/src/utils/rate-limiter/quota.ts
@@ -1,0 +1,110 @@
+// packages/lib/src/utils/rate-limiter/quota.ts
+// The partition key for shared pacing: *what* the upstream actually meters.
+//
+// Every provider meters something different — Quo meters the API key (workspace),
+// Shopify the shop domain, Gmail the project + user. Getting that partition wrong is
+// the difference between "one shared budget" and "N processes 429ing each other", so
+// it is declared explicitly here rather than being implied by whatever id happened to
+// be in scope at the call site.
+
+import { createHash } from 'node:crypto'
+import type { IntegrationProviderType } from '@auxx/database/types'
+import { ENHANCED_PROVIDER_LIMITS } from './provider-configs'
+
+/** What the upstream meters. Names the *dimension*, not the id we happen to hold. */
+export type QuotaScope = 'apiKey' | 'account' | 'shop' | 'connection'
+
+/**
+ * One metered budget. `provider` + `scope` + `scopeId` form the Redis cursor key, so
+ * two callers agreeing on all three share a budget and everyone else is isolated.
+ */
+export interface Quota {
+  /** Key namespace — an `IntegrationProviderType` for channels, `'connection'` for connectors. */
+  provider: string
+  scope: QuotaScope
+  /** Hash for secrets (see {@link hashScopeId}), a plain id otherwise. */
+  scopeId: string
+  /** Sustained requests per second across every process sharing this quota. */
+  rps: number
+  /**
+   * How far ahead of `now` a reservation may land before it is refused instead of
+   * slept. Doubles as the caller's maximum wait: a `Retry-After` past this ceiling
+   * surfaces as a `RateLimitError` rather than parking a worker.
+   */
+  burstMs: number
+}
+
+/** Look-ahead ceiling when a caller doesn't pick one. 30s ≈ the longest a worker job
+ *  should ever block on pacing before yielding. */
+export const DEFAULT_BURST_MS = 30_000
+
+/** Fallback rate for a provider whose `requestsPerSecond` isn't declared. Deliberately
+ *  conservative — an undeclared limit is an unknown limit. */
+export const DEFAULT_RPS = 5
+
+/** Pacing rate for a connector connection, which declares no provider limits of its
+ *  own. High enough to be a no-op for a healthy backfill; low enough that two
+ *  concurrent slices on one connection can't stampede an upstream. */
+export const DEFAULT_CONNECTION_RPS = 10
+
+/**
+ * Derive a stable, non-reversible scope id from a secret (an API key, a token).
+ *
+ * Hashing the metered secret rather than the row that stores it is both cheaper and
+ * more correct: two `Credential` rows can hold the same API key, and keying on the row
+ * id would hand one upstream workspace two budgets — which is exactly how you 429
+ * yourself. 16 hex chars is 64 bits; collisions across one org's credentials are not a
+ * practical concern, and no raw secret reaches Redis.
+ */
+export function hashScopeId(secret: string): string {
+  return createHash('sha256').update(secret).digest('hex').slice(0, 16)
+}
+
+/** The Redis key holding this quota's shared slot cursor. */
+export function quotaCursorKey(quota: Quota): string {
+  return `pace:${quota.provider}:${quota.scope}:${quota.scopeId}`
+}
+
+/**
+ * Build a {@link Quota} for an integration provider, reading the sustained rate from
+ * `ENHANCED_PROVIDER_LIMITS[provider].requestsPerSecond` — which is what makes
+ * `provider-configs.ts` load-bearing instead of decorative.
+ *
+ * @param provider - The metering upstream.
+ * @param scope - What that upstream meters.
+ * @param scopeId - The identity within that scope; hash it first if it's a secret.
+ * @param overrides - Explicit `rps` / `burstMs`, for callers that know better.
+ */
+export function resolveQuota(
+  provider: IntegrationProviderType,
+  scope: QuotaScope,
+  scopeId: string,
+  overrides: { rps?: number; burstMs?: number } = {}
+): Quota {
+  const declared = ENHANCED_PROVIDER_LIMITS[provider]?.requestsPerSecond
+  return {
+    provider,
+    scope,
+    scopeId,
+    rps: overrides.rps ?? declared ?? DEFAULT_RPS,
+    burstMs: overrides.burstMs ?? DEFAULT_BURST_MS,
+  }
+}
+
+/**
+ * Build a {@link Quota} for a data-connector connection. Connections have no provider
+ * limits table, so the rate is either supplied by the caller (from the endpoint's
+ * rate-limit policy) or falls back to {@link DEFAULT_CONNECTION_RPS}.
+ */
+export function connectionQuota(
+  connectionId: string,
+  overrides: { rps?: number; burstMs?: number } = {}
+): Quota {
+  return {
+    provider: 'connection',
+    scope: 'connection',
+    scopeId: connectionId,
+    rps: overrides.rps ?? DEFAULT_CONNECTION_RPS,
+    burstMs: overrides.burstMs ?? DEFAULT_BURST_MS,
+  }
+}

--- a/packages/lib/src/utils/rate-limiter/types.ts
+++ b/packages/lib/src/utils/rate-limiter/types.ts
@@ -10,8 +10,6 @@ export interface RateLimiterConfig {
   perInterval: number
   /** Maximum concurrent requests (optional) */
   maxConcurrent?: number
-  /** Minimum time between requests in milliseconds (optional) */
-  minInterval?: number
   /** Retry configuration (optional) */
   retryConfig?: RetryConfig
   /** Name for logging/metrics (optional) */
@@ -47,14 +45,10 @@ export interface EnhancedRateLimits {
   /** Messages per day (from existing capabilities) */
   messagesPerDay?: number
 
-  /** API calls per second */
+  /** API calls per second. The rate the shared pacer enforces (see `quota.ts`). */
   requestsPerSecond?: number
   /** API calls per minute */
   requestsPerMinute?: number
-  /** API calls per hour */
-  requestsPerHour?: number
-  /** Maximum burst requests */
-  burstLimit?: number
   /** Maximum concurrent API calls */
   concurrentRequests?: number
   /** Maximum items per batch */

--- a/packages/lib/src/utils/rate-limiter/universal-throttler.ts
+++ b/packages/lib/src/utils/rate-limiter/universal-throttler.ts
@@ -30,7 +30,6 @@ export class UniversalThrottler {
   private concurrencySemaphore: ConcurrencySemaphore
   private metrics: MetricsCollector
   private processingQueues: Set<string> = new Set()
-  private coalescedRequests: Map<string, Promise<any>> = new Map()
   private initialized = false
   private logger = createScopedLogger('UniversalThrottler')
 
@@ -264,10 +263,6 @@ export class UniversalThrottler {
             }
           }
 
-          // Record available tokens
-          const availableTokens = await limiter.getAvailableTokens(key)
-          this.metrics.recordAvailableTokens(context, availableTokens)
-
           // Execute the function with default timeout if none specified
           const timeout = options?.timeout ?? DEFAULT_OPERATION_TIMEOUT_MS
 
@@ -432,80 +427,6 @@ export class UniversalThrottler {
   }
 
   /**
-   * Coalesce similar requests within a time window
-   * @param key - Coalescing key
-   * @param fn - Function to execute
-   * @param windowMs - Time window in milliseconds
-   * @returns Result of the function
-   */
-  async coalesce<T>(key: string, fn: () => Promise<T>, windowMs: number = 100): Promise<T> {
-    // Check if we already have a pending request for this key
-    if (this.coalescedRequests.has(key)) {
-      return this.coalescedRequests.get(key) as Promise<T>
-    }
-
-    // Create a new promise that will be shared by all requests in the window
-    const promise = (async () => {
-      try {
-        return await fn()
-      } finally {
-        // Clean up after the window expires
-        setTimeout(() => {
-          this.coalescedRequests.delete(key)
-        }, windowMs)
-      }
-    })()
-
-    this.coalescedRequests.set(key, promise)
-    return promise
-  }
-
-  /**
-   * Adapt rate limits based on response headers
-   * @param context - Context identifier
-   * @param headers - Response headers
-   */
-  async adaptLimits(context: string, headers: Headers | Record<string, string>): Promise<void> {
-    const getHeader = (name: string): string | null => {
-      if (headers instanceof Headers) {
-        return headers.get(name)
-      }
-      return headers[name] || null
-    }
-
-    const remaining = getHeader('x-ratelimit-remaining')
-    const limit = getHeader('x-ratelimit-limit')
-    const reset = getHeader('x-ratelimit-reset')
-
-    if (remaining !== null && limit !== null) {
-      const remainingNum = parseInt(remaining, 10)
-      const limitNum = parseInt(limit, 10)
-
-      // Log when we're approaching limits
-      if (remainingNum < limitNum * 0.2) {
-        this.logger.warn('Approaching rate limit', {
-          context,
-          remaining: remainingNum,
-          limit: limitNum,
-          reset,
-        })
-      }
-    }
-
-    // Check for Retry-After header
-    const retryAfter = getHeader('retry-after')
-    if (retryAfter) {
-      const retryAfterMs = this.parseRetryAfter(retryAfter)
-      if (retryAfterMs > 0) {
-        this.logger.info('Received Retry-After header', {
-          context,
-          retryAfterMs,
-        })
-      }
-    }
-  }
-
-  /**
    * Build a rate limit key from context and options
    * @param context - Context identifier
    * @param options - Execution options
@@ -550,27 +471,6 @@ export class UniversalThrottler {
     const config = this.getConfigForContext(context)
     // Simple calculation - could be more sophisticated
     return config.perInterval / config.maxRequests
-  }
-
-  /**
-   * Parse Retry-After header value
-   * @param retryAfter - Retry-After header value
-   * @returns Retry time in milliseconds
-   */
-  private parseRetryAfter(retryAfter: string): number {
-    // Check if it's a number (seconds)
-    const seconds = parseInt(retryAfter, 10)
-    if (!Number.isNaN(seconds)) {
-      return seconds * 1000
-    }
-
-    // Check if it's a date
-    const date = new Date(retryAfter)
-    if (!Number.isNaN(date.getTime())) {
-      return Math.max(0, date.getTime() - Date.now())
-    }
-
-    return 0
   }
 
   /**
@@ -637,7 +537,6 @@ export class UniversalThrottler {
       queues: this.queues.size,
       circuitBreakers: this.circuitBreakers.size,
       processingQueues: this.processingQueues.size,
-      coalescedRequests: this.coalescedRequests.size,
       queueStats: {},
       circuitBreakerStats: {},
       concurrencyStats: this.concurrencySemaphore.getStats(),
@@ -685,7 +584,6 @@ export class UniversalThrottler {
     this.queues.clear()
     this.circuitBreakers.clear()
     this.processingQueues.clear()
-    this.coalescedRequests.clear()
 
     this.initialized = false
   }

--- a/packages/redis/src/providers/ioredis-provider.ts
+++ b/packages/redis/src/providers/ioredis-provider.ts
@@ -242,6 +242,13 @@ export function createIORedisClient(provider: 'aws' | 'hosted', onDead?: () => v
 
     // Pipeline support
     pipeline: () => client.pipeline() as any,
+
+    // Lua scripting — a straight passthrough to ioredis. Covers `hosted` (Railway
+    // prod) and `aws` (ElastiCache); both are stock upstream Redis on this path.
+    eval: async (script: string, numKeys: number, ...args: any[]) =>
+      await client.eval(script, numKeys, ...args),
+    evalsha: async (sha1: string, numKeys: number, ...args: any[]) =>
+      await client.evalsha(sha1, numKeys, ...args),
   }
 
   logger.info(`Enhanced ${provider} Redis client created successfully`)

--- a/packages/redis/src/providers/provider-detector.ts
+++ b/packages/redis/src/providers/provider-detector.ts
@@ -100,6 +100,8 @@ export function getProviderCapabilities(provider: RedisProvider): RedisProviderC
           'zscore',
           'ttl',
           'pttl',
+          'eval',
+          'evalsha',
         ],
       }
 
@@ -141,6 +143,8 @@ export function getProviderCapabilities(provider: RedisProvider): RedisProviderC
           'zscore',
           'ttl',
           'pttl',
+          'eval',
+          'evalsha',
         ],
       }
 
@@ -182,6 +186,8 @@ export function getProviderCapabilities(provider: RedisProvider): RedisProviderC
           'zscore',
           'ttl',
           'pttl',
+          'eval',
+          'evalsha',
         ],
       }
 

--- a/packages/redis/src/providers/upstash-provider.ts
+++ b/packages/redis/src/providers/upstash-provider.ts
@@ -500,6 +500,38 @@ export function createUpstashClient(): RedisClient {
     // Pipeline support (Upstash supports pipelines via REST)
     pipeline: () => upstashClient.pipeline() as any,
 
+    // Lua scripting. Upstash takes (script, keys[], args[]) rather than the wire
+    // layout (script, numKeys, ...keys, ...argv), so split on `numKeys` here.
+    eval: async (script: string, numKeys: number, ...args: any[]) => {
+      try {
+        return await upstashClient.eval(
+          script,
+          args.slice(0, numKeys).map(String),
+          args.slice(numKeys)
+        )
+      } catch (error) {
+        logger.error('Error running EVAL in Upstash', { error: (error as Error).message })
+        throw error
+      }
+    },
+
+    evalsha: async (sha1: string, numKeys: number, ...args: any[]) => {
+      try {
+        return await upstashClient.evalsha(
+          sha1,
+          args.slice(0, numKeys).map(String),
+          args.slice(numKeys)
+        )
+      } catch (error) {
+        // NOSCRIPT is expected on a cold cache — the caller re-sends via EVAL, so
+        // don't log it as an error.
+        if (!(error as Error).message?.includes('NOSCRIPT')) {
+          logger.error('Error running EVALSHA in Upstash', { error: (error as Error).message })
+        }
+        throw error
+      }
+    },
+
     // Pub/Sub operations (not supported by Upstash, will throw errors)
     subscribe: async () => {
       throw new Error(

--- a/packages/redis/src/types.ts
+++ b/packages/redis/src/types.ts
@@ -116,8 +116,14 @@ export interface RedisClient {
   // Pipeline support (batch operations)
   pipeline(): RedisPipeline
 
-  // Lua script support (IORedis/AWS)
-  eval?(script: string, numKeys: number, ...args: any[]): Promise<any>
+  // Lua script support. REQUIRED: a provider that cannot script must say so with a
+  // throw, never by leaving the member undefined — callers (the shared pacer in
+  // `@auxx/lib/utils/rate-limiter`) would otherwise degrade invisibly.
+  // `args` is `[...keys, ...argv]`, matching the wire protocol.
+  eval(script: string, numKeys: number, ...args: any[]): Promise<any>
+  /** EVALSHA with the same arg layout as {@link eval}. Rejects with `NOSCRIPT` when
+   *  the script isn't cached, which the caller answers by re-sending via `eval`. */
+  evalsha(sha1: string, numKeys: number, ...args: any[]): Promise<any>
 }
 
 /**


### PR DESCRIPTION
Replaces the per-process Quo pacer and the racy `UniversalThrottler` token bucket with one primitive: a GCRA slot cursor advanced by a single Lua script, so N workers on one upstream credential stay under the rate **combined**.

## Why the existing throttler couldn't be reused

Five providers declare rate-limit configs in `provider-configs.ts`. **Only `google` ever consumed one** — Outlook, Facebook, Shopify and Quo had config blocks that read as authoritative and did nothing. Beyond that:

- **`RedisRateLimiter.acquireFromRedis` is a non-atomic read-modify-write** (2 GETs → compute in JS → 2 SETEXs). Two processes read the same token count and both admit, so "Redis-backed" never actually meant one shared budget. It also costs ~6 Redis round trips per call.
- **`UniversalThrottler` ignores `Retry-After` entirely.** The extractor in `backoff-handler.ts` is never called; `wait()` is pure exponential backoff, and `adaptLimits` only logs. Moving Quo onto it as-is would have been a *regression* — `quoFetch` already honored `Retry-After`.
- **It rejects rather than paces**, which is why Gmail must pass `queue: true` on every call and drain through a priority queue hardcoded to 100ms/item regardless of configured rate.

## The primitive

One Lua script decides admission and returns how long to sleep. Three properties that a bare `INCRBY` cannot provide:

- the burst check runs **before** the write, so a refused reservation costs no budget (post-increment checking permanently shifts the cursor every time a caller gives up);
- re-anchoring an idle cursor is exact, not a two-command check-then-set two processes can interleave into a backdated slot;
- `Retry-After` folds onto the same cursor as a **max, never an add** — adding compounds repeated 429s into a stall (2s on a cursor already 5s ahead → 7s instead of 5s).

Both scripts write through `string.format('%d', math.floor(...))`. Lua 5.1 serializes numbers with `%.14g`, and a 13-digit ms epoch plus a fractional interval rounds into scientific notation — silent, drifting mispacing.

Quota keys **hash the metered secret** rather than using `credentialId`: `saveConnection` still has no `providerKey` dedupe, so two `Credential` rows can hold one Quo API key, and keying on the row id would hand one workspace two budgets and 429 itself.

## Verification

The shipped Lua was **executed against real Redis**, not just unit-tested:

| check | result |
|---|---|
| 3 reservations @125ms | waits `0 / 125 / 250` |
| stored cursor | `1786764718917` — plain integer, no scientific notation |
| burst refusal | `{0, 375}`, cursor **byte-identical** (no leak) |
| `cost: 100` | cursor advanced exactly `12500ms` |
| uncached script | rejects with exactly `NOSCRIPT No matching script. Please use EVAL.` |

Lua availability was confirmed against **production** first (read-only): Railway Redis is 8.2.1 standalone, `COMMAND INFO eval` present with ACL categories `@slow @scripting`.

Tests: 57 files / 518 tests pass across `utils/rate-limiter`, `connections`, `sync-core`, `data-connectors`, `providers/openphone`. `@auxx/redis` typecheck clean, 23 tests pass. `packages/lib` `tsc --noEmit` has zero `src/` errors.

**Honest limit:** `pacer.test.ts` fakes `eval` with a JS re-implementation of the scripts, so it proves the client layer but *cannot* prove the Lua parses — that's what the live-Redis run above covers.

## Also removed — config nothing read

`getConfig()` (called from nowhere), `minInterval` (written, read nowhere), `requestsPerHour`, `burstLimit`, `adaptLimits`, `coalesce`, `getContextLimits`, and the hot-path `getAvailableTokens` call that spent 2 Redis round trips per execute to feed one metric.

## Scope limits — please read before assuming coverage

- **Gmail deliberately stays on `UniversalThrottler`.** It is the only throttling path carrying production traffic. The technical blocker is gone (cost-weighting is just the script's `cost` arg), but porting it needs validation against real Gmail 429 behavior. Two implementations coexist until then, by design.
- **No connector paces yet.** Transport pacing is opt-in — it activates only when `req.quota` is set, or the policy declares `rps`/`minDelayMs` and a connection is present. Turning it on unconditionally would rate-cap every `httpTransport` consumer (workflow HTTP node, agent tools). Nothing sets `minDelayMs` today, so Phase 3 is mechanism-only. **Quo is live.**
- **No production evidence.** Every guarantee here is proven by construction and single-host testing. "Two Railway workers on one Quo key stay under 8 rps combined" is inferred, not observed.
- **Clock skew is unmeasured.** `now` is passed in rather than read via `redis.call('TIME')` to keep the scripts deterministic; the assumption that Railway containers share a platform clock is stated, not verified.

## ⚠️ Contains one unrelated change

`api.ts` and `openphone-provider.ts` are atomically coupled in this tree, so this PR also carries a **concurrent fix to Quo webhook provisioning**: webhooks are immutable — `PATCH /v1/webhooks/{id}` 404s against the live API, so the create-`disabled`-then-enable sequence shipped in #1646 could never work (the create succeeded, the enable 404'd, rollback tore the webhook down — a channel that reported connected and received nothing). Includes its one-off repair script. That work is not mine and is unrelated to pacing; splitting it would have broken the build, since HEAD's `openphone-provider.ts` calls the `updateWebhookStatus` that its `api.ts` change removes.
