### PR TITLE
fix(messages): render sms as chat bubbles and stamp the right message type

### DIFF
--- a/apps/web/src/components/mail/chat-timeline.test.ts
+++ b/apps/web/src/components/mail/chat-timeline.test.ts
@@ -1,0 +1,90 @@
+// apps/web/src/components/mail/chat-timeline.test.ts
+//
+// The grouping gate used to be `messageType === 'CHAT'`, which is why every SMS
+// message fell through to `single` and rendered in the email-shaped fallback
+// card while chat got bubbles. These lock in the widened gate.
+
+import type { ParticipantId } from '@auxx/types'
+import { describe, expect, it } from 'vitest'
+import type { MessageMeta, MessageType } from '~/components/threads/store'
+import { buildChatTimeline } from './chat-timeline'
+
+function message(
+  id: string,
+  overrides: Partial<MessageMeta> & { messageType: MessageType }
+): MessageMeta {
+  return {
+    id,
+    threadId: 't1',
+    subject: null,
+    snippet: null,
+    textHtml: null,
+    textPlain: `body ${id}`,
+    isInbound: true,
+    isFirstInThread: false,
+    hasAttachments: false,
+    hasHtmlBody: false,
+    hasTextBody: true,
+    sentAt: '2026-08-17T10:00:00.000Z',
+    receivedAt: null,
+    createdAt: '2026-08-17T10:00:00.000Z',
+    participants: ['from:p1' as ParticipantId],
+    createdById: null,
+    sendStatus: null,
+    providerError: null,
+    attempts: 0,
+    attachments: [],
+    ...overrides,
+  }
+}
+
+describe('buildChatTimeline', () => {
+  it('bubbles a lone SMS instead of dropping it to the fallback card', () => {
+    const items = buildChatTimeline([message('m1', { messageType: 'SMS' })], [])
+    expect(items).toHaveLength(1)
+    expect(items[0]?.kind).toBe('chat-group')
+  })
+
+  it('clusters consecutive same-sender SMS inside the 5-minute window', () => {
+    const items = buildChatTimeline(
+      [
+        message('m1', { messageType: 'SMS', sentAt: '2026-08-17T10:00:00.000Z' }),
+        message('m2', { messageType: 'SMS', sentAt: '2026-08-17T10:02:00.000Z' }),
+      ],
+      []
+    )
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({ kind: 'chat-group', startIndex: 0, endIndex: 1 })
+  })
+
+  it('breaks a cluster when the direction flips', () => {
+    const items = buildChatTimeline(
+      [
+        message('m1', { messageType: 'SMS' }),
+        message('m2', { messageType: 'SMS', isInbound: false }),
+      ],
+      []
+    )
+    expect(items).toHaveLength(2)
+  })
+
+  it('never groups across transports', () => {
+    const items = buildChatTimeline(
+      [message('m1', { messageType: 'SMS' }), message('m2', { messageType: 'CHAT' })],
+      []
+    )
+    expect(items).toHaveLength(2)
+  })
+
+  it('leaves email as a single so EmailDisplay still renders it', () => {
+    const items = buildChatTimeline([message('m1', { messageType: 'EMAIL' })], [])
+    expect(items[0]).toMatchObject({ kind: 'single', index: 0 })
+  })
+
+  it('keeps WhatsApp and DM messages on the bubble path', () => {
+    for (const messageType of ['WHATSAPP', 'FACEBOOK', 'INSTAGRAM'] as const) {
+      const items = buildChatTimeline([message('m1', { messageType })], [])
+      expect(items[0]?.kind, messageType).toBe('chat-group')
+    }
+  })
+})

--- a/apps/web/src/components/mail/chat-timeline.ts
+++ b/apps/web/src/components/mail/chat-timeline.ts
@@ -1,10 +1,14 @@
 // apps/web/src/components/mail/chat-timeline.ts
 //
-// Interleave admin-side chat messages with thread lifecycle events
+// Interleave admin-side conversational messages with thread lifecycle events
 // (taken_over, returned_to_ai, archived, reopened, assignee:changed,
 // visitor:identified) into a single sorted render list. Consecutive
-// same-sender CHAT messages within a 5-minute window collapse into a
+// same-sender bubble messages within a 5-minute window collapse into a
 // `chat-group`; any event between them breaks the cluster.
+//
+// "Bubble message" is `isBubbleMessage` — CHAT *and* SMS/WhatsApp/DM. Gating on
+// `messageType === 'CHAT'` is what kept SMS out of the bubble renderer and in
+// the email-shaped fallback card.
 //
 // Mirrors the widget's `buildTimeline` in
 // `apps/chat-widget/src/views/conversation/conversation-view.tsx`, but
@@ -14,6 +18,7 @@
 
 import type { MessageMeta } from '~/components/threads/store'
 import type { ChatThreadEvent } from './chat-panel/system-line'
+import { isBubbleMessage } from './utils/message-bubble'
 
 const CHAT_GROUP_WINDOW_MS = 5 * 60_000
 
@@ -24,7 +29,7 @@ export type ChatTimelineItem =
 
 /**
  * Interleave messages and thread events by timestamp, collapsing consecutive
- * same-sender CHAT messages into groups. `index` / `startIndex` / `endIndex`
+ * same-sender bubble messages into groups. `index` / `startIndex` / `endIndex`
  * point back into the original `messages` array so existing per-message UI
  * (latest-message check, animation delay) keeps working.
  */
@@ -60,7 +65,7 @@ export function buildChatTimeline(
       out.push({ kind: 'event', event: entry.event })
       continue
     }
-    if (entry.message.messageType !== 'CHAT') {
+    if (!isBubbleMessage(entry.message.messageType)) {
       out.push({ kind: 'single', message: entry.message, index: entry.index })
       continue
     }
@@ -70,7 +75,7 @@ export function buildChatTimeline(
     while (i + 1 < entries.length) {
       const next = entries[i + 1]!
       if (next.kind !== 'message') break
-      if (!canGroupChat(run[run.length - 1]!, next.message)) break
+      if (!canGroupBubble(run[run.length - 1]!, next.message)) break
       run.push(next.message)
       endIndex = next.index
       i++
@@ -89,8 +94,12 @@ function messageTimestamp(m: MessageMeta): number {
   return 0
 }
 
-function canGroupChat(a: MessageMeta, b: MessageMeta): boolean {
-  if (b.messageType !== 'CHAT') return false
+function canGroupBubble(a: MessageMeta, b: MessageMeta): boolean {
+  if (!isBubbleMessage(b.messageType)) return false
+  // Same transport only. One channel per thread makes a mixed run unlikely, but
+  // `openphone` alone emits SMS and CALL, and a merged stack of two different
+  // message shapes would render as one conversation turn.
+  if (a.messageType !== b.messageType) return false
   if (a.isInbound !== b.isInbound) return false
   if (fromParticipant(a) !== fromParticipant(b)) return false
   const aT = messageTimestamp(a) || null

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -244,6 +244,16 @@ function ReplyComposeEditorComponent({
   // was live in every mode with `disabled={isSending}` as its only gate.
   const isNewCompose = mode === 'new'
   const canSwitchChannel = isNewCompose || isEmailChannel
+
+  // A conversational channel's composer is always on — `useReplyBox` re-opens it
+  // the instant it closes (see `channelUsesAlwaysOnComposer`), so an inline X
+  // discards the draft and immediately gets a fresh empty composer back. That is
+  // a flicker, not an exit, so the button is not offered.
+  //
+  // Floating/dialog mode keeps it: there the X is a window control
+  // (`handleCloseClick`, no discard) and closing genuinely puts the composer
+  // away.
+  const showCloseButton = isDialogMode || isEmailChannel
   const pinnedChannelLabel =
     selectedChannel?.identifier ??
     selectedChannelFromList?.identifier ??
@@ -513,7 +523,16 @@ function ReplyComposeEditorComponent({
           providerError: null,
           attempts: 1,
           attachments,
-          messageType: 'EMAIL',
+          // Must match what the server will echo. `Message.messageType` is not
+          // stored — `message-query.service` derives it from the channel's
+          // provider on every read — so hardcoding EMAIL here rendered a
+          // just-sent SMS through `EmailDisplay` until the echo landed and
+          // flipped it to a bubble.
+          //
+          // The cast bridges two unions that drifted: the store's ends in
+          // `CALL`, the DB enum's in `OPENPHONE`. No capability entry declares
+          // either, so every value this can produce is in both.
+          messageType: (platformCaps?.messageType ?? 'EMAIL') as MessageMeta['messageType'],
         }
         appendOptimisticMessage(utils, sentMessage.threadId, optimistic)
 
@@ -1300,15 +1319,17 @@ function ReplyComposeEditorComponent({
               </Button>
             )}
 
-            {/* Close/Discard button */}
-            <Button
-              size='icon-sm'
-              variant='ghost'
-              className='rounded-full text-muted-foreground hover:bg-gray-200 dark:hover:bg-gray-700'
-              onClick={isDialogMode ? handleCloseClick : handleDiscardClick}
-              disabled={isSending || isUpserting || (isDeleting && !isDialogMode)}>
-              {isDeleting && !isDialogMode ? <Loader2 className='size-4 animate-spin' /> : <X />}
-            </Button>
+            {/* Close/Discard button — hidden on an always-on messaging composer */}
+            {showCloseButton && (
+              <Button
+                size='icon-sm'
+                variant='ghost'
+                className='rounded-full text-muted-foreground hover:bg-gray-200 dark:hover:bg-gray-700'
+                onClick={isDialogMode ? handleCloseClick : handleDiscardClick}
+                disabled={isSending || isUpserting || (isDeleting && !isDialogMode)}>
+                {isDeleting && !isDialogMode ? <Loader2 className='size-4 animate-spin' /> : <X />}
+              </Button>
+            )}
           </div>
         </div>
 

--- a/apps/web/src/components/mail/utils/message-bubble.ts
+++ b/apps/web/src/components/mail/utils/message-bubble.ts
@@ -1,0 +1,33 @@
+// apps/web/src/components/mail/utils/message-bubble.ts
+
+import type { MessageType } from '~/components/threads/store'
+
+/**
+ * Message types that render as a chat bubble (`ChatMessageDisplay`) and cluster
+ * into same-sender runs, rather than as an email card (`EmailDisplay`) or the
+ * boxed fallback card (`MessageDisplay`).
+ *
+ * An explicit set, deliberately NOT `messageType !== 'EMAIL'` — which is what it
+ * would reduce to today, since EMAIL is the only non-conversational type the
+ * read path derives (`getMessageTypeFromProvider`). Membership should be an
+ * opt-in: inverting the test silently bubbles whatever the enum grows next,
+ * and the store's union already carries a vestigial `CALL` that no provider
+ * emits. `messageType === 'CHAT'` being the only gate is how SMS ended up
+ * first-class everywhere except the renderer.
+ *
+ * Keyed on the MESSAGE rather than the thread's provider so the timeline can
+ * decide per row without resolving the channel.
+ */
+const BUBBLE_MESSAGE_TYPES: ReadonlySet<MessageType> = new Set<MessageType>([
+  'CHAT',
+  'SMS',
+  'WHATSAPP',
+  'FACEBOOK',
+  'INSTAGRAM',
+])
+
+/** Whether this message renders as a chat bubble. See {@link BUBBLE_MESSAGE_TYPES}. */
+export function isBubbleMessage(messageType: MessageType | string | null | undefined): boolean {
+  if (!messageType) return false
+  return BUBBLE_MESSAGE_TYPES.has(messageType as MessageType)
+}

--- a/packages/lib/src/channels/__tests__/capabilities.message-type.test.ts
+++ b/packages/lib/src/channels/__tests__/capabilities.message-type.test.ts
@@ -1,0 +1,35 @@
+// packages/lib/src/channels/__tests__/capabilities.message-type.test.ts
+//
+// `PlatformCapabilities.messageType` restates an answer the server already owns:
+// `Message.messageType` is not a stored column, it is derived on every read by
+// `getMessageTypeFromProvider` (`providers/type-utils.ts`, called from
+// `messages/message-query.service.ts`). The restatement exists because
+// `providers/` has no client-safe subpath and the composer needs the same value
+// to stamp an optimistic row with — but two per-provider maps is exactly the
+// drift that kept `openphone` out of the From picker for months.
+//
+// So they are pinned together here. A provider added to one map and not the
+// other, or given a different type in each, is a failing test rather than a
+// just-sent SMS that renders as an email card until the realtime echo lands.
+
+import { IntegrationProviderTypeValues } from '@auxx/database/enums'
+import { describe, expect, it } from 'vitest'
+import { getMessageTypeFromProvider } from '../../providers/type-utils'
+import type { ChannelProviderType } from '../../providers/types'
+import { PLATFORM_CAPABILITIES } from '../capabilities'
+
+describe('PlatformCapabilities.messageType', () => {
+  it('agrees with getMessageTypeFromProvider for every provider', () => {
+    for (const provider of IntegrationProviderTypeValues) {
+      expect(PLATFORM_CAPABILITIES[provider].messageType).toBe(
+        getMessageTypeFromProvider(provider as ChannelProviderType)
+      )
+    }
+  })
+
+  it('declares a messageType for every provider — no gaps', () => {
+    for (const provider of IntegrationProviderTypeValues) {
+      expect(PLATFORM_CAPABILITIES[provider].messageType).toBeTruthy()
+    }
+  })
+})

--- a/packages/lib/src/channels/capabilities.ts
+++ b/packages/lib/src/channels/capabilities.ts
@@ -1,9 +1,10 @@
 // packages/lib/src/channels/capabilities.ts
 
-import { IdentifierType, IntegrationProviderType } from '@auxx/database/enums'
+import { IdentifierType, IntegrationProviderType, MessageType } from '@auxx/database/enums'
 import type {
   IdentifierType as IdentifierTypeValue,
   IntegrationProviderType as IntegrationProviderTypeValue,
+  MessageType as MessageTypeValue,
 } from '@auxx/database/types'
 
 /**
@@ -85,6 +86,23 @@ export interface PlatformCapabilities {
    * participants at all. Callers must handle that rather than defaulting.
    */
   identifierType?: IdentifierTypeValue
+  /**
+   * The `MessageType` a message on this channel reads back as.
+   *
+   * `Message.messageType` is NOT a stored column — it was removed and is derived
+   * from `Integration.provider` on every read
+   * (`messages/message-query.service.ts` → `getMessageTypeFromProvider`). That
+   * function is the server-side authority and this field MUST agree with it;
+   * `__tests__/capabilities.message-type.test.ts` asserts the two maps match for
+   * every provider.
+   *
+   * It is restated here because `getMessageTypeFromProvider` lives in
+   * `providers/`, which has no client-safe subpath — the composer needs this
+   * answer to stamp an optimistic row with the same value the server echo will
+   * carry, and stamping the wrong one flips a just-sent SMS through the email
+   * renderer until the echo lands.
+   */
+  messageType: MessageTypeValue
   /** Free-form note surfaced to the LLM in the catalog stanza. */
   notes?: string
 }
@@ -110,6 +128,7 @@ export type ComposerCapabilities = Pick<
   | 'richText'
   | 'signature'
   | 'maxMessageLength'
+  | 'messageType'
 >
 
 /**
@@ -130,6 +149,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   [IntegrationProviderType.google]: {
     channel: 'email',
     channelGroup: 'email',
+    messageType: MessageType.EMAIL,
     newOutbound: true,
     threadReply: true,
     subject: true,
@@ -144,6 +164,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   [IntegrationProviderType.outlook]: {
     channel: 'email',
     channelGroup: 'email',
+    messageType: MessageType.EMAIL,
     newOutbound: true,
     threadReply: true,
     subject: true,
@@ -158,6 +179,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   [IntegrationProviderType.email]: {
     channel: 'email',
     channelGroup: 'email',
+    messageType: MessageType.EMAIL,
     newOutbound: true,
     threadReply: true,
     subject: true,
@@ -172,6 +194,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   [IntegrationProviderType.imap]: {
     channel: 'email',
     channelGroup: 'email',
+    messageType: MessageType.EMAIL,
     newOutbound: true,
     threadReply: true,
     subject: true,
@@ -186,6 +209,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   [IntegrationProviderType.mailgun]: {
     channel: 'email',
     channelGroup: 'email',
+    messageType: MessageType.EMAIL,
     newOutbound: true,
     threadReply: true,
     subject: true,
@@ -200,6 +224,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   [IntegrationProviderType.facebook]: {
     channel: 'messaging',
     channelGroup: 'facebook',
+    messageType: MessageType.FACEBOOK,
     newOutbound: false,
     threadReply: true,
     subject: false,
@@ -215,6 +240,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   [IntegrationProviderType.instagram]: {
     channel: 'messaging',
     channelGroup: 'instagram',
+    messageType: MessageType.INSTAGRAM,
     newOutbound: false,
     threadReply: true,
     subject: false,
@@ -229,6 +255,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   [IntegrationProviderType.sms]: {
     channel: 'messaging',
     channelGroup: 'sms',
+    messageType: MessageType.SMS,
     newOutbound: true,
     threadReply: true,
     subject: false,
@@ -246,6 +273,10 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   [IntegrationProviderType.openphone]: {
     channel: 'messaging',
     channelGroup: 'sms',
+    // Quo also ingests call records, but a composer send is always a text —
+    // and the read path derives one type per provider, so SMS is the answer
+    // for every message on this channel.
+    messageType: MessageType.SMS,
     newOutbound: true,
     threadReply: true,
     subject: false,
@@ -272,6 +303,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   [IntegrationProviderType.whatsapp]: {
     channel: 'messaging',
     channelGroup: 'whatsapp',
+    messageType: MessageType.WHATSAPP,
     newOutbound: true,
     threadReply: true,
     subject: false,
@@ -287,6 +319,7 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
   [IntegrationProviderType.chat]: {
     channel: 'messaging',
     channelGroup: 'chat',
+    messageType: MessageType.CHAT,
     newOutbound: true,
     threadReply: true,
     subject: false,
@@ -302,6 +335,9 @@ export const PLATFORM_CAPABILITIES: Record<IntegrationProviderTypeValue, Platfor
     // Data-only integration — not a messaging channel. Excluded from the
     // catalog by callers via `channel` filter or `newOutbound + threadReply`.
     channel: 'messaging',
+    // Never produces messages. EMAIL only to agree with the server-side
+    // `getMessageTypeFromProvider`, whose fallback is EMAIL.
+    messageType: MessageType.EMAIL,
     newOutbound: false,
     threadReply: false,
     subject: false,


### PR DESCRIPTION
SMS is first-class everywhere except the renderer. A phone thread showed the
boxy fallback card — the one with Forward, Resend and View Source in its menu —
while chat got proper bubbles.

## What was wrong

**`buildChatTimeline` gated grouping on `messageType === 'CHAT'`.** Every SMS
message fell through to `single`, which routes to `MessageDisplay`. Now gated on
an explicit `isBubbleMessage` set (`CHAT`, `SMS`, `WHATSAPP`, `FACEBOOK`,
`INSTAGRAM`), plus a same-transport guard on the cluster check so a merged stack
can never span two message shapes.

Explicit set rather than `!== 'EMAIL'` — which is what it reduces to today —
because membership should be an opt-in. Inverting the test silently bubbles
whatever the enum grows next, and the store's union already carries a vestigial
`CALL` that no provider emits.

**The composer stamped its optimistic row `messageType: 'EMAIL'`.** A just-sent
SMS rendered through `EmailDisplay` until the realtime echo landed and flipped
it to a bubble.

`Message.messageType` is not a stored column — it was removed, and
`message-query.service.ts` derives it from `Integration.provider` on every read
via `getMessageTypeFromProvider`. So the hardcode was inventing a value the
server would contradict a moment later. The client has to derive the same
answer, but `providers/` has no client-safe subpath, so `messageType` joins
`PlatformCapabilities` — the same precedent as `identifierType`, which is
declared there for exactly this reason. `capabilities.message-type.test.ts`
pins the two maps together for all twelve providers so they cannot drift.

**The composer offered a close button on an always-on messaging composer.**
Inline, the X discarded the draft and `useReplyBox` immediately re-opened an
empty composer — a flicker, not an exit. Floating/dialog mode keeps it, where
it is `handleCloseClick` (a window control, no discard) and closing genuinely
puts the composer away.

## What did not need changing

Routing to `ChatMessageDisplay`. `buildChatTimeline` emits a `chat-group` for a
run of one, and `thread-messages` already renders that through
`ChatMessageGroup`. Widening the gate was enough — SMS now gets the bubble, the
same-sender clustering, the alignment and the delivered/read receipts.
`MessageDisplay` stays as the fallback for non-bubble, non-email types.

## Known gap, deliberately left

`thread-messages.tsx` filters the redacted (`myLens === 'identity'`) branch to
`messageType === 'EMAIL'`, so an SMS thread at identity lens renders the lock
notice and no rows. Bubbles have no collapsed envelope-only state, so routing
them there would render empty bubbles rather than the useful envelope rows email
gets. Sparse but safe; a proper fix needs an envelope-only bubble variant.

## Verification

- `packages/lib` channels: 65 tests pass, including the new parity test
- `apps/web` mail: 155 tests pass, plus 6 new `chat-timeline.test.ts` cases
  (lone SMS bubbles, clusters inside the window, breaks on direction flip,
  never groups across transports, email stays `single`, WhatsApp/DMs bubble)
- Typecheck ratchet: web 0/baseline 0, lib 29/baseline 29 — no new errors
- Biome clean at error level