### PR TITLE
fix(composer): mint recipient chip ids and remount the input on a model switch

### DIFF
--- a/apps/web/src/components/mail/email-editor/derive-initial.test.ts
+++ b/apps/web/src/components/mail/email-editor/derive-initial.test.ts
@@ -1,0 +1,108 @@
+// apps/web/src/components/mail/email-editor/derive-initial.test.ts
+//
+// Chip identity. `RecipientState.id` used to be whatever id the chip's source
+// happened to carry — here, `Participant.id` from a draft's participants or a
+// reply's `from`. The parent removes chips by that id and the badge list keys on
+// it, so a source that can hand back the same id twice produced two chips that
+// could not be told apart. These pin: ids are minted per chip, and reply-all's
+// "don't Cc the sender again" dedupe keys on the identifier (the only field that
+// still means what it used to).
+
+import { ParticipantRole } from '@auxx/database/enums'
+import { describe, expect, it } from 'vitest'
+import { deriveInitialState } from './derive-initial'
+import type { DraftMessageType, MessageType } from './types'
+
+const participant = (id: string, identifier: string, name = 'Ada') => ({
+  id,
+  identifier,
+  identifierType: 'EMAIL',
+  name,
+})
+
+describe('deriveInitialState — chip ids', () => {
+  it('mints a chip id per draft recipient instead of reusing Participant.id', () => {
+    const draft = {
+      id: 'd1',
+      participants: [
+        { role: ParticipantRole.TO, participant: participant('p1', 'a@x.com') },
+        { role: ParticipantRole.CC, participant: participant('p2', 'b@x.com') },
+      ],
+    } as unknown as DraftMessageType
+
+    const state = deriveInitialState({ mode: 'draft', draft })
+
+    expect(state.to).toHaveLength(1)
+    expect(state.cc).toHaveLength(1)
+    expect(state.to[0]?.identifier).toBe('a@x.com')
+    expect(state.to[0]?.id).not.toBe('p1')
+    expect(state.cc[0]?.id).not.toBe('p2')
+    expect(state.to[0]?.id).not.toBe(state.cc[0]?.id)
+  })
+
+  it('mints a chip id for the reply sender instead of reusing the message from id', () => {
+    const sourceMessage = {
+      id: 'm1',
+      from: participant('p1', 'sender@x.com'),
+      participants: [],
+    } as unknown as MessageType
+
+    const state = deriveInitialState({ mode: 'reply', sourceMessage })
+
+    expect(state.to[0]?.identifier).toBe('sender@x.com')
+    expect(state.to[0]?.id).not.toBe('p1')
+    expect(state.to[0]?.id).toBeTruthy()
+  })
+
+  it('reply-all does not Cc the sender again — the dedupe keys on identifier', () => {
+    // The regression this guards: the old dedupe compared a chip id against
+    // `Participant.id`. Once chip ids are minted, that comparison matches
+    // nothing, and the sender lands in both TO and CC.
+    const sender = participant('p1', 'sender@x.com', 'Sender')
+    const sourceMessage = {
+      id: 'm1',
+      from: sender,
+      participants: [
+        { role: ParticipantRole.TO, participant: sender },
+        { role: ParticipantRole.CC, participant: participant('p2', 'other@x.com', 'Other') },
+      ],
+    } as unknown as MessageType
+
+    const state = deriveInitialState({ mode: 'replyAll', sourceMessage })
+
+    expect(state.to.map((r) => r.identifier)).toEqual(['sender@x.com'])
+    expect(state.cc.map((r) => r.identifier)).toEqual(['other@x.com'])
+  })
+
+  it('reply-all still dedupes when the sender appears under a different Participant row', () => {
+    // Same address, different `Participant.id` — an id-keyed dedupe never caught
+    // this case at all, so it is strictly new coverage.
+    const sourceMessage = {
+      id: 'm1',
+      from: participant('p1', 'sender@x.com'),
+      participants: [{ role: ParticipantRole.TO, participant: participant('p9', 'sender@x.com') }],
+    } as unknown as MessageType
+
+    const state = deriveInitialState({ mode: 'replyAll', sourceMessage })
+
+    expect(state.cc).toHaveLength(0)
+  })
+
+  it('gives every chip a distinct id across TO, CC and BCC', () => {
+    const draft = {
+      id: 'd1',
+      participants: [
+        { role: ParticipantRole.TO, participant: participant('p1', 'a@x.com') },
+        { role: ParticipantRole.TO, participant: participant('p2', 'b@x.com') },
+        { role: ParticipantRole.CC, participant: participant('p3', 'c@x.com') },
+        { role: ParticipantRole.BCC, participant: participant('p4', 'd@x.com') },
+      ],
+    } as unknown as DraftMessageType
+
+    const state = deriveInitialState({ mode: 'draft', draft })
+    const ids = [...state.to, ...state.cc, ...state.bcc].map((r) => r.id)
+
+    expect(ids).toHaveLength(4)
+    expect(new Set(ids).size).toBe(4)
+  })
+})

--- a/apps/web/src/components/mail/email-editor/derive-initial.ts
+++ b/apps/web/src/components/mail/email-editor/derive-initial.ts
@@ -1,5 +1,6 @@
 import { ParticipantRole } from '@auxx/database/enums'
 import { htmlToDoc } from '@auxx/lib/tiptap'
+import { generateId } from '@auxx/utils'
 import type { JSONContent } from '@tiptap/core'
 import type {
   DraftMessageType,
@@ -112,7 +113,7 @@ export function deriveInitialState({
         return
       }
       const recipient: RecipientState = {
-        id: participant.id,
+        id: generateId(),
         identifier: participant.identifier,
         identifierType: participant.identifierType,
         name: participant.name,
@@ -163,26 +164,31 @@ export function deriveInitialState({
     const from = sourceMessage.from
     if (from) {
       to.push({
-        id: from.id,
+        id: generateId(),
         identifier: from.identifier,
         identifierType: from.identifierType,
         name: from.name,
       })
     }
-    // For reply all, add other participants to CC
+    // For reply all, add other participants to CC.
+    //
+    // Deduped on `identifier`, NOT on the chip id: a chip id is minted per chip
+    // and can never equal a `Participant.id`, so the old `addedIds` set would
+    // have matched nothing and replied-all to the sender twice. Identifier is
+    // also the key `upsertRecipient` and `deduplicateRecipients` already use.
     if (mode === 'replyAll') {
-      const addedIds = new Set(to.map((r) => r.id))
+      const addedIdentifiers = new Set(to.map((r) => r.identifier))
       sourceMessage.participants?.forEach((p) => {
         const participant = p.participant
-        if (!participant || addedIds.has(participant.id)) return
+        if (!participant || addedIdentifiers.has(participant.identifier)) return
         if (p.role === ParticipantRole.TO || p.role === ParticipantRole.CC) {
           cc.push({
-            id: participant.id,
+            id: generateId(),
             identifier: participant.identifier,
             identifierType: participant.identifierType,
             name: participant.name,
           })
-          addedIds.add(participant.id)
+          addedIdentifiers.add(participant.identifier)
         }
       })
     }

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -10,6 +10,7 @@ import { Button } from '@auxx/ui/components/button'
 import { Separator } from '@auxx/ui/components/separator'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
+import { generateId } from '@auxx/utils'
 import { stableStringify } from '@auxx/utils/json'
 import type { JSONContent } from '@tiptap/core'
 import {
@@ -380,7 +381,8 @@ function ReplyComposeEditorComponent({
             ...prev,
             TO: [
               {
-                id: threadCounterparty.id,
+                // `threadCounterparty.id` is a `Participant.id` — not a chip id.
+                id: generateId(),
                 identifier: threadCounterparty.identifier,
                 identifierType: threadCounterparty.identifierType,
                 name: threadCounterparty.name,
@@ -795,17 +797,21 @@ function ReplyComposeEditorComponent({
     (
       role: 'TO' | 'CC' | 'BCC',
       contactData: {
-        id: string
+        recordId: string
         identifier: string
         identifierType: IdentifierType
         name?: string | null
       }
     ) => {
+      // The chip id is minted here; the contact's id goes to `recordId`. Writing
+      // the record id into `id` made two addresses of one contact collide — see
+      // the note on `RecipientState.id`.
       upsertRecipient(role, {
-        id: contactData.id,
+        id: generateId(),
         identifier: contactData.identifier,
         identifierType: contactData.identifierType,
         name: contactData.name,
+        recordId: contactData.recordId,
       })
     },
     [upsertRecipient]
@@ -1383,6 +1389,14 @@ function ReplyComposeEditorComponent({
                 <div className='flex items-center gap-2 px-4 py-2'>
                   <span className='w-10 shrink-0 text-sm text-muted-foreground'>To:</span>
                   <RecipientInput
+                    // Remount on a From switch that changes the identifier model.
+                    // `reconcile-channel-switch` fixes the committed chips, but
+                    // the input keeps per-contact address lists fetched under the
+                    // OLD spec plus a half-typed value — so a pick made right
+                    // after switching email→phone offered email addresses and
+                    // committed one with `identifierType: PHONE`. Shipped in
+                    // #1654; reply mode can't reach it because From is pinned.
+                    key={platformCaps?.recipientModel ?? 'email'}
                     ref={toInputRef}
                     recipientModel={platformCaps?.recipientModel}
                     defaultRegion={phoneRegion}
@@ -1438,6 +1452,7 @@ function ReplyComposeEditorComponent({
                   <div className='flex items-center gap-2 px-4 py-2'>
                     <span className='w-10 shrink-0 text-sm text-muted-foreground'>Cc:</span>
                     <RecipientInput
+                      key={platformCaps?.recipientModel ?? 'email'}
                       ref={ccInputRef}
                       recipientModel={platformCaps?.recipientModel}
                       defaultRegion={phoneRegion}
@@ -1473,6 +1488,7 @@ function ReplyComposeEditorComponent({
                   <div className='flex items-center gap-2 px-4 py-2'>
                     <span className='w-10 shrink-0 text-sm text-muted-foreground'>Bcc:</span>
                     <RecipientInput
+                      key={platformCaps?.recipientModel ?? 'email'}
                       ref={bccInputRef}
                       recipientModel={platformCaps?.recipientModel}
                       defaultRegion={phoneRegion}

--- a/apps/web/src/components/mail/email-editor/recipient-input.test.tsx
+++ b/apps/web/src/components/mail/email-editor/recipient-input.test.tsx
@@ -124,22 +124,28 @@ function emailValues(addresses: string[], recordId = 'contact:c1') {
 }
 
 function renderInput(
-  recipients: Array<{ id: string; identifier: string; identifierType: 'EMAIL' }>,
+  recipients: Array<{
+    id: string
+    identifier: string
+    identifierType: 'EMAIL'
+    recordId?: string
+  }>,
   onContactSelect = vi.fn(),
-  onAdd = vi.fn()
+  onAdd = vi.fn(),
+  onRemove = vi.fn()
 ) {
   const utils = render(
     <RecipientInput
       recipients={recipients as never}
       field='TO'
       onAdd={onAdd}
-      onRemove={vi.fn()}
+      onRemove={onRemove}
       onMoveTo={vi.fn()}
       onContactSelect={onContactSelect}
       placeholder='To'
     />
   )
-  return { ...utils, onContactSelect, onAdd }
+  return { ...utils, onContactSelect, onAdd, onRemove }
 }
 
 interface PhoneRecipientStub {
@@ -209,7 +215,9 @@ describe('RecipientInput — contact expansion into N addresses', () => {
 
     await userEvent.click(rowB)
     expect(onContactSelect).toHaveBeenCalledWith({
-      id: 'c1',
+      // The contact's `EntityInstance.id`, under `recordId` — the chip id is
+      // minted by the parent, never the record id (see `RecipientState.id`).
+      recordId: 'c1',
       identifier: 'b@x.com',
       identifierType: 'EMAIL',
       name: 'Ada Lovelace',
@@ -224,7 +232,7 @@ describe('RecipientInput — contact expansion into N addresses', () => {
 
     await waitFor(() =>
       expect(onContactSelect).toHaveBeenCalledWith({
-        id: 'c1',
+        recordId: 'c1',
         identifier: 'a@x.com',
         identifierType: 'EMAIL',
         name: 'Ada Lovelace',
@@ -295,6 +303,43 @@ describe('RecipientInput — contact expansion into N addresses', () => {
   })
 })
 
+// Two addresses of ONE contact is a supported motion — the exclude filter keeps
+// a contact pickable until every address of theirs is a recipient. It used to
+// produce two chips carrying the SAME id, because `handleContactSelect` wrote
+// the contact's `EntityInstance.id` into `RecipientState.id`: duplicate React
+// keys, and `onRemove(id)` matching both chips in the parent's filter.
+describe('two chips sourced from the same contact', () => {
+  const bothOfAdas = [
+    { id: 'chip-1', identifier: 'a@x.com', identifierType: 'EMAIL' as const, recordId: 'c1' },
+    { id: 'chip-2', identifier: 'b@x.com', identifierType: 'EMAIL' as const, recordId: 'c1' },
+  ]
+
+  it('renders one badge per address', () => {
+    renderInput(bothOfAdas)
+
+    expect(screen.getByRole('option', { name: 'Recipient: a@x.com' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Recipient: b@x.com' })).toBeInTheDocument()
+  })
+
+  it('removes only the clicked chip — onRemove gets that chip id, not the shared recordId', async () => {
+    const { onRemove } = renderInput(bothOfAdas, vi.fn(), vi.fn(), vi.fn())
+
+    await userEvent.click(screen.getByLabelText('Remove b@x.com'))
+
+    expect(onRemove).toHaveBeenCalledTimes(1)
+    expect(onRemove).toHaveBeenCalledWith('chip-2')
+    expect(onRemove).not.toHaveBeenCalledWith('c1')
+  })
+
+  // Worth being precise about what these two tests do and do not cover: they pin
+  // the CONTRACT (distinct ids in → the right id back out), not the defect. The
+  // defect was the parent minting `id: contactData.id`, and what actually makes
+  // that unrepresentable is the type — `onContactSelect` now takes `recordId`,
+  // so no caller can hand a record id to the field the badge list keys on.
+  // Reproducing the original two-identical-chips state needs the whole editor;
+  // the type is the stronger guarantee, so it is deliberately not restated here.
+})
+
 // Quo (formerly OpenPhone) is the first channel whose recipient is a phone
 // number, not an address. The same input has to accept E.164, reject anything
 // libphonenumber can't parse, commit `PHONE`, and read the contact's
@@ -359,7 +404,7 @@ describe('RecipientInput — phone recipientModel', () => {
     await userEvent.click(screen.getByRole('option', { name: /\+442071838750/ }))
 
     expect(onContactSelect).toHaveBeenCalledWith({
-      id: 'c1',
+      recordId: 'c1',
       identifier: '+442071838750',
       identifierType: 'PHONE',
       name: 'Ada Lovelace',

--- a/apps/web/src/components/mail/email-editor/recipient-input.tsx
+++ b/apps/web/src/components/mail/email-editor/recipient-input.tsx
@@ -14,6 +14,7 @@ import {
 } from '@auxx/ui/components/dropdown-menu'
 import { Popover, PopoverAnchor, PopoverContent } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
+import { generateId } from '@auxx/utils'
 import { Copy, Mail, Phone, X } from 'lucide-react'
 import type React from 'react'
 import { useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react'
@@ -33,6 +34,7 @@ import {
   type PhoneRegion,
   type RecipientModel,
 } from './identifier-model'
+import type { RecipientState } from './types'
 
 export type RecipientField = 'TO' | 'CC' | 'BCC'
 
@@ -44,12 +46,9 @@ export type RecipientField = 'TO' | 'CC' | 'BCC'
  */
 const PASTE_SEPARATORS = /[,;\n\t]+/
 
-interface RecipientState {
-  id: string
-  identifier: string
-  identifierType: IdentifierTypeType
-  name?: string | null
-}
+// `RecipientState` is imported from `./types`, not redeclared here. It carried a
+// structurally identical local copy until the `id`/`recordId` split, which is
+// exactly the drift a second declaration invites.
 
 /** Imperative handle exposed via ref for parent components */
 export interface RecipientInputHandle {
@@ -64,8 +63,14 @@ interface RecipientInputProps {
   onAdd: (recipient: RecipientState) => void
   onRemove: (id: string) => void
   onMoveTo: (id: string, target: RecipientField) => void
+  /**
+   * A picked contact's identifier, committed. Carries `recordId` — the contact's
+   * `EntityInstance.id` — and **not** a chip id: the parent mints that. Passing
+   * the record id as the chip id is the collision documented on
+   * {@link RecipientState.id}.
+   */
   onContactSelect: (contact: {
-    id: string
+    recordId: string
     identifier: string
     identifierType: IdentifierTypeType
     name?: string | null
@@ -261,9 +266,8 @@ export function RecipientInput({
   const tryCommitInput = (): boolean => {
     const normalized = spec.normalize(inputValue)
     if (!normalized) return false
-    const dummyId = `temp_${Date.now()}_${normalized}`
     onAdd({
-      id: dummyId,
+      id: generateId(),
       identifier: normalized,
       identifierType: spec.identifierType,
       name: null,
@@ -379,7 +383,7 @@ export function RecipientInput({
   const commitContactAddress = useCallback(
     (contactId: string, address: string, name: string | null) => {
       onContactSelect({
-        id: contactId,
+        recordId: contactId,
         identifier: spec.normalize(address) ?? address,
         identifierType: spec.identifierType,
         name,
@@ -526,7 +530,6 @@ export function RecipientInput({
     // grown as we go since `recipients` doesn't update mid-loop.
     const seen = new Set(excludeIdentifiers)
     const leftover: string[] = []
-    const now = Date.now()
     for (const part of merged.split(PASTE_SEPARATORS)) {
       const trimmed = part.trim()
       if (!trimmed) continue
@@ -539,7 +542,7 @@ export function RecipientInput({
       if (seen.has(key)) continue
       seen.add(key)
       onAdd({
-        id: `temp_${now}_${normalized}`,
+        id: generateId(),
         identifier: normalized,
         identifierType: spec.identifierType,
         name: null,

--- a/apps/web/src/components/mail/email-editor/types.ts
+++ b/apps/web/src/components/mail/email-editor/types.ts
@@ -187,10 +187,36 @@ export type LocalAttachment = FileAttachment & {
 
 export type EditorMode = 'reply' | 'replyAll' | 'forward' | 'new' | 'draft'
 export interface RecipientState {
+  /**
+   * Chip identity, minted per chip with `generateId()`.
+   *
+   * 🔴 **NEVER a domain id.** This used to carry whatever id the chip's source
+   * happened to have — an `EntityInstance.id` from the record picker
+   * (`handleContactSelect`), a `Participant.id` from a draft, a reply's `from`
+   * or the always-on seed, or a `temp_<now>_<identifier>` string from typing.
+   * Four keyspaces in one field, and `removeRecipient` filters on it while the
+   * badge list keys on it — so two chips sourced from the SAME contact (two of
+   * Jane's email addresses, which the picker deliberately allows) collided:
+   * duplicate React keys, and `×` on either chip removed BOTH.
+   *
+   * Use {@link RecipientState.recordId} when you need the contact.
+   */
   id: string
   identifier: string
   identifierType: IdentifierType
   name?: string | null
+  /**
+   * `EntityInstance.id` of the contact this identifier belongs to, when the chip
+   * came from a source that knew one (the record picker). Absent for typed,
+   * pasted, reply-derived and draft-restored chips — the send payload
+   * (`toPayload`) carries only `{identifier, identifierType, name}`, so a chip
+   * that survives a draft round-trip comes back without it.
+   *
+   * Consumed by nothing yet; it is the prerequisite for the chip-menu
+   * "switch to another address" surface
+   * (`plans/email-editor/recipient-address-switch.md`).
+   */
+  recordId?: string
 }
 
 export type Recipients = {


### PR DESCRIPTION
Two live defects in the compose recipient field. Both are reachable on `main` today, neither needs a new feature to trigger, and the second one has been shipped since #1654.

Groundwork for the recipient-search rewrite (it consumes `recordId`), but both fixes stand on their own.

## 1. `RecipientState.id` carried four different keyspaces

The chip id was whatever id its source happened to have:

| source | what `id` held |
|---|---|
| record picker (`handleContactSelect`) | `EntityInstance.id` |
| draft participants (`derive-initial`) | `Participant.id` |
| a reply's `from` | `Participant.id` |
| the always-on SMS seed | `Participant.id` |
| typing / pasting | `temp_<now>_<identifier>` |

`removeRecipient` filters on that id and the badge list keys on it, so **two chips sourced from the same contact collided.** That is a supported motion, not an edge case: the picker's exclude filter keeps a contact pickable until *every* one of its addresses is a recipient, so picking two of Jane's email addresses one after the other is the normal path. The result was a duplicate React key and `×` on either chip removing **both**.

### Fix

`id` is now minted per chip with `generateId()`; the contact moves to a new optional `recordId`. `onContactSelect` takes `recordId` instead of `id`, so **a caller can no longer hand a record id to the field the badge list keys on** — the type is what makes the collision unrepresentable, not a runtime guard.

### Knock-on worth reviewing

`derive-initial.ts` used `r.id` as a `Participant.id` dedupe key for reply-all ("don't Cc the sender again"). With minted ids that comparison matches nothing, and reply-all would have Cc'd the sender it had just put in To. It now dedupes on `identifier`, which is also what `upsertRecipient` and `deduplicateRecipients` already use — and which catches a case the id version never could: the same address arriving under two `Participant` rows.

Also drops `recipient-input.tsx`'s own structurally-identical copy of `RecipientState` in favour of importing it from `./types`. Two declarations of the same shape is how they drift, and this split is exactly the kind of change that would have drifted them.

## 2. `RecipientInput` was not remounted when the identifier model changed

`reconcile-channel-switch` rewrites the *committed chips* on a From switch, but the input keeps state the reconciler never sees: per-contact address lists fetched under the **old** spec, and a half-typed value. So in new-compose, switching an email channel to Quo and then picking a contact offered that contact's **email addresses** under the phone spec, and committed one with `identifierType: PHONE` (`spec.normalize` returns null for an email, and the code falls back to the raw string).

Reply mode cannot reach it because From is pinned. Fixed with `key={platformCaps?.recipientModel}` on all three inputs (TO/CC/BCC), which clears the stale caches and the typed value on a model change.

## Testing

- **New `derive-initial.test.ts`** (the file had no coverage): 5 cases — minted ids from a draft, from a reply, distinct across TO/CC/BCC, plus both reply-all dedupe cases. The "same address under two `Participant` rows" case fails on the old id-keyed dedupe.
- **`recipient-input.test.tsx`**: two cases pinning that two chips sharing a `recordId` render separately and that `onRemove` receives the clicked chip's id. Existing `onContactSelect` assertions updated to the `recordId` contract.
- 71 tests passing across the 4 editor test files. Biome clean. `tsc` clean for the editor (the 10 remaining errors in `apps/web` are pre-existing, all in `workflow/nodes/core/human/panel.tsx`).

### Reviewer note on coverage

The two `recipient-input` cases pin the **contract** (distinct ids in → the right id back out); they do not reproduce the original defect, which lived in the parent's minting. Reproducing the two-identical-chips state needs the whole editor rendered, and the `recordId` signature change is the stronger guarantee — that reasoning is written into the test file rather than left implicit.

## Manual check suggested

1. New compose, email channel → pick a contact with 2 email addresses → add both → remove one. Only one should disappear.
2. New compose → switch From from an email channel to a Quo number → open the picker and pick a contact. No email address may appear, and nothing may commit an email with `identifierType: PHONE`.
3. Reply-all on a thread where the sender is also a TO participant. The sender should appear once, in To.
