### PR TITLE
feat(threads): inline timeline v2 with day separators, event blocks and net-effect summaries

### DIFF
--- a/apps/web/src/components/mail/chat-panel/messages.tsx
+++ b/apps/web/src/components/mail/chat-panel/messages.tsx
@@ -12,8 +12,7 @@ import { buildChatTimeline } from '../chat-timeline'
 import type { EmailActions } from '../email-actions'
 import EmailDisplay from '../email-display'
 import MessageDisplay from '../message-display'
-import { SystemLine } from './system-line'
-import { SystemLineRun } from './system-line-run'
+import { DaySeparator, EventBlock } from './system-line-run'
 import { useChatThreadEvents } from './use-thread-events'
 
 interface ChatPanelMessagesProps {
@@ -93,11 +92,11 @@ export function ChatPanelMessages({ threadId, popoverClassName }: ChatPanelMessa
       scrollbarClassName='w-1!'>
       <div className='flex flex-col gap-2 px-3 py-2 pe-4'>
         {items.map((item) => {
-          if (item.kind === 'event') {
-            return <SystemLine key={`evt:${item.event.id}`} event={item.event} />
+          if (item.kind === 'day-separator') {
+            return <DaySeparator key={item.key} label={item.label} />
           }
-          if (item.kind === 'event-run') {
-            return <SystemLineRun key={`evtrun:${item.events[0]!.id}`} events={item.events} />
+          if (item.kind === 'event-block') {
+            return <EventBlock key={item.key} entries={item.entries} isTrailing={item.isTrailing} />
           }
           if (item.kind === 'chat-group') {
             const groupIsLast = item.endIndex === messages.length - 1

--- a/apps/web/src/components/mail/chat-panel/system-line-run.tsx
+++ b/apps/web/src/components/mail/chat-panel/system-line-run.tsx
@@ -1,123 +1,270 @@
 // apps/web/src/components/mail/chat-panel/system-line-run.tsx
 'use client'
 
+import type { ActorId, ActorType } from '@auxx/types/actor'
+import { isWorkerActor, toActorId } from '@auxx/types/actor'
+import { AnimatedCollapsibleContent, CollapsibleChevron } from '@auxx/ui/components/collapsible'
+import { Separator } from '@auxx/ui/components/separator'
 import { cn } from '@auxx/ui/lib/utils'
-import { ChevronDown } from 'lucide-react'
-import { Fragment, type ReactNode, useState } from 'react'
-import { eventActorKey } from '../chat-timeline'
-import { type ChatThreadEvent, SystemLine, TagLine, useEventActor } from './system-line'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useSession } from '~/auth/auth-client'
+import { useActors } from '~/components/resources/hooks'
+import { getActorStoreState } from '~/components/resources/store/actor-store'
+import { ActorAvatar } from '~/components/resources/ui/actor-badge'
+import { actorAvatarType } from '~/components/resources/utils/actor-id'
+import {
+  composeEventGroupSummary,
+  type EventBlockEntry,
+  eventActorKey,
+  formatEventGroupSummary,
+  type GroupActorLabelResolver,
+} from '../chat-timeline'
+import { type ChatThreadEvent, formatTimeOnly, pickEventSource, SystemLine } from './system-line'
 
-interface SystemLineRunProps {
-  /** ≥2 consecutive same-actor events, ASC — produced by `buildChatTimeline`. */
-  events: ChatThreadEvent[]
+interface EventBlockProps {
+  /** The block's entries, ASC — produced by `buildChatTimeline`. */
+  entries: EventBlockEntry[]
+  /** Trailing blocks (events after the last message) start expanded (§15.4.3). */
+  isTrailing: boolean
 }
 
 /**
- * Collapsed summary line for an `event-run` timeline item (admin surfaces
- * only — the widget keeps flat lines). Same centered/muted visual language as
- * `SystemLine`: the actor prefix once, then composed fragments — "Markus
- * marked as done and tagged with x, y" — with a chevron toggle that expands to
- * the individual `SystemLine` rows. Runs that don't compose cleanly (a
- * non-composable type, or the mixed-actor case that shouldn't occur by
- * construction) fall back to "made N updates".
+ * One event block: a shared left rail (`mx-auto w-full max-w-2xl`, matching
+ * the message column) drawing every row in the block — loose singles and
+ * collapsed group-rows alike. Expanding a group splices its sub-rows onto the
+ * same rail in place (plans/threads/thread-events.md §15.2).
  */
-export function SystemLineRun({ events }: SystemLineRunProps) {
-  const [expanded, setExpanded] = useState(false)
-  const first = events[0]
-  const actor = useEventActor(first)
-  if (!first) return null
+export function EventBlock({ entries, isTrailing }: EventBlockProps) {
+  return (
+    <div className='mx-auto w-full max-w-2xl'>
+      <div className='flex flex-col'>
+        {entries.map((entry, i) => {
+          const continuesAfter = i !== entries.length - 1
+          if (entry.kind === 'single') {
+            return <SystemLine key={entry.event.id} event={entry.event} showRail={continuesAfter} />
+          }
+          return (
+            <GroupRow
+              key={entry.events[0]!.id}
+              events={entry.events}
+              continuesAfter={continuesAfter}
+              defaultExpanded={isTrailing}
+            />
+          )
+        })}
+      </div>
+    </div>
+  )
+}
 
-  const prefix = actor.label
-  // Actor identity is part of the run key, so a mixed run shouldn't exist —
-  // but guard anyway and degrade to the count summary.
-  const sameActor = events.every((e) => eventActorKey(e) === eventActorKey(first))
-  const fragments = events.map(eventRunFragment)
-  const composable = sameActor && fragments.every((f) => f !== null)
+interface FacepileActor {
+  key: string
+  type: ActorType
+  avatarUrl: string | null
+  isTeam?: boolean
+}
 
-  let summary: ReactNode
-  if (!composable) {
-    const count = `made ${events.length} updates`
-    summary = sameActor && prefix ? `${prefix} ${count}` : `${events.length} updates`
-  } else {
-    const parts: ReactNode[] = []
-    fragments.forEach((fragment, i) => {
-      if (!fragment) return
-      if (i > 0) parts.push(i === fragments.length - 1 ? ' and ' : ', ')
-      const text = i === 0 && !prefix ? capitalize(fragment.text) : fragment.text
-      if (fragment.tags && fragment.tags.length > 0) {
-        parts.push(<TagLine text={text} tags={fragment.tags} />)
-      } else {
-        parts.push(text)
-      }
-    })
-    summary = (
-      <>
-        {prefix ? `${prefix} ` : null}
-        {parts.map((part, i) => (
-          <Fragment key={i}>{part}</Fragment>
-        ))}
-      </>
-    )
-  }
+/**
+ * Collapsed group-row (≥3 contiguous same-day events, mixed actors welcome):
+ * condensed count dot + facepile (up to 3 stacked `ActorAvatar`s) + net-effect
+ * summary + time range, all on the block's shared rail. Expands in place to
+ * splice each event's own `SystemLine` row below it (§15.4.4).
+ */
+function GroupRow({
+  events,
+  continuesAfter,
+  defaultExpanded,
+}: {
+  events: ChatThreadEvent[]
+  continuesAfter: boolean
+  defaultExpanded: boolean
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded)
+  const { actorLabel, facepile } = useGroupActorResolution(events)
 
-  const timestamp = `${new Date(first.createdAt).toLocaleString()} – ${new Date(
-    events[events.length - 1]!.createdAt
-  ).toLocaleString()}`
+  const summary = useMemo(
+    () => formatEventGroupSummary(composeEventGroupSummary(events, actorLabel)),
+    [events, actorLabel]
+  )
+
+  const first = events[0]!
+  const last = events[events.length - 1]!
+  const timeRange = `${formatTimeOnly(new Date(first.createdAt))} – ${formatTimeOnly(new Date(last.createdAt))}`
+  const fullRange = `${new Date(first.createdAt).toLocaleString()} – ${new Date(last.createdAt).toLocaleString()}`
+
+  const headerHasRail = continuesAfter || expanded
 
   return (
-    <div className='flex flex-col items-stretch gap-1 self-center'>
+    <div className='flex flex-col'>
       <button
         type='button'
         onClick={() => setExpanded((v) => !v)}
-        title={timestamp}
         aria-expanded={expanded}
-        className='inline-flex flex-wrap items-center justify-center gap-1 self-center px-3 text-center text-xs italic text-muted-foreground transition-colors hover:text-foreground'>
-        <span className='inline-flex flex-wrap items-center justify-center gap-1'>{summary}</span>
-        <ChevronDown
-          className={cn('size-3 shrink-0 transition-transform', expanded && 'rotate-180')}
-        />
+        title={fullRange}
+        className={cn(
+          'relative flex w-full items-center gap-2 rounded-md py-1 pl-0 text-left transition-colors hover:bg-muted',
+          headerHasRail &&
+            'before:absolute before:inset-y-0 before:left-[7.5px] before:w-px before:bg-border'
+        )}>
+        <span
+          aria-hidden
+          className='relative z-10 flex size-4 shrink-0 items-center justify-center rounded-full bg-muted text-[9px] font-medium text-muted-foreground'>
+          {events.length}
+        </span>
+        <Facepile actors={facepile} />
+        <span className='min-w-0 flex-1 truncate text-sm text-foreground'>{summary}</span>
+        <span className='shrink-0 text-[10px] text-muted-foreground'>{timeRange}</span>
+        <CollapsibleChevron open={expanded} className='size-3 shrink-0 text-muted-foreground' />
       </button>
-      {expanded && events.map((event) => <SystemLine key={event.id} event={event} />)}
+      <AnimatedCollapsibleContent open={expanded}>
+        <div className='flex flex-col pt-1'>
+          {events.map((event, idx) => (
+            <SystemLine
+              key={event.id}
+              event={event}
+              showRail={idx !== events.length - 1 || continuesAfter}
+            />
+          ))}
+        </div>
+      </AnimatedCollapsibleContent>
     </div>
   )
 }
 
 /**
- * The composable verb phrase for one event inside a run summary — no actor
- * prefix, no per-event lookups. Returns null for types that only read as a
- * full sentence (visitor identified); a null anywhere makes the whole run fall
- * back to the "made N updates" summary.
+ * Viewer-local day divider spanning the whole conversation — message bubbles
+ * AND event rows share this one day spine (§15.6). "Today" / "Yesterday" /
+ * weekday / "Aug 12" labeling comes from `buildChatTimeline`; this just draws
+ * the Slack/WhatsApp-style centered line.
  */
-export function eventRunFragment(event: ChatThreadEvent): { text: string; tags?: string[] } | null {
-  switch (event.type) {
-    case 'thread:taken_over':
-      return { text: 'took over the conversation' }
-    case 'thread:returned_to_ai':
-      return { text: 'returned the conversation to AI' }
-    case 'thread:archived':
-      return { text: 'marked as done' }
-    case 'thread:reopened':
-      return { text: 'reopened the conversation' }
-    case 'thread:assignee:changed':
-      // The summary stays generic; the expanded row names the assignee.
-      return { text: 'changed the assignee' }
-    case 'thread:tagged':
-      return { text: 'tagged with', tags: pickTags(event) }
-    case 'thread:untagged':
-      return { text: 'removed tags', tags: pickTags(event) }
-    case 'thread:merged':
-      return { text: 'merged a conversation into this one' }
-    default:
-      return null
-  }
+export function DaySeparator({ label }: { label: string }) {
+  return (
+    <div
+      role='separator'
+      aria-label={label}
+      className='mx-auto flex w-full max-w-2xl items-center gap-3 px-4 py-1'>
+      <Separator className='flex-1' />
+      <span className='shrink-0 text-[11px] font-medium text-muted-foreground'>{label}</span>
+      <Separator className='flex-1' />
+    </div>
+  )
 }
 
-function pickTags(event: ChatThreadEvent): string[] {
-  const names = event.data.tagNames
-  if (!Array.isArray(names)) return []
-  return names.filter((n): n is string => typeof n === 'string' && n.length > 0)
+function Facepile({ actors }: { actors: FacepileActor[] }) {
+  if (actors.length === 0) return null
+  return (
+    <span className='flex shrink-0 items-center'>
+      {actors.map((a, i) => (
+        <ActorAvatar
+          key={a.key}
+          type={a.type}
+          avatarUrl={a.avatarUrl}
+          isTeam={a.isTeam}
+          className={cn('size-4 rounded-full ring-2 ring-background', i > 0 && '-ml-1.5')}
+        />
+      ))}
+    </span>
+  )
 }
 
-function capitalize(text: string): string {
-  return text.charAt(0).toUpperCase() + text.slice(1)
+/**
+ * Resolve display names + a facepile for a group's events, without the
+ * per-row live workflow-name refinement (`useEventActor` does that for
+ * expanded rows) — the group summary is a compact net-effect line, so it
+ * stays on the actor store's already-hydrated names and the emit-time
+ * automation snapshot. Actors not yet in the store get requested here too.
+ */
+function useGroupActorResolution(events: ChatThreadEvent[]): {
+  actorLabel: GroupActorLabelResolver
+  facepile: FacepileActor[]
+} {
+  const { data: session } = useSession()
+  const currentUserId = session?.user?.id ?? null
+  const currentUserKey = currentUserId ? `actor:${toActorId('user', currentUserId)}` : null
+
+  const actorIds = useMemo(() => {
+    const seen = new Set<string>()
+    const ids: ActorId[] = []
+    const add = (id: string) => {
+      if (seen.has(id)) return
+      seen.add(id)
+      ids.push(id as ActorId)
+    }
+    for (const e of events) {
+      if (typeof e.actorId === 'string' && e.actorId) add(e.actorId)
+      else {
+        // Legacy pre-cut-over rows: `eventActorKey` falls back to `data.userId`,
+        // so the summary resolver will ask for that actor — request it too.
+        const legacy = e.data?.userId
+        if (typeof legacy === 'string' && legacy) add(toActorId('user', legacy))
+      }
+      if (e.type === 'thread:assignee:changed') {
+        const branded = e.data.assigneeActorId
+        const legacyTo = e.data?.toUserId
+        if (typeof branded === 'string' && branded) add(branded)
+        else if (typeof legacyTo === 'string' && legacyTo) add(toActorId('user', legacyTo))
+      }
+    }
+    return ids
+  }, [events])
+
+  useEffect(() => {
+    for (const id of actorIds) getActorStoreState().requestActor(id)
+  }, [actorIds])
+
+  const actorsMap = useActors(actorIds)
+
+  const actorLabel = useCallback<GroupActorLabelResolver>(
+    (actorKey, sample) => {
+      if (currentUserKey && actorKey === currentUserKey) return 'You'
+      if (actorKey.startsWith('actor:')) {
+        const id = actorKey.slice('actor:'.length) as ActorId
+        const actor = actorsMap.get(id)
+        return actor?.name || 'A teammate'
+      }
+      if (actorKey.startsWith('source:')) {
+        const source = pickEventSource(sample)
+        if (!source) return 'Automation'
+        switch (source.kind) {
+          case 'workflow':
+            return source.name ? `Workflow "${source.name}"` : 'A workflow'
+          case 'mail_filter':
+            return source.name ? `Filter "${source.name}"` : 'A filter'
+          case 'record_rule':
+            return source.name ? `Rule "${source.name}"` : 'A rule'
+          case 'classification':
+            return 'AI classification'
+          default:
+            return 'Automation'
+        }
+      }
+      return 'System'
+    },
+    [actorsMap, currentUserKey]
+  )
+
+  const facepile = useMemo<FacepileActor[]>(() => {
+    const seen = new Set<string>()
+    const result: FacepileActor[] = []
+    for (const e of events) {
+      const key = eventActorKey(e)
+      if (seen.has(key) || result.length >= 3) continue
+      seen.add(key)
+      if (key.startsWith('actor:')) {
+        const id = key.slice('actor:'.length) as ActorId
+        const actor = actorsMap.get(id)
+        result.push({
+          key,
+          type: actorAvatarType(id, actor?.type),
+          avatarUrl: actor?.avatarUrl ?? null,
+          isTeam: !!actor && isWorkerActor(actor) && actor.workerType === 'team',
+        })
+      } else {
+        result.push({ key, type: 'system', avatarUrl: null })
+      }
+    }
+    return result
+  }, [events, actorsMap])
+
+  return { actorLabel, facepile }
 }

--- a/apps/web/src/components/mail/chat-panel/system-line.tsx
+++ b/apps/web/src/components/mail/chat-panel/system-line.tsx
@@ -1,13 +1,20 @@
 // apps/web/src/components/mail/chat-panel/system-line.tsx
 'use client'
 
+import type { RecordId } from '@auxx/lib/resources/client'
 import type { ThreadEventSource, ThreadEventType } from '@auxx/lib/thread-events/client'
 import { type ActorId, toActorId } from '@auxx/types/actor'
 import { Badge } from '@auxx/ui/components/badge'
+import { cn } from '@auxx/ui/lib/utils'
+import { format } from 'date-fns'
+import Link from 'next/link'
 import type { ReactNode } from 'react'
 import { useSession } from '~/auth/auth-client'
-import { useActor } from '~/components/resources/hooks'
+import { useActor, useRecord } from '~/components/resources/hooks'
+import { ActorBadge } from '~/components/resources/ui/actor-badge'
+import { TagBadge } from '~/components/tags/ui/tag-badge'
 import { api } from '~/trpc/react'
+import { ThreadEventDot } from '../thread-event-icon'
 
 export type ChatThreadEventType = ThreadEventType
 
@@ -22,28 +29,48 @@ export interface ChatThreadEvent {
 
 interface SystemLineProps {
   event: ChatThreadEvent
+  /**
+   * Whether the shared left rail continues below this row — every row in a
+   * block draws the same rail (§15.2/§15.3), except the block's visually LAST
+   * row, which hides its trailing segment. Defaults to `true`.
+   */
+  showRail?: boolean
 }
 
 /**
- * Centered, muted text rendered between message bubbles for thread lifecycle
- * events in the admin thread view (email, SMS and chat alike). Copy is
- * channel-neutral — "took over the conversation", "marked as done" — because
- * the same events fire on every transport, unlike the widget's chat-specific
- * visitor copy.
+ * One event-block row: type-icon dot + copy + right-aligned time-only
+ * timestamp (full datetime in the hover title), left-aligned on the block's
+ * shared rail. Used both for a block's loose single rows and for an expanded
+ * group's spliced-in sub-rows (plans/threads/thread-events.md §15.3).
  */
-export function SystemLine({ event }: SystemLineProps) {
+export function SystemLine({ event, showRail = true }: SystemLineProps) {
   const actor = useEventActor(event)
   const assignee = useEventAssignee(event)
   const content = eventContent(event, actor, assignee)
   if (!content) return null
-  const timestamp = new Date(event.createdAt).toLocaleString()
+  const date = new Date(event.createdAt)
   return (
     <div
-      className='self-center px-3 text-center text-xs italic text-muted-foreground'
-      title={timestamp}>
-      {content}
+      className={cn(
+        'relative flex items-start gap-2.5 py-1',
+        showRail &&
+          'before:absolute before:inset-y-0 before:left-[7.5px] before:w-px before:bg-border'
+      )}>
+      <ThreadEventDot type={event.type} className='relative z-10 mt-0.5' />
+      <div className='min-w-0 flex-1 text-sm text-foreground'>{content}</div>
+      <time
+        dateTime={event.createdAt}
+        title={date.toLocaleString()}
+        className='shrink-0 pt-0.5 text-[10px] text-muted-foreground'>
+        {formatTimeOnly(date)}
+      </time>
     </div>
   )
+}
+
+/** "2:41 PM" — time-only; the day is established by the §15.6 day separators. */
+export function formatTimeOnly(date: Date): string {
+  return format(date, 'h:mm a')
 }
 
 export interface EventActor {
@@ -51,10 +78,14 @@ export interface EventActor {
   label: string | null
   /** The acting principal's branded id when one exists (column or legacy payload). */
   actorId: ActorId | null
+  /** Discriminates how {@link EventActorPrefix} renders the label. */
+  kind: 'self' | 'actor' | 'workflow' | 'mail_filter' | 'record_rule' | 'classification' | 'none'
+  /** Link target for provenance kinds that have one — workflow editor / mail filter settings. */
+  href: string | null
 }
 
 /**
- * Resolve the actor prefix for an event line (shared with `SystemLineRun`).
+ * Resolve the actor prefix for an event line (shared with the group summary).
  *
  * Precedence (plans/threads/thread-events.md §5.5): the persisted `actorId`
  * column (can name an agent, resolved lazily via the actor store) → the legacy
@@ -91,38 +122,82 @@ export function useEventActor(event: ChatThreadEvent | undefined): EventActor {
 
   if (actorId) {
     if (currentUserId && actorId === toActorId('user', currentUserId)) {
-      return { label: 'You', actorId }
+      return { label: 'You', actorId, kind: 'self', href: null }
     }
-    return { label: actor?.name ?? 'A teammate', actorId }
+    return { label: actor?.name ?? 'A teammate', actorId, kind: 'actor', href: null }
   }
-  if (!source) return { label: null, actorId: null }
+  if (!source) return { label: null, actorId: null, kind: 'none', href: null }
   switch (source.kind) {
     case 'workflow': {
       const name = workflow?.name ?? source.name
-      return { label: name ? `Workflow "${name}"` : 'A workflow', actorId: null }
+      return {
+        label: name ? `Workflow "${name}"` : 'A workflow',
+        actorId: null,
+        kind: 'workflow',
+        // The workflow builder route — deep-links straight to the editor.
+        href: source.id ? `/app/workflows/${source.id}` : null,
+      }
     }
     case 'mail_filter':
-      return { label: source.name ? `Filter "${source.name}"` : 'A filter', actorId: null }
+      return {
+        label: source.name ? `Filter "${source.name}"` : 'A filter',
+        actorId: null,
+        kind: 'mail_filter',
+        // No per-filter deep link exists yet — the Rules settings page hosts
+        // every org's mail filters, so that's the closest honest target.
+        href: '/app/settings/rules',
+      }
     case 'record_rule':
-      return { label: source.name ? `Rule "${source.name}"` : 'A rule', actorId: null }
+      return {
+        label: source.name ? `Rule "${source.name}"` : 'A rule',
+        actorId: null,
+        kind: 'record_rule',
+        href: null,
+      }
     case 'classification':
-      return { label: 'AI classification', actorId: null }
+      return { label: 'AI classification', actorId: null, kind: 'classification', href: null }
     default:
       // 'system' (or an unknown future kind): no actor prefix.
-      return { label: null, actorId: null }
+      return { label: null, actorId: null, kind: 'none', href: null }
   }
+}
+
+/**
+ * Renders an {@link EventActor} as the row's leading prefix: plain "You" for
+ * self, `ActorBadge variant='text'` for an addressable actor, a link to the
+ * workflow editor / mail filter settings for automation provenance that has
+ * one, else plain text (§15.3 — provenance isn't an `ActorId`, by design, so
+ * it never gets the avatar badge treatment).
+ */
+function EventActorPrefix({ actor }: { actor: EventActor }): ReactNode {
+  if (!actor.label) return null
+  if (actor.kind === 'self') return <>You</>
+  if (actor.kind === 'actor' && actor.actorId) {
+    return <ActorBadge actorId={actor.actorId} variant='text' size='sm' />
+  }
+  if (actor.href) {
+    return (
+      <Link
+        href={actor.href}
+        className='font-medium text-foreground underline-offset-2 hover:underline'>
+        {actor.label}
+      </Link>
+    )
+  }
+  return <>{actor.label}</>
 }
 
 interface EventAssignee {
   actorId: ActorId | null
-  name: string | null
   isSelf: boolean
 }
 
 /**
  * Resolve the NEW assignee for `thread:assignee:changed` — a referenced actor,
  * not the acting principal. New rows carry a branded `data.assigneeActorId`
- * ('user:…' / 'agent:…'); legacy rows carry a bare `data.toUserId`.
+ * ('user:…' / 'agent:…'); legacy rows carry a bare `data.toUserId`. The name
+ * itself is rendered live via `ActorBadge`, so this only needs the id + the
+ * self-assign check.
  */
 function useEventAssignee(event: ChatThreadEvent): EventAssignee {
   const { data: session } = useSession()
@@ -139,9 +214,8 @@ function useEventAssignee(event: ChatThreadEvent): EventAssignee {
           ? toActorId('user', legacy)
           : null
   }
-  const { actor } = useActor({ actorId: assigneeId, enabled: !!assigneeId })
   const isSelf = !!currentUserId && assigneeId === toActorId('user', currentUserId)
-  return { actorId: assigneeId, name: actor?.name ?? null, isSelf }
+  return { actorId: assigneeId, isSelf }
 }
 
 /**
@@ -169,7 +243,14 @@ export function pickEventSource(event: ChatThreadEvent): ThreadEventSource | nul
   return source as ThreadEventSource
 }
 
-/** Extract `data.tagNames` for tagged/untagged events. */
+/** Extract `data.tagIds` for tagged/untagged events. */
+function pickTagIds(event: ChatThreadEvent): string[] {
+  const ids = event.data.tagIds
+  if (!Array.isArray(ids)) return []
+  return ids.filter((id): id is string => typeof id === 'string' && id.length > 0)
+}
+
+/** Extract `data.tagNames` for tagged/untagged events (snapshot fallback for deleted tags). */
 function pickTagNames(event: ChatThreadEvent): string[] {
   const names = event.data.tagNames
   if (!Array.isArray(names)) return []
@@ -191,28 +272,43 @@ function eventContent(
   actor: EventActor,
   assignee: EventAssignee
 ): ReactNode | null {
-  const prefix = actor.label
-  const withPrefix = (fragment: string): string =>
-    prefix ? `${prefix} ${fragment}` : capitalize(fragment)
+  const hasPrefix = !!actor.label
+  const prefix = hasPrefix ? <EventActorPrefix actor={actor} /> : null
+  const wrap = (fragment: string): ReactNode =>
+    hasPrefix ? (
+      <>
+        {prefix} {fragment}
+      </>
+    ) : (
+      capitalize(fragment)
+    )
 
   switch (event.type) {
     case 'thread:taken_over':
-      return withPrefix('took over the conversation')
+      return wrap('took over the conversation')
     case 'thread:returned_to_ai':
-      return withPrefix('returned the conversation to AI')
+      return wrap('returned the conversation to AI')
     case 'thread:archived':
-      return withPrefix('marked as done')
+      return wrap('marked as done')
     case 'thread:reopened':
-      return withPrefix('reopened the conversation')
+      return wrap('reopened the conversation')
     case 'thread:assignee:changed': {
-      if (!assignee.actorId) return withPrefix('unassigned the conversation')
-      const target = assignee.isSelf ? 'you' : (assignee.name ?? 'a teammate')
+      if (!assignee.actorId) return wrap('unassigned the conversation')
+      const targetNode: ReactNode = assignee.isSelf ? (
+        'you'
+      ) : (
+        <ActorBadge actorId={assignee.actorId} variant='text' size='sm' />
+      )
       // Skip the actor prefix when the actor IS the assignee (self-assign, or
       // legacy rows whose only identity was `toUserId`).
-      if (!prefix || actor.actorId === assignee.actorId) {
-        return `Assigned to ${target}`
+      if (!hasPrefix || actor.actorId === assignee.actorId) {
+        return <>Assigned to {targetNode}</>
       }
-      return `${prefix} assigned this to ${target}`
+      return (
+        <>
+          {prefix} assigned this to {targetNode}
+        </>
+      )
     }
     case 'thread:visitor:identified': {
       const email = event.data.visitorEmail
@@ -220,35 +316,94 @@ function eventContent(
       return `Visitor identified as ${email}`
     }
     case 'thread:tagged':
-      return <TagLine text={withPrefix('tagged with')} tags={pickTagNames(event)} />
+      return (
+        <TagLine
+          prefix={prefix}
+          hasPrefix={hasPrefix}
+          verb='tagged with'
+          tagIds={pickTagIds(event)}
+          tagNames={pickTagNames(event)}
+        />
+      )
     case 'thread:untagged':
-      return <TagLine text={withPrefix('removed tags')} tags={pickTagNames(event)} />
+      return (
+        <TagLine
+          prefix={prefix}
+          hasPrefix={hasPrefix}
+          verb='removed tags'
+          tagIds={pickTagIds(event)}
+          tagNames={pickTagNames(event)}
+        />
+      )
     case 'thread:merged':
       // `data.sourceThreadId` names the merged-in thread, but that thread is
       // typically hidden post-merge — plain copy degrades gracefully instead
       // of fetching a row the viewer can no longer open.
-      return prefix
-        ? `${prefix} merged a conversation into this one`
-        : 'A conversation was merged into this one'
+      return prefix ? (
+        <>{prefix} merged a conversation into this one</>
+      ) : (
+        'A conversation was merged into this one'
+      )
     default:
       return null
   }
 }
 
 /**
- * "{text} {pill pill pill}" — the same Badge-pill idiom the record timeline
- * uses for TAG_ADDED / TAG_REMOVED in `~/components/timeline/event-description.tsx`.
+ * "{prefix} {verb} {chip chip chip}" — colored tag chips resolved live by
+ * `tagIds` (org cache via `TagBadge`), falling back to the emit-time
+ * `tagNames` snapshot for a deleted tag — same live-then-snapshot precedence
+ * as workflow provenance (§5.5/§15.3).
  */
-export function TagLine({ text, tags }: { text: string; tags: string[] }) {
-  if (tags.length === 0) return <>{text}</>
+export function TagLine({
+  prefix,
+  hasPrefix,
+  verb,
+  tagIds,
+  tagNames,
+}: {
+  prefix: ReactNode
+  hasPrefix: boolean
+  verb: string
+  tagIds: string[]
+  tagNames: string[]
+}) {
+  const lead = hasPrefix ? (
+    <>
+      {prefix} {verb}
+    </>
+  ) : (
+    capitalize(verb)
+  )
+  if (tagIds.length === 0 && tagNames.length === 0) return <>{lead}</>
   return (
-    <span className='inline-flex flex-wrap items-center justify-center gap-1'>
-      <span>{text}</span>
-      {tags.map((tag, idx) => (
-        <Badge variant='pill' size='sm' className='not-italic' key={idx}>
-          {tag}
-        </Badge>
-      ))}
+    <span className='inline-flex flex-wrap items-center gap-1'>
+      <span>{lead}</span>
+      {tagIds.length > 0
+        ? tagIds.map((id, i) => <EventTagChip key={id} tagId={id} fallbackName={tagNames[i]} />)
+        : tagNames.map((name, i) => (
+            <Badge variant='pill' size='sm' className='not-italic' key={`${name}:${i}`}>
+              {name}
+            </Badge>
+          ))}
     </span>
   )
+}
+
+/**
+ * One tag chip inside an event line: the live-resolved `TagBadge` (color +
+ * emoji, org cache) when the tag record still exists, else a plain pill using
+ * the emit-time snapshot name for a deleted tag.
+ */
+function EventTagChip({ tagId, fallbackName }: { tagId: string; fallbackName?: string }) {
+  const recordId = tagId as RecordId
+  const { isNotFound } = useRecord({ recordId, enabled: !!tagId })
+  if (isNotFound) {
+    return (
+      <Badge variant='pill' size='sm' className='not-italic'>
+        {fallbackName ?? 'Unknown tag'}
+      </Badge>
+    )
+  }
+  return <TagBadge recordId={recordId} size='sm' />
 }

--- a/apps/web/src/components/mail/chat-timeline.test.ts
+++ b/apps/web/src/components/mail/chat-timeline.test.ts
@@ -3,17 +3,48 @@
 // The grouping gate used to be `messageType === 'CHAT'`, which is why every SMS
 // message fell through to `single` and rendered in the email-shaped fallback
 // card while chat got bubbles. These lock in the widened gate.
+//
+// v2 (plans/threads/thread-events.md §15): `buildChatTimeline` now also emits
+// `day-separator` items across the WHOLE timeline and folds events into
+// `event-block`s (retiring `event` / `event-run` + same-actor run keying). Most
+// of the pre-existing message-grouping tests below strip the leading
+// day-separator via `withoutSeparators` so they keep testing chat-group
+// behavior in isolation; day-separator placement/labeling and block
+// segmentation get their own describe blocks.
+//
+// All timestamps go through `localIso` (a LOCAL Date constructor, not a raw
+// UTC ISO literal) so "same calendar day" / "crosses midnight" assertions are
+// correct under whatever timezone the test runner uses — a UTC-literal
+// "23:58Z" → "00:01Z" pair does NOT cross a local midnight in every zone.
 
 import type { ParticipantId } from '@auxx/types'
 import { describe, expect, it } from 'vitest'
 import type { MessageMeta, MessageType } from '~/components/threads/store'
 import type { ChatThreadEvent } from './chat-panel/system-line'
-import { buildChatTimeline } from './chat-timeline'
+import {
+  buildChatTimeline,
+  type ChatTimelineItem,
+  composeEventGroupSummary,
+  formatEventGroupSummary,
+} from './chat-timeline'
+
+/** Local-time constructor → ISO string, so day-boundary math is TZ-independent. */
+function localIso(y: number, m: number, d: number, h = 10, mi = 0): string {
+  return new Date(y, m - 1, d, h, mi, 0, 0).toISOString()
+}
+
+/** Pin "now" to 2026-08-17 (a Monday), local time, for deterministic day labels. */
+const NOW = new Date(2026, 7, 17, 20, 0, 0)
+
+function withoutSeparators(items: ChatTimelineItem[]): ChatTimelineItem[] {
+  return items.filter((i) => i.kind !== 'day-separator')
+}
 
 function message(
   id: string,
   overrides: Partial<MessageMeta> & { messageType: MessageType }
 ): MessageMeta {
+  const defaultSentAt = localIso(2026, 8, 17, 10, 0)
   return {
     id,
     threadId: 't1',
@@ -26,9 +57,9 @@ function message(
     hasAttachments: false,
     hasHtmlBody: false,
     hasTextBody: true,
-    sentAt: '2026-08-17T10:00:00.000Z',
+    sentAt: defaultSentAt,
     receivedAt: null,
-    createdAt: '2026-08-17T10:00:00.000Z',
+    createdAt: defaultSentAt,
     participants: ['from:p1' as ParticipantId],
     createdById: null,
     sendStatus: null,
@@ -39,179 +70,519 @@ function message(
   }
 }
 
-describe('buildChatTimeline', () => {
-  it('bubbles a lone SMS instead of dropping it to the fallback card', () => {
-    const items = buildChatTimeline([message('m1', { messageType: 'SMS' })], [])
-    expect(items).toHaveLength(1)
-    expect(items[0]?.kind).toBe('chat-group')
-  })
-
-  it('clusters consecutive same-sender SMS inside the 5-minute window', () => {
-    const items = buildChatTimeline(
-      [
-        message('m1', { messageType: 'SMS', sentAt: '2026-08-17T10:00:00.000Z' }),
-        message('m2', { messageType: 'SMS', sentAt: '2026-08-17T10:02:00.000Z' }),
-      ],
-      []
-    )
-    expect(items).toHaveLength(1)
-    expect(items[0]).toMatchObject({ kind: 'chat-group', startIndex: 0, endIndex: 1 })
-  })
-
-  it('breaks a cluster when the direction flips', () => {
-    const items = buildChatTimeline(
-      [
-        message('m1', { messageType: 'SMS' }),
-        message('m2', { messageType: 'SMS', isInbound: false }),
-      ],
-      []
-    )
-    expect(items).toHaveLength(2)
-  })
-
-  it('never groups across transports', () => {
-    const items = buildChatTimeline(
-      [message('m1', { messageType: 'SMS' }), message('m2', { messageType: 'CHAT' })],
-      []
-    )
-    expect(items).toHaveLength(2)
-  })
-
-  it('leaves email as a single so EmailDisplay still renders it', () => {
-    const items = buildChatTimeline([message('m1', { messageType: 'EMAIL' })], [])
-    expect(items[0]).toMatchObject({ kind: 'single', index: 0 })
-  })
-
-  it('keeps CHAT and SMS messages on the bubble path', () => {
-    for (const messageType of ['CHAT', 'SMS'] as const) {
-      const items = buildChatTimeline([message('m1', { messageType })], [])
-      expect(items[0]?.kind, messageType).toBe('chat-group')
-    }
-  })
-
-  it('never bubbles CALL or VOICEMAIL', () => {
-    for (const messageType of ['CALL', 'VOICEMAIL'] as const) {
-      const items = buildChatTimeline([message('m1', { messageType })], [])
-      expect(items[0], messageType).toMatchObject({ kind: 'single', index: 0 })
-    }
-  })
-})
-
 function event(id: string, overrides: Partial<ChatThreadEvent> = {}): ChatThreadEvent {
   return {
     id,
     type: 'thread:archived',
-    createdAt: '2026-08-17T10:00:00.000Z',
+    createdAt: localIso(2026, 8, 17, 10, 0),
     actorId: 'user:u1',
     data: {},
     ...overrides,
   }
 }
 
-describe('buildChatTimeline event runs', () => {
-  it('keeps a single event as a flat event item', () => {
-    const items = buildChatTimeline([], [event('e1')])
-    expect(items).toHaveLength(1)
-    expect(items[0]?.kind).toBe('event')
-  })
-
-  it('collapses consecutive same-actor events within the window into one run', () => {
-    const items = buildChatTimeline(
-      [],
-      [
-        event('e1', { createdAt: '2026-08-17T10:00:00.000Z' }),
-        event('e2', { type: 'thread:tagged', createdAt: '2026-08-17T10:01:00.000Z' }),
-        event('e3', { type: 'thread:reopened', createdAt: '2026-08-17T10:02:00.000Z' }),
-      ]
+describe('buildChatTimeline — bubble grouping', () => {
+  it('bubbles a lone SMS instead of dropping it to the fallback card', () => {
+    const items = withoutSeparators(
+      buildChatTimeline([message('m1', { messageType: 'SMS' })], [], { now: NOW })
     )
     expect(items).toHaveLength(1)
-    expect(items[0]).toMatchObject({ kind: 'event-run' })
-    expect(items[0]?.kind === 'event-run' && items[0].events.map((e) => e.id)).toEqual([
+    expect(items[0]?.kind).toBe('chat-group')
+  })
+
+  it('clusters consecutive same-sender SMS inside the 5-minute window', () => {
+    const items = withoutSeparators(
+      buildChatTimeline(
+        [
+          message('m1', { messageType: 'SMS', sentAt: localIso(2026, 8, 17, 10, 0) }),
+          message('m2', { messageType: 'SMS', sentAt: localIso(2026, 8, 17, 10, 2) }),
+        ],
+        [],
+        { now: NOW }
+      )
+    )
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({ kind: 'chat-group', startIndex: 0, endIndex: 1 })
+  })
+
+  it('breaks a cluster when the direction flips', () => {
+    const items = withoutSeparators(
+      buildChatTimeline(
+        [
+          message('m1', { messageType: 'SMS' }),
+          message('m2', { messageType: 'SMS', isInbound: false }),
+        ],
+        [],
+        { now: NOW }
+      )
+    )
+    expect(items).toHaveLength(2)
+  })
+
+  it('never groups across transports', () => {
+    const items = withoutSeparators(
+      buildChatTimeline(
+        [message('m1', { messageType: 'SMS' }), message('m2', { messageType: 'CHAT' })],
+        [],
+        { now: NOW }
+      )
+    )
+    expect(items).toHaveLength(2)
+  })
+
+  it('leaves email as a single so EmailDisplay still renders it', () => {
+    const items = withoutSeparators(
+      buildChatTimeline([message('m1', { messageType: 'EMAIL' })], [], { now: NOW })
+    )
+    expect(items[0]).toMatchObject({ kind: 'single', index: 0 })
+  })
+
+  it('keeps CHAT and SMS messages on the bubble path', () => {
+    for (const messageType of ['CHAT', 'SMS'] as const) {
+      const items = withoutSeparators(
+        buildChatTimeline([message('m1', { messageType })], [], { now: NOW })
+      )
+      expect(items[0]?.kind, messageType).toBe('chat-group')
+    }
+  })
+
+  it('never bubbles CALL or VOICEMAIL', () => {
+    for (const messageType of ['CALL', 'VOICEMAIL'] as const) {
+      const items = withoutSeparators(
+        buildChatTimeline([message('m1', { messageType })], [], { now: NOW })
+      )
+      expect(items[0], messageType).toMatchObject({ kind: 'single', index: 0 })
+    }
+  })
+
+  it('splits a chat-group across a day boundary', () => {
+    const items = withoutSeparators(
+      buildChatTimeline(
+        [
+          message('m1', { messageType: 'CHAT', sentAt: localIso(2026, 8, 16, 23, 58) }),
+          message('m2', { messageType: 'CHAT', sentAt: localIso(2026, 8, 17, 0, 1) }),
+        ],
+        [],
+        { now: NOW }
+      )
+    )
+    // Same sender, 3 minutes apart (within CHAT_GROUP_WINDOW_MS) — but the day
+    // flips, so this must NOT collapse into one chat-group.
+    expect(items.map((i) => i.kind)).toEqual(['chat-group', 'chat-group'])
+  })
+})
+
+describe('buildChatTimeline — day separators (§15.6)', () => {
+  it('emits a leading separator even for a single-day timeline', () => {
+    const items = buildChatTimeline([message('m1', { messageType: 'CHAT' })], [], { now: NOW })
+    expect(items[0]).toMatchObject({ kind: 'day-separator' })
+    expect(items).toHaveLength(2)
+  })
+
+  it('labels the current day "Today"', () => {
+    const items = buildChatTimeline(
+      [message('m1', { messageType: 'CHAT', sentAt: localIso(2026, 8, 17, 10, 0) })],
+      [],
+      { now: NOW }
+    )
+    expect(items[0]).toMatchObject({ kind: 'day-separator', label: 'Today' })
+  })
+
+  it('labels the prior day "Yesterday"', () => {
+    const items = buildChatTimeline(
+      [message('m1', { messageType: 'CHAT', sentAt: localIso(2026, 8, 16, 10, 0) })],
+      [],
+      { now: NOW }
+    )
+    expect(items[0]).toMatchObject({ kind: 'day-separator', label: 'Yesterday' })
+  })
+
+  it('labels 2–6 days ago with the weekday name', () => {
+    // 2026-08-17 is a Monday; 3 days back is 2026-08-14, a Friday.
+    const items = buildChatTimeline(
+      [message('m1', { messageType: 'CHAT', sentAt: localIso(2026, 8, 14, 10, 0) })],
+      [],
+      { now: NOW }
+    )
+    expect(items[0]).toMatchObject({ kind: 'day-separator', label: 'Friday' })
+  })
+
+  it('labels 7+ days ago with the short date, no year when current', () => {
+    const items = buildChatTimeline(
+      [message('m1', { messageType: 'CHAT', sentAt: localIso(2026, 8, 1, 10, 0) })],
+      [],
+      { now: NOW }
+    )
+    expect(items[0]).toMatchObject({ kind: 'day-separator', label: 'Aug 1' })
+  })
+
+  it('appends the year when it differs from the current year', () => {
+    const items = buildChatTimeline(
+      [message('m1', { messageType: 'CHAT', sentAt: localIso(2025, 8, 1, 10, 0) })],
+      [],
+      { now: NOW }
+    )
+    expect(items[0]).toMatchObject({ kind: 'day-separator', label: 'Aug 1, 2025' })
+  })
+
+  it('splices one separator between two messages on different days, none for a same-day run', () => {
+    const items = buildChatTimeline(
+      [
+        message('m1', { messageType: 'CHAT', sentAt: localIso(2026, 8, 16, 10, 0) }),
+        message('m2', {
+          messageType: 'CHAT',
+          sentAt: localIso(2026, 8, 16, 10, 5),
+          isInbound: false,
+        }),
+        message('m3', { messageType: 'CHAT', sentAt: localIso(2026, 8, 17, 9, 0) }),
+      ],
+      [],
+      { now: NOW }
+    )
+    expect(items.map((i) => i.kind)).toEqual([
+      'day-separator',
+      'chat-group',
+      'chat-group',
+      'day-separator',
+      'chat-group',
+    ])
+    expect(items[0]).toMatchObject({ label: 'Yesterday' })
+    expect(items[3]).toMatchObject({ label: 'Today' })
+  })
+
+  it('shares one day spine across messages and events', () => {
+    const items = buildChatTimeline(
+      [message('m1', { messageType: 'CHAT', sentAt: localIso(2026, 8, 17, 9, 0) })],
+      [event('e1', { createdAt: localIso(2026, 8, 16, 10, 0) })],
+      { now: NOW }
+    )
+    expect(items.map((i) => i.kind)).toEqual([
+      'day-separator',
+      'event-block',
+      'day-separator',
+      'chat-group',
+    ])
+  })
+})
+
+describe('buildChatTimeline — event blocks (§15.2/§15.4)', () => {
+  it('folds a lone event into a single-entry block', () => {
+    const items = withoutSeparators(buildChatTimeline([], [event('e1')], { now: NOW }))
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({ kind: 'event-block' })
+    const block = items[0]!
+    if (block.kind !== 'event-block') throw new Error('expected event-block')
+    expect(block.entries).toEqual([
+      { kind: 'single', event: expect.objectContaining({ id: 'e1' }) },
+    ])
+  })
+
+  it('keeps 1–2 contiguous events as singles inside the block', () => {
+    const items = withoutSeparators(
+      buildChatTimeline(
+        [],
+        [
+          event('e1', { createdAt: localIso(2026, 8, 17, 10, 0) }),
+          event('e2', { type: 'thread:tagged', createdAt: localIso(2026, 8, 17, 10, 1) }),
+        ],
+        { now: NOW }
+      )
+    )
+    expect(items).toHaveLength(1)
+    const block = items[0]!
+    if (block.kind !== 'event-block') throw new Error('expected event-block')
+    expect(block.entries).toHaveLength(2)
+    expect(block.entries.every((e) => e.kind === 'single')).toBe(true)
+  })
+
+  it('collapses ≥3 contiguous same-day events into one group, mixed actors welcome', () => {
+    const items = withoutSeparators(
+      buildChatTimeline(
+        [],
+        [
+          event('e1', { actorId: 'user:u1', createdAt: localIso(2026, 8, 17, 10, 0) }),
+          event('e2', {
+            type: 'thread:tagged',
+            actorId: 'user:u2',
+            createdAt: localIso(2026, 8, 17, 10, 1),
+          }),
+          event('e3', {
+            type: 'thread:reopened',
+            actorId: null,
+            createdAt: localIso(2026, 8, 17, 10, 2),
+          }),
+        ],
+        { now: NOW }
+      )
+    )
+    expect(items).toHaveLength(1)
+    const block = items[0]!
+    if (block.kind !== 'event-block') throw new Error('expected event-block')
+    expect(block.entries).toHaveLength(1)
+    expect(block.entries[0]!.kind).toBe('group')
+    expect(block.entries[0]!.kind === 'group' && block.entries[0].events.map((e) => e.id)).toEqual([
       'e1',
       'e2',
       'e3',
     ])
   })
 
-  it('splits a run when the actor identity changes', () => {
-    const items = buildChatTimeline(
-      [],
-      [
-        event('e1', { createdAt: '2026-08-17T10:00:00.000Z' }),
-        event('e2', { actorId: 'user:u2', createdAt: '2026-08-17T10:01:00.000Z' }),
-      ]
+  it('never groups just 2 events, however close together', () => {
+    const items = withoutSeparators(
+      buildChatTimeline(
+        [],
+        [
+          event('e1', { createdAt: localIso(2026, 8, 17, 10, 0) }),
+          event('e2', { createdAt: localIso(2026, 8, 17, 10, 1) }),
+        ],
+        { now: NOW }
+      )
     )
-    expect(items).toHaveLength(2)
-    expect(items.map((i) => i.kind)).toEqual(['event', 'event'])
+    const block = items[0]!
+    if (block.kind !== 'event-block') throw new Error('expected event-block')
+    expect(block.entries.every((e) => e.kind === 'single')).toBe(true)
   })
 
-  it('collapses null-actor events sharing the same source kind + id', () => {
-    const source = { kind: 'workflow', id: 'wf1' }
-    const items = buildChatTimeline(
-      [],
-      [
-        event('e1', { actorId: null, data: { source }, createdAt: '2026-08-17T10:00:00.000Z' }),
-        event('e2', { actorId: null, data: { source }, createdAt: '2026-08-17T10:01:00.000Z' }),
-      ]
+  it('breaks a block when a message lands between events', () => {
+    const items = withoutSeparators(
+      buildChatTimeline(
+        [message('m1', { messageType: 'CHAT', sentAt: localIso(2026, 8, 17, 10, 1) })],
+        [
+          event('e1', { createdAt: localIso(2026, 8, 17, 10, 0) }),
+          event('e2', { createdAt: localIso(2026, 8, 17, 10, 2) }),
+        ],
+        { now: NOW }
+      )
     )
-    expect(items).toHaveLength(1)
-    expect(items[0]?.kind).toBe('event-run')
+    expect(items.map((i) => i.kind)).toEqual(['event-block', 'chat-group', 'event-block'])
   })
 
-  it('splits null-actor events with different source ids', () => {
-    const items = buildChatTimeline(
-      [],
-      [
-        event('e1', {
-          actorId: null,
-          data: { source: { kind: 'workflow', id: 'wf1' } },
-          createdAt: '2026-08-17T10:00:00.000Z',
-        }),
-        event('e2', {
-          actorId: null,
-          data: { source: { kind: 'workflow', id: 'wf2' } },
-          createdAt: '2026-08-17T10:01:00.000Z',
-        }),
-      ]
+  it('splits a block at a day boundary even with no message between', () => {
+    const items = withoutSeparators(
+      buildChatTimeline(
+        [],
+        [
+          event('e1', { createdAt: localIso(2026, 8, 16, 23, 58) }),
+          event('e2', { createdAt: localIso(2026, 8, 16, 23, 59) }),
+          event('e3', { createdAt: localIso(2026, 8, 17, 0, 1) }),
+        ],
+        { now: NOW }
+      )
     )
-    expect(items).toHaveLength(2)
+    expect(items.map((i) => i.kind)).toEqual(['event-block', 'event-block'])
+    const [first, second] = items as Extract<ChatTimelineItem, { kind: 'event-block' }>[]
+    expect(first!.entries.every((e) => e.kind === 'single')).toBe(true)
+    expect(first!.entries).toHaveLength(2)
+    expect(second!.entries).toHaveLength(1)
   })
 
-  it('splits when an event falls outside the 5-minute window from the run start', () => {
+  it('marks a block trailing when it falls entirely after the last message', () => {
     const items = buildChatTimeline(
-      [],
-      [
-        event('e1', { createdAt: '2026-08-17T10:00:00.000Z' }),
-        event('e2', { createdAt: '2026-08-17T10:04:00.000Z' }),
-        // 6 min after e1 (the run START), though only 2 min after e2.
-        event('e3', { createdAt: '2026-08-17T10:06:00.000Z' }),
-      ]
+      [message('m1', { messageType: 'CHAT', sentAt: localIso(2026, 8, 17, 9, 0) })],
+      [event('e1', { createdAt: localIso(2026, 8, 17, 10, 0) })],
+      { now: NOW }
     )
-    expect(items).toHaveLength(2)
-    expect(items[0]).toMatchObject({ kind: 'event-run' })
-    expect(items[1]?.kind).toBe('event')
+    const block = items.find((i) => i.kind === 'event-block')
+    expect(block).toMatchObject({ isTrailing: true })
   })
 
-  it('breaks a run when a message lands between the events', () => {
+  it('marks a block NOT trailing when a message follows it', () => {
     const items = buildChatTimeline(
-      [message('m1', { messageType: 'CHAT', sentAt: '2026-08-17T10:01:00.000Z' })],
-      [
-        event('e1', { createdAt: '2026-08-17T10:00:00.000Z' }),
-        event('e2', { createdAt: '2026-08-17T10:02:00.000Z' }),
-      ]
+      [message('m1', { messageType: 'CHAT', sentAt: localIso(2026, 8, 17, 11, 0) })],
+      [event('e1', { createdAt: localIso(2026, 8, 17, 10, 0) })],
+      { now: NOW }
     )
-    expect(items.map((i) => i.kind)).toEqual(['event', 'chat-group', 'event'])
+    const block = items.find((i) => i.kind === 'event-block')
+    expect(block).toMatchObject({ isTrailing: false })
   })
 
-  it('preserves ASC ordering across messages, events and runs', () => {
-    const items = buildChatTimeline(
-      [message('m1', { messageType: 'CHAT', sentAt: '2026-08-17T10:05:00.000Z' })],
-      [
-        event('e1', { createdAt: '2026-08-17T10:00:00.000Z' }),
-        event('e2', { createdAt: '2026-08-17T10:01:00.000Z' }),
-        event('e3', { createdAt: '2026-08-17T10:10:00.000Z' }),
-      ]
+  it('preserves ASC ordering across messages, events and blocks', () => {
+    const items = withoutSeparators(
+      buildChatTimeline(
+        [message('m1', { messageType: 'CHAT', sentAt: localIso(2026, 8, 17, 10, 5) })],
+        [
+          event('e1', { createdAt: localIso(2026, 8, 17, 10, 0) }),
+          event('e2', { createdAt: localIso(2026, 8, 17, 10, 1) }),
+          event('e3', { createdAt: localIso(2026, 8, 17, 10, 10) }),
+        ],
+        { now: NOW }
+      )
     )
-    expect(items.map((i) => i.kind)).toEqual(['event-run', 'chat-group', 'event'])
+    expect(items.map((i) => i.kind)).toEqual(['event-block', 'chat-group', 'event-block'])
+  })
+})
+
+describe('composeEventGroupSummary (§15.5)', () => {
+  const label = (actorKey: string) => {
+    if (actorKey === 'actor:user:u1') return 'Markus'
+    if (actorKey === 'actor:user:u2') return 'Lena'
+    if (actorKey.startsWith('source:')) return 'Auto-close'
+    return 'Someone'
+  }
+
+  it('folds repeated tag events by the same actor into one union fragment', () => {
+    const events = [
+      event('e1', {
+        type: 'thread:tagged',
+        actorId: 'user:u1',
+        data: { tagIds: ['tag:a'], tagNames: ['VIP'] },
+      }),
+      event('e2', {
+        type: 'thread:tagged',
+        actorId: 'user:u1',
+        data: { tagIds: ['tag:b'], tagNames: ['Urgent'] },
+      }),
+      event('e3', { type: 'thread:reopened', actorId: 'user:u1' }),
+    ]
+    const summary = composeEventGroupSummary(events, label)
+    expect(summary.count).toBe(3)
+    expect(summary.fragments).toHaveLength(1)
+    expect(summary.fragments[0]).toContain('Markus')
+    expect(summary.fragments[0]).toContain('VIP')
+    expect(summary.fragments[0]).toContain('Urgent')
+    expect(summary.fragments[0]).toContain('reopened the conversation')
+  })
+
+  it('folds repeated assignee changes to only the final assignee', () => {
+    const events = [
+      event('e1', {
+        type: 'thread:assignee:changed',
+        actorId: 'user:u1',
+        data: { assigneeActorId: 'user:u2' },
+      }),
+      event('e2', {
+        type: 'thread:assignee:changed',
+        actorId: 'user:u1',
+        data: { assigneeActorId: 'user:u1' },
+      }),
+      event('e3', {
+        type: 'thread:assignee:changed',
+        actorId: 'user:u1',
+        data: { assigneeActorId: 'user:u2' },
+      }),
+    ]
+    const summary = composeEventGroupSummary(events, label)
+    expect(summary.fragments).toHaveLength(1)
+    expect(summary.fragments[0]).toBe('Markus assigned to Lena')
+  })
+
+  it('cancels archived→reopened→archived by the same actor to the final state', () => {
+    const events = [
+      event('e1', { type: 'thread:archived', actorId: 'user:u1' }),
+      event('e2', { type: 'thread:reopened', actorId: 'user:u1' }),
+      event('e3', { type: 'thread:archived', actorId: 'user:u1' }),
+    ]
+    const summary = composeEventGroupSummary(events, label)
+    expect(summary.fragments).toEqual(['Markus marked as done'])
+  })
+
+  it('cancels tagged then untagged of the same tag to nothing', () => {
+    const events = [
+      event('e1', {
+        type: 'thread:tagged',
+        actorId: 'user:u1',
+        data: { tagIds: ['tag:a'], tagNames: ['VIP'] },
+      }),
+      event('e2', {
+        type: 'thread:untagged',
+        actorId: 'user:u1',
+        data: { tagIds: ['tag:a'], tagNames: ['VIP'] },
+      }),
+      event('e3', { type: 'thread:visitor:identified', actorId: null }),
+    ]
+    const summary = composeEventGroupSummary(events, label)
+    expect(summary.fragments).toEqual([])
+    expect(summary.count).toBe(3)
+  })
+
+  it('does not cancel archived/reopened across DIFFERENT actors', () => {
+    // Auto-close archives, then a human reopens — these are two independent
+    // actor bundles, not a toggle pair, so both survive as fragments.
+    const events = [
+      event('e1', {
+        type: 'thread:archived',
+        actorId: null,
+        data: { source: { kind: 'workflow', id: 'wf1', name: 'Auto-close' } },
+      }),
+      event('e2', { type: 'thread:reopened', actorId: 'user:u1' }),
+      event('e3', {
+        type: 'thread:tagged',
+        actorId: 'user:u1',
+        data: { tagIds: ['tag:a'], tagNames: ['VIP'] },
+      }),
+    ]
+    const summary = composeEventGroupSummary(events, label)
+    expect(summary.fragments).toHaveLength(2)
+    expect(summary.fragments[0]).toContain('Auto-close')
+    expect(summary.fragments[0]).toContain('marked as done')
+    expect(summary.fragments[1]).toContain('Markus')
+    expect(summary.fragments[1]).toContain('reopened the conversation')
+    expect(summary.fragments[1]).toContain('tagged with VIP')
+  })
+
+  it('ranks merged above taken_over/returned_to_ai above archived/reopened above assignee above tags', () => {
+    const events = [
+      event('e1', {
+        type: 'thread:tagged',
+        actorId: 'user:u1',
+        data: { tagIds: ['tag:a'], tagNames: ['VIP'] },
+      }),
+      event('e2', { type: 'thread:archived', actorId: 'user:u2' }),
+      event('e3', { type: 'thread:merged', actorId: null, data: { source: { kind: 'system' } } }),
+      event('e4', { type: 'thread:taken_over', actorId: 'user:u1' }),
+    ]
+    const summary = composeEventGroupSummary(events, label)
+    // Only the top 2 ranked bundles survive: the merge (tier 0) and u1's
+    // bundle (tier 1, since taken_over outranks u1's own tier-4 tag action) —
+    // u2's lone archive (tier 2) is dropped.
+    expect(summary.fragments).toHaveLength(2)
+    expect(summary.fragments[0]).toContain('merged a conversation into this one')
+    expect(summary.fragments[1]).toContain('Markus')
+    expect(summary.fragments[1]).toContain('took over the conversation')
+  })
+
+  it('non-composable visitor:identified events count toward N without a fragment', () => {
+    const events = [
+      event('e1', { type: 'thread:visitor:identified', actorId: null }),
+      event('e2', { type: 'thread:visitor:identified', actorId: null }),
+      event('e3', { type: 'thread:visitor:identified', actorId: null }),
+    ]
+    const summary = composeEventGroupSummary(events, label)
+    expect(summary.fragments).toEqual([])
+    expect(summary.count).toBe(3)
+  })
+
+  it('always shows the count even when fragments survive', () => {
+    const events = [
+      event('e1', { type: 'thread:archived', actorId: 'user:u1' }),
+      event('e2', { type: 'thread:visitor:identified', actorId: null }),
+      event('e3', { type: 'thread:visitor:identified', actorId: null }),
+    ]
+    const summary = composeEventGroupSummary(events, label)
+    expect(summary.count).toBe(3)
+    expect(formatEventGroupSummary(summary)).toBe('Markus marked as done · 3 updates')
+  })
+})
+
+describe('formatEventGroupSummary', () => {
+  it('renders count-only when nothing survives cancellation', () => {
+    expect(formatEventGroupSummary({ fragments: [], count: 4 })).toBe('4 updates')
+  })
+
+  it('singularizes a count of 1', () => {
+    expect(formatEventGroupSummary({ fragments: [], count: 1 })).toBe('1 update')
+  })
+
+  it('joins two fragments with Intl.ListFormat, not a hand-rolled separator', () => {
+    const text = formatEventGroupSummary({
+      fragments: ['Auto-close archived', 'Markus reopened'],
+      count: 6,
+    })
+    expect(text).toBe(
+      `${new Intl.ListFormat('en', { style: 'long', type: 'conjunction' }).format([
+        'Auto-close archived',
+        'Markus reopened',
+      ])} · 6 updates`
+    )
   })
 })

--- a/apps/web/src/components/mail/chat-timeline.ts
+++ b/apps/web/src/components/mail/chat-timeline.ts
@@ -2,49 +2,66 @@
 //
 // Interleave admin-side conversational messages with thread lifecycle events
 // (taken_over, returned_to_ai, archived, reopened, assignee:changed,
-// visitor:identified) into a single sorted render list. Consecutive
-// same-sender bubble messages within a 5-minute window collapse into a
-// `chat-group`; any event between them breaks the cluster.
+// visitor:identified, tagged, untagged, merged) into a single sorted render
+// list, plus viewer-local day separators across the whole conversation
+// (plans/threads/thread-events.md §15, "Timeline UI v2").
 //
 // "Bubble message" is `isBubbleMessage` — CHAT *and* SMS/WhatsApp/DM. Gating on
 // `messageType === 'CHAT'` is what kept SMS out of the bubble renderer and in
 // the email-shaped fallback card.
 //
-// Mirrors the widget's `buildTimeline` in
-// `apps/chat-widget/src/views/conversation/conversation-view.tsx`, but
-// operates on the admin `MessageMeta` shape and emits the same
-// `chat-group` / `single` item kinds the existing `thread-messages` and
-// `chat-panel/messages` renderers already understand.
+// v2 retires the `event` / `event-run` item kinds and same-actor run keying
+// (§13.5/Phase 6, superseded). Every contiguous stretch of events between two
+// messages — bounded also by a day boundary — becomes one `event-block`; day
+// separators (`day-separator`) are emitted across messages AND events so both
+// share one day spine, and chat-group coalescing never spans one either.
 
+import type { ThreadEventType } from '@auxx/lib/thread-events/client'
 import type { MessageMeta } from '~/components/threads/store'
 import type { ChatThreadEvent } from './chat-panel/system-line'
 import { isBubbleMessage } from './utils/message-bubble'
 
 const CHAT_GROUP_WINDOW_MS = 5 * 60_000
 
-/**
- * Window for collapsing consecutive same-actor events into an `event-run`
- * (plans/threads/thread-events.md §13.5, Phase 6) — measured from the run's
- * FIRST event, so a slow drip of changes doesn't chain into one endless run.
- */
-export const EVENT_RUN_WINDOW_MS = 5 * 60_000
+/** A single event row, or ≥3 contiguous same-day events collapsed into one group-row. */
+export type EventBlockEntry =
+  | { kind: 'single'; event: ChatThreadEvent }
+  | { kind: 'group'; events: ChatThreadEvent[] /* always ≥3 */ }
 
 export type ChatTimelineItem =
   | { kind: 'single'; message: MessageMeta; index: number }
   | { kind: 'chat-group'; messages: MessageMeta[]; startIndex: number; endIndex: number }
-  | { kind: 'event'; event: ChatThreadEvent }
-  | { kind: 'event-run'; events: ChatThreadEvent[] /* always ≥2 */ }
+  | { kind: 'day-separator'; key: string; label: string }
+  | {
+      kind: 'event-block'
+      key: string
+      entries: EventBlockEntry[]
+      /**
+       * True when every event in this block falls after the thread's last
+       * message — the thread's current tail state. Trailing blocks render
+       * expanded initially (§15.4.3); earlier blocks start collapsed.
+       */
+      isTrailing: boolean
+    }
 
 /**
  * Interleave messages and thread events by timestamp, collapsing consecutive
- * same-sender bubble messages into groups. `index` / `startIndex` / `endIndex`
- * point back into the original `messages` array so existing per-message UI
- * (latest-message check, animation delay) keeps working.
+ * same-sender bubble messages into `chat-group`s and consecutive events (no
+ * message between them) into `event-block`s, with viewer-local day separators
+ * spliced across the whole list. `index` / `startIndex` / `endIndex` point back
+ * into the original `messages` array so existing per-message UI (latest-message
+ * check, animation delay) keeps working.
+ *
+ * @param now Reference instant for "Today" / "Yesterday" labeling — defaults to
+ * the real clock; tests pin it for deterministic labels.
  */
 export function buildChatTimeline(
   messages: MessageMeta[],
-  events: ChatThreadEvent[]
+  events: ChatThreadEvent[],
+  options?: { now?: Date }
 ): ChatTimelineItem[] {
+  const now = options?.now ?? new Date()
+
   type Entry =
     | { kind: 'message'; createdAt: number; message: MessageMeta; index: number }
     | { kind: 'event'; createdAt: number; event: ChatThreadEvent }
@@ -66,28 +83,43 @@ export function buildChatTimeline(
   // stay adjacent (Array.prototype.sort is stable since ES2019).
   entries.sort((a, b) => a.createdAt - b.createdAt)
 
+  const lastMessageTs =
+    messages.length > 0
+      ? Math.max(...messages.map((m) => messageTimestamp(m)))
+      : Number.NEGATIVE_INFINITY
+
   const out: ChatTimelineItem[] = []
+  let lastDayKey: string | null = null
+
   for (let i = 0; i < entries.length; i++) {
     const entry = entries[i]!
+    const dayKey = localDayKey(new Date(entry.createdAt))
+    if (dayKey !== lastDayKey) {
+      out.push({ kind: 'day-separator', key: `day:${dayKey}`, label: dayLabel(dayKey, now) })
+      lastDayKey = dayKey
+    }
+
     if (entry.kind === 'event') {
-      // Collapse consecutive events (no message between them) by the same
-      // actor identity, within EVENT_RUN_WINDOW_MS of the run's start, into
-      // one `event-run`. A lone event stays a flat `event` line.
-      const run: ChatThreadEvent[] = [entry.event]
-      const runStart = entry.createdAt
-      const runKey = eventActorKey(entry.event)
+      // Gather the contiguous stretch of events (no message between them,
+      // same calendar day) into one block.
+      const block: ChatThreadEvent[] = [entry.event]
+      const blockStartCreatedAt = entry.createdAt
       while (i + 1 < entries.length) {
         const next = entries[i + 1]!
         if (next.kind !== 'event') break
-        if (eventActorKey(next.event) !== runKey) break
-        if (next.createdAt - runStart > EVENT_RUN_WINDOW_MS) break
-        run.push(next.event)
+        if (localDayKey(new Date(next.createdAt)) !== dayKey) break
+        block.push(next.event)
         i++
       }
-      if (run.length === 1) out.push({ kind: 'event', event: entry.event })
-      else out.push({ kind: 'event-run', events: run })
+      out.push({
+        kind: 'event-block',
+        key: `evtblock:${block[0]!.id}`,
+        entries: groupBlockEvents(block),
+        isTrailing: blockStartCreatedAt > lastMessageTs,
+      })
       continue
     }
+
     if (!isBubbleMessage(entry.message.messageType)) {
       out.push({ kind: 'single', message: entry.message, index: entry.index })
       continue
@@ -98,6 +130,7 @@ export function buildChatTimeline(
     while (i + 1 < entries.length) {
       const next = entries[i + 1]!
       if (next.kind !== 'message') break
+      if (localDayKey(new Date(next.createdAt)) !== dayKey) break
       if (!canGroupBubble(run[run.length - 1]!, next.message)) break
       run.push(next.message)
       endIndex = next.index
@@ -109,10 +142,22 @@ export function buildChatTimeline(
 }
 
 /**
- * Actor-identity key for run collapsing: the branded `actorId` when present
- * (falling back to the legacy `data.userId` payload on pre-cut-over rows),
- * else the automation provenance (`source.kind` + `source.id`), else a shared
- * 'system' bucket. Two events collapse only when their keys match.
+ * Partition one contiguous, same-day event stretch (an event block) into its
+ * render entries. Collapse only at ≥3 (§15.4.2) — below that, singles read
+ * identically to expanded group members, so grouping saves nothing.
+ */
+function groupBlockEvents(events: ChatThreadEvent[]): EventBlockEntry[] {
+  if (events.length >= 3) return [{ kind: 'group', events }]
+  return events.map((event) => ({ kind: 'single', event }))
+}
+
+/**
+ * Actor-identity key for an event: the branded `actorId` when present (falling
+ * back to the legacy `data.userId` payload on pre-cut-over rows), else the
+ * automation provenance (`source.kind` + `source.id`), else a shared 'system'
+ * bucket. Used by {@link composeEventGroupSummary} to fold/cancel per actor —
+ * no longer used to decide which rows visually group (that's day + contiguity
+ * now, mixed actors welcome).
  */
 export function eventActorKey(event: ChatThreadEvent): string {
   if (typeof event.actorId === 'string' && event.actorId) return `actor:${event.actorId}`
@@ -153,4 +198,247 @@ function canGroupBubble(a: MessageMeta, b: MessageMeta): boolean {
 
 function fromParticipant(m: MessageMeta): string | null {
   return m.participants.find((p) => p.startsWith('from:')) ?? null
+}
+
+// ============================================================================
+// Day separators (§15.6)
+// ============================================================================
+
+/** Viewer-local calendar-day identity — stable across DST, independent of locale. */
+function localDayKey(date: Date): string {
+  return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`
+}
+
+const WEEKDAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+const MONTH_NAMES = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+]
+
+/**
+ * "Today" / "Yesterday" / weekday name (within the last 7 days) / "Aug 12"
+ * (+ ", 2025" when the year isn't the current one). Hardcoded weekday/month
+ * names, not `toLocaleDateString`, so the label is deterministic in tests
+ * regardless of the runner's locale.
+ */
+function dayLabel(dayKey: string, now: Date): string {
+  const [y, m, d] = dayKey.split('-').map(Number) as [number, number, number]
+  const date = new Date(y, m, d)
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const diffDays = Math.round((today.getTime() - date.getTime()) / 86_400_000)
+
+  if (diffDays === 0) return 'Today'
+  if (diffDays === 1) return 'Yesterday'
+  if (diffDays > 1 && diffDays < 7) return WEEKDAY_NAMES[date.getDay()]!
+
+  const monthDay = `${MONTH_NAMES[date.getMonth()]} ${date.getDate()}`
+  return date.getFullYear() === now.getFullYear() ? monthDay : `${monthDay}, ${date.getFullYear()}`
+}
+
+// ============================================================================
+// Group summary composer (§15.5) — pure, unit-testable net-effect composer for
+// a collapsed group-row. Folds repeats per actor per type, cancels opposites,
+// ranks survivors, and always surfaces the total count.
+// ============================================================================
+
+export interface EventGroupSummary {
+  /** Up to 2 actor-attributed net-effect fragments, ranked highest first. */
+  fragments: string[]
+  /** Total raw event count folded into this group — always shown (§15.5 rule 3). */
+  count: number
+}
+
+/** merged > taken_over/returned_to_ai > archived/reopened > assignee > tagged/untagged. */
+const TYPE_TIER: Partial<Record<ThreadEventType, number>> = {
+  'thread:merged': 0,
+  'thread:taken_over': 1,
+  'thread:returned_to_ai': 1,
+  'thread:archived': 2,
+  'thread:reopened': 2,
+  'thread:assignee:changed': 3,
+  'thread:tagged': 4,
+  'thread:untagged': 4,
+}
+
+/**
+ * Resolve a display label for an actor-identity key (as produced by
+ * {@link eventActorKey}, or the `actor:<ActorId>` form for a referenced
+ * assignee target). `sample` is only consulted for automation provenance
+ * (`source:*` keys) — the label there is the emit-time snapshot, never a live
+ * refined name; that refinement is a per-row concern (`useEventActor`), not
+ * the group summary's.
+ */
+export type GroupActorLabelResolver = (actorKey: string, sample: ChatThreadEvent) => string
+
+function joinList(items: string[]): string {
+  if (items.length === 0) return ''
+  if (items.length === 1) return items[0]!
+  return new Intl.ListFormat('en', { style: 'long', type: 'conjunction' }).format(items)
+}
+
+/**
+ * Compose the net-effect summary for one collapsed group (§15.5). Folds
+ * repeats per actor per type (tag union; assignee → final), cancels opposites
+ * (archived↔reopened; tagged x then untagged x) per actor, ranks surviving
+ * actor-bundles, and returns the top 2 fragments plus the always-shown count.
+ * Non-composable types (`thread:visitor:identified`) contribute to `count`
+ * only — they never produce a fragment, and only appear once the group
+ * expands.
+ */
+export function composeEventGroupSummary(
+  events: ChatThreadEvent[],
+  actorLabel: GroupActorLabelResolver
+): EventGroupSummary {
+  const order: string[] = []
+  const buckets = new Map<string, ChatThreadEvent[]>()
+  for (const event of events) {
+    const key = eventActorKey(event)
+    let bucket = buckets.get(key)
+    if (!bucket) {
+      bucket = []
+      buckets.set(key, bucket)
+      order.push(key)
+    }
+    bucket.push(event)
+  }
+
+  interface Bundle {
+    tier: number
+    text: string
+    firstIndex: number
+  }
+  const bundles: Bundle[] = []
+
+  for (const key of order) {
+    const bucketEvents = buckets.get(key)!
+    const verbs: { text: string; tier: number }[] = []
+
+    const takeoverEvents = bucketEvents.filter(
+      (e) => e.type === 'thread:taken_over' || e.type === 'thread:returned_to_ai'
+    )
+    if (takeoverEvents.length > 0) {
+      const last = takeoverEvents[takeoverEvents.length - 1]!
+      verbs.push({
+        text:
+          last.type === 'thread:taken_over'
+            ? 'took over the conversation'
+            : 'returned the conversation to AI',
+        tier: TYPE_TIER['thread:taken_over']!,
+      })
+    }
+
+    const archiveEvents = bucketEvents.filter(
+      (e) => e.type === 'thread:archived' || e.type === 'thread:reopened'
+    )
+    if (archiveEvents.length > 0) {
+      const last = archiveEvents[archiveEvents.length - 1]!
+      verbs.push({
+        text: last.type === 'thread:archived' ? 'marked as done' : 'reopened the conversation',
+        tier: TYPE_TIER['thread:archived']!,
+      })
+    }
+
+    const mergedEvents = bucketEvents.filter((e) => e.type === 'thread:merged')
+    if (mergedEvents.length > 0) {
+      verbs.push({
+        text:
+          mergedEvents.length > 1
+            ? 'merged conversations into this one'
+            : 'merged a conversation into this one',
+        tier: TYPE_TIER['thread:merged']!,
+      })
+    }
+
+    const assigneeEvents = bucketEvents.filter((e) => e.type === 'thread:assignee:changed')
+    if (assigneeEvents.length > 0) {
+      const last = assigneeEvents[assigneeEvents.length - 1]!
+      const branded = last.data?.assigneeActorId
+      const legacy = last.data?.toUserId
+      const targetKey =
+        typeof branded === 'string' && branded
+          ? `actor:${branded}`
+          : typeof legacy === 'string' && legacy
+            ? `actor:user:${legacy}`
+            : null
+      verbs.push({
+        text: targetKey
+          ? `assigned to ${actorLabel(targetKey, last)}`
+          : 'unassigned the conversation',
+        tier: TYPE_TIER['thread:assignee:changed']!,
+      })
+    }
+
+    const tagEvents = bucketEvents.filter(
+      (e) => e.type === 'thread:tagged' || e.type === 'thread:untagged'
+    )
+    if (tagEvents.length > 0) {
+      const added = new Map<string, string>()
+      const removed = new Map<string, string>()
+      for (const e of tagEvents) {
+        const ids = Array.isArray(e.data?.tagIds) ? (e.data.tagIds as unknown[]) : []
+        const names = Array.isArray(e.data?.tagNames) ? (e.data.tagNames as unknown[]) : []
+        ids.forEach((rawId, i) => {
+          if (typeof rawId !== 'string' || !rawId) return
+          const name = typeof names[i] === 'string' ? (names[i] as string) : rawId
+          if (e.type === 'thread:tagged') {
+            if (removed.has(rawId)) removed.delete(rawId)
+            else added.set(rawId, name)
+          } else {
+            if (added.has(rawId)) added.delete(rawId)
+            else removed.set(rawId, name)
+          }
+        })
+      }
+      if (added.size > 0) {
+        verbs.push({
+          text: `tagged with ${joinList([...added.values()])}`,
+          tier: TYPE_TIER['thread:tagged']!,
+        })
+      }
+      if (removed.size > 0) {
+        verbs.push({
+          text: `removed ${joinList([...removed.values()])}`,
+          tier: TYPE_TIER['thread:untagged']!,
+        })
+      }
+    }
+
+    if (verbs.length === 0) continue // fully cancelled, or only non-composable events
+
+    const tier = Math.min(...verbs.map((v) => v.tier))
+    const label = actorLabel(key, bucketEvents[0]!)
+    bundles.push({
+      tier,
+      text: `${label} ${joinList(verbs.map((v) => v.text))}`,
+      firstIndex: events.indexOf(bucketEvents[0]!),
+    })
+  }
+
+  bundles.sort((a, b) => a.tier - b.tier || a.firstIndex - b.firstIndex)
+  return {
+    fragments: bundles.slice(0, 2).map((b) => b.text),
+    count: events.length,
+  }
+}
+
+/**
+ * Render a composed summary into the group-row's single line of copy: the
+ * fragments joined with `Intl.ListFormat` (never a hand-rolled `', '`/`' and '`
+ * — §15.5 rule 4), then the always-on count. "6 updates" alone when nothing
+ * survived cancellation.
+ */
+export function formatEventGroupSummary(summary: EventGroupSummary): string {
+  const countText = `${summary.count} update${summary.count === 1 ? '' : 's'}`
+  if (summary.fragments.length === 0) return countText
+  return `${joinList(summary.fragments)} · ${countText}`
 }

--- a/apps/web/src/components/mail/thread-event-icon.tsx
+++ b/apps/web/src/components/mail/thread-event-icon.tsx
@@ -1,0 +1,92 @@
+// apps/web/src/components/mail/thread-event-icon.tsx
+'use client'
+
+import type { ThreadEventType } from '@auxx/lib/thread-events/client'
+import { cn } from '@auxx/ui/lib/utils'
+import {
+  BadgeCheck,
+  Bot,
+  CircleCheck,
+  GitMerge,
+  RotateCcw,
+  Settings,
+  Tag,
+  UserRound,
+  UserRoundCheck,
+} from 'lucide-react'
+
+/**
+ * Thread-event type → icon/color map for the v2 inline timeline (admin only).
+ * Deliberately its OWN mapping — `~/components/timeline/event-icon.tsx` is the
+ * record timeline's `TimelineEvent` map and stays bound to that vocabulary; this
+ * file is the pattern reference only (plans/threads/thread-events.md §15.7).
+ */
+export function getThreadEventIcon(type: ThreadEventType) {
+  switch (type) {
+    case 'thread:taken_over':
+      return UserRoundCheck
+    case 'thread:returned_to_ai':
+      return Bot
+    case 'thread:archived':
+      return CircleCheck
+    case 'thread:reopened':
+      return RotateCcw
+    case 'thread:assignee:changed':
+      return UserRound
+    case 'thread:tagged':
+    case 'thread:untagged':
+      return Tag
+    case 'thread:merged':
+      return GitMerge
+    case 'thread:visitor:identified':
+      return BadgeCheck
+    default:
+      return Settings
+  }
+}
+
+/** Tailwind text-color classes for the type-icon dot — kept muted/small per §15.3. */
+export function getThreadEventColor(type: ThreadEventType): string {
+  switch (type) {
+    case 'thread:taken_over':
+      return 'text-blue-600 dark:text-blue-400'
+    case 'thread:returned_to_ai':
+      return 'text-violet-600 dark:text-violet-400'
+    case 'thread:archived':
+      return 'text-good-600 dark:text-good-400'
+    case 'thread:reopened':
+      return 'text-orange-600 dark:text-orange-400'
+    case 'thread:assignee:changed':
+      return 'text-comparison-600 dark:text-comparison-400'
+    case 'thread:tagged':
+      return 'text-indigo-600 dark:text-indigo-400'
+    case 'thread:untagged':
+      return 'text-muted-foreground'
+    case 'thread:merged':
+      return 'text-comparison-600 dark:text-comparison-400'
+    case 'thread:visitor:identified':
+      return 'text-blue-600 dark:text-blue-400'
+    default:
+      return 'text-muted-foreground'
+  }
+}
+
+/**
+ * The small type-icon dot for one event row — "what happened", never an actor
+ * avatar (the avatar lives in the copy, via `ActorBadge`). Sits on the block's
+ * shared left rail.
+ */
+export function ThreadEventDot({ type, className }: { type: ThreadEventType; className?: string }) {
+  const Icon = getThreadEventIcon(type)
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        'flex size-4 shrink-0 items-center justify-center rounded-full bg-muted',
+        getThreadEventColor(type),
+        className
+      )}>
+      <Icon className='size-2.5' />
+    </span>
+  )
+}

--- a/apps/web/src/components/mail/thread-messages.tsx
+++ b/apps/web/src/components/mail/thread-messages.tsx
@@ -23,8 +23,7 @@ import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import CallDisplay from './call-display'
 import { ChatMessageGroup } from './chat-message-group'
-import { SystemLine } from './chat-panel/system-line'
-import { SystemLineRun } from './chat-panel/system-line-run'
+import { DaySeparator, EventBlock } from './chat-panel/system-line-run'
 import { useChatThreadEvents } from './chat-panel/use-thread-events'
 import { buildChatTimeline } from './chat-timeline'
 import EmailDisplay from './email-display'
@@ -273,11 +272,13 @@ export function ThreadMessages() {
         {/* Email messages */}
         <div className={`flex flex-col gap-4 px-4 py-2 ${isMuted ? 'opacity-50' : ''}`}>
           {buildChatTimeline(messages, threadEvents).map((item) => {
-            if (item.kind === 'event') {
-              return <SystemLine key={`evt:${item.event.id}`} event={item.event} />
+            if (item.kind === 'day-separator') {
+              return <DaySeparator key={item.key} label={item.label} />
             }
-            if (item.kind === 'event-run') {
-              return <SystemLineRun key={`evtrun:${item.events[0]!.id}`} events={item.events} />
+            if (item.kind === 'event-block') {
+              return (
+                <EventBlock key={item.key} entries={item.entries} isTrailing={item.isTrailing} />
+              )
             }
             if (item.kind === 'chat-group') {
               const groupIsLast =

--- a/docs/channels-mail-architecture-guide.md
+++ b/docs/channels-mail-architecture-guide.md
@@ -2,7 +2,7 @@
 
 # Channels & Mail Architecture Guide
 
-**Last Updated:** 2026-08-01
+**Last Updated:** 2026-08-17
 **Scope:** The conversation layer — how an external mailbox or messaging account becomes a
 **channel**, how its mail lands in **threads/messages** through the inbound doors (webhook push,
 two-phase polling, SES forwarding), how a reply goes back out, and who is allowed to see any of
@@ -170,6 +170,32 @@ merge stick), `ThreadEntityLink` (secondary record links; the primary lives on `
 
 `Participant` is org-scoped and unique on `(organizationId, identifier, identifierType)`, carries
 `isInternal` (own-domain), `isSpammer`, and `entityInstanceId` for the contact link.
+
+### `ThreadEvent` — the inline lifecycle timeline
+
+Append-only system-line events rendered between message bubbles on **every** channel ("Markus
+took over", "Archived by workflow *Auto-close*", "tagged with x, y, z"): `threadId` (real FK,
+cascade-on-delete), `type`, `actorId`, `data` jsonb, `createdAt` — no `updatedAt`, nothing
+updates these rows. **Single writer**: `events/handlers/publish-thread-event-to-realtime.ts`
+persists the row, then fans it out over realtime (visitor fan-out allowlist-gated — see gotcha
+28). Read via `@auxx/lib/thread-events` (`listThreadEvents`, keyset-cursor on
+`(createdAt, id) DESC`).
+
+The `type` vocabulary is plain `text`, defined **once** in `@auxx/lib/thread-events/client`
+(`THREAD_EVENT_TYPES` — grows over time; `VISITOR_FACING_THREAD_EVENT_TYPES` — frozen at the
+original six). The strings double as Pusher event names and public webhook event names
+(`thread:archived`/`thread:reopened`), so they are never renamed. `actorId` is a branded
+`ActorId` (`user:…`/`agent:…`) rendered as an avatar badge; automation writes `actorId = null`
+plus `data.source` provenance (`{kind: 'workflow' | 'mail_filter' | …, id, runId?, name?}`)
+rendered as copy — emitters pass a `ThreadActor` descriptor and `threadActorToEventFields`
+does the mapping.
+
+**Boundary rule (do not re-litigate):** `ThreadEvent` = **conversation-surface** history,
+rendered inline in the thread view; `TimelineEvent` = **record-surface** history, rendered in
+the record drawer's timeline tab. Merge is deliberately both: the `TimelineEvent` merge
+markers are the *mechanism* (unmerge reads them back) and the `thread:merged` `ThreadEvent`
+on the surviving thread is the *surface* (deleted on unmerge). Design record:
+`plans/threads/thread-events.md`.
 
 ---
 
@@ -648,7 +674,7 @@ without that, a member could list a row whose every field then redacts.
 | `channel.ts` (1095 ln) | connect/prepare, list, disconnect, toggle, sync, settings, allowed/excluded senders, chat-widget CRUD, IMAP connect/test, `resetSyncState` |
 | `channel-reauth.ts` | reconnect + sync-breaker reset |
 | `inbox.ts` | inbox CRUD, members, floors, channel routing, `myLenses` |
-| `thread.ts` (1250 ln) | list/get/status/assign/merge/link/handoff |
+| `thread.ts` (1250 ln) | list/get/status/assign/merge/link/handoff, `listEvents` (lifecycle timeline, cursor-paginated, lens-gated) |
 | `message.ts`, `draft.ts`, `label.ts`, `mailView.ts`, `mailDomain.ts`, `participant.ts`, `emailTemplate.ts` | |
 
 The area is unusually well test-covered at the router layer — `mail-router-front-door.test.ts`,
@@ -720,6 +746,14 @@ components in `~/components/mail` (thread list/display/composer, chat panel, sea
 27. **Outlook webhook callbacks must be HTTPS.** Build them via
     `providers/webhook-callback-base.ts` (`NGROK_URL || WEBAPP_URL`), never from `WEBAPP_URL`
     directly — Graph rejects `http://` and dev arming silently falls back to polling.
+28. **Thread lifecycle events gate at the `metadata` rung on BOTH doors.** The `thread-{id}`
+    realtime room and `thread.listEvents` must ask the same lens question, and `listEvents`
+    returns empty — never 403/404 — so an invisible thread id fails exactly like a
+    nonexistent one. The visitor fan-out is an **allowlist frozen at the original six**
+    (`VISITOR_FACING_THREAD_EVENT_TYPES`): new event types are admin-surface only unless
+    deliberately added, and a type whose payload narrates an identity/read-tier fact
+    (subject, body snippet) must not join the vocabulary at all — it would leak through the
+    events sidecar what `redactThreadMeta` blanks on the thread itself.
 
 ---
 
@@ -763,8 +797,13 @@ message-sync,message-processing,email}-worker.ts`.
 `links.service.ts`, `thread-merge.service.ts`, `handoff.service.ts`),
 `packages/lib/src/email/labels/`.
 
+**Lifecycle timeline** — `packages/lib/src/thread-events/` (`client.ts` vocabulary + `ThreadActor`,
+queries/mutations), `packages/lib/src/events/handlers/publish-thread-event-to-realtime.ts` (the
+single writer), `apps/web/src/components/mail/chat-timeline.ts` (interleave + event-run grouping),
+`apps/web/src/components/mail/chat-panel/{use-thread-events.ts,system-line.tsx}`.
+
 **Schema** — `packages/database/src/db/schema/`: `integration.ts`, `inbox-integration.ts`,
-`thread.ts`, `message.ts`, `participant.ts`, `thread-participant.ts`, `message-participant.ts`,
+`thread.ts`, `thread-event.ts`, `message.ts`, `participant.ts`, `thread-participant.ts`, `message-participant.ts`,
 `thread-external-key.ts`, `thread-entity-link.ts`, `thread-read-status.ts`, `message-receipt.ts`,
 `label.ts`, `labels-on-thread.ts`, `integration-tag-label.ts`, `scheduled-message.ts`,
 `mail-view.ts`, `mail-domain.ts`, `email-address.ts`, `email-template.ts`, `email-embedding.ts`.

--- a/docs/realtime-architecture-guide.md
+++ b/docs/realtime-architecture-guide.md
@@ -110,7 +110,11 @@ Each `RoomDef.authorize` enforces its own rule:
   `InboxService.hasUserAccess`); the `none` triage slug is open to all members.
 - **events / presence** — caller is an org member.
 - **user** — `ctx.session.userId === userId`.
-- **thread** (admin) — any authenticated session (org scoping handled upstream).
+- **thread** (admin) — member of the thread's owning org **and**
+  `effectiveLens ≥ metadata` on the thread (`getThreadLens` + `satisfiesRung`);
+  fails closed. The tRPC history door (`thread.listEvents`) asks the same lens
+  question, returning empty rather than a 403 so an invisible thread id fails
+  exactly like a nonexistent one.
 - **chat session** (`chat-*`) — public, always allowed; channel name is an
   unguessable random session id, the `authorize` hook is unreachable because Pusher
   never asks the server to sign public channels.
@@ -348,9 +352,14 @@ re-subscribes only when the room key itself changes.
 - `useMessageArrivalCue` coalesces inbound `message:created` over a 1s window into a
   single toast/chime/favicon cue, suppressing outbound sends and the
   actively-viewed thread.
-- **`useThreadEvents`** (chat panel) subscribes to `chatThread(threadId)` for
-  lifecycle events (`thread:taken_over`, `returned_to_ai`, `archived`, …), merging
-  persisted (`thread.listEvents`) with live, deduped by event id.
+- **`useChatThreadEvents`** (`chat-panel/use-thread-events.ts`, but rendered on
+  **every** channel's thread view, not just chat) subscribes to
+  `chatThread(threadId)` for lifecycle events (`thread:taken_over`, `archived`,
+  `assignee:changed`, `tagged`, `merged`, …), merging persisted history with live
+  events, deduped by event id. Persisted history is `thread.listEvents` — keyset-
+  cursor pages off the dedicated `ThreadEvent` table (newest-first, reversed
+  client-side, older pages drained in the background until exhausted). See
+  `channels-mail-architecture-guide.md` §3 for the table and its boundary rule.
 
 ### C. Agent / procedure / eval admin state
 
@@ -392,7 +401,7 @@ small. It does **not** use `PusherRealtimeAdapter` or `@auxx/lib/realtime/client
 | Auth endpoint | `/api/pusher/auth` (session) | `/api/chat/pusher/auth` (passport bearer) |
 | Message stream | `message:created` on inbox channel | `new-message` on public `chat-{sessionId}` |
 | Cross-thread | `thread:updated` on inbox | `thread-updated` on `private-visitor-{id}` |
-| Lifecycle | `thread:*` on `thread-{id}` | same `thread-{id}` **plus** redundant `visitor-{id}` |
+| Lifecycle | all `thread:*` types on `thread-{id}` | the six visitor-facing types only, on `thread-{id}` **plus** redundant `visitor-{id}` |
 | Dependencies | full `@auxx/lib` | none |
 
 Widget specifics:
@@ -405,8 +414,10 @@ Widget specifics:
   (before the widget is opened) so the unread badge updates while closed; it
   survives identity rotation via an epoch bump.
 - Event type definitions are **duplicated locally** (`transport/thread-events.ts`)
-  rather than imported, kept in sync by hand with `apps/api`'s
-  `WIDGET_THREAD_EVENT_TYPES`.
+  rather than imported (`packages/chat` has no `@auxx/lib` dependency), pinned by
+  a set-equality test (`packages/lib/src/thread-events/__tests__/visitor-parity.test.ts`)
+  to the **frozen** `VISITOR_FACING_THREAD_EVENT_TYPES` — the original six — and
+  deliberately NOT to the growing admin-side `THREAD_EVENT_TYPES` vocabulary.
 
 This is a deliberate "two clients" decision (bundle isolation) — don't try to DRY
 the widget client and the admin adapter into one.
@@ -429,11 +440,13 @@ Inbound (visitor → agent) flows through `ChatProvider.receiveMessage`; outboun
 `skipInboxMessagePublish: true` (the `MessageSenderService` already published the
 inbox event). Agent replies are composed in `process-chat-turn.ts`.
 
-**Thread lifecycle** events (takeover, archive, reopen, assignee change, visitor
-identified) are persisted then fanned out by
-`events/handlers/publish-thread-event-to-realtime.ts` to **both** `thread-{id}`
-(admin + open widget) and `visitor-{id}` (widget in any state, deduped by event id
-client-side).
+**Thread lifecycle** events (takeover, archive, reopen, assignee change, tag,
+merge, …) are persisted to the dedicated `ThreadEvent` table then fanned out by
+`events/handlers/publish-thread-event-to-realtime.ts`. Every type goes to
+`thread-{id}` (admin + open widget); the `visitor-{id}` publish is
+**allowlist-gated** on the frozen six `VISITOR_FACING_THREAD_EVENT_TYPES` and
+shaped down to `{threadId, id, createdAt}` — a visitor must never learn a thread
+was tagged or merged. Dedupe by event id client-side.
 
 > Pusher frames never carry attachment URLs (10KB limit). The widget resolves them
 > lazily via `/api/chat/attachments/{id}/url` with a short TTL.
@@ -523,7 +536,7 @@ stay untouched.
 
 **Server chat publishing**
 - `packages/lib/src/chat/realtime.ts` — `publishChatMessageCreated`, `publishVisitorThreadCreated`
-- `packages/lib/src/events/handlers/publish-thread-event-to-realtime.ts` — lifecycle dual fan-out
+- `packages/lib/src/events/handlers/publish-thread-event-to-realtime.ts` — lifecycle persist (`ThreadEvent`) + gated dual fan-out
 - `packages/lib/src/chat/agent/process-chat-turn.ts` — agent reply composition
 - `apps/api/src/routes/chat/pusher-auth.ts` — widget channel auth
 - `apps/api/src/routes/chat/{threads,initialize}.ts` — message POST / bootstrap


### PR DESCRIPTION
## Summary

Redesigns the admin inline thread-event timeline (v1 shipped in #1686) per the v2 design agreed in `plans/threads/thread-events.md` §15. Admin surfaces only — the chat widget keeps its flat lines and frozen visitor vocabulary.

- **Day separators across the whole conversation** — Slack-style "Today" / "Yesterday" / weekday / "Aug 12" dividers emitted by `buildChatTimeline` for messages AND events, so both share one day spine. All timestamps below a divider are time-only (chat bubbles switched from relative "2 hours ago" — that hunk already landed via #1691).
- **Event blocks** — every contiguous stretch of events between two messages renders as one block in the `max-w-2xl` message column, with a shared left rail and a type-icon dot per row (new `thread-event-icon.tsx` map; dot = what happened, copy = who did it).
- **Mixed-actor day grouping** — replaces the same-actor 5-minute `event-run`: ≥3 contiguous same-day events collapse into a group row (count dot, up-to-3-avatar facepile, time range) that expands in place onto the same rail. The trailing block (events after the last message) starts expanded. 2 events never collapse.
- **Net-effect summaries** — a pure, unit-tested composer replaces the comma-join transcript: folds repeats per actor per type (tag unions, final assignee), cancels opposites (archived↔reopened, tagged x then untagged x), ranks survivors (merged > handoff > status > assignee > tags), shows the top 2 fragments + an always-on count, joined with `Intl.ListFormat`.
- **Richer copy** — actors and assignees render as `ActorBadge variant='text'` (avatar + name inline); tags as live colored `TagBadge` chips with the emit-time snapshot as deleted-tag fallback; workflow provenance links to the workflow editor, mail filters to the rules settings page.
- Docs: the channels-mail and realtime architecture guides updated for the ThreadEvent table (from #1686) and the v2 timeline shape.

## Test plan

- `chat-timeline.test.ts` rewritten: 36 tests covering bubble grouping, day-separator labeling/placement, block segmentation, day-boundary splits, ≥3 grouping, trailing detection, and the summary composer (fold / cancel / cross-actor non-cancellation / ranking / counts).
- Full `src/components/mail` suite: 238 tests passing.
- Not yet live-tested in the browser — worth a look at a busy thread before merge.