### PR TITLE
fix(kopilot): normalize agent phone recipients through libphonenumber, not a separator strip

### DIFF
--- a/apps/web/src/components/mail/email-editor/identifier-model.ts
+++ b/apps/web/src/components/mail/email-editor/identifier-model.ts
@@ -6,34 +6,24 @@ import {
   PHONE_IDENTIFIER_FIELDS,
   type RecipientModel,
 } from '@auxx/lib/participants/channel-identifier-fields'
-import { formatPhoneNumber } from '@auxx/utils'
-import { type CountryCode, parsePhoneNumberFromString } from 'libphonenumber-js'
+import {
+  DEFAULT_PHONE_REGION,
+  formatPhoneNumber,
+  type PhoneRegion,
+  regionFromIdentifier,
+} from '@auxx/utils'
+import { parsePhoneNumberFromString } from 'libphonenumber-js'
 
 /** The shape of identifier a channel addresses — `PlatformCapabilities.recipientModel`. */
 export type { RecipientModel }
 
 /**
- * ISO-3166 region a national (no `+`) phone number is parsed against.
- * Re-exported so callers don't have to reach into `libphonenumber-js`.
+ * Region handling lives in `@auxx/utils` beside `formatPhoneNumber`, because the
+ * agent send path needs the same answer for the same reason (a channel's own
+ * number is what tells you how to parse a national number for that channel).
+ * Re-exported here so the composer's existing imports keep working.
  */
-export type PhoneRegion = CountryCode
-
-/** Region assumed when the sending channel has no parseable E.164 number. */
-export const DEFAULT_PHONE_REGION: PhoneRegion = 'US'
-
-/**
- * Region implied by a channel's OWN sending number.
- *
- * There is no `country` on the org profile, and an org with a German and a US
- * number should parse national input differently depending on which one it is
- * sending from — so the From channel's E.164 identifier is both the cheaper
- * and the more correct source. Falls back to {@link DEFAULT_PHONE_REGION} when
- * the channel carries no number (every email channel) or it doesn't parse.
- */
-export function regionFromIdentifier(identifier?: string | null): PhoneRegion {
-  if (!identifier) return DEFAULT_PHONE_REGION
-  return parsePhoneNumberFromString(identifier.trim())?.country ?? DEFAULT_PHONE_REGION
-}
+export { DEFAULT_PHONE_REGION, type PhoneRegion, regionFromIdentifier }
 
 /**
  * Everything the recipient input needs to know about ONE identifier shape:

--- a/packages/lib/src/ai/kopilot/capabilities/mail/__tests__/normalize-recipient-identifier.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/__tests__/normalize-recipient-identifier.test.ts
@@ -1,0 +1,82 @@
+// packages/lib/src/ai/kopilot/capabilities/mail/__tests__/normalize-recipient-identifier.test.ts
+//
+// The agent send path's identifier normalizer. It used to be
+// `value.replace(/[\s().-]/g, '')` — separator removal, which is only correct in
+// the NANP and not even there (it never adds the `+1`). Every case below either
+// produced a wrong string or a silently undeliverable one before the fix.
+
+import { describe, expect, it } from 'vitest'
+import { normalizeRecipientIdentifier } from '../recipient-resolver'
+
+describe('normalizeRecipientIdentifier — phone', () => {
+  it('produces E.164 for national US input, which the old strip never did', () => {
+    // Old behavior: '4155551234' — no country code, matches no stored participant.
+    expect(normalizeRecipientIdentifier('(415) 555-1234', 'PHONE', 'US')).toBe('+14155551234')
+    expect(normalizeRecipientIdentifier('415.555.1234', 'PHONE', 'US')).toBe('+14155551234')
+    expect(normalizeRecipientIdentifier('415-555-1234 ', 'PHONE', 'US')).toBe('+14155551234')
+  })
+
+  it('🔴 drops the trunk prefix for a region that has one — the case the strip got backwards', () => {
+    // Old behavior: '030901820'. E.164 drops the leading trunk `0`, so the old
+    // value was not a substring of the stored '+4930901820' either.
+    expect(normalizeRecipientIdentifier('030 901820', 'PHONE', 'DE')).toBe('+4930901820')
+    expect(normalizeRecipientIdentifier('020 7183 8750', 'PHONE', 'GB')).toBe('+442071838750')
+  })
+
+  it('parses the same national digits differently per region — which is why region is a parameter', () => {
+    const asUs = normalizeRecipientIdentifier('020 7183 8750', 'PHONE', 'US')
+    const asGb = normalizeRecipientIdentifier('020 7183 8750', 'PHONE', 'GB')
+    expect(asGb).toBe('+442071838750')
+    // Not merely different — the US reading is invalid, so it is refused rather
+    // than blessed with a `+1`.
+    expect(asUs).toBeNull()
+    expect(asUs).not.toBe(asGb)
+  })
+
+  it('is idempotent on an already-E.164 value, regardless of region', () => {
+    expect(normalizeRecipientIdentifier('+14155551234', 'PHONE', 'US')).toBe('+14155551234')
+    expect(normalizeRecipientIdentifier('+14155551234', 'PHONE', 'DE')).toBe('+14155551234')
+    expect(normalizeRecipientIdentifier('+4930901820', 'PHONE', 'US')).toBe('+4930901820')
+  })
+
+  it('returns null for numbers no numbering plan accepts, instead of a plausible string', () => {
+    // The point of null: the LLM gets a resolution error it can act on, rather
+    // than a send that silently goes nowhere.
+    expect(normalizeRecipientIdentifier('12345', 'PHONE', 'US')).toBeNull()
+    expect(normalizeRecipientIdentifier('1111111111', 'PHONE', 'US')).toBeNull()
+    expect(normalizeRecipientIdentifier('not a phone', 'PHONE', 'US')).toBeNull()
+    expect(normalizeRecipientIdentifier('   ', 'PHONE', 'US')).toBeNull()
+  })
+
+  it('agrees with formatPhoneNumber, because it IS formatPhoneNumber', async () => {
+    // Guards against a future "quick fix" reintroducing a local strip: write and
+    // lookup normalization must not drift.
+    const { formatPhoneNumber } = await import('@auxx/utils')
+    for (const raw of ['(415) 555-1234', '030 901820', '+442071838750', 'nonsense']) {
+      for (const region of ['US', 'DE', 'GB'] as const) {
+        expect(normalizeRecipientIdentifier(raw, 'PHONE', region)).toBe(
+          formatPhoneNumber(raw, region)
+        )
+      }
+    }
+  })
+})
+
+describe('normalizeRecipientIdentifier — other types', () => {
+  it('lowercases and trims email', () => {
+    expect(normalizeRecipientIdentifier('  Jane@Corp.COM ', 'EMAIL', 'US')).toBe('jane@corp.com')
+  })
+
+  it('passes opaque provider tokens through untouched apart from trimming', () => {
+    // A PSID is case-sensitive and has no canonical form to impose.
+    expect(normalizeRecipientIdentifier(' 1234567890AbCd ', 'FACEBOOK_PSID', 'US')).toBe(
+      '1234567890AbCd'
+    )
+    expect(normalizeRecipientIdentifier('Visitor_XyZ', 'CHAT_VISITOR', 'US')).toBe('Visitor_XyZ')
+  })
+
+  it('returns null for an empty value of any type', () => {
+    expect(normalizeRecipientIdentifier('', 'EMAIL', 'US')).toBeNull()
+    expect(normalizeRecipientIdentifier('  ', 'FACEBOOK_PSID', 'US')).toBeNull()
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/mail/recipient-resolver.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/mail/recipient-resolver.ts
@@ -3,6 +3,7 @@
 import { schema } from '@auxx/database'
 import type { IdentifierType } from '@auxx/database/types'
 import { isRecordId, parseRecordId, type RecordId } from '@auxx/types/resource'
+import { formatPhoneNumber, type PhoneRegion, regionFromIdentifier } from '@auxx/utils'
 import { and, asc, desc, eq, inArray } from 'drizzle-orm'
 import type { IntegrationCatalogEntry } from '../../../../cache/integration-catalog'
 import { getCachedCustomFields } from '../../../../cache/org-cache-helpers'
@@ -84,6 +85,44 @@ async function lookupIdentifierFromFieldValue(
   return undefined
 }
 
+/**
+ * Canonical form of a recipient identifier, or `null` when the value is not a
+ * valid identifier of that type.
+ *
+ * 🔴 **Phone goes through `formatPhoneNumber`, never a hand-rolled strip.** This
+ * used to be `value.replace(/[\s().-]/g, '')`, which is separator removal and not
+ * normalization: E.164 drops the trunk prefix, so `030 901820` became
+ * `030901820` where storage and the send both expect `+4930901820`, and
+ * `(415) 555-1234` became `4155551234` rather than `+14155551234`. The result was
+ * a `Participant.identifier` matching no stored row and an address handed to the
+ * channel raw. `formatPhoneNumber` is THE normalizer — the write validator,
+ * `normalizeForLookup` and the import resolver all funnel through it
+ * specifically so write and lookup cannot drift (`@auxx/utils` `contact.ts`).
+ *
+ * `region` matters and must come from the SENDING channel's own number
+ * (`regionFromIdentifier(integration.identifier)`), not a global default: an org
+ * with a German and a US number parses the same national input differently
+ * depending on which one it is sending from.
+ *
+ * Returning `null` rather than a best-effort string is deliberate — an invalid
+ * number should reach the LLM as a resolution error it can act on, not become a
+ * silently undeliverable send. Compare `normalizeOwnIdentifier`
+ * (`channels/own-identities.ts`), which applies the same rule but returns `''`
+ * because its contract is "never matches an own identity".
+ */
+export function normalizeRecipientIdentifier(
+  value: string,
+  type: IdentifierType,
+  region: PhoneRegion
+): string | null {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  if (type === 'PHONE') return formatPhoneNumber(trimmed, region)
+  if (type === 'EMAIL') return trimmed.toLowerCase()
+  // PSIDs / chat-visitor ids are opaque provider tokens — pass through as-is.
+  return trimmed
+}
+
 function detectFormat(entry: string): 'recordId' | 'participantId' | 'email' | 'phone' | 'unknown' {
   if (entry.includes(':') && isRecordId(entry)) return 'recordId'
   if (entry.includes('@')) return 'email'
@@ -113,6 +152,8 @@ export async function resolveRecipients(
   ctx: ToolContext
 ): Promise<TypedResult<ResolvedRecipient[], RecipientResolutionError>> {
   const acceptableTypes = identifierTypesForModel(integration.recipientModel)
+  // Region for national (no `+`) phone input: the sending channel's own number.
+  const region = regionFromIdentifier(integration.identifier)
   if (acceptableTypes.length === 0) {
     return Result.error(
       new RecipientResolutionError(
@@ -187,9 +228,25 @@ export async function resolveRecipients(
           : undefined
         // Prefer the participant matching the primary identifier; otherwise
         // fall back to the stable most-recently-used ordering above.
+        //
+        // 🔴 Both sides are normalized, not just lowercased. `own-identities.ts`
+        // states the rule and the reason: ingest's `normalizeIdentifier(x, PHONE)`
+        // is a bare digit-strip, so `+18889155797` and `18889155797` can both
+        // exist as stored identifiers while the contact's field value is E.164.
+        // A `toLowerCase()` comparison misses that, and the miss is silent — it
+        // falls through to `matches[0]` and addresses a DIFFERENT number of the
+        // same person.
+        const primaryNormalized =
+          primaryIdentifier && sysAttr
+            ? normalizeRecipientIdentifier(primaryIdentifier, sysAttr.identifierType, region)
+            : undefined
         const pick =
-          (primaryIdentifier &&
-            matches?.find((p) => p.identifier.toLowerCase() === primaryIdentifier.toLowerCase())) ||
+          (primaryNormalized &&
+            matches?.find(
+              (p) =>
+                normalizeRecipientIdentifier(p.identifier, p.identifierType, region) ===
+                primaryNormalized
+            )) ||
           matches?.[0]
         if (pick) {
           resolved.push({
@@ -207,16 +264,27 @@ export async function resolveRecipients(
         // from FieldValue via the contact's primary_email / phone
         // systemAttribute above.
         if (sysAttr && primaryIdentifier) {
+          const normalized = normalizeRecipientIdentifier(
+            primaryIdentifier,
+            sysAttr.identifierType,
+            region
+          )
+          if (!normalized) {
+            return Result.error(
+              new RecipientResolutionError(
+                `Contact's ${integration.channel} identifier "${primaryIdentifier}" is not a valid ${sysAttr.identifierType.toLowerCase()}`,
+                entry.value,
+                entry.role
+              )
+            )
+          }
           resolved.push({
             recordId: entry.value,
-            identifier:
-              sysAttr.identifierType === 'EMAIL'
-                ? primaryIdentifier.toLowerCase()
-                : sysAttr.identifierType === 'PHONE'
-                  ? primaryIdentifier.replace(/[\s().-]/g, '')
-                  : primaryIdentifier,
+            identifier: normalized,
             identifierType: sysAttr.identifierType,
             role: entry.role,
+            // The stored value, not the normalized one — this is the label a
+            // human recognizes on the confirmation card.
             displayName: primaryIdentifier,
           })
           break
@@ -269,7 +337,7 @@ export async function resolveRecipients(
           )
         }
         resolved.push({
-          identifier: entry.value.trim().toLowerCase(),
+          identifier: normalizeRecipientIdentifier(entry.value, 'EMAIL', region) ?? entry.value,
           identifierType: 'EMAIL',
           role: entry.role,
         })
@@ -285,8 +353,18 @@ export async function resolveRecipients(
             )
           )
         }
+        const normalizedPhone = normalizeRecipientIdentifier(entry.value, 'PHONE', region)
+        if (!normalizedPhone) {
+          return Result.error(
+            new RecipientResolutionError(
+              `"${entry.value}" is not a valid phone number${region === 'US' ? '' : ` for region ${region}`} — use E.164 (e.g. +14155551234)`,
+              entry.value,
+              entry.role
+            )
+          )
+        }
         resolved.push({
-          identifier: entry.value.replace(/[\s().-]/g, ''),
+          identifier: normalizedPhone,
           identifierType: 'PHONE',
           role: entry.role,
         })

--- a/packages/lib/src/cache/integration-catalog.ts
+++ b/packages/lib/src/cache/integration-catalog.ts
@@ -2,6 +2,7 @@
 
 import { createScopedLogger } from '@auxx/logger'
 import { PLATFORM_CAPABILITIES, type PlatformCapabilities } from '../channels/capabilities'
+import { getIdentifier } from '../channels/internal/identifier'
 import type { CachedChannel } from './providers/channels-provider'
 import { getOrgCache } from './singletons'
 
@@ -23,6 +24,16 @@ export interface IntegrationCatalogEntry {
   drafts: boolean
   attachments: boolean
   recipientModel: PlatformCapabilities['recipientModel']
+  /**
+   * The channel's OWN identifier — the address or number it sends *as*
+   * (`getIdentifier`: `Integration.email`, else `metadata.email` /
+   * `metadata.phoneNumber`, else the display name).
+   *
+   * Carried here because a phone channel's E.164 number is the only correct
+   * source for the region a national (no `+`) recipient number must be parsed
+   * against — see `regionFromIdentifier`. `null` when the channel exposes none.
+   */
+  identifier: string | null
   notes?: string
 }
 
@@ -72,6 +83,7 @@ export async function getCachedIntegrationCatalog(
       drafts: caps.drafts,
       attachments: caps.attachments,
       recipientModel: caps.recipientModel,
+      identifier: getIdentifier(c) ?? null,
       notes: caps.notes,
     })
   }

--- a/packages/utils/src/contact.ts
+++ b/packages/utils/src/contact.ts
@@ -95,6 +95,35 @@ export const formatPhoneNumber = (
   return parsed?.isValid() ? parsed.number : null
 }
 
+/** ISO-3166 region a national (no `+`) phone number is parsed against. */
+export type PhoneRegion = CountryCode
+
+/** Region assumed when nothing better is known. Matches `formatPhoneNumber`'s own default. */
+export const DEFAULT_PHONE_REGION: PhoneRegion = 'US'
+
+/**
+ * Region implied by an E.164 identifier — typically a channel's OWN sending
+ * number.
+ *
+ * This is the region to hand {@link formatPhoneNumber} when normalizing a
+ * national (no `+`) number for that channel. It is both cheaper and more correct
+ * than the org profile: an org with a German and a US number must parse
+ * `030 901820` differently depending on which one it is sending from, and there
+ * is no per-send country on the profile to express that.
+ *
+ * 🔴 **Getting this wrong is silent.** E.164 drops the trunk prefix, so parsing
+ * a Berlin number against `US` does not fail loudly — it yields `null` (caller
+ * sees "invalid") or, worse, a plausible `+1` number for input that happens to
+ * fit the NANP. Prefer a real region over the default whenever one is available.
+ *
+ * Falls back to {@link DEFAULT_PHONE_REGION} when the identifier is absent (every
+ * email channel) or does not parse.
+ */
+export const regionFromIdentifier = (identifier?: string | null): PhoneRegion => {
+  if (!identifier) return DEFAULT_PHONE_REGION
+  return parsePhoneNumberFromString(identifier.trim())?.country ?? DEFAULT_PHONE_REGION
+}
+
 export const formatStreetAddress = (street: string | null): string | null => {
   if (!street || typeof street !== 'string') return null // Handle empty or invalid input
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -18,6 +18,7 @@ export { getGroupPosition, groupConsecutiveComments } from './comments'
 // Contact utilities
 export {
   type ContactName,
+  DEFAULT_PHONE_REGION,
   formatCityName,
   formatCompanyName,
   formatComplexName,
@@ -27,6 +28,8 @@ export {
   getFullName,
   getInitials,
   getInitialsFromName,
+  type PhoneRegion,
+  regionFromIdentifier,
 } from './contact'
 // Counter utilities
 export { createCounter, createIdAllocator } from './counter'


### PR DESCRIPTION
A live correctness bug in the agent send path, surfaced by #1666's refactor. Not groundwork — if an agent has ever been asked to text someone, it has been producing wrong identifiers.

## The bug

`recipient-resolver.ts` normalized phone recipients with `value.replace(/[\s().-]/g, '')` at two sites. That is separator removal, not normalization, and it fails in two independent ways:

| input | old output | storage/send expects |
|---|---|---|
| `(415) 555-1234` | `4155551234` | `+14155551234` |
| `030 901820` (Berlin) | `030901820` | `+4930901820` |

It never adds the country code, so **even NANP input** produced an identifier matching no stored `Participant` and an address handed to the channel raw. And E.164 *drops* the trunk prefix, so for DE/GB/FR/NL/IT the old value wasn't even a substring of the stored number.

`formatPhoneNumber` is THE normalizer and says so in its own doc comment — the write validator, `normalizeForLookup` and the import resolver all funnel through it *specifically* so write and lookup cannot drift. This path bypassed it.

## The fix

One exported `normalizeRecipientIdentifier(value, type, region)`, used at both sites plus a third the same defect had reached:

**Raw phone entry and the `FieldValue` primary-identifier fallback** both normalize now, and an unparseable number returns a `RecipientResolutionError` instead of a best-effort string. An invalid number should reach the LLM as something it can act on, not become a silently undeliverable send.

**The "prefer the participant matching the contact's primary identifier" comparison** normalized *both sides* instead of lowercasing them. This one is worth a look: ingest's `normalizeIdentifier(x, PHONE)` is a bare digit-strip, so `+18889155797` and `18889155797` can both exist as stored identifiers while the contact's field value is E.164. A `toLowerCase()` compare misses that, falls through to `matches[0]`, and **addresses a different number of the same person** — silently. `own-identities.ts` already states this rule ("MUST be applied to both sides of every membership test") and the reason.

## Where the region comes from

The **sending channel's own number**, which is the only correct source: an org with a German and a US number parses the same national input differently depending on which one it's sending from, and there is no per-send country on the org profile to express that.

That needed `identifier` on `IntegrationCatalogEntry`, populated from the existing `getIdentifier` (`Integration.email`, else `metadata.email` / `metadata.phoneNumber`). **The LLM-visible prompt is unchanged** — the `integration-catalog` prompt section renders explicit named fields rather than serializing the entry, so nothing new reaches the model.

`regionFromIdentifier` / `PhoneRegion` / `DEFAULT_PHONE_REGION` moved out of the web composer into `@auxx/utils` beside `formatPhoneNumber`, since the agent path needs the same answer for the same reason. The composer re-exports them, so its call sites are untouched.

## Tests

9 cases on the normalizer, each covering a value that was previously wrong or silently undeliverable:

- E.164 out for national US input — the case the old strip never handled even in its own region
- trunk-prefix drop for DE and GB
- **the same national digits parse differently per region**: `020 7183 8750` is `+442071838750` as GB and *invalid* as US, so it's refused rather than blessed with a `+1`
- idempotence on already-E.164 values, regardless of region
- `null` (not a plausible string) for numbers no numbering plan accepts
- output equals `formatPhoneNumber`'s for every input × region pair — the guard that stops a future "quick fix" local strip from creeping back

691 lib tests pass across 81 files. utils, lib and web typecheck with no new errors (the 10 in web are pre-existing, in an unrelated workflow panel).

## Note for the reviewer

The working tree had unrelated dependency additions from a parallel session (`bson`, `libphonenumber-geo-carrier` in the workspace catalog and `packages/lib`). Those are deliberately **not** in this PR — only the six files above are staged.
