### PR TITLE
fix(kbar): stop the palette double-gutting nested dialog footers

### DIFF
--- a/apps/web/src/components/inbox/inbox-members-page.tsx
+++ b/apps/web/src/components/inbox/inbox-members-page.tsx
@@ -104,11 +104,11 @@ export function InboxMembersPage({
         )}
       </Section>
 
-      {/* The bangs are required, not stylistic: `DialogNavPages` gutters nested
-          footers with `[&_[data-slot=dialog-footer]]:px-4 …:pb-4`, and that
-          descendant selector outranks a plain utility. Without them this compact
-          footer silently renders at the standard 4-gutter, misaligned with the
-          Section's `p-3` above it. */}
+      {/* The bangs are required, not stylistic: this drill runs inside a
+          `DialogNavPages` with the footer gutter ON (`[&_[data-slot=dialog-footer]]:px-4
+          …:pb-4`), and that descendant selector outranks a plain utility. Without
+          them this compact footer silently renders at the standard 4-gutter,
+          misaligned with the Section's `p-3` above it. */}
       <DialogFooter className='px-3! py-2!'>
         <Button variant='outline' size='sm' type='button' onClick={onBack}>
           Done

--- a/apps/web/src/components/kbar/command-palette.tsx
+++ b/apps/web/src/components/kbar/command-palette.tsx
@@ -162,7 +162,13 @@ export function CommandPalette() {
             />
           ) : null}
 
-          <DialogNavPages value={page} className='max-sm:min-h-0 max-sm:flex-1'>
+          {/* Every palette page pads itself in full (`p-4` around body *and*
+              footer), so the nested-footer gutter would stack on top of it and
+              indent the buttons past the fields. The footer's own `pt-4` stays. */}
+          <DialogNavPages
+            value={page}
+            footerGutter={false}
+            className='max-sm:min-h-0 max-sm:flex-1'>
             <DialogNavPage value='root' size='md'>
               <RootPage sections={sections} recentActions={recentActions} />
             </DialogNavPage>

--- a/apps/web/src/components/webhooks/ui/webhook-endpoint-configure-form.tsx
+++ b/apps/web/src/components/webhooks/ui/webhook-endpoint-configure-form.tsx
@@ -188,9 +188,10 @@ export function WebhookEndpointConfigureForm({
       className='flex flex-col'>
       {/* The gutter lives on the body, not the `<form>`: `DialogNavPages` re-gutters a
           nested `[data-slot=dialog-footer]` on the assumption that the footer is an
-          unpadded sibling of the padded body. Padding the form instead stacks both
-          gutters and indents the buttons past the fields. The bottom edge is left to
-          the footer's own `pt-4`; only the footer-less host pads it here. */}
+          unpadded sibling of the padded body (its `footerGutter` default). Padding the
+          form instead stacks both gutters and indents the buttons past the fields. The
+          bottom edge is left to the footer's own `pt-4`; only the footer-less host pads
+          it here. */}
       <div className={showFooter ? 'flex flex-col gap-4 px-4 pt-4' : 'flex flex-col gap-4 p-4'}>
         {isEdit && endpoint && <CopyRow label='Webhook URL' value={endpoint.url} icon={<Link />} />}
 

--- a/packages/ui/src/components/dialog-nav.tsx
+++ b/packages/ui/src/components/dialog-nav.tsx
@@ -155,6 +155,13 @@ export interface DialogNavPagesProps {
   value: string
   children: ReactNode
   className?: string
+  /**
+   * Re-apply the dialog gutter to a footer nested inside a page (default `true`).
+   * Set `false` when the host already pads each page in full — body *and* footer,
+   * as the command palette does — otherwise the two gutters stack and the buttons
+   * indent past the fields.
+   */
+  footerGutter?: boolean
 }
 
 /**
@@ -164,7 +171,12 @@ export interface DialogNavPagesProps {
  * content. The active page crossfades in. Pair with a `DialogContent
  * size='content'` shell so the card width follows the animating body.
  */
-export function DialogNavPages({ value, children, className }: DialogNavPagesProps) {
+export function DialogNavPages({
+  value,
+  children,
+  className,
+  footerGutter = true,
+}: DialogNavPagesProps) {
   const [height, setHeight] = useState<number | 'auto'>('auto')
   const ref = useRef<HTMLDivElement>(null)
   // The first measured height (from the observer, post-paint) must snap, not
@@ -219,9 +231,11 @@ export function DialogNavPages({ value, children, className }: DialogNavPagesPro
         // the footer is a sibling of that body, so its buttons sit flush against
         // the (rounded, overflow-hidden) card edges and get clipped. Re-apply the
         // dialog's standard `p-4` gutter to any nested footer via its data-slot.
+        // Only the horizontal + bottom edges — the footer's own `pt-4` stands.
         // Footers rendered as a *sibling* of DialogNavPages (the common wizard
         // layout) aren't descendants, so they keep their own padding untouched.
-        '[&_[data-slot=dialog-footer]]:px-4 [&_[data-slot=dialog-footer]]:pb-4',
+        // Hosts that pad the whole page (footer included) opt out via `footerGutter`.
+        footerGutter && '[&_[data-slot=dialog-footer]]:px-4 [&_[data-slot=dialog-footer]]:pb-4',
         className
       )}>
       {/* Stable measuring wrapper: the keyed page below remounts on every change,


### PR DESCRIPTION
## The bug

Every create form reached from the command palette renders its footer buttons indented past the fields, with an oversized gap below them.

The extra padding doesn't come from `DialogFooter` — it comes from the palette's own shell. `DialogNavPages` puts a blanket descendant rule on itself:

```
[&_[data-slot=dialog-footer]]:px-4 [&_[data-slot=dialog-footer]]:pb-4
```

That rule exists for the wizard pattern: a page pads its own body (`px-4 pt-4`) and leaves the footer as an *unpadded sibling*, so without it the buttons clip against the rounded card edge. `print-wizard-dialog`, `billing-action-dialog`, `worker-dialog`, `add-mcp-server-dialog`, `crawl-website-wizard` and the inbox members drill are all built that way.

The command palette does the opposite — each page wraps the whole form, body *and* footer, in one `p-4`:

```tsx
<div className='p-4 …'>
  <MailViewForm … />   // ← its DialogFooter is inside this p-4
</div>
```

So the footer got the page's `p-4` **plus** the rule's `px-4 pb-4`: 32px side gutters, 32px below. It hits all 13 palette create pages (api-key, mail-view, webhook, snippet, group, inbox, signature, meeting, dataset, dashboard, record `create`, `create-field`, task).

`create-task` is the same bug in a different shape: `TaskForm`'s footer is deliberately compact (`border-t py-1 px-4`), but the rule is a descendant selector at specificity (0,2,0) and beat the footer's own `py-1` (0,1,0) — so it rendered 16px of bottom padding instead of 4px. That specificity gap is also why `inbox-members-page` had to reach for `px-3! py-2!`.

## The fix

Make the gutter opt-out at the shell rather than patching 13 forms:

- **`packages/ui/src/components/dialog-nav.tsx`** — `DialogNavPagesProps` gains `footerGutter?: boolean`, defaulting to `true`, and the rule is gated on it. Default `true` means every existing wizard host is byte-identical.
- **`apps/web/src/components/kbar/command-palette.tsx`** — passes `footerGutter={false}`.

The rule only ever added `px`/`pb`, so `DialogFooter`'s own `pt-4` stands either way — the 16px above the buttons is unchanged.

Nothing else in the palette needs the gutter: no `DialogFooter` is authored in `kbar/` itself, and `InboxForm` runs there with `enableMembersPage=false`, so there's no nested `DialogNavPages` re-introducing it.

The remaining three files are comment-only, so the ones that document this assumption name the prop instead of describing the rule as unconditional. The `!` bangs in `inbox-members-page` stay — that drill runs inside the inbox form's own nested `DialogNavPages`, where the gutter is still on.

## Result

- Palette create pages: footer buttons align with the fields — 16px above from `pt-4`, 16px sides/bottom from the page's `p-4`. Identical to how the same form looks in its standalone dialog.
- `create-task`: compact `border-t py-1 px-4` footer renders as designed, border spanning the card.
- Every other `DialogNavPages` host: unchanged.

## Verification

`@auxx/ui` typechecks clean; Biome clean on all five files. `@auxx/ui` exports raw source, so no dist rebuild is involved.