### PR TITLE
fix(search): stop the recipients procedure breaking router test collection

### DIFF
--- a/apps/web/src/server/api/routers/search.ts
+++ b/apps/web/src/server/api/routers/search.ts
@@ -1,11 +1,8 @@
 import { schema } from '@auxx/database'
-import { getCachedEntityDefId, getCachedUserInstanceGrants } from '@auxx/lib/cache'
 import { InboxService } from '@auxx/lib/inboxes'
 import { IsOperatorValue, SearchOperator } from '@auxx/lib/mail-query'
-import { buildMailVisibilityPredicate } from '@auxx/lib/mail-query/visibility-scope'
 import { listMembersWithUser } from '@auxx/lib/members'
-import { searchRecipients } from '@auxx/lib/participants/search'
-import { PermissionKey, resolveRecordVisibilityScope } from '@auxx/lib/permissions'
+import { PermissionKey } from '@auxx/lib/permissions'
 import { listAll } from '@auxx/lib/resources'
 import { createScopedLogger } from '@auxx/logger'
 import { and, asc, count as drizzleCount, eq, ilike, inArray, or, sql } from 'drizzle-orm'
@@ -468,6 +465,29 @@ export const searchRouter = createTRPCRouter({
       // Same coarse mail door as `participants` above — this is the same
       // `Participant` corpus reached through a better query.
       ctx.capabilities.assert(PermissionKey.inboxesView)
+
+      // 🔴 Lazy imports, and NOT a style choice. At module scope these pull
+      // `@auxx/lib/cache`'s provider graph and `visibility-scope`'s
+      // `import { database }`, both of which touch `schema` / the db singleton
+      // while the module is being evaluated. That broke COLLECTION for every
+      // router test that mocks `@auxx/database` — `search-participant-gate.test.ts`
+      // went from 17 passing tests to 0 with `No "database" export is defined on
+      // the "@auxx/database" mock`. Introduced by #1670 and missed because a suite
+      // collecting zero tests does not read as a failure at a glance. Same reason
+      // `@auxx/lib/apps` and the workflow engine are imported dynamically.
+      const [
+        { getCachedEntityDefId },
+        { getCachedUserInstanceGrants },
+        { buildMailVisibilityPredicate },
+        { searchRecipients },
+        { resolveRecordVisibilityScope },
+      ] = await Promise.all([
+        import('@auxx/lib/cache/org-cache-helpers'),
+        import('@auxx/lib/cache/user-cache-helpers'),
+        import('@auxx/lib/mail-query/visibility-scope'),
+        import('@auxx/lib/participants/search'),
+        import('@auxx/lib/permissions'),
+      ])
       const organizationId = ctx.session.organizationId
       const userId = ctx.session.user.id
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -202,11 +202,23 @@
       "import": "./dist/cache/index.mjs",
       "default": "./src/cache/index.ts"
     },
+    "./cache/org-cache-helpers": {
+      "types": "./src/cache/org-cache-helpers.ts",
+      "source": "./src/cache/org-cache-helpers.ts",
+      "import": "./dist/cache/org-cache-helpers.mjs",
+      "default": "./src/cache/org-cache-helpers.ts"
+    },
     "./cache/providers/governing-instance-ids-provider": {
       "types": "./src/cache/providers/governing-instance-ids-provider.ts",
       "source": "./src/cache/providers/governing-instance-ids-provider.ts",
       "import": "./dist/cache/providers/governing-instance-ids-provider.mjs",
       "default": "./src/cache/providers/governing-instance-ids-provider.ts"
+    },
+    "./cache/user-cache-helpers": {
+      "types": "./src/cache/user-cache-helpers.ts",
+      "source": "./src/cache/user-cache-helpers.ts",
+      "import": "./dist/cache/user-cache-helpers.mjs",
+      "default": "./src/cache/user-cache-helpers.ts"
     },
     "./channels": {
       "types": "./src/channels/index.ts",


### PR DESCRIPTION
**My own regression from #1670**, found while investigating why CI was red on #1672.

## The bug

`src/server/api/routers/search-participant-gate.test.ts` went from **17 passing tests to 0** — it stopped *collecting*, with:

```
No "database" export is defined on the "@auxx/database" mock
```

Proven rather than inferred: restoring the pre-#1670 `search.ts` makes it pass 17; with mine it collects 0.

## Cause

The `recipients` procedure imported `@auxx/lib/cache` and `@auxx/lib/mail-query/visibility-scope` at **module scope**:

- the cache barrel pulls `cache/providers/agents-provider` → `files/core/media-asset-service`, which calls `getTableColumns(schema.…)` in a **static initializer**
- `visibility-scope` does `import { database }` for its `exists()` subquery

Both touch the schema/db singleton while the module is being evaluated, so any test that mocks `@auxx/database` dies before a single test runs.

## Fix

All five imports move inside the handler, in one `Promise.all`. Same reason `@auxx/lib/apps` and the workflow engine are already imported dynamically.

Worth noting: **leaf subpaths alone were not enough.** I tried `@auxx/lib/cache/org-cache-helpers` first — it still reaches the provider graph. Laziness is the actual fix, not path precision.

## Why it slipped past me

Three things lined up:

1. A suite that collects **zero** tests doesn't read as a failure at a glance — it looks like an empty file.
2. The web Test lane was **already red** for unrelated reasons. Verified: `Test` was failing on `3303bd822`, the commit `main` sat at before any of this work started, so a red X carried no signal.
3. I only ran the email-editor subset and the lib suites on each PR, never the whole web suite. Running it once would have caught this.

## Result

| | before | after |
|---|---|---|
| web test files failing | 5 | **4** |
| web tests passing | 3403 | **3420** |
| typecheck errors | 10 (baseline) | 10 (unchanged) |

## The remaining 4 are pre-existing — and one has a root cause worth fixing

`src/app/api/outlook/webhook/route.test.ts` fails at collection for the **same barrel hazard**, reached from a different route (`agents-provider` → `media-asset-service` → `getTableColumns` at module scope). Mine was one instance of a systemic trap: *any* test that mocks `@auxx/database` and transitively imports the cache barrel dies at collection, and the symptom is a silently empty suite.

The root fix is to stop `media-asset-service` calling `getTableColumns` at module scope. That's a separate change in someone else's module, so it isn't in this PR — but it's the reason this class of bug will recur.

The other three (`mail-suggestions.test.ts` ×2, `mail-router-front-door.test.ts`, `record-identity-header.test.tsx`) are unrelated to this work.
