### PR TITLE
feat(channels): pick the facebook page at connect time

### DIFF
--- a/apps/web/src/app/(protected)/app/settings/channels/_components/calendar-sync-toggle.tsx
+++ b/apps/web/src/app/(protected)/app/settings/channels/_components/calendar-sync-toggle.tsx
@@ -78,7 +78,7 @@ export function CalendarSyncToggle({ integrationId, disabled }: CalendarSyncTogg
             const integration = status.integrations.find((i) => i.id === integrationId)
             return integration?.calendarSyncEnabled ? true : null
           },
-          onDone: (ok) => {
+          onDone: ({ ok }) => {
             void utils.calendar.getSyncStatus.invalidate()
             if (ok) void utils.channel.list.invalidate()
           },

--- a/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/callback/route.ts
+++ b/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/callback/route.ts
@@ -36,6 +36,13 @@ function renderPopupTerminationPage(payload: {
   ok: boolean
   credId?: string | null
   error?: string | null
+  /**
+   * The connect committed a credential but provisioned nothing — it needs a choice the user can
+   * only make in the app (e.g. which Facebook Page). A latency hint ONLY: the opener re-reads the
+   * authoritative server query on settle either way, because the `verify` poll can win this race
+   * and settle before this page is ever read.
+   */
+  awaiting?: string | null
   originOfOpener: string
 }): NextResponse {
   const message = {
@@ -43,13 +50,16 @@ function renderPopupTerminationPage(payload: {
     ok: payload.ok,
     credId: payload.credId ?? null,
     error: payload.error ?? null,
+    awaiting: payload.awaiting ?? null,
   }
   const serializedMessage = JSON.stringify(message).replace(/</g, '\\u003c')
   const serializedOrigin = JSON.stringify(payload.originOfOpener).replace(/</g, '\\u003c')
-  const heading = payload.ok ? 'Connected' : 'Connection failed'
-  const body = payload.ok
-    ? 'You can close this window.'
-    : `Something went wrong: ${payload.error ?? 'Unknown error'}. You can close this window.`
+  const heading = payload.awaiting ? 'Almost there' : payload.ok ? 'Connected' : 'Connection failed'
+  const body = payload.awaiting
+    ? 'Head back to Auxx to finish setting up this channel. You can close this window.'
+    : payload.ok
+      ? 'You can close this window.'
+      : `Something went wrong: ${payload.error ?? 'Unknown error'}. You can close this window.`
 
   const html = `<!doctype html>
 <html>
@@ -298,8 +308,9 @@ export async function GET(
     // + inbox link + webhook arming here). The credential is already committed, so the hook
     // can resolve a fresh token. A failure surfaces via the shared error redirect below so a
     // half-provisioned channel never looks connected.
+    let awaiting: string | null = null
     if (connDef.providerKey) {
-      await runPostConnectHook(connDef.providerKey, {
+      const hookResult = await runPostConnectHook(connDef.providerKey, {
         credentialId: result.value,
         providerKey: connDef.providerKey,
         organizationId: metadata.organizationId,
@@ -308,12 +319,14 @@ export async function GET(
         ...(metadata.personal && { personal: true }),
         ...(metadata.postConnect && { extra: metadata.postConnect }),
       })
+      awaiting = hookResult?.awaiting?.kind ?? null
     }
 
     if (isPopup) {
       const popupResponse = renderPopupTerminationPage({
         ok: true,
         credId: result.value,
+        awaiting,
         originOfOpener,
       })
       popupResponse.cookies.delete('oauth_return_to')

--- a/apps/web/src/components/apps/hooks/use-connect-flow.tsx
+++ b/apps/web/src/components/apps/hooks/use-connect-flow.tsx
@@ -147,6 +147,15 @@ export interface UseConnectFlowOptions {
   /** Fired when a connect attempt produces a new credId. */
   onConnected?: (credId: string, args: ConnectFlowArgs) => void
   /**
+   * Fired INSTEAD of `onConnected` when the connect committed a credential but provisioned
+   * nothing, because it needs a choice the user makes in the app (e.g. which Facebook Page).
+   * `kind` names the outstanding selection.
+   *
+   * Callers should open the picker rather than treating this as a finished connect — a channel
+   * does not exist yet.
+   */
+  onAwaiting?: (kind: string, credId: string | null, args: ConnectFlowArgs) => void
+  /**
    * Render the editable connection-name row in the field dialog (fresh connects only). The typed
    * name rides through to the save as `payload.name`; reconnect never shows it. Defaults off — the
    * name falls back to `ConnectFlowArgs.name` (seeded via `start`) or the target title.
@@ -176,7 +185,7 @@ function pickDef(args: ConnectFlowArgs): ConnectFlowDefinition | null | undefine
 }
 
 export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectFlow {
-  const { onConnected, mode = 'popup', showName } = options
+  const { onConnected, onAwaiting, mode = 'popup', showName } = options
   const utils = api.useUtils()
 
   // Shared OAuth-popup lifecycle: single-settle via message / server-side verify poll / hard
@@ -289,10 +298,21 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
         fallbackUrl,
         channelName: 'oauth-app-connect',
         verify: a.verify ?? buildConnectionVerify(utils, a),
-        onDone: (ok, credId, matchedExisting) => {
+        onDone: ({ ok, credId, matchedExisting, awaiting }) => {
           invalidateForOwner(owner)
           setArgs(null)
           const resolvedId = credId ?? (ok ? (a.connectionId ?? null) : null)
+          if (ok && awaiting) {
+            // The credential committed but NOTHING was provisioned — the connect needs a choice
+            // (e.g. which Facebook Page). `onConnected` must not fire: the gallery's handler
+            // invalidates and closes, which is wrong while a selection is outstanding.
+            //
+            // `awaiting` here is only a latency hint. The picker self-drives from the server's
+            // pending-selection query, so a settle that LOST the race to the verify poll (and
+            // therefore never saw this flag) still opens the picker — one query later.
+            onAwaiting?.(awaiting, resolvedId, a)
+            return
+          }
           if (ok && resolvedId) {
             setLastConnectedCredId(resolvedId)
             onConnected?.(resolvedId, a)
@@ -305,7 +325,7 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
         },
       })
     },
-    [mode, openPopup, utils, onConnected, invalidateForOwner]
+    [mode, openPopup, utils, onConnected, onAwaiting, invalidateForOwner]
   )
 
   // `hosted-provision` (platform providers only — Account-Links-style onboarding): no dialog, no

--- a/apps/web/src/components/channels/ui/channel-gallery-dialog.tsx
+++ b/apps/web/src/components/channels/ui/channel-gallery-dialog.tsx
@@ -25,6 +25,7 @@ import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { CHANNEL_CATALOG, CHANNEL_CATEGORIES, type ChannelCatalogItem } from '../catalog'
 import { getIntegrationProviderIcon } from './channel-icon'
+import { ConnectSelectionDialog } from './connect-selection-dialog'
 import ImapConnectForm from './imap-connect-form'
 import { InboxDestinationField, useInboxDestination } from './inbox-destination-field'
 import QuoConnectForm from './quo-connect-form'
@@ -114,6 +115,15 @@ export function ChannelGalleryDialog({
       void utils.channel.list.invalidate()
       void utils.inbox.settingsList.invalidate()
       void utils.record.listAll.invalidate()
+      onOpenChange(false)
+    },
+    // The credential committed but NOTHING was provisioned — the connect needs a choice (which
+    // Facebook Page). Close the gallery so the picker is the only thing on screen, and pull the
+    // pending query so it opens without waiting for a refetch interval. Deliberately NOT
+    // `onConnected`: there is no channel yet, and invalidating `channel.list` here would render
+    // a success the user has not earned.
+    onAwaiting: () => {
+      void utils.channel.pendingConnectSelection.invalidate()
       onOpenChange(false)
     },
   })
@@ -505,6 +515,9 @@ export function ChannelGalleryDialog({
         }}
       />
       {flow.Dialogs}
+      {/* Self-drives from `channel.pendingConnectSelection`, so mounting it here covers all
+          three gallery hosts (channels-page, inbox-list, inbox-detail). */}
+      <ConnectSelectionDialog />
     </>
   )
 }

--- a/apps/web/src/components/channels/ui/connect-selection-dialog.tsx
+++ b/apps/web/src/components/channels/ui/connect-selection-dialog.tsx
@@ -1,0 +1,207 @@
+// apps/web/src/components/channels/ui/connect-selection-dialog.tsx
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { Input } from '@auxx/ui/components/input'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { RadioGroup } from '@auxx/ui/components/radio-group'
+import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import { toastError } from '@auxx/ui/components/toast'
+import { useEffect, useMemo, useState } from 'react'
+import { getIntegrationProviderIcon } from '~/components/channels/ui/channel-icon'
+import { api } from '~/trpc/react'
+
+/**
+ * The picker that finishes a connect the OAuth callback could not finish on its own.
+ *
+ * ## Why this exists
+ *
+ * A Facebook grant reaches EVERY Page the connecting user administers, and only one of them
+ * becomes the channel. Provisioning used to take `pages[0]` — Graph documents no ordering — so a
+ * business running several Pages got an arbitrary one, silently. When the choice is genuinely
+ * ambiguous the hook now parks a marker and provisions nothing; this dialog collects the answer.
+ *
+ * ## Why it self-drives instead of taking props
+ *
+ * It renders from `channel.pendingConnectSelection`, which is the AUTHORITY. The OAuth popup's
+ * `awaiting` flag is only a latency hint — the popup's `verify` poll can settle before the
+ * termination page is ever read — so every abandonment path converges on the query instead:
+ * popup blocked and redirected, COOP severed the message, the user closed the tab, the page was
+ * reloaded mid-pick. Mount this anywhere on the channels surface and all of them resume.
+ *
+ * ## Generic on purpose
+ *
+ * It knows no Meta nouns. The router maps Pages to `{ id, label, sublabel, selectable,
+ * disabledReason }` before they get here, so a second selection kind is a `COPY` entry and a
+ * submit arm — not a second dialog. See plans/channels/facebook-page-picker.md §11.
+ */
+
+type SelectionKind = 'social-page-selection'
+
+/** Per-kind copy. The one place a new selection kind adds a line. */
+const COPY: Record<SelectionKind, { title: string; description: string; submit: string }> = {
+  'social-page-selection': {
+    title: 'Choose a Page',
+    description:
+      'This Facebook account manages more than one Page. Pick the one this channel should send and receive messages for.',
+    submit: 'Connect Page',
+  },
+}
+
+/** Above this many options a flat radio list stops being scannable. */
+const FILTER_THRESHOLD = 10
+
+export function ConnectSelectionDialog() {
+  const utils = api.useUtils()
+  const pending = api.channel.pendingConnectSelection.useQuery(undefined, {
+    // The picker is the point of the flow, not a background nicety — a stale cached `null` right
+    // after the popup settles is exactly the case this must not miss.
+    staleTime: 0,
+  })
+
+  const [selected, setSelected] = useState('')
+  const [filter, setFilter] = useState('')
+  /**
+   * Credential ids the user dismissed in THIS session.
+   *
+   * Cancel deliberately leaves the marker on the credential — that is what makes "reload and
+   * finish later" work, and the short-lived token beside it expires on its own within the hour.
+   * Without this the query would immediately re-open the dialog the user just closed.
+   */
+  const [dismissed, setDismissed] = useState<string[]>([])
+
+  const selectSocialPage = api.channel.selectSocialPage.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utils.channel.pendingConnectSelection.invalidate(),
+        utils.channel.list.invalidate(),
+        utils.inbox.settingsList.invalidate(),
+      ])
+    },
+    onError: (error) =>
+      toastError({ title: 'Could not connect this Page', description: error.message }),
+  })
+
+  const data = pending.data ?? null
+  const open = !!data && !dismissed.includes(data.credentialId)
+
+  // A different pending connect is a different question — never carry the previous pick into it.
+  useEffect(() => {
+    setSelected('')
+    setFilter('')
+  }, [data?.credentialId])
+
+  const options = data?.options ?? []
+  const visible = useMemo(() => {
+    const needle = filter.trim().toLowerCase()
+    if (!needle) return options
+    return options.filter(
+      (option) =>
+        option.label.toLowerCase().includes(needle) ||
+        (option.sublabel ?? '').toLowerCase().includes(needle)
+    )
+  }, [options, filter])
+
+  if (!data) return null
+
+  const copy = COPY[data.kind as SelectionKind] ?? COPY['social-page-selection']
+  const selectable = options.filter((option) => option.selectable)
+  const noneSelectable = options.length > 0 && selectable.length === 0
+
+  function dismiss() {
+    if (data) setDismissed((prev) => [...prev, data.credentialId])
+  }
+
+  async function submit() {
+    if (!data || !selected) return
+    try {
+      await selectSocialPage.mutateAsync({ credentialId: data.credentialId, pageId: selected })
+    } catch {
+      // Toasted in `onError`; the dialog stays open so the user can pick again.
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) dismiss()
+      }}>
+      <DialogContent position='tc' size='md'>
+        <DialogHeader>
+          <DialogTitle>{copy.title}</DialogTitle>
+          <DialogDescription>{copy.description}</DialogDescription>
+        </DialogHeader>
+
+        {pending.isPending ? (
+          <Skeleton className='h-32 w-full rounded-lg' />
+        ) : (
+          <div className='flex flex-col gap-2'>
+            {options.length > FILTER_THRESHOLD && (
+              <Input
+                value={filter}
+                onChange={(event) => setFilter(event.target.value)}
+                placeholder='Filter…'
+                aria-label='Filter the list'
+              />
+            )}
+            <RadioGroup value={selected} onValueChange={setSelected} className='grid gap-2'>
+              {visible.map((option) => (
+                <RadioGroupItemCard
+                  key={option.id}
+                  value={option.id}
+                  icon={getIntegrationProviderIcon(data.providerKey, 'size-4')}
+                  label={option.label}
+                  sublabel={option.disabledReason ?? option.sublabel ?? undefined}
+                  disabled={!option.selectable || selectSocialPage.isPending}
+                  className={option.selectable ? undefined : 'opacity-60'}
+                />
+              ))}
+            </RadioGroup>
+            {noneSelectable && (
+              // Otherwise every card is disabled and the submit never enables, with nothing
+              // saying why.
+              <p className='text-xs text-muted-foreground'>
+                None of these can be connected right now. They are either already connected in this
+                organization, or missing a linked Instagram Professional account.
+              </p>
+            )}
+            {visible.length === 0 && !noneSelectable && (
+              <p className='text-xs text-muted-foreground'>Nothing matches that filter.</p>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={dismiss}
+            disabled={selectSocialPage.isPending}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={submit}
+            disabled={!selected || selectSocialPage.isPending}
+            loading={selectSocialPage.isPending}
+            loadingText='Connecting…'
+            data-dialog-submit>
+            {copy.submit} <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/mcp/hooks/use-mcp-oauth-popup.ts
+++ b/apps/web/src/components/mcp/hooks/use-mcp-oauth-popup.ts
@@ -53,7 +53,7 @@ export function useMcpOAuthPopup() {
         fallbackUrl: authorizeUrl,
         channelName: 'oauth-mcp-connect',
         windowName: 'auxx-mcp-oauth',
-        onDone: (ok) => onDone(ok),
+        onDone: ({ ok }) => onDone(ok),
         verify: verifyFn,
       })
     },

--- a/apps/web/src/hooks/use-oauth-popup.ts
+++ b/apps/web/src/hooks/use-oauth-popup.ts
@@ -12,6 +12,24 @@ interface OAuthDonePayload {
   error?: string | null
   /** True when the connect matched an existing identity and updated it in place (no new row). */
   matchedExisting?: boolean
+  /**
+   * Set when the credential committed but nothing was provisioned — the connect needs a choice
+   * the user makes in the app (e.g. which Facebook Page). Carries the selection `kind`.
+   *
+   * A LATENCY HINT, not the authority: the `verify` poll can settle before this page is read, so
+   * the caller must re-read the server's pending-selection query on every settle regardless.
+   */
+  awaiting?: string | null
+}
+
+/** What a settled popup flow reports back. */
+export interface OAuthPopupResult {
+  ok: boolean
+  credId: string | null
+  /** The connect deduped onto an existing identity (update-in-place). */
+  matchedExisting: boolean
+  /** A selection `kind` the connect is waiting on, or null. See {@link OAuthDonePayload.awaiting}. */
+  awaiting: string | null
 }
 
 export interface OpenOAuthPopupOptions {
@@ -24,10 +42,11 @@ export interface OpenOAuthPopupOptions {
   /** `window.open` target name (defaults to `auxx-oauth`). */
   windowName?: string
   /**
-   * Settled exactly once: `ok` + the connected credId when known. `matchedExisting` is true when
-   * the connect deduped onto an existing identity (update-in-place) — the caller toasts it.
+   * Settled exactly once. An object rather than positional args: the settle carries four facts
+   * now (`ok`, `credId`, `matchedExisting`, `awaiting`) and a positional list that long reads
+   * wrong at every call site.
    */
-  onDone: (ok: boolean, credId?: string | null, matchedExisting?: boolean) => void
+  onDone: (result: OAuthPopupResult) => void
   /**
    * Authoritative success backstop, polled every {@link verifyIntervalMs}. Resolve to a credId
    * (or `true`) once the connect is observed server-side; `null`/`false` while still pending.
@@ -112,7 +131,7 @@ export function useOAuthPopup() {
         ok: boolean,
         credId?: string | null,
         error?: string | null,
-        opts?: { closePopup?: boolean; matchedExisting?: boolean }
+        opts?: { closePopup?: boolean; matchedExisting?: boolean; awaiting?: string | null }
       ) => {
         if (settled) return
         settled = true
@@ -127,7 +146,12 @@ export function useOAuthPopup() {
         if (!ok && error) {
           toastError({ title: 'Failed to connect', description: error })
         }
-        onDone(ok, credId ?? null, opts?.matchedExisting ?? false)
+        onDone({
+          ok,
+          credId: credId ?? null,
+          matchedExisting: opts?.matchedExisting ?? false,
+          awaiting: opts?.awaiting ?? null,
+        })
       }
 
       const handleDone = (payload: OAuthDonePayload) => {
@@ -137,6 +161,7 @@ export function useOAuthPopup() {
           payload.ok ? undefined : payload.error || 'Connection failed',
           {
             matchedExisting: payload.matchedExisting ?? false,
+            awaiting: payload.awaiting ?? null,
           }
         )
       }

--- a/apps/web/src/server/api/routers/channel.ts
+++ b/apps/web/src/server/api/routers/channel.ts
@@ -17,10 +17,12 @@ import {
   list as listChannels,
   listQuoPhoneNumbers,
   provisionQuoChannel,
+  provisionSocialChannel,
   readCachedQuoNumbers,
   recoverChannel,
   requireChannelManageAccess,
   resolveChannelDefinitionId,
+  type SocialPageSelectionPayload,
   supportsPersonalChannelConnection,
   syncAllMessages,
   syncMessages,
@@ -34,7 +36,7 @@ import {
   type UpdateChatWidgetInput,
   updateChatWidget,
 } from '@auxx/lib/chat-widget/config'
-import { resolveOwnClientRequirement } from '@auxx/lib/connections'
+import { findPendingSelectionForUser, resolveOwnClientRequirement } from '@auxx/lib/connections'
 import { getUserOrganizationId } from '@auxx/lib/email'
 import { SyncMessages } from '@auxx/lib/messages'
 import {
@@ -49,7 +51,7 @@ import { fanOutAuxxChatAudienceToShopify } from '@auxx/lib/shopify'
 import { widgetSchema as chatWidgetInputSchema } from '@auxx/lib/widgets/types'
 import { createScopedLogger } from '@auxx/logger'
 import { TRPCError } from '@trpc/server'
-import { count, eq } from 'drizzle-orm'
+import { and, count, eq, isNull } from 'drizzle-orm'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
 import { createTRPCRouter, notDemo, permissionProcedure, protectedProcedure } from '../trpc'
@@ -69,6 +71,17 @@ async function checkChannelLimit(db: Database, organizationId: string) {
       })
     }
   }
+}
+
+/**
+ * Compile-time exhaustiveness guard for `PendingSelectionKind`.
+ *
+ * A new selection kind that nobody mapped to options would otherwise return `null` and dead-end
+ * the user in a connect that never finishes — this makes it a build error instead.
+ */
+function assertNoPendingKind(kind: never): null {
+  logger.warn('Unhandled pending selection kind', { kind })
+  return null
 }
 
 /**
@@ -1019,6 +1032,113 @@ export const channelRouter = createTRPCRouter({
    * number is validated against a live `GET /v1/phone-numbers` (never the cached list) and gets
    * its own Integration + inbox link.
    */
+  /**
+   * The connect this user left waiting on a choice, if any.
+   *
+   * A query, not a mutation — no secret rides the input, so it is safe in a react-query key —
+   * and it is the AUTHORITY for resuming a two-phase connect, not the popup's `awaiting` flag.
+   * The popup can settle via its `verify` poll before the termination page is ever read, so
+   * every abandonment path (popup blocked, COOP severed, tab closed, page reloaded) converges
+   * here instead: the picker re-opens on the next mount.
+   *
+   * Returns the GENERIC option shape rather than provider nouns. Mapping Pages → options happens
+   * here so the dialog that renders it stays reusable; a second selection kind is a `switch` arm,
+   * not a new component.
+   *
+   * Scoped to org + `createdById`: the person who ran the OAuth is the person who finishes it,
+   * because the grant — and the app-scoped user id stamped from it — is theirs.
+   */
+  pendingConnectSelection: protectedProcedure.query(async ({ ctx }) => {
+    const { userId } = ctx.session
+    const organizationId = getUserOrganizationId(ctx.session)
+    // Social channels are shared-only (`supportsPersonalConnection === false`), so there is no
+    // personal branch to consider here.
+    await requirePermission(userId, organizationId, PermissionKey.channelsManage)
+
+    const pending = await findPendingSelectionForUser<SocialPageSelectionPayload>(
+      organizationId,
+      userId
+    )
+    if (!pending) return null
+
+    switch (pending.selection.kind) {
+      case 'social-page-selection': {
+        const { payload } = pending.selection
+        const candidateIds = new Set(payload.candidateIds)
+
+        // Turn a ConflictError at submit time into a disabled card at pick time: a Page already
+        // claimed by a live channel in this org cannot be picked again.
+        const live = await ctx.db
+          .select({ webhookRouteKey: schema.Integration.webhookRouteKey })
+          .from(schema.Integration)
+          .where(
+            and(
+              eq(schema.Integration.organizationId, organizationId),
+              eq(schema.Integration.provider, payload.provider),
+              isNull(schema.Integration.deletedAt)
+            )
+          )
+        const connected = new Set(live.map((row) => row.webhookRouteKey).filter(Boolean))
+
+        return {
+          kind: pending.selection.kind,
+          credentialId: pending.credentialId,
+          providerKey: pending.selection.providerKey,
+          options: payload.pages.map((page) => {
+            const claimed =
+              payload.provider === 'instagram'
+                ? !!page.igBusinessAccountId && connected.has(page.igBusinessAccountId)
+                : connected.has(page.id)
+            const selectable = candidateIds.has(page.id) && !claimed
+            return {
+              id: page.id,
+              label: page.name,
+              sublabel: page.igUsername ? `@${page.igUsername}` : null,
+              selectable,
+              disabledReason: selectable
+                ? null
+                : claimed
+                  ? 'Already connected'
+                  : 'No Instagram account linked',
+            }
+          }),
+        }
+      }
+      default:
+        // Exhaustive by construction — `PendingSelectionKind` is a closed union, so a new member
+        // fails the build here rather than silently returning null and dead-ending the user.
+        return assertNoPendingKind(pending.selection.kind)
+    }
+  }),
+
+  /**
+   * Finish a two-phase social connect by choosing which Page becomes the channel.
+   *
+   * Deliberately kind-SPECIFIC: the resume query above is generic because the dialog reads it,
+   * but only the domain knows what a choice means, so a generic `completePendingSelection` would
+   * just be a dispatch table with one entry.
+   *
+   * The channel limit is re-checked here, not only in `prepareConnect` before the OAuth hop: an
+   * arbitrary amount of wall-clock (and another admin's connect) can pass before the picker is
+   * submitted.
+   */
+  selectSocialPage: protectedProcedure
+    .use(notDemo('connect a Facebook Page'))
+    .input(z.object({ credentialId: z.string().min(1), pageId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      const { userId } = ctx.session
+      const organizationId = getUserOrganizationId(ctx.session)
+      await requirePermission(userId, organizationId, PermissionKey.channelsManage)
+      await checkChannelLimit(ctx.db, organizationId)
+
+      return provisionSocialChannel({
+        credentialId: input.credentialId,
+        organizationId,
+        userId,
+        pageId: input.pageId,
+      })
+    }),
+
   addQuoNumber: protectedProcedure
     .use(notDemo('add Quo phone numbers'))
     .input(

--- a/packages/lib/src/channels/__tests__/social-page-selection.test.ts
+++ b/packages/lib/src/channels/__tests__/social-page-selection.test.ts
@@ -1,0 +1,318 @@
+// packages/lib/src/channels/__tests__/social-page-selection.test.ts
+//
+// Phase two of the Facebook / Instagram connect: the candidate rules, and turning a chosen Page
+// into a channel. The two things worth pinning here are the STALE-CACHE guard (a Page that is no
+// longer on the grant must never produce an Integration) and the probe-avoidance rule, which is
+// asserted by call count rather than by outcome — an implementation that probed every page would
+// still return the right candidates and pass an outcome-only test.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  setChannelTokens,
+  assertSharedConnectInbox,
+  upsertSocialIntegration,
+  cacheAvailablePages,
+  subscribePageToApp,
+  resolveUserTokenForCredential,
+  readPendingSelection,
+  clearPendingSelection,
+  addIntegration,
+  publishLater,
+} = vi.hoisted(() => ({
+  setChannelTokens: vi.fn(async () => {}),
+  assertSharedConnectInbox: vi.fn(async () => 'rec_inbox'),
+  upsertSocialIntegration: vi.fn(async () => ({ id: 'int_1', isNew: true, displayName: 'Acme' })),
+  cacheAvailablePages: vi.fn(async () => {}),
+  subscribePageToApp: vi.fn(async () => {}),
+  resolveUserTokenForCredential: vi.fn(async () => 'user-token'),
+  readPendingSelection: vi.fn(async (): Promise<unknown> => null),
+  clearPendingSelection: vi.fn(async () => {}),
+  addIntegration: vi.fn(async () => {}),
+  publishLater: vi.fn(async () => {}),
+}))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+vi.mock('@auxx/credentials', () => ({
+  configService: {
+    get: (key: string) =>
+      ({ FACEBOOK_APP_ID: 'app-id', FACEBOOK_APP_SECRET: 'app-secret' })[key] ?? '',
+  },
+}))
+vi.mock('@auxx/database', () => ({
+  database: { query: { InboxIntegration: { findFirst: vi.fn(async () => undefined) } } },
+  schema: new Proxy({}, { get: () => ({}) }),
+}))
+vi.mock('../../cache', () => ({ onCacheEvent: vi.fn(async () => {}) }))
+vi.mock('../../events', () => ({ publisher: { publishLater } }))
+vi.mock('../../inboxes/inbox-service', () => ({
+  InboxService: class {
+    addIntegration = addIntegration
+  },
+}))
+vi.mock('../../providers/channel-token-accessor', () => ({ setChannelTokens }))
+vi.mock('../../providers/social/api', () => ({
+  graphApiVersion: () => 'v26.0',
+  SOCIAL_SUBSCRIBED_FIELDS: { facebook: [], instagram: [] },
+  subscribePageToApp: vi.fn(async () => {}),
+}))
+vi.mock('../connect-inbox', () => ({ assertSharedConnectInbox }))
+vi.mock('../../connections/pending-selection', () => ({
+  readPendingSelection,
+  clearPendingSelection,
+}))
+// PARTIAL: only the writers and the token resolver are replaced. The Graph reads live in
+// `providers/social/connect-api` and stay real so the `fetch` stub drives them.
+vi.mock('../internal/social-integration', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../internal/social-integration')>()),
+  resolveUserTokenForCredential,
+  upsertSocialIntegration,
+  cacheAvailablePages,
+  subscribePageToApp,
+}))
+
+const { provisionSocialChannel, selectSocialCandidates, noLinkedInstagramError } = await import(
+  '../social-page-selection'
+)
+
+const ORG = 'org_cuid000000000000000000000'
+const USER = 'usr_cuid000000000000000000000'
+const CRED = 'cred_cuid00000000000000000000'
+
+interface StubPage {
+  id: string
+  name: string
+  access_token: string
+  instagram_business_account?: { id?: string; username?: string }
+}
+
+function page(id: string, name: string, ig?: { id: string; username: string }): StubPage {
+  return {
+    id,
+    name,
+    access_token: `${id}-token`,
+    ...(ig && { instagram_business_account: ig }),
+  }
+}
+
+function stubGraph(options: {
+  pages?: StubPage[]
+  pagesFail?: boolean
+  igProbe?: Record<string, { id: string; username: string }>
+}) {
+  const pages = options.pages ?? [page('page-1', 'Acme')]
+  const probes = options.igProbe ?? {}
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: string) => {
+      const url = String(input)
+      if (url.includes('/oauth/access_token')) {
+        return { ok: true, json: async () => ({ access_token: 'long-lived' }) }
+      }
+      if (url.includes('/me/accounts')) {
+        if (options.pagesFail) {
+          return {
+            ok: false,
+            json: async () => ({ error: { message: 'Error validating access token' } }),
+          }
+        }
+        return { ok: true, json: async () => ({ data: pages }) }
+      }
+      if (url.includes('/me?fields=id')) {
+        return { ok: true, status: 200, json: async () => ({ id: 'asid-1' }) }
+      }
+      const pageId = url.split('/').pop()?.split('?')[0] ?? ''
+      const hit = probes[pageId]
+      return {
+        ok: true,
+        status: 200,
+        json: async () => (hit ? { instagram_business_account: hit } : {}),
+      }
+    })
+  )
+}
+
+function pendingFor(provider: 'facebook' | 'instagram', pages: StubPage[]) {
+  return {
+    kind: 'social-page-selection',
+    providerKey: provider,
+    createdAt: '2026-08-18T00:00:00.000Z',
+    payload: {
+      provider,
+      inboxRecordId: 'rec_inbox',
+      facebookUserId: 'asid-1',
+      candidateIds: pages.map((p) => p.id),
+      pages: pages.map((p) => ({ id: p.id, name: p.name })),
+    },
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  readPendingSelection.mockResolvedValue(null)
+  upsertSocialIntegration.mockResolvedValue({ id: 'int_1', isNew: true, displayName: 'Acme' })
+})
+
+describe('selectSocialCandidates', () => {
+  it('takes every Page for Facebook and probes nothing', async () => {
+    const probe = vi.fn(async () => null)
+    const pages = [page('a', 'A'), page('b', 'B')]
+
+    const result = await selectSocialCandidates('facebook', pages as never, probe)
+
+    expect(result.candidates.map((p) => p.id)).toEqual(['a', 'b'])
+    expect(probe).not.toHaveBeenCalled()
+  })
+
+  it('uses the EXPANDED pages and probes nothing when any came back expanded', async () => {
+    const probe = vi.fn(async () => null)
+    const pages = [page('a', 'A'), page('b', 'B', { id: 'ig-b', username: 'bee' })]
+
+    const result = await selectSocialCandidates('instagram', pages as never, probe)
+
+    // Asserted by CALL COUNT: an implementation that probed page `a` anyway would return the
+    // same candidates and pass an outcome-only assertion.
+    expect(probe).not.toHaveBeenCalled()
+    expect(result.candidates.map((p) => p.id)).toEqual(['b'])
+    expect(result.instagramByPageId.get('b')).toEqual({ id: 'ig-b', username: 'bee' })
+  })
+
+  it('probes EVERY page only when nothing came back expanded', async () => {
+    const probe = vi.fn(async (pageId: string) =>
+      pageId === 'b' ? { id: 'ig-b', username: 'bee' } : null
+    )
+    const pages = [page('a', 'A'), page('b', 'B')]
+
+    const result = await selectSocialCandidates('instagram', pages as never, probe)
+
+    expect(probe).toHaveBeenCalledTimes(2)
+    expect(result.candidates.map((p) => p.id)).toEqual(['b'])
+  })
+
+  it('throws the multi-cause error when the probe finds nothing either', async () => {
+    const probe = vi.fn(async () => null)
+    const pages = [page('a', 'Acme'), page('b', 'Beta')]
+
+    await expect(selectSocialCandidates('instagram', pages as never, probe)).rejects.toThrow(
+      noLinkedInstagramError(pages as never).message
+    )
+  })
+})
+
+describe('provisionSocialChannel', () => {
+  it('provisions from the pending marker and clears it before publishing', async () => {
+    const pages = [page('page-1', 'Acme'), page('page-2', 'Beta')]
+    readPendingSelection.mockResolvedValue(pendingFor('facebook', pages))
+    stubGraph({ pages })
+
+    const result = await provisionSocialChannel({
+      credentialId: CRED,
+      organizationId: ORG,
+      userId: USER,
+      pageId: 'page-2',
+    })
+
+    expect(result).toEqual({ integrationId: 'int_1' })
+    expect(upsertSocialIntegration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'facebook',
+        identity: expect.objectContaining({ pageId: 'page-2', facebookUserId: 'asid-1' }),
+      })
+    )
+    expect(addIntegration).toHaveBeenCalledWith('rec_inbox', 'int_1')
+
+    // Ordering, both directions: tokens land before the webhook is armed, and the marker is gone
+    // before anything downstream can observe a provisioned channel that still claims to be
+    // waiting on a choice.
+    const order = (m: { mock: { invocationCallOrder: number[] } }) => m.mock.invocationCallOrder[0]!
+    expect(order(setChannelTokens)).toBeLessThan(order(subscribePageToApp))
+    expect(order(clearPendingSelection)).toBeLessThan(order(publishLater))
+  })
+
+  it('refuses a Page that is no longer on the grant, and writes nothing', async () => {
+    const pages = [page('page-1', 'Acme')]
+    readPendingSelection.mockResolvedValue(
+      pendingFor('facebook', [page('page-1', 'Acme'), page('page-2', 'Beta')])
+    )
+    stubGraph({ pages })
+
+    await expect(
+      provisionSocialChannel({
+        credentialId: CRED,
+        organizationId: ORG,
+        userId: USER,
+        pageId: 'page-2',
+      })
+    ).rejects.toThrow(/no longer available on this Facebook account/)
+
+    // The stale-cache guard: the marker still lists page-2, the live fetch does not.
+    expect(upsertSocialIntegration).not.toHaveBeenCalled()
+    expect(setChannelTokens).not.toHaveBeenCalled()
+  })
+
+  it('rejects when there is no marker and no explicit inbox', async () => {
+    stubGraph({})
+
+    await expect(
+      provisionSocialChannel({
+        credentialId: CRED,
+        organizationId: ORG,
+        userId: USER,
+        pageId: 'page-1',
+      })
+    ).rejects.toThrow(/no page selection waiting/)
+  })
+
+  it('provisions with an EXPLICIT inbox and no marker at all', async () => {
+    // The "add another Page from this connection" entry point: the marker is one SOURCE of the
+    // inbox, never a precondition. If this regresses, that feature stops being a call site.
+    stubGraph({ pages: [page('page-1', 'Acme')] })
+
+    const result = await provisionSocialChannel({
+      credentialId: CRED,
+      organizationId: ORG,
+      userId: USER,
+      pageId: 'page-1',
+      inboxRecordId: 'rec_other',
+    })
+
+    expect(result).toEqual({ integrationId: 'int_1' })
+    expect(assertSharedConnectInbox).toHaveBeenCalledWith(expect.anything(), ORG, 'rec_other')
+    // Nothing to clear — and clearing unconditionally would be a pointless write on this path.
+    expect(clearPendingSelection).not.toHaveBeenCalled()
+  })
+
+  it('reports an expired session, rather than a Graph error, when the token is dead', async () => {
+    readPendingSelection.mockResolvedValue(pendingFor('facebook', [page('page-1', 'Acme')]))
+    stubGraph({ pagesFail: true })
+
+    await expect(
+      provisionSocialChannel({
+        credentialId: CRED,
+        organizationId: ORG,
+        userId: USER,
+        pageId: 'page-1',
+      })
+    ).rejects.toThrow(/Facebook session has expired/)
+    expect(upsertSocialIntegration).not.toHaveBeenCalled()
+  })
+
+  it('names the chosen Page when it has no linked Instagram account', async () => {
+    const pages = [page('page-1', 'Acme')]
+    readPendingSelection.mockResolvedValue(pendingFor('instagram', pages))
+    stubGraph({ pages })
+
+    // Distinct from the phase-one "none anywhere" text: here the user picked a specific Page.
+    await expect(
+      provisionSocialChannel({
+        credentialId: CRED,
+        organizationId: ORG,
+        userId: USER,
+        pageId: 'page-1',
+      })
+    ).rejects.toThrow(/“Acme” has no linked Instagram Professional account/)
+    expect(upsertSocialIntegration).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/channels/__tests__/social-provisioning-hook.test.ts
+++ b/packages/lib/src/channels/__tests__/social-provisioning-hook.test.ts
@@ -3,27 +3,49 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
- * `socialProvisioningHook` — the connect must FAIL when the Facebook user id is unknown.
+ * `socialProvisioningHook` — two things this file exists to pin.
  *
- * The hole this pins: Meta's data-deletion and deauthorize callbacks POST a
- * `signed_request` whose payload carries `user_id` and nothing else — no page id, no
- * email, no org — so `Integration.metadata.userId` (written from
- * `SocialIdentity.facebookUserId`) is the ONLY key that can resolve such a callback to a
- * channel. `fetchFacebookUserId` used to swallow every error and return `undefined`, and
- * `discoverIdentity` never checked it, so a channel connected during a transient Graph
- * blip provisioned fine and was then permanently invisible to the callback: we would hand
- * Meta a confirmation code while the user's OAuth tokens sat untouched in `Credential`.
+ * **1. The connect must FAIL when the Facebook user id is unknown.**
+ * Meta's data-deletion and deauthorize callbacks POST a `signed_request` whose payload carries
+ * `user_id` and nothing else — no page id, no email, no org — so `Integration.metadata.userId`
+ * (written from `SocialIdentity.facebookUserId`) is the ONLY key that can resolve such a callback
+ * to a channel. `fetchFacebookUserId` used to swallow every error and return `undefined`, and
+ * nothing checked it, so a channel connected during a transient Graph blip provisioned fine and
+ * was then permanently invisible to the callback: we would hand Meta a confirmation code while
+ * the user's OAuth tokens sat untouched in `Credential`. A retryable connect error is the correct
+ * trade against a silent compliance hole.
  *
- * So the assertions that matter are (1) the connect rejects with a message a user can act
- * on, and (2) it rejects BEFORE anything is provisioned — no page lookup, no token swap,
- * no Integration row. A retryable connect error is the correct trade against a silent
- * compliance hole.
+ * **2. An ambiguous grant must provision NOTHING.**
+ * `/me/accounts` returns every Page the user administers. When more than one is a candidate the
+ * hook parks a marker and returns `awaiting` — no Integration, no page token, no webhook — and
+ * the picker finishes the connect. The highest-value assertion in the file is the negative one:
+ * that the two-page case writes no tokens and arms no webhook.
  */
 
-const { setChannelTokens, subscribePageToApp, assertSharedConnectInbox } = vi.hoisted(() => ({
+const {
+  setChannelTokens,
+  subscribePageToApp,
+  assertSharedConnectInbox,
+  upsertSocialIntegration,
+  cacheAvailablePages,
+  findLiveSocialIntegrationForCredential,
+  writePendingSelection,
+  deleteSupersededPendingCredentials,
+} = vi.hoisted(() => ({
   setChannelTokens: vi.fn(async () => {}),
   subscribePageToApp: vi.fn(async () => {}),
   assertSharedConnectInbox: vi.fn(async () => 'rec_inbox'),
+  upsertSocialIntegration: vi.fn(async () => ({
+    id: 'int_1',
+    isNew: true,
+    displayName: 'Acme',
+  })),
+  cacheAvailablePages: vi.fn(async () => {}),
+  findLiveSocialIntegrationForCredential: vi.fn(
+    async (): Promise<{ id: string; pageId: string | null; pageName: string | null } | null> => null
+  ),
+  writePendingSelection: vi.fn(async () => {}),
+  deleteSupersededPendingCredentials: vi.fn(async () => {}),
 }))
 
 vi.mock('@auxx/logger', () => ({
@@ -35,6 +57,12 @@ vi.mock('@auxx/credentials', () => ({
       ({ FACEBOOK_APP_ID: 'app-id', FACEBOOK_APP_SECRET: 'app-secret' })[key] ?? '',
   },
 }))
+// The only DB touch left in the hook itself: the "is this channel already linked to an inbox"
+// probe. Every other write goes through a module boundary mocked below.
+vi.mock('@auxx/database', () => ({
+  database: { query: { InboxIntegration: { findFirst: vi.fn(async () => undefined) } } },
+  schema: new Proxy({}, { get: () => ({}) }),
+}))
 vi.mock('../../cache', () => ({ onCacheEvent: vi.fn(async () => {}) }))
 vi.mock('../../events', () => ({ publisher: { publishLater: vi.fn(async () => {}) } }))
 vi.mock('../../inboxes/inbox-service', () => ({
@@ -44,8 +72,9 @@ vi.mock('../../inboxes/inbox-service', () => ({
 }))
 vi.mock('../../providers/channel-token-accessor', () => ({ setChannelTokens }))
 vi.mock('../../providers/social/api', () => ({
+  graphApiVersion: () => 'v26.0',
   SOCIAL_SUBSCRIBED_FIELDS: { facebook: [], instagram: [] },
-  subscribePageToApp,
+  subscribePageToApp: vi.fn(async () => {}),
 }))
 vi.mock('../connect-inbox', () => ({ assertSharedConnectInbox }))
 vi.mock('../../connections/resolve-connection-for-runtime', () => ({
@@ -53,6 +82,23 @@ vi.mock('../../connections/resolve-connection-for-runtime', () => ({
     isErr: () => false,
     value: { organizationConnection: { value: 'short-lived-user-token' } },
   }),
+}))
+vi.mock('../../connections/pending-selection', () => ({
+  writePendingSelection,
+  deleteSupersededPendingCredentials,
+}))
+// PARTIAL mock: only the DB writers are replaced. The Graph reads in
+// `providers/social/connect-api` stay REAL — they are what the `fetch` stub drives, and stubbing
+// them would make every page-count assertion in this file vacuous.
+vi.mock('../internal/social-integration', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../internal/social-integration')>()),
+  subscribePageToApp,
+  upsertSocialIntegration,
+  cacheAvailablePages,
+}))
+vi.mock('../social-page-selection', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../social-page-selection')>()),
+  findLiveSocialIntegrationForCredential,
 }))
 
 const { socialProvisioningHook } = await import('../social-provisioning-hook')
@@ -64,8 +110,27 @@ const ctx = {
   credentialId: 'cred_cuid00000000000000000000',
 } as never
 
-/** One fetch stub for all three Graph endpoints the hook can reach. */
-function stubGraph(me: { status: number; body: unknown } | Error) {
+const igCtx = { ...(ctx as object), providerKey: 'instagram' } as never
+
+interface StubPage {
+  id: string
+  name: string
+  access_token: string
+  instagram_business_account?: { id?: string; username?: string }
+}
+
+/** One fetch stub for every Graph endpoint the hook can reach. */
+function stubGraph(options: {
+  me?: { status: number; body: unknown } | Error
+  pages?: StubPage[]
+  /** Per-page `?fields=instagram_business_account` probe results. */
+  igProbe?: Record<string, { id: string; username: string }>
+}) {
+  const me = options.me ?? { status: 200, body: { id: 'asid-1' } }
+  const pages = options.pages ?? [{ id: 'page-1', name: 'Acme', access_token: 'page-token' }]
+  const probes = options.igProbe ?? {}
+  const probeCalls: string[] = []
+
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: string) => {
@@ -74,29 +139,38 @@ function stubGraph(me: { status: number; body: unknown } | Error) {
         return { ok: true, json: async () => ({ access_token: 'long-lived-user-token' }) }
       }
       if (url.includes('/me/accounts')) {
-        return {
-          ok: true,
-          json: async () => ({
-            data: [{ id: 'page-1', name: 'Acme', access_token: 'page-token' }],
-          }),
-        }
+        return { ok: true, json: async () => ({ data: pages }) }
       }
-      // `/me?fields=id` — the one under test.
-      if (me instanceof Error) throw me
-      return { ok: me.status < 400, status: me.status, json: async () => me.body }
+      if (url.includes('/me?fields=id')) {
+        if (me instanceof Error) throw me
+        return { ok: me.status < 400, status: me.status, json: async () => me.body }
+      }
+      // A per-page `instagram_business_account` probe.
+      const pageId = url.split('/').pop()?.split('?')[0] ?? ''
+      probeCalls.push(pageId)
+      const hit = probes[pageId]
+      return {
+        ok: true,
+        status: 200,
+        json: async () => (hit ? { instagram_business_account: hit } : {}),
+      }
     })
   )
+  return { probeCalls }
 }
 
 beforeEach(() => {
   vi.clearAllMocks()
+  findLiveSocialIntegrationForCredential.mockResolvedValue(null)
 })
 
 describe('socialProvisioningHook — Facebook user id is mandatory', () => {
   it('rejects the connect when Graph errors on /me instead of provisioning an unlinkable channel', async () => {
     stubGraph({
-      status: 400,
-      body: { error: { message: 'Error validating access token: Session has expired' } },
+      me: {
+        status: 400,
+        body: { error: { message: 'Error validating access token: Session has expired' } },
+      },
     })
 
     await expect(socialProvisioningHook.run(ctx)).rejects.toThrow(
@@ -110,7 +184,7 @@ describe('socialProvisioningHook — Facebook user id is mandatory', () => {
   })
 
   it('rejects the connect when /me answers 200 with no id', async () => {
-    stubGraph({ status: 200, body: {} })
+    stubGraph({ me: { status: 200, body: {} } })
 
     await expect(socialProvisioningHook.run(ctx)).rejects.toThrow(
       /Could not retrieve your Facebook account: ensure permissions were granted/
@@ -119,12 +193,224 @@ describe('socialProvisioningHook — Facebook user id is mandatory', () => {
   })
 
   it('rejects with a readable message when the /me request itself fails', async () => {
-    stubGraph(new Error('fetch failed'))
+    stubGraph({ me: new Error('fetch failed') })
 
     // The network cause is surfaced, not a bare `TypeError: fetch failed`.
     await expect(socialProvisioningHook.run(ctx)).rejects.toThrow(
       /Could not retrieve your Facebook account: fetch failed\. Please try connecting again\./
     )
     expect(setChannelTokens).not.toHaveBeenCalled()
+  })
+
+  it('stays fatal with two pages — the ASID throw precedes the pending write', async () => {
+    stubGraph({
+      me: { status: 500, body: { error: { message: 'boom' } } },
+      pages: [
+        { id: 'page-1', name: 'Acme', access_token: 't1' },
+        { id: 'page-2', name: 'Beta', access_token: 't2' },
+      ],
+    })
+
+    await expect(socialProvisioningHook.run(ctx)).rejects.toThrow(
+      /Could not retrieve your Facebook account/
+    )
+    // The picker is NOT an escape hatch from the compliance invariant.
+    expect(writePendingSelection).not.toHaveBeenCalled()
+    expect(setChannelTokens).not.toHaveBeenCalled()
+  })
+})
+
+describe('socialProvisioningHook — candidate gating', () => {
+  it('provisions with zero extra clicks when the grant has one Page', async () => {
+    stubGraph({ pages: [{ id: 'page-1', name: 'Acme', access_token: 'page-token' }] })
+
+    const result = await socialProvisioningHook.run(ctx)
+
+    expect(result).toBeUndefined()
+    expect(setChannelTokens).toHaveBeenCalledTimes(1)
+    expect(subscribePageToApp).toHaveBeenCalledWith('facebook', 'page-1', expect.any(String))
+    expect(assertSharedConnectInbox).toHaveBeenCalled()
+    expect(writePendingSelection).not.toHaveBeenCalled()
+  })
+
+  it('provisions NOTHING when two Pages are candidates', async () => {
+    stubGraph({
+      pages: [
+        { id: 'page-1', name: 'Acme', access_token: 't1' },
+        { id: 'page-2', name: 'Beta', access_token: 't2' },
+      ],
+    })
+
+    const result = await socialProvisioningHook.run(ctx)
+
+    expect(result).toEqual({
+      awaiting: { kind: 'social-page-selection', credentialId: 'cred_cuid00000000000000000000' },
+    })
+    // The assertions that matter: no channel exists yet.
+    expect(upsertSocialIntegration).not.toHaveBeenCalled()
+    expect(setChannelTokens).not.toHaveBeenCalled()
+    expect(subscribePageToApp).not.toHaveBeenCalled()
+
+    // The marker carries both candidate ids and the whole page list (the picker renders
+    // non-candidates disabled), plus the ASID phase two refuses to provision without.
+    expect(writePendingSelection).toHaveBeenCalledWith(
+      'cred_cuid00000000000000000000',
+      'org_cuid000000000000000000000',
+      expect.objectContaining({
+        kind: 'social-page-selection',
+        providerKey: 'facebook',
+        payload: expect.objectContaining({
+          provider: 'facebook',
+          inboxRecordId: 'rec_inbox',
+          facebookUserId: 'asid-1',
+          candidateIds: ['page-1', 'page-2'],
+        }),
+      })
+    )
+    expect(deleteSupersededPendingCredentials).toHaveBeenCalled()
+  })
+
+  it('rejects before writing a marker when the destination inbox is invalid', async () => {
+    stubGraph({
+      pages: [
+        { id: 'page-1', name: 'Acme', access_token: 't1' },
+        { id: 'page-2', name: 'Beta', access_token: 't2' },
+      ],
+    })
+    assertSharedConnectInbox.mockRejectedValueOnce(new Error('Pick an inbox') as never)
+
+    await expect(socialProvisioningHook.run(ctx)).rejects.toThrow('Pick an inbox')
+    expect(writePendingSelection).not.toHaveBeenCalled()
+  })
+})
+
+describe('socialProvisioningHook — reconnect forces the bound Page', () => {
+  it('relinks the existing Page instead of showing a picker', async () => {
+    stubGraph({
+      pages: [
+        { id: 'page-1', name: 'Acme', access_token: 't1' },
+        { id: 'page-2', name: 'Beta', access_token: 't2' },
+      ],
+    })
+    findLiveSocialIntegrationForCredential.mockResolvedValue({
+      id: 'int_1',
+      pageId: 'page-2',
+      pageName: 'Beta',
+    })
+
+    const result = await socialProvisioningHook.run({
+      ...(ctx as object),
+      connectionId: 'cred_x',
+    } as never)
+
+    expect(result).toBeUndefined()
+    expect(writePendingSelection).not.toHaveBeenCalled()
+    expect(upsertSocialIntegration).toHaveBeenCalledWith(
+      expect.objectContaining({ identity: expect.objectContaining({ pageId: 'page-2' }) })
+    )
+  })
+
+  it('shows the picker again when the credential is PENDING (connectionId set, no Integration)', async () => {
+    // The rule keys on the Integration, not on `connectionId`. Re-authing a pending credential
+    // wipes its marker (an OAuth mint REPLACES `Credential.metadata`) and must land back in the
+    // picker — keying on `connectionId` would dead-end the user with no marker and no picker.
+    stubGraph({
+      pages: [
+        { id: 'page-1', name: 'Acme', access_token: 't1' },
+        { id: 'page-2', name: 'Beta', access_token: 't2' },
+      ],
+    })
+    findLiveSocialIntegrationForCredential.mockResolvedValue(null)
+
+    const result = await socialProvisioningHook.run({
+      ...(ctx as object),
+      connectionId: 'cred_x',
+    } as never)
+
+    expect(result).toMatchObject({ awaiting: { kind: 'social-page-selection' } })
+    expect(writePendingSelection).toHaveBeenCalled()
+  })
+
+  it('errors, rather than picking a different Page, when the bound Page is no longer granted', async () => {
+    stubGraph({ pages: [{ id: 'page-1', name: 'Acme', access_token: 't1' }] })
+    findLiveSocialIntegrationForCredential.mockResolvedValue({
+      id: 'int_1',
+      pageId: 'page-gone',
+      pageName: 'Gone Ltd',
+    })
+
+    await expect(socialProvisioningHook.run(ctx)).rejects.toThrow(/Gone Ltd/)
+    expect(upsertSocialIntegration).not.toHaveBeenCalled()
+  })
+})
+
+describe('socialProvisioningHook — Instagram candidates', () => {
+  it('auto-selects the one Page with a linked account, and probes nothing', async () => {
+    const { probeCalls } = stubGraph({
+      pages: [
+        { id: 'page-1', name: 'Acme', access_token: 't1' },
+        {
+          id: 'page-2',
+          name: 'Beta',
+          access_token: 't2',
+          instagram_business_account: { id: 'ig-2', username: 'beta' },
+        },
+      ],
+    })
+
+    const result = await socialProvisioningHook.run(igCtx)
+
+    expect(result).toBeUndefined()
+    // Rule 2: something came back expanded, so the per-page probe never runs.
+    expect(probeCalls).toEqual([])
+    expect(upsertSocialIntegration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identity: expect.objectContaining({ pageId: 'page-2', instagramAccountId: 'ig-2' }),
+      })
+    )
+  })
+
+  it('asks when two Pages both have linked accounts', async () => {
+    stubGraph({
+      pages: [
+        {
+          id: 'page-1',
+          name: 'Acme',
+          access_token: 't1',
+          instagram_business_account: { id: 'ig-1', username: 'acme' },
+        },
+        {
+          id: 'page-2',
+          name: 'Beta',
+          access_token: 't2',
+          instagram_business_account: { id: 'ig-2', username: 'beta' },
+        },
+      ],
+    })
+
+    const result = await socialProvisioningHook.run(igCtx)
+
+    expect(result).toMatchObject({ awaiting: { kind: 'social-page-selection' } })
+    expect(setChannelTokens).not.toHaveBeenCalled()
+  })
+
+  it('throws the exact multi-cause error when no Page anywhere has a linked account', async () => {
+    stubGraph({
+      pages: [
+        { id: 'page-1', name: 'Acme', access_token: 't1' },
+        { id: 'page-2', name: 'Beta', access_token: 't2' },
+      ],
+    })
+
+    // Asserted against the LITERAL, not a loose regex: the wording names both causes (no linked
+    // account vs. `instagram_basic` not granted) and is what a Meta reviewer sees. The point of
+    // the test is that it does not drift into a paraphrase.
+    await expect(socialProvisioningHook.run(igCtx)).rejects.toThrow(
+      'No linked Instagram Professional account was found on any of the 2 managed Facebook ' +
+        'Page(s) (Acme, Beta). Either no Instagram Professional account is linked to the Page, ' +
+        'or the connection was granted without the instagram_basic permission — in which case ' +
+        'Graph hides the link rather than reporting it.'
+    )
+    expect(writePendingSelection).not.toHaveBeenCalled()
   })
 })

--- a/packages/lib/src/channels/index.ts
+++ b/packages/lib/src/channels/index.ts
@@ -58,6 +58,16 @@ export {
   updateAllowedSenders,
   updateSettings,
 } from './settings'
+export {
+  findLiveSocialIntegrationForCredential,
+  type PendingSocialPageSelection,
+  type ProvisionSocialChannelInput,
+  provisionSocialChannel,
+  SOCIAL_PAGE_SELECTION_KIND,
+  type SocialCandidateSet,
+  type SocialPageSelectionPayload,
+  selectSocialCandidates,
+} from './social-page-selection'
 export { getAllStats } from './stats'
 export { syncAllMessages, syncMessages } from './sync'
 export { toggle } from './toggle'

--- a/packages/lib/src/channels/internal/social-integration.ts
+++ b/packages/lib/src/channels/internal/social-integration.ts
@@ -1,0 +1,284 @@
+// packages/lib/src/channels/internal/social-integration.ts
+// The CHANNEL-side half of a social connect, shared by both phases.
+//
+// Phase one (the post-connect hook) discovers the grant; phase two (`social-page-selection.ts`)
+// finishes a connect the user had to answer a question about. Both write the same Integration
+// row and cache the same page list, so the body lives here once — a second copy is how the
+// zero-click path and the picker path would silently drift apart.
+//
+// The Graph calls themselves are NOT here: they belong with the provider, in
+// `providers/social/connect-api.ts` beside the rest of the Graph surface. What is here is
+// everything that touches OUR tables — the Integration upsert and its route-key conflict
+// mapping, the credential's page cache, the credential token resolution — plus the identity
+// types that describe a connected channel.
+
+import { database as db, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNull, sql } from 'drizzle-orm'
+import { resolveConnectionForRuntime } from '../../connections/resolve-connection-for-runtime'
+import { ConflictError } from '../../errors'
+import {
+  SOCIAL_SUBSCRIBED_FIELDS,
+  subscribePageToApp as subscribePageToAppApi,
+} from '../../providers/social/api'
+
+const logger = createScopedLogger('social-integration')
+
+export type SocialProvider = 'facebook' | 'instagram'
+
+/**
+ * A page the connecting user administers, trimmed to what a picker needs.
+ *
+ * Cached on the CREDENTIAL, not the Integration: it describes the OAuth grant (what this token
+ * can reach), not one channel.
+ *
+ * Deliberately does NOT include page access tokens: those live encrypted on the credential, and
+ * a plaintext copy in a metadata blob is a credential leak waiting to be logged. Phase two
+ * re-fetches instead, which also gives it live validation of the chosen Page.
+ */
+export interface CachedSocialPage {
+  id: string
+  name: string
+  igBusinessAccountId?: string
+  igUsername?: string
+}
+
+/** Resolve a credential's stored access token (the Facebook user token during a connect). */
+export async function resolveUserTokenForCredential(args: {
+  credentialId: string
+  organizationId: string
+  userId: string
+}): Promise<string> {
+  const resolved = await resolveConnectionForRuntime({
+    connectionId: args.credentialId,
+    organizationId: args.organizationId,
+    userId: args.userId,
+    ensureFresh: true,
+  })
+  if (resolved.isErr()) {
+    throw new Error(`Failed to resolve social channel token: ${resolved.error.message}`)
+  }
+  const conn = resolved.value.organizationConnection ?? resolved.value.userConnection
+  if (!conn?.value) throw new Error('Social credential resolved without an access token')
+  return conn.value
+}
+
+/** The connected Page (+ optional linked IG account) plus its long-lived page token. */
+export interface SocialIdentity {
+  pageId: string
+  pageName: string
+  longLivedPageToken: string
+  longLivedUserToken: string
+  /**
+   * The connecting user's app-scoped id (ASID). Required, not optional: it is the ONLY join key
+   * Meta's data-deletion / deauthorize callback gives us, so a channel stored without it can
+   * never be matched to a deletion request. Neither phase reaches `upsertSocialIntegration`
+   * without one — see `fetchFacebookUserId`.
+   */
+  facebookUserId: string
+  /** Every page this grant can reach — cached for the picker (see CachedSocialPage). */
+  availablePages: CachedSocialPage[]
+  instagramAccountId?: string
+  instagramUsername?: string
+}
+
+/** Subscribe the Page to the app's webhook (the social analogue of arming Gmail watch). */
+export async function subscribePageToApp(
+  provider: SocialProvider,
+  pageId: string,
+  pageToken: string
+): Promise<void> {
+  const subscribedFields =
+    provider === 'instagram'
+      ? SOCIAL_SUBSCRIBED_FIELDS.instagram
+      : SOCIAL_SUBSCRIBED_FIELDS.facebook
+  try {
+    await subscribePageToAppApi(pageId, pageToken, subscribedFields)
+    logger.info('Page subscribed to app webhook', { pageId, provider, subscribedFields })
+  } catch (error) {
+    // Swallowed on purpose: a failed subscription means real-time delivery is off, but the
+    // channel is otherwise connected and `recoverChannel` re-arms it. A throw here would abort
+    // provisioning after the Integration row already exists.
+    logger.error('Error subscribing Page to app webhook — real-time messages may not arrive', {
+      pageId,
+      provider,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * Postgres unique_violation (SQLSTATE 23505) raised by
+ * `Integration_provider_webhookRouteKey_key` — the unique partial index on
+ * `(provider, webhookRouteKey)` among live rows.
+ *
+ * Drizzle wraps the raw `pg` error (which carries `.code` / `.constraint`) in a
+ * `DrizzleQueryError` and hangs the original off `.cause`, so both spots are checked. The
+ * constraint name is checked too: `Integration` carries other unique indexes
+ * (`(organizationId, provider, email)`), and only this one means "someone else owns this Page".
+ */
+function isRouteKeyConflict(error: unknown): boolean {
+  const chain = [error, (error as { cause?: unknown })?.cause]
+  return chain.some((node) => {
+    const e = node as { code?: string; constraint?: string } | undefined
+    return e?.code === '23505' && e?.constraint === 'Integration_provider_webhookRouteKey_key'
+  })
+}
+
+/**
+ * The connect-time failure a duplicate Page produces, phrased for the person who just clicked
+ * Connect. Reached from the picker dialog now as well as the OAuth popup, which is strictly
+ * better copy placement.
+ *
+ * Before `webhookRouteKey` was adopted the second org connected happily and then split that
+ * Page's inbound DMs between two tenants at random — the unique index turns that silent
+ * mis-delivery into this error.
+ */
+function duplicateRouteKeyError(provider: SocialProvider, displayName: string): ConflictError {
+  const subject =
+    provider === 'instagram'
+      ? `The Instagram account “${displayName}”`
+      : `The Facebook Page “${displayName}”`
+  return new ConflictError(
+    `${subject} is already connected to another Auxx organization. A Page can only deliver ` +
+      'its messages to one organization — disconnect it there first, then connect it here.'
+  )
+}
+
+/**
+ * Create the Integration row, or relink the credential onto the existing one (reauth / reconnect).
+ * Social channels are matched by the Page id (Facebook) or Instagram Business Account id
+ * (Instagram) carried in metadata, not by the email column (which stays null).
+ */
+export async function upsertSocialIntegration(args: {
+  organizationId: string
+  provider: SocialProvider
+  credentialId: string
+  identity: SocialIdentity
+}): Promise<{ id: string; isNew: boolean; displayName: string }> {
+  const { organizationId, provider, credentialId, identity } = args
+  const matchId = provider === 'instagram' ? identity.instagramAccountId! : identity.pageId
+  const displayName =
+    provider === 'instagram' ? (identity.instagramUsername ?? identity.pageName) : identity.pageName
+
+  const metadata: Record<string, unknown> = {
+    pageId: identity.pageId,
+    pageName: identity.pageName,
+    userId: identity.facebookUserId,
+    ...(provider === 'instagram' && {
+      instagramBusinessAccountId: identity.instagramAccountId,
+      instagramUsername: identity.instagramUsername,
+    }),
+  }
+
+  // Match on the page/IG id inside the jsonb metadata (no clean drizzle json-path filter), so
+  // reauth/reconnect relinks the existing row instead of inserting a duplicate.
+  const rows = await db
+    .select({ id: schema.Integration.id, metadata: schema.Integration.metadata })
+    .from(schema.Integration)
+    .where(
+      and(
+        eq(schema.Integration.organizationId, organizationId),
+        eq(schema.Integration.provider, provider),
+        // Disconnect is a SOFT delete. Without this, a reconnect after disconnect relinks the
+        // tombstoned row: the connect reports success, the Integration is updated, and the
+        // channel never appears anywhere — every list path filters `deletedAt`. Both sibling
+        // hooks document this exact failure.
+        isNull(schema.Integration.deletedAt)
+      )
+    )
+  const existing =
+    rows.find((r) => {
+      const m = r.metadata as Record<string, unknown> | null
+      const id = provider === 'instagram' ? m?.instagramBusinessAccountId : m?.pageId
+      return id === matchId
+    }) ?? null
+
+  if (existing) {
+    // jsonb MERGE, never replace. `backfillCutoffAt` / `initialBackfillCompletedAt` and any
+    // `settings` live in this same blob, and a wholesale `.set({ metadata })` on reconnect would
+    // wipe them — reopening a suppression window that has already closed, or dropping the
+    // channel's record-creation settings. Same rule `quo-channel.ts` documents at its own upsert.
+    const metadataJson = JSON.stringify(metadata)
+    try {
+      await db
+        .update(schema.Integration)
+        .set({
+          credentialId,
+          enabled: true,
+          name: displayName,
+          // The inbound routing index. Same value as the metadata id above — this is an index,
+          // not a migration of truth; the jsonb keys stay and are read for plenty besides
+          // routing. Written on relink too, because a revoke nulls the column while leaving the
+          // row alive, so a reconnect has to re-claim it.
+          webhookRouteKey: matchId,
+          metadata: sql`COALESCE(${schema.Integration.metadata}, '{}'::jsonb) || ${metadataJson}::jsonb`,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.Integration.id, existing.id))
+    } catch (error) {
+      if (isRouteKeyConflict(error)) throw duplicateRouteKeyError(provider, displayName)
+      throw error
+    }
+    return { id: existing.id, isNew: false, displayName }
+  }
+
+  let created: { id: string } | undefined
+  try {
+    ;[created] = await db
+      .insert(schema.Integration)
+      .values({
+        organizationId,
+        provider,
+        credentialId,
+        enabled: true,
+        // Persisted, not just emitted on the `integration:connected` event — this is what every
+        // channel surface reads to label the row. Without it FB/IG render as a bare "Facebook
+        // Integration" with no page name anywhere.
+        name: displayName,
+        // The inbound routing index — what both webhook routes resolve a delivery on. Its unique
+        // partial index across live rows is what makes "the same Page in two organizations"
+        // unrepresentable instead of a silent 50/50 message split.
+        webhookRouteKey: matchId,
+        // Received-time trigger cutoff, stamped at the connect epoch and ONLY on a first connect
+        // (a reconnect must not reopen a window that already closed). Consumed by both providers'
+        // `initialize()` via `setBackfillCutoff`, so a history backfill stores messages without
+        // firing `message:received` for them.
+        metadata: { ...metadata, backfillCutoffAt: new Date().toISOString() } as any,
+        updatedAt: new Date(),
+      })
+      .returning({ id: schema.Integration.id })
+  } catch (error) {
+    if (isRouteKeyConflict(error)) throw duplicateRouteKeyError(provider, displayName)
+    throw error
+  }
+  return { id: created!.id, isNew: true, displayName }
+}
+
+/**
+ * Cache the trimmed page list on the credential.
+ *
+ * jsonb MERGE under a `meta` key so this cannot clobber whatever else the credential's metadata
+ * carries (the OAuth bookkeeping the connections layer writes, and the pending-selection marker),
+ * and best-effort: a channel that connected fine must not fail provisioning because a convenience
+ * cache could not be written.
+ */
+export async function cacheAvailablePages(
+  credentialId: string,
+  pages: CachedSocialPage[]
+): Promise<void> {
+  try {
+    const metaJson = JSON.stringify({ meta: { pages, cachedAt: new Date().toISOString() } })
+    await db
+      .update(schema.Credential)
+      .set({
+        metadata: sql`COALESCE(${schema.Credential.metadata}, '{}'::jsonb) || ${metaJson}::jsonb`,
+      })
+      .where(eq(schema.Credential.id, credentialId))
+  } catch (error) {
+    logger.warn('Failed to cache available pages on the credential', {
+      credentialId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/packages/lib/src/channels/social-page-selection.ts
+++ b/packages/lib/src/channels/social-page-selection.ts
@@ -1,0 +1,370 @@
+// packages/lib/src/channels/social-page-selection.ts
+// The two-phase half of the Facebook / Instagram connect: which Page becomes the channel.
+//
+// `/me/accounts` returns EVERY Page the connecting user administers. Provisioning picked
+// `pages[0]` and threw the rest away silently, so a business running several Pages got whichever
+// one Graph happened to return first (Graph documents no ordering). This module holds the
+// candidate rules, the pending-marker payload, and the phase-two provisioning that the picker
+// dialog calls once the user has chosen.
+//
+// The Page list can only exist AFTER the OAuth hop — there is no token before it — which is why
+// this is a post-credential selection and not a form field like Quo's phone-number picker. See
+// `connections/pending-selection.ts` for the marker itself.
+//
+// Style note: this throws `AuxxError` subclasses rather than returning a `Result`, matching
+// `quo-channel.ts` (which documents the same exemption) — it sits beside `connect-inbox.ts` and
+// both provisioning hooks, all imperative/throwing, and composes with `InboxService`, which
+// throws. There are NO permission checks here; the router asserts `channelsManage`.
+
+import { database as db, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNull } from 'drizzle-orm'
+import { onCacheEvent } from '../cache'
+import {
+  clearPendingSelection,
+  type PendingConnectSelection,
+  readPendingSelection,
+} from '../connections/pending-selection'
+import { BadRequestError, NotFoundError } from '../errors'
+import { publisher } from '../events'
+import { InboxService } from '../inboxes/inbox-service'
+import { setChannelTokens } from '../providers/channel-token-accessor'
+import {
+  exchangeForLongLived,
+  type FacebookPage,
+  fetchFacebookUserId,
+  fetchInstagramAccount,
+  fetchUserPages,
+  type InstagramAccount,
+} from '../providers/social/connect-api'
+import { assertSharedConnectInbox } from './connect-inbox'
+import {
+  type CachedSocialPage,
+  cacheAvailablePages,
+  resolveUserTokenForCredential,
+  type SocialProvider,
+  subscribePageToApp,
+  upsertSocialIntegration,
+} from './internal/social-integration'
+
+const logger = createScopedLogger('social-page-selection')
+
+/** The `kind` this module answers to. Kept next to the payload it describes. */
+export const SOCIAL_PAGE_SELECTION_KIND = 'social-page-selection' as const
+
+/** The Meta body of a `PendingConnectSelection`. Opaque to the connections layer. */
+export interface SocialPageSelectionPayload {
+  provider: SocialProvider
+  /** RecordId of the already-validated destination inbox (from `ctx.extra.inboxId`). */
+  inboxRecordId: string
+  /**
+   * The connecting user's app-scoped id, resolved in phase one. Phase two re-checks it and
+   * never provisions without one — it is the only join key Meta's data-deletion callback has.
+   */
+  facebookUserId: string
+  /** Page ids the user may actually pick (Instagram: only those with a linked IG account). */
+  candidateIds: string[]
+  /** Every page the grant can reach; the picker renders non-candidates disabled. */
+  pages: CachedSocialPage[]
+}
+
+export type PendingSocialPageSelection = PendingConnectSelection<SocialPageSelectionPayload>
+
+/** The outcome of applying the §candidate rules to one grant. */
+export interface SocialCandidateSet {
+  /** Pages the user may pick. Length 1 → auto-select; length > 1 → picker. */
+  candidates: FacebookPage[]
+  /** Resolved IG account per candidate page id (Instagram only; empty for Facebook). */
+  instagramByPageId: Map<string, InstagramAccount>
+}
+
+/**
+ * The multi-cause Instagram failure, thrown when NO page in the grant has a linked account.
+ *
+ * Deliberately names BOTH causes. An absent `instagram_business_account` does not prove there is
+ * no linked account: Graph omits a permission-gated field rather than erroring, so a grant
+ * without `instagram_basic` answers exactly like a Page with nothing linked.
+ *
+ * The wording is asserted verbatim in tests — it is what a Meta reviewer sees on a failed
+ * connect, and it must not drift into a paraphrase.
+ */
+export function noLinkedInstagramError(pages: FacebookPage[]): Error {
+  return new Error(
+    `No linked Instagram Professional account was found on any of the ${pages.length} managed ` +
+      `Facebook Page(s) (${pages.map((page) => page.name).join(', ')}). Either no Instagram ` +
+      'Professional account is linked to the Page, or the connection was granted without the ' +
+      'instagram_basic permission — in which case Graph hides the link rather than reporting it.'
+  )
+}
+
+/**
+ * Which Pages in this grant may become the channel.
+ *
+ * **Facebook** — every Page. Zero is the caller's error (thrown before this runs).
+ *
+ * **Instagram** — only Pages with a resolvable linked IG Business Account, resolved without
+ * reintroducing the N-round-trip probe the previous implementation deliberately removed:
+ *  1. `/me/accounts` already expands `instagram_business_account{id,username}` — take those.
+ *  2. If ANY page came back expanded, that set is the candidates and nothing is probed.
+ *  3. Only when NOTHING was expanded is every page probed, because that is precisely the case
+ *     where the field is permission-hidden and a probe is the only way to tell "hidden" from
+ *     "absent". The probes mostly fail in that case too, degrading into (4) after N cheap calls.
+ *  4. Still empty → `noLinkedInstagramError`.
+ *
+ * Behaviour change worth knowing: the old loop probed pages in order and took the first hit, so
+ * an unexpanded `pages[0]` with a linked account beat an expanded `pages[1]`. Under rule 2
+ * `pages[1]` wins (or the picker appears). That is a fix, but it does change which Page a
+ * single-outcome Instagram connect resolves to in that one narrow case.
+ *
+ * `probe` is injected so the "only probe when nothing was expanded" rule can be asserted by call
+ * count rather than by outcome.
+ */
+export async function selectSocialCandidates(
+  provider: SocialProvider,
+  pages: FacebookPage[],
+  probe: (
+    pageId: string,
+    pageToken: string
+  ) => Promise<InstagramAccount | null> = fetchInstagramAccount
+): Promise<SocialCandidateSet> {
+  if (provider === 'facebook') {
+    return { candidates: pages, instagramByPageId: new Map() }
+  }
+
+  const instagramByPageId = new Map<string, InstagramAccount>()
+  const expanded = pages.filter((page) => page.instagram_business_account?.id)
+
+  if (expanded.length > 0) {
+    for (const page of expanded) {
+      instagramByPageId.set(page.id, {
+        id: page.instagram_business_account!.id!,
+        username: page.instagram_business_account!.username ?? '',
+      })
+    }
+    return { candidates: expanded, instagramByPageId }
+  }
+
+  const probed: FacebookPage[] = []
+  for (const page of pages) {
+    const account = await probe(page.id, page.access_token)
+    if (account) {
+      instagramByPageId.set(page.id, account)
+      probed.push(page)
+    }
+  }
+  if (probed.length === 0) throw noLinkedInstagramError(pages)
+  return { candidates: probed, instagramByPageId }
+}
+
+/**
+ * The LIVE Integration already bound to this credential, if any.
+ *
+ * Drives the forced-page rule: a full-OAuth reconnect must relink the Page the channel already
+ * has, never show a picker — a mis-click there would move a live channel onto a different Page
+ * or collide with the `webhookRouteKey` unique index.
+ *
+ * `isNull(deletedAt)` is mandatory: disconnect is a SOFT delete, and a tombstoned row must not
+ * force a selection, because reconnecting after a disconnect is a fresh connect that legitimately
+ * gets the picker.
+ */
+export async function findLiveSocialIntegrationForCredential(
+  credentialId: string,
+  provider: SocialProvider
+): Promise<{ id: string; pageId: string | null; pageName: string | null } | null> {
+  const [row] = await db
+    .select({
+      id: schema.Integration.id,
+      name: schema.Integration.name,
+      metadata: schema.Integration.metadata,
+    })
+    .from(schema.Integration)
+    .where(
+      and(
+        eq(schema.Integration.credentialId, credentialId),
+        eq(schema.Integration.provider, provider),
+        isNull(schema.Integration.deletedAt)
+      )
+    )
+    .limit(1)
+  if (!row) return null
+  const metadata = row.metadata as { pageId?: string; pageName?: string } | null
+  return {
+    id: row.id,
+    pageId: metadata?.pageId ?? null,
+    pageName: metadata?.pageName ?? row.name ?? null,
+  }
+}
+
+export interface ProvisionSocialChannelInput {
+  /** The Credential holding the Facebook user token. */
+  credentialId: string
+  organizationId: string
+  /** The acting user (permission is asserted by the caller, not here). */
+  userId: string
+  /** The Page id the user picked. Validated against a LIVE fetch, never the cache. */
+  pageId: string
+  /**
+   * Destination inbox. Optional ONLY because the picker path reads it off the pending marker;
+   * pass it explicitly and no marker is required. That is what makes "add another Page from this
+   * connection" a call site rather than a rewrite.
+   */
+  inboxRecordId?: string
+}
+
+/**
+ * Phase two: turn a chosen Page into a channel.
+ *
+ * Steps, in order:
+ *  1. resolve the inbox + ASID (argument first, pending marker second — neither → NotFound);
+ *  2. resolve and long-live the credential's user token (a dead token is the EXPECTED abandonment
+ *     path — the pending window deliberately holds a short-lived token, see the hook);
+ *  3. re-fetch `/me/accounts` and validate the chosen page against it — a stale cache must never
+ *     produce a channel;
+ *  4. Instagram only: resolve the IG account for THAT page;
+ *  5. exchange for the long-lived PAGE token and upsert the Integration;
+ *  6. write the channel tokens, link the inbox, refresh the page cache, clear the marker;
+ *  7. arm the webhook, invalidate caches, publish `integration:connected`.
+ */
+export async function provisionSocialChannel(
+  input: ProvisionSocialChannelInput
+): Promise<{ integrationId: string }> {
+  const { credentialId, organizationId, userId, pageId } = input
+
+  const pending = await readPendingSelection<SocialPageSelectionPayload>(
+    credentialId,
+    organizationId
+  )
+  const payload = pending?.payload
+  const inboxRecordId = input.inboxRecordId ?? payload?.inboxRecordId
+  if (!inboxRecordId) {
+    throw new NotFoundError(
+      'This connection has no page selection waiting. Connect the channel again.'
+    )
+  }
+
+  const provider: SocialProvider = payload?.provider ?? 'facebook'
+
+  const userToken = await resolveUserTokenForCredential({ credentialId, organizationId, userId })
+  const longLivedUserToken = await exchangeForLongLived(userToken)
+
+  // The ASID invariant, preserved structurally: `upsertSocialIntegration` is only ever reached
+  // with a non-empty `facebookUserId`, in BOTH phases. Without it the channel is permanently
+  // invisible to Meta's data-deletion callback, which joins on it and nothing else.
+  const facebookUserId = payload?.facebookUserId || (await fetchFacebookUserId(longLivedUserToken))
+
+  let pages: FacebookPage[]
+  try {
+    pages = await fetchUserPages(longLivedUserToken)
+  } catch (error) {
+    // A rejected token here is the pending window expiring, not a bug — say so plainly.
+    logger.warn('Could not re-read Pages while finishing a page selection', {
+      credentialId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    throw new BadRequestError(
+      'Your Facebook session has expired. Connect the channel again to pick a Page.'
+    )
+  }
+
+  const page = pages.find((candidate) => candidate.id === pageId)
+  if (!page) {
+    throw new BadRequestError(
+      'That Page is no longer available on this Facebook account. Connect again to refresh the list.'
+    )
+  }
+
+  let instagramAccount: InstagramAccount | null = null
+  if (provider === 'instagram') {
+    instagramAccount = page.instagram_business_account?.id
+      ? {
+          id: page.instagram_business_account.id,
+          username: page.instagram_business_account.username ?? '',
+        }
+      : await fetchInstagramAccount(page.id, page.access_token)
+    if (!instagramAccount) {
+      // Page-specific on purpose: the multi-cause "none anywhere" text belongs to phase one.
+      throw new BadRequestError(
+        `The Facebook Page “${page.name}” has no linked Instagram Professional account. Link one ` +
+          'in Meta Business Suite, or pick a different Page.'
+      )
+    }
+  }
+
+  const longLivedPageToken = await exchangeForLongLived(page.access_token)
+
+  const integration = await upsertSocialIntegration({
+    organizationId,
+    provider,
+    credentialId,
+    identity: {
+      pageId: page.id,
+      pageName: page.name,
+      longLivedPageToken,
+      longLivedUserToken,
+      facebookUserId,
+      availablePages: payload?.pages ?? [],
+      ...(instagramAccount && {
+        instagramAccountId: instagramAccount.id,
+        instagramUsername: instagramAccount.username,
+      }),
+    },
+  })
+
+  await setChannelTokens(
+    integration.id,
+    {
+      accessToken: longLivedPageToken,
+      refreshToken: longLivedUserToken,
+      expiresAt: null,
+    },
+    { createdById: userId }
+  )
+
+  // Re-validated even though phase one validated it: the inbox could have been deleted or turned
+  // personal in the meantime, and this must fail closed.
+  const existingLink = await db.query.InboxIntegration.findFirst({
+    where: eq(schema.InboxIntegration.integrationId, integration.id),
+  })
+  if (!existingLink) {
+    const recordId = await assertSharedConnectInbox(db, organizationId, inboxRecordId)
+    await new InboxService(db, organizationId, userId).addIntegration(recordId, integration.id)
+  }
+
+  await cacheAvailablePages(
+    credentialId,
+    pages.map((candidate) => ({
+      id: candidate.id,
+      name: candidate.name,
+      igBusinessAccountId: candidate.instagram_business_account?.id,
+      igUsername: candidate.instagram_business_account?.username,
+    }))
+  )
+
+  // Cleared BEFORE the connected publish so nothing downstream can observe a provisioned
+  // channel whose credential still claims to be waiting on a choice.
+  if (pending) await clearPendingSelection(credentialId, organizationId)
+
+  await subscribePageToApp(provider, page.id, longLivedPageToken)
+
+  await onCacheEvent('channel.connected', { orgId: organizationId })
+
+  await publisher.publishLater({
+    type: 'integration:connected',
+    data: {
+      organizationId,
+      userId,
+      provider,
+      identifier: integration.displayName,
+      integrationId: integration.id,
+    },
+  })
+
+  logger.info('Social channel provisioned from a page selection', {
+    integrationId: integration.id,
+    provider,
+    pageId: page.id,
+    isNew: integration.isNew,
+  })
+
+  return { integrationId: integration.id }
+}

--- a/packages/lib/src/channels/social-provisioning-hook.ts
+++ b/packages/lib/src/channels/social-provisioning-hook.ts
@@ -1,260 +1,97 @@
 // packages/lib/src/channels/social-provisioning-hook.ts
 // Post-connect provisioning for social channels (Facebook / Instagram). The generic OAuth
 // callback commits a Credential holding the short-lived Facebook USER token, then runs this
-// hook to do the work that used to live in FacebookOAuthService.handleCallback /
-// InstagramOAuthService.handleCallback (minus the user-token storage the credential layer owns):
-//   exchange the user token for a long-lived one, discover the managed Page (+ linked Instagram
-//   Business Account), exchange for a long-lived PAGE token, SWAP that page token onto the
-//   credential (the working channel token), create-or-relink the Integration row, link the default
-//   inbox, and subscribe the Page to the app webhook (the social analogue of arming Gmail watch).
+// hook to discover the grant and decide whether the connect can finish on its own:
 //
-// Token model: the page token is what every runtime read (facebook-provider / instagram-provider /
-// getPageAccessToken / revoke) needs, and getChannelTokens already serves the credential secret —
-// so writing the page token via setChannelTokens makes the runtime paths work unchanged. Long-lived
-// page tokens (~60d, often non-expiring) have no OAuth refresh grant, so expiresAt is stored null
-// and a dead token surfaces as requiresReauth rather than a scanner refresh.
+//   0 or 1 candidate Page → provision immediately (the zero-click path, unchanged)
+//   2+ candidate Pages    → park a pending marker and return `awaiting` — NO Integration, NO
+//                           page token, NO webhook — for the in-app picker to finish
+//
+// `/me/accounts` returns every Page the connecting user administers. Auto-selecting `pages[0]`
+// gave a multi-Page business whichever Page Graph happened to return first, silently. The picker
+// is gated on genuine ambiguity, so a single-Page connect is still zero extra clicks.
+//
+// Token model: the page token is what every runtime read (facebook-provider / instagram-provider
+// / getPageAccessToken / revoke) needs, and getChannelTokens already serves the credential secret
+// — so writing the page token via setChannelTokens makes the runtime paths work unchanged.
+// Long-lived page tokens (~60d, often non-expiring) have no OAuth refresh grant, so expiresAt is
+// stored null and a dead token surfaces as requiresReauth rather than a scanner refresh.
+//
+// ⚠️ The pending window deliberately keeps the SHORT-LIVED user token on the credential. A
+// pending credential has no Integration, so it is invisible in principle to Meta's data-deletion
+// callback (which joins on `Integration.metadata.userId`); holding a ~60-day grant there would
+// mean holding something a deletion request structurally cannot reach. The short-lived token
+// expires on its own within the hour, with no code involved — that is what makes the pending
+// state self-limiting.
 
-import { configService } from '@auxx/credentials'
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq, isNull, sql } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import { onCacheEvent } from '../cache'
-import type { PostConnectHook, PostConnectHookContext } from '../connections/post-connect-hooks'
-import { resolveConnectionForRuntime } from '../connections/resolve-connection-for-runtime'
-import { ConflictError } from '../errors'
+import {
+  deleteSupersededPendingCredentials,
+  writePendingSelection,
+} from '../connections/pending-selection'
+import type {
+  PostConnectHook,
+  PostConnectHookContext,
+  PostConnectHookResult,
+} from '../connections/post-connect-hooks'
 import { publisher } from '../events'
 import { InboxService } from '../inboxes/inbox-service'
 import { setChannelTokens } from '../providers/channel-token-accessor'
 import {
-  SOCIAL_SUBSCRIBED_FIELDS,
-  subscribePageToApp as subscribePageToAppApi,
-} from '../providers/social/api'
+  exchangeForLongLived,
+  type FacebookPage,
+  fetchFacebookUserId,
+  fetchInstagramAccount,
+  fetchUserPages,
+  type InstagramAccount,
+} from '../providers/social/connect-api'
 import { assertSharedConnectInbox } from './connect-inbox'
+import {
+  type CachedSocialPage,
+  cacheAvailablePages,
+  resolveUserTokenForCredential,
+  type SocialIdentity,
+  type SocialProvider,
+  subscribePageToApp,
+  upsertSocialIntegration,
+} from './internal/social-integration'
+import {
+  findLiveSocialIntegrationForCredential,
+  SOCIAL_PAGE_SELECTION_KIND,
+  type SocialPageSelectionPayload,
+  selectSocialCandidates,
+} from './social-page-selection'
 
 const logger = createScopedLogger('social-provisioning-hook')
-
-const DEFAULT_API_VERSION = 'v26.0'
-
-type SocialProvider = 'facebook' | 'instagram'
 
 const PROVIDER_BY_KEY: Record<string, SocialProvider> = {
   facebook: 'facebook',
   instagram: 'instagram',
 }
 
-interface FacebookPage {
-  id: string
-  name: string
-  access_token: string
-  /** Expanded in the same `/me/accounts` call — one extra field, no extra request. */
-  instagram_business_account?: { id?: string; username?: string }
-}
+/** Re-exported: `CachedSocialPage` was defined here before the phase split. */
+export type { CachedSocialPage } from './internal/social-integration'
 
-/**
- * A page the connecting user administers, trimmed to what a picker needs.
- *
- * Cached on the CREDENTIAL, not the Integration: it describes the OAuth grant
- * (what this token can reach), not one channel. Auto-select-first stays for v1 —
- * the user can already steer it from Facebook's own "choose pages" consent step —
- * but caching the full list is what makes a real picker, or "add another channel
- * from this connection", possible later without a second OAuth round trip.
- *
- * Deliberately does NOT include page access tokens: those live encrypted on the
- * credential, and a plaintext copy in a metadata blob is a credential leak waiting
- * to be logged.
- */
-export interface CachedSocialPage {
-  id: string
-  name: string
-  igBusinessAccountId?: string
-  igUsername?: string
-}
-
-interface InstagramAccount {
-  id: string
-  username: string
-}
-
-/** The connected Page (+ optional linked IG account) plus its long-lived page token. */
-interface SocialIdentity {
-  pageId: string
-  pageName: string
-  longLivedPageToken: string
+/** Everything one OAuth grant can reach, resolved once and shared by both branches. */
+interface SocialGrant {
   longLivedUserToken: string
-  /**
-   * The connecting user's app-scoped id (ASID). Required, not optional: it is the ONLY
-   * join key Meta's data-deletion / deauthorize callback gives us, so a channel stored
-   * without it can never be matched to a deletion request. `discoverIdentity` refuses to
-   * return an identity without one — see `fetchFacebookUserId`.
-   */
   facebookUserId: string
-  /** Every page this grant can reach — cached for a future picker (see CachedSocialPage). */
+  pages: FacebookPage[]
   availablePages: CachedSocialPage[]
-  instagramAccountId?: string
-  instagramUsername?: string
-}
-
-function apiVersion(): string {
-  try {
-    return configService.get<string>('FACEBOOK_GRAPH_API_VERSION') || DEFAULT_API_VERSION
-  } catch {
-    return DEFAULT_API_VERSION
-  }
-}
-
-/** Platform Facebook app client (v1 uses the platform app only — no per-org BYO client). */
-function facebookClient(): { clientId: string; clientSecret: string } {
-  const clientId = configService.get<string>('FACEBOOK_APP_ID') || ''
-  const clientSecret = configService.get<string>('FACEBOOK_APP_SECRET') || ''
-  if (!clientId || !clientSecret) {
-    throw new Error(
-      'Facebook app credentials (FACEBOOK_APP_ID / FACEBOOK_APP_SECRET) not configured'
-    )
-  }
-  return { clientId, clientSecret }
-}
-
-/** Resolve the just-committed credential's access token (the short-lived Facebook user token). */
-async function resolveUserToken(ctx: PostConnectHookContext): Promise<string> {
-  const resolved = await resolveConnectionForRuntime({
-    connectionId: ctx.credentialId,
-    organizationId: ctx.organizationId,
-    userId: ctx.userId,
-    ensureFresh: true,
-  })
-  if (resolved.isErr()) {
-    throw new Error(`Failed to resolve social channel token: ${resolved.error.message}`)
-  }
-  const conn = resolved.value.organizationConnection ?? resolved.value.userConnection
-  if (!conn?.value) throw new Error('Social credential resolved without an access token')
-  return conn.value
-}
-
-/** Exchange a short-lived token for a long-lived one (`fb_exchange_token`). Returns input on failure. */
-async function exchangeForLongLived(shortToken: string): Promise<string> {
-  const { clientId, clientSecret } = facebookClient()
-  const url = `https://graph.facebook.com/${apiVersion()}/oauth/access_token`
-  const params = new URLSearchParams({
-    grant_type: 'fb_exchange_token',
-    client_id: clientId,
-    client_secret: clientSecret,
-    fb_exchange_token: shortToken,
-  })
-  try {
-    const res = await fetch(`${url}?${params.toString()}`)
-    const data = await res.json()
-    if (!res.ok || !data.access_token) {
-      logger.warn('Long-lived token exchange failed; using short-lived token', {
-        error: data.error?.message,
-      })
-      return shortToken
-    }
-    return data.access_token as string
-  } catch (error) {
-    logger.warn('Long-lived token exchange errored; using short-lived token', {
-      error: error instanceof Error ? error.message : String(error),
-    })
-    return shortToken
-  }
 }
 
 /**
- * The connecting user's app-scoped id (ASID) — `GET /me?fields=id`.
+ * Read the whole grant: long-lived user token, ASID, and every managed Page.
  *
- * Throws rather than returning undefined. Meta's data-deletion and deauthorize callbacks
- * POST a `signed_request` whose payload carries `user_id` and nothing else — no page id,
- * no email, no org — so `Integration.metadata.userId` is the only thing that can resolve
- * a callback to a channel. Swallowing a transient Graph failure here used to provision a
- * channel with no `userId`, permanently invisible to that callback: we would hand Meta a
- * confirmation code while the user's tokens sat untouched in `Credential`. A retryable
- * connect error is the far better failure, so this is fatal to the connect.
+ * Order is load-bearing and unchanged: `exchangeForLongLived` → `fetchFacebookUserId` (still
+ * FATAL, still before anything is written) → `fetchUserPages` → the empty-pages throw. The ASID
+ * failure must precede any write, including the pending marker, so a connect that cannot be
+ * matched to a Meta deletion request leaves nothing behind at all.
  */
-async function fetchFacebookUserId(token: string): Promise<string> {
-  let data: { id?: string; error?: { message?: string } } = {}
-  try {
-    const res = await fetch(
-      `https://graph.facebook.com/${apiVersion()}/me?fields=id&access_token=${token}`
-    )
-    data = await res.json()
-  } catch (error) {
-    data = { error: { message: error instanceof Error ? error.message : String(error) } }
-  }
-  if (!data?.id) {
-    throw new Error(
-      `Could not retrieve your Facebook account: ${data?.error?.message ?? 'ensure permissions were granted'}. Please try connecting again.`
-    )
-  }
-  return data.id
-}
-
-/** Pages the user manages, each with its own page access token. */
-async function fetchUserPages(token: string): Promise<FacebookPage[]> {
-  const url = `https://graph.facebook.com/${apiVersion()}/me/accounts?fields=id,name,access_token,instagram_business_account{id,username}&access_token=${token}`
-  const res = await fetch(url)
-  const data = await res.json()
-  if (!res.ok || !Array.isArray(data.data)) {
-    throw new Error(
-      `Could not retrieve Facebook Pages: ${data.error?.message ?? 'ensure permissions were granted'}`
-    )
-  }
-  return data.data
-}
-
-/**
- * The Instagram Business Account linked to a Page, if any — the per-page probe.
- *
- * Only reached when `/me/accounts` did not already expand the field (it asks for
- * `instagram_business_account{id,username}` in the same request), so this is the
- * fallback, not the primary read. Failures are logged rather than swallowed
- * silently: a null here is indistinguishable from "no linked account", and that
- * ambiguity is exactly what produced a misleading "link the account" error.
- */
-async function fetchInstagramAccount(
-  pageId: string,
-  pageToken: string
-): Promise<InstagramAccount | null> {
-  try {
-    const url = `https://graph.facebook.com/${apiVersion()}/${pageId}?fields=instagram_business_account{id,username}&access_token=${pageToken}`
-    const res = await fetch(url)
-    const data = await res.json()
-    if (res.ok && data.instagram_business_account?.id) {
-      return {
-        id: data.instagram_business_account.id,
-        username: data.instagram_business_account.username,
-      }
-    }
-    if (!res.ok || data.error) {
-      logger.warn('Could not read instagram_business_account for a Page', {
-        pageId,
-        status: res.status,
-        code: data?.error?.code,
-        subcode: data?.error?.error_subcode,
-        error: data?.error?.message,
-      })
-    }
-    return null
-  } catch (error) {
-    logger.warn('instagram_business_account probe errored', {
-      pageId,
-      error: error instanceof Error ? error.message : String(error),
-    })
-    return null
-  }
-}
-
-/**
- * Discover the Page (and, for Instagram, its linked IG Business Account) and mint the
- * long-lived page token. v1 auto-selects the first matching Page (Facebook: the first page;
- * Instagram: the first page that has a linked IG account) — multi-page selection is deferred.
- *
- * Throws — and so aborts the connect — if the Facebook user id cannot be resolved, before any
- * Integration row is written. Every identity this returns therefore carries a `facebookUserId`,
- * which is what makes the resulting channel reachable by Meta's data-deletion callback.
- */
-async function discoverIdentity(
-  provider: SocialProvider,
-  userToken: string
-): Promise<SocialIdentity> {
+async function fetchGrant(userToken: string): Promise<SocialGrant> {
   const longLivedUserToken = await exchangeForLongLived(userToken)
   const facebookUserId = await fetchFacebookUserId(longLivedUserToken)
   const pages = await fetchUserPages(longLivedUserToken)
@@ -263,342 +100,221 @@ async function discoverIdentity(
       'No Facebook Pages found. Ensure a Page is managed and permissions were granted.'
     )
   }
-
   const availablePages: CachedSocialPage[] = pages.map((page) => ({
     id: page.id,
     name: page.name,
     igBusinessAccountId: page.instagram_business_account?.id,
     igUsername: page.instagram_business_account?.username,
   }))
-
-  if (provider === 'facebook') {
-    const page = pages[0]!
-    const longLivedPageToken = await exchangeForLongLived(page.access_token)
-    return {
-      pageId: page.id,
-      pageName: page.name,
-      longLivedPageToken,
-      longLivedUserToken,
-      facebookUserId,
-      availablePages,
-    }
-  }
-
-  // Instagram: pick the first Page with a linked Instagram Business Account.
-  //
-  // `/me/accounts` already expanded `instagram_business_account{id,username}`, so
-  // read that first and only probe the Page node when it is absent. The probe used
-  // to run unconditionally: N extra Graph round trips per connect, and — because it
-  // returns null on any failure — a transient error was reported to the user as
-  // "no linked Instagram account", which is a different problem with a different fix.
-  for (const page of pages) {
-    const igAccount: InstagramAccount | null = page.instagram_business_account?.id
-      ? {
-          id: page.instagram_business_account.id,
-          username: page.instagram_business_account.username ?? '',
-        }
-      : await fetchInstagramAccount(page.id, page.access_token)
-    if (igAccount) {
-      const longLivedPageToken = await exchangeForLongLived(page.access_token)
-      return {
-        pageId: page.id,
-        pageName: page.name,
-        longLivedPageToken,
-        longLivedUserToken,
-        facebookUserId,
-        availablePages,
-        instagramAccountId: igAccount.id,
-        instagramUsername: igAccount.username,
-      }
-    }
-  }
-  // Deliberately names BOTH causes. An absent `instagram_business_account` does not
-  // prove there is no linked account: Graph omits a permission-gated field rather
-  // than erroring, so a grant without `instagram_basic` answers exactly like a Page
-  // with nothing linked. The Instagram scopes are only requestable once the app's
-  // Instagram use case is configured for "API setup with Facebook login" — until
-  // then the login dialog rejects them as invalid and this is what the user sees.
-  throw new Error(
-    `No linked Instagram Professional account was found on any of the ${pages.length} managed ` +
-      `Facebook Page(s) (${pages.map((page) => page.name).join(', ')}). Either no Instagram ` +
-      'Professional account is linked to the Page, or the connection was granted without the ' +
-      'instagram_basic permission — in which case Graph hides the link rather than reporting it.'
-  )
+  return { longLivedUserToken, facebookUserId, pages, availablePages }
 }
 
-/** Subscribe the Page to the app's webhook (the social analogue of arming Gmail watch). */
-async function subscribePageToApp(
-  provider: SocialProvider,
-  pageId: string,
-  pageToken: string
-): Promise<void> {
-  const subscribedFields =
-    provider === 'instagram'
-      ? SOCIAL_SUBSCRIBED_FIELDS.instagram
-      : SOCIAL_SUBSCRIBED_FIELDS.facebook
-  try {
-    await subscribePageToAppApi(pageId, pageToken, subscribedFields)
-    logger.info('Page subscribed to app webhook', { pageId, provider, subscribedFields })
-  } catch (error) {
-    // Swallowed on purpose: a failed subscription means real-time delivery is off,
-    // but the channel is otherwise connected and `recoverChannel` re-arms it. A
-    // throw here would abort provisioning after the Integration row already exists.
-    logger.error('Error subscribing Page to app webhook — real-time messages may not arrive', {
-      pageId,
-      provider,
-      error: error instanceof Error ? error.message : String(error),
-    })
-  }
-}
-
-/**
- * Postgres unique_violation (SQLSTATE 23505) raised by
- * `Integration_provider_webhookRouteKey_key` — the unique partial index on
- * `(provider, webhookRouteKey)` among live rows.
- *
- * Drizzle wraps the raw `pg` error (which carries `.code` / `.constraint`) in a
- * `DrizzleQueryError` and hangs the original off `.cause`, so both spots are checked.
- * The constraint name is checked too: `Integration` carries other unique indexes
- * (`(organizationId, provider, email)`), and only this one means "someone else owns
- * this Page".
- */
-function isRouteKeyConflict(error: unknown): boolean {
-  const chain = [error, (error as { cause?: unknown })?.cause]
-  return chain.some((node) => {
-    const e = node as { code?: string; constraint?: string } | undefined
-    return e?.code === '23505' && e?.constraint === 'Integration_provider_webhookRouteKey_key'
-  })
-}
-
-/**
- * The connect-time failure a duplicate Page produces, phrased for the person who just
- * clicked Connect and will see this string in the OAuth popup.
- *
- * Before `webhookRouteKey` was adopted the second org connected happily and then split
- * that Page's inbound DMs between two tenants at random — the unique index turns that
- * silent mis-delivery into this error, which is the whole point of WS17.
- */
-function duplicateRouteKeyError(provider: SocialProvider, displayName: string): ConflictError {
-  const subject =
-    provider === 'instagram'
-      ? `The Instagram account “${displayName}”`
-      : `The Facebook Page “${displayName}”`
-  return new ConflictError(
-    `${subject} is already connected to another Auxx organization. A Page can only deliver ` +
-      'its messages to one organization — disconnect it there first, then connect it here.'
-  )
-}
-
-/**
- * Create the Integration row, or relink the credential onto the existing one (reauth / reconnect).
- * Social channels are matched by the Page id (Facebook) or Instagram Business Account id
- * (Instagram) carried in metadata, not by the email column (which stays null).
- */
-async function upsertSocialIntegration(args: {
-  organizationId: string
-  provider: SocialProvider
-  credentialId: string
-  identity: SocialIdentity
-}): Promise<{ id: string; isNew: boolean; displayName: string }> {
-  const { organizationId, provider, credentialId, identity } = args
-  const matchId = provider === 'instagram' ? identity.instagramAccountId! : identity.pageId
-  const displayName =
-    provider === 'instagram' ? (identity.instagramUsername ?? identity.pageName) : identity.pageName
-
-  const metadata: Record<string, unknown> = {
-    pageId: identity.pageId,
-    pageName: identity.pageName,
-    userId: identity.facebookUserId,
-    ...(provider === 'instagram' && {
-      instagramBusinessAccountId: identity.instagramAccountId,
-      instagramUsername: identity.instagramUsername,
+/** Build the identity for one chosen Page, including its long-lived page token. */
+async function buildIdentity(
+  grant: SocialGrant,
+  page: FacebookPage,
+  instagram?: { id: string; username: string }
+): Promise<SocialIdentity> {
+  const longLivedPageToken = await exchangeForLongLived(page.access_token)
+  return {
+    pageId: page.id,
+    pageName: page.name,
+    longLivedPageToken,
+    longLivedUserToken: grant.longLivedUserToken,
+    facebookUserId: grant.facebookUserId,
+    availablePages: grant.availablePages,
+    ...(instagram && {
+      instagramAccountId: instagram.id,
+      instagramUsername: instagram.username,
     }),
   }
+}
 
-  // Match on the page/IG id inside the jsonb metadata (no clean drizzle json-path filter), so
-  // reauth/reconnect relinks the existing row instead of inserting a duplicate.
-  const rows = await db
-    .select({ id: schema.Integration.id, metadata: schema.Integration.metadata })
-    .from(schema.Integration)
-    .where(
-      and(
-        eq(schema.Integration.organizationId, organizationId),
-        eq(schema.Integration.provider, provider),
-        // Disconnect is a SOFT delete. Without this, a reconnect after disconnect
-        // relinks the tombstoned row: the connect reports success, the Integration
-        // is updated, and the channel never appears anywhere — every list path
-        // filters `deletedAt`. Both sibling hooks document this exact failure.
-        isNull(schema.Integration.deletedAt)
-      )
-    )
-  const existing =
-    rows.find((r) => {
-      const m = r.metadata as Record<string, unknown> | null
-      const id = provider === 'instagram' ? m?.instagramBusinessAccountId : m?.pageId
-      return id === matchId
-    }) ?? null
-
-  if (existing) {
-    // jsonb MERGE, never replace. `backfillCutoffAt` / `initialBackfillCompletedAt`
-    // and any `settings` live in this same blob, and a wholesale `.set({ metadata })`
-    // on reconnect would wipe them — reopening a suppression window that has already
-    // closed, or dropping the channel's record-creation settings. Same rule
-    // `quo-channel.ts` documents at its own upsert.
-    const metadataJson = JSON.stringify(metadata)
-    try {
-      await db
-        .update(schema.Integration)
-        .set({
-          credentialId,
-          enabled: true,
-          name: displayName,
-          // The inbound routing index. Same value as the metadata id above — this is an
-          // index, not a migration of truth; the jsonb keys stay and are read for plenty
-          // besides routing. Written on relink too, because a revoke nulls the column
-          // while leaving the row alive, so a reconnect has to re-claim it.
-          webhookRouteKey: matchId,
-          metadata: sql`COALESCE(${schema.Integration.metadata}, '{}'::jsonb) || ${metadataJson}::jsonb`,
-          updatedAt: new Date(),
-        })
-        .where(eq(schema.Integration.id, existing.id))
-    } catch (error) {
-      if (isRouteKeyConflict(error)) throw duplicateRouteKeyError(provider, displayName)
-      throw error
+/** Resolve the IG account for ONE page: the expanded field first, the per-page probe second. */
+async function resolveInstagramFor(page: FacebookPage): Promise<InstagramAccount | undefined> {
+  if (page.instagram_business_account?.id) {
+    return {
+      id: page.instagram_business_account.id,
+      username: page.instagram_business_account.username ?? '',
     }
-    return { id: existing.id, isNew: false, displayName }
   }
-
-  let created: { id: string } | undefined
-  try {
-    ;[created] = await db
-      .insert(schema.Integration)
-      .values({
-        organizationId,
-        provider,
-        credentialId,
-        enabled: true,
-        // Persisted, not just emitted on the `integration:connected` event — this is
-        // what every channel surface reads to label the row. Without it FB/IG render
-        // as a bare "Facebook Integration" with no page name anywhere.
-        name: displayName,
-        // The inbound routing index — what both webhook routes resolve a delivery on.
-        // Its unique partial index across live rows is what makes "the same Page in two
-        // organizations" unrepresentable instead of a silent 50/50 message split.
-        webhookRouteKey: matchId,
-        // Received-time trigger cutoff, stamped at the connect epoch and ONLY on a
-        // first connect (a reconnect must not reopen a window that already closed).
-        // Consumed by both providers' `initialize()` via `setBackfillCutoff`, so a
-        // history backfill stores messages without firing `message:received` for
-        // them. Lifted by `initialBackfillCompletedAt` when the capped backfill
-        // (WS7) finishes; until that exists the window stays open, which is the
-        // safe direction — live inbound still fires, only history stays silent.
-        metadata: { ...metadata, backfillCutoffAt: new Date().toISOString() } as any,
-        updatedAt: new Date(),
-      })
-      .returning({ id: schema.Integration.id })
-  } catch (error) {
-    if (isRouteKeyConflict(error)) throw duplicateRouteKeyError(provider, displayName)
-    throw error
-  }
-  return { id: created!.id, isNew: true, displayName }
+  return (await fetchInstagramAccount(page.id, page.access_token)) ?? undefined
 }
 
 /**
- * Cache the trimmed page list on the credential.
+ * Turn one chosen Page into a channel — the tail both the single-candidate connect and the
+ * forced reconnect run.
  *
- * jsonb MERGE under a `meta` key so this cannot clobber whatever else the
- * credential's metadata carries (OAuth bookkeeping written by the connections
- * layer), and best-effort: a channel that connected fine must not fail
- * provisioning because a convenience cache could not be written.
+ * Deliberately the SAME body phase two runs (`provisionSocialChannel`): token swap → Integration
+ * upsert → inbox link → page cache → webhook → publish. Two copies of this is how the zero-click
+ * path and the picker path would drift.
  */
-async function cacheAvailablePages(credentialId: string, pages: CachedSocialPage[]): Promise<void> {
-  try {
-    const metaJson = JSON.stringify({ meta: { pages, cachedAt: new Date().toISOString() } })
-    await db
-      .update(schema.Credential)
-      .set({
-        metadata: sql`COALESCE(${schema.Credential.metadata}, '{}'::jsonb) || ${metaJson}::jsonb`,
-      })
-      .where(eq(schema.Credential.id, credentialId))
-  } catch (error) {
-    logger.warn('Failed to cache available pages on the credential', {
-      credentialId,
-      error: error instanceof Error ? error.message : String(error),
-    })
+async function provisionChosenPage(
+  ctx: PostConnectHookContext,
+  provider: SocialProvider,
+  grant: SocialGrant,
+  page: FacebookPage,
+  instagram?: InstagramAccount
+): Promise<void> {
+  const identity = await buildIdentity(grant, page, instagram)
+
+  const integration = await upsertSocialIntegration({
+    organizationId: ctx.organizationId,
+    provider,
+    credentialId: ctx.credentialId,
+    identity,
+  })
+
+  // Swap the credential's stored token from the Facebook USER token to the long-lived PAGE token
+  // (the working channel token). The user token rides along as the "refresh" slot for revoke.
+  // Long-lived page tokens have no refresh grant → expiresAt null (no scanner refresh).
+  await setChannelTokens(
+    integration.id,
+    {
+      accessToken: identity.longLivedPageToken,
+      refreshToken: identity.longLivedUserToken,
+      expiresAt: null,
+    },
+    { createdById: ctx.userId }
+  )
+
+  // Inbox-first (channels v2): a new (or legacy unlinked) channel REQUIRES a validated shared
+  // inbox chosen up-front (forwarded via `pc_inboxId` → `ctx.extra.inboxId`); a reconnect of an
+  // already-linked channel keeps its link and ignores the param.
+  const existingLink = await db.query.InboxIntegration.findFirst({
+    where: eq(schema.InboxIntegration.integrationId, integration.id),
+  })
+  if (!existingLink) {
+    const recordId = await assertSharedConnectInbox(
+      db,
+      ctx.organizationId,
+      ctx.extra?.inboxId as string | undefined
+    )
+    await new InboxService(db, ctx.organizationId, ctx.userId).addIntegration(
+      recordId,
+      integration.id
+    )
   }
+
+  await cacheAvailablePages(ctx.credentialId, identity.availablePages)
+
+  await subscribePageToApp(provider, identity.pageId, identity.longLivedPageToken)
+
+  await onCacheEvent('channel.connected', { orgId: ctx.organizationId })
+
+  await publisher.publishLater({
+    type: 'integration:connected',
+    data: {
+      organizationId: ctx.organizationId,
+      userId: ctx.userId,
+      provider,
+      identifier: integration.displayName,
+      integrationId: integration.id,
+    },
+  })
+
+  logger.info('Social channel provisioned', {
+    integrationId: integration.id,
+    provider,
+    pageId: identity.pageId,
+    isNew: integration.isNew,
+  })
 }
 
 /** The social channel post-connect hook — handles `facebook` and `instagram`. */
 export const socialProvisioningHook: PostConnectHook = {
   providerKeys: ['facebook', 'instagram'],
-  async run(ctx: PostConnectHookContext): Promise<void> {
+  async run(ctx: PostConnectHookContext): Promise<void | PostConnectHookResult> {
     const provider = PROVIDER_BY_KEY[ctx.providerKey]
     if (!provider) {
       logger.warn('No social provider mapping for key', { providerKey: ctx.providerKey })
       return
     }
 
-    const userToken = await resolveUserToken(ctx)
-    const identity = await discoverIdentity(provider, userToken)
-
-    const integration = await upsertSocialIntegration({
-      organizationId: ctx.organizationId,
-      provider,
+    const userToken = await resolveUserTokenForCredential({
       credentialId: ctx.credentialId,
-      identity,
+      organizationId: ctx.organizationId,
+      userId: ctx.userId,
     })
+    const grant = await fetchGrant(userToken)
 
-    // Swap the credential's stored token from the Facebook USER token to the long-lived PAGE token
-    // (the working channel token). The user token rides along as the "refresh" slot for revoke.
-    // Long-lived page tokens have no refresh grant → expiresAt null (no scanner refresh).
-    await setChannelTokens(
-      integration.id,
-      {
-        accessToken: identity.longLivedPageToken,
-        refreshToken: identity.longLivedUserToken,
-        expiresAt: null,
-      },
-      { createdById: ctx.userId }
-    )
+    // A full-OAuth reconnect of a LIVE channel must relink the Page it already has, never show a
+    // picker: a mis-click there would move a live channel onto a different Page or collide with
+    // the `webhookRouteKey` unique index. Checked BEFORE candidate selection, so a reconnect
+    // never pays for the Instagram probe fallback over pages it is not going to use.
+    //
+    // The rule keys on the INTEGRATION and NOT on `ctx.connectionId`: re-authing a *pending*
+    // credential also arrives with `connectionId` set, has no Integration, and must legitimately
+    // get the picker again. `isNull(deletedAt)` inside the lookup is what keeps a reconnect
+    // after disconnect a fresh connect.
+    const bound = await findLiveSocialIntegrationForCredential(ctx.credentialId, provider)
+    if (bound?.pageId) {
+      const forcedPage = grant.pages.find((page) => page.id === bound.pageId)
+      if (!forcedPage) {
+        throw new Error(
+          `The Page “${bound.pageName ?? bound.pageId}” this channel is connected to is not ` +
+            'available on this Facebook account. Grant it on the Facebook consent screen and try ' +
+            'again, or disconnect the channel and connect a different Page.'
+        )
+      }
+      const forcedInstagram =
+        provider === 'instagram' ? await resolveInstagramFor(forcedPage) : undefined
+      if (provider === 'instagram' && !forcedInstagram) {
+        throw new Error(
+          `The Facebook Page “${forcedPage.name}” no longer has a linked Instagram ` +
+            'Professional account. Re-link it in Meta Business Suite and try again.'
+        )
+      }
+      await provisionChosenPage(ctx, provider, grant, forcedPage, forcedInstagram)
+      return
+    }
 
-    // Inbox-first (channels v2): a new (or legacy unlinked) channel REQUIRES a validated
-    // shared inbox chosen up-front (forwarded via `pc_inboxId` → `ctx.extra.inboxId`); a
-    // reconnect of an already-linked channel keeps its link and ignores the param.
-    const existingLink = await db.query.InboxIntegration.findFirst({
-      where: eq(schema.InboxIntegration.integrationId, integration.id),
-    })
-    if (!existingLink) {
-      const recordId = await assertSharedConnectInbox(
+    const { candidates, instagramByPageId } = await selectSocialCandidates(provider, grant.pages)
+    const chosen = candidates.length === 1 ? candidates[0]! : null
+
+    if (!chosen) {
+      // PICKER PATH — validate the inbox first so a bad one fails here rather than after the
+      // user has picked, park the marker, and hand the choice to the UI. Nothing is provisioned.
+      const inboxRecordId = await assertSharedConnectInbox(
         db,
         ctx.organizationId,
         ctx.extra?.inboxId as string | undefined
       )
-      const inboxService = new InboxService(db, ctx.organizationId, ctx.userId)
-      await inboxService.addIntegration(recordId, integration.id)
-    }
 
-    await cacheAvailablePages(ctx.credentialId, identity.availablePages)
-
-    await subscribePageToApp(provider, identity.pageId, identity.longLivedPageToken)
-
-    await onCacheEvent('channel.connected', { orgId: ctx.organizationId })
-
-    await publisher.publishLater({
-      type: 'integration:connected',
-      data: {
+      // Repeated abandoned connects would otherwise accumulate orphan credentials, because
+      // `saveConnection` with no `connectionId` always INSERTs. Caps them at one per
+      // (org, provider, user).
+      await deleteSupersededPendingCredentials({
         organizationId: ctx.organizationId,
         userId: ctx.userId,
-        provider,
-        identifier: integration.displayName,
-        integrationId: integration.id,
-      },
-    })
+        providerKey: ctx.providerKey,
+        keepCredentialId: ctx.credentialId,
+      })
 
-    logger.info('Social channel provisioned', {
-      integrationId: integration.id,
-      provider,
-      pageId: identity.pageId,
-      isNew: integration.isNew,
-    })
+      const payload: SocialPageSelectionPayload = {
+        provider,
+        inboxRecordId,
+        facebookUserId: grant.facebookUserId,
+        candidateIds: candidates.map((page) => page.id),
+        pages: grant.availablePages,
+      }
+      await writePendingSelection<SocialPageSelectionPayload>(
+        ctx.credentialId,
+        ctx.organizationId,
+        { kind: SOCIAL_PAGE_SELECTION_KIND, providerKey: ctx.providerKey, payload }
+      )
+      await cacheAvailablePages(ctx.credentialId, grant.availablePages)
+
+      logger.info('Social connect awaiting a page selection', {
+        credentialId: ctx.credentialId,
+        provider,
+        candidates: candidates.length,
+        pages: grant.pages.length,
+      })
+      return { awaiting: { kind: SOCIAL_PAGE_SELECTION_KIND, credentialId: ctx.credentialId } }
+    }
+
+    // ZERO-CLICK PATH — one candidate, nothing to ask.
+    await provisionChosenPage(ctx, provider, grant, chosen, instagramByPageId.get(chosen.id))
   },
 }

--- a/packages/lib/src/connections/__tests__/pending-selection.test.ts
+++ b/packages/lib/src/connections/__tests__/pending-selection.test.ts
@@ -1,0 +1,183 @@
+// packages/lib/src/connections/__tests__/pending-selection.test.ts
+//
+// The pending-marker envelope. These assert on RENDERED SQL for the two writes, deliberately.
+//
+// The whole §4.4 design rests on one property: our writes MERGE into `Credential.metadata` rather
+// than replacing it, because the OAuth bookkeeping the connections layer writes and the providers'
+// own caches (`metadata.meta.pages`, `metadata.quo`) live in the same blob. A `.set({ metadata })`
+// that looked correct in TypeScript would silently erase all of it, and no runtime assertion on a
+// mocked driver would notice. Rendering the SQL is what makes the difference visible.
+//
+// The reverse guarantee does NOT hold and is not asserted here: `saveConnection` REPLACES the blob
+// on an OAuth mint, so the marker survives only because the post-connect hook runs after it.
+
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const captured: { sets: unknown[]; selects: unknown[] } = { sets: [], selects: [] }
+
+/** Rows the next `select()` chain resolves to. */
+let selectRows: Array<Record<string, unknown>> = []
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+// The REAL schema barrel (pure Drizzle, no connection) so the rendered SQL names real columns,
+// paired with a hand-rolled `database` that records what it was handed.
+vi.mock('@auxx/database', async () => {
+  const schema = await import('../../../../database/src/db/schema/index')
+  const selectChain = () => {
+    const chain: Record<string, unknown> = {}
+    for (const key of ['from', 'where', 'orderBy']) chain[key] = () => chain
+    chain.limit = async () => selectRows
+    // Awaited without `.limit()` (findPendingSelectionForUser ends on `.limit`, but keep both).
+    chain.then = (resolve: (rows: unknown) => unknown) => resolve(selectRows)
+    return chain
+  }
+  const updateChain = () => {
+    const chain: Record<string, unknown> = {}
+    chain.set = (values: unknown) => {
+      captured.sets.push(values)
+      return chain
+    }
+    chain.where = async () => undefined
+    return chain
+  }
+  return {
+    schema,
+    database: {
+      select: () => selectChain(),
+      update: () => updateChain(),
+      query: { Integration: { findFirst: vi.fn(async () => undefined) } },
+    },
+  }
+})
+
+const {
+  writePendingSelection,
+  readPendingSelection,
+  findPendingSelectionForUser,
+  clearPendingSelection,
+} = await import('../pending-selection')
+
+const dialect = new PgDialect()
+const renderLastSet = () => {
+  const values = captured.sets.at(-1) as { metadata?: unknown }
+  return dialect.sqlToQuery(values?.metadata as never)
+}
+
+const ORG = 'org_1'
+const CRED = 'cred_1'
+const USER = 'usr_1'
+
+const marker = {
+  kind: 'social-page-selection' as const,
+  providerKey: 'facebook',
+  payload: { provider: 'facebook', candidateIds: ['page-1', 'page-2'] },
+}
+
+beforeEach(() => {
+  captured.sets = []
+  captured.selects = []
+  selectRows = []
+})
+
+describe('writePendingSelection', () => {
+  it('MERGES into the existing metadata instead of replacing it', async () => {
+    await writePendingSelection(CRED, ORG, marker)
+
+    const { sql } = renderLastSet()
+    // `COALESCE(metadata,'{}') || $json` — the `||` is the whole point. A plain assignment here
+    // would drop `metadata.meta.pages` and every OAuth bookkeeping key on the row.
+    expect(sql).toContain('COALESCE')
+    expect(sql).toContain('||')
+    expect(sql).toContain('"metadata"')
+  })
+
+  it('stamps createdAt when the caller does not supply one', async () => {
+    await writePendingSelection(CRED, ORG, marker)
+
+    const { params } = renderLastSet()
+    const json = params.map(String).find((value) => value.includes('pendingSelection'))
+    expect(json).toBeTruthy()
+    const parsed = JSON.parse(json!)
+    expect(parsed.pendingSelection.kind).toBe('social-page-selection')
+    // The sort key `findPendingSelectionForUser` orders on — an unstamped marker would sort last
+    // forever and lose to any older one.
+    expect(typeof parsed.pendingSelection.createdAt).toBe('string')
+  })
+})
+
+describe('clearPendingSelection', () => {
+  it('removes ONLY the pendingSelection key', async () => {
+    await clearPendingSelection(CRED, ORG)
+
+    const { sql, params } = renderLastSet()
+    // `jsonb - text` deletes one top-level key. A `.set({ metadata: {} })` would take the rest
+    // of the blob with it.
+    expect(sql).toContain('COALESCE')
+    expect(sql).toMatch(/- \$\d+::text/)
+    expect(params).toEqual(['pendingSelection'])
+  })
+})
+
+describe('readPendingSelection', () => {
+  it('reads a well-formed marker back', async () => {
+    selectRows = [
+      { metadata: { pendingSelection: { ...marker, createdAt: '2026-08-18T00:00:00.000Z' } } },
+    ]
+
+    const result = await readPendingSelection(CRED, ORG)
+
+    expect(result).toMatchObject({ kind: 'social-page-selection', providerKey: 'facebook' })
+  })
+
+  it('answers null — never an error — for a credential in another org', async () => {
+    // The org predicate is the AUTHORIZATION boundary here, not a filter: `credentialId` arrives
+    // from the client. A foreign id simply matches no row.
+    selectRows = []
+
+    await expect(readPendingSelection(CRED, 'org_other')).resolves.toBeNull()
+  })
+
+  it('answers null for a credential that has no marker', async () => {
+    selectRows = [{ metadata: { meta: { pages: [] } } }]
+
+    await expect(readPendingSelection(CRED, ORG)).resolves.toBeNull()
+  })
+})
+
+describe('findPendingSelectionForUser', () => {
+  it('returns the row and its credential id', async () => {
+    selectRows = [
+      {
+        id: CRED,
+        metadata: { pendingSelection: { ...marker, createdAt: '2026-08-18T00:00:00.000Z' } },
+      },
+    ]
+
+    const found = await findPendingSelectionForUser(ORG, USER)
+
+    expect(found).toMatchObject({ credentialId: CRED })
+  })
+
+  it('skips rows whose marker is malformed rather than returning a broken one', async () => {
+    selectRows = [{ id: 'cred_bad', metadata: { pendingSelection: { kind: 'x' } } }]
+
+    await expect(findPendingSelectionForUser(ORG, USER)).resolves.toBeNull()
+  })
+
+  it('filters by kind when asked', async () => {
+    selectRows = [
+      {
+        id: CRED,
+        metadata: { pendingSelection: { ...marker, createdAt: '2026-08-18T00:00:00.000Z' } },
+      },
+    ]
+
+    await expect(
+      findPendingSelectionForUser(ORG, USER, ['social-page-selection'])
+    ).resolves.toMatchObject({ credentialId: CRED })
+  })
+})

--- a/packages/lib/src/connections/index.ts
+++ b/packages/lib/src/connections/index.ts
@@ -37,8 +37,19 @@ export {
   resolveHostedProvisionHandler,
 } from './hosted-provision'
 export {
+  clearPendingSelection,
+  deleteSupersededPendingCredentials,
+  findPendingSelectionForUser,
+  type PendingConnectSelection,
+  type PendingSelectionKind,
+  type PendingSelectionRow,
+  readPendingSelection,
+  writePendingSelection,
+} from './pending-selection'
+export {
   type PostConnectHook,
   type PostConnectHookContext,
+  type PostConnectHookResult,
   registerPostConnectHook,
   runPostConnectHook,
 } from './post-connect-hooks'

--- a/packages/lib/src/connections/pending-selection.ts
+++ b/packages/lib/src/connections/pending-selection.ts
@@ -1,0 +1,247 @@
+// packages/lib/src/connections/pending-selection.ts
+// A connect that cannot finish without a user choice, parked on the Credential.
+//
+// Some providers grant access to MORE than the one thing we provision — a Facebook grant
+// reaches every Page the user administers, and only one of them becomes the channel. When the
+// list is only knowable AFTER the OAuth hop (unlike Quo, where the API key is pasted into a form
+// and the numbers are listed before anything commits), the post-connect hook has to stop short of
+// provisioning and leave a marker saying what it is waiting on. This module owns that marker and
+// nothing else: no Graph calls, no Integration, no channels.
+//
+// The envelope is kind-agnostic; the payload is not. `kind` is the discriminator every resume
+// path dispatches on, so a second provider is a union member and a `switch` arm rather than a
+// reshape of the storage, the hook result, or the resume query.
+//
+// ⚠️ ORDERING, load-bearing. `saveConnection` REPLACES `Credential.metadata` wholesale on an
+// OAuth mint (`updateCredential` does `set.metadata = input.metadata`, not a jsonb merge), and the
+// OAuth callback runs it BEFORE `runPostConnectHook`. The merge below therefore protects us from
+// everything except that one write, which we survive purely by running after it. A marker written
+// before `saveConnection` would be silently erased.
+
+import { database as db, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, sql } from 'drizzle-orm'
+
+const logger = createScopedLogger('pending-selection')
+
+/** The jsonb key on `Credential.metadata`. Top-level on purpose — see the module note. */
+const METADATA_KEY = 'pendingSelection'
+
+/**
+ * What the connect is waiting on. One member today.
+ *
+ * Add a member rather than widening to `string`: the resume query and the picker dialog both
+ * switch on this, and an open string type turns a missing arm into a silent no-picker dead end.
+ */
+export type PendingSelectionKind = 'social-page-selection'
+
+/** A connect parked mid-flight, waiting for the user to choose which resource to provision. */
+export interface PendingConnectSelection<T = unknown> {
+  kind: PendingSelectionKind
+  /** Provider blueprint key the credential was minted for (`facebook`, `instagram`, …). */
+  providerKey: string
+  /** Kind-specific body. Opaque here — never narrowed in this module. */
+  payload: T
+  /** ISO stamp, also the sort key for `findPendingSelectionForUser`. */
+  createdAt: string
+}
+
+/** One pending marker plus the credential it sits on. */
+export interface PendingSelectionRow<T = unknown> {
+  credentialId: string
+  selection: PendingConnectSelection<T>
+}
+
+function parseSelection<T>(metadata: unknown): PendingConnectSelection<T> | null {
+  const blob = (metadata as Record<string, unknown> | null)?.[METADATA_KEY]
+  if (!blob || typeof blob !== 'object') return null
+  const candidate = blob as Partial<PendingConnectSelection<T>>
+  if (!candidate.kind || !candidate.payload) return null
+  return candidate as PendingConnectSelection<T>
+}
+
+/**
+ * Park a pending selection on a credential.
+ *
+ * jsonb MERGE, never replace: the connections layer's OAuth bookkeeping and the providers' own
+ * caches (`metadata.meta.pages`, `metadata.quo`) live in this same blob.
+ */
+export async function writePendingSelection<T>(
+  credentialId: string,
+  organizationId: string,
+  selection: Omit<PendingConnectSelection<T>, 'createdAt'> & { createdAt?: string }
+): Promise<void> {
+  const stored: PendingConnectSelection<T> = {
+    ...selection,
+    createdAt: selection.createdAt ?? new Date().toISOString(),
+  }
+  const json = JSON.stringify({ [METADATA_KEY]: stored })
+  await db
+    .update(schema.Credential)
+    .set({
+      metadata: sql`COALESCE(${schema.Credential.metadata}, '{}'::jsonb) || ${json}::jsonb`,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(schema.Credential.id, credentialId),
+        eq(schema.Credential.organizationId, organizationId)
+      )
+    )
+}
+
+/**
+ * Read a credential's pending marker back.
+ *
+ * Org-scoped on purpose: `credentialId` arrives from the client, so the org predicate is the
+ * authorization boundary and not a filter. A credential from another org, a missing row, or a
+ * credential with no marker all read as `null` — never an error, matching the contract
+ * `readCachedQuoNumbers` documents.
+ */
+export async function readPendingSelection<T>(
+  credentialId: string,
+  organizationId: string
+): Promise<PendingConnectSelection<T> | null> {
+  const [row] = await db
+    .select({ metadata: schema.Credential.metadata })
+    .from(schema.Credential)
+    .where(
+      and(
+        eq(schema.Credential.id, credentialId),
+        eq(schema.Credential.organizationId, organizationId)
+      )
+    )
+    .limit(1)
+  return row ? parseSelection<T>(row.metadata) : null
+}
+
+/**
+ * The newest pending marker belonging to one user in one org, if any.
+ *
+ * Scoped to `createdById` as well as the org: the person who ran the OAuth is the person who
+ * finishes it, because the grant (and the app-scoped user id we stamp from it) is theirs.
+ * Sorted on the marker's own `createdAt` rather than a row timestamp — `Credential.updatedAt`
+ * moves for token refreshes and cache writes, which have nothing to do with connect recency.
+ */
+export async function findPendingSelectionForUser<T>(
+  organizationId: string,
+  userId: string,
+  kinds?: PendingSelectionKind[]
+): Promise<PendingSelectionRow<T> | null> {
+  const rows = await db
+    .select({ id: schema.Credential.id, metadata: schema.Credential.metadata })
+    .from(schema.Credential)
+    .where(
+      and(
+        eq(schema.Credential.organizationId, organizationId),
+        eq(schema.Credential.createdById, userId),
+        sql`${schema.Credential.metadata} -> ${METADATA_KEY}::text IS NOT NULL`
+      )
+    )
+    .orderBy(sql`${schema.Credential.metadata} -> ${METADATA_KEY}::text ->> 'createdAt' DESC`)
+    .limit(10)
+
+  for (const row of rows) {
+    const selection = parseSelection<T>(row.metadata)
+    if (!selection) continue
+    if (kinds && !kinds.includes(selection.kind)) continue
+    return { credentialId: row.id, selection }
+  }
+  return null
+}
+
+/**
+ * Drop the marker, leaving every other key in the blob intact (`#-` removes one path).
+ *
+ * Called when the selection is answered. Not called when the user cancels the picker: the
+ * marker is what makes "reload and finish later" work, and the short-lived token it sits beside
+ * expires on its own within the hour.
+ */
+export async function clearPendingSelection(
+  credentialId: string,
+  organizationId: string
+): Promise<void> {
+  await db
+    .update(schema.Credential)
+    .set({
+      // `jsonb - text` removes one top-level key and leaves the rest of the blob alone.
+      metadata: sql`COALESCE(${schema.Credential.metadata}, '{}'::jsonb) - ${METADATA_KEY}::text`,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(schema.Credential.id, credentialId),
+        eq(schema.Credential.organizationId, organizationId)
+      )
+    )
+}
+
+/**
+ * Delete this user's other pending credentials for the same provider, so abandoned connects
+ * cannot accumulate.
+ *
+ * `saveConnection` with no `connectionId` always INSERTs, so a user who starts the picker three
+ * times leaves three credentials behind. A pending credential is safe to delete by definition:
+ * nothing references it (there is no Integration — that is what "pending" means) and the
+ * short-lived token it holds is dying anyway. Caps the orphan count at one per
+ * (org, provider, user).
+ *
+ * Best-effort: a cleanup failure must never fail the connect that triggered it.
+ */
+export async function deleteSupersededPendingCredentials(args: {
+  organizationId: string
+  userId: string
+  providerKey: string
+  /** The credential being connected right now — never deleted. */
+  keepCredentialId: string
+}): Promise<void> {
+  const { organizationId, userId, providerKey, keepCredentialId } = args
+  try {
+    const rows = await db
+      .select({ id: schema.Credential.id, metadata: schema.Credential.metadata })
+      .from(schema.Credential)
+      .where(
+        and(
+          eq(schema.Credential.organizationId, organizationId),
+          eq(schema.Credential.createdById, userId),
+          eq(schema.Credential.type, providerKey),
+          sql`${schema.Credential.metadata} -> ${METADATA_KEY}::text IS NOT NULL`
+        )
+      )
+
+    const stale = rows.filter((row) => row.id !== keepCredentialId && parseSelection(row.metadata))
+    if (stale.length === 0) return
+
+    // Belt and braces: only delete rows nothing points at. A pending credential has no
+    // Integration by construction, so a hit here means our own invariant broke — skip it
+    // rather than cascade a live channel's credential away.
+    const { deleteCredential } = await import('@auxx/credentials/store')
+    for (const row of stale) {
+      const referenced = await db.query.Integration.findFirst({
+        where: eq(schema.Integration.credentialId, row.id),
+        columns: { id: true },
+      })
+      if (referenced) {
+        logger.warn('Pending credential is referenced by an Integration — not deleting', {
+          credentialId: row.id,
+        })
+        continue
+      }
+      const deleted = await deleteCredential(row.id, organizationId)
+      if (deleted.isErr()) {
+        logger.warn('Could not delete superseded pending credential', {
+          credentialId: row.id,
+          error: deleted.error.message,
+        })
+        continue
+      }
+      logger.info('Deleted superseded pending credential', { credentialId: row.id, providerKey })
+    }
+  } catch (error) {
+    logger.warn('Failed to clean up superseded pending credentials', {
+      organizationId,
+      providerKey,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/packages/lib/src/connections/post-connect-hooks.ts
+++ b/packages/lib/src/connections/post-connect-hooks.ts
@@ -6,6 +6,7 @@
 // registered for the provider — most platform providers are "just a Credential".
 
 import { createScopedLogger } from '@auxx/logger'
+import type { PendingSelectionKind } from './pending-selection'
 
 const logger = createScopedLogger('post-connect-hooks')
 
@@ -28,10 +29,28 @@ export interface PostConnectHookContext {
   extra?: Record<string, unknown>
 }
 
+/**
+ * What a hook reports back when it could NOT finish the connect on its own.
+ *
+ * `undefined` (or a hook that returns nothing) means "provisioned, done" — the shape every
+ * existing hook already satisfies, which is why widening the return type edits no hook body.
+ */
+export interface PostConnectHookResult {
+  /**
+   * The connect stopped short of provisioning and needs a user choice to finish. The user's
+   * answer is collected by a domain-specific mutation; this only names WHAT is outstanding.
+   *
+   * Typed as `PendingSelectionKind` rather than an inline literal so a second waiting provider
+   * is a union member instead of a signature change rippling through the OAuth callback, the
+   * popup payload, and the connect flow.
+   */
+  awaiting?: { kind: PendingSelectionKind; credentialId: string }
+}
+
 export interface PostConnectHook {
   /** Provider keys this hook handles. */
   providerKeys: string[]
-  run(ctx: PostConnectHookContext): Promise<void>
+  run(ctx: PostConnectHookContext): Promise<void | PostConnectHookResult>
 }
 
 const registry = new Map<string, PostConnectHook>()
@@ -43,13 +62,18 @@ export function registerPostConnectHook(hook: PostConnectHook): void {
   }
 }
 
-/** Run the hook registered for `providerKey`, if any. No-op otherwise. */
+/**
+ * Run the hook registered for `providerKey`, if any. No-op (and `undefined`) otherwise.
+ *
+ * A result carrying `awaiting` means the credential is committed but nothing was provisioned —
+ * the caller must not report the connect as finished. See `pending-selection.ts`.
+ */
 export async function runPostConnectHook(
   providerKey: string,
   ctx: PostConnectHookContext
-): Promise<void> {
+): Promise<PostConnectHookResult | undefined> {
   const hook = registry.get(providerKey)
-  if (!hook) return
+  if (!hook) return undefined
   logger.info('Running post-connect hook', { providerKey, credentialId: ctx.credentialId })
-  await hook.run(ctx)
+  return (await hook.run(ctx)) ?? undefined
 }

--- a/packages/lib/src/providers/social/connect-api.ts
+++ b/packages/lib/src/providers/social/connect-api.ts
@@ -1,0 +1,164 @@
+// packages/lib/src/providers/social/connect-api.ts
+// The Graph calls a CONNECT makes, before there is a channel: exchange the short-lived user
+// token, resolve the connecting user's app-scoped id, list their Pages, probe a Page's linked
+// Instagram account.
+//
+// Sits beside `api.ts` rather than inside it, deliberately and temporarily. `api.ts` routes
+// everything through `graphRequest`, which throws `GraphApiError` (an `AuxxError` carrying
+// `code`/`error_subcode`) and never logs a token-bearing URL — it is the better implementation,
+// and `listPages` / `getPageIgAccount` here are near-duplicates of the two reads below.
+//
+// ⚠️ Consolidating onto them CHANGES USER-VISIBLE ERROR STRINGS on the connect path, which is the
+// exact path a Meta App Review reviewer exercises. These bodies were moved here verbatim from the
+// provisioning hook and their message text must stay byte-identical until that consolidation is
+// done as its own change. See plans/channels/facebook-page-picker.md §7.
+
+import { configService } from '@auxx/credentials'
+import { createScopedLogger } from '@auxx/logger'
+import { graphApiVersion } from './api'
+
+const logger = createScopedLogger('social-connect-api')
+
+/** A Page from `/me/accounts`, with the page token the connect needs. */
+export interface FacebookPage {
+  id: string
+  name: string
+  access_token: string
+  /** Expanded in the same `/me/accounts` call — one extra field, no extra request. */
+  instagram_business_account?: { id?: string; username?: string }
+}
+
+export interface InstagramAccount {
+  id: string
+  username: string
+}
+
+/** Platform Facebook app client (v1 uses the platform app only — no per-org BYO client). */
+function facebookClient(): { clientId: string; clientSecret: string } {
+  const clientId = configService.get<string>('FACEBOOK_APP_ID') || ''
+  const clientSecret = configService.get<string>('FACEBOOK_APP_SECRET') || ''
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      'Facebook app credentials (FACEBOOK_APP_ID / FACEBOOK_APP_SECRET) not configured'
+    )
+  }
+  return { clientId, clientSecret }
+}
+
+/**
+ * Exchange a short-lived token for a long-lived one (`fb_exchange_token`).
+ *
+ * Returns the INPUT token on failure rather than throwing: a connect that cannot upgrade its
+ * token still works, just for an hour instead of ~60 days, and failing the whole connect over a
+ * lifetime extension would be the worse trade.
+ */
+export async function exchangeForLongLived(shortToken: string): Promise<string> {
+  const { clientId, clientSecret } = facebookClient()
+  const url = `https://graph.facebook.com/${graphApiVersion()}/oauth/access_token`
+  const params = new URLSearchParams({
+    grant_type: 'fb_exchange_token',
+    client_id: clientId,
+    client_secret: clientSecret,
+    fb_exchange_token: shortToken,
+  })
+  try {
+    const res = await fetch(`${url}?${params.toString()}`)
+    const data = await res.json()
+    if (!res.ok || !data.access_token) {
+      logger.warn('Long-lived token exchange failed; using short-lived token', {
+        error: data.error?.message,
+      })
+      return shortToken
+    }
+    return data.access_token as string
+  } catch (error) {
+    logger.warn('Long-lived token exchange errored; using short-lived token', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return shortToken
+  }
+}
+
+/**
+ * The connecting user's app-scoped id (ASID) — `GET /me?fields=id`.
+ *
+ * Throws rather than returning undefined. Meta's data-deletion and deauthorize callbacks POST a
+ * `signed_request` whose payload carries `user_id` and nothing else — no page id, no email, no
+ * org — so `Integration.metadata.userId` is the only thing that can resolve a callback to a
+ * channel. Swallowing a transient Graph failure here used to provision a channel with no
+ * `userId`, permanently invisible to that callback: we would hand Meta a confirmation code while
+ * the user's tokens sat untouched in `Credential`. A retryable connect error is the far better
+ * failure, so this is fatal to the connect.
+ */
+export async function fetchFacebookUserId(token: string): Promise<string> {
+  let data: { id?: string; error?: { message?: string } } = {}
+  try {
+    const res = await fetch(
+      `https://graph.facebook.com/${graphApiVersion()}/me?fields=id&access_token=${token}`
+    )
+    data = await res.json()
+  } catch (error) {
+    data = { error: { message: error instanceof Error ? error.message : String(error) } }
+  }
+  if (!data?.id) {
+    throw new Error(
+      `Could not retrieve your Facebook account: ${data?.error?.message ?? 'ensure permissions were granted'}. Please try connecting again.`
+    )
+  }
+  return data.id
+}
+
+/** Pages the user manages, each with its own page access token. */
+export async function fetchUserPages(token: string): Promise<FacebookPage[]> {
+  const url = `https://graph.facebook.com/${graphApiVersion()}/me/accounts?fields=id,name,access_token,instagram_business_account{id,username}&access_token=${token}`
+  const res = await fetch(url)
+  const data = await res.json()
+  if (!res.ok || !Array.isArray(data.data)) {
+    throw new Error(
+      `Could not retrieve Facebook Pages: ${data.error?.message ?? 'ensure permissions were granted'}`
+    )
+  }
+  return data.data
+}
+
+/**
+ * The Instagram Business Account linked to a Page, if any — the per-page probe.
+ *
+ * Only reached when `/me/accounts` did not already expand the field (it asks for
+ * `instagram_business_account{id,username}` in the same request), so this is the fallback, not
+ * the primary read. Failures are logged rather than swallowed silently: a null here is
+ * indistinguishable from "no linked account", and that ambiguity is exactly what produced a
+ * misleading "link the account" error.
+ */
+export async function fetchInstagramAccount(
+  pageId: string,
+  pageToken: string
+): Promise<InstagramAccount | null> {
+  try {
+    const url = `https://graph.facebook.com/${graphApiVersion()}/${pageId}?fields=instagram_business_account{id,username}&access_token=${pageToken}`
+    const res = await fetch(url)
+    const data = await res.json()
+    if (res.ok && data.instagram_business_account?.id) {
+      return {
+        id: data.instagram_business_account.id,
+        username: data.instagram_business_account.username,
+      }
+    }
+    if (!res.ok || data.error) {
+      logger.warn('Could not read instagram_business_account for a Page', {
+        pageId,
+        status: res.status,
+        code: data?.error?.code,
+        subcode: data?.error?.error_subcode,
+        error: data?.error?.message,
+      })
+    }
+    return null
+  } catch (error) {
+    logger.warn('instagram_business_account probe errored', {
+      pageId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}


### PR DESCRIPTION
## The problem

`social-provisioning-hook.ts` did `const page = pages[0]!`. `/me/accounts` returns **every** Page the connecting user administers and Graph documents no ordering, so a business running several Pages got an arbitrary one — silently, with no UI showing what was discarded or letting them change it.

Changing it afterwards is not a settings edit: `disconnect()` **hard-deletes** the channel's threads and messages, and `Integration.webhookRouteKey` is uniquely indexed across live rows. So the choice has to be made before the channel exists.

Separately, `pages_show_list` is one of nine permissions in the App Review submission, and the only evidence for it today is Facebook's own consent screen. A rendered list of the user's Pages is the direct evidence.

## What ships

A two-phase connect, **gated on genuine ambiguity**:

- **0 or 1 candidate Page** → provisions exactly as before. Zero extra clicks, which is most orgs.
- **2+ candidates** → the hook parks a pending marker and returns `awaiting`. **No Integration, no page token, no webhook subscription, no `integration:connected` event.** A picker dialog finishes the connect through `channel.selectSocialPage`.

Deliberately the same model the Quo channel already ships — one connection, N provisioned things — applied to a provider whose selection step falls *after* the OAuth hop instead of before it.

## Design notes worth reviewing

**The marker is protected by ordering, not by its merge.** It lives at top-level `Credential.metadata.pendingSelection` as a `{ kind, providerKey, payload }` envelope, written with a jsonb `||` merge. But that guarantee is one-directional: `saveConnection` **replaces** the whole metadata blob on an OAuth mint (`updateCredential` does `set.metadata = input.metadata`), and the callback runs it *before* `runPostConnectHook`. The marker survives purely because the hook runs after. Never hoist that write.

**Resumption is a server query, not the popup message.** `useOAuthPopup` settles on whichever arrives first, and for a platform connect the default `verify` is `connections.list` — where the credential appears as soon as `saveConnection` commits, i.e. *before the hook has run*. So the verify poll can win and settle with the payload never read. `channel.pendingConnectSelection` is the authority; `awaiting` is a latency hint. Every abandonment path converges on the query: popup blocked → redirect, COOP severed, tab closed, reload mid-pick.

**A reconnect forces the bound Page — and the rule keys on the Integration, not on `connectionId`.** Re-authing a *pending* credential also arrives with `connectionId` set, has no Integration, and must legitimately get the picker again (its marker was just wiped by the metadata replace above). Keying on `connectionId` would dead-end that user with no marker and no picker. `isNull(deletedAt)` is what keeps a reconnect-after-disconnect a fresh connect.

**The pending window keeps the SHORT-LIVED user token, on purpose.** Phase one computes a long-lived token in memory but does not persist it. A pending credential has no Integration, so it is invisible *in principle* to Meta's data-deletion callback, which joins on `Integration.metadata->>'userId'` — persisting a ~60-day grant there would mean holding something a deletion request structurally cannot reach. The short-lived token dies within the hour with no code involved, which is what makes the pending state self-limiting. Abandoned credentials are additionally capped at one per (org, provider, user).

**Only what needs to be generic, is.** The marker key, the hook result `kind`, the resume query's option shape, the dialog, and `provisionSocialChannel`'s signature are kind-agnostic — each was cheap now and migration-shaped later. The candidate rules, Graph calls, forced-page rule and the provisioning mutation stay concrete: a registry of selection kinds with one member is the premature half. Aliases (Gmail/Outlook), Quo numbers, and app connections were each checked and do **not** belong on this path; the reasoning is in the plan.

## Behaviour change to be aware of

The Instagram candidate rule changes which Page a **single-outcome** connect resolves to in one narrow case. Previously the loop probed pages in order and took the first hit, so an unexpanded `pages[0]` with a linked account beat an expanded `pages[1]`. Now the expanded set wins (or the picker appears). This is a fix, but it is a change, and it lands during an App Review window.

The per-page probe still only runs when *nothing* came back expanded — asserted by call count, not by outcome.

## Refactor included

The connect-time Graph calls moved to `providers/social/connect-api.ts`, beside the rest of the Graph surface. They had been sitting in the channels layer with a duplicated `graphApiVersion()`. `channels/internal/social-integration.ts` keeps only what touches our tables (Integration upsert + route-key conflict mapping, page cache, credential token resolution).

`connect-api.ts` stays separate from `api.ts` rather than merging into `graphRequest` **only** because that changes user-visible error strings on the connect path — the exact path a Meta reviewer walks. Its header says so; consolidate it deliberately, as its own change, after submission.

## Testing

- 32 new tests: 13 hook (candidate gating, forced reconnect, pending re-auth, Instagram rules), 10 phase two (stale-cache guard, ordering, expired session, explicit-inbox entry point), 9 marker envelope (rendered SQL pins the merge and the single-key delete).
- Full `channels` + `connections` suites: 220/220.
- `packages/lib` and `apps/web` typecheck clean on every touched path.
- The two pre-existing ASID compliance tests are untouched, plus a new one asserting the ASID throw still precedes the pending write — the picker is not an escape hatch from that invariant.

Not yet done: the multi-Page manual rehearsal on a real Facebook account. That is the run that de-risks the screencast and should happen before filming.
