### PR TITLE
feat(participants): contact-name precedence for mail labels

### DIFF
--- a/apps/web/src/components/mail/call-display.tsx
+++ b/apps/web/src/components/mail/call-display.tsx
@@ -9,11 +9,11 @@ import { Phone, PhoneMissed, PhoneOutgoing, Voicemail } from 'lucide-react'
 import type { ComponentType } from 'react'
 import { useMessage, useMessageParticipants } from '~/components/threads/hooks'
 import type { AttachmentMeta } from '~/components/threads/store'
+import { participantInitials, participantLabel } from '~/components/threads/utils/participant-label'
 import { ContactHoverCard } from '../contacts/contact-hover-card'
 import { AttachmentDisplay } from '../files/utils/attachment-display'
 import { Tooltip } from '../global/tooltip'
 import type { EmailActions } from './email-actions'
-import { initialsFor } from './utils/participant-initials'
 
 interface CallDisplayProps {
   /** Message ID to display */
@@ -57,8 +57,8 @@ const CallDisplay = ({ messageId }: CallDisplayProps) => {
           : { Icon: Phone, title: 'Call' }
 
   const isInbound = message.isInbound
-  const senderName = sender?.displayName ?? 'Unknown'
-  const senderInitials = initialsFor(sender)
+  const senderName = sender ? participantLabel(sender) : 'Unknown'
+  const senderInitials = participantInitials(sender)
   const contactId = sender?.entityInstanceId
   const nonInlineAttachments = (message.attachments ?? []).filter((a) => !a.inline)
   const duration =

--- a/apps/web/src/components/mail/chat-message-display.tsx
+++ b/apps/web/src/components/mail/chat-message-display.tsx
@@ -13,16 +13,16 @@ import {
 } from '@auxx/ui/components/dropdown-menu'
 import { Skeleton } from '@auxx/ui/components/skeleton'
 import { cn } from '@auxx/ui/lib/utils'
-import { formatDistanceToNow } from 'date-fns'
+import { format } from 'date-fns'
 import { Check, CheckCheck, CopyPlusIcon, EllipsisVertical, Mail, Trash } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { useMessage, useMessageParticipants, useThreadReadStatus } from '~/components/threads/hooks'
 import type { AttachmentMeta, MessageMeta } from '~/components/threads/store'
+import { participantInitials, participantLabel } from '~/components/threads/utils/participant-label'
 import { AttachmentDisplay } from '../files/utils/attachment-display'
 import { Tooltip } from '../global/tooltip'
 import type { EmailActions } from './email-actions'
 import { SendStatusIndicator } from './send-status-indicator'
-import { initialsFor } from './utils/participant-initials'
 
 export type ChatGroupPosition = 'solo' | 'first' | 'middle' | 'last'
 
@@ -74,8 +74,8 @@ const ChatMessageDisplay = ({
   if (!message) return null
 
   const isInbound = message.isInbound
-  const senderName = sender?.displayName ?? 'Unknown'
-  const senderInitials = initialsFor(sender)
+  const senderName = sender ? participantLabel(sender) : 'Unknown'
+  const senderInitials = participantInitials(sender)
   const content = message.textPlain ?? message.snippet ?? ''
 
   // Read-only seam: an empty `messageActions` (e.g. the palette's
@@ -207,6 +207,11 @@ const ChatMessageDisplay = ({
 
 export default ChatMessageDisplay
 
+/**
+ * Time-only ("2:41 PM") — a day separator now establishes the day for every
+ * bubble below it (plans/threads/thread-events.md §15.6), so the relative
+ * "2 hours ago" label this used to show would be redundant with it.
+ */
 function TimestampLabel({
   sentAt,
   className,
@@ -217,14 +222,14 @@ function TimestampLabel({
   const date = sentAt ? new Date(sentAt) : new Date()
   return (
     <Tooltip
-      content={sentAt ? date.toString() : ''}
+      content={sentAt ? date.toLocaleString() : ''}
       delayDuration={500}
       side='top'
       sideOffset={5}
       className='text-xs text-muted-foreground'>
       <span
         className={cn('shrink-0 whitespace-nowrap text-[10px] text-muted-foreground', className)}>
-        {formatDistanceToNow(date, { addSuffix: true })}
+        {format(date, 'h:mm a')}
       </span>
     </Tooltip>
   )

--- a/apps/web/src/components/mail/compact-thread-item.tsx
+++ b/apps/web/src/components/mail/compact-thread-item.tsx
@@ -34,6 +34,7 @@ import {
   useSelectionAnchorId,
   useThreadSelectionStore,
 } from '~/components/threads/store'
+import { participantLabel } from '~/components/threads/utils/participant-label'
 import { threadFieldResolver } from '~/components/threads/utils/thread-field-resolver'
 import { useIsRecordProcessing } from '~/components/workflow/use-is-record-processing'
 import { AssigneeChip } from './assignee-chip'
@@ -172,7 +173,7 @@ export const CompactThreadItem = memo(function CompactThreadItem({
       : ''
   }, [thread?.lastMessageAt])
 
-  const senderName = senderParticipant?.displayName ?? null
+  const senderName = senderParticipant ? participantLabel(senderParticipant) : null
 
   // On subject-less channels (SMS/WhatsApp/DMs) the title slot falls back to
   // the thread's participant; `null` means "render the usual placeholder".

--- a/apps/web/src/components/mail/email-display.tsx
+++ b/apps/web/src/components/mail/email-display.tsx
@@ -40,6 +40,7 @@ import {
   useThreadReadStatus,
 } from '~/components/threads/hooks'
 import type { MessageMeta } from '~/components/threads/store'
+import { participantInitials } from '~/components/threads/utils/participant-label'
 import { api } from '~/trpc/react'
 import { Tooltip } from '../global/tooltip'
 import type { EmailActions } from './email-actions'
@@ -49,7 +50,6 @@ import { useRetrySend } from './hooks/use-retry-send'
 import { ParticipantList, type ParticipantListEntry } from './participant-display'
 import { SendStatusIndicator } from './send-status-indicator'
 import { supportsRichText } from './utils/channel-rich-text'
-import { initialsFor } from './utils/participant-initials'
 import { resolveInlineEmailHtml } from './utils/resolve-inline-email-html'
 import { SandboxedEmailHtml } from './utils/sandboxed-email-html'
 import { toEditorMessage } from './utils/to-editor-message'
@@ -223,7 +223,7 @@ const EmailDisplay = ({ messageId, messageActions, isOpen, isLastMessage }: Emai
   }
 
   const isMe = !message.isInbound
-  const senderInitials = initialsFor(from)
+  const senderInitials = participantInitials(from)
 
   // Outbound messages carry a blue frame; a send that never landed swaps it for
   // a red one so the failure reads from the card, not just the status icon.

--- a/apps/web/src/components/mail/mail-thread-item.tsx
+++ b/apps/web/src/components/mail/mail-thread-item.tsx
@@ -58,6 +58,7 @@ import {
   useSelectionAnchorId,
   useThreadSelectionStore,
 } from '~/components/threads/store'
+import { participantLabel } from '~/components/threads/utils/participant-label'
 import { threadFieldResolver } from '~/components/threads/utils/thread-field-resolver'
 import { useIsRecordProcessing } from '~/components/workflow/use-is-record-processing'
 import { WorkflowSubMenu } from '~/components/workflow/workflow-submenu'
@@ -372,7 +373,7 @@ export const MailThreadItem = memo(function MailThreadItem({
   // Show the counterparty, not the owner. Shared with `CompactThreadItem` — see
   // `useThreadRowSender` for why this is a hook and not a block of code in here.
   const displaySender = useThreadRowSender(rowParticipantIds)
-  const senderName = displaySender?.displayName ?? 'Unknown'
+  const senderName = displaySender ? participantLabel(displaySender) : 'Unknown'
 
   // On subject-less channels (SMS/WhatsApp/DMs) the title slot falls back to
   // the thread's participant; `null` means "render the usual placeholder".

--- a/apps/web/src/components/mail/message-display.tsx
+++ b/apps/web/src/components/mail/message-display.tsx
@@ -36,6 +36,7 @@ import {
   useThreadReadStatus,
 } from '~/components/threads/hooks'
 import type { MessageMeta } from '~/components/threads/store'
+import { participantInitials, participantLabel } from '~/components/threads/utils/participant-label'
 import { api } from '~/trpc/react'
 import { ContactHoverCard } from '../contacts/contact-hover-card'
 import { Tooltip } from '../global/tooltip'
@@ -45,7 +46,6 @@ import { useHtmlBody } from './hooks/use-html-body'
 import { useRetrySend } from './hooks/use-retry-send'
 import { SendStatusIndicator } from './send-status-indicator'
 import { supportsRichText } from './utils/channel-rich-text'
-import { initialsFor } from './utils/participant-initials'
 import { resolveInlineEmailHtml } from './utils/resolve-inline-email-html'
 import { SandboxedEmailHtml } from './utils/sandboxed-email-html'
 import { toEditorMessage } from './utils/to-editor-message'
@@ -162,8 +162,8 @@ const MessageDisplay = ({ messageId, messageActions, isOpen }: MessageDisplayPro
   const hasActions = typeof messageActions?.onReply === 'function'
 
   const isInbound = message.isInbound
-  const senderName = sender?.displayName ?? 'Unknown'
-  const senderInitials = initialsFor(sender)
+  const senderName = sender ? participantLabel(sender) : 'Unknown'
+  const senderInitials = participantInitials(sender)
   const contactId = sender?.entityInstanceId
 
   return (

--- a/apps/web/src/components/mail/participant-display.tsx
+++ b/apps/web/src/components/mail/participant-display.tsx
@@ -19,6 +19,7 @@ import { useQueryState } from 'nuqs'
 import React from 'react'
 import { useParticipant, useThreadMutation } from '~/components/threads/hooks'
 import type { ParticipantMeta } from '~/components/threads/store'
+import { participantLabel } from '~/components/threads/utils/participant-label'
 import { api } from '~/trpc/react'
 
 /** Role types for message participants */
@@ -87,9 +88,9 @@ export const ParticipantDisplay: React.FC<ParticipantDisplayProps> = ({
     return null
   }
 
-  const { id, identifier, identifierType, name, displayName, entityInstanceId, isInternal } =
-    participant
-  const displayLabel = displayName || identifier
+  const { id, identifier, identifierType, name, entityInstanceId, isInternal } = participant
+  // Label only — the details span below keeps showing the raw identifier.
+  const displayLabel = participantLabel(participant)
 
   const senderDomain =
     identifierType === 'EMAIL' ? (identifier.split('@')[1] ?? undefined) : undefined

--- a/apps/web/src/components/resources/hooks/use-resource-sync.ts
+++ b/apps/web/src/components/resources/hooks/use-resource-sync.ts
@@ -10,9 +10,10 @@ import type {
   RecordsInvalidatedEvent,
   RecordUpdatedEvent,
 } from '@auxx/lib/realtime'
-import { type RecordId, toRecordId } from '@auxx/lib/resources/client'
+import { getInstanceId, isRecordId, type RecordId, toRecordId } from '@auxx/lib/resources/client'
 import type { FieldReference, FieldValueKey } from '@auxx/types/field'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { patchParticipantsForContact } from '~/components/threads/store/participant-store'
 import { useOrgChannel, useRecordChannels } from '~/realtime/hooks'
 import { api } from '~/trpc/react'
 import { fieldValueFetchQueue } from '../store/field-value-fetch-queue'
@@ -97,6 +98,37 @@ function cachedValueRequests(
 }
 
 /**
+ * Record lane → participant store bridge (contact-name precedence): a contact
+ * rename/avatar change must flip mail labels live, and this lane already
+ * carries exactly that event. Instance ids are globally unique, so no def
+ * check is needed — the store scan simply matches nothing for non-contacts.
+ * Only keys present on the payload are forwarded (`undefined` = don't touch);
+ * per-participant "usable name" normalization happens inside the store patch.
+ */
+function patchParticipantsForRecordMeta(record: {
+  id: string
+  displayName?: string
+  avatarUrl?: string | null
+}) {
+  if (record.displayName === undefined && record.avatarUrl === undefined) return
+  patchParticipantsForContact(record.id, {
+    contactName: record.displayName,
+    avatarUrl: record.avatarUrl,
+  })
+}
+
+/**
+ * Deleted/archived contacts fall back to the header/identifier label —
+ * mirrors the FK `ON DELETE set null` / archived-contact semantics of the
+ * fetch path. `recordId` on these events is the composite form.
+ */
+function clearParticipantsForRecord(recordId: RecordId | string) {
+  const instanceId = isRecordId(recordId) ? getInstanceId(recordId) : recordId
+  if (!instanceId) return
+  patchParticipantsForContact(instanceId, { contactName: null, avatarUrl: null })
+}
+
+/**
  * Global hook that subscribes to real-time resource events and feeds data into
  * the existing Zustand stores. Mount once in the app layout.
  *
@@ -167,6 +199,7 @@ export function useResourceSync() {
       if (data.fieldValues?.length) {
         setValues(data.fieldValues)
       }
+      patchParticipantsForRecordMeta(data.record)
     },
     [setRecords, invalidateLists, setValues, utils]
   )
@@ -184,6 +217,7 @@ export function useResourceSync() {
       if (updatedAt !== undefined) patch.updatedAt = updatedAt
       if (Object.keys(patch).length === 0) return
       updateRecord(data.entityDefinitionId, data.record.id, patch)
+      patchParticipantsForRecordMeta(data.record)
     },
     [updateRecord]
   )
@@ -195,6 +229,7 @@ export function useResourceSync() {
       invalidateLists(data.entityDefinitionId)
       invalidateResource(data.recordId)
       utils.record.listFiltered.invalidate({ entityDefinitionId: data.entityDefinitionId })
+      clearParticipantsForRecord(data.recordId)
     },
     [removeRecord, invalidateLists, invalidateResource, utils]
   )
@@ -204,6 +239,7 @@ export function useResourceSync() {
       const data = raw as RecordArchivedEvent['data']
       invalidateLists(data.entityDefinitionId)
       utils.record.listFiltered.invalidate({ entityDefinitionId: data.entityDefinitionId })
+      clearParticipantsForRecord(data.recordId)
     },
     [invalidateLists, utils]
   )

--- a/apps/web/src/components/threads/store/participant-store.ts
+++ b/apps/web/src/components/threads/store/participant-store.ts
@@ -1,6 +1,7 @@
 // apps/web/src/components/threads/store/participant-store.ts
 
 import '~/lib/immer-config'
+import { usableContactName } from '@auxx/lib/participants/client'
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
@@ -37,6 +38,12 @@ export interface ParticipantMeta {
   avatarUrl: string | null
   /** Reference to EntityInstance (contact entity type) */
   entityInstanceId: string | null
+  /**
+   * The linked contact's display name, normalized server-side (`null` when
+   * empty or just the identifier echoed back). Label precedence is resolved in
+   * `~/components/threads/utils/participant-label`.
+   */
+  contactName: string | null
   isSpammer: boolean
   /** True when the participant's identifier is on the organization's own domain. */
   isInternal: boolean
@@ -181,3 +188,32 @@ export const useParticipantStore = create<ParticipantStoreState>()(
  * Get store state outside of React.
  */
 export const getParticipantStoreState = () => useParticipantStore.getState()
+
+/**
+ * Realtime bridge (record lane → participant store): patch every cached
+ * participant linked to a contact after a `record:*` event on the contact.
+ *
+ * `contactName` is the RAW contact display name (or `null` on delete/archive);
+ * it is normalized per participant against that participant's identifier here,
+ * because "the contact's display value is just the phone/email" depends on
+ * which participant is being labeled. `avatarUrl` merges verbatim. A key set
+ * to `undefined` is left untouched.
+ *
+ * O(n) scan over the map — it holds at most a few hundred entries.
+ */
+export function patchParticipantsForContact(
+  entityInstanceId: string,
+  patch: { contactName?: string | null; avatarUrl?: string | null }
+) {
+  useParticipantStore.setState((state) => {
+    for (const participant of state.participants.values()) {
+      if (participant.entityInstanceId !== entityInstanceId) continue
+      if (patch.contactName !== undefined) {
+        participant.contactName = usableContactName(patch.contactName, participant.identifier)
+      }
+      if (patch.avatarUrl !== undefined) {
+        participant.avatarUrl = patch.avatarUrl
+      }
+    }
+  })
+}

--- a/apps/web/src/components/threads/utils/index.ts
+++ b/apps/web/src/components/threads/utils/index.ts
@@ -1,5 +1,10 @@
 // apps/web/src/components/threads/utils/index.ts
 
+export {
+  type LabelParticipant,
+  participantInitials,
+  participantLabel,
+} from './participant-label'
 export { threadFieldResolver } from './thread-field-resolver'
 export {
   channelCarriesSubject,

--- a/apps/web/src/components/threads/utils/participant-label.test.ts
+++ b/apps/web/src/components/threads/utils/participant-label.test.ts
@@ -1,0 +1,110 @@
+// apps/web/src/components/threads/utils/participant-label.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { type LabelParticipant, participantInitials, participantLabel } from './participant-label'
+
+const phone = (overrides: Partial<LabelParticipant> = {}): LabelParticipant => ({
+  name: null,
+  identifier: '+15102055536',
+  identifierType: 'PHONE',
+  displayName: '+15102055536',
+  initials: '',
+  contactName: null,
+  isInternal: false,
+  ...overrides,
+})
+
+const email = (overrides: Partial<LabelParticipant> = {}): LabelParticipant => ({
+  name: 'Ada Lovelace',
+  identifier: 'ada@example.com',
+  identifierType: 'EMAIL',
+  displayName: 'Ada Lovelace',
+  initials: 'AL',
+  contactName: null,
+  isInternal: false,
+  ...overrides,
+})
+
+const chatVisitor = (overrides: Partial<LabelParticipant> = {}): LabelParticipant => ({
+  name: null,
+  identifier: '0f2b8a1e-1111-2222-3333-444455556666',
+  identifierType: 'CHAT_VISITOR',
+  displayName: 'Chat user #5556',
+  initials: '#5556',
+  contactName: null,
+  isInternal: false,
+  ...overrides,
+})
+
+describe('participantLabel', () => {
+  it('lets the linked contact name win over the header-derived one', () => {
+    expect(participantLabel(email({ contactName: 'Countess Lovelace' }))).toBe('Countess Lovelace')
+  })
+
+  it('falls back to the header-derived name without a contact', () => {
+    expect(participantLabel(email())).toBe('Ada Lovelace')
+  })
+
+  it('formats a nameless phone as PHONE_INTL instead of raw E.164', () => {
+    expect(participantLabel(phone())).toBe('+1 510 205 5536')
+  })
+
+  it('a contact name on a phone participant beats the formatted number', () => {
+    expect(participantLabel(phone({ contactName: 'Bruno Klooth' }))).toBe('Bruno Klooth')
+  })
+
+  it('ignores contactName on internal participants', () => {
+    // Their name is pinned to the org member profile at ingest; a stray
+    // auto-created contact must not rename a teammate.
+    expect(
+      participantLabel(
+        email({
+          name: 'Support Team',
+          displayName: 'Support Team',
+          contactName: 'Wrong Contact',
+          isInternal: true,
+        })
+      )
+    ).toBe('Support Team')
+  })
+
+  it('keeps the friendly chat handle for nameless chat visitors', () => {
+    expect(participantLabel(chatVisitor())).toBe('Chat user #5556')
+  })
+
+  it('tolerates slices without contactName/isInternal (pre-enrichment payloads)', () => {
+    const legacy: LabelParticipant = {
+      name: null,
+      identifier: 'ada@example.com',
+      identifierType: 'EMAIL',
+      displayName: 'ada@example.com',
+      initials: '',
+    }
+    expect(participantLabel(legacy)).toBe('ada@example.com')
+  })
+})
+
+describe('participantInitials', () => {
+  it('derives initials from the contact name when it wins the label', () => {
+    // A stored `BS` from headers must not pair with a renamed contact label.
+    expect(
+      participantInitials(email({ name: 'BS', initials: 'BS', contactName: 'Bruno Klooth' }))
+    ).toBe('BK')
+  })
+
+  it('keeps the persisted initials when the contact name does not win', () => {
+    expect(participantInitials(email())).toBe('AL')
+    expect(participantInitials(chatVisitor())).toBe('#5556')
+  })
+
+  it('keeps persisted initials for internal participants regardless of contactName', () => {
+    expect(
+      participantInitials(email({ initials: 'ST', contactName: 'Wrong Contact', isInternal: true }))
+    ).toBe('ST')
+  })
+
+  it('returns ? for a missing participant', () => {
+    expect(participantInitials(null)).toBe('?')
+    expect(participantInitials(undefined)).toBe('?')
+  })
+})

--- a/apps/web/src/components/threads/utils/participant-label.ts
+++ b/apps/web/src/components/threads/utils/participant-label.ts
@@ -1,0 +1,67 @@
+// apps/web/src/components/threads/utils/participant-label.ts
+
+import { initialsFor } from '~/components/mail/utils/participant-initials'
+import type { ParticipantMeta } from '../store'
+import { formatParticipantIdentifier } from './thread-title'
+
+/**
+ * The slice of a participant label resolution needs. A `Pick` so any surface
+ * holding a full {@link ParticipantMeta} can pass it straight through;
+ * `contactName`/`isInternal` are optional so narrower slices (and pre-Phase-1
+ * payloads) still resolve.
+ */
+export type LabelParticipant = Pick<
+  ParticipantMeta,
+  'name' | 'identifier' | 'identifierType' | 'displayName' | 'initials'
+> &
+  Partial<Pick<ParticipantMeta, 'contactName' | 'isInternal'>>
+
+/**
+ * The contact name for a participant, when it should win the label.
+ *
+ * Internal participants ignore `contactName`: their name is pinned to the org
+ * member profile at ingest, and a stray auto-created contact must not rename a
+ * teammate. `contactName` itself is already normalized server-side (never
+ * empty, never the identifier echoed back).
+ */
+function winningContactName(meta: LabelParticipant): string | null {
+  if (meta.isInternal) return null
+  return meta.contactName?.trim() || null
+}
+
+/**
+ * The ONE label precedence for mail/chat participant surfaces:
+ *
+ *   linked contact name > header-derived name > formatted identifier
+ *
+ * The formatted-identifier rung renders phones as PHONE_INTL
+ * (`+1 888 915 5797`) instead of raw E.164 — previously only thread titles and
+ * the details line formatted them. Chat visitors fall through to the server's
+ * friendly `Chat user #xxxx` handle in `displayName`.
+ */
+export function participantLabel(meta: LabelParticipant): string {
+  const contactName = winningContactName(meta)
+  if (contactName) return contactName
+
+  if (meta.name?.trim()) return meta.displayName?.trim() || meta.name.trim()
+
+  const formatted = formatParticipantIdentifier(meta)
+  if (formatted) return formatted
+
+  return meta.displayName?.trim() || meta.identifier
+}
+
+/**
+ * Avatar initials for a participant, following the WINNING label: when the
+ * contact name wins, initials derive from it (a stored `BS` from headers must
+ * not pair with a renamed contact label); otherwise the server-persisted
+ * `initials` keep working (preserves the CHAT_VISITOR `#xxxx` handling).
+ */
+export function participantInitials(meta?: LabelParticipant | null): string {
+  if (!meta) return '?'
+  const contactName = winningContactName(meta)
+  if (contactName) {
+    return initialsFor({ initials: '', displayName: contactName })
+  }
+  return initialsFor(meta)
+}

--- a/apps/web/src/components/threads/utils/thread-title.test.ts
+++ b/apps/web/src/components/threads/utils/thread-title.test.ts
@@ -165,6 +165,36 @@ describe('resolveThreadTitle', () => {
     ).toBe('Ada Lovelace')
   })
 
+  it('lets a linked CRM contact name win over the header-derived one', () => {
+    expect(
+      resolveThreadTitle({
+        subject: '',
+        integrationProvider: 'openphone',
+        participant: phoneParticipant({
+          name: 'BS',
+          displayName: 'BS',
+          contactName: 'Bruno Klooth',
+        }),
+      })
+    ).toBe('Bruno Klooth')
+  })
+
+  it('ignores contactName on internal participants', () => {
+    // A stray auto-created contact must not retitle a thread after a teammate.
+    expect(
+      resolveThreadTitle({
+        subject: '',
+        integrationProvider: 'openphone',
+        participant: phoneParticipant({
+          name: 'Support Line',
+          displayName: 'Support Line',
+          contactName: 'Wrong Contact',
+          isInternal: true,
+        }),
+      })
+    ).toBe('Support Line')
+  })
+
   it('falls back to a formatted phone number when there is no name', () => {
     expect(
       resolveThreadTitle({

--- a/apps/web/src/components/threads/utils/thread-title.ts
+++ b/apps/web/src/components/threads/utils/thread-title.ts
@@ -7,11 +7,14 @@ import type { ParticipantMeta } from '../store'
 /**
  * The slice of a participant a thread title needs. Deliberately a `Pick` so any
  * surface holding a full {@link ParticipantMeta} can pass it straight through.
+ * `contactName`/`isInternal` are optional so narrower legacy slices still fit;
+ * when present, a linked contact's name tops the derived-title chain.
  */
 export type ThreadTitleParticipant = Pick<
   ParticipantMeta,
   'name' | 'identifier' | 'identifierType' | 'displayName'
->
+> &
+  Partial<Pick<ParticipantMeta, 'contactName' | 'isInternal'>>
 
 /**
  * Whether a channel's threads carry a real subject line.
@@ -123,6 +126,12 @@ export function resolveThreadTitle({
   if (trimmedSubject) return trimmedSubject
 
   if (channelCarriesSubject(integrationProvider)) return null
+
+  // A linked contact's name wins over the header-derived one — same precedence
+  // as `participantLabel`, guarded on `isInternal` so a stray auto-created
+  // contact can't retitle a thread after a teammate.
+  const contactName = participant?.isInternal ? null : participant?.contactName?.trim()
+  if (contactName) return contactName
 
   const name = participant?.name?.trim()
   if (name) return name

--- a/apps/web/src/server/api/routers/search.ts
+++ b/apps/web/src/server/api/routers/search.ts
@@ -2,10 +2,11 @@ import { schema } from '@auxx/database'
 import { InboxService } from '@auxx/lib/inboxes'
 import { IsOperatorValue, SearchOperator } from '@auxx/lib/mail-query'
 import { listMembersWithUser } from '@auxx/lib/members'
+import { usableContactName } from '@auxx/lib/participants'
 import { PermissionKey } from '@auxx/lib/permissions'
 import { listAll } from '@auxx/lib/resources'
 import { createScopedLogger } from '@auxx/logger'
-import { and, asc, count as drizzleCount, eq, ilike, inArray, or, sql } from 'drizzle-orm'
+import { and, asc, count as drizzleCount, eq, ilike, inArray, isNull, or, sql } from 'drizzle-orm'
 import { z } from 'zod'
 import { capabilityProcedure, createTRPCRouter, protectedProcedure } from '../trpc'
 
@@ -58,15 +59,44 @@ const getStatusDescription = (status: string): string => {
   }
   return descriptions[status] || ''
 }
-// Helper function to get display name with entity instance (contact) priority
-const getParticipantDisplayName = (participant: any) => {
-  // Try entityInstance (was contact before migration)
-  const entity = participant.entityInstance || participant.contact
-  if (entity) {
-    const contactName = [entity.firstName, entity.lastName].filter(Boolean).join(' ')
-    if (contactName) return contactName
-  }
-  return participant.displayName || participant.name || participant.identifier
+// Batch-resolve linked (non-archived) contact display names for participant
+// rows — one query, keyed by entityInstanceId. The previous helper read
+// `participant.entityInstance || participant.contact`, but no caller ever
+// joined that relation, so the contact branch was dead code.
+const fetchContactNames = async (
+  db: any,
+  organizationId: string,
+  participants: Array<{ entityInstanceId: string | null }>
+): Promise<Map<string, string | null>> => {
+  const contactIds = [
+    ...new Set(
+      participants
+        .map((p) => p.entityInstanceId)
+        .filter((id): id is string => typeof id === 'string')
+    ),
+  ]
+  if (contactIds.length === 0) return new Map()
+  const rows = await db
+    .select({ id: schema.EntityInstance.id, displayName: schema.EntityInstance.displayName })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        inArray(schema.EntityInstance.id, contactIds),
+        eq(schema.EntityInstance.organizationId, organizationId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+  return new Map(rows.map((r: { id: string; displayName: string | null }) => [r.id, r.displayName]))
+}
+
+// Label with contact-name precedence — the same normalization the
+// `ParticipantMeta` fetch path uses (`usableContactName`).
+const getParticipantDisplayName = (participant: any, contactNames: Map<string, string | null>) => {
+  const contactName = usableContactName(
+    participant.entityInstanceId ? contactNames.get(participant.entityInstanceId) : null,
+    participant.identifier
+  )
+  return contactName || participant.displayName || participant.name || participant.identifier
 }
 // Helper function to save search query with limit management
 const saveSearchQuery = async (ctx: any, query: string) => {
@@ -261,11 +291,12 @@ export const searchRouter = createTRPCRouter({
               )
             )
             .limit(10)
+          const contactNames = await fetchContactNames(ctx.db, organizationId, participants)
           suggestions.push(
             ...participants.map((p: any) => ({
               type: 'participant',
               value: p.identifier,
-              label: getParticipantDisplayName(p),
+              label: getParticipantDisplayName(p, contactNames),
               secondary: p.identifier,
             }))
           )
@@ -419,10 +450,11 @@ export const searchRouter = createTRPCRouter({
           )
         )
         .limit(20)
+      const contactNames = await fetchContactNames(ctx.db, organizationId, participants)
       return participants.map((p: any) => ({
         id: p.id,
         identifier: p.identifier,
-        displayName: getParticipantDisplayName(p),
+        displayName: getParticipantDisplayName(p, contactNames),
         identifierType: p.identifierType,
         contactId: p.entityInstanceId,
         contact: p.contact || null,

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -904,6 +904,12 @@
       "import": "./dist/participants/channel-identifier-fields.mjs",
       "default": "./src/participants/channel-identifier-fields.ts"
     },
+    "./participants/client": {
+      "types": "./src/participants/client.ts",
+      "source": "./src/participants/client.ts",
+      "import": "./dist/participants/client.mjs",
+      "default": "./src/participants/client.ts"
+    },
     "./participants/search": {
       "types": "./src/participants/search/index.ts",
       "source": "./src/participants/search/index.ts",

--- a/packages/lib/src/participants/__tests__/get-participant-meta-batch.test.ts
+++ b/packages/lib/src/participants/__tests__/get-participant-meta-batch.test.ts
@@ -1,0 +1,150 @@
+// packages/lib/src/participants/__tests__/get-participant-meta-batch.test.ts
+//
+// contact-name-precedence plan §Phase 1 — the read-time contact projection.
+//
+// `getParticipantMetaBatch` used to select only Participant columns and
+// hardcode `avatarUrl: null`; a renamed contact never surfaced on mail. Now it
+// batch-resolves non-archived linked contacts and stamps `contactName`
+// (normalized by `usableContactName`) + the contact's `avatarUrl` onto every
+// meta. Read-time, never write-through: `Participant.name` stays untouched.
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@auxx/database', async () => {
+  const { createChainableDatabaseMock, createSchemaMock } = await import('../../test/database-mock')
+  // `database` must be chainable, not `{}` — modules in this graph build
+  // prepared statements at module scope and would throw during collection.
+  return { schema: createSchemaMock(), database: createChainableDatabaseMock() }
+})
+
+// Partial mock, never a full replacement: the module graph behind
+// `participant-service` reaches `getTableColumns` (media-asset-service via the
+// cache providers), and a full replacement dies at COLLECTION rather than at an
+// assertion.
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>()
+  const passthrough = (...a: unknown[]) => a as never
+  return { ...actual, and: passthrough, eq: passthrough, inArray: passthrough, isNull: passthrough }
+})
+
+import { ParticipantService } from '../participant-service'
+
+interface ParticipantRow {
+  id: string
+  name: string | null
+  identifier: string
+  identifierType: string
+  displayName: string | null
+  initials: string | null
+  entityInstanceId: string | null
+  isSpammer: boolean
+  isInternal: boolean
+}
+
+interface ContactRow {
+  id: string
+  displayName: string | null
+  avatarUrl: string | null
+}
+
+function makeService(participants: ParticipantRow[], contacts: ContactRow[]) {
+  const findManyParticipants = vi.fn(async () => participants)
+  const findManyContacts = vi.fn(async () => contacts)
+  const db = {
+    query: {
+      Participant: { findMany: findManyParticipants },
+      EntityInstance: { findMany: findManyContacts },
+    },
+  } as any
+  return { service: new ParticipantService('org_1', db), findManyContacts }
+}
+
+function participantRow(overrides: Partial<ParticipantRow> = {}): ParticipantRow {
+  return {
+    id: 'part_1',
+    name: null,
+    identifier: '+18889155797',
+    identifierType: 'PHONE',
+    displayName: '+18889155797',
+    initials: null,
+    entityInstanceId: 'contact_1',
+    isSpammer: false,
+    isInternal: false,
+    ...overrides,
+  }
+}
+
+describe('getParticipantMetaBatch contact enrichment', () => {
+  it('stamps contactName + avatarUrl from the linked contact', async () => {
+    const { service } = makeService(
+      [participantRow()],
+      [{ id: 'contact_1', displayName: 'Bruno Klooth', avatarUrl: 'https://cdn/x.png' }]
+    )
+
+    const [meta] = await service.getParticipantMetaBatch(['part_1'])
+
+    expect(meta?.contactName).toBe('Bruno Klooth')
+    expect(meta?.avatarUrl).toBe('https://cdn/x.png')
+    // Read-time projection only — the participant's own label fields survive.
+    expect(meta?.displayName).toBe('+18889155797')
+    expect(meta?.name).toBeNull()
+  })
+
+  it('nulls contactName when the contact display value IS the identifier', async () => {
+    // A contact whose display value is just the phone/email echoed back must
+    // not masquerade as a name (case-insensitive, trimmed).
+    const { service } = makeService(
+      [participantRow({ identifier: 'ada@acme.io', identifierType: 'EMAIL' })],
+      [{ id: 'contact_1', displayName: '  ADA@ACME.IO ', avatarUrl: null }]
+    )
+
+    const [meta] = await service.getParticipantMetaBatch(['part_1'])
+
+    expect(meta?.contactName).toBeNull()
+  })
+
+  it('nulls contactName for a blank contact display value', async () => {
+    const { service } = makeService(
+      [participantRow()],
+      [{ id: 'contact_1', displayName: '   ', avatarUrl: null }]
+    )
+
+    const [meta] = await service.getParticipantMetaBatch(['part_1'])
+
+    expect(meta?.contactName).toBeNull()
+  })
+
+  it('falls back when the contact is not returned (archived / deleted)', async () => {
+    // The enrichment query filters `archivedAt IS NULL`; an archived contact's
+    // participant reverts to the header/identifier label.
+    const { service } = makeService([participantRow()], [])
+
+    const [meta] = await service.getParticipantMetaBatch(['part_1'])
+
+    expect(meta?.contactName).toBeNull()
+    expect(meta?.avatarUrl).toBeNull()
+  })
+
+  it('skips the contact query entirely when no participant links a contact', async () => {
+    const { service, findManyContacts } = makeService(
+      [participantRow({ entityInstanceId: null })],
+      []
+    )
+
+    const [meta] = await service.getParticipantMetaBatch(['part_1'])
+
+    expect(meta?.contactName).toBeNull()
+    expect(findManyContacts).not.toHaveBeenCalled()
+  })
+
+  it('still returns metas in input order with misses excluded', async () => {
+    const { service } = makeService(
+      [participantRow({ id: 'part_2', identifier: 'b@x.io' }), participantRow({ id: 'part_1' })],
+      [{ id: 'contact_1', displayName: 'Bruno Klooth', avatarUrl: null }]
+    )
+
+    const metas = await service.getParticipantMetaBatch(['part_1', 'part_missing', 'part_2'])
+
+    expect(metas.map((m) => m.id)).toEqual(['part_1', 'part_2'])
+  })
+})

--- a/packages/lib/src/participants/__tests__/usable-contact-name.test.ts
+++ b/packages/lib/src/participants/__tests__/usable-contact-name.test.ts
@@ -1,0 +1,40 @@
+// packages/lib/src/participants/__tests__/usable-contact-name.test.ts
+//
+// The ONE normalization behind contact-name precedence, shared by the
+// `ParticipantMeta` fetch path, the realtime bridge in the web participant
+// store, and the search router's label helper.
+
+import { describe, expect, it } from 'vitest'
+import { usableContactName } from '../client'
+
+describe('usableContactName', () => {
+  it('returns the trimmed name when it is a real name', () => {
+    expect(usableContactName('  Bruno Klooth ', '+18889155797')).toBe('Bruno Klooth')
+  })
+
+  it('returns null for null/undefined/empty/whitespace', () => {
+    expect(usableContactName(null, '+18889155797')).toBeNull()
+    expect(usableContactName(undefined, '+18889155797')).toBeNull()
+    expect(usableContactName('', '+18889155797')).toBeNull()
+    expect(usableContactName('   ', '+18889155797')).toBeNull()
+  })
+
+  it('returns null when the name is the identifier echoed back', () => {
+    expect(usableContactName('+18889155797', '+18889155797')).toBeNull()
+    expect(usableContactName('ada@acme.io', 'ada@acme.io')).toBeNull()
+  })
+
+  it('compares case-insensitively and trimmed', () => {
+    expect(usableContactName(' ADA@Acme.IO ', 'ada@acme.io')).toBeNull()
+    expect(usableContactName('ada@acme.io', '  ADA@ACME.IO ')).toBeNull()
+  })
+
+  it('keeps a name that merely CONTAINS the identifier', () => {
+    expect(usableContactName('ada@acme.io (Ada)', 'ada@acme.io')).toBe('ada@acme.io (Ada)')
+  })
+
+  it('treats a missing identifier as "any non-blank name is usable"', () => {
+    expect(usableContactName('Bruno', null)).toBe('Bruno')
+    expect(usableContactName('Bruno', undefined)).toBe('Bruno')
+  })
+})

--- a/packages/lib/src/participants/client.ts
+++ b/packages/lib/src/participants/client.ts
@@ -34,7 +34,33 @@ export interface ParticipantMeta {
   avatarUrl: string | null
   /** Reference to EntityInstance (contact entity type) */
   entityInstanceId: string | null
+  /**
+   * The linked contact's `EntityInstance.displayName`, already normalized by
+   * {@link usableContactName} — `null` when there is no linked (non-archived)
+   * contact, or when its display value is just the identifier echoed back.
+   * Kept separate from `displayName` on purpose: label precedence
+   * (contactName > name > formatted identifier) is resolved in ONE client util,
+   * and the composer's "real name vs identifier" honesty must survive.
+   */
+  contactName: string | null
   isSpammer: boolean
   /** True when the participant's identifier is on the organization's own domain. */
   isInternal: boolean
+}
+
+/**
+ * Normalize a contact's display value into a usable *name* for a participant.
+ *
+ * Returns the trimmed name, or `null` when it is empty/whitespace or equal
+ * (case-insensitive, trimmed) to the participant's identifier — a contact whose
+ * display value IS the phone/email must not masquerade as a name.
+ */
+export function usableContactName(
+  contactDisplayName: string | null | undefined,
+  identifier: string | null | undefined
+): string | null {
+  const name = contactDisplayName?.trim()
+  if (!name) return null
+  if (identifier && name.toLowerCase() === identifier.trim().toLowerCase()) return null
+  return name
 }

--- a/packages/lib/src/participants/index.ts
+++ b/packages/lib/src/participants/index.ts
@@ -1,8 +1,12 @@
 // packages/lib/src/participants/index.ts
 
 export { type ClassifyIsInternalInput, classifyIsInternal } from './classify-internal'
-// Re-export client-safe types
-export type { ParticipantIdentifierType, ParticipantMeta } from './client'
+// Re-export client-safe types + helpers
+export {
+  type ParticipantIdentifierType,
+  type ParticipantMeta,
+  usableContactName,
+} from './client'
 export {
   type ContactIdentifier,
   type ListContactIdentifiersParams,

--- a/packages/lib/src/participants/participant-service.ts
+++ b/packages/lib/src/participants/participant-service.ts
@@ -3,12 +3,12 @@
 import { type Database, database, schema } from '@auxx/database'
 import type { IdentifierType, ParticipantEntity } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { identifierTypeForProvider } from '../channels/capabilities'
 import { getIdentifier } from '../channels/internal/identifier'
 import { generateVisitorName } from '../chat/visitor-naming'
 import { classifyIsInternal } from './classify-internal'
-import type { ParticipantIdentifierType, ParticipantMeta } from './client'
+import { type ParticipantIdentifierType, type ParticipantMeta, usableContactName } from './client'
 
 const logger = createScopedLogger('participant-service')
 
@@ -357,6 +357,30 @@ export class ParticipantService {
       },
     })
 
+    // Read-time contact projection: resolve linked contacts in one batch so a
+    // renamed contact surfaces on mail without any write-through into
+    // `Participant.name`. Archived contacts are skipped, so their participants
+    // fall back to the header/identifier label (design decision 6).
+    const contactIds = [
+      ...new Set(
+        participants
+          .map((p) => p.entityInstanceId)
+          .filter((id): id is string => typeof id === 'string')
+      ),
+    ]
+    const contacts =
+      contactIds.length > 0
+        ? await this.db.query.EntityInstance.findMany({
+            where: and(
+              inArray(schema.EntityInstance.id, contactIds),
+              eq(schema.EntityInstance.organizationId, this.organizationId),
+              isNull(schema.EntityInstance.archivedAt)
+            ),
+            columns: { id: true, displayName: true, avatarUrl: true },
+          })
+        : []
+    const contactById = new Map(contacts.map((c) => [c.id, c]))
+
     const participantMap = new Map(
       participants.map((p) => {
         // Trust the recomputed values over whatever's persisted: legacy
@@ -367,6 +391,7 @@ export class ParticipantService {
           p.identifier,
           p.identifierType
         )
+        const contact = p.entityInstanceId ? contactById.get(p.entityInstanceId) : undefined
 
         const meta: ParticipantMeta = {
           id: p.id,
@@ -375,8 +400,9 @@ export class ParticipantService {
           identifierType: p.identifierType as ParticipantIdentifierType,
           displayName,
           initials: p.initials || initials,
-          avatarUrl: null,
+          avatarUrl: contact?.avatarUrl ?? null,
           entityInstanceId: p.entityInstanceId,
+          contactName: usableContactName(contact?.displayName, p.identifier),
           isSpammer: p.isSpammer ?? false,
           isInternal: p.isInternal ?? false,
         }

--- a/packages/lib/src/participants/search/participant-search-sql.test.ts
+++ b/packages/lib/src/participants/search/participant-search-sql.test.ts
@@ -8,6 +8,7 @@
 import { PgDialect } from 'drizzle-orm/pg-core'
 import { describe, expect, it } from 'vitest'
 import {
+  participantDisplayLabel,
   participantRecencyScore,
   participantSearchBinding,
   participantSearchPredicate,
@@ -96,6 +97,37 @@ describe('participantSearchRank', () => {
     const { sql: text } = render(participantSearchRank('klooth', P))
     expect(weight).toBe('2')
     expect(text).toContain(`COALESCE(similarity(p."displayName", $1), 0) * ${weight}`)
+  })
+})
+
+describe('participantDisplayLabel', () => {
+  it('COALESCEs the usable contact name over the participant displayName', () => {
+    const { sql: text } = render(participantDisplayLabel(P, 'ct'))
+    // Blank/NULL contact names collapse to NULL…
+    expect(text).toContain(`WHEN BTRIM(COALESCE(ct."displayName", '')) = '' THEN NULL`)
+    // …and a contact whose display value IS the identifier must not masquerade
+    // as a name — same rule as `usableContactName` in `../client.ts`.
+    expect(text).toContain(
+      `WHEN LOWER(BTRIM(ct."displayName")) = LOWER(BTRIM(p."identifier")) THEN NULL`
+    )
+    expect(text).toContain(`ELSE BTRIM(ct."displayName")`)
+    expect(text).toContain(`p."displayName")`)
+  })
+
+  it('🔴 stays out of the match predicate and the rank — label only', () => {
+    // A contact renamed five minutes ago must still be findable by the old
+    // header name, and the trigram indexes only cover the stored columns.
+    const contactRef = 'ct."displayName"'
+    expect(render(participantSearchPredicate('klooth', P)).sql).not.toContain(contactRef)
+    expect(render(participantSearchRank('klooth', P)).sql).not.toContain(contactRef)
+  })
+
+  it('respects both aliases it was built with', () => {
+    const { sql: text } = render(participantDisplayLabel(participantSearchBinding('cand'), 'ei2'))
+    expect(text).toContain('ei2."displayName"')
+    expect(text).toContain('cand."identifier"')
+    expect(text).not.toContain('ct."displayName"')
+    expect(text).not.toContain('p."displayName"')
   })
 })
 

--- a/packages/lib/src/participants/search/participant-search-sql.ts
+++ b/packages/lib/src/participants/search/participant-search-sql.ts
@@ -101,6 +101,8 @@ export interface ParticipantSearchBinding {
    */
   cols: TextSearchColumns
   identifier: SQL
+  /** The label column, read by {@link participantDisplayLabel} only. */
+  displayName: SQL
   lastSentMessageAt: SQL
 }
 
@@ -115,6 +117,7 @@ export function participantSearchBinding(alias: string): ParticipantSearchBindin
       id: col('id'),
     },
     identifier: col('identifier'),
+    displayName: col('displayName'),
     lastSentMessageAt: col('lastSentMessageAt'),
   }
 }
@@ -177,6 +180,35 @@ export function participantSearchPredicate(
     ...phonePatterns.map((pattern) => sql`${binding.identifier} ILIKE ${`%${pattern}%`}`),
   ]
   return sql`(${sql.join(arms, sql` OR `)})`
+}
+
+/**
+ * The emitted display label for a participant row LEFT-JOINed to its linked
+ * contact: the contact's *usable* displayName wins over the participant's.
+ *
+ * "Usable" mirrors `usableContactName` (`../client.ts`): NULL/blank collapses
+ * to NULL, and a contact whose display value IS the identifier (case-insensitive,
+ * trimmed) must not masquerade as a name. The identifier fallback stays in TS
+ * (`toParticipantCandidate`), where it already lives.
+ *
+ * 🔴 **Label only.** This must never feed the match predicate or the rank —
+ * a contact renamed five minutes ago is still findable by the old header name,
+ * and the trigram indexes only cover the stored participant columns.
+ *
+ * @param binding The participant binding (identifier + displayName refs).
+ * @param contactAlias Alias of the LEFT-JOINed `EntityInstance` (filtered to
+ *   `archivedAt IS NULL` by the join, so an archived contact falls back here).
+ */
+export function participantDisplayLabel(
+  binding: ParticipantSearchBinding,
+  contactAlias: string
+): SQL {
+  const contactName = sql.raw(`${contactAlias}."displayName"`)
+  return sql`COALESCE(CASE
+    WHEN BTRIM(COALESCE(${contactName}, '')) = '' THEN NULL
+    WHEN LOWER(BTRIM(${contactName})) = LOWER(BTRIM(${binding.identifier})) THEN NULL
+    ELSE BTRIM(${contactName})
+  END, ${binding.displayName})`
 }
 
 /**

--- a/packages/lib/src/participants/search/search-recipients.ts
+++ b/packages/lib/src/participants/search/search-recipients.ts
@@ -35,6 +35,7 @@ import {
   type RecipientModel,
 } from '../channel-identifier-fields'
 import {
+  participantDisplayLabel,
   participantSearchBinding,
   participantSearchPredicate,
   participantSearchRank,
@@ -349,16 +350,23 @@ async function participantArm(
   const predicate = participantSearchPredicate(input.query, p, input.phonePatterns)
   const lens = lensExists(sql`c."id"`, params.threadVisibility)
 
+  // The linked contact joins for the LABEL only (`participantDisplayLabel`) —
+  // predicate and rank stay on the stored participant columns, so match/rank
+  // behavior and the trigram index plan are untouched.
   const result = await db.execute(sql`
     WITH candidates AS (
       SELECT p."id",
              p."identifier",
              p."identifierType",
-             p."displayName",
+             ${participantDisplayLabel(p, 'ct')} AS "displayName",
              p."entityInstanceId",
              p."lastSentMessageAt",
              ${rank} AS score
       FROM ${schema.Participant} p
+      LEFT JOIN ${schema.EntityInstance} ct
+        ON ct."id" = p."entityInstanceId"
+        AND ct."organizationId" = ${params.organizationId}
+        AND ct."archivedAt" IS NULL
       WHERE p."organizationId" = ${params.organizationId}
         AND NOT p."isSpammer"
         AND p."identifierType" IN ${inList(input.identifierTypes)}
@@ -402,16 +410,23 @@ async function recentlyMailedArm(
   input: { identifierTypes: readonly IdentifierType[]; limit: number }
 ): Promise<ParticipantArmResult> {
   const lens = lensExists(sql`p."id"`, params.threadVisibility)
+  const p = participantSearchBinding('p')
 
+  // Same label-only contact join as `participantArm` — the empty-query list
+  // feeds the same picker, so its rows must carry the same name.
   const result = await db.execute(sql`
     SELECT p."id",
            p."identifier",
            p."identifierType",
-           p."displayName",
+           ${participantDisplayLabel(p, 'ct')} AS "displayName",
            p."entityInstanceId",
            p."lastSentMessageAt",
            0::float8 AS score
     FROM ${schema.Participant} p
+    LEFT JOIN ${schema.EntityInstance} ct
+      ON ct."id" = p."entityInstanceId"
+      AND ct."organizationId" = ${params.organizationId}
+      AND ct."archivedAt" IS NULL
     WHERE p."organizationId" = ${params.organizationId}
       AND NOT p."isSpammer"
       AND p."identifierType" IN ${inList(input.identifierTypes)}


### PR DESCRIPTION
## Summary

When a linked contact has a display name, mail surfaces now show it — and flip live when it changes — instead of the header-derived name or raw identifier frozen at ingest. A nameless SMS counterparty renders as a formatted number (`+1 888 915 5797`), and the moment an event/agent names the contact, every visible row, bubble, title and chip updates in place with no refetch.

Plan: `plans/participants/contact-name-precedence.md` (phases 1–4; phase 5 — publishing `participant:updated` from the composer/visitor-identity write paths — is a deliberate follow-up).

## How

- **Server** — `getParticipantMetaBatch` batch-resolves linked non-archived contacts and adds `ParticipantMeta.contactName` (normalized via shared `usableContactName`: never blank, never the identifier echoed back), and populates the previously hardcoded-null `avatarUrl` from the contact. Read-time precedence, not write-through: nothing copies names into `Participant`, so merges re-point and deletes/archives self-heal.
- **Client** — one label util (`participant-label.ts`): `contactName` > header-derived name > PHONE_INTL-formatted identifier, with an `isInternal` guard (a stray auto-created contact can't rename a teammate) and initials that follow the winning label. Applied at thread rows, message/chat/call displays, the email participant list and thread titles. Chat-header `claimedVisitorName` precedence, composer chips, and the details span's raw identifier are deliberately untouched.
- **Realtime** — `useResourceSync` (already bound to every def's record channel) patches a new `patchParticipantsForContact()` on `record:updated/created` and clears on `record:deleted/archived`. No new subscriptions; per-participant name normalization happens in the store patch.
- **Search** — both recipient-search participant arms and global search emit the contact-name label (label only — match/rank/suppression SQL unchanged), and the previously dead contact branch in `search.ts`'s `getParticipantDisplayName` is now wired to a real batch lookup.

## Notes for review

- Accepted trade-offs are documented in the plan: `inboxesView` holders see the contact display name at fetch time even without contact read (live renames still ride the `canViewEntity`-ACL'd record channel), and a fuzzily-linked contact now renames mail surfaces visibly rather than only the header chip.
- `packages/lib/package.json` diff is the codegen'd `./participants/client` subpath (`pnpm generate:exports`).

## Testing

- lib participants suite: 107/107 (19 new: meta-batch enrichment, `usableContactName`, SQL label cases)
- web: 11 new label-util tests, thread-title 24 (3 new), recipient-input 61, mail-router front door 77 — all green
- Scoped typechecks clean in all touched files