### PR TITLE
perf(workflow): guard whole-array store subscriptions and add a canvas drag probe

### DIFF
--- a/apps/web/src/components/workflow/canvas/workflow-canvas.tsx
+++ b/apps/web/src/components/workflow/canvas/workflow-canvas.tsx
@@ -48,6 +48,7 @@ import { EmptyTriggerButton } from '~/components/workflow/ui/empty-trigger-butto
 import { GettingStartedOverlay } from '~/components/workflow/ui/getting-started-overlay'
 import HelpLine from '~/components/workflow/ui/helpline'
 import { createCenterOnNodeHandler } from '~/components/workflow/utils'
+import { WorkflowPerfSwitch } from '../debug/perf-switch'
 import { useContextMenu } from '../hooks/use-context-menu'
 import { CanvasNodeInfo } from '../ui/canvas-node-info'
 import { NodeContextMenu } from '../ui/node-context-menu'
@@ -405,6 +406,16 @@ const WorkflowCanvasInner = React.memo<WorkflowCanvasProps>(
           <Panel position='bottom-left'>
             <WorkflowOperators />
           </Panel>
+
+          {/* Dev-only perf probe toggle. Gated on the build constant rather than
+              inside the component so the bundler drops it from production. */}
+          {process.env.NODE_ENV !== 'production' && (
+            <Panel position='bottom-right'>
+              <div className='flex items-center gap-0.5 p-0.5 bg-white/40 dark:bg-white/10 backdrop-blur-sm rounded-lg ring-black/5 ring-1'>
+                <WorkflowPerfSwitch />
+              </div>
+            </Panel>
+          )}
           <CanvasNodeInfo />
         </ReactFlow>
 

--- a/apps/web/src/components/workflow/debug/drag-probe.ts
+++ b/apps/web/src/components/workflow/debug/drag-probe.ts
@@ -1,0 +1,83 @@
+// apps/web/src/components/workflow/debug/drag-probe.ts
+
+import { perfNow, WORKFLOW_PERF_ENABLED } from './perf-flag'
+import { getRenderCounts, resetRenderCounts } from './render-trace'
+
+/** A gap between pointer frames longer than this is a dropped frame (60fps budget). */
+const FRAME_BUDGET_MS = 16.7
+
+interface DragWindow {
+  openedAt: number
+  lastFrameAt: number
+  frames: number
+  droppedFrames: number
+  handlerMs: number
+  setNodesMs: number
+}
+
+let openWindow: DragWindow | null = null
+
+/**
+ * Open a drag measurement window. The gesture is the unit of measurement,
+ * because the subscription regressions this probes for only exist during one.
+ */
+export function startDragWindow(): void {
+  if (!WORKFLOW_PERF_ENABLED) return
+  resetRenderCounts()
+  const openedAt = perfNow()
+  openWindow = {
+    openedAt,
+    lastFrameAt: openedAt,
+    frames: 0,
+    droppedFrames: 0,
+    handlerMs: 0,
+    setNodesMs: 0,
+  }
+}
+
+/**
+ * Record one pointer frame: how long the drag handler ran, how much of that was
+ * `setNodes`, and how long since the previous frame.
+ *
+ * @param frameStartedAt `perfNow()` taken at the top of the drag handler
+ * @param setNodesMs time spent inside `setNodes` during this frame
+ */
+export function recordDragFrame(frameStartedAt: number, setNodesMs: number): void {
+  if (!openWindow) return
+
+  const now = perfNow()
+  if (openWindow.frames > 0 && now - openWindow.lastFrameAt > FRAME_BUDGET_MS) {
+    openWindow.droppedFrames += 1
+  }
+
+  openWindow.lastFrameAt = now
+  openWindow.frames += 1
+  openWindow.handlerMs += now - frameStartedAt
+  openWindow.setNodesMs += setNodesMs
+}
+
+/**
+ * Close the window and emit the report: one `console.table` of per-component
+ * render counts sorted by count, plus one summary line. A component whose
+ * `rendersPerFrame` is ~1 re-rendered on every pointer frame — that component
+ * is the regression.
+ */
+export function endDragWindow(): void {
+  const closed = openWindow
+  if (!closed) return
+  openWindow = null
+
+  const durationMs = perfNow() - closed.openedAt
+  const rows = getRenderCounts().map(({ component, renders }) => ({
+    component,
+    renders,
+    rendersPerFrame: closed.frames > 0 ? Number((renders / closed.frames).toFixed(2)) : 0,
+  }))
+
+  console.table(rows)
+  console.info(
+    `[workflow:perf] drag ${durationMs.toFixed(1)}ms · ${closed.frames} frames · ` +
+      `${closed.droppedFrames} dropped (>${FRAME_BUDGET_MS}ms) · ` +
+      `handler ${closed.handlerMs.toFixed(1)}ms · setNodes ${closed.setNodesMs.toFixed(1)}ms`
+  )
+}

--- a/apps/web/src/components/workflow/debug/index.ts
+++ b/apps/web/src/components/workflow/debug/index.ts
@@ -1,0 +1,10 @@
+// apps/web/src/components/workflow/debug/index.ts
+
+export { endDragWindow, recordDragFrame, startDragWindow } from './drag-probe'
+export { perfNow, WORKFLOW_PERF_ENABLED } from './perf-flag'
+// NOTE: `perf-switch.tsx` is deliberately NOT re-exported here. It pulls in
+// `@auxx/ui` (Radix), and this barrel is imported by plain store/hook modules
+// (`store/use-var-store.ts`, `hooks/use-node-interactions.ts`) that must not
+// reach UI code. Import it from `debug/perf-switch` directly.
+export { getRenderCounts, resetRenderCounts, useRenderTrace } from './render-trace'
+export { measureSync } from './user-timing'

--- a/apps/web/src/components/workflow/debug/perf-flag.ts
+++ b/apps/web/src/components/workflow/debug/perf-flag.ts
@@ -1,0 +1,38 @@
+// apps/web/src/components/workflow/debug/perf-flag.ts
+
+/** `localStorage` key that arms the probes across reloads. */
+export const PERF_STORAGE_KEY = 'workflow:perf'
+
+/**
+ * Is the perf switch armed *right now* — `?perf=1` in the URL or a
+ * `workflow:perf` key in `localStorage`, and never in a production build.
+ *
+ * Live read. Only `WorkflowPerfSwitch` should call this, to render its own
+ * checked state; every probe reads {@link WORKFLOW_PERF_ENABLED} instead.
+ */
+export function isPerfArmed(): boolean {
+  if (process.env.NODE_ENV === 'production') return false
+  if (typeof window === 'undefined') return false
+
+  try {
+    if (new URLSearchParams(window.location.search).get('perf') === '1') return true
+    return window.localStorage.getItem(PERF_STORAGE_KEY) !== null
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Whether the dev-only workflow perf probes are armed for THIS page load.
+ *
+ * Evaluated exactly once, at module evaluation, so that nothing on a render path
+ * — and nothing subscribed to a store — ever pays for the switch itself. A probe
+ * that costs something when it is off would be a memorable way to fail. That is
+ * also why `WorkflowPerfSwitch` reloads the page instead of mutating this.
+ */
+export const WORKFLOW_PERF_ENABLED = isPerfArmed()
+
+/** `performance.now()` when the probes are armed, `0` otherwise. */
+export function perfNow(): number {
+  return WORKFLOW_PERF_ENABLED ? performance.now() : 0
+}

--- a/apps/web/src/components/workflow/debug/perf-switch.tsx
+++ b/apps/web/src/components/workflow/debug/perf-switch.tsx
@@ -1,0 +1,48 @@
+// apps/web/src/components/workflow/debug/perf-switch.tsx
+'use client'
+
+import { ButtonSwitch } from '@auxx/ui/components/button-switch'
+import { useEffect, useState } from 'react'
+import { isPerfArmed, PERF_STORAGE_KEY } from './perf-flag'
+
+/**
+ * Dev-only toggle for the workflow perf probes (`plans/workflow/debug/canvas-performance-and-debug-switch.md` §3).
+ *
+ * **Reloads the page on every flip, by design.** `WORKFLOW_PERF_ENABLED` is read
+ * once at module evaluation precisely so nothing on a render path pays for the
+ * switch when it is off; making it reactive would hand that cost back. A reload
+ * is the honest way to re-read it.
+ *
+ * Flipping also strips `?perf=1` from the URL, so this control is the single
+ * authority once used — otherwise toggling "off" while the query param armed the
+ * probes would appear to do nothing.
+ *
+ * Callers must gate the render on `process.env.NODE_ENV`, not on this component,
+ * so the bundler can eliminate it from production builds entirely.
+ */
+export function WorkflowPerfSwitch() {
+  // Resolved after mount: `localStorage` does not exist during SSR, and seeding
+  // state from it directly would render a different `checked` on the server than
+  // on the client.
+  const [armed, setArmed] = useState(false)
+
+  useEffect(() => {
+    setArmed(isPerfArmed())
+  }, [])
+
+  const handleChange = (next: boolean) => {
+    try {
+      if (next) window.localStorage.setItem(PERF_STORAGE_KEY, '1')
+      else window.localStorage.removeItem(PERF_STORAGE_KEY)
+    } catch {
+      // Private-mode or blocked storage — nothing to persist, so nothing to reload for.
+      return
+    }
+
+    const url = new URL(window.location.href)
+    url.searchParams.delete('perf')
+    window.location.replace(url.toString())
+  }
+
+  return <ButtonSwitch label='Perf probe' checked={armed} onCheckedChange={handleChange} />
+}

--- a/apps/web/src/components/workflow/debug/render-trace.ts
+++ b/apps/web/src/components/workflow/debug/render-trace.ts
@@ -1,0 +1,31 @@
+// apps/web/src/components/workflow/debug/render-trace.ts
+
+import { WORKFLOW_PERF_ENABLED } from './perf-flag'
+
+const renderCounts = new Map<string, number>()
+
+/**
+ * Count a component's renders under `name`. No state, no context, no
+ * subscription — a single `Map` bump during render, and an immediate no-op when
+ * the perf switch is off.
+ *
+ * The read: during a drag, any component whose count approaches the frame count
+ * is re-rendering on every pointer frame, which is the regression this exists to
+ * name. See `docs/core-workflow-architecture-guide.md` §8.
+ */
+export function useRenderTrace(name: string): void {
+  if (!WORKFLOW_PERF_ENABLED) return
+  renderCounts.set(name, (renderCounts.get(name) ?? 0) + 1)
+}
+
+/** Zero every counter — called when a drag window opens. */
+export function resetRenderCounts(): void {
+  renderCounts.clear()
+}
+
+/** Current counters, highest render count first. */
+export function getRenderCounts(): Array<{ component: string; renders: number }> {
+  return [...renderCounts]
+    .map(([component, renders]) => ({ component, renders }))
+    .sort((a, b) => b.renders - a.renders)
+}

--- a/apps/web/src/components/workflow/debug/user-timing.ts
+++ b/apps/web/src/components/workflow/debug/user-timing.ts
@@ -1,0 +1,26 @@
+// apps/web/src/components/workflow/debug/user-timing.ts
+
+import { WORKFLOW_PERF_ENABLED } from './perf-flag'
+
+/**
+ * Run `fn` inside a User Timing measure so a Chrome performance recording
+ * attributes its cost in the Timings track without anyone reading a console.
+ * Returns `fn()` untouched, and calls it directly when the switch is off.
+ *
+ * @param name measure name, e.g. `workflow:updateGraph`
+ */
+export function measureSync<T>(name: string, fn: () => T): T {
+  if (!WORKFLOW_PERF_ENABLED) return fn()
+
+  const startMark = `${name}:start`
+  const endMark = `${name}:end`
+  performance.mark(startMark)
+  try {
+    return fn()
+  } finally {
+    performance.mark(endMark)
+    performance.measure(name, startMark, endMark)
+    performance.clearMarks(startMark)
+    performance.clearMarks(endMark)
+  }
+}

--- a/apps/web/src/components/workflow/edges/custom-edge/index.tsx
+++ b/apps/web/src/components/workflow/edges/custom-edge/index.tsx
@@ -4,6 +4,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import { BaseEdge, EdgeLabelRenderer, type EdgeProps, useReactFlow } from '@xyflow/react'
 import { Plus, Trash2 } from 'lucide-react'
 import { memo, useCallback, useMemo, useState } from 'react'
+import { useRenderTrace } from '~/components/workflow/debug'
 import { useAvailableBlocks, useEdgeInteractions } from '~/components/workflow/hooks'
 import { unifiedNodeRegistry } from '~/components/workflow/nodes/unified-registry'
 import type { EdgeData } from '~/components/workflow/types'
@@ -42,6 +43,8 @@ const CustomEdge = memo<EdgeProps>(
     targetY,
     selected = false,
   }: EdgeProps) => {
+    useRenderTrace('CustomEdge')
+
     // Type guard for edge data with stable defaults
     const edgeData = useMemo(() => {
       const defaultData: EdgeData = {

--- a/apps/web/src/components/workflow/hooks/use-node-interactions.ts
+++ b/apps/web/src/components/workflow/hooks/use-node-interactions.ts
@@ -18,6 +18,12 @@ import {
 import { produce } from 'immer'
 import { useCallback, useRef } from 'react'
 import {
+  endDragWindow,
+  perfNow,
+  recordDragFrame,
+  startDragWindow,
+} from '~/components/workflow/debug'
+import {
   useHelpline,
   useNodesReadOnly,
   useNodeValidation,
@@ -680,6 +686,14 @@ export const useNodesInteractions = () => {
       const { nodes, setNodes } = store.getState()
       e.stopPropagation()
 
+      const frameStartedAt = perfNow()
+      let setNodesMs = 0
+      const applyNodes = (next: FlowNode[]) => {
+        const startedAt = perfNow()
+        setNodes(next)
+        setNodesMs += perfNow() - startedAt
+      }
+
       // Get all selected nodes
       const selectedNodes = nodes.filter((n) => n.selected)
       const isMultiDrag = selectedNodes.length > 1 && selectedNodes.some((n) => n.id === node.id)
@@ -704,7 +718,7 @@ export const useNodesInteractions = () => {
             }
           })
         })
-        setNodes(newNodes)
+        applyNodes(newNodes)
       } else {
         // const { restrict } = handleNodeLoopChildDrag(node)
         // Single node drag - original behavior
@@ -723,11 +737,13 @@ export const useNodesInteractions = () => {
           // }
           currentNode.position = { ...node.position }
         })
-        setNodes(newNodes)
+        applyNodes(newNodes)
       }
 
       // Update helplines during drag
       handleSetHelpline(node)
+
+      recordDragFrame(frameStartedAt, setNodesMs)
     },
     [getNodesReadOnly, store, handleSetHelpline]
   )
@@ -735,6 +751,8 @@ export const useNodesInteractions = () => {
   const handleNodeDragStart = useCallback<OnNodeDrag<FlowNode>>(
     (_event, node) => {
       if (getNodesReadOnly()) return
+
+      startDragWindow()
 
       // Store initial position of the dragged node
       dragNodeStartPosition.current = { x: node.position.x, y: node.position.y }
@@ -795,6 +813,8 @@ export const useNodesInteractions = () => {
       // Reset start positions
       dragNodeStartPosition.current = null
       dragStartPositions.current.clear()
+
+      endDragWindow()
     },
     [getNodesReadOnly, debouncedSave, handleClearHelpline]
   )

--- a/apps/web/src/components/workflow/hooks/use-var-store-sync.ts
+++ b/apps/web/src/components/workflow/hooks/use-var-store-sync.ts
@@ -8,6 +8,30 @@ import { useVarStore } from '../store/use-var-store'
 import type { FlowEdge, FlowNode } from '../types'
 
 /**
+ * Whether two node arrays are equivalent *for variable purposes*.
+ *
+ * A node's coordinates cannot affect any variable, but `handleNodeDrag` replaces
+ * the whole node array on every pointer frame, so whole-array reference equality
+ * never holds during a drag. Comparing each node's `data` reference and
+ * `parentId` (in order, so an id change or a reorder counts as changed) is a
+ * reference scan rather than a deep compare: immer structural sharing in
+ * `use-node-data-update` keeps an untouched node's `data` reference intact.
+ */
+function nodesEqualForVariables(next: FlowNode[], prev: FlowNode[]): boolean {
+  if (next === prev) return true
+  if (next.length !== prev.length) return false
+
+  for (let i = 0; i < next.length; i++) {
+    const a = next[i]
+    const b = prev[i]
+    if (!a || !b) return false
+    if (a.id !== b.id || a.data !== b.data || a.parentId !== b.parentId) return false
+  }
+
+  return true
+}
+
+/**
  * Event-driven sync bridge between ReactFlow and the variable store.
  * Replaces the old 5s polling with RAF-debounced subscription.
  */
@@ -43,8 +67,11 @@ export function useVarStoreSync() {
     syncFromState(store.getState())
 
     const unsub = store.subscribe((state, prevState) => {
-      // Early bail-out: skip pan/zoom/selection (reference equality check)
-      if (state.nodes === prevState.nodes && state.edges === prevState.edges) return
+      // Early bail-out: skip pan/zoom/selection, and skip position-only changes
+      // (a drag frame) — neither can affect a variable.
+      if (state.edges === prevState.edges && nodesEqualForVariables(state.nodes, prevState.nodes)) {
+        return
+      }
 
       // Debounce with RAF to batch rapid changes (e.g., drag operations)
       if (rafId) cancelAnimationFrame(rafId)

--- a/apps/web/src/components/workflow/nodes/shared/base/custom-node.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/base/custom-node.tsx
@@ -3,12 +3,15 @@
 import type { Node, NodeProps } from '@xyflow/react'
 import { useMemo } from 'react'
 import { AppWorkflowNode } from '~/components/workflow/apps/app-workflow-node'
+import { useRenderTrace } from '~/components/workflow/debug'
 import { useRegistryVersion } from '~/components/workflow/hooks'
 import type { BaseNodeData } from '~/components/workflow/types'
 import { NoteNode } from '../../core/note'
 import { unifiedNodeRegistry } from '../../unified-registry'
 
 const StandardNode = (props: NodeProps<Node<BaseNodeData>>) => {
+  useRenderTrace('StandardNode')
+
   const nodeData = props.data
   const nodeType = nodeData.type
 

--- a/apps/web/src/components/workflow/panels/property-panel.tsx
+++ b/apps/web/src/components/workflow/panels/property-panel.tsx
@@ -4,6 +4,7 @@ import { useStore } from '@xyflow/react'
 import React, { useEffect, useMemo } from 'react'
 import { useShallow } from 'zustand/shallow'
 import { isWorkflowNode, NodeType } from '~/components/workflow/types'
+import { useRenderTrace } from '../debug'
 import { useRegistryVersion } from '../hooks'
 import { unifiedNodeRegistry } from '../nodes/unified-registry'
 import { usePanelStore } from '../store/panel-store'
@@ -23,6 +24,8 @@ interface NodePanelBodyProps {
  * The header is rendered by the node panel itself via `PanelFrameHeader`.
  */
 const NodePanelBody: React.FC<NodePanelBodyProps> = React.memo(({ nodeId }) => {
+  useRenderTrace('NodePanelBody')
+
   const closeDrawer = usePanelStore((state) => state.closeDrawer)
 
   // Subscribe to registry updates to detect when app blocks are loaded

--- a/apps/web/src/components/workflow/parity/monorepo-paths.ts
+++ b/apps/web/src/components/workflow/parity/monorepo-paths.ts
@@ -6,12 +6,13 @@ import { fileURLToPath } from 'node:url'
 
 /**
  * Shared filesystem plumbing for the parity suite's static readers
- * (`engine-write-scrape.ts`, `builder-declared-keys.ts`) — both need to locate
- * the monorepo root and read/strip source files, and neither should carry its
- * own copy of that logic. Split out of `engine-contract.ts` when it was
- * deleted (node-catalog Phase 1 exit criterion) so the two readers it used to
- * house — one genuinely ENGINE-side, one BUILDER-side — don't depend on each
- * other just to find a path.
+ * (`engine-write-scrape.ts`, `builder-declared-keys.ts`,
+ * `store-subscription-scrape.test.ts`) — all need to locate the monorepo root
+ * and read/strip source files, and none should carry its own copy of that
+ * logic. Split out of `engine-contract.ts` when it was deleted (node-catalog
+ * Phase 1 exit criterion) so the two readers it used to house — one genuinely
+ * ENGINE-side, one BUILDER-side — don't depend on each other just to find a
+ * path.
  */
 
 /** Walk up from this file until the monorepo root (the one with `packages/lib`). */
@@ -28,12 +29,38 @@ export function repoRoot(): string {
 export const ENGINE_ROOT = join(repoRoot(), 'packages/lib/src/workflow-engine')
 export const BUILDER_ROOT = join(repoRoot(), 'apps/web/src/components/workflow/nodes')
 
-/** List every non-test `.ts` source file under `dir`, recursively. */
-export function listSources(dir: string, out: string[] = []): string[] {
+/**
+ * The whole builder tree, not just its node definitions.
+ *
+ * `BUILDER_ROOT` is deliberately narrower (`.../workflow/nodes`) because the
+ * builder↔engine contract only lives in the node folders. The store-subscription
+ * scrape (`store-subscription-scrape.test.ts`) has to see the canvas, panels and
+ * hooks too, and those sit beside `nodes/`, not under it.
+ */
+export const WORKFLOW_ROOT = join(repoRoot(), 'apps/web/src/components/workflow')
+
+/**
+ * List every non-test source file under `dir`, recursively.
+ *
+ * `extensions` defaults to `.ts` alone — the engine and node-catalog readers
+ * that predate this parameter scan pure-TypeScript trees and must keep
+ * ignoring React files. Pass `['.ts', '.tsx']` to include components; the
+ * test-file exclusion covers both suffixes either way.
+ *
+ * @param dir - Directory to walk.
+ * @param extensions - File suffixes to collect (matched with `endsWith`).
+ * @param out - Accumulator, supplied by the recursion.
+ */
+export function listSources(
+  dir: string,
+  extensions: readonly string[] = ['.ts'],
+  out: string[] = []
+): string[] {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry)
-    if (statSync(full).isDirectory()) listSources(full, out)
-    else if (full.endsWith('.ts') && !/\.(test|spec)\.ts$/.test(full)) out.push(full)
+    if (statSync(full).isDirectory()) listSources(full, extensions, out)
+    else if (extensions.some((ext) => full.endsWith(ext)) && !/\.(test|spec)\.tsx?$/.test(full))
+      out.push(full)
   }
   return out
 }

--- a/apps/web/src/components/workflow/parity/store-subscription-scrape.test.ts
+++ b/apps/web/src/components/workflow/parity/store-subscription-scrape.test.ts
@@ -1,0 +1,155 @@
+// apps/web/src/components/workflow/parity/store-subscription-scrape.test.ts
+
+import { readFileSync } from 'node:fs'
+import { relative } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { listSources, stripComments, WORKFLOW_ROOT } from './monorepo-paths'
+
+/**
+ * CI guardrail for the builder's single worst performance regression class.
+ *
+ * ── THE RULE ────────────────────────────────────────────────────────────────
+ * Never subscribe to React Flow's whole node or edge array from inside
+ * `apps/web/src/components/workflow/`:
+ *
+ * ```ts
+ * const nodes = useStore((state) => state.nodes)   // ← banned
+ * const edges = useStore((s) => s.edges)           // ← banned
+ * ```
+ *
+ * React Flow replaces `state.nodes` with a NEW array on every pointer frame of
+ * a drag (~60/s — `handleNodeDrag` in `hooks/use-node-interactions.ts` rebuilds
+ * the array through `produce()` per frame). One such subscription therefore
+ * re-renders its component for the entire duration of every node drag,
+ * regardless of whether that component cares about positions.
+ *
+ * This is documented in `docs/core-workflow-architecture-guide.md` §8, but a
+ * doc does not fail a build. The regression is invisible in review (the diff is
+ * one more `useStore` call), invisible in tests (nothing asserts render counts)
+ * and only reproduces on a graph big enough to feel it — which is exactly the
+ * profile of a rule that needs a machine to enforce it.
+ *
+ * ── WHY A TEXTUAL SCRAPE ────────────────────────────────────────────────────
+ * Same reason as `engine-write-scrape.ts`, which the repo already accepts: the
+ * property being asserted is about SOURCE SHAPE, not runtime behaviour. There
+ * is nothing to execute — a render-count assertion would need a mounted canvas,
+ * a real React Flow provider and a synthesized drag gesture to observe what one
+ * regex sees for free. `stripComments()` runs first so a banned line quoted in
+ * a doc block (this one included) is not read as code.
+ *
+ * ── WHAT IT MATCHES ─────────────────────────────────────────────────────────
+ * The SELECTOR BODY, not the import name. `useStore` reaches this tree under at
+ * least three identities — React Flow's `useStore`, the same thing aliased
+ * (`useStore as useReactFlowStore` in `hooks/use-node-data-update.ts`), and
+ * Zustand's own `useStore` (`shared/test-events/use-test-event-listener.ts`) —
+ * so keying on the import name would miss two of the three. Instead:
+ *
+ *   1. an arrow passed to a callee whose name contains `Store` or `Shallow`,
+ *      whose body is the parameter followed by a bare `.nodes` / `.edges`; or
+ *   2. a standalone arrow whose parameter is explicitly typed `ReactFlowState`
+ *      and whose body is a bare `.nodes` / `.edges` — the module-level named
+ *      selector form used in `ui/canvas-node-info.tsx`.
+ *
+ * "Bare" means nothing follows: `state.nodes.length` (a primitive — only
+ * re-renders when the count changes) and `state.nodes.find(...)` are NOT
+ * matched. Both arms deliberately accept false negatives over false positives.
+ * The job is to stop the obvious case, not to be a type checker; a rule that
+ * fires on innocent code gets suppressed and then ignored.
+ *
+ * ── WHAT THIS DOES NOT CATCH ────────────────────────────────────────────────
+ * Say it out loud so the next person doesn't over-trust a green run:
+ *
+ *  - **Expensive `useShallow` selector BODIES.** `useShallow` (and a `shallow`
+ *    equality argument) suppresses the RE-RENDER, never the selector body — the
+ *    body still runs on every store update, drag frames included.
+ *    `hooks/use-available-variables.tsx` rebuilds a full node-title map inside
+ *    one and defends itself with a manual hash ref; `panels/property-panel.tsx`,
+ *    `panels/workflow-panel-drawer.tsx`, `hooks/use-variable.ts` and
+ *    `nodes/core/manual/connected-inputs-editor.tsx` all do a `state.nodes.find`
+ *    per store update. All of these are legal here and all are unmeasured. See
+ *    `plans/workflow/debug/canvas-performance-and-debug-switch.md` §2.3/§3.
+ *  - **`store.getState().nodes` inside a callback.** That is a read, not a
+ *    subscription — it is the correct way to touch the array from an event
+ *    handler, it is used all over this tree via `useStoreApi()`, and it must
+ *    stay legal.
+ *  - **Anything reached through a custom hook wrapper.** A hook that itself
+ *    subscribes and returns the array launders the violation past this scan;
+ *    only the hook's own file can be caught, and only if it is written inline.
+ *  - **Block-bodied selectors** (`(s) => { return s.nodes }`) and selectors
+ *    passed by reference from another module.
+ *
+ * ── THE ALLOWLIST ───────────────────────────────────────────────────────────
+ * Same convention as `contract-drift-allowlist.ts`: one entry per known
+ * violation, each with a one-line reason, so the test can land green without
+ * weakening the assertion. It is EMPTY today — §5 of the plan above removed the
+ * only entry (`ui/variables/variable-explorer-enhanced.tsx`, which subscribed
+ * to the node array for a loop-context conversion that was never implemented).
+ * An empty allowlist is not an invitation to delete it: it is the landing zone
+ * for the next entry, and every addition needs a reason and, ideally, the plan
+ * section that removes it again. An allowlist that grows silently is worse than
+ * no test at all.
+ */
+
+/**
+ * Files permitted to subscribe to the whole node/edge array, keyed by path
+ * relative to `WORKFLOW_ROOT`. Every value is the reason the entry exists.
+ */
+const ALLOWLIST: Record<string, string> = {
+  // (empty — keep the shape, add entries with a reason and a removal plan)
+}
+
+/** Arrow selector handed to a `*Store*` / `*Shallow*` callee: `useStore((s) => s.nodes)`. */
+const INLINE_SELECTOR =
+  /\b[A-Za-z_$][\w$]*(?:[Ss]tore|[Ss]hallow)[\w$]*\s*(?:<[^<>]*>)?\s*\(\s*\(?\s*([A-Za-z_$][\w$]*)\s*(?::[^)=]*)?\)?\s*=>\s*\1\s*\.\s*(nodes|edges)\b(?!\s*[.[])/g
+
+/** Named selector typed against React Flow: `const sel = (s: ReactFlowState) => s.nodes`. */
+const NAMED_SELECTOR =
+  /\(\s*([A-Za-z_$][\w$]*)\s*:\s*ReactFlowState[^)]*\)\s*=>\s*\1\s*\.\s*(nodes|edges)\b(?!\s*[.[])/g
+
+interface Violation {
+  file: string
+  line: number
+  text: string
+}
+
+/** Scan one already-comment-stripped source for both selector shapes. */
+function findViolations(file: string, source: string): Violation[] {
+  const found: Violation[] = []
+  for (const pattern of [INLINE_SELECTOR, NAMED_SELECTOR]) {
+    pattern.lastIndex = 0
+    let match = pattern.exec(source)
+    while (match) {
+      found.push({
+        file,
+        line: source.slice(0, match.index).split('\n').length,
+        text: match[0].replace(/\s+/g, ' '),
+      })
+      match = pattern.exec(source)
+    }
+  }
+  return found
+}
+
+describe('workflow store subscriptions', () => {
+  const violations = listSources(WORKFLOW_ROOT, ['.ts', '.tsx']).flatMap((path) =>
+    findViolations(relative(WORKFLOW_ROOT, path), stripComments(readFileSync(path, 'utf8')))
+  )
+
+  it('never subscribes to the whole node or edge array', () => {
+    const unlisted = violations.filter((v) => !(v.file in ALLOWLIST))
+    expect(
+      unlisted.map((v) => `${v.file}:${v.line}  ${v.text}`),
+      'React Flow replaces state.nodes/state.edges every drag frame — select a narrower ' +
+        'slice, read via store.getState() in a callback, or resolve it from useVarStore'
+    ).toEqual([])
+  })
+
+  it('lists no already-fixed files in the allowlist', () => {
+    const offending = new Set(violations.map((v) => v.file))
+    const stale = Object.keys(ALLOWLIST).filter((file) => !offending.has(file))
+    expect(
+      stale,
+      'these files no longer violate the rule — delete their allowlist entries'
+    ).toEqual([])
+  })
+})

--- a/apps/web/src/components/workflow/store/use-var-store.ts
+++ b/apps/web/src/components/workflow/store/use-var-store.ts
@@ -16,6 +16,7 @@ import { immer } from 'zustand/middleware/immer'
 import { BaseType, type UnifiedVariable } from '~/components/workflow/types'
 import { cloneAndRewriteVariableIds } from '~/components/workflow/utils/variable-cloning'
 import { getNodeIdFromVariableId } from '~/components/workflow/utils/variable-utils'
+import { measureSync } from '../debug'
 import type { EnvVar } from '../types'
 import {
   buildVariableIndex,
@@ -370,143 +371,152 @@ export const useVarStore = create<VarStoreState>()(
         },
 
         updateGraph: (nodes: NodeMeta[], edges: EdgeMeta[]) => {
-          const state = get()
+          measureSync('workflow:updateGraph', () => {
+            const state = get()
 
-          // Detect structural changes (nodes added/removed, edges changed, parentIds changed)
-          const prevNodeIds = new Set(state.graph.nodes.map((n) => n.id))
-          const newNodeIds = new Set(nodes.map((n) => n.id))
-          const nodeMap = new Map(nodes.map((n) => [n.id, n]))
+            // Detect structural changes (nodes added/removed, edges changed, parentIds changed)
+            const prevNodeMap = new Map(state.graph.nodes.map((n) => [n.id, n]))
+            const newNodeIds = new Set(nodes.map((n) => n.id))
+            const nodeMap = new Map(nodes.map((n) => [n.id, n]))
 
-          const nodesChanged =
-            prevNodeIds.size !== newNodeIds.size ||
-            [...prevNodeIds].some((id) => !newNodeIds.has(id)) ||
-            [...newNodeIds].some((id) => !prevNodeIds.has(id))
+            const nodesChanged =
+              prevNodeMap.size !== newNodeIds.size || nodes.some((n) => !prevNodeMap.has(n.id))
 
-          const edgesChanged =
-            state.graph.edges.length !== edges.length ||
-            state.graph.edges.some(
-              (e, i) =>
-                e.id !== edges[i]?.id ||
-                e.source !== edges[i]?.source ||
-                e.target !== edges[i]?.target
-            )
+            const edgesChanged =
+              state.graph.edges.length !== edges.length ||
+              state.graph.edges.some(
+                (e, i) =>
+                  e.id !== edges[i]?.id ||
+                  e.source !== edges[i]?.source ||
+                  e.target !== edges[i]?.target
+              )
 
-          const parentIdsChanged = nodes.some((n) => {
-            const prev = state.graph.nodes.find((p) => p.id === n.id)
-            return prev && prev.parentId !== n.parentId
-          })
+            const parentIdsChanged = nodes.some((n) => {
+              const prev = prevNodeMap.get(n.id)
+              return !!prev && prev.parentId !== n.parentId
+            })
 
-          const structureChanged = nodesChanged || edgesChanged
+            const structureChanged = nodesChanged || edgesChanged
 
-          // Rebuild graph maps if structure changed
-          let upstreamMap = state.upstreamMap
-          let downstreamMap = state.downstreamMap
-          if (structureChanged) {
-            upstreamMap = buildUpstreamMap(edges, nodes)
-            downstreamMap = buildDownstreamMap(upstreamMap)
-          }
-
-          // Rebuild loop ancestry if parentIds or structure changed
-          let loopAncestry = state.loopAncestry
-          if (structureChanged || parentIdsChanged) {
-            loopAncestry = computeLoopAncestry(nodes)
-          }
-
-          // Compute outputs in topological order for changed nodes
-          const topoOrder = topologicalSort(nodes, edges)
-          const newNodeOutputs = new Map(state.nodeOutputs)
-
-          // Remove deleted nodes
-          for (const [nodeId] of state.nodeOutputs) {
-            if (!newNodeIds.has(nodeId)) {
-              newNodeOutputs.delete(nodeId)
+            // Rebuild graph maps if structure changed
+            let upstreamMap = state.upstreamMap
+            let downstreamMap = state.downstreamMap
+            if (structureChanged) {
+              upstreamMap = buildUpstreamMap(edges, nodes)
+              downstreamMap = buildDownstreamMap(upstreamMap)
             }
-          }
 
-          // Build resolver that reads from already-computed outputs
-          const resolveVariable = (variableId: string): UnifiedVariable | undefined => {
-            const sourceNodeId = getNodeIdFromVariableId(variableId)
-            const outputs = newNodeOutputs.get(sourceNodeId)
-            if (!outputs) return undefined
-            return findVariableInTree(outputs.variables, variableId)
-          }
+            // Rebuild loop ancestry if parentIds or structure changed
+            let loopAncestry = state.loopAncestry
+            if (structureChanged || parentIdsChanged) {
+              loopAncestry = computeLoopAncestry(nodes)
+            }
 
-          // Compute outputs in topo order for nodes whose data changed
-          let outputsChanged = false
-          for (const nodeId of topoOrder) {
-            const node = nodeMap.get(nodeId)
-            if (!node) continue
-
-            const existing = newNodeOutputs.get(nodeId)
-            // Skip if data reference hasn't changed (Immer structural sharing)
-            if (existing && existing.dataRef === node.data) continue
-
-            const nodeType = node.data?.type || node.type || ''
-            const outputs = computeNodeOutputs(
-              nodeId,
-              nodeType,
-              node.data,
-              state.resources,
-              resolveVariable
+            // Compute outputs in topological order for changed nodes
+            const topoOrder = measureSync('workflow:topologicalSort', () =>
+              topologicalSort(nodes, edges)
             )
+            const newNodeOutputs = new Map(state.nodeOutputs)
 
-            newNodeOutputs.set(nodeId, {
-              type: nodeType,
-              dataRef: node.data,
-              variables: outputs,
-            })
-            outputsChanged = true
-          }
-
-          // Skip availability + index recomputation if nothing changed
-          if (!outputsChanged && !structureChanged && !parentIdsChanged) {
-            set((s) => {
-              s.graph = { nodes, edges }
-            })
-            return
-          }
-
-          // Compute availability for all nodes
-          const newAvailability = new Map<string, AvailabilityEntry>()
-          for (const node of nodes) {
-            const vars = computeNodeAvailability(
-              node.id,
-              newNodeOutputs,
-              upstreamMap,
-              loopAncestry,
-              { nodes },
-              state.environmentVariables,
-              state.systemVariables,
-              resolveVariable
-            )
-            newAvailability.set(node.id, { variables: vars })
-          }
-
-          // Rebuild variable index
-          const newVariableIndex = buildVariableIndex(
-            newNodeOutputs,
-            state.environmentVariables,
-            state.systemVariables
-          )
-
-          // Also add loop iteration variables to the index
-          for (const node of nodes) {
-            const loopVars = computeLoopVariables(node.id, loopAncestry, { nodes }, resolveVariable)
-            for (const loopVar of loopVars) {
-              for (const flat of flattenVariableForStorage(loopVar)) {
-                newVariableIndex.set(flat.id, flat)
+            // Remove deleted nodes
+            for (const [nodeId] of state.nodeOutputs) {
+              if (!newNodeIds.has(nodeId)) {
+                newNodeOutputs.delete(nodeId)
               }
             }
-          }
 
-          set((s) => {
-            s.graph = { nodes, edges }
-            s.nodeOutputs = newNodeOutputs
-            s.upstreamMap = upstreamMap
-            s.downstreamMap = downstreamMap
-            s.loopAncestry = loopAncestry
-            s.availability = newAvailability
-            s.variableIndex = newVariableIndex
+            // Build resolver that reads from already-computed outputs
+            const resolveVariable = (variableId: string): UnifiedVariable | undefined => {
+              const sourceNodeId = getNodeIdFromVariableId(variableId)
+              const outputs = newNodeOutputs.get(sourceNodeId)
+              if (!outputs) return undefined
+              return findVariableInTree(outputs.variables, variableId)
+            }
+
+            // Compute outputs in topo order for nodes whose data changed
+            let outputsChanged = false
+            measureSync('workflow:computeNodeOutputs', () => {
+              for (const nodeId of topoOrder) {
+                const node = nodeMap.get(nodeId)
+                if (!node) continue
+
+                const existing = newNodeOutputs.get(nodeId)
+                // Skip if data reference hasn't changed (Immer structural sharing)
+                if (existing && existing.dataRef === node.data) continue
+
+                const nodeType = node.data?.type || node.type || ''
+                const outputs = computeNodeOutputs(
+                  nodeId,
+                  nodeType,
+                  node.data,
+                  state.resources,
+                  resolveVariable
+                )
+
+                newNodeOutputs.set(nodeId, {
+                  type: nodeType,
+                  dataRef: node.data,
+                  variables: outputs,
+                })
+                outputsChanged = true
+              }
+            })
+
+            // Skip availability + index recomputation if nothing changed
+            if (!outputsChanged && !structureChanged && !parentIdsChanged) {
+              set((s) => {
+                s.graph = { nodes, edges }
+              })
+              return
+            }
+
+            // Compute availability for all nodes
+            const newAvailability = new Map<string, AvailabilityEntry>()
+            for (const node of nodes) {
+              const vars = computeNodeAvailability(
+                node.id,
+                newNodeOutputs,
+                upstreamMap,
+                loopAncestry,
+                { nodes },
+                state.environmentVariables,
+                state.systemVariables,
+                resolveVariable
+              )
+              newAvailability.set(node.id, { variables: vars })
+            }
+
+            // Rebuild variable index
+            const newVariableIndex = buildVariableIndex(
+              newNodeOutputs,
+              state.environmentVariables,
+              state.systemVariables
+            )
+
+            // Also add loop iteration variables to the index
+            for (const node of nodes) {
+              const loopVars = computeLoopVariables(
+                node.id,
+                loopAncestry,
+                { nodes },
+                resolveVariable
+              )
+              for (const loopVar of loopVars) {
+                for (const flat of flattenVariableForStorage(loopVar)) {
+                  newVariableIndex.set(flat.id, flat)
+                }
+              }
+            }
+
+            set((s) => {
+              s.graph = { nodes, edges }
+              s.nodeOutputs = newNodeOutputs
+              s.upstreamMap = upstreamMap
+              s.downstreamMap = downstreamMap
+              s.loopAncestry = loopAncestry
+              s.availability = newAvailability
+              s.variableIndex = newVariableIndex
+            })
           })
         },
 

--- a/apps/web/src/components/workflow/ui/variables/variable-explorer-enhanced.tsx
+++ b/apps/web/src/components/workflow/ui/variables/variable-explorer-enhanced.tsx
@@ -16,7 +16,6 @@ import {
 import { Kbd } from '@auxx/ui/components/kbd'
 import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { cn } from '@auxx/ui/lib/utils'
-import { useStore } from '@xyflow/react'
 import { Check, ChevronLeft, ChevronRight, Copy, Search } from 'lucide-react'
 import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -146,9 +145,6 @@ export const VariableExplorerEnhanced: React.FC<VariableExplorerEnhancedProps> =
 
   const { variables, groups, allVariables } = useAvailableVariables({ nodeId })
 
-  // Get nodes from React Flow store for loop context resolution
-  const nodes = useStore((state) => state.nodes)
-
   // Performance optimizations
   const debouncedSearch = useDebounce(search, CONSTANTS.DEBOUNCE_MS)
 
@@ -261,8 +257,14 @@ export const VariableExplorerEnhanced: React.FC<VariableExplorerEnhancedProps> =
     (variable: UnifiedVariable) => {
       const finalVariable = variable
 
-      // Try to convert array[*] notation to loop.item if inside a loop
-      // const convertedVariable = convertArrayWildcardToLoopItem(variable, nodeId, nodes)
+      // Try to convert array[*] notation to loop.item if inside a loop.
+      // Never implemented — `convertArrayWildcardToLoopItem` does not exist anywhere in
+      // the tree (only `convert-array-wildcard.test.ts` describes the intended logic).
+      // Whoever revives it must read loop context from `useVarStore`'s `loopAncestry`
+      // map, NOT from React Flow's node array: React Flow replaces `state.nodes` with a
+      // new array on every drag frame, so subscribing to it re-renders every open
+      // explorer ~60x/s for the whole duration of every node drag.
+      // const convertedVariable = convertArrayWildcardToLoopItem(variable, nodeId)
 
       // if (convertedVariable) {
       //   finalVariable = convertedVariable

--- a/docs/core-workflow-architecture-guide.md
+++ b/docs/core-workflow-architecture-guide.md
@@ -515,43 +515,63 @@ The mitigations in the tree today are drag gates, not fixes:
 `store/panel-store.ts:350` drops `selection:changed` while `isDragging` (else the
 panel opens mid-drag and re-renders the editor shell) and re-opens it 50 ms after
 `drag:ended`; `useOnViewportChange` is debounced 300 ms. **Read `isDragging` as
-evidence that something downstream is too expensive**, not as architecture. Two
-real fixes are available and unclaimed: skip the var-store sync when only
-`position` changed, and make the parent-id check a map lookup.
+evidence that something downstream is too expensive**, not as architecture.
 
-### There is no perf debug switch today
+Both cheap fixes have since shipped: `use-var-store-sync.ts` now bails when only
+node *positions* (or selection) changed, so a drag frame never reaches the
+`topologicalSort`, and the parent-id check is a map lookup. What remains
+per-frame is the `produce()` rebuild itself — and see the measurement below
+before assuming that is worth removing.
 
-Worth stating plainly, because it keeps getting assumed: nothing in the tree or
-in git history ever shipped one. `hooks/use-variable-performance.ts` is a
-`useDebounce` and nothing else, and `canvas/workflow-canvas.tsx:20` has a
-commented-out `DevTools` import pointing at a `~/components/devtools` that does
-not exist. Measuring today means driving React DevTools' Profiler by hand, which
-is why regressions land.
+### The perf switch — how to use it
 
-### Proposed switch (design, not shipped)
+Dev-only, and gated on `process.env.NODE_ENV` at the call site so it is
+eliminated from production builds entirely.
 
-One dev-only flag, three probes, one report. Kept here so the next person builds
-*this* rather than another ad-hoc `console.log` pass.
+- **Arm it** with the **Perf probe** toggle in the canvas's bottom-right panel,
+  or `?perf=1`, or a `workflow:perf` key in `localStorage`. The toggle writes
+  `localStorage` and reloads: `WORKFLOW_PERF_ENABLED` (`debug/perf-flag.ts`) is
+  read **once** at module evaluation precisely so nothing on a render path pays
+  for the switch when it is off, and a reload is the honest way to re-read it.
+- **Drag a node.** On `dragStop` the probe prints one `console.table` of render
+  counts plus a summary line: gesture duration, frames, dropped frames
+  (inter-frame delta > 16.7 ms), cumulative handler time and cumulative
+  `setNodes` time.
+- **The read:** a component whose `rendersPerFrame` tracks the *number of
+  affected elements* is normal; one that stays pinned regardless of which node
+  you drag is rendering repeatedly per frame, which is the bug shape.
+- `debug/user-timing.ts` also marks `updateGraph` / `topologicalSort` /
+  `computeNodeOutputs`, so a Chrome performance recording attributes them in its
+  Timings track without any console reading.
 
-- **Gate** — `?perf=1` or `localStorage['workflow:perf']`, read **once** into a
-  module-level const, and `&& process.env.NODE_ENV !== 'production'`. Reading the
-  flag must never be part of a render path, or the switch becomes its own cost.
-- **Probe 1 — render attribution.** `useRenderTrace('VariableExplorer')` bumps a
-  module counter keyed by name. No state, no re-render.
-- **Probe 2 — the drag window.** `handleNodeDragStart` opens a window;
-  `handleNodeDragStop` closes it and reports: frames, dropped frames
-  (`performance.now()` deltas > 16.7 ms), cumulative time inside `setNodes`, and
-  the per-component render counts collected since `dragStart`. One
-  `console.table`, sorted by render count — the offending subscription is
-  whatever sits at the top with a count equal to the frame count.
-- **Probe 3 — User Timing marks.** `performance.mark`/`measure` around
-  `updateGraph`, `computeNodeOutputs` and `topologicalSort`, so a Chrome
-  performance recording attributes the cost in its Timings track without any
-  console reading.
+### What the first measurement said
 
-The acceptance bar for the switch: on a 50-node graph, dragging one node should
-show render counts in the low tens, not ~60 × the number of mounted panels. Any
-component whose count tracks the frame count is the regression.
+One node dragged for ~800 ms on an 18-node / 19-edge graph, dev build:
+
+```
+812.7ms · 39 frames · 21 dropped · handler 21.9ms · setNodes 11.5ms
+StandardNode 158 renders (4.05/frame) · CustomEdge 96 renders (2.46/frame)
+```
+
+**The drag handler is not the bottleneck.** 21.9 ms over 39 frames is 0.56 ms
+per frame — 3.4 % of a 16.7 ms budget. Any plan that begins "rewrite the drag
+pipeline so it stops rebuilding the array every frame" is optimizing 3 % of a
+frame; that hypothesis is not supported, and the unwired `onNodesChange` in
+`canvas/workflow-canvas.tsx` is a curiosity rather than a cost.
+
+**One node dragged should re-render one node per frame.** `StandardNode` sat at
+4.04 and 4.05 across two drags while `CustomEdge` moved 6.39 → 2.46 with the
+dragged node's edge count. Edges tracking connectivity is expected; a node count
+pinned across different nodes points at the *same* instance rendering ~4× per
+frame. React StrictMode (`next.config.ts`) doubles renders in dev, so read that
+as ~2 logical renders where 1 would do.
+
+**Treat the dropped-frame count as contaminated.** That run had an unminified
+dev bundle, StrictMode, DevTools attached over CDP, and console log forwarding
+all inflating frame time. 54 % dropped frames under those conditions is not
+evidence of a production problem. Re-measure with DevTools closed before
+concluding anything from it, and note the render counters are keyed by component
+*name*, not instance — which is why "4.05" above is an inference, not a fact.
 
 ---
 


### PR DESCRIPTION
## Why

The workflow canvas has repeatedly regressed by someone subscribing to React Flow's whole node array. React Flow replaces `state.nodes` on every drag frame (~60/s), so one such subscription re-renders that component for the duration of every node drag. It looks like one more `useStore` call in review, and only reproduces on a graph large enough to feel it.

This makes that class of regression a build failure, takes two cheap correctness wins, and adds the instrumentation needed to tell whether any of it actually matters.

## What

**Guardrail** — `parity/store-subscription-scrape.test.ts` fails on `useStore((s) => s.nodes)` / `s.edges` anywhere under `components/workflow/`. Textual scrape, modelled on the existing `engine-write-scrape.ts` precedent. `monorepo-paths.ts` grew an extension parameter (existing callers untouched, still `.ts`-only) and a `WORKFLOW_ROOT`.

The allowlist is **empty**, and the test's doc comment names what it deliberately cannot see: shallow-guarded selector *bodies*, `store.getState().nodes` in callbacks, and custom hook wrappers.

**The one real offender** — `variable-explorer-enhanced.tsx` dropped its `state.nodes` subscription. Worth noting the value was entirely dead: its only consumer was a commented-out call to `convertArrayWildcardToLoopItem`, a function that has never existed in this repo. Biome had flagged it as unused, but that rule is a warning and `pnpm lint` runs errors-only. The fix was deletion, not re-plumbing.

**Two cheap fixes** — `use-var-store-sync` now bails when only node positions *or selection* changed, so a drag frame never reaches `topologicalSort`. `updateGraph`'s parent-id check is a map lookup instead of a `find` nested inside a `some` (O(n²) → O(n)).

**The probe** — a dev-only `debug/` module behind a flag read **once** at module scope, so nothing on a render path pays for it when off: render counters, a `dragStart`→`dragStop` window reporting frames / dropped frames / handler and `setNodes` time, and User Timing marks around `updateGraph` / `topologicalSort` / `computeNodeOutputs`. The **Perf probe** toggle sits in a new bottom-right canvas panel gated on `process.env.NODE_ENV` at the call site, so the bundler eliminates it from production. It flips `localStorage['workflow:perf']` and reloads — deliberately, since making the flag reactive would hand back the cost the module-scope read exists to avoid.

## The measurement, and what it killed

One node dragged ~800ms on an 18-node / 19-edge graph, dev build:

```
812.7ms · 39 frames · 21 dropped · handler 21.9ms · setNodes 11.5ms
StandardNode 158 renders (4.05/frame) · CustomEdge 96 renders (2.46/frame)
```

**The drag handler is not the bottleneck.** 21.9ms over 39 frames is 0.56ms/frame — **3.4% of a 16.7ms budget**. I had this repo's per-frame `produce()` rebuild pegged as the main prize; rewiring the drag pipeline would win back half a millisecond. That hypothesis is dead and the guide now says so.

**Read the dropped-frame count as contaminated**: StrictMode, an unminified dev bundle, DevTools attached over CDP, and console log forwarding were all inflating frame time. 54% dropped frames under those conditions is not evidence of a production problem.

**One open lead**: `StandardNode` sat at 4.04 and 4.05 across two drags while `CustomEdge` moved 6.39 → 2.46 with the dragged node's connectivity. Edges tracking connectivity is expected; a node count pinned across *different* dragged nodes suggests the same instance rendering ~4×/frame (~2 logical, StrictMode doubles it) where 1 would do. Not chased here — the counters are keyed by component name rather than instance, so that remains an inference.

## Verification

- `vitest run src/components/workflow` — 20 files / 137 tests pass
- `typecheck-ratchet --package web` — `no new type errors (0 total, baseline 0)`
- Guardrail confirmed to fire: introduced a violating file, watched it fail with the intended message, removed it, confirmed green
- Perf switch verified in the running app — renders bottom-right, arms, and emits its table on drag

Biome reports three `noUnusedVariables` / `useExhaustiveDependencies` warnings in `canvas/`; all three reproduce at `HEAD` on untouched lines.