### PR TITLE
fix(workflow): strip braces from agent-written picker-bound field refs

### DIFF
--- a/packages/lib/src/workflow-engine/catalog/nodes/chunker.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/chunker.ts
@@ -6,7 +6,7 @@ import type { UnifiedVariable } from '../../types/unified-variable'
 import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
 import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
 import { createNestedVariable } from '../variable-conversion'
-import { extractVarIdsFromString, isNodeVariable, isVariableMode } from '../variable-inference'
+import { extractFieldVariableIds, isVariableMode } from '../variable-inference'
 
 /**
  * The chunker node's catalog manifest.
@@ -127,20 +127,12 @@ export function extractChunkerVariables(data: Partial<ChunkerNodeData>): string[
 
   // Extract from content
   if (data.content && isVariableMode(fieldModes, 'content')) {
-    if (isNodeVariable(data.content)) {
-      variableIds.add(data.content)
-    } else {
-      extractVarIdsFromString(data.content).forEach((id) => variableIds.add(id))
-    }
+    extractFieldVariableIds(data.content).forEach((id) => variableIds.add(id))
   }
 
   // Extract from delimiter
   if (data.delimiter && isVariableMode(fieldModes, 'delimiter')) {
-    if (isNodeVariable(data.delimiter)) {
-      variableIds.add(data.delimiter)
-    } else {
-      extractVarIdsFromString(data.delimiter).forEach((id) => variableIds.add(id))
-    }
+    extractFieldVariableIds(data.delimiter).forEach((id) => variableIds.add(id))
   }
 
   // Extract from the numeric/boolean settings — each holds a reference string
@@ -152,8 +144,8 @@ export function extractChunkerVariables(data: Partial<ChunkerNodeData>): string[
     'removeUrlsAndEmails',
   ] as const) {
     const value = data[field]
-    if (typeof value === 'string' && isVariableMode(fieldModes, field) && isNodeVariable(value)) {
-      variableIds.add(value)
+    if (isVariableMode(fieldModes, field)) {
+      extractFieldVariableIds(value).forEach((id) => variableIds.add(id))
     }
   }
 

--- a/packages/lib/src/workflow-engine/catalog/nodes/crud.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/crud.ts
@@ -14,7 +14,7 @@ import {
   type NodeManifest,
   type NodeValidationResult,
 } from '../types'
-import { extractVarIdsFromString, isNodeVariable } from '../variable-inference'
+import { extractFieldVariableIds, extractVarIdsFromString } from '../variable-inference'
 
 /**
  * The crud node's catalog manifest — resource-backed like find, plus a
@@ -226,9 +226,7 @@ export function extractCrudVariables(data: Partial<CrudNodeData>): string[] {
   const variableIds = new Set<string>()
 
   // Extract from resourceId (for update/delete operations)
-  if (isNodeVariable(data.resourceId)) {
-    variableIds.add(data.resourceId!)
-  }
+  extractFieldVariableIds(data.resourceId).forEach((id) => variableIds.add(id))
 
   // Extract from field values (for create/update operations)
   if (data.data) {

--- a/packages/lib/src/workflow-engine/catalog/nodes/dataset.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/dataset.ts
@@ -8,7 +8,11 @@ import type { UnifiedVariable } from '../../types/unified-variable'
 import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
 import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
 import { createNestedVariable } from '../variable-conversion'
-import { extractVarIdsFromString, isNodeVariable, isVariableMode } from '../variable-inference'
+import {
+  extractFieldVariableIds,
+  extractVarIdsFromString,
+  isVariableMode,
+} from '../variable-inference'
 
 /**
  * The dataset node's catalog manifest.
@@ -149,20 +153,12 @@ export function extractDatasetVariables(data: Partial<DatasetNodeData>): string[
 
   // Extract from datasetId (if in variable mode)
   if (data.datasetId && isVariableMode(fieldModes, 'datasetId')) {
-    if (isNodeVariable(data.datasetId)) {
-      variableIds.add(data.datasetId)
-    } else {
-      extractVarIdsFromString(data.datasetId).forEach((id) => variableIds.add(id))
-    }
+    extractFieldVariableIds(data.datasetId).forEach((id) => variableIds.add(id))
   }
 
   // Extract from chunks (typically a variable reference like "chunker.chunks")
   if (data.chunks) {
-    if (isNodeVariable(data.chunks)) {
-      variableIds.add(data.chunks)
-    } else {
-      extractVarIdsFromString(data.chunks).forEach((id) => variableIds.add(id))
-    }
+    extractFieldVariableIds(data.chunks).forEach((id) => variableIds.add(id))
   }
 
   // Extract from documentTitle (if in variable mode)
@@ -177,9 +173,7 @@ export function extractDatasetVariables(data: Partial<DatasetNodeData>): string[
 
   // Extract from fileId (if in variable mode)
   if (data.fileId && isVariableMode(fieldModes, 'fileId')) {
-    if (isNodeVariable(data.fileId)) {
-      variableIds.add(data.fileId)
-    }
+    extractFieldVariableIds(data.fileId).forEach((id) => variableIds.add(id))
   }
 
   // Extract from the processing options bound to a variable — the two boolean
@@ -187,8 +181,8 @@ export function extractDatasetVariables(data: Partial<DatasetNodeData>): string[
   // mode
   for (const field of ['skipEmbedding', 'waitForEmbeddings', 'embeddingTimeoutMinutes'] as const) {
     const value = data[field]
-    if (typeof value === 'string' && isVariableMode(fieldModes, field) && isNodeVariable(value)) {
-      variableIds.add(value)
+    if (isVariableMode(fieldModes, field)) {
+      extractFieldVariableIds(value).forEach((id) => variableIds.add(id))
     }
   }
 

--- a/packages/lib/src/workflow-engine/catalog/nodes/document-extractor.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/document-extractor.ts
@@ -6,7 +6,7 @@ import type { UnifiedVariable } from '../../types/unified-variable'
 import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
 import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
 import { createNestedVariable } from '../variable-conversion'
-import { extractVarIdsFromString, isNodeVariable, isVariableMode } from '../variable-inference'
+import { extractFieldVariableIds, isVariableMode } from '../variable-inference'
 
 /**
  * The document-extractor node's catalog manifest.
@@ -125,36 +125,28 @@ export function extractDocumentExtractorVariables(
 
   // Extract from fileId (for file source type)
   if (data.sourceType === DocumentSourceType.FILE && data.fileId) {
-    if (isVariableMode(fieldModes, 'fileId') && isNodeVariable(data.fileId)) {
-      variableIds.add(data.fileId)
+    if (isVariableMode(fieldModes, 'fileId')) {
+      extractFieldVariableIds(data.fileId).forEach((id) => variableIds.add(id))
     }
   }
 
   // Extract from url (for URL source type — may contain variable references)
   if (data.sourceType === DocumentSourceType.URL && data.url) {
     if (isVariableMode(fieldModes, 'url')) {
-      if (isNodeVariable(data.url)) {
-        variableIds.add(data.url)
-      } else {
-        extractVarIdsFromString(data.url).forEach((id) => variableIds.add(id))
-      }
+      extractFieldVariableIds(data.url).forEach((id) => variableIds.add(id))
     }
   }
 
   // Extract from language (string field that could contain variables)
   if (data.language && isVariableMode(fieldModes, 'language')) {
-    if (isNodeVariable(data.language)) {
-      variableIds.add(data.language)
-    } else {
-      extractVarIdsFromString(data.language).forEach((id) => variableIds.add(id))
-    }
+    extractFieldVariableIds(data.language).forEach((id) => variableIds.add(id))
   }
 
   // Extract from the extraction toggles bound to a variable
   for (const field of ['preserveFormatting', 'extractImages'] as const) {
     const value = data[field]
-    if (typeof value === 'string' && isVariableMode(fieldModes, field) && isNodeVariable(value)) {
-      variableIds.add(value)
+    if (isVariableMode(fieldModes, field)) {
+      extractFieldVariableIds(value).forEach((id) => variableIds.add(id))
     }
   }
 

--- a/packages/lib/src/workflow-engine/catalog/nodes/knowledge-retrieval.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/knowledge-retrieval.ts
@@ -6,7 +6,7 @@ import type { UnifiedVariable } from '../../types/unified-variable'
 import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
 import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
 import { createNestedVariable } from '../variable-conversion'
-import { extractVarIdsFromString, isNodeVariable, isVariableMode } from '../variable-inference'
+import { extractFieldVariableIds, isVariableMode } from '../variable-inference'
 
 /**
  * The knowledge-retrieval node's catalog manifest.
@@ -186,11 +186,7 @@ export function extractKnowledgeRetrievalVariables(
 
   // Extract from query (if in variable mode)
   if (data.query && isVariableMode(fieldModes, 'query')) {
-    if (isNodeVariable(data.query)) {
-      variableIds.add(data.query)
-    } else {
-      extractVarIdsFromString(data.query).forEach((id) => variableIds.add(id))
-    }
+    extractFieldVariableIds(data.query).forEach((id) => variableIds.add(id))
   }
 
   // Extract from sources (each row's id can be a variable)
@@ -198,38 +194,24 @@ export function extractKnowledgeRetrievalVariables(
     data.sources.forEach((row, index) => {
       const rawId = sourceRawId(row)
       if (rawId && isVariableMode(fieldModes, sourceFieldKey(row, index))) {
-        if (isNodeVariable(rawId)) {
-          variableIds.add(rawId)
-        } else {
-          extractVarIdsFromString(rawId).forEach((id) => variableIds.add(id))
-        }
+        extractFieldVariableIds(rawId).forEach((id) => variableIds.add(id))
       }
     })
   }
 
   // Extract from searchType (if in variable mode)
-  if (
-    data.searchType &&
-    isVariableMode(fieldModes, 'searchType') &&
-    isNodeVariable(data.searchType)
-  ) {
-    variableIds.add(data.searchType)
+  if (data.searchType && isVariableMode(fieldModes, 'searchType')) {
+    extractFieldVariableIds(data.searchType).forEach((id) => variableIds.add(id))
   }
 
   // Extract from limit (if in variable mode)
   if (data.limit !== undefined && isVariableMode(fieldModes, 'limit')) {
-    const limitStr = String(data.limit)
-    if (isNodeVariable(limitStr)) {
-      variableIds.add(limitStr)
-    }
+    extractFieldVariableIds(String(data.limit)).forEach((id) => variableIds.add(id))
   }
 
   // Extract from similarityThreshold (if in variable mode)
   if (data.similarityThreshold !== undefined && isVariableMode(fieldModes, 'similarityThreshold')) {
-    const thresholdStr = String(data.similarityThreshold)
-    if (isNodeVariable(thresholdStr)) {
-      variableIds.add(thresholdStr)
-    }
+    extractFieldVariableIds(String(data.similarityThreshold)).forEach((id) => variableIds.add(id))
   }
 
   return Array.from(variableIds)

--- a/packages/lib/src/workflow-engine/catalog/variable-inference.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/variable-inference.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, it } from 'vitest'
 import {
+  extractFieldVariableIds,
   parseArraySegmentsFromId,
   parseVariablePath,
   setSegmentAccessor,
@@ -179,5 +180,44 @@ describe('setSegmentAccessor', () => {
     // rewriting there would corrupt the key into "find_1.ord[0]ers".
     expect(setSegmentAccessor('find_1.orders[*]', 'find_1.ord', '0')).toBe('find_1.orders[*]')
     expect(setSegmentAccessor('find_1.orders[*]', 'other.path', '0')).toBe('find_1.orders[*]')
+  })
+})
+
+/**
+ * The two shapes a picker-bound field can hold. The canvas writes bare ids;
+ * `update_node` patches write the braced form. `isNodeVariable` accepts both
+ * (it only tests for a dot), which is why callers must go through this helper
+ * rather than trusting it — see plan-17 §9.1.
+ */
+describe('extractFieldVariableIds', () => {
+  it('returns the bare picker-written id as-is', () => {
+    expect(extractFieldVariableIds('find1.count')).toEqual(['find1.count'])
+  })
+
+  it('strips the braces off an agent-written ref', () => {
+    expect(extractFieldVariableIds('{{find1.count}}')).toEqual(['find1.count'])
+  })
+
+  it('handles a node id containing a colon (app blocks)', () => {
+    expect(extractFieldVariableIds('{{appid:fedex-abc.trackingNumber}}')).toEqual([
+      'appid:fedex-abc.trackingNumber',
+    ])
+  })
+
+  it('returns every ref embedded in a mixed string', () => {
+    expect(extractFieldVariableIds('id-{{a.b}}-and-{{c.d}}')).toEqual(['a.b', 'c.d'])
+  })
+
+  it('ignores plain text, non-strings and dotless values', () => {
+    expect(extractFieldVariableIds('just text')).toEqual([])
+    expect(extractFieldVariableIds('nodot')).toEqual([])
+    expect(extractFieldVariableIds(undefined)).toEqual([])
+    expect(extractFieldVariableIds(42)).toEqual([])
+    expect(extractFieldVariableIds('')).toEqual([])
+  })
+
+  it('skips env/sys refs in the bare form, matching isNodeVariable', () => {
+    expect(extractFieldVariableIds('env.THRESHOLD')).toEqual([])
+    expect(extractFieldVariableIds('sys.userId')).toEqual([])
   })
 })

--- a/packages/lib/src/workflow-engine/catalog/variable-inference.ts
+++ b/packages/lib/src/workflow-engine/catalog/variable-inference.ts
@@ -372,6 +372,26 @@ export function isNodeVariable(variableId: string | undefined): boolean {
 }
 
 /**
+ * Every ref one picker-bound field contributes, whichever shape it holds.
+ *
+ * A canvas-bound field stores a BARE `nodeId.path`; anything written as text —
+ * which is what the agent's `update_node` patches produce — stores the braced
+ * `{{nodeId.path}}` form, possibly several inside one string.
+ * {@link isNodeVariable} only tests for a dot, so a braced value passes it too
+ * and every caller that trusted it recorded the ref verbatim, braces and all.
+ * `ref-check` then reads `{{nodeId` as the node name and reports a perfectly
+ * valid reference as "points at unknown node", with a did-you-mean that is the
+ * same id un-braced — an error the agent cannot act on. Route braced values
+ * through {@link extractVarIdsFromString} first, and the bare form still wins
+ * the fast path.
+ */
+export function extractFieldVariableIds(value: unknown): string[] {
+  if (typeof value !== 'string' || !value) return []
+  if (containsVariableReference(value)) return extractVarIdsFromString(value)
+  return isNodeVariable(value) ? [value] : []
+}
+
+/**
  * Check if a field is in variable mode (not constant mode)
  * fieldModes[field] === true means constant mode
  * fieldModes[field] === false or undefined means variable mode

--- a/packages/lib/src/workflows/graph-edit/__tests__/ref-check.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/ref-check.test.ts
@@ -200,3 +200,62 @@ describe('checkVariableRefsAgainstOutputs', () => {
     expect(issues).toEqual([])
   })
 })
+
+/**
+ * Live regression from plan-17 §9.1: a `{{ref}}` the AGENT wrote into a
+ * picker-bound field.
+ *
+ * The canvas writes those fields bare (`nodeId.path`); `update_node` patches
+ * write the braced `{{nodeId.path}}` form. `isNodeVariable` only tests for a
+ * dot, so every extractor that trusted it recorded the braced string verbatim
+ * — and ref-check then read `{{nodeId` as the node name. In dev that turned a
+ * perfectly valid `{{FedEx.trackingNumber}}` on a crud `resourceId` into
+ * `points at unknown node "{{z3prn…:fedex-DmJu…"`, suggesting the same id
+ * un-braced: an error the agent could not act on, and one that hid the real
+ * path error underneath it.
+ */
+describe('braced refs in picker-bound fields (crud.resourceId)', () => {
+  const crudConsumer = (resourceId: string): NodeMeta => ({
+    id: CONSUMER,
+    type: 'standard',
+    data: {
+      id: CONSUMER,
+      type: 'crud',
+      title: 'Update Record',
+      mode: 'update',
+      resourceType: 'contact',
+      resourceId,
+      data: {},
+    },
+  })
+
+  const checkResourceId = (resourceId: string) =>
+    checkVariableRefsAgainstOutputs({
+      graph: graphWith(crudConsumer(resourceId)),
+      outputs: new Map([[FIND, FIND_OUTPUTS]]),
+      lookup: coreLookup,
+    })
+
+  it('accepts a valid braced ref instead of calling the node unknown', () => {
+    expect(checkResourceId(`{{${FIND}.count}}`).issues).toEqual([])
+  })
+
+  it('still accepts the bare picker-written form', () => {
+    expect(checkResourceId(`${FIND}.count`).issues).toEqual([])
+  })
+
+  it('reports the PATH error with candidates, not a bogus unknown-node error', () => {
+    const { issues } = checkResourceId(`{{${FIND}.${TICKET_ID}.emial}}`)
+    expect(issues).toHaveLength(1)
+    expect(issues[0]!.message).not.toContain('unknown node')
+    expect(issues[0]!.message).toContain('No output "emial" on node Find Contact')
+    expect(issues[0]!.suggestion).toBe(`${FIND}.${TICKET_ID}.email`)
+  })
+
+  it('never emits a doubly-braced message for a genuinely unknown node', () => {
+    const { issues } = checkResourceId('{{ghostaaaaaaaaaaaaaaaa.id}}')
+    expect(issues).toHaveLength(1)
+    expect(issues[0]!.message).toContain('points at unknown node "ghostaaaaaaaaaaaaaaaa"')
+    expect(issues[0]!.message).not.toContain('{{{{')
+  })
+})


### PR DESCRIPTION
Found running **plan-17 §9.1** live in dev against the "Fedex Shipment" workflow (`plans/kopilot/workflow/17-app-block-authoring-and-connections.md`). Not a Phase-A/B regression — a pre-existing bug that §9.1 items 3 and 4 walked straight into.

## What happened

Kopilot's `update_node` set `crud.resourceId` to `{{FedEx.trackingNumber}}` — a valid reference to a real, resolved output — and ref-check answered:

```
Reference "{{{{z3prn…:fedex-DmJu….trackingNumber}}}}" points at unknown node
"{{z3prn…:fedex-DmJu…". Did you mean "z3prn…:fedex-DmJu…"?
```

Note the `{{{{`, the `{{` glued to the node id, and a did-you-mean identical to what it just called unknown. The agent read that, could not act on it, and gave up: *"the FedEx output path being used is resolving as an unknown node reference"*.

## Why

A picker-bound field has two shapes:

| written by | shape |
|---|---|
| the canvas picker | bare `nodeId.path` |
| an `update_node` patch (text) | `{{nodeId.path}}` |

`isNodeVariable` only tests for a dot, so the braced string passes it too and every extractor that trusted it recorded the ref **verbatim, braces included**. `ref-check.ts:218` then takes `firstPathSegment` of that and reads `{{nodeId` as the node name.

`extractCrudVariables` was the worst case — it had no `extractVarIdsFromString` fallback at all (`crud.ts:229-231`), so `resourceId` could *only* produce the broken form. Its sibling `data` values went through `extractVarIdsFromString` and were fine, which is exactly why `{{UPS.trackingNumber}}` in the same node validated cleanly while `resourceId` did not.

Two consequences, both bad: a **false positive on a valid reference**, and the real path error (`record.id` is not an output of FedEx) is **never reported**, because the unknown-node check short-circuits first.

## The fix

`extractFieldVariableIds(value)` in `catalog/variable-inference.ts` handles both shapes plus several refs in one string; the bare form keeps the fast path. Applied at every `isNodeVariable`-guarded extraction site: crud, chunker, dataset, document-extractor, knowledge-retrieval.

**`isNodeVariable` itself is deliberately unchanged.** `apps/web` re-exports it through `workflow-engine/client`, and four canvas `node.tsx` components use it to decide whether a field renders as a variable chip. Narrowing it there is a display change this fix has no reason to make.

**Free-text fields keep plain `extractVarIdsFromString`** — `dataset.documentTitle`, `dataset.sourceUrl`, crud's `data` values. A bare dotted literal like `report.pdf` is not a reference in those.

## Tests

- `variable-inference.test.ts` — 7 cases on the helper: bare, braced, colon-containing node id (app blocks), mixed string, plain text, non-string, env/sys.
- `ref-check.test.ts` — a new describe driving a real `crud` node end to end: a valid braced ref produces **no** issue; a typo'd one produces the **path** error with candidates instead of a bogus unknown-node error; a genuinely unknown node still reports, without `{{{{`.

Reverting the helper to its pre-fix behaviour fails 6 of these; restoring it passes all 40.

## Verification

- `packages/lib` — `vitest run src/workflows/graph-edit src/workflow-engine` → **83 files, 1450 tests passing**
- `node scripts/ci/typecheck-ratchet.js --package lib` → no new type errors (29 total, baseline 29)
- `biome check --write` on both touched dirs