### PR TITLE
fix(workflow): make resolveGraphOutputs honour its Result contract

### DIFF
--- a/docs/core-workflow-architecture-guide.md
+++ b/docs/core-workflow-architecture-guide.md
@@ -1,7 +1,9 @@
 # Core Workflow Architecture Guide
 
 **Scope:** the workflow system Auxx owns — the node catalog, the execution
-engine, the draft-mutation service, and the Kopilot builder capability.
+engine, edges and graph traversal, the run lifecycle (trigger → engine → events
+→ UI), the canvas/panel layer, the draft-mutation service, and the Kopilot
+builder capability.
 
 **Not this guide:** `docs/workflow-architecture-guide.md` covers the *Workflow
 App System* — third-party blocks contributed by installed apps (SDK bundles,
@@ -10,8 +12,10 @@ the only overlap is that an app block appears in the canvas alongside core nodes
 (`nodes/app-workflow-block-processor.ts`).
 
 Read this before touching node schemas, output variables, the engine's
-preprocess/execute contract, draft mutations, or anything Kopilot does to a
-workflow graph.
+preprocess/execute contract, edges/handles or graph traversal, the run and its
+event stream, the canvas stores and panel stack, draft mutations, or anything
+Kopilot does to a workflow graph. §8 is the one to read before "just a small
+change" to anything the canvas renders during a drag.
 
 ---
 
@@ -25,10 +29,18 @@ packages/lib/src/ai/kopilot/capabilities/workflow-builder/  ← 4. How Kopilot a
 apps/web/src/components/workflow/             ← the canvas, panels, run UI
 ```
 
+Two more things cut across all four and get their own sections because they are
+where most of the surprises live:
+
+```
+packages/lib/src/workflow-engine/core/workflow-graph-builder.ts  ← edges → an executable graph (§5)
+packages/lib/src/workflows/workflow-execution-service.ts         ← a run, start to finish (§6)
+```
+
 The load-bearing idea: **a node's data contract lives in lib, its React lives in
 web.** One node type is described once, in `catalog/nodes/<type>.ts`, and both
 the builder and the engine read that description. Before the catalog existed the
-two had independent copies that silently drifted — the parity harness (§7) exists
+two had independent copies that silently drifted — the parity harness (§11) exists
 because of what that cost.
 
 ---
@@ -185,7 +197,365 @@ Two conventions worth knowing:
 
 ---
 
-## 5. `workflows/graph-edit/` — the draft-mutation layer
+## 5. Edges and handles — the connection contract
+
+An edge is a plain object inside `Workflow.graph.edges`. There is no `Edge`
+table and no edge model; the graph jsonb is the entire store.
+
+```ts
+{ id, source, sourceHandle, target, targetHandle,
+  data: { sourceType, targetType, isLoopBackEdge? } }
+```
+
+`data.sourceType`/`targetType` are the *node* types denormalized onto the edge so
+`edges/custom-edge` can colour and route without looking nodes up mid-render.
+
+**Handle vocabulary.** The graph builder defaults absent handles to
+`sourceHandle: 'source'` / `targetHandle: 'target'`. Beyond those:
+
+| Handle | Means | Read by |
+| --- | --- | --- |
+| `source` | the success path | `getNextNodes` |
+| `true`/`false`, branch ids | conditional outputs (`manifest.connection.branches`) | `getNextNodes` |
+| `fail`, legacy `onError` | failure route | `findFailureEdge` |
+| `target` | the **only** handle counted as execution flow *into* a node | `detectJoinPoints` |
+| `loop-start` / `loop-back` | loop body entry / iteration return | `buildLoopInfo` |
+| `input` | form-input data wired into a trigger | deliberately **excluded** from join detection |
+
+The `targetHandle === 'target'` filter in `detectJoinPoints` is load-bearing.
+Without it a `loop-back` or form-input `input` edge makes its target look like a
+convergence point, and the engine parks there waiting for branches that will
+never arrive.
+
+**React Flow owns edges in the browser — `store/edge-store.ts` does not.** Every
+method on that store is marked `@deprecated` in favour of
+`useStoreApi().setEdges`. It is legacy scaffolding; read and write edges through
+React Flow's store.
+
+**Connection validity is deliberately thin.** `services/edge-validation-service.ts`
+rejects exactly three things: a missing endpoint, a self-connection, and an exact
+duplicate (same source + target + *both* handles). Type compatibility is never
+checked there, because it is enforced one level up: `useAvailableBlocks` decides
+whether a source handle is connectable at all, so an illegal target never offers
+a handle to drop on. That is why there is no "invalid connection" toast.
+
+**Handles render their connected state off node data, not off edges.**
+`_connectedSourceHandleIds` / `_connectedTargetHandleIds` live in `node.data`,
+are rebuilt on load by `utils/workflow-initializer.ts` and patched on every
+add/remove by `getNodesConnectedSourceOrTargetHandleIdsMap`
+(`utils/edge-utils.ts`). Like every `_`-prefixed key they are **derived canvas
+state, stripped on every save** — see `catalog/derived-keys.ts`, which is the one
+declaration of that rule, and its test asserting no `configSchema` may declare
+one.
+
+### Graph traversal — what the engine does with those edges
+
+`core/workflow-graph-builder.ts` compiles the persisted graph into a
+`WorkflowGraph` (cached per workflow id on the engine instance), in four passes:
+
+1. **Filter** — drop UI-only types (`note`, `group`, `annotation`, `comment`) and
+   any node whose type has no registered processor.
+2. **Bypass disabled nodes** — a node with `data.disabled` is dropped and each of
+   its outgoing edges becomes a bypass edge from the node *before* it, carrying
+   the incoming edge's `sourceHandle` and the outgoing edge's `targetHandle`.
+   Two sharp corners: chasing a chain of disabled nodes stops with a
+   `Skipping complex disabled node routing` warning the moment a link has
+   anything other than exactly one outgoing edge — **that path is silently
+   dropped** — and bypasses are deduped by `source→finalTarget` pair, so two
+   handles from the same source landing on the same target collapse into one
+   edge. Disabling a node in the middle of a fork is not a safe edit.
+3. **Transform + index** — `edgesBySourceHandle` (`"nodeId:handle"`),
+   `edgesByTarget`, per-node `nodeRoutes`, `entryNodes`, `terminalNodes`,
+   `loopNodes`.
+4. **Analyse** — cycle detection, then `detectForkPoints` / `detectJoinPoints` /
+   `mapForksToJoins`.
+
+Routing at run time (`core/graph-navigation.ts`):
+
+- `getNextNodes(graph, nodeId, handle)` tries the exact handle, then **falls back
+  to `source`**. When the unmatched handle is error-ish, it logs a loud warning —
+  a succeeded result carrying an error-ish handle with no wired edge legitimately
+  continues down the success path (http's `error_strategy: 'none'`), but the same
+  fallback would otherwise mask a mis-wired fail branch.
+- A **failed** result never reaches that fallback. `findFailureEdge` runs first
+  and prefers the handle the processor actually emitted, then legacy `onError`;
+  `source` is explicitly excluded so a failure can never walk the success path.
+  No failure edge wired ⇒ the run throws.
+- `outputHandles` (plural) exists on the result type and is never used. One
+  result, one handle.
+
+Fork/join is inferred, not declared:
+
+- A **fork** is one source handle with more than one edge. `findJoinForFork` BFSes
+  every branch, intersects their reachable sets, and takes the nearest common
+  descendant as the join.
+- A **join** is a node with >1 incoming `target`-handle edge. Its config is read
+  from `data.joinConfig` **or** `data.mergeConfig` (`joinType`, `requiredCount`,
+  `timeout`, `mergeStrategy`, `errorHandling`), defaulting to `all` /
+  `merge-all`.
+- A fork with no common descendant is an **orphan fork** — a fan-out. The engine
+  runs the branches to completion in parallel and then stops; there is no
+  post-fan-out continuation.
+- Branches execute in isolated child contexts and merge at the join
+  (`core/context-merger.ts`, `core/branch-merger.ts`); a branch that reaches the
+  join first registers a continuation and returns.
+
+Loops are the one place the cycle guard is relaxed: `executeWorkflowNodes` breaks
+on `contextManager.hasVisitedNode` for every type **except** `loop`. The hard
+backstop is `maxIterations = 1000` for the whole run.
+
+---
+
+## 6. A run, end to end
+
+Two entry paths converge on the same engine.
+
+**Production.** A domain event (`message:received`, a record change, a schedule
+tick, a webhook, an app trigger) reaches a dispatcher under
+`packages/lib/src/events/handlers/` or a scheduler. The dispatcher does the
+cheap matching itself — it reads *published* graphs out of the org cache
+(`getCachedWorkflowAppsByTrigger`), applies the trigger node's own filters
+(channel scope, machine-mail tier, own-address, condition groups), and enqueues
+one BullMQ job per surviving workflow. The job
+(`packages/lib/src/jobs/workflow/*-trigger-job.ts`) creates the run and executes
+it. `trigger-message-workflows.ts` → `message-trigger-job.ts` is the reference
+pair; resource, scheduled, polling, webhook-endpoint and app-trigger jobs all
+mirror it.
+
+**Test run from the builder.** `POST /api/workflows/[workflowId]/run` — gated on
+instance **`edit`**, because test-running is authoring. The route creates the
+run, subscribes to Redis, kicks off `executeWorkflowAsync`, and streams the
+result back over the *same* POST response as SSE. `workflowId` here is a
+`Workflow.id` (a version/draft), not the parent `WorkflowApp.id`.
+
+Both then run:
+
+```
+WorkflowExecutionService.createRun()      → WorkflowRun row (status RUNNING)
+  .executeWorkflowAsync(run, reporter)
+    WorkflowEngine.executeWorkflow()
+      buildGraph() → executeWorkflowNodes() loop
+        per node: INSERT WorkflowNodeExecution (Running)
+                  preprocessNode() → UPDATE .inputs
+                  emit NODE_STARTED
+                  execute() (or LoopExecutionManager for `loop`)
+                  UPDATE outputs/status, emit NODE_COMPLETED | NODE_FAILED
+      → UPDATE WorkflowRun (SUCCEEDED | FAILED | PAUSED)
+```
+
+**Evidence tables.** `WorkflowRun` stores an immutable `graph` snapshot plus
+`inputs`, `outputs`, `status`, `elapsedTime`, `totalTokens`, `totalSteps`, and
+the pause columns (`pausedAt`, `pausedNodeId`, `resumeAt`, `serializedState`).
+`WorkflowNodeExecution` is one row per node execution with `index`,
+`predecessorNodeId`, `inputs`, `processData`, `outputs`, and an
+`executionMetadata` blob carrying `depth`, `forkId`, `branchIndex`,
+`executionPath` and loop info — that blob is what lets the run panel rebuild a
+tree from a flat table.
+
+**Event transport is Redis pub/sub, one channel per run.**
+`RedisWorkflowExecutionReporter.emit` publishes to `workflow:run:<runId>`;
+`WorkflowEventType` (`workflow-engine/shared/types.ts`) is the closed vocabulary
+— workflow lifecycle, node lifecycle, loop lifecycle, connection/run. **Emission
+is best-effort**: `emit` catches and logs, never throws, so a Redis outage
+degrades the live view without failing the run. The DB rows are the truth; the
+events are a tail.
+
+Two SSE endpoints consume that channel, and they are not interchangeable:
+
+| Endpoint | Shape | Gate | Use |
+| --- | --- | --- | --- |
+| `POST /api/workflows/[workflowId]/run` | starts the run *and* streams it | instance `edit` | builder test run |
+| `GET /api/workflow/run/[runId]/events` | replays `WorkflowNodeExecution` rows, then tails | instance `view` | opening an existing/finished run |
+
+The replay endpoint also synthesizes a terminal `workflow-finished` for an
+already-completed run, so a client sees the same event sequence whether it
+connected before or after the run ended.
+
+Client side, `~/hooks/use-workflow-run.tsx` owns the POST-SSE connection (via
+`useSSE` — a fetch stream, **not** `EventSource`, because the run needs a body)
+and dispatches each event into `hooks/run-hooks/*`, one hook per event type,
+each writing `store/run-store.ts`. The run store holds `activeRun`,
+`runViewMode` (`live` | `previous` | `single-node`), a `nodeExecutions` map, the
+loop-iteration map and the execution tree. Node status on the canvas and edge
+colours are downstream of that store
+(`use-workflow-run-node-sync`, `use-edge-status-updater`).
+
+**Pause/resume.** A node returns `status: Paused` with a `PauseReason`;
+`shouldPauseBeTerminal` (`core/pause-resume.ts`) decides whether that pauses the
+whole run or just the branch — sequential pauses are always terminal, in-branch
+pauses default to non-terminal. The engine serializes context into
+`WorkflowRun.serializedState` and throws `WorkflowPausedException`. Resume comes
+from a scheduled job (`wait`), an approval decision, a timeout or an admin
+cancel, all through `WorkflowExecutionService.resumeWorkflow(runId, fromNodeId,
+payload)`. `WORKFLOW_PAUSED`/`WORKFLOW_RESUMED` are deliberately **not**
+terminal SSE events — the builder connection stays open across them.
+
+**Single-node run** is a third mode: `runSingleNode` executes one node against
+`core/single-node-executor.ts` with a synthetic context and writes a
+`WorkflowNodeExecution` stamped `triggeredFrom: SINGLE_STEP` with a null
+`workflowRunId` — it creates **no** `WorkflowRun`, so it never appears in run
+history. `runViewMode: 'single-node'` is the only run mode that leaves the
+canvas editable.
+
+---
+
+## 7. The canvas — stores, interactions, panels
+
+**React Flow's store is the graph.** Nodes and edges live in
+`useStoreApi()`; every Zustand store beside it holds something else and must not
+duplicate the graph. What each one owns:
+
+| Store | Owns |
+| --- | --- |
+| `workflow-store` | workflow identity, dirty flag, drag state, `kopilotEditing`, `instanceReadOnly`, connect/menu payloads |
+| `canvas-store` | viewport, grid/minimap settings, version-preview read-only |
+| `panel-store` | the drawer's frame stack, panel width, pinning, run-panel tab, Kopilot thread |
+| `run-store` | active run, node executions, loop iterations, execution tree |
+| `selection-store` / `interaction-store` / `clipboard-store` | selection ops, pointer/pan mode, copy-paste |
+| `use-var-store` | the variable index — outputs per node, availability per node, upstream/downstream maps |
+| `history-manager` | undo/redo snapshots |
+| `event-bus` | cross-store notifications (`selection:changed`, `node:updated`, `drag:ended`, `workflow:externalUpdate`) |
+
+`store/edge-store.ts` and `store/node-store.ts` are dead: the former is fully
+`@deprecated`, the latter is an empty stub (and `workflow-store.exportWorkflow`
+still carries a TS18004 scar from when it wasn't).
+
+**Interactions all funnel through hooks, never through components.**
+`use-node-interactions` (add/select/drag/connect/delete/duplicate),
+`use-edge-interactions` (hover, edge changes, single/bulk/branch delete),
+`use-selection-interactions`, `use-context-menu`. `canvas/workflow-canvas.tsx`
+only wires the handlers onto `<ReactFlow>`.
+
+Adding a node has three front doors and one factory: the `+` on a source handle
+(`ui/node-handle/source-handle.tsx` → `AddNodeTrigger`), the pane context menu,
+and clicking an edge to insert a node into it (`edges/custom-edge/index.tsx`).
+All three go through `utils/node-layout` `NodeFactory`, which mints the id,
+seeds `defaultData`, inherits `parentId` for loop bodies, and initializes the
+derived `_connected*` arrays. A node created any other way renders every handle
+as unconnected.
+
+**Panels are frames in one drawer, not separate drawers.**
+`panels/workflow-panel-drawer.tsx` owns a single `DockableDrawer` + `NavStack`.
+`panel-store.frames` is `[]` (closed), `[base]`, or `[base, overlay]` — **never
+deeper**. The base is a node (or `empty`); Test / Settings / Kopilot are
+*peer overlays*, so opening one while another is up replaces it. That is what
+keeps the back chevron unambiguous. Selecting a node sets the base and pops the
+overlay. See `plans/workflow/panel-nav-stack.md`.
+
+The node's panel body resolves from the frame's `nodeId`, not from React Flow's
+selection — the frame must stay stable while an overlay covers it. Panel
+components come from `unifiedNodeRegistry.getPanel(type)`, registered beside
+`component` and `traceRenderer` in `nodes/core/index.ts`.
+
+**Panels write config through one hook.** `use-node-data-update`'s
+`handleNodeDataUpdateWithSync` immer-patches `node.data` in React Flow, then
+fires `debouncedSave()` and a history snapshot. Never `setNodes` from a panel
+directly — that skips both.
+
+**Saving is debounced and CAS-guarded.** `use-workflow-save` accumulates pending
+changes (graph, name, icon, config, env vars…) and flushes them through one
+`workflow.update` tRPC mutation after 5 s. It strips derived keys and re-derives
+trigger columns before sending. A `409 CONFLICT` latches `conflictRef` and
+**stops that editor saving entirely** — its in-memory graph is stale, so every
+retry would either re-conflict or clobber. The user must reload.
+
+**`useReadOnly` is the single client authority** for "can this canvas be
+edited", with five sources: version preview, viewer embed, run playback,
+per-workflow instance access, and `kopilotEditing`. Every affordance keys off
+it, which is also its cost model — a flip re-renders all of them. Nothing that
+changes more than a couple of times per turn belongs in it.
+
+**The variable index is a derived projection, kept in sync by one bridge.**
+`use-var-store-sync` subscribes to React Flow's store, bails on
+`nodes`/`edges` reference equality, RAF-debounces, and calls
+`useVarStore.updateGraph`, which topologically walks the graph and recomputes
+each node's outputs via `computeNodeOutputs` — the browser half of §3. Nothing
+else may push into that store.
+
+---
+
+## 8. Performance — what costs, and how to measure it
+
+The failure mode this section exists for: a canvas that was smooth becomes janky
+on node drag, and the cause is a **subscription**, not an algorithm. React Flow
+replaces `state.nodes` with a new array on every drag frame (~60/s). Anything
+that subscribes to the array — or to something derived from it — re-renders at
+that rate while a node moves. The diff that introduces it looks harmless, and it
+only shows on a graph with enough nodes.
+
+### Subscription rules
+
+- **Never `useStore((s) => s.nodes)` or `s.edges`.**
+  `ui/variables/variable-explorer-enhanced.tsx:150` does exactly this today, so an
+  open variable explorer re-renders on every drag frame. Subscribe to a scalar
+  (`s.nodes.length` — `hooks/use-workflow-trigger.ts:32`) or project narrowly and
+  wrap in `useShallow` (`panels/property-panel.tsx:31`).
+- **`useShallow` suppresses the re-render, not the selector.** The selector body
+  still runs on every store update. `s.nodes.find(n => n.id === id)` is fine; a
+  `.reduce` over every node is not — `hooks/use-available-variables.tsx:86`
+  builds a full title map per update and defends itself with a manual hash ref.
+  That ref is the tell, not the fix.
+- **Whole-graph derivations belong behind `store.subscribe` + RAF, never a render
+  subscription.** `hooks/use-var-store-sync.ts` is the reference: reference-equality
+  bail-out, then one RAF-coalesced recompute.
+- A node component that subscribes to state its own panel writes re-renders the
+  whole canvas on every keystroke in that panel.
+
+### Where drag time actually goes today
+
+`handleNodeDrag` (`hooks/use-node-interactions.ts:676`) rebuilds the entire node
+array with `produce()` and calls `setNodes` on **every pointer frame** — O(nodes)
+per frame before React Flow does any work. That fresh array reference then fans
+out to every subscriber, and in particular to `updateGraph`
+(`store/use-var-store.ts`), which per RAF runs a `topologicalSort` plus a
+parent-id check shaped `nodes.some(n => state.graph.nodes.find(...))` — O(n²) —
+for a change that is *only* a position and cannot affect any variable.
+
+The mitigations in the tree today are drag gates, not fixes:
+`store/panel-store.ts:350` drops `selection:changed` while `isDragging` (else the
+panel opens mid-drag and re-renders the editor shell) and re-opens it 50 ms after
+`drag:ended`; `useOnViewportChange` is debounced 300 ms. **Read `isDragging` as
+evidence that something downstream is too expensive**, not as architecture. Two
+real fixes are available and unclaimed: skip the var-store sync when only
+`position` changed, and make the parent-id check a map lookup.
+
+### There is no perf debug switch today
+
+Worth stating plainly, because it keeps getting assumed: nothing in the tree or
+in git history ever shipped one. `hooks/use-variable-performance.ts` is a
+`useDebounce` and nothing else, and `canvas/workflow-canvas.tsx:20` has a
+commented-out `DevTools` import pointing at a `~/components/devtools` that does
+not exist. Measuring today means driving React DevTools' Profiler by hand, which
+is why regressions land.
+
+### Proposed switch (design, not shipped)
+
+One dev-only flag, three probes, one report. Kept here so the next person builds
+*this* rather than another ad-hoc `console.log` pass.
+
+- **Gate** — `?perf=1` or `localStorage['workflow:perf']`, read **once** into a
+  module-level const, and `&& process.env.NODE_ENV !== 'production'`. Reading the
+  flag must never be part of a render path, or the switch becomes its own cost.
+- **Probe 1 — render attribution.** `useRenderTrace('VariableExplorer')` bumps a
+  module counter keyed by name. No state, no re-render.
+- **Probe 2 — the drag window.** `handleNodeDragStart` opens a window;
+  `handleNodeDragStop` closes it and reports: frames, dropped frames
+  (`performance.now()` deltas > 16.7 ms), cumulative time inside `setNodes`, and
+  the per-component render counts collected since `dragStart`. One
+  `console.table`, sorted by render count — the offending subscription is
+  whatever sits at the top with a count equal to the frame count.
+- **Probe 3 — User Timing marks.** `performance.mark`/`measure` around
+  `updateGraph`, `computeNodeOutputs` and `topologicalSort`, so a Chrome
+  performance recording attributes the cost in its Timings track without any
+  console reading.
+
+The acceptance bar for the switch: on a 50-node graph, dragging one node should
+show render counts in the low tens, not ~60 × the number of mounted panels. Any
+component whose count tracks the frame count is the regression.
+
+---
+
+## 9. `workflows/graph-edit/` — the draft-mutation layer
 
 Eight mutations, all funnelled through `runGraphMutation`:
 
@@ -218,10 +588,27 @@ Rules that are easy to get wrong:
 - **Bare-ref normalization must withhold prose keys** (`title`, `desc`) or a
   title equal to another node's title rewrites into a raw node id.
 - Node ids are **nanoid (21 chars)**, not cuids.
+- **`applied: false` is the BLOCKING vocabulary — never a no-op.** A mutation
+  that changed nothing returns `applied: true, unchanged: true` and skips the
+  write, the snapshot and the realtime signal. `mutationToToolResult` renders
+  `applied: false` as "Update X blocked", so reporting a harmless idempotent
+  write that way sends the caller off to repair something that is already
+  correct. The no-op check is guarded on `envVars`/`variables`/`icon`, which
+  `set_workflow_details` and `apply_template` pass through the same seam.
+- **A node with no manifest is not an issue.** Uncatalogued nodes (app blocks,
+  not-yet-migrated types) are named once on `GraphSummary.readOnlyNodes`, never
+  as a per-node `info` issue — an un-actionable line repeated on every read
+  buries the issues that ARE actionable.
+- **Outputs are enrichment; they must never fail a write.**
+  `resolveGraphOutputs` runs BEFORE `persistDraft`, so it returns
+  `err` rather than throwing — a cache blip must not abort an
+  already-validated edit. It also must not degrade to an empty app-block
+  lookup: `checkVariableRefsAgainstOutputs` would then flag valid references as
+  unresolvable, and inventing issues is worse than reporting none.
 
 ---
 
-## 6. The Kopilot workflow-builder capability
+## 10. The Kopilot workflow-builder capability
 
 `ai/kopilot/capabilities/workflow-builder/` — a capability factory plus **20**
 tool files sharing one authoring guard. Registered in `apps/web`'s Kopilot stream
@@ -250,7 +637,7 @@ in every tool).
 
 ---
 
-## 7. The parity harness — what CI actually gates
+## 11. The parity harness — what CI actually gates
 
 `apps/web/src/components/workflow/parity/`:
 
@@ -270,7 +657,7 @@ runtime-reflectable. It has a documented retirement path.
 
 ---
 
-## 8. Verification recipe
+## 12. Verification recipe
 
 ```bash
 node scripts/ci/typecheck-ratchet.js --package lib   # NEVER bare tsc
@@ -287,7 +674,7 @@ target module". That build runs `generate:exports` codegen which may churn
 
 ---
 
-## 9. Gotchas, collected
+## 13. Gotchas, collected
 
 - **`SearchService.search` has no ACL of its own** — see
   `docs/knowledge-base-architecture-guide.md` §6. Any node reaching it must
@@ -308,3 +695,17 @@ target module". That build runs `generate:exports` codegen which may churn
   `BaseAiNodeProcessor undefined`.
 - **A trace renderer that throws looks like "no preview", not a failure** —
   `TraceRenderBoundary` swallows it. Test renderers.
+- **Run events are best-effort, DB rows are truth.** `RedisWorkflowExecutionReporter.emit`
+  catches and logs everything. Never build correctness (a status transition, a
+  counter, a downstream job) on an event arriving — read the `WorkflowRun` /
+  `WorkflowNodeExecution` row.
+- **An unmatched output handle falls back to `source`.** `getNextNodes` logs a
+  warning for error-ish handles and continues down the success path. A branch
+  that "somehow ran anyway" is usually a `sourceHandle` typo, not an engine bug.
+- **The two run SSE endpoints have different gates** — `POST …/run` requires
+  instance `edit` (it starts a run), `GET /api/workflow/run/[runId]/events`
+  requires `view` (it only replays). A new run surface must pick deliberately;
+  they are not interchangeable.
+- **Subscribing to `state.nodes` is a canvas-wide regression, not a local one.**
+  See §8 — one such subscription re-renders that component ~60×/s for the whole
+  duration of every node drag.

--- a/packages/lib/src/workflow-engine/catalog/resolve-outputs.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/resolve-outputs.test.ts
@@ -436,4 +436,47 @@ describe('app-block nodes', () => {
 
     expect(getCachedInstalledApps).not.toHaveBeenCalled()
   })
+
+  // The declared `Result<…, Error>` was never produced: both cache reads could
+  // throw straight through it, past every caller's `isOk()` guard. Since
+  // `runGraphMutation` resolves outputs BEFORE `persistDraft`, a blip in either
+  // aborted an already-validated edit and lost the user's change.
+  it('returns err instead of throwing when the resources read fails', async () => {
+    noResources()
+    getCachedResources.mockRejectedValue(new Error('redis down'))
+    const graph = { nodes: [varAssignArrayNode('n1', 'items')], edges: [] }
+
+    const result = await resolveGraphOutputs('org-1', { graph })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toBe('redis down')
+  })
+
+  it('returns err instead of throwing when the app-block lookup fails', async () => {
+    noResources()
+    getCachedInstalledApps.mockRejectedValue(new Error('installed apps unavailable'))
+    // A colon-shaped type is what routes into `buildAppBlockLookup`.
+    const graph = {
+      nodes: [
+        { id: 'n1', type: 'app1:block1', data: { id: 'n1', type: 'app1:block1', title: 'Block' } },
+      ],
+      edges: [],
+    }
+
+    const result = await resolveGraphOutputs('org-1', { graph })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toBe('installed apps unavailable')
+  })
+
+  it('wraps a non-Error throw so callers always get an Error', async () => {
+    noResources()
+    getCachedResources.mockRejectedValue('just a string')
+    const graph = { nodes: [varAssignArrayNode('n1', 'items')], edges: [] }
+
+    const result = await resolveGraphOutputs('org-1', { graph })
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(Error)
+    expect(result._unsafeUnwrapErr().message).toBe('just a string')
+  })
 })

--- a/packages/lib/src/workflow-engine/catalog/resolve-outputs.ts
+++ b/packages/lib/src/workflow-engine/catalog/resolve-outputs.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/workflow-engine/catalog/resolve-outputs.ts
 
+import { createScopedLogger } from '@auxx/logger'
 import { err, ok, type Result } from 'neverthrow'
 import { getCachedResources } from '../../cache'
 import { NotFoundError } from '../../errors'
@@ -9,6 +10,8 @@ import { buildOutputContextFromResources } from './build-output-context'
 import { buildUpstreamMap, type EdgeMeta, type NodeMeta, topologicalSort } from './graph-vars'
 import { getManifest } from './registry'
 import { getNodeIdFromVariableId } from './variable-inference'
+
+const logger = createScopedLogger('workflow-resolve-outputs')
 
 /**
  * The persisted-graph shape output resolution reads: React Flow nodes, engine
@@ -195,10 +198,40 @@ export async function resolveGraphOutputs(
   orgId: string,
   params: { graph: WorkflowOutputGraph }
 ): Promise<Result<Map<string, UnifiedVariable[]>, Error>> {
-  const [allResources, appBlocks] = await Promise.all([
-    getCachedResources(orgId),
-    appBlocksForGraph(orgId, params.graph.nodes),
-  ])
-  const memo = resolveInTopoOrder(allResources, params.graph.nodes, params.graph.edges, appBlocks)
-  return ok(memo)
+  try {
+    const [allResources, appBlocks] = await Promise.all([
+      getCachedResources(orgId),
+      appBlocksForGraph(orgId, params.graph.nodes),
+    ])
+    const memo = resolveInTopoOrder(allResources, params.graph.nodes, params.graph.edges, appBlocks)
+    return ok(memo)
+  } catch (error) {
+    // Outputs are ENRICHMENT, not correctness — and every caller already says
+    // so: `ops.ts` and `read.ts` guard on `isOk()` and simply carry on without
+    // them. But that branch is only reachable through a RETURNED `err`; a
+    // throw sails past it. This function has always declared
+    // `Result<…, Error>` and never produced one, so both cache reads below it
+    // were effectively un-caught:
+    //
+    //   - `getCachedResources` (Redis + Postgres)
+    //   - `appBlocksForGraph` → `buildAppBlockLookup` → the installedApps
+    //     provider (Redis + Postgres), reached by any graph holding an
+    //     `appId:blockId` node
+    //
+    // `runGraphMutation` calls this BEFORE `persistDraft`, so a blip in either
+    // aborted an already-validated, about-to-be-written edit and lost the
+    // user's change. Honouring the declared contract is the whole fix; no
+    // call site needs to change.
+    //
+    // Deliberately NOT degrading to an empty lookup: outputs would keep
+    // flowing minus the app-block variables, and `checkVariableRefsAgainstOutputs`
+    // would then report perfectly valid references as unresolvable — inventing
+    // issues is worse than reporting none.
+    logger.warn('Output resolution failed — continuing without outputs', {
+      orgId,
+      nodeCount: params.graph.nodes.length,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return err(error instanceof Error ? error : new Error(String(error)))
+  }
 }

--- a/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
@@ -8,6 +8,7 @@
  * column re-derivation through the persist seam, and the readDraft shape.
  */
 
+import { err as errResult } from 'neverthrow'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Partial mock — the cache barrel is imported by half of lib; replacing it
@@ -29,6 +30,24 @@ vi.mock('../../workflow-service', () => ({
     }
   },
 }))
+
+// Partial mock — `resolveGraphOutputs` is a collaborator of the mutation
+// pipeline, not the thing under test here. Stubbing the cache instead would
+// not work: `normalizeConfig` reads resources too, so a rejection would land
+// in the wrong place. Partial, never wholesale — a full replacement of a
+// shared module dies at collection.
+const resolveGraphOutputs = vi.fn()
+vi.mock('../../../workflow-engine/catalog/resolve-outputs', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../workflow-engine/catalog/resolve-outputs')>()
+  return {
+    ...actual,
+    resolveGraphOutputs: (...args: unknown[]) =>
+      resolveGraphOutputs.getMockImplementation()
+        ? resolveGraphOutputs(...args)
+        : actual.resolveGraphOutputs(...(args as Parameters<typeof actual.resolveGraphOutputs>)),
+  }
+})
 
 // The blocking mail guard — checked in the pipeline so it reports as an issue.
 const mailGuard = vi.fn(async (..._args: unknown[]) => {})
@@ -869,6 +888,30 @@ describe('updateNode / disconnectNodes', () => {
     const value = result._unsafeUnwrap()
     expect(value.graphSummary.readOnlyNodes).toEqual(['Incoming Webhook'])
     expect(value.issues.some((i) => /not in the catalog|read-only/.test(i.message))).toBe(false)
+  })
+
+  it('still persists the edit when output resolution fails', async () => {
+    // Outputs are enrichment, resolved BEFORE persistDraft. A throw there used
+    // to sail past `if (resolved.isOk())` and abort an already-validated edit,
+    // losing the user's change over a cache blip. Now it returns err, the
+    // guard does what it was written to do, and the write lands without
+    // outputs — and WITHOUT inventing unresolvable-ref issues.
+    resolveGraphOutputs.mockImplementation(async () => errResult(new Error('redis down')))
+    const graph: DraftGraph = { nodes: [triggerNode(), loopNode()], edges: [] }
+
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'For each order',
+      config: { maxIterations: 9 },
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().applied).toBe(true)
+    expect(result._unsafeUnwrap().outputs).toBeUndefined()
+    expect(serviceUpdate).toHaveBeenCalled()
+    expect(persistedGraph().nodes.find((n) => n.id === LOOP_ID)?.data?.maxIterations).toBe(9)
+    resolveGraphOutputs.mockReset()
   })
 
   it('reports a re-issued identical edit as unchanged and does NOT write', async () => {


### PR DESCRIPTION
Found while implementing plan 16's D11. It looked like a test problem; it isn't.

## The contract was never true

`resolveGraphOutputs` declares `Promise<Result<Map<…>, Error>>` — and cannot
produce an `err`:

```ts
export async function resolveGraphOutputs(orgId, params): Promise<Result<…, Error>> {
  const [allResources, appBlocks] = await Promise.all([
    getCachedResources(orgId),
    appBlocksForGraph(orgId, params.graph.nodes),   // throws straight through
  ])
  return ok(resolveInTopoOrder(…))
}
```

Every caller was written as though failure were routine:

| Caller | Handling |
|---|---|
| `graph-edit/ops.ts:155` | `if (resolved.isOk())` — carry on without outputs |
| `graph-edit/read.ts:214` | same |
| `graph-edit/read.ts:264` | same |
| `normalize/ref-check.ts:329` | `if (outputs.isErr()) return err(...)` |

None of that is reachable through a throw. Four call sites guarding a branch
that could never be taken.

## Why it matters beyond tests

`runGraphMutation` resolves outputs **before `persistDraft`**. So a failure in
an enrichment step the caller has explicitly marked optional aborts an
already-validated, about-to-be-written edit — and the user's change is lost.

Two throw sources sit under it, both reaching Redis *and* Postgres:

- `getCachedResources` — always did
- `appBlocksForGraph` → `buildAppBlockLookup` → the `installedApps` provider,
  added in #1705, reached by **any graph holding an `appId:blockId` node**

The second is what surfaced it: an app-block fixture crashed a graph-edit test
on `db.query.AppInstallation.findMany`, because that suite's mock db has no
`.query`. The test was the messenger — the mismatch is pre-existing, and #1705
only widened the blast radius from "one cache" to "one cache plus every graph
containing an app block".

## The fix

Return `err` instead of throwing. **No call site changes** — the four guards
above start doing what they were always written to do.

**Deliberately not** degrading to an empty app-block lookup on failure: outputs
would keep flowing minus the app-block variables, and
`checkVariableRefsAgainstOutputs` would then report perfectly valid references
as unresolvable. Inventing issues is worse than reporting none — an `err` skips
the ref-check entirely, so the failure mode is "no outputs", never "wrong
outputs".

Failures log at `scope='workflow-resolve-outputs'` so a silent degradation is
still queryable.

## Tests

`resolve-outputs.test.ts` — err on a failed resources read, err on a failed
app-block lookup, and a non-`Error` throw wrapped so callers always get an
`Error`. **All three verified red without the fix.**

`graph-edit/__tests__/ops.test.ts` — the end-to-end consequence: a mutation
whose output resolution fails still persists, still reports `applied: true`,
and carries no `outputs`. This one is green either way by construction (it
mocks the collaborator, so it locks in the *caller's* behaviour rather than the
throw→err change) — it is the regression guard for the pipeline, not the proof
of this fix.

`src/workflows src/workflow-engine src/ai` green — 2714 passed. `typescript7`
clean, biome clean.

## Follow-up not done here

With this in place, a graph-edit fixture containing an `appId:blockId` node no
longer crashes — it just resolves no outputs. A test that specifically wants
app-block *outputs* still needs `getCachedInstalledApps` stubbed, so a small
shared mock helper in that suite is worth having as convenience. Plan 16's D11
test uses a not-yet-migrated type (`webhook`) to sidestep this and could now be
switched to a real app block.



---

## Also in this PR: the architecture guide

`docs/core-workflow-architecture-guide.md` gains sections 5–11 — edges and
handles, a run end to end, the canvas stores/panels, performance and
subscription rules, the `graph-edit` draft-mutation layer, the Kopilot
workflow-builder capability, and what the parity harness gates.

It already cites `catalog/derived-keys.ts` (from #1701), so it was written
against current code rather than needing a staleness pass. I added three rules
to §9's easy-to-get-wrong list, covering what #1701/#1704/#1706 established:

- `applied: false` is the **blocking** vocabulary and never a no-op — a
  changed-nothing mutation is `applied: true, unchanged: true`.
- A node with no manifest belongs on `GraphSummary.readOnlyNodes`, not a
  repeated per-node `info` issue.
- Outputs are enrichment and must return `err` rather than throw, because
  resolution runs before `persistDraft`.

**One thing to know:** §8 documents a perf debug switch as *"design, not
shipped"*, and work matching that description is currently in flight in another
branch (a `workflow/debug/` directory and store-subscription parity scrapes).
The section is honest as written either way, but whoever lands that work should
flip §8 when it ships.
