### PR TITLE
feat(mail-filters): channel-aware mail filters

### DIFF
--- a/apps/web/src/components/fields/inputs/field-input-adapter.tsx
+++ b/apps/web/src/components/fields/inputs/field-input-adapter.tsx
@@ -17,6 +17,7 @@ import { ActorPicker } from '~/components/pickers/actor-picker/actor-picker'
 import { ParticipantPicker } from '~/components/pickers/participant-picker'
 import { RecordEditorDialog } from '~/components/records/record-editor-dialog'
 import { MultiRelationInput } from '~/components/shared/multi-relation-input'
+import type { ParticipantIdentifierType } from '~/components/threads/store'
 import type { PickerTriggerOptions } from '~/components/ui/picker-trigger'
 import {
   AddressInput,
@@ -433,6 +434,7 @@ export function FieldInputAdapter({
             value={identifiers as string[]}
             onChange={onChange as (identifiers: string[]) => void}
             type={emailOpts.participantType}
+            identifierTypes={emailOpts.identifierTypes as ParticipantIdentifierType[] | undefined}
             multi={multi}
             placeholder={placeholder}
             disabled={disabled}

--- a/apps/web/src/components/mail-filters/hooks/use-authorable-inboxes.ts
+++ b/apps/web/src/components/mail-filters/hooks/use-authorable-inboxes.ts
@@ -19,6 +19,8 @@ export interface AuthorableInboxes {
   canAuthorAny: boolean
   /** True when this exact inbox (an EntityInstance id) is authorable. */
   canAuthor: (inboxId: string | null | undefined) => boolean
+  /** Display name of an authorable inbox, or undefined when it is not one. */
+  inboxName: (inboxId: string | null | undefined) => string | undefined
 }
 
 /**
@@ -38,11 +40,12 @@ export function useAuthorableInboxes(): AuthorableInboxes {
 
   return useMemo(() => {
     const inboxes = data ?? []
-    const ids = new Set(inboxes.map((inbox) => inbox.id))
+    const byId = new Map(inboxes.map((inbox) => [inbox.id, inbox]))
     return {
       inboxes,
       canAuthorAny: inboxes.length > 0,
-      canAuthor: (inboxId) => !!inboxId && ids.has(inboxId),
+      canAuthor: (inboxId) => !!inboxId && byId.has(inboxId),
+      inboxName: (inboxId) => (inboxId ? byId.get(inboxId)?.name : undefined),
     }
   }, [data])
 }

--- a/apps/web/src/components/mail-filters/hooks/use-inbox-identifier-types.ts
+++ b/apps/web/src/components/mail-filters/hooks/use-inbox-identifier-types.ts
@@ -1,0 +1,46 @@
+// apps/web/src/components/mail-filters/hooks/use-inbox-identifier-types.ts
+
+'use client'
+
+import { identifierTypeForProvider } from '@auxx/lib/channels/client'
+import { useMemo } from 'react'
+import { api } from '~/trpc/react'
+
+/** Channel lists move with connect/disconnect, not with typing. */
+const CHANNELS_STALE_TIME = 60_000
+
+/**
+ * The identifier types the channels attached to one inbox can produce —
+ * `['PHONE']` for the Quo inbox, `['EMAIL']` for Outlook, `['EMAIL','PHONE']`
+ * for a mixed one.
+ *
+ * An inbox is a UNION of channel types, never one type (plan 09 §2): dev alone
+ * has a "Shared Inbox" on `google` + `email` and a "Chat Support" on `chat` +
+ * `google`, and a channel can be attached after a filter is written. So this is
+ * recomputed per render from the live channel list and used only as a soft hint.
+ *
+ * **Fails open.** Returns an empty array while the query is loading, when the
+ * caller lacks the capability to read channels, and when the inbox genuinely has
+ * none — and every consumer reads an empty array as "do not narrow anything".
+ * Losing a suggestion is cheap; hiding a field the author needed is not.
+ *
+ * `provider` → `IdentifierType` goes through `identifierTypeForProvider`, the
+ * one declared map (a fourth hand-written provider switch is what left
+ * `openphone` out of the composer's From picker for months).
+ *
+ * @param inboxId Inbox EntityInstance id, or undefined before one is chosen.
+ */
+export function useInboxIdentifierTypes(inboxId?: string | null): string[] {
+  const { data } = api.channel.list.useQuery(undefined, { staleTime: CHANNELS_STALE_TIME })
+
+  return useMemo(() => {
+    if (!inboxId || !data) return []
+    const types = new Set<string>()
+    for (const channel of data.channels) {
+      if (channel.inboxId !== inboxId) continue
+      const type = identifierTypeForProvider(channel.provider)
+      if (type) types.add(type)
+    }
+    return [...types]
+  }, [data, inboxId])
+}

--- a/apps/web/src/components/mail-filters/ui/mail-filter-configure-page.tsx
+++ b/apps/web/src/components/mail-filters/ui/mail-filter-configure-page.tsx
@@ -22,6 +22,7 @@ import {
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { RuleActionsSummaryRow } from '~/components/rules/ui/rule-actions-summary-row'
+import { useInboxIdentifierTypes } from '../hooks/use-inbox-identifier-types'
 
 /** The provider drives groups here; the flat condition list stays empty. */
 const EMPTY_CONDITIONS: Condition[] = []
@@ -107,7 +108,30 @@ export function MailFilterConfigurePage({
   onCancel,
   statusBar,
 }: MailFilterConfigurePageProps) {
-  const fieldDefinitions = useMemo(() => getMailFilterFields(), [])
+  /**
+   * The catalog, scoped to what the SELECTED inbox's channels can produce
+   * (plan 09 §6). Recomputed on every inbox change — the combobox stays live
+   * after a prefill — and never persisted.
+   *
+   * Fails OPEN by construction: `useInboxIdentifierTypes` returns an empty set
+   * while `channel.list` is loading, when the caller may not read it, and when
+   * the inbox has no channels, and an empty set means "hide nothing". A hidden
+   * field is a convenience; a wrongly hidden one costs the author a condition
+   * they cannot re-add.
+   *
+   * Fields the CURRENT filter already has a condition on are kept regardless,
+   * or editing a filter written before a channel moved would silently drop
+   * conditions out of the editor.
+   */
+  const identifierTypes = useInboxIdentifierTypes(inboxId)
+  const usedFieldIds = useMemo(
+    () => groups.flatMap((group) => group.conditions.map((c) => String(c.fieldId))),
+    [groups]
+  )
+  const fieldDefinitions = useMemo(
+    () => getMailFilterFields(identifierTypes, usedFieldIds),
+    [identifierTypes, usedFieldIds]
+  )
 
   const conditionConfig: ConditionSystemConfig = useMemo(
     () => ({

--- a/apps/web/src/components/mail-filters/ui/thread-filter-entry.tsx
+++ b/apps/web/src/components/mail-filters/ui/thread-filter-entry.tsx
@@ -9,7 +9,7 @@ import { useMemo } from 'react'
 import { useThreadCounterparty } from '~/components/mail/hooks/use-thread-counterparty'
 import { useThread } from '~/components/threads/hooks'
 import { useAuthorableInboxes } from '../hooks/use-authorable-inboxes'
-import { buildThreadPrefillConditions, toConditionGroups } from '../utils/prefill-conditions'
+import { buildThreadPrefill, toConditionGroups } from '../utils/prefill-conditions'
 import { MailFilterPrefillDialog } from './mail-filter-prefill-dialog'
 
 /**
@@ -81,21 +81,31 @@ export function ThreadFilterPrefillDialog({ threadId, onClose }: ThreadFilterPre
   const { thread } = useThread({ threadId })
   const inboxInstanceId = useThreadInboxInstanceId(threadId)
   const counterparty = useThreadCounterparty(threadId)
+  const { inboxName } = useAuthorableInboxes()
 
-  const senderEmail = useMemo(() => {
-    const participant = counterparty.primary ?? counterparty.fallback
-    // Only an email identifier makes sense on `from`, which compiles to an
-    // `ilike` over `Participant.identifier`. A chat/social handle would build a
-    // condition that can never match an email thread.
-    const identifier = participant?.identifier
-    return identifier?.includes('@') ? identifier : null
-  }, [counterparty.primary, counterparty.fallback])
-
-  const groups = useMemo(
+  const prefill = useMemo(
     () =>
-      toConditionGroups(buildThreadPrefillConditions({ senderEmail, subject: thread?.subject })),
-    [senderEmail, thread?.subject]
+      buildThreadPrefill({
+        participant: counterparty.primary ?? counterparty.fallback,
+        subject: thread?.subject,
+        // Declared `ChannelProvider` ('GMAIL' | …) but carries the raw
+        // `IntegrationProviderType` value ('google', 'openphone') at runtime —
+        // `thread-query.service.ts` casts rather than maps. Every other reader
+        // of this field does the same widening.
+        integrationProvider: thread?.integrationProvider as string | null | undefined,
+        inboxName: inboxName(inboxInstanceId),
+      }),
+    [
+      counterparty.primary,
+      counterparty.fallback,
+      thread?.subject,
+      thread?.integrationProvider,
+      inboxName,
+      inboxInstanceId,
+    ]
   )
+
+  const groups = useMemo(() => toConditionGroups(prefill.conditions), [prefill.conditions])
 
   // The prefill is frozen when the dialog mounts, so wait for the participants
   // to resolve first — mounting early would permanently freeze a filter with no
@@ -105,8 +115,9 @@ export function ThreadFilterPrefillDialog({ threadId, onClose }: ThreadFilterPre
   return (
     <MailFilterPrefillDialog
       onClose={onClose}
-      name={senderEmail ? `Mail from ${senderEmail}` : undefined}
+      name={prefill.name}
       conditions={groups}
+      notes={prefill.notes}
       inboxId={inboxInstanceId ?? undefined}
     />
   )

--- a/apps/web/src/components/mail-filters/utils/prefill-conditions.test.ts
+++ b/apps/web/src/components/mail-filters/utils/prefill-conditions.test.ts
@@ -1,0 +1,98 @@
+// apps/web/src/components/mail-filters/utils/prefill-conditions.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { buildThreadPrefill } from './prefill-conditions'
+
+const EMAIL = { identifier: 'ada@acme.com', identifierType: 'EMAIL' as const }
+const PHONE = { identifier: '+15102055536', identifierType: 'PHONE' as const }
+
+const conditionOn = (result: ReturnType<typeof buildThreadPrefill>, fieldId: string) =>
+  result.conditions.find((c) => c.fieldId === fieldId)
+
+describe('buildThreadPrefill — the sender arm is chosen by identifierType', () => {
+  it('prefills an email sender', () => {
+    const result = buildThreadPrefill({ participant: EMAIL, integrationProvider: 'google' })
+
+    expect(conditionOn(result, 'from')).toMatchObject({ operator: 'is', value: 'ada@acme.com' })
+    expect(result.name).toBe('Mail from ada@acme.com')
+    expect(result.notes).toEqual([])
+  })
+
+  it('prefills a PHONE sender — the bug this replaced dropped it silently', () => {
+    // The old test was `identifier.includes('@')`, so every SMS thread opened
+    // the dialog with no sender condition and no name: the half the user came
+    // for. `from` has no type predicate, so `from is +1…` is a real filter.
+    const result = buildThreadPrefill({ participant: PHONE, integrationProvider: 'openphone' })
+
+    expect(conditionOn(result, 'from')).toMatchObject({ operator: 'is', value: '+15102055536' })
+    expect(result.notes).toEqual([])
+    expect(result.name).toMatch(/^Texts from /)
+    // Named in display format, filtered in E.164 — the value is the routing key.
+    expect(result.name).not.toBe('Texts from +15102055536')
+  })
+
+  for (const identifierType of ['FACEBOOK_PSID', 'INSTAGRAM_IGSID', 'CHAT_VISITOR'] as const) {
+    it(`prefills NO sender condition for ${identifierType}, and says why`, () => {
+      // Technically valid, practically useless: the id is opaque and per-app
+      // (per-session for chat), so a filter on it matches one conversation
+      // forever. Reported in the banner rather than dropped in silence.
+      const result = buildThreadPrefill({
+        participant: { identifier: 'psid_9912873', identifierType },
+        integrationProvider: 'facebook',
+        inboxName: 'Chat Support',
+      })
+
+      expect(conditionOn(result, 'from')).toBeUndefined()
+      expect(result.notes).toHaveLength(1)
+      expect(result.notes[0]).toMatch(/no sender condition/i)
+      expect(result.name).toBe('Conversations in Chat Support')
+    })
+  }
+
+  it('prefills nothing at all when the counterparty has not resolved', () => {
+    const result = buildThreadPrefill({ participant: null, integrationProvider: 'google' })
+
+    expect(result.conditions).toEqual([])
+    expect(result.name).toBeUndefined()
+    expect(result.notes).toEqual([])
+  })
+})
+
+describe('buildThreadPrefill — the subject arm is gated on the channel capability', () => {
+  it('adds `subject contains` on a channel that carries subjects', () => {
+    const result = buildThreadPrefill({
+      participant: EMAIL,
+      subject: 'Order #1024',
+      integrationProvider: 'google',
+    })
+
+    expect(conditionOn(result, 'subject')).toMatchObject({
+      operator: 'contains',
+      value: 'Order #1024',
+    })
+  })
+
+  it('skips it on a channel that does not — by decision, not by empty string', () => {
+    // SMS threads happen to store `subject = ''` today, which skipped this arm
+    // by accident. `PLATFORM_CAPABILITIES.subject` makes it deliberate, and
+    // keeps it right for a channel that has a subject we would not filter on.
+    const result = buildThreadPrefill({
+      participant: PHONE,
+      subject: 'Some carrier-supplied subject',
+      integrationProvider: 'openphone',
+    })
+
+    expect(conditionOn(result, 'subject')).toBeUndefined()
+    expect(conditionOn(result, 'from')).toBeDefined()
+  })
+
+  it('treats an unknown provider as subject-carrying', () => {
+    const result = buildThreadPrefill({
+      participant: EMAIL,
+      subject: 'Order #1024',
+      integrationProvider: null,
+    })
+
+    expect(conditionOn(result, 'subject')).toBeDefined()
+  })
+})

--- a/apps/web/src/components/mail-filters/utils/prefill-conditions.ts
+++ b/apps/web/src/components/mail-filters/utils/prefill-conditions.ts
@@ -6,6 +6,14 @@ import { MAIL_FILTER_EXCLUDED_FIELD_IDS } from '@auxx/lib/mail-filters/client'
 import { getInstanceId, isRecordId, type RecordId } from '@auxx/types/resource'
 import { generateId } from '@auxx/utils'
 import type { SearchCondition } from '~/components/searchbar/types'
+// The client-side mirror of `@auxx/lib/participants/client`'s union — there is
+// no client subpath for that module, and the lib barrel is server-only.
+import type { ParticipantIdentifierType } from '~/components/threads/store'
+import {
+  channelCarriesSubject,
+  formatParticipantIdentifier,
+  type ThreadTitleParticipant,
+} from '~/components/threads/utils/thread-title'
 
 /**
  * Building the `ConditionGroup[]` the mail-filter dialog opens with, from the
@@ -51,25 +59,90 @@ export function toConditionGroups(conditions: PrefillCondition[]): ConditionGrou
   ]
 }
 
+/** What the thread entry point prefilled, and anything it deliberately did not. */
+export interface ThreadPrefill {
+  conditions: PrefillCondition[]
+  /** Suggested filter name, or undefined to leave the field empty. */
+  name?: string
+  /** Same banner contract as {@link SearchConversion.notes}. */
+  notes: string[]
+}
+
 /**
- * Gmail's "Filter messages like this": sender exact, subject fuzzy.
+ * The counterparty slice the prefill reads.
  *
- * `from is <email>` and `subject contains <subject>` — both editable in the
+ * Structurally the same slice `formatParticipantIdentifier` takes, so a
+ * `ParticipantMeta` from the thread store passes straight through and the
+ * PHONE arm can reuse the shared display formatter.
+ */
+export type ThreadPrefillParticipant = ThreadTitleParticipant & {
+  identifierType: ParticipantIdentifierType
+}
+
+/**
+ * Gmail's "Filter messages like this": sender exact, subject fuzzy — on
+ * whichever channel the conversation actually arrived on.
+ *
+ * `from is <identifier>` and `subject contains <subject>`, both editable in the
  * dialog, which is the point of prefilling rather than creating. `contains` on
  * the subject is deliberate: an exact subject match would only ever fire on a
  * literal resend, while reply prefixes and ticket suffixes drift constantly.
+ *
+ * ## The sender arm is chosen by `identifierType`, never by shape
+ *
+ * This used to be `identifier.includes('@') ? identifier : null`, which silently
+ * dropped the sender condition — the half the user came for — on every
+ * non-email channel. `from` compiles to `ilike(Participant.identifier, …)` with
+ * no type predicate, so `from is +15102055536` is a perfectly good filter; the
+ * `@` test was a guess at a question the participant row answers exactly.
+ *
+ * `FACEBOOK_PSID` / `INSTAGRAM_IGSID` / `CHAT_VISITOR` are the exception, and
+ * they are REPORTED rather than silently dropped: a PSID is opaque and scoped to
+ * one app, and a chat-visitor id is per-session, so a filter on one is
+ * technically valid and practically matches exactly one conversation forever.
+ * The note says so, in the same banner `convertSearchConditions` uses.
+ *
+ * ## The subject arm is gated on the channel's capability
+ *
+ * SMS threads store `subject = ''`, so today the arm skips itself by accident.
+ * `channelCarriesSubject` makes it a decision — and keeps it correct for a
+ * channel that has a non-empty subject we still would not want to prefill on.
  */
-export function buildThreadPrefillConditions(input: {
-  senderEmail?: string | null
+export function buildThreadPrefill(input: {
+  participant?: ThreadPrefillParticipant | null
   subject?: string | null
-}): PrefillCondition[] {
+  /** `Thread.integrationProvider` — an `IntegrationProviderType` value. */
+  integrationProvider?: string | null
+  /** Inbox name, used to name a filter that has no sender condition. */
+  inboxName?: string | null
+}): ThreadPrefill {
   const conditions: PrefillCondition[] = []
-  const sender = input.senderEmail?.trim()
-  if (sender) conditions.push({ fieldId: 'from', operator: 'is' as Operator, value: sender })
+  const notes: string[] = []
+  let name: string | undefined
+
+  const identifier = input.participant?.identifier?.trim()
+  const identifierType = input.participant?.identifierType
+
+  if (identifier && identifierType === 'EMAIL') {
+    conditions.push({ fieldId: 'from', operator: 'is' as Operator, value: identifier })
+    name = `Mail from ${identifier}`
+  } else if (identifier && identifierType === 'PHONE') {
+    conditions.push({ fieldId: 'from', operator: 'is' as Operator, value: identifier })
+    name = `Texts from ${formatParticipantIdentifier(input.participant) ?? identifier}`
+  } else if (identifier) {
+    // FACEBOOK_PSID / INSTAGRAM_IGSID / CHAT_VISITOR — see the doc comment.
+    notes.push(
+      'No sender condition was added. This conversation’s sender is identified by an internal handle that is specific to one app — for live chat, to one visit — so a filter on it would match this conversation and nothing else. Add a condition below to describe the mail you want to catch.'
+    )
+    if (input.inboxName) name = `Conversations in ${input.inboxName}`
+  }
+
   const subject = input.subject?.trim()
-  if (subject)
+  if (subject && channelCarriesSubject(input.integrationProvider)) {
     conditions.push({ fieldId: 'subject', operator: 'contains' as Operator, value: subject })
-  return conditions
+  }
+
+  return { conditions, name, notes }
 }
 
 /** What a searchbar → filter conversion produced, and what it had to change. */

--- a/apps/web/src/components/participants/drawer/participant-drawer.tsx
+++ b/apps/web/src/components/participants/drawer/participant-drawer.tsx
@@ -15,6 +15,7 @@ import { ThreadVisitCard } from '~/components/drawers/cards/thread-visit-card'
 import { useDrawerContext } from '~/components/drawers/drawer-context'
 import { DockToggleButton } from '~/components/global/dock-toggle-button'
 import { useParticipant } from '~/components/threads/hooks'
+import type { ParticipantIdentifierType } from '~/components/threads/store'
 import { useEffectiveDockState } from '~/hooks/use-effective-dock-state'
 import { useDockStore } from '~/stores/dock-store'
 import { api } from '~/trpc/react'
@@ -152,12 +153,18 @@ function ParticipantCard({
 }: {
   displayName: string | null
   identifier: string | null
-  identifierType: 'EMAIL' | 'PHONE' | 'CHAT_VISITOR' | null
+  identifierType: ParticipantIdentifierType | null
   initials: string | null
   isLoading: boolean
 }) {
+  // Social handles share the chat icon: like a chat visitor, the identifier is
+  // an opaque platform id rather than an address a person would recognise.
   const IdentifierIcon =
-    identifierType === 'PHONE' ? Phone : identifierType === 'CHAT_VISITOR' ? MessageSquare : Mail
+    identifierType === 'PHONE'
+      ? Phone
+      : identifierType && identifierType !== 'EMAIL'
+        ? MessageSquare
+        : Mail
 
   return (
     <div className='flex gap-3 py-3 px-3 flex-row items-center justify-start border-b'>

--- a/apps/web/src/components/pickers/participant-picker.tsx
+++ b/apps/web/src/components/pickers/participant-picker.tsx
@@ -6,18 +6,29 @@ import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/pop
 import { cn } from '@auxx/ui/lib/utils'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { MultiSelectPicker } from '~/components/pickers/multi-select-picker'
+import type { ParticipantIdentifierType } from '~/components/threads/store'
 import { ItemsListView } from '~/components/ui/items-list-view'
 import { PickerTrigger, type PickerTriggerOptions } from '~/components/ui/picker-trigger'
 import { useDebouncedValue } from '~/hooks/use-debounced-value'
 import { api } from '~/trpc/react'
 
 export interface ParticipantPickerProps {
-  /** Currently selected email identifiers */
+  /** Currently selected identifiers — email, E.164 phone, or platform handle */
   value: string[]
   /** Callback when selection changes */
   onChange: (identifiers: string[]) => void
-  /** Filter participants by type */
+  /** Filter participants by role */
   type?: 'from' | 'to' | 'cc' | 'any'
+  /**
+   * Narrow the suggestions to these identifier types — the ones the surface's
+   * channels can actually produce, so a phone-only inbox does not suggest email
+   * addresses.
+   *
+   * A SOFT hint, never a gate: typed-in values still pass through `canAdd`,
+   * because an inbox's channel set is a union that changes after a filter is
+   * written (plan 09 D4). Omit for "every type".
+   */
+  identifierTypes?: ParticipantIdentifierType[]
   /** Allow multiple selections (default: true) */
   multi?: boolean
   /** Whether the input is disabled */
@@ -40,6 +51,7 @@ export function ParticipantPicker({
   value = [],
   onChange,
   type = 'any',
+  identifierTypes,
   multi = true,
   disabled = false,
   placeholder = 'Select participant...',
@@ -80,7 +92,10 @@ export function ParticipantPicker({
     data: participants = [],
     isLoading,
     isFetched,
-  } = api.search.participants.useQuery({ query: debouncedSearch, type }, { enabled: shouldFetch })
+  } = api.search.participants.useQuery(
+    { query: debouncedSearch, type, identifierTypes },
+    { enabled: shouldFetch }
+  )
 
   // Track queries that return 0 results to avoid redundant fetches
   useEffect(() => {
@@ -171,7 +186,7 @@ export function ParticipantPicker({
           canAdd={true}
           useValueAsLabel
           multi={multi}
-          placeholder='Search by name or email...'
+          placeholder='Search by name, email or number...'
           onSelectSingle={handleSelectSingle}
           disabled={disabled}
         />

--- a/apps/web/src/components/threads/store/participant-store.ts
+++ b/apps/web/src/components/threads/store/participant-store.ts
@@ -9,8 +9,19 @@ import { immer } from 'zustand/middleware/immer'
 const BATCH_DELAY = 50
 const MAX_BATCH_SIZE = 50
 
-/** Identifier type for participants */
-export type ParticipantIdentifierType = 'EMAIL' | 'PHONE' | 'CHAT_VISITOR'
+/**
+ * Identifier type for participants.
+ *
+ * Mirrors `@auxx/lib/participants/client`'s union, which mirrors the
+ * `IdentifierType` pg enum — all five members. See the note there: a short
+ * union here makes any exhaustive `switch` unsound on live rows.
+ */
+export type ParticipantIdentifierType =
+  | 'EMAIL'
+  | 'PHONE'
+  | 'FACEBOOK_PSID'
+  | 'INSTAGRAM_IGSID'
+  | 'CHAT_VISITOR'
 
 /**
  * ParticipantMeta - email/phone participant for display.

--- a/apps/web/src/server/api/routers/mail-filters.test.ts
+++ b/apps/web/src/server/api/routers/mail-filters.test.ts
@@ -347,8 +347,22 @@ const hoisted = vi.hoisted(() => {
     }
   })
 
+  /**
+   * Authoring-time phone normalisation (plan 09 §7).
+   *
+   * A pass-through that STAMPS its output, so these tests can prove the router
+   * hands the NORMALISED conditions to the compile gate, the write and the
+   * preview — never the raw input. The rewriting itself is
+   * `@auxx/lib`'s `normalize-conditions.test.ts`.
+   */
+  const normalizePhoneConditionValues = vi.fn((groups: unknown) => {
+    calls.push('normalizePhoneConditionValues')
+    return Array.isArray(groups) ? groups.map((g) => ({ ...g, normalized: true })) : groups
+  })
+
   const mailFilters = {
     ACTION_REQUIRING_AUTOMATION_KEY: ['run-agent', 'run-workflow'],
+    normalizePhoneConditionValues,
     MAX_PERSONAL_MAIL_FILTERS: 50,
     applyRetroactively,
     countBillableMailFilters,
@@ -1096,7 +1110,9 @@ describe('mailFilters router — conditions that do not compile', () => {
     ).rejects.toMatchObject(BAD_REQUEST)
 
     expect(lib.createMailFilter).not.toHaveBeenCalled()
-    expect(calls).toEqual(['assertFilterConditionsCompile'])
+    // Normalisation runs FIRST, so the gate judges the values that would be
+    // written rather than the ones that were typed.
+    expect(calls).toEqual(['normalizePhoneConditionValues', 'assertFilterConditionsCompile'])
   })
 
   it('names the offending field and operator, so the author can fix it', async () => {
@@ -1116,6 +1132,53 @@ describe('mailFilters router — conditions that do not compile', () => {
     ).rejects.toMatchObject(BAD_REQUEST)
 
     expect(lib.updateMailFilter).not.toHaveBeenCalled()
+  })
+
+  /**
+   * Plan 09 §7. A phone number typed `(510) 205-5536` compiles, saves, previews
+   * "0 matches" and then never fires — never-matching is not dropping, so
+   * neither the compile gate nor the fail-closed `AND false` sees it. The fix
+   * is to rewrite the value at authoring, which only works if every path that
+   * touches conditions uses the REWRITTEN set.
+   */
+  describe('authoring-time value normalisation', () => {
+    const writtenConditions = (mock: { mock: { calls: any[][] } }, argIndex: number) =>
+      mock.mock.calls[0]?.[argIndex]
+
+    it('writes the normalised conditions on create, not the raw input', async () => {
+      await caller().create({
+        inboxId: OWN_PERSONAL,
+        name: 'Texts from Ada',
+        conditions: COMPILABLE_CONDITIONS,
+        actions: ARCHIVE,
+      })
+
+      expect(hoisted.mailFilters.normalizePhoneConditionValues).toHaveBeenCalledWith(
+        COMPILABLE_CONDITIONS
+      )
+      expect(writtenConditions(lib.createMailFilter as any, 2).conditions).toEqual(
+        COMPILABLE_CONDITIONS.map((g) => ({ ...g, normalized: true }))
+      )
+    })
+
+    it('writes them on update too — an edit must not undo the rewrite', async () => {
+      await caller().update({ filterId: OWN_FILTER, conditions: COMPILABLE_CONDITIONS })
+
+      expect(writtenConditions(lib.updateMailFilter as any, 3).conditions).toEqual(
+        COMPILABLE_CONDITIONS.map((g) => ({ ...g, normalized: true }))
+      )
+    })
+
+    it('previews them, so the count matches what saving would produce', async () => {
+      await caller().previewMatchCount({
+        inboxId: OWN_PERSONAL,
+        conditions: COMPILABLE_CONDITIONS,
+      })
+
+      expect(writtenConditions(lib.previewMatchCount as any, 3)).toEqual(
+        COMPILABLE_CONDITIONS.map((g) => ({ ...g, normalized: true }))
+      )
+    })
   })
 
   it('accepts conditions that compile, on both write paths', async () => {

--- a/apps/web/src/server/api/routers/mail-filters.ts
+++ b/apps/web/src/server/api/routers/mail-filters.ts
@@ -19,6 +19,7 @@ import {
   loadBackfillableFilter,
   MAX_PERSONAL_MAIL_FILTERS,
   type MailFilterAction,
+  normalizePhoneConditionValues,
   previewMatchCount,
   reorderMailFilters,
   setMailFilterEnabled,
@@ -338,7 +339,14 @@ export const mailFiltersRouter = createTRPCRouter({
       const inbox = assertCanAuthorMailFilters(authority, input.inboxId)
       assertActionsAllowed(authority, input.actions)
       assertActionDestinationsAllowed(authority, input.actions as MailFilterAction[])
-      assertFilterConditionsCompile(input.conditions as ConditionGroup[], organizationId)
+      /**
+       * Normalise BEFORE the compile check and before the write, so the saved
+       * filter reads back exactly what it will match (plan 09 §7). A phone
+       * number typed `(510) 205-5536` compiles and saves fine and then never
+       * fires — never-matching is not dropping, so no guard here would catch it.
+       */
+      const conditions = normalizePhoneConditionValues(input.conditions as ConditionGroup[])
+      assertFilterConditionsCompile(conditions, organizationId)
 
       /**
        * Two ceilings, chosen by the target inbox's DEFINITION (§5.2).
@@ -371,7 +379,7 @@ export const mailFiltersRouter = createTRPCRouter({
         {
           inboxId: input.inboxId,
           name: input.name,
-          conditions: input.conditions as ConditionGroup[],
+          conditions,
           actions: input.actions as MailFilterAction[],
           stopProcessing: input.stopProcessing,
           enabled: input.enabled,
@@ -395,19 +403,25 @@ export const mailFiltersRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const organizationId = ctx.session.organizationId
       const authority = await loadMailFilterAuthority(ctx)
-      const { filterId, actions, conditions, ...rest } = input
+      const { filterId, actions, conditions: rawConditions, ...rest } = input
       await loadFilterForWrite(ctx.db, authority, organizationId, filterId)
       if (actions) {
         assertActionsAllowed(authority, actions)
         assertActionDestinationsAllowed(authority, actions as MailFilterAction[])
       }
+      // Same normalisation as `create` — an edit that re-saved the raw value
+      // would silently undo it (plan 09 §7).
+      const conditions =
+        rawConditions === undefined
+          ? undefined
+          : normalizePhoneConditionValues(rawConditions as ConditionGroup[])
       if (conditions !== undefined) {
-        assertFilterConditionsCompile(conditions as ConditionGroup[], organizationId)
+        assertFilterConditionsCompile(conditions, organizationId)
       }
 
       const result = await updateMailFilter(ctx.db, organizationId, filterId, {
         ...rest,
-        ...(conditions !== undefined && { conditions: conditions as ConditionGroup[] }),
+        ...(conditions !== undefined && { conditions }),
         ...(actions !== undefined && { actions: actions as MailFilterAction[] }),
       })
       if (result.isErr()) throw result.error
@@ -500,11 +514,14 @@ export const mailFiltersRouter = createTRPCRouter({
       assertCanAuthorMailFilters(authority, input.inboxId)
 
       const viewer = await getCachedUserInstanceGrants(ctx.session.userId, organizationId)
+      // Preview the conditions AS THEY WILL BE SAVED — `create`/`update`
+      // normalise phone values, so previewing the raw ones would show "0
+      // matches" for a filter that is about to match plenty (plan 09 §7).
       return previewMatchCount(
         ctx.db,
         organizationId,
         input.inboxId,
-        input.conditions as ConditionGroup[],
+        normalizePhoneConditionValues(input.conditions as ConditionGroup[]),
         viewer
       )
     }),

--- a/apps/web/src/server/api/routers/search.ts
+++ b/apps/web/src/server/api/routers/search.ts
@@ -1,5 +1,4 @@
 import { schema } from '@auxx/database'
-import { ParticipantRole } from '@auxx/database/enums'
 import { InboxService } from '@auxx/lib/inboxes'
 import { IsOperatorValue, SearchOperator } from '@auxx/lib/mail-query'
 import { listMembersWithUser } from '@auxx/lib/members'
@@ -380,29 +379,36 @@ export const searchRouter = createTRPCRouter({
     .input(
       z.object({
         query: z.string(),
+        /**
+         * Accepted and IGNORED. A `Participant` row has no role — role lives on
+         * `MessageParticipant`, per message — so "addresses that have ever been
+         * a FROM" would be a different query over a different table. This used
+         * to build a `roleFilter` object that was never referenced in the
+         * `where`; the parameter stays only because every caller passes it.
+         */
         type: z.enum(['from', 'to', 'cc', 'any']).optional(),
+        /**
+         * Narrow to these identifier types — how a phone-only surface stops
+         * suggesting email addresses. Omitted means every type.
+         */
+        identifierTypes: z
+          .array(z.enum(['EMAIL', 'PHONE', 'FACEBOOK_PSID', 'INSTAGRAM_IGSID', 'CHAT_VISITOR']))
+          .optional(),
       })
     )
     .query(async ({ input, ctx }) => {
       ctx.capabilities.assert(PermissionKey.inboxesView)
-      const { query, type } = input
+      const { query, identifierTypes } = input
       const organizationId = ctx.session.organizationId
-      // Build role filter based on type
-      let roleFilter = {}
-      if (type && type !== 'any') {
-        const roleMap = {
-          from: ParticipantRole.FROM,
-          to: ParticipantRole.TO,
-          cc: ParticipantRole.CC,
-        }
-        roleFilter = { role: roleMap[type] }
-      }
       const participants = await ctx.db
         .select()
         .from(schema.Participant)
         .where(
           and(
             eq(schema.Participant.organizationId, organizationId),
+            identifierTypes && identifierTypes.length > 0
+              ? inArray(schema.Participant.identifierType, identifierTypes)
+              : undefined,
             query
               ? or(
                   ilike(schema.Participant.identifier, `%${query}%`),

--- a/docs/channels-mail-architecture-guide.md
+++ b/docs/channels-mail-architecture-guide.md
@@ -189,10 +189,20 @@ and maps the `provider` string onto the concrete class.
 | Map | File | Who reads it |
 | --- | --- | --- |
 | `PROVIDER_CAPABILITIES` | `providers/provider-capabilities.ts` | **the runtime matrix** — `canSend`, `canDraft`, `canApplyLabel`, `labelScope`, `maxAttachmentSize`, rate limits, `supportsPersonalConnection`, `supportsBidirectionalStatusSync`, `requiresSendReconciliation`, `triggersPostSendSync`, `countsAgainstOutboundEmailsQuota` |
-| `PLATFORM_CAPABILITIES` | `channels/capabilities.ts` | **the coarse LLM-facing map** — `channel: email\|messaging`, `newOutbound`, `threadReply`, `subject`, `ccBcc`, `recipientModel` |
+| `PLATFORM_CAPABILITIES` | `channels/capabilities.ts` | **the coarse LLM-facing map** — `channel: email\|messaging`, `channelGroup`, `newOutbound`, `threadReply`, `subject`, `ccBcc`, `recipientModel`, `identifierType` |
 
 The second exists so the agent tool catalog can describe a channel in one stanza; it is
 deliberately *not* the gate for runtime behavior. Gate on `PROVIDER_CAPABILITIES`.
+
+Two per-provider values on it are **declared, not derived**, and both exist because a derivation
+was tried and lost information:
+
+- **`identifierType`** — the `IdentifierType` a channel's `Participant` rows are keyed by.
+  `facebook` and `instagram` are both `thread_only` yet key on different id spaces.
+- **`channelGroup`** — the coarse channel a person names in a rule (`email` / `sms` / `whatsapp` /
+  `facebook` / `instagram` / `chat`). It is what the `channelType` condition compiles through
+  (§14). `undefined` means "not a conversation channel" and keeps `shopify` out of every channel
+  option list.
 
 ### Sync mode resolution
 `providers/sync-mode-resolver.ts`. `polling`/`webhook` pass through; `auto` resolves per provider:
@@ -598,6 +608,28 @@ without that, a member could list a row whose every field then redacts.
   regconfig or a dropped `COALESCE` silently drops to a sequential scan.
 - **Mail views** (`mail-views/`) are saved `ConditionGroup[]` filters over threads, compiled by the
   same builder and evaluated against the viewer.
+- **The field catalog is channel-aware, and it is ONE catalog.** `MAIL_VIEW_FIELD_DEFINITIONS`
+  serves the searchbar, mail views *and* mail filters, because all three compile through the one
+  builder. Three rules follow:
+  - `from` / `to` / `sender` are **address** fields, not email fields. They compile to
+    `ilike(Participant.identifier, …)` with **no `identifierType` predicate**, so
+    `from is +15102055536` is as valid as `from is ada@acme.com`. Never split them per channel and
+    never re-introduce an `@`-shaped test — the participant row already answers the question.
+  - `channelType` is how a rule says "SMS" on a **mixed** inbox (an inbox is a union of channel
+    types, not one type). It compiles to `Thread.integrationId IN (SELECT id FROM Integration
+    WHERE provider IN …)` over a `channelGroup`'s providers, and **deliberately does not filter
+    `Integration.deletedAt`** — disconnect is a soft delete, and the threads that channel
+    delivered are still in the inbox. It is the one channel query in the codebase that must not
+    carry `isNull(Integration.deletedAt)`.
+  - Scoping the catalog to an inbox's channels (`getMailFilterFields(identifierTypes, keep)`) is a
+    **soft, recomputed hide** — never persisted on the row, never applied to a field an existing
+    filter already uses, and it fails open when the channel list is unavailable.
+- **Filter values are normalised at authoring, not at compile** (`mail-filters/normalize-conditions.ts`).
+  A phone number typed `(510) 205-5536` compiles, saves and previews cleanly and then never fires:
+  never-matching is not dropping, so neither `assertFilterConditionsCompile` nor the fail-closed
+  `AND false` sees it. Exact operators on address fields go through the shared `formatPhoneNumber`
+  (the same E.164 normaliser as `fieldValueSchemas.phone`); `contains` / `starts with` /
+  `ends with` are left verbatim, because `starts with +1510` is an area-code rule.
 - **Counts** (`threads/mail-counts.ts`) are delta-maintained, not queried: one Redis hash per
   `(org, user)` with fields `inbox` / `drafts` / `si:{inboxId}` / `view:{viewId}`; mutations apply
   atomic `HINCRBY` deltas; a lazily-enqueued reconcile recounts from Postgres every ~5 min and

--- a/docs/mail-suggestions-architecture-guide.md
+++ b/docs/mail-suggestions-architecture-guide.md
@@ -143,6 +143,22 @@ time either side gains a third prefix — and **the failure is silent**. A key t
 counts no mail, and "no mail since" is exactly what the product reports as *"the sender honored your
 unsubscribe."* Add a prefix in `mail-suggestions/client.ts`, never in the unsubscribe copy.
 
+### Email-only, by decision — there is no phone or chat analogue
+
+Both keyspace halves are derived from EMAIL headers, and both source columns are NULL on every SMS,
+chat and social message, so the miner simply never mines non-email traffic. **That is the intended
+behaviour, not an oversight to fix when phone volume grows:** `List-Id` has no SMS analogue, a
+sender domain has no meaning for an E.164 number, and the SMS equivalent of unsubscribe is STOP —
+carrier-handled inside the provider, never modelled here (§9).
+
+Stated because it currently reads as an emergent property of NULL columns rather than a choice: if
+a future channel does gain a stable bulk-sender identity, it needs its own prefix in
+`mail-suggestions/client.ts` and its own evidence shape — not a reinterpretation of `domain:`.
+
+Channel-awareness elsewhere in mail filters (polymorphic `from`/`to`/`sender`, the `channelType`
+condition, inbox-scoped catalogs) is documented in `channels-mail-architecture-guide.md` §14 and
+does **not** reach this miner.
+
 ### Why two columns, not one fused key
 
 `listId` and `senderDomain` stay two `Message` columns (S7 / invariant 8) because **the unsubscribe

--- a/packages/lib/src/channels/capabilities.ts
+++ b/packages/lib/src/channels/capabilities.ts
@@ -7,6 +7,28 @@ import type {
 } from '@auxx/database/types'
 
 /**
+ * The coarse channel a person would name in a rule — "when a new **SMS**
+ * arrives", "when a **Facebook** message arrives".
+ *
+ * Deliberately NOT the provider (`openphone`, `google`) and NOT derived from
+ * `channel` + `recipientModel`:
+ *
+ * - Providers are an implementation detail a filter should survive. `google`,
+ *   `outlook`, `imap` and `mailgun` are all just "Email" to the author, and a
+ *   second SMS provider beside `openphone` must not silently stop matching an
+ *   existing `channelType is sms` rule.
+ * - The derivation does not work: `facebook` and `instagram` are both
+ *   `messaging` + `thread_only`, so the pair is indistinguishable, and
+ *   `shopify` — a data-only integration that is not a channel at all — lands in
+ *   the same bucket.
+ *
+ * So it is declared per provider, here, in the ONE map (the same reasoning as
+ * `identifierType` below). `undefined` means "not a conversation channel" and
+ * keeps the provider out of every channel-type option list.
+ */
+export type ChannelGroup = 'email' | 'sms' | 'whatsapp' | 'facebook' | 'instagram' | 'chat'
+
+/**
  * Coarse, kopilot-facing capability map for an integration platform. This is
  * deliberately separate from `provider-capabilities.ts` (which is the detailed
  * runtime capability matrix) — the LLM only needs to know which channel each
@@ -15,6 +37,8 @@ import type {
  */
 export interface PlatformCapabilities {
   channel: 'email' | 'messaging'
+  /** Coarse, author-facing channel bucket. See {@link ChannelGroup}. */
+  channelGroup?: ChannelGroup
   /** Can a brand-new outbound conversation be started (no existing thread). */
   newOutbound: boolean
   /** Can the platform reply on an existing thread. */
@@ -105,6 +129,7 @@ export type ChannelSelectionScope = 'email' | 'addressable'
 export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, PlatformCapabilities> = {
   [IntegrationProviderType.google]: {
     channel: 'email',
+    channelGroup: 'email',
     newOutbound: true,
     threadReply: true,
     subject: true,
@@ -118,6 +143,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   },
   [IntegrationProviderType.outlook]: {
     channel: 'email',
+    channelGroup: 'email',
     newOutbound: true,
     threadReply: true,
     subject: true,
@@ -131,6 +157,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   },
   [IntegrationProviderType.email]: {
     channel: 'email',
+    channelGroup: 'email',
     newOutbound: true,
     threadReply: true,
     subject: true,
@@ -144,6 +171,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   },
   [IntegrationProviderType.imap]: {
     channel: 'email',
+    channelGroup: 'email',
     newOutbound: true,
     threadReply: true,
     subject: true,
@@ -157,6 +185,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   },
   [IntegrationProviderType.mailgun]: {
     channel: 'email',
+    channelGroup: 'email',
     newOutbound: true,
     threadReply: true,
     subject: true,
@@ -170,6 +199,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   },
   [IntegrationProviderType.facebook]: {
     channel: 'messaging',
+    channelGroup: 'facebook',
     newOutbound: false,
     threadReply: true,
     subject: false,
@@ -184,6 +214,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   },
   [IntegrationProviderType.instagram]: {
     channel: 'messaging',
+    channelGroup: 'instagram',
     newOutbound: false,
     threadReply: true,
     subject: false,
@@ -197,6 +228,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   },
   [IntegrationProviderType.sms]: {
     channel: 'messaging',
+    channelGroup: 'sms',
     newOutbound: true,
     threadReply: true,
     subject: false,
@@ -213,6 +245,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   },
   [IntegrationProviderType.openphone]: {
     channel: 'messaging',
+    channelGroup: 'sms',
     newOutbound: true,
     threadReply: true,
     subject: false,
@@ -238,6 +271,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   },
   [IntegrationProviderType.whatsapp]: {
     channel: 'messaging',
+    channelGroup: 'whatsapp',
     newOutbound: true,
     threadReply: true,
     subject: false,
@@ -252,6 +286,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   },
   [IntegrationProviderType.chat]: {
     channel: 'messaging',
+    channelGroup: 'chat',
     newOutbound: true,
     threadReply: true,
     subject: false,
@@ -278,6 +313,56 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
     recipientModel: 'thread_only',
     notes: 'data-only integration, not a messaging channel',
   },
+}
+
+/** Author-facing label for each {@link ChannelGroup}. */
+export const CHANNEL_GROUP_LABELS: Record<ChannelGroup, string> = {
+  email: 'Email',
+  sms: 'SMS',
+  whatsapp: 'WhatsApp',
+  facebook: 'Facebook',
+  instagram: 'Instagram',
+  chat: 'Live chat',
+}
+
+/**
+ * Every channel group, in catalog order, with its label — the option list for
+ * the `channelType` filter/view/search field.
+ *
+ * DERIVED from `PLATFORM_CAPABILITIES` rather than hand-written, so a new
+ * provider becomes filterable by declaring `channelGroup` and nothing else.
+ * Providers with no `channelGroup` (`shopify` — a data-only integration) never
+ * appear.
+ */
+export const CHANNEL_GROUP_OPTIONS: ReadonlyArray<{ value: ChannelGroup; label: string }> =
+  Object.keys(CHANNEL_GROUP_LABELS)
+    .filter((group) =>
+      Object.values(PLATFORM_CAPABILITIES).some((caps) => caps.channelGroup === group)
+    )
+    .map((group) => ({
+      value: group as ChannelGroup,
+      label: CHANNEL_GROUP_LABELS[group as ChannelGroup],
+    }))
+
+/**
+ * Every provider belonging to a channel group — the `Integration.provider`
+ * values a `channelType` condition compiles to.
+ *
+ * Unknown group names return an empty list, which callers must treat as
+ * "matches nothing" rather than "matches everything".
+ */
+export function providersForChannelGroup(group: string): IntegrationProviderTypeValue[] {
+  return (Object.keys(PLATFORM_CAPABILITIES) as IntegrationProviderTypeValue[]).filter(
+    (provider) => PLATFORM_CAPABILITIES[provider].channelGroup === group
+  )
+}
+
+/** The coarse channel group a provider belongs to; `undefined` when it is not a channel. */
+export function channelGroupForProvider(
+  provider: string | null | undefined
+): ChannelGroup | undefined {
+  if (!provider) return undefined
+  return PLATFORM_CAPABILITIES[provider as IntegrationProviderTypeValue]?.channelGroup
 }
 
 /** Plucks the composer-facing subset for one provider. `undefined` for an unknown provider. */

--- a/packages/lib/src/channels/client.ts
+++ b/packages/lib/src/channels/client.ts
@@ -5,11 +5,16 @@
 // in client components that only need static capability metadata.
 
 export {
+  CHANNEL_GROUP_LABELS,
+  CHANNEL_GROUP_OPTIONS,
+  type ChannelGroup,
   type ChannelSelectionScope,
   type ComposerCapabilities,
   canStartOutbound,
+  channelGroupForProvider,
   getComposerCapabilities,
   identifierTypeForProvider,
   PLATFORM_CAPABILITIES,
   type PlatformCapabilities,
+  providersForChannelGroup,
 } from './capabilities'

--- a/packages/lib/src/custom-fields/field-options.ts
+++ b/packages/lib/src/custom-fields/field-options.ts
@@ -171,6 +171,14 @@ export interface FieldOptions {
 export interface EmailFieldOptions {
   /** Filter participants by type (from/to/cc/any) */
   participantType?: 'from' | 'to' | 'cc' | 'any'
+  /**
+   * Narrow the participant typeahead to these `IdentifierType` values.
+   *
+   * A SOFT hint the surface recomputes (a phone-only inbox should not suggest
+   * email addresses); typed-in values are still accepted, because an inbox's
+   * channel set is a union that can grow after the filter is written.
+   */
+  identifierTypes?: string[]
 }
 
 /**

--- a/packages/lib/src/mail-filters/client.test.ts
+++ b/packages/lib/src/mail-filters/client.test.ts
@@ -1,0 +1,69 @@
+// packages/lib/src/mail-filters/client.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { getMailFilterFields, MAIL_FILTER_EXCLUDED_FIELD_IDS } from './client'
+
+const idsOf = (...args: Parameters<typeof getMailFilterFields>) =>
+  getMailFilterFields(...args).map((f) => f.id)
+
+describe('getMailFilterFields — the unscoped catalog', () => {
+  it('drops exactly the fields a filter must not offer', () => {
+    for (const excluded of MAIL_FILTER_EXCLUDED_FIELD_IDS) {
+      expect(idsOf()).not.toContain(excluded)
+    }
+    expect(idsOf()).toContain('from')
+    expect(idsOf()).toContain('channelType')
+  })
+
+  it('is the fallback whenever the channel set is unknown — hiding nothing', () => {
+    // Loading, or a caller without the capability to read channels. A hidden
+    // field costs the author a condition they cannot re-add; a shown one that
+    // can never match costs nothing.
+    expect(idsOf(undefined)).toEqual(idsOf())
+    expect(idsOf([])).toEqual(idsOf())
+  })
+})
+
+describe('getMailFilterFields — soft scoping to an inbox', () => {
+  it('hides the email-only fields on a phone-only inbox', () => {
+    const ids = idsOf(['PHONE'])
+
+    expect(ids).not.toContain('list')
+    expect(ids).not.toContain('senderDomain')
+    expect(ids).not.toContain('hasAttachments')
+  })
+
+  it('keeps `subject` there — empty is not the same as meaningless', () => {
+    // SMS threads store `subject = ''`, and `subject is empty` is a legitimate
+    // predicate over that.
+    expect(idsOf(['PHONE'])).toContain('subject')
+  })
+
+  it('hides nothing on a MIXED inbox — an inbox is a union of channel types', () => {
+    expect(idsOf(['PHONE', 'EMAIL'])).toEqual(idsOf())
+  })
+
+  it('keeps a hidden field that the filter being edited already uses', () => {
+    // Otherwise opening an existing filter would silently drop conditions out
+    // of the editor — and saving would then delete them.
+    const ids = idsOf(['PHONE'], ['senderDomain'])
+
+    expect(ids).toContain('senderDomain')
+    expect(ids).not.toContain('list')
+  })
+
+  it('narrows the participant typeahead on the address fields', () => {
+    const from = getMailFilterFields(['PHONE']).find((f) => f.id === 'from')
+
+    expect(from?.options?.email?.identifierTypes).toEqual(['PHONE'])
+    // The participant role is untouched by scoping.
+    expect(from?.options?.email?.participantType).toBe('from')
+  })
+
+  it('never mutates the shared catalog', () => {
+    getMailFilterFields(['PHONE'])
+    expect(getMailFilterFields().find((f) => f.id === 'from')?.options?.email).toEqual({
+      participantType: 'from',
+    })
+  })
+})

--- a/packages/lib/src/mail-filters/client.ts
+++ b/packages/lib/src/mail-filters/client.ts
@@ -59,16 +59,66 @@ export const MAIL_FILTER_EXCLUDED_FIELD_IDS: readonly string[] = [
 ]
 
 /**
- * The condition-editor field catalog for a mail filter.
+ * Fields that only an EMAIL channel can ever populate.
+ *
+ * `Message.listId` and `Message.senderDomain` are derived at ingest from
+ * headers no other channel has, and Quo declares `attachments: false`, so on a
+ * phone-only inbox all three are dead rows in the editor rather than filters.
+ *
+ * `subject` is deliberately NOT here: it is empty on SMS, not meaningless, and
+ * `subject is empty` is a legitimate predicate.
+ */
+const EMAIL_ONLY_FIELD_IDS: readonly string[] = ['list', 'senderDomain', 'hasAttachments']
+
+/**
+ * The condition-editor field catalog for a mail filter, optionally scoped to
+ * what the target inbox's channels can actually produce.
  *
  * DERIVED from {@link MAIL_VIEW_FIELD_DEFINITIONS} rather than duplicated: the
  * searchbar, mail views and filters must share one condition language, because
  * they share one evaluator (`mail-query/condition-query-builder.ts`, invariant
  * 5). Adding a field there — `category` in the AI phase, say — makes it
  * filterable here for free; re-declaring the catalog would fork it.
+ *
+ * ## Scoping is SOFT, and recomputed — never persisted (plan 09 D4)
+ *
+ * An inbox is a union of channel types, not one type, and a channel can be
+ * attached to it AFTER a filter is written. So this is a hint derived from the
+ * currently selected inbox at render time; it never reaches the saved
+ * `MailFilter` row, and callers must keep showing a field that an existing
+ * filter already has a condition on (`keepFieldIds`) or editing that filter
+ * would silently drop conditions out of the editor.
+ *
+ * @param identifierTypes Identifier types present on the inbox's channels.
+ *   Omit (or pass an empty list) for the unscoped catalog — the correct
+ *   fallback whenever the channel list has not loaded or the caller may not
+ *   read it, because hiding nothing is the failure mode that loses no work.
+ * @param keepFieldIds Field ids to show regardless of scoping.
  */
-export function getMailFilterFields(): MailViewFieldDefinition[] {
-  return MAIL_VIEW_FIELD_DEFINITIONS.filter((f) => !MAIL_FILTER_EXCLUDED_FIELD_IDS.includes(f.id))
+export function getMailFilterFields(
+  identifierTypes?: readonly string[],
+  keepFieldIds: readonly string[] = []
+): MailViewFieldDefinition[] {
+  const fields = MAIL_VIEW_FIELD_DEFINITIONS.filter(
+    (f) => !MAIL_FILTER_EXCLUDED_FIELD_IDS.includes(f.id)
+  )
+  if (!identifierTypes || identifierTypes.length === 0) return fields
+
+  const hasEmail = identifierTypes.includes('EMAIL')
+  const kept = new Set(keepFieldIds)
+  return fields
+    .filter((f) => hasEmail || kept.has(f.id) || !EMAIL_ONLY_FIELD_IDS.includes(f.id))
+    .map((f) =>
+      f.options?.email
+        ? {
+            ...f,
+            options: {
+              ...f.options,
+              email: { ...f.options.email, identifierTypes: [...identifierTypes] },
+            },
+          }
+        : f
+    )
 }
 
 /** Look up one filterable field by id; undefined when it is excluded or unknown. */

--- a/packages/lib/src/mail-filters/index.ts
+++ b/packages/lib/src/mail-filters/index.ts
@@ -50,6 +50,8 @@ export {
   type UpdateMailFilterInput,
   updateMailFilter,
 } from './mutations'
+// Authoring-time value normalisation (plan 09 §7)
+export { normalizePhoneConditionValues } from './normalize-conditions'
 // Reads
 export {
   getMailFilterById,

--- a/packages/lib/src/mail-filters/normalize-conditions.test.ts
+++ b/packages/lib/src/mail-filters/normalize-conditions.test.ts
@@ -1,0 +1,121 @@
+// packages/lib/src/mail-filters/normalize-conditions.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { ConditionGroup } from '../conditions/types'
+import { normalizePhoneConditionValues } from './normalize-conditions'
+
+function groups(
+  fieldId: string,
+  operator: string,
+  value: unknown,
+  second?: { fieldId: string; operator: string; value: unknown }
+): ConditionGroup[] {
+  return [
+    {
+      id: 'g1',
+      logicalOperator: 'AND',
+      conditions: [
+        { id: 'c1', fieldId, operator: operator as never, value },
+        ...(second
+          ? [
+              {
+                id: 'c2',
+                fieldId: second.fieldId,
+                operator: second.operator as never,
+                value: second.value,
+              },
+            ]
+          : []),
+      ],
+    },
+  ]
+}
+
+const firstValue = (result: ConditionGroup[]) => result[0]?.conditions[0]?.value
+
+describe('normalizePhoneConditionValues', () => {
+  it('rewrites a national-format number to E.164 on an exact operator', () => {
+    // The whole point: ingest stores `+15102055536`, so the raw typed value
+    // saves fine, previews 0 and never fires — with nothing in the logs.
+    expect(firstValue(normalizePhoneConditionValues(groups('from', 'is', '(510) 205-5536')))).toBe(
+      '+15102055536'
+    )
+  })
+
+  it('normalizes on every exact operator and every address field', () => {
+    for (const fieldId of ['from', 'to', 'sender']) {
+      for (const operator of ['is', 'is not', 'in', 'not in']) {
+        expect(
+          firstValue(normalizePhoneConditionValues(groups(fieldId, operator, '510-205-5536'))),
+          `${fieldId} ${operator}`
+        ).toBe('+15102055536')
+      }
+    }
+  })
+
+  it('leaves an already-normalized number untouched', () => {
+    expect(firstValue(normalizePhoneConditionValues(groups('from', 'is', '+15102055536')))).toBe(
+      '+15102055536'
+    )
+  })
+
+  it('keeps an international number in its own country code', () => {
+    expect(firstValue(normalizePhoneConditionValues(groups('to', 'is', '+49 30 901820')))).toBe(
+      '+4930901820'
+    )
+  })
+
+  it('leaves FRAGMENT operators verbatim — `starts with +1510` is an area-code rule', () => {
+    for (const operator of ['contains', 'not contains', 'starts with', 'ends with']) {
+      expect(
+        firstValue(normalizePhoneConditionValues(groups('from', operator, '+1510'))),
+        operator
+      ).toBe('+1510')
+    }
+  })
+
+  it('leaves email addresses and opaque handles alone', () => {
+    expect(firstValue(normalizePhoneConditionValues(groups('from', 'is', 'ada@acme.com')))).toBe(
+      'ada@acme.com'
+    )
+    expect(firstValue(normalizePhoneConditionValues(groups('from', 'is', '61540983712345')))).toBe(
+      '61540983712345'
+    )
+  })
+
+  it('leaves non-address fields alone even when the value looks like a number', () => {
+    expect(
+      firstValue(normalizePhoneConditionValues(groups('subject', 'is', '(510) 205-5536')))
+    ).toBe('(510) 205-5536')
+  })
+
+  it('normalizes each member of a multi-value condition independently', () => {
+    const result = normalizePhoneConditionValues(
+      groups('from', 'in', ['(510) 205-5536', 'ada@acme.com', '+4930901820'])
+    )
+    expect(firstValue(result)).toEqual(['+15102055536', 'ada@acme.com', '+4930901820'])
+  })
+
+  it('leaves every other condition in the group untouched', () => {
+    const result = normalizePhoneConditionValues(
+      groups('from', 'is', '(510) 205-5536', {
+        fieldId: 'subject',
+        operator: 'contains',
+        value: 'invoice',
+      })
+    )
+    expect(result[0]?.conditions[1]).toEqual({
+      id: 'c2',
+      fieldId: 'subject',
+      operator: 'contains',
+      value: 'invoice',
+    })
+  })
+
+  it('does not mutate the input', () => {
+    const input = groups('from', 'is', '(510) 205-5536')
+    const before = JSON.stringify(input)
+    normalizePhoneConditionValues(input)
+    expect(JSON.stringify(input)).toBe(before)
+  })
+})

--- a/packages/lib/src/mail-filters/normalize-conditions.ts
+++ b/packages/lib/src/mail-filters/normalize-conditions.ts
@@ -1,0 +1,91 @@
+// packages/lib/src/mail-filters/normalize-conditions.ts
+
+import { formatPhoneNumber } from '@auxx/utils/contact'
+import type { Condition, ConditionGroup } from '../conditions/types'
+
+/**
+ * The address fields whose values are `Participant.identifier` — the only ones
+ * a phone number can be written into.
+ */
+const ADDRESS_FIELD_IDS = new Set(['from', 'to', 'sender'])
+
+/**
+ * Operators that compare a WHOLE identifier.
+ *
+ * Only these are normalized. `contains` / `starts with` / `ends with` compare a
+ * FRAGMENT, and E.164 normalisation would destroy the fragment: "starts with
+ * `+1510`" is a legitimate area-code rule, and `formatPhoneNumber('+1510')`
+ * is `null` anyway (it is not a valid number). Leaving them verbatim is the
+ * whole reason this is a per-operator decision rather than a blanket one.
+ */
+const EXACT_OPERATORS = new Set(['is', 'is not', 'in', 'not in'])
+
+/**
+ * Rewrite phone values on address conditions into E.164, at AUTHORING time.
+ *
+ * ## Why this exists
+ *
+ * Ingest stores phone identifiers in E.164 (`+15102055536`). A human typing
+ * `(510) 205-5536` into a filter condition produces a value that compiles
+ * cleanly, saves cleanly, previews "0 matches" and then never fires — with
+ * nothing in the logs, because nothing was dropped. `assertFilterConditionsCompile`
+ * and the fail-closed `AND false` both catch UNDISPATCHABLE conditions, not
+ * NEVER-MATCHING ones, so neither guard sees this. It is the defect most likely
+ * to reach a user as "filters are broken".
+ *
+ * ## Why at authoring rather than at compile
+ *
+ * So the saved filter reads back exactly what it will match. Normalising inside
+ * the query builder would leave the editor showing `(510) 205-5536` while the
+ * engine matched something else — the same class of silent divergence, just
+ * moved. It also keeps the fire path, the preview count and the retroactive
+ * backfill compiling the identical string, which is what makes all three agree.
+ *
+ * ## Why `formatPhoneNumber`
+ *
+ * It is THE shared E.164 normaliser — `fieldValueSchemas.phone` (the write path
+ * for every `PHONE_INTL` field value) and `normalizeForLookup` (the read-side
+ * lookup key) both go through it, and `field-values/__tests__/phone-e164.test.ts`
+ * pins the pair in lockstep. A second parse here is how the ingest normaliser
+ * (`ingest/participants/normalize.ts`, digit-strip only, never adds a country
+ * code) and this one would drift.
+ *
+ * It returns `null` for anything that is not a valid phone number, which is
+ * exactly the test for "is this value a phone number at all" — an email address
+ * or a Facebook PSID falls through untouched. Its default region is `US`, so a
+ * national-format number is read as a US one; an international number must be
+ * written with its `+` prefix either way.
+ *
+ * Pure: returns a new tree and never mutates the input.
+ */
+export function normalizePhoneConditionValues(groups: ConditionGroup[]): ConditionGroup[] {
+  return groups.map((group) => ({
+    ...group,
+    conditions: group.conditions.map(normalizeCondition),
+  }))
+}
+
+function normalizeCondition(condition: Condition): Condition {
+  if (typeof condition.fieldId !== 'string' || !ADDRESS_FIELD_IDS.has(condition.fieldId)) {
+    return condition
+  }
+  if (!EXACT_OPERATORS.has(condition.operator)) return condition
+
+  if (Array.isArray(condition.value)) {
+    const values = condition.value.map(normalizeValue)
+    return values.some((v, i) => v !== condition.value[i])
+      ? { ...condition, value: values }
+      : condition
+  }
+
+  const normalized = normalizeValue(condition.value)
+  return normalized === condition.value ? condition : { ...condition, value: normalized }
+}
+
+/** E.164 if the value parses as a phone number; the original value otherwise. */
+function normalizeValue(value: unknown): unknown {
+  if (typeof value !== 'string') return value
+  const trimmed = value.trim()
+  if (trimmed === '' || trimmed.includes('@')) return value
+  return formatPhoneNumber(trimmed) ?? value
+}

--- a/packages/lib/src/mail-filters/seed-suggested-filters.test.ts
+++ b/packages/lib/src/mail-filters/seed-suggested-filters.test.ts
@@ -89,8 +89,10 @@ function caseLabelsOf(fnName: string): Set<string> {
 
 /** `fieldId` → the field builder `dispatchConditionQuery` routes it to. */
 const FIELD_BUILDERS: Record<string, string> = {
-  // `buildFromQuery` is a one-line delegation to `buildSenderQuery`, which owns the cases.
-  from: 'buildSenderQuery',
+  // `buildFromQuery` delegates to `buildSenderQuery`, which delegates in turn to the
+  // shared `buildParticipantIdentifierQuery` (it serves `to` as well, with a different
+  // role predicate) — that is where the operator cases live.
+  from: 'buildParticipantIdentifierQuery',
   subject: 'buildSubjectQuery',
   // `buildListQuery` is likewise a one-line delegation — the operator cases live in the
   // shared `buildMessageTextColumnQuery` it hands `Message.listId` to.

--- a/packages/lib/src/mail-query/__tests__/condition-query-builder.test.ts
+++ b/packages/lib/src/mail-query/__tests__/condition-query-builder.test.ts
@@ -613,3 +613,181 @@ describe('list / senderDomain — operator semantics', () => {
     expect(byDomain.sqlText).not.toBe(baseScopeSql())
   })
 })
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 🔴 The SAME parity rule, on the address fields. These are the ones the mail
+// searchbar, mail views and mail filters all put in front of a user first, and
+// they were the ones missing four of the ten operators `FieldType.EMAIL`
+// offers: `starts with`, `ends with`, `in` and `not in` had no case, so
+// `from starts with +1510` — an area-code rule, the archetypal phone filter —
+// was rejected outright at save (`assertFilterConditionsCompile` throws on ANY
+// dropped condition) and fails closed on rows that predate the gate.
+// ═══════════════════════════════════════════════════════════════════════════
+
+const ADDRESS_FIELDS = ['sender', 'from', 'to'] as const
+
+/** A value shaped the way the editor would submit it for an address field. */
+function sampleAddress(operator: OperatorDefinition): unknown {
+  if (operator.valueType === 'none') return undefined
+  if (operator.valueType === 'multiple') return ['ada@acme.com', '+15102055536']
+  return 'ada@acme.com'
+}
+
+describe('sender / from / to — the offered operator set is exactly the handled one', () => {
+  it('offers the full FieldType.EMAIL string set on all three fields', () => {
+    const expected = [
+      'is',
+      'is not',
+      'contains',
+      'not contains',
+      'starts with',
+      'ends with',
+      'in',
+      'not in',
+      'empty',
+      'not empty',
+    ]
+
+    for (const fieldId of ADDRESS_FIELDS) {
+      expect(offeredOperators(fieldId).map((op) => op.key)).toEqual(expected)
+    }
+  })
+
+  for (const fieldId of ADDRESS_FIELDS) {
+    it(`compiles every operator \`${fieldId}\` offers — nothing dropped`, () => {
+      const operators = offeredOperators(fieldId)
+      expect(operators.length).toBeGreaterThan(0)
+
+      for (const operator of operators) {
+        const result = buildOne(fieldId, operator.key, sampleAddress(operator))
+
+        expect({ operator: operator.key, dropped: result.droppedConditions }).toEqual({
+          operator: operator.key,
+          dropped: [],
+        })
+        expect(result.allConditionsDropped).toBe(false)
+        expect(toSql(result.sql)).not.toBe(baseScopeSql())
+      }
+    })
+  }
+
+  it('anchors `starts with` / `ends with` on the right side', () => {
+    expect(toParams(buildWithSubquery('from', 'starts with', '+1510').where)).toContain('+1510%')
+    expect(toParams(buildWithSubquery('from', 'ends with', '@acme.com').where)).toContain(
+      '%@acme.com'
+    )
+  })
+
+  it('treats `in` as the set form of `is`, and `not in` as its negation', () => {
+    const isMany = buildWithSubquery('from', 'is', ['ada@acme.com', '+15102055536'])
+    const inMany = buildWithSubquery('from', 'in', ['ada@acme.com', '+15102055536'])
+    const notIn = buildWithSubquery('from', 'not in', ['ada@acme.com', '+15102055536'])
+
+    expect(toSql(inMany.where)).toBe(toSql(isMany.where))
+    expect(toSql(notIn.where)).toBe(toSql(isMany.where))
+    expect(notIn.sqlText).toMatch(/\bnot exists \$\d+/)
+  })
+})
+
+describe('sender / from / to — channel-agnostic by construction', () => {
+  // The load-bearing claim of the channel-aware plan: `Participant.identifier`
+  // is polymorphic and the builder never tests `identifierType`, so ONE `from`
+  // field serves email, SMS, chat and social alike.
+  it('compiles a phone number exactly like an email address', () => {
+    const byPhone = buildWithSubquery('from', 'is', '+15102055536')
+    const byEmail = buildWithSubquery('from', 'is', 'ada@acme.com')
+
+    expect(byPhone.result.droppedConditions).toEqual([])
+    expect(toSql(byPhone.where)).toBe(toSql(byEmail.where))
+    expect(toParams(byPhone.where)).toContain('+15102055536')
+  })
+
+  it('never constrains `Participant.identifierType`', () => {
+    // Asserted on the bound PARAMETERS, not the rendered column names: under
+    // Vitest the schema columns render empty (`src/test/setup.ts` mocks the
+    // query builder), so a regex over the SQL text would pass vacuously.
+    const IDENTIFIER_TYPES = ['EMAIL', 'PHONE', 'FACEBOOK_PSID', 'INSTAGRAM_IGSID', 'CHAT_VISITOR']
+
+    for (const fieldId of ADDRESS_FIELDS) {
+      const params = toParams(buildWithSubquery(fieldId, 'is', '+15102055536').where)
+      expect(params).toContain('+15102055536')
+      expect(params.filter((p) => IDENTIFIER_TYPES.includes(p as string))).toEqual([])
+    }
+  })
+
+  it('reads the FROM role for `sender`/`from` and the recipient roles for `to`', () => {
+    expect(toParams(buildWithSubquery('from', 'is', 'ada@acme.com').where)).toContain('FROM')
+    expect(toParams(buildWithSubquery('sender', 'is', 'ada@acme.com').where)).toContain('FROM')
+
+    const toParamsList = toParams(buildWithSubquery('to', 'is', 'ada@acme.com').where)
+    expect(toParamsList).toEqual(expect.arrayContaining(['TO', 'CC', 'BCC']))
+    expect(toParamsList).not.toContain('FROM')
+  })
+
+  it('skips the Participant join entirely for `empty` / `not empty`', () => {
+    // Nothing to match an identifier against — the probe is "does a FROM
+    // participant row exist at all", which is two tables, not three.
+    const built = buildWithSubquery('from', 'not empty', undefined)
+    expect(built.chain.innerJoin).toHaveBeenCalledTimes(1)
+    expect(toSql(built.where)).not.toMatch(/identifier/i)
+  })
+})
+
+describe('channelType', () => {
+  it('offers only operators the builder dispatches', () => {
+    const operators = offeredOperators('channelType')
+    expect(operators.length).toBeGreaterThan(0)
+
+    for (const operator of operators) {
+      const value = operator.valueType === 'none' ? undefined : ['sms']
+      const result = buildOne('channelType', operator.key, value)
+
+      expect({ operator: operator.key, dropped: result.droppedConditions }).toEqual({
+        operator: operator.key,
+        dropped: [],
+      })
+      expect(result.allConditionsDropped).toBe(false)
+    }
+  })
+
+  it('compiles a group to every provider in it, through Thread.integrationId', () => {
+    const built = buildWithSubquery('channelType', 'is', 'sms')
+
+    expect(built.table).toBe(schema.Integration)
+    // `Thread.integrationId IN (<subquery>)`. The subquery collapses to one
+    // bound parameter under Vitest, so the shape is asserted on the mock.
+    expect(built.sqlText).toMatch(/\bin \$\d+/)
+    expect(built.projection).toHaveProperty('id')
+    // Both SMS providers, not just the wired one — a filter must survive a
+    // second provider being added to the group.
+    expect(toParams(built.where)).toEqual(expect.arrayContaining(['sms', 'openphone']))
+  })
+
+  it('matches threads on a DISCONNECTED channel — deletedAt is deliberately not filtered', () => {
+    // Disconnect is a soft delete. The conversations that channel delivered are
+    // still in the inbox, so a saved view or filter must keep matching them.
+    // Every other channel query in the codebase does the opposite; this one is
+    // the documented exception.
+    const built = buildWithSubquery('channelType', 'is', 'email')
+    // ONE predicate — the provider set. A `deletedAt IS NULL` arm would add an
+    // `and` and a second clause. (Column names render empty under Vitest, so
+    // the assertion is on the clause SHAPE, not on the word "deletedAt".)
+    expect(toSql(built.where)).not.toMatch(/\band\b/i)
+    expect(toSql(built.where)).not.toMatch(/is null/i)
+  })
+
+  it('fails closed on an unknown group instead of matching the whole mailbox', () => {
+    const result = buildOne('channelType', 'is', 'carrier-pigeon')
+
+    expect(result.droppedConditions).toEqual([])
+    expect(toSql(result.sql)).toMatch(/false/)
+    expect(toSql(result.sql)).not.toBe(baseScopeSql())
+  })
+
+  it('answers `empty` as constant false — Thread.integrationId is NOT NULL', () => {
+    // Dispatched rather than left to fall through: an undispatched operator is
+    // a DROP, and a filter whose conditions all drop fails the whole rule shut.
+    expect(toSql(buildOne('channelType', 'empty', undefined).sql)).toMatch(/false/)
+    expect(toSql(buildOne('channelType', 'not empty', undefined).sql)).toMatch(/true/)
+  })
+})

--- a/packages/lib/src/mail-query/condition-query-builder.ts
+++ b/packages/lib/src/mail-query/condition-query-builder.ts
@@ -24,6 +24,7 @@ import {
   sql,
 } from 'drizzle-orm'
 import type { AnyPgColumn } from 'drizzle-orm/pg-core'
+import { providersForChannelGroup } from '../channels/capabilities'
 import type { Operator } from '../conditions/operator-definitions'
 import type { Condition, ConditionGroup } from '../conditions/types'
 import {
@@ -311,6 +312,8 @@ function dispatchConditionQuery(
       return buildFromQuery(op, value)
     case 'to':
       return buildToQuery(op, value)
+    case 'channelType':
+      return buildChannelTypeQuery(op, value)
     case 'subject':
       return withScope(buildSubjectQuery(op, value), scopes.subject)
     case 'body':
@@ -624,109 +627,200 @@ function getDateColumn(field: string) {
 }
 
 /**
+ * `exists (select 1 from "Message" join "MessageParticipant" [join "Participant"]
+ * where "Message"."threadId" = "Thread"."id" and <role> [and <identifier>])` —
+ * the correlated shape every participant-backed condition uses.
+ *
+ * `Participant` is joined ONLY when an identifier match needs it, so the
+ * `empty` / `not empty` arms stay a two-table probe.
+ *
+ * ⚠️ Same invariant-6 rule as {@link messageExists}: the predicates live in the
+ * WHERE position and the projection is a literal `1`, or the correlation
+ * degrades into a self-join.
+ */
+function participantExists(roleMatch: SQL<unknown>, identifierMatch?: SQL<unknown>): SQL<unknown> {
+  const { Message, MessageParticipant, Participant } = schema
+  const joined = db
+    .select({ id: sql`1` })
+    .from(Message)
+    .innerJoin(MessageParticipant, eq(MessageParticipant.messageId, Message.id))
+  const query = identifierMatch
+    ? joined.innerJoin(Participant, eq(Participant.id, MessageParticipant.participantId))
+    : joined
+  return exists(query.where(and(eq(Message.threadId, Thread.id), roleMatch, identifierMatch)))
+}
+
+/** OR-fold one identifier pattern per needle. */
+function anyIdentifier(needles: string[], pattern: (needle: string) => string): SQL<unknown> {
+  const { Participant } = schema
+  const clauses = needles.map((needle) => ilike(Participant.identifier, pattern(needle)))
+  return clauses.length === 1 ? clauses[0]! : or(...clauses)!
+}
+
+/**
+ * Build a condition over `Participant.identifier` for the messages in a thread
+ * that carry one of `roleMatch`'s roles.
+ *
+ * **Channel-agnostic by construction.** The column is polymorphic — an email
+ * address, an E.164 phone number, a Facebook PSID or a chat-visitor id,
+ * disambiguated by `Participant.identifierType` — and this builder never tests
+ * the type. `from is +15102055536` and `from is ada@acme.com` compile to the
+ * same shape, which is what lets ONE `from` field serve every channel
+ * (plans/mail-filter/09-channel-aware-filters-plan.md D1).
+ *
+ * **Handles the COMPLETE `FieldType.EMAIL` operator set** — `is`, `is not`,
+ * `contains`, `not contains`, `starts with`, `ends with`, `in`, `not in`,
+ * `empty`, `not empty` — because that is what `getOperatorsForFieldType`
+ * offers for the `sender` / `from` / `to` field definitions. The four set and
+ * prefix operators were previously undispatched, which made
+ * `from starts with +1510` (an area-code filter, the archetypal phone rule)
+ * un-saveable: `assertFilterConditionsCompile` rejects ANY dropped condition,
+ * and a row that predates the gate fails closed on `AND false`
+ * (mail-filters invariant 19). The parity suite pins this set against
+ * `getOperatorsForFieldType` — extend both together or not at all.
+ *
+ * Equality uses `ILIKE` without wildcards rather than `=`: identifiers are
+ * normalized at ingest but case only for email, and an address typed
+ * `Ada@Acme.com` must still match the stored `ada@acme.com`.
+ */
+function buildParticipantIdentifierQuery(
+  operator: Operator,
+  value: unknown,
+  roleMatch: SQL<unknown>
+): SQL<unknown> | null {
+  switch (operator) {
+    case 'is':
+    case 'in': {
+      const needles = textList(value)
+      if (needles.length === 0) return null
+      return participantExists(
+        roleMatch,
+        anyIdentifier(needles, (n) => n)
+      )
+    }
+    case 'is not':
+    case 'not in': {
+      const needles = textList(value)
+      if (needles.length === 0) return null
+      return not(
+        participantExists(
+          roleMatch,
+          anyIdentifier(needles, (n) => n)
+        )
+      )
+    }
+    case 'contains': {
+      const needle = firstText(value)
+      return needle
+        ? participantExists(
+            roleMatch,
+            anyIdentifier([needle], (n) => `%${n}%`)
+          )
+        : null
+    }
+    case 'not contains': {
+      const needle = firstText(value)
+      return needle
+        ? not(
+            participantExists(
+              roleMatch,
+              anyIdentifier([needle], (n) => `%${n}%`)
+            )
+          )
+        : null
+    }
+    case 'starts with': {
+      const needle = firstText(value)
+      return needle
+        ? participantExists(
+            roleMatch,
+            anyIdentifier([needle], (n) => `${n}%`)
+          )
+        : null
+    }
+    case 'ends with': {
+      const needle = firstText(value)
+      return needle
+        ? participantExists(
+            roleMatch,
+            anyIdentifier([needle], (n) => `%${n}`)
+          )
+        : null
+    }
+    case 'empty':
+      return not(participantExists(roleMatch))
+    case 'not empty':
+      return participantExists(roleMatch)
+    default:
+      return null
+  }
+}
+
+/**
  * Build sender condition query.
- * Filters through Message and MessageParticipant joins.
+ * Filters through Message and MessageParticipant joins with role='FROM'.
  */
 function buildSenderQuery(operator: Operator, value: any): SQL<unknown> | null {
-  const { Message, MessageParticipant, Participant } = schema
+  const { MessageParticipant } = schema
+  return buildParticipantIdentifierQuery(operator, value, eq(MessageParticipant.role, 'FROM'))
+}
+
+/**
+ * Build the `channelType` condition — the coarse channel a thread arrived on.
+ *
+ * `Thread.integrationId` → `Integration.provider` → `channelGroup`, compiled as
+ * a subquery over the provider values in the requested groups. Groups, not
+ * providers: reconnecting a channel mints a NEW `Integration` row, so an id
+ * predicate would quietly stop matching, and `google`/`outlook`/`imap` are one
+ * channel to the author (plan 09 D3).
+ *
+ * ⚠️ **Deliberately does NOT filter `Integration.deletedAt IS NULL`**, which is
+ * the opposite of every other channel query in the codebase (disconnect is a
+ * soft delete, so channel LISTS must exclude them). The threads a disconnected
+ * channel delivered still exist, are still in the inbox, and a saved view or
+ * filter that silently stopped matching them the moment someone disconnected a
+ * channel would be a data-loss-shaped bug. `Integration.id` is a primary key,
+ * so the join is unambiguous with or without the flag.
+ *
+ * `empty` / `not empty` are constant: `Thread.integrationId` is `NOT NULL`
+ * (verified against the live schema). They are still dispatched rather than
+ * left to fall through, because `SINGLE_SELECT` OFFERS them and an
+ * undispatched operator is a DROP — which fails the whole filter closed
+ * (mail-filters invariant 19).
+ */
+function buildChannelTypeQuery(operator: Operator, value: unknown): SQL<unknown> | null {
+  const { Integration } = schema
+
+  const threadsOnGroups = (groups: string[]): SQL<unknown> => {
+    const providers = [...new Set(groups.flatMap((group) => providersForChannelGroup(group)))]
+    // An unknown group name matches no provider. Fail closed rather than
+    // emitting `IN ()`, which is a syntax error, or dropping the condition,
+    // which would widen the filter to the whole mailbox.
+    if (providers.length === 0) return sql`false`
+    return inArray(
+      Thread.integrationId,
+      db
+        .select({ id: Integration.id })
+        .from(Integration)
+        .where(inArray(Integration.provider, providers as any))
+    )
+  }
 
   switch (operator) {
+    case 'is':
+    case 'in': {
+      const groups = textList(value)
+      return groups.length > 0 ? threadsOnGroups(groups) : null
+    }
+    case 'is not':
+    case 'not in': {
+      const groups = textList(value)
+      return groups.length > 0 ? not(threadsOnGroups(groups)) : null
+    }
     case 'empty':
-      return not(
-        exists(
-          db
-            .select({ id: sql`1` })
-            .from(Message)
-            .innerJoin(MessageParticipant, eq(MessageParticipant.messageId, Message.id))
-            .where(and(eq(Message.threadId, Thread.id), eq(MessageParticipant.role, 'FROM')))
-        )
-      )
+      return sql`false`
     case 'not empty':
-      return exists(
-        db
-          .select({ id: sql`1` })
-          .from(Message)
-          .innerJoin(MessageParticipant, eq(MessageParticipant.messageId, Message.id))
-          .where(and(eq(Message.threadId, Thread.id), eq(MessageParticipant.role, 'FROM')))
-      )
-    case 'is': {
-      const emails = Array.isArray(value) ? value : [value]
-      if (emails.length === 0) return null
-      const identifierMatch =
-        emails.length === 1
-          ? ilike(Participant.identifier, emails[0])
-          : or(...emails.map((e: string) => ilike(Participant.identifier, e)))!
-      return exists(
-        db
-          .select({ id: sql`1` })
-          .from(Message)
-          .innerJoin(MessageParticipant, eq(MessageParticipant.messageId, Message.id))
-          .innerJoin(Participant, eq(Participant.id, MessageParticipant.participantId))
-          .where(
-            and(
-              eq(Message.threadId, Thread.id),
-              eq(MessageParticipant.role, 'FROM'),
-              identifierMatch
-            )
-          )
-      )
-    }
-    case 'is not': {
-      const excludeEmails = Array.isArray(value) ? value : [value]
-      if (excludeEmails.length === 0) return null
-      const excludeMatch =
-        excludeEmails.length === 1
-          ? ilike(Participant.identifier, excludeEmails[0])
-          : or(...excludeEmails.map((e: string) => ilike(Participant.identifier, e)))!
-      return not(
-        exists(
-          db
-            .select({ id: sql`1` })
-            .from(Message)
-            .innerJoin(MessageParticipant, eq(MessageParticipant.messageId, Message.id))
-            .innerJoin(Participant, eq(Participant.id, MessageParticipant.participantId))
-            .where(
-              and(
-                eq(Message.threadId, Thread.id),
-                eq(MessageParticipant.role, 'FROM'),
-                excludeMatch
-              )
-            )
-        )
-      )
-    }
-    case 'contains':
-      return exists(
-        db
-          .select({ id: sql`1` })
-          .from(Message)
-          .innerJoin(MessageParticipant, eq(MessageParticipant.messageId, Message.id))
-          .innerJoin(Participant, eq(Participant.id, MessageParticipant.participantId))
-          .where(
-            and(
-              eq(Message.threadId, Thread.id),
-              eq(MessageParticipant.role, 'FROM'),
-              ilike(Participant.identifier, `%${value}%`)
-            )
-          )
-      )
-    case 'not contains':
-      return not(
-        exists(
-          db
-            .select({ id: sql`1` })
-            .from(Message)
-            .innerJoin(MessageParticipant, eq(MessageParticipant.messageId, Message.id))
-            .innerJoin(Participant, eq(Participant.id, MessageParticipant.participantId))
-            .where(
-              and(
-                eq(Message.threadId, Thread.id),
-                eq(MessageParticipant.role, 'FROM'),
-                ilike(Participant.identifier, `%${value}%`)
-              )
-            )
-        )
-      )
+      return sql`true`
     default:
       return null
   }
@@ -768,118 +862,12 @@ function buildFromQuery(operator: Operator, value: any): SQL<unknown> | null {
  * Filters through Message and MessageParticipant joins with role='TO', 'CC', or 'BCC'.
  */
 function buildToQuery(operator: Operator, value: any): SQL<unknown> | null {
-  const { Message, MessageParticipant, Participant } = schema
-
-  switch (operator) {
-    case 'empty':
-      return not(
-        exists(
-          db
-            .select({ id: sql`1` })
-            .from(Message)
-            .innerJoin(MessageParticipant, eq(MessageParticipant.messageId, Message.id))
-            .where(
-              and(
-                eq(Message.threadId, Thread.id),
-                inArray(MessageParticipant.role, ['TO', 'CC', 'BCC'])
-              )
-            )
-        )
-      )
-    case 'not empty':
-      return exists(
-        db
-          .select({ id: sql`1` })
-          .from(Message)
-          .innerJoin(MessageParticipant, eq(MessageParticipant.messageId, Message.id))
-          .where(
-            and(
-              eq(Message.threadId, Thread.id),
-              inArray(MessageParticipant.role, ['TO', 'CC', 'BCC'])
-            )
-          )
-      )
-    case 'is': {
-      const emails = Array.isArray(value) ? value : [value]
-      if (emails.length === 0) return null
-      const identifierMatch =
-        emails.length === 1
-          ? ilike(Participant.identifier, emails[0])
-          : or(...emails.map((e: string) => ilike(Participant.identifier, e)))!
-      return exists(
-        db
-          .select({ id: sql`1` })
-          .from(Message)
-          .innerJoin(MessageParticipant, eq(MessageParticipant.messageId, Message.id))
-          .innerJoin(Participant, eq(Participant.id, MessageParticipant.participantId))
-          .where(
-            and(
-              eq(Message.threadId, Thread.id),
-              inArray(MessageParticipant.role, ['TO', 'CC', 'BCC']),
-              identifierMatch
-            )
-          )
-      )
-    }
-    case 'is not': {
-      const excludeEmails = Array.isArray(value) ? value : [value]
-      if (excludeEmails.length === 0) return null
-      const excludeMatch =
-        excludeEmails.length === 1
-          ? ilike(Participant.identifier, excludeEmails[0])
-          : or(...excludeEmails.map((e: string) => ilike(Participant.identifier, e)))!
-      return not(
-        exists(
-          db
-            .select({ id: sql`1` })
-            .from(Message)
-            .innerJoin(MessageParticipant, eq(MessageParticipant.messageId, Message.id))
-            .innerJoin(Participant, eq(Participant.id, MessageParticipant.participantId))
-            .where(
-              and(
-                eq(Message.threadId, Thread.id),
-                inArray(MessageParticipant.role, ['TO', 'CC', 'BCC']),
-                excludeMatch
-              )
-            )
-        )
-      )
-    }
-    case 'contains':
-      return exists(
-        db
-          .select({ id: sql`1` })
-          .from(Message)
-          .innerJoin(MessageParticipant, eq(MessageParticipant.messageId, Message.id))
-          .innerJoin(Participant, eq(Participant.id, MessageParticipant.participantId))
-          .where(
-            and(
-              eq(Message.threadId, Thread.id),
-              inArray(MessageParticipant.role, ['TO', 'CC', 'BCC']),
-              ilike(Participant.identifier, `%${value}%`)
-            )
-          )
-      )
-    case 'not contains':
-      return not(
-        exists(
-          db
-            .select({ id: sql`1` })
-            .from(Message)
-            .innerJoin(MessageParticipant, eq(MessageParticipant.messageId, Message.id))
-            .innerJoin(Participant, eq(Participant.id, MessageParticipant.participantId))
-            .where(
-              and(
-                eq(Message.threadId, Thread.id),
-                inArray(MessageParticipant.role, ['TO', 'CC', 'BCC']),
-                ilike(Participant.identifier, `%${value}%`)
-              )
-            )
-        )
-      )
-    default:
-      return null
-  }
+  const { MessageParticipant } = schema
+  return buildParticipantIdentifierQuery(
+    operator,
+    value,
+    inArray(MessageParticipant.role, ['TO', 'CC', 'BCC'])
+  )
 }
 
 /**

--- a/packages/lib/src/mail-views/mail-view-field-definitions.ts
+++ b/packages/lib/src/mail-views/mail-view-field-definitions.ts
@@ -2,6 +2,7 @@
 
 import { FieldType } from '@auxx/database/enums'
 import { toResourceFieldId } from '@auxx/types/field'
+import { CHANNEL_GROUP_OPTIONS } from '../channels/capabilities'
 import { getOperatorsForFieldType, type Operator } from '../conditions/operator-definitions'
 import type { FieldOptions } from '../custom-fields/field-options'
 // NOTE: This file is used on both client and server.
@@ -122,31 +123,49 @@ export const MAIL_VIEW_FIELD_DEFINITIONS: MailViewFieldDefinition[] = [
   // ═══════════════════════════════════════════════════════════════════════════
   // TEXT FIELDS
   // ═══════════════════════════════════════════════════════════════════════════
+  // `sender` / `from` / `to` are ADDRESS fields, not email fields. All three
+  // compile to `ilike(Participant.identifier, …)`, and that column is
+  // polymorphic — an email address, an E.164 phone number, a Facebook PSID or a
+  // chat-visitor id — so `from is +15102055536` is as valid as
+  // `from is ada@acme.com`. One field per concept, never one per channel
+  // (plans/mail-filter/09-channel-aware-filters-plan.md D1): the searchbar,
+  // mail views and filters share this catalog because they share one evaluator,
+  // and splitting `from` into three would fork that language where the SQL has
+  // one column.
+  //
+  // `type` is STRING rather than EMAIL for exactly that reason. `fieldType`
+  // STAYS `FieldType.EMAIL`: it is what routes the value input to
+  // `ParticipantPicker` (which searches identifiers of every type) instead of an
+  // `<input type="email">` that rejects a phone number, and its operator set is
+  // fully dispatched by `buildParticipantIdentifierQuery`.
   {
     id: 'sender',
     label: 'Sender',
-    type: BaseType.EMAIL,
+    type: BaseType.STRING,
     fieldType: FieldType.EMAIL,
-    placeholder: 'Email address...',
-    description: 'Filter by sender email address',
+    // Same `participantType` as `from` — the two ids compile to the identical
+    // `role = 'FROM'` predicate, so they must offer the identical input.
+    options: { email: { participantType: 'from' } },
+    placeholder: 'Email, phone number or handle...',
+    description: 'Filter by the sender’s address on any channel',
   },
   {
     id: 'from',
     label: 'From',
-    type: BaseType.EMAIL,
+    type: BaseType.STRING,
     fieldType: FieldType.EMAIL,
     options: { email: { participantType: 'from' } },
-    placeholder: 'Sender email...',
-    description: 'Filter by sender email address',
+    placeholder: 'Email, phone number or handle...',
+    description: 'Filter by the sender’s address on any channel',
   },
   {
     id: 'to',
     label: 'To',
-    type: BaseType.EMAIL,
+    type: BaseType.STRING,
     fieldType: FieldType.EMAIL,
     options: { email: { participantType: 'to' } },
-    placeholder: 'Recipient email...',
-    description: 'Filter by recipient email address',
+    placeholder: 'Email, phone number or handle...',
+    description: 'Filter by a recipient’s address on any channel',
   },
   {
     id: 'subject',
@@ -208,6 +227,28 @@ export const MAIL_VIEW_FIELD_DEFINITIONS: MailViewFieldDefinition[] = [
       ],
     },
     description: 'Filter by thread status',
+  },
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // CHANNEL FIELD
+  // ═══════════════════════════════════════════════════════════════════════════
+  // The only way to say "when a new SMS arrives in this inbox" on a MIXED
+  // inbox. An inbox is a union of channel types, not one type — "Shared Inbox"
+  // carries a `google` and an `email` channel, "Chat Support" a `chat` and a
+  // `google` one — and a channel can be attached AFTER a filter is written. So
+  // channel-awareness is expressed as a CONDITION the author writes, never as a
+  // catalog partition frozen at authoring time (plan 09 D2).
+  //
+  // Options are the coarse groups declared on `PLATFORM_CAPABILITIES`, not raw
+  // providers (plan 09 D3 + Q1): `Integration` rows are re-minted on reconnect
+  // and `google`/`outlook`/`imap`/`mailgun` are all just "Email" to the author.
+  {
+    id: 'channelType',
+    label: 'Channel',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    options: { options: CHANNEL_GROUP_OPTIONS.map((o) => ({ value: o.value, label: o.label })) },
+    description: 'Filter by the channel a conversation arrived on',
   },
 
   // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/lib/src/participants/client.ts
+++ b/packages/lib/src/participants/client.ts
@@ -7,8 +7,19 @@
 
 /**
  * Identifier type for participants.
+ *
+ * Mirrors the `IdentifierType` pg enum (`schema/_shared.ts`) **completely** —
+ * all five members, not the three that were once wired. `participant-service`
+ * casts the DB value onto this type, so a short union does not narrow anything:
+ * it just tells every consumer a Facebook or Instagram participant cannot
+ * exist, and any `switch` written against it is unsound on live rows.
  */
-export type ParticipantIdentifierType = 'EMAIL' | 'PHONE' | 'CHAT_VISITOR'
+export type ParticipantIdentifierType =
+  | 'EMAIL'
+  | 'PHONE'
+  | 'FACEBOOK_PSID'
+  | 'INSTAGRAM_IGSID'
+  | 'CHAT_VISITOR'
 
 /**
  * Participant display data for frontend store.


### PR DESCRIPTION
## The reproduction

**More actions → Filter messages like this** on an SMS thread in the Quo inbox opened a dialog titled **"Mail from m4rkuskk@gmail.com"** with one condition, `From is m4rkuskk@gmail.com` — on a phone-only inbox.

Two defects stacked. #1655 fixed the stale participant row (Auxx-composed SMS recorded the operator's *email* as its sender). This fixes the second one, which that bug was masking: with #1655 in place the counterparty resolves to `+15102055536`, the prefill's `identifier.includes('@')` test returns `null`, and the dialog opens with **no sender condition at all** — the half the user came for.

## The load-bearing fact

The query layer was already channel-agnostic. `from`/`to`/`sender` compile to `ilike(Participant.identifier, …)` joined through `MessageParticipant.role`, with **no `identifierType` predicate**, so `from is +15102055536` worked end to end (fire path, preview count and retroactive backfill all go through `buildFilterPredicate`). Only the field catalog above it still described the world as email. Nothing in the SQL moved except the new `channelType` case.

## What changed

**Address fields are addresses.** `sender`/`from`/`to` retyped off `BaseType.EMAIL` with channel-neutral copy. `sender` gains the `participantType` it lacked — it was falling through to `StringInput` with `validationType='email'`, which renders `<input type="email">` and flags "Invalid email address" on a phone number.

**The prefill switches on `identifierType`.** `Mail from …` / `Texts from …` (E.164 stored, display-formatted in the name) / for `FACEBOOK_PSID`, `INSTAGRAM_IGSID`, `CHAT_VISITOR`: no sender condition plus a visible banner saying why — those ids are opaque and per-app (per-session for chat), so a filter on one matches exactly one conversation forever. The subject arm is now gated on `PLATFORM_CAPABILITIES.subject` instead of skipping itself by accident on SMS's empty subject.

**A `channelType` condition.** On a mixed inbox this is the only way to write *"when a new SMS arrives in Chat Support → assign to on-call"* — an inbox is a union of channel types (dev has one on `google` + `email`, another on `chat` + `google`) and can gain a channel after a filter is written, so channel-awareness has to be a condition, not a catalog partition.

**Soft catalog scoping.** A phone-only inbox hides `list` / `senderDomain` / `hasAttachments` (all NULL or unsupported off email) and keeps `subject` — empty is not meaningless, `subject is empty` is a real predicate. Recomputed per selected inbox, never persisted, never applied to a field an existing filter already uses, and it fails open when the channel list is loading or unreadable.

**Phone normalisation at authoring.** `(510) 205-5536` compiled cleanly, saved cleanly, previewed "0 matches" and never fired — with nothing in the logs, because *never-matching is not dropping* and neither `assertFilterConditionsCompile` nor the fail-closed `AND false` can see it. Exact operators on address fields now go through the shared `formatPhoneNumber` (same E.164 normaliser as `fieldValueSchemas.phone`) on create, update **and** preview. `contains` / `starts with` / `ends with` stay verbatim.

## Two defects found while implementing

**`from`/`to`/`sender` were missing four of their ten operators.** `FieldType.EMAIL` advertises `starts with`, `ends with`, `in` and `not in`; the builders dispatched none of them. Because `assertFilterConditionsCompile` throws on *any* dropped condition, `from starts with +1510` — an area-code rule, the archetypal phone filter — was **un-saveable**, and a row predating that gate fails closed on `AND false`. The existing parity suite covered only `list`/`senderDomain`, so nothing caught it. Both builders now share one `buildParticipantIdentifierQuery`, and the parity suite covers `sender`/`from`/`to`/`channelType`.

**`ParticipantIdentifierType` listed 3 of the pg enum's 5 members.** `participant-service` casts the DB value onto it, so the short union narrowed nothing — it just told every consumer that Facebook and Instagram participants cannot exist, making any exhaustive switch unsound on live rows. Widened, along with its web mirror.

Also removed a dead `roleFilter` in `search.participants`: it was built from `type` and never referenced in the `where`, so the picker's `type='from'` restricted nothing. A `Participant` row has no role — role lives on `MessageParticipant` — so the parameter is now documented as ignored rather than silently pretending.

## Design decisions worth reviewing

- **One polymorphic address field, not one per channel.** Splitting into `fromEmail`/`fromPhone`/`fromHandle` would fork the condition language the searchbar, mail views and filters share into three fields where the SQL has one column, for zero expressive gain.
- **`channelType` options are a declared `PlatformCapabilities.channelGroup`, not raw providers and not a derivation.** Raw `PLATFORM_CAPABILITIES` keys would offer "Shopify" (explicitly *not a messaging channel*), plus `imap`, `mailgun` and the unwired `sms` placeholder. Deriving from `channel + recipientModel` cannot separate `facebook` from `instagram` (both `messaging` + `thread_only`) and drags `shopify` in with them. So it is declared per provider, in the one map — the same reasoning that already applies to `identifierType`.
- **⚠️ `channelType` deliberately does NOT filter `Integration.deletedAt`.** Every other channel query in the codebase does the opposite, and correctly so — but disconnect is a soft delete, and the conversations that channel delivered are still in the inbox. A saved view that silently stopped matching them the moment someone disconnected a channel would be a data-loss-shaped bug. Called out in the code comment and in the guide.
- **Groups, not specific channels.** Reconnecting a channel mints a new `Integration` row; a type predicate survives that, an id predicate does not.

## Testing

- `packages/lib` — **383 tests** across `mail-filters`, `mail-query`, `mail-views`, `channels`, `participants`.
- `apps/web` — **194 tests** across `mail-filters`, the router and `threads`.
- New coverage: full operator parity on the address fields; a phone number compiling identically to an email; `identifierType` never appearing in the predicate; `channelType` matching a disconnected channel and failing closed on an unknown group; every `identifierType` arm of the prefill including the no-condition-plus-note case; catalog scoping including the keep-what's-in-use rule; E.164 normalisation reaching create, update and preview.
- Typecheck ratchet clean on both packages (`lib 29/29`, `web 0/0`); Biome clean on every touched file.

## Not in scope

The mail-suggestions miner stays email-only by decision (no `List-Id` analogue for phone), unsubscribe stays email-only (STOP is carrier-handled inside the provider and must never be a `MailFilterAction`), blocked senders stay a channel-settings feature, and a specific-channel condition field is deferred. All four are now stated as decisions in the guides rather than left as accidents.

## Open question for you

The surface still says **"mail"** — the dialog reads *"Match new mail arriving in an inbox"*. Whether that becomes "message filters" or stays "mail" because the nav section is Mail is a product call, not a technical one. The prefill names are channel-correct either way, and changing it is a copy pass, not a re-plan.
