### PR TITLE
feat(fields): give multi-value phone fields a country selector and e.164 entry

### DIFF
--- a/apps/web/src/components/fields/inputs/multi-value-input-field.test.tsx
+++ b/apps/web/src/components/fields/inputs/multi-value-input-field.test.tsx
@@ -39,6 +39,11 @@ vi.mock('../property-provider', () => ({
 vi.mock('../field-navigation-context', () => ({
   useFieldNavigationOptional: () => null,
 }))
+// Reads the org settings blob off the dehydrated-state provider, which THROWS
+// outside its context — the wrappers call it for the phone arm's country.
+vi.mock('./use-org-business-country', () => ({
+  useOrgBusinessCountry: () => 'US',
+}))
 
 // Heavy siblings of the adapter's multi branch — not under test here.
 vi.mock('~/components/records/record-editor-dialog', () => ({
@@ -120,6 +125,44 @@ describe('MultiValueInputField (panel popover)', () => {
     })
     expect(h.ctx.commitValue).toHaveBeenCalledWith(['b@x.com', 'a@x.com'])
   })
+
+  // The server rewrites what it stores (E.164, lowercased email) and the
+  // provider re-derives `value` from the store. Without this sync the popover
+  // keeps showing what was TYPED until it is closed and reopened.
+  it('adopts the server-normalized list into an open popover', async () => {
+    h.ctx = makePropertyContext(['5102055536'])
+    const { rerender } = render(<MultiValueInputField />)
+    expect(screen.getByText('5102055536')).toBeInTheDocument()
+
+    // Same field, server echo with the normalized value.
+    h.ctx = { ...h.ctx, value: ['+15102055536'] }
+    rerender(<MultiValueInputField />)
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('+15102055536')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('5102055536')).not.toBeInTheDocument()
+  })
+
+  it('a debounce that already fired does not block a later sync', async () => {
+    h.ctx = makePropertyContext(['a@x.com'])
+    const { rerender } = render(<MultiValueInputField />)
+
+    await userEvent.type(screen.getByPlaceholderText('Search or add email...'), 'b@x.com')
+    await userEvent.click(screen.getByText(/^Add "/))
+    // Let the 300ms debounce fire on its own — this is what used to leave a
+    // dead timer id in the ref forever.
+    await vi.waitFor(() => {
+      expect(h.ctx.commitValue).toHaveBeenCalledWith(['a@x.com', 'b@x.com'])
+    })
+
+    h.ctx = { ...h.ctx, value: ['a@x.com', 'b@x.com', 'c@x.com'] }
+    rerender(<MultiValueInputField />)
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('c@x.com')).toBeInTheDocument()
+    })
+  })
 })
 
 describe('FieldInputAdapter — multi EMAIL branch (create dialog path)', () => {
@@ -148,5 +191,22 @@ describe('FieldInputAdapter — multi EMAIL branch (create dialog path)', () => 
     render(<FieldInputAdapter fieldType='EMAIL' value='a@x.com' onChange={vi.fn()} />)
     // The scalar branch renders a text input, not the picker trigger.
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  })
+
+  // The trigger chips used to render the raw stored string, so a correctly
+  // stored E.164 number ignored the field's own `phoneFormat` and read as
+  // `+15102055536` — inconsistent with DisplayPhone and the table cell.
+  it('display-formats multi PHONE chips per the field phoneFormat', () => {
+    render(
+      <FieldInputAdapter
+        fieldType='PHONE_INTL'
+        fieldOptions={{ multi: true, phoneFormat: 'international' }}
+        value={['+15102055536']}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('+1 510 205 5536')).toBeInTheDocument()
+    expect(screen.queryByText('+15102055536')).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/components/fields/inputs/multi-value-input-field.tsx
+++ b/apps/web/src/components/fields/inputs/multi-value-input-field.tsx
@@ -5,14 +5,15 @@ import type { FieldOptions } from '@auxx/lib/field-values/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { MultiValuePicker } from '~/components/pickers/multi-value-picker'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { formatValueForDisplay, MultiValuePicker } from '~/components/pickers/multi-value-picker'
 import { ItemsListView } from '~/components/ui/items-list-view'
 import { PickerTrigger, type PickerTriggerOptions } from '~/components/ui/picker-trigger'
 import { useFieldNavigationOptional } from '../field-navigation-context'
 import { usePropertyContext } from '../property-provider'
+import { useOrgBusinessCountry } from './use-org-business-country'
 
-/** Placeholder per field type for the picker's combined filter/entry input. */
+/** Placeholder per field type for the picker's entry input. */
 function placeholderFor(fieldType: string): string {
   switch (fieldType) {
     case 'EMAIL':
@@ -20,7 +21,8 @@ function placeholderFor(fieldType: string): string {
     case 'URL':
       return 'Search or add website...'
     case 'PHONE_INTL':
-      return 'Search or add phone...'
+      // The phone arm is a real phone input, not a search box.
+      return 'Enter phone number'
     default:
       return 'Search or add...'
   }
@@ -45,6 +47,7 @@ function toValueList(value: unknown): string[] {
 export function MultiValueInputField() {
   const { value, field, commitValue, onBeforeClose } = usePropertyContext()
   const nav = useFieldNavigationOptional()
+  const defaultCountry = useOrgBusinessCountry()
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   const fieldType: string = field?.fieldType || field?.type
@@ -57,6 +60,21 @@ export function MultiValueInputField() {
     localValuesRef.current = localValues
   }, [localValues])
 
+  // Adopt the server's shape of the list. The provider re-derives `value` from
+  // the store on every confirmed write (`property-provider.tsx` syncs on
+  // `storeValue`), so this is what brings the WRITE-NORMALIZED form back into an
+  // open popover — E.164 for phone, lowercased for email — and what visibly
+  // drops a value the server rejected and rolled back.
+  //
+  // Keyed on the CONTENT, not on `value`'s identity: the provider derives it
+  // through `formatToRawValue`, which mints a fresh array, and an identity dep
+  // would eat in-flight edits the day that moves into render.
+  const serverKey = JSON.stringify(toValueList(value))
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on serverKey by design — see above
+  useEffect(() => {
+    setLocalValues(toValueList(value))
+  }, [serverKey])
+
   /** Debounced whole-array save — waits for the user to stop editing. */
   const debouncedSave = useCallback(
     (newValues: string[]) => {
@@ -64,6 +82,10 @@ export function MultiValueInputField() {
         clearTimeout(saveTimeoutRef.current)
       }
       saveTimeoutRef.current = setTimeout(() => {
+        // Null the ref as the timer fires. Without this it holds a DEAD id
+        // forever, which makes `onBeforeClose` issue a redundant second commit
+        // and would silently disable any future "is a save pending?" guard.
+        saveTimeoutRef.current = null
         commitValue(newValues)
       }, 300)
     },
@@ -116,6 +138,7 @@ export function MultiValueInputField() {
       fieldOptions={field?.options as FieldOptions | undefined}
       placeholder={placeholderFor(fieldType)}
       onCaptureChange={handleCaptureChange}
+      defaultCountry={defaultCountry}
     />
   )
 }
@@ -173,6 +196,19 @@ export function MultiValueFieldInput({
   shouldPreventDismiss,
 }: MultiValueFieldInputProps) {
   const values = toValueList(value)
+  const defaultCountry = useOrgBusinessCountry()
+
+  // Chips render display-formatted, matching `DisplayPhone` and the table cell.
+  // Raw text here meant a stored `+15102055536` ignored the field's own
+  // `phoneFormat` and read as an unformatted E.164 blob.
+  const chips = useMemo(
+    () =>
+      values.map((v, index) => ({
+        id: `${index}:${v}`,
+        value: formatValueForDisplay(fieldType, v, fieldOptions),
+      })),
+    [values, fieldType, fieldOptions]
+  )
 
   const [internalOpen, setInternalOpen] = useState(false)
   const open = controlledOpen ?? internalOpen
@@ -207,7 +243,7 @@ export function MultiValueFieldInput({
           asCombobox
           className={cn(className, triggerProps?.className)}>
           <ItemsListView
-            items={values.map((v, index) => ({ id: `${index}:${v}`, value: v }))}
+            items={chips}
             renderItem={(item) => (
               <Badge variant='pill' className='shrink-0'>
                 {typeof item === 'object' ? (item.value as string) : String(item)}
@@ -234,6 +270,7 @@ export function MultiValueFieldInput({
           fieldOptions={fieldOptions}
           placeholder={placeholder ?? placeholderFor(fieldType)}
           disabled={disabled}
+          defaultCountry={defaultCountry}
         />
       </PopoverContent>
     </Popover>

--- a/apps/web/src/components/pickers/multi-value-picker.test.tsx
+++ b/apps/web/src/components/pickers/multi-value-picker.test.tsx
@@ -90,6 +90,123 @@ describe('MultiValuePicker — Create row gating', () => {
   })
 })
 
+// ── PHONE_INTL entry: a real phone input, not a search box ──────────────────
+//
+// The picker's phone arm must normalize through `formatPhoneNumber` (the same
+// libphonenumber call the write path runs), so the Add row can never offer a
+// value the server would 400 on, and a national number typed without a `+`
+// depends on `defaultCountry`.
+
+describe('MultiValuePicker — PHONE_INTL entry', () => {
+  it('normalizes a US national number to E.164 on add', async () => {
+    const onChange = vi.fn()
+    render(<MultiValuePicker fieldType='PHONE_INTL' values={[]} onChange={onChange} />)
+
+    await typeInto(screen.getByPlaceholderText('Enter phone number'), '5102055536')
+    await userEvent.click(screen.getByText(/^Add "/))
+
+    expect(onChange).toHaveBeenCalledWith(['+15102055536'])
+  })
+
+  it('parses a national number against defaultCountry, not always US', async () => {
+    const onChange = vi.fn()
+    // Berlin landline in national form — valid as DE, not as US.
+    render(
+      <MultiValuePicker
+        fieldType='PHONE_INTL'
+        values={[]}
+        onChange={onChange}
+        defaultCountry='DE'
+      />
+    )
+
+    await typeInto(screen.getByPlaceholderText('Enter phone number'), '030901820')
+    await userEvent.click(screen.getByText(/^Add "/))
+
+    expect(onChange).toHaveBeenCalledWith(['+4930901820'])
+  })
+
+  it('rejects the same national number when the country is US', async () => {
+    render(
+      <MultiValuePicker fieldType='PHONE_INTL' values={[]} onChange={vi.fn()} defaultCountry='US' />
+    )
+
+    await typeInto(screen.getByPlaceholderText('Enter phone number'), '030901820')
+    expect(screen.queryByText(/^Add "/)).not.toBeInTheDocument()
+  })
+
+  it('keeps an impossible number out of the list (isValid, not a length check)', async () => {
+    render(<MultiValuePicker fieldType='PHONE_INTL' values={[]} onChange={vi.fn()} />)
+
+    // 555-555-5555 is length-valid but not a real US number.
+    await typeInto(screen.getByPlaceholderText('Enter phone number'), '5555555555')
+    expect(screen.queryByText(/^Add "/)).not.toBeInTheDocument()
+  })
+
+  it('treats a differently-formatted duplicate as a duplicate', async () => {
+    render(<MultiValuePicker fieldType='PHONE_INTL' values={['+15102055536']} onChange={vi.fn()} />)
+
+    await typeInto(screen.getByPlaceholderText('Enter phone number'), '(510) 205-5536')
+    expect(screen.queryByText(/^Add "/)).not.toBeInTheDocument()
+  })
+
+  it(`hides the Add row at the ${MAX_MULTI_VALUES}-value cap`, async () => {
+    // Distinct, individually valid US numbers.
+    const values = Array.from({ length: MAX_MULTI_VALUES }, (_, i) => `+1510205553${i}`)
+    render(<MultiValuePicker fieldType='PHONE_INTL' values={values} onChange={vi.fn()} />)
+
+    await typeInto(screen.getByPlaceholderText('Enter phone number'), '2136210001')
+    expect(screen.queryByText(/^Add "/)).not.toBeInTheDocument()
+  })
+
+  it('keeps existing rows visible while a new number is typed', async () => {
+    render(<MultiValuePicker fieldType='PHONE_INTL' values={['+15102055536']} onChange={vi.fn()} />)
+
+    await typeInto(screen.getByPlaceholderText('Enter phone number'), '2136210001')
+    // `searchValue` is ENTRY text on the phone arm — it must not filter the list.
+    // No `phoneFormat` option here, so the converter's default (national) applies.
+    expect(screen.getByText('(510) 205-5536')).toBeInTheDocument()
+  })
+})
+
+describe('MultiValuePicker — entry control by type (scope boundary)', () => {
+  it('EMAIL and URL keep the searchable CommandInput', () => {
+    const { unmount } = render(
+      <MultiValuePicker fieldType='EMAIL' values={[]} onChange={vi.fn()} />
+    )
+    expect(screen.getByPlaceholderText('Search or add...')).toHaveAttribute('cmdk-input', '')
+    unmount()
+
+    render(<MultiValuePicker fieldType='URL' values={[]} onChange={vi.fn()} />)
+    expect(screen.getByPlaceholderText('Search or add...')).toHaveAttribute('cmdk-input', '')
+  })
+
+  // The country-select button precedes the number field in the DOM, so a popover
+  // focus scope grabs IT on open. Focusing the button here stands in for that —
+  // `autoFocus` alone has already fired by this point, so this fails without the
+  // picker's own reclaim-on-next-frame effect.
+  it('claims the caret back from the country button', async () => {
+    render(<MultiValuePicker fieldType='PHONE_INTL' values={[]} onChange={vi.fn()} />)
+
+    const input = screen.getByPlaceholderText('Enter phone number')
+    const countryButton = screen.getByLabelText('Select country')
+
+    countryButton.focus()
+    expect(document.activeElement).toBe(countryButton)
+
+    await vi.waitFor(() => {
+      expect(document.activeElement).toBe(input)
+    })
+  })
+
+  it('PHONE_INTL renders the flag input instead, with a country selector', () => {
+    render(<MultiValuePicker fieldType='PHONE_INTL' values={[]} onChange={vi.fn()} />)
+
+    expect(screen.getByPlaceholderText('Enter phone number')).not.toHaveAttribute('cmdk-input')
+    expect(screen.getByLabelText('Select country')).toBeInTheDocument()
+  })
+})
+
 describe('MultiValuePicker — rows', () => {
   it('marks index 0 with the Primary badge', () => {
     render(

--- a/apps/web/src/components/pickers/multi-value-picker.tsx
+++ b/apps/web/src/components/pickers/multi-value-picker.tsx
@@ -17,10 +17,12 @@ import {
   CommandItem,
   CommandList,
 } from '@auxx/ui/components/command'
+import PhoneInputWithFlag from '@auxx/ui/components/phone-input'
 import { cn } from '@auxx/ui/lib/utils'
-import { formatUrlForDisplay, normalizeUrl } from '@auxx/utils'
+import { formatPhoneNumber, formatUrlForDisplay, normalizeUrl } from '@auxx/utils'
+import { type CountryCode, isSupportedCountry } from 'libphonenumber-js'
 import { ArrowUpToLine, Plus, Trash2 } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 /**
  * Props for the MultiValuePicker component
@@ -38,7 +40,7 @@ export interface MultiValuePickerProps {
   /** Field options (phoneFormat, …) for display formatting */
   fieldOptions?: FieldOptions
 
-  /** Placeholder text for the combined filter/entry input */
+  /** Placeholder text for the entry input */
   placeholder?: string
 
   /** Disabled state */
@@ -49,10 +51,28 @@ export interface MultiValuePickerProps {
 
   /** Additional className for Command wrapper */
   className?: string
+
+  /**
+   * PHONE_INTL only — country assumed for a number typed without a `+` prefix,
+   * and the flag the picker opens on. Callers pass the org's business country;
+   * anything unrecognised falls back to `US`.
+   */
+  defaultCountry?: string
+}
+
+/** Narrow a loose country string to a libphonenumber `CountryCode`, defaulting to `US`. */
+function toCountryCode(country: string | undefined): CountryCode {
+  if (!country) return 'US'
+  const code = country.trim().toUpperCase()
+  return isSupportedCountry(code) ? (code as CountryCode) : 'US'
 }
 
 /** Client-side per-type validation gate for the Create row. Server still normalizes. */
-export function isValidMultiValue(fieldType: string, raw: string): boolean {
+export function isValidMultiValue(
+  fieldType: string,
+  raw: string,
+  defaultCountry?: string
+): boolean {
   const value = raw.trim()
   if (!value) return false
   switch (fieldType) {
@@ -68,18 +88,22 @@ export function isValidMultiValue(fieldType: string, raw: string): boolean {
       }
     }
     case 'PHONE_INTL':
-      return /^[+]?[1-9][\d\s\-().]{7,15}$/.test(value.replace(/\s/g, ''))
+      // `formatPhoneNumber` IS the decision — the same libphonenumber `isValid()`
+      // the write path runs (`fieldValueSchemas.phone`). Never a looser regex
+      // beside it, or the picker accepts values the server then 400s on.
+      return formatPhoneNumber(value, toCountryCode(defaultCountry)) !== null
     default:
       return true
   }
 }
 
 /** Display-format one value for its row title (raw value stays the stored one). */
-function formatValueForDisplay(
+export function formatValueForDisplay(
   fieldType: string,
   value: string,
   fieldOptions?: FieldOptions
 ): string {
+  if (!value) return value
   if (fieldType === 'PHONE_INTL') {
     return (
       (formatToDisplayValue({ type: 'text', value }, 'PHONE_INTL', fieldOptions) as string) || value
@@ -92,31 +116,60 @@ function formatValueForDisplay(
   return value
 }
 
-/** Normalize a typed value before storing — email lowercases (matches the server hooks). */
-function normalizeNewValue(fieldType: string, raw: string): string {
+/**
+ * Normalize a typed value before storing — email lowercases (matches the server
+ * hooks), phone goes to E.164 through the shared normalizer.
+ */
+function normalizeNewValue(fieldType: string, raw: string, defaultCountry?: string): string {
   const value = raw.trim()
-  return fieldType === 'EMAIL' ? value.toLowerCase() : value
+  if (fieldType === 'EMAIL') return value.toLowerCase()
+  if (fieldType === 'PHONE_INTL') {
+    return formatPhoneNumber(value, toCountryCode(defaultCountry)) ?? value
+  }
+  return value
+}
+
+/**
+ * Duplicate-detection key. Phone normalizes first, so `(510) 111-3333` collides
+ * with a stored `+15101113333` instead of being appended as a second value.
+ */
+function compareKey(fieldType: string, value: string, defaultCountry?: string): string {
+  if (fieldType === 'PHONE_INTL') {
+    return formatPhoneNumber(value, toCountryCode(defaultCountry)) ?? value.trim()
+  }
+  return value.trim().toLowerCase()
+}
+
+/** Default entry placeholder per type. */
+function defaultPlaceholder(fieldType: string): string {
+  return fieldType === 'PHONE_INTL' ? 'Enter phone number' : 'Search or add...'
 }
 
 /**
  * MultiValuePicker
  * Tags-style value-list editor for multi-value scalar fields (options.multi
- * EMAIL/URL/PHONE). The `CommandInput` doubles as filter and entry field; a
- * `Create "«typed»"` row appears for valid, non-duplicate input while under
- * the value cap. Value rows are `CommandDetailItem`s with `selectionMode='none'`
+ * EMAIL/URL/PHONE). Value rows are `CommandDetailItem`s with `selectionMode='none'`
  * — a bare row click is deliberately a no-op (it must never silently retarget
  * outbound mail); explicit hover actions handle set-as-primary and remove.
+ *
+ * The entry control is type-shaped. EMAIL/URL use a `CommandInput` that doubles
+ * as filter and entry. PHONE_INTL instead gets `PhoneInputWithFlag` (country
+ * dropdown, E.164 as you type) — filtering is dead weight under a 10-value cap,
+ * and a phone number needs a country to be parseable at all.
  */
 export function MultiValuePicker({
   fieldType,
   values,
   onChange,
   fieldOptions,
-  placeholder = 'Search or add...',
+  placeholder,
   disabled = false,
   onCaptureChange,
   className,
+  defaultCountry,
 }: MultiValuePickerProps) {
+  const isPhone = fieldType === 'PHONE_INTL'
+
   // Notify parent about capture state on mount/unmount
   useEffect(() => {
     onCaptureChange?.(true)
@@ -125,27 +178,29 @@ export function MultiValuePicker({
 
   const [searchValue, setSearchValue] = useState('')
 
-  // Filter values by search (raw + display-formatted, case-insensitive)
+  // Filter values by search (raw + display-formatted, case-insensitive).
+  // The phone arm has NO search box — `searchValue` there is pending entry text,
+  // so filtering by it would hide the existing numbers as a new one is typed.
   const filteredValues = useMemo(() => {
-    if (!searchValue.trim()) return values
+    if (isPhone || !searchValue.trim()) return values
     const search = searchValue.toLowerCase()
     return values.filter(
       (v) =>
         v.toLowerCase().includes(search) ||
         formatValueForDisplay(fieldType, v, fieldOptions).toLowerCase().includes(search)
     )
-  }, [values, searchValue, fieldType, fieldOptions])
+  }, [values, searchValue, fieldType, fieldOptions, isPhone])
 
-  // Hide the Create row when the typed value already exists (case-insensitive)
+  // Hide the Create row when the typed value already exists (normalized compare)
   const searchMatchesExisting = useMemo(() => {
-    const typed = normalizeNewValue(fieldType, searchValue).toLowerCase()
+    const typed = compareKey(fieldType, searchValue, defaultCountry)
     if (!typed) return true
-    return values.some((v) => v.toLowerCase() === typed)
-  }, [values, searchValue, fieldType])
+    return values.some((v) => compareKey(fieldType, v, defaultCountry) === typed)
+  }, [values, searchValue, fieldType, defaultCountry])
 
   const typedIsValid = useMemo(
-    () => isValidMultiValue(fieldType, searchValue),
-    [fieldType, searchValue]
+    () => isValidMultiValue(fieldType, searchValue, defaultCountry),
+    [fieldType, searchValue, defaultCountry]
   )
 
   const atCap = values.length >= MAX_MULTI_VALUES
@@ -154,16 +209,38 @@ export function MultiValuePicker({
 
   /** Append the typed value at the end of the list. */
   const createValue = useCallback(() => {
-    const newValue = normalizeNewValue(fieldType, searchValue)
-    if (!newValue || !isValidMultiValue(fieldType, newValue)) return
-    if (values.some((v) => v.toLowerCase() === newValue.toLowerCase())) {
+    const newValue = normalizeNewValue(fieldType, searchValue, defaultCountry)
+    if (!newValue || !isValidMultiValue(fieldType, newValue, defaultCountry)) return
+    const key = compareKey(fieldType, newValue, defaultCountry)
+    if (values.some((v) => compareKey(fieldType, v, defaultCountry) === key)) {
       setSearchValue('')
       return
     }
     if (values.length >= MAX_MULTI_VALUES) return
     onChange([...values, newValue])
     setSearchValue('')
-  }, [fieldType, searchValue, values, onChange])
+  }, [fieldType, searchValue, values, onChange, defaultCountry])
+
+  /** Enter in the phone input commits — must not bubble into a form or the popover. */
+  const handlePhoneKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key !== 'Enter') return
+      e.preventDefault()
+      e.stopPropagation()
+      createValue()
+    },
+    [createValue]
+  )
+
+  /** Label on the Add row — phone shows the normalized number, formatted. */
+  const createLabel = useMemo(() => {
+    if (!isPhone) return searchValue.trim()
+    return formatValueForDisplay(
+      fieldType,
+      normalizeNewValue(fieldType, searchValue, defaultCountry),
+      fieldOptions
+    )
+  }, [isPhone, fieldType, searchValue, defaultCountry, fieldOptions])
 
   /** Move a value to the front — index 0 IS the primary. */
   const setPrimary = useCallback(
@@ -183,14 +260,50 @@ export function MultiValuePicker({
     [values, onChange]
   )
 
+  // Land the caret in the NUMBER field on open, the way a bare `CommandInput`
+  // does. `autoFocus` alone loses this race: the popover's focus scope focuses
+  // the first TABBABLE element when it opens, and inside the phone input that
+  // is the country-select button (react-phone-number-input renders it ahead of
+  // the number field). Claim focus back on the next frame, once the scope has
+  // settled — earlier than that and the scope simply overwrites it.
+  const phoneRowRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!isPhone || disabled) return
+    const frame = requestAnimationFrame(() => {
+      phoneRowRef.current?.querySelector<HTMLInputElement>('input[data-slot=phone-input]')?.focus()
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [isPhone, disabled])
+
   return (
     <Command shouldFilter={false} className={cn('rounded-lg', className)}>
-      <CommandInput
-        placeholder={placeholder}
-        value={searchValue}
-        onValueChange={setSearchValue}
-        disabled={disabled}
-      />
+      {isPhone ? (
+        // `cmdk-input-wrapper` is load-bearing, not decoration: `Command` rounds
+        // the list's top corners via `:not(:has([cmdk-input-wrapper]))`, which
+        // would fire under this square-cornered row without it.
+        <div
+          ref={phoneRowRef}
+          cmdk-input-wrapper=''
+          className='flex shrink-0 items-center border-b border-border/50 dark:border-[#323842]/80 ps-1 pe-2'>
+          <PhoneInputWithFlag
+            value={searchValue}
+            onChange={setSearchValue}
+            onKeyDown={handlePhoneKeyDown}
+            defaultCountry={defaultCountry}
+            disabled={disabled}
+            placeholder={placeholder ?? defaultPlaceholder(fieldType)}
+            autoFocus
+            className='h-8 flex-1 border-none shadow-none! [&>input]:h-8 [&>input]:flex-1 [&>input]:outline-none [&>input]:focus:ring-0 [&_[data-slot=country-select]]:bg-transparent [&_[data-slot=phone-input]]:w-full'
+          />
+        </div>
+      ) : (
+        <CommandInput
+          placeholder={placeholder ?? defaultPlaceholder(fieldType)}
+          value={searchValue}
+          onValueChange={setSearchValue}
+          disabled={disabled}
+        />
+      )}
 
       <CommandList>
         {/* Create row — inside the list, beside the results it filters. Hidden
@@ -204,7 +317,7 @@ export function MultiValuePicker({
                 disabled={disabled}>
                 <Plus className='text-muted-foreground' />
                 <span>
-                  Add "<span className='font-medium'>{searchValue.trim()}</span>"
+                  Add "<span className='font-medium'>{createLabel}</span>"
                 </span>
               </CommandItem>
             </CommandGroup>


### PR DESCRIPTION
Follow-up to #1656, which threaded the org business country into `PhoneInputWithFlag` but could not reach contact phone: `get-input-component.tsx:46-49` routes on `options.multi` **before** the scalar component is constructed, and contact phone has been multi since #1634. So the field people actually use rendered `MultiValuePicker` — a generic string-list editor with no country selector and no client-side normalization.

Storage was never wrong (all 307 local `PHONE_INTL` values are E.164; the server normalizes every array element through `fieldValueSchemas.phone`). This fixes the entry and display path.

## Changes

**`multi-value-picker.tsx`**
- `PHONE_INTL` now renders `PhoneInputWithFlag` — country dropdown, E.164 as you type — in place of `CommandInput`. EMAIL and URL are unchanged, asserted by test.
- New `defaultCountry?: string` prop, narrowed to a `CountryCode` via `isSupportedCountry` with a `US` fallback.
- **The regex is gone.** `formatPhoneNumber` is now the only gate — the same libphonenumber `isValid()` the write path runs — so the picker can no longer offer a value the server would 400 on. The old `/^[+]?[1-9][\d\s\-().]{7,15}$/` was strictly looser than `isValid()`.
- New `compareKey()` for duplicate detection, so `(510) 205-5536` collides with a stored `+15102055536` instead of appending a second copy.
- `filteredValues` skips filtering on the phone arm — `searchValue` there is pending *entry* text, and filtering by it would hide existing numbers as a new one is typed.
- Enter in the phone input commits.
- Focus: the country-select button precedes the number field in the DOM, so the popover's focus scope claimed it on open. The picker now reclaims focus to the number field on the next frame.

**`multi-value-input-field.tsx`**
- Both wrappers pass `useOrgBusinessCountry()`.
- Trigger chips are display-formatted, so a stored `+15102055536` now honors the field's own `phoneFormat` — matching `DisplayPhone` and the table cell, which already did.
- Local state syncs from `value`, keyed on **content** rather than identity (the provider derives it through `formatToRawValue`, which mints a fresh array). This is what brings the write-normalized form back into an open popover, and what visibly drops a value the server rejected and rolled back.
- The debounce callback nulls its own ref. It previously left a dead timer id there forever, which made `onBeforeClose` issue a redundant second commit (benign only because `hasValueChanged` no-ops it upstream) and would silently disable any future "is a save pending?" guard.

## Implementation notes

- `cmdk-input-wrapper=''` on the phone row is **load-bearing, not decoration**: `Command` rounds the list's top corners via `:not(:has([cmdk-input-wrapper]))`, which would fire under this square-cornered row without it.
- Deviation from plan: the plan called for an Add button beside the input. The existing "Add …" row is kept instead — consistent with EMAIL/URL, no new control, and it shows the *normalized, formatted* number before you commit.

## Tests

`multi-value-picker.test.tsx` 19, `multi-value-input-field.test.tsx` 8, full `pickers` + `fields` suites 171 — all passing. New coverage:
- US national → E.164; DE national under `defaultCountry='DE'` → `+4930901820`; the **same** string rejected under `'US'` (proves the country is wired, not just passed)
- an impossible-but-length-valid number stays blocked
- differently-formatted duplicate detected
- existing rows stay visible while typing
- EMAIL/URL still render a `CommandInput`, PHONE does not (scope boundary)
- focus lands in the number field, not the country button
- server-normalized list adopted into an open popover; a fired debounce does not block a later sync
- multi PHONE chips display-format per `phoneFormat`

## Verification

`apps/web` typecheck clean for the touched files; Biome clean. Focus behavior confirmed in the browser against real Radix.