### PR TITLE
feat(fields): default phone inputs to the org business country

### DIFF
--- a/apps/web/src/components/fields/inputs/phone-input-field.tsx
+++ b/apps/web/src/components/fields/inputs/phone-input-field.tsx
@@ -2,6 +2,7 @@
 import PhoneInputWithFlag from '@auxx/ui/components/phone-input'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { usePropertyContext } from '../property-provider'
+import { useOrgBusinessCountry } from './use-org-business-country'
 
 /**
  * PhoneInputField
@@ -13,6 +14,7 @@ import { usePropertyContext } from '../property-provider'
  */
 export function PhoneInputField() {
   const { value, commitValue, onBeforeClose, close, isSaving } = usePropertyContext()
+  const defaultCountry = useOrgBusinessCountry()
   const [phoneValue, setPhoneValue] = useState(value || '')
 
   // Keep ref in sync for save-on-close
@@ -62,6 +64,7 @@ export function PhoneInputField() {
       value={phoneValue}
       onChange={handleChange}
       onKeyDown={handleKeyDown}
+      defaultCountry={defaultCountry}
       autoFocus
       className={`h-7 border-none outline-none focus:ring-0 [&>input]:h-7 [&>input]:w-40 [&>input]:outline-none [&>input]:focus:ring-0 ${isSaving ? 'opacity-70' : ''}`}
       disabled={isSaving}

--- a/apps/web/src/components/fields/inputs/use-org-business-country.ts
+++ b/apps/web/src/components/fields/inputs/use-org-business-country.ts
@@ -4,9 +4,18 @@ import { useSettings } from '~/hooks/use-settings'
 
 /**
  * Reads the org's business-address country (`documents.business.address.country`) as the
- * address parser/formatter's domestic default (decision #8 in
- * plans/address-field/01-single-input-address-field.md); falls back to `'US'` when unset.
- * Shared by the single-input address field (drawer) and the workflow/FieldPanel `AddressInput`.
+ * domestic default for locale-sensitive inputs; falls back to `'US'` when unset.
+ *
+ * Two consumers:
+ * - Address — the parser/formatter's domestic default (decision #8 in
+ *   `plans/address-field/01-single-input-address-field.md`): the single-input address
+ *   field (drawer) and the workflow/FieldPanel `AddressInput`.
+ * - Phone — `PhoneInputWithFlag`'s `defaultCountry`, i.e. the country a number typed
+ *   without a `+` prefix is parsed as, and the flag the picker opens on.
+ *
+ * The value is an ISO 3166-1 alpha-2 code (`'US'`, `'DE'`). Consumers that need a
+ * narrower type validate it themselves — `PhoneInputWithFlag` falls back to `'US'` for
+ * anything `react-phone-number-input` doesn't recognise.
  */
 export function useOrgBusinessCountry(): string {
   const { getSetting } = useSettings({})

--- a/apps/web/src/components/workflow/nodes/shared/node-inputs/phone-input.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/node-inputs/phone-input.tsx
@@ -3,6 +3,7 @@
 import PhoneInputWithFlag from '@auxx/ui/components/phone-input'
 import type React from 'react'
 import { useCallback, useEffect, useState } from 'react'
+import { useOrgBusinessCountry } from '~/components/fields/inputs/use-org-business-country'
 import { createNodeInput, type NodeInputProps } from './base-node-input'
 
 /**
@@ -21,6 +22,8 @@ interface PhoneInputProps extends NodeInputProps {
  */
 export const PhoneInput = createNodeInput<PhoneInputProps>(
   ({ inputs, onChange, onError, isLoading, name, placeholder = 'Enter phone number' }) => {
+    const defaultCountry = useOrgBusinessCountry()
+
     // Local state for immediate UI updates
     const [localValue, setLocalValue] = useState(inputs[name] ?? '')
 
@@ -57,6 +60,7 @@ export const PhoneInput = createNodeInput<PhoneInputProps>(
         onChange={handleChange}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
+        defaultCountry={defaultCountry}
         disabled={isLoading}
         className='h-7 shadow-none! border-none ring-0! outline-none focus:ring-0 [&>input]:h-7 [&>input]:outline-none [&>input]:focus:ring-0 [&_[data-slot=country-select]]:bg-transparent [&_[data-slot=phone-input]]:w-full [&_[data-slot=phone-input]]:flex-1'
       />

--- a/packages/ui/src/components/phone-input.tsx
+++ b/packages/ui/src/components/phone-input.tsx
@@ -35,6 +35,20 @@ export interface PhoneInputWithFlagProps {
   countryClassName?: string
   onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>
   autoFocus?: boolean
+  /**
+   * Country assumed for a number typed without a `+` prefix, and the flag the
+   * picker starts on. Accepts a loose `string` so callers can pass an org
+   * setting straight through — anything `react-phone-number-input` doesn't
+   * recognise falls back to `US` rather than throwing.
+   */
+  defaultCountry?: string
+}
+
+/** Narrow a loose country string to an RPN `Country`, falling back to `US`. */
+function toCountry(country: string | undefined): RPNInput.Country {
+  if (!country) return 'US'
+  const code = country.trim().toUpperCase()
+  return RPNInput.isSupportedCountry(code) ? (code as RPNInput.Country) : 'US'
 }
 
 function PhoneInputWithFlag({
@@ -49,10 +63,12 @@ function PhoneInputWithFlag({
   countryClassName,
   onKeyDown,
   autoFocus,
+  defaultCountry,
   ...props
 }: PhoneInputWithFlagProps) {
   const id = useId()
   const containerRef = useRef<HTMLDivElement>(null)
+  const country = toCountry(defaultCountry)
 
   /** Support both setValue (original) and onChange (react-hook-form style) */
   const handleChange = (newValue: string | undefined) => {
@@ -67,11 +83,12 @@ function PhoneInputWithFlag({
           className={cn('flex rounded-xl shadow-2xs', className)}
           international
           flagComponent={FlagComponent}
-          defaultCountry='US'
+          defaultCountry={country}
           countrySelectComponent={CountrySelect}
           countrySelectProps={{
             className: countryClassName || '',
             containerRef,
+            favoriteCountry: country,
           }}
           inputComponent={PhoneInput}
           numberInputProps={{ autoFocus }}
@@ -133,6 +150,12 @@ type CountrySelectProps = {
   trigger?: (props: { value: RPNInput.Country; label: string | undefined }) => React.ReactNode
   /** Whether to show calling codes in the dropdown list */
   showCallingCodes?: boolean
+  /**
+   * Country pinned above the full list under "Favorites". Defaults to `US`;
+   * `PhoneInputWithFlag` passes the org's own country so a non-US org gets its
+   * own dial code one click away instead of the US one.
+   */
+  favoriteCountry?: RPNInput.Country
 }
 
 /** Searchable country select using a combobox */
@@ -145,6 +168,7 @@ const CountrySelect = ({
   containerRef,
   trigger,
   showCallingCodes = true,
+  favoriteCountry = 'US',
 }: CountrySelectProps) => {
   const [open, setOpen] = useState(false)
   const [popoverWidth, setPopoverWidth] = useState<number | undefined>(undefined)
@@ -232,12 +256,12 @@ const CountrySelect = ({
                 <CommandSeparator />
               </>
             )}
-            {/* Favorites - show US if not selected */}
-            {value !== 'US' && (
+            {/* Favorites - show the org's country if it isn't already selected */}
+            {value !== favoriteCountry && (
               <>
                 <CommandGroup heading='Favorites'>
                   {countryOptions
-                    .filter((option) => option.value === 'US')
+                    .filter((option) => option.value === favoriteCountry)
                     .map((option) => (
                       <CommandItem
                         key={option.value}
@@ -259,7 +283,7 @@ const CountrySelect = ({
             {/* All other countries */}
             <CommandGroup heading='Countries'>
               {countryOptions
-                .filter((option) => option.value !== value && option.value !== 'US')
+                .filter((option) => option.value !== value && option.value !== favoriteCountry)
                 .map((option) => (
                   <CommandItem
                     key={option.value}


### PR DESCRIPTION
Phone inputs hardcoded `defaultCountry='US'`, so a number typed without a `+` prefix was always parsed as US and the country dropdown always opened on the US flag. This sources the default from the org's own business address instead.

## Changes

**`packages/ui/src/components/phone-input.tsx`**
- `PhoneInputWithFlag` gains an optional `defaultCountry?: string`. Deliberately loose `string` so callers can pass an org setting straight through — `toCountry()` narrows it via `RPNInput.isSupportedCountry` and falls back to `'US'` for anything unrecognised.
- The named `CountrySelect` export gains an optional `favoriteCountry?: RPNInput.Country` (defaults `'US'`), replacing three hardcoded `'US'` literals in the Favorites/Countries grouping. A non-US org now gets its own dial code pinned above the full list instead of the US one.

**`apps/web`** — the two consumers that sit inside an authenticated org context now pass `useOrgBusinessCountry()`:
- `components/fields/inputs/phone-input-field.tsx` (record drawer / property editor)
- `components/workflow/nodes/shared/node-inputs/phone-input.tsx` (workflow node inputs, and the FieldPanel PHONE branch via `field-input-adapter.tsx`)
- `components/fields/inputs/use-org-business-country.ts` — docstring only; it claimed to be address-only and is now shared with phone.

## Notes

- **Backward compatible.** Both new props are optional with unchanged defaults. `packages/ui/src/components/country-select.tsx` (billing forms) passes neither and behaves exactly as before.
- **`signup-form.tsx` deliberately left on `'US'`.** It renders in the `(auth)` route group, which has no session and does not mount `DehydratedStateProvider` — `useOrgBusinessCountry` would throw there.
- **The setting is ISO 3166-1 alpha-2.** Verified three ways: the stored value, the writer (a closed-list combobox over `constants/countries.ts`), and `packages/utils/src/address.ts:15`. Nothing server-side validates the shape though — `normalize-setting-value.ts` only checks it is an object — hence the `isSupportedCountry` guard rather than a bare cast.

## Scope

This does **not** change contact phone fields. `get-input-component.tsx:46-49` routes on `options.multi` before the scalar component is constructed, and contact phone is multi as of #1634, so it renders `MultiValuePicker` — which has no country selector at all. That is tracked separately; this PR is the plumbing it will consume.

## Verification

- `packages/ui` typecheck: clean
- `apps/web` typecheck: clean (no diagnostics in the touched files)
- Biome: clean