### PR TITLE
fix(kopilot): validate a record deep-link id instead of casting it

### DIFF
--- a/apps/web/src/components/kopilot/ui/messages/auxx-inline-link.tsx
+++ b/apps/web/src/components/kopilot/ui/messages/auxx-inline-link.tsx
@@ -4,7 +4,7 @@
 
 import type { ActorId } from '@auxx/types/actor'
 import { isActorId } from '@auxx/types/actor'
-import type { RecordId } from '@auxx/types/resource'
+import { isRecordId, type RecordId } from '@auxx/types/resource'
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@auxx/ui/components/hover-card'
 import { cn } from '@auxx/ui/lib/utils'
 import { ExternalLink, FileText, type LucideIcon } from 'lucide-react'
@@ -34,7 +34,16 @@ export function AuxxInlineLink({ href, label, snapshot }: AuxxInlineLinkProps) {
 
   switch (parsed.kind) {
     case 'record':
-      return <RecordChip recordId={parsed.id as RecordId} />
+      // Validate, don't cast. A model naming a WORKFLOW NODE
+      // (`auxx://record/crud-YPeyf8rneRJPTBBbpVm0z`) satisfies the href grammar
+      // but is not a `<defId>:<instId>` pair, and an unchecked cast reaches
+      // `parseRecordId` — which console.errors on EVERY render of the chip.
+      // Same shape as the `actor` arm below.
+      return isRecordId(parsed.id) ? (
+        <RecordChip recordId={parsed.id} />
+      ) : (
+        <FallbackChip label={label} />
+      )
     case 'thread':
       return <ThreadChip threadId={parsed.id} />
     case 'task':


### PR DESCRIPTION
## What

`auxx://record/<id>` was cast straight through (`parsed.id as RecordId`) into `RecordChip`.

A model naming a workflow **node** — `auxx://record/crud-YPeyf8rneRJPTBBbpVm0z`, seen verbatim in a real builder session — satisfies the href grammar but is not a `<defId>:<instId>` pair. The unchecked cast reaches `parseRecordId`, which `console.error`s on **every render** of the chip.

## Fix

Guard with the existing `isRecordId` and fall back to `FallbackChip` — the same shape the `actor` arm four lines below already uses with `isActorId`.

## Deliberately not changed

`RecordHoverCard` / `RecordBadge` keep their truthiness-only guards. Their `console.error` is the only signal that something upstream is passing a bad id; silencing the sink would have hidden this defect rather than surfacing it.

## Notes

Found while live-testing plan 17 Phase A. Unrelated to that plan's subject matter, so it ships on its own.