### PR TITLE
fix(channels): name meta dm counterparts, mark our own page internal, un-dead the graph version

### DIFF
--- a/apps/web/src/app/api/facebook/webhook/route.ts
+++ b/apps/web/src/app/api/facebook/webhook/route.ts
@@ -3,6 +3,7 @@
 import { configService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
 import { MessageStorageService } from '@auxx/lib/email'
+import { resolveSocialCounterpartName } from '@auxx/lib/providers/social/profile'
 import type {
   MetaWebhookEnvelope,
   MetaWebhookMessagingEvent,
@@ -12,7 +13,7 @@ import { convertMetaWebhookEventToMessageData } from '@auxx/lib/providers/social
 import { metaPreset, verifyWebhook } from '@auxx/lib/webhooks'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq, isNull, sql } from 'drizzle-orm'
-import { type NextRequest, NextResponse } from 'next/server'
+import { after, type NextRequest, NextResponse } from 'next/server'
 
 const logger = createScopedLogger('facebook-webhook')
 
@@ -80,6 +81,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   // 3. Process the events
   if (payload.object === 'page') {
     const storageService = new MessageStorageService()
+    // One profile fetch per counterpart per delivery. Meta batches several
+    // events into one POST, and a burst from the same person would otherwise
+    // schedule the same Graph call once per message.
+    const scheduledNameLookups = new Set<string>()
     const processingPromises = (payload.entry ?? []).map(async (entry) => {
       // Post comments / feed activity ride on `entry.changes`, a different envelope
       // with different identity (comment ids, not PSIDs). We do not subscribe to
@@ -170,6 +175,25 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
             integrationId: integration.id,
             externalThreadId: messageData.externalThreadId,
           })
+
+          // Meta's messaging webhook carries only `sender.id`, so the counterpart
+          // participant was just created with the raw id as its label. Resolving a
+          // real name costs a Graph call, which must NOT happen before the 200:
+          // Meta retries a slow webhook and eventually disables the subscription.
+          // `after()` runs it once the response is already on the wire.
+          const counterpartId = event.sender?.id
+          const lookupKey = `${integration.id}:${counterpartId}`
+          if (counterpartId && !scheduledNameLookups.has(lookupKey)) {
+            scheduledNameLookups.add(lookupKey)
+            after(() =>
+              resolveSocialCounterpartName(db, {
+                platform: 'facebook',
+                organizationId: integration.organizationId,
+                integrationId: integration.id,
+                counterpartId,
+              })
+            )
+          }
         } catch (storeError) {
           logger.error('Failed to store Facebook message', {
             mid: event.message.mid,

--- a/apps/web/src/app/api/instagram/webhook/route.ts
+++ b/apps/web/src/app/api/instagram/webhook/route.ts
@@ -3,6 +3,7 @@
 import { configService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
 import { MessageStorageService } from '@auxx/lib/email'
+import { resolveSocialCounterpartName } from '@auxx/lib/providers/social/profile'
 import type {
   MetaWebhookEnvelope,
   MetaWebhookMessagingEvent,
@@ -12,7 +13,7 @@ import { convertMetaWebhookEventToMessageData } from '@auxx/lib/providers/social
 import { metaPreset, verifyWebhook } from '@auxx/lib/webhooks'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq, isNull, sql } from 'drizzle-orm'
-import { type NextRequest, NextResponse } from 'next/server'
+import { after, type NextRequest, NextResponse } from 'next/server'
 
 const logger = createScopedLogger('instagram-webhook')
 
@@ -77,6 +78,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   // 3. Process Instagram Events
   if (payload.object === 'instagram') {
     const storageService = new MessageStorageService()
+    // One profile fetch per counterpart per delivery. Meta batches several
+    // events into one POST, and a burst from the same person would otherwise
+    // schedule the same Graph call once per message.
+    const scheduledNameLookups = new Set<string>()
     const processingPromises = (payload.entry ?? []).map(async (entry) => {
       // Comments / mentions ride on `entry.changes`, a different envelope with
       // different identity. Not subscribed today; the branch exists so WS10 is a
@@ -159,6 +164,25 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
             integrationId: integration.id,
             externalThreadId: messageData.externalThreadId,
           })
+
+          // Meta's messaging webhook carries only `sender.id`, so the counterpart
+          // participant was just created with the raw id as its label. Resolving a
+          // real name costs a Graph call, which must NOT happen before the 200:
+          // Meta retries a slow webhook and eventually disables the subscription.
+          // `after()` runs it once the response is already on the wire.
+          const counterpartId = event.sender?.id
+          const lookupKey = `${integration.id}:${counterpartId}`
+          if (counterpartId && !scheduledNameLookups.has(lookupKey)) {
+            scheduledNameLookups.add(lookupKey)
+            after(() =>
+              resolveSocialCounterpartName(db, {
+                platform: 'instagram',
+                organizationId: integration.organizationId,
+                integrationId: integration.id,
+                counterpartId,
+              })
+            )
+          }
         } catch (storeError) {
           logger.error('Failed to store Instagram message', {
             mid: event.message.mid,

--- a/packages/credentials/src/config/config-registry.ts
+++ b/packages/credentials/src/config/config-registry.ts
@@ -430,12 +430,17 @@ export const CONFIG_VARIABLES = {
     isSensitive: true,
     isEnvOnly: false,
   },
+  // This default wins over every `|| DEFAULT_*_API_VERSION` fallback in calling code —
+  // `configService.get` returns it whenever the env var is absent — so it is the one
+  // place the Graph version is really decided. Keep it on a supported version: v19.0 is
+  // past deprecation and Graph silently answers as a current one (observed live
+  // 2026-08-17, `paging.next` links came back stamped v25.0).
   FACEBOOK_GRAPH_API_VERSION: {
     key: 'FACEBOOK_GRAPH_API_VERSION',
     description: 'Facebook Graph API version',
     type: ConfigVariableType.STRING,
     group: ConfigVariableGroup.FACEBOOK,
-    defaultValue: 'v19.0',
+    defaultValue: 'v26.0',
     isSensitive: false,
     isEnvOnly: false,
   },

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1078,6 +1078,12 @@
       "import": "./dist/providers/openphone/webhook-message.mjs",
       "default": "./src/providers/openphone/webhook-message.ts"
     },
+    "./providers/social/profile": {
+      "types": "./src/providers/social/profile.ts",
+      "source": "./src/providers/social/profile.ts",
+      "import": "./dist/providers/social/profile.mjs",
+      "default": "./src/providers/social/profile.ts"
+    },
     "./providers/social/types": {
       "types": "./src/providers/social/types.ts",
       "source": "./src/providers/social/types.ts",

--- a/packages/lib/src/channels/__tests__/own-identities.test.ts
+++ b/packages/lib/src/channels/__tests__/own-identities.test.ts
@@ -198,14 +198,125 @@ describe('buildOrgOwnIdentitySets — the phone arm', () => {
     expect(sets[IdentifierType.PHONE]).toBeUndefined()
   })
 
-  it('contributes nothing for chat and social channels', () => {
-    // Their org side is an EMAIL participant minted from the agent's user row;
-    // a CHAT_VISITOR / PSID / IGSID always names the customer.
+  it('contributes nothing for a chat channel', () => {
+    // Chat's org side is an EMAIL participant minted from the agent's user row,
+    // so a CHAT_VISITOR identifier always names the customer. Unlike the Meta
+    // channels below, that premise still holds.
     const sets = buildOrgOwnIdentitySets([
       channel({ provider: 'chat' as CachedChannel['provider'], email: null, name: 'Widget' }),
-      channel({ provider: 'facebook' as CachedChannel['provider'], email: null, name: 'Page' }),
     ])
     expect(sets[IdentifierType.CHAT_VISITOR]).toBeUndefined()
+  })
+})
+
+describe('buildOrgOwnIdentitySets — the Meta arm', () => {
+  const PAGE_ID = '869289333164075'
+  const IGBID = '17841400000000000'
+  const CUSTOMER_PSID = '27893553143563440'
+
+  const facebook = (metadata: unknown, overrides: Partial<CachedChannel> = {}) =>
+    channel({
+      id: 'fb',
+      provider: 'facebook' as CachedChannel['provider'],
+      email: null,
+      name: 'Auxx-Lift',
+      metadata,
+      ...overrides,
+    })
+
+  const instagram = (metadata: unknown, overrides: Partial<CachedChannel> = {}) =>
+    channel({
+      id: 'ig',
+      provider: 'instagram' as CachedChannel['provider'],
+      email: null,
+      name: 'auxxlift',
+      metadata,
+      ...overrides,
+    })
+
+  it('puts a Facebook page id in the FACEBOOK_PSID bucket', () => {
+    const sets = buildOrgOwnIdentitySets([facebook({ pageId: PAGE_ID, pageName: 'Auxx-Lift' })])
+    expect(sets[IdentifierType.FACEBOOK_PSID]).toEqual(new Set([PAGE_ID]))
+    expect(isOwnChannelIdentity(sets, PAGE_ID, IdentifierType.FACEBOOK_PSID)).toBe(true)
+  })
+
+  it('leaves a customer PSID on that same channel external — the whole point', () => {
+    // Both sides of a Messenger thread live in the FACEBOOK_PSID space. Only the
+    // page id is ours; a set that matched anything broader would flip every
+    // customer to internal and empty the thread list of counterparts.
+    const sets = buildOrgOwnIdentitySets([facebook({ pageId: PAGE_ID, pageName: 'Auxx-Lift' })])
+    expect(isOwnChannelIdentity(sets, CUSTOMER_PSID, IdentifierType.FACEBOOK_PSID)).toBe(false)
+  })
+
+  it('puts an Instagram business account id in the INSTAGRAM_IGSID bucket', () => {
+    const sets = buildOrgOwnIdentitySets([
+      instagram({
+        pageId: PAGE_ID,
+        pageName: 'Auxx-Lift',
+        instagramBusinessAccountId: IGBID,
+        instagramUsername: 'auxxlift',
+      }),
+    ])
+    expect(sets[IdentifierType.INSTAGRAM_IGSID]).toEqual(new Set([IGBID]))
+    expect(isOwnChannelIdentity(sets, IGBID, IdentifierType.INSTAGRAM_IGSID)).toBe(true)
+    expect(isOwnChannelIdentity(sets, CUSTOMER_PSID, IdentifierType.INSTAGRAM_IGSID)).toBe(false)
+  })
+
+  it('reads only the field the channel routes as — an IG channel carries a pageId that is not its identity', () => {
+    // `upsertSocialIntegration` writes `pageId` on BOTH providers; on an
+    // Instagram channel it names the page the account publishes through, and no
+    // IGSID participant is ever keyed on it.
+    const sets = buildOrgOwnIdentitySets([
+      instagram({ pageId: PAGE_ID, instagramBusinessAccountId: IGBID }),
+    ])
     expect(sets[IdentifierType.FACEBOOK_PSID]).toBeUndefined()
+    expect(sets[IdentifierType.INSTAGRAM_IGSID]).toEqual(new Set([IGBID]))
+  })
+
+  it('never crosses the two Meta id spaces', () => {
+    const sets = buildOrgOwnIdentitySets([
+      facebook({ pageId: PAGE_ID }),
+      instagram({ pageId: PAGE_ID, instagramBusinessAccountId: IGBID }),
+    ])
+    expect(isOwnChannelIdentity(sets, IGBID, IdentifierType.FACEBOOK_PSID)).toBe(false)
+    expect(isOwnChannelIdentity(sets, PAGE_ID, IdentifierType.INSTAGRAM_IGSID)).toBe(false)
+    expect(isOwnChannelIdentity(sets, PAGE_ID, IdentifierType.EMAIL)).toBe(false)
+  })
+
+  it('omits the buckets when no Meta channel is connected, or its id is missing', () => {
+    expect(
+      buildOrgOwnIdentitySets([channel({ email: 'support@company.com' })])[
+        IdentifierType.FACEBOOK_PSID
+      ]
+    ).toBeUndefined()
+    expect(buildOrgOwnIdentitySets([facebook(null)])[IdentifierType.FACEBOOK_PSID]).toBeUndefined()
+    expect(
+      buildOrgOwnIdentitySets([facebook({ pageName: 'Auxx-Lift' })])[IdentifierType.FACEBOOK_PSID]
+    ).toBeUndefined()
+    expect(
+      buildOrgOwnIdentitySets([facebook({ pageId: 12345 })])[IdentifierType.FACEBOOK_PSID]
+    ).toBeUndefined()
+    expect(
+      buildOrgOwnIdentitySets([instagram({ pageId: PAGE_ID })])[IdentifierType.INSTAGRAM_IGSID]
+    ).toBeUndefined()
+  })
+
+  it('honours excludeInboxIds on Meta channels too', () => {
+    const sets = buildOrgOwnIdentitySets(
+      [facebook({ pageId: PAGE_ID }, { inboxId: 'ibx_personal' })],
+      { excludeInboxIds: new Set(['ibx_personal']) }
+    )
+    expect(sets[IdentifierType.FACEBOOK_PSID]).toBeUndefined()
+  })
+
+  it('stays out of the email arm — buildOrgOwnEmailAddressSet returns only emails', () => {
+    // `getOrgOwnEmailAddresses` (SES direction, `fromOwnAddress`) reads that set
+    // and has no business seeing an account id.
+    const emails = buildOrgOwnEmailAddressSet([
+      facebook({ pageId: PAGE_ID, pageName: 'Auxx-Lift' }),
+      instagram({ pageId: PAGE_ID, instagramBusinessAccountId: IGBID }),
+      channel({ id: 'mail', email: 'support@company.com' }),
+    ])
+    expect(emails).toEqual(new Set(['support@company.com']))
   })
 })

--- a/packages/lib/src/channels/own-identities.ts
+++ b/packages/lib/src/channels/own-identities.ts
@@ -28,10 +28,32 @@ export type OwnIdentitySets = Readonly<Partial<Record<IdentifierTypeValue, Reado
  *    it is itself an `Integration.email` row (provider `email`,
  *    `metadata.systemManaged: true`).
  *  - `PHONE` — `metadata.phoneNumber`, normalized to E.164.
- *  - `CHAT_VISITOR` / `FACEBOOK_PSID` / `INSTAGRAM_IGSID` — nothing. There is no
- *    org-side identifier in those id spaces: the org's half of a chat is an
- *    EMAIL participant minted from the agent's user row (`chat/outbound.ts`),
- *    and a PSID/IGSID always names the customer.
+ *  - `FACEBOOK_PSID` / `INSTAGRAM_IGSID` — the channel's own Meta account id:
+ *    `metadata.pageId` on a `facebook` channel, `metadata.instagramBusinessAccountId`
+ *    on an `instagram` one.
+ *  - `CHAT_VISITOR` — nothing, and unlike the Meta arm that premise still holds:
+ *    the org's half of a chat is an EMAIL participant minted from the agent's
+ *    user row (`chat/outbound.ts`), so no org-side identifier exists in the
+ *    visitor id space at all.
+ *
+ * **Why the Meta arm exists — do not "simplify" it away.** On a Meta channel
+ * BOTH sides of the conversation live in ONE id space: our Page id and the
+ * customer's PSID are both `FACEBOOK_PSID`, and nothing but this set tells them
+ * apart. (Email is the same shape — our address and theirs are both `EMAIL` —
+ * but there the address itself carries the distinction; a bare numeric Meta id
+ * carries none.) Ingest mints a page-side participant identified by the Page id
+ * (`providers/social/webhook-message.ts`) and the composer sends FROM that same
+ * id, so with no Meta arm our own Page is stored `isInternal: false` and the
+ * thread list — which names a thread after its most recent *external*
+ * participant — attributes every Meta conversation to ourselves.
+ *
+ * Exactly ONE id per channel is ours: the account id the channel routes as. Any
+ * other PSID/IGSID names the customer, so this arm must never widen to "every
+ * Meta id we have seen". It also reads the field the channel's own id space
+ * names rather than going through `getIdentifier`, because an `instagram`
+ * channel's metadata carries BOTH `pageId` (the Facebook page it publishes
+ * through) and `instagramBusinessAccountId` — only the latter shares an id space
+ * with the IGSIDs on its threads.
  *
  * **Phone identifiers are normalized through `formatPhoneNumber`, both here and
  * at every comparison site.** `Integration.metadata.phoneNumber` is E.164 today
@@ -50,6 +72,8 @@ export function buildOrgOwnIdentitySets(
 ): OwnIdentitySets {
   const emails = new Set<string>()
   const phones = new Set<string>()
+  const facebookPageIds = new Set<string>()
+  const instagramAccountIds = new Set<string>()
 
   for (const channel of channels) {
     if (channel.inboxId && options?.excludeInboxIds?.has(channel.inboxId)) continue
@@ -63,16 +87,29 @@ export function buildOrgOwnIdentitySets(
     addAliasArray(emails, metadata?.userEmails) // Gmail verified send-as
 
     const type = identifierTypeForProvider(channel.provider)
-    if (type !== IdentifierType.PHONE) continue
-    const identifier = getIdentifier(channel)
-    if (!identifier) continue
-    const normalized = normalizeOwnIdentifier(identifier, IdentifierType.PHONE)
-    if (normalized) phones.add(normalized)
+
+    if (type === IdentifierType.PHONE) {
+      const identifier = getIdentifier(channel)
+      if (!identifier) continue
+      const normalized = normalizeOwnIdentifier(identifier, IdentifierType.PHONE)
+      if (normalized) phones.add(normalized)
+      continue
+    }
+
+    // The Meta arm — see the "why" in the doc comment above. One id per channel,
+    // read off the field its own id space names.
+    if (type === IdentifierType.FACEBOOK_PSID) {
+      addMetadataId(facebookPageIds, metadata?.pageId, type)
+    } else if (type === IdentifierType.INSTAGRAM_IGSID) {
+      addMetadataId(instagramAccountIds, metadata?.instagramBusinessAccountId, type)
+    }
   }
 
   const sets: Partial<Record<IdentifierTypeValue, ReadonlySet<string>>> = {}
   if (emails.size > 0) sets[IdentifierType.EMAIL] = emails
   if (phones.size > 0) sets[IdentifierType.PHONE] = phones
+  if (facebookPageIds.size > 0) sets[IdentifierType.FACEBOOK_PSID] = facebookPageIds
+  if (instagramAccountIds.size > 0) sets[IdentifierType.INSTAGRAM_IGSID] = instagramAccountIds
   return sets
 }
 
@@ -135,6 +172,13 @@ export function buildOrgOwnEmailAddressSet(
 ): Set<string> {
   const emails = buildOrgOwnIdentitySets(channels, options)[IdentifierType.EMAIL]
   return new Set(emails ?? [])
+}
+
+/** Adds one metadata-sourced identifier to `target`, folded for its type, if it is a usable string. */
+function addMetadataId(target: Set<string>, value: unknown, type: IdentifierTypeValue): void {
+  if (typeof value !== 'string') return
+  const normalized = normalizeOwnIdentifier(value, type)
+  if (normalized) target.add(normalized)
 }
 
 /** Adds every non-empty string entry of `value` (lowercased, trimmed) to `target`. */

--- a/packages/lib/src/participants/__tests__/classify-internal.test.ts
+++ b/packages/lib/src/participants/__tests__/classify-internal.test.ts
@@ -83,16 +83,58 @@ describe('classifyIsInternal', () => {
     })
   })
 
-  describe('id spaces that only ever name the customer', () => {
-    for (const type of [
-      IdentifierType.CHAT_VISITOR,
-      IdentifierType.FACEBOOK_PSID,
-      IdentifierType.INSTAGRAM_IGSID,
-    ]) {
-      it(`${type} is always external`, async () => {
-        expect(await classify('some-opaque-id', type)).toBe(false)
-      })
+  describe('CHAT_VISITOR — an id space that only ever names the customer', () => {
+    it('is always external', async () => {
+      // The org's half of a chat is an EMAIL participant minted from the agent's
+      // user row, so no visitor id is ever ours.
+      expect(await classify('some-opaque-id', IdentifierType.CHAT_VISITOR)).toBe(false)
+    })
+  })
+
+  describe('Meta ids — one id space, both sides in it', () => {
+    // Unlike chat, a Meta channel DOES have an org-side identifier in the
+    // customer's id space: ingest mints a page-side participant keyed on the
+    // page id / IG business account id. The own-identity set is the only thing
+    // that tells our numeric id from theirs.
+    const META_OWN = {
+      [IdentifierType.FACEBOOK_PSID]: new Set(['869289333164075']),
+      [IdentifierType.INSTAGRAM_IGSID]: new Set(['17841400000000000']),
     }
+
+    const classifyMeta = (
+      identifier: string,
+      identifierType: (typeof IdentifierType)[keyof typeof IdentifierType]
+    ) =>
+      classifyIsInternal({
+        organizationId: 'org_1',
+        identifier,
+        identifierType,
+        ownIdentities: META_OWN,
+      })
+
+    it('our own Facebook page is internal', async () => {
+      expect(await classifyMeta('869289333164075', IdentifierType.FACEBOOK_PSID)).toBe(true)
+    })
+
+    it('our own Instagram business account is internal', async () => {
+      expect(await classifyMeta('17841400000000000', IdentifierType.INSTAGRAM_IGSID)).toBe(true)
+    })
+
+    it("a customer's PSID on the same channel stays external", async () => {
+      // The load-bearing case: over-matching here would attribute every
+      // Messenger thread to nobody and break the sender column outright.
+      expect(await classifyMeta('27893553143563440', IdentifierType.FACEBOOK_PSID)).toBe(false)
+      expect(await classifyMeta('27893553143563440', IdentifierType.INSTAGRAM_IGSID)).toBe(false)
+    })
+
+    it('does not cross the two Meta id spaces', async () => {
+      expect(await classifyMeta('17841400000000000', IdentifierType.FACEBOOK_PSID)).toBe(false)
+      expect(await classifyMeta('869289333164075', IdentifierType.INSTAGRAM_IGSID)).toBe(false)
+    })
+
+    it('is external when no Meta channel is connected', async () => {
+      expect(await classify('869289333164075', IdentifierType.FACEBOOK_PSID)).toBe(false)
+    })
   })
 
   describe('phone normalization', () => {

--- a/packages/lib/src/participants/classify-internal.ts
+++ b/packages/lib/src/participants/classify-internal.ts
@@ -69,10 +69,16 @@ export interface ClassifyIsInternalInput {
  *    honest way to know otherwise. (`User.phoneNumber` exists but is
  *    unpopulated, un-normalized, and answering "is this a support conversation"
  *    from it is a product decision, not a lookup.)
- *  - `CHAT_VISITOR` / `FACEBOOK_PSID` / `INSTAGRAM_IGSID` → always external.
- *    There is no org-side identifier in those id spaces at all: the org's half
- *    of a chat is an EMAIL participant minted from the agent's user row
- *    (`chat/outbound.ts`), which rungs 1–3 classify on the email path.
+ *  - `FACEBOOK_PSID` / `INSTAGRAM_IGSID` → channel identities only, and the set
+ *    holds exactly one id per channel: our Page id / IG business account id.
+ *    Both sides of a Meta conversation live in this one id space — ingest mints
+ *    a page-side participant identified by the Page id — so the set is the only
+ *    thing that says which of two numeric ids is us. Every other PSID/IGSID
+ *    names the customer; do not widen this rung.
+ *  - `CHAT_VISITOR` → always external. There is no org-side identifier in that
+ *    id space at all: the org's half of a chat is an EMAIL participant minted
+ *    from the agent's user row (`chat/outbound.ts`), which rungs 1–3 classify on
+ *    the email path.
  *
  * That asymmetry is the honest ceiling of what each channel carries, not a gap
  * to close. Don't "fix" it by widening rung 3.

--- a/packages/lib/src/providers/facebook/facebook-provider.ts
+++ b/packages/lib/src/providers/facebook/facebook-provider.ts
@@ -25,7 +25,9 @@ import { socialThreadKey } from '../social/thread-key'
 import { type FacebookIntegrationMetadata, FacebookOAuthService } from './facebook-oauth'
 
 const logger = createScopedLogger('facebook-provider')
-const DEFAULT_API_VERSION = 'v19.0'
+// v19.0 is past deprecation — Graph silently answers as a current version
+// (observed live 2026-08-17: `paging.next` links came back stamped v25.0).
+const DEFAULT_API_VERSION = 'v26.0'
 
 // --- Interface Definitions (for clarity, align with Graph API responses) ---
 interface FacebookWebhookMessage {

--- a/packages/lib/src/providers/instagram/instagram-provider.ts
+++ b/packages/lib/src/providers/instagram/instagram-provider.ts
@@ -25,7 +25,9 @@ import { socialThreadKey } from '../social/thread-key'
 import { type InstagramIntegrationMetadata, InstagramOAuthService } from './instagram-oauth'
 
 const logger = createScopedLogger('instagram-provider')
-const DEFAULT_API_VERSION = 'v19.0'
+// v19.0 is past deprecation — Graph silently answers as a current version
+// (observed live 2026-08-17: `paging.next` links came back stamped v25.0).
+const DEFAULT_API_VERSION = 'v26.0'
 
 // --- Interface Definitions (Align with Graph API) ---
 // Structure of message content within webhook/API response

--- a/packages/lib/src/providers/social/__tests__/profile.test.ts
+++ b/packages/lib/src/providers/social/__tests__/profile.test.ts
@@ -1,0 +1,243 @@
+// packages/lib/src/providers/social/__tests__/profile.test.ts
+
+import type { Database } from '@auxx/database'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getUserProfile } from '../api'
+import { buildSocialDisplayName, resolveSocialCounterpartName } from '../profile'
+
+/**
+ * FB/IG plan WS13 — the counterpart display name.
+ *
+ * Meta's messaging webhook carries only `sender.id`, so without this resolver
+ * every Messenger/Instagram thread is labelled with a raw PSID. The properties
+ * worth pinning are the failure ones: a person who restricted profile access is
+ * a NORMAL outcome that must not throw (ingest runs behind a webhook Meta
+ * retries), and a participant that already has a name must not cost a Graph
+ * call at all — that lookup IS the cache.
+ */
+
+const { getChannelTokens, findOrCreateParticipant } = vi.hoisted(() => ({
+  getChannelTokens: vi.fn(),
+  findOrCreateParticipant: vi.fn(),
+}))
+
+vi.mock('../../channel-token-accessor', () => ({ getChannelTokens }))
+
+vi.mock('../../../participants/participant-service', () => ({
+  ParticipantService: class {
+    findOrCreateParticipant = findOrCreateParticipant
+  },
+}))
+
+/** Queue one array per `select(...).from(...).where(...).limit(...)` in order. */
+function fakeDb(results: unknown[][]): Database {
+  const queue = [...results]
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => queue.shift() ?? [],
+        }),
+      }),
+    }),
+  } as unknown as Database
+}
+
+function graphOk(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response
+}
+
+function graphError(status: number, error: Record<string, unknown>): Response {
+  return { ok: false, status, json: async () => ({ error }) } as unknown as Response
+}
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+  getChannelTokens.mockReset()
+  findOrCreateParticipant.mockReset()
+  getChannelTokens.mockResolvedValue({
+    accessToken: 'page-token',
+    refreshToken: null,
+    expiresAt: null,
+  })
+  findOrCreateParticipant.mockResolvedValue({ id: 'participant_1' })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('buildSocialDisplayName', () => {
+  it('prefers the Instagram-style single `name`', () => {
+    expect(buildSocialDisplayName({ name: 'Ada Lovelace', username: 'ada' })).toBe('Ada Lovelace')
+  })
+
+  it('joins the Messenger-style first/last pair', () => {
+    expect(buildSocialDisplayName({ first_name: 'Ada', last_name: 'Lovelace' })).toBe(
+      'Ada Lovelace'
+    )
+  })
+
+  it('tolerates a half-present name pair', () => {
+    expect(buildSocialDisplayName({ first_name: 'Ada' })).toBe('Ada')
+    expect(buildSocialDisplayName({ last_name: 'Lovelace' })).toBe('Lovelace')
+  })
+
+  it('falls back to the Instagram handle when no name came back', () => {
+    expect(buildSocialDisplayName({ username: 'ada' })).toBe('ada')
+  })
+
+  it('returns undefined for a node that carried nothing usable', () => {
+    expect(buildSocialDisplayName({ id: '27893553143563440' })).toBeUndefined()
+    expect(buildSocialDisplayName({ first_name: '  ' })).toBeUndefined()
+    expect(buildSocialDisplayName(null)).toBeUndefined()
+  })
+})
+
+describe('getUserProfile', () => {
+  it('asks Messenger for first_name/last_name and sends the token as a header', async () => {
+    fetchMock.mockResolvedValue(graphOk({ id: 'psid_1', first_name: 'Ada', last_name: 'Lovelace' }))
+
+    const profile = await getUserProfile({
+      platform: 'facebook',
+      userId: 'psid_1',
+      pageAccessToken: 'page-token',
+    })
+
+    expect(profile).toEqual({ id: 'psid_1', first_name: 'Ada', last_name: 'Lovelace' })
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/psid_1?')
+    expect(decodeURIComponent(url)).toContain('fields=first_name,last_name,profile_pic')
+    // Never in the query string: a token there leaks into logs and paging links.
+    expect(url).not.toContain('access_token')
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer page-token')
+  })
+
+  it('asks Instagram for name/username instead', async () => {
+    fetchMock.mockResolvedValue(graphOk({ id: 'igsid_1', name: 'Ada', username: 'ada' }))
+
+    const profile = await getUserProfile({
+      platform: 'instagram',
+      userId: 'igsid_1',
+      pageAccessToken: 'page-token',
+    })
+
+    expect(profile).toEqual({ id: 'igsid_1', name: 'Ada', username: 'ada' })
+    const [url] = fetchMock.mock.calls[0] as [string]
+    expect(decodeURIComponent(url)).toContain('fields=name,username,profile_pic')
+  })
+
+  it('returns null instead of throwing when Graph refuses', async () => {
+    fetchMock.mockResolvedValue(
+      graphError(400, { message: 'Unsupported get request.', code: 100, error_subcode: 33 })
+    )
+
+    await expect(
+      getUserProfile({ platform: 'facebook', userId: 'psid_1', pageAccessToken: 'page-token' })
+    ).resolves.toBeNull()
+  })
+})
+
+describe('resolveSocialCounterpartName', () => {
+  const base = {
+    organizationId: 'org_1',
+    integrationId: 'int_1',
+    counterpartId: '27893553143563440',
+  }
+
+  it('resolves a Facebook counterpart and writes it through the participant seam', async () => {
+    fetchMock.mockResolvedValue(graphOk({ first_name: 'Ada', last_name: 'Lovelace' }))
+    // 1st query: the participant (unnamed). 2nd: the integration's inbox link.
+    const db = fakeDb([[{ name: null }], [{ inboxId: 'inbox_1' }]])
+
+    const name = await resolveSocialCounterpartName(db, { ...base, platform: 'facebook' })
+
+    expect(name).toBe('Ada Lovelace')
+    expect(findOrCreateParticipant).toHaveBeenCalledWith(
+      {
+        identifier: '27893553143563440',
+        identifierType: 'FACEBOOK_PSID',
+        name: 'Ada Lovelace',
+      },
+      // The publish context is what makes the open thread list flip live.
+      { inboxId: 'inbox_1' }
+    )
+  })
+
+  it('resolves an Instagram counterpart on the IGSID identifier space', async () => {
+    fetchMock.mockResolvedValue(graphOk({ name: 'Ada Lovelace', username: 'ada' }))
+    const db = fakeDb([[{ name: null }], [{ inboxId: 'inbox_2' }]])
+
+    const name = await resolveSocialCounterpartName(db, { ...base, platform: 'instagram' })
+
+    expect(name).toBe('Ada Lovelace')
+    expect(findOrCreateParticipant).toHaveBeenCalledWith(
+      expect.objectContaining({ identifierType: 'INSTAGRAM_IGSID', name: 'Ada Lovelace' }),
+      { inboxId: 'inbox_2' }
+    )
+  })
+
+  it('returns undefined without throwing when profile access is restricted', async () => {
+    fetchMock.mockResolvedValue(
+      graphError(400, { message: 'Unsupported get request.', code: 100, error_subcode: 33 })
+    )
+    const db = fakeDb([[{ name: null }], [{ inboxId: 'inbox_1' }]])
+
+    await expect(
+      resolveSocialCounterpartName(db, { ...base, platform: 'facebook' })
+    ).resolves.toBeUndefined()
+    expect(findOrCreateParticipant).not.toHaveBeenCalled()
+  })
+
+  it('leaves the id fallback in place when the profile carried no name at all', async () => {
+    fetchMock.mockResolvedValue(graphOk({ id: '27893553143563440' }))
+    const db = fakeDb([[{ name: null }], [{ inboxId: 'inbox_1' }]])
+
+    await expect(
+      resolveSocialCounterpartName(db, { ...base, platform: 'facebook' })
+    ).resolves.toBeUndefined()
+    expect(findOrCreateParticipant).not.toHaveBeenCalled()
+  })
+
+  it('spends no Graph call when the participant already has a name', async () => {
+    const db = fakeDb([[{ name: 'Ada Lovelace' }]])
+
+    await expect(
+      resolveSocialCounterpartName(db, { ...base, platform: 'facebook' })
+    ).resolves.toBeUndefined()
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(getChannelTokens).not.toHaveBeenCalled()
+    expect(findOrCreateParticipant).not.toHaveBeenCalled()
+  })
+
+  it('does NOT treat the raw id stored as a name as "already named"', async () => {
+    fetchMock.mockResolvedValue(graphOk({ first_name: 'Ada', last_name: 'Lovelace' }))
+    const db = fakeDb([[{ name: '27893553143563440' }], [{ inboxId: 'inbox_1' }]])
+
+    await expect(resolveSocialCounterpartName(db, { ...base, platform: 'facebook' })).resolves.toBe(
+      'Ada Lovelace'
+    )
+  })
+
+  it('skips the Graph call when the channel has no page token', async () => {
+    getChannelTokens.mockResolvedValue({ accessToken: null, refreshToken: null, expiresAt: null })
+    const db = fakeDb([[{ name: null }]])
+
+    await expect(
+      resolveSocialCounterpartName(db, { ...base, platform: 'facebook' })
+    ).resolves.toBeUndefined()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('swallows a credential read failure rather than surfacing it to the webhook', async () => {
+    getChannelTokens.mockRejectedValue(new Error('Channel int_1 not found'))
+    const db = fakeDb([[{ name: null }]])
+
+    await expect(
+      resolveSocialCounterpartName(db, { ...base, platform: 'facebook' })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/lib/src/providers/social/api.ts
+++ b/packages/lib/src/providers/social/api.ts
@@ -3,6 +3,7 @@
 import { configService } from '@auxx/credentials'
 import { createScopedLogger } from '@auxx/logger'
 import { AuxxError } from '../../errors'
+import type { SocialPlatform } from './types'
 
 const logger = createScopedLogger('social-graph-api')
 
@@ -331,6 +332,91 @@ export async function sendMessage(args: SendMessageArgs): Promise<{ messageId?: 
     }
   )
   return { messageId: result.message_id }
+}
+
+/**
+ * The subset of a Meta user-profile node this codebase reads.
+ *
+ * Every field is optional on purpose. A person who has restricted profile
+ * access — or simply never set a display name — is answered with a node that
+ * carries the id and nothing else, and that is a legitimate outcome, not an
+ * error. Callers build a label out of whatever came back and fall back to the
+ * raw PSID/IGSID when nothing did.
+ */
+export interface GraphUserProfile {
+  id?: string
+  /** Instagram: the account's display name. */
+  name?: string
+  /** Messenger: given name. */
+  first_name?: string
+  /** Messenger: family name. */
+  last_name?: string
+  /** Instagram: the `@handle`, without the `@`. */
+  username?: string
+  profile_pic?: string
+}
+
+/**
+ * Fields requested per platform.
+ *
+ * **These sets are deliberately narrow and platform-specific, and that is the
+ * whole risk in this call.** Graph rejects an entire request with error 100
+ * ("nonexisting field") when one requested field is not supported on the node,
+ * so asking for the union of both would fail on both. What is encoded here is
+ * what Meta documents for each surface:
+ *
+ * - Messenger's User Profile API on a PSID: `first_name`, `last_name`,
+ *   `profile_pic` (plus locale/timezone/gender, which we do not want). It has
+ *   NO `name` field.
+ * - Instagram's on an IGSID: `name`, `username`, `profile_pic`.
+ *
+ * Not live-verified against v26 on a real PSID at the time of writing, so the
+ * response side is handled defensively: absent fields are normal, and the whole
+ * call is non-throwing.
+ */
+const USER_PROFILE_FIELDS: Record<SocialPlatform, string> = {
+  facebook: 'first_name,last_name,profile_pic',
+  instagram: 'name,username,profile_pic',
+}
+
+/**
+ * `GET /{psid|igsid}` — the counterpart's public profile.
+ *
+ * **The one operation in this module that does not throw.** Every other op here
+ * surfaces a `GraphApiError` because its caller is doing something the user
+ * asked for and a failure has to be visible. This one runs on the ingest path
+ * for a *cosmetic* value: a display name instead of a raw id. Two entirely
+ * normal conditions — a person who restricted profile access, and a page whose
+ * token has since gone stale — would otherwise turn a delivered message into a
+ * failed webhook, and Meta retries a webhook that does not answer 200.
+ *
+ * Requires `pages_messaging` (Messenger) / `instagram_manage_messages` (IG),
+ * both already held by the connected page token.
+ *
+ * @returns the profile node, or `null` when Graph refused or answered nothing.
+ */
+export async function getUserProfile(args: {
+  platform: SocialPlatform
+  /** PSID (Messenger) or IGSID (Instagram Direct). */
+  userId: string
+  pageAccessToken: string
+}): Promise<GraphUserProfile | null> {
+  const { platform, userId, pageAccessToken } = args
+  try {
+    const profile = await graphRequest<GraphUserProfile>(userId, {
+      accessToken: pageAccessToken,
+      query: { fields: USER_PROFILE_FIELDS[platform] },
+    })
+    return profile ?? null
+  } catch (error) {
+    logger.warn('Could not read Meta user profile (ignored)', {
+      platform,
+      code: error instanceof GraphApiError ? error.code : undefined,
+      subcode: error instanceof GraphApiError ? error.subcode : undefined,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
 }
 
 export interface GraphConversation {

--- a/packages/lib/src/providers/social/profile.ts
+++ b/packages/lib/src/providers/social/profile.ts
@@ -1,0 +1,172 @@
+// packages/lib/src/providers/social/profile.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq } from 'drizzle-orm'
+import { identifierTypeForProvider } from '../../channels/capabilities'
+import { ParticipantService } from '../../participants/participant-service'
+import { getChannelTokens } from '../channel-token-accessor'
+import { type GraphUserProfile, getUserProfile } from './api'
+import type { SocialPlatform } from './types'
+
+const logger = createScopedLogger('social-profile')
+
+/**
+ * Build a display label out of whatever a Meta profile node actually carried.
+ *
+ * Deliberately tolerant of every field being absent: Messenger answers a PSID
+ * with `first_name`/`last_name` and Instagram answers an IGSID with
+ * `name`/`username`, but a person who restricted profile access is answered
+ * with neither — and that must read as "no name available", not as an error.
+ *
+ * @returns the label, or `undefined` when the node carried nothing usable — in
+ * which case the caller leaves the participant on its raw-id fallback.
+ */
+export function buildSocialDisplayName(
+  profile: GraphUserProfile | null | undefined
+): string | undefined {
+  if (!profile) return undefined
+
+  const fullName = profile.name?.trim()
+  if (fullName) return fullName
+
+  const parts = [profile.first_name?.trim(), profile.last_name?.trim()].filter(
+    (part): part is string => !!part
+  )
+  if (parts.length > 0) return parts.join(' ')
+
+  // Instagram's handle is a real, human-recognisable label — better than an
+  // IGSID — so it is the last resort before giving up.
+  return profile.username?.trim() || undefined
+}
+
+/**
+ * Does this participant already carry a name worth keeping?
+ *
+ * The raw id counts as "no name": some rows were written before this resolver
+ * existed with the PSID itself as the label, and treating those as named would
+ * make the id permanent.
+ */
+function hasResolvedName(name: string | null | undefined, identifier: string): boolean {
+  const trimmed = name?.trim()
+  return !!trimmed && trimmed !== identifier
+}
+
+/** The inbox whose lens channels a `participant:updated` event routes to. */
+async function resolveInboxId(db: Database, integrationId: string): Promise<string | null> {
+  const [link] = await db
+    .select({ inboxId: schema.InboxIntegration.inboxId })
+    .from(schema.InboxIntegration)
+    .where(eq(schema.InboxIntegration.integrationId, integrationId))
+    .limit(1)
+  return link?.inboxId ?? null
+}
+
+export interface ResolveSocialCounterpartNameArgs {
+  platform: SocialPlatform
+  organizationId: string
+  integrationId: string
+  /** The customer's PSID (Messenger) or IGSID (Instagram Direct). */
+  counterpartId: string
+  /** Skips the lookup when the caller already knows it. */
+  inboxId?: string | null
+}
+
+/**
+ * Give a Meta DM counterpart a human name.
+ *
+ * Meta's messaging webhook carries **only `sender.id`** — verified against a
+ * real captured payload — so every FB/IG thread renders a raw PSID until
+ * something asks Graph who that is. This is that something.
+ *
+ * Three properties matter, in this order:
+ *
+ * 1. **It never throws.** Ingest already stored the message by the time this
+ *    runs; a missing display name must never turn a delivered message into a
+ *    failed webhook (Meta retries those, and eventually disables the
+ *    subscription).
+ * 2. **It is cached by the data it writes.** One indexed point-lookup on
+ *    `(organizationId, identifier, identifierType)` decides whether to spend a
+ *    Graph call, so a busy thread costs exactly one profile fetch, ever — no
+ *    second cache layer to invalidate.
+ * 3. **It writes through the existing seam.** `findOrCreateParticipant` with a
+ *    `publish` context diffs the tracked name columns and emits
+ *    `participant:updated` on the inbox's lens channels, so open mail lists
+ *    flip from PSID to name with no refetch. Its upgrade-only name rule also
+ *    makes the write safe to repeat and impossible to downgrade.
+ *
+ * Call it AFTER the webhook has answered 200 (`after()` in the route handlers),
+ * never inline.
+ *
+ * @returns the name written, or `undefined` when nothing was written — already
+ * named, no token, restricted profile, or a Graph failure.
+ */
+export async function resolveSocialCounterpartName(
+  db: Database,
+  args: ResolveSocialCounterpartNameArgs
+): Promise<string | undefined> {
+  const { platform, organizationId, integrationId, counterpartId } = args
+
+  try {
+    const identifierType = identifierTypeForProvider(platform)
+    if (!identifierType) {
+      logger.warn('No identifier type for social platform; skipping name resolution', { platform })
+      return undefined
+    }
+
+    const [existing] = await db
+      .select({ name: schema.Participant.name })
+      .from(schema.Participant)
+      .where(
+        and(
+          eq(schema.Participant.organizationId, organizationId),
+          eq(schema.Participant.identifier, counterpartId),
+          eq(schema.Participant.identifierType, identifierType)
+        )
+      )
+      .limit(1)
+
+    if (existing && hasResolvedName(existing.name, counterpartId)) return undefined
+
+    const tokens = await getChannelTokens(integrationId)
+    if (!tokens.accessToken) {
+      logger.warn('No page access token; cannot resolve counterpart name', {
+        platform,
+        integrationId,
+      })
+      return undefined
+    }
+
+    const profile = await getUserProfile({
+      platform,
+      userId: counterpartId,
+      pageAccessToken: tokens.accessToken,
+    })
+    const name = buildSocialDisplayName(profile)
+    if (!name) {
+      // Entirely normal: restricted profile access, or a person with no name set.
+      logger.debug('Meta profile carried no usable name; keeping the id fallback', {
+        platform,
+        integrationId,
+      })
+      return undefined
+    }
+
+    const inboxId = args.inboxId ?? (await resolveInboxId(db, integrationId))
+    const participantService = new ParticipantService(organizationId, db)
+    await participantService.findOrCreateParticipant(
+      { identifier: counterpartId, identifierType, name },
+      { inboxId }
+    )
+
+    logger.info('Resolved Meta counterpart display name', { platform, integrationId })
+    return name
+  } catch (error) {
+    logger.warn('Counterpart name resolution failed (ignored)', {
+      platform,
+      integrationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return undefined
+  }
+}


### PR DESCRIPTION
Three follow-ups to #1711, all surfaced by actually running the Facebook DM smoke test rather than by reading code. Independent of each other; grouped because they are all small and all from the same session.

## WS13 — counterpart display name

Every FB/IG thread rendered a raw PSID (`27893553143563440`) as the contact name. Meta's messaging webhook carries **only `sender.id`** — verified against a real captured payload — so a name requires a second Graph call.

- `getUserProfile` joins the existing Graph seam (`social/api.ts`), token in the Authorization header like every other op.
- New `providers/social/profile.ts` orchestrates. One indexed lookup on `(organizationId, identifier, identifierType)` decides whether to spend the Graph call, so a busy thread costs **exactly one profile fetch, ever** — no second cache to invalidate. The raw id stored as a label does not count as named, so rows written before this get upgraded.
- Scheduled with `after()` **once the response is on the wire, never inline** — Meta retries a slow webhook and eventually disables the subscription. Deduped per counterpart per delivery, since Meta batches events into one POST.
- Writes through `findOrCreateParticipant` with a publish context, so `participant:updated` reaches the inbox lens channels and open mail lists flip from id to name **with no refetch**. Its upgrade-only name rule (`find-or-create.ts:212`) makes the write idempotent and impossible to downgrade.
- `webhook-message.ts` stays pure — it is the unit-testable wire converter and gains no network call. Nothing in the frontend changed; that half was already wired.

**Stated plainly: Graph v26 field availability is NOT live-verified.** Messenger documents `first_name`/`last_name` on a PSID; Instagram documents `name`/`username` on an IGSID. The field list is per-platform because Graph rejects the *entire* request with error 100 if one requested field is unsupported on the node. If v26 differs, the symptom is "names still absent" plus a `social-graph-api` warn log carrying Meta's code/subcode — never a broken ingest. Worth one live check after merge.

## WS14 — `isInternal` for our own Page

`own-identities.ts` returned nothing for `FACEBOOK_PSID`/`INSTAGRAM_IGSID`, on the documented premise that those id spaces *"always name the customer"*. #1697 broke that premise: ingest mints a page-side participant identified by the Page id, and #1711 makes the composer's outbound FROM the same id.

Result: our own Page classified as **external**, and `thread-query.service.ts:120` names a thread after its most recent *external* participant — so the thread list attributed every Meta conversation to **"Auxx-Lift"** instead of to the customer. Verified against the live dev DB.

- Adds the Meta arm: `metadata.pageId` for facebook, `metadata.instagramBusinessAccountId` for instagram.
- Read **per provider** rather than through `getIdentifier`, so it does not depend on that function's field precedence staying as it is. Mirrors the existing per-provider read at `social-provisioning-hook.ts:331`.
- **Exactly one id per channel is ours.** Both sides of a Meta DM live in one id space, so widening this to "any Meta id we have seen" would flip every customer to internal. A test pins that a customer PSID stays external.
- `CHAT_VISITOR` still contributes nothing — that premise *does* still hold, and the docstring now says why the two cases differ.
- The same stale claim in `classify-internal.ts`'s docstring is corrected (doc-only).

Other `isInternal` consumers were audited; none break, and several get more correct — interaction stamping stops treating our Page as a correspondent, `contacts/find-or-create` stops auto-creating a Contact for it, and `derive-message-signals` stops deriving `message:replied` from our own sends.

## WS12 — Graph version was dead config

`config-registry.ts` still defaulted `FACEBOOK_GRAPH_API_VERSION` to `v19.0`. `configService.get` returns the registry default when the env var is absent (`config-service.ts:153`), so it resolved **before** every `|| DEFAULT_*_API_VERSION` fallback — making all four `v26.0` constants in `social/api.ts`, both `-oauth.ts` files and `social-provisioning-hook.ts` unreachable. Any environment without an explicit env var was still on a deprecated version.

Also bumps `facebook-provider.ts:28` and `instagram-provider.ts:28`, which #1698 missed. Confirmed no `AppSetting` override row exists that would outrank the new default.

## Testing

- `packages/lib`: **648 tests / 63 files pass** (`src/providers/social`, `src/channels`, `src/participants`, `src/ingest`, `src/messages`, `src/threads`)
- 16 new tests for the profile resolver: FB resolve, IG resolve, Graph refusal returning `undefined` without throwing, no-usable-name keeping the id fallback, skip-when-already-named (asserts zero fetch *and* zero token read), raw-id-is-not-a-name, no-token skip, credential-read rejection swallowed
- New/extended tests for the Meta own-identity arm, including the customer-stays-external guard and `getOrgOwnEmailAddresses` still returning only emails
- Typecheck clean under `src/` in `packages/lib` and `packages/credentials`; `apps/web` clean for the touched routes
- `generate-exports.ts --check` passes — the new `./providers/social/profile` subpath was generated, not hand-edited

## Follow-up not in this PR

`ThreadParticipant` rollup rows do **not** self-heal. `Participant.isInternal` is last-writer-wins so it corrects on the next message, but the rollup only updates on threads receiving new traffic, and that is what the sender expression reads. Existing quiet threads keep the wrong attribution until a new message arrives. No migration written — one more test DM fixes the dev thread.

Refs: `plans/channels/facebook-instagram-runtime-fixes.md` (WS12, WS13, WS14)