### PR TITLE
feat(participants): publish participant:updated from composer and chat identity writes

### DIFF
--- a/apps/api/src/routes/chat/passport.ts
+++ b/apps/api/src/routes/chat/passport.ts
@@ -11,6 +11,7 @@ import {
 import { findOrCreateVisitorParticipant } from '@auxx/lib/chat-widget/visitor'
 import { type GeoLocation, lookupIp } from '@auxx/lib/geo'
 import { findOrCreateContactFromJwt } from '@auxx/lib/ingest'
+import { diffParticipantNamePatch, publishParticipantPatch } from '@auxx/lib/participants'
 import { RedisRateLimiter } from '@auxx/lib/utils/rate-limiter'
 import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
@@ -373,6 +374,30 @@ passportRoute.post('/', async (c) => {
             .update(schema.Participant)
             .set(participantUpdates)
             .where(eq(schema.Participant.id, participant.id))
+
+          // Emit `participant:updated` when the verified identity actually
+          // changed the label — open mail lists/bubbles flip without remount.
+          // Routed via the chat channel's inbox; fire-and-forget (the helper
+          // never throws), so a realtime hiccup can't block the mint.
+          if (displayName) {
+            const patch = diffParticipantNamePatch(
+              { name: participant.name, displayName: participant.displayName },
+              { name: displayName, displayName }
+            )
+            if (Object.keys(patch).length > 0) {
+              const [inboxLink] = await database
+                .select({ inboxId: schema.InboxIntegration.inboxId })
+                .from(schema.InboxIntegration)
+                .where(eq(schema.InboxIntegration.integrationId, channelId))
+                .limit(1)
+              await publishParticipantPatch({
+                organizationId: widget.organizationId,
+                participantId: participant.id,
+                patch,
+                inboxId: inboxLink?.inboxId ?? null,
+              })
+            }
+          }
         }
 
         // Shopify storefront identity (plans/chat/v6 phase-5 §2): write the

--- a/apps/api/src/routes/chat/visitor-info.ts
+++ b/apps/api/src/routes/chat/visitor-info.ts
@@ -1,10 +1,11 @@
 // apps/api/src/routes/chat/visitor-info.ts
 
 import { issueChatPassport } from '@auxx/credentials/passport'
-import { database } from '@auxx/database'
+import { database, schema } from '@auxx/database'
 import { patchChatThreadMetadata, updateVisitorClaimedIdentity } from '@auxx/lib/chat'
 import { publisher } from '@auxx/lib/events'
 import { createScopedLogger } from '@auxx/logger'
+import { and, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { parseIdentifyPayload } from './identify'
 import { applyChatCorsHeaders } from './lib'
@@ -57,10 +58,19 @@ visitorInfoRoute.patch('/', async (c) => {
     })
 
     // Overwrite the synthetic `Chat user #xxxx` displayName so message FROM
-    // and future thread subjects pick up the real identity.
+    // and future thread subjects pick up the real identity. The thread's inbox
+    // routes the resulting `participant:updated` to the right lens channels.
+    const thread = await database.query.Thread.findFirst({
+      where: and(
+        eq(schema.Thread.id, body.threadId),
+        eq(schema.Thread.organizationId, chat.organizationId)
+      ),
+      columns: { inboxId: true },
+    })
     await updateVisitorClaimedIdentity(ctx, chat.visitorParticipantId, {
       name: claimedVisitorName,
       email: claimedVisitorEmail,
+      inboxId: thread?.inboxId ?? null,
     })
 
     // Emit `thread:visitor:identified` once an email is attached to an active

--- a/apps/web/src/server/api/routers/search-participant-gate.test.ts
+++ b/apps/web/src/server/api/routers/search-participant-gate.test.ts
@@ -72,7 +72,15 @@ vi.mock('drizzle-orm', () => ({
   ilike: (...args: unknown[]) => ({ ilike: args }),
   asc: (x: unknown) => x,
   inArray: (...args: unknown[]) => ({ inArray: args }),
+  isNull: (x: unknown) => ({ isNull: x }),
   count: () => ({ count: true }),
+  // `@auxx/lib/participants` (the barrel `search.ts` imports since #1691)
+  // reaches modules that build `sql` fragments at module scope — the tag must
+  // exist for collection even though no assertion ever compiles SQL.
+  sql: Object.assign((strings: TemplateStringsArray, ...vals: unknown[]) => ({ strings, vals }), {
+    raw: (s: string) => ({ raw: s }),
+    join: (...args: unknown[]) => ({ join: args }),
+  }),
 }))
 
 // Spread form rather than a `schema:` override, because this file needs COLUMN-

--- a/apps/web/src/server/api/routers/search-participant-label-repair.test.ts
+++ b/apps/web/src/server/api/routers/search-participant-label-repair.test.ts
@@ -1,0 +1,243 @@
+// apps/web/src/server/api/routers/search-participant-label-repair.test.ts
+
+import { Area, expandLevelsToKeys, Level } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * contact-name-precedence plan Phase 5 — `search.ts` used to return the stored
+ * `Participant.displayName` verbatim. That column is nullable, and legacy
+ * CHAT_VISITOR rows persist the raw session uuid there. Both participant reads
+ * (the `participants` typeahead and the `suggestions` operator labels) now
+ * route through the same read-time repair `getParticipantMetaBatch` uses:
+ * contact-name precedence (`usableContactName`) first, then
+ * `calculateParticipantDisplayInfo` over the stored name/identifier.
+ */
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Doubles
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Rows the stub db hands back, in call order. */
+let dbRows: unknown[][] = []
+
+// Unlike the gate test's stub, `where()` must BE awaitable as well as carry
+// `.limit()` — `fetchContactNames` awaits the where-chain directly while the
+// participant reads chain `.limit(n)` after it.
+const db = {
+  select: () => ({
+    from: () => ({
+      where: () => {
+        const rows = dbRows.shift() ?? []
+        const chain = Promise.resolve(rows) as Promise<unknown[]> & {
+          limit: (n: number) => Promise<unknown[]>
+        }
+        chain.limit = async () => rows
+        return chain
+      },
+    }),
+  }),
+}
+
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => ({ and: args }),
+  or: (...args: unknown[]) => ({ or: args }),
+  eq: (...args: unknown[]) => ({ eq: args }),
+  ilike: (...args: unknown[]) => ({ ilike: args }),
+  asc: (x: unknown) => x,
+  inArray: (...args: unknown[]) => ({ inArray: args }),
+  isNull: (x: unknown) => ({ isNull: x }),
+  count: () => ({ count: true }),
+  sql: Object.assign((strings: TemplateStringsArray, ...vals: unknown[]) => ({ strings, vals }), {
+    raw: (s: string) => ({ raw: s }),
+    join: (...args: unknown[]) => ({ join: args }),
+  }),
+}))
+
+vi.mock('@auxx/database', async () => ({
+  ...(await (await import('~/test/database-mock')).mockAuxxDatabase()),
+  schema: new Proxy({} as Record<string, Record<string, object>>, {
+    get: (target, table: string) => {
+      if (!(table in target)) {
+        target[table] = new Proxy(
+          {},
+          {
+            get: (cols: Record<string, object>, col: string) => {
+              if (!(col in cols)) cols[col] = { table, col }
+              return cols[col]
+            },
+          }
+        )
+      }
+      return target[table]
+    },
+  }),
+}))
+
+vi.mock('@auxx/database/enums', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ParticipantRole: { FROM: 'FROM', TO: 'TO', CC: 'CC' },
+}))
+
+vi.mock('@auxx/logger', async () => (await import('~/test/logger-mock')).mockAuxxLogger())
+
+vi.mock('@auxx/lib/mail-query', async () => {
+  const parser = await vi.importActual<Record<string, unknown>>(
+    '@auxx/lib/mail-query/search-query-parser'
+  )
+  return { SearchOperator: parser.SearchOperator, IsOperatorValue: parser.IsOperatorValue }
+})
+
+vi.mock('@auxx/lib/permissions', async () => {
+  const registry = await vi.importActual<Record<string, unknown>>(
+    '@auxx/lib/permissions/capabilities/registry'
+  )
+  return { PermissionKey: registry.PermissionKey }
+})
+
+vi.mock('@auxx/lib/resources', () => ({ listAll: vi.fn(async () => ({ items: [] })) }))
+vi.mock('@auxx/lib/members', () => ({ listMembersWithUser: vi.fn(async () => []) }))
+vi.mock('@auxx/lib/inboxes', () => ({
+  InboxService: class {
+    listInboxes = vi.fn(async () => [])
+  },
+}))
+
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    capabilityProcedure: t.procedure,
+    protectedProcedure: t.procedure,
+    permissionProcedure: () => t.procedure,
+    isAuxxError: (e: unknown) =>
+      typeof e === 'object' && e !== null && 'statusCode' in (e as Record<string, unknown>),
+  }
+})
+
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+// The repair itself stays REAL — the assertions below pin the router to the
+// same label `getParticipantMetaBatch` computes for the same row.
+const { generateVisitorName } = await import('@auxx/lib/chat/visitor-naming')
+const { searchRouter } = await import('./search')
+
+type Caps = InstanceType<typeof CapabilitySet>
+
+function capabilities(): Caps {
+  const toSlug = (id: string) => id
+  return new CapabilitySet(
+    new Set(expandLevelsToKeys({ [Area.inboxes]: Level.Read, [Area.records]: Level.Edit })),
+    {},
+    'MEMBER',
+    'full',
+    toSlug,
+    undefined,
+    toSlug,
+    {},
+    new Set(),
+    {},
+    new Set()
+  )
+}
+
+function caller() {
+  return searchRouter.createCaller({
+    db,
+    capabilities: capabilities(),
+    headers: new Headers(),
+    session: {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      user: { id: USER_ID, defaultOrganizationId: ORG_ID, isAdmin: false },
+    },
+  } as never)
+}
+
+const SESSION_UUID = '7c0e8605-4a2b-4c3d-9e1f-d1a566d4354b'
+
+function participantRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'prt_cuid00000000000000000a',
+    identifier: 'someone@example.com',
+    name: null,
+    displayName: null,
+    identifierType: 'EMAIL',
+    entityInstanceId: null,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  dbRows = []
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('search.participants — read-time label repair', () => {
+  it('repairs a NULL displayName to the identifier', async () => {
+    dbRows = [[participantRow()]]
+
+    const [row] = await caller().participants({ query: 'someone' })
+
+    expect(row?.displayName).toBe('someone@example.com')
+  })
+
+  it('repairs a legacy CHAT_VISITOR row storing its raw session uuid', async () => {
+    dbRows = [
+      [
+        participantRow({
+          identifier: SESSION_UUID,
+          displayName: SESSION_UUID,
+          identifierType: 'CHAT_VISITOR',
+        }),
+      ],
+    ]
+
+    const [row] = await caller().participants({ query: 'turtle' })
+
+    expect(row?.displayName).toBe(generateVisitorName(SESSION_UUID))
+    expect(row?.displayName).not.toContain(SESSION_UUID)
+  })
+
+  it('a linked (non-archived) contact name still wins over the repair', async () => {
+    dbRows = [
+      [participantRow({ entityInstanceId: 'ent_c1', name: 'Old Header Name' })],
+      [{ id: 'ent_c1', displayName: 'Bruno Klooth' }],
+    ]
+
+    const [row] = await caller().participants({ query: 'bruno' })
+
+    expect(row?.displayName).toBe('Bruno Klooth')
+  })
+
+  it('a stored name still beats the identifier', async () => {
+    dbRows = [[participantRow({ name: 'Someone', displayName: 'Someone' })]]
+
+    const [row] = await caller().participants({ query: 'someone' })
+
+    expect(row?.displayName).toBe('Someone')
+  })
+})
+
+describe('search.suggestions — participant operator labels stay consistent', () => {
+  it('the suggestion label goes through the SAME repair', async () => {
+    dbRows = [
+      [
+        participantRow({
+          identifier: SESSION_UUID,
+          displayName: SESSION_UUID,
+          identifierType: 'CHAT_VISITOR',
+        }),
+      ],
+    ]
+
+    const [suggestion] = (await caller().suggestions({ operator: 'from', query: 'turtle' })) as [
+      { label: string },
+    ]
+
+    expect(suggestion?.label).toBe(generateVisitorName(SESSION_UUID))
+  })
+})

--- a/apps/web/src/server/api/routers/search.ts
+++ b/apps/web/src/server/api/routers/search.ts
@@ -2,7 +2,7 @@ import { schema } from '@auxx/database'
 import { InboxService } from '@auxx/lib/inboxes'
 import { IsOperatorValue, SearchOperator } from '@auxx/lib/mail-query'
 import { listMembersWithUser } from '@auxx/lib/members'
-import { usableContactName } from '@auxx/lib/participants'
+import { calculateParticipantDisplayInfo, usableContactName } from '@auxx/lib/participants'
 import { PermissionKey } from '@auxx/lib/permissions'
 import { listAll } from '@auxx/lib/resources'
 import { createScopedLogger } from '@auxx/logger'
@@ -90,13 +90,21 @@ const fetchContactNames = async (
 }
 
 // Label with contact-name precedence — the same normalization the
-// `ParticipantMeta` fetch path uses (`usableContactName`).
+// `ParticipantMeta` fetch path uses (`usableContactName`), then the same
+// read-time repair (`calculateParticipantDisplayInfo`): the stored
+// `displayName` is nullable and legacy CHAT_VISITOR rows persist the raw
+// session uuid there, so it is recomputed rather than trusted.
 const getParticipantDisplayName = (participant: any, contactNames: Map<string, string | null>) => {
   const contactName = usableContactName(
     participant.entityInstanceId ? contactNames.get(participant.entityInstanceId) : null,
     participant.identifier
   )
-  return contactName || participant.displayName || participant.name || participant.identifier
+  if (contactName) return contactName
+  return calculateParticipantDisplayInfo(
+    participant.name,
+    participant.identifier,
+    participant.identifierType
+  ).displayName
 }
 // Helper function to save search query with limit management
 const saveSearchQuery = async (ctx: any, query: string) => {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -262,6 +262,12 @@
       "import": "./dist/chat/agent/index.mjs",
       "default": "./src/chat/agent/index.ts"
     },
+    "./chat/visitor-naming": {
+      "types": "./src/chat/visitor-naming.ts",
+      "source": "./src/chat/visitor-naming.ts",
+      "import": "./dist/chat/visitor-naming.mjs",
+      "default": "./src/chat/visitor-naming.ts"
+    },
     "./comments": {
       "types": "./src/comments/index.ts",
       "source": "./src/comments/index.ts",

--- a/packages/lib/src/chat/visitor-identity.test.ts
+++ b/packages/lib/src/chat/visitor-identity.test.ts
@@ -1,0 +1,142 @@
+// packages/lib/src/chat/visitor-identity.test.ts
+//
+// contact-name-precedence plan Phase 5 — the visitor claimed-identity write
+// path. `updateVisitorClaimedIdentity` used to overwrite the synthetic
+// `Cyan Turtle` label silently; it now diffs the tracked columns and emits
+// `participant:updated` on the thread's inbox — and only on a real change.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@auxx/database', async () => {
+  const { createChainableDatabaseMock, createSchemaMock } = await import('../test/database-mock')
+  return { schema: createSchemaMock(), database: createChainableDatabaseMock() }
+})
+
+// Partial mock, never a full replacement (a full one dies at collection).
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>()
+  const passthrough = (...a: unknown[]) => a as never
+  return { ...actual, and: passthrough, eq: passthrough }
+})
+
+// Partial mock of our own publish module: the diff stays REAL (it decides
+// whether an event fires at all), only the fanout is spied.
+vi.mock('../participants/publish-participant-changes', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../participants/publish-participant-changes')>()
+  return { ...actual, publishParticipantPatch: vi.fn(async () => {}) }
+})
+
+import { publishParticipantPatch } from '../participants/publish-participant-changes'
+import { updateVisitorClaimedIdentity } from './visitor-identity'
+
+const publishSpy = vi.mocked(publishParticipantPatch)
+
+const h = {
+  previousRow: null as { name: string | null; displayName: string | null } | null,
+  setValues: null as Record<string, unknown> | null,
+  updateCalls: 0,
+}
+
+function makeCtx() {
+  const db = {
+    query: {
+      Participant: { findFirst: vi.fn(async () => h.previousRow ?? undefined) },
+    },
+    update: () => ({
+      set: (values: Record<string, unknown>) => {
+        h.setValues = values
+        h.updateCalls += 1
+        return { where: async () => undefined }
+      },
+    }),
+  } as any
+  return { db, organizationId: 'org_1' } as any
+}
+
+beforeEach(() => {
+  publishSpy.mockReset()
+  publishSpy.mockResolvedValue(undefined)
+  h.previousRow = null
+  h.setValues = null
+  h.updateCalls = 0
+})
+
+describe('updateVisitorClaimedIdentity participant:updated emission', () => {
+  it('publishes name + displayName on the thread inbox when a name is claimed', async () => {
+    h.previousRow = { name: 'Cyan Turtle', displayName: 'Cyan Turtle' }
+
+    const result = await updateVisitorClaimedIdentity(makeCtx(), 'part_1', {
+      name: 'Bruno Klooth',
+      inboxId: 'inbox_1',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(h.setValues).toMatchObject({ name: 'Bruno Klooth', displayName: 'Bruno Klooth' })
+    expect(publishSpy).toHaveBeenCalledTimes(1)
+    expect(publishSpy).toHaveBeenCalledWith({
+      organizationId: 'org_1',
+      participantId: 'part_1',
+      patch: { name: 'Bruno Klooth', displayName: 'Bruno Klooth' },
+      inboxId: 'inbox_1',
+    })
+  })
+
+  it('does NOT publish when the claimed name is already stored', async () => {
+    h.previousRow = { name: 'Bruno Klooth', displayName: 'Bruno Klooth' }
+
+    const result = await updateVisitorClaimedIdentity(makeCtx(), 'part_1', {
+      name: 'Bruno Klooth',
+      inboxId: 'inbox_1',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(publishSpy).not.toHaveBeenCalled()
+  })
+
+  it('email-only claim patches displayName but never name', async () => {
+    h.previousRow = { name: null, displayName: 'Cyan Turtle' }
+
+    await updateVisitorClaimedIdentity(makeCtx(), 'part_1', {
+      email: 'bruno@example.com',
+      inboxId: 'inbox_1',
+    })
+
+    expect(publishSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ patch: { displayName: 'bruno@example.com' } })
+    )
+  })
+
+  it('does NOT publish when the scoped row does not exist', async () => {
+    h.previousRow = null
+
+    const result = await updateVisitorClaimedIdentity(makeCtx(), 'part_missing', {
+      name: 'Bruno',
+      inboxId: 'inbox_1',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(publishSpy).not.toHaveBeenCalled()
+  })
+
+  it('stays a no-op (no db write, no publish) without name or email', async () => {
+    const ctx = makeCtx()
+    const result = await updateVisitorClaimedIdentity(ctx, 'part_1', { inboxId: 'inbox_1' })
+
+    expect(result.ok).toBe(true)
+    expect(h.updateCalls).toBe(0)
+    expect(publishSpy).not.toHaveBeenCalled()
+  })
+
+  it('a db failure still returns a Result.error, unchanged behavior', async () => {
+    const ctx = makeCtx()
+    ctx.db.query.Participant.findFirst = vi.fn(async () => {
+      throw new Error('db down')
+    })
+
+    const result = await updateVisitorClaimedIdentity(ctx, 'part_1', { name: 'Bruno' })
+
+    expect(result.ok).toBe(false)
+    expect(publishSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/chat/visitor-identity.ts
+++ b/packages/lib/src/chat/visitor-identity.ts
@@ -5,6 +5,10 @@ import type { ParticipantEntity } from '@auxx/database/types'
 import { and, eq } from 'drizzle-orm'
 import { BadRequestError } from '../errors'
 import type { GeoLocation } from '../geo'
+import {
+  diffParticipantNamePatch,
+  publishParticipantPatch,
+} from '../participants/publish-participant-changes'
 import { Result, type TypedResult } from '../result'
 import type { ServiceContext } from './types'
 import { generateVisitorName } from './visitor-naming'
@@ -67,11 +71,15 @@ export async function findOrCreateVisitorParticipant(
  * identity (name/email). Overwrites the synthetic `Chat user #xxxx` label
  * baked in at create time so message headers and threads start showing the
  * real name. No-op if neither field is provided.
+ *
+ * When a tracked label column actually changes, emits `participant:updated` on
+ * `opts.inboxId`'s lens channels (fire-and-forget — a realtime failure never
+ * fails the identity claim) so open mail lists/bubbles flip without remount.
  */
 export async function updateVisitorClaimedIdentity(
   ctx: ServiceContext,
   visitorParticipantId: string,
-  opts: { name?: string; email?: string }
+  opts: { name?: string; email?: string; inboxId?: string | null }
 ): Promise<TypedResult<undefined, Error>> {
   const trimmedName = opts.name?.trim()
   const trimmedEmail = opts.email?.trim()
@@ -87,6 +95,18 @@ export async function updateVisitorClaimedIdentity(
       updates.displayName = trimmedEmail
     }
 
+    // Pre-read the tracked columns so the publish below fires only on a real
+    // change (ingest's diff-then-publish contract). Also tells us whether the
+    // scoped UPDATE can match at all — no row, no event.
+    const previous = await ctx.db.query.Participant.findFirst({
+      where: and(
+        eq(schema.Participant.id, visitorParticipantId),
+        eq(schema.Participant.organizationId, ctx.organizationId),
+        eq(schema.Participant.identifierType, 'CHAT_VISITOR')
+      ),
+      columns: { name: true, displayName: true },
+    })
+
     await ctx.db
       .update(schema.Participant)
       .set(updates)
@@ -97,6 +117,21 @@ export async function updateVisitorClaimedIdentity(
           eq(schema.Participant.identifierType, 'CHAT_VISITOR')
         )
       )
+
+    if (previous) {
+      const patch = diffParticipantNamePatch(previous, {
+        name: trimmedName ?? previous.name,
+        displayName: (updates.displayName as string | undefined) ?? previous.displayName,
+      })
+      if (Object.keys(patch).length > 0) {
+        await publishParticipantPatch({
+          organizationId: ctx.organizationId,
+          participantId: visitorParticipantId,
+          patch,
+          inboxId: opts.inboxId ?? null,
+        })
+      }
+    }
     return Result.nil()
   } catch (error) {
     return Result.error(error instanceof Error ? error : new Error(String(error)))

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -224,7 +224,7 @@ export class MessageSenderService {
         externalId: threadContext.externalId,
       })
       // Step 2: Process participants
-      const participants = await this.processParticipants(input)
+      const participants = await this.processParticipants(input, threadContext.inboxId ?? null)
       const isAutomatedSend = !this.viewer || isSystemViewer(this.viewer)
       // Step 2.4: §6 fix #3 — per-thread auto-reply alternation. Existing threads only;
       // a freshly-created (pending) thread has no prior message to alternate against.
@@ -602,16 +602,26 @@ export class MessageSenderService {
     }
   }
   /**
-   * Processes participants and ensures they exist in the database
+   * Processes participants and ensures they exist in the database.
+   *
+   * `inboxId` is the sending thread's inbox — it routes `participant:updated`
+   * events for any tracked-column change these upserts cause (the composer used
+   * to mutate names silently, leaving open clients stale until remount).
    */
-  private async processParticipants(input: SendMessageInput): Promise<ProcessedParticipants> {
+  private async processParticipants(
+    input: SendMessageInput,
+    inboxId: string | null
+  ): Promise<ProcessedParticipants> {
+    const publish = { inboxId, excludeSocketId: this.socketId }
     // FROM is the sending mailbox (e.g. markus@auxx.ai), not the operator's
     // login email — those can differ, and keying FROM off the user collapses it
     // onto a recipient when the operator's email matches a recipient. Providers
     // without a mailbox address (e.g. chat) fall back to the user identity.
     const fromParticipant =
-      (await this.participantService.findOrCreateParticipantForIntegration(input.integrationId)) ??
-      (await this.participantService.findOrCreateParticipantForUser(input.userId))
+      (await this.participantService.findOrCreateParticipantForIntegration(
+        input.integrationId,
+        publish
+      )) ?? (await this.participantService.findOrCreateParticipantForUser(input.userId, publish))
     if (!fromParticipant) {
       throw new Error(
         `Could not resolve FROM participant for integration ${input.integrationId} / user ${input.userId}`
@@ -619,7 +629,7 @@ export class MessageSenderService {
     }
     // Process recipients
     const processParticipant = async (p: (typeof input.to)[0], role: ParticipantRoleType) => {
-      const participant = await this.participantService.findOrCreateParticipant(p)
+      const participant = await this.participantService.findOrCreateParticipant(p, publish)
       if (!participant) {
         throw new Error(`Could not create participant for ${p.identifier}`)
       }

--- a/packages/lib/src/messages/thread-manager.service.ts
+++ b/packages/lib/src/messages/thread-manager.service.ts
@@ -61,6 +61,7 @@ export class ThreadManagerService {
           organizationId: true,
           integrationId: true,
           externalId: true,
+          inboxId: true,
           metadata: true,
         },
       })
@@ -75,6 +76,7 @@ export class ThreadManagerService {
         integrationId: thread.integrationId,
         externalId: this.sanitizeExternalId(thread.externalId),
         isPending: false,
+        inboxId: thread.inboxId ?? null,
         metadata: thread.metadata as Record<string, any>,
       }
     }
@@ -89,6 +91,7 @@ export class ThreadManagerService {
         integrationId: reusable.integrationId,
         externalId: this.sanitizeExternalId(reusable.externalId),
         isPending: false,
+        inboxId: reusable.inboxId ?? null,
         metadata: (reusable.metadata ?? {}) as Record<string, any>,
       }
     }
@@ -106,6 +109,7 @@ export class ThreadManagerService {
       integrationId: pendingThread.integrationId,
       externalId: null,
       isPending: true,
+      inboxId: pendingThread.inboxId ?? null,
       metadata: {
         state: ThreadState.PENDING_SEND,
       },

--- a/packages/lib/src/messages/types/message-sending.types.ts
+++ b/packages/lib/src/messages/types/message-sending.types.ts
@@ -52,6 +52,12 @@ export interface ThreadContext {
   integrationId: string
   externalId: string | null
   isPending: boolean
+  /**
+   * The thread's inbox — realtime routing context for `participant:updated`
+   * publishes on the compose path. Optional because the retry path builds a
+   * minimal context; absent/null routes to the admin-only `none` channel.
+   */
+  inboxId?: string | null
   metadata?: Record<string, any>
 }
 /**

--- a/packages/lib/src/participants/__tests__/display-info.test.ts
+++ b/packages/lib/src/participants/__tests__/display-info.test.ts
@@ -1,0 +1,56 @@
+// packages/lib/src/participants/__tests__/display-info.test.ts
+//
+// contact-name-precedence plan Phase 5 — `calculateParticipantDisplayInfo` is
+// the exported read-time repair (extracted from the service's private
+// `_calculateDisplayInfo`) that both `getParticipantMetaBatch` and the search
+// router use, so a nullable stored `displayName` or a legacy CHAT_VISITOR row
+// carrying its raw session uuid never reaches a label.
+
+import { describe, expect, it } from 'vitest'
+import { generateVisitorName } from '../../chat/visitor-naming'
+import { calculateParticipantDisplayInfo } from '../display-info'
+
+const SESSION_UUID = '7c0e8605-4a2b-4c3d-9e1f-d1a566d4354b'
+
+describe('calculateParticipantDisplayInfo', () => {
+  it('prefers the stored name and derives initials from it', () => {
+    const { displayName, initials } = calculateParticipantDisplayInfo(
+      'Anna Klooth',
+      'anna@example.com',
+      'EMAIL'
+    )
+    expect(displayName).toBe('Anna Klooth')
+    expect(initials).toBe('AK')
+  })
+
+  it('falls back to the identifier when there is no name', () => {
+    const { displayName, initials } = calculateParticipantDisplayInfo(
+      null,
+      'anna@example.com',
+      'EMAIL'
+    )
+    expect(displayName).toBe('anna@example.com')
+    expect(initials).toBe('A')
+  })
+
+  it('repairs a nameless CHAT_VISITOR to the friendly handle, never the uuid', () => {
+    const { displayName } = calculateParticipantDisplayInfo(null, SESSION_UUID, 'CHAT_VISITOR')
+    expect(displayName).toBe(generateVisitorName(SESSION_UUID))
+    expect(displayName).not.toContain(SESSION_UUID)
+  })
+
+  it('a claimed name still beats the friendly handle on CHAT_VISITOR', () => {
+    const { displayName } = calculateParticipantDisplayInfo('Bruno', SESSION_UUID, 'CHAT_VISITOR')
+    expect(displayName).toBe('Bruno')
+  })
+
+  it('whitespace-only names do not count', () => {
+    const { displayName } = calculateParticipantDisplayInfo('   ', '+18889155797', 'PHONE')
+    expect(displayName).toBe('+18889155797')
+  })
+
+  it('answers Unknown when there is nothing at all', () => {
+    const { displayName } = calculateParticipantDisplayInfo(null, null, null)
+    expect(displayName).toBe('Unknown')
+  })
+})

--- a/packages/lib/src/participants/__tests__/participant-service-publish.test.ts
+++ b/packages/lib/src/participants/__tests__/participant-service-publish.test.ts
@@ -1,0 +1,170 @@
+// packages/lib/src/participants/__tests__/participant-service-publish.test.ts
+//
+// contact-name-precedence plan Phase 5 — the composer/outbound write path.
+// `ParticipantService.findOrCreateParticipant` used to mutate tracked name
+// columns silently; with a publish context it now diffs old vs new (ingest's
+// `findOrCreateParticipantRecord` precedent) and emits `participant:updated`
+// on the triggering inbox's lens channels — and ONLY on a real change.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  previousRow: null as Record<string, unknown> | null,
+  returnedRow: {} as Record<string, unknown>,
+  selectCalls: 0,
+}))
+
+vi.mock('@auxx/database', async () => {
+  const { createChainableDatabaseMock, createSchemaMock } = await import('../../test/database-mock')
+  // `database` must be chainable, not `{}` — modules in this graph build
+  // prepared statements at module scope and would throw during collection.
+  return { schema: createSchemaMock(), database: createChainableDatabaseMock() }
+})
+
+// Partial mock, never a full replacement: the module graph behind
+// `participant-service` reaches `getTableColumns` (media-asset-service via the
+// cache providers), and a full replacement dies at COLLECTION rather than at an
+// assertion.
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('drizzle-orm')>()
+  const passthrough = (...a: unknown[]) => a as never
+  return { ...actual, and: passthrough, eq: passthrough, inArray: passthrough, isNull: passthrough }
+})
+
+// Keep the classifier away from the org cache — internal/external is not what
+// is under test, and the real one lazy-imports `../cache`.
+vi.mock('../classify-internal', () => ({
+  classifyIsInternal: vi.fn(async () => false),
+}))
+
+// Same full replacement the ingest publish tests use — the realtime barrel is
+// reached lazily from `publishParticipantPatch`.
+vi.mock('../../realtime', () => ({
+  getRealtimeService: () => ({}),
+  publishParticipantUpdated: vi.fn(),
+}))
+
+import { publishParticipantUpdated } from '../../realtime'
+import { ParticipantService } from '../participant-service'
+
+const publishSpy = vi.mocked(publishParticipantUpdated)
+
+function makeService() {
+  const db = {
+    select: () => {
+      h.selectCalls += 1
+      return {
+        from: () => ({
+          where: () => ({
+            limit: async () => (h.previousRow ? [h.previousRow] : []),
+          }),
+        }),
+      }
+    },
+    insert: () => ({
+      values: () => ({
+        onConflictDoUpdate: () => ({ returning: async () => [h.returnedRow] }),
+      }),
+    }),
+  } as any
+  return new ParticipantService('org_1', db)
+}
+
+function returnedRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'part_1',
+    identifier: 'anna@example.com',
+    identifierType: 'EMAIL',
+    name: 'Anna Klooth',
+    displayName: 'Anna Klooth',
+    initials: 'AK',
+    isInternal: false,
+    entityInstanceId: 'contact_1',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  publishSpy.mockReset()
+  h.previousRow = null
+  h.returnedRow = returnedRow()
+  h.selectCalls = 0
+})
+
+const INPUT = {
+  identifier: 'anna@example.com',
+  identifierType: 'EMAIL' as never,
+  name: 'Anna Klooth',
+}
+
+describe('findOrCreateParticipant participant:updated emission', () => {
+  it('publishes the changed columns on the given inbox when a tracked column changed', async () => {
+    h.previousRow = { name: 'Anna', displayName: 'Anna', isInternal: false }
+
+    const participant = await makeService().findOrCreateParticipant(INPUT, {
+      inboxId: 'inbox_1',
+      excludeSocketId: 'sock_1',
+    })
+
+    expect(participant.id).toBe('part_1')
+    expect(publishSpy).toHaveBeenCalledTimes(1)
+    expect(publishSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'org_1',
+      {
+        participantId: 'part_1',
+        patch: { name: 'Anna Klooth', displayName: 'Anna Klooth' },
+        inboxId: 'inbox_1',
+      },
+      { excludeSocketId: 'sock_1' }
+    )
+  })
+
+  it('does NOT publish when nothing changed', async () => {
+    h.previousRow = { name: 'Anna Klooth', displayName: 'Anna Klooth', isInternal: false }
+
+    await makeService().findOrCreateParticipant(INPUT, { inboxId: 'inbox_1' })
+
+    expect(publishSpy).not.toHaveBeenCalled()
+  })
+
+  it('does NOT publish for a brand-new row (no previous state)', async () => {
+    h.previousRow = null
+
+    await makeService().findOrCreateParticipant(INPUT, { inboxId: 'inbox_1' })
+
+    expect(publishSpy).not.toHaveBeenCalled()
+  })
+
+  it('stays fully silent without a publish context — no pre-select, no event', async () => {
+    h.previousRow = { name: 'Anna', displayName: 'Anna', isInternal: false }
+
+    await makeService().findOrCreateParticipant(INPUT)
+
+    expect(h.selectCalls).toBe(0)
+    expect(publishSpy).not.toHaveBeenCalled()
+  })
+
+  it('publishes an isInternal flip even when the label is unchanged', async () => {
+    h.previousRow = { name: 'Anna Klooth', displayName: 'Anna Klooth', isInternal: true }
+    h.returnedRow = returnedRow({ isInternal: false })
+
+    await makeService().findOrCreateParticipant(INPUT, { inboxId: 'inbox_1' })
+
+    expect(publishSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'org_1',
+      expect.objectContaining({ patch: { isInternal: false } }),
+      undefined
+    )
+  })
+
+  it('a publish failure never fails the upsert', async () => {
+    h.previousRow = { name: 'Anna', displayName: 'Anna', isInternal: false }
+    publishSpy.mockRejectedValueOnce(new Error('realtime down'))
+
+    const participant = await makeService().findOrCreateParticipant(INPUT, { inboxId: 'inbox_1' })
+
+    expect(participant.id).toBe('part_1')
+  })
+})

--- a/packages/lib/src/participants/__tests__/publish-participant-changes.test.ts
+++ b/packages/lib/src/participants/__tests__/publish-participant-changes.test.ts
@@ -1,0 +1,113 @@
+// packages/lib/src/participants/__tests__/publish-participant-changes.test.ts
+//
+// contact-name-precedence plan Phase 5 — the shared diff-then-publish contract
+// for the non-ingest participant write paths. The diff decides WHAT changed;
+// `publishParticipantPatch` reuses the existing inbox-lens fanout
+// (`publishParticipantUpdated`) and must never throw into the caller's path.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../realtime', () => ({
+  getRealtimeService: () => ({}),
+  publishParticipantUpdated: vi.fn(),
+}))
+
+import { publishParticipantUpdated } from '../../realtime'
+import { diffParticipantNamePatch, publishParticipantPatch } from '../publish-participant-changes'
+
+const publishSpy = vi.mocked(publishParticipantUpdated)
+
+beforeEach(() => {
+  publishSpy.mockReset()
+})
+
+describe('diffParticipantNamePatch', () => {
+  it('returns an empty patch when nothing changed', () => {
+    const row = { name: 'Anna', displayName: 'Anna', isInternal: false }
+    expect(diffParticipantNamePatch(row, { ...row })).toEqual({})
+  })
+
+  it('carries only the columns that actually changed', () => {
+    const patch = diffParticipantNamePatch(
+      { name: null, displayName: '+18889155797', isInternal: false },
+      { name: 'Bruno', displayName: 'Bruno', isInternal: false }
+    )
+    expect(patch).toEqual({ name: 'Bruno', displayName: 'Bruno' })
+  })
+
+  it('maps a null next displayName to undefined (realtime field shape)', () => {
+    const patch = diffParticipantNamePatch(
+      { name: null, displayName: 'x' },
+      { name: null, displayName: null }
+    )
+    expect(patch).toEqual({ displayName: undefined })
+    expect('displayName' in patch).toBe(true)
+  })
+
+  it('compares isInternal only when the write recomputed it', () => {
+    // Callers that never touch isInternal (visitor identity, passport) omit it.
+    expect(
+      diffParticipantNamePatch(
+        { name: 'A', displayName: 'A', isInternal: true },
+        { name: 'A', displayName: 'A' }
+      )
+    ).toEqual({})
+    expect(
+      diffParticipantNamePatch(
+        { name: 'A', displayName: 'A', isInternal: false },
+        { name: 'A', displayName: 'A', isInternal: true }
+      )
+    ).toEqual({ isInternal: true })
+  })
+})
+
+describe('publishParticipantPatch', () => {
+  it('publishes through the shared inbox-lens fanout', async () => {
+    await publishParticipantPatch({
+      organizationId: 'org_1',
+      participantId: 'part_1',
+      patch: { name: 'Bruno' },
+      inboxId: 'inbox_1',
+      excludeSocketId: 'sock_1',
+    })
+
+    expect(publishSpy).toHaveBeenCalledTimes(1)
+    expect(publishSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'org_1',
+      { participantId: 'part_1', patch: { name: 'Bruno' }, inboxId: 'inbox_1' },
+      { excludeSocketId: 'sock_1' }
+    )
+  })
+
+  it('defaults a missing inboxId to null (admin-only `none` channel)', async () => {
+    await publishParticipantPatch({
+      organizationId: 'org_1',
+      participantId: 'part_1',
+      patch: { displayName: 'Bruno' },
+    })
+
+    expect(publishSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'org_1',
+      expect.objectContaining({ inboxId: null }),
+      undefined
+    )
+  })
+
+  it('no-ops on an empty patch', async () => {
+    await publishParticipantPatch({ organizationId: 'org_1', participantId: 'part_1', patch: {} })
+    expect(publishSpy).not.toHaveBeenCalled()
+  })
+
+  it('never throws when the underlying publish fails', async () => {
+    publishSpy.mockRejectedValueOnce(new Error('realtime down'))
+    await expect(
+      publishParticipantPatch({
+        organizationId: 'org_1',
+        participantId: 'part_1',
+        patch: { name: 'Bruno' },
+      })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/lib/src/participants/display-info.ts
+++ b/packages/lib/src/participants/display-info.ts
@@ -1,0 +1,51 @@
+// packages/lib/src/participants/display-info.ts
+
+import { generateVisitorName } from '../chat/visitor-naming'
+
+/**
+ * Compute the display name + initials for a participant from its stored
+ * columns — THE read-time repair for participant labels.
+ *
+ * For anonymous chat visitors the raw identifier is an opaque session UUID, so
+ * when there's no name we surface the friendly `Cyan Turtle` handle instead of
+ * the uuid. Callers should always prefer this over the persisted `displayName`
+ * column: legacy CHAT_VISITOR rows have the raw session uuid stored there, and
+ * the column is nullable besides. `ParticipantService.getParticipantMetaBatch`
+ * and the search router both route through this so every surface repairs
+ * identically.
+ */
+export function calculateParticipantDisplayInfo(
+  name?: string | null,
+  identifier?: string | null,
+  identifierType?: string | null
+): {
+  displayName: string
+  initials: string
+} {
+  const validName = name?.trim()
+  const trimmedIdentifier = identifier?.trim()
+  const identifierFallback =
+    identifierType === 'CHAT_VISITOR' && trimmedIdentifier
+      ? generateVisitorName(trimmedIdentifier)
+      : (trimmedIdentifier ?? 'Unknown')
+  const validIdentifier = identifierFallback
+  const displayName = validName || validIdentifier
+  let initials = '?'
+  if (validName) {
+    const nameParts = validName.split(' ').filter(Boolean)
+    if (nameParts.length > 1) {
+      initials =
+        `${nameParts[0]?.[0] ?? ''}${nameParts[nameParts.length - 1]?.[0] ?? ''}`.toUpperCase()
+    } else if (nameParts.length === 1) {
+      initials = (nameParts[0]?.[0] ?? '').toUpperCase()
+    }
+  } else if (validIdentifier) {
+    initials = (validIdentifier[0] ?? '?').toUpperCase()
+    if (validIdentifier.includes('@')) {
+      initials = (validIdentifier.split('@')[0]?.[0] ?? '?').toUpperCase()
+    }
+  }
+  if (initials.length > 2) initials = initials.substring(0, 2)
+  if (!initials || initials === '?') initials = displayName[0]?.toUpperCase() ?? '?'
+  return { displayName, initials }
+}

--- a/packages/lib/src/participants/index.ts
+++ b/packages/lib/src/participants/index.ts
@@ -7,6 +7,7 @@ export {
   type ParticipantMeta,
   usableContactName,
 } from './client'
+export { calculateParticipantDisplayInfo } from './display-info'
 export {
   type ContactIdentifier,
   type ListContactIdentifiersParams,
@@ -15,3 +16,9 @@ export {
 } from './list-contact-identifiers'
 export { type EnsureContactResult, ensureContactForParticipant } from './participant-queries'
 export { type FindOrCreateParticipantInput, ParticipantService } from './participant-service'
+export {
+  diffParticipantNamePatch,
+  type ParticipantNameColumns,
+  type ParticipantPublishContext,
+  publishParticipantPatch,
+} from './publish-participant-changes'

--- a/packages/lib/src/participants/participant-service.ts
+++ b/packages/lib/src/participants/participant-service.ts
@@ -6,9 +6,14 @@ import { createScopedLogger } from '@auxx/logger'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { identifierTypeForProvider } from '../channels/capabilities'
 import { getIdentifier } from '../channels/internal/identifier'
-import { generateVisitorName } from '../chat/visitor-naming'
 import { classifyIsInternal } from './classify-internal'
 import { type ParticipantIdentifierType, type ParticipantMeta, usableContactName } from './client'
+import { calculateParticipantDisplayInfo } from './display-info'
+import {
+  diffParticipantNamePatch,
+  type ParticipantPublishContext,
+  publishParticipantPatch,
+} from './publish-participant-changes'
 
 const logger = createScopedLogger('participant-service')
 
@@ -64,11 +69,10 @@ export class ParticipantService {
   /**
    * Calculates display name and initials for a participant.
    *
-   * For anonymous chat visitors the raw identifier is an opaque session UUID,
-   * so when there's no name we surface the friendly `Chat user #xxxx` handle
-   * instead. This is the single source of truth — every consumer that reads
-   * `ParticipantMeta.displayName` gets the correct label without needing its
-   * own fallback chain.
+   * Delegates to the exported {@link calculateParticipantDisplayInfo} — the
+   * single source of truth shared with the search router — so every consumer
+   * that reads `ParticipantMeta.displayName` gets the correct label (friendly
+   * chat-visitor handles included) without needing its own fallback chain.
    */
   private _calculateDisplayInfo(
     name?: string | null,
@@ -78,32 +82,7 @@ export class ParticipantService {
     displayName: string
     initials: string
   } {
-    const validName = name?.trim()
-    const trimmedIdentifier = identifier?.trim()
-    const identifierFallback =
-      identifierType === 'CHAT_VISITOR' && trimmedIdentifier
-        ? generateVisitorName(trimmedIdentifier)
-        : (trimmedIdentifier ?? 'Unknown')
-    const validIdentifier = identifierFallback
-    const displayName = validName || validIdentifier
-    let initials = '?'
-    if (validName) {
-      const nameParts = validName.split(' ').filter(Boolean)
-      if (nameParts.length > 1) {
-        initials =
-          `${nameParts[0]?.[0] ?? ''}${nameParts[nameParts.length - 1]?.[0] ?? ''}`.toUpperCase()
-      } else if (nameParts.length === 1) {
-        initials = (nameParts[0]?.[0] ?? '').toUpperCase()
-      }
-    } else if (validIdentifier) {
-      initials = (validIdentifier[0] ?? '?').toUpperCase()
-      if (validIdentifier.includes('@')) {
-        initials = (validIdentifier.split('@')[0]?.[0] ?? '?').toUpperCase()
-      }
-    }
-    if (initials.length > 2) initials = initials.substring(0, 2)
-    if (!initials || initials === '?') initials = displayName[0]?.toUpperCase() ?? '?'
-    return { displayName, initials }
+    return calculateParticipantDisplayInfo(name, identifier, identifierType)
   }
 
   /**
@@ -111,11 +90,21 @@ export class ParticipantService {
    * Ensures the participant is linked to the correct organization.
    * Normalizes email identifiers to lowercase.
    *
+   * When `publish` is supplied, tracked column changes (name / displayName /
+   * isInternal) on an EXISTING row emit `participant:updated` on the given
+   * inbox's lens channels — same diff-then-publish contract as ingest's
+   * `findOrCreateParticipantRecord`. Callers with no inbox context omit it and
+   * stay silent; publish failures never propagate.
+   *
    * @param input - The participant identifier, type, and optional name.
+   * @param publish - Optional realtime routing context (triggering inbox).
    * @returns The found or created Participant record.
    * @throws Error if input is invalid or database operation fails.
    */
-  async findOrCreateParticipant(input: FindOrCreateParticipantInput): Promise<ParticipantEntity> {
+  async findOrCreateParticipant(
+    input: FindOrCreateParticipantInput,
+    publish?: ParticipantPublishContext
+  ): Promise<ParticipantEntity> {
     let { identifier, identifierType, name } = input
     if (!identifier || !identifierType) {
       throw new Error('Identifier and identifierType are required.')
@@ -134,6 +123,32 @@ export class ParticipantService {
     try {
       const { displayName, initials } = this._calculateDisplayInfo(name, identifier, identifierType)
       const isInternal = await this._classifyIsInternal(identifier, identifierType)
+
+      // Capture pre-upsert state so tracked column changes can emit
+      // `participant:updated` (ingest precedent: a cheap point-lookup on the
+      // unique index). Skipped entirely for silent callers.
+      let previous:
+        | { name: string | null; displayName: string | null; isInternal: boolean | null }
+        | undefined
+      if (publish) {
+        const rows = await this.db
+          .select({
+            name: schema.Participant.name,
+            displayName: schema.Participant.displayName,
+            isInternal: schema.Participant.isInternal,
+          })
+          .from(schema.Participant)
+          .where(
+            and(
+              eq(schema.Participant.organizationId, this.organizationId),
+              eq(schema.Participant.identifier, identifier),
+              eq(schema.Participant.identifierType, identifierType)
+            )
+          )
+          .limit(1)
+        previous = rows[0]
+      }
+
       const updateValues: Record<string, unknown> = {
         ...(name !== undefined && { name: name }),
         ...(displayName !== undefined && { displayName: displayName }),
@@ -166,6 +181,27 @@ export class ParticipantService {
         })
         .returning()
 
+      // Emit only when this was an UPDATE (previous row existed) AND a tracked
+      // column actually changed — new rows don't get an event, matching ingest
+      // (the FE looks them up on demand). Fire-and-forget: the helper swallows
+      // publish failures so a realtime hiccup can never fail a send.
+      if (publish && previous && participant) {
+        const patch = diffParticipantNamePatch(previous, {
+          name: participant.name,
+          displayName: participant.displayName,
+          isInternal: participant.isInternal,
+        })
+        if (Object.keys(patch).length > 0) {
+          await publishParticipantPatch({
+            organizationId: this.organizationId,
+            participantId: participant.id,
+            patch,
+            inboxId: publish.inboxId,
+            excludeSocketId: publish.excludeSocketId,
+          })
+        }
+      }
+
       if (!participant!.entityInstanceId) {
         logger.debug(`Participant ${participant!.id} created/found without entity instance link.`)
       }
@@ -195,7 +231,10 @@ export class ParticipantService {
    * @returns The found or created Participant record for the user.
    * @throws Error if the user is not found, doesn't belong to the organization, or lacks an email.
    */
-  async findOrCreateParticipantForUser(userId: string): Promise<ParticipantEntity> {
+  async findOrCreateParticipantForUser(
+    userId: string,
+    publish?: ParticipantPublishContext
+  ): Promise<ParticipantEntity> {
     logger.debug('Finding or creating participant for user', {
       userId,
       organizationId: this.organizationId,
@@ -227,11 +266,14 @@ export class ParticipantService {
       throw new Error(`User ${userId} lacks required email address.`)
     }
     try {
-      const participant = await this.findOrCreateParticipant({
-        identifier: user.email,
-        identifierType: 'EMAIL' as IdentifierType,
-        name: user.name,
-      })
+      const participant = await this.findOrCreateParticipant(
+        {
+          identifier: user.email,
+          identifierType: 'EMAIL' as IdentifierType,
+          name: user.name,
+        },
+        publish
+      )
       logger.info('Successfully found/created participant for user', {
         userId,
         participantId: participant.id,
@@ -278,7 +320,8 @@ export class ParticipantService {
    * @returns The channel-identity Participant, or null to fall back.
    */
   async findOrCreateParticipantForIntegration(
-    integrationId: string
+    integrationId: string,
+    publish?: ParticipantPublishContext
   ): Promise<ParticipantEntity | null> {
     const [integration] = await this.db
       .select({
@@ -319,11 +362,14 @@ export class ParticipantService {
     })
     if (!identifier) return null
 
-    return this.findOrCreateParticipant({
-      identifier,
-      identifierType: identifierType as IdentifierType,
-      name: integration.name,
-    })
+    return this.findOrCreateParticipant(
+      {
+        identifier,
+        identifierType: identifierType as IdentifierType,
+        name: integration.name,
+      },
+      publish
+    )
   }
 
   /**

--- a/packages/lib/src/participants/publish-participant-changes.ts
+++ b/packages/lib/src/participants/publish-participant-changes.ts
@@ -1,0 +1,86 @@
+// packages/lib/src/participants/publish-participant-changes.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import type { ParticipantMeta as RealtimeParticipantMeta } from '../realtime/events'
+
+const logger = createScopedLogger('participant-publish')
+
+/**
+ * The name-bearing `Participant` columns the non-ingest write paths can change.
+ * Ingest's own diff (`ingest/participants/find-or-create.ts`) additionally
+ * tracks `hasReceivedMessage` / `lastSentMessageAt`; the composer and chat
+ * identity paths never touch those.
+ */
+export interface ParticipantNameColumns {
+  name: string | null
+  displayName: string | null
+  isInternal?: boolean | null
+}
+
+/**
+ * Routing context for a `participant:updated` publish — the inbox whose lens
+ * channels receive the event (mail-permissions §6.2). `inboxId: null` falls
+ * back to the admin-only `none` channel, same as ingest.
+ */
+export interface ParticipantPublishContext {
+  inboxId: string | null
+  /** Originating socket id for self-echo suppression. */
+  excludeSocketId?: string
+}
+
+/**
+ * Diff the tracked name columns of a participant row before/after a write into
+ * a partial `participant:updated` patch. Empty object = nothing changed, don't
+ * publish. Same column semantics as ingest's inline diff: `displayName` maps
+ * null → undefined (the realtime field is `string | undefined`), and
+ * `isInternal` is only compared when the write actually recomputed it.
+ */
+export function diffParticipantNamePatch(
+  previous: ParticipantNameColumns,
+  next: ParticipantNameColumns
+): Partial<RealtimeParticipantMeta> {
+  const patch: Partial<RealtimeParticipantMeta> = {}
+  if (next.name !== previous.name) patch.name = next.name
+  if (next.displayName !== previous.displayName) {
+    patch.displayName = next.displayName ?? undefined
+  }
+  if (next.isInternal != null && next.isInternal !== previous.isInternal) {
+    patch.isInternal = next.isInternal
+  }
+  return patch
+}
+
+/**
+ * Fire-and-forget `participant:updated` publish through the shared inbox-lens
+ * fanout ({@link import('../realtime').publishParticipantUpdated}). Never
+ * throws into the caller's path — a realtime hiccup must not fail a send or a
+ * chat identity claim. No-ops on an empty patch.
+ *
+ * The realtime barrel is imported lazily on purpose: a static import from this
+ * low-level module widens the graph into the cache/kopilot cycle and silently
+ * breaks `vi.mock` interception in lib test suites.
+ */
+export async function publishParticipantPatch(args: {
+  organizationId: string
+  participantId: string
+  patch: Partial<RealtimeParticipantMeta>
+  inboxId?: string | null
+  excludeSocketId?: string
+}): Promise<void> {
+  if (Object.keys(args.patch).length === 0) return
+  try {
+    const { getRealtimeService, publishParticipantUpdated } = await import('../realtime')
+    await publishParticipantUpdated(
+      getRealtimeService(),
+      args.organizationId,
+      { participantId: args.participantId, patch: args.patch, inboxId: args.inboxId ?? null },
+      args.excludeSocketId ? { excludeSocketId: args.excludeSocketId } : undefined
+    )
+  } catch (error) {
+    logger.warn('participant:updated publish failed (ignored)', {
+      participantId: args.participantId,
+      organizationId: args.organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}


### PR DESCRIPTION
## Summary

Phase 5 of `plans/participants/contact-name-precedence.md` (phases 1–4 landed in #1691). Until now only ingest published `participant:updated`, so composer sends and chat visitor identity claims mutated participant names silently — open clients held a stale participant until remount. These paths now diff-and-publish through the same inbox-lens fanout ingest uses.

## How

- **Shared plumbing** — new `publish-participant-changes.ts`: `diffParticipantNamePatch` (name / displayName / isInternal, same diff semantics as ingest's inline version) + `publishParticipantPatch`, fire-and-forget through the existing `publishParticipantUpdated` fanout. Empty patch no-ops; a publish failure logs and never fails the send or the identity claim; the realtime barrel is lazy-imported (known vi.mock cycle).
- **Composer** — `findOrCreateParticipant` takes an optional `publish` context (silent callers pay nothing, not even the pre-select). `MessageSenderService.processParticipants` passes `{ inboxId, excludeSocketId }` to all three upserts (FROM-integration, FROM-user, to/cc/bcc). To carry the inbox there, `ThreadContext` gains `inboxId`, populated on all three paths of `getOrCreateThreadForSending`.
- **Chat identity** — `updateVisitorClaimedIdentity` pre-reads, diffs, and publishes on the thread's inbox (`visitor-info.ts` resolves it); `passport.ts`'s verified-JWT write publishes inside its existing best-effort catch, so token minting is never blocked. `chat/outbound.ts` stays silent by design — it has no inbox at hand and the same send immediately re-upserts with context via `processParticipants`.
- **Search repair** — the private `_calculateDisplayInfo` is promoted to exported `calculateParticipantDisplayInfo`; `search.participants` and the suggestion labels now emit `usableContactName || repaired displayName`, so NULL rows and raw CHAT_VISITOR uuids render the friendly handle, consistent with `getParticipantMetaBatch`.
- **Test fix** — `search-participant-gate.test.ts` was failing at collection since #1691 (barrel import reaches module-scope `sql.raw`; the drizzle mock lacked `sql`/`isNull`). Mock extended; 17/17 pass again.

## Notes for review

- No org-wide fanout anywhere — publishes happen only where inbox context genuinely exists, per the plan's routing decision.
- Pre-existing quirk left as-is (out of scope): the composer path can still downgrade `displayName` to the bare identifier when a send carries no name (ingest is upgrade-only, the composer isn't); the publish honestly mirrors whatever the DB write did.
- `packages/lib/package.json` diff is codegen (`pnpm generate:exports`).

## Testing

- 32 new tests: publish-on-real-change-only, unchanged/new-row/no-context silence, isInternal-only flips, publish-failure never throws, search repair (NULL / CHAT_VISITOR uuid / contact-name precedence / suggestion-label consistency)
- lib participants 127/127, messages+chat 84/84, ingest participant suites green, web search 22/22
- Scoped typechecks clean in all touched files (lib, api, web)