### PR TITLE
fix(ci): publish the sdk with npm, not pnpm

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -109,10 +109,20 @@ jobs:
         working-directory: packages/sdk
         run: pnpm pack
 
+      # `npm publish`, not `pnpm publish`: pnpm forwards its own `--no-git-checks`
+      # down to npm, and npm has no such flag. It used to warn and carry on;
+      # the `npm install -g npm@latest` step above now pulls a version that
+      # errors (EUNKNOWNCONFIG) — which broke this job with the package already
+      # built and packed. npm is also what performs the Trusted Publishing
+      # exchange, so calling it directly is the shorter path anyway.
+      #
+      # Safe here because @auxx/sdk has no `workspace:` dependencies — nothing
+      # needs pnpm's protocol rewriting on publish. Re-check that before adding
+      # one.
       - name: Publish to npm
         if: ${{ !inputs.dry-run }}
         working-directory: packages/sdk
-        run: pnpm publish --access public --tag ${{ inputs.tag }} --no-git-checks --provenance
+        run: npm publish --access public --tag ${{ inputs.tag }} --provenance
 
       - name: Check tag availability
         if: ${{ !inputs.dry-run }}


### PR DESCRIPTION
The SDK publish run failed at the final step:

```
npm error code EUNKNOWNCONFIG
npm error Unknown cli flag:
npm error   - --git-checks
```

`--no-git-checks` is a **pnpm** flag, and `pnpm publish` forwards it down to `npm publish`, which has never had it. npm used to warn and carry on — that's why this worked for 0.0.19 in July. The `npm install -g npm@latest` step two steps earlier now pulls a version that **errors** on unknown flags instead, so the same command that shipped the last release now fails.

The job did everything else correctly — bumped, built, stripped implementations, and packed — and only failed to upload. The version bump was never committed and the tag/release steps were skipped, so nothing is half-published and `packages/sdk/package.json` is still at 0.0.19. A retry after this merges is clean.

## The fix

Call `npm publish` directly. It drops the flag-forwarding problem entirely, and it is the shorter path regardless: **npm is what performs the Trusted Publishing exchange**, which is precisely why this job upgrades npm two steps earlier.

Safe because `@auxx/sdk` declares **no `workspace:` dependencies** — nothing here needs pnpm's protocol rewriting on publish. The comment in the workflow says to re-check that before adding one, since a `workspace:*` dep would silently publish an uninstallable package under plain npm.

`--access public`, `--tag`, and `--provenance` are all genuine npm flags and are unchanged.

## Why it matters now

npm `latest` is still 0.0.19 from 2026-07-03, which predates #1705 — its `compile-and-extract-catalog.js` has no `opOutputsJsonSchema`. CI installs `@auxx/sdk@latest` for every app publish, so until a release goes out, app publishes through CI cannot emit the new catalog fields, and the production redeploy wave for plan 17 stays blocked.