### PR TITLE
feat(billing): add stripe account cutover data migration

### DIFF
--- a/packages/lib/src/data-migrations/migrations/094-stripe-account-cutover.int.test.ts
+++ b/packages/lib/src/data-migrations/migrations/094-stripe-account-cutover.int.test.ts
@@ -1,0 +1,473 @@
+// packages/lib/src/data-migrations/migrations/094-stripe-account-cutover.int.test.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createTestOrganization, getTestDb } from '@auxx/test-utils'
+import { eq } from 'drizzle-orm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { migration094StripeAccountCutover as migration } from './094-stripe-account-cutover'
+
+/**
+ * The cutover against a real Postgres. Everything load-bearing about this migration is a
+ * *row selection* decision — which subscriptions are in scope, which of those get closed
+ * out — and three of the four carve-outs (`isFree` via LEFT JOIN, the `planId IS NULL`
+ * name fallback, `billingProvider IS NULL` meaning "stripe") are only expressible against
+ * real SQL. A mocked `db` would pin the shape of the calls, not the outcome.
+ *
+ * `getOrgCache` is the one thing stubbed: it wants Redis, and the assertion we actually
+ * care about is *which orgs* get invalidated with *which keys*.
+ */
+
+const { invalidateAndRecompute } = vi.hoisted(() => ({ invalidateAndRecompute: vi.fn() }))
+
+vi.mock('../../cache', async (importOriginal) => {
+  // Partial mock — replacing the barrel wholesale breaks collection for anything else
+  // that reaches into it.
+  const actual = await importOriginal<typeof import('../../cache')>()
+  return { ...actual, getOrgCache: () => ({ invalidateAndRecompute }) }
+})
+
+/** The legacy account's id shape, so a surviving pointer is obvious in a failure diff. */
+const LEGACY = {
+  product: 'prod_legacy_T8Cu1',
+  priceMonthly: 'price_legacy_monthly',
+  priceAnnual: 'price_legacy_annual',
+  customer: 'cus_legacy_T8Cu1',
+  subscription: 'sub_legacy_T8Cu1',
+}
+
+type PlanRow = typeof schema.Plan.$inferSelect
+type SubRow = typeof schema.PlanSubscription.$inferSelect
+
+describe('migration 094 — Stripe account cutover', () => {
+  let db: Database
+
+  beforeEach(() => {
+    db = getTestDb() as unknown as Database
+    invalidateAndRecompute.mockReset().mockResolvedValue(undefined)
+  })
+
+  /** A plan carrying legacy Stripe pointers unless the caller says otherwise. */
+  const createPlan = async (
+    overrides: Partial<typeof schema.Plan.$inferInsert> = {}
+  ): Promise<PlanRow> => {
+    const [plan] = await db
+      .insert(schema.Plan)
+      .values({
+        name: 'Starter',
+        monthlyPrice: 2900,
+        annualPrice: 29000,
+        isFree: false,
+        stripeProductId: LEGACY.product,
+        stripePriceIdMonthly: LEGACY.priceMonthly,
+        stripePriceIdAnnual: LEGACY.priceAnnual,
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+        ...overrides,
+      })
+      .returning()
+    return plan as PlanRow
+  }
+
+  /**
+   * One subscription per org — `PlanSubscription_organizationId_key` is unique — so every
+   * fixture row mints its own organization and hands the id back for the cache assertions.
+   */
+  const createSub = async (
+    overrides: Partial<typeof schema.PlanSubscription.$inferInsert> = {}
+  ): Promise<SubRow> => {
+    const organizationId = (await createTestOrganization()).id
+    const [sub] = await db
+      .insert(schema.PlanSubscription)
+      .values({
+        organizationId,
+        plan: 'starter',
+        billingProvider: 'stripe',
+        status: 'trialing',
+        seats: 3,
+        creditsBalance: 4_200,
+        stripeCustomerId: LEGACY.customer,
+        stripeSubscriptionId: LEGACY.subscription,
+        trialStart: new Date('2026-02-01T00:00:00.000Z'),
+        trialEnd: new Date('2026-02-15T00:00:00.000Z'),
+        updatedAt: new Date('2026-02-01T00:00:00.000Z'),
+        ...overrides,
+      })
+      .returning()
+    return sub as SubRow
+  }
+
+  const readSub = async (id: string): Promise<SubRow> => {
+    const [row] = await db
+      .select()
+      .from(schema.PlanSubscription)
+      .where(eq(schema.PlanSubscription.id, id))
+    return row as SubRow
+  }
+
+  const readPlan = async (id: string): Promise<PlanRow> => {
+    const [row] = await db.select().from(schema.Plan).where(eq(schema.Plan.id, id))
+    return row as PlanRow
+  }
+
+  /** The org ids handed to the cache, deduped, in no particular order. */
+  const invalidatedOrgs = (): string[] =>
+    invalidateAndRecompute.mock.calls.map((call) => call[0] as string).sort()
+
+  // ── Plan pointers ───────────────────────────────────────────────────────────
+
+  describe('Plan pointers', () => {
+    it('nulls product and price ids on every plan, free and paid alike', async () => {
+      const paid = await createPlan({ name: 'Growth' })
+      const free = await createPlan({ name: 'Free', isFree: true, monthlyPrice: 0, annualPrice: 0 })
+
+      await migration.run(db)
+
+      for (const id of [paid.id, free.id]) {
+        const row = await readPlan(id)
+        expect(row.stripeProductId).toBeNull()
+        expect(row.stripePriceIdMonthly).toBeNull()
+        expect(row.stripePriceIdAnnual).toBeNull()
+      }
+    })
+
+    it('preserves everything about a plan except its Stripe pointers', async () => {
+      const plan = await createPlan({ name: 'Growth', monthlyPrice: 9900, hierarchyLevel: 3 })
+
+      await migration.run(db)
+
+      const row = await readPlan(plan.id)
+      expect(row.name).toBe('Growth')
+      expect(row.monthlyPrice).toBe(9900)
+      expect(row.hierarchyLevel).toBe(3)
+      expect(row.isFree).toBe(false)
+    })
+
+    it('leaves a plan that never carried Stripe ids untouched', async () => {
+      // Enterprise/custom-pricing plans are never synced, so the WHERE must not
+      // rewrite (and re-stamp `updatedAt` on) rows with nothing to clear.
+      const clean = await createPlan({
+        name: 'Enterprise',
+        isCustomPricing: true,
+        stripeProductId: null,
+        stripePriceIdMonthly: null,
+        stripePriceIdAnnual: null,
+      })
+
+      await migration.run(db)
+
+      expect(await readPlan(clean.id)).toEqual(clean)
+    })
+  })
+
+  // ── Scope: which subscriptions are in play at all ───────────────────────────
+
+  describe('scope', () => {
+    it('unlinks a stripe row while preserving its entitlement', async () => {
+      const plan = await createPlan()
+      const sub = await createSub({ planId: plan.id, status: 'active' })
+
+      await migration.run(db)
+
+      const row = await readSub(sub.id)
+      expect(row.stripeCustomerId).toBeNull()
+      expect(row.stripeSubscriptionId).toBeNull()
+      // Entitlement is ours, not Stripe's — none of this may move.
+      expect(row.planId).toBe(plan.id)
+      expect(row.plan).toBe('starter')
+      expect(row.seats).toBe(3)
+      expect(row.creditsBalance).toBe(4_200)
+      expect(row.billingCycle).toBe(sub.billingCycle)
+      expect(row.trialStart).toEqual(sub.trialStart)
+      expect(row.trialEnd).toEqual(sub.trialEnd)
+    })
+
+    it('treats a NULL billingProvider as stripe', async () => {
+      // null means "unlinked"; the provider registry resolves it to Stripe, so the
+      // pointers it carries are legacy-account pointers like any other.
+      const plan = await createPlan()
+      const sub = await createSub({ planId: plan.id, billingProvider: null })
+
+      await migration.run(db)
+
+      const row = await readSub(sub.id)
+      expect(row.stripeCustomerId).toBeNull()
+      expect(row.stripeSubscriptionId).toBeNull()
+      expect(row.status).toBe('canceled')
+    })
+
+    it('never touches a shopify row, even one carrying stray stripe ids', async () => {
+      // The seeder can leave `stripe*` ids on Shopify rows, which is exactly why the
+      // scope is `billingProvider`-explicit instead of inferred from populated columns.
+      const plan = await createPlan()
+      const sub = await createSub({
+        planId: plan.id,
+        billingProvider: 'shopify',
+        shopifyShopDomain: 'acme.myshopify.com',
+        status: 'trialing',
+      })
+
+      await migration.run(db)
+
+      expect(await readSub(sub.id)).toEqual(sub)
+      expect(invalidatedOrgs()).not.toContain(sub.organizationId)
+    })
+
+    it('ignores a stripe row that carries no pointers at all', async () => {
+      const plan = await createPlan()
+      const sub = await createSub({
+        planId: plan.id,
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+      })
+
+      await migration.run(db)
+
+      expect(await readSub(sub.id)).toEqual(sub)
+      expect(invalidatedOrgs()).not.toContain(sub.organizationId)
+    })
+
+    it('is in scope when only one of the two pointers is set', async () => {
+      const plan = await createPlan()
+      const customerOnly = await createSub({ planId: plan.id, stripeSubscriptionId: null })
+      const subscriptionOnly = await createSub({ planId: plan.id, stripeCustomerId: null })
+
+      await migration.run(db)
+
+      expect((await readSub(customerOnly.id)).stripeCustomerId).toBeNull()
+      expect((await readSub(subscriptionOnly.id)).stripeSubscriptionId).toBeNull()
+      expect((await readSub(customerOnly.id)).status).toBe('canceled')
+      expect((await readSub(subscriptionOnly.id)).status).toBe('canceled')
+    })
+  })
+
+  // ── Termination: which of the in-scope rows get closed out ──────────────────
+
+  describe('termination', () => {
+    it.each([
+      'trialing',
+      'past_due',
+      'incomplete',
+    ] as const)('closes out a paid %s row', async (status) => {
+      const plan = await createPlan()
+      const sub = await createSub({ planId: plan.id, status, cancelAtPeriodEnd: true })
+
+      await migration.run(db)
+
+      const row = await readSub(sub.id)
+      expect(row.status).toBe('canceled')
+      expect(row.canceledAt).toBeInstanceOf(Date)
+      expect(row.endDate).toBeInstanceOf(Date)
+      expect(row.cancelAtPeriodEnd).toBe(false)
+      // The three trial/cleanup jobs use `stripeSubscriptionId IS NULL` as their
+      // "no subscription" proxy; both email jobs additionally gate on
+      // `hasTrialEnded = false`, so this flag is what actually silences them.
+      expect(row.hasTrialEnded).toBe(true)
+    })
+
+    it('nulls every scheduled* field on a row it closes out', async () => {
+      const plan = await createPlan()
+      const scheduledPlan = await createPlan({ name: 'Growth' })
+      const sub = await createSub({
+        planId: plan.id,
+        status: 'past_due',
+        scheduledPlanId: scheduledPlan.id,
+        scheduledPlan: 'growth',
+        scheduledBillingCycle: 'ANNUAL',
+        scheduledSeats: 12,
+        scheduledChangeAt: new Date('2026-03-01T00:00:00.000Z'),
+      })
+
+      await migration.run(db)
+
+      const row = await readSub(sub.id)
+      expect(row.scheduledPlanId).toBeNull()
+      expect(row.scheduledPlan).toBeNull()
+      expect(row.scheduledBillingCycle).toBeNull()
+      expect(row.scheduledSeats).toBeNull()
+      expect(row.scheduledChangeAt).toBeNull()
+    })
+
+    it('leaves trialConversionStatus alone rather than arming the deletion pipeline', async () => {
+      // `expired-trial-account-cleanup-job` deletes the org 14 days after it sees
+      // EXPIRED_WITHOUT_CONVERSION / CANCELED_DURING_TRIAL. A pointer cleanup must not
+      // schedule org deletions.
+      const plan = await createPlan()
+      const untouched = await createSub({ planId: plan.id, status: 'trialing' })
+      const preexisting = await createSub({
+        planId: plan.id,
+        status: 'trialing',
+        trialConversionStatus: 'CONVERTED_TO_PAID',
+      })
+
+      await migration.run(db)
+
+      expect((await readSub(untouched.id)).trialConversionStatus).toBeNull()
+      expect((await readSub(preexisting.id)).trialConversionStatus).toBe('CONVERTED_TO_PAID')
+    })
+
+    it('leaves an active paid row unlinked but NOT canceled', async () => {
+      // There should be none — the legacy account never took a payment — but silently
+      // downgrading a payer is worse than leaving a row for a human.
+      const plan = await createPlan()
+      const sub = await createSub({ planId: plan.id, status: 'active' })
+
+      await migration.run(db)
+
+      const row = await readSub(sub.id)
+      expect(row.status).toBe('active')
+      expect(row.canceledAt).toBeNull()
+      expect(row.endDate).toBeNull()
+      expect(row.hasTrialEnded).toBe(false)
+      expect(row.stripeSubscriptionId).toBeNull()
+    })
+
+    it.each([
+      'unpaid',
+      'incomplete_expired',
+      'canceled',
+    ] as const)('leaves a %s row unlinked but NOT canceled — only three statuses terminate', async (status) => {
+      const plan = await createPlan()
+      const sub = await createSub({ planId: plan.id, status })
+
+      await migration.run(db)
+
+      const row = await readSub(sub.id)
+      expect(row.status).toBe(status)
+      expect(row.canceledAt).toBeNull()
+      expect(row.stripeCustomerId).toBeNull()
+    })
+
+    it('leaves a free-plan row unlinked but NOT canceled — read through the LEFT JOIN', async () => {
+      const free = await createPlan({ name: 'Free', isFree: true, monthlyPrice: 0, annualPrice: 0 })
+      // Deliberately named something the FREE_PLAN_NAMES fallback would NOT catch, so
+      // this can only pass by reading `Plan.isFree` off the join.
+      const sub = await createSub({ planId: free.id, plan: 'starter', status: 'trialing' })
+
+      await migration.run(db)
+
+      const row = await readSub(sub.id)
+      expect(row.status).toBe('trialing')
+      expect(row.canceledAt).toBeNull()
+      expect(row.hasTrialEnded).toBe(false)
+      expect(row.stripeCustomerId).toBeNull()
+      expect(row.stripeSubscriptionId).toBeNull()
+    })
+
+    it.each([
+      'free',
+      'FREE',
+      'demo',
+    ])('falls back to the plan name %s when planId is null', async (planName) => {
+      const sub = await createSub({ planId: null, plan: planName, status: 'trialing' })
+
+      await migration.run(db)
+
+      const row = await readSub(sub.id)
+      expect(row.status).toBe('trialing')
+      expect(row.canceledAt).toBeNull()
+      expect(row.stripeCustomerId).toBeNull()
+    })
+
+    it('still closes out a planId-less row whose name is not a free-plan name', async () => {
+      // The fallback must not swallow every orphaned row — only free/demo.
+      const sub = await createSub({ planId: null, plan: 'starter', status: 'trialing' })
+
+      await migration.run(db)
+
+      expect((await readSub(sub.id)).status).toBe('canceled')
+    })
+
+    it('leaves an adminOverrideAt row unlinked but NOT canceled', async () => {
+      // A super admin owns this row's lifecycle; no reconciler may write status.
+      const plan = await createPlan()
+      const sub = await createSub({
+        planId: plan.id,
+        status: 'trialing',
+        adminOverrideAt: new Date('2026-01-15T00:00:00.000Z'),
+        adminOverrideReason: 'comped',
+      })
+
+      await migration.run(db)
+
+      const row = await readSub(sub.id)
+      expect(row.status).toBe('trialing')
+      expect(row.canceledAt).toBeNull()
+      expect(row.hasTrialEnded).toBe(false)
+      expect(row.adminOverrideAt).toEqual(sub.adminOverrideAt)
+      expect(row.stripeCustomerId).toBeNull()
+      expect(row.stripeSubscriptionId).toBeNull()
+    })
+  })
+
+  // ── Cache ───────────────────────────────────────────────────────────────────
+
+  describe('org cache', () => {
+    it('invalidates subscription+features once per affected org', async () => {
+      const plan = await createPlan()
+      const free = await createPlan({ name: 'Free', isFree: true, monthlyPrice: 0, annualPrice: 0 })
+      const terminated = await createSub({ planId: plan.id, status: 'trialing' })
+      const untouched = await createSub({ planId: free.id, status: 'trialing' })
+      const shopify = await createSub({ planId: plan.id, billingProvider: 'shopify' })
+      const unlinkedAlready = await createSub({
+        planId: plan.id,
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+      })
+
+      await migration.run(db)
+
+      // Every org whose pointers moved — including the free row that was only
+      // unlinked — and nobody else.
+      expect(invalidatedOrgs()).toEqual(
+        [terminated.organizationId, untouched.organizationId].sort()
+      )
+      expect(invalidatedOrgs()).not.toContain(shopify.organizationId)
+      expect(invalidatedOrgs()).not.toContain(unlinkedAlready.organizationId)
+      for (const call of invalidateAndRecompute.mock.calls) {
+        expect(call[1]).toEqual(['subscription', 'features'])
+      }
+    })
+
+    it('invalidates nothing when there is no Stripe-linked subscription', async () => {
+      await createPlan()
+
+      await migration.run(db)
+
+      expect(invalidateAndRecompute).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── Idempotency ─────────────────────────────────────────────────────────────
+
+  describe('idempotency', () => {
+    it('is a clean no-op on a second run', async () => {
+      // The linked set is snapshotted BEFORE the nulling, so after one pass the
+      // predicate matches nothing — no writes, no cache churn.
+      const plan = await createPlan()
+      const free = await createPlan({ name: 'Free', isFree: true, monthlyPrice: 0, annualPrice: 0 })
+      const terminated = await createSub({ planId: plan.id, status: 'trialing' })
+      const unlinkedOnly = await createSub({ planId: free.id, status: 'trialing' })
+      const shopify = await createSub({ planId: plan.id, billingProvider: 'shopify' })
+
+      await migration.run(db)
+      const after = {
+        plan: await readPlan(plan.id),
+        terminated: await readSub(terminated.id),
+        unlinkedOnly: await readSub(unlinkedOnly.id),
+        shopify: await readSub(shopify.id),
+      }
+      const callsAfterFirst = invalidateAndRecompute.mock.calls.length
+      expect(callsAfterFirst).toBe(2)
+
+      await migration.run(db)
+
+      // `updatedAt` carries `$onUpdate` on PlanSubscription, so an unchanged row here
+      // is proof no UPDATE was issued — not merely that the values matched.
+      expect(await readPlan(plan.id)).toEqual(after.plan)
+      expect(await readSub(terminated.id)).toEqual(after.terminated)
+      expect(await readSub(unlinkedOnly.id)).toEqual(after.unlinkedOnly)
+      expect(await readSub(shopify.id)).toEqual(after.shopify)
+      expect(invalidateAndRecompute.mock.calls).toHaveLength(callsAfterFirst)
+    })
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/094-stripe-account-cutover.test.ts
+++ b/packages/lib/src/data-migrations/migrations/094-stripe-account-cutover.test.ts
@@ -1,0 +1,356 @@
+// packages/lib/src/data-migrations/migrations/094-stripe-account-cutover.test.ts
+
+import type { Database } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ALL_DATA_MIGRATIONS } from '../registry'
+import { migration094StripeAccountCutover as migration } from './094-stripe-account-cutover'
+
+/**
+ * The four carve-outs from the cancel step are the whole risk surface of this migration —
+ * getting one wrong downgrades a live org. Three of them (`adminOverrideAt`, `Plan.isFree`,
+ * the `planId IS NULL` name fallback) are decided in TypeScript over the snapshot the
+ * migration reads, so they are testable without Postgres by handing `run` a fake `db` that
+ * returns exactly one row and asking whether the cancel UPDATE was issued at all.
+ *
+ * The fourth (Shopify) lives in the SQL `WHERE` and is only pinned here structurally; it is
+ * exercised for real, alongside idempotency and entitlement preservation, in
+ * `094-stripe-account-cutover.int.test.ts`.
+ */
+
+const { invalidateAndRecompute } = vi.hoisted(() => ({ invalidateAndRecompute: vi.fn() }))
+
+vi.mock('../../cache', async (importOriginal) => {
+  // Partial — `registry.ts` pulls in ninety-odd migrations, plenty of which reach into this
+  // barrel for something other than `getOrgCache`. A wholesale replacement dies at collection.
+  const actual = await importOriginal<typeof import('../../cache')>()
+  return { ...actual, getOrgCache: () => ({ invalidateAndRecompute }) }
+})
+
+/** One row of the snapshot the migration takes before it nulls anything. */
+type LinkedRow = {
+  id: string
+  organizationId: string
+  status: string
+  planName: string
+  isFree: boolean | null
+  adminOverrideAt: Date | null
+  hasTrialEnded: boolean
+}
+
+function linkedRow(overrides: Partial<LinkedRow> = {}): LinkedRow {
+  return {
+    id: 'sub_1',
+    organizationId: 'org_1',
+    status: 'trialing',
+    planName: 'starter',
+    isFree: false,
+    adminOverrideAt: null,
+    hasTrialEnded: false,
+    ...overrides,
+  }
+}
+
+/**
+ * Minimal stand-in for the three builder shapes `run` uses: one
+ * `select().from().leftJoin().where()` read, and `update().set().where()` writes (one of
+ * which also calls `.returning()`). Every `set()` payload is captured, which is all the
+ * classification assertions need — with a single row in the snapshot, "a cancel UPDATE was
+ * issued" and "this row was classified as terminate" are the same statement.
+ */
+function fakeDb(rows: LinkedRow[]) {
+  const setPayloads: Record<string, unknown>[] = []
+  let transactions = 0
+
+  const db: Record<string, unknown> = {
+    // Steps 1–4 run inside `db.transaction`, so the fake has to supply one. It hands the
+    // same builder back as the `tx` handle, which is what makes every write below land in
+    // `setPayloads` regardless of whether `run` reaches for `db` or `tx`.
+    transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => {
+      transactions++
+      return cb(db)
+    },
+    select: () => ({
+      from: () => ({
+        leftJoin: () => ({
+          where: () => Promise.resolve(rows),
+        }),
+      }),
+    }),
+    update: () => ({
+      set: (values: Record<string, unknown>) => {
+        setPayloads.push(values)
+        // A real promise with `.returning()` bolted on: the unlink/cancel writes are
+        // awaited directly, the Plan clear goes through `.returning()` first.
+        const awaited = Object.assign(Promise.resolve(undefined), {
+          returning: () => Promise.resolve([]),
+        })
+        return { where: () => awaited }
+      },
+    }),
+  }
+
+  return {
+    db: db as unknown as Database,
+    setPayloads,
+    /** How many times `run` opened a transaction — the unlink and cancel must share one. */
+    transactionCount: () => transactions,
+    /** The cancel write from step 4, if the row was classified as terminate. */
+    cancelWrite: () => setPayloads.find((payload) => payload.status === 'canceled'),
+    /** The step-3 unlink, which every in-scope row gets regardless of classification. */
+    unlinkWrite: () =>
+      setPayloads.find(
+        (payload) => 'stripeCustomerId' in payload && !('stripeProductId' in payload)
+      ),
+  }
+}
+
+describe('migration094StripeAccountCutover', () => {
+  beforeEach(() => {
+    invalidateAndRecompute.mockReset().mockResolvedValue(undefined)
+  })
+
+  describe('registry contract', () => {
+    it('is registered with the id its filename claims', () => {
+      expect(migration.id).toBe('094-stripe-account-cutover')
+    })
+
+    it('is registered exactly once', () => {
+      expect(ALL_DATA_MIGRATIONS.filter((m) => m.id === migration.id)).toHaveLength(1)
+    })
+  })
+
+  describe('atomicity', () => {
+    // The snapshot-before-nulling that makes this migration idempotent also destroys its
+    // recovery path: once the pointers are null, a re-run selects nothing. So an unlink that
+    // committed without its cancel could never be repaired by re-running, and would strand
+    // rows in the exact `trialing` + `hasTrialEnded = false` + no-subscription state the
+    // trial-email and org-deletion jobs act on. One transaction makes that unrepresentable.
+    it('performs every write inside a single transaction', async () => {
+      const harness = fakeDb([linkedRow({ status: 'trialing' })])
+
+      await migration.run(harness.db)
+
+      expect(harness.transactionCount()).toBe(1)
+      // Plan clear, unlink and cancel — all three writes, all inside that one transaction.
+      expect(harness.setPayloads).toHaveLength(3)
+      expect(harness.unlinkWrite()).toBeDefined()
+      expect(harness.cancelWrite()).toBeDefined()
+    })
+  })
+
+  describe('which rows get closed out', () => {
+    it.each(['trialing', 'past_due', 'incomplete'])('cancels a paid %s row', async (status) => {
+      const harness = fakeDb([linkedRow({ status })])
+
+      await migration.run(harness.db)
+
+      expect(harness.cancelWrite()).toBeDefined()
+    })
+
+    it.each([
+      'active',
+      'unpaid',
+      'incomplete_expired',
+      'canceled',
+      'paused',
+    ])('unlinks but does not cancel a %s row', async (status) => {
+      // `active` is the load-bearing one: the legacy account never took a payment, so a
+      // paid active row means the audit was wrong — leave it for a human rather than
+      // silently downgrading someone who might be paying.
+      const harness = fakeDb([linkedRow({ status })])
+
+      await migration.run(harness.db)
+
+      expect(harness.cancelWrite()).toBeUndefined()
+      expect(harness.unlinkWrite()).toBeDefined()
+    })
+
+    it('does not cancel a row whose joined plan is free', async () => {
+      // Entitlement on Free is ours; the org only ever had a $0 subscription because the
+      // seeder mints Stripe products for free plans. Named `starter` on purpose, so this
+      // can only pass by reading `Plan.isFree` off the LEFT JOIN.
+      const harness = fakeDb([linkedRow({ isFree: true, planName: 'starter' })])
+
+      await migration.run(harness.db)
+
+      expect(harness.cancelWrite()).toBeUndefined()
+      expect(harness.unlinkWrite()).toBeDefined()
+    })
+
+    it.each([
+      'free',
+      'Free',
+      'DEMO',
+      'demo',
+    ])('falls back to the plan name %s when the join produced no isFree', async (planName) => {
+      const harness = fakeDb([linkedRow({ isFree: null, planName })])
+
+      await migration.run(harness.db)
+
+      expect(harness.cancelWrite()).toBeUndefined()
+    })
+
+    it('still cancels an unjoined row whose plan name is not a free-plan name', async () => {
+      // The fallback must not swallow every orphaned row — only free/demo.
+      const harness = fakeDb([linkedRow({ isFree: null, planName: 'growth' })])
+
+      await migration.run(harness.db)
+
+      expect(harness.cancelWrite()).toBeDefined()
+    })
+
+    it('lets a joined isFree=false override a free-sounding plan name', async () => {
+      // `??` means the join wins whenever it produced a value; the name is a fallback,
+      // not a veto.
+      const harness = fakeDb([linkedRow({ isFree: false, planName: 'free' })])
+
+      await migration.run(harness.db)
+
+      expect(harness.cancelWrite()).toBeDefined()
+    })
+
+    it('does not cancel a row under admin override', async () => {
+      // A super admin owns that row's lifecycle — the same rule `subscription-updated.ts`
+      // enforces against the Stripe webhook.
+      const harness = fakeDb([linkedRow({ adminOverrideAt: new Date('2026-01-15') })])
+
+      await migration.run(harness.db)
+
+      expect(harness.cancelWrite()).toBeUndefined()
+      expect(harness.unlinkWrite()).toBeDefined()
+    })
+  })
+
+  describe('what the cancel write sets', () => {
+    it('closes the row out and clears every dangling schedule', async () => {
+      const harness = fakeDb([linkedRow({ status: 'trialing' })])
+
+      await migration.run(harness.db)
+
+      const cancel = harness.cancelWrite()
+      expect(cancel).toMatchObject({
+        status: 'canceled',
+        cancelAtPeriodEnd: false,
+        // trial-conversion-job and mid-trial-job both gate on `hasTrialEnded = false`;
+        // unlinking alone would make every legacy trial row newly eligible and fire real
+        // emails at the bot addresses that created them.
+        hasTrialEnded: true,
+        scheduledPlanId: null,
+        scheduledPlan: null,
+        scheduledBillingCycle: null,
+        scheduledSeats: null,
+        scheduledChangeAt: null,
+      })
+      expect(cancel?.canceledAt).toBeInstanceOf(Date)
+      expect(cancel?.endDate).toBeInstanceOf(Date)
+    })
+
+    it('leaves trialConversionStatus alone', async () => {
+      // `expired-trial-account-cleanup-job` matches EXPIRED_WITHOUT_CONVERSION /
+      // CANCELED_DURING_TRIAL and deletes the org 14 days later. Writing either value here
+      // would arm org deletion as a side effect of a pointer cleanup.
+      const harness = fakeDb([linkedRow({ status: 'trialing' })])
+
+      await migration.run(harness.db)
+
+      expect(harness.cancelWrite()).not.toHaveProperty('trialConversionStatus')
+    })
+
+    it('never writes entitlement on the unlink', async () => {
+      const harness = fakeDb([linkedRow({ status: 'active' })])
+
+      await migration.run(harness.db)
+
+      expect(harness.unlinkWrite()).toEqual({ stripeCustomerId: null, stripeSubscriptionId: null })
+    })
+  })
+
+  describe('plan pointers', () => {
+    it('nulls all three Stripe columns on Plan', async () => {
+      const harness = fakeDb([])
+
+      await migration.run(harness.db)
+
+      expect(harness.setPayloads[0]).toMatchObject({
+        stripeProductId: null,
+        stripePriceIdMonthly: null,
+        stripePriceIdAnnual: null,
+      })
+    })
+
+    it('clears plans even when no subscription is linked', async () => {
+      const harness = fakeDb([])
+
+      await migration.run(harness.db)
+
+      expect(harness.setPayloads).toHaveLength(1)
+      expect(invalidateAndRecompute).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('org cache', () => {
+    it('recomputes subscription and features once per distinct affected org', async () => {
+      const harness = fakeDb([
+        linkedRow({ id: 'sub_1', organizationId: 'org_a' }),
+        linkedRow({ id: 'sub_2', organizationId: 'org_a' }),
+        linkedRow({ id: 'sub_3', organizationId: 'org_b', status: 'active' }),
+      ])
+
+      await migration.run(harness.db)
+
+      expect(invalidateAndRecompute.mock.calls).toEqual([
+        ['org_a', ['subscription', 'features']],
+        ['org_b', ['subscription', 'features']],
+      ])
+    })
+
+    it('invalidates the org of a row it only unlinked, not just the ones it canceled', async () => {
+      // `CachedSubscription` carries `stripeCustomerId`/`stripeSubscriptionId` verbatim, so
+      // an unlink alone already makes the cached blob wrong.
+      const harness = fakeDb([linkedRow({ organizationId: 'org_free', isFree: true })])
+
+      await migration.run(harness.db)
+
+      expect(harness.cancelWrite()).toBeUndefined()
+      expect(invalidateAndRecompute).toHaveBeenCalledWith('org_free', ['subscription', 'features'])
+    })
+  })
+
+  describe('scope, pinned structurally', () => {
+    const source = migration.run.toString()
+
+    /**
+     * Shopify rows have their own lifecycle (`shopify-billing-sync-job`,
+     * `shopify-seat-usage-job`) and the seeder can leave stray `stripe*` ids on them, which
+     * is why the scope is `billingProvider`-explicit rather than inferred from which columns
+     * happen to be populated. Widening the WHERE to "has stripe ids" would sweep them in.
+     * Exercised for real in the int test.
+     */
+    it('selects on billingProvider rather than on which columns are populated', () => {
+      expect(source).toContain('billingProvider')
+      expect(source).toContain("'stripe'")
+      expect(source).not.toContain('shopify')
+    })
+
+    /** null billingProvider means "unlinked", which the provider registry resolves to Stripe. */
+    it('counts a NULL billingProvider as in scope', () => {
+      // Loose on the call shape — Vite rewrites bare imports to
+      // `(0,__vite_ssr_import_2__.isNull)(…)` before `toString()` ever sees them.
+      expect(source).toMatch(/isNull\)?\([^)]*PlanSubscription\.billingProvider/)
+    })
+
+    /**
+     * Idempotency rests entirely on this ordering: the linked set is read BEFORE the
+     * columns are nulled, so a re-run's predicate matches nothing. Reading after would make
+     * the second pass a no-op by accident and the first pass wrong.
+     */
+    it('snapshots the linked set before nulling anything', () => {
+      const read = source.indexOf('.select(')
+      const planUpdate = source.indexOf('schema.Plan)')
+      const unlink = source.indexOf('stripeCustomerId: null')
+      expect(read).toBeGreaterThan(-1)
+      expect(read).toBeLessThan(planUpdate)
+      expect(read).toBeLessThan(unlink)
+    })
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/094-stripe-account-cutover.ts
+++ b/packages/lib/src/data-migrations/migrations/094-stripe-account-cutover.ts
@@ -1,0 +1,261 @@
+// packages/lib/src/data-migrations/migrations/094-stripe-account-cutover.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, inArray, isNotNull, isNull, or } from 'drizzle-orm'
+import { getOrgCache } from '../../cache'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-094')
+
+/** Statuses whose entitlement came from a Stripe subscription that no longer exists. */
+const TERMINATE_STATUSES = ['trialing', 'past_due', 'incomplete'] as const
+
+/** Plan names treated as free when `planId` is null and we cannot read `Plan.isFree`. */
+const FREE_PLAN_NAMES = new Set(['free', 'demo'])
+
+/**
+ * Stripe account cutover (`plans/billing/stripe-account-migration.md` §3c): drop every pointer
+ * into the legacy Stripe account `acct_1T8Cu1RtpSux2lhZ` so the app can be re-pointed at
+ * `acct_1TLVTnDXcNjD5O4X` ("Auxx AI, LLC").
+ *
+ * Product/price/customer/subscription ids are account-scoped — an id minted on the old account
+ * 404s against the new one. Entitlement, though, is ours: which plan an org is on and until when
+ * lives in `PlanSubscription`, not in Stripe. So this nulls the *pointers* and leaves the
+ * *entitlement* alone wherever a human could still be relying on it.
+ *
+ * ## Ordering
+ *
+ * Must run AFTER `STRIPE_SECRET_KEY` points at the new account and BEFORE `syncToStripe`.
+ * `PlanAdminService.syncToStripe` calls `products.update(stripeProductId)` whenever the column is
+ * set, which 404s cross-account; with the column null it takes the create path cleanly. Checkout
+ * throws `PRICE_NOT_CONFIGURED` between this migration and the two `/admin/plans` sync clicks —
+ * that window is expected and is why the runbook keeps those steps back to back.
+ *
+ * ## What this does NOT do
+ *
+ * - **Does not touch Shopify rows.** `billingProvider = 'shopify'` has its own lifecycle
+ *   (`shopify-billing-sync-job`, `shopify-seat-usage-job`) and is unaffected by the Stripe move.
+ *   Seeded Shopify rows can still carry stray `stripe*` ids, so the scope is explicit rather than
+ *   inferred from which columns happen to be populated.
+ * - **Does not cancel free-plan rows.** An org on Free never needed Stripe to hold its
+ *   entitlement; it only ever had a $0 subscription because the seeder mints Stripe products for
+ *   free plans (`billing.domain.ts` excludes custom pricing, not free). Unlinking is the whole
+ *   change for those rows.
+ * - **Does not touch rows under admin override.** A non-null `adminOverrideAt` means a super
+ *   admin owns the row's lifecycle and no reconciler may write status — the same rule
+ *   `subscription-updated.ts` enforces. Comped orgs keep their plan.
+ * - **Does not cancel `active` paid rows.** There should be none (the legacy account has $0 gross
+ *   volume and no successful payment), but silently downgrading a paying customer is far worse
+ *   than leaving a row that needs a human. Any that exist are logged loudly and left alone.
+ *
+ * ## Why `hasTrialEnded` is forced on the rows it terminates
+ *
+ * Three maintenance jobs use `stripeSubscriptionId IS NULL` as their proxy for "has no active
+ * subscription": `trial-conversion-job` (trial ending in ~3 days), `mid-trial-job` (trial started
+ * ~7 days ago) and `expired-trial-account-cleanup-job` (warn at 7d/13d, delete the org at 14d).
+ * Unlinking alone would make every legacy trial row newly eligible and fire real emails at the
+ * bot addresses that created them. Both trial-email jobs additionally require
+ * `hasTrialEnded = false`, so setting it true is what actually stops them.
+ *
+ * `trialConversionStatus` is deliberately left as-is rather than set to `CANCELED_DURING_TRIAL`:
+ * the cleanup job matches `trialConversionStatus IN ('EXPIRED_WITHOUT_CONVERSION',
+ * 'CANCELED_DURING_TRIAL')`, so writing either value would arm the 14-day org-deletion pipeline
+ * on rows this migration just touched. Deleting the dead signups is a deliberate admin action,
+ * not a side effect of a pointer cleanup.
+ *
+ * ## Idempotency
+ *
+ * The linked set is snapshotted BEFORE the nulling, so a re-run selects nothing and no-ops.
+ * That snapshot is also why steps 1–4 must share one transaction: nulling the pointers
+ * destroys the only evidence of which rows still needed closing out, so a partial commit
+ * could never be repaired by re-running. See the note in `run`.
+ *
+ * Raw Drizzle throughout — data migrations do not use the `ensure*` entity helpers.
+ *
+ * ## Environments
+ *
+ * This runs wherever the worker boots, dev included. Dev/staging `Plan` rows lose their test-mode
+ * ids too and need their own `syncToStripe` pass against the new account's test mode before
+ * checkout works there again.
+ */
+export const migration094StripeAccountCutover: DataMigrationDef = {
+  id: '094-stripe-account-cutover',
+  description:
+    'Drop legacy Stripe account pointers from Plan and PlanSubscription (Atlas account cutover)',
+  async run(db: Database): Promise<void> {
+    // Steps 1–4 run in ONE transaction. The snapshot-before-nulling that gives this
+    // migration its idempotency also removes its recovery path: once step 3 nulls the
+    // pointers, a re-run selects nothing. So if step 3 committed and step 4 did not, the
+    // retry would find `linked` empty and never close out the rows that needed terminating —
+    // leaving exactly the `trialing` + `hasTrialEnded = false` + no-subscription state that
+    // makes every legacy trial row eligible for the trial-email and org-deletion jobs. The
+    // runner calls `run(db)` with no transaction of its own (`run-pending-data-migrations.ts`),
+    // so partial application has to be made unrepresentable here.
+    const { linked, activePaid, toTerminate, clearedPlans } = await db.transaction(async (tx) => {
+      // ── 1. Snapshot the Stripe-linked subscriptions BEFORE nulling ──────────────
+      // Reading first is what makes the migration idempotent: after the update the
+      // predicate matches nothing, so a re-run is a clean no-op.
+      const linkedRows = await tx
+        .select({
+          id: schema.PlanSubscription.id,
+          organizationId: schema.PlanSubscription.organizationId,
+          status: schema.PlanSubscription.status,
+          planName: schema.PlanSubscription.plan,
+          isFree: schema.Plan.isFree,
+          adminOverrideAt: schema.PlanSubscription.adminOverrideAt,
+          hasTrialEnded: schema.PlanSubscription.hasTrialEnded,
+        })
+        .from(schema.PlanSubscription)
+        .leftJoin(schema.Plan, eq(schema.Plan.id, schema.PlanSubscription.planId))
+        .where(
+          and(
+            // Stripe rows only. `billingProvider` defaults to 'stripe' and null means
+            // "unlinked", which the provider registry also resolves to Stripe.
+            or(
+              eq(schema.PlanSubscription.billingProvider, 'stripe'),
+              isNull(schema.PlanSubscription.billingProvider)
+            ),
+            or(
+              isNotNull(schema.PlanSubscription.stripeCustomerId),
+              isNotNull(schema.PlanSubscription.stripeSubscriptionId)
+            )
+          )
+        )
+
+      const isFreeRow = (row: (typeof linkedRows)[number]) =>
+        row.isFree ?? FREE_PLAN_NAMES.has(row.planName.toLowerCase())
+
+      // Paid rows still marked `active` should not exist — the legacy account never took a
+      // payment. If one does, the audit behind this migration was wrong: surface it instead of
+      // downgrading someone who might be paying.
+      const activePaid = linkedRows.filter(
+        (r) => r.status === 'active' && !isFreeRow(r) && !r.adminOverrideAt
+      )
+      if (activePaid.length > 0) {
+        logger.warn(
+          'Active paid subscriptions found on the legacy account — unlinked but NOT canceled; these need a human',
+          {
+            count: activePaid.length,
+            subscriptions: activePaid.map((r) => ({
+              id: r.id,
+              organizationId: r.organizationId,
+              plan: r.planName,
+            })),
+          }
+        )
+      }
+
+      // Rows whose entitlement was genuinely backed by a Stripe subscription that is about to
+      // become unreachable, and that nothing else is holding open.
+      const toTerminate = linkedRows.filter(
+        (r) =>
+          !r.adminOverrideAt &&
+          !isFreeRow(r) &&
+          (TERMINATE_STATUSES as readonly string[]).includes(r.status)
+      )
+
+      // ── 2. Null the Plan product/price pointers ─────────────────────────────────
+      // Every plan, including Demo/Free/Enterprise. `syncToStripe` refuses free and
+      // custom-pricing plans, so those three stay null permanently — which is correct. Leaving
+      // their legacy ids in place would point at objects on an account we no longer hold keys
+      // for, and mislead whoever debugs billing next.
+      const clearedPlanRows = await tx
+        .update(schema.Plan)
+        .set({
+          stripeProductId: null,
+          stripePriceIdMonthly: null,
+          stripePriceIdAnnual: null,
+          updatedAt: new Date(),
+        })
+        .where(
+          or(
+            isNotNull(schema.Plan.stripeProductId),
+            isNotNull(schema.Plan.stripePriceIdMonthly),
+            isNotNull(schema.Plan.stripePriceIdAnnual)
+          )
+        )
+        .returning({ id: schema.Plan.id, name: schema.Plan.name })
+
+      // ── 3. Unlink the subscriptions ─────────────────────────────────────────────
+      // Entitlement (planId, status, trial dates, seats, credits) is deliberately preserved.
+      // The next checkout mints a fresh customer: `CustomerService.getOrCreateCustomer` falls
+      // through to an email lookup and then `customers.create`, and
+      // `handleCheckoutSessionCompleted` re-links by OUR subscription id carried in checkout
+      // metadata — so no duplicate row and no unique-constraint fight.
+      if (linkedRows.length > 0) {
+        await tx
+          .update(schema.PlanSubscription)
+          .set({ stripeCustomerId: null, stripeSubscriptionId: null })
+          .where(
+            inArray(
+              schema.PlanSubscription.id,
+              linkedRows.map((r) => r.id)
+            )
+          )
+      }
+
+      // ── 4. Close out the rows whose backing subscription is gone ────────────────
+      if (toTerminate.length > 0) {
+        const now = new Date()
+        await tx
+          .update(schema.PlanSubscription)
+          .set({
+            status: 'canceled',
+            canceledAt: now,
+            endDate: now,
+            cancelAtPeriodEnd: false,
+            // Stops trial-conversion-job and mid-trial-job, both of which gate on
+            // `hasTrialEnded = false`. See the header note on why trialConversionStatus
+            // is left untouched.
+            hasTrialEnded: true,
+            // A dangling schedule would be applied against a subscription that no longer
+            // exists by apply-scheduled-subscription-changes-job.
+            scheduledPlanId: null,
+            scheduledPlan: null,
+            scheduledBillingCycle: null,
+            scheduledSeats: null,
+            scheduledChangeAt: null,
+          })
+          .where(
+            inArray(
+              schema.PlanSubscription.id,
+              toTerminate.map((r) => r.id)
+            )
+          )
+      }
+
+      return {
+        linked: linkedRows,
+        activePaid,
+        toTerminate,
+        clearedPlans: clearedPlanRows,
+      }
+    })
+
+    // ── 5. Recompute the org cache ──────────────────────────────────────────────
+    // Deliberately OUTSIDE the transaction: Redis does not roll back, so priming the cache
+    // from rows that a later abort would undo is worse than a stale key. By here the DB is
+    // committed. A crash mid-loop leaves the remaining orgs serving legacy ids until their
+    // TTL, and a re-run will not repair it (the migration is applied) — flush the org cache
+    // by hand if this step is interrupted.
+    // `CachedSubscription` carries `stripeCustomerId` and `stripeSubscriptionId` verbatim
+    // (cache/providers/subscription-provider.ts), so without this the cache keeps serving
+    // legacy ids after the columns are null. `features` is derived from the plan and moves
+    // with any status change.
+    const affectedOrgs = new Set(linked.map((r) => r.organizationId))
+    for (const orgId of affectedOrgs) {
+      await getOrgCache().invalidateAndRecompute(orgId, ['subscription', 'features'])
+    }
+
+    logger.info('Stripe account cutover complete', {
+      plansCleared: clearedPlans.length,
+      planNames: clearedPlans.map((p) => p.name),
+      subscriptionsUnlinked: linked.length,
+      subscriptionsTerminated: toTerminate.length,
+      activePaidLeftForReview: activePaid.length,
+      orgsInvalidated: affectedOrgs.size,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -58,6 +58,7 @@ import { migration090ThreadEventsExtraction } from './migrations/090-thread-even
 import { migration091BackfillParticipantDisplayName } from './migrations/091-backfill-participant-display-name'
 import { migration092ReseedPlatformProvidersMetaGlobal } from './migrations/092-reseed-platform-providers-meta-global'
 import { migration093BackfillSocialWebhookRouteKey } from './migrations/093-backfill-social-webhook-route-key'
+import { migration094StripeAccountCutover } from './migrations/094-stripe-account-cutover'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -142,6 +143,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration091BackfillParticipantDisplayName,
     migration092ReseedPlatformProvidersMetaGlobal,
     migration093BackfillSocialWebhookRouteKey,
+    migration094StripeAccountCutover,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))


### PR DESCRIPTION
Data migration `094-stripe-account-cutover` for moving production billing off the legacy Stripe account `acct_1T8Cu1RtpSux2lhZ` onto the Atlas account of the operating entity, `acct_1TLVTnDXcNjD5O4X` ("Auxx AI, LLC").

Plan: `plans/billing/stripe-account-migration.md`. Env vars: `plans/billing/stripe-cutover-env-vars.md`.

## What it does

Product, price, customer and subscription ids are account-scoped — an id minted on the old account 404s against the new one. Entitlement, though, is ours: which plan an org is on and until when lives in `PlanSubscription`, not in Stripe. So this nulls the **pointers** and leaves the **entitlement** alone wherever a human could still be relying on it.

1. Nulls `Plan.stripeProductId` / `stripePriceIdMonthly` / `stripePriceIdAnnual` on every plan.
2. Unlinks `PlanSubscription.stripeCustomerId` / `stripeSubscriptionId` where `billingProvider` is `stripe` or null.
3. Closes out the unbacked paid rows (`trialing` / `past_due` / `incomplete`).
4. Recomputes `subscription` + `features` in the org cache per affected org.

## Four carve-outs, each load-bearing

- **Shopify rows are out of scope entirely.** They have their own lifecycle, and seeded rows can carry stray `stripe*` ids — so scope is explicit rather than inferred from which columns happen to be populated. The dev DB has exactly such a row, which is why this is a real case and not a hypothetical.
- **Free-plan rows unlinked, not canceled.** An org on Free never needed Stripe to hold its entitlement; it only ever had a $0 subscription because the seeder mints products for free plans (`billing.domain.ts` excludes custom pricing, not free).
- **`adminOverrideAt` rows unlinked, not canceled.** A super admin owns that row's lifecycle — the same rule `subscription-updated.ts` enforces.
- **`active` paid rows unlinked, not canceled, only logged.** There should be none (the legacy account has $0 gross volume and never took a payment), but silently downgrading a paying customer is far worse than surfacing a row that needs a human.

## Why `hasTrialEnded` is forced on the rows it closes

`trial-conversion-job`, `mid-trial-job` and `expired-trial-account-cleanup-job` all use `stripeSubscriptionId IS NULL` as their proxy for "no active subscription". Unlinking alone would make every legacy trial row newly eligible and fire real emails at the bot addresses that created them; the cleanup job then warns at 7d/13d and deletes the org at 14d. Both trial-email jobs additionally gate on `hasTrialEnded = false`, so setting it true is what actually stops them.

`trialConversionStatus` is deliberately left untouched. The cleanup job matches `IN ('EXPIRED_WITHOUT_CONVERSION','CANCELED_DURING_TRIAL')`, so writing either value would arm the 14-day org-deletion pipeline on rows this migration just touched. Deleting the dead signups is a deliberate admin action, not a side effect of a pointer cleanup.

## One transaction

Steps 1–4 share a `db.transaction`. The snapshot-before-nulling that gives this migration its idempotency also destroys its recovery path: once the pointers are null, a re-run selects nothing. An unlink that committed without its cancel could therefore never be repaired by re-running, stranding rows at `trialing` + `hasTrialEnded = false` + no subscription — exactly the state the trial jobs act on. `run-pending-data-migrations.ts` calls `run(db)` with no transaction of its own, so partial application has to be made unrepresentable here.

The cache loop stays **outside** on purpose: Redis does not roll back, so priming it from rows a later abort would undo is worse than a stale key.

## Tests

29 unit + 26 integration, all passing.

```
cd packages/lib && pnpm exec vitest run src/data-migrations/migrations/094-stripe-account-cutover.test.ts
cd packages/lib && pnpm exec vitest run --config vitest.integration.config.ts src/data-migrations/migrations/094-stripe-account-cutover.int.test.ts
```

Covers all four carve-outs (both the joined `Plan.isFree` path and the `planId = null` name fallback, plus their inverses), the exact cancel payload, entitlement preservation, cache invalidation once per distinct org, idempotency, and that every write shares one transaction.

## Deploy notes

- **Runs itself on worker boot** — `enqueueDataMigrationsRun()` in `apps/worker/src/workers/index.ts`. No manual step; watch `/admin/data-migrations`.
- **Needs no Stripe env at all** — it never calls Stripe. The only hard ordering constraint in the cutover is that `syncToStripe` runs *after* the key swap.
- **Opens a window**: between this landing and the two `/admin/plans` sync clicks, new checkouts fail with a clean `PRICE_NOT_CONFIGURED`. Existing customers are unaffected.
- **Runs in dev too.** Local and staging `Plan` rows lose their test-mode ids and need their own sync pass against the new account's test mode.