### PR TITLE
feat(connections): reseed platform providers without a release

### DIFF
--- a/apps/web/src/components/config/config-view.tsx
+++ b/apps/web/src/components/config/config-view.tsx
@@ -20,8 +20,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@auxx/ui/components/select'
+import { toastError } from '@auxx/ui/components/toast'
 import { Search, X } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
+import { useConfirm } from '~/hooks/use-confirm'
 import { useDockedPanels } from '~/hooks/use-docked-panels'
 import { api } from '~/trpc/react'
 import { ConfigDrawer } from './config-drawer'
@@ -35,6 +37,8 @@ import { ConfigTable } from './ui/config-table'
 export function ConfigView() {
   const { data: groups, isLoading } = api.configVariable.getGrouped.useQuery()
   const { data: status } = api.configVariable.getStatus.useQuery()
+
+  const [confirm, ConfirmDialog] = useConfirm()
 
   /** Filter state from store */
   const search = useConfigStore((state) => state.search)
@@ -61,6 +65,32 @@ export function ConfigView() {
 
   const isDbEnabled = status?.isDbEnabled ?? false
 
+  /**
+   * Re-bake the platform `ConnectionDefinition` rows from the current config.
+   *
+   * Lives on THIS page because this is where someone stands after rotating a
+   * platform OAuth client: the rows bake an encrypted copy of the client id and
+   * secret at seed time, so changing the value — here or in the environment — is
+   * inert until something re-runs the seed. Before this button that something was
+   * a one-line data migration and a full release.
+   */
+  const reseedProviders = api.admin.reseedConnectionProviders.useMutation({
+    onError: (error) => toastError({ title: 'Reseed failed to start', description: error.message }),
+  })
+
+  const handleReseedProviders = async () => {
+    const confirmed = await confirm({
+      title: 'Reseed connection providers?',
+      description:
+        'Re-writes the built-in connection definitions from the deployed catalog and the ' +
+        'current config, including the encrypted platform OAuth client id and secret. ' +
+        'Idempotent — existing connections keep working.',
+      confirmText: 'Reseed',
+      cancelText: 'Cancel',
+    })
+    if (confirmed) reseedProviders.mutate()
+  }
+
   const { dockedPanels, overlays } = useDockedPanels([
     {
       key: 'config-detail',
@@ -78,8 +108,19 @@ export function ConfigView() {
 
   return (
     <>
+      <ConfirmDialog />
       <MainPage>
-        <MainPageHeader>
+        <MainPageHeader
+          action={
+            <Button
+              variant='outline'
+              size='sm'
+              loading={reseedProviders.isPending}
+              loadingText='Reseeding...'
+              onClick={handleReseedProviders}>
+              Reseed connection providers
+            </Button>
+          }>
           <MainPageBreadcrumb>
             <MainPageBreadcrumbItem title='Admin' href='/admin' />
             <MainPageBreadcrumbItem title='Config' />

--- a/apps/web/src/server/api/routers/admin.ts
+++ b/apps/web/src/server/api/routers/admin.ts
@@ -1639,6 +1639,32 @@ export const adminRouter = createTRPCRouter({
   }),
 
   /**
+   * Re-bake the platform `ConnectionDefinition` rows from the deployed catalog and
+   * the worker's current config — the no-deploy path for rotating a platform OAuth
+   * client.
+   *
+   * Enqueued rather than run inline, deliberately: the client id/secret are read
+   * from the resolving process's config, and the worker is where these have always
+   * been applied (`dataMigrationsJob`). Running it here would bake whatever the web
+   * service's env happens to hold.
+   */
+  reseedConnectionProviders: superAdminProcedure.mutation(async ({ ctx }) => {
+    const { enqueueReseedConnectionProviders } = await import('@auxx/lib/jobs')
+    await enqueueReseedConnectionProviders()
+    await recordAuditFromCtx(ctx, {
+      organizationId: null,
+      category: 'settings',
+      action: 'org.migrations_run',
+      actorType: 'admin',
+      visibility: 'internal',
+      targetType: 'Organization',
+      targetId: null,
+      metadata: { scope: 'all', trigger: 'reseed-connection-providers' },
+    })
+    return { success: true }
+  }),
+
+  /**
    * Clear a failed migration's ledger row and re-enqueue a run. Migrations after it
    * run too once it succeeds (fail-stop is lifted).
    */

--- a/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
@@ -35,6 +35,7 @@ import {
   reconcileRecordIdentitiesJob,
   recordUsageEventJob,
   recurringVisitsJob,
+  reseedConnectionProvidersJob,
   sendGettingStartedEmailsJob,
   sendMidTrialEmailsJob,
   sendTrialConversionEmailsJob,
@@ -215,6 +216,11 @@ export const jobMappings = {
 
   // Data migrations runner (enqueued at boot + from the superadmin panel)
   dataMigrationsJob,
+
+  // Platform connection-provider reseed (superadmin panel only). Re-bakes the
+  // ConnectionDefinition rows from the deployed catalog + this process's config,
+  // so rotating a platform OAuth client is a button, not a release.
+  reseedConnectionProvidersJob,
 
   // RecordIdentity drift backstop (daily; rebuilds the index from
   // FieldValue ⋈ CustomField(isIdentity) for any un-instrumented writer)

--- a/packages/credentials/src/config/config-service.ts
+++ b/packages/credentials/src/config/config-service.ts
@@ -386,6 +386,20 @@ export class ConfigService {
   }
 
   /** Refresh the cache from DB. */
+  /**
+   * Re-read every DB override into this process's cache, now.
+   *
+   * The cache otherwise refreshes on a 5-minute timer, which is fine for reads but
+   * not for a job that must act on a value an admin JUST wrote from another
+   * process — the connection-provider reseed bakes the platform OAuth client into
+   * a row, and baking the previous secret would look like it worked. No-op when DB
+   * overrides are disabled, where `get()` reads `process.env` at call time anyway.
+   */
+  async refresh(): Promise<void> {
+    if (!this.isDbEnabled) return
+    await this.refreshCache()
+  }
+
   private async refreshCache(): Promise<void> {
     try {
       const storage = await this.getStorage()

--- a/packages/lib/src/connections/__tests__/ensure-platform-providers.test.ts
+++ b/packages/lib/src/connections/__tests__/ensure-platform-providers.test.ts
@@ -1,0 +1,135 @@
+// packages/lib/src/connections/__tests__/ensure-platform-providers.test.ts
+//
+// `ensurePlatformProviders` is now reachable from a superadmin button, which makes it
+// an operational tool rather than a seed step — and an operational tool that cannot be
+// audited is worse than no tool. Two properties matter, and both are about what the run
+// LEAVES BEHIND rather than what it writes:
+//
+//   1. `updatedAt` moves. The column has no `$onUpdate`, so unless the upsert stamps it
+//      the row carries no evidence a reseed ever happened, and "did my new client secret
+//      land?" has no answer in the database.
+//   2. A provider that declares a system client but resolved no config is REPORTED. The
+//      cred columns are deliberately left untouched rather than nulled, so a missing or
+//      misspelled config key looks exactly like a successful no-op.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  logInfo: vi.fn(),
+  selected: [] as Array<{ id: string }>,
+  updates: [] as Array<Record<string, unknown>>,
+  inserts: [] as Array<Record<string, unknown>>,
+}))
+
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({
+    info: mocks.logInfo,
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+// Encryption is not what this suite is about, and a real `encryptValue` needs a key.
+vi.mock('@auxx/credentials/crypto', () => ({
+  encryptValue: (value: string) => `enc(${value})`,
+}))
+
+function fakeDb() {
+  return {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: async () => mocks.selected }) }),
+    }),
+    update: () => ({
+      set: (values: Record<string, unknown>) => {
+        mocks.updates.push(values)
+        return { where: async () => undefined }
+      },
+    }),
+    insert: () => ({
+      values: async (values: Record<string, unknown>) => {
+        mocks.inserts.push(values)
+      },
+    }),
+  } as never
+}
+
+/** The summary the run logged, i.e. what an operator actually sees. */
+function summary(): { credentialed: string[]; skippedMissingConfig: string[] } {
+  const call = mocks.logInfo.mock.calls.find(
+    ([message]) => message === 'Ensured platform connection providers'
+  )
+  return call?.[1] as { credentialed: string[]; skippedMissingConfig: string[] }
+}
+
+const ORIGINAL_ENV = { ...process.env }
+
+beforeEach(() => {
+  mocks.logInfo.mockClear()
+  mocks.selected = [{ id: 'def_existing' }]
+  mocks.updates = []
+  mocks.inserts = []
+})
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV }
+  vi.resetModules()
+})
+
+describe('ensurePlatformProviders', () => {
+  it('stamps updatedAt on every row, so a reseed is visible in the database', async () => {
+    const { ensurePlatformProviders } = await import('../providers/ensure-platform-providers')
+    const before = Date.now()
+
+    await ensurePlatformProviders(fakeDb())
+
+    expect(mocks.updates.length).toBeGreaterThan(0)
+    for (const values of mocks.updates) {
+      expect(values.updatedAt).toBeInstanceOf(Date)
+      expect((values.updatedAt as Date).getTime()).toBeGreaterThanOrEqual(before)
+    }
+  })
+
+  it('reports a provider whose system client config is missing instead of failing quietly', async () => {
+    process.env.FACEBOOK_APP_ID = ''
+    process.env.FACEBOOK_APP_SECRET = ''
+    const { ensurePlatformProviders } = await import('../providers/ensure-platform-providers')
+
+    await ensurePlatformProviders(fakeDb())
+
+    // Reported, not written: the columns are left alone so a partial env cannot null a
+    // live credential — which is exactly why the operator has to be told.
+    expect(summary().skippedMissingConfig).toContain('facebook')
+    expect(summary().credentialed).not.toContain('facebook')
+    const facebookWrite = mocks.updates.find((v) => v.providerKey === 'facebook')
+    expect(facebookWrite).toBeDefined()
+    expect(facebookWrite?.oauth2ClientId).toBeUndefined()
+    expect(facebookWrite?.oauth2ClientSecret).toBeUndefined()
+  })
+
+  it('reports — and encrypts — a provider whose client config resolved', async () => {
+    process.env.FACEBOOK_APP_ID = 'app-id'
+    process.env.FACEBOOK_APP_SECRET = 'app-secret'
+    const { ensurePlatformProviders } = await import('../providers/ensure-platform-providers')
+
+    await ensurePlatformProviders(fakeDb())
+
+    expect(summary().credentialed).toEqual(expect.arrayContaining(['facebook', 'instagram']))
+    const facebookWrite = mocks.updates.find((v) => v.providerKey === 'facebook')
+    expect(facebookWrite?.oauth2ClientId).toBe('enc(app-id)')
+    expect(facebookWrite?.oauth2ClientSecret).toBe('enc(app-secret)')
+  })
+
+  it('never lists a provider that has no system client at all', async () => {
+    const { ensurePlatformProviders } = await import('../providers/ensure-platform-providers')
+
+    await ensurePlatformProviders(fakeDb())
+
+    // `openaiApi` and friends take the user's own key at connect time; they have no
+    // platform client to bake, so neither bucket should mention them.
+    const { credentialed, skippedMissingConfig } = summary()
+    expect([...credentialed, ...skippedMissingConfig]).not.toContain('openaiApi')
+    expect([...credentialed, ...skippedMissingConfig]).not.toContain('smtp')
+  })
+})

--- a/packages/lib/src/connections/providers/ensure-platform-providers.ts
+++ b/packages/lib/src/connections/providers/ensure-platform-providers.ts
@@ -4,6 +4,7 @@
 // Platform OAuth client id/secret are read from env and ENCRYPTED into the row
 // (§9.3), so the runtime path is uniform with app/mcp definitions (no env branch).
 
+import { configService } from '@auxx/credentials'
 import { encryptValue } from '@auxx/credentials/crypto'
 import { type Database, database as defaultDb, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
@@ -17,19 +18,28 @@ const PLATFORM_MAJOR = 1
 
 /**
  * Build the ConnectionDefinition column values for a provider def. OAuth client
- * id/secret are pulled from their named env vars and encrypted; when the env var
- * is unset the column is left `undefined` so existing values are not clobbered.
+ * id/secret are pulled from their named config keys and encrypted; when the key
+ * resolves to nothing the column is left `undefined` so existing values are not
+ * clobbered.
+ *
+ * Read through `configService`, not `process.env` directly: it resolves a DB
+ * override first and falls back to `process.env`, so with
+ * `IS_CONFIG_VARIABLES_IN_DB_ENABLED` on, rotating a platform OAuth client is an
+ * edit in the admin config panel plus a reseed — no environment change, no
+ * restart, no release. With the flag off this is exactly the previous behaviour.
  */
 function toRowValues(def: PlatformProviderDef): Record<string, unknown> {
-  const clientId = def.systemClientIdEnv ? process.env[def.systemClientIdEnv] : undefined
-  const clientSecret = def.systemClientSecretEnv
-    ? process.env[def.systemClientSecretEnv]
+  const clientId = def.systemClientIdEnv
+    ? configService.get<string>(def.systemClientIdEnv)
     : undefined
-  // Approval gate (§3.1): the platform client is usable unless its env flag is an
+  const clientSecret = def.systemClientSecretEnv
+    ? configService.get<string>(def.systemClientSecretEnv)
+    : undefined
+  // Approval gate (§3.1): the platform client is usable unless its flag is an
   // explicit 'false'. Unset → true (ops continuity), so providers without the flag
   // keep working with their platform client.
   const platformClientApproved = def.systemClientApprovedEnv
-    ? process.env[def.systemClientApprovedEnv] !== 'false'
+    ? configService.get<string>(def.systemClientApprovedEnv) !== 'false'
     : true
 
   return {
@@ -49,7 +59,13 @@ function toRowValues(def: PlatformProviderDef): Record<string, unknown> {
     connectionVariables: def.connectionVariables ?? [],
     authApply: def.authApply ?? null,
     baseUrlTemplate: def.baseUrlTemplate ?? null,
-    // Only write client creds when the env var is set (avoid clobbering on re-upsert).
+    // Stamped explicitly because the column has no `$onUpdate`. Without it a reseed
+    // leaves no trace in the row at all, and the one question this operation exists
+    // to answer — "did my new client secret actually land?" — has no answer in the
+    // database. The log line below says WHICH providers got creds; this says when.
+    updatedAt: new Date(),
+    // Only write client creds when config resolves a value (avoid clobbering on
+    // re-upsert from a process whose env carries only some of them).
     ...(clientId ? { oauth2ClientId: encryptValue(clientId) } : {}),
     ...(clientSecret ? { oauth2ClientSecret: encryptValue(clientSecret) } : {}),
   }
@@ -61,6 +77,11 @@ function toRowValues(def: PlatformProviderDef): Record<string, unknown> {
  * Credential.connectionDefinitionId FKs survive re-seeds.
  */
 export async function ensurePlatformProviders(db: Database = defaultDb): Promise<void> {
+  /** Providers whose system client id AND secret both resolved this run. */
+  const credentialed: string[] = []
+  /** Providers that declare a system client but whose config carried no value. */
+  const skipped: string[] = []
+
   for (const def of PLATFORM_PROVIDER_DEFS) {
     const existing = await db
       .select({ id: schema.ConnectionDefinition.id })
@@ -74,6 +95,17 @@ export async function ensurePlatformProviders(db: Database = defaultDb): Promise
       .limit(1)
 
     const values = toRowValues(def)
+
+    // A def that declares a system client but resolved no value is the silent
+    // failure mode of this whole operation: the columns are deliberately left
+    // untouched rather than nulled, so the run reports success while the row keeps
+    // the PREVIOUS secret. Naming those providers is what makes a missing or
+    // misspelled config key visible instead of looking like a no-op success.
+    if (def.systemClientIdEnv || def.systemClientSecretEnv) {
+      ;(values.oauth2ClientId && values.oauth2ClientSecret ? credentialed : skipped).push(
+        def.providerKey
+      )
+    }
 
     if (existing.length > 0) {
       await db
@@ -89,7 +121,13 @@ export async function ensurePlatformProviders(db: Database = defaultDb): Promise
     }
   }
 
-  logger.info('Ensured platform connection providers', { count: PLATFORM_PROVIDER_DEFS.length })
+  logger.info('Ensured platform connection providers', {
+    count: PLATFORM_PROVIDER_DEFS.length,
+    credentialed,
+    // Non-empty here means those providers kept whatever secret was baked before —
+    // check the config keys named by their `systemClientIdEnv`/`systemClientSecretEnv`.
+    skippedMissingConfig: skipped,
+  })
 }
 
 /** Convenience predicate: is this a platform built-in provider key? */

--- a/packages/lib/src/data-migrations/migrations/092-reseed-platform-providers-meta-global.ts
+++ b/packages/lib/src/data-migrations/migrations/092-reseed-platform-providers-meta-global.ts
@@ -1,0 +1,69 @@
+// packages/lib/src/data-migrations/migrations/092-reseed-platform-providers-meta-global.ts
+
+import { type Database, sql } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { ensurePlatformProviders } from '../../connections/providers'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-092')
+
+/**
+ * Apply #1721's `global: true` flip on the `facebook` / `instagram` connection
+ * definitions, and re-scope the credentials the old flag produced.
+ *
+ * **This is the deploy step that fails silently.** `PLATFORM_PROVIDER_DEFS` is a
+ * code catalog that is only ever read at seed time — `ensurePlatformProviders`
+ * bakes the row, including `global` and the scope list, into
+ * `ConnectionDefinition`. Editing defs.ts and deploying changes nothing at all:
+ * every environment keeps serving whatever was baked the last time a reseed ran,
+ * with no error anywhere to say so. Same reason 025, 038 and 089 exist.
+ *
+ * What the flip fixes, from the FB/IG plan's WS8: with `global: false` the OAuth
+ * callback mints a **USER-scoped** credential (`userId: personal ? userId :
+ * global ? null : userId`), the connections list then derives `scope: 'user'`,
+ * and `buildConnectionVerify`'s matcher — which requires `r.scope === a.scope` —
+ * can never match the `organization` connect the dialog believes it ran. The
+ * dialog spins on "Connecting…" for a connect that already succeeded.
+ *
+ * **The second half is not optional, and it is the dangerous one.**
+ * `resolve-connection-for-runtime.ts` does `scopedUserId = def.global ? null :
+ * userId` and `findCredential` maps `userId: null` to `userId IS NULL`, so a
+ * credential written under the old flag **stops resolving the moment the
+ * definition flips** — the channel goes dead with no error. Any environment
+ * holding an FB/IG credential needs both halves or it is worse off than before.
+ *
+ * `metadata.personal` rows are left alone: a personal connect is legitimately
+ * user-scoped, and `personal` is evaluated before `global` on every path. No
+ * FB/IG credential should carry it today (personal connects are gated to
+ * email-like channels), which is exactly why it costs nothing to honour.
+ *
+ * Idempotent: the reseed SELECTs by `(providerKey, major)` and UPDATEs in place
+ * so row ids — and the `Credential.connectionDefinitionId` FKs pointing at them
+ * — survive; the credential update matches only rows still carrying a `userId`.
+ */
+export const migration092ReseedPlatformProvidersMetaGlobal: DataMigrationDef = {
+  id: '092-reseed-platform-providers-meta-global',
+  description:
+    'Reseed platform connection providers (Meta global flag) and re-scope FB/IG credentials',
+  async run(db: Database): Promise<void> {
+    await ensurePlatformProviders(db)
+
+    // Org-scoped is what `global: true` means, and what the runtime now looks for.
+    // `createdById` is deliberately untouched — it is the audit trail of who
+    // connected the page, and it is not what scopes the credential.
+    const rescoped = await db.execute<{ id: string }>(sql`
+      UPDATE "Credential" AS c
+         SET "userId" = NULL
+        FROM "ConnectionDefinition" AS d
+       WHERE c."connectionDefinitionId" = d."id"
+         AND d."providerKey" IN ('facebook', 'instagram')
+         AND c."userId" IS NOT NULL
+         AND COALESCE(c."metadata" ->> 'personal', 'false') <> 'true'
+      RETURNING c."id"
+    `)
+
+    logger.info('Reseeded Meta connection definitions', {
+      credentialsRescoped: rescoped.rows?.length ?? 0,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -56,6 +56,7 @@ import { migration088PhoneGeoBackfill } from './migrations/088-phone-geo-backfil
 import { migration089ReseedPlatformProvidersAuthApply } from './migrations/089-reseed-platform-providers-auth-apply'
 import { migration090ThreadEventsExtraction } from './migrations/090-thread-events-extraction'
 import { migration091BackfillParticipantDisplayName } from './migrations/091-backfill-participant-display-name'
+import { migration092ReseedPlatformProvidersMetaGlobal } from './migrations/092-reseed-platform-providers-meta-global'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -138,6 +139,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration089ReseedPlatformProvidersAuthApply,
     migration090ThreadEventsExtraction,
     migration091BackfillParticipantDisplayName,
+    migration092ReseedPlatformProvidersMetaGlobal,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/jobs/index.ts
+++ b/packages/lib/src/jobs/index.ts
@@ -210,6 +210,10 @@ export {
 } from './maintenance/reconcile-record-identities-job'
 // Dispatch recurring engine daily sweep (M2c)
 export { recurringVisitsJob } from './maintenance/recurring-visits-job'
+export {
+  enqueueReseedConnectionProviders,
+  reseedConnectionProvidersJob,
+} from './maintenance/reseed-connection-providers-job'
 // Client-notifications sequence enrollment hourly sweep (plan 19 §4.3, decision #13)
 export { sequenceEnrollmentSweepJob } from './maintenance/sequence-enrollment-sweep-job'
 export {

--- a/packages/lib/src/jobs/maintenance/reseed-connection-providers-job.ts
+++ b/packages/lib/src/jobs/maintenance/reseed-connection-providers-job.ts
@@ -1,0 +1,74 @@
+// packages/lib/src/jobs/maintenance/reseed-connection-providers-job.ts
+
+import { configService } from '@auxx/credentials'
+import { database as db } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { ensurePlatformProviders } from '../../connections/providers'
+import type { JobContext } from '../types/job-context'
+
+const logger = createScopedLogger('reseed-connection-providers-job')
+
+/** Fixed jobId so repeat clicks coalesce while one run is queued/active. */
+const RESEED_JOB_ID = 'reseed-connection-providers'
+
+/**
+ * Re-upsert the platform built-in `ConnectionDefinition` rows from the deployed
+ * catalog + the current config.
+ *
+ * **This exists so rotating a platform OAuth client is not a release.** The rows
+ * bake an ENCRYPTED copy of the client id/secret at seed time (`§9.3` — it keeps
+ * the runtime resolution path uniform with app/mcp definitions, with no env
+ * branch), and the only writers were the seed CLI, a local script, and a
+ * one-line data migration. So the emergency path for a compromised app secret
+ * was "author migration NNN, open a PR, wait for a full deploy" — half an hour,
+ * to re-run an idempotent function that takes milliseconds.
+ *
+ * Runs **on the worker** deliberately: the values come from that process's
+ * resolved config, and the worker is the process that has always applied these
+ * (via `dataMigrationsJob`). Running it from the web request would bake whatever
+ * the web service's env happens to hold.
+ *
+ * Scope, and what it does NOT cover: this re-bakes what the DEPLOYED catalog
+ * says. A change to `defs.ts` itself — new scopes, a `global` flip, new
+ * connection variables — is code and still ships with a release; this button
+ * then applies it without also needing a migration id. Only the config-sourced
+ * client id/secret can change with no deploy at all.
+ *
+ * Idempotent: `ensurePlatformProviders` SELECTs by `(providerKey, major)` and
+ * UPDATEs in place, so row ids — and every `Credential.connectionDefinitionId`
+ * FK pointing at them — survive. Safe to run at any time.
+ */
+export async function reseedConnectionProvidersJob(ctx: JobContext): Promise<{ reseeded: true }> {
+  logger.info('Reseeding platform connection providers', { jobId: ctx.jobId })
+  // The admin wrote the new value in the WEB process; this cache lives in the
+  // worker and otherwise refreshes on a 5-minute timer. Without this the job
+  // cheerfully re-bakes the previous secret and reports success.
+  await configService.refresh()
+  await ensurePlatformProviders(db)
+  logger.info('Reseeded platform connection providers', { jobId: ctx.jobId })
+  return { reseeded: true }
+}
+
+/**
+ * Enqueue a reseed on the maintenance queue. `attempts: 1` — a failure is worth
+ * looking at rather than retrying blindly against the same config.
+ */
+export async function enqueueReseedConnectionProviders(): Promise<void> {
+  const { getQueue } = await import('../queues')
+  const { Queues } = await import('../queues/types')
+  const queue = getQueue(Queues.maintenanceQueue)
+
+  await queue.add(
+    'reseedConnectionProvidersJob',
+    {},
+    {
+      jobId: RESEED_JOB_ID,
+      attempts: 1,
+      removeOnComplete: true,
+      removeOnFail: true,
+      priority: 5,
+    }
+  )
+
+  logger.info('Enqueued connection-provider reseed')
+}


### PR DESCRIPTION
Rotating a platform OAuth client meant authoring a one-line data migration, opening a PR and waiting for a full deploy — close to **half an hour to re-run an idempotent function that takes milliseconds**.

The migration was never really a migration. It was the only way to *call* `ensurePlatformProviders` in production: `025`, `038` and `089` all exist for that reason alone.

## The button

A superadmin **Reseed connection providers** action on `/admin/config` (top-right, next to the breadcrumb — that's where you're standing after rotating a secret) enqueues a maintenance job.

It runs **on the worker deliberately**: the client id/secret come from the resolving process's config, so running it from the web request would bake whatever the *web* service's env happens to hold — a different variable set.

## Reading resolved config, not raw env

`ensure-platform-providers` reached into `process.env` directly, bypassing the config system entirely. Through `configService` it resolves a DB override first and falls back to env:

- with `IS_CONFIG_VARIABLES_IN_DB_ENABLED` **off** (production today) this is byte-identical to before;
- with it **on**, rotating a client becomes an edit in the config panel plus a reseed — no environment change, no restart, no release.

## Three things this exposed, all fixed

- **A staleness bug that would have silently defeated the whole feature.** The admin writes the value in the *web* process; the config cache lives in the *worker* and refreshes on a 5-minute timer. Pressing Reseed immediately would re-bake the **previous** secret and report success. `ConfigService.refresh()` is now public and the job calls it first.
- **`ConnectionDefinition.updatedAt` has no `$onUpdate`** and the upsert never set it, so a reseed left no trace in the row at all — the one question this operation exists to answer ("did my new secret land?") had no answer in the database. Now stamped. This is also why the timestamps looked 56 days old right after a successful run.
- **A missing config key looked exactly like a successful no-op.** A provider that declares a system client but resolves no value has its cred columns left *untouched* rather than nulled — correct, since a partial env must never null a live credential, but invisible. The run now names both buckets:

```
Ensured platform connection providers {
  count: 34,
  credentialed: [googleOAuth2Api, outlookOAuth2Api, gmail, outlookMail, facebook, instagram, DROPBOX],
  skippedMissingConfig: [shopifyOAuth2Api, GOOGLE_DRIVE, ONEDRIVE, BOX]
}
```

## Scope

Platform defs only (owner = `providerKey`). App-contributed and MCP connection definitions have their own ensure paths and are untouched; no `Credential` row is modified by the button. Row ids stay stable — SELECT by `(providerKey, major)`, UPDATE in place — so every `Credential.connectionDefinitionId` FK survives and existing connections keep working.

A change to `defs.ts` itself (scopes, `global`, connection variables) is code and still ships with a release; it just no longer *also* needs a migration id.

## Also: data migration 092

Applies #1721's `global: true` flip on the `facebook`/`instagram` definitions and re-scopes the credentials the old flag produced (`userId → NULL`, non-personal only).

Both halves are needed together: `resolve-connection-for-runtime.ts:364` maps `def.global` to `userId IS NULL`, so a credential written under the old flag **stops resolving the moment the definition flips** — a dead channel with no error. It ships as a migration rather than as button-work so it lands on deploy instead of waiting for someone to remember.

## Verified

End to end locally: button → tRPC → BullMQ → worker → reseed, confirmed in the logs

```
[@auxx/web]    Enqueued connection-provider reseed
[@auxx/worker] Reseeding platform connection providers
[@auxx/worker] Ensured platform connection providers
[@auxx/worker] Reseeded platform connection providers
```

with `updatedAt` moving on the rows afterwards. 4 new tests cover the `updatedAt` stamp, both reporting buckets, and that credential-less providers appear in neither.