### PR TITLE
feat(workflow): let kopilot discover and describe app blocks

### DIFF
--- a/packages/lib/src/ai/kopilot/capabilities/__tests__/tool-permission-declarations.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/__tests__/tool-permission-declarations.test.ts
@@ -94,6 +94,7 @@ const IDEMPOTENT_READ_TOOLS = [
   'describe_node_type',
   'find_threads',
   'find_workflow_templates',
+  'list_app_blocks',
   'get_article',
   'get_article_section',
   'get_entity',
@@ -224,11 +225,16 @@ const NO_AUTHORIZATION_REQUIRED: readonly string[] = [
   'assign_variable',
   'suggest_replies',
   'search_docs',
-  // workflow.builder discovery — static product data (the node-type registry
-  // and the public template gallery), identical for every org. Everything that
-  // touches the workflow itself routes through `resolveWorkflowAuthoring`.
+  // workflow.builder discovery — static product data (the CORE node-type
+  // registry and the public template gallery), identical for every org.
+  // Everything that touches the workflow itself routes through
+  // `resolveWorkflowAuthoring`.
+  //
+  // `describe_node_type` LEFT this list when it learned to answer for app-block
+  // types: those come from the org's installed apps, so its answer is no longer
+  // org-independent and it now takes the `workflowsView` area rung. That is
+  // exactly the change this list exists to force someone to make deliberately.
   'list_node_types',
-  'describe_node_type',
   'find_workflow_templates',
 ]
 

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/index.ts
@@ -14,6 +14,7 @@ import { createDisconnectNodesTool } from './tools/disconnect-nodes'
 import { createFindWorkflowTemplatesTool } from './tools/find-workflow-templates'
 import { createGetNodeTool } from './tools/get-node'
 import { createGetWorkflowTool } from './tools/get-workflow'
+import { createListAppBlocksTool } from './tools/list-app-blocks'
 import { createListNodeTypesTool } from './tools/list-node-types'
 import { createReplaceGraphTool } from './tools/replace-graph'
 import { createRunNodeTool } from './tools/run-node'
@@ -65,6 +66,7 @@ export function createWorkflowBuilderCapabilities(getDeps: GetToolDeps): PageCap
     tools: [
       // Discovery (progressive disclosure — the prompt carries no node list).
       createListNodeTypesTool(getDeps),
+      createListAppBlocksTool(getDeps),
       createDescribeNodeTypeTool(getDeps),
       createFindWorkflowTemplatesTool(getDeps),
       // Read

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
@@ -131,6 +131,43 @@ vi.mock('@auxx/services/workflow-templates', () => ({
   getAllTemplates: vi.fn(async () => ok([])),
 }))
 
+/**
+ * The installed-app fleet `list_app_blocks` lists and `buildManifestLookup`
+ * synthesizes from. Two apps on purpose: one contributing a block, one
+ * contributing none — the second is what proves the list is per-BLOCK, not
+ * per-app.
+ */
+const installedApps = vi.fn(async (..._a: unknown[]) => [
+  {
+    installationId: 'inst-1',
+    app: { id: 'appfedex', slug: 'fedex', title: 'Fedex', description: null, avatarUrl: null },
+    orgConnectionPresent: false,
+    orgConnectionExpiresAt: null,
+    workflowBlocks: [
+      {
+        id: 'fedex',
+        label: 'FedEx',
+        description: 'Track FedEx shipments',
+        requiresConnection: true,
+        ops: [
+          { key: 'shipment.track', resource: 'shipment', operation: 'track', toolId: 't1' },
+          { key: 'shipment.watch', resource: 'shipment', operation: 'watch', toolId: 't2' },
+        ],
+      },
+    ],
+  },
+  {
+    installationId: 'inst-2',
+    app: { id: 'apphub', slug: 'hubspot', title: 'HubSpot', description: null, avatarUrl: null },
+    orgConnectionPresent: true,
+    orgConnectionExpiresAt: null,
+    workflowBlocks: [],
+  },
+])
+vi.mock('../../../../../../cache', () => ({
+  getCachedInstalledApps: (...a: unknown[]) => installedApps(...a),
+}))
+
 import { createWorkflowBuilderCapabilities } from '../../index'
 import { DIRTY_CANVAS_ERROR, NO_WORKFLOW_REF_ERROR } from '../workflow-authoring-guard'
 
@@ -208,6 +245,7 @@ const VALID_ARGS: Record<string, Record<string, unknown>> = {
   apply_template: { templateId: 'file:x' },
   set_workflow_details: { name: 'Renamed workflow' },
   run_node: { ref: 'Wait A Bit' },
+  list_app_blocks: {},
 }
 
 function run(t: AgentToolDefinition, args: Record<string, unknown> = {}): Promise<AgentToolResult> {
@@ -225,9 +263,20 @@ const MUTATION_TOOLS = [
   'apply_template',
   'set_workflow_details',
 ] as const
-const VIEW_TOOLS = ['get_workflow', 'get_node', 'validate_workflow'] as const
+const VIEW_TOOLS = ['get_workflow', 'get_node', 'validate_workflow', 'list_app_blocks'] as const
 const GUARDED = [...VIEW_TOOLS, ...MUTATION_TOOLS, 'run_node'] as const
-const DISCOVERY = ['list_node_types', 'describe_node_type', 'find_workflow_templates'] as const
+/**
+ * Discovery splits in two now.
+ *
+ * `describe_node_type` answers for app-block types, which are per-ORG installed
+ * data, so it takes the `workflowsView` area rung — but NOT a workflow ref: it
+ * is addressed by type id and there is no instance to gate on. It is therefore
+ * in neither bucket, and `AREA_ONLY` names that third state explicitly rather
+ * than letting it fall out of the enumeration unnoticed.
+ */
+const UNGATED_DISCOVERY = ['list_node_types', 'find_workflow_templates'] as const
+const AREA_ONLY = ['describe_node_type'] as const
+const DISCOVERY = [...UNGATED_DISCOVERY, ...AREA_ONLY] as const
 
 beforeEach(() => {
   caps = makeCaps()
@@ -242,6 +291,7 @@ beforeEach(() => {
   updateWorkflowDetails.mockClear()
   publishDraftUpdatedSignal.mockClear()
   beginWorkflowTurnLock.mockClear()
+  installedApps.mockClear()
 })
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -304,6 +354,29 @@ describe('workflow.builder authorization enumeration', () => {
       await expect(run(tool(name)), name).rejects.toThrow(ForbiddenError)
     }
     expect(opMock).not.toHaveBeenCalled()
+  })
+
+  /**
+   * `describe_node_type` answers for app-block types, which are per-org, so it
+   * must not stay ungated — but it takes no workflow ref, so the enumeration
+   * above cannot cover it. Asserted here on both rungs, and asserted to still
+   * work WITHOUT a workflow ref, because losing that would break every
+   * off-builder caller for no security gain.
+   */
+  it('area-only tools take the workflows rung but need no workflow ref', async () => {
+    refs = []
+    for (const name of AREA_ONLY) {
+      const allowed = await run(tool(name), VALID_ARGS[name] ?? { type: 'wait' })
+      expect(allowed.success, name).toBe(true)
+
+      caps = undefined
+      await expect(run(tool(name), { type: 'wait' }), name).rejects.toThrow(ForbiddenError)
+
+      caps = makeCaps()
+      caps.can.mockReturnValue(false)
+      await expect(run(tool(name), { type: 'wait' }), name).rejects.toThrow(ForbiddenError)
+      caps = makeCaps()
+    }
   })
 
   it('a crafted foreign-org ref reads as "not in this workspace" — silent for reads, thrown for writes', async () => {
@@ -529,6 +602,109 @@ describe('discovery tools', () => {
     const result = await run(tool('describe_node_type'), { type: 'quantum-blockchain' })
     expect(result.success).toBe(false)
     expect(result.error).toContain('quantum-blockchain')
+  })
+
+  /**
+   * The §9.1 blocker: before this, `describe_node_type` read the CORE registry
+   * only, so the one tool an agent calls before configuring an unfamiliar type
+   * told it every app-block type did not exist — and it then refused to write a
+   * node the write path would have accepted.
+   */
+  it('describe_node_type resolves an app-block type, with its operation vocabulary', async () => {
+    const result = await run(tool('describe_node_type'), { type: 'appfedex:fedex' })
+    expect(result.success).toBe(true)
+    const out = result.output as Record<string, any>
+    expect(out.type).toBe('appfedex:fedex')
+    expect(out.authorable).toBe(true)
+    // The vocabulary the agent could not otherwise reach — an enum, because the
+    // synthesized manifest declares `operation` as `z.enum` over the real ops.
+    expect(out.configSchema.properties.operation.enum).toEqual(['track', 'watch'])
+    expect(out.configSchema.properties.resource.enum).toEqual(['shipment'])
+    expect(out.usage).toContain('shipment.track')
+  })
+
+  it('describe_node_type does not read the org cache for a core type', async () => {
+    await run(tool('describe_node_type'), { type: 'wait' })
+    expect(installedApps).not.toHaveBeenCalled()
+  })
+
+  it('describe_node_type gives a colon type the app-block-shaped refusal', async () => {
+    const result = await run(tool('describe_node_type'), { type: 'jira:issue' })
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('shaped like an app block')
+    expect(result.error).toContain('list_app_blocks')
+  })
+
+  it('list_app_blocks lists one row per installed BLOCK, not per app', async () => {
+    const result = await run(tool('list_app_blocks'))
+    expect(result.success).toBe(true)
+    const blocks = (result.output as { blocks: Array<Record<string, unknown>> }).blocks
+    // HubSpot is installed but contributes no block — it must not appear.
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]).toMatchObject({
+      type: 'appfedex:fedex',
+      app: 'Fedex',
+      appSlug: 'fedex',
+      label: 'FedEx',
+      resources: ['shipment'],
+      operationCount: 2,
+      requiresConnection: true,
+      connected: false,
+    })
+    // The vocabulary is describe_node_type's job — quickbooks declares 42
+    // operations and shopify 64, so listing them here would swamp the answer.
+    expect(blocks[0]).not.toHaveProperty('operations')
+  })
+
+  it('list_app_blocks searches app, label, description and operation names (unemitted)', async () => {
+    for (const query of ['fedex', 'FEDEX SHIPMENTS', 'shipment.watch', 'appfedex:fedex']) {
+      const result = await run(tool('list_app_blocks'), { query })
+      expect(result.success, query).toBe(true)
+      expect((result.output as { blocks: unknown[] }).blocks, query).toHaveLength(1)
+    }
+  })
+
+  it('list_app_blocks reports an actionable error when nothing matches', async () => {
+    const result = await run(tool('list_app_blocks'), { query: 'quantum-blockchain' })
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('quantum-blockchain')
+    expect(result.error).toContain('without a query')
+  })
+
+  it('list_app_blocks says so when no installed app contributes a block', async () => {
+    installedApps.mockResolvedValueOnce([])
+    const result = await run(tool('list_app_blocks'))
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('No app installed in this workspace')
+  })
+
+  /**
+   * `requiresConnection: undefined` means UNKNOWN — a catalog published before
+   * the field existed simply does not say. Emitting `false` there would let the
+   * agent read a guess as a fact, so the key is omitted instead.
+   */
+  it('list_app_blocks omits requiresConnection rather than guessing false', async () => {
+    installedApps.mockResolvedValueOnce([
+      {
+        installationId: 'inst-3',
+        app: { id: 'appold', slug: 'old', title: 'Old', description: null, avatarUrl: null },
+        orgConnectionPresent: true,
+        orgConnectionExpiresAt: null,
+        workflowBlocks: [{ id: 'blk', label: 'Blk', description: 'd', ops: [] }],
+      },
+    ] as never)
+    const result = await run(tool('list_app_blocks'))
+    expect(result.success).toBe(true)
+    const blocks = (result.output as { blocks: Array<Record<string, unknown>> }).blocks
+    expect(blocks[0]).not.toHaveProperty('requiresConnection')
+    expect(blocks[0]!.connected).toBe(true)
+  })
+
+  it('list_app_blocks builds a compact count digest', () => {
+    expect(tool('list_app_blocks').buildDigest?.({ blocks: [{}, {}, {}] })).toEqual({
+      label: 'App blocks listed',
+      resultCount: 3,
+    })
   })
 })
 

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/describe-node-type.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/describe-node-type.ts
@@ -5,6 +5,7 @@ import { getManifest } from '../../../../../workflow-engine/catalog/registry'
 import type { NodeManifest } from '../../../../../workflow-engine/catalog/types'
 import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
+import { assertWorkflowAreaAccess } from './workflow-authoring-guard'
 
 /** Agent-facing config schema as JSON Schema — `agentSchema ?? configSchema`. */
 function configJsonSchema(manifest: NodeManifest<unknown>): Record<string, unknown> {
@@ -24,15 +25,41 @@ function configJsonSchema(manifest: NodeManifest<unknown>): Record<string, unkno
 /**
  * Full agent-facing description of one node type (04 §1): the config schema
  * the write tools accept, connection/branch rules, the manifest's usage
- * guidance and worked examples. Static product data — no authorization gate.
+ * guidance and worked examples.
+ *
+ * **Resolves app-block types too, and that is why this is no longer a static
+ * tool.** It used to read `getManifest` — the CORE registry — so every
+ * `<appId>:<blockId>` type came back "does not exist. Call list_node_types for
+ * the catalog." Phase B made those types authorable, which meant the one tool
+ * an agent is told to call before configuring an unfamiliar type was also the
+ * one telling it the type was not real. Live in dev (plan 17 §9.1 prompt 5) the
+ * agent asked for the FedEx block's schema, got that message, and refused to
+ * write — twice. Handed the operation vocabulary by hand it wrote correctly on
+ * the first try, so the shipped write path was never the problem; discovery
+ * was.
+ *
+ * The synthesized manifest already carries everything rendered below, and
+ * because its `resource`/`operation` are `z.enum` over the block's real ops,
+ * `z.toJSONSchema` emits the operation vocabulary as an enum — exactly what was
+ * missing.
+ *
+ * The cost is that the answer is now per-org, so the tool takes the
+ * `workflowsView` area rung instead of no gate at all. Not the full
+ * `resolveWorkflowAuthoring` ladder: this takes a type id, not a workflow ref,
+ * and there is no instance to gate on.
+ *
+ * A core type never pays the org-cache read — the lookup is built only for a
+ * type carrying a colon, which no core id does.
  */
 export function createDescribeNodeTypeTool(getDeps: GetToolDeps): AgentToolDefinition {
-  void getDeps
   return {
     name: 'describe_node_type',
     permission: {
-      target: 'none',
-      note: 'Static node-type manifest (schema, connection rules, usage docs) — identical for every org, no workspace data.',
+      target: 'area',
+      area: 'workflows',
+      level: 'view',
+      enforcement: 'enforced',
+      note: 'assertWorkflowAreaAccess — fail-closed on absent capabilities, then PermissionKey.workflowsView. Core node types are static product data; app-block types are this org’s installed-app catalog, which is what the gate is for.',
     },
     displayName: 'Describe node type',
     surfaces: ['builder'],
@@ -42,19 +69,35 @@ export function createDescribeNodeTypeTool(getDeps: GetToolDeps): AgentToolDefin
     parameters: {
       type: 'object',
       properties: {
-        type: { type: 'string', description: "Node type id from list_node_types (e.g. 'http')." },
+        type: {
+          type: 'string',
+          description:
+            "Node type id from list_node_types (e.g. 'http'), or an app block's '<appId>:<blockId>' from list_app_blocks.",
+        },
       },
       required: ['type'],
       additionalProperties: false,
     },
-    execute: async (args) => {
+    execute: async (args, agentDeps) => {
+      assertWorkflowAreaAccess(getDeps().capabilities)
       const type = typeof args.type === 'string' ? args.type : ''
-      const manifest = getManifest(type)
+
+      // Colon pre-filter, same one `resolve-outputs` keeps: a core id never
+      // contains one, so a core-only call still pays for no cache read.
+      let manifest = getManifest(type)
+      if (!manifest && type.includes(':')) {
+        const { buildManifestLookup } = await import(
+          '../../../../../workflow-engine/catalog/app-manifests'
+        )
+        manifest = (await buildManifestLookup(agentDeps.organizationId))(type)
+      }
       if (!manifest) {
         return {
           success: false,
           output: null,
-          error: `Node type "${type}" does not exist. Call list_node_types for the catalog.`,
+          error: type.includes(':')
+            ? `Node type "${type}" is shaped like an app block (<appId>:<blockId>), but no app installed in this workspace contributes it. Call list_app_blocks for the ones that are.`
+            : `Node type "${type}" does not exist. Call list_node_types for the catalog, or list_app_blocks for blocks contributed by installed apps.`,
         }
       }
 

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/list-app-blocks.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/list-app-blocks.ts
@@ -1,0 +1,125 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/list-app-blocks.ts
+
+import type { AgentToolDefinition } from '../../../../agent-framework/types'
+import type { GetToolDeps } from '../../types'
+import { workflowToolPermission } from './graph-tool-helpers'
+import { resolveWorkflowAuthoring } from './workflow-authoring-guard'
+
+/**
+ * The workflow blocks this org's installed apps contribute (plan 17 §6, C1).
+ *
+ * `list_node_types` reads `listManifests()` — the core registry — and app
+ * blocks are deliberately never registered there (`catalog-coverage.test.ts`
+ * asserts exact set equality between the `NodeType` enum and
+ * {registered manifests ∪ `NOT_YET_MIGRATED`}, and an app block is in neither).
+ * So the two lists cannot merge, and without this tool an installed block is
+ * unreachable by name: live in dev (§9.1 prompt 8) `list_node_types` was asked
+ * for "quickbooks", answered "No node types match", and the agent concluded
+ * QuickBooks was unavailable — while it was installed and contributing a block.
+ * A false negative, not a missing feature.
+ *
+ * One row per installed block, deliberately compact: this is discovery, and the
+ * operation vocabulary belongs to `describe_node_type`, which now returns it as
+ * an enum on `configSchema.properties.operation`.
+ *
+ * `resources` + `operationCount` rather than the operation list, because the
+ * list does not stay small: quickbooks declares **42** operations and shopify
+ * **64**, so an unfiltered call that spelled them all out would spend thousands
+ * of characters on a tool whose only job is "which blocks exist". The `query`
+ * filter still matches operation names, so searching "invoice" finds the
+ * QuickBooks block — you just get the block, not its whole vocabulary.
+ *
+ * `connected` is the denormalized `orgConnectionPresent` already on
+ * `CachedInstalledApp` — no extra read. It is surfaced because a block whose
+ * app has no workspace connection produces a tier-2 `error` the moment it is
+ * added, and an agent that can see that up front can say so instead of
+ * authoring a node that is guaranteed not to run.
+ */
+export function createListAppBlocksTool(getDeps: GetToolDeps): AgentToolDefinition {
+  return {
+    name: 'list_app_blocks',
+    permission: workflowToolPermission('view'),
+    displayName: 'List app blocks',
+    surfaces: ['builder'],
+    idempotent: true,
+    description:
+      'List the workflow blocks contributed by apps installed in this workspace — the node types that are NOT in list_node_types. Each row carries the "<appId>:<blockId>" type add_node takes, the resources it covers, how many operations it offers, and whether the app has a workspace connection. Call describe_node_type with the type for its config schema and the full operation vocabulary.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            'Optional free-text search over app name, block label, description, and operation names.',
+        },
+      },
+      additionalProperties: false,
+    },
+    buildDigest: (output) => {
+      const out = (output ?? {}) as { blocks?: unknown[] }
+      return {
+        label: 'App blocks listed',
+        resultCount: Array.isArray(out.blocks) ? out.blocks.length : 0,
+      }
+    },
+    execute: async (args, agentDeps) => {
+      const auth = await resolveWorkflowAuthoring(getDeps, agentDeps, 'view')
+      if (!auth.ok) return { success: false, output: null, error: auth.error }
+
+      // Lazy import — the cache module pulls server-only deps; same reason
+      // get-workflow.ts defers graph-edit.
+      const { getCachedInstalledApps } = await import('../../../../../cache')
+      const apps = await getCachedInstalledApps(agentDeps.organizationId)
+
+      const query = typeof args.query === 'string' ? args.query.trim() : ''
+      const normalizedQuery = query.toLowerCase()
+
+      const blocks = apps
+        .flatMap((inst) =>
+          (inst.workflowBlocks ?? []).map((block) => ({
+            opKeys: block.ops.map((op) => `${op.resource}.${op.operation}`),
+            row: {
+              type: `${inst.app.id}:${block.id}`,
+              app: inst.app.title,
+              appSlug: inst.app.slug,
+              label: block.label || block.id,
+              description: block.description || `${inst.app.title} block`,
+              resources: [...new Set(block.ops.map((op) => op.resource))],
+              operationCount: block.ops.length,
+              // `undefined` means UNKNOWN, not false — a catalog published before
+              // the field existed simply does not say. Omitted rather than
+              // defaulted, so the agent never reads a guess as a fact.
+              ...(block.requiresConnection !== undefined
+                ? { requiresConnection: block.requiresConnection }
+                : {}),
+              connected: inst.orgConnectionPresent,
+            },
+          }))
+        )
+        // Search over the operation KEYS too, even though they are not emitted:
+        // "find me the invoice block" is exactly how this tool gets used, and
+        // the block is the answer — its vocabulary is one describe_node_type
+        // away.
+        .filter(
+          ({ row, opKeys }) =>
+            !normalizedQuery ||
+            [row.type, row.app, row.appSlug, row.label, row.description, ...opKeys].some((value) =>
+              value.toLowerCase().includes(normalizedQuery)
+            )
+        )
+        .map(({ row }) => row)
+        .sort((a, b) => a.type.localeCompare(b.type))
+
+      if (blocks.length === 0) {
+        return {
+          success: false,
+          output: null,
+          error: query
+            ? `No installed app contributes a workflow block matching "${query}". Call list_app_blocks without a query to see them all.`
+            : 'No app installed in this workspace contributes a workflow block. Apps are installed from Settings → Apps.',
+        }
+      }
+      return { success: true, output: { blocks } }
+    },
+  }
+}

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/list-node-types.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/list-node-types.ts
@@ -21,7 +21,7 @@ export function createListNodeTypesTool(getDeps: GetToolDeps): AgentToolDefiniti
     surfaces: ['builder'],
     idempotent: true,
     description:
-      'List or search workflow node types: id, display name, one-line description, category, whether it is a trigger, and whether you may author it. Call describe_node_type before configuring one.',
+      'List or search workflow node types: id, display name, one-line description, category, whether it is a trigger, and whether you may author it. Call describe_node_type before configuring one. This is the CORE catalog only — blocks contributed by installed apps are addressed as "<appId>:<blockId>" and are listed by list_app_blocks, so an empty result here does not mean no such block exists.',
     parameters: {
       type: 'object',
       properties: {
@@ -75,7 +75,7 @@ export function createListNodeTypesTool(getDeps: GetToolDeps): AgentToolDefiniti
         return {
           success: false,
           output: null,
-          error: `No node types match ${filter || 'the supplied filters'}. Call list_node_types without filters to see the full catalog.`,
+          error: `No CORE node types match ${filter || 'the supplied filters'}. Call list_node_types without filters to see the full catalog — and list_app_blocks for blocks contributed by installed apps, which are not in it.`,
         }
       }
       return { success: true, output: { types } }

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/workflow-authoring-guard.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/workflow-authoring-guard.ts
@@ -3,6 +3,7 @@
 import { schema } from '@auxx/database'
 import { and, eq } from 'drizzle-orm'
 import { ForbiddenError } from '../../../../../errors'
+import type { CapabilityView } from '../../../../../permissions/capabilities/capability-view'
 import { PermissionKey } from '../../../../../permissions/capabilities/registry'
 import { beginWorkflowTurnLock } from '../../../../../workflows/graph-edit/turn-lock'
 import { assertWorkflowAppNotSystemOwned } from '../../../../../workflows/workflow-app-access-guard'
@@ -47,6 +48,41 @@ export type WorkflowAuthoringResolution =
  * cheaper than the router it mirrors.
  */
 export type WorkflowAuthoringTier = 'view' | 'edit' | 'admin'
+
+/**
+ * Rungs (1) and (2) of {@link resolveWorkflowAuthoring}, on their own: fail
+ * closed on absent capabilities, then the `workflowsView` area key.
+ *
+ * Extracted so the CATALOG tools — the ones that answer "what node types exist
+ * and what config do they take" — can assert the area without the rest of the
+ * ladder. They have no workflow instance to gate on: they take a type id, not a
+ * ref, and requiring a session workflow would make them unusable off the
+ * builder page for no security gain. Everything instance-shaped (org scope, the
+ * per-workflow rung, system-owned lockdown, the dirty gate, the turn lock)
+ * stays below, where a workflow id actually exists.
+ *
+ * It is a function rather than two copied `if`s so the fail-closed decision has
+ * exactly ONE definition. Throws `ForbiddenError` on both rungs, same as the
+ * full gate.
+ *
+ * Declared as an assertion signature, not `void`: extracting the null check out
+ * of {@link resolveWorkflowAuthoring} would otherwise cost it the narrowing it
+ * used to get from the inline `if`, and every later `capabilities.` call below
+ * would need a non-null assertion — turning a refactor into three new places
+ * where a future edit could silently deref undefined.
+ */
+export function assertWorkflowAreaAccess(
+  capabilities: CapabilityView | undefined
+): asserts capabilities is CapabilityView {
+  if (!capabilities) {
+    throw new ForbiddenError(
+      'This session carries no permission context — workflow editing is unavailable.'
+    )
+  }
+  if (!capabilities.can(PermissionKey.workflowsView)) {
+    throw new ForbiddenError('You don’t have permission to work with workflows.')
+  }
+}
 
 /**
  * **The** authorization gate for every graph tool in the `workflow.builder`
@@ -99,17 +135,10 @@ export async function resolveWorkflowAuthoring(
   const organizationId = agentDeps.organizationId
 
   // (1) Fail closed — see the docblock. Deliberately opposite the lib-wide
-  // `undefined ⇒ unrestricted` convention, so it is stated loudly here.
-  if (!capabilities) {
-    throw new ForbiddenError(
-      'This session carries no permission context — workflow editing is unavailable.'
-    )
-  }
-
-  // (2) Area rung.
-  if (!capabilities.can(PermissionKey.workflowsView)) {
-    throw new ForbiddenError('You don’t have permission to work with workflows.')
-  }
+  // `undefined ⇒ unrestricted` convention, so it is stated loudly there.
+  // (2) Area rung. Both live in `assertWorkflowAreaAccess` so the catalog tools
+  // share this exact decision rather than reimplementing it.
+  assertWorkflowAreaAccess(capabilities)
 
   // (3) Org scope. The id comes from client-supplied session refs — verify it
   // belongs to THIS org before any instance assert, so a foreign id reads as


### PR DESCRIPTION
Phase **C0 + C1** of `plans/kopilot/workflow/17-app-block-authoring-and-connections.md`. Follows #1715, and comes straight out of running that plan's §9.1 live verification in dev.

## The problem §9.1 found

Phase B (#1709/#1710/#1712) made app-block nodes authorable. §9.1 asked Kopilot to change the FedEx node's operation. It called `get_node`, said it needed the type's schema, called `describe_node_type` — and got:

```
Node type "z3prn…:fedex" does not exist. Call list_node_types for the catalog.
```

It then refused, twice. Handed the operation vocabulary by hand, `update_node` applied cleanly on the first try. **The write path B3 shipped was never the problem — discovery was.** Two tools were lying about app blocks:

| tool | why it lied |
|---|---|
| `describe_node_type` | resolved through `getManifest` — the **core registry** — so every `<appId>:<blockId>` came back nonexistent |
| `list_node_types` | reads `listManifests()`, and app blocks are deliberately never registered there (`catalog-coverage.test.ts` pins that set) |

The second one produced a false negative live: asked for "quickbooks" it answered *"No node types match"* for an app that **is** installed and **does** contribute a block, and the agent reported it unavailable.

## What this does

**`describe_node_type`** falls back to `buildManifestLookup(orgId)`, behind a colon pre-filter so a core type still pays for no cache read. Nothing else changed — the synthesized manifest already carried every field the tool renders, and because `resource`/`operation` are `z.enum` over the block's real ops, `z.toJSONSchema` emits the vocabulary as an enum:

```json
"operation": { "type": "string", "enum": ["track","watch","unwatch","trackByReference"] }
```

**New `list_app_blocks`** covers the discovery gap, and `list_node_types` now says out loud that it is the core catalog only.

## The review question

**`describe_node_type` is no longer org-independent.** It leaves `NO_AUTHORIZATION_REQUIRED` and takes the `workflowsView` area rung. Rungs 1–2 of `resolveWorkflowAuthoring` are extracted as `assertWorkflowAreaAccess` — *not* the full ladder, because these tools take a type id, not a workflow ref, and there is no instance to gate on. `list_app_blocks` **does** take the full `workflowToolPermission('view')` ladder, per §6.

Three deliberate calls, flagged so they aren't read as oversights:

- `assertWorkflowAreaAccess` is an **assertion signature**, not `void` — as `void` it costs `resolveWorkflowAuthoring` its narrowing and adds three non-null assertions.
- The failing `tool-permission-declarations.test.ts` was **the guardrail working**: that curated list exists to force this decision deliberately.
- `list_app_blocks` **omits** `requiresConnection` when undefined rather than emitting `false` — undefined means the catalog predates the field, and a guess must not read as a fact.

## `resources` + `operationCount`, not the operation list

I first emitted the full `operations` array, arguing the list stays short. **The live call disproved that**: QuickBooks returned **42** operations, and shopify declares **64**. Spelling them out would swamp a tool whose only job is "which blocks exist", so rows carry `resources` + `operationCount` and the vocabulary lives one `describe_node_type` away. The `query` filter still matches operation names, so "invoice" finds the QuickBooks block.

## Verification

Live in dev against the "Fedex Shipment" workflow, fresh Kopilot session:

- §9.1 prompt 5 now runs **unassisted** — `get_node → describe_node_type → update_node`, applied, outputs flipping to `shipment.watch`'s exact 3.
- *"Add a Quickbooks block"* now calls `list_app_blocks` and **finds** the block.
- #1715 confirmed in the same turn: the CRUD issue reads *"…reads node FedEx, which is not upstream of CRUD Operation 1"* — single braces, right node name, actionable.

Automated:

- `packages/lib` — `vitest run src/ai/kopilot` → **67 files / 572 tests passing**
- `node scripts/ci/typecheck-ratchet.js --package lib` → no new type errors (29, baseline 29)
- `biome check --write` on the touched dirs

**One caveat, stated plainly:** the live run above exercised the *original* `operations`-list shape. The switch to `resources` + `operationCount` came after it and is covered by unit tests, but its live re-check did not finish streaming before I stopped. Worth one `list_app_blocks` call before merge to confirm the emitted rows.

## Not in scope

C2 (`describe_app_block`) is downgraded from blocker to refinement — C0 already returns the vocabulary; what C2 still buys is per-**operation** input filtering, since `describe_node_type` returns the union of all inputs across every op. C3's `describe_node_type` redirect is now obsolete; its prompt paragraph and `NON_CONFIG_KEYS` hygiene are not.