### PR TITLE
feat(participants): searchRecipients read and the search.recipients procedure

### DIFF
--- a/apps/web/src/server/api/routers/search.ts
+++ b/apps/web/src/server/api/routers/search.ts
@@ -1,11 +1,14 @@
 import { schema } from '@auxx/database'
+import { getCachedEntityDefId, getCachedUserInstanceGrants } from '@auxx/lib/cache'
 import { InboxService } from '@auxx/lib/inboxes'
 import { IsOperatorValue, SearchOperator } from '@auxx/lib/mail-query'
+import { buildMailVisibilityPredicate } from '@auxx/lib/mail-query/visibility-scope'
 import { listMembersWithUser } from '@auxx/lib/members'
-import { PermissionKey } from '@auxx/lib/permissions'
+import { searchRecipients } from '@auxx/lib/participants/search'
+import { PermissionKey, resolveRecordVisibilityScope } from '@auxx/lib/permissions'
 import { listAll } from '@auxx/lib/resources'
 import { createScopedLogger } from '@auxx/logger'
-import { and, asc, count as drizzleCount, eq, ilike, inArray, or } from 'drizzle-orm'
+import { and, asc, count as drizzleCount, eq, ilike, inArray, or, sql } from 'drizzle-orm'
 import { z } from 'zod'
 import { capabilityProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
 
@@ -427,6 +430,82 @@ export const searchRouter = createTRPCRouter({
         contactId: p.entityInstanceId,
         contact: p.contact || null,
       }))
+    }),
+  /**
+   * Ranked recipient search for the composer — participants ∪ contacts.
+   *
+   * Replaces the composer's contact-record picker, which searched records and then
+   * reconstructed identifiers on the client. One `Participant` row IS one
+   * identifier, so searching that collapses the per-record fan-out; the contact arm
+   * covers the people never corresponded with, whom `Participant` has no row for.
+   *
+   * 🔴 **Two arms, two gates, deliberately not flattened.** The participant arm is
+   * mail data and narrows with the mail lens; the contact arm is CRM data and
+   * narrows with record scope. A viewer can legitimately see one and not the other,
+   * and the endpoint answers with whichever arm admits rows — the lib function is
+   * built so a fully-excluding lens still returns contacts, and a `none` record
+   * scope still returns participants. Merging the two authorization models is how a
+   * permissions bug gets written (`text-search-sql.ts:14-19`).
+   */
+  recipients: capabilityProcedure
+    .input(
+      z.object({
+        /** Empty switches to most-recently-mailed, the composer's focus state. */
+        query: z.string(),
+        /** `PlatformCapabilities.recipientModel` of the SENDING channel. */
+        model: z.enum(['email', 'phone', 'thread_only', 'platform_user']),
+        /**
+         * ISO-3166 region for national (no `+`) phone input. The composer derives
+         * it from the sending channel's own number (`regionFromIdentifier`) — the
+         * same digits mean different numbers in different regions, and the org
+         * profile cannot express a per-send answer.
+         */
+        region: z.string().length(2).optional(),
+        limit: z.number().int().min(1).max(50).optional(),
+      })
+    )
+    .query(async ({ input, ctx }) => {
+      // Same coarse mail door as `participants` above — this is the same
+      // `Participant` corpus reached through a better query.
+      ctx.capabilities.assert(PermissionKey.inboxesView)
+      const organizationId = ctx.session.organizationId
+      const userId = ctx.session.user.id
+
+      // Participant arm: the mail lens. `undefined` (SYSTEM) means unscoped and
+      // emits no EXISTS at all; a user viewer is always scoped, admins included.
+      const grants = await getCachedUserInstanceGrants(userId, organizationId)
+      const threadVisibility = buildMailVisibilityPredicate(grants)
+
+      // Contact arm: record scope, built against the `ei` alias the lib query uses.
+      // A `PgColumn` would render `"EntityInstance"."id"`, which Postgres rejects
+      // once the table is aliased.
+      const contactDefId = await getCachedEntityDefId(organizationId, 'contact')
+      const scope = contactDefId
+        ? await resolveRecordVisibilityScope({
+            organizationId,
+            userId,
+            entityDefinitionId: contactDefId,
+            capabilities: ctx.capabilities,
+            instanceIdColumn: sql.raw('ei."id"'),
+          })
+        : undefined
+      // `null` is "no rows for this viewer" and skips the arm entirely; `undefined`
+      // is "no narrowing needed". They are different answers and the lib function
+      // treats them differently, so do not collapse them into one falsy check.
+      const contactVisibility =
+        scope === undefined ? undefined : scope.arm === 'none' ? null : scope.where
+
+      const result = await searchRecipients(ctx.db, {
+        organizationId,
+        query: input.query,
+        model: input.model,
+        region: input.region as Parameters<typeof searchRecipients>[1]['region'],
+        limit: input.limit,
+        threadVisibility,
+        contactVisibility,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
     }),
   // Save search query (called when user executes a search) - DEPRECATED
   saveQuery: protectedProcedure

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -772,6 +772,12 @@
       "import": "./dist/mail-query/client.mjs",
       "default": "./src/mail-query/client.ts"
     },
+    "./mail-query/visibility-scope": {
+      "types": "./src/mail-query/visibility-scope.ts",
+      "source": "./src/mail-query/visibility-scope.ts",
+      "import": "./dist/mail-query/visibility-scope.mjs",
+      "default": "./src/mail-query/visibility-scope.ts"
+    },
     "./mail-schedule": {
       "types": "./src/mail-schedule/index.ts",
       "source": "./src/mail-schedule/index.ts",
@@ -873,6 +879,12 @@
       "source": "./src/participants/channel-identifier-fields.ts",
       "import": "./dist/participants/channel-identifier-fields.mjs",
       "default": "./src/participants/channel-identifier-fields.ts"
+    },
+    "./participants/search": {
+      "types": "./src/participants/search/index.ts",
+      "source": "./src/participants/search/index.ts",
+      "import": "./dist/participants/search/index.mjs",
+      "default": "./src/participants/search/index.ts"
     },
     "./permissions": {
       "types": "./src/permissions/index.ts",

--- a/packages/lib/scripts/verify-recipient-search.ts
+++ b/packages/lib/scripts/verify-recipient-search.ts
@@ -1,0 +1,140 @@
+// packages/lib/scripts/verify-recipient-search.ts
+//
+// Runs `searchRecipients` against the dev database on a real org.
+//
+// Rendered-SQL unit tests cannot catch a malformed CTE, a column that does not
+// exist, or a `WHERE` fragment that lands in the wrong scope — all of which are
+// syntax- or plan-level facts. This exercises every path once and prints the
+// EXPLAIN for the two that carry the index requirements
+// (`plans/email-editor/recipient-search.md` §10).
+//
+// Usage: npx dotenv -- npx tsx packages/lib/scripts/verify-recipient-search.ts [orgId]
+
+import { database, schema } from '@auxx/database'
+import { sql } from 'drizzle-orm'
+import { searchRecipients } from '../src/participants/search/search-recipients'
+
+const orgId = process.argv[2]
+
+async function pickOrg(): Promise<string> {
+  if (orgId) return orgId
+  const rows = await database.execute(sql`
+    SELECT "organizationId", count(*)::int AS n
+    FROM ${schema.Participant}
+    GROUP BY 1 ORDER BY n DESC LIMIT 1
+  `)
+  const row = rows.rows?.[0] as { organizationId?: string } | undefined
+  if (!row?.organizationId) throw new Error('no org with participants found')
+  return row.organizationId
+}
+
+async function show(label: string, run: () => ReturnType<typeof searchRecipients>) {
+  const result = await run()
+  if (result.isErr()) {
+    console.log(`\n✗ ${label}\n  ERROR: ${result.error.message}`)
+    return
+  }
+  const { candidates, truncated } = result.value
+  // Invariants worth asserting rather than eyeballing: one row per identifier
+  // (the arms are merged, so a person in both must appear once), and every row
+  // carries something committable.
+  const keys = candidates.map((c) => c.identifier.toLowerCase())
+  const dupes = keys.filter((k, i) => keys.indexOf(k) !== i)
+  const empty = candidates.filter((c) => !c.identifier?.trim())
+  const flags = [
+    dupes.length ? `🔴 DUPLICATE identifiers: ${[...new Set(dupes)].join(', ')}` : '',
+    empty.length ? `🔴 ${empty.length} row(s) with no identifier` : '',
+  ].filter(Boolean)
+  console.log(`\n✓ ${label}  (${candidates.length} rows, truncated=${truncated})`)
+  for (const flag of flags) console.log(`    ${flag}`)
+  for (const c of candidates.slice(0, 5)) {
+    console.log(
+      `    [${c.source}] ${c.displayName} <${c.identifier}> ${c.identifierType} score=${c.score.toFixed(3)}`
+    )
+  }
+}
+
+async function main() {
+  const organizationId = await pickOrg()
+  console.log(`org: ${organizationId}`)
+
+  await show('email / name query', () =>
+    searchRecipients(database, { organizationId, query: 'klooth', model: 'email' })
+  )
+  await show('email / two-char query', () =>
+    searchRecipients(database, { organizationId, query: 'kl', model: 'email' })
+  )
+  await show('email / bare domain', () =>
+    searchRecipients(database, { organizationId, query: 'gmail', model: 'email' })
+  )
+  await show('email / empty query → most recently mailed', () =>
+    searchRecipients(database, { organizationId, query: '', model: 'email' })
+  )
+  await show('phone / national US digits', () =>
+    searchRecipients(database, { organizationId, query: '(415) 555', model: 'phone', region: 'US' })
+  )
+  await show('phone / national DE digits', () =>
+    searchRecipients(database, {
+      organizationId,
+      query: '030 901820',
+      model: 'phone',
+      region: 'DE',
+    })
+  )
+  await show('phone / name query on a phone channel', () =>
+    searchRecipients(database, { organizationId, query: 'klooth', model: 'phone', region: 'US' })
+  )
+  await show('thread_only → contact arm skipped', () =>
+    searchRecipients(database, { organizationId, query: 'klooth', model: 'thread_only' })
+  )
+  await show('platform_user → empty, NOT unfiltered', () =>
+    searchRecipients(database, { organizationId, query: 'klooth', model: 'platform_user' })
+  )
+  await show('lens scoped to an inbox that matches nothing', () =>
+    searchRecipients(database, {
+      organizationId,
+      query: 'klooth',
+      model: 'email',
+      threadVisibility: sql`${schema.Thread}."inboxId" = 'no-such-inbox'`,
+    })
+  )
+  await show('contact scope resolved to none → participants still answer', () =>
+    searchRecipients(database, {
+      organizationId,
+      query: 'klooth',
+      model: 'email',
+      contactVisibility: null,
+    })
+  )
+
+  // §10's acceptance test: the participant OR block must plan as a BitmapOr.
+  //
+  // `enable_seqscan = off` is required for this to prove anything: the dev org has
+  // ~5k participants, where a sequential scan is genuinely cheaper, so without it
+  // the plan says nothing about whether the indexes CAN serve the block. The
+  // question here is index-servability, not which plan wins at this size.
+  console.log('\n--- EXPLAIN: participant arm (enable_seqscan=off) ---')
+  await database.execute(sql`SET enable_seqscan = off`)
+  const plan = await database.execute(sql`
+    EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF)
+    SELECT p."id" FROM ${schema.Participant} p
+    WHERE p."organizationId" = ${organizationId}
+      AND NOT p."isSpammer"
+      AND (
+        (p."displayName" % 'klooth' AND similarity(p."displayName", 'klooth') > 0.3)
+        OR p."displayName" ILIKE '%klooth%'
+        OR p."identifier" ILIKE '%klooth%'
+      )
+    LIMIT 20
+  `)
+  for (const row of plan.rows ?? [])
+    console.log('   ', (row as Record<string, string>)['QUERY PLAN'])
+  await database.execute(sql`RESET enable_seqscan`)
+
+  process.exit(0)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/packages/lib/src/participants/search/index.ts
+++ b/packages/lib/src/participants/search/index.ts
@@ -1,11 +1,12 @@
 // packages/lib/src/participants/search/index.ts
 //
-// Ranked recipient search. Explicit named exports per `docs/lib-module-guide.md`.
+// Ranked recipient search: participants ∪ contacts. Explicit named exports per
+// `docs/lib-module-guide.md`.
 //
-// The SQL builders ship ahead of the read function that assembles them
-// (`search-recipients.ts`, the participants ∪ contacts union) so the two halves
-// can be reviewed apart: these are pure, testable-by-rendered-SQL fragments with
-// no IO, and index-servability is a property of the text they emit.
+// `searchRecipients` is the entry point; the SQL builders are exported too
+// because they are the reviewable unit — index-servability is a property of the
+// text they emit, and they are pinned by rendered-SQL tests that the read
+// function's own integration path cannot express.
 
 export {
   type ParticipantSearchBinding,
@@ -15,3 +16,9 @@ export {
   participantSearchRank,
 } from './participant-search-sql'
 export { phoneSearchPatterns } from './phone-query'
+export {
+  type RecipientCandidate,
+  type RecipientSearchResult,
+  type SearchRecipientsParams,
+  searchRecipients,
+} from './search-recipients'

--- a/packages/lib/src/participants/search/merge-arms.test.ts
+++ b/packages/lib/src/participants/search/merge-arms.test.ts
@@ -1,0 +1,126 @@
+// packages/lib/src/participants/search/merge-arms.test.ts
+//
+// The union's actual decisions. Everything either side of this is SQL, verified
+// against a real database by `scripts/verify-recipient-search.ts`; this is the
+// part with branches worth pinning.
+
+import { describe, expect, it } from 'vitest'
+import type { RecipientCandidate } from './search-recipients'
+import { mergeArms } from './search-recipients'
+
+const participant = (
+  identifier: string,
+  contactId: string | null = null,
+  score = 1
+): RecipientCandidate => ({
+  identifier,
+  identifierType: 'EMAIL',
+  displayName: identifier,
+  contactId,
+  source: 'participant',
+  score,
+})
+
+const contact = (
+  identifier: string,
+  contactId: string | null = 'c1',
+  score = 1
+): RecipientCandidate => ({
+  identifier,
+  identifierType: 'EMAIL',
+  displayName: identifier,
+  contactId,
+  source: 'contact',
+  score,
+})
+
+describe('mergeArms — suppression by contact id', () => {
+  it('drops a contact row whose contact already appears as a participant', () => {
+    // The participant row is strictly better: same person, plus a recency signal.
+    const merged = mergeArms([participant('a@x.com', 'c1')], [contact('b@x.com', 'c1')], 20)
+    expect(merged.map((r) => r.identifier)).toEqual(['a@x.com'])
+  })
+
+  it('keeps a contact row for a DIFFERENT contact', () => {
+    const merged = mergeArms([participant('a@x.com', 'c1')], [contact('b@x.com', 'c2')], 20)
+    expect(merged.map((r) => r.identifier)).toEqual(['a@x.com', 'b@x.com'])
+  })
+
+  it('does not suppress on a null contact id — null is not a key', () => {
+    // Two unlinked rows are not evidence of the same person. Treating null as a
+    // match would collapse every unlinked contact into the first one.
+    const merged = mergeArms([participant('a@x.com', null)], [contact('b@x.com', null)], 20)
+    expect(merged).toHaveLength(2)
+  })
+})
+
+describe('mergeArms — dedupe by identifier', () => {
+  it('drops a contact row with the same address as a participant, without a shared id', () => {
+    // The `Participant.entityInstanceId` link is nullable and often absent, so the
+    // contact-id rule alone would let the same address appear twice.
+    const merged = mergeArms([participant('a@x.com', null)], [contact('a@x.com', 'c1')], 20)
+    expect(merged.map((r) => r.identifier)).toEqual(['a@x.com'])
+    expect(merged[0]?.source).toBe('participant')
+  })
+
+  it('is case-insensitive', () => {
+    const merged = mergeArms([participant('Jane@Corp.com')], [contact('jane@corp.com', 'c9')], 20)
+    expect(merged).toHaveLength(1)
+  })
+
+  it('dedupes contacts against each other too', () => {
+    const merged = mergeArms([], [contact('a@x.com', 'c1'), contact('a@x.com', 'c2')], 20)
+    expect(merged).toHaveLength(1)
+  })
+})
+
+describe('mergeArms — ordering', () => {
+  it('🔴 keeps participants ahead of contacts even when a contact scores higher', () => {
+    // The scores are on different scales and nothing calibrates them, so sorting
+    // the merged list would be a guess presented as a ranking.
+    const merged = mergeArms([participant('p@x.com', null, 0.2)], [contact('c@x.com', 'c1', 9)], 20)
+    expect(merged.map((r) => r.source)).toEqual(['participant', 'contact'])
+  })
+
+  it('preserves each arm’s own order', () => {
+    const merged = mergeArms(
+      [participant('p1@x.com', null, 3), participant('p2@x.com', null, 2)],
+      [contact('c1@x.com', 'a'), contact('c2@x.com', 'b')],
+      20
+    )
+    expect(merged.map((r) => r.identifier)).toEqual([
+      'p1@x.com',
+      'p2@x.com',
+      'c1@x.com',
+      'c2@x.com',
+    ])
+  })
+})
+
+describe('mergeArms — limit', () => {
+  it('never exceeds the limit', () => {
+    const participants = Array.from({ length: 30 }, (_, i) => participant(`p${i}@x.com`))
+    expect(mergeArms(participants, [], 20)).toHaveLength(20)
+  })
+
+  it('truncates participants before contacts are considered', () => {
+    const participants = Array.from({ length: 25 }, (_, i) => participant(`p${i}@x.com`))
+    const merged = mergeArms(participants, [contact('c@x.com', 'c1')], 20)
+    expect(merged).toHaveLength(20)
+    expect(merged.every((r) => r.source === 'participant')).toBe(true)
+  })
+
+  it('fills the remainder with contacts when participants are short', () => {
+    const merged = mergeArms(
+      [participant('p@x.com')],
+      Array.from({ length: 30 }, (_, i) => contact(`c${i}@x.com`, `id${i}`)),
+      5
+    )
+    expect(merged).toHaveLength(5)
+    expect(merged.filter((r) => r.source === 'contact')).toHaveLength(4)
+  })
+
+  it('handles both arms empty', () => {
+    expect(mergeArms([], [], 20)).toEqual([])
+  })
+})

--- a/packages/lib/src/participants/search/search-recipients.ts
+++ b/packages/lib/src/participants/search/search-recipients.ts
@@ -1,0 +1,603 @@
+// packages/lib/src/participants/search/search-recipients.ts
+//
+// Ranked recipient search: **participants ∪ contacts**, one endpoint.
+//
+// Why a union. `Participant` rows are written only by ingest and chat visitor
+// identity, so a row means *you have corresponded with this address* — one row IS
+// one identifier. A contact imported into the CRM and never messaged has no row
+// at all. A helpdesk composer needs both: "reply to the person who wrote in" and
+// "email this contact for the first time" are both core motions. The composer this
+// replaces searched contact RECORDS only, and then had to fan each record out to
+// its N identifiers on the client to find something addressable.
+//
+// 🔴 **Zero access checks live here.** The router asserts and hands both scopes
+// down as SQL (`docs/lib-module-guide.md` §6). The two arms keep two *different*
+// gates and this file must not flatten them: the participant arm narrows with the
+// mail lens (`threadVisibility`), the contact arm with record scope
+// (`contactVisibility`). They are different authorization models; merging them is
+// how a permissions bug gets written.
+
+import { type Database, schema } from '@auxx/database'
+import type { IdentifierType } from '@auxx/database/types'
+import { DEFAULT_PHONE_REGION, type PhoneRegion } from '@auxx/utils'
+import { type SQL, sql } from 'drizzle-orm'
+import { err, ok, type Result } from 'neverthrow'
+import { getCachedCustomFields, getCachedEntityDefId } from '../../cache/org-cache-helpers'
+import { BadRequestError } from '../../errors'
+import {
+  recordSearchColumnsAliased,
+  recordSearchPredicate,
+  recordSearchRank,
+} from '../../resources/search/record-search-sql'
+import {
+  identifierFieldsForModel,
+  identifierTypesForModel,
+  type RecipientModel,
+} from '../channel-identifier-fields'
+import {
+  participantSearchBinding,
+  participantSearchPredicate,
+  participantSearchRank,
+} from './participant-search-sql'
+import { phoneSearchPatterns } from './phone-query'
+
+/** Default page size. A recipient picker shows ~20 and you refine by typing. */
+const DEFAULT_LIMIT = 20
+
+/**
+ * How many text matches the lens `EXISTS` may examine before giving up.
+ *
+ * 🔴 **This is a recall cap and it is deliberate.** Measured on 200k participants
+ * / 10k per org: the lens semi-join costs 12 ms in the typical case (Postgres
+ * sorts the outer side first and probes ~22 rows to fill 20), but **51 ms when a
+ * wide lens excludes every match** — all matching candidates probed, zero rows
+ * returned. That case is not exotic: a member holding several inboxes searching a
+ * common surname whose threads live elsewhere. Capping the candidate set bounds it
+ * at ~1 200 probes instead of unbounded, with no effect on the good case.
+ *
+ * If the 20 visible matches all rank below the 200th text match they are missed.
+ * For a picker where you refine by typing, rank 200+ on a fuzzy-name query is not
+ * a row anyone was going to scroll to — but it IS a cap, so
+ * {@link RecipientSearchResult.truncated} reports when it bound the answer.
+ */
+const CANDIDATE_CEILING = 200
+
+/** One addressable candidate. */
+export interface RecipientCandidate {
+  /**
+   * The committable value — E.164 or a lowercased email. **Never null**: both
+   * arms resolve it in SQL, the contact arm via an inner LATERAL that doubles as
+   * the filter, so a contact with no value for this channel cannot reach the list.
+   */
+  identifier: string
+  identifierType: IdentifierType
+  /** The person's name. Equals `identifier` when no name is known. */
+  displayName: string
+  /** `EntityInstance.id` of the contact, when there is one. */
+  contactId: string | null
+  /**
+   * Which arm produced it. Drives the "never messaged before" affordance only —
+   * both arms return equally committable rows.
+   */
+  source: 'participant' | 'contact'
+  /**
+   * Relevance within this row's OWN arm.
+   *
+   * ⚠️ **Not comparable across arms**, which is why the ordering is tiered rather
+   * than blended — see {@link searchRecipients}.
+   */
+  score: number
+}
+
+export interface RecipientSearchResult {
+  candidates: RecipientCandidate[]
+  /**
+   * True when {@link CANDIDATE_CEILING} was reached AND fewer than `limit` rows
+   * came back — the one combination where the cap can have changed the answer.
+   * Surfaced rather than logged so a caller can say "refine your search" instead
+   * of implying the list is exhaustive.
+   */
+  truncated: boolean
+}
+
+export interface SearchRecipientsParams {
+  organizationId: string
+  /** Empty or whitespace switches to the most-recently-mailed path. */
+  query: string
+  /**
+   * The channel's recipient model.
+   *
+   * 🔴 **The model, not a pair of filters.** The plan originally specified
+   * `identifierTypes` and `systemAttributes` as separate params, which makes it
+   * *representable* to filter participants to `PHONE` while reading
+   * `primary_email` off contacts — a wrong answer that looks plausible because
+   * both halves are individually correct. Taking the model and deriving both from
+   * `channel-identifier-fields` makes that disagreement unrepresentable.
+   *
+   * It also removes the `identifierTypes: []` fail-open entirely rather than
+   * guarding it: `identifierTypesForModel` never returns `undefined`, and a model
+   * with no addressable type (`platform_user`) returns `[]`, which this function
+   * answers with an empty result — never with "no filter".
+   */
+  model: RecipientModel
+  /**
+   * Region national (no `+`) phone input is parsed against. Must be the SENDING
+   * channel's own region (`regionFromIdentifier`) — the same input means different
+   * numbers in different regions. Ignored by non-phone models.
+   */
+  region?: PhoneRegion
+  limit?: number
+  /**
+   * Mail-lens predicate for the participant arm, from
+   * `buildMailVisibilityPredicate`. `undefined` means unscoped (SYSTEM only) and
+   * emits **no `EXISTS` at all** — not an always-true one, which would still pay
+   * for the semi-join.
+   *
+   * 🔴 Must constrain the `Thread` table **unaliased**. It is built from
+   * `schema.Thread` `PgColumn` refs, which render as `"Thread"."inboxId"`, and a
+   * Postgres alias replaces the table name — so the join below deliberately does
+   * not alias `Thread`.
+   */
+  threadVisibility?: SQL
+  /**
+   * Record-scope predicate for the contact arm, built against the `ei` alias.
+   * `null` means the caller resolved scope to "no rows" — the contact arm is
+   * skipped entirely and the participant arm still answers.
+   */
+  contactVisibility?: SQL | null
+}
+
+/**
+ * Search addressable recipients for one channel.
+ *
+ * **Ordering is tiered, not blended: participants first, then contacts.**
+ * The two arms' scores are on different scales — the participant rank is
+ * `2·name + 1·identifier + 0.25·recency` and the contact rank is the record
+ * binding's `2·trigram + ts_rank_cd` — and nothing calibrates them against each
+ * other. Blending them would be a guess dressed as a ranking. Tiering is also the
+ * right answer on the merits: a person you have corresponded with is a better
+ * recipient guess than one you have not, which is the same reasoning that lets a
+ * participant row suppress its contact row below.
+ *
+ * **No cursor, no paging.** A deliberate scope cut that buys real safety: the
+ * record picker has a live skip/duplicate bug from pairing a two-part keyset with
+ * a three-part `ORDER BY` (`record-search-sql.ts:143-151`). Not having a cursor
+ * makes that unrepresentable — and it is *required* here, because
+ * `participantSearchRank` reads `now()` and so is not stable across calls.
+ */
+export async function searchRecipients(
+  db: Database,
+  params: SearchRecipientsParams
+): Promise<Result<RecipientSearchResult, Error>> {
+  const limit = params.limit ?? DEFAULT_LIMIT
+  if (limit < 1) return err(new BadRequestError('limit must be at least 1'))
+
+  const identifierTypes = identifierTypesForModel(params.model)
+  // `[]` means nothing is addressable on this channel — an empty result, never an
+  // unfiltered one. See `SearchRecipientsParams.model`.
+  if (identifierTypes.length === 0) return ok({ candidates: [], truncated: false })
+
+  const query = params.query.trim()
+  const region = params.region ?? DEFAULT_PHONE_REGION
+  const phonePatterns = params.model === 'phone' && query ? phoneSearchPatterns(query, region) : []
+
+  const participants = query
+    ? await participantArm(db, params, { query, identifierTypes, phonePatterns, limit })
+    : await recentlyMailedArm(db, params, { identifierTypes, limit })
+
+  // §4.2: a contact reachable through the participant arm is already listed, with
+  // a recency signal the contact row has no equivalent for. Semantically exact,
+  // not a heuristic — the contact arm exists ONLY to surface people never
+  // corresponded with.
+  const contacts =
+    // An empty query lists most-recently-mailed; a contact never messaged has no
+    // business at the top of that list.
+    query && params.contactVisibility !== null
+      ? await contactArm(db, params, { query, phonePatterns, limit, region })
+      : []
+
+  const candidates = mergeArms(participants.rows, contacts, limit)
+  return ok({
+    candidates,
+    truncated: participants.hitCeiling && candidates.length < limit,
+  })
+}
+
+/**
+ * Merge the two arms into one ordered list.
+ *
+ * Extracted as a pure function because this is where the real decisions live —
+ * everything around it is SQL. Two rules, in this order:
+ *
+ * 1. **Suppress by contact id (§4.2).** A contact reachable through the
+ *    participant arm is already listed, and that row is strictly better: it
+ *    carries a recency signal the contact row has no equivalent for. Semantically
+ *    exact rather than a heuristic — the contact arm exists ONLY to surface people
+ *    never corresponded with.
+ *
+ *    ⚠️ Consequence accepted knowingly: a contact with two emails where you have
+ *    mailed only one returns ONE row, not two. The second address is reachable by
+ *    typing it, or through the chip menu
+ *    (`plans/email-editor/recipient-address-switch.md`). The picker is for
+ *    *people*, and reintroducing per-record fan-out is what this endpoint exists
+ *    to delete.
+ *
+ * 2. **Then dedupe by identifier**, which catches the same address arriving from
+ *    both arms without a shared contact id — a `Participant` whose
+ *    `entityInstanceId` was never linked, for instance.
+ *
+ * Participants keep their position ahead of contacts. 🔴 **Do not sort the merged
+ * list by `score`.** The two arms' scores are on different scales (participant:
+ * `2·name + 1·identifier + 0.25·recency`; contact: the record binding's
+ * `2·trigram + ts_rank_cd`) and nothing calibrates them, so a blended sort would be
+ * a guess presented as a ranking. Tiering is also right on the merits: someone you
+ * have corresponded with is the better guess.
+ */
+export function mergeArms(
+  participants: readonly RecipientCandidate[],
+  contacts: readonly RecipientCandidate[],
+  limit: number
+): RecipientCandidate[] {
+  const seenContactIds = new Set(
+    participants.map((row) => row.contactId).filter((id): id is string => id !== null)
+  )
+  const seenIdentifiers = new Set(participants.map((row) => identifierKey(row.identifier)))
+
+  const merged = participants.slice(0, limit)
+  for (const row of contacts) {
+    if (merged.length >= limit) break
+    if (row.contactId && seenContactIds.has(row.contactId)) continue
+    const key = identifierKey(row.identifier)
+    if (seenIdentifiers.has(key)) continue
+    seenIdentifiers.add(key)
+    merged.push(row)
+  }
+  return merged
+}
+
+/**
+ * Rows off a raw `db.execute`, typed by the caller.
+ *
+ * Drizzle types a raw result as `Record<string, unknown>[]`, so a cast is
+ * unavoidable for hand-written SQL. Keeping it in one function means there is one
+ * place to look when a column is renamed, instead of four casts that each looked
+ * fine in isolation. 🔴 The row interfaces below are a CLAIM about the `SELECT`
+ * list, not a check on it — change one, change the other.
+ */
+function rowsOf<T>(result: { rows?: Record<string, unknown>[] }): T[] {
+  return (result.rows ?? []) as unknown as T[]
+}
+
+/**
+ * Dedupe key across arms. Lowercased only — the identifiers are already canonical
+ * (E.164 from the phone write path, lowercased email from the read paths), so
+ * this is a case fold rather than a normalizer. Deliberately NOT
+ * `formatPhoneNumber`: that would need a region here and would silently drop a
+ * legacy value it cannot parse.
+ */
+function identifierKey(identifier: string): string {
+  return identifier.trim().toLowerCase()
+}
+
+/** `IN (…)` over a string list. Drizzle's `= ANY(${array}::text[])` matches nothing. */
+function inList(values: readonly string[]): SQL {
+  return sql`(${sql.join(
+    values.map((value) => sql`${value}`),
+    sql`, `
+  )})`
+}
+
+/**
+ * The lens `EXISTS`, or `undefined` when the viewer is unscoped.
+ *
+ * `MessageParticipant → Message → Thread`, the id-correct path.
+ * **Deliberately not `ThreadParticipant`**, despite being one hop shorter: its
+ * only usable key is `email` (a wide text column with no index of its own), it
+ * measured 1.5× *slower*, and it is a rollup rather than a mirror — 55 of 19 807
+ * thread↔identifier pairs present in `MessageParticipant` are missing from it, so
+ * scoping on it would silently hide real correspondence.
+ *
+ * `EXISTS` rather than a join + `DISTINCT`: a hot participant is on 5 000+
+ * messages, and the semi-join stops at the first visible thread.
+ */
+function lensExists(participantId: SQL, threadVisibility: SQL | undefined): SQL | undefined {
+  if (!threadVisibility) return undefined
+  return sql`EXISTS (
+    SELECT 1
+    FROM ${schema.MessageParticipant} mp
+    JOIN ${schema.Message} m ON m."id" = mp."messageId"
+    JOIN ${schema.Thread} ON ${schema.Thread}."id" = m."threadId"
+    WHERE mp."participantId" = ${participantId}
+      AND ${threadVisibility}
+      -- Merged-away threads must not keep a participant visible. There is NO
+      -- \`deletedAt\` on Thread — an early draft filtered one, on the strength of
+      -- the guide's soft-delete rule, which is about \`Integration.deletedAt\`.
+      -- Postgres rejected it; a rendered-SQL test would not have.
+      -- \`Thread_organizationId_...\` carries a partial index on exactly this
+      -- predicate.
+      AND ${schema.Thread}."mergedIntoThreadId" IS NULL
+  )`
+}
+
+interface ParticipantArmResult {
+  rows: RecipientCandidate[]
+  /** The text-match set reached {@link CANDIDATE_CEILING}. */
+  hitCeiling: boolean
+}
+
+/**
+ * The ranked participant arm: text match capped at {@link CANDIDATE_CEILING},
+ * then the lens semi-join, then the page.
+ *
+ * The cap sits in a CTE so the `EXISTS` cannot be applied to an unbounded match
+ * set. Its inner `ORDER BY` is the same expression the outer one uses, because a
+ * cap that slices by a different ordering than it reports is a silent wrong answer
+ * rather than a slow one.
+ */
+async function participantArm(
+  db: Database,
+  params: SearchRecipientsParams,
+  input: {
+    query: string
+    identifierTypes: readonly IdentifierType[]
+    phonePatterns: readonly string[]
+    limit: number
+  }
+): Promise<ParticipantArmResult> {
+  const p = participantSearchBinding('p')
+  const rank = participantSearchRank(input.query, p)
+  const predicate = participantSearchPredicate(input.query, p, input.phonePatterns)
+  const lens = lensExists(sql`c."id"`, params.threadVisibility)
+
+  const result = await db.execute(sql`
+    WITH candidates AS (
+      SELECT p."id",
+             p."identifier",
+             p."identifierType",
+             p."displayName",
+             p."entityInstanceId",
+             p."lastSentMessageAt",
+             ${rank} AS score
+      FROM ${schema.Participant} p
+      WHERE p."organizationId" = ${params.organizationId}
+        AND NOT p."isSpammer"
+        AND p."identifierType" IN ${inList(input.identifierTypes)}
+        AND ${predicate}
+      ORDER BY score DESC, p."lastSentMessageAt" DESC NULLS LAST, p."id" DESC
+      LIMIT ${CANDIDATE_CEILING}
+    )
+    SELECT c.*, (SELECT count(*)::int FROM candidates) AS candidate_count
+    FROM candidates c
+    ${lens ? sql`WHERE ${lens}` : sql``}
+    ORDER BY c."score" DESC, c."lastSentMessageAt" DESC NULLS LAST, c."id" DESC
+    LIMIT ${input.limit}
+  `)
+
+  const rows = rowsOf<ParticipantRow>(result)
+  return {
+    rows: rows.map(toParticipantCandidate),
+    hitCeiling: Number(rows[0]?.candidate_count ?? 0) >= CANDIDATE_CEILING,
+  }
+}
+
+/**
+ * The empty-query path: most recently mailed.
+ *
+ * The single most useful default a composer has, and the one case where the answer
+ * is exact rather than fuzzy. A straight index scan on
+ * `Participant_org_lastSent_idx`.
+ *
+ * 🔴 `DESC NULLS LAST`, not bare `DESC`. SQL defaults `DESC` to `NULLS FIRST`, the
+ * index is `NULLS LAST`, and the planner will not prove them equivalent even
+ * though the `WHERE` excludes nulls — measured, bare `DESC` keeps a `Sort` on top
+ * of the scan while `DESC NULLS LAST` is an ordered scan that stops at `limit`.
+ *
+ * Scoped by the same lens: this is the widest possible enumeration of the org's
+ * correspondents, so leaving it unscoped while scoping the typed path would leave
+ * the hole open at its widest.
+ */
+async function recentlyMailedArm(
+  db: Database,
+  params: SearchRecipientsParams,
+  input: { identifierTypes: readonly IdentifierType[]; limit: number }
+): Promise<ParticipantArmResult> {
+  const lens = lensExists(sql`p."id"`, params.threadVisibility)
+
+  const result = await db.execute(sql`
+    SELECT p."id",
+           p."identifier",
+           p."identifierType",
+           p."displayName",
+           p."entityInstanceId",
+           p."lastSentMessageAt",
+           0::float8 AS score
+    FROM ${schema.Participant} p
+    WHERE p."organizationId" = ${params.organizationId}
+      AND NOT p."isSpammer"
+      AND p."identifierType" IN ${inList(input.identifierTypes)}
+      AND p."lastSentMessageAt" IS NOT NULL
+      ${lens ? sql`AND ${lens}` : sql``}
+    ORDER BY p."lastSentMessageAt" DESC NULLS LAST, p."id" DESC
+    LIMIT ${input.limit}
+  `)
+
+  return {
+    rows: rowsOf<ParticipantRow>(result).map(toParticipantCandidate),
+    hitCeiling: false,
+  }
+}
+
+interface ParticipantRow {
+  id: string
+  identifier: string
+  identifierType: IdentifierType
+  displayName: string | null
+  entityInstanceId: string | null
+  score: number | string
+  candidate_count?: number | string
+}
+
+function toParticipantCandidate(row: ParticipantRow): RecipientCandidate {
+  return {
+    identifier: row.identifier,
+    identifierType: row.identifierType,
+    // `displayName` is nullable and the nulls are real (403 of 15 244 rows; 29% in
+    // one live org). Falling back to the identifier matches what every write site
+    // would have stored, and §5's row renders one line when the two are equal.
+    displayName: row.displayName ?? row.identifier,
+    contactId: row.entityInstanceId,
+    source: 'participant',
+    score: Number(row.score),
+  }
+}
+
+/**
+ * The contact arm — people in the CRM never corresponded with.
+ *
+ * Two shapes, because the selective table differs by query kind:
+ *
+ * 1. **name query** — search `EntityInstance` with the existing record predicate,
+ *    and resolve the identifier through an **inner** `LATERAL` on `FieldValue`.
+ *    The LATERAL does both jobs at once: a contact with no value for this
+ *    channel's field produces an empty subquery and drops out, and every surviving
+ *    row arrives carrying the exact string to commit. That is what makes a
+ *    phone-less contact in a phone composer *unrepresentable* rather than
+ *    filtered-after-the-fact.
+ * 2. **digit query** — `EntityInstance.searchText` is `displayName +
+ *    secondaryDisplayValue` and nothing else, so the record predicate cannot match
+ *    a field value: measured **0 rows** for a 7-digit query over 100k contacts
+ *    that all had phone numbers. For digits the selective side is `FieldValue`, so
+ *    the join is inverted and served by
+ *    `FieldValue_org_field_valueText_trgm_idx` (0.30 ms over 200k rows).
+ *
+ * Both are needed: (1) cannot find a number, (2) cannot find a name.
+ */
+async function contactArm(
+  db: Database,
+  params: SearchRecipientsParams,
+  input: {
+    query: string
+    phonePatterns: readonly string[]
+    limit: number
+    region: PhoneRegion
+  }
+): Promise<RecipientCandidate[]> {
+  const fields = identifierFieldsForModel(params.model)
+  // `undefined` is a real answer, not a gap: no contact field holds a Facebook
+  // PSID or a platform user id, so the arm is skipped rather than falling back to
+  // email — which would offer addresses the channel cannot send to.
+  if (!fields) return []
+
+  const contactDefId = await getCachedEntityDefId(params.organizationId, 'contact')
+  if (!contactDefId) return []
+
+  const customFields = await getCachedCustomFields(params.organizationId, contactDefId)
+  const fieldIds = customFields
+    .filter(
+      (field) => field.systemAttribute && fields.systemAttributes.includes(field.systemAttribute)
+    )
+    .map((field) => field.id)
+  // Zero queries so far — `getCachedCustomFields` is the org cache, so the field
+  // ids are inlined as literals below. An empty list means this org has no field
+  // for the channel's systemAttributes; nothing is addressable through records.
+  if (fieldIds.length === 0) return []
+
+  const scope = params.contactVisibility ? sql`AND ${params.contactVisibility}` : sql``
+  const rows = input.phonePatterns.length
+    ? await contactsByFieldValue(db, params, { ...input, fieldIds, contactDefId, scope })
+    : await contactsByName(db, params, { ...input, fieldIds, contactDefId, scope })
+
+  return rows.map((row) => ({
+    identifier: row.identifier,
+    identifierType: fields.identifierType,
+    displayName: row.displayName ?? row.identifier,
+    contactId: row.id,
+    source: 'contact' as const,
+    score: Number(row.score ?? 0),
+  }))
+}
+
+interface ContactRow {
+  id: string
+  displayName: string | null
+  identifier: string
+  score?: number | string
+}
+
+/** Shape (1): text-match records, resolve the identifier via an inner LATERAL. */
+async function contactsByName(
+  db: Database,
+  params: SearchRecipientsParams,
+  input: {
+    query: string
+    limit: number
+    fieldIds: string[]
+    contactDefId: string
+    scope: SQL
+  }
+): Promise<ContactRow[]> {
+  const ei = recordSearchColumnsAliased('ei')
+  const result = await db.execute(sql`
+    SELECT ei."id",
+           ei."displayName",
+           ident."valueText" AS identifier,
+           ${recordSearchRank(input.query, ei)} AS score
+    FROM ${schema.EntityInstance} ei
+    JOIN LATERAL (
+      SELECT fv."valueText"
+      FROM ${schema.FieldValue} fv
+      WHERE fv."entityId" = ei."id"
+        AND fv."fieldId" IN ${inList(input.fieldIds)}
+        AND fv."valueText" IS NOT NULL
+      -- The primary value is the FIRST row by ascending sortKey (#1613). Both
+      -- contact.primary_email and contact.phone are multi-value since #1625/#1634,
+      -- and omitting this ordering returns a non-deterministic "primary".
+      ORDER BY fv."sortKey" ASC
+      LIMIT 1
+    ) ident ON TRUE
+    WHERE ei."organizationId" = ${params.organizationId}
+      AND ei."entityDefinitionId" = ${input.contactDefId}
+      AND ei."archivedAt" IS NULL
+      AND ${recordSearchPredicate(input.query, ei)}
+      ${input.scope}
+    ORDER BY score DESC, ei."updatedAt" DESC, ei."id" DESC
+    LIMIT ${input.limit}
+  `)
+  return rowsOf<ContactRow>(result)
+}
+
+/** Shape (2): `FieldValue`-first for a digit query, then join back to the record. */
+async function contactsByFieldValue(
+  db: Database,
+  params: SearchRecipientsParams,
+  input: {
+    phonePatterns: readonly string[]
+    limit: number
+    fieldIds: string[]
+    contactDefId: string
+    scope: SQL
+  }
+): Promise<ContactRow[]> {
+  const valueArms = sql.join(
+    input.phonePatterns.map((pattern) => sql`fv."valueText" ILIKE ${`%${pattern}%`}`),
+    sql` OR `
+  )
+  const result = await db.execute(sql`
+    SELECT ei."id",
+           ei."displayName",
+           fv."valueText" AS identifier,
+           0::float8 AS score
+    FROM ${schema.FieldValue} fv
+    JOIN ${schema.EntityInstance} ei ON ei."id" = fv."entityId"
+    WHERE fv."organizationId" = ${params.organizationId}
+      AND fv."fieldId" IN ${inList(input.fieldIds)}
+      AND fv."valueText" IS NOT NULL
+      AND (${valueArms})
+      AND ei."entityDefinitionId" = ${input.contactDefId}
+      AND ei."archivedAt" IS NULL
+      ${input.scope}
+    ORDER BY fv."sortKey" ASC, ei."id" DESC
+    LIMIT ${input.limit}
+  `)
+  return rowsOf<ContactRow>(result)
+}


### PR DESCRIPTION
Completes step 4 of the recipient-search plan: the two-arm read and the tRPC procedure that binds both gates. Follows #1668, which shipped the SQL builders this assembles. **Nothing consumes it yet** — the composer swap is next.

## Two arms, two gates, deliberately not flattened

The participant arm is mail data and narrows with the mail lens; the contact arm is CRM data and narrows with record scope. A viewer can legitimately hold one and not the other, so the union answers with whichever arm admits rows. Both directions verified against the dev database:

| scenario | result |
|---|---|
| lens excludes every thread | **4 rows, all contacts** — participants gone, contact arm still answers |
| record scope resolves to `none` | **12 rows, all participants** — contact arm skipped |

That is the design claim from the plan, checked rather than argued. Merging the two authorization models is how a permissions bug gets written, so the lib function keeps them as separate parameters and the router resolves each independently.

## The contact arm has two shapes

Because the selective table differs by query kind:

- **name query** → search `EntityInstance`, resolve the identifier through an **inner `LATERAL`** on `FieldValue`. The LATERAL does both jobs: a contact with no value for this channel produces an empty subquery and drops out, so a phone-less contact in a phone composer is *unrepresentable* rather than filtered after the fact. Verified — a phone-model search returned `Chrissi Klooth <+15102055536>`, a contact reached by name and carrying a phone number.
- **digit query** → invert the join and lead with `FieldValue`, because `EntityInstance.searchText` is `displayName + secondaryDisplayValue` and nothing else, so the record predicate cannot match a field value at all.

Both are needed: (1) cannot find a number, (2) cannot find a name.

## `mergeArms`, extracted as a pure function

Suppress by contact id → dedupe by identifier → participants ahead of contacts. Extracted because this is where the actual decisions live; everything either side is SQL. 12 unit tests, no database needed.

**The ordering is tiered, not blended, and that's deliberate.** The two arms' scores are on different scales — participant is `2·name + 1·identifier + 0.25·recency`, contact is the record binding's `2·trigram + ts_rank_cd` — and nothing calibrates them. Sorting the merged list would be a guess presented as a ranking. Tiering is also right on the merits: someone you've corresponded with is the better guess, which is the same reasoning that lets a participant row suppress its contact row.

## One deviation from the plan worth reviewing

It takes the channel's **`recipientModel`**, not the plan's separate `identifierTypes` + `systemAttributes` params. Those make it *representable* to filter participants to `PHONE` while reading `primary_email` off contacts — a wrong answer that looks plausible because both halves are individually correct. Deriving both from `channel-identifier-fields` (#1666) makes that disagreement unrepresentable, and removes the `identifierTypes: []` fail-open entirely rather than guarding it: `platform_user` returns `[]`, which the function answers with an empty result, never with "no filter". Verified.

## The candidate ceiling

`CANDIDATE_CEILING = 200` bounds the one case that regresses — a wide lens excluding every match does maximum work to return an empty list (51 ms measured, vs 12 ms typical). It's a **recall cap**, so it's reported through `truncated` rather than silently changing the answer.

## Verification

`packages/lib/scripts/verify-recipient-search.ts` — 11 scenarios against the dev database, asserting no duplicate and no empty identifiers in any result, plus the EXPLAIN. All pass; the participant OR block plans as a **three-way `BitmapOr`** on real data (§10's acceptance test), which is why the script sets `enable_seqscan = off` — at 5k rows a seq scan is genuinely cheaper and the plan would otherwise prove nothing about index-servability.

**Two things only a real database caught**, both worth knowing:

1. **`Thread.deletedAt` does not exist.** I'd added that filter to the lens `EXISTS` on the strength of the guide's soft-delete rule — which is about `Integration.deletedAt`. Postgres rejected it. `mergedIntoThreadId IS NULL` is the correct filter and there's a partial index on exactly that predicate. A rendered-SQL test would have passed happily.
2. **`@auxx/utils` needed a local rebuild** for the runtime to see `regionFromIdentifier` from #1667 — types resolve to source, runtime to `dist`. CI builds fresh so nothing is wrong in prod, but it's a local-dev trap.

76 tests pass in `src/participants`; lib and web typecheck with no new errors.

## Note on `packages/lib/package.json`

The two new export subpaths are codegen (`scripts/generate-exports.ts`), regenerated after rebasing onto #1669 so the diff contains only these two entries and none of that PR's.
