### PR TITLE
fix(channels): give facebook/instagram replies a recipient and a routable sender

### DIFF
--- a/packages/lib/src/cache/providers/channels-provider.ts
+++ b/packages/lib/src/cache/providers/channels-provider.ts
@@ -3,6 +3,7 @@
 import { schema } from '@auxx/database'
 import type { IntegrationProviderType } from '@auxx/database/types'
 import { and, eq, isNull } from 'drizzle-orm'
+import { getChannelLabel } from '../../channels/internal/identifier'
 import type { ChannelSettings } from '../../channels/types'
 import type { CacheProvider } from '../org-cache-provider'
 
@@ -71,7 +72,18 @@ export const channelsProvider: CacheProvider<CachedChannel[]> = {
         id: i.id,
         credentialId: i.credentialId,
         provider: i.provider,
-        displayName: i.name ?? i.email ?? i.provider,
+        // Meta channels carry their name only in `metadata` (the Page name / IG
+        // handle) — `Integration.name` is NULL on anything connected before it
+        // was persisted, which is why this goes through the shared label helper
+        // instead of reading the column directly.
+        displayName:
+          getChannelLabel({
+            provider: i.provider,
+            email: i.email,
+            name: i.name,
+            metadata,
+            chatWidget: r.chatWidget,
+          }) ?? i.provider,
         name: i.name,
         email: i.email,
         metadata,

--- a/packages/lib/src/channels/__tests__/identifier.test.ts
+++ b/packages/lib/src/channels/__tests__/identifier.test.ts
@@ -1,7 +1,79 @@
 // packages/lib/src/channels/__tests__/identifier.test.ts
 
 import { describe, expect, it } from 'vitest'
-import { getIdentifier } from '../internal/identifier'
+import { getChannelLabel, getIdentifier } from '../internal/identifier'
+
+const fbPage = {
+  provider: 'facebook',
+  email: null,
+  name: null,
+  metadata: { pageId: '869289333164075', pageName: 'Auxx-Lift' },
+}
+
+const igAccount = {
+  provider: 'instagram',
+  email: null,
+  name: null,
+  metadata: {
+    pageId: '869289333164075',
+    pageName: 'Auxx-Lift',
+    instagramBusinessAccountId: '17841400000000000',
+    instagramUsername: 'auxxlift',
+  },
+}
+
+/**
+ * The address a channel sends *as*. This feeds
+ * `findOrCreateParticipantForIntegration`, so anything it returns becomes the
+ * FROM `Participant.identifier` of every outbound message on that channel.
+ *
+ * Regression under test: the Page name used to be returned here, which minted a
+ * participant with `identifier: 'Auxx-Lift'` typed FACEBOOK_PSID — unroutable,
+ * and never corrected because the reconciler does not rewrite participants.
+ */
+describe('getIdentifier — routing identity', () => {
+  it('routes a Facebook channel by Page id, never the Page name', () => {
+    expect(getIdentifier(fbPage)).toBe('869289333164075')
+  })
+
+  it('routes an Instagram channel by IG business account id, not the handle', () => {
+    expect(getIdentifier(igAccount)).toBe('17841400000000000')
+  })
+
+  it('returns undefined rather than a display name when nothing routable exists', () => {
+    // Declared as rows rather than inline literals on purpose: `getIdentifier`'s
+    // parameter type no longer has a `name` field at all, so the compiler already
+    // refuses the inline form. These assert the runtime half of that guarantee.
+    const namedPage = { provider: 'facebook', email: null, name: 'Fallback', metadata: {} }
+    const namedLine = { provider: 'openphone', email: null, name: 'Support Line', metadata: {} }
+    expect(getIdentifier(namedPage)).toBeUndefined()
+    expect(getIdentifier(namedLine)).toBeUndefined()
+  })
+
+  it('still prefers an explicit email over social metadata', () => {
+    const mailbox = {
+      provider: 'google',
+      email: 'support@auxx.ai',
+      name: null,
+      metadata: { pageName: 'ignored' },
+    }
+    expect(getIdentifier(mailbox)).toBe('support@auxx.ai')
+  })
+
+  it('reads a phone channel number from metadata', () => {
+    const phoneChannel = {
+      provider: 'openphone',
+      email: null,
+      name: 'Support Line',
+      metadata: { phoneNumber: '+15551234567' },
+    }
+    expect(getIdentifier(phoneChannel)).toBe('+15551234567')
+  })
+
+  it('returns undefined for a null channel', () => {
+    expect(getIdentifier(null)).toBeUndefined()
+  })
+})
 
 /**
  * The channel label every settings/list surface renders. Meta social channels had
@@ -9,46 +81,35 @@ import { getIdentifier } from '../internal/identifier'
  * Integration" with the page name nowhere on the screen — the name was computed at
  * connect time, emitted on the `integration:connected` event, and then dropped.
  */
-describe('getIdentifier — Meta social channels', () => {
-  const row = (provider: string, metadata: unknown, name: string | null = null) =>
-    ({ provider, email: null, name, metadata }) as Parameters<typeof getIdentifier>[0]
-
+describe('getChannelLabel — display only', () => {
   it('labels a Facebook channel with its page name', () => {
-    expect(
-      getIdentifier(row('facebook', { pageId: '869289333164075', pageName: 'Auxx-Lift' }))
-    ).toBe('Auxx-Lift')
+    expect(getChannelLabel(fbPage)).toBe('Auxx-Lift')
   })
 
   it('prefers the Instagram handle over the page name', () => {
     // The IG channel is the account customers actually see; the linked Page name
     // is frequently different and would read as the wrong account.
-    expect(
-      getIdentifier(
-        row('instagram', {
-          pageId: '869289333164075',
-          pageName: 'Auxx-Lift',
-          instagramUsername: 'auxxlift',
-        })
-      )
-    ).toBe('auxxlift')
+    expect(getChannelLabel(igAccount)).toBe('auxxlift')
   })
 
   it('reads from metadata, so channels connected before the name was persisted still resolve', () => {
-    expect(getIdentifier(row('facebook', { pageName: 'Auxx-Lift' }, null))).toBe('Auxx-Lift')
+    expect(
+      getChannelLabel({
+        provider: 'facebook',
+        email: null,
+        name: null,
+        metadata: { pageName: 'Auxx-Lift' },
+      })
+    ).toBe('Auxx-Lift')
   })
 
-  it('still prefers an explicit email over social metadata', () => {
-    const channel = {
-      provider: 'google',
-      email: 'support@auxx.ai',
-      name: null,
-      metadata: { pageName: 'ignored' },
-    } as Parameters<typeof getIdentifier>[0]
-    expect(getIdentifier(channel)).toBe('support@auxx.ai')
+  it('prefers a persisted Integration.name over metadata', () => {
+    expect(getChannelLabel({ ...fbPage, name: 'Renamed Channel' })).toBe('Renamed Channel')
   })
 
-  it('falls back to the row name, then undefined', () => {
-    expect(getIdentifier(row('facebook', {}, 'Fallback'))).toBe('Fallback')
-    expect(getIdentifier(row('facebook', {}, null))).toBeUndefined()
+  it('falls back to undefined when there is nothing human-readable', () => {
+    expect(
+      getChannelLabel({ provider: 'facebook', email: null, name: null, metadata: {} })
+    ).toBeUndefined()
   })
 })

--- a/packages/lib/src/channels/internal/identifier.ts
+++ b/packages/lib/src/channels/internal/identifier.ts
@@ -2,19 +2,36 @@
 
 import type { schema } from '@auxx/database'
 
-interface IdentifierRow {
+interface ChannelIdentityRow {
   provider: string
   email: string | null
-  name: string | null
   metadata: unknown
   chatWidget?: typeof schema.ChatWidget.$inferSelect | null
 }
 
+interface ChannelLabelRow extends ChannelIdentityRow {
+  name: string | null
+}
+
 /**
- * Safely extract a human identifier (email, phone, widget name) from a
- * channel row plus optional joined ChatWidget.
+ * The channel's **routing identity** — the address it sends *as*, in the id
+ * space {@link import('../capabilities').identifierTypeForProvider} names for
+ * its provider.
+ *
+ * Never a display name, and structurally incapable of returning one: this feeds
+ * `ParticipantService.findOrCreateParticipantForIntegration`, which mints the
+ * FROM `Participant` of every outbound message from it. A label reaching this
+ * return value becomes a `Participant.identifier` no provider can route, in a
+ * row the reconciler never rewrites — the failure mode already documented on
+ * that method, where composed SMS recorded the operator's *email* as its sender.
+ *
+ * Meta channels route by account id (Page id, IG business account id). The page
+ * name and IG handle are labels and belong to {@link getChannelLabel}; a caller
+ * that wants something human-readable must ask for it by name.
+ *
+ * Returns `undefined` when the channel has no addressable identity of its own.
  */
-export function getIdentifier(channel: IdentifierRow | null): string | undefined {
+export function getIdentifier(channel: ChannelIdentityRow | null): string | undefined {
   if (!channel) return undefined
   if (channel.provider === 'chat' && channel.chatWidget) {
     return channel.chatWidget.name
@@ -26,13 +43,42 @@ export function getIdentifier(channel: IdentifierRow | null): string | undefined
     if ('email' in metadata && typeof metadata.email === 'string') return metadata.email
     if ('phoneNumber' in metadata && typeof metadata.phoneNumber === 'string')
       return metadata.phoneNumber
-    // Meta social channels identify by the account they post as, not an address:
-    // the IG handle where there is one, otherwise the Facebook Page name. Read
-    // from metadata rather than `Integration.name` so channels connected before
-    // the name was persisted still show something other than a bare provider label.
+    // Meta social channels: the account id, never `pageName` / `instagramUsername`.
+    // Instagram Direct addresses the IG business account; Messenger the Page.
+    if (
+      'instagramBusinessAccountId' in metadata &&
+      typeof metadata.instagramBusinessAccountId === 'string'
+    )
+      return metadata.instagramBusinessAccountId
+    if ('pageId' in metadata && typeof metadata.pageId === 'string') return metadata.pageId
+  }
+  return undefined
+}
+
+/**
+ * Human label for a channel — what a picker, a channel list or a thread header
+ * shows. Display only: never pass this to anything that routes, addresses or
+ * keys a participant (see {@link getIdentifier}).
+ *
+ * Meta channels are read from `metadata` rather than `Integration.name` so
+ * channels connected before the name was persisted still show the account they
+ * post as instead of a bare provider label.
+ */
+export function getChannelLabel(channel: ChannelLabelRow | null): string | undefined {
+  if (!channel) return undefined
+  if (channel.provider === 'chat' && channel.chatWidget) {
+    return channel.chatWidget.name
+  }
+  if (channel.name) return channel.name
+  if (channel.email) return channel.email
+  const metadata = channel.metadata
+  if (metadata && typeof metadata === 'object') {
+    if ('email' in metadata && typeof metadata.email === 'string') return metadata.email
+    if ('phoneNumber' in metadata && typeof metadata.phoneNumber === 'string')
+      return metadata.phoneNumber
     if ('instagramUsername' in metadata && typeof metadata.instagramUsername === 'string')
       return metadata.instagramUsername
     if ('pageName' in metadata && typeof metadata.pageName === 'string') return metadata.pageName
   }
-  return channel.name || undefined
+  return undefined
 }

--- a/packages/lib/src/messages/__tests__/message-sender.social-recipients.test.ts
+++ b/packages/lib/src/messages/__tests__/message-sender.social-recipients.test.ts
@@ -1,0 +1,92 @@
+// packages/lib/src/messages/__tests__/message-sender.social-recipients.test.ts
+//
+// Direct unit coverage of `resolveRecipients`, the private helper that gives a
+// `thread_only` channel (Messenger, Instagram Direct) its outbound recipient.
+// Those channels have no recipient field anywhere — the composer sends `to: []`
+// and `requiresRecipients` is false — so the address comes from the thread key
+// `socialThreadKey` minted at ingest. Without this the provider threw
+// "Recipient PSID (Page-Scoped ID) is required in 'to' field" and no reply ever
+// reached Messenger.
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@auxx/database', async () => {
+  const { createChainableDatabaseMock, createSchemaMock } = await import('../../test/database-mock')
+  return {
+    database: createChainableDatabaseMock(),
+    schema: createSchemaMock(),
+    IntegrationProviderTypeValues: ['google', 'outlook', 'email', 'mailgun', 'imap'],
+  }
+})
+
+import { MessageSenderService } from '../message-sender.service'
+
+function createService(): any {
+  return new MessageSenderService('org-1')
+}
+
+const DM_KEY = 'dm:869289333164075:27893553143563440'
+
+describe('resolveRecipients', () => {
+  it('derives the Messenger counterpart from the thread key when `to` is empty', () => {
+    expect(createService().resolveRecipients({ to: [] }, 'facebook', DM_KEY)).toEqual([
+      { identifier: '27893553143563440', identifierType: 'FACEBOOK_PSID' },
+    ])
+  })
+
+  it('types an Instagram recipient as IGSID, not PSID', () => {
+    // The two channels share a thread-key format but not an id space; a wrong
+    // type forks the participant identity even when the send succeeds.
+    expect(createService().resolveRecipients({ to: [] }, 'instagram', DM_KEY)).toEqual([
+      { identifier: '27893553143563440', identifierType: 'INSTAGRAM_IGSID' },
+    ])
+  })
+
+  it('never overrides an explicit recipient address', () => {
+    const to = [{ identifier: '999', identifierType: 'FACEBOOK_PSID' }]
+    expect(createService().resolveRecipients({ to }, 'facebook', DM_KEY)).toEqual(to)
+  })
+
+  it('corrects an id space the caller guessed wrong on a thread_only channel', () => {
+    // The workflow answer node resolves the right identifier off the thread but
+    // labels every recipient EMAIL. On Messenger there is only one id space, so
+    // that label is wrong rather than a choice — left alone it forks a second
+    // participant for a person ingest already has.
+    expect(
+      createService().resolveRecipients(
+        { to: [{ identifier: '27893553143563440', identifierType: 'EMAIL' }] },
+        'facebook',
+        DM_KEY
+      )
+    ).toEqual([{ identifier: '27893553143563440', identifierType: 'FACEBOOK_PSID' }])
+  })
+
+  it('leaves a correctly-typed recipient untouched', () => {
+    const to = [{ identifier: '27893553143563440', identifierType: 'FACEBOOK_PSID' }]
+    expect(createService().resolveRecipients({ to }, 'facebook', DM_KEY)[0]).toBe(to[0])
+  })
+
+  it('never rewrites the id space on an email channel', () => {
+    const to = [{ identifier: 'customer@example.com', identifierType: 'EMAIL' }]
+    expect(createService().resolveRecipients({ to }, 'google', DM_KEY)).toBe(to)
+  })
+
+  it('leaves email channels alone — they are not thread_only', () => {
+    // Email must keep failing loudly on an empty recipient list rather than
+    // silently addressing whatever the thread id happens to look like.
+    expect(createService().resolveRecipients({ to: [] }, 'google', DM_KEY)).toEqual([])
+  })
+
+  it('leaves chat alone — its counterpart is encoded on the Thread, not the key', () => {
+    expect(createService().resolveRecipients({ to: [] }, 'chat', DM_KEY)).toEqual([])
+  })
+
+  it.each([
+    ['a comment thread', 'comment:1234567890'],
+    ['a pending/placeholder thread', undefined],
+    ['a null external id', null],
+    ['a provider conversation id', 't_1234567890'],
+  ])('returns an empty list for %s rather than guessing', (_label, externalId) => {
+    expect(createService().resolveRecipients({ to: [] }, 'facebook', externalId)).toEqual([])
+  })
+})

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -6,6 +6,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
 import { and, asc, desc, eq, sql } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
+import { getComposerCapabilities, identifierTypeForProvider } from '../channels/capabilities'
 import {
   touchActivityForThreadLinks,
   touchInteractionForMessage,
@@ -24,6 +25,7 @@ import { getThreadLens } from '../permissions/visibility/thread-lens'
 import type { NormalizedEmailError as NormalizedEmailErrorInstance } from '../providers/error-normalization'
 import type { AttachmentFile } from '../providers/message-provider-interface'
 import type { ProviderRegistryService } from '../providers/provider-registry-service'
+import { parseSocialDmThreadKey } from '../providers/social/thread-key'
 import {
   getRealtimeService,
   publishMessageCreated,
@@ -224,7 +226,16 @@ export class MessageSenderService {
         externalId: threadContext.externalId,
       })
       // Step 2: Process participants
-      const participants = await this.processParticipants(input, threadContext.inboxId ?? null)
+      const recipients = this.resolveRecipients(
+        input,
+        capabilities.provider,
+        threadContext.externalId
+      )
+      const participants = await this.processParticipants(
+        input,
+        threadContext.inboxId ?? null,
+        recipients
+      )
       const isAutomatedSend = !this.viewer || isSystemViewer(this.viewer)
       // Step 2.4: §6 fix #3 — per-thread auto-reply alternation. Existing threads only;
       // a freshly-created (pending) thread has no prior message to alternate against.
@@ -608,9 +619,55 @@ export class MessageSenderService {
    * events for any tracked-column change these upserts cause (the composer used
    * to mutate names silently, leaving open clients stale until remount).
    */
+  /**
+   * The TO recipients for this send.
+   *
+   * `thread_only` channels (Messenger, Instagram Direct) have no recipient field
+   * anywhere: `PLATFORM_CAPABILITIES` declares the model, `requiresRecipients` is
+   * false so validation lets an empty list through, and the reply composer sends
+   * `to: []` because there is genuinely nothing for a user to type. The address is
+   * a property of the conversation instead — `socialThreadKey` derived it from the
+   * webhook as `dm:{pageId}:{counterpartId}`, so the counterpart is recoverable
+   * from the thread with no query and no Graph call.
+   *
+   * Resolved HERE rather than in the provider, deliberately. A provider-side
+   * fallback would put the right PSID on the wire while leaving the outbound row
+   * with no TO participant at all — precisely the split
+   * `findOrCreateParticipantForIntegration` documents ("The wire was always fine;
+   * only the DB row disagreed"). Deriving before `processParticipants` keeps the
+   * message's participant rollup and the wire in agreement, and fixes every
+   * caller at once: the composer, the workflow answer node, and anything later
+   * that replies on a social thread without inventing its own address lookup.
+   *
+   * An explicit `to` wins on the address; only its id space is corrected, and
+   * only on channels where that space is fixed by the channel itself.
+   */
+  private resolveRecipients(
+    input: SendMessageInput,
+    provider: string,
+    externalThreadId: string | null | undefined
+  ): SendMessageInput['to'] {
+    if (getComposerCapabilities(provider)?.recipientModel !== 'thread_only') return input.to
+    const identifierType = identifierTypeForProvider(provider)
+    if (!identifierType) return input.to
+    // A `thread_only` channel has exactly one possible id space, so any other
+    // type on a supplied recipient is definitionally wrong rather than a choice.
+    // The workflow answer node auto-resolves the right *identifier* off the
+    // thread but labels every recipient EMAIL, which would fork the participant
+    // from the one ingest already created for that person.
+    if (input.to.length > 0) {
+      return input.to.map((p) =>
+        p.identifierType === identifierType ? p : { ...p, identifierType }
+      )
+    }
+    const parsed = parseSocialDmThreadKey(externalThreadId)
+    if (!parsed) return input.to
+    return [{ identifier: parsed.counterpartId, identifierType }]
+  }
   private async processParticipants(
     input: SendMessageInput,
-    inboxId: string | null
+    inboxId: string | null,
+    recipients: SendMessageInput['to']
   ): Promise<ProcessedParticipants> {
     const publish = { inboxId, excludeSocketId: this.socketId }
     // FROM is the sending mailbox (e.g. markus@auxx.ai), not the operator's
@@ -640,7 +697,7 @@ export class MessageSenderService {
     }
     // Process all recipients in parallel
     const [toParticipants, ccParticipants, bccParticipants] = await Promise.all([
-      Promise.all(input.to.map((p) => processParticipant(p, ParticipantRole.TO))),
+      Promise.all(recipients.map((p) => processParticipant(p, ParticipantRole.TO))),
       Promise.all((input.cc || []).map((p) => processParticipant(p, ParticipantRole.CC))),
       Promise.all((input.bcc || []).map((p) => processParticipant(p, ParticipantRole.BCC))),
     ])

--- a/packages/lib/src/participants/__tests__/participant-for-integration.test.ts
+++ b/packages/lib/src/participants/__tests__/participant-for-integration.test.ts
@@ -132,8 +132,10 @@ describe('findOrCreateParticipantForIntegration', () => {
   })
 
   it('never falls back to the channel display name as an identifier', async () => {
-    // `getIdentifier` ends with `channel.name` for UI labelling. A display name
-    // is not routable and must never become a Participant identifier.
+    // A display name is not routable and must never become a Participant
+    // identifier. `getIdentifier` no longer reads `channel.name` at all (display
+    // labelling moved to `getChannelLabel`), so this is now structural — the
+    // test stays as the regression guard for that split.
     h.integrationRow = {
       provider: 'openphone',
       email: null,

--- a/packages/lib/src/participants/participant-service.ts
+++ b/packages/lib/src/participants/participant-service.ts
@@ -360,10 +360,11 @@ export class ParticipantService {
     // provider with no declared type at all (`shopify`, or an unknown one).
     if (!identifierType || identifierType === 'CHAT_VISITOR') return null
 
+    // `getIdentifier` is routing-only by construction — it cannot return a
+    // display name, so there is nothing to defend against here any more.
     const identifier = getIdentifier({
       provider: integration.provider,
       email: integration.email,
-      name: null, // never fall back to the channel's display name as an identifier
       metadata: integration.metadata,
     })
     if (!identifier) return null

--- a/packages/lib/src/providers/social/__tests__/thread-key.test.ts
+++ b/packages/lib/src/providers/social/__tests__/thread-key.test.ts
@@ -1,0 +1,44 @@
+// packages/lib/src/providers/social/__tests__/thread-key.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { isSocialDmThreadKey, parseSocialDmThreadKey, socialThreadKey } from '../thread-key'
+
+describe('parseSocialDmThreadKey', () => {
+  it('round-trips a key minted by socialThreadKey', () => {
+    const key = socialThreadKey('869289333164075', '27893553143563440')
+    expect(key).toBe('dm:869289333164075:27893553143563440')
+    expect(parseSocialDmThreadKey(key)).toEqual({
+      pageId: '869289333164075',
+      counterpartId: '27893553143563440',
+    })
+  })
+
+  it('rejects the comment namespace', () => {
+    // Comments share the column. Reading one as a DM would address a reply to a
+    // comment id as if it were a PSID.
+    expect(parseSocialDmThreadKey('comment:1234567890')).toBeNull()
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty', ''],
+    ['a provider-issued conversation id', 't_1234567890'],
+    ['an email thread id', '<CAF=abc@mail.gmail.com>'],
+    ['a bare prefix', 'dm:'],
+    ['a missing counterpart', 'dm:869289333164075'],
+    ['an empty counterpart', 'dm:869289333164075:'],
+    ['an empty page id', 'dm::27893553143563440'],
+    ['an extra segment', 'dm:869289333164075:27893553143563440:extra'],
+  ])('returns null for %s', (_label, key) => {
+    expect(parseSocialDmThreadKey(key)).toBeNull()
+  })
+
+  it('agrees with isSocialDmThreadKey on what is a DM key', () => {
+    // A key the predicate accepts but the parser rejects would send a reply with
+    // no recipient; the reverse would address one the thread never named.
+    for (const key of ['dm:1:2', 'dm:', 'comment:1', 't_1', '']) {
+      if (parseSocialDmThreadKey(key)) expect(isSocialDmThreadKey(key)).toBe(true)
+    }
+  })
+})

--- a/packages/lib/src/providers/social/thread-key.ts
+++ b/packages/lib/src/providers/social/thread-key.ts
@@ -53,3 +53,29 @@ export function socialThreadKey(pageId: string, counterpartId: string): string {
 export function isSocialDmThreadKey(key: string | null | undefined): boolean {
   return !!key?.startsWith(`${SOCIAL_THREAD_KEY_NAMESPACES.dm}:`)
 }
+
+/**
+ * Inverse of {@link socialThreadKey}: recover `(pageId, counterpartId)` from a
+ * stored DM key. Returns `null` for anything else — a `comment:` key, a
+ * provider-issued id, a placeholder, or a malformed string.
+ *
+ * This is what makes a Messenger / IG reply addressable without asking Meta.
+ * Those channels are `recipientModel: 'thread_only'`: the composer has no
+ * recipient field because there is nothing for a user to type, so the outbound
+ * recipient has to come from the conversation itself. Since a DM is strictly
+ * 1:1, the key already *is* the address — no Graph round trip, no participant
+ * query.
+ *
+ * Strict on arity: ids Meta issues are numeric and never contain `:`, so a key
+ * with extra segments is a key we did not mint and must not guess at.
+ */
+export function parseSocialDmThreadKey(
+  key: string | null | undefined
+): { pageId: string; counterpartId: string } | null {
+  if (!isSocialDmThreadKey(key)) return null
+  const parts = (key as string).split(':')
+  if (parts.length !== 3) return null
+  const [, pageId, counterpartId] = parts
+  if (!pageId || !counterpartId) return null
+  return { pageId, counterpartId }
+}

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/answer.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/answer.ts
@@ -282,6 +282,10 @@ export class AnswerProcessor extends BaseNodeProcessor {
     }
 
     // 4. Process recipients - convert email strings to ParticipantInput format
+    //
+    // The id space follows the channel, not the field name, but the provider is
+    // not known here — `MessageSenderService.resolveRecipients` normalises the
+    // type for channels whose recipient model fixes it (Messenger, Instagram).
     const toParticipants: ParticipantInput[] = resolvedTo.map((email) => ({
       identifier: email,
       identifierType: IdentifierType.EMAIL,


### PR DESCRIPTION
The first real DM to the connected Auxx-Lift Page arrived and stored correctly (thread key, `mid`, participants all right), but replying to it failed 1ms in — before any Graph call:

> `Recipient PSID (Page-Scoped ID) is required in 'to' field for Facebook messages.`

Two independent defects, both in participant identity. **Verified live: the reply now arrives in Messenger.**

## 1. Nobody supplied the recipient

FB/IG declare `requiresRecipients: false`, so `validateInput` lets an empty `to` through — but `facebook-provider.ts:225` reads `options.to[0]` and throws. The capability comment states the intent:

> its recipient is a PSID the composer never types — the thread already knows who it is talking to

`chat`, the other `requiresRecipients: false` channel, genuinely works that way ("visitor is encoded on the Thread"). **FB/IG copied the flag but not the mechanism**, so `requiresRecipients: false` meant "the user doesn't type it" and was implemented as "nobody supplies it".

`MessageSenderService.resolveRecipients` now derives the counterpart from the thread key — `parseSocialDmThreadKey`, added to `thread-key.ts`, the module that already declares it owns the keyspace. Gated on `recipientModel === 'thread_only'`, so email still fails loudly on an empty recipient list and chat is untouched.

**Why the sender and not the provider.** A provider-side fallback would put the right PSID on the wire while leaving the outbound row with *no TO participant* — the exact split `findOrCreateParticipantForIntegration` documents: *"The wire was always fine; only the DB row disagreed."* Resolving before `processParticipants` keeps the rollup and the wire in agreement, and fixes every caller at once (composer, workflow answer node, anything later).

It also corrects a wrong id space on supplied recipients. The answer node resolves the right identifier off the thread but labels every recipient `EMAIL`; on a channel whose recipient model fixes the space that is wrong rather than a choice, and left alone it forks a second participant for someone ingest already has. No extra query — the sender already fetches the provider for its capability lookup.

## 2. The sender identity was a display string

The outbound row's FROM was a participant with `identifier: 'Auxx-Lift'` typed `FACEBOOK_PSID` — the Page **name**, unroutable, in a row the reconciler never rewrites.

`findOrCreateParticipantForIntegration` passes `name: null` specifically to stop this, but that guard only neutralises `getIdentifier`'s **final** `channel.name` fallback — and #1700 added `pageName` to the **metadata** branch above it. Same bug class as the SMS incident documented in that method's own docstring, through a door the guard didn't cover.

- `getIdentifier` is now routing-only: Page id / IG business account id.
- New `getChannelLabel` owns display: IG handle → Page name.
- `name` is **gone from `getIdentifier`'s parameter type**, so a display name can no longer reach it. The guard became structural and was removed.
- #1700's user-visible fix is preserved by routing `CachedChannel.displayName` through `getChannelLabel`, where it belonged.

## Testing

- `packages/lib`: **1870 tests pass**, typecheck clean, lint clean
- New: `thread-key.test.ts` (13), `message-sender.social-recipients.test.ts` (12)
- Rewritten: `channels/__tests__/identifier.test.ts` — now covers both contracts
- **Live**: inbound DM → stored under one thread; reply from the composer → **received in Messenger**

## Not in scope

The thread still displays the raw PSID as the contact name — Meta's webhook carries no name, so that needs a User Profile fetch on the existing `publishParticipantPatch` seam. Separate PR. WS7 (backfill) remains blocked on a real payload from the conversation-messages edge.

Refs: `plans/channels/facebook-instagram-runtime-fixes.md`