### PR TITLE
feat(workflow): resolve app-block outputs server-side

### DIFF
--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -156,6 +156,42 @@ export interface CatalogBlock {
   /** Dispatch table: `${resource}.${operation}` → tool id. */
   toolMap: Record<string, string>
   refs: Array<{ path: string[]; kind: string }>
+  /**
+   * The block's declared `schema.outputs`. `{}` for every router-style block in
+   * practice — real outputs come **per operation** from the tool `toolMap`
+   * dispatches to (see `CachedBlockOp` in `@auxx/lib`). Present for
+   * completeness and for future non-router blocks.
+   *
+   * Optional — absent on catalogs published before this projection existed.
+   */
+  outputsJsonSchema?: Record<string, unknown>
+  /**
+   * `config.requiresConnection`.
+   *
+   * Optional, and `undefined` means **unknown**, NOT `false`: catalogs
+   * published before this projection carry nothing, and callers must fall back
+   * to the per-app approximation ("does this app have a ConnectionDefinition?")
+   * rather than concluding the block needs no connection.
+   */
+  requiresConnection?: boolean
+  /** `config.canRunSingle` (SDK default `true`). Optional — absent ⇒ true. */
+  canRunSingle?: boolean
+  /**
+   * Per-operation outputs, keyed by `${resource}.${operation}` — the block's own
+   * `schema.computeOutputs` evaluated once per `toolMap` key at publish time.
+   *
+   * This is the block's answer to "what do I emit for this selection", and it is
+   * the same answer the canvas renders, so agent and canvas agree by
+   * construction. Preferred over the dispatched tool's `outputsJsonSchema`,
+   * which describes the TOOL and is an open `z.record` on most published apps.
+   *
+   * An entry is `{}` when the block declares no `computeOutputs`, when it
+   * returns nothing for that selection, or when it threw during extraction —
+   * all three mean **unknown shape**, never "emits nothing".
+   *
+   * Optional — absent on catalogs published before this projection.
+   */
+  opOutputsJsonSchema?: Record<string, Record<string, unknown>>
 }
 
 /**

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -393,6 +393,57 @@ export interface CachedAction extends CatalogAction {
   inputsJsonSchema: Record<string, unknown>
 }
 
+/**
+ * One `${resource}.${operation}` of an app workflow block, joined from the
+ * deployment's **full** `catalog.tools` registry via `CatalogBlock.toolMap`.
+ * Block tools carry no agent surface and so are absent from `agent.tools` —
+ * the same reason `CachedAction` joins from `catalog.tools` rather than
+ * client-side.
+ *
+ * This is the server's only view of what an app block produces.
+ * `CatalogBlock` itself carries no outputs, and the block's own
+ * `computeOutputs` is a function that runs inside the app iframe — see
+ * `plans/kopilot/workflow/17-app-block-authoring-and-connections.md` §2.3.
+ */
+export interface CachedBlockOp {
+  /** `${resource}.${operation}` — the `toolMap` key the dispatcher routes on. */
+  key: string
+  resource: string
+  operation: string
+  toolId: string
+  /**
+   * The dispatched tool's declared inputs. ADVISORY for authoring: most blocks
+   * forward the flat panel input to `ctx.runTool` unchanged, but some (whatsapp)
+   * project it first, so this is the tool's contract and not necessarily the
+   * block's.
+   */
+  inputsJsonSchema: Record<string, unknown>
+  /**
+   * The dispatched tool's declared outputs — the shape the engine writes as
+   * `${nodeId}.${field}`.
+   *
+   * Frequently an OPEN object (`{ type: 'object', additionalProperties: {} }`,
+   * i.e. a `z.record` with no named properties): as of 2026-08-18 only 71 of
+   * 261 published ops declare named output properties, and shopify/quickbooks/
+   * github/stripe/ms-teams/notion/gog-sheets/gog-contacts declare none on any
+   * op. Callers must treat a property-less schema as *unknown*, never as
+   * "produces nothing".
+   */
+  outputsJsonSchema: Record<string, unknown>
+  requiresConnection: boolean
+  /** `tool.exampleOutput`, when the app declared one. No published app does yet. */
+  exampleOutput?: unknown
+}
+
+/**
+ * A workflow block projection with its per-operation contracts resolved.
+ * `ops` is empty when the block declares no `toolMap`, and drops entries whose
+ * tool id is missing from the catalog or whose key is not `resource.operation`.
+ */
+export interface CachedWorkflowBlock extends CatalogBlock {
+  ops: CachedBlockOp[]
+}
+
 export interface CachedAgentToolset extends CatalogToolset {
   /** Short header text used inside the app/sub-group render. Falls back to `name`. */
   shortLabel?: string
@@ -494,7 +545,7 @@ export interface CachedInstalledApp {
   agentTools?: CachedAgentTool[]
   agentToolsets?: CachedAgentToolset[]
   agentTriggers?: CatalogTriggerProjection[]
-  workflowBlocks?: CatalogBlock[]
+  workflowBlocks?: CachedWorkflowBlock[]
   workflowTriggers?: CatalogTriggerProjection[]
   actions?: CachedAction[]
   /**
@@ -802,7 +853,9 @@ export const ORG_CACHE_KEY_CONFIG: Record<
   // v2: connectionDefinition (singular) → connectionDefinitions (pair). Bump on shape changes.
   // v4: CachedAction.inputHints (dynamic-select pickers). See plans/actions/09-dynamic-action-inputs.md.
   // v5: + methods[] (multi-connection-per-app). See plans/connections/multi-connection-per-app.md.
-  installedApps: { prefix: 'org:installed-apps:v5', ttlSeconds: 900 },
+  // v6: workflowBlocks carry `ops[]` (toolMap → catalog.tools join) so the server
+  //     can resolve what an app block produces. See plans/kopilot/workflow/17-*.md §4 A2.
+  installedApps: { prefix: 'org:installed-apps:v6', ttlSeconds: 900 },
   mcpServers: { prefix: 'org:mcpServers', ttlSeconds: ONE_DAY },
   // Read per CRUD event by trigger dispatch; changes only on admin edits →
   // 5 s local window (dispatch enqueues jobs, so peer staleness is benign).

--- a/packages/lib/src/cache/providers/installed-apps-block-ops.test.ts
+++ b/packages/lib/src/cache/providers/installed-apps-block-ops.test.ts
@@ -1,0 +1,126 @@
+// packages/lib/src/cache/providers/installed-apps-block-ops.test.ts
+// The `toolMap` → `catalog.tools` join that gives the server its only view of
+// what an app workflow block produces. Pure function over catalog shapes — no
+// DB, no cache. See plans/kopilot/workflow/17-app-block-authoring-and-connections.md §4 A2.
+
+import type { CatalogBlock, CatalogTool } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import { projectWorkflowBlocks } from './installed-apps-provider'
+
+function tool(id: string, overrides: Partial<CatalogTool> = {}): CatalogTool {
+  return {
+    id,
+    name: id,
+    description: `${id} description`,
+    inputsJsonSchema: { type: 'object', properties: { trackingNumber: { type: 'string' } } },
+    outputsJsonSchema: { type: 'object', properties: { statusType: { type: 'string' } } },
+    requiresConnection: true,
+    timeoutMs: 30_000,
+    streaming: false,
+    refs: [],
+    ...overrides,
+  }
+}
+
+function block(toolMap: Record<string, string>): CatalogBlock {
+  return {
+    id: 'fedex',
+    label: 'FedEx',
+    iconKey: null,
+    inputsJsonSchema: {},
+    toolMap,
+    refs: [],
+  }
+}
+
+describe('projectWorkflowBlocks', () => {
+  it('resolves each toolMap entry to its dispatched tool contract', () => {
+    const result = projectWorkflowBlocks(
+      [block({ 'shipment.track': 'fedex_block_track' })],
+      [tool('fedex_block_track')]
+    )
+
+    expect(result?.[0]?.ops).toEqual([
+      {
+        key: 'shipment.track',
+        resource: 'shipment',
+        operation: 'track',
+        toolId: 'fedex_block_track',
+        inputsJsonSchema: { type: 'object', properties: { trackingNumber: { type: 'string' } } },
+        outputsJsonSchema: { type: 'object', properties: { statusType: { type: 'string' } } },
+        requiresConnection: true,
+      },
+    ])
+  })
+
+  it('carries the whole CatalogBlock through alongside ops', () => {
+    const source = block({ 'shipment.track': 'fedex_block_track' })
+    const result = projectWorkflowBlocks([source], [tool('fedex_block_track')])
+
+    expect(result?.[0]).toMatchObject({ id: 'fedex', label: 'FedEx', toolMap: source.toolMap })
+  })
+
+  it('forwards exampleOutput only when the tool declares one', () => {
+    const [withExample, without] =
+      projectWorkflowBlocks(
+        [block({ 'a.one': 'has_example', 'b.two': 'no_example' })],
+        [tool('has_example', { exampleOutput: { statusType: 'delivered' } }), tool('no_example')]
+      )?.[0]?.ops ?? []
+
+    expect(withExample?.exampleOutput).toEqual({ statusType: 'delivered' })
+    expect(without).not.toHaveProperty('exampleOutput')
+  })
+
+  it('drops a dangling toolMap entry instead of throwing', () => {
+    const result = projectWorkflowBlocks(
+      [block({ 'shipment.track': 'fedex_block_track', 'shipment.gone': 'deleted_tool' })],
+      [tool('fedex_block_track')]
+    )
+
+    expect(result?.[0]?.ops.map((o) => o.key)).toEqual(['shipment.track'])
+  })
+
+  it('drops malformed keys — no dot, empty half, or an extra segment', () => {
+    const result = projectWorkflowBlocks(
+      [
+        block({
+          track: 't',
+          '.track': 't',
+          'shipment.': 't',
+          'a.b.c': 't',
+          'shipment.track': 't',
+        }),
+      ],
+      [tool('t')]
+    )
+
+    expect(result?.[0]?.ops.map((o) => o.key)).toEqual(['shipment.track'])
+  })
+
+  it('gives a block with no toolMap an empty ops list, not undefined', () => {
+    expect(projectWorkflowBlocks([block({})], [tool('t')])?.[0]?.ops).toEqual([])
+  })
+
+  it('preserves an open (property-less) output schema verbatim', () => {
+    // 190 of 261 published ops declare `z.record(z.string(), z.unknown())`. That
+    // is "unknown shape", not "produces nothing" — callers must be able to tell
+    // the difference, so the projection must not normalize it away.
+    const open = { type: 'object', propertyNames: { type: 'string' }, additionalProperties: {} }
+    const result = projectWorkflowBlocks(
+      [block({ 'issue.create': 'github_issue_create' })],
+      [tool('github_issue_create', { outputsJsonSchema: open })]
+    )
+
+    expect(result?.[0]?.ops[0]?.outputsJsonSchema).toEqual(open)
+  })
+
+  it('returns undefined for a deployment with no catalog blocks', () => {
+    expect(projectWorkflowBlocks(undefined, [tool('t')])).toBeUndefined()
+  })
+
+  it('drops every op when the catalog carries no tools at all', () => {
+    expect(projectWorkflowBlocks([block({ 'shipment.track': 't' })], undefined)?.[0]?.ops).toEqual(
+      []
+    )
+  })
+})

--- a/packages/lib/src/cache/providers/installed-apps-provider.ts
+++ b/packages/lib/src/cache/providers/installed-apps-provider.ts
@@ -1,12 +1,67 @@
 // packages/lib/src/cache/providers/installed-apps-provider.ts
 
 import { gateConnectionVariables, resolveOwnClientRequirement } from '@auxx/credentials/connections'
+import type { CatalogBlock, CatalogTool } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { getBuiltinAuxxInstalledRow } from '../../agents/builtin-installed-row'
 import { getRegisteredToolName } from '../../ai/kopilot/capabilities/apps/tool-naming'
-import type { CachedAction, CachedAgentTool, CachedInstalledApp } from '../org-cache-keys'
+import type {
+  CachedAction,
+  CachedAgentTool,
+  CachedBlockOp,
+  CachedInstalledApp,
+  CachedWorkflowBlock,
+} from '../org-cache-keys'
 import type { CacheProvider } from '../org-cache-provider'
+
+/**
+ * Join each workflow block to the contracts of the tools its `toolMap`
+ * dispatches to, from the deployment's **full** `catalog.tools` registry.
+ *
+ * Why the full registry and not `agent.tools`: block tools carry no agent
+ * surface, so they are absent there — the same reason `CachedAction` joins
+ * from `catalog.tools`.
+ *
+ * Why at all: `CatalogBlock` declares no outputs, and the block's own
+ * `computeOutputs` is a function that only runs inside the app iframe. The
+ * dispatched tool's `outputsJsonSchema` is the only server-readable answer to
+ * "what does this node produce". See
+ * `plans/kopilot/workflow/17-app-block-authoring-and-connections.md` §2.3/D3.
+ *
+ * Malformed entries are dropped, never thrown: a dangling tool id or a key
+ * that isn't `resource.operation` is an app-authoring mistake, and failing the
+ * projection would poison the whole org's `installedApps` cache over one bad
+ * block.
+ */
+export function projectWorkflowBlocks(
+  blocks: CatalogBlock[] | undefined,
+  tools: CatalogTool[] | undefined
+): CachedWorkflowBlock[] | undefined {
+  if (!blocks) return undefined
+  const toolById = new Map((tools ?? []).map((t) => [t.id, t]))
+  return blocks.map((block) => ({
+    ...block,
+    ops: Object.entries(block.toolMap ?? {}).flatMap<CachedBlockOp>(([key, toolId]) => {
+      const tool = toolById.get(toolId)
+      if (!tool) return []
+      const [resource, operation, ...rest] = key.split('.')
+      if (!resource || !operation || rest.length > 0) return []
+      return [
+        {
+          key,
+          resource,
+          operation,
+          toolId,
+          inputsJsonSchema: tool.inputsJsonSchema,
+          outputsJsonSchema: tool.outputsJsonSchema,
+          requiresConnection: tool.requiresConnection,
+          ...(tool.exampleOutput !== undefined ? { exampleOutput: tool.exampleOutput } : {}),
+        },
+      ]
+    }),
+  }))
+}
 
 /**
  * Computes installed apps with connection definitions for an organization.
@@ -135,6 +190,11 @@ export const installedAppsProvider: CacheProvider<CachedInstalledApp[]> = {
         (a) => ({ ...a, inputsJsonSchema: toolInputsById.get(a.toolId) ?? {} })
       )
 
+      const workflowBlocks = projectWorkflowBlocks(
+        inst.currentDeployment?.catalog?.workflow.blocks,
+        inst.currentDeployment?.catalog?.tools
+      )
+
       return {
         installationId: inst.id,
         installationType: inst.installationType as 'development' | 'production',
@@ -204,7 +264,7 @@ export const installedAppsProvider: CacheProvider<CachedInstalledApp[]> = {
         agentTools,
         agentToolsets: inst.currentDeployment?.catalog?.agent.toolsets ?? undefined,
         agentTriggers: inst.currentDeployment?.catalog?.agent.triggers ?? undefined,
-        workflowBlocks: inst.currentDeployment?.catalog?.workflow.blocks ?? undefined,
+        workflowBlocks,
         workflowTriggers: inst.currentDeployment?.catalog?.workflow.triggers ?? undefined,
         actions,
         dataConnectors: inst.currentDeployment?.catalog?.dataConnectors ?? undefined,

--- a/packages/lib/src/workflow-engine/catalog/app-manifests.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/app-manifests.test.ts
@@ -1,0 +1,364 @@
+// packages/lib/src/workflow-engine/catalog/app-manifests.test.ts
+// Server-side app-block output resolution. Pure over catalog shapes — the org
+// cache read (`buildAppBlockLookup`) is covered by resolve-outputs.test.ts,
+// which exercises it through the graph walk.
+//
+// See plans/kopilot/workflow/17-app-block-authoring-and-connections.md §4 A3.
+
+import { describe, expect, it } from 'vitest'
+import type { CachedBlockOp, CachedWorkflowBlock } from '../../cache/org-cache-keys'
+import {
+  fieldNodeMapToUnifiedVariables,
+  resolveAppBlockOutputs,
+  schemaPropertiesToUnifiedVariables,
+} from './app-manifests'
+
+const NODE = 'fedex-DmJuCD8M2cAE0Hqdua0Ns'
+
+/** The real shape `fedex_block_track` publishes, trimmed to three fields. */
+const trackOutputs = {
+  type: 'object',
+  required: ['trackingNumber', 'isDelivered'],
+  properties: {
+    trackingNumber: { type: 'string' },
+    isDelivered: { type: 'boolean' },
+    statusType: { type: 'string', enum: ['delivered', 'in_transit'] },
+  },
+}
+
+/** What shopify/quickbooks/github publish: `z.record(z.string(), z.unknown())`. */
+const openOutputs = {
+  type: 'object',
+  propertyNames: { type: 'string' },
+  additionalProperties: {},
+}
+
+function op(key: string, outputsJsonSchema: unknown): CachedBlockOp {
+  const [resource = '', operation = ''] = key.split('.')
+  return {
+    key,
+    resource,
+    operation,
+    toolId: `tool_${operation}`,
+    inputsJsonSchema: {},
+    outputsJsonSchema: outputsJsonSchema as Record<string, unknown>,
+    requiresConnection: true,
+  }
+}
+
+function block(ops: CachedBlockOp[]): CachedWorkflowBlock {
+  return {
+    id: 'fedex',
+    label: 'FedEx',
+    iconKey: null,
+    inputsJsonSchema: {},
+    toolMap: {},
+    refs: [],
+    ops,
+  }
+}
+
+const tracked = block([op('shipment.track', trackOutputs), op('shipment.watch', openOutputs)])
+
+describe('schemaPropertiesToUnifiedVariables', () => {
+  it('flattens top-level properties into one variable each', () => {
+    const vars = schemaPropertiesToUnifiedVariables(trackOutputs, NODE)
+
+    // The engine writes `setNodeVariable(nodeId, fieldName, …)` per top-level
+    // key, so these ids ARE the refs the agent may write. A wrapper variable
+    // here would produce `{{node.structured_output.trackingNumber}}` — a ref
+    // that passes ref-checking and then resolves to nothing at run time.
+    expect(vars.map((v) => v.id)).toEqual([
+      `${NODE}.trackingNumber`,
+      `${NODE}.isDelivered`,
+      `${NODE}.statusType`,
+    ])
+    expect(vars.some((v) => v.id.includes('structured_output'))).toBe(false)
+  })
+
+  it('carries type and enum through', () => {
+    const byId = new Map(
+      schemaPropertiesToUnifiedVariables(trackOutputs, NODE).map((v) => [v.id, v])
+    )
+
+    expect(byId.get(`${NODE}.isDelivered`)?.type).toBe('boolean')
+    expect(byId.get(`${NODE}.statusType`)?.enum).toEqual(['delivered', 'in_transit'])
+  })
+
+  it('nests object properties under their parent path', () => {
+    const vars = schemaPropertiesToUnifiedVariables(
+      {
+        type: 'object',
+        properties: { address: { type: 'object', properties: { city: { type: 'string' } } } },
+      },
+      NODE
+    )
+
+    expect(vars[0]?.id).toBe(`${NODE}.address`)
+    expect(vars[0]?.properties?.city?.id).toBe(`${NODE}.address.city`)
+  })
+
+  it('returns nothing for a property-less or absent schema', () => {
+    expect(schemaPropertiesToUnifiedVariables(openOutputs, NODE)).toEqual([])
+    expect(schemaPropertiesToUnifiedVariables(undefined, NODE)).toEqual([])
+    expect(schemaPropertiesToUnifiedVariables(null, NODE)).toEqual([])
+  })
+})
+
+describe('fieldNodeMapToUnifiedVariables', () => {
+  // The SDK field `toJSON()` shape — what `opOutputsJsonSchema` carries. NOT a
+  // JSON Schema; there is no `properties` key to find.
+  it('converts a field-node map that a JSON-Schema reader would see as empty', () => {
+    const map = {
+      trackingNumber: { type: 'string', _metadata: { label: 'Tracking number' } },
+      isDelivered: { type: 'boolean', _metadata: {} },
+    }
+
+    expect(fieldNodeMapToUnifiedVariables(map, NODE).map((v) => [v.id, v.type, v.label])).toEqual([
+      [`${NODE}.trackingNumber`, 'string', 'Tracking number'],
+      [`${NODE}.isDelivered`, 'boolean', expect.any(String)],
+    ])
+    // The load-bearing assertion: the other converter finds nothing here.
+    expect(schemaPropertiesToUnifiedVariables(map, NODE)).toEqual([])
+  })
+
+  it('descends structs via `fields` and arrays via `items`', () => {
+    // Shopify's real shape: one top-level `order` struct with nested fields.
+    const map = {
+      order: {
+        type: 'struct',
+        _metadata: { label: 'Order' },
+        fields: {
+          currency: { type: 'string' },
+          lineItems: { type: 'array', items: { type: 'string' } },
+        },
+      },
+    }
+
+    const [order] = fieldNodeMapToUnifiedVariables(map, NODE)
+    expect(order?.id).toBe(`${NODE}.order`)
+    expect(order?.type).toBe('object')
+    expect(order?.properties?.currency?.id).toBe(`${NODE}.order.currency`)
+    expect(order?.properties?.lineItems?.items?.id).toBe(`${NODE}.order.lineItems[*]`)
+  })
+
+  it('maps SDK-only types, and refuses to guess at unknown ones', () => {
+    const map = {
+      total: { type: 'currency' },
+      when: { type: 'datetime' },
+      kind: { type: 'select', _metadata: { options: ['a', 'b'] } },
+      mystery: { type: 'quantum-flux' },
+    }
+    const byId = new Map(fieldNodeMapToUnifiedVariables(map, NODE).map((v) => [v.id, v]))
+
+    expect(byId.get(`${NODE}.total`)?.type).toBe('currency')
+    expect(byId.get(`${NODE}.when`)?.type).toBe('datetime')
+    expect(byId.get(`${NODE}.kind`)?.type).toBe('enum')
+    expect(byId.get(`${NODE}.kind`)?.enum).toEqual(['a', 'b'])
+    // ANY, not a confidently-wrong STRING.
+    expect(byId.get(`${NODE}.mystery`)?.type).toBe('any')
+  })
+
+  it('returns nothing for absent or non-object input', () => {
+    expect(fieldNodeMapToUnifiedVariables(undefined, NODE)).toEqual([])
+    expect(fieldNodeMapToUnifiedVariables({}, NODE)).toEqual([])
+  })
+})
+
+describe('resolveAppBlockOutputs', () => {
+  it('prefers the block’s computeOutputs over the dispatched tool’s outputs', () => {
+    // Rung 2a beats 2b: the block's own answer is also the canvas's answer, so
+    // preferring it keeps agent and canvas in agreement.
+    const withComputed: CachedWorkflowBlock = {
+      ...tracked,
+      opOutputsJsonSchema: {
+        'shipment.track': { fromCompute: { type: 'string', _metadata: { label: 'From compute' } } },
+      },
+    }
+
+    const result = resolveAppBlockOutputs(
+      withComputed,
+      { resource: 'shipment', operation: 'track' },
+      NODE
+    )
+
+    expect(result.status).toBe('resolved')
+    expect(result.variables.map((v) => v.id)).toEqual([`${NODE}.fromCompute`])
+  })
+
+  it('falls back to the tool’s outputs when computeOutputs gave nothing for that op', () => {
+    // What a throwing or unhandled selection looks like: `{}` at that key.
+    const threw: CachedWorkflowBlock = {
+      ...tracked,
+      opOutputsJsonSchema: { 'shipment.track': {} },
+    }
+
+    const result = resolveAppBlockOutputs(threw, { resource: 'shipment', operation: 'track' }, NODE)
+
+    expect(result.status).toBe('resolved')
+    expect(result.variables.map((v) => v.id)).toContain(`${NODE}.trackingNumber`)
+  })
+
+  it('reports undeclared when neither computeOutputs nor the tool declares anything', () => {
+    const nothing: CachedWorkflowBlock = {
+      ...block([op('shipment.watch', openOutputs)]),
+      opOutputsJsonSchema: { 'shipment.watch': {} },
+    }
+
+    expect(
+      resolveAppBlockOutputs(nothing, { resource: 'shipment', operation: 'watch' }, NODE)
+    ).toEqual({ variables: [], status: 'undeclared' })
+  })
+
+  it('resolves the selected operation’s declared outputs', () => {
+    const result = resolveAppBlockOutputs(
+      tracked,
+      { resource: 'shipment', operation: 'track' },
+      NODE
+    )
+
+    expect(result.status).toBe('resolved')
+    expect(result.variables.map((v) => v.id)).toEqual([
+      `${NODE}.trackingNumber`,
+      `${NODE}.isDelivered`,
+      `${NODE}.statusType`,
+    ])
+  })
+
+  it('reports no-operation-selected on a half-configured draft', () => {
+    expect(resolveAppBlockOutputs(tracked, {}, NODE)).toEqual({
+      variables: [],
+      status: 'no-operation-selected',
+    })
+    expect(resolveAppBlockOutputs(tracked, { resource: 'shipment' }, NODE).status).toBe(
+      'no-operation-selected'
+    )
+    expect(resolveAppBlockOutputs(tracked, undefined, NODE).status).toBe('no-operation-selected')
+  })
+
+  it('reports unknown-operation when the toolMap has no such key', () => {
+    // What an app upgrade that drops an op looks like to a stored node.
+    expect(
+      resolveAppBlockOutputs(tracked, { resource: 'shipment', operation: 'teleport' }, NODE)
+    ).toEqual({ variables: [], status: 'unknown-operation' })
+  })
+
+  it('reports undeclared — not resolved — for an open output schema', () => {
+    // 190 of 261 published ops are in this state. "Unknown shape" must be
+    // distinguishable from "produces nothing", or the agent is told with
+    // confidence that a Shopify block emits no variables.
+    const result = resolveAppBlockOutputs(
+      tracked,
+      { resource: 'shipment', operation: 'watch' },
+      NODE
+    )
+
+    expect(result).toEqual({ variables: [], status: 'undeclared' })
+    expect(result.status).not.toBe('resolved')
+  })
+
+  it('lets a real run’s inferredSchema win over the declaration', () => {
+    const result = resolveAppBlockOutputs(
+      tracked,
+      {
+        resource: 'shipment',
+        operation: 'track',
+        inferredSchema: {
+          type: 'object',
+          properties: { trackingNumber: { type: 'number' }, extraFromRun: { type: 'string' } },
+        },
+      },
+      NODE
+    )
+
+    expect(result.status).toBe('inferred')
+    // Declared order preserved; the overlapping field takes the observed type;
+    // run-only fields append. Same precedence as the canvas's merge.
+    expect(result.variables.map((v) => v.id)).toEqual([
+      `${NODE}.trackingNumber`,
+      `${NODE}.isDelivered`,
+      `${NODE}.statusType`,
+      `${NODE}.extraFromRun`,
+    ])
+    expect(result.variables[0]?.type).toBe('number')
+  })
+
+  it('falls back to inferredSchema when the declaration is open', () => {
+    const result = resolveAppBlockOutputs(
+      tracked,
+      {
+        resource: 'shipment',
+        operation: 'watch',
+        inferredSchema: { type: 'object', properties: { watchId: { type: 'string' } } },
+      },
+      NODE
+    )
+
+    expect(result.status).toBe('inferred')
+    expect(result.variables.map((v) => v.id)).toEqual([`${NODE}.watchId`])
+  })
+
+  it('falls back to inferredSchema when the operation is unknown', () => {
+    const result = resolveAppBlockOutputs(
+      tracked,
+      {
+        resource: 'shipment',
+        operation: 'teleport',
+        inferredSchema: { type: 'object', properties: { whatever: { type: 'string' } } },
+      },
+      NODE
+    )
+
+    expect(result.status).toBe('inferred')
+    expect(result.variables.map((v) => v.id)).toEqual([`${NODE}.whatever`])
+  })
+
+  it('falls back to the block’s own declared outputs when the op declares none', () => {
+    // Rung 3: a non-router block that declares its shape once, op-independent.
+    // Also what keeps A1's `CatalogBlock.outputsJsonSchema` from being dead data.
+    const nonRouter: CachedWorkflowBlock = {
+      ...block([op('shipment.watch', openOutputs)]),
+      outputsJsonSchema: { type: 'object', properties: { watchId: { type: 'string' } } },
+    }
+
+    expect(
+      resolveAppBlockOutputs(nonRouter, { resource: 'shipment', operation: 'watch' }, NODE)
+    ).toEqual({
+      variables: [expect.objectContaining({ id: `${NODE}.watchId` })],
+      status: 'resolved',
+    })
+  })
+
+  it('prefers the op’s outputs over the block’s own when both exist', () => {
+    const both: CachedWorkflowBlock = {
+      ...tracked,
+      outputsJsonSchema: { type: 'object', properties: { blockLevel: { type: 'string' } } },
+    }
+
+    const ids = resolveAppBlockOutputs(
+      both,
+      { resource: 'shipment', operation: 'track' },
+      NODE
+    ).variables.map((v) => v.id)
+
+    expect(ids).toContain(`${NODE}.trackingNumber`)
+    expect(ids).not.toContain(`${NODE}.blockLevel`)
+  })
+
+  it('resolves block-level outputs even with no operation picked', () => {
+    // Op-independent by definition, so not selecting an op does not hide them.
+    const nonRouter: CachedWorkflowBlock = {
+      ...block([]),
+      outputsJsonSchema: { type: 'object', properties: { watchId: { type: 'string' } } },
+    }
+
+    expect(resolveAppBlockOutputs(nonRouter, {}, NODE).status).toBe('resolved')
+  })
+
+  it('returns nothing for a block whose ops never got projected', () => {
+    // A catalog published before the A2 join, or a block with no toolMap.
+    expect(
+      resolveAppBlockOutputs(block([]), { resource: 'shipment', operation: 'track' }, NODE)
+    ).toEqual({ variables: [], status: 'unknown-operation' })
+  })
+})

--- a/packages/lib/src/workflow-engine/catalog/app-manifests.ts
+++ b/packages/lib/src/workflow-engine/catalog/app-manifests.ts
@@ -1,0 +1,271 @@
+// packages/lib/src/workflow-engine/catalog/app-manifests.ts
+//
+// SERVER-ONLY. Imports the org cache (which pulls in bullmq) — must never be
+// re-exported from `../client.ts` or the `workflow-engine` index barrel. Import
+// it by relative path within lib, or by its own leaf subpath from an app. Same
+// rule `catalog/resolve-outputs` and `catalog/derive-trigger-server` follow.
+//
+// What an app workflow block produces, resolved server-side. The canvas answers
+// this by executing the block's `computeOutputs` inside the app's iframe; a
+// server-side agent has no iframe, so it reads the contract of the tool the
+// block's `toolMap` dispatches to instead. See
+// plans/kopilot/workflow/17-app-block-authoring-and-connections.md §2.3/D3.
+
+import { getCachedInstalledApps } from '../../cache'
+import type { CachedWorkflowBlock } from '../../cache/org-cache-keys'
+import { BaseType } from '../core/types'
+import type { UnifiedVariable } from '../types/unified-variable'
+import { schemaToUnifiedVariable } from './schema-to-variable'
+import { createUnifiedOutputVariable } from './variable-conversion'
+
+/** An app-block node type — `${appId}:${blockId}`, as persisted in `node.data.type`. */
+export type AppBlockType = string
+
+/** `${appId}:${blockId}` → the installed block, for every app installed in the org. */
+export type AppBlockLookup = ReadonlyMap<AppBlockType, CachedWorkflowBlock>
+
+/**
+ * Why a resolution produced the variables it did. Callers that only need
+ * variables ignore this; the authoring layer (PR B1's synthesized `validate`)
+ * turns the non-`resolved` cases into actionable issues, which is the whole
+ * reason they are distinguished rather than all collapsing to an empty array.
+ */
+export type AppBlockOutputStatus =
+  /** The dispatched tool declares named outputs, and here they are. */
+  | 'resolved'
+  /** Resolved from a real run's `inferredSchema` rather than a declaration. */
+  | 'inferred'
+  /** No `resource`/`operation` picked yet — a legitimate half-configured draft. */
+  | 'no-operation-selected'
+  /** An operation is set but no `toolMap` entry matches it (app upgrade drift). */
+  | 'unknown-operation'
+  /**
+   * The op resolves, but its tool declares an OPEN output object (a `z.record`
+   * with no named properties) and the node has never run. The shape is
+   * **unknown**, NOT empty — 190 of 261 published ops are in this state, so
+   * treating it as "produces nothing" would be wrong for most of the fleet.
+   */
+  | 'undeclared'
+
+export interface AppBlockOutputs {
+  variables: UnifiedVariable[]
+  status: AppBlockOutputStatus
+}
+
+/**
+ * Build the `${appId}:${blockId}` → block lookup for one org.
+ *
+ * Rides the `installedApps` org cache, so it inherits that key's invalidation
+ * (`app.installed` / `app.uninstalled` / `app.deployment.changed` / …) with no
+ * new wiring. Uninstalled apps are already filtered out by the provider, so a
+ * node left behind by an uninstall simply does not resolve — see §11.
+ */
+export async function buildAppBlockLookup(orgId: string): Promise<AppBlockLookup> {
+  const apps = await getCachedInstalledApps(orgId)
+  const byType = new Map<AppBlockType, CachedWorkflowBlock>()
+  for (const inst of apps) {
+    for (const block of inst.workflowBlocks ?? []) {
+      byType.set(`${inst.app.id}:${block.id}`, block)
+    }
+  }
+  return byType
+}
+
+/**
+ * SDK field type → `BaseType`. The SDK's vocabulary is wider than JSON Schema's
+ * (`currency`, `datetime`, `struct`, `select`, …) and most names already match a
+ * `BaseType` value, so identity carries the common cases and this table covers
+ * the rest. Unknown ⇒ `ANY`, never a silent `STRING` — a wrong concrete type is
+ * worse for a variable picker than an honest "unknown".
+ */
+const SDK_TYPE_TO_BASE: Readonly<Record<string, BaseType>> = {
+  struct: BaseType.OBJECT,
+  object: BaseType.OBJECT,
+  select: BaseType.ENUM,
+  integer: BaseType.NUMBER,
+  text: BaseType.STRING,
+  textarea: BaseType.STRING,
+}
+
+const BASE_TYPE_VALUES = new Set<string>(Object.values(BaseType))
+
+function sdkTypeToBaseType(type: unknown): BaseType {
+  if (typeof type !== 'string') return BaseType.ANY
+  const mapped = SDK_TYPE_TO_BASE[type]
+  if (mapped) return mapped
+  return BASE_TYPE_VALUES.has(type) ? (type as BaseType) : BaseType.ANY
+}
+
+/** One SDK field node (`toJSON()` output) → a `UnifiedVariable` at `basePath`. */
+function fieldNodeToUnifiedVariable(
+  node: Record<string, unknown> | undefined,
+  nodeId: string,
+  basePath: string
+): UnifiedVariable {
+  const metadata = (node?._metadata ?? {}) as Record<string, unknown>
+  const variable = createUnifiedOutputVariable({
+    nodeId,
+    path: basePath,
+    type: sdkTypeToBaseType(node?.type),
+    ...(typeof metadata.label === 'string' ? { label: metadata.label } : {}),
+    ...(typeof metadata.description === 'string' ? { description: metadata.description } : {}),
+    ...(Array.isArray(metadata.options)
+      ? { enum: metadata.options.filter((o): o is string | number => typeof o !== 'object') }
+      : {}),
+  })
+
+  // Arrays nest under `items`, structs under `fields` — NOT JSON Schema's
+  // `items`/`properties`. Same two keys the canvas's `catalogFieldToBlockField`
+  // walks, so both sides descend identically.
+  if (node?.type === 'array' && node.items) {
+    variable.items = fieldNodeToUnifiedVariable(
+      node.items as Record<string, unknown>,
+      nodeId,
+      `${basePath}[*]`
+    )
+  }
+  const fields = node?.fields as Record<string, unknown> | undefined
+  if ((node?.type === 'struct' || node?.type === 'object') && fields) {
+    variable.properties = {}
+    for (const [key, child] of Object.entries(fields)) {
+      variable.properties[key] = fieldNodeToUnifiedVariable(
+        child as Record<string, unknown>,
+        nodeId,
+        `${basePath}.${key}`
+      )
+    }
+  }
+
+  return variable
+}
+
+/**
+ * A `{ fieldName: fieldNodeJSON }` map → one `UnifiedVariable` per entry.
+ *
+ * This is the shape `CatalogBlock.opOutputsJsonSchema` and `inputsJsonSchema`
+ * carry — the SDK field `toJSON()` shape, NOT a JSON Schema. The distinction
+ * matters: a JSON-Schema reader looking for `properties` finds nothing here and
+ * silently returns an empty set, which is precisely the bug this whole plan
+ * exists to fix. {@link schemaPropertiesToUnifiedVariables} is the other one.
+ */
+export function fieldNodeMapToUnifiedVariables(
+  map: Record<string, unknown> | undefined,
+  nodeId: string
+): UnifiedVariable[] {
+  if (!map || typeof map !== 'object') return []
+  return Object.entries(map).map(([name, node]) =>
+    fieldNodeToUnifiedVariable(node as Record<string, unknown>, nodeId, name)
+  )
+}
+
+/**
+ * Top-level JSON-Schema properties → one `UnifiedVariable` per property.
+ *
+ * Deliberately NOT `schemaRootToUnifiedVariables`, which wraps the whole schema
+ * in a single `structured_output` variable. App blocks are flat: the engine
+ * writes every top-level key of the tool result as its own node variable
+ * (`app-workflow-block-processor.ts` → `setNodeVariable(nodeId, fieldName, …)`),
+ * so a ref is `{{Node.trackingNumber}}`, never
+ * `{{Node.structured_output.trackingNumber}}`. This mirrors the canvas's
+ * `schemaRootToWorkflowFields`, which flattens the same way.
+ *
+ * Getting this wrong would be worse than resolving nothing: ref-checking
+ * validates against the resolved set, so a wrongly-shaped set would *approve*
+ * refs the engine can never resolve.
+ */
+export function schemaPropertiesToUnifiedVariables(
+  schema: unknown,
+  nodeId: string
+): UnifiedVariable[] {
+  const properties = (schema as { properties?: Record<string, unknown> } | null)?.properties
+  if (!properties) return []
+  return Object.entries(properties).map(([key, propSchema]) =>
+    schemaToUnifiedVariable(propSchema, nodeId, key)
+  )
+}
+
+/**
+ * Resolve one app-block node's outputs, on a three-rung ladder:
+ *
+ *  1. `node.data.inferredSchema` — what a real run actually returned. Wins,
+ *     because a declaration is only a subset guarantee (the engine's permissive
+ *     mode passes undeclared keys straight through).
+ *  2a. `block.opOutputsJsonSchema[resource.operation]` — the block's own
+ *     `computeOutputs`, evaluated per op at publish time. Preferred, because it
+ *     is the block's own answer AND the same one the canvas renders, so agent
+ *     and canvas agree by construction.
+ *  2b. The dispatched op's tool outputs, via `toolMap`. Fallback for catalogs
+ *     published before 2a existed — 71 of 261 ops have these.
+ *  3. The block's own `schema.outputs` — op-independent, and `{}` on every
+ *     published block today. Here for the non-router block that declares its
+ *     shape once, and so that A1's projection of this field is not dead data.
+ *
+ * Rungs 1 and 2 merge when both exist; the same precedence as the canvas's
+ * `resolve-app-outputs.ts`.
+ */
+export function resolveAppBlockOutputs(
+  block: CachedWorkflowBlock,
+  data: Record<string, unknown> | undefined,
+  nodeId: string
+): AppBlockOutputs {
+  const inferred = schemaPropertiesToUnifiedVariables(data?.inferredSchema, nodeId)
+
+  const resource = typeof data?.resource === 'string' ? data.resource : undefined
+  const operation = typeof data?.operation === 'string' ? data.operation : undefined
+
+  // Why the op is missing, when it is — kept so the caller can say something
+  // useful ("pick an operation" vs "that operation no longer exists") instead
+  // of handing back a bare empty set, which is the §1 bug.
+  let unresolvedOp: Extract<
+    AppBlockOutputStatus,
+    'no-operation-selected' | 'unknown-operation'
+  > | null = null
+  let opDeclared: UnifiedVariable[] = []
+
+  if (!resource || !operation) {
+    unresolvedOp = 'no-operation-selected'
+  } else {
+    const key = `${resource}.${operation}`
+    const op = block.ops.find((o) => o.key === key)
+    if (!op) {
+      unresolvedOp = 'unknown-operation'
+    } else {
+      // 2a then 2b. Note the two carry DIFFERENT shapes — a field-node map vs a
+      // JSON Schema — hence two converters. Reading either with the other's
+      // reader yields a silent empty set.
+      const computed = fieldNodeMapToUnifiedVariables(block.opOutputsJsonSchema?.[key], nodeId)
+      opDeclared =
+        computed.length > 0
+          ? computed
+          : schemaPropertiesToUnifiedVariables(op.outputsJsonSchema, nodeId)
+    }
+  }
+
+  const declared =
+    opDeclared.length > 0
+      ? opDeclared
+      : schemaPropertiesToUnifiedVariables(block.outputsJsonSchema, nodeId)
+
+  if (inferred.length > 0) {
+    return {
+      variables: declared.length > 0 ? mergeById(declared, inferred) : inferred,
+      status: 'inferred',
+    }
+  }
+  if (declared.length > 0) return { variables: declared, status: 'resolved' }
+  return { variables: [], status: unresolvedOp ?? 'undeclared' }
+}
+
+/**
+ * Declared variables in declared order, each replaced by its inferred
+ * counterpart where one exists, then any inferred-only variables appended.
+ */
+function mergeById(declared: UnifiedVariable[], inferred: UnifiedVariable[]): UnifiedVariable[] {
+  const inferredById = new Map(inferred.map((v) => [v.id, v]))
+  const merged = declared.map((v) => inferredById.get(v.id) ?? v)
+  const declaredIds = new Set(declared.map((v) => v.id))
+  for (const v of inferred) {
+    if (!declaredIds.has(v.id)) merged.push(v)
+  }
+  return merged
+}

--- a/packages/lib/src/workflow-engine/catalog/resolve-outputs.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/resolve-outputs.test.ts
@@ -8,9 +8,11 @@ import { BaseType } from '../core/types'
 // dies at collection (see `resource-trigger-base.test.ts`). Only the one read this
 // module makes is stubbed.
 const getCachedResources = vi.fn()
+const getCachedInstalledApps = vi.fn()
 vi.mock('../../cache', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../cache')>()),
   getCachedResources: (...args: unknown[]) => getCachedResources(...args),
+  getCachedInstalledApps: (...args: unknown[]) => getCachedInstalledApps(...args),
 }))
 
 // Partial mock: a synthetic `__throwing__` type whose resolver always crashes,
@@ -36,6 +38,8 @@ const { resolveGraphOutputs, resolveNodeOutputs } = await import('./resolve-outp
 const noResources = () => {
   getCachedResources.mockReset()
   getCachedResources.mockResolvedValue([])
+  getCachedInstalledApps.mockReset()
+  getCachedInstalledApps.mockResolvedValue([])
 }
 
 /** `var-assign` node data producing an ARRAY output — a deterministic, resource-free
@@ -282,5 +286,154 @@ describe('scheduled manifest config-less guards', () => {
     expect(
       extractScheduledTriggerVariables({ id: 's1', type: 'scheduled', title: 'Schedule' } as never)
     ).toEqual([])
+  })
+})
+
+describe('app-block nodes', () => {
+  const APP = 'z3prnwpd3rt31mp7f9yxo5m6'
+  const TYPE = `${APP}:fedex`
+  const NODE_ID = `${TYPE}-DmJuCD8M2cAE0Hqdua0Ns`
+
+  /** One installed app contributing one block with one declared operation. */
+  const installedFedex = () => [
+    {
+      app: { id: APP, slug: 'fedex' },
+      workflowBlocks: [
+        {
+          id: 'fedex',
+          label: 'FedEx',
+          iconKey: null,
+          inputsJsonSchema: {},
+          toolMap: { 'shipment.track': 'fedex_block_track' },
+          refs: [],
+          ops: [
+            {
+              key: 'shipment.track',
+              resource: 'shipment',
+              operation: 'track',
+              toolId: 'fedex_block_track',
+              inputsJsonSchema: {},
+              outputsJsonSchema: {
+                type: 'object',
+                properties: {
+                  trackingNumber: { type: 'string' },
+                  isDelivered: { type: 'boolean' },
+                },
+              },
+              requiresConnection: true,
+            },
+          ],
+        },
+      ],
+    },
+  ]
+
+  const fedexNode = (data: Record<string, unknown>) => ({
+    id: NODE_ID,
+    type: 'standard',
+    data: { id: NODE_ID, type: TYPE, title: 'FedEx', appId: APP, blockId: 'fedex', ...data },
+  })
+
+  it('resolves outputs from the catalog projection, not the core registry', async () => {
+    // The §1 regression: this returned [] for every app block, which let the
+    // agent write `{{FedEx.record.id}}` and have it pass ref-checking.
+    noResources()
+    getCachedInstalledApps.mockResolvedValue(installedFedex())
+    const graph = { nodes: [fedexNode({ resource: 'shipment', operation: 'track' })], edges: [] }
+
+    const result = await resolveGraphOutputs('org-1', { graph })
+
+    expect(
+      result
+        ._unsafeUnwrap()
+        .get(NODE_ID)
+        ?.map((v) => v.id)
+    ).toEqual([`${NODE_ID}.trackingNumber`, `${NODE_ID}.isDelivered`])
+  })
+
+  it('resolves the same node through the single-node entry point', async () => {
+    noResources()
+    getCachedInstalledApps.mockResolvedValue(installedFedex())
+    const graph = { nodes: [fedexNode({ resource: 'shipment', operation: 'track' })], edges: [] }
+
+    const result = await resolveNodeOutputs('org-1', { graph, nodeId: NODE_ID })
+
+    expect(result._unsafeUnwrap().map((v) => v.id)).toEqual([
+      `${NODE_ID}.trackingNumber`,
+      `${NODE_ID}.isDelivered`,
+    ])
+  })
+
+  it('feeds an app block’s outputs to a downstream node’s resolveVariable', async () => {
+    noResources()
+    getCachedInstalledApps.mockResolvedValue(installedFedex())
+    const graph = {
+      nodes: [
+        fedexNode({ resource: 'shipment', operation: 'track' }),
+        listFilterNode('n2', NODE_ID, 'trackingNumber'),
+      ],
+      edges: [{ id: 'e1', source: NODE_ID, target: 'n2' }],
+    }
+
+    const result = await resolveGraphOutputs('org-1', { graph })
+
+    // The point is that the upstream memo entry is non-empty and the walk
+    // completes — an app block is now a legitimate variable source.
+    expect((result._unsafeUnwrap().get(NODE_ID) ?? []).length).toBe(2)
+    expect(result.isOk()).toBe(true)
+  })
+
+  it('returns [] with no operation picked, and does not throw', async () => {
+    noResources()
+    getCachedInstalledApps.mockResolvedValue(installedFedex())
+    const graph = { nodes: [fedexNode({})], edges: [] }
+
+    const result = await resolveGraphOutputs('org-1', { graph })
+    expect(result._unsafeUnwrap().get(NODE_ID)).toEqual([])
+  })
+
+  it('returns [] for a node whose app is no longer installed', async () => {
+    // Orphan node from an uninstalled app — the provider filters uninstalled
+    // rows out, so the lookup misses and the node falls through to read-only.
+    noResources()
+    getCachedInstalledApps.mockResolvedValue([])
+    const graph = { nodes: [fedexNode({ resource: 'shipment', operation: 'track' })], edges: [] }
+
+    const result = await resolveGraphOutputs('org-1', { graph })
+    expect(result._unsafeUnwrap().get(NODE_ID)).toEqual([])
+  })
+
+  it('lets inferredSchema from a real run win', async () => {
+    noResources()
+    getCachedInstalledApps.mockResolvedValue(installedFedex())
+    const graph = {
+      nodes: [
+        fedexNode({
+          resource: 'shipment',
+          operation: 'track',
+          inferredSchema: { type: 'object', properties: { observedOnly: { type: 'string' } } },
+        }),
+      ],
+      edges: [],
+    }
+
+    const result = await resolveGraphOutputs('org-1', { graph })
+
+    expect(
+      result
+        ._unsafeUnwrap()
+        .get(NODE_ID)
+        ?.map((v) => v.id)
+    ).toContain(`${NODE_ID}.observedOnly`)
+  })
+
+  it('skips the installed-apps read entirely for a graph of core nodes', async () => {
+    // A colon-free graph must not pay for an org-cache read it cannot use.
+    noResources()
+    const graph = { nodes: [varAssignArrayNode('n1', 'items')], edges: [] }
+
+    await resolveGraphOutputs('org-1', { graph })
+
+    expect(getCachedInstalledApps).not.toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/workflow-engine/catalog/resolve-outputs.ts
+++ b/packages/lib/src/workflow-engine/catalog/resolve-outputs.ts
@@ -4,6 +4,7 @@ import { err, ok, type Result } from 'neverthrow'
 import { getCachedResources } from '../../cache'
 import { NotFoundError } from '../../errors'
 import type { UnifiedVariable } from '../types/unified-variable'
+import { type AppBlockLookup, buildAppBlockLookup, resolveAppBlockOutputs } from './app-manifests'
 import { buildOutputContextFromResources } from './build-output-context'
 import { buildUpstreamMap, type EdgeMeta, type NodeMeta, topologicalSort } from './graph-vars'
 import { getManifest } from './registry'
@@ -74,7 +75,8 @@ function findVariableInTree(
 function resolveInTopoOrder(
   allResources: Awaited<ReturnType<typeof getCachedResources>>,
   nodes: NodeMeta[],
-  edges: EdgeMeta[]
+  edges: EdgeMeta[],
+  appBlocks: AppBlockLookup
 ): Map<string, UnifiedVariable[]> {
   const topoOrder = topologicalSort(nodes, edges)
   const nodeMap = new Map(nodes.map((n) => [n.id, n]))
@@ -89,6 +91,21 @@ function resolveInTopoOrder(
     if (!node) continue
 
     const nodeType: string | undefined = node.data?.type ?? node.type
+
+    // App blocks resolve from their catalog projection, not the core registry —
+    // they are never registered there and never will be (D1). Checked before
+    // the manifest bail below, which is what used to give every app-block node
+    // an empty output set and let the agent invent refs against it (§1).
+    //
+    // A positive lookup is the guard: only a block the org actually has
+    // installed resolves. Do NOT widen this to "any type containing a colon" —
+    // that is `hasProcessor`'s fail-open, and it does not belong here (D8).
+    const appBlock = nodeType ? appBlocks.get(nodeType) : undefined
+    if (appBlock) {
+      memo.set(nodeId, resolveAppBlockOutputs(appBlock, node.data, nodeId).variables)
+      continue
+    }
+
     const manifest = nodeType ? getManifest(nodeType) : undefined
     if (!manifest?.resolveOutputs) {
       // Not-yet-migrated or unknown type (`NOT_YET_MIGRATED` — `crud`/`find`
@@ -120,6 +137,23 @@ function resolveInTopoOrder(
 }
 
 /**
+ * The app-block lookup for this graph, or an empty one when the graph has no
+ * candidate node — a `${appId}:${blockId}` type is the only thing that could
+ * match, so a graph of purely core nodes must not pay for an `installedApps`
+ * cache read. The colon test is a cheap pre-filter, never an authorization
+ * decision: the real gate is the positive map lookup in `resolveInTopoOrder`.
+ */
+const EMPTY_APP_BLOCKS: AppBlockLookup = new Map()
+
+async function appBlocksForGraph(orgId: string, nodes: NodeMeta[]): Promise<AppBlockLookup> {
+  const hasCandidate = nodes.some((n) => {
+    const type = n.data?.type ?? n.type
+    return typeof type === 'string' && type.includes(':')
+  })
+  return hasCandidate ? await buildAppBlockLookup(orgId) : EMPTY_APP_BLOCKS
+}
+
+/**
  * Outputs for one node, given the full graph for upstream resolution.
  *
  * Only walks `nodeId`'s own ancestor set (via `buildUpstreamMap`), not the
@@ -143,8 +177,11 @@ export async function resolveNodeOutputs(
   const relevantIds = new Set([...ancestorIds, nodeId])
   const relevantNodes = graph.nodes.filter((n) => relevantIds.has(n.id))
 
-  const allResources = await getCachedResources(orgId)
-  const memo = resolveInTopoOrder(allResources, relevantNodes, graph.edges)
+  const [allResources, appBlocks] = await Promise.all([
+    getCachedResources(orgId),
+    appBlocksForGraph(orgId, relevantNodes),
+  ])
+  const memo = resolveInTopoOrder(allResources, relevantNodes, graph.edges, appBlocks)
   return ok(memo.get(nodeId) ?? [])
 }
 
@@ -158,7 +195,10 @@ export async function resolveGraphOutputs(
   orgId: string,
   params: { graph: WorkflowOutputGraph }
 ): Promise<Result<Map<string, UnifiedVariable[]>, Error>> {
-  const allResources = await getCachedResources(orgId)
-  const memo = resolveInTopoOrder(allResources, params.graph.nodes, params.graph.edges)
+  const [allResources, appBlocks] = await Promise.all([
+    getCachedResources(orgId),
+    appBlocksForGraph(orgId, params.graph.nodes),
+  ])
+  const memo = resolveInTopoOrder(allResources, params.graph.nodes, params.graph.edges, appBlocks)
   return ok(memo)
 }

--- a/packages/sdk/__fixtures__/tool-app/src/app.ts
+++ b/packages/sdk/__fixtures__/tool-app/src/app.ts
@@ -66,12 +66,74 @@ export const app = {
             resource: {
               toJSON: () => ({ type: 'string', _metadata: { label: 'Resource' } }),
             },
+            // A select the outputs condition on — slack's `sendTo` shape.
+            target: {
+              toJSON: () => ({
+                type: 'select',
+                _metadata: {
+                  label: 'Target',
+                  options: [{ value: 'channel' }, { value: 'user' }],
+                },
+              }),
+            },
           },
-          outputs: {},
+          outputs: {
+            messageId: {
+              toJSON: () => ({ type: 'string', _metadata: { label: 'Message ID' } }),
+            },
+          },
+          // Dynamic per-selection outputs — the shape the canvas computes live
+          // in the app iframe. `explode` throws, to prove one bad selection
+          // degrades to `{}` rather than failing the author's whole publish.
+          computeOutputs: (inputs: { operation?: string; target?: string }) => {
+            if (inputs.operation === 'send') {
+              const base = {
+                messageId: {
+                  toJSON: () => ({ type: 'string', _metadata: { label: 'Message ID' } }),
+                },
+                sentAt: { toJSON: () => ({ type: 'string', _metadata: { label: 'Sent at' } }) },
+              }
+              // Conditional on a second input — invisible unless the extractor
+              // varies `target`.
+              if (inputs.target === 'channel') {
+                return {
+                  ...base,
+                  channelId: { toJSON: () => ({ type: 'string', _metadata: {} }) },
+                }
+              }
+              if (inputs.target === 'user') {
+                return { ...base, userId: { toJSON: () => ({ type: 'string', _metadata: {} }) } }
+              }
+              return base
+            }
+            if (inputs.operation === 'react') {
+              return {
+                reactionId: {
+                  toJSON: () => ({ type: 'string', _metadata: { label: 'Reaction ID' } }),
+                },
+              }
+            }
+            throw new Error('computeOutputs blew up for this selection')
+          },
         },
         toolMap: {
           'message.send': 'send_message',
+          'message.react': 'send_message',
+          'message.explode': 'send_message',
         },
+        config: {
+          requiresConnection: true,
+          canRunSingle: false,
+        },
+        execute: async () => ({}),
+      },
+      {
+        // Declares neither `config` nor `schema.outputs` — the shape every
+        // pre-projection catalog has. Must NOT gain the optional keys.
+        id: 'bare',
+        label: 'Bare',
+        schema: { inputs: {} },
+        toolMap: { 'thing.do': 'send_message' },
         execute: async () => ({}),
       },
     ],

--- a/packages/sdk/src/util/__tests__/compile-and-extract-catalog.test.ts
+++ b/packages/sdk/src/util/__tests__/compile-and-extract-catalog.test.ts
@@ -128,7 +128,7 @@ describe('compileAndExtractCatalog', () => {
     expect(catalog.agent.triggers[0]).not.toHaveProperty('defaultEnabled')
 
     // Workflow blocks — `toolMap` is the dispatcher table the runtime reads.
-    expect(catalog.workflow.blocks).toHaveLength(1)
+    expect(catalog.workflow.blocks).toHaveLength(2)
     expect(catalog.workflow.blocks[0]).toMatchObject({
       id: 'messaging',
       label: 'Messaging',
@@ -138,6 +138,48 @@ describe('compileAndExtractCatalog', () => {
         'message.send': 'send_message',
       },
     })
+    // `schema.outputs` reaches the catalog for blocks, same as it already did
+    // for triggers — the compiler used to call only the inputs serializer.
+    expect(catalog.workflow.blocks[0]?.outputsJsonSchema).toEqual({
+      messageId: { type: 'string', _metadata: { label: 'Message ID' } },
+    })
+    // Per-operation outputs — `computeOutputs` evaluated once per toolMap key at
+    // publish time. This is what gives the server the same per-selection shapes
+    // the canvas computes live in the app iframe.
+    expect(catalog.workflow.blocks[0]?.opOutputsJsonSchema).toEqual({
+      // `channelId`/`userId` are conditional on the `target` select, and appear
+      // only because the extractor varies each select input one value at a time
+      // and unions. Slack's `message.send`/`sendTo` is the real instance.
+      'message.send': {
+        messageId: { type: 'string', _metadata: { label: 'Message ID' } },
+        sentAt: { type: 'string', _metadata: { label: 'Sent at' } },
+        channelId: { type: 'string', _metadata: {} },
+        userId: { type: 'string', _metadata: {} },
+      },
+      'message.react': {
+        reactionId: { type: 'string', _metadata: { label: 'Reaction ID' } },
+      },
+      // Threw. Degraded to `{}` — "unknown shape" — and the publish still
+      // succeeded, which is the whole point of catching per key.
+      'message.explode': {},
+    })
+
+    // `config` members the catalog projects. Carried verbatim, so `false` is
+    // preserved and distinguishable from absent.
+    expect(catalog.workflow.blocks[0]?.requiresConnection).toBe(true)
+    expect(catalog.workflow.blocks[0]?.canRunSingle).toBe(false)
+
+    // A block declaring neither must not acquire the keys at all. `undefined`
+    // has to stay distinguishable from `false` — every consumer treats absent
+    // as "unknown, fall back", and `false` as "the author said no".
+    const bare = catalog.workflow.blocks[1]
+    expect(bare?.id).toBe('bare')
+    expect(bare).not.toHaveProperty('requiresConnection')
+    expect(bare).not.toHaveProperty('canRunSingle')
+    expect(bare?.outputsJsonSchema).toEqual({})
+    // No `computeOutputs` at all ⇒ an entry per op, each `{}` (unknown), rather
+    // than a missing key the reader would have to special-case.
+    expect(bare?.opOutputsJsonSchema).toEqual({ 'thing.do': {} })
 
     // App-registered custom fields — projected from `app.fields[]`. Carries the
     // catalog the platform provisions on install/connect (Phase 5/7).

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -147,6 +147,20 @@ export interface CatalogBlock {
   /** Dispatch table: `${resource}.${operation}` → tool id. */
   toolMap: Record<string, string>
   refs: Array<{ path: string[]; kind: string }>
+  /** The block's declared `schema.outputs`. `{}` for router-style blocks — real
+   *  outputs come per-operation from the tool `toolMap` dispatches to. Optional:
+   *  absent on catalogs published before this projection. */
+  outputsJsonSchema?: Record<string, unknown>
+  /** `config.requiresConnection`. Optional, and `undefined` means **unknown**,
+   *  NOT `false` — older catalogs carry nothing. */
+  requiresConnection?: boolean
+  /** `config.canRunSingle` (SDK default `true`). Optional — absent ⇒ true. */
+  canRunSingle?: boolean
+  /** Per-operation outputs keyed by `${resource}.${operation}` — `computeOutputs`
+   *  evaluated once per `toolMap` key at publish time. `{}` for an op means
+   *  UNKNOWN shape (not declared / returned nothing / threw), never "emits
+   *  nothing". Optional: absent on catalogs published before this projection. */
+  opOutputsJsonSchema?: Record<string, Record<string, unknown>>
 }
 
 /**
@@ -643,8 +657,18 @@ export async function compileAndExtractCatalog(): Promise<
       iconKey: null,
       color: block.color,
       inputsJsonSchema: serializeWorkflowSchemaInputs(block.schema),
+      outputsJsonSchema: serializeWorkflowSchemaOutputs(block.schema),
+      opOutputsJsonSchema: projectOpOutputs(block),
       toolMap: block.toolMap ?? {},
       refs: [],
+      // Spread-when-present, never `?? false`: a consumer must be able to tell
+      // "the author said no" from "this catalog predates the projection".
+      ...(block.config?.requiresConnection !== undefined
+        ? { requiresConnection: block.config.requiresConnection }
+        : {}),
+      ...(block.config?.canRunSingle !== undefined
+        ? { canRunSingle: block.config.canRunSingle }
+        : {}),
     })
   }
 
@@ -845,6 +869,93 @@ export async function compileAndExtractCatalog(): Promise<
 }
 
 /**
+ * Evaluate a block's `computeOutputs` per `toolMap` key, so the catalog carries
+ * the per-selection output shapes the canvas computes live in the app iframe.
+ * Without this the server sees only the dispatched TOOL's declared outputs,
+ * which is an open `z.record` on most published apps.
+ *
+ * `computeOutputs` returns the same `Record<string, FieldNode>` shape as
+ * `schema.outputs`, so the existing field serializer handles its result
+ * unchanged.
+ *
+ * Most blocks read only `resource` + `operation`, but some condition on another
+ * input too (slack's `message.send` on `sendTo`), so each select-typed input is
+ * additionally varied one value at a time and the results unioned — see the
+ * comments in the loop for why one-at-a-time and what the union costs.
+ */
+function selectOptionValues(
+  inputsJsonSchema: Record<string, unknown>
+): Array<readonly [string, unknown[]]> {
+  const out: Array<readonly [string, unknown[]]> = []
+  for (const [name, node] of Object.entries(inputsJsonSchema)) {
+    // `resource`/`operation` are already the loop axis — varying them here would
+    // ask a block about a selection that is not the one being projected.
+    if (name === 'resource' || name === 'operation') continue
+    const options = (node as { _metadata?: { options?: unknown } } | null)?._metadata?.options
+    if (!Array.isArray(options) || options.length === 0) continue
+    const values = options.map((o) =>
+      o && typeof o === 'object' && 'value' in o ? (o as { value: unknown }).value : o
+    )
+    out.push([name, values] as const)
+  }
+  return out
+}
+
+function projectOpOutputs(block: RawBlock): Record<string, Record<string, unknown>> {
+  const computeOutputs = block.schema?.computeOutputs
+  const toolMapKeys = Object.keys(block.toolMap ?? {})
+  const opOutputs: Record<string, Record<string, unknown>> = {}
+
+  if (typeof computeOutputs !== 'function') {
+    for (const key of toolMapKeys) {
+      const [resource, operation] = key.split('.')
+      if (resource && operation) opOutputs[key] = {}
+    }
+    return opOutputs
+  }
+
+  const selects = selectOptionValues(serializeWorkflowSchemaInputs(block.schema))
+
+  for (const key of toolMapKeys) {
+    const [resource, operation] = key.split('.')
+    if (!resource || !operation) continue
+
+    // THIRD-PARTY CODE RUNS HERE. Every call is caught independently: one
+    // selection that throws must degrade to nothing, never fail the author's
+    // whole publish. The extraction bundle also stubs `@auxx/sdk/client` and
+    // every `*.server` module, so a `computeOutputs` reaching into either gets a
+    // null-returning no-op or a throw — which is what this absorbs.
+    const call = (inputs: Record<string, unknown>): Record<string, unknown> => {
+      try {
+        return serializeWorkflowSchemaFields(computeOutputs(inputs))
+      } catch {
+        return {}
+      }
+    }
+
+    // The base selection first, so its fields keep leading position, then each
+    // select input varied ONE AT A TIME and unioned. One-at-a-time keeps this
+    // O(sum of options) rather than O(product) — and it is a no-op for the
+    // blocks whose `computeOutputs` reads only resource+operation, which is all
+    // of them but slack's `message.send` / `sendTo`.
+    //
+    // The union is a SUPERSET for conditional outputs: the agent may see a field
+    // that only appears under a different selection. That is the safe direction
+    // (never missing a field the block can emit); the canvas still computes the
+    // exact per-selection set live, because there the conditioning input is set.
+    let merged = call({ resource, operation })
+    for (const [field, values] of selects) {
+      for (const value of values) {
+        merged = { ...merged, ...call({ resource, operation, [field]: value }) }
+      }
+    }
+    opOutputs[key] = merged
+  }
+
+  return opOutputs
+}
+
+/**
  * Serialize a WorkflowSchema's `inputs` object into a plain JSON record. Each
  * field carries a `toJSON()` from `base-node.ts` — fields that don't are passed
  * through as-is and rely on the JSON-serializable check at the catalog level.
@@ -928,11 +1039,20 @@ interface RawBlock {
   color?: string
   schema?: RawWorkflowSchema
   toolMap?: Record<string, string>
+  /** `WorkflowBlockConfig` — only the two members the catalog projects. */
+  config?: { requiresConnection?: boolean; canRunSingle?: boolean }
 }
 
 interface RawWorkflowSchema {
   inputs?: Record<string, unknown>
   outputs?: Record<string, unknown>
+  /**
+   * The block's dynamic-output function. Called at publish time, once per
+   * `toolMap` key — see {@link projectOpOutputs}. Returns the same
+   * `Record<string, FieldNode>` shape as `outputs`, so the existing field
+   * serializer consumes it unchanged.
+   */
+  computeOutputs?: (inputs: Record<string, unknown>) => Record<string, unknown>
 }
 
 interface RawAppField {


### PR DESCRIPTION
## Problem

Kopilot saw `outputs: []` for every app-block node. With nothing to wire from it invented refs like `{{FedEx.record.id}}` — and **the writes succeeded**, because tier-3 ref checking validates against a node's resolved outputs and an empty set has nothing to contradict. One logged session wrote that ref 108 times and ended at the iteration cap with no assistant message.

The server genuinely could not know what an app block emits. `CatalogBlock` carried no outputs, and a block's real answer lives in `schema.computeOutputs` — a function that only ran inside the app's iframe.

## Approach

Extract it at publish time. `computeOutputs` is called once per `toolMap` key and baked into `CatalogBlock.opOutputsJsonSchema`, so the catalog carries the same per-selection shapes the canvas computes live. **No app source changes** — this was going to be a 190-operation hand-sweep across 8 apps.

Some blocks condition on a second input (slack `message.send` on `sendTo`), so each select input is additionally varied one value at a time and the results unioned. `O(sum of options)`, and a no-op for the 17 blocks that read only `resource`+`operation`.

Resolution ladder mirrors the canvas: `inferredSchema` from a real run > `opOutputsJsonSchema` > the dispatched tool's outputs > the block's own `schema.outputs`.

## Verified against real app bundles

| app | ops | populated | extraction |
|---|---|---|---|
| fedex | 4 | 4 | 30ms |
| github | 22 | 22 | 41ms |
| shopify | 64 | 64 | 73ms |
| quickbooks | 42 | 42 | 47ms |
| stripe | 19 | 19 | 44ms |
| telegram | 23 | 23 | 33ms |
| notion | 14 | 14 | 35ms |
| slack | 4 | 4 | 61ms |

`fedex shipment.track` returns exactly its 16 declared fields. Per-op counts on the non-conditional apps are byte-identical before and after the select-varying, so that addition is provably a no-op except for slack:

```
slack message.send   before: messageTs
                      after: messageTs, channelId, channelName, userId, dmChannelId
```

End-to-end through compiler → cache projection → resolver: **132/132 ops across four apps**, up from 4.

## Things a reviewer should push on

- **Two shapes, two converters.** `opOutputsJsonSchema` is a field-node map (`{name: {type, _metadata, fields}}`); a tool's `outputsJsonSchema` is a JSON Schema (`{type, properties}`). A JSON-Schema reader finds nothing in a field-node map and returns empty *silently* — the exact bug this PR fixes. There's a test asserting that mismatch directly. I shipped this wrong first and only caught it because Shopify's real output is a `struct` with `fields`.
- **Property-less means unknown, never "emits nothing".** 190 of 261 published ops declare `z.record(z.string(), z.unknown())`. `resolveAppBlockOutputs` reports `undeclared` so the authoring layer can say "run it once" rather than asserting the node produces nothing.
- **Third-party code runs in our build.** Every `computeOutputs` call is caught per key: one throwing selection degrades to `{}`, never fails the author's publish. The fixture has a deliberately throwing op covering this. The extraction bundle also stubs `@auxx/sdk/client` and every `*.server` module, so that's the realistic failure mode.
- **`requiresConnection` absent means unknown, NOT false.** Older catalogs carry nothing; callers must fall back to the per-app approximation.
- **The union is a superset** for conditional outputs — the agent may see a field that only appears under another selection. Safe direction (never omits an emittable field); the canvas still computes the exact set live. Commented so nobody "fixes" it into an intersection.
- **`app-manifests.ts` is server-only** and must never be re-exported from `workflow-engine/client.ts` — same rule `resolve-outputs` and `derive-trigger-server` follow. Header says so.
- **`CatalogBlock` is declared twice** — canonically in `@auxx/database`, mirrored in the SDK (which ships standalone with no `@auxx/database` dep). Both updated; member lists diffed.

## Deploy notes

- Bumps `installedApps` to **v6**. No invalidation-graph change needed — every `app.*` edge already maps onto that key.
- **Adds no new write surface.** Read paths only.
- Apps must be **redeployed** for the new catalog fields to appear. The 71 ops that already have tool-level outputs (fedex, ups, telegram, discord, airtable, whatsapp, gog-calendar, slack, twilio) resolve without one.

## Test plan

- [x] `packages/sdk` — `vitest src/util` (5 files, 10 tests)
- [x] `packages/sdk` — `tsc --noEmit` clean
- [x] `packages/lib` — `vitest src/workflow-engine src/workflows/graph-edit src/cache` (95 files, 1471 tests)
- [x] `packages/lib` + `apps/web` — `typecheck-ratchet` no new errors
- [x] `packages/database` — build + `tsc` clean
- [x] biome clean
- [x] real bundles: 8 apps compiled, all ops populated, per-op counts diffed
- [ ] post-redeploy: `get_node` on a FedEx node returns 16 outputs and no "not in the catalog" issue; `{{FedEx.record.id}}` is rejected with a suggestion

Plan: `plans/kopilot/workflow/17-app-block-authoring-and-connections.md` (A1–A3). B (authoring) is unblocked now that #1701 has landed.