### PR TITLE
feat(workflow): teach kopilot the app-block surface and trim node summaries

### DIFF
--- a/packages/lib/src/ai/kopilot/prompts/sections/__tests__/workflow-builder.test.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/__tests__/workflow-builder.test.ts
@@ -12,4 +12,34 @@ describe('buildWorkflowBuilderPromptSection', () => {
     expect(prompt).toContain('`Remaining validation`')
     expect(prompt).toContain('Apply every safe, unambiguous part before asking')
   })
+
+  it('teaches the app-block surface: discovery, operation-first, connections', () => {
+    const prompt = buildWorkflowBuilderPromptSection()
+
+    // Discovery — the live run's failure was the agent concluding an installed
+    // block did not exist because `list_node_types` did not list it.
+    expect(prompt).toContain('`list_app_blocks`')
+    expect(prompt).toContain('NOT in `list_node_types`')
+    expect(prompt).toContain('`<appId>:<blockId>`')
+    // Operation first, or the block resolves no outputs at all.
+    expect(prompt).toContain('set `resource` and `operation` FIRST')
+    expect(prompt).toContain('resolves NO outputs')
+    // Unbound is the healthy default (§0 S1).
+    expect(prompt).toContain('leave `connectionId` unset')
+  })
+
+  it('forbids auxx:// deep links for workflow nodes', () => {
+    // Live-run finding: node ids are shaped like record ids, so the model
+    // linked them and the chat rendered every one as "Unknown".
+    const prompt = buildWorkflowBuilderPromptSection()
+
+    expect(prompt).toContain('Workflow nodes are not CRM records')
+    expect(prompt).toContain('auxx://record/<nodeId>')
+  })
+
+  it('stays static — no per-org content leaks into the cached section', () => {
+    // The section is cached as one static block; naming an org's apps here
+    // would drop it out of that block on every turn.
+    expect(buildWorkflowBuilderPromptSection()).toBe(buildWorkflowBuilderPromptSection())
+  })
 })

--- a/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
@@ -37,6 +37,18 @@ export function buildWorkflowBuilderPromptSection(): string {
     // Canvas readability.
     'Every node you add needs a concise `description` that explains why it exists in the user’s terms. This appears under the node title on the canvas.',
 
+    // App blocks (plan 17 §6 C3). Static: the paragraph teaches the SHAPE of the
+    // surface, never which apps this org installed — that is `list_app_blocks`'
+    // answer, and naming apps here would drop the section out of the cached
+    // static tier.
+    'App blocks: apps installed in this workspace contribute their own node types, addressed as `<appId>:<blockId>` (for example `z3prnwpd3rt31mp7f9yxo5m6:fedex`). They are NOT in `list_node_types` — an empty result there never means the block does not exist. Find them with `list_app_blocks`, then call `describe_node_type` with the full `<appId>:<blockId>` type for the config schema; `add_node` and `update_node` take that same type.',
+    "Configuring an app block: set `resource` and `operation` FIRST, picking both from the enums `describe_node_type` returns. Until an operation is set the block dispatches nothing and resolves NO outputs, so nothing downstream can reference it — and the operation you pick decides which of the block's inputs apply and what it outputs. Never invent an operation: one the block does not offer is refused, and the refusal names the real ones.",
+    "App-block connections: leave `connectionId` unset — that is the healthy default, and the block runs on the workspace's default connection for its app. If the app has no workspace connection at all, the node reports an error the moment it is added; `list_app_blocks` says so up front as `connected: false`, so mention it to the user rather than authoring a node that cannot run.",
+
+    // Prose rendering. Live-run finding: the model deep-linked node ids, which
+    // the chat renders as "Unknown" (plan 17 §0, and #1708 for the crash).
+    'Workflow nodes are not CRM records. When you name a node or one of its outputs in your reply, write the plain title — FedEx, `{{FedEx.trackingNumber}}` — never a markdown link with an `auxx://` href. A node id looks like a record id but is not one, and `auxx://record/<nodeId>` renders to the user as “Unknown”.',
+
     // Safe nested edits.
     'Nested config edits: call `get_node` immediately before editing, then use `update_node` with its `configHash` and `patches`. Paths are segment arrays, for example `["model", "completion_params", "temperature"]`; use numeric segments for arrays. Prefer patches over resending a nested object. `expectedConfigHash` is optional — pass it when you have it, and if a call is refused for a stale one the error names the node\'s CURRENT hash, so retry immediately with that value rather than switching to `config` mode to avoid the hash. Use legacy `config` only for top-level fields such as `title`.',
 
@@ -59,6 +71,6 @@ export function buildWorkflowBuilderPromptSection(): string {
     ].join('\n'),
 
     // Honesty rules.
-    'Never invent node ids, output names, template ids, or node types — use `list_node_types` / `describe_node_type` / `find_workflow_templates` and the refs the tools return. If a requested node type is not authorable, say so plainly and name the type; do not silently substitute another type. If an edit is refused because the canvas has unsaved changes, ask the user to save (or discard) their canvas changes and then retry.',
+    'Never invent node ids, output names, template ids, or node types — use `list_node_types` / `list_app_blocks` / `describe_node_type` / `find_workflow_templates` and the refs the tools return. If a requested node type is not authorable, say so plainly and name the type; do not silently substitute another type. If an edit is refused because the canvas has unsaved changes, ask the user to save (or discard) their canvas changes and then retry.',
   ].join('\n\n')
 }

--- a/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
@@ -1231,6 +1231,48 @@ describe('app blocks — authoring (§5 B3 checkpoint)', () => {
     )
   })
 
+  it('withholds app identity from the node summary, and the patch path keeps it', async () => {
+    // C3 hygiene: `appId`/`appSlug`/`blockId` are stamped identity, not config —
+    // `appId` and `blockId` are already the two halves of `type`. Withholding
+    // them also makes them DURABLE: the `patches` path deletes every key the
+    // summary showed before re-applying, so a key the summary never showed
+    // survives the write untouched.
+    installAcme()
+    const graph: DraftGraph = {
+      nodes: [
+        plainNode(ACME_NODE_ID, ACME_TYPE, 'Acme Sync', {
+          appId: ACME_APP_ID,
+          appSlug: 'acme',
+          blockId: 'sync',
+          resource: 'record',
+          operation: 'sync',
+        }),
+      ],
+      edges: [],
+    }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'Acme Sync',
+      patches: [{ op: 'set', path: ['operation'], value: 'archive' }],
+    })
+
+    expect(result.isOk()).toBe(true)
+    const summary = result._unsafeUnwrap().node
+    expect(summary?.config).not.toHaveProperty('appId')
+    expect(summary?.config).not.toHaveProperty('appSlug')
+    expect(summary?.config).not.toHaveProperty('blockId')
+    expect(summary?.config).toMatchObject({ resource: 'record', operation: 'archive' })
+
+    // Still on the node, so the processor can still dispatch it.
+    expect(persistedGraph().nodes.find((n) => n.id === ACME_NODE_ID)?.data).toMatchObject({
+      appId: ACME_APP_ID,
+      appSlug: 'acme',
+      blockId: 'sync',
+      operation: 'archive',
+    })
+  })
+
   it('names the app-block shape when the type resolves to nothing', async () => {
     // Listing the ~27 core ids at someone who typed a colon answers a question
     // they did not ask.

--- a/packages/lib/src/workflows/graph-edit/read.ts
+++ b/packages/lib/src/workflows/graph-edit/read.ts
@@ -110,11 +110,25 @@ export async function loadDraftContext(
   })
 }
 
-/** Data keys that are identity/bookkeeping, not config — withheld from summaries. */
+/**
+ * Data keys that are identity/bookkeeping, not config — withheld from summaries.
+ *
+ * `appId`/`appSlug`/`blockId` are an app block's identity, stamped by
+ * `add_node` from the synthesized manifest's `defaultData` and never settable:
+ * `appId` and `blockId` are already the two halves of `type`, and re-emitting
+ * all three in every node summary spent space on every read for nothing.
+ * Withholding them also makes them durable — the `patches` path deletes every
+ * key the summary showed before re-applying, so a key that is not in the
+ * summary survives the write untouched. `connectionId` and `fieldModes` stay in
+ * config on purpose: both are agent-settable.
+ */
 const NON_CONFIG_KEYS = new Set([
   'id',
   'type',
   'title',
+  'appId',
+  'appSlug',
+  'blockId',
   'desc',
   'icon',
   'selected',


### PR DESCRIPTION
Plan 17 (`plans/kopilot/workflow/17-app-block-authoring-and-connections.md`) §6 **C3**.

Two of C3's three items turned out to be **already shipped in #1716** — the `describe_node_type` app-block arm and the `list_node_types` cross-reference — so this PR is the prompt paragraph plus one hygiene fix. C3 was pulled ahead of C2, which is now optional refinement.

## Prompt — `prompts/sections/workflow-builder.ts`

Stays in the **static, cached tier**: it teaches the shape of the surface, never which apps an org has installed (that answer is `list_app_blocks`'). Four paragraphs, placed after *Canvas readability* so the closing-shape rules stay last:

- **Discovery** — app blocks are `<appId>:<blockId>`, are NOT in `list_node_types`, and an empty result there never means the block does not exist. In the live §9.1 run the agent concluded an installed QuickBooks block was unavailable for exactly that reason.
- **Operation first** — set `resource` + `operation` from the enums `describe_node_type` returns. Until an operation is set the block dispatches nothing and resolves **no** outputs, so nothing downstream can reference it.
- **Connections** — leave `connectionId` unset; that is the healthy default and the workspace default connection resolves at run time. `connected: false` from `list_app_blocks` is worth telling the user before authoring a node that cannot run.
- **`auxx://record/<nodeId>` is forbidden** — a node id is shaped like a record id, so the model deep-linked workflow nodes and the chat rendered every one as "Unknown". #1708 stopped the crash; nothing stopped the model choosing the link. This is the fix for §9.1 prompt 1's user-visible answer, where the tool returned all 16 outputs correctly and the reply read "Unknown, Unknown, Unknown, Unknown".

`list_app_blocks` also joins the existing "never invent ids" honesty line.

## Hygiene — `graph-edit/read.ts`

`appId`/`appSlug`/`blockId` move into `NON_CONFIG_KEYS`. They are identity stamped by `add_node` from the synthesized manifest's `defaultData`, never agent-settable, and `appId`/`blockId` are already the two halves of `type`.

Beyond the space saved in every node summary, this buys something the plan did not claim: the `patches` path deletes every key the summary showed before re-applying, so a **withheld key now survives a patch untouched** instead of round-tripping through the agent. `connectionId` and `fieldModes` deliberately stay in config — both are agent-settable. `installationId` was deliberately not added: nothing stamps it and the canvas does not persist it.

## Tests

- 3 new cases in `prompts/sections/__tests__/workflow-builder.test.ts` (discovery/operation-first/connections, the `auxx://` rule, and that the section is still static)
- 1 new case in `graph-edit/__tests__/ops.test.ts` asserting both halves of the hygiene change — hidden from the summary, still on the persisted node after a patch

`vitest run src/ai/kopilot src/workflows/graph-edit` — 543 + 261 pass. Biome clean.

## Not in this PR

- **C2** (`describe_app_block`, per-operation input filtering) — optional refinement
- **O1** (block a bad ref written by *this* mutation) — decided, not implemented; it also needs `03-graph-edit-service.md` §5 amended in the same PR
- The `list_app_blocks` live re-check and a §9.1 re-run to confirm the `auxx://` rule actually changes model behavior — this is prompt work, so it is mitigated, not proven