### PR TITLE
fix(composer): show the account name in From, not the routing id

### DIFF
--- a/apps/web/src/components/channels/channel-label.ts
+++ b/apps/web/src/components/channels/channel-label.ts
@@ -1,0 +1,33 @@
+// apps/web/src/components/channels/channel-label.ts
+
+import { PLATFORM_CAPABILITIES } from '@auxx/lib/channels/client'
+
+/**
+ * What the user sees in the From row: the identity the message will come FROM.
+ *
+ * `identifier` is the server-resolved *routing* identity (`channels/internal/
+ * identifier.ts`) and is only something a human recognises where the address
+ * space is one they read — an email address or a phone number. On Meta channels
+ * it is deliberately an opaque account id (Page id / IG business account id, see
+ * that file's contract), so showing it rendered a bare number in the From row.
+ *
+ * So: `identifier` for the addressable models (`email` / `phone`), and the
+ * server-computed `displayName` (`getChannelLabel` — Page name, IG handle,
+ * widget name) for everything else. Reading `email` first, as an earlier version
+ * did, renders an empty badge for a phone channel: an SMS `Integration` carries
+ * no `email`, and `name` is null on a channel the user never renamed.
+ */
+export function channelLabel(channel: {
+  provider: string
+  identifier?: string
+  displayName?: string | null
+  email?: string
+  name: string | null
+}) {
+  const caps = PLATFORM_CAPABILITIES[channel.provider as keyof typeof PLATFORM_CAPABILITIES]
+  const addressable = caps?.recipientModel === 'email' || caps?.recipientModel === 'phone'
+  if (addressable && channel.identifier) return channel.identifier
+  return (
+    channel.displayName || channel.identifier || channel.email || channel.name || 'Unnamed channel'
+  )
+}

--- a/apps/web/src/components/mail/email-editor/index.tsx
+++ b/apps/web/src/components/mail/email-editor/index.tsx
@@ -27,6 +27,7 @@ import {
 import type React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { flushSync } from 'react-dom'
+import { channelLabel } from '~/components/channels/channel-label'
 import { useChannel, useChannels } from '~/components/channels/hooks/use-channels'
 import { useDefaultChannelId } from '~/components/channels/hooks/use-default-channel'
 import { EditorToolbar } from '~/components/editor/editor-button'
@@ -257,12 +258,13 @@ function ReplyComposeEditorComponent({
   // (`handleCloseClick`, no discard) and closing genuinely puts the composer
   // away.
   const showCloseButton = isDialogMode || isEmailChannel
-  const pinnedChannelLabel =
-    selectedChannel?.identifier ??
-    selectedChannelFromList?.identifier ??
-    selectedChannel?.email ??
-    selectedChannel?.name ??
-    'Unknown channel'
+  // Same rule as the picker's badge, so a pinned From and a switchable From read
+  // identically: an address where the channel has one, the account's display
+  // name where `identifier` is an opaque routing id (Meta Page id / IG account
+  // id). Reading `identifier` unconditionally, as this did, put a bare Page
+  // number in the From row of every Facebook and Instagram reply.
+  const pinnedChannelRow = selectedChannel ?? selectedChannelFromList
+  const pinnedChannelLabel = pinnedChannelRow ? channelLabel(pinnedChannelRow) : 'Unknown channel'
 
   // Every channel this org can send from, so a From switch can resolve the
   // INCOMING channel's capabilities (the memo above only covers the current
@@ -287,6 +289,14 @@ function ReplyComposeEditorComponent({
   const [isSending, setIsSending] = useState(false)
   const [isDraftSaved, setIsDraftSaved] = useState(!!initialDraft)
   const [showNoToWarning, setShowNoToWarning] = useState(false)
+
+  // The rule under From is the divider ABOVE the next header row — Cc, Bcc and
+  // Subject each bring their own leading one, so From only owns the divider that
+  // introduces To. On a channel with neither (Facebook/Instagram are
+  // `thread_only`, chat is `platform_user`, and all three are `subject: false`)
+  // there is no next row, and the rule stacked against the header block's own
+  // bottom border as a double line.
+  const showFromSeparator = showRecipientField || (showSubjectField && showSubject)
 
   // Mark the draft dirty so autosave picks up changes.
   const markDraftDirty = useCallback(() => setIsDraftSaved(false), [])
@@ -1408,7 +1418,7 @@ function ReplyComposeEditorComponent({
                   )}
                 </div>
               </div>
-              <Separator className='mx-4 w-auto' />
+              {showFromSeparator && <Separator className='mx-4 w-auto' />}
 
               {/* To Field & Toggles */}
               {showRecipientField && (

--- a/apps/web/src/components/pickers/channel-picker.tsx
+++ b/apps/web/src/components/pickers/channel-picker.tsx
@@ -9,6 +9,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import { Star, TriangleAlert } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { channelLabel } from '~/components/channels/channel-label'
 import { useDefaultChannelId } from '~/components/channels/hooks/use-default-channel'
 import { useSendableChannels } from '~/components/channels/store/channel-store'
 import { Tooltip } from '~/components/global/tooltip'
@@ -31,19 +32,6 @@ interface ChannelPickerProps {
   triggerProps?: PickerTriggerOptions
   /** className forwarded to PopoverContent (e.g. for z-index override) */
   className?: string
-}
-
-/**
- * What the user sees in the From row: the address the message will come FROM.
- *
- * `identifier` is the server-resolved sending identity (`channels/internal/
- * identifier.ts`) — email for mail channels, `metadata.phoneNumber` for
- * Quo/SMS, widget name for chat. Reading `email` first, as this did, renders an
- * empty badge for a phone channel: an SMS `Integration` carries no `email`, and
- * `name` is null on a channel the user never renamed.
- */
-function channelLabel(channel: { identifier?: string; email?: string; name: string | null }) {
-  return channel.identifier || channel.email || channel.name || 'Unnamed channel'
 }
 
 /**


### PR DESCRIPTION
## What

Two fixes to the compose editor's **From** row (`apps/web/src/components/mail/email-editor/index.tsx`, `headerFields` slot).

### 1. Facebook/Instagram showed the Page id instead of the Page name

Both label sites read `channel.identifier`:

- `ChannelPicker`'s badge (`apps/web/src/components/pickers/channel-picker.tsx`)
- the pinned `<Badge>` used for every non-email reply (`canSwitchChannel === false`)

`identifier` is the server-resolved **routing** identity from `getIdentifier` (`packages/lib/src/channels/internal/identifier.ts`), which is deliberately the bare Page id / IG business account id on Meta channels — its doc comment states a label must never come out of it. The display counterpart `getChannelLabel` already exists and is already exposed to the client as `channel.displayName` (Page name, IG handle, widget name); neither site read it.

Extracted the rule into one shared helper, `apps/web/src/components/channels/channel-label.ts`:

- `recipientModel` is `email` or `phone` → `identifier` (an address a person recognises)
- otherwise → `displayName`

Email and SMS render exactly as before. Facebook, Instagram and chat now show the account name. Both sites call the same helper, so the pinned From and the switchable From cannot drift.

It lives in its own module rather than being exported from `channel-picker` because `channel-switch.test.tsx` fully mocks that module — a re-export there breaks test collection.

### 2. Double border under From on messaging channels

`<Separator className='mx-4 w-auto' />` under the From row was unconditional. It is really the divider *above* the To row — Cc, Bcc and Subject each render their own leading separator, so From only owns the one that introduces To.

Facebook/Instagram (`thread_only`), chat (`platform_user`) and all three `subject: false` have no next row, so the separator had nothing under it and stacked against the header block's own `border-b` as a double line. Now gated on:

```ts
const showFromSeparator = showRecipientField || (showSubjectField && showSubject)
```

Cc/Bcc only render when `showCcBccToggle`, which implies email, which implies `showRecipientField` — so the To arm covers them.

Note: removing Subject on an email composer never produced the double line (To is still there). This is messaging-channel only.

## Testing

- `pnpm exec vitest run apps/web/src/components/mail/email-editor/` — 108 passed
- `apps/web` `tsc --noEmit` — clean on the touched files