### PR TITLE
fix(channels): invalidate channels cache when credential auth state changes

### DIFF
--- a/apps/web/src/server/api/routers/channel-reauth.ts
+++ b/apps/web/src/server/api/routers/channel-reauth.ts
@@ -1,6 +1,7 @@
 // ~/server/api/routers/channel-reauth.ts
 
 import { schema } from '@auxx/database'
+import { onCacheEvent } from '@auxx/lib/cache'
 import { TRPCError } from '@trpc/server'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { z } from 'zod'
@@ -51,6 +52,9 @@ export const channelReauthRouter = createTRPCRouter({
           .update(schema.Credential)
           .set({ requiresReauth: false })
           .where(eq(schema.Credential.id, integration.credentialId))
+        // The banner reads from the cached channel list — recompute it or the
+        // dismissed banner reappears on the next fetch.
+        await onCacheEvent('channel.auth-state.changed', { orgId: organizationId })
       }
 
       return {

--- a/packages/lib/src/cache/invalidation-graph.ts
+++ b/packages/lib/src/cache/invalidation-graph.ts
@@ -63,6 +63,10 @@ export const INVALIDATION_GRAPH: Record<string, InvalidationMapping> = {
   'channel.toggled': ['channels'],
   'channel.settings_updated': ['channels'],
   'channel.inbox-link.changed': ['channels', 'inboxes'],
+  // requiresReauth/lastAuthError live on the Credential but are served to the UI
+  // through the cached channel list — without this, an auth failure stays
+  // invisible until the day-long TTL expires or an unrelated channel event fires.
+  'channel.auth-state.changed': ['channels'],
 
   'group.created': ['groups'],
   'group.updated': ['groups'],

--- a/packages/lib/src/providers/credential-auth-state.ts
+++ b/packages/lib/src/providers/credential-auth-state.ts
@@ -4,17 +4,39 @@
 // linked Credential, not the Integration (Phase 6 of channels-onto-connections). These helpers
 // resolve a channel's credential and update that state, so any caller holding only an
 // integrationId can flag/clear the reconnect signal without re-implementing the join.
+//
+// Both helpers emit `channel.auth-state.changed` so the cached channel list
+// (`channels` org-cache key, day-long TTL) picks up the new auth state — the
+// UI's reauth banner and channel status read from that cache, not the DB.
 
 import { database as db, schema } from '@auxx/database'
 import { eq } from 'drizzle-orm'
+import { onCacheEvent } from '../cache'
 
-async function getCredentialId(integrationId: string): Promise<string | null> {
+async function getCredentialRef(integrationId: string): Promise<{
+  credentialId: string
+  organizationId: string
+  requiresReauth: boolean
+  lastAuthError: string | null
+} | null> {
   const [row] = await db
-    .select({ credentialId: schema.Integration.credentialId })
+    .select({
+      credentialId: schema.Integration.credentialId,
+      organizationId: schema.Integration.organizationId,
+      requiresReauth: schema.Credential.requiresReauth,
+      lastAuthError: schema.Credential.lastAuthError,
+    })
     .from(schema.Integration)
+    .leftJoin(schema.Credential, eq(schema.Credential.id, schema.Integration.credentialId))
     .where(eq(schema.Integration.id, integrationId))
     .limit(1)
-  return row?.credentialId ?? null
+  if (!row?.credentialId) return null
+  return {
+    credentialId: row.credentialId,
+    organizationId: row.organizationId,
+    requiresReauth: row.requiresReauth ?? false,
+    lastAuthError: row.lastAuthError,
+  }
 }
 
 /** Flag the channel's credential as needing re-auth (surfaces the reconnect banner). */
@@ -23,20 +45,27 @@ export async function markCredentialReauth(
   lastAuthError: string,
   requiresReauth: boolean
 ): Promise<void> {
-  const credentialId = await getCredentialId(integrationId)
-  if (!credentialId) return
+  const ref = await getCredentialRef(integrationId)
+  if (!ref) return
   await db
     .update(schema.Credential)
     .set({ requiresReauth, lastAuthError, lastAuthErrorAt: new Date() })
-    .where(eq(schema.Credential.id, credentialId))
+    .where(eq(schema.Credential.id, ref.credentialId))
+  await onCacheEvent('channel.auth-state.changed', { orgId: ref.organizationId })
 }
 
-/** Clear the channel credential's auth-error state after a successful operation. */
+/**
+ * Clear the channel credential's auth-error state after a successful operation.
+ * No-ops when there is nothing to clear — this runs after every successful
+ * sync, and an unconditional write would bust the channels cache each time.
+ */
 export async function clearCredentialReauth(integrationId: string): Promise<void> {
-  const credentialId = await getCredentialId(integrationId)
-  if (!credentialId) return
+  const ref = await getCredentialRef(integrationId)
+  if (!ref) return
+  if (!ref.requiresReauth && ref.lastAuthError === null) return
   await db
     .update(schema.Credential)
     .set({ requiresReauth: false, lastAuthError: null, lastAuthErrorAt: null })
-    .where(eq(schema.Credential.id, credentialId))
+    .where(eq(schema.Credential.id, ref.credentialId))
+  await onCacheEvent('channel.auth-state.changed', { orgId: ref.organizationId })
 }


### PR DESCRIPTION
## Problem

When an OAuth grant dies (e.g. Gmail `invalid_grant: Token has been expired or revoked`), the backend correctly flags `Credential.requiresReauth` — but the UI never shows the reconnect banner or auth-error status. Not on the Channels list, not on the channel's settings page.

Every surface reads auth state through `channel.list`, which serves the `channels` org-cache key (1-day TTL). The cache snapshot includes `requiresReauth`/`lastAuthError`, but **no invalidation event fires when auth state changes** — `markCredentialReauth`/`clearCredentialReauth` are raw `db.update`s. So an auth failure stays invisible until the TTL expires or an unrelated channel event (connect/disconnect/toggle) happens to bust the key.

History: surfacing worked until #645 moved `channel.list` behind the org cache (auth-state writes live in `providers/`, outside the channels module, so they were missed when the invalidation events were added). #920 moved the flag onto the Credential without touching invalidation. #1233 fixed the flag not being *set* for revoked grants, but assumed "no UI changes needed" — the read path was still day-stale.

## Changes

- **`invalidation-graph.ts`**: new event `channel.auth-state.changed` → invalidates `channels`.
- **`credential-auth-state.ts`**: `markCredentialReauth` and `clearCredentialReauth` emit the event after writing (single seam — covers AuthErrorHandler, facebook/instagram token checks, sync recovery, and `recoverChannel`). `clearCredentialReauth` now no-ops when there is nothing to clear: it runs after **every successful sync**, and an unconditional write would bust the cache once per sync (also skips a pointless UPDATE per sync).
- **`channel-reauth.ts` router**: `dismissReauthBanner` emits the event after clearing the flag — otherwise a dismissed banner reappears from the stale cache on the next fetch.

## Tests

- `packages/lib`: providers + channels + cache suites — 16 files, 135 passed.
- `pnpm exec tsc --noEmit` in packages/lib: no errors in touched files (pre-existing `scripts/` errors unchanged).
- Biome clean on all three files.