### PR TITLE
feat(composer): offer phone channels in the From picker

### DIFF
--- a/apps/web/src/components/channels/hooks/use-default-channel.ts
+++ b/apps/web/src/components/channels/hooks/use-default-channel.ts
@@ -1,18 +1,29 @@
 // apps/web/src/components/channels/hooks/use-default-channel.ts
 
+import type { ChannelSelectionScope } from '@auxx/lib/channels/client'
 import { useSettings } from '~/hooks/use-settings'
-import { useEmailChannels } from '../store/channel-store'
+import { useSendableChannels } from '../store/channel-store'
 
 /**
  * Resolves the user's default sending channel for compose actions.
  *
  * Falls back to the first available channel when the saved channel was
  * deleted / auth-errored away.
+ *
+ * `scope` must match the picker this feeds. Resolving against an email-only
+ * list while the picker offers phone channels silently discards a saved SMS
+ * default — the star button would appear to do nothing, because the saved id
+ * is never found in `channels` and the fallback picks the first email channel
+ * instead.
  */
-export function useDefaultChannelId(): string | undefined {
+export function useDefaultChannelId(scope: ChannelSelectionScope = 'email'): string | undefined {
   const { getSetting } = useSettings({})
-  const channels = useEmailChannels()
+  const channels = useSendableChannels(scope)
+  const emailOnly = useSendableChannels('email')
   const saved = getSetting('compose.defaultIntegrationId') as string | null
   if (saved && channels.some((c) => c.id === saved)) return saved
-  return channels[0]?.id
+  // No explicit choice: prefer email. `channels` is in org-cache insertion
+  // order, so falling straight through to `channels[0]` would open the composer
+  // on SMS for any org that happened to connect a phone channel first.
+  return emailOnly[0]?.id ?? channels[0]?.id
 }

--- a/apps/web/src/components/channels/store/channel-store.ts
+++ b/apps/web/src/components/channels/store/channel-store.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/channels/store/channel-store.ts
 
+import { type ChannelSelectionScope, canStartOutbound } from '@auxx/lib/channels/client'
 import { create } from 'zustand'
 import { useShallow } from 'zustand/react/shallow'
 import { getIntegrationStatus } from '~/components/global/integration-status-utils'
@@ -9,9 +10,24 @@ export type Channel = RouterOutputs['channel']['list']['channels'][number]
 
 const EMPTY_CHANNELS: Channel[] = []
 
-// Provider groupings — mirror packages/lib/src/providers/query-helpers.ts `getEmailProviders()`
-// (omits IMAP, matching today's getEmailClients() behavior).
-const EMAIL_PROVIDERS = new Set(['google', 'outlook', 'mailgun', 'email'])
+/**
+ * Providers held back from every send surface regardless of what the capability
+ * map says.
+ *
+ * `imap` declares `newOutbound: true` (channels/capabilities.ts) and
+ * `canSend: true` (provider-capabilities.ts), but has been excluded from the
+ * send lists since `getEmailClients()` — IMAP is a receive protocol and sending
+ * needs SMTP. Neither capability flag has been verified against a live IMAP
+ * channel, so this stays a carve-out rather than a flip of the maps. One named
+ * constant instead of a hand-kept allowlist: when someone confirms IMAP send
+ * works, this is the single line to delete.
+ */
+const LEGACY_SEND_EXCLUDED = new Set(['imap'])
+
+function isSendable(provider: string, scope: ChannelSelectionScope): boolean {
+  return !LEGACY_SEND_EXCLUDED.has(provider) && canStartOutbound(provider, scope)
+}
+
 const MESSAGING_PROVIDERS = new Set([
   'facebook',
   'instagram',
@@ -70,9 +86,20 @@ export function getChannelStoreState() {
   return useChannelStore.getState()
 }
 
-/** Channels whose provider can send email (excludes IMAP). */
+/** Channels whose provider can send email (excludes IMAP — see `LEGACY_SEND_EXCLUDED`). */
 export const useEmailChannels = () =>
-  useChannelStore(useShallow((s) => s.channels.filter((c) => EMAIL_PROVIDERS.has(c.provider))))
+  useChannelStore(useShallow((s) => s.channels.filter((c) => isSendable(c.provider, 'email'))))
+
+/**
+ * Channels a human can start a NEW conversation on — email **and** phone.
+ *
+ * This is what the composer's From picker reads. Capability-derived rather
+ * than a hand-kept list: the old hardcoded `EMAIL_PROVIDERS` set is why a
+ * connected Quo/SMS channel could never be selected, which in turn made every
+ * `recipientModel === 'phone'` branch in the composer unreachable.
+ */
+export const useSendableChannels = (scope: ChannelSelectionScope = 'addressable') =>
+  useChannelStore(useShallow((s) => s.channels.filter((c) => isSendable(c.provider, scope))))
 
 /** Channels whose provider is messaging (chat, social DMs, SMS). */
 export const useMessagingChannels = () =>

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -133,7 +133,10 @@ function ReplyComposeEditorComponent({
   const { data: integrations } = api.channel.list.useQuery(undefined, {
     enabled: mode === 'new',
   })
-  const defaultIntegrationId = useDefaultChannelId()
+  // 'addressable' — the composer can address email OR phone, so a starred SMS
+  // channel has to be honoured as the default. Falls back to email when the
+  // user has never picked one (see the hook).
+  const defaultIntegrationId = useDefaultChannelId('addressable')
   // Initialize state with pure function + lazy evaluation
   const [state, setState] = useState<InitState>(() => {
     const derived = deriveInitialState({
@@ -1083,6 +1086,7 @@ function ReplyComposeEditorComponent({
                     value={state.integrationId}
                     onChange={handleIntegrationChange}
                     disabled={isSending}
+                    scope='addressable'
                     className={popoverZIndex}
                   />
                 </div>

--- a/apps/web/src/components/pickers/channel-picker.tsx
+++ b/apps/web/src/components/pickers/channel-picker.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/pickers/channel-picker.tsx
 'use client'
 
+import type { ChannelSelectionScope } from '@auxx/lib/channels/client'
 import type { SelectOption } from '@auxx/types/custom-field'
 import { Badge } from '@auxx/ui/components/badge'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
@@ -9,7 +10,7 @@ import { Star } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useDefaultChannelId } from '~/components/channels/hooks/use-default-channel'
-import { useEmailChannels } from '~/components/channels/store/channel-store'
+import { useSendableChannels } from '~/components/channels/store/channel-store'
 import { Tooltip } from '~/components/global/tooltip'
 import { PickerTrigger, type PickerTriggerOptions } from '~/components/ui/picker-trigger'
 import { useSettings } from '~/hooks/use-settings'
@@ -19,28 +20,49 @@ interface ChannelPickerProps {
   value: string
   onChange: (value: string) => void
   disabled?: boolean
+  /**
+   * Which channels to offer. Defaults to `'email'` so every existing caller
+   * (sequences, quotes/invoices, dispatch notifications) keeps its behaviour —
+   * those surfaces build a subject + HTML body and cannot degrade to SMS.
+   * The mail composer passes `'addressable'` to include phone channels.
+   */
+  scope?: ChannelSelectionScope
   /** Styling for the shared picker trigger. */
   triggerProps?: PickerTriggerOptions
   /** className forwarded to PopoverContent (e.g. for z-index override) */
   className?: string
 }
 
+/**
+ * What the user sees in the From row: the address the message will come FROM.
+ *
+ * `identifier` is the server-resolved sending identity (`channels/internal/
+ * identifier.ts`) — email for mail channels, `metadata.phoneNumber` for
+ * Quo/SMS, widget name for chat. Reading `email` first, as this did, renders an
+ * empty badge for a phone channel: an SMS `Integration` carries no `email`, and
+ * `name` is null on a channel the user never renamed.
+ */
+function channelLabel(channel: { identifier?: string; email?: string; name: string | null }) {
+  return channel.identifier || channel.email || channel.name || 'Unnamed channel'
+}
+
 export function ChannelPicker({
   value,
   onChange,
   disabled,
+  scope = 'email',
   triggerProps,
   className,
 }: ChannelPickerProps) {
   const router = useRouter()
-  const allChannels = useEmailChannels()
+  const allChannels = useSendableChannels(scope)
   // Example integrations are seeded placeholders — they can't actually send.
   // See plans/seeding/example-data-for-new-accounts.md §7a.
   const channels = useMemo(() => allChannels.filter((c) => !c.isExample), [allChannels])
 
   const { getSetting, updateUserSetting } = useSettings({})
   const defaultChannelId = getSetting('compose.defaultIntegrationId') as string | null
-  const resolvedDefault = useDefaultChannelId()
+  const resolvedDefault = useDefaultChannelId(scope)
 
   const [open, setOpen] = useState(false)
 
@@ -61,7 +83,7 @@ export function ChannelPicker({
     () =>
       channels.map((c) => ({
         value: c.id,
-        label: c.email || c.name,
+        label: channelLabel(c),
       })),
     [channels]
   )
@@ -71,7 +93,7 @@ export function ChannelPicker({
   }
 
   const selected = channels.find((c) => c.id === value)
-  const displayName = selected ? selected.email || selected.name : 'Select channel'
+  const displayName = selected ? channelLabel(selected) : 'Select channel'
 
   return (
     <Popover

--- a/packages/lib/src/channels/capabilities.ts
+++ b/packages/lib/src/channels/capabilities.ts
@@ -35,6 +35,30 @@ export interface PlatformCapabilities {
 }
 
 /**
+ * The subset of `PlatformCapabilities` the composer UI reads.
+ *
+ * Deliberately a `Pick`, never a second literal: a new channel type is
+ * described in exactly ONE place (`PLATFORM_CAPABILITIES` below), and the
+ * front end plucks what it needs. Widening this type is how a new UI
+ * affordance gets wired — adding a per-provider value anywhere else is how
+ * the two maps in `provider-capabilities.ts` and here drifted apart.
+ */
+export type ComposerCapabilities = Pick<
+  PlatformCapabilities,
+  'channel' | 'newOutbound' | 'threadReply' | 'subject' | 'ccBcc' | 'attachments' | 'recipientModel'
+>
+
+/**
+ * Which channels a From picker should offer.
+ *
+ * - `email` — email-shaped surfaces (sequences, quotes/invoices, dispatch
+ *   notifications). These build a subject + HTML body and cannot degrade.
+ * - `addressable` — anything a human can start a new conversation on by
+ *   typing an identifier. Email **and** phone.
+ */
+export type ChannelSelectionScope = 'email' | 'addressable'
+
+/**
  * Static capability map keyed by `IntegrationProviderType` enum values
  * (mirrors `packages/database/src/db/schema/_shared.ts`).
  */
@@ -172,4 +196,28 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
     recipientModel: 'thread_only',
     notes: 'data-only integration, not a messaging channel',
   },
+}
+
+/** Plucks the composer-facing subset for one provider. `undefined` for an unknown provider. */
+export function getComposerCapabilities(provider: string): ComposerCapabilities | undefined {
+  return PLATFORM_CAPABILITIES[provider as IntegrationProviderTypeValue]
+}
+
+/**
+ * Can a channel of this provider be the From of a **new** outbound message?
+ *
+ * `newOutbound` alone is not enough: `chat` declares it but addresses a
+ * `platform_user`, which the composer has no input for — picking it would
+ * render a composer with no recipient field and no way to send. So the
+ * recipient model must also be one the composer can actually collect.
+ *
+ * Excluded by this rule today: `facebook`/`instagram` (`thread_only` — reply
+ * only, inside the 24h customer-service window), `chat` (`platform_user`),
+ * `shopify` (not a messaging channel at all).
+ */
+export function canStartOutbound(provider: string, scope: ChannelSelectionScope): boolean {
+  const caps = getComposerCapabilities(provider)
+  if (!caps?.newOutbound) return false
+  if (scope === 'email') return caps.recipientModel === 'email'
+  return caps.recipientModel === 'email' || caps.recipientModel === 'phone'
 }

--- a/packages/lib/src/channels/client.ts
+++ b/packages/lib/src/channels/client.ts
@@ -4,4 +4,11 @@
 // pulls in `./sync` (bullmq, sharp, etc.) via re-exports — use this entry
 // in client components that only need static capability metadata.
 
-export { PLATFORM_CAPABILITIES, type PlatformCapabilities } from './capabilities'
+export {
+  type ChannelSelectionScope,
+  type ComposerCapabilities,
+  canStartOutbound,
+  getComposerCapabilities,
+  PLATFORM_CAPABILITIES,
+  type PlatformCapabilities,
+} from './capabilities'

--- a/packages/lib/src/channels/index.ts
+++ b/packages/lib/src/channels/index.ts
@@ -5,7 +5,14 @@ export {
   getOrgOwnEmailAddresses,
   invalidateOrgChannelProviderMap,
 } from './cache'
-export { PLATFORM_CAPABILITIES, type PlatformCapabilities } from './capabilities'
+export {
+  type ChannelSelectionScope,
+  type ComposerCapabilities,
+  canStartOutbound,
+  getComposerCapabilities,
+  PLATFORM_CAPABILITIES,
+  type PlatformCapabilities,
+} from './capabilities'
 export {
   CHANNEL_PROVIDER_TO_KEY,
   channelProviderKey,


### PR DESCRIPTION
## Why

The composer's From picker read a hardcoded `new Set(['google','outlook','mailgun','email'])`, so a connected Quo/SMS channel **could never be selected**. Every `recipientModel === 'phone'` branch that shipped with the Quo rewrite (#1646) was therefore unreachable — the phone recipient input had never once rendered.

## What changed

**One declaration site.** `canStartOutbound(provider, scope)` in `channels/capabilities.ts` replaces the hardcoded set. `ComposerCapabilities` is a `Pick` of `PlatformCapabilities`, never a second literal, so a provider is still described in exactly one place.

The rule is `newOutbound && recipientModel ∈ {email, phone}`, not `newOutbound` alone — `chat` declares `newOutbound: true` but addresses a `platform_user`, which the composer has no input for. Picking it would render a composer with no To field and no way to send. Correctly excludes `chat`, `facebook`/`instagram` (`thread_only`) and `shopify`.

**Scoped, so nothing else moves.** `ChannelPicker` gains `scope`, defaulting to `'email'`. Sequences, quotes/invoices and dispatch notifications are untouched — those build a subject + HTML body and cannot degrade to SMS. Only the composer passes `'addressable'`.

### Two smaller bugs found alongside

- **Empty From badge for phone channels.** The picker labelled options `c.email || c.name`; an SMS `Integration` carries neither. Now uses `channel.identifier`, the server-resolved sending identity, which already handled `metadata.phoneNumber`.
- **Starring an SMS channel silently did nothing.** `useDefaultChannelId` resolved the saved default against an email-only list, so the id was never found and it fell back to the first email channel. Now takes the same scope; with no explicit choice it prefers email, because `channels` is in org-cache insertion order and `channels[0]` would open the composer on SMS for any org that connected a phone channel first.

## IMAP

Held back by one named `LEGACY_SEND_EXCLUDED` constant. Both capability maps claim it can send, neither has been verified against a live IMAP channel, and IMAP is a receive protocol. Deliberately not flipped here — one line to delete when someone confirms SMTP send works.

## Verification

Live in the browser: **+18889155797** appears in From, and selecting it drops the Subject row and the Cc/Bcc toggles — previously-dead capability code executing for the first time.

- `packages/lib` channels: 53 tests pass
- `apps/web` composer: 13 tests pass
- web typecheck clean on all touched files

## Known follow-up (not in this PR)

This makes an existing gap *reachable*: switching From mid-draft doesn't reconcile the draft, so email recipients survive a switch to SMS and the hidden subject/cc are still submitted. That's Phase 1 of `plans/email-editor/composer-channel-capabilities.md` and is the next PR.