### PR TITLE
fix(inboxes): use the inbox picker on the channel connect step

### DIFF
--- a/apps/web/src/components/channels/ui/inbox-destination-field.tsx
+++ b/apps/web/src/components/channels/ui/inbox-destination-field.tsx
@@ -1,20 +1,20 @@
 // apps/web/src/components/channels/ui/inbox-destination-field.tsx
 'use client'
 
-import { FieldType } from '@auxx/database/enums'
+import { DEFAULT_SELECT_OPTION_COLOR, type SelectOptionColor } from '@auxx/lib/custom-fields/client'
 import type { Lens } from '@auxx/lib/permissions/visibility/client'
-import type { SelectOption } from '@auxx/types/custom-field'
 import { RadioGroup } from '@auxx/ui/components/radio-group'
 import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
 import { Lock, UsersIcon } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
-import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanelRow } from '~/components/global/forms/field-panel'
+import { InboxNameField } from '~/components/inbox/ui/inbox-name-field'
 import {
   GranularPermissionsUpgradeDialog,
   useGranularPermissionsGated,
 } from '~/components/mail-permissions/ui/granular-permissions-gate'
 import { LensSelect } from '~/components/mail-permissions/ui/lens-select'
+import { InboxPicker } from '~/components/pickers/inbox-picker'
 import { useInboxes } from '~/components/threads/hooks'
 import { invalidateInboxRecordLists } from '~/components/threads/hooks/use-inbox'
 import { BaseType } from '~/components/workflow/types'
@@ -33,6 +33,8 @@ export interface InboxDestinationController {
   setSelection: (value: string) => void
   name: string
   setName: (value: string) => void
+  color: SelectOptionColor
+  setColor: (color: SelectOptionColor) => void
   accessType: 'anyone' | 'restricted'
   onAccessTypeChange: (value: string) => void
   floorLens: Exclude<Lens, 'none'>
@@ -71,6 +73,7 @@ export function useInboxDestination(
   // isn't a shared inbox it simply won't match an option and the user picks one.
   const [selection, setSelection] = useState<string>(initialInboxId ?? '')
   const [name, setName] = useState('')
+  const [color, setColor] = useState<SelectOptionColor>(DEFAULT_SELECT_OPTION_COLOR)
   const [accessType, setAccessType] = useState<'anyone' | 'restricted'>('anyone')
   const [floorLens, setFloorLens] = useState<Exclude<Lens, 'none'>>('read')
   const [upgradeOpen, setUpgradeOpen] = useState(false)
@@ -98,17 +101,19 @@ export function useInboxDestination(
     const targetLens: Lens = accessType === 'anyone' ? floorLens : 'none'
     const created = await createInbox.mutateAsync({
       name: name.trim(),
+      color,
       status: 'ACTIVE',
       defaultLens: targetLens,
     })
     utils.inbox.myLenses.invalidate()
     invalidateInboxRecordLists(utils)
     return created.id
-  }, [isCreate, selection, accessType, floorLens, name, createInbox, utils])
+  }, [isCreate, selection, accessType, floorLens, name, color, createInbox, utils])
 
   const reset = useCallback(() => {
     setSelection('')
     setName('')
+    setColor(DEFAULT_SELECT_OPTION_COLOR)
     setAccessType('anyone')
     setFloorLens('read')
     setUpgradeOpen(false)
@@ -120,6 +125,8 @@ export function useInboxDestination(
     setSelection,
     name,
     setName,
+    color,
+    setColor,
     accessType,
     onAccessTypeChange,
     floorLens,
@@ -153,6 +160,8 @@ export function InboxDestinationField({
     setSelection,
     name,
     setName,
+    color,
+    setColor,
     accessType,
     onAccessTypeChange,
     floorLens,
@@ -163,24 +172,36 @@ export function InboxDestinationField({
     isCreate,
   } = controller
 
-  // Existing shared inboxes + a trailing "Create new inbox" choice.
-  const inboxOptions = useMemo<SelectOption[]>(
-    () => [
-      ...shared.map((inbox) => ({ value: inbox.id, label: inbox.name })),
-      { value: CREATE_NEW, label: 'Create new inbox' },
-    ],
-    [shared]
+  // `InboxPicker` speaks RecordIds; `selection` is a bare instance id, because that is
+  // what `resolve()` hands to `pc_inboxId` (see `channels/connect-inbox.ts`). Convert at
+  // both edges rather than storing the RecordId — the conversion has to happen somewhere,
+  // and doing it here keeps the id the rest of the connect flow sees unambiguous.
+  const selectedRecordIds = useMemo(() => {
+    const match = shared.find((inbox) => inbox.id === selection)
+    return match ? [match.recordId] : []
+  }, [shared, selection])
+
+  const handlePick = useCallback(
+    (recordIds: string[]) => {
+      const picked = shared.find((inbox) => inbox.recordId === recordIds[0])
+      setSelection(picked?.id ?? '')
+    },
+    [shared, setSelection]
   )
 
   return (
     <>
       <FieldPanelRow title='Deliver to inbox' type={BaseType.STRING} showIcon isRequired>
-        <FieldInputAdapter
-          fieldType={FieldType.SINGLE_SELECT}
-          fieldOptions={{ options: inboxOptions }}
-          value={selection}
-          onChange={(v) => setSelection(Array.isArray(v) ? (v[0] ?? '') : ((v as string) ?? ''))}
+        <InboxPicker
+          inboxes={shared}
+          selected={selectedRecordIds}
+          onChange={handlePick}
           placeholder='Choose an inbox'
+          // Deferred create: flips this field into its inline name/access rows instead of
+          // opening `InboxDialog`, which would write the inbox before the channel connects.
+          onCreate={() => setSelection(CREATE_NEW)}
+          createLabel='Create new inbox'
+          selectedLabel={isCreate ? 'New inbox' : undefined}
           triggerProps={FIELD_TRIGGER_PROPS}
           disabled={disabled}
         />
@@ -189,12 +210,12 @@ export function InboxDestinationField({
       {isCreate && (
         <>
           <FieldPanelRow title='Inbox name' type={BaseType.STRING} showIcon isRequired>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={name}
-              onChange={(v) => setName((v as string) ?? '')}
+            <InboxNameField
+              name={name}
+              onNameChange={setName}
+              color={color}
+              onColorChange={setColor}
               placeholder='e.g. Support'
-              triggerProps={FIELD_TRIGGER_PROPS}
               disabled={disabled}
             />
           </FieldPanelRow>
@@ -203,7 +224,7 @@ export function InboxDestinationField({
             <RadioGroup
               value={accessType}
               onValueChange={onAccessTypeChange}
-              className='grid gap-2 sm:grid-cols-2'>
+              className='grid gap-2 py-2 pe-2'>
               <RadioGroupItemCard
                 value='anyone'
                 label='Everyone'

--- a/apps/web/src/components/inbox/inbox-form.tsx
+++ b/apps/web/src/components/inbox/inbox-form.tsx
@@ -34,7 +34,6 @@ import {
 } from '~/components/permissions/utils/grantee'
 import { useSaveSystemValues, useSystemValues } from '~/components/resources/hooks'
 import { ActorBadge } from '~/components/resources/ui/actor-badge'
-import { FormColorTagPicker } from '~/components/tags/ui/color-tag-picker'
 import {
   type InboxItem,
   invalidateInboxRecordLists,
@@ -48,6 +47,7 @@ import { useUnsavedChangesGuard } from '~/hooks/use-unsaved-changes-guard'
 import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import { InboxMembersPage } from './inbox-members-page'
+import { InboxNameField } from './ui/inbox-name-field'
 
 /** A grantee row as the form edits it. */
 interface FormGrant {
@@ -641,7 +641,8 @@ export function InboxForm({
   // so the footer remains an unpadded sibling of the body, which is what
   // `DialogNavPages` re-gutters via its `[data-slot=dialog-footer]` rule. Padding the
   // form instead stacks both gutters and indents the buttons past the fields.
-  // The palette host supplies its own padding.
+  // The palette host pads the whole page instead and turns that rule off
+  // (`footerGutter={false}`), so this form stays unpadded in both hosts.
   const configurePage = (
     <form
       onSubmit={(e) => {
@@ -666,11 +667,11 @@ export function InboxForm({
             isRequired
             validationError={errors.name}
             validationType='error'>
-            <FieldInputAdapter
-              fieldType={FieldType.TEXT}
-              value={values.name}
-              onChange={(val) => handleChange('name', (val as string) ?? '')}
-              placeholder='Enter inbox name'
+            <InboxNameField
+              name={values.name}
+              onNameChange={(val) => handleChange('name', val)}
+              color={values.color}
+              onColorChange={(color) => handleChange('color', color)}
               disabled={isPending}
             />
           </FieldPanelRow>
@@ -685,16 +686,6 @@ export function InboxForm({
               disabled={isPending}
               fieldOptions={{ multiline: true }}
             />
-          </FieldPanelRow>
-
-          {/* Color */}
-          <FieldPanelRow title='Color' type={BaseType.ENUM} showIcon>
-            <div className='py-2'>
-              <FormColorTagPicker
-                value={values.color}
-                onChange={(color) => handleChange('color', color)}
-              />
-            </div>
           </FieldPanelRow>
 
           {/* Access section — org admins and inbox Managers only */}

--- a/apps/web/src/components/inbox/ui/inbox-name-field.tsx
+++ b/apps/web/src/components/inbox/ui/inbox-name-field.tsx
@@ -1,0 +1,82 @@
+// apps/web/src/components/inbox/ui/inbox-name-field.tsx
+'use client'
+
+import { getColorSwatch, type SelectOptionColor } from '@auxx/lib/custom-fields/client'
+import { Input } from '@auxx/ui/components/input'
+import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
+import { cn } from '@auxx/ui/lib/utils'
+import { ColorTagPicker } from '~/components/tags/ui/color-tag-picker'
+
+/** Props for {@link InboxNameField}. */
+interface InboxNameFieldProps {
+  name: string
+  onNameChange: (name: string) => void
+  color: SelectOptionColor
+  onColorChange: (color: SelectOptionColor) => void
+  placeholder?: string
+  disabled?: boolean
+  className?: string
+  id?: string
+}
+
+/**
+ * Inbox name input with the colour swatch folded into it: the dot sits at the head of the
+ * field and opens a {@link ColorTagPicker} popover, so colour costs no separate row. Shared
+ * by the inbox create/edit dialog and the channel connect step's inline create — the two
+ * places an inbox is named. Render inside a `FieldPanelRow`.
+ */
+export function InboxNameField({
+  name,
+  onNameChange,
+  color,
+  onColorChange,
+  placeholder = 'Enter inbox name',
+  disabled,
+  className,
+  id,
+}: InboxNameFieldProps) {
+  return (
+    <div className={cn('flex min-h-8 items-center gap-2', className)}>
+      <Popover>
+        {/* The hover grow lives on the inner dot, never on the trigger: Radix anchors the
+            popover to the trigger's measured box, and a transform is inside that measurement —
+            scaling the trigger itself makes the open popover drift on hover. The button keeps a
+            fixed `size-5` (also a saner hit target than a 14px dot). */}
+        <PopoverTrigger asChild disabled={disabled}>
+          <button
+            type='button'
+            aria-label='Inbox color'
+            disabled={disabled}
+            className={cn(
+              'group/dot flex size-5 shrink-0 items-center justify-center rounded-full',
+              'focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-60'
+            )}>
+            <span
+              className={cn(
+                'size-3.5 rounded-full transition-transform group-hover/dot:scale-115',
+                'group-focus-visible/dot:ring-2 group-focus-visible/dot:ring-muted-foreground/50',
+                'group-focus-visible/dot:ring-offset-1 group-focus-visible/dot:ring-offset-background',
+                getColorSwatch(color)
+              )}
+            />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className='w-auto max-w-56 p-3' align='start'>
+          <ColorTagPicker value={color} onChange={onColorChange} disabled={disabled} />
+        </PopoverContent>
+      </Popover>
+
+      <Input
+        id={id}
+        variant='transparent'
+        size='sm'
+        className='min-h-8 px-0'
+        autoComplete='off'
+        value={name}
+        onChange={(e) => onNameChange(e.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/pickers/inbox-picker.tsx
+++ b/apps/web/src/components/pickers/inbox-picker.tsx
@@ -6,12 +6,13 @@ import {
   type SelectOption,
   type SelectOptionColor,
 } from '@auxx/types/custom-field'
-import { Button } from '@auxx/ui/components/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
 import { useCallback, useMemo, useState } from 'react'
 import { InboxDialog } from '~/components/inbox/inbox-dialog'
 import { type InboxItem, useInboxes } from '~/components/threads/hooks'
+import { PickerTrigger, type PickerTriggerOptions } from '~/components/ui/picker-trigger'
+import { TagsView } from '~/components/ui/tags-view'
 import { MultiSelectPicker } from './multi-select-picker'
 
 /** Props for InboxPicker component */
@@ -26,24 +27,39 @@ interface InboxPickerProps {
   className?: string
   inboxes?: InboxItem[]
   children?: React.ReactNode
+  disabled?: boolean
   align?: 'start' | 'center' | 'end'
   side?: 'top' | 'right' | 'bottom' | 'left'
   sideOffset?: number
   style?: React.CSSProperties
+  /** Trigger placeholder when nothing is selected. */
+  placeholder?: string
   /**
-   * Passed through to the default trigger `<Button>` (variant/className/size/…)
-   * when no custom `children` trigger is given. Lets callers match the shared
-   * `w-full ps-0 pe-1` flush-in-a-`FieldPanelRow` sizing convention without
-   * hand-rolling a trigger, see `docs/ui-design-guide.md` §5.
+   * Overrides the default trigger's rendered value, forcing it to read as
+   * selected. For a caller whose "selected" state isn't one of the options —
+   * the channel connect step's pending "New inbox", say.
    */
-  triggerProps?: React.ComponentProps<typeof Button>
+  selectedLabel?: React.ReactNode
+  /**
+   * Replaces the footer "Create inbox" action. The default opens {@link InboxDialog},
+   * which creates the inbox immediately; a caller that must defer the write until its
+   * own submit (the channel connect step) passes its own handler instead.
+   */
+  onCreate?: () => void
+  createLabel?: string
+  /**
+   * Customizes the default {@link PickerTrigger} when no `children` trigger is given.
+   * Lets callers match the shared `w-full ps-0 pe-1` flush-in-a-`FieldPanelRow` sizing
+   * convention without hand-rolling a trigger, see `docs/ui-design-guide.md` §5.
+   */
+  triggerProps?: PickerTriggerOptions
 }
 
 /** Special value for "Select All" option */
 export const INBOX_SELECT_ALL_VALUE = '__all__'
 
 /** `Inbox.color` is a free-form string column; anything off-palette falls back. */
-function toOptionColor(color: string | null | undefined): SelectOptionColor {
+export function toOptionColor(color: string | null | undefined): SelectOptionColor {
   return typeof color === 'string' && (SELECT_OPTION_COLORS as readonly string[]).includes(color)
     ? (color as SelectOptionColor)
     : 'indigo'
@@ -64,6 +80,11 @@ export function InboxPicker({
   className,
   inboxes: externalInboxes,
   children,
+  disabled,
+  placeholder = 'Select inbox',
+  selectedLabel,
+  onCreate,
+  createLabel = 'Create inbox',
   triggerProps,
   ...props
 }: InboxPickerProps) {
@@ -74,7 +95,7 @@ export function InboxPicker({
 
   // Fetch inboxes if not provided. Personal inboxes are never valid
   // routing/move targets (mail-permissions §11), exclude them everywhere.
-  const { inboxes: fetchedInboxes } = useInboxes()
+  const { inboxes: fetchedInboxes } = useInboxes({ enabled: !externalInboxes })
   const inboxes = (externalInboxes || fetchedInboxes || []).filter((inbox) => !inbox.isPersonal)
 
   // Dialog state for creating new inbox
@@ -126,10 +147,18 @@ export function InboxPicker({
     [setIsOpen]
   )
 
-  // Handle create button click
+  // Handle create button click — the caller's handler wins over the dialog. The override
+  // closes the popover (its UI lands where the popover was); the dialog path deliberately
+  // does not, because unmounting the popover in the same commit hands focus back to the
+  // trigger and takes it off the dialog that just opened.
   const handleCreate = useCallback(() => {
+    if (onCreate) {
+      setIsOpen(false)
+      onCreate()
+      return
+    }
     setDialogOpen(true)
-  }, [])
+  }, [onCreate, setIsOpen])
 
   // Handle dialog success (optionally select the new inbox)
   const handleDialogSuccess = useCallback(
@@ -144,15 +173,32 @@ export function InboxPicker({
     [allowMultiple, selected, onChange, setIsOpen]
   )
 
+  const hasValue = selectedLabel !== undefined || selected.length > 0
+
+  const trigger = children ?? (
+    <PickerTrigger
+      open={isOpen}
+      disabled={disabled}
+      variant={triggerProps?.variant ?? 'transparent'}
+      size={triggerProps?.size}
+      hasValue={hasValue}
+      placeholder={placeholder}
+      showClear={triggerProps?.showClear ?? allowMultiple}
+      onClear={() => onChange?.([])}
+      icon={triggerProps?.icon}
+      iconPosition={triggerProps?.iconPosition}
+      hideIcon={triggerProps?.hideIcon}
+      asCombobox
+      className={triggerProps?.className}>
+      {selectedLabel ?? <TagsView value={selected} options={options} className='flex-1' />}
+    </PickerTrigger>
+  )
+
   return (
     <>
       <Popover open={isOpen} onOpenChange={setIsOpen}>
-        <PopoverTrigger asChild>
-          {children || (
-            <Button variant='outline' {...triggerProps}>
-              Select Inbox{allowMultiple ? 'es' : ''}
-            </Button>
-          )}
+        <PopoverTrigger asChild disabled={disabled}>
+          {trigger}
         </PopoverTrigger>
         <PopoverContent
           className={cn('w-[300px] p-0 backdrop-blur-sm bg-popover/60', className)}
@@ -167,12 +213,13 @@ export function InboxPicker({
             canAdd={false}
             multi={allowMultiple}
             onCreate={handleCreate}
-            createLabel='Create inbox'
+            createLabel={createLabel}
+            disabled={disabled}
           />
         </PopoverContent>
       </Popover>
 
-      {/* Inbox creation dialog */}
+      {/* Inbox creation dialog — only the default (non-overridden) create path. */}
       {dialogOpen && (
         <InboxDialog
           open={dialogOpen}

--- a/apps/web/src/components/tags/ui/color-tag-picker.tsx
+++ b/apps/web/src/components/tags/ui/color-tag-picker.tsx
@@ -30,9 +30,13 @@ function ColorTagPicker({ onChange, value, disabled = false }: ColorPickerProps)
           <button
             key={color.id}
             className={cn(
-              'flex h-6 w-6 items-center justify-center rounded-full transition-all hover:scale-110 focus:outline-hidden focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+              'flex h-6 w-6 items-center justify-center rounded-full transition-all hover:scale-110',
+              'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
               color.swatch,
-              isSelected && 'ring-2 ring-blue-500 ring-offset-2'
+              // Keyboard focus reads as muted so it never competes with the blue
+              // selection ring; on the selected swatch the selection ring stands.
+              !isSelected && 'focus-visible:ring-muted-foreground/50',
+              isSelected && 'ring-2 ring-blue-500 ring-offset-2 ring-offset-background'
             )}
             onClick={() => onChange(color.id)}
             type='button'


### PR DESCRIPTION
Closes the `InboxPicker` swap left open as §13.5-3 in `plans/channels/facebook-page-picker.md` — though not for the reason recorded there (see below).

## The actual problem

The connect step's **Deliver to inbox** field rendered a bare `SINGLE_SELECT` through `FieldInputAdapter`, with `"Create new inbox"` stuffed into the options array. That put the create action *inside* the searchable result list instead of the pinned footer group (`multi-select-picker.tsx`, outside `CommandList`, `border-t`) that every other picker uses.

> **Correcting the plan.** §13.5-3 justified the swap on search and colours. Search was never missing — `FieldInputAdapter → SelectInputField → MultiSelectPicker` already renders a `CommandInput`, and `InboxPicker` wraps that *same* picker. Colour was a three-line fix. The separated create row is the real reason, and it's the one thing the swap genuinely buys.

## What changed

### `InboxPicker` brought up to the `SignaturePicker` shape

It was the one picker that never got this treatment:

- **Default trigger is `PickerTrigger` + `TagsView`** (selected inbox renders as a coloured badge) instead of a static `"Select Inbox"` button. `triggerProps` retyped `ComponentProps<Button>` → `PickerTriggerOptions`, so it finally does what its docstring claimed. No regression — all three existing callers pass their own `children` trigger.
- **Optional `onCreate`** replaces the default footer action. The default opens `InboxDialog`, which writes the inbox *immediately*; the connect step passes its own handler so the write stays deferred to Connect-click, where `resolve()` already does it. The override closes the popover; the dialog path deliberately does not — unmounting the popover in the same commit hands focus back to the trigger and takes it off the dialog that just opened.
- **`useInboxes({ enabled: !externalInboxes })`** — a caller supplying the list no longer triggers a second fetch.

### Colour folded into the name field

New `InboxNameField`: a name input with the swatch at its head, opening a `ColorTagPicker` popover. Shared by the two places an inbox gets named — the create/edit dialog (which loses its separate **Color** row) and the connect step's inline create (which gains colour, passed through to `inbox.create`; the input already accepted it).

The hover grow lives on an inner span, never on the trigger. Radix measures the trigger's box to anchor the popover and a CSS transform is part of that measurement, so scaling the trigger itself made an open popover drift on hover.

### Swatch focus rings

`focus:` → `focus-visible:` (keyboard-only), and `ring-blue-500` → `ring-muted-foreground/50` so it stops competing with the blue selection ring. Applied **conditionally** rather than by cascade — Tailwind's variant ordering would otherwise let the focus ring override the selection ring on the selected swatch, which is backwards. Also affects the tags dialog, the other `ColorTagPicker` consumer.

### Connect-step Access radios

Stack vertically with the same `py-2 pe-2` padding the inbox form uses; two columns were cramped in the panel's narrow control lane.

## Notes

- **`pc_inboxId` id-space.** `InboxPicker` speaks `RecordId`s, `selection` is a bare instance id because that's what `resolve()` hands to `pc_inboxId`. Converted explicitly at both edges and commented — this is §0.1's first defect class.
- **Orphan inboxes are unchanged, not fixed.** `resolve()` still runs at Connect-click, before the OAuth popup, so a cancelled popup or abandoned Page picker still leaves an inbox behind. Keeping the create deferred just avoids *widening* that window to "opened the create dialog, then changed my mind." Genuinely closing it means server-side creation in `selectSocialPage` — worth its own §13.5 entry, not pre-submission work.

## Testing

- `apps/web` typecheck: clean for these files. The one error it reports is pre-existing and unrelated (`packages/lib/src/ingest/contacts/identity-candidate.ts`, `IdentifierTypeValue` vs `IdentifierTypeValues`).
- Biome clean.
- **Not browser-verified.**