### PR TITLE
feat(kbar): weight palette scoring and flatten search results

### DIFF
--- a/apps/web/src/components/kbar/__tests__/palette-ranking.test.tsx
+++ b/apps/web/src/components/kbar/__tests__/palette-ranking.test.tsx
@@ -1,0 +1,142 @@
+// apps/web/src/components/kbar/__tests__/palette-ranking.test.tsx
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { RootPage } from '../pages/root'
+import { createPaletteFilter, scorePaletteAction } from '../score'
+import type { PaletteAction, PaletteSection } from '../types'
+
+// base-ui's ScrollArea (inside CommandList) does `new IntersectionObserver(...)`,
+// and the global setup stubs it as a plain `vi.fn()` returning an object literal —
+// not a constructor. Same workaround the other palette/picker tests carry.
+class NoopIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return []
+  }
+}
+vi.stubGlobal('IntersectionObserver', NoopIntersectionObserver)
+
+vi.mock('../contextual/select-contextual', () => ({ useContextualSections: () => [] }))
+vi.mock('../store', () => ({
+  useCommandPaletteStore: Object.assign(
+    (selector: (s: { goTo: () => void }) => unknown) => selector({ goTo: () => {} }),
+    { getState: () => ({ goTo: () => {}, close: () => {} }) }
+  ),
+}))
+
+const action = (partial: Partial<PaletteAction> & Pick<PaletteAction, 'id' | 'label'>) => ({
+  perform: () => {},
+  ...partial,
+})
+
+const THEME_DARK = action({
+  id: 'theme.dark',
+  label: 'Set Dark Theme',
+  keywords: 'dark theme',
+})
+const THEME_TOGGLE = action({
+  id: 'theme.toggle',
+  label: 'Toggle Theme',
+  keywords: 'dark light theme toggle',
+})
+const TICKET_DASHBOARD = action({
+  id: 'nav.tickets.dashboard',
+  label: 'Ticket dashboard',
+  keywords: 'tickets dashboard',
+})
+const INBOX = action({
+  id: 'nav.inbox',
+  label: 'Inbox',
+  subtitle: 'View your inbox',
+  keywords: 'inbox',
+})
+const SEARCH_RECORDS = action({
+  id: 'search-records',
+  label: 'Search records',
+  subtitle: 'Find contacts, companies, tickets, parts…',
+  keywords: 'search records find lookup',
+})
+
+describe('scorePaletteAction', () => {
+  it('ranks the labelled match above the fuzzy one and drops noise', () => {
+    const dark = scorePaletteAction(THEME_DARK, 'dark')
+    const toggle = scorePaletteAction(THEME_TOGGLE, 'dark')
+
+    // Label word-start beats keyword-only — under cmdk's default filter these
+    // tied at exactly 0.8910 and the winner was decided by DOM order.
+    expect(dark).toBeGreaterThan(toggle)
+    expect(toggle).toBeGreaterThan(0)
+
+    // The id is no longer part of the scored text, so `nav.tickets.dashboard`
+    // stops contributing a phantom `dashboard` token.
+    expect(scorePaletteAction(TICKET_DASHBOARD, 'dark')).toBe(0)
+  })
+
+  it('scores an exact label match highest', () => {
+    expect(scorePaletteAction(INBOX, 'inbox')).toBe(1)
+    expect(scorePaletteAction(INBOX, 'inb')).toBe(0.95)
+  })
+
+  it('keeps the search escape hatches visible below every real match', () => {
+    const hatch = scorePaletteAction(SEARCH_RECORDS, 'acme corp')
+    expect(hatch).toBeGreaterThan(0)
+    expect(hatch).toBeLessThan(scorePaletteAction(THEME_DARK, 'dark'))
+  })
+})
+
+describe('createPaletteFilter', () => {
+  it('scores known ids, resolves the recent: prefix, and falls back otherwise', () => {
+    const filter = createPaletteFilter([
+      { action: THEME_DARK },
+      { action: TICKET_DASHBOARD, boost: 1.05 },
+    ])
+
+    expect(filter('theme.dark', 'dark')).toBe(scorePaletteAction(THEME_DARK, 'dark'))
+    expect(filter('recent:theme.dark', 'dark')).toBe(scorePaletteAction(THEME_DARK, 'dark'))
+    expect(filter('nav.tickets.dashboard', 'ticket')).toBeCloseTo(
+      scorePaletteAction(TICKET_DASHBOARD, 'ticket') * 1.05
+    )
+    // Unknown value (cmdk also scores group headings) → default filter, never 0.
+    expect(filter('Navigation', 'nav', [])).toBeGreaterThan(0)
+  })
+})
+
+describe('RootPage ranking', () => {
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = () => {}
+  })
+
+  const sections: PaletteSection[] = [
+    { label: 'Navigation', actions: [INBOX, TICKET_DASHBOARD] },
+    { label: 'Theme', actions: [THEME_TOGGLE, THEME_DARK] },
+  ]
+
+  const visibleValues = () =>
+    Array.from(document.querySelectorAll('[cmdk-item]')).map((el) => el.getAttribute('data-value'))
+
+  it('puts the best match first even though Theme is the last section', async () => {
+    render(<RootPage sections={sections} recentActions={[]} />)
+
+    await userEvent.type(screen.getByPlaceholderText('Type a command or search…'), 'dark')
+
+    const values = visibleValues()
+    expect(values[0]).toBe('theme.dark')
+    expect(values[1]).toBe('theme.toggle')
+    // Noise is gone entirely, escape hatches remain at the bottom.
+    expect(values).not.toContain('nav.tickets.dashboard')
+    expect(values).toContain('search-records')
+  })
+
+  it('keeps sections and Recent on an empty query', () => {
+    render(<RootPage sections={sections} recentActions={[INBOX]} />)
+
+    const headings = Array.from(document.querySelectorAll('[cmdk-group-heading]')).map(
+      (el) => el.textContent
+    )
+    expect(headings).toEqual(['Search', 'Recent', 'Navigation', 'Theme'])
+    expect(visibleValues()).toContain('recent:nav.inbox')
+  })
+})

--- a/apps/web/src/components/kbar/pages/root.tsx
+++ b/apps/web/src/components/kbar/pages/root.tsx
@@ -8,19 +8,38 @@ import {
   CommandInput,
   CommandList,
 } from '@auxx/ui/components/command'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useContextualSections } from '../contextual/select-contextual'
 import { PaletteActionItem } from '../palette-action-item'
 import { useRecentsStore } from '../recents-store'
+import { createPaletteFilter } from '../score'
 import { selectOnEnter } from '../select-on-enter'
 import { useCommandPaletteStore } from '../store'
 import type { PaletteAction, PaletteSection } from '../types'
+
+/** Page-scoped rows take a small edge so they win ties in the flat search list. */
+const CONTEXTUAL_BOOST = 1.05
+
+/** One row in the flat (searching) list. */
+interface FlatEntry {
+  action: PaletteAction
+  boost?: number
+  /** Contextual rows are excluded from recents — their ids are page-ephemeral. */
+  recordRecent: boolean
+}
 
 /**
  * Root page: a single-column, client-filtered action list (cmdk). The first row
  * is "Search records", which drills into the record-search page; everything else
  * is grouped by section (Actions, Navigation, Create, Settings, Theme). On an
  * empty query a "Recent" group surfaces the last-run actions.
+ *
+ * **Sections only survive an empty query.** cmdk cannot reorder groups — its
+ * `sort()` looks a group up by its internal id against a `data-value` that holds
+ * the *heading*, so the selector never matches and groups keep their declared
+ * order no matter how their members score. Item sorting *inside* a group does
+ * work, so as soon as there is a query every row is rendered into one unheaded
+ * group and ranking becomes global. Scoring is ours — see {@link createPaletteFilter}.
  */
 export function RootPage({
   sections,
@@ -38,10 +57,54 @@ export function RootPage({
   const contextualSections = useContextualSections()
 
   const onRun = (action: PaletteAction) => pushRecent(action.id)
-  const showRecents = query.trim() === '' && recentActions.length > 0
+  const searching = query.trim() !== ''
+  const showRecents = !searching && recentActions.length > 0
+
+  const searchActions = useMemo<PaletteAction[]>(
+    () => [
+      {
+        id: 'search-records',
+        label: 'Search records',
+        subtitle: 'Find contacts, companies, tickets, parts…',
+        icon: 'search',
+        keywords: 'search records find lookup',
+        perform: () => goTo('search'),
+      },
+      {
+        id: 'search-threads',
+        label: 'Search threads',
+        subtitle: 'Read mail across every inbox',
+        icon: 'mail',
+        keywords: 'search threads mail email read inbox conversation',
+        perform: () => goTo('search-threads'),
+      },
+    ],
+    [goTo]
+  )
+
+  // Every row the palette can show, de-duped by id (cmdk requires unique values).
+  const flat = useMemo<FlatEntry[]>(() => {
+    const entries: FlatEntry[] = [
+      ...contextualSections.flatMap((section) =>
+        section.actions.map((action) => ({ action, boost: CONTEXTUAL_BOOST, recordRecent: false }))
+      ),
+      ...searchActions.map((action) => ({ action, recordRecent: false })),
+      ...sections.flatMap((section) =>
+        section.actions.map((action) => ({ action, recordRecent: true }))
+      ),
+    ]
+    const seen = new Set<string>()
+    return entries.filter((entry) => {
+      if (seen.has(entry.action.id)) return false
+      seen.add(entry.action.id)
+      return true
+    })
+  }, [contextualSections, searchActions, sections])
+
+  const filter = useMemo(() => createPaletteFilter(flat), [flat])
 
   return (
-    <Command loop onKeyDown={selectOnEnter} className='min-h-0'>
+    <Command loop filter={filter} onKeyDown={selectOnEnter} className='min-h-0'>
       <CommandInput
         value={query}
         onValueChange={setQuery}
@@ -51,62 +114,60 @@ export function RootPage({
       <CommandList scrollAreaClassName='max-h-[min(420px,60vh)] max-sm:min-h-0 max-sm:flex-1 max-sm:max-h-none'>
         <CommandEmpty>No results found.</CommandEmpty>
 
-        {/* Contextual groups — page-ephemeral, excluded from recents (unstable ids). */}
-        {contextualSections.map((section) =>
-          section.actions.length > 0 ? (
-            <CommandGroup key={`ctx:${section.label}`} heading={section.label}>
-              {section.actions.map((action) => (
-                <PaletteActionItem key={action.id} action={action} />
-              ))}
-            </CommandGroup>
-          ) : null
-        )}
-
-        <CommandGroup heading='Search'>
-          <PaletteActionItem
-            action={{
-              id: 'search-records',
-              label: 'Search records',
-              subtitle: 'Find contacts, companies, tickets, parts…',
-              icon: 'search',
-              keywords: 'search records find lookup',
-              perform: () => goTo('search'),
-            }}
-          />
-          <PaletteActionItem
-            action={{
-              id: 'search-threads',
-              label: 'Search threads',
-              subtitle: 'Read mail across every inbox',
-              icon: 'mail',
-              keywords: 'search threads mail email read inbox conversation',
-              perform: () => goTo('search-threads'),
-            }}
-          />
-        </CommandGroup>
-
-        {showRecents && (
-          <CommandGroup heading='Recent'>
-            {recentActions.map((action) => (
-              // Prefix the value so it stays unique vs the same action in its
-              // section group below (cmdk requires unique item values).
+        {searching ? (
+          // One group → one sort container → global ranking.
+          <CommandGroup>
+            {flat.map((entry) => (
               <PaletteActionItem
-                key={`recent:${action.id}`}
-                action={{ ...action, id: `recent:${action.id}` }}
-                onRun={() => onRun(action)}
+                key={entry.action.id}
+                action={entry.action}
+                onRun={entry.recordRecent ? onRun : undefined}
               />
             ))}
           </CommandGroup>
-        )}
+        ) : (
+          <>
+            {/* Contextual groups — page-ephemeral, excluded from recents (unstable ids). */}
+            {contextualSections.map((section) =>
+              section.actions.length > 0 ? (
+                <CommandGroup key={`ctx:${section.label}`} heading={section.label}>
+                  {section.actions.map((action) => (
+                    <PaletteActionItem key={action.id} action={action} />
+                  ))}
+                </CommandGroup>
+              ) : null
+            )}
 
-        {sections.map((section) =>
-          section.actions.length > 0 ? (
-            <CommandGroup key={section.label} heading={section.label}>
-              {section.actions.map((action) => (
-                <PaletteActionItem key={action.id} action={action} onRun={onRun} />
+            <CommandGroup heading='Search'>
+              {searchActions.map((action) => (
+                <PaletteActionItem key={action.id} action={action} />
               ))}
             </CommandGroup>
-          ) : null
+
+            {showRecents && (
+              <CommandGroup heading='Recent'>
+                {recentActions.map((action) => (
+                  // Prefix the value so it stays unique vs the same action in its
+                  // section group below (cmdk requires unique item values).
+                  <PaletteActionItem
+                    key={`recent:${action.id}`}
+                    action={{ ...action, id: `recent:${action.id}` }}
+                    onRun={() => onRun(action)}
+                  />
+                ))}
+              </CommandGroup>
+            )}
+
+            {sections.map((section) =>
+              section.actions.length > 0 ? (
+                <CommandGroup key={section.label} heading={section.label}>
+                  {section.actions.map((action) => (
+                    <PaletteActionItem key={action.id} action={action} onRun={onRun} />
+                  ))}
+                </CommandGroup>
+              ) : null
+            )}
+          </>
         )}
       </CommandList>
     </Command>

--- a/apps/web/src/components/kbar/score.ts
+++ b/apps/web/src/components/kbar/score.ts
@@ -1,0 +1,112 @@
+// apps/web/src/components/kbar/score.ts
+'use client'
+
+import { defaultFilter } from 'cmdk'
+import type { PaletteAction } from './types'
+
+/**
+ * Below this, a fuzzy match is noise rather than a result — `dark` scored
+ * `Ticket dashboard` at 0.026 and `Search records` at 0.005 under cmdk's raw
+ * scorer, and both rendered *above* `Set Dark Theme`. Returning 0 is how the
+ * floor is enforced: cmdk hides zero-scored items and `CommandEmpty` still
+ * counts correctly, so no extra render logic is needed.
+ */
+const FLOOR = 0.1
+
+/** Fuzzy matches are compressed below the deterministic prefix tiers. */
+const FUZZY_SCALE = 0.75
+
+/**
+ * Rows that must survive the floor: with an arbitrary query (`acme corp`) the
+ * palette should still offer a way through to record/thread search instead of
+ * "No results found". The value is low enough that they sink below any real
+ * match.
+ */
+const ALWAYS_VISIBLE_IDS = new Set(['search-records', 'search-threads'])
+const ALWAYS_VISIBLE_MIN = 0.08
+
+/** Matches the `recent:` value prefix the root page uses to keep cmdk values unique. */
+const RECENT_PREFIX = 'recent:'
+
+const WORD_SPLIT = /[\s\-_/.]+/
+
+function words(text: string): string[] {
+  return text.toLowerCase().split(WORD_SPLIT).filter(Boolean)
+}
+
+/**
+ * Score one action against the query.
+ *
+ * Deliberately scores `label` / `keywords` / `subtitle` **separately** rather
+ * than as one flattened blob (which is what cmdk's default filter does with the
+ * `keywords` prop), for two reasons:
+ *
+ * 1. The action id stays out of the scored text. `value` is the id, so under the
+ *    default filter `nav.tickets.dashboard` injects a phantom `dashboard` token —
+ *    that is literally where the `dark` → "Ticket dashboard" match came from.
+ * 2. A subtitle hit no longer counts as much as a label hit.
+ *
+ * The blob is still scored at `×0.4` so cross-field matches keep working, just
+ * ranked below any clean single-field hit.
+ */
+export function scorePaletteAction(action: PaletteAction, query: string): number {
+  const q = query.trim().toLowerCase()
+  if (!q) return 1
+
+  const label = action.label.toLowerCase()
+  if (label === q) return 1
+  if (label.startsWith(q)) return 0.95
+  if (words(action.label).some((word) => word.startsWith(q))) return 0.9
+
+  const keywords = action.keywords ? words(action.keywords) : []
+  if (keywords.includes(q)) return 0.88
+  if (keywords.some((word) => word.startsWith(q))) return 0.86
+
+  if (action.subtitle && words(action.subtitle).some((word) => word.startsWith(q))) return 0.8
+
+  const blob = [action.label, action.subtitle, action.keywords].filter(Boolean).join(' ')
+  const fuzzy = Math.max(
+    defaultFilter(action.label, q),
+    action.keywords ? defaultFilter(action.keywords, q) * 0.7 : 0,
+    action.subtitle ? defaultFilter(action.subtitle, q) * 0.5 : 0,
+    defaultFilter(blob, q) * 0.4
+  )
+
+  const scaled = fuzzy * FUZZY_SCALE
+  if (scaled >= FLOOR) return scaled
+  return ALWAYS_VISIBLE_IDS.has(action.id) ? ALWAYS_VISIBLE_MIN : 0
+}
+
+/** One scoreable row: the action plus an optional final-score multiplier. */
+export interface PaletteScoreEntry {
+  action: PaletteAction
+  /**
+   * Multiplier on the final score. Page-scoped (contextual) rows take a small
+   * edge so they win ties against the static registry — they lose their
+   * `priority` ordering once the list goes flat. cmdk puts no upper bound on
+   * filter scores, so values above 1 are fine.
+   */
+  boost?: number
+}
+
+/**
+ * Build the cmdk `filter` for a rendered set of rows. Works because
+ * `PaletteActionItem` sets `value={action.id}`, so cmdk hands the id straight
+ * back and the full action can be looked up and scored field-by-field.
+ *
+ * Anything not in the set (cmdk also scores group headings) falls back to the
+ * default filter, so an unregistered row can never silently vanish.
+ */
+export function createPaletteFilter(
+  entries: PaletteScoreEntry[]
+): (value: string, search: string, keywords?: string[]) => number {
+  const byId = new Map<string, PaletteScoreEntry>()
+  for (const entry of entries) byId.set(entry.action.id, entry)
+
+  return (value, search, keywords) => {
+    const id = value.startsWith(RECENT_PREFIX) ? value.slice(RECENT_PREFIX.length) : value
+    const entry = byId.get(id)
+    if (!entry) return defaultFilter(value, search, keywords)
+    return scorePaletteAction(entry.action, search) * (entry.boost ?? 1)
+  }
+}


### PR DESCRIPTION
Typing `dark` left **Set Dark Theme** three rows down, under *Search records* and *Ticket dashboard*.

## Why

The score was never the problem — `theme.dark` beat everything else 0.891 to 0.026. **cmdk cannot reorder groups.** Its `sort()` looks a group up by its internal `useId`:

```js
listInnerRef.current?.querySelector(`[cmdk-group=""][data-value="${encodeURIComponent(group[0])}"]`)
```

…but the DOM attribute holds the *heading*. The selector never matches, the optional chain swallows the null, and groups keep declared order however well their members score. Theme is the last section in `usePaletteActions`, so it could never surface. Verified in jsdom — a group scoring 0.891 stayed below one scoring 0.026.

Item sorting *within* a group does work, which is what the fix leans on.

## What changed

- **Flat while searching** — one unheaded `CommandGroup` holds every row when there's a query, so they share a single sort container and ranking goes global. Sections + Recent are untouched on an empty query.
- **Own the score** (`score.ts`) — `value={action.id}` means cmdk hands the id straight back, so the action can be looked up and `label`/`keywords`/`subtitle` weighted separately instead of scored as one blob. That also drops the id from the scored text, which is where the phantom `dashboard` token in `nav.tickets.dashboard` came from. Deterministic tiers first (exact label 1.0 → label prefix 0.95 → label word prefix 0.90 → keyword exact 0.88 → keyword prefix 0.86 → subtitle word prefix 0.80), then weighted fuzzy `max(label, kw×0.7, sub×0.5, blob×0.4) × 0.75`. The blob term keeps today's cross-field matching alive, just ranked below any clean single-field hit.
- **Noise floor** — below 0.1 returns `0`. That *is* the implementation: cmdk hides zero-scored items and `CommandEmpty` still counts correctly, so no extra render logic.

## Measured on the real registry

```
before  0.891 theme.toggle │ 0.891 theme.dark │ 0.026 nav.tickets.dashboard │ 0.005 search-records
after   0.900 theme.dark   │ 0.880 theme.toggle │ 0.080 search-records │ 0.080 search-threads

dash  → 0.950 nav.dashboards │ 0.900 nav.tickets.dashboard │ 0.900 create.dashboard
api   → 0.950 settings.apiKeys │ 0.900 create.apiKey │ 0.466 nav.approvals
inbox → 1.000 nav.inbox │ 0.880 search-threads │ 0.880 nav.approvals
```

The `theme.toggle` / `theme.dark` tie is broken too — both were exactly 0.8910, so DOM order picked the winner.

## Behavior changes worth reviewing

- **Section headings disappear while searching.** Deliberate trade — keeping them means hand-rolling the render loop with `shouldFilter={false}`.
- **`CommandEmpty` is effectively unreachable during search.** `search-records` / `search-threads` are floor-exempt at 0.08, so an unmatched query (`acme corp`) shows those two rather than "No results found". Intended escape hatch, but it's visible.
- Contextual (page-scoped) rows carry a ×1.05 boost so they win ties — they lose their `priority` ordering once the list is flat. cmdk puts no upper bound on filter scores.

## Not in scope

Recency/frequency weighting (`recents-store` keeps ids only, no counts), multi-token AND matching (`toggle dark` still misses "Toggle Theme" — same as today), and a keyword-alias pass (`night mode`, `appearance`, `sign out`).

## Test plan

`pnpm exec vitest run src/components/kbar` — 6 pass: 4 unit on the ladder/filter, 2 jsdom integration. The integration test renders `RootPage` with Theme as the **last** section, types `dark`, and asserts row 1 is `theme.dark`; a second asserts empty-query headings are still `['Search', 'Recent', 'Navigation', 'Theme']`.

Adjacent tests green (`record-drawer-request-access`, `records-view-request-access`, `agent-page-gates`). `tsc` reports nothing new in `components/kbar` — the one `command-palette.tsx` error is pre-existing.

> Note: the new test carries the same local `NoopIntersectionObserver` stub seven other files already do, because `src/test/setup.ts` stubs `IntersectionObserver` as a `vi.fn()` returning an object literal rather than a constructor. Worth hoisting the way `ResizeObserver` already was, but left out of this PR.