### PR TITLE
feat(workflow): synthesize a node manifest for app workflow blocks

### DIFF
--- a/packages/lib/src/workflow-engine/catalog/app-manifests.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/app-manifests.test.ts
@@ -5,13 +5,29 @@
 //
 // See plans/kopilot/workflow/17-app-block-authoring-and-connections.md §4 A3.
 
-import { describe, expect, it } from 'vitest'
-import type { CachedBlockOp, CachedWorkflowBlock } from '../../cache/org-cache-keys'
+import { describe, expect, it, vi } from 'vitest'
+import type {
+  CachedBlockOp,
+  CachedInstalledApp,
+  CachedWorkflowBlock,
+} from '../../cache/org-cache-keys'
+
+// Partial mock — the cache barrel is imported by half of lib, and replacing it
+// wholesale dies at collection. Only the one read this module makes is stubbed.
+const getCachedInstalledApps = vi.fn()
+vi.mock('../../cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../cache')>()),
+  getCachedInstalledApps: (...args: unknown[]) => getCachedInstalledApps(...args),
+}))
+
 import {
+  buildManifestLookup,
   fieldNodeMapToUnifiedVariables,
   resolveAppBlockOutputs,
   schemaPropertiesToUnifiedVariables,
+  synthesizeAppBlockManifest,
 } from './app-manifests'
+import { NodeCategory } from './types'
 
 const NODE = 'fedex-DmJuCD8M2cAE0Hqdua0Ns'
 
@@ -360,5 +376,394 @@ describe('resolveAppBlockOutputs', () => {
     expect(
       resolveAppBlockOutputs(block([]), { resource: 'shipment', operation: 'track' }, NODE)
     ).toEqual({ variables: [], status: 'unknown-operation' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The synthesized manifest (PR B1)
+// ---------------------------------------------------------------------------
+
+/** The block's own `inputsJsonSchema` — the SDK field `toJSON()` map the panel declares. */
+const fedexInputs: Record<string, unknown> = {
+  resource: { type: 'select', _metadata: { options: ['shipment'] } },
+  operation: { type: 'select', _metadata: { options: ['track', 'watch'] } },
+  trackingNumber: { type: 'string', _metadata: { label: 'Tracking number' } },
+  referenceType: {
+    type: 'select',
+    _metadata: { options: ['PART_NUMBER'], defaultValue: 'PART_NUMBER' },
+  },
+}
+
+function installedApp(overrides: Partial<CachedInstalledApp> = {}): CachedInstalledApp {
+  return {
+    installationId: 'inst_1',
+    installationType: 'production',
+    installedAt: '2026-08-01T00:00:00.000Z',
+    app: {
+      id: 'z3prnwpd3rt31mp7f9yxo5m6',
+      slug: 'fedex',
+      title: 'FedEx',
+      description: null,
+      avatarUrl: null,
+      category: null,
+    },
+    currentDeployment: null,
+    methods: [],
+    connectionDefinitions: {},
+    orgConnectionPresent: true,
+    orgConnectionExpiresAt: null,
+    ...overrides,
+  } as CachedInstalledApp
+}
+
+/** A block shaped like the real FedEx one: two ops, declared panel inputs. */
+function fedexBlock(overrides: Partial<CachedWorkflowBlock> = {}): CachedWorkflowBlock {
+  return {
+    ...block([op('shipment.track', trackOutputs), op('shipment.watch', openOutputs)]),
+    description: 'Track FedEx shipments',
+    inputsJsonSchema: fedexInputs,
+    toolMap: { 'shipment.track': 'tool_track', 'shipment.watch': 'tool_watch' },
+    ...overrides,
+  }
+}
+
+const APP_TYPE = 'z3prnwpd3rt31mp7f9yxo5m6:fedex'
+
+function manifestFor(
+  blockOverrides: Partial<CachedWorkflowBlock> = {},
+  appOverrides: Partial<CachedInstalledApp> = {}
+) {
+  return synthesizeAppBlockManifest(installedApp(appOverrides), fedexBlock(blockOverrides))
+}
+
+/** Config an agent would have to write to get a clean node — the "healthy" baseline. */
+const healthyConfig = {
+  type: APP_TYPE,
+  appId: 'z3prnwpd3rt31mp7f9yxo5m6',
+  blockId: 'fedex',
+  resource: 'shipment',
+  operation: 'track',
+  trackingNumber: '123',
+}
+
+describe('synthesizeAppBlockManifest — shape', () => {
+  it('parses its own defaultData with its own configSchema', () => {
+    // The invariant `catalog-coverage.test.ts` enforces for every REGISTERED
+    // manifest. Synthesized ones are outside that suite's set by design, so it
+    // has to be asserted here or nothing checks it.
+    const manifest = manifestFor()
+
+    expect(manifest.configSchema.safeParse(manifest.defaultData()).success).toBe(true)
+  })
+
+  it('stamps identity and the first operation into defaultData', () => {
+    expect(manifestFor().defaultData()).toMatchObject({
+      type: APP_TYPE,
+      appId: 'z3prnwpd3rt31mp7f9yxo5m6',
+      appSlug: 'fedex',
+      blockId: 'fedex',
+      title: 'FedEx',
+      resource: 'shipment',
+      operation: 'track',
+      // From the panel field's declared `_metadata.defaultValue`.
+      referenceType: 'PART_NUMBER',
+    })
+    // Resolved at run time from `appId`; the canvas does not persist it either.
+    expect(manifestFor().defaultData()).not.toHaveProperty('installationId')
+  })
+
+  it('is an INTEGRATION node that never accepts input wiring', () => {
+    // Until B1 this was enforced by accident — `isInputNodePair` disqualified
+    // any node whose manifest was missing. That stops being true the moment app
+    // blocks HAVE manifests, so both facts are now explicit.
+    const manifest = manifestFor()
+
+    expect(manifest.category).toBe(NodeCategory.INTEGRATION)
+    expect(manifest.connection.acceptsInputNodes).toBe(false)
+    expect(manifest.connection.branches).toBeUndefined()
+  })
+
+  it('honours the projected canRunSingle, defaulting to true', () => {
+    // `undefined` is a pre-projection catalog, and today's behaviour for those
+    // is runnable — `run-node.ts` only refuses on an explicit `false`.
+    expect(manifestFor().connection.canRunSingle).toBe(true)
+    expect(manifestFor({ canRunSingle: false }).connection.canRunSingle).toBe(false)
+  })
+
+  it('keeps app-authored config keys through the schema, and declares no derived key', () => {
+    const parsed = manifestFor().configSchema.safeParse({
+      ...healthyConfig,
+      somethingTheAppInvented: 'kept',
+    })
+
+    expect(parsed.success && (parsed.data as Record<string, unknown>).somethingTheAppInvented).toBe(
+      'kept'
+    )
+    // No `configSchema` may declare a derived (`_`-prefixed) key — the invariant
+    // `derived-keys.ts` exists to protect, which cost every stored HTTP node a
+    // permanent unfixable warning when it was broken.
+    const shape = (manifestFor().configSchema as unknown as { shape: Record<string, unknown> })
+      .shape
+    expect(Object.keys(shape).filter((k) => k.startsWith('_'))).toEqual([])
+  })
+
+  it('rejects an operation the block does not offer, at the schema level', () => {
+    expect(
+      manifestFor().configSchema.safeParse({ ...healthyConfig, operation: 'teleport' }).success
+    ).toBe(false)
+  })
+
+  it('degrades to a free-string operation when the catalog predates the ops projection', () => {
+    // An enum over an empty op set would reject every stored node.
+    const manifest = manifestFor({ ops: [], toolMap: {} })
+
+    expect(
+      manifest.configSchema.safeParse({ ...healthyConfig, operation: 'anything' }).success
+    ).toBe(true)
+  })
+
+  it('is authorable, and names its operations in bounded usage text', () => {
+    const manifest = manifestFor()
+
+    expect(manifest.agent?.authorable).toBe(true)
+    expect(manifest.agent?.usage).toContain('shipment.track')
+    expect(manifest.agent?.examples[0]?.config).toMatchObject({
+      resource: 'shipment',
+      operation: 'track',
+    })
+  })
+
+  it('summarizes instead of listing when a block has many operations', () => {
+    // QuickBooks has 42 behind one type; the prompt budget is not unbounded.
+    const many = Array.from({ length: 40 }, (_, i) => op(`res.op${i}`, openOutputs))
+    const usage = manifestFor({ ops: many }).agent?.usage ?? ''
+
+    expect(usage).toContain('more (call describe_app_block)')
+    expect(usage).not.toContain('res.op39')
+  })
+
+  it('delegates resolveOutputs to the ladder', () => {
+    const vars = manifestFor().resolveOutputs?.(
+      { resource: 'shipment', operation: 'track' },
+      NODE,
+      { allResources: [], resolveVariable: () => undefined }
+    )
+
+    expect(vars?.map((v) => v.id)).toContain(`${NODE}.trackingNumber`)
+  })
+})
+
+describe('synthesizeAppBlockManifest — validate', () => {
+  /** Only the errors whose message concerns `field`, so a table stays readable. */
+  const errorsFor = (config: Record<string, unknown>, field: string, manifest = manifestFor()) =>
+    manifest.validate(config).errors.filter((e) => e.field === field)
+
+  it('accepts a fully configured node', () => {
+    const result = manifestFor().validate(healthyConfig)
+
+    expect(result.isValid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it('errors on an operation the block no longer offers', () => {
+    // Tier 2, so this gates `run_node` for this node and NOTHING else — the
+    // mutation-blocking half lives in `validateGraphStructure`, keyed on
+    // `newNodeIds`, so one drifted node never makes a workflow uneditable.
+    const errors = errorsFor({ ...healthyConfig, operation: 'teleport' }, 'operation')
+
+    expect(errors[0]?.type).toBe('error')
+    expect(errors[0]?.message).toContain('shipment.track')
+  })
+
+  it('errors when no operation is selected', () => {
+    expect(errorsFor({ type: APP_TYPE }, 'operation')[0]?.type).toBe('error')
+  })
+
+  it('says nothing about operations when the catalog predates the ops projection', () => {
+    // Flagging every healthy node until its app is republished would be worse
+    // than silence.
+    const manifest = manifestFor({ ops: [], toolMap: {} })
+
+    expect(errorsFor({ type: APP_TYPE }, 'operation', manifest)).toEqual([])
+  })
+
+  it('warns — never errors — on a missing required tool input', () => {
+    // Advisory: most blocks forward the flat panel input unchanged, but some
+    // project it first, so a required name here is the TOOL's, not the block's.
+    const withRequired = manifestFor({
+      ops: [
+        {
+          ...op('shipment.track', trackOutputs),
+          inputsJsonSchema: {
+            type: 'object',
+            required: ['trackingNumber'],
+            properties: { trackingNumber: { type: 'string' } },
+          },
+        },
+      ],
+    })
+
+    const errors = errorsFor(
+      { ...healthyConfig, trackingNumber: '' },
+      'trackingNumber',
+      withRequired
+    )
+    expect(errors[0]?.type).toBe('warning')
+    expect(withRequired.validate(healthyConfig).errors).toEqual([])
+  })
+
+  it('warns about a {{ref}} stranded in a constant-mode field', () => {
+    // The engine passes constant fields through RAW, so the app receives the
+    // literal text. Nothing else reports it: `extractVariables` mirrors the
+    // engine and skips constant fields, so ref-checking cannot see it either.
+    const errors = errorsFor(
+      { ...healthyConfig, trackingNumber: '{{FedEx.trackingNumber}}' },
+      'trackingNumber'
+    )
+
+    expect(errors[0]?.type).toBe('warning')
+    expect(errors[0]?.message).toContain('fieldModes.trackingNumber')
+  })
+
+  it('says nothing when that same ref is properly in variable mode', () => {
+    expect(
+      errorsFor(
+        {
+          ...healthyConfig,
+          trackingNumber: '{{FedEx.trackingNumber}}',
+          fieldModes: { trackingNumber: false },
+        },
+        'trackingNumber'
+      )
+    ).toEqual([])
+  })
+})
+
+describe('synthesizeAppBlockManifest — the connection issue', () => {
+  const connectionErrors = (
+    app: Partial<CachedInstalledApp>,
+    blockOverrides: Partial<CachedWorkflowBlock> = {}
+  ) =>
+    manifestFor(blockOverrides, app)
+      .validate(healthyConfig)
+      .errors.filter((e) => e.field === 'connectionId')
+
+  it('says nothing when the node is simply unbound and the workspace is connected', () => {
+    // Unbound is the NORMAL, healthy state: the runtime resolver takes its
+    // `appId` arm and picks the org default. Firing on a missing `connectionId`
+    // would put an issue on nearly every app node in every workflow.
+    expect(connectionErrors({ orgConnectionPresent: true })).toEqual([])
+  })
+
+  it('errors when the block declares it needs a connection and the workspace has none', () => {
+    const errors = connectionErrors({ orgConnectionPresent: false }, { requiresConnection: true })
+
+    expect(errors[0]?.type).toBe('error')
+    expect(errors[0]?.message).toContain('Settings → Apps → FedEx → Connections')
+  })
+
+  it('only warns when the requirement is the per-app approximation', () => {
+    // `requiresConnection: undefined` means UNKNOWN, not false — the catalog
+    // predates the projection. Refusing to run on an approximation would punish
+    // a block that may genuinely need no connection.
+    const errors = connectionErrors({
+      orgConnectionPresent: false,
+      connectionDefinitions: { organization: {} as never },
+    })
+
+    expect(errors[0]?.type).toBe('warning')
+  })
+
+  it('says nothing when the app declares no connection definition at all', () => {
+    expect(connectionErrors({ orgConnectionPresent: false })).toEqual([])
+  })
+
+  it('says nothing when the block declares it needs no connection', () => {
+    expect(
+      connectionErrors({ orgConnectionPresent: false }, { requiresConnection: false })
+    ).toEqual([])
+  })
+
+  it('warns when the workspace connection is present but expired', () => {
+    const errors = connectionErrors({
+      orgConnectionPresent: true,
+      orgConnectionExpiresAt: '2020-01-01T00:00:00.000Z',
+    })
+
+    expect(errors[0]?.type).toBe('warning')
+    expect(errors[0]?.message).toContain('expired')
+  })
+})
+
+describe('synthesizeAppBlockManifest — extractVariables', () => {
+  const extract = (config: Record<string, unknown>) =>
+    manifestFor().extractVariables?.(config) ?? []
+
+  it('reads refs only from fields in variable mode', () => {
+    // Exactly the engine's contract, and the canvas's. All three must agree on
+    // which strings are refs, or ref-checking validates a different set than
+    // the one that gets resolved.
+    expect(
+      extract({
+        ...healthyConfig,
+        trackingNumber: '{{other.value}}',
+        fieldModes: { trackingNumber: false },
+      })
+    ).toEqual(['other.value'])
+
+    expect(extract({ ...healthyConfig, trackingNumber: '{{other.value}}' })).toEqual([])
+  })
+
+  it('treats a bare value in variable mode as a PICKER-mode path', () => {
+    expect(
+      extract({
+        ...healthyConfig,
+        trackingNumber: 'node_a.id',
+        fieldModes: { trackingNumber: false },
+      })
+    ).toEqual(['node_a.id'])
+  })
+
+  it('never reads a platform-owned key', () => {
+    expect(
+      extract({
+        ...healthyConfig,
+        title: '{{never.this}}',
+        connectionId: '{{nor.this}}',
+        fieldModes: { title: false, connectionId: false },
+      })
+    ).toEqual([])
+  })
+})
+
+describe('buildManifestLookup', () => {
+  it('resolves core types from the registry and app blocks from the org cache', async () => {
+    getCachedInstalledApps.mockReset()
+    getCachedInstalledApps.mockResolvedValue([
+      { ...installedApp(), workflowBlocks: [fedexBlock()] },
+    ])
+
+    const lookup = await buildManifestLookup('org_1')
+
+    expect(lookup('wait')?.id).toBe('wait')
+    expect(lookup(APP_TYPE)?.category).toBe(NodeCategory.INTEGRATION)
+    // An uninstalled app's leftover node: the provider filters it out, so it
+    // simply does not resolve and stays read-only.
+    expect(lookup('some-other-app:block')).toBeUndefined()
+  })
+
+  it('widens the lookup, never the registry', async () => {
+    // `catalog-coverage.test.ts` asserts exact set equality between the
+    // `NodeType` enum and {registered manifests ∪ NOT_YET_MIGRATED}. An app
+    // block is in neither, so it must never enter the shared Map.
+    getCachedInstalledApps.mockReset()
+    getCachedInstalledApps.mockResolvedValue([
+      { ...installedApp(), workflowBlocks: [fedexBlock()] },
+    ])
+    await buildManifestLookup('org_1')
+
+    const { getManifest, listManifests } = await import('./registry')
+    expect(getManifest(APP_TYPE)).toBeUndefined()
+    expect(listManifests().some((m) => m.id.includes(':'))).toBe(false)
   })
 })

--- a/packages/lib/src/workflow-engine/catalog/app-manifests.ts
+++ b/packages/lib/src/workflow-engine/catalog/app-manifests.ts
@@ -11,12 +11,22 @@
 // block's `toolMap` dispatches to instead. See
 // plans/kopilot/workflow/17-app-block-authoring-and-connections.md §2.3/D3.
 
+import { z } from 'zod'
 import { getCachedInstalledApps } from '../../cache'
-import type { CachedWorkflowBlock } from '../../cache/org-cache-keys'
+import type { CachedInstalledApp, CachedWorkflowBlock } from '../../cache/org-cache-keys'
 import { BaseType } from '../core/types'
+import { isAppInputField } from '../nodes/utils/app-input-fields'
 import type { UnifiedVariable } from '../types/unified-variable'
+import { getManifest } from './registry'
 import { schemaToUnifiedVariable } from './schema-to-variable'
+import {
+  type ManifestLookup,
+  NodeCategory,
+  type NodeManifest,
+  type NodeValidationResult,
+} from './types'
 import { createUnifiedOutputVariable } from './variable-conversion'
+import { extractVarIdsFromString } from './variable-inference'
 
 /** An app-block node type — `${appId}:${blockId}`, as persisted in `node.data.type`. */
 export type AppBlockType = string
@@ -268,4 +278,422 @@ function mergeById(declared: UnifiedVariable[], inferred: UnifiedVariable[]): Un
     if (!declaredIds.has(v.id)) merged.push(v)
   }
   return merged
+}
+
+// ---------------------------------------------------------------------------
+// The synthesized manifest (PR B1)
+//
+// An app block gets a real `NodeManifest` built from the catalog projection,
+// rather than an `if (isAppBlock(type))` branch at each of the six sites that
+// currently fail differently on one (silent `[]`, silent `continue`, hard 400,
+// wrong handle). Six branches would mean six independently-driftable
+// semantics; one manifest means every existing consumer — `validateNodeConfigs`,
+// `requireAuthorableManifest`, `resolveOutputs`, `isInputNodePair`, `run-node`
+// — works unchanged. See plan 17 D1/D2.
+// ---------------------------------------------------------------------------
+
+/** An app block's persisted `node.data`: platform keys plus the block's own flat inputs. */
+export type AppBlockConfig = Record<string, unknown>
+
+/**
+ * Platform-owned `node.data` keys, declared so the agent sees them in the
+ * schema and so `configSchema` types the ones it may set (`connectionId`,
+ * `fieldModes`, `title`). Identity keys are declared but not agent-facing —
+ * `add_node` stamps them from `defaultData`.
+ *
+ * Deliberately NOT exhaustive: the schema is `.passthrough()`, because an app
+ * block's input names are the app's to choose and a strict object would strip
+ * every one of them. Derived (`_`-prefixed) keys are excluded by construction —
+ * see `derived-keys.ts` for why no `configSchema` may ever declare one.
+ */
+const PLATFORM_CONFIG_SHAPE = {
+  type: z.string().optional(),
+  appId: z.string().optional(),
+  appSlug: z.string().optional(),
+  blockId: z.string().optional(),
+  installationId: z.string().optional(),
+  /** Bound `Credential` id. Absent ⇒ follow the workspace default (§0 S1). */
+  connectionId: z.string().optional(),
+  title: z.string().optional(),
+  desc: z.string().optional(),
+  /** `false` ⇒ the field holds a variable ref; `true`/absent ⇒ a literal. */
+  fieldModes: z.record(z.string(), z.boolean()).optional(),
+  collapsed: z.boolean().optional(),
+  inferredSchema: z.unknown().optional(),
+} as const
+
+/** Distinct values in first-seen order. */
+function uniqueInOrder(values: string[]): string[] {
+  return Array.from(new Set(values))
+}
+
+/** `_metadata` of one SDK field node, or `{}`. */
+function fieldMetadata(node: unknown): Record<string, unknown> {
+  return ((node as { _metadata?: Record<string, unknown> } | null)?._metadata ?? {}) as Record<
+    string,
+    unknown
+  >
+}
+
+/**
+ * The block's own input field names — the keys of its `inputsJsonSchema` field-
+ * node map, minus anything the platform owns or derives.
+ *
+ * `inputsJsonSchema` is `{}` on catalogs published before the projection
+ * existed, in which case there are no declared inputs and every consumer here
+ * degrades to the `PLATFORM_NODE_DATA_KEYS` denylist — the same fallback
+ * `isAppInputField` documents.
+ */
+function declaredInputNames(block: CachedWorkflowBlock): string[] {
+  return Object.keys(block.inputsJsonSchema ?? {}).filter(
+    (name) => name !== 'resource' && name !== 'operation' && isAppInputField(name, undefined)
+  )
+}
+
+/** Declared `_metadata.defaultValue`s, for `defaultData()`. */
+function defaultInputValues(block: CachedWorkflowBlock): Record<string, unknown> {
+  const defaults: Record<string, unknown> = {}
+  for (const name of declaredInputNames(block)) {
+    const value = fieldMetadata(block.inputsJsonSchema?.[name]).defaultValue
+    if (value !== undefined) defaults[name] = value
+  }
+  return defaults
+}
+
+/**
+ * The `required` array of a dispatched tool's `inputsJsonSchema`.
+ *
+ * Note the shape: a tool's inputs are a REAL JSON Schema (zod → JSON Schema at
+ * publish), unlike the block's own `inputsJsonSchema`, which is the SDK field
+ * `toJSON()` map. The same two-shapes trap the output converters exist for.
+ */
+function requiredToolInputs(schema: Record<string, unknown> | undefined): string[] {
+  const required = (schema as { required?: unknown } | undefined)?.required
+  return Array.isArray(required) ? required.filter((n): n is string => typeof n === 'string') : []
+}
+
+/**
+ * The block's config schema: every declared input optional, `resource` and
+ * `operation` enumerated over the `toolMap` key set, plus the platform keys.
+ *
+ * Loose on purpose. Required-ness is **per operation** and this schema is per
+ * type — QuickBooks has 42 operations behind one `type` — so a required field
+ * here would reject 41 of them. The per-operation contract is `validate`'s job
+ * (advisory) and `describe_app_block`'s (authoritative, per op).
+ */
+function buildAppBlockConfigSchema(block: CachedWorkflowBlock): z.ZodType<AppBlockConfig> {
+  const shape: Record<string, z.ZodType> = {}
+
+  for (const name of declaredInputNames(block)) {
+    shape[name] = z.unknown()
+  }
+
+  const resources = uniqueInOrder(block.ops.map((o) => o.resource))
+  const operations = uniqueInOrder(block.ops.map((o) => o.operation))
+  // A pre-projection catalog has no ops; an enum over nothing would reject every
+  // stored node, so fall back to a free string and let `validate` stay silent.
+  shape.resource = resources.length > 0 ? z.enum(resources).optional() : z.string().optional()
+  shape.operation = operations.length > 0 ? z.enum(operations).optional() : z.string().optional()
+
+  // Platform keys last: they win a name collision, and `isAppInputField`'s
+  // denylist already guarantees such a key was never an app input anyway.
+  Object.assign(shape, PLATFORM_CONFIG_SHAPE)
+
+  return z.object(shape).passthrough() as unknown as z.ZodType<AppBlockConfig>
+}
+
+/** Where an admin connects an app — named in prose because `auxx://` has no settings kind. */
+function connectionsPath(inst: CachedInstalledApp): string {
+  return `Settings → Apps → ${inst.app.title} → Connections (/app/settings/apps/installed/${inst.app.slug}/connections)`
+}
+
+/**
+ * Tier-2 config validation for one app-block node.
+ *
+ * Severity discipline, because it is easy to get backwards: nothing here blocks
+ * a graph mutation — `validateNodeConfigs` runs *after* the blocking gate — but
+ * an `error` does refuse `run_node` for this node. So `error` means "running
+ * this is guaranteed to fail", and everything approximate stays `warning`.
+ *
+ * The mutation-blocking half of the op check lives in `validateGraphStructure`,
+ * keyed on `newNodeIds`: a freshly authored node with a fabricated operation
+ * must fail the write, while a pre-existing node whose op vanished in an app
+ * upgrade must never make the whole workflow uneditable. See plan 17 §0 S2.
+ */
+function validateAppBlockConfig(
+  inst: CachedInstalledApp,
+  block: CachedWorkflowBlock,
+  config: AppBlockConfig
+): NodeValidationResult {
+  const errors: NodeValidationResult['errors'] = []
+  const appTitle = inst.app.title
+
+  // 1. Is the selected operation one this block actually dispatches?
+  const resource = typeof config.resource === 'string' ? config.resource : ''
+  const operation = typeof config.operation === 'string' ? config.operation : ''
+  const opKeys = block.ops.map((o) => o.key)
+  let op = block.ops.find((o) => o.key === `${resource}.${operation}`)
+
+  if (block.ops.length === 0) {
+    // Pre-projection catalog (no `toolMap`, or published before `ops` existed).
+    // There is nothing to check against, and inventing an error would flag every
+    // healthy node until the app is republished.
+    op = undefined
+  } else if (!resource || !operation) {
+    errors.push({
+      field: 'operation',
+      message: `This ${appTitle} block has no operation selected, so it cannot run and produces no outputs. Set resource and operation to one of: ${opKeys.join(', ')}.`,
+      type: 'error',
+    })
+  } else if (!op) {
+    errors.push({
+      field: 'operation',
+      message: `"${resource}.${operation}" is not an operation this ${appTitle} block offers — the app may have changed it. Available: ${opKeys.join(', ')}.`,
+      type: 'error',
+    })
+  }
+
+  // 2. Required inputs of the dispatched tool. ADVISORY — most blocks forward
+  //    the flat panel input to `ctx.runTool` unchanged, but some (whatsapp)
+  //    project it first, so a name here is the tool's and not necessarily the
+  //    block's. Never an error on that basis.
+  if (op) {
+    for (const name of requiredToolInputs(op.inputsJsonSchema)) {
+      if (name === 'resource' || name === 'operation') continue
+      const value = config[name]
+      if (value !== undefined && value !== null && value !== '') continue
+      errors.push({
+        field: name,
+        message: `"${name}" is required by ${op.key} and is empty.`,
+        type: 'warning',
+      })
+    }
+  }
+
+  // 3. Does the WORKSPACE have a usable connection? Deliberately not keyed on a
+  //    missing `connectionId`: unbound is the normal, healthy state — the
+  //    runtime resolver takes its `appId` arm and picks the org default, and the
+  //    canvas renders unbound as "follows the workspace default". Firing on
+  //    unbound would put an issue on nearly every app node in every workflow.
+  const hasDefinition = Boolean(
+    inst.connectionDefinitions?.user || inst.connectionDefinitions?.organization
+  )
+  if (block.requiresConnection !== false) {
+    if (!inst.orgConnectionPresent) {
+      if (block.requiresConnection === true) {
+        errors.push({
+          field: 'connectionId',
+          message: `${appTitle} has no workspace connection, so this block cannot run. An admin needs to connect one at ${connectionsPath(inst)}.`,
+          type: 'error',
+        })
+      } else if (hasDefinition) {
+        // `requiresConnection` is `undefined` — unknown, NOT false: the catalog
+        // predates the projection. Blocking a run on the per-app approximation
+        // would punish a block that may genuinely need no connection.
+        errors.push({
+          field: 'connectionId',
+          message: `${appTitle} has no workspace connection. Blocks from this app usually need one — an admin can connect it at ${connectionsPath(inst)}.`,
+          type: 'warning',
+        })
+      }
+    } else if (
+      inst.orgConnectionExpiresAt &&
+      new Date(inst.orgConnectionExpiresAt).getTime() < Date.now()
+    ) {
+      errors.push({
+        field: 'connectionId',
+        message: `The workspace connection for ${appTitle} has expired. An admin needs to reconnect it at ${connectionsPath(inst)}.`,
+        type: 'warning',
+      })
+    }
+  }
+
+  // 4. A `{{ref}}` sitting in a constant-mode field. The engine passes constant
+  //    fields through RAW (`app-workflow-block-processor.ts` — `isConstant`
+  //    branch), so the app receives the literal text `{{Node.field}}`. Nothing
+  //    else reports this: `extractVariables` below deliberately mirrors the
+  //    engine and skips constant fields, so without this the ref is invisible to
+  //    ref-checking too, and the failure only shows up in the app's response.
+  const fieldModes = (config.fieldModes ?? {}) as Record<string, unknown>
+  for (const [name, value] of Object.entries(config)) {
+    if (!isAppInputField(name, block.inputsJsonSchema)) continue
+    if (fieldModes[name] === false) continue
+    if (typeof value !== 'string' || !value.includes('{{') || !value.includes('}}')) continue
+    errors.push({
+      field: name,
+      message: `"${name}" holds a variable reference but is in constant mode, so ${appTitle} receives the literal text. Set fieldModes.${name} to false.`,
+      type: 'warning',
+    })
+  }
+
+  return { isValid: errors.every((e) => e.type === 'warning'), errors }
+}
+
+/**
+ * Every variable ref this node reads — the engine's own contract, reproduced.
+ *
+ * Only fields in **variable mode** (`fieldModes[field] === false`) are scanned,
+ * because only those are resolved at run time; and only app input fields, per
+ * `isAppInputField`. Both halves match `AppWorkflowBlockProcessor
+ * .extractRequiredVariables` and the canvas's `extractAppBlockVariables`, so
+ * all three agree on which strings are refs.
+ *
+ * A bare value with no `{{ }}` is a PICKER-mode variable path and counts as a
+ * ref — the engine resolves it via `contextManager.getVariable(value)`.
+ */
+function extractAppBlockVariables(block: CachedWorkflowBlock, config: AppBlockConfig): string[] {
+  const fieldModes = (config.fieldModes ?? {}) as Record<string, unknown>
+  const refs = new Set<string>()
+
+  for (const [name, value] of Object.entries(config)) {
+    if (!isAppInputField(name, block.inputsJsonSchema)) continue
+    if (fieldModes[name] !== false) continue
+    if (typeof value !== 'string' || value.length === 0) continue
+
+    if (value.includes('{{')) {
+      for (const id of extractVarIdsFromString(value)) refs.add(id)
+    } else {
+      refs.add(value)
+    }
+  }
+
+  return Array.from(refs)
+}
+
+/** How many operations to name inline before summarizing. Keeps `usage` bounded — QuickBooks has 42. */
+const USAGE_OP_LIMIT = 12
+
+/** Prompt-facing docs. `NodeAgentDocs` requires both members, so both are generated. */
+function buildAgentDocs(
+  inst: CachedInstalledApp,
+  block: CachedWorkflowBlock
+): NonNullable<NodeManifest<AppBlockConfig>['agent']> {
+  const opKeys = block.ops.map((o) => o.key)
+  const shown = opKeys.slice(0, USAGE_OP_LIMIT).join(', ')
+  const opList =
+    opKeys.length === 0
+      ? 'none declared in this app version — call describe_app_block'
+      : opKeys.length > USAGE_OP_LIMIT
+        ? `${shown}, and ${opKeys.length - USAGE_OP_LIMIT} more (call describe_app_block)`
+        : shown
+
+  const usage =
+    `A workflow block contributed by the ${inst.app.title} app. Set \`resource\` and \`operation\` first — ` +
+    `every other field, and the node's outputs, depend on that selection. Operations: ${opList}. ` +
+    "Remaining config keys are the block's own flat input fields; a field whose value is a " +
+    '{{ref}} must also set `fieldModes.<field>` to false, or the app receives the literal text. ' +
+    'Leave `connectionId` unset to use the workspace default connection.'
+
+  const first = block.ops[0]
+  const exampleConfig: AppBlockConfig = first
+    ? { resource: first.resource, operation: first.operation }
+    : {}
+  if (first) {
+    for (const name of requiredToolInputs(first.inputsJsonSchema)) {
+      if (name === 'resource' || name === 'operation') continue
+      exampleConfig[name] = `<${name}>`
+    }
+  }
+
+  return {
+    authorable: true,
+    usage,
+    examples: [
+      {
+        description: first
+          ? `Run ${block.label}'s ${first.key} operation (input values are placeholders)`
+          : `Add a ${block.label} block`,
+        config: exampleConfig,
+      },
+    ],
+  }
+}
+
+/**
+ * Build one app block's `NodeManifest` from its catalog projection.
+ *
+ * Per-org data, never registered: `listManifests()` stays core-only, because
+ * `catalog-coverage.test.ts` asserts exact set equality between the `NodeType`
+ * enum and {registered manifests ∪ `NOT_YET_MIGRATED`}, and an app block is in
+ * neither. This widens the *lookup*, never the *registry*.
+ */
+export function synthesizeAppBlockManifest(
+  inst: CachedInstalledApp,
+  block: CachedWorkflowBlock
+): NodeManifest<AppBlockConfig> {
+  const type = `${inst.app.id}:${block.id}`
+  const displayName = block.label || block.id
+
+  return {
+    id: type,
+    category: NodeCategory.INTEGRATION,
+    displayName,
+    description: block.description || `${inst.app.title} block`,
+    // Icon NAME only — the web registry resolves it to a component. `iconKey` is
+    // hardcoded `null` by the compiler today and unsupported platform-wide, and
+    // `app.avatarUrl` is a URL, not a name, so it cannot stand in here.
+    icon: block.iconKey || 'package',
+    ...(block.color ? { color: block.color } : {}),
+
+    defaultData: () => {
+      const first = block.ops[0]
+      return {
+        ...defaultInputValues(block),
+        // Identity last — a block may not shadow it, and `isAppInputField`'s
+        // denylist means these were never app inputs to begin with.
+        type,
+        appId: inst.app.id,
+        appSlug: inst.app.slug,
+        blockId: block.id,
+        title: displayName,
+        // `installationId` is deliberately absent: the processor resolves it at
+        // run time from `appId`, and the canvas does not persist it either.
+        ...(first ? { resource: first.resource, operation: first.operation } : {}),
+      }
+    },
+
+    configSchema: buildAppBlockConfigSchema(block),
+    validate: (config) => validateAppBlockConfig(inst, block, config),
+    extractVariables: (config) => extractAppBlockVariables(block, config),
+    resolveOutputs: (config, nodeId) => resolveAppBlockOutputs(block, config, nodeId).variables,
+
+    connection: {
+      // No `branches`: an app node body renders exactly one `target` and one
+      // `source` handle, so the default source handle is correct — not a
+      // shortcut.
+      canRunSingle: block.canRunSingle ?? true,
+      /**
+       * Never an input node. Until now this was enforced accidentally, by
+       * `isInputNodePair` disqualifying any node whose manifest was missing —
+       * which stops being true the moment app blocks have manifests. The guard
+       * is now these two explicit facts: `category` is INTEGRATION (≠ INPUT),
+       * and input wiring is refused outright.
+       */
+      acceptsInputNodes: false,
+    },
+
+    agent: buildAgentDocs(inst, block),
+  }
+}
+
+/**
+ * The per-org manifest lookup: core registry ∪ this org's installed app blocks.
+ *
+ * Built once per graph-edit operation. Deliberately NOT memoized across
+ * operations: the underlying `installedApps` cache has a 900s TTL, and pinning
+ * a lookup for longer than one op would let two tool calls in the same turn
+ * disagree about a block's shape in a way nothing can invalidate.
+ *
+ * Core types win a name collision, which is free in practice — a core id has no
+ * colon and an app-block type always does.
+ */
+export async function buildManifestLookup(orgId: string): Promise<ManifestLookup> {
+  const apps = await getCachedInstalledApps(orgId)
+  const byType = new Map<AppBlockType, NodeManifest<any>>()
+  for (const inst of apps) {
+    for (const block of inst.workflowBlocks ?? []) {
+      byType.set(`${inst.app.id}:${block.id}`, synthesizeAppBlockManifest(inst, block))
+    }
+  }
+  return (type: string) => getManifest(type) ?? byType.get(type)
 }

--- a/packages/lib/src/workflow-engine/catalog/types.ts
+++ b/packages/lib/src/workflow-engine/catalog/types.ts
@@ -137,3 +137,22 @@ export interface NodeManifest<TConfig = unknown> {
   connection: NodeConnectionRules<TConfig>
   agent?: NodeAgentDocs
 }
+
+/**
+ * How a caller resolves a node type to its manifest.
+ *
+ * The core registry (`getManifest`) answers for the 27 migrated platform types
+ * and nothing else. App workflow blocks are **per-org data**, not platform
+ * code — they are declared by an installed app's published catalog — so their
+ * manifests are synthesized per request (`buildManifestLookup`) and reach the
+ * sync call sites through this function rather than through the registry Map.
+ *
+ * Two things follow, and both are deliberate:
+ *  - `getManifest` stays synchronous, pure and core-only. It has ~30 call
+ *    sites, including the browser registry merge, which has no org context.
+ *  - Wherever a call site can see app blocks, this parameter is **required**,
+ *    never optional-defaulting-to-`getManifest`. A silent fallback to the core
+ *    registry is how a caller quietly loses app-block awareness; make
+ *    forgetting it a compile error.
+ */
+export type ManifestLookup = (type: string) => NodeManifest<any> | undefined


### PR DESCRIPTION
Phase **B1** of `plans/kopilot/workflow/17-app-block-authoring-and-connections.md`.

Phase A (#1705) taught the server what an app block **produces**. This builds the manifest that makes one describable and — once B2 threads the lookup — authorable.

## What

`synthesizeAppBlockManifest(installation, block)` builds a real `NodeManifest` from the catalog projection already in the `installedApps` cache.

The alternative was an `if (isAppBlock(type))` branch at each of the six sites that currently fail on one — and each fails *differently*: silent `[]` from `resolve-outputs`, silent `continue` from `validateNodeConfigs`, a hard 400 from `requireAuthorableManifest`, the wrong handle from `normalize/connection`. Six branches means six independently-driftable semantics. One manifest means every existing consumer works unchanged.

`buildManifestLookup(orgId)` returns `getManifest(type) ?? synthesized`. `ManifestLookup` lands in `catalog/types.ts`, which stays import-free.

**Nothing calls the lookup yet** — threading it through graph-edit is B2. This PR adds no write surface.

## Design notes worth reading

**`configSchema` is loose by necessity.** Required-ness is *per operation* and the schema is *per type* — QuickBooks has 42 operations behind one `type`, so a required field would reject 41 of them. `resource`/`operation` are enumerated over the toolMap key set, so the agent reads the operation vocabulary out of the schema rather than needing a second call.

**`validate` severity tracks confidence.** Nothing here blocks a mutation — `validateNodeConfigs` runs *after* the blocking gate at `ops.ts:147` — but an `error` does refuse `run_node` for that node. So `error` means "running this is guaranteed to fail", and everything approximate stays `warning`. The mutation-blocking half of the op check belongs in `validateGraphStructure`, keyed on `newNodeIds` (B3).

**The connection issue fires on `!orgConnectionPresent`, never on a missing `connectionId`.** Unbound is the normal, healthy state: `resolveConnectionForRuntime` takes its `appId` arm and picks the org default, and the canvas renders unbound as "follows the workspace default". Firing on unbound would put an issue on nearly every app node in every workflow. `requiresConnection: undefined` is treated as **unknown**, never `false`.

**`acceptsInputNodes: false` and `category: INTEGRATION` are now explicit.** Until now this was enforced by accident — `isInputNodePair` disqualifies any node whose manifest is missing — which stops being true the moment app blocks *have* manifests. B3 re-points the regression test at a catalogued block.

**`buildManifestLookup` widens the lookup, never the registry**, asserted directly. `catalog-coverage.test.ts` cannot see synthesized manifests, so a future refactor that registered them into the shared Map would break `NOT_YET_MIGRATED`'s "may only shrink" invariant with nothing catching it. `defaultData()` parsing its own `configSchema` is asserted here for the same reason.

## One rule the plan does not have

A `{{ref}}` stranded in a **constant-mode** field now warns.

`extractVariables` reproduces the engine's contract — only fields with `fieldModes[f] === false` are scanned — which is correct, because the engine passes constant fields through **raw** (`app-workflow-block-processor.ts`, the `isConstant` branch). But it is narrower than what runs *today*: with no manifest, `ref-check.ts:140` falls through to a generic walk that sees every `{{…}}` in `node.data`. Without this warning, a ref written into a constant-mode field becomes invisible to ref-checking and the app silently receives the literal text `{{Node.field}}`. The canvas has the same blind spot (`workflow-block-registry.tsx:354-371`), so this is the only place that reports it at all.

Three smaller departures from §5's table are recorded in the plan file's §0.

## Verification

- 50 tests in `app-manifests.test.ts`
- `packages/lib` graph-edit + catalog suites: 336 tests, green
- `node scripts/ci/typecheck-ratchet.js --package lib` — no new errors (29, baseline 29)