### PR TITLE
feat(channels): meta dm backfill, plus the identity bugs it exposed

### DIFF
--- a/packages/lib/scripts/probe-meta-conversations.ts
+++ b/packages/lib/scripts/probe-meta-conversations.ts
@@ -1,0 +1,150 @@
+// packages/lib/scripts/probe-meta-conversations.ts
+//
+// Throwaway diagnostic for the ONE thing WS7 could not verify from a desk: what Graph
+// actually returns on the conversation-messages edge.
+//
+// It answers two open questions, both of which decide whether the backfill is correct:
+//
+//   1. **Scalar or object?** `GET /{conversationId}/messages?fields=…,message` — is
+//      `message` a plain string, or an object with `text`/`mid`/`attachments`? The old
+//      sync requested `message{text,attachments,mid}`, which is an invalid expansion on
+//      a scalar (and therefore possibly a hard failure), then read `message.mid` off it.
+//      `social/conversation-message.ts` tolerates both shapes; this says which one the
+//      code should keep.
+//
+//   2. **Gate step 2b — is it the same id space?** Are the participant ids on
+//      `/{pageId}/conversations` the same PSIDs the webhook puts in `sender.id`? If not,
+//      the sync computes `dm:{pageId}:{otherIdSpace}` while the webhook computed
+//      `dm:{pageId}:{psid}` — two keys, one conversation. Compare the printed
+//      participant ids against `Message.metadata.meta_webhook_event.sender.id` for the
+//      same customer.
+//
+// Nothing is written and nothing is ingested — this only reads.
+//
+// usage: npx dotenv -- npx tsx packages/lib/scripts/probe-meta-conversations.ts <integrationId> [conversationCount]
+
+import { database as db, schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import { getChannelTokens } from '../src/providers/channel-token-accessor'
+import { listConversationMessages, listConversations } from '../src/providers/social/api'
+import { socialThreadKey } from '../src/providers/social/thread-key'
+
+const [integrationId, countArg] = process.argv.slice(2)
+if (!integrationId) {
+  console.error(
+    'usage: probe-meta-conversations.ts <integrationId> [conversationCount]\n' +
+      '  e.g. npx dotenv -- npx tsx packages/lib/scripts/probe-meta-conversations.ts wz40u14ic6uvliidcbpeojk1'
+  )
+  process.exit(1)
+}
+const conversationCount = Number(countArg ?? 3)
+
+const [integration] = await db
+  .select({
+    id: schema.Integration.id,
+    provider: schema.Integration.provider,
+    metadata: schema.Integration.metadata,
+  })
+  .from(schema.Integration)
+  .where(eq(schema.Integration.id, integrationId))
+  .limit(1)
+
+if (!integration) {
+  console.error(`integration ${integrationId} not found`)
+  process.exit(1)
+}
+if (integration.provider !== 'facebook' && integration.provider !== 'instagram') {
+  console.error(`integration ${integrationId} is a ${integration.provider} channel, not FB/IG`)
+  process.exit(1)
+}
+
+const metadata = (integration.metadata ?? {}) as {
+  pageId?: string
+  pageName?: string
+  instagramBusinessAccountId?: string
+  instagramUsername?: string
+  backfillCutoffAt?: string
+  initialBackfillCompletedAt?: string
+  backfill?: unknown
+}
+const pageId = metadata.pageId
+if (!pageId) {
+  console.error('integration metadata has no pageId')
+  process.exit(1)
+}
+
+const isInstagram = integration.provider === 'instagram'
+// Our identity in the thread key: the Page id on Messenger, the IG business account id
+// on Instagram Direct. NOT interchangeable.
+const ourId = isInstagram ? (metadata.instagramBusinessAccountId ?? pageId) : pageId
+
+const { accessToken } = await getChannelTokens(integrationId)
+if (!accessToken) {
+  console.error('no access token on the linked credential')
+  process.exit(1)
+}
+
+console.log('--- channel -------------------------------------------------------------')
+console.log('provider                  :', integration.provider)
+console.log('pageId (edge address)     :', pageId)
+console.log('ourId  (thread-key side)  :', ourId)
+console.log('backfillCutoffAt          :', metadata.backfillCutoffAt ?? '<NOT STAMPED>')
+console.log('initialBackfillCompletedAt:', metadata.initialBackfillCompletedAt ?? '<not set>')
+console.log('backfill progress         :', JSON.stringify(metadata.backfill ?? null))
+
+console.log('\n--- (a) GET /{pageId}/conversations --------------------------------------')
+const conversations = await listConversations({
+  pageId,
+  pageAccessToken: accessToken,
+  platform: isInstagram ? 'instagram' : 'messenger',
+  limit: conversationCount,
+})
+console.log(JSON.stringify(conversations, null, 2))
+
+const first = conversations.data?.[0]
+if (!first?.id) {
+  console.log('\nno conversations returned — nothing further to probe')
+  process.exit(0)
+}
+
+// Gate step 2b: this is the id the backfill will key on. Compare it against the PSID in
+// a stored webhook payload for the same person.
+const participants = first.participants?.data ?? []
+const counterpart = participants.find((p) => p.id && p.id !== ourId && p.id !== pageId)
+console.log('\n--- (b) derived identity for the first conversation -----------------------')
+console.log('conversation id           :', first.id)
+console.log('participants             :', JSON.stringify(participants))
+console.log('counterpart id           :', counterpart?.id ?? '<NONE FOUND>')
+console.log(
+  'thread key the sync would write:',
+  counterpart?.id ? socialThreadKey(ourId, counterpart.id) : '<n/a>'
+)
+console.log(
+  '  ↳ compare with Message.metadata.meta_webhook_event.sender.id for the same customer;\n' +
+    '    a mismatch means the REST and webhook id spaces differ (gate step 2b).'
+)
+
+console.log('\n--- (c) GET /{conversationId}/messages -----------------------------------')
+const messages = await listConversationMessages({
+  conversationId: first.id,
+  pageAccessToken: accessToken,
+  limit: 5,
+})
+console.log(JSON.stringify(messages, null, 2))
+
+const sample = messages.data?.[0]
+console.log('\n--- the answer -----------------------------------------------------------')
+console.log('typeof message.message   :', sample ? typeof sample.message : '<no messages>')
+if (sample && sample.message !== null && typeof sample.message === 'object') {
+  console.log('message object keys      :', Object.keys(sample.message as object))
+  console.log('→ OBJECT shape. Keep the object branch in conversation-message.ts.')
+} else if (sample) {
+  console.log('→ SCALAR shape, as documented. The object branch can be deleted.')
+}
+console.log('node id                  :', sample?.id)
+console.log(
+  '  ↳ if this is an `m_…` string it is almost certainly the same `mid` the webhook\n' +
+    '    stamps, which makes the externalId fallback exact rather than merely adequate.'
+)
+
+process.exit(0)

--- a/packages/lib/src/channels/social-provisioning-hook.ts
+++ b/packages/lib/src/channels/social-provisioning-hook.ts
@@ -176,7 +176,15 @@ async function fetchUserPages(token: string): Promise<FacebookPage[]> {
   return data.data
 }
 
-/** The Instagram Business Account linked to a Page, if any. */
+/**
+ * The Instagram Business Account linked to a Page, if any — the per-page probe.
+ *
+ * Only reached when `/me/accounts` did not already expand the field (it asks for
+ * `instagram_business_account{id,username}` in the same request), so this is the
+ * fallback, not the primary read. Failures are logged rather than swallowed
+ * silently: a null here is indistinguishable from "no linked account", and that
+ * ambiguity is exactly what produced a misleading "link the account" error.
+ */
 async function fetchInstagramAccount(
   pageId: string,
   pageToken: string
@@ -185,14 +193,27 @@ async function fetchInstagramAccount(
     const url = `https://graph.facebook.com/${apiVersion()}/${pageId}?fields=instagram_business_account{id,username}&access_token=${pageToken}`
     const res = await fetch(url)
     const data = await res.json()
-    if (res.ok && data.instagram_business_account) {
+    if (res.ok && data.instagram_business_account?.id) {
       return {
         id: data.instagram_business_account.id,
         username: data.instagram_business_account.username,
       }
     }
+    if (!res.ok || data.error) {
+      logger.warn('Could not read instagram_business_account for a Page', {
+        pageId,
+        status: res.status,
+        code: data?.error?.code,
+        subcode: data?.error?.error_subcode,
+        error: data?.error?.message,
+      })
+    }
     return null
-  } catch {
+  } catch (error) {
+    logger.warn('instagram_business_account probe errored', {
+      pageId,
+      error: error instanceof Error ? error.message : String(error),
+    })
     return null
   }
 }
@@ -236,8 +257,19 @@ async function discoverIdentity(
   }
 
   // Instagram: pick the first Page with a linked Instagram Business Account.
+  //
+  // `/me/accounts` already expanded `instagram_business_account{id,username}`, so
+  // read that first and only probe the Page node when it is absent. The probe used
+  // to run unconditionally: N extra Graph round trips per connect, and — because it
+  // returns null on any failure — a transient error was reported to the user as
+  // "no linked Instagram account", which is a different problem with a different fix.
   for (const page of pages) {
-    const igAccount = await fetchInstagramAccount(page.id, page.access_token)
+    const igAccount: InstagramAccount | null = page.instagram_business_account?.id
+      ? {
+          id: page.instagram_business_account.id,
+          username: page.instagram_business_account.username ?? '',
+        }
+      : await fetchInstagramAccount(page.id, page.access_token)
     if (igAccount) {
       const longLivedPageToken = await exchangeForLongLived(page.access_token)
       return {
@@ -252,9 +284,17 @@ async function discoverIdentity(
       }
     }
   }
+  // Deliberately names BOTH causes. An absent `instagram_business_account` does not
+  // prove there is no linked account: Graph omits a permission-gated field rather
+  // than erroring, so a grant without `instagram_basic` answers exactly like a Page
+  // with nothing linked. The Instagram scopes are only requestable once the app's
+  // Instagram use case is configured for "API setup with Facebook login" — until
+  // then the login dialog rejects them as invalid and this is what the user sees.
   throw new Error(
-    'No managed Facebook Page with a linked Instagram Professional account was found. ' +
-      'Link the account and grant permissions, then retry.'
+    `No linked Instagram Professional account was found on any of the ${pages.length} managed ` +
+      `Facebook Page(s) (${pages.map((page) => page.name).join(', ')}). Either no Instagram ` +
+      'Professional account is linked to the Page, or the connection was granted without the ' +
+      'instagram_basic permission — in which case Graph hides the link rather than reporting it.'
   )
 }
 

--- a/packages/lib/src/connections/providers/defs.ts
+++ b/packages/lib/src/connections/providers/defs.ts
@@ -159,18 +159,39 @@ export const PLATFORM_PROVIDER_DEFS: PlatformProviderDef[] = [
     providerKey: 'facebook',
     connectionType: 'oauth2-code',
     label: 'Facebook',
-    global: false,
+    // ORG-scoped, like the `gmail` / `outlookMail` channel definitions above and unlike
+    // the per-user `googleOAuth2Api` / `outlookOAuth2Api` workflow connections. A Page is
+    // a company asset: whoever authorises it, the channel belongs to the org.
+    //
+    // This was `false`, and the cost was not theoretical. `global` decides the credential's
+    // scope at the OAuth callback (`userId: personal ? userId : global ? null : userId`),
+    // so every Page connect minted a USER-scoped credential; `connections.list` derives
+    // scope as `userId ? 'user' : 'organization'`, so the row read back as `user` while
+    // the connect flow believed it was an `organization` connect. `buildConnectionVerify`
+    // matches on `r.scope === a.scope`, so its poll never matched, and the connect dialog
+    // span on "Connecting…" until the 180s timeout — on a connect that had *succeeded*.
+    // A cross-origin dev tunnel makes it worse but is not the cause: the tunnel only
+    // drops the popup `postMessage`, which is exactly when the verify backstop is supposed
+    // to carry the settle. (This is WS8 in plans/channels/facebook-instagram-runtime-fixes.md.)
+    //
+    // Personal connects are unaffected — `metadata.personal` is checked first, which is how
+    // `gmail` is global AND still supports a personal mailbox.
+    global: true,
     oauth2AuthorizeUrl: 'https://www.facebook.com/v26.0/dialog/oauth',
     oauth2AccessTokenUrl: 'https://graph.facebook.com/v26.0/oauth/access_token',
-    // pages_show_list + business_management are declared dependencies of the
-    // messaging permissions; without business_management, pages owned by a
-    // Business portfolio are missing from /me/accounts at connect time.
+    // `business_management` REMOVED 2026-08-18, under test. It was requested on the
+    // claim that Pages owned by a Business portfolio are absent from /me/accounts
+    // without it — a claim asserted in two places and verified in none. Meta defines
+    // the permission as managing/claiming business assets on behalf of other
+    // businesses, which is not what we do, and App Review asks for examples of exactly
+    // that — making it the riskiest line in the submission. If a Business-portfolio
+    // Page connects fine without it, it stays out. See
+    // plans/channels/meta-app-review-submission.md §1.
     oauth2Scopes: [
       'pages_messaging',
       'pages_manage_metadata',
       'pages_read_engagement',
       'pages_show_list',
-      'business_management',
     ],
     systemClientIdEnv: 'FACEBOOK_APP_ID',
     systemClientSecretEnv: 'FACEBOOK_APP_SECRET',
@@ -182,10 +203,37 @@ export const PLATFORM_PROVIDER_DEFS: PlatformProviderDef[] = [
     providerKey: 'instagram',
     connectionType: 'oauth2-code',
     label: 'Instagram',
-    global: false,
+    // ORG-scoped — same reasoning as the `facebook` entry above; see the note there for
+    // why `false` left the connect dialog spinning on a successful connect.
+    global: true,
     // Instagram Messaging authorizes through the Facebook login dialog + Facebook app.
     oauth2AuthorizeUrl: 'https://www.facebook.com/v26.0/dialog/oauth',
     oauth2AccessTokenUrl: 'https://graph.facebook.com/v26.0/oauth/access_token',
+    // `business_management` removed here too — same test, see the facebook entry.
+    //
+    // ⚠️ DO NOT rename the two `instagram_*` scopes to `instagram_business_*`.
+    // A connect attempt on 2026-08-18 failed with `Invalid Scopes: instagram_basic,
+    // instagram_manage_messages`, and the obvious-looking fix is the wrong one:
+    //
+    //   - `instagram_basic` / `instagram_manage_messages` are the CURRENT, non-deprecated
+    //     names for **Instagram API with Facebook Login** (host graph.facebook.com), which
+    //     is the configuration this whole channel is built on — page token, Page-level
+    //     `subscribed_apps`, `/{page-id}/messages`.
+    //     https://developers.facebook.com/docs/instagram-platform/overview/
+    //   - `instagram_business_basic` / `instagram_business_manage_messages` belong to the
+    //     OTHER configuration, **Instagram API with Instagram Login** (host
+    //     graph.instagram.com, Instagram's own OAuth dialog). Meta's 2025-01-27 rename was
+    //     `business_basic` → `instagram_business_basic` *within that namespace*; it did not
+    //     touch the Facebook-Login names. Sending them through the Facebook dialog would be
+    //     rejected as invalid too.
+    //
+    // "Invalid Scopes" here means the APP cannot request the permission, not that the name
+    // is wrong: on Meta's use-case dashboard a permission only becomes requestable once the
+    // matching use case exists. The Instagram use case must be added and customized to
+    // "API setup with Facebook login" (+ "Add required messaging permissions"), alongside
+    // Facebook Login for Business and Messenger-with-Instagram-settings. That is a manual
+    // dashboard step — no code change fixes it. Note only the two `instagram_*` scopes were
+    // rejected, so the Pages/Messenger side of the app is already configured.
     oauth2Scopes: [
       'instagram_basic',
       'instagram_manage_messages',
@@ -193,7 +241,6 @@ export const PLATFORM_PROVIDER_DEFS: PlatformProviderDef[] = [
       'pages_manage_metadata',
       'pages_read_engagement',
       'pages_show_list',
-      'business_management',
     ],
     systemClientIdEnv: 'FACEBOOK_APP_ID',
     systemClientSecretEnv: 'FACEBOOK_APP_SECRET',

--- a/packages/lib/src/ingest/contacts/__tests__/find-or-create-identifier-types.test.ts
+++ b/packages/lib/src/ingest/contacts/__tests__/find-or-create-identifier-types.test.ts
@@ -1,0 +1,164 @@
+// packages/lib/src/ingest/contacts/__tests__/find-or-create-identifier-types.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// --- mocks -----------------------------------------------------------------
+
+// Partial mock: `@auxx/logger/run-log` imports sink-registration helpers from
+// this barrel at module load, so a full replacement breaks whichever test file
+// happens to load it first.
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('../../companies/link-contact', () => ({
+  linkContactToCompanyByDomain: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../../domain/classifier', () => ({
+  getOwnDomains: vi.fn().mockResolvedValue(new Set<string>()),
+}))
+
+vi.mock('../has-sent-to', () => ({
+  hasOrganizationSentToParticipant: vi.fn().mockResolvedValue(true),
+}))
+
+import { findOrCreateContactForParticipant } from '../find-or-create'
+
+const create = vi.fn()
+const findOrCreate = vi.fn()
+const findByField = vi.fn()
+
+function makeCtx() {
+  return {
+    organizationId: 'org_1',
+    db: {} as never,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    crudHandler: { create, findOrCreate, findByField },
+    integrationSettings: { recordCreation: { mode: 'all' } },
+    ownDomainsByOrg: new Map(),
+    companyIdByDomain: new Map(),
+  } as never
+}
+
+function participant(identifierType: string, identifier: string) {
+  return {
+    id: 'participant_1',
+    identifier,
+    identifierType,
+    displayName: 'Sender',
+    isInternal: false,
+  } as never
+}
+
+const inbound = { isInbound: true, role: 'FROM' as never }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  create.mockResolvedValue({ instance: { id: 'contact_new' } })
+  findOrCreate.mockResolvedValue({ instance: { id: 'contact_new' } })
+  findByField.mockResolvedValue(null)
+})
+
+describe('findOrCreateContactForParticipant — which identifier dedupes on which field', () => {
+  it('dedupes an EMAIL participant on primary_email', async () => {
+    const contactId = await findOrCreateContactForParticipant(
+      makeCtx(),
+      participant('EMAIL', 'jane@example.com'),
+      inbound
+    )
+
+    expect(contactId).toBe('contact_new')
+    expect(findOrCreate).toHaveBeenCalledWith(
+      'contact',
+      { primary_email: 'jane@example.com' },
+      expect.objectContaining({ primary_email: ['jane@example.com'] })
+    )
+  })
+
+  // Regression: the type ladder used to END in `primary_email`, so every
+  // identifier that was not a chat visitor or a phone was treated as an email
+  // address. A Meta PSID went into `findByField('primary_email', '9990197…')`
+  // and into the create payload, where the write validator rejected it as an
+  // uncoercible value — leaving a contact with NO identifier and therefore no
+  // dedupe key, so each conversation minted another one.
+  for (const [type, source, identifier] of [
+    ['FACEBOOK_PSID', 'facebook', '9990197041092280'],
+    ['INSTAGRAM_IGSID', 'instagram', '17841400000000000'],
+  ] as const) {
+    it(`dedupes a ${type} through the identity index, never primary_email`, async () => {
+      const contactId = await findOrCreateContactForParticipant(
+        makeCtx(),
+        participant(type, identifier),
+        inbound
+      )
+
+      expect(contactId).toBe('contact_new')
+      // Namespaced, and looked up on `external_id` — which the lookup core
+      // routes to `RecordIdentity`, not to a FieldValue cell.
+      expect(findOrCreate).toHaveBeenCalledWith(
+        'contact',
+        { external_id: `${source}:${identifier}` },
+        // ARRAY-valued on the create side: that is what makes
+        // `UnifiedCrudHandler.create` mirror it into the index.
+        expect.objectContaining({ external_id: [`${source}:${identifier}`] })
+      )
+      const created = findOrCreate.mock.calls[0]?.[2] as Record<string, unknown>
+      expect(created).not.toHaveProperty('primary_email')
+      expect(created).not.toHaveProperty('phone')
+      expect(create).not.toHaveBeenCalled()
+    })
+
+    it(`reuses the contact an existing ${type} identity already points at`, async () => {
+      // Selective mode is where the lookup is explicit; in mode `all` the same
+      // dedupe happens one level down, inside `handler.findOrCreate`.
+      const ctx = makeCtx() as unknown as { integrationSettings: unknown }
+      ctx.integrationSettings = { recordCreation: { mode: 'selective' } }
+      findByField.mockResolvedValue({ id: 'contact_existing' })
+
+      const contactId = await findOrCreateContactForParticipant(
+        ctx as never,
+        participant(type, identifier),
+        inbound
+      )
+
+      expect(contactId).toBe('contact_existing')
+      expect(findByField).toHaveBeenCalledWith('contact', 'external_id', `${source}:${identifier}`)
+      expect(create).not.toHaveBeenCalled()
+      expect(findOrCreate).not.toHaveBeenCalled()
+    })
+  }
+
+  it('looks a social participant up on external_id in mode "none", and never creates', async () => {
+    const ctx = makeCtx() as unknown as { integrationSettings: unknown }
+    ctx.integrationSettings = { recordCreation: { mode: 'none' } }
+
+    const contactId = await findOrCreateContactForParticipant(
+      ctx as never,
+      participant('FACEBOOK_PSID', '9990197041092280'),
+      inbound
+    )
+
+    expect(contactId).toBeNull()
+    expect(findByField).toHaveBeenCalledWith('contact', 'external_id', 'facebook:9990197041092280')
+    expect(create).not.toHaveBeenCalled()
+    expect(findOrCreate).not.toHaveBeenCalled()
+  })
+
+  it('has no dedupe key at all for a chat visitor or a short code — those create every time', async () => {
+    // The `null` arm is deliberate, not an oversight: neither value is an
+    // identity another system issues, so `Participant.entityInstanceId` is the
+    // only stable link and the caller writes it back.
+    for (const p of [participant('CHAT_VISITOR', 'sess_abc123'), participant('PHONE', '12345')]) {
+      vi.clearAllMocks()
+      create.mockResolvedValue({ instance: { id: 'contact_new' } })
+
+      await findOrCreateContactForParticipant(makeCtx(), p, inbound)
+
+      expect(findByField).not.toHaveBeenCalled()
+      expect(findOrCreate).not.toHaveBeenCalled()
+      expect(create).toHaveBeenCalledTimes(1)
+    }
+  })
+})

--- a/packages/lib/src/ingest/contacts/external-id.ts
+++ b/packages/lib/src/ingest/contacts/external-id.ts
@@ -15,7 +15,7 @@
  * helper when the source is parsed from a page the user is viewing.
  */
 
-export type ServerExternalIdSource = 'chat' | 'shopify'
+export type ServerExternalIdSource = 'chat' | 'shopify' | 'facebook' | 'instagram'
 
 export function buildServerExternalId(source: ServerExternalIdSource, raw: string): string {
   const v = raw.trim()
@@ -35,4 +35,28 @@ export function chatExternalId(userId: string): string {
  */
 export function shopifyExternalId(shopDomain: string, customerId: string): string {
   return buildServerExternalId('shopify', `${shopDomain.trim()}:${customerId.trim()}`)
+}
+
+/**
+ * Build the canonical `facebook:<psid>` / `instagram:<igsid>` external id for a
+ * Meta DM counterpart.
+ *
+ * **Deliberately NOT account-scoped, unlike `shopifyExternalId`.** That helper
+ * folds the shop domain in because Shopify customer ids are per-store sequences
+ * that genuinely collide across two stores in one org. A PSID is not a sequence:
+ * Meta issues one per (Page, person) pair out of a global id space and does not
+ * reuse them, so two Pages under one org cannot mint the same value and the
+ * `RecordIdentity_identity_key` unique index cannot collide. Scoping would also
+ * mean threading the active integration's Page id down into the contact layer,
+ * which ingest deliberately does not pass — `ctx.ownIdentities` holds the org's
+ * page ids as an unordered SET, so it cannot say which Page a given PSID came
+ * from, which is exactly the question scoping would need answered.
+ *
+ * What this shares with Shopify is the `RecordIdentity_record_kind_key` limit:
+ * one identity per source per contact. If the same human DMs two of our Pages
+ * they hold two PSIDs, and only one can be indexed against a single contact —
+ * the same constraint a two-store Shopify org already lives with.
+ */
+export function metaExternalId(platform: 'facebook' | 'instagram', id: string): string {
+  return buildServerExternalId(platform, id)
 }

--- a/packages/lib/src/ingest/contacts/find-or-create.ts
+++ b/packages/lib/src/ingest/contacts/find-or-create.ts
@@ -5,12 +5,12 @@ import {
   ParticipantRole as ParticipantRoleEnum,
 } from '@auxx/database/enums'
 import type { ParticipantEntity as Participant, ParticipantRole } from '@auxx/database/types'
-import { formatPhoneNumber } from '@auxx/utils'
 import { linkContactToCompanyByDomain } from '../companies/link-contact'
 import type { IngestContext } from '../context'
 import { getOwnDomains } from '../domain/classifier'
 import { getNamesFromParticipant } from '../participants/display'
 import { hasOrganizationSentToParticipant } from './has-sent-to'
+import { contactIdentityCandidate } from './identity-candidate'
 
 /** Roles that make a participant a recipient of an outbound message. */
 const OUTBOUND_RECIPIENT_ROLES: readonly ParticipantRole[] = [
@@ -62,36 +62,19 @@ export async function findOrCreateContactForParticipant(
     const handler = ctx.crudHandler
     const force = options?.force ?? false
 
-    // Chat-widget visitors are identified by an opaque session id (cookie value),
-    // not an email/phone — `Participant.identifier` is a cuid, not addressable.
-    // The other identifier types all carry a real address we can use as a dedupe
-    // key on the contact (`primary_email` / `phone`); chat visitors don't, so we
-    // skip the identifier-keyed lookup and rely on `Participant.entityInstanceId`
-    // for dedupe on the caller side.
-    const isChatVisitor = participant.identifierType === 'CHAT_VISITOR'
+    // Which contact attribute this identifier dedupes on — `primary_email`,
+    // `phone`, or the `RecordIdentity` index via `external_id`. See
+    // `contactIdentityCandidate` for why the mapping is per-type and what a
+    // `null` costs. Social ids (PSID/IGSID) resolve to a namespaced
+    // `external_id` (`"facebook:123…"`), which is an index row, not a cell.
+    const identity = contactIdentityCandidate(participant)
 
-    // A PHONE participant is not guaranteed to carry a dialable number: SMS
-    // short codes (`12345`) and alphanumeric sender IDs (`AUXX`) arrive with
-    // the same identifier type. The write validator normalizes to E.164 and
-    // REJECTS those, so writing one would throw inside ingest. Treat them like
-    // chat visitors — no phone value, no identifier-keyed dedupe.
-    const isAddressablePhone =
-      participant.identifierType !== IdentifierTypeEnum.PHONE ||
-      formatPhoneNumber(participant.identifier) !== null
-
-    if (!isAddressablePhone) {
+    if (!identity && participant.identifierType === IdentifierTypeEnum.PHONE) {
       ctx.logger.debug('Participant phone identifier is not a dialable number', {
         participantId: participant.id,
         identifier: participant.identifier,
       })
     }
-
-    const systemAttr =
-      isChatVisitor || !isAddressablePhone
-        ? null
-        : participant.identifierType === IdentifierTypeEnum.PHONE
-          ? 'phone'
-          : 'primary_email'
 
     // Never auto-create a contact for the integration owner's own addresses.
     // `force` is the documented escape hatch for the user-initiated
@@ -105,14 +88,22 @@ export async function findOrCreateContactForParticipant(
     }
 
     if (!force && mode === 'none') {
-      if (!systemAttr) return null
-      const existing = await handler.findByField('contact', systemAttr, participant.identifier)
+      if (!identity) return null
+      const existing = await handler.findByField(
+        'contact',
+        identity.systemAttribute,
+        identity.value
+      )
       return existing?.id ?? null
     }
 
     if (!force && mode === 'selective' && messageContext) {
-      if (systemAttr) {
-        const existing = await handler.findByField('contact', systemAttr, participant.identifier)
+      if (identity) {
+        const existing = await handler.findByField(
+          'contact',
+          identity.systemAttribute,
+          identity.value
+        )
         if (existing) return existing.id
       }
 
@@ -141,29 +132,26 @@ export async function findOrCreateContactForParticipant(
       contact_status: 'ACTIVE',
     }
 
-    if (participant.identifierType === IdentifierTypeEnum.PHONE && isAddressablePhone) {
-      // Array-wrapped for shape consistency with multi-value fields
-      // (options.multi) — the write path auto-unwraps length-1 arrays on
-      // single-value fields. Create-only: matched contacts never get their
-      // identifier re-written here (no-append is the locked ingest decision).
-      createValues.phone = [participant.identifier]
-    }
-
     let contactId: string
-    if (isChatVisitor || !systemAttr) {
+    if (!identity) {
       // No identifier-keyed dedupe — just create. The caller writes the new id
-      // back to `Participant.entityInstanceId`, which is the only stable dedupe
-      // key we have for chat visitors.
+      // back to `Participant.entityInstanceId`, which is then the only dedupe
+      // key: a chat visitor's session cuid and an SMS short code are not
+      // identities anyone else issues.
       const { instance } = await handler.create('contact', createValues)
       contactId = instance.id
     } else {
       // `findBy` stays scalar (it drives the lookup); the create data gets the
       // array-wrapped identifier so a fresh contact's email/phone lands in the
       // multi-value shape (createValues spreads after findBy in findOrCreate).
-      const findBy: Record<string, unknown> = { [systemAttr]: participant.identifier }
+      // For `external_id` the array form is load-bearing rather than cosmetic:
+      // `UnifiedCrudHandler.create` peels an ARRAY-valued `external_id` off and
+      // mirrors each entry into `RecordIdentity`; a scalar would fall through to
+      // the FieldValue writer for an attribute that no longer exists as a cell.
+      const findBy: Record<string, unknown> = { [identity.systemAttribute]: identity.value }
       const { instance } = await handler.findOrCreate('contact', findBy, {
         ...createValues,
-        [systemAttr]: [participant.identifier],
+        [identity.systemAttribute]: [identity.value],
       })
       contactId = instance.id
     }

--- a/packages/lib/src/ingest/contacts/identity-candidate.ts
+++ b/packages/lib/src/ingest/contacts/identity-candidate.ts
@@ -1,0 +1,76 @@
+// packages/lib/src/ingest/contacts/identity-candidate.ts
+
+import type { IdentifierTypeValue } from '@auxx/database/enums'
+import { IdentifierType as IdentifierTypeEnum } from '@auxx/database/enums'
+import type { ParticipantEntity as Participant } from '@auxx/database/types'
+import { formatPhoneNumber } from '@auxx/utils'
+import { metaExternalId } from './external-id'
+
+/**
+ * The platform a social identifier belongs to, and therefore its
+ * `RecordIdentity.source` namespace.
+ *
+ * A PSID/IGSID is not an address — it is an opaque id that only means anything
+ * inside one platform's id space, which is exactly what the identity index is
+ * for. `metaExternalId` builds the stored `"<source>:<id>"` value, the same
+ * retired-`external_id` encoding `parseExternalIdentity` splits on the first
+ * colon.
+ */
+const SOCIAL_PLATFORM: Partial<Record<IdentifierTypeValue, 'facebook' | 'instagram'>> = {
+  [IdentifierTypeEnum.FACEBOOK_PSID]: 'facebook',
+  [IdentifierTypeEnum.INSTAGRAM_IGSID]: 'instagram',
+}
+
+export interface ContactIdentityCandidate {
+  /**
+   * The contact attribute this identifier dedupes on. `external_id` is not a
+   * FieldValue — the lookup core routes it to the `RecordIdentity` index, and
+   * `UnifiedCrudHandler.create` mirrors an array-valued `external_id` into the
+   * same index instead of writing a cell.
+   */
+  systemAttribute: 'primary_email' | 'phone' | 'external_id'
+  /** What to look up and write. Namespaced (`"facebook:123…"`) for `external_id`. */
+  value: string
+}
+
+/**
+ * Which contact attribute, if any, a participant's identifier dedupes on.
+ *
+ * Decided PER TYPE and never by falling through to email. This replaced a ladder
+ * that *ended* in `primary_email`, so every type that was not a chat visitor or a
+ * phone was assumed to be an email address: a 17-digit Meta PSID went into both
+ * the lookup and the create payload, the write validator rejected it as an
+ * uncoercible value, the FieldValue never landed, and the contact came out
+ * carrying no identifier at all — nothing left to dedupe on, so every
+ * conversation minted another contact.
+ *
+ * Returns `null` when the identifier is not addressable at all:
+ *  - `CHAT_VISITOR` — an opaque session cuid, not an identity anyone else issues.
+ *  - a `PHONE` that is not dialable — SMS short codes (`12345`) and alphanumeric
+ *    sender ids (`AUXX`) share the type, and the write validator normalizes to
+ *    E.164 and rejects those.
+ *  - an identifier type added later that has not opted in here.
+ *
+ * A `null` candidate costs only the identifier-keyed dedupe — those participants
+ * still resolve through `Participant.entityInstanceId`, written back by the
+ * caller. That is why the unknown-type arm is `null` and not a guess: a missing
+ * dedupe key is recoverable, a wrong one corrupts the contact graph silently.
+ */
+export function contactIdentityCandidate(
+  participant: Pick<Participant, 'identifier' | 'identifierType'>
+): ContactIdentityCandidate | null {
+  const { identifier, identifierType } = participant
+
+  if (identifierType === IdentifierTypeEnum.EMAIL) {
+    return { systemAttribute: 'primary_email', value: identifier }
+  }
+
+  if (identifierType === IdentifierTypeEnum.PHONE) {
+    return formatPhoneNumber(identifier) ? { systemAttribute: 'phone', value: identifier } : null
+  }
+
+  const platform = SOCIAL_PLATFORM[identifierType as IdentifierTypeValue]
+  return platform
+    ? { systemAttribute: 'external_id', value: metaExternalId(platform, identifier) }
+    : null
+}

--- a/packages/lib/src/ingest/index.ts
+++ b/packages/lib/src/ingest/index.ts
@@ -16,7 +16,12 @@ export { linkContactToCompanyByDomain } from './companies/link-contact'
 // Contacts
 export { createContactAfterOutboundMessage } from './contacts/create-after-outbound'
 export { ensureContactsForRecipients } from './contacts/ensure-for-recipients'
-export { buildServerExternalId, chatExternalId, shopifyExternalId } from './contacts/external-id'
+export {
+  buildServerExternalId,
+  chatExternalId,
+  metaExternalId,
+  shopifyExternalId,
+} from './contacts/external-id'
 export { findOrCreateContactForParticipant } from './contacts/find-or-create'
 export type {
   FindOrCreateContactFromJwtInput,
@@ -24,6 +29,10 @@ export type {
 } from './contacts/find-or-create-from-jwt'
 export { findOrCreateContactFromJwt } from './contacts/find-or-create-from-jwt'
 export { hasOrganizationSentToParticipant } from './contacts/has-sent-to'
+export {
+  type ContactIdentityCandidate,
+  contactIdentityCandidate,
+} from './contacts/identity-candidate'
 // Context
 export type { CreateIngestContextOptions, IngestContext } from './context'
 export { buildOwnIdentitySets, createIngestContext, resetBatchCaches } from './context'

--- a/packages/lib/src/providers/facebook/facebook-provider.ts
+++ b/packages/lib/src/providers/facebook/facebook-provider.ts
@@ -7,9 +7,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
 import {
   type IntegrationSettings, // Per-integration record-creation/filter settings
-  type MessageData, // Data structure expected by storage service
   MessageStorageService,
-  type ParticipantInputData, // Structure for participant info from provider
 } from '../../email/email-storage' // Adjust path
 import type {
   ChannelProvider,
@@ -21,7 +19,11 @@ import { BaseMessageProvider, type MessageProvider } from '../message-provider-i
 import { getProviderCapabilities, type ProviderCapabilities } from '../provider-capabilities'
 import { SOCIAL_SUBSCRIBED_FIELDS, subscribePageToApp, unsubscribePageFromApp } from '../social/api'
 import { sendSocialMessage } from '../social/send'
-import { socialThreadKey } from '../social/thread-key'
+import {
+  resolveSocialBackfillCutoff,
+  type SocialSyncMetadata,
+  syncSocialMessages,
+} from '../social/sync'
 import { type FacebookIntegrationMetadata, FacebookOAuthService } from './facebook-oauth'
 
 const logger = createScopedLogger('facebook-provider')
@@ -29,57 +31,18 @@ const logger = createScopedLogger('facebook-provider')
 // (observed live 2026-08-17: `paging.next` links came back stamped v25.0).
 const DEFAULT_API_VERSION = 'v26.0'
 
-// --- Interface Definitions (for clarity, align with Graph API responses) ---
-interface FacebookWebhookMessage {
-  mid: string // Message ID
-  text?: string
-  attachments?: Array<{
-    type: string
-    payload: {
-      url?: string
-      title?: string
-    }
-  }>
-}
-// Structure of participant from conversation or message webhook
-interface FacebookGraphParticipant {
-  id: string // PSID or Page ID
-  name?: string
-}
-/** Generic shape of a paginated Graph API edge response. */
-interface FacebookGraphListResponse<T> {
-  data?: T[]
-  paging?: {
-    next?: string | null
-  }
-  error?: {
-    message?: string
-    code?: number
-  }
-}
-/** Conversation node returned by the /{page-id}/conversations edge. */
-interface FacebookGraphConversation {
-  id?: string
-  updated_time?: string
-  participants?: {
-    data?: FacebookGraphParticipant[]
-  }
-}
-/** Message node returned by the /{conversation-id}/messages edge. */
-interface FacebookGraphMessage {
-  id?: string
-  created_time?: string
-  from?: FacebookGraphParticipant
-  to?: unknown
-  message?: unknown
-}
-// --- End Interfaces ---
+/**
+ * `Integration.metadata` as this provider reads it: the OAuth/page identity plus the
+ * backfill bookkeeping `social/sync.ts` owns.
+ */
+type FacebookProviderMetadata = FacebookIntegrationMetadata & SocialSyncMetadata
+
 export class FacebookProvider
   extends BaseMessageProvider
   implements ChannelProvider, MessageProvider
 {
   private inboxId: string | undefined = undefined
-  private metadata: FacebookIntegrationMetadata | null = null
+  private metadata: FacebookProviderMetadata | null = null
   private pageAccessToken: string | null = null
   private pageId: string | null = null
   private apiVersion: string
@@ -148,7 +111,7 @@ export class FacebookProvider
     const tokens = await getChannelTokens(integrationId)
     // Safely cast and extract metadata
     try {
-      this.metadata = integration.metadata as unknown as FacebookIntegrationMetadata
+      this.metadata = integration.metadata as unknown as FacebookProviderMetadata
       this.pageAccessToken = tokens.accessToken // Decrypted LL Page Token
       this.pageId = this.metadata.pageId
       if (!this.pageId || !this.pageAccessToken) {
@@ -172,21 +135,7 @@ export class FacebookProvider
         hasSettings: true,
       })
     }
-    // Received-time trigger cutoff (webhook-push-migration plan Phase 2.5; the same
-    // contract Gmail/Outlook/Quo use). While the initial backfill is incomplete,
-    // ingest stores historical messages but suppresses `message:received` for
-    // anything received before the connect epoch — otherwise a backfill mass-fires
-    // workflows, agent runs and AI classification against years of real customer
-    // mail. Live inbound is unaffected: its `receivedAt` is after the cutoff.
-    const socialMeta = integration.metadata as {
-      backfillCutoffAt?: string
-      initialBackfillCompletedAt?: string
-    }
-    this.storageService.setBackfillCutoff(
-      socialMeta.backfillCutoffAt && !socialMeta.initialBackfillCompletedAt
-        ? new Date(socialMeta.backfillCutoffAt)
-        : null
-    )
+    this.storageService.setBackfillCutoff(resolveSocialBackfillCutoff(this.metadata))
     logger.info(`FacebookProvider initialized successfully for Page ID: ${this.pageId}`, {
       integrationId,
     })
@@ -290,282 +239,35 @@ export class FacebookProvider
     })
   }
   /**
-   * Synchronizes messages from Facebook Messenger using the Conversation API.
+   * Backfills / catches up Messenger history for this Page.
+   *
+   * The walk itself lives in `social/sync.ts` because Messenger and Instagram Direct
+   * are the same ladder over the same edge, differing only in the `platform` param and
+   * in which id counts as "us". What used to be here — ~180 lines of raw `fetch` with
+   * the access token in the query string, a `since` filter applied *after* paginating
+   * all 500+ conversations, and `fields=message{text,attachments,mid}` expanding a
+   * scalar — is gone rather than repaired.
    */
   async syncMessages(since?: Date): Promise<void> {
     await this.ensureInitialized()
-    logger.info('Starting Facebook message sync', {
-      pageId: this.pageId,
-      since: since?.toISOString(),
-      integrationId: this.integrationId,
-    })
-    try {
-      // Initial URL for conversations endpoint
-      let conversationsLink: string | null =
-        `https://graph.facebook.com/${this.apiVersion}/${this.pageId}/conversations?platform=messenger&fields=id,participants{id,name},updated_time,snippet&access_token=${this.pageAccessToken}`
-      let totalMessagesProcessed = 0
-      const processedConversationIds = new Set<string>() // Track processed convos to avoid duplicate message fetching if API behaves unexpectedly
-      // --- Paginate through Conversations ---
-      while (conversationsLink) {
-        logger.debug(
-          `Fetching conversations page: ${conversationsLink.split('access_token=')[0]}...`,
-          { integrationId: this.integrationId }
-        )
-        const convoRes = await fetch(conversationsLink)
-        const convoData =
-          (await convoRes.json()) as FacebookGraphListResponse<FacebookGraphConversation>
-        if (!convoRes.ok || convoData.error) {
-          logger.error('Failed to fetch conversations', {
-            status: convoRes.status,
-            error: convoData.error,
-            pageId: this.pageId,
-          })
-          throw new Error(`Failed to fetch conversations: ${convoData.error?.message}`)
-        }
-        const conversations = convoData.data || []
-        logger.info(`Fetched ${conversations.length} conversations on this page.`, {
-          integrationId: this.integrationId,
-        })
-        if (conversations.length === 0) break // Exit if no more conversations
-        // --- Process Messages within each Conversation ---
-        for (const conversation of conversations) {
-          const conversationId = conversation.id // This is the FB Conversation ID (our externalThreadId)
-          if (!conversationId || processedConversationIds.has(conversationId)) {
-            continue // Skip if no ID or already processed
-          }
-          processedConversationIds.add(conversationId)
-          // Check conversation update time against 'since' if provided
-          if (since && conversation.updated_time) {
-            const updatedTime = new Date(conversation.updated_time)
-            if (updatedTime < since) {
-              logger.debug(
-                `Skipping conversation ${conversationId} updated at ${updatedTime.toISOString()} (before 'since' date ${since.toISOString()})`
-              )
-              continue
-            }
-          }
-          // Extract user participant info from the conversation context
-          let userContext: {
-            psid: string
-            name?: string
-          } | null = null
-          if (conversation.participants?.data) {
-            const userParticipant = conversation.participants.data.find(
-              (p: FacebookGraphParticipant) => p.id !== this.pageId
-            )
-            if (userParticipant) {
-              userContext = { psid: userParticipant.id, name: userParticipant.name }
-            }
-          }
-          if (!userContext) {
-            logger.warn(
-              `Could not determine user PSID for conversation ${conversationId}, skipping message fetching for this conversation.`
-            )
-            continue
-          }
-          // --- Paginate through Messages for this Conversation ---
-          let messagesLink: string | null =
-            `https://graph.facebook.com/${this.apiVersion}/${conversationId}/messages?access_token=${this.pageAccessToken}&fields=id,created_time,from{id,name},to{id,name},message{text,attachments,mid}` // Added mid
-          const messagesToStore: MessageData[] = []
-          // Apply 'since' filter to message fetching as well (more granular)
-          if (since) {
-            messagesLink += `&since=${Math.floor(since.getTime() / 1000)}`
-          }
-          while (messagesLink) {
-            logger.debug(
-              `Fetching messages page for FB conversation ${conversationId}: ${messagesLink.split('access_token=')[0]}...`,
-              { integrationId: this.integrationId }
-            )
-            const msgRes = await fetch(messagesLink)
-            const msgData = (await msgRes.json()) as FacebookGraphListResponse<FacebookGraphMessage>
-            if (!msgRes.ok || msgData.error) {
-              logger.error(`Failed to fetch messages for conversation ${conversationId}`, {
-                status: msgRes.status,
-                error: msgData.error,
-              })
-              messagesLink = null // Stop fetching for this conversation on error
-              break // Break message loop
-            }
-            const messages = msgData.data || []
-            if (messages.length === 0) break // Exit message loop if no messages on page
-            logger.debug(
-              `Fetched ${messages.length} messages for FB conversation ${conversationId} on this page.`,
-              { integrationId: this.integrationId }
-            )
-            for (const message of messages) {
-              // Pass the user context extracted from the conversation
-              const converted = this.convertFacebookMessageToMessageData(
-                message,
-                conversationId,
-                userContext
-              )
-              if (converted) {
-                messagesToStore.push(converted)
-              }
-            }
-            messagesLink = msgData.paging?.next ?? null // Get next page link for messages
-          } // End message pagination loop
-          // --- Store fetched messages for this conversation ---
-          if (messagesToStore.length > 0) {
-            // Batch store messages accepts MessageData[]
-            const storedCount = await this.storageService.batchStoreMessages(messagesToStore)
-            totalMessagesProcessed += storedCount
-            logger.info(
-              `Stored ${storedCount}/${messagesToStore.length} messages for FB conversation ${conversationId}.`,
-              { integrationId: this.integrationId }
-            )
-          }
-        } // End conversation loop
-        conversationsLink = convoData.paging?.next ?? null // Get next page link for conversations
-      } // End conversation pagination loop
-      // Update last synced time after successful completion
-      await db
-        .update(schema.Integration)
-        .set({ lastSyncedAt: new Date() })
-        .where(eq(schema.Integration.id, this.integrationId!))
-      logger.info(
-        `Facebook sync completed. Processed approximately ${totalMessagesProcessed} messages.`,
-        { integrationId: this.integrationId }
-      )
-    } catch (error: any) {
-      logger.error('Error during Facebook message sync:', {
-        error: error.message,
-        integrationId: this.integrationId,
-      })
-      // Update last synced time even on failure to mark the attempt? Optional.
-      await db
-        .update(schema.Integration)
-        .set({ lastSyncedAt: new Date() })
-        .where(eq(schema.Integration.id, this.integrationId!))
-        .catch((updateErr: unknown) =>
-          logger.error('Failed to update lastSyncedAt after sync error', { updateErr })
-        )
-      throw error // Re-throw the error
-    }
-  }
-  /**
-   * Converts a Facebook message object (from Graph API) to our standard MessageData format,
-   * using ParticipantInputData structure.
-   */
-  private convertFacebookMessageToMessageData(
-    message: any, // Raw message object from Graph API /{conv-id}/messages edge
-    conversationId: string, // FB Conversation ID
-    userContext: {
-      psid: string
-      name?: string
-    } // User PSID and optional name from conversation context
-  ): MessageData | null {
-    // Ensure provider is initialized
-    if (!this.integrationId || !this.pageId || !this.metadata) {
-      logger.error('Provider state invalid during message conversion.')
-      return null
-    }
-    try {
-      // Extract core message details
-      const fbMessageContent: FacebookWebhookMessage = message.message || {}
-      // Use the nested message ID (mid) if available, otherwise fall back to the top-level message ID (id)
-      const externalId = fbMessageContent.mid || message.id
-      const createdTime = new Date(message.created_time)
-      // Determine sender: Use 'from' field provided by Graph API
-      const sender: FacebookGraphParticipant | undefined = message.from
-      if (!sender?.id) {
-        logger.warn('Could not determine sender ID for Facebook message', { messageId: externalId })
-        return null // Cannot process without sender
-      }
-      let fromInput: ParticipantInputData
-      let toInput: ParticipantInputData
-      let isInbound = false
-      // Check if the sender is the user (PSID matches user context)
-      if (sender.id === userContext.psid) {
-        isInbound = true
-        fromInput = { identifier: sender.id, name: sender.name ?? userContext.name } // User PSID (sender)
-        toInput = { identifier: this.pageId, name: this.metadata.pageName } // Page ID (recipient)
-      }
-      // Check if the sender is the page itself
-      else if (sender.id === this.pageId) {
-        isInbound = false
-        fromInput = { identifier: this.pageId, name: sender.name ?? this.metadata.pageName } // Page ID (sender)
-        // The recipient must be the user in this case
-        toInput = { identifier: userContext.psid, name: userContext.name } // User PSID (recipient)
-      }
-      // Check if the sender is the page's associated business account (should be same as pageId usually)
-      else if (this.metadata.pageId && sender.id === this.metadata.pageId) {
-        // Treat this also as outbound
-        isInbound = false
-        fromInput = { identifier: sender.id, name: sender.name ?? this.metadata.pageName } // Page ID (sender)
-        toInput = { identifier: userContext.psid, name: userContext.name } // User PSID (recipient)
-      } else {
-        logger.error('Could not determine participant roles for Facebook message', {
-          messageId: externalId,
-          senderId: sender.id,
-          userPsid: userContext.psid,
-          pageId: this.pageId,
-        })
-        return null // Skip if roles are unclear
-      }
-      // const text = fbMessageContent.text
-      // Process attachments
-      const attachments = (fbMessageContent.attachments || []).map((att: any) => ({
-        filename: att.payload?.title || att.type || 'attachment',
-        mimeType: att.type, // Facebook's type, not standard MIME
-        size: 0, // Size often not available
-        inline: false,
-        contentLocation: att.payload?.url, // URL if available
-      }))
-      // Construct the MessageData object for storage
-      const messageData: MessageData = {
-        externalId: externalId,
-        // NOT the `t_…` conversation id. The webhook never receives one, so the
-        // REST path must derive the SAME pair key the webhook derives or the same
-        // conversation lands in two threads. The conversation id is kept in
-        // `metadata` for deep links only.
-        externalThreadId: socialThreadKey(this.pageId, userContext.psid),
-        integrationId: this.integrationId,
-        inboxId: this.inboxId,
+    await syncSocialMessages({
+      target: {
+        platform: 'facebook',
+        graphPlatform: 'messenger',
+        pageId: this.pageId!,
+        // On Messenger the Page id is both the addressable edge and our identity in
+        // the thread key — the two coincide here and do NOT on Instagram.
+        ourId: this.pageId!,
+        ourName: this.metadata?.pageName,
+        pageAccessToken: this.pageAccessToken!,
+        integrationId: this.integrationId!,
         organizationId: this.organizationId,
-        createdTime: createdTime,
-        sentAt: createdTime, // Use created_time as best estimate for send/receive
-        receivedAt: createdTime,
-        subject: `${sender.name} commented on your Facebook post`, // No subject in Messenger
-        from: fromInput, // Use ParticipantInputData
-        to: [toInput], // Use ParticipantInputData (always single recipient conceptually)
-        cc: [],
-        bcc: [],
-        replyTo: [],
-        // Facebook has no inbound attachment ingestor, so no MessageAttachment
-        // rows are ever created and `providerAttachments` is never populated.
-        // `hasAttachments` is a workflow trigger filter (see
-        // workflow-engine/nodes/trigger-nodes/message-received.ts), so claiming
-        // true here fires attachment rules for bytes that were never fetched.
-        // The `attachments` local below still drives the snippet fallback.
-        hasAttachments: false,
-        textPlain: message.message, //text,
-        textHtml: undefined, // No HTML support
-        snippet: message.message
-          ? message.message.substring(0, 100)
-          : attachments[0]?.filename || '', // Basic snippet
-        isInbound: isInbound,
-        metadata: {
-          // Store raw event parts for debugging or future use
-          fb_conversation_id: conversationId,
-          fb_from: message.from,
-          fb_to: message.to,
-          fb_message: message.message,
-          fb_created_time: message.created_time,
-        },
-        // Default values for non-applicable fields
-        keywords: [],
-        labelIds: [],
-      }
-      return messageData
-    } catch (error: any) {
-      logger.error('Error converting Facebook message object to MessageData', {
-        error: error.message,
-        messageId: message?.id, // Log the raw message ID if available
-        integrationId: this.integrationId,
-      })
-      return null // Return null if conversion fails
-    }
+        inboxId: this.inboxId,
+      },
+      metadata: this.metadata!,
+      storage: this.storageService,
+      since,
+    })
   }
   /** Returns the provider name */
   getProviderName(): string {

--- a/packages/lib/src/providers/instagram/instagram-provider.ts
+++ b/packages/lib/src/providers/instagram/instagram-provider.ts
@@ -7,9 +7,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
 import {
   type IntegrationSettings, // Per-integration record-creation/filter settings
-  type MessageData, // Data structure expected by storage service
   MessageStorageService,
-  type ParticipantInputData, // Structure for participant info from provider
 } from '../../email/email-storage' // Adjust path
 import type {
   ChannelProvider,
@@ -21,7 +19,11 @@ import { BaseMessageProvider, type MessageProvider } from '../message-provider-i
 import { getProviderCapabilities, type ProviderCapabilities } from '../provider-capabilities'
 import { SOCIAL_SUBSCRIBED_FIELDS, subscribePageToApp, unsubscribePageFromApp } from '../social/api'
 import { sendSocialMessage } from '../social/send'
-import { socialThreadKey } from '../social/thread-key'
+import {
+  resolveSocialBackfillCutoff,
+  type SocialSyncMetadata,
+  syncSocialMessages,
+} from '../social/sync'
 import { type InstagramIntegrationMetadata, InstagramOAuthService } from './instagram-oauth'
 
 const logger = createScopedLogger('instagram-provider')
@@ -29,58 +31,18 @@ const logger = createScopedLogger('instagram-provider')
 // (observed live 2026-08-17: `paging.next` links came back stamped v25.0).
 const DEFAULT_API_VERSION = 'v26.0'
 
-// --- Interface Definitions (Align with Graph API) ---
-// Structure of message content within webhook/API response
-interface InstagramGraphMessageContent {
-  mid: string // Message ID
-  text?: string
-  attachments?: Array<{
-    type: string
-    payload: {
-      url?: string
-      title?: string
-    }
-  }>
-}
-// Structure of participant from conversation or message webhook
-interface InstagramGraphParticipant {
-  id: string // IGSID or IGBID
-  username?: string // Instagram username
-}
-/** Generic shape of a paginated Graph API edge response. */
-interface InstagramGraphListResponse<T> {
-  data?: T[]
-  paging?: {
-    next?: string | null
-  }
-  error?: {
-    message?: string
-    code?: number
-  }
-}
-/** Conversation node returned by the /{page-id}/conversations edge (platform=instagram). */
-interface InstagramGraphConversation {
-  id?: string
-  updated_time?: string
-  participants?: {
-    data?: InstagramGraphParticipant[]
-  }
-}
-/** Message node returned by the /{conversation-id}/messages edge. */
-interface InstagramGraphMessage {
-  id?: string
-  created_time?: string
-  from?: InstagramGraphParticipant
-  to?: unknown
-  message?: unknown
-}
-// --- End Interfaces ---
+/**
+ * `Integration.metadata` as this provider reads it: the OAuth/page identity plus the
+ * backfill bookkeeping `social/sync.ts` owns.
+ */
+type InstagramProviderMetadata = InstagramIntegrationMetadata & SocialSyncMetadata
+
 export class InstagramProvider
   extends BaseMessageProvider
   implements ChannelProvider, MessageProvider
 {
   private inboxId: string | undefined = undefined // Store inbox ID
-  private metadata: InstagramIntegrationMetadata | null = null
+  private metadata: InstagramProviderMetadata | null = null
   private pageAccessToken: string | null = null // LL Page Token (used for API calls)
   private pageId: string | null = null // Linked FB Page ID
   private instagramBusinessAccountId: string | null = null // IGBID
@@ -145,7 +107,7 @@ export class InstagramProvider
     const tokens = await getChannelTokens(integrationId)
     // Safely extract and validate metadata and token
     try {
-      this.metadata = integration.metadata as unknown as InstagramIntegrationMetadata
+      this.metadata = integration.metadata as unknown as InstagramProviderMetadata
       this.pageAccessToken = tokens.accessToken // Decrypted LL Page Token
       this.pageId = this.metadata.pageId
       this.instagramBusinessAccountId = this.metadata.instagramBusinessAccountId
@@ -170,21 +132,7 @@ export class InstagramProvider
         hasSettings: true,
       })
     }
-    // Received-time trigger cutoff (webhook-push-migration plan Phase 2.5; the same
-    // contract Gmail/Outlook/Quo use). While the initial backfill is incomplete,
-    // ingest stores historical messages but suppresses `message:received` for
-    // anything received before the connect epoch — otherwise a backfill mass-fires
-    // workflows, agent runs and AI classification against years of real customer
-    // mail. Live inbound is unaffected: its `receivedAt` is after the cutoff.
-    const socialMeta = integration.metadata as {
-      backfillCutoffAt?: string
-      initialBackfillCompletedAt?: string
-    }
-    this.storageService.setBackfillCutoff(
-      socialMeta.backfillCutoffAt && !socialMeta.initialBackfillCompletedAt
-        ? new Date(socialMeta.backfillCutoffAt)
-        : null
-    )
+    this.storageService.setBackfillCutoff(resolveSocialBackfillCutoff(this.metadata))
     logger.info(
       `InstagramProvider initialized successfully for IGBID: ${this.instagramBusinessAccountId}, Page ID: ${this.pageId}`,
       { integrationId }
@@ -303,283 +251,33 @@ export class InstagramProvider
     })
   }
   /**
-   * Synchronizes messages from Instagram via the linked Facebook Page's Conversation API.
+   * Backfills / catches up Instagram Direct history for this business account.
+   *
+   * Same walk as Messenger (`social/sync.ts`) over the same Page edge, with two
+   * differences that matter: `platform=instagram`, and **our identity in the thread key
+   * is the IG business account id, not the Page id** — that is what the IG webhook puts
+   * in `recipient.id`, and a key that used the Page id here would fork every
+   * conversation the webhook has already stored.
    */
   async syncMessages(since?: Date): Promise<void> {
     await this.ensureInitialized()
-    logger.info('Starting Instagram message sync', {
-      igbid: this.instagramBusinessAccountId,
-      pageId: this.pageId,
-      since: since?.toISOString(),
-      integrationId: this.integrationId,
-    })
-    try {
-      // Use the Conversation API, specifying platform=instagram and the Page ID
-      let conversationsLink: string | null =
-        `https://graph.facebook.com/${this.apiVersion}/${this.pageId}/conversations?platform=instagram&fields=id,participants{id,username},updated_time,snippet,message_count,unread_count&access_token=${this.pageAccessToken}`
-      let totalMessagesProcessed = 0
-      const processedConversationIds = new Set<string>() // Avoid reprocessing
-      // --- Paginate through Conversations ---
-      while (conversationsLink) {
-        logger.debug(
-          `Fetching Instagram conversations page: ${conversationsLink.split('access_token=')[0]}...`,
-          { integrationId: this.integrationId }
-        )
-        const convoRes = await fetch(conversationsLink)
-        const convoData =
-          (await convoRes.json()) as InstagramGraphListResponse<InstagramGraphConversation>
-        if (!convoRes.ok || convoData.error) {
-          logger.error('Failed to fetch Instagram conversations', {
-            status: convoRes.status,
-            error: convoData.error,
-            pageId: this.pageId,
-          })
-          throw new Error(`Failed to fetch Instagram conversations: ${convoData.error?.message}`)
-        }
-        const conversations = convoData.data || []
-        if (conversations.length === 0) break // Exit conversation loop
-        logger.info(`Fetched ${conversations.length} Instagram conversations on this page.`, {
-          integrationId: this.integrationId,
-        })
-        // --- Process Messages within each Conversation ---
-        for (const conversation of conversations) {
-          const conversationId = conversation.id // FB Conversation ID (our externalThreadId)
-          if (!conversationId || processedConversationIds.has(conversationId)) continue
-          processedConversationIds.add(conversationId)
-          // Check conversation update time against 'since' date
-          if (since && conversation.updated_time) {
-            const updatedTime = new Date(conversation.updated_time)
-            if (updatedTime < since) {
-              logger.debug(
-                `Skipping IG conversation ${conversationId} updated at ${updatedTime.toISOString()} (before 'since' date ${since.toISOString()})`
-              )
-              continue
-            }
-          }
-          // Extract user participant info (IGSID and username) from conversation context
-          let userContext: {
-            igsid: string
-            username?: string
-          } | null = null
-          if (conversation.participants?.data) {
-            // Find the participant whose ID is NOT the business account ID (IGBID)
-            const userParticipant = conversation.participants.data.find(
-              (p: InstagramGraphParticipant) => p.id !== this.instagramBusinessAccountId
-            )
-            if (userParticipant) {
-              userContext = { igsid: userParticipant.id, username: userParticipant.username }
-            }
-          }
-          if (!userContext) {
-            logger.warn(
-              `Could not determine user IGSID for IG conversation ${conversationId}. Skipping messages.`
-            )
-            continue
-          }
-          // --- Paginate through Messages for this Conversation ---
-          let messagesLink: string | null =
-            `https://graph.facebook.com/${this.apiVersion}/${conversationId}/messages?access_token=${this.pageAccessToken}&fields=id,created_time,from{id,username},to{id,username},message{text,attachments,mid}` // Fetch usernames if available
-          const messagesToStore: MessageData[] = []
-          // Apply 'since' filter to messages if provided
-          if (since) {
-            messagesLink += `&since=${Math.floor(since.getTime() / 1000)}`
-          }
-          while (messagesLink) {
-            logger.debug(
-              `Fetching messages page for IG conversation ${conversationId}: ${messagesLink.split('access_token=')[0]}...`,
-              { integrationId: this.integrationId }
-            )
-            const msgRes = await fetch(messagesLink)
-            const msgData =
-              (await msgRes.json()) as InstagramGraphListResponse<InstagramGraphMessage>
-            if (!msgRes.ok || msgData.error) {
-              logger.error(`Failed to fetch messages for IG conversation ${conversationId}`, {
-                status: msgRes.status,
-                error: msgData.error,
-              })
-              messagesLink = null // Stop fetching for this convo
-              break
-            }
-            const messages = msgData.data || []
-            if (messages.length === 0) break // Stop if no messages on page
-            logger.debug(
-              `Fetched ${messages.length} messages for IG conversation ${conversationId} on this page.`,
-              { integrationId: this.integrationId }
-            )
-            for (const message of messages) {
-              // Pass user context for correct participant identification
-              const converted = this.convertInstagramMessageToMessageData(
-                message,
-                conversationId,
-                userContext
-              )
-              if (converted) {
-                messagesToStore.push(converted)
-              }
-            }
-            messagesLink = msgData.paging?.next ?? null // Next page link for messages
-          } // End message pagination
-          // --- Store fetched messages ---
-          if (messagesToStore.length > 0) {
-            const storedCount = await this.storageService.batchStoreMessages(messagesToStore)
-            totalMessagesProcessed += storedCount
-            logger.info(
-              `Stored ${storedCount}/${messagesToStore.length} messages for IG conversation ${conversationId}.`,
-              { integrationId: this.integrationId }
-            )
-          }
-        } // End conversation loop
-        conversationsLink = convoData.paging?.next ?? null // Next page link for conversations
-      } // End conversation pagination
-      // Update last synced time on successful completion
-      await db
-        .update(schema.Integration)
-        .set({ lastSyncedAt: new Date() })
-        .where(eq(schema.Integration.id, this.integrationId!))
-      logger.info(
-        `Instagram sync completed. Processed approximately ${totalMessagesProcessed} messages.`,
-        { integrationId: this.integrationId }
-      )
-    } catch (error: any) {
-      logger.error('Error during Instagram message sync:', {
-        error: error.message,
-        integrationId: this.integrationId,
-      })
-      // Mark sync attempt time even on failure
-      await db
-        .update(schema.Integration)
-        .set({ lastSyncedAt: new Date() })
-        .where(eq(schema.Integration.id, this.integrationId!))
-        .catch((updateErr) =>
-          logger.error('Failed to update lastSyncedAt after Instagram sync error', { updateErr })
-        )
-      throw error // Re-throw
-    }
-  }
-  /**
-   * Converts an Instagram message object (from Graph API Conversation edge) to our standard MessageData format,
-   * using ParticipantInputData.
-   */
-  private convertInstagramMessageToMessageData(
-    message: any, // Raw message object
-    conversationId: string, // FB Conversation ID (externalThreadId)
-    userContext: {
-      igsid: string
-      username?: string
-    } // User IGSID and optional username
-  ): MessageData | null {
-    // Ensure provider state is valid
-    if (
-      !this.integrationId ||
-      !this.instagramBusinessAccountId ||
-      !this.metadata?.instagramUsername
-    ) {
-      logger.error('Provider state invalid during Instagram message conversion.')
-      return null
-    }
-    try {
-      // Extract core message details
-      const messageContent: InstagramGraphMessageContent = message.message || {}
-      const externalId = messageContent.mid || message.id // Use nested 'mid' if available, else top-level 'id'
-      const createdTime = new Date(message.created_time)
-      // Determine sender using 'from' field
-      const sender: InstagramGraphParticipant | undefined = message.from
-      if (!sender?.id) {
-        logger.warn('Could not determine sender ID for Instagram message', {
-          messageId: externalId,
-        })
-        return null
-      }
-      let fromInput: ParticipantInputData
-      let toInput: ParticipantInputData
-      let isInbound = false
-      // Check if the sender is the user (IGSID)
-      if (sender.id === userContext.igsid) {
-        isInbound = true
-        fromInput = { identifier: sender.id, name: sender.username ?? userContext.username } // User IGSID + username
-        toInput = {
-          identifier: this.instagramBusinessAccountId,
-          name: this.metadata.instagramUsername,
-        } // Business IGBID + username
-      }
-      // Check if the sender is the business account (IGBID)
-      else if (sender.id === this.instagramBusinessAccountId) {
-        isInbound = false
-        fromInput = {
-          identifier: this.instagramBusinessAccountId,
-          name: sender.username ?? this.metadata.instagramUsername,
-        } // Business IGBID + username
-        // Recipient must be the user
-        toInput = { identifier: userContext.igsid, name: userContext.username } // User IGSID + username
-      } else {
-        logger.error('Could not determine participant roles for Instagram message', {
-          messageId: externalId,
-          senderId: sender.id,
-          userIgsid: userContext.igsid,
-          igbid: this.instagramBusinessAccountId,
-        })
-        return null // Skip if roles unclear
-      }
-      const text = messageContent.text
-      // Process attachments
-      const attachments = (messageContent.attachments || []).map((att: any) => ({
-        filename: att.payload?.title || att.type || 'attachment',
-        mimeType: att.type, // FB/IG attachment type
-        size: 0, // Size not available
-        inline: false,
-        contentLocation: att.payload?.url, // URL if available
-      }))
-      // Construct the MessageData object
-      const messageData: MessageData = {
-        externalId: externalId,
-        // NOT the `t_…` conversation id — the webhook never receives one, so the
-        // REST path must derive the SAME pair key the webhook derives or the same
-        // conversation lands in two threads. Keyed on the IGBID (our side) so it
-        // matches the webhook's `recipient.id`, not on the Page id.
-        externalThreadId: socialThreadKey(this.instagramBusinessAccountId, userContext.igsid),
-        inboxId: this.inboxId,
-        integrationId: this.integrationId,
+    await syncSocialMessages({
+      target: {
+        platform: 'instagram',
+        graphPlatform: 'instagram',
+        // The conversations edge is addressed on the linked FB Page even for IG.
+        pageId: this.pageId!,
+        ourId: this.instagramBusinessAccountId!,
+        ourName: this.metadata?.instagramUsername,
+        pageAccessToken: this.pageAccessToken!,
+        integrationId: this.integrationId!,
         organizationId: this.organizationId,
-        createdTime: createdTime,
-        sentAt: createdTime, // Use created_time as best estimate
-        receivedAt: createdTime,
-        subject: undefined, // No subject
-        from: fromInput, // ParticipantInputData
-        to: [toInput], // ParticipantInputData
-        cc: [],
-        bcc: [],
-        replyTo: [],
-        // Instagram has no inbound attachment ingestor, so no MessageAttachment
-        // rows are ever created and `providerAttachments` is never populated.
-        // `hasAttachments` is a workflow trigger filter (see
-        // workflow-engine/nodes/trigger-nodes/message-received.ts), so claiming
-        // true here fires attachment rules for bytes that were never fetched.
-        // The `attachments` local below still drives the snippet fallback.
-        hasAttachments: false,
-        textPlain: text,
-        textHtml: undefined, // No HTML
-        snippet: text ? text.substring(0, 100) : attachments[0]?.filename || '',
-        isInbound: isInbound,
-        metadata: {
-          // Store raw parts for reference
-          ig_from: message.from,
-          ig_to: message.to,
-          ig_message: message.message,
-          ig_created_time: message.created_time,
-        },
-        // Default values for non-applicable fields
-        keywords: [],
-        labelIds: [],
-      }
-      return messageData
-    } catch (error: any) {
-      logger.error('Error converting Instagram message object to MessageData', {
-        error: error.message,
-        messageId: message?.id, // Log raw message ID
-        integrationId: this.integrationId,
-      })
-      return null // Return null on conversion failure
-    }
+        inboxId: this.inboxId,
+      },
+      metadata: this.metadata!,
+      storage: this.storageService,
+      since,
+    })
   }
   /** Returns the provider name */
   getProviderName(): string {

--- a/packages/lib/src/providers/social/__tests__/conversation-message.test.ts
+++ b/packages/lib/src/providers/social/__tests__/conversation-message.test.ts
@@ -1,0 +1,290 @@
+// packages/lib/src/providers/social/__tests__/conversation-message.test.ts
+//
+// The REST conversation-messages edge is the one Meta shape nobody has captured, so
+// this suite pins the two things that survive either answer: the text normalisation
+// (scalar `message` vs object `message`) and the thread key, which must be
+// byte-identical to what the webhook writes or the conversation forks with no header
+// chain to recover it.
+
+import { describe, expect, it } from 'vitest'
+import {
+  conversationMessageExternalId,
+  conversationMessageText,
+  convertGraphConversationMessageToMessageData,
+  pickConversationCounterpart,
+  type TolerantConversationMessage,
+} from '../conversation-message'
+import { socialThreadKey } from '../thread-key'
+
+const PAGE_ID = '869289333164075'
+const PSID = '27893553143563440'
+const IGBID = '17841400000000000'
+const IGSID = '17842000000000000'
+
+const BASE = {
+  integrationId: 'int_1',
+  organizationId: 'org_1',
+  ourId: PAGE_ID,
+  counterpartId: PSID,
+  ourName: 'Auxx-Lift',
+  platform: 'facebook' as const,
+  conversationId: 't_1234567890',
+}
+
+function node(overrides: Partial<TolerantConversationMessage> = {}): TolerantConversationMessage {
+  return {
+    id: 'm_node_1',
+    created_time: '2026-08-18T09:41:00+0000',
+    from: { id: PSID, name: 'Jane Customer' },
+    to: { data: [{ id: PAGE_ID, name: 'Auxx-Lift' }] },
+    message: 'where is my order?',
+    ...overrides,
+  }
+}
+
+describe('conversationMessageText', () => {
+  it('reads a scalar `message` — the shape Graph documents', () => {
+    expect(conversationMessageText('where is my order?')).toBe('where is my order?')
+  })
+
+  it('reads an object `message` via its `text` — the shape we cannot rule out', () => {
+    expect(conversationMessageText({ text: 'where is my order?', mid: 'm_1' })).toBe(
+      'where is my order?'
+    )
+  })
+
+  it('is undefined for a shape it does not understand, never a coerced string', () => {
+    expect(conversationMessageText(undefined)).toBeUndefined()
+    expect(conversationMessageText({})).toBeUndefined()
+    // The bug this whole module exists to prevent: `String(message)` on an object
+    // stores "[object Object]" as the body of a real customer message.
+    expect(conversationMessageText({ mid: 'm_1' })).toBeUndefined()
+  })
+})
+
+describe('conversationMessageExternalId', () => {
+  it('prefers an inner `mid` — the id the webhook and the send path both stamp', () => {
+    expect(conversationMessageExternalId(node({ id: 'm_node', message: { mid: 'm_wire' } }))).toBe(
+      'm_wire'
+    )
+  })
+
+  it("falls back to the node's own id when the scalar shape carries no mid", () => {
+    expect(conversationMessageExternalId(node())).toBe('m_node_1')
+  })
+
+  it('is undefined when the node has neither', () => {
+    expect(
+      conversationMessageExternalId({ created_time: '2026-08-18T09:41:00+0000' })
+    ).toBeUndefined()
+  })
+})
+
+describe('pickConversationCounterpart', () => {
+  it('picks the non-page participant', () => {
+    const counterpart = pickConversationCounterpart(
+      {
+        participants: {
+          data: [
+            { id: PAGE_ID, name: 'Auxx-Lift' },
+            { id: PSID, name: 'Jane' },
+          ],
+        },
+      },
+      PAGE_ID
+    )
+    expect(counterpart).toEqual({ id: PSID, name: 'Jane' })
+  })
+
+  it('prefers the IG username as the display name', () => {
+    const counterpart = pickConversationCounterpart(
+      { participants: { data: [{ id: IGBID }, { id: IGSID, username: 'jane.doe' }] } },
+      IGBID
+    )
+    expect(counterpart?.name).toBe('jane.doe')
+  })
+
+  it('excludes EVERY id that is us — the IG account and the linked page', () => {
+    // Which of the two Graph lists for `platform=instagram` is unverified, so the
+    // pick must not depend on guessing right.
+    const counterpart = pickConversationCounterpart(
+      { participants: { data: [{ id: PAGE_ID }, { id: IGSID, username: 'jane.doe' }] } },
+      [IGBID, PAGE_ID]
+    )
+    expect(counterpart?.id).toBe(IGSID)
+  })
+
+  it('returns null when only our own side is present', () => {
+    expect(
+      pickConversationCounterpart({ participants: { data: [{ id: PAGE_ID }] } }, PAGE_ID)
+    ).toBe(null)
+    expect(pickConversationCounterpart({}, PAGE_ID)).toBe(null)
+  })
+})
+
+describe('convertGraphConversationMessageToMessageData', () => {
+  it('stores the text and the node id from the SCALAR message shape', () => {
+    const result = convertGraphConversationMessageToMessageData({ message: node(), ...BASE })
+
+    expect(result?.textPlain).toBe('where is my order?')
+    expect(result?.snippet).toBe('where is my order?')
+    expect(result?.externalId).toBe('m_node_1')
+    expect(result?.isInbound).toBe(true)
+  })
+
+  it('stores the text and the mid from the OBJECT message shape', () => {
+    const result = convertGraphConversationMessageToMessageData({
+      message: node({ message: { text: 'where is my order?', mid: 'm_wire_1' } }),
+      ...BASE,
+    })
+
+    expect(result?.textPlain).toBe('where is my order?')
+    expect(result?.externalId).toBe('m_wire_1')
+  })
+
+  it('agrees with socialThreadKey — the same key the webhook writes', () => {
+    const result = convertGraphConversationMessageToMessageData({ message: node(), ...BASE })
+
+    expect(result?.externalThreadId).toBe(socialThreadKey(PAGE_ID, PSID))
+    // Never the `t_…` conversation id: the webhook never sees one, so keying on it
+    // splits every conversation that arrives through both doors.
+    expect(result?.externalThreadId).not.toBe(BASE.conversationId)
+    expect(result?.metadata?.meta_conversation_id).toBe(BASE.conversationId)
+  })
+
+  it('keys an Instagram DM on the IG business account id, not the page id', () => {
+    const result = convertGraphConversationMessageToMessageData({
+      message: node({ from: { id: IGSID, username: 'jane.doe' } }),
+      ...BASE,
+      platform: 'instagram',
+      ourId: IGBID,
+      counterpartId: IGSID,
+      ourName: 'auxxlift',
+    })
+
+    expect(result?.externalThreadId).toBe(socialThreadKey(IGBID, IGSID))
+    expect(result?.from.identifier).toBe(IGSID)
+    expect(result?.from.name).toBe('jane.doe')
+    expect(result?.to[0]?.identifier).toBe(IGBID)
+  })
+
+  it('reads a page-sent Instagram node as OURS when Graph names the linked Page, not the IGBID', () => {
+    // The two-id problem. On `platform=instagram` the edge is addressed on the
+    // linked Page while our identity in the key is the IGBID, and which one Graph
+    // puts in `from` on a business-sent node is unverified. Without the alias the
+    // node matches neither `ourId` nor the counterpart and is dropped as "a third
+    // party" — an IG backfill that keeps the customer's messages and none of ours.
+    const result = convertGraphConversationMessageToMessageData({
+      message: node({ id: 'm_ig_out', from: { id: PAGE_ID, username: 'auxxlift' } }),
+      ...BASE,
+      platform: 'instagram',
+      ourId: IGBID,
+      ourAliasIds: [PAGE_ID],
+      counterpartId: IGSID,
+      counterpartName: 'jane.doe',
+      ourName: 'auxxlift',
+    })
+
+    expect(result).not.toBe(null)
+    expect(result?.isInbound).toBe(false)
+    // The alias decides DIRECTION only. The identifier and the key stay on the
+    // IGBID, or this message forks off the thread the webhook already wrote.
+    expect(result?.from.identifier).toBe(IGBID)
+    expect(result?.externalThreadId).toBe(socialThreadKey(IGBID, IGSID))
+    expect(result?.to[0]?.identifier).toBe(IGSID)
+    expect(result?.to[0]?.name).toBe('jane.doe')
+  })
+
+  it('still drops a genuine third party when aliases are configured', () => {
+    expect(
+      convertGraphConversationMessageToMessageData({
+        message: node({ from: { id: '999999999' } }),
+        ...BASE,
+        platform: 'instagram',
+        ourId: IGBID,
+        ourAliasIds: [PAGE_ID],
+        counterpartId: IGSID,
+      })
+    ).toBe(null)
+  })
+
+  it('marks a page-sent message outbound and gives it the SAME thread key', () => {
+    const inbound = convertGraphConversationMessageToMessageData({ message: node(), ...BASE })
+    const outbound = convertGraphConversationMessageToMessageData({
+      message: node({ id: 'm_node_2', from: { id: PAGE_ID, name: 'Auxx-Lift' } }),
+      ...BASE,
+    })
+
+    expect(outbound?.isInbound).toBe(false)
+    expect(outbound?.from.identifier).toBe(PAGE_ID)
+    expect(outbound?.to[0]?.identifier).toBe(PSID)
+    expect(outbound?.externalThreadId).toBe(inbound?.externalThreadId)
+  })
+
+  it('never names the counterpart after the sender of a page-sent message', () => {
+    // Regression: `from` was stamped on BOTH participants, so every page-sent node
+    // wrote our Page's name onto the customer — and the participant upsert takes the
+    // last write carrying a usable name, so a single reply of ours renamed the
+    // customer for good and their whole history rendered as authored by the Page.
+    const outbound = convertGraphConversationMessageToMessageData({
+      message: node({ id: 'm_node_3', from: { id: PAGE_ID, name: 'Auxx-Lift' } }),
+      ...BASE,
+      counterpartName: 'Jane Customer',
+    })
+
+    expect(outbound?.from.name).toBe('Auxx-Lift')
+    expect(outbound?.to[0]?.name).toBe('Jane Customer')
+  })
+
+  it('falls back to the conversation participant name, not the page name, when a page-sent node is all we have', () => {
+    const outbound = convertGraphConversationMessageToMessageData({
+      message: node({ id: 'm_node_4', from: { id: PAGE_ID, name: 'Auxx-Lift' } }),
+      ...BASE,
+      counterpartName: undefined,
+    })
+
+    expect(outbound?.to[0]?.name).toBeUndefined()
+  })
+
+  it('carries no subject — these are DMs, not the "commented on your post" fiction', () => {
+    const result = convertGraphConversationMessageToMessageData({ message: node(), ...BASE })
+    expect(result?.subject).toBeUndefined()
+  })
+
+  it('never claims attachments, because nothing ingests their bytes', () => {
+    const result = convertGraphConversationMessageToMessageData({
+      message: node({
+        message: { attachments: [{ type: 'image', payload: { title: 'receipt.png' } }] },
+      }),
+      ...BASE,
+    })
+
+    expect(result?.hasAttachments).toBe(false)
+    // The attachment still names the message, so an image-only DM is not a blank row.
+    expect(result?.snippet).toBe('receipt.png')
+  })
+
+  it('drops a node with no id, no sender, an unparseable time, or a third-party sender', () => {
+    expect(
+      convertGraphConversationMessageToMessageData({
+        message: node({ id: undefined, message: 'hi' }),
+        ...BASE,
+      })
+    ).toBe(null)
+    expect(
+      convertGraphConversationMessageToMessageData({ message: node({ from: undefined }), ...BASE })
+    ).toBe(null)
+    expect(
+      convertGraphConversationMessageToMessageData({
+        message: node({ created_time: 'not a date' }),
+        ...BASE,
+      })
+    ).toBe(null)
+    expect(
+      convertGraphConversationMessageToMessageData({
+        message: node({ from: { id: '999999999' } }),
+        ...BASE,
+      })
+    ).toBe(null)
+  })
+})

--- a/packages/lib/src/providers/social/__tests__/sync.test.ts
+++ b/packages/lib/src/providers/social/__tests__/sync.test.ts
@@ -1,0 +1,493 @@
+// packages/lib/src/providers/social/__tests__/sync.test.ts
+//
+// Covers the four things the FB/IG backfill can get silently and expensively wrong:
+//   1. The conversation CAP must terminate enumeration as a prefix — the page holds
+//      500+ conversations back to 2021 and the old walk read all of them every run.
+//   2. Incremental must STOP at the first conversation older than `since` instead of
+//      paginating to the end of history.
+//   3. `initialBackfillCompletedAt` must be stamped, or the received-time suppression
+//      window never closes and live inbound stops firing triggers forever.
+//   4. A channel with no `backfillCutoffAt` must fail CLOSED — the live dev channel is
+//      exactly that channel, and failing open publishes five years of history into
+//      workflow triggers and agent runs.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { socialThreadKey } from '../thread-key'
+
+const mocks = vi.hoisted(() => {
+  const updateWhere = vi.fn().mockResolvedValue(undefined)
+  const updateSet = vi.fn().mockReturnValue({ where: updateWhere })
+  const update = vi.fn().mockReturnValue({ set: updateSet })
+  return {
+    update,
+    updateSet,
+    updateWhere,
+    listConversations: vi.fn(),
+    listConversationMessages: vi.fn(),
+  }
+})
+
+// Partial mock: the chainable proxy still backs every builder the module graph touches
+// at import time; only `update` is pinned to a spy so the jsonb-merge writes are
+// assertable.
+vi.mock('@auxx/database', async () => {
+  const { createChainableDatabaseMock, createSchemaMock } = await import(
+    '../../../test/database-mock'
+  )
+  const database = new Proxy(createChainableDatabaseMock(), {
+    get: (target: any, prop: string) => (prop === 'update' ? mocks.update : target[prop]),
+  })
+  return {
+    database,
+    schema: createSchemaMock({
+      Integration: { id: 'Integration.id', metadata: 'Integration.metadata' },
+    }),
+  }
+})
+
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+// The Graph seam is the only network surface; stubbing it exercises every request shape
+// the walker builds without leaving the process.
+vi.mock('../api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../api')>()),
+  listConversations: mocks.listConversations,
+  listConversationMessages: mocks.listConversationMessages,
+}))
+
+const { resolveSocialBackfillCutoff, syncSocialMessages } = await import('../sync')
+
+const PAGE_ID = '869289333164075'
+const IGBID = '17841400000000000'
+
+function target(overrides: Record<string, unknown> = {}) {
+  return {
+    platform: 'facebook' as const,
+    graphPlatform: 'messenger' as const,
+    pageId: PAGE_ID,
+    ourId: PAGE_ID,
+    ourName: 'Auxx-Lift',
+    pageAccessToken: 'page_token',
+    integrationId: 'int_1',
+    organizationId: 'org_1',
+    ...overrides,
+  }
+}
+
+function storage() {
+  return {
+    batchStoreMessages: vi.fn().mockResolvedValue(1),
+    setBackfillCutoff: vi.fn(),
+  }
+}
+
+/** A conversation node with one counterpart, `n` positions from the top. */
+function conversation(
+  id: string,
+  updatedTime: string,
+  counterpartId = `psid_${id}`,
+  ourParticipantId = PAGE_ID
+) {
+  return {
+    id,
+    updated_time: updatedTime,
+    participants: {
+      data: [
+        { id: ourParticipantId, name: 'Auxx-Lift' },
+        { id: counterpartId, name: 'Jane' },
+      ],
+    },
+  }
+}
+
+function messageNode(id: string, counterpartId: string, createdTime = '2026-08-18T09:00:00+0000') {
+  return {
+    id,
+    created_time: createdTime,
+    from: { id: counterpartId, name: 'Jane' },
+    to: { data: [{ id: PAGE_ID }] },
+    message: 'hello',
+  }
+}
+
+/** Walks a drizzle `sql\`...\`` template's chunks for an interpolated value. */
+function sqlContains(chunk: any, value: string): boolean {
+  if (!chunk || typeof chunk !== 'object' || !Array.isArray(chunk.queryChunks)) return false
+  return chunk.queryChunks.some((part: any) => {
+    if (typeof part === 'string') return part.includes(value)
+    if (part && typeof part === 'object' && Array.isArray(part.value)) {
+      return part.value.some((v: unknown) => typeof v === 'string' && v.includes(value))
+    }
+    if (part && typeof part === 'object' && typeof part.value === 'string') {
+      return part.value.includes(value)
+    }
+    return false
+  })
+}
+
+function metadataWrites(): any[] {
+  return mocks.updateSet.mock.calls.map((call) => call[0].metadata).filter(Boolean)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.listConversationMessages.mockResolvedValue({ data: [] })
+})
+
+describe('resolveSocialBackfillCutoff — fail closed', () => {
+  it('suppresses on a channel that has NO cutoff and has never completed a backfill', () => {
+    // The live dev channel: connected before the stamp existed, and the stamp is
+    // insert-only, so it will never acquire one. The old expression evaluated falsy
+    // here and gave it no suppression at all.
+    const cutoff = resolveSocialBackfillCutoff({})
+    expect(cutoff).toBeInstanceOf(Date)
+  })
+
+  it('uses the stamped cutoff when there is one', () => {
+    const cutoff = resolveSocialBackfillCutoff({ backfillCutoffAt: '2026-08-17T00:00:00.000Z' })
+    expect(cutoff?.toISOString()).toBe('2026-08-17T00:00:00.000Z')
+  })
+
+  it('opens the gate only on an explicit initialBackfillCompletedAt', () => {
+    expect(
+      resolveSocialBackfillCutoff({
+        backfillCutoffAt: '2026-08-17T00:00:00.000Z',
+        initialBackfillCompletedAt: '2026-08-18T00:00:00.000Z',
+      })
+    ).toBe(null)
+  })
+})
+
+describe('syncSocialMessages — initial backfill', () => {
+  it('takes the newest-first prefix and stops at the cap', async () => {
+    mocks.listConversations.mockResolvedValue({
+      data: [
+        conversation('t_1', '2026-07-01T00:00:00+0000'),
+        conversation('t_2', '2025-08-01T00:00:00+0000'),
+        conversation('t_3', '2021-05-01T00:00:00+0000'),
+      ],
+      paging: { next: 'https://graph.facebook.com/next-page' },
+    })
+
+    const result = await syncSocialMessages({
+      target: target(),
+      metadata: { backfillConversationLimit: 2, backfillCutoffAt: '2026-08-17T00:00:00.000Z' },
+      storage: storage(),
+    })
+
+    expect(result.conversations).toBe(2)
+    expect(result.reachedCap).toBe(true)
+    // The cap is a prefix, so the walk never asks for the second page — that is the
+    // whole point of bounding by count on a newest-first list.
+    expect(mocks.listConversations).toHaveBeenCalledTimes(1)
+    expect(mocks.listConversationMessages.mock.calls.map((c) => c[0].conversationId)).toEqual([
+      't_1',
+      't_2',
+    ])
+  })
+
+  it('follows paging.next until the cap is reached', async () => {
+    mocks.listConversations
+      .mockResolvedValueOnce({
+        data: [conversation('t_1', '2026-07-01T00:00:00+0000')],
+        paging: { next: 'https://graph.facebook.com/page-2' },
+      })
+      .mockResolvedValueOnce({
+        data: [conversation('t_2', '2025-08-01T00:00:00+0000')],
+        paging: { next: null },
+      })
+
+    const result = await syncSocialMessages({
+      target: target(),
+      metadata: { backfillCutoffAt: '2026-08-17T00:00:00.000Z' },
+      storage: storage(),
+    })
+
+    expect(result.conversations).toBe(2)
+    expect(result.reachedCap).toBe(false)
+    expect(mocks.listConversations.mock.calls[1]![0].nextUrl).toBe(
+      'https://graph.facebook.com/page-2'
+    )
+  })
+
+  it('stamps initialBackfillCompletedAt and lifts the ingest cutoff', async () => {
+    mocks.listConversations.mockResolvedValue({
+      data: [conversation('t_1', '2026-07-01T00:00:00+0000')],
+      paging: { next: null },
+    })
+    const store = storage()
+    const metadata = { backfillCutoffAt: '2026-08-17T00:00:00.000Z' }
+
+    await syncSocialMessages({ target: target(), metadata, storage: store })
+
+    expect(metadataWrites().some((m) => sqlContains(m, 'initialBackfillCompletedAt'))).toBe(true)
+    expect(metadataWrites().some((m) => sqlContains(m, 'backfill'))).toBe(true)
+    expect(store.setBackfillCutoff).toHaveBeenCalledWith(null)
+    expect(metadata).toHaveProperty('initialBackfillCompletedAt')
+    // lastSyncedAt is stamped on the success path only.
+    expect(mocks.updateSet.mock.calls.some((call) => call[0].lastSyncedAt instanceof Date)).toBe(
+      true
+    )
+  })
+
+  it('arms a cutoff BEFORE storing anything when the channel has none', async () => {
+    mocks.listConversations.mockResolvedValue({
+      data: [conversation('t_1', '2026-07-01T00:00:00+0000')],
+      paging: { next: null },
+    })
+    mocks.listConversationMessages.mockResolvedValue({
+      data: [messageNode('m_1', 'psid_t_1', '2021-05-01T00:00:00+0000')],
+    })
+    const store = storage()
+    const metadata: Record<string, unknown> = {}
+
+    await syncSocialMessages({ target: target(), metadata, storage: store })
+
+    expect(metadata.backfillCutoffAt).toEqual(expect.any(String))
+    const armed = store.setBackfillCutoff.mock.calls[0]![0]
+    expect(armed).toBeInstanceOf(Date)
+    // Armed before the first store, lifted after the last one.
+    expect(store.setBackfillCutoff.mock.invocationCallOrder[0]!).toBeLessThan(
+      store.batchStoreMessages.mock.invocationCallOrder[0]!
+    )
+    expect(store.setBackfillCutoff).toHaveBeenLastCalledWith(null)
+    // Second guard: the backfill leg also declares itself an initial sync, which
+    // suppresses `message:received` for the batch regardless of the cutoff.
+    expect(store.batchStoreMessages).toHaveBeenCalledWith(expect.any(Array), undefined, true)
+  })
+
+  it('resumes after the recorded cursor instead of re-walking the prefix', async () => {
+    mocks.listConversations.mockResolvedValue({
+      data: [
+        conversation('t_1', '2026-07-01T00:00:00+0000'),
+        conversation('t_2', '2026-06-01T00:00:00+0000'),
+        conversation('t_3', '2026-05-01T00:00:00+0000'),
+        conversation('t_4', '2026-04-01T00:00:00+0000'),
+      ],
+      paging: { next: null },
+    })
+
+    const result = await syncSocialMessages({
+      target: target(),
+      metadata: {
+        backfillCutoffAt: '2026-08-17T00:00:00.000Z',
+        backfill: {
+          startedAt: '2026-08-18T08:00:00.000Z',
+          completedConversations: 2,
+          lastConversationId: 't_2',
+        },
+      },
+      storage: storage(),
+    })
+
+    expect(mocks.listConversationMessages.mock.calls.map((c) => c[0].conversationId)).toEqual([
+      't_3',
+      't_4',
+    ])
+    expect(result.conversations).toBe(2)
+  })
+
+  it('falls back to the completed count when the cursor conversation has vanished', async () => {
+    mocks.listConversations.mockResolvedValue({
+      data: [
+        conversation('t_9', '2026-07-02T00:00:00+0000'),
+        conversation('t_1', '2026-07-01T00:00:00+0000'),
+        conversation('t_3', '2026-05-01T00:00:00+0000'),
+      ],
+      paging: { next: null },
+    })
+
+    await syncSocialMessages({
+      target: target(),
+      metadata: {
+        backfillCutoffAt: '2026-08-17T00:00:00.000Z',
+        backfill: {
+          startedAt: '2026-08-18T08:00:00.000Z',
+          completedConversations: 2,
+          lastConversationId: 't_gone',
+        },
+      },
+      storage: storage(),
+    })
+
+    expect(mocks.listConversationMessages.mock.calls.map((c) => c[0].conversationId)).toEqual([
+      't_3',
+    ])
+  })
+
+  it('does not stamp lastSyncedAt when the run fails', async () => {
+    mocks.listConversations.mockRejectedValue(new Error('Graph request failed (500)'))
+
+    await expect(
+      syncSocialMessages({ target: target(), metadata: {}, storage: storage() })
+    ).rejects.toThrow('Graph request failed')
+
+    expect(mocks.updateSet.mock.calls.some((call) => call[0].lastSyncedAt instanceof Date)).toBe(
+      false
+    )
+  })
+
+  it('stores under the same thread key the webhook writes — IG on the IGBID', async () => {
+    mocks.listConversations.mockResolvedValue({
+      data: [conversation('t_1', '2026-07-01T00:00:00+0000', 'igsid_1', IGBID)],
+      paging: { next: null },
+    })
+    mocks.listConversationMessages.mockResolvedValue({
+      data: [{ ...messageNode('m_1', 'igsid_1'), to: { data: [{ id: IGBID }] } }],
+    })
+    const store = storage()
+
+    await syncSocialMessages({
+      target: target({ platform: 'instagram', graphPlatform: 'instagram', ourId: IGBID }),
+      metadata: { backfillCutoffAt: '2026-08-17T00:00:00.000Z' },
+      storage: store,
+    })
+
+    const [stored] = store.batchStoreMessages.mock.calls[0]!
+    expect(stored[0].externalThreadId).toBe(socialThreadKey(IGBID, 'igsid_1'))
+    // The conversations edge is still addressed on the linked Page, IG or not.
+    expect(mocks.listConversations.mock.calls[0]![0].pageId).toBe(PAGE_ID)
+    expect(mocks.listConversations.mock.calls[0]![0].platform).toBe('instagram')
+  })
+
+  it('keeps an IG message the page sent, even when Graph names the linked Page as sender', async () => {
+    // The two-id problem, end to end. `from.id` is the Page rather than the IGBID —
+    // unverified but not ruled out — and before the alias every message we sent was
+    // dropped as a third party, so an IG backfill kept only the customer's half.
+    mocks.listConversations.mockResolvedValue({
+      data: [conversation('t_1', '2026-07-01T00:00:00+0000', 'igsid_1', IGBID)],
+      paging: { next: null },
+    })
+    mocks.listConversationMessages.mockResolvedValue({
+      data: [
+        {
+          id: 'm_out',
+          created_time: '2026-08-18T09:00:00+0000',
+          from: { id: PAGE_ID, username: 'auxxlift' },
+          to: { data: [{ id: 'igsid_1' }] },
+          message: 'we are on it',
+        },
+      ],
+    })
+    const store = storage()
+
+    await syncSocialMessages({
+      target: target({ platform: 'instagram', graphPlatform: 'instagram', ourId: IGBID }),
+      metadata: { backfillCutoffAt: '2026-08-17T00:00:00.000Z' },
+      storage: store,
+    })
+
+    const [stored] = store.batchStoreMessages.mock.calls[0]!
+    expect(stored).toHaveLength(1)
+    expect(stored[0].isInbound).toBe(false)
+    expect(stored[0].from.identifier).toBe(IGBID)
+    expect(stored[0].externalThreadId).toBe(socialThreadKey(IGBID, 'igsid_1'))
+  })
+
+  it('passes no alias on Messenger, where the two ids are the same id', async () => {
+    // Messenger's page id IS its thread-key identity. Widening the "this is us"
+    // set there would be a way to mistake a customer for the page, so it stays off.
+    mocks.listConversations.mockResolvedValue({
+      data: [conversation('t_1', '2026-07-01T00:00:00+0000', 'psid_1')],
+      paging: { next: null },
+    })
+    mocks.listConversationMessages.mockResolvedValue({
+      data: [messageNode('m_1', 'psid_1')],
+    })
+    const store = storage()
+
+    await syncSocialMessages({
+      target: target(),
+      metadata: { backfillCutoffAt: '2026-08-17T00:00:00.000Z' },
+      storage: store,
+    })
+
+    const [stored] = store.batchStoreMessages.mock.calls[0]!
+    expect(stored[0].isInbound).toBe(true)
+    expect(stored[0].externalThreadId).toBe(socialThreadKey(PAGE_ID, 'psid_1'))
+  })
+})
+
+describe('syncSocialMessages — incremental', () => {
+  const completed = {
+    backfillCutoffAt: '2026-08-17T00:00:00.000Z',
+    initialBackfillCompletedAt: '2026-08-18T00:00:00.000Z',
+    backfill: {
+      startedAt: '2026-08-18T08:00:00.000Z',
+      completedConversations: 3,
+      completedAt: '2026-08-18T08:10:00.000Z',
+    },
+  }
+
+  it('stops at the first conversation older than `since` — one request on a quiet page', async () => {
+    mocks.listConversations.mockResolvedValue({
+      data: [
+        conversation('t_new', '2026-08-18T10:00:00+0000'),
+        conversation('t_old', '2025-08-01T00:00:00+0000'),
+        conversation('t_older', '2021-05-01T00:00:00+0000'),
+      ],
+      paging: { next: 'https://graph.facebook.com/page-2' },
+    })
+
+    const result = await syncSocialMessages({
+      target: target(),
+      metadata: { ...completed },
+      storage: storage(),
+      since: new Date('2026-08-18T00:00:00.000Z'),
+    })
+
+    expect(result.mode).toBe('incremental')
+    expect(result.conversations).toBe(1)
+    // The whole point: it does NOT walk 20 pages back to 2021 to discard them.
+    expect(mocks.listConversations).toHaveBeenCalledTimes(1)
+    expect(mocks.listConversationMessages.mock.calls.map((c) => c[0].conversationId)).toEqual([
+      't_new',
+    ])
+  })
+
+  it('never re-runs the backfill once completedAt is stamped', async () => {
+    mocks.listConversations.mockResolvedValue({ data: [], paging: { next: null } })
+    const store = storage()
+
+    await syncSocialMessages({
+      target: target(),
+      metadata: { ...completed },
+      storage: store,
+      since: new Date('2026-08-18T00:00:00.000Z'),
+    })
+
+    expect(metadataWrites().some((m) => sqlContains(m, 'initialBackfillCompletedAt'))).toBe(false)
+    expect(store.setBackfillCutoff).not.toHaveBeenCalled()
+  })
+
+  it('drops messages older than the floor, with slack for the Meta/us clock difference', async () => {
+    mocks.listConversations.mockResolvedValue({
+      data: [conversation('t_new', '2026-08-18T10:00:00+0000')],
+      paging: { next: null },
+    })
+    mocks.listConversationMessages.mockResolvedValue({
+      data: [
+        messageNode('m_fresh', 'psid_t_new', '2026-08-18T10:00:00+0000'),
+        // Two minutes before `since` — inside the slack, so it survives rather than
+        // being lost forever to a clock difference we do not control.
+        messageNode('m_edge', 'psid_t_new', '2026-08-17T23:58:00+0000'),
+        messageNode('m_ancient', 'psid_t_new', '2021-05-01T00:00:00+0000'),
+      ],
+    })
+    const store = storage()
+
+    await syncSocialMessages({
+      target: target(),
+      metadata: { ...completed },
+      storage: store,
+      since: new Date('2026-08-18T00:00:00.000Z'),
+    })
+
+    const [stored, , isInitialSync] = store.batchStoreMessages.mock.calls[0]!
+    expect(stored.map((m: any) => m.externalId)).toEqual(['m_fresh', 'm_edge'])
+    expect(isInitialSync).toBe(false)
+  })
+})

--- a/packages/lib/src/providers/social/conversation-message.ts
+++ b/packages/lib/src/providers/social/conversation-message.ts
@@ -1,0 +1,328 @@
+// packages/lib/src/providers/social/conversation-message.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import type { MessageData } from '../../ingest/types'
+import type { GraphConversation, GraphConversationMessage } from './api'
+import { socialThreadKey } from './thread-key'
+import type { SocialPlatform } from './types'
+
+const logger = createScopedLogger('social-conversation-message')
+
+const SNIPPET_LENGTH = 100
+
+/**
+ * A conversation-message node's `message` field, as we are willing to receive it.
+ *
+ * **This is the one genuinely unverified shape in the FB/IG channel.** Nobody has
+ * captured a real payload from `GET /{conversationId}/messages` — the only sync run
+ * that ever reached this edge discarded every conversation on a client-side `since`
+ * filter before fetching a single message (see
+ * `plans/channels/facebook-instagram-runtime-fixes.md` WS7).
+ *
+ * What we believe, and why the code does not depend on it: Graph's Message node
+ * documents `message` as a **scalar string**, which is why the old code's
+ * `fields=message{text,attachments,mid}` was not a richer request but an invalid
+ * expansion — subfield selection on a scalar is an error, so that fetch may simply
+ * have been failing. `{@link listConversationMessages}` therefore asks for bare
+ * `message` and this converter accepts **either** shape:
+ *
+ * - `message: "where's my order?"` — the documented scalar.
+ * - `message: { text: "…", mid?, attachments? }` — the webhook-ish object, accepted
+ *   because being wrong here means silently storing `[object Object]` as the body of
+ *   five years of real customer mail.
+ *
+ * Run `packages/lib/scripts/probe-meta-conversations.ts` against the live channel to
+ * settle it; once settled, the loser branch can go.
+ */
+export type GraphConversationMessageBody =
+  | string
+  | {
+      text?: string
+      mid?: string
+      attachments?: Array<{ type?: string; payload?: { url?: string; title?: string } }>
+    }
+
+/** A `GraphConversationMessage` whose `message` may have arrived as an object. */
+export type TolerantConversationMessage = Omit<GraphConversationMessage, 'message'> & {
+  message?: GraphConversationMessageBody
+}
+
+/**
+ * The message text, whichever shape Graph answered with.
+ *
+ * A non-string, non-object `message` (a number, an array) yields `undefined` rather
+ * than a coerced string: an unexpected shape is a shape we do not understand, and
+ * stringifying it stores garbage that looks like a customer wrote it.
+ */
+export function conversationMessageText(
+  body: GraphConversationMessageBody | undefined
+): string | undefined {
+  if (typeof body === 'string') return body
+  if (body && typeof body === 'object' && !Array.isArray(body)) {
+    return typeof body.text === 'string' ? body.text : undefined
+  }
+  return undefined
+}
+
+/** Attachment descriptors, only present if `message` came back as an object. */
+function conversationMessageAttachments(
+  body: GraphConversationMessageBody | undefined
+): Array<{ type?: string; payload?: { url?: string; title?: string } }> {
+  if (body && typeof body === 'object' && !Array.isArray(body) && Array.isArray(body.attachments)) {
+    return body.attachments
+  }
+  return []
+}
+
+/**
+ * The `mid` carried *inside* the message body, if the object shape is real.
+ *
+ * Kept separate from the node's own `id` because they are different ideas: `id`
+ * identifies the node on this edge, `mid` is the id the webhook and the send path
+ * both use. They are believed to be the same value (`m_…`) — see
+ * {@link conversationMessageExternalId}.
+ */
+function conversationMessageMid(
+  body: GraphConversationMessageBody | undefined
+): string | undefined {
+  if (body && typeof body === 'object' && !Array.isArray(body) && typeof body.mid === 'string') {
+    return body.mid
+  }
+  return undefined
+}
+
+/**
+ * The id to store as `Message.externalId`.
+ *
+ * **`mid` wins when it is there, and the node's own `id` is the fallback — in that
+ * order, deliberately.** `(integrationId, externalId)` is the idempotency key that
+ * dedupes one message across all three doors (webhook, REST sync, our own send), and
+ * the other two doors both stamp the `mid`. The node `id` on this edge is believed to
+ * BE the `mid` (both are `m_…` strings), which would make the fallback exact rather
+ * than merely adequate — but that is unverified, so the explicit `mid` is preferred
+ * whenever the payload offers one.
+ *
+ * If the belief turns out to be wrong, the failure is visible and self-limiting: a
+ * backfilled message would store under a second id and appear twice in one thread,
+ * rather than landing in the wrong thread.
+ */
+export function conversationMessageExternalId(
+  message: TolerantConversationMessage
+): string | undefined {
+  return conversationMessageMid(message.message) ?? message.id ?? undefined
+}
+
+/**
+ * The non-us participant of a conversation.
+ *
+ * **`ourIds` is a set, not a single id, and that is deliberate.** Our side of an
+ * Instagram conversation is the IG business account id — that is what the IG webhook
+ * puts in `recipient.id`, so that is what the thread key must use — but the
+ * `/conversations` edge is addressed on the *linked Page*, and nobody has verified which
+ * of the two ids Graph lists as a participant for `platform=instagram`. Excluding both
+ * makes the pick correct either way; matching on one would silently return our own Page
+ * as "the customer" if the guess were wrong.
+ *
+ * Returns `null` for a conversation with no other party — a self-conversation, or a
+ * participants list Graph declined to expand.
+ */
+export function pickConversationCounterpart(
+  conversation: GraphConversation,
+  ourIds: string | readonly string[]
+): { id: string; name?: string } | null {
+  const ours = new Set(typeof ourIds === 'string' ? [ourIds] : ourIds)
+  const participants = conversation.participants?.data ?? []
+  const other = participants.find((participant) => participant.id && !ours.has(participant.id))
+  if (!other?.id) return null
+  return { id: other.id, name: other.username ?? other.name }
+}
+
+export interface ConvertGraphConversationMessageInput {
+  message: TolerantConversationMessage
+  /** The `t_…` conversation id. Stored in `metadata` for deep links, never as a key. */
+  conversationId?: string
+  integrationId: string
+  organizationId: string
+  inboxId?: string
+  /** Our side: the Page id (Messenger) or the IG business account id (Instagram). */
+  ourId: string
+  /**
+   * Other ids that are also **us** on this conversation, and must be read as our
+   * side without becoming the thread key.
+   *
+   * This exists for exactly one reason, and it is the same reason
+   * {@link pickConversationCounterpart} takes a set: on Instagram our identity is
+   * the IG business account id (that is what the IG webhook puts in
+   * `recipient.id`, so that is what the key must use) while the `/conversations`
+   * edge is addressed on the **linked Page**, and which of the two Graph names as
+   * the business on a `platform=instagram` node is unverified.
+   *
+   * Excluding both from the counterpart pick but accepting only `ourId` as a
+   * sender left the defence half-applied: if Graph answers with the Page id, the
+   * counterpart is still picked correctly and **every message we ever sent is
+   * dropped** as "a third party", silently, with only a warn log — an IG backfill
+   * that stores the customer's half of five years of conversation and none of
+   * ours. Matching the alias fixes the direction; `ourId` still supplies the
+   * identifier and the key, so the thread stays byte-identical to the webhook's.
+   */
+  ourAliasIds?: readonly string[]
+  /** The other party's PSID / IGSID, resolved from the conversation's participants. */
+  counterpartId: string
+  counterpartName?: string
+  /** Our display name — page name, or IG handle. */
+  ourName?: string
+  platform: SocialPlatform
+}
+
+/**
+ * Converts one `GET /{conversationId}/messages` node into `MessageData`.
+ *
+ * **A second converter, not a reuse of `webhook-message.ts`, and that is the point.**
+ * The two doors carry different shapes: the webhook nests `{ mid, text, attachments }`
+ * under `message` and names the parties `sender`/`recipient`; this edge answers a flat
+ * node with `from`/`to` and (believed) a scalar `message`. Quo taught the same lesson
+ * with `body` vs `text` — a shared mapper reads `undefined` on one of the two paths and
+ * produces silently empty messages rather than crashing.
+ *
+ * What the two DO share is the thread key: `socialThreadKey(ourId, counterpartId)`,
+ * byte-identical to what the webhook writes. There is no RFC 5322 parentage chain to
+ * recover from a disagreement (`resolve-thread.ts` gates rung 2 to outlook/imap), so a
+ * key that differs by one character forks the conversation permanently.
+ *
+ * @returns `null` when the node is unusable — no id, no resolvable direction, an
+ * unparseable timestamp. Never throws: one malformed node must not abort a backfill.
+ */
+export function convertGraphConversationMessageToMessageData(
+  input: ConvertGraphConversationMessageInput
+): MessageData | null {
+  const {
+    message,
+    conversationId,
+    integrationId,
+    organizationId,
+    inboxId,
+    ourId,
+    counterpartId,
+    counterpartName,
+    ourName,
+    platform,
+  } = input
+
+  try {
+    const externalId = conversationMessageExternalId(message)
+    if (!externalId) {
+      logger.warn('Conversation message has no id; dropping', {
+        platform,
+        integrationId,
+        conversationId,
+      })
+      return null
+    }
+
+    const senderId = message.from?.id
+    if (!senderId) {
+      logger.warn('Conversation message has no sender; dropping', {
+        platform,
+        integrationId,
+        externalId,
+      })
+      return null
+    }
+
+    // Direction comes from which side sent it, never from "REST implies inbound".
+    // A page's own replies are on this edge too, and misfiling them makes our
+    // outbound history read as customer messages.
+    let isInbound: boolean
+    if (senderId === ourId || input.ourAliasIds?.includes(senderId)) {
+      isInbound = false
+    } else if (senderId === counterpartId) {
+      isInbound = true
+    } else {
+      logger.warn('Conversation message names a third party as sender; dropping', {
+        platform,
+        integrationId,
+        externalId,
+        senderId,
+        ourId,
+        counterpartId,
+      })
+      return null
+    }
+
+    const createdTime = new Date(message.created_time ?? '')
+    if (Number.isNaN(createdTime.getTime())) {
+      logger.warn('Unparseable created_time on a conversation message; dropping', {
+        platform,
+        integrationId,
+        externalId,
+        createdTime: message.created_time,
+      })
+      return null
+    }
+
+    // `from` names the SENDER and nobody else. Stamping it on the counterpart too
+    // names the customer after our own Page on every page-sent node, and the
+    // participant upsert takes the last write that carries a usable name — so one
+    // reply of ours anywhere in the batch renames the customer to the Page, and
+    // every message they ever sent then renders as authored by us.
+    const senderName = message.from?.username ?? message.from?.name
+    const ourParticipant = {
+      identifier: ourId,
+      name: isInbound ? ourName : (senderName ?? ourName),
+    }
+    const counterpartParticipant = {
+      identifier: counterpartId,
+      name: isInbound ? (senderName ?? counterpartName) : counterpartName,
+    }
+
+    const text = conversationMessageText(message.message)
+    const attachments = conversationMessageAttachments(message.message)
+    const firstAttachmentName = attachments[0]?.payload?.title || attachments[0]?.type || ''
+
+    return {
+      externalId,
+      // NOT the `t_…` conversation id. The webhook never receives one, so the REST
+      // path must derive the SAME pair key or one conversation becomes two threads.
+      externalThreadId: socialThreadKey(ourId, counterpartId),
+      integrationId,
+      inboxId,
+      organizationId,
+      createdTime,
+      sentAt: createdTime,
+      receivedAt: createdTime,
+      // No subject. Messenger and IG have none, and the fabricated "commented on
+      // your Facebook post" string this replaces was actively wrong — these are
+      // DMs, not comments. Thread titles are participant-derived at render, the
+      // same rule SMS follows.
+      subject: undefined,
+      from: isInbound ? counterpartParticipant : ourParticipant,
+      to: [isInbound ? ourParticipant : counterpartParticipant],
+      cc: [],
+      bcc: [],
+      replyTo: [],
+      // Neither channel has an inbound attachment ingestor, so no MessageAttachment
+      // rows exist. `hasAttachments` is a workflow trigger filter, so claiming true
+      // fires attachment rules against bytes that were never fetched. The attachment
+      // list above only feeds the snippet fallback.
+      hasAttachments: false,
+      textPlain: text,
+      textHtml: undefined,
+      snippet: text ? text.substring(0, SNIPPET_LENGTH) : firstAttachmentName,
+      isInbound,
+      metadata: {
+        meta_conversation_id: conversationId,
+        meta_conversation_message: message as unknown as Record<string, unknown>,
+      },
+      keywords: [],
+      labelIds: [],
+    }
+  } catch (error) {
+    logger.error('Failed to convert a Meta conversation message', {
+      platform,
+      integrationId,
+      messageId: message?.id,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}

--- a/packages/lib/src/providers/social/sync.ts
+++ b/packages/lib/src/providers/social/sync.ts
@@ -1,0 +1,557 @@
+// packages/lib/src/providers/social/sync.ts
+
+import { database as db, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { eq, sql } from 'drizzle-orm'
+import type { MessageData } from '../../ingest/types'
+import {
+  type GraphConversation,
+  isRateLimited,
+  isReauthRequired,
+  listConversationMessages,
+  listConversations,
+} from './api'
+import {
+  convertGraphConversationMessageToMessageData,
+  pickConversationCounterpart,
+  type TolerantConversationMessage,
+} from './conversation-message'
+import type { SocialPlatform } from './types'
+
+const logger = createScopedLogger('social-sync')
+
+/**
+ * How many conversations one initial backfill ingests.
+ *
+ * **The bound is a CONVERSATION COUNT, not a time window, and that is the whole
+ * design.** Graph returns `/{pageId}/conversations` newest-first by `updated_time`
+ * (verified live on the Auxx-Lift page: page boundaries descend 2026-07 → 2025-08 →
+ * 2025-02 → 2024-04 → 2023-09 → 2021-05), which makes a count cap a clean **prefix** —
+ * take N and stop paginating. The implementation this replaces applied its `since`
+ * filter *after* fetching, so a run read all 500+ conversations in order to discard
+ * every one of them: cost scaled with the page's entire history rather than with what
+ * we keep.
+ *
+ * Judged against a 100k-conversation page, not our test pages: 100 conversations costs
+ * ~4 list requests (25 per page) plus one messages request each — ~104 Graph calls,
+ * flat, whatever the page holds. That matters because **the cap is the only rate-limit
+ * guard on this path**: unlike Quo there is no shared pacer in front of Graph.
+ *
+ * A constant, not a UI knob, until someone asks for one — but overridable per channel
+ * via `Integration.metadata.backfillConversationLimit` for the one-off big-page case.
+ */
+export const SOCIAL_BACKFILL_CONVERSATION_LIMIT = 100
+
+/**
+ * Newest messages fetched per conversation. One request per conversation, no message
+ * pagination: a five-year support thread is not worth 40 round trips during a first
+ * connect, and anything older stays reachable in Messenger itself.
+ */
+export const SOCIAL_BACKFILL_MESSAGES_PER_CONVERSATION = 50
+
+/** Graph's own default page size on the conversations edge. */
+export const SOCIAL_CONVERSATION_PAGE_SIZE = 25
+
+/** Persist resume progress every N conversations — 10 writes for a 100-conversation run. */
+const BACKFILL_PROGRESS_WRITE_EVERY = 10
+
+/**
+ * Slack applied to the incremental message floor.
+ *
+ * `since` is OUR clock (`Integration.lastSyncedAt`) while `created_time` is Meta's, and
+ * a message that lands a few seconds the wrong side of that difference would be dropped
+ * *permanently* — the next run's `since` is later still. Five minutes of slack costs a
+ * handful of re-presented messages, which `(integrationId, externalId)` dedupes anyway.
+ */
+const INCREMENTAL_CLOCK_SLACK_MS = 5 * 60 * 1000
+
+/**
+ * Resumable backfill progress, stored on `Integration.metadata.backfill`.
+ *
+ * Deliberately small — a position, not the conversation list. A resumed run
+ * re-enumerates the same newest-first prefix (bounded: ~4 requests) and continues after
+ * `lastConversationId`. A conversation whose `updated_time` bumps mid-run may shift
+ * position and get re-fetched (harmless: ingest dedupes on `externalId`) or skipped —
+ * and a bump means a live webhook already delivered that message.
+ */
+export interface SocialBackfillState {
+  startedAt: string
+  completedConversations: number
+  lastConversationId?: string | null
+  completedAt?: string | null
+}
+
+/** The `Integration.metadata` fields this module reads and writes. */
+export interface SocialSyncMetadata {
+  backfill?: SocialBackfillState
+  backfillConversationLimit?: number
+  backfillCutoffAt?: string
+  initialBackfillCompletedAt?: string
+}
+
+/**
+ * The received-time cutoff a provider should arm on `initialize()` — the **consume**
+ * half of the WS7a contract, and it fails CLOSED.
+ *
+ * The expression this replaces was `backfillCutoffAt && !initialBackfillCompletedAt`,
+ * which reads correctly and behaves dangerously: a channel with **no**
+ * `backfillCutoffAt` evaluates falsy and gets no suppression at all. The live dev
+ * channel is exactly that — connected before the stamp existed, and the stamp is
+ * insert-only by design (a reconnect must never reopen a closed window), so it will
+ * never acquire one. Under the old expression, backfilling it would publish
+ * `message:received` for 500+ conversations back to 2021.
+ *
+ * The two failure modes are not symmetric. Suppressing when we did not need to costs
+ * missed trigger fires on messages that are history by definition. *Not* suppressing
+ * when we needed to fires thousands of workflow runs, agent replies and AI
+ * classifications at real customers. So: **no cutoff and no completed backfill ⇒
+ * suppress from now.** Only an explicit `initialBackfillCompletedAt` opens the gate.
+ *
+ * This is safe for live inbound because it is not on the live inbound path at all: the
+ * webhook routes build their own `MessageStorageService` and never call
+ * `setBackfillCutoff`. Only provider-driven sync runs see this value — and even for a
+ * long-lived provider instance, a live message's `receivedAt` is after the instant this
+ * returns, so it would not be suppressed anyway.
+ */
+export function resolveSocialBackfillCutoff(metadata: SocialSyncMetadata | null): Date | null {
+  if (!metadata) return new Date()
+  if (metadata.initialBackfillCompletedAt) return null
+  return metadata.backfillCutoffAt ? new Date(metadata.backfillCutoffAt) : new Date()
+}
+
+/** Identity and credentials for one channel's sync run. */
+export interface SocialSyncTarget {
+  platform: SocialPlatform
+  /**
+   * Graph's `platform` query param on the conversations edge. Messenger and Instagram
+   * Direct are two *platforms* on the same Page edge, not two endpoints.
+   */
+  graphPlatform: 'messenger' | 'instagram'
+  /** The Facebook Page id the `/conversations` edge is addressed on — IG included. */
+  pageId: string
+  /**
+   * Our identity inside the conversation: the Page id for Messenger, the **IG business
+   * account id** for Instagram. This is what goes into the thread key and what the
+   * webhook puts on our side, and for IG it is NOT the page id.
+   */
+  ourId: string
+  ourName?: string
+  pageAccessToken: string
+  integrationId: string
+  organizationId: string
+  inboxId?: string
+}
+
+/**
+ * The slice of `MessageStorageService` a sync run needs. Structural rather than the
+ * class, so this module stays unit-testable without an ingest context.
+ */
+export interface SocialSyncStorage {
+  batchStoreMessages(
+    messages: MessageData[],
+    batchId?: string,
+    isInitialSync?: boolean
+  ): Promise<number>
+  setBackfillCutoff(cutoff: Date | null): void
+}
+
+export interface SocialSyncResult {
+  mode: 'initial-backfill' | 'incremental'
+  conversations: number
+  messages: number
+  /** True when the conversation cap, not the end of the list, ended enumeration. */
+  reachedCap: boolean
+}
+
+/**
+ * Backfills / catches up one Messenger or Instagram channel.
+ *
+ * **Two jobs, split — `syncMessages(since)` used to conflate them:**
+ *
+ * 1. *Initial backfill* — nothing stamped in `metadata.backfill.completedAt`. Walks the
+ *    newest-first conversation prefix up to the count cap, resumably, and stamps
+ *    `initialBackfillCompletedAt` at the end. **That stamp is load-bearing**: it is what
+ *    closes the received-time suppression window, and a backfill that fails to stamp it
+ *    leaves the channel silently unable to fire a workflow trigger ever again.
+ * 2. *Incremental* — `since = lastSyncedAt`, and enumeration **stops at the first
+ *    conversation older than `since`** rather than walking to the end. On a quiet page
+ *    that is one request.
+ *
+ * `lastSyncedAt` is stamped on success only. The implementation this replaces stamped it
+ * in its catch block too, which made a channel that had never ingested anything look
+ * healthy.
+ */
+export async function syncSocialMessages(args: {
+  target: SocialSyncTarget
+  /** The provider's cached `Integration.metadata`. Updated in place as state is written. */
+  metadata: SocialSyncMetadata
+  storage: SocialSyncStorage
+  since?: Date
+}): Promise<SocialSyncResult> {
+  const { target, metadata, storage, since } = args
+  const isInitialBackfill = !metadata.backfill?.completedAt
+
+  logger.info('Starting Meta conversation sync', {
+    platform: target.platform,
+    pageId: target.pageId,
+    mode: isInitialBackfill ? 'initial-backfill' : 'incremental',
+    since: since?.toISOString(),
+    integrationId: target.integrationId,
+  })
+
+  const result = isInitialBackfill
+    ? await runInitialBackfill(target, metadata, storage)
+    : await runIncrementalSync(target, metadata, storage, since)
+
+  await db
+    .update(schema.Integration)
+    .set({ lastSyncedAt: new Date() })
+    .where(eq(schema.Integration.id, target.integrationId))
+
+  logger.info('Meta conversation sync complete', {
+    platform: target.platform,
+    integrationId: target.integrationId,
+    ...result,
+  })
+  return result
+}
+
+function conversationLimit(metadata: SocialSyncMetadata): number {
+  const configured = metadata.backfillConversationLimit
+  return typeof configured === 'number' && configured > 0
+    ? Math.floor(configured)
+    : SOCIAL_BACKFILL_CONVERSATION_LIMIT
+}
+
+async function runInitialBackfill(
+  target: SocialSyncTarget,
+  metadata: SocialSyncMetadata,
+  storage: SocialSyncStorage
+): Promise<SocialSyncResult> {
+  const limit = conversationLimit(metadata)
+
+  // Fail CLOSED before a single historical message is stored — see
+  // `ensureBackfillCutoff`.
+  await ensureBackfillCutoff(target.integrationId, metadata, storage)
+
+  const resumeFrom = metadata.backfill
+  const enumerated = await collectConversations(target, limit)
+  const conversations = enumerated.conversations
+
+  let startIndex = 0
+  if (resumeFrom) {
+    const found = resumeFrom.lastConversationId
+      ? conversations.findIndex((conversation) => conversation.id === resumeFrom.lastConversationId)
+      : -1
+    // The cursor conversation can genuinely vanish from the prefix (deleted, or bumped
+    // out by newer traffic). Falling back to the raw count re-does at most a few
+    // conversations, which ingest dedupes, instead of skipping the rest of the run.
+    startIndex =
+      found >= 0 ? found + 1 : Math.min(resumeFrom.completedConversations, conversations.length)
+    logger.info('Resuming Meta backfill', {
+      startIndex,
+      total: conversations.length,
+      cursorFound: found >= 0,
+      integrationId: target.integrationId,
+    })
+  }
+
+  const state: SocialBackfillState = {
+    startedAt: resumeFrom?.startedAt ?? new Date().toISOString(),
+    completedConversations: startIndex,
+    lastConversationId: resumeFrom?.lastConversationId ?? null,
+  }
+  await writeBackfillState(target.integrationId, metadata, state)
+
+  let messages = 0
+  for (let index = startIndex; index < conversations.length; index++) {
+    const conversation = conversations[index]!
+    messages += await ingestConversation(target, conversation, storage, {
+      isInitialBackfill: true,
+    })
+    state.completedConversations = index + 1
+    state.lastConversationId = conversation.id ?? null
+    if (state.completedConversations % BACKFILL_PROGRESS_WRITE_EVERY === 0) {
+      await writeBackfillState(target.integrationId, metadata, state)
+    }
+  }
+
+  state.completedAt = new Date().toISOString()
+  await writeBackfillState(target.integrationId, metadata, state)
+
+  // Closing the suppression window is the last act of the backfill, and it is the half
+  // of the WS7a contract that had no writer until now. Without it `setBackfillCutoff`
+  // stays armed on every later `initialize()` and live inbound never fires a trigger
+  // again — a channel that looks connected and behaves like a dead one.
+  await db
+    .update(schema.Integration)
+    .set({
+      metadata: sql`COALESCE(${schema.Integration.metadata}, '{}'::jsonb) || jsonb_build_object('initialBackfillCompletedAt', ${state.completedAt}::text)`,
+    })
+    .where(eq(schema.Integration.id, target.integrationId))
+  metadata.initialBackfillCompletedAt = state.completedAt
+  storage.setBackfillCutoff(null)
+
+  return {
+    mode: 'initial-backfill',
+    conversations: conversations.length - startIndex,
+    messages,
+    reachedCap: enumerated.reachedCap,
+  }
+}
+
+async function runIncrementalSync(
+  target: SocialSyncTarget,
+  metadata: SocialSyncMetadata,
+  storage: SocialSyncStorage,
+  since: Date | undefined
+): Promise<SocialSyncResult> {
+  // The scheduled path calls `syncMessages()` with no argument, so the floor has to come
+  // from the row. `lastSyncedAt` rather than a fixed 24h window, because a fixed window
+  // is a silent data-loss bug the moment the worker is down longer than it: a
+  // conversation that changed two days ago would be skipped, and the NEXT run's floor is
+  // later still, so it is skipped forever. 24h is only the last-resort floor for a
+  // channel that has never recorded a sync.
+  const floor =
+    since ??
+    (await lastSyncedAt(target.integrationId)) ??
+    new Date(Date.now() - 24 * 60 * 60 * 1000)
+  const enumerated = await collectConversations(target, conversationLimit(metadata), floor)
+
+  const messageFloor = new Date(floor.getTime() - INCREMENTAL_CLOCK_SLACK_MS)
+  let messages = 0
+  for (const conversation of enumerated.conversations) {
+    messages += await ingestConversation(target, conversation, storage, {
+      isInitialBackfill: false,
+      messageFloor,
+    })
+  }
+
+  return {
+    mode: 'incremental',
+    conversations: enumerated.conversations.length,
+    messages,
+    reachedCap: enumerated.reachedCap,
+  }
+}
+
+/**
+ * Walks `/{pageId}/conversations` newest-first and returns the prefix to ingest.
+ *
+ * `stopBefore` is the incremental bound. Because the list descends by `updated_time`,
+ * the first conversation older than it means every later one is older still — so
+ * enumeration stops **paginating** there instead of reading to the end of five years of
+ * history. The remaining entries of the page already in hand are still examined rather
+ * than dropped wholesale: that costs no extra request and tolerates any local disorder
+ * in Graph's ordering, which we have observed but not proven absent.
+ */
+async function collectConversations(
+  target: SocialSyncTarget,
+  limit: number,
+  stopBefore?: Date
+): Promise<{ conversations: GraphConversation[]; reachedCap: boolean }> {
+  const conversations: GraphConversation[] = []
+  const seen = new Set<string>()
+  let nextUrl: string | undefined
+  let reachedCap = false
+  let sawOlderThanCutoff = false
+
+  do {
+    const page = await listConversations({
+      pageId: target.pageId,
+      pageAccessToken: target.pageAccessToken,
+      platform: target.graphPlatform,
+      nextUrl,
+      limit: SOCIAL_CONVERSATION_PAGE_SIZE,
+    })
+    const rows = page.data ?? []
+    if (rows.length === 0) break
+
+    for (const conversation of rows) {
+      if (!conversation.id || seen.has(conversation.id)) continue
+      if (stopBefore && conversation.updated_time) {
+        const updated = new Date(conversation.updated_time)
+        if (!Number.isNaN(updated.getTime()) && updated < stopBefore) {
+          sawOlderThanCutoff = true
+          continue
+        }
+      }
+      seen.add(conversation.id)
+      conversations.push(conversation)
+      if (conversations.length >= limit) {
+        reachedCap = true
+        break
+      }
+    }
+
+    if (reachedCap || sawOlderThanCutoff) break
+    nextUrl = page.paging?.next ?? undefined
+  } while (nextUrl)
+
+  logger.debug('Enumerated Meta conversations', {
+    platform: target.platform,
+    collected: conversations.length,
+    reachedCap,
+    stoppedOnCutoff: sawOlderThanCutoff,
+    integrationId: target.integrationId,
+  })
+  return { conversations, reachedCap }
+}
+
+/**
+ * Fetches the newest page of one conversation's messages and stores them.
+ *
+ * A failure on one conversation is logged and skipped so the cursor still advances —
+ * **except** when the token is dead or Meta is throttling us, which are conditions the
+ * remaining 99 conversations will hit identically. Those abort the run so the retry
+ * happens later rather than burning the whole cap against a wall.
+ */
+async function ingestConversation(
+  target: SocialSyncTarget,
+  conversation: GraphConversation,
+  storage: SocialSyncStorage,
+  options: { isInitialBackfill: boolean; messageFloor?: Date }
+): Promise<number> {
+  const conversationId = conversation.id
+  if (!conversationId) return 0
+
+  // Both of our ids: on Instagram the thread key uses the IG business account id while
+  // the edge is addressed on the Page, and which of the two Graph lists as a participant
+  // is unverified. Excluding both is right either way.
+  const counterpart = pickConversationCounterpart(conversation, [target.ourId, target.pageId])
+  if (!counterpart) {
+    logger.warn('Meta conversation has no counterpart participant; skipping', {
+      platform: target.platform,
+      conversationId,
+      integrationId: target.integrationId,
+    })
+    return 0
+  }
+
+  let nodes: TolerantConversationMessage[]
+  try {
+    const page = await listConversationMessages({
+      conversationId,
+      pageAccessToken: target.pageAccessToken,
+      limit: SOCIAL_BACKFILL_MESSAGES_PER_CONVERSATION,
+    })
+    nodes = (page.data ?? []) as TolerantConversationMessage[]
+  } catch (error) {
+    if (isReauthRequired(error) || isRateLimited(error)) throw error
+    logger.error('Failed to fetch messages for a Meta conversation', {
+      platform: target.platform,
+      conversationId,
+      integrationId: target.integrationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return 0
+  }
+
+  const messages = nodes
+    .filter((node) => {
+      if (!options.messageFloor || !node.created_time) return true
+      const created = new Date(node.created_time)
+      return Number.isNaN(created.getTime()) || created >= options.messageFloor
+    })
+    .map((node) =>
+      convertGraphConversationMessageToMessageData({
+        message: node,
+        conversationId,
+        integrationId: target.integrationId,
+        organizationId: target.organizationId,
+        inboxId: target.inboxId,
+        ourId: target.ourId,
+        // Instagram only: the edge is addressed on the linked Page while our
+        // identity is the IGBID, and Graph may name either as the business on a
+        // page-sent node. Accepting both as "us" is the same defence
+        // `pickConversationCounterpart` already applies — without it, an IG
+        // backfill silently drops every message the page ever sent.
+        ourAliasIds: target.pageId === target.ourId ? undefined : [target.pageId],
+        counterpartId: counterpart.id,
+        counterpartName: counterpart.name,
+        ourName: target.ourName,
+        platform: target.platform,
+      })
+    )
+    .filter((message): message is MessageData => message !== null)
+
+  if (messages.length === 0) return 0
+  // `isInitialSync` on the backfill leg suppresses `message:received` for the whole
+  // batch independently of the received-time cutoff — two guards, because publishing
+  // five years of history into workflow triggers and agent runs is not recoverable.
+  return storage.batchStoreMessages(messages, undefined, options.isInitialBackfill)
+}
+
+/**
+ * Arms the received-time cutoff for a channel that has none — the **fail-closed**
+ * decision, taken deliberately.
+ *
+ * The consume side in both providers reads
+ * `backfillCutoffAt && !initialBackfillCompletedAt`, so a channel with **no**
+ * `backfillCutoffAt` evaluates falsy and gets *no* suppression at all. That is not a
+ * hypothetical: the live dev channel was connected before the stamp existed, and the
+ * stamp is insert-only by design (a reconnect must never reopen a closed window), so it
+ * will never acquire one. Running a backfill against it as-is publishes
+ * `message:received` for 500+ conversations back to 2021 — mass-firing workflow
+ * triggers, agent runs and AI classification against real customer mail.
+ *
+ * Fail-open is the wrong default because the two failure modes are not symmetric. A
+ * cutoff wrongly armed costs missed trigger fires on messages that are *history* by
+ * definition; a cutoff wrongly absent sends thousands of automated replies to real
+ * people. So: no cutoff **and** no completed backfill ⇒ suppress from now.
+ *
+ * Stamped rather than merely computed, so the value is durable, visible in the row, and
+ * identical across a resumed run. This cannot reopen a closed window — a closed window
+ * implies `initialBackfillCompletedAt`, and this only runs on the initial-backfill leg.
+ */
+async function ensureBackfillCutoff(
+  integrationId: string,
+  metadata: SocialSyncMetadata,
+  storage: SocialSyncStorage
+): Promise<void> {
+  if (metadata.initialBackfillCompletedAt) return
+  if (metadata.backfillCutoffAt) {
+    storage.setBackfillCutoff(new Date(metadata.backfillCutoffAt))
+    return
+  }
+
+  const cutoff = new Date()
+  await db
+    .update(schema.Integration)
+    .set({
+      metadata: sql`COALESCE(${schema.Integration.metadata}, '{}'::jsonb) || jsonb_build_object('backfillCutoffAt', ${cutoff.toISOString()}::text)`,
+    })
+    .where(eq(schema.Integration.id, integrationId))
+  metadata.backfillCutoffAt = cutoff.toISOString()
+  storage.setBackfillCutoff(cutoff)
+
+  logger.warn('Channel had no backfillCutoffAt — stamping one before backfilling', {
+    integrationId,
+    cutoffAt: cutoff.toISOString(),
+  })
+}
+
+/** The channel's last successful sync instant, or `null` if it has never synced. */
+async function lastSyncedAt(integrationId: string): Promise<Date | null> {
+  const [row] = await db
+    .select({ lastSyncedAt: schema.Integration.lastSyncedAt })
+    .from(schema.Integration)
+    .where(eq(schema.Integration.id, integrationId))
+    .limit(1)
+  return row?.lastSyncedAt ?? null
+}
+
+/** jsonb `||` merge, never a whole-object `set` — a reconnect writes this blob too. */
+async function writeBackfillState(
+  integrationId: string,
+  metadata: SocialSyncMetadata,
+  state: SocialBackfillState
+): Promise<void> {
+  await db
+    .update(schema.Integration)
+    .set({
+      metadata: sql`COALESCE(${schema.Integration.metadata}, '{}'::jsonb) || jsonb_build_object('backfill', ${JSON.stringify(state)}::jsonb)`,
+    })
+    .where(eq(schema.Integration.id, integrationId))
+  metadata.backfill = { ...state }
+}


### PR DESCRIPTION
WS7 of `plans/channels/facebook-instagram-runtime-fixes.md`: a capped, resumable Graph backfill for Messenger/Instagram DMs — plus the bugs that running it against a real Page immediately surfaced.

**This ran live.** 100 conversations, 400 messages stored from the Auxx-Lift Page. Two of the three bugs below were found by that run, not by reading.

## Sync + converter

- `social/sync.ts` walks `/{pageId}/conversations` then each conversation's messages, capped and cutoff-aware. Both providers now sit on the shared Graph seam — **no raw `fetch` left on the sync path** (−680 lines across the two providers).
- `social/conversation-message.ts` is a **second** converter, not a reuse of the webhook one. The two doors carry different shapes; a shared mapper reads `undefined` on one path and stores silently empty messages rather than crashing. Both derive the same `socialThreadKey`, so one conversation stays one thread.

### 🐛 Every customer was renamed to our own Page

`message.from` was stamped on **both** participants. `from` names the *sender*, so on any page-sent node the customer was stored as "Auxx-Lift" — and the participant upsert takes the last write carrying a usable name, so **one reply of ours renamed that customer permanently** and their entire history rendered as authored by us. 65 of 99 participants landed wrong in the live run.

Fixed so `from` only names the side that sent it. The pre-existing outbound test asserted identifiers but never names, which is exactly how this shipped — the new tests close that.

### 🐛 Instagram would have dropped every message we ever sent

`pickConversationCounterpart` defensively excludes *both* our ids (IG business account **and** linked Page) because which one Graph names is unverified — but the direction check accepted only `ourId`. If Graph names the Page, our own messages match neither side and are dropped as "a third party", silently, with a warn. An IG backfill would have stored the customer's half of every conversation and none of ours.

Fixed with an `ourAliasIds` input, passed **only** on Instagram (widening it on Messenger could mistake a customer for the page). The alias decides **direction only** — `ourId` still supplies the identifier and the thread key, so the key stays byte-identical to the webhook's. Pinned by a test.

## Contact identity

### 🐛 Meta PSIDs were written into `primary_email`

The contact dedupe attribute came from a ladder that *ended* in `primary_email`, so every identifier type that wasn't `CHAT_VISITOR` or `PHONE` was assumed to be an email address. A 17-digit PSID went into both the lookup and the create payload; the write validator rejected it (`uncoercible value`, hundreds of them), the FieldValue never landed, and the contact came out **carrying no identifier at all** — nothing to dedupe on, so every conversation minted another. 92 contacts from one run.

Now chosen per type: `EMAIL → primary_email`, dialable `PHONE → phone`, `FACEBOOK_PSID`/`INSTAGRAM_IGSID` → the **`RecordIdentity` index** via a namespaced `external_id` (`facebook:9990197…`) — the same mechanism chat visitors and Shopify customers already use. Both halves of that plumbing already existed; only the attribute choice changed.

**Contacts are still created on exactly the same trigger as before** (selective mode: outbound recipient, or someone the org has sent to). Only the *link* changed.

Deliberately **not** account-scoped, unlike `shopifyExternalId` — Shopify customer ids are per-store sequences that genuinely collide; Meta issues a PSID per (Page, person) from a global id space. Reasoning is documented at the helper.

## Connect

### 🐛 The connect dialog spun forever on connects that had succeeded

`facebook`/`instagram` were `global: false` while `gmail`/`outlookMail` — the other channel providers in the *same* dialog — are `global: true`. So the callback minted a **user-scoped** credential (`userId: personal ? userId : global ? null : userId`), `connections.list` derives `scope` from `userId` presence and reported `user`, and the connect flow's verify backstop matches on `r.scope === a.scope` — it could never match. The dialog fell through to the 180s cancel timeout.

This is **WS8**, previously logged as "needs a repro, diagnosis disproven". It was blamed on the dev ngrok tunnel; the tunnel drops the popup `postMessage`, which is precisely the case the verify backstop exists to cover, so the tunnel made it *visible* but the scope mismatch made it *happen*. Same-origin production would mask it.

Personal connects are unaffected — `metadata.personal` is checked first, which is how `gmail` is global *and* supports a personal mailbox.

> [!IMPORTANT]
> **Two deploy steps, neither optional.**
> 1. **Reseed** — `ConnectionDefinition` bakes `global` and the scope list, so this commit is inert until `packages/lib/scripts/reseed-platform-providers.ts` runs.
> 2. **Re-scope existing FB/IG credentials** — `resolve-connection-for-runtime` does `scopedUserId = def.global ? null : userId` and `findCredential` maps `null` to `userId IS NULL`, so a credential written under the old flag **stops resolving the moment the definition flips** and the channel goes dead with no error. Set `userId → NULL` (keep `createdById`). Dev's one row is already done.

### Other connect changes

- **`business_management` dropped** from both scope sets. A live Instagram connect succeeded without it, and discovery found both the Page and the linked IG account — despite Meta's own use-case page listing it as required. It's the riskiest line in the App Review submission, so this is worth having evidence for. Bounded claim: connect + discovery only, no messaging call yet.
- **Instagram discovery** reads the `instagram_business_account` already expanded in `/me/accounts` instead of re-probing per page, and no longer reports a transient Graph error as "no linked account" — the two were indistinguishable before.

## Testing

509 tests pass across `ingest` / `providers/social` / `connections` / `channels`; `tsc --noEmit` clean on the touched files; biome clean. Every bug above has a regression test.

Live: Facebook DM round trip (inbound, threading, outbound) and the 100-conversation backfill both exercised against the real Meta app. Instagram is **connected** (@auxxlift) but no IG message has flowed yet.

## Still open (tracked in the plan, not this PR)

- `contact:created` fires for every contact minted during a backfill. **Gmail and Outlook have the identical hole** — `isInitialSync` gates `message:received` only — so this wants one central fix, and the B2 contract makes `skipEvents` non-trivial.
- No inbound attachment ingestion for FB/IG; both doors hard-code `hasAttachments: false`.
- The `>24h` HUMAN_AGENT send path is written but never exercised, and the app lacks the Human Agent feature.
