### PR TITLE
feat(composer): offer a contact's other addresses from the recipient chip

### DIFF
--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -74,6 +74,7 @@ import PrevMessage from './prev-message'
 import { AddActionButton, QuickActionPanel } from './quick-action-panel'
 import { type RecipientField, RecipientInput, type RecipientInputHandle } from './recipient-input'
 import { formatDroppedList, reconcileDraftForChannel } from './reconcile-channel-switch'
+import { switchRecipientIdentifier } from './switch-recipient-identifier'
 import type {
   ParticipantInputData,
   RecipientState,
@@ -838,6 +839,23 @@ function ReplyComposeEditorComponent({
     },
     []
   )
+  /**
+   * Switch ONE chip to another of the same contact's addresses, in place — the
+   * chip keeps its `id`, its field and its position. The rule itself lives in
+   * {@link switchRecipientIdentifier}, which returns the same object on a no-op
+   * so a refused switch re-renders nothing.
+   */
+  const handleSwitchIdentifier = useCallback(
+    (
+      role: keyof Recipients,
+      id: string,
+      next: { identifier: string; identifierType: IdentifierType }
+    ) => {
+      setRecipients((prev) => switchRecipientIdentifier(prev, role, id, next))
+      setIsDraftSaved(false)
+    },
+    []
+  )
   // Calculate if editor has content
   // biome-ignore lint/correctness/useExhaustiveDependencies: content triggers recalculation when editor content changes
   const hasContent = useMemo(() => {
@@ -1406,6 +1424,7 @@ function ReplyComposeEditorComponent({
                     onAdd={(r) => upsertRecipient('TO', r)}
                     onRemove={(id) => removeRecipient('TO', id)}
                     onMoveTo={(id, target) => handleMoveTo('TO', id, target)}
+                    onSwitchIdentifier={(id, next) => handleSwitchIdentifier('TO', id, next)}
                     onContactSelect={(c) => handleContactSelect('TO', c)}
                     placeholder='Add recipients...'
                     disabled={isSending}
@@ -1462,6 +1481,7 @@ function ReplyComposeEditorComponent({
                       onAdd={(r) => upsertRecipient('CC', r)}
                       onRemove={(id) => removeRecipient('CC', id)}
                       onMoveTo={(id, target) => handleMoveTo('CC', id, target)}
+                      onSwitchIdentifier={(id, next) => handleSwitchIdentifier('CC', id, next)}
                       onContactSelect={(c) => handleContactSelect('CC', c)}
                       placeholder='Add Cc recipients...'
                       disabled={isSending}
@@ -1498,6 +1518,7 @@ function ReplyComposeEditorComponent({
                       onAdd={(r) => upsertRecipient('BCC', r)}
                       onRemove={(id) => removeRecipient('BCC', id)}
                       onMoveTo={(id, target) => handleMoveTo('BCC', id, target)}
+                      onSwitchIdentifier={(id, next) => handleSwitchIdentifier('BCC', id, next)}
                       onContactSelect={(c) => handleContactSelect('BCC', c)}
                       placeholder='Add Bcc recipients...'
                       disabled={isSending}

--- a/apps/web/src/components/mail/email-editor/recipient-input.test.tsx
+++ b/apps/web/src/components/mail/email-editor/recipient-input.test.tsx
@@ -24,11 +24,22 @@ interface CandidateStub {
   score: number
 }
 
+interface IdentifierStub {
+  identifier: string
+  identifierType: 'EMAIL' | 'PHONE'
+  onRecord: boolean
+  rank: number | null
+}
+
 const h = vi.hoisted(() => ({
   toastError: vi.fn(),
   candidates: [] as unknown[],
   /** Every `{ query, model, region }` the component asked the endpoint for. */
   queryInputs: [] as unknown[],
+  /** `participant.listContactIdentifiers` rows the chip menu will see. */
+  contactIdentifiers: [] as unknown[],
+  /** Every `{ recordId, model }` a chip menu asked for — empty means no request. */
+  identifierQueryInputs: [] as unknown[],
 }))
 
 vi.mock('~/trpc/react', () => ({
@@ -41,6 +52,18 @@ vi.mock('~/trpc/react', () => ({
             data: { candidates: h.candidates, truncated: false },
             isFetching: false,
           }
+        },
+      },
+    },
+    participant: {
+      listContactIdentifiers: {
+        // `data: undefined` while disabled, exactly like React Query — a chip
+        // that never opens (or has no recordId) must render no section at all,
+        // and a stub that always returned rows would hide that.
+        useQuery: (input: unknown, options?: { enabled?: boolean }) => {
+          if (options?.enabled === false) return { data: undefined }
+          h.identifierQueryInputs.push(input)
+          return { data: h.contactIdentifiers }
         },
       },
     },
@@ -80,11 +103,13 @@ function renderInput(
     id: string
     identifier: string
     identifierType: 'EMAIL'
+    name?: string | null
     recordId?: string
   }>,
   onContactSelect = vi.fn(),
   onAdd = vi.fn(),
-  onRemove = vi.fn()
+  onRemove = vi.fn(),
+  onSwitchIdentifier = vi.fn()
 ) {
   const utils = render(
     <RecipientInput
@@ -93,25 +118,32 @@ function renderInput(
       onAdd={onAdd}
       onRemove={onRemove}
       onMoveTo={vi.fn()}
+      onSwitchIdentifier={onSwitchIdentifier}
       onContactSelect={onContactSelect}
       placeholder='To'
     />
   )
-  return { ...utils, onContactSelect, onAdd, onRemove }
+  return { ...utils, onContactSelect, onAdd, onRemove, onSwitchIdentifier }
 }
 
 interface PhoneRecipientStub {
   id: string
   identifier: string
   identifierType: 'PHONE'
+  recordId?: string
 }
 
 /** Same render, on a `recipientModel: 'phone'` channel (Quo/SMS). */
 function renderPhoneInput(
   onAdd = vi.fn(),
   onContactSelect = vi.fn(),
-  extra: { defaultRegion?: PhoneRegion; recipients?: PhoneRecipientStub[] } = {}
+  extra: {
+    defaultRegion?: PhoneRegion
+    recipients?: PhoneRecipientStub[]
+    onSwitchIdentifier?: ReturnType<typeof vi.fn>
+  } = {}
 ) {
+  const onSwitchIdentifier = extra.onSwitchIdentifier ?? vi.fn()
   const utils = render(
     <RecipientInput
       recipients={(extra.recipients ?? []) as never}
@@ -119,13 +151,14 @@ function renderPhoneInput(
       onAdd={onAdd}
       onRemove={vi.fn()}
       onMoveTo={vi.fn()}
+      onSwitchIdentifier={onSwitchIdentifier}
       onContactSelect={onContactSelect}
       placeholder='To'
       recipientModel='phone'
       defaultRegion={extra.defaultRegion}
     />
   )
-  return { ...utils, onAdd, onContactSelect }
+  return { ...utils, onAdd, onContactSelect, onSwitchIdentifier }
 }
 
 /** Focus the input and fire a real paste event carrying `text`. */
@@ -157,6 +190,8 @@ beforeEach(() => {
   h.toastError.mockReset()
   h.candidates = []
   h.queryInputs = []
+  h.contactIdentifiers = []
+  h.identifierQueryInputs = []
   Element.prototype.scrollIntoView = vi.fn()
 })
 
@@ -351,6 +386,219 @@ describe('two chips sourced from the same contact', () => {
   // the type is the stronger guarantee, so it is deliberately not restated here.
 })
 
+// The chip menu's "Other addresses" section — the capability
+// `search.recipients` gives up by returning one row per person
+// (`recipient-search.md` §4.2). Fetched on OPEN, never on render.
+describe('RecipientBadge — other addresses', () => {
+  const janeChip = {
+    id: 'chip-1',
+    identifier: 'jane@corp.com',
+    identifierType: 'EMAIL' as const,
+    name: 'Jane Smith',
+    recordId: 'c1',
+  }
+
+  const onRecord = (identifier: string, rank: number): IdentifierStub => ({
+    identifier,
+    identifierType: 'EMAIL',
+    onRecord: true,
+    rank,
+  })
+  const correspondedWith = (identifier: string): IdentifierStub => ({
+    identifier,
+    identifierType: 'EMAIL',
+    onRecord: false,
+    rank: null,
+  })
+
+  /** Click the chip, which is the dropdown trigger, and wait for the menu. */
+  async function openChipMenu(label: string) {
+    await userEvent.click(screen.getByRole('option', { name: `Recipient: ${label}` }))
+    return screen.findByRole('menu')
+  }
+
+  function switchRows() {
+    return screen.getAllByRole('menuitemradio')
+  }
+
+  it('issues NO request while the chips are merely rendered', () => {
+    h.contactIdentifiers = [onRecord('jane@corp.com', 0), onRecord('j.smith@corp.com', 1)]
+    renderInput([janeChip, { ...janeChip, id: 'chip-2', identifier: 'b@x.com' }])
+
+    // Two chips, zero fetches. This is the entire argument for fetch-on-open
+    // over an identifierCount on the search.
+    expect(h.identifierQueryInputs).toEqual([])
+  })
+
+  it('fetches on open, keyed on the record AND the model', async () => {
+    h.contactIdentifiers = [onRecord('jane@corp.com', 0), onRecord('j.smith@corp.com', 1)]
+    renderInput([janeChip])
+
+    await openChipMenu('Jane Smith')
+
+    // The model is half the key: a list fetched under email must never be read
+    // under phone (`key={recipientModel}`, #1654).
+    expect(h.identifierQueryInputs).toContainEqual({ recordId: 'c1', model: 'email' })
+  })
+
+  it('passes the phone model through', async () => {
+    h.contactIdentifiers = []
+    renderPhoneInput(vi.fn(), vi.fn(), {
+      recipients: [
+        { id: 'chip-1', identifier: '+14155551234', identifierType: 'PHONE', recordId: 'c1' },
+      ],
+    })
+
+    await openChipMenu('(415) 555-1234')
+
+    expect(h.identifierQueryInputs).toContainEqual({ recordId: 'c1', model: 'phone' })
+  })
+
+  it('lists the addresses with the committed one checked and disabled', async () => {
+    h.contactIdentifiers = [onRecord('jane@corp.com', 0), onRecord('j.smith@corp.com', 1)]
+    renderInput([janeChip])
+
+    await openChipMenu('Jane Smith')
+
+    expect(screen.getByText('Other addresses')).toBeInTheDocument()
+    const rows = switchRows()
+    expect(rows.map((row) => row.textContent)).toEqual(['jane@corp.com', 'j.smith@corp.com'])
+    expect(rows[0]).toHaveAttribute('aria-checked', 'true')
+    // The committed address IS committed in this field, so the same
+    // already-a-recipient rule disables it.
+    expect(rows[0]).toHaveAttribute('aria-disabled', 'true')
+    expect(rows[1]).toHaveAttribute('aria-checked', 'false')
+    expect(rows[1]).not.toHaveAttribute('aria-disabled')
+  })
+
+  it('switches THIS chip in place — onSwitchIdentifier gets the chip id', async () => {
+    h.contactIdentifiers = [onRecord('jane@corp.com', 0), onRecord('j.smith@corp.com', 1)]
+    const { onSwitchIdentifier, onRemove, onAdd } = renderInput([janeChip])
+
+    await openChipMenu('Jane Smith')
+    await userEvent.click(screen.getByRole('menuitemradio', { name: 'j.smith@corp.com' }))
+
+    expect(onSwitchIdentifier).toHaveBeenCalledWith('chip-1', {
+      identifier: 'j.smith@corp.com',
+      identifierType: 'EMAIL',
+    })
+    // 🔴 Not remove-then-add: that moves the chip to the end of the field and
+    // loses focus, and the add no-ops when the target is already present.
+    expect(onRemove).not.toHaveBeenCalled()
+    expect(onAdd).not.toHaveBeenCalled()
+  })
+
+  it('disables an address already committed in this field, comparing NORMALIZED', async () => {
+    // The record holds a legacy, un-normalized copy of a number that is already
+    // a chip in E.164. `identifierKey` is what makes them one address.
+    h.contactIdentifiers = [
+      { identifier: '+1 415 555 1234', identifierType: 'PHONE', onRecord: true, rank: 0 },
+      { identifier: '+18052227374', identifierType: 'PHONE', onRecord: true, rank: 1 },
+    ]
+    const onSwitchIdentifier = vi.fn()
+    renderPhoneInput(vi.fn(), vi.fn(), {
+      onSwitchIdentifier,
+      recipients: [
+        { id: 'chip-1', identifier: '+18052227374', identifierType: 'PHONE', recordId: 'c1' },
+        { id: 'chip-2', identifier: '+14155551234', identifierType: 'PHONE', recordId: 'c1' },
+      ],
+    })
+
+    await openChipMenu('(805) 222-7374')
+
+    const rows = switchRows()
+    // Disabled, not hidden: hiding it changes the list's shape between opens for
+    // no visible reason.
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toHaveAttribute('aria-disabled', 'true')
+
+    await userEvent.click(rows[0] as HTMLElement)
+    expect(onSwitchIdentifier).not.toHaveBeenCalled()
+  })
+
+  it('collapses a record value and its differently-formatted Participant twin', async () => {
+    // The server dedupes on a case fold only — it has no region to parse a
+    // number against — so both of these arrive. Two rows here would also mean
+    // two React children under one key.
+    h.contactIdentifiers = [
+      { identifier: '+1 415 555 1234', identifierType: 'PHONE', onRecord: true, rank: 0 },
+      { identifier: '+14155551234', identifierType: 'PHONE', onRecord: false, rank: null },
+    ]
+    renderPhoneInput(vi.fn(), vi.fn(), {
+      recipients: [
+        { id: 'chip-1', identifier: '+18052227374', identifierType: 'PHONE', recordId: 'c1' },
+      ],
+    })
+
+    await openChipMenu('(805) 222-7374')
+
+    const rows = switchRows()
+    expect(rows).toHaveLength(1)
+    // First wins, so the record row survives and keeps its un-marked shape.
+    expect(screen.queryByTitle(/Not saved on this contact’s record/)).not.toBeInTheDocument()
+  })
+
+  it('marks a corresponded-with-only address as not on the record', async () => {
+    h.contactIdentifiers = [onRecord('jane@corp.com', 0), correspondedWith('jane@personal.com')]
+    renderInput([janeChip])
+
+    await openChipMenu('Jane Smith')
+
+    expect(screen.getAllByTitle(/Not saved on this contact’s record/)[0]).toBeInTheDocument()
+  })
+
+  it('appends a separate chip with a fresh id and the same recordId', async () => {
+    h.contactIdentifiers = [onRecord('jane@corp.com', 0), onRecord('j.smith@corp.com', 1)]
+    const { onAdd, onSwitchIdentifier } = renderInput([janeChip])
+
+    await openChipMenu('Jane Smith')
+    await userEvent.click(screen.getByRole('menuitem', { name: /Add as separate recipient/ }))
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'j.smith@corp.com' }))
+
+    expect(onAdd).toHaveBeenCalledTimes(1)
+    const added = onAdd.mock.calls[0]?.[0] as { id: string; identifier: string; recordId?: string }
+    expect(added.identifier).toBe('j.smith@corp.com')
+    expect(added.recordId).toBe('c1')
+    // A fresh chip id, never the record id — that collision is what #1664 split.
+    expect(added.id).not.toBe('c1')
+    expect(added.id).not.toBe('chip-1')
+    expect(onSwitchIdentifier).not.toHaveBeenCalled()
+  })
+
+  it('renders no section when the record has only the committed address', async () => {
+    h.contactIdentifiers = [onRecord('jane@corp.com', 0)]
+    renderInput([janeChip])
+
+    await openChipMenu('Jane Smith')
+
+    expect(screen.queryByText('Other addresses')).not.toBeInTheDocument()
+    expect(screen.queryAllByRole('menuitemradio')).toEqual([])
+  })
+
+  it('renders no section when the fetch comes back empty', async () => {
+    h.contactIdentifiers = []
+    renderInput([janeChip])
+
+    await openChipMenu('Jane Smith')
+
+    // Not "No other addresses" — that is noise on every single-address
+    // recipient, which is most of them.
+    expect(screen.queryByText('Other addresses')).not.toBeInTheDocument()
+  })
+
+  it('never fetches, and shows no section, for a chip with no recordId', async () => {
+    h.contactIdentifiers = [onRecord('jane@corp.com', 0), onRecord('j.smith@corp.com', 1)]
+    renderInput([{ id: 'chip-1', identifier: 'typed@x.com', identifierType: 'EMAIL' }])
+
+    await openChipMenu('typed@x.com')
+
+    expect(h.identifierQueryInputs).toEqual([])
+    expect(screen.queryByText('Other addresses')).not.toBeInTheDocument()
+    // The rest of the menu is untouched.
+    expect(screen.getByRole('menuitem', { name: /Copy 'typed@x\.com'/ })).toBeInTheDocument()
+  })
+})
+
 // Quo (formerly OpenPhone) is the first channel whose recipient is a phone
 // number, not an address. The same input has to accept E.164, reject anything
 // libphonenumber can't parse, and commit `PHONE`.
@@ -483,6 +731,7 @@ describe('RecipientInput — badge formatting vs stored identifier', () => {
         onAdd={onAdd}
         onRemove={vi.fn()}
         onMoveTo={vi.fn()}
+        onSwitchIdentifier={vi.fn()}
         onContactSelect={vi.fn()}
         placeholder='To'
         recipientModel='phone'

--- a/apps/web/src/components/mail/email-editor/recipient-input.tsx
+++ b/apps/web/src/components/mail/email-editor/recipient-input.tsx
@@ -7,12 +7,19 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
 import { Popover, PopoverAnchor, PopoverContent } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
 import { generateId } from '@auxx/utils'
-import { Copy, Mail, X } from 'lucide-react'
+import { ArrowUpRight, Copy, Mail, UserPlus, X } from 'lucide-react'
 import type React from 'react'
 import { useCallback, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { Tooltip } from '~/components/global/tooltip'
@@ -22,6 +29,7 @@ import { useEditorActiveStateContext } from './editor-active-state-context'
 import {
   DEFAULT_PHONE_REGION,
   getIdentifierModel,
+  type IdentifierModelSpec,
   identifierKey,
   type PhoneRegion,
   type RecipientModel,
@@ -56,6 +64,19 @@ interface RecipientInputProps {
   onAdd: (recipient: RecipientState) => void
   onRemove: (id: string) => void
   onMoveTo: (id: string, target: RecipientField) => void
+  /**
+   * Replace ONE chip's identifier in place, keeping its `id`, its field and its
+   * position in the list.
+   *
+   * 🔴 **Not remove-then-add.** That would move the chip to the end of the
+   * field, drop focus, and — because `upsertRecipient` dedupes on `identifier` —
+   * silently no-op whenever the target address was already committed elsewhere
+   * in the same field, leaving the user with one fewer recipient than they had.
+   */
+  onSwitchIdentifier: (
+    id: string,
+    next: { identifier: string; identifierType: IdentifierTypeType }
+  ) => void
   /**
    * A picked suggestion's identifier, committed. Carries `recordId` — the
    * contact's `EntityInstance.id` — and **not** a chip id: the parent mints
@@ -101,15 +122,54 @@ const ALL_FIELDS: RecipientField[] = ['TO', 'CC', 'BCC']
 /** Keystroke settle before the search fires. */
 const SEARCH_DEBOUNCE_MS = 200
 
+/**
+ * The `↗` mark on an address that exists only as a `Participant` row.
+ *
+ * ⚠️ These rows are the capability this menu recovers — an address someone
+ * mailed you from that was never saved to their record — and also the ones that
+ * can surprise: `Participant.entityInstanceId` is set by ingest matching and is
+ * `ON DELETE set null`, so it can point at a contact the user does not think of
+ * as "them". Marked rather than presented as the contact's own data, and picking
+ * one writes nothing back to the record.
+ */
+function NotOnRecordMark() {
+  return (
+    <span
+      className='shrink-0 text-muted-foreground'
+      title='Not saved on this contact’s record — you have corresponded with this address'>
+      <ArrowUpRight className='size-3' />
+    </span>
+  )
+}
+
+/** One row of the chip menu's "Other addresses" section. */
+interface AddressOption {
+  /** Normalized comparison key, and the radio group's value. */
+  key: string
+  /** The exact string to commit. */
+  identifier: string
+  identifierType: IdentifierTypeType
+  onRecord: boolean
+  display: string
+  /** This is the address the chip already carries. */
+  isCommitted: boolean
+  /** Committed anywhere in this field, this chip included. */
+  inField: boolean
+}
+
 function RecipientBadge({
   person,
-  displayIdentifier,
+  spec,
+  recipientModel,
+  committedInField,
   index,
   highlightedIndex,
   disabled,
   field,
   onRemove,
   onMoveTo,
+  onSwitchIdentifier,
+  onAdd,
   onFocus,
   onBlur,
   onKeyDown,
@@ -117,14 +177,25 @@ function RecipientBadge({
   popoverClassName,
 }: {
   person: RecipientState
-  /** `spec.formatDisplay(person.identifier)` — display only; never committed. */
-  displayIdentifier: string
+  spec: IdentifierModelSpec
+  /** Query key half — a list fetched under email must not be read under phone. */
+  recipientModel?: RecipientModel
+  /**
+   * Normalized identifiers already committed in THIS field, this chip's own
+   * included. Drives the disabled state of the switch rows.
+   */
+  committedInField: Set<string>
   index: number
   highlightedIndex: number | null
   disabled?: boolean
   field: RecipientField
   onRemove: (id: string) => void
   onMoveTo: (id: string, target: RecipientField) => void
+  onSwitchIdentifier: (
+    id: string,
+    next: { identifier: string; identifierType: IdentifierTypeType }
+  ) => void
+  onAdd: (recipient: RecipientState) => void
   onFocus: () => void
   onBlur: () => void
   onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void
@@ -134,8 +205,62 @@ function RecipientBadge({
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const activeState = useEditorActiveStateContext()
   const dropdownId = `recipient-badge-${person.id}`
+  const displayIdentifier = spec.formatDisplay(person.identifier)
   const displayName = person.name ?? displayIdentifier
   const isHighlighted = highlightedIndex === index
+
+  /**
+   * The contact's other addresses, fetched ON OPEN.
+   *
+   * `useQuery`, never a mutation: the deleted `fieldValue.batchGet` was a
+   * mutation and therefore uncacheable, which is the only reason the composer
+   * ever hand-rolled a request cache. Reopening the same chip, and switching
+   * back and forth, must be free.
+   *
+   * `enabled` is the whole performance argument: rendering N chips issues ZERO
+   * requests, one open costs two index probes, and most chips are never opened.
+   * A chip with no `recordId` — free-typed, pasted, reply-derived, or restored
+   * from a draft (`toPayload` carries no record id) — never fetches and gets no
+   * section.
+   */
+  const { data: contactIdentifiers } = api.participant.listContactIdentifiers.useQuery(
+    // `?? ''` only satisfies the input type on the disabled path; `enabled`
+    // guarantees no request is made without a real record id.
+    { recordId: person.recordId ?? '', model: recipientModel ?? 'email' },
+    { enabled: dropdownOpen && !!person.recordId, staleTime: 5 * 60_000 }
+  )
+
+  const committedKey = identifierKey(spec, person.identifier)
+  const addressOptions = useMemo(() => {
+    const seen = new Set<string>()
+    const options: AddressOption[] = []
+    for (const row of contactIdentifiers ?? []) {
+      // `identifierKey` normalizes, so `+1 415 555 1234` and `+14155551234` are
+      // ONE address — the same comparison `excludeIdentifiers` uses for the
+      // suggestion list. The server deduped on a case fold only (it has no
+      // region to parse a number against), so a legacy un-normalized record
+      // value and its E.164 twin both arrive and collapse HERE — without this
+      // they would render as two rows sharing one React key.
+      const key = identifierKey(spec, row.identifier)
+      if (seen.has(key)) continue
+      seen.add(key)
+      options.push({
+        key,
+        identifier: row.identifier,
+        identifierType: row.identifierType,
+        onRecord: row.onRecord,
+        display: spec.formatDisplay(row.identifier),
+        isCommitted: key === committedKey,
+        /** Already a recipient of this field — disabled, not hidden. */
+        inField: committedInField.has(key),
+      })
+    }
+    return options
+  }, [contactIdentifiers, spec, committedKey, committedInField])
+  // No section at all when the record has nothing but the address already on
+  // this chip. An empty "Other addresses" heading would be noise on every
+  // single-address recipient, which is most of them.
+  const hasOtherAddresses = addressOptions.some((option) => !option.isCommitted)
 
   return (
     <DropdownMenu
@@ -200,6 +325,70 @@ function RecipientBadge({
             Copy '{person.name}'
           </DropdownMenuItem>
         )}
+        {hasOtherAddresses && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>Other addresses</DropdownMenuLabel>
+            {/* The committed address is the checked one, so the group's value is
+                this chip's own key — switching is a radio choice, not a list of
+                commands. */}
+            <DropdownMenuRadioGroup value={committedKey}>
+              {addressOptions.map((option) => (
+                <DropdownMenuRadioItem
+                  key={option.key}
+                  value={option.key}
+                  // Hiding an address that is already a recipient makes the list
+                  // change shape between opens for no visible reason; disabling
+                  // it explains itself. This chip's own address is disabled by
+                  // the same rule — it IS committed in this field. `disabled` is
+                  // the send lock, the same one that freezes the chip's `×`.
+                  disabled={option.inField || disabled}
+                  onSelect={() =>
+                    onSwitchIdentifier(person.id, {
+                      identifier: option.identifier,
+                      identifierType: option.identifierType,
+                    })
+                  }>
+                  <span className='inline-flex min-w-0 items-center gap-1'>
+                    <span className='truncate'>{option.display}</span>
+                    {!option.onRecord && <NotOnRecordMark />}
+                  </span>
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger>
+                <UserPlus />
+                Add as separate recipient
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className={popoverClassName}>
+                {addressOptions.map((option) => (
+                  <DropdownMenuItem
+                    key={option.key}
+                    disabled={option.inField || disabled}
+                    onSelect={() =>
+                      // A fresh chip id and the SAME `recordId`: two chips for
+                      // one contact is the motion the `id`/`recordId` split
+                      // (#1664) exists for.
+                      onAdd({
+                        id: generateId(),
+                        identifier: option.identifier,
+                        identifierType: option.identifierType,
+                        name: person.name,
+                        recordId: person.recordId,
+                      })
+                    }>
+                    <span className='inline-flex min-w-0 items-center gap-1'>
+                      <span className='truncate'>{option.display}</span>
+                      {!option.onRecord && <NotOnRecordMark />}
+                    </span>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+            <DropdownMenuSeparator />
+          </>
+        )}
         {ALL_FIELDS.filter((f) => f !== field).map((target) => (
           <DropdownMenuItem key={target} onSelect={() => onMoveTo(person.id, target)}>
             <Mail />
@@ -218,6 +407,7 @@ export function RecipientInput({
   onAdd,
   onRemove,
   onMoveTo,
+  onSwitchIdentifier,
   onContactSelect,
   placeholder,
   disabled,
@@ -493,7 +683,9 @@ export function RecipientInput({
         <RecipientBadge
           key={person.id}
           person={person}
-          displayIdentifier={spec.formatDisplay(person.identifier)}
+          spec={spec}
+          recipientModel={recipientModel}
+          committedInField={excludeIdentifiers}
           index={index}
           highlightedIndex={highlightedIndex}
           disabled={disabled}
@@ -503,6 +695,8 @@ export function RecipientInput({
             setHighlightedIndex(null)
           }}
           onMoveTo={onMoveTo}
+          onSwitchIdentifier={onSwitchIdentifier}
+          onAdd={onAdd}
           onFocus={() => setHighlightedIndex(index)}
           onBlur={() => setHighlightedIndex(null)}
           onKeyDown={(e) => handleBadgeKeyDown(e, index, person.id)}

--- a/apps/web/src/components/mail/email-editor/switch-recipient-identifier.test.ts
+++ b/apps/web/src/components/mail/email-editor/switch-recipient-identifier.test.ts
@@ -1,0 +1,113 @@
+// apps/web/src/components/mail/email-editor/switch-recipient-identifier.test.ts
+//
+// The chip menu's switch is IN PLACE. What that has to mean, and what these
+// tests pin: the chip keeps its `id` (the badge list keys on it and `onRemove`
+// filters on it), its field, its index, its `name` and its `recordId` — because
+// the address changed and the person did not.
+
+import { describe, expect, it } from 'vitest'
+import { switchRecipientIdentifier } from './switch-recipient-identifier'
+import type { Recipients } from './types'
+
+const jane = {
+  id: 'chip-1',
+  identifier: 'jane@corp.com',
+  identifierType: 'EMAIL' as const,
+  name: 'Jane Smith',
+  recordId: 'c1',
+}
+const ada = {
+  id: 'chip-2',
+  identifier: 'ada@x.com',
+  identifierType: 'EMAIL' as const,
+  name: 'Ada Lovelace',
+}
+
+function recipients(overrides: Partial<Recipients> = {}): Recipients {
+  return { TO: [], CC: [], BCC: [], ...overrides }
+}
+
+describe('switchRecipientIdentifier', () => {
+  it('replaces the identifier while keeping id, position, name and recordId', () => {
+    const before = recipients({ TO: [jane, ada] })
+
+    const after = switchRecipientIdentifier(before, 'TO', 'chip-1', {
+      identifier: 'j.smith@corp.com',
+      identifierType: 'EMAIL',
+    })
+
+    expect(after.TO).toEqual([{ ...jane, identifier: 'j.smith@corp.com' }, ada])
+    // Position, not just membership: a remove-then-add would put it last.
+    expect(after.TO[0]?.id).toBe('chip-1')
+  })
+
+  it('leaves the other fields untouched', () => {
+    const before = recipients({ TO: [jane], CC: [ada] })
+
+    const after = switchRecipientIdentifier(before, 'TO', 'chip-1', {
+      identifier: 'j.smith@corp.com',
+      identifierType: 'EMAIL',
+    })
+
+    expect(after.CC).toBe(before.CC)
+    expect(after.BCC).toBe(before.BCC)
+  })
+
+  it('switches identifierType too — a channel switch can change the shape', () => {
+    const before = recipients({ TO: [jane] })
+
+    const after = switchRecipientIdentifier(before, 'TO', 'chip-1', {
+      identifier: '+14155551234',
+      identifierType: 'PHONE',
+    })
+
+    expect(after.TO[0]).toMatchObject({ identifier: '+14155551234', identifierType: 'PHONE' })
+  })
+
+  it('returns the SAME object when the address is already the committed one', () => {
+    const before = recipients({ TO: [jane] })
+
+    const after = switchRecipientIdentifier(before, 'TO', 'chip-1', {
+      identifier: 'jane@corp.com',
+      identifierType: 'EMAIL',
+    })
+
+    // Identity, not equality: a no-op switch must not re-render the field.
+    expect(after).toBe(before)
+  })
+
+  it('returns the SAME object for an unknown chip id', () => {
+    const before = recipients({ TO: [jane] })
+
+    expect(
+      switchRecipientIdentifier(before, 'TO', 'chip-nope', {
+        identifier: 'j.smith@corp.com',
+        identifierType: 'EMAIL',
+      })
+    ).toBe(before)
+  })
+
+  it('refuses to switch onto an address another chip in the field already holds', () => {
+    // The menu renders that row disabled, so this is only reachable if the two
+    // ever disagree — and collapsing two chips into one is not a switch.
+    const before = recipients({ TO: [jane, { ...ada, identifier: 'j.smith@corp.com' }] })
+
+    expect(
+      switchRecipientIdentifier(before, 'TO', 'chip-1', {
+        identifier: 'j.smith@corp.com',
+        identifierType: 'EMAIL',
+      })
+    ).toBe(before)
+  })
+
+  it('allows the same address to exist in a DIFFERENT field', () => {
+    const before = recipients({ TO: [jane], CC: [{ ...ada, identifier: 'j.smith@corp.com' }] })
+
+    const after = switchRecipientIdentifier(before, 'TO', 'chip-1', {
+      identifier: 'j.smith@corp.com',
+      identifierType: 'EMAIL',
+    })
+
+    expect(after.TO[0]?.identifier).toBe('j.smith@corp.com')
+  })
+})

--- a/apps/web/src/components/mail/email-editor/switch-recipient-identifier.ts
+++ b/apps/web/src/components/mail/email-editor/switch-recipient-identifier.ts
@@ -1,0 +1,50 @@
+// apps/web/src/components/mail/email-editor/switch-recipient-identifier.ts
+
+import type { IdentifierType } from '@auxx/database/types'
+import type { Recipients } from './types'
+
+/**
+ * Swap ONE chip's identifier for another address of the same person, in place.
+ *
+ * 🔴 **In place, not remove-then-add.** The chip keeps its `id`, its field and
+ * its index in that field. Remove-then-add would move it to the end of the list
+ * and drop focus, and — because `upsertRecipient` dedupes on `identifier` — the
+ * add would silently no-op whenever the target address was already committed
+ * somewhere in the same field, costing the user a recipient they still see
+ * nothing about.
+ *
+ * `name` and `recordId` are carried over untouched: the address changed, the
+ * person did not.
+ *
+ * Extracted as a pure function so the position/identity contract is testable
+ * without mounting the whole composer — the same reason `derive-initial.ts` and
+ * `reconcile-channel-switch.ts` are pure.
+ *
+ * Returns the SAME `Recipients` object when nothing changes (unknown chip, or
+ * the address is already the committed one), so a no-op switch cannot re-render
+ * the field or mark the draft dirty a second time.
+ */
+export function switchRecipientIdentifier(
+  recipients: Recipients,
+  role: keyof Recipients,
+  id: string,
+  next: { identifier: string; identifierType: IdentifierType }
+): Recipients {
+  const list = recipients[role]
+  const index = list.findIndex((r) => r.id === id)
+  const current = list[index]
+  if (!current) return recipients
+  if (current.identifier === next.identifier) return recipients
+  // Belt to the menu's braces: the row for an address already committed in this
+  // field renders disabled, so this is reachable only if the two ever disagree —
+  // and collapsing two chips into one is not what "switch" means.
+  if (list.some((r) => r.id !== id && r.identifier === next.identifier)) return recipients
+
+  const updated = [...list]
+  updated[index] = {
+    ...current,
+    identifier: next.identifier,
+    identifierType: next.identifierType,
+  }
+  return { ...recipients, [role]: updated }
+}

--- a/apps/web/src/server/api/routers/participant.ts
+++ b/apps/web/src/server/api/routers/participant.ts
@@ -1,11 +1,18 @@
 // apps/web/src/server/api/routers/participant.ts
 
+import { schema } from '@auxx/database'
+import { getCachedEntityDefId } from '@auxx/lib/cache'
 import { getUserOrganizationId } from '@auxx/lib/email'
 import { BadRequestError, NotFoundError } from '@auxx/lib/errors'
-import { ensureContactForParticipant, ParticipantService } from '@auxx/lib/participants'
-import { PermissionKey } from '@auxx/lib/permissions'
+import {
+  ensureContactForParticipant,
+  listContactIdentifiers,
+  ParticipantService,
+} from '@auxx/lib/participants'
+import { PermissionKey, resolveRecordVisibilityScope } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
+import { and, eq, isNull } from 'drizzle-orm'
 import { z } from 'zod'
 import { createTRPCRouter, isAuxxError, permissionProcedure } from '~/server/api/trpc'
 
@@ -91,6 +98,89 @@ export const participantRouter = createTRPCRouter({
           message: 'Failed to fetch participants.',
         })
       }
+    }),
+
+  /**
+   * Every address one contact is reachable at on one channel — the composer's
+   * recipient-chip "switch to another address" menu
+   * (`plans/email-editor/recipient-address-switch.md`).
+   *
+   * **Why this router.** It is not a search and must not live beside
+   * `search.recipients`: that endpoint ranks an org-wide corpus, this one probes
+   * two btrees for one id, and filing them together is the invitation to
+   * "just add a recordId filter to `searchRecipients`". It belongs here because
+   * both of its arms are this router's own subject matter — `Participant` rows
+   * plus the contact those rows are linked to — and because {@link mailProcedure}
+   * is already the exact authority it needs: the coarse mail door,
+   * `PermissionKey.inboxesView`, the SAME answer `search.recipients` asserts.
+   * `recipient-address-switch.md` §4 requires that gate not be decided twice,
+   * and reusing the procedure is how it stays undecided-twice.
+   *
+   * 🔴 **Record read is asserted per call, on this one id.** The search returned
+   * ONE primary identifier under `resolveRecordVisibilityScope`; this returns
+   * EVERY identifier on the record, `recordId` is caller-supplied, and the chip
+   * may have arrived from a draft, a reply or a share rather than from a search
+   * this caller ran. So the same instance-level predicate the record picker
+   * applies (`record-picker-service.ts:1406-1414`) is applied here, narrowed to
+   * one id.
+   *
+   * An unreadable record answers with an **empty array, not a 403**. The chip is
+   * legitimately in the draft either way, and this fires from opening a menu — a
+   * thrown error would toast at someone who did nothing wrong. Mail reach itself
+   * still 403s, because a member with no mail reach is not composing.
+   */
+  listContactIdentifiers: mailProcedure
+    .input(
+      z.object({
+        /** `EntityInstance.id` from `RecipientState.recordId`. */
+        recordId: z.string(),
+        /**
+         * `PlatformCapabilities.recipientModel` of the SENDING channel. Part of
+         * the query key on the client too: a list fetched under the email model
+         * must never be read under the phone model.
+         */
+        model: z.enum(['email', 'phone', 'thread_only', 'platform_user']),
+        limit: z.number().int().min(1).max(50).optional(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const organizationId = ctx.session.organizationId
+      const contactDefId = await getCachedEntityDefId(organizationId, 'contact')
+      if (!contactDefId) return []
+
+      const scope = await resolveRecordVisibilityScope({
+        organizationId,
+        userId: ctx.session.userId,
+        entityDefinitionId: contactDefId,
+        capabilities: ctx.capabilities,
+      })
+      // Arm 4 — this member reaches no contact at all, so there is nothing to
+      // probe. `scope.where` is `undefined` on arm 'all' and `and()` drops it.
+      if (scope.arm === 'none') return []
+
+      const [readable] = await ctx.db
+        .select({ id: schema.EntityInstance.id })
+        .from(schema.EntityInstance)
+        .where(
+          and(
+            eq(schema.EntityInstance.id, input.recordId),
+            eq(schema.EntityInstance.organizationId, organizationId),
+            eq(schema.EntityInstance.entityDefinitionId, contactDefId),
+            isNull(schema.EntityInstance.archivedAt),
+            scope.where
+          )
+        )
+        .limit(1)
+      if (!readable) return []
+
+      const result = await listContactIdentifiers(ctx.db, {
+        organizationId,
+        recordId: input.recordId,
+        model: input.model,
+        limit: input.limit,
+      })
+      if (result.isErr()) throw result.error
+      return result.value
     }),
 
   /**

--- a/packages/lib/src/participants/__tests__/list-contact-identifiers.test.ts
+++ b/packages/lib/src/participants/__tests__/list-contact-identifiers.test.ts
@@ -1,0 +1,314 @@
+// packages/lib/src/participants/__tests__/list-contact-identifiers.test.ts
+//
+// The chip menu's point lookup: every address ONE contact is reachable at, for
+// ONE channel. What is worth pinning here is not the SQL (two equality probes)
+// but the four decisions around it: the model→field switch is bound so a phone
+// composer never reads the email field, the record arm's ordering is the
+// primary-value contract, the arms dedupe with record values winning, and a
+// model with nothing addressable answers empty rather than unfiltered.
+//
+// ⚠️ `src/test/setup.ts` mocks `@auxx/database` wholesale, so `schema.Foo` is a
+// memoized `{}` and its COLUMNS are `undefined`. Table identity therefore works
+// (`.from(schema.FieldValue)` is comparable by reference, which is how the db
+// double routes the two arms) but no assertion can name a column — so "ordered
+// by sortKey" is pinned only as "this arm applies an ORDER BY at all". The
+// column identity is asserted by review of `list-contact-identifiers.ts`.
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BadRequestError } from '../../errors'
+
+// Partial mock: other modules in this graph import other helpers from the same
+// file, and a full replacement of a shared module dies at COLLECTION rather than
+// in the test that needed it.
+const getCachedEntityDefId = vi.fn()
+const getCachedCustomFields = vi.fn()
+vi.mock('../../cache/org-cache-helpers', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getCachedEntityDefId: (...args: unknown[]) => getCachedEntityDefId(...args),
+  getCachedCustomFields: (...args: unknown[]) => getCachedCustomFields(...args),
+}))
+
+const { listContactIdentifiers, mergeIdentifiers } = await import('../list-contact-identifiers')
+
+const ORG = 'org_1'
+const RECORD = 'ei_jane'
+
+const EMAIL_FIELD = { id: 'fld_email', systemAttribute: 'primary_email' }
+const PHONE_FIELD = { id: 'fld_phone', systemAttribute: 'phone' }
+
+interface DbCalls {
+  /** Tables `.from()` was called with, in order. */
+  tables: string[]
+  /** How many times each arm applied an ORDER BY. */
+  orderBy: { fieldValue: number; participant: number }
+}
+
+/**
+ * Minimal `Database` stand-in. Routes on the table reference — the setup mock
+ * memoizes `schema.X`, so `schema.FieldValue === schema.FieldValue` holds.
+ */
+function makeDb(rows: {
+  fieldValues?: Array<{ identifier: string | null }>
+  participants?: Array<{ identifier: string; identifierType: string }>
+}): { db: Database; calls: DbCalls } {
+  const calls: DbCalls = { tables: [], orderBy: { fieldValue: 0, participant: 0 } }
+  const db = {
+    select: () => ({
+      from: (table: unknown) => {
+        const isFieldValue = table === schema.FieldValue
+        calls.tables.push(isFieldValue ? 'FieldValue' : 'Participant')
+        const result = isFieldValue ? (rows.fieldValues ?? []) : (rows.participants ?? [])
+        const chain = {
+          where: () => chain,
+          orderBy: () => {
+            if (isFieldValue) calls.orderBy.fieldValue++
+            else calls.orderBy.participant++
+            return chain
+          },
+          limit: async () => result,
+        }
+        return chain
+      },
+    }),
+  }
+  return { db: db as unknown as Database, calls }
+}
+
+/** Unwrap an expected-ok result, failing loudly instead of on `undefined`. */
+function unwrap<T>(result: { isErr(): boolean; value?: T; error?: Error }): T {
+  if (result.isErr()) throw result.error
+  return result.value as T
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getCachedEntityDefId.mockResolvedValue('def_contact')
+  getCachedCustomFields.mockResolvedValue([EMAIL_FIELD, PHONE_FIELD])
+})
+
+describe('listContactIdentifiers — record values arm', () => {
+  it('ranks the record values in the order the query returned them, 0 = primary', async () => {
+    const { db } = makeDb({
+      fieldValues: [{ identifier: 'jane@corp.com' }, { identifier: 'j.smith@corp.com' }],
+    })
+
+    const rows = unwrap(
+      await listContactIdentifiers(db, { organizationId: ORG, recordId: RECORD, model: 'email' })
+    )
+
+    expect(rows).toEqual([
+      { identifier: 'jane@corp.com', identifierType: 'EMAIL', onRecord: true, rank: 0 },
+      { identifier: 'j.smith@corp.com', identifierType: 'EMAIL', onRecord: true, rank: 1 },
+    ])
+  })
+
+  it('applies an ORDER BY on the record arm — the sortKey contract (#1613)', async () => {
+    const { db, calls } = makeDb({ fieldValues: [{ identifier: 'jane@corp.com' }] })
+
+    await listContactIdentifiers(db, { organizationId: ORG, recordId: RECORD, model: 'email' })
+
+    expect(calls.orderBy.fieldValue).toBe(1)
+  })
+
+  it('stamps the identifierType from the model, not from the FieldValue row', async () => {
+    const { db } = makeDb({ fieldValues: [{ identifier: '+14155551234' }] })
+
+    const rows = unwrap(
+      await listContactIdentifiers(db, { organizationId: ORG, recordId: RECORD, model: 'phone' })
+    )
+
+    expect(rows[0]?.identifierType).toBe('PHONE')
+  })
+
+  it('drops a row whose valueText came back null', async () => {
+    const { db } = makeDb({ fieldValues: [{ identifier: null }, { identifier: 'jane@corp.com' }] })
+
+    const rows = unwrap(
+      await listContactIdentifiers(db, { organizationId: ORG, recordId: RECORD, model: 'email' })
+    )
+
+    expect(rows.map((r) => r.identifier)).toEqual(['jane@corp.com'])
+  })
+
+  it('skips the arm — no FieldValue query — when the org has no field for this model', async () => {
+    // An org carrying only `primary_email`, composing on a phone channel. This is
+    // `recipient-search.md` §1.2's dead-row bug: reading the email field here
+    // would offer addresses the channel cannot send to.
+    getCachedCustomFields.mockResolvedValue([EMAIL_FIELD])
+    const { db, calls } = makeDb({
+      fieldValues: [{ identifier: 'jane@corp.com' }],
+      participants: [{ identifier: '+14155551234', identifierType: 'PHONE' }],
+    })
+
+    const rows = unwrap(
+      await listContactIdentifiers(db, { organizationId: ORG, recordId: RECORD, model: 'phone' })
+    )
+
+    expect(calls.tables).toEqual(['Participant'])
+    expect(rows.map((r) => r.identifier)).toEqual(['+14155551234'])
+  })
+
+  it('skips the arm when the org has no contact definition', async () => {
+    getCachedEntityDefId.mockResolvedValue(undefined)
+    const { db, calls } = makeDb({ fieldValues: [{ identifier: 'jane@corp.com' }] })
+
+    const rows = unwrap(
+      await listContactIdentifiers(db, { organizationId: ORG, recordId: RECORD, model: 'email' })
+    )
+
+    expect(calls.tables).toEqual(['Participant'])
+    expect(rows).toEqual([])
+  })
+})
+
+describe('listContactIdentifiers — corresponded-with arm', () => {
+  it('marks a participant-only address as not on the record, with no rank', async () => {
+    const { db } = makeDb({
+      fieldValues: [{ identifier: 'jane@corp.com' }],
+      participants: [{ identifier: 'jane@personal.com', identifierType: 'EMAIL' }],
+    })
+
+    const rows = unwrap(
+      await listContactIdentifiers(db, { organizationId: ORG, recordId: RECORD, model: 'email' })
+    )
+
+    expect(rows).toEqual([
+      { identifier: 'jane@corp.com', identifierType: 'EMAIL', onRecord: true, rank: 0 },
+      { identifier: 'jane@personal.com', identifierType: 'EMAIL', onRecord: false, rank: null },
+    ])
+  })
+
+  it('carries the identifierType off the Participant row', async () => {
+    const { db } = makeDb({
+      participants: [{ identifier: 'psid_1', identifierType: 'FACEBOOK_PSID' }],
+    })
+
+    // `thread_only` has no contact field at all, so this is the participant arm
+    // answering alone — the shape a Facebook/Instagram chip would see.
+    const rows = unwrap(
+      await listContactIdentifiers(db, {
+        organizationId: ORG,
+        recordId: RECORD,
+        model: 'thread_only',
+      })
+    )
+
+    expect(rows).toEqual([
+      { identifier: 'psid_1', identifierType: 'FACEBOOK_PSID', onRecord: false, rank: null },
+    ])
+  })
+})
+
+describe('listContactIdentifiers — the union', () => {
+  it('dedupes an address present on both sides, keeping the record row', async () => {
+    const { db } = makeDb({
+      fieldValues: [{ identifier: 'jane@corp.com' }],
+      participants: [{ identifier: 'jane@corp.com', identifierType: 'EMAIL' }],
+    })
+
+    const rows = unwrap(
+      await listContactIdentifiers(db, { organizationId: ORG, recordId: RECORD, model: 'email' })
+    )
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.onRecord).toBe(true)
+  })
+
+  it('dedupes case-insensitively', async () => {
+    const { db } = makeDb({
+      fieldValues: [{ identifier: 'jane@corp.com' }],
+      participants: [{ identifier: 'Jane@Corp.com', identifierType: 'EMAIL' }],
+    })
+
+    const rows = unwrap(
+      await listContactIdentifiers(db, { organizationId: ORG, recordId: RECORD, model: 'email' })
+    )
+
+    expect(rows).toHaveLength(1)
+  })
+
+  it('truncates the union at the limit', async () => {
+    const { db } = makeDb({
+      fieldValues: [{ identifier: 'a@x.com' }, { identifier: 'b@x.com' }],
+      participants: [{ identifier: 'c@x.com', identifierType: 'EMAIL' }],
+    })
+
+    const rows = unwrap(
+      await listContactIdentifiers(db, {
+        organizationId: ORG,
+        recordId: RECORD,
+        model: 'email',
+        limit: 2,
+      })
+    )
+
+    expect(rows.map((r) => r.identifier)).toEqual(['a@x.com', 'b@x.com'])
+  })
+
+  it('rejects a limit below 1 instead of querying', async () => {
+    const { db, calls } = makeDb({})
+
+    const result = await listContactIdentifiers(db, {
+      organizationId: ORG,
+      recordId: RECORD,
+      model: 'email',
+      limit: 0,
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+    expect(calls.tables).toEqual([])
+  })
+
+  // `identifierTypesForModel('platform_user')` is `[]`, which means "nothing is
+  // addressable", NOT "no filter". A caller that read it as no-filter would hand
+  // back every participant on the record of every type.
+  it('answers a model with no addressable type with an empty list and no query', async () => {
+    const { db, calls } = makeDb({
+      participants: [{ identifier: 'jane@corp.com', identifierType: 'EMAIL' }],
+    })
+
+    const rows = unwrap(
+      await listContactIdentifiers(db, {
+        organizationId: ORG,
+        recordId: RECORD,
+        model: 'platform_user',
+      })
+    )
+
+    expect(rows).toEqual([])
+    expect(calls.tables).toEqual([])
+  })
+})
+
+describe('mergeIdentifiers', () => {
+  const onRecord = {
+    identifier: 'a@x.com',
+    identifierType: 'EMAIL' as const,
+    onRecord: true,
+    rank: 0,
+  }
+  const corresponded = {
+    identifier: 'b@x.com',
+    identifierType: 'EMAIL' as const,
+    onRecord: false,
+    rank: null,
+  }
+
+  it('keeps record values first and appends the rest', () => {
+    expect(mergeIdentifiers([onRecord], [corresponded], 10)).toEqual([onRecord, corresponded])
+  })
+
+  it('does not reorder by rank — nulls would sort', () => {
+    const second = { ...onRecord, identifier: 'c@x.com', rank: 1 }
+    expect(
+      mergeIdentifiers([onRecord, second], [corresponded], 10).map((r) => r.identifier)
+    ).toEqual(['a@x.com', 'c@x.com', 'b@x.com'])
+  })
+
+  it('stops at the limit', () => {
+    expect(mergeIdentifiers([onRecord], [corresponded], 1)).toEqual([onRecord])
+  })
+})

--- a/packages/lib/src/participants/index.ts
+++ b/packages/lib/src/participants/index.ts
@@ -3,5 +3,11 @@
 export { type ClassifyIsInternalInput, classifyIsInternal } from './classify-internal'
 // Re-export client-safe types
 export type { ParticipantIdentifierType, ParticipantMeta } from './client'
+export {
+  type ContactIdentifier,
+  type ListContactIdentifiersParams,
+  listContactIdentifiers,
+  mergeIdentifiers,
+} from './list-contact-identifiers'
 export { type EnsureContactResult, ensureContactForParticipant } from './participant-queries'
 export { type FindOrCreateParticipantInput, ParticipantService } from './participant-service'

--- a/packages/lib/src/participants/list-contact-identifiers.ts
+++ b/packages/lib/src/participants/list-contact-identifiers.ts
@@ -1,0 +1,278 @@
+// packages/lib/src/participants/list-contact-identifiers.ts
+//
+// Every identifier ONE contact record is reachable at, for one channel.
+//
+// 🔴 **A point lookup, emphatically not a search.** `search/search-recipients.ts`
+// answers "who could I address?" over the whole org and pays for it: trigram
+// `similarity()`, a recency rank, a `BitmapOr` sized for a 200k-row corpus, a
+// candidate ceiling. This answers "which addresses does THIS record have?" —
+// two equality probes on existing btrees (`FieldValue_entityId_fieldId_idx`,
+// `Participant_entityInstanceId_idx`), no index and no migration added. Routing
+// it through `searchRecipients` with a recordId filter would compute a fuzzy
+// rank to order three rows whose correct order is `sortKey`.
+//
+// The ONE thing the two must share is `channel-identifier-fields`: if this read
+// `primary_email` while the composer sits on a phone channel it would offer
+// addresses the channel cannot send to — `recipient-search.md` §1.2's dead-row
+// bug, rebuilt inside a menu. So it takes the `recipientModel` and derives both
+// filters, exactly as `searchRecipients` does; passing `identifierTypes` and
+// `systemAttributes` in separately (as the plan originally specified) makes
+// their disagreement representable.
+//
+// 🔴 **Zero access checks live here.** `recordId` is caller-supplied, and this
+// returns EVERY identifier on the record rather than the one primary a scoped
+// search returned — so the router asserts record read on that one id before
+// calling, and answers an unreadable record with an empty list rather than a
+// 403 (`docs/lib-module-guide.md` §6).
+
+import { type Database, schema } from '@auxx/database'
+import type { IdentifierType } from '@auxx/database/types'
+import { and, asc, eq, inArray, isNotNull, sql } from 'drizzle-orm'
+import { err, ok, type Result } from 'neverthrow'
+import { getCachedCustomFields, getCachedEntityDefId } from '../cache/org-cache-helpers'
+import { BadRequestError } from '../errors'
+import {
+  identifierFieldsForModel,
+  identifierTypesForModel,
+  type RecipientModel,
+} from './channel-identifier-fields'
+
+/**
+ * A dropdown of addresses for one person. 25 is far past what any contact
+ * carries (1–3 in practice) and exists only so a pathological record cannot
+ * stream a thousand rows into a menu.
+ */
+const DEFAULT_LIMIT = 25
+
+/** One address this contact is reachable at on the requested channel. */
+export interface ContactIdentifier {
+  /** The committable value — E.164 or a lowercased email, as stored. */
+  identifier: string
+  identifierType: IdentifierType
+  /**
+   * `true` = a value on the contact record; `false` = an address only ever
+   * corresponded with.
+   *
+   * ⚠️ The `false` rows are the capability this surface exists to recover
+   * (`recipient-search.md` §4.2 gives up the second address of a contact you
+   * have only mailed once), and they are also the ones that can surprise:
+   * `Participant.entityInstanceId` is set by ingest matching and is
+   * `ON DELETE set null`, so it can point at a contact the user does not think
+   * of as "them". Present them as *not on record*, never as the contact's own
+   * data, and never write one back to the record as a side effect of picking it.
+   */
+  onRecord: boolean
+  /**
+   * Record values only: position in ascending `sortKey`, so `0` is the record's
+   * primary value. `null` for a corresponded-with row, which has no place in the
+   * record's ordering at all — deliberately not `-1` or a large sentinel, both
+   * of which sort silently.
+   */
+  rank: number | null
+}
+
+export interface ListContactIdentifiersParams {
+  organizationId: string
+  /** `EntityInstance.id` of the contact. Read access is the router's job. */
+  recordId: string
+  /**
+   * The sending channel's `PlatformCapabilities.recipientModel`. The model, not
+   * a pair of filters — see the file header.
+   */
+  model: RecipientModel
+  limit?: number
+}
+
+/**
+ * Every address one contact is reachable at on one channel: record values ∪
+ * corresponded-with, deduped, record values winning.
+ *
+ * The two arms run concurrently because neither informs the other — one
+ * dropdown open costs two probes, which is the whole argument for fetching on
+ * open instead of teaching the recipient search to return an identifier count
+ * (~20 extra probes per keystroke, forever, for every user).
+ */
+export async function listContactIdentifiers(
+  db: Database,
+  params: ListContactIdentifiersParams
+): Promise<Result<ContactIdentifier[], Error>> {
+  const limit = params.limit ?? DEFAULT_LIMIT
+  if (limit < 1) return err(new BadRequestError('limit must be at least 1'))
+
+  const identifierTypes = identifierTypesForModel(params.model)
+  // `[]` means nothing is addressable on this channel (`platform_user`) — an
+  // empty result, never an unfiltered one. See `identifierTypesForModel`.
+  if (identifierTypes.length === 0) return ok([])
+
+  const [onRecord, correspondedWith] = await Promise.all([
+    recordValueArm(db, params, limit),
+    correspondedWithArm(db, params, identifierTypes, limit),
+  ])
+
+  return ok(mergeIdentifiers(onRecord, correspondedWith, limit))
+}
+
+/**
+ * Union the two arms, record values first.
+ *
+ * Extracted as a pure function because the ordering and the tie rule are the
+ * only decisions here — everything else is two index probes. Record values win
+ * a tie: the same address on the record and in `Participant` is the record's,
+ * and reporting it as corresponded-with-only would mark it with an affordance
+ * that tells the user to be suspicious of their own data.
+ *
+ * Record ordering is preserved as-is (ascending `sortKey`, so the primary is
+ * first) and corresponded-with rows are appended. 🔴 **Do not sort the merged
+ * list.** `rank` is `null` on half the rows by construction, and the two arms
+ * are ordered by different things (`sortKey` vs. last-sent recency) with nothing
+ * calibrating them.
+ */
+export function mergeIdentifiers(
+  onRecord: readonly ContactIdentifier[],
+  correspondedWith: readonly ContactIdentifier[],
+  limit: number
+): ContactIdentifier[] {
+  const seen = new Set<string>()
+  const merged: ContactIdentifier[] = []
+  for (const row of [...onRecord, ...correspondedWith]) {
+    if (merged.length >= limit) break
+    const key = dedupeKey(row.identifier)
+    if (seen.has(key)) continue
+    seen.add(key)
+    merged.push(row)
+  }
+  return merged
+}
+
+/**
+ * Dedupe key across the arms. Lowercased only — both sides are already
+ * canonical (E.164 from the phone write path since #1629, lowercased email from
+ * the read paths), so this is a case fold rather than a normalizer.
+ * Deliberately NOT `formatPhoneNumber`: that needs a region this function has no
+ * business knowing, and it would silently drop a legacy value it cannot parse.
+ * The same choice `search-recipients.ts` makes, for the same reason.
+ */
+function dedupeKey(identifier: string): string {
+  return identifier.trim().toLowerCase()
+}
+
+/**
+ * Arm 1 — values on the contact record.
+ *
+ * 🔴 `ORDER BY sortKey ASC` is the primary-value contract, not decoration.
+ * `contact.primary_email` and `contact.phone` are both multi-value (#1625/#1634)
+ * and one row IS one value, so omitting the ordering returns a
+ * non-deterministic "primary" — #1613 exists because a read omitted it. This is
+ * also the ordering `searchRecipients`' contact LATERAL slices its single row
+ * with, which is what keeps the chip's own committed address at `rank: 0` here
+ * instead of somewhere in the middle.
+ */
+async function recordValueArm(
+  db: Database,
+  params: ListContactIdentifiersParams,
+  limit: number
+): Promise<ContactIdentifier[]> {
+  const fields = identifierFieldsForModel(params.model)
+  // `undefined` is a real answer, not a gap: no contact field holds a Facebook
+  // PSID or a platform user id, so the arm is skipped rather than falling back
+  // to email — which would offer addresses the channel cannot send to.
+  if (!fields) return []
+
+  const contactDefId = await getCachedEntityDefId(params.organizationId, 'contact')
+  if (!contactDefId) return []
+
+  const customFields = await getCachedCustomFields(params.organizationId, contactDefId)
+  const fieldIds = customFields
+    .filter(
+      (field) => field.systemAttribute && fields.systemAttributes.includes(field.systemAttribute)
+    )
+    .map((field) => field.id)
+  // Zero queries so far — `getCachedCustomFields` is the org cache. An empty
+  // list means this org has no field for the channel's systemAttributes, so
+  // nothing is addressable through the record. (It is also the only way this
+  // arm can plan as a seq scan: `fieldId IN ()`. That would be a cache bug, not
+  // an index bug.)
+  if (fieldIds.length === 0) return []
+
+  const rows = await db
+    .select({ identifier: schema.FieldValue.valueText })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, params.organizationId),
+        eq(schema.FieldValue.entityId, params.recordId),
+        inArray(schema.FieldValue.fieldId, fieldIds),
+        isNotNull(schema.FieldValue.valueText)
+      )
+    )
+    // `fieldId` only breaks a tie the `sortKey` ordering cannot: an org holding
+    // BOTH `phone` and `primary_phone` has two fields whose first value is
+    // `sortKey` 'a'. It makes the answer stable across calls; it does not
+    // reorder anything `sortKey` already decides.
+    .orderBy(asc(schema.FieldValue.sortKey), asc(schema.FieldValue.fieldId))
+    .limit(limit)
+
+  return rows.flatMap((row, index) =>
+    row.identifier
+      ? [
+          {
+            identifier: row.identifier,
+            // From the model's field spec, never from the row: `FieldValue` has
+            // no identifier type, and this is the same switch the composer
+            // commits with.
+            identifierType: fields.identifierType,
+            onRecord: true,
+            rank: index,
+          },
+        ]
+      : []
+  )
+}
+
+/**
+ * Arm 2 — addresses this contact has actually corresponded from.
+ *
+ * A `Participant` row is written only by ingest and chat visitor identity, so a
+ * row means *this address has corresponded with you*. That is exactly the
+ * address the recipient search cannot offer (it returns one row per person), and
+ * therefore the whole reason this surface exists.
+ *
+ * Ordered most-recently-mailed first, with `identifier` as the tie-break so an
+ * address never messaged (`lastSentMessageAt IS NULL` — the common case for an
+ * inbound-only correspondent) still has a stable position.
+ */
+async function correspondedWithArm(
+  db: Database,
+  params: ListContactIdentifiersParams,
+  identifierTypes: readonly IdentifierType[],
+  limit: number
+): Promise<ContactIdentifier[]> {
+  const rows = await db
+    .select({
+      identifier: schema.Participant.identifier,
+      identifierType: schema.Participant.identifierType,
+    })
+    .from(schema.Participant)
+    .where(
+      and(
+        eq(schema.Participant.organizationId, params.organizationId),
+        eq(schema.Participant.entityInstanceId, params.recordId),
+        inArray(schema.Participant.identifierType, [...identifierTypes]),
+        eq(schema.Participant.isSpammer, false)
+      )
+    )
+    // `DESC NULLS LAST`, not bare `DESC`: SQL defaults `DESC` to `NULLS FIRST`,
+    // which would float every never-mailed address above the ones you use.
+    .orderBy(
+      sql`${schema.Participant.lastSentMessageAt} DESC NULLS LAST`,
+      asc(schema.Participant.identifier)
+    )
+    .limit(limit)
+
+  return rows.map((row) => ({
+    identifier: row.identifier,
+    identifierType: row.identifierType,
+    onRecord: false,
+    rank: null,
+  }))
+}


### PR DESCRIPTION
Implements `plans/email-editor/recipient-address-switch.md`. Depends on #1670/#1671.

## What it recovers

The recipient-search union returns **one row per person**, so a contact with three addresses where you've only ever mailed one was reachable at exactly one address. That was a knowing trade (`recipient-search.md` §4.2 — "the picker is for *people*"), and this is the surface that pays it back: clicking a recipient chip offers that contact's other addresses, switch or add.

## A point lookup, not a search

Two equality arms on **existing btrees** — `FieldValue` by `entityId + fieldId`, `Participant` by `entityInstanceId` — unioned and deduped with record values winning ties. **No index, no migration.** Two probes per dropdown open.

🔴 Deliberately *not* `searchRecipients` with a `recordId` filter. That would compute `similarity()` and a recency rank to order three rows whose correct order is `sortKey`. Different question, different query. The one thing the two **do** share is the `channel-identifier-fields` switch — reading `primary_email` while the composer is on a phone channel would rebuild the dead-row bug inside a menu.

`§3.1`'s arithmetic is why the fetch is on open rather than a count returned by the search: a count would cost ~20 index probes **per keystroke** forever; a dropdown open costs 2, and most chips are never opened.

## Permissions — a real probe, not an inference

🔴 The record-read check runs **per call** and is not inferred from "the search already returned this chip". The search returned ONE primary identifier under record scope; this returns **every** identifier on the record, and `recordId` is caller-supplied.

Scope resolves → arm `none` returns empty → one `EntityInstance` lookup narrowed by `id + org + contact def + archivedAt IS NULL + scope.where` → no row means an **empty array, not a 403**, because the chip is legitimately in the draft either way and a thrown error would toast on opening a menu. Lib receives no scope argument at all.

Participant-only addresses — an address someone mailed you from that was never saved to their record — are marked rather than presented as the contact's own data (`Participant.entityInstanceId` is set by ingest matching and nulled on delete), and picking one **never writes to the record**.

## Switch is in place

Same chip id, field and position. Not remove-then-add, which would move the chip to the end, lose focus, and hit `upsertRecipient`'s identifier-dedupe as a silent no-op if the target address were already present elsewhere in the field. Extracted as a pure reducer so that contract is testable without mounting the composer.

An address already in the same field renders **disabled, not hidden** — hiding makes the list change shape between opens for no visible reason. Comparison is normalized via `identifierKey`, so `+1 415 555 1234` and `+14155551234` are one address.

## Four deviations from the plan, each with a reason

1. **Procedure on `participant.ts`, not a new `recipient` router** (§3.2 shows `api.recipient.*`). Both arms are that router's own subject, and its existing `mailProcedure = permissionProcedure(PermissionKey.inboxesView)` **is** the gate §4 asks for — so the "don't decide the participant-read question twice" constraint is met by reusing the procedure rather than restating an assert. Filing a point lookup in `searchRouter` is also a standing invitation to "just add a recordId filter to `searchRecipients`".
2. **Takes the channel `model`, not `{identifierTypes, systemAttributes}`** — the same deviation `searchRecipients` shipped with, for the same reason: the pair makes "filter PHONE, read primary_email" representable. §3's own 🔴 note argues against its own signature two paragraphs later.
3. **File in `participants/`, not `participants/search/`** — it isn't a search.
4. **Client-side re-dedupe added** (not in the plan). The server folds case only — no region is available there — so a legacy un-normalized record value and its E.164 twin both arrive and would render as two rows sharing one React key.

## Tests

96 web editor tests (was 77) and 92 lib participant tests (was 76). Notably: **zero requests while chips are only rendered**; the fetch keyed on `{recordId, model}`; the in-field row disabled *and* inert with a normalized comparison proven by a phone chip; a phone model never reading the email field (an org with only `primary_email` skips the `FieldValue` arm entirely, issuing no query); a chip with no `recordId` getting no section with the rest of the menu intact; and the switch preserving id/position/field/name/recordId.

`packages/lib` `src/` typechecks clean; web at the 10-error pre-existing baseline (none in the touched files); biome clean.

## Known gaps, worth reading before merge

- **A chip restored from a draft has no `recordId`, so it gets no section.** `toPayload` sends only `{identifier, identifierType, name}`, so the record link doesn't survive a draft round-trip. That's the accepted v1 consequence from §1, not a regression — widening `ParticipantInputData` is a send-path change.
- **The app was not run.** "Reopening a chip issues zero requests" is React Query's `staleTime` doing its job and is asserted in the source (`5 * 60_000`), not in a browser network panel. The "Add as separate recipient" **submenu** inside the composer's own popover stack is also visually unverified — `popoverClassName` is forwarded to `DropdownMenuSubContent`, but Radix renders `SubContent` without its own Portal, so that's where to look if the z-index misbehaves in the floating composer.
- **The `sortKey` ordering is review-only.** `packages/lib/src/test/setup.ts` mocks `@auxx/database` wholesale, so `schema.FieldValue`'s columns read as `undefined` — table identity is assertable but no assertion can name a column. The record arm's ordering is pinned as "an ORDER BY is applied" plus the resulting rank sequence.
