### PR TITLE
fix(channels): derive one thread key for facebook/instagram DMs

### DIFF
--- a/apps/web/src/app/api/facebook/webhook/route.ts
+++ b/apps/web/src/app/api/facebook/webhook/route.ts
@@ -2,15 +2,20 @@
 
 import { configService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
-import type { MessageData } from '@auxx/lib/email'
 import { MessageStorageService } from '@auxx/lib/email'
-import type { FacebookIntegrationMetadata } from '@auxx/lib/providers'
+import type {
+  MetaWebhookEnvelope,
+  MetaWebhookMessagingEvent,
+  SocialIntegrationMetadata,
+} from '@auxx/lib/providers/social/types'
+import { convertMetaWebhookEventToMessageData } from '@auxx/lib/providers/social/webhook-message'
 import { metaPreset, verifyWebhook } from '@auxx/lib/webhooks'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, isNull, sql } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 
 const logger = createScopedLogger('facebook-webhook')
+
 /**
  * Handles Facebook webhook verification (GET request).
  */
@@ -20,38 +25,38 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   const token = url.searchParams.get('hub.verify_token')
   const challenge = url.searchParams.get('hub.challenge')
   logger.info('Received Facebook webhook verification request', { mode, token })
-  // Check if mode and token are present
   if (mode && token) {
-    // Check the mode and token sent are correct
     if (
       mode === 'subscribe' &&
       token === configService.get<string>('FACEBOOK_WEBHOOK_VERIFY_TOKEN')
     ) {
-      // Respond with the challenge token from the request
       logger.info('Facebook webhook verification successful.')
       return new NextResponse(challenge, { status: 200 })
-    } else {
-      // Respond with '403 Forbidden' if verify tokens do not match
-      logger.warn('Facebook webhook verification failed: Invalid mode or token.')
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     }
-  } else {
-    logger.warn('Facebook webhook verification failed: Missing mode or token.')
-    return NextResponse.json({ error: 'Bad Request' }, { status: 400 })
+    logger.warn('Facebook webhook verification failed: Invalid mode or token.')
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
+  logger.warn('Facebook webhook verification failed: Missing mode or token.')
+  return NextResponse.json({ error: 'Bad Request' }, { status: 400 })
 }
+
 /**
  * Handles incoming Facebook webhook events (POST request).
+ *
+ * Verify → parse → resolve Integration → convert → store. The conversion itself
+ * lives in `@auxx/lib/providers/social/webhook-message` so the wire format is
+ * unit-testable; this handler only does transport and lookup.
  */
 export async function POST(req: NextRequest): Promise<NextResponse> {
   logger.info('Received Facebook webhook event')
+
   // 1. Verify Request Signature (CRITICAL FOR SECURITY)
   const signature = req.headers.get('x-hub-signature-256')
   if (!signature) {
     logger.error('Missing X-Hub-Signature-256 header. Rejecting request.')
     return NextResponse.json({ error: 'Forbidden: Missing signature' }, { status: 403 })
   }
-  const bodyText = await req.text() // Read body as text for signature verification
+  const bodyText = await req.text()
   const verified = verifyWebhook(metaPreset, {
     rawBody: bodyText,
     headers: { 'x-hub-signature-256': signature },
@@ -62,168 +67,125 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Forbidden: Invalid signature' }, { status: 403 })
   }
   logger.debug('Facebook webhook signature verified successfully.')
+
   // 2. Parse the validated body
-  let payload: any
+  let payload: MetaWebhookEnvelope
   try {
-    payload = JSON.parse(bodyText)
+    payload = JSON.parse(bodyText) as MetaWebhookEnvelope
   } catch (e) {
     logger.error('Failed to parse Facebook webhook payload:', { error: e })
     return NextResponse.json({ error: 'Bad Request: Invalid JSON' }, { status: 400 })
   }
+
   // 3. Process the events
   if (payload.object === 'page') {
     const storageService = new MessageStorageService()
-    // Use Promise.allSettled to process entries concurrently and handle errors gracefully
-    const processingPromises = payload.entry?.map(async (entry: any) => {
-      // Check if entry has messaging events
+    const processingPromises = (payload.entry ?? []).map(async (entry) => {
+      // Post comments / feed activity ride on `entry.changes`, a different envelope
+      // with different identity (comment ids, not PSIDs). We do not subscribe to
+      // `feed` today so this never fires; the branch exists so adding comments is a
+      // filled-in case rather than a restructure. See WS10 of the FB/IG plan.
+      if (entry.changes?.length) {
+        logger.debug('Ignoring Facebook feed/changes event (comments not yet ingested).', {
+          entryId: entry.id,
+          changeCount: entry.changes.length,
+        })
+      }
+
       if (!entry.messaging || !Array.isArray(entry.messaging)) {
         logger.debug('Skipping entry without messaging array.', { entryId: entry.id })
-        return // Skip entries without messaging events
+        return
       }
-      for (const event of entry.messaging) {
-        if (event.message && !event.message.is_echo) {
-          // Process incoming messages (ignore echoes from page)
-          const senderPsid = event.sender.id
-          const recipientPageId = event.recipient.id
-          const timestamp = event.timestamp
-          const messageContent = event.message
-          logger.info(`Processing incoming Facebook message`, {
-            senderPsid,
-            pageId: recipientPageId,
-            mid: messageContent.mid,
-          })
-          // Find the integration associated with the Page ID
-          const [integration] = await db
-            .select({
-              id: schema.Integration.id,
-              organizationId: schema.Integration.organizationId,
-              metadata: schema.Integration.metadata,
-            })
-            .from(schema.Integration)
-            .where(
-              and(
-                eq(schema.Integration.provider, 'facebook'),
-                eq(schema.Integration.enabled, true),
-                sql`${schema.Integration.metadata} ->> 'pageId' = ${recipientPageId}`
-              )
-            )
-            .limit(1)
-          if (!integration) {
-            logger.warn(
-              `No active Facebook integration found for Page ID ${recipientPageId}. Skipping message.`
-            )
-            continue // Skip if no matching integration
-          }
-          // Convert webhook event to MessageData format
-          const messageData = convertWebhookEventToMessageData(
-            event,
-            integration.id,
-            integration.organizationId,
-            integration.metadata as Partial<FacebookIntegrationMetadata> | null // Pass metadata
-          )
-          if (messageData) {
-            try {
-              await storageService.storeMessage(messageData)
-              logger.info(`Successfully stored Facebook message`, {
-                mid: messageContent.mid,
-                integrationId: integration.id,
-              })
-            } catch (storeError: any) {
-              logger.error(`Failed to store Facebook message`, {
-                mid: messageContent.mid,
-                integrationId: integration.id,
-                error: storeError.message,
-              })
-              // Decide if we should throw/retry based on the error (e.g., unique constraint vs. DB down)
-            }
+
+      for (const event of entry.messaging as MetaWebhookMessagingEvent[]) {
+        if (!event.message) {
+          if (event.delivery) {
+            logger.debug('Received delivery confirmation, ignoring.', { event })
+          } else if (event.read) {
+            logger.debug('Received read receipt, ignoring.', { event })
           } else {
-            logger.warn('Failed to convert webhook event to MessageData', { event })
+            logger.debug('Received unhandled Facebook messaging event type:', { event })
           }
-        } else if (event.delivery) {
-          logger.debug('Received delivery confirmation, ignoring.', { event })
-        } else if (event.read) {
-          logger.debug('Received read receipt, ignoring.', { event })
-        } else if (event.message?.is_echo) {
-          logger.debug('Received message echo, ignoring.', { event })
-        } else {
-          logger.debug('Received unhandled Facebook messaging event type:', event)
+          continue
+        }
+
+        // Echoes are the page's own sends played back. Dropped for now — a reply
+        // typed in Meta Business Suite will not appear in Auxx until WS4 decides
+        // the reconciliation policy.
+        if (event.message.is_echo) {
+          logger.debug('Received message echo, ignoring.', { mid: event.message.mid })
+          continue
+        }
+
+        const recipientPageId = event.recipient?.id
+        if (!recipientPageId) {
+          logger.warn('Facebook messaging event has no recipient page id; skipping.', { event })
+          continue
+        }
+
+        // `isNull(deletedAt)`: disconnect is a soft delete, so without this a
+        // disconnected channel keeps ingesting for as long as `enabled` stayed true.
+        const [integration] = await db
+          .select({
+            id: schema.Integration.id,
+            organizationId: schema.Integration.organizationId,
+            metadata: schema.Integration.metadata,
+          })
+          .from(schema.Integration)
+          .where(
+            and(
+              eq(schema.Integration.provider, 'facebook'),
+              eq(schema.Integration.enabled, true),
+              isNull(schema.Integration.deletedAt),
+              sql`${schema.Integration.metadata} ->> 'pageId' = ${recipientPageId}`
+            )
+          )
+          .limit(1)
+
+        if (!integration) {
+          logger.warn(
+            `No active Facebook integration found for Page ID ${recipientPageId}. Skipping message.`
+          )
+          continue
+        }
+
+        const messageData = convertMetaWebhookEventToMessageData({
+          event,
+          integrationId: integration.id,
+          organizationId: integration.organizationId,
+          pageId: recipientPageId,
+          platform: 'facebook',
+          metadata: integration.metadata as SocialIntegrationMetadata | null,
+        })
+
+        if (!messageData) {
+          logger.warn('Failed to convert webhook event to MessageData', { event })
+          continue
+        }
+
+        try {
+          await storageService.storeMessage(messageData)
+          logger.info('Successfully stored Facebook message', {
+            mid: event.message.mid,
+            integrationId: integration.id,
+            externalThreadId: messageData.externalThreadId,
+          })
+        } catch (storeError) {
+          logger.error('Failed to store Facebook message', {
+            mid: event.message.mid,
+            integrationId: integration.id,
+            error: storeError instanceof Error ? storeError.message : String(storeError),
+          })
         }
       }
     })
-    // Wait for all entries to be processed
+
     await Promise.allSettled(processingPromises)
   } else {
     logger.warn(`Received webhook event for unexpected object type: ${payload.object}`)
   }
-  // 4. Respond with 200 OK quickly
-  // Facebook requires a quick response to avoid retries and webhook disabling.
+
+  // 4. Respond with 200 OK quickly — Facebook retries and eventually disables
+  // subscriptions that do not answer fast.
   return NextResponse.json({ status: 'success' }, { status: 200 })
-}
-/**
- * Helper function to convert a Facebook webhook messaging event into MessageData.
- */
-function convertWebhookEventToMessageData(
-  event: any,
-  integrationId: string,
-  organizationId: string,
-  integrationMetadata: Partial<FacebookIntegrationMetadata> | null
-): MessageData | null {
-  try {
-    const senderPsid = event.sender.id
-    const recipientPageId = event.recipient.id
-    const timestamp = event.timestamp
-    const message = event.message
-    const messageId = message.mid
-    const pageName = integrationMetadata?.pageName
-    // Determine direction
-    // This assumes webhooks only receive messages sent TO the page
-    const isInbound = true // Webhook messages are typically inbound
-    const fromParticipant = { name: undefined, identifier: senderPsid } // Name might be fetched later
-    const toParticipant = { name: pageName, identifier: recipientPageId }
-    const text = message.text
-    const attachments = (message.attachments || []).map((att: any) => ({
-      filename: att.payload?.title || att.type || 'attachment',
-      mimeType: att.type,
-      size: 0,
-      inline: false,
-      contentLocation: att.payload?.url,
-    }))
-    const createdTime = new Date(timestamp)
-    const messageData: MessageData = {
-      externalId: messageId,
-      // Need a way to associate with a conversation/thread ID.
-      // Facebook doesn't send conversation ID in message webhook.
-      // We might need to look up conversation based on sender/recipient pair or store it separately.
-      // Using sender PSID as a temporary proxy for thread ID - **THIS IS NOT CORRECT**, needs proper conversation mapping.
-      externalThreadId: senderPsid, // <<< !!! Placeholder - Needs Conversation ID Mapping !!!
-      integrationId: integrationId,
-      // Note: integrationType and messageType removed - derived from Integration.provider
-      organizationId: organizationId,
-      createdTime: createdTime,
-      sentAt: createdTime,
-      receivedAt: createdTime,
-      subject: undefined,
-      from: fromParticipant,
-      to: [toParticipant],
-      cc: [],
-      bcc: [],
-      replyTo: [],
-      // Facebook has no inbound attachment ingestor, so no MessageAttachment rows
-      // are ever created and `providerAttachments` is never populated. Mirrors
-      // FacebookProvider.convertToMessageData — `hasAttachments` is a workflow
-      // trigger filter, so claiming true fires attachment rules for bytes that
-      // were never fetched. The `attachments` local still drives the snippet fallback.
-      hasAttachments: false,
-      textPlain: text,
-      snippet: text ? text.substring(0, 100) : attachments[0]?.filename || '',
-      isInbound: isInbound,
-      metadata: { event: event }, // Store the raw event
-      keywords: [],
-      labelIds: [],
-    }
-    return messageData
-  } catch (error: any) {
-    logger.error('Failed to convert Facebook webhook event', { error: error.message, event })
-    return null
-  }
 }

--- a/apps/web/src/app/api/instagram/webhook/route.ts
+++ b/apps/web/src/app/api/instagram/webhook/route.ts
@@ -2,12 +2,16 @@
 
 import { configService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
-import type { MessageData } from '@auxx/lib/email'
 import { MessageStorageService } from '@auxx/lib/email'
-import type { InstagramIntegrationMetadata } from '@auxx/lib/providers'
+import type {
+  MetaWebhookEnvelope,
+  MetaWebhookMessagingEvent,
+  SocialIntegrationMetadata,
+} from '@auxx/lib/providers/social/types'
+import { convertMetaWebhookEventToMessageData } from '@auxx/lib/providers/social/webhook-message'
 import { metaPreset, verifyWebhook } from '@auxx/lib/webhooks'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, isNull, sql } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 
 const logger = createScopedLogger('instagram-webhook')
@@ -62,9 +66,9 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   logger.debug('Instagram webhook signature verified.')
 
   // 2. Parse Body
-  let payload: any
+  let payload: MetaWebhookEnvelope
   try {
-    payload = JSON.parse(bodyText)
+    payload = JSON.parse(bodyText) as MetaWebhookEnvelope
   } catch (e) {
     logger.error('Failed to parse Instagram webhook payload:', { error: e })
     return NextResponse.json({ error: 'Bad Request: Invalid JSON' }, { status: 400 })
@@ -73,79 +77,93 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   // 3. Process Instagram Events
   if (payload.object === 'instagram') {
     const storageService = new MessageStorageService()
-    const processingPromises = payload.entry?.map(async (entry: any) => {
+    const processingPromises = (payload.entry ?? []).map(async (entry) => {
+      // Comments / mentions ride on `entry.changes`, a different envelope with
+      // different identity. Not subscribed today; the branch exists so WS10 is a
+      // filled-in case rather than a restructure.
+      if (entry.changes?.length) {
+        logger.debug('Ignoring Instagram changes event (comments not yet ingested).', {
+          entryId: entry.id,
+          changeCount: entry.changes.length,
+        })
+      }
+
       if (!entry.messaging || !Array.isArray(entry.messaging)) {
         logger.debug('Skipping Instagram entry without messaging array.', { entryId: entry.id })
         return
       }
 
-      for (const event of entry.messaging) {
-        // Check for actual message events and ignore echoes
-        if (event.message && !event.message.is_echo) {
-          const senderIgsid = event.sender.id // Instagram Scoped User ID
-          const recipientIgbid = event.recipient.id // Instagram Business Account ID
-          const messageContent = event.message
-          // const timestamp = event.timestamp
-
-          logger.info(`Processing incoming Instagram message`, {
-            senderIgsid,
-            recipientIgbid,
-            mid: messageContent.mid,
+      for (const event of entry.messaging as MetaWebhookMessagingEvent[]) {
+        if (!event.message) {
+          logger.debug('Ignoring non-message event in Instagram webhook:', {
+            eventType: Object.keys(event)[0],
           })
+          continue
+        }
 
-          // Find the integration based on the recipient IGBID
-          const [integration] = await db
-            .select({
-              id: schema.Integration.id,
-              organizationId: schema.Integration.organizationId,
-              metadata: schema.Integration.metadata,
-            })
-            .from(schema.Integration)
-            .where(
-              and(
-                eq(schema.Integration.provider, 'instagram'),
-                eq(schema.Integration.enabled, true),
-                sql`${schema.Integration.metadata} ->> 'instagramBusinessAccountId' = ${recipientIgbid}`
-              )
+        if (event.message.is_echo) {
+          logger.debug('Received Instagram message echo, ignoring.', { mid: event.message.mid })
+          continue
+        }
+
+        const recipientIgbid = event.recipient?.id
+        if (!recipientIgbid) {
+          logger.warn('Instagram messaging event has no recipient IGBID; skipping.', { event })
+          continue
+        }
+
+        // `isNull(deletedAt)`: disconnect is a soft delete, so without this a
+        // disconnected channel keeps ingesting while `enabled` stayed true.
+        const [integration] = await db
+          .select({
+            id: schema.Integration.id,
+            organizationId: schema.Integration.organizationId,
+            metadata: schema.Integration.metadata,
+          })
+          .from(schema.Integration)
+          .where(
+            and(
+              eq(schema.Integration.provider, 'instagram'),
+              eq(schema.Integration.enabled, true),
+              isNull(schema.Integration.deletedAt),
+              sql`${schema.Integration.metadata} ->> 'instagramBusinessAccountId' = ${recipientIgbid}`
             )
-            .limit(1)
-
-          if (!integration) {
-            logger.warn(
-              `No active Instagram integration found for IGBID ${recipientIgbid}. Skipping message.`
-            )
-            continue
-          }
-
-          // Convert and store the message
-          const messageData = convertInstagramWebhookEventToMessageData(
-            event,
-            integration.id,
-            integration.organizationId,
-            integration.metadata as Partial<InstagramIntegrationMetadata> | null
           )
+          .limit(1)
 
-          if (messageData) {
-            try {
-              await storageService.storeMessage(messageData)
-              logger.info(`Successfully stored Instagram message`, {
-                mid: messageContent.mid,
-                integrationId: integration.id,
-              })
-            } catch (storeError: any) {
-              logger.error(`Failed to store Instagram message`, {
-                mid: messageContent.mid,
-                integrationId: integration.id,
-                error: storeError.message,
-              })
-            }
-          } else {
-            logger.warn('Failed to convert Instagram webhook event to MessageData', { event })
-          }
-        } else {
-          // Handle or ignore other event types (delivery, read, echo)
-          logger.debug('Ignoring non-message or echo event in Instagram webhook:', {
-            eventType: event.message ? 'echo' : Object.keys(event)[0],
+        if (!integration) {
+          logger.warn(
+            `No active Instagram integration found for IGBID ${recipientIgbid}. Skipping message.`
+          )
+          continue
+        }
+
+        const messageData = convertMetaWebhookEventToMessageData({
+          event,
+          integrationId: integration.id,
+          organizationId: integration.organizationId,
+          pageId: recipientIgbid,
+          platform: 'instagram',
+          metadata: integration.metadata as SocialIntegrationMetadata | null,
+        })
+
+        if (!messageData) {
+          logger.warn('Failed to convert Instagram webhook event to MessageData', { event })
+          continue
+        }
+
+        try {
+          await storageService.storeMessage(messageData)
+          logger.info('Successfully stored Instagram message', {
+            mid: event.message.mid,
+            integrationId: integration.id,
+            externalThreadId: messageData.externalThreadId,
+          })
+        } catch (storeError) {
+          logger.error('Failed to store Instagram message', {
+            mid: event.message.mid,
+            integrationId: integration.id,
+            error: storeError instanceof Error ? storeError.message : String(storeError),
           })
         }
       }
@@ -157,84 +175,4 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
   // 4. Respond OK quickly
   return NextResponse.json({ status: 'success' }, { status: 200 })
-}
-
-/**
- * Helper to convert Instagram webhook event to MessageData.
- */
-function convertInstagramWebhookEventToMessageData(
-  event: any,
-  integrationId: string,
-  organizationId: string,
-  integrationMetadata: Partial<InstagramIntegrationMetadata> | null
-): MessageData | null {
-  try {
-    const senderIgsid = event.sender.id
-    const recipientIgbid = event.recipient.id // This is our IGBID
-    const timestamp = event.timestamp
-    const message = event.message
-    const messageId = message.mid // Instagram message ID
-
-    const metadata = integrationMetadata
-    const igUsername = metadata?.instagramUsername // Our username
-
-    // Directionality: Webhook always receives messages sent TO the business account
-    const isInbound = true
-
-    const fromParticipant = { name: undefined, identifier: senderIgsid } // Sender is the user (IGSID)
-    const toParticipant = { name: igUsername, identifier: recipientIgbid } // Recipient is the business (IGBID)
-
-    const text = message.text
-    const attachments = (message.attachments || []).map((att: any) => ({
-      filename: att.payload?.title || att.type || 'attachment',
-      mimeType: att.type,
-      size: 0,
-      inline: false,
-      contentLocation: att.payload?.url,
-    }))
-
-    const createdTime = new Date(timestamp)
-
-    // Determine Thread ID: Requires mapping IGSID to a conversation ID.
-    // This mapping isn't provided directly. A common approach is to fetch
-    // the conversation ID using the page ID and user IGSID, or use the
-    // IGSID itself as a proxy (less ideal as it doesn't group threads correctly
-    // if the same user messages via FB Messenger and Instagram).
-    // Using IGSID as placeholder - !!! NEEDS REPLACEMENT WITH CONVERSATION LOOKUP/MAPPING !!!
-    const externalThreadId = senderIgsid
-
-    const messageData: MessageData = {
-      externalId: messageId,
-      externalThreadId: externalThreadId, // Placeholder - fetch conversation ID
-      integrationId: integrationId,
-      // Note: integrationType and messageType removed - derived from Integration.provider
-      organizationId: organizationId,
-      createdTime: createdTime,
-      sentAt: createdTime,
-      receivedAt: createdTime,
-      subject: undefined,
-      from: fromParticipant,
-      to: [toParticipant],
-      cc: [],
-      bcc: [],
-      replyTo: [],
-      // Instagram has no inbound attachment ingestor, so no MessageAttachment rows
-      // are ever created and `providerAttachments` is never populated. Mirrors
-      // InstagramProvider.convertToMessageData — `hasAttachments` is a workflow
-      // trigger filter, so claiming true fires attachment rules for bytes that
-      // were never fetched. The `attachments` local still drives the snippet fallback.
-      hasAttachments: false,
-      textPlain: text,
-      snippet: text ? text.substring(0, 100) : attachments[0]?.filename || '',
-      isInbound: isInbound,
-      metadata: { event: event },
-      keywords: [],
-      labelIds: [],
-    }
-
-    return messageData
-  } catch (error: any) {
-    logger.error('Failed to convert Instagram webhook event', { error: error.message, event })
-    return null
-  }
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1078,6 +1078,18 @@
       "import": "./dist/providers/openphone/webhook-message.mjs",
       "default": "./src/providers/openphone/webhook-message.ts"
     },
+    "./providers/social/types": {
+      "types": "./src/providers/social/types.ts",
+      "source": "./src/providers/social/types.ts",
+      "import": "./dist/providers/social/types.mjs",
+      "default": "./src/providers/social/types.ts"
+    },
+    "./providers/social/webhook-message": {
+      "types": "./src/providers/social/webhook-message.ts",
+      "source": "./src/providers/social/webhook-message.ts",
+      "import": "./dist/providers/social/webhook-message.mjs",
+      "default": "./src/providers/social/webhook-message.ts"
+    },
     "./quick-actions": {
       "types": "./src/quick-actions/index.ts",
       "source": "./src/quick-actions/index.ts",

--- a/packages/lib/src/channels/__tests__/identifier.test.ts
+++ b/packages/lib/src/channels/__tests__/identifier.test.ts
@@ -1,0 +1,54 @@
+// packages/lib/src/channels/__tests__/identifier.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { getIdentifier } from '../internal/identifier'
+
+/**
+ * The channel label every settings/list surface renders. Meta social channels had
+ * no case here at all, so a connected Facebook Page showed as a bare "Facebook
+ * Integration" with the page name nowhere on the screen — the name was computed at
+ * connect time, emitted on the `integration:connected` event, and then dropped.
+ */
+describe('getIdentifier — Meta social channels', () => {
+  const row = (provider: string, metadata: unknown, name: string | null = null) =>
+    ({ provider, email: null, name, metadata }) as Parameters<typeof getIdentifier>[0]
+
+  it('labels a Facebook channel with its page name', () => {
+    expect(
+      getIdentifier(row('facebook', { pageId: '869289333164075', pageName: 'Auxx-Lift' }))
+    ).toBe('Auxx-Lift')
+  })
+
+  it('prefers the Instagram handle over the page name', () => {
+    // The IG channel is the account customers actually see; the linked Page name
+    // is frequently different and would read as the wrong account.
+    expect(
+      getIdentifier(
+        row('instagram', {
+          pageId: '869289333164075',
+          pageName: 'Auxx-Lift',
+          instagramUsername: 'auxxlift',
+        })
+      )
+    ).toBe('auxxlift')
+  })
+
+  it('reads from metadata, so channels connected before the name was persisted still resolve', () => {
+    expect(getIdentifier(row('facebook', { pageName: 'Auxx-Lift' }, null))).toBe('Auxx-Lift')
+  })
+
+  it('still prefers an explicit email over social metadata', () => {
+    const channel = {
+      provider: 'google',
+      email: 'support@auxx.ai',
+      name: null,
+      metadata: { pageName: 'ignored' },
+    } as Parameters<typeof getIdentifier>[0]
+    expect(getIdentifier(channel)).toBe('support@auxx.ai')
+  })
+
+  it('falls back to the row name, then undefined', () => {
+    expect(getIdentifier(row('facebook', {}, 'Fallback'))).toBe('Fallback')
+    expect(getIdentifier(row('facebook', {}, null))).toBeUndefined()
+  })
+})

--- a/packages/lib/src/channels/internal/identifier.ts
+++ b/packages/lib/src/channels/internal/identifier.ts
@@ -26,6 +26,13 @@ export function getIdentifier(channel: IdentifierRow | null): string | undefined
     if ('email' in metadata && typeof metadata.email === 'string') return metadata.email
     if ('phoneNumber' in metadata && typeof metadata.phoneNumber === 'string')
       return metadata.phoneNumber
+    // Meta social channels identify by the account they post as, not an address:
+    // the IG handle where there is one, otherwise the Facebook Page name. Read
+    // from metadata rather than `Integration.name` so channels connected before
+    // the name was persisted still show something other than a bare provider label.
+    if ('instagramUsername' in metadata && typeof metadata.instagramUsername === 'string')
+      return metadata.instagramUsername
+    if ('pageName' in metadata && typeof metadata.pageName === 'string') return metadata.pageName
   }
   return channel.name || undefined
 }

--- a/packages/lib/src/channels/social-provisioning-hook.ts
+++ b/packages/lib/src/channels/social-provisioning-hook.ts
@@ -17,7 +17,7 @@
 import { configService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import { onCacheEvent } from '../cache'
 import type { PostConnectHook, PostConnectHookContext } from '../connections/post-connect-hooks'
 import { resolveConnectionForRuntime } from '../connections/resolve-connection-for-runtime'
@@ -300,9 +300,21 @@ async function upsertSocialIntegration(args: {
     }) ?? null
 
   if (existing) {
+    // jsonb MERGE, never replace. `backfillCutoffAt` / `initialBackfillCompletedAt`
+    // and any `settings` live in this same blob, and a wholesale `.set({ metadata })`
+    // on reconnect would wipe them — reopening a suppression window that has already
+    // closed, or dropping the channel's record-creation settings. Same rule
+    // `quo-channel.ts` documents at its own upsert.
+    const metadataJson = JSON.stringify(metadata)
     await db
       .update(schema.Integration)
-      .set({ credentialId, enabled: true, metadata: metadata as any, updatedAt: new Date() })
+      .set({
+        credentialId,
+        enabled: true,
+        name: displayName,
+        metadata: sql`COALESCE(${schema.Integration.metadata}, '{}'::jsonb) || ${metadataJson}::jsonb`,
+        updatedAt: new Date(),
+      })
       .where(eq(schema.Integration.id, existing.id))
     return { id: existing.id, isNew: false, displayName }
   }
@@ -314,7 +326,18 @@ async function upsertSocialIntegration(args: {
       provider,
       credentialId,
       enabled: true,
-      metadata: metadata as any,
+      // Persisted, not just emitted on the `integration:connected` event — this is
+      // what every channel surface reads to label the row. Without it FB/IG render
+      // as a bare "Facebook Integration" with no page name anywhere.
+      name: displayName,
+      // Received-time trigger cutoff, stamped at the connect epoch and ONLY on a
+      // first connect (a reconnect must not reopen a window that already closed).
+      // Consumed by both providers' `initialize()` via `setBackfillCutoff`, so a
+      // history backfill stores messages without firing `message:received` for
+      // them. Lifted by `initialBackfillCompletedAt` when the capped backfill
+      // (WS7) finishes; until that exists the window stays open, which is the
+      // safe direction — live inbound still fires, only history stays silent.
+      metadata: { ...metadata, backfillCutoffAt: new Date().toISOString() } as any,
       updatedAt: new Date(),
     })
     .returning({ id: schema.Integration.id })

--- a/packages/lib/src/ingest/__tests__/store-message.social-alias.test.ts
+++ b/packages/lib/src/ingest/__tests__/store-message.social-alias.test.ts
@@ -1,0 +1,388 @@
+// packages/lib/src/ingest/__tests__/store-message.social-alias.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * FB/IG runtime-fixes plan WS1b — the alias net on the reconcile path.
+ *
+ * Facebook and Instagram have no rung 2: `resolveThreadId` gates its RFC 5322
+ * parentage fallback to `outlook`/`imap`, so if the alias lookup misses, the
+ * thread forks with nothing to catch it.
+ *
+ * The pair key `dm:{pageId}:{counterpartId}` is only correct if the participant
+ * ids the REST `/conversations` edge returns are the same PSIDs the webhook puts
+ * in `sender.id` — unverified against live data. If they ever diverge, the two
+ * doors compute two different keys for one conversation. What saves it is message
+ * identity: both doors carry the same `mid`, so `reconcileMessage` dedupes on
+ * `(integrationId, externalId)`, and recording the second door's key as an alias
+ * at that moment binds the conversation back together for every later message.
+ */
+
+const h = vi.hoisted(() => ({
+  store: {} as Record<string, Array<Record<string, any>>>,
+  seq: 0,
+  /** Table whose INSERT should blow up, standing in for a table the migration has not created yet. */
+  failInsertOn: null as string | null,
+}))
+
+vi.mock('@auxx/database', async () => {
+  const { createChainableDatabaseMock, createSchemaMock } = await import('../../test/database-mock')
+  const table = (name: string) =>
+    new Proxy({}, { get: (_t, key) => `${name}.${String(key)}` }) as Record<string, unknown>
+  const pinned = [
+    'Thread',
+    'Message',
+    'ThreadExternalKey',
+    'Integration',
+    'InboxIntegration',
+    'MessageParticipant',
+    'ThreadParticipant',
+    'ThreadReadStatus',
+  ]
+  return {
+    database: createChainableDatabaseMock(),
+    schema: createSchemaMock(Object.fromEntries(pinned.map((n) => [n, table(n)]))),
+  }
+})
+
+// Partial mock — replacing `drizzle-orm` wholesale dies at COLLECTION time once
+// `store-message`'s import graph grows. Only the predicate builders are swapped.
+vi.mock('drizzle-orm', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    and: (...conds: unknown[]) => ({ op: 'and', conds: conds.filter(Boolean) }),
+    eq: (col: unknown, value: unknown) => ({ op: 'eq', col, value }),
+    isNull: (col: unknown) => ({ op: 'isNull', col }),
+    inArray: (col: unknown, values: unknown[]) => ({ op: 'inArray', col, values }),
+  }
+})
+
+vi.mock('../inbox-meta', () => ({ isPersonalInbox: async () => false }))
+vi.mock('../../inbox-record-ids', () => ({ toInboxRecordId: async () => 'inbox:i_1' }))
+// Own-address loop guard (message-trigger-scoping plan §6 #1) reads the
+// `channels` org cache at the publish gate. No channels configured here means
+// no address is ever "our own", matching every test in this file's intent —
+// they're all about thread resolution, not the loop guard.
+vi.mock('../../cache', () => ({ getOrgCache: () => ({ get: async () => [] }) }))
+vi.mock('../../realtime', () => ({
+  getRealtimeService: () => ({}),
+  publishThreadCreated: vi.fn(),
+  publishThreadUpdated: vi.fn(),
+  publishMessageCreated: vi.fn(),
+}))
+vi.mock('../../threads/mail-counts', () => ({ applyMailCountDeltas: vi.fn() }))
+vi.mock('../../entity-instances/activity', () => ({
+  touchActivityForThreadLinks: vi.fn(),
+  resolveThreadLinkedEntityIds: vi.fn(async () => []),
+  touchEntityActivity: vi.fn(),
+  touchInteractionForMessage: vi.fn(),
+}))
+vi.mock('../../events/publisher', () => ({ publisher: { publishLater: vi.fn() } }))
+vi.mock('../../permissions/visibility/audience', () => ({
+  getFullLensAudienceForInbox: async () => [],
+}))
+vi.mock('../filtering/machine-mail', () => ({ detectMachineMail: () => null }))
+vi.mock('../filtering/should-ignore', () => ({ shouldIgnoreMessage: () => false }))
+vi.mock('../filtering/store-ignored', () => ({ storeIgnoredMessage: vi.fn() }))
+vi.mock('../reconciliation/extract-internet-message-id', () => ({
+  extractInternetMessageId: () => null,
+}))
+// The real `reconcileMessage` falls back to an `(integrationId, externalId)`
+// lookup — that is the arm this test exercises, so it is emulated rather than
+// stubbed to null.
+vi.mock('../reconciliation/reconcile-message', () => ({
+  reconcileMessage: async (_ctx: unknown, messageData: any) =>
+    (h.store.Message ?? []).find(
+      (m: any) =>
+        m.integrationId === messageData.integrationId && m.externalId === messageData.externalId
+    ) ?? null,
+}))
+vi.mock('../threads/update-metadata', () => ({ updateThreadMetadataEfficient: vi.fn() }))
+vi.mock('../participants/normalize', () => ({
+  determineIdentifierType: async () => 'SOCIAL',
+  normalizeIdentifier: (v: string) => v.toLowerCase(),
+}))
+vi.mock('../participants/find-or-create', () => ({
+  findOrCreateParticipantRecord: async () => ({
+    id: 'p_1',
+    identifier: 'psid',
+    name: undefined,
+    entityInstanceId: null,
+    isInternal: false,
+  }),
+}))
+
+// NOT mocked, deliberately: `../threads/resolve-thread` is the unit under test.
+import { socialThreadKey } from '../../providers/social/thread-key'
+import { storeMessage } from '../store-message'
+
+const ORG = 'org_1'
+const FACEBOOK = 'int_facebook'
+const PAGE = '869289333164075'
+const PSID = '2495701234567890'
+const INBOX = 'i_1'
+
+/** `'Message.organizationId'` → `'organizationId'`. */
+const field = (col: unknown) => String(col).split('.').slice(1).join('.')
+const tableOf = (t: any) => String(t?.id ?? '').split('.')[0] ?? ''
+
+function matches(row: Record<string, any>, pred: any): boolean {
+  if (!pred || typeof pred !== 'object') return true
+  switch (pred.op) {
+    case 'and':
+      return pred.conds.every((c: unknown) => matches(row, c))
+    case 'eq':
+      return row[field(pred.col)] === pred.value
+    case 'isNull':
+      return row[field(pred.col)] == null
+    case 'inArray':
+      return pred.values.includes(row[field(pred.col)])
+    default:
+      return true
+  }
+}
+
+const rows = (name: string) => (h.store[name] ??= [])
+
+/** Unique keys the real schema enforces, for the `ON CONFLICT` emulation. */
+const CONFLICT_KEYS: Record<string, string[]> = {
+  Thread: ['integrationId', 'externalId'],
+  Message: ['integrationId', 'externalId'],
+  ThreadExternalKey: ['integrationId', 'externalId'],
+  MessageParticipant: ['messageId', 'participantId', 'role'],
+  ThreadParticipant: ['threadId', 'email'],
+}
+
+function selectChain() {
+  let table = ''
+  let pred: unknown = null
+  let lim: number | undefined
+  const chain: any = {
+    from(t: any) {
+      table = tableOf(t)
+      return chain
+    },
+    where(p: unknown) {
+      pred = p
+      return chain
+    },
+    limit(n: number) {
+      lim = n
+      return chain
+    },
+    then(resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) {
+      const all = rows(table).filter((r) => matches(r, pred))
+      return Promise.resolve(lim === undefined ? all : all.slice(0, lim)).then(resolve, reject)
+    },
+  }
+  return chain
+}
+
+function insertChain(table: string) {
+  let values: Array<Record<string, any>> = []
+  let mode: 'throw' | 'nothing' | 'update' = 'throw'
+  let target = CONFLICT_KEYS[table] ?? []
+  let updateSet: Record<string, unknown> = {}
+
+  const run = () => {
+    if (h.failInsertOn === table) {
+      throw new Error(`relation "${table}" does not exist`)
+    }
+    const out: Array<Record<string, any>> = []
+    for (const value of values) {
+      const existing = target.length
+        ? rows(table).find((r) => target.every((c) => value[c] !== undefined && r[c] === value[c]))
+        : undefined
+      if (existing) {
+        if (mode === 'update') {
+          for (const [k, v] of Object.entries(updateSet)) {
+            if (v !== undefined && typeof v !== 'object') existing[k] = v
+          }
+          out.push(existing)
+        }
+        continue
+      }
+      const row = { id: `${table}_${++h.seq}`, ...value }
+      rows(table).push(row)
+      out.push(row)
+    }
+    return out
+  }
+
+  const chain: any = {
+    values(v: any) {
+      values = Array.isArray(v) ? v : [v]
+      return chain
+    },
+    onConflictDoNothing() {
+      mode = 'nothing'
+      return chain
+    },
+    onConflictDoUpdate(cfg: any) {
+      mode = 'update'
+      if (cfg?.target) target = cfg.target.map(field)
+      updateSet = cfg?.set ?? {}
+      return chain
+    },
+    returning() {
+      return chain
+    },
+    then(resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) {
+      return Promise.resolve(run()).then(resolve, reject)
+    },
+  }
+  return chain
+}
+
+function updateChain(table: string) {
+  let assigned: Record<string, unknown> = {}
+  let pred: unknown = null
+  const chain: any = {
+    set(s: Record<string, unknown>) {
+      assigned = s
+      return chain
+    },
+    where(p: unknown) {
+      pred = p
+      return chain
+    },
+    returning() {
+      return chain
+    },
+    then(resolve: (v: unknown) => unknown, reject: (e: unknown) => unknown) {
+      const hit = rows(table).filter((r) => matches(r, pred))
+      for (const row of hit) {
+        for (const [k, v] of Object.entries(assigned)) {
+          if (v !== undefined && typeof v !== 'object') row[k] = v
+        }
+      }
+      return Promise.resolve(hit).then(resolve, reject)
+    },
+  }
+  return chain
+}
+
+const db: any = {
+  select: () => selectChain(),
+  insert: (t: any) => insertChain(tableOf(t)),
+  update: (t: any) => updateChain(tableOf(t)),
+  transaction: async (cb: (tx: unknown) => Promise<unknown>) => cb(db),
+  query: { SequenceRun: { findFirst: async () => null } },
+}
+
+function ctx() {
+  return {
+    organizationId: ORG,
+    db,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    systemUserId: 'sys',
+    crudHandler: {},
+    reconciler: {},
+    threadManager: {},
+    selectiveCache: {},
+    integrationSettings: {},
+    isInitialSync: false,
+    ownIdentities: {},
+    ownIdentitiesByOrg: new Map(),
+    inSyncBatch: false,
+    touchedInboxIds: new Set<string | null>(),
+    companyIdByDomain: new Map(),
+    ownDomainsByOrg: new Map(),
+    providerByIntegrationId: new Map(),
+  } as any
+}
+
+let clock = 0
+function messageData(overrides: Record<string, unknown> = {}) {
+  const at = new Date(Date.UTC(2026, 6, 29, 10, ++clock))
+  return {
+    organizationId: ORG,
+    integrationId: FACEBOOK,
+    externalId: `ext_${clock}`,
+    externalThreadId: socialThreadKey(PAGE, PSID),
+    inboxId: INBOX,
+    subject: undefined,
+    isInbound: true,
+    sentAt: at,
+    receivedAt: at,
+    createdTime: at,
+    hasAttachments: false,
+    from: { identifier: PSID },
+    to: [{ identifier: PAGE }],
+    ...overrides,
+  } as any
+}
+
+const messages = () => rows('Message')
+const aliasKeysFor = (threadId: string) =>
+  rows('ThreadExternalKey')
+    .filter((r) => r.threadId === threadId)
+    .map((r) => r.externalId)
+    .sort()
+
+beforeEach(() => {
+  h.failInsertOn = null
+  h.store = {
+    Integration: [{ id: FACEBOOK, provider: 'facebook', deletedAt: null, metadata: {} }],
+  }
+  h.seq = 0
+  clock = 0
+})
+
+describe('storeMessage — WS1b alias net for providers with no header chain', () => {
+  it('binds a second conversation key to the existing thread when the mid already exists', async () => {
+    const c = ctx()
+    const webhookKey = socialThreadKey(PAGE, PSID)
+    // What sync would compute if `/conversations` returned a different id space
+    // for the same human than the webhook does.
+    const syncKey = socialThreadKey(PAGE, 'other_id_space_9999')
+
+    // Door 1 — the webhook.
+    await storeMessage(c, messageData({ externalId: 'm_1', externalThreadId: webhookKey }))
+    expect(rows('Thread')).toHaveLength(1)
+    const threadId = rows('Thread')[0]?.id
+
+    // Door 2 — the REST sync re-delivering the SAME message under a key that
+    // disagrees. Without WS1b this returns early and records nothing.
+    await storeMessage(c, messageData({ externalId: 'm_1', externalThreadId: syncKey }))
+
+    expect(rows('Thread')).toHaveLength(1)
+    expect(messages()).toHaveLength(1)
+    expect(aliasKeysFor(threadId)).toEqual([syncKey, webhookKey].sort())
+  })
+
+  it('routes a LATER message under the disagreeing key onto the same thread', async () => {
+    // The point of recording the alias: rung 1 now answers for the key that was
+    // never the thread's canonical `externalId`.
+    const c = ctx()
+    const webhookKey = socialThreadKey(PAGE, PSID)
+    const syncKey = socialThreadKey(PAGE, 'other_id_space_9999')
+
+    await storeMessage(c, messageData({ externalId: 'm_1', externalThreadId: webhookKey }))
+    const threadId = rows('Thread')[0]?.id
+    await storeMessage(c, messageData({ externalId: 'm_1', externalThreadId: syncKey }))
+
+    // A message the webhook never saw, arriving only through sync.
+    await storeMessage(c, messageData({ externalId: 'm_2', externalThreadId: syncKey }))
+
+    expect(rows('Thread')).toHaveLength(1)
+    expect(messages()).toHaveLength(2)
+    expect(messages().every((m) => m.threadId === threadId)).toBe(true)
+  })
+
+  it('does not fail ingest when the alias write blows up', async () => {
+    const c = ctx()
+    const webhookKey = socialThreadKey(PAGE, PSID)
+    await storeMessage(c, messageData({ externalId: 'm_1', externalThreadId: webhookKey }))
+
+    h.failInsertOn = 'ThreadExternalKey'
+    const result = await storeMessage(
+      c,
+      messageData({ externalId: 'm_1', externalThreadId: socialThreadKey(PAGE, 'zzz') })
+    )
+
+    expect(result?.isNew).toBe(false)
+    expect(messages()).toHaveLength(1)
+  })
+})

--- a/packages/lib/src/ingest/store-message.ts
+++ b/packages/lib/src/ingest/store-message.ts
@@ -207,6 +207,13 @@ export async function storeMessage(
         }
       }
 
+      // The incoming conversation key may differ from the one this thread was
+      // created under — the same message reaching us through two doors under two
+      // keys is exactly the fork the alias table exists to prevent. Recording it
+      // here is what makes the NEXT message under the incoming key resolve at
+      // rung 1 instead of opening a second thread.
+      await recordThreadExternalKey(ctx, messageData, existingByMsgId.threadId)
+
       await updateThreadMetadataEfficient(ctx, existingByMsgId.threadId)
       return { messageId: existingByMsgId.id, isNew: false }
     }
@@ -246,7 +253,15 @@ export async function storeMessage(
         }
       }
 
+      // Same reasoning as the `existingByMsgId` branch above, and this is the arm
+      // that matters for providers with no RFC 5322 fallback: `reconcileMessage`
+      // dedupes on `(integrationId, externalId)`, so a message seen by both the
+      // webhook and the REST sync binds whichever conversation key the second door
+      // presented to the thread the first door created. Facebook/Instagram depend
+      // on this — `resolveThreadId` gates its header-chain rung to outlook/imap, so
+      // for them a rung-1 miss forks with nothing to catch it.
       if (existingMessage.threadId) {
+        await recordThreadExternalKey(ctx, messageData, existingMessage.threadId)
         await updateThreadMetadataEfficient(ctx, existingMessage.threadId)
       }
 

--- a/packages/lib/src/providers/facebook/facebook-provider.ts
+++ b/packages/lib/src/providers/facebook/facebook-provider.ts
@@ -19,6 +19,7 @@ import type {
 import { getChannelTokens } from '../channel-token-accessor'
 import { BaseMessageProvider, type MessageProvider } from '../message-provider-interface'
 import { getProviderCapabilities, type ProviderCapabilities } from '../provider-capabilities'
+import { socialThreadKey } from '../social/thread-key'
 import { type FacebookIntegrationMetadata, FacebookOAuthService } from './facebook-oauth'
 
 const logger = createScopedLogger('facebook-provider')
@@ -184,6 +185,21 @@ export class FacebookProvider
         hasSettings: true,
       })
     }
+    // Received-time trigger cutoff (webhook-push-migration plan Phase 2.5; the same
+    // contract Gmail/Outlook/Quo use). While the initial backfill is incomplete,
+    // ingest stores historical messages but suppresses `message:received` for
+    // anything received before the connect epoch — otherwise a backfill mass-fires
+    // workflows, agent runs and AI classification against years of real customer
+    // mail. Live inbound is unaffected: its `receivedAt` is after the cutoff.
+    const socialMeta = integration.metadata as {
+      backfillCutoffAt?: string
+      initialBackfillCompletedAt?: string
+    }
+    this.storageService.setBackfillCutoff(
+      socialMeta.backfillCutoffAt && !socialMeta.initialBackfillCompletedAt
+        ? new Date(socialMeta.backfillCutoffAt)
+        : null
+    )
     logger.info(`FacebookProvider initialized successfully for Page ID: ${this.pageId}`, {
       integrationId,
     })
@@ -524,7 +540,11 @@ export class FacebookProvider
       // Construct the MessageData object for storage
       const messageData: MessageData = {
         externalId: externalId,
-        externalThreadId: conversationId, // Use FB Conversation ID
+        // NOT the `t_…` conversation id. The webhook never receives one, so the
+        // REST path must derive the SAME pair key the webhook derives or the same
+        // conversation lands in two threads. The conversation id is kept in
+        // `metadata` for deep links only.
+        externalThreadId: socialThreadKey(this.pageId, userContext.psid),
         integrationId: this.integrationId,
         inboxId: this.inboxId,
         organizationId: this.organizationId,
@@ -552,6 +572,7 @@ export class FacebookProvider
         isInbound: isInbound,
         metadata: {
           // Store raw event parts for debugging or future use
+          fb_conversation_id: conversationId,
           fb_from: message.from,
           fb_to: message.to,
           fb_message: message.message,

--- a/packages/lib/src/providers/instagram/instagram-provider.ts
+++ b/packages/lib/src/providers/instagram/instagram-provider.ts
@@ -19,6 +19,7 @@ import type {
 import { getChannelTokens } from '../channel-token-accessor'
 import { BaseMessageProvider, type MessageProvider } from '../message-provider-interface'
 import { getProviderCapabilities, type ProviderCapabilities } from '../provider-capabilities'
+import { socialThreadKey } from '../social/thread-key'
 import { type InstagramIntegrationMetadata, InstagramOAuthService } from './instagram-oauth'
 
 const logger = createScopedLogger('instagram-provider')
@@ -174,6 +175,21 @@ export class InstagramProvider
         hasSettings: true,
       })
     }
+    // Received-time trigger cutoff (webhook-push-migration plan Phase 2.5; the same
+    // contract Gmail/Outlook/Quo use). While the initial backfill is incomplete,
+    // ingest stores historical messages but suppresses `message:received` for
+    // anything received before the connect epoch — otherwise a backfill mass-fires
+    // workflows, agent runs and AI classification against years of real customer
+    // mail. Live inbound is unaffected: its `receivedAt` is after the cutoff.
+    const socialMeta = integration.metadata as {
+      backfillCutoffAt?: string
+      initialBackfillCompletedAt?: string
+    }
+    this.storageService.setBackfillCutoff(
+      socialMeta.backfillCutoffAt && !socialMeta.initialBackfillCompletedAt
+        ? new Date(socialMeta.backfillCutoffAt)
+        : null
+    )
     logger.info(
       `InstagramProvider initialized successfully for IGBID: ${this.instagramBusinessAccountId}, Page ID: ${this.pageId}`,
       { integrationId }
@@ -524,7 +540,11 @@ export class InstagramProvider
       // Construct the MessageData object
       const messageData: MessageData = {
         externalId: externalId,
-        externalThreadId: conversationId, // Use FB Conversation ID
+        // NOT the `t_…` conversation id — the webhook never receives one, so the
+        // REST path must derive the SAME pair key the webhook derives or the same
+        // conversation lands in two threads. Keyed on the IGBID (our side) so it
+        // matches the webhook's `recipient.id`, not on the Page id.
+        externalThreadId: socialThreadKey(this.instagramBusinessAccountId, userContext.igsid),
         inboxId: this.inboxId,
         integrationId: this.integrationId,
         organizationId: this.organizationId,

--- a/packages/lib/src/providers/social/__tests__/webhook-message.test.ts
+++ b/packages/lib/src/providers/social/__tests__/webhook-message.test.ts
@@ -1,0 +1,125 @@
+// packages/lib/src/providers/social/__tests__/webhook-message.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { socialThreadKey } from '../thread-key'
+import type { MetaWebhookMessagingEvent } from '../types'
+import { convertMetaWebhookEventToMessageData } from '../webhook-message'
+
+const PAGE_ID = '869289333164075'
+const PSID = '24957012345678901'
+const BASE = {
+  integrationId: 'int_1',
+  organizationId: 'org_1',
+  pageId: PAGE_ID,
+  platform: 'facebook' as const,
+  metadata: { pageId: PAGE_ID, pageName: 'Auxx-Lift' },
+}
+
+function inbound(overrides: Partial<MetaWebhookMessagingEvent> = {}): MetaWebhookMessagingEvent {
+  return {
+    sender: { id: PSID },
+    recipient: { id: PAGE_ID },
+    timestamp: 1_755_000_000_000,
+    message: { mid: 'm_inbound_1', text: "where's my order?" },
+    ...overrides,
+  }
+}
+
+describe('convertMetaWebhookEventToMessageData', () => {
+  it('keys an inbound DM on the page/counterpart pair, not the sender PSID', () => {
+    const result = convertMetaWebhookEventToMessageData({ event: inbound(), ...BASE })
+
+    expect(result?.externalThreadId).toBe(socialThreadKey(PAGE_ID, PSID))
+    expect(result?.externalThreadId).not.toBe(PSID)
+    expect(result?.externalId).toBe('m_inbound_1')
+    expect(result?.isInbound).toBe(true)
+    expect(result?.from.identifier).toBe(PSID)
+    expect(result?.to[0]?.identifier).toBe(PAGE_ID)
+  })
+
+  it('gives an echo the SAME thread key as the inbound message it answers', () => {
+    // The regression this whole module exists for: on an echo Meta swaps sender
+    // and recipient, so keying on `sender.id` filed our own replies under the page
+    // id and split every conversation in two.
+    const echo = inbound({
+      sender: { id: PAGE_ID },
+      recipient: { id: PSID },
+      message: { mid: 'm_echo_1', text: 'on its way', is_echo: true },
+    })
+
+    const inboundResult = convertMetaWebhookEventToMessageData({ event: inbound(), ...BASE })
+    const echoResult = convertMetaWebhookEventToMessageData({ event: echo, ...BASE })
+
+    expect(echoResult?.externalThreadId).toBe(inboundResult?.externalThreadId)
+    expect(echoResult?.isInbound).toBe(false)
+    expect(echoResult?.from.identifier).toBe(PAGE_ID)
+    expect(echoResult?.to[0]?.identifier).toBe(PSID)
+  })
+
+  it('uses the IGBID as our side for Instagram', () => {
+    const igbid = '17841400000000000'
+    const igsid = '19876543210'
+    const result = convertMetaWebhookEventToMessageData({
+      event: {
+        sender: { id: igsid },
+        recipient: { id: igbid },
+        timestamp: 1_755_000_000_000,
+        message: { mid: 'm_ig_1', text: 'hi' },
+      },
+      integrationId: 'int_2',
+      organizationId: 'org_1',
+      pageId: igbid,
+      platform: 'instagram',
+      metadata: { instagramUsername: 'auxxlift' },
+    })
+
+    expect(result?.externalThreadId).toBe(socialThreadKey(igbid, igsid))
+    expect(result?.to[0]?.name).toBe('auxxlift')
+  })
+
+  it('drops an event whose page side is not this channel', () => {
+    const result = convertMetaWebhookEventToMessageData({
+      event: inbound({ recipient: { id: 'some_other_page' } }),
+      ...BASE,
+    })
+    expect(result).toBeNull()
+  })
+
+  it('drops unusable events instead of throwing', () => {
+    expect(
+      convertMetaWebhookEventToMessageData({ event: inbound({ message: {} }), ...BASE })
+    ).toBeNull()
+    expect(
+      convertMetaWebhookEventToMessageData({ event: inbound({ sender: {} }), ...BASE })
+    ).toBeNull()
+    expect(
+      convertMetaWebhookEventToMessageData({
+        event: {} as MetaWebhookMessagingEvent,
+        ...BASE,
+      })
+    ).toBeNull()
+  })
+
+  it('falls back to the attachment title for the snippet when there is no text', () => {
+    const result = convertMetaWebhookEventToMessageData({
+      event: inbound({
+        message: {
+          mid: 'm_att_1',
+          attachments: [{ type: 'image', payload: { url: 'https://x/y.jpg', title: 'receipt' } }],
+        },
+      }),
+      ...BASE,
+    })
+
+    expect(result?.snippet).toBe('receipt')
+    // No inbound attachment ingestor exists, so claiming true would fire
+    // attachment workflow rules for bytes that were never fetched.
+    expect(result?.hasAttachments).toBe(false)
+  })
+})
+
+describe('socialThreadKey', () => {
+  it('namespaces DM keys so post comments can share the column', () => {
+    expect(socialThreadKey('page', 'user')).toBe('dm:page:user')
+  })
+})

--- a/packages/lib/src/providers/social/thread-key.ts
+++ b/packages/lib/src/providers/social/thread-key.ts
@@ -1,0 +1,55 @@
+// packages/lib/src/providers/social/thread-key.ts
+
+/**
+ * Thread-key namespaces for Meta social channels.
+ *
+ * The whole keyspace is defined here and nowhere else. A key written by the
+ * webhook, by `syncMessages`, and by the outbound send path must be byte-identical
+ * or the same conversation forks into several threads — and unlike email there is
+ * no RFC 5322 parentage chain to fall back on (`resolve-thread.ts` gates rung 2 to
+ * `outlook`/`imap`), so a key disagreement is unrecoverable at read time.
+ */
+export const SOCIAL_THREAD_KEY_NAMESPACES = {
+  /** 1:1 Messenger / Instagram Direct conversation. */
+  dm: 'dm',
+  /** A root comment on a page post plus its replies (see WS10 — not yet ingested). */
+  comment: 'comment',
+} as const
+
+/**
+ * Conversation key for a Messenger / Instagram DM.
+ *
+ * **Derived, not provider-issued, and deliberately so.** Meta's page messaging
+ * webhook carries no conversation id at all — only `sender.id`, `recipient.id` and
+ * `message.mid`. The REST conversation id (`t_…`) exists on the `/conversations`
+ * edge but recovering it per inbound message costs a Graph round-trip inside a
+ * handler Meta retries on any non-2xx. A Messenger/IG DM is strictly 1:1 between a
+ * page and one user, so `(pageId, counterpartId)` *is* the conversation identity.
+ *
+ * The counterpart is always the **non-page** party, which is direction-dependent:
+ * `sender.id` on an inbound message, `recipient.id` on an echo or our own send.
+ * Keying on `sender.id` alone — what the routes did before — files our replies
+ * under the page id and the customer's messages under theirs, splitting every
+ * conversation in two.
+ *
+ * The `dm:` prefix is not decoration: post comments share this column under
+ * `comment:{rootCommentId}`, and retrofitting a namespace means rewriting every
+ * stored key.
+ *
+ * @param pageId Facebook Page id, or the Instagram business account id.
+ * @param counterpartId The other party's PSID (Messenger) or IGSID (Instagram).
+ */
+export function socialThreadKey(pageId: string, counterpartId: string): string {
+  return `${SOCIAL_THREAD_KEY_NAMESPACES.dm}:${pageId}:${counterpartId}`
+}
+
+/**
+ * True when `key` is a DM key minted by {@link socialThreadKey}.
+ *
+ * Public/private is a property of the *surface*, not of `Message.messageType` —
+ * comments and DMs both store as `CHAT`, so callers that need the distinction ask
+ * here rather than reading the message type.
+ */
+export function isSocialDmThreadKey(key: string | null | undefined): boolean {
+  return !!key?.startsWith(`${SOCIAL_THREAD_KEY_NAMESPACES.dm}:`)
+}

--- a/packages/lib/src/providers/social/types.ts
+++ b/packages/lib/src/providers/social/types.ts
@@ -1,0 +1,83 @@
+// packages/lib/src/providers/social/types.ts
+
+/** The two Meta channels that share this wire format. */
+export type SocialPlatform = 'facebook' | 'instagram'
+
+/**
+ * Which Meta surface an event arrived on.
+ *
+ * A one-member union today. It exists so post comments (WS10) add a case to the
+ * existing converter instead of growing a second one — `entry.messaging` and
+ * `entry.changes` are different envelopes carrying different identity, and the
+ * lesson from Quo is that two wire shapes need two mappers, never one that guesses.
+ */
+export type SocialSurface = 'dm'
+
+/** `entry.messaging[].message` — the inbound/echo message body. */
+export interface MetaWebhookMessage {
+  mid?: string
+  text?: string
+  /** Present (and `true`) on echoes of messages the page itself sent. */
+  is_echo?: boolean
+  /** Present when the user replied to a specific message. */
+  reply_to?: { mid?: string }
+  attachments?: MetaWebhookAttachment[]
+}
+
+export interface MetaWebhookAttachment {
+  type?: string
+  payload?: {
+    url?: string
+    title?: string
+    sticker_id?: number
+  }
+}
+
+/**
+ * One entry in `entry.messaging[]`.
+ *
+ * `sender`/`recipient` swap by direction: on an inbound message the sender is the
+ * user and the recipient is the page; on an echo it is the other way round. Every
+ * consumer must derive the page side explicitly rather than assuming a position.
+ */
+export interface MetaWebhookMessagingEvent {
+  sender?: { id?: string }
+  recipient?: { id?: string }
+  /** Milliseconds since epoch. */
+  timestamp?: number
+  message?: MetaWebhookMessage
+  delivery?: { mids?: string[]; watermark?: number }
+  read?: { watermark?: number }
+  postback?: { mid?: string; title?: string; payload?: string }
+}
+
+/** One `entry` of the webhook envelope. */
+export interface MetaWebhookEntry {
+  id?: string
+  time?: number
+  /** DMs. */
+  messaging?: MetaWebhookMessagingEvent[]
+  /**
+   * Comments, reactions, and other page-feed activity. Never populated today —
+   * we subscribe to `messages,messaging_postbacks,message_reads` only — and the
+   * routes log-and-drop it. WS10 fills this in.
+   */
+  changes?: unknown[]
+}
+
+/** Top-level webhook body. `object` is `page` for Messenger, `instagram` for IG. */
+export interface MetaWebhookEnvelope {
+  object?: string
+  entry?: MetaWebhookEntry[]
+}
+
+/**
+ * Integration metadata fields this module reads. Structural on purpose — the
+ * provider-specific metadata interfaces live with their providers and carry more.
+ */
+export interface SocialIntegrationMetadata {
+  pageId?: string
+  pageName?: string
+  instagramBusinessAccountId?: string
+  instagramUsername?: string
+}

--- a/packages/lib/src/providers/social/webhook-message.ts
+++ b/packages/lib/src/providers/social/webhook-message.ts
@@ -1,0 +1,146 @@
+// packages/lib/src/providers/social/webhook-message.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import type { MessageData } from '../../ingest/types'
+import { socialThreadKey } from './thread-key'
+import type {
+  MetaWebhookMessagingEvent,
+  SocialIntegrationMetadata,
+  SocialPlatform,
+  SocialSurface,
+} from './types'
+
+const logger = createScopedLogger('social-webhook-message')
+
+const SNIPPET_LENGTH = 100
+
+export interface ConvertMetaWebhookEventInput {
+  event: MetaWebhookMessagingEvent
+  integrationId: string
+  organizationId: string
+  /** The Page id (Messenger) or IG business account id this channel owns. */
+  pageId: string
+  platform: SocialPlatform
+  metadata?: SocialIntegrationMetadata | null
+  surface?: SocialSurface
+}
+
+/**
+ * Converts one Meta `entry.messaging[]` event into `MessageData`.
+ *
+ * **Lives in lib, not in the Next route, so the wire format is unit-testable.** The
+ * bug this replaces — `externalThreadId: senderPsid`, marked `!!! Placeholder !!!`
+ * in both routes — was invisible to tests for as long as the mapper was a private
+ * function inside a request handler.
+ *
+ * One converter for both platforms: Messenger and Instagram Direct share this wire
+ * format exactly, differing only in which id space the participants live in (PSID
+ * vs IGSID) and which side is "us". REST `/conversations` returns a *different*
+ * shape and gets its own mapper — never reuse this one for it.
+ *
+ * @returns `null` when the event is unusable, which callers treat as "ack and
+ * drop". Never throws: a webhook that 500s is retried by Meta indefinitely and
+ * repeated failures get the subscription disabled.
+ */
+export function convertMetaWebhookEventToMessageData(
+  input: ConvertMetaWebhookEventInput
+): MessageData | null {
+  const { event, integrationId, organizationId, pageId, platform, metadata } = input
+
+  try {
+    const message = event.message
+    const externalId = message?.mid
+    if (!externalId) {
+      logger.warn('Meta messaging event has no message id; dropping', { platform, integrationId })
+      return null
+    }
+
+    const senderId = event.sender?.id
+    const recipientId = event.recipient?.id
+    if (!senderId || !recipientId) {
+      logger.warn('Meta messaging event is missing sender or recipient; dropping', {
+        platform,
+        integrationId,
+        mid: externalId,
+      })
+      return null
+    }
+
+    // An echo is the page's own message played back to us, so the sides are
+    // swapped relative to an inbound message. Deriving direction from which side
+    // is the page — rather than assuming "webhook implies inbound" — is what keeps
+    // our sends and the customer's messages on ONE thread key.
+    const isEcho = message?.is_echo === true
+    const pageSideId = isEcho ? senderId : recipientId
+    const counterpartId = isEcho ? recipientId : senderId
+
+    if (pageSideId !== pageId) {
+      logger.warn('Meta messaging event does not name this channel as the page side; dropping', {
+        platform,
+        integrationId,
+        mid: externalId,
+        pageSideId,
+        expectedPageId: pageId,
+      })
+      return null
+    }
+
+    const ourName =
+      platform === 'instagram'
+        ? (metadata?.instagramUsername ?? metadata?.pageName)
+        : metadata?.pageName
+
+    const pageParticipant = { name: ourName, identifier: pageId }
+    const counterpartParticipant = { name: undefined, identifier: counterpartId }
+
+    const timestamp = typeof event.timestamp === 'number' ? event.timestamp : Date.now()
+    const createdTime = new Date(timestamp)
+    if (Number.isNaN(createdTime.getTime())) {
+      logger.warn('Unparseable timestamp on Meta messaging event; dropping', {
+        platform,
+        integrationId,
+        mid: externalId,
+        timestamp: event.timestamp,
+      })
+      return null
+    }
+
+    const text = message?.text
+    const firstAttachmentName =
+      message?.attachments?.[0]?.payload?.title || message?.attachments?.[0]?.type || ''
+
+    return {
+      externalId,
+      externalThreadId: socialThreadKey(pageId, counterpartId),
+      integrationId,
+      organizationId,
+      createdTime,
+      sentAt: createdTime,
+      receivedAt: createdTime,
+      subject: undefined,
+      from: isEcho ? pageParticipant : counterpartParticipant,
+      to: [isEcho ? counterpartParticipant : pageParticipant],
+      cc: [],
+      bcc: [],
+      replyTo: [],
+      // Neither channel has an inbound attachment ingestor, so no MessageAttachment
+      // rows are ever created. `hasAttachments` is a workflow trigger filter, so
+      // claiming true fires attachment rules for bytes that were never fetched.
+      hasAttachments: false,
+      textPlain: text ?? undefined,
+      textHtml: undefined,
+      snippet: text ? text.substring(0, SNIPPET_LENGTH) : firstAttachmentName,
+      isInbound: !isEcho,
+      metadata: { meta_webhook_event: event as unknown as Record<string, unknown> },
+      keywords: [],
+      labelIds: [],
+    }
+  } catch (error) {
+    logger.error('Failed to convert Meta messaging event', {
+      platform,
+      integrationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}


### PR DESCRIPTION
Plan: `plans/channels/facebook-instagram-runtime-fixes.md` — WS1 + WS1b + WS2, plus WS7a pulled forward.

## The core bug

Both webhook routes stamped `externalThreadId: senderPsid` — marked `!!! Placeholder !!!` in the code — while `syncMessages` stamped the REST conversation id `t_…`. Same conversation, two keys, duplicate threads.

There is a worse half that the placeholder comment doesn't mention: Meta **swaps sender and recipient on an echo**, so keying on `sender.id` files our own replies under the *page* id. Every conversation splits in two before sync is even involved.

## Why a derived key

Meta's page messaging webhook carries no conversation id at all — only `sender.id`, `recipient.id`, `message.mid`. The real `t_…` exists only on the REST `/conversations` edge, and fetching it per inbound message costs a Graph round-trip inside a handler Meta retries on any non-2xx.

A Messenger/IG DM is strictly 1:1, so `(pageId, counterpartId)` **is** the conversation identity. Namespaced `dm:` from day one so post comments can share the column as `comment:{rootCommentId}` later without rewriting every stored key.

## What's in here

- **`packages/lib/src/providers/social/`** — `thread-key.ts`, wire `types.ts`, and one converter for both platforms. The routes shrink to verify → parse → resolve → convert → store, so the wire format is finally unit-testable.
- **`isNull(Integration.deletedAt)`** in both route lookups. Disconnect is a soft delete, so a disconnected channel kept ingesting for as long as `enabled` stayed true.
- **Alias net in ingest.** `reconcileMessage` matched an existing message by `(integrationId, externalId)` and returned early *without* recording the incoming conversation key. Facebook has no rung 2 — `resolveThreadId` gates the RFC 5322 fallback to outlook/imap — so a rung-1 miss forks with nothing to catch it. Recording the alias there self-heals a key disagreement between the two doors via `mid`. Provider-agnostic; also closes it for SMS.
- **Backfill trigger cutoff, both halves.** FB/IG had *neither* side of the contract Gmail/Outlook/Quo implement. The hook now stamps `backfillCutoffAt` on first connect; both providers consume it via `setBackfillCutoff`.
- **Reconnect merged instead of replacing `metadata`** — a wholesale `.set({ metadata })` would have wiped `backfillCutoffAt` and `settings` on every reconnect.
- **Channel display name.** The page name was computed at connect, emitted on the `integration:connected` event, then dropped — `Integration.name` stayed NULL and `getIdentifier` knew nothing about social metadata, so channels rendered as a bare "Facebook Integration". Fixed on both sides; existing channels resolve without reconnecting.

## Why the cutoff is in this PR and not PR 4

A manual sync against the connected page revealed it holds **500+ real customer conversations going back to 2021** (the run walked 20 pagination pages and skipped all of them on the 7-day `since` cutoff). Without the guard, any backfill publishes `message:received` for every one — mass-firing workflow triggers, agent runs and AI classification against five years of real customer mail.

Nothing stamps `initialBackfillCompletedAt` yet because no capped backfill exists. The window therefore stays open until WS7, which is the safe direction: live inbound still fires normally, only history stays silent.

## Testing

- 564 tests pass across `channels`, `providers`, `ingest` (51 files)
- The alias test was verified non-vacuous: reverting the fix fails 2 of its 3 cases
- `packages/lib` typecheck clean in `src/` (29 pre-existing errors, all in `scripts/` and a vitest config)
- `apps/web` typecheck clean on both routes

## Not covered

The hook's stamp/merge paths are covered by typecheck and review only — they're exercised for real by the plan's gate step 5 (disconnect → reconnect → same row, no dup). Live inbound is still untested end to end; that smoke test is the next step.