### PR TITLE
fix(composer): keep the composer mounted across every display-mode swap

### DIFF
--- a/apps/web/src/components/mail/email-editor/floating-compose.test.tsx
+++ b/apps/web/src/components/mail/email-editor/floating-compose.test.tsx
@@ -1,0 +1,195 @@
+// apps/web/src/components/mail/email-editor/floating-compose.test.tsx
+//
+// Minimize is presentation, not teardown. The composer holds recipients, body,
+// attachments and the Cc/Bcc disclosure in its own `useState` and mirrors none
+// of it onto the store instance — so a minimize that swapped the editor out for
+// the bar was a silent "clear the To field", and maximize had nothing to restore
+// from (autosave refuses the first save until the body is non-empty, and the
+// draft id it eventually learns never reaches the store).
+
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { act, useEffect, useState } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useComposeStore } from '../store/compose-store'
+
+const h = vi.hoisted(() => ({ mounts: 0 }))
+
+/**
+ * Stands in for the whole composer. The uncontrolled input IS the thing under
+ * test: local state that only survives if the component is never unmounted.
+ */
+vi.mock('./index', () => ({
+  default: () => {
+    const [value, setValue] = useState('')
+    useEffect(() => {
+      h.mounts++
+    }, [])
+    return (
+      <input
+        data-testid='recipients'
+        aria-label='recipients'
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    )
+  },
+}))
+
+vi.mock('../chat-panel', () => ({ ChatPanel: () => null }))
+vi.mock('../chat-composer', () => ({ default: () => null }))
+vi.mock('~/components/channels/hooks/use-channels', () => ({ useChannel: () => undefined }))
+vi.mock('./hooks/use-draft', () => ({ useDraft: () => ({ draft: null, isLoading: false }) }))
+
+const { FloatingCompose } = await import('./floating-compose')
+
+/** The store-driven render loop, same shape as `FloatingComposeRoot`. */
+function Harness() {
+  const instances = useComposeStore((s) => s.instances)
+  return (
+    <>
+      {instances.map((instance) => (
+        <FloatingCompose key={instance.id} instance={instance} />
+      ))}
+    </>
+  )
+}
+
+beforeEach(() => {
+  h.mounts = 0
+  useComposeStore.setState({ instances: [], nextZIndex: 101 })
+})
+
+async function openFloatingCompose() {
+  const id = useComposeStore.getState().open({ mode: 'new', displayMode: 'floating' })
+  render(<Harness />)
+  // Floating instances defer the editor mount by 200ms.
+  await waitFor(() => expect(screen.getByLabelText('recipients')).toBeInTheDocument())
+  return id
+}
+
+const TARGET_ID = 'reply-portal-t1'
+
+/**
+ * Open a docked composer the way `useCompose.openInline` does: the thread has
+ * already committed its target div, THEN the instance is opened and docked. That
+ * order is why the target lookup can be a plain render-time `getElementById`.
+ */
+function openInlineCompose() {
+  render(
+    <>
+      <div id={TARGET_ID} />
+      <Harness />
+    </>
+  )
+  let id = ''
+  act(() => {
+    id = useComposeStore.getState().open({
+      mode: 'reply',
+      thread: { id: 't1' } as never,
+      displayMode: 'inline',
+    })
+    useComposeStore.getState().dock(id, TARGET_ID)
+  })
+  return id
+}
+
+const target = () => document.getElementById(TARGET_ID) as HTMLElement
+const composer = () => screen.getByLabelText('recipients')
+/** The wrapper whose class carries the docked/floating presentation. */
+const wrapper = () => composer().parentElement as HTMLElement
+
+describe('FloatingCompose — minimize', () => {
+  it('keeps the composer mounted, and its state, across minimize and maximize', async () => {
+    const id = await openFloatingCompose()
+    await userEvent.type(screen.getByLabelText('recipients'), 'jane@corp.com')
+
+    act(() => useComposeStore.getState().minimize(id))
+    expect(screen.getByText('New Message')).toBeInTheDocument()
+
+    act(() => useComposeStore.getState().maximize(id))
+
+    expect(screen.getByLabelText('recipients')).toHaveValue('jane@corp.com')
+    // One mount for the whole round trip — a second would mean the editor was
+    // torn down and re-derived from the store instance's stale props.
+    expect(h.mounts).toBe(1)
+  })
+
+  it('hides the mounted composer behind the bar', async () => {
+    const id = await openFloatingCompose()
+
+    act(() => useComposeStore.getState().minimize(id))
+
+    // Still in the tree, out of view: `display: none` takes it out of layout and
+    // out of the tab order without touching its state.
+    expect(wrapper()).toHaveClass('hidden')
+  })
+
+  it('closing from the bar tears it down', async () => {
+    const id = await openFloatingCompose()
+    act(() => useComposeStore.getState().minimize(id))
+
+    await userEvent.click(screen.getByRole('button'))
+
+    expect(useComposeStore.getState().instances).toEqual([])
+    expect(screen.queryByLabelText('recipients')).not.toBeInTheDocument()
+  })
+})
+
+// Pop-out and dock-back used to swap `createPortal(el, target)` for a
+// `<motion.div>` — different element types at the same tree position, so React
+// remounted the composer and cleared it exactly as minimize did. Now there is one
+// portal host per instance and the DOM node is MOVED between parents, which React
+// cannot see.
+describe('FloatingCompose — pop-out and dock-back', () => {
+  it('renders a docked composer inside the thread target', () => {
+    openInlineCompose()
+
+    expect(target().contains(composer())).toBe(true)
+    // No fixed positioning while docked — it is a block in the thread's flow.
+    expect(wrapper()).not.toHaveClass('fixed')
+  })
+
+  it('keeps the composer mounted, and its state, across pop-out and dock-back', async () => {
+    const id = openInlineCompose()
+    await userEvent.type(composer(), 'jane@corp.com')
+
+    act(() => useComposeStore.getState().undock(id))
+
+    expect(target().contains(composer())).toBe(false)
+    // input → wrapper → host, and the host is parked on the body.
+    expect(wrapper().parentElement?.parentElement).toBe(document.body)
+    expect(wrapper()).toHaveClass('fixed')
+    expect(composer()).toHaveValue('jane@corp.com')
+
+    act(() => useComposeStore.getState().dock(id, TARGET_ID))
+
+    expect(target().contains(composer())).toBe(true)
+    expect(wrapper()).not.toHaveClass('fixed')
+    expect(composer()).toHaveValue('jane@corp.com')
+    // One mount across both moves. This is the whole point of the stable host.
+    expect(h.mounts).toBe(1)
+  })
+
+  it('keeps the caret in the field the user was typing in', async () => {
+    const id = openInlineCompose()
+    await userEvent.type(composer(), 'jane@corp.com')
+    expect(composer()).toHaveFocus()
+
+    act(() => useComposeStore.getState().undock(id))
+
+    // A DOM move is remove + insert, which blurs the active element — popping out
+    // mid-address must not drop the user out of the field.
+    expect(composer()).toHaveFocus()
+    expect((composer() as HTMLInputElement).selectionStart).toBe('jane@corp.com'.length)
+  })
+
+  it('takes its host with it when the instance closes', () => {
+    const id = openInlineCompose()
+
+    act(() => useComposeStore.getState().close(id))
+
+    expect(target().childElementCount).toBe(0)
+    expect(screen.queryByLabelText('recipients')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/mail/email-editor/floating-compose.tsx
+++ b/apps/web/src/components/mail/email-editor/floating-compose.tsx
@@ -6,7 +6,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import { Loader2, Minus, X } from 'lucide-react'
 import { motion, useDragControls, useMotionValue } from 'motion/react'
 import type React from 'react'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useChannel } from '~/components/channels/hooks/use-channels'
 import ChatComposer from '../chat-composer'
@@ -52,6 +52,48 @@ function MinimizedBar({
   )
 }
 
+/**
+ * Capture what the browser is about to throw away, and return the undo.
+ *
+ * Re-parenting the host is `remove` + `insert`, and a removed node loses focus
+ * and takes the caret with it — so popping out mid-sentence would drop the user
+ * out of the field they were typing in. Everything captured here (the focused
+ * node, an input's selection range, a contenteditable's DOM Range) references
+ * nodes that the move preserves, so restoring is just re-pointing at them.
+ *
+ * Only ever fires for focus INSIDE the host: a move must not steal focus from
+ * whatever else the user happened to be in.
+ */
+function preserveFocusAcrossMove(host: HTMLElement): () => void {
+  const active = document.activeElement as HTMLElement | null
+  if (!active || !host.contains(active)) return () => {}
+
+  const input =
+    active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement ? active : null
+  const start = input?.selectionStart ?? null
+  const end = input?.selectionEnd ?? null
+  // Tiptap's body is a contenteditable, so its caret is a DOM Range, not an
+  // input selection. Cloned because the live Range is collapsed by the removal.
+  const selection = window.getSelection()
+  const range =
+    !input && selection && selection.rangeCount > 0 ? selection.getRangeAt(0).cloneRange() : null
+
+  return () => {
+    // preventScroll — the composer is 480px of fixed-position UI, and scrolling
+    // the thread underneath to "reveal" it is never what the user asked for.
+    active.focus({ preventScroll: true })
+    if (input && start !== null && end !== null) {
+      input.setSelectionRange(start, end)
+      return
+    }
+    if (range) {
+      const next = window.getSelection()
+      next?.removeAllRanges()
+      next?.addRange(range)
+    }
+  }
+}
+
 /** Per-instance floating compose wrapper — handles portal vs fixed positioning, drag, minimize */
 export function FloatingCompose({ instance }: { instance: ComposeInstance }) {
   const close = useComposeStore((s) => s.close)
@@ -67,6 +109,28 @@ export function FloatingCompose({ instance }: { instance: ComposeInstance }) {
   const dragControls = useDragControls()
   const dragX = useMotionValue(0)
   const dragY = useMotionValue(0)
+
+  /**
+   * ONE portal container for this instance's whole life, moved between parents
+   * rather than swapped out — the fix for pop-out and dock-back clearing the
+   * composer.
+   *
+   * `createPortal` keys off the container's *identity*, not its position in the
+   * document, so moving this node is invisible to React and nothing unmounts.
+   * `appendChild` MOVES existing DOM rather than recreating it, so Tiptap's
+   * document and undo history, in-flight uploads, and every `useState` in the
+   * composer (recipients above all — they are mirrored nowhere) come along.
+   *
+   * 🔴 Do not go back to `createPortal(el, target)` in one branch and a
+   * `<motion.div>` in another. Those are different element types at the same
+   * tree position, so React tears the composer down and re-derives it from the
+   * store instance's props — which never learned anything the user typed.
+   */
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  if (hostRef.current === null && typeof document !== 'undefined') {
+    hostRef.current = document.createElement('div')
+  }
+  const host = hostRef.current
 
   // Deferred editor mount for floating/minimized (same pattern as NewMessageDialog)
   const [editorMounted, setEditorMounted] = useState(instance.displayMode === 'inline')
@@ -118,6 +182,29 @@ export function FloatingCompose({ instance }: { instance: ComposeInstance }) {
       dock(instance.id, portalTargetId)
     }
   }, [dock, instance.id, portalTargetId])
+
+  // Read during render, exactly as the old portal branch did: by the time an
+  // inline instance exists, thread-details has already committed the target div
+  // (it opens the instance from an effect, after that render), and dock-back only
+  // fires for a target `canDockBack` just saw. A miss therefore means the target
+  // is GONE — navigated away — and the composer presents as floating, which is
+  // the same fallback as before, now a className swap instead of a remount.
+  const inlineTarget =
+    instance.displayMode === 'inline' && instance.portalTargetId
+      ? document.getElementById(instance.portalTargetId)
+      : null
+
+  useLayoutEffect(() => {
+    if (!host) return
+    const parent = inlineTarget ?? document.body
+    if (host.parentElement === parent) return
+    const restoreFocus = preserveFocusAcrossMove(host)
+    parent.appendChild(host)
+    restoreFocus()
+  }, [host, inlineTarget])
+
+  // The host is ours, so it is ours to take with us.
+  useEffect(() => () => host?.remove(), [host])
 
   const showLoading =
     !editorMounted || (instance.mode === 'draft' && instance.draft?.id && isDraftLoading)
@@ -177,61 +264,78 @@ export function FloatingCompose({ instance }: { instance: ComposeInstance }) {
     />
   )
 
-  // INLINE MODE — portal into the target DOM node
-  if (instance.displayMode === 'inline' && instance.portalTargetId) {
-    const target = document.getElementById(instance.portalTargetId)
-    if (target) {
-      return createPortal(editorElement, target)
-    }
-    // Target not found (navigated away?) — fall through to floating
-  }
+  // MINIMIZED MODE — the bar renders *beside* the editor, never instead of it.
+  //
+  // Swapping the tree for the bar unmounted the composer and took all of its
+  // local state with it: recipients above all, which live only in
+  // ReplyComposeEditor's `useState` and are mirrored nowhere. Nothing could
+  // restore them on maximize either — autosave refuses the first save until the
+  // body is non-empty, and even after a save the new draft id lands in the
+  // editor's own state, not on the store instance the remount reads from. So a
+  // minimize was a silent "clear the To field".
+  //
+  // Keeping it mounted under `display: none` preserves the body, attachments,
+  // Cc/Bcc disclosure and the Tiptap selection with it, and costs nothing:
+  // a hidden subtree lays out nothing and takes no pointer events.
+  const isMinimized = instance.displayMode === 'minimized'
+  const minimizedBar = isMinimized ? (
+    <MinimizedBar
+      instance={instance}
+      stackIndex={instances
+        .filter((i) => i.displayMode === 'minimized')
+        .findIndex((i) => i.id === instance.id)}
+      onMaximize={() => maximize(instance.id)}
+      onClose={handleClose}
+    />
+  ) : null
 
-  // MINIMIZED MODE
-  if (instance.displayMode === 'minimized') {
-    const minimizedInstances = instances.filter((i) => i.displayMode === 'minimized')
-    const stackIndex = minimizedInstances.findIndex((i) => i.id === instance.id)
-    return (
-      <MinimizedBar
-        instance={instance}
-        stackIndex={stackIndex}
-        onMaximize={() => maximize(instance.id)}
-        onClose={handleClose}
-      />
-    )
-  }
-
-  // FLOATING MODE — fixed position, draggable
+  // Docked, the composer is a plain block in the thread's flow; undocked it is a
+  // fixed, draggable panel. Same element either way — only the class changes.
   const floatingWidthClass = isChat
     ? 'fixed w-[min(380px,calc(100vw-32px))]'
     : 'fixed w-[min(480px,calc(100vw-32px))]'
-  return (
-    <motion.div
-      className={floatingWidthClass}
-      style={{
-        bottom: `calc(16px + ${instance.position.y}px)`,
-        right: `calc(16px + ${instance.position.x}px)`,
-        zIndex: instance.zIndex,
-        x: dragX,
-        y: dragY,
-      }}
-      drag
-      dragControls={dragControls}
-      dragListener={false}
-      dragMomentum={false}
-      dragElastic={0}
-      onDragEnd={() => {
-        // Bake drag offset into stored position, then reset motion transform
-        const dx = dragX.get()
-        const dy = dragY.get()
-        dragX.jump(0)
-        dragY.jump(0)
-        updatePosition(instance.id, {
-          x: instance.position.x - dx,
-          y: instance.position.y - dy,
-        })
-      }}
-      onPointerDown={() => bringToFront(instance.id)}>
-      {editorElement}
-    </motion.div>
+  const isDocked = !!inlineTarget
+
+  if (!host) return null
+
+  return createPortal(
+    <>
+      {minimizedBar}
+      <motion.div
+        className={cn(!isDocked && floatingWidthClass, isMinimized && 'hidden')}
+        style={{
+          bottom: `calc(16px + ${instance.position.y}px)`,
+          right: `calc(16px + ${instance.position.x}px)`,
+          zIndex: instance.zIndex,
+          x: dragX,
+          y: dragY,
+        }}
+        // Docked, this element is inside the thread's scroll container, and motion
+        // stamps `touch-action: none` on anything draggable — which would eat
+        // touch scrolling over the composer. It has no drag handle when docked
+        // anyway (`dragHandleProps` is floating-only).
+        drag={!isDocked}
+        dragControls={dragControls}
+        dragListener={false}
+        dragMomentum={false}
+        dragElastic={0}
+        onDragEnd={() => {
+          // Bake drag offset into stored position, then reset motion transform
+          const dx = dragX.get()
+          const dy = dragY.get()
+          dragX.jump(0)
+          dragY.jump(0)
+          updatePosition(instance.id, {
+            x: instance.position.x - dx,
+            y: instance.position.y - dy,
+          })
+        }}
+        // Stacking order is a floating-window concern; a docked composer has no
+        // siblings to be behind, and raising it on every click is a store write.
+        onPointerDown={isDocked ? undefined : () => bringToFront(instance.id)}>
+        {editorElement}
+      </motion.div>
+    </>,
+    host
   )
 }

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -132,6 +132,7 @@ function ReplyComposeEditorComponent({
     instanceId ? (s.instances.find((i) => i.id === instanceId)?.pendingFocus ?? false) : false
   )
   const clearPendingFocus = useComposeStore((s) => s.clearPendingFocus)
+  const recordSavedDraft = useComposeStore((s) => s.recordSavedDraft)
 
   // Auto-focus editor when opened via reply action (not draft auto-open)
   useEffect(() => {
@@ -452,10 +453,12 @@ function ReplyComposeEditorComponent({
     onDeleteMutate: (draftId) => {
       // Clear local draft state immediately (optimistic update)
       setState((prev) => ({ ...prev, draftId: null }))
+      if (instanceId) recordSavedDraft(instanceId, null)
     },
     onDeleteError: (error, draftId) => {
       // Rollback on error
       setState((prev) => ({ ...prev, draftId }))
+      if (instanceId) recordSavedDraft(instanceId, draftId)
       // Error toast is handled by the hook
     },
   })
@@ -661,6 +664,11 @@ function ReplyComposeEditorComponent({
         }
         return { ...prev, draftId, threadId: nextThreadId }
       })
+      // Tell the store which draft this composer now owns, so opening that draft
+      // from the drafts list raises THIS window instead of opening a second one
+      // onto the same draft (`findByDraft`). Not written into the instance's
+      // `draft` — see the note on `savedDraftId`.
+      if (instanceId) recordSavedDraft(instanceId, draftId)
       setIsDraftSaved(true)
     },
     onCacheSync: ({ threadId, draftData }) => {},
@@ -1419,6 +1427,7 @@ function ReplyComposeEditorComponent({
                     ref={toInputRef}
                     recipientModel={platformCaps?.recipientModel}
                     defaultRegion={phoneRegion}
+                    supportsCcBcc={showCcBccToggle}
                     field='TO'
                     recipients={recipients.TO}
                     onAdd={(r) => upsertRecipient('TO', r)}
@@ -1476,6 +1485,7 @@ function ReplyComposeEditorComponent({
                       ref={ccInputRef}
                       recipientModel={platformCaps?.recipientModel}
                       defaultRegion={phoneRegion}
+                      supportsCcBcc={showCcBccToggle}
                       field='CC'
                       recipients={recipients.CC}
                       onAdd={(r) => upsertRecipient('CC', r)}
@@ -1513,6 +1523,7 @@ function ReplyComposeEditorComponent({
                       ref={bccInputRef}
                       recipientModel={platformCaps?.recipientModel}
                       defaultRegion={phoneRegion}
+                      supportsCcBcc={showCcBccToggle}
                       field='BCC'
                       recipients={recipients.BCC}
                       onAdd={(r) => upsertRecipient('BCC', r)}

--- a/apps/web/src/components/mail/email-editor/recipient-input.test.tsx
+++ b/apps/web/src/components/mail/email-editor/recipient-input.test.tsx
@@ -14,6 +14,7 @@ import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { PhoneRegion } from './identifier-model'
+import type { RecipientField } from './recipient-input'
 
 interface CandidateStub {
   identifier: string
@@ -596,6 +597,82 @@ describe('RecipientBadge — other addresses', () => {
     expect(screen.queryByText('Other addresses')).not.toBeInTheDocument()
     // The rest of the menu is untouched.
     expect(screen.getByRole('menuitem', { name: /Copy 'typed@x\.com'/ })).toBeInTheDocument()
+  })
+})
+
+// The chip menu's "Move to Cc/Bcc" rows against `PlatformCapabilities.ccBcc`.
+// SMS/FB/IG have one recipient list, so the header hides the Cc/Bcc toggles —
+// but the menu offered the move anyway, and moving a recipient into a field
+// nothing renders and no send reads is how a recipient silently disappears.
+describe('RecipientBadge — moving between fields', () => {
+  const chip = {
+    id: 'chip-1',
+    identifier: 'jane@corp.com',
+    identifierType: 'EMAIL' as const,
+    recordId: 'c1',
+  }
+
+  function renderField(supportsCcBcc: boolean | undefined, field: RecipientField = 'TO') {
+    return render(
+      <RecipientInput
+        recipients={[chip] as never}
+        field={field}
+        onAdd={vi.fn()}
+        onRemove={vi.fn()}
+        onMoveTo={vi.fn()}
+        onSwitchIdentifier={vi.fn()}
+        onContactSelect={vi.fn()}
+        placeholder='To'
+        supportsCcBcc={supportsCcBcc}
+      />
+    )
+  }
+
+  async function openChipMenu() {
+    await userEvent.click(screen.getByRole('option', { name: 'Recipient: jane@corp.com' }))
+    return screen.findByRole('menu')
+  }
+
+  it('offers Cc and Bcc on an email channel', async () => {
+    renderField(true)
+
+    await openChipMenu()
+
+    expect(screen.getByRole('menuitem', { name: 'Move to Cc' })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Move to Bcc' })).toBeInTheDocument()
+  })
+
+  it('defaults to offering them — an unresolved channel is an email channel', async () => {
+    renderField(undefined)
+
+    await openChipMenu()
+
+    expect(screen.getByRole('menuitem', { name: 'Move to Cc' })).toBeInTheDocument()
+  })
+
+  it('offers neither on a channel without carbon copies', async () => {
+    renderField(false)
+
+    await openChipMenu()
+
+    expect(screen.queryByRole('menuitem', { name: /Move to/ })).not.toBeInTheDocument()
+    // The rest of the menu still stands — this gates two rows, not the menu.
+    expect(screen.getByRole('menuitem', { name: /Copy 'jane@corp\.com'/ })).toBeInTheDocument()
+  })
+
+  it('drops the separator the move rows were under, not just the rows', async () => {
+    h.contactIdentifiers = [
+      { identifier: 'jane@corp.com', identifierType: 'EMAIL', onRecord: true, rank: 0 },
+      { identifier: 'j.smith@corp.com', identifierType: 'EMAIL', onRecord: true, rank: 1 },
+    ]
+    renderField(false)
+
+    const menu = await openChipMenu()
+
+    // "Other addresses" is present, so the section renders — and its closing
+    // separator would otherwise dangle at the bottom of the menu.
+    expect(screen.getByText('Other addresses')).toBeInTheDocument()
+    expect(within(menu).getAllByRole('separator')).toHaveLength(1)
   })
 })
 

--- a/apps/web/src/components/mail/email-editor/recipient-input.tsx
+++ b/apps/web/src/components/mail/email-editor/recipient-input.tsx
@@ -114,6 +114,18 @@ interface RecipientInputProps {
    * Ignored by the email model.
    */
   defaultRegion?: PhoneRegion
+  /**
+   * Whether the selected channel carries carbon copies at all
+   * (`PlatformCapabilities.ccBcc`). False on SMS, FB, IG — every channel whose
+   * envelope has one recipient list — and it must gate the chip menu's "Move to
+   * Cc/Bcc" rows, not just the header's Cc/Bcc toggles: the move writes a
+   * recipient into a field the composer never renders and the send never reads,
+   * so the recipient silently disappears.
+   *
+   * Absent → true, which is email, the model for every caller without resolved
+   * capabilities.
+   */
+  supportsCcBcc?: boolean
 }
 
 const FIELD_LABELS: Record<RecipientField, string> = { TO: 'To', CC: 'Cc', BCC: 'Bcc' }
@@ -166,6 +178,7 @@ function RecipientBadge({
   highlightedIndex,
   disabled,
   field,
+  supportsCcBcc = true,
   onRemove,
   onMoveTo,
   onSwitchIdentifier,
@@ -189,6 +202,8 @@ function RecipientBadge({
   highlightedIndex: number | null
   disabled?: boolean
   field: RecipientField
+  /** See {@link RecipientInputProps.supportsCcBcc} — gates the move rows. */
+  supportsCcBcc?: boolean
   onRemove: (id: string) => void
   onMoveTo: (id: string, target: RecipientField) => void
   onSwitchIdentifier: (
@@ -208,6 +223,11 @@ function RecipientBadge({
   const displayIdentifier = spec.formatDisplay(person.identifier)
   const displayName = person.name ?? displayIdentifier
   const isHighlighted = highlightedIndex === index
+  /**
+   * On a channel without carbon copies this is empty, and the menu ends after
+   * the addresses — a Cc that cannot be sent must not be offerable.
+   */
+  const moveTargets = ALL_FIELDS.filter((f) => f !== field && (supportsCcBcc || f === 'TO'))
 
   /**
    * The contact's other addresses, fetched ON OPEN.
@@ -386,10 +406,10 @@ function RecipientBadge({
                 ))}
               </DropdownMenuSubContent>
             </DropdownMenuSub>
-            <DropdownMenuSeparator />
+            {moveTargets.length > 0 && <DropdownMenuSeparator />}
           </>
         )}
-        {ALL_FIELDS.filter((f) => f !== field).map((target) => (
+        {moveTargets.map((target) => (
           <DropdownMenuItem key={target} onSelect={() => onMoveTo(person.id, target)}>
             <Mail />
             Move to {FIELD_LABELS[target]}
@@ -414,6 +434,7 @@ export function RecipientInput({
   popoverClassName,
   recipientModel,
   defaultRegion = DEFAULT_PHONE_REGION,
+  supportsCcBcc = true,
 }: RecipientInputProps) {
   const spec = useMemo(
     () => getIdentifierModel(recipientModel, defaultRegion),
@@ -690,6 +711,7 @@ export function RecipientInput({
           highlightedIndex={highlightedIndex}
           disabled={disabled}
           field={field}
+          supportsCcBcc={supportsCcBcc}
           onRemove={(id) => {
             onRemove(id)
             setHighlightedIndex(null)

--- a/apps/web/src/components/mail/store/compose-store.ts
+++ b/apps/web/src/components/mail/store/compose-store.ts
@@ -25,11 +25,31 @@ export interface ComposeInstance {
   zIndex: number
   subject: string
   pendingFocus: boolean
+  /**
+   * The draft this composer has autosaved into, which is how {@link
+   * ComposeStore.findByDraft} recognises it. A composer opened as `mode: 'new'`
+   * or `'reply'` creates its draft *while open*, and that id only ever lived in
+   * the editor's own state — so opening the same draft from the drafts list
+   * matched nothing and opened a SECOND composer onto it.
+   *
+   * 🔴 Deliberately NOT written into `draft`. That field is the editor's
+   * `initialDraft` prop, and the editor re-derives its entire state (recipients,
+   * body, attachments) whenever the prop's id changes — pushing a freshly-saved
+   * id back in would wipe the draft the user is still typing.
+   */
+  savedDraftId: string | null
 }
 
 type OpenConfig = Omit<
   ComposeInstance,
-  'id' | 'displayMode' | 'portalTargetId' | 'position' | 'zIndex' | 'subject' | 'pendingFocus'
+  | 'id'
+  | 'displayMode'
+  | 'portalTargetId'
+  | 'position'
+  | 'zIndex'
+  | 'subject'
+  | 'pendingFocus'
+  | 'savedDraftId'
 > & {
   displayMode?: DisplayMode
   pendingFocus?: boolean
@@ -49,6 +69,8 @@ interface ComposeStore {
   bringToFront: (id: string) => void
   updatePosition: (id: string, position: { x: number; y: number }) => void
   updateSubject: (id: string, subject: string) => void
+  /** Record the draft autosave just wrote (or `null` when it was deleted). */
+  recordSavedDraft: (id: string, draftId: string | null) => void
   dock: (id: string, portalTargetId: string) => void
   undock: (id: string) => void
   clearPendingFocus: (id: string) => void
@@ -99,6 +121,7 @@ export const useComposeStore = create<ComposeStore>((set, get) => ({
       subject:
         config.draft?.subject || config.presetValues?.subject || config.thread?.subject || '',
       pendingFocus: config.pendingFocus ?? false,
+      savedDraftId: null,
     }
 
     console.log('[ComposeStore] open', id, instance.displayMode, instance.mode)
@@ -158,6 +181,14 @@ export const useComposeStore = create<ComposeStore>((set, get) => ({
     }))
   },
 
+  recordSavedDraft: (id, draftId) => {
+    set((state) => ({
+      instances: state.instances.map((i) =>
+        i.id === id && i.savedDraftId !== draftId ? { ...i, savedDraftId: draftId } : i
+      ),
+    }))
+  },
+
   dock: (id, portalTargetId) => {
     set((state) => ({
       instances: state.instances.map((i) =>
@@ -194,6 +225,6 @@ export const useComposeStore = create<ComposeStore>((set, get) => ({
   },
 
   findByDraft: (draftId) => {
-    return get().instances.find((i) => i.draft?.id === draftId)
+    return get().instances.find((i) => i.draft?.id === draftId || i.savedDraftId === draftId)
   },
 }))


### PR DESCRIPTION
## The bug

Minimizing the composer emptied the recipients list. So did popping it out and docking it back.

`ComposeInstance` stores only `displayMode`, `position`, `zIndex`, `subject`. Everything the user typed — recipients, body, attachments, the Cc/Bcc disclosure, quick actions — lives in `ReplyComposeEditor`'s own `useState`. Every display-mode change swapped the React tree for a **different element type** at the same position, so the editor unmounted and took all of it:

- minimize returned `<MinimizedBar/>` *instead of* the editor;
- inline vs floating swapped `createPortal(el, target)` for `<motion.div>`.

And nothing could restore it. Autosave refuses the first save until the *body* is non-empty (`buildFirstKey`), so a recipients-only compose was never persisted at all; even after a save, `onSaved` writes the new draft id into the editor's own state, never onto the store instance a remount re-derives from. A minimize was a silent "clear the To field".

## The fix

**Minimize** — the bar renders *beside* the editor, and the floating wrapper takes `hidden`. Mounted, out of layout, out of the tab order, state intact.

**Pop-out / dock-back** — one portal host per instance, created once, and the DOM node is *moved* between the thread's target div and `document.body`:

```
input → motion.div (class swap: fixed+width vs plain block) → host (re-parented) → target | body
```

`createPortal` keys off the container's identity, not its position in the document, so the move is invisible to React; `appendChild` moves existing DOM rather than recreating it. Tiptap's document and undo history, in-flight uploads and every `useState` come along.

Supporting details:

- **Caret preservation** (`preserveFocusAcrossMove`) — a re-parent is remove+insert, which blurs the active element. The focused node plus either the input's selection range or the contenteditable's cloned DOM Range are captured and restored with `focus({ preventScroll: true })`. Covered by a test that fails without it.
- **`drag={!isDocked}`** — motion stamps `touch-action: none` on draggables, which would have eaten touch scrolling over a docked composer inside the thread's `ScrollArea`. It has no drag handle when docked anyway.
- **`bringToFront` only when floating** — otherwise every click in a docked composer was a store write.
- The inline target is still read during render, as the old branch did. A miss means the target is *gone* (navigated away) and it presents as floating — same fallback as before, now a class swap instead of a remount.

## Two related bugs, same area

**"Move to Cc/Bcc" on channels with no carbon copies.** The chip menu built its move rows from a bare `ALL_FIELDS.filter(f => f !== field)` — capabilities never reached it. On SMS/FB/IG the move wrote a recipient into a field the header doesn't render and no send reads, so the recipient vanished while staying in the payload. Now gated on `PlatformCapabilities.ccBcc` via a `supportsCcBcc` prop (defaults true = email), with the section separator dropped alongside the rows. This closes the last hole in that class — `reconcileDraftForChannel` already clears Cc/Bcc wholesale on an email→SMS From switch.

**A second composer onto the same draft.** Nothing ever told the store which draft a composer had autosaved into, so `findByDraft` (matching `i.draft?.id`) missed it and clicking that draft in the list opened a duplicate editor. New `savedDraftId` field + `recordSavedDraft` action, written from `onSaved` and cleared/rolled back on the delete paths.

Deliberately **not** written into `instance.draft`: that field is the editor's `initialDraft` prop, and the editor re-derives its entire state whenever the prop's id changes — pushing a freshly-saved id back in would wipe the draft being typed.

## Testing

- New `floating-compose.test.tsx` (7): docked placement, state + mount-count across pop-out → dock-back, caret retention, host teardown, and the three minimize cases. The mount counter is the real assertion — one mount for the whole round trip.
- 4 new cases in `recipient-input.test.tsx` for the move rows.
- Full `src/components/mail` suite: 204 passing.
- Typecheck ratchet: no new errors in any file touched here.

## Not covered

Chat threads still lose composer text on pop-out — `editorElement` swaps `ChatComposer` (docked) for `ChatPanel` (floating), genuinely different components, so that subtree remounts regardless of the stable host. Separate piece of work.
