### PR TITLE
fix(kopilot): keep a failed turn's work instead of reverting it

### DIFF
--- a/apps/web/src/app/api/kopilot/stream/route.ts
+++ b/apps/web/src/app/api/kopilot/stream/route.ts
@@ -39,6 +39,7 @@ import {
   createWorkflowBuilderCapabilities,
   findRef,
   generateSessionTitle,
+  KOPILOT_TURN_BUDGET,
   LAST_CONTEXT_KEY,
   LAST_PAGE_KEY,
   resolveContinuationSurface,
@@ -965,8 +966,7 @@ async function runInProcessPath(params: {
     domainConfig: domainConfig as unknown as AgentDomainConfig,
     callModel,
     signal: request.signal,
-    maxTotalIterations: 100,
-    maxApprovalsPerTurn: 50,
+    ...KOPILOT_TURN_BUDGET,
   }
 
   // Create engine with restored state (including approval state if paused)

--- a/apps/web/src/components/workflow/editor/workflow-editor.tsx
+++ b/apps/web/src/components/workflow/editor/workflow-editor.tsx
@@ -27,6 +27,7 @@ import { WorkflowHistoryProvider } from '../store/workflow-history-provider'
 import { useWorkflowStore } from '../store/workflow-store'
 import { WorkflowStoreProvider } from '../store/workflow-store-provider'
 import type { FlowEdge, FlowNode } from '../types'
+import { KopilotTurnReviewBanner } from '../ui/kopilot-turn-review-banner'
 import { WorkflowEditorProvider } from './workflow-editor-provider'
 
 interface WorkflowEditorProps {
@@ -81,6 +82,12 @@ const WorkflowEditorInner = memo<{
       <div className='workflow-editor flex flex-col h-full rounded-2xl'>
         {/* Toolbar */}
         <WorkflowToolbar className='flex-shrink-0' />
+
+        {/* Keep/Undo for a Kopilot turn that stopped early and left its edits
+            behind (plan 20 phase D). Mounted HERE, not in the Kopilot panel:
+            that frame is a peer overlay and unmounts whenever another panel is
+            popped, and this offer has to stay reachable for 24h. */}
+        <KopilotTurnReviewBanner workflowAppId={workflow?.id} />
 
         {/* Main content */}
         <div className='flex-1 min-h-0 w-full flex flex-row'>

--- a/apps/web/src/components/workflow/hooks/use-kopilot-turn-review.ts
+++ b/apps/web/src/components/workflow/hooks/use-kopilot-turn-review.ts
@@ -1,0 +1,175 @@
+// apps/web/src/components/workflow/hooks/use-kopilot-turn-review.ts
+
+'use client'
+
+import { toastError } from '@auxx/ui/components/toast'
+import { useCallback, useState } from 'react'
+import { useOrgChannel } from '~/realtime/hooks'
+import { api } from '~/trpc/react'
+
+/**
+ * How the turn ended, as stamped on the pre-turn snapshot. Mirrors the server's
+ * `WorkflowTurnEnding` (`@auxx/lib/workflows/graph-edit`) rather than importing
+ * it: that barrel is SERVER-ONLY (Redis + the persist seam) and has no `/client`
+ * subpath, so importing it here would pull server deps into the bundle.
+ *
+ * `null` means "not recorded" — see {@link KopilotTurnReview.endedAs}.
+ */
+export type KopilotTurnEnding = 'exhausted' | 'aborted' | 'error'
+
+interface UseKopilotTurnReviewArgs {
+  /** WorkflowApp id — the snapshot slot is keyed to it. Undefined before init. */
+  workflowAppId: string | undefined
+}
+
+export interface KopilotTurnReview {
+  /** Show the turn-review banner: a snapshot is pending for a turn that ended. */
+  pending: boolean
+  /** Nodes on the canvas immediately before the turn's first write. */
+  preTurnNodeCount: number
+  /** Nodes on the draft now — what the stopped turn left behind. */
+  currentNodeCount: number
+  /** When the turn's first write happened (ms epoch). */
+  capturedAt: number
+  /**
+   * How the turn ended — what lets the banner say WHY it stopped instead of
+   * only that it did. `null` when the snapshot carries no ending (captured
+   * before the field existed, the turn died before its turn-end hook ran, or
+   * the stamp's Redis write failed); the banner falls back to generic wording
+   * and the offer stands. Absence must never suppress the Undo.
+   */
+  endedAs: KopilotTurnEnding | null
+  /** Commit the turn — clears the snapshot, removes the Undo affordance. */
+  onKeep: () => Promise<void>
+  /** Roll the draft back to the pre-turn graph. Confirm first — it is destructive. */
+  onUndo: () => Promise<void>
+  /** A Keep/Undo mutation is in flight. */
+  isBusy: boolean
+  /**
+   * The server's verbatim explanation of a refused Undo that left the offer
+   * ALIVE (409 — the canvas moved on since the turn, or a save raced the
+   * revert). Rendered on the banner rather than toasted, because the banner is
+   * still there and the message is the reason it still is.
+   */
+  refusalMessage: string | null
+}
+
+/**
+ * Surfaces a pending Kopilot turn review for the builder banner — the workflow
+ * twin of `~/components/kb/hooks/use-kopilot-review.ts`, deliberately the same
+ * shape (recovery query + Keep/Undo + `pending`).
+ *
+ * `workflow.getKopilotTurnReview` is the source of truth. It runs on mount, so
+ * a review survives a refresh (the agent's SSE stream does not, and it never
+ * carried a `turnId` to begin with), and it is invalidated on the org channel's
+ * turn boundary for liveness.
+ *
+ * WHAT MAKES A REVIEW PENDING: the pre-turn snapshot's existence. After plan 20
+ * phase A the workflow-builder capability never reverts automatically and only
+ * finalizes on a COMPLETED turn, so a surviving snapshot means exactly one
+ * thing — the last turn wrote to the draft and then stopped early. Unlike KB,
+ * which keeps its snapshot on every outcome and reviews every turn, this banner
+ * appears ONLY for a turn that did not finish.
+ *
+ * The two node counts are what the offer can honestly prove. The snapshot
+ * stores the pre-turn graph, not a tool-call log, so plan 20's "12 edits were
+ * applied" is still not derivable. WHY it stopped is: `endedAs` is stamped onto
+ * the snapshot by the capability's turn-end hook, from the engine's own
+ * classification of the terminal event — three states (`exhausted` / `aborted` /
+ * `error`), never the five-way `TurnErrorReason`, because the capability
+ * lifecycle is only handed the outcome. The banner says what that proves and
+ * nothing more.
+ */
+export function useKopilotTurnReview({
+  workflowAppId,
+}: UseKopilotTurnReviewArgs): KopilotTurnReview {
+  const utils = api.useUtils()
+  const [refusalMessage, setRefusalMessage] = useState<string | null>(null)
+
+  const reviewQuery = api.workflow.getKopilotTurnReview.useQuery(
+    { workflowAppId: workflowAppId ?? '' },
+    // `retry: false` so a failed read settles on "no review" rather than
+    // holding a phantom banner through three backed-off attempts.
+    { enabled: !!workflowAppId, retry: false, staleTime: 10_000 }
+  )
+  const review = reviewQuery.data ?? null
+
+  const refresh = useCallback(() => {
+    if (!workflowAppId) return
+    void utils.workflow.getKopilotTurnReview.invalidate({ workflowAppId })
+  }, [utils, workflowAppId])
+
+  /**
+   * A turn ending is the moment a review can appear; a `system` draft write is
+   * the revert itself landing. Not polled — the builder is already on the org
+   * channel for the canvas edit lock.
+   *
+   * Every mutation of a RUNNING turn also publishes `workflow:draft-updated`,
+   * and the query answers null for as long as that turn holds the lock, so only
+   * the boundary is worth a refetch.
+   */
+  useOrgChannel({
+    onEvent: (event, payload) => {
+      if (event !== 'workflow:kopilot-turn' && event !== 'workflow:draft-updated') return
+      const data = (payload ?? {}) as { workflowAppId?: string; phase?: string }
+      if (!workflowAppId || data.workflowAppId !== workflowAppId) return
+      if (event === 'workflow:kopilot-turn' && data.phase !== 'ended') return
+      refresh()
+    },
+  })
+
+  const undo = api.workflow.revertKopilotTurn.useMutation()
+  const keep = api.workflow.keepKopilotTurn.useMutation()
+
+  const onUndo = useCallback(async () => {
+    if (!workflowAppId || !review) return
+    setRefusalMessage(null)
+    try {
+      // The `turnId` the query handed us, never one re-derived at click time: a
+      // banner left up across a newer turn must fail, not revert a turn the
+      // user never saw.
+      await undo.mutateAsync({ workflowAppId, turnId: review.turnId })
+    } catch (error) {
+      // `revertWorkflowTurn` writes NOTHING on either refusal, and both
+      // messages are authored server-side to be shown verbatim — so neither is
+      // reworded here. They differ in whether the offer survives:
+      //
+      //  - 409 — the canvas moved on since the turn (post-turn hash mismatch),
+      //    or a save raced the revert. The snapshot is LEFT IN PLACE, so the
+      //    banner stays and carries the explanation.
+      //  - 404 — the snapshot is gone (a manual canvas save cleared it, a later
+      //    turn superseded the slot, the 24h TTL expired). The offer is dead,
+      //    so it goes to a toast and the refresh below takes the banner away.
+      const shape = error as { data?: { code?: string }; message?: string }
+      const message = shape.message ?? 'These changes are no longer available to undo.'
+      if (shape.data?.code === 'CONFLICT') {
+        setRefusalMessage(message)
+        return
+      }
+      toastError({ title: 'Could not undo', description: message })
+    }
+    refresh()
+  }, [workflowAppId, review, undo, refresh])
+
+  const onKeep = useCallback(async () => {
+    if (!workflowAppId || !review) return
+    setRefusalMessage(null)
+    // Soft `{ ok, reason }` by design (matching `kb.keepKopilotTurn`): the only
+    // failure is "there was nothing left to keep", which is indistinguishable
+    // from success from the user's side.
+    await keep.mutateAsync({ workflowAppId, turnId: review.turnId })
+    refresh()
+  }, [workflowAppId, review, keep, refresh])
+
+  return {
+    pending: !!review,
+    preTurnNodeCount: review?.preTurnNodeCount ?? 0,
+    currentNodeCount: review?.currentNodeCount ?? 0,
+    capturedAt: review?.capturedAt ?? 0,
+    endedAs: review?.endedAs ?? null,
+    onKeep,
+    onUndo,
+    isBusy: undo.isPending || keep.isPending,
+    refusalMessage,
+  }
+}

--- a/apps/web/src/components/workflow/ui/kopilot-turn-review-banner.test.tsx
+++ b/apps/web/src/components/workflow/ui/kopilot-turn-review-banner.test.tsx
@@ -1,0 +1,98 @@
+// apps/web/src/components/workflow/ui/kopilot-turn-review-banner.test.tsx
+//
+// The Undo banner's copy — plan 20 §5 / §9 phase D, "the turn says why it
+// stopped".
+//
+// The banner is the ONLY place the turn's ending becomes a sentence, and the
+// two things worth pinning are both silent failures:
+//
+//   1. the wording actually differs per ending. A refactor that dropped the
+//      switch would still render a banner, still offer the Undo, and read as
+//      "stopped early" forever — i.e. exactly the gap this closes, restored
+//      without a single test going red;
+//   2. an ending of `null` FAILS OPEN. Absence must cost the adjective and
+//      never the offer: the buttons stay, the counts stay, only the reason
+//      falls back to the generic sentence.
+//
+// The hook is mocked because the copy is the unit under test — the query, the
+// realtime refresh and the two mutations are covered server-side in
+// `server/api/routers/workflow-kopilot-turn-review.test.ts`.
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { KopilotTurnEnding } from '../hooks/use-kopilot-turn-review'
+
+const h = vi.hoisted(() => ({
+  review: {
+    pending: true,
+    preTurnNodeCount: 6,
+    currentNodeCount: 9,
+    capturedAt: Date.now() - 5 * 60 * 1000,
+    endedAs: null as KopilotTurnEnding | null,
+    onKeep: vi.fn(async () => undefined),
+    onUndo: vi.fn(async () => undefined),
+    isBusy: false,
+    refusalMessage: null as string | null,
+  },
+}))
+
+vi.mock('../hooks/use-kopilot-turn-review', () => ({
+  useKopilotTurnReview: () => h.review,
+}))
+
+// The confirm dialog is the destructive path's own concern; rendering it here
+// would drag in the whole dialog stack for a copy assertion.
+vi.mock('~/hooks/use-confirm', () => ({
+  useConfirm: () => [vi.fn(async () => true), () => null],
+}))
+
+const { KopilotTurnReviewBanner } = await import('./kopilot-turn-review-banner')
+
+function renderWith(endedAs: KopilotTurnEnding | null) {
+  h.review.endedAs = endedAs
+  render(<KopilotTurnReviewBanner workflowAppId='wf_cuid0000000000000000000' />)
+  return screen.getByText(/Kopilot’s last turn/).textContent ?? ''
+}
+
+describe('KopilotTurnReviewBanner copy', () => {
+  it.each([
+    // Resource caps — token budget, iteration cap, approval cap, failure
+    // streak. Deliberately NOT "token budget": the capability lifecycle is
+    // handed the four-way outcome, never the five-way reason, so naming the
+    // budget would be a claim the stored data cannot back.
+    ['exhausted' as const, 'ran out of room before it finished'],
+    // A client disconnect — a reload or navigating away. There is no stop
+    // button in the Kopilot composer.
+    ['aborted' as const, 'was interrupted before it finished'],
+    ['error' as const, 'hit an error before it finished'],
+  ])('%s reads as its own ending', (endedAs, phrase) => {
+    expect(renderWith(endedAs)).toContain(phrase)
+  })
+
+  it('every ending produces a DISTINCT first sentence', () => {
+    const endings: KopilotTurnEnding[] = ['exhausted', 'aborted', 'error']
+    const sentences = endings.map((e) => {
+      const text = renderWith(e)
+      screen.getByText(/Kopilot’s last turn/).remove()
+      return text.split('.')[0]
+    })
+    expect(new Set(sentences).size).toBe(endings.length)
+  })
+
+  it('FAILS OPEN with no ending — generic wording, offer intact', () => {
+    const text = renderWith(null)
+    expect(text).toContain('stopped early')
+    // The load-bearing half: absence must never suppress the Undo.
+    expect(screen.getByRole('button', { name: 'Undo' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Keep' })).toBeTruthy()
+    // ...and the offer still says what it would cost.
+    expect(text).toContain('taking it from 9 nodes back to 6')
+  })
+
+  it('renders nothing when there is no pending review', () => {
+    h.review.pending = false
+    const { container } = render(<KopilotTurnReviewBanner workflowAppId='wf_1' />)
+    expect(container.textContent).toBe('')
+    h.review.pending = true
+  })
+})

--- a/apps/web/src/components/workflow/ui/kopilot-turn-review-banner.tsx
+++ b/apps/web/src/components/workflow/ui/kopilot-turn-review-banner.tsx
@@ -1,0 +1,141 @@
+// apps/web/src/components/workflow/ui/kopilot-turn-review-banner.tsx
+
+'use client'
+
+import { Button } from '@auxx/ui/components/button'
+import { formatRelativeTime } from '@auxx/utils'
+import { useCallback } from 'react'
+import { useConfirm } from '~/hooks/use-confirm'
+import { type KopilotTurnEnding, useKopilotTurnReview } from '../hooks/use-kopilot-turn-review'
+
+interface KopilotTurnReviewBannerProps {
+  /** WorkflowApp id — the snapshot slot is keyed to it. Undefined before init. */
+  workflowAppId: string | undefined
+}
+
+/**
+ * "Kopilot's last turn stopped early — Keep or Undo" (plan 20 §5, phase D).
+ *
+ * WHY A BANNER ABOVE THE CANVAS, not a card in the chat. Two reasons, and the
+ * second is decisive:
+ *
+ *  - the KB precedent. `kb.getKopilotTurnReview` backs a Keep/Undo bar pinned
+ *    above the article body (`kb/ui/editor/article-editor.tsx`), not a message
+ *    in the transcript, because the review is about the CONTENT the user is
+ *    looking at. The canvas is this surface's article;
+ *  - the builder's Kopilot frame is a peer overlay — popping the node
+ *    properties, Test or Settings frame unmounts it. An offer that lived only
+ *    there would be invisible exactly when the user is on the canvas wondering
+ *    where their nodes went, and it has to stay reachable for 24h.
+ *
+ * It is also not an `auxx:*` block. Those are LLM-AUTHORED fences the model
+ * embeds in its prose, and the model cannot author this one: the turn is
+ * discarded by the ENGINE, after the agent has already finished and streamed
+ * its reply, so at the moment the offer becomes true there is no model left to
+ * write it.
+ *
+ * Mounted in `workflow-editor.tsx` beside the other once-per-editor hooks, for
+ * the same reason `useWorkflowKopilotTurn` is: it must not depend on a drawer
+ * being open.
+ */
+export function KopilotTurnReviewBanner({ workflowAppId }: KopilotTurnReviewBannerProps) {
+  const review = useKopilotTurnReview({ workflowAppId })
+  const [confirm, ConfirmDialog] = useConfirm()
+
+  const handleUndo = useCallback(async () => {
+    // KB's Undo has no confirm because its editor keeps a full version history
+    // to walk back through. Undoing here throws away every node the turn
+    // created in one write, so it asks.
+    const confirmed = await confirm({
+      title: 'Undo that turn?',
+      description:
+        'The workflow is restored exactly as it was before Kopilot’s last turn. ' +
+        'Anything that turn added, removed or reconfigured is discarded.',
+      confirmText: 'Undo turn',
+      cancelText: 'Cancel',
+      destructive: true,
+    })
+    if (!confirmed) return
+    await review.onUndo()
+  }, [confirm, review])
+
+  if (!review.pending) return null
+
+  return (
+    <>
+      <div className='flex flex-shrink-0 flex-wrap items-center gap-3 border-b bg-primary-150 px-7 py-2 text-sm'>
+        <span className='text-foreground'>
+          {describeEnding(review.endedAs)} Its edits were kept — undoing restores the workflow as it
+          was {formatRelativeTime(new Date(review.capturedAt))},{' '}
+          {describeDelta(review.currentNodeCount, review.preTurnNodeCount)}.
+        </span>
+        <div className='ml-auto flex items-center gap-2'>
+          <Button variant='outline' size='xs' loading={review.isBusy} onClick={review.onKeep}>
+            Keep
+          </Button>
+          <Button
+            variant='outline'
+            size='xs'
+            loading={review.isBusy}
+            onClick={() => void handleUndo()}>
+            Undo
+          </Button>
+        </div>
+        {review.refusalMessage && (
+          <p className='w-full text-xs text-destructive'>{review.refusalMessage}</p>
+        )}
+      </div>
+      <ConfirmDialog />
+    </>
+  )
+}
+
+/**
+ * Why the turn stopped, in the only vocabulary the snapshot can prove. The
+ * capability's turn-end hook is handed the engine's four-way `TurnOutcome`, not
+ * the five-way `TurnErrorReason`, so the honest ceiling here is THREE states —
+ * plan 20's literal "(token budget)" would be a claim the stored data cannot
+ * back, and `exhausted` also covers the iteration cap, the approval cap and the
+ * tool-failure streak.
+ *
+ * `null` — a snapshot from before the field existed, a turn that died before
+ * its turn-end hook ran, or a stamp whose Redis write failed — falls back to
+ * the wording this banner shipped with. It must never withhold the offer:
+ * losing the adjective is a far smaller loss than losing the Undo.
+ *
+ * Each sentence is self-contained and ends in a full stop, because the copy
+ * that follows it is fixed.
+ */
+function describeEnding(endedAs: KopilotTurnEnding | null): string {
+  switch (endedAs) {
+    // Resource caps — token budget, iteration cap, approval cap, failure
+    // streak. All four mean the same thing to the user: the turn had more to do
+    // and no room left to do it in.
+    case 'exhausted':
+      return 'Kopilot’s last turn ran out of room before it finished.'
+    // Not a stop button — there isn’t one. This is a client disconnect: a page
+    // reload or navigating away mid-turn.
+    case 'aborted':
+      return 'Kopilot’s last turn was interrupted before it finished.'
+    case 'error':
+      return 'Kopilot’s last turn hit an error before it finished.'
+    default:
+      return 'Kopilot’s last turn stopped early.'
+  }
+}
+
+/**
+ * What an undo would cost, in the only unit the snapshot can prove — it stores
+ * the pre-turn GRAPH, not a tool-call log, so plan 20's "12 edits were applied"
+ * is not derivable from it.
+ */
+function describeDelta(currentNodeCount: number, preTurnNodeCount: number): string {
+  if (currentNodeCount === preTurnNodeCount) {
+    return `still ${currentNodeCount} ${plural(currentNodeCount, 'node')} with their earlier configuration`
+  }
+  return `taking it from ${currentNodeCount} ${plural(currentNodeCount, 'node')} back to ${preTurnNodeCount}`
+}
+
+function plural(count: number, word: string): string {
+  return count === 1 ? word : `${word}s`
+}

--- a/apps/web/src/server/api/routers/workflow-kopilot-turn-review.test.ts
+++ b/apps/web/src/server/api/routers/workflow-kopilot-turn-review.test.ts
@@ -1,0 +1,497 @@
+// apps/web/src/server/api/routers/workflow-kopilot-turn-review.test.ts
+
+import { Area, expandLevelsToKeys, Level, PermissionKey } from '@auxx/lib/permissions/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * `workflow.getKopilotTurnReview` + `revertKopilotTurn` + `keepKopilotTurn` — plan 20
+ * phase D (`plans/kopilot/workflow/20-partial-turn-survival.md` §5, §9).
+ *
+ * The claims under test:
+ *
+ *  - the OFFER is derived from the surviving pre-turn snapshot, not from a
+ *    `turnId` plumbed through SSE (there is none), and it is withheld while the
+ *    turn that owns the snapshot still holds the draft lock;
+ *  - the offer reads at instance `view`, but TAKING it is instance `edit` — a
+ *    viewer cannot revert a workflow they can only look at;
+ *  - `revertWorkflowTurn`'s three outcomes each reach the client intact.
+ *    **[C3]** in the plan: the 404 ("that turn's snapshot is gone") and the 409
+ *    ("the canvas moved on") are distinct statements the card has to be able to
+ *    show, so the router must NOT flatten either into a 500. Under this file's
+ *    `~/server/api/trpc` stub there is no `auxxErrorMiddleware`, so the AuxxError
+ *    arrives on `.cause` — which is exactly what the real middleware maps.
+ *
+ * Behavioural: the real router runs through a tRPC caller with a REAL
+ * `CapabilitySet`; only the graph-edit seam and the row lookup are faked.
+ */
+
+const { graphEdit, guards, featureService, appRows } = vi.hoisted(() => ({
+  /** Rows `db.select()...limit(1)` hands back — empty models "not in this org". */
+  appRows: {
+    value: [{ id: 'wf_cuid0000000000000000000', draftNodeCount: 9 }] as Record<string, unknown>[],
+  },
+  graphEdit: {
+    finalizeWorkflowTurn: vi.fn(async () => undefined),
+    readWorkflowTurnLock: vi.fn(async () => null as { turnId: string } | null),
+    readWorkflowTurnSnapshot: vi.fn(async () => null as Record<string, unknown> | null),
+    revertWorkflowTurn: vi.fn(async () => ({ isErr: () => false, value: { graphHash: 'h' } })),
+  },
+  guards: { app: vi.fn(async () => undefined) },
+  featureService: { requireAccess: vi.fn(async () => undefined) },
+}))
+
+vi.mock('@auxx/lib/workflows/graph-edit', () => graphEdit)
+
+// Real drizzle columns come back undefined under vitest — the org predicate is
+// exercised through the rows the fake query builder returns, not generated SQL.
+vi.mock('@auxx/database', async () =>
+  (await import('~/test/database-mock')).mockAuxxDatabase({
+    schema: {
+      WorkflowApp: {
+        id: 'WorkflowApp.id',
+        organizationId: 'WorkflowApp.organizationId',
+        draftWorkflowId: 'WorkflowApp.draftWorkflowId',
+      },
+      Workflow: { id: 'Workflow.id', graph: 'Workflow.graph' },
+    },
+  })
+)
+
+vi.mock('@auxx/lib/workflows', () => ({
+  WorkflowService: class {
+    test = vi.fn(async () => ({ success: true }))
+  },
+  WorkflowVersionService: class {},
+  WorkflowStatsService: class {},
+  WorkflowExecutionService: class {},
+  assertWorkflowAppNotSystemOwned: guards.app,
+  assertWorkflowRunNotSystemOwned: vi.fn(async () => 'wf_cuid0000000000000000000'),
+  getWorkflowRunCreatorId: vi.fn(async () => null),
+  buildTemplateWorkflowData: vi.fn(async () => ({})),
+  toWorkflowAppResponse: (app: unknown) => app,
+  WORKFLOW_TRIGGER_TYPE_VALUES: ['manual', 'form', 'scheduled'] as const,
+  checkEntityReadiness: vi.fn(async () => ({ ready: true })),
+  listFileTemplates: vi.fn(() => []),
+}))
+
+vi.mock('@auxx/lib/workflow-engine', () => ({
+  triggerManualResourceWorkflow: vi.fn(),
+  triggerManualResourceWorkflowBulk: vi.fn(),
+}))
+
+vi.mock('@auxx/services/workflows', () => ({ getWorkflowAppsByTrigger: vi.fn(async () => []) }))
+vi.mock('@auxx/services/workflow-templates', () => ({
+  getAllTemplates: vi.fn(async () => ({ isErr: () => false, value: [] })),
+  getTemplateById: vi.fn(async () => ({ isErr: () => false, value: null })),
+}))
+
+vi.mock('@auxx/lib/cache', () => ({
+  getCachedWorkflowAppCount: vi.fn(async () => 0),
+  getAppCache: () => ({ getOrRecompute: vi.fn(async () => ({})) }),
+}))
+
+vi.mock('@auxx/lib/demo', () => ({ DemoGuard: { requireNotDemo: vi.fn(async () => undefined) } }))
+vi.mock('~/server/api/audit-context', () => ({ recordAuditFromCtx: vi.fn(async () => undefined) }))
+vi.mock('~/server/api/workflow-template-resolver', () => ({
+  resolveTemplateById: vi.fn(async () => null),
+}))
+
+// The `@auxx/lib/permissions` barrel reaches redis/db at import time and hangs
+// under vitest — see `dataset-instance-access.test.ts`. Real registry, stub
+// feature service.
+vi.mock('@auxx/lib/permissions', async () => {
+  const registry = await import('@auxx/lib/permissions/capabilities/registry')
+  const types = await import('@auxx/lib/permissions/types')
+  return {
+    PermissionKey: registry.PermissionKey,
+    FeatureKey: types.FeatureKey,
+    FeaturePermissionService: class {
+      requireAccess = featureService.requireAccess
+      requireAccessAndLimit = featureService.requireAccess
+      requireLimit = featureService.requireAccess
+    },
+  }
+})
+
+/** Mirrors the real `permissionProcedure` gate — a plain `capabilities.assert(key)`. */
+vi.mock('~/server/api/trpc', async () => {
+  const { initTRPC } = await import('@trpc/server')
+  const t = initTRPC.context<Record<string, unknown>>().create()
+  return {
+    createTRPCRouter: t.router,
+    capabilityProcedure: t.procedure,
+    protectedProcedure: t.procedure,
+    isAuxxError: (error: unknown) => error instanceof Error,
+    permissionProcedure: (key: string) =>
+      t.procedure.use(({ ctx, next }) => {
+        ;(ctx as { capabilities: { assert: (k: string) => void } }).capabilities.assert(key)
+        return next()
+      }),
+    notDemo:
+      () =>
+      ({ next }: { next: () => unknown }) =>
+        next(),
+  }
+})
+
+// Deep path on purpose — the permissions barrel hangs under vitest.
+const { CapabilitySet } = await import('@auxx/lib/permissions/capabilities/capability-set')
+const { ConflictError, NotFoundError } = await import('@auxx/lib/errors')
+const { workflowRouter } = await import('./workflow')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const WF_ID = 'wf_cuid0000000000000000000'
+const TURN_ID = 'turn_cuid00000000000000000'
+const CAPTURED_AT = 1_755_000_000_000
+
+/** AuxxError, wrapped by tRPC as `cause` (the app's middleware maps it to a status). */
+const FORBIDDEN = { cause: { name: 'ForbiddenError', statusCode: 403 } }
+
+/**
+ * The four `Rung` values `instanceAccess` actually holds. NOT
+ * `ResourcePermission` — that vocabulary's read rung is `view`, which is not a
+ * `Rung` at all, so `satisfiesRung` would silently answer false and every
+ * "succeeds at view" assertion would pass for the wrong reason.
+ */
+type Grant = 'none' | 'read' | 'edit' | 'admin'
+
+const AREA_LEVEL_OF: Record<Grant, Level> = {
+  none: Level.None,
+  read: Level.Read,
+  edit: Level.Edit,
+  admin: Level.Full,
+}
+
+function capabilitiesFor(
+  permission: Grant,
+  opts: { instances?: Record<string, Grant>; areaPermission?: Grant } = {}
+) {
+  const instances = opts.instances ?? { [WF_ID]: permission }
+  const derived = Object.values(instances).some((p) => p !== 'none')
+    ? [PermissionKey.workflowsView]
+    : []
+  return new CapabilitySet(
+    new Set(
+      expandLevelsToKeys({ [Area.workflows]: AREA_LEVEL_OF[opts.areaPermission ?? permission] })
+    ),
+    {},
+    'MEMBER',
+    'full',
+    undefined,
+    undefined,
+    undefined,
+    instances,
+    new Set(Object.keys(instances)),
+    undefined,
+    new Set(derived)
+  )
+}
+
+/** `db.select().from().leftJoin().where().limit()` — resolves to {@link appRows}. */
+function fakeDb() {
+  const chain: Record<string, unknown> = {}
+  chain.select = () => chain
+  chain.from = () => chain
+  chain.leftJoin = () => chain
+  chain.innerJoin = () => chain
+  chain.where = () => chain
+  chain.limit = async () => appRows.value
+  return chain
+}
+
+function caller(capabilities: InstanceType<typeof CapabilitySet>) {
+  return workflowRouter.createCaller({
+    db: fakeDb(),
+    capabilities,
+    session: {
+      organizationId: ORG_ID,
+      userId: USER_ID,
+      isSuperAdmin: false,
+      user: { id: USER_ID, defaultOrganizationId: ORG_ID, email: 'a@b.c', name: 'A' },
+    },
+  } as never)
+}
+
+/** A surviving pre-turn snapshot: 6 nodes before the turn, 9 on the draft now. */
+function snapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    turnId: TURN_ID,
+    name: 'Order triage',
+    description: null,
+    graph: { nodes: [1, 2, 3, 4, 5, 6].map((n) => ({ id: `n${n}` })), edges: [] },
+    triggerType: 'manual',
+    capturedAt: CAPTURED_AT,
+    postTurnGraphHash: 'post-hash',
+    /** Stamped at turn end by the capability — why the offer exists at all. */
+    endedAs: 'exhausted',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  graphEdit.finalizeWorkflowTurn.mockReset().mockResolvedValue(undefined)
+  graphEdit.readWorkflowTurnLock.mockReset().mockResolvedValue(null)
+  graphEdit.readWorkflowTurnSnapshot.mockReset().mockResolvedValue(null)
+  graphEdit.revertWorkflowTurn
+    .mockReset()
+    .mockResolvedValue({ isErr: () => false, value: { graphHash: 'h' } })
+  guards.app.mockClear().mockResolvedValue(undefined)
+  appRows.value = [{ id: WF_ID, draftNodeCount: 9 }]
+})
+
+describe('workflow.getKopilotTurnReview', () => {
+  it('returns null when no snapshot survived — the common case, and it costs no query', async () => {
+    await expect(
+      caller(capabilitiesFor('read')).getKopilotTurnReview({
+        workflowAppId: WF_ID,
+      })
+    ).resolves.toBeNull()
+    // The snapshot's ABSENCE is the whole answer: no row lookup should follow.
+    expect(graphEdit.readWorkflowTurnLock).not.toHaveBeenCalled()
+  })
+
+  it('returns the offer, with the node counts an undo would move between', async () => {
+    graphEdit.readWorkflowTurnSnapshot.mockResolvedValue(snapshot())
+    await expect(
+      caller(capabilitiesFor('read')).getKopilotTurnReview({
+        workflowAppId: WF_ID,
+      })
+    ).resolves.toEqual({
+      turnId: TURN_ID,
+      capturedAt: CAPTURED_AT,
+      preTurnNodeCount: 6,
+      currentNodeCount: 9,
+      endedAs: 'exhausted',
+    })
+  })
+
+  it.each([
+    'exhausted',
+    'aborted',
+    'error',
+  ] as const)('passes the turn’s %s ending through — the banner’s wording is derived from it', async (endedAs) => {
+    graphEdit.readWorkflowTurnSnapshot.mockResolvedValue(snapshot({ endedAs }))
+    await expect(
+      caller(capabilitiesFor('read')).getKopilotTurnReview({
+        workflowAppId: WF_ID,
+      })
+    ).resolves.toMatchObject({ endedAs })
+  })
+
+  it('FAILS OPEN on an unlabelled snapshot — no ending, but still an offer', async () => {
+    // A snapshot captured before the field existed, a turn that died before its
+    // turn-end hook ran, or a stamp whose Redis write failed. Losing the
+    // adjective is a far smaller loss than losing the Undo, so the offer stands
+    // in full and only `endedAs` goes null.
+    const { endedAs: _dropped, ...unlabelled } = snapshot()
+    graphEdit.readWorkflowTurnSnapshot.mockResolvedValue(unlabelled)
+    await expect(
+      caller(capabilitiesFor('read')).getKopilotTurnReview({
+        workflowAppId: WF_ID,
+      })
+    ).resolves.toEqual({
+      turnId: TURN_ID,
+      capturedAt: CAPTURED_AT,
+      preTurnNodeCount: 6,
+      currentNodeCount: 9,
+      endedAs: null,
+    })
+  })
+
+  it('reads the CURRENT snapshot, unfiltered by turn — nothing plumbs a turnId to the client', async () => {
+    graphEdit.readWorkflowTurnSnapshot.mockResolvedValue(snapshot())
+    await caller(capabilitiesFor('read')).getKopilotTurnReview({
+      workflowAppId: WF_ID,
+    })
+    // Second arg withheld on purpose: `readWorkflowTurnSnapshot(id, turnId)`
+    // would answer null for every turn the caller cannot name, and the SSE
+    // stream never carries one.
+    expect(graphEdit.readWorkflowTurnSnapshot).toHaveBeenCalledWith(WF_ID)
+  })
+
+  it('withholds the offer while the snapshot’s own turn still holds the draft', async () => {
+    // Mid-turn the snapshot exists and is live fuel — offering an undo there
+    // would let the user roll back underneath a running agent.
+    graphEdit.readWorkflowTurnSnapshot.mockResolvedValue(snapshot())
+    graphEdit.readWorkflowTurnLock.mockResolvedValue({ turnId: TURN_ID })
+    await expect(
+      caller(capabilitiesFor('read')).getKopilotTurnReview({
+        workflowAppId: WF_ID,
+      })
+    ).resolves.toBeNull()
+  })
+
+  it('still offers when a DIFFERENT turn holds the lock — that turn superseded nothing yet', async () => {
+    graphEdit.readWorkflowTurnSnapshot.mockResolvedValue(snapshot())
+    graphEdit.readWorkflowTurnLock.mockResolvedValue({ turnId: 'turn_someothernewerturn00' })
+    await expect(
+      caller(capabilitiesFor('read')).getKopilotTurnReview({
+        workflowAppId: WF_ID,
+      })
+    ).resolves.toMatchObject({ turnId: TURN_ID })
+  })
+
+  it('returns null for a workflow outside the caller’s org, before any counts leak', async () => {
+    // `workflow` is `baselineAtCreate: false`, so a row-less (foreign) id falls
+    // back to the caller's AREA level and sails through the instance assert.
+    graphEdit.readWorkflowTurnSnapshot.mockResolvedValue(snapshot())
+    appRows.value = []
+    await expect(
+      caller(capabilitiesFor('admin', { instances: {} })).getKopilotTurnReview({
+        workflowAppId: 'wf_someotherorg000000000',
+      })
+    ).resolves.toBeNull()
+  })
+
+  it('counts a draft with no graph row as zero nodes rather than failing', async () => {
+    graphEdit.readWorkflowTurnSnapshot.mockResolvedValue(snapshot())
+    appRows.value = [{ id: WF_ID, draftNodeCount: null }]
+    await expect(
+      caller(capabilitiesFor('read')).getKopilotTurnReview({
+        workflowAppId: WF_ID,
+      })
+    ).resolves.toMatchObject({ currentNodeCount: 0 })
+  })
+
+  it('refuses a member restricted from the workflow entirely', async () => {
+    await expect(
+      caller(
+        capabilitiesFor('none', {
+          areaPermission: 'admin',
+          instances: { [WF_ID]: 'none' },
+        })
+      ).getKopilotTurnReview({ workflowAppId: WF_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(graphEdit.readWorkflowTurnSnapshot).not.toHaveBeenCalled()
+  })
+})
+
+describe('workflow.revertKopilotTurn', () => {
+  it('reverts for an instance `edit` holder, passing the turnId the offer handed out', async () => {
+    await expect(
+      caller(capabilitiesFor('edit')).revertKopilotTurn({
+        workflowAppId: WF_ID,
+        turnId: TURN_ID,
+      })
+    ).resolves.toEqual({ reverted: true })
+    expect(graphEdit.revertWorkflowTurn).toHaveBeenCalledWith(
+      expect.anything(),
+      { workflowAppId: WF_ID, organizationId: ORG_ID },
+      TURN_ID
+    )
+  })
+
+  it('refuses an instance `view` holder — the offer renders at view, taking it does not', async () => {
+    await expect(
+      caller(capabilitiesFor('read')).revertKopilotTurn({
+        workflowAppId: WF_ID,
+        turnId: TURN_ID,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(graphEdit.revertWorkflowTurn).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the 404 verbatim when the snapshot is gone — [C3], not a 500', async () => {
+    // The plan's case: an intervening MANUAL canvas save called
+    // `clearWorkflowTurnSnapshot`, so there is nothing left to revert. The card
+    // has to be able to say so, which means the message must survive the router.
+    const error = new NotFoundError(
+      'No snapshot for turn "x" — either the turn never wrote to the draft, or a later ' +
+        'turn superseded it. Nothing was reverted.'
+    )
+    graphEdit.revertWorkflowTurn.mockResolvedValue({ isErr: () => true, error } as never)
+    await expect(
+      caller(capabilitiesFor('edit')).revertKopilotTurn({
+        workflowAppId: WF_ID,
+        turnId: TURN_ID,
+      })
+    ).rejects.toMatchObject({
+      cause: { name: 'NotFoundError', statusCode: 404, message: error.message },
+    })
+  })
+
+  it('surfaces the 409 verbatim when the canvas moved on — [C3], distinct from the 404', async () => {
+    const error = new ConflictError(
+      'The workflow canvas has changed since that turn finished, so those edits can no ' +
+        'longer be undone as a group. Nothing was reverted.',
+      { reason: 'canvas-changed-since-turn' }
+    )
+    graphEdit.revertWorkflowTurn.mockResolvedValue({ isErr: () => true, error } as never)
+    await expect(
+      caller(capabilitiesFor('edit')).revertKopilotTurn({
+        workflowAppId: WF_ID,
+        turnId: TURN_ID,
+      })
+    ).rejects.toMatchObject({
+      cause: { name: 'ConflictError', statusCode: 409, message: error.message },
+    })
+  })
+
+  it('refuses a system-owned workflow before touching the snapshot', async () => {
+    const { ForbiddenError } = await import('@auxx/lib/errors')
+    guards.app.mockRejectedValueOnce(new ForbiddenError('system-owned'))
+    await expect(
+      caller(capabilitiesFor('admin')).revertKopilotTurn({
+        workflowAppId: WF_ID,
+        turnId: TURN_ID,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(graphEdit.revertWorkflowTurn).not.toHaveBeenCalled()
+  })
+
+  it('a row-less workflow still needs the AREA at Edit', async () => {
+    await expect(
+      caller(capabilitiesFor('read', { instances: {} })).revertKopilotTurn({
+        workflowAppId: WF_ID,
+        turnId: TURN_ID,
+      })
+    ).rejects.toMatchObject(FORBIDDEN)
+    await expect(
+      caller(capabilitiesFor('edit', { instances: {} })).revertKopilotTurn({
+        workflowAppId: WF_ID,
+        turnId: TURN_ID,
+      })
+    ).resolves.toEqual({ reverted: true })
+  })
+})
+
+describe('workflow.keepKopilotTurn', () => {
+  it('discards the snapshot for the pinned turn, turn-checked', async () => {
+    graphEdit.readWorkflowTurnSnapshot.mockResolvedValue(snapshot())
+    await expect(
+      caller(capabilitiesFor('edit')).keepKopilotTurn({ workflowAppId: WF_ID, turnId: TURN_ID })
+    ).resolves.toEqual({ ok: true })
+    // `finalizeWorkflowTurn`, not `clearWorkflowTurnSnapshot`: the delete has to
+    // be turn-checked or a stale Keep button destroys a NEWER turn's recovery
+    // path, which is the one thing this whole phase exists to preserve.
+    expect(graphEdit.finalizeWorkflowTurn).toHaveBeenCalledWith(WF_ID, TURN_ID)
+  })
+
+  it('reads the snapshot turn-PINNED, and soft-fails when a newer turn owns the slot', async () => {
+    graphEdit.readWorkflowTurnSnapshot.mockResolvedValue(null)
+    await expect(
+      caller(capabilitiesFor('edit')).keepKopilotTurn({ workflowAppId: WF_ID, turnId: TURN_ID })
+    ).resolves.toEqual({ ok: false, reason: 'turn_mismatch' })
+    expect(graphEdit.readWorkflowTurnSnapshot).toHaveBeenCalledWith(WF_ID, TURN_ID)
+    expect(graphEdit.finalizeWorkflowTurn).not.toHaveBeenCalled()
+  })
+
+  it('soft-fails a workflow outside the caller’s org without reading the slot', async () => {
+    appRows.value = []
+    await expect(
+      caller(capabilitiesFor('admin', { instances: {} })).keepKopilotTurn({
+        workflowAppId: 'wf_someotherorg000000000',
+        turnId: TURN_ID,
+      })
+    ).resolves.toEqual({ ok: false, reason: 'not_found' })
+    expect(graphEdit.readWorkflowTurnSnapshot).not.toHaveBeenCalled()
+  })
+
+  it('refuses an instance `view` holder — Keep discards a recovery path', async () => {
+    await expect(
+      caller(capabilitiesFor('read')).keepKopilotTurn({ workflowAppId: WF_ID, turnId: TURN_ID })
+    ).rejects.toMatchObject(FORBIDDEN)
+    expect(graphEdit.finalizeWorkflowTurn).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/server/api/routers/workflow.ts
+++ b/apps/web/src/server/api/routers/workflow.ts
@@ -23,12 +23,17 @@ import {
   WorkflowStatsService,
   WorkflowVersionService,
 } from '@auxx/lib/workflows'
-import { readWorkflowTurnLock } from '@auxx/lib/workflows/graph-edit'
+import {
+  finalizeWorkflowTurn,
+  readWorkflowTurnLock,
+  readWorkflowTurnSnapshot,
+  revertWorkflowTurn,
+} from '@auxx/lib/workflows/graph-edit'
 import { getWorkflowAppsByTrigger } from '@auxx/services/workflows'
 import { type RecordId, recordIdSchema } from '@auxx/types/resource'
 import { generateId } from '@auxx/utils/generateId'
 import { TRPCError } from '@trpc/server'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'
 import {
@@ -375,6 +380,179 @@ export const workflowRouter = createTRPCRouter({
       ctx.capabilities.assertViewInstance('workflow', input.workflowAppId)
       const lock = await readWorkflowTurnLock(input.workflowAppId)
       return { active: lock !== null, turnId: lock?.turnId ?? null }
+    }),
+  /**
+   * Recover a pending Kopilot turn review for this workflow — the `base` half
+   * of the post-turn banner, or `null` when nothing is pending (plan 20 §5,
+   * phase D). The workflow twin of `kb.getKopilotTurnReview`, and the two are
+   * deliberately the same shape: a query that runs on mount (so the review
+   * survives a refresh, which no agent event does) and is re-read on the turn
+   * boundary for liveness.
+   *
+   * THE SNAPSHOT'S EXISTENCE *IS* THE SIGNAL. After plan 20 phase A the
+   * workflow-builder capability never reverts automatically and only calls
+   * `finalizeWorkflowTurn` on a COMPLETED turn, so the one-slot-per-workflow
+   * pre-turn snapshot survives exactly one situation: a turn that wrote to the
+   * draft and then stopped without completing (token budget, disconnect, a
+   * throw). Every other path clears it — success finalizes, a manual canvas
+   * save calls `clearWorkflowTurnSnapshot`, the next turn's first write
+   * overwrites the slot, and Redis expires it after 24h. That is why this reads
+   * the snapshot server-side instead of plumbing `turnId` through SSE: the SSE
+   * stream never carries one, and the offer has to survive a reload anyway.
+   *
+   * `view` rung like `kopilotTurnStatus` — the offer is *shown* to anyone who
+   * can see the canvas; taking it is gated at instance `edit` on the mutation.
+   *
+   * Deliberately reads Redis BEFORE the DB: the overwhelmingly common answer is
+   * "no snapshot", and that costs one Redis GET with no query at all. The org
+   * predicate on the row lookup below is what pins the workflow to the caller's
+   * org before any real data (the node counts) is returned — `workflow` is
+   * `baselineAtCreate: false`, so a row-less/foreign id falls back to the
+   * caller's AREA level and would otherwise sail through `assertViewInstance`.
+   */
+  getKopilotTurnReview: permissionProcedure(PermissionKey.workflowsView)
+    .input(z.object({ workflowAppId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      ctx.capabilities.assertViewInstance('workflow', input.workflowAppId)
+
+      const snapshot = await readWorkflowTurnSnapshot(input.workflowAppId)
+      if (!snapshot) return null
+
+      // A turn still holding the draft has not "stopped early" — it is mid-write.
+      // Its snapshot is live fuel for a revert that only becomes an offer once
+      // the turn is over, so offering it now would let the user undo underneath
+      // a running agent.
+      const lock = await readWorkflowTurnLock(input.workflowAppId)
+      if (lock?.turnId === snapshot.turnId) return null
+
+      // Node counts, not edit counts: the snapshot records the graph, never a
+      // tool-call log, so "12 edits were applied" is not provable from here.
+      // The current count is computed IN SQL (`jsonb_array_length`) so this
+      // costs one indexed row and never ships the whole graph jsonb over the
+      // wire — the same reason it does not go through `loadDraftContext`, which
+      // would also build a manifest lookup off the org cache for nothing.
+      const [row] = await ctx.db
+        .select({
+          id: schema.WorkflowApp.id,
+          draftNodeCount: sql<number>`
+            case when jsonb_typeof(${schema.Workflow.graph} -> 'nodes') = 'array'
+              then jsonb_array_length(${schema.Workflow.graph} -> 'nodes')
+              else 0 end
+          `,
+        })
+        .from(schema.WorkflowApp)
+        // LEFT, not INNER: a workflow whose draft row does not exist yet is a
+        // real state (`WorkflowService.update` creates it on first persist), and
+        // it must still resolve the app row that proves org ownership.
+        .leftJoin(schema.Workflow, eq(schema.Workflow.id, schema.WorkflowApp.draftWorkflowId))
+        .where(
+          and(
+            eq(schema.WorkflowApp.id, input.workflowAppId),
+            eq(schema.WorkflowApp.organizationId, ctx.session.organizationId)
+          )
+        )
+        .limit(1)
+      if (!row) return null
+
+      return {
+        turnId: snapshot.turnId,
+        capturedAt: snapshot.capturedAt,
+        /** Nodes on the canvas the moment before the turn's first write. */
+        preTurnNodeCount: snapshot.graph.nodes.length,
+        /** Nodes on the draft right now — the turn's result, still in place. */
+        currentNodeCount: Number(row.draftNodeCount ?? 0),
+        /**
+         * How the turn ended (`exhausted` / `aborted` / `error`), stamped on
+         * the snapshot at turn end. NULL is a real, expected answer — a
+         * snapshot from before the field existed, a turn that died before its
+         * turn-end hook ran, or a stamp whose Redis write failed — and the
+         * banner must fall back to its generic wording rather than withhold
+         * the offer. Normalised to null (not omitted) so the client sees one
+         * shape.
+         */
+        endedAs: snapshot.endedAs ?? null,
+      }
+    }),
+  /**
+   * Take the offer above: restore the exact pre-turn graph.
+   *
+   * Instance `edit`, like every other draft-writing mutation in this file — the
+   * offer renders at `view`, but undoing a turn rewrites the draft.
+   *
+   * `turnId` is an INPUT rather than re-derived server-side on purpose: it is
+   * the one the query handed this client, so a card left open across a newer
+   * turn cannot revert a turn the user never saw. `revertWorkflowTurn` checks it
+   * against the slot and refuses with `NotFoundError` when they disagree.
+   *
+   * Three outcomes reach the client, and the card is expected to tell them
+   * apart — the two refusals carry messages written to be shown verbatim:
+   * `NotFoundError` (404, the snapshot is gone), `ConflictError` (409, the
+   * canvas moved on since the turn — `details.reason ===
+   * 'canvas-changed-since-turn'` — or `persistDraft`'s own CAS losing to a save
+   * racing the revert), and success. NOTHING is written on either refusal; the
+   * 409 additionally leaves the snapshot in place, so that offer stays live and
+   * can be retried once the canvas is back where the turn left it.
+   */
+  revertKopilotTurn: permissionProcedure(PermissionKey.workflowsView)
+    .input(z.object({ workflowAppId: z.string(), turnId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertEditInstance('workflow', input.workflowAppId)
+      await assertWorkflowAppNotSystemOwned(ctx.db, {
+        workflowAppId: input.workflowAppId,
+        organizationId: ctx.session.organizationId,
+        isSuperAdmin: ctx.session.isSuperAdmin,
+      })
+      // No try/catch: the AuxxError travels as-is and `auxxErrorMiddleware`
+      // maps 404/409 to the matching tRPC code. Wrapping it here would flatten
+      // both into a 500 and take the user-facing message with it.
+      const reverted = await revertWorkflowTurn(
+        ctx.db,
+        {
+          workflowAppId: input.workflowAppId,
+          organizationId: ctx.session.organizationId,
+        },
+        input.turnId
+      )
+      if (reverted.isErr()) throw reverted.error
+      return { reverted: true }
+    }),
+  /**
+   * Commit the turn — the user is happy with what it left behind. Discards the
+   * pre-turn snapshot, which removes the Undo affordance; the turn lock was
+   * already released by the capability's `onTurnEnd`.
+   *
+   * The workflow twin of `kb.keepKopilotTurn`, including its soft
+   * `{ ok, reason }` return: Keep is not destructive and its only failure mode
+   * is "there was nothing left to keep", which is indistinguishable from
+   * success from the user's side — a thrown 404 would be noise.
+   *
+   * Turn-pinned through `finalizeWorkflowTurn`, so a stale Keep button cannot
+   * clear a NEWER turn's snapshot and silently destroy that turn's recovery
+   * path. Without this the only way an offer went away was the 24h TTL.
+   */
+  keepKopilotTurn: permissionProcedure(PermissionKey.workflowsView)
+    .input(z.object({ workflowAppId: z.string(), turnId: z.string().min(1) }))
+    .mutation(async ({ ctx, input }) => {
+      ctx.capabilities.assertEditInstance('workflow', input.workflowAppId)
+      // Snapshots are keyed by workflowAppId alone in Redis, so pin the org
+      // before touching one — `workflow` is `baselineAtCreate: false` and a
+      // row-less (foreign) id falls back to the caller's AREA level.
+      const [workflowApp] = await ctx.db
+        .select({ id: schema.WorkflowApp.id })
+        .from(schema.WorkflowApp)
+        .where(
+          and(
+            eq(schema.WorkflowApp.id, input.workflowAppId),
+            eq(schema.WorkflowApp.organizationId, ctx.session.organizationId)
+          )
+        )
+        .limit(1)
+      if (!workflowApp) return { ok: false as const, reason: 'not_found' as const }
+
+      const snapshot = await readWorkflowTurnSnapshot(input.workflowAppId, input.turnId)
+      if (!snapshot) return { ok: false as const, reason: 'turn_mismatch' as const }
+      await finalizeWorkflowTurn(input.workflowAppId, input.turnId)
+      return { ok: true as const }
     }),
   /**
    * Create a new workflow app with initial workflow version

--- a/packages/lib/scripts/seed-turn-snapshot.ts
+++ b/packages/lib/scripts/seed-turn-snapshot.ts
@@ -1,0 +1,33 @@
+// packages/lib/scripts/seed-turn-snapshot.ts
+//
+// Dev-only: seed a Kopilot pre-turn snapshot so the workflow builder's
+// "turn stopped early" Undo banner can be exercised without having to make a
+// real turn trip the token budget. See plans/kopilot/workflow/20-partial-turn-survival.md
+//
+//   npx dotenv -- npx tsx packages/lib/scripts/seed-turn-snapshot.ts <workflowAppId> <endedAs> [--bad-hash]
+
+import { getRedisData, setRedisData } from '@auxx/redis'
+
+const [workflowAppId, endedAs = 'exhausted'] = process.argv.slice(2)
+const badHash = process.argv.includes('--bad-hash')
+if (!workflowAppId)
+  throw new Error('usage: seed-turn-snapshot.ts <workflowAppId> [endedAs] [--bad-hash]')
+
+const key = `workflow:graph:${workflowAppId}:preturn`
+
+const snapshot = {
+  turnId: `turn-seeded-${Date.now()}`,
+  name: 'Tracking number',
+  description: null,
+  // Deliberately EMPTY: the banner should report "N nodes back to 0".
+  graph: { nodes: [], edges: [] },
+  triggerType: null,
+  capturedAt: Date.now() - 5 * 60 * 1000,
+  ...(badHash ? { postTurnGraphHash: 'deadbeefdeadbeefdeadbeefdeadbeef' } : {}),
+  endedAs,
+}
+
+await setRedisData(key, snapshot, 24 * 60 * 60)
+console.log('seeded', key)
+console.log(JSON.stringify(await getRedisData(key), null, 2))
+process.exit(0)

--- a/packages/lib/src/ai/agent-framework/__tests__/turn-outcome.test.ts
+++ b/packages/lib/src/ai/agent-framework/__tests__/turn-outcome.test.ts
@@ -1,0 +1,430 @@
+// packages/lib/src/ai/agent-framework/__tests__/turn-outcome.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { ToolCall, UsageMetrics } from '../../clients/base/types'
+import { AgentEngine } from '../engine'
+import type {
+  AgentDefinition,
+  AgentDomainConfig,
+  AgentEngineConfig,
+  AgentEvent,
+  AgentToolDefinition,
+  LLMCallParams,
+  LLMStreamEvent,
+  TurnOutcome,
+} from '../types'
+
+/**
+ * A failed turn used to destroy the work it had already done.
+ *
+ * `onTurnEnd`'s outcome was one bit — `'completed' | 'error'` — so "ran out of
+ * tokens after twelve good edits" and "threw mid-write" arrived at the domain
+ * hook identically, and the hook rolled the whole turn back. These tests pin
+ * the widened vocabulary and, critically, that the classification reads the
+ * `turn-error` event's `reason` discriminator and NEVER its message text.
+ */
+
+const ZERO_USAGE: UsageMetrics = { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }
+const SOME_USAGE: UsageMetrics = { prompt_tokens: 8, completion_tokens: 2, total_tokens: 10 }
+
+const makeToolCall = (id: string, name: string): ToolCall => ({
+  id,
+  type: 'function',
+  function: { name, arguments: '{}' },
+})
+
+async function drain(gen: AsyncGenerator<AgentEvent>): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = []
+  for await (const event of gen) events.push(event)
+  return events
+}
+
+/**
+ * A `callModel` that fails the way a provider outage does. Rejects rather than
+ * `throw`ing so the generator body keeps a reachable `yield`.
+ */
+function explodingModel(message: string) {
+  return async function* (): AsyncGenerator<LLMStreamEvent> {
+    await Promise.reject(new Error(message))
+    yield { type: 'done', content: '', toolCalls: [], usage: ZERO_USAGE }
+  }
+}
+
+const okTool: AgentToolDefinition = {
+  name: 'poke',
+  displayName: 'Poke',
+  description: 'Always succeeds',
+  parameters: { type: 'object', properties: {} },
+  execute: async () => ({ success: true, output: { ok: true } }),
+}
+
+const failingTool: AgentToolDefinition = {
+  name: 'boom',
+  displayName: 'Boom',
+  description: 'Always fails',
+  parameters: { type: 'object', properties: {} },
+  execute: async () => ({ success: false, output: undefined, error: 'nope' }),
+}
+
+interface HarnessOptions {
+  callModel: (params: LLMCallParams) => AsyncGenerator<LLMStreamEvent>
+  agents?: Record<string, AgentDefinition>
+  route?: string[]
+  tools?: AgentToolDefinition[]
+  maxIterations?: number
+  maxTokensPerTurn?: number
+  maxTotalIterations?: number
+  maxApprovalsPerTurn?: number
+  signal?: AbortSignal
+}
+
+function buildEngine(opts: HarnessOptions) {
+  const outcomes: TurnOutcome[] = []
+
+  const agents: Record<string, AgentDefinition> = opts.agents ?? {
+    agent: {
+      name: 'agent',
+      tools: opts.tools ?? [okTool],
+      buildMessages: async () => [{ role: 'user', content: 'go' }],
+      processResult: async (_c, _tc, state) => state,
+      ...(opts.maxIterations !== undefined ? { maxIterations: opts.maxIterations } : {}),
+    },
+  }
+
+  const domainConfig: AgentDomainConfig = {
+    type: 'kopilot',
+    agents,
+    routes: [{ name: 'default', agents: opts.route ?? ['agent'] }],
+    createInitialState: () => ({}),
+    defaultModel: 'm',
+    defaultProvider: 'p',
+    onTurnEnd: async (_state, outcome) => {
+      outcomes.push(outcome)
+    },
+  }
+
+  const config: AgentEngineConfig = {
+    organizationId: 'org-1',
+    userId: 'user-1',
+    sessionId: 'sess-1',
+    // biome-ignore lint/suspicious/noExplicitAny: tests don't touch the db handle
+    db: {} as any,
+    domainConfig,
+    callModel: opts.callModel,
+    ...(opts.maxTokensPerTurn !== undefined ? { maxTokensPerTurn: opts.maxTokensPerTurn } : {}),
+    ...(opts.maxTotalIterations !== undefined
+      ? { maxTotalIterations: opts.maxTotalIterations }
+      : {}),
+    ...(opts.maxApprovalsPerTurn !== undefined
+      ? { maxApprovalsPerTurn: opts.maxApprovalsPerTurn }
+      : {}),
+    ...(opts.signal ? { signal: opts.signal } : {}),
+  }
+
+  return { engine: new AgentEngine(config), outcomes }
+}
+
+function turnError(events: AgentEvent[]) {
+  return events.find((e) => e.type === 'turn-error') as
+    | Extract<AgentEvent, { type: 'turn-error' }>
+    | undefined
+}
+
+describe('turn outcome vocabulary', () => {
+  it('reports "completed" for a turn that finishes normally', async () => {
+    const { engine, outcomes } = buildEngine({
+      callModel: async function* () {
+        yield { type: 'done', content: 'all set', toolCalls: [], usage: ZERO_USAGE }
+      },
+    })
+
+    const events = await drain(engine.submitMessage('go'))
+
+    expect(events.some((e) => e.type === 'turn-completed')).toBe(true)
+    expect(outcomes).toEqual(['completed'])
+  })
+
+  it('reports "exhausted" — not "error" — when the token budget runs out', async () => {
+    const { engine, outcomes } = buildEngine({
+      maxTokensPerTurn: 5,
+      callModel: async function* () {
+        yield { type: 'done', content: 'did a lot of work', toolCalls: [], usage: SOME_USAGE }
+      },
+    })
+
+    const events = await drain(engine.submitMessage('go'))
+
+    expect(turnError(events)?.reason).toBe('token-budget')
+    expect(outcomes).toEqual(['exhausted'])
+  })
+
+  it('reports "exhausted" when the same tool fails three times in a row', async () => {
+    const { engine, outcomes } = buildEngine({
+      tools: [failingTool],
+      callModel: async function* () {
+        yield {
+          type: 'done',
+          content: '',
+          toolCalls: [makeToolCall('c1', 'boom')],
+          usage: ZERO_USAGE,
+        }
+      },
+    })
+
+    const events = await drain(engine.submitMessage('go'))
+
+    expect(turnError(events)?.reason).toBe('tool-failure-streak')
+    expect(outcomes).toEqual(['exhausted'])
+  })
+
+  it('reports "exhausted" when the turn chains past the max-approvals cap', async () => {
+    // The cap trips BETWEEN approvals — the tool that tripped it already ran and
+    // settled — so this is a resource cap like the others, not corruption.
+    // Reachable in practice: Kopilot allows 50, and a long authoring turn chains
+    // approvals.
+    const approvalTool: AgentToolDefinition = {
+      name: 'write',
+      displayName: 'Write',
+      description: 'Needs approval',
+      parameters: { type: 'object', properties: {} },
+      requiresApproval: true,
+      execute: async () => ({ success: true, output: { written: true } }),
+    }
+
+    const { engine, outcomes } = buildEngine({
+      tools: [approvalTool],
+      maxApprovalsPerTurn: 0,
+      callModel: async function* () {
+        yield {
+          type: 'done',
+          content: '',
+          toolCalls: [makeToolCall('c1', 'write')],
+          usage: ZERO_USAGE,
+        }
+      },
+    })
+
+    await drain(engine.submitMessage('go'))
+    // The pause is not a turn end — `waitingForApproval` suppresses the hook.
+    expect(engine.getState().pendingToolCall).toBeDefined()
+    expect(outcomes).toEqual([])
+
+    const events = await drain(engine.resume({ action: 'approve' }))
+
+    expect(turnError(events)?.reason).toBe('max-approvals')
+    expect(outcomes).toEqual(['exhausted'])
+  })
+
+  it('reports "error" for a thrown failure inside the turn', async () => {
+    const { engine, outcomes } = buildEngine({
+      callModel: explodingModel('provider exploded'),
+    })
+
+    const events = await drain(engine.submitMessage('go'))
+
+    expect(turnError(events)?.reason).toBe('internal')
+    expect(outcomes).toEqual(['error'])
+  })
+
+  it('reports "aborted" when the consumer stops draining an interrupted turn', async () => {
+    // The real scenario: the SSE route's request-abort listener calls
+    // interrupt() and then the response generator is cancelled, so no terminal
+    // event is ever yielded and only `withTurnEnd`'s finally guard runs.
+    const { engine, outcomes } = buildEngine({
+      callModel: async function* () {
+        yield { type: 'done', content: 'hi', toolCalls: [], usage: ZERO_USAGE }
+      },
+    })
+
+    const gen = engine.submitMessage('go')
+    await gen.next() // turn-started
+    engine.interrupt()
+    await gen.return(undefined as never)
+
+    expect(outcomes).toEqual(['aborted'])
+  })
+
+  it('still reports "error" for an undrained close that was NOT aborted', async () => {
+    const { engine, outcomes } = buildEngine({
+      callModel: async function* () {
+        yield { type: 'done', content: 'hi', toolCalls: [], usage: ZERO_USAGE }
+      },
+    })
+
+    const gen = engine.submitMessage('go')
+    await gen.next()
+    await gen.return(undefined as never)
+
+    expect(outcomes).toEqual(['error'])
+  })
+
+  it('classifies on `reason`, never on the error text', async () => {
+    // An LLM failure whose message is a verbatim copy of the token-budget
+    // wording. Text-matching would call this exhaustion; the discriminator says
+    // it is a real error.
+    const { engine, outcomes } = buildEngine({
+      callModel: explodingModel('Turn exceeded token budget (999/100)'),
+    })
+
+    const events = await drain(engine.submitMessage('go'))
+
+    expect(turnError(events)?.error).toContain('Turn exceeded token budget')
+    expect(turnError(events)?.reason).toBe('internal')
+    expect(outcomes).toEqual(['error'])
+  })
+})
+
+describe('maxTotalIterations counts iterations, not agents (fix 10.1)', () => {
+  it('advances the total by one agent run’s LLM calls, not by 1', async () => {
+    // `assistant-message-finished` fires once per AGENT, so the old
+    // `totalIterations++` could never exceed 1 on a route — a cap of 3 was
+    // unreachable no matter how long the agent looped. The first agent here
+    // burns four metered LLM calls; the cap must bite before the second agent
+    // ever starts.
+    let calls = 0
+    const callModel = async function* (): AsyncGenerator<LLMStreamEvent> {
+      calls++
+      if (calls < 4) {
+        yield {
+          type: 'done',
+          content: '',
+          toolCalls: [makeToolCall(`c${calls}`, 'poke')],
+          usage: SOME_USAGE,
+        }
+        return
+      }
+      yield { type: 'done', content: 'done', toolCalls: [], usage: SOME_USAGE }
+    }
+
+    const makeAgent = (name: string): AgentDefinition => ({
+      name,
+      tools: [okTool],
+      buildMessages: async () => [{ role: 'user', content: 'go' }],
+      processResult: async (_c, _tc, state) => state,
+      maxIterations: 10,
+    })
+
+    const { engine, outcomes } = buildEngine({
+      callModel,
+      agents: { first: makeAgent('first'), second: makeAgent('second') },
+      route: ['first', 'second'],
+      maxTotalIterations: 3,
+    })
+
+    const events = await drain(engine.submitMessage('go'))
+
+    expect(turnError(events)?.reason).toBe('max-iterations')
+    // The second agent never got to run — proof the counter saw 4, not 1.
+    expect(events.some((e) => e.type === 'agent-started' && e.agent === 'second')).toBe(false)
+    expect(calls).toBe(4)
+    // A cap is exhaustion, not corruption.
+    expect(outcomes).toEqual(['exhausted'])
+  })
+
+  it('does not trip the cap when the agent stays under it', async () => {
+    let calls = 0
+    const callModel = async function* (): AsyncGenerator<LLMStreamEvent> {
+      calls++
+      if (calls < 2) {
+        yield {
+          type: 'done',
+          content: '',
+          toolCalls: [makeToolCall('c1', 'poke')],
+          usage: SOME_USAGE,
+        }
+        return
+      }
+      yield { type: 'done', content: 'done', toolCalls: [], usage: SOME_USAGE }
+    }
+
+    const { engine, outcomes } = buildEngine({
+      callModel,
+      maxIterations: 10,
+      maxTotalIterations: 5,
+    })
+
+    const events = await drain(engine.submitMessage('go'))
+
+    expect(events.some((e) => e.type === 'turn-error')).toBe(false)
+    expect(outcomes).toEqual(['completed'])
+  })
+})
+
+describe('AgentEngineConfig.signal is honoured (fix 10.2)', () => {
+  it('stops a turn whose caller-supplied signal is already aborted', async () => {
+    const caller = new AbortController()
+    caller.abort()
+
+    let calls = 0
+    const { engine } = buildEngine({
+      signal: caller.signal,
+      callModel: async function* (): AsyncGenerator<LLMStreamEvent> {
+        calls++
+        yield { type: 'done', content: 'hi', toolCalls: [], usage: ZERO_USAGE }
+      },
+    })
+
+    await drain(engine.submitMessage('go'))
+
+    // The engine used to overwrite `config.signal` with its own controller's
+    // signal, so the caller's abort was invisible and the model still ran.
+    expect(calls).toBe(0)
+  })
+
+  it('stops a turn when the caller aborts mid-flight', async () => {
+    const caller = new AbortController()
+
+    const abortingTool: AgentToolDefinition = {
+      name: 'poke',
+      displayName: 'Poke',
+      description: 'Aborts the caller signal',
+      parameters: { type: 'object', properties: {} },
+      execute: async () => {
+        caller.abort()
+        return { success: true, output: { ok: true } }
+      },
+    }
+
+    let calls = 0
+    const { engine } = buildEngine({
+      signal: caller.signal,
+      tools: [abortingTool],
+      maxIterations: 10,
+      callModel: async function* (): AsyncGenerator<LLMStreamEvent> {
+        calls++
+        yield {
+          type: 'done',
+          content: '',
+          toolCalls: [makeToolCall(`c${calls}`, 'poke')],
+          usage: ZERO_USAGE,
+        }
+      },
+    })
+
+    await drain(engine.submitMessage('go'))
+
+    expect(calls).toBe(1)
+  })
+
+  it('leaves engine.interrupt() working when no caller signal is supplied', async () => {
+    let calls = 0
+    const { engine } = buildEngine({
+      maxIterations: 10,
+      tools: [okTool],
+      callModel: async function* (): AsyncGenerator<LLMStreamEvent> {
+        calls++
+        if (calls === 1) engine.interrupt()
+        yield {
+          type: 'done',
+          content: '',
+          toolCalls: [makeToolCall(`c${calls}`, 'poke')],
+          usage: ZERO_USAGE,
+        }
+      },
+    })
+
+    await drain(engine.submitMessage('go'))
+
+    expect(calls).toBe(1)
+  })
+})

--- a/packages/lib/src/ai/agent-framework/__tests__/turn-token-meter.test.ts
+++ b/packages/lib/src/ai/agent-framework/__tests__/turn-token-meter.test.ts
@@ -1,0 +1,431 @@
+// packages/lib/src/ai/agent-framework/__tests__/turn-token-meter.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { ToolCall, UsageMetrics } from '../../clients/base/types'
+import { KOPILOT_TURN_BUDGET } from '../../kopilot/turn-budget'
+import { AgentEngine } from '../engine'
+import type {
+  AgentDefinition,
+  AgentDomainConfig,
+  AgentEngineConfig,
+  AgentEvent,
+  AgentToolDefinition,
+  LLMCallParams,
+  LLMStreamEvent,
+  TurnOutcome,
+} from '../types'
+import { meterRollupTokens, normalizeCallUsage, promptIncludesCachedReads } from '../usage-metering'
+
+/**
+ * The per-turn token budget used to charge for the conversation, not the work.
+ *
+ * It summed each LLM call's `total_tokens`, which includes prompt tokens — and
+ * the entire conversation is re-sent every iteration. So the meter grew
+ * superlinearly in iteration count while the turn produced a steady trickle of
+ * genuinely new tokens, and a long editing turn died on bookkeeping after doing
+ * all of its work. The meter now charges non-cached input + completion, read off
+ * the raw per-call `IterationUsage` records rather than the cumulative roll-up.
+ *
+ * These tests pin the unit, the two provider semantics that make it
+ * expressible, the fallback when neither is reported, and — critically — that
+ * the budget still bounds the one loop it is the only bound on.
+ */
+
+// ===== USAGE SHAPES =====
+
+/**
+ * Anthropic-shaped usage: `prompt_tokens` is the UNCACHED remainder; cache
+ * reads and writes arrive as separate counts and are NOT inside it.
+ */
+const anthropicUsage = (
+  uncachedInput: number,
+  cachedInput: number,
+  completion: number,
+  cacheWrite = 0
+): UsageMetrics => ({
+  prompt_tokens: uncachedInput,
+  completion_tokens: completion,
+  total_tokens: uncachedInput + completion,
+  cached_input_tokens: cachedInput,
+  cache_write_tokens: cacheWrite,
+})
+
+/**
+ * OpenAI-shaped usage (and every other provider in the registry, which all
+ * share `OpenAILLMClient.convertUsage`): `prompt_tokens` INCLUDES the cached
+ * reads, and there is no explicit write count.
+ */
+const openaiUsage = (
+  promptTokens: number,
+  cachedInput: number,
+  completion: number
+): UsageMetrics => ({
+  prompt_tokens: promptTokens,
+  completion_tokens: completion,
+  total_tokens: promptTokens + completion,
+  cached_input_tokens: cachedInput,
+})
+
+/** A provider that reports no cache accounting at all. */
+const bareUsage = (prompt: number, completion: number): UsageMetrics => ({
+  prompt_tokens: prompt,
+  completion_tokens: completion,
+  total_tokens: prompt + completion,
+})
+
+// ===== HARNESS =====
+
+interface CallScript {
+  content?: string
+  toolCalls?: ToolCall[]
+  usage: UsageMetrics
+}
+
+const toolCall = (n: number): ToolCall[] => [
+  // Args vary per iteration on purpose: identical (name, args) pairs trip the
+  // turn-wide identical-call budget long before 30 iterations, and this suite
+  // is about tokens, not repetition.
+  { id: `c${n}`, type: 'function', function: { name: 'edit', arguments: `{"n":${n}}` } },
+]
+
+const editTool: AgentToolDefinition = {
+  name: 'edit',
+  displayName: 'Edit',
+  description: 'Applies one graph edit',
+  parameters: { type: 'object', properties: { n: { type: 'number' } } },
+  execute: async () => ({ success: true, output: { applied: true } }),
+}
+
+async function drain(gen: AsyncGenerator<AgentEvent>): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = []
+  for await (const event of gen) events.push(event)
+  return events
+}
+
+function turnError(events: AgentEvent[]) {
+  return events.find((e) => e.type === 'turn-error') as
+    | Extract<AgentEvent, { type: 'turn-error' }>
+    | undefined
+}
+
+interface HarnessOptions {
+  script: CallScript[]
+  provider?: string
+  maxTokensPerTurn?: number
+  maxIterations?: number
+}
+
+function buildEngine(opts: HarnessOptions) {
+  const outcomes: TurnOutcome[] = []
+  const calls: LLMCallParams[] = []
+
+  let index = 0
+  // Past the end of the script the last step repeats — that step is always the
+  // text-only reply, so the loop terminates naturally.
+  const callModel = async function* (params: LLMCallParams): AsyncGenerator<LLMStreamEvent> {
+    calls.push(params)
+    const step = opts.script[Math.min(index, opts.script.length - 1)]!
+    index++
+    yield {
+      type: 'done',
+      content: step.content ?? '',
+      toolCalls: step.toolCalls ?? [],
+      usage: step.usage,
+    }
+  }
+
+  const agent: AgentDefinition = {
+    name: 'agent',
+    tools: [editTool],
+    buildMessages: async () => [{ role: 'user', content: 'go' }],
+    processResult: async (_c, _tc, state) => state,
+    maxIterations: opts.maxIterations ?? 40,
+  }
+
+  const domainConfig: AgentDomainConfig = {
+    type: 'kopilot',
+    agents: { agent },
+    routes: [{ name: 'default', agents: ['agent'] }],
+    createInitialState: () => ({}),
+    defaultModel: 'model-x',
+    defaultProvider: opts.provider ?? 'anthropic',
+    onTurnEnd: async (_state, outcome) => {
+      outcomes.push(outcome)
+    },
+  }
+
+  const config: AgentEngineConfig = {
+    organizationId: 'org-1',
+    userId: 'user-1',
+    sessionId: 'sess-1',
+    db: {} as never,
+    domainConfig,
+    callModel,
+    ...(opts.maxTokensPerTurn !== undefined ? { maxTokensPerTurn: opts.maxTokensPerTurn } : {}),
+  }
+
+  return { engine: new AgentEngine(config), outcomes, calls }
+}
+
+/**
+ * A twelve-tool-iteration editing turn in the OpenAI shape, where the whole
+ * conversation is re-sent every call and almost all of it comes back from the
+ * prompt cache. Each call presents a bigger prompt but does the same small
+ * amount of new work: 2,000 fresh input tokens + a 500-token completion.
+ */
+function growingPromptScript(): { script: CallScript[]; metered: number; oldMeter: number } {
+  const script: CallScript[] = []
+  let metered = 0
+  let oldMeter = 0
+  for (let i = 0; i <= 12; i++) {
+    const promptTokens = 20_000 + i * 5_000
+    const usage = openaiUsage(promptTokens, promptTokens - 2_000, 500)
+    metered += 2_000 + 500
+    oldMeter += usage.total_tokens
+    script.push(
+      i < 12 ? { toolCalls: toolCall(i), usage } : { content: 'twelve edits applied', usage }
+    )
+  }
+  return { script, metered, oldMeter }
+}
+
+// ===== THE NORMALIZATION HELPER =====
+
+describe('normalizeCallUsage', () => {
+  it('reconciles the OpenAI and Anthropic shapes of the SAME call', () => {
+    // One physical call: 30k input presented, 20k of it served from cache,
+    // 1k completion. Each provider reports that differently.
+    const asOpenai = normalizeCallUsage(openaiUsage(30_000, 20_000, 1_000), 'openai')
+    const asAnthropic = normalizeCallUsage(anthropicUsage(10_000, 20_000, 1_000), 'anthropic')
+
+    expect(asOpenai.totalInput).toBe(30_000)
+    expect(asAnthropic.totalInput).toBe(30_000)
+    expect(asOpenai.rateLimitInput).toBe(10_000)
+    expect(asAnthropic.rateLimitInput).toBe(10_000)
+    // The whole point: the budget cannot depend on which vendor served the call.
+    expect(asOpenai.meteredTokens).toBe(11_000)
+    expect(asAnthropic.meteredTokens).toBe(asOpenai.meteredTokens)
+  })
+
+  it('treats every non-Anthropic provider as prompt-includes-cached', () => {
+    // They all share OpenAILLMClient.convertUsage, so a substring test for
+    // "openai" would double-charge their cached prefix.
+    for (const provider of [
+      'openai',
+      'google',
+      'groq',
+      'deepseek',
+      'qwen',
+      'kimi',
+      'zai',
+      'grok',
+    ]) {
+      expect(promptIncludesCachedReads(provider)).toBe(true)
+      expect(normalizeCallUsage(openaiUsage(30_000, 20_000, 1_000), provider).meteredTokens).toBe(
+        11_000
+      )
+    }
+    expect(promptIncludesCachedReads('anthropic')).toBe(false)
+    expect(promptIncludesCachedReads('Anthropic')).toBe(false)
+  })
+
+  it('charges cache writes on both shapes — they are new input', () => {
+    expect(
+      normalizeCallUsage(anthropicUsage(1_000, 20_000, 100, 4_000), 'anthropic')
+    ).toMatchObject({ rateLimitInput: 5_000, meteredTokens: 5_100, totalInput: 25_000 })
+  })
+
+  it('falls back to prompt + completion when no cache field is reported', () => {
+    for (const provider of ['anthropic', 'openai', undefined]) {
+      const norm = normalizeCallUsage(bareUsage(9_000, 700), provider)
+      expect(norm.meteredTokens).toBe(9_700)
+      expect(Number.isNaN(norm.meteredTokens)).toBe(false)
+      expect(norm.meteredTokens).toBeGreaterThan(0)
+    }
+  })
+
+  it('never yields NaN or a negative charge from malformed counts', () => {
+    // A deliberately malformed provider payload.
+    const nan = normalizeCallUsage(
+      { prompt_tokens: Number.NaN, total_tokens: Number.NaN } as UsageMetrics,
+      'openai'
+    )
+    expect(nan.meteredTokens).toBe(0)
+    expect(Number.isNaN(nan.meteredTokens)).toBe(false)
+
+    // cached > prompt is nonsense, but it must not produce a negative charge
+    // that would refund the meter.
+    const inverted = normalizeCallUsage(openaiUsage(1_000, 5_000, 200), 'openai')
+    expect(inverted.rateLimitInput).toBe(0)
+    expect(inverted.meteredTokens).toBe(200)
+
+    expect(normalizeCallUsage(undefined, 'openai').meteredTokens).toBe(0)
+  })
+
+  it('meters an unknown-provider roll-up on prompt + completion', () => {
+    // A roll-up can span providers, so neither cache semantics applies — and a
+    // silent 0 would disable the budget outright.
+    expect(meterRollupTokens(openaiUsage(30_000, 20_000, 1_000))).toBe(31_000)
+    expect(meterRollupTokens(undefined)).toBe(0)
+  })
+})
+
+// ===== THE METER, END TO END THROUGH THE ENGINE =====
+
+describe('per-turn token meter', () => {
+  it('does not grow with re-sent prompt tokens across iterations', async () => {
+    const { script, metered, oldMeter } = growingPromptScript()
+    // Sanity-check the fixture itself: the old unit really was ~20x the new one
+    // on this turn, and really did exceed the framework default.
+    expect(metered).toBe(32_500)
+    expect(oldMeter).toBe(656_500)
+
+    const { engine, outcomes } = buildEngine({
+      script,
+      provider: 'openai',
+      // Below the old meter (656_500), far above the new one (32_500).
+      maxTokensPerTurn: 200_000,
+    })
+
+    const events = await drain(engine.submitMessage('build the workflow'))
+
+    expect(turnError(events)).toBeUndefined()
+    expect(events.some((e) => e.type === 'turn-completed')).toBe(true)
+    expect(outcomes).toEqual(['completed'])
+  })
+
+  it('meters exactly the new work — bracketing the budget pins the value', async () => {
+    const { script, metered } = growingPromptScript()
+
+    const under = buildEngine({ script, provider: 'openai', maxTokensPerTurn: metered + 1 })
+    expect(turnError(await drain(under.engine.submitMessage('go')))).toBeUndefined()
+
+    const over = buildEngine({ script, provider: 'openai', maxTokensPerTurn: metered })
+    const events = await drain(over.engine.submitMessage('go'))
+    expect(turnError(events)?.reason).toBe('token-budget')
+    expect(turnError(events)?.error).toContain(`${metered}/${metered}`)
+  })
+
+  it('lets a long editing turn (30 tool iterations) finish under the Kopilot budget', async () => {
+    // The pessimistic per-call reading the constant is sized against: the
+    // observed `promptInput: 34389` treated as ALL uncached (Anthropic shape),
+    // plus a 1,500-token completion. 31 calls ≈ 1.11M metered.
+    const script: CallScript[] = []
+    for (let i = 0; i <= 30; i++) {
+      const usage = anthropicUsage(34_389, 19_072, 1_500)
+      script.push(i < 30 ? { toolCalls: toolCall(i), usage } : { content: 'done', usage })
+    }
+
+    const { engine, outcomes } = buildEngine({
+      script,
+      provider: 'anthropic',
+      maxTokensPerTurn: KOPILOT_TURN_BUDGET.maxTokensPerTurn,
+      maxIterations: 40,
+    })
+
+    const events = await drain(engine.submitMessage('build the workflow'))
+
+    expect(turnError(events)).toBeUndefined()
+    expect(outcomes).toEqual(['completed'])
+  })
+
+  it('still trips on a genuine runaway', async () => {
+    // Same per-call cost, but the model will not stop: 80 tool iterations of
+    // real new input is real spend, and the budget must say so. It is scripted
+    // to reply at the end only so the query loop finalizes normally — the meter
+    // is what is under test, not the iteration cap's close.
+    const script: CallScript[] = []
+    for (let i = 0; i <= 80; i++) {
+      const usage = anthropicUsage(34_389, 19_072, 1_500)
+      script.push(i < 80 ? { toolCalls: toolCall(i), usage } : { content: 'done', usage })
+    }
+
+    const { engine, outcomes } = buildEngine({
+      script,
+      provider: 'anthropic',
+      maxTokensPerTurn: KOPILOT_TURN_BUDGET.maxTokensPerTurn,
+      maxIterations: 100,
+    })
+
+    const events = await drain(engine.submitMessage('go'))
+
+    expect(turnError(events)?.reason).toBe('token-budget')
+    // Exhaustion, not corruption — the work this turn did stays.
+    expect(outcomes).toEqual(['exhausted'])
+  })
+
+  it('uses the documented fallback for a provider reporting no cache fields', async () => {
+    const script: CallScript[] = [
+      { toolCalls: toolCall(0), usage: bareUsage(1_000, 100) },
+      { toolCalls: toolCall(1), usage: bareUsage(1_000, 100) },
+      { content: 'done', usage: bareUsage(1_000, 100) },
+    ]
+    // prompt + completion, three calls = 3,300. Never NaN, never 0.
+    const under = buildEngine({ script, maxTokensPerTurn: 3_301 })
+    expect(turnError(await drain(under.engine.submitMessage('go')))).toBeUndefined()
+
+    const over = buildEngine({ script, maxTokensPerTurn: 3_300 })
+    const events = await drain(over.engine.submitMessage('go'))
+    expect(turnError(events)?.reason).toBe('token-budget')
+    expect(turnError(events)?.error).toContain('3300/3300')
+    expect(turnError(events)?.error).not.toContain('NaN')
+  })
+
+  it('reads the same meter for OpenAI-shaped and Anthropic-shaped turns', async () => {
+    // Identical physical turns, reported in each vendor's native shape. Both
+    // must trip at the same budget and clear the same one.
+    const build = (provider: string, usage: UsageMetrics, cap: number) =>
+      buildEngine({
+        script: [
+          { toolCalls: toolCall(0), usage },
+          { toolCalls: toolCall(1), usage },
+          { content: 'done', usage },
+        ],
+        provider,
+        maxTokensPerTurn: cap,
+      })
+
+    const openai = openaiUsage(30_000, 20_000, 1_000)
+    const anthropic = anthropicUsage(10_000, 20_000, 1_000)
+    const perCall = 11_000
+    const total = perCall * 3
+
+    for (const [provider, usage] of [
+      ['openai', openai],
+      ['anthropic', anthropic],
+    ] as const) {
+      const cleared = build(provider, usage, total + 1)
+      expect(turnError(await drain(cleared.engine.submitMessage('go')))).toBeUndefined()
+
+      const tripped = build(provider, usage, total)
+      const events = await drain(tripped.engine.submitMessage('go'))
+      expect(turnError(events)?.reason).toBe('token-budget')
+      expect(turnError(events)?.error).toContain(`${total}/${total}`)
+    }
+  })
+
+  it('[C8] still bounds a runaway continueTurn() reinvoke loop', async () => {
+    // `continueTurn` deliberately does NOT reset turn usage, and
+    // `maxTotalIterations` counts agents, so the token budget is the only thing
+    // standing between a broken procedure stepper and an infinite loop.
+    const usage = anthropicUsage(29_000, 50_000, 1_000) // 30,000 metered per call
+    const { engine, calls } = buildEngine({
+      script: [{ content: 'still going', usage }],
+      provider: 'anthropic',
+      maxTokensPerTurn: 100_000,
+    })
+
+    expect(turnError(await drain(engine.submitMessage('go')))).toBeUndefined() // 30k
+    expect(turnError(await drain(engine.continueTurn()))).toBeUndefined() // 60k
+    expect(turnError(await drain(engine.continueTurn()))).toBeUndefined() // 90k
+
+    // The fourth continuation crosses the cap on its way out.
+    expect(turnError(await drain(engine.continueTurn()))?.reason).toBe('token-budget')
+
+    // And the fifth is refused BEFORE the model is called — the loop is bounded,
+    // not merely reported on.
+    const callsSoFar = calls.length
+    expect(turnError(await drain(engine.continueTurn()))?.reason).toBe('token-budget')
+    expect(calls.length).toBe(callsSoFar)
+  })
+})

--- a/packages/lib/src/ai/agent-framework/engine.ts
+++ b/packages/lib/src/ai/agent-framework/engine.ts
@@ -2,6 +2,7 @@
 
 import { createScopedLogger } from '@auxx/logger'
 import { generateId } from '@auxx/utils/generateId'
+import type { UsageMetrics } from '../clients/base/types'
 import { KopilotContextStore, readContextSlice, syncContextSlice } from './context'
 import { manageContext } from './context-manager'
 import { type AgentQueryResumeHint, agentQueryLoop } from './query-loop'
@@ -14,20 +15,38 @@ import {
   type AssistantSessionMessage,
   type ContentPart,
   createEmptyTurnSnapshots,
+  type IterationUsage,
   type ResumeOptions,
   type Route,
   type SessionMessage,
   type SystemSessionMessage,
   type ToolCallPart,
   type TurnBudget,
+  type TurnErrorReason,
+  type TurnOutcome,
   type TurnUsageSummary,
 } from './types'
+import { meterRollupTokens, normalizeCallUsage } from './usage-metering'
 import { buildToolDigest, executeToolWithProgress } from './utils'
 
 const logger = createScopedLogger('agent-engine')
 const DEFAULT_MAX_TOTAL_ITERATIONS = 50
 const DEFAULT_MAX_TOKENS_PER_TURN = 200_000
 const DEFAULT_MAX_APPROVALS_PER_TURN = 5
+
+/**
+ * The `turn-error` reasons that mean "ran out of room", not "went wrong".
+ * A turn that trips one of these has already done N complete, individually
+ * valid pieces of work — nothing is broken, so `onTurnEnd` hears `'exhausted'`
+ * rather than `'error'`. Membership is what keeps the mapping off the
+ * human-readable `error` string.
+ */
+const EXHAUSTION_REASONS: ReadonlySet<TurnErrorReason> = new Set([
+  'token-budget',
+  'max-iterations',
+  'max-approvals',
+  'tool-failure-streak',
+])
 
 /**
  * AgentEngine — session owner and turn orchestrator.
@@ -42,6 +61,13 @@ export class AgentEngine {
   private abortController: AbortController | null = null
   private turnId: string | null = null
   private turnTokensUsed = 0
+  /**
+   * What `maxTokensPerTurn` is actually compared against — see
+   * {@link AgentEngine.accumulateUsage}. Deliberately separate from
+   * `turnTokensUsed`, which stays the provider-reported grand total so
+   * `TurnUsageSummary` keeps reporting what the turn really consumed.
+   */
+  private turnMeteredTokens = 0
   private turnPromptTokens = 0
   private turnCompletionTokens = 0
   private turnLlmCalls = 0
@@ -117,11 +143,7 @@ export class AgentEngine {
       contextSummary: this.config.domainConfig.summarizeContext?.(context),
     })
 
-    this.abortController = new AbortController()
-    const configWithAbort: AgentEngineConfig = {
-      ...this.config,
-      signal: this.abortController.signal,
-    }
+    const configWithAbort = this.startTurnAbort()
 
     try {
       yield* this.withTurnEnd(this.tagTurnId(this.runPipeline(configWithAbort)))
@@ -158,17 +180,17 @@ export class AgentEngine {
 
     const pending = this.state.pendingToolCall
     if (!pending) {
-      yield this.tagEvent({ type: 'turn-error', error: 'No pending tool call to resume' })
+      yield this.tagEvent({
+        type: 'turn-error',
+        error: 'No pending tool call to resume',
+        reason: 'internal',
+      })
       return
     }
 
     const route = this.state.currentRoute ?? 'default'
 
-    this.abortController = new AbortController()
-    const configWithAbort: AgentEngineConfig = {
-      ...this.config,
-      signal: this.abortController.signal,
-    }
+    const configWithAbort = this.startTurnAbort()
 
     try {
       yield* this.withTurnEnd(this.tagTurnId(this.runResume(opts, route, configWithAbort)))
@@ -197,11 +219,7 @@ export class AgentEngine {
   async *continueTurn(): AsyncGenerator<AgentEvent> {
     if (!this.turnId) this.turnId = generateId('turn')
 
-    this.abortController = new AbortController()
-    const configWithAbort: AgentEngineConfig = {
-      ...this.config,
-      signal: this.abortController.signal,
-    }
+    const configWithAbort = this.startTurnAbort()
 
     logger.info('Turn continued (no new user message)', {
       turnId: this.turnId,
@@ -244,6 +262,7 @@ export class AgentEngine {
         yield this.tagEvent({
           type: 'turn-error',
           error: `Supervisor agent "${domainConfig.supervisorAgent}" not found`,
+          reason: 'internal',
         })
         return
       }
@@ -261,6 +280,7 @@ export class AgentEngine {
       yield this.tagEvent({
         type: 'turn-error',
         error: `No routes configured in domain "${domainConfig.type}"`,
+        reason: 'internal',
       })
       return
     }
@@ -286,14 +306,25 @@ export class AgentEngine {
     for (const agentName of route.agents) {
       if (config.signal?.aborted) break
       if (totalIterations >= budget.maxIterations) {
-        yield this.tagEvent({ type: 'turn-error', error: 'Max total iterations exceeded' })
-        return
-      }
-      if (this.turnTokensUsed >= budget.maxTokensPerTurn) {
+        logger.warn('Max total iterations exceeded — closing the turn', {
+          turnId: this.turnId,
+          sessionId: this.config.sessionId,
+          reason: 'max-iterations',
+          totalIterations,
+          maxIterations: budget.maxIterations,
+          turnTokensUsed: this.turnTokensUsed,
+          turnMeteredTokens: this.turnMeteredTokens,
+          llmCalls: this.turnLlmCalls,
+        })
         yield this.tagEvent({
           type: 'turn-error',
-          error: `Turn exceeded token budget (${this.turnTokensUsed}/${budget.maxTokensPerTurn})`,
+          error: 'Max total iterations exceeded',
+          reason: 'max-iterations',
         })
+        return
+      }
+      if (this.turnMeteredTokens >= budget.maxTokensPerTurn) {
+        yield this.tokenBudgetExit(budget)
         return
       }
 
@@ -304,6 +335,7 @@ export class AgentEngine {
         yield this.tagEvent({
           type: 'turn-error',
           error: `Agent "${agentName}" not found in domain config`,
+          reason: 'internal',
         })
         return
       }
@@ -313,13 +345,18 @@ export class AgentEngine {
         if (event.type === 'turn-error') return
         // Roll up usage from each assistant message finish for budget enforcement.
         if (event.type === 'assistant-message-finished' && event.usage) {
-          totalIterations++
-          this.accumulateUsage(event.usage)
-          if (this.turnTokensUsed >= budget.maxTokensPerTurn) {
-            yield this.tagEvent({
-              type: 'turn-error',
-              error: `Turn exceeded token budget (${this.turnTokensUsed}/${budget.maxTokensPerTurn})`,
-            })
+          // `assistant-message-finished` fires ONCE PER AGENT RUN, not once per
+          // LLM iteration — so `totalIterations++` made `maxTotalIterations`
+          // count agents in the route, which is structurally unreachable on a
+          // single-agent route (1 vs a cap of 100). The event's `iterations`
+          // array is the per-LLM-call billing breakdown for this segment, so it
+          // is the real iteration count. Caveat: query-loop skips zero-usage
+          // calls when building it, so this slightly UNDERCOUNTS — still vastly
+          // closer to the knob's documented meaning than a flat 1.
+          totalIterations += event.iterations?.length ?? 1
+          this.accumulateUsage(event)
+          if (this.turnMeteredTokens >= budget.maxTokensPerTurn) {
+            yield this.tokenBudgetExit(budget)
             return
           }
         }
@@ -370,6 +407,7 @@ export class AgentEngine {
       yield this.tagEvent({
         type: 'turn-error',
         error: `Paused tool_call part not found (messageId=${pending.messageId}, partIndex=${pending.partIndex})`,
+        reason: 'internal',
       })
       return
     }
@@ -438,6 +476,7 @@ export class AgentEngine {
           yield this.tagEvent({
             type: 'turn-error',
             error: `Invalid input amendment for "${pending.toolName}": ${issues}`,
+            reason: 'internal',
           })
           return
         }
@@ -672,11 +711,25 @@ export class AgentEngine {
       }
     }
 
-    // Enforce max-approvals cap.
+    // Enforce max-approvals cap. This fires BETWEEN approvals — the one that
+    // tripped it already executed and settled — so it is exhaustion, not
+    // corruption. A long authoring turn that chains approvals is exactly the
+    // shape that reaches it.
     if ((this.state.approvalsThisTurn ?? 0) > budget.maxApprovalsPerTurn) {
+      logger.warn('Max approvals per turn exceeded — closing the turn', {
+        turnId: this.turnId,
+        sessionId: this.config.sessionId,
+        reason: 'max-approvals',
+        approvalsThisTurn: this.state.approvalsThisTurn,
+        maxApprovalsPerTurn: budget.maxApprovalsPerTurn,
+        turnTokensUsed: this.turnTokensUsed,
+        turnMeteredTokens: this.turnMeteredTokens,
+        llmCalls: this.turnLlmCalls,
+      })
       yield this.tagEvent({
         type: 'turn-error',
         error: `Exceeded max approvals per turn (${budget.maxApprovalsPerTurn})`,
+        reason: 'max-approvals',
       })
       return
     }
@@ -690,6 +743,7 @@ export class AgentEngine {
       yield this.tagEvent({
         type: 'turn-error',
         error: `Agent "${pending.agentName}" not found for re-entry`,
+        reason: 'internal',
       })
       return
     }
@@ -714,12 +768,9 @@ export class AgentEngine {
       yield event
       if (event.type === 'turn-error') return
       if (event.type === 'assistant-message-finished' && event.usage) {
-        this.accumulateUsage(event.usage)
-        if (this.turnTokensUsed >= budget.maxTokensPerTurn) {
-          yield this.tagEvent({
-            type: 'turn-error',
-            error: `Turn exceeded token budget (${this.turnTokensUsed}/${budget.maxTokensPerTurn})`,
-          })
+        this.accumulateUsage(event)
+        if (this.turnMeteredTokens >= budget.maxTokensPerTurn) {
+          yield this.tokenBudgetExit(budget)
           return
         }
       }
@@ -741,6 +792,44 @@ export class AgentEngine {
 
   // ===== HELPERS =====
 
+  /**
+   * Open a fresh per-turn abort scope and return the config the turn runs on.
+   *
+   * The engine mints its own `AbortController` because that is what
+   * `interrupt()` drives. It used to write that signal straight over
+   * `config.signal`, so a caller that supplied one had it silently discarded —
+   * the documented field did nothing, and every caller only worked because it
+   * ALSO wired `interrupt()` by hand. `AbortSignal.any` composes the two so
+   * either source really stops the turn.
+   */
+  private startTurnAbort(): AgentEngineConfig {
+    this.abortController = new AbortController()
+    const callerSignal = this.config.signal
+    return {
+      ...this.config,
+      signal: callerSignal
+        ? AbortSignal.any([this.abortController.signal, callerSignal])
+        : this.abortController.signal,
+    }
+  }
+
+  /** Did either abort source fire? Read by `withTurnEnd`'s finally guard. */
+  private isTurnAborted(): boolean {
+    return this.abortController?.signal.aborted === true || this.config.signal?.aborted === true
+  }
+
+  /**
+   * Classify a `turn-error` for {@link AgentDomainConfig.onTurnEnd}.
+   *
+   * Deliberately reads only the event's `reason` discriminator — the `error`
+   * string is a human-readable message that changes freely, and matching on it
+   * is how "ran out of tokens after twelve good edits" gets mistaken for
+   * "threw mid-write".
+   */
+  private outcomeForTurnError(reason: TurnErrorReason | undefined): TurnOutcome {
+    return reason !== undefined && EXHAUSTION_REASONS.has(reason) ? 'exhausted' : 'error'
+  }
+
   private buildTurnBudget(config: AgentEngineConfig): TurnBudget {
     return {
       maxTokensPerTurn: config.maxTokensPerTurn ?? DEFAULT_MAX_TOKENS_PER_TURN,
@@ -749,22 +838,90 @@ export class AgentEngine {
     }
   }
 
+  /**
+   * The token-budget exit, shared by the three sites that meter turn usage
+   * (between agents, after each assistant message, and on the resume path).
+   *
+   * The log line is the point of the helper: these exits used to emit an event
+   * and nothing else, so a turn discarded on a token tally left no trace at all
+   * in log search. `reason` is what lets `withTurnEnd` classify this as
+   * exhaustion without reading the message text.
+   */
+  private tokenBudgetExit(budget: TurnBudget): AgentEvent {
+    logger.warn('Turn exceeded token budget — closing the turn', {
+      turnId: this.turnId,
+      sessionId: this.config.sessionId,
+      reason: 'token-budget',
+      turnTokensUsed: this.turnTokensUsed,
+      turnMeteredTokens: this.turnMeteredTokens,
+      maxTokensPerTurn: budget.maxTokensPerTurn,
+      llmCalls: this.turnLlmCalls,
+    })
+    return this.tagEvent({
+      type: 'turn-error',
+      error: `Turn exceeded token budget (${this.turnMeteredTokens}/${budget.maxTokensPerTurn})`,
+      reason: 'token-budget',
+    })
+  }
+
   private resetTurnUsage(): void {
     this.turnTokensUsed = 0
+    this.turnMeteredTokens = 0
     this.turnPromptTokens = 0
     this.turnCompletionTokens = 0
     this.turnLlmCalls = 0
   }
 
-  private accumulateUsage(usage: {
-    prompt_tokens?: number
-    completion_tokens?: number
-    total_tokens?: number
-  }): void {
+  /**
+   * Roll an `assistant-message-finished` event into the turn's usage counters.
+   *
+   * **The budget meters off `event.iterations`, not `event.usage`** — three
+   * reasons, all load-bearing:
+   *
+   * 1. *Unit.* `event.usage` is the query loop's cumulative roll-up of
+   *    `total_tokens`, and `total_tokens` includes prompt tokens while the whole
+   *    conversation is re-sent every iteration. Metering it charges the same
+   *    prompt once per tool round-trip, so the budget measured iteration count
+   *    wearing a token-shaped mask. The per-call records carry the cache fields,
+   *    which is what makes "charge only for new input" expressible at all.
+   * 2. *Provider.* Whether `prompt_tokens` already contains the cached reads
+   *    depends on which provider served the call. `IterationUsage` keeps that;
+   *    a roll-up spanning two providers cannot answer it.
+   * 3. *Double-charging.* `iterations` is the query loop's `segmentIterations` —
+   *    reset across a pause/resume — whereas `usage` is seeded from the paused
+   *    message and therefore re-counts the pre-pause calls. It is exactly the
+   *    source billing already drains, for exactly this reason.
+   *
+   * `turnTokensUsed` / `turnPromptTokens` / `turnCompletionTokens` remain the
+   * provider-reported grand totals for reporting. Only `turnMeteredTokens`
+   * gates the budget.
+   */
+  private accumulateUsage(event: { usage?: UsageMetrics; iterations?: IterationUsage[] }): void {
+    const records = event.iterations
+    if (records && records.length > 0) {
+      for (const record of records) {
+        const norm = normalizeCallUsage(record.usage, record.provider)
+        this.turnPromptTokens += norm.promptInput
+        this.turnCompletionTokens += norm.completion
+        this.turnTokensUsed += record.usage.total_tokens ?? norm.promptInput + norm.completion
+        this.turnMeteredTokens += norm.meteredTokens
+        this.turnLlmCalls += 1
+      }
+      return
+    }
+
+    // No per-call records: the query loop only builds them for calls reporting
+    // a non-zero `total_tokens`, so this is the degenerate case where a provider
+    // reported prompt/completion but no total. Meter the roll-up on the
+    // documented fallback (`prompt + completion`) — never NaN, and never a
+    // silent 0, which would disable the budget outright.
+    const usage = event.usage
+    if (!usage) return
     this.turnPromptTokens += usage.prompt_tokens ?? 0
     this.turnCompletionTokens += usage.completion_tokens ?? 0
     this.turnTokensUsed +=
       usage.total_tokens ?? (usage.prompt_tokens ?? 0) + (usage.completion_tokens ?? 0)
+    this.turnMeteredTokens += meterRollupTokens(usage)
     this.turnLlmCalls += 1
   }
 
@@ -794,12 +951,19 @@ export class AgentEngine {
    * Wrap a turn's event stream so the domain's `onTurnEnd` hook fires exactly
    * once with the resolved outcome, before the terminal event is yielded.
    *
-   * Terminal events drive the normal path (`turn-completed` → 'completed',
-   * `turn-error` → 'error'). An abnormal close that yields no terminal event —
-   * abort, client disconnect, a thrown error — fires 'error' from the finally
-   * guard so locks release and the turn rolls back. The one exception is an
-   * approval pause: it returns without a terminal event but the turn isn't
-   * over, so `waitingForApproval` suppresses the guard.
+   * Terminal events drive the normal path: `turn-completed` → `'completed'`,
+   * and a `turn-error` is classified by its `reason` — a resource cap becomes
+   * `'exhausted'`, anything else `'error'` (see {@link outcomeForTurnError}).
+   *
+   * An abnormal close that yields no terminal event — a client disconnect that
+   * cancels this generator, a thrown error — hits the `finally` guard, which
+   * reads the abort flag to tell `'aborted'` from `'error'`. Note that an abort
+   * the engine is still *draining* does NOT come through here: the route loop
+   * breaks and falls through to `turn-completed`. It is specifically the
+   * undrained close that lands in the guard.
+   *
+   * The one exception is an approval pause: it returns without a terminal event
+   * but the turn isn't over, so `waitingForApproval` suppresses the guard.
    *
    * A hook failure is logged and swallowed; it must never mask the turn result.
    */
@@ -810,7 +974,7 @@ export class AgentEngine {
       return
     }
     let fired = false
-    const fire = async (outcome: 'completed' | 'error') => {
+    const fire = async (outcome: TurnOutcome) => {
       if (fired) return
       fired = true
       try {
@@ -826,11 +990,19 @@ export class AgentEngine {
     try {
       for await (const event of gen) {
         if (event.type === 'turn-completed') await fire('completed')
-        else if (event.type === 'turn-error') await fire('error')
+        else if (event.type === 'turn-error') await fire(this.outcomeForTurnError(event.reason))
         yield event
       }
     } finally {
-      if (!fired && !this.state.waitingForApproval) await fire('error')
+      // LOAD-BEARING ORDERING: `this.abortController` is still non-null here.
+      // `submitMessage` / `resume` / `continueTurn` null it in an OUTER finally,
+      // and an outer finally only runs after the delegated generator's own
+      // finally has completed — so the flag is still readable at this point.
+      // Moving the null-out inward, or hoisting this guard outward, silently
+      // turns every disconnect back into `'error'`.
+      if (!fired && !this.state.waitingForApproval) {
+        await fire(this.isTurnAborted() ? 'aborted' : 'error')
+      }
     }
   }
 

--- a/packages/lib/src/ai/agent-framework/index.ts
+++ b/packages/lib/src/ai/agent-framework/index.ts
@@ -64,6 +64,8 @@ export type {
   ThinkingPart,
   ToolCallPart,
   ToolCallStatus,
+  TurnErrorReason,
+  TurnOutcome,
   UserSessionMessage,
 } from './types'
 

--- a/packages/lib/src/ai/agent-framework/llm-adapter.ts
+++ b/packages/lib/src/ai/agent-framework/llm-adapter.ts
@@ -7,6 +7,7 @@ import { LLMOrchestrator } from '../orchestrator/llm-orchestrator'
 import type { LLMInvocationRequest, UsageSource, UsageTrackingService } from '../orchestrator/types'
 import { UsageTrackingService as DefaultUsageTrackingService } from '../usage/usage-tracking-service'
 import type { LLMCallParams, LLMStreamEvent } from './types'
+import { normalizeCallUsage } from './usage-metering'
 
 const logger = createScopedLogger('agent-llm')
 
@@ -325,31 +326,25 @@ export function createCallModel(config: LLMAdapterConfig) {
     // avoid the logger's `token`/`secret`/`apikey` redaction markers so the
     // counts actually survive into the log (the `usage` object above is
     // redacted because its keys contain "token"). See plans/kopilot/cache/.
+    //
+    // The provider-semantics normalization used to be inlined right here, which
+    // meant the numbers we LOGGED and the numbers the engine's turn budget
+    // METERED came from two different formulas. Both now read
+    // `normalizeCallUsage`, so the log line and the budget cannot drift.
     if (lastUsage.total_tokens > 0) {
-      const cachedInput = lastUsage.cached_input_tokens ?? 0
-      const cacheWrite = lastUsage.cache_write_tokens ?? 0
-      const promptInput = lastUsage.prompt_tokens
-      // Provider semantics differ: OpenAI's prompt_tokens INCLUDES cached reads;
-      // Anthropic's EXCLUDES them. Normalize to a single total + rate-limit cost.
-      const includesCached = (provider ?? '').toLowerCase().includes('openai')
-      const totalInput = includesCached
-        ? promptInput + cacheWrite
-        : promptInput + cachedInput + cacheWrite
-      // Input that actually counts toward the provider's input rate limit
-      // (cached reads are free on Anthropic/OpenAI; cache writes are not).
-      const rateLimitInput = includesCached
-        ? promptInput - cachedInput + cacheWrite
-        : promptInput + cacheWrite
+      const norm = normalizeCallUsage(lastUsage, provider)
       logger.info('LLM cache metrics', {
         provider,
         model,
-        promptInput,
-        cachedInput,
-        cacheWrite,
-        outputCount: lastUsage.completion_tokens,
-        totalInput,
-        rateLimitInput,
-        cachedPct: totalInput > 0 ? Math.round((cachedInput / totalInput) * 100) : 0,
+        promptInput: norm.promptInput,
+        cachedInput: norm.cachedInput,
+        cacheWrite: norm.cacheWrite,
+        outputCount: norm.completion,
+        totalInput: norm.totalInput,
+        rateLimitInput: norm.rateLimitInput,
+        // What one call contributes to the per-turn token budget.
+        meteredTokens: norm.meteredTokens,
+        cachedPct: norm.totalInput > 0 ? Math.round((norm.cachedInput / norm.totalInput) * 100) : 0,
       })
     }
 

--- a/packages/lib/src/ai/agent-framework/process-agent-job.ts
+++ b/packages/lib/src/ai/agent-framework/process-agent-job.ts
@@ -15,6 +15,11 @@ import type { JobContext } from '../../jobs/types'
 import { docToText } from '../../tiptap'
 import { buildInstructionReferenceResolver } from '../kopilot/prompts/resolve-instruction-references'
 import type { TriggerContext, TriggerKind } from '../kopilot/prompts/trigger-context'
+// Leaf module, imported by path rather than through `../kopilot`'s barrel: the
+// barrel pulls the whole capability tree (which imports agent-framework) back
+// into this file and would close a real import cycle. `turn-budget.ts` itself
+// imports nothing, so this direction is safe as a static import.
+import { KOPILOT_TURN_BUDGET } from '../kopilot/turn-budget'
 import { resolveAgentRunCapabilities } from './agent-run-capabilities'
 import { KopilotContextStore, readContextSlice } from './context'
 import { type AgentRuntimeDomain, buildEffectiveAgentRuntime } from './effective-runtime'
@@ -176,10 +181,12 @@ async function processAgentMessageInternal(ctx: JobContext<AgentJobPayload>) {
     // No-op for master Kopilot (no tools declare bindings + empty overrides).
     // See plans/chat/v8 phase-4.
     applyToolRestrictions: runtime.applyToolRestrictions,
-    // Kopilot domain: long-running plans routinely chain >5 approvals
-    // (one per ticket reply, etc.) and need iteration headroom for plan
-    // step churn. Other domains stay on framework defaults.
-    ...(domain === 'kopilot' ? { maxTotalIterations: 100, maxApprovalsPerTurn: 50 } : {}),
+    // Kopilot domain: its own turn budget (see `KOPILOT_TURN_BUDGET` for why
+    // each number is what it is). Shared with the SSE route in apps/web so the
+    // worker and streaming paths can never drift — `shouldUseWorker()` is
+    // env-gated, so any divergence would stay invisible until it flipped.
+    // Other domains stay on framework defaults.
+    ...(domain === 'kopilot' ? KOPILOT_TURN_BUDGET : {}),
     ...(data.approvalMode ? { approvalMode: data.approvalMode } : {}),
   }
 

--- a/packages/lib/src/ai/agent-framework/query-loop.ts
+++ b/packages/lib/src/ai/agent-framework/query-loop.ts
@@ -453,10 +453,14 @@ export async function* agentQueryLoop(
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error)
       logger.error('LLM error', { turnId, agent: agent.name, iteration, error: errorMessage })
+      // A provider/stream failure, not a resource cap — `'internal'` so the
+      // engine's outcome mapping treats it as a real error rather than
+      // exhaustion.
       yield {
         type: 'turn-error',
         messageId,
         error: `LLM error in ${agent.name}: ${errorMessage}`,
+        reason: 'internal',
       }
       // Flip any still-running tool_call parts to error so the persisted
       // shape doesn't carry zombies.
@@ -1103,10 +1107,14 @@ export async function* agentQueryLoop(
           iteration,
           lastError,
         })
+        // Exhaustion, not corruption: the turn's earlier work all landed, the
+        // loop just stopped burning calls on a tool that keeps failing. The
+        // `reason` is what tells the engine that — never the message text.
         yield {
           type: 'turn-error',
           messageId,
           error: `Tool \`${onlyName}\` failed ${failingToolStreak} times in a row: ${lastError}`,
+          reason: 'tool-failure-streak',
         }
         markRunningPartsAsError(parts, 'Same-tool failure streak')
         currentState = upsertAssistantMessage()
@@ -1312,12 +1320,33 @@ function findApprovalTool(
   })
 }
 
+/**
+ * Roll one call's usage into the turn-total carried on the assistant message.
+ *
+ * The cache fields ride along because dropping them made the persisted metadata
+ * under-report the cache dimension entirely — a turn that read 200k tokens from
+ * the prompt cache looked identical to one that paid for all of them. They are
+ * only materialized when a provider actually reported them, so a cache-blind
+ * provider keeps the keys absent rather than claiming a measured zero.
+ *
+ * This is a reporting fix, not the turn budget's input: the budget meters off
+ * the per-call `IterationUsage` records, which keep raw usage AND the provider
+ * each call ran on — and the provider is what decides whether `prompt_tokens`
+ * already contains the cached reads. A roll-up can span providers, so it cannot
+ * answer that question at all.
+ */
 function accumulateUsage(target: UsageMetrics, src: UsageMetrics): void {
   target.prompt_tokens = (target.prompt_tokens ?? 0) + (src.prompt_tokens ?? 0)
   target.completion_tokens = (target.completion_tokens ?? 0) + (src.completion_tokens ?? 0)
   target.total_tokens =
     (target.total_tokens ?? 0) +
     (src.total_tokens ?? (src.prompt_tokens ?? 0) + (src.completion_tokens ?? 0))
+  if (src.cached_input_tokens !== undefined) {
+    target.cached_input_tokens = (target.cached_input_tokens ?? 0) + src.cached_input_tokens
+  }
+  if (src.cache_write_tokens !== undefined) {
+    target.cache_write_tokens = (target.cache_write_tokens ?? 0) + src.cache_write_tokens
+  }
 }
 
 function markRunningPartsAsError(parts: ContentPart[], reason: string): void {

--- a/packages/lib/src/ai/agent-framework/types.ts
+++ b/packages/lib/src/ai/agent-framework/types.ts
@@ -704,6 +704,30 @@ export interface Route {
 
 // ===== DOMAIN CONFIG =====
 
+/**
+ * How a turn ended, as reported to {@link AgentDomainConfig.onTurnEnd}.
+ *
+ * The distinction that matters to a domain hook is **"is anything broken?"**,
+ * and only `'error'` answers yes:
+ *
+ * - `'completed'` — the turn reached `turn-completed`. Normal finish.
+ * - `'exhausted'` — a resource cap stopped the turn: the per-turn token budget,
+ *   the max-total-iterations cap, the max-approvals-per-turn cap, or the
+ *   same-tool failure streak. The work
+ *   already done is intact — the draft/document is N complete, individually
+ *   valid mutations, each of which went through its own validation and its own
+ *   write. The turn simply ran out of room.
+ * - `'aborted'` — the caller's abort signal fired, or the consumer stopped
+ *   draining the event stream (a client disconnect, page reload, navigate-away).
+ *   Same shape as `'exhausted'`: nothing is broken, the turn just stopped.
+ * - `'error'` — an unexpected failure: a thrown exception, an LLM/stream
+ *   failure, a misconfigured route or agent. This is the only outcome that
+ *   says the turn itself went wrong.
+ *
+ * Neither `'exhausted'` nor `'aborted'` implies the domain should undo anything.
+ */
+export type TurnOutcome = 'completed' | 'exhausted' | 'aborted' | 'error'
+
 /** Domain-specific configuration — each consumer (Kopilot, Builder) provides one */
 export interface AgentDomainConfig<TDomainState = Record<string, unknown>> {
   /** Domain identifier (matches AgentSessionType) */
@@ -793,17 +817,22 @@ export interface AgentDomainConfig<TDomainState = Record<string, unknown>> {
    * BullMQ path), so a domain can commit or roll back side-effects keyed off
    * domain state regardless of where the turn ran.
    *
-   * `outcome` is `'completed'` for a clean finish and `'error'` for a
-   * turn-error, an aborted run, or a client disconnect. It does NOT fire when
-   * a turn pauses for approval (the turn isn't over). Must not throw — the
-   * engine wraps it in try/catch so a hook failure can't mask the turn result.
+   * `outcome` is a {@link TurnOutcome}: `'completed'` for a clean finish,
+   * `'exhausted'` when a resource cap (token budget, iteration cap, approval
+   * cap, same-tool failure streak) stopped the turn, `'aborted'` when the abort signal fired or
+   * the consumer stopped draining the stream, and `'error'` for anything that
+   * actually went wrong. `'exhausted'` and `'aborted'` both mean *the
+   * draft/document is N complete, valid mutations and nothing is broken* — a
+   * hook must not treat them as corruption. It does NOT fire when a turn pauses
+   * for approval (the turn isn't over). Must not throw — the engine wraps it in
+   * try/catch so a hook failure can't mask the turn result.
    *
    * `turnId` is the engine's id for the turn that just ended (undefined only if
    * no turn was active). Domains that scope per-turn side-effects by turn id —
    * e.g. fanning the hook out to capability lifecycles — read it here instead of
    * smuggling turn-ephemeral identity through the persisted `domainState`.
    */
-  onTurnEnd?: (state: AgentState, outcome: 'completed' | 'error', turnId?: string) => Promise<void>
+  onTurnEnd?: (state: AgentState, outcome: TurnOutcome, turnId?: string) => Promise<void>
   /**
    * Optional hook to clear per-turn domain state at the start of a NEW user
    * turn (`submitMessage`) — NOT on approval-resume, which continues the same
@@ -841,7 +870,13 @@ export interface AgentEngineConfig {
   domainConfig: AgentDomainConfig
   /** LLM call function (injected, wraps LLMOrchestrator) */
   callModel: (params: LLMCallParams) => AsyncGenerator<LLMStreamEvent>
-  /** Optional abort signal */
+  /**
+   * Optional caller-owned abort signal. The engine mints its OWN controller per
+   * turn (that is what `engine.interrupt()` drives) and composes the two with
+   * `AbortSignal.any`, so aborting either one stops the turn. Passing this is
+   * therefore an alternative to wiring `interrupt()` by hand, not a duplicate
+   * of it.
+   */
   signal?: AbortSignal
   /** Max total iterations across all agents in a pipeline run (default: 50) */
   maxTotalIterations?: number
@@ -966,6 +1001,31 @@ export interface TurnUsageSummary {
 }
 
 /**
+ * Why a `turn-error` was emitted — a machine-readable discriminator so consumers
+ * never have to pattern-match the human-readable `error` string.
+ *
+ * The first four are resource caps and map to {@link TurnOutcome} `'exhausted'`;
+ * `'internal'` (and an unset reason) maps to `'error'`.
+ *
+ * - `'token-budget'` — the turn's cumulative token usage crossed
+ *   `maxTokensPerTurn`.
+ * - `'max-iterations'` — the route crossed `maxTotalIterations`.
+ * - `'max-approvals'` — the turn chained more approved tool calls than
+ *   `maxApprovalsPerTurn`. It stops BETWEEN approvals, so every one of them
+ *   completed — a long authoring turn hitting this has all its work intact.
+ * - `'tool-failure-streak'` — the same tool failed `SAME_TOOL_FAILURE_LIMIT`
+ *   times in a row, so the loop stopped rather than keep burning calls on it.
+ * - `'internal'` — something actually went wrong: an LLM/stream failure, a
+ *   misconfigured route or agent, a tool that couldn't be resumed.
+ */
+export type TurnErrorReason =
+  | 'token-budget'
+  | 'max-iterations'
+  | 'max-approvals'
+  | 'tool-failure-streak'
+  | 'internal'
+
+/**
  * Events emitted by the engine during turn execution — streamed to the frontend.
  * Every event (except `done`) carries a `turnId` tying it to a single user request.
  *
@@ -977,7 +1037,7 @@ export interface TurnUsageSummary {
 export type AgentEvent = { turnId?: string } & (
   | { type: 'turn-started'; route: string; agents: string[]; budget: TurnBudget }
   | { type: 'turn-completed'; route: string; usage: TurnUsageSummary }
-  | { type: 'turn-error'; error: string; messageId?: string }
+  | { type: 'turn-error'; error: string; messageId?: string; reason?: TurnErrorReason }
   | { type: 'agent-started'; agent: string }
   /** Opens a new assistant message. The frontend appends an empty bubble keyed by `messageId`. */
   | { type: 'assistant-message-started'; messageId: string; agent: string }

--- a/packages/lib/src/ai/agent-framework/usage-metering.ts
+++ b/packages/lib/src/ai/agent-framework/usage-metering.ts
@@ -1,0 +1,119 @@
+// packages/lib/src/ai/agent-framework/usage-metering.ts
+
+import type { UsageMetrics } from '../clients/base/types'
+
+/**
+ * Providers whose `prompt_tokens` **excludes** cached reads and cache writes,
+ * reporting them as separate counts instead.
+ *
+ * Anthropic is the only one: `anthropic-llm-client` builds `prompt_tokens` from
+ * `usage.input_tokens`, which the API defines as the uncached remainder, and
+ * carries `cache_read_input_tokens` / `cache_creation_input_tokens` alongside.
+ *
+ * Every other provider in the registry (openai, google, groq, deepseek, qwen,
+ * kimi, zai, grok) routes through the single `OpenAILLMClient.convertUsage`,
+ * where `prompt_tokens` INCLUDES the cached portion and `cached_input_tokens`
+ * is a subset of it rather than an addend — so the rule is stated as "Anthropic
+ * is the exception" rather than "OpenAI is the special case". A substring test
+ * for `openai` would silently treat the six OpenAI-shaped vendors as
+ * cache-separate and double-count their cached prefix.
+ */
+const PROMPT_EXCLUDES_CACHED_PROVIDERS: ReadonlySet<string> = new Set(['anthropic'])
+
+/** True when the provider's `prompt_tokens` already contains its cached reads. */
+export function promptIncludesCachedReads(provider: string | undefined): boolean {
+  return !PROMPT_EXCLUDES_CACHED_PROVIDERS.has((provider ?? '').toLowerCase())
+}
+
+/** Provider-neutral view of one LLM call's token usage. */
+export interface NormalizedCallUsage {
+  /** `prompt_tokens` exactly as the provider reported it. */
+  promptInput: number
+  /** Input served from the provider's prompt cache. */
+  cachedInput: number
+  /** Input written to the provider's prompt cache on this call. */
+  cacheWrite: number
+  /** `completion_tokens` as reported. */
+  completion: number
+  /** Every input token presented to the model, cached prefix included. */
+  totalInput: number
+  /**
+   * Input the provider actually had to process — i.e. what counts toward its
+   * input rate limit. Cached reads are free on the providers we use; cache
+   * writes are not.
+   */
+  rateLimitInput: number
+  /**
+   * The per-turn budget unit: `rateLimitInput + completion`. Charges for work
+   * that is genuinely new, so re-sending a cached conversation prefix on every
+   * tool round-trip costs nothing. Falls back to `prompt + completion` when the
+   * provider reports no cache fields at all.
+   */
+  meteredTokens: number
+  /** Which of the two provider semantics was applied. */
+  includesCached: boolean
+}
+
+/** Coerce a reported count to a usable non-negative number (never NaN). */
+function count(value: number | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0
+}
+
+/**
+ * Normalize one LLM call's `UsageMetrics` into provider-neutral totals.
+ *
+ * This exists because the two provider semantics disagree about what
+ * `prompt_tokens` contains, and the disagreement used to live inside
+ * `llm-adapter`'s log block — so the numbers we *logged* and the numbers the
+ * turn budget *metered* were computed from different formulas. Both now call
+ * here, and they cannot drift.
+ *
+ * When a provider reports neither cache field both branches collapse to
+ * `prompt + completion`, which is the documented fallback: never `NaN`, and
+ * never a silent `0` — a zero would disable the turn budget outright, which is
+ * the worst available failure mode.
+ */
+export function normalizeCallUsage(
+  usage: UsageMetrics | undefined,
+  provider?: string
+): NormalizedCallUsage {
+  const promptInput = count(usage?.prompt_tokens)
+  const cachedInput = count(usage?.cached_input_tokens)
+  const cacheWrite = count(usage?.cache_write_tokens)
+  const completion = count(usage?.completion_tokens)
+  const includesCached = promptIncludesCachedReads(provider)
+
+  const totalInput = includesCached
+    ? promptInput + cacheWrite
+    : promptInput + cachedInput + cacheWrite
+  // `Math.max` guards the subtraction: a provider that reports more cached
+  // tokens than prompt tokens must not produce a negative charge.
+  const rateLimitInput = includesCached
+    ? Math.max(0, promptInput - cachedInput) + cacheWrite
+    : promptInput + cacheWrite
+
+  return {
+    promptInput,
+    cachedInput,
+    cacheWrite,
+    completion,
+    totalInput,
+    rateLimitInput,
+    meteredTokens: rateLimitInput + completion,
+    includesCached,
+  }
+}
+
+/**
+ * The metered charge for a usage roll-up whose provider is unknown.
+ *
+ * A roll-up sums calls that may have come from different providers, so neither
+ * cache semantics can be applied soundly — `prompt + completion` is the
+ * documented fallback. Reachable only when an assistant message finishes with a
+ * usage roll-up but no per-call `IterationUsage` records, which the query loop
+ * builds under the same condition the roll-up accumulates under; the meter
+ * prefers the per-call records precisely because they keep the provider.
+ */
+export function meterRollupTokens(usage: UsageMetrics | undefined): number {
+  return count(usage?.prompt_tokens) + count(usage?.completion_tokens)
+}

--- a/packages/lib/src/ai/kopilot/capabilities/kb/__tests__/lifecycle.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/__tests__/lifecycle.test.ts
@@ -1,0 +1,131 @@
+// packages/lib/src/ai/kopilot/capabilities/kb/__tests__/lifecycle.test.ts
+//
+// KB turn-end lifecycle ([C5] of plans/kopilot/workflow/20-partial-turn-survival.md).
+// The KB capability had the same defect as the workflow builder: any outcome
+// other than `completed` restored the pre-turn article, so a turn that rewrote
+// six sections and then tripped the token budget lost all six.
+//
+// The rule now: **revert is never automatic.** Every outcome finalizes.
+// KB's finalize is NOT the workflow builder's — `finalizeKopilotKbTurn` means
+// "release the editor lock, KEEP the snapshot so the turn stays reviewable",
+// whereas `finalizeWorkflowTurn` DISCARDS its snapshot (the canvas owns undo of
+// a completed turn). So finalizing on every outcome is exactly right here: the
+// article keeps the turn's blocks, the editor unlocks, and the rollback is
+// offered by the turn-review banner (`kb.revertKopilotTurn`) — the user's
+// click, never the server's inference.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TurnOutcome } from '../../../../agent-framework/types'
+import type { GetToolDeps, ToolDeps } from '../../types'
+
+const readKopilotSnapshot = vi.fn()
+const captureKopilotSnapshot = vi.fn()
+const clearKopilotSnapshot = vi.fn()
+vi.mock('../../../../../kb/kopilot-snapshot', () => ({
+  readKopilotSnapshot: (...a: unknown[]) => readKopilotSnapshot(...a),
+  captureKopilotSnapshot: (...a: unknown[]) => captureKopilotSnapshot(...a),
+  clearKopilotSnapshot: (...a: unknown[]) => clearKopilotSnapshot(...a),
+}))
+
+const finalizeKopilotKbTurn = vi.fn()
+const revertKopilotKbTurn = vi.fn()
+// PARTIAL mock: the four block-CRUD tool modules this capability constructs all
+// import `runBlockCrudOp` & friends from the same module, so a wholesale
+// replacement would fail at COLLECTION on the exports the factory omitted.
+vi.mock('../tools/write-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../tools/write-helpers')>()),
+  finalizeKopilotKbTurn: (...a: unknown[]) => finalizeKopilotKbTurn(...a),
+  revertKopilotKbTurn: (...a: unknown[]) => revertKopilotKbTurn(...a),
+}))
+
+import { createKbCapabilities } from '../index'
+
+const ARTICLE = 'art-1'
+const TURN = 'turn-1'
+
+/** The three outcomes that must keep the work AND the snapshot. */
+const KEEP_OUTCOMES: TurnOutcome[] = ['exhausted', 'aborted', 'error']
+const ALL_OUTCOMES: TurnOutcome[] = ['completed', ...KEEP_OUTCOMES]
+
+let refs: Array<Record<string, unknown>> = [{ kind: 'article', id: ARTICLE }]
+
+const getDeps: GetToolDeps = () =>
+  ({
+    db: { tag: 'db' },
+    sessionContext: { page: 'kb', references: refs },
+    organizationId: 'org-1',
+    userId: 'member-1',
+    sessionId: 's-1',
+    capabilities: undefined,
+  }) as unknown as ToolDeps
+
+function lifecycle() {
+  const capability = createKbCapabilities(getDeps)
+  if (!capability.lifecycle?.onTurnEnd) throw new Error('lifecycle missing')
+  return capability.lifecycle.onTurnEnd.bind(capability.lifecycle)
+}
+
+beforeEach(() => {
+  refs = [{ kind: 'article', id: ARTICLE }]
+  readKopilotSnapshot
+    .mockReset()
+    .mockResolvedValue({ turnId: TURN, contentJson: [], contentHash: 'h', capturedAt: 1 })
+  finalizeKopilotKbTurn.mockReset().mockResolvedValue(undefined)
+  revertKopilotKbTurn.mockReset().mockResolvedValue({ ok: true, reverted: true })
+})
+
+describe('kb onTurnEnd', () => {
+  it('completed ⇒ finalizes (unlock, snapshot kept for review)', async () => {
+    await lifecycle()('completed', { turnId: TURN })
+    expect(readKopilotSnapshot).toHaveBeenCalledWith(ARTICLE, TURN)
+    expect(finalizeKopilotKbTurn).toHaveBeenCalledTimes(1)
+    expect(finalizeKopilotKbTurn).toHaveBeenCalledWith({ articleId: ARTICLE })
+    expect(revertKopilotKbTurn).not.toHaveBeenCalled()
+  })
+
+  // The inverted contract: these three used to restore the pre-turn article.
+  it.each(KEEP_OUTCOMES)('%s after a write ⇒ the edits are KEPT, never reverted', async (o) => {
+    await lifecycle()(o, { turnId: TURN })
+    expect(revertKopilotKbTurn).not.toHaveBeenCalled()
+    // Finalize is still called — it is what releases the editor lock, and it
+    // keeps the snapshot, so the Undo banner still has something to offer.
+    expect(finalizeKopilotKbTurn).toHaveBeenCalledWith({ articleId: ARTICLE })
+  })
+
+  it.each(ALL_OUTCOMES)('releases the editor lock on %s', async (outcome) => {
+    // `finalizeKopilotKbTurn` IS the unlock (it publishes `locked: false`
+    // with `reviewable: true`), so a turn that wrote must always reach it —
+    // otherwise the article stays read-only until the 24h TTL.
+    await lifecycle()(outcome, { turnId: TURN })
+    expect(finalizeKopilotKbTurn).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(ALL_OUTCOMES)('a turn that never wrote is untouched on %s', async (outcome) => {
+    // The turn-checked read returning null IS the "did THIS turn write" record;
+    // a prior turn's still-pending review snapshot answers null here too, so it
+    // can never be finalized (or reverted) by a later turn. No snapshot also
+    // means no `locked: true` was ever published — nothing to release.
+    readKopilotSnapshot.mockResolvedValue(null)
+    await lifecycle()(outcome, { turnId: 'turn-2' })
+    expect(readKopilotSnapshot).toHaveBeenCalledWith(ARTICLE, 'turn-2')
+    expect(finalizeKopilotKbTurn).not.toHaveBeenCalled()
+    expect(revertKopilotKbTurn).not.toHaveBeenCalled()
+  })
+
+  it('no article ref ⇒ no snapshot read at all', async () => {
+    refs = []
+    await lifecycle()('error', { turnId: TURN })
+    expect(readKopilotSnapshot).not.toHaveBeenCalled()
+    expect(finalizeKopilotKbTurn).not.toHaveBeenCalled()
+  })
+
+  it('a failing finalize is swallowed and logged — turn end must not throw', async () => {
+    finalizeKopilotKbTurn.mockRejectedValue(new Error('redis down'))
+    await expect(lifecycle()('exhausted', { turnId: TURN })).resolves.toBeUndefined()
+  })
+
+  it('a failing snapshot read is swallowed — turn end must not throw', async () => {
+    readKopilotSnapshot.mockRejectedValue(new Error('redis down'))
+    await expect(lifecycle()('completed', { turnId: TURN })).resolves.toBeUndefined()
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/kb/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/kb/index.ts
@@ -12,7 +12,10 @@ import { createListArticlesTool } from './tools/list-articles'
 import { createMoveBlocksTool } from './tools/move-blocks'
 import { createReplaceBlockTool } from './tools/replace-block'
 import { createResolveBlockByHeadingTool } from './tools/resolve-block-by-heading'
-import { finalizeKopilotKbTurn, revertKopilotKbTurn } from './tools/write-helpers'
+// `revertKopilotKbTurn` is deliberately NOT imported here: the rollback is the
+// user's click on the turn-review banner (`kb.revertKopilotTurn`), never
+// something this hook performs — see `onTurnEnd` below.
+import { finalizeKopilotKbTurn } from './tools/write-helpers'
 
 export const KB_PAGE = 'kb'
 const GLOBAL_PAGE = '__global__'
@@ -53,36 +56,53 @@ export function createKbCapabilities(getDeps: GetToolDeps): PageCapability {
         ? ['Read, rewrite, and restructure the active knowledge-base article']
         : [],
     lifecycle: {
-      // A KB turn runs a turn-scoped transaction against the active article: the
-      // first write captures a pre-turn snapshot in Redis and locks the article;
-      // turn end must finalize (release lock, keep snapshot for Undo) or revert
-      // (restore snapshot, unlock). Every block-CRUD write resolves its target
-      // from `findRef(sessionContext, 'article')`, so a turn touches exactly one
+      // A KB turn runs against the active article: its first write captures a
+      // pre-turn snapshot in Redis and emits the `locked: true` editor signal.
+      // Turn end always finalizes — `finalizeKopilotKbTurn` means "release the
+      // lock, KEEP the snapshot so the turn stays reviewable", which is already
+      // the shape every outcome wants. (Note the contrast with the workflow
+      // builder, whose finalize DISCARDS its snapshot because the canvas owns
+      // undo of a completed turn; KB has no client-side history, so its Undo is
+      // always the server snapshot.)
+      //
+      // [C5] Revert is NEVER automatic (plans/kopilot/workflow/20 §2, Q1). The
+      // old `else` branch here threw the turn's block edits away on any
+      // non-`completed` outcome — so a turn that rewrote six sections and then
+      // tripped the token budget lost all six, even though every block-CRUD op
+      // had already persisted through its own hash guard and the user had
+      // watched them land. `exhausted` / `aborted` / `error` all leave the
+      // article as N complete, valid patches; the rollback is offered by the
+      // turn-review banner (`kb.revertKopilotTurn` / `kb.keepKopilotTurn`,
+      // both turn-pinned) — the user's click, never the server's inference.
+      //
+      // Every block-CRUD write resolves its target from
+      // `findRef(sessionContext, 'article')`, so a turn touches exactly one
       // article — the active one. The snapshot keyed by `(articleId, turnId)` is
       // already the "did THIS turn write it" record: `readKopilotSnapshot` with
       // the turn id returns null unless this turn wrote the article, which also
       // stops a prior turn's still-pending review snapshot (24h TTL) from being
-      // finalized/reverted here.
+      // finalized here. That same read is why the unlock can live inside the
+      // snapshot branch (unlike the workflow capability's lock release): the KB
+      // lock is only ever emitted alongside a capture, so a read-only turn never
+      // locked the editor and has nothing to release.
       async onTurnEnd(outcome, { turnId }) {
-        const { db, organizationId, userId, sessionContext } = getDeps()
+        const { sessionContext } = getDeps()
         const articleId = findRef(sessionContext, 'article')?.id
         if (!articleId) return
-        const snapshot = await readKopilotSnapshot(articleId, turnId)
-        if (!snapshot) return
         try {
-          if (outcome === 'completed') {
-            await finalizeKopilotKbTurn({ articleId })
-          } else {
-            // `expectedTurnId` is load-bearing now that we derive `articleId`
-            // from `sessionContext` rather than a per-turn touched list: it
-            // rejects a stale (prior-turn) snapshot so a later failed turn can't
-            // roll back an article it never wrote.
-            await revertKopilotKbTurn({
-              db,
-              organizationId,
-              userId,
+          // Inside the try — the domain config swallows a throwing hook, but
+          // this must not depend on that.
+          const snapshot = await readKopilotSnapshot(articleId, turnId)
+          if (!snapshot) return
+          await finalizeKopilotKbTurn({ articleId })
+          if (outcome !== 'completed') {
+            // Warn (not error): the edits survived and the article is
+            // reviewable — but a turn that stopped early yet kept its writes
+            // is worth seeing in OpenObserve.
+            logger.warn('Kopilot KB turn stopped early — edits kept, snapshot retained', {
               articleId,
-              expectedTurnId: turnId,
+              turnId,
+              outcome,
             })
           }
         } catch (err) {

--- a/packages/lib/src/ai/kopilot/capabilities/types.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/types.ts
@@ -3,7 +3,7 @@
 import type { Database } from '@auxx/database'
 import type { ResolvedKnowledgeScope } from '../../../agents/resolve-knowledge-scope'
 import type { CapabilityView } from '../../../permissions/capabilities/capability-view'
-import type { AgentDeps, AgentToolDefinition } from '../../agent-framework/types'
+import type { AgentDeps, AgentToolDefinition, TurnOutcome } from '../../agent-framework/types'
 import type { SessionContext } from '../types'
 
 /** Dependencies injected into tool execution (superset of AgentDeps) */
@@ -74,12 +74,22 @@ export interface CapabilityTurnDeps {
  */
 export interface CapabilityLifecycle {
   /**
-   * Fired once at the end of a turn. `outcome` mirrors the engine
-   * (`'completed'` for a clean finish, `'error'` for a turn-error / abort /
-   * disconnect). Sources everything but `turnId` from the capability's own
-   * `GetToolDeps` closure. Must not throw — the domain config wraps it.
+   * Fired once at the end of a turn. `outcome` is the engine's
+   * {@link TurnOutcome}, forwarded verbatim by the domain config — one source
+   * of truth, never a locally restated union.
+   *
+   * Only `'error'` means something actually went wrong. `'exhausted'` (a
+   * resource cap: token budget, iteration cap, same-tool failure streak) and
+   * `'aborted'` (abort signal / client disconnect / page reload) both leave the
+   * capability's turn-scoped resource as N complete, individually valid
+   * mutations — **a hook must never treat them as corruption and roll them
+   * back** (plans/kopilot/workflow/20 §2). Restoring a snapshot is offered to
+   * the user, never performed here.
+   *
+   * Sources everything but `turnId` from the capability's own `GetToolDeps`
+   * closure. Must not throw — the domain config wraps it.
    */
-  onTurnEnd?(outcome: 'completed' | 'error', deps: CapabilityTurnDeps): Promise<void>
+  onTurnEnd?(outcome: TurnOutcome, deps: CapabilityTurnDeps): Promise<void>
 }
 
 /** A page capability set — tools available on a specific page */

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/index.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/index.ts
@@ -94,21 +94,25 @@ export function createWorkflowBuilderCapabilities(getDeps: GetToolDeps): PageCap
         ? ['Read, build, and edit the workflow open in this builder']
         : ['Read the workflow open in this builder'],
     lifecycle: {
-      // A workflow turn is a turn-scoped transaction against the open draft:
-      // the first mutation captures a pre-turn snapshot in Redis
-      // (`graph-edit/turn-snapshot.ts`, inside `runGraphMutation`); turn end
-      // discards it (completed — the turn committed atomically) or reverts
-      // (restore the pre-turn graph, guarded by `expectedTurnId`). Undo of a
-      // successful turn is the CANVAS's job: the builder's realtime subscriber
-      // records each Kopilot edit as a normal client-side history entry, so
-      // the snapshot exists only for failed-turn atomicity — there is no
-      // per-turn Undo card and no server-side undo of a completed turn.
+      // A workflow turn writes through a pre-turn snapshot: the first mutation
+      // captures the prior graph in Redis (`graph-edit/turn-snapshot.ts`,
+      // inside `runGraphMutation`). Turn end has exactly ONE job now —
+      // `completed` discards the snapshot; every other outcome leaves it
+      // alone. **Revert is never automatic** (plans/kopilot/workflow/20 §2,
+      // Q1): each mutation persisted independently, through its own
+      // validation, its own ref gate, its own hash-CAS and its own realtime
+      // signal, so a turn that stopped early leaves N complete, valid edits
+      // the user already watched land — not a corrupt half-write.
+      // Undo of a COMPLETED turn is the CANVAS's job: the builder's realtime
+      // subscriber records each Kopilot edit as a normal client-side history
+      // entry. Undo of a turn that stopped early is the USER's click on the
+      // phase-D card, served from the snapshot this hook deliberately keeps.
       // The snapshot keyed by `(workflowAppId, turnId)` IS the "did THIS turn
       // write" record: `readWorkflowTurnSnapshot` with the turn id returns
       // null unless this turn wrote, which also stops a prior turn's
       // still-pending snapshot (24h TTL) from being touched here.
       async onTurnEnd(outcome, { turnId }) {
-        const { db, sessionContext, organizationId } = getDeps()
+        const { sessionContext, organizationId } = getDeps()
         const workflowAppId = findRef(sessionContext, 'workflow')?.id
         if (!workflowAppId) return
 
@@ -118,7 +122,9 @@ export function createWorkflowBuilderCapabilities(getDeps: GetToolDeps): PageCap
         // releasing inside the `if (!snapshot)` path would strand the canvas
         // read-only for the whole of every question-only turn. Turn-checked
         // inside, and its own try/catch so a Redis failure cannot stop the
-        // revert that follows.
+        // snapshot bookkeeping that follows. This ordering holds for EVERY
+        // outcome — an exhausted or aborted turn must not leave the canvas
+        // locked either.
         const { endWorkflowTurnLock } = await import('../../../../workflows/graph-edit/turn-lock')
         try {
           await endWorkflowTurnLock(organizationId, workflowAppId, turnId)
@@ -130,35 +136,70 @@ export function createWorkflowBuilderCapabilities(getDeps: GetToolDeps): PageCap
           })
         }
 
-        // Lazy import — turn-snapshot pulls @auxx/redis and (via the revert
-        // path) the persist seam; neither belongs in this capability's
-        // import-time graph, and the laziness keeps tests free to mock the
-        // graph-edit module wholesale.
-        const { finalizeWorkflowTurn, readWorkflowTurnSnapshot, revertWorkflowTurn } = await import(
-          '../../../../workflows/graph-edit/turn-snapshot'
-        )
-        const snapshot = await readWorkflowTurnSnapshot(workflowAppId, turnId)
-        if (!snapshot) return
         try {
-          if (outcome === 'completed') {
-            // The turn committed — discard its snapshot (turn-checked, so a
-            // fresher turn's slot is never cleared). Keeping it would only
-            // leave a stale revert target around; client-side canvas history
-            // owns undo from here.
-            await finalizeWorkflowTurn(workflowAppId, turnId)
-            return
-          }
-          // `expectedTurnId` (the third argument) is load-bearing: it rejects
-          // a stale prior-turn snapshot so a later failed turn can never roll
-          // back a workflow it didn't touch.
-          const reverted = await revertWorkflowTurn(db, { workflowAppId, organizationId }, turnId)
-          if (reverted.isErr()) {
-            logger.error('Kopilot workflow turn revert failed', {
+          // Lazy import — turn-snapshot pulls @auxx/redis and the persist seam;
+          // neither belongs in this capability's import-time graph, and the
+          // laziness keeps tests free to mock the graph-edit module wholesale.
+          // `revertWorkflowTurn` is deliberately NOT imported here any more:
+          // the restore is offered by the phase-D card (tRPC), never performed
+          // by this hook. Inside the try with the read — the engine swallows a
+          // throwing hook, but this must not depend on that.
+          const { finalizeWorkflowTurn, readWorkflowTurnSnapshot, recordWorkflowTurnEnding } =
+            await import('../../../../workflows/graph-edit/turn-snapshot')
+          const snapshot = await readWorkflowTurnSnapshot(workflowAppId, turnId)
+          if (!snapshot) return
+          if (outcome !== 'completed') {
+            // [C4] The turn stopped early — KEEP the work AND the snapshot.
+            //
+            // Not reverting is the point of plan 20: `exhausted` (token
+            // budget / iteration cap / failure streak), `aborted` (page
+            // reload, navigate-away) and even `error` all leave a draft that
+            // is N complete, individually persisted mutations. A draft graph
+            // has no atomicity requirement to protect — "half-finished" is
+            // what the canvas looks like every time a human stops mid-thought.
+            //
+            // Not FINALIZING is just as load-bearing, and less obvious.
+            // Finalizing DISCARDS the snapshot, which is the only recovery
+            // path this turn has left — and it is exactly what phase D's Undo
+            // card consumes. `delete_nodes` carries no approval gate, so a
+            // turn that deletes five nodes and then trips the budget leaves
+            // them deleted; the snapshot is what makes that recoverable.
+            //
+            // Leaving it behind is safe, not a leak — do NOT "tidy this up":
+            //  - the slot is one-per-workflow (`workflow:graph:<id>:preturn`)
+            //  - `captureWorkflowTurnSnapshot` overwrites it on the NEXT
+            //    turn's first write
+            //  - `readWorkflowTurnSnapshot` is turn-checked, so a superseded
+            //    caller reads null rather than a foreign turn's graph
+            //  - `clearWorkflowTurnSnapshot` wipes it unconditionally on a
+            //    manual canvas save
+            //  - Redis expires it after 24h
+            // Stamp HOW it ended onto the snapshot before returning. This is
+            // the ONLY place the ending is knowable and durable at once: the
+            // engine classifies the terminal event and hands it here, then the
+            // turn is gone — the snapshot is a graph, not a transcript, so
+            // without this stamp the Undo offer can only say "stopped early".
+            //
+            // ADDITIVE, not a finalize — [C4] above still holds in full. It
+            // rewrites one field of the same slot and cannot delete it, and it
+            // is turn-checked inside, so a superseded turn relabels nothing.
+            // Best-effort by construction (it swallows its own failures), so a
+            // Redis blip costs the adjective, never the offer.
+            await recordWorkflowTurnEnding(workflowAppId, turnId, outcome)
+            // Warn (not error): nothing is broken, but a turn that kept work
+            // it did not finish is worth seeing in the logs.
+            logger.warn('Kopilot workflow turn stopped early — edits kept, snapshot retained', {
               workflowAppId,
               turnId,
-              error: reverted.error.message,
+              outcome,
             })
+            return
           }
+          // The turn committed — discard its snapshot (turn-checked, so a
+          // fresher turn's slot is never cleared). Keeping it would only
+          // leave a stale revert target around; client-side canvas history
+          // owns undo from here.
+          await finalizeWorkflowTurn(workflowAppId, turnId)
         } catch (err) {
           logger.error('Kopilot turn-end workflow lifecycle failed', {
             workflowAppId,

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/lifecycle.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/lifecycle.test.ts
@@ -1,24 +1,40 @@
 // packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/lifecycle.test.ts
 //
-// Turn-end lifecycle (04 §4, revised 2026-08-14): undo of a successful turn is
-// CLIENT-SIDE (the builder's realtime subscriber records a canvas history
-// entry), so a COMPLETED turn DISCARDS its snapshot via `finalizeWorkflowTurn`
-// — the snapshot survives only as failed-turn atomicity. A failed turn
-// reverts, guarded by `expectedTurnId` so a later failed turn can never roll
-// back a workflow it didn't touch.
+// Turn-end lifecycle. Two rules, and the second one INVERTED an earlier
+// contract (plans/kopilot/workflow/20-partial-turn-survival.md phase A):
+//
+//  1. A COMPLETED turn discards its snapshot via `finalizeWorkflowTurn` —
+//     undo of a successful turn is CLIENT-SIDE (the builder's realtime
+//     subscriber records a canvas history entry), so the server copy is dead
+//     weight.
+//  2. Every OTHER outcome — `exhausted` (token budget / iteration cap /
+//     failure streak), `aborted` (reload, navigate-away) and `error` — keeps
+//     BOTH the work and the snapshot. Revert is never automatic: the edits
+//     each persisted through their own validation and hash-CAS, and the
+//     snapshot is the fuel for the user-driven Undo card ([C4]). Finalizing
+//     would delete that recovery path, so it must not happen either. The
+//     outcome is additionally STAMPED onto the surviving snapshot, because it
+//     is the only record of why the card exists — the snapshot is a graph, not
+//     a transcript, and by the time the card renders the turn is long gone.
+//
+// The canvas edit lock is released on all four outcomes, before and outside
+// the snapshot branch.
 
 import { err, ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { NotFoundError } from '../../../../../../errors'
+import { ConflictError } from '../../../../../../errors'
+import type { TurnOutcome } from '../../../../../agent-framework/types'
 import type { GetToolDeps, ToolDeps } from '../../../types'
 
 const readWorkflowTurnSnapshot = vi.fn()
 const revertWorkflowTurn = vi.fn()
 const finalizeWorkflowTurn = vi.fn()
+const recordWorkflowTurnEnding = vi.fn()
 vi.mock('../../../../../../workflows/graph-edit/turn-snapshot', () => ({
   readWorkflowTurnSnapshot: (...a: unknown[]) => readWorkflowTurnSnapshot(...a),
   revertWorkflowTurn: (...a: unknown[]) => revertWorkflowTurn(...a),
   finalizeWorkflowTurn: (...a: unknown[]) => finalizeWorkflowTurn(...a),
+  recordWorkflowTurnEnding: (...a: unknown[]) => recordWorkflowTurnEnding(...a),
 }))
 
 const endWorkflowTurnLock = vi.fn()
@@ -31,6 +47,10 @@ import { createWorkflowBuilderCapabilities } from '../../index'
 const ORG = 'org-1'
 const WF = 'wfapp-1'
 const TURN = 'turn-1'
+
+/** The three outcomes that must keep the work AND the snapshot. */
+const KEEP_OUTCOMES: TurnOutcome[] = ['exhausted', 'aborted', 'error']
+const ALL_OUTCOMES: TurnOutcome[] = ['completed', ...KEEP_OUTCOMES]
 
 let refs: Array<Record<string, unknown>> = [{ kind: 'workflow', id: WF }]
 const db = { tag: 'db' }
@@ -58,6 +78,7 @@ beforeEach(() => {
     .mockResolvedValue({ turnId: TURN, graph: { nodes: [], edges: [] }, capturedAt: 1 })
   revertWorkflowTurn.mockReset().mockResolvedValue(ok({ graphHash: 'h' }))
   finalizeWorkflowTurn.mockReset().mockResolvedValue(undefined)
+  recordWorkflowTurnEnding.mockReset().mockResolvedValue(undefined)
   endWorkflowTurnLock.mockReset().mockResolvedValue(undefined)
 })
 
@@ -68,6 +89,9 @@ describe('workflow.builder onTurnEnd', () => {
     expect(finalizeWorkflowTurn).toHaveBeenCalledTimes(1)
     expect(finalizeWorkflowTurn).toHaveBeenCalledWith(WF, TURN)
     expect(revertWorkflowTurn).not.toHaveBeenCalled()
+    // No ending to record: the snapshot is being deleted, and a completed turn
+    // is the one ending the Undo banner never has to explain.
+    expect(recordWorkflowTurnEnding).not.toHaveBeenCalled()
   })
 
   it('completed on a turn that never wrote ⇒ nothing to finalize', async () => {
@@ -76,28 +100,63 @@ describe('workflow.builder onTurnEnd', () => {
     expect(finalizeWorkflowTurn).not.toHaveBeenCalled()
   })
 
-  it('error ⇒ reverts, threading the turn id as expectedTurnId', async () => {
-    await lifecycle()('error', { turnId: TURN })
-    expect(revertWorkflowTurn).toHaveBeenCalledTimes(1)
-    expect(revertWorkflowTurn).toHaveBeenCalledWith(
-      db,
-      { workflowAppId: WF, organizationId: ORG },
-      TURN
-    )
+  // The reported bug: twelve good edits thrown away because the engine tallied
+  // the turn's tokens AFTER it had already finished and replied.
+  it.each(
+    KEEP_OUTCOMES
+  )('%s after a write ⇒ neither reverted NOR finalized — the snapshot survives', async (outcome) => {
+    await lifecycle()(outcome, { turnId: TURN })
+    expect(readWorkflowTurnSnapshot).toHaveBeenCalledWith(WF, TURN)
+    expect(revertWorkflowTurn).not.toHaveBeenCalled()
+    // Finalizing would discard the snapshot — i.e. delete the only recovery
+    // path for a turn that ran `delete_nodes` and then ran out of room.
+    expect(finalizeWorkflowTurn).not.toHaveBeenCalled()
+    // ...and the ending IS stamped on it. Additive: this rewrites one field of
+    // the slot the two assertions above just pinned as surviving, which is what
+    // lets the Undo offer say why it is there instead of only that it is.
+    expect(recordWorkflowTurnEnding).toHaveBeenCalledTimes(1)
+    expect(recordWorkflowTurnEnding).toHaveBeenCalledWith(WF, TURN, outcome)
   })
 
-  it('error on a turn that never wrote (or was superseded) ⇒ nothing reverted', async () => {
-    // The turn-checked read returning null IS the "did this turn write" record —
-    // a stale prior-turn snapshot answers null for this turn id too.
+  it.each(
+    KEEP_OUTCOMES
+  )('%s on a turn that never wrote (or was superseded) ⇒ nothing touched', async (outcome) => {
+    // The turn-checked read returning null IS the "did this turn write"
+    // record — a stale prior-turn snapshot answers null for this turn id too.
     readWorkflowTurnSnapshot.mockResolvedValue(null)
-    await lifecycle()('error', { turnId: 'turn-2' })
+    await lifecycle()(outcome, { turnId: 'turn-2' })
     expect(readWorkflowTurnSnapshot).toHaveBeenCalledWith(WF, 'turn-2')
+    expect(revertWorkflowTurn).not.toHaveBeenCalled()
+    expect(finalizeWorkflowTurn).not.toHaveBeenCalled()
+    // Nothing to label either — there is no offer for the ending to describe.
+    expect(recordWorkflowTurnEnding).not.toHaveBeenCalled()
+  })
+
+  it('a failing ending stamp is swallowed — the offer costs the adjective, not the Undo', async () => {
+    recordWorkflowTurnEnding.mockRejectedValue(new Error('redis down'))
+    await expect(lifecycle()('exhausted', { turnId: TURN })).resolves.toBeUndefined()
+    // Still no finalize: a stamp that failed must not take the snapshot with it.
+    expect(finalizeWorkflowTurn).not.toHaveBeenCalled()
     expect(revertWorkflowTurn).not.toHaveBeenCalled()
   })
 
-  it('a failed revert is swallowed and logged — turn end must not throw', async () => {
-    revertWorkflowTurn.mockResolvedValue(err(new NotFoundError('superseded')))
-    await expect(lifecycle()('error', { turnId: TURN })).resolves.toBeUndefined()
+  it.each(ALL_OUTCOMES)('never reverts on %s — the restore is the user’s call', async (o) => {
+    // Guard against a future "helpful" auto-rollback creeping back in: a
+    // ConflictError from a stale revert is not something this hook can ever
+    // see, because it never calls revert at all.
+    revertWorkflowTurn.mockResolvedValue(err(new ConflictError('canvas moved on')))
+    await lifecycle()(o, { turnId: TURN })
+    expect(revertWorkflowTurn).not.toHaveBeenCalled()
+  })
+
+  it('a failing finalize is swallowed and logged — turn end must not throw', async () => {
+    finalizeWorkflowTurn.mockRejectedValue(new Error('redis down'))
+    await expect(lifecycle()('completed', { turnId: TURN })).resolves.toBeUndefined()
+  })
+
+  it('a failing snapshot read is swallowed — turn end must not throw', async () => {
+    readWorkflowTurnSnapshot.mockRejectedValue(new Error('redis down'))
+    await expect(lifecycle()('exhausted', { turnId: TURN })).resolves.toBeUndefined()
   })
 
   it('no workflow ref ⇒ no snapshot read at all', async () => {
@@ -111,14 +170,9 @@ describe('workflow.builder onTurnEnd', () => {
 // its release cannot live behind the snapshot branch above — a turn that only
 // read holds the lock but has no snapshot. See plan 14 §6.7.
 describe('workflow.builder onTurnEnd — canvas edit lock', () => {
-  it('releases the lock on a completed turn', async () => {
-    await lifecycle()('completed', { turnId: TURN })
+  it.each(ALL_OUTCOMES)('releases the lock on %s', async (outcome) => {
+    await lifecycle()(outcome, { turnId: TURN })
     expect(endWorkflowTurnLock).toHaveBeenCalledTimes(1)
-    expect(endWorkflowTurnLock).toHaveBeenCalledWith(ORG, WF, TURN)
-  })
-
-  it('releases the lock on a failed turn', async () => {
-    await lifecycle()('error', { turnId: TURN })
     expect(endWorkflowTurnLock).toHaveBeenCalledWith(ORG, WF, TURN)
   })
 
@@ -126,17 +180,17 @@ describe('workflow.builder onTurnEnd — canvas edit lock', () => {
   // path would strand the canvas read-only for the whole of every
   // question-only turn ("what does this workflow do?"), which writes nothing
   // and therefore never captures a snapshot.
-  it('releases even when the turn never wrote — a read-only turn still held it', async () => {
+  it.each(ALL_OUTCOMES)('releases even when the turn never wrote on %s', async (outcome) => {
     readWorkflowTurnSnapshot.mockResolvedValue(null)
-    await lifecycle()('completed', { turnId: TURN })
+    await lifecycle()(outcome, { turnId: TURN })
     expect(finalizeWorkflowTurn).not.toHaveBeenCalled()
     expect(endWorkflowTurnLock).toHaveBeenCalledWith(ORG, WF, TURN)
   })
 
-  it('a failing release cannot stop the revert — turn end must still roll back', async () => {
+  it('a failing release cannot stop the snapshot bookkeeping', async () => {
     endWorkflowTurnLock.mockRejectedValue(new Error('redis down'))
-    await expect(lifecycle()('error', { turnId: TURN })).resolves.toBeUndefined()
-    expect(revertWorkflowTurn).toHaveBeenCalledTimes(1)
+    await expect(lifecycle()('completed', { turnId: TURN })).resolves.toBeUndefined()
+    expect(finalizeWorkflowTurn).toHaveBeenCalledTimes(1)
   })
 
   it('no workflow ref ⇒ nothing to release', async () => {

--- a/packages/lib/src/ai/kopilot/domain-config.ts
+++ b/packages/lib/src/ai/kopilot/domain-config.ts
@@ -13,6 +13,7 @@ import type {
   AgentToolDefinition,
   AgentToolResult,
   PostProcessResult,
+  TurnOutcome,
   TurnSnapshots,
 } from '../agent-framework/types'
 import { resolveUtilityModel } from '../providers/utility-model'
@@ -236,15 +237,14 @@ export function createKopilotDomainConfig(
         ? { content: next, linkSnapshots }
         : { content: next }
     },
-    async onTurnEnd(
-      _state: AgentState,
-      outcome: 'completed' | 'error',
-      turnId?: string
-    ): Promise<void> {
+    async onTurnEnd(_state: AgentState, outcome: TurnOutcome, turnId?: string): Promise<void> {
       // Fan the engine's turn-end out to every capability that declares a
       // lifecycle — capability-scoped cleanup (e.g. the KB snapshot/lock
       // transaction) lives with the capability, not here. The domain config
       // stays capability-agnostic: no per-tool sniffing, no KB imports.
+      // `outcome` is forwarded VERBATIM: the four-way TurnOutcome is the whole
+      // point (a capability must be able to tell "ran out of room" from "went
+      // wrong"), so this fan-out must never collapse it back to two states.
       if (!turnId) return
       for (const lifecycle of capabilityRegistry?.getLifecycles() ?? []) {
         if (!lifecycle.onTurnEnd) continue

--- a/packages/lib/src/ai/kopilot/index.ts
+++ b/packages/lib/src/ai/kopilot/index.ts
@@ -62,6 +62,7 @@ export {
   type TaskNotificationSummary,
   type TaskSnapshot,
 } from './task-notifications'
+export { KOPILOT_TURN_BUDGET } from './turn-budget'
 export type {
   KopilotDomainState,
   PlanState,

--- a/packages/lib/src/ai/kopilot/turn-budget.ts
+++ b/packages/lib/src/ai/kopilot/turn-budget.ts
@@ -1,0 +1,113 @@
+// packages/lib/src/ai/kopilot/turn-budget.ts
+
+/**
+ * Kopilot's engine turn budget — the single source for the three `AgentEngine`
+ * per-turn caps on every Kopilot path (the SSE route and the worker job).
+ *
+ * It lives next to `domain-config.ts` deliberately: that file owns this domain's
+ * other limit, the per-agent `maxIterations = 30`, and the two numbers only make
+ * sense read together. Before this constant existed they disagreed by more than
+ * an order of magnitude and were hand-synced across two call sites.
+ *
+ * This module imports nothing on purpose — that is what keeps
+ * `process-agent-job.ts`'s leaf-path import inert.
+ *
+ * ## `maxTokensPerTurn` — 1,500,000
+ *
+ * The framework default is `DEFAULT_MAX_TOKENS_PER_TURN = 200_000`
+ * (`agent-framework/engine.ts`). Kopilot never set this knob, so it ran on that
+ * default — and a turn that exceeds it yields `turn-error`, which used to make
+ * the workflow-builder capability roll the whole draft graph back to its
+ * pre-turn snapshot. A dozen watched, individually-persisted edits vanished.
+ *
+ * ### The unit, and why this number was re-derived
+ *
+ * The first version of this constant (2,000,000) was sized under the OLD meter,
+ * which summed each LLM call's `total_tokens`. `total_tokens` includes prompt
+ * tokens and the entire conversation is re-sent on every iteration, so that
+ * meter charged the same prompt once per tool round-trip — superlinear in
+ * iteration count rather than linear in work done. It was an iteration cap
+ * wearing a token-shaped mask.
+ *
+ * The engine now meters **non-cached input + completion**, per LLM call, off the
+ * raw `IterationUsage` records (`agent-framework/usage-metering.ts`). Re-sending
+ * a cached prefix is nearly free on every provider we use, and the meter now
+ * says so, which makes 2,000,000 meaningless: the same turn meters far lower.
+ *
+ * ### The arithmetic
+ *
+ * From the one observed mid-turn Kopilot call — `promptInput: 34389`,
+ * `cachedInput: 19072` — read under both provider semantics, because Kopilot is
+ * BYO-model and the turn can run on either shape:
+ *
+ * ```text
+ *   Anthropic shape (prompt_tokens EXCLUDES cached reads):
+ *     metered/call ≈ 34_389 + ~1_500 completion   ≈  36_000   (pessimistic:
+ *                                                              assumes the cache
+ *                                                              never improves)
+ *   OpenAI shape   (prompt_tokens INCLUDES cached reads):
+ *     metered/call ≈ (34_389 − 19_072) + ~1_500   ≈  17_000   (realistic)
+ *
+ *   One full-length agent run is the per-agent cap, 30 iterations:
+ *     pessimistic   30 × 36_000                    = 1_080_000
+ *     realistic     30 × 17_000                    =   510_000
+ *
+ *   Sizing rule — the budget must cover ONE full-length run even on the
+ *   pessimistic reading (so the graceful `maxIterations: 30` close, never the
+ *   destructive token meter, is what ends a long turn), and THREE on the
+ *   realistic one (so a procedure-stepper turn with legitimate continuations
+ *   still fits):
+ *     max(1_080_000, 3 × 510_000) = 1_530_000  →  1_500_000
+ * ```
+ *
+ * **Still an estimate, pending live measurement.** The per-call figures above
+ * are arithmetic on a single logged `LLM cache metrics` line, not a measurement
+ * of a whole turn — the `LLM complete` log redacts `usage` because its keys
+ * contain "token". The `logger.warn` at the engine's budget exits is the
+ * instrumentation that will settle it: it now carries both `turnTokensUsed` (the
+ * provider-reported grand total) and `turnMeteredTokens` (what this cap is
+ * compared against), so one real exit in OpenObserve gives the true ratio.
+ *
+ * ### Why not lower
+ *
+ * The nominal drop from 2,000,000 is modest and that is deliberate. The fix is
+ * the unit, not the constant: the budget must still clear 30 iterations on the
+ * *worst* provider reading, or Phase B would reintroduce the very failure it
+ * exists to remove — turns dying at the meter after doing all their work.
+ *
+ * ### Why not higher, and why not dropped
+ *
+ * It is the **only** bound on a runaway `continueTurn()` reinvoke loop. The
+ * engine deliberately does not reset turn usage across procedure-stepper
+ * continuations, and `maxTotalIterations` counts agents rather than iterations
+ * (see below), so nothing else stops that loop. At 1,500,000 a runaway is cut
+ * off after roughly three full-length agent runs.
+ *
+ * ## `maxTotalIterations` — 100
+ *
+ * Long-running plans routinely chain more than five approvals (one per ticket
+ * reply, etc.) and need iteration headroom for plan-step churn. Other domains
+ * stay on the framework defaults.
+ *
+ * Note that this knob counts **agents in the route** far more than iterations —
+ * the engine advances it per `assistant-message-finished`, which the query loop
+ * emits once per agent run. Kopilot is a solo-agent domain (`agents: ['agent']`),
+ * so 100 is effectively unreachable here. It is kept at the historical value
+ * rather than tuned, because tuning a knob whose unit is wrong would only bake
+ * in the confusion; the unit itself is tracked as §10.1 of
+ * `plans/kopilot/workflow/20-partial-turn-survival.md`.
+ *
+ * ## `maxApprovalsPerTurn` — 50
+ *
+ * Same reasoning as `maxTotalIterations`: the framework default of 5 is far
+ * below what a multi-step Kopilot plan legitimately asks for.
+ */
+export const KOPILOT_TURN_BUDGET = {
+  maxTokensPerTurn: 1_500_000,
+  maxTotalIterations: 100,
+  maxApprovalsPerTurn: 50,
+} as const satisfies {
+  maxTokensPerTurn: number
+  maxTotalIterations: number
+  maxApprovalsPerTurn: number
+}

--- a/packages/lib/src/workflows/graph-edit/__tests__/turn-lifecycle.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/turn-lifecycle.test.ts
@@ -16,7 +16,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ConflictError, NotFoundError, UnprocessableEntityError } from '../../../errors'
-import { hashWorkflowGraph } from '../../graph-hash'
+import { hashGraphSemantics, hashWorkflowGraph } from '../../graph-hash'
 
 // Partial mock — the cache barrel is imported by half of lib; replacing it
 // wholesale dies at collection. Only the read the graph-edit path makes is stubbed.
@@ -71,9 +71,12 @@ vi.mock('../../../realtime', () => ({
 }))
 
 const { addNode } = await import('../ops')
-const { finalizeWorkflowTurn, readWorkflowTurnSnapshot, revertWorkflowTurn } = await import(
-  '../turn-snapshot'
-)
+const {
+  finalizeWorkflowTurn,
+  readWorkflowTurnSnapshot,
+  recordWorkflowTurnEnding,
+  revertWorkflowTurn,
+} = await import('../turn-snapshot')
 
 import type { DraftGraph, GraphNode } from '../types'
 
@@ -146,12 +149,19 @@ beforeEach(() => {
   mailGuard.mockResolvedValue(undefined)
   publishWorkflowDraftUpdated.mockReset()
   serviceUpdate.mockReset()
+  // `WorkflowService.update` returns `hashWorkflowGraph` of the row it just
+  // wrote — the same function `loadDraftContext` runs over the stored column.
+  // The fake must keep that identity or the post-turn hash means nothing.
   serviceUpdate.mockImplementation(async (_org: string, input: Record<string, unknown>) => ({
-    graphHash: 'hash-after',
+    graphHash: input.graph ? hashWorkflowGraph(input.graph) : null,
     triggerType: input.triggerType ?? null,
     entityDefinitionId: input.entityDefinitionId ?? null,
   }))
 })
+
+/** The graph the last persist actually wrote — i.e. what the canvas now holds. */
+const persistedGraph = (): DraftGraph =>
+  (serviceUpdate.mock.calls.at(-1)?.[1] as { graph: DraftGraph }).graph
 
 describe('turn snapshot capture', () => {
   it('captures the PRE-edit graph on the first mutation of a turn', async () => {
@@ -175,7 +185,7 @@ describe('turn snapshot capture', () => {
     const first = await readWorkflowTurnSnapshot(APP, TURN_A)
 
     // Second mutation of the SAME turn, on the now-grown draft.
-    const grown = (serviceUpdate.mock.calls.at(-1)?.[1] as { graph: DraftGraph }).graph
+    const grown = persistedGraph()
     const result = await addNode(makeDb(grown), {
       ...scope(TURN_A),
       type: 'wait',
@@ -185,8 +195,16 @@ describe('turn snapshot capture', () => {
     expect(result.isOk()).toBe(true)
 
     const second = await readWorkflowTurnSnapshot(APP, TURN_A)
-    expect(second).toEqual(first) // still the turn's ORIGINAL pre-edit graph
+    // Still the turn's ORIGINAL pre-edit state — everything the capture owns
+    // is byte-identical.
+    expect({ ...second, postTurnGraphSemanticHash: undefined }).toEqual({
+      ...first,
+      postTurnGraphSemanticHash: undefined,
+    })
     expect(second?.graph.nodes).toHaveLength(1)
+    // ...but the post-turn hash tracks the LATEST write, not the first.
+    expect(second?.postTurnGraphSemanticHash).toBe(hashGraphSemantics(persistedGraph()))
+    expect(second?.postTurnGraphSemanticHash).not.toBe(first?.postTurnGraphSemanticHash)
   })
 
   it('takes no snapshot without a turnId, and none when the mutation is rejected', async () => {
@@ -209,17 +227,11 @@ describe('revert / finalize lifecycle', () => {
   it('a failed turn restores the exact prior graph through the persist seam', async () => {
     const graph = baseGraph()
     await addWait(makeDb(graph), TURN_A)
+
+    // The draft now holds exactly what the turn wrote — an untouched canvas.
+    const mutated = persistedGraph()
     serviceUpdate.mockClear()
     publishWorkflowDraftUpdated.mockClear()
-
-    // The draft now holds the mutated graph; revert must write back the original.
-    const mutated = { ...baseGraph(), nodes: [...baseGraph().nodes] }
-    mutated.nodes.push({
-      id: 'wait-zzzzzzzzzzzzzzzzzzzzz',
-      type: 'standard',
-      position: { x: 500, y: 200 },
-      data: { id: 'wait-zzzzzzzzzzzzzzzzzzzzz', type: 'wait', title: 'Wait A Bit' },
-    })
     const db = makeDb(mutated)
 
     const reverted = await revertWorkflowTurn(db, scope(), TURN_A)
@@ -271,6 +283,227 @@ describe('revert / finalize lifecycle', () => {
 
     await finalizeWorkflowTurn(APP, TURN_B)
     expect(await readWorkflowTurnSnapshot(APP, TURN_B)).toBeNull()
+  })
+})
+
+/**
+ * Plan 20 §5 / [C3] + §10.4. `persistDraft`'s CAS token is read fresh
+ * microseconds before the write, so it guards a race INSIDE the revert and
+ * nothing across time. Because phase D makes the revert a user-clickable Undo
+ * that can fire minutes later, the snapshot carries the hash of the graph the
+ * turn LEFT BEHIND, and the revert refuses when the live draft no longer
+ * matches it.
+ */
+describe('post-turn hash guard', () => {
+  /** A hand edit landing on the canvas after the turn stopped writing. */
+  function withExtraNode(graph: DraftGraph): DraftGraph {
+    return {
+      ...graph,
+      nodes: [
+        ...graph.nodes,
+        {
+          id: 'wait-yyyyyyyyyyyyyyyyyyyyy',
+          type: 'standard',
+          position: { x: 900, y: 200 },
+          data: { id: 'wait-yyyyyyyyyyyyyyyyyyyyy', type: 'wait', title: 'Human Edit' },
+        },
+      ],
+    }
+  }
+
+  it('stamps the hash of what the write actually stored', async () => {
+    await addWait(makeDb(baseGraph()), TURN_A)
+    const snapshot = await readWorkflowTurnSnapshot(APP, TURN_A)
+    expect(snapshot?.postTurnGraphSemanticHash).toBe(hashGraphSemantics(persistedGraph()))
+    // Never the PRE-turn graph — that is what `graph` already holds.
+    expect(snapshot?.postTurnGraphSemanticHash).not.toBe(hashGraphSemantics(baseGraph()))
+  })
+
+  it('does not stamp for a non-turn caller (no snapshot to stamp)', async () => {
+    await addWait(makeDb(baseGraph()))
+    expect(redisStore.size).toBe(0)
+  })
+
+  it('refuses with a ConflictError when the canvas changed after the turn', async () => {
+    await addWait(makeDb(baseGraph()), TURN_A)
+    const divergent = withExtraNode(persistedGraph())
+    serviceUpdate.mockClear()
+    publishWorkflowDraftUpdated.mockClear()
+
+    const reverted = await revertWorkflowTurn(makeDb(divergent), scope(), TURN_A)
+    expect(reverted.isErr()).toBe(true)
+    const error = reverted._unsafeUnwrapErr()
+    expect(error).toBeInstanceOf(ConflictError)
+    expect(error.statusCode).toBe(409)
+    expect(error.details.reason).toBe('canvas-changed-since-turn')
+    expect(error.message).toMatch(/changed since that turn finished/i)
+    expect(error.message).toMatch(/nothing was reverted/i)
+
+    // The pre-turn graph was NOT restored, and no canvas was told to refetch.
+    expect(serviceUpdate).not.toHaveBeenCalled()
+    expect(publishWorkflowDraftUpdated).not.toHaveBeenCalled()
+    // The snapshot is left in place — refusing must not destroy the record.
+    expect((await readWorkflowTurnSnapshot(APP, TURN_A))?.turnId).toBe(TURN_A)
+  })
+
+  it('the two refusals are distinguishable by class and status', async () => {
+    // (a) canvas moved on → 409
+    await addWait(makeDb(baseGraph()), TURN_A)
+    const divergent = withExtraNode(persistedGraph())
+    const conflict = (
+      await revertWorkflowTurn(makeDb(divergent), scope(), TURN_A)
+    )._unsafeUnwrapErr()
+
+    // (b) snapshot gone (manual save cleared it / TTL / superseded turn) → 404
+    redisStore.clear()
+    const missing = (
+      await revertWorkflowTurn(makeDb(divergent), scope(), TURN_A)
+    )._unsafeUnwrapErr()
+
+    expect(conflict).toBeInstanceOf(ConflictError)
+    expect(conflict).not.toBeInstanceOf(NotFoundError)
+    expect(missing).toBeInstanceOf(NotFoundError)
+    expect(missing).not.toBeInstanceOf(ConflictError)
+    expect([conflict.statusCode, missing.statusCode]).toEqual([409, 404])
+    expect(conflict.message).not.toBe(missing.message)
+  })
+
+  it('reverts a canvas that only the turn touched, hash and all', async () => {
+    await addWait(makeDb(baseGraph()), TURN_A)
+    const untouched = persistedGraph()
+    serviceUpdate.mockClear()
+
+    const reverted = await revertWorkflowTurn(makeDb(untouched), scope(), TURN_A)
+    expect(reverted.isOk()).toBe(true)
+    const written = (serviceUpdate.mock.calls.at(-1)?.[1] as { graph: DraftGraph }).graph
+    expect(written.nodes.map((n) => n.id)).toEqual([TRIGGER_ID])
+  })
+
+  it('compares against the LAST write of the turn, not the first', async () => {
+    await addWait(makeDb(baseGraph()), TURN_A)
+    const afterFirst = persistedGraph()
+    // Same turn writes again — the canvas the user is left looking at is this one.
+    await addNode(makeDb(afterFirst), {
+      ...scope(TURN_A),
+      type: 'wait',
+      title: 'Wait Again',
+      after: 'Wait A Bit',
+    })
+    const afterSecond = persistedGraph()
+    serviceUpdate.mockClear()
+
+    // A canvas still sitting on the FIRST write is a diverged canvas.
+    const stale = await revertWorkflowTurn(makeDb(afterFirst), scope(), TURN_A)
+    expect(stale._unsafeUnwrapErr()).toBeInstanceOf(ConflictError)
+    expect(serviceUpdate).not.toHaveBeenCalled()
+
+    // Reverting against the turn's FINAL graph is what succeeds.
+    expect((await revertWorkflowTurn(makeDb(afterSecond), scope(), TURN_A)).isOk()).toBe(true)
+  })
+
+  it('fails OPEN for a snapshot captured before the hash was recorded', async () => {
+    // A snapshot written by the previous deploy: no `postTurnGraphSemanticHash`. It
+    // must still be undoable — unknown never turns into a hard refusal.
+    redisStore.set(`workflow:graph:${APP}:preturn`, {
+      turnId: TURN_A,
+      name: 'My Flow',
+      description: 'Original description',
+      graph: baseGraph(),
+      triggerType: 'scheduled',
+      capturedAt: Date.now(),
+    })
+
+    const divergent = withExtraNode(baseGraph())
+    const reverted = await revertWorkflowTurn(makeDb(divergent), scope(), TURN_A)
+    expect(reverted.isOk()).toBe(true)
+    expect(serviceUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('survives a turn that never finalized — the snapshot stays undoable', async () => {
+    await addWait(makeDb(baseGraph()), TURN_A)
+    const afterTurn = persistedGraph()
+    // Turn dies: no `finalizeWorkflowTurn`, no automatic revert (plan 20 §2).
+    const snapshot = await readWorkflowTurnSnapshot(APP, TURN_A)
+    expect(snapshot?.turnId).toBe(TURN_A)
+    expect(snapshot?.postTurnGraphSemanticHash).toBe(hashGraphSemantics(afterTurn))
+
+    // ...and a much later Undo still works against the untouched canvas.
+    serviceUpdate.mockClear()
+    expect((await revertWorkflowTurn(makeDb(afterTurn), scope(), TURN_A)).isOk()).toBe(true)
+    expect(await readWorkflowTurnSnapshot(APP, TURN_A)).toBeNull()
+  })
+})
+
+/**
+ * Plan 20 §5 / §9 phase D — "the turn says why it stopped". The snapshot is a
+ * graph, not a transcript, so the ONLY way the Undo offer can name a reason is
+ * a label written at turn end. Three rules: it labels its own turn, it can
+ * never relabel a fresher one, and its absence is inert.
+ */
+describe('turn-ending stamp', () => {
+  it('labels the turn’s own snapshot without disturbing anything else', async () => {
+    await addWait(makeDb(baseGraph()), TURN_A)
+    const before = await readWorkflowTurnSnapshot(APP, TURN_A)
+
+    await recordWorkflowTurnEnding(APP, TURN_A, 'exhausted')
+
+    const after = await readWorkflowTurnSnapshot(APP, TURN_A)
+    expect(after?.endedAs).toBe('exhausted')
+    // ADDITIVE, not a finalize: the snapshot, its pre-turn graph and the
+    // post-turn hash the revert guards on all survive untouched ([C4]).
+    expect(after?.turnId).toBe(TURN_A)
+    expect(after?.graph).toEqual(before?.graph)
+    expect(after?.postTurnGraphSemanticHash).toBe(before?.postTurnGraphSemanticHash)
+    expect(after?.capturedAt).toBe(before?.capturedAt)
+  })
+
+  it.each([
+    'exhausted',
+    'aborted',
+    'error',
+  ] as const)('records %s verbatim — the banner’s wording is derived, never guessed', async (ending) => {
+    await addWait(makeDb(baseGraph()), TURN_A)
+    await recordWorkflowTurnEnding(APP, TURN_A, ending)
+    expect((await readWorkflowTurnSnapshot(APP, TURN_A))?.endedAs).toBe(ending)
+  })
+
+  it('a stale turn cannot stamp a fresher turn’s slot', async () => {
+    await addWait(makeDb(baseGraph()), TURN_B)
+    // Turn A ended late, after B already superseded the slot. Its ending
+    // describes a turn whose snapshot is gone — writing it here would put a
+    // wrong reason on the offer the user is actually looking at.
+    await recordWorkflowTurnEnding(APP, TURN_A, 'error')
+    const snapshot = await readWorkflowTurnSnapshot(APP, TURN_B)
+    expect(snapshot?.turnId).toBe(TURN_B)
+    expect(snapshot?.endedAs).toBeUndefined()
+  })
+
+  it('stamping a turn that never wrote creates nothing to undo', async () => {
+    await recordWorkflowTurnEnding(APP, TURN_A, 'aborted')
+    expect(redisStore.size).toBe(0)
+    expect(await readWorkflowTurnSnapshot(APP, TURN_A)).toBeNull()
+  })
+
+  it('a failed stamp is swallowed and leaves the offer intact', async () => {
+    await addWait(makeDb(baseGraph()), TURN_A)
+    const redis = await import('@auxx/redis')
+    const setRedisData = vi.mocked(redis.setRedisData)
+    setRedisData.mockRejectedValueOnce(new Error('redis down'))
+
+    // Best-effort: turn end must not throw, and the cost of the failure is the
+    // adjective — never the Undo.
+    await expect(recordWorkflowTurnEnding(APP, TURN_A, 'exhausted')).resolves.toBeUndefined()
+    const snapshot = await readWorkflowTurnSnapshot(APP, TURN_A)
+    expect(snapshot?.endedAs).toBeUndefined()
+    expect((await revertWorkflowTurn(makeDb(persistedGraph()), scope(), TURN_A)).isOk()).toBe(true)
+  })
+
+  it('an unlabelled snapshot is still fully undoable — absence never gates the offer', async () => {
+    await addWait(makeDb(baseGraph()), TURN_A)
+    // No stamp at all: pre-deploy snapshot, or a turn that died before its
+    // turn-end hook ran.
+    expect((await readWorkflowTurnSnapshot(APP, TURN_A))?.endedAs).toBeUndefined()
+    expect((await revertWorkflowTurn(makeDb(persistedGraph()), scope(), TURN_A)).isOk()).toBe(true)
   })
 })
 
@@ -332,5 +565,87 @@ describe('hash-CAS surfacing (07 §6)', () => {
     expect(error.message).toMatch(/retry/i)
     // No refresh signal for a write that never landed.
     expect(publishWorkflowDraftUpdated).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * Plan 20 F5 — reproduced in the browser 2026-08-19. Merely OPENING the builder
+ * fires an autosave carrying a fresh `viewport` and `selected: true` over
+ * byte-identical node content. Both the snapshot clear and the revert guard used
+ * to key off the full-document hash, so that phantom save destroyed the Undo
+ * offer about eight seconds after it appeared — without the user touching
+ * anything.
+ *
+ * These pin the distinction the fix rests on: presentation churn is not an edit,
+ * but anything the user actually authored still is.
+ */
+describe('F5 — presentation churn is not an authored change', () => {
+  /** What React Flow rewrites just from the canvas being looked at. */
+  const withPresentationChurn = (g: DraftGraph): DraftGraph => ({
+    ...g,
+    viewport: { x: -124.9, y: 70.25, zoom: 0.7 },
+    nodes: g.nodes.map((n) => ({
+      ...n,
+      selected: true,
+      dragging: false,
+      width: 244,
+      height: 100,
+    })),
+  })
+
+  it('hashes identically across selection, drag-state, measurement and viewport', () => {
+    const base = baseGraph()
+    expect(hashGraphSemantics(withPresentationChurn(base))).toBe(hashGraphSemantics(base))
+    // The full-document hash is what made this a bug — it disagrees. Keep that
+    // contrast pinned: `hashWorkflowGraph` MUST stay whole-document, because two
+    // tabs disagreeing about the viewport is still a real save conflict.
+    expect(hashWorkflowGraph(withPresentationChurn(base))).not.toBe(hashWorkflowGraph(base))
+  })
+
+  it('still sees a real edit — a moved node, a changed title, a new node', () => {
+    const base = baseGraph()
+    const baseHash = hashGraphSemantics(base)
+
+    const moved = {
+      ...base,
+      nodes: base.nodes.map((n, i) => (i === 0 ? { ...n, position: { x: 1, y: 2 } } : n)),
+    }
+    expect(hashGraphSemantics(moved)).not.toBe(baseHash)
+
+    const retitled = {
+      ...base,
+      nodes: base.nodes.map((n, i) =>
+        i === 0 ? { ...n, data: { ...n.data, title: 'Renamed by hand' } } : n
+      ),
+    }
+    expect(hashGraphSemantics(retitled)).not.toBe(baseHash)
+
+    const added = {
+      ...base,
+      nodes: [...base.nodes, { ...base.nodes[0]!, id: 'brand-new-node' }],
+    }
+    expect(hashGraphSemantics(added)).not.toBe(baseHash)
+  })
+
+  it('a revert survives a canvas that was only opened, and still refuses a real edit', async () => {
+    await addWait(makeDb(baseGraph()), TURN_A)
+    const afterTurn = persistedGraph()
+
+    // The phantom autosave: same content, new viewport + selection.
+    const opened = withPresentationChurn(afterTurn)
+    const survives = await revertWorkflowTurn(makeDb(opened), scope(), TURN_A)
+    expect(survives.isOk()).toBe(true)
+
+    // And the guard still bites on an actual hand edit.
+    await addWait(makeDb(baseGraph()), TURN_B)
+    const edited = {
+      ...persistedGraph(),
+      nodes: persistedGraph().nodes.map((n, i) =>
+        i === 0 ? { ...n, position: { x: 999, y: 999 } } : n
+      ),
+    }
+    const refused = await revertWorkflowTurn(makeDb(edited), scope(), TURN_B)
+    expect(refused.isErr()).toBe(true)
+    expect(refused._unsafeUnwrapErr()).toBeInstanceOf(ConflictError)
   })
 })

--- a/packages/lib/src/workflows/graph-edit/index.ts
+++ b/packages/lib/src/workflows/graph-edit/index.ts
@@ -122,8 +122,11 @@ export {
   clearWorkflowTurnSnapshot,
   finalizeWorkflowTurn,
   readWorkflowTurnSnapshot,
+  recordWorkflowTurnEnding,
+  recordWorkflowTurnPostHash,
   revertWorkflowTurn,
   type WorkflowPreTurnSnapshot,
+  type WorkflowTurnEnding,
 } from './turn-snapshot'
 export type {
   DraftGraph,

--- a/packages/lib/src/workflows/graph-edit/ops.ts
+++ b/packages/lib/src/workflows/graph-edit/ops.ts
@@ -61,7 +61,7 @@ import {
   renderFriendlyOutputs,
 } from './read'
 import { describeNode, formatNodeRef, resolveNodeRef } from './refs'
-import { captureWorkflowTurnSnapshot } from './turn-snapshot'
+import { captureWorkflowTurnSnapshot, recordWorkflowTurnPostHash } from './turn-snapshot'
 import type { DraftGraph, GraphEdge, GraphMutationResult, GraphNode, Issue, Point } from './types'
 import {
   INPUT_WIRING_HANDLES,
@@ -335,6 +335,21 @@ async function runGraphMutation(
       )
     }
     return err(persisted.error)
+  }
+
+  // Stamp what the turn now leaves behind. Last write of the turn wins, so
+  // this is the post-turn hash a later Undo compares the live draft against —
+  // the snapshot's capture ran before the FIRST write and cannot know it.
+  //
+  // The SEMANTIC hash, not `graphHash`: the canvas autosaves a new viewport and
+  // selection just from being opened, and against the full-document hash that
+  // reads as "someone edited this" and kills the Undo offer (plan 20 F5).
+  if (scope.turnId !== undefined) {
+    await recordWorkflowTurnPostHash(
+      scope.workflowAppId,
+      scope.turnId,
+      persisted.value.graphSemanticHash
+    )
   }
 
   // Refresh signal AFTER the successful persist — open canvases refetch.

--- a/packages/lib/src/workflows/graph-edit/persist.ts
+++ b/packages/lib/src/workflows/graph-edit/persist.ts
@@ -29,6 +29,7 @@ import { err, ok, type Result } from 'neverthrow'
 import { AuxxError, NotFoundError, UnprocessableEntityError } from '../../errors'
 import { deriveTriggerColumns } from '../../workflow-engine/catalog/derive-trigger'
 import { stripDerivedKeys } from '../../workflow-engine/catalog/derived-keys'
+import { hashGraphSemantics } from '../graph-hash'
 import type { WorkflowTriggerType, WorkflowUpdateInput } from '../types'
 import type { GraphEditScope } from './read'
 import type { DraftGraph, GraphEdge, GraphNode } from './types'
@@ -75,6 +76,17 @@ export interface PersistDraftInput {
 /** What the persist wrote — chained into the next mutation's CAS token. */
 export interface PersistDraftOutcome {
   graphHash: string | null
+  /**
+   * Hash of the AUTHORED content only (see {@link hashGraphSemantics}) of the
+   * CLEANED graph this call wrote — the same projection `loadDraftContext`'s
+   * graph produces on the next read, so the two are directly comparable.
+   *
+   * Separate from `graphHash` because that one is the save-path CAS token and
+   * must stay full-document. This is what the Kopilot Undo offer compares
+   * against, so that merely opening the builder (which autosaves a new viewport
+   * and selection) does not read as "the canvas moved on".
+   */
+  graphSemanticHash: string
   triggerType?: string | null
   entityDefinitionId?: string | null
 }
@@ -127,6 +139,11 @@ export async function persistDraft(
     })
     return ok({
       graphHash: (updated?.graphHash as string | null | undefined) ?? null,
+      // Hashed from `graph` (the cleaned document written above), NOT
+      // `input.graph` — `cleanGraphForSave` strips derived `node.data` keys, and
+      // the next read sees the cleaned form. Hashing the input would make every
+      // later comparison a false mismatch.
+      graphSemanticHash: hashGraphSemantics(graph),
       triggerType: (updated?.triggerType as string | null | undefined) ?? triggerType ?? null,
       entityDefinitionId:
         (updated?.entityDefinitionId as string | null | undefined) ?? entityDefinitionId,

--- a/packages/lib/src/workflows/graph-edit/turn-snapshot.ts
+++ b/packages/lib/src/workflows/graph-edit/turn-snapshot.ts
@@ -4,13 +4,15 @@
  * Per-turn pre-edit snapshot of the draft graph — SERVER-ONLY (Redis + the
  * persist seam). Mirrors `kb/kopilot-snapshot.ts` (`03-graph-edit-service.md`
  * §7): the FIRST mutation of a turn stores the pre-edit graph under
- * `(workflowAppId, turnId)` with a 24h TTL. The snapshot exists ONLY for
- * failed-turn atomicity: on turn FAILURE the lifecycle reverts (restores the
- * exact prior graph and workflow details through `persistDraft`); on turn SUCCESS it is discarded
- * via {@link finalizeWorkflowTurn}. Undo of a completed turn is client-side —
- * the builder's `workflow:draft-updated` subscriber records each Kopilot edit
- * as a normal canvas history entry, so there is no per-turn Undo card and no
- * server-side undo. Residual cleanup is the next turn's capture overwriting
+ * `(workflowAppId, turnId)` with a 24h TTL. The snapshot exists ONLY to make a
+ * turn's edits reversible AS A GROUP: {@link revertWorkflowTurn} restores the
+ * exact prior graph and workflow details through `persistDraft`, and on turn
+ * SUCCESS it is discarded via {@link finalizeWorkflowTurn}. Undo of a
+ * completed turn is client-side — the builder's `workflow:draft-updated`
+ * subscriber records each Kopilot edit as a normal canvas history entry.
+ * The snapshot deliberately OUTLIVES a turn that stopped early (nothing
+ * consumes it at turn end), so the recovery path is still there when the
+ * caller offers it; residual cleanup is the next turn's capture overwriting
  * the slot, the TTL, or a manual draft save clearing it via
  * {@link clearWorkflowTurnSnapshot}.
  *
@@ -22,6 +24,19 @@
  * snapshot in the slot means the asking turn was superseded, and restoring it
  * would roll the draft back past edits the asking turn never made.
  *
+ * The turn id is only half the check. Because the restore is offered rather
+ * than performed, it can be taken long after the turn ended, so the snapshot
+ * also carries the hash of the graph the turn LEFT BEHIND
+ * (`postTurnGraphSemanticHash`, stamped per write by
+ * {@link recordWorkflowTurnPostHash}). If the draft no longer hashes to that,
+ * the canvas moved on and the revert refuses — see {@link revertWorkflowTurn}.
+ *
+ * The snapshot also carries HOW its turn ended (`endedAs`, stamped once at turn
+ * end by {@link recordWorkflowTurnEnding}), because the offer has to be able to
+ * say why it exists and by then the turn is over — nothing else on this side
+ * remembers. It is additive bookkeeping only: absence must never suppress the
+ * offer.
+ *
  * No permission checks live here (house rule): the capability layer asserts
  * `assertEditInstance('workflow', workflowAppId)` +
  * `assertWorkflowAppNotSystemOwned` before calling in.
@@ -31,7 +46,8 @@ import type { Database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { deleteRedisData, getRedisData, setRedisData } from '@auxx/redis'
 import { err, type Result } from 'neverthrow'
-import { type AuxxError, NotFoundError } from '../../errors'
+import { type AuxxError, ConflictError, NotFoundError } from '../../errors'
+import { hashGraphSemantics } from '../graph-hash'
 import { type PersistDraftOutcome, persistDraft, publishDraftUpdatedSignal } from './persist'
 import { type GraphEditScope, loadDraftContext } from './read'
 import type { DraftGraph } from './types'
@@ -39,6 +55,23 @@ import type { DraftGraph } from './types'
 const logger = createScopedLogger('workflow-turn-snapshot')
 
 const TTL_SECONDS = 24 * 60 * 60
+
+/**
+ * How the turn that owns a snapshot ended — the three non-`completed` members
+ * of the agent framework's `TurnOutcome`, mirrored here rather than imported.
+ *
+ * WHY MIRRORED: `workflows/graph-edit` is a headless draft-editing module and
+ * must not take a dependency on `ai/agent-framework` to name three strings.
+ * The two vocabularies cannot drift silently anyway — the capability passes
+ * `outcome` straight into {@link recordWorkflowTurnEnding} on the branch where
+ * TypeScript has already narrowed it to exactly these three, so a framework
+ * rename fails the build at the call site.
+ *
+ * `completed` is deliberately unrepresentable: a completed turn calls
+ * {@link finalizeWorkflowTurn} and its snapshot is gone, so no snapshot the
+ * user can ever be offered was left by a completed turn.
+ */
+export type WorkflowTurnEnding = 'exhausted' | 'aborted' | 'error'
 
 /**
  * Pre-turn snapshot captured before a turn's first draft write. Backs the
@@ -54,6 +87,30 @@ export interface WorkflowPreTurnSnapshot {
   /** The draft row's trigger type column at capture time (persist fallback). */
   triggerType: string | null
   capturedAt: number
+  /**
+   * Hash of the stored graph as of the turn's LAST successful write — the
+   * "did the canvas move on since?" token {@link revertWorkflowTurn} compares
+   * against. Stamped by {@link recordWorkflowTurnPostHash} after every persist
+   * in the turn (last write wins), never at capture: the capture runs BEFORE
+   * the turn's first write and is idempotent per turn, so it cannot know where
+   * the turn ends up. Undefined only for a snapshot written by code older than
+   * this field, or when a stamp's Redis write failed.
+   */
+  postTurnGraphSemanticHash?: string
+  /**
+   * How the turn ended, stamped once at turn end by
+   * {@link recordWorkflowTurnEnding}. The ONLY record of why the offer exists:
+   * the snapshot is a graph, not a tool-call log or a transcript, and by the
+   * time the Undo is offered the turn is over and there is no agent left to
+   * ask.
+   *
+   * Undefined is a first-class value, not a bug — a snapshot captured by code
+   * older than this field, a turn that died before its `onTurnEnd` hook ran at
+   * all, or a stamp whose Redis write failed. Every reader MUST fail OPEN on
+   * undefined and still make the offer: losing the adjective is a far smaller
+   * loss than losing the Undo.
+   */
+  endedAs?: WorkflowTurnEnding
 }
 
 const snapshotKey = (workflowAppId: string): string => `workflow:graph:${workflowAppId}:preturn`
@@ -92,6 +149,101 @@ export async function captureWorkflowTurnSnapshot(
   }
   await setRedisData(snapshotKey(workflowAppId), snapshot, TTL_SECONDS)
   return true
+}
+
+/**
+ * Stamp the graph hash the turn's write just produced onto the turn's own
+ * snapshot — called from the mutation pipeline AFTER every successful
+ * `persistDraft`, with the hash `persistDraft` returned (i.e. the hash of what
+ * the draft row now actually holds, which is exactly what the next
+ * `loadDraftContext` will compute). Last write wins, so once the turn stops
+ * writing the stamp IS the post-turn hash.
+ *
+ * WHY here and not at turn end: a turn that dies — token budget, disconnect,
+ * a throw — may never reach a turn-end call at all, and after plan 20 phase A
+ * the capability deliberately stops calling `finalizeWorkflowTurn` on
+ * non-completed outcomes. Those are precisely the turns whose snapshot has to
+ * survive and stay checkable, so the stamp must not depend on any turn-end
+ * hook running. Stamping per write cannot go stale: the last write to land is
+ * by definition the graph the turn left behind.
+ *
+ * Turn-checked like {@link finalizeWorkflowTurn} — a stale turn must never
+ * re-stamp a fresher turn's snapshot. Best-effort: a failed stamp leaves
+ * `postTurnGraphSemanticHash` at its previous (older) value, which makes a later
+ * revert refuse rather than clobber — the safe direction.
+ */
+export async function recordWorkflowTurnPostHash(
+  workflowAppId: string,
+  turnId: string,
+  graphSemanticHash: string | null
+): Promise<void> {
+  if (!graphSemanticHash) return
+  try {
+    const existing = (await getRedisData(
+      snapshotKey(workflowAppId)
+    )) as WorkflowPreTurnSnapshot | null
+    if (existing?.turnId !== turnId) return
+    if (existing.postTurnGraphSemanticHash === graphSemanticHash) return
+    // Re-`setex` refreshes the 24h TTL. Bounded by the turn's own duration
+    // (only this turn's writes reach this line), so the window a snapshot
+    // outlives its turn by never grows meaningfully.
+    await setRedisData(
+      snapshotKey(workflowAppId),
+      { ...existing, postTurnGraphSemanticHash: graphSemanticHash },
+      TTL_SECONDS
+    )
+  } catch (error) {
+    logger.warn('Failed to record post-turn semantic graph hash', {
+      workflowAppId,
+      turnId,
+      error: (error as Error).message,
+    })
+  }
+}
+
+/**
+ * Stamp HOW the turn ended onto the turn's own snapshot — called from the
+ * capability's `onTurnEnd` on the outcomes that keep the snapshot alive
+ * (`exhausted` / `aborted` / `error`). ADDITIVE, never a finalize: the whole
+ * point of plan 20 [C4] is that a turn which stopped early keeps both its work
+ * and its snapshot, and this only writes the label the Undo offer needs to say
+ * WHY it is there.
+ *
+ * WHY at turn end and not per write (the opposite of
+ * {@link recordWorkflowTurnPostHash}): a write cannot know how the turn will
+ * end, and the ending is exactly what a write has no view of. The cost is that
+ * a turn dying before its hook runs leaves this undefined — which is why every
+ * reader fails open (see {@link WorkflowPreTurnSnapshot.endedAs}).
+ *
+ * Turn-checked like {@link finalizeWorkflowTurn}: a stale turn must never
+ * relabel a fresher turn's snapshot with its own ending. Best-effort — a
+ * failure leaves the field undefined, i.e. today's generic wording, and the
+ * offer itself is untouched. It must never throw: it runs on a turn-end path
+ * whose one job is to leave the recovery route intact.
+ */
+export async function recordWorkflowTurnEnding(
+  workflowAppId: string,
+  turnId: string,
+  endedAs: WorkflowTurnEnding
+): Promise<void> {
+  try {
+    const existing = (await getRedisData(
+      snapshotKey(workflowAppId)
+    )) as WorkflowPreTurnSnapshot | null
+    if (existing?.turnId !== turnId) return
+    if (existing.endedAs === endedAs) return
+    // Re-`setex` refreshes the 24h TTL from turn end rather than from the
+    // turn's first write — which is the window the user actually gets to
+    // decide in, so this is the correct clock, not an accidental extension.
+    await setRedisData(snapshotKey(workflowAppId), { ...existing, endedAs }, TTL_SECONDS)
+  } catch (error) {
+    logger.warn('Failed to record workflow turn ending', {
+      workflowAppId,
+      turnId,
+      endedAs,
+      error: (error as Error).message,
+    })
+  }
 }
 
 /**
@@ -155,18 +307,31 @@ export async function clearWorkflowTurnSnapshot(workflowAppId: string): Promise<
 }
 
 /**
- * Restore the exact pre-turn graph — the FAILURE half of the turn lifecycle
- * (a completed turn's snapshot is discarded, so this is unreachable after
- * success by design).
- * The stored snapshot must belong to `turnId`: a snapshot from a prior turn
- * is REJECTED, never restored (restoring it would roll back edits this turn
- * never made), and no snapshot means the turn never wrote — also nothing to
- * revert.
+ * Restore the exact pre-turn graph. Not automatic — the caller offers it (plan
+ * 20 phase D) and the user's click is what runs it, which means it can fire
+ * minutes after the turn ended, on a canvas that has moved on.
  *
- * The restore goes through `persistDraft`, so trigger-column re-derivation,
- * the mail-trigger guard and the hash-CAS all run: a write that landed
- * between the failure and this revert surfaces as a `ConflictError` instead
- * of being clobbered. On success the snapshot is discarded and the
+ * TWO distinct refusals, and callers are expected to tell them apart because
+ * the user-facing statement differs:
+ *
+ * - `NotFoundError` (404) — there is no snapshot under `turnId`: the turn never
+ *   wrote to the draft, a later turn superseded the slot, the 24h TTL expired,
+ *   or a manual canvas save cleared it via {@link clearWorkflowTurnSnapshot}.
+ *   Nothing to undo, and nothing was touched.
+ * - `ConflictError` (409, `details.reason === 'canvas-changed-since-turn'`) —
+ *   the snapshot is there, but the draft no longer hashes to what the turn left
+ *   behind ({@link WorkflowPreTurnSnapshot.postTurnGraphSemanticHash}). Someone edited
+ *   the canvas after the turn, so restoring the pre-turn graph would destroy
+ *   work the turn never made. Refused; the snapshot is LEFT IN PLACE.
+ *
+ * That comparison is the whole point of the post-turn hash: `persistDraft`'s
+ * own CAS token is read fresh microseconds before the write, so it guards a
+ * race INSIDE this function and nothing across time. It still runs (a save
+ * racing the revert surfaces as its own `ConflictError`) — it is simply not
+ * the check that detects a diverged canvas.
+ *
+ * The restore goes through `persistDraft`, so trigger-column re-derivation and
+ * the mail-trigger guard also run. On success the snapshot is discarded and the
  * `workflow:draft-updated` signal fires (reason `system`) so open canvases
  * refetch.
  */
@@ -187,6 +352,35 @@ export async function revertWorkflowTurn(
 
   const loaded = await loadDraftContext(db, scope)
   if (loaded.isErr()) return err(loaded.error)
+
+  // Both sides are `hashGraphSemantics` over the CLEANED graph — the stamp
+  // hashes what `persistDraft` wrote, this hashes what `loadDraftContext` read
+  // back — so it is an exact comparison, not an approximation.
+  //
+  // It must be the SEMANTIC hash, not `graphHash`. Opening the builder fires an
+  // autosave carrying a fresh viewport and selection with byte-identical node
+  // content; against the full-document hash that reads as "the canvas moved on"
+  // and every Undo refuses seconds after the offer appears (plan 20 F5).
+  //
+  // Fails OPEN when either side is unknown — a snapshot captured before this
+  // field existed, or a draft row with no graph at all. Unknown must not turn
+  // a legitimate Undo into a hard refusal; the pre-existing guards (turn id,
+  // TTL, the manual-save clear, the CAS below) still apply.
+  const liveSemanticHash = loaded.value.graph ? hashGraphSemantics(loaded.value.graph) : undefined
+  if (
+    snapshot.postTurnGraphSemanticHash !== undefined &&
+    liveSemanticHash !== undefined &&
+    liveSemanticHash !== snapshot.postTurnGraphSemanticHash
+  ) {
+    return err(
+      new ConflictError(
+        'The workflow canvas has changed since that turn finished, so those edits can no ' +
+          'longer be undone as a group — undoing now would also discard the newer changes. ' +
+          'Nothing was reverted. Use the canvas history to step back instead.',
+        { reason: 'canvas-changed-since-turn' }
+      )
+    )
+  }
 
   const persisted = await persistDraft(db, scope, {
     graph: snapshot.graph,

--- a/packages/lib/src/workflows/graph-hash.ts
+++ b/packages/lib/src/workflows/graph-hash.ts
@@ -16,3 +16,73 @@ import { stableStringify } from '@auxx/utils/json'
 export function hashWorkflowGraph(graph: unknown): string {
   return createHash('sha256').update(stableStringify(graph), 'utf8').digest('hex')
 }
+
+/**
+ * React Flow interaction state that lives in the graph document but carries no
+ * authored meaning. Panning, clicking a node, or letting the canvas re-measure
+ * a node rewrites these — and the editor autosaves the result, so a graph that
+ * nobody edited still hashes differently on every visit.
+ *
+ * `position` is deliberately NOT here: dragging a node is a real edit the user
+ * made. `width`/`height` are, because React Flow writes its own measurements
+ * into them; if a node type ever becomes user-resizable, move them out.
+ */
+const EPHEMERAL_NODE_KEYS = new Set([
+  'selected',
+  'dragging',
+  'resizing',
+  'selectable',
+  'focusable',
+  'deletable',
+  'draggable',
+  'zIndex',
+  'width',
+  'height',
+  'measured',
+  'positionAbsolute',
+])
+
+/** Ephemeral state on an edge — same argument as {@link EPHEMERAL_NODE_KEYS}. */
+const EPHEMERAL_EDGE_KEYS = new Set(['selected', 'animated', 'zIndex'])
+
+function stripEphemeral(item: Record<string, unknown>, drop: Set<string>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(item)) {
+    if (!drop.has(k)) out[k] = v
+  }
+  return out
+}
+
+/**
+ * SHA-256 hash of a graph's AUTHORED content — nodes and edges with React Flow's
+ * interaction state removed, and the viewport dropped entirely.
+ *
+ * Answers "did anyone actually change this workflow?", which
+ * {@link hashWorkflowGraph} cannot: that one hashes the whole document, so a
+ * pan or a node click changes it. Two things depend on the distinction:
+ *
+ *  - `WorkflowService.update` clears the Kopilot turn snapshot on a manual save.
+ *    Keyed off the full hash, merely OPENING the builder fires an autosave that
+ *    destroys the pending Undo offer seconds after it appears.
+ *  - `revertWorkflowTurn` refuses when the live draft no longer matches what the
+ *    turn left behind. Keyed off the full hash, the same autosave turns every
+ *    Undo into a "the canvas moved on" conflict.
+ *
+ * Both must ask the semantic question, or the Undo offer is unusable in practice
+ * (plans/kopilot/workflow/20-partial-turn-survival.md F5).
+ *
+ * Never use this as the save-path CAS token — that one MUST stay full-document,
+ * because two tabs disagreeing about the viewport is still a real write conflict.
+ */
+export function hashGraphSemantics(graph: unknown): string {
+  const g = (graph ?? {}) as { nodes?: unknown[]; edges?: unknown[] }
+  const projection = {
+    nodes: (g.nodes ?? []).map((n) =>
+      stripEphemeral((n ?? {}) as Record<string, unknown>, EPHEMERAL_NODE_KEYS)
+    ),
+    edges: (g.edges ?? []).map((e) =>
+      stripEphemeral((e ?? {}) as Record<string, unknown>, EPHEMERAL_EDGE_KEYS)
+    ),
+  }
+  return createHash('sha256').update(stableStringify(projection), 'utf8').digest('hex')
+}

--- a/packages/lib/src/workflows/workflow-service.ts
+++ b/packages/lib/src/workflows/workflow-service.ts
@@ -12,7 +12,7 @@ import { getQueue, Queues } from '../jobs/queues'
 import type { TriggerDerivationNode } from '../workflow-engine/catalog/derive-trigger'
 import { deriveTriggerLinkColumns } from '../workflow-engine/catalog/derive-trigger-server'
 import { WorkflowEngine } from '../workflow-engine/core/workflow-engine'
-import { hashWorkflowGraph } from './graph-hash'
+import { hashGraphSemantics, hashWorkflowGraph } from './graph-hash'
 import { assertMailTriggerNotPersonal } from './mail-trigger-guard'
 import { PollingTriggerService } from './polling-trigger-service'
 import { ScheduledTriggerService } from './scheduled-trigger-service'
@@ -589,14 +589,32 @@ export class WorkflowService {
       // A non-Kopilot graph write invalidates the per-turn Undo snapshot (KB
       // parity: KBService clears on every manual save unless the agent path
       // bypasses). Only the graph-edit persist seam sets `preserveTurnSnapshot`.
+      //
+      // Gated on a SEMANTIC change, not on "a graph was posted". The editor
+      // autosaves on load, and that save carries a fresh viewport plus
+      // `selected: true` over byte-identical node content — so clearing on any
+      // graph-bearing write destroyed the pending Undo offer about eight
+      // seconds after it appeared, without the user touching anything
+      // (plan 20 F5, reproduced in the browser 2026-08-19).
+      //
+      // Safe to relax only because `revertWorkflowTurn` now refuses when the
+      // live draft no longer matches what the turn left behind: THAT is what
+      // stops a stale Undo clobbering hand edits, and this clear no longer has
+      // to be the blunt instrument standing in for it.
+      //
       // Best-effort + lazy — the snapshot module pulls @auxx/redis, which must
       // not become an import-time dependency of every WorkflowService caller.
       if (graph !== undefined && !preserveTurnSnapshot) {
-        try {
-          const { clearWorkflowTurnSnapshot } = await import('./graph-edit/turn-snapshot')
-          await clearWorkflowTurnSnapshot(id)
-        } catch {
-          // A leftover snapshot expires via TTL; never fail the save over it.
+        const previousGraph = existingWorkflowApp.draftWorkflow?.graph
+        const authoredChange =
+          previousGraph == null || hashGraphSemantics(previousGraph) !== hashGraphSemantics(graph)
+        if (authoredChange) {
+          try {
+            const { clearWorkflowTurnSnapshot } = await import('./graph-edit/turn-snapshot')
+            await clearWorkflowTurnSnapshot(id)
+          } catch {
+            // A leftover snapshot expires via TTL; never fail the save over it.
+          }
         }
       }
 


### PR DESCRIPTION
## The bug

Kopilot edits a workflow for a dozen iterations — each mutation persisted, validated and broadcast so the user watches it land. The agent finishes and streams its summary. Then the engine tallies the turn's tokens, finds them over budget, yields `turn-error`, and `onTurnEnd('error')` restores the pre-turn graph.

**Every edit disappears.**

Worth being precise about *when* this fires: Kopilot's route is a single agent, and `query-loop` emits exactly one `assistant-message-finished` per agent run, so the budget check at `engine.ts:318` runs **after the agent run has completely finished**. The model was never cut off mid-plan — it did the work, finalized, and replied. A completed turn was thrown away on bookkeeping alone.

A draft graph has no atomicity requirement to protect. Every mutation already persists through its own validation, its own ref gate and its own hash-CAS. "Half-finished" is what a draft looks like whenever a human stops mid-thought.

## The change

**Revert is now never automatic.** On `completed` the snapshot is discarded as before. On every other outcome the work *and* the snapshot are kept, and the user gets an explicit Undo.

| | |
|---|---|
| `TurnOutcome` | `completed \| exhausted \| aborted \| error`; `turn-error` carries a `reason` so the mapping never pattern-matches message text |
| exhaustion exits | token budget, max iterations, **max approvals**, same-tool failure streak |
| Undo offer | `getKopilotTurnReview` / `revertKopilotTurn` / `keepKopilotTurn` + a banner above the canvas |
| token meter | non-cached input + completion, off raw per-call `IterationUsage` |

### KB is fixed too — with the opposite shape

KB had the identical bug, but copying the workflow fix would have broken it. `finalizeKopilotKbTurn` **keeps** its snapshot and is one of only two emitters of the editor unlock, so KB must **always finalize, never revert**. Returning early there would have leaked the editor lock until the 24h TTL.

Relatedly, KB already shipped this PR's principle — `kb.revertKopilotTurn` / `keepKopilotTurn` with a Keep/Undo banner. The workflow surface mirrors it rather than inventing a second shape.

## Also fixed (all found while verifying the above)

- **`maxTotalIterations` counted agents, not iterations.** Incremented once per `assistant-message-finished`, i.e. once per agent — unreachable on a one-agent route, and it silently mis-bounded evals, which feed it a per-agent iteration limit. ⚠️ **Behaviour change for evals**: the knob now actually bounds.
- **`AgentEngineConfig.signal` was silently discarded.** Documented as an abort signal, then overwritten at all three entry points. It only worked because every caller separately wired `engine.interrupt()`.
- **The cached-token predicate was wrong.** `provider.includes('openai')` — but seven providers extend `OpenAILLMClient` and inherit its usage shape. The rule is that *Anthropic is the exception*.
- **`revertWorkflowTurn`'s CAS guarded nothing.** It read the current hash immediately before writing and compared it to itself. Now it compares against what the turn actually left behind.
- **Opening the builder destroyed the Undo offer.** A load-time autosave carries a fresh viewport and `selected: true` over byte-identical node content, and that cleared the snapshot ~8s after the banner appeared. Both the clear and the revert guard now key off `hashGraphSemantics`, which ignores React Flow interaction state. `hashWorkflowGraph` stays whole-document — it is the save-path CAS token, and a viewport disagreement between two tabs is still a real write conflict.

## The token meter

It charged `total_tokens` per call, so the re-sent prompt was re-charged every iteration — superlinear in iteration count, not linear in work done. A 12-iteration turn metered **656,500** where the actual new work was **32,500**.

It now reads the raw per-call `IterationUsage` records, which is also what billing drains — the cumulative `usage` field double-charges pre-pause calls across an approval resume, so the old path had that bug too.

## Verification

- **1,665 tests** in `packages/lib`, **261** in `apps/web`, 0 failures. Scoped typechecks clean on every touched file.
- **Live, in the browser**, replaying the exact failure: the load-time save still fires, the snapshot now survives it, and Undo completes — where it previously returned 404 within ~8s of the banner appearing.

Three pre-existing tests were found asserting nothing and are now real: a `serviceUpdate` fake returning a constant hash, a revert test checking a hand-built graph, and a permission test using `ResourcePermission`'s `'view'` where a `Rung` was required.

## Not in this PR

- `quota/estimate-cost.ts` carries the same `new Set(['openai'])` bug, so cached reads are **double-charged** on six providers. It changes what customers are billed, so it wants its own decision.
- `query-loop.ts` — the iteration-cap graceful close only emits `assistant-message-finished` when it produced text, so a text-less closing call is never metered.
- Carrying an iteration count across the resume boundary, so `maxTotalIterations` bounds a pause-heavy turn end to end.

## Note

`packages/lib/scripts/seed-turn-snapshot.ts` is a dev-only script for exercising the Undo banner without having to make a real turn trip the budget. Happy to drop it if you'd rather not carry it.

Plan, including the correction ledger: `plans/kopilot/workflow/20-partial-turn-survival.md`