### PR TITLE
refactor(participants): one channel model to identifier-field map, bound by both callers

### DIFF
--- a/apps/web/src/components/mail/email-editor/identifier-model.ts
+++ b/apps/web/src/components/mail/email-editor/identifier-model.ts
@@ -1,13 +1,16 @@
 // apps/web/src/components/mail/email-editor/identifier-model.ts
 
-import { IdentifierType } from '@auxx/database/enums'
 import type { IdentifierType as IdentifierTypeType } from '@auxx/database/types'
-import type { PlatformCapabilities } from '@auxx/lib/channels/client'
+import {
+  EMAIL_IDENTIFIER_FIELDS,
+  PHONE_IDENTIFIER_FIELDS,
+  type RecipientModel,
+} from '@auxx/lib/participants/channel-identifier-fields'
 import { formatPhoneNumber } from '@auxx/utils'
 import { type CountryCode, parsePhoneNumberFromString } from 'libphonenumber-js'
 
 /** The shape of identifier a channel addresses — `PlatformCapabilities.recipientModel`. */
-export type RecipientModel = PlatformCapabilities['recipientModel']
+export type { RecipientModel }
 
 /**
  * ISO-3166 region a national (no `+`) phone number is parsed against.
@@ -38,10 +41,12 @@ export function regionFromIdentifier(identifier?: string | null): PhoneRegion {
  * which contact field holds the candidate values, and what to call the thing
  * in copy.
  *
- * Keyed by `recipientModel` so the composer stays capability-driven — the same
- * switch the agent path uses in
- * `packages/lib/src/ai/kopilot/capabilities/mail/recipient-resolver.ts`
- * (`identifierTypesForIntegration` / `systemAttributeForChannel`).
+ * Keyed by `recipientModel` so the composer stays capability-driven. The
+ * model→field half now comes from `@auxx/lib/participants/channel-identifier-fields`,
+ * which the agent send path (`recipient-resolver.ts`) binds too — so there is one
+ * answer to "which contact field does this channel address", not two that agree
+ * by inspection. What stays local is genuinely UI: validation, display
+ * formatting, and copy.
  */
 export interface IdentifierModelSpec {
   /** `IdentifierType` committed on every recipient of this model. */
@@ -49,10 +54,13 @@ export interface IdentifierModelSpec {
 
   /**
    * `systemAttribute` candidates on the contact definition, in preference
-   * order. The first one that resolves to a field wins. Mirrors
-   * `systemAttributeForChannel` in the kopilot recipient resolver.
+   * order. The first one that resolves to a field wins.
+   *
+   * Comes from `@auxx/lib/participants/channel-identifier-fields` — the SAME
+   * switch the agent send path binds. It used to be restated here, which is how
+   * a composer reading `primary_email` on a phone channel becomes possible.
    */
-  systemAttributes: string[]
+  systemAttributes: readonly string[]
 
   /**
    * Key on the picker row's raw `data` holding the record's primary value —
@@ -94,8 +102,8 @@ export interface IdentifierModelSpec {
 const EMAIL_RE = /\S+@\S+\.\S+/
 
 const EMAIL_SPEC: IdentifierModelSpec = {
-  identifierType: IdentifierType.EMAIL,
-  systemAttributes: ['primary_email'],
+  identifierType: EMAIL_IDENTIFIER_FIELDS.identifierType,
+  systemAttributes: EMAIL_IDENTIFIER_FIELDS.systemAttributes,
   rowDataKey: 'email',
   secondaryInfoIsIdentifier: true,
   normalize: (raw) => {
@@ -117,10 +125,8 @@ const EMAIL_SPEC: IdentifierModelSpec = {
  */
 function createPhoneSpec(region: PhoneRegion): IdentifierModelSpec {
   return {
-    identifierType: IdentifierType.PHONE,
-    // `phone` is what the contact registry seeds (contact-fields.ts); older /
-    // connector-provisioned orgs can carry `primary_phone`.
-    systemAttributes: ['phone', 'primary_phone'],
+    identifierType: PHONE_IDENTIFIER_FIELDS.identifierType,
+    systemAttributes: PHONE_IDENTIFIER_FIELDS.systemAttributes,
     rowDataKey: 'phone',
     secondaryInfoIsIdentifier: false,
     // `formatPhoneNumber` is THE phone normalizer (libphonenumber-backed, E.164

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -868,6 +868,12 @@
       "import": "./dist/participants/index.mjs",
       "default": "./src/participants/index.ts"
     },
+    "./participants/channel-identifier-fields": {
+      "types": "./src/participants/channel-identifier-fields.ts",
+      "source": "./src/participants/channel-identifier-fields.ts",
+      "import": "./dist/participants/channel-identifier-fields.mjs",
+      "default": "./src/participants/channel-identifier-fields.ts"
+    },
     "./permissions": {
       "types": "./src/permissions/index.ts",
       "source": "./src/permissions/index.ts",

--- a/packages/lib/src/ai/kopilot/capabilities/mail/recipient-resolver.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/recipient-resolver.ts
@@ -6,6 +6,10 @@ import { isRecordId, parseRecordId, type RecordId } from '@auxx/types/resource'
 import { and, asc, desc, eq, inArray } from 'drizzle-orm'
 import type { IntegrationCatalogEntry } from '../../../../cache/integration-catalog'
 import { getCachedCustomFields } from '../../../../cache/org-cache-helpers'
+import {
+  identifierFieldsForModel,
+  identifierTypesForModel,
+} from '../../../../participants/channel-identifier-fields'
 import { Result, type TypedResult } from '../../../../result'
 import type { ToolContext } from '../../../agent-framework/tool-context'
 
@@ -44,42 +48,6 @@ export class RecipientResolutionError extends Error {
 const CUID_RE = /^[a-z0-9]{20,32}$/i
 const PHONE_RE = /^\+?[\d\s().-]{7,}$/
 
-type ChannelIdTypes = readonly IdentifierType[]
-
-function identifierTypesForIntegration(integration: IntegrationCatalogEntry): ChannelIdTypes {
-  switch (integration.recipientModel) {
-    case 'email':
-      return ['EMAIL']
-    case 'phone':
-      return ['PHONE']
-    case 'thread_only':
-      // Facebook/Instagram replies — both PSID variants accepted; specific tool
-      // calls reach this path only when threadReply mode resolves recipients.
-      return ['FACEBOOK_PSID', 'INSTAGRAM_IGSID']
-    case 'platform_user':
-      return []
-  }
-}
-
-/**
- * `systemAttribute` value on the contact's identifier `CustomField` for each
- * channel. Used as the fallback path when no `Participant` exists for the
- * contact yet (e.g. brand-new contact with only the email/phone set as a
- * field value, no inbound message history).
- */
-function systemAttributeForChannel(
-  integration: IntegrationCatalogEntry
-): { systemAttributes: string[]; identifierType: IdentifierType } | undefined {
-  switch (integration.recipientModel) {
-    case 'email':
-      return { systemAttributes: ['primary_email'], identifierType: 'EMAIL' }
-    case 'phone':
-      return { systemAttributes: ['phone', 'primary_phone'], identifierType: 'PHONE' }
-    default:
-      return undefined
-  }
-}
-
 /**
  * Look up the contact's primary identifier (email/phone) directly on the
  * `FieldValue` table for the relevant `systemAttribute` `CustomField`. This
@@ -93,7 +61,7 @@ async function lookupIdentifierFromFieldValue(
   ctx: ToolContext,
   entityDefinitionId: string,
   entityInstanceId: string,
-  systemAttributes: string[]
+  systemAttributes: readonly string[]
 ): Promise<string | undefined> {
   const customFields = await getCachedCustomFields(ctx.organizationId, entityDefinitionId)
   const matchingFieldIds = customFields
@@ -144,7 +112,7 @@ export async function resolveRecipients(
   integration: IntegrationCatalogEntry,
   ctx: ToolContext
 ): Promise<TypedResult<ResolvedRecipient[], RecipientResolutionError>> {
-  const acceptableTypes = identifierTypesForIntegration(integration)
+  const acceptableTypes = identifierTypesForModel(integration.recipientModel)
   if (acceptableTypes.length === 0) {
     return Result.error(
       new RecipientResolutionError(
@@ -208,7 +176,7 @@ export async function resolveRecipients(
         const parsed = parseRecordId(entry.value as RecordId)
         const matches = byInstance.get(parsed.entityInstanceId)
         // The contact's primary identifier: first FieldValue row by sortKey.
-        const sysAttr = systemAttributeForChannel(integration)
+        const sysAttr = identifierFieldsForModel(integration.recipientModel)
         const primaryIdentifier = sysAttr
           ? await lookupIdentifierFromFieldValue(
               ctx,

--- a/packages/lib/src/participants/__tests__/channel-identifier-fields.test.ts
+++ b/packages/lib/src/participants/__tests__/channel-identifier-fields.test.ts
@@ -1,0 +1,101 @@
+// packages/lib/src/participants/__tests__/channel-identifier-fields.test.ts
+//
+// The one model→identifier map. Two things are worth pinning here and nothing
+// else is:
+//
+// 1. `platform_user` returns `[]`, and `[]` must never be read as "no filter".
+//    `search.participants` shipped with
+//    `identifierTypes.length > 0 ? inArray(...) : undefined`, which turns that
+//    empty list into "every participant in the org, of every type". It is a
+//    silent fail-open, so it needs a test or it will not announce itself.
+// 2. The two halves cannot disagree. Filtering participants to `PHONE` while
+//    reading `primary_email` off the contact record is a plausible-looking wrong
+//    answer, and it is exactly what having two switches produced.
+
+import { describe, expect, it } from 'vitest'
+import {
+  EMAIL_IDENTIFIER_FIELDS,
+  identifierFieldsForModel,
+  identifierTypesForModel,
+  PHONE_IDENTIFIER_FIELDS,
+  type RecipientModel,
+} from '../channel-identifier-fields'
+
+/** Every `recipientModel`. If `PlatformCapabilities` grows one, this array is
+ *  the thing to extend — and the switches are exhaustive, so tsc will say so. */
+const ALL_MODELS: RecipientModel[] = ['email', 'phone', 'thread_only', 'platform_user']
+
+describe('identifierTypesForModel', () => {
+  it('maps email and phone to their single type', () => {
+    expect(identifierTypesForModel('email')).toEqual(['EMAIL'])
+    expect(identifierTypesForModel('phone')).toEqual(['PHONE'])
+  })
+
+  it('accepts both PSID variants for thread_only', () => {
+    expect(identifierTypesForModel('thread_only')).toEqual(['FACEBOOK_PSID', 'INSTAGRAM_IGSID'])
+  })
+
+  it('🔴 returns an EMPTY array for platform_user — which is "nothing addressable", not "no filter"', () => {
+    expect(identifierTypesForModel('platform_user')).toEqual([])
+  })
+
+  it('never returns undefined, so a caller cannot confuse "no types" with "unfiltered"', () => {
+    for (const model of ALL_MODELS) {
+      expect(Array.isArray(identifierTypesForModel(model))).toBe(true)
+    }
+  })
+})
+
+describe('identifierFieldsForModel', () => {
+  it('reads primary_email for email', () => {
+    expect(identifierFieldsForModel('email')).toEqual({
+      systemAttributes: ['primary_email'],
+      identifierType: 'EMAIL',
+    })
+  })
+
+  it('reads phone then primary_phone, in that preference order', () => {
+    const fields = identifierFieldsForModel('phone')
+    // Order is the contract: `phone` is what the contact registry seeds, and
+    // `primary_phone` only exists on older / connector-provisioned orgs.
+    expect(fields?.systemAttributes).toEqual(['phone', 'primary_phone'])
+    expect(fields?.identifierType).toBe('PHONE')
+  })
+
+  it('returns undefined for the models no contact field can serve', () => {
+    // Not a gap: no contact field holds a Facebook PSID or a platform user id,
+    // so the caller must SKIP the contact arm rather than fall back to email.
+    expect(identifierFieldsForModel('thread_only')).toBeUndefined()
+    expect(identifierFieldsForModel('platform_user')).toBeUndefined()
+  })
+})
+
+describe('the two halves agree', () => {
+  it('every model with contact fields has that fields type among its participant types', () => {
+    for (const model of ALL_MODELS) {
+      const fields = identifierFieldsForModel(model)
+      if (!fields) continue
+      expect(identifierTypesForModel(model)).toContain(fields.identifierType)
+    }
+  })
+
+  it('every model WITHOUT contact fields is either type-less or thread-scoped', () => {
+    // The inverse direction: a model may legitimately have participant types but
+    // no contact field (thread_only), but one with NO participant types must not
+    // claim a contact field — that would offer an address nothing can send to.
+    for (const model of ALL_MODELS) {
+      if (identifierTypesForModel(model).length === 0) {
+        expect(identifierFieldsForModel(model)).toBeUndefined()
+      }
+    }
+  })
+
+  it('the exported constants are the same objects both functions serve', () => {
+    // Guards the drift this module exists to prevent: a future edit that changes
+    // one switch arm without the other.
+    expect(identifierFieldsForModel('email')).toBe(EMAIL_IDENTIFIER_FIELDS)
+    expect(identifierFieldsForModel('phone')).toBe(PHONE_IDENTIFIER_FIELDS)
+    expect(identifierTypesForModel('email')).toEqual([EMAIL_IDENTIFIER_FIELDS.identifierType])
+    expect(identifierTypesForModel('phone')).toEqual([PHONE_IDENTIFIER_FIELDS.identifierType])
+  })
+})

--- a/packages/lib/src/participants/channel-identifier-fields.ts
+++ b/packages/lib/src/participants/channel-identifier-fields.ts
@@ -1,0 +1,110 @@
+// packages/lib/src/participants/channel-identifier-fields.ts
+//
+// THE map from a channel's `recipientModel` to (a) the `IdentifierType`s its
+// participants carry and (b) the contact fields that hold an addressable value.
+//
+// 🔴 **These two answers must come from the same place.** Anything that filters
+// participants to `PHONE` while reading `primary_email` off the contact record is
+// serving two different channels in one query — a wrong answer that looks
+// entirely plausible, because both halves are individually correct. That is why
+// this is one module exporting one pair, and not two switches that happen to
+// agree today.
+//
+// It is keyed on `recipientModel` — a plain string from
+// `PlatformCapabilities` — rather than on an `Integration` row or an
+// `IntegrationCatalogEntry`, so the composer (client) and the agent path
+// (server) can bind the SAME function. Do not add a parameter that only exists
+// server-side; that is what forced the duplication this module removes.
+//
+// ⚠️ **Client-safe: types and pure switches only.** No `db`, no cache, no
+// `'use client'` directive (a directive here would break every server import).
+// Bound today by:
+//   - `ai/kopilot/capabilities/mail/recipient-resolver.ts` (agent sends)
+//   - `apps/web/.../email-editor/identifier-model.ts` (the composer)
+
+import type { IdentifierType } from '@auxx/database/types'
+import type { PlatformCapabilities } from '../channels/client'
+
+/** The shape of identifier a channel addresses. */
+export type RecipientModel = PlatformCapabilities['recipientModel']
+
+/** The contact fields holding an addressable value, plus the type they produce. */
+export interface ChannelIdentifierFields {
+  /**
+   * `systemAttribute` candidates on the contact definition, in preference
+   * order — the first that resolves to a field wins.
+   */
+  readonly systemAttributes: readonly string[]
+  /** `IdentifierType` committed for a value read out of those fields. */
+  readonly identifierType: IdentifierType
+}
+
+export const EMAIL_IDENTIFIER_FIELDS: ChannelIdentifierFields = {
+  systemAttributes: ['primary_email'],
+  identifierType: 'EMAIL',
+}
+
+export const PHONE_IDENTIFIER_FIELDS: ChannelIdentifierFields = {
+  // `phone` is what the contact registry seeds (`contact-fields.ts`); older and
+  // connector-provisioned orgs can carry `primary_phone`.
+  systemAttributes: ['phone', 'primary_phone'],
+  identifierType: 'PHONE',
+}
+
+/**
+ * `IdentifierType`s a channel of this model can address.
+ *
+ * 🔴 **An empty array means "no valid type", NOT "no filter".** `platform_user`
+ * returns `[]`, and a caller that treats an empty list as "unfiltered" hands
+ * back every participant in the organization, of every type — the fail-open
+ * that `search.participants` shipped with
+ * (`identifierTypes.length > 0 ? inArray(...) : undefined`). Callers must
+ * distinguish three cases:
+ *
+ * | value | meaning |
+ * |---|---|
+ * | `undefined` (never returned here) | caller chose not to filter |
+ * | `['PHONE']` | that type only |
+ * | `[]` | nothing is addressable → empty result, not every result |
+ *
+ * The `switch` is exhaustive with no `default`, so adding a `recipientModel`
+ * to `PlatformCapabilities` is a type error here rather than a silent `[]`.
+ */
+export function identifierTypesForModel(model: RecipientModel): readonly IdentifierType[] {
+  switch (model) {
+    case 'email':
+      return [EMAIL_IDENTIFIER_FIELDS.identifierType]
+    case 'phone':
+      return [PHONE_IDENTIFIER_FIELDS.identifierType]
+    case 'thread_only':
+      // Facebook/Instagram replies — both PSID variants are accepted, because a
+      // thread's participant carries whichever the platform issued.
+      return ['FACEBOOK_PSID', 'INSTAGRAM_IGSID']
+    case 'platform_user':
+      // Internal platform recipients are addressed by user, not by identifier.
+      return []
+  }
+}
+
+/**
+ * The contact fields to read an addressable value from, or `undefined` when the
+ * model has none.
+ *
+ * `undefined` is a real answer, not a gap: no contact field holds a Facebook
+ * PSID or a platform user id, so a caller reading contact records for those
+ * models must **skip that arm entirely** rather than fall back to email — which
+ * would offer addresses the channel cannot send to.
+ */
+export function identifierFieldsForModel(
+  model: RecipientModel
+): ChannelIdentifierFields | undefined {
+  switch (model) {
+    case 'email':
+      return EMAIL_IDENTIFIER_FIELDS
+    case 'phone':
+      return PHONE_IDENTIFIER_FIELDS
+    case 'thread_only':
+    case 'platform_user':
+      return undefined
+  }
+}


### PR DESCRIPTION
**No behavior change.** Step 3 of the recipient-search work, after #1664 and #1665.

## The duplication

The map from a channel's `recipientModel` to (a) the `IdentifierType`s its participants carry and (b) the contact fields holding an addressable value existed in two places:

| | lib | web |
|---|---|---|
| model → identifier types | `identifierTypesForIntegration` (`recipient-resolver.ts`) | `spec.identifierType` |
| model → contact fields | `systemAttributeForChannel` (`recipient-resolver.ts`) | hardcoded `systemAttributes` arrays |

`identifier-model.ts` documented this against itself — "Mirrors `systemAttributeForChannel` in the kopilot recipient resolver."

**Why it matters more than tidiness:** filtering participants to `PHONE` while reading `primary_email` off the contact record is a wrong answer that looks entirely plausible, because both halves are *individually* correct — they just serve different channels. That failure is only representable while there are two switches.

## What replaces it

One module: `@auxx/lib/participants/channel-identifier-fields`, exporting `identifierTypesForModel`, `identifierFieldsForModel`, and the two constants (`EMAIL_IDENTIFIER_FIELDS`, `PHONE_IDENTIFIER_FIELDS`) the switches are built from.

Both switches are exhaustive with no `default`, so adding a `recipientModel` to `PlatformCapabilities` is a **type error here** rather than a silent empty result.

### Three design points worth a look

**Keyed on the `recipientModel` string, not on `IntegrationCatalogEntry`.** This was the actual *cause* of the duplication: the resolver's version took a server-only cache type, so the client composer could not bind it and had to restate the map. Client-safe here means types and pure switches only — and deliberately **no `'use client'` directive**, which would break every server import of this module.

**Placed at `participants/channel-identifier-fields.ts`, not `participants/search/`** as the plan first specified. Both consumers are the composer and the agent send path; neither is search, and a `search/` path would have the composer importing `@auxx/lib/participants/search/...`, implying a server-search dependency it does not have.

**The constants are exported alongside the functions** so the composer's specs read them directly with no non-null assertion at module scope. A test pins that both functions serve *the same objects*, so one switch arm cannot be edited without the other.

## Tests

10 cases on the new module. The one that matters most is the fail-open that motivated the whole section: **`platform_user` returns `[]`, and `[]` means "nothing addressable", never "no filter".** `search.participants` shipped with `identifierTypes.length > 0 ? inArray(...) : undefined`, which turns that empty list into every participant in the org, of every type. It is silent, so it gets a test.

Existing suites unchanged: 37 in `packages/lib/src/participants`, 71 in the web email-editor. lib and web typecheck with no new errors (the 29 in lib are in `scripts/` and a vitest config; the 10 in web are in an unrelated workflow panel — all pre-existing).

## Note on `packages/lib/package.json`

The `exports` field is codegen — `scripts/generate-exports.ts` scans source for `@auxx/lib/<subpath>` specifiers — so the new subpath appears because the composer imports it. Regenerated with the script, not hand-edited.

## 🔴 Bug found while extracting, NOT fixed here

`recipient-resolver.ts:216` and `:289` normalize a phone recipient with `value.replace(/[\s().-]/g, '')` — separator removal, not normalization:

| kopilot is told to text | resolver emits | storage/send expects |
|---|---|---|
| `(415) 555-1234` | `4155551234` | `+14155551234` |
| `030 901820` (Berlin) | `030901820` | `+4930901820` |

`formatPhoneNumber` is THE normalizer and says so in its own doc comment (`packages/utils/src/contact.ts`) — the write validator, `normalizeForLookup` and the import resolver all funnel through it *specifically* so write and lookup cannot drift. This path bypasses it, so an agent-resolved phone recipient can be a `Participant.identifier` matching no stored row, and a send address the channel receives raw.

Left alone on purpose: it is a behavior change to the agent send path rather than a move, and it needs an answer to "which region?" that the resolver has no input for today (`regionFromIdentifier(integration.identifier)` is probably it — the same source the composer uses). Its own change with its own tests. Flagging it here because this refactor is what surfaced it, and because two callers disagreeing about normalization is exactly the class of bug this module exists to prevent.
