### PR TITLE
test(workflow): messageType is a valid find-message field again

### DIFF
--- a/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/find-thread-message.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/find-thread-message.test.ts
@@ -348,9 +348,10 @@ describe('FindProcessor - Thread and Message Support', () => {
       expect(result.errors).toHaveLength(0)
     })
 
-    it('should reject removed messageType field (no longer in schema)', async () => {
-      // messageType was removed from the message schema - it's now derived from Integration.provider
-      const node = findNode('find_message_8', 'Find Message - Removed Field', {
+    it('should accept the messageType field (stored column, registered again)', async () => {
+      // messageType returned as a stored, filterable registry field in the
+      // message-type overhaul (Phase 3) — it must validate like any other field.
+      const node = findNode('find_message_8', 'Find Message - Message Type', {
         resourceType: 'message',
         findMode: 'findOne',
         conditions: [
@@ -366,9 +367,8 @@ describe('FindProcessor - Thread and Message Support', () => {
 
       const result = await findProcessor.validate(node)
 
-      expect(result.valid).toBe(false)
-      expect(result.errors.length).toBeGreaterThan(0)
-      expect(result.errors[0]).toContain('Invalid field')
+      expect(result.valid).toBe(true)
+      expect(result.errors).toHaveLength(0)
     })
 
     it('should reject unknown thread field', async () => {


### PR DESCRIPTION
Fixes the remaining red on main's CI after #1685 merged.

Main's post-#1685 run failed three ways:
1. **Lint (lib exports check)** — our new `providers/openphone/webhook-call` subpath wasn't in the exports map. Already healed: #1686's codegen commit carried the entry.
2. **Typecheck web (TS2307 in the openphone webhook route)** — same root cause, same incidental fix by #1686.
3. **This test** — `find-thread-message.test.ts` asserted `messageType` is an *invalid* find-message field, a premise from when the column was removed. Phase 3 re-registered it as a stored, filterable field (`RESOURCE_FIELD_REGISTRY` feeds workflow Find-node validation), so the rejection test now correctly fails. Flipped to the positive case: a `messageType` condition validates like any other field.

Suite passes 16/16 locally. With this merged, main's CI should be green again (#1688's run predates this and will show the same single test failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)