### PR TITLE
fix(channels): defer channel media deletion to the cleanup job

### DIFF
--- a/packages/lib/src/channels/disconnect.ts
+++ b/packages/lib/src/channels/disconnect.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/channels/disconnect.ts
 
 import { type Database, schema, type Transaction } from '@auxx/database'
-import { and, eq, inArray, isNotNull, sql } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import { clearImportCache } from '../email/polling-import-cache'
 import type { NotFoundError } from '../errors'
 import { enqueueStorageCleanupJob } from '../jobs/maintenance/storage-cleanup-job'
@@ -20,10 +20,19 @@ const logger = createScopedLogger('channels.disconnect')
 type DbHandle = Database | Transaction
 
 /**
- * Delete threads + messages for a channel, clean up MediaAssets, and mark
- * StorageLocations for async S3 deletion. Exported for the personal-inbox
- * delete path (§11.4), which destroys channel data without the ownership
- * validation `disconnect` performs (its integration is already soft-deleted).
+ * Mark a channel's data for destruction and drop its threads.
+ *
+ * Deliberately does NOT hard-delete media. Attachment assets carry derived rows
+ * (thumbnails are their own `MediaAsset`, linked back through
+ * `MediaAssetVersion.derivedFromVersionId`, a self-FK with NO ACTION on delete), so a
+ * `DELETE` here can raise 23503 and take the whole disconnect with it — leaving the
+ * channel permanently undisconnectable. Everything below is set-based and UPDATE-only
+ * apart from the thread delete, which cascades cleanly. The destructive half runs in
+ * `storageCleanupJob`, where it is batched and retryable.
+ *
+ * Exported for the personal-inbox delete path (§11.4), which destroys channel data
+ * without the ownership validation `disconnect` performs (its integration is already
+ * soft-deleted).
  */
 export async function deleteChannelData(tx: DbHandle, channelId: string, provider: string) {
   logger.warn(`Deleting data for channel: ${channelId} (${provider})`)
@@ -41,67 +50,58 @@ export async function deleteChannelData(tx: DbHandle, channelId: string, provide
     return
   }
 
-  const messageRows = await tx
-    .select({ id: schema.Message.id })
-    .from(schema.Message)
-    .where(eq(schema.Message.integrationId, channelId))
-  const messageIds = messageRows.map((r) => r.id)
-  logger.info(`Found ${messageIds.length} messages for channel ${channelId}`)
+  // Email body blobs. Nothing else points at these StorageLocations once the messages
+  // below are gone, so marking them here is safe to sweep whenever the job runs.
+  await tx
+    .update(schema.StorageLocation)
+    .set({ deletedAt: new Date() })
+    .where(
+      sql`${schema.StorageLocation.id} IN (
+        SELECT ${schema.Message.htmlBodyStorageLocationId}
+        FROM ${schema.Message}
+        WHERE ${schema.Message.integrationId} = ${channelId}
+        AND ${schema.Message.htmlBodyStorageLocationId} IS NOT NULL
+      )`
+    )
 
-  if (messageIds.length > 0) {
-    const assetRows = await tx
-      .selectDistinct({ assetId: schema.Attachment.assetId })
-      .from(schema.Attachment)
-      .where(
-        and(
-          eq(schema.Attachment.entityType, 'MESSAGE'),
-          inArray(schema.Attachment.entityId, messageIds),
-          isNotNull(schema.Attachment.assetId)
-        )
-      )
-    const mediaAssetIds = assetRows.map((r) => r.assetId).filter(Boolean) as string[]
-    logger.info(`Found ${mediaAssetIds.length} MediaAssets for channel ${channelId}`)
+  // Soft-delete the attachment assets while the `Message` rows they hang off still
+  // exist — this is the last moment the join is available. The job purges them for
+  // real; until then the markers keep them off read paths, and a soft-deleted source
+  // version is exactly what `cleanupOrphanedThumbnails` treats as orphaned, so the
+  // nightly reaper is a free backstop if the job never lands.
+  const channelAssetIds = sql`(
+    SELECT a."assetId"
+    FROM ${schema.Attachment} a
+    JOIN ${schema.Message} m ON m."id" = a."entityId"
+    WHERE a."entityType" = 'MESSAGE'
+      AND a."assetId" IS NOT NULL
+      AND m."integrationId" = ${channelId}
+  )`
 
-    // Mark email body StorageLocations as deleted
-    await tx
-      .update(schema.StorageLocation)
-      .set({ deletedAt: new Date() })
-      .where(
-        sql`${schema.StorageLocation.id} IN (
-          SELECT ${schema.Message.htmlBodyStorageLocationId}
-          FROM ${schema.Message}
-          WHERE ${schema.Message.integrationId} = ${channelId}
-          AND ${schema.Message.htmlBodyStorageLocationId} IS NOT NULL
-        )`
-      )
+  await tx
+    .update(schema.MediaAssetVersion)
+    .set({ deletedAt: new Date() })
+    .where(
+      sql`${schema.MediaAssetVersion.assetId} IN ${channelAssetIds} AND ${schema.MediaAssetVersion.deletedAt} IS NULL`
+    )
 
-    // Mark attachment StorageLocations as deleted (via MediaAssetVersion)
-    if (mediaAssetIds.length > 0) {
-      await tx
-        .update(schema.StorageLocation)
-        .set({ deletedAt: new Date() })
-        .where(
-          sql`${schema.StorageLocation.id} IN (
-            SELECT ${schema.MediaAssetVersion.storageLocationId}
-            FROM ${schema.MediaAssetVersion}
-            WHERE ${schema.MediaAssetVersion.assetId} IN (${sql.join(
-              mediaAssetIds.map((id) => sql`${id}`),
-              sql`, `
-            )})
-            AND ${schema.MediaAssetVersion.storageLocationId} IS NOT NULL
-          )`
-        )
+  await tx
+    .update(schema.MediaAsset)
+    .set({ deletedAt: new Date(), updatedAt: new Date() })
+    .where(
+      sql`${schema.MediaAsset.id} IN ${channelAssetIds} AND ${schema.MediaAsset.deletedAt} IS NULL`
+    )
 
-      await tx.delete(schema.MediaAsset).where(inArray(schema.MediaAsset.id, mediaAssetIds))
-      logger.info(`Deleted ${mediaAssetIds.length} MediaAssets for channel ${channelId}`)
-    }
-  }
-
-  await tx.delete(schema.Message).where(eq(schema.Message.integrationId, channelId))
-  logger.info(`Deleted messages for channel ${channelId}`)
-
+  // One statement: `Message`, `ThreadEvent`, `MessageParticipant`, `ThreadParticipant`,
+  // `LabelsOnThread`, `Draft`, `ScheduledMessage`, `ThreadExternalKey`, `ThreadReadStatus`
+  // and `EmailEmbedding` all cascade off `Thread`. Deleting messages first would only
+  // churn `Thread.latestMessageId` (SET NULL) on the way out.
+  //
+  // 🔴 Stays synchronous. `Thread` has no soft-delete column and no mail list path
+  // filters on `Integration.deletedAt`, so deferring this leaves disconnected mail
+  // sitting in the inbox until the worker catches up.
   await tx.delete(schema.Thread).where(eq(schema.Thread.integrationId, channelId))
-  logger.info(`Deleted threads for channel ${channelId}`)
+  logger.info(`Deleted threads for channel ${channelId}, media marked for async purge`)
 }
 
 /**

--- a/packages/lib/src/jobs/maintenance/storage-cleanup-job.ts
+++ b/packages/lib/src/jobs/maintenance/storage-cleanup-job.ts
@@ -19,6 +19,7 @@ export interface StorageCleanupJobData {
 }
 
 interface CleanupResult {
+  mediaAssetsPurged: number
   storageLocationsDeleted: number
   s3ObjectsDeleted: number
   redisKeysCleared: number
@@ -46,6 +47,7 @@ export async function storageCleanupJob(
   })
 
   const result: CleanupResult = {
+    mediaAssetsPurged: 0,
     storageLocationsDeleted: 0,
     s3ObjectsDeleted: 0,
     redisKeysCleared: 0,
@@ -54,6 +56,27 @@ export async function storageCleanupJob(
   }
 
   try {
+    // Phase 0: Purge media left behind by deleted messages.
+    //
+    // 🔴 Must run BEFORE the StorageLocation sweep. `MediaAssetVersion.storageLocationId`
+    // is ON DELETE CASCADE, so hard-deleting a StorageLocation first cascade-deletes the
+    // version while `MediaAsset.currentVersionId` (NO ACTION) still points at it — 23503.
+    await ctx.updateProgress(5)
+    try {
+      await purgeDanglingMessageAssets(organizationId, result)
+    } catch (error) {
+      // Never fail the job here. An asset can be pinned by a non-Attachment FK
+      // (`Document.mediaAssetId`, KB/ChatWidget logos — all NO ACTION), and one poison
+      // batch must not wedge the S3 sweep, Redis cleanup and Integration hard-delete
+      // behind it. The nightly thumbnail reaper is the backstop for derived rows.
+      const message = error instanceof Error ? error.message : String(error)
+      logger.warn('Dangling media purge failed, continuing cleanup', {
+        organizationId,
+        error: message,
+      })
+      result.errors.push(`Media purge failed: ${message}`)
+    }
+
     // Phase 1: Delete S3 objects for marked StorageLocations
     await ctx.updateProgress(10)
     await deleteMarkedStorageLocations(organizationId, result)
@@ -102,6 +125,124 @@ export async function storageCleanupJob(
     })
     throw error
   }
+}
+
+const ASSET_PURGE_BATCH = 500
+const ASSET_PURGE_MAX_ROUNDS = 100
+
+/**
+ * Hard-delete the MediaAssets whose only tie to anything was a message that no longer
+ * exists — the destructive half of `deleteChannelData`.
+ *
+ * Work is derived from live table state rather than the job payload, so this is
+ * idempotent across retries and also reaps orphans left by earlier disconnects.
+ *
+ * Two constraints shape the queries:
+ *
+ * 1. An asset is only purgeable if EVERY `Attachment` row pointing at it is a dangling
+ *    MESSAGE row. Attachments are polymorphic (`entityId` is not an FK), so a row of any
+ *    other `entityType` is conservatively treated as still live — as is a
+ *    `temp-message-%` placeholder, which is an OPEN COMPOSER holding an upload whose
+ *    message does not exist yet (`use-composer-attachments.ts:50`). Reading those as
+ *    dangling would delete an attachment out from under someone mid-send.
+ * 2. Thumbnails are their own `MediaAsset`, tied to the source only by
+ *    `MediaAssetVersion.derivedFromVersionId` — a self-FK with NO ACTION on delete. They
+ *    have no `Attachment` row of their own, so query 1 never sees them, and deleting a
+ *    source without them raises 23503. `expandDerivedAssets` pulls in that closure so the
+ *    whole set goes in ONE statement, where NO ACTION is checked at statement end with
+ *    every referencing row already gone.
+ */
+async function purgeDanglingMessageAssets(
+  organizationId: string,
+  result: CleanupResult
+): Promise<void> {
+  for (let round = 0; round < ASSET_PURGE_MAX_ROUNDS; round++) {
+    const dangling = await db.execute(sql`
+      SELECT DISTINCT a."assetId"
+      FROM ${schema.Attachment} a
+      WHERE a."organizationId" = ${organizationId}
+        AND a."entityType" = 'MESSAGE'
+        AND a."assetId" IS NOT NULL
+        AND a."entityId" NOT LIKE 'temp-message-%'
+        AND NOT EXISTS (SELECT 1 FROM ${schema.Message} m WHERE m."id" = a."entityId")
+        AND NOT EXISTS (
+          SELECT 1
+          FROM ${schema.Attachment} o
+          WHERE o."assetId" = a."assetId"
+            AND (
+              o."entityType" <> 'MESSAGE'
+              OR o."entityId" LIKE 'temp-message-%'
+              OR EXISTS (SELECT 1 FROM ${schema.Message} m2 WHERE m2."id" = o."entityId")
+            )
+        )
+      LIMIT ${ASSET_PURGE_BATCH}
+    `)
+
+    const seedIds = ((dangling.rows ?? []) as { assetId: string }[]).map((r) => r.assetId)
+    if (seedIds.length === 0) return
+
+    const assetIds = await expandDerivedAssets(seedIds)
+    const idList = sql.join(
+      assetIds.map((id) => sql`${id}`),
+      sql`, `
+    )
+
+    // Mark storage first — the delete below cascades the versions away, and an unmarked
+    // StorageLocation is an S3 object nothing will ever reap.
+    await db.execute(sql`
+      UPDATE ${schema.StorageLocation} SET "deletedAt" = now()
+      WHERE "deletedAt" IS NULL
+        AND "id" IN (
+          SELECT v."storageLocationId"
+          FROM ${schema.MediaAssetVersion} v
+          WHERE v."assetId" IN (${idList}) AND v."storageLocationId" IS NOT NULL
+        )
+    `)
+
+    await db.execute(sql`DELETE FROM ${schema.MediaAsset} WHERE "id" IN (${idList})`)
+    result.mediaAssetsPurged += assetIds.length
+
+    logger.info('Purged dangling message assets', {
+      organizationId,
+      seeds: seedIds.length,
+      withDerived: assetIds.length,
+      totalPurged: result.mediaAssetsPurged,
+    })
+
+    if (seedIds.length < ASSET_PURGE_BATCH) return
+  }
+
+  // Bounded so a batch that somehow deletes nothing cannot spin. The next disconnect —
+  // or the next org cleanup — picks up where this left off.
+  logger.warn('Dangling media purge hit its round cap, deferring the rest', {
+    organizationId,
+    purged: result.mediaAssetsPurged,
+  })
+}
+
+/**
+ * Expand a set of MediaAssets to include every asset derived from them, transitively.
+ */
+async function expandDerivedAssets(assetIds: string[]): Promise<string[]> {
+  const result = await db.execute(sql`
+    WITH RECURSIVE closure AS (
+      SELECT v."id", v."assetId"
+      FROM ${schema.MediaAssetVersion} v
+      WHERE v."assetId" IN (${sql.join(
+        assetIds.map((id) => sql`${id}`),
+        sql`, `
+      )})
+      UNION
+      SELECT c."id", c."assetId"
+      FROM ${schema.MediaAssetVersion} c
+      JOIN closure p ON c."derivedFromVersionId" = p."id"
+    )
+    SELECT DISTINCT "assetId" FROM closure
+  `)
+
+  const ids = new Set(assetIds)
+  for (const row of (result.rows ?? []) as { assetId: string }[]) ids.add(row.assetId)
+  return [...ids]
 }
 
 /**


### PR DESCRIPTION
## Problem

Disconnecting a channel whose attachments ever had a thumbnail generated failed with `23503`, and could never succeed on retry:

```
delete from "MediaAsset" where "MediaAsset"."id" in ($1 … $27)
  → violates foreign key constraint
    "MediaAssetVersion_derivedFromVersionId_MediaAssetVersion_id_fk"
```

A thumbnail is **not** a version of the source asset — it is its own `MediaAsset` (`kind: THUMBNAIL`, `purpose: DERIVED`) whose version links backwards through `MediaAssetVersion.derivedFromVersionId`, a self-FK with `NO ACTION` on delete. `deleteChannelData` collected assets by walking `Attachment` → `assetId`; a thumbnail has no `Attachment` row of its own, so it was never in the delete set and its surviving version still referenced a source version the cascade was removing.

Those rows are minted on demand by the attachment-thumbnail endpoint when the UI renders a preview — so **viewing** a thread was enough to make its channel undisconnectable.

The deeper problem is that the whole destructive sequence ran inside the request transaction: one failing statement failed the disconnect, permanently.

## Change

**`deleteChannelData` marks and hides only.** Soft-deletes the channel's attachment assets/versions while the `Attachment ⋈ Message` join is still available, then drops threads in one statement — `Message` (`threadId` is `NOT NULL`) and every thread child cascade off it. Set-based and `UPDATE`-only apart from that delete, so `23503` is unreachable in the request path.

**`storageCleanupJob` gains Phase 0.** Purges assets whose *every* `Attachment` row points at a message that no longer exists, expanding through `derivedFromVersionId` so the closure goes in one statement (`NO ACTION` is checked at statement end, when every referencing row is already gone). Work is derived from live table state rather than the job payload, so it is idempotent across retries and self-heals orphans left by earlier disconnects.

Thread deletion stays synchronous on purpose: `Thread` has no soft-delete column and no mail list path filters on `Integration.deletedAt`, so deferring it would leave disconnected mail sitting in the inbox until the worker caught up.

## Ordering constraint

Phase 0 **must** precede the existing StorageLocation sweep. `MediaAssetVersion.storageLocationId` is `ON DELETE CASCADE` and `MediaAsset.currentVersionId` is `NO ACTION`, so hard-deleting a StorageLocation first cascade-deletes the version out from under a live `currentVersionId` — the same violation, relocated into the worker. Commented at the call site.

## Guards

- **`temp-message-%` attachments count as live.** The composer uploads before a draft exists and keys the link row to a synthetic entity id, cleaned up on send by `discardTempAttachmentLinks`. Reading those as dangling would delete an attachment out from under an open composer.
- **Phase 0 is try/caught with a bounded loop.** An asset can be pinned by a non-`Attachment` FK (`Document.mediaAssetId`, KB/ChatWidget logos — all `NO ACTION`); a poison batch must not wedge the S3 sweep, Redis cleanup and Integration hard-delete behind it.

## Rejected alternatives

Changing the self-FK to `SET NULL` or `CASCADE` both look tidier and both leak S3. `cleanupOrphanedThumbnails` identifies orphans by `derivedFromVersionId IS NOT NULL AND NOT EXISTS(live source)` — nulling the column makes every thumbnail invisible to its own reaper; cascading kills the version but strands the `THUMBNAIL` asset and its unmarked `StorageLocation`.

No schema change, no migration.

## Verification

Rolled-back dry run against dev for the channel that reproduced it, then the real disconnect through the UI:

```
18.946  Deleting data for channel j2t9plbtpf5ruoxh390x54fx (facebook)
19.476  Deleted threads, media marked for async purge      ← 530ms, request done
19.482  Enqueued storage cleanup job
19.512  Purged dangling message assets  seeds:29 withDerived:32
23.242  Processed batch of marked StorageLocations  32
23.249  Hard-deleted Integration — job completed
```

Final result: `mediaAssetsPurged: 32, s3ObjectsDeleted: 32, storageLocationsDeleted: 32, integrationHardDeleted: true, errors: []`. The closure expansion earned its keep — 3 of those 32 were thumbnails that would each have thrown.

The 17 existing tests covering `deleteChannelData` (`delete-own-personal-inbox`, `personal-inbox-lifecycle`) pass; the personal-inbox delete path inherits the new behavior. No new test added — mocking the drizzle chain for `deleteChannelData` would assert the mock, not the FK behavior that was broken.

## Follow-ups (not in this PR)

- `packages/lib/src/files/lifecycle/cleanup-service.ts:99` hard-deletes assets one at a time and carries the identical FK hazard.
- `hardDeleteIntegration` swallows failures and `Sequence.integrationId` is `RESTRICT`, so a channel referenced by a sequence stays soft-deleted forever. Pre-existing.