### PR TITLE
refactor(workflow): thread the manifest lookup through graph-edit

### DIFF
--- a/packages/lib/src/workflow-engine/catalog/app-manifests.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/app-manifests.test.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/workflow-engine/catalog/app-manifests.test.ts
 // Server-side app-block output resolution. Pure over catalog shapes — the org
-// cache read (`buildAppBlockLookup`) is covered by resolve-outputs.test.ts,
+// cache read (`buildManifestLookup`) is covered by resolve-outputs.test.ts,
 // which exercises it through the graph walk.
 //
 // See plans/kopilot/workflow/17-app-block-authoring-and-connections.md §4 A3.

--- a/packages/lib/src/workflow-engine/catalog/app-manifests.ts
+++ b/packages/lib/src/workflow-engine/catalog/app-manifests.ts
@@ -31,9 +31,6 @@ import { extractVarIdsFromString } from './variable-inference'
 /** An app-block node type — `${appId}:${blockId}`, as persisted in `node.data.type`. */
 export type AppBlockType = string
 
-/** `${appId}:${blockId}` → the installed block, for every app installed in the org. */
-export type AppBlockLookup = ReadonlyMap<AppBlockType, CachedWorkflowBlock>
-
 /**
  * Why a resolution produced the variables it did. Callers that only need
  * variables ignore this; the authoring layer (PR B1's synthesized `validate`)
@@ -60,25 +57,6 @@ export type AppBlockOutputStatus =
 export interface AppBlockOutputs {
   variables: UnifiedVariable[]
   status: AppBlockOutputStatus
-}
-
-/**
- * Build the `${appId}:${blockId}` → block lookup for one org.
- *
- * Rides the `installedApps` org cache, so it inherits that key's invalidation
- * (`app.installed` / `app.uninstalled` / `app.deployment.changed` / …) with no
- * new wiring. Uninstalled apps are already filtered out by the provider, so a
- * node left behind by an uninstall simply does not resolve — see §11.
- */
-export async function buildAppBlockLookup(orgId: string): Promise<AppBlockLookup> {
-  const apps = await getCachedInstalledApps(orgId)
-  const byType = new Map<AppBlockType, CachedWorkflowBlock>()
-  for (const inst of apps) {
-    for (const block of inst.workflowBlocks ?? []) {
-      byType.set(`${inst.app.id}:${block.id}`, block)
-    }
-  }
-  return byType
 }
 
 /**

--- a/packages/lib/src/workflow-engine/catalog/resolve-outputs.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/resolve-outputs.test.ts
@@ -455,7 +455,7 @@ describe('app-block nodes', () => {
   it('returns err instead of throwing when the app-block lookup fails', async () => {
     noResources()
     getCachedInstalledApps.mockRejectedValue(new Error('installed apps unavailable'))
-    // A colon-shaped type is what routes into `buildAppBlockLookup`.
+    // A colon-shaped type is what routes into `buildManifestLookup`.
     const graph = {
       nodes: [
         { id: 'n1', type: 'app1:block1', data: { id: 'n1', type: 'app1:block1', title: 'Block' } },

--- a/packages/lib/src/workflow-engine/catalog/resolve-outputs.ts
+++ b/packages/lib/src/workflow-engine/catalog/resolve-outputs.ts
@@ -5,10 +5,11 @@ import { err, ok, type Result } from 'neverthrow'
 import { getCachedResources } from '../../cache'
 import { NotFoundError } from '../../errors'
 import type { UnifiedVariable } from '../types/unified-variable'
-import { type AppBlockLookup, buildAppBlockLookup, resolveAppBlockOutputs } from './app-manifests'
+import { buildManifestLookup } from './app-manifests'
 import { buildOutputContextFromResources } from './build-output-context'
 import { buildUpstreamMap, type EdgeMeta, type NodeMeta, topologicalSort } from './graph-vars'
 import { getManifest } from './registry'
+import type { ManifestLookup } from './types'
 import { getNodeIdFromVariableId } from './variable-inference'
 
 const logger = createScopedLogger('workflow-resolve-outputs')
@@ -79,7 +80,7 @@ function resolveInTopoOrder(
   allResources: Awaited<ReturnType<typeof getCachedResources>>,
   nodes: NodeMeta[],
   edges: EdgeMeta[],
-  appBlocks: AppBlockLookup
+  lookup: ManifestLookup
 ): Map<string, UnifiedVariable[]> {
   const topoOrder = topologicalSort(nodes, edges)
   const nodeMap = new Map(nodes.map((n) => [n.id, n]))
@@ -95,21 +96,16 @@ function resolveInTopoOrder(
 
     const nodeType: string | undefined = node.data?.type ?? node.type
 
-    // App blocks resolve from their catalog projection, not the core registry —
-    // they are never registered there and never will be (D1). Checked before
-    // the manifest bail below, which is what used to give every app-block node
-    // an empty output set and let the agent invent refs against it (§1).
+    // One lookup for both worlds: core types come from the registry, app blocks
+    // from a manifest synthesized off their catalog projection. There is no
+    // separate app-block arm here on purpose — a second resolution path would
+    // be free to drift from the manifest's own `resolveOutputs`, which is the
+    // duplication D1 exists to prevent.
     //
     // A positive lookup is the guard: only a block the org actually has
     // installed resolves. Do NOT widen this to "any type containing a colon" —
     // that is `hasProcessor`'s fail-open, and it does not belong here (D8).
-    const appBlock = nodeType ? appBlocks.get(nodeType) : undefined
-    if (appBlock) {
-      memo.set(nodeId, resolveAppBlockOutputs(appBlock, node.data, nodeId).variables)
-      continue
-    }
-
-    const manifest = nodeType ? getManifest(nodeType) : undefined
+    const manifest = nodeType ? lookup(nodeType) : undefined
     if (!manifest?.resolveOutputs) {
       // Not-yet-migrated or unknown type (`NOT_YET_MIGRATED` — `crud`/`find`
       // today): no server-side resolver exists yet. Empty, not an error —
@@ -140,20 +136,20 @@ function resolveInTopoOrder(
 }
 
 /**
- * The app-block lookup for this graph, or an empty one when the graph has no
- * candidate node — a `${appId}:${blockId}` type is the only thing that could
+ * The manifest lookup for this graph — the core registry alone when no node
+ * could possibly be an app block.
+ *
+ * A `${appId}:${blockId}` type is the only thing the synthesized half could
  * match, so a graph of purely core nodes must not pay for an `installedApps`
  * cache read. The colon test is a cheap pre-filter, never an authorization
- * decision: the real gate is the positive map lookup in `resolveInTopoOrder`.
+ * decision: the real gate is the positive lookup in `resolveInTopoOrder`.
  */
-const EMPTY_APP_BLOCKS: AppBlockLookup = new Map()
-
-async function appBlocksForGraph(orgId: string, nodes: NodeMeta[]): Promise<AppBlockLookup> {
+async function manifestLookupForGraph(orgId: string, nodes: NodeMeta[]): Promise<ManifestLookup> {
   const hasCandidate = nodes.some((n) => {
     const type = n.data?.type ?? n.type
     return typeof type === 'string' && type.includes(':')
   })
-  return hasCandidate ? await buildAppBlockLookup(orgId) : EMPTY_APP_BLOCKS
+  return hasCandidate ? await buildManifestLookup(orgId) : getManifest
 }
 
 /**
@@ -180,11 +176,11 @@ export async function resolveNodeOutputs(
   const relevantIds = new Set([...ancestorIds, nodeId])
   const relevantNodes = graph.nodes.filter((n) => relevantIds.has(n.id))
 
-  const [allResources, appBlocks] = await Promise.all([
+  const [allResources, lookup] = await Promise.all([
     getCachedResources(orgId),
-    appBlocksForGraph(orgId, relevantNodes),
+    manifestLookupForGraph(orgId, relevantNodes),
   ])
-  const memo = resolveInTopoOrder(allResources, relevantNodes, graph.edges, appBlocks)
+  const memo = resolveInTopoOrder(allResources, relevantNodes, graph.edges, lookup)
   return ok(memo.get(nodeId) ?? [])
 }
 
@@ -199,11 +195,11 @@ export async function resolveGraphOutputs(
   params: { graph: WorkflowOutputGraph }
 ): Promise<Result<Map<string, UnifiedVariable[]>, Error>> {
   try {
-    const [allResources, appBlocks] = await Promise.all([
+    const [allResources, lookup] = await Promise.all([
       getCachedResources(orgId),
-      appBlocksForGraph(orgId, params.graph.nodes),
+      manifestLookupForGraph(orgId, params.graph.nodes),
     ])
-    const memo = resolveInTopoOrder(allResources, params.graph.nodes, params.graph.edges, appBlocks)
+    const memo = resolveInTopoOrder(allResources, params.graph.nodes, params.graph.edges, lookup)
     return ok(memo)
   } catch (error) {
     // Outputs are ENRICHMENT, not correctness — and every caller already says
@@ -214,7 +210,7 @@ export async function resolveGraphOutputs(
     // were effectively un-caught:
     //
     //   - `getCachedResources` (Redis + Postgres)
-    //   - `appBlocksForGraph` → `buildAppBlockLookup` → the installedApps
+    //   - `manifestLookupForGraph` → `buildManifestLookup` → the installedApps
     //     provider (Redis + Postgres), reached by any graph holding an
     //     `appId:blockId` node
     //

--- a/packages/lib/src/workflows/graph-edit/__tests__/input-wiring.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/input-wiring.test.ts
@@ -22,6 +22,9 @@ const getCachedResources = vi.fn()
 vi.mock('../../../cache', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../cache')>()),
   getCachedResources: (...args: unknown[]) => getCachedResources(...args),
+  // No installed apps: these suites exercise CORE node types, so the manifest
+  // lookup `loadDraftContext` builds must resolve to the registry alone.
+  getCachedInstalledApps: async () => [],
 }))
 
 // The persist seam writes through WorkflowService.update (lazy-imported in
@@ -49,11 +52,15 @@ const { runNode } = await import('../run-node')
 import { BadRequestError } from '../../../errors'
 import { manualManifest } from '../../../workflow-engine/catalog/nodes/manual'
 import { staticOutputContext } from '../../../workflow-engine/catalog/output-context'
+import { getManifest } from '../../../workflow-engine/catalog/registry'
 // The SHIPPED template, loaded rather than re-typed, so this test cannot drift
 // away from the graph shape that actually exists in the repo.
 import manualTicketTriage from '../../templates/manual-ticket-triage.template.json'
 import type { DraftGraph, GraphEdge, GraphNode } from '../types'
 import { validateGraphStructure } from '../validate'
+
+/** The core registry alone — no app installed in these fixtures. */
+const coreLookup = getManifest
 
 const ORG = 'org_1'
 const APP = 'wfapp_1'
@@ -187,7 +194,7 @@ beforeEach(() => {
 
 describe('validateGraphStructure — input wiring (§2)', () => {
   it('the shipped manual-ticket-triage graph produces ZERO blocking issues', () => {
-    const issues = validateGraphStructure(TEMPLATE_GRAPH)
+    const issues = validateGraphStructure(TEMPLATE_GRAPH, { lookup: coreLookup })
     expect(errors(issues)).toEqual([])
   })
 
@@ -196,7 +203,7 @@ describe('validateGraphStructure — input wiring (§2)', () => {
       nodes: [formInputNode(), manualNode(), waitNode()],
       edges: [inputEdge(FORM_ID, MANUAL_ID), edge(MANUAL_ID, 'source', WAIT_ID)],
     }
-    expect(errors(validateGraphStructure(graph))).toEqual([])
+    expect(errors(validateGraphStructure(graph, { lookup: coreLookup }))).toEqual([])
   })
 
   it('an input-handle edge into a node that does NOT accept inputs is still an error', () => {
@@ -204,7 +211,7 @@ describe('validateGraphStructure — input wiring (§2)', () => {
       nodes: [manualNode(), formInputNode(), waitNode()],
       edges: [edge(MANUAL_ID, 'source', WAIT_ID), inputEdge(FORM_ID, WAIT_ID)],
     }
-    const blocking = errors(validateGraphStructure(graph))
+    const blocking = errors(validateGraphStructure(graph, { lookup: coreLookup }))
     expect(blocking.some((i) => /unknown handle "input"/.test(i.message))).toBe(true)
   })
 
@@ -213,7 +220,7 @@ describe('validateGraphStructure — input wiring (§2)', () => {
       nodes: [manualNode(), waitNode()],
       edges: [edge(WAIT_ID, 'source', MANUAL_ID)],
     }
-    const blocking = errors(validateGraphStructure(graph))
+    const blocking = errors(validateGraphStructure(graph, { lookup: coreLookup }))
     expect(blocking.some((i) => /incoming connections/.test(i.message))).toBe(true)
   })
 
@@ -222,7 +229,7 @@ describe('validateGraphStructure — input wiring (§2)', () => {
       nodes: [formInputNode(), manualNode()],
       edges: [edge(FORM_ID, 'source', MANUAL_ID)],
     }
-    const blocking = errors(validateGraphStructure(graph))
+    const blocking = errors(validateGraphStructure(graph, { lookup: coreLookup }))
     expect(blocking.some((i) => /incoming connections/.test(i.message))).toBe(true)
   })
 
@@ -247,7 +254,7 @@ describe('validateGraphStructure — input wiring (§2)', () => {
       ],
       edges: [inputEdge(APP_BLOCK_ID, MANUAL_ID)],
     }
-    const blocking = errors(validateGraphStructure(graph))
+    const blocking = errors(validateGraphStructure(graph, { lookup: coreLookup }))
     expect(blocking.some((i) => /unknown handle "input"/.test(i.message))).toBe(true)
     expect(blocking.some((i) => /incoming connections/.test(i.message))).toBe(true)
   })
@@ -416,7 +423,7 @@ describe('addNode({ inputFor }) (§4b)', () => {
 
     // Canvas parity, and the graph the writer produced is one the validator accepts.
     expect(persisted.nodes.find((n) => n.id === MANUAL_ID)?.data?.inputNodes).toEqual([created.id])
-    expect(errors(validateGraphStructure(persisted))).toEqual([])
+    expect(errors(validateGraphStructure(persisted, { lookup: coreLookup }))).toEqual([])
   })
 
   it('stacks a second field left of the trigger with an ordered run-form position', async () => {
@@ -460,7 +467,7 @@ describe('addNode({ inputFor }) (§4b)', () => {
       subject.id,
       body.id,
     ])
-    expect(errors(validateGraphStructure(afterSecond))).toEqual([])
+    expect(errors(validateGraphStructure(afterSecond, { lookup: coreLookup }))).toEqual([])
   })
 
   it('keeps a `position` the caller set explicitly', async () => {

--- a/packages/lib/src/workflows/graph-edit/__tests__/manifest-lookup.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/manifest-lookup.test.ts
@@ -1,0 +1,220 @@
+// packages/lib/src/workflows/graph-edit/__tests__/manifest-lookup.test.ts
+
+/**
+ * The threaded `ManifestLookup` (plan 17 PR B2).
+ *
+ * Every assertion here is a PAIR: the same graph judged with the core registry
+ * alone, and with a lookup that also resolves an installed app's block. The
+ * pair is the point — each of these sites used to read `getManifest` directly,
+ * so the app-block column is what threading the lookup bought, and the
+ * core-only column is the regression guard that core types did not shift.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import type { CachedInstalledApp, CachedWorkflowBlock } from '../../../cache/org-cache-keys'
+
+// Partial mock — `read.ts` pulls the cache barrel in through its module graph.
+// Nothing here reads the cache; the lookups are built by hand.
+vi.mock('../../../cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../cache')>()),
+  getCachedInstalledApps: async () => [],
+}))
+
+const { buildGraphSummary } = await import('../read')
+
+import { synthesizeAppBlockManifest } from '../../../workflow-engine/catalog/app-manifests'
+import { getManifest } from '../../../workflow-engine/catalog/registry'
+import type { ManifestLookup } from '../../../workflow-engine/catalog/types'
+import { resolveConnectionSpec } from '../normalize/connection'
+import type { DraftGraph, GraphNode } from '../types'
+import { isInputNodePair, validateGraphStructure, validateNodeConfigs } from '../validate'
+
+const APP_ID = 'z3prnwpd3rt31mp7f9yxo5m6'
+const APP_TYPE = `${APP_ID}:fedex`
+const BLOCK_ID = 'fedex-DmJuCD8M2cAE0Hqdua0Ns'
+const MANUAL_ID = 'manual-aaaaaaaaaaaaaaaaaaa'
+const FORM_ID = 'form-input-aaaaaaaaaaaaaaa'
+
+const installation = {
+  installationId: 'inst_1',
+  installationType: 'production',
+  installedAt: '2026-08-01T00:00:00.000Z',
+  app: {
+    id: APP_ID,
+    slug: 'fedex',
+    title: 'FedEx',
+    description: null,
+    avatarUrl: null,
+    category: null,
+  },
+  currentDeployment: null,
+  methods: [],
+  connectionDefinitions: {},
+  orgConnectionPresent: true,
+  orgConnectionExpiresAt: null,
+} as CachedInstalledApp
+
+const block: CachedWorkflowBlock = {
+  id: 'fedex',
+  label: 'FedEx',
+  iconKey: null,
+  inputsJsonSchema: {},
+  toolMap: { 'shipment.track': 'tool_track' },
+  refs: [],
+  ops: [
+    {
+      key: 'shipment.track',
+      resource: 'shipment',
+      operation: 'track',
+      toolId: 'tool_track',
+      inputsJsonSchema: {},
+      outputsJsonSchema: {},
+      requiresConnection: true,
+    },
+  ],
+}
+
+/** The core registry alone — what every one of these sites used to read. */
+const coreOnly: ManifestLookup = getManifest
+
+/** Core registry ∪ one installed app's block — what `buildManifestLookup` returns. */
+const withApp: ManifestLookup = (type) =>
+  getManifest(type) ??
+  (type === APP_TYPE ? synthesizeAppBlockManifest(installation, block) : undefined)
+
+function appBlockNode(data: Record<string, unknown> = {}): GraphNode {
+  return {
+    id: BLOCK_ID,
+    type: 'standard',
+    position: { x: 0, y: 0 },
+    data: {
+      id: BLOCK_ID,
+      type: APP_TYPE,
+      title: 'FedEx',
+      appId: APP_ID,
+      blockId: 'fedex',
+      resource: 'shipment',
+      operation: 'track',
+      ...data,
+    },
+  }
+}
+
+function manualNode(): GraphNode {
+  return {
+    id: MANUAL_ID,
+    type: 'standard',
+    position: { x: 0, y: 0 },
+    data: { id: MANUAL_ID, type: 'manual', title: 'Manual Trigger' },
+  }
+}
+
+const errors = (issues: ReturnType<typeof validateGraphStructure>) =>
+  issues.filter((i) => i.severity === 'error')
+
+describe('validateGraphStructure', () => {
+  const graph: DraftGraph = { nodes: [manualNode(), appBlockNode()], edges: [] }
+
+  it('refuses a NEWLY authored app-block node the org has not installed', () => {
+    const blocking = errors(
+      validateGraphStructure(graph, { lookup: coreOnly, newNodeIds: new Set([BLOCK_ID]) })
+    )
+
+    expect(blocking).toHaveLength(1)
+    expect(blocking[0]?.message).toContain('Unknown node type')
+  })
+
+  it('accepts the same node once the lookup resolves it', () => {
+    // The whole point of B2: this write used to be impossible, and the error
+    // said the type did not exist when it plainly did.
+    expect(
+      errors(validateGraphStructure(graph, { lookup: withApp, newNodeIds: new Set([BLOCK_ID]) }))
+    ).toEqual([])
+  })
+
+  it('never blocks a PRE-EXISTING app-block node either way', () => {
+    // Not in `newNodeIds`: an orphan from an uninstalled app must not make the
+    // whole workflow uneditable (the #1649 shape).
+    expect(errors(validateGraphStructure(graph, { lookup: coreOnly }))).toEqual([])
+    expect(errors(validateGraphStructure(graph, { lookup: withApp }))).toEqual([])
+  })
+})
+
+describe('validateNodeConfigs', () => {
+  it('says nothing about an app block the core registry cannot see', () => {
+    // `if (!manifest) continue` — zero config validation, ever. This is the
+    // silence B2 replaces.
+    const graph: DraftGraph = { nodes: [appBlockNode({ operation: 'teleport' })], edges: [] }
+
+    expect(validateNodeConfigs(graph, coreOnly)).toEqual([])
+  })
+
+  it('runs the synthesized validator once the lookup resolves it', () => {
+    const graph: DraftGraph = { nodes: [appBlockNode({ operation: 'teleport' })], edges: [] }
+    const issues = validateNodeConfigs(graph, withApp)
+
+    expect(issues.some((i) => i.severity === 'error' && i.field === 'operation')).toBe(true)
+  })
+})
+
+describe('buildGraphSummary', () => {
+  const graph: DraftGraph = { nodes: [manualNode(), appBlockNode()], edges: [] }
+
+  it('lists an unresolvable app block as read-only', () => {
+    expect(buildGraphSummary(graph, coreOnly).readOnlyNodes).toEqual(['FedEx'])
+  })
+
+  it('stops listing it once the org has the app installed', () => {
+    // The §8 outcome: an installed app's block is authorable, so it is no
+    // longer announced as read-only on every single read.
+    expect(buildGraphSummary(graph, withApp).readOnlyNodes).toBeUndefined()
+  })
+})
+
+describe('isInputNodePair', () => {
+  it('refuses an app block as an input node, by declaration rather than by absence', () => {
+    // Before B2 this held because the app block had NO manifest. Now it holds
+    // because the manifest says `category: INTEGRATION` and
+    // `acceptsInputNodes: false` — which is what must keep holding.
+    const target = manualNode()
+
+    expect(isInputNodePair(appBlockNode(), target, coreOnly)).toBe(false)
+    expect(isInputNodePair(appBlockNode(), target, withApp)).toBe(false)
+    // The manifest states it outright, so the guard no longer rests on silence.
+    expect(withApp(APP_TYPE)?.connection.acceptsInputNodes).toBe(false)
+  })
+
+  it('still accepts the real input pair it exists for', () => {
+    const form: GraphNode = {
+      id: FORM_ID,
+      type: 'standard',
+      position: { x: 0, y: 0 },
+      data: { id: FORM_ID, type: 'form-input', title: 'Order number' },
+    }
+
+    expect(isInputNodePair(form, manualNode(), withApp)).toBe(true)
+  })
+})
+
+describe('resolveConnectionSpec', () => {
+  it('connects an app block on the default source handle', () => {
+    // App blocks declare no branches, so this is unchanged — but it is now
+    // unchanged because the manifest says so, not because it was missing.
+    const nodes = [appBlockNode()]
+
+    expect(resolveConnectionSpec(nodes, { after: 'FedEx' }, withApp)._unsafeUnwrap()).toEqual({
+      sourceNodeId: BLOCK_ID,
+      sourceHandle: 'source',
+    })
+  })
+
+  it('rejects a branch on a node that has none', () => {
+    const result = resolveConnectionSpec(
+      [appBlockNode()],
+      { after: 'FedEx', branch: 'fail' },
+      withApp
+    )
+
+    expect(result.isErr()).toBe(true)
+  })
+})

--- a/packages/lib/src/workflows/graph-edit/__tests__/normalize.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/normalize.test.ts
@@ -15,6 +15,9 @@ const getCachedResources = vi.fn()
 vi.mock('../../../cache', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../cache')>()),
   getCachedResources: (...args: unknown[]) => getCachedResources(...args),
+  // No installed apps: these suites exercise CORE node types, so the manifest
+  // lookup `loadDraftContext` builds must resolve to the registry alone.
+  getCachedInstalledApps: async () => [],
 }))
 
 const { resolveConnectionSpec } = await import('../normalize/connection')
@@ -24,7 +27,11 @@ const { buildResourceAliasIndex, normalizeResourceConfig, resolveResourceRef } =
   '../normalize/resource-refs'
 )
 
+import { getManifest } from '../../../workflow-engine/catalog/registry'
 import type { NodeMeta } from '../types'
+
+/** The core registry alone — no app installed in these fixtures. */
+const coreLookup = getManifest
 
 const ORG = 'org_1'
 const TICKET_ID = 'i5aezsg4bc6n8gof2uan3wcf'
@@ -233,7 +240,9 @@ describe('resolveConnectionSpec', () => {
   const nodes = [ifElse, wait, http]
 
   it('connects after a branchless node on the default source handle', () => {
-    expect(resolveConnectionSpec(nodes, { after: 'Wait A Bit' })._unsafeUnwrap()).toEqual({
+    expect(
+      resolveConnectionSpec(nodes, { after: 'Wait A Bit' }, coreLookup)._unsafeUnwrap()
+    ).toEqual({
       sourceNodeId: 'w1aaaaaaaaaaaaaaaaaaaa',
       sourceHandle: 'source',
     })
@@ -241,28 +250,38 @@ describe('resolveConnectionSpec', () => {
 
   it('resolves a branch by display name through manifest.connection.branches', () => {
     expect(
-      resolveConnectionSpec(nodes, { after: 'Route It', branch: 'else' })._unsafeUnwrap()
+      resolveConnectionSpec(
+        nodes,
+        { after: 'Route It', branch: 'else' },
+        coreLookup
+      )._unsafeUnwrap()
     ).toEqual({ sourceNodeId: 'if1aaaaaaaaaaaaaaaaaaa', sourceHandle: 'false' })
     expect(
-      resolveConnectionSpec(nodes, { after: 'Route It', branch: 'IF' })._unsafeUnwrap()
+      resolveConnectionSpec(nodes, { after: 'Route It', branch: 'IF' }, coreLookup)._unsafeUnwrap()
     ).toEqual({ sourceNodeId: 'if1aaaaaaaaaaaaaaaaaaa', sourceHandle: 'case-a' })
   })
 
   it('resolves a branch by handle id', () => {
     expect(
-      resolveConnectionSpec(nodes, { after: 'Call API', branch: 'fail' })._unsafeUnwrap()
+      resolveConnectionSpec(
+        nodes,
+        { after: 'Call API', branch: 'fail' },
+        coreLookup
+      )._unsafeUnwrap()
     ).toEqual({ sourceNodeId: 'h1aaaaaaaaaaaaaaaaaaaa', sourceHandle: 'fail' })
   })
 
   it('uses the single default branch when none is specified (http)', () => {
-    expect(resolveConnectionSpec(nodes, { after: 'Call API' })._unsafeUnwrap()).toEqual({
-      sourceNodeId: 'h1aaaaaaaaaaaaaaaaaaaa',
-      sourceHandle: 'source',
-    })
+    expect(resolveConnectionSpec(nodes, { after: 'Call API' }, coreLookup)._unsafeUnwrap()).toEqual(
+      {
+        sourceNodeId: 'h1aaaaaaaaaaaaaaaaaaaa',
+        sourceHandle: 'source',
+      }
+    )
   })
 
   it('errors when a multi-branch node gets no branch, naming every branch', () => {
-    const result = resolveConnectionSpec(nodes, { after: 'Route It' })
+    const result = resolveConnectionSpec(nodes, { after: 'Route It' }, coreLookup)
     expect(result.isErr()).toBe(true)
     const message = result._unsafeUnwrapErr().message
     expect(message).toContain('case-a')
@@ -270,7 +289,11 @@ describe('resolveConnectionSpec', () => {
   })
 
   it('errors on an unknown branch, naming the candidates', () => {
-    const result = resolveConnectionSpec(nodes, { after: 'Route It', branch: 'no match' })
+    const result = resolveConnectionSpec(
+      nodes,
+      { after: 'Route It', branch: 'no match' },
+      coreLookup
+    )
     expect(result.isErr()).toBe(true)
     const message = result._unsafeUnwrapErr().message
     expect(message).toContain('No branch "no match"')
@@ -279,12 +302,12 @@ describe('resolveConnectionSpec', () => {
   })
 
   it('errors when a branch is named on a branchless node', () => {
-    const result = resolveConnectionSpec(nodes, { after: 'Wait A Bit', branch: 'fail' })
+    const result = resolveConnectionSpec(nodes, { after: 'Wait A Bit', branch: 'fail' }, coreLookup)
     expect(result.isErr()).toBe(true)
     expect(result._unsafeUnwrapErr().message).toContain('has no branches')
   })
 
   it('propagates node-ref resolution errors (unknown after)', () => {
-    expect(resolveConnectionSpec(nodes, { after: 'Ghost' }).isErr()).toBe(true)
+    expect(resolveConnectionSpec(nodes, { after: 'Ghost' }, coreLookup).isErr()).toBe(true)
   })
 })

--- a/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
@@ -17,6 +17,9 @@ const getCachedResources = vi.fn()
 vi.mock('../../../cache', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../cache')>()),
   getCachedResources: (...args: unknown[]) => getCachedResources(...args),
+  // No installed apps: these suites exercise CORE node types, so the manifest
+  // lookup `loadDraftContext` builds must resolve to the registry alone.
+  getCachedInstalledApps: async () => [],
 }))
 
 // The persist seam writes through WorkflowService.update (lazy-imported in

--- a/packages/lib/src/workflows/graph-edit/__tests__/ref-check.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/ref-check.test.ts
@@ -8,9 +8,13 @@
  */
 
 import { describe, expect, it, vi } from 'vitest'
+import { getManifest } from '../../../workflow-engine/catalog/registry'
 import { BaseType } from '../../../workflow-engine/core/types'
 import type { UnifiedVariable } from '../../../workflow-engine/types/unified-variable'
 import type { NodeMeta, WorkflowOutputGraph } from '../types'
+
+/** The core registry alone — no app installed in these fixtures. */
+const coreLookup = getManifest
 
 // ref-check statically imports the catalog's server-side resolve-outputs, whose
 // cache read must not hit a real backend if the composed helper is ever used.
@@ -18,6 +22,9 @@ const getCachedResources = vi.fn().mockResolvedValue([])
 vi.mock('../../../cache', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../cache')>()),
   getCachedResources: (...args: unknown[]) => getCachedResources(...args),
+  // No installed apps: these suites exercise CORE node types, so the manifest
+  // lookup `loadDraftContext` builds must resolve to the registry alone.
+  getCachedInstalledApps: async () => [],
 }))
 
 const { checkVariableRefsAgainstOutputs } = await import('../normalize/ref-check')
@@ -86,6 +93,7 @@ const check = (refs: string[]) =>
   checkVariableRefsAgainstOutputs({
     graph: graphWith(consumerNode(refs.map((r) => `{{${r}}}`))),
     outputs: new Map([[FIND, FIND_OUTPUTS]]),
+    lookup: coreLookup,
   })
 
 describe('checkVariableRefsAgainstOutputs', () => {
@@ -161,7 +169,11 @@ describe('checkVariableRefsAgainstOutputs', () => {
 
   it('skips path validation for nodes with no declared outputs (not-yet-migrated)', () => {
     const graph = graphWith(consumerNode([`{{${FIND}.anything.at.all}}`]))
-    const { issues } = checkVariableRefsAgainstOutputs({ graph, outputs: new Map() })
+    const { issues } = checkVariableRefsAgainstOutputs({
+      graph,
+      outputs: new Map(),
+      lookup: coreLookup,
+    })
     expect(issues).toEqual([])
   })
 
@@ -180,7 +192,11 @@ describe('checkVariableRefsAgainstOutputs', () => {
       ],
       edges: [],
     }
-    const { issues } = checkVariableRefsAgainstOutputs({ graph, outputs: new Map() })
+    const { issues } = checkVariableRefsAgainstOutputs({
+      graph,
+      outputs: new Map(),
+      lookup: coreLookup,
+    })
     expect(issues).toEqual([])
   })
 })

--- a/packages/lib/src/workflows/graph-edit/__tests__/run-node.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/run-node.test.ts
@@ -12,6 +12,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NotFoundError, UnprocessableEntityError } from '../../../errors'
 
+// Partial mock — `loadDraftContext` builds the per-org manifest lookup, which
+// reads the installed-apps org cache. No app is installed in these fixtures, so
+// the lookup must resolve to the core registry alone. Partial, never wholesale:
+// the cache barrel is imported by half of lib and replacing it dies at
+// collection.
+vi.mock('../../../cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../cache')>()),
+  getCachedInstalledApps: async () => [],
+}))
+
 // The execution service constructs the whole engine off its constructor —
 // replaced so none of that module graph loads (run-node lazy-imports it).
 const runSingleNode = vi.fn()

--- a/packages/lib/src/workflows/graph-edit/__tests__/turn-lifecycle.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/turn-lifecycle.test.ts
@@ -24,6 +24,9 @@ const getCachedResources = vi.fn()
 vi.mock('../../../cache', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../cache')>()),
   getCachedResources: (...args: unknown[]) => getCachedResources(...args),
+  // No installed apps: these suites exercise CORE node types, so the manifest
+  // lookup `loadDraftContext` builds must resolve to the registry alone.
+  getCachedInstalledApps: async () => [],
 }))
 
 // The persist seam writes through WorkflowService.update (lazy-imported in

--- a/packages/lib/src/workflows/graph-edit/normalize/connection.ts
+++ b/packages/lib/src/workflows/graph-edit/normalize/connection.ts
@@ -10,12 +10,16 @@
  * single source for the handle ids the canvas renders and the processors
  * emit — NEVER string-matched locally, so a rename of a branch-derivation rule
  * can't silently detach agent-authored edges.
+ *
+ * The manifest arrives as a `ManifestLookup` rather than being read from the
+ * registry here, so an app block resolves through the same path as a core type.
+ * App blocks declare no branches, so they keep landing on `source` — but by
+ * their manifest saying so, not by their manifest being absent.
  */
 
 import { err, ok, type Result } from 'neverthrow'
 import { type AuxxError, BadRequestError } from '../../../errors'
-import { getManifest } from '../../../workflow-engine/catalog/registry'
-import type { NodeBranch } from '../../../workflow-engine/catalog/types'
+import type { ManifestLookup, NodeBranch } from '../../../workflow-engine/catalog/types'
 import { describeNode, resolveNodeRef } from '../refs'
 import type { NodeMeta } from '../types'
 
@@ -46,14 +50,15 @@ function describeBranch(branch: NodeBranch): string {
  */
 export function resolveConnectionSpec(
   nodes: NodeMeta[],
-  params: { after: string; branch?: string }
+  params: { after: string; branch?: string },
+  lookup: ManifestLookup
 ): Result<ConnectionSpec, AuxxError> {
   const resolved = resolveNodeRef(nodes, params.after)
   if (resolved.isErr()) return err(resolved.error)
   const source = resolved.value.node
 
   const nodeType: string | undefined = source.data?.type ?? source.type
-  const manifest = nodeType ? getManifest(nodeType) : undefined
+  const manifest = nodeType ? lookup(nodeType) : undefined
   const branches = manifest?.connection.branches?.(source.data) ?? []
 
   const branchRef = params.branch?.trim()

--- a/packages/lib/src/workflows/graph-edit/normalize/ref-check.ts
+++ b/packages/lib/src/workflows/graph-edit/normalize/ref-check.ts
@@ -20,9 +20,10 @@
  */
 
 import { err, ok, type Result } from 'neverthrow'
+import { buildManifestLookup } from '../../../workflow-engine/catalog/app-manifests'
 import { buildUpstreamMap } from '../../../workflow-engine/catalog/graph-vars'
-import { getManifest } from '../../../workflow-engine/catalog/registry'
 import { resolveGraphOutputs } from '../../../workflow-engine/catalog/resolve-outputs'
+import type { ManifestLookup } from '../../../workflow-engine/catalog/types'
 import type { UnifiedVariable } from '../../../workflow-engine/types/unified-variable'
 import { firstPathSegment, rewriteVariableRefs } from '../../variable-ref-rewriter'
 import { closestMatches, formatNodeRef, nodeTitle } from '../refs'
@@ -135,8 +136,8 @@ function collectionCorrection(rawPath: string, idMap: Map<string, UnifiedVariabl
 }
 
 /** Extract every variable ref a node reads: manifest extractor first, generic walk otherwise. */
-function extractNodeRefs(node: NodeMeta, nodeIds: Set<string>): string[] {
-  const manifest = getManifest(node.data?.type ?? node.type)
+function extractNodeRefs(node: NodeMeta, nodeIds: Set<string>, lookup: ManifestLookup): string[] {
+  const manifest = lookup(node.data?.type ?? node.type)
   if (manifest?.extractVariables) {
     try {
       return manifest.extractVariables(node.data)
@@ -187,8 +188,9 @@ function containerAncestors(node: NodeMeta, nodeById: Map<string, NodeMeta>): Se
 export function checkVariableRefsAgainstOutputs(params: {
   graph: WorkflowOutputGraph
   outputs: Map<string, UnifiedVariable[]>
+  lookup: ManifestLookup
 }): RefCheckResult {
-  const { graph, outputs } = params
+  const { graph, outputs, lookup } = params
   const issues: Issue[] = []
   const corrections: RefCorrection[] = []
 
@@ -212,7 +214,7 @@ export function checkVariableRefsAgainstOutputs(params: {
     const upstream = upstreamMap.get(consumer.id) ?? new Set<string>()
     const containers = containerAncestors(consumer, nodeById)
 
-    for (const rawPath of extractNodeRefs(consumer, nodeIds)) {
+    for (const rawPath of extractNodeRefs(consumer, nodeIds, lookup)) {
       const head = firstPathSegment(rawPath)
       if (!head || RESERVED_PREFIXES.has(head)) continue
       // A head-only string carries no output path to validate — and bare
@@ -328,5 +330,11 @@ export async function checkGraphRefs(
 ): Promise<Result<RefCheckResult, Error>> {
   const outputs = await resolveGraphOutputs(orgId, { graph: params.graph })
   if (outputs.isErr()) return err(outputs.error)
-  return ok(checkVariableRefsAgainstOutputs({ graph: params.graph, outputs: outputs.value }))
+  return ok(
+    checkVariableRefsAgainstOutputs({
+      graph: params.graph,
+      outputs: outputs.value,
+      lookup: await buildManifestLookup(orgId),
+    })
+  )
 }

--- a/packages/lib/src/workflows/graph-edit/ops.ts
+++ b/packages/lib/src/workflows/graph-edit/ops.ts
@@ -23,9 +23,13 @@ import { err, ok, type Result } from 'neverthrow'
 import { AuxxError, BadRequestError, ConflictError, NotFoundError } from '../../errors'
 import { isDerivedKey, stripDerivedKeys } from '../../workflow-engine/catalog/derived-keys'
 import { LOOP_HANDLES } from '../../workflow-engine/catalog/nodes/loop'
-import { getAuthorableManifests, getManifest } from '../../workflow-engine/catalog/registry'
+import { getAuthorableManifests } from '../../workflow-engine/catalog/registry'
 import { resolveGraphOutputs } from '../../workflow-engine/catalog/resolve-outputs'
-import { NodeCategory, type NodeManifest } from '../../workflow-engine/catalog/types'
+import {
+  type ManifestLookup,
+  NodeCategory,
+  type NodeManifest,
+} from '../../workflow-engine/catalog/types'
 import type { UnifiedVariable } from '../../workflow-engine/types/unified-variable'
 import { hashWorkflowGraph } from '../graph-hash'
 import { assertMailTriggerNotPersonal } from '../mail-trigger-guard'
@@ -124,6 +128,7 @@ async function runGraphMutation(
   const { graph } = plan
 
   const structural = validateGraphStructure(graph, {
+    lookup: ctx.lookup,
     ...(plan.skipAuthorableCheck ? {} : { newNodeIds: plan.newNodeIds }),
   })
   const guardIssues: Issue[] = []
@@ -146,16 +151,22 @@ async function runGraphMutation(
     return ok({
       applied: false,
       issues: [...plan.normalizeIssues, ...structural, ...guardIssues],
-      graphSummary: buildGraphSummary(ctx.graph, ctx.triggerType),
+      graphSummary: buildGraphSummary(ctx.graph, ctx.lookup, ctx.triggerType),
     })
   }
 
-  const issues: Issue[] = [...plan.normalizeIssues, ...structural, ...validateNodeConfigs(graph)]
+  const issues: Issue[] = [
+    ...plan.normalizeIssues,
+    ...structural,
+    ...validateNodeConfigs(graph, ctx.lookup),
+  ]
   let outputsMap: Map<string, UnifiedVariable[]> | undefined
   const resolved = await resolveGraphOutputs(scope.organizationId, { graph })
   if (resolved.isOk()) {
     outputsMap = resolved.value
-    issues.push(...checkVariableRefsAgainstOutputs({ graph, outputs: outputsMap }).issues)
+    issues.push(
+      ...checkVariableRefsAgainstOutputs({ graph, outputs: outputsMap, lookup: ctx.lookup }).issues
+    )
   }
 
   // Mark what this edit did NOT cause. A mutation reports the whole draft's
@@ -205,7 +216,7 @@ async function runGraphMutation(
       unchanged: true,
       ...(unchangedNode ? { node: buildNodeSummary(graph, unchangedNode, aliases) } : {}),
       issues,
-      graphSummary: buildGraphSummary(ctx.graph, ctx.triggerType),
+      graphSummary: buildGraphSummary(ctx.graph, ctx.lookup, ctx.triggerType),
     })
   }
 
@@ -273,7 +284,11 @@ async function runGraphMutation(
       ? { outputs: renderFriendlyOutputs(graph, outputsMap.get(touched.id) ?? [], aliases) }
       : {}),
     issues,
-    graphSummary: buildGraphSummary(graph, persisted.value.triggerType ?? ctx.triggerType),
+    graphSummary: buildGraphSummary(
+      graph,
+      ctx.lookup,
+      persisted.value.triggerType ?? ctx.triggerType
+    ),
   })
 }
 
@@ -307,8 +322,11 @@ async function normalizeConfig(
 }
 
 /** Manifest for an authorable type, or an actionable error naming the options. */
-function requireAuthorableManifest(type: string): Result<NodeManifest<any>, AuxxError> {
-  const manifest = getManifest(type)
+function requireAuthorableManifest(
+  type: string,
+  lookup: ManifestLookup
+): Result<NodeManifest<any>, AuxxError> {
+  const manifest = lookup(type)
   if (manifest?.agent?.authorable === true) return ok(manifest)
   const authorable = getAuthorableManifests()
     .map((m) => m.id)
@@ -355,9 +373,10 @@ function makeEdge(
 function resolveEdgeHandles(
   source: GraphNode | undefined,
   target: GraphNode,
-  sourceHandle: string
+  sourceHandle: string,
+  lookup: ManifestLookup
 ): { sourceHandle: string; targetHandle: string } {
-  if (source && isInputNodePair(source, target)) return { ...INPUT_WIRING_HANDLES }
+  if (source && isInputNodePair(source, target, lookup)) return { ...INPUT_WIRING_HANDLES }
   return { sourceHandle, targetHandle: 'target' }
 }
 
@@ -370,11 +389,11 @@ function resolveEdgeHandles(
 function updateInputNodes(
   nodes: GraphNode[],
   update: (current: string[]) => string[],
-  opts: { onlyNodeId?: string } = {}
+  opts: { lookup: ManifestLookup; onlyNodeId?: string }
 ): GraphNode[] {
   return nodes.map((node) => {
     if (opts.onlyNodeId !== undefined && node.id !== opts.onlyNodeId) return node
-    if (getManifest(nodeType(node))?.connection.acceptsInputNodes !== true) return node
+    if (opts.lookup(nodeType(node))?.connection.acceptsInputNodes !== true) return node
     const current = Array.isArray(node.data?.inputNodes)
       ? (node.data.inputNodes as unknown[]).filter((id): id is string => typeof id === 'string')
       : []
@@ -515,7 +534,7 @@ export async function addNode(
   params: AddNodeInput
 ): Promise<Result<GraphMutationResult, AuxxError>> {
   return runGraphMutation(db, params, async (ctx, aliases) => {
-    const manifestResult = requireAuthorableManifest(params.type)
+    const manifestResult = requireAuthorableManifest(params.type, ctx.lookup)
     if (manifestResult.isErr()) return err(manifestResult.error)
     const manifest = manifestResult.value
 
@@ -551,7 +570,7 @@ export async function addNode(
       const resolved = resolveNodeRef(nodes, params.inputFor)
       if (resolved.isErr()) return err(resolved.error)
       inputTarget = resolved.value.node as GraphNode
-      if (getManifest(nodeType(inputTarget))?.connection.acceptsInputNodes !== true) {
+      if (ctx.lookup(nodeType(inputTarget))?.connection.acceptsInputNodes !== true) {
         const accepting = getAuthorableManifests()
           .filter((m) => m.connection.acceptsInputNodes === true)
           .map((m) => m.id)
@@ -583,7 +602,11 @@ export async function addNode(
 
     let connection: { sourceNodeId: string; sourceHandle: string } | undefined
     if (params.after !== undefined) {
-      const spec = resolveConnectionSpec(nodes, { after: params.after, branch: params.branch })
+      const spec = resolveConnectionSpec(
+        nodes,
+        { after: params.after, branch: params.branch },
+        ctx.lookup
+      )
       if (spec.isErr()) return err(spec.error)
       connection = spec.value
       const anchor = nodes.find((n) => n.id === connection?.sourceNodeId)
@@ -685,7 +708,7 @@ export async function addNode(
     // The other half of the input-wiring rule, asked of the real node through
     // the one predicate `validateGraphStructure` uses — so this can never mint
     // an edge the validator would then reject.
-    if (inputTarget && !isInputNodePair(newNode, inputTarget)) {
+    if (inputTarget && !isInputNodePair(newNode, inputTarget, ctx.lookup)) {
       const inputTypes = getAuthorableManifests()
         .filter((m) => m.category === NodeCategory.INPUT)
         .map((m) => m.id)
@@ -702,7 +725,7 @@ export async function addNode(
 
     const newEdges: GraphEdge[] = []
     if (inputTarget) {
-      const handles = resolveEdgeHandles(newNode, inputTarget, 'source')
+      const handles = resolveEdgeHandles(newNode, inputTarget, 'source', ctx.lookup)
       newEdges.push(makeEdge(nodeId, handles.sourceHandle, inputTarget.id, handles.targetHandle))
     } else if (connection) {
       newEdges.push(makeEdge(connection.sourceNodeId, connection.sourceHandle, nodeId, 'target'))
@@ -719,7 +742,7 @@ export async function addNode(
       nextNodes = updateInputNodes(
         nextNodes as GraphNode[],
         (current) => (current.includes(nodeId) ? current : [...current, nodeId]),
-        { onlyNodeId: inputTarget.id }
+        { lookup: ctx.lookup, onlyNodeId: inputTarget.id }
       )
     }
     return ok({
@@ -778,7 +801,7 @@ export async function updateNode(
     if (resolved.isErr()) return err(resolved.error)
     const node = resolved.value.node as GraphNode
     const type = nodeType(node)
-    const manifestResult = requireAuthorableManifest(type)
+    const manifestResult = requireAuthorableManifest(type, ctx.lookup)
     if (manifestResult.isErr()) return err(manifestResult.error)
 
     const hasPatches = params.patches !== undefined
@@ -965,7 +988,8 @@ export async function deleteNodes(
       graph: {
         nodes: updateInputNodes(
           nodes.filter((n) => !toDelete.has(n.id)) as GraphNode[],
-          (current) => current.filter((id) => !toDelete.has(id))
+          (current) => current.filter((id) => !toDelete.has(id)),
+          { lookup: ctx.lookup }
         ),
         edges: [
           ...edges.filter((e) => !toDelete.has(e.source) && !toDelete.has(e.target)),
@@ -999,7 +1023,11 @@ export async function connectNodes(
 ): Promise<Result<GraphMutationResult, AuxxError>> {
   return runGraphMutation(db, params, async (ctx) => {
     const { nodes, edges } = ctx.graph
-    const spec = resolveConnectionSpec(nodes, { after: params.from, branch: params.branch })
+    const spec = resolveConnectionSpec(
+      nodes,
+      { after: params.from, branch: params.branch },
+      ctx.lookup
+    )
     if (spec.isErr()) return err(spec.error)
     const target = resolveNodeRef(nodes, params.to)
     if (target.isErr()) return err(target.error)
@@ -1010,7 +1038,7 @@ export async function connectNodes(
       nodeType(targetNode) === 'loop' &&
       (source?.parentId === targetNode.id || source?.data?.loopId === targetNode.id)
 
-    const handles = resolveEdgeHandles(source, targetNode, spec.value.sourceHandle)
+    const handles = resolveEdgeHandles(source, targetNode, spec.value.sourceHandle, ctx.lookup)
     const edge = isLoopBack
       ? makeEdge(spec.value.sourceNodeId, spec.value.sourceHandle, targetNode.id, 'loop-back', {
           isLoopBackEdge: true,
@@ -1031,7 +1059,7 @@ export async function connectNodes(
         ? updateInputNodes(
             nodes as GraphNode[],
             (current) => (current.includes(edge.source) ? current : [...current, edge.source]),
-            { onlyNodeId: targetNode.id }
+            { lookup: ctx.lookup, onlyNodeId: targetNode.id }
           )
         : nodes
 
@@ -1083,9 +1111,7 @@ export async function disconnectNodes(
       ? updateInputNodes(
           nodes as GraphNode[],
           (current) => current.filter((id) => id !== sourceId),
-          {
-            onlyNodeId: targetId,
-          }
+          { lookup: ctx.lookup, onlyNodeId: targetId }
         )
       : nodes
 
@@ -1117,7 +1143,7 @@ export async function setTrigger(
   params: SetTriggerInput
 ): Promise<Result<GraphMutationResult, AuxxError>> {
   return runGraphMutation(db, params, async (ctx, aliases) => {
-    const manifestResult = requireAuthorableManifest(params.triggerType)
+    const manifestResult = requireAuthorableManifest(params.triggerType, ctx.lookup)
     if (manifestResult.isErr()) return err(manifestResult.error)
     const manifest = manifestResult.value
     if (!manifest.triggerType) {
@@ -1134,7 +1160,7 @@ export async function setTrigger(
     }
 
     const { nodes, edges } = ctx.graph
-    const triggers = nodes.filter((n) => isTriggerNode(n as GraphNode))
+    const triggers = nodes.filter((n) => isTriggerNode(n as GraphNode, ctx.lookup))
     if (triggers.length > 1) {
       return err(
         new BadRequestError(
@@ -1261,7 +1287,7 @@ export async function replaceGraph(
     // Pass 1 — mint ids and titles so refs in configs/edges can resolve.
     const built: GraphNode[] = []
     for (const spec of params.nodes) {
-      const manifestResult = requireAuthorableManifest(spec.type)
+      const manifestResult = requireAuthorableManifest(spec.type, ctx.lookup)
       if (manifestResult.isErr()) return err(manifestResult.error)
       const manifest = manifestResult.value
       const nodeId = generateId(spec.type)
@@ -1301,7 +1327,7 @@ export async function replaceGraph(
         node.extent = 'parent'
         node.data = { ...node.data, isInLoop: true, loopId: inside.value.node.id }
       }
-      const manifest = getManifest(spec.type)
+      const manifest = ctx.lookup(spec.type)
       if (!manifest) continue
       const normalized = await normalizeConfig(
         ctx.organizationId,
@@ -1318,14 +1344,18 @@ export async function replaceGraph(
     // Pass 3 — edges through the branch resolver, loop-backs detected.
     const edges: GraphEdge[] = []
     for (const spec of params.edges) {
-      const from = resolveConnectionSpec(built, { after: spec.from, branch: spec.branch })
+      const from = resolveConnectionSpec(
+        built,
+        { after: spec.from, branch: spec.branch },
+        ctx.lookup
+      )
       if (from.isErr()) return err(from.error)
       const to = resolveNodeRef(built, spec.to)
       if (to.isErr()) return err(to.error)
       const source = built.find((n) => n.id === from.value.sourceNodeId)
       const targetNode = to.value.node as GraphNode
       const isLoopBack = nodeType(targetNode) === 'loop' && source?.parentId === targetNode.id
-      const handles = resolveEdgeHandles(source, targetNode, from.value.sourceHandle)
+      const handles = resolveEdgeHandles(source, targetNode, from.value.sourceHandle, ctx.lookup)
       const edge = isLoopBack
         ? makeEdge(from.value.sourceNodeId, from.value.sourceHandle, targetNode.id, 'loop-back', {
             isLoopBackEdge: true,
@@ -1341,8 +1371,10 @@ export async function replaceGraph(
       // `built` is mutated in place through the layout passes, so this writes
       // straight onto the node object rather than rebuilding the array.
       if (!isLoopBack && handles.targetHandle === INPUT_WIRING_HANDLES.targetHandle) {
-        const [updated] = updateInputNodes([targetNode], (current) =>
-          current.includes(edge.source) ? current : [...current, edge.source]
+        const [updated] = updateInputNodes(
+          [targetNode],
+          (current) => (current.includes(edge.source) ? current : [...current, edge.source]),
+          { lookup: ctx.lookup }
         )
         if (updated) targetNode.data = updated.data
       }

--- a/packages/lib/src/workflows/graph-edit/read.ts
+++ b/packages/lib/src/workflows/graph-edit/read.ts
@@ -16,9 +16,10 @@ import { type Database, schema } from '@auxx/database'
 import { and, eq } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import { type AuxxError, NotFoundError } from '../../errors'
+import { buildManifestLookup } from '../../workflow-engine/catalog/app-manifests'
 import { isDerivedKey, stripDerivedKeys } from '../../workflow-engine/catalog/derived-keys'
-import { getManifest } from '../../workflow-engine/catalog/registry'
 import { resolveGraphOutputs } from '../../workflow-engine/catalog/resolve-outputs'
+import type { ManifestLookup } from '../../workflow-engine/catalog/types'
 import type { UnifiedVariable } from '../../workflow-engine/types/unified-variable'
 import { hashWorkflowGraph } from '../graph-hash'
 import { type ResourceAliasIndex, renderPersistedRefs } from './normalize/friendly-refs'
@@ -48,6 +49,15 @@ export interface DraftContext {
   /** CAS token — hash of the stored graph; undefined when there is none yet. */
   graphHash?: string
   triggerType?: string | null
+  /**
+   * Core registry ∪ this org's installed app blocks, built once per operation.
+   *
+   * Deliberately built here rather than memoized somewhere longer-lived: the
+   * `installedApps` cache behind it has a 900s TTL, and a lookup pinned across
+   * operations would let two tool calls in one turn disagree about a block's
+   * shape with nothing able to invalidate the difference.
+   */
+  lookup: ManifestLookup
 }
 
 /** Scope every operation takes. */
@@ -96,6 +106,7 @@ export async function loadDraftContext(
     graph: toDraftGraph(rawGraph),
     ...(rawGraph ? { graphHash: hashWorkflowGraph(rawGraph) } : {}),
     triggerType: (draftRow?.triggerType as string | null | undefined) ?? null,
+    lookup: await buildManifestLookup(organizationId),
   })
 }
 
@@ -148,7 +159,11 @@ export function buildNodeSummary(
 }
 
 /** Compact graph summary with friendly refs. */
-export function buildGraphSummary(graph: DraftGraph, triggerType?: string | null): GraphSummary {
+export function buildGraphSummary(
+  graph: DraftGraph,
+  lookup: ManifestLookup,
+  triggerType?: string | null
+): GraphSummary {
   const edges: EdgeSummary[] = graph.edges.map((edge) => {
     const handle = edge.sourceHandle ?? 'source'
     return {
@@ -162,8 +177,12 @@ export function buildGraphSummary(graph: DraftGraph, triggerType?: string | null
   })
   // Nodes with no catalog manifest are read-only to this editor. Reported here
   // once instead of as a repeated per-node `info` issue — see GraphSummary.
+  // Read through `lookup`, so a block from an app THIS org has installed is no
+  // longer listed: it is authorable now. What stays listed is what genuinely is
+  // read-only — an unmigrated core type, or an orphan node whose app was
+  // uninstalled or whose deployment dropped the block.
   const readOnlyNodes = graph.nodes
-    .filter((node) => !getManifest(nodeType(node)))
+    .filter((node) => !lookup(nodeType(node)))
     .map((node) => formatNodeRef(graph.nodes, node.id))
 
   return {
@@ -208,13 +227,20 @@ export async function readDraft(
   const ctx = loaded.value
   const aliases = await buildResourceAliasIndex(params.organizationId)
 
-  const issues: Issue[] = [...validateGraphStructure(ctx.graph), ...validateNodeConfigs(ctx.graph)]
+  const issues: Issue[] = [
+    ...validateGraphStructure(ctx.graph, { lookup: ctx.lookup }),
+    ...validateNodeConfigs(ctx.graph, ctx.lookup),
+  ]
 
   const outputs: Record<string, UnifiedVariable[]> = {}
   const resolved = await resolveGraphOutputs(params.organizationId, { graph: ctx.graph })
   if (resolved.isOk()) {
     issues.push(
-      ...checkVariableRefsAgainstOutputs({ graph: ctx.graph, outputs: resolved.value }).issues
+      ...checkVariableRefsAgainstOutputs({
+        graph: ctx.graph,
+        outputs: resolved.value,
+        lookup: ctx.lookup,
+      }).issues
     )
     for (const node of ctx.graph.nodes) {
       outputs[formatNodeRef(ctx.graph.nodes, node.id)] = renderFriendlyOutputs(
@@ -230,10 +256,10 @@ export async function readDraft(
     name: ctx.appName,
     triggerType: ctx.triggerType,
     nodes: ctx.graph.nodes.map((node) => buildNodeSummary(ctx.graph, node, aliases)),
-    edges: buildGraphSummary(ctx.graph, ctx.triggerType).edges,
+    edges: buildGraphSummary(ctx.graph, ctx.lookup, ctx.triggerType).edges,
     outputs,
     issues,
-    graphSummary: buildGraphSummary(ctx.graph, ctx.triggerType),
+    graphSummary: buildGraphSummary(ctx.graph, ctx.lookup, ctx.triggerType),
   })
 }
 
@@ -260,11 +286,18 @@ export async function validateWorkflow(
   if (loaded.isErr()) return err(loaded.error)
   const ctx = loaded.value
 
-  const issues: Issue[] = [...validateGraphStructure(ctx.graph), ...validateNodeConfigs(ctx.graph)]
+  const issues: Issue[] = [
+    ...validateGraphStructure(ctx.graph, { lookup: ctx.lookup }),
+    ...validateNodeConfigs(ctx.graph, ctx.lookup),
+  ]
   const resolved = await resolveGraphOutputs(params.organizationId, { graph: ctx.graph })
   if (resolved.isOk()) {
     issues.push(
-      ...checkVariableRefsAgainstOutputs({ graph: ctx.graph, outputs: resolved.value }).issues
+      ...checkVariableRefsAgainstOutputs({
+        graph: ctx.graph,
+        outputs: resolved.value,
+        lookup: ctx.lookup,
+      }).issues
     )
   }
 

--- a/packages/lib/src/workflows/graph-edit/run-node.ts
+++ b/packages/lib/src/workflows/graph-edit/run-node.ts
@@ -32,7 +32,6 @@
 import type { Database } from '@auxx/database'
 import { err, ok, type Result } from 'neverthrow'
 import { AuxxError, BadRequestError, NotFoundError, UnprocessableEntityError } from '../../errors'
-import { getManifest } from '../../workflow-engine/catalog/registry'
 import { type GraphEditScope, loadDraftContext } from './read'
 import { describeNode, resolveNodeRef } from './refs'
 import type { GraphNode, Issue } from './types'
@@ -91,7 +90,7 @@ export async function runNode(
   // `form-input`, which never executes at all — `NON_EXECUTABLE_NODE_TYPES`)
   // are refused HERE. Sent on, they reach the engine, get skipped, and come
   // back as a meaningless "succeeded" with no outputs.
-  const manifest = getManifest(nodeType(node))
+  const manifest = ctx.lookup(nodeType(node))
   if (manifest?.connection.canRunSingle === false) {
     return err(
       new BadRequestError(
@@ -103,7 +102,7 @@ export async function runNode(
 
   // Tier-2 config validation, scoped to this node — a run needs a valid
   // config even though a draft legitimately persists without one.
-  const configIssues = validateNodeConfigs({ nodes: [node], edges: [] })
+  const configIssues = validateNodeConfigs({ nodes: [node], edges: [] }, ctx.lookup)
   const blocking = configIssues.filter((issue) => issue.severity === 'error')
   if (blocking.length > 0) {
     return err(

--- a/packages/lib/src/workflows/graph-edit/validate.ts
+++ b/packages/lib/src/workflows/graph-edit/validate.ts
@@ -23,8 +23,8 @@
  * that declares `acceptsInputNodes` (see `isInputNodePair`).
  */
 
-import { getAuthorableManifests, getManifest } from '../../workflow-engine/catalog/registry'
-import { NodeCategory } from '../../workflow-engine/catalog/types'
+import { getAuthorableManifests } from '../../workflow-engine/catalog/registry'
+import { type ManifestLookup, NodeCategory } from '../../workflow-engine/catalog/types'
 import { formatNodeRef } from './refs'
 import type { DraftGraph, GraphEdge, GraphNode, Issue } from './types'
 
@@ -63,26 +63,42 @@ export const INPUT_WIRING_HANDLES = { sourceHandle: 'input-output', targetHandle
  * `Workflow` and `WorkflowTemplate` is `form-input --input-output--> manual`,
  * 8 edges, no exceptions — so strictness rejects nothing that exists. The
  * canvas cannot author a counterexample either; its own rule is this rule.
+ *
+ * **The strictness no longer carries the app-block half of that argument.**
+ * Once `lookup` resolves app blocks, "no manifest" stops being permanent for
+ * them — so what keeps an app block off a trigger's `input` handle is now the
+ * two explicit facts its synthesized manifest states: `category` is
+ * `INTEGRATION` (≠ `INPUT`) and `acceptsInputNodes` is `false`. Strictness
+ * still guards the genuinely uncatalogued (`webhook`, `webhook-endpoint`).
  */
-export function isInputNodePair(source: GraphNode, target: GraphNode): boolean {
+export function isInputNodePair(
+  source: GraphNode,
+  target: GraphNode,
+  lookup: ManifestLookup
+): boolean {
   return (
-    getManifest(nodeType(target))?.connection.acceptsInputNodes === true &&
-    getManifest(nodeType(source))?.category === NodeCategory.INPUT
+    lookup(nodeType(target))?.connection.acceptsInputNodes === true &&
+    lookup(nodeType(source))?.category === NodeCategory.INPUT
   )
 }
 
 /** An input-provider → input-accepting wiring on the handles it must use. */
-function isInputWiring(source: GraphNode, target: GraphNode, edge: GraphEdge): boolean {
+function isInputWiring(
+  source: GraphNode,
+  target: GraphNode,
+  edge: GraphEdge,
+  lookup: ManifestLookup
+): boolean {
   return (
-    isInputNodePair(source, target) &&
+    isInputNodePair(source, target, lookup) &&
     (edge.sourceHandle ?? 'source') === INPUT_WIRING_HANDLES.sourceHandle &&
     (edge.targetHandle ?? 'target') === INPUT_WIRING_HANDLES.targetHandle
   )
 }
 
 /** Whether a node is an in-graph trigger per its catalog manifest. */
-export function isTriggerNode(node: GraphNode): boolean {
-  return getManifest(nodeType(node))?.triggerType !== undefined
+export function isTriggerNode(node: GraphNode, lookup: ManifestLookup): boolean {
+  return lookup(nodeType(node))?.triggerType !== undefined
 }
 
 /**
@@ -142,12 +158,13 @@ function cycleMembers(graph: DraftGraph): string[] {
  */
 export function validateGraphStructure(
   graph: DraftGraph,
-  opts: { newNodeIds?: ReadonlySet<string> } = {}
+  opts: { lookup: ManifestLookup; newNodeIds?: ReadonlySet<string> }
 ): Issue[] {
   const issues: Issue[] = []
   const nodes = graph.nodes
   const nodeById = new Map(nodes.map((n) => [n.id, n]))
   const ref = (id: string) => formatNodeRef(nodes, id)
+  const { lookup } = opts
   const newNodeIds = opts.newNodeIds ?? new Set<string>()
   const authorableTypes = () =>
     getAuthorableManifests()
@@ -160,7 +177,7 @@ export function validateGraphStructure(
   // states once instead of an issue per node per read.
   for (const node of nodes) {
     const type = nodeType(node)
-    const manifest = getManifest(type)
+    const manifest = lookup(type)
     if (newNodeIds.has(node.id)) {
       if (!manifest) {
         issues.push({
@@ -215,12 +232,12 @@ export function validateGraphStructure(
       continue
     }
 
-    const sourceManifest = getManifest(nodeType(source))
+    const sourceManifest = lookup(nodeType(source))
     if (sourceManifest) {
       const branches = sourceManifest.connection.branches?.(source.data) ?? []
       const handle = edge.sourceHandle ?? 'source'
       const allowed = branches.length > 0 ? branches.map((b) => b.id) : ['source']
-      if (!allowed.includes(handle) && !isInputWiring(source, target, edge)) {
+      if (!allowed.includes(handle) && !isInputWiring(source, target, edge, lookup)) {
         issues.push({
           severity: 'error',
           nodeRef: ref(source.id),
@@ -240,7 +257,7 @@ export function validateGraphStructure(
           message: `Edge "${edge.id}" targets handle "loop-back" on ${ref(target.id)}, which is not a loop.`,
         })
       }
-    } else if (targetHandle !== 'target' && !isInputWiring(source, target, edge)) {
+    } else if (targetHandle !== 'target' && !isInputWiring(source, target, edge, lookup)) {
       issues.push({
         severity: 'error',
         nodeRef: ref(target.id),
@@ -251,7 +268,7 @@ export function validateGraphStructure(
 
   // Connection limits and non-connectable nodes.
   for (const node of nodes) {
-    const manifest = getManifest(nodeType(node))
+    const manifest = lookup(nodeType(node))
     if (!manifest) continue
     const incoming = graph.edges.filter((e) => e.target === node.id)
     const outgoing = graph.edges.filter((e) => e.source === node.id)
@@ -282,7 +299,7 @@ export function validateGraphStructure(
 
   // Trigger rules — at most one; none is a warning (a draft under construction);
   // an edge INTO a trigger is structural corruption.
-  const triggers = nodes.filter(isTriggerNode)
+  const triggers = nodes.filter((node) => isTriggerNode(node, lookup))
   if (triggers.length === 0 && nodes.length > 0) {
     issues.push({
       severity: 'warning',
@@ -303,7 +320,7 @@ export function validateGraphStructure(
     if (
       incoming.some((e) => {
         const source = nodeById.get(e.source)
-        return !source || !isInputWiring(source, trigger, e)
+        return !source || !isInputWiring(source, trigger, e, lookup)
       })
     ) {
       issues.push({
@@ -356,10 +373,10 @@ export function validateGraphStructure(
  * `validate`, per node, per field. Never blocks: a half-configured node is a
  * legitimate draft state. Validator warnings map to `warning` severity.
  */
-export function validateNodeConfigs(graph: DraftGraph): Issue[] {
+export function validateNodeConfigs(graph: DraftGraph, lookup: ManifestLookup): Issue[] {
   const issues: Issue[] = []
   for (const node of graph.nodes) {
-    const manifest = getManifest(nodeType(node))
+    const manifest = lookup(nodeType(node))
     if (!manifest) continue
     const ref = formatNodeRef(graph.nodes, node.id)
 


### PR DESCRIPTION
Phase **B2** of `plans/kopilot/workflow/17-app-block-authoring-and-connections.md`. Stacked on #1709, which built `synthesizeAppBlockManifest` / `buildManifestLookup` but wired them to nothing.

## What

Every direct `getManifest` read on the graph-edit path becomes the threaded `ManifestLookup`, so an app block resolves wherever a core type does.

`loadDraftContext` builds it once per operation and hands it down on `DraftContext`. **Not** memoized across operations: the `installedApps` cache behind it has a 900s TTL, and a longer-lived lookup would let two tool calls in one turn disagree about a block's shape with nothing able to invalidate the difference.

The parameter is **required** everywhere, never optional-defaulting-to-`getManifest` — a silent fallback to the core registry is how a call site quietly loses app-block awareness, so forgetting it is a compile error.

Threaded: `validateGraphStructure`, `validateNodeConfigs`, `isInputNodePair`, `isTriggerNode`, `isInputWiring`, `buildGraphSummary`, `checkVariableRefsAgainstOutputs`, `resolveConnectionSpec`, `requireAuthorableManifest`, `resolveEdgeHandles`, `updateInputNodes`, and `runNode`'s `canRunSingle` gate.

`getAuthorableManifests` is left alone — the "available types" error strings it builds are B3's job.

## `resolve-outputs.ts` folds its app-block arm into the same lookup

It had been resolving app-block outputs directly through `resolveAppBlockOutputs` while core types went through `manifest.resolveOutputs`. After #1709 those are two paths to the same answer and free to drift — the duplication D1 exists to prevent. App blocks now resolve through the manifest like everything else, which also moves them *inside* the per-node crash isolation they were outside of.

The colon pre-filter is kept, so a graph of purely core nodes still pays for no `installedApps` cache read.

`buildAppBlockLookup` and `AppBlockLookup` are deleted — `buildManifestLookup` subsumed their only caller.

## Two behaviour changes, both intended

**`GraphSummary.readOnlyNodes` stops listing blocks from apps this org has installed.** That is §8's outcome. What stays listed is what genuinely is read-only: an unmigrated core type, or an orphan node whose app was uninstalled or whose deployment dropped the block.

**`isInputNodePair`'s strictness stops carrying the app-block argument.** It held because app blocks had no manifest. Now it holds because their manifest states `category: INTEGRATION` and `acceptsInputNodes: false`. Strictness still guards the genuinely uncatalogued (`webhook`, `webhook-endpoint`). B3 re-points `input-wiring.test.ts`'s regression case at a *catalogued* block, per §9 — until then that case passes against the core-only lookup, which is no longer the interesting condition.

## Tests

New `manifest-lookup.test.ts`. Every assertion is a **pair** — the same graph judged with the core registry alone, and with a lookup that resolves an installed block. The difference between the two columns is exactly what this PR buys, so asserting only one column would not show it:

- a newly authored app-block node: `Unknown node type` with core-only, accepted with the app resolved
- a pre-existing one: never blocking either way (the #1649 shape)
- `validateNodeConfigs`: silent with core-only, runs the synthesized validator with the app resolved
- `readOnlyNodes` and `isInputNodePair`, as above

Suites reaching `loadDraftContext` gained a `getCachedInstalledApps` stub; without it the new cache read hits a real backend.

## Verification

- graph-edit + catalog: 347 tests, green
- `node scripts/ci/typecheck-ratchet.js --package lib` — no new type errors (29, baseline 29)

Two unrelated failures are visible in a full `packages/lib` run and are **not** from this branch:
- `workflow-draft-cas.test.ts` — flaky, a 10s timeout that reproduces on `main`-only files (2 of 3 isolated runs)
- `builder-run-send-safety.test.ts` — caused by an in-flight uncommitted edit to `action-nodes/answer.ts` in another session's working tree