### PR TITLE
fix(channels): stop a Meta PSID becoming a contact's name

### DIFF
--- a/packages/lib/src/ingest/contacts/__tests__/find-or-create-names.test.ts
+++ b/packages/lib/src/ingest/contacts/__tests__/find-or-create-names.test.ts
@@ -1,0 +1,130 @@
+// packages/lib/src/ingest/contacts/__tests__/find-or-create-names.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * What a new contact is NAMED — FB/IG follow-up, Aug 2026.
+ *
+ * `Participant.displayName` restates the identifier when no name is known, and
+ * `full_name` is the contact's primary display field, so the old unconditional
+ * fallback wrote a 17-digit PSID into First Name and made it the record's
+ * `EntityInstance.displayName`. Downstream nothing could tell it from a real
+ * name, and nothing ever revisited it.
+ *
+ * The rule pinned here is per identifier type, not blanket: an address and a
+ * phone number are labels a human reads and the contacts list has always shown
+ * them, so only the opaque types lose the fallback.
+ */
+
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('../../companies/link-contact', () => ({
+  linkContactToCompanyByDomain: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../../domain/classifier', () => ({
+  getOwnDomains: vi.fn().mockResolvedValue(new Set<string>()),
+}))
+
+vi.mock('../has-sent-to', () => ({
+  hasOrganizationSentToParticipant: vi.fn().mockResolvedValue(true),
+}))
+
+import { findOrCreateContactForParticipant } from '../find-or-create'
+
+const create = vi.fn()
+const findOrCreate = vi.fn()
+const findByField = vi.fn()
+
+function makeCtx() {
+  return {
+    organizationId: 'org_1',
+    db: {} as never,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    crudHandler: { create, findOrCreate, findByField },
+    integrationSettings: { recordCreation: { mode: 'all' } },
+    ownDomainsByOrg: new Map(),
+    companyIdByDomain: new Map(),
+  } as never
+}
+
+/** A participant the way ingest writes one before any name is known. */
+function nameless(identifierType: string, identifier: string) {
+  return {
+    id: 'participant_1',
+    identifier,
+    identifierType,
+    name: null,
+    // What `calculateDisplayName` produces with no name: the identifier itself.
+    displayName: identifier,
+    isInternal: false,
+  } as never
+}
+
+const inbound = { isInbound: true, role: 'FROM' as never }
+
+/** The create payload, whichever arm minted the contact. */
+function createdValues(): Record<string, unknown> {
+  const viaFindOrCreate = findOrCreate.mock.calls[0]?.[2]
+  return (viaFindOrCreate ?? create.mock.calls[0]?.[1]) as Record<string, unknown>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  create.mockResolvedValue({ instance: { id: 'contact_new' } })
+  findOrCreate.mockResolvedValue({ instance: { id: 'contact_new' } })
+  findByField.mockResolvedValue(null)
+})
+
+describe('findOrCreateContactForParticipant — naming a nameless participant', () => {
+  for (const [type, identifier] of [
+    ['FACEBOOK_PSID', '27893553143563440'],
+    ['INSTAGRAM_IGSID', '17841448440510270'],
+    ['CHAT_VISITOR', 'cm4x9visitorsessioncuid'],
+  ] as const) {
+    it(`never launders a ${type} into the contact's first name`, async () => {
+      await findOrCreateContactForParticipant(makeCtx(), nameless(type, identifier), inbound)
+
+      const values = createdValues()
+      expect(values.first_name).toBeNull()
+      expect(values.last_name).toBeNull()
+      // Blank is the point: the profile lookup fills the participant in within
+      // seconds and `repairContactNameFromParticipant` patches the record. A
+      // laundered id would have been indistinguishable from a real name forever.
+      expect(Object.values(values)).not.toContain(identifier)
+    })
+  }
+
+  it('still names an EMAIL contact after its address', async () => {
+    await findOrCreateContactForParticipant(
+      makeCtx(),
+      nameless('EMAIL', 'jane@example.com'),
+      inbound
+    )
+
+    expect(createdValues().first_name).toBe('jane@example.com')
+  })
+
+  it('still names a PHONE contact after its number', async () => {
+    await findOrCreateContactForParticipant(makeCtx(), nameless('PHONE', '+14056121542'), inbound)
+
+    expect(createdValues().first_name).toBe('+14056121542')
+  })
+
+  it('splits a resolved name normally, whatever the identifier type', async () => {
+    const participant = {
+      ...(nameless('FACEBOOK_PSID', '27893553143563440') as object),
+      name: 'Markus Klooth',
+      displayName: 'Markus Klooth',
+    } as never
+
+    await findOrCreateContactForParticipant(makeCtx(), participant, inbound)
+
+    const values = createdValues()
+    expect(values.first_name).toBe('Markus')
+    expect(values.last_name).toBe('Klooth')
+  })
+})

--- a/packages/lib/src/ingest/contacts/__tests__/repair-name.test.ts
+++ b/packages/lib/src/ingest/contacts/__tests__/repair-name.test.ts
@@ -1,0 +1,143 @@
+// packages/lib/src/ingest/contacts/__tests__/repair-name.test.ts
+
+import type { Database } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The contact-name repair — FB/IG follow-up, Aug 2026.
+ *
+ * Contact creation and Meta name resolution run on different clocks: ingest
+ * mints a contact on the first outbound reply, and `resolveSocialCounterpartName`
+ * only learns the real name once Graph answers. A contact minted inside that
+ * window was named from a nameless participant and stayed called
+ * `27893553143563440` forever, because name resolution writes `Participant`,
+ * never the record.
+ *
+ * What has to hold: the repair upgrades a record whose display value is only the
+ * identifier echoed back, and refuses to touch anything a human might have
+ * named.
+ */
+
+const { update } = vi.hoisted(() => ({ update: vi.fn() }))
+
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('../../../resources/crud/unified-handler', () => ({
+  UnifiedCrudHandler: class {
+    update = update
+  },
+}))
+
+vi.mock('../../../users/system-user-service', () => ({
+  SystemUserService: { getSystemUserForActions: vi.fn().mockResolvedValue('system_user_1') },
+}))
+
+import { repairContactNameFromParticipant } from '../repair-name'
+
+const PSID = '27893553143563440'
+
+/** One `select(...).from(...).where(...).limit(...)` answering `rows`. */
+function fakeDb(rows: unknown[]): Database {
+  return {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: async () => rows }) }),
+    }),
+  } as unknown as Database
+}
+
+function contactRow(displayName: string | null) {
+  return { id: 'contact_1', displayName, entityDefinitionId: 'def_contact' }
+}
+
+const args = {
+  organizationId: 'org_1',
+  entityInstanceId: 'contact_1',
+  identifier: PSID,
+  name: 'Markus Klooth',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  update.mockResolvedValue(undefined)
+})
+
+describe('repairContactNameFromParticipant', () => {
+  it('names a contact whose display value is just the PSID echoed back', async () => {
+    const repaired = await repairContactNameFromParticipant(fakeDb([contactRow(PSID)]), args)
+
+    expect(repaired).toBe(true)
+    expect(update).toHaveBeenCalledWith('def_contact:contact_1', {
+      first_name: 'Markus',
+      last_name: 'Klooth',
+    })
+  })
+
+  it('names a contact that has no display value at all', async () => {
+    // What a Meta contact now looks like at creation time: the identifier is no
+    // longer laundered into First Name, so the record starts out blank.
+    const repaired = await repairContactNameFromParticipant(fakeDb([contactRow(null)]), args)
+
+    expect(repaired).toBe(true)
+    expect(update).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves a contact that already carries a real name alone', async () => {
+    const repaired = await repairContactNameFromParticipant(
+      fakeDb([contactRow('Ada Lovelace')]),
+      args
+    )
+
+    expect(repaired).toBe(false)
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it('writes a single-word name as the first name only', async () => {
+    const repaired = await repairContactNameFromParticipant(fakeDb([contactRow(PSID)]), {
+      ...args,
+      name: 'auxxlift',
+    })
+
+    expect(repaired).toBe(true)
+    expect(update).toHaveBeenCalledWith('def_contact:contact_1', {
+      first_name: 'auxxlift',
+      last_name: null,
+    })
+  })
+
+  it('does nothing when the participant is linked to no contact', async () => {
+    const db = fakeDb([contactRow(PSID)])
+    const select = vi.spyOn(db, 'select')
+
+    const repaired = await repairContactNameFromParticipant(db, {
+      ...args,
+      entityInstanceId: null,
+    })
+
+    expect(repaired).toBe(false)
+    // The null guard is ahead of the read: no query is spent on the ordinary
+    // case of a counterpart no contact was ever minted for.
+    expect(select).not.toHaveBeenCalled()
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the contact is gone or archived', async () => {
+    // `Participant.entityInstanceId` is not cleared on archival, so a stale link
+    // is normal — and repairing an archived record would resurrect it into every
+    // list that filters on `archivedAt IS NULL`.
+    const repaired = await repairContactNameFromParticipant(fakeDb([]), args)
+
+    expect(repaired).toBe(false)
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it('swallows a write failure — the caller is a post-200 webhook hook', async () => {
+    update.mockRejectedValue(new Error('field validator rejected the value'))
+
+    await expect(repairContactNameFromParticipant(fakeDb([contactRow(PSID)]), args)).resolves.toBe(
+      false
+    )
+  })
+})

--- a/packages/lib/src/ingest/contacts/repair-name.ts
+++ b/packages/lib/src/ingest/contacts/repair-name.ts
@@ -1,0 +1,119 @@
+// packages/lib/src/ingest/contacts/repair-name.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNull } from 'drizzle-orm'
+import { usableContactName } from '../../participants/client'
+import { toRecordId } from '../../resources/resource-id'
+import { getNamesFromParticipant } from '../participants/display'
+
+const logger = createScopedLogger('contact-name-repair')
+
+export interface RepairContactNameArgs {
+  organizationId: string
+  /**
+   * The contact this participant is linked to (`Participant.entityInstanceId`).
+   * `null` is the ordinary case for a counterpart no contact was minted for —
+   * accepted here so callers do not each repeat the guard.
+   */
+  entityInstanceId: string | null
+  /** The participant's raw identifier — what a laundered name looks like. */
+  identifier: string
+  /** The name that just became known. Must be a real name, never an identifier. */
+  name: string
+}
+
+/**
+ * Give a contact the name its participant just acquired, if it has none of its own.
+ *
+ * Contact creation and name resolution are two different events on two different
+ * clocks. Ingest mints a contact the moment `selective` mode is satisfied — for a
+ * Meta DM that is the first outbound reply — while the counterpart's real name only
+ * arrives once `resolveSocialCounterpartName` has answered Graph. A contact minted
+ * inside that window is named from a participant that had no name, and **nothing
+ * afterwards ever revisits it**: name resolution writes `Participant`, not the
+ * record. That is how a contact ends up permanently called `27893553143563440`.
+ *
+ * This closes the window from the other side. It is deliberately narrow:
+ *
+ * - **Upgrade-only, never a rename.** {@link usableContactName} is the same test the
+ *   mail label resolver uses — a display value equal to the identifier is not a
+ *   name. Anything that passes it is a real name (typed by a human, imported, or
+ *   resolved earlier) and is left alone.
+ * - **Writes through `UnifiedCrudHandler`.** `full_name` is a computed field over
+ *   `first_name`/`last_name`, and `EntityInstance.displayName` is denormalized from
+ *   it; a direct `FieldValue` write would leave the record displaying the old id.
+ *   The handler also emits `record:updated`, which is what makes open mail lists
+ *   flip from id to name without a refetch (the record lane, not the mail lane —
+ *   see `useResourceSync`'s `patchParticipantsForContact`).
+ * - **Never throws.** Every caller is a post-200 `after()` hook on a webhook. A
+ *   failed repair costs a stale label, not a retried delivery.
+ *
+ * The handler and the system-user lookup are imported lazily for the reason
+ * documented on `publishParticipantPatch`: `profile.ts` is a provider module on
+ * the webhook path, and a static edge from it into `UnifiedCrudHandler` widens
+ * the graph into the org-cache cycle and breaks `vi.mock` interception in lib
+ * tests. Same precedent as `record-rules/actions.ts`.
+ *
+ * @returns `true` when the contact's name was written.
+ */
+export async function repairContactNameFromParticipant(
+  db: Database,
+  args: RepairContactNameArgs
+): Promise<boolean> {
+  const { organizationId, entityInstanceId, identifier, name } = args
+  if (!entityInstanceId) return false
+
+  try {
+    const [instance] = await db
+      .select({
+        id: schema.EntityInstance.id,
+        displayName: schema.EntityInstance.displayName,
+        entityDefinitionId: schema.EntityInstance.entityDefinitionId,
+      })
+      .from(schema.EntityInstance)
+      .where(
+        and(
+          eq(schema.EntityInstance.id, entityInstanceId),
+          eq(schema.EntityInstance.organizationId, organizationId),
+          // A linked contact can be archived out from under the participant —
+          // `entityInstanceId` is not cleared by archival. Repairing one would
+          // resurrect it into every list that filters on `archivedAt IS NULL`.
+          isNull(schema.EntityInstance.archivedAt)
+        )
+      )
+      .limit(1)
+
+    if (!instance) return false
+    if (usableContactName(instance.displayName, identifier)) return false
+
+    // Split through the same helper contact creation uses, with the name passed
+    // as `name` so the identifier fallback cannot re-enter here.
+    const names = getNamesFromParticipant({ name })
+    if (!names.firstName) return false
+
+    const [{ UnifiedCrudHandler }, { SystemUserService }] = await Promise.all([
+      import('../../resources/crud/unified-handler'),
+      import('../../users/system-user-service'),
+    ])
+    const systemUserId = await SystemUserService.getSystemUserForActions(organizationId)
+    const handler = new UnifiedCrudHandler(organizationId, systemUserId, db)
+    await handler.update(toRecordId(instance.entityDefinitionId, instance.id), {
+      first_name: names.firstName,
+      last_name: names.lastName ?? null,
+    })
+
+    logger.info('Repaired contact name from a resolved participant name', {
+      organizationId,
+      entityInstanceId,
+    })
+    return true
+  } catch (error) {
+    logger.warn('Contact name repair failed (ignored)', {
+      organizationId,
+      entityInstanceId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return false
+  }
+}

--- a/packages/lib/src/ingest/participants/display.ts
+++ b/packages/lib/src/ingest/participants/display.ts
@@ -1,5 +1,7 @@
 // packages/lib/src/ingest/participants/display.ts
 
+import { IdentifierType as IdentifierTypeEnum } from '@auxx/database/enums'
+
 /**
  * Up-to-2 initials from a name string, uppercased. Letters only.
  *
@@ -39,16 +41,51 @@ export function calculateDisplayName(
 }
 
 /**
- * Split a participant's name into first/last parts. Falls back to displayName
- * if no usable name is present.
+ * Identifier types whose value is an opaque platform id rather than a label a
+ * person would recognise — a Meta PSID/IGSID and a chat visitor's session cuid.
+ *
+ * These are excluded from the `displayName` fallback below, and that exclusion
+ * is the whole point of it. `calculateDisplayName` restates the identifier when
+ * no name is known, and `full_name` is the contact's PRIMARY DISPLAY FIELD — so
+ * the fallback wrote a 17-digit PSID into First Name and made it the record's
+ * `EntityInstance.displayName`, where nothing downstream can tell it apart from
+ * a real name. An empty name is recoverable: `resolveSocialCounterpartName`
+ * fills the participant in within seconds of the first inbound message, and
+ * `repairContactNameFromParticipant` patches a contact minted inside that
+ * window.
+ *
+ * EMAIL and PHONE deliberately KEEP the fallback. An address and a number are
+ * labels a human reads, they are what the contacts list has always shown for a
+ * nameless sender, and blanking them would leave the whole mail path nameless.
  */
-export function getNamesFromParticipant(p: { name?: string | null; displayName?: string | null }): {
+const OPAQUE_IDENTIFIER_TYPES: ReadonlySet<string> = new Set([
+  IdentifierTypeEnum.FACEBOOK_PSID,
+  IdentifierTypeEnum.INSTAGRAM_IGSID,
+  IdentifierTypeEnum.CHAT_VISITOR,
+])
+
+/**
+ * Split a participant's name into first/last parts.
+ *
+ * Falls back to `displayName` when there is no usable name — but only for the
+ * identifier types whose displayName is a human-readable label. See
+ * {@link OPAQUE_IDENTIFIER_TYPES}. An absent `identifierType` is treated as
+ * non-opaque, preserving the historical behaviour for callers that do not know
+ * it.
+ */
+export function getNamesFromParticipant(p: {
+  name?: string | null
+  displayName?: string | null
+  identifierType?: string | null
+}): {
   firstName?: string | null
   lastName?: string | null
 } {
+  const fallback =
+    p.identifierType && OPAQUE_IDENTIFIER_TYPES.has(p.identifierType) ? null : p.displayName
   const name = p.name?.trim()
-  if (!name) return { firstName: p.displayName, lastName: null }
+  if (!name) return { firstName: fallback, lastName: null }
   const parts = name.split(' ').filter(Boolean)
-  if (parts.length <= 1) return { firstName: parts[0] || p.displayName, lastName: null }
+  if (parts.length <= 1) return { firstName: parts[0] || fallback, lastName: null }
   return { firstName: parts.slice(0, -1).join(' '), lastName: parts[parts.length - 1] }
 }

--- a/packages/lib/src/providers/social/__tests__/profile.test.ts
+++ b/packages/lib/src/providers/social/__tests__/profile.test.ts
@@ -16,9 +16,10 @@ import { buildSocialDisplayName, resolveSocialCounterpartName } from '../profile
  * call at all — that lookup IS the cache.
  */
 
-const { getChannelTokens, findOrCreateParticipant } = vi.hoisted(() => ({
+const { getChannelTokens, findOrCreateParticipant, repairContactName } = vi.hoisted(() => ({
   getChannelTokens: vi.fn(),
   findOrCreateParticipant: vi.fn(),
+  repairContactName: vi.fn(),
 }))
 
 vi.mock('../../channel-token-accessor', () => ({ getChannelTokens }))
@@ -27,6 +28,10 @@ vi.mock('../../../participants/participant-service', () => ({
   ParticipantService: class {
     findOrCreateParticipant = findOrCreateParticipant
   },
+}))
+
+vi.mock('../../../ingest/contacts/repair-name', () => ({
+  repairContactNameFromParticipant: repairContactName,
 }))
 
 /** Queue one array per `select(...).from(...).where(...).limit(...)` in order. */
@@ -58,12 +63,14 @@ beforeEach(() => {
   fetchMock.mockReset()
   getChannelTokens.mockReset()
   findOrCreateParticipant.mockReset()
+  repairContactName.mockReset()
+  repairContactName.mockResolvedValue(false)
   getChannelTokens.mockResolvedValue({
     accessToken: 'page-token',
     refreshToken: null,
     expiresAt: null,
   })
-  findOrCreateParticipant.mockResolvedValue({ id: 'participant_1' })
+  findOrCreateParticipant.mockResolvedValue({ id: 'participant_1', entityInstanceId: null })
 })
 
 afterEach(() => {
@@ -203,7 +210,7 @@ describe('resolveSocialCounterpartName', () => {
   })
 
   it('spends no Graph call when the participant already has a name', async () => {
-    const db = fakeDb([[{ name: 'Ada Lovelace' }]])
+    const db = fakeDb([[{ name: 'Ada Lovelace', entityInstanceId: null }]])
 
     await expect(
       resolveSocialCounterpartName(db, { ...base, platform: 'facebook' })
@@ -213,9 +220,51 @@ describe('resolveSocialCounterpartName', () => {
     expect(findOrCreateParticipant).not.toHaveBeenCalled()
   })
 
+  // The contact is minted on the first outbound reply, which can land before
+  // Graph answers — so the record keeps the raw PSID while the participant gets
+  // the name. Nothing else in the system ever revisits it.
+  it('repairs the linked contact after resolving a name', async () => {
+    fetchMock.mockResolvedValue(graphOk({ first_name: 'Ada', last_name: 'Lovelace' }))
+    findOrCreateParticipant.mockResolvedValue({
+      id: 'participant_1',
+      entityInstanceId: 'contact_1',
+    })
+    const db = fakeDb([[{ name: null, entityInstanceId: 'contact_1' }], [{ inboxId: 'inbox_1' }]])
+
+    await resolveSocialCounterpartName(db, { ...base, platform: 'facebook' })
+
+    expect(repairContactName).toHaveBeenCalledWith(db, {
+      organizationId: 'org_1',
+      entityInstanceId: 'contact_1',
+      identifier: '27893553143563440',
+      name: 'Ada Lovelace',
+    })
+  })
+
+  // The name can arrive from the backfill's conversation edge instead of from
+  // here, in which case this early return is the ONLY place that ever sees both
+  // a named participant and its unnamed contact.
+  it('repairs the linked contact even when the participant was already named', async () => {
+    const db = fakeDb([[{ name: 'Ada Lovelace', entityInstanceId: 'contact_1' }]])
+
+    await expect(
+      resolveSocialCounterpartName(db, { ...base, platform: 'facebook' })
+    ).resolves.toBeUndefined()
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(repairContactName).toHaveBeenCalledWith(db, {
+      organizationId: 'org_1',
+      entityInstanceId: 'contact_1',
+      identifier: '27893553143563440',
+      name: 'Ada Lovelace',
+    })
+  })
+
   it('does NOT treat the raw id stored as a name as "already named"', async () => {
     fetchMock.mockResolvedValue(graphOk({ first_name: 'Ada', last_name: 'Lovelace' }))
-    const db = fakeDb([[{ name: '27893553143563440' }], [{ inboxId: 'inbox_1' }]])
+    const db = fakeDb([
+      [{ name: '27893553143563440', entityInstanceId: null }],
+      [{ inboxId: 'inbox_1' }],
+    ])
 
     await expect(resolveSocialCounterpartName(db, { ...base, platform: 'facebook' })).resolves.toBe(
       'Ada Lovelace'

--- a/packages/lib/src/providers/social/profile.ts
+++ b/packages/lib/src/providers/social/profile.ts
@@ -4,6 +4,7 @@ import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
 import { identifierTypeForProvider } from '../../channels/capabilities'
+import { repairContactNameFromParticipant } from '../../ingest/contacts/repair-name'
 import { ParticipantService } from '../../participants/participant-service'
 import { getChannelTokens } from '../channel-token-accessor'
 import { type GraphUserProfile, getUserProfile } from './api'
@@ -115,7 +116,10 @@ export async function resolveSocialCounterpartName(
     }
 
     const [existing] = await db
-      .select({ name: schema.Participant.name })
+      .select({
+        name: schema.Participant.name,
+        entityInstanceId: schema.Participant.entityInstanceId,
+      })
       .from(schema.Participant)
       .where(
         and(
@@ -126,7 +130,20 @@ export async function resolveSocialCounterpartName(
       )
       .limit(1)
 
-    if (existing && hasResolvedName(existing.name, counterpartId)) return undefined
+    if (existing && hasResolvedName(existing.name, counterpartId)) {
+      // Named already, so no Graph call — but the CONTACT may still not be. A
+      // participant can acquire its name from the backfill's conversation edge
+      // rather than from here, in which case this early return is the only place
+      // that ever sees both halves. The repair is one indexed point-read that
+      // exits immediately once the record carries a real name.
+      await repairContactNameFromParticipant(db, {
+        organizationId,
+        entityInstanceId: existing.entityInstanceId,
+        identifier: counterpartId,
+        name: existing.name!.trim(),
+      })
+      return undefined
+    }
 
     const tokens = await getChannelTokens(integrationId)
     if (!tokens.accessToken) {
@@ -154,10 +171,23 @@ export async function resolveSocialCounterpartName(
 
     const inboxId = args.inboxId ?? (await resolveInboxId(db, integrationId))
     const participantService = new ParticipantService(organizationId, db)
-    await participantService.findOrCreateParticipant(
+    const participant = await participantService.findOrCreateParticipant(
       { identifier: counterpartId, identifierType, name },
       { inboxId }
     )
+
+    // A contact may already exist for this participant, minted before the name
+    // was known — selective mode creates one on the first outbound reply, which
+    // can land seconds after the inbound message that triggered this lookup and
+    // long before Graph answers. Ingest names such a contact from a participant
+    // that had none, and nothing else ever revisits it, so the record keeps the
+    // raw PSID/IGSID forever. This is the write that closes that window.
+    await repairContactNameFromParticipant(db, {
+      organizationId,
+      entityInstanceId: participant.entityInstanceId,
+      identifier: counterpartId,
+      name,
+    })
 
     logger.info('Resolved Meta counterpart display name', { platform, integrationId })
     return name


### PR DESCRIPTION
A Facebook/Instagram contact could end up permanently called `27893553143563440` — the raw PSID as its First Name, and therefore as the record's name everywhere. Found on a live dev thread; one contact was in that state.

Two independent causes, both here.

## 1. Ingest laundered the identifier into a name

`getNamesFromParticipant` fell back to `Participant.displayName` whenever no name was known — and for a nameless participant `displayName` **is** the identifier restated (`calculateDisplayName`'s `^\+?\d+$` branch returns the digits verbatim). Since `full_name` is the contact's primary display field, that PSID became `EntityInstance.displayName`, where nothing downstream can tell it apart from a real name.

The fallback is now skipped for the opaque identifier types — `FACEBOOK_PSID`, `INSTAGRAM_IGSID`, `CHAT_VISITOR`.

`EMAIL` and `PHONE` **keep** it, deliberately. An address and a phone number are labels a human reads, they are what the contacts list has always shown for a nameless sender, and blanking them would leave the whole mail path nameless. That is why this is a per-type rule and not a blanket "never write the identifier".

## 2. Nothing repaired the contact once the name arrived

Fixing the fallback alone is not enough, because the two writes race on different clocks:

| | |
|---|---|
| `18:41` | webhook creates the participant — Meta's messaging payload carries only `sender.id`, no name |
| `19:15` | first outbound reply → `selective` mode mints the contact from a **nameless** participant |
| `19:44` | `resolveSocialCounterpartName` finally lands "Markus Klooth" — **on the participant only** |

Name resolution writes `Participant` and nothing else, so the record kept the id forever.

`repairContactNameFromParticipant` (new, `ingest/contacts/repair-name.ts`) closes the window from the other side. It runs on **both** exits of the resolver:

- after a fresh Graph lookup, and
- on the *already-named* early return — because the name can arrive from the backfill's conversation edge rather than from the webhook, in which case that early return is the only place that ever sees both a named participant and its unnamed contact.

### It writes the root, not the denormalization

`full_name` (type `NAME`) is composed at read time from `first_name`/`last_name` — `resolveNameFieldValues`: *"NAME is composed, not stored — there is no FieldValue row behind it."* `EntityInstance.displayName` is denormalized from the same two sources by `resolveNameFieldDisplayValue`. So the repair writes `first_name`/`last_name` through `UnifiedCrudHandler` and never touches `displayName`; the handler is also what emits `record:updated`, the lane that flips open mail lists without a refetch.

Other guarantees:

- **Upgrade-only.** Gated on `usableContactName` — the same test the mail label resolver uses, so a display value equal to the identifier is not a name. Anything that passes is left alone.
- **Never throws.** Every caller is a post-200 `after()` hook; a failed repair costs a stale label, not a retried webhook delivery.
- **Skips archived records.** `Participant.entityInstanceId` is not cleared on archival, and repairing an archived contact would resurrect it into every list filtering on `archivedAt IS NULL`.
- **Lazy-imports the handler**, per the precedent documented on `publishParticipantPatch`: a static edge from a provider module into `UnifiedCrudHandler` widens the graph into the org-cache cycle and breaks `vi.mock` interception in lib tests.

## Verification

Run against the real dev row, not just mocks:

```
before:  displayName = "27893553143563440"
repaired: true
after:   displayName = "Markus Klooth"
         FieldValue first_name = 'Markus', last_name = 'Klooth'   ← root written
         FieldValue full_name  = none                             ← composed, no row
re-run:  repaired: false                                          ← idempotent
```

`record:updated` was published on the records room as expected.

## Tests

- `find-or-create-names.test.ts` (new, 6) — the per-type rule through contact creation: no laundering for the three opaque types, EMAIL/PHONE unchanged, resolved names still split normally.
- `repair-name.test.ts` (new, 7) — upgrade-only, blank-record repair, archived/missing/unlinked no-ops, write failures swallowed.
- `profile.test.ts` (+2) — the repair fires on both resolver exits.

All 468 tests across `src/ingest`, `src/participants`, `src/providers/social` pass; lint and typecheck clean.

## Not in scope

Two adjacent findings, deliberately left out:

- **12 FB messages carry `hasAttachments = true` with zero `Attachment` rows** — an expired AWS credential during a dev backfill (`S3 putObject failed: Token is expired`), 12 log errors matching 12 rows exactly. Environmental, and the owner has confirmed it will not occur in production. Worth knowing that a lost attachment is currently permanent: ingest swallows the failure by design, the backfill is marked complete, and incremental sync stops at conversations newer than `lastSyncedAt`, so nothing revisits it. A manual channel sync with `days >= 1` repairs them.
- **A `NAME` field write does not decompose into its source fields.** `full_name` is `isUpdatable`, and a write stores a json `FieldValue` that no read path consults — it only sets `displayName` once. One dev contact is already divergent: `displayName = "Chicago Person"` from a typed Name edit while the Name field itself renders `first_name = "+18325525397"`. Opposite direction from this PR and generic to every `NAME` field on every resource, so it needs its own change.