### PR TITLE
feat(composer): always-on composer for phone threads, pin From to the thread channel

### DIFF
--- a/apps/web/src/components/mail/email-editor/channel-switch.test.tsx
+++ b/apps/web/src/components/mail/email-editor/channel-switch.test.tsx
@@ -21,9 +21,10 @@ const h = vi.hoisted(() => ({
   showFormatting: undefined as boolean | undefined,
   referencesPassed: undefined as unknown,
   variantPassed: undefined as string | undefined,
+  pickerScope: undefined as string | undefined,
   channels: [
-    { id: 'ch_email', provider: 'google' },
-    { id: 'ch_sms', provider: 'openphone' },
+    { id: 'ch_email', provider: 'google', identifier: 'support@auxx.ai' },
+    { id: 'ch_sms', provider: 'openphone', identifier: '+18889155797' },
   ],
   editor: {
     isEditable: true,
@@ -133,15 +134,18 @@ vi.mock('../composer-shared', async () => {
 })
 
 vi.mock('~/components/pickers/channel-picker', () => ({
-  ChannelPicker: ({ onChange }: { onChange: (id: string) => void }) => (
-    <>
-      {h.channels.map((c) => (
-        <button key={c.id} type='button' onClick={() => onChange(c.id)}>
-          {`pick-${c.id}`}
-        </button>
-      ))}
-    </>
-  ),
+  ChannelPicker: ({ onChange, scope }: { onChange: (id: string) => void; scope?: string }) => {
+    h.pickerScope = scope
+    return (
+      <>
+        {h.channels.map((c) => (
+          <button key={c.id} type='button' onClick={() => onChange(c.id)}>
+            {`pick-${c.id}`}
+          </button>
+        ))}
+      </>
+    )
+  },
 }))
 
 vi.mock('~/components/channels/hooks/use-channels', () => ({
@@ -223,6 +227,12 @@ vi.mock('~/components/threads/store/thread-store', () => ({
     updateDraft: () => {},
     markDraftNotFound: () => {},
   }),
+}))
+// The composer seeds its recipient from the thread counterparty on an always-on
+// composer. Stubbed to "not resolved" so these cases exercise only the channel
+// switch — the seeding path has its own coverage in always-on-composer.test.tsx.
+vi.mock('~/components/threads/hooks/use-thread-envelope-counterparty', () => ({
+  useThreadEnvelopeCounterparty: () => undefined,
 }))
 vi.mock('~/hooks/use-analytics', () => ({ useAnalytics: () => ({ capture: () => {} }) }))
 vi.mock('~/hooks/use-confirm', () => ({
@@ -363,5 +373,57 @@ describe('capability-gated affordances', () => {
     expect(h.referencesPassed).toBeUndefined()
     // Send AND schedule stay available on every channel.
     expect(screen.getByText('send')).toBeTruthy()
+  })
+})
+
+/**
+ * A thread is a conversation on ONE channel. Its participants are identifiers in
+ * that channel's address space, so switching an SMS thread to an email channel
+ * does not produce an email to the same person — it produces a send with no
+ * valid recipient.
+ *
+ * The composer plan asserted "reply mode is unaffected — From is pinned by the
+ * thread's channel". It was not pinned: `ChannelPicker` rendered in every mode
+ * with `disabled={isSending}` as its only gate. These cases pin the claim down.
+ */
+describe('From is pinned to the thread channel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    h.pickerScope = undefined
+  })
+
+  const renderReply = (integrationId: string) =>
+    render(
+      <ReplyComposeEditor
+        mode='reply'
+        thread={{ id: 'th_1', integrationId }}
+        onClose={() => {}}
+        onSendSuccess={() => {}}
+      />
+    )
+
+  it('offers no channel picker when replying on a messaging thread', () => {
+    renderReply('ch_sms')
+
+    expect(screen.queryByText('pick-ch_email')).toBeNull()
+    expect(screen.queryByText('pick-ch_sms')).toBeNull()
+    // The sending identity is still shown — pinned, not hidden.
+    expect(screen.getByText('+18889155797')).toBeTruthy()
+  })
+
+  it('keeps a picker on an email thread, scoped to email only', () => {
+    renderReply('ch_email')
+
+    // Email is the exception: a mail thread can be answered from another mailbox
+    // or alias. It must NOT be able to degrade to a phone channel, so the scope
+    // is 'email' rather than the 'addressable' scope new-compose uses.
+    expect(screen.getByText('pick-ch_email')).toBeTruthy()
+    expect(h.pickerScope).toBe('email')
+  })
+
+  it('offers the full addressable scope only in new compose', () => {
+    renderComposer()
+
+    expect(h.pickerScope).toBe('addressable')
   })
 })

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -40,6 +40,7 @@ import {
   appendOptimisticMessage,
   toAttachmentMeta,
 } from '~/components/threads/hooks/append-optimistic-message'
+import { useThreadEnvelopeCounterparty } from '~/components/threads/hooks/use-thread-envelope-counterparty'
 import type { MessageMeta } from '~/components/threads/store/message-store'
 import { useParticipantStore } from '~/components/threads/store/participant-store'
 import { getThreadStoreState } from '~/components/threads/store/thread-store'
@@ -224,6 +225,32 @@ function ReplyComposeEditorComponent({
   const supportsAttachments = platformCaps ? platformCaps.attachments : true
   const maxMessageLength = platformCaps?.maxMessageLength
 
+  // Whether the From channel can be changed at all.
+  //
+  // A thread is a conversation on ONE channel. Its participants are identifiers
+  // in that channel's address space, so switching an SMS thread to an email
+  // channel does not produce an email to the same person — it produces a send
+  // with no valid recipient. The reply is pinned to the channel the thread
+  // arrived on.
+  //
+  // Email is the exception, and only within email: a mail thread can legitimately
+  // be answered from a different mailbox or alias (reply from support@ rather
+  // than the alias it landed on), so email threads keep a picker scoped to
+  // `'email'` — a different mailbox, never a different channel class.
+  //
+  // New compose is the only place a channel class is genuinely open, and it is
+  // the only caller that reaches `reconcileDraftForChannel`. An earlier draft of
+  // this design assumed reply mode was already pinned; it was not — the picker
+  // was live in every mode with `disabled={isSending}` as its only gate.
+  const isNewCompose = mode === 'new'
+  const canSwitchChannel = isNewCompose || isEmailChannel
+  const pinnedChannelLabel =
+    selectedChannel?.identifier ??
+    selectedChannelFromList?.identifier ??
+    selectedChannel?.email ??
+    selectedChannel?.name ??
+    'Unknown channel'
+
   // Every channel this org can send from, so a From switch can resolve the
   // INCOMING channel's capabilities (the memo above only covers the current
   // one). `integrations` is the new-compose fallback before the store hydrates.
@@ -297,6 +324,61 @@ function ReplyComposeEditorComponent({
       setIsDraftSaved(true) // Draft was loaded from server
     }
   }, [initialDraft, mode, thread, sourceMessage, integrations, presetValues])
+
+  // Seed the recipient on an always-on composer.
+  //
+  // A composer opened by clicking Reply on a message derives its recipient from
+  // that message. A conversational channel has no such click — the composer is
+  // simply there — so `reply` mode with no `sourceMessage` would otherwise render
+  // an empty To field on every SMS thread. Chat gets away with it only because
+  // `recipientModel: 'thread_only'` hides the field entirely and the server
+  // resolves the recipient from the thread; phone shows the field, so it has to
+  // be filled here.
+  //
+  // Deliberately NOT `sourceMessage.from`: on a thread whose last message is
+  // outbound that is US, which would address the reply to our own channel.
+  // `useThreadEnvelopeCounterparty` is the same selection the thread title uses, so the
+  // thread is addressed to exactly the person it is named after.
+  //
+  // Fires at most once per composer instance — clearing the chip is a deliberate
+  // act and must not be undone by a re-render.
+  // Only ever seed an identifier this channel can actually address. A thread's
+  // participant set is not guaranteed to be single-model: an outbound SMS records
+  // its FROM participant as the operator's login email today
+  // (`participant-service.findOrCreateParticipantForIntegration` reads only
+  // `Integration.email`, which is NULL on a phone channel), so counterparty
+  // selection can hand back an EMAIL participant on a phone thread. Seeding that
+  // would put an unsendable recipient in the To field and blame the user for it.
+  // Guarding on the channel's own model means the seed degrades to empty rather
+  // than to wrong.
+  const threadCounterparty = useThreadEnvelopeCounterparty(thread?.id)
+  const seededRecipientRef = useRef(false)
+  useEffect(() => {
+    if (seededRecipientRef.current || initialDraft || mode !== 'reply' || sourceMessage) return
+    if (!threadCounterparty) return
+    if (
+      threadCounterparty.identifierType !==
+      getIdentifierModel(platformCaps?.recipientModel).identifierType
+    ) {
+      return
+    }
+    seededRecipientRef.current = true
+    setRecipients((prev) =>
+      prev.TO.length > 0
+        ? prev
+        : {
+            ...prev,
+            TO: [
+              {
+                id: threadCounterparty.id,
+                identifier: threadCounterparty.identifier,
+                identifierType: threadCounterparty.identifierType,
+                name: threadCounterparty.name,
+              },
+            ],
+          }
+    )
+  }, [threadCounterparty, initialDraft, mode, sourceMessage, platformCaps?.recipientModel])
 
   // Defensive sync: if quickActions is empty but initialDraft has actions, restore them.
   // Covers the case where the draft prop arrives with richer data after initial mount.
@@ -1251,13 +1333,17 @@ function ReplyComposeEditorComponent({
               <div className='flex items-center gap-2 px-4 py-2'>
                 <span className='w-10 shrink-0 text-sm text-muted-foreground'>From:</span>
                 <div className='flex-1'>
-                  <ChannelPicker
-                    value={state.integrationId}
-                    onChange={handleIntegrationChange}
-                    disabled={isSending}
-                    scope='addressable'
-                    className={popoverZIndex}
-                  />
+                  {canSwitchChannel ? (
+                    <ChannelPicker
+                      value={state.integrationId}
+                      onChange={handleIntegrationChange}
+                      disabled={isSending}
+                      scope={isNewCompose ? 'addressable' : 'email'}
+                      className={popoverZIndex}
+                    />
+                  ) : (
+                    <Badge variant='user'>{pinnedChannelLabel}</Badge>
+                  )}
                 </div>
               </div>
               <Separator className='mx-4 w-auto' />

--- a/apps/web/src/components/mail/hooks/use-thread-counterparty.ts
+++ b/apps/web/src/components/mail/hooks/use-thread-counterparty.ts
@@ -24,6 +24,12 @@ export interface ThreadCounterparty {
  * external as `primary` with the rest as `others`. Internal-only threads fall
  * back to the first message's FROM (today's behavior). No extra network call —
  * reads the messages already loaded for the open thread.
+ *
+ * Sibling: `~/components/threads/hooks/use-thread-envelope-counterparty` answers
+ * "who is the one counterparty" from `ThreadMeta.participants` alone, so it works
+ * in list rows where no messages are loaded. This hook needs the whole thread and
+ * returns the full external set, so the two do not merge. Prefer the envelope one
+ * for titling/addressing; prefer this one when you need `others`.
  */
 export function useThreadCounterparty(threadId: string): ThreadCounterparty {
   const { messages, isLoading } = useMessages({ threadId })

--- a/apps/web/src/components/mail/message-display.tsx
+++ b/apps/web/src/components/mail/message-display.tsx
@@ -40,6 +40,7 @@ import { api } from '~/trpc/react'
 import { ContactHoverCard } from '../contacts/contact-hover-card'
 import { Tooltip } from '../global/tooltip'
 import type { EmailActions } from './email-actions'
+import type { MessageType } from './email-editor/types'
 import { useHtmlBody } from './hooks/use-html-body'
 import { useRetrySend } from './hooks/use-retry-send'
 import { SendStatusIndicator } from './send-status-indicator'
@@ -47,6 +48,7 @@ import { supportsRichText } from './utils/channel-rich-text'
 import { initialsFor } from './utils/participant-initials'
 import { resolveInlineEmailHtml } from './utils/resolve-inline-email-html'
 import { SandboxedEmailHtml } from './utils/sandboxed-email-html'
+import { toEditorMessage } from './utils/to-editor-message'
 
 interface MessageDisplayProps {
   /** Message ID to display */
@@ -86,7 +88,19 @@ const MessageDisplay = ({ messageId, messageActions, isOpen }: MessageDisplayPro
   const { markAsUnread } = useThreadReadStatus(message?.threadId ?? null)
 
   // Fetch sender participant using the new hook
-  const { from: sender } = useMessageParticipants(message?.participants ?? [])
+  const { from: sender, to, cc } = useMessageParticipants(message?.participants ?? [])
+
+  // The editor-shaped view of this message, for the reply/forward actions.
+  //
+  // `EmailDisplay` has always built this; the chat-bubble renderer passed the
+  // raw `MessageMeta` straight through instead, and `deriveInitialState` reads
+  // `sourceMessage.from` — a field `MessageMeta` does not have. So replying to
+  // any non-email message produced a composer with no recipient, no subject and
+  // no quoted body. Same shape, same helper, one source of truth.
+  const editorMessage: MessageType | null = useMemo(
+    () => (message ? toEditorMessage(message, { from: sender, to, cc }) : null),
+    [message, sender, to, cc]
+  )
 
   const { retry, isRetrying } = useRetrySend(message?.id)
 
@@ -192,9 +206,20 @@ const MessageDisplay = ({ messageId, messageActions, isOpen }: MessageDisplayPro
                   <div className='flex items-center'>
                     <MessageDropdownMenu
                       message={message}
+                      editorMessage={editorMessage}
                       emailActions={messageActions}
                       onMarkUnread={markAsUnread}
                     />
+                    <Button
+                      variant='ghost'
+                      size='icon'
+                      aria-label='Reply'
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        if (editorMessage) messageActions.onReply(editorMessage)
+                      }}>
+                      <Reply />
+                    </Button>
                   </div>
                 </div>
               )}
@@ -259,15 +284,23 @@ function MessageSkeleton() {
  */
 function MessageDropdownMenu({
   message,
+  editorMessage,
   emailActions,
   onMarkUnread,
 }: {
   message: MessageMeta
+  editorMessage: MessageType | null
   emailActions: EmailActions
   onMarkUnread: () => void
 }) {
   const handleSelect = (action: (msg: any) => void) => (event?: Event) => {
     action(message)
+  }
+
+  // Reply/forward need the editor shape; everything else (delete, print, copy
+  // id) acts on the raw message.
+  const handleEditorAction = (action: (msg: any) => void) => (event?: Event) => {
+    if (editorMessage) action(editorMessage)
   }
 
   return (
@@ -279,15 +312,15 @@ function MessageDropdownMenu({
       </DropdownMenuTrigger>
       <DropdownMenuContent align='end' className='w-56'>
         <DropdownMenuGroup>
-          <DropdownMenuItem onSelect={handleSelect(emailActions.onReply)}>
+          <DropdownMenuItem onSelect={handleEditorAction(emailActions.onReply)}>
             <Reply className='opacity-60' />
             Reply
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleSelect(emailActions.onReplyAll)}>
+          <DropdownMenuItem onSelect={handleEditorAction(emailActions.onReplyAll)}>
             <ReplyAll className='opacity-60' />
             Reply all
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleSelect(emailActions.onForward)}>
+          <DropdownMenuItem onSelect={handleEditorAction(emailActions.onForward)}>
             <Forward className='opacity-60' />
             Forward
           </DropdownMenuItem>

--- a/apps/web/src/components/mail/utils/channel-composer-mode.test.ts
+++ b/apps/web/src/components/mail/utils/channel-composer-mode.test.ts
@@ -1,0 +1,47 @@
+// apps/web/src/components/mail/utils/channel-composer-mode.test.ts
+
+import { IntegrationProviderType } from '@auxx/database/enums'
+import { PLATFORM_CAPABILITIES } from '@auxx/lib/channels/client'
+import { describe, expect, it } from 'vitest'
+import { channelUsesAlwaysOnComposer } from './channel-composer-mode'
+
+/**
+ * The bug this guards: the always-on composer was keyed to `provider === 'chat'`,
+ * so SMS threads rendered with no reachable composer at all — the affordance was
+ * tied to one provider name instead of to the property that motivates it. A
+ * table over every provider is what catches the next channel being added without
+ * anyone thinking about which flow it belongs in.
+ */
+describe('channelUsesAlwaysOnComposer', () => {
+  it('covers every provider in the capability map', () => {
+    expect(new Set(Object.keys(PLATFORM_CAPABILITIES))).toEqual(
+      new Set(Object.values(IntegrationProviderType))
+    )
+  })
+
+  it.each(
+    Object.values(IntegrationProviderType)
+  )('agrees with PlatformCapabilities.channel for %s', (provider) => {
+    const caps = PLATFORM_CAPABILITIES[provider]
+    expect(channelUsesAlwaysOnComposer(provider)).toBe(caps.channel !== 'email')
+  })
+
+  it('puts email channels on the click-to-reveal flow', () => {
+    expect(channelUsesAlwaysOnComposer(IntegrationProviderType.google)).toBe(false)
+    expect(channelUsesAlwaysOnComposer(IntegrationProviderType.outlook)).toBe(false)
+  })
+
+  it('puts conversational channels on the always-on composer', () => {
+    // The regression case: openphone must not depend on being named 'chat'.
+    expect(channelUsesAlwaysOnComposer(IntegrationProviderType.openphone)).toBe(true)
+    expect(channelUsesAlwaysOnComposer(IntegrationProviderType.chat)).toBe(true)
+  })
+
+  it('treats an unknown or absent provider as email', () => {
+    // Anything not yet in the capability map keeps today's behaviour rather than
+    // acquiring a composer nobody designed for it.
+    expect(channelUsesAlwaysOnComposer(undefined)).toBe(false)
+    expect(channelUsesAlwaysOnComposer(null)).toBe(false)
+    expect(channelUsesAlwaysOnComposer('not_a_provider')).toBe(false)
+  })
+})

--- a/apps/web/src/components/mail/utils/channel-composer-mode.ts
+++ b/apps/web/src/components/mail/utils/channel-composer-mode.ts
@@ -1,0 +1,31 @@
+// apps/web/src/components/mail/utils/channel-composer-mode.ts
+
+import { getComposerCapabilities } from '@auxx/lib/channels/client'
+
+/**
+ * Whether a channel's threads present an always-on composer instead of the
+ * email "click Reply to reveal" flow.
+ *
+ * Every non-`email` channel does. A conversational thread (web chat, SMS/Quo,
+ * WhatsApp, Facebook/Instagram DMs) has one counterparty and one obvious next
+ * action, so hiding the input behind a Reply click is friction email earns —
+ * because email has forwarding, reply-all, and a per-message choice of who you
+ * are answering — and messaging does not.
+ *
+ * Reads `PlatformCapabilities.channel` from the single capability map in
+ * `@auxx/lib/channels/client` rather than a local provider list. The previous
+ * `provider === 'chat'` check is exactly why SMS threads shipped with no
+ * reachable composer at all: the affordance was keyed to one provider name
+ * instead of to the property that actually motivates it.
+ *
+ * Unknown or absent providers read as email, so anything not yet in the
+ * capability map keeps today's click-to-reveal behaviour.
+ *
+ * @param provider Raw `Integration.provider` value (lowercase enum, e.g. `'google'`, `'openphone'`).
+ */
+export function channelUsesAlwaysOnComposer(provider: string | null | undefined): boolean {
+  if (!provider) return false
+  const capabilities = getComposerCapabilities(provider)
+  if (!capabilities) return false
+  return capabilities.channel !== 'email'
+}

--- a/apps/web/src/components/threads/hooks/index.ts
+++ b/apps/web/src/components/threads/hooks/index.ts
@@ -18,6 +18,10 @@ export { useParticipant } from './use-participant'
 export { useParticipants, useParticipantsArray } from './use-participants'
 export { useSelectionReset } from './use-selection-reset'
 export { useIsThreadLoading, useIsThreadNotFound, useThread } from './use-thread'
+export {
+  channelSelfIdentifier,
+  useThreadEnvelopeCounterparty,
+} from './use-thread-envelope-counterparty'
 export { useThreadKeyboardNav } from './use-thread-keyboard-nav'
 export { useThreadList } from './use-thread-list'
 export { type ThreadUpdates, useThreadMutation } from './use-thread-mutation'

--- a/apps/web/src/components/threads/hooks/use-thread-envelope-counterparty.ts
+++ b/apps/web/src/components/threads/hooks/use-thread-envelope-counterparty.ts
@@ -1,0 +1,65 @@
+// apps/web/src/components/threads/hooks/use-thread-envelope-counterparty.ts
+
+import type { ParticipantId } from '@auxx/types'
+import { useMemo } from 'react'
+import { useChannel } from '~/components/channels/hooks/use-channels'
+import type { ParticipantMeta } from '../store'
+import { pickThreadCounterparty } from '../utils/thread-title'
+import { useMessageParticipants } from './use-message-participants'
+import { useThread } from './use-thread'
+
+const NO_PARTICIPANTS: ParticipantId[] = []
+
+/**
+ * The sending channel's own address/number, used to drop ourselves from a
+ * thread's participant list. Email channels carry it on `email`; Quo/openphone
+ * rows carry a NULL email and keep the number on `metadata.phoneNumber`.
+ */
+export function channelSelfIdentifier(
+  channel: { email?: string | null; metadata?: unknown } | undefined
+) {
+  if (channel?.email) return channel.email
+  const metadata = channel?.metadata as { phoneNumber?: unknown } | null | undefined
+  return typeof metadata?.phoneNumber === 'string' ? metadata.phoneNumber : null
+}
+
+/**
+ * The participant on the other side of a thread, resolved from the thread's
+ * **envelope** — `ThreadMeta.participants`, the latest message's participant ids.
+ *
+ * Not to be confused with `~/components/mail/hooks/use-thread-counterparty`,
+ * which answers a related but different question. The distinction is what each
+ * one can afford to read:
+ *
+ * | | this hook | `mail/hooks` version |
+ * |---|---|---|
+ * | source | `ThreadMeta.participants` (envelope) | every message via `useMessages` |
+ * | returns | one participant | `{ primary, others, fallback }` |
+ * | excludes us by | `isInternal` **and** the channel's own identifier | `isInternal` only |
+ * | usable in list rows | yes — no messages needed | no |
+ *
+ * The list-row constraint is why this one exists: `useThreadTitle` renders in
+ * `mail-thread-item` / `compact-thread-item`, where a thread's messages are not
+ * loaded and fetching them per row would be absurd.
+ *
+ * Keeping `selfIdentifier` in play is deliberate even though `isInternal` now
+ * classifies PHONE participants correctly: it is a render-time check against the
+ * channel actually in hand, so it stays right against a row whose stored flag is
+ * stale, and costs one string compare.
+ *
+ * Costs no extra network call: the envelope is metadata tier (it survives every
+ * mail lens), the participant store batches its lookups, and the channel comes
+ * from the already-hydrated channel store.
+ */
+export function useThreadEnvelopeCounterparty(
+  threadId: string | null | undefined
+): ParticipantMeta | undefined {
+  const { thread } = useThread({ threadId })
+  const channel = useChannel(thread?.integrationId)
+  const { from, to, cc } = useMessageParticipants(thread?.participants ?? NO_PARTICIPANTS)
+
+  return useMemo(
+    () => pickThreadCounterparty([from, ...to, ...cc], channelSelfIdentifier(channel)),
+    [from, to, cc, channel]
+  )
+}

--- a/apps/web/src/components/threads/hooks/use-thread-title.ts
+++ b/apps/web/src/components/threads/hooks/use-thread-title.ts
@@ -1,24 +1,9 @@
 // apps/web/src/components/threads/hooks/use-thread-title.ts
 
-import type { ParticipantId } from '@auxx/types'
 import { useMemo } from 'react'
-import { useChannel } from '~/components/channels/hooks/use-channels'
-import { pickThreadCounterparty, resolveThreadTitle } from '../utils/thread-title'
-import { useMessageParticipants } from './use-message-participants'
+import { resolveThreadTitle } from '../utils/thread-title'
 import { useThread } from './use-thread'
-
-const NO_PARTICIPANTS: ParticipantId[] = []
-
-/**
- * The sending channel's own address/number, used to drop ourselves from a
- * thread's participant list. Email channels carry it on `email`; Quo/openphone
- * rows carry a NULL email and keep the number on `metadata.phoneNumber`.
- */
-function channelSelfIdentifier(channel: { email?: string | null; metadata?: unknown } | undefined) {
-  if (channel?.email) return channel.email
-  const metadata = channel?.metadata as { phoneNumber?: unknown } | null | undefined
-  return typeof metadata?.phoneNumber === 'string' ? metadata.phoneNumber : null
-}
+import { useThreadEnvelopeCounterparty } from './use-thread-envelope-counterparty'
 
 /**
  * Render-time title for a thread — the one derivation every thread surface
@@ -29,22 +14,21 @@ function channelSelfIdentifier(channel: { email?: string | null; metadata?: unkn
  * caller should render its own empty-subject placeholder. See
  * `resolveThreadTitle` for why the derived title is never persisted.
  *
- * Costs no extra network call: `ThreadMeta.participants` is the latest
- * message's envelope (metadata tier, so it survives every mail lens), the
- * participant store batches its lookups, and the channel comes from the
- * already-hydrated channel store.
+ * Counterparty selection lives in {@link useThreadEnvelopeCounterparty}, shared with the
+ * composer's default recipient so a thread is titled after exactly the person it
+ * would be addressed to.
  */
 export function useThreadTitle(threadId: string | null | undefined): string | null {
   const { thread } = useThread({ threadId })
-  const channel = useChannel(thread?.integrationId)
-  const { from, to, cc } = useMessageParticipants(thread?.participants ?? NO_PARTICIPANTS)
+  const participant = useThreadEnvelopeCounterparty(threadId)
 
-  return useMemo(() => {
-    const participant = pickThreadCounterparty([from, ...to, ...cc], channelSelfIdentifier(channel))
-    return resolveThreadTitle({
-      subject: thread?.subject,
-      integrationProvider: thread?.integrationProvider,
-      participant,
-    })
-  }, [thread?.subject, thread?.integrationProvider, from, to, cc, channel])
+  return useMemo(
+    () =>
+      resolveThreadTitle({
+        subject: thread?.subject,
+        integrationProvider: thread?.integrationProvider,
+        participant,
+      }),
+    [thread?.subject, thread?.integrationProvider, participant]
+  )
 }

--- a/apps/web/src/hooks/use-reply-box.tsx
+++ b/apps/web/src/hooks/use-reply-box.tsx
@@ -7,6 +7,7 @@ import type {
   MessageType as EditorMessageType,
   EditorMode,
 } from '~/components/mail/email-editor/types'
+import { channelUsesAlwaysOnComposer } from '~/components/mail/utils/channel-composer-mode'
 import { useMessage, useParticipant } from '~/components/threads/hooks'
 import type { ThreadMeta } from '~/components/threads/store'
 import { useThreadStore } from '~/components/threads/store/thread-store'
@@ -109,22 +110,27 @@ export function useReplyBox(thread: ThreadMeta | null | undefined) {
     }
   }, [effectiveDraft])
 
-  // Chat threads use an always-on composer (no "click Reply to reveal" flow).
-  // Auto-open the reply box for chat and keep it open across thread switches —
-  // the existing thread-id reset effect below would otherwise close it.
+  // Conversational channels (chat, SMS/WhatsApp, DMs) use an always-on composer
+  // — no "click Reply to reveal" flow. Auto-open the reply box and keep it open
+  // across thread switches; the thread-id reset effect below would otherwise
+  // close it.
   //
-  // `integrationProvider` is declared `ChannelProvider` ('GMAIL' | 'OUTLOOK' | …)
-  // but carries the raw `Integration.provider` column, whose enum is lowercase
-  // ('google' | 'outlook' | … | 'chat'). The declared type is the stale side;
-  // the cast matches the runtime value and the sibling checks in
-  // components/mail/{mail,compact}-thread-item.tsx.
-  const isChat = (thread?.integrationProvider as string | null | undefined) === 'chat'
+  // Derived from `PlatformCapabilities.channel` rather than a provider list:
+  // hardcoding `=== 'chat'` here is what kept SMS on the email flow, and a
+  // per-provider set maintained beside the capability map is exactly the drift
+  // that made phone channels unselectable in the From picker for months. An
+  // unknown/absent provider reads as email, so anything not yet in the map keeps
+  // today's click-to-reveal behaviour.
+  const alwaysOnComposer = useMemo(
+    () => channelUsesAlwaysOnComposer(thread?.integrationProvider),
+    [thread?.integrationProvider]
+  )
   useEffect(() => {
-    if (isChat && !isShowReplyBox) {
+    if (alwaysOnComposer && !isShowReplyBox) {
       setIsShowReplyBox(true)
       setEditorMode('reply')
     }
-  }, [isChat, isShowReplyBox])
+  }, [alwaysOnComposer, isShowReplyBox])
 
   // Reset internal state ONLY when the thread ID actually changes
   const previousThreadId = useRef<string | null | undefined>(null)
@@ -133,7 +139,7 @@ export function useReplyBox(thread: ThreadMeta | null | undefined) {
     const hasDraft = !!effectiveDraft
 
     if (currentThreadId !== previousThreadId.current) {
-      if (!hasDraft && !isChat) {
+      if (!hasDraft && !alwaysOnComposer) {
         setIsShowReplyBox(false)
         setSourceMessage(null)
         setEditorMode('reply')
@@ -151,7 +157,7 @@ export function useReplyBox(thread: ThreadMeta | null | undefined) {
         // Don't override sourceMessage - let it be populated from sourceMessageFromDraft
       }
     }
-  }, [thread?.id, effectiveDraft, isShowReplyBox])
+  }, [thread?.id, effectiveDraft, isShowReplyBox, alwaysOnComposer])
 
   /** Scrolls the reply box into view */
   const scrollIntoView = useCallback(() => {


### PR DESCRIPTION
## The bug

An SMS thread had **no reachable reply composer**. The composer itself was fine — nothing ever opened it.

`thread-details.tsx` only mounts the reply portal once `replyBox.isOpen`, and three things set that flag: an email thread's per-message Reply button (`email-display.tsx:313`), `use-reply-box.tsx`'s `provider === 'chat'` auto-open, and the R/F hotkeys. A Quo thread renders through `MessageDisplay` — which had no Reply button, only the overflow menu — and is not `chat`, so it hit none of them.

## Changes

**Always-on composer is capability-derived.** `channelUsesAlwaysOnComposer` reads `PlatformCapabilities.channel !== 'email'` instead of a provider name. Keying the affordance to `'chat'` is what left SMS with no way in, and a provider list maintained beside the capability map is the same drift that made phone channels unselectable in the From picker for months.

**From is pinned to the thread's channel.** The composer plan asserted *"reply mode is unaffected — From is pinned by the thread's channel."* It was not — `ChannelPicker` rendered in every mode with `disabled={isSending}` as its only gate, so an SMS thread could be switched to an email channel. A thread's participants are identifiers in one address space, so that produces a send with no valid recipient rather than an email to the same person.

| context | From |
|---|---|
| new compose | picker, `scope='addressable'` (unchanged) |
| email thread | picker, `scope='email'` — another mailbox or alias, never another channel class |
| non-email thread | pinned, static badge |

This also makes new compose the only caller that reaches `reconcileDraftForChannel`, which is what the plan assumed all along.

**`MessageDisplay` reply wiring.** It passed the raw `MessageMeta` to `onReply`; `deriveInitialState` reads `sourceMessage.from`, a field `MessageMeta` does not have. So replying to any non-email message produced a composer with no recipient, no subject and no quoted body. It now builds an editor message via `toEditorMessage` — the same helper `EmailDisplay` uses — and gains a Reply button.

**Recipient seeded from the thread counterparty.** An always-on composer has no "reply to THIS message" click to derive a recipient from. Deliberately not `sourceMessage.from`: on an outbound-last thread that is us.

Seeding is guarded on the channel's own `recipientModel`. A thread's participant set is not guaranteed single-model, so an unrelated identifier type can reach counterparty selection; the guard makes the seed degrade to **empty rather than to an unsendable recipient**. This was caught in the browser, not in review — the first live check seeded an email address into a phone To field.

## `useThreadEnvelopeCounterparty`

Extracts the selection `useThreadTitle` already did inline, so a thread is **addressed to exactly the person it is named after**.

Deliberately *not* merged with the existing `mail/hooks/use-thread-counterparty`:

| | this one | existing |
|---|---|---|
| source | `ThreadMeta.participants` (latest message's envelope) | every message via `useMessages` |
| returns | one participant | `{ primary, others, fallback }` |
| works in list rows | yes | no |

`useThreadTitle` renders in `mail-thread-item` / `compact-thread-item`, where a thread's messages are not loaded — that constraint is why both exist. Both docblocks cross-reference each other.

## Tests

Assert on capability resolution rather than rendering, per the composer plan's §5 lesson — the Phase-0 branches were unreachable for months without anything failing:

- a table over **every** `IntegrationProviderType` asserting `channelUsesAlwaysOnComposer` matches `PlatformCapabilities.channel`, so a new provider added without a decision is a failing test
- three cases pinning From across all three modes

`tsc` clean. Full web suite **3359 passed / 0 failed** (one pre-existing collection failure in `outlook/webhook`, a Drizzle `Symbol(drizzle:Columns)` error inside `packages/lib`, unmodified by this PR and failing at HEAD).

## Notes

- Verified live against a real Quo thread before that dev data was cleared.
- Depends on nothing in #1655, but benefits from it: with channel identity resolving on phone channels, counterparty selection picks the customer rather than the org's own identity.
- Not addressed here: `ThreadManagerService.updateThreadParticipants` never inserts `ThreadParticipant` rows despite its name, so any outbound-first thread is invisible to contact-derived mail grants. Broader than SMS — recorded in §6 of `plans/participants/channel-identity-and-is-internal.md`.
