### PR TITLE
feat(channels): ingest inbound meta attachments

### DIFF
--- a/apps/web/src/app/api/facebook/webhook/route.ts
+++ b/apps/web/src/app/api/facebook/webhook/route.ts
@@ -3,6 +3,10 @@
 import { configService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
 import { MessageStorageService } from '@auxx/lib/email'
+import {
+  ingestStoredMessageAttachments,
+  webhookAttachmentRefs,
+} from '@auxx/lib/providers/social/attachments'
 import { resolveSocialCounterpartName } from '@auxx/lib/providers/social/profile'
 import type {
   MetaWebhookEnvelope,
@@ -169,12 +173,29 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         }
 
         try {
-          await storageService.storeMessage(messageData)
+          const { messageId } = await storageService.storeMessage(messageData)
           logger.info('Successfully stored Facebook message', {
             mid: event.message.mid,
             integrationId: integration.id,
             externalThreadId: messageData.externalThreadId,
           })
+
+          // Attachment bytes live on a signed CDN link that has to be fetched.
+          // Same rule as the name lookup below: never before the 200. The
+          // message is already stored and already says `hasAttachments`, so a
+          // failed download costs the file, not the message.
+          const attachmentRefs = webhookAttachmentRefs(event.message)
+          if (attachmentRefs.length > 0) {
+            after(() =>
+              ingestStoredMessageAttachments(db, {
+                refs: attachmentRefs,
+                organizationId: integration.organizationId,
+                messageId,
+                contentScopeId: messageData.externalId,
+                platform: 'facebook',
+              })
+            )
+          }
 
           // Meta's messaging webhook carries only `sender.id`, so the counterpart
           // participant was just created with the raw id as its label. Resolving a

--- a/apps/web/src/app/api/instagram/webhook/route.ts
+++ b/apps/web/src/app/api/instagram/webhook/route.ts
@@ -3,6 +3,10 @@
 import { configService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
 import { MessageStorageService } from '@auxx/lib/email'
+import {
+  ingestStoredMessageAttachments,
+  webhookAttachmentRefs,
+} from '@auxx/lib/providers/social/attachments'
 import { resolveSocialCounterpartName } from '@auxx/lib/providers/social/profile'
 import type {
   MetaWebhookEnvelope,
@@ -158,12 +162,29 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         }
 
         try {
-          await storageService.storeMessage(messageData)
+          const { messageId } = await storageService.storeMessage(messageData)
           logger.info('Successfully stored Instagram message', {
             mid: event.message.mid,
             integrationId: integration.id,
             externalThreadId: messageData.externalThreadId,
           })
+
+          // Attachment bytes live on a signed CDN link that has to be fetched.
+          // Same rule as the name lookup below: never before the 200. The
+          // message is already stored and already says `hasAttachments`, so a
+          // failed download costs the file, not the message.
+          const attachmentRefs = webhookAttachmentRefs(event.message)
+          if (attachmentRefs.length > 0) {
+            after(() =>
+              ingestStoredMessageAttachments(db, {
+                refs: attachmentRefs,
+                organizationId: integration.organizationId,
+                messageId,
+                contentScopeId: messageData.externalId,
+                platform: 'instagram',
+              })
+            )
+          }
 
           // Meta's messaging webhook carries only `sender.id`, so the counterpart
           // participant was just created with the raw id as its label. Resolving a

--- a/docs/channels-mail-architecture-guide.md
+++ b/docs/channels-mail-architecture-guide.md
@@ -499,6 +499,30 @@ Per message, in order:
    `applyMailCountDeltas`, `touchActivityForThreadLinks`, the `MessageReceivedEvent` on the event
    bus, and realtime publishes (unless batched).
 
+### Attachments are ingested *after* the message row, per channel
+
+`storeMessage` never fetches bytes. Attachment ingest is a separate post-store step each
+channel wires itself, because only the provider knows how to get the bytes: Gmail fetches
+them from its API (`GmailInboundContentIngestor`), SES parses them out of the raw MIME
+(`InboundEmailProcessor`), and Meta downloads a signed CDN link
+(`providers/social/attachments.ts`). All three converge on
+`InboundAttachmentIngestService.ingestAll`, which writes StorageLocation → MediaAsset →
+`Attachment(entityType: 'MESSAGE')`, and all three are idempotent through
+`deriveAttachmentId(contentScopeId, order, filename)` — so a re-delivered webhook or a
+re-synced conversation lands on the same rows.
+
+`Message.hasAttachments` therefore means **"the payload declared a file"**, not "the bytes
+are stored". It is set at conversion time, before ingest, and deliberately: it is the
+`message:received` workflow trigger's filter, which is evaluated at store time — a flag
+flipped after ingest could never fire an attachment rule. A provider with no ingestor at
+all (Quo/SMS today) must keep it `false`, or it fires rules against files that will never
+exist.
+
+Ingest runs after `message:created` has already gone out with an empty attachment list, so
+a live-inbound path should publish `message:updated` with the stored attachments once it
+finishes — otherwise the file only appears on the next refetch. Sync paths do not: a
+backfill publishes nothing per message by design.
+
 **Thread status on personal channels** derives from Gmail labels (`INBOX` → `OPEN`, sent-only /
 archived / label-only → `ARCHIVED`, `TRASH`/`SPAM` straight through). Shared inboxes never call
 this — they keep everything-open helpdesk semantics.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1078,6 +1078,12 @@
       "import": "./dist/providers/openphone/webhook-message.mjs",
       "default": "./src/providers/openphone/webhook-message.ts"
     },
+    "./providers/social/attachments": {
+      "types": "./src/providers/social/attachments.ts",
+      "source": "./src/providers/social/attachments.ts",
+      "import": "./dist/providers/social/attachments.mjs",
+      "default": "./src/providers/social/attachments.ts"
+    },
     "./providers/social/profile": {
       "types": "./src/providers/social/profile.ts",
       "source": "./src/providers/social/profile.ts",

--- a/packages/lib/src/providers/social/__tests__/attachments.test.ts
+++ b/packages/lib/src/providers/social/__tests__/attachments.test.ts
@@ -1,0 +1,190 @@
+// packages/lib/src/providers/social/__tests__/attachments.test.ts
+//
+// Meta describes an attachment two incompatible ways — `{type, payload:{url}}` on the
+// webhook, `{mime_type, name, image_data{url}}` on the Graph edge — and only one of
+// them is a shape anyone has captured live. This suite pins the normalisation of both
+// and the refusals around the download, which is the half that touches the open
+// internet with a URL that arrived over the wire.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  attachmentFilename,
+  conversationAttachmentRefs,
+  fetchSocialAttachment,
+  SOCIAL_ATTACHMENT_MAX_BYTES,
+  webhookAttachmentRefs,
+} from '../attachments'
+
+const CONTEXT = { platform: 'facebook' as const, messageId: 'msg_1' }
+
+function response(body: Buffer, headers: Record<string, string>, status = 200): Response {
+  return new Response(body, { status, headers })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('webhookAttachmentRefs', () => {
+  it('keeps the media kinds that have bytes behind them', () => {
+    const refs = webhookAttachmentRefs({
+      attachments: [
+        { type: 'image', payload: { url: 'https://cdn/1.jpg', title: 'receipt' } },
+        { type: 'video', payload: { url: 'https://cdn/2.mp4' } },
+        { type: 'file', payload: { url: 'https://cdn/3.pdf' } },
+      ],
+    })
+
+    expect(refs.map((ref) => ref.type)).toEqual(['image', 'video', 'file'])
+    expect(refs[0]?.name).toBe('receipt')
+  })
+
+  it('drops the kinds that are UI payloads, not files', () => {
+    // A `share` points at whatever was shared — usually an external page. Downloading
+    // it stores someone else's HTML as the customer's attachment.
+    expect(
+      webhookAttachmentRefs({
+        attachments: [
+          { type: 'template', payload: { url: 'https://cdn/t' } },
+          { type: 'fallback', payload: { url: 'https://example.com/article' } },
+          { type: 'share', payload: { url: 'https://example.com/article' } },
+          { type: 'location', payload: { title: 'Berlin' } },
+        ],
+      })
+    ).toEqual([])
+  })
+
+  it('drops an entry with no URL, whatever it claims to be', () => {
+    expect(webhookAttachmentRefs({ attachments: [{ type: 'image', payload: {} }] })).toEqual([])
+    expect(webhookAttachmentRefs(undefined)).toEqual([])
+  })
+})
+
+describe('conversationAttachmentRefs', () => {
+  it('reads the URL out of whichever media field Graph used', () => {
+    const refs = conversationAttachmentRefs({
+      attachments: {
+        data: [
+          { image_data: { url: 'https://cdn/i' }, mime_type: 'image/png', name: 'a.png', size: 10 },
+          { video_data: { url: 'https://cdn/v' } },
+          { file_url: 'https://cdn/f' },
+          { id: 'no-url' },
+        ],
+      },
+    })
+
+    expect(refs.map((ref) => [ref.type, ref.url])).toEqual([
+      ['image', 'https://cdn/i'],
+      ['video', 'https://cdn/v'],
+      ['file', 'https://cdn/f'],
+    ])
+    expect(refs[0]).toMatchObject({ name: 'a.png', mimeType: 'image/png', size: 10 })
+  })
+
+  it('reads an absent connection as "no attachments", never as an error', () => {
+    // This edge is the one shape in the channel nobody has captured live, so every
+    // field on it has to be optional in behaviour as well as in the type.
+    expect(conversationAttachmentRefs({})).toEqual([])
+    expect(conversationAttachmentRefs({ attachments: {} })).toEqual([])
+    expect(conversationAttachmentRefs(null)).toEqual([])
+  })
+})
+
+describe('attachmentFilename', () => {
+  it('names an unnamed attachment by kind and position, so a retry derives the same id', () => {
+    // `deriveAttachmentId` hashes the filename; a name that varied between two
+    // deliveries of one message would store the same photo twice.
+    const ref = { url: 'https://lookaside.fbsbx.com/?asset_id=1', type: 'image' }
+    expect(attachmentFilename(ref, 0, 'image/jpeg')).toBe('image-1.jpg')
+    expect(attachmentFilename(ref, 1, 'image/jpeg')).toBe('image-2.jpg')
+  })
+
+  it('keeps a name that already carries an extension', () => {
+    expect(
+      attachmentFilename({ url: 'u', type: 'file', name: 'invoice.pdf' }, 0, 'application/pdf')
+    ).toBe('invoice.pdf')
+  })
+
+  it('sanitises a name into something a storage key can hold', () => {
+    expect(attachmentFilename({ url: 'u', type: 'file', name: '../../etc/passwd' }, 0, '')).toBe(
+      '.._.._etc_passwd'
+    )
+  })
+})
+
+describe('fetchSocialAttachment', () => {
+  it('returns the bytes and the header mime type', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        response(Buffer.from('bytes'), { 'content-type': 'image/jpeg; charset=binary' })
+      )
+    )
+
+    const result = await fetchSocialAttachment({ url: 'https://cdn/1.jpg', type: 'image' }, CONTEXT)
+    expect(result?.mimeType).toBe('image/jpeg')
+    expect(result?.content.toString()).toBe('bytes')
+  })
+
+  it('refuses an oversized body on the declared length, before reading it', async () => {
+    const fetchMock = vi.fn(async () =>
+      response(Buffer.from('x'), {
+        'content-type': 'video/mp4',
+        'content-length': String(SOCIAL_ATTACHMENT_MAX_BYTES + 1),
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    expect(
+      await fetchSocialAttachment({ url: 'https://cdn/1.mp4', type: 'video' }, CONTEXT)
+    ).toBeNull()
+  })
+
+  it('refuses a document served in place of a file', async () => {
+    // An expired CDN link answers 200 with an error page. Storing that as the
+    // customer's photo is worse than storing nothing.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => response(Buffer.from('<html>gone</html>'), { 'content-type': 'text/html' }))
+    )
+
+    expect(
+      await fetchSocialAttachment({ url: 'https://cdn/1.jpg', type: 'image' }, CONTEXT)
+    ).toBeNull()
+  })
+
+  it('returns null rather than throwing on a dead link', async () => {
+    // Every caller is past the point of no return — the webhook has answered 200 and
+    // the backfill has committed the batch. A throw here would cost the message.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => response(Buffer.from(''), {}, 404))
+    )
+    expect(
+      await fetchSocialAttachment({ url: 'https://cdn/1.jpg', type: 'image' }, CONTEXT)
+    ).toBeNull()
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('ECONNRESET')
+      })
+    )
+    expect(
+      await fetchSocialAttachment({ url: 'https://cdn/1.jpg', type: 'image' }, CONTEXT)
+    ).toBeNull()
+  })
+
+  it('refuses a URL pointing at our own network', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    expect(
+      await fetchSocialAttachment(
+        { url: 'http://169.254.169.254/latest/meta-data', type: 'file' },
+        CONTEXT
+      )
+    ).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/providers/social/__tests__/conversation-message.test.ts
+++ b/packages/lib/src/providers/social/__tests__/conversation-message.test.ts
@@ -251,7 +251,7 @@ describe('convertGraphConversationMessageToMessageData', () => {
     expect(result?.subject).toBeUndefined()
   })
 
-  it('never claims attachments, because nothing ingests their bytes', () => {
+  it('claims no attachments for a descriptor with no URL to download', () => {
     const result = convertGraphConversationMessageToMessageData({
       message: node({
         message: { attachments: [{ type: 'image', payload: { title: 'receipt.png' } }] },
@@ -262,6 +262,42 @@ describe('convertGraphConversationMessageToMessageData', () => {
     expect(result?.hasAttachments).toBe(false)
     // The attachment still names the message, so an image-only DM is not a blank row.
     expect(result?.snippet).toBe('receipt.png')
+  })
+
+  it("claims attachments from the node's own `attachments` connection", () => {
+    const result = convertGraphConversationMessageToMessageData({
+      message: node({
+        message: undefined,
+        attachments: {
+          data: [
+            {
+              id: 'a1',
+              name: 'receipt.png',
+              mime_type: 'image/png',
+              size: 1024,
+              image_data: { url: 'https://lookaside.fbsbx.com/a1' },
+            },
+          ],
+        },
+      }),
+      ...BASE,
+    })
+
+    expect(result?.hasAttachments).toBe(true)
+    expect(result?.snippet).toBe('receipt.png')
+  })
+
+  it('claims attachments from the tolerated object body when the connection is absent', () => {
+    const result = convertGraphConversationMessageToMessageData({
+      message: node({
+        message: {
+          attachments: [{ type: 'image', payload: { url: 'https://lookaside.fbsbx.com/b1' } }],
+        },
+      }),
+      ...BASE,
+    })
+
+    expect(result?.hasAttachments).toBe(true)
   })
 
   it('drops a node with no id, no sender, an unparseable time, or a third-party sender', () => {

--- a/packages/lib/src/providers/social/__tests__/sync.test.ts
+++ b/packages/lib/src/providers/social/__tests__/sync.test.ts
@@ -24,6 +24,8 @@ const mocks = vi.hoisted(() => {
     updateWhere,
     listConversations: vi.fn(),
     listConversationMessages: vi.fn(),
+    ingestSocialAttachments: vi.fn().mockResolvedValue(0),
+    selectWhere: vi.fn().mockResolvedValue([]),
   }
 })
 
@@ -34,8 +36,13 @@ vi.mock('@auxx/database', async () => {
   const { createChainableDatabaseMock, createSchemaMock } = await import(
     '../../../test/database-mock'
   )
+  const select = () => ({ from: () => ({ where: mocks.selectWhere }) })
   const database = new Proxy(createChainableDatabaseMock(), {
-    get: (target: any, prop: string) => (prop === 'update' ? mocks.update : target[prop]),
+    get: (target: any, prop: string) => {
+      if (prop === 'update') return mocks.update
+      if (prop === 'select') return select
+      return target[prop]
+    },
   })
   return {
     database,
@@ -56,6 +63,13 @@ vi.mock('../api', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../api')>()),
   listConversations: mocks.listConversations,
   listConversationMessages: mocks.listConversationMessages,
+}))
+
+// Partial mock again — the converter imports the ref extractors from this module, so
+// replacing it wholesale would take `hasAttachments` down with the spy.
+vi.mock('../attachments', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../attachments')>()),
+  ingestSocialAttachments: mocks.ingestSocialAttachments,
 }))
 
 const { resolveSocialBackfillCutoff, syncSocialMessages } = await import('../sync')
@@ -135,6 +149,8 @@ function metadataWrites(): any[] {
 beforeEach(() => {
   vi.clearAllMocks()
   mocks.listConversationMessages.mockResolvedValue({ data: [] })
+  mocks.selectWhere.mockResolvedValue([])
+  mocks.ingestSocialAttachments.mockResolvedValue(0)
 })
 
 describe('resolveSocialBackfillCutoff — fail closed', () => {
@@ -489,5 +505,54 @@ describe('syncSocialMessages — incremental', () => {
     const [stored, , isInitialSync] = store.batchStoreMessages.mock.calls[0]!
     expect(stored.map((m: any) => m.externalId)).toEqual(['m_fresh', 'm_edge'])
     expect(isInitialSync).toBe(false)
+  })
+})
+
+describe('attachment ingest', () => {
+  it("recovers the stored message ids and ingests each node's attachments", async () => {
+    // `batchStoreMessages` answers with a count, and `Attachment` rows hang off a
+    // `Message.id` — so the ids come back out of the `(integrationId, externalId)`
+    // index. Getting that lookup wrong stores every photo against nothing, silently.
+    mocks.listConversations.mockResolvedValue({
+      data: [conversation('t_1', '2026-08-18T10:00:00+0000')],
+      paging: { next: null },
+    })
+    mocks.listConversationMessages.mockResolvedValue({
+      data: [
+        {
+          ...messageNode('m_photo', 'psid_t_1'),
+          message: undefined,
+          attachments: { data: [{ image_data: { url: 'https://cdn/photo.jpg' } }] },
+        },
+        messageNode('m_text', 'psid_t_1'),
+      ],
+    })
+    mocks.selectWhere.mockResolvedValue([{ id: 'msg_row_1', externalId: 'm_photo' }])
+
+    await syncSocialMessages({ target: target(), metadata: {}, storage: storage() })
+
+    expect(mocks.ingestSocialAttachments).toHaveBeenCalledTimes(1)
+    expect(mocks.ingestSocialAttachments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: 'msg_row_1',
+        contentScopeId: 'm_photo',
+        organizationId: 'org_1',
+        platform: 'facebook',
+        refs: [expect.objectContaining({ url: 'https://cdn/photo.jpg', type: 'image' })],
+      })
+    )
+  })
+
+  it('does not query for ids when no node in the conversation has an attachment', async () => {
+    mocks.listConversations.mockResolvedValue({
+      data: [conversation('t_1', '2026-08-18T10:00:00+0000')],
+      paging: { next: null },
+    })
+    mocks.listConversationMessages.mockResolvedValue({ data: [messageNode('m_text', 'psid_t_1')] })
+
+    await syncSocialMessages({ target: target(), metadata: {}, storage: storage() })
+
+    expect(mocks.selectWhere).not.toHaveBeenCalled()
+    expect(mocks.ingestSocialAttachments).not.toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/providers/social/__tests__/webhook-message.test.ts
+++ b/packages/lib/src/providers/social/__tests__/webhook-message.test.ts
@@ -112,9 +112,25 @@ describe('convertMetaWebhookEventToMessageData', () => {
     })
 
     expect(result?.snippet).toBe('receipt')
-    // No inbound attachment ingestor exists, so claiming true would fire
-    // attachment workflow rules for bytes that were never fetched.
+    expect(result?.hasAttachments).toBe(true)
+  })
+
+  it('claims no attachments for a payload with nothing downloadable behind it', () => {
+    const result = convertMetaWebhookEventToMessageData({
+      event: inbound({
+        message: {
+          mid: 'm_att_2',
+          attachments: [{ type: 'location', payload: { title: 'Berlin' } }],
+        },
+      }),
+      ...BASE,
+    })
+
+    // `hasAttachments` gates the workflow trigger filter, so it has to mean
+    // "there is a file on this message", not "the payload had an attachments key".
     expect(result?.hasAttachments).toBe(false)
+    // The snippet still names it — "Berlin" beats an empty bubble.
+    expect(result?.snippet).toBe('Berlin')
   })
 })
 

--- a/packages/lib/src/providers/social/api.ts
+++ b/packages/lib/src/providers/social/api.ts
@@ -450,6 +450,23 @@ export async function listConversations(args: {
   })
 }
 
+/**
+ * One entry on a message node's `attachments` connection.
+ *
+ * Graph splits the download URL by media kind instead of answering a single
+ * `url`, and every field here is optional because the connection is requested
+ * **bare** — see {@link listConversationMessages}.
+ */
+export interface GraphMessageAttachment {
+  id?: string
+  name?: string
+  mime_type?: string
+  size?: number
+  file_url?: string
+  image_data?: { url?: string; preview_url?: string }
+  video_data?: { url?: string; preview_url?: string }
+}
+
 export interface GraphConversationMessage {
   id?: string
   created_time?: string
@@ -461,9 +478,31 @@ export interface GraphConversationMessage {
    * both providers used to do) is an invalid expansion, not a richer payload.
    */
   message?: string
+  /** Absent on a text-only message, and on any node this request could not expand. */
+  attachments?: { data?: GraphMessageAttachment[] }
 }
 
-/** `GET /{conversationId}/messages` — one page of messages, newest-first. */
+/** Without `attachments` — the field set proven live by the first backfill. */
+const CONVERSATION_MESSAGE_FIELDS = 'id,created_time,from,to,message'
+
+/**
+ * With attachments. Requested **bare**, never as `attachments{...}`: subfield
+ * expansion is exactly what made the old `message{text,attachments,mid}` an
+ * invalid request rather than a richer one, and a bare connection cannot be
+ * mis-expanded.
+ */
+const CONVERSATION_MESSAGE_FIELDS_WITH_ATTACHMENTS = `${CONVERSATION_MESSAGE_FIELDS},attachments`
+
+/**
+ * `GET /{conversationId}/messages` — one page of messages, newest-first.
+ *
+ * Asks for `attachments` and **falls back to the field set without it** on a
+ * non-auth, non-throttle error. Instagram Direct and Messenger are two platforms
+ * on one edge and only Messenger's support for this connection is documented; if
+ * IG rejects the field, the fallback costs one extra request per conversation
+ * instead of turning every conversation into a logged skip — which is how a
+ * backfill silently stores nothing at all.
+ */
 export async function listConversationMessages(args: {
   conversationId: string
   pageAccessToken: string
@@ -471,11 +510,27 @@ export async function listConversationMessages(args: {
   limit?: number
 }): Promise<GraphListResponse<GraphConversationMessage>> {
   const { conversationId, pageAccessToken, nextUrl, limit } = args
-  return graphRequest<GraphListResponse<GraphConversationMessage>>(`${conversationId}/messages`, {
-    accessToken: pageAccessToken,
-    url: nextUrl,
-    query: { fields: 'id,created_time,from,to,message', limit },
-  })
+  try {
+    return await graphRequest<GraphListResponse<GraphConversationMessage>>(
+      `${conversationId}/messages`,
+      {
+        accessToken: pageAccessToken,
+        url: nextUrl,
+        query: { fields: CONVERSATION_MESSAGE_FIELDS_WITH_ATTACHMENTS, limit },
+      }
+    )
+  } catch (error) {
+    if (isReauthRequired(error) || isRateLimited(error)) throw error
+    logger.warn('Conversation messages request rejected with attachments; retrying without', {
+      conversationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return graphRequest<GraphListResponse<GraphConversationMessage>>(`${conversationId}/messages`, {
+      accessToken: pageAccessToken,
+      url: nextUrl,
+      query: { fields: CONVERSATION_MESSAGE_FIELDS, limit },
+    })
+  }
 }
 
 /** `GET /debug_token` — validity, scopes and expiry of a token. */

--- a/packages/lib/src/providers/social/attachments.ts
+++ b/packages/lib/src/providers/social/attachments.ts
@@ -1,0 +1,477 @@
+// packages/lib/src/providers/social/attachments.ts
+
+import { type Database, database as defaultDb, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq } from 'drizzle-orm'
+import { InboundAttachmentIngestService } from '../../email/inbound/attachment-ingest.service'
+import type { AttachmentIngestInput } from '../../email/inbound/ingest-types'
+import { assertPublicHost } from '../../files/fetch-remote-image'
+import type { GraphConversationMessage } from './api'
+import type { MetaWebhookMessage, SocialPlatform } from './types'
+
+const logger = createScopedLogger('social-attachments')
+
+/**
+ * Hard cap on a single downloaded attachment.
+ *
+ * 25 MB is Meta's own ceiling on what a person can send through Messenger, so a
+ * larger response is not a big photo — it is a redirect to something that is not
+ * the attachment. Enforced twice: on `content-length` before reading a byte, and
+ * again on the buffer for the responses that carry no length header.
+ */
+export const SOCIAL_ATTACHMENT_MAX_BYTES = 25 * 1024 * 1024
+
+/** Attachments ingested per message. A Messenger message carries a handful. */
+export const SOCIAL_ATTACHMENTS_PER_MESSAGE = 10
+
+/** Download timeout. Generous because the cap admits 25 MB videos. */
+const FETCH_TIMEOUT_MS = 20_000
+
+/**
+ * Meta attachment types that carry bytes worth storing.
+ *
+ * The excluded types are not oversights: `template` and `fallback` are UI
+ * payloads with no file behind them, `location` is a coordinate pair, and
+ * `share` points at whatever was shared — usually an external page, so
+ * downloading it stores someone else's HTML as a customer's attachment.
+ */
+const INGESTIBLE_TYPES = new Set(['image', 'video', 'audio', 'file', 'story_mention'])
+
+/** Content types that mean "you were served a page, not a file". */
+const REFUSED_MIME_PREFIXES = ['text/html', 'application/xhtml']
+
+/**
+ * One downloadable attachment, normalized across the two doors.
+ *
+ * The webhook and the Graph conversation edge describe attachments completely
+ * differently — `{type, payload:{url}}` versus `{mime_type, name, size,
+ * image_data{url}}` — and only one of them knows the mime type up front. Both
+ * collapse to this, so the fetch-and-ingest half is written once.
+ */
+export interface SocialAttachmentRef {
+  /** Direct download URL. Meta's CDN links are signed and expire. */
+  url: string
+  /** Meta's own type word, kept for the derived filename and for logging. */
+  type: string
+  /** Only the Graph edge supplies these; the webhook never does. */
+  name?: string
+  mimeType?: string
+  size?: number
+}
+
+/**
+ * The attachments on a webhook `message` payload.
+ *
+ * Order is the wire order, and it is load-bearing: `attachmentOrder` feeds
+ * `deriveAttachmentId`, which is what makes a re-delivered webhook (Meta retries
+ * freely) ingest onto the same rows instead of duplicating them.
+ */
+export function webhookAttachmentRefs(
+  message: MetaWebhookMessage | undefined | null
+): SocialAttachmentRef[] {
+  const refs: SocialAttachmentRef[] = []
+  for (const attachment of message?.attachments ?? []) {
+    const url = attachment.payload?.url
+    const type = attachment.type ?? 'file'
+    if (!url) continue
+    if (!INGESTIBLE_TYPES.has(type)) continue
+    refs.push({ url, type, name: attachment.payload?.title ?? undefined })
+  }
+  return refs
+}
+
+/**
+ * The attachments on a Graph conversation-message node.
+ *
+ * Three URL fields, because Graph splits by media kind rather than answering one
+ * `url`: `image_data.url` for photos and stickers, `video_data.url` for video,
+ * `file_url` for everything else. The node is typed loosely on purpose — this
+ * edge is the one shape in this channel nobody has captured live (see
+ * `conversation-message.ts`), so an absent `attachments` connection must read as
+ * "no attachments", never as an error.
+ */
+export function conversationAttachmentRefs(
+  message: Pick<GraphConversationMessage, 'attachments'> | undefined | null
+): SocialAttachmentRef[] {
+  const refs: SocialAttachmentRef[] = []
+  for (const attachment of message?.attachments?.data ?? []) {
+    const url = attachment.image_data?.url ?? attachment.video_data?.url ?? attachment.file_url
+    if (!url) continue
+    refs.push({
+      url,
+      type: attachment.video_data ? 'video' : attachment.image_data ? 'image' : 'file',
+      name: attachment.name ?? undefined,
+      mimeType: attachment.mime_type ?? undefined,
+      size: typeof attachment.size === 'number' ? attachment.size : undefined,
+    })
+  }
+  return refs
+}
+
+export interface IngestSocialAttachmentsArgs {
+  refs: SocialAttachmentRef[]
+  organizationId: string
+  /** The stored `Message.id` the `Attachment` rows hang off. */
+  messageId: string
+  /** `Message.externalId` (the `mid`) — scopes the object keys and the derived ids. */
+  contentScopeId: string
+  platform: SocialPlatform
+  /** Publishes `message:updated` so an open thread shows the file without a refetch. */
+  publish?: { threadId: string; inboxId: string | null; excludeSocketId?: string }
+  db?: Database
+}
+
+/**
+ * Downloads a Meta message's attachments and stores them as canonical
+ * `Attachment` rows, reusing the inbound-email ingest pipeline unchanged.
+ *
+ * **Never throws.** Every caller is on a path where the message is already
+ * stored: the webhook has answered 200 and is inside `after()`, and the backfill
+ * has committed the batch. A CDN link that expired between delivery and download
+ * must cost one photo, not a retried webhook or an aborted backfill.
+ *
+ * Idempotent twice over — it returns early when the message already carries as
+ * many attachments as the payload declares, and `deriveAttachmentId` collapses a
+ * repeat ingest onto the same rows even when it does not.
+ *
+ * @returns how many attachments were stored.
+ */
+export async function ingestSocialAttachments(args: IngestSocialAttachmentsArgs): Promise<number> {
+  const { organizationId, messageId, contentScopeId, platform } = args
+  const db = args.db ?? defaultDb
+  const refs = args.refs.slice(0, SOCIAL_ATTACHMENTS_PER_MESSAGE)
+  if (refs.length === 0) return 0
+
+  if (args.refs.length > refs.length) {
+    logger.warn(
+      'Meta message declares more attachments than the per-message cap; ingesting a prefix',
+      {
+        platform,
+        messageId,
+        declared: args.refs.length,
+        cap: SOCIAL_ATTACHMENTS_PER_MESSAGE,
+      }
+    )
+  }
+
+  try {
+    const existing = await db
+      .select({ id: schema.Attachment.id })
+      .from(schema.Attachment)
+      .where(
+        and(
+          eq(schema.Attachment.organizationId, organizationId),
+          eq(schema.Attachment.entityType, 'MESSAGE'),
+          eq(schema.Attachment.entityId, messageId)
+        )
+      )
+    if (existing.length >= refs.length) {
+      logger.debug('Meta message attachments already ingested; skipping download', {
+        platform,
+        messageId,
+        existing: existing.length,
+      })
+      return 0
+    }
+
+    const inputs: AttachmentIngestInput[] = []
+    let failed = 0
+    for (let order = 0; order < refs.length; order++) {
+      const ref = refs[order]!
+      const downloaded = await fetchSocialAttachment(ref, { platform, messageId })
+      if (!downloaded) {
+        failed++
+        continue
+      }
+      inputs.push({
+        content: downloaded.content,
+        filename: attachmentFilename(ref, order, downloaded.mimeType),
+        mimeType: downloaded.mimeType,
+        // Meta DMs have no HTML body, so nothing can reference an attachment by
+        // `cid:`. Marking these inline would hide them: the chat bubble renders
+        // non-inline attachments only.
+        inline: false,
+        contentId: null,
+        attachmentOrder: order,
+      })
+    }
+
+    if (inputs.length === 0) return 0
+
+    const stored = await new InboundAttachmentIngestService(db).ingestAll(
+      inputs,
+      { organizationId, messageId, contentScopeId },
+      // A partial set must not reconcile: reconciliation deletes the rows it did
+      // not just write, so one expired CDN link would wipe the attachments a
+      // previous run stored successfully.
+      { skipReconciliation: failed > 0 }
+    )
+
+    logger.info('Ingested Meta message attachments', {
+      platform,
+      messageId,
+      stored: stored.length,
+      failed,
+    })
+
+    if (args.publish) {
+      await publishAttachmentsPatch({
+        organizationId,
+        messageId,
+        threadId: args.publish.threadId,
+        inboxId: args.publish.inboxId,
+        excludeSocketId: args.publish.excludeSocketId,
+        attachments: stored.map((meta) => ({
+          id: meta.attachmentId,
+          name: meta.filename,
+          mimeType: meta.mimeType,
+          size: meta.size,
+          url: null,
+          inline: meta.inline,
+          contentId: meta.contentId,
+        })),
+      })
+    }
+
+    return stored.length
+  } catch (error) {
+    logger.error('Meta attachment ingest failed (ignored)', {
+      platform,
+      messageId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return 0
+  }
+}
+
+/**
+ * Fetches one attachment's bytes.
+ *
+ * @returns `null` on any refusal — a dead link, an oversized body, or an HTML
+ * error page served with a 200. All of those are one missing file, not a
+ * failure of the message.
+ */
+export async function fetchSocialAttachment(
+  ref: SocialAttachmentRef,
+  context: { platform: SocialPlatform; messageId: string }
+): Promise<{ content: Buffer; mimeType: string } | null> {
+  try {
+    // Meta's CDN hostnames are fixed, but the URL arrives over the wire and
+    // `fetch` follows redirects, so the same guard the enrichment fetcher uses
+    // applies here.
+    assertPublicHost(ref.url)
+
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    let response: Response
+    try {
+      response = await fetch(ref.url, { signal: controller.signal, redirect: 'follow' })
+    } finally {
+      clearTimeout(timer)
+    }
+
+    if (!response.ok) {
+      logger.warn('Meta attachment download refused', {
+        ...context,
+        type: ref.type,
+        status: response.status,
+      })
+      return null
+    }
+
+    const declaredLength = Number(response.headers.get('content-length') ?? Number.NaN)
+    if (Number.isFinite(declaredLength) && declaredLength > SOCIAL_ATTACHMENT_MAX_BYTES) {
+      logger.warn('Meta attachment exceeds the size cap; skipping', {
+        ...context,
+        type: ref.type,
+        size: declaredLength,
+        cap: SOCIAL_ATTACHMENT_MAX_BYTES,
+      })
+      return null
+    }
+
+    const mimeType = normalizeMimeType(response.headers.get('content-type'), ref.mimeType)
+    if (REFUSED_MIME_PREFIXES.some((prefix) => mimeType.startsWith(prefix))) {
+      logger.warn('Meta attachment URL served a document, not a file; skipping', {
+        ...context,
+        type: ref.type,
+        mimeType,
+      })
+      return null
+    }
+
+    const content = Buffer.from(await response.arrayBuffer())
+    if (content.byteLength === 0) return null
+    if (content.byteLength > SOCIAL_ATTACHMENT_MAX_BYTES) {
+      logger.warn('Meta attachment exceeded the size cap after download; discarding', {
+        ...context,
+        type: ref.type,
+        size: content.byteLength,
+      })
+      return null
+    }
+
+    return { content, mimeType }
+  } catch (error) {
+    logger.warn('Meta attachment download failed (ignored)', {
+      ...context,
+      type: ref.type,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}
+
+/** `content-type` minus its parameters, falling back to what Graph declared. */
+function normalizeMimeType(header: string | null, declared: string | undefined): string {
+  const fromHeader = header?.split(';')[0]?.trim().toLowerCase()
+  if (fromHeader) return fromHeader
+  return declared?.trim().toLowerCase() || 'application/octet-stream'
+}
+
+/**
+ * The filename an attachment is stored and displayed under.
+ *
+ * Derived, never taken raw: Meta's webhook supplies no name at all and its CDN
+ * URLs carry no path filename, so the honest default is the media type plus its
+ * position. The result feeds `deriveAttachmentId`, so it has to be a pure
+ * function of inputs that do not change between two deliveries of the same
+ * message — which is why the position, and not a timestamp, disambiguates.
+ */
+export function attachmentFilename(
+  ref: SocialAttachmentRef,
+  order: number,
+  mimeType: string
+): string {
+  const base = ref.name?.trim() || `${ref.type}-${order + 1}`
+  const safe = base.replace(/[^a-zA-Z0-9._-]/g, '_')
+  if (/\.[a-zA-Z0-9]{2,5}$/.test(safe)) return safe
+  const extension = extensionForMimeType(mimeType)
+  return extension ? `${safe}${extension}` : safe
+}
+
+/** Extension for the handful of types Messenger and Instagram actually deliver. */
+function extensionForMimeType(mimeType: string): string {
+  switch (mimeType) {
+    case 'image/jpeg':
+    case 'image/jpg':
+      return '.jpg'
+    case 'image/png':
+      return '.png'
+    case 'image/gif':
+      return '.gif'
+    case 'image/webp':
+      return '.webp'
+    case 'video/mp4':
+      return '.mp4'
+    case 'video/quicktime':
+      return '.mov'
+    case 'audio/mpeg':
+      return '.mp3'
+    case 'audio/mp4':
+    case 'audio/aac':
+      return '.m4a'
+    case 'audio/ogg':
+      return '.ogg'
+    case 'application/pdf':
+      return '.pdf'
+    default:
+      return ''
+  }
+}
+
+/**
+ * Fire-and-forget `message:updated` carrying the freshly stored attachments.
+ *
+ * Ingest runs after the message row exists, so `message:created` has already
+ * gone out with an empty attachment list — without this patch a photo shows up
+ * as an empty bubble until something refetches the thread.
+ *
+ * The realtime barrel is imported lazily for the reason documented on
+ * `publishParticipantPatch`: a static import from a provider module widens the
+ * graph into the cache cycle and breaks `vi.mock` interception in lib tests.
+ */
+async function publishAttachmentsPatch(args: {
+  organizationId: string
+  messageId: string
+  threadId: string
+  inboxId: string | null
+  excludeSocketId?: string
+  attachments: Array<{
+    id: string
+    name: string
+    mimeType: string | null
+    size: number | null
+    url: string | null
+    inline: boolean
+    contentId: string | null
+  }>
+}): Promise<void> {
+  try {
+    const { getRealtimeService, publishMessageUpdated } = await import('../../realtime')
+    await publishMessageUpdated(
+      getRealtimeService(),
+      args.organizationId,
+      {
+        messageId: args.messageId,
+        threadId: args.threadId,
+        inboxId: args.inboxId,
+        patch: { hasAttachments: true, attachments: args.attachments },
+      },
+      args.excludeSocketId ? { excludeSocketId: args.excludeSocketId } : undefined
+    )
+  } catch (error) {
+    logger.warn('message:updated attachment publish failed (ignored)', {
+      messageId: args.messageId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * Ingest a stored message's attachments and patch every open view of its thread.
+ *
+ * The webhook door's entry point: it holds only the `Message.id` `storeMessage`
+ * handed back, so the thread and inbox the realtime patch has to route to are
+ * looked up here. Call it from `after()`, never before the 200 — a 25 MB video
+ * download inside the request would have Meta retrying the delivery and, on
+ * repeat, disabling the subscription.
+ */
+export async function ingestStoredMessageAttachments(
+  db: Database,
+  args: {
+    refs: SocialAttachmentRef[]
+    organizationId: string
+    messageId: string
+    contentScopeId: string
+    platform: SocialPlatform
+  }
+): Promise<number> {
+  if (args.refs.length === 0) return 0
+  const target = await resolveMessagePublishTarget(db, args.messageId).catch(() => null)
+  return ingestSocialAttachments({
+    ...args,
+    db,
+    publish: target ?? undefined,
+  })
+}
+
+/**
+ * Looks up the routing a `message:updated` publish needs.
+ *
+ * The webhook door only holds the id `storeMessage` handed back, and the patch
+ * has to reach the thread's inbox lens channels — publishing to `null` would
+ * route it to the admin-only channel and nobody watching the thread would see it.
+ */
+export async function resolveMessagePublishTarget(
+  db: Database,
+  messageId: string
+): Promise<{ threadId: string; inboxId: string | null } | null> {
+  const [row] = await db
+    .select({ threadId: schema.Message.threadId, inboxId: schema.Thread.inboxId })
+    .from(schema.Message)
+    .innerJoin(schema.Thread, eq(schema.Message.threadId, schema.Thread.id))
+    .where(eq(schema.Message.id, messageId))
+    .limit(1)
+  return row ? { threadId: row.threadId, inboxId: row.inboxId ?? null } : null
+}

--- a/packages/lib/src/providers/social/conversation-message.ts
+++ b/packages/lib/src/providers/social/conversation-message.ts
@@ -3,6 +3,11 @@
 import { createScopedLogger } from '@auxx/logger'
 import type { MessageData } from '../../ingest/types'
 import type { GraphConversation, GraphConversationMessage } from './api'
+import {
+  conversationAttachmentRefs,
+  type SocialAttachmentRef,
+  webhookAttachmentRefs,
+} from './attachments'
 import { socialThreadKey } from './thread-key'
 import type { SocialPlatform } from './types'
 
@@ -72,6 +77,26 @@ function conversationMessageAttachments(
     return body.attachments
   }
   return []
+}
+
+/**
+ * Every attachment on a conversation-message node, from whichever of the two
+ * places Graph put them.
+ *
+ * The node's own `attachments` connection is the documented one and wins. The
+ * fallback exists because the `message` field's object shape — the one this
+ * module already tolerates rather than trusts — carries webhook-style
+ * `{type, payload:{url}}` entries, and dropping those would mean a payload we
+ * *did* understand still lost its photo. The two are alternatives, never merged:
+ * a node answering both would be describing the same files twice, and duplicate
+ * `attachmentOrder`s would store them twice.
+ */
+export function conversationMessageAttachmentRefs(
+  message: TolerantConversationMessage | undefined | null
+): SocialAttachmentRef[] {
+  const fromConnection = conversationAttachmentRefs(message)
+  if (fromConnection.length > 0) return fromConnection
+  return webhookAttachmentRefs({ attachments: conversationMessageAttachments(message?.message) })
 }
 
 /**
@@ -276,8 +301,16 @@ export function convertGraphConversationMessageToMessageData(
     }
 
     const text = conversationMessageText(message.message)
-    const attachments = conversationMessageAttachments(message.message)
-    const firstAttachmentName = attachments[0]?.payload?.title || attachments[0]?.type || ''
+    const attachmentRefs = conversationMessageAttachmentRefs(message)
+    // The snippet still falls back to the raw first descriptor, which may be a
+    // kind we deliberately do not download (a share, a location).
+    const rawAttachments = conversationMessageAttachments(message.message)
+    const firstAttachmentName =
+      attachmentRefs[0]?.name ||
+      attachmentRefs[0]?.type ||
+      rawAttachments[0]?.payload?.title ||
+      rawAttachments[0]?.type ||
+      ''
 
     return {
       externalId,
@@ -300,11 +333,12 @@ export function convertGraphConversationMessageToMessageData(
       cc: [],
       bcc: [],
       replyTo: [],
-      // Neither channel has an inbound attachment ingestor, so no MessageAttachment
-      // rows exist. `hasAttachments` is a workflow trigger filter, so claiming true
-      // fires attachment rules against bytes that were never fetched. The attachment
-      // list above only feeds the snippet fallback.
-      hasAttachments: false,
+      // True as soon as the payload declares a downloadable attachment, not once
+      // the bytes land. It describes the MESSAGE — the customer did send a photo —
+      // and the workflow trigger filter reads it at store time, which is before
+      // any ingestor could have finished. `Attachment` rows follow from
+      // `ingestSocialAttachments`, the same order Gmail's ingest uses.
+      hasAttachments: attachmentRefs.length > 0,
       textPlain: text,
       textHtml: undefined,
       snippet: text ? text.substring(0, SNIPPET_LENGTH) : firstAttachmentName,

--- a/packages/lib/src/providers/social/sync.ts
+++ b/packages/lib/src/providers/social/sync.ts
@@ -2,7 +2,7 @@
 
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { eq, sql } from 'drizzle-orm'
+import { and, eq, inArray, sql } from 'drizzle-orm'
 import type { MessageData } from '../../ingest/types'
 import {
   type GraphConversation,
@@ -11,7 +11,10 @@ import {
   listConversationMessages,
   listConversations,
 } from './api'
+import { ingestSocialAttachments, type SocialAttachmentRef } from './attachments'
 import {
+  conversationMessageAttachmentRefs,
+  conversationMessageExternalId,
   convertGraphConversationMessageToMessageData,
   pickConversationCounterpart,
   type TolerantConversationMessage,
@@ -479,7 +482,76 @@ async function ingestConversation(
   // `isInitialSync` on the backfill leg suppresses `message:received` for the whole
   // batch independently of the received-time cutoff — two guards, because publishing
   // five years of history into workflow triggers and agent runs is not recoverable.
-  return storage.batchStoreMessages(messages, undefined, options.isInitialBackfill)
+  const stored = await storage.batchStoreMessages(messages, undefined, options.isInitialBackfill)
+
+  await ingestConversationAttachments(target, nodes, messages)
+
+  return stored
+}
+
+/**
+ * Downloads the attachments of a conversation's just-stored messages.
+ *
+ * Runs after the batch rather than inside the converter because `Attachment` rows
+ * hang off a `Message.id`, and `batchStoreMessages` answers with a count — so the
+ * ids are recovered here with one indexed lookup on
+ * `(integrationId, externalId)`, the same key ingest deduped on.
+ *
+ * No realtime patch: a backfill publishes nothing per message by design
+ * (`isInitialSync`), and an incremental run's messages arrive by webhook first —
+ * whose own `after()` ingest already fetched these bytes and made this a no-op.
+ *
+ * Never throws. A backfill that has stored a conversation must advance its cursor
+ * even if every CDN link in it had expired.
+ */
+async function ingestConversationAttachments(
+  target: SocialSyncTarget,
+  nodes: TolerantConversationMessage[],
+  stored: MessageData[]
+): Promise<void> {
+  const refsByExternalId = new Map<string, SocialAttachmentRef[]>()
+  for (const node of nodes) {
+    const refs = conversationMessageAttachmentRefs(node)
+    if (refs.length === 0) continue
+    const externalId = conversationMessageExternalId(node)
+    if (externalId) refsByExternalId.set(externalId, refs)
+  }
+  if (refsByExternalId.size === 0) return
+
+  const externalIds = stored
+    .map((message) => message.externalId)
+    .filter((externalId) => refsByExternalId.has(externalId))
+  if (externalIds.length === 0) return
+
+  try {
+    const rows = await db
+      .select({ id: schema.Message.id, externalId: schema.Message.externalId })
+      .from(schema.Message)
+      .where(
+        and(
+          eq(schema.Message.integrationId, target.integrationId),
+          inArray(schema.Message.externalId, externalIds)
+        )
+      )
+
+    for (const row of rows) {
+      const refs = row.externalId ? refsByExternalId.get(row.externalId) : undefined
+      if (!refs || !row.externalId) continue
+      await ingestSocialAttachments({
+        refs,
+        organizationId: target.organizationId,
+        messageId: row.id,
+        contentScopeId: row.externalId,
+        platform: target.platform,
+      })
+    }
+  } catch (error) {
+    logger.error('Attachment ingest failed for a Meta conversation (ignored)', {
+      platform: target.platform,
+      integrationId: target.integrationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
 }
 
 /**

--- a/packages/lib/src/providers/social/webhook-message.ts
+++ b/packages/lib/src/providers/social/webhook-message.ts
@@ -2,6 +2,7 @@
 
 import { createScopedLogger } from '@auxx/logger'
 import type { MessageData } from '../../ingest/types'
+import { webhookAttachmentRefs } from './attachments'
 import { socialThreadKey } from './thread-key'
 import type {
   MetaWebhookMessagingEvent,
@@ -106,8 +107,16 @@ export function convertMetaWebhookEventToMessageData(
     }
 
     const text = message?.text
+    const attachmentRefs = webhookAttachmentRefs(message)
+    // The snippet still falls back to the raw first attachment, which may be a
+    // kind we deliberately do not download (a share, a location). "shared a link"
+    // is a better snippet than an empty one.
     const firstAttachmentName =
-      message?.attachments?.[0]?.payload?.title || message?.attachments?.[0]?.type || ''
+      attachmentRefs[0]?.name ||
+      attachmentRefs[0]?.type ||
+      message?.attachments?.[0]?.payload?.title ||
+      message?.attachments?.[0]?.type ||
+      ''
 
     return {
       externalId,
@@ -123,10 +132,12 @@ export function convertMetaWebhookEventToMessageData(
       cc: [],
       bcc: [],
       replyTo: [],
-      // Neither channel has an inbound attachment ingestor, so no MessageAttachment
-      // rows are ever created. `hasAttachments` is a workflow trigger filter, so
-      // claiming true fires attachment rules for bytes that were never fetched.
-      hasAttachments: false,
+      // True as soon as the payload declares a downloadable attachment, not once
+      // the bytes land. It describes the MESSAGE — the customer did send a photo —
+      // and the workflow trigger filter reads it at store time, which is before the
+      // route's `after()` ingest could possibly have finished. `Attachment` rows
+      // follow from `ingestSocialAttachments`.
+      hasAttachments: attachmentRefs.length > 0,
       textPlain: text ?? undefined,
       textHtml: undefined,
       snippet: text ? text.substring(0, SNIPPET_LENGTH) : firstAttachmentName,


### PR DESCRIPTION
Both FB/IG doors hard-coded `hasAttachments: false` and never wrote an `Attachment` row, so a photo — most of what people send on Messenger — landed as a message whose entire content was the snippet "image".

**Verified live: a photo sent to the page arrived and stored.**

## What it does

New `providers/social/attachments.ts` normalizes the two incompatible ways Meta describes an attachment — `{type, payload:{url}}` on the webhook, `{mime_type, name, image_data{url}}` on the Graph edge — into one ref, downloads the bytes, and hands them to the existing inbound-email ingest pipeline. The rows, the read path and the chat bubble needed no new code: `InboundAttachmentIngestService` already writes StorageLocation → MediaAsset → `Attachment`, `message-query.service.ts` already reads them for every channel, `chat-message-display.tsx` already renders them, and `attachments` was already in `MESSAGE_CONTENT_FIELDS` so a `message:updated` patch redacts to the `read` rung on its own.

Only kinds with bytes behind them are downloaded. `share`/`fallback` point at whatever was shared, usually an external page, so fetching one would store someone else's HTML as the customer's attachment; those still feed the snippet fallback.

## Refusals, which are the point of the module

- **25MB cap** (Meta's own send ceiling) checked on `content-length` *before* reading a byte, and again on the buffer for responses with no length header.
- **`text/html` refused** — an expired CDN link answers `200` with an error page.
- **`assertPublicHost`** reused from the enrichment fetcher, since the URL arrives over the wire and `fetch` follows redirects.

Nothing throws. Every caller is past the point of no return — the webhook has answered 200, the backfill has committed the batch — so a dead link costs one file, never a retried webhook or an aborted run.

## Wiring

- **Webhook door** ingests inside `after()`, never before the 200, then publishes `message:updated` — `message:created` already went out with an empty attachment list, so without the patch a photo is an empty bubble until something refetches.
- **Sync door** ingests after the batch, recovering message ids from the `(integrationId, externalId)` index because `batchStoreMessages` only answers with a count.
- `listConversationMessages` now asks for `attachments` **bare** — subfield expansion is what made the old `message{text,attachments,mid}` invalid rather than richer — and falls back to the proven field set on a non-auth, non-throttle error, so an Instagram rejection cannot turn every conversation into a silent skip.

## One reversal worth reviewing

`hasAttachments` now flips at conversion time, reversing the comment that stood in both converters. That comment was right *while no ingestor existed*, but the `message:received` trigger filter is evaluated at store time — strictly before any ingestor could finish — so a flip-after-ingest would mean an attachment rule could **never** fire on this channel. Gmail already works this way (`parse-message.ts` sets the flag, the fetch is best-effort after).

## Tests

13 new in `attachments.test.ts` (size caps, HTML refusal, dead links, SSRF, filename determinism), 2 in `sync.test.ts` for the id recovery, 3 updated converter cases. `vitest run src/providers src/ingest src/email` → 630 passed.

## Out of scope

Outbound attachments — sending a photo from the composer still fails at `facebook-provider.ts:182`. Follow-up PR.