### PR TITLE
feat(messages): quo call/voicemail ingest and a messageType filter

### DIFF
--- a/apps/web/src/app/api/openphone/webhook/route.ts
+++ b/apps/web/src/app/api/openphone/webhook/route.ts
@@ -12,17 +12,24 @@
 // directly, exactly like the Recall/Svix call site. `openphonePreset` documents the scheme as data.
 
 import { database as db, schema } from '@auxx/database'
-import { MessageStorageService } from '@auxx/lib/email'
+import {
+  type AttachmentIngestInput,
+  InboundAttachmentIngestService,
+  MessageStorageService,
+} from '@auxx/lib/email'
 import { parseConversationIdFromDeepLink } from '@auxx/lib/providers/openphone/deep-link'
 import type {
   OpenPhoneIntegrationMetadata,
+  QuoWebhookCall,
   QuoWebhookEvent,
   QuoWebhookMessage,
 } from '@auxx/lib/providers/openphone/types'
+import { convertQuoWebhookCallEventToMessageData } from '@auxx/lib/providers/openphone/webhook-call'
 import { convertQuoWebhookEventToMessageData } from '@auxx/lib/providers/openphone/webhook-message'
+import { getRealtimeService, publishMessageUpdated } from '@auxx/lib/realtime'
 import { resolveWebhookSecret, verifyHmacSignature } from '@auxx/lib/webhooks'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, like, sql } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 
 const logger = createScopedLogger('openphone-webhook')
@@ -32,6 +39,14 @@ const SIGNATURE_HEADER = 'openphone-signature'
 
 /** Replay window, in seconds. Matches the Recall/Svix call site's tolerance. */
 const TIMESTAMP_TOLERANCE_SEC = 300
+
+/**
+ * Cap on a single fetched media file (voicemail or call recording). REST never returns this
+ * media (see the Quo plan's "Inbound media"), so the webhook delivery is the only shot at it —
+ * this cap exists purely to stop a pathological response from blowing up memory, not because we
+ * expect to hit it.
+ */
+const MAX_MEDIA_BYTES = 25 * 1024 * 1024
 
 /** The events that carry a `phoneNumberId` and therefore resolve to one of our Integrations. */
 type QuoPhoneScopedPayload = { phoneNumberId?: string }
@@ -216,18 +231,289 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         break
       }
 
-      // Call events are logged no-ops today. The names below are the real ones — there is no
-      // `call.finished`. Turning any of these into a Message row needs a call-shaped payload
-      // mapper (voicemail/recording `media[]`), which is out of scope here.
+      // `call.ringing` never creates a row — we don't subscribe to it (see
+      // `QuoCreateMessageWebhookInput`), but a stray delivery (e.g. from a webhook created
+      // before this shipped) is still handled as a harmless no-op rather than falling to
+      // `default`, so it's obvious in logs this is deliberate, not unhandled.
       case 'call.ringing':
-      case 'call.completed':
-      case 'call.recording.completed':
-        logger.info('Received Quo call event (no-op)', {
-          type: payload.type,
+        logger.info('Received Quo call.ringing event (no-op)', {
           eventId: payload.id,
           integrationId: integration.id,
         })
         break
+
+      // A completed (answered or missed) call becomes a Message row: `CALL`, or `VOICEMAIL`
+      // when the call carries voicemail audio. Voicemail bytes are fetched right here, because
+      // REST never returns call media at all (message-type-overhaul plan §"Inbound media") —
+      // this webhook delivery is the only chance to capture them.
+      case 'call.completed': {
+        const event = payload as QuoWebhookEvent<QuoWebhookCall>
+        logger.info('Processing Quo call.completed event', {
+          eventId: payload.id,
+          integrationId: integration.id,
+        })
+
+        const conversationId = resolveQuoConversationId(event, { integrationId: integration.id })
+        const messageData = convertQuoWebhookCallEventToMessageData(
+          event,
+          integration.id,
+          integration.organizationId,
+          metadata,
+          conversationId
+        )
+        if (!messageData) {
+          logger.warn('Failed to convert Quo call.completed event data', { eventId: payload.id })
+          break
+        }
+
+        const storageService = new MessageStorageService(integration.organizationId)
+        let stored: { messageId: string; isNew: boolean }
+        try {
+          stored = await storageService.storeMessage(messageData)
+          logger.info('Stored Quo call', {
+            mid: messageData.externalId,
+            messageType: messageData.messageType,
+            isNew: stored.isNew,
+            integrationId: integration.id,
+          })
+        } catch (storeError) {
+          const message = storeError instanceof Error ? storeError.message : String(storeError)
+          logger.error('Failed to store Quo call', {
+            mid: messageData.externalId,
+            integrationId: integration.id,
+            error: message,
+          })
+          return NextResponse.json({ error: 'Failed to store call' }, { status: 500 })
+        }
+
+        const voicemail = event.data?.object?.voicemail
+        if (voicemail?.url) {
+          // Checked by attachment existence, NOT `stored.isNew`: after a fetch failure below we
+          // return 500 so Quo redelivers the same event, and by then `storeMessage` has already
+          // upserted the row, so `isNew` would read false on the retry and silently skip the
+          // fetch forever. An existing-attachment check is idempotent across any number of
+          // redeliveries regardless of `isNew`. Scoped to voicemail files so a recording that
+          // somehow attached first can never block the voicemail (and vice versa below).
+          const alreadyIngested = await hasExistingAttachment(
+            stored.messageId,
+            integration.organizationId,
+            'voicemail.'
+          )
+          if (alreadyIngested) {
+            logger.debug('Voicemail already ingested for this call; skipping refetch', {
+              messageId: stored.messageId,
+              eventId: payload.id,
+            })
+            break
+          }
+
+          const bytes = await fetchQuoMediaBytes(voicemail.url, {
+            eventId: payload.id,
+            kind: 'voicemail',
+          })
+          if (!bytes) {
+            // The presigned URL is only valid for this delivery attempt and REST never returns
+            // voicemail media, so a dropped fetch here is unrecoverable once this response is
+            // sent. Returning 500 makes Quo redeliver with a fresh URL; `storeMessage` already
+            // upserted on `externalId` above, so the redelivery is safe and simply retries the
+            // fetch (see the `hasExistingAttachment` guard above for why it isn't skipped).
+            return NextResponse.json({ error: 'Failed to fetch voicemail media' }, { status: 500 })
+          }
+
+          try {
+            const ingestService = new InboundAttachmentIngestService()
+            const input: AttachmentIngestInput = {
+              content: bytes,
+              filename: `voicemail.${extensionForMimeType(voicemail.type)}`,
+              mimeType: voicemail.type || 'audio/mpeg',
+              inline: false,
+              attachmentOrder: 0,
+            }
+            // `skipReconciliation`: this call only ever carries the voicemail, never the full
+            // attachment set for the message, so reconciliation would delete anything a later
+            // `call.recording.completed` adds (or vice versa).
+            await ingestService.ingestAll(
+              [input],
+              {
+                organizationId: integration.organizationId,
+                messageId: stored.messageId,
+                contentScopeId: messageData.externalId,
+              },
+              { skipReconciliation: true }
+            )
+            logger.info('Ingested Quo voicemail attachment', {
+              messageId: stored.messageId,
+              eventId: payload.id,
+            })
+          } catch (ingestError) {
+            const message = ingestError instanceof Error ? ingestError.message : String(ingestError)
+            logger.error('Failed to ingest Quo voicemail attachment', {
+              messageId: stored.messageId,
+              eventId: payload.id,
+              error: message,
+            })
+            return NextResponse.json(
+              { error: 'Failed to ingest voicemail attachment' },
+              { status: 500 }
+            )
+          }
+        }
+        break
+      }
+
+      // Attaches the recording to the call row `call.completed` already created. Dropped
+      // silently when no such row exists (a call from before this feature shipped) — there is
+      // no retriable fix for a missing parent message.
+      case 'call.recording.completed': {
+        const event = payload as QuoWebhookEvent<QuoWebhookCall>
+        const callId = event.data?.object?.id
+        logger.info('Processing Quo call.recording.completed event', {
+          eventId: payload.id,
+          integrationId: integration.id,
+        })
+
+        if (!callId) {
+          logger.warn('Quo recording event carries no call id', { eventId: payload.id })
+          break
+        }
+
+        const [existing] = await db
+          .select({
+            id: schema.Message.id,
+            threadId: schema.Message.threadId,
+            hasAttachments: schema.Message.hasAttachments,
+          })
+          .from(schema.Message)
+          .where(
+            and(
+              eq(schema.Message.organizationId, integration.organizationId),
+              eq(schema.Message.integrationId, integration.id),
+              eq(schema.Message.externalId, callId)
+            )
+          )
+          .limit(1)
+
+        if (!existing) {
+          // Recording events only flow on webhooks that also subscribe to `call.completed`, so
+          // a missing parent row is almost always an out-of-order delivery, not a call from
+          // before this shipped. 500 makes Quo redeliver, by which time the call row exists;
+          // for a genuinely orphaned recording, Quo's bounded retries give up on their own.
+          logger.warn('No stored call found for Quo recording event; retrying via 500', {
+            callId,
+            eventId: payload.id,
+            integrationId: integration.id,
+          })
+          return NextResponse.json({ error: 'No stored call for recording yet' }, { status: 500 })
+        }
+
+        // Scoped to recording files: a voicemail attachment on the same call must not read as
+        // "recording already ingested".
+        const alreadyIngested = await hasExistingAttachment(
+          existing.id,
+          integration.organizationId,
+          'recording-'
+        )
+        if (alreadyIngested) {
+          logger.debug('Recording already ingested for this call; skipping', {
+            messageId: existing.id,
+            eventId: payload.id,
+          })
+          break
+        }
+
+        const media = event.data?.object?.media ?? []
+        if (media.length === 0) {
+          logger.warn('Quo recording event carries no media', { callId, eventId: payload.id })
+          break
+        }
+
+        // All-or-nothing across the media entries: ingesting a partial set and then 500ing
+        // would make the redelivery see recordings already present and skip the rest forever
+        // (the existence check above is per-kind, not per-entry). Fetch everything first;
+        // ingest only a complete set.
+        const inputs: AttachmentIngestInput[] = []
+        let anyFetchFailed = false
+        for (let i = 0; i < media.length; i++) {
+          const item = media[i]!
+          const bytes = await fetchQuoMediaBytes(item.url, {
+            eventId: payload.id,
+            kind: 'recording',
+          })
+          if (!bytes) {
+            anyFetchFailed = true
+            break
+          }
+          inputs.push({
+            content: bytes,
+            filename: `recording-${i}.${extensionForMimeType(item.type)}`,
+            mimeType: item.type || 'audio/mpeg',
+            inline: false,
+            attachmentOrder: i,
+          })
+        }
+        if (anyFetchFailed) {
+          return NextResponse.json({ error: 'Failed to fetch recording media' }, { status: 500 })
+        }
+
+        if (inputs.length > 0) {
+          try {
+            const ingestService = new InboundAttachmentIngestService()
+            await ingestService.ingestAll(
+              inputs,
+              {
+                organizationId: integration.organizationId,
+                messageId: existing.id,
+                contentScopeId: callId,
+              },
+              { skipReconciliation: true }
+            )
+            logger.info('Ingested Quo call recording attachment(s)', {
+              messageId: existing.id,
+              count: inputs.length,
+              eventId: payload.id,
+            })
+
+            if (!existing.hasAttachments) {
+              await db
+                .update(schema.Message)
+                .set({ hasAttachments: true, updatedAt: new Date() })
+                .where(eq(schema.Message.id, existing.id))
+
+              const [thread] = await db
+                .select({ inboxId: schema.Thread.inboxId, assigneeId: schema.Thread.assigneeId })
+                .from(schema.Thread)
+                .where(eq(schema.Thread.id, existing.threadId))
+                .limit(1)
+
+              await publishMessageUpdated(getRealtimeService(), integration.organizationId, {
+                messageId: existing.id,
+                threadId: existing.threadId,
+                inboxId: thread?.inboxId ?? null,
+                assigneeId: thread?.assigneeId ?? null,
+                patch: { hasAttachments: true },
+              }).catch((error) => {
+                logger.warn('Failed to publish message:updated for Quo recording', {
+                  messageId: existing.id,
+                  error: error instanceof Error ? error.message : String(error),
+                })
+              })
+            }
+          } catch (ingestError) {
+            const message = ingestError instanceof Error ? ingestError.message : String(ingestError)
+            logger.error('Failed to ingest Quo call recording attachment(s)', {
+              messageId: existing.id,
+              eventId: payload.id,
+              error: message,
+            })
+            return NextResponse.json(
+              { error: 'Failed to ingest recording attachment' },
+              { status: 500 }
+            )
+          }
+        }
+
+        break
+      }
 
       default:
         logger.debug('Ignoring unhandled Quo event type', { type: payload.type })
@@ -244,13 +530,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 }
 
 /**
- * Recovers the Quo conversation id (`CN…`) for a message webhook event.
+ * Recovers the Quo conversation id (`CN…`) for a message OR call webhook event — both share the
+ * same envelope shape, and neither payload object carries `conversationId` (verified live, v4).
  *
- * **Why this exists.** The v4 message webhook payload carries no `conversationId` — verified
- * against a live event. Without one, `MessageData.externalThreadId` is undefined, ingest's alias
+ * **Why this exists.** Without one, `MessageData.externalThreadId` is undefined, ingest's alias
  * rung (`resolveThreadId`) has nothing to look up, `Thread.externalId` stays NULL, and every
- * inbound message opens a brand-new thread. SMS has no `In-Reply-To`/`References` either, so the
- * conversation key is the ONLY threading signal this channel has.
+ * inbound message/call opens a brand-new thread. SMS/calls have no `In-Reply-To`/`References`
+ * either, so the conversation key is the ONLY threading signal this channel has.
  *
  * The source is `data.deepLink`, whose `/c/<CN…>` segment carries the id. It is free,
  * synchronous, and arrives **inside the HMAC-signed body**, so it is authenticated by the same
@@ -263,12 +549,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
  * authenticated than the one already in hand. The webhook is the delivery mechanism for this
  * event; asking the API to repeat itself is not more correct, only slower.
  *
- * Never throws, and a miss returns `null` — which is exactly the pre-fix behaviour: the message
- * still stores, it just opens its own thread. Ingest must not be breakable by a lookup that is
- * an improvement over nothing.
+ * Never throws, and a miss returns `null` — which is exactly the pre-fix behaviour: the
+ * message/call still stores, it just opens its own thread. Ingest must not be breakable by a
+ * lookup that is an improvement over nothing.
  */
-function resolveQuoConversationId(
-  event: QuoWebhookEvent<QuoWebhookMessage>,
+function resolveQuoConversationId<T extends { id?: string }>(
+  event: QuoWebhookEvent<T>,
   ctx: { integrationId: string }
 ): string | null {
   const conversationId = parseConversationIdFromDeepLink(event.data?.deepLink)
@@ -283,6 +569,107 @@ function resolveQuoConversationId(
     hasDeepLink: !!event.data?.deepLink,
   })
   return null
+}
+
+/**
+ * Whether the message already has an Attachment row of the given kind (voicemail vs recording,
+ * distinguished by the filename prefix this route itself assigns — `Attachment.title` carries the
+ * ingest filename). Per-kind, so the two media kinds on one call never mask each other. Used to
+ * make voicemail and recording ingest idempotent across webhook redeliveries WITHOUT relying on `storeMessage`'s
+ * `isNew` flag, which flips false on any redelivery once the row exists — including a redelivery
+ * triggered by returning 500 from a failed media fetch, which is exactly the case that must still
+ * retry.
+ */
+async function hasExistingAttachment(
+  messageId: string,
+  organizationId: string,
+  titlePrefix: 'voicemail.' | 'recording-'
+): Promise<boolean> {
+  const [row] = await db
+    .select({ id: schema.Attachment.id })
+    .from(schema.Attachment)
+    .where(
+      and(
+        eq(schema.Attachment.organizationId, organizationId),
+        eq(schema.Attachment.entityType, 'MESSAGE'),
+        eq(schema.Attachment.entityId, messageId),
+        like(schema.Attachment.title, `${titlePrefix}%`)
+      )
+    )
+    .limit(1)
+  return !!row
+}
+
+/**
+ * Fetches one voicemail or recording media URL as bytes. Plain `fetch` — Quo hands out
+ * presigned CDN URLs, not API endpoints, so there is no auth header to add (`quoFetch` is
+ * JSON-only and cannot be reused here).
+ *
+ * Returns `null` on any failure (non-2xx, over the size cap, or a network error) and never
+ * throws; the caller decides retry policy.
+ */
+async function fetchQuoMediaBytes(
+  url: string,
+  ctx: { eventId: string; kind: 'voicemail' | 'recording' }
+): Promise<Buffer | null> {
+  try {
+    const res = await fetch(url)
+    if (!res.ok) {
+      logger.error('Quo media fetch returned a non-2xx status', {
+        status: res.status,
+        kind: ctx.kind,
+        eventId: ctx.eventId,
+      })
+      return null
+    }
+
+    const contentLength = res.headers.get('content-length')
+    if (contentLength && Number(contentLength) > MAX_MEDIA_BYTES) {
+      logger.error('Quo media exceeds the size cap; skipping', {
+        contentLength,
+        kind: ctx.kind,
+        eventId: ctx.eventId,
+      })
+      return null
+    }
+
+    const arrayBuffer = await res.arrayBuffer()
+    if (arrayBuffer.byteLength > MAX_MEDIA_BYTES) {
+      logger.error('Quo media exceeded the size cap after download; skipping', {
+        size: arrayBuffer.byteLength,
+        kind: ctx.kind,
+        eventId: ctx.eventId,
+      })
+      return null
+    }
+
+    return Buffer.from(arrayBuffer)
+  } catch (error) {
+    logger.error('Quo media fetch failed', {
+      error: error instanceof Error ? error.message : String(error),
+      kind: ctx.kind,
+      eventId: ctx.eventId,
+    })
+    return null
+  }
+}
+
+/** Best-effort extension for the attachment filename. Defaults to `mp3` — Quo's common case. */
+function extensionForMimeType(mimeType: string | undefined): string {
+  switch (mimeType) {
+    case 'audio/wav':
+    case 'audio/x-wav':
+      return 'wav'
+    case 'audio/mp4':
+    case 'audio/x-m4a':
+    case 'audio/m4a':
+      return 'm4a'
+    case 'audio/ogg':
+      return 'ogg'
+    default:
+      // Includes 'audio/mpeg', Quo's common case.
+      return 'mp3'
+  }
 }
 
 /**

--- a/apps/web/src/components/files/utils/__tests__/attachment-display.test.tsx
+++ b/apps/web/src/components/files/utils/__tests__/attachment-display.test.tsx
@@ -159,6 +159,50 @@ describe('AttachmentDisplay', () => {
     })
   })
 
+  describe('audio attachments', () => {
+    const audioAttachment: CommentAttachmentInfo = {
+      ...mockAttachment,
+      id: 'att_audio',
+      name: 'voicemail.mp3',
+      mimeType: 'audio/mpeg',
+    }
+
+    test('renders an inline audio player instead of the download button', () => {
+      const { container } = render(<AttachmentDisplay attachment={audioAttachment} />)
+
+      expect(screen.getByText('voicemail.mp3')).toBeInTheDocument()
+      expect(container.querySelector('button')).not.toBeInTheDocument()
+      const audio = container.querySelector('audio')
+      expect(audio).toBeInTheDocument()
+      expect(audio).toHaveAttribute('src', '/api/attachments/att_audio/download')
+      expect(audio).toHaveAttribute('controls')
+      expect(audio).toHaveAttribute('preload', 'none')
+    })
+
+    test('shows the remove button for audio when requested', () => {
+      const onRemove = vi.fn()
+      render(
+        <AttachmentDisplay
+          attachment={audioAttachment}
+          showRemoveButton={true}
+          onRemove={onRemove}
+        />
+      )
+
+      const removeButton = screen.getByTitle('Remove file')
+      fireEvent.click(removeButton)
+      expect(onRemove).toHaveBeenCalledWith('att_audio')
+    })
+
+    test('applies custom className to the audio container', () => {
+      const { container } = render(
+        <AttachmentDisplay attachment={audioAttachment} className='custom-class' />
+      )
+
+      expect(container.firstChild).toHaveClass('custom-class')
+    })
+  })
+
   describe('edge cases', () => {
     test('handles attachment with zero size', () => {
       const zeroSizeAttachment: CommentAttachmentInfo = {

--- a/apps/web/src/components/files/utils/attachment-display.tsx
+++ b/apps/web/src/components/files/utils/attachment-display.tsx
@@ -49,6 +49,56 @@ export function AttachmentDisplay({
   }
 
   const isImage = isPreviewableImage(attachment.mimeType)
+  const isAudio = attachment.mimeType?.toLowerCase().startsWith('audio/') ?? false
+
+  // Audio (voicemail / call recording) attachments get an inline player
+  // instead of the click-to-download chip — nesting <audio controls> inside
+  // the download <button> below would make play/seek clicks also trigger a
+  // download navigation, so this is a separate, non-button container. The
+  // player streams from the same `/download` route the button uses (a 302 to
+  // a presigned URL); the route's Content-Disposition only applies to direct
+  // navigation, not to a media element's fetch.
+  if (isAudio) {
+    return (
+      <div
+        className={cn(
+          'flex flex-col gap-2 rounded-xl border bg-gray-50/50 p-2 ps-3 dark:bg-muted',
+          className
+        )}>
+        <div className='flex min-w-0 items-center gap-3'>
+          <FileIcon
+            mimeType={attachment.mimeType || 'audio/mpeg'}
+            className='size-4 shrink-0 text-gray-500'
+          />
+          <div className='min-w-0 flex-1'>
+            <span className='block truncate text-sm font-medium' title={attachment.name}>
+              {attachment.name}
+            </span>
+            {attachment.size && (
+              <div className='text-xs text-gray-500'>{formatBytes(attachment.size ?? 0)}</div>
+            )}
+          </div>
+          {showRemoveButton && onRemove && (
+            <Button
+              variant='ghost'
+              size='icon-sm'
+              onClick={handleRemove}
+              title='Remove file'
+              className='rounded-full hover:bg-bad-200/50 hover:text-bad-500'>
+              <Trash2 />
+            </Button>
+          )}
+        </div>
+        <audio
+          controls
+          preload='none'
+          className='h-8 w-full min-w-0'
+          src={`/api/attachments/${attachment.id}/download`}>
+          <track kind='captions' />
+        </audio>
+      </div>
+    )
+  }
 
   return (
     <button

--- a/apps/web/src/components/mail/call-display.tsx
+++ b/apps/web/src/components/mail/call-display.tsx
@@ -1,0 +1,181 @@
+// apps/web/src/components/mail/call-display.tsx
+'use client'
+
+import { Avatar, AvatarFallback, AvatarImage } from '@auxx/ui/components/avatar'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { cn } from '@auxx/ui/lib/utils'
+import { formatDistanceToNow } from 'date-fns'
+import { Phone, PhoneMissed, PhoneOutgoing, Voicemail } from 'lucide-react'
+import type { ComponentType } from 'react'
+import { useMessage, useMessageParticipants } from '~/components/threads/hooks'
+import type { AttachmentMeta } from '~/components/threads/store'
+import { ContactHoverCard } from '../contacts/contact-hover-card'
+import { AttachmentDisplay } from '../files/utils/attachment-display'
+import { Tooltip } from '../global/tooltip'
+import type { EmailActions } from './email-actions'
+import { initialsFor } from './utils/participant-initials'
+
+interface CallDisplayProps {
+  /** Message ID to display */
+  messageId: string
+  /** Actions for this message — mirrors MessageDisplay's prop shape; the call card has no dropdown today. */
+  messageActions: EmailActions
+  /** Whether message is expanded by default — mirrors MessageDisplay's prop shape; unused (the call card never collapses). */
+  isOpen: boolean
+}
+
+/**
+ * Displays a CALL or VOICEMAIL message as a compact card: state icon + title,
+ * duration when known, and any non-inline attachments (voicemail audio, or a
+ * later call recording) via `AttachmentDisplay`. Fetches its own data from
+ * the message store, same as `MessageDisplay`.
+ */
+const CallDisplay = ({ messageId }: CallDisplayProps) => {
+  const { message, isLoading } = useMessage({ messageId })
+  const { from: sender } = useMessageParticipants(message?.participants ?? [])
+
+  if (isLoading) {
+    return <CallSkeleton />
+  }
+
+  if (!message) {
+    return null
+  }
+
+  const callMeta = message.callMeta ?? null
+  const isVoicemail = message.messageType === 'VOICEMAIL'
+  const answered = callMeta?.answered ?? true
+  const direction = callMeta?.direction ?? (message.isInbound ? 'incoming' : 'outgoing')
+
+  const { Icon, title }: { Icon: ComponentType<{ className?: string }>; title: string } =
+    isVoicemail
+      ? { Icon: Voicemail, title: 'Voicemail' }
+      : !answered
+        ? { Icon: PhoneMissed, title: 'Missed call' }
+        : direction === 'outgoing'
+          ? { Icon: PhoneOutgoing, title: 'Outgoing call' }
+          : { Icon: Phone, title: 'Call' }
+
+  const isInbound = message.isInbound
+  const senderName = sender?.displayName ?? 'Unknown'
+  const senderInitials = initialsFor(sender)
+  const contactId = sender?.entityInstanceId
+  const nonInlineAttachments = (message.attachments ?? []).filter((a) => !a.inline)
+  const duration =
+    callMeta?.durationSeconds != null ? formatCallDuration(callMeta.durationSeconds) : null
+
+  return (
+    <div className='mt-2 flex flex-col'>
+      <div className={cn('flex flex-row', isInbound ? 'justify-start' : 'justify-end')}>
+        <div className={cn('mt-1 shrink-0', isInbound ? 'order-1' : 'order-3')}>
+          <ContactHoverCard contactId={contactId ?? undefined}>
+            <Avatar className='h-8 w-8'>
+              <AvatarFallback className='bg-foreground/50 text-background hover:bg-foreground/70'>
+                {senderInitials}
+              </AvatarFallback>
+              <AvatarImage src={sender?.avatarUrl ?? undefined} />
+            </Avatar>
+          </ContactHoverCard>
+        </div>
+
+        <div
+          className={cn(
+            'max-w-lg px-2',
+            isInbound ? 'order-2 justify-self-start' : 'order-2 justify-self-end'
+          )}>
+          <div className='min-h-[70px] min-w-[192px] rounded-2xl border border-black/10 bg-background shadow-xs dark:bg-gray-500'>
+            <div className='truncate px-4 py-2'>
+              <div className='truncate font-medium text-gray-700 text-sm'>{senderName}</div>
+            </div>
+
+            <div className='px-4 pb-3'>
+              <div className='flex items-center gap-2 text-foreground text-sm'>
+                <Icon className='size-4 shrink-0' />
+                <span className='font-medium'>{title}</span>
+                {duration && <span className='text-muted-foreground text-xs'>{duration}</span>}
+              </div>
+
+              {nonInlineAttachments.length > 0 && (
+                <div className='mt-2 flex flex-col gap-1.5'>
+                  {nonInlineAttachments.map((a) => (
+                    <AttachmentDisplay
+                      key={a.id}
+                      attachment={toAttachmentInfo(a)}
+                      showRemoveButton={false}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div
+          className={cn(
+            'px-1 pt-4 text-gray-500 text-xs font-normal uppercase',
+            isInbound ? 'order-3' : 'order-1'
+          )}>
+          <Tooltip
+            content={message.sentAt ? new Date(message.sentAt).toString() : ''}
+            delayDuration={0}
+            side='top'
+            sideOffset={5}
+            className='text-muted-foreground text-xs'>
+            <span className='shrink-0 whitespace-nowrap'>
+              {formatDistanceToNow(message.sentAt ? new Date(message.sentAt) : new Date(), {
+                addSuffix: true,
+              })}
+            </span>
+          </Tooltip>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CallDisplay
+
+/** Formats seconds as `m:ss` — `125` → `2:05`. Negative/NaN inputs clamp to `0:00`. */
+export function formatCallDuration(totalSeconds: number): string {
+  const clamped = Number.isFinite(totalSeconds) ? Math.max(0, Math.floor(totalSeconds)) : 0
+  const minutes = Math.floor(clamped / 60)
+  const seconds = clamped % 60
+  return `${minutes}:${String(seconds).padStart(2, '0')}`
+}
+
+/**
+ * Bridge from `AttachmentMeta` (the store's display shape, already loaded for
+ * every message) to the `GroupedAttachmentInfo` shape `AttachmentDisplay`
+ * expects. Mirrors `chat-message-display.tsx`'s `toAttachmentInfo` — at
+ * runtime the component only reads id/name/mimeType/size.
+ */
+function toAttachmentInfo(a: AttachmentMeta) {
+  return {
+    id: a.id,
+    role: 'ATTACHMENT',
+    title: null,
+    sort: 0,
+    createdAt: new Date(),
+    type: 'asset' as const,
+    fileId: a.id,
+    name: a.name,
+    mimeType: a.mimeType,
+    size: a.size ?? null,
+  }
+}
+
+function CallSkeleton() {
+  return (
+    <div className='mt-2 flex flex-col'>
+      <div className='flex flex-row justify-start'>
+        <Skeleton className='mt-1 h-8 w-8 rounded-full' />
+        <div className='max-w-lg px-2'>
+          <div className='min-h-[70px] min-w-[192px] space-y-2 rounded-2xl border p-4'>
+            <Skeleton className='h-4 w-24' />
+            <Skeleton className='h-4 w-32' />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/mail/chat-panel/messages.tsx
+++ b/apps/web/src/components/mail/chat-panel/messages.tsx
@@ -6,9 +6,12 @@ import { Skeleton } from '@auxx/ui/components/skeleton'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { useEffect, useMemo, useRef } from 'react'
 import { useMessages, useThreadMutation } from '~/components/threads/hooks'
+import CallDisplay from '../call-display'
 import { ChatMessageGroup } from '../chat-message-group'
 import { buildChatTimeline } from '../chat-timeline'
 import type { EmailActions } from '../email-actions'
+import EmailDisplay from '../email-display'
+import MessageDisplay from '../message-display'
 import { SystemLine } from './system-line'
 import { useChatThreadEvents } from './use-thread-events'
 
@@ -104,14 +107,41 @@ export function ChatPanelMessages({ threadId, popoverClassName }: ChatPanelMessa
               />
             )
           }
-          // Non-chat messages are unexpected in a chat thread; render a
-          // compact text fallback so we still surface them.
+          // Non-chat messages are unexpected in a chat thread (the floating
+          // panel only mounts for `provider === 'chat'` threads), but
+          // `buildChatTimeline` is shared with `thread-messages.tsx` and a
+          // mixed-transport thread (e.g. openphone SMS + CALL) is possible in
+          // principle — give the "single" branch the same type switch instead
+          // of a generic text fallback.
+          const isLastMessage = item.index === messages.length - 1
+          if (item.message.messageType === 'EMAIL') {
+            return (
+              <EmailDisplay
+                key={item.message.id}
+                messageId={item.message.id}
+                messageActions={messageActions}
+                isOpen={isLastMessage}
+                isLastMessage={isLastMessage}
+              />
+            )
+          }
+          if (item.message.messageType === 'CALL' || item.message.messageType === 'VOICEMAIL') {
+            return (
+              <CallDisplay
+                key={item.message.id}
+                messageId={item.message.id}
+                messageActions={messageActions}
+                isOpen={isLastMessage}
+              />
+            )
+          }
           return (
-            <div
+            <MessageDisplay
               key={item.message.id}
-              className='mx-auto w-full max-w-2xl rounded-md border border-dashed border-muted-foreground/30 px-3 py-2 text-xs text-muted-foreground'>
-              {item.message.snippet || item.message.textPlain || '(non-chat message)'}
-            </div>
+              messageId={item.message.id}
+              messageActions={messageActions}
+              isOpen={isLastMessage}
+            />
           )
         })}
       </div>

--- a/apps/web/src/components/mail/thread-messages.tsx
+++ b/apps/web/src/components/mail/thread-messages.tsx
@@ -21,6 +21,7 @@ import { getThreadStoreState } from '~/components/threads/store/thread-store'
 import { useCompose } from '~/hooks/use-compose'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
+import CallDisplay from './call-display'
 import { ChatMessageGroup } from './chat-message-group'
 import { SystemLine } from './chat-panel/system-line'
 import { useChatThreadEvents } from './chat-panel/use-thread-events'
@@ -305,6 +306,12 @@ export function ThreadMessages() {
                   messageActions={messageActions}
                   isOpen={isLastMessage}
                   isLastMessage={isLastMessage}
+                />
+              ) : message.messageType === 'CALL' || message.messageType === 'VOICEMAIL' ? (
+                <CallDisplay
+                  messageId={message.id}
+                  messageActions={messageActions}
+                  isOpen={isLastMessage}
                 />
               ) : (
                 <MessageDisplay

--- a/apps/web/src/components/threads/store/message-store.ts
+++ b/apps/web/src/components/threads/store/message-store.ts
@@ -68,6 +68,21 @@ export interface MessageMeta {
   /** Chat-only: delivery/read receipts for the (single) recipient. ISO dates. */
   deliveredAt?: string | null
   readAt?: string | null
+
+  /**
+   * CALL/VOICEMAIL-only: call envelope. `messageType === 'VOICEMAIL'` is an
+   * unanswered call that left audio (the audio itself is a regular
+   * attachment, mimeType `audio/*`); `messageType === 'CALL'` is a completed
+   * call — `answered: false` means missed with no voicemail. Call recordings
+   * may attach to CALL messages too, also as `audio/*` attachments.
+   */
+  callMeta?: {
+    direction: 'incoming' | 'outgoing'
+    answered: boolean
+    answeredAt: string | null
+    completedAt: string | null
+    durationSeconds: number | null
+  } | null
 }
 
 /**

--- a/packages/database/src/db/schema/message.ts
+++ b/packages/database/src/db/schema/message.ts
@@ -161,6 +161,15 @@ export const Message = pgTable(
     index('Message_listId_threadId_idx')
       .using('btree', table.listId.asc().nullsLast(), table.threadId.asc().nullsLast())
       .where(sql`("listId" IS NOT NULL)`),
+    // Serves the correlated `exists(...)` that a `messageType` condition compiles
+    // to (message-type-overhaul plan §Phase 3, condition-query-builder.ts
+    // `buildMessageTypeQuery`) — threadId must be IN the index or every
+    // candidate thread degrades to a heap lookup, same reasoning as
+    // Message_listId_threadId_idx above. Partial on CALL/VOICEMAIL because
+    // those are a tiny fraction of rows; EMAIL/SMS/CHAT never hit this path.
+    index('Message_messageType_threadId_idx')
+      .using('btree', table.messageType.asc().nullsLast(), table.threadId.asc().nullsLast())
+      .where(sql`"messageType" IN ('CALL', 'VOICEMAIL')`),
     uniqueIndex('Message_organizationId_internetMessageId_key')
       .using(
         'btree',

--- a/packages/lib/src/mail-query/__tests__/condition-query-builder.test.ts
+++ b/packages/lib/src/mail-query/__tests__/condition-query-builder.test.ts
@@ -791,3 +791,83 @@ describe('channelType', () => {
     expect(toSql(buildOne('channelType', 'not empty', undefined).sql)).toMatch(/true/)
   })
 })
+
+// ═══════════════════════════════════════════════════════════════════════════
+// `messageType` — the FORM a message takes (email/sms/chat/call/voicemail),
+// contrasted with `channelType` above (the channel a thread ARRIVED on).
+// "Thread contains a voicemail" is a correlated `exists` over `Message`, the
+// same shape as `hasAttachments` / `list` / `senderDomain`, not the
+// `channelType` shape (message-type-overhaul plan §3a).
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('messageType', () => {
+  it('offers only operators the builder dispatches', () => {
+    const operators = offeredOperators('messageType')
+    expect(operators.length).toBeGreaterThan(0)
+
+    for (const operator of operators) {
+      const value = operator.valueType === 'none' ? undefined : ['VOICEMAIL']
+      const result = buildOne('messageType', operator.key, value)
+
+      expect({ operator: operator.key, dropped: result.droppedConditions }).toEqual({
+        operator: operator.key,
+        dropped: [],
+      })
+      expect(result.allConditionsDropped).toBe(false)
+    }
+  })
+
+  it('compiles `is`/`in` to a correlated exists over Message', () => {
+    const built = buildWithSubquery('messageType', 'is', 'VOICEMAIL')
+
+    expect(built.table).toBe(schema.Message)
+    expect(built.sqlText).toMatch(/\bexists \$\d+/)
+    expect(toParams(built.where)).toContain('VOICEMAIL')
+
+    const inMany = buildWithSubquery('messageType', 'in', ['VOICEMAIL', 'CALL'])
+    expect(toSql(inMany.where)).toMatch(/ in \(/i)
+    expect(toParams(inMany.where)).toEqual(expect.arrayContaining(['VOICEMAIL', 'CALL']))
+  })
+
+  it('negates `is not` / `not in` as NOT EXISTS over the thread', () => {
+    for (const [operator, value] of [
+      ['is not', 'VOICEMAIL'],
+      ['not in', ['VOICEMAIL']],
+    ] as const) {
+      const built = buildWithSubquery('messageType', operator, value)
+
+      expect(built.sqlText).toMatch(/\bnot exists \$\d+/)
+      expect(built.table).toBe(schema.Message)
+    }
+  })
+
+  it('answers `empty` as constant false / `not empty` as constant true — messageType is NOT NULL', () => {
+    // Dispatched explicitly rather than left to fall through: an undispatched
+    // operator is a silent DROP, which fails the whole filter OPEN (mail-filters
+    // invariant 19).
+    expect(toSql(buildOne('messageType', 'empty', undefined).sql)).toMatch(/false/)
+    expect(toSql(buildOne('messageType', 'not empty', undefined).sql)).toMatch(/true/)
+  })
+
+  it('drops the condition on an empty value list rather than matching every thread', () => {
+    const result = buildOne('messageType', 'in', [])
+
+    expect(result.allConditionsDropped).toBe(true)
+    expect(result.droppedConditions[0]?.reason).toBe('unsupported-operator-or-value')
+    expect(toSql(result.sql)).toBe(baseScopeSql())
+  })
+
+  it('filters an unknown value out of the list instead of passing it through', () => {
+    const built = buildWithSubquery('messageType', 'in', ['VOICEMAIL', 'carrier-pigeon'])
+
+    expect(toParams(built.where)).toContain('VOICEMAIL')
+    expect(toParams(built.where)).not.toContain('carrier-pigeon')
+  })
+
+  it('drops entirely when every value in the list is unknown', () => {
+    const result = buildOne('messageType', 'is', ['carrier-pigeon'])
+
+    expect(result.allConditionsDropped).toBe(true)
+    expect(toSql(result.sql)).toBe(baseScopeSql())
+  })
+})

--- a/packages/lib/src/mail-query/condition-query-builder.ts
+++ b/packages/lib/src/mail-query/condition-query-builder.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/mail-query/condition-query-builder.ts
 
 import { database as db, schema } from '@auxx/database'
+import { MessageTypeValues } from '@auxx/database/enums'
 
 const { Thread } = schema
 
@@ -314,6 +315,8 @@ function dispatchConditionQuery(
       return buildToQuery(op, value)
     case 'channelType':
       return buildChannelTypeQuery(op, value)
+    case 'messageType':
+      return buildMessageTypeQuery(op, value)
     case 'subject':
       return withScope(buildSubjectQuery(op, value), scopes.subject)
     case 'body':
@@ -816,6 +819,68 @@ function buildChannelTypeQuery(operator: Operator, value: unknown): SQL<unknown>
     case 'not in': {
       const groups = textList(value)
       return groups.length > 0 ? not(threadsOnGroups(groups)) : null
+    }
+    case 'empty':
+      return sql`false`
+    case 'not empty':
+      return sql`true`
+    default:
+      return null
+  }
+}
+
+/**
+ * Build the `messageType` condition — "this thread CONTAINS a message of the
+ * given FORM (email/sms/chat/call/voicemail)".
+ *
+ * A correlated `exists(select 1 from Message where Message.threadId =
+ * Thread.id and Message.messageType IN (values))` — the same shape as
+ * `hasAttachments` (`:1060` below) / `list` / `body` / `sent` / `sender`
+ * (message-type-overhaul plan §3a). A per-message column expressed as a
+ * thread condition through the established pattern, not a new capability.
+ *
+ * ⚠️ **Contrast with `buildChannelTypeQuery` above.** `channelType` resolves
+ * `Thread.integrationId → Integration.provider` and never touches `Message` —
+ * it answers *"arrived on a text channel"*. `messageType` reads
+ * `Message.messageType` per row — it answers *"contains a voicemail"*. On an
+ * ordinary thread those agree (provider determines type for 11 of 12
+ * providers), but on a mixed `openphone` thread — a voicemail and three texts
+ * on the same `Integration` — they genuinely differ, which is the entire
+ * reason this condition exists instead of reusing `channelType`.
+ *
+ * `empty` / `not empty` are dispatched as CONSTANTS rather than left to fall
+ * through: `Message.messageType` is `NOT NULL`, so no thread can lack a typed
+ * message. `SINGLE_SELECT` OFFERS these operators regardless, and an
+ * undispatched operator is a silent DROP that fails the whole filter OPEN
+ * (mail-filters invariant 19 — see `buildChannelTypeQuery`'s docstring).
+ *
+ * Unknown values (anything outside the five `MessageType` members) are
+ * dropped from the list rather than passed through to `IN (...)`.
+ */
+function buildMessageTypeQuery(operator: Operator, value: unknown): SQL<unknown> | null {
+  const { Message } = schema
+  const knownTypes = new Set<string>(MessageTypeValues)
+
+  const validTypes = (values: string[]): string[] => values.filter((v) => knownTypes.has(v))
+
+  const threadsWithType = (types: string[]): SQL<unknown> =>
+    exists(
+      db
+        .select({ id: sql`1` })
+        .from(Message)
+        .where(and(eq(Message.threadId, Thread.id), inArray(Message.messageType, types as any)))
+    )
+
+  switch (operator) {
+    case 'is':
+    case 'in': {
+      const types = validTypes(textList(value))
+      return types.length > 0 ? threadsWithType(types) : null
+    }
+    case 'is not':
+    case 'not in': {
+      const types = validTypes(textList(value))
+      return types.length > 0 ? not(threadsWithType(types)) : null
     }
     case 'empty':
       return sql`false`

--- a/packages/lib/src/mail-views/mail-view-field-definitions.ts
+++ b/packages/lib/src/mail-views/mail-view-field-definitions.ts
@@ -5,6 +5,7 @@ import { toResourceFieldId } from '@auxx/types/field'
 import { CHANNEL_GROUP_OPTIONS } from '../channels/capabilities'
 import { getOperatorsForFieldType, type Operator } from '../conditions/operator-definitions'
 import type { FieldOptions } from '../custom-fields/field-options'
+import { MESSAGE_TYPE_OPTIONS } from '../providers/types'
 // NOTE: This file is used on both client and server.
 // Only import from client-safe paths.
 import { BaseType } from '../workflow-engine/types'
@@ -249,6 +250,28 @@ export const MAIL_VIEW_FIELD_DEFINITIONS: MailViewFieldDefinition[] = [
     fieldType: FieldType.SINGLE_SELECT,
     options: { options: CHANNEL_GROUP_OPTIONS.map((o) => ({ value: o.value, label: o.label })) },
     description: 'Filter by the channel a conversation arrived on',
+  },
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // MESSAGE TYPE FIELD
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Contrast with `channelType` above: `channelType` is the coarse channel a
+  // thread ARRIVED on (`Thread.integrationId` → `Integration.provider`).
+  // `messageType` is the FORM a message in the thread takes — a per-`Message`
+  // column (message-type-overhaul plan §2.7). They coexist because provider
+  // determines type for 11 of 12 providers but not for `openphone`, which can
+  // put a CALL/VOICEMAIL and a SMS in the same thread: `channelType is sms`
+  // matches every Quo thread, `messageType is VOICEMAIL` matches only the ones
+  // that actually contain one (plan §3a). The condition-query-builder case
+  // (`case 'messageType':`) must ship in the same commit as this entry — an
+  // undispatched condition id is dropped silently and fails the filter OPEN.
+  {
+    id: 'messageType',
+    label: 'Message type',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    options: { options: MESSAGE_TYPE_OPTIONS },
+    description: 'Filter by the kind of message a conversation contains (e.g. a voicemail)',
   },
 
   // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/lib/src/messages/message-query.service.ts
+++ b/packages/lib/src/messages/message-query.service.ts
@@ -12,6 +12,7 @@ import { getThreadLensBatch } from '../permissions/visibility/thread-lens'
 import type { MessageType } from '../providers/types'
 import type {
   AttachmentMeta,
+  CallMessageMeta,
   ListMessagesByThreadResult,
   MessageMeta,
   SendStatus,
@@ -43,6 +44,16 @@ export class MessageQueryService {
   /** The viewer's lens on a set of threads (§5.2) — see {@link getThreadLensBatch}. */
   private async getThreadLenses(threadIds: string[]): Promise<Map<string, Lens>> {
     return getThreadLensBatch(this.db, this.organizationId, this.viewer, threadIds)
+  }
+
+  /**
+   * Projects `Message.metadata.call` (the `QuoCallMeta` shape `webhook-call.ts` writes) onto
+   * `MessageMeta.callMeta`. Only that one key ever reaches the client — the rest of `metadata`
+   * (e.g. `quo_webhook_event`) is never selected past this point.
+   */
+  private extractCallMeta(metadata: unknown): CallMessageMeta | null {
+    const call = (metadata as { call?: unknown } | null | undefined)?.call
+    return (call as CallMessageMeta | undefined) ?? null
   }
 
   /**
@@ -97,6 +108,7 @@ export class MessageQueryService {
         replyToId: true,
         integrationId: true,
         messageType: true,
+        metadata: true,
         sendStatus: true,
         providerError: true,
         attempts: true,
@@ -133,6 +145,7 @@ export class MessageQueryService {
         participants,
         createdById: m.createdById,
         messageType: m.messageType as MessageType,
+        callMeta: this.extractCallMeta(m.metadata),
         sendStatus: (m.sendStatus as SendStatus) ?? null,
         providerError: m.providerError ?? null,
         attempts: m.attempts ?? 0,
@@ -182,6 +195,7 @@ export class MessageQueryService {
         replyToId: true,
         integrationId: true,
         messageType: true,
+        metadata: true,
         sendStatus: true,
         providerError: true,
         attempts: true,
@@ -226,6 +240,7 @@ export class MessageQueryService {
           participants,
           createdById: m.createdById,
           messageType: m.messageType as MessageType,
+          callMeta: this.extractCallMeta(m.metadata),
           sendStatus: (m.sendStatus as SendStatus) ?? null,
           providerError: m.providerError ?? null,
           attempts: m.attempts ?? 0,

--- a/packages/lib/src/messages/types/message-query.types.ts
+++ b/packages/lib/src/messages/types/message-query.types.ts
@@ -14,6 +14,19 @@ export type SendStatus = 'PENDING' | 'SENT' | 'FAILED' | 'BOUNCED'
 export { MessageType }
 
 /**
+ * Projection of `Message.metadata.call` (written by `webhook-call.ts`'s `QuoCallMeta`) — the
+ * only call/voicemail shape exposed to the client. The raw `metadata` blob (which also carries
+ * `quo_webhook_event`) is never sent as-is.
+ */
+export interface CallMessageMeta {
+  direction: 'incoming' | 'outgoing'
+  answered: boolean
+  answeredAt: string | null
+  completedAt: string | null
+  durationSeconds: number | null
+}
+
+/**
  * Attachment metadata for display.
  */
 export interface AttachmentMeta {
@@ -71,6 +84,13 @@ export type MessageMeta = {
 
   // Message type for rendering (EMAIL, CHAT, SMS)
   messageType: MessageType
+
+  /**
+   * Call/voicemail detail, projected from `Message.metadata.call` — `null` for every
+   * non-CALL/VOICEMAIL message and for a CALL/VOICEMAIL row stored before this projection
+   * existed. Never the raw `metadata` blob.
+   */
+  callMeta?: CallMessageMeta | null
 }
 
 /**

--- a/packages/lib/src/permissions/visibility/redact.ts
+++ b/packages/lib/src/permissions/visibility/redact.ts
@@ -65,6 +65,9 @@ export const MESSAGE_CONTENT_FIELDS: readonly string[] = [
   'snippet',
   'htmlBodyStorageLocationId',
   'attachments',
+  // Call/voicemail duration + answered state — as much content as a snippet, just for CALL/
+  // VOICEMAIL rows (message-type-overhaul Phase 4).
+  'callMeta',
 ]
 
 /** Blanked values for redacted full-tier fields (keeps the ThreadMeta shape intact). */
@@ -137,6 +140,7 @@ const REDACTED_MESSAGE_DEFAULTS: Record<string, unknown> = {
   snippet: null,
   htmlBodyStorageLocationId: null,
   attachments: [],
+  callMeta: null,
 }
 
 /**

--- a/packages/lib/src/providers/openphone/__tests__/openphone-provider.test.ts
+++ b/packages/lib/src/providers/openphone/__tests__/openphone-provider.test.ts
@@ -149,7 +149,12 @@ describe('OpenPhoneProvider.setupWebhook', () => {
 
     const body = mocks.createMessageWebhook.mock.calls[0]![1]
     expect(body.url).toBe(CALLBACK_URL)
-    expect(body.events).toEqual(['message.received', 'message.delivered'])
+    expect(body.events).toEqual([
+      'message.received',
+      'message.delivered',
+      'call.completed',
+      'call.recording.completed',
+    ])
     // Per-number, not `["*"]` — one channel owns one webhook.
     expect(body.resourceIds).toEqual([PHONE_NUMBER_ID])
     // Created ENABLED, because Quo webhooks are immutable — `/v1/webhooks/{id}` routes only GET

--- a/packages/lib/src/providers/openphone/__tests__/webhook-call.test.ts
+++ b/packages/lib/src/providers/openphone/__tests__/webhook-call.test.ts
@@ -1,0 +1,199 @@
+// packages/lib/src/providers/openphone/__tests__/webhook-call.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { MessageType } from '../../types'
+import type { QuoWebhookCall, QuoWebhookEvent } from '../types'
+import { convertQuoWebhookCallEventToMessageData } from '../webhook-call'
+
+/**
+ * NOT captured from a live event — we don't subscribe to call events yet (this is the mapper
+ * that makes subscribing to them safe). Built strictly from the documented/verified shape in
+ * `types.ts` (`QuoWebhookCall`), which mirrors the message shape plus voicemail/recording media,
+ * `answeredAt`, `completedAt`. Per `webhook-message.test.ts`'s convention: when a real captured
+ * `call.completed` payload lands in `Message.metadata.quo_webhook_event`, replace this fixture
+ * with it rather than hand-editing this one further.
+ */
+const ANSWERED_INBOUND: QuoWebhookEvent<QuoWebhookCall> = {
+  id: 'EVcall_answered_inbound',
+  object: 'event',
+  apiVersion: 'v4',
+  createdAt: '2026-08-17T10:00:00.000Z',
+  type: 'call.completed',
+  data: {
+    object: {
+      id: 'AC_redacted_call_id',
+      object: 'call',
+      to: '+18889155797',
+      from: '+15102055536',
+      direction: 'incoming',
+      status: 'completed',
+      answeredAt: '2026-08-17T10:00:05.000Z',
+      completedAt: '2026-08-17T10:02:18.000Z', // 2:13 after answeredAt
+      createdAt: '2026-08-17T10:00:00.000Z',
+      userId: 'USLPYvl8qp',
+      phoneNumberId: 'PN0eLoM7TQ',
+    },
+    deepLink:
+      'https://my.quo.com/inbox/PN0eLoM7TQ/c/CNa71b750b888a4cdd81cd3a1ff0f8c0a9?at=AC_redacted_call_id',
+  },
+}
+
+const MISSED_NO_VOICEMAIL: QuoWebhookEvent<QuoWebhookCall> = {
+  ...ANSWERED_INBOUND,
+  id: 'EVcall_missed',
+  data: {
+    ...ANSWERED_INBOUND.data,
+    object: {
+      ...ANSWERED_INBOUND.data.object,
+      id: 'AC_redacted_missed_call_id',
+      answeredAt: null,
+      completedAt: '2026-08-17T10:00:12.000Z',
+    },
+  },
+}
+
+const VOICEMAIL: QuoWebhookEvent<QuoWebhookCall> = {
+  ...ANSWERED_INBOUND,
+  id: 'EVcall_voicemail',
+  data: {
+    ...ANSWERED_INBOUND.data,
+    object: {
+      ...ANSWERED_INBOUND.data.object,
+      id: 'AC_redacted_voicemail_call_id',
+      answeredAt: null,
+      completedAt: '2026-08-17T10:00:50.000Z',
+      voicemail: { url: 'https://cdn.quo.example/vm.mp3', type: 'audio/mpeg', duration: 42 },
+    },
+  },
+}
+
+const OUTGOING_ANSWERED: QuoWebhookEvent<QuoWebhookCall> = {
+  ...ANSWERED_INBOUND,
+  id: 'EVcall_outgoing_answered',
+  data: {
+    ...ANSWERED_INBOUND.data,
+    object: {
+      ...ANSWERED_INBOUND.data.object,
+      id: 'AC_redacted_outgoing_call_id',
+      to: '+15102055536',
+      from: '+18889155797',
+      direction: 'outgoing',
+      answeredAt: '2026-08-17T10:00:05.000Z',
+      completedAt: '2026-08-17T10:00:35.000Z', // 0:30
+    },
+  },
+}
+
+const METADATA = { phoneNumberId: 'PN0eLoM7TQ', phoneNumber: '+18889155797' }
+const CONVERSATION_ID = 'CNa71b750b888a4cdd81cd3a1ff0f8c0a9'
+
+const convert = (
+  event: QuoWebhookEvent<QuoWebhookCall>,
+  conversationId: string | null = CONVERSATION_ID
+) => convertQuoWebhookCallEventToMessageData(event, 'int-1', 'org-1', METADATA, conversationId)
+
+describe('convertQuoWebhookCallEventToMessageData', () => {
+  describe('answered call', () => {
+    it('maps to CALL with the computed duration and answered:true', () => {
+      const data = convert(ANSWERED_INBOUND)
+      expect(data?.messageType).toBe(MessageType.CALL)
+      expect(data?.hasAttachments).toBe(false)
+      expect(data?.snippet).toBe('Call (2:13)')
+
+      const callMeta = (data?.metadata as any)?.call
+      expect(callMeta.answered).toBe(true)
+      expect(callMeta.direction).toBe('incoming')
+      expect(callMeta.durationSeconds).toBe(133) // 2:13
+      expect(callMeta.answeredAt).toBe('2026-08-17T10:00:05.000Z')
+      expect(callMeta.completedAt).toBe('2026-08-17T10:02:18.000Z')
+    })
+
+    it('labels an outgoing answered call distinctly and computes duration from its own timestamps', () => {
+      const data = convert(OUTGOING_ANSWERED)
+      expect(data?.isInbound).toBe(false)
+      expect(data?.snippet).toBe('Outgoing call (0:30)')
+      expect((data?.metadata as any)?.call.direction).toBe('outgoing')
+    })
+  })
+
+  describe('missed call, no voicemail', () => {
+    it('maps to CALL, answered:false, "Missed call"', () => {
+      const data = convert(MISSED_NO_VOICEMAIL)
+      expect(data?.messageType).toBe(MessageType.CALL)
+      expect(data?.snippet).toBe('Missed call')
+      expect(data?.hasAttachments).toBe(false)
+      expect((data?.metadata as any)?.call.answered).toBe(false)
+      expect((data?.metadata as any)?.call.durationSeconds).toBeNull()
+    })
+  })
+
+  describe('voicemail', () => {
+    it('maps to VOICEMAIL, hasAttachments:true, duration from voicemail.duration', () => {
+      const data = convert(VOICEMAIL)
+      expect(data?.messageType).toBe(MessageType.VOICEMAIL)
+      expect(data?.hasAttachments).toBe(true)
+      expect(data?.snippet).toBe('Voicemail (0:42)')
+      const callMeta = (data?.metadata as any)?.call
+      expect(callMeta.durationSeconds).toBe(42)
+      expect(callMeta.answered).toBe(false)
+    })
+
+    it('retains the raw event for a future recording/voicemail backfill', () => {
+      expect(convert(VOICEMAIL)?.metadata).toEqual({
+        call: (convert(VOICEMAIL)?.metadata as any).call,
+        quo_webhook_event: VOICEMAIL,
+      })
+    })
+  })
+
+  describe('threading and envelope', () => {
+    it('takes the conversation key from the caller, not the payload', () => {
+      expect(convert(ANSWERED_INBOUND)?.externalThreadId).toBe(CONVERSATION_ID)
+      expect(convert(ANSWERED_INBOUND, null)?.externalThreadId).toBeUndefined()
+    })
+
+    it('carries no subject', () => {
+      expect(convert(ANSWERED_INBOUND)?.subject).toBeNull()
+    })
+
+    it('externalId is the call id', () => {
+      expect(convert(ANSWERED_INBOUND)?.externalId).toBe('AC_redacted_call_id')
+    })
+  })
+
+  describe('unusable payloads return null rather than throwing', () => {
+    it('drops an event with no call object', () => {
+      expect(
+        convertQuoWebhookCallEventToMessageData(
+          { ...ANSWERED_INBOUND, data: { object: undefined as never } },
+          'int-1',
+          'org-1',
+          METADATA,
+          CONVERSATION_ID
+        )
+      ).toBeNull()
+    })
+
+    it('drops an event with an unparseable createdAt', () => {
+      const bad = {
+        ...ANSWERED_INBOUND,
+        data: {
+          ...ANSWERED_INBOUND.data,
+          object: { ...ANSWERED_INBOUND.data.object, createdAt: 'not-a-date' },
+        },
+      }
+      expect(convert(bad)).toBeNull()
+    })
+
+    it('falls back to our own number for the missing side of the exchange', () => {
+      const noTo = {
+        ...ANSWERED_INBOUND,
+        data: {
+          ...ANSWERED_INBOUND.data,
+          object: { ...ANSWERED_INBOUND.data.object, to: '' },
+        },
+      }
+      expect(convert(noTo)?.to?.[0]?.identifier).toBe('+18889155797')
+    })
+  })
+})

--- a/packages/lib/src/providers/openphone/openphone-provider.ts
+++ b/packages/lib/src/providers/openphone/openphone-provider.ts
@@ -311,7 +311,11 @@ export class OpenPhoneProvider
   // -------------------------------------------------------------------------
 
   /**
-   * Arms a `message.received` / `message.delivered` webhook scoped to this channel's number.
+   * Arms a `message.received` / `message.delivered` / `call.completed` /
+   * `call.recording.completed` webhook scoped to this channel's number (message-type-overhaul
+   * Phase 4). Deliberately excludes `call.ringing` (no-op — no row is ever created for it) and
+   * the summary/transcript/contact events, which carry no `phoneNumberId` and cannot be resolved
+   * by the route's channel-scoped lookup — see `QuoCreateMessageWebhookInput`.
    *
    * ```
    * POST /v1/webhooks/messages
@@ -361,7 +365,12 @@ export class OpenPhoneProvider
 
     const created = await createMessageWebhook(this.apiKey!, {
       url: callbackUrl,
-      events: ['message.received', 'message.delivered'],
+      events: [
+        'message.received',
+        'message.delivered',
+        'call.completed',
+        'call.recording.completed',
+      ],
       // Per-number rather than `["*"]`: it matches the one-channel-one-webhook model the rest of
       // the code assumes and makes teardown on disconnect unambiguous.
       resourceIds: [this.phoneNumberId!],

--- a/packages/lib/src/providers/openphone/types.ts
+++ b/packages/lib/src/providers/openphone/types.ts
@@ -238,6 +238,9 @@ export interface QuoWebhookEventData<T = unknown> {
 /** Convenience alias for the two message events we subscribe to. */
 export type QuoMessageWebhookEvent = QuoWebhookEvent<QuoWebhookMessage>
 
+/** Convenience alias for the two call events we subscribe to (message-type-overhaul Phase 4). */
+export type QuoCallWebhookEvent = QuoWebhookEvent<QuoWebhookCall>
+
 // ---------------------------------------------------------------------------
 // Request payloads
 // ---------------------------------------------------------------------------
@@ -255,10 +258,20 @@ export interface QuoSendMessageInput {
   setInboxStatus?: 'done'
 }
 
-/** `POST /v1/webhooks/messages`. */
+/**
+ * `POST /v1/webhooks/messages`.
+ *
+ * Deliberately excludes `call.ringing` (no row is ever created for it — see
+ * `webhook-call.ts` — so subscribing would just be retry noise) and
+ * `call.summary.completed` / `call.transcript.completed` / `contact.*` (no
+ * `phoneNumberId` on the payload — see the Quo plan's "Three consequences for
+ * our route" — so today's channel-scoped lookup can never resolve them).
+ */
 export interface QuoCreateMessageWebhookInput {
   url: string
-  events: Array<'message.received' | 'message.delivered'>
+  events: Array<
+    'message.received' | 'message.delivered' | 'call.completed' | 'call.recording.completed'
+  >
   resourceIds: string[]
   label?: string
   status?: 'enabled' | 'disabled'

--- a/packages/lib/src/providers/openphone/webhook-call.ts
+++ b/packages/lib/src/providers/openphone/webhook-call.ts
@@ -1,0 +1,162 @@
+// packages/lib/src/providers/openphone/webhook-call.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import type { MessageData } from '../../ingest/types'
+import { MessageType } from '../types'
+import type { OpenPhoneIntegrationMetadata, QuoWebhookCall, QuoWebhookEvent } from './types'
+
+const logger = createScopedLogger('quo-webhook-call')
+
+/**
+ * The `Message.metadata.call` contract. This is the ONLY window the read path
+ * (`message-query.service.ts`) projects onto `MessageMeta.callMeta` — everything else in
+ * `metadata.quo_webhook_event` stays internal. Treat a field rename here as a breaking API
+ * change for the UI.
+ */
+export interface QuoCallMeta {
+  direction: 'incoming' | 'outgoing'
+  answered: boolean
+  answeredAt: string | null
+  completedAt: string | null
+  durationSeconds: number | null
+}
+
+/** `125` seconds → `"2:05"`. */
+function formatDuration(totalSeconds: number): string {
+  const clamped = Math.max(0, Math.round(totalSeconds))
+  const minutes = Math.floor(clamped / 60)
+  const seconds = clamped % 60
+  return `${minutes}:${String(seconds).padStart(2, '0')}`
+}
+
+/**
+ * Converts a Quo `call.completed` webhook event into `MessageData`.
+ *
+ * Mirrors `webhook-message.ts`'s shape and mapper style — same envelope, same
+ * from/to/direction handling, same "never throws, null means ack-and-drop" contract — so
+ * threading, participant resolution and reconciliation behave identically to a text message on
+ * the same integration. The two things a call adds:
+ *
+ * - `messageType` is `VOICEMAIL` when the call carries voicemail audio, else `CALL` (an
+ *   answered call and a missed call with no voicemail are both `CALL` — `answered` lives in
+ *   `metadata.call` instead of earning its own type; see message-type-overhaul plan §2.3).
+ * - `hasAttachments` is true iff a voicemail is present. The recording (when one exists) arrives
+ *   later on its own `call.recording.completed` event and is attached to this same message row
+ *   by the webhook route, which flips `hasAttachments` at that point if needed.
+ *
+ * @param conversationId Recovered by the caller from the envelope's `deepLink`, exactly like the
+ *   message mapper — the call payload carries no `conversationId` either.
+ * @returns `null` when the event is unusable, which the caller treats as "ack and drop".
+ */
+export function convertQuoWebhookCallEventToMessageData(
+  event: QuoWebhookEvent<QuoWebhookCall>,
+  integrationId: string,
+  organizationId: string,
+  metadata: OpenPhoneIntegrationMetadata | null,
+  conversationId: string | null
+): MessageData | null {
+  const call = event.data?.object
+  if (!call?.id) {
+    logger.error('Cannot convert Quo webhook call event: no call object on the payload.', {
+      eventId: event.id,
+    })
+    return null
+  }
+
+  try {
+    const isInbound = call.direction === 'incoming'
+    // Quo puts both sides on the payload. `metadata.phoneNumber` is only a fallback for our own
+    // side of the exchange — same convention as the message mapper.
+    const ourNumber = metadata?.phoneNumber
+    const fromNumber = call.from || (isInbound ? undefined : ourNumber)
+    const toNumber = call.to || (isInbound ? ourNumber : undefined)
+
+    if (!fromNumber || !toNumber) {
+      logger.warn('Missing caller or callee number on Quo call webhook', {
+        callId: call.id,
+        eventType: event.type,
+      })
+      return null
+    }
+
+    const createdTime = new Date(call.createdAt)
+    if (Number.isNaN(createdTime.getTime())) {
+      logger.warn('Unparseable createdAt on Quo call webhook', {
+        callId: call.id,
+        createdAt: call.createdAt,
+      })
+      return null
+    }
+
+    const hasVoicemail = call.voicemail != null
+    const answered = call.answeredAt != null
+
+    let durationSeconds: number | null = null
+    if (hasVoicemail) {
+      durationSeconds = call.voicemail?.duration ?? null
+    } else if (answered && call.answeredAt && call.completedAt) {
+      const answeredMs = new Date(call.answeredAt).getTime()
+      const completedMs = new Date(call.completedAt).getTime()
+      if (
+        Number.isFinite(answeredMs) &&
+        Number.isFinite(completedMs) &&
+        completedMs >= answeredMs
+      ) {
+        durationSeconds = Math.round((completedMs - answeredMs) / 1000)
+      }
+    }
+
+    let snippet: string
+    if (hasVoicemail) {
+      snippet =
+        durationSeconds != null ? `Voicemail (${formatDuration(durationSeconds)})` : 'Voicemail'
+    } else if (answered) {
+      const label = isInbound ? 'Call' : 'Outgoing call'
+      snippet = durationSeconds != null ? `${label} (${formatDuration(durationSeconds)})` : label
+    } else {
+      snippet = 'Missed call'
+    }
+
+    const callMeta: QuoCallMeta = {
+      direction: call.direction,
+      answered,
+      answeredAt: call.answeredAt ?? null,
+      completedAt: call.completedAt ?? null,
+      durationSeconds,
+    }
+
+    return {
+      externalId: call.id,
+      externalThreadId: conversationId ?? undefined,
+      integrationId,
+      organizationId,
+      createdTime,
+      sentAt: createdTime,
+      receivedAt: createdTime,
+      subject: null, // Calls have no subject, same as SMS.
+      from: { identifier: fromNumber },
+      to: [{ identifier: toNumber }],
+      cc: [],
+      bcc: [],
+      replyTo: [],
+      messageType: hasVoicemail ? MessageType.VOICEMAIL : MessageType.CALL,
+      // A voicemail claims an attachment because the webhook route fetches and ingests it
+      // synchronously right after this row is stored. A plain call/missed-call has nothing to
+      // attach yet — a recording, if any, arrives later on `call.recording.completed` and the
+      // route flips this itself when it lands.
+      hasAttachments: hasVoicemail,
+      textPlain: snippet,
+      snippet,
+      isInbound,
+      metadata: { call: callMeta, quo_webhook_event: event },
+      keywords: [],
+      labelIds: [],
+    } satisfies MessageData
+  } catch (error) {
+    logger.error('Failed to convert Quo webhook call event data', {
+      error: error instanceof Error ? error.message : String(error),
+      eventId: event.id,
+    })
+    return null
+  }
+}

--- a/packages/lib/src/providers/types.ts
+++ b/packages/lib/src/providers/types.ts
@@ -131,6 +131,28 @@ export enum MessageType {
 }
 
 /**
+ * Every {@link MessageType} member, in catalog order, with its author-facing
+ * label — the option list for the `messageType` filter/view field
+ * (`plans/threads/message-type-overhaul.md` §Phase 3).
+ *
+ * Mirrors `CHANNEL_GROUP_OPTIONS` (`channels/capabilities.ts:376`) in shape,
+ * but `MessageType` is a fixed five-member vocabulary rather than something
+ * derived from a per-provider capabilities map, so this is a literal list, not
+ * a derivation. Declared here (not `resources/registry/enum-values.ts`, and
+ * not deleted like that file's dead `MessageType` block) because this module
+ * is client-safe — it only imports the generated `@auxx/database/enums` — and
+ * `mail-view-field-definitions.ts`, which is used on both client and server,
+ * already reaches into it via a plain relative import.
+ */
+export const MESSAGE_TYPE_OPTIONS: Array<{ value: MessageType; label: string }> = [
+  { value: MessageType.EMAIL, label: 'Email' },
+  { value: MessageType.SMS, label: 'SMS' },
+  { value: MessageType.CHAT, label: 'Chat' },
+  { value: MessageType.CALL, label: 'Call' },
+  { value: MessageType.VOICEMAIL, label: 'Voicemail' },
+]
+
+/**
  * Active Messaging Providers
  * Providers that can actually send/receive messages
  */

--- a/packages/lib/src/resources/registry/resources/message-fields.ts
+++ b/packages/lib/src/resources/registry/resources/message-fields.ts
@@ -2,9 +2,9 @@
 
 import { FieldType } from '@auxx/database/enums'
 import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { MESSAGE_TYPE_OPTIONS } from '../../../providers/types'
 import { BaseType } from '../../types'
 import type { ResourceField } from '../field-types'
-// `messageType` has no entry in MESSAGE_FIELDS below — see the comment there.
 
 /**
  * Field definitions for the Message resource
@@ -120,13 +120,29 @@ export const MESSAGE_FIELDS: Record<string, ResourceField> = {
     description: 'Plain text content of message',
   },
 
-  // `messageType` IS a stored column again (message-type-overhaul plan §2.7)
-  // but is deliberately NOT registered as a field here: it is an internal
-  // render discriminator (email/sms/chat/call/voicemail), not a user-facing
-  // vocabulary — provider already determines it for 11 of 12 providers, and
-  // `channelType` is the filter vocabulary rule authors actually want (plan
-  // §2.6). Re-adding it here as `filterable: true` is Phase 3, deferred until
-  // someone asks for a "Voicemails" view.
+  // Phase 3 of the message-type-overhaul plan (§Phase 3). Filterable, but
+  // write-locked: `messageType` is stamped at ingest
+  // (`getMessageTypeFromProvider` as the default, provider mappers as
+  // authority for `openphone`'s CALL/VOICEMAIL split) and is never
+  // user-writable, so `creatable`/`updatable` stay false.
+  messageType: {
+    id: toFieldId('messageType'),
+    key: 'messageType',
+    label: 'Message type',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    dbColumn: 'messageType',
+    nullable: false,
+    options: { options: MESSAGE_TYPE_OPTIONS },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'The form of the message (email, SMS, chat, call, or voicemail)',
+  },
 
   isInbound: {
     id: toFieldId('isInbound'),


### PR DESCRIPTION
Implements Phases 3–4 of `plans/threads/message-type-overhaul.md` — the two phases deferred from #1683. `CALL` and `VOICEMAIL` now actually get written, rendered, and filtered.

## Phase 3 — `messageType` becomes filterable

- One `MAIL_VIEW_FIELD_DEFINITIONS` entry (ENUM / SINGLE_SELECT over the five members) — all six filter surfaces render it generically, zero UI edits.
- `buildMessageTypeQuery` in the condition builder: correlated `exists` over `Message`, the `hasAttachments` house pattern. **Contains-semantics**: `messageType is VOICEMAIL` = *thread contains a voicemail*, deliberately distinct from `channelType is sms` = *arrived on a text channel* — on a Quo thread these differ, which is the point. Every offered operator is dispatched, including the `empty`/`not empty` constants (the column is NOT NULL), so nothing silently drops and fails open.
- Registry field on `MESSAGE_FIELDS`, write-locked (`creatable/updatable: false`) — ingest owns the value.
- Partial index `(messageType, threadId) WHERE messageType IN ('CALL','VOICEMAIL')` added to the schema. **Its migration intentionally rides the next `db:generate`**: a parallel in-flight branch holds the next migration numbers, and generating here would have entangled the snapshots. The index is a pure read optimization — nothing correctness-critical waits on it. (Already created manually on local dev.)

## Phase 4 — `CALL` / `VOICEMAIL` become reachable

- Quo webhooks now subscribe to `call.completed` + `call.recording.completed` (not `call.ringing`, and not the summary/transcript/contact events, which carry no `phoneNumberId` and can't be resolved — per the Quo plan). Existing channels heal automatically: `recoverChannel` already re-arms the webhook unconditionally for openphone.
- New call mapper: `VOICEMAIL` when the call carries voicemail audio, else `CALL`; `metadata.call` carries `{direction, answered, answeredAt, completedAt, durationSeconds}`. Thread resolution rides the same deep-link conversation-id path as messages.
- **Media is fetched at webhook time** — REST never returns call media, so the delivery is the only shot. Fetch failure → 500 → Quo redelivers with a fresh presigned URL. Idempotency is per-kind attachment-existence (`voicemail.` / `recording-` filename prefixes), not `isNew` — a retry after a failed fetch must not be skipped, and a voicemail must never mask a recording. Recording ingest is all-or-nothing across media entries so a partial set can't hide the remainder from the redelivery; a recording arriving before its call row 500s for retry instead of dropping (out-of-order delivery, not a legacy call — old webhooks don't subscribe to recording events at all).
- Read path projects a typed `callMeta` onto `MessageMeta` (raw metadata never leaves the service), redacted below the `read` lens alongside snippet/attachments.
- UI: `CallDisplay` card in the timeline `single` branch (both consumers) — voicemail / call / missed / outgoing states with duration — and an `audio/*` branch in `AttachmentDisplay` (inline `<audio>` player streaming through the existing download route, kept outside the download button so play/seek don't trigger downloads).

## Verification

- `packages/lib`: 876 tests green across openphone/mail-query/mail-views/messages/visibility/resources/channels (11 new mapper tests, 7 new condition-builder tests); typecheck clean of new errors.
- `apps/web`: 307 tests green across mail/files/threads components (3 new audio-branch tests); typecheck clean on all touched files.
- Local dev DB verified with the index in place.

Not included, still deferred on purpose: MMS picture ingest (rides the same media path later, per the Quo plan), `Thread.waitingSince` (a dead, unwired column repo-wide — voicemails reopen threads via the existing inbound logic), and transcripts/summaries (need a `callId` lookup the route doesn't have).

🤖 Generated with [Claude Code](https://claude.com/claude-code)