### PR TITLE
feat(threads): collapsible day separators and group-row hover polish

### DIFF
--- a/apps/web/src/components/mail/chat-panel/messages.tsx
+++ b/apps/web/src/components/mail/chat-panel/messages.tsx
@@ -12,7 +12,7 @@ import { buildChatTimeline } from '../chat-timeline'
 import type { EmailActions } from '../email-actions'
 import EmailDisplay from '../email-display'
 import MessageDisplay from '../message-display'
-import { DaySeparator, EventBlock } from './system-line-run'
+import { DaySeparator, EventBlock, useCollapsedDays } from './system-line-run'
 import { useChatThreadEvents } from './use-thread-events'
 
 interface ChatPanelMessagesProps {
@@ -30,6 +30,7 @@ export function ChatPanelMessages({ threadId, popoverClassName }: ChatPanelMessa
   const { messages, isLoading } = useMessages({ threadId })
   const { events } = useChatThreadEvents({ threadId, enabled: true })
   const { update: updateThread } = useThreadMutation()
+  const collapsedDays = useCollapsedDays(threadId)
   const scrollRef = useRef<HTMLDivElement>(null)
 
   const messageActions = useMemo<EmailActions>(
@@ -85,6 +86,10 @@ export function ChatPanelMessages({ threadId, popoverClassName }: ChatPanelMessa
 
   const items = buildChatTimeline(messages, events)
 
+  // Tracks which day the map iteration is inside — set by each separator item,
+  // read by the items after it. Reset per render, mutated in render order.
+  let currentDayKey: string | null = null
+
   return (
     <ScrollArea
       viewportRef={scrollRef}
@@ -93,8 +98,17 @@ export function ChatPanelMessages({ threadId, popoverClassName }: ChatPanelMessa
       <div className='flex flex-col gap-2 px-3 py-2 pe-4'>
         {items.map((item) => {
           if (item.kind === 'day-separator') {
-            return <DaySeparator key={item.key} label={item.label} />
+            currentDayKey = item.key
+            return (
+              <DaySeparator
+                key={item.key}
+                label={item.label}
+                collapsed={collapsedDays.isCollapsed(item.key)}
+                onToggle={() => collapsedDays.toggle(item.key)}
+              />
+            )
           }
+          if (currentDayKey && collapsedDays.isCollapsed(currentDayKey)) return null
           if (item.kind === 'event-block') {
             return <EventBlock key={item.key} entries={item.entries} isTrailing={item.isTrailing} />
           }

--- a/apps/web/src/components/mail/chat-panel/system-line-run.tsx
+++ b/apps/web/src/components/mail/chat-panel/system-line-run.tsx
@@ -96,15 +96,17 @@ function GroupRow({
 
   return (
     <div className='flex flex-col'>
+      {/* -mx-2/px-2 lets the hover pill breathe past the content on both sides
+          while the count dot stays aligned with the rail (rail shifts +8px). */}
       <button
         type='button'
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
         title={fullRange}
         className={cn(
-          'relative flex w-full items-center gap-2 rounded-md py-1 pl-0 text-left transition-colors hover:bg-muted',
+          'relative -mx-2 flex items-center gap-2 rounded-md px-2 py-1 text-left transition-colors hover:bg-muted',
           headerHasRail &&
-            'before:absolute before:inset-y-0 before:left-[7.5px] before:w-px before:bg-border'
+            'before:absolute before:inset-y-0 before:left-[15.5px] before:w-px before:bg-border'
         )}>
         <span
           aria-hidden
@@ -112,7 +114,13 @@ function GroupRow({
           {events.length}
         </span>
         <Facepile actors={facepile} />
-        <span className='min-w-0 flex-1 truncate text-sm text-foreground'>{summary}</span>
+        <span
+          className={cn(
+            'min-w-0 flex-1 truncate text-sm transition-colors',
+            expanded ? 'text-foreground' : 'text-foreground/70'
+          )}>
+          {summary}
+        </span>
         <span className='shrink-0 text-[10px] text-muted-foreground'>{timeRange}</span>
         <CollapsibleChevron open={expanded} className='size-3 shrink-0 text-muted-foreground' />
       </button>
@@ -134,20 +142,68 @@ function GroupRow({
 /**
  * Viewer-local day divider spanning the whole conversation — message bubbles
  * AND event rows share this one day spine (§15.6). "Today" / "Yesterday" /
- * weekday / "Aug 12" labeling comes from `buildChatTimeline`; this just draws
- * the Slack/WhatsApp-style centered line.
+ * weekday / "Aug 12" labeling comes from `buildChatTimeline`; this draws the
+ * Slack/WhatsApp-style centered line. With `onToggle`, the label is a pill
+ * button that collapses/expands everything under this day (until the next
+ * separator) — the consumer owns the collapsed set and skips the day's items.
  */
-export function DaySeparator({ label }: { label: string }) {
+export function DaySeparator({
+  label,
+  collapsed = false,
+  onToggle,
+}: {
+  label: string
+  collapsed?: boolean
+  onToggle?: () => void
+}) {
   return (
     <div
       role='separator'
       aria-label={label}
       className='mx-auto flex w-full max-w-2xl items-center gap-3 px-4 py-1'>
       <Separator className='flex-1' />
-      <span className='shrink-0 text-[11px] font-medium text-muted-foreground'>{label}</span>
+      {onToggle ? (
+        <button
+          type='button'
+          onClick={onToggle}
+          aria-expanded={!collapsed}
+          className='flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'>
+          {label}
+          <CollapsibleChevron open={!collapsed} className='size-3' />
+        </button>
+      ) : (
+        <span className='shrink-0 text-[11px] font-medium text-muted-foreground'>{label}</span>
+      )}
       <Separator className='flex-1' />
     </div>
   )
+}
+
+/**
+ * Collapsed-day set for the §15.6 separators — the consumer calls
+ * `isCollapsed(sep.key)` while iterating the timeline and skips a day's items.
+ * Resets when `resetKey` (the thread id) changes, so a collapsed "Yesterday"
+ * on one thread doesn't collapse another thread's.
+ */
+export function useCollapsedDays(resetKey: string | null | undefined): {
+  isCollapsed: (dayKey: string) => boolean
+  toggle: (dayKey: string) => void
+} {
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set())
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resetKey is deliberately the only trigger
+  useEffect(() => {
+    setCollapsed(new Set())
+  }, [resetKey])
+  const isCollapsed = useCallback((dayKey: string) => collapsed.has(dayKey), [collapsed])
+  const toggle = useCallback((dayKey: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      if (next.has(dayKey)) next.delete(dayKey)
+      else next.add(dayKey)
+      return next
+    })
+  }, [])
+  return { isCollapsed, toggle }
 }
 
 function Facepile({ actors }: { actors: FacepileActor[] }) {

--- a/apps/web/src/components/mail/thread-messages.tsx
+++ b/apps/web/src/components/mail/thread-messages.tsx
@@ -23,7 +23,7 @@ import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
 import CallDisplay from './call-display'
 import { ChatMessageGroup } from './chat-message-group'
-import { DaySeparator, EventBlock } from './chat-panel/system-line-run'
+import { DaySeparator, EventBlock, useCollapsedDays } from './chat-panel/system-line-run'
 import { useChatThreadEvents } from './chat-panel/use-thread-events'
 import { buildChatTimeline } from './chat-timeline'
 import EmailDisplay from './email-display'
@@ -175,6 +175,10 @@ export function ThreadMessages() {
     enabled: !!thread,
   })
 
+  // Collapsed day-separator set (§15.6) — collapsing a separator hides every
+  // timeline item under that day until the next separator.
+  const collapsedDays = useCollapsedDays(thread?.id ?? null)
+
   if (!thread) return null
 
   // Redacted rendering (mail-permissions): below `read`, message content is
@@ -240,6 +244,10 @@ export function ThreadMessages() {
 
   const isMuted = thread.status === 'TRASH' || thread.status === 'IGNORED'
 
+  // Tracks which day the map iteration is inside — set by each separator item,
+  // read by the items after it. Reset per render, mutated in render order.
+  let currentDayKey: string | null = null
+
   return (
     <div className='flex flex-col'>
       <ConfirmDialog />
@@ -273,8 +281,17 @@ export function ThreadMessages() {
         <div className={`flex flex-col gap-4 px-4 py-2 ${isMuted ? 'opacity-50' : ''}`}>
           {buildChatTimeline(messages, threadEvents).map((item) => {
             if (item.kind === 'day-separator') {
-              return <DaySeparator key={item.key} label={item.label} />
+              currentDayKey = item.key
+              return (
+                <DaySeparator
+                  key={item.key}
+                  label={item.label}
+                  collapsed={collapsedDays.isCollapsed(item.key)}
+                  onToggle={() => collapsedDays.toggle(item.key)}
+                />
+              )
             }
+            if (currentDayKey && collapsedDays.isCollapsed(currentDayKey)) return null
             if (item.kind === 'event-block') {
               return (
                 <EventBlock key={item.key} entries={item.entries} isTrailing={item.isTrailing} />


### PR DESCRIPTION
## Summary

Follow-up polish on the inline timeline v2 (#1692), from first live use:

- **Day separators are collapsible** — the label is now a pill button with a chevron; clicking collapses everything under that day (messages and event blocks) until the next separator. Collapsed state lives in a new `useCollapsedDays` hook shared by both consumers and resets on thread switch.
- **Group-row hover breathing room** — the hover pill extends 8px past the content on both sides (`-mx-2 px-2`), so the chevron no longer touches the right edge of the highlight; the count dot stays aligned on the rail (rail pseudo-element shifted to compensate).
- **Collapsed group summaries render lighter** — `text-foreground/70` while collapsed, transitioning to full `text-foreground` when expanded.

## Test plan

- `src/components/mail` suite: 238 tests passing (no builder changes — rendering only).
- Biome clean (the one `useExhaustiveDependencies` warning in `chat-panel/messages.tsx` is the pre-existing scroll effect, untouched).