### PR TITLE
fix(chat): keep the chat composer mounted when a chat thread pops out

### DIFF
--- a/apps/web/src/components/mail/chat-panel/chat-panel.test.tsx
+++ b/apps/web/src/components/mail/chat-panel/chat-panel.test.tsx
@@ -1,0 +1,91 @@
+// apps/web/src/components/mail/chat-panel/chat-panel.test.tsx
+//
+// Docked and undocked are ONE component with conditional chrome, not two
+// components. `FloatingCompose` used to choose between `<ChatPanel>` and a bare
+// `<ChatComposer>` — different element types at the same tree position — so
+// popping a chat out remounted the composer and destroyed its Tiptap editor
+// along with whatever the agent had typed.
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useEffect, useState } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({ mounts: 0 }))
+
+/** Stands in for the composer: local state that only survives a re-render. */
+vi.mock('../chat-composer', () => ({
+  default: ({ hideHeader }: { hideHeader?: boolean }) => {
+    const [value, setValue] = useState('')
+    useEffect(() => {
+      h.mounts++
+    }, [])
+    return (
+      <div>
+        {!hideHeader && <span>composer header</span>}
+        <input aria-label='reply' value={value} onChange={(e) => setValue(e.target.value)} />
+      </div>
+    )
+  },
+}))
+
+vi.mock('./header', () => ({
+  ChatPanelHeader: () => <div>panel header</div>,
+}))
+vi.mock('./messages', () => ({
+  ChatPanelMessages: () => <div>message log</div>,
+}))
+
+const { ChatPanel } = await import('./index')
+
+const thread = { id: 't1', integrationId: 'i1' } as never
+
+function renderPanel(expanded: boolean) {
+  return render(
+    <ChatPanel thread={thread} expanded={expanded} onClose={vi.fn()} onSendSuccess={vi.fn()} />
+  )
+}
+
+beforeEach(() => {
+  h.mounts = 0
+})
+
+describe('ChatPanel', () => {
+  it('docked, renders only the composer and its own header', () => {
+    renderPanel(false)
+
+    expect(screen.getByLabelText('reply')).toBeInTheDocument()
+    expect(screen.getByText('composer header')).toBeInTheDocument()
+    // The thread view behind it already shows these.
+    expect(screen.queryByText('panel header')).not.toBeInTheDocument()
+    expect(screen.queryByText('message log')).not.toBeInTheDocument()
+  })
+
+  it('undocked, wraps the composer in the panel chrome', () => {
+    renderPanel(true)
+
+    expect(screen.getByText('panel header')).toBeInTheDocument()
+    expect(screen.getByText('message log')).toBeInTheDocument()
+    // One header, not two — the panel's replaces the composer's.
+    expect(screen.queryByText('composer header')).not.toBeInTheDocument()
+  })
+
+  it('keeps what the agent typed when the chrome appears and disappears', async () => {
+    const { rerender } = renderPanel(false)
+    await userEvent.type(screen.getByLabelText('reply'), 'on my way')
+
+    rerender(
+      <ChatPanel thread={thread} expanded={true} onClose={vi.fn()} onSendSuccess={vi.fn()} />
+    )
+    expect(screen.getByText('panel header')).toBeInTheDocument()
+    expect(screen.getByLabelText('reply')).toHaveValue('on my way')
+
+    rerender(
+      <ChatPanel thread={thread} expanded={false} onClose={vi.fn()} onSendSuccess={vi.fn()} />
+    )
+    expect(screen.getByLabelText('reply')).toHaveValue('on my way')
+    // One mount for the round trip. The conditional chrome holds its slots with
+    // `false`, so the composer never shifts index and React never remounts it.
+    expect(h.mounts).toBe(1)
+  })
+})

--- a/apps/web/src/components/mail/chat-panel/index.tsx
+++ b/apps/web/src/components/mail/chat-panel/index.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/mail/chat-panel/index.tsx
 'use client'
 
+import { cn } from '@auxx/ui/lib/utils'
 import type React from 'react'
 import ChatComposer from '../chat-composer'
 import type { EditorThread } from '../email-editor/types'
@@ -9,7 +10,19 @@ import { ChatPanelMessages } from './messages'
 
 interface ChatPanelProps {
   thread: EditorThread
-  isDialogMode: boolean
+  /**
+   * Undocked: the panel wears its own chrome — window header and the message
+   * log above the composer. Docked, the surrounding thread view already shows
+   * both, so only the composer renders.
+   *
+   * 🔴 This is a flag rather than two call sites on purpose. `FloatingCompose`
+   * used to pick between `<ChatPanel>` and a bare `<ChatComposer>`, which are
+   * different element types at the same tree position — so popping a chat out
+   * remounted the composer, destroying its Tiptap editor along with whatever
+   * the agent had typed and attached. Rendering one component whose chrome is
+   * conditional keeps the composer in a stable slot, and React keeps its state.
+   */
+  expanded: boolean
   onClose: () => void
   onSendSuccess: () => void
   onPopOut?: () => void
@@ -21,17 +34,14 @@ interface ChatPanelProps {
 }
 
 /**
- * Floating chat conversation: header (visitor + window controls),
- * scrollable message log, and the chat composer pinned at the bottom.
+ * The chat surface for one thread: the composer, plus — when undocked — a
+ * header (visitor + window controls) and the scrollable message log above it.
  *
- * Mounted by `FloatingCompose` when the thread is a chat thread AND the
- * compose instance is in floating/minimized mode. Inline (docked) chat
- * still renders just the `ChatComposer` — the surrounding thread view
- * already shows the messages.
+ * Mounted by `FloatingCompose` for every chat thread, docked or not.
  */
 export function ChatPanel({
   thread,
-  isDialogMode,
+  expanded,
   onClose,
   onSendSuccess,
   onPopOut,
@@ -41,26 +51,35 @@ export function ChatPanel({
   dragHandleProps,
 }: ChatPanelProps) {
   return (
-    <div className='relative flex h-[560px] max-h-[calc(100vh-96px)] flex-col bg-gray-300 dark:bg-gray-800 rounded-[20px] border border-transparent shadow-lg'>
-      <ChatPanelHeader
-        threadId={thread.id}
-        isDialogMode={isDialogMode}
-        onClose={onClose}
-        onPopOut={onPopOut}
-        onMinimize={onMinimize}
-        onDockBack={onDockBack}
-        dragHandleProps={dragHandleProps}
-      />
-
-      <ChatPanelMessages threadId={thread.id} popoverClassName='z-[200]' />
-
+    <div
+      className={cn(
+        'relative flex flex-col',
+        expanded &&
+          'h-[560px] max-h-[calc(100vh-96px)] bg-gray-300 dark:bg-gray-800 rounded-[20px] border border-transparent shadow-lg'
+      )}>
+      {/* Both slots stay in place when collapsed — `false` holds the position,
+          so the composer below never shifts index and never remounts. */}
+      {expanded && (
+        <ChatPanelHeader
+          threadId={thread.id}
+          isDialogMode={true}
+          onClose={onClose}
+          onMinimize={onMinimize}
+          onDockBack={onDockBack}
+          dragHandleProps={dragHandleProps}
+        />
+      )}
+      {expanded && <ChatPanelMessages threadId={thread.id} popoverClassName='z-[200]' />}
       <ChatComposer
         thread={thread}
-        isDialogMode={isDialogMode}
+        isDialogMode={expanded}
         onClose={onClose}
         onSendSuccess={onSendSuccess}
+        // Docked, the composer wears the header itself — and it is the only
+        // place the pop-out control appears.
+        onPopOut={expanded ? undefined : onPopOut}
         instanceId={instanceId}
-        hideHeader
+        hideHeader={expanded}
       />
     </div>
   )

--- a/apps/web/src/components/mail/email-editor/floating-compose.test.tsx
+++ b/apps/web/src/components/mail/email-editor/floating-compose.test.tsx
@@ -13,7 +13,11 @@ import { act, useEffect, useState } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useComposeStore } from '../store/compose-store'
 
-const h = vi.hoisted(() => ({ mounts: 0 }))
+const h = vi.hoisted(() => ({
+  mounts: 0,
+  chatMounts: 0,
+  provider: undefined as string | undefined,
+}))
 
 /**
  * Stands in for the whole composer. The uncontrolled input IS the thing under
@@ -36,9 +40,18 @@ vi.mock('./index', () => ({
   },
 }))
 
-vi.mock('../chat-panel', () => ({ ChatPanel: () => null }))
-vi.mock('../chat-composer', () => ({ default: () => null }))
-vi.mock('~/components/channels/hooks/use-channels', () => ({ useChannel: () => undefined }))
+/** Chat threads render this instead, docked or not — only `expanded` differs. */
+vi.mock('../chat-panel', () => ({
+  ChatPanel: ({ expanded }: { expanded: boolean }) => {
+    useEffect(() => {
+      h.chatMounts++
+    }, [])
+    return <div data-testid='chat' data-expanded={String(expanded)} />
+  },
+}))
+vi.mock('~/components/channels/hooks/use-channels', () => ({
+  useChannel: () => (h.provider ? { provider: h.provider } : undefined),
+}))
 vi.mock('./hooks/use-draft', () => ({ useDraft: () => ({ draft: null, isLoading: false }) }))
 
 const { FloatingCompose } = await import('./floating-compose')
@@ -57,6 +70,8 @@ function Harness() {
 
 beforeEach(() => {
   h.mounts = 0
+  h.chatMounts = 0
+  h.provider = undefined
   useComposeStore.setState({ instances: [], nextZIndex: 101 })
 })
 
@@ -182,6 +197,20 @@ describe('FloatingCompose — pop-out and dock-back', () => {
     // mid-address must not drop the user out of the field.
     expect(composer()).toHaveFocus()
     expect((composer() as HTMLInputElement).selectionStart).toBe('jane@corp.com'.length)
+  })
+
+  it('keeps a chat thread on ONE component across the move', () => {
+    h.provider = 'chat'
+    const id = openInlineCompose()
+
+    expect(screen.getByTestId('chat')).toHaveAttribute('data-expanded', 'false')
+
+    act(() => useComposeStore.getState().undock(id))
+
+    // Same component, told to wear its chrome — not a swap to a different one,
+    // which is what used to destroy the chat composer's editor.
+    expect(screen.getByTestId('chat')).toHaveAttribute('data-expanded', 'true')
+    expect(h.chatMounts).toBe(1)
   })
 
   it('takes its host with it when the instance closes', () => {

--- a/apps/web/src/components/mail/email-editor/floating-compose.tsx
+++ b/apps/web/src/components/mail/email-editor/floating-compose.tsx
@@ -9,7 +9,6 @@ import type React from 'react'
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useChannel } from '~/components/channels/hooks/use-channels'
-import ChatComposer from '../chat-composer'
 import { ChatPanel } from '../chat-panel'
 import type { ComposeInstance } from '../store/compose-store'
 import { useComposeStore } from '../store/compose-store'
@@ -210,7 +209,7 @@ export function FloatingCompose({ instance }: { instance: ComposeInstance }) {
     !editorMounted || (instance.mode === 'draft' && instance.draft?.id && isDraftLoading)
 
   // Resolve the integration's provider to decide which composer to mount.
-  // Chat threads use the dedicated ChatComposer; everything else (email +
+  // Chat threads use the dedicated ChatPanel; everything else (email +
   // FB/IG/SMS for now) flows through ReplyComposeEditor.
   const threadChannel = useChannel(instance.thread?.integrationId)
   const isChat = threadChannel?.provider === 'chat'
@@ -225,25 +224,20 @@ export function FloatingCompose({ instance }: { instance: ComposeInstance }) {
     <div className='flex items-center justify-center rounded-[20px] bg-background p-8'>
       <Loader2 className='size-6 animate-spin text-muted-foreground' />
     </div>
-  ) : isChat && instance.thread && instance.displayMode !== 'inline' ? (
+  ) : isChat && instance.thread ? (
+    // One component across both modes — see the note on `ChatPanel.expanded`.
+    // Picking between `<ChatPanel>` and a bare `<ChatComposer>` here is what
+    // used to remount the chat composer on every pop-out.
     <ChatPanel
       thread={instance.thread}
-      isDialogMode={true}
+      expanded={instance.displayMode !== 'inline'}
       onClose={handleClose}
       onSendSuccess={() => {}}
+      onPopOut={handlePopOut}
       onMinimize={instance.displayMode === 'floating' ? handleMinimize : undefined}
       onDockBack={canDockBack ? handleDockBack : undefined}
       instanceId={instance.id}
       dragHandleProps={dragHandleProps}
-    />
-  ) : isChat && instance.thread ? (
-    <ChatComposer
-      thread={instance.thread}
-      isDialogMode={false}
-      onClose={handleClose}
-      onSendSuccess={() => {}}
-      onPopOut={handlePopOut}
-      instanceId={instance.id}
     />
   ) : (
     <ReplyComposeEditor


### PR DESCRIPTION
Follow-up to #1676, which left this case open.

## The bug

`FloatingCompose` picked the chat surface by display mode:

```tsx
isChat && displayMode !== 'inline' ? <ChatPanel …/> : isChat ? <ChatComposer …/> : …
```

Two different element types at the same tree position — so popping a chat thread out (or docking it back) remounted the composer. `ChatComposer` wraps its own `EditorProvider`, so the remount destroyed the Tiptap instance along with the typed message, the attachment strip and the in-flight uploads.

That's the same failure #1676 fixed for the email composer; the stable portal host can't help here, because the component itself changes.

## The fix

`ChatPanel` takes an `expanded` flag and is now the single chat surface, docked or not. The chrome is conditional *inside* one tree:

```tsx
<div className={cn('relative flex flex-col', expanded && panelChrome)}>
  {expanded && <ChatPanelHeader …/>}
  {expanded && <ChatPanelMessages …/>}
  <ChatComposer … hideHeader={expanded} />
</div>
```

Both conditional slots hold their position with `false` when collapsed, so the composer never shifts index and React keeps its state — only its props change (`hideHeader`, `isDialogMode`, and `onPopOut`, which is the docked header's control).

Docked still renders composer-only, so the thread view behind it keeps owning the header and message log. No visual change in either mode.

## Testing

- New `chat-panel/chat-panel.test.tsx` (3): docked renders composer + its own header only; expanded adds the panel chrome and drops the composer's header; typed text survives an expand/collapse round trip with a mount count of 1.
- `floating-compose.test.tsx` gains a chat case: a chat thread renders the same component in both modes (`data-expanded` flips, mount count stays 1).
- Full `src/components/mail` suite: 208 passing.
- Typecheck ratchet: no new errors in either file touched here.
