### PR TITLE
fix(messages): stop the sent-echo reconciler from swallowing inbound SMS

### DIFF
--- a/packages/lib/src/messages/__tests__/message-reconciler.window.test.ts
+++ b/packages/lib/src/messages/__tests__/message-reconciler.window.test.ts
@@ -377,3 +377,100 @@ describe('reconcileIncomingSync — Strategy 1 still wins', () => {
     expect(result).toEqual({ isReconciled: true, existingMessageId: 'msg-by-message-id' })
   })
 })
+
+/**
+ * Strategy 2 has no identity key — it matches on (integration, subject, 60s skew)
+ * alone. On email the subject carries the selectivity. **SMS has no subject**, so
+ * `eq(subject, messageData.subject || '')` degenerates to `'' = ''` and matches every
+ * SMS on the channel, leaving the 60-second window as the only discriminator.
+ *
+ * Measured live on Quo (2026-08-14): an outbound SMS at 20:49:47 and the customer's
+ * reply 49s later collapsed into ONE row. The inbound message overwrote the outbound
+ * row's `externalId` and timestamps while keeping the outbound body and
+ * `isInbound: false`; the reply text survived only inside `metadata`. "Customer
+ * replies within a minute" is the normal case on a support line, not an edge case.
+ *
+ * The guard is direction: a Sent-folder echo is by definition a copy of a message WE
+ * sent, so it is always outbound. These tests pin that, and pin that it did not
+ * over-fire and break the subject-less OUTBOUND echo.
+ */
+describe('reconcileIncomingSync — Strategy 2 never claims an inbound message', () => {
+  /** Our outbound SMS: no subject, sent, carries a sendToken. */
+  function sentSmsRow(overrides: Row = {}): Row {
+    return localSentRow({
+      id: 'msg-sms-out',
+      subject: '',
+      sendStatus: 'SENT',
+      internetMessageId: null,
+      textPlain: 'Test message.',
+      ...overrides,
+    })
+  }
+
+  /** The customer's reply arriving over the Quo webhook. */
+  function inboundSms(overrides: Partial<MessageData> = {}): MessageData {
+    return sentItemsEcho({
+      // Shape-accurate but synthetic. A real Quo message id is `AC` + 32 hex, which
+      // is byte-for-byte Twilio's Account SID format (Quo runs on Twilio), so a real
+      // one in a fixture trips GitHub push protection as a leaked credential.
+      externalId: 'AC_quo_inbound_reply',
+      externalThreadId: 'CN_quo_conversation',
+      isInbound: true,
+      subject: undefined, // `route.ts` — SMS has no subject.
+      internetMessageId: undefined,
+      textPlain: 'Ok',
+      from: { identifier: '+15102055536' } as any,
+      ...overrides,
+    })
+  }
+
+  it('does not swallow a reply that arrives 49s after our send (the measured Quo case)', async () => {
+    const db = createDb([sentSmsRow()], [{ id: 'thread-1', externalId: 'ext-real' }])
+    ingestAt(49)
+
+    const result = await createService(db).reconcileIncomingSync(
+      inboundSms({ sentAt: new Date(SENT_AT.getTime() + 49_000) })
+    )
+
+    expect(result).toEqual({ isReconciled: false })
+  })
+
+  it('does not swallow a reply whose text is identical to ours', async () => {
+    // The nastiest shape: with no subject AND no sender check, identical text is
+    // indistinguishable to every predicate Strategy 2 has. Only direction separates them.
+    const db = createDb([sentSmsRow({ textPlain: 'Ok' })], [{ id: 'thread-1', externalId: 'e' }])
+    ingestAt(10)
+
+    const result = await createService(db).reconcileIncomingSync(
+      inboundSms({ sentAt: new Date(SENT_AT.getTime() + 10_000) })
+    )
+
+    expect(result).toEqual({ isReconciled: false })
+  })
+
+  it('skips the Strategy 2 query entirely for an inbound message', async () => {
+    // Not just a filtered-out result — inbound ingest is the hot path, so the guard
+    // is placed before the query rather than inside its predicate.
+    const db = createDb([sentSmsRow()], [{ id: 'thread-1', externalId: 'ext-real' }])
+    ingestAt(49)
+
+    await createService(db).reconcileIncomingSync(
+      inboundSms({ sentAt: new Date(SENT_AT.getTime() + 49_000) })
+    )
+
+    // Strategy 0 is skipped (no echoedMessageId) and Strategy 1 is skipped (no
+    // internetMessageId), so a running Strategy 2 would be the FIRST Message query.
+    expect(db.query.Message.findFirst).not.toHaveBeenCalled()
+  })
+
+  it('still reconciles a subject-less OUTBOUND echo — the guard must not over-fire', async () => {
+    const db = createDb([sentSmsRow()], [{ id: 'thread-1', externalId: 'ext-real' }])
+    ingestAt(30)
+
+    const result = await createService(db).reconcileIncomingSync(
+      sentItemsEcho({ subject: undefined, internetMessageId: undefined, isInbound: false })
+    )
+
+    expect(result).toEqual({ isReconciled: true, existingMessageId: 'msg-sms-out' })
+  })
+})

--- a/packages/lib/src/messages/message-reconciler.service.ts
+++ b/packages/lib/src/messages/message-reconciler.service.ts
@@ -227,38 +227,58 @@ export class MessageReconcilerService {
     // `internetMessageId` nor a usable `externalId` (Outlook: Graph mints its own
     // Message-ID and returns nothing from `/me/sendMail`). It is a heuristic, so it
     // is deliberately narrow:
+    //   - OUTBOUND only — see the direction guard below
     //   - same integration — never reconcile an echo onto another channel's message
     //   - `sendToken IS NOT NULL` — only a message WE sent can have a Sent-folder
     //     echo, so this is both a correctness guard and the main selectivity win
     //   - newest candidate first, so two same-subject sends in the window resolve to
     //     the one nearest in time rather than an arbitrary row
-    const recentlySent = await this.db.query.Message.findFirst({
-      where: (messages, { eq, and, inArray, gte, isNotNull }) =>
-        and(
-          eq(messages.organizationId, messageData.organizationId),
-          eq(messages.integrationId, messageData.integrationId),
-          eq(messages.subject, messageData.subject || ''),
-          inArray(messages.sendStatus, [SendStatus.PENDING, SendStatus.SENT]),
-          isNotNull(messages.sendToken),
-          // 30 minutes, measured from INGEST time. This only bounds the scan — it is
-          // NOT the precision control. Precision comes from the `< 60000` relative-skew
-          // check against `recentlySent.createdAt` below, plus the integration /
-          // `sendToken` / subject predicates and `orderBy desc(createdAt)`.
-          // The previous 5 minutes was too short: Outlook polls every ~5-7 minutes, and
-          // a measured live case had our row created at 06:28:02.744 and the echo
-          // ingested at 06:34:50 — a 6m47s gap, so the candidate was never even
-          // SELECTED and the skew check never got to run.
-          gte(messages.createdAt, new Date(Date.now() - 30 * 60 * 1000))
-        ),
-      orderBy: (messages, { desc }) => [desc(messages.createdAt)],
-      columns: {
-        id: true,
-        sendToken: true,
-        internetMessageId: true,
-        threadId: true,
-        createdAt: true,
-      },
-    })
+    //
+    // ⚠️ The direction guard is what makes this strategy safe on subject-less
+    // channels. Unlike Strategy 1 and the echoed-id strategy above, this one has NO
+    // identity key — it matches purely on (integration, subject, 60s skew). On email
+    // the subject carries the selectivity. **SMS has no subject**, so
+    // `eq(subject, messageData.subject || '')` degenerates to `'' = ''` and matches
+    // every SMS on the channel, leaving a 60-second window as the only discriminator.
+    //
+    // Measured live on Quo (2026-08-14): an outbound SMS at 20:49:47 and the
+    // customer's reply 49s later collapsed into ONE row — the inbound message
+    // overwrote the outbound row's `externalId` and timestamps while keeping the
+    // outbound body and `isInbound: false`. The reply survived only inside
+    // `metadata`. On a support line "customer replies within a minute" is the normal
+    // case, not an edge case.
+    //
+    // A Sent-folder echo is by definition a copy of a message WE sent, so it is
+    // always outbound. An inbound message can never be one, on any provider.
+    const recentlySent = messageData.isInbound
+      ? null
+      : await this.db.query.Message.findFirst({
+          where: (messages, { eq, and, inArray, gte, isNotNull }) =>
+            and(
+              eq(messages.organizationId, messageData.organizationId),
+              eq(messages.integrationId, messageData.integrationId),
+              eq(messages.subject, messageData.subject || ''),
+              inArray(messages.sendStatus, [SendStatus.PENDING, SendStatus.SENT]),
+              isNotNull(messages.sendToken),
+              // 30 minutes, measured from INGEST time. This only bounds the scan — it is
+              // NOT the precision control. Precision comes from the `< 60000` relative-skew
+              // check against `recentlySent.createdAt` below, plus the integration /
+              // `sendToken` / subject predicates and `orderBy desc(createdAt)`.
+              // The previous 5 minutes was too short: Outlook polls every ~5-7 minutes, and
+              // a measured live case had our row created at 06:28:02.744 and the echo
+              // ingested at 06:34:50 — a 6m47s gap, so the candidate was never even
+              // SELECTED and the skew check never got to run.
+              gte(messages.createdAt, new Date(Date.now() - 30 * 60 * 1000))
+            ),
+          orderBy: (messages, { desc }) => [desc(messages.createdAt)],
+          columns: {
+            id: true,
+            sendToken: true,
+            internetMessageId: true,
+            threadId: true,
+            createdAt: true,
+          },
+        })
 
     if (recentlySent) {
       // Verify it's likely the same message. Compare the echo's `sentAt` against the
@@ -273,9 +293,13 @@ export class MessageReconcilerService {
 
       if (timeDiff < 60000) {
         // Within 1 minute of the candidate's creation
-        logger.info('Found likely matching message by subject/sender, reconciling', {
+        // Named for what it actually compares. It used to say "by subject/sender",
+        // which sent every reader looking for a sender check that has never existed
+        // — and made the SMS collapse above much harder to spot in the logs.
+        logger.info('Found likely matching sent message by subject + time window', {
           messageId: recentlySent.id,
           subject: messageData.subject,
+          timeDiffMs: timeDiff,
         })
 
         await this.mergeIncomingProviderData(recentlySent.id, messageData)


### PR DESCRIPTION
## The bug

`reconcileIncomingSync` **Strategy 2** exists to catch a Sent-folder echo from a provider that returns no correlation key (Outlook: Graph mints its own Message-ID and `/me/sendMail` returns nothing). Unlike Strategy 0 and 1, it has **no identity key at all** — it matches on:

| guard | on SMS |
|---|---|
| same org + integration | ✅ |
| `eq(subject, messageData.subject \|\| '')` | ✅ **both `''` — vacuous** |
| `sendStatus IN (PENDING, SENT)` | ✅ |
| `sendToken IS NOT NULL` | ✅ |
| created within 30 min | ✅ |
| `abs(inbound.sentAt − outbound.createdAt) < 60000` | ✅ |

On email the subject carries the selectivity. **SMS has no subject**, so the predicate degenerates to `'' = ''` and matches every SMS on the channel — leaving a 60-second window as the only discriminator. There is no direction check and no sender check.

### Measured live on Quo, 2026-08-14

An outbound SMS at 20:49:47 and the customer's reply 49s later **collapsed into one row**. The inbound message overwrote the outbound row's `externalId` and both timestamps while keeping the outbound body and `isInbound: false`. The reply text survived only inside `metadata.quo_webhook_event`.

On a support line, "customer replies within a minute" is the normal case, not an edge case. This silently destroys inbound messages.

## The fix

A Sent-folder echo is by definition a copy of a message **we sent**, so it is always outbound. An inbound message can never be one, on any provider.

```ts
const recentlySent = messageData.isInbound
  ? null
  : await this.db.query.Message.findFirst({ … })
```

The guard sits **before** the query rather than inside its predicate, so inbound ingest — the hot path — now skips that SELECT entirely instead of running it and discarding the result.

**Strategies 0 and 1 are deliberately not guarded.** Both match on a real identity key (the echoed `X-AuxxAi-Message-Id`, and `internetMessageId`), and Gmail's All Mail echo legitimately arrives flagged inbound. Only Strategy 2 — the one with no key — needs direction to stay safe.

Also renames the log line, which claimed `"by subject/sender"` when no sender comparison has ever existed there. It sent every reader looking for a check that wasn't in the code, and made this collapse harder to spot in the logs.

## Tests

Four new cases in the existing `message-reconciler.window.test.ts` harness, which drives the real Drizzle predicate against in-memory rows:

- reply 49s after our send — the measured Quo case
- reply whose text is **identical** to ours (with no subject and no sender check, only direction separates them)
- Strategy 2 query is **not issued at all** for inbound
- a subject-less **outbound** echo still reconciles — the guard must not over-fire

Verified the first three **fail without the guard** and the fourth passes either way, so they are not vacuous. 247 messages + ingest tests green, lib typecheck clean.

Fixture ids are synthetic on purpose: a real Quo message id is `AC` + 32 hex, which is byte-for-byte Twilio's Account SID format (Quo runs on Twilio), so a real one trips GitHub push protection as a leaked credential.

## Note

Same masking pattern as the `externalId` bug fixed in #1646: email has a discriminator that SMS doesn't, so the defect sat latent until a subject-less channel went live.