### PR TITLE
refactor(utils): one parse-and-validate gate for phone numbers

### DIFF
--- a/packages/lib/src/data-migrations/migrations/088-phone-geo-backfill.ts
+++ b/packages/lib/src/data-migrations/migrations/088-phone-geo-backfill.ts
@@ -136,6 +136,10 @@ export const migration088PhoneGeoBackfill: DataMigrationDef = {
 
         const inserts: Array<typeof schema.FieldValue.$inferInsert> = []
         for (const contact of contacts.rows) {
+          // No region argument: `valueText` is E.164 (`fieldValueSchemas.phone` normalizes on
+          // write), which is self-describing. Any legacy national-format row resolves to `null`
+          // rather than being guessed against US — the right outcome for a job whose entire
+          // output is a claim about where a number is from.
           const geo = lookupPhoneGeo(contact.valueText)
           if (!geo) continue
           for (const target of org.targets) {

--- a/packages/lib/src/participants/search/phone-query.ts
+++ b/packages/lib/src/participants/search/phone-query.ts
@@ -1,7 +1,6 @@
 // packages/lib/src/participants/search/phone-query.ts
 
-import type { PhoneRegion } from '@auxx/utils'
-import { parsePhoneNumberFromString } from 'libphonenumber-js'
+import { type PhoneRegion, parseValidPhone } from '@auxx/utils'
 
 /**
  * Minimum pattern length. Below three characters `pg_trgm` extracts no full
@@ -56,14 +55,16 @@ export function phoneSearchPatterns(query: string, region: PhoneRegion): string[
   if (digits.length < TRIGRAM_FLOOR) return []
 
   const patterns = new Set<string>()
-  const parsed = parsePhoneNumberFromString(query, region)
-  // 🔴 `isValid()`, not merely "parsed" — the same gate `formatPhoneNumber` uses.
-  // `parsePhoneNumberFromString` happily returns a PhoneNumber for a fragment:
-  // `('415', 'US')` yields `+1415`, whose patterns would be `1415` and `415`. That
-  // synthetic `1415` is a real false-positive arm (it matches `+13161415000`), and
-  // it is invented rather than typed. An invalid or partial parse contributes
-  // nothing, and the raw-digits pattern below carries the fragment instead.
-  if (parsed?.isValid()) {
+  // 🔴 `parseValidPhone`, not a bare parse — it carries the `isValid()` gate that
+  // `formatPhoneNumber` and `lookupPhoneGeo` share, so "valid" cannot drift between
+  // search and the write path. `parsePhoneNumberFromString` happily returns a
+  // PhoneNumber for a fragment: `('415', 'US')` yields `+1415`, whose patterns would
+  // be `1415` and `415`. That synthetic `1415` is a real false-positive arm (it
+  // matches `+13161415000`), and it is invented rather than typed. An invalid or
+  // partial parse contributes nothing, and the raw-digits pattern below carries the
+  // fragment instead.
+  const parsed = parseValidPhone(query, region)
+  if (parsed) {
     // `.number` is `+4930901820`; drop the `+` so the pattern is a substring of
     // the stored identifier rather than an anchored equality.
     patterns.add(parsed.number.slice(1))

--- a/packages/lib/src/phone-geo/__tests__/lookup.test.ts
+++ b/packages/lib/src/phone-geo/__tests__/lookup.test.ts
@@ -66,8 +66,25 @@ describe('lookupPhoneGeo', () => {
     expect(result?.region).toBe('Illinois')
   })
 
-  it('parses national numbers using the default country', () => {
-    expect(lookupPhoneGeo('(310) 203-0000')?.city).toBe('Los Angeles')
+  it('parses a national number when given an explicit region', () => {
+    expect(lookupPhoneGeo('(310) 203-0000', 'US')?.city).toBe('Los Angeles')
+  })
+
+  it('refuses to guess a region for national input', () => {
+    // Assuming one fails silently: `030 901820` parsed as US would yield a plausible answer for a
+    // number the caller never meant, and this function's whole job is to say where a number is
+    // from. Returning null is the only honest answer.
+    expect(lookupPhoneGeo('(310) 203-0000')).toBeNull()
+    expect(lookupPhoneGeo('030 901820')).toBeNull()
+  })
+
+  it('parses the same national input differently per region', () => {
+    // The point of requiring a region: identical digits, different countries.
+    expect(lookupPhoneGeo('030 901820', 'DE')).toMatchObject({ country: 'Germany' })
+  })
+
+  it('needs no region for E.164, which is self-describing', () => {
+    expect(lookupPhoneGeo('+493012345678')?.country).toBe('Germany')
   })
 
   it.each([

--- a/packages/lib/src/phone-geo/lookup.ts
+++ b/packages/lib/src/phone-geo/lookup.ts
@@ -22,8 +22,8 @@
 import { readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { createScopedLogger } from '@auxx/logger'
+import { type PhoneRegion, parseValidPhone } from '@auxx/utils'
 import { deserialize } from 'bson'
-import { type CountryCode, parsePhoneNumberFromString } from 'libphonenumber-js'
 import type { PhoneGeo } from './types'
 
 const logger = createScopedLogger('phone-geo')
@@ -215,24 +215,35 @@ export function warmPhoneGeo(): void {
 }
 
 /**
- * Derive city/region/country/timezone from an E.164 phone number.
+ * Derive city/region/country/timezone from a phone number.
  *
- * Pure and synchronous — no database, no network. Returns `null` when the number is unparseable
- * or nothing at all could be derived.
+ * Pure and synchronous — no database, no network. Returns `null` when the number is unparseable,
+ * invalid, or nothing at all could be derived.
  *
- * @param e164 A phone number. Anything `libphonenumber-js` can parse works, but callers should
- *   pass E.164; values read from `Participant.identifier` are only digit-stripped and must go
- *   through `formatPhoneNumber` from `@auxx/utils` first.
- * @param defaultCountry Region assumed for numbers written without a `+` prefix.
+ * 🔴 **A national (no `+`) number without an explicit `region` returns `null` rather than being
+ * guessed at.** Assuming a region here fails *silently*: E.164 drops the trunk prefix, so parsing
+ * Berlin's `030 901820` against `US` does not error — it yields a plausible answer for a number
+ * the caller never meant. Since this function's whole job is to say where a number is from, a
+ * wrong region produces a confidently wrong city. E.164 input is self-describing and needs no
+ * region, which is every production caller: the hook and the backfill both read `FieldValue`,
+ * already normalized by `fieldValueSchemas.phone`.
+ *
+ * @param phone A phone number. E.164 (`+13102030000`) needs no `region`.
+ * @param region Region a national (no `+`) number is parsed against. Derive it from the relevant
+ *   channel's own number via `regionFromIdentifier` — never a global default. Values read from
+ *   `Participant.identifier` are only digit-stripped, not E.164, so they need this too.
  */
 export function lookupPhoneGeo(
-  e164: string | null | undefined,
-  defaultCountry: CountryCode = 'US'
+  phone: string | null | undefined,
+  region?: PhoneRegion
 ): PhoneGeo | null {
-  if (!e164) return null
+  if (!phone) return null
 
-  const parsed = parsePhoneNumberFromString(e164.trim(), defaultCountry)
-  if (!parsed?.isValid()) return null
+  const trimmed = phone.trim()
+  if (!trimmed.startsWith('+') && !region) return null
+
+  const parsed = parseValidPhone(trimmed, region)
+  if (!parsed) return null
 
   const callingCode = String(parsed.countryCallingCode)
   const nationalNumber = parsed.nationalNumber

--- a/packages/utils/src/__tests__/contact.test.ts
+++ b/packages/utils/src/__tests__/contact.test.ts
@@ -1,7 +1,7 @@
 // packages/utils/src/__tests__/contact.test.ts
 
 import { describe, expect, it } from 'vitest'
-import { formatPhoneNumber } from '../contact'
+import { formatPhoneNumber, parseValidPhone } from '../contact'
 
 describe('formatPhoneNumber', () => {
   describe('US national numbers (the default country)', () => {
@@ -65,5 +65,47 @@ describe('formatPhoneNumber', () => {
     it('returns null for an unknown country calling code', () => {
       expect(formatPhoneNumber('+999 1234567')).toBeNull()
     })
+  })
+})
+
+describe('parseValidPhone', () => {
+  it('returns the parsed number, not just the E.164 string', () => {
+    // The reason this exists alongside formatPhoneNumber: callers need the parts.
+    // `phoneSearchPatterns` wants `nationalNumber`, `lookupPhoneGeo` wants
+    // `countryCallingCode` + `nationalNumber` + `country`.
+    const parsed = parseValidPhone('+13102030000')
+    expect(parsed?.number).toBe('+13102030000')
+    expect(parsed?.nationalNumber).toBe('3102030000')
+    expect(parsed?.countryCallingCode).toBe('1')
+    expect(parsed?.country).toBe('US')
+  })
+
+  it('honors an explicit region for national input', () => {
+    expect(parseValidPhone('030 901820', 'DE')?.number).toBe('+4930901820')
+  })
+
+  it('applies the isValid gate, not a bare parse', () => {
+    // `parsePhoneNumberFromString('415', 'US')` returns a PhoneNumber for `+1415`.
+    // Letting that through would invent a `1415` search pattern that matches
+    // `+13161415000` — a false positive nobody typed.
+    expect(parseValidPhone('415')).toBeNull()
+    expect(parseValidPhone('0123456789')).toBeNull()
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty', ''],
+    ['whitespace', '   '],
+    ['garbage', 'not a phone'],
+  ])('returns null for %s', (_label, input) => {
+    expect(parseValidPhone(input)).toBeNull()
+  })
+
+  it('agrees with formatPhoneNumber on every verdict', () => {
+    // The two must never disagree — formatPhoneNumber is defined over this.
+    for (const input of ['+13102030000', '4155551234', '415', 'not a phone', '', '+999 1234567']) {
+      expect(parseValidPhone(input)?.number ?? null).toBe(formatPhoneNumber(input))
+    }
   })
 })

--- a/packages/utils/src/contact.ts
+++ b/packages/utils/src/contact.ts
@@ -1,6 +1,6 @@
 // packages/utils/src/contact.ts
 
-import { type CountryCode, parsePhoneNumberFromString } from 'libphonenumber-js'
+import { type CountryCode, type PhoneNumber, parsePhoneNumberFromString } from 'libphonenumber-js'
 
 export type ContactName = {
   id?: string
@@ -68,6 +68,44 @@ export const getInitialsFromName = (name: string | null, empty: string = 'U'): s
 }
 
 /**
+ * Parse a phone number and return it only if it is genuinely valid.
+ *
+ * This is THE parse-and-validate gate. Everything that needs to know "is this a
+ * real number" funnels through it — {@link formatPhoneNumber} for the E.164
+ * string, `phoneSearchPatterns` for digit patterns, `lookupPhoneGeo` for the
+ * numbering-plan prefixes — so the notion of "valid" can never drift between
+ * the write path, search and enrichment.
+ *
+ * 🔴 **`isValid()`, not merely "parsed".** `parsePhoneNumberFromString` happily
+ * returns a `PhoneNumber` for a fragment: `('415', 'US')` yields `+1415`.
+ * `isValid()` is the per-country numbering-plan check, so impossible numbers are
+ * rejected rather than blessed with a `+1`.
+ *
+ * Returns the parsed object rather than a string because callers need different
+ * parts of it — `.number`, `.nationalNumber`, `.countryCallingCode`, `.country`.
+ * Reach for {@link formatPhoneNumber} when all you want is the E.164 string.
+ *
+ * ⚠️ Deliberately NOT used by the two display formatters
+ * (`field-values/converters/phone.ts`, the composer's `identifier-model.ts`):
+ * those format whatever parses and fall back to the raw string, so gating them
+ * on validity would stop them rendering already-stored legacy values.
+ *
+ * @param phone Raw user/CSV/provider input, any formatting.
+ * @param defaultCountry Region a national (no `+`) number is parsed against.
+ * @returns The parsed number, or `null` when unparseable or invalid.
+ */
+export const parseValidPhone = (
+  phone: string | null | undefined,
+  defaultCountry: CountryCode = 'US'
+): PhoneNumber | null => {
+  if (!phone) return null
+
+  const parsed = parsePhoneNumberFromString(phone.trim(), defaultCountry)
+
+  return parsed?.isValid() ? parsed : null
+}
+
+/**
  * Normalize a phone number to E.164 (`+4930901820`).
  *
  * This is THE phone normalizer — the write-path validator
@@ -76,9 +114,8 @@ export const getInitialsFromName = (name: string | null, empty: string = 'U'): s
  * drift apart.
  *
  * National numbers with no country code are parsed as `defaultCountry`
- * (US in v1; org-profile-based inference is the v2 lever). Validation uses
- * `isValid()` — the per-country numbering-plan check, not just a length check —
- * so impossible numbers are rejected rather than blessed with a `+1`.
+ * (US in v1; org-profile-based inference is the v2 lever). Validity is
+ * {@link parseValidPhone}'s `isValid()` gate.
  *
  * @param phone Raw user/CSV/provider input, any formatting.
  * @param defaultCountry Country assumed for numbers written without a `+` prefix.
@@ -87,13 +124,7 @@ export const getInitialsFromName = (name: string | null, empty: string = 'U'): s
 export const formatPhoneNumber = (
   phone: string | null,
   defaultCountry: CountryCode = 'US'
-): string | null => {
-  if (!phone) return null
-
-  const parsed = parsePhoneNumberFromString(phone.trim(), defaultCountry)
-
-  return parsed?.isValid() ? parsed.number : null
-}
+): string | null => parseValidPhone(phone, defaultCountry)?.number ?? null
 
 /** ISO-3166 region a national (no `+`) phone number is parsed against. */
 export type PhoneRegion = CountryCode

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -29,6 +29,7 @@ export {
   getInitials,
   getInitialsFromName,
   type PhoneRegion,
+  parseValidPhone,
   regionFromIdentifier,
 } from './contact'
 // Counter utilities


### PR DESCRIPTION
Follow-up to #1669, from review feedback there. Two of the three overlaps named in that comment turned out not to be real, but the underlying concern held for something nobody had named — and it was hiding an actual silent-failure mode.

## What did not overlap

**`region` is a name collision, not a duplicate implementation.** `regionFromIdentifier` returns `PhoneRegion = CountryCode` (`'US'`, `'DE'`) — a *parsing default*, taken from the sending channel's own number. `PhoneGeo.region` is a geographic state/province name (`'California'`, `'Ontario'`), and it is named after the seeded contact `region` field from entity migration 023, which predates both PRs. Nothing to converge; documented instead.

**`lookupPhoneGeo` was not re-implementing `formatPhoneNumber`.** It needs the parsed object's `countryCallingCode`, `nationalNumber` and `country` to walk the numbering-plan prefix ladder. `formatPhoneNumber` returns the E.164 *string* and discards exactly that, so routing through it would mean parsing twice.

## What did overlap

**parse + `isValid()`, at three sites** — `formatPhoneNumber`, `phoneSearchPatterns` and `lookupPhoneGeo`. Each needs a different part of the result, which is precisely why none could reuse `formatPhoneNumber`.

`parseValidPhone(phone, region): PhoneNumber | null` in `@auxx/utils/contact` is now that gate, returning the parsed object. `formatPhoneNumber` becomes a one-liner over it, so "valid" cannot drift between the write path, search and enrichment.

For the record, the comment's "third implementation" framing undercounted: six non-test sites call `parsePhoneNumberFromString` directly, and four predate both PRs.

**Deliberately not converged** — the two display formatters (`field-values/converters/phone.ts`, the composer's `identifier-model.ts`) omit `isValid()` on purpose: they format whatever parses and fall back to the raw string. Gating them on validity would stop them rendering already-stored legacy values. `regionFromIdentifier` likewise omits it on purpose — it wants a country even from a partially valid channel number.

## The real catch

`lookupPhoneGeo` defaulted to `region = 'US'`. `regionFromIdentifier`'s own doc carries a 🔴 warning that this fails **silently**: E.164 drops the trunk prefix, so Berlin's `030 901820` parsed as US does not error — it yields a plausible answer for a number the caller never meant.

For a function whose entire output is a claim about *where a number is from*, that is a confidently wrong city written onto a contact. National input without an explicit region now returns `null`. E.164 is self-describing and needs no region, which is every production caller — the hook and the backfill both read `FieldValue`, already normalized by `fieldValueSchemas.phone`.

```ts
lookupPhoneGeo('+13102030000')            // Los Angeles, California  — E.164, no region needed
lookupPhoneGeo('(310) 203-0000', 'US')    // Los Angeles, California  — explicit region
lookupPhoneGeo('(310) 203-0000')          // null — refuses to guess
lookupPhoneGeo('030 901820', 'DE')        // Germany — same digits, different country
```

## Verification

- `parseValidPhone` gets its own tests, including one asserting it agrees with `formatPhoneNumber` on every verdict.
- `lookupPhoneGeo`'s stricter contract is pinned both ways: refuses to guess, and parses the same national input differently per region.
- `phone-query.test.ts` (15 tests) passes **unchanged**, which is the evidence the refactor is behaviour-preserving.
- utils 201/201; phone-geo + participants/search 69/69. Typecheck clean for utils, lib and web; Biome clean.

Pre-existing on main and untouched here: 4 lib suites failing on a full-replacement `vi.mock('@auxx/redis')` that omits `createCredentialLockProvider`, plus a flaky `workflow-draft-cas` test that passes 3/3 in isolation.
