### PR TITLE
feat(sdk): add `auxx dev --once`, and fail loudly when auth is headless

### DIFF
--- a/packages/sdk/src/auth/auth.ts
+++ b/packages/sdk/src/auth/auth.ts
@@ -70,6 +70,17 @@ class Authenticator {
    */
   private async promptToAuthenticate(): Promise<Result<string, AuthError | any>> {
     if (process.env.NODE_ENV !== 'test') {
+      // Nobody is there to press Enter. `stdin.once('data')` never fires on a
+      // closed or piped stream — it emits 'end' — so the awaited promise never
+      // settles, the event loop drains, and the process exits **0 having done
+      // nothing**. A batch caller reads that as success. Refuse loudly instead.
+      if (!process.stdin.isTTY) {
+        process.stderr.write(
+          'Not logged in, and this is not an interactive terminal.\n' +
+            'Set AUXX_API_KEY (headless/CI), or run `auxx login` in a terminal first.\n'
+        )
+        process.exit(1)
+      }
       process.stdout.write('You need to log in with Auxx. Press Enter to continue...\n\n')
       await new Promise((resolve) => process.stdin.once('data', resolve))
     }

--- a/packages/sdk/src/commands/dev.ts
+++ b/packages/sdk/src/commands/dev.ts
@@ -16,6 +16,7 @@ import { generateGitignore } from '../util/generate-gitignore.js'
 import { generateSettingsFiles } from '../util/generate-settings-files.js'
 import { hardExit } from '../util/hard-exit.js'
 import { printMessage } from '../util/print-message.js'
+import { spinnerify } from '../util/spinner.js'
 import { printJsError, printTsError } from '../util/typescript.js'
 import { boot } from './dev/boot.js'
 import { bundleJavaScript } from './dev/bundle-javascript.js'
@@ -23,8 +24,8 @@ import { bundleJavaScript } from './dev/bundle-javascript.js'
 import { onboarding } from './dev/onboarding.js'
 import { printBuildContextError } from './dev/prepare-build-context.js'
 import { upload } from './dev/upload.js'
-
 import { validateTypeScript } from './dev/validate-typescript.js'
+import { bundleJavaScript as bundleOnce } from './version/create/bundle-javascript.js'
 
 const notifyTsErrors = (errors: any[]) => {
   try {
@@ -46,14 +47,21 @@ const notifyJsErrors = (errors: { errors: []; warnings: [] }) => {
 
 export const optionsSchema = z.object({
   organization: z.string().optional(),
+  once: z.boolean().optional(),
 })
 type CleanupFunction = () => void
 
 export const dev = new Command('dev')
   .description('Develop your Auxx.ai app')
   .addOption(new Option('-o, --organization <handle>', 'The handle of the organization to use'))
+  .addOption(
+    new Option(
+      '--once',
+      'Deploy once and exit — bundle, extract the catalog, upload, create the development deployment. No local server, no file watching.'
+    )
+  )
   .action(async (unparsedOptions) => {
-    const { organization: organizationSlug } = optionsSchema.parse(unparsedOptions)
+    const { organization: organizationSlug, once } = optionsSchema.parse(unparsedOptions)
 
     const cleanupFunctions: CleanupFunction[] = []
 
@@ -130,9 +138,72 @@ export const dev = new Command('dev')
       }
     }
     try {
+      // `--once` refuses to PROMPT for the organization. `determineOrganization`
+      // asks when the account has several and none was named — fine for an
+      // interactive session, a hang for the batch loop that this flag exists to
+      // serve (stdout piped, nobody watching). One org, or `-o`, or refuse.
+      if (once && !organizationSlug && !process.stdin.isTTY) {
+        hardExit('`auxx dev --once` needs an organization: pass -o <handle>.')
+      }
+
       const { appId, appSlug, organization, environmentVariables, cliVersion } = await boot({
         organizationSlug,
       })
+
+      // One-shot: exactly what a watch cycle uploads, without becoming a
+      // watcher. `version create`'s bundler is reused deliberately — it is the
+      // one that runs `compileAndExtractCatalog()` and fails loudly when
+      // extraction breaks, which is the whole point of deploying at all.
+      if (once) {
+        const bundleResult = await spinnerify(
+          'Bundling JavaScript...',
+          'Bundling complete',
+          bundleOnce
+        )
+        if (isErrored(bundleResult)) {
+          if (bundleResult.error.code === 'ERROR_EXTRACTING_CATALOG') {
+            const catalogError = bundleResult.error.error
+            const detail =
+              'message' in catalogError
+                ? catalogError.message
+                : 'error' in catalogError
+                  ? catalogError.error.message
+                  : ''
+            hardExit(
+              `Catalog extraction failed (${catalogError.code})${detail ? `: ${detail}` : ''}`
+            )
+          }
+          if (bundleResult.error.code === 'ERROR_BUILDING_BUNDLE') {
+            const { error } = bundleResult.error
+            if (error.code === 'BUILD_JAVASCRIPT_ERROR') {
+              error.errors?.forEach((e: any) => printJsError(e, 'error'))
+              error.warnings?.forEach((w: any) => printJsError(w, 'warning'))
+            } else {
+              printBuildContextError(error)
+            }
+            process.exit(1)
+          }
+          hardExit(`Build failed: ${JSON.stringify(bundleResult.error)}`)
+        }
+        const { bundles, settingsSchema, catalog } = bundleResult.value
+        const uploadResult = await upload({
+          contents: bundles,
+          appId,
+          targetOrganizationId: organization.id,
+          environmentVariables,
+          cliVersion,
+          settingsSchema,
+          catalog,
+        })
+        if (isErrored(uploadResult)) {
+          printUploadError(uploadResult)
+          process.exit(1)
+        }
+        process.stdout.write(
+          `${chalk.green('✓ ')}Development deployment created for ${organization.name}\n`
+        )
+        process.exit(0)
+      }
 
       // const cleanupGraphqlServer = graphqlServer()
 


### PR DESCRIPTION
Two changes, both surfaced by batch-deploying every first-party app.

## `auxx dev --once`

Deploy once and exit: `boot` → bundle → **extract the catalog** → upload → create the `development` deployment. No local server, no file watching.

It reuses **`version create`'s** one-shot bundler on purpose — that is the one that runs `compileAndExtractCatalog()` and fails loudly when extraction breaks, which is the whole point of deploying at all. (`auxx build` does *not* run it, so a green `auxx build` proves less than it looks.)

Why it needs to exist: a **development** deployment is what a local workspace actually reads — `AppInstallation.currentDeploymentId` points at it — so syncing a machine after an SDK change means one dev deploy per app, and `auxx dev` never exits. Publishing production versions instead writes rows nothing local reads.

`--once` also refuses to **prompt** for the organization. `determineOrganization` asks when the account has several and none was named: fine interactively, a hang in a batch loop with piped stdio. With `--once` and no `-o` on a non-TTY it exits with `auxx dev --once needs an organization: pass -o <handle>`.

## The auth fix — the more serious half

`promptToAuthenticate` wrote `You need to log in with Auxx. Press Enter to continue...` and then awaited `process.stdin.once('data')`.

On a closed or piped stdin **that event never fires** — the stream emits `end`, not `data`. The promise never settled, the event loop drained, and the process exited **0 having done nothing**. Every caller reads exit 0 as success: a 20-app deploy loop reported twenty successes and wrote zero deployments, and the only way to catch it was querying the database.

Now a non-TTY refuses with exit 1 and names both remedies: set `AUXX_API_KEY`, or run `auxx login` in a terminal.

`AUXX_API_KEY` itself already worked — `ensureAuthed` sends it as the bearer ahead of the keychain, and nothing about that path changes here.

## Verified

`auxx dev --once -o demoorg` against local dev: catalog extracted (9 tools, 1 toolset, 1 block, 2 triggers), upload complete, development deployment created — then confirmed in the database. Driven across all 20 apps by `pnpm sync-dev` in `auxxai-apps` (Auxx-Ai/auxxai-apps#49), 19 succeeded, and 18 apps now carry `opOutputsJsonSchema` where exactly one did before.

`vitest run` in `packages/sdk`: 41 pass. `tsc -p tsconfig.cli.json --noEmit` clean.

**Note for releasing:** npm `latest` is 0.0.19 from 2026-07-03, which predates #1705 — its `compile-and-extract-catalog.js` has no `opOutputsJsonSchema` at all. CI installs `latest`, so app publishes through CI cannot emit the new catalog fields until an SDK release goes out.