### PR TITLE
feat(workflow): let Kopilot author app-block nodes

### DIFF
--- a/apps/web/src/components/workflow/parity/catalog-coverage.test.ts
+++ b/apps/web/src/components/workflow/parity/catalog-coverage.test.ts
@@ -24,7 +24,8 @@ import { NodeType } from '../types/node-types'
  *
  * The NOT_YET_MIGRATED list is the migration tracker and may only shrink.
  * App blocks (`appId:blockId` dynamic types) are outside NodeType and outside
- * this contract — they get a declarative adapter in a later wave.
+ * this contract — they reach consumers through a per-org `ManifestLookup`
+ * (`buildManifestLookup`), never through the registry.
  */
 describe('node catalog coverage', () => {
   const nodeTypes = new Set<string>(Object.values(NodeType))
@@ -35,6 +36,15 @@ describe('node catalog coverage', () => {
     const uncovered = [...nodeTypes].filter((t) => !migrated.has(t) && !notYetMigrated.has(t))
     const doubleCovered = [...nodeTypes].filter((t) => migrated.has(t) && notYetMigrated.has(t))
     expect({ uncovered, doubleCovered }).toEqual({ uncovered: [], doubleCovered: [] })
+  })
+
+  it('registers no app-block manifest — the lookup widens, the registry does not', () => {
+    // `buildManifestLookup` returns `getManifest(type) ?? synthesized`, and the
+    // synthesized half must stay OUT of the shared Map. If a refactor ever
+    // registered app blocks instead, every assertion in this file would start
+    // reporting per-org data as an unmigrated NodeType, and NOT_YET_MIGRATED's
+    // "may only shrink" invariant would break with nothing else catching it.
+    expect(listManifests().filter((manifest) => manifest.id.includes(':'))).toEqual([])
   })
 
   it('lists no unknown types in NOT_YET_MIGRATED and registers no unknown manifests', () => {

--- a/packages/lib/src/cache/providers/channels-provider.ts
+++ b/packages/lib/src/cache/providers/channels-provider.ts
@@ -3,6 +3,7 @@
 import { schema } from '@auxx/database'
 import type { IntegrationProviderType } from '@auxx/database/types'
 import { and, eq, isNull } from 'drizzle-orm'
+import { getChannelLabel } from '../../channels/internal/identifier'
 import type { ChannelSettings } from '../../channels/types'
 import type { CacheProvider } from '../org-cache-provider'
 
@@ -71,7 +72,18 @@ export const channelsProvider: CacheProvider<CachedChannel[]> = {
         id: i.id,
         credentialId: i.credentialId,
         provider: i.provider,
-        displayName: i.name ?? i.email ?? i.provider,
+        // Meta channels carry their name only in `metadata` (the Page name / IG
+        // handle) — `Integration.name` is NULL on anything connected before it
+        // was persisted, which is why this goes through the shared label helper
+        // instead of reading the column directly.
+        displayName:
+          getChannelLabel({
+            provider: i.provider,
+            email: i.email,
+            name: i.name,
+            metadata,
+            chatWidget: r.chatWidget,
+          }) ?? i.provider,
         name: i.name,
         email: i.email,
         metadata,

--- a/packages/lib/src/channels/__tests__/identifier.test.ts
+++ b/packages/lib/src/channels/__tests__/identifier.test.ts
@@ -1,7 +1,79 @@
 // packages/lib/src/channels/__tests__/identifier.test.ts
 
 import { describe, expect, it } from 'vitest'
-import { getIdentifier } from '../internal/identifier'
+import { getChannelLabel, getIdentifier } from '../internal/identifier'
+
+const fbPage = {
+  provider: 'facebook',
+  email: null,
+  name: null,
+  metadata: { pageId: '869289333164075', pageName: 'Auxx-Lift' },
+}
+
+const igAccount = {
+  provider: 'instagram',
+  email: null,
+  name: null,
+  metadata: {
+    pageId: '869289333164075',
+    pageName: 'Auxx-Lift',
+    instagramBusinessAccountId: '17841400000000000',
+    instagramUsername: 'auxxlift',
+  },
+}
+
+/**
+ * The address a channel sends *as*. This feeds
+ * `findOrCreateParticipantForIntegration`, so anything it returns becomes the
+ * FROM `Participant.identifier` of every outbound message on that channel.
+ *
+ * Regression under test: the Page name used to be returned here, which minted a
+ * participant with `identifier: 'Auxx-Lift'` typed FACEBOOK_PSID — unroutable,
+ * and never corrected because the reconciler does not rewrite participants.
+ */
+describe('getIdentifier — routing identity', () => {
+  it('routes a Facebook channel by Page id, never the Page name', () => {
+    expect(getIdentifier(fbPage)).toBe('869289333164075')
+  })
+
+  it('routes an Instagram channel by IG business account id, not the handle', () => {
+    expect(getIdentifier(igAccount)).toBe('17841400000000000')
+  })
+
+  it('returns undefined rather than a display name when nothing routable exists', () => {
+    // Declared as rows rather than inline literals on purpose: `getIdentifier`'s
+    // parameter type no longer has a `name` field at all, so the compiler already
+    // refuses the inline form. These assert the runtime half of that guarantee.
+    const namedPage = { provider: 'facebook', email: null, name: 'Fallback', metadata: {} }
+    const namedLine = { provider: 'openphone', email: null, name: 'Support Line', metadata: {} }
+    expect(getIdentifier(namedPage)).toBeUndefined()
+    expect(getIdentifier(namedLine)).toBeUndefined()
+  })
+
+  it('still prefers an explicit email over social metadata', () => {
+    const mailbox = {
+      provider: 'google',
+      email: 'support@auxx.ai',
+      name: null,
+      metadata: { pageName: 'ignored' },
+    }
+    expect(getIdentifier(mailbox)).toBe('support@auxx.ai')
+  })
+
+  it('reads a phone channel number from metadata', () => {
+    const phoneChannel = {
+      provider: 'openphone',
+      email: null,
+      name: 'Support Line',
+      metadata: { phoneNumber: '+15551234567' },
+    }
+    expect(getIdentifier(phoneChannel)).toBe('+15551234567')
+  })
+
+  it('returns undefined for a null channel', () => {
+    expect(getIdentifier(null)).toBeUndefined()
+  })
+})
 
 /**
  * The channel label every settings/list surface renders. Meta social channels had
@@ -9,46 +81,35 @@ import { getIdentifier } from '../internal/identifier'
  * Integration" with the page name nowhere on the screen — the name was computed at
  * connect time, emitted on the `integration:connected` event, and then dropped.
  */
-describe('getIdentifier — Meta social channels', () => {
-  const row = (provider: string, metadata: unknown, name: string | null = null) =>
-    ({ provider, email: null, name, metadata }) as Parameters<typeof getIdentifier>[0]
-
+describe('getChannelLabel — display only', () => {
   it('labels a Facebook channel with its page name', () => {
-    expect(
-      getIdentifier(row('facebook', { pageId: '869289333164075', pageName: 'Auxx-Lift' }))
-    ).toBe('Auxx-Lift')
+    expect(getChannelLabel(fbPage)).toBe('Auxx-Lift')
   })
 
   it('prefers the Instagram handle over the page name', () => {
     // The IG channel is the account customers actually see; the linked Page name
     // is frequently different and would read as the wrong account.
-    expect(
-      getIdentifier(
-        row('instagram', {
-          pageId: '869289333164075',
-          pageName: 'Auxx-Lift',
-          instagramUsername: 'auxxlift',
-        })
-      )
-    ).toBe('auxxlift')
+    expect(getChannelLabel(igAccount)).toBe('auxxlift')
   })
 
   it('reads from metadata, so channels connected before the name was persisted still resolve', () => {
-    expect(getIdentifier(row('facebook', { pageName: 'Auxx-Lift' }, null))).toBe('Auxx-Lift')
+    expect(
+      getChannelLabel({
+        provider: 'facebook',
+        email: null,
+        name: null,
+        metadata: { pageName: 'Auxx-Lift' },
+      })
+    ).toBe('Auxx-Lift')
   })
 
-  it('still prefers an explicit email over social metadata', () => {
-    const channel = {
-      provider: 'google',
-      email: 'support@auxx.ai',
-      name: null,
-      metadata: { pageName: 'ignored' },
-    } as Parameters<typeof getIdentifier>[0]
-    expect(getIdentifier(channel)).toBe('support@auxx.ai')
+  it('prefers a persisted Integration.name over metadata', () => {
+    expect(getChannelLabel({ ...fbPage, name: 'Renamed Channel' })).toBe('Renamed Channel')
   })
 
-  it('falls back to the row name, then undefined', () => {
-    expect(getIdentifier(row('facebook', {}, 'Fallback'))).toBe('Fallback')
-    expect(getIdentifier(row('facebook', {}, null))).toBeUndefined()
+  it('falls back to undefined when there is nothing human-readable', () => {
+    expect(
+      getChannelLabel({ provider: 'facebook', email: null, name: null, metadata: {} })
+    ).toBeUndefined()
   })
 })

--- a/packages/lib/src/channels/internal/identifier.ts
+++ b/packages/lib/src/channels/internal/identifier.ts
@@ -2,19 +2,36 @@
 
 import type { schema } from '@auxx/database'
 
-interface IdentifierRow {
+interface ChannelIdentityRow {
   provider: string
   email: string | null
-  name: string | null
   metadata: unknown
   chatWidget?: typeof schema.ChatWidget.$inferSelect | null
 }
 
+interface ChannelLabelRow extends ChannelIdentityRow {
+  name: string | null
+}
+
 /**
- * Safely extract a human identifier (email, phone, widget name) from a
- * channel row plus optional joined ChatWidget.
+ * The channel's **routing identity** — the address it sends *as*, in the id
+ * space {@link import('../capabilities').identifierTypeForProvider} names for
+ * its provider.
+ *
+ * Never a display name, and structurally incapable of returning one: this feeds
+ * `ParticipantService.findOrCreateParticipantForIntegration`, which mints the
+ * FROM `Participant` of every outbound message from it. A label reaching this
+ * return value becomes a `Participant.identifier` no provider can route, in a
+ * row the reconciler never rewrites — the failure mode already documented on
+ * that method, where composed SMS recorded the operator's *email* as its sender.
+ *
+ * Meta channels route by account id (Page id, IG business account id). The page
+ * name and IG handle are labels and belong to {@link getChannelLabel}; a caller
+ * that wants something human-readable must ask for it by name.
+ *
+ * Returns `undefined` when the channel has no addressable identity of its own.
  */
-export function getIdentifier(channel: IdentifierRow | null): string | undefined {
+export function getIdentifier(channel: ChannelIdentityRow | null): string | undefined {
   if (!channel) return undefined
   if (channel.provider === 'chat' && channel.chatWidget) {
     return channel.chatWidget.name
@@ -26,13 +43,42 @@ export function getIdentifier(channel: IdentifierRow | null): string | undefined
     if ('email' in metadata && typeof metadata.email === 'string') return metadata.email
     if ('phoneNumber' in metadata && typeof metadata.phoneNumber === 'string')
       return metadata.phoneNumber
-    // Meta social channels identify by the account they post as, not an address:
-    // the IG handle where there is one, otherwise the Facebook Page name. Read
-    // from metadata rather than `Integration.name` so channels connected before
-    // the name was persisted still show something other than a bare provider label.
+    // Meta social channels: the account id, never `pageName` / `instagramUsername`.
+    // Instagram Direct addresses the IG business account; Messenger the Page.
+    if (
+      'instagramBusinessAccountId' in metadata &&
+      typeof metadata.instagramBusinessAccountId === 'string'
+    )
+      return metadata.instagramBusinessAccountId
+    if ('pageId' in metadata && typeof metadata.pageId === 'string') return metadata.pageId
+  }
+  return undefined
+}
+
+/**
+ * Human label for a channel — what a picker, a channel list or a thread header
+ * shows. Display only: never pass this to anything that routes, addresses or
+ * keys a participant (see {@link getIdentifier}).
+ *
+ * Meta channels are read from `metadata` rather than `Integration.name` so
+ * channels connected before the name was persisted still show the account they
+ * post as instead of a bare provider label.
+ */
+export function getChannelLabel(channel: ChannelLabelRow | null): string | undefined {
+  if (!channel) return undefined
+  if (channel.provider === 'chat' && channel.chatWidget) {
+    return channel.chatWidget.name
+  }
+  if (channel.name) return channel.name
+  if (channel.email) return channel.email
+  const metadata = channel.metadata
+  if (metadata && typeof metadata === 'object') {
+    if ('email' in metadata && typeof metadata.email === 'string') return metadata.email
+    if ('phoneNumber' in metadata && typeof metadata.phoneNumber === 'string')
+      return metadata.phoneNumber
     if ('instagramUsername' in metadata && typeof metadata.instagramUsername === 'string')
       return metadata.instagramUsername
     if ('pageName' in metadata && typeof metadata.pageName === 'string') return metadata.pageName
   }
-  return channel.name || undefined
+  return undefined
 }

--- a/packages/lib/src/messages/__tests__/message-sender.social-recipients.test.ts
+++ b/packages/lib/src/messages/__tests__/message-sender.social-recipients.test.ts
@@ -1,0 +1,92 @@
+// packages/lib/src/messages/__tests__/message-sender.social-recipients.test.ts
+//
+// Direct unit coverage of `resolveRecipients`, the private helper that gives a
+// `thread_only` channel (Messenger, Instagram Direct) its outbound recipient.
+// Those channels have no recipient field anywhere — the composer sends `to: []`
+// and `requiresRecipients` is false — so the address comes from the thread key
+// `socialThreadKey` minted at ingest. Without this the provider threw
+// "Recipient PSID (Page-Scoped ID) is required in 'to' field" and no reply ever
+// reached Messenger.
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@auxx/database', async () => {
+  const { createChainableDatabaseMock, createSchemaMock } = await import('../../test/database-mock')
+  return {
+    database: createChainableDatabaseMock(),
+    schema: createSchemaMock(),
+    IntegrationProviderTypeValues: ['google', 'outlook', 'email', 'mailgun', 'imap'],
+  }
+})
+
+import { MessageSenderService } from '../message-sender.service'
+
+function createService(): any {
+  return new MessageSenderService('org-1')
+}
+
+const DM_KEY = 'dm:869289333164075:27893553143563440'
+
+describe('resolveRecipients', () => {
+  it('derives the Messenger counterpart from the thread key when `to` is empty', () => {
+    expect(createService().resolveRecipients({ to: [] }, 'facebook', DM_KEY)).toEqual([
+      { identifier: '27893553143563440', identifierType: 'FACEBOOK_PSID' },
+    ])
+  })
+
+  it('types an Instagram recipient as IGSID, not PSID', () => {
+    // The two channels share a thread-key format but not an id space; a wrong
+    // type forks the participant identity even when the send succeeds.
+    expect(createService().resolveRecipients({ to: [] }, 'instagram', DM_KEY)).toEqual([
+      { identifier: '27893553143563440', identifierType: 'INSTAGRAM_IGSID' },
+    ])
+  })
+
+  it('never overrides an explicit recipient address', () => {
+    const to = [{ identifier: '999', identifierType: 'FACEBOOK_PSID' }]
+    expect(createService().resolveRecipients({ to }, 'facebook', DM_KEY)).toEqual(to)
+  })
+
+  it('corrects an id space the caller guessed wrong on a thread_only channel', () => {
+    // The workflow answer node resolves the right identifier off the thread but
+    // labels every recipient EMAIL. On Messenger there is only one id space, so
+    // that label is wrong rather than a choice — left alone it forks a second
+    // participant for a person ingest already has.
+    expect(
+      createService().resolveRecipients(
+        { to: [{ identifier: '27893553143563440', identifierType: 'EMAIL' }] },
+        'facebook',
+        DM_KEY
+      )
+    ).toEqual([{ identifier: '27893553143563440', identifierType: 'FACEBOOK_PSID' }])
+  })
+
+  it('leaves a correctly-typed recipient untouched', () => {
+    const to = [{ identifier: '27893553143563440', identifierType: 'FACEBOOK_PSID' }]
+    expect(createService().resolveRecipients({ to }, 'facebook', DM_KEY)[0]).toBe(to[0])
+  })
+
+  it('never rewrites the id space on an email channel', () => {
+    const to = [{ identifier: 'customer@example.com', identifierType: 'EMAIL' }]
+    expect(createService().resolveRecipients({ to }, 'google', DM_KEY)).toBe(to)
+  })
+
+  it('leaves email channels alone — they are not thread_only', () => {
+    // Email must keep failing loudly on an empty recipient list rather than
+    // silently addressing whatever the thread id happens to look like.
+    expect(createService().resolveRecipients({ to: [] }, 'google', DM_KEY)).toEqual([])
+  })
+
+  it('leaves chat alone — its counterpart is encoded on the Thread, not the key', () => {
+    expect(createService().resolveRecipients({ to: [] }, 'chat', DM_KEY)).toEqual([])
+  })
+
+  it.each([
+    ['a comment thread', 'comment:1234567890'],
+    ['a pending/placeholder thread', undefined],
+    ['a null external id', null],
+    ['a provider conversation id', 't_1234567890'],
+  ])('returns an empty list for %s rather than guessing', (_label, externalId) => {
+    expect(createService().resolveRecipients({ to: [] }, 'facebook', externalId)).toEqual([])
+  })
+})

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -6,6 +6,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
 import { and, asc, desc, eq, sql } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
+import { getComposerCapabilities, identifierTypeForProvider } from '../channels/capabilities'
 import {
   touchActivityForThreadLinks,
   touchInteractionForMessage,
@@ -24,6 +25,7 @@ import { getThreadLens } from '../permissions/visibility/thread-lens'
 import type { NormalizedEmailError as NormalizedEmailErrorInstance } from '../providers/error-normalization'
 import type { AttachmentFile } from '../providers/message-provider-interface'
 import type { ProviderRegistryService } from '../providers/provider-registry-service'
+import { parseSocialDmThreadKey } from '../providers/social/thread-key'
 import {
   getRealtimeService,
   publishMessageCreated,
@@ -224,7 +226,16 @@ export class MessageSenderService {
         externalId: threadContext.externalId,
       })
       // Step 2: Process participants
-      const participants = await this.processParticipants(input, threadContext.inboxId ?? null)
+      const recipients = this.resolveRecipients(
+        input,
+        capabilities.provider,
+        threadContext.externalId
+      )
+      const participants = await this.processParticipants(
+        input,
+        threadContext.inboxId ?? null,
+        recipients
+      )
       const isAutomatedSend = !this.viewer || isSystemViewer(this.viewer)
       // Step 2.4: §6 fix #3 — per-thread auto-reply alternation. Existing threads only;
       // a freshly-created (pending) thread has no prior message to alternate against.
@@ -608,9 +619,55 @@ export class MessageSenderService {
    * events for any tracked-column change these upserts cause (the composer used
    * to mutate names silently, leaving open clients stale until remount).
    */
+  /**
+   * The TO recipients for this send.
+   *
+   * `thread_only` channels (Messenger, Instagram Direct) have no recipient field
+   * anywhere: `PLATFORM_CAPABILITIES` declares the model, `requiresRecipients` is
+   * false so validation lets an empty list through, and the reply composer sends
+   * `to: []` because there is genuinely nothing for a user to type. The address is
+   * a property of the conversation instead — `socialThreadKey` derived it from the
+   * webhook as `dm:{pageId}:{counterpartId}`, so the counterpart is recoverable
+   * from the thread with no query and no Graph call.
+   *
+   * Resolved HERE rather than in the provider, deliberately. A provider-side
+   * fallback would put the right PSID on the wire while leaving the outbound row
+   * with no TO participant at all — precisely the split
+   * `findOrCreateParticipantForIntegration` documents ("The wire was always fine;
+   * only the DB row disagreed"). Deriving before `processParticipants` keeps the
+   * message's participant rollup and the wire in agreement, and fixes every
+   * caller at once: the composer, the workflow answer node, and anything later
+   * that replies on a social thread without inventing its own address lookup.
+   *
+   * An explicit `to` wins on the address; only its id space is corrected, and
+   * only on channels where that space is fixed by the channel itself.
+   */
+  private resolveRecipients(
+    input: SendMessageInput,
+    provider: string,
+    externalThreadId: string | null | undefined
+  ): SendMessageInput['to'] {
+    if (getComposerCapabilities(provider)?.recipientModel !== 'thread_only') return input.to
+    const identifierType = identifierTypeForProvider(provider)
+    if (!identifierType) return input.to
+    // A `thread_only` channel has exactly one possible id space, so any other
+    // type on a supplied recipient is definitionally wrong rather than a choice.
+    // The workflow answer node auto-resolves the right *identifier* off the
+    // thread but labels every recipient EMAIL, which would fork the participant
+    // from the one ingest already created for that person.
+    if (input.to.length > 0) {
+      return input.to.map((p) =>
+        p.identifierType === identifierType ? p : { ...p, identifierType }
+      )
+    }
+    const parsed = parseSocialDmThreadKey(externalThreadId)
+    if (!parsed) return input.to
+    return [{ identifier: parsed.counterpartId, identifierType }]
+  }
   private async processParticipants(
     input: SendMessageInput,
-    inboxId: string | null
+    inboxId: string | null,
+    recipients: SendMessageInput['to']
   ): Promise<ProcessedParticipants> {
     const publish = { inboxId, excludeSocketId: this.socketId }
     // FROM is the sending mailbox (e.g. markus@auxx.ai), not the operator's
@@ -640,7 +697,7 @@ export class MessageSenderService {
     }
     // Process all recipients in parallel
     const [toParticipants, ccParticipants, bccParticipants] = await Promise.all([
-      Promise.all(input.to.map((p) => processParticipant(p, ParticipantRole.TO))),
+      Promise.all(recipients.map((p) => processParticipant(p, ParticipantRole.TO))),
       Promise.all((input.cc || []).map((p) => processParticipant(p, ParticipantRole.CC))),
       Promise.all((input.bcc || []).map((p) => processParticipant(p, ParticipantRole.BCC))),
     ])

--- a/packages/lib/src/participants/__tests__/participant-for-integration.test.ts
+++ b/packages/lib/src/participants/__tests__/participant-for-integration.test.ts
@@ -132,8 +132,10 @@ describe('findOrCreateParticipantForIntegration', () => {
   })
 
   it('never falls back to the channel display name as an identifier', async () => {
-    // `getIdentifier` ends with `channel.name` for UI labelling. A display name
-    // is not routable and must never become a Participant identifier.
+    // A display name is not routable and must never become a Participant
+    // identifier. `getIdentifier` no longer reads `channel.name` at all (display
+    // labelling moved to `getChannelLabel`), so this is now structural — the
+    // test stays as the regression guard for that split.
     h.integrationRow = {
       provider: 'openphone',
       email: null,

--- a/packages/lib/src/participants/participant-service.ts
+++ b/packages/lib/src/participants/participant-service.ts
@@ -360,10 +360,11 @@ export class ParticipantService {
     // provider with no declared type at all (`shopify`, or an unknown one).
     if (!identifierType || identifierType === 'CHAT_VISITOR') return null
 
+    // `getIdentifier` is routing-only by construction — it cannot return a
+    // display name, so there is nothing to defend against here any more.
     const identifier = getIdentifier({
       provider: integration.provider,
       email: integration.email,
-      name: null, // never fall back to the channel's display name as an identifier
       metadata: integration.metadata,
     })
     if (!identifier) return null

--- a/packages/lib/src/providers/social/__tests__/thread-key.test.ts
+++ b/packages/lib/src/providers/social/__tests__/thread-key.test.ts
@@ -1,0 +1,44 @@
+// packages/lib/src/providers/social/__tests__/thread-key.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { isSocialDmThreadKey, parseSocialDmThreadKey, socialThreadKey } from '../thread-key'
+
+describe('parseSocialDmThreadKey', () => {
+  it('round-trips a key minted by socialThreadKey', () => {
+    const key = socialThreadKey('869289333164075', '27893553143563440')
+    expect(key).toBe('dm:869289333164075:27893553143563440')
+    expect(parseSocialDmThreadKey(key)).toEqual({
+      pageId: '869289333164075',
+      counterpartId: '27893553143563440',
+    })
+  })
+
+  it('rejects the comment namespace', () => {
+    // Comments share the column. Reading one as a DM would address a reply to a
+    // comment id as if it were a PSID.
+    expect(parseSocialDmThreadKey('comment:1234567890')).toBeNull()
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['empty', ''],
+    ['a provider-issued conversation id', 't_1234567890'],
+    ['an email thread id', '<CAF=abc@mail.gmail.com>'],
+    ['a bare prefix', 'dm:'],
+    ['a missing counterpart', 'dm:869289333164075'],
+    ['an empty counterpart', 'dm:869289333164075:'],
+    ['an empty page id', 'dm::27893553143563440'],
+    ['an extra segment', 'dm:869289333164075:27893553143563440:extra'],
+  ])('returns null for %s', (_label, key) => {
+    expect(parseSocialDmThreadKey(key)).toBeNull()
+  })
+
+  it('agrees with isSocialDmThreadKey on what is a DM key', () => {
+    // A key the predicate accepts but the parser rejects would send a reply with
+    // no recipient; the reverse would address one the thread never named.
+    for (const key of ['dm:1:2', 'dm:', 'comment:1', 't_1', '']) {
+      if (parseSocialDmThreadKey(key)) expect(isSocialDmThreadKey(key)).toBe(true)
+    }
+  })
+})

--- a/packages/lib/src/providers/social/thread-key.ts
+++ b/packages/lib/src/providers/social/thread-key.ts
@@ -53,3 +53,29 @@ export function socialThreadKey(pageId: string, counterpartId: string): string {
 export function isSocialDmThreadKey(key: string | null | undefined): boolean {
   return !!key?.startsWith(`${SOCIAL_THREAD_KEY_NAMESPACES.dm}:`)
 }
+
+/**
+ * Inverse of {@link socialThreadKey}: recover `(pageId, counterpartId)` from a
+ * stored DM key. Returns `null` for anything else — a `comment:` key, a
+ * provider-issued id, a placeholder, or a malformed string.
+ *
+ * This is what makes a Messenger / IG reply addressable without asking Meta.
+ * Those channels are `recipientModel: 'thread_only'`: the composer has no
+ * recipient field because there is nothing for a user to type, so the outbound
+ * recipient has to come from the conversation itself. Since a DM is strictly
+ * 1:1, the key already *is* the address — no Graph round trip, no participant
+ * query.
+ *
+ * Strict on arity: ids Meta issues are numeric and never contain `:`, so a key
+ * with extra segments is a key we did not mint and must not guess at.
+ */
+export function parseSocialDmThreadKey(
+  key: string | null | undefined
+): { pageId: string; counterpartId: string } | null {
+  if (!isSocialDmThreadKey(key)) return null
+  const parts = (key as string).split(':')
+  if (parts.length !== 3) return null
+  const [, pageId, counterpartId] = parts
+  if (!pageId || !counterpartId) return null
+  return { pageId, counterpartId }
+}

--- a/packages/lib/src/workflow-engine/catalog/app-manifests.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/app-manifests.test.ts
@@ -575,6 +575,20 @@ describe('synthesizeAppBlockManifest — validate', () => {
     expect(errors[0]?.message).toContain('shipment.track')
   })
 
+  it('marks ONLY the operation errors as blocking authoring', () => {
+    // `blocksAuthoring` is what lets `validateGraphStructure` refuse a write
+    // for a node the caller just authored. It must not leak onto the other
+    // tier-2 errors: a workspace with no connection yet is a legitimate state
+    // to add a node in, and blocking it would be unfixable from the editor.
+    const unconnected = manifestFor(
+      { requiresConnection: true },
+      { orgConnectionPresent: false }
+    ).validate({ ...healthyConfig, operation: 'teleport' }).errors
+
+    expect(unconnected.filter((e) => e.blocksAuthoring).map((e) => e.field)).toEqual(['operation'])
+    expect(unconnected.some((e) => e.field === 'connectionId' && e.type === 'error')).toBe(true)
+  })
+
   it('errors when no operation is selected', () => {
     expect(errorsFor({ type: APP_TYPE }, 'operation')[0]?.type).toBe('error')
   })

--- a/packages/lib/src/workflow-engine/catalog/app-manifests.ts
+++ b/packages/lib/src/workflow-engine/catalog/app-manifests.ts
@@ -422,12 +422,19 @@ function validateAppBlockConfig(
       field: 'operation',
       message: `This ${appTitle} block has no operation selected, so it cannot run and produces no outputs. Set resource and operation to one of: ${opKeys.join(', ')}.`,
       type: 'error',
+      blocksAuthoring: true,
     })
   } else if (!op) {
     errors.push({
       field: 'operation',
       message: `"${resource}.${operation}" is not an operation this ${appTitle} block offers — the app may have changed it. Available: ${opKeys.join(', ')}.`,
       type: 'error',
+      // Authoring a node on an operation the block does not dispatch is the
+      // same class of defect as a fabricated `{{Node.field}}` ref: nothing
+      // downstream contradicts it, so the author believes it worked. A
+      // PRE-EXISTING node in this state still only gates `run_node` — the
+      // asymmetry lives in `validateGraphStructure`, keyed on `newNodeIds`.
+      blocksAuthoring: true,
     })
   }
 

--- a/packages/lib/src/workflow-engine/catalog/types.ts
+++ b/packages/lib/src/workflow-engine/catalog/types.ts
@@ -44,7 +44,28 @@ export enum NodeCategory {
  */
 export interface NodeValidationResult {
   isValid: boolean
-  errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }>
+  errors: Array<{
+    field: string
+    message: string
+    type?: 'warning' | 'error'
+    /**
+     * This defect makes the node MALFORMED, not merely unusable — so a caller
+     * that is authoring the node right now must refuse the write.
+     *
+     * The distinction matters because the two are genuinely different. An
+     * ordinary `error` says "running this will fail" and gates `run_node`; a
+     * half-configured draft legitimately persists and the user fixes it later.
+     * A `blocksAuthoring` error says the config names something that does not
+     * exist — a fabricated app-block operation, say — which nothing downstream
+     * would contradict, so the author would believe it succeeded.
+     *
+     * Read ONLY for nodes a mutation introduced (`newNodeIds` in
+     * `validateGraphStructure`). A pre-existing node carrying one — an app
+     * upgrade dropped its operation — must never block a graph-wide edit, or
+     * one drifted node makes the whole workflow uneditable.
+     */
+    blocksAuthoring?: boolean
+  }>
 }
 
 /** A branch handle a node exposes for a given config (if-else cases, fail branches, …). */

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/answer.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/answer.ts
@@ -282,6 +282,10 @@ export class AnswerProcessor extends BaseNodeProcessor {
     }
 
     // 4. Process recipients - convert email strings to ParticipantInput format
+    //
+    // The id space follows the channel, not the field name, but the provider is
+    // not known here — `MessageSenderService.resolveRecipients` normalises the
+    // type for channels whose recipient model fixes it (Messenger, Instagram).
     const toParticipants: ParticipantInput[] = resolvedTo.map((email) => ({
       identifier: email,
       identifierType: IdentifierType.EMAIL,

--- a/packages/lib/src/workflows/graph-edit/__tests__/input-wiring.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/input-wiring.test.ts
@@ -19,12 +19,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // Partial mock — the cache barrel is imported by half of lib; replacing it
 // wholesale dies at collection. Only the read the graph-edit path makes is stubbed.
 const getCachedResources = vi.fn()
+const getCachedInstalledApps = vi.fn()
 vi.mock('../../../cache', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../cache')>()),
   getCachedResources: (...args: unknown[]) => getCachedResources(...args),
-  // No installed apps: these suites exercise CORE node types, so the manifest
-  // lookup `loadDraftContext` builds must resolve to the registry alone.
-  getCachedInstalledApps: async () => [],
+  // Controllable per test: most cases exercise CORE node types and want the
+  // manifest lookup to resolve to the registry alone, but the app-block case
+  // below needs a real installed block.
+  getCachedInstalledApps: (...args: unknown[]) => getCachedInstalledApps(...args),
 }))
 
 // The persist seam writes through WorkflowService.update (lazy-imported in
@@ -182,6 +184,8 @@ function errors(issues: ReturnType<typeof validateGraphStructure>) {
 beforeEach(() => {
   getCachedResources.mockReset()
   getCachedResources.mockResolvedValue([])
+  getCachedInstalledApps.mockReset()
+  getCachedInstalledApps.mockResolvedValue([])
   mailGuard.mockReset()
   mailGuard.mockResolvedValue(undefined)
   serviceUpdate.mockReset()
@@ -307,14 +311,64 @@ describe('edge handle resolution (§4a)', () => {
   })
 
   /**
-   * `isInputNodePair` is strict on the SOURCE side, and app-block node types
-   * are uncatalogued permanently (installed apps never ship a manifest). So an
-   * app-block aimed at the trigger stays a plain `source` → `target` edge and
-   * is rejected exactly as it was before §2 — the exception belongs to
-   * catalogued INPUT-category types alone, not to "anything unknown".
+   * `isInputNodePair` is strict on the SOURCE side, and the exception belongs
+   * to catalogued INPUT-category types alone — never to "anything unknown".
+   *
+   * **Re-pointed at a CATALOGUED app block (plan 17 §9).** This case used to
+   * pass because an app block had no manifest at all, which is exactly the
+   * condition B2 removed. Asserting it against an uncatalogued type now proves
+   * nothing about app blocks — it proves the generic unknown-type path, which
+   * the `webhook` case below already covers. What must hold today is that a
+   * block from an app the org HAS installed, whose manifest resolves and which
+   * is authorable, is still refused as input wiring: by its declared
+   * `category: INTEGRATION` and `acceptsInputNodes: false`, not by absence.
    */
-  it('an uncatalogued app-block source never mints an input wiring', async () => {
+  it('a CATALOGUED app-block source never mints an input wiring', async () => {
+    const APP_ID = 'acme00000000000000000000'
+    const APP_BLOCK_TYPE = `${APP_ID}:sync`
     const APP_BLOCK_ID = 'app-block-aaaaaaaaaaaaaa'
+    getCachedInstalledApps.mockResolvedValue([
+      {
+        installationId: 'inst_1',
+        installationType: 'production',
+        installedAt: '2026-08-01T00:00:00.000Z',
+        app: {
+          id: APP_ID,
+          slug: 'acme',
+          title: 'Acme',
+          description: null,
+          avatarUrl: null,
+          category: null,
+        },
+        currentDeployment: null,
+        methods: [],
+        connectionDefinitions: {},
+        orgConnectionPresent: true,
+        orgConnectionExpiresAt: null,
+        workflowBlocks: [
+          {
+            id: 'sync',
+            label: 'Acme Sync',
+            iconKey: null,
+            inputsJsonSchema: {},
+            toolMap: { 'record.sync': 'tool_sync' },
+            refs: [],
+            ops: [
+              {
+                key: 'record.sync',
+                resource: 'record',
+                operation: 'sync',
+                toolId: 'tool_sync',
+                inputsJsonSchema: {},
+                outputsJsonSchema: {},
+                requiresConnection: false,
+              },
+            ],
+          },
+        ],
+      },
+    ])
+
     const graph: DraftGraph = {
       nodes: [
         {
@@ -323,7 +377,15 @@ describe('edge handle resolution (§4a)', () => {
           position: { x: -200, y: 100 },
           width: 244,
           height: 100,
-          data: { id: APP_BLOCK_ID, type: 'app:acme:sync', title: 'Acme Sync' },
+          data: {
+            id: APP_BLOCK_ID,
+            type: APP_BLOCK_TYPE,
+            title: 'Acme Sync',
+            appId: APP_ID,
+            blockId: 'sync',
+            resource: 'record',
+            operation: 'sync',
+          },
         },
         manualNode(),
         waitNode(),
@@ -337,6 +399,40 @@ describe('edge handle resolution (§4a)', () => {
       to: 'Manual Trigger',
     })
     expect(result.isOk()).toBe(true)
+    // The discriminator: the block RESOLVED. Without this the test would keep
+    // passing if the stub broke and it silently fell back to the uncatalogued
+    // path — which is precisely how the pre-B2 version of this case stopped
+    // testing what its name claims.
+    expect(result._unsafeUnwrap().graphSummary?.readOnlyNodes).toBeUndefined()
+    expect(result._unsafeUnwrap().applied).toBe(false)
+    expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('an uncatalogued type is still refused too — the generic path', async () => {
+    const UNKNOWN_ID = 'app-block-aaaaaaaaaaaaaa'
+    const graph: DraftGraph = {
+      nodes: [
+        {
+          id: UNKNOWN_ID,
+          type: 'standard',
+          position: { x: -200, y: 100 },
+          width: 244,
+          height: 100,
+          data: { id: UNKNOWN_ID, type: 'app:acme:sync', title: 'Acme Sync' },
+        },
+        manualNode(),
+        waitNode(),
+      ],
+      edges: [edge(MANUAL_ID, 'source', WAIT_ID)],
+    }
+    const result = await connectNodes(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      from: 'Acme Sync',
+      to: 'Manual Trigger',
+    })
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().graphSummary?.readOnlyNodes).toEqual(['Acme Sync'])
     expect(result._unsafeUnwrap().applied).toBe(false)
     expect(serviceUpdate).not.toHaveBeenCalled()
   })

--- a/packages/lib/src/workflows/graph-edit/__tests__/manifest-lookup.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/manifest-lookup.test.ts
@@ -140,6 +140,75 @@ describe('validateGraphStructure', () => {
   })
 })
 
+describe('validateGraphStructure — the S2 op asymmetry', () => {
+  const fabricated = (): DraftGraph => ({
+    nodes: [manualNode(), appBlockNode({ operation: 'teleport' })],
+    edges: [],
+  })
+
+  it('BLOCKS a newly authored node whose operation the block does not offer', () => {
+    // Same class of defect as a fabricated `{{Node.field}}` ref: nothing
+    // downstream contradicts it, so the author believes the write worked.
+    const blocking = errors(
+      validateGraphStructure(fabricated(), { lookup: withApp, newNodeIds: new Set([BLOCK_ID]) })
+    )
+
+    expect(blocking).toHaveLength(1)
+    expect(blocking[0]?.field).toBe('operation')
+    expect(blocking[0]?.message).toContain('shipment.track')
+  })
+
+  it('never blocks the SAME defect on a pre-existing node', () => {
+    // An app upgrade dropped the operation under a stored node. Blocking here
+    // would make the whole workflow uneditable over one drifted node — the
+    // #1649 shape. It is still reported (and still refuses `run_node`) through
+    // the non-blocking tier-2 pass.
+    expect(errors(validateGraphStructure(fabricated(), { lookup: withApp }))).toEqual([])
+    expect(
+      validateNodeConfigs(fabricated(), withApp).some(
+        (i) => i.severity === 'error' && i.field === 'operation'
+      )
+    ).toBe(true)
+  })
+
+  it('does not promote the other tier-2 errors a validator reports', () => {
+    // A missing WORKSPACE CONNECTION is a tier-2 `error` — it gates `run_node`
+    // because the run is guaranteed to fail. It must NOT block the write:
+    // adding a node before anyone has connected the app is legitimate
+    // authoring, and refusing it would be unfixable from inside the editor.
+    const unconnected: ManifestLookup = (type) =>
+      getManifest(type) ??
+      (type === APP_TYPE
+        ? synthesizeAppBlockManifest(
+            { ...installation, orgConnectionPresent: false } as CachedInstalledApp,
+            { ...block, requiresConnection: true }
+          )
+        : undefined)
+    const graph: DraftGraph = { nodes: [manualNode(), appBlockNode()], edges: [] }
+
+    expect(
+      errors(
+        validateGraphStructure(graph, { lookup: unconnected, newNodeIds: new Set([BLOCK_ID]) })
+      )
+    ).toEqual([])
+    expect(
+      validateNodeConfigs(graph, unconnected).some(
+        (i) => i.severity === 'error' && i.field === 'connectionId'
+      )
+    ).toBe(true)
+  })
+
+  it('promotes nothing for core types', () => {
+    // No core manifest sets `blocksAuthoring`, so the newNodeIds arm must stay
+    // exactly as strict as it was — type existence and authorability only.
+    const graph: DraftGraph = { nodes: [manualNode()], edges: [] }
+
+    expect(
+      errors(validateGraphStructure(graph, { lookup: withApp, newNodeIds: new Set([MANUAL_ID]) }))
+    ).toEqual([])
+  })
+})
+
 describe('validateNodeConfigs', () => {
   it('says nothing about an app block the core registry cannot see', () => {
     // `if (!manifest) continue` — zero config validation, ever. This is the

--- a/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
@@ -14,12 +14,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // Partial mock — the cache barrel is imported by half of lib; replacing it
 // wholesale dies at collection. Only the read the graph-edit path makes is stubbed.
 const getCachedResources = vi.fn()
+const getCachedInstalledApps = vi.fn()
 vi.mock('../../../cache', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../../cache')>()),
   getCachedResources: (...args: unknown[]) => getCachedResources(...args),
-  // No installed apps: these suites exercise CORE node types, so the manifest
-  // lookup `loadDraftContext` builds must resolve to the registry alone.
-  getCachedInstalledApps: async () => [],
+  // Controllable per test: most cases exercise CORE node types and want the
+  // manifest lookup to resolve to the registry alone; the app-block suite
+  // below installs one.
+  getCachedInstalledApps: (...args: unknown[]) => getCachedInstalledApps(...args),
 }))
 
 // The persist seam writes through WorkflowService.update (lazy-imported in
@@ -202,6 +204,8 @@ function persistedGraph(): DraftGraph {
 beforeEach(() => {
   getCachedResources.mockReset()
   getCachedResources.mockResolvedValue(RESOURCES)
+  getCachedInstalledApps.mockReset()
+  getCachedInstalledApps.mockResolvedValue([])
   mailGuard.mockReset()
   mailGuard.mockResolvedValue(undefined)
   serviceUpdate.mockReset()
@@ -1055,5 +1059,204 @@ describe('readDraft (§1)', () => {
     // Outputs keyed by friendly ref.
     expect(Object.keys(draft.outputs)).toContain('Every Morning')
     expect(Object.keys(draft.outputs)).toContain('Cool Down')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// App blocks, end to end (plan 17 PR B3)
+//
+// The checkpoint the plan describes: Kopilot can add and edit a node
+// contributed by an installed app. Everything below goes through the real
+// mutation pipeline — `loadDraftContext` builds the manifest lookup off the
+// stubbed org cache, exactly as it does in production.
+// ---------------------------------------------------------------------------
+
+const ACME_APP_ID = 'acme00000000000000000000'
+const ACME_TYPE = `${ACME_APP_ID}:sync`
+const ACME_NODE_ID = 'acme-sync-aaaaaaaaaaaaaaa'
+const APP_WAIT_ID = 'wait-aaaaaaaaaaaaaaaaaaaaa'
+
+function plainNode(id: string, type: string, title: string, data: Record<string, unknown>) {
+  return {
+    id,
+    type: 'standard',
+    position: { x: 100, y: 200 },
+    width: 244,
+    height: 100,
+    data: { id, type, title, ...data },
+  } as GraphNode
+}
+
+function installAcme() {
+  getCachedInstalledApps.mockResolvedValue([
+    {
+      installationId: 'inst_1',
+      installationType: 'production',
+      installedAt: '2026-08-01T00:00:00.000Z',
+      app: {
+        id: ACME_APP_ID,
+        slug: 'acme',
+        title: 'Acme',
+        description: null,
+        avatarUrl: null,
+        category: null,
+      },
+      currentDeployment: null,
+      methods: [],
+      connectionDefinitions: {},
+      orgConnectionPresent: true,
+      orgConnectionExpiresAt: null,
+      workflowBlocks: [
+        {
+          id: 'sync',
+          label: 'Acme Sync',
+          description: 'Sync a record with Acme',
+          iconKey: null,
+          inputsJsonSchema: {
+            recordId: { type: 'string', _metadata: { label: 'Record' } },
+          },
+          toolMap: { 'record.sync': 'tool_sync', 'record.archive': 'tool_archive' },
+          refs: [],
+          ops: [
+            {
+              key: 'record.sync',
+              resource: 'record',
+              operation: 'sync',
+              toolId: 'tool_sync',
+              inputsJsonSchema: {},
+              outputsJsonSchema: {},
+              requiresConnection: false,
+            },
+            {
+              key: 'record.archive',
+              resource: 'record',
+              operation: 'archive',
+              toolId: 'tool_archive',
+              inputsJsonSchema: {},
+              outputsJsonSchema: {},
+              requiresConnection: false,
+            },
+          ],
+        },
+      ],
+    },
+  ])
+}
+
+const waitOnlyGraph = (): DraftGraph => ({
+  nodes: [
+    plainNode(APP_WAIT_ID, 'wait', 'Wait A Bit', { waitType: 'duration', durationAmount: 5 }),
+  ],
+  edges: [],
+})
+
+describe('app blocks — authoring (§5 B3 checkpoint)', () => {
+  it('adds a node contributed by an installed app', async () => {
+    installAcme()
+    const result = await addNode(makeDb(waitOnlyGraph()), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      type: ACME_TYPE,
+      after: 'Wait A Bit',
+      config: { resource: 'record', operation: 'archive' },
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().applied).toBe(true)
+
+    const added = persistedGraph().nodes.find((n) => n.data?.type === ACME_TYPE)
+    expect(added?.data).toMatchObject({
+      type: ACME_TYPE,
+      appId: ACME_APP_ID,
+      appSlug: 'acme',
+      blockId: 'sync',
+      title: 'Acme Sync',
+      resource: 'record',
+      operation: 'archive',
+    })
+    // A plain downstream edge on the default source handle — app blocks
+    // declare no branches.
+    expect(persistedGraph().edges).toContainEqual(
+      expect.objectContaining({ source: APP_WAIT_ID, sourceHandle: 'source', target: added?.id })
+    )
+  })
+
+  it('refuses a node whose operation the block does not offer', async () => {
+    // S2: a FABRICATED operation must fail the write, or the agent believes it
+    // succeeded and nothing downstream says otherwise.
+    installAcme()
+    const result = await addNode(makeDb(waitOnlyGraph()), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      type: ACME_TYPE,
+      after: 'Wait A Bit',
+      config: { resource: 'record', operation: 'teleport' },
+    })
+
+    expect(result.isOk()).toBe(true)
+    const value = result._unsafeUnwrap()
+    expect(value.applied).toBe(false)
+    expect(value.issues.some((i) => i.severity === 'error' && i.field === 'operation')).toBe(true)
+    expect(serviceUpdate).not.toHaveBeenCalled()
+  })
+
+  it('edits an existing app-block node — the hard 400 is gone', async () => {
+    // `updateNode` checks the EXISTING node's type through
+    // `requireAuthorableManifest`, which used to reject every app block
+    // outright. This is the §1 log's blocked path.
+    installAcme()
+    const graph: DraftGraph = {
+      nodes: [
+        plainNode(APP_WAIT_ID, 'wait', 'Wait A Bit', { waitType: 'duration', durationAmount: 5 }),
+        plainNode(ACME_NODE_ID, ACME_TYPE, 'Acme Sync', {
+          appId: ACME_APP_ID,
+          blockId: 'sync',
+          resource: 'record',
+          operation: 'sync',
+        }),
+      ],
+      edges: [],
+    }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'Acme Sync',
+      config: { resource: 'record', operation: 'archive' },
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().applied).toBe(true)
+    expect(persistedGraph().nodes.find((n) => n.id === ACME_NODE_ID)?.data?.operation).toBe(
+      'archive'
+    )
+  })
+
+  it('names the app-block shape when the type resolves to nothing', async () => {
+    // Listing the ~27 core ids at someone who typed a colon answers a question
+    // they did not ask.
+    const result = await addNode(makeDb(waitOnlyGraph()), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      type: 'notinstalled0000000000000:sync',
+      after: 'Wait A Bit',
+    })
+
+    expect(result.isErr()).toBe(true)
+    const message = result._unsafeUnwrapErr().message
+    expect(message).toContain('<appId>:<blockId>')
+    expect(message).toContain('not installed')
+    expect(message).not.toContain('wait, ')
+  })
+
+  it('still lists the core types for a plain unknown type', async () => {
+    const result = await addNode(makeDb(waitOnlyGraph()), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      type: 'nonsense',
+      after: 'Wait A Bit',
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('Core node types:')
   })
 })

--- a/packages/lib/src/workflows/graph-edit/ops.ts
+++ b/packages/lib/src/workflows/graph-edit/ops.ts
@@ -321,21 +321,52 @@ async function normalizeConfig(
   }
 }
 
-/** Manifest for an authorable type, or an actionable error naming the options. */
+/**
+ * Manifest for an authorable type, or an actionable error naming the options.
+ *
+ * The message splits on the SHAPE of the type, because the two populations have
+ * different fixes and one list cannot serve both. A core type is one of ~27
+ * platform ids, so listing them is the fix. An app block is `<appId>:<blockId>`,
+ * per-org and unbounded — listing every installed block would be a wall of text
+ * on an error whose real cause is almost always that the app is not installed
+ * here, or the id was invented. Naming the 27 core types at someone who typed a
+ * colon is worse than useless: it answers a question they did not ask.
+ */
 function requireAuthorableManifest(
   type: string,
   lookup: ManifestLookup
 ): Result<NodeManifest<any>, AuxxError> {
   const manifest = lookup(type)
   if (manifest?.agent?.authorable === true) return ok(manifest)
-  const authorable = getAuthorableManifests()
-    .map((m) => m.id)
-    .sort()
-    .join(', ')
+
+  if (manifest) {
+    return err(
+      new BadRequestError(
+        `Node type "${type}" cannot be authored here. Authorable types: ${getAuthorableManifests()
+          .map((m) => m.id)
+          .sort()
+          .join(', ')}.`
+      )
+    )
+  }
+
+  if (type.includes(':')) {
+    return err(
+      new BadRequestError(
+        `Node type "${type}" is shaped like an app block (<appId>:<blockId>), but no app ` +
+          'installed in this workspace contributes it. Either the app is not installed, its ' +
+          'current deployment no longer declares that block, or the id is wrong.'
+      )
+    )
+  }
+
   return err(
     new BadRequestError(
-      `Node type "${type}" ${manifest ? 'cannot be authored here' : 'does not exist'}. ` +
-        `Authorable types: ${authorable}.`
+      `Node type "${type}" does not exist. Core node types: ${getAuthorableManifests()
+        .map((m) => m.id)
+        .sort()
+        .join(', ')}. Blocks contributed by installed apps are addressed as ` +
+        '"<appId>:<blockId>" and are not in that list.'
     )
   )
 }

--- a/packages/lib/src/workflows/graph-edit/types.ts
+++ b/packages/lib/src/workflows/graph-edit/types.ts
@@ -149,8 +149,13 @@ export interface GraphSummary {
   /** The draft row's trigger type column (what the workflow fires on). */
   triggerType?: string | null
   /**
-   * Refs of nodes this editor can read but not author — no catalog manifest
-   * (app blocks, not-yet-migrated types).
+   * Refs of nodes this editor can read but not author — nothing the manifest
+   * lookup resolves.
+   *
+   * Post-B2 that is a NARROWER set than it used to be: a block from an app
+   * this org has installed is authorable and no longer listed. What remains is
+   * a not-yet-migrated core type, or an orphan whose app was uninstalled or
+   * whose deployment dropped the block.
    *
    * Stated ONCE here, as data, rather than as one `info` issue per node per
    * read. The agent does need to know a node is untouchable; it does not need

--- a/packages/lib/src/workflows/graph-edit/validate.ts
+++ b/packages/lib/src/workflows/graph-edit/validate.ts
@@ -24,7 +24,11 @@
  */
 
 import { getAuthorableManifests } from '../../workflow-engine/catalog/registry'
-import { type ManifestLookup, NodeCategory } from '../../workflow-engine/catalog/types'
+import {
+  type ManifestLookup,
+  NodeCategory,
+  type NodeValidationResult,
+} from '../../workflow-engine/catalog/types'
 import { formatNodeRef } from './refs'
 import type { DraftGraph, GraphEdge, GraphNode, Issue } from './types'
 
@@ -80,6 +84,22 @@ export function isInputNodePair(
     lookup(nodeType(target))?.connection.acceptsInputNodes === true &&
     lookup(nodeType(source))?.category === NodeCategory.INPUT
   )
+}
+
+/**
+ * The `blocksAuthoring` errors a manifest reports for this node's config, or
+ * none. A validator crashing on half-built data must not take the pipeline
+ * down — same tolerance `validateNodeConfigs` applies.
+ */
+function authoringBlockers(
+  manifest: NonNullable<ReturnType<ManifestLookup>>,
+  node: GraphNode
+): NodeValidationResult['errors'] {
+  try {
+    return manifest.validate(node.data).errors.filter((error) => error.blocksAuthoring === true)
+  } catch {
+    return []
+  }
 }
 
 /** An input-provider → input-accepting wiring on the handles it must use. */
@@ -191,6 +211,25 @@ export function validateGraphStructure(
           nodeRef: ref(node.id),
           message: `Node type "${type}" cannot be authored here. Authorable types: ${authorableTypes()}.`,
         })
+      } else {
+        // The type exists and may be authored — but the CONFIG can still name
+        // something that does not, and only the manifest knows its own
+        // vocabulary. `blocksAuthoring` is how a validator says "this is
+        // malformed, not merely unusable"; everything else it reports stays
+        // tier-2 and lands non-blocking through `validateNodeConfigs`.
+        //
+        // Deliberately scoped to `newNodeIds`, the same asymmetry the type
+        // check above uses: a node the caller just wrote must fail the write,
+        // while a pre-existing one that drifted (an app upgrade dropped its
+        // operation) must never make the whole workflow uneditable.
+        for (const error of authoringBlockers(manifest, node)) {
+          issues.push({
+            severity: 'error',
+            nodeRef: ref(node.id),
+            ...(error.field ? { field: error.field } : {}),
+            message: error.message,
+          })
+        }
       }
     }
     // A node with no manifest that the caller did NOT introduce is simply


### PR DESCRIPTION
Phase **B3** of `plans/kopilot/workflow/17-app-block-authoring-and-connections.md` — and the checkpoint the plan names. Stacked on #1709 and #1710.

`add_node` on an `<appId>:<blockId>` type now works, and `update_node` on an existing app-block node no longer returns a hard 400. That was the blocked path in the §1 session log, where 19 update attempts burned an entire turn and the user got nothing back.

## S2's op asymmetry

A **newly authored** node naming an operation the block does not dispatch must fail the write — it is the same class of defect as a fabricated `{{Node.field}}` ref: nothing downstream contradicts it, so the author believes it succeeded.

A **pre-existing** node in that state (an app upgrade dropped its operation) must never block a graph-wide edit, or one drifted node makes the whole workflow uneditable. That is the #1649 shape.

Implemented as one optional flag on the shared validation contract — `blocksAuthoring` — rather than a second validator or a type-shape branch inside `validateGraphStructure`. A validator uses it to say "this config is malformed, not merely unusable"; `validateGraphStructure` reads it **only** for `newNodeIds`, reusing the exact asymmetry it already applies to node types. Everything else a validator reports stays tier-2 and non-blocking.

The distinction is load-bearing in the other direction too. A **missing workspace connection** is a tier-2 `error` — the run is guaranteed to fail, so it gates `run_node` — but it must **not** block the write: adding a node before anyone has connected the app is legitimate authoring, and refusing it would be unfixable from inside the editor. Asserted both ways, at the manifest and through the pipeline.

## `requireAuthorableManifest` splits its message by the shape of the type

Core types are ~27 platform ids, so listing them *is* the fix. App blocks are per-org and unbounded — listing every installed block would be a wall of text on an error whose real cause is almost always that the app is not installed here, or the id was invented. Naming the 27 core types at someone who typed a colon answers a question they did not ask.

## The re-pointed input-wiring test (§9)

`input-wiring.test.ts`'s *"uncatalogued app-block source never mints an input wiring"* case used to pass because an app block had no manifest at all — precisely the condition #1710 removed. As written it had quietly stopped testing app blocks and started testing the generic unknown-type path, which another case already covers.

It now installs a real app and asserts that a **catalogued, authorable** block is still refused as input wiring — by its declared `category: INTEGRATION` and `acceptsInputNodes: false`, not by absence. The assertion carries a discriminator on `readOnlyNodes`, so if the stub ever breaks the test fails instead of silently degrading to the uncatalogued path again. The old case is kept as its own test, renamed for what it actually covers.

## Also

- `catalog-coverage.test.ts` gains the registry-purity assertion. Nothing else catches a refactor that registered app-block manifests into the shared Map, which would break `NOT_YET_MIGRATED`'s "may only shrink" invariant.
- `GraphSummary.readOnlyNodes`' docblock is corrected — post-#1710 it no longer lists blocks from installed apps. I deliberately did **not** re-add per-node prose distinguishing "app uninstalled" from "deployment dropped the block": #1704 shrank that to one data field on purpose, and neither case is agent-actionable beyond "do not touch this node". Flagging it since D9 asked for that wording.

## Verification

- graph-edit + catalog + kopilot: 919 tests, green
- `apps/web` parity: 28 tests, green
- `node scripts/ci/typecheck-ratchet.js --package lib` — no new type errors (29, baseline 29)

Five of the new tests drive add / update / refuse **end to end** through the real mutation pipeline, with `loadDraftContext` building the lookup off a stubbed org cache exactly as in production. Still not exercised against the real FedEx workflow in dev — that is now possible for the first time, and worth doing before C1.