### PR TITLE
fix(files): purge derived assets when deleting a MediaAsset

### DIFF
--- a/packages/lib/src/files/core/media-asset-purge.ts
+++ b/packages/lib/src/files/core/media-asset-purge.ts
@@ -1,0 +1,77 @@
+// packages/lib/src/files/core/media-asset-purge.ts
+
+import { type Database, schema, type Transaction } from '@auxx/database'
+import { sql } from 'drizzle-orm'
+
+type DbHandle = Database | Transaction
+
+/**
+ * Expand a set of MediaAssets to include every asset derived from them, transitively.
+ *
+ * A thumbnail or preview is its own `MediaAsset` (`kind: THUMBNAIL`, `purpose: DERIVED`),
+ * tied to its source only by `MediaAssetVersion.derivedFromVersionId` — a self-FK with
+ * `onUpdate: cascade` and no `onDelete`, i.e. NO ACTION. It carries no `Attachment` row,
+ * so nothing that walks attachments ever sees it, and deleting a source without it raises
+ * FK 23503.
+ */
+export async function expandDerivedAssetIds(db: DbHandle, assetIds: string[]): Promise<string[]> {
+  if (assetIds.length === 0) return []
+
+  const result = await db.execute(sql`
+    WITH RECURSIVE closure AS (
+      SELECT v."id", v."assetId"
+      FROM ${schema.MediaAssetVersion} v
+      WHERE v."assetId" IN (${sql.join(
+        assetIds.map((id) => sql`${id}`),
+        sql`, `
+      )})
+      UNION
+      SELECT c."id", c."assetId"
+      FROM ${schema.MediaAssetVersion} c
+      JOIN closure p ON c."derivedFromVersionId" = p."id"
+    )
+    SELECT DISTINCT "assetId" FROM closure
+  `)
+
+  const ids = new Set(assetIds)
+  for (const row of (result.rows ?? []) as { assetId: string }[]) ids.add(row.assetId)
+  return [...ids]
+}
+
+/**
+ * Hard-delete MediaAssets together with everything derived from them.
+ *
+ * 🔴 The whole closure goes in ONE statement. NO ACTION is checked at statement end, so a
+ * delete that covers both the referencing and referenced rows passes, while deleting the
+ * source alone — or paging the closure across statements — raises 23503.
+ *
+ * Storage is marked rather than deleted: `MediaAssetVersion.storageLocationId` is
+ * `ON DELETE CASCADE`, so the versions vanish with the assets and an unmarked
+ * `StorageLocation` becomes an S3 object nothing will ever reap. Callers that delete S3
+ * inline (see `cleanupAssetThumbnails`) just re-mark rows that are already gone.
+ *
+ * Returns the full set of purged asset ids, derived ones included.
+ */
+export async function purgeMediaAssets(db: DbHandle, assetIds: string[]): Promise<string[]> {
+  const closure = await expandDerivedAssetIds(db, assetIds)
+  if (closure.length === 0) return []
+
+  const idList = sql.join(
+    closure.map((id) => sql`${id}`),
+    sql`, `
+  )
+
+  await db.execute(sql`
+    UPDATE ${schema.StorageLocation} SET "deletedAt" = now()
+    WHERE "deletedAt" IS NULL
+      AND "id" IN (
+        SELECT v."storageLocationId"
+        FROM ${schema.MediaAssetVersion} v
+        WHERE v."assetId" IN (${idList}) AND v."storageLocationId" IS NOT NULL
+      )
+  `)
+
+  await db.execute(sql`DELETE FROM ${schema.MediaAsset} WHERE "id" IN (${idList})`)
+
+  return closure
+}

--- a/packages/lib/src/files/core/media-asset-service.ts
+++ b/packages/lib/src/files/core/media-asset-service.ts
@@ -26,6 +26,7 @@ import {
 import type { PgColumn } from 'drizzle-orm/pg-core'
 import type { DownloadRef } from '../adapters/base-adapter'
 import { BaseService, type DatabaseClient, defaultDatabase } from './base-service'
+import { purgeMediaAssets } from './media-asset-purge'
 import type { ContentAccessible } from './mixins/content-accessible'
 import type { Versioned } from './mixins/versioned'
 import type {
@@ -1406,6 +1407,21 @@ export class MediaAssetService
       this.db
     )
     await thumbnailService.deleteThumbnailsForSource(version.id)
+
+    // `deleteThumbnailsForSource` drops the S3 objects but only SOFT-deletes the rows,
+    // and a thumbnail is a separate MediaAsset pointing back here through
+    // `derivedFromVersionId` (NO ACTION) — so the version delete below would still be
+    // blocked by them. Purge the derived assets outright.
+    const derived = await this.db
+      .selectDistinct({ assetId: schema.MediaAssetVersion.assetId })
+      .from(schema.MediaAssetVersion)
+      .where(eq(schema.MediaAssetVersion.derivedFromVersionId, version.id))
+    if (derived.length > 0) {
+      await purgeMediaAssets(
+        this.db,
+        derived.map((d) => d.assetId)
+      )
+    }
 
     await this.db
       .delete(schema.MediaAssetVersion)

--- a/packages/lib/src/files/lifecycle/cleanup-service.ts
+++ b/packages/lib/src/files/lifecycle/cleanup-service.ts
@@ -5,6 +5,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { eq, exists, not, sql } from 'drizzle-orm'
 import { createAttachmentService } from '../core/attachment-service'
 import { createFileService } from '../core/file-service'
+import { purgeMediaAssets } from '../core/media-asset-purge'
 import { createMediaAssetService } from '../core/media-asset-service'
 import { ThumbnailService } from '../core/thumbnail-service'
 
@@ -96,7 +97,11 @@ export async function deleteEntityFiles(
           if (file) {
             await database.delete(schema.FolderFile).where(eq(schema.FolderFile.id, file.id))
           } else if (asset) {
-            await database.delete(schema.MediaAsset).where(eq(schema.MediaAsset.id, asset.id))
+            // Thumbnails are separate MediaAssets referencing this one through
+            // `derivedFromVersionId` (NO ACTION), so a bare delete raises 23503. Drop
+            // their S3 objects first, then purge the whole closure in one statement.
+            if (deleteFromStorage) await cleanupAssetThumbnails(asset.id)
+            await purgeMediaAssets(database, [asset.id])
           }
           logger.info(`Deleted ${file ? 'file' : 'asset'} record: ${item.id}`)
         } else if (markAsDeleted) {

--- a/packages/lib/src/jobs/maintenance/storage-cleanup-job.ts
+++ b/packages/lib/src/jobs/maintenance/storage-cleanup-job.ts
@@ -5,6 +5,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
 import { and, eq, isNotNull, sql } from 'drizzle-orm'
 import { clearImportCache } from '../../email/polling-import-cache'
+import { purgeMediaAssets } from '../../files/core/media-asset-purge'
 import { StorageManager } from '../../files/storage/storage-manager'
 import type { JobContext } from '../types/job-context'
 
@@ -148,7 +149,7 @@ const ASSET_PURGE_MAX_ROUNDS = 100
  * 2. Thumbnails are their own `MediaAsset`, tied to the source only by
  *    `MediaAssetVersion.derivedFromVersionId` — a self-FK with NO ACTION on delete. They
  *    have no `Attachment` row of their own, so query 1 never sees them, and deleting a
- *    source without them raises 23503. `expandDerivedAssets` pulls in that closure so the
+ *    source without them raises 23503. `purgeMediaAssets` pulls in that closure so the
  *    whole set goes in ONE statement, where NO ACTION is checked at statement end with
  *    every referencing row already gone.
  */
@@ -181,25 +182,7 @@ async function purgeDanglingMessageAssets(
     const seedIds = ((dangling.rows ?? []) as { assetId: string }[]).map((r) => r.assetId)
     if (seedIds.length === 0) return
 
-    const assetIds = await expandDerivedAssets(seedIds)
-    const idList = sql.join(
-      assetIds.map((id) => sql`${id}`),
-      sql`, `
-    )
-
-    // Mark storage first — the delete below cascades the versions away, and an unmarked
-    // StorageLocation is an S3 object nothing will ever reap.
-    await db.execute(sql`
-      UPDATE ${schema.StorageLocation} SET "deletedAt" = now()
-      WHERE "deletedAt" IS NULL
-        AND "id" IN (
-          SELECT v."storageLocationId"
-          FROM ${schema.MediaAssetVersion} v
-          WHERE v."assetId" IN (${idList}) AND v."storageLocationId" IS NOT NULL
-        )
-    `)
-
-    await db.execute(sql`DELETE FROM ${schema.MediaAsset} WHERE "id" IN (${idList})`)
+    const assetIds = await purgeMediaAssets(db, seedIds)
     result.mediaAssetsPurged += assetIds.length
 
     logger.info('Purged dangling message assets', {
@@ -218,31 +201,6 @@ async function purgeDanglingMessageAssets(
     organizationId,
     purged: result.mediaAssetsPurged,
   })
-}
-
-/**
- * Expand a set of MediaAssets to include every asset derived from them, transitively.
- */
-async function expandDerivedAssets(assetIds: string[]): Promise<string[]> {
-  const result = await db.execute(sql`
-    WITH RECURSIVE closure AS (
-      SELECT v."id", v."assetId"
-      FROM ${schema.MediaAssetVersion} v
-      WHERE v."assetId" IN (${sql.join(
-        assetIds.map((id) => sql`${id}`),
-        sql`, `
-      )})
-      UNION
-      SELECT c."id", c."assetId"
-      FROM ${schema.MediaAssetVersion} c
-      JOIN closure p ON c."derivedFromVersionId" = p."id"
-    )
-    SELECT DISTINCT "assetId" FROM closure
-  `)
-
-  const ids = new Set(assetIds)
-  for (const row of (result.rows ?? []) as { assetId: string }[]) ids.add(row.assetId)
-  return [...ids]
 }
 
 /**


### PR DESCRIPTION
Follow-up to #1737, which fixed channel disconnect. Same FK hazard, two more call sites — one live, one latent.

A thumbnail is its own `MediaAsset` (`kind: THUMBNAIL`, `purpose: DERIVED`) tied to its source only by `MediaAssetVersion.derivedFromVersionId`, a self-FK with `NO ACTION` on delete. It carries no `Attachment` row, so nothing that walks attachments ever sees it, and any bare delete of a thumbnailed asset raises `23503`.

## Sites fixed

**`cleanup-service.ts` `deleteEntityFiles`** — hard-deleted the asset row directly, so deleting an entity's files blew up on anything that had ever been previewed. It now drops the thumbnails' S3 objects through `cleanupAssetThumbnails` (already exported from that same file, and already doing the S3 half correctly — it just never removed the rows), then purges the closure.

**`media-asset-service.ts` `deleteVersion`** — calls `deleteThumbnailsForSource`, which *looks* like it handles thumbnails but only **soft**-deletes the rows, leaving the hard delete of the source version blocked. Latent rather than live: the function refuses to delete a current version, and every thumbnailed version in dev happens to be its asset's current one. Real defect, just unreachable today.

## Shared helper

New `packages/lib/src/files/core/media-asset-purge.ts`:

- `expandDerivedAssetIds(db, ids)` — the recursive CTE.
- `purgeMediaAssets(db, ids)` — expands, marks the closure's `StorageLocation`s (versions cascade away with the assets, and an unmarked location is an S3 object nothing will ever reap), deletes the closure in **one statement**. `NO ACTION` is checked at statement end, so a delete covering both referencing and referenced rows passes where deleting the source alone — or paging the closure across statements — fails.

The inline copy added to `storageCleanupJob` in #1737 now uses it too, so this is a net simplification there (−46 lines).

## Verification

A/B against dev, all rolled back. 139 source→thumbnail pairs available to test with:

```
old   DELETE FROM "MediaAsset" WHERE id = <src>   → ERROR 23503 (derivedFromVersionId)
new   mark storage + closure delete               → UPDATE 2, DELETE 2
```

`deleteVersion` needed a synthetic case (asset with a thumbnailed **non-current** version, since dev has none): old path errors with the same constraint, new path succeeds.

227 tests across `src/files` and `src/channels` pass. No schema change, no migration.