### PR TITLE
fix(connections): stop a tombstoned channel pinning a stale pending marker

### DIFF
--- a/packages/lib/src/connections/__tests__/pending-selection.test.ts
+++ b/packages/lib/src/connections/__tests__/pending-selection.test.ts
@@ -16,6 +16,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const captured: { sets: unknown[]; selects: unknown[] } = { sets: [], selects: [] }
 
+/** Controllable per-test: what the superseded-credential reference check finds. */
+const { integrationFindFirst, deleteCredential } = vi.hoisted(() => ({
+  integrationFindFirst: vi.fn(async (): Promise<unknown> => undefined),
+  deleteCredential: vi.fn(async () => ({ isErr: () => false })),
+}))
+
+vi.mock('@auxx/credentials/store', () => ({ deleteCredential }))
+
 /** Rows the next `select()` chain resolves to. */
 let selectRows: Array<Record<string, unknown>> = []
 
@@ -49,7 +57,7 @@ vi.mock('@auxx/database', async () => {
     database: {
       select: () => selectChain(),
       update: () => updateChain(),
-      query: { Integration: { findFirst: vi.fn(async () => undefined) } },
+      query: { Integration: { findFirst: integrationFindFirst } },
     },
   }
 })
@@ -59,6 +67,7 @@ const {
   readPendingSelection,
   findPendingSelectionForUser,
   clearPendingSelection,
+  deleteSupersededPendingCredentials,
 } = await import('../pending-selection')
 
 const dialect = new PgDialect()
@@ -81,6 +90,8 @@ beforeEach(() => {
   captured.sets = []
   captured.selects = []
   selectRows = []
+  integrationFindFirst.mockResolvedValue(undefined)
+  deleteCredential.mockResolvedValue({ isErr: () => false })
 })
 
 describe('writePendingSelection', () => {
@@ -179,5 +190,66 @@ describe('findPendingSelectionForUser', () => {
     await expect(
       findPendingSelectionForUser(ORG, USER, ['social-page-selection'])
     ).resolves.toMatchObject({ credentialId: CRED })
+  })
+})
+
+/**
+ * A superseded pending credential must stop mattering — by deletion, or at minimum by losing its
+ * marker.
+ *
+ * The failure this pins was silent and permanent. Disconnect is a SOFT delete, and a connect that
+ * died part-way through provisioning leaves a tombstoned Integration still pointing at its
+ * credential. The reference check had no `deletedAt` filter, so it read that tombstone as "a live
+ * channel depends on this" and skipped the row — leaving the marker in place. From then on
+ * `pendingConnectSelection` resumed the picker on every page load, for a credential whose token had
+ * already been swapped away, and no later connect ever cleared it.
+ */
+describe('deleteSupersededPendingCredentials', () => {
+  const args = {
+    organizationId: ORG,
+    userId: USER,
+    providerKey: 'facebook',
+    keepCredentialId: CRED,
+  }
+  const staleRow = {
+    id: 'cred_stale',
+    metadata: { pendingSelection: { ...marker, createdAt: 'x' } },
+  }
+
+  it('asks only about LIVE Integrations — a tombstone must not pin the credential', async () => {
+    selectRows = [staleRow]
+
+    await deleteSupersededPendingCredentials(args)
+
+    // Asserted on the rendered predicate, not on the outcome: with the mock answering `undefined`
+    // either way, a check that had dropped the `deletedAt` filter would still delete the row here
+    // and pass an outcome-only test. The filter IS the fix.
+    const where = (integrationFindFirst.mock.calls[0]?.[0] as { where: unknown }).where
+    const { sql } = dialect.sqlToQuery(where as never)
+    expect(sql).toContain('"Integration"."deletedAt" is null')
+    expect(deleteCredential).toHaveBeenCalledWith('cred_stale', ORG)
+  })
+
+  it('clears the marker instead of deleting when a LIVE Integration references it', async () => {
+    selectRows = [staleRow]
+    integrationFindFirst.mockResolvedValue({ id: 'int_live' })
+
+    await deleteSupersededPendingCredentials(args)
+
+    // The credential survives — something live depends on it.
+    expect(deleteCredential).not.toHaveBeenCalled()
+    // ...but the marker must not, or the picker resumes forever on a connect nobody can finish.
+    const { sql } = renderLastSet()
+    expect(sql).toContain('-')
+    expect(captured.sets.length).toBe(1)
+  })
+
+  it('never touches the credential being connected right now', async () => {
+    selectRows = [{ id: CRED, metadata: { pendingSelection: { ...marker, createdAt: 'x' } } }]
+
+    await deleteSupersededPendingCredentials(args)
+
+    expect(deleteCredential).not.toHaveBeenCalled()
+    expect(captured.sets).toEqual([])
   })
 })

--- a/packages/lib/src/connections/pending-selection.ts
+++ b/packages/lib/src/connections/pending-selection.ts
@@ -20,7 +20,7 @@
 
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, isNull, sql } from 'drizzle-orm'
 
 const logger = createScopedLogger('pending-selection')
 
@@ -212,19 +212,37 @@ export async function deleteSupersededPendingCredentials(args: {
     const stale = rows.filter((row) => row.id !== keepCredentialId && parseSelection(row.metadata))
     if (stale.length === 0) return
 
-    // Belt and braces: only delete rows nothing points at. A pending credential has no
+    // Belt and braces: only delete rows nothing LIVE points at. A pending credential has no
     // Integration by construction, so a hit here means our own invariant broke — skip it
     // rather than cascade a live channel's credential away.
+    //
+    // ⚠️ `isNull(deletedAt)` is what makes that reasoning true. Disconnect is a SOFT delete, so a
+    // tombstoned Integration keeps pointing at its credential forever — and a connect that died
+    // part-way through provisioning leaves exactly that shape. Without this filter the tombstone
+    // read as "the invariant broke", the superseded credential was skipped, and its marker
+    // survived every subsequent connect: `pendingConnectSelection` kept resuming a picker for a
+    // credential whose token had already been swapped away, on every page load, forever. The FK is
+    // `ON DELETE SET NULL`, so deleting the credential leaves the tombstone intact and unlinked.
     const { deleteCredential } = await import('@auxx/credentials/store')
     for (const row of stale) {
       const referenced = await db.query.Integration.findFirst({
-        where: eq(schema.Integration.credentialId, row.id),
+        where: and(
+          eq(schema.Integration.credentialId, row.id),
+          isNull(schema.Integration.deletedAt)
+        ),
         columns: { id: true },
       })
       if (referenced) {
-        logger.warn('Pending credential is referenced by an Integration — not deleting', {
-          credentialId: row.id,
-        })
+        // Genuinely live — leave the credential alone, but the marker must still go. A superseded
+        // selection can never be completed (a newer connect owns the flow now), so keeping it only
+        // means re-offering a choice that cannot be taken.
+        logger.warn(
+          'Pending credential is referenced by a live Integration — clearing its marker',
+          {
+            credentialId: row.id,
+          }
+        )
+        await clearPendingSelection(row.id, organizationId).catch(() => {})
         continue
       }
       const deleted = await deleteCredential(row.id, organizationId)


### PR DESCRIPTION
Follow-up to #1739, found by running the flow: after a *successful* page selection, refreshing still reopened the "Choose a Page" dialog — for a **different, dead** credential.

## What happened

`deleteSupersededPendingCredentials` caps abandoned connects at one pending credential per (org, provider, user). It refuses to delete a row an Integration still points at, on the reasoning in its own comment:

> Belt and braces: only delete rows nothing points at. A pending credential has no Integration **by construction**, so a hit here means our own invariant broke — skip it rather than cascade a live channel's credential away.

The check had no `deletedAt` filter:

```ts
where: eq(schema.Integration.credentialId, row.id)
```

But **disconnect is a soft delete**, and a connect that dies part-way through provisioning leaves exactly that shape — a tombstoned Integration still pointing at its credential. So the tombstone read as a live dependency, the row was skipped, and its marker survived. Observed in dev during a successful connect:

```
warn | pending-selection | Pending credential is referenced by an Integration — not deleting
       {"credentialId":"qz60yf9l8p424t7moe5j9fap"}
```

From then on `pendingConnectSelection` resumed the picker on **every page load**, for a credential whose User token had already been swapped for a Page token (#1739 §3), so the choice it offered could never be completed — and no later connect would ever have cleared it. Silent and permanent.

This is the channels-guide rule (*every channel query needs `isNull(Integration.deletedAt)`*) missed in one spot.

## The fix

1. **Filter the reference check on `isNull(deletedAt)`.** A tombstone is not a live reference. The FK is `ON DELETE SET NULL`, so deleting the credential leaves the tombstone intact and unlinked.
2. **Clear the marker in the branch that genuinely does find a live Integration.** The credential is left alone — something live depends on it — but a superseded selection can never be completed, because a newer connect owns the flow. Keeping it only re-offers a choice nobody can take.

## Testing

Three new tests in `pending-selection.test.ts` (90 connection + 140 channel tests green).

The first asserts on the **rendered predicate** — `"Integration"."deletedAt" is null` — not on the outcome. With the lookup answering `undefined` either way, a check that had dropped the filter would still delete the row and pass an outcome-only test. The filter *is* the fix, so that is what gets pinned.

The others cover the live-Integration branch (credential survives, marker cleared) and the invariant that the credential being connected right now is never touched.

## Note

The fix prevents this state; it does not retroactively clear a marker already stuck. One dev row needed `metadata - 'pendingSelection'` by hand. There is no production exposure — the two-phase connect only shipped in #1739 and #1734, and the trigger is a provisioning failure mid-connect, which #1739 also made impossible by validating before any write.

Still open from #1739 §13.5: nothing ages a marker out server-side, so a marker older than its short-lived token resumes a picker that can only fail. A `createdAt` TTL in `pendingConnectSelection` would close that separately.