### PR TITLE
fix(kopilot): stop the agent edit loop — cache invalidation and derived-key honesty

### DIFF
--- a/apps/web/src/components/workflow/hooks/use-workflow-save.ts
+++ b/apps/web/src/components/workflow/hooks/use-workflow-save.ts
@@ -1,6 +1,6 @@
 // apps/web/src/components/workflow/hooks/use-workflow-save.ts
 
-import { deriveTriggerColumns } from '@auxx/lib/workflow-engine/client'
+import { deriveTriggerColumns, stripDerivedKeys } from '@auxx/lib/workflow-engine/client'
 import { toastError } from '@auxx/ui/components/toast'
 import { debounce } from '@auxx/utils'
 import { useStoreApi } from '@xyflow/react'
@@ -123,20 +123,17 @@ export const useWorkflowSave = () => {
         return null
       }
 
-      // Clean nodes - remove UI-only properties (prefixed with _)
-      const cleanNodes = nodes.map((node) => {
-        const cleanData = Object.fromEntries(
-          Object.entries(node.data || {}).filter(([key]) => !key.startsWith('_'))
-        )
-        return { ...node, data: cleanData }
-      })
+      // Clean nodes/edges — derived (canvas-owned) keys never persist. The rule
+      // lives in lib (`stripDerivedKeys`) so this and the agent's own save seam
+      // (`graph-edit/persist.ts` cleanGraphForSave) can never drift apart.
+      const cleanNodes = nodes.map((node) => ({
+        ...node,
+        data: stripDerivedKeys(node.data || {}),
+      }))
 
-      // Clean edges - remove UI-only properties
       const cleanEdges = edges.map((edge) => {
         if (!edge.data) return edge
-        const cleanData = Object.fromEntries(
-          Object.entries(edge.data).filter(([key]) => !key.startsWith('_'))
-        )
+        const cleanData = stripDerivedKeys(edge.data)
         return { ...edge, data: Object.keys(cleanData).length > 0 ? cleanData : undefined }
       })
 

--- a/apps/web/src/components/workflow/utils/workflow-initializer.ts
+++ b/apps/web/src/components/workflow/utils/workflow-initializer.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/workflow/utils/workflow-initializer.ts
 
+import type { TargetBranch } from '@auxx/lib/workflow-engine/client'
 import { getConnectedEdges } from '@xyflow/react'
 import type { CrudNodeData } from '../nodes/core/crud/types'
 import type { HttpNodeData } from '../nodes/core/http/types'
@@ -13,18 +14,25 @@ import { branchNameCorrect } from './branch-name-correct'
 import { calculateZIndex } from './edge-utils'
 
 /**
- * Calculate target branches based on node type and current data
+ * Calculate target branches based on node type and current data.
+ *
+ * Derived state — `_targetBranches` is stripped on every save and rebuilt
+ * here on load. The authoritative derivation is each manifest's
+ * `connection.branches(config)`; these arms mirror it and should collapse
+ * into it (see `catalog/derived-keys.ts`).
  */
-export const calculateTargetBranches = (
-  nodeData: FlowNode['data']
-): Array<{ id: string; name: string; type?: string }> | undefined => {
+export const calculateTargetBranches = (nodeData: FlowNode['data']): TargetBranch[] | undefined => {
   switch (nodeData.type) {
     case NodeType.IF_ELSE: {
       const ifElseData = nodeData as IfElseNodeData
       // Build branches from cases + ELSE branch
-      const branches = [
-        ...(ifElseData.cases || []).map((c) => ({ id: c.case_id, name: '' })),
-        { id: 'false', name: '' },
+      const branches: TargetBranch[] = [
+        ...(ifElseData.cases || []).map((c) => ({
+          id: c.case_id,
+          name: '',
+          type: 'default' as const,
+        })),
+        { id: 'false', name: '', type: 'default' as const },
       ]
       // Apply proper naming (IF/ELSE for 2 branches, CASE 1/2/ELSE for multiple)
       return branchNameCorrect(branches)
@@ -41,7 +49,7 @@ export const calculateTargetBranches = (
           ...classifierData.categories.map((cat) => ({
             id: cat.id,
             name: cat.name,
-            type: 'default',
+            type: 'default' as const,
           })),
           { id: 'unmatched', name: 'Unmatched', type: 'default' },
         ]
@@ -51,7 +59,7 @@ export const calculateTargetBranches = (
 
     case NodeType.HTTP: {
       const httpData = nodeData as HttpNodeData
-      const branches = [{ id: 'source', name: '', type: 'default' }]
+      const branches: TargetBranch[] = [{ id: 'source', name: '', type: 'default' }]
       // Add fail branch if error strategy is set to fail
       if (httpData.error_strategy === ErrorStrategy.fail) {
         branches.push({ id: 'fail', name: 'Fail', type: 'fail' })
@@ -61,7 +69,7 @@ export const calculateTargetBranches = (
 
     case NodeType.CRUD: {
       const crudData = nodeData as CrudNodeData
-      const branches = [{ id: 'source', name: '', type: 'default' }]
+      const branches: TargetBranch[] = [{ id: 'source', name: '', type: 'default' }]
 
       // Add fail branch if error strategy is set to fail
       if (`${crudData.error_strategy}` === 'fail') {

--- a/packages/lib/src/ai/agent-framework/__tests__/idempotent-cache.test.ts
+++ b/packages/lib/src/ai/agent-framework/__tests__/idempotent-cache.test.ts
@@ -1,0 +1,248 @@
+// packages/lib/src/ai/agent-framework/__tests__/idempotent-cache.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { ToolCall, UsageMetrics } from '../../clients/base/types'
+import { AgentEngine } from '../engine'
+import type {
+  AgentDefinition,
+  AgentDomainConfig,
+  AgentEngineConfig,
+  AgentEvent,
+  AgentToolDefinition,
+  LLMCallParams,
+  LLMStreamEvent,
+} from '../types'
+
+/**
+ * The per-turn idempotent cache and its ONE invariant: a write drops it whole.
+ *
+ * There was no test of this cache at all, and its absence cost a real turn —
+ * an agent fixed three fields in a workflow, re-read it to confirm, and was
+ * served the pre-fix graph out of the cache for the rest of the turn. It fixed
+ * them again, and again, until it hit the iteration cap and returned nothing.
+ * The read tools take `{}` args, so their cache key was constant for the whole
+ * turn: one answer, replayed forever.
+ */
+
+const ZERO: UsageMetrics = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }
+
+const makeToolCall = (id: string, name: string, args: Record<string, unknown> = {}): ToolCall => ({
+  id,
+  type: 'function',
+  function: { name, arguments: JSON.stringify(args) },
+})
+
+async function drain(gen: AsyncGenerator<AgentEvent>): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = []
+  for await (const event of gen) events.push(event)
+  return events
+}
+
+interface ScriptedTurn {
+  content: string
+  toolCalls: ToolCall[]
+}
+
+function buildEngine(opts: {
+  turns: ScriptedTurn[]
+  tools: AgentToolDefinition[]
+  approvalMode?: 'pause' | 'capture'
+}) {
+  let llmCalls = 0
+  const callModel = async function* (_params: LLMCallParams): AsyncGenerator<LLMStreamEvent> {
+    const turn = opts.turns[llmCalls++] ?? { content: 'done', toolCalls: [] }
+    yield { type: 'done', content: turn.content, toolCalls: turn.toolCalls, usage: ZERO }
+  }
+
+  const agent: AgentDefinition = {
+    name: 'agent',
+    tools: opts.tools,
+    buildMessages: async () => [],
+    processResult: async (_c, _tc, state) => state,
+    maxIterations: 8,
+  }
+
+  const domainConfig: AgentDomainConfig = {
+    type: 'kopilot',
+    agents: { agent },
+    routes: [{ name: 'default', agents: ['agent'] }],
+    createInitialState: () => ({}),
+    defaultModel: 'm',
+    defaultProvider: 'p',
+  }
+
+  const config: AgentEngineConfig = {
+    organizationId: 'org-1',
+    userId: 'user-1',
+    sessionId: 'sess-1',
+    // biome-ignore lint/suspicious/noExplicitAny: tests don't touch the db handle
+    db: {} as any,
+    domainConfig,
+    callModel,
+    ...(opts.approvalMode ? { approvalMode: opts.approvalMode } : {}),
+  }
+
+  return new AgentEngine(config)
+}
+
+/** A read tool over a mutable value, counting its own executions. */
+function makeWorld() {
+  const state = { value: 'before' }
+  const reads: string[] = []
+  let writeCalls = 0
+
+  const readTool: AgentToolDefinition = {
+    name: 'get_thing',
+    displayName: 'Get thing',
+    description: 'Read the thing',
+    parameters: { type: 'object', properties: { which: { type: 'string' } } },
+    idempotent: true,
+    execute: async () => {
+      reads.push(state.value)
+      return { success: true, output: { value: state.value } }
+    },
+  }
+
+  const writeTool: AgentToolDefinition = {
+    name: 'set_thing',
+    displayName: 'Set thing',
+    description: 'Write the thing',
+    parameters: { type: 'object', properties: {} },
+    execute: async () => {
+      writeCalls += 1
+      state.value = 'after'
+      return { success: true, output: { ok: true } }
+    },
+  }
+
+  const failingWriteTool: AgentToolDefinition = {
+    name: 'set_thing',
+    displayName: 'Set thing',
+    description: 'Write the thing, badly',
+    parameters: { type: 'object', properties: {} },
+    execute: async () => {
+      writeCalls += 1
+      // A failed write may still have partially landed — the cache must drop.
+      state.value = 'after'
+      return { success: false, output: null, error: 'boom' }
+    },
+  }
+
+  return {
+    readTool,
+    writeTool,
+    failingWriteTool,
+    reads,
+    getWriteCalls: () => writeCalls,
+  }
+}
+
+describe('per-turn idempotent tool cache', () => {
+  it('serves an identical read from cache when nothing has written', async () => {
+    const world = makeWorld()
+    const engine = buildEngine({
+      tools: [world.readTool],
+      turns: [
+        { content: '', toolCalls: [makeToolCall('c1', 'get_thing')] },
+        { content: '', toolCalls: [makeToolCall('c2', 'get_thing')] },
+        { content: 'done', toolCalls: [] },
+      ],
+    })
+
+    await drain(engine.submitMessage('go'))
+
+    expect(world.reads).toEqual(['before'])
+  })
+
+  it('re-executes a read that FOLLOWS a write (read → write → read)', async () => {
+    const world = makeWorld()
+    const engine = buildEngine({
+      tools: [world.readTool, world.writeTool],
+      turns: [
+        { content: '', toolCalls: [makeToolCall('c1', 'get_thing')] },
+        { content: '', toolCalls: [makeToolCall('c2', 'set_thing')] },
+        { content: '', toolCalls: [makeToolCall('c3', 'get_thing')] },
+        { content: 'done', toolCalls: [] },
+      ],
+    })
+
+    await drain(engine.submitMessage('go'))
+
+    expect(world.reads).toEqual(['before', 'after'])
+  })
+
+  it('invalidates WITHIN one batch — [read, write, read] in a single iteration', async () => {
+    // The exact shape of the logged failure: the model batched its edits and
+    // the validate call that checked them into one tool-call array.
+    const world = makeWorld()
+    const engine = buildEngine({
+      tools: [world.readTool, world.writeTool],
+      turns: [
+        {
+          content: '',
+          toolCalls: [
+            makeToolCall('c1', 'get_thing'),
+            makeToolCall('c2', 'set_thing'),
+            makeToolCall('c3', 'get_thing'),
+          ],
+        },
+        { content: 'done', toolCalls: [] },
+      ],
+    })
+
+    await drain(engine.submitMessage('go'))
+
+    expect(world.reads).toEqual(['before', 'after'])
+  })
+
+  it('drops the cache even when the write FAILED', async () => {
+    const world = makeWorld()
+    const engine = buildEngine({
+      tools: [world.readTool, world.failingWriteTool],
+      turns: [
+        { content: '', toolCalls: [makeToolCall('c1', 'get_thing')] },
+        { content: '', toolCalls: [makeToolCall('c2', 'set_thing')] },
+        { content: '', toolCalls: [makeToolCall('c3', 'get_thing')] },
+        { content: 'done', toolCalls: [] },
+      ],
+    })
+
+    await drain(engine.submitMessage('go'))
+
+    expect(world.reads).toEqual(['before', 'after'])
+  })
+
+  it('keys on args — different args never serve each other', async () => {
+    const world = makeWorld()
+    const engine = buildEngine({
+      tools: [world.readTool],
+      turns: [
+        { content: '', toolCalls: [makeToolCall('c1', 'get_thing', { which: 'a' })] },
+        { content: '', toolCalls: [makeToolCall('c2', 'get_thing', { which: 'b' })] },
+        { content: 'done', toolCalls: [] },
+      ],
+    })
+
+    await drain(engine.submitMessage('go'))
+
+    expect(world.reads).toEqual(['before', 'before'])
+  })
+
+  it('applies the same invalidation in capture mode', async () => {
+    const world = makeWorld()
+    const engine = buildEngine({
+      approvalMode: 'capture',
+      tools: [world.readTool, world.writeTool],
+      turns: [
+        { content: '', toolCalls: [makeToolCall('c1', 'get_thing')] },
+        { content: '', toolCalls: [makeToolCall('c2', 'set_thing')] },
+        { content: '', toolCalls: [makeToolCall('c3', 'get_thing')] },
+        { content: 'done', toolCalls: [] },
+      ],
+    })
+
+    await drain(engine.submitMessage('go'))
+
+    expect(world.reads).toEqual(['before', 'after'])
+  })
+})

--- a/packages/lib/src/ai/agent-framework/capture-mode.ts
+++ b/packages/lib/src/ai/agent-framework/capture-mode.ts
@@ -7,10 +7,10 @@ import type { AgentEvent, AgentToolDefinition, CapturedAction } from './types'
 import {
   buildToolDigest,
   executeToolWithProgress,
+  type IdempotentToolCache,
   needsApproval,
   parseToolArgs,
   previewValue,
-  stableStringify,
   type ToolExecResult,
   validateRequiredParams,
 } from './utils'
@@ -42,7 +42,7 @@ export async function processCaptureToolCalls(
   agentTools: AgentToolDefinition[],
   agentName: string,
   ctx: ToolContext,
-  idempotentCache: Map<string, ToolExecResult>,
+  idempotentCache: IdempotentToolCache,
   existingCaptures: CapturedAction[],
   transformInput?: (toolName: string, args: Record<string, unknown>) => Record<string, unknown>,
   applyToolRestrictions?: (
@@ -266,7 +266,12 @@ export async function processCaptureToolCalls(
       args = v.args
     }
 
-    const cacheKey = tool.idempotent ? `${toolName}::${stableStringify(args)}` : null
+    const cacheKey = idempotentCache.keyFor(tool, args)
+    if (!cacheKey) {
+      // Not cacheable ⇒ this call writes; every cached read is now suspect.
+      // Same rule as the live loop — see IdempotentToolCache.
+      idempotentCache.invalidateAll()
+    }
     if (cacheKey) {
       const cached = idempotentCache.get(cacheKey)
       if (cached) {

--- a/packages/lib/src/ai/agent-framework/query-loop.ts
+++ b/packages/lib/src/ai/agent-framework/query-loop.ts
@@ -24,6 +24,7 @@ import type {
 } from './types'
 import {
   buildToolDigest,
+  IdempotentToolCache,
   needsApproval,
   parseToolArgs,
   previewArgs,
@@ -140,8 +141,8 @@ export async function* agentQueryLoop(
   // successful calls to them (see `AgentToolDefinition.endsTurn`).
   const endsTurnToolNames = new Set(agent.tools.filter((t) => t.endsTurn).map((t) => t.name))
 
-  /** Per-turn cache of idempotent tool results. */
-  const idempotentCache = new Map<string, ToolExecResult>()
+  /** Per-turn cache of idempotent tool results; dropped whole on any write. */
+  const idempotentCache = new IdempotentToolCache()
 
   // Open a single assistant message for this entire agent run — or reuse
   // the paused message's id when resuming, so the frontend appends parts to
@@ -1274,7 +1275,7 @@ async function* executeToolCalls(
   agentName: string,
   messageId: string,
   ctx: ToolContext,
-  idempotentCache: Map<string, ToolExecResult>,
+  idempotentCache: IdempotentToolCache,
   transformInput?: (toolName: string, args: Record<string, unknown>) => Record<string, unknown>,
   applyToolRestrictions?: AgentEngineConfig['applyToolRestrictions']
 ): AsyncGenerator<AgentEvent, ToolExecResult[]> {
@@ -1390,10 +1391,27 @@ async function* executeToolCalls(
       ;(parts[partIndex] as ToolCallPart).args = args
     }
 
-    const cacheKey = tool.idempotent ? `${toolName}::${stableStringify(args)}` : null
+    const cacheKey = idempotentCache.keyFor(tool, args)
+    if (!cacheKey) {
+      // Not cacheable ⇒ this call writes. Every cached read is now suspect,
+      // including one queued LATER IN THIS SAME BATCH: executeToolCalls is a
+      // sequential await loop, so batch order is execution order, and
+      // `[update_node, …, validate_workflow]` is the exact shape that broke.
+      idempotentCache.invalidateAll()
+    }
     if (cacheKey) {
       const cached = idempotentCache.get(cacheKey)
       if (cached) {
+        // A cache hit produced NO log line at all before this, which is why the
+        // replay bug took a forensic pass to find: the hit branch `continue`s
+        // above the 'Tool result' line every real execution passes through.
+        logger.debug('Tool result (cached)', {
+          turnId: ctx.turnId,
+          toolCallId: toolCall.id,
+          agent: agentName,
+          tool: toolName,
+          cacheKey,
+        })
         yield {
           type: 'tool-call-completed',
           messageId,

--- a/packages/lib/src/ai/agent-framework/types.ts
+++ b/packages/lib/src/ai/agent-framework/types.ts
@@ -258,10 +258,18 @@ export interface AgentToolDefinition {
    */
   requiresApproval?: boolean | ((args: Record<string, unknown>) => boolean)
   /**
-   * Marks this tool as a read-only / side-effect-free operation. When true, the
-   * agent query loop caches the first call's result for the duration of the turn
-   * and reuses it on any subsequent call with identical args — avoiding redundant
-   * DB/API roundtrips when the LLM retries the same lookup.
+   * Marks this tool as read-only / side-effect-free. When true, the query loop
+   * caches the first call's result and replays it for identical args **until
+   * any non-idempotent tool runs in the same turn**, which drops the whole
+   * cache (see `IdempotentToolCache`).
+   *
+   * Declare it only when BOTH hold:
+   *  - the tool writes nothing, AND
+   *  - its answer can only be changed by a non-idempotent tool call.
+   *
+   * A tool that WRITES must leave this unset — that is what makes the
+   * invalidation above correct for every reader in the turn. Enforced by
+   * `kopilot/capabilities/__tests__/tool-permission-declarations.test.ts`.
    */
   idempotent?: boolean
   /**

--- a/packages/lib/src/ai/agent-framework/utils.ts
+++ b/packages/lib/src/ai/agent-framework/utils.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/ai/agent-framework/utils.ts
 
 import { createScopedLogger } from '@auxx/logger'
+import { stableStringify } from '@auxx/utils/json'
 import type { Message, ToolCall } from '../clients/base/types'
 import type { ToolContext } from './tool-context'
 import type {
@@ -510,3 +511,47 @@ function findLastFinalAssistantIdx(messages: SessionMessage[]): number {
 // re-exported so existing `import { stableStringify } from './utils'` call sites
 // keep working.
 export { stableStringify } from '@auxx/utils/json'
+
+/**
+ * Per-turn dedupe cache for read-only tool results.
+ *
+ * INVARIANT: a cached read is only valid while nothing in the turn has
+ * written. Any dispatch of a NON-idempotent tool — success or failure, since a
+ * failed write may still have partially landed — drops the whole cache, so a
+ * read that follows a write always re-executes.
+ *
+ * Without that rule the cache is a correctness bug, not an optimization: for a
+ * tool whose args are `{}` the key is constant for the entire turn, so the
+ * FIRST answer is replayed forever. An agent that fixes a workflow and re-reads
+ * it to confirm gets served the pre-fix graph, concludes nothing landed, and
+ * fixes it again — which is exactly how one real turn burned all 30 iterations
+ * and never produced a reply. Seven capabilities carried the same shape
+ * (workflow-builder, kb, entities, agents-builder, mail, record-views, tasks);
+ * `get_eval_run` is the sharpest case, a poll that could never observe its run
+ * finish.
+ *
+ * Scoping invalidation per resource would need every tool annotated and would
+ * fail OPEN on the ones nobody annotated. Dropping everything costs one
+ * redundant read and cannot be wrong.
+ */
+export class IdempotentToolCache {
+  private readonly entries = new Map<string, ToolExecResult>()
+
+  /** Cache key for a call, or null when the tool is not cacheable (i.e. writes). */
+  keyFor(tool: AgentToolDefinition, args: Record<string, unknown>): string | null {
+    return tool.idempotent ? `${tool.name}::${stableStringify(args)}` : null
+  }
+
+  get(key: string): ToolExecResult | undefined {
+    return this.entries.get(key)
+  }
+
+  set(key: string, result: ToolExecResult): void {
+    this.entries.set(key, result)
+  }
+
+  /** Called immediately BEFORE a non-idempotent tool executes. */
+  invalidateAll(): void {
+    this.entries.clear()
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/__tests__/tool-permission-declarations.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/__tests__/tool-permission-declarations.test.ts
@@ -84,6 +84,49 @@ import { createWorkflowBuilderCapabilities } from '../workflow-builder'
 
 const ORG = 'org-1'
 
+/**
+ * Tools declaring `idempotent: true` — every one read-only, and every one
+ * whose answer can only change when a non-idempotent tool runs in the same
+ * turn. That second clause is what the flag actually promises; see the test
+ * at the bottom of this file for why it matters.
+ */
+const IDEMPOTENT_READ_TOOLS = [
+  'describe_node_type',
+  'find_threads',
+  'find_workflow_templates',
+  'get_article',
+  'get_article_section',
+  'get_entity',
+  'get_entity_history',
+  'get_eval_case',
+  'get_eval_run',
+  'get_node',
+  'get_suite_diff',
+  'get_thread_detail',
+  'get_transcript',
+  'get_workflow',
+  'list_articles',
+  'list_drafts',
+  'list_entities',
+  'list_entity_fields',
+  'list_eval_cases',
+  'list_field_changes',
+  'list_groups',
+  'list_members',
+  'list_node_types',
+  'list_notes',
+  'list_table_views',
+  'list_tags',
+  'list_tasks',
+  'list_transcripts_for_entity',
+  'query_records',
+  'resolve_block_by_heading',
+  'search_docs',
+  'search_entities',
+  'search_knowledge',
+  'validate_workflow',
+] as const
+
 // Tool factories capture `getDeps` for execute-time use only; construction never
 // calls it — except the builder factory, which reads `sessionContext` to resolve
 // the agent under edit.
@@ -269,6 +312,37 @@ describe('agent tool permission declarations — registry enumeration', () => {
       .filter((t) => t.permission?.target === 'bridge')
       .map((t) => t.name)
     expect(bridges).toEqual([])
+  })
+
+  /**
+   * The `idempotent` flag is a CORRECTNESS declaration, not a hint: the query
+   * loop replays a cached answer for identical args until a non-idempotent
+   * tool runs, at which point the whole cache is dropped. A WRITE tool that
+   * declared it would suppress that invalidation for every reader in the turn
+   * — the failure mode that let an agent re-read a workflow it had just
+   * edited, be served the pre-edit graph, and re-fix it until the iteration
+   * cap. See `agent-framework/utils.ts` IdempotentToolCache.
+   *
+   * Pinned exactly, both ways, like the two curated sets above — a NEW tool
+   * that sets the flag fails until someone adds it here, which is the moment
+   * to check it is genuinely read-only. `permission.level` cannot be the
+   * discriminator: the eval reads are `admin` because the agents area has a
+   * single rung, not because they write.
+   */
+  it('the idempotent set is EXACTLY the curated read-only list', async () => {
+    const declared = (await collectNativeTools())
+      .filter((tool) => tool.idempotent === true)
+      .map((tool) => tool.name)
+      .sort()
+    expect(declared).toEqual([...IDEMPOTENT_READ_TOOLS].sort())
+  })
+
+  it('no approval-gated tool declares itself idempotent', async () => {
+    // Approval means the call does something worth confirming — i.e. it writes.
+    const offenders = (await collectNativeTools())
+      .filter((tool) => tool.idempotent === true && tool.requiresApproval !== undefined)
+      .map((tool) => tool.name)
+    expect(offenders).toEqual([])
   })
 
   it('every tool reachable through a real registry declares a permission', async () => {

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/write-tools.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/write-tools.test.ts
@@ -229,7 +229,7 @@ describe('get_node / update_node deep patches', () => {
     })
   })
 
-  it('requires exactly one update mode and a hash for patches', async () => {
+  it('requires exactly one update mode', async () => {
     const both = await run(createUpdateNodeTool(getDeps), {
       ref: 'HTTP Request',
       config: { method: 'POST' },
@@ -237,14 +237,32 @@ describe('get_node / update_node deep patches', () => {
     })
     expect(both.success).toBe(false)
     expect(both.error).toContain('exactly one')
+    expect(updateNodeMock).not.toHaveBeenCalled()
+  })
 
-    const unhashed = await run(createUpdateNodeTool(getDeps), {
+  it('passes patches through WITHOUT a hash — the CAS is optional and lives in lib', async () => {
+    // The wrapper has no DB read, so a hash check up here could only ever say
+    // "no", never hand back the value that makes the retry work. Rejecting an
+    // unhashed call taught the model to abandon patches for `config`.
+    const result = await run(createUpdateNodeTool(getDeps), {
       ref: 'HTTP Request',
       patches: [{ op: 'set', path: ['method'], value: 'POST' }],
     })
-    expect(unhashed.success).toBe(false)
-    expect(unhashed.error).toContain('expectedConfigHash')
-    expect(updateNodeMock).not.toHaveBeenCalled()
+
+    expect(result.success).toBe(true)
+    expect(updateNodeMock).toHaveBeenCalled()
+    expect(updateNodeMock.mock.calls[0]?.[1]).not.toHaveProperty('expectedConfigHash')
+  })
+
+  it('accepts expectedConfigHash WITH config mode instead of rejecting it', async () => {
+    const result = await run(createUpdateNodeTool(getDeps), {
+      ref: 'HTTP Request',
+      config: { method: 'POST' },
+      expectedConfigHash: 'abc123',
+    })
+
+    expect(result.success).toBe(true)
+    expect(updateNodeMock.mock.calls[0]?.[1]).toMatchObject({ expectedConfigHash: 'abc123' })
   })
 })
 

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/update-node.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/update-node.ts
@@ -19,7 +19,7 @@ export function createUpdateNodeTool(getDeps: GetToolDeps): AgentToolDefinition 
     displayName: 'Update workflow node',
     surfaces: ['builder'],
     description:
-      'Update one node of the open workflow draft. Use `config` for a legacy top-level shallow merge, or `patches` plus the configHash from get_node for atomic deep set/unset edits that preserve nested siblings. Pass exactly one mode. Patch paths are arrays of field names and numeric array indexes.',
+      'Update one node of the open workflow draft. TWO modes, pass exactly one: (1) `patches` — atomic deep set/unset that preserves nested siblings; this is the default choice. (2) `config` — a shallow merge of TOP-LEVEL fields only (title, simple scalars). `expectedConfigHash` is optional with either mode: pass the configHash from your last read and the edit is rejected if the node changed underneath you; omit it and the edit still applies. The result carries the node back with its new configHash — do not re-read it.',
     parameters: {
       type: 'object',
       properties: {
@@ -31,7 +31,9 @@ export function createUpdateNodeTool(getDeps: GetToolDeps): AgentToolDefinition 
         },
         expectedConfigHash: {
           type: 'string',
-          description: 'Opaque configHash from get_node; required with patches.',
+          description:
+            'Optional optimistic-concurrency token: the opaque configHash from the get_node ' +
+            'or mutation result this edit was chosen against. Checked when given.',
         },
         patches: {
           type: 'array',
@@ -98,38 +100,24 @@ export function createUpdateNodeTool(getDeps: GetToolDeps): AgentToolDefinition 
       }
       const patches =
         hasPatches && Array.isArray(args.patches) ? (args.patches as ConfigPatch[]) : []
+      if (hasPatches && patches.length === 0) {
+        return { success: false, output: null, error: 'patches must contain at least one edit.' }
+      }
       const expectedConfigHash =
         typeof args.expectedConfigHash === 'string' ? args.expectedConfigHash.trim() : ''
-      if (hasPatches && (patches.length === 0 || !expectedConfigHash)) {
-        return {
-          success: false,
-          output: null,
-          error: 'patches must be non-empty and expectedConfigHash is required.',
-        }
-      }
-      if (hasConfig && args.expectedConfigHash !== undefined) {
-        return {
-          success: false,
-          output: null,
-          error: 'expectedConfigHash is only used with patches.',
-        }
-      }
 
+      // Everything hash-shaped is enforced in lib, where the node — and so its
+      // CURRENT hash — is in hand and can ride the error message. Checking it
+      // up here could only ever say "no", never "here is the right value".
       const { db } = getDeps()
       // Lazy import — see get-workflow.ts.
       const { updateNode } = await import('../../../../../workflows/graph-edit')
-      const result = hasPatches
-        ? await updateNode(db, {
-            ...write.scope,
-            ref,
-            patches,
-            expectedConfigHash,
-          })
-        : await updateNode(db, {
-            ...write.scope,
-            ref,
-            config: config!,
-          })
+      const result = await updateNode(db, {
+        ...write.scope,
+        ref,
+        ...(hasPatches ? { patches } : { config: config as Record<string, unknown> }),
+        ...(expectedConfigHash ? { expectedConfigHash } : {}),
+      })
       return mutationToToolResult(result, (value) =>
         value.applied ? `Updated ${value.node?.title ?? ref}` : `Update ${ref} blocked`
       )

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/validate-workflow.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/validate-workflow.ts
@@ -39,7 +39,7 @@ export function createValidateWorkflowTool(getDeps: GetToolDeps): AgentToolDefin
     surfaces: ['builder'],
     idempotent: true,
     description:
-      'Check whether the open workflow draft would pass the publish gate — without publishing (publishing stays the user’s action). Returns publishability, publish errors/warnings, and the structural/config/reference issues.',
+      'Check whether the open workflow draft would pass the publish gate — without publishing (publishing stays the user’s action). Returns publishability, publish errors/warnings, and the structural/config/reference issues. Call it in a LATER step, never in the same tool-call batch as the edits it checks: every mutation already returns the issues for what it touched, so a same-batch call is redundant.',
     parameters: { type: 'object', properties: {}, additionalProperties: false },
     buildDigest: (output) => ({
       label: 'Workflow validated',

--- a/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
@@ -38,10 +38,11 @@ export function buildWorkflowBuilderPromptSection(): string {
     'Every node you add needs a concise `description` that explains why it exists in the user’s terms. This appears under the node title on the canvas.',
 
     // Safe nested edits.
-    'Nested config edits: call `get_node` immediately before editing, then use `update_node` with its `configHash` and `patches`. Paths are segment arrays, for example `["model", "completion_params", "temperature"]`; use numeric segments for arrays. Prefer patches over resending a nested object. If the hash is stale, re-read and retry. Use legacy `config` only for top-level fields such as `title`.',
+    'Nested config edits: call `get_node` immediately before editing, then use `update_node` with its `configHash` and `patches`. Paths are segment arrays, for example `["model", "completion_params", "temperature"]`; use numeric segments for arrays. Prefer patches over resending a nested object. `expectedConfigHash` is optional — pass it when you have it, and if a call is refused for a stale one the error names the node\'s CURRENT hash, so retry immediately with that value rather than switching to `config` mode to avoid the hash. Use legacy `config` only for top-level fields such as `title`.',
 
     // Verification + simulation.
-    'Verifying: `validate_workflow` runs the real publish gate without publishing — use it after a batch of edits. `run_node` executes ONE node as a SIMULATED debug run (side-effecting nodes do not send email, call webhooks, etc.); you supply its input values — upstream nodes are not executed. Say clearly in your reply that the run was simulated.',
+    'Every mutation returns the node it touched, with its new `configHash` and the issues for what it changed — read that result instead of re-reading the node you just wrote. Call `validate_workflow` in a LATER step, never in the same tool-call batch as the edits it is meant to check.',
+    'Verifying: `validate_workflow` runs the real publish gate without publishing — use it once, after your edits have come back applied. `run_node` executes ONE node as a SIMULATED debug run (side-effecting nodes do not send email, call webhooks, etc.); you supply its input values — upstream nodes are not executed. Say clearly in your reply that the run was simulated.',
 
     // Completion shape.
     'After workflow work, close with three compact sections: `Done` (what changed), `Still needs your input` (a numbered list of unresolved choices, or “Nothing”), and `Remaining validation` (the exact errors/warnings from validate_workflow, or “None”). Apply every safe, unambiguous part before asking about the genuinely unresolved parts.',

--- a/packages/lib/src/workflow-engine/catalog/derived-keys.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/derived-keys.test.ts
@@ -1,0 +1,91 @@
+// packages/lib/src/workflow-engine/catalog/derived-keys.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { isDerivedKey, stripDerivedKeys } from './derived-keys'
+import { listManifests } from './registry'
+
+/**
+ * THE catalog invariant behind `derived-keys.ts`.
+ *
+ * A manifest's `configSchema` describes PERSISTED config, and derived
+ * (`_`-prefixed) keys are stripped from every save — by `cleanGraphForSave`
+ * on the agent path and `use-workflow-save`'s cleaner on the canvas path. A
+ * schema that declares one therefore lies to three different consumers:
+ *
+ *  - `describe_node_type` publishes `configSchema` as the agent-facing JSON
+ *    Schema, so the model is told a canvas-only key is a writable field —
+ *    and, when the key is required, a MANDATORY one.
+ *  - `validateNodeConfigs` safe-parses stored data against it, so a required
+ *    derived key emits a permanent warning on every read of every node of
+ *    that type.
+ *  - `patch-config` refuses `_`-rooted paths, so the only edit that would
+ *    clear that warning is rejected.
+ *
+ * `http` sat in exactly that trap: `_targetBranches` was required, absent
+ * from every stored node, reported on every read, and unpatchable.
+ */
+describe('catalog derived-key invariant', () => {
+  it('no manifest configSchema declares a derived key', () => {
+    const offenders = listManifests()
+      .map((manifest) => {
+        let json: Record<string, unknown>
+        try {
+          json = z.toJSONSchema(manifest.configSchema as z.ZodType, {
+            unrepresentable: 'any',
+          }) as Record<string, unknown>
+        } catch {
+          return null
+        }
+        const properties = (json.properties ?? {}) as Record<string, unknown>
+        const declared = Object.keys(properties).filter(isDerivedKey)
+        return declared.length > 0 ? { id: manifest.id, declared } : null
+      })
+      .filter((entry): entry is { id: string; declared: string[] } => entry !== null)
+
+    expect(offenders).toEqual([])
+  })
+
+  it('every manifest default parses against its own schema in its STORED shape', () => {
+    // What persists is `defaultData()` minus derived keys. Parsing the
+    // as-authored shape (which the pre-existing coverage test does) cannot see
+    // a schema that requires something the save path removes.
+    const failures = listManifests()
+      .map((manifest) => ({
+        id: manifest.id,
+        result: manifest.configSchema.safeParse({
+          id: 'test-node',
+          type: manifest.id,
+          title: manifest.displayName,
+          ...stripDerivedKeys(manifest.defaultData() as Record<string, unknown>),
+        }),
+      }))
+      .filter(({ result }) => !result.success)
+      .map(({ id, result }) => ({
+        id,
+        issues: (result.success ? [] : result.error.issues).map(
+          (issue) => `${issue.path.join('.')}: ${issue.message}`
+        ),
+      }))
+
+    expect(failures).toEqual([])
+  })
+
+  it('parses canvas data that still carries derived keys (zod strips them)', () => {
+    // Legacy rows written before the save-path strip landed still hold
+    // `_targetBranches` (26 if-else and 4 text-classifier nodes in dev at the
+    // time of writing). Dropping the key from the schema must not turn those
+    // into validation errors.
+    const manifest = listManifests().find((m) => m.id === 'if-else')
+    expect(manifest).toBeDefined()
+    const parsed = manifest?.configSchema.safeParse({
+      id: 'test-node',
+      type: 'if-else',
+      title: 'IF/ELSE',
+      ...(manifest.defaultData() as Record<string, unknown>),
+      _targetBranches: [{ id: 'true', name: 'IF', type: 'default' }],
+      _connectedSourceHandleIds: ['source'],
+    })
+    expect(parsed?.success).toBe(true)
+  })
+})

--- a/packages/lib/src/workflow-engine/catalog/derived-keys.ts
+++ b/packages/lib/src/workflow-engine/catalog/derived-keys.ts
@@ -1,0 +1,34 @@
+// packages/lib/src/workflow-engine/catalog/derived-keys.ts
+
+/**
+ * The ONE declaration of what a *derived* node/edge data key is.
+ *
+ * Derived keys are canvas state: written by the workflow initializer on load
+ * (connection metadata, branch handles, loop bookkeeping, run status),
+ * stripped on every save, never read by the engine, and never authorable by
+ * an agent. `_targetBranches` is the canonical member.
+ *
+ * Six places independently re-implemented `key.startsWith('_')` and the
+ * seventh — config-schema validation — forgot to, which is how every stored
+ * HTTP node acquired a permanent, unfixable "`_targetBranches` is required"
+ * warning that the patcher then refused to let anyone clear.
+ *
+ * THE INVARIANT this file exists to protect: a manifest's `configSchema`
+ * validates *persisted* config, and derived keys are guaranteed absent from
+ * persisted config — so no `configSchema` may declare one. Asserted by
+ * `derived-keys.test.ts`.
+ */
+
+export const DERIVED_KEY_PREFIX = '_'
+
+/** Is this a derived (canvas-owned, never-persisted) data key? */
+export function isDerivedKey(key: string): boolean {
+  return key.startsWith(DERIVED_KEY_PREFIX)
+}
+
+/** A shallow copy of `record` with every derived key removed. */
+export function stripDerivedKeys<T extends Record<string, unknown>>(
+  record: T
+): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(record).filter(([key]) => !isDerivedKey(key)))
+}

--- a/packages/lib/src/workflow-engine/catalog/node-base.ts
+++ b/packages/lib/src/workflow-engine/catalog/node-base.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/workflow-engine/catalog/node-base.ts
 
 import { z } from 'zod'
-import { NodeRunningStatus } from '../core/types'
+import type { NodeRunningStatus } from '../core/types'
 
 /**
  * The pure half of the builder's node-base types (node-catalog Phase 1):
@@ -48,7 +48,14 @@ export interface NodeConnectionMetadata {
 }
 
 /**
- * Runtime/UI state properties for nodes
+ * Runtime/UI state properties for nodes.
+ *
+ * Every `_`-prefixed member here is DERIVED state (see
+ * `catalog/derived-keys.ts`): the canvas initializer writes it on load, the
+ * save path strips it, the engine never reads it, and no agent may author it.
+ * It is declared on the TS type because canvas code legitimately reads it —
+ * but it must never appear in a manifest's `configSchema`, which describes
+ * PERSISTED config.
  */
 export interface NodeRuntimeState extends NodeConnectionMetadata {
   // Selection and UI state
@@ -68,6 +75,15 @@ export interface NodeRuntimeState extends NodeConnectionMetadata {
 
   // Container relationships
   _children?: { nodeId: string; nodeType: string }[]
+
+  /**
+   * Branch handles this node renders, top-to-bottom. Declared ONCE here
+   * rather than per node type: five node interfaces used to redeclare it, and
+   * `http` additionally required it in its zod schema — a key the save path
+   * guarantees will be absent. The authoritative derivation is the manifest's
+   * `connection.branches(config)`.
+   */
+  _targetBranches?: TargetBranch[]
 }
 
 /**
@@ -159,20 +175,6 @@ export const baseNodeDataSchema = z.object({
   // Selection state
   selected: z.boolean().default(false),
 
-  // Runtime state properties (all optional)
-  _isBundled: z.boolean().optional(),
-  _inParallelHovering: z.boolean().optional(),
-  _isEntering: z.boolean().optional(),
-  _isCandidate: z.boolean().optional(),
-  _runningStatus: z.enum(NodeRunningStatus).optional(),
-  _waitingRun: z.boolean().optional(),
-  _singleRun: z.boolean().optional(),
-  _singleRunningStatus: z.enum(NodeRunningStatus).optional(),
-  _runningBranchId: z.string().optional(),
-  _retryIndex: z.number().optional(),
-  _children: z.array(z.object({ nodeId: z.string(), nodeType: z.string() })).optional(),
-  _connectedSourceHandleIds: z.array(z.string()).optional(),
-  _connectedTargetHandleIds: z.array(z.string()).optional(),
   collapsed: z.boolean().optional(),
 
   // Loop context
@@ -180,8 +182,12 @@ export const baseNodeDataSchema = z.object({
   loopId: z.string().optional(),
   isInIteration: z.boolean().optional(),
   iterationId: z.string().optional(),
-  _iterationLength: z.number().optional(),
-  _iterationIndex: z.number().optional(),
-  _loopLength: z.number().optional(),
-  _loopIndex: z.number().optional(),
+
+  // NOTE: the `_`-prefixed runtime/derived keys declared on `NodeRuntimeState`
+  // are DELIBERATELY absent from this schema. It validates PERSISTED config,
+  // and derived keys are stripped before every save — so declaring them here
+  // taught `describe_node_type` to advertise 17 phantom writable fields on
+  // most of the catalog, and taught `validateNodeConfigs` to report issues no
+  // caller could ever fix. Zod strips unknown keys, so canvas data carrying
+  // them still parses. See `catalog/derived-keys.ts`.
 })

--- a/packages/lib/src/workflow-engine/catalog/nodes/crud.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/crud.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 import { generateCrudNodeVariablesFromFields } from '../../../resources/variable-generators'
 import { BaseType } from '../../core/types'
 import type { UnifiedVariable } from '../../types/unified-variable'
-import type { BaseNodeData, TargetBranch } from '../node-base'
+import type { BaseNodeData } from '../node-base'
 import type { OutputContext } from '../output-context'
 import { resolveResourceGeneratorInputs } from '../resource-meta'
 import {
@@ -61,7 +61,6 @@ export interface CrudNodeData extends BaseNodeData {
   // Error handling configuration
   error_strategy: CrudErrorStrategy
   default_values: CrudDefaultValue[]
-  _targetBranches?: TargetBranch[]
 }
 
 /**
@@ -92,15 +91,7 @@ export const crudNodeDataSchema = z.object({
       })
     )
     .default([]),
-  _targetBranches: z
-    .array(
-      z.object({
-        id: z.string(),
-        name: z.string(),
-        type: z.enum(['default', 'fail']).default('default'),
-      })
-    )
-    .optional(),
+  // `_targetBranches` is DERIVED state — see catalog/derived-keys.ts.
   isValid: z.boolean().optional(),
   errors: z.array(z.string()).optional(),
   disabled: z.boolean().optional(),

--- a/packages/lib/src/workflow-engine/catalog/nodes/http.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/http.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import { HTTP_NODE_CONSTANTS } from '../../constants'
 import { BaseType } from '../../core/types'
 import type { UnifiedVariable } from '../../types/unified-variable'
-import type { BaseNodeData, TargetBranch } from '../node-base'
+import type { BaseNodeData } from '../node-base'
 import {
   type NodeBranch,
   NodeCategory,
@@ -132,7 +132,6 @@ export interface HttpNodeData extends BaseNodeData {
   ssl_verify: boolean
   error_strategy: ErrorStrategy
   default_value: DefaultValueItem[]
-  _targetBranches: TargetBranch[]
 }
 
 /**
@@ -204,13 +203,9 @@ export const httpNodeDataSchema = z.object({
   ssl_verify: z.boolean(),
   error_strategy: z.string(),
   default_value: z.array(z.object({ key: z.string(), type: z.string(), value: z.string() })),
-  _targetBranches: z.array(
-    z.object({
-      id: z.string(),
-      name: z.string(),
-      type: z.enum(['default', 'fail']).default('default'),
-    })
-  ),
+  // `_targetBranches` is DERIVED (canvas-owned) state and is deliberately not
+  // declared here — see catalog/derived-keys.ts. It used to be REQUIRED, which
+  // made every stored HTTP node report a warning nothing could clear.
 })
 
 /** Data validator for flattened structure */

--- a/packages/lib/src/workflow-engine/catalog/nodes/human.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/human.ts
@@ -3,7 +3,7 @@
 import { z } from 'zod'
 import { BaseType } from '../../core/types'
 import type { UnifiedVariable } from '../../types/unified-variable'
-import { type BaseNodeData, baseNodeDataSchema, type TargetBranch } from '../node-base'
+import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
 import {
   type NodeBranch,
   NodeCategory,
@@ -81,7 +81,6 @@ export interface HumanConfirmationNodeData extends BaseNodeData {
 
   // Branch configuration
   /** Target branches for human confirmation outcomes */
-  _targetBranches?: TargetBranch[]
 }
 
 /**

--- a/packages/lib/src/workflow-engine/catalog/nodes/if-else.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/if-else.ts
@@ -4,7 +4,7 @@ import { generateId } from '@auxx/utils/generateId'
 import { z } from 'zod'
 import { ALL_OPERATOR_KEYS, type Operator } from '../../../conditions/client'
 import { BaseType } from '../../core/types'
-import type { BaseNodeData, TargetBranch } from '../node-base'
+import type { BaseNodeData } from '../node-base'
 import {
   type NodeBranch,
   NodeCategory,
@@ -58,7 +58,6 @@ export interface NodeCase {
  */
 export interface IfElseNodeData extends BaseNodeData {
   cases: NodeCase[]
-  _targetBranches?: TargetBranch[]
 }
 
 /**
@@ -97,15 +96,7 @@ export const ifElseNodeDataSchema = z.object({
   title: z.string().min(1),
   desc: z.string().optional(),
   cases: z.array(caseSchema).min(1),
-  _targetBranches: z
-    .array(
-      z.object({
-        id: z.string(),
-        name: z.string(),
-        type: z.enum(['default', 'fail']).default('default'),
-      })
-    )
-    .optional(),
+  // `_targetBranches` is DERIVED state — see catalog/derived-keys.ts.
 
   // Other node data properties
   isValid: z.boolean().optional(),

--- a/packages/lib/src/workflow-engine/catalog/nodes/text-classifier.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/text-classifier.ts
@@ -4,7 +4,7 @@ import { generateId } from '@auxx/utils/generateId'
 import { z } from 'zod'
 import { AI_NODE_CONSTANTS } from '../../constants'
 import { BaseType } from '../../core/types'
-import type { BaseNodeData, TargetBranch } from '../node-base'
+import type { BaseNodeData } from '../node-base'
 import {
   type NodeBranch,
   NodeCategory,
@@ -90,7 +90,6 @@ export interface TextClassifierNodeData extends BaseNodeData {
   vision: VisionConfig
   instruction: InstructionConfig
   outputMode?: TextClassifierOutputMode
-  _targetBranches?: TargetBranch[]
 }
 
 /**

--- a/packages/lib/src/workflow-engine/client.ts
+++ b/packages/lib/src/workflow-engine/client.ts
@@ -88,6 +88,11 @@ export {
   type TriggerDerivationNode,
 } from './catalog/derive-trigger'
 export {
+  DERIVED_KEY_PREFIX,
+  isDerivedKey,
+  stripDerivedKeys,
+} from './catalog/derived-keys'
+export {
   buildDownstreamMap,
   buildUpstreamMap,
   computeLoopAncestry,

--- a/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
@@ -756,8 +756,9 @@ describe('updateNode / disconnectNodes', () => {
     })
   })
 
-  it('rejects a patch based on a stale get_node configHash without persisting', async () => {
-    const graph: DraftGraph = { nodes: [triggerNode(), loopNode()], edges: [] }
+  it('rejects a patch based on a stale configHash, naming the CURRENT hash', async () => {
+    const loop = loopNode()
+    const graph: DraftGraph = { nodes: [triggerNode(), loop], edges: [] }
     const result = await updateNode(makeDb(graph), {
       workflowAppId: APP,
       organizationId: ORG,
@@ -767,8 +768,115 @@ describe('updateNode / disconnectNodes', () => {
     })
 
     expect(result.isErr()).toBe(true)
-    expect(result._unsafeUnwrapErr().message).toContain('Re-read the node')
+    // The value that makes the retry succeed rides the error — a caller that
+    // lost its hash used to have no way back except abandoning the mode.
+    expect(result._unsafeUnwrapErr().message).toContain(hashWorkflowGraph(loop.data))
+    expect(result._unsafeUnwrapErr().message).toContain('get_node')
     expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('applies patches WITHOUT expectedConfigHash — the CAS is optional', async () => {
+    // The graph-level CAS in persistDraft already prevents a concurrent save
+    // being overwritten; the node hash only narrows "my paths were chosen
+    // against a stale shape". Requiring it made a lost hash unrecoverable.
+    const graph: DraftGraph = { nodes: [triggerNode(), loopNode()], edges: [] }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'For each order',
+      patches: [{ op: 'set', path: ['maxIterations'], value: 5 }],
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(persistedGraph().nodes.find((n) => n.id === LOOP_ID)?.data?.maxIterations).toBe(5)
+  })
+
+  it('ignores a derived-key patch, applies its siblings, and says so', async () => {
+    const graph: DraftGraph = { nodes: [triggerNode(), loopNode()], edges: [] }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'For each order',
+      patches: [
+        { op: 'set', path: ['_targetBranches'], value: [] },
+        { op: 'set', path: ['maxIterations'], value: 7 },
+      ],
+    })
+
+    expect(result.isOk()).toBe(true)
+    const value = result._unsafeUnwrap()
+    expect(value.applied).toBe(true)
+    expect(persistedGraph().nodes.find((n) => n.id === LOOP_ID)?.data?.maxIterations).toBe(7)
+    expect(
+      value.issues.some(
+        (issue) => issue.severity === 'info' && issue.message.includes('_targetBranches')
+      )
+    ).toBe(true)
+  })
+
+  it("marks an untouched node's issues preExisting, and the edited node's not", async () => {
+    const brokenId = 'crud-bbbbbbbbbbbbbbbbbbbbb'
+    const crud: GraphNode = {
+      id: brokenId,
+      position: { x: 0, y: 0 },
+      data: { id: brokenId, type: 'crud', title: 'Create Ticket', mode: 'create' },
+    }
+    const graph: DraftGraph = { nodes: [triggerNode(), loopNode(), crud], edges: [] }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'For each order',
+      config: { maxIterations: 4 },
+    })
+
+    expect(result.isOk()).toBe(true)
+    const issues = result._unsafeUnwrap().issues.filter((issue) => issue.nodeRef)
+    // The half-configured CRUD node was already broken before this edit.
+    expect(issues.some((issue) => issue.nodeRef === 'Create Ticket')).toBe(true)
+    for (const issue of issues) {
+      expect(issue.preExisting === true, `${issue.nodeRef}: ${issue.message}`).toBe(
+        issue.nodeRef !== 'For each order'
+      )
+    }
+  })
+
+  it('rejects a config-mode write of ONLY derived keys instead of silently dropping it', async () => {
+    // `config` used to spread derived keys into node data and let persist strip
+    // them, so the same edit was a hard error through `patches` and a silent
+    // no-op through `config`. Both modes now agree.
+    const graph: DraftGraph = { nodes: [triggerNode(), loopNode()], edges: [] }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'For each order',
+      config: { _targetBranches: [] },
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('derived state')
+    expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('honours expectedConfigHash with config mode instead of rejecting it', async () => {
+    const loop = loopNode()
+    const graph: DraftGraph = { nodes: [triggerNode(), loop], edges: [] }
+    const stale = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'For each order',
+      config: { maxIterations: 3 },
+      expectedConfigHash: 'stale',
+    })
+    expect(stale.isErr()).toBe(true)
+
+    const fresh = await updateNode(makeDb({ nodes: [triggerNode(), loopNode()], edges: [] }), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'For each order',
+      config: { maxIterations: 3 },
+      expectedConfigHash: hashWorkflowGraph(loop.data),
+    })
+    expect(fresh.isOk()).toBe(true)
   })
 
   it('disconnectNodes removes the edge and errors when none exists', async () => {

--- a/packages/lib/src/workflows/graph-edit/__tests__/patch-config.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/patch-config.test.ts
@@ -17,11 +17,12 @@ describe('applyConfigPatches', () => {
     ])
 
     expect(result.isOk()).toBe(true)
-    expect(result._unsafeUnwrap()).toEqual({
+    expect(result._unsafeUnwrap().config).toEqual({
       model: { completion_params: { temperature: 0.2, max_tokens: 500 } },
       schema: { properties: { 'order.total': { type: 'number' } } },
       cases: [{ id: 'case-1', logical_operator: 'or' }],
     })
+    expect(result._unsafeUnwrap().ignoredPaths).toEqual([])
     expect(original.model.completion_params.temperature).toBe(0.7)
   })
 
@@ -31,7 +32,7 @@ describe('applyConfigPatches', () => {
       { op: 'unset', path: ['authorization', 'token'] },
     ])
 
-    expect(result._unsafeUnwrap()).toEqual({ authorization: { type: 'bearer' } })
+    expect(result._unsafeUnwrap().config).toEqual({ authorization: { type: 'bearer' } })
   })
 
   it.each([
@@ -39,13 +40,37 @@ describe('applyConfigPatches', () => {
     [{ op: 'set', path: ['items', 1], value: 'b' }],
     [{ op: 'unset', path: ['items', 0] }],
     [{ op: 'set', path: ['__proto__', 'polluted'], value: true }],
-    [{ op: 'set', path: ['_targetBranches'], value: [] }],
     [{ op: 'set', path: ['id'], value: 'evil' }],
   ])('rejects unsafe or ambiguous path operations: %j', (patch) => {
     const result = applyConfigPatches({ items: ['a'] }, [patch] as Parameters<
       typeof applyConfigPatches
     >[1])
     expect(result.isErr()).toBe(true)
+  })
+
+  it('IGNORES a derived-key patch and still applies the real ones', () => {
+    // A `_`-rooted path is canvas state no save persists and no caller can
+    // change. Rejecting the whole call threw away the sibling patches that
+    // carried the actual fix, and left the model retrying an edit that could
+    // never land.
+    const result = applyConfigPatches({ url: '', items: ['a'] }, [
+      { op: 'set', path: ['_targetBranches'], value: [] },
+      { op: 'set', path: ['url'], value: 'https://example.com' },
+    ])
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().config).toEqual({ url: 'https://example.com', items: ['a'] })
+    expect(result._unsafeUnwrap().ignoredPaths).toEqual(['["_targetBranches"]'])
+  })
+
+  it('errors when EVERY patch is a derived key — there is nothing to apply', () => {
+    const result = applyConfigPatches({ url: '' }, [
+      { op: 'set', path: ['_targetBranches'], value: [] },
+    ])
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('derived state')
+    expect(result._unsafeUnwrapErr().message).toContain('connect_nodes')
   })
 
   it('does not mutate the input when a later patch fails', () => {

--- a/packages/lib/src/workflows/graph-edit/ops.ts
+++ b/packages/lib/src/workflows/graph-edit/ops.ts
@@ -21,6 +21,7 @@ import { incrementTitle, nextKeyAfter } from '@auxx/utils'
 import { generateId } from '@auxx/utils/generateId'
 import { err, ok, type Result } from 'neverthrow'
 import { AuxxError, BadRequestError, ConflictError, NotFoundError } from '../../errors'
+import { isDerivedKey, stripDerivedKeys } from '../../workflow-engine/catalog/derived-keys'
 import { LOOP_HANDLES } from '../../workflow-engine/catalog/nodes/loop'
 import { getAuthorableManifests, getManifest } from '../../workflow-engine/catalog/registry'
 import { resolveGraphOutputs } from '../../workflow-engine/catalog/resolve-outputs'
@@ -154,6 +155,19 @@ async function runGraphMutation(
   if (resolved.isOk()) {
     outputsMap = resolved.value
     issues.push(...checkVariableRefsAgainstOutputs({ graph, outputs: outputsMap }).issues)
+  }
+
+  // Mark what this edit did NOT cause. A mutation reports the whole draft's
+  // issues, so an untouched node's long-standing warning is indistinguishable
+  // from damage the current call just did — and a caller that cannot tell them
+  // apart keeps "fixing" things it never broke.
+  const touchedRefs = new Set(
+    [...(plan.newNodeIds ?? []), ...(plan.touchedNodeId ? [plan.touchedNodeId] : [])].map((id) =>
+      formatNodeRef(graph.nodes, id)
+    )
+  )
+  for (const issue of issues) {
+    if (issue.nodeRef && !touchedRefs.has(issue.nodeRef)) issue.preExisting = true
   }
 
   // Pre-turn snapshot — captured only now that the write is certain to be
@@ -687,27 +701,34 @@ interface UpdateNodeBaseInput extends GraphMutationScope {
   ref: string
 }
 
-/** Input for {@link updateNode}: a legacy shallow merge or guarded deep patches. */
-export type UpdateNodeInput = UpdateNodeBaseInput &
-  (
-    | {
-        /** Friendly config, shallow-merged over the node's current data. */
-        config: Record<string, unknown>
-        patches?: never
-        expectedConfigHash?: never
-      }
-    | {
-        /** Atomic edits against the complete friendly config returned by `get_node`. */
-        patches: ConfigPatch[]
-        /** `configHash` from the same `get_node` result used to choose the patch paths. */
-        expectedConfigHash: string
-        config?: never
-      }
-  )
+/** Input for {@link updateNode}: a legacy shallow merge or deep patches. */
+export type UpdateNodeInput = UpdateNodeBaseInput & {
+  /** Friendly config, shallow-merged over the node's current data. */
+  config?: Record<string, unknown>
+  /** Atomic edits against the complete friendly config returned by `get_node`. */
+  patches?: ConfigPatch[]
+  /**
+   * OPTIONAL optimistic-concurrency token — the `configHash` from the
+   * `get_node`/mutation result the caller chose its edit against. Honoured
+   * with BOTH modes.
+   *
+   * It is not required, and that is deliberate. The write is already guarded
+   * at the graph level: `runGraphMutation` reloads the draft inside the
+   * mutation and `persistDraft` CASes on `expectedGraphHash`, so a concurrent
+   * save can never be silently overwritten with or without this token. What
+   * the node hash adds is narrower — it catches "the patch paths were chosen
+   * against a shape that has since changed". Worth checking when offered;
+   * not worth failing an otherwise-correct edit over, which is what a hard
+   * requirement did: a caller that lost the hash could not make ANY progress
+   * and fell back to the shallow `config` mode to escape it.
+   */
+  expectedConfigHash?: string
+}
 
 /**
- * Update one node using either the legacy top-level merge or atomic, stale-safe
- * deep patches. `id`, `type`, and derived keys cannot be patched.
+ * Update one node using either the legacy top-level merge or atomic deep
+ * patches. `id` and `type` cannot be written; derived keys are ignored with a
+ * reported issue rather than rejected (see `applyConfigPatches`).
  */
 export async function updateNode(
   db: Database,
@@ -721,29 +742,52 @@ export async function updateNode(
     const manifestResult = requireAuthorableManifest(type)
     if (manifestResult.isErr()) return err(manifestResult.error)
 
+    const hasPatches = params.patches !== undefined
+    const hasConfig = params.config !== undefined
+    if (hasPatches === hasConfig) {
+      return err(new BadRequestError('Pass exactly one of config or patches.'))
+    }
+
+    // One optimistic-concurrency check for both modes. Absent ⇒ no check; the
+    // graph-level CAS in `persistDraft` still guards the write. Present and
+    // stale ⇒ conflict, and the message carries the CURRENT hash so the next
+    // call can succeed without another read.
+    const actualConfigHash = hashNodeConfig((node.data ?? {}) as Record<string, unknown>)
+    if (params.expectedConfigHash && params.expectedConfigHash !== actualConfigHash) {
+      return err(
+        new ConflictError(
+          'This node changed after it was read. Nothing was overwritten. Its current ' +
+            `configHash is "${actualConfigHash}" — re-read it with get_node, confirm your ` +
+            'edit still applies, and retry with that hash.'
+        )
+      )
+    }
+
     let nextData: Record<string, unknown>
     let normalized: Awaited<ReturnType<typeof normalizeConfig>>
+    const derivedIssues: Issue[] = []
+    const refLabel = formatNodeRef(ctx.graph.nodes, node.id)
 
-    if ('patches' in params) {
-      const actualConfigHash = hashNodeConfig((node.data ?? {}) as Record<string, unknown>)
-      if (params.expectedConfigHash !== actualConfigHash) {
-        return err(
-          new ConflictError(
-            'This node changed after get_node returned it. Re-read the node and retry the ' +
-              'patches with its new configHash. Nothing was overwritten.'
-          )
-        )
-      }
-
+    if (params.patches) {
       const currentFriendly = buildNodeSummary(ctx.graph, node, aliases).config
       const patched = applyConfigPatches(currentFriendly, params.patches)
       if (patched.isErr()) return err(patched.error)
+      if (patched.value.ignoredPaths.length > 0) {
+        derivedIssues.push({
+          severity: 'info',
+          nodeRef: refLabel,
+          message:
+            `Ignored ${patched.value.ignoredPaths.join(', ')} — derived state, maintained ` +
+            "automatically from the node's connections. The other edits were applied; use " +
+            'connect_nodes to change branch wiring.',
+        })
+      }
       normalized = await normalizeConfig(
         ctx.organizationId,
         ctx.graph.nodes,
         aliases,
         type,
-        patched.value
+        patched.value.config
       )
       const { id: _id, type: _type, ...replacement } = normalized.config
 
@@ -758,9 +802,33 @@ export async function updateNode(
         ctx.graph.nodes,
         aliases,
         type,
-        params.config
+        params.config as Record<string, unknown>
       )
-      const { id: _id, type: _type, ...mergeable } = normalized.config
+      const { id: _id, type: _type, ...merged } = normalized.config
+      // Same derived-key treatment as the patch path — the two modes must not
+      // disagree about what a caller may write. `config` used to accept them
+      // silently and let persist drop them, so the identical edit was a hard
+      // error one way and a no-op the other.
+      const ignored = Object.keys(merged).filter(isDerivedKey)
+      if (ignored.length === Object.keys(merged).length && ignored.length > 0) {
+        return err(
+          new BadRequestError(
+            `Nothing to apply: ${ignored.join(', ')} ${ignored.length === 1 ? 'is' : 'are'} ` +
+              "derived state, maintained automatically from the node's connections. Use " +
+              'connect_nodes to change branch wiring.'
+          )
+        )
+      }
+      if (ignored.length > 0) {
+        derivedIssues.push({
+          severity: 'info',
+          nodeRef: refLabel,
+          message:
+            `Ignored ${ignored.join(', ')} — derived state, maintained automatically from ` +
+            "the node's connections. The other fields were applied.",
+        })
+      }
+      const mergeable = stripDerivedKeys(merged)
       nextData = { ...(node.data as Record<string, unknown>), ...mergeable }
     }
 
@@ -769,7 +837,7 @@ export async function updateNode(
       graph: { ...ctx.graph, nodes: nextNodes },
       touchedNodeId: node.id,
       newNodeIds: new Set([node.id]),
-      normalizeIssues: normalized.issues,
+      normalizeIssues: [...normalized.issues, ...derivedIssues],
     })
   })
 }

--- a/packages/lib/src/workflows/graph-edit/patch-config.ts
+++ b/packages/lib/src/workflows/graph-edit/patch-config.ts
@@ -2,6 +2,7 @@
 
 import { err, ok, type Result } from 'neverthrow'
 import { BadRequestError } from '../../errors'
+import { isDerivedKey } from '../../workflow-engine/catalog/derived-keys'
 
 /** One unambiguous segment in an agent-visible node config path. */
 export type ConfigPathSegment = string | number
@@ -41,7 +42,7 @@ function validatePath(path: ConfigPathSegment[]): Result<void, BadRequestError> 
   if (typeof root !== 'string') {
     return err(new BadRequestError('Patch paths must start with a config field name.'))
   }
-  if (FORBIDDEN_ROOT_KEYS.has(root) || root.startsWith('_')) {
+  if (FORBIDDEN_ROOT_KEYS.has(root)) {
     return err(new BadRequestError(`Config field "${root}" cannot be patched.`))
   }
   return ok(undefined)
@@ -74,18 +75,37 @@ function descend(
   return ok((current as Record<string, unknown>)[segment])
 }
 
+/** What {@link applyConfigPatches} produced: the new config plus what it skipped. */
+export interface AppliedConfigPatches {
+  config: Record<string, unknown>
+  /**
+   * Derived-key patch paths that were IGNORED rather than rejected, rendered
+   * for a message. Empty on the normal path.
+   */
+  ignoredPaths: string[]
+}
+
 /**
  * Apply config patches to a clone. Parents must exist; `set` may create its
  * final object key, while arrays are replacement-only and never sparse.
+ *
+ * Patches rooted at a DERIVED key are dropped rather than rejected. Such a key
+ * is canvas state that no save persists and no caller can change, so a hard
+ * error taught the model to retry an edit that could never land — while the
+ * *other* patches in the same call, which usually carry the real fix, were
+ * thrown away with it. Dropping applies the real work and reports the skip.
+ * A call whose patches are ALL derived still errors: there is nothing to
+ * apply, and reporting success would claim an edit that did not happen.
  */
 export function applyConfigPatches(
   config: Record<string, unknown>,
   patches: ConfigPatch[]
-): Result<Record<string, unknown>, BadRequestError> {
+): Result<AppliedConfigPatches, BadRequestError> {
   if (patches.length === 0) {
     return err(new BadRequestError('At least one config patch is required.'))
   }
 
+  const ignoredPaths: string[] = []
   const next = structuredClone(config)
   for (const patch of patches) {
     if (
@@ -99,6 +119,12 @@ export function applyConfigPatches(
     }
     const valid = validatePath(patch.path)
     if (valid.isErr()) return err(valid.error)
+
+    const root = patch.path[0]
+    if (typeof root === 'string' && isDerivedKey(root)) {
+      ignoredPaths.push(JSON.stringify(patch.path))
+      continue
+    }
 
     let parent: unknown = next
     for (let index = 0; index < patch.path.length - 1; index += 1) {
@@ -143,5 +169,16 @@ export function applyConfigPatches(
       record[leaf] = structuredClone(patch.value)
     }
   }
-  return ok(next)
+
+  if (ignoredPaths.length === patches.length) {
+    return err(
+      new BadRequestError(
+        `Nothing to apply: ${ignoredPaths.join(', ')} ${
+          ignoredPaths.length === 1 ? 'is' : 'are'
+        } derived state, maintained automatically from the node's connections. It cannot be ` +
+          'set, and nothing needs to set it — use connect_nodes to change branch wiring.'
+      )
+    )
+  }
+  return ok({ config: next, ignoredPaths })
 }

--- a/packages/lib/src/workflows/graph-edit/persist.ts
+++ b/packages/lib/src/workflows/graph-edit/persist.ts
@@ -28,14 +28,10 @@ import type { Database } from '@auxx/database'
 import { err, ok, type Result } from 'neverthrow'
 import { AuxxError, NotFoundError, UnprocessableEntityError } from '../../errors'
 import { deriveTriggerColumns } from '../../workflow-engine/catalog/derive-trigger'
+import { stripDerivedKeys } from '../../workflow-engine/catalog/derived-keys'
 import type { WorkflowTriggerType, WorkflowUpdateInput } from '../types'
 import type { GraphEditScope } from './read'
 import type { DraftGraph, GraphEdge, GraphNode } from './types'
-
-/** Strip `_`-prefixed keys — derived state the initializer regenerates on load. */
-function stripDerivedKeys(record: Record<string, unknown>): Record<string, unknown> {
-  return Object.fromEntries(Object.entries(record).filter(([key]) => !key.startsWith('_')))
-}
 
 /**
  * The same cleanup the canvas save applies (`use-workflow-save.ts`

--- a/packages/lib/src/workflows/graph-edit/read.ts
+++ b/packages/lib/src/workflows/graph-edit/read.ts
@@ -16,6 +16,7 @@ import { type Database, schema } from '@auxx/database'
 import { and, eq } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import { type AuxxError, NotFoundError } from '../../errors'
+import { isDerivedKey, stripDerivedKeys } from '../../workflow-engine/catalog/derived-keys'
 import { resolveGraphOutputs } from '../../workflow-engine/catalog/resolve-outputs'
 import type { UnifiedVariable } from '../../workflow-engine/types/unified-variable'
 import { hashWorkflowGraph } from '../graph-hash'
@@ -116,11 +117,9 @@ const NON_CONFIG_KEYS = new Set([
   'outputVariables',
 ])
 
-/** Hash durable node data only; `_` keys are regenerated and stripped on save. */
+/** Hash durable node data only; derived keys are regenerated and stripped on save. */
 export function hashNodeConfig(data: Record<string, unknown>): string {
-  return hashWorkflowGraph(
-    Object.fromEntries(Object.entries(data).filter(([key]) => !key.startsWith('_')))
-  )
+  return hashWorkflowGraph(stripDerivedKeys(data))
 }
 
 /** One node's summary: friendly ref + friendly-rendered config. */
@@ -131,7 +130,7 @@ export function buildNodeSummary(
 ): NodeSummary {
   const config: Record<string, unknown> = {}
   for (const [key, value] of Object.entries((node.data ?? {}) as Record<string, unknown>)) {
-    if (key.startsWith('_') || NON_CONFIG_KEYS.has(key)) continue
+    if (isDerivedKey(key) || NON_CONFIG_KEYS.has(key)) continue
     config[key] = value
   }
   const container = node.parentId ?? (node.data?.loopId as string | undefined)

--- a/packages/lib/src/workflows/graph-edit/types.ts
+++ b/packages/lib/src/workflows/graph-edit/types.ts
@@ -41,6 +41,16 @@ export interface Issue {
   message: string
   /** Machine-usable corrected form (e.g. `att.values[*].name` for `att[*].name`). */
   suggestion?: string
+  /**
+   * True when this issue is about a node the current mutation did NOT touch —
+   * it was already there and is not a consequence of this edit.
+   *
+   * Without the distinction a caller re-reads a full issue list after every
+   * write and cannot tell "I just caused this" from "this was already here",
+   * which is how one agent spent a whole turn chasing three warnings it had
+   * already fixed.
+   */
+  preExisting?: boolean
 }
 
 /**


### PR DESCRIPTION
## What happened

One Kopilot turn on workflow "Fedex Shipment" burned all 30 iterations, issued
~20 `update_node` calls with 7 hard failures, and **never produced a reply**.
The agent found three real problems, fixed all three, re-read the workflow to
confirm — and the re-read replayed the *pre-edit* graph out of a per-turn cache.
So it fixed them again. Every `validate_workflow` in the turn returned the
byte-identical report because it was the same cached object.

Three independent causes. All three are fixed here.

## 1. The idempotent cache was never invalidated (the root cause)

`query-loop.ts` cached idempotent tool results for the whole turn and never
cleared them. For a tool whose parameters are `{}` — `get_workflow`,
`validate_workflow` — the cache key is a **constant for the entire turn**: one
call, one answer, forever. There was no test of this cache and a cache hit
produced no log line, which is why it took a forensic pass to find.

Any dispatch of a **non-idempotent** tool now drops the whole cache — success
or failure, since a failed write may still have partially landed. Invalidation
reaches a later read **in the same batch**, because `executeToolCalls` is a
sequential `await` loop, which is exactly the `[update_node, …,
validate_workflow]` shape from the log.

**This is not a workflow bug.** Seven capabilities carried it: workflow-builder,
kb (`resolve_block_by_heading` hands back block ids that moved), entities
("create the record then read it back" replayed the pre-create answer),
agents-builder (`get_eval_run` is a **poll** — identical args meant the first
`running` snapshot replayed for the rest of the turn, so polling a run to
completion was impossible by construction), mail, record-views, tasks.

Cache hits now log at `scope='agent-query-loop'`, same shape as real results.

## 2. Derived keys were declared in schemas that describe persisted config

`_`-prefixed keys are canvas state: written by the initializer on load,
stripped on every save, never read by the engine, never authorable. But they
were declared in `configSchema` — which validates **persisted** config, where
they are guaranteed absent.

That lied to three consumers at once:

- **`describe_node_type`** publishes `agentSchema ?? configSchema` as the
  agent-facing JSON Schema, and no manifest declares `agentSchema`. So the model
  was told `_targetBranches` was a **required** field of the HTTP config — and
  12 other node types were shown the full 17-key `baseNodeDataSchema` runtime
  block (`_isBundled`, `_runningStatus`, `_retryIndex`, `_children`, …) as
  writable config. The tool's own description says *"Always call this before
  configuring an unfamiliar type."* The agent wasn't guessing.
- **`validateNodeConfigs`** safe-parsed stored data against it, so every stored
  HTTP node in every org carried a permanent `_targetBranches is required`
  warning on every read.
- **`patch-config`** refused `_`-rooted paths — so the only edit that would
  clear that warning was rejected. The agent tried three times.

Now: **no `configSchema` declares a derived key.** `_targetBranches` is declared
once on `NodeRuntimeState` instead of in five node interfaces, and one exported
`isDerivedKey`/`stripDerivedKeys` replaces six hand-rolled `startsWith('_')`
copies. Zod strips unknown keys, so legacy rows that still carry the key (26
if-else, 4 text-classifier in dev) keep validating — asserted.

## 3. `update_node`'s contract was unrecoverable

- Derived-key patches now **drop with an `info` issue** instead of rejecting the
  sibling patches that carried the real fix. An all-derived call still errors.
- `config` mode now agrees with `patches` mode about derived keys. It used to
  accept them silently and let persist drop them, so the identical edit was a
  hard error one way and a no-op the other.
- **`expectedConfigHash` is optional in both modes.** The write is already
  guarded at the graph level — `runGraphMutation` reloads the draft and
  `persistDraft` CASes on `expectedGraphHash` — so a concurrent save can never
  be silently overwritten either way. The node hash only narrows "my patch paths
  were chosen against a stale shape", which is not worth failing an otherwise
  correct edit over. Requiring it is what taught the model to abandon `patches`
  for `config` (4 of the 7 failures). Every conflict now carries the node's
  **current** hash, so the retry succeeds without another read.

## Self-healing

`Issue.preExisting` marks issues about nodes the current mutation did **not**
touch. A mutation reports the whole draft's issues, so a long-standing warning
elsewhere was indistinguishable from damage the current edit caused — and a
caller that can't tell them apart keeps "fixing" things it never broke.

Prompt + tool descriptions now say that every mutation returns the touched node
with its new `configHash` (so re-reading it is waste), and that
`validate_workflow` belongs in a **later** step, never in the same batch as the
edits it checks.

## Tests

- `idempotent-cache.test.ts` — 6 cases: dedupe with no writes, `read → write →
  read`, `[read, write, read]` in one batch, invalidation after a **failed**
  write, arg-keying, capture mode. **Verified red with the invalidation
  disabled** (4 fail, including capture mode), green with it restored.
- `catalog/derived-keys.test.ts` — the static invariant (no `configSchema`
  declares a `_` key, over `z.toJSONSchema`, the exact surface
  `describe_node_type` publishes), plus a stored-shape parse and a legacy-data
  case. The stored-shape assertion fails on `http` alone before this change.
- `tool-permission-declarations.test.ts` — the 34 idempotent tools pinned
  exactly, both directions, so a new flag fails until someone confirms the tool
  is read-only. (`permission.level` can't be the discriminator: the eval reads
  sit at `admin` because the agents area has one rung.)
- `patch-config.test.ts` / `ops.test.ts` / `write-tools.test.ts` — drop-and-warn,
  all-derived rejection, optional CAS, config-mode agreement, hash echoed in
  conflicts, `preExisting` tagging.

Green: lib 2673 passed, apps/web workflow 135 passed (parity suite included),
`typescript7` typecheck clean on every touched file, biome clean.

## Deliberately not in this PR

D9 (`unchanged: true` no-op short-circuit), D10 (graceful close at
`maxIterations`), D11 (`readOnlyNodes` replacing per-node app-block `info`
issues — needs sequencing against plan 17). All independent of the above.

**Follow-up this makes possible:** `_targetBranches` should stop being node
*data* entirely. Its only consumers are canvas layout, and
`manifest.connection.branches(config)` is already the declared source of truth —
the canvas's `calculateTargetBranches` duplicates it for four node types, as its
own comments admit.
