### PR TITLE
feat(contacts): derive city, region and timezone from phone numbers

### DIFF
--- a/apps/worker/src/server.ts
+++ b/apps/worker/src/server.ts
@@ -7,6 +7,7 @@ import { configService } from '@auxx/credentials'
 import { closePools } from '@auxx/database'
 import { registerChannelHooks } from '@auxx/lib/channels'
 import { closeAllQueues, closeFlowProducer } from '@auxx/lib/jobs/queues'
+import { warmPhoneGeo } from '@auxx/lib/phone-geo'
 import { shutdownPostHog } from '@auxx/lib/posthog/posthog-client'
 import { serve } from '@hono/node-server'
 import type { Worker } from 'bullmq'
@@ -30,6 +31,10 @@ let inboundEmailPoller: InboundEmailPoller | null = null
 async function initializeApp() {
   await configService.init()
   registerChannelHooks()
+  // Deserialize the phone geocoding tables (~13ms) up front. The worker runs mail/SMS ingest,
+  // which is the heaviest producer of phone writes, so paying this at boot keeps it off the
+  // first inbound message. Idempotent and never throws.
+  warmPhoneGeo()
 
   console.log('Setting up schedules...')
   await setupSchedules()

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -964,6 +964,12 @@
       "import": "./dist/permissions/visibility/client.mjs",
       "default": "./src/permissions/visibility/client.ts"
     },
+    "./phone-geo": {
+      "types": "./src/phone-geo/index.ts",
+      "source": "./src/phone-geo/index.ts",
+      "import": "./dist/phone-geo/index.mjs",
+      "default": "./src/phone-geo/index.ts"
+    },
     "./placeholders": {
       "types": "./src/placeholders/index.ts",
       "source": "./src/placeholders/index.ts",
@@ -1489,6 +1495,7 @@
     "@trpc/server": "catalog:",
     "addressparser": "^1.0.1",
     "ajv": "^8",
+    "bson": "catalog:",
     "bullmq": "catalog:",
     "cheerio": "^1.1.2",
     "cohere-ai": "^7.18.1",
@@ -1519,6 +1526,7 @@
     "json-logic-js": "^2.0.5",
     "langsmith": "^0.3.0",
     "ldapjs": "^3.0.7",
+    "libphonenumber-geo-carrier": "catalog:",
     "libphonenumber-js": "catalog:",
     "lru-cache": "11.1.0",
     "lucide-react": "catalog:",

--- a/packages/lib/src/data-migrations/migrations/088-phone-geo-backfill.test.ts
+++ b/packages/lib/src/data-migrations/migrations/088-phone-geo-backfill.test.ts
@@ -1,0 +1,52 @@
+// packages/lib/src/data-migrations/migrations/088-phone-geo-backfill.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { CONTACT_FIELDS } from '../../resources/registry/resources/contact-fields'
+import { ALL_DATA_MIGRATIONS } from '../registry'
+import { migration088PhoneGeoBackfill } from './088-phone-geo-backfill'
+
+/**
+ * The backfill's row-level behaviour needs a database; what is worth pinning without one is the
+ * set of assumptions it would silently violate if the registry moved underneath it.
+ */
+describe('migration088PhoneGeoBackfill', () => {
+  it('is registered with the id its filename claims', () => {
+    expect(migration088PhoneGeoBackfill.id).toBe('088-phone-geo-backfill')
+  })
+
+  it('is registered exactly once', () => {
+    const matches = ALL_DATA_MIGRATIONS.filter((m) => m.id === migration088PhoneGeoBackfill.id)
+    expect(matches).toHaveLength(1)
+  })
+
+  it('targets system attributes that actually exist on the contact registry', () => {
+    // The four fields it fills, plus the one it reads. A rename on either side would turn the
+    // backfill into a silent no-op — it matches on `systemAttribute` strings.
+    for (const key of ['phone', 'city', 'region', 'country', 'timezone'] as const) {
+      expect(CONTACT_FIELDS[key]?.systemAttribute).toBe(key)
+    }
+  })
+
+  /**
+   * Load-bearing, for the same reason migration 086 needed it: `phone` is a generic attribute
+   * name that ORG-CREATED defs reuse (the dev DB carries it on `leads` and `vendors`). Without
+   * the `entityType` join the backfill would walk records on defs that have no geo fields to
+   * fill.
+   */
+  it('is scoped to the seeded contact def', () => {
+    const source = migration088PhoneGeoBackfill.run.toString()
+    expect(source).toContain('EntityDefinition')
+    expect(source).toContain("entityType\" = 'contact'")
+  })
+
+  /**
+   * The fill-if-blank rule is the whole safety story: area-code geo is the weakest of the three
+   * producers (chat visitor-IP geo and human input both outrank it), so the backfill must skip
+   * any contact that already holds a value rather than overwrite it.
+   */
+  it('skips values that are already filled', () => {
+    const source = migration088PhoneGeoBackfill.run.toString()
+    expect(source).toContain('filledKeys')
+    expect(source).toContain('valueText" IS NOT NULL')
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/088-phone-geo-backfill.ts
+++ b/packages/lib/src/data-migrations/migrations/088-phone-geo-backfill.ts
@@ -1,0 +1,170 @@
+// packages/lib/src/data-migrations/migrations/088-phone-geo-backfill.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { sql } from 'drizzle-orm'
+import { lookupPhoneGeo } from '../../phone-geo'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-088')
+
+/** Target systemAttribute → the `PhoneGeo` key that feeds it. Mirrors `derive-geo-hook.ts`. */
+const GEO_ATTRIBUTES = [
+  ['city', 'city'],
+  ['region', 'region'],
+  ['country', 'country'],
+  ['timezone', 'timezone'],
+] as const
+
+/** Contacts pulled per round. Bounded so one org with a large book cannot balloon the heap. */
+const BATCH_SIZE = 500
+
+interface FieldIds {
+  organizationId: string
+  phoneFieldId: string
+  targets: Array<{ attribute: (typeof GEO_ATTRIBUTES)[number][1]; fieldId: string }>
+}
+
+/**
+ * Backfill contact city/region/country/timezone from the numbering-plan origin of each contact's
+ * primary phone number.
+ *
+ * The `PHONE_INTL` field hook (`phone-geo/derive-geo-hook.ts`) covers every phone written from
+ * now on; this catches everything already stored — most importantly the contacts auto-created by
+ * SMS ingest, whose only content is a phone number.
+ *
+ * **Self-sufficient.** Reads and writes `FieldValue` directly and derives via the same
+ * `lookupPhoneGeo` the hook uses; it does not depend on the hook having run, on the org cache
+ * being warm, or on any field being newly seeded — the four target fields have existed since
+ * entity migration 023.
+ *
+ * **Fill-only-if-blank, exactly like the hook.** A row is written only where the contact has no
+ * value for that attribute, so chat's visitor-IP geo and anything a user typed both survive.
+ * Number portability makes area-code geo the weakest of the three signals, and it must never
+ * outrank them.
+ *
+ * **Writes are quiet.** Direct inserts fire no field hooks, no timeline entries and no realtime
+ * publish — correct for a bulk derivation, which is not a user edit and should not read as a few
+ * hundred thousand activity-feed rows.
+ *
+ * Idempotent: re-running only matches contacts that are still blank.
+ */
+export const migration088PhoneGeoBackfill: DataMigrationDef = {
+  id: '088-phone-geo-backfill',
+  description: 'Derive contact city/region/country/timezone from existing phone numbers',
+  async run(db: Database): Promise<void> {
+    // The five field ids per org, scoped to the CONTACT def. `systemAttribute = 'phone'` alone is
+    // too broad — org-created `leads`/`vendors` defs use it too (see migration 086) — and those
+    // defs have no city/region/country/timezone to fill anyway.
+    const fieldRows = await db.execute<{
+      organizationId: string
+      systemAttribute: string
+      fieldId: string
+    }>(sql`
+      SELECT cf."organizationId", cf."systemAttribute", cf."id" AS "fieldId"
+      FROM "CustomField" cf
+      JOIN "EntityDefinition" ed ON ed."id" = cf."entityDefinitionId"
+      WHERE ed."entityType" = 'contact'
+        AND cf."systemAttribute" IN ('phone', 'city', 'region', 'country', 'timezone')
+    `)
+
+    const byOrg = new Map<string, Map<string, string>>()
+    for (const row of fieldRows.rows) {
+      const existing = byOrg.get(row.organizationId) ?? new Map<string, string>()
+      existing.set(row.systemAttribute, row.fieldId)
+      byOrg.set(row.organizationId, existing)
+    }
+
+    const orgs: FieldIds[] = []
+    for (const [organizationId, attributes] of byOrg) {
+      const phoneFieldId = attributes.get('phone')
+      if (!phoneFieldId) continue
+      const targets = GEO_ATTRIBUTES.flatMap(([attribute]) => {
+        const fieldId = attributes.get(attribute)
+        return fieldId ? [{ attribute, fieldId }] : []
+      })
+      if (targets.length > 0) orgs.push({ organizationId, phoneFieldId, targets })
+    }
+
+    let contactsScanned = 0
+    let valuesWritten = 0
+
+    for (const org of orgs) {
+      const targetFieldIds = org.targets.map((t) => t.fieldId)
+      let cursor = ''
+
+      for (;;) {
+        // One row per contact: the primary phone is the lowest `sortKey` for that entity, which
+        // is the same value outbound SMS/voice dials.
+        const contacts = await db.execute<{
+          entityId: string
+          entityDefinitionId: string
+          valueText: string
+        }>(sql`
+          SELECT DISTINCT ON (fv."entityId")
+            fv."entityId", fv."entityDefinitionId", fv."valueText"
+          FROM "FieldValue" fv
+          WHERE fv."fieldId" = ${org.phoneFieldId}
+            AND fv."valueText" IS NOT NULL
+            AND fv."valueText" <> ''
+            AND fv."entityId" > ${cursor}
+          ORDER BY fv."entityId", fv."sortKey"
+          LIMIT ${BATCH_SIZE}
+        `)
+        if (contacts.rows.length === 0) break
+
+        const entityIds = contacts.rows.map((r) => r.entityId)
+        cursor = entityIds[entityIds.length - 1] as string
+        contactsScanned += entityIds.length
+
+        // Which (contact, target field) pairs already hold a value — the blank test.
+        const filled = await db.execute<{ entityId: string; fieldId: string }>(sql`
+          SELECT DISTINCT fv."entityId", fv."fieldId"
+          FROM "FieldValue" fv
+          WHERE fv."fieldId" IN (${sql.join(
+            targetFieldIds.map((id) => sql`${id}`),
+            sql`, `
+          )})
+            AND fv."entityId" IN (${sql.join(
+              entityIds.map((id) => sql`${id}`),
+              sql`, `
+            )})
+            AND fv."valueText" IS NOT NULL
+            AND fv."valueText" <> ''
+        `)
+        const filledKeys = new Set(filled.rows.map((r) => `${r.entityId}:${r.fieldId}`))
+
+        const inserts: Array<typeof schema.FieldValue.$inferInsert> = []
+        for (const contact of contacts.rows) {
+          const geo = lookupPhoneGeo(contact.valueText)
+          if (!geo) continue
+          for (const target of org.targets) {
+            const value = geo[target.attribute]
+            if (!value) continue
+            if (filledKeys.has(`${contact.entityId}:${target.fieldId}`)) continue
+            inserts.push({
+              organizationId: org.organizationId,
+              fieldId: target.fieldId,
+              entityId: contact.entityId,
+              entityDefinitionId: contact.entityDefinitionId,
+              valueText: value,
+            })
+          }
+        }
+
+        if (inserts.length > 0) {
+          await db.insert(schema.FieldValue).values(inserts)
+          valuesWritten += inserts.length
+        }
+
+        if (contacts.rows.length < BATCH_SIZE) break
+      }
+    }
+
+    logger.info('phone geo backfill complete', {
+      organizationsScanned: orgs.length,
+      contactsScanned,
+      valuesWritten,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -52,6 +52,7 @@ import { migration084PrimaryEmailUnique } from './migrations/084-primary-email-u
 import { migration085MultiEmailWebsiteFlip } from './migrations/085-multi-email-website-flip'
 import { migration086MultiPhoneFlip } from './migrations/086-multi-phone-flip'
 import { migration087KnowledgeRetrievalSources } from './migrations/087-knowledge-retrieval-sources'
+import { migration088PhoneGeoBackfill } from './migrations/088-phone-geo-backfill'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -130,6 +131,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration085MultiEmailWebsiteFlip,
     migration086MultiPhoneFlip,
     migration087KnowledgeRetrievalSources,
+    migration088PhoneGeoBackfill,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/field-hooks/register-hooks.ts
+++ b/packages/lib/src/field-hooks/register-hooks.ts
@@ -34,6 +34,7 @@ import {
   recomputeOnLineChange,
   recomputeOnQuoteBillingChange,
 } from '../money/totals-hooks'
+import { derivePhoneGeoOnChange, warmPhoneGeo } from '../phone-geo'
 import { handleRecordRulesOnFieldChange } from '../record-rules/hook-handler'
 import {
   enqueueQuickbooksInvoiceSyncOnSent,
@@ -185,6 +186,18 @@ export function registerAllHooks(): void {
   // field on every entity without flipping `hasEntityFieldChangeHooks` on for entities that have
   // no address fields.
   registerFieldTypeChangeHooks(FieldTypeEnum.ADDRESS_STRUCT, [normalizeAddressOnChange])
+
+  // Phone geo derivation — same field-type-keyed reasoning as the address hook above: one
+  // registration covers every PHONE_INTL field on every entity, so SMS ingest, panel edits, CSV
+  // import, connector sync and Kopilot all get it from a single door. Fills only BLANK
+  // city/region/country/timezone (chat's visitor-IP geo and human input both outrank an area
+  // code), and no-ops on entities that have no such fields. Unlike the address hook this needs
+  // no fire-and-forget — the lookup is an in-memory table read, not a MapTiler call.
+  registerFieldTypeChangeHooks(FieldTypeEnum.PHONE_INTL, [derivePhoneGeoOnChange])
+  // Deserialize the geocoding tables now rather than on the first phone write. Co-located with
+  // the registration so the warm can never drift away from the hook that needs it; the worker
+  // additionally calls this at boot. Idempotent and never throws.
+  warmPhoneGeo()
 
   // Route planner build contract item 8 (09-route-planner.md §B): pin the work order's visit
   // row(s) whenever its address geocodes — unscheduled backlog jobs need pins too. Rides the

--- a/packages/lib/src/phone-geo/__tests__/derive-geo-hook.test.ts
+++ b/packages/lib/src/phone-geo/__tests__/derive-geo-hook.test.ts
@@ -1,0 +1,195 @@
+// packages/lib/src/phone-geo/__tests__/derive-geo-hook.test.ts
+
+import { toRecordId } from '@auxx/types/resource'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EntityFieldChangeEvent } from '../../field-hooks/types'
+import type { CachedField } from '../../field-values/types'
+
+// Mock the cache LEAF rather than the '../../cache' barrel, which drags in the Redis client.
+vi.mock('../../cache/org-cache-helpers', () => ({ getCachedCustomFields: vi.fn() }))
+
+// Mock the realtime LEAF, not the '../../realtime' barrel — the barrel has a known import-cycle
+// gotcha with vi.mock (project memory). Same pattern as the address-normalize-hook test.
+// Must resolve a promise, not `undefined` — the SUT attaches `.catch` to the returned value, and
+// a bare `vi.fn()` would throw there and be swallowed, letting the happy-path tests pass without
+// ever reaching the publish.
+vi.mock('../../realtime/publish-helpers', () => ({
+  publishFieldValueUpdates: vi.fn(() => Promise.resolve()),
+}))
+
+// Plain synchronous factories (not `importOriginal`) — an async factory does not reliably apply
+// to the SUT's own bindings here; see the note in address-normalize-hook.test.ts.
+vi.mock('../../field-values/field-value-mutations', () => ({
+  setValueWithBuiltIn: vi.fn(),
+  buildPublishEntry: (args: { fieldId: unknown; values: unknown[] }) => ({
+    key: String(args.fieldId),
+    value: args.values[0] ?? null,
+  }),
+}))
+vi.mock('../../field-values/field-value-queries', () => ({ getValues: vi.fn() }))
+vi.mock('../../field-values/field-value-helpers', () => ({
+  createFieldValueContext: vi.fn(() => ({ organizationId: 'org1' })),
+  getField: vi.fn(async () => ({ id: 'f', type: 'TEXT' })),
+}))
+
+import { getCachedCustomFields } from '../../cache/org-cache-helpers'
+import { setValueWithBuiltIn } from '../../field-values/field-value-mutations'
+import { getValues } from '../../field-values/field-value-queries'
+import { publishFieldValueUpdates } from '../../realtime/publish-helpers'
+import { derivePhoneGeoOnChange } from '../derive-geo-hook'
+
+const mockedFields = getCachedCustomFields as unknown as ReturnType<typeof vi.fn>
+const mockedSetValue = setValueWithBuiltIn as unknown as ReturnType<typeof vi.fn>
+const mockedGetValues = getValues as unknown as ReturnType<typeof vi.fn>
+const mockedPublish = publishFieldValueUpdates as unknown as ReturnType<typeof vi.fn>
+
+const CONTACT_DEF = 'contact'
+
+/** The four geo fields as the contact definition carries them. */
+const CONTACT_GEO_FIELDS = [
+  { id: 'fld_city', systemAttribute: 'city' },
+  { id: 'fld_region', systemAttribute: 'region' },
+  { id: 'fld_country', systemAttribute: 'country' },
+  { id: 'fld_timezone', systemAttribute: 'timezone' },
+]
+
+function buildEvent(phone: string | null): EntityFieldChangeEvent {
+  return {
+    recordId: toRecordId(CONTACT_DEF, 'inst1'),
+    entityDefinitionId: CONTACT_DEF,
+    entityType: 'contact',
+    entitySlug: 'contacts',
+    field: { id: 'fld_phone', type: 'PHONE_INTL' } as unknown as CachedField,
+    oldValue: null,
+    // Contact `phone` is multi-value, so a write arrives as an array ordered by sortKey.
+    newValue: phone === null ? null : [{ type: 'text', value: phone }],
+    oldDisplay: null,
+    newDisplay: null,
+    organizationId: 'org1',
+    userId: 'user1',
+  } as unknown as EntityFieldChangeEvent
+}
+
+/** What `setValueWithBuiltIn` was asked to write, as `{ fieldId: value }`. */
+function writtenValues(): Record<string, unknown> {
+  return Object.fromEntries(
+    mockedSetValue.mock.calls.map(([, params]) => [params.fieldId, params.value])
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockedPublish.mockResolvedValue(undefined)
+  mockedFields.mockResolvedValue(CONTACT_GEO_FIELDS)
+  // Nothing filled in yet.
+  mockedGetValues.mockResolvedValue(new Map())
+  mockedSetValue.mockResolvedValue({ values: [{ id: 'v1', type: 'text', value: 'x' }] })
+})
+
+describe('derivePhoneGeoOnChange', () => {
+  it('fills all four geo fields from the primary number', async () => {
+    await derivePhoneGeoOnChange(buildEvent('+13102030000'))
+
+    expect(writtenValues()).toEqual({
+      fld_city: 'Los Angeles',
+      fld_region: 'California',
+      fld_country: 'United States',
+      fld_timezone: 'America/Los_Angeles',
+    })
+  })
+
+  it('writes quietly so the derivation never lands in the activity feed', async () => {
+    await derivePhoneGeoOnChange(buildEvent('+13102030000'))
+
+    for (const [, params] of mockedSetValue.mock.calls) {
+      expect(params.publishEvents).toBe(false)
+    }
+    // …but still pushes realtime itself, so an open drawer updates without a reload.
+    expect(mockedPublish).toHaveBeenCalledTimes(1)
+  })
+
+  it('derives from the FIRST number when the field holds several', async () => {
+    const event = buildEvent('+13102030000')
+    event.newValue = [
+      { type: 'text', value: '+13102030000' },
+      { type: 'text', value: '+16172670000' },
+    ] as unknown as EntityFieldChangeEvent['newValue']
+
+    await derivePhoneGeoOnChange(event)
+
+    expect(writtenValues().fld_city).toBe('Los Angeles')
+  })
+
+  it('never overwrites a field that already holds a value', async () => {
+    // City came from the chat widget's visitor IP — a better signal than an area code.
+    mockedGetValues.mockResolvedValue(
+      new Map([['fld_city', { type: 'text', value: 'Denver' }]] as Array<[string, unknown]>)
+    )
+
+    await derivePhoneGeoOnChange(buildEvent('+13102030000'))
+
+    const written = writtenValues()
+    expect(written.fld_city).toBeUndefined()
+    expect(written.fld_region).toBe('California')
+  })
+
+  it('treats a whitespace-only stored value as blank', async () => {
+    mockedGetValues.mockResolvedValue(
+      new Map([['fld_city', { type: 'text', value: '   ' }]] as Array<[string, unknown]>)
+    )
+
+    await derivePhoneGeoOnChange(buildEvent('+13102030000'))
+
+    expect(writtenValues().fld_city).toBe('Los Angeles')
+  })
+
+  it('writes nothing when every target is already filled', async () => {
+    mockedGetValues.mockResolvedValue(
+      new Map(
+        CONTACT_GEO_FIELDS.map((f) => [f.id, { type: 'text', value: 'set' }]) as Array<
+          [string, unknown]
+        >
+      )
+    )
+
+    await derivePhoneGeoOnChange(buildEvent('+13102030000'))
+
+    expect(mockedSetValue).not.toHaveBeenCalled()
+    expect(mockedPublish).not.toHaveBeenCalled()
+  })
+
+  it('omits timezone when the number’s prefix spans several zones', async () => {
+    await derivePhoneGeoOnChange(buildEvent('+447400123456'))
+
+    const written = writtenValues()
+    expect(written.fld_country).toBe('United Kingdom')
+    expect(written.fld_timezone).toBeUndefined()
+  })
+
+  it('no-ops on an entity that has no geo fields', async () => {
+    // The hook is field-type-keyed, so it fires for PHONE_INTL on companies and custom entities
+    // too — there is simply nothing to fill there.
+    mockedFields.mockResolvedValue([{ id: 'fld_phone', systemAttribute: 'phone' }])
+
+    await derivePhoneGeoOnChange(buildEvent('+13102030000'))
+
+    expect(mockedSetValue).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['a cleared field', null],
+    ['an unparseable number', 'not-a-number'],
+  ])('no-ops for %s', async (_label, phone) => {
+    await derivePhoneGeoOnChange(buildEvent(phone))
+
+    expect(mockedFields).not.toHaveBeenCalled()
+    expect(mockedSetValue).not.toHaveBeenCalled()
+  })
+
+  it('swallows a write failure rather than breaking the phone write', async () => {
+    // Post-write hooks must never break the write that triggered them.
+    mockedSetValue.mockRejectedValue(new Error('db down'))
+
+    await expect(derivePhoneGeoOnChange(buildEvent('+13102030000'))).resolves.toBeUndefined()
+  })
+})

--- a/packages/lib/src/phone-geo/__tests__/lookup.test.ts
+++ b/packages/lib/src/phone-geo/__tests__/lookup.test.ts
@@ -1,0 +1,97 @@
+// packages/lib/src/phone-geo/__tests__/lookup.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { lookupPhoneGeo, warmPhoneGeo } from '../lookup'
+
+// NOTE: never use `555` prefixes here. They are fictional, carry no NPA-NXX entry, and silently
+// fall back to state level — a test built on them would pass while asserting nothing about the
+// city path, and would make a genuinely broken lookup look correct.
+
+describe('lookupPhoneGeo', () => {
+  it('resolves city + region from an NPA-NXX prefix', () => {
+    expect(lookupPhoneGeo('+13102030000')).toMatchObject({
+      city: 'Los Angeles',
+      region: 'California',
+      country: 'United States',
+      timezone: 'America/Los_Angeles',
+    })
+  })
+
+  it('expands the state abbreviation to a full name', () => {
+    // Google publishes `Boston, MA`; we store the expanded form so phone-derived values match
+    // what the IP-geo writer produces.
+    expect(lookupPhoneGeo('+16172670000')).toMatchObject({
+      city: 'Boston',
+      region: 'Massachusetts',
+    })
+  })
+
+  it('falls back to region alone when the area code has no city data', () => {
+    const result = lookupPhoneGeo('+19497520000')
+    expect(result).toMatchObject({ region: 'California', country: 'United States' })
+    expect(result?.city).toBeUndefined()
+  })
+
+  it('normalizes Google’s "Washington State" to the plain state name', () => {
+    expect(lookupPhoneGeo('+12064560000')?.region).toBe('Washington')
+  })
+
+  it('resolves Canadian provinces', () => {
+    expect(lookupPhoneGeo('+14165550100')).toMatchObject({
+      region: 'Ontario',
+      country: 'Canada',
+      timezone: 'America/Toronto',
+    })
+  })
+
+  it('resolves non-NANP numbers', () => {
+    expect(lookupPhoneGeo('+493012345678')).toMatchObject({
+      region: 'Berlin',
+      country: 'Germany',
+      timezone: 'Europe/Berlin',
+    })
+  })
+
+  it('omits timezone when the prefix spans more than one zone', () => {
+    // A UK mobile maps to Europe/London, Europe/Guernsey and Europe/Isle_of_Man. Picking the
+    // first would be a coin flip presented as a fact.
+    const result = lookupPhoneGeo('+447400123456')
+    expect(result?.country).toBe('United Kingdom')
+    expect(result?.timezone).toBeUndefined()
+  })
+
+  it('never returns a raw "City, ST" string in either field', () => {
+    const result = lookupPhoneGeo('+13124430000')
+    expect(result?.city).toBe('Chicago')
+    expect(result?.region).toBe('Illinois')
+  })
+
+  it('parses national numbers using the default country', () => {
+    expect(lookupPhoneGeo('(310) 203-0000')?.city).toBe('Los Angeles')
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty', ''],
+    ['not a number', 'hello'],
+    ['impossible number', '+1999'],
+  ])('returns null for %s', (_label, input) => {
+    expect(lookupPhoneGeo(input)).toBeNull()
+  })
+
+  it('warms without throwing and stays consistent afterwards', () => {
+    expect(() => warmPhoneGeo()).not.toThrow()
+    expect(lookupPhoneGeo('+13102030000')?.city).toBe('Los Angeles')
+  })
+
+  it('is fast enough to run inline on a write path', () => {
+    warmPhoneGeo()
+    const started = process.hrtime.bigint()
+    for (let i = 0; i < 20_000; i++) lookupPhoneGeo('+1310203000' + (i % 10))
+    const msPerLookup = Number(process.hrtime.bigint() - started) / 1e6 / 20_000
+    // Warm lookups measure ~0.2µs. A regression past 0.1ms means the memoization broke and we
+    // are back on the library's uncached ~6ms path, which would make the inline hook untenable.
+    expect(msPerLookup).toBeLessThan(0.1)
+  })
+})

--- a/packages/lib/src/phone-geo/derive-geo-hook.ts
+++ b/packages/lib/src/phone-geo/derive-geo-hook.ts
@@ -1,0 +1,168 @@
+// packages/lib/src/phone-geo/derive-geo-hook.ts
+//
+// Post-write hook that fills a record's city/region/country/timezone from the numbering-plan
+// origin of the phone number just written.
+//
+// Registered field-type-keyed on PHONE_INTL (`field-hooks/register-hooks.ts`), mirroring the
+// ADDRESS_STRUCT normalize hook — so it fires for every phone field on every entity without
+// flipping `hasEntityFieldChangeHooks` on for entities that have no phone field. That one
+// registration covers every write path: SMS ingest creating a contact, panel edits, CSV import,
+// connector sync and Kopilot all funnel through the field-value mutations.
+//
+// Unlike `normalizeAddressOnChange` this does NOT need to be fire-and-forget: the lookup is an
+// in-memory table read (~0.2µs, see `lookup.ts`), not a network call, so the whole handler is
+// awaited inline and still costs less than the logging around it.
+
+import { createScopedLogger } from '@auxx/logger'
+import { extractValue, type TypedFieldValue } from '@auxx/types'
+import type { FieldId } from '@auxx/types/field'
+import { getCachedCustomFields } from '../cache/org-cache-helpers'
+import type { EntityFieldChangeEvent, EntityFieldChangeHandler } from '../field-hooks/types'
+import { createFieldValueContext, getField } from '../field-values/field-value-helpers'
+import { buildPublishEntry, setValueWithBuiltIn } from '../field-values/field-value-mutations'
+import { getValues } from '../field-values/field-value-queries'
+import type { CachedField } from '../field-values/types'
+import { getRealtimeService, publishFieldValueUpdates } from '../realtime'
+import { parseRecordId, toRecordId } from '../resources/resource-id'
+import { lookupPhoneGeo } from './lookup'
+import type { PhoneGeo } from './types'
+
+const logger = createScopedLogger('phone-geo')
+
+/** Target systemAttribute → the {@link PhoneGeo} key that feeds it. */
+const GEO_TARGETS = [
+  ['city', 'city'],
+  ['region', 'region'],
+  ['country', 'country'],
+  ['timezone', 'timezone'],
+] as const satisfies ReadonlyArray<readonly [string, keyof PhoneGeo]>
+
+/**
+ * The number to derive from.
+ *
+ * Contact `phone` is `options: { multi: true }`, so a multi write arrives as an array ordered by
+ * `sortKey` — index 0 is the primary, which is also what outbound SMS/voice dials. A cleared
+ * field arrives as `null`.
+ */
+function extractPrimaryPhone(value: unknown): string | null {
+  const typed = value as TypedFieldValue | TypedFieldValue[] | null
+  const first = Array.isArray(typed) ? typed[0] : typed
+  if (!first) return null
+  const extracted = extractValue(first)
+  return typeof extracted === 'string' && extracted.trim() ? extracted.trim() : null
+}
+
+function isBlank(value: unknown): boolean {
+  if (value === null || value === undefined) return true
+  const typed = value as TypedFieldValue | TypedFieldValue[]
+  const first = Array.isArray(typed) ? typed[0] : typed
+  if (!first) return true
+  const extracted = extractValue(first)
+  return typeof extracted === 'string' ? extracted.trim().length === 0 : false
+}
+
+/**
+ * Fill blank geo fields on the record whose phone number just changed.
+ *
+ * No-ops — never throws — when the number is unparseable, when the entity has no geo fields
+ * (the hook fires for PHONE_INTL on any entity, but city/region/country/timezone are contact
+ * fields), or when every target already holds a value.
+ */
+export const derivePhoneGeoOnChange: EntityFieldChangeHandler = async (event) => {
+  const phone = extractPrimaryPhone(event.newValue)
+  if (!phone) return
+
+  const geo = lookupPhoneGeo(phone)
+  if (!geo) return
+
+  try {
+    await fillBlankGeoFields(event, geo)
+  } catch (error) {
+    logger.error('Phone geo derivation failed', {
+      recordId: event.recordId,
+      fieldId: event.field.id,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+async function fillBlankGeoFields(event: EntityFieldChangeEvent, geo: PhoneGeo): Promise<void> {
+  // Resolve targets within THIS entity definition rather than through `resolveFieldIds`, whose
+  // systemAttribute map is global across every definition in the org and would happily hand back
+  // another entity's `city` field.
+  const fields = await getCachedCustomFields(event.organizationId, event.entityDefinitionId)
+  const byAttribute = new Map(
+    fields.filter((f) => f.systemAttribute).map((f) => [f.systemAttribute as string, f])
+  )
+
+  const candidates = GEO_TARGETS.flatMap(([attribute, geoKey]) => {
+    const derived = geo[geoKey]
+    const field = byAttribute.get(attribute)
+    if (!derived || !field) return []
+    return [{ fieldId: field.id, value: derived }]
+  })
+  if (candidates.length === 0) return
+
+  const ctx = createFieldValueContext(event.organizationId, event.userId, undefined, undefined, {
+    skipPreHooks: true,
+  })
+
+  // Fill-only-if-blank. These same four fields are written by the chat widget's visitor-IP
+  // lookup (`chat/visit-fields.ts`) and by users typing into the panel; both are better signals
+  // than an area code, so a phone-derived value may only ever fill a vacuum.
+  const existing = await getValues(ctx, {
+    recordId: event.recordId,
+    fieldIds: candidates.map((c) => c.fieldId),
+  })
+  const writes = candidates.filter((c) => isBlank(existing.get(c.fieldId)))
+  if (writes.length === 0) return
+
+  // Publish against the field's own definition id, matching the address hook. Subscribers key on
+  // the cuid-form recordId, and an alias-form id here would publish to a channel nobody is
+  // listening on.
+  const { entityInstanceId } = parseRecordId(event.recordId)
+  const publishRecordId = event.field.entityDefinitionId
+    ? toRecordId(event.field.entityDefinitionId, entityInstanceId)
+    : event.recordId
+  const entries = []
+
+  for (const write of writes) {
+    // Quiet write: `publishEvents: false` skips the post-hook chain, field triggers, the timeline
+    // entry and the inline realtime publish. Recursion is structurally impossible anyway (this
+    // hook keys on PHONE_INTL and only ever writes TEXT fields), but a derivation is not a user
+    // edit and should not read as one in the activity feed.
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId: event.recordId,
+      fieldId: write.fieldId,
+      value: write.value,
+      publishEvents: false,
+    })
+    if (result.values.length === 0) continue
+
+    let field: CachedField | undefined
+    try {
+      field = await getField(ctx, write.fieldId)
+    } catch {
+      field = undefined
+    }
+    entries.push(
+      buildPublishEntry({
+        publishRecordId,
+        fieldId: write.fieldId as FieldId,
+        field,
+        values: result.values,
+      })
+    )
+  }
+
+  if (entries.length === 0) return
+
+  // Publish ourselves, since the quiet writes above skipped it — an open contact drawer should
+  // show the derived location without a reload.
+  publishFieldValueUpdates(getRealtimeService(), event.organizationId, entries).catch((error) => {
+    logger.warn('Phone geo realtime publish failed', {
+      recordId: event.recordId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  })
+}

--- a/packages/lib/src/phone-geo/index.ts
+++ b/packages/lib/src/phone-geo/index.ts
@@ -1,0 +1,5 @@
+// packages/lib/src/phone-geo/index.ts
+
+export { derivePhoneGeoOnChange } from './derive-geo-hook'
+export { __resetPhoneGeoForTests, lookupPhoneGeo, warmPhoneGeo } from './lookup'
+export type { PhoneGeo } from './types'

--- a/packages/lib/src/phone-geo/lookup.ts
+++ b/packages/lib/src/phone-geo/lookup.ts
@@ -1,0 +1,273 @@
+// packages/lib/src/phone-geo/lookup.ts
+//
+// Phone-number → city/region/country/timezone, resolved from Google's libphonenumber
+// geocoding metadata as republished by `libphonenumber-geo-carrier`.
+//
+// ## Why this reads the package's resource files instead of calling its API
+//
+// `libphonenumber-geo-carrier`'s `geocoder()`/`timezones()` re-read AND re-deserialize their
+// BSON resource on EVERY call — there is no cache, not even for a repeated lookup of the same
+// number (measured: 5.7ms for 300 lookups of one number, 5.9ms for 300 distinct ones). That is
+// ~30,000x the cost of the work and would make an inline field hook untenable.
+//
+// Deserializing each resource once into a plain object and walking the prefix ladder ourselves
+// costs ~13ms one-time and ~0.2µs per lookup, and was verified to produce byte-identical output
+// to the library's own API across 407 numbers spanning NANP, DE, FR, GB, AU, JP, BR and CA.
+//
+// The cost is a dependency on the package's internal `resources/` layout, which its `exports`
+// map does not expose. {@link loadResource} therefore fails soft: if the layout ever changes the
+// maps come back empty, every lookup returns `null`, and callers degrade to writing nothing —
+// never to writing something wrong.
+
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { createScopedLogger } from '@auxx/logger'
+import { deserialize } from 'bson'
+import { type CountryCode, parsePhoneNumberFromString } from 'libphonenumber-js'
+import type { PhoneGeo } from './types'
+
+const logger = createScopedLogger('phone-geo')
+
+/**
+ * Google publishes regions as bare names but cities as `City, ST`. Expanding the abbreviation
+ * keeps phone-derived values in the same shape as the IP-geolocation writer
+ * (`chat/visit-fields.ts`), which sources full names from ipapi/MaxMind — otherwise the same
+ * contact field would read `California` or `CA` depending on which producer happened to win.
+ */
+const REGION_BY_CODE: Readonly<Record<string, string>> = {
+  AL: 'Alabama',
+  AK: 'Alaska',
+  AZ: 'Arizona',
+  AR: 'Arkansas',
+  CA: 'California',
+  CO: 'Colorado',
+  CT: 'Connecticut',
+  DE: 'Delaware',
+  DC: 'District of Columbia',
+  FL: 'Florida',
+  GA: 'Georgia',
+  HI: 'Hawaii',
+  ID: 'Idaho',
+  IL: 'Illinois',
+  IN: 'Indiana',
+  IA: 'Iowa',
+  KS: 'Kansas',
+  KY: 'Kentucky',
+  LA: 'Louisiana',
+  ME: 'Maine',
+  MD: 'Maryland',
+  MA: 'Massachusetts',
+  MI: 'Michigan',
+  MN: 'Minnesota',
+  MS: 'Mississippi',
+  MO: 'Missouri',
+  MT: 'Montana',
+  NE: 'Nebraska',
+  NV: 'Nevada',
+  NH: 'New Hampshire',
+  NJ: 'New Jersey',
+  NM: 'New Mexico',
+  NY: 'New York',
+  NC: 'North Carolina',
+  ND: 'North Dakota',
+  OH: 'Ohio',
+  OK: 'Oklahoma',
+  OR: 'Oregon',
+  PA: 'Pennsylvania',
+  RI: 'Rhode Island',
+  SC: 'South Carolina',
+  SD: 'South Dakota',
+  TN: 'Tennessee',
+  TX: 'Texas',
+  UT: 'Utah',
+  VT: 'Vermont',
+  VA: 'Virginia',
+  WA: 'Washington',
+  WV: 'West Virginia',
+  WI: 'Wisconsin',
+  WY: 'Wyoming',
+  AS: 'American Samoa',
+  GU: 'Guam',
+  MP: 'Northern Mariana Islands',
+  PR: 'Puerto Rico',
+  VI: 'U.S. Virgin Islands',
+  AB: 'Alberta',
+  BC: 'British Columbia',
+  MB: 'Manitoba',
+  NB: 'New Brunswick',
+  NL: 'Newfoundland and Labrador',
+  NS: 'Nova Scotia',
+  NT: 'Northwest Territories',
+  NU: 'Nunavut',
+  ON: 'Ontario',
+  PE: 'Prince Edward Island',
+  QC: 'Quebec',
+  SK: 'Saskatchewan',
+  YT: 'Yukon',
+}
+
+/**
+ * Google's own region strings that are not the plain place name. `Washington State` is
+ * disambiguated from `Washington D.C.` in the source data; our `region` field wants the state.
+ */
+const REGION_ALIASES: Readonly<Record<string, string>> = {
+  'Washington State': 'Washington',
+}
+
+type PrefixMap = Record<string, string | undefined>
+
+const geocodeMaps = new Map<string, PrefixMap | null>()
+let timezoneMap: PrefixMap | null | undefined
+let resourceRoot: string | null | undefined
+
+const countryNames = new Intl.DisplayNames(['en'], { type: 'region' })
+
+/**
+ * Locate the package's `resources/` directory. Its `exports` map only exposes `.`, so
+ * `package.json` is not resolvable — go via the main entry and strip `lib/index.js`.
+ */
+function getResourceRoot(): string | null {
+  if (resourceRoot !== undefined) return resourceRoot
+  try {
+    const entry = createRequire(import.meta.url).resolve('libphonenumber-geo-carrier')
+    const root = entry.replace(/lib[/\\]index\.js$/, '')
+    resourceRoot = root === entry ? null : root
+  } catch {
+    resourceRoot = null
+  }
+  if (resourceRoot === null) {
+    logger.warn('libphonenumber-geo-carrier resources not resolvable; phone geo disabled')
+  }
+  return resourceRoot
+}
+
+function loadResource(relativePath: string): PrefixMap | null {
+  const root = getResourceRoot()
+  if (!root) return null
+  try {
+    return deserialize(readFileSync(`${root}resources/${relativePath}`)) as PrefixMap
+  } catch {
+    // Expected for calling codes with no published geocoding data — not an error.
+    return null
+  }
+}
+
+function getGeocodeMap(callingCode: string): PrefixMap | null {
+  const cached = geocodeMaps.get(callingCode)
+  if (cached !== undefined) return cached
+  const map = loadResource(`geocodes/en/${callingCode}.bson`)
+  geocodeMaps.set(callingCode, map)
+  return map
+}
+
+function getTimezoneMap(): PrefixMap | null {
+  if (timezoneMap === undefined) timezoneMap = loadResource('timezones.bson')
+  return timezoneMap
+}
+
+/**
+ * Walk `digits` from the longest prefix down to `minLength`, returning the first hit.
+ *
+ * This ladder is the whole mechanism: NANP geocoding data is keyed at both NPA (3 digits,
+ * state-level) and NPA-NXX (6 digits, city-level), so the longest match is the most specific
+ * answer available for that number.
+ */
+function matchLongestPrefix(
+  map: PrefixMap | null,
+  digits: string,
+  minLength: number
+): string | undefined {
+  if (!map) return undefined
+  for (let length = digits.length; length >= minLength; length--) {
+    const hit = map[digits.slice(0, length)]
+    if (hit !== undefined) return hit
+  }
+  return undefined
+}
+
+/**
+ * Split Google's geocode string into city + region.
+ *
+ * `Los Angeles, CA` is a city with a state; a bare `California`, `Ontario` or `Berlin` is a
+ * region with no city at all. Storing the raw string in either field would be wrong in one of
+ * those two cases, so the comma is load-bearing.
+ */
+function splitGeocode(raw: string): { city?: string; region?: string } {
+  const match = raw.match(/^(.*),\s*([A-Z]{2})$/)
+  if (match?.[1] && match[2]) {
+    return { city: match[1].trim(), region: REGION_BY_CODE[match[2]] ?? match[2] }
+  }
+  const region = raw.trim()
+  return region ? { region: REGION_ALIASES[region] ?? region } : {}
+}
+
+/**
+ * Preload the geocoding tables so the first real lookup does not pay the ~13ms deserialize.
+ *
+ * Call once at process start (worker/web bootstrap), the way `apps/api` calls `initGeo()`.
+ * Safe to call repeatedly — subsequent calls are no-ops. Never throws.
+ */
+export function warmPhoneGeo(): void {
+  // `1` is the NANP table and covers the overwhelming majority of our numbers; other calling
+  // codes load lazily on first use.
+  getGeocodeMap('1')
+  getTimezoneMap()
+}
+
+/**
+ * Derive city/region/country/timezone from an E.164 phone number.
+ *
+ * Pure and synchronous — no database, no network. Returns `null` when the number is unparseable
+ * or nothing at all could be derived.
+ *
+ * @param e164 A phone number. Anything `libphonenumber-js` can parse works, but callers should
+ *   pass E.164; values read from `Participant.identifier` are only digit-stripped and must go
+ *   through `formatPhoneNumber` from `@auxx/utils` first.
+ * @param defaultCountry Region assumed for numbers written without a `+` prefix.
+ */
+export function lookupPhoneGeo(
+  e164: string | null | undefined,
+  defaultCountry: CountryCode = 'US'
+): PhoneGeo | null {
+  if (!e164) return null
+
+  const parsed = parsePhoneNumberFromString(e164.trim(), defaultCountry)
+  if (!parsed?.isValid()) return null
+
+  const callingCode = String(parsed.countryCallingCode)
+  const nationalNumber = parsed.nationalNumber
+
+  const result: PhoneGeo = {}
+
+  const geocode = matchLongestPrefix(getGeocodeMap(callingCode), nationalNumber, 1)
+  if (geocode) Object.assign(result, splitGeocode(geocode))
+
+  if (parsed.country) {
+    try {
+      result.country = countryNames.of(parsed.country) ?? undefined
+    } catch {
+      // Non-region code (e.g. libphonenumber's `001` for non-geographic numbers) — skip.
+    }
+  }
+
+  // Timezones are keyed by calling code + national number, so the ladder must never shorten past
+  // the calling code itself — `1` alone maps to all 42 NANP zones.
+  const zones = matchLongestPrefix(
+    getTimezoneMap(),
+    callingCode + nationalNumber,
+    callingCode.length
+  )?.split('&')
+  // Only an unambiguous prefix yields a usable answer. A UK mobile spans Europe/London,
+  // Europe/Guernsey and Europe/Isle_of_Man; picking the first would be a coin flip presented
+  // as a fact.
+  if (zones?.length === 1 && zones[0]) result.timezone = zones[0]
+
+  return Object.keys(result).length > 0 ? result : null
+}
+
+/** Test-only: drop the memoized tables so a test can exercise the cold path. */
+export function __resetPhoneGeoForTests(): void {
+  geocodeMaps.clear()
+  timezoneMap = undefined
+  resourceRoot = undefined
+}

--- a/packages/lib/src/phone-geo/types.ts
+++ b/packages/lib/src/phone-geo/types.ts
@@ -1,0 +1,25 @@
+// packages/lib/src/phone-geo/types.ts
+
+/**
+ * Location derived from a phone number's numbering-plan prefix.
+ *
+ * This is geographic **origin** data, not the contact's location: a `+1 212`
+ * number can belong to someone who moved to Denver fifteen years ago, and
+ * mobile numbers — the bulk of what we hold — are the most-ported of all.
+ * Every consumer must treat these as a hint that may only ever fill a blank,
+ * never overwrite a value sourced from IP geolocation or a human.
+ *
+ * Every field is independently optional: NANP numbers almost always resolve a
+ * `region`, only ~70% of area codes carry city-level data, and `timezone` is
+ * omitted whenever the prefix spans more than one zone.
+ */
+export interface PhoneGeo {
+  /** e.g. `Los Angeles`. Absent when the prefix only resolves to a state/province. */
+  city?: string
+  /** State, province or region — expanded to its full name, e.g. `California`. */
+  region?: string
+  /** Full English country name, e.g. `United States`. */
+  country?: string
+  /** IANA zone, e.g. `America/Los_Angeles`. Absent when the prefix is ambiguous. */
+  timezone?: string
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ catalogs:
     better-auth:
       specifier: ^1.3.18
       version: 1.4.19
+    bson:
+      specifier: ^7.2.0
+      version: 7.2.0
     bullmq:
       specifier: ^5.41.5
       version: 5.70.1
@@ -129,6 +132,9 @@ catalogs:
     jsdom:
       specifier: ^28.1.0
       version: 28.1.0
+    libphonenumber-geo-carrier:
+      specifier: ^2.0.0
+      version: 2.0.0
     libphonenumber-js:
       specifier: ^1.12.8
       version: 1.12.38
@@ -1975,6 +1981,9 @@ importers:
       ajv:
         specifier: ^8
         version: 8.18.0
+      bson:
+        specifier: 'catalog:'
+        version: 7.2.0
       bullmq:
         specifier: 'catalog:'
         version: 5.70.1
@@ -2065,6 +2074,9 @@ importers:
       ldapjs:
         specifier: ^3.0.7
         version: 3.0.7
+      libphonenumber-geo-carrier:
+        specifier: 'catalog:'
+        version: 2.0.0(libphonenumber-js@1.12.38)
       libphonenumber-js:
         specifier: 'catalog:'
         version: 1.12.38
@@ -9550,6 +9562,10 @@ packages:
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
 
+  bson@7.2.0:
+    resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
+    engines: {node: '>=20.19.0'}
+
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
@@ -11861,6 +11877,11 @@ packages:
 
   libmime@5.3.7:
     resolution: {integrity: sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==}
+
+  libphonenumber-geo-carrier@2.0.0:
+    resolution: {integrity: sha512-U6C4JhIKECrURGofMJG3GeskTuTwPTZvSlZM/pivsRrQ95C9lGr+mxiP1IUvdvM0P+3bZN+Y255J+zF3/prOLw==}
+    peerDependencies:
+      libphonenumber-js: 1.12.31
 
   libphonenumber-js@1.12.38:
     resolution: {integrity: sha512-vwzxmasAy9hZigxtqTbFEwp8ZdZ975TiqVDwj5bKx5sR+zi5ucUQy9mbVTkKM9GzqdLdxux/hTw2nmN5J7POMA==}
@@ -23220,6 +23241,8 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
+  bson@7.2.0: {}
+
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
@@ -25687,6 +25710,11 @@ snapshots:
       iconv-lite: 0.6.3
       libbase64: 1.3.0
       libqp: 2.1.1
+
+  libphonenumber-geo-carrier@2.0.0(libphonenumber-js@1.12.38):
+    dependencies:
+      bson: 7.2.0
+      libphonenumber-js: 1.12.38
 
   libphonenumber-js@1.12.38: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,6 +49,7 @@ catalog:
   '@vitest/ui': ^4.0.18
   ai: ^4.2.8
   better-auth: ^1.3.18
+  bson: ^7.2.0
   bullmq: ^5.41.5
   date-fns: 4.1.0
   date-fns-tz: ^3.2.0
@@ -62,6 +63,7 @@ catalog:
   isolated-vm: ^6.0.1
   jose: ^6.1.3
   jsdom: ^28.1.0
+  libphonenumber-geo-carrier: ^2.0.0
   libphonenumber-js: ^1.12.8
   lucide-react: 0.575.0
   minisearch: ^7.1.0


### PR DESCRIPTION
## Why

An inbound SMS from an unknown number creates a contact whose only content is that number — no name, no location, nothing to segment on. Now that every phone is E.164 (#1629) we can derive where the number is *from* and fill the four contact geo fields that already exist but today are only ever populated by the chat widget's visitor-IP lookup.

No schema change, no new fields, no new queues.

## One correction to the premise

**An area code alone gives you state, not city.** `480` covers most of Phoenix's East Valley with `602`/`623` overlaying the same ground; `949` spans most of Orange County. City resolution needs **NPA-NXX** — the first 6 digits, which maps to a rate center.

Measured coverage from the shipped NANP table: 409 NPA entries (state-level), 31,257 NPA-NXX entries of which 30,522 are `City, ST`, spanning 289 of 409 area codes and 10,267 distinct cities. So region is effectively total; city is partial.

## Where it hooks in

Field-type-keyed on `PHONE_INTL`, directly mirroring the `ADDRESS_STRUCT` normalize hook it sits next to in `register-hooks.ts`. One registration covers every write path — SMS ingest creating a contact, panel edits, CSV import, connector sync, Kopilot — because they all funnel through the field-value mutations.

**Fill-only-if-blank.** Number portability is the governing constraint: a `+1 212` number can belong to someone who moved to Denver fifteen years ago, and mobile — the bulk of what we hold — is the most-ported of all. Chat's visitor-IP geo and human input are both better signals, so this may only ever fill a vacuum. It also no-ops on entities that have no geo fields, since the hook fires for `PHONE_INTL` everywhere.

Writes are quiet (`publishEvents: false`) with a manual realtime publish, so a derivation doesn't read as a user edit in the activity feed.

## Why it reads the package's resources instead of calling its API

`libphonenumber-geo-carrier`'s `geocoder()` re-reads **and re-deserializes** its BSON on every call — there is no cache, not even for a repeated lookup of the same number:

| | cost |
|---|---|
| library API, same number ×300 | **5.7 ms** each |
| library API, distinct numbers ×300 | **5.9 ms** each |
| load once + prefix ladder | **0.20 µs** each, ~13 ms one-time |

A per-prefix memo would not have fixed this — it still pays ~6 ms per distinct prefix, which is thousands of prefixes on a backfill. Loading the resource once is what makes an inline hook viable rather than a queue hop.

Output was verified **identical to the library's own API across 407 numbers** spanning NANP, DE, FR, GB, AU, JP, BR and CA — zero mismatches on both geocoding and timezones. It fails soft: if the package's internal layout ever changes, lookups return `null` and we write nothing rather than something wrong.

## Notable behaviours

- `"Los Angeles, CA"` splits into city + region and the code expands to `California`, so phone-derived values match the shape the IP-geo writer produces. A bare `"California"` / `"Ontario"` / `"Berlin"` is a region with **no** city.
- Timezone is written only when the prefix is unambiguous. A UK mobile spans `Europe/London`, `Europe/Guernsey` and `Europe/Isle_of_Man`; picking the first would be a coin flip presented as a fact.
- Country comes from `Intl.DisplayNames`, no lookup table.

## Backfill

One-shot data migration `088-phone-geo-backfill`, batched, idempotent, scoped to the contact def via the `entityType` join (`phone` is a generic attribute name that org-created `leads`/`vendors` defs reuse — same reason migration 086 needed it). Same fill-if-blank rule as the hook.

## Verification

- **32 new tests** — 16 lookup, 11 hook, 5 migration — including a perf guard that fails if the memoization regresses back to the library's ~6 ms path.
- `tsc --noEmit` clean for `@auxx/lib` and `apps/worker`; Biome clean; `check:exports` passes.
- Ran the derivation over every number in the dev DB. All genuine numbers resolved correctly (`+12133734253 → Los Angeles, California, America/Los_Angeles`). Aggregate percentages there are not meaningful — 35 of 116 distinct values are synthetic seed numbers with unassigned area codes (211, 222, 232), correctly rejected by `isValid()`.

Tests deliberately avoid `555` prefixes: they are fictional, silently degrade to state level, and would let a broken lookup pass.

## Follow-ups, deliberately out of scope

- **SMS quiet hours.** No outbound SMS path has a time-of-day gate today; sequence delivery windows are a property of the sequence, not the recipient, and are email-only. Deriving `timezone` is the prerequisite, wiring it is separate work.
- Per-number geo on `FieldValue.valueJson` — viable, but the primary number is enough for v1.
- Three divergent phone normalizers exist (`ingest/participants/normalize.ts` digit-strips rather than E.164, plus `apps/api/.../find-contact-by-phone.ts` and `participants/participant-service.ts`). Real drift, worth its own ticket.
