### PR TITLE
fix(channels): point fb/ig oauth defs at the live meta app

### DIFF
--- a/packages/lib/scripts/reseed-platform-providers.ts
+++ b/packages/lib/scripts/reseed-platform-providers.ts
@@ -1,6 +1,9 @@
 // packages/lib/scripts/reseed-platform-providers.ts
 // One-off: re-upsert the platform built-in ConnectionDefinition rows so their
-// `connectionVariables` jsonb carries the current FieldType-based shape.
+// `connectionVariables` jsonb carries the current FieldType-based shape AND the
+// encrypted oauth2ClientId/Secret columns are re-derived from the CURRENT env
+// vars. The rows bake encrypted copies of the platform OAuth client at seed
+// time, so changing e.g. FACEBOOK_APP_ID in .env is inert until this re-runs.
 // Run: npx dotenv -- npx tsx packages/lib/scripts/reseed-platform-providers.ts
 
 import { closePools } from '@auxx/database'

--- a/packages/lib/src/connections/providers/defs.ts
+++ b/packages/lib/src/connections/providers/defs.ts
@@ -157,9 +157,18 @@ export const PLATFORM_PROVIDER_DEFS: PlatformProviderDef[] = [
     connectionType: 'oauth2-code',
     label: 'Facebook',
     global: false,
-    oauth2AuthorizeUrl: 'https://www.facebook.com/v19.0/dialog/oauth',
-    oauth2AccessTokenUrl: 'https://graph.facebook.com/v19.0/oauth/access_token',
-    oauth2Scopes: ['pages_messaging', 'pages_manage_metadata', 'pages_read_engagement'],
+    oauth2AuthorizeUrl: 'https://www.facebook.com/v26.0/dialog/oauth',
+    oauth2AccessTokenUrl: 'https://graph.facebook.com/v26.0/oauth/access_token',
+    // pages_show_list + business_management are declared dependencies of the
+    // messaging permissions; without business_management, pages owned by a
+    // Business portfolio are missing from /me/accounts at connect time.
+    oauth2Scopes: [
+      'pages_messaging',
+      'pages_manage_metadata',
+      'pages_read_engagement',
+      'pages_show_list',
+      'business_management',
+    ],
     systemClientIdEnv: 'FACEBOOK_APP_ID',
     systemClientSecretEnv: 'FACEBOOK_APP_SECRET',
     oauth2Features: { additionalAuthorizeParams: { response_type: 'code' } },
@@ -172,14 +181,16 @@ export const PLATFORM_PROVIDER_DEFS: PlatformProviderDef[] = [
     label: 'Instagram',
     global: false,
     // Instagram Messaging authorizes through the Facebook login dialog + Facebook app.
-    oauth2AuthorizeUrl: 'https://www.facebook.com/v19.0/dialog/oauth',
-    oauth2AccessTokenUrl: 'https://graph.facebook.com/v19.0/oauth/access_token',
+    oauth2AuthorizeUrl: 'https://www.facebook.com/v26.0/dialog/oauth',
+    oauth2AccessTokenUrl: 'https://graph.facebook.com/v26.0/oauth/access_token',
     oauth2Scopes: [
       'instagram_basic',
       'instagram_manage_messages',
       'pages_messaging',
       'pages_manage_metadata',
       'pages_read_engagement',
+      'pages_show_list',
+      'business_management',
     ],
     systemClientIdEnv: 'FACEBOOK_APP_ID',
     systemClientSecretEnv: 'FACEBOOK_APP_SECRET',


### PR DESCRIPTION
## Summary
- Bump the facebook/instagram OAuth dialog + token URLs from the dead **v19.0** to **v26.0** in the platform connection defs
- Add `pages_show_list` + `business_management` to both scope lists — declared dependencies of the messaging permissions; without `business_management`, pages owned by a Business portfolio are missing from `/me/accounts` at connect time
- Document the seed-time credential-baking trap in `reseed-platform-providers.ts`: the `ConnectionDefinition` rows store **encrypted copies** of `FACEBOOK_APP_ID`/`SECRET`, so changing the env vars is inert until the script re-runs. This (a seeded dead app id) is what produced Facebook's "App not active" error on every connect attempt.

## Context
First slice of the FB/IG channel revival (plans/channels/facebook-instagram-runtime-fixes.md, local). The Meta-app side (webhook fields, redirect URIs, verify token) was configured out-of-band the same day.

## Testing
Live-verified 2026-08-17 against the Auxx.ai Meta app after re-seeding: OAuth connect → token exchange → social provisioning hook → page `subscribed_apps` all succeeded end to end (first successful connect in this channel's history). Webhook hub-challenge handshake returns 200 through the dev tunnel.