### PR TITLE
fix(channels): arm and tear down facebook/instagram webhooks for real

### DIFF
--- a/packages/lib/src/channels/recover.ts
+++ b/packages/lib/src/channels/recover.ts
@@ -116,6 +116,22 @@ export async function recoverChannel(
     await armQuoWebhook(channelId, ctx.organizationId)
   }
 
+  // Same two-path reasoning as Outlook and Quo above, and the FB/IG case is the one
+  // most likely to bite in dev: `OAUTH_REDIRECT_BASE` moving with an ngrok tunnel
+  // changes the app-level callback, and a page whose `subscribed_apps` arm was never
+  // re-run stays silent while looking perfectly connected. Re-arming is idempotent —
+  // Meta treats a repeat POST as a no-op — so re-running it can never double-subscribe.
+  if (channel.provider === 'facebook' || channel.provider === 'instagram') {
+    const { rearmSocialPageSubscription } = await import('./social-channel')
+    await rearmSocialPageSubscription(channelId, channel.provider).catch((error) =>
+      logger.warn('Social page re-subscribe failed during channel recovery', {
+        channelId,
+        provider: channel.provider,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    )
+  }
+
   // After the metadata write, not before: `toggle`'s own invalidation fires
   // while the stale `auth` block is still on the row, and the cached channel
   // list carries both `metadata` and `enabled`.

--- a/packages/lib/src/channels/social-channel.ts
+++ b/packages/lib/src/channels/social-channel.ts
@@ -1,0 +1,68 @@
+// packages/lib/src/channels/social-channel.ts
+
+import { database as db, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNull } from 'drizzle-orm'
+import { getChannelTokens } from '../providers/channel-token-accessor'
+import { SOCIAL_SUBSCRIBED_FIELDS, subscribePageToApp } from '../providers/social/api'
+
+const logger = createScopedLogger('social-channel')
+
+export type SocialProviderKey = 'facebook' | 'instagram'
+
+/**
+ * Re-arm a page's `subscribed_apps` subscription outside the OAuth popup.
+ *
+ * **Why this exists at all.** Reconnect settles through two paths and only the
+ * OAuth popup runs the post-connect provisioning hook. The silent token-refresh
+ * path that `useConnectFlow.attemptRefreshThenOAuth` tries first lands in
+ * `recoverChannel` instead — so a channel that recovers silently never re-runs
+ * `subscribePageToApp` and stays deaf while showing as connected. Outlook and Quo
+ * both carry the same branch for the same reason.
+ *
+ * Idempotent: Meta treats a repeat subscription POST as a no-op, so this can be
+ * re-run freely and can never leave two subscriptions for one page.
+ *
+ * Throws on failure — the caller decides whether that is fatal. `recoverChannel`
+ * catches and warns, because recovering the enabled/breaker state must not fail
+ * just because Graph is briefly unavailable.
+ */
+export async function rearmSocialPageSubscription(
+  integrationId: string,
+  provider: SocialProviderKey
+): Promise<void> {
+  const [integration] = await db
+    .select({ metadata: schema.Integration.metadata })
+    .from(schema.Integration)
+    .where(and(eq(schema.Integration.id, integrationId), isNull(schema.Integration.deletedAt)))
+    .limit(1)
+
+  const pageId = (integration?.metadata as { pageId?: string } | null)?.pageId
+  if (!pageId) {
+    logger.warn('Cannot re-arm social page subscription: no pageId on the channel', {
+      integrationId,
+      provider,
+    })
+    return
+  }
+
+  const tokens = await getChannelTokens(integrationId)
+  if (!tokens.accessToken) {
+    logger.warn('Cannot re-arm social page subscription: no page access token', {
+      integrationId,
+      provider,
+    })
+    return
+  }
+
+  // The SAME field set the provisioning hook uses. Re-arming with a narrower set
+  // is how a channel ends up subscribed but missing half its events.
+  await subscribePageToApp(pageId, tokens.accessToken, SOCIAL_SUBSCRIBED_FIELDS[provider])
+
+  logger.info('Re-armed social page subscription', {
+    integrationId,
+    provider,
+    pageId,
+    subscribedFields: SOCIAL_SUBSCRIBED_FIELDS[provider],
+  })
+}

--- a/packages/lib/src/channels/social-provisioning-hook.ts
+++ b/packages/lib/src/channels/social-provisioning-hook.ts
@@ -17,29 +17,20 @@
 import { configService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, isNull, sql } from 'drizzle-orm'
 import { onCacheEvent } from '../cache'
 import type { PostConnectHook, PostConnectHookContext } from '../connections/post-connect-hooks'
 import { resolveConnectionForRuntime } from '../connections/resolve-connection-for-runtime'
 import { publisher } from '../events'
 import { InboxService } from '../inboxes/inbox-service'
 import { setChannelTokens } from '../providers/channel-token-accessor'
-import { subscribePageToApp as subscribePageToAppApi } from '../providers/social/api'
+import {
+  SOCIAL_SUBSCRIBED_FIELDS,
+  subscribePageToApp as subscribePageToAppApi,
+} from '../providers/social/api'
 import { assertSharedConnectInbox } from './connect-inbox'
 
 const logger = createScopedLogger('social-provisioning-hook')
-
-/**
- * Webhook fields each channel subscribes its Page to.
- *
- * Named so `recoverChannel` (WS5) re-arms with exactly the same set — a silent
- * token refresh that subscribes a narrower set is how a channel ends up
- * "connected" but deaf. Comments/feed are deliberately absent: WS10.
- */
-const SUBSCRIBED_FIELDS = {
-  facebook: 'messages,messaging_postbacks,message_reads',
-  instagram: 'messages,messaging_postbacks',
-} as const
 
 const DEFAULT_API_VERSION = 'v26.0'
 
@@ -54,6 +45,28 @@ interface FacebookPage {
   id: string
   name: string
   access_token: string
+  /** Expanded in the same `/me/accounts` call — one extra field, no extra request. */
+  instagram_business_account?: { id?: string; username?: string }
+}
+
+/**
+ * A page the connecting user administers, trimmed to what a picker needs.
+ *
+ * Cached on the CREDENTIAL, not the Integration: it describes the OAuth grant
+ * (what this token can reach), not one channel. Auto-select-first stays for v1 —
+ * the user can already steer it from Facebook's own "choose pages" consent step —
+ * but caching the full list is what makes a real picker, or "add another channel
+ * from this connection", possible later without a second OAuth round trip.
+ *
+ * Deliberately does NOT include page access tokens: those live encrypted on the
+ * credential, and a plaintext copy in a metadata blob is a credential leak waiting
+ * to be logged.
+ */
+export interface CachedSocialPage {
+  id: string
+  name: string
+  igBusinessAccountId?: string
+  igUsername?: string
 }
 
 interface InstagramAccount {
@@ -68,6 +81,8 @@ interface SocialIdentity {
   longLivedPageToken: string
   longLivedUserToken: string
   facebookUserId?: string
+  /** Every page this grant can reach — cached for a future picker (see CachedSocialPage). */
+  availablePages: CachedSocialPage[]
   instagramAccountId?: string
   instagramUsername?: string
 }
@@ -150,7 +165,7 @@ async function fetchFacebookUserId(token: string): Promise<string | undefined> {
 
 /** Pages the user manages, each with its own page access token. */
 async function fetchUserPages(token: string): Promise<FacebookPage[]> {
-  const url = `https://graph.facebook.com/${apiVersion()}/me/accounts?fields=id,name,access_token&access_token=${token}`
+  const url = `https://graph.facebook.com/${apiVersion()}/me/accounts?fields=id,name,access_token,instagram_business_account{id,username}&access_token=${token}`
   const res = await fetch(url)
   const data = await res.json()
   if (!res.ok || !Array.isArray(data.data)) {
@@ -200,6 +215,13 @@ async function discoverIdentity(
     )
   }
 
+  const availablePages: CachedSocialPage[] = pages.map((page) => ({
+    id: page.id,
+    name: page.name,
+    igBusinessAccountId: page.instagram_business_account?.id,
+    igUsername: page.instagram_business_account?.username,
+  }))
+
   if (provider === 'facebook') {
     const page = pages[0]!
     const longLivedPageToken = await exchangeForLongLived(page.access_token)
@@ -209,6 +231,7 @@ async function discoverIdentity(
       longLivedPageToken,
       longLivedUserToken,
       facebookUserId,
+      availablePages,
     }
   }
 
@@ -223,6 +246,7 @@ async function discoverIdentity(
         longLivedPageToken,
         longLivedUserToken,
         facebookUserId,
+        availablePages,
         instagramAccountId: igAccount.id,
         instagramUsername: igAccount.username,
       }
@@ -241,7 +265,9 @@ async function subscribePageToApp(
   pageToken: string
 ): Promise<void> {
   const subscribedFields =
-    provider === 'instagram' ? SUBSCRIBED_FIELDS.instagram : SUBSCRIBED_FIELDS.facebook
+    provider === 'instagram'
+      ? SOCIAL_SUBSCRIBED_FIELDS.instagram
+      : SOCIAL_SUBSCRIBED_FIELDS.facebook
   try {
     await subscribePageToAppApi(pageId, pageToken, subscribedFields)
     logger.info('Page subscribed to app webhook', { pageId, provider, subscribedFields })
@@ -291,7 +317,12 @@ async function upsertSocialIntegration(args: {
     .where(
       and(
         eq(schema.Integration.organizationId, organizationId),
-        eq(schema.Integration.provider, provider)
+        eq(schema.Integration.provider, provider),
+        // Disconnect is a SOFT delete. Without this, a reconnect after disconnect
+        // relinks the tombstoned row: the connect reports success, the Integration
+        // is updated, and the channel never appears anywhere — every list path
+        // filters `deletedAt`. Both sibling hooks document this exact failure.
+        isNull(schema.Integration.deletedAt)
       )
     )
   const existing =
@@ -346,6 +377,31 @@ async function upsertSocialIntegration(args: {
   return { id: created!.id, isNew: true, displayName }
 }
 
+/**
+ * Cache the trimmed page list on the credential.
+ *
+ * jsonb MERGE under a `meta` key so this cannot clobber whatever else the
+ * credential's metadata carries (OAuth bookkeeping written by the connections
+ * layer), and best-effort: a channel that connected fine must not fail
+ * provisioning because a convenience cache could not be written.
+ */
+async function cacheAvailablePages(credentialId: string, pages: CachedSocialPage[]): Promise<void> {
+  try {
+    const metaJson = JSON.stringify({ meta: { pages, cachedAt: new Date().toISOString() } })
+    await db
+      .update(schema.Credential)
+      .set({
+        metadata: sql`COALESCE(${schema.Credential.metadata}, '{}'::jsonb) || ${metaJson}::jsonb`,
+      })
+      .where(eq(schema.Credential.id, credentialId))
+  } catch (error) {
+    logger.warn('Failed to cache available pages on the credential', {
+      credentialId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
 /** The social channel post-connect hook — handles `facebook` and `instagram`. */
 export const socialProvisioningHook: PostConnectHook = {
   providerKeys: ['facebook', 'instagram'],
@@ -394,6 +450,8 @@ export const socialProvisioningHook: PostConnectHook = {
       const inboxService = new InboxService(db, ctx.organizationId, ctx.userId)
       await inboxService.addIntegration(recordId, integration.id)
     }
+
+    await cacheAvailablePages(ctx.credentialId, identity.availablePages)
 
     await subscribePageToApp(provider, identity.pageId, identity.longLivedPageToken)
 

--- a/packages/lib/src/providers/__tests__/sync-mode-resolver.social.test.ts
+++ b/packages/lib/src/providers/__tests__/sync-mode-resolver.social.test.ts
@@ -1,0 +1,24 @@
+// packages/lib/src/providers/__tests__/sync-mode-resolver.social.test.ts
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@auxx/credentials', () => ({ configService: { get: () => undefined } }))
+
+import { resolveEffectiveSyncMode } from '../sync-mode-resolver'
+
+/**
+ * FB/IG plan WS6. Meta delivers page messages by webhook only. Before this branch
+ * existed both providers fell through to `'polling'`, and
+ * `WebhookManagerService.setupWebhooks` early-returns on a polling channel — so
+ * the page `subscribed_apps` arm silently never ran. Quo documents the same trap.
+ */
+describe('resolveEffectiveSyncMode — social channels', () => {
+  it('resolves facebook and instagram to webhook in auto mode', () => {
+    expect(resolveEffectiveSyncMode({ syncMode: 'auto', provider: 'facebook' })).toBe('webhook')
+    expect(resolveEffectiveSyncMode({ syncMode: 'auto', provider: 'instagram' })).toBe('webhook')
+  })
+
+  it('still honours an explicit polling override', () => {
+    expect(resolveEffectiveSyncMode({ syncMode: 'polling', provider: 'facebook' })).toBe('polling')
+  })
+})

--- a/packages/lib/src/providers/facebook/facebook-oauth.ts
+++ b/packages/lib/src/providers/facebook/facebook-oauth.ts
@@ -8,6 +8,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
 import { deleteChannelTokens, getChannelTokens } from '../channel-token-accessor'
 import { markCredentialReauth } from '../credential-auth-state'
+import { isLastChannelForFacebookUser } from '../social/disconnect'
 
 const logger = createScopedLogger('facebook-oauth')
 const DEFAULT_API_VERSION = 'v26.0'
@@ -179,7 +180,15 @@ export class FacebookOAuthService {
       }
 
       // 2. Revoke App Permissions for the User
-      if (facebookUserId && userAccessToken && userAccessToken !== 'N/A') {
+      // Gated: `DELETE /{user-id}/permissions` revokes the app for the WHOLE
+      // Facebook account, so revoking here while a sibling channel (the linked
+      // Instagram account, a second page) still uses that login silently kills it.
+      // The per-page unsubscribe above is the real teardown; this step is only
+      // correct when nothing else depends on the grant.
+      const mayRevokeAppPermissions =
+        !!facebookUserId && (await isLastChannelForFacebookUser({ integrationId, facebookUserId }))
+
+      if (mayRevokeAppPermissions && userAccessToken && userAccessToken !== 'N/A') {
         const revokeUrl = `https://graph.facebook.com/${this.apiVersion}/${facebookUserId}/permissions`
         const revokeParams = new URLSearchParams({ access_token: userAccessToken })
         try {

--- a/packages/lib/src/providers/facebook/facebook-provider.ts
+++ b/packages/lib/src/providers/facebook/facebook-provider.ts
@@ -19,6 +19,7 @@ import type {
 import { getChannelTokens } from '../channel-token-accessor'
 import { BaseMessageProvider, type MessageProvider } from '../message-provider-interface'
 import { getProviderCapabilities, type ProviderCapabilities } from '../provider-capabilities'
+import { SOCIAL_SUBSCRIBED_FIELDS, subscribePageToApp, unsubscribePageFromApp } from '../social/api'
 import { sendSocialMessage } from '../social/send'
 import { socialThreadKey } from '../social/thread-key'
 import { type FacebookIntegrationMetadata, FacebookOAuthService } from './facebook-oauth'
@@ -257,26 +258,34 @@ export class FacebookProvider
     return { id: messageId, success: true }
   }
 
-  /** Confirms webhook setup (managed externally via FB App Dashboard) */
-  async setupWebhook(callbackUrl: string): Promise<void> {
+  /**
+   * Subscribe this Page to the app's webhook.
+   *
+   * Real work now, not a log line. The APP-level config (callback URL, verify
+   * token, which objects the app listens to) stays manual in the Meta App
+   * Dashboard — only the per-page subscription is ours to arm, and it is the half
+   * that goes missing when a page is reconnected or a token is refreshed silently.
+   *
+   * `callbackUrl` is accepted for interface parity and deliberately unused: Meta
+   * has no per-page callback: every page on the app posts to the app's one URL.
+   */
+  async setupWebhook(_callbackUrl: string): Promise<void> {
     await this.ensureInitialized()
-    // Actual subscription is done via OAuthService.subscribePageToApp and FB App Dashboard.
-    // This method serves as a placeholder or potential verification step.
-    logger.info(
-      `Facebook webhook setup confirmation check for Page ID: ${this.pageId}. Ensure webhooks are configured in the Facebook App Dashboard pointing to the correct callback URL.`,
-      { integrationId: this.integrationId, expectedCallback: callbackUrl }
-    )
-    return Promise.resolve()
+    await subscribePageToApp(this.pageId!, this.pageAccessToken!, SOCIAL_SUBSCRIBED_FIELDS.facebook)
+    logger.info('Facebook page subscribed to app webhook', {
+      integrationId: this.integrationId,
+      pageId: this.pageId,
+      subscribedFields: SOCIAL_SUBSCRIBED_FIELDS.facebook,
+    })
   }
-  /** Confirms webhook removal (managed externally via FB App Dashboard/Disconnect) */
+  /** Unsubscribe this Page from the app's webhook — real `DELETE`, not a log line. */
   async removeWebhook(): Promise<void> {
     await this.ensureInitialized()
-    // Actual unsubscription is done via OAuthService.unsubscribePageFromApp during disconnect.
-    logger.info(
-      `Facebook webhook removal confirmation check for Page ID: ${this.pageId}. Unsubscription is typically handled during integration disconnect.`,
-      { integrationId: this.integrationId }
-    )
-    return Promise.resolve()
+    await unsubscribePageFromApp(this.pageId!, this.pageAccessToken!)
+    logger.info('Facebook page unsubscribed from app webhook', {
+      integrationId: this.integrationId,
+      pageId: this.pageId,
+    })
   }
   /**
    * Synchronizes messages from Facebook Messenger using the Conversation API.

--- a/packages/lib/src/providers/instagram/instagram-oauth.ts
+++ b/packages/lib/src/providers/instagram/instagram-oauth.ts
@@ -9,6 +9,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
 import { deleteChannelTokens, getChannelTokens } from '../channel-token-accessor'
 import { markCredentialReauth } from '../credential-auth-state'
+import { isLastChannelForFacebookUser } from '../social/disconnect'
 
 const logger = createScopedLogger('instagram-oauth')
 const DEFAULT_API_VERSION = 'v26.0'
@@ -112,7 +113,15 @@ export class InstagramOAuthService {
         logger.warn('Missing Page ID or PAT, cannot unsubscribe webhooks.', { integrationId })
       }
 
-      if (facebookUserId && userAccessToken && userAccessToken !== 'N/A') {
+      // Gated: `DELETE /{user-id}/permissions` revokes the app for the WHOLE
+      // Facebook account, so revoking here while a sibling channel (the Facebook
+      // page this IG account is linked to, another page) still uses that login
+      // silently kills it. The per-page unsubscribe above is the real teardown;
+      // this step is only correct when nothing else depends on the grant.
+      const mayRevokeAppPermissions =
+        !!facebookUserId && (await isLastChannelForFacebookUser({ integrationId, facebookUserId }))
+
+      if (mayRevokeAppPermissions && userAccessToken && userAccessToken !== 'N/A') {
         const revokeUrl = `https://graph.facebook.com/${this.apiVersion}/${facebookUserId}/permissions`
         const revokeParams = new URLSearchParams({ access_token: userAccessToken })
         try {

--- a/packages/lib/src/providers/instagram/instagram-provider.ts
+++ b/packages/lib/src/providers/instagram/instagram-provider.ts
@@ -19,6 +19,7 @@ import type {
 import { getChannelTokens } from '../channel-token-accessor'
 import { BaseMessageProvider, type MessageProvider } from '../message-provider-interface'
 import { getProviderCapabilities, type ProviderCapabilities } from '../provider-capabilities'
+import { SOCIAL_SUBSCRIBED_FIELDS, subscribePageToApp, unsubscribePageFromApp } from '../social/api'
 import { sendSocialMessage } from '../social/send'
 import { socialThreadKey } from '../social/thread-key'
 import { type InstagramIntegrationMetadata, InstagramOAuthService } from './instagram-oauth'
@@ -269,24 +270,35 @@ export class InstagramProvider
     return { id: messageId, success: true }
   }
 
-  /** Confirms webhook setup (managed externally via FB App Dashboard) */
-  async setupWebhook(callbackUrl: string): Promise<void> {
+  /**
+   * Subscribe the linked Page to the app's webhook for the `instagram` object.
+   *
+   * Subscribes on the **Page** id, not the IG account id — that is where Meta
+   * holds the subscription for a page-linked Instagram account. App-level config
+   * stays manual in the Meta App Dashboard.
+   */
+  async setupWebhook(_callbackUrl: string): Promise<void> {
     await this.ensureInitialized()
-    logger.info(
-      `Instagram webhook setup confirmation check for Page ID: ${this.pageId}. Ensure webhooks are configured in the Facebook App Dashboard for the 'instagram' object.`,
-      { integrationId: this.integrationId, expectedCallback: callbackUrl }
+    await subscribePageToApp(
+      this.pageId!,
+      this.pageAccessToken!,
+      SOCIAL_SUBSCRIBED_FIELDS.instagram
     )
-    // Verification/subscription occurs during OAuth and via FB App Dashboard settings.
-    return Promise.resolve()
+    logger.info('Instagram page subscribed to app webhook', {
+      integrationId: this.integrationId,
+      pageId: this.pageId,
+      igBusinessAccountId: this.instagramBusinessAccountId,
+      subscribedFields: SOCIAL_SUBSCRIBED_FIELDS.instagram,
+    })
   }
-  /** Confirms webhook removal (managed externally via FB App Dashboard/Disconnect) */
+  /** Unsubscribe the linked Page from the app's webhook. */
   async removeWebhook(): Promise<void> {
     await this.ensureInitialized()
-    logger.info(
-      `Instagram webhook removal confirmation check for Page ID: ${this.pageId}. Unsubscription is handled during integration disconnect.`,
-      { integrationId: this.integrationId }
-    )
-    return Promise.resolve()
+    await unsubscribePageFromApp(this.pageId!, this.pageAccessToken!)
+    logger.info('Instagram page unsubscribed from app webhook', {
+      integrationId: this.integrationId,
+      pageId: this.pageId,
+    })
   }
   /**
    * Synchronizes messages from Instagram via the linked Facebook Page's Conversation API.

--- a/packages/lib/src/providers/social/__tests__/subscribed-fields.test.ts
+++ b/packages/lib/src/providers/social/__tests__/subscribed-fields.test.ts
@@ -1,0 +1,37 @@
+// packages/lib/src/providers/social/__tests__/subscribed-fields.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { SOCIAL_SUBSCRIBED_FIELDS } from '../api'
+
+/**
+ * FB/IG plan WS5/WS6 — one field set, three arm sites.
+ *
+ * The provisioning hook, the provider's `setupWebhook`, and `recoverChannel`'s
+ * re-arm all subscribe the same Page. If they disagree, a channel re-armed by the
+ * silent-refresh path ends up subscribed to a NARROWER set than the one it
+ * connected with — it looks connected and is deaf to half its events, which is the
+ * hardest kind of channel bug to notice.
+ */
+describe('SOCIAL_SUBSCRIBED_FIELDS', () => {
+  it('subscribes messages and postbacks on both channels', () => {
+    for (const fields of Object.values(SOCIAL_SUBSCRIBED_FIELDS)) {
+      const set = fields.split(',')
+      expect(set).toContain('messages')
+      expect(set).toContain('messaging_postbacks')
+    }
+  })
+
+  it('does NOT subscribe feed/comments — comments are not ingested yet (WS10)', () => {
+    // Subscribing early would deliver comment events to a route that drops them,
+    // making the "we handle comments" question look answered when it isn't.
+    for (const fields of Object.values(SOCIAL_SUBSCRIBED_FIELDS)) {
+      expect(fields).not.toContain('feed')
+      expect(fields).not.toContain('comments')
+      expect(fields).not.toContain('mentions')
+    }
+  })
+
+  it('has an entry for exactly the two social providers', () => {
+    expect(Object.keys(SOCIAL_SUBSCRIBED_FIELDS).sort()).toEqual(['facebook', 'instagram'])
+  })
+})

--- a/packages/lib/src/providers/social/api.ts
+++ b/packages/lib/src/providers/social/api.ts
@@ -248,6 +248,23 @@ export async function getPageIgAccount(
   return result.instagram_business_account ?? null
 }
 
+/**
+ * Webhook fields each channel subscribes its Page to.
+ *
+ * Exported so the provisioning hook, the provider's `setupWebhook`, and
+ * `recoverChannel`'s re-arm all use the SAME set. A silent re-arm that subscribes
+ * a narrower set is how a channel ends up "connected" but deaf to half its events.
+ *
+ * Both objects subscribe on the **Page** — `/{page-id}/subscribed_apps` — including
+ * Instagram, whose events are delivered for the IG account linked to that page.
+ *
+ * Comments/feed are deliberately absent: post comments are WS10, not yet ingested.
+ */
+export const SOCIAL_SUBSCRIBED_FIELDS = {
+  facebook: 'messages,messaging_postbacks,message_reads',
+  instagram: 'messages,messaging_postbacks',
+} as const
+
 /** `POST /{pageId}/subscribed_apps` — the social analogue of arming a Gmail watch. */
 export async function subscribePageToApp(
   pageId: string,

--- a/packages/lib/src/providers/social/disconnect.ts
+++ b/packages/lib/src/providers/social/disconnect.ts
@@ -1,0 +1,53 @@
+// packages/lib/src/providers/social/disconnect.ts
+
+import { database as db, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNull, ne, or, sql } from 'drizzle-orm'
+
+const logger = createScopedLogger('social-disconnect')
+
+/**
+ * May we revoke this app's permissions for the Facebook user?
+ *
+ * `DELETE /{user-id}/permissions` revokes the app's access for the WHOLE user, not
+ * for one page — so disconnecting a Facebook channel would silently kill every
+ * other channel connected through the same Facebook account: the linked Instagram
+ * channel, a second page, another org member's channel on the same login. They
+ * keep their rows and their tokens and simply stop working.
+ *
+ * The page-level `subscribed_apps` unsubscribe is the correct per-channel teardown
+ * and always runs. This gate only protects the account-wide step.
+ *
+ * @returns true when this is the last live channel on that Facebook user id.
+ */
+export async function isLastChannelForFacebookUser(args: {
+  integrationId: string
+  facebookUserId: string
+}): Promise<boolean> {
+  const { integrationId, facebookUserId } = args
+
+  const siblings = await db
+    .select({ id: schema.Integration.id })
+    .from(schema.Integration)
+    .where(
+      and(
+        ne(schema.Integration.id, integrationId),
+        isNull(schema.Integration.deletedAt),
+        or(
+          eq(schema.Integration.provider, 'facebook'),
+          eq(schema.Integration.provider, 'instagram')
+        ),
+        sql`${schema.Integration.metadata} ->> 'userId' = ${facebookUserId}`
+      )
+    )
+    .limit(1)
+
+  if (siblings.length > 0) {
+    logger.info('Skipping app-permission revoke: other channels still use this Facebook account', {
+      integrationId,
+      facebookUserId,
+    })
+    return false
+  }
+  return true
+}

--- a/packages/lib/src/providers/sync-mode-resolver.ts
+++ b/packages/lib/src/providers/sync-mode-resolver.ts
@@ -58,6 +58,18 @@ export function resolveEffectiveSyncMode(integration: {
     return 'webhook'
   }
 
+  if (integration.provider === 'facebook' || integration.provider === 'instagram') {
+    // Meta delivers page messages by webhook only — there is no polling story for
+    // Messenger/IG DMs beyond the REST conversation backfill, which is a separate
+    // job. Without this branch they fall through to 'polling' below and
+    // `WebhookManagerService.setupWebhooks` early-returns, silently no-opping the
+    // page `subscribed_apps` arm (same trap Quo documents above).
+    //
+    // The app-level webhook config (callback URL, verify token, subscribed objects)
+    // stays manual in the Meta App Dashboard; only the per-page subscription is ours.
+    return 'webhook'
+  }
+
   // Default for future providers (IMAP, etc.)
   return 'polling'
 }


### PR DESCRIPTION
Plan: `plans/channels/facebook-instagram-runtime-fixes.md` — WS5 + WS6. Follows #1697 and #1698.

## The lifecycle was decorative

`setupWebhook` and `removeWebhook` were log lines on both providers. And both channels resolved to `'polling'` in `sync-mode-resolver`, where `WebhookManagerService.setupWebhooks` early-returns — so even the call that would have armed them never fired. Quo carries a comment documenting this exact trap.

Both now resolve to `'webhook'` and do real `subscribed_apps` POST/DELETE through the WS3 seam. Both subscribe on the **Page** id — that's where Meta holds the subscription even for Instagram. `callbackUrl` is accepted and unused on purpose: Meta has no per-page callback, only the app's one URL.

## Three reconnect defects, one symptom

Each of these ends with a channel that reports connected and then does nothing:

1. **`upsertSocialIntegration` matched without `isNull(deletedAt)`.** Disconnect is a soft delete, so a reconnect relinked the tombstoned row — connect succeeds, the Integration updates, and the channel never appears anywhere because every list path filters `deletedAt`. Both sibling hooks document this failure.

2. **The silent-refresh path never re-armed.** Only the OAuth popup runs the post-connect hook; `useConnectFlow.attemptRefreshThenOAuth` tries a silent refresh first and lands in `recoverChannel` instead. New `channels/social-channel.ts` exports `rearmSocialPageSubscription`, called from `recoverChannel` alongside the existing Outlook and Quo branches. Idempotent — Meta treats a repeat subscribe as a no-op. This is the dev-tunnel case exactly: move `NGROK_URL` and the channel goes quiet while looking fine.

3. **The field set lived in one place and was used in three.** Any re-arm could subscribe a narrower set than the original connect did, leaving a channel deaf to half its events. Now one exported `SOCIAL_SUBSCRIBED_FIELDS`, with a test asserting it contains messages+postbacks and does *not* contain `feed`/`comments` (subscribing to comments before WS10 would deliver events to a route that drops them, making the question look answered).

## Bug found while verifying disconnect

WS6 only asked me to *verify* that disconnect unsubscribes the page. It does — step 1 of `revokeAccess` in both OAuth services. Step 2 is the problem.

`DELETE /{user-id}/permissions` revokes the app for the **whole Facebook account**, not for one page. So disconnecting a Facebook channel silently killed every other channel connected through that same login: the linked Instagram channel, a second page, another org member's channel. They keep their rows and their tokens and simply stop working — no error, no banner.

Now gated on `isLastChannelForFacebookUser`. The per-page unsubscribe always runs, since that's the correct per-channel teardown; the account-wide revoke only fires when nothing else depends on the grant.

## Page-list cache

`/me/accounts` gains an `instagram_business_account{id,username}` expansion — one extra field, **no extra request** — and the trimmed list lands on `Credential.metadata.meta`.

On the credential rather than the Integration, because it describes the OAuth grant (what this token can reach), not one channel. **No page access tokens are cached**: those stay encrypted on the credential, and a plaintext copy in a metadata blob is a leak waiting to be logged. Auto-select-first is unchanged — this only unblocks a real picker, or "add another channel from this connection", without a second OAuth round trip.

## Testing

- 575 tests green across `providers`, `channels`, `ingest` (54 files); 5 new
- `packages/lib` typecheck clean in `src/`

## Not verified

The re-arm and reconnect paths are covered by typecheck and review — they need gate step 5 (disconnect → reconnect → same row, no dup) against the real app. The sibling-channel revoke guard has no test because it needs a second connected social channel to be meaningful; the query is a straight `ne(id) AND isNull(deletedAt) AND metadata->>'userId' = …`.