### PR TITLE
fix(kopilot): report no-op writes, and name read-only nodes once

### DIFF
--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/graph-tool-helpers.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/graph-tool-helpers.ts
@@ -91,6 +91,8 @@ export function projectOutputs(outputs: unknown[] | undefined): ProjectedOutput[
 /** The projected success output every graph mutation tool returns. */
 export interface ProjectedMutation {
   applied: boolean
+  /** Nothing was written because the requested state already held. */
+  unchanged?: boolean
   /** Human line for the status pill — also what `buildDigest` picks up. */
   summary: string
   node?: ProjectedNode
@@ -123,7 +125,13 @@ export function mutationToToolResult(
   const value = result.value
   const projected: ProjectedMutation = {
     applied: value.applied,
-    summary: summarize(value),
+    ...(value.unchanged ? { unchanged: true } : {}),
+    // Say plainly that nothing moved. `summarize` would otherwise report
+    // "Updated X" for a write that wrote nothing, which is what let the model
+    // re-issue the same edit without ever learning it was already applied.
+    summary: value.unchanged
+      ? `No change — ${value.node?.title ?? 'the target'} already had these values.`
+      : summarize(value),
     ...(value.node ? { node: projectNode(value.node) } : {}),
     ...(value.outputs ? { outputs: projectOutputs(value.outputs) } : {}),
     issues: value.issues,

--- a/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
@@ -818,6 +818,7 @@ describe('updateNode / disconnectNodes', () => {
     const brokenId = 'crud-bbbbbbbbbbbbbbbbbbbbb'
     const crud: GraphNode = {
       id: brokenId,
+      type: 'standard',
       position: { x: 0, y: 0 },
       data: { id: brokenId, type: 'crud', title: 'Create Ticket', mode: 'create' },
     }
@@ -838,6 +839,69 @@ describe('updateNode / disconnectNodes', () => {
         issue.nodeRef !== 'For each order'
       )
     }
+  })
+
+  it('names uncatalogued nodes ONCE on the summary, not as an issue per read', async () => {
+    // Anything with no catalog manifest — an app block, or a not-yet-migrated
+    // type like `webhook` — used to emit an `info` issue on every read and
+    // every mutation result: un-actionable noise that buried the issues that
+    // WERE actionable. It is a fact about the graph, so it rides the summary.
+    //
+    // `webhook` rather than an `appId:blockId` app block on purpose: a
+    // colon-shaped type sends `resolveGraphOutputs` into the org cache for the
+    // app-block lookup, which this suite's bare mock db cannot serve.
+    const readOnlyId = 'webhook-aaaaaaaaaaaaaaaaaa'
+    const readOnly: GraphNode = {
+      id: readOnlyId,
+      type: 'standard',
+      position: { x: 900, y: 100 },
+      data: { id: readOnlyId, type: 'webhook', title: 'Incoming Webhook' },
+    }
+    const graph: DraftGraph = { nodes: [triggerNode(), loopNode(), readOnly], edges: [] }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'For each order',
+      config: { maxIterations: 11 },
+    })
+
+    expect(result.isOk()).toBe(true)
+    const value = result._unsafeUnwrap()
+    expect(value.graphSummary.readOnlyNodes).toEqual(['Incoming Webhook'])
+    expect(value.issues.some((i) => /not in the catalog|read-only/.test(i.message))).toBe(false)
+  })
+
+  it('reports a re-issued identical edit as unchanged and does NOT write', async () => {
+    // The logged failure turn wrote the same config repeatedly, each time to an
+    // identical hash, and nothing told it. `applied` stays true — the requested
+    // state holds; `applied: false` is the blocking-issue vocabulary.
+    const graph: DraftGraph = { nodes: [triggerNode(), loopNode()], edges: [] }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'For each order',
+      // loopNode() already has maxIterations: 100.
+      config: { maxIterations: 100 },
+    })
+
+    expect(result.isOk()).toBe(true)
+    const value = result._unsafeUnwrap()
+    expect(value.applied).toBe(true)
+    expect(value.unchanged).toBe(true)
+    expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('a real edit is NOT reported unchanged', async () => {
+    const graph: DraftGraph = { nodes: [triggerNode(), loopNode()], edges: [] }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'For each order',
+      config: { maxIterations: 42 },
+    })
+
+    expect(result._unsafeUnwrap().unchanged).toBeUndefined()
+    expect(serviceUpdate).toHaveBeenCalled()
   })
 
   it('rejects a config-mode write of ONLY derived keys instead of silently dropping it', async () => {

--- a/packages/lib/src/workflows/graph-edit/ops.ts
+++ b/packages/lib/src/workflows/graph-edit/ops.ts
@@ -27,6 +27,7 @@ import { getAuthorableManifests, getManifest } from '../../workflow-engine/catal
 import { resolveGraphOutputs } from '../../workflow-engine/catalog/resolve-outputs'
 import { NodeCategory, type NodeManifest } from '../../workflow-engine/catalog/types'
 import type { UnifiedVariable } from '../../workflow-engine/types/unified-variable'
+import { hashWorkflowGraph } from '../graph-hash'
 import { assertMailTriggerNotPersonal } from '../mail-trigger-guard'
 import { calculateContainerSize, getLayoutByDagre, getLayoutForChildNodes } from './layout'
 import { LAYOUT_SPACING, NODE_ADDITION_CONFIG } from './layout-constants'
@@ -36,7 +37,7 @@ import { normalizeAiPromptConfig } from './normalize/prompt'
 import { checkVariableRefsAgainstOutputs } from './normalize/ref-check'
 import { buildResourceAliasIndex, normalizeResourceConfig } from './normalize/resource-refs'
 import { applyConfigPatches, type ConfigPatch } from './patch-config'
-import { persistDraft, publishDraftUpdatedSignal } from './persist'
+import { cleanGraphForSave, persistDraft, publishDraftUpdatedSignal } from './persist'
 import {
   DEFAULT_NODE_SIZE,
   findNearestEmptySpace,
@@ -168,6 +169,44 @@ async function runGraphMutation(
   )
   for (const issue of issues) {
     if (issue.nodeRef && !touchedRefs.has(issue.nodeRef)) issue.preExisting = true
+  }
+
+  // NO-OP SHORT-CIRCUIT: a mutation whose cleaned graph hashes to what was
+  // loaded changed nothing. Skip the write, the turn snapshot and the realtime
+  // signal, and SAY so — without this the caller cannot tell "my edit landed"
+  // from "my edit was already the state", so it keeps re-issuing it. The
+  // logged failure turn wrote the same HTTP config twice and the same CRUD
+  // config three times, each to an identical hash, and nothing told it.
+  //
+  // Stays `applied: true`: the requested state holds. `applied: false` is the
+  // BLOCKING-issue vocabulary (`mutationToToolResult` renders it as
+  // "Update X blocked"), and telling the model a harmless idempotent write
+  // failed is the loop this whole plan exists to kill.
+  //
+  // `hashWorkflowGraph(cleanGraphForSave(…))` is exactly what the next load
+  // will hash (`read.ts` hashes the stored graph, and the stored graph is
+  // always the cleaned one), so the comparison is exact, not approximate.
+  //
+  // Guarded on the non-graph fields: `set_workflow_details` and
+  // `apply_template` pass envVars/variables/icon through this same seam and
+  // must not be short-circuited by an unchanged *graph*.
+  const touchesOnlyGraph =
+    plan.envVars === undefined && plan.variables === undefined && plan.icon === undefined
+  if (
+    touchesOnlyGraph &&
+    ctx.graphHash !== undefined &&
+    hashWorkflowGraph(cleanGraphForSave(graph)) === ctx.graphHash
+  ) {
+    const unchangedNode = plan.touchedNodeId
+      ? graph.nodes.find((n) => n.id === plan.touchedNodeId)
+      : undefined
+    return ok({
+      applied: true,
+      unchanged: true,
+      ...(unchangedNode ? { node: buildNodeSummary(graph, unchangedNode, aliases) } : {}),
+      issues,
+      graphSummary: buildGraphSummary(ctx.graph, ctx.triggerType),
+    })
   }
 
   // Pre-turn snapshot — captured only now that the write is certain to be

--- a/packages/lib/src/workflows/graph-edit/read.ts
+++ b/packages/lib/src/workflows/graph-edit/read.ts
@@ -17,6 +17,7 @@ import { and, eq } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import { type AuxxError, NotFoundError } from '../../errors'
 import { isDerivedKey, stripDerivedKeys } from '../../workflow-engine/catalog/derived-keys'
+import { getManifest } from '../../workflow-engine/catalog/registry'
 import { resolveGraphOutputs } from '../../workflow-engine/catalog/resolve-outputs'
 import type { UnifiedVariable } from '../../workflow-engine/types/unified-variable'
 import { hashWorkflowGraph } from '../graph-hash'
@@ -159,6 +160,12 @@ export function buildGraphSummary(graph: DraftGraph, triggerType?: string | null
         : {}),
     }
   })
+  // Nodes with no catalog manifest are read-only to this editor. Reported here
+  // once instead of as a repeated per-node `info` issue — see GraphSummary.
+  const readOnlyNodes = graph.nodes
+    .filter((node) => !getManifest(nodeType(node)))
+    .map((node) => formatNodeRef(graph.nodes, node.id))
+
   return {
     nodeCount: graph.nodes.length,
     edgeCount: graph.edges.length,
@@ -172,6 +179,7 @@ export function buildGraphSummary(graph: DraftGraph, triggerType?: string | null
     }),
     edges,
     triggerType: triggerType ?? null,
+    ...(readOnlyNodes.length > 0 ? { readOnlyNodes } : {}),
   }
 }
 

--- a/packages/lib/src/workflows/graph-edit/types.ts
+++ b/packages/lib/src/workflows/graph-edit/types.ts
@@ -148,6 +148,17 @@ export interface GraphSummary {
   edges: EdgeSummary[]
   /** The draft row's trigger type column (what the workflow fires on). */
   triggerType?: string | null
+  /**
+   * Refs of nodes this editor can read but not author — no catalog manifest
+   * (app blocks, not-yet-migrated types).
+   *
+   * Stated ONCE here, as data, rather than as one `info` issue per node per
+   * read. The agent does need to know a node is untouchable; it does not need
+   * to be told twice on every single read, forever. A workflow with two app
+   * blocks put two un-actionable issues on every `get_workflow`, `get_node`,
+   * `validate_workflow` AND every mutation result for the whole turn.
+   */
+  readOnlyNodes?: string[]
 }
 
 /**
@@ -159,6 +170,13 @@ export interface GraphSummary {
  */
 export interface GraphMutationResult {
   applied: boolean
+  /**
+   * The mutation was a NO-OP: the requested state already held, so nothing was
+   * written, snapshotted, or signalled. Still `applied: true` — the caller got
+   * what it asked for. Only `applied: false` means "blocked, go fix
+   * something".
+   */
+  unchanged?: boolean
   /** The touched node, when the operation targets one. */
   node?: NodeSummary
   /** The touched node's resolved outputs, friendly-rendered — wire refs from these. */

--- a/packages/lib/src/workflows/graph-edit/validate.ts
+++ b/packages/lib/src/workflows/graph-edit/validate.ts
@@ -155,7 +155,9 @@ export function validateGraphStructure(
       .sort()
       .join(', ')
 
-  // Node types — authorable for introduced nodes, informational otherwise.
+  // Node types — an INTRODUCED node must be authorable; an existing one that
+  // has no manifest is merely read-only, which `GraphSummary.readOnlyNodes`
+  // states once instead of an issue per node per read.
   for (const node of nodes) {
     const type = nodeType(node)
     const manifest = getManifest(type)
@@ -173,13 +175,11 @@ export function validateGraphStructure(
           message: `Node type "${type}" cannot be authored here. Authorable types: ${authorableTypes()}.`,
         })
       }
-    } else if (!manifest) {
-      issues.push({
-        severity: 'info',
-        nodeRef: ref(node.id),
-        message: `Node type "${type}" is not in the catalog — it is read-only to this editor.`,
-      })
     }
+    // A node with no manifest that the caller did NOT introduce is simply
+    // read-only. That is reported once on `GraphSummary.readOnlyNodes`, not as
+    // an issue per node per read — it is never actionable, and repeating it
+    // buries the issues that are.
   }
 
   // Containment — parentId must name an existing loop node.


### PR DESCRIPTION
The last two items from `plans/kopilot/workflow/16-agent-edit-loop-reliability.md`
(D9, D11). Both are about the same thing: a mutation result that doesn't let
the caller tell signal from noise. After this, plan 16 is fully done.

## D9 — a no-op write says so

A mutation whose cleaned graph hashes to what was loaded changed nothing. It
now skips the write, the turn snapshot and the realtime signal, and reports
`unchanged: true`.

Before, a re-issued identical edit came back byte-identical to a real one:

```jsonc
{ "applied": true, "summary": "Updated HTTP Request", "node": { "configHash": "24b3e59d…" } }
```

…exactly what the previous attempt returned. Nothing said "this changed
nothing". The logged failure turn wrote the same HTTP config **twice** and the
same CRUD config **three times**, each to an identical hash, with no signal.

Now:

```jsonc
{ "applied": true, "unchanged": true, "summary": "No change — HTTP Request already had these values." }
```

**It stays `applied: true` deliberately.** `applied: false` is the
*blocking-issue* vocabulary — `mutationToToolResult` renders it as
"Update X blocked". Telling the model a harmless idempotent write is a failure
it must repair is precisely the loop this plan exists to kill.

Guarded on the non-graph fields: `set_workflow_details` and `apply_template`
pass `envVars`/`variables`/`icon` through this same seam and must not be
short-circuited by an unchanged *graph*.

The comparison is exact, not approximate: `hashWorkflowGraph(cleanGraphForSave(…))`
is precisely what the next load will hash, because the stored graph is always
the cleaned one.

## D11 — read-only nodes named once, as data

A node with no catalog manifest (app block, or a not-yet-migrated type) is
read-only to this editor. That was emitted as an `info` issue **per node, per
read**:

```jsonc
"issues": [
  { "severity": "info", "nodeRef": "FedEx", "message": "Node type \"…:fedex\" is not in the catalog — it is read-only to this editor." },
  { "severity": "info", "nodeRef": "UPS",   "message": "Node type \"…:ups\" is not in the catalog — it is read-only to this editor." }
]
```

A workflow with two app blocks put those on every `get_workflow`, `get_node`,
`validate_workflow` **and every mutation result** for a whole turn — burying
the issues that were actionable. It is a fact about the graph, not a finding,
so it now rides the summary once:

```jsonc
"graphSummary": { "nodeCount": 7, "readOnlyNodes": ["FedEx", "UPS"] }
```

The model still learns the nodes are untouchable; it just isn't told twice per
read, forever. This was verified in the real §7.6 re-run: after the agent fixed
everything else, those two notices were the **only** issues left in the report,
and its closing reply apologised for being unable to act on them.

`readOnlyNodes` is the neutral meeting point plan 17 (app-block authoring)
names — if 17 lands, app blocks drop out of this list on their own and the
field narrows to not-yet-migrated types.

## Tests

`graph-edit/__tests__/ops.test.ts` gains three cases: a re-issued identical
edit reports `unchanged` and does **not** call the service update; a real edit
does not report `unchanged` and does write; and an uncatalogued node appears in
`readOnlyNodes` with no matching issue. **Both fixes verified red without them.**

`src/workflows src/ai src/workflow-engine` green — 2710 passed. `typescript7`
clean, biome clean.

One note: `workflows/__tests__/workflow-draft-cas.test.ts` intermittently times
out at the 10s default on a loaded machine (it needs ~13.5s and passes with
`--testTimeout=45000`). Pre-existing, Redis-backed, unrelated to this diff —
flagging it as a latent CI flake rather than fixing it here.
