### PR TITLE
fix(channels): drop placeholder attachment links, and purge business_management

### DIFF
--- a/docs/setup-facebook.md
+++ b/docs/setup-facebook.md
@@ -56,25 +56,34 @@ npx dotenv -- npx tsx packages/lib/scripts/reseed-platform-providers.ts
 
 ## 3. OAuth redirect URI
 
-The callback is keyed on the **ConnectionDefinition id**, not the provider name:
+The callback is keyed on the **provider name**, and the URLs are static:
 
 ```
-{BASE}/api/connections/{connectionDefinitionId}/oauth2/callback
+{BASE}/api/connections/facebook/oauth2/callback
+{BASE}/api/connections/instagram/oauth2/callback
 ```
 
-**That id is a cuid, and it differs per environment** — dev and production have separate
-seeded rows. There is no static URL to copy. Read the ids for your environment:
+The route segment accepts *either* the ConnectionDefinition cuid or the `providerKey`
+(`or(eq(cd.id, defParam), eq(cd.providerKey, defParam))`), and the channel connect flow
+passes the **`providerKey`** (`channel.ts` → `authorizeUrl`). The callback route then
+echoes that same segment back into `redirect_uri`, so what Meta receives is the
+provider-named form above — never a cuid. Nothing here differs per environment except
+`{BASE}`.
 
-```sql
-SELECT id, "providerKey" FROM "ConnectionDefinition"
-WHERE "providerKey" IN ('facebook', 'instagram');
-```
+Register all four URLs (dev + production × facebook + instagram) under **Facebook Login
+for Business → Settings → Valid OAuth Redirect URIs**.
 
-Register **both** resulting URLs under **Facebook Login → Settings → Valid OAuth Redirect
-URIs**.
+> ⚠️ **Strict Mode is on, so these must match byte for byte.** On 2026-08-18 the
+> production Facebook entry was whitelisted as `.../facebook/oauth2/` — missing the
+> trailing `callback` — and every production Facebook connect failed with *"the redirect
+> URI is not whitelisted in the app's Client OAuth Settings."* The Instagram entry beside
+> it was correct, which is why it looked like a Facebook credential problem rather than a
+> typo. Paste these, do not retype them, and use the dashboard's **Redirect URI Validator**
+> to confirm before assuming the app config is at fault.
 
 In dev, `{BASE}` is `NGROK_URL` when set, otherwise `WEBAPP_URL` — the tunnel host, not
-`localhost:3000`, because Meta will not redirect to a private address.
+`localhost:3000`, because Meta will not redirect to a private address. In production
+`NGROK_URL` is unset, so `{BASE}` is `WEBAPP_URL` (`https://app.auxx.ai`).
 
 ## 4. Webhooks
 
@@ -104,12 +113,23 @@ shows "The URL couldn't be validated".
 Requested by the connect flow (`connections/providers/defs.ts`):
 
 - **Facebook:** `pages_messaging`, `pages_manage_metadata`, `pages_read_engagement`,
-  `pages_show_list`, `business_management`
-- **Instagram:** the same five, plus `instagram_basic` and `instagram_manage_messages`
+  `pages_show_list`
+- **Instagram:** the same four, plus `instagram_basic` and `instagram_manage_messages`
 
-`business_management` is not optional: without it, Pages owned by a Business portfolio
-are simply absent from `/me/accounts` at connect time, and the connect fails with
-"No Facebook Pages found" on an account that plainly has Pages.
+**`business_management` is NOT requested, and messaging does not need it.** This file
+previously stated the opposite as fact — that Pages owned by a Business portfolio are
+absent from `/me/accounts` without it — on a claim that was never tested. It was removed
+from `defs.ts` on 2026-08-18 and a full Instagram round trip then ran on a token carrying
+only the scopes above: inbound webhook stored, outbound send delivered, and
+`GET /{pageId}/conversations?platform=instagram` returned the conversation. Meta's own
+use-case page lists `business_management` under "Send messages on Instagram" — **that
+listing is wrong, or at least not enforced.** Do not re-add it on the strength of that
+page alone; it was the riskiest line in the App Review submission, because Meta defines it
+as managing business assets *on behalf of other businesses*, which is not what we do.
+
+The narrower **discovery** claim — whether a Business-portfolio-owned Page is missing from
+`/me/accounts` without the scope — is a different question and is still untested. It does
+not gate the submission. See `plans/channels/meta-app-review-submission.md` §1.
 
 In **Development** mode these work immediately for people holding a role on the app
 (admin, developer, tester) against Pages they administer — no App Review. External users
@@ -134,6 +154,7 @@ first eligible Page, so grant only the Page you want, or steer it there.
 | Symptom | Cause |
 | --- | --- |
 | "App not active" on connect | Env changed without re-seeding — see §2. |
+| "The redirect URI is not whitelisted in the app's Client OAuth Settings" | The exact URL is missing from **Valid OAuth Redirect URIs**, and Strict Mode requires a byte-for-byte match. Almost never a bad app id or secret — check §3 and run the dashboard's Redirect URI Validator first. One provider failing while the other works is the tell. |
 | Webhook validation fails | Verify token mismatch, or `{BASE}` not publicly reachable. |
 | Connected, but no messages arrive | The Page subscription did not arm. Check `GET /{pageId}/subscribed_apps`. Reconnecting through the OAuth popup re-arms it; so does channel recovery. |
 | Instagram connects but stays silent | "Allow access to messages" is off, the IG account is not professional, or the app needs to be Live. |

--- a/packages/lib/src/messages/message-sender.service.ts
+++ b/packages/lib/src/messages/message-sender.service.ts
@@ -4,7 +4,7 @@ import { IntegrationProviderType, ParticipantRole, SendStatus } from '@auxx/data
 import type { ParticipantRole as ParticipantRoleType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
-import { and, asc, desc, eq, sql } from 'drizzle-orm'
+import { and, asc, desc, eq, inArray, like, or, sql } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
 import { getComposerCapabilities, identifierTypeForProvider } from '../channels/capabilities'
 import {
@@ -555,6 +555,7 @@ export class MessageSenderService {
       // Step 10: Convert temp attachments to permanent after successful send
       if (input.attachmentIds && input.attachmentIds.length > 0 && sendResult.success) {
         await this.convertAttachmentsToPermanent(input.attachmentIds)
+        await this.discardTempAttachmentLinks(input.attachmentIds)
       }
       // Step 11: Return result, carrying the resolved participants so the
       // client can render the optimistic row with correct from/to immediately.
@@ -1452,6 +1453,53 @@ export class MessageSenderService {
       }
     }
   }
+  /**
+   * Drops the composer's placeholder `Attachment` links once the real ones exist.
+   *
+   * The composer uploads before a draft exists, so `MessageAttachmentProcessor`
+   * keys the link row to a synthetic `temp-message-<ts>-<rand>` entity id
+   * (`files/upload/processors/entity-processors.ts`). The send then writes a
+   * second link row against the real message id — and nothing ever removed the
+   * first, so every attachment send left a row pointing at a message that does
+   * not exist. Seven had accumulated in dev between 2026-03 and 2026-08, one per
+   * attachment ever sent.
+   *
+   * Deleting is right rather than re-parenting: the real row is already written
+   * with the correct `sort`/`role`, so re-parenting would produce a duplicate
+   * attachment on the message instead of a dangling one beside it.
+   *
+   * Matching on the `temp-message-` prefix is what makes this safe — a row bound
+   * to a real message can never match, so a send that reuses an asset another
+   * message also carries cannot lose that message's link.
+   *
+   * Best-effort: a failure here must never fail a send that already went out.
+   */
+  private async discardTempAttachmentLinks(ids: string[]): Promise<void> {
+    if (ids.length === 0) return
+    try {
+      const deleted = await (this.db ?? db)
+        .delete(schema.Attachment)
+        .where(
+          and(
+            eq(schema.Attachment.organizationId, this.organizationId),
+            like(schema.Attachment.entityId, 'temp-message-%'),
+            // `inArray`, never a raw `IN ${ids}` — a bare array in a Drizzle
+            // template binds as ONE parameter and silently matches nothing.
+            or(inArray(schema.Attachment.assetId, ids), inArray(schema.Attachment.fileId, ids))
+          )
+        )
+        .returning({ id: schema.Attachment.id })
+      if (deleted.length > 0) {
+        logger.info('Discarded placeholder attachment links after send', {
+          count: deleted.length,
+          organizationId: this.organizationId,
+        })
+      }
+    } catch (error) {
+      logger.error('Failed to discard placeholder attachment links', { error, ids })
+    }
+  }
+
   /**
    * Retries sending a failed message
    * - Validates the message exists and is in failed state

--- a/packages/workflow-nodes/src/credentials/facebook-oauth2.credentials.ts
+++ b/packages/workflow-nodes/src/credentials/facebook-oauth2.credentials.ts
@@ -37,14 +37,24 @@ export class FacebookOAuth2Api implements ICredentialType {
     systemClientIdEnv: 'FACEBOOK_CLIENT_ID',
     systemClientSecretEnv: 'FACEBOOK_CLIENT_SECRET',
 
-    // Facebook Graph API scopes
+    // Facebook Graph API scopes.
+    //
+    // `business_management` was dropped 2026-08-18: messaging provably does not need it
+    // (see docs/setup-facebook.md §5), and it is the riskiest line in the App Review
+    // submission — Meta defines it as managing business assets on behalf of OTHER
+    // businesses, which is not what we do. Keep it out of every scope list on this app,
+    // including dead ones, so a reviewer never sees the app request it.
+    //
+    // NOTE: this whole credential type is inert. It keys on `FACEBOOK_CLIENT_ID` /
+    // `FACEBOOK_CLIENT_SECRET`, which exist in no env file, and points at Graph v18.0.
+    // The live Facebook/Instagram CHANNEL defs are in
+    // `packages/lib/src/connections/providers/defs.ts` — edit those, not this.
     scopes: [
       'pages_manage_metadata', // Manage page metadata
       'pages_read_engagement', // Read page engagement
       'pages_manage_posts', // Manage page posts
       'pages_messaging', // Send/receive messages
       'pages_show_list', // Access to pages list
-      'business_management', // Business management
     ],
 
     // Facebook-specific OAuth parameters


### PR DESCRIPTION
Two independent fixes, both surfaced while live-verifying the Meta channels today.

---

## 1. Placeholder attachment links were never cleaned up

Every attachment send — on **every** channel, not just Meta — left behind an `Attachment` row pointing at a message that does not exist.

```
7 rows, entityType MESSAGE, entityId 'temp-message-…', 2026-03-12 → 2026-08-18
   → none of those ids is a real Message. One per attachment ever sent.
```

The composer uploads before a draft exists, so `MessageAttachmentProcessor` keys the link row to a synthetic `temp-message-<ts>-<rand>` entity id (`files/upload/processors/entity-processors.ts:423`). The send then writes a **second** link row against the real message id — and nothing ever removed the first.

Two things could have caught it and neither did:

- `convertAttachmentsToPermanent` only flips `MediaAsset.kind`; it never touched the link rows.
- `scheduleCleanup` (`entity-processors.ts:462`) is a log statement with a *"would integrate with your job queue system"* comment, so nothing collected them either.

### The fix

`MessageSenderService.discardTempAttachmentLinks`, called from Step 10 beside `convertAttachmentsToPermanent`.

**Delete rather than re-parent.** The real row is already written with the correct `sort`/`role`, so re-parenting would give the message a *duplicate* attachment instead of a dangling one beside it.

**The `temp-message-` prefix match is what makes it safe.** A row bound to a real message can never match, so a send that reuses an asset another message also carries cannot strip that message's link.

**`inArray`, not a raw `IN ${ids}`** — a bare array in a Drizzle template binds as one parameter and silently matches nothing.

**Best-effort and try-caught.** This runs after the message has already gone out; it must never fail a completed send.

### How it was verified

The predicate was run as a `SELECT` against the real rows before being trusted:

| Row | `entityId` | Matches? |
|---|---|---|
| `g5xgrw0qirfs14o4mu1wwwh0` | `temp-message-1787090033905-ewpecrhwr` | ✅ deleted (orphan) |
| `zx4sm35aidf3umwwu2josmt5` | `nilnkkvv8ptbc95dzqqyd328` | ❌ untouched (real link, same asset) |

---

## 2. `business_management` is gone from every scope list

Completes the removal that landed in `defs.ts` — this strips it from the `packages/workflow-nodes` Facebook credential and from the docs, so no scope list on this app requests it and a reviewer never sees the app ask for it.

`docs/setup-facebook.md` had asserted the opposite **as fact** — that Pages owned by a Business portfolio are absent from `/me/accounts` without it — on a claim that was never tested. A full Instagram round trip then ran on a token carrying only the reduced scopes:

- inbound webhook stored
- outbound send delivered
- `GET /{pageId}/conversations?platform=instagram` returned the conversation

Meta's own use-case page lists `business_management` under *"Send messages on Instagram"*. **That listing is wrong, or at least not enforced** — the doc now says so, so nobody re-adds it on the strength of that page. It was the riskiest line in the App Review submission, because Meta defines the permission as managing business assets *on behalf of other businesses*, which is not what we do.

The narrower **discovery** claim — whether a Business-portfolio-owned Page is missing from `/me/accounts` without the scope — is a different question, still untested, and does not gate the submission.

### Also in the doc

**§3 was wrong about the OAuth callback.** It described the URL as keyed on a per-environment `ConnectionDefinition` cuid with no static form to copy. The route accepts either the cuid or the `providerKey`, and the connect flow passes the `providerKey`, so the URLs are static and identical across environments apart from `{BASE}`.

That mattered: a production Facebook connect had been failing because the whitelisted URI was missing its trailing `callback` segment, and Strict Mode requires a byte-for-byte match. Now recorded in Troubleshooting — one provider failing while the other works is the tell, and it reads as a credential problem when it is a typo.

The workflow-nodes credential is **inert** — it keys on `FACEBOOK_CLIENT_ID` / `FACEBOOK_CLIENT_SECRET`, which exist in no env file, and points at Graph v18.0. Noted in place so the next reader edits `defs.ts` instead of it.

---

## Checks

- 85 tests in `packages/lib/src/messages/__tests__/` pass
- Biome clean; `tsc --noEmit` clean on the touched files

## Not in this PR

The **7 existing orphan rows** are not cleaned up — this stops new ones, it does not backfill. They are inert (nothing joins on a non-existent message id) but they keep their `MediaAsset` referenced, so a future asset GC would skip them. Worth a small data migration if we ever add that GC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)