### PR TITLE
fix(channels): self-heal stale channels cache on live-state refusals

### DIFF
--- a/packages/lib/src/cache/index.ts
+++ b/packages/lib/src/cache/index.ts
@@ -44,6 +44,7 @@ export {
   flushOrganization,
   invalidateAppCatalog,
   invalidateAppSlugMap,
+  invalidateChannelsIfStale,
   invalidatePlans,
   invalidateWorkflowTemplates,
   onCacheEvent,

--- a/packages/lib/src/cache/invalidate.ts
+++ b/packages/lib/src/cache/invalidate.ts
@@ -127,6 +127,33 @@ export async function onCacheEvent(
   }
 }
 
+/**
+ * Self-heal for the cached channel list: call when a live DB read just refused
+ * an action because of channel state (`enabled` / `requiresReauth`) the cached
+ * snapshot may not reflect — e.g. sync refused on a disabled channel, send
+ * refused on an expired login. Recomputes `channels` only when the cache
+ * actually disagrees, so hot paths that keep hitting a broken channel
+ * (pollers, retried sends) recompute at most once. Best-effort: a cache
+ * hiccup must never mask the caller's real error.
+ */
+export async function invalidateChannelsIfStale(
+  orgId: string,
+  channelId: string,
+  live: { enabled?: boolean; requiresReauth?: boolean }
+): Promise<void> {
+  try {
+    const channels = await getOrgCache().get(orgId, 'channels')
+    const cached = channels.find((c) => c.id === channelId)
+    if (!cached) return
+    const stale =
+      (live.enabled !== undefined && cached.enabled !== live.enabled) ||
+      (live.requiresReauth !== undefined && cached.requiresReauth !== live.requiresReauth)
+    if (stale) await onCacheEvent('channel.stale-state.detected', { orgId })
+  } catch {
+    // swallow — self-heal only
+  }
+}
+
 /** Flush everything for an org (e.g. org deletion) */
 export async function flushOrganization(orgId: string): Promise<void> {
   await getOrgCache().flush(orgId)

--- a/packages/lib/src/cache/invalidation-graph.ts
+++ b/packages/lib/src/cache/invalidation-graph.ts
@@ -67,6 +67,9 @@ export const INVALIDATION_GRAPH: Record<string, InvalidationMapping> = {
   // through the cached channel list — without this, an auth failure stays
   // invisible until the day-long TTL expires or an unrelated channel event fires.
   'channel.auth-state.changed': ['channels'],
+  // Emitted by `invalidateChannelsIfStale` when a live DB read observes channel
+  // state (enabled/requiresReauth) the cached snapshot disagrees with.
+  'channel.stale-state.detected': ['channels'],
 
   'group.created': ['groups'],
   'group.updated': ['groups'],

--- a/packages/lib/src/channels/sync.ts
+++ b/packages/lib/src/channels/sync.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/channels/sync.ts
 
+import { invalidateChannelsIfStale } from '../cache'
 import { AuxxError, BadRequestError } from '../errors'
 import { createScopedLogger } from '../logger'
 import { SyncMessages } from '../messages/sync-messages'
@@ -23,6 +24,9 @@ export async function syncMessages(
   const channel = validated.value
 
   if (!channel.enabled) {
+    // The UI offered this action off the cached channel list — a refusal here
+    // means that snapshot is stale, so recompute it (self-heal).
+    await invalidateChannelsIfStale(ctx.organizationId, channelId, { enabled: false })
     return Result.error(new BadRequestError('Cannot sync messages for disabled channel'))
   }
 

--- a/packages/lib/src/providers/provider-registry-service.ts
+++ b/packages/lib/src/providers/provider-registry-service.ts
@@ -4,6 +4,7 @@ import { IntegrationProviderType as IntegrationProviderEnum } from '@auxx/databa
 import type { IntegrationProviderType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { and, desc, eq, isNull } from 'drizzle-orm'
+import { invalidateChannelsIfStale } from '../cache'
 import type { ActiveIntegration, ProviderInstance } from '../email/message-service'
 import { UnprocessableEntityError } from '../errors'
 import type { ChannelProvider } from './channel-provider.interface'
@@ -291,6 +292,14 @@ export class ProviderRegistryService {
           consecutiveFailures: authDetails.consecutiveFailures,
           googleError: authDetails.googleError,
           googleErrorDescription: authDetails.googleErrorDescription,
+        })
+
+        // A live read just observed reauth state the cached channel list may
+        // not reflect (e.g. flagged before an invalidation existed) — self-heal
+        // so the banner/warning surfaces catch up.
+        await invalidateChannelsIfStale(this.organizationId, integrationId, {
+          requiresReauth: true,
+          enabled: integration.enabled,
         })
 
         // UnprocessableEntityError (not plain Error) so the tRPC layer maps it to


### PR DESCRIPTION
Follow-up to #1681/#1682. A channel flagged/disabled *before* #1681 existed (or after any missed invalidation) serves a stale `channels` snapshot for up to the key's 1-day TTL: the settings page says **Active** while "Sync messages" refuses with "Cannot sync messages for disabled channel", and refreshing the browser doesn't help because the staleness is server-side.

## Changes

- **`invalidateChannelsIfStale(orgId, channelId, live)`** (cache module): compares a live-observed `enabled`/`requiresReauth` against the cached channel snapshot and emits the new `channel.stale-state.detected` event (→ `channels`) only on mismatch — so hot paths that repeatedly hit a broken channel (pollers, retried sends) recompute at most once, and a cache hiccup never masks the caller's real error (best-effort, swallowed).
- **`syncMessages`**: refusing a disabled channel now self-heals the cache — the UI only offered the button because the snapshot said enabled.
- **`getProvider`**: the requires-reauth throw self-heals too, so any send attempt against a stale-cached channel makes the banner/warning surfaces catch up.

Placed in the cache module (not channels) because both `channels/` and `providers/` call it, and `providers → channels` would be an import cycle (`channels/list` imports `providers/provider-capabilities`).

## Tests

- `packages/lib` providers + channels + cache suites: 44 files, 412 passed.
- Biome clean.