### PR TITLE
fix(workflow): refuse a graph edit that writes a broken variable reference

### DIFF
--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/graph-tool-helpers.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/graph-tool-helpers.ts
@@ -139,13 +139,25 @@ export function mutationToToolResult(
   }
   if (!value.applied) {
     const blocking = value.issues.filter((issue) => issue.severity === 'error')
+    // Fresh first, inherited ones labelled: a refused edit lists the whole
+    // draft's errors, and without the split the caller reads damage it did not
+    // do as the reason it was refused — then "fixes" a node it never touched.
+    const shown = (blocking.length > 0 ? blocking : value.issues)
+      .slice()
+      .sort((a, b) => Number(a.preExisting ?? false) - Number(b.preExisting ?? false))
     return {
       success: false,
       output: projected,
       error:
         'The edit was NOT applied — blocking issues:\n' +
-        (blocking.length > 0 ? blocking : value.issues)
-          .map((issue) => `- ${issue.nodeRef ? `${issue.nodeRef}: ` : ''}${issue.message}`)
+        shown
+          .map(
+            (issue) =>
+              `- ${issue.nodeRef ? `${issue.nodeRef}: ` : ''}${issue.message}` +
+              (issue.preExisting
+                ? ' (pre-existing — already in the draft, not what blocked this edit)'
+                : '')
+          )
           .join('\n'),
     }
   }

--- a/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
@@ -8,8 +8,8 @@
  * column re-derivation through the persist seam, and the readDraft shape.
  */
 
-import { err as errResult } from 'neverthrow'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { err as errResult, ok as okResult } from 'neverthrow'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Partial mock — the cache barrel is imported by half of lib; replacing it
 // wholesale dies at collection. Only the read the graph-edit path makes is stubbed.
@@ -1148,6 +1148,145 @@ const waitOnlyGraph = (): DraftGraph => ({
     plainNode(APP_WAIT_ID, 'wait', 'Wait A Bit', { waitType: 'duration', durationAmount: 5 }),
   ],
   edges: [],
+})
+
+describe('reference gate — O1 (plan 17 §0)', () => {
+  const HTTP_ID = 'http-aaaaaaaaaaaaaaaaaaaaa'
+
+  /** The trigger declares exactly one output, so `.bogus` is provably wrong. */
+  function stubTriggerOutputs() {
+    resolveGraphOutputs.mockImplementation(async () =>
+      okResult(
+        new Map([
+          [TRIGGER_ID, [{ id: `${TRIGGER_ID}.timestamp`, label: 'Timestamp', type: 'string' }]],
+        ])
+      )
+    )
+  }
+
+  function httpNode(url: string): GraphNode {
+    return {
+      id: HTTP_ID,
+      type: 'standard',
+      position: { x: 500, y: 200 },
+      data: { id: HTTP_ID, type: 'http', title: 'Post To Webhook', method: 'GET', url },
+    }
+  }
+
+  beforeEach(stubTriggerOutputs)
+  afterEach(() => resolveGraphOutputs.mockReset())
+
+  it('refuses an edit that writes a reference the outputs do not have', async () => {
+    // The S2 asymmetry, applied to tier 3: a ref this call wrote — against
+    // outputs it could see — is a defect nothing downstream contradicts.
+    const graph: DraftGraph = {
+      nodes: [triggerNode(), httpNode('https://example.com')],
+      edges: [edge(TRIGGER_ID, 'source', HTTP_ID)],
+    }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'Post To Webhook',
+      config: { url: 'https://example.com/{{Every Morning.bogus}}' },
+    })
+
+    expect(result.isOk()).toBe(true)
+    const value = result._unsafeUnwrap()
+    expect(value.applied).toBe(false)
+    expect(serviceUpdate).not.toHaveBeenCalled()
+    const blocking = value.issues.filter((i) => i.severity === 'error' && !i.preExisting)
+    expect(blocking.some((i) => /bogus/.test(i.message))).toBe(true)
+  })
+
+  it('applies the same edit when the reference resolves', async () => {
+    const graph: DraftGraph = {
+      nodes: [triggerNode(), httpNode('https://example.com')],
+      edges: [edge(TRIGGER_ID, 'source', HTTP_ID)],
+    }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'Post To Webhook',
+      config: { url: 'https://example.com/{{Every Morning.timestamp}}' },
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().applied).toBe(true)
+    expect(serviceUpdate).toHaveBeenCalled()
+  })
+
+  it('still edits a node that ALREADY carried a broken reference', async () => {
+    // The #1649 trap: the `preExisting` stamp is per NODE, so an old bad ref on
+    // the very node being edited looks fresh. Gating on that alone would make
+    // the node uneditable — the gate subtracts the draft's before-state instead.
+    const graph: DraftGraph = {
+      nodes: [triggerNode(), httpNode(`https://example.com/{{${TRIGGER_ID}.bogus}}`)],
+      edges: [edge(TRIGGER_ID, 'source', HTTP_ID)],
+    }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'Post To Webhook',
+      config: { method: 'POST' },
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().applied).toBe(true)
+    expect(persistedGraph().nodes.find((n) => n.id === HTTP_ID)?.data?.method).toBe('POST')
+    // Reported, never silent — tier 3 is still a report for what it inherited.
+    expect(
+      result._unsafeUnwrap().issues.some((i) => i.severity === 'error' && /bogus/.test(i.message))
+    ).toBe(true)
+  })
+
+  it('does not block a delete that strands a downstream reference', async () => {
+    // Removing a producer is an intentional, user-requested act, and
+    // `deleteNodes` names no touched node — so the stranded refs it leaves
+    // behind are reported, not refused.
+    const graph: DraftGraph = {
+      nodes: [triggerNode(), httpNode(`https://example.com/{{${TRIGGER_ID}.timestamp}}`)],
+      edges: [edge(TRIGGER_ID, 'source', HTTP_ID)],
+    }
+    const result = await deleteNodes(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      refs: ['Every Morning'],
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().applied).toBe(true)
+    expect(serviceUpdate).toHaveBeenCalled()
+  })
+
+  it('fails OPEN when the before-state cannot be resolved', async () => {
+    // No "before" to compare against ⇒ nothing is provably fresh. Refusing a
+    // write on an unknown is worse than flagging one.
+    let call = 0
+    resolveGraphOutputs.mockImplementation(async () => {
+      call += 1
+      // First call is the post-edit graph; the second is the before-pass.
+      return call === 1
+        ? okResult(
+            new Map([
+              [TRIGGER_ID, [{ id: `${TRIGGER_ID}.timestamp`, label: 'Timestamp', type: 'string' }]],
+            ])
+          )
+        : errResult(new Error('redis down'))
+    })
+    const graph: DraftGraph = {
+      nodes: [triggerNode(), httpNode('https://example.com')],
+      edges: [edge(TRIGGER_ID, 'source', HTTP_ID)],
+    }
+    const result = await updateNode(makeDb(graph), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      ref: 'Post To Webhook',
+      config: { url: 'https://example.com/{{Every Morning.bogus}}' },
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().applied).toBe(true)
+  })
 })
 
 describe('app blocks — authoring (§5 B3 checkpoint)', () => {

--- a/packages/lib/src/workflows/graph-edit/ops.ts
+++ b/packages/lib/src/workflows/graph-edit/ops.ts
@@ -101,6 +101,44 @@ interface MutationPlan {
 }
 
 /**
+ * Stable identity for a reference error: the node it sits on plus the ref
+ * itself. Keyed on the node ID rather than the friendly `nodeRef`, because a
+ * mutation that renames a node changes every `nodeRef` in the draft — and a
+ * rename must not make an old broken ref read as newly written.
+ */
+function refErrorKey(graph: DraftGraph, issue: Issue): string {
+  const nodeId = graph.nodes.find((n) => formatNodeRef(graph.nodes, n.id) === issue.nodeRef)?.id
+  return `${nodeId ?? issue.nodeRef ?? ''}|${issue.ref ?? issue.message}`
+}
+
+/**
+ * The reference errors the draft carried BEFORE this mutation — the set O1's
+ * gate subtracts, so only what the current call introduced can block it.
+ *
+ * Returns `null`, NOT an empty set, when the pre-edit outputs cannot be
+ * resolved: an empty set reads as "the draft carried no errors", which would
+ * make every candidate look freshly written and fail the write CLOSED on a
+ * cache blip. `null` means unknown, and unknown never blocks.
+ */
+async function inheritedRefErrorKeys(
+  organizationId: string,
+  ctx: Pick<DraftContext, 'graph' | 'lookup'>
+): Promise<Set<string> | null> {
+  const resolved = await resolveGraphOutputs(organizationId, { graph: ctx.graph })
+  if (resolved.isErr()) return null
+  const before = checkVariableRefsAgainstOutputs({
+    graph: ctx.graph,
+    outputs: resolved.value,
+    lookup: ctx.lookup,
+  })
+  return new Set(
+    before.issues
+      .filter((i) => i.severity === 'error')
+      .map((issue) => refErrorKey(ctx.graph, issue))
+  )
+}
+
+/**
  * The shared mutation pipeline. Blocking tiers (normalize errors, structural
  * errors, the mail-trigger guard) return `applied: false` with the original
  * graph untouched; everything else persists through the one seam
@@ -161,12 +199,14 @@ async function runGraphMutation(
     ...validateNodeConfigs(graph, ctx.lookup),
   ]
   let outputsMap: Map<string, UnifiedVariable[]> | undefined
+  const refIssues: Issue[] = []
   const resolved = await resolveGraphOutputs(scope.organizationId, { graph })
   if (resolved.isOk()) {
     outputsMap = resolved.value
-    issues.push(
+    refIssues.push(
       ...checkVariableRefsAgainstOutputs({ graph, outputs: outputsMap, lookup: ctx.lookup }).issues
     )
+    issues.push(...refIssues)
   }
 
   // Mark what this edit did NOT cause. A mutation reports the whole draft's
@@ -180,6 +220,38 @@ async function runGraphMutation(
   )
   for (const issue of issues) {
     if (issue.nodeRef && !touchedRefs.has(issue.nodeRef)) issue.preExisting = true
+  }
+
+  // O1 (plan 17 §0): a bad reference THIS call wrote, against outputs it could
+  // see, is the same class of defect as a fabricated `resource.operation` — the
+  // author believes it succeeded and nothing downstream contradicts it. So tier
+  // 3 gates the write for what this mutation INTRODUCED, and stays non-blocking
+  // for everything else.
+  //
+  // The asymmetry is what keeps it safe. A ref error the draft already carried
+  // never blocks, so a workflow that is already broken stays editable (#1649);
+  // `delete_nodes`, `disconnect_nodes` and `apply_template` name no touched
+  // node at all, so breaking a downstream ref by removing its producer — or
+  // applying a curated template — is still allowed.
+  const candidates = refIssues.filter((i) => i.severity === 'error' && i.preExisting !== true)
+  if (candidates.length > 0) {
+    // The node-level `preExisting` stamp is not enough on its own: editing one
+    // field of a node that ALREADY carried a broken ref marks that old error as
+    // untouched-by-nobody, and gating on it would make the node uneditable —
+    // exactly the trap this asymmetry exists to avoid. So compare against the
+    // errors the draft carried BEFORE the mutation, and block only the
+    // difference. Paid for only when there is something to block.
+    const inherited = await inheritedRefErrorKeys(scope.organizationId, ctx)
+    const introduced = inherited
+      ? candidates.filter((issue) => !inherited.has(refErrorKey(graph, issue)))
+      : []
+    if (introduced.length > 0) {
+      return ok({
+        applied: false,
+        issues,
+        graphSummary: buildGraphSummary(ctx.graph, ctx.lookup, ctx.triggerType),
+      })
+    }
   }
 
   // NO-OP SHORT-CIRCUIT: a mutation whose cleaned graph hashes to what was


### PR DESCRIPTION
Plan 17 **O1** (`plans/kopilot/workflow/17-app-block-authoring-and-connections.md` §0). A decision, not a bug fix — it deliberately changes a locked design choice, so the reasoning is below in full.

## The problem

Tier-3 reference checking was non-blocking **in both directions**. `#1705` made app-block outputs resolve, so `{{FedEx.record.id}}` finally produced an `error` naming the real candidates — but the write still landed. Live: the agent rewrote a bad ref, the write applied, and it reported *"the node still has a stale broken reference error"* — its own, one call old.

A ref the agent wrote **in this very call**, against outputs the same call could see, is the same class of defect as a fabricated `resource.operation`: the author believes it succeeded and nothing downstream contradicts it.

## The gate, and why it is asymmetric

A mutation is refused for the ref errors it **introduces**. Everything the draft already carried is still checked, still reported, still persisted — so a workflow that is already broken stays editable (the #1649 trap). `delete_nodes`, `disconnect_nodes`, `apply_template` and `set_workflow_details` set no `touchedNodeId`/`newNodeIds`, so they are exempt **by construction**, not by a flag: stranding a downstream ref by deleting its producer is a user-requested act and stays allowed. In practice only `add_node` and `update_node` can realistically trip it.

## Two things the obvious implementation gets wrong

**1. The `preExisting` stamp is per NODE.** Editing one field of a node that *already* carried a broken ref leaves that old error unstamped — it reads as freshly written, and gating on the stamp alone makes that node **uneditable**, which is exactly the trap the asymmetry exists to avoid. So the gate re-resolves outputs for the **pre-edit** graph, re-runs the check over it, and blocks only the difference. Paid for only when there is a candidate to block.

Keyed by **node id**, not the friendly `nodeRef`: a mutation that renames a node changes every ref in the draft, and a rename must not make an old error read as new.

**2. Unknown must not mean "clean".** The before-pass returns `null`, not an empty `Set`, when outputs cannot be resolved. An empty Set reads as *"the draft carried no errors"* — every candidate then looks fresh and the write fails **closed** on a cache blip. My first version had exactly that inversion; the fail-open test caught it.

## Also in this PR

`mutationToToolResult` sorts fresh issues first and labels inherited ones *"(pre-existing — already in the draft, not what blocked this edit)"*. A refused edit lists the whole draft's errors, and without the split the caller reads damage it did not do as the reason it was refused — then "fixes" a node it never touched. This was the plan's *cheaper alternative* to the gate; it turns out to be worth having **as well**.

## Tests

Five new cases in `graph-edit/__tests__/ops.test.ts` — refuses a freshly-written bad ref (nothing persisted), applies the same edit when the ref resolves, **still edits a node that already carried a broken ref**, does not block a delete that strands a downstream ref, and fails open when the before-state cannot be resolved.

`vitest run src/workflows/graph-edit src/ai/kopilot/capabilities/workflow-builder` — 266 pass. `tsc --noEmit` clean for the touched files. Biome clean.

## Doc

`plans/kopilot/workflow/03-graph-edit-service.md` §5 tier 3 said *"Reference (non-blocking)"*; amended to state the asymmetry and the fail-open rule. (`plans/` is gitignored, so that edit is local-only by design.)