### PR TITLE
fix(ingest): stop freezing threadparticipant.isinternal at its first write

### DIFF
--- a/packages/lib/src/ingest/__tests__/store-message-thread-participant-rollup.test.ts
+++ b/packages/lib/src/ingest/__tests__/store-message-thread-participant-rollup.test.ts
@@ -1,0 +1,220 @@
+// packages/lib/src/ingest/__tests__/store-message-thread-participant-rollup.test.ts
+//
+// The `ThreadParticipant` rollup's ON CONFLICT clause. `isInternal` must be in
+// it, unconditionally.
+//
+// This exact omission has now happened on two tables. `Participant` had it and
+// it was fixed (`participants/find-or-create.ts`: "Omitting it here … froze the
+// column at its first write"); the rollup kept it. The flag is derived from org
+// configuration — connected channels, org domains — never from message content,
+// so every recomputation is at least as good as the last and there is no reason
+// to preserve an older one.
+//
+// The cost of freezing it is not academic: `buildSenderSortExpression`
+// (`threads/thread-query.service.ts`) names a thread after its most recent
+// EXTERNAL participant and reads THIS table. When the org's own Meta Page only
+// became recognisable later — once the own-identity sets learned Page ids — its
+// rollup row stayed `isInternal: false` and every Facebook/Instagram thread went
+// on attributing itself to us instead of to the customer. New traffic did not
+// heal it, because new traffic takes the conflict branch.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  /** Every `onConflictDoUpdate` config, keyed by table. */
+  conflictConfigs: [] as Array<{ table: string; config: any }>,
+  participant: {
+    id: 'p_1',
+    identifier: '27893553143563440',
+    name: 'Markus Klooth',
+    entityInstanceId: null,
+    isInternal: false,
+  },
+  threadRow: {} as Record<string, unknown>,
+}))
+
+vi.mock('../../cache', () => ({ getOrgCache: () => ({ get: async () => [] }) }))
+vi.mock('../../realtime', () => ({
+  getRealtimeService: () => ({}),
+  publishThreadCreated: vi.fn(),
+  publishThreadUpdated: vi.fn(),
+  publishMessageCreated: vi.fn(),
+}))
+vi.mock('../../threads/mail-counts', () => ({ applyMailCountDeltas: vi.fn() }))
+vi.mock('../../entity-instances/activity', () => ({
+  touchActivityForThreadLinks: vi.fn(),
+  resolveThreadLinkedEntityIds: vi.fn(async () => []),
+  touchEntityActivity: vi.fn(),
+  touchInteractionForMessage: vi.fn(),
+}))
+vi.mock('../../events/publisher', () => ({ publisher: { publishLater: vi.fn() } }))
+vi.mock('../../permissions/visibility/audience', () => ({
+  getFullLensAudienceForInbox: async () => [],
+}))
+vi.mock('../inbox-meta', () => ({ isPersonalInbox: async () => false }))
+vi.mock('../../inbox-record-ids', () => ({ toInboxRecordId: async () => 'inbox:i_1' }))
+vi.mock('../filtering/machine-mail', () => ({ detectMachineMail: () => null }))
+vi.mock('../filtering/should-ignore', () => ({ shouldIgnoreMessage: () => false }))
+vi.mock('../filtering/store-ignored', () => ({ storeIgnoredMessage: vi.fn() }))
+vi.mock('../reconciliation/extract-internet-message-id', () => ({
+  extractInternetMessageId: () => null,
+}))
+vi.mock('../reconciliation/reconcile-message', () => ({ reconcileMessage: async () => null }))
+vi.mock('../threads/update-metadata', () => ({ updateThreadMetadataEfficient: vi.fn() }))
+vi.mock('../participants/normalize', () => ({
+  determineIdentifierType: async () => 'FACEBOOK_PSID',
+  normalizeIdentifier: (v: string) => v,
+}))
+vi.mock('../participants/find-or-create', () => ({
+  findOrCreateParticipantRecord: async () => h.participant,
+}))
+
+vi.mock('@auxx/database', () => ({
+  schema: new Proxy(
+    {},
+    { get: (_t, table) => new Proxy({}, { get: (_t2, col) => `${String(table)}.${String(col)}` }) }
+  ),
+}))
+
+vi.mock('drizzle-orm', () => {
+  const passthrough = (...a: unknown[]) => a
+  return {
+    and: passthrough,
+    eq: passthrough,
+    isNull: passthrough,
+    sql: Object.assign(passthrough, { raw: passthrough }),
+  }
+})
+
+import { storeMessage } from '../store-message'
+
+const ORG = 'org_1'
+const SENT_AT = new Date('2026-08-18T19:47:02.000Z')
+
+function emptyChain(): any {
+  const obj: any = new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        if (prop === 'then') return (res: (v: unknown[]) => unknown) => Promise.resolve(res([]))
+        return () => obj
+      },
+    }
+  )
+  return obj
+}
+
+function tx() {
+  const returningFor = (table: string) => {
+    if (table.startsWith('Thread')) return [h.threadRow]
+    if (table.startsWith('Message')) return [{ id: 'm_1' }]
+    return []
+  }
+  const chainFor = (table: string): any => {
+    const obj: any = new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          if (prop === 'onConflictDoUpdate') {
+            return (config: any) => {
+              h.conflictConfigs.push({ table, config })
+              return obj
+            }
+          }
+          if (prop === 'returning') return async () => returningFor(table)
+          if (prop === 'then') return (res: (v: unknown[]) => unknown) => Promise.resolve(res([]))
+          return () => obj
+        },
+      }
+    )
+    return obj
+  }
+  const tableName = (t: unknown) => String((t as any)?.id ?? '').split('.')[0] ?? ''
+  return {
+    insert: (t: unknown) => chainFor(tableName(t)),
+    update: (t: unknown) => chainFor(tableName(t)),
+  }
+}
+
+function ctx() {
+  return {
+    organizationId: ORG,
+    db: {
+      select: () => emptyChain(),
+      update: () => emptyChain(),
+      transaction: async (cb: (t: unknown) => Promise<unknown>) => cb(tx()),
+      query: { SequenceRun: { findFirst: async () => null } },
+    },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    systemUserId: 'sys',
+    crudHandler: {},
+    reconciler: {},
+    threadManager: {},
+    selectiveCache: {},
+    isInitialSync: false,
+    ownIdentities: {},
+    ownIdentitiesByOrg: new Map(),
+    inSyncBatch: false,
+    touchedInboxIds: new Set<string | null>(),
+    companyIdByDomain: new Map(),
+    ownDomainsByOrg: new Map(),
+    providerByIntegrationId: new Map(),
+  } as any
+}
+
+function messageData() {
+  return {
+    organizationId: ORG,
+    integrationId: 'int_facebook',
+    externalId: 'm_abc',
+    externalThreadId: 'dm:869289333164075:27893553143563440',
+    inboxId: 'i_shared',
+    subject: '',
+    isInbound: true,
+    sentAt: SENT_AT,
+    receivedAt: SENT_AT,
+    createdTime: SENT_AT,
+    hasAttachments: false,
+    from: { identifier: '27893553143563440' },
+    to: [{ identifier: '869289333164075', name: 'Auxx-Lift' }],
+  } as any
+}
+
+beforeEach(() => {
+  h.conflictConfigs = []
+  h.threadRow = {
+    id: 't_1',
+    inboxId: 'i_shared',
+    status: 'OPEN',
+    assigneeId: null,
+    messageCount: 1,
+    firstMessageAt: SENT_AT,
+    lastMessageAt: SENT_AT,
+    participantCount: 1,
+  }
+})
+
+describe('storeMessage — ThreadParticipant rollup conflict clause', () => {
+  const rollupSet = () =>
+    h.conflictConfigs.find((c) => c.table === 'ThreadParticipant')?.config?.set
+
+  it('recomputes isInternal on every upsert instead of freezing the first write', async () => {
+    await storeMessage(ctx(), messageData())
+
+    const set = rollupSet()
+    expect(set).toBeDefined()
+    expect(Object.keys(set)).toContain('isInternal')
+  })
+
+  it('still keeps the existing name when a later message carries none', async () => {
+    // `name` is deliberately upgrade-only (COALESCE), the opposite rule to
+    // `isInternal` — a nameless message must not blank a resolved name. Pinned
+    // here so a future "make the rollup consistent" pass cannot flatten the two
+    // into one policy.
+    await storeMessage(ctx(), messageData())
+
+    const set = rollupSet()
+    expect(Object.keys(set)).toContain('name')
+    expect(Object.keys(set)).toContain('entityInstanceId')
+  })
+})

--- a/packages/lib/src/ingest/store-message.ts
+++ b/packages/lib/src/ingest/store-message.ts
@@ -736,6 +736,31 @@ export async function storeMessage(
               // Prefer a freshly resolved contact link / name; keep the old one otherwise.
               entityInstanceId: sql`COALESCE(excluded."entityInstanceId", ${schema.ThreadParticipant.entityInstanceId})`,
               name: sql`COALESCE(excluded."name", ${schema.ThreadParticipant.name})`,
+              // Unconditional last-writer-wins, unlike `name` above — the same rule
+              // `Participant.isInternal` follows, and for the same reason: it is derived
+              // from org configuration (connected channels, org domains), never from
+              // message content, so every recomputation is at least as good as the last.
+              //
+              // Omitting it froze the column at its first write. That is not academic:
+              // `buildSenderSortExpression` names a thread after its most recent
+              // *external* participant and reads THIS table, so a channel identity that
+              // only became recognisable later — our own Meta Page, once the own-identity
+              // arm learned Page ids — stayed `false` forever and every Meta thread went
+              // on attributing itself to us instead of to the customer. New traffic did
+              // not heal it, because new traffic took this branch.
+              isInternal: sql`excluded."isInternal"`,
+              // Unconditional last-writer-wins, unlike `name` above — the same rule
+              // `Participant.isInternal` follows, and for the same reason: it is derived
+              // from org configuration (connected channels, org domains), never from
+              // message content, so every recomputation is at least as good as the last.
+              //
+              // Omitting it froze the column at its first write. That is not academic:
+              // `buildSenderSortExpression` names a thread after its most recent
+              // *external* participant and reads THIS table, so a channel identity that
+              // only became recognisable later — our own Meta Page, once the own-identity
+              // arm learned Page ids — stayed `false` forever and every Meta thread went
+              // on attributing itself to us instead of to the customer. New traffic did
+              // not heal it, because new traffic took this branch.
             },
           })
       }


### PR DESCRIPTION
Found by testing #1713 live rather than by reading code.

## The bug

`store-message.ts`'s `ThreadParticipant` rollup upsert updates `messageCount`, `firstMessageAt`, `lastMessageAt`, `entityInstanceId` and `name` on conflict — **but not `isInternal`**. On an existing row that flag is therefore write-once, and no amount of new traffic corrects it: new traffic is exactly what takes the conflict branch.

This is the **same omission already found and fixed on `Participant`** (`participants/find-or-create.ts`, whose comment reads *"Omitting it here … froze the column at its first write"*), surviving on the second table. `isInternal` is derived from org configuration — connected channels, org domains — never from message content, so every recomputation is at least as good as the last and there is no reason to preserve an older one.

## How it showed up

After #1713 taught the own-identity sets about Meta Page ids, our own Page's `Participant.isInternal` correctly flipped to `true` on the very next message — while its `ThreadParticipant` row stayed `false`:

```
Participant       869289333164075  Auxx-Lift  isInternal = true    ← correct after #1713
ThreadParticipant 869289333164075  Auxx-Lift  isInternal = false   ← frozen
```

`buildSenderSortExpression` (`threads/thread-query.service.ts`) names a thread after its most recent **external** participant and reads the rollup, so every Facebook/Instagram thread kept attributing itself to us instead of to the customer. #1713's fix was real but could not reach the surface that consumes it.

Worth noting the rollup *did* update on that message — `messageCount` incremented and the newly resolved name "Markus Klooth" propagated. Only `isInternal` was excluded, which is what made this look like it had healed when it hadn't.

## The fix

Add `isInternal: sql\`excluded.\"isInternal\"\`` to the conflict set, with a comment explaining why it is unconditional and what freezing it costs.

`name` deliberately keeps its **opposite** rule — upgrade-only `COALESCE`, so a nameless message cannot blank a resolved name. The new test pins **both** policies, so a future "make the rollup consistent" pass cannot flatten them into one.

## Testing

- New `store-message-thread-participant-rollup.test.ts` (2 tests). **Verified to fail without the fix** — I removed the line, watched the assertion fail, and restored it.
- `src/ingest src/threads src/channels src/participants src/providers/social`: **575 tests / 56 files pass**
- Typecheck clean under `src/`; biome clean

## Existing rows

Not backfilled. New rows are correct immediately, and any thread receiving traffic self-corrects from this commit on — which is what the fix restores. A stale row only persists on a thread that never gets another message; not worth a migration unless it shows up on a real account.

Refs: `plans/channels/facebook-instagram-runtime-fixes.md` (WS14)