### PR TITLE
feat(composer): swap the recipient picker onto ranked recipient search

### DIFF
--- a/apps/web/src/components/mail/email-editor/identifier-model.ts
+++ b/apps/web/src/components/mail/email-editor/identifier-model.ts
@@ -28,43 +28,25 @@ export { DEFAULT_PHONE_REGION, type PhoneRegion, regionFromIdentifier }
 /**
  * Everything the recipient input needs to know about ONE identifier shape:
  * how to validate/normalize a typed value, which `IdentifierType` to commit,
- * which contact field holds the candidate values, and what to call the thing
- * in copy.
+ * and what to call the thing in copy.
  *
- * Keyed by `recipientModel` so the composer stays capability-driven. The
- * model→field half now comes from `@auxx/lib/participants/channel-identifier-fields`,
- * which the agent send path (`recipient-resolver.ts`) binds too — so there is one
- * answer to "which contact field does this channel address", not two that agree
- * by inspection. What stays local is genuinely UI: validation, display
- * formatting, and copy.
+ * Keyed by `recipientModel` so the composer stays capability-driven. This is
+ * genuinely UI — validation, display formatting, copy. **Which contact field a
+ * channel addresses is deliberately NOT here**: `search.recipients` resolves the
+ * identifier server-side from
+ * `@auxx/lib/participants/channel-identifier-fields`, so the client never names
+ * the addressable field and cannot disagree with the server about it.
  */
 export interface IdentifierModelSpec {
-  /** `IdentifierType` committed on every recipient of this model. */
-  identifierType: IdentifierTypeType
-
   /**
-   * `systemAttribute` candidates on the contact definition, in preference
-   * order. The first one that resolves to a field wins.
+   * `IdentifierType` committed on every recipient of this model.
    *
-   * Comes from `@auxx/lib/participants/channel-identifier-fields` — the SAME
-   * switch the agent send path binds. It used to be restated here, which is how
-   * a composer reading `primary_email` on a phone channel becomes possible.
+   * Read off `@auxx/lib/participants/channel-identifier-fields` — the SAME
+   * switch the agent send path and the recipient search bind — rather than
+   * restated, which is how a composer committing `EMAIL` on a phone channel
+   * becomes possible.
    */
-  systemAttributes: readonly string[]
-
-  /**
-   * Key on the picker row's raw `data` holding the record's primary value —
-   * the fallback when the field read fails or returns nothing.
-   */
-  rowDataKey: string
-
-  /**
-   * Whether the picker row's `secondaryInfo` (the secondary display field) is
-   * a value of THIS model. True for email — contacts render their address as
-   * the subtitle — and false for everything else, where the subtitle is still
-   * an email and would poison a phone recipient list.
-   */
-  secondaryInfoIsIdentifier: boolean
+  identifierType: IdentifierTypeType
 
   /**
    * Canonical form of a raw typed/stored value, or `null` when it is not a
@@ -84,8 +66,7 @@ export interface IdentifierModelSpec {
   invalidTitle: string
   invalidDescription: string
 
-  /** Singular/plural noun used in the "which one?" popover. */
-  noun: string
+  /** Plural noun for the suggestion list's empty state. */
   nounPlural: string
 }
 
@@ -93,9 +74,6 @@ const EMAIL_RE = /\S+@\S+\.\S+/
 
 const EMAIL_SPEC: IdentifierModelSpec = {
   identifierType: EMAIL_IDENTIFIER_FIELDS.identifierType,
-  systemAttributes: EMAIL_IDENTIFIER_FIELDS.systemAttributes,
-  rowDataKey: 'email',
-  secondaryInfoIsIdentifier: true,
   normalize: (raw) => {
     const trimmed = raw.trim()
     return trimmed && EMAIL_RE.test(trimmed) ? trimmed.toLowerCase() : null
@@ -103,7 +81,6 @@ const EMAIL_SPEC: IdentifierModelSpec = {
   formatDisplay: (value) => value,
   invalidTitle: 'Invalid Email',
   invalidDescription: 'Please enter a valid email address.',
-  noun: 'email address',
   nounPlural: 'email addresses',
 }
 
@@ -116,9 +93,6 @@ const EMAIL_SPEC: IdentifierModelSpec = {
 function createPhoneSpec(region: PhoneRegion): IdentifierModelSpec {
   return {
     identifierType: PHONE_IDENTIFIER_FIELDS.identifierType,
-    systemAttributes: PHONE_IDENTIFIER_FIELDS.systemAttributes,
-    rowDataKey: 'phone',
-    secondaryInfoIsIdentifier: false,
     // `formatPhoneNumber` is THE phone normalizer (libphonenumber-backed, E.164
     // out, `null` for anything unparseable or impossible). Never hand-roll a
     // second one here — write-path and lookup normalization must not drift.
@@ -133,7 +107,6 @@ function createPhoneSpec(region: PhoneRegion): IdentifierModelSpec {
     },
     invalidTitle: 'Invalid Phone Number',
     invalidDescription: 'Please enter a valid phone number, e.g. +14155551234.',
-    noun: 'phone number',
     nounPlural: 'phone numbers',
   }
 }

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -797,7 +797,8 @@ function ReplyComposeEditorComponent({
     (
       role: 'TO' | 'CC' | 'BCC',
       contactData: {
-        recordId: string
+        /** `null` for a participant never linked to a contact record. */
+        recordId: string | null
         identifier: string
         identifierType: IdentifierType
         name?: string | null
@@ -811,7 +812,7 @@ function ReplyComposeEditorComponent({
         identifier: contactData.identifier,
         identifierType: contactData.identifierType,
         name: contactData.name,
-        recordId: contactData.recordId,
+        recordId: contactData.recordId ?? undefined,
       })
     },
     [upsertRecipient]

--- a/apps/web/src/components/mail/email-editor/recipient-input.test.tsx
+++ b/apps/web/src/components/mail/email-editor/recipient-input.test.tsx
@@ -1,89 +1,50 @@
 // apps/web/src/components/mail/email-editor/recipient-input.test.tsx
 //
-// C6 (multi-email plan): the compose recipient picker under the multi-value
-// email flip. A picked contact is expanded into its N addresses — the user
-// picks WHICH address the mail goes to (a contact with 2 emails yields 2
-// address rows) — and the exclude filter keys on ADDRESSES: a contact whose
-// primary is already a recipient stays pickable for its other addresses and
-// hides only once every known address is a recipient.
+// The compose recipient picker on `api.search.recipients` — participants ∪
+// contacts, one ranked read. Each suggestion IS one identifier (`Participant` is
+// unique on `(organizationId, identifier, identifierType)`), so there is no
+// record-to-addresses fan-out left to test: a contact with two addresses arrives
+// as two rows, and excluding one is set membership on a string.
+//
+// The user-visible behaviours the old record-picker tests pinned still hold and
+// are still covered here, one layer down: a contact with two addresses is
+// reachable at both, and an address already in the field is not offered again.
 
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { PhoneRegion } from './identifier-model'
 
-interface PickerItemStub {
-  id: string
-  recordId: string
+interface CandidateStub {
+  identifier: string
+  identifierType: 'EMAIL' | 'PHONE'
   displayName: string
-  secondaryInfo?: string
-  data: Record<string, unknown>
+  contactId: string | null
+  source: 'participant' | 'contact'
+  score: number
 }
 
 const h = vi.hoisted(() => ({
-  batchGet: vi.fn(),
   toastError: vi.fn(),
-  pickerItems: [] as unknown[],
+  candidates: [] as unknown[],
+  /** Every `{ query, model, region }` the component asked the endpoint for. */
+  queryInputs: [] as unknown[],
 }))
 
 vi.mock('~/trpc/react', () => ({
   api: {
-    fieldValue: {
-      batchGet: { useMutation: () => ({ mutateAsync: h.batchGet }) },
+    search: {
+      recipients: {
+        useQuery: (input: unknown, options?: { enabled?: boolean }) => {
+          if (options?.enabled !== false) h.queryInputs.push(input)
+          return {
+            data: { candidates: h.candidates, truncated: false },
+            isFetching: false,
+          }
+        },
+      },
     },
   },
-}))
-
-// The record picker's own behavior (search, hydration) is exercised elsewhere;
-// this stub renders the item list with the SAME excludeFilter/onSelectItem/
-// onResultsChange contract so the expansion + per-address exclude logic is
-// what's under test.
-vi.mock('~/components/pickers/record-picker/record-picker-content', async () => {
-  const { useEffect } = await import('react')
-  return {
-    RecordPickerContent: ({
-      onSelectItem,
-      onResultsChange,
-      excludeFilter,
-    }: {
-      onSelectItem: (item: unknown) => void
-      onResultsChange?: (items: unknown[]) => void
-      excludeFilter?: (item: unknown) => boolean
-    }) => {
-      useEffect(() => {
-        onResultsChange?.(h.pickerItems)
-      }, [onResultsChange])
-      return (
-        <div data-testid='record-picker'>
-          {(h.pickerItems as Array<{ id: string; displayName: string }>)
-            .filter((item) => !excludeFilter?.(item))
-            .map((item) => (
-              <button key={item.id} type='button' onClick={() => onSelectItem(item)}>
-                {item.displayName}
-              </button>
-            ))}
-        </div>
-      )
-    },
-  }
-})
-
-vi.mock('~/components/resources/store/resource-store', () => ({
-  useResourceStore: {
-    getState: () => ({
-      systemAttributeMap: {},
-      systemAttributeByDef: {},
-      ambiguousSystemAttributes: new Set(),
-    }),
-  },
-}))
-
-vi.mock('~/components/resources/utils/normalize-record-id', () => ({
-  getNormalizedRecordId: (id: string) => id,
-}))
-
-vi.mock('~/components/resources/utils/resolve-system-attribute', () => ({
-  resolveSystemAttributeRef: () => 'contact:field-email',
 }))
 
 vi.mock('@auxx/ui/components/toast', () => ({ toastError: h.toastError }))
@@ -101,25 +62,16 @@ vi.mock('./editor-active-state-context', () => ({
 
 const { RecipientInput } = await import('./recipient-input')
 
-const ADA: PickerItemStub = {
-  id: 'c1',
-  recordId: 'contact:c1',
-  displayName: 'Ada Lovelace',
-  secondaryInfo: 'a@x.com',
-  data: {},
-}
-
-/** batchGet payload for a contact whose primary_email holds the given addresses. */
-function emailValues(addresses: string[], recordId = 'contact:c1') {
+/** One participant row for Ada, addressable at `identifier`. */
+function participant(identifier: string, overrides: Partial<CandidateStub> = {}): CandidateStub {
   return {
-    values: [
-      {
-        recordId,
-        fieldRef: 'contact:field-email',
-        fieldType: 'EMAIL',
-        value: addresses.map((value) => ({ type: 'text', value })),
-      },
-    ],
+    identifier,
+    identifierType: 'EMAIL',
+    displayName: 'Ada Lovelace',
+    contactId: 'c1',
+    source: 'participant',
+    score: 1,
+    ...overrides,
   }
 }
 
@@ -187,127 +139,186 @@ function committedIdentifiers(onAdd: ReturnType<typeof vi.fn>): string[] {
   return onAdd.mock.calls.map((call) => (call[0] as { identifier: string }).identifier)
 }
 
-async function openPickerAndPick(name: string) {
-  await userEvent.type(screen.getByLabelText('Add recipient'), 'ada')
-  await userEvent.click(await screen.findByRole('button', { name }))
+/** Type into the field, which is what opens the suggestion popover. */
+async function search(text = 'ada') {
+  await userEvent.type(screen.getByLabelText('Add recipient'), text)
+}
+
+/**
+ * Suggestion rows only. Committed chips are `role='option'` too, so a bare
+ * `getAllByRole('option')` counts the badges already in the field.
+ */
+async function suggestionRows() {
+  const list = await screen.findByRole('listbox', { name: /^Recipient / })
+  return within(list).getAllByRole('option')
 }
 
 beforeEach(() => {
-  h.batchGet.mockReset()
   h.toastError.mockReset()
-  h.pickerItems = [ADA]
+  h.candidates = []
+  h.queryInputs = []
   Element.prototype.scrollIntoView = vi.fn()
 })
 
-describe('RecipientInput — contact expansion into N addresses', () => {
-  it('a contact with 2 emails yields 2 address rows; picking one commits that address', async () => {
-    h.batchGet.mockResolvedValue(emailValues(['a@x.com', 'b@x.com']))
+describe('RecipientInput — suggestions from search.recipients', () => {
+  it('commits the picked row identifier and its contactId as recordId', async () => {
+    h.candidates = [participant('a@x.com')]
     const { onContactSelect } = renderInput([])
 
-    await openPickerAndPick('Ada Lovelace')
+    await search()
+    await userEvent.click(await screen.findByRole('option', { name: /Ada Lovelace/ }))
 
-    // One row per address — the pick must not silently choose one.
-    const rowA = await screen.findByRole('option', { name: /a@x\.com/ })
-    const rowB = screen.getByRole('option', { name: /b@x\.com/ })
-    expect(rowA).toBeVisible()
-    expect(rowB).toBeVisible()
-    expect(onContactSelect).not.toHaveBeenCalled()
-
-    await userEvent.click(rowB)
     expect(onContactSelect).toHaveBeenCalledWith({
       // The contact's `EntityInstance.id`, under `recordId` — the chip id is
       // minted by the parent, never the record id (see `RecipientState.id`).
       recordId: 'c1',
-      identifier: 'b@x.com',
+      identifier: 'a@x.com',
       identifierType: 'EMAIL',
       name: 'Ada Lovelace',
     })
   })
 
-  it('a single-address contact commits directly without an address list', async () => {
-    h.batchGet.mockResolvedValue(emailValues(['a@x.com']))
+  // The behaviour the old "Jane has 2 addresses" popover existed to provide,
+  // now free: one Participant row per identifier, so both are just rows.
+  it('a contact with two addresses is reachable at both', async () => {
+    h.candidates = [participant('a@x.com'), participant('b@x.com')]
     const { onContactSelect } = renderInput([])
 
-    await openPickerAndPick('Ada Lovelace')
+    await search()
+    expect(await suggestionRows()).toHaveLength(2)
 
-    await waitFor(() =>
-      expect(onContactSelect).toHaveBeenCalledWith({
-        recordId: 'c1',
-        identifier: 'a@x.com',
-        identifierType: 'EMAIL',
-        name: 'Ada Lovelace',
-      })
-    )
-    expect(screen.queryByRole('option', { name: /a@x\.com/ })).not.toBeInTheDocument()
-  })
-
-  it('excludes per ADDRESS: with the primary already a recipient, picking offers only the rest', async () => {
-    h.batchGet.mockResolvedValue(emailValues(['a@x.com', 'b@x.com']))
-    const { onContactSelect } = renderInput([
-      { id: 'r1', identifier: 'a@x.com', identifierType: 'EMAIL' },
-    ])
-
-    await openPickerAndPick('Ada Lovelace')
-
-    // Only the not-yet-added address remains — exactly one candidate, so it
-    // commits directly.
-    await waitFor(() =>
-      expect(onContactSelect).toHaveBeenCalledWith(
-        expect.objectContaining({ identifier: 'b@x.com' })
-      )
+    await userEvent.click(screen.getByRole('option', { name: /b@x\.com/ }))
+    expect(onContactSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ identifier: 'b@x.com', recordId: 'c1' })
     )
   })
 
-  it('hides the contact from the list once ALL its known addresses are recipients', async () => {
-    h.batchGet.mockResolvedValue(emailValues(['a@x.com', 'b@x.com']))
-    const { rerender, onContactSelect } = renderInput([
-      { id: 'r1', identifier: 'a@x.com', identifierType: 'EMAIL' },
-    ])
+  it('excludes an identifier already in the field, keeping the contact’s others', async () => {
+    h.candidates = [participant('a@x.com'), participant('b@x.com')]
+    renderInput([{ id: 'r1', identifier: 'a@x.com', identifierType: 'EMAIL' }])
 
-    // First pick fetches + caches the full address list and commits b@x.com.
-    await openPickerAndPick('Ada Lovelace')
-    await waitFor(() => expect(onContactSelect).toHaveBeenCalled())
+    await search()
 
-    // With both addresses now recipients, the contact row is excluded.
-    rerender(
-      <RecipientInput
-        recipients={
-          [
-            { id: 'r1', identifier: 'a@x.com', identifierType: 'EMAIL' },
-            { id: 'r2', identifier: 'b@x.com', identifierType: 'EMAIL' },
-          ] as never
-        }
-        field='TO'
-        onAdd={vi.fn()}
-        onRemove={vi.fn()}
-        onMoveTo={vi.fn()}
-        onContactSelect={onContactSelect}
-        placeholder='To'
-      />
-    )
-    await userEvent.type(screen.getByLabelText('Add recipient'), 'ada')
-    expect(screen.queryByRole('button', { name: 'Ada Lovelace' })).not.toBeInTheDocument()
+    const rows = await suggestionRows()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toHaveTextContent('b@x.com')
   })
 
-  it('falls back to the picker row primary when the field read fails', async () => {
-    h.batchGet.mockRejectedValue(new Error('offline'))
+  it('shows an empty state rather than a dead row when nothing matches', async () => {
+    h.candidates = []
     const { onContactSelect } = renderInput([])
 
-    await openPickerAndPick('Ada Lovelace')
+    await search('zzz')
 
-    await waitFor(() =>
-      expect(onContactSelect).toHaveBeenCalledWith(
-        expect.objectContaining({ identifier: 'a@x.com' })
-      )
+    expect(await screen.findByText('No matching email addresses')).toBeInTheDocument()
+    expect(onContactSelect).not.toHaveBeenCalled()
+  })
+
+  it('carries a null contactId through as recordId: null', async () => {
+    h.candidates = [participant('nobody@x.com', { contactId: null, displayName: 'nobody@x.com' })]
+    const { onContactSelect } = renderInput([])
+
+    await search()
+    await userEvent.click(await screen.findByRole('option', { name: /nobody@x\.com/ }))
+
+    expect(onContactSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ recordId: null, name: null })
     )
+  })
+
+  it('passes the channel model and region to the endpoint', async () => {
+    renderPhoneInput(vi.fn(), vi.fn(), { defaultRegion: 'DE' })
+
+    await search('030')
+
+    expect(h.queryInputs).toContainEqual(expect.objectContaining({ model: 'phone', region: 'DE' }))
+  })
+
+  it('arrow keys move the highlight and Enter commits it', async () => {
+    h.candidates = [participant('a@x.com'), participant('b@x.com')]
+    const { onContactSelect, onAdd } = renderInput([])
+
+    await search()
+    await userEvent.keyboard('{ArrowDown}{ArrowDown}{Enter}')
+
+    expect(onContactSelect).toHaveBeenCalledWith(expect.objectContaining({ identifier: 'b@x.com' }))
+    // The typed text is not ALSO committed as a free-typed recipient.
+    expect(onAdd).not.toHaveBeenCalled()
+  })
+
+  it('Enter with nothing highlighted still commits the typed identifier', async () => {
+    h.candidates = [participant('a@x.com')]
+    const { onAdd, onContactSelect } = renderInput([])
+
+    await userEvent.type(screen.getByLabelText('Add recipient'), 'brand-new@x.com{Enter}')
+
+    expect(committedIdentifiers(onAdd)).toEqual(['brand-new@x.com'])
+    expect(onContactSelect).not.toHaveBeenCalled()
   })
 })
 
-// Two addresses of ONE contact is a supported motion — the exclude filter keeps
-// a contact pickable until every address of theirs is a recipient. It used to
-// produce two chips carrying the SAME id, because `handleContactSelect` wrote
-// the contact's `EntityInstance.id` into `RecipientState.id`: duplicate React
-// keys, and `onRemove(id)` matching both chips in the parent's filter.
+// §5: the subtitle is what clicking commits, and it is formatted. The record
+// picker showed `secondaryDisplayValue` — an email — on every channel, and
+// promoted it to the TITLE when the display name was missing.
+describe('RecipientInput — suggestion row shape', () => {
+  it('renders the name over the formatted identifier', async () => {
+    h.candidates = [
+      participant('+14155551234', {
+        identifierType: 'PHONE',
+        displayName: 'Ada Lovelace',
+      }),
+    ]
+    renderPhoneInput()
+
+    await search('ada')
+
+    expect(await screen.findByText('Ada Lovelace')).toBeInTheDocument()
+    expect(screen.getByText('(415) 555-1234')).toBeInTheDocument()
+    expect(screen.queryByText('+14155551234')).not.toBeInTheDocument()
+  })
+
+  it('renders ONE line when displayName equals the identifier', async () => {
+    h.candidates = [
+      participant('+14155551234', {
+        identifierType: 'PHONE',
+        // `calculateDisplayName` falls back to the identifier — ~31% of live rows.
+        displayName: '+14155551234',
+      }),
+    ]
+    renderPhoneInput()
+
+    await search('415')
+
+    const [row] = await suggestionRows()
+    // The formatted form, exactly once — not the raw string twice.
+    expect(row?.textContent).toBe('(415) 555-1234')
+  })
+
+  it('marks a contact-arm row as never messaged', async () => {
+    h.candidates = [participant('a@x.com', { source: 'contact' })]
+    renderInput([])
+
+    await search()
+
+    expect(await screen.findByTitle('You have not messaged this contact before')).toBeVisible()
+  })
+
+  it('leaves a participant-arm row unmarked', async () => {
+    h.candidates = [participant('a@x.com')]
+    renderInput([])
+
+    await search()
+
+    await suggestionRows()
+    expect(screen.queryByTitle('You have not messaged this contact before')).not.toBeInTheDocument()
+  })
+})
+
+// Two addresses of ONE contact is a supported motion — the picker lists one row
+// per identifier. It used to produce two chips carrying the SAME id, because
+// `handleContactSelect` wrote the contact's `EntityInstance.id` into
+// `RecipientState.id`: duplicate React keys, and `onRemove(id)` matching both
+// chips in the parent's filter.
 describe('two chips sourced from the same contact', () => {
   const bothOfAdas = [
     { id: 'chip-1', identifier: 'a@x.com', identifierType: 'EMAIL' as const, recordId: 'c1' },
@@ -342,23 +353,8 @@ describe('two chips sourced from the same contact', () => {
 
 // Quo (formerly OpenPhone) is the first channel whose recipient is a phone
 // number, not an address. The same input has to accept E.164, reject anything
-// libphonenumber can't parse, commit `PHONE`, and read the contact's
-// multi-value `phone` field instead of `primary_email`.
+// libphonenumber can't parse, and commit `PHONE`.
 describe('RecipientInput — phone recipientModel', () => {
-  /** batchGet payload for a contact whose phone field holds the given numbers. */
-  function phoneValues(numbers: string[]) {
-    return {
-      values: [
-        {
-          recordId: 'contact:c1',
-          fieldRef: 'contact:field-email',
-          fieldType: 'PHONE_INTL',
-          value: numbers.map((value) => ({ type: 'text', value })),
-        },
-      ],
-    }
-  }
-
   it('commits a typed number as E.164 with identifierType PHONE', async () => {
     const { onAdd } = renderPhoneInput()
 
@@ -392,33 +388,19 @@ describe('RecipientInput — phone recipientModel', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 
-  it('expands a picked contact into its phone numbers, not its addresses', async () => {
-    h.pickerItems = [{ ...ADA, data: { phone: '+14155551234' } }]
-    h.batchGet.mockResolvedValue(phoneValues(['+14155551234', '+442071838750']))
+  // The dead-row bug this endpoint deletes: a phone-less contact used to render
+  // as a clickable row that silently did nothing, with its EMAIL as the
+  // subtitle. It cannot reach the list now — the query that would list it is the
+  // same query that failed to find a number for it — so there is nothing to
+  // filter on the client, and nothing that can show an address on an SMS picker.
+  it('never offers an email row on a phone channel', async () => {
+    h.candidates = []
     const { onContactSelect } = renderPhoneInput()
 
-    await openPickerAndPick('Ada Lovelace')
+    await search('ada')
 
-    const rowUs = await screen.findByRole('option', { name: /\+14155551234/ })
-    expect(rowUs).toBeVisible()
-    await userEvent.click(screen.getByRole('option', { name: /\+442071838750/ }))
-
-    expect(onContactSelect).toHaveBeenCalledWith({
-      recordId: 'c1',
-      identifier: '+442071838750',
-      identifierType: 'PHONE',
-      name: 'Ada Lovelace',
-    })
-  })
-
-  it('never falls back to the row secondaryInfo (an email) when the field read fails', async () => {
-    h.pickerItems = [{ ...ADA, data: {} }]
-    h.batchGet.mockRejectedValue(new Error('offline'))
-    const { onContactSelect } = renderPhoneInput()
-
-    await openPickerAndPick('Ada Lovelace')
-
-    await waitFor(() => expect(screen.getByTestId('record-picker')).toBeInTheDocument())
+    expect(await screen.findByText('No matching phone numbers')).toBeInTheDocument()
+    expect(screen.queryByText(/@/)).not.toBeInTheDocument()
     expect(onContactSelect).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/components/mail/email-editor/recipient-input.tsx
+++ b/apps/web/src/components/mail/email-editor/recipient-input.tsx
@@ -1,9 +1,6 @@
 // apps/web/src/components/mail/email-editor/recipient-input.tsx
 'use client'
-import type { FieldType, IdentifierType as IdentifierTypeType } from '@auxx/database/types'
-import { extractValues } from '@auxx/lib/field-values/client'
-import { getDefinitionId, type RecordPickerItem } from '@auxx/lib/resources/client'
-import type { TypedFieldValue } from '@auxx/types/field-value'
+import type { IdentifierType as IdentifierTypeType } from '@auxx/database/types'
 import { AutosizeInput, type AutosizeInputRef } from '@auxx/ui/components/autosize-input'
 import { Badge } from '@auxx/ui/components/badge'
 import {
@@ -15,25 +12,21 @@ import {
 import { Popover, PopoverAnchor, PopoverContent } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
 import { generateId } from '@auxx/utils'
-import { Copy, Mail, Phone, X } from 'lucide-react'
+import { Copy, Mail, X } from 'lucide-react'
 import type React from 'react'
 import { useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
-import { RecordPickerContent } from '~/components/pickers/record-picker/record-picker-content'
-import { useResourceStore } from '~/components/resources/store/resource-store'
-import { getNormalizedRecordId } from '~/components/resources/utils/normalize-record-id'
-import { resolveSystemAttributeRef } from '~/components/resources/utils/resolve-system-attribute'
+import { useDebounce } from '~/hooks/use-debounced-value'
 import { api } from '~/trpc/react'
-import { toEmailAddressList } from '../email-address-list'
 import { useEditorActiveStateContext } from './editor-active-state-context'
 import {
   DEFAULT_PHONE_REGION,
   getIdentifierModel,
-  type IdentifierModelSpec,
   identifierKey,
   type PhoneRegion,
   type RecipientModel,
 } from './identifier-model'
+import { type RecipientCandidate, RecipientSuggestions } from './recipient-suggestions'
 import type { RecipientState } from './types'
 
 export type RecipientField = 'TO' | 'CC' | 'BCC'
@@ -64,13 +57,16 @@ interface RecipientInputProps {
   onRemove: (id: string) => void
   onMoveTo: (id: string, target: RecipientField) => void
   /**
-   * A picked contact's identifier, committed. Carries `recordId` — the contact's
-   * `EntityInstance.id` — and **not** a chip id: the parent mints that. Passing
-   * the record id as the chip id is the collision documented on
+   * A picked suggestion's identifier, committed. Carries `recordId` — the
+   * contact's `EntityInstance.id` — and **not** a chip id: the parent mints
+   * that. Passing the record id as the chip id is the collision documented on
    * {@link RecipientState.id}.
+   *
+   * `recordId` is `null` for a `Participant` never linked to a contact — a real
+   * answer, not a gap, and the reason the field is nullable here.
    */
   onContactSelect: (contact: {
-    recordId: string
+    recordId: string | null
     identifier: string
     identifierType: IdentifierTypeType
     name?: string | null
@@ -82,15 +78,18 @@ interface RecipientInputProps {
   /**
    * Shape of identifier the selected channel addresses
    * (`PlatformCapabilities.recipientModel`). Drives validation, the committed
-   * `IdentifierType`, which contact field the picker reads, and the copy.
+   * `IdentifierType`, the copy, and — passed straight through to
+   * `search.recipients` — which identifiers the suggestions are drawn from.
    * Absent → email, which is every caller without resolved capabilities.
    */
   recipientModel?: RecipientModel
   /**
-   * Region national (no `+`) phone numbers are parsed and displayed against.
+   * Region national (no `+`) phone numbers are parsed and displayed against,
+   * and that `search.recipients` normalizes a typed number search against.
    * Derive it from the sending channel's own E.164 number with
    * `regionFromIdentifier` — an org with a German and a US number should parse
-   * national input differently depending on which one it is sending from.
+   * national input differently depending on which one it is sending from
+   * (`030 901820` is a substring of no E.164 number until it is trunk-stripped).
    * Ignored by the email model.
    */
   defaultRegion?: PhoneRegion
@@ -99,18 +98,8 @@ interface RecipientInputProps {
 const FIELD_LABELS: Record<RecipientField, string> = { TO: 'To', CC: 'Cc', BCC: 'Bcc' }
 const ALL_FIELDS: RecipientField[] = ['TO', 'CC', 'BCC']
 
-/** The picker row's own single known identifier (the primary) — the fallback
- *  when the field read fails or returns nothing. `toEmailAddressList` is a
- *  generic system-value normalizer (scalar or sortKey-ordered array); phone is
- *  multi-value too since #1629. */
-function itemFallbackAddresses(item: RecordPickerItem, spec: IdentifierModelSpec): string[] {
-  const fromRow = toEmailAddressList(item.data?.[spec.rowDataKey])[0]
-  // `secondaryInfo` is the contact's secondary DISPLAY field — an email. It is
-  // only a usable fallback when this channel addresses emails.
-  const single =
-    fromRow ?? (spec.secondaryInfoIsIdentifier ? item.secondaryInfo || undefined : undefined)
-  return single ? [single] : []
-}
+/** Keystroke settle before the search fires. */
+const SEARCH_DEBOUNCE_MS = 200
 
 function RecipientBadge({
   person,
@@ -240,27 +229,16 @@ export function RecipientInput({
     () => getIdentifierModel(recipientModel, defaultRegion),
     [recipientModel, defaultRegion]
   )
-  const IdentifierIcon = recipientModel === 'phone' ? Phone : Mail
   const [inputValue, setInputValue] = useState('')
   // Inline validity hint. Replaces the red toast that used to fire on every
   // Enter with a half-typed number — this is a field people type slowly.
   const [invalidHint, setInvalidHint] = useState(false)
   const [highlightedIndex, setHighlightedIndex] = useState<number | null>(null)
   const [showPicker, setShowPicker] = useState(false)
-  // A picked contact with more than one not-yet-added address: the popover
-  // swaps to one row per address so the user picks WHICH one to add.
-  const [pendingContact, setPendingContact] = useState<{
-    id: string
-    name: string | null
-    addresses: string[]
-  } | null>(null)
-  // Full address lists prefetched for visible search results (and fetched on
-  // pick as a fallback), keyed by contact instance id. Feeds the per-address
-  // exclude: a contact stays pickable until ALL its known addresses are
-  // recipients.
-  const [contactAddresses, setContactAddresses] = useState<Map<string, string[]>>(new Map())
+  // Highlighted suggestion. `null` = nothing highlighted, so Enter commits what
+  // was typed rather than a fuzzy match nobody asked for.
+  const [activeIndex, setActiveIndex] = useState<number | null>(null)
   const inputRef = useRef<AutosizeInputRef>(null)
-  const pickerRef = useRef<HTMLDivElement>(null)
 
   /** Silently commits a valid identifier. No hint on invalid. Returns true if committed. */
   const tryCommitInput = (): boolean => {
@@ -292,179 +270,90 @@ export function RecipientInput({
     commitPendingInput: () => tryCommitInput(),
   }))
 
-  const batchGetAsync = api.fieldValue.batchGet.useMutation().mutateAsync
-  // Instance ids a fetch was already issued for — dedupes the prefetch across
-  // result batches (state alone lags in-flight requests).
-  const requestedAddressIdsRef = useRef<Set<string>>(new Set())
-
-  /**
-   * Fetch the FULL identifier list for each contact (both `primary_email` and
-   * `phone` are multi-value — they read back as one row per value, primary
-   * first) in one batch read. Falls back per item to its own row data when the
-   * field ref can't resolve or the read fails.
-   */
-  const fetchContactAddresses = useCallback(
-    async (items: RecordPickerItem[]): Promise<Map<string, string[]>> => {
-      const result = new Map<string, string[]>()
-      const fallbackAll = () => {
-        for (const item of items) result.set(item.id, itemFallbackAddresses(item, spec))
-        return result
-      }
-      try {
-        const normalizedToItem = new Map(
-          items.map((item) => [getNormalizedRecordId(item.recordId), item] as const)
-        )
-        const maps = useResourceStore.getState()
-        const [firstRecordId] = normalizedToItem.keys()
-        // First systemAttribute candidate that resolves on this definition wins
-        // (mirrors `systemAttributeForChannel` in the kopilot recipient resolver).
-        const ref = firstRecordId
-          ? spec.systemAttributes.reduce<ReturnType<typeof resolveSystemAttributeRef>>(
-              (found, attr) =>
-                found ?? resolveSystemAttributeRef(maps, attr, getDefinitionId(firstRecordId)),
-              undefined
-            )
-          : undefined
-        if (!ref) return fallbackAll()
-        const batch = await batchGetAsync({
-          recordIds: [...normalizedToItem.keys()],
-          fieldReferences: [ref],
-        })
-        for (const row of batch.values) {
-          const item = normalizedToItem.get(row.recordId)
-          if (!item) continue
-          const addresses = extractValues(
-            row.value as TypedFieldValue | TypedFieldValue[] | null,
-            row.fieldType as FieldType
-          ).filter((v): v is string => typeof v === 'string' && v.length > 0)
-          result.set(item.id, addresses.length > 0 ? addresses : itemFallbackAddresses(item, spec))
-        }
-        for (const item of items) {
-          if (!result.has(item.id)) result.set(item.id, itemFallbackAddresses(item, spec))
-        }
-        return result
-      } catch {
-        return fallbackAll()
-      }
-    },
-    [batchGetAsync, spec]
-  )
-
-  /**
-   * Prefetch address lists for the visible search results so the exclude
-   * filter can key on ADDRESSES (a contact hides only when every address is a
-   * recipient) and a pick can expand without waiting.
-   */
-  const handlePickerResults = useCallback(
-    (items: RecordPickerItem[]) => {
-      const missing = items.filter((item) => !requestedAddressIdsRef.current.has(item.id))
-      if (missing.length === 0) return
-      for (const item of missing) requestedAddressIdsRef.current.add(item.id)
-      void fetchContactAddresses(missing).then((fetched) => {
-        setContactAddresses((prev) => {
-          const next = new Map(prev)
-          for (const [id, addresses] of fetched) next.set(id, addresses)
-          return next
-        })
-      })
-    },
-    [fetchContactAddresses]
-  )
-
-  // Normalized identifiers of recipients already in this field — used to hide
-  // their matching contacts from the picker. Covers picker/draft/reply/
-  // free-typed alike.
+  // Normalized identifiers already in this field. `Participant` is unique on
+  // `(organizationId, identifier, identifierType)` — one row IS one identifier —
+  // so excluding a suggestion is set membership on a string, not a per-record
+  // "hide only when EVERY address is a recipient" walk. Covers picker/draft/
+  // reply/free-typed alike.
   const excludeIdentifiers = useMemo(
     () => new Set(recipients.map((r) => identifierKey(spec, r.identifier))),
     [recipients, spec]
   )
 
-  /** Commit one identifier as a recipient and reset the picker state. */
-  const commitContactAddress = useCallback(
-    (contactId: string, address: string, name: string | null) => {
+  const query = inputValue.trim()
+  const debouncedQuery = useDebounce(query, SEARCH_DEBOUNCE_MS)
+  // One ranked read: participants ∪ contacts, already filtered to what this
+  // channel can address and already carrying the exact string to commit. An
+  // empty query is meaningful — it lists most-recently-mailed, the right answer
+  // for a focused-but-empty field.
+  const { data, isFetching } = api.search.recipients.useQuery(
+    { query: debouncedQuery, model: recipientModel ?? 'email', region: defaultRegion },
+    {
+      enabled: showPicker,
+      // Keep the previous page rendered while the next one loads so the list
+      // does not blink empty between keystrokes.
+      placeholderData: (previous) => previous,
+      staleTime: 30_000,
+    }
+  )
+
+  const candidates = useMemo(
+    () =>
+      (data?.candidates ?? []).filter(
+        (candidate) => !excludeIdentifiers.has(identifierKey(spec, candidate.identifier))
+      ),
+    [data, excludeIdentifiers, spec]
+  )
+  const activeCandidate = activeIndex === null ? undefined : candidates[activeIndex]
+
+  /** Commit one suggestion as a recipient and close the picker. */
+  const commitCandidate = useCallback(
+    (candidate: RecipientCandidate) => {
       onContactSelect({
-        recordId: contactId,
-        identifier: spec.normalize(address) ?? address,
-        identifierType: spec.identifierType,
-        name,
+        recordId: candidate.contactId,
+        identifier: candidate.identifier,
+        identifierType: candidate.identifierType,
+        // `displayName` falls back to the identifier when no name is known;
+        // storing that as the chip's `name` would defeat the badge's own
+        // formatting (`+14155551234` instead of `(415) 555-1234`).
+        name: candidate.displayName === candidate.identifier ? null : candidate.displayName,
       })
       setInputValue('')
       setShowPicker(false)
-      setPendingContact(null)
+      setActiveIndex(null)
+      setInvalidHint(false)
       inputRef.current?.focus()
     },
-    [onContactSelect, spec]
+    [onContactSelect]
   )
 
-  /**
-   * Handle contact selection from RecordPickerContent. A picked contact is
-   * expanded into its N identifiers: exactly one not yet a recipient commits
-   * directly; several swap the popover to a per-value row list.
-   */
-  const handleContactPick = useCallback(
-    async (item: RecordPickerItem) => {
-      const name = item.displayName || null
-      let addresses = contactAddresses.get(item.id)
-      if (!addresses) {
-        // Prefetch hasn't landed for this row yet — fetch it alone.
-        requestedAddressIdsRef.current.add(item.id)
-        const fetched = await fetchContactAddresses([item])
-        addresses = fetched.get(item.id) ?? []
-        const known = addresses
-        setContactAddresses((prev) => new Map(prev).set(item.id, known))
-      }
-      const candidates = addresses.filter((a) => !excludeIdentifiers.has(identifierKey(spec, a)))
-      if (candidates.length === 0) return
-      if (candidates.length === 1) {
-        commitContactAddress(item.id, candidates[0]!, name)
-        return
-      }
-      setPendingContact({ id: item.id, name, addresses: candidates })
-    },
-    [contactAddresses, fetchContactAddresses, excludeIdentifiers, commitContactAddress, spec]
-  )
-
-  const excludeFilter = useCallback(
-    (item: RecordPickerItem) => {
-      // Per-value exclude: once the contact's full list is known (results
-      // prefetch), the contact hides only when EVERY identifier is a recipient.
-      const known = contactAddresses.get(item.id)
-      if (known && known.length > 0) {
-        return known.every((a) => excludeIdentifiers.has(identifierKey(spec, a)))
-      }
-      // Unfetched: the only known value is the row's own primary.
-      const [primary] = itemFallbackAddresses(item, spec)
-      return !!primary && excludeIdentifiers.has(identifierKey(spec, primary))
-    },
-    [contactAddresses, excludeIdentifiers, spec]
-  )
-
-  /** Forward a keyboard event to the cmdk Command inside the picker popover */
-  const forwardToPicker = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    const cmdkRoot = pickerRef.current?.querySelector('[cmdk-root]')
-    if (!cmdkRoot) return false
-    // Dispatch a synthetic keyboard event on the cmdk root
-    cmdkRoot.dispatchEvent(new KeyboardEvent('keydown', { key: e.key, bubbles: true }))
-    e.preventDefault()
-    return true
+  /** Move the highlight, wrapping. `null` enters the list at either end. */
+  const moveActive = (delta: 1 | -1) => {
+    if (candidates.length === 0) return
+    setActiveIndex((current) => {
+      if (current === null) return delta === 1 ? 0 : candidates.length - 1
+      return (current + delta + candidates.length) % candidates.length
+    })
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     switch (e.key) {
       case 'ArrowDown':
       case 'ArrowUp':
-        // Forward arrow keys to the picker when open
+        // The list is ours, so the highlight moves directly — no synthetic
+        // `KeyboardEvent` dispatched at a cmdk root that owns its own state.
         if (showPicker) {
-          forwardToPicker(e)
+          e.preventDefault()
+          moveActive(e.key === 'ArrowDown' ? 1 : -1)
         }
         break
       case 'Enter':
-        // When picker is open, forward Enter to select the highlighted item
-        if (showPicker && pickerRef.current?.querySelector('[cmdk-item][data-selected="true"]')) {
-          forwardToPicker(e)
+        // A highlighted suggestion wins; otherwise commit what was typed.
+        if (showPicker && activeCandidate) {
+          e.preventDefault()
+          commitCandidate(activeCandidate)
           break
         }
-        // Otherwise commit the free-typed identifier
         if (inputValue.trim()) {
           e.preventDefault()
           addRecipientFromInput()
@@ -498,7 +387,7 @@ export function RecipientInput({
       case 'Escape':
         setHighlightedIndex(null)
         setShowPicker(false)
-        setPendingContact(null)
+        setActiveIndex(null)
         setInvalidHint(false)
         break
       default:
@@ -552,7 +441,7 @@ export function RecipientInput({
     setInputValue(leftover.join(', '))
     setInvalidHint(false)
     setHighlightedIndex(null)
-    setPendingContact(null)
+    setActiveIndex(null)
     setShowPicker(false)
   }
 
@@ -561,10 +450,10 @@ export function RecipientInput({
     setInputValue(val)
     setInvalidHint(false)
     setHighlightedIndex(null)
-    // Typing resumes the contact search — drop any pending address choice
-    setPendingContact(null)
-    // Show picker when there's text to search
-    setShowPicker(val.trim().length > 0)
+    // A new query is a new result set — nothing is highlighted until the user
+    // arrows into it, so Enter keeps committing what they typed.
+    setActiveIndex(null)
+    setShowPicker(true)
   }
   // Handle keyboard events on badges for deletion
   const handleBadgeKeyDown = (
@@ -623,10 +512,12 @@ export function RecipientInput({
       ))}
 
       <Popover
-        open={showPicker || pendingContact !== null}
+        // Nothing to show and nothing typed = no empty box on focus. Typing
+        // always opens it, so "no matches" is still an answer the user sees.
+        open={showPicker && (candidates.length > 0 || query.length > 0)}
         onOpenChange={(open) => {
           setShowPicker(open)
-          if (!open) setPendingContact(null)
+          if (!open) setActiveIndex(null)
         }}>
         <PopoverAnchor asChild>
           <div className='relative grow cursor-text' onMouseDown={routeFocusToInput}>
@@ -637,9 +528,9 @@ export function RecipientInput({
               onChange={handleInputChange}
               onKeyDown={handleKeyDown}
               onPaste={handlePaste}
-              onFocus={() => {
-                if (inputValue.trim().length > 0) setShowPicker(true)
-              }}
+              // An empty focused field is a real query: it lists the people you
+              // most recently mailed.
+              onFocus={() => setShowPicker(true)}
               onBlur={() => {
                 // Silently commit a valid identifier on blur (no toast for invalid)
                 tryCommitInput()
@@ -666,48 +557,21 @@ export function RecipientInput({
           </div>
         </PopoverAnchor>
         <PopoverContent
-          ref={pickerRef}
-          className={cn('w-72 p-0', popoverClassName)}
+          className={cn('w-80 p-0', popoverClassName)}
           align='start'
           side='bottom'
           sideOffset={5}
           onOpenAutoFocus={(e) => e.preventDefault()}
           onCloseAutoFocus={(e) => e.preventDefault()}>
-          {pendingContact ? (
-            <div className='py-1' role='listbox' aria-label={`Choose a ${spec.noun}`}>
-              <div className='px-3 py-1.5 text-xs text-muted-foreground'>
-                {pendingContact.name
-                  ? `${pendingContact.name} has ${pendingContact.addresses.length} ${spec.nounPlural}`
-                  : `Choose a ${spec.noun}`}
-              </div>
-              {pendingContact.addresses.map((address) => (
-                <button
-                  key={address}
-                  type='button'
-                  role='option'
-                  aria-selected={false}
-                  className='flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-accent focus:bg-accent focus:outline-hidden'
-                  onClick={() =>
-                    commitContactAddress(pendingContact.id, address, pendingContact.name)
-                  }>
-                  <IdentifierIcon className='size-3.5 text-muted-foreground' />
-                  <span className='truncate'>{address}</span>
-                </button>
-              ))}
-            </div>
-          ) : (
-            <RecordPickerContent
-              value={[]}
-              onChange={() => {}}
-              entityDefinitionId='contact'
-              multi={false}
-              onSelectItem={handleContactPick}
-              onResultsChange={handlePickerResults}
-              externalSearch={inputValue}
-              excludeFilter={excludeFilter}
-              placeholder='Search contacts...'
-            />
-          )}
+          <RecipientSuggestions
+            candidates={candidates}
+            spec={spec}
+            activeIndex={activeIndex}
+            truncated={data?.truncated ?? false}
+            isLoading={isFetching}
+            onSelect={commitCandidate}
+            onHover={setActiveIndex}
+          />
         </PopoverContent>
       </Popover>
 

--- a/apps/web/src/components/mail/email-editor/recipient-suggestions.tsx
+++ b/apps/web/src/components/mail/email-editor/recipient-suggestions.tsx
@@ -1,0 +1,142 @@
+// apps/web/src/components/mail/email-editor/recipient-suggestions.tsx
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import { Mail, Phone } from 'lucide-react'
+import type { RouterOutputs } from '~/trpc/react'
+import type { IdentifierModelSpec } from './identifier-model'
+
+/**
+ * One addressable row from `search.recipients` — a `Participant` (someone
+ * corresponded with) or a contact never messaged. `identifier` is always the
+ * exact string to commit; the client never reconstructs it.
+ */
+export type RecipientCandidate = RouterOutputs['search']['recipients']['candidates'][number]
+
+/**
+ * A recipient row is NOT a record row.
+ *
+ * `record-item.tsx` renders `secondaryInfo` — the contact's secondary DISPLAY
+ * value, which is an email on every channel — and `record-picker-service.ts`
+ * promotes it to the *title* when `displayName` is missing. Both are wrong for a
+ * picker whose job is to tell you what clicking will send to. Here the subtitle
+ * is exactly the identifier about to be committed, formatted for humans
+ * (`(415) 555-1234`, never `+14155551234`).
+ *
+ * 🔴 When `displayName === identifier` the row collapses to ONE line. That is
+ * ~31% of rows on live data (`Participant.displayName` falls back to the
+ * identifier at every write site), not an edge case — without the collapse one in
+ * three rows renders the same string twice.
+ */
+function RecipientRow({
+  candidate,
+  spec,
+  active,
+  onSelect,
+  onHover,
+}: {
+  candidate: RecipientCandidate
+  spec: IdentifierModelSpec
+  active: boolean
+  onSelect: () => void
+  onHover: () => void
+}) {
+  const formatted = spec.formatDisplay(candidate.identifier)
+  const collapsed = candidate.displayName === candidate.identifier
+  const Icon = candidate.identifierType === 'PHONE' ? Phone : Mail
+
+  return (
+    <button
+      type='button'
+      role='option'
+      aria-selected={active}
+      // Keep focus in the input: a blur would fire `tryCommitInput` and commit
+      // the half-typed query *alongside* the row being clicked.
+      onMouseDown={(e) => e.preventDefault()}
+      onMouseEnter={onHover}
+      onClick={onSelect}
+      className={cn(
+        'flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-accent focus:outline-hidden',
+        active && 'bg-accent'
+      )}>
+      <Icon className='size-3.5 shrink-0 text-muted-foreground' />
+      <span className='flex min-w-0 flex-1 flex-col'>
+        <span className='truncate'>{collapsed ? formatted : candidate.displayName}</span>
+        {!collapsed && <span className='truncate text-xs text-muted-foreground'>{formatted}</span>}
+      </span>
+      {candidate.source === 'contact' && (
+        <span
+          className='shrink-0 text-muted-foreground text-xs'
+          title='You have not messaged this contact before'>
+          New
+        </span>
+      )}
+    </button>
+  )
+}
+
+/**
+ * The recipient suggestion list: participants ∪ contacts, already ranked and
+ * already filtered to what this channel can address.
+ *
+ * Presentational — highlight state and keyboard handling live in
+ * `RecipientInput`, because the arrow keys are typed into the input, not into
+ * this list. That is deliberately unlike the record picker, which owned a cmdk
+ * `Command` and had to be fed synthetic `KeyboardEvent`s.
+ */
+export function RecipientSuggestions({
+  candidates,
+  spec,
+  activeIndex,
+  isLoading,
+  truncated,
+  onSelect,
+  onHover,
+}: {
+  candidates: RecipientCandidate[]
+  spec: IdentifierModelSpec
+  /** `null` when nothing is highlighted — Enter then commits the typed value. */
+  activeIndex: number | null
+  isLoading: boolean
+  /**
+   * The server's candidate ceiling bound the answer AND returned fewer rows than
+   * asked for — so this SHORT list may be missing matches the viewer can see.
+   *
+   * Worth surfacing precisely because it is short: a truncated-but-full list looks
+   * like any other page, but a truncated list of three reads as "there are three",
+   * which is the one case where silence is a lie.
+   */
+  truncated: boolean
+  onSelect: (candidate: RecipientCandidate) => void
+  onHover: (index: number) => void
+}) {
+  if (candidates.length === 0) {
+    return (
+      <div className='px-3 py-2 text-muted-foreground text-sm'>
+        {isLoading ? 'Searching…' : `No matching ${spec.nounPlural}`}
+      </div>
+    )
+  }
+
+  return (
+    <div className='max-h-72 overflow-y-auto py-1'>
+      <div role='listbox' aria-label={`Recipient ${spec.nounPlural}`}>
+        {candidates.map((candidate, index) => (
+          <RecipientRow
+            key={`${candidate.identifierType}:${candidate.identifier}`}
+            candidate={candidate}
+            spec={spec}
+            active={activeIndex === index}
+            onSelect={() => onSelect(candidate)}
+            onHover={() => onHover(index)}
+          />
+        ))}
+      </div>
+      {truncated && (
+        <p className='border-border border-t px-3 py-1.5 text-muted-foreground text-xs'>
+          Showing the closest matches — keep typing to narrow.
+        </p>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Step 5 of the recipient-search plan, and **the first user-visible change of the sequence** — everything before this was groundwork. Consumes #1670's endpoint.

## What changes for a user

**A phone composer stops showing email addresses.** Today a contact with no phone number renders as a clickable row that silently does nothing when clicked — and shows that contact's *email* as its subtitle, in a picker that cannot send email. Both are gone: the server's inner LATERAL means a phone-less contact cannot reach the client at all, and the row now shows the identifier it is about to commit, formatted (`(415) 555-1234`, never the raw E.164).

**Focusing an empty To field lists most-recently-mailed** instead of nothing.

## What gets deleted, and why it was all one bug

Six pieces of machinery existed only because a record does not carry its identifiers:

| deleted | existed because |
|---|---|
| `fetchContactAddresses` + `batchGet` | a record doesn't carry its identifiers |
| the "Jane has 2 addresses" popover | one pick mapped to many possible commits |
| the per-address exclude walk | exclusion is per-identifier, results were per-record |
| `contactAddresses` + `requestedAddressIdsRef` | `batchGet` is a **mutation**, so nothing cached — the client hand-rolled one |
| `systemAttributes` / `rowDataKey` / `secondaryInfoIsIdentifier` on the spec | the client had to name the addressable field itself |
| `RecordPickerContent` + synthetic `KeyboardEvent` forwarding | the picker owned a cmdk `Command` |

One `Participant` row **is** one identifier, so all six collapse. `excludeFilter` is now set membership on a string.

## The row is not a record row

Deliberately not reusing `record-item.tsx`: it renders `secondaryInfo` (an email on every channel) and `record-picker-service.ts` promotes it to the **title** when `displayName` is missing. Both are wrong for a picker whose job is to say what clicking will send to.

🔴 It collapses to **one line when `displayName === identifier`** — that's ~31% of rows on live data (`Participant.displayName` falls back to the identifier at every write site), so without it one in three rows renders the same string twice.

Contact-arm rows carry a quiet "New" marker: sending to one is a first contact.

## Two things I added on review

The subagent's implementation was clean and its report accurate — I verified the tests, typecheck baseline and lint independently rather than taking them on trust. Two additions:

1. **`truncated` is now surfaced.** The endpoint returns it and the UI was ignoring it. It means the candidate ceiling bound the answer *and* returned a short list — a truncated-but-full page looks like any other, but a truncated list of three reads as "there are three", which is the one case where silence misleads.
2. Kept the `role='listbox'` on an inner element so the truncation hint isn't announced as an option.

## Behaviour worth reviewing

- **`activeIndex` starts `null` on every new query**, so Enter commits what you typed unless you arrowed into the list. Deliberately unlike the old cmdk auto-select-first — with a live search under a debounce, auto-highlighting means Enter can commit a row that arrived between keystrokes.
- Rows `preventDefault` on mousedown so the input never blurs, which also closes a latent double-commit (blur's `tryCommitInput` firing alongside the click).
- 200ms debounce, `placeholderData` so the list doesn't blink between keystrokes, `enabled` only while the picker is open.

## Size

`recipient-input.tsx` 721 → 584. The plan estimated −250; it's −137, because the §5 row is a new 128-line component that couldn't be free. The two files together are 712 vs 721 — the win is in what the code *does*, not the line count.

## Tests

45 (was 39), 77 across the editor. The deleted machinery's tests were **replaced, not dropped** — the user-visible behaviours behind them still exist and are still covered: a contact with two addresses is reachable at both, an address already in the field is excluded while the contact's others remain, and two new cases pin the dead-row bug (no email row on a phone channel; an empty state rather than a dead row). All phone, region, badge-formatting and paste tests kept verbatim.

Typecheck baseline unchanged (10 pre-existing, none in `email-editor`); biome clean.

## Worth clicking through before merge

This is the first change here a user would notice, so green tests aren't the whole story — particularly the phone composer, and the reply/draft paths where recipients arrive pre-filled rather than picked.
