### PR TITLE
feat(channels): typed reauth send error and composer warning icon

### DIFF
--- a/apps/web/src/components/pickers/channel-picker.tsx
+++ b/apps/web/src/components/pickers/channel-picker.tsx
@@ -6,7 +6,7 @@ import type { SelectOption } from '@auxx/types/custom-field'
 import { Badge } from '@auxx/ui/components/badge'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
-import { Star } from 'lucide-react'
+import { Star, TriangleAlert } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useDefaultChannelId } from '~/components/channels/hooks/use-default-channel'
@@ -44,6 +44,26 @@ interface ChannelPickerProps {
  */
 function channelLabel(channel: { identifier?: string; email?: string; name: string | null }) {
   return channel.identifier || channel.email || channel.name || 'Unnamed channel'
+}
+
+/**
+ * Whether the channel's credential needs a reconnect before it can send.
+ * Checked directly (not via `getIntegrationStatus`) because the threshold
+ * disable after repeated auth failures flips `enabled` off, and the status
+ * helper reports those channels as `disabled` — but the send would still fail
+ * with the same login-expired error, so the picker warns on both.
+ */
+function needsReconnect(channel: { requiresReauth: boolean; lastAuthError: string | null }) {
+  return channel.requiresReauth || !!channel.lastAuthError
+}
+
+/** Amber warning mirroring the connected-apps pickers (`connection-picker.tsx`). */
+function ReconnectWarning() {
+  return (
+    <Tooltip content='Login expired — sending will fail until this channel is reconnected'>
+      <TriangleAlert className='size-3.5 shrink-0 text-amber-600' />
+    </Tooltip>
+  )
 }
 
 export function ChannelPicker({
@@ -115,7 +135,10 @@ export function ChannelPicker({
           hideIcon={triggerProps?.hideIcon}
           asCombobox
           className={triggerProps?.className}>
-          <Badge variant='user'>{displayName}</Badge>
+          <span className='flex items-center gap-1.5'>
+            <Badge variant='user'>{displayName}</Badge>
+            {selected && needsReconnect(selected) && <ReconnectWarning />}
+          </span>
         </PickerTrigger>
       </PopoverTrigger>
       <PopoverContent className={cn('w-auto min-w-[240px] p-0', className)}>
@@ -139,22 +162,28 @@ export function ChannelPicker({
           browseLabel='Manage channels'
           renderItemAction={(opt) => {
             const isDefault = opt.value === defaultChannelId
+            const channel = channels.find((c) => c.id === opt.value)
             return (
-              <Tooltip content={isDefault ? 'Default channel' : 'Make default'}>
-                <button
-                  type='button'
-                  aria-label={isDefault ? 'Default channel' : 'Make default'}
-                  className={cn(
-                    'flex size-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-primary-200',
-                    !isDefault && 'opacity-0 group-hover/item:opacity-100'
-                  )}
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    updateUserSetting('compose.defaultIntegrationId', opt.value)
-                  }}>
-                  <Star className={cn('size-3', isDefault && 'fill-yellow-400 text-yellow-400')} />
-                </button>
-              </Tooltip>
+              <>
+                {channel && needsReconnect(channel) && <ReconnectWarning />}
+                <Tooltip content={isDefault ? 'Default channel' : 'Make default'}>
+                  <button
+                    type='button'
+                    aria-label={isDefault ? 'Default channel' : 'Make default'}
+                    className={cn(
+                      'flex size-5 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-primary-200',
+                      !isDefault && 'opacity-0 group-hover/item:opacity-100'
+                    )}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      updateUserSetting('compose.defaultIntegrationId', opt.value)
+                    }}>
+                    <Star
+                      className={cn('size-3', isDefault && 'fill-yellow-400 text-yellow-400')}
+                    />
+                  </button>
+                </Tooltip>
+              </>
             )
           }}
         />

--- a/packages/lib/src/providers/__tests__/provider-registry-service.test.ts
+++ b/packages/lib/src/providers/__tests__/provider-registry-service.test.ts
@@ -83,6 +83,7 @@ vi.mock('@auxx/database/enums', async (importOriginal) => {
   }
 })
 
+import { UnprocessableEntityError } from '../../errors'
 import { ProviderRegistryService } from '../provider-registry-service'
 
 // ---------------------------------------------------------------------------
@@ -449,11 +450,16 @@ describe('ProviderRegistryService', () => {
       )
     })
 
-    it('should throw when the linked credential requires re-authentication', async () => {
+    it('should throw an UnprocessableEntityError when the linked credential requires re-authentication', async () => {
       const row = makeGetProviderRow({ id: 'int-reauth', provider: 'google' }, true)
       setupSelectChain([row])
 
-      await expect(service.getProvider('int-reauth')).rejects.toThrow('requires re-authentication')
+      // Must be an AuxxError (422), not a plain Error — the thread router passes
+      // AuxxErrors through so the composer toast shows this message instead of
+      // "An unexpected error occurred" from a generic 500.
+      await expect(service.getProvider('int-reauth')).rejects.toThrow(UnprocessableEntityError)
+      setupSelectChain([row])
+      await expect(service.getProvider('int-reauth')).rejects.toThrow('login has expired')
     })
 
     it('should allow getting provider for disabled integrations', async () => {

--- a/packages/lib/src/providers/provider-registry-service.ts
+++ b/packages/lib/src/providers/provider-registry-service.ts
@@ -5,6 +5,7 @@ import type { IntegrationProviderType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { and, desc, eq, isNull } from 'drizzle-orm'
 import type { ActiveIntegration, ProviderInstance } from '../email/message-service'
+import { UnprocessableEntityError } from '../errors'
 import type { ChannelProvider } from './channel-provider.interface'
 import { ChatProvider } from './chat/chat-provider'
 import { EmailForwardingProvider } from './email/email-forwarding-provider'
@@ -292,8 +293,10 @@ export class ProviderRegistryService {
           googleErrorDescription: authDetails.googleErrorDescription,
         })
 
-        throw new Error(
-          `Integration ${integrationId} requires re-authentication. User must re-connect the integration.`
+        // UnprocessableEntityError (not plain Error) so the tRPC layer maps it to
+        // 422 and the composer toast shows this message instead of a generic 500.
+        throw new UnprocessableEntityError(
+          "This channel's login has expired. Reconnect it under Settings → Channels."
         )
       }
 


### PR DESCRIPTION
Follow-up to #1681 (UX side of the reauth surfacing).

## Changes

1. **Typed send error** — `ProviderRegistryService.getProvider` now throws `UnprocessableEntityError` ("This channel's login has expired. Reconnect it under Settings → Channels.") instead of a plain `Error` when the credential requires reauth. The thread router's `handleServiceError` passes AuxxErrors through to `auxxErrorMiddleware`, so the composer toast shows the actionable message instead of "An unexpected error occurred in messageSender.sendMessage" (generic 500). Verified the propagation path: `getProvider` is called outside `sendViaProvider`'s normalizer try/catch, and `sendMessage`'s outer catch rethrows the original error.

2. **Composer From-picker warning** — channels needing reconnect stay selectable but show the amber `TriangleAlert` (same rendering as `connection-picker.tsx`'s expired-connection rows), both on the option rows and next to the selected-channel badge, with a tooltip explaining sends will fail until reconnected. The check is `requiresReauth || lastAuthError` directly rather than `getIntegrationStatus`, because the 3-failure threshold disables the integration and the status helper would report those as `disabled` — but the send fails with the same login-expired error either way.

## Tests

- `provider-registry-service.test.ts`: reauth case now asserts the `UnprocessableEntityError` class and new message — 43 passed.
- Biome clean on all three files.