### PR TITLE
feat(participants): ranked recipient search SQL builders

### DIFF
--- a/packages/lib/src/participants/search/index.ts
+++ b/packages/lib/src/participants/search/index.ts
@@ -1,0 +1,17 @@
+// packages/lib/src/participants/search/index.ts
+//
+// Ranked recipient search. Explicit named exports per `docs/lib-module-guide.md`.
+//
+// The SQL builders ship ahead of the read function that assembles them
+// (`search-recipients.ts`, the participants ∪ contacts union) so the two halves
+// can be reviewed apart: these are pure, testable-by-rendered-SQL fragments with
+// no IO, and index-servability is a property of the text they emit.
+
+export {
+  type ParticipantSearchBinding,
+  participantRecencyScore,
+  participantSearchBinding,
+  participantSearchPredicate,
+  participantSearchRank,
+} from './participant-search-sql'
+export { phoneSearchPatterns } from './phone-query'

--- a/packages/lib/src/participants/search/participant-search-sql.test.ts
+++ b/packages/lib/src/participants/search/participant-search-sql.test.ts
@@ -1,0 +1,117 @@
+// packages/lib/src/participants/search/participant-search-sql.test.ts
+//
+// Only the aliased form exists to assert, and that is deliberate rather than a
+// test limitation — see the binding's own doc. Rendered SQL is checked because
+// what matters is index-servability, and that is a property of the emitted text
+// (`% ` vs a bare `similarity()`), not of the values.
+
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { describe, expect, it } from 'vitest'
+import {
+  participantRecencyScore,
+  participantSearchBinding,
+  participantSearchPredicate,
+  participantSearchRank,
+} from './participant-search-sql'
+
+const dialect = new PgDialect()
+const P = participantSearchBinding('p')
+const render = (fragment: Parameters<PgDialect['sqlToQuery']>[0]) => dialect.sqlToQuery(fragment)
+
+describe('participantSearchPredicate', () => {
+  it('emits three arms: fuzzy displayName, displayName ILIKE, identifier ILIKE', () => {
+    const { sql: text } = render(participantSearchPredicate('klooth', P))
+    expect(text).toContain(`(p."displayName" % $1 AND similarity(p."displayName", $2) > 0.3)`)
+    expect(text).toContain(`p."displayName" ILIKE $3`)
+    expect(text).toContain(`p."identifier" ILIKE $4`)
+  })
+
+  it('🔴 keeps the `%` operator beside the explicit similarity comparison', () => {
+    // The two say the same thing on purpose. `gin_trgm_ops` indexes the OPERATORS
+    // only, so a bare `similarity() > 0.3` can never be an index condition — and
+    // inside an OR block one unindexable arm forfeits the other arms' indexes
+    // too. Measured: 0.35 ms with the bitmap, 32.6 ms without it.
+    const { sql: text } = render(participantSearchPredicate('klooth', P))
+    expect(text).toContain('p."displayName" % ')
+    expect(text).toContain('similarity(p."displayName"')
+  })
+
+  it('emits NO tsvector arm — Participant has no corpus', () => {
+    const { sql: text } = render(participantSearchPredicate('klooth', P))
+    expect(text).not.toContain('to_tsvector')
+    expect(text).not.toContain('plainto_tsquery')
+  })
+
+  it('emits NO name arm — redundant with displayName by construction', () => {
+    const { sql: text } = render(participantSearchPredicate('klooth', P))
+    expect(text).not.toContain('p."name"')
+  })
+
+  it('adds one identifier arm per phone pattern, and none for an empty list', () => {
+    const none = render(participantSearchPredicate('klooth', P, []))
+    expect(none.sql.match(/p\."identifier" ILIKE/g)).toHaveLength(1)
+
+    const two = render(participantSearchPredicate('030 901820', P, ['4930901820', '30901820']))
+    expect(two.sql.match(/p\."identifier" ILIKE/g)).toHaveLength(3) // base arm + 2 patterns
+    expect(two.params).toContain('%4930901820%')
+    expect(two.params).toContain('%30901820%')
+  })
+
+  it('returns a parenthesized block, so AND-ing it cannot reassociate the WHERE', () => {
+    // An unparenthesized OR chain AND-ed into a WHERE widens the result set past
+    // every other filter — including the org scope.
+    const { sql: text } = render(participantSearchPredicate('klooth', P))
+    expect(text.startsWith('(')).toBe(true)
+    expect(text.endsWith(')')).toBe(true)
+  })
+
+  it('respects the alias it was built with', () => {
+    const { sql: text } = render(
+      participantSearchPredicate('klooth', participantSearchBinding('cand'))
+    )
+    expect(text).toContain('cand."displayName"')
+    expect(text).not.toContain('p."displayName"')
+  })
+})
+
+describe('participantSearchRank', () => {
+  it('weights name 2, identifier 1, recency 0.25', () => {
+    const { sql: text } = render(participantSearchRank('klooth', P))
+    expect(text).toContain(`COALESCE(similarity(p."displayName", $1), 0) * 2`)
+    expect(text).toContain(`COALESCE(similarity(p."identifier", $2), 0) * 1`)
+    expect(text).toContain('* 0.25')
+  })
+
+  it('COALESCEs every arm, so a row matching one arm still ranks', () => {
+    const { sql: text } = render(participantSearchRank('klooth', P))
+    // Three COALESCEs: name, identifier, and the recency term's own.
+    expect(text.match(/COALESCE\(/g)?.length).toBe(3)
+  })
+
+  it('takes the name weight from the shared TRIGRAM_WEIGHT rather than retyping 2', async () => {
+    // Guards the drift the shared module exists to prevent: records, mail and
+    // participants must weight their name arm with the same number.
+    const { TRIGRAM_WEIGHT } = await import('../../search/text-search-sql')
+    const weight = render(TRIGRAM_WEIGHT).sql
+    const { sql: text } = render(participantSearchRank('klooth', P))
+    expect(weight).toBe('2')
+    expect(text).toContain(`COALESCE(similarity(p."displayName", $1), 0) * ${weight}`)
+  })
+})
+
+describe('participantRecencyScore', () => {
+  it('is bounded and saturating, which is what makes the 0.25 weight derivable', () => {
+    const { sql: text } = render(participantRecencyScore(P))
+    // 1/(1+age) — strictly decreasing, supremum 1, so the weighted arm caps at 0.25.
+    expect(text).toContain('1.0 / (1.0 + EXTRACT(EPOCH FROM (now() - p."lastSentMessageAt"))')
+    expect(text).toContain('2592000.0')
+  })
+
+  it('scores a never-mailed participant 0 rather than NULL', () => {
+    // A NULL here would null the whole rank expression and drop the row from any
+    // ordering that compares it.
+    const { sql: text } = render(participantRecencyScore(P))
+    expect(text).toMatch(/^COALESCE\(/)
+    expect(text).toContain(', 0)')
+  })
+})

--- a/packages/lib/src/participants/search/participant-search-sql.ts
+++ b/packages/lib/src/participants/search/participant-search-sql.ts
@@ -1,0 +1,209 @@
+// packages/lib/src/participants/search/participant-search-sql.ts
+//
+// The PARTICIPANT binding of the shared ranked-search builder
+// (`search/text-search-sql.ts`). It names `Participant` columns and nothing
+// else — the trigram match arm and every scoring primitive come from the shared
+// module, so participants, records (`resources/search/record-search-sql.ts`) and
+// mail (`mail-query/thread-search-sql.ts`) cannot drift apart.
+//
+// 🔴 **No visibility predicate lives here.** The participant arm narrows with the
+// mail lens (`buildMailVisibilityPredicate`), applied by the caller as an `EXISTS`
+// alongside — never inside — this predicate. Same rule the shared module states
+// for itself.
+//
+// **What this binding does NOT take from the shared module: `textSearchPredicate`
+// and `textSearchRank`.** Both assume a maintained `tsvector` corpus, and
+// `Participant` deliberately has none:
+//
+//   - `record-search-sql.ts:31-36` measured why stemming is the wrong tool here:
+//     `to_tsvector` collapses `ada@acme-supply.io` into a single `email` token, so
+//     a tsvector arm cannot match `acme` *inside* an address. Identifier search is
+//     exactly the case stemming fails.
+//   - Names on this table are one to three short tokens. Stemming buys nothing
+//     trigram does not already give.
+//   - It would mean adding a maintained `searchText` column to `Participant` plus
+//     a write path to keep it fresh, for no measured recall.
+//
+// So the arms are composed here from the shared *parts*, the same way mail
+// composes its own three-arm rank rather than forking the formula.
+
+import { type SQL, sql } from 'drizzle-orm'
+import {
+  type TextSearchColumns,
+  TRIGRAM_WEIGHT,
+  textSearchTrigramMatch,
+  textSearchTrigramScore,
+} from '../../search/text-search-sql'
+
+/**
+ * How much an identifier similarity hit counts, against {@link TRIGRAM_WEIGHT}'s
+ * 2 on the name.
+ *
+ * People search a recipient field by name first and by address second, so this
+ * sits below the name arm and above nothing. A rank ordering, not a tuned number.
+ *
+ * ⚠️ On the phone model this arm is close to noise — trigrams over digit strings
+ * carry little signal. It stays bounded and the `ILIKE` arms do the real work
+ * there; not worth a per-model weight, but do not read the phone measurements as
+ * evidence that phone *ranking* works.
+ */
+const IDENTIFIER_WEIGHT = sql.raw('1')
+
+/**
+ * Weight on the recency term.
+ *
+ * 🔴 **Derived from a bound, not chosen.** {@link participantRecencyScore} is
+ * bounded on `[0, 1]`, so this arm contributes at most `0.25` — meaning it can
+ * only reorder rows whose name similarity differs by less than `0.125` (the name
+ * arm is weighted 2). It breaks ties inside a relevance band and **cannot**
+ * promote a clearly worse name match above a better one. That ceiling is the
+ * entire reason the recency function had to be bounded; with an unbounded one, any
+ * weight here is an unfalsifiable guess.
+ */
+const RECENCY_WEIGHT = sql.raw('0.25')
+
+/**
+ * Recency half-life, in seconds (30 days).
+ *
+ * **The one genuinely undetermined number in this file**, stated as such rather
+ * than dressed up. Nothing measured says 30 days; it says "about a month of
+ * correspondence still feels current". Changing it cannot break the
+ * {@link RECENCY_WEIGHT} guarantee, which follows from the *bound* on the
+ * function rather than from this constant.
+ */
+const RECENCY_HALF_LIFE_SECONDS = sql.raw('2592000.0')
+
+/**
+ * One aliased `Participant` binding.
+ *
+ * 🔴 **Everything is a raw aliased `SQL` ref, and the alias is carried
+ * explicitly.** The consumer (`search-recipients.ts`) is hand-written SQL of the
+ * shape `FROM "Participant" p`, and a Drizzle `PgColumn` renders table-qualified
+ * (`"Participant"."displayName"`), which Postgres rejects once the table carries
+ * an alias — see the `TextSearchRef` note in `search/text-search-sql.ts`. There is
+ * no Drizzle-column form here, unlike the record binding's two, because no
+ * Drizzle-composed consumer exists and an unused second binding only invites
+ * someone to pick the wrong one.
+ *
+ * `identifier` and `lastSentMessageAt` are fields on this interface rather than
+ * being derived from {@link TextSearchColumns}, which has no slot for them.
+ * Recovering the alias by string-splitting a rendered chunk would work until the
+ * first caller used a different alias.
+ */
+export interface ParticipantSearchBinding {
+  /**
+   * The shared-builder view of this table.
+   *
+   * `document` is bound to `displayName` and **never read**:
+   * {@link TextSearchColumns} requires the field, and this binding uses only the
+   * trigram primitives (there is no corpus — see the file header). It is not a
+   * corpus claim.
+   */
+  cols: TextSearchColumns
+  identifier: SQL
+  lastSentMessageAt: SQL
+}
+
+/** Build the binding for a given table alias. */
+export function participantSearchBinding(alias: string): ParticipantSearchBinding {
+  const col = (name: string) => sql.raw(`${alias}."${name}"`)
+  return {
+    cols: {
+      document: col('displayName'),
+      rank: col('displayName'),
+      fallbacks: [col('displayName'), col('identifier')],
+      id: col('id'),
+    },
+    identifier: col('identifier'),
+    lastSentMessageAt: col('lastSentMessageAt'),
+  }
+}
+
+/**
+ * Saturating recency: `1 / (1 + age_in_half_lives)`, `NULL → 0`.
+ *
+ * The same `r / (r + 1)` shape as `TS_RANK_SATURATING` — strictly decreasing in
+ * age, bounded on `(0, 1]` for a real timestamp, and 0 for a participant never
+ * mailed. Bounded is the requirement, not a nicety: {@link RECENCY_WEIGHT} is
+ * derived against the supremum.
+ */
+export function participantRecencyScore(binding: ParticipantSearchBinding): SQL<number> {
+  return sql<number>`COALESCE(1.0 / (1.0 + EXTRACT(EPOCH FROM (now() - ${binding.lastSentMessageAt})) / ${RECENCY_HALF_LIFE_SECONDS}), 0)`
+}
+
+/**
+ * The match predicate — a parenthesized `OR` block, safe to `AND` into a `WHERE`
+ * that already filters `organizationId`.
+ *
+ * Arms, all index-servable by the two `gin_trgm_ops` indexes from migration `0334`:
+ *
+ * ```text
+ *   (displayName % q AND similarity(displayName, q) > 0.3)   -- typo tolerance
+ *   OR displayName ILIKE '%q%'                              -- short queries
+ *   OR identifier  ILIKE '%q%'                              -- address substring
+ *   [OR identifier ILIKE '%<pattern>%' …]                   -- phone patterns
+ * ```
+ *
+ * 🔴 **Every arm must be index-servable, or none of them are.** Postgres builds
+ * this as a `BitmapOr` of one index scan per arm; a single arm with no index
+ * condition makes it abandon the bitmap entirely and filter the whole org slice.
+ * Measured on 200k rows / 10k per org: **0.35 ms** with both trigram indexes,
+ * **32.6 ms** with only the identifier one, for a byte-identical result set. The
+ * fuzzy arm keeps its redundant-looking `%` for the same reason
+ * (`text-search-sql.ts:188-225`) — a bare `similarity() > 0.3` is operator-free
+ * and therefore never an index condition.
+ *
+ * ⚠️ **There is deliberately no `name ILIKE` arm.** `Participant.name` is
+ * redundant with `displayName` by construction — `calculateDisplayName` returns
+ * the trimmed name whenever one exists, and every write site sets the pair
+ * together — so the arm could not match a row `displayName` did not, and it would
+ * have cost a third GIN index on a hot table. `schema/participant.ts` documents
+ * the invariant and names all six writers.
+ *
+ * @param query The raw user query, used for the name arms.
+ * @param phonePatterns From `phoneSearchPatterns` — `[]` adds no arm. Never pass
+ *   a bare `\D` strip; that is wrong outside the NANP for the reason documented
+ *   there.
+ */
+export function participantSearchPredicate(
+  query: string,
+  binding: ParticipantSearchBinding,
+  phonePatterns: readonly string[] = []
+): SQL {
+  const like = `%${query}%`
+  const arms: SQL[] = [
+    textSearchTrigramMatch(query, binding.cols),
+    ...binding.cols.fallbacks.map((fallback) => sql`${fallback} ILIKE ${like}`),
+    ...phonePatterns.map((pattern) => sql`${binding.identifier} ILIKE ${`%${pattern}%`}`),
+  ]
+  return sql`(${sql.join(arms, sql` OR `)})`
+}
+
+/**
+ * The relevance score:
+ *
+ * ```text
+ *   2    × similarity(displayName, q)
+ * + 1    × similarity(identifier,  q)
+ * + 0.25 × recency
+ * ```
+ *
+ * each `COALESCE`d to 0 so a row matching one arm still ranks. The name weight is
+ * {@link TRIGRAM_WEIGHT}, imported rather than retyped as `2` — the same number
+ * the record and mail bindings weight their name arm with.
+ *
+ * ⚠️ **Non-deterministic across calls**, because `now()` moves. Safe here and only
+ * here: this endpoint has no cursor (a recipient picker shows ~20 and you refine
+ * by typing), so no keyset can disagree with a re-evaluated rank. 🔴 If paging is
+ * ever added this becomes a skip/duplicate bug of exactly the kind
+ * `text-search-sql.ts` exists to prevent — pin `now()` into a parameter first, or
+ * leave the recency arm out of the cursor's expression.
+ */
+export function participantSearchRank(
+  query: string,
+  binding: ParticipantSearchBinding
+): SQL<number> {
+  const nameScore = textSearchTrigramScore(query, binding.cols)
+  const identifierScore = sql<number>`similarity(${binding.identifier}, ${query})`
+  return sql<number>`(COALESCE(${nameScore}, 0) * ${TRIGRAM_WEIGHT} + COALESCE(${identifierScore}, 0) * ${IDENTIFIER_WEIGHT} + ${participantRecencyScore(binding)} * ${RECENCY_WEIGHT})`
+}

--- a/packages/lib/src/participants/search/phone-query.test.ts
+++ b/packages/lib/src/participants/search/phone-query.test.ts
@@ -1,0 +1,128 @@
+// packages/lib/src/participants/search/phone-query.test.ts
+//
+// Every case here is one that a `query.replace(/\D/g, '')` implementation gets
+// wrong or misses. The NANP ones it gets right by luck; the trunk-prefix ones are
+// the reason this function exists.
+
+import { describe, expect, it } from 'vitest'
+import { phoneSearchPatterns } from './phone-query'
+
+/** Does any pattern match the stored E.164 the way the SQL arm would? */
+const matches = (patterns: string[], stored: string) => patterns.some((p) => stored.includes(p))
+
+describe('phoneSearchPatterns — trunk-prefix regions', () => {
+  it('🔴 finds a Berlin number typed the way it is printed', () => {
+    // The whole point. A `\D` strip yields '030901820', which is NOT a substring
+    // of '+4930901820' — E.164 drops the trunk 0.
+    const patterns = phoneSearchPatterns('030 901820', 'DE')
+    expect(matches(patterns, '+4930901820')).toBe(true)
+    expect(patterns).toContain('30901820')
+  })
+
+  it('finds a London number typed nationally', () => {
+    const patterns = phoneSearchPatterns('020 7183 8750', 'GB')
+    expect(matches(patterns, '+442071838750')).toBe(true)
+  })
+
+  it('a bare digit strip would NOT have matched either — pinning the contrast', () => {
+    for (const [typed, stored] of [
+      ['030 901820', '+4930901820'],
+      ['020 7183 8750', '+442071838750'],
+    ] as const) {
+      expect(stored.includes(typed.replace(/\D/g, ''))).toBe(false)
+    }
+  })
+})
+
+describe('phoneSearchPatterns — NANP', () => {
+  it('matches a fully typed US number in any common formatting', () => {
+    for (const typed of ['(415) 555-1234', '415.555.1234', '415 555 1234', '+1 415 555 1234']) {
+      expect(matches(phoneSearchPatterns(typed, 'US'), '+14155551234')).toBe(true)
+    }
+  })
+
+  it('matches a partial number, which never parses to a VALID one', () => {
+    // A fragment either fails to parse or parses to something `isValid()` rejects,
+    // so the raw-digits pattern is the only one that can carry it — which is why
+    // that pattern is unconditional rather than an `else` branch.
+    expect(matches(phoneSearchPatterns('(415) 555', 'US'), '+14155551234')).toBe(true)
+    expect(matches(phoneSearchPatterns('4155551', 'US'), '+14155551234')).toBe(true)
+  })
+})
+
+describe('phoneSearchPatterns — the region parameter earns its keep', () => {
+  it('produces different patterns for the same digits in different regions', () => {
+    const asGb = phoneSearchPatterns('020 7183 8750', 'GB')
+    const asUs = phoneSearchPatterns('020 7183 8750', 'US')
+    expect(matches(asGb, '+442071838750')).toBe(true)
+    // US cannot parse it, so it falls back to raw digits and finds nothing.
+    expect(matches(asUs, '+442071838750')).toBe(false)
+    expect(asGb).not.toEqual(asUs)
+  })
+})
+
+describe('phoneSearchPatterns — the trigram floor', () => {
+  it('returns [] below three digits, because no full trigram is extractable', () => {
+    // Not "match everything" — [] means the caller adds no phone arm at all. An
+    // ILIKE '%xy%' has no index to use and would drop the whole OR block to a
+    // sequential scan.
+    expect(phoneSearchPatterns('4', 'US')).toEqual([])
+    expect(phoneSearchPatterns('41', 'US')).toEqual([])
+    expect(phoneSearchPatterns('(4', 'US')).toEqual([])
+  })
+
+  it('returns [] for input with no digits at all', () => {
+    expect(phoneSearchPatterns('klooth', 'US')).toEqual([])
+    expect(phoneSearchPatterns('', 'US')).toEqual([])
+    expect(phoneSearchPatterns('   ', 'US')).toEqual([])
+  })
+
+  it('admits exactly three digits, and invents nothing from them', () => {
+    // Not `['1415', '415']`: `parsePhoneNumberFromString('415', 'US')` parses to
+    // `+1415`, which is not a valid number. Its patterns would include a
+    // synthetic '1415' that matches unrelated numbers like '+13161415000' — an
+    // arm nobody typed. Hence the `isValid()` gate.
+    expect(phoneSearchPatterns('415', 'US')).toEqual(['415'])
+  })
+
+  it('contributes no parsed patterns for a fragment that only LOOKS parseable', () => {
+    for (const fragment of ['415', '4155', '41555']) {
+      // Only the raw digits survive — one arm, exactly what was typed.
+      expect(phoneSearchPatterns(fragment, 'US')).toEqual([fragment])
+    }
+  })
+
+  it('never returns a pattern shorter than the floor', () => {
+    for (const typed of ['415', '4155', '(415) 555-1234', '030 901820', '+49 30 901820']) {
+      for (const pattern of phoneSearchPatterns(typed, 'DE')) {
+        expect(pattern.length).toBeGreaterThanOrEqual(3)
+      }
+    }
+  })
+})
+
+describe('phoneSearchPatterns — shape', () => {
+  it('deduplicates, so a fully typed national number is not three identical probes', () => {
+    const patterns = phoneSearchPatterns('4155551234', 'US')
+    expect(new Set(patterns).size).toBe(patterns.length)
+  })
+
+  it('keeps the arm count small — at most three probes', () => {
+    for (const typed of ['(415) 555-1234', '030 901820', '+442071838750', '415555']) {
+      expect(phoneSearchPatterns(typed, 'DE').length).toBeLessThanOrEqual(3)
+    }
+  })
+
+  it('strips the + so patterns are substrings of the stored identifier', () => {
+    // An E.164 pattern WITH the `+` would still match, but the national and raw
+    // forms would not — and the point is that all arms search the same way.
+    for (const pattern of phoneSearchPatterns('+14155551234', 'US')) {
+      expect(pattern.startsWith('+')).toBe(false)
+    }
+  })
+
+  it('is idempotent on an already-E.164 input', () => {
+    expect(matches(phoneSearchPatterns('+4930901820', 'US'), '+4930901820')).toBe(true)
+    expect(matches(phoneSearchPatterns('+14155551234', 'DE'), '+14155551234')).toBe(true)
+  })
+})

--- a/packages/lib/src/participants/search/phone-query.ts
+++ b/packages/lib/src/participants/search/phone-query.ts
@@ -1,0 +1,78 @@
+// packages/lib/src/participants/search/phone-query.ts
+
+import type { PhoneRegion } from '@auxx/utils'
+import { parsePhoneNumberFromString } from 'libphonenumber-js'
+
+/**
+ * Minimum pattern length. Below three characters `pg_trgm` extracts no full
+ * trigram, so an `ILIKE '%xy%'` degrades to a sequential scan no matter what is
+ * indexed (`search/text-search-sql.ts` documents the same floor for its ILIKE
+ * fallbacks).
+ */
+const TRIGRAM_FLOOR = 3
+
+/**
+ * Substring patterns to match a typed phone query against stored E.164
+ * identifiers.
+ *
+ * 🔴 **Stripping non-digits is NOT normalization, and that was the bug this
+ * function exists to prevent.** `Participant.identifier` is E.164, and E.164
+ * **drops the trunk prefix** every country with one prints. So the digits a
+ * German reads off their own invoice are not a substring of what we store:
+ *
+ * | typed | `\D`-stripped | stored | matches? |
+ * |---|---|---|---|
+ * | `(415) 555-1234` | `4155551234` | `+14155551234` | ✅ |
+ * | `030 901820` (Berlin) | `030901820` | `+4930901820` | 🔴 **no** |
+ * | `030 901820` → national | `30901820` | `+4930901820` | ✅ |
+ *
+ * A digit-strip-only implementation therefore works in the NANP and silently
+ * finds nobody in DE/GB/FR/NL/IT — for an org sending from a German number, that
+ * is every search they will ever run.
+ *
+ * So the query is parsed, and up to three patterns come back:
+ *
+ * 1. the full E.164 **without** the `+` (so it is a substring of the stored form),
+ * 2. the national significant number (trunk prefix removed),
+ * 3. the raw digits as typed.
+ *
+ * ⚠️ **(3) is kept even when parsing succeeds, deliberately.**
+ * `parsePhoneNumberFromString` returns `undefined` for a partial number, which is
+ * the common case while someone is still typing — so (3) cannot be the `else`
+ * branch of an `if`. When the parse *does* succeed it is usually a duplicate of
+ * (2) and the `Set` collapses it; when it is not, it costs one extra index probe
+ * and can still match a legacy row stored without a `+`. Three probes is within
+ * the budget `text-search-sql.ts` sets (the record binding spends four).
+ *
+ * @param query Raw user input, any formatting.
+ * @param region Region national (no `+`) input is parsed against. Must come from
+ *   the SENDING channel's own number (`regionFromIdentifier`), never a global
+ *   default — the same input means different numbers in different regions.
+ * @returns Distinct digit patterns, or `[]` when there is nothing safely
+ *   searchable. **`[]` means "add no phone arm", not "match everything".**
+ */
+export function phoneSearchPatterns(query: string, region: PhoneRegion): string[] {
+  const digits = query.replace(/\D/g, '')
+  if (digits.length < TRIGRAM_FLOOR) return []
+
+  const patterns = new Set<string>()
+  const parsed = parsePhoneNumberFromString(query, region)
+  // 🔴 `isValid()`, not merely "parsed" — the same gate `formatPhoneNumber` uses.
+  // `parsePhoneNumberFromString` happily returns a PhoneNumber for a fragment:
+  // `('415', 'US')` yields `+1415`, whose patterns would be `1415` and `415`. That
+  // synthetic `1415` is a real false-positive arm (it matches `+13161415000`), and
+  // it is invented rather than typed. An invalid or partial parse contributes
+  // nothing, and the raw-digits pattern below carries the fragment instead.
+  if (parsed?.isValid()) {
+    // `.number` is `+4930901820`; drop the `+` so the pattern is a substring of
+    // the stored identifier rather than an anchored equality.
+    patterns.add(parsed.number.slice(1))
+    patterns.add(parsed.nationalNumber)
+  }
+  patterns.add(digits)
+
+  // A pattern can fall under the floor even when the input does not — a national
+  // number of one or two digits is not a thing, but `nationalNumber` is provider
+  // data and this keeps the guarantee unconditional.
+  return [...patterns].filter((pattern) => pattern.length >= TRIGRAM_FLOOR)
+}


### PR DESCRIPTION
The pure half of step 4 of the recipient-search plan. **Nothing consumes these yet** — `search-recipients.ts` (the participants ∪ contacts read) and the tRPC procedure follow in the next PR.

Split deliberately: these are pure fragments with no IO, and index-servability is a property of the SQL text they emit, so they can be reviewed and tested on their own. The orchestration is a different kind of change.

## `participant-search-sql.ts`

Binds the shared builder's trigram *parts* — **not** `textSearchPredicate` / `textSearchRank`. Both assume a maintained tsvector corpus and `Participant` deliberately has none:

- `to_tsvector` collapses `ada@acme-supply.io` into a single `email` token, so a stemming arm **cannot match `acme` inside an address** — exactly the case identifier search needs. (`record-search-sql.ts` measured this.)
- Names on this table are one to three short tokens; stemming buys nothing trigram doesn't already give.
- A corpus would mean a maintained `searchText` column on `Participant` plus a write path to keep it fresh, for no measured recall.

**Predicate** — fuzzy `displayName` (`%` AND explicit `similarity`), `displayName ILIKE`, `identifier ILIKE`, plus one arm per phone pattern. All index-servable by migration `0334`'s two trigram indexes. No `name` arm: redundant with `displayName` by construction, and it would have cost a third GIN index on a hot table.

**Rank** — `2 × similarity(displayName) + 1 × similarity(identifier) + 0.25 × recency`.

The name weight is the shared `TRIGRAM_WEIGHT`, imported rather than retyped as `2`, and a test pins that so records/mail/participants can't drift. Recency is `1/(1 + age/30d)`, bounded on `[0,1]` — **which is what makes `0.25` derivable rather than guessed**: the arm contributes at most `0.25`, so it can only reorder rows whose name similarity differs by less than `0.125`. It breaks ties inside a relevance band and cannot promote a worse name match above a better one. The 30-day half-life is the one genuinely undetermined number and says so.

**One design note for the reviewer:** the binding carries `identifier` and `lastSentMessageAt` as explicit fields. The first draft recovered the table alias by string-splitting a rendered SQL chunk, which works right up until a caller uses a different alias — there's now a test asserting alias independence.

## `phone-query.ts`

Up to three substring patterns for a typed phone query. Stripping non-digits is **not** normalization: E.164 drops the trunk prefix, so `030 901820` → `030901820`, which is not a substring of the stored `+4930901820`. A strip-only implementation works in the NANP and silently finds nobody in DE/GB/FR/NL/IT.

**Gated on `isValid()`, not merely "parsed" — found while writing the tests, and it matters.** `parsePhoneNumberFromString('415', 'US')` happily returns `+1415`, whose patterns would include a synthetic `1415` matching unrelated numbers like `+13161415000`. That's an arm nobody typed. Invalid or partial parses now contribute nothing, and the raw-digits pattern carries the fragment instead — which is also why that pattern is unconditional rather than an `else` branch (a fragment never parses validly).

Returns `[]` below three digits — the trigram floor, where an `ILIKE` has no index to use and would drop the whole OR block to a sequential scan. **`[]` means "add no phone arm", never "match everything."**

## Tests (27)

Rendered-SQL assertions for arm shape; the redundant-looking `%` that keeps the fuzzy arm indexable (a bare `similarity() > 0.3` is operator-free and can never be an index condition — 0.35 ms vs 32.6 ms measured); absence of the tsvector and `name` arms; alias independence; weight provenance; the recency bound and its `COALESCE`.

For phone: the trunk-prefix cases, plus an explicit assertion that **a bare digit strip would not have matched** — pinning the contrast rather than just the fix. And that the same national digits produce different patterns per region (`020 7183 8750` finds `+442071838750` as GB and nothing as US).

64 tests pass across `src/participants`; `packages/lib` typechecks with no errors in `src/`.

## Note

The working tree has unrelated in-progress work from a parallel session — a new `packages/lib/src/phone-geo/` module, `libphonenumber-geo-carrier`, worker and field-hook registrations. **None of it is in this PR** (only the five files above are staged), but worth flagging: that module and this one both do libphonenumber work on phone identifiers, so there may be something to reconcile once both land.
