### PR TITLE
fix(messages): write the thread participant rollup on outbound sends

### DIFF
--- a/packages/lib/src/messages/__tests__/message-composer.thread-participants.test.ts
+++ b/packages/lib/src/messages/__tests__/message-composer.thread-participants.test.ts
@@ -1,0 +1,155 @@
+// packages/lib/src/messages/__tests__/message-composer.thread-participants.test.ts
+//
+// The outbound `ThreadParticipant` rollup.
+//
+// The gap this closes: `ThreadManagerService.updateThreadParticipantCount` was
+// called `updateThreadParticipants`, so the send path LOOKED like it maintained
+// the rollup. It never did — it only wrote `Thread.participantCount`. An
+// outbound-first thread therefore had zero rollup rows until someone replied and
+// ingest wrote them, which made it invisible to contact-derived mail sharing
+// (`mail-query/visibility-scope.ts` joins `ThreadParticipant.entityInstanceId`).
+//
+// Assertions are on the ROWS handed to the insert, not on a call count: "we
+// called the rollup function" is exactly the kind of check that passed for the
+// count-only method while the table stayed empty.
+
+import { ParticipantRole } from '@auxx/database/enums'
+import { describe, expect, it, vi } from 'vitest'
+import { upsertOutboundThreadParticipants } from '../message-composer.service'
+import type { ProcessedParticipant, ProcessedParticipants } from '../types/message-sending.types'
+
+const AT = new Date('2026-08-15T05:15:53.000Z')
+
+function participant(
+  identifier: string,
+  role: (typeof ParticipantRole)[keyof typeof ParticipantRole],
+  extra: Partial<ProcessedParticipant> = {}
+): ProcessedParticipant {
+  return {
+    id: `p_${identifier}`,
+    identifier,
+    identifierType: 'EMAIL',
+    name: null,
+    role,
+    ...extra,
+  } as ProcessedParticipant
+}
+
+/** Captures the rows handed to `insert().values()`; `onConflictDoUpdate` resolves. */
+function makeTx() {
+  const captured: { rows: unknown[][] } = { rows: [] }
+  const tx = {
+    insert: () => ({
+      values: (rows: unknown[]) => {
+        captured.rows.push(rows)
+        return { onConflictDoUpdate: vi.fn(async () => undefined) }
+      },
+    }),
+  }
+  return { tx, captured }
+}
+
+const emails = (rows: unknown[]) => (rows as { email: string }[]).map((r) => r.email)
+
+describe('upsertOutboundThreadParticipants', () => {
+  it('writes a row for FROM, TO and CC', async () => {
+    const { tx, captured } = makeTx()
+    const participants: ProcessedParticipants = {
+      from: participant('agent@auxx.ai', ParticipantRole.FROM),
+      to: [participant('customer@example.com', ParticipantRole.TO)],
+      cc: [participant('cc@example.com', ParticipantRole.CC)],
+      all: [],
+    }
+
+    await upsertOutboundThreadParticipants(tx as never, 'th_1', participants, AT)
+
+    expect(captured.rows).toHaveLength(1)
+    expect(emails(captured.rows[0]!)).toEqual([
+      'agent@auxx.ai',
+      'customer@example.com',
+      'cc@example.com',
+    ])
+  })
+
+  it('EXCLUDES bcc — a rollup row is an access-granting fact', async () => {
+    // A ThreadParticipant row is what lets a contact grant reach this thread.
+    // Including a blind-copied recipient would hand that recipient's grantees the
+    // whole conversation, inverting what BCC means.
+    const { tx, captured } = makeTx()
+    const participants: ProcessedParticipants = {
+      from: participant('agent@auxx.ai', ParticipantRole.FROM),
+      to: [participant('customer@example.com', ParticipantRole.TO)],
+      bcc: [participant('secret@example.com', ParticipantRole.BCC)],
+      all: [],
+    }
+
+    await upsertOutboundThreadParticipants(tx as never, 'th_1', participants, AT)
+
+    expect(emails(captured.rows[0]!)).not.toContain('secret@example.com')
+    expect(emails(captured.rows[0]!)).toEqual(['agent@auxx.ai', 'customer@example.com'])
+  })
+
+  it('carries entityInstanceId and isInternal onto the row', async () => {
+    // entityInstanceId is the column contact-derived sharing joins on — a row
+    // without it grants nobody anything, so this is the load-bearing field.
+    const { tx, captured } = makeTx()
+    const participants: ProcessedParticipants = {
+      from: participant('agent@auxx.ai', ParticipantRole.FROM, { isInternal: true }),
+      to: [
+        participant('customer@example.com', ParticipantRole.TO, {
+          entityInstanceId: 'ei_contact_1',
+          name: 'Customer',
+        }),
+      ],
+      all: [],
+    }
+
+    await upsertOutboundThreadParticipants(tx as never, 'th_1', participants, AT)
+
+    expect(captured.rows[0]).toEqual([
+      expect.objectContaining({
+        threadId: 'th_1',
+        email: 'agent@auxx.ai',
+        isInternal: true,
+        entityInstanceId: null,
+        firstMessageAt: AT,
+        lastMessageAt: AT,
+        messageCount: 1,
+      }),
+      expect.objectContaining({
+        email: 'customer@example.com',
+        entityInstanceId: 'ei_contact_1',
+        name: 'Customer',
+        isInternal: false,
+      }),
+    ])
+  })
+
+  it('keys phone rows on the E.164 identifier, not an email', async () => {
+    // The column is named `email` but holds the routing identifier, and must match
+    // the key ingest writes or the unique index won't collapse the two sides.
+    const { tx, captured } = makeTx()
+    const participants: ProcessedParticipants = {
+      from: participant('+18889155797', ParticipantRole.FROM, { identifierType: 'PHONE' }),
+      to: [participant('+15102055536', ParticipantRole.TO, { identifierType: 'PHONE' })],
+      all: [],
+    }
+
+    await upsertOutboundThreadParticipants(tx as never, 'th_1', participants, AT)
+
+    expect(emails(captured.rows[0]!)).toEqual(['+18889155797', '+15102055536'])
+  })
+
+  it('skips participants with no identifier and inserts nothing when none remain', async () => {
+    const { tx, captured } = makeTx()
+    const participants = {
+      from: participant('', ParticipantRole.FROM),
+      to: [],
+      all: [],
+    } as unknown as ProcessedParticipants
+
+    await upsertOutboundThreadParticipants(tx as never, 'th_1', participants, AT)
+
+    expect(captured.rows).toHaveLength(0)
+  })
+})

--- a/packages/lib/src/messages/__tests__/message-sender.send-safety.test.ts
+++ b/packages/lib/src/messages/__tests__/message-sender.send-safety.test.ts
@@ -109,7 +109,7 @@ vi.mock('../thread-manager.service', () => ({
   ThreadManagerService: class {
     getOrCreateThreadForSending = mocks.getOrCreateThreadForSending
     updateThreadMetadata = vi.fn(async () => undefined)
-    updateThreadParticipants = vi.fn(async () => undefined)
+    updateThreadParticipantCount = vi.fn(async () => undefined)
     deletePendingThread = vi.fn(async () => undefined)
   },
 }))

--- a/packages/lib/src/messages/message-composer.service.ts
+++ b/packages/lib/src/messages/message-composer.service.ts
@@ -4,7 +4,7 @@ import { getAppHostname } from '@auxx/config/server'
 import { type Database, schema, type Transaction } from '@auxx/database'
 import { ParticipantRole, SendStatus } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import { convert as htmlToText } from 'html-to-text'
 import { type FileAttachment, MessageAttachmentService } from './message-attachment.service'
 import type { ComposedMessage, ProcessedParticipants } from './types/message-sending.types'
@@ -25,6 +25,68 @@ function outboundHtmlToText(html: string): string {
     preserveNewlines: true,
     selectors: [{ selector: 'img', format: 'skip' }],
   })
+}
+
+/**
+ * Upsert the thread-grained participant rollup for an outbound message, mirroring
+ * `ingest/store-message.ts`.
+ *
+ * Without this an outbound-first thread has NO `ThreadParticipant` rows until
+ * somebody replies. That matters because contact-derived mail sharing joins on
+ * `ThreadParticipant.entityInstanceId` (`mail-query/visibility-scope.ts`), so a
+ * thread you sent to a contact but that was never answered is invisible to
+ * everyone whose access comes from a grant on that contact — it would appear only
+ * once the customer replied and ingest wrote the rows.
+ *
+ * `ThreadManagerService.updateThreadParticipantCount` does not cover this: despite
+ * its former name (`updateThreadParticipants`) it only ever wrote
+ * `Thread.participantCount` and never touched this table. The name is why the gap
+ * went unnoticed.
+ *
+ * **BCC is deliberately excluded.** A rollup row is an access-granting fact — it is
+ * what lets a contact grant reach this thread — so including a blind-copied
+ * recipient would hand that recipient's grantees the entire conversation, which
+ * inverts what BCC means. Ingest never has to make this call: inbound mail carries
+ * no BCC.
+ */
+export async function upsertOutboundThreadParticipants(
+  tx: Transaction,
+  threadId: string,
+  participants: ProcessedParticipants,
+  at: Date
+): Promise<void> {
+  const rows = [participants.from, ...participants.to, ...(participants.cc ?? [])]
+    .filter((p) => !!p?.identifier)
+    .map((p) => ({
+      threadId,
+      // Column is named `email` but holds the routing identifier — an E.164 number
+      // on a phone channel. Same key ingest writes, so the unique index matches.
+      email: p.identifier,
+      name: p.name ?? null,
+      entityInstanceId: p.entityInstanceId ?? null,
+      isInternal: p.isInternal ?? false,
+      messageCount: 1,
+      // Outbound rows are written before the send lands, so `Message.sentAt` is
+      // still null here; `at` is this message's own timestamp.
+      firstMessageAt: at,
+      lastMessageAt: at,
+    }))
+  if (rows.length === 0) return
+
+  await tx
+    .insert(schema.ThreadParticipant)
+    .values(rows)
+    .onConflictDoUpdate({
+      target: [schema.ThreadParticipant.threadId, schema.ThreadParticipant.email],
+      set: {
+        messageCount: sql`${schema.ThreadParticipant.messageCount} + 1`,
+        firstMessageAt: sql`LEAST(${schema.ThreadParticipant.firstMessageAt}, excluded."firstMessageAt")`,
+        lastMessageAt: sql`GREATEST(${schema.ThreadParticipant.lastMessageAt}, excluded."lastMessageAt")`,
+        // Prefer a freshly resolved contact link / name; keep the old one otherwise.
+        entityInstanceId: sql`COALESCE(excluded."entityInstanceId", ${schema.ThreadParticipant.entityInstanceId})`,
+        name: sql`COALESCE(excluded."name", ${schema.ThreadParticipant.name})`,
+      },
+    })
 }
 
 /**
@@ -205,6 +267,8 @@ export class MessageComposerService {
       ]
 
       await tx.insert(schema.MessageParticipant).values(participantLinks).onConflictDoNothing()
+
+      await upsertOutboundThreadParticipants(tx, input.threadId, input.participants, now)
 
       // Update thread latestMessageId
       // All messages are now "real" messages - drafts are in separate Draft table
@@ -402,6 +466,8 @@ export class MessageComposerService {
 
       await tx.insert(schema.MessageParticipant).values(participantLinks).onConflictDoNothing()
 
+      await upsertOutboundThreadParticipants(tx, input.threadId, input.participants, now)
+
       return message
     })
 
@@ -549,6 +615,8 @@ export class MessageComposerService {
       ]
 
       await tx.insert(schema.MessageParticipant).values(participantLinks).onConflictDoNothing()
+
+      await upsertOutboundThreadParticipants(tx, input.threadId, input.participants, now)
 
       // Update thread latestMessageId
       // All messages are now "real" messages - drafts are in separate Draft table

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -397,7 +397,7 @@ export class MessageSenderService {
 
       // Step 8: Update thread metadata
       await this.threadManager.updateThreadMetadata(threadContext.id)
-      await this.threadManager.updateThreadParticipants(threadContext.id)
+      await this.threadManager.updateThreadParticipantCount(threadContext.id)
       // Outbound send is real activity on any linked entity (deal/ticket/lead).
       await touchActivityForThreadLinks(threadContext.id, this.organizationId)
       // Interaction stamp for Auxx-sent mail: this path never reaches ingest's
@@ -1552,7 +1552,7 @@ export class MessageSenderService {
     // retry that finally lands has to recompute them — otherwise the thread
     // keeps `lastMessageAt = NULL` and renders as "0 seconds" forever.
     await this.threadManager.updateThreadMetadata(threadId)
-    await this.threadManager.updateThreadParticipants(threadId)
+    await this.threadManager.updateThreadParticipantCount(threadId)
     await touchActivityForThreadLinks(threadId, this.organizationId)
     // Interaction stamp — same rationale as the first-send path: Auxx-sent mail
     // never reaches ingest's touch, and only a landed retry is correspondence.

--- a/packages/lib/src/messages/thread-manager.service.ts
+++ b/packages/lib/src/messages/thread-manager.service.ts
@@ -376,9 +376,17 @@ export class ThreadManagerService {
   }
 
   /**
-   * Updates thread participants
+   * Recount `Thread.participantCount` from the thread's `MessageParticipant` links.
+   *
+   * Counts only — it does NOT write the `ThreadParticipant` rollup, despite what
+   * its old name (`updateThreadParticipants`) implied. That name is why an
+   * outbound-first thread silently had no rollup rows for so long: the send path
+   * called this, it looked like the rollup was handled, and it never was. The
+   * rollup is written by `ingest/store-message.ts` inbound, `chat/session.ts` for
+   * visitors, thread merges, and `upsertOutboundThreadParticipants` on the
+   * outbound path.
    */
-  async updateThreadParticipants(threadId: string): Promise<void> {
+  async updateThreadParticipantCount(threadId: string): Promise<void> {
     const participants = await this.db
       .selectDistinct({ participantId: schema.MessageParticipant.participantId })
       .from(schema.MessageParticipant)

--- a/packages/lib/src/messages/types/message-sending.types.ts
+++ b/packages/lib/src/messages/types/message-sending.types.ts
@@ -106,6 +106,11 @@ export interface ProcessedParticipant {
    * suppression checks + the List-Unsubscribe token (MessageSenderService) don't need a
    * second lookup. */
   entityInstanceId?: string | null
+  /** Whether this identifier is one of the org's own (channel identity, org domain).
+   * Carried through from the raw `Participant` row for the same reason as
+   * `entityInstanceId` — the outbound `ThreadParticipant` rollup needs it and must not
+   * re-query. Recomputed on every participant upsert since #1655, so it is current. */
+  isInternal?: boolean
 }
 /**
  * Provider send response

--- a/packages/lib/src/threads/thread-mutation.service.ts
+++ b/packages/lib/src/threads/thread-mutation.service.ts
@@ -1414,9 +1414,13 @@ export class ThreadMutationService {
   }
 
   /**
-   * Updates thread participants after message operations
+   * Recount `Thread.participantCount` from the thread's message participants.
+   *
+   * Counts only — it does NOT write the `ThreadParticipant` rollup. Currently has
+   * no callers; `ThreadManagerService#updateThreadParticipantCount` is the one the
+   * send path uses and this duplicates it.
    */
-  async updateThreadParticipants(threadId: string): Promise<void> {
+  async updateThreadParticipantCount(threadId: string): Promise<void> {
     // Get messages and their participants for this thread
     // All messages are now "real" messages - drafts are in separate Draft table
     const messages = await this.db.query.Message.findMany({
@@ -1440,7 +1444,7 @@ export class ThreadMutationService {
     ]
 
     // `Thread.participantIds` was dropped in migration 0028 — only the count is
-    // a column. Matches `ThreadManagerService#updateThreadParticipants`.
+    // a column. Matches `ThreadManagerService#updateThreadParticipantCount`.
     await this.db
       .update(schema.Thread)
       .set({ participantCount: participantIds.length })


### PR DESCRIPTION
## The bug

A thread that **starts outbound** had no `ThreadParticipant` rows until somebody replied.

Contact-derived mail sharing joins on `ThreadParticipant.entityInstanceId` (`mail-query/visibility-scope.ts:74-89`):

```ts
exists(db.select({one: sql`1`}).from(ThreadParticipant).where(and(
  eq(ThreadParticipant.threadId, Thread.id),
  inArray(ThreadParticipant.entityInstanceId, contactIds))))
```

So a thread you sent to a contact **that was never answered** was invisible to everyone whose access came from a grant on that contact. It would appear only once the customer replied and ingest wrote the rows.

## Why nobody noticed: the name lied

`ThreadManagerService.updateThreadParticipants` is the only participant-related call the send path makes (`message-sender.service.ts:400`, `:1555`), so it read as though the rollup was handled. It never touched that table — it counts distinct `MessageParticipant` rows and writes `Thread.participantCount`.

Renamed to `updateThreadParticipantCount`.

## The fix

`upsertOutboundThreadParticipants` mirrors the ingest upsert (`ingest/store-message.ts`) and runs in the same transaction as the `MessageParticipant` insert, at all three message-creation paths in the composer (create pending, update existing draft, promote draft to pending).

**BCC is deliberately excluded.** A rollup row is an access-granting fact — it is what lets a contact grant reach the thread — so including a blind-copied recipient would hand that recipient's grantees the whole conversation, inverting what BCC means. Ingest never has to make this call: inbound mail carries no BCC.

`ProcessedParticipant.isInternal` is now declared. It was already spread onto the object at runtime by `processParticipants` (`{...participant, role}`) and merely missing from the type, so this is a type correction rather than new plumbing.

## Measured, not assumed

Before the fix, on the dev DB:

| | has rollup | no rollup |
|---|---|---|
| has inbound | 7,161 | 3 |
| outbound only | 853 | **29** |

32 of 8,046. The number is small for two reasons worth stating so nobody over-reads the severity: migration `032` backfilled all history, and ingest writes the rollup for the **whole envelope**, so the gap closes on the first reply. The exposure is threads created after the backfill that were never answered.

The 3 with inbound but no rollup are a **different bug** — those messages have zero `MessageParticipant` rows at all, so participant resolution produced nothing for them (all Gmail, one message each). Not addressed here.

## Also

`ThreadMutationService#updateThreadParticipants` was a count-only duplicate of the same logic with the same misleading name and **zero callers**. Renamed for consistency and left in place rather than deleted.

## Tests

Assert on the **rows handed to the insert**, not on a call count — "we called the rollup function" is exactly the check that would have passed for the count-only method while the table stayed empty. Covers FROM/TO/CC inclusion, BCC exclusion, `entityInstanceId`/`isInternal` carry-through, E.164 keying on phone channels (the `email` column holds the routing identifier and must match ingest's key or the unique index won't collapse the two sides), and the empty case.

`packages/lib` `src/` typechecks clean. Lib suite: **9239 passed, 0 failed**. Four pre-existing collection failures, all the identical `@auxx/redis` mock missing `createCredentialLockProvider`; this diff adds no redis or credential-lock usage, and they were independently confirmed failing at HEAD.

Closes the item recorded in §6 of `plans/participants/channel-identity-and-is-internal.md`.
