### PR TITLE
feat(channels): send attachments on meta channels

### DIFF
--- a/apps/web/src/components/mail/chat-composer/use-chat-send.ts
+++ b/apps/web/src/components/mail/chat-composer/use-chat-send.ts
@@ -8,6 +8,7 @@ import {
   appendOptimisticMessage,
   toAttachmentMeta,
 } from '~/components/threads/hooks/append-optimistic-message'
+import type { AttachmentMeta } from '~/components/threads/store'
 import type { MessageMeta } from '~/components/threads/store/message-store'
 import { api } from '~/trpc/react'
 import type { FileAttachment } from '../email-editor/types'
@@ -18,6 +19,23 @@ interface UseChatSendOptions {
   /** Called after optimistic updates land. Use to clear local composer state.
    * Does NOT close the surrounding window — that's the parent's call. */
   onSendSuccess: () => void
+}
+
+/** One message of a split send, as `SentMessage.splitMessages` reports it. */
+interface SplitMessage {
+  id: string
+  sentAt?: Date | string | null
+  attachmentIds: string[]
+  hasText: boolean
+}
+
+/** The content of one optimistic bubble — one per message actually sent. */
+interface OptimisticPart {
+  id: string
+  sentAt: string
+  textPlain: string
+  textHtml: string | null
+  attachments: AttachmentMeta[]
 }
 
 interface SendArgs {
@@ -40,45 +58,75 @@ export function useChatSend({ threadId, integrationId, onSendSuccess }: UseChatS
 
       if (sentMessage.threadId && sentMessage.id) {
         const sentAt = sentMessage.sentAt?.toISOString() ?? new Date().toISOString()
-        const textPlain = variables.textPlain ?? ''
-        const attachments = (variables.attachments ?? []).map(toAttachmentMeta)
-        const snippet =
-          textPlain.length > 0
-            ? textPlain.length > 140
-              ? `${textPlain.slice(0, 139)}…`
-              : textPlain
-            : (attachments[0]?.name ?? '')
-        const optimistic: MessageMeta = {
-          id: sentMessage.id,
-          threadId: sentMessage.threadId,
-          subject: sentMessage.subject ?? null,
-          snippet,
-          textHtml: variables.textHtml ?? null,
-          textPlain,
-          isInbound: false,
-          isFirstInThread: false,
-          hasAttachments: attachments.length > 0,
-          hasHtmlBody: !!variables.textHtml,
-          hasTextBody: textPlain.length > 0,
-          sentAt,
-          receivedAt: null,
-          createdAt: sentAt,
-          // Tag ids as `<role>:<id>` so the participant store + grouping render
-          // sender/recipient immediately rather than waiting on the realtime echo.
-          // `thread.sendMessage` returns `any` (the router widens its
-          // sent/scheduled union), so this shape is stated locally. It mirrors
-          // `SentMessage['participants']` in @auxx/lib.
-          participants: (sentMessage.participants ?? []).map((p: { id: string; role: string }) =>
-            toParticipantId(p.role.toLowerCase() as ParticipantRole, p.id)
-          ),
-          createdById: null,
-          sendStatus: 'SENT',
-          providerError: null,
-          attempts: 1,
-          attachments,
-          messageType: 'CHAT',
+        const staged = (variables.attachments ?? []).map(toAttachmentMeta)
+        const threadId = sentMessage.threadId
+
+        const buildOptimistic = (part: OptimisticPart): MessageMeta => {
+          const snippet =
+            part.textPlain.length > 0
+              ? part.textPlain.length > 140
+                ? `${part.textPlain.slice(0, 139)}…`
+                : part.textPlain
+              : (part.attachments[0]?.name ?? '')
+
+          return {
+            id: part.id,
+            threadId,
+            subject: sentMessage.subject ?? null,
+            snippet,
+            textHtml: part.textHtml,
+            textPlain: part.textPlain,
+            isInbound: false,
+            isFirstInThread: false,
+            hasAttachments: part.attachments.length > 0,
+            hasHtmlBody: !!part.textHtml,
+            hasTextBody: part.textPlain.length > 0,
+            sentAt: part.sentAt,
+            receivedAt: null,
+            createdAt: part.sentAt,
+            // Tag ids as `<role>:<id>` so the participant store + grouping render
+            // sender/recipient immediately rather than waiting on the realtime echo.
+            // `thread.sendMessage` returns `any` (the router widens its
+            // sent/scheduled union), so this shape is stated locally. It mirrors
+            // `SentMessage['participants']` in @auxx/lib.
+            participants: (sentMessage.participants ?? []).map((p: { id: string; role: string }) =>
+              toParticipantId(p.role.toLowerCase() as ParticipantRole, p.id)
+            ),
+            createdById: null,
+            sendStatus: 'SENT',
+            providerError: null,
+            attempts: 1,
+            attachments: part.attachments,
+            messageType: 'CHAT',
+          }
         }
-        appendOptimisticMessage(utils, sentMessage.threadId, optimistic)
+
+        // A send the channel could not carry in one message — Meta's `message`
+        // object takes `text` OR one `attachment` — came back as several rows, and
+        // this tab is excluded from its own `message:created` echo. One combined
+        // bubble here would therefore be the only thing the sender ever saw, and it
+        // is not what the customer received.
+        const parts: OptimisticPart[] = sentMessage.splitMessages?.length
+          ? sentMessage.splitMessages.map((part: SplitMessage) => ({
+              id: part.id,
+              sentAt: part.sentAt ? new Date(part.sentAt).toISOString() : sentAt,
+              textPlain: part.hasText ? (variables.textPlain ?? '') : '',
+              textHtml: part.hasText ? (variables.textHtml ?? null) : null,
+              attachments: staged.filter((file) => part.attachmentIds.includes(file.id)),
+            }))
+          : [
+              {
+                id: sentMessage.id,
+                sentAt,
+                textPlain: variables.textPlain ?? '',
+                textHtml: variables.textHtml ?? null,
+                attachments: staged,
+              },
+            ]
+
+        for (const part of parts) {
+          appendOptimisticMessage(utils, threadId, buildOptimistic(part))
+        }
       }
 
       onSendSuccess()

--- a/docs/channels-mail-architecture-guide.md
+++ b/docs/channels-mail-architecture-guide.md
@@ -507,6 +507,36 @@ this — they keep everything-open helpdesk semantics.
 
 ## 11. Outbound — composer → sender → provider
 
+### One composer send is not always one message
+
+`MessageSenderService.sendMessage` first asks `splitSendForProvider` whether the
+provider can carry this send in **one** message. Two capabilities decide it —
+`maxAttachmentsPerMessage` and `canSendTextWithAttachment` (`providers/types.ts`).
+Email answers yes to everything and is never split. Meta answers no to both: its
+Send API's `message` object takes `text` **or** one `attachment`, so a caption
+with two photos becomes three messages, sent in order, each with its own row.
+
+**The split is here rather than inside the provider because of ingest, not
+aesthetics.** Each Meta message returns its own `mid`, and a `Message` row holds
+one `externalId` — the key `(integrationId, externalId)` dedupes on. A provider
+that sent three and reported one would leave two ids belonging to no row of ours,
+and the next scheduled sync (FB/IG are in `sync-all-messages-job`) would re-import
+them as duplicate outbound messages. It also matches what the customer sees:
+Messenger renders three bubbles whatever we do.
+
+Parts 2..N carry `splitContinuation`, which skips the auto-reply alternation
+guard — they are one send, not a workflow replying to itself. Send-level fields
+(`messageId`, `draftMessageId`, `signatureId`, `includePreviousMessage`) belong to
+the first part only. A part that fails throws with the earlier parts already sent,
+which is the honest outcome: they really did arrive.
+
+`SentMessage.splitMessages` reports the whole shape back to the composer, which
+needs it because the originating tab is excluded from its own `message:created`
+echo (`excludeSocketId`) — its optimistic row is the only thing it sees until a
+refetch.
+
+
+
 `MessageComposerService` commits the `Message` row **before** the provider is called, mints the
 `sendToken`, and resolves attachments. `MessageSenderService` then:
 

--- a/packages/lib/src/messages/__tests__/split-send.test.ts
+++ b/packages/lib/src/messages/__tests__/split-send.test.ts
@@ -1,0 +1,138 @@
+// packages/lib/src/messages/__tests__/split-send.test.ts
+//
+// The split exists to keep one invariant true: every provider message id we are
+// handed back belongs to a row of ours. Meta mints one `mid` per message and takes
+// `text` OR one `attachment`, so a caption with two photos is three ids — and any
+// id without a row comes back as a duplicate outbound message on the next sync
+// (FB/IG are in `sync-all-messages-job`). These tests pin the shape of the split
+// and the field ownership that keeps the parts from stepping on each other.
+
+import { describe, expect, it } from 'vitest'
+import { splitSendForProvider } from '../split-send'
+import type { SendMessageInput } from '../types/message-sending.types'
+
+const META = { maxAttachmentsPerMessage: 1, canSendTextWithAttachment: false }
+const EMAIL = {}
+
+function input(overrides: Partial<SendMessageInput> = {}): SendMessageInput {
+  return {
+    userId: 'user_1',
+    organizationId: 'org_1',
+    integrationId: 'int_1',
+    threadId: 'thread_1',
+    to: [],
+    ...overrides,
+  }
+}
+
+describe('splitSendForProvider', () => {
+  it('leaves an email send alone, however many files it carries', () => {
+    const send = input({ textPlain: 'here you go', attachmentIds: ['a', 'b', 'c'] })
+    expect(splitSendForProvider(send, EMAIL)).toEqual([send])
+  })
+
+  it('leaves a text-only send alone on every provider', () => {
+    const send = input({ textPlain: 'hello' })
+    expect(splitSendForProvider(send, META)).toEqual([send])
+  })
+
+  it('leaves a single attachment with no caption alone — it already fits', () => {
+    const send = input({ attachmentIds: ['a'] })
+    expect(splitSendForProvider(send, META)).toEqual([send])
+  })
+
+  it('splits a caption plus two photos into three messages, text first', () => {
+    const parts = splitSendForProvider(
+      input({ textPlain: 'here you go', attachmentIds: ['a', 'b'] }),
+      META
+    )
+
+    expect(parts).toHaveLength(3)
+    expect(parts[0]).toMatchObject({ textPlain: 'here you go', attachmentIds: undefined })
+    expect(parts[1]).toMatchObject({ textPlain: null, attachmentIds: ['a'] })
+    expect(parts[2]).toMatchObject({ textPlain: null, attachmentIds: ['b'] })
+  })
+
+  it('never repeats the text on an attachment part', () => {
+    // Carrying the body onto every part would send the caption three times, which
+    // is exactly what the separate text part exists to prevent.
+    const parts = splitSendForProvider(
+      input({ textHtml: '<p>hi</p>', textPlain: 'hi', attachmentIds: ['a', 'b'] }),
+      META
+    )
+
+    for (const part of parts.slice(1)) {
+      expect(part.textHtml).toBeNull()
+      expect(part.textPlain).toBeNull()
+    }
+  })
+
+  it('splits a caption and one photo, because Meta cannot carry both in one message', () => {
+    const parts = splitSendForProvider(
+      input({ textPlain: 'receipt attached', attachmentIds: ['a'] }),
+      META
+    )
+
+    expect(parts).toHaveLength(2)
+  })
+
+  it('gives the send-level fields to the first part only', () => {
+    // A duplicated RFC Message-ID would collide, one draft is consumed once, and a
+    // signature appended to an attachment-only message becomes that message's body.
+    const parts = splitSendForProvider(
+      input({
+        textPlain: 'hi',
+        attachmentIds: ['a', 'b'],
+        messageId: '<generated@auxx>',
+        draftMessageId: 'draft_1',
+        signatureId: 'sig_1',
+        includePreviousMessage: true,
+      }),
+      META
+    )
+
+    expect(parts[0]).toMatchObject({
+      messageId: '<generated@auxx>',
+      draftMessageId: 'draft_1',
+      signatureId: 'sig_1',
+      includePreviousMessage: true,
+    })
+    for (const part of parts.slice(1)) {
+      expect(part.messageId).toBeUndefined()
+      expect(part.draftMessageId).toBeNull()
+      expect(part.signatureId).toBeNull()
+      expect(part.includePreviousMessage).toBe(false)
+    }
+  })
+
+  it('promotes the first attachment part when there is no text to carry them', () => {
+    const parts = splitSendForProvider(
+      input({ attachmentIds: ['a', 'b'], draftMessageId: 'draft_1' }),
+      META
+    )
+
+    expect(parts).toHaveLength(2)
+    expect(parts[0]?.draftMessageId).toBe('draft_1')
+    expect(parts[1]?.draftMessageId).toBeNull()
+  })
+
+  it('treats whitespace-only text as no text, so it does not mint an empty message', () => {
+    const parts = splitSendForProvider(
+      input({ textPlain: '   ', textHtml: '', attachmentIds: ['a'] }),
+      META
+    )
+
+    expect(parts).toHaveLength(1)
+  })
+
+  it('produces parts that are themselves unsplittable — the recursion is one level deep', () => {
+    const parts = splitSendForProvider(
+      input({ textPlain: 'hi', attachmentIds: ['a', 'b', 'c'] }),
+      META
+    )
+
+    for (const part of parts) {
+      expect(splitSendForProvider(part, META)).toEqual([part])
+    }
+  })
+})

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -41,6 +41,7 @@ import { createUsageGuard } from '../usage/create-usage-guard'
 import { checkAutomatedSendLimits, notifyAdminsOfSendBreakerTrip } from './automated-send-guard'
 import { MessageComposerService } from './message-composer.service'
 import { MessageReconcilerService } from './message-reconciler.service'
+import { splitSendForProvider } from './split-send'
 import { ThreadManagerService } from './thread-manager.service'
 import type {
   ComposedMessage,
@@ -56,6 +57,16 @@ import type {
 } from './types/message-sending.types'
 
 const logger = createScopedLogger('message-sender')
+
+/**
+ * Send-internal state, never part of the public input.
+ *
+ * `splitContinuation` marks parts 2..N of one split send so the auto-reply
+ * alternation guard does not treat them as a second automated reply.
+ */
+interface SendInternalOptions {
+  splitContinuation?: boolean
+}
 
 /** Module default connection, reachable from inside the constructor where the
  *  `db` parameter shadows the `database as db` import. */
@@ -147,6 +158,52 @@ export class MessageSenderService {
    * §7 send gate — only bites when an interactive viewer was provided.
    * `none` reads as not-found; `metadata`/`subject` as restricted.
    */
+  /**
+   * Send the parts of one split composer send, in order, as separate messages.
+   *
+   * Sequential, never concurrent: Messenger renders in arrival order, so a
+   * caption racing its photo would read backwards. The FIRST part's result is
+   * what the caller gets — it is the message the composer's optimistic row
+   * represents.
+   *
+   * A part that fails throws, leaving the earlier parts sent. That is the honest
+   * outcome for a multi-message send: they really did arrive, and swallowing the
+   * failure would tell the user their photo went out when it did not.
+   */
+  private async sendSplitParts(parts: SendMessageInput[]): Promise<SentMessage> {
+    logger.info('Splitting send into separate provider messages', {
+      partCount: parts.length,
+      integrationId: parts[0]?.integrationId,
+    })
+
+    const results: SentMessage[] = []
+    for (const [index, part] of parts.entries()) {
+      const first = results[0]
+      const pinned =
+        first && this.isPlaceholderThreadId(part.threadId)
+          ? // The first part may have CREATED the thread. Later parts must land on
+            // it rather than opening one thread per attachment.
+            { ...part, threadId: first.threadId }
+          : part
+      results.push(await this.sendMessage(pinned, { splitContinuation: index > 0 }))
+    }
+
+    // The caller gets the first message, plus the shape of the whole send — the
+    // composer's optimistic row is the only thing the sending tab sees (its own
+    // `message:created` is suppressed by `excludeSocketId`), so it has to know
+    // this became several rows.
+    return {
+      ...results[0]!,
+      splitMessages: results.map((sent, index) => ({
+        id: sent.id,
+        threadId: sent.threadId,
+        sentAt: sent.sentAt,
+        attachmentIds: parts[index]?.attachmentIds ?? [],
+        hasText: !!(parts[index]?.textHtml?.trim() || parts[index]?.textPlain?.trim()),
+      })),
+    }
+  }
+
   private async assertCanSendOnThread(threadId: string | null): Promise<void> {
     if (!threadId || !this.viewer || isSystemViewer(this.viewer)) return
     const lens = await getThreadLens(this.db ?? db, this.organizationId, this.viewer, threadId)
@@ -171,7 +228,7 @@ export class MessageSenderService {
   /**
    * Main entry point for sending messages
    */
-  async sendMessage(input: SendMessageInput): Promise<SentMessage> {
+  async sendMessage(input: SendMessageInput, internal?: SendInternalOptions): Promise<SentMessage> {
     logger.info('Starting message send', {
       userId: input.userId,
       organizationId: input.organizationId,
@@ -187,6 +244,13 @@ export class MessageSenderService {
     // Validate input (capability-driven — subject/recipients depend on provider)
     const capabilities = await this.getCapabilitiesForIntegration(input.integrationId)
     this.validateInput(input, capabilities)
+
+    // A send the provider cannot carry in one message becomes several, each with
+    // its own row — see `splitSendForProvider` for why this is not a loop inside
+    // the provider. Every part is unsplittable by construction, so the recursion
+    // is one level deep.
+    const parts = splitSendForProvider(input, capabilities)
+    if (parts.length > 1) return this.sendSplitParts(parts)
     // Usage guard: count outbound email before sending (skip for providers that
     // don't count, e.g. chat).
     if (capabilities.countsAgainstOutboundEmailsQuota) {
@@ -239,7 +303,11 @@ export class MessageSenderService {
       const isAutomatedSend = !this.viewer || isSystemViewer(this.viewer)
       // Step 2.4: §6 fix #3 — per-thread auto-reply alternation. Existing threads only;
       // a freshly-created (pending) thread has no prior message to alternate against.
-      if (isAutomatedSend && !threadContext.isPending) {
+      // `splitContinuation`: parts 2..N of ONE split send are not a second
+      // automated reply, and the guard would block them precisely because part 1
+      // just landed. The guard still applies to the first part, which is the one
+      // that represents the send.
+      if (isAutomatedSend && !threadContext.isPending && !internal?.splitContinuation) {
         await this.assertAlternation(threadContext.id, input.organizationId)
       }
       // Step 2.5: Send-time suppression + List-Unsubscribe context (signals plan 02
@@ -592,6 +660,8 @@ export class MessageSenderService {
     countsAgainstOutboundEmailsQuota: boolean
     triggersPostSendSync: boolean
     requiresSendReconciliation: boolean
+    maxAttachmentsPerMessage?: number
+    canSendTextWithAttachment?: boolean
   }> {
     const [integration] = await (this.db ?? db)
       .select({ provider: schema.Integration.provider })
@@ -610,6 +680,10 @@ export class MessageSenderService {
       countsAgainstOutboundEmailsQuota: caps.countsAgainstOutboundEmailsQuota,
       triggersPostSendSync: caps.triggersPostSendSync,
       requiresSendReconciliation: caps.requiresSendReconciliation,
+      // The send SHAPE — how many attachments one message may carry, and whether
+      // it may carry text beside them. Drives `splitSendForProvider`.
+      maxAttachmentsPerMessage: caps.maxAttachmentsPerMessage,
+      canSendTextWithAttachment: caps.canSendTextWithAttachment,
     }
   }
   /**

--- a/packages/lib/src/messages/split-send.ts
+++ b/packages/lib/src/messages/split-send.ts
@@ -1,0 +1,91 @@
+// packages/lib/src/messages/split-send.ts
+
+import type { ProviderCapabilities } from '../providers/types'
+import type { SendMessageInput } from './types/message-sending.types'
+
+/** The two capability fields that decide whether one send fits in one message. */
+export type SendShapeCapabilities = Pick<
+  ProviderCapabilities,
+  'maxAttachmentsPerMessage' | 'canSendTextWithAttachment'
+>
+
+/**
+ * Split one composer send into the messages a provider can actually carry.
+ *
+ * **Why this exists rather than a loop inside the provider.** Meta's Send API
+ * takes `text` OR one `attachment`, so a caption with two photos is three Graph
+ * calls and three `mid`s — but a `Message` row holds ONE `externalId`, and that
+ * is the key ingest dedupes on. A provider that sent three and reported one
+ * would leave two ids belonging to no row of ours, and the next scheduled sync
+ * (FB/IG are in `sync-all-messages-job`) would re-import them as duplicate
+ * outbound messages. Splitting up here gives every provider id a row.
+ *
+ * It also matches what the customer sees: Messenger renders three bubbles
+ * whatever we do, so three rows is the honest model, not a workaround.
+ *
+ * The parts are ordered text-first, then one message per attachment in composer
+ * order.
+ *
+ * Field ownership across parts, all for the same reason — these belong to the
+ * *send*, not to each message, so only the first part may claim them:
+ * `messageId` (a duplicated RFC Message-ID would collide), `draftMessageId` (one
+ * draft is consumed once), `signatureId` and `includePreviousMessage` (a
+ * signature appended to an attachment-only message becomes that message's body).
+ *
+ * @returns `[input]` unchanged when the provider can carry it in one message —
+ * which is every email provider, and every send with no attachments.
+ */
+export function splitSendForProvider(
+  input: SendMessageInput,
+  capabilities: SendShapeCapabilities
+): SendMessageInput[] {
+  const attachmentIds = input.attachmentIds ?? []
+  if (attachmentIds.length === 0) return [input]
+
+  const maxPerMessage = capabilities.maxAttachmentsPerMessage ?? Number.POSITIVE_INFINITY
+  const canCombine = capabilities.canSendTextWithAttachment !== false
+  const hasText = !!(input.textHtml?.trim() || input.textPlain?.trim())
+
+  const fitsInOne = attachmentIds.length <= maxPerMessage && (canCombine || !hasText)
+  if (fitsInOne) return [input]
+
+  const parts: SendMessageInput[] = []
+  if (hasText) {
+    parts.push({ ...input, attachmentIds: undefined })
+  }
+
+  const chunkSize = Number.isFinite(maxPerMessage)
+    ? Math.max(1, maxPerMessage)
+    : attachmentIds.length
+  for (let index = 0; index < attachmentIds.length; index += chunkSize) {
+    parts.push({
+      ...input,
+      attachmentIds: attachmentIds.slice(index, index + chunkSize),
+      // An attachment-only message. Carrying the text again would send it twice —
+      // the whole point of the text part above.
+      textHtml: null,
+      textPlain: null,
+      messageId: undefined,
+      draftMessageId: null,
+      signatureId: null,
+      includePreviousMessage: false,
+    })
+  }
+
+  // The first part keeps whatever the caller passed; everything after it gives up
+  // the send-level fields. When there is no text the first ATTACHMENT part is the
+  // one that inherits them.
+  const [first, ...rest] = parts
+  if (!first) return [input]
+  const head = hasText
+    ? first
+    : {
+        ...first,
+        messageId: input.messageId,
+        draftMessageId: input.draftMessageId,
+        signatureId: input.signatureId,
+        includePreviousMessage: input.includePreviousMessage,
+      }
+
+  return [head, ...rest]
+}

--- a/packages/lib/src/messages/types/message-sending.types.ts
+++ b/packages/lib/src/messages/types/message-sending.types.ts
@@ -150,6 +150,29 @@ export interface SentMessage {
    * participant-less row that waits on the realtime echo / refetch.
    */
   participants?: { id: string; role: ParticipantRole }[]
+  /**
+   * Every message this send became, primary first — set only when the provider
+   * could not carry it in one message (Meta: one attachment, never beside text;
+   * see `splitSendForProvider`).
+   *
+   * The composer needs it because the originating tab is excluded from its own
+   * `message:created` echo (`excludeSocketId`), so its optimistic row is the only
+   * thing it sees until a refetch. Without this it would render ONE row carrying
+   * both the text and the files, which is not what was sent and not what the
+   * customer sees.
+   */
+  splitMessages?: SplitSentMessage[]
+}
+
+/** One message of a split send, as the composer needs to render it. */
+export interface SplitSentMessage {
+  id: string
+  threadId: string
+  sentAt: Date | null
+  /** The MediaAsset ids this message carried — matched against the staged files. */
+  attachmentIds: string[]
+  /** Whether this is the part that carried the composed text. */
+  hasText: boolean
 }
 /**
  * Reconciliation input

--- a/packages/lib/src/providers/facebook/facebook-provider.ts
+++ b/packages/lib/src/providers/facebook/facebook-provider.ts
@@ -179,8 +179,18 @@ export class FacebookProvider
         "Recipient PSID (Page-Scoped ID) is required in 'to' field for Facebook messages."
       )
     }
-    if (!options.text) {
-      throw new Error('Facebook message must contain text (attachments not implemented).')
+    // One attachment per message, never beside text: Meta's `message` object takes
+    // `text` OR `attachment`. `MessageSenderService` has already split a composer
+    // send that needs both, so anything arriving here is a single message —
+    // extra attachments would be silently dropped, so refuse them instead.
+    const attachment = options.attachments?.[0]
+    if (options.attachments && options.attachments.length > 1) {
+      throw new Error(
+        'Meta accepts one attachment per message; the send should have been split upstream.'
+      )
+    }
+    if (!options.text && !attachment) {
+      throw new Error('A message must contain text or an attachment.')
     }
     // Messaging-window policy (24h `RESPONSE`, `HUMAN_AGENT` outside it, automation
     // blocked outside it) plus the Graph call itself live in `social/send.ts` so
@@ -191,7 +201,16 @@ export class FacebookProvider
       pageId: this.pageId!,
       pageAccessToken: this.pageAccessToken!,
       recipientId: recipientPsid,
-      text: options.text,
+      text: attachment ? undefined : options.text,
+      attachment: attachment
+        ? {
+            content: Buffer.isBuffer(attachment.content)
+              ? attachment.content
+              : Buffer.from(attachment.content),
+            filename: attachment.filename,
+            contentType: attachment.contentType,
+          }
+        : undefined,
       externalThreadId: options.externalThreadId,
       automated: options.automated,
     })

--- a/packages/lib/src/providers/instagram/instagram-provider.ts
+++ b/packages/lib/src/providers/instagram/instagram-provider.ts
@@ -183,9 +183,18 @@ export class InstagramProvider
         "Recipient IGSID (Instagram-Scoped User ID) is required in 'to' field for Instagram messages."
       )
     }
-    if (!options.text) {
-      throw new Error('Instagram message must contain text.')
-      // TODO: Handle attachments if needed (complex process involving uploads or asset URLs)
+    // One attachment per message, never beside text: Meta's `message` object takes
+    // `text` OR `attachment`. `MessageSenderService` has already split a composer
+    // send that needs both, so anything arriving here is a single message —
+    // extra attachments would be silently dropped, so refuse them instead.
+    const attachment = options.attachments?.[0]
+    if (options.attachments && options.attachments.length > 1) {
+      throw new Error(
+        'Meta accepts one attachment per message; the send should have been split upstream.'
+      )
+    }
+    if (!options.text && !attachment) {
+      throw new Error('A message must contain text or an attachment.')
     }
     // Shared with Messenger — see `social/send.ts`.
     //
@@ -205,7 +214,16 @@ export class InstagramProvider
       pageId: this.pageId!,
       pageAccessToken: this.pageAccessToken!,
       recipientId: recipientIgsid,
-      text: options.text,
+      text: attachment ? undefined : options.text,
+      attachment: attachment
+        ? {
+            content: Buffer.isBuffer(attachment.content)
+              ? attachment.content
+              : Buffer.from(attachment.content),
+            filename: attachment.filename,
+            contentType: attachment.contentType,
+          }
+        : undefined,
       externalThreadId: options.externalThreadId,
       automated: options.automated,
     })

--- a/packages/lib/src/providers/provider-capabilities.ts
+++ b/packages/lib/src/providers/provider-capabilities.ts
@@ -84,6 +84,10 @@ export const PROVIDER_CAPABILITIES: Record<ChannelProviderType, ProviderCapabili
     canBulkOperations: false,
     canAttachFiles: true,
     maxAttachmentSize: 10 * 1024 * 1024, // 10MB
+    // Meta's `message` object takes `text` OR one `attachment`, never both — a
+    // caption with a photo is two messages, split by `MessageSenderService`.
+    maxAttachmentsPerMessage: 1,
+    canSendTextWithAttachment: false,
     supportedAttachmentTypes: ['image/jpeg', 'image/png', 'image/gif', 'video/mp4'],
     canScheduleSend: false,
     canTrackOpens: false,
@@ -137,6 +141,10 @@ export const PROVIDER_CAPABILITIES: Record<ChannelProviderType, ProviderCapabili
     canBulkOperations: false,
     canAttachFiles: true,
     maxAttachmentSize: 8 * 1024 * 1024, // 8MB
+    // Meta's `message` object takes `text` OR one `attachment`, never both — a
+    // caption with a photo is two messages, split by `MessageSenderService`.
+    maxAttachmentsPerMessage: 1,
+    canSendTextWithAttachment: false,
     supportedAttachmentTypes: ['image/jpeg', 'image/png', 'video/mp4'],
     canScheduleSend: false,
     canTrackOpens: false,

--- a/packages/lib/src/providers/social/__tests__/send-attachment.test.ts
+++ b/packages/lib/src/providers/social/__tests__/send-attachment.test.ts
@@ -1,0 +1,124 @@
+// packages/lib/src/providers/social/__tests__/send-attachment.test.ts
+//
+// The attachment send is a multipart POST whose field names are load-bearing: Meta
+// accepts the HTTP request either way and then delivers a message with no
+// attachment on it, so a wrong field name is a silent product failure rather than
+// an error. These tests read the form back off a stubbed `fetch`.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { sendAttachment, sendAttachmentTypeForMimeType } from '../api'
+
+const BASE = {
+  pageId: '869289333164075',
+  pageAccessToken: 'page_token',
+  recipientId: '27893553143563440',
+  content: Buffer.from('bytes'),
+  filename: 'receipt.png',
+  contentType: 'image/png',
+}
+
+function stubFetch() {
+  const fetchMock = vi.fn(
+    async () =>
+      new Response(JSON.stringify({ message_id: 'm_sent_1', recipient_id: BASE.recipientId }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+  )
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+/** The multipart body of the single call the stub recorded. */
+async function sentForm(fetchMock: ReturnType<typeof stubFetch>): Promise<FormData> {
+  const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+  return init.body as FormData
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('sendAttachmentTypeForMimeType', () => {
+  it('maps a MIME type to the word Meta renders by', () => {
+    // Meta renders by this word, not the MIME type: a JPEG sent as `file` arrives
+    // as a download link instead of a photo.
+    expect(sendAttachmentTypeForMimeType('image/jpeg')).toBe('image')
+    expect(sendAttachmentTypeForMimeType('IMAGE/PNG')).toBe('image')
+    expect(sendAttachmentTypeForMimeType('video/mp4')).toBe('video')
+    expect(sendAttachmentTypeForMimeType('audio/mpeg')).toBe('audio')
+    expect(sendAttachmentTypeForMimeType('application/pdf')).toBe('file')
+    expect(sendAttachmentTypeForMimeType('')).toBe('file')
+  })
+})
+
+describe('sendAttachment', () => {
+  it('uploads the bytes as multipart and returns the mid', async () => {
+    const fetchMock = stubFetch()
+
+    const result = await sendAttachment(BASE)
+
+    expect(result.messageId).toBe('m_sent_1')
+    const form = await sentForm(fetchMock)
+    expect(JSON.parse(form.get('recipient') as string)).toEqual({ id: BASE.recipientId })
+    expect(form.get('messaging_type')).toBe('RESPONSE')
+    expect(JSON.parse(form.get('message') as string)).toEqual({
+      attachment: { type: 'image', payload: { is_reusable: false } },
+    })
+
+    // `filedata` is the field name the Send API looks for. Anything else is a 200
+    // with an attachment-less message.
+    const file = form.get('filedata') as File
+    expect(file).toBeInstanceOf(Blob)
+    expect(file.type).toBe('image/png')
+    expect(await file.text()).toBe('bytes')
+  })
+
+  it('lets fetch set its own Content-Type so the multipart boundary matches', async () => {
+    const fetchMock = stubFetch()
+
+    await sendAttachment(BASE)
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    const headers = init.headers as Record<string, string>
+    expect(headers['Content-Type']).toBeUndefined()
+    expect(headers.Authorization).toBe('Bearer page_token')
+  })
+
+  it('carries the tag when the send is outside the 24h window', async () => {
+    const fetchMock = stubFetch()
+
+    await sendAttachment({ ...BASE, messagingType: 'MESSAGE_TAG', tag: 'HUMAN_AGENT' })
+
+    const form = await sentForm(fetchMock)
+    expect(form.get('messaging_type')).toBe('MESSAGE_TAG')
+    expect(form.get('tag')).toBe('HUMAN_AGENT')
+  })
+
+  it('omits the tag entirely on an ordinary response', async () => {
+    const fetchMock = stubFetch()
+
+    await sendAttachment(BASE)
+
+    // Sending `tag: undefined` as the literal string "undefined" is rejected by
+    // Graph with a message that names the tag, not the field.
+    expect((await sentForm(fetchMock)).has('tag')).toBe(false)
+  })
+
+  it('surfaces a Graph rejection as an AuxxError, not a silent success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              error: { message: 'Attachment size exceeds allowable limit', code: 100 },
+            }),
+            { status: 400, headers: { 'content-type': 'application/json' } }
+          )
+      )
+    )
+
+    await expect(sendAttachment(BASE)).rejects.toThrow('Attachment size exceeds allowable limit')
+  })
+})

--- a/packages/lib/src/providers/social/api.ts
+++ b/packages/lib/src/providers/social/api.ts
@@ -128,6 +128,14 @@ export interface GraphRequestOptions {
   query?: Record<string, string | number | boolean | undefined>
   /** JSON body for POST. */
   body?: Record<string, unknown>
+  /**
+   * Multipart body for POST, used by the attachment upload.
+   *
+   * Mutually exclusive with `body`. The `Content-Type` header is deliberately
+   * left unset when this is present — `fetch` has to generate it itself so the
+   * multipart boundary matches the body it encoded.
+   */
+  formData?: FormData
   /** Full URL to call instead of building one — for following `paging.next`. */
   url?: string
 }
@@ -151,7 +159,7 @@ export interface GraphRequestOptions {
  * is throttling, `GraphApiError` otherwise, all carrying Meta's `code`/`subcode`.
  */
 export async function graphRequest<T>(path: string, options: GraphRequestOptions): Promise<T> {
-  const { accessToken, method = 'GET', query, body, url } = options
+  const { accessToken, method = 'GET', query, body, formData, url } = options
 
   let target: string
   if (url) {
@@ -175,6 +183,7 @@ export async function graphRequest<T>(path: string, options: GraphRequestOptions
         ...(body ? { 'Content-Type': 'application/json' } : {}),
       },
       ...(body ? { body: JSON.stringify(body) } : {}),
+      ...(formData ? { body: formData } : {}),
     })
   } catch (error) {
     // Transport failure — no Graph envelope to read.
@@ -330,6 +339,85 @@ export async function sendMessage(args: SendMessageArgs): Promise<{ messageId?: 
         message: { text },
       },
     }
+  )
+  return { messageId: result.message_id }
+}
+
+/** The five `message.attachment.type` words Meta's Send API accepts. */
+export type SendAttachmentType = 'image' | 'video' | 'audio' | 'file'
+
+export interface SendAttachmentArgs extends Omit<SendMessageArgs, 'text'> {
+  content: Buffer
+  filename: string
+  contentType: string
+}
+
+/**
+ * Which `attachment.type` a file goes out as.
+ *
+ * Meta renders by this word, not by the MIME type: a JPEG sent as `file`
+ * arrives as a download link rather than a photo, so getting this wrong is a
+ * visible product regression rather than an error.
+ */
+export function sendAttachmentTypeForMimeType(mimeType: string): SendAttachmentType {
+  const normalized = mimeType.toLowerCase()
+  if (normalized.startsWith('image/')) return 'image'
+  if (normalized.startsWith('video/')) return 'video'
+  if (normalized.startsWith('audio/')) return 'audio'
+  return 'file'
+}
+
+/**
+ * `POST /{pageId}/messages` with the bytes attached — the multipart form of
+ * {@link sendMessage}.
+ *
+ * **Uploads the bytes rather than handing Meta a URL.** The Send API also
+ * accepts `payload: {url}`, which would mean minting a presigned S3 link and
+ * trusting Meta to fetch it before it expires; uploading keeps private storage
+ * private and removes a dependency on our object store being reachable from
+ * Meta's crawlers at all.
+ *
+ * `is_reusable: false` because these are one-shot support replies. A reusable
+ * upload returns an `attachment_id` worth keeping only if the same file goes to
+ * many people, which is the marketing case, not this one.
+ *
+ * **One attachment per message, and never alongside text** — Meta's `message`
+ * object takes `text` OR `attachment`. The split into separate messages happens
+ * upstream in `MessageSenderService`, so that every message we send has its own
+ * `mid` to store; see `canSendTextWithAttachment` in the provider capabilities.
+ */
+export async function sendAttachment(args: SendAttachmentArgs): Promise<{ messageId?: string }> {
+  const {
+    pageId,
+    pageAccessToken,
+    recipientId,
+    content,
+    filename,
+    contentType,
+    messagingType = 'RESPONSE',
+    tag,
+  } = args
+
+  const form = new FormData()
+  form.append('recipient', JSON.stringify({ id: recipientId }))
+  form.append('messaging_type', messagingType)
+  if (tag) form.append('tag', tag)
+  form.append(
+    'message',
+    JSON.stringify({
+      attachment: {
+        type: sendAttachmentTypeForMimeType(contentType),
+        payload: { is_reusable: false },
+      },
+    })
+  )
+  // `filedata` is the field name Meta's Send API looks for; anything else is
+  // accepted by the HTTP layer and then rejected as a message with no attachment.
+  form.append('filedata', new Blob([new Uint8Array(content)], { type: contentType }), filename)
+
+  const result = await graphRequest<{ message_id?: string; recipient_id?: string }>(
+    `${pageId}/messages`,
+    { accessToken: pageAccessToken, method: 'POST', formData: form }
   )
   return { messageId: result.message_id }
 }

--- a/packages/lib/src/providers/social/send.ts
+++ b/packages/lib/src/providers/social/send.ts
@@ -4,7 +4,7 @@ import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, desc, eq } from 'drizzle-orm'
 import { BadRequestError } from '../../errors'
-import { type MessagingType, sendMessage } from './api'
+import { type MessagingType, sendAttachment, sendMessage } from './api'
 import type { SocialPlatform } from './types'
 
 const logger = createScopedLogger('social-send')
@@ -107,6 +107,13 @@ export function resolveSendPolicy(args: {
   return { messagingType: 'MESSAGE_TAG', tag: HUMAN_AGENT_TAG, lastInboundAt, withinWindow }
 }
 
+/** One file to send. Bytes, because the composer already has them in hand. */
+export interface SocialSendAttachment {
+  content: Buffer
+  filename: string
+  contentType: string
+}
+
 export interface SendSocialMessageArgs {
   platform: SocialPlatform
   integrationId: string
@@ -114,7 +121,17 @@ export interface SendSocialMessageArgs {
   pageId: string
   pageAccessToken: string
   recipientId: string
-  text: string
+  /** Empty when this message carries an attachment instead — never both. */
+  text?: string
+  /**
+   * The file this message carries, if any.
+   *
+   * Exactly one, and never together with `text`: Meta's `message` object takes
+   * `text` OR `attachment`. A composer send with a caption and two photos is
+   * three messages, split upstream by `MessageSenderService` so each one gets its
+   * own row and its own `mid` — see `canSendTextWithAttachment`.
+   */
+  attachment?: SocialSendAttachment
   externalThreadId?: string
   automated?: boolean
 }
@@ -128,12 +145,18 @@ export interface SendSocialMessageArgs {
 export async function sendSocialMessage(
   args: SendSocialMessageArgs
 ): Promise<{ messageId?: string; policy: SocialSendPolicy }> {
-  const { platform, integrationId, pageId, pageAccessToken, recipientId, text } = args
+  const { platform, integrationId, pageId, pageAccessToken, recipientId, text, attachment } = args
+
+  if (!attachment && !text) {
+    throw new BadRequestError('A message must carry text or an attachment.')
+  }
 
   const lastInboundAt = args.externalThreadId
     ? await getLastInboundAt(integrationId, args.externalThreadId)
     : null
 
+  // The window policy is the same for both — an attachment outside 24 hours is as
+  // much an unsolicited message as a sentence is, and Meta enforces it identically.
   const policy = resolveSendPolicy({ lastInboundAt, automated: args.automated === true })
 
   logger.info('Sending social message', {
@@ -141,16 +164,28 @@ export async function sendSocialMessage(
     integrationId,
     messagingType: policy.messagingType,
     withinWindow: policy.withinWindow,
+    hasAttachment: !!attachment,
   })
 
-  const { messageId } = await sendMessage({
-    pageId,
-    pageAccessToken,
-    recipientId,
-    text,
-    messagingType: policy.messagingType,
-    tag: policy.tag,
-  })
+  const { messageId } = attachment
+    ? await sendAttachment({
+        pageId,
+        pageAccessToken,
+        recipientId,
+        content: attachment.content,
+        filename: attachment.filename,
+        contentType: attachment.contentType,
+        messagingType: policy.messagingType,
+        tag: policy.tag,
+      })
+    : await sendMessage({
+        pageId,
+        pageAccessToken,
+        recipientId,
+        text: text!,
+        messagingType: policy.messagingType,
+        tag: policy.tag,
+      })
 
   return { messageId, policy }
 }

--- a/packages/lib/src/providers/types.ts
+++ b/packages/lib/src/providers/types.ts
@@ -36,6 +36,23 @@ export interface ProviderCapabilities {
   canAttachFiles: boolean
   maxAttachmentSize?: number // in bytes
   supportedAttachmentTypes?: string[]
+  /**
+   * How many attachments one message on this provider can carry. Undefined = no
+   * per-message limit (email).
+   *
+   * Meta's Send API takes exactly one, which is why this exists: a composer send
+   * that exceeds it is SPLIT into several messages by `MessageSenderService`
+   * rather than truncated, so every provider id we are handed back belongs to a
+   * row of ours and ingest can dedupe it on the next sync.
+   */
+  maxAttachmentsPerMessage?: number
+  /**
+   * Whether one message can carry text AND an attachment. Undefined = yes.
+   *
+   * False on Meta: its `message` object takes `text` or `attachment`, never both,
+   * so a caption and a photo are two messages.
+   */
+  canSendTextWithAttachment?: boolean
 
   // Special features
   canScheduleSend: boolean


### PR DESCRIPTION
Follow-up to #1724 (inbound). Sending a photo failed at `facebook-provider.ts:182` — `'Facebook message must contain text (attachments not implemented)'` — while `PlatformCapabilities` advertised `attachments: true` for both channels, so the composer offered a paperclip for something the provider refused.

## The upload was the easy half

Meta's `message` object takes `text` **or** one `attachment`, never both. So a caption with two photos is three Graph calls and three `mid`s — but a `Message` row holds one `externalId`, which is the key `(integrationId, externalId)` dedupes on.

A provider that sent three and reported one would leave two `mid`s belonging to no row of ours, and **FB/IG are in `sync-all-messages-job`**, so the next scheduled sync would re-import them as duplicate outbound messages. The reconciler would not have caught them either: its subject+time fallback matches `subject = ''` and a chat row's subject is `NULL`.

## So the split happens in `MessageSenderService`

Two new runtime capabilities — `maxAttachmentsPerMessage` and `canSendTextWithAttachment`, `1` and `false` on both Meta providers — drive `splitSendForProvider`, which turns one composer send into text-first-then-one-message-per-attachment. Each part is a full send: its own row, its own `sendToken`, its own `mid`. Every id we are handed back belongs to a row, so sync dedupes and nothing duplicates.

It is also the honest model: Messenger renders three bubbles whatever we do.

```
composer: "here you go" + receipt.png
         │
         ├─ Message row 1  text="here you go"   externalId=m_aaa
         └─ Message row 2  attachment=receipt   externalId=m_bbb
```

### Three details the split has to get right

- **Parts 2..N carry `splitContinuation`**, which skips the auto-reply alternation guard. Without it an agent sending a file is blocked on its own second part, *because* the first one just landed.
- **Send-level fields belong to the first part only** — `messageId` (a duplicated RFC Message-ID collides), `draftMessageId` (one draft is consumed once), `signatureId` and `includePreviousMessage` (a signature appended to an attachment-only message becomes that message's body).
- **The composer has to be told.** The originating tab is excluded from its own `message:created` echo (`excludeSocketId`), so its optimistic row is the only thing it sees until a refetch — one combined bubble there would be the only thing the sender ever saw, and it is not what was sent. `SentMessage.splitMessages` reports the parts back and `use-chat-send` renders one bubble each.

## The Graph call

`sendAttachment` posts the bytes as multipart `filedata` rather than handing Meta a presigned S3 URL, so private storage stays private and Meta never has to reach our object store. `is_reusable: false` — these are one-shot support replies, not marketing assets. `sendAttachmentTypeForMimeType` picks the word Meta **renders** by: a JPEG sent as `file` arrives as a download link rather than a photo.

The 24-hour window policy is unchanged and applies identically — an attachment outside the window is as unsolicited as a sentence.

## Known gap, deliberate

`prepareAttachments` validates against the generic email size limit, not the provider's (`maxAttachmentSize` is 10MB on Messenger, 8MB on Instagram). An oversized photo is refused by Graph with "Attachment size exceeds allowable limit" and surfaces as a toast, rather than being caught before the upload.

## Tests

10 for the split (shape, field ownership, whitespace-only text, and that every part is itself unsplittable so the recursion is one level deep), 6 for the Graph call (multipart field names read back off a stubbed `fetch`, the `Content-Type` that must stay unset so the boundary matches, tag handling, error surfacing). `vitest run src/messages src/providers` → 427 passed.

## Not verified live

Every test stubs `fetch`. **Send a photo from the composer on each platform** — that is the whole test, and it also settles whether an IG attachment send is addressed on the Page id (the same unverified choice WS4 flagged for text).