### PR TITLE
fix(participants): composer upsert never downgrades a known name

### DIFF
--- a/packages/lib/src/participants/__tests__/participant-service-publish.test.ts
+++ b/packages/lib/src/participants/__tests__/participant-service-publish.test.ts
@@ -12,6 +12,7 @@ const h = vi.hoisted(() => ({
   previousRow: null as Record<string, unknown> | null,
   returnedRow: {} as Record<string, unknown>,
   selectCalls: 0,
+  lastConflictSet: null as Record<string, unknown> | null,
 }))
 
 vi.mock('@auxx/database', async () => {
@@ -63,7 +64,10 @@ function makeService() {
     },
     insert: () => ({
       values: () => ({
-        onConflictDoUpdate: () => ({ returning: async () => [h.returnedRow] }),
+        onConflictDoUpdate: (args: { set: Record<string, unknown> }) => {
+          h.lastConflictSet = args.set
+          return { returning: async () => [h.returnedRow] }
+        },
       }),
     }),
   } as any
@@ -89,6 +93,7 @@ beforeEach(() => {
   h.previousRow = null
   h.returnedRow = returnedRow()
   h.selectCalls = 0
+  h.lastConflictSet = null
 })
 
 const INPUT = {
@@ -157,6 +162,36 @@ describe('findOrCreateParticipant participant:updated emission', () => {
       expect.objectContaining({ patch: { isInternal: false } }),
       undefined
     )
+  })
+
+  it('a nameless input never downgrades the name trio on conflict (upgrade-only)', async () => {
+    // The chips send `name: null` for a raw typed/pasted address — the
+    // conflict-set must leave name/displayName/initials untouched (ingest's
+    // rule), and with nothing overwritten there is nothing to publish.
+    h.previousRow = { name: 'Anna Klooth', displayName: 'Anna Klooth', isInternal: false }
+
+    await makeService().findOrCreateParticipant(
+      { identifier: 'anna@example.com', identifierType: 'EMAIL' as never, name: null },
+      { inboxId: 'inbox_1' }
+    )
+
+    expect(h.lastConflictSet).not.toHaveProperty('name')
+    expect(h.lastConflictSet).not.toHaveProperty('displayName')
+    expect(h.lastConflictSet).not.toHaveProperty('initials')
+    expect(h.lastConflictSet).toHaveProperty('isInternal')
+    expect(publishSpy).not.toHaveBeenCalled()
+  })
+
+  it('a usable name still overwrites the trio together on conflict', async () => {
+    h.previousRow = { name: 'Anna', displayName: 'Anna', isInternal: false }
+
+    await makeService().findOrCreateParticipant(INPUT, { inboxId: 'inbox_1' })
+
+    expect(h.lastConflictSet).toMatchObject({
+      name: 'Anna Klooth',
+      displayName: 'Anna Klooth',
+      initials: 'AK',
+    })
   })
 
   it('a publish failure never fails the upsert', async () => {

--- a/packages/lib/src/participants/participant-service.ts
+++ b/packages/lib/src/participants/participant-service.ts
@@ -149,10 +149,16 @@ export class ParticipantService {
         previous = rows[0]
       }
 
+      // Never downgrade a known name to a bare address — ingest's rule
+      // (`ingest/participants/find-or-create.ts`): the name trio only
+      // overwrites when this write actually carries a usable name. A raw
+      // typed/pasted address (the chips send `name: null`) leaves the row's
+      // best-known name untouched; the insert branch below still gets the
+      // identifier-fallback displayName for brand-new rows. This also means
+      // the diff-then-publish underneath can never emit a name downgrade.
+      const hasUsableName = !!name?.trim()
       const updateValues: Record<string, unknown> = {
-        ...(name !== undefined && { name: name }),
-        ...(displayName !== undefined && { displayName: displayName }),
-        ...(initials !== undefined && { initials: initials }),
+        ...(hasUsableName && { name, displayName, initials }),
         // Recomputed on every upsert — see the matching note in
         // `ingest/participants/find-or-create.ts`. Derived from org config, not
         // from message content, so last-writer-wins is always an improvement.


### PR DESCRIPTION
## Summary

Closes out the quirk noted in #1694: the composer's `findOrCreateParticipant` unconditionally overwrote `displayName`/`initials` on conflict — and nulled `name` when the recipient chip sent an explicit `name: null` for a raw typed/pasted address. Sending to a known participant without picking a named suggestion downgraded their stored label to the bare identifier, and since #1694 the diff-then-publish broadcast that downgrade live to every open client.

## How

Adopts ingest's upgrade-only rule (`ingest/participants/find-or-create.ts`) in the composer upsert's conflict-`set`:

```ts
const hasUsableName = !!name?.trim()
...(hasUsableName && { name, displayName, initials }),
```

- A nameless write leaves the row's best-known name trio untouched; a usable name still overwrites all three together (preserving the schema's written-together invariant).
- Brand-new rows keep the identifier-fallback `displayName` from the insert branch.
- `isInternal` stays unconditional last-writer-wins (derived from org config, not message content).
- The #1694 diff-then-publish is now structurally incapable of emitting a name downgrade — the columns can no longer move in that direction.

No legitimate caller relied on the downgrade: there is no UI for editing participant names directly; contact rename (the record lane, #1691) is the correction path.

## Testing

- Two new tests assert the captured conflict-`set` directly: nameless input touches none of the trio (and publishes nothing); named input overwrites all three together.
- lib participants suite 129/129; biome clean; scoped typecheck clean in touched files.