### PR TITLE
chore(channels): delete dead facebook/instagram defs and rewrite the setup doc

### DIFF
--- a/apps/worker/.env.example
+++ b/apps/worker/.env.example
@@ -37,14 +37,11 @@ OUTLOOK_WEBHOOK_SECRET=
 # Facebook
 FACEBOOK_APP_ID=
 FACEBOOK_APP_SECRET=
-FACEBOOK_GRAPH_API_VERSION="v19.0"
+FACEBOOK_GRAPH_API_VERSION="v26.0"
 FACEBOOK_WEBHOOK_VERIFY_TOKEN=
 
-# Instagram
-# INSTAGRAM_APP_ID=
-# INSTAGRAM_APP_SECRET=
-# INSTAGRAM_GRAPH_API_VERSION="v19.0"
-# INSTAGRAM_WEBHOOK_VERIFY_TOKEN=
+# Instagram DMs ride the SAME Facebook app (IG Messaging is a Facebook-Graph child).
+# There is no separate Instagram app, client id, or verify token.
 
 DATABASE_URL="postgresql://postgres:password@localhost:5432/auxx-ai"
 # DB_POOL_MAX=10

--- a/docs/setup-facebook.md
+++ b/docs/setup-facebook.md
@@ -1,110 +1,141 @@
-# Setup Guide for Facebook Messenger Integration
+# Facebook Messenger & Instagram DM setup
+
+Both channels run on **one Meta app** and **one OAuth route**. Instagram Messaging is a
+child of the Facebook Graph API, so there is no separate Instagram app, client id, or
+verify token — connecting Instagram means authorizing the same Facebook app against a
+Page that has an Instagram professional account linked to it.
+
+> Architecture decisions behind this (why Facebook Login rather than Instagram Login,
+> why page tokens rather than the 60-day refresh treadmill) live in
+> `plans/channels/facebook-instagram-channel-rewrite.md`.
 
 ## Prerequisites
 
-- A Facebook account
-- A Facebook Page (the integration connects to a Page, not a personal profile)
+- A Facebook account with a **Page** (the integration connects to a Page, never a personal profile)
+- For Instagram: an Instagram **professional** account (Business or Creator), linked to
+  that Page, with **Settings → Messages → Allow access to messages** turned on. Without
+  that toggle Meta delivers no message webhooks for the account, and nothing in the
+  connect flow will tell you.
 
-## Step 1: Create a Facebook App
+## 1. Create the Meta app
 
-1. Go to [Meta for Developers](https://developers.facebook.com/)
-2. Click **My Apps** in the top-right corner
-3. Click **Create App**
-4. Select **Other** as the use case, then click **Next**
-5. Select **Business** as the app type, then click **Next**
-6. Enter an app name (e.g., "Auxx AI Support")
-7. Enter a contact email
-8. Optionally select a Business Portfolio, then click **Create App**
+1. [Meta for Developers](https://developers.facebook.com/) → **My Apps** → **Create App**
+2. Use case: **Other** → type: **Business**
+3. Name it, add a contact email, create.
+4. Add the **Messenger** product, and **Facebook Login** (Login is what the connect flow uses).
 
-## Step 2: Get App ID and App Secret
+## 2. App ID and secret
 
-1. In your app dashboard, go to **App Settings** > **Basic**
-2. Copy the **App ID** — this is your `FACEBOOK_APP_ID`
-3. Click **Show** next to the App Secret field, enter your password
-4. Copy the **App Secret** — this is your `FACEBOOK_APP_SECRET`
+**App Settings → Basic.** Copy the App ID and (after **Show**) the App Secret.
 
-## Step 3: Add Messenger Product
+| Variable | Value |
+| --- | --- |
+| `FACEBOOK_APP_ID` | App ID |
+| `FACEBOOK_APP_SECRET` | App Secret |
+| `FACEBOOK_GRAPH_API_VERSION` | `v26.0` |
+| `FACEBOOK_WEBHOOK_VERIFY_TOKEN` | `openssl rand -hex 32` |
 
-1. In the left sidebar, click **Add Product**
-2. Find **Messenger** and click **Set Up**
-3. This adds the Messenger product to your app
+**Set these in the worker's env too, not just the web app's.** Message sync runs in
+`@auxx/worker`, which loads its own `.env` — a version pinned only in the root `.env` will
+not reach it.
 
-## Step 4: Configure OAuth Redirect URI
+> `FACEBOOK_GRAPH_API_VERSION` must not be left at an old value. Graph answers a
+> deprecated version by silently serving a current one and returning `paging.next` links
+> stamped with the newer version, so a stale pin produces requests whose behaviour you
+> cannot predict from the code.
 
-1. In the left sidebar, go to **Facebook Login** > **Settings** (if Facebook Login was auto-added) or add the **Facebook Login** product first
-2. Under **Valid OAuth Redirect URIs**, add:
+### After ANY credential change: re-seed
 
-```
-https://app.auxx.ai/api/facebook/oauth2/callback
-```
-
-3. Click **Save Changes**
-
-## Step 5: Configure Webhook
-
-1. In the left sidebar, go to **Messenger** > **Messenger API Settings**
-2. Scroll to the **Webhooks** section and click **Add Callback URL**
-3. Enter the following:
-   - **Callback URL**: `https://app.auxx.ai/api/facebook/webhook`
-   - **Verify Token**: A random string you generate (see step below)
-4. Click **Verify and Save**
-
-### Generate the Verify Token
-
-Generate a random token to use as `FACEBOOK_WEBHOOK_VERIFY_TOKEN`:
+`ensurePlatformProviders` bakes **encrypted copies** of the OAuth client into the
+`ConnectionDefinition` rows at seed time. Editing env alone is inert at runtime — the old
+client is still in the database, and the connect fails with "App not active".
 
 ```bash
-openssl rand -hex 32
+npx dotenv -- npx tsx packages/lib/scripts/reseed-platform-providers.ts
 ```
 
-Set this value in your environment/secrets, and use the same value in the webhook **Verify Token** field above.
+## 3. OAuth redirect URI
 
-## Step 6: Subscribe to Webhook Events
+The callback is keyed on the **ConnectionDefinition id**, not the provider name:
 
-1. After verifying the webhook, you need to subscribe your Page to events
-2. In the **Webhooks** section, click **Add Subscriptions**
-3. Select the following fields:
-   - `messages` — Receive incoming messages
-   - `messaging_postbacks` — Receive postback button clicks
-   - `message_deliveries` — Delivery confirmations
-   - `message_reads` — Read receipts
+```
+{BASE}/api/connections/{connectionDefinitionId}/oauth2/callback
+```
 
-## Step 7: Connect Your Page
+**That id is a cuid, and it differs per environment** — dev and production have separate
+seeded rows. There is no static URL to copy. Read the ids for your environment:
 
-1. In the **Webhooks** section, under **Page Subscriptions**, select the Facebook Page you want to connect
-2. Click **Subscribe** to link the page to your app
-3. This step is also handled automatically during the OAuth flow in the app
+```sql
+SELECT id, "providerKey" FROM "ConnectionDefinition"
+WHERE "providerKey" IN ('facebook', 'instagram');
+```
 
-## Step 8: Configure App Permissions
+Register **both** resulting URLs under **Facebook Login → Settings → Valid OAuth Redirect
+URIs**.
 
-1. Go to **App Review** > **Permissions and Features**
-2. Request the following permissions:
-   - `pages_messaging` — Send and receive messages
-   - `pages_manage_metadata` — Subscribe to webhooks
-   - `pages_read_engagement` — Read messages and conversations
+In dev, `{BASE}` is `NGROK_URL` when set, otherwise `WEBAPP_URL` — the tunnel host, not
+`localhost:3000`, because Meta will not redirect to a private address.
 
-> **Note:** For development/testing, these permissions work immediately for app admins and testers. For production use with external users, you need to submit for App Review.
+## 4. Webhooks
 
-## Step 9: Set Environment Variables
+App-level webhook configuration is **manual, in the App Dashboard**. Only the *per-page*
+subscription is automated (the connect flow and `recoverChannel` both arm it).
 
-Set the following environment variables in your app:
+**Messenger → Messenger API Settings → Webhooks → Add Callback URL:**
 
-| Variable                         | Value                                        |
-| -------------------------------- | -------------------------------------------- |
-| `FACEBOOK_APP_ID`                | App ID from Step 2                           |
-| `FACEBOOK_APP_SECRET`            | App Secret from Step 2                       |
-| `FACEBOOK_GRAPH_API_VERSION`     | `v19.0` (default, already set)               |
-| `FACEBOOK_WEBHOOK_VERIFY_TOKEN`  | Random string from Step 5                    |
+- Callback URL: `{BASE}/api/facebook/webhook`
+- Verify Token: your `FACEBOOK_WEBHOOK_VERIFY_TOKEN`
 
-## Step 10: Switch to Live Mode
+Subscribe the `page` object to: `messages`, `messaging_postbacks`, `message_reads`.
 
-1. At the top of your app dashboard, toggle the app mode from **Development** to **Live**
-2. You may need to complete a few requirements:
-   - Add a Privacy Policy URL in **App Settings** > **Basic**
-   - Complete any required App Review submissions
+**Instagram → Webhooks** (separate callback, same verify token):
+
+- Callback URL: `{BASE}/api/instagram/webhook`
+- Subscribe the `instagram` object to: `messages`, `messaging_postbacks`
+
+Do **not** subscribe `feed` or `comments`. Post comments are not ingested — the routes
+log and drop them — so subscribing only makes the gap look handled.
+
+The verify handshake is a `GET` with `hub.challenge`; a mismatch answers 403 and Meta
+shows "The URL couldn't be validated".
+
+## 5. Permissions
+
+Requested by the connect flow (`connections/providers/defs.ts`):
+
+- **Facebook:** `pages_messaging`, `pages_manage_metadata`, `pages_read_engagement`,
+  `pages_show_list`, `business_management`
+- **Instagram:** the same five, plus `instagram_basic` and `instagram_manage_messages`
+
+`business_management` is not optional: without it, Pages owned by a Business portfolio
+are simply absent from `/me/accounts` at connect time, and the connect fails with
+"No Facebook Pages found" on an account that plainly has Pages.
+
+In **Development** mode these work immediately for people holding a role on the app
+(admin, developer, tester) against Pages they administer — no App Review. External users
+need App Review and Live mode.
+
+Two review items worth knowing before you rely on them:
+
+- **Human Agent** — required to reply outside Meta's 24-hour messaging window. Auxx uses
+  the `HUMAN_AGENT` tag for composer replies past the window; automated (agent/workflow)
+  sends are blocked there rather than tagged, because tagging bot traffic as human is a
+  policy violation Meta detects.
+- Instagram message webhooks may require the app to be **Live** even for role-holders.
+
+## 6. Connect
+
+In Auxx: **Settings → Channels → Add channel → Facebook** (or Instagram). Facebook's own
+consent step is where you choose which Pages to grant; Auxx currently auto-selects the
+first eligible Page, so grant only the Page you want, or steer it there.
 
 ## Troubleshooting
 
-- **Webhook verification fails:** Ensure the verify token in Meta Developer Console matches your `FACEBOOK_WEBHOOK_VERIFY_TOKEN` env variable exactly, and that the webhook endpoint is publicly accessible.
-- **Not receiving messages:** Check that the Page is subscribed to the webhook events and that the app is in Live mode for non-admin users.
-- **Token errors:** Facebook Page Access Tokens obtained via the OAuth flow are long-lived but can still be invalidated if the user removes the app from their Page settings.
+| Symptom | Cause |
+| --- | --- |
+| "App not active" on connect | Env changed without re-seeding — see §2. |
+| Webhook validation fails | Verify token mismatch, or `{BASE}` not publicly reachable. |
+| Connected, but no messages arrive | The Page subscription did not arm. Check `GET /{pageId}/subscribed_apps`. Reconnecting through the OAuth popup re-arms it; so does channel recovery. |
+| Instagram connects but stays silent | "Allow access to messages" is off, the IG account is not professional, or the app needs to be Live. |
+| Connect succeeds, channel never appears | Historically a disconnected (soft-deleted) row being relinked. Fixed — but check `Integration.deletedAt` if it recurs. |
+| Token errors after working fine | Page tokens are long-lived but die if the user removes the app from Page settings. Surfaces as `requiresReauth`; there is no refresh grant. |

--- a/packages/lib/scripts/link-channel-credentials.ts
+++ b/packages/lib/scripts/link-channel-credentials.ts
@@ -14,8 +14,12 @@ import { and, eq, isNull } from 'drizzle-orm'
 const PROVIDER_TO_PROVIDER_KEY: Record<string, string> = {
   google: 'gmail',
   outlook: 'outlookMail',
-  facebook: 'facebookOAuth2Api',
-  instagram: 'instagramOAuth2Api',
+  // The CHANNEL defs, not the workflow `facebookOAuth2Api`/`instagramOAuth2Api`
+  // connectors — those are a different (and non-functional) pair keyed on env vars
+  // that do not exist. Mapping to them here meant this script could never resolve a
+  // def id for a social channel and silently linked nothing.
+  facebook: 'facebook',
+  instagram: 'instagram',
   shopify: 'shopifyOAuth2Api',
   imap: 'imap',
   email: 'smtp',

--- a/packages/lib/src/connections/providers/defs.ts
+++ b/packages/lib/src/connections/providers/defs.ts
@@ -144,8 +144,11 @@ export const PLATFORM_PROVIDER_DEFS: PlatformProviderDef[] = [
     uiMetadata: { icon: 'brand:outlook', category: 'email', brandColor: '#0078d4' },
   },
   // ── Social messaging channel defs (Facebook + Instagram) ────────────────────
-  // These are the CHANNEL defs (providerKey == Integration.provider class), distinct
-  // from the workflow `facebookOAuth2Api`/`instagramOAuth2Api` connectors below. Both
+  // These are the CHANNEL defs (providerKey == Integration.provider class), and as of
+  // 2026-08-17 the ONLY Facebook/Instagram defs — the workflow `facebookOAuth2Api` /
+  // `instagramOAuth2Api` connectors that used to sit below were deleted: they keyed on
+  // `FACEBOOK_CLIENT_ID`/`INSTAGRAM_CLIENT_ID` env vars that exist nowhere, and the
+  // Instagram one pointed at the Basic Display API Meta retired in Dec 2024. Both
   // use the platform Facebook app (IG Messaging is a Facebook-Graph child — no separate
   // Instagram app) and authorize through the Facebook login dialog. The OAuth code
   // exchange yields a USER token; the social post-connect hook derives the long-lived
@@ -232,42 +235,6 @@ export const PLATFORM_PROVIDER_DEFS: PlatformProviderDef[] = [
     baseUrlTemplate: 'https://{shop}.myshopify.com/admin/api/2024-10',
     uiMetadata: { icon: 'brand:shopify', category: 'ecommerce', brandColor: '#5d8a66' },
   },
-  {
-    providerKey: 'facebookOAuth2Api',
-    connectionType: 'oauth2-code',
-    label: 'Facebook OAuth2',
-    global: false,
-    oauth2AuthorizeUrl: 'https://www.facebook.com/v18.0/dialog/oauth',
-    oauth2AccessTokenUrl: 'https://graph.facebook.com/v18.0/oauth/access_token',
-    oauth2Scopes: [
-      'pages_manage_metadata',
-      'pages_read_engagement',
-      'pages_manage_posts',
-      'pages_messaging',
-      'pages_show_list',
-      'business_management',
-    ],
-    systemClientIdEnv: 'FACEBOOK_CLIENT_ID',
-    systemClientSecretEnv: 'FACEBOOK_CLIENT_SECRET',
-    oauth2Features: { additionalAuthorizeParams: { response_type: 'code', display: 'popup' } },
-    authApply: BEARER,
-    uiMetadata: { icon: 'brand:facebook', category: 'social', brandColor: '#1877f2' },
-  },
-  {
-    providerKey: 'instagramOAuth2Api',
-    connectionType: 'oauth2-code',
-    label: 'Instagram OAuth2',
-    global: false,
-    oauth2AuthorizeUrl: 'https://api.instagram.com/oauth/authorize',
-    oauth2AccessTokenUrl: 'https://api.instagram.com/oauth/access_token',
-    oauth2Scopes: ['user_profile', 'user_media'],
-    systemClientIdEnv: 'INSTAGRAM_CLIENT_ID',
-    systemClientSecretEnv: 'INSTAGRAM_CLIENT_SECRET',
-    oauth2Features: { additionalAuthorizeParams: { response_type: 'code' } },
-    authApply: BEARER,
-    uiMetadata: { icon: 'brand:instagram', category: 'social', brandColor: '#e4405f' },
-  },
-
   // ────────────────────────────────────────────────────────────────────────
   // Storage OAuth2 providers (per-user, platform client creds)
   // ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Plan: `plans/channels/facebook-instagram-runtime-fixes.md` — WS9. Follows #1697, #1698, #1699.

## Dead connection defs

`facebookOAuth2Api` and `instagramOAuth2Api` could never work. They keyed on `FACEBOOK_CLIENT_ID` / `INSTAGRAM_CLIENT_ID` — env vars that appear nowhere in the repo (the real ones are `FACEBOOK_APP_ID`/`FACEBOOK_APP_SECRET`) — and the Instagram def pointed at `api.instagram.com/oauth/authorize` with `user_profile,user_media` scopes, i.e. the Basic Display API Meta retired in December 2024. No workflow node referenced either.

Deleted. The two working channel defs are now the only Facebook/Instagram entries.

**Follow-up not taken here:** `packages/workflow-nodes/src/credentials/{facebook,instagram}-oauth2.credentials.ts` still exist and are registered in `packages/credentials`' `credential-type-registry.ts`. Their `name` no longer resolves to any ConnectionDefinition. Not a regression — they were equally broken before — but removing them spans two more packages than this change, so it's flagged rather than folded in.

## `link-channel-credentials.ts`

Mapped `facebook`/`instagram` to those same dead defs, so the script could never resolve a definition id for a social channel and silently linked nothing. Now points at the channel defs.

## The setup doc

It was wrong in the way that costs the most time — it told you to register:

```
https://app.auxx.ai/api/facebook/oauth2/callback
```

That route does not exist. The real callback is `/api/connections/{connectionDefinitionId}/oauth2/callback`, keyed on a **cuid that differs per environment**, so there is no static URL to copy into the Meta dashboard. The doc now gives the SQL to read your own ids.

The plan's own instruction for this item was also wrong in the same way — it said `/api/connections/{facebook|instagram}/oauth2/callback`, a slug the route never accepts. Corrected in the plan too.

Rewritten to cover:

- both channels on **one** Meta app (Instagram Messaging is a Facebook-Graph child — no separate app, client id, or verify token)
- the re-seed trap: `ensurePlatformProviders` bakes encrypted OAuth client copies into `ConnectionDefinition` rows, so env edits alone are inert and surface as "App not active"
- the real scope lists, including why `business_management` is mandatory — without it, Pages owned by a Business portfolio are absent from `/me/accounts` and connect fails with "No Facebook Pages found" on an account that visibly has Pages
- webhook subscriptions per object, and why `feed`/`comments` must **not** be subscribed yet (the routes drop them)
- Instagram prerequisites: professional account, Page link, "Allow access to messages"
- the dev-mode vs App-Review split, including Human Agent for the 24h window
- a symptom → cause table

## Env examples

`apps/worker/.env.example` carried its own `FACEBOOK_GRAPH_API_VERSION=v19.0` — and **sync runs in the worker**, which is the likeliest explanation for the live run going out on v19.0 while the web env was current. Both examples now pin `v26.0`, and the commented-dead `INSTAGRAM_*` block is replaced by a line explaining why there is no separate Instagram app.

## Two plan items that turned out to be wrong

Both corrected in the plan rather than implemented:

- **WS8's diagnosis is disproven.** It blamed the opener-side listener for dropping the foreign-origin message. `use-oauth-popup.ts:146-149` explicitly trusts messages from the popup it opened regardless of origin, and that shipped in #910 on 2026-06-19 — two months before the symptom was seen. There's also an authoritative verify poll as a backstop. No fix written: changing settle plumbing that already handles the stated case, on a one-off symptom with no repro, is how a working path acquires a bug.
- **The `INSTAGRAM_IGSID` enum item pointed at the wrong vocabulary.** The DB `IdentifierType` enum already has it (`_shared.ts:221`), used throughout `participants/`. The `FACEBOOK_PSID` in `enum-values.ts` belongs to `CustomerSourceType`, where nothing writes it — grep finds no producer. Adding it there would mean a DB enum change and a cache bump for zero behaviour.

## Testing

439 tests green across `connections`, `providers`, `channels`; `packages/lib` typecheck clean in `src/`.