### PR TITLE
fix(rules): move rule card badges to the card footer

### DIFF
--- a/apps/web/src/components/rules/ui/rule-list-section.tsx
+++ b/apps/web/src/components/rules/ui/rule-list-section.tsx
@@ -50,7 +50,7 @@ export interface RuleListSectionProps<R extends RuleListRow> {
   subtitle: (row: R) => ReactNode
   /** Card description line. */
   describe: (row: R) => string
-  /** Header-end chips, e.g. "Managed" / "Disabled". */
+  /** Footer chips, e.g. "Managed" / "Disabled". */
   badges?: (row: R) => ListCardBadgeChip[]
   /**
    * Rows that can't be edited or deleted (feature-provisioned). Their menu drops
@@ -155,7 +155,7 @@ export function RuleListSection<R extends RuleListRow>({
         subtitle={subtitle(row)}
         description={describe(row)}
         icon={<Icon className='size-4' />}
-        headerEnd={chips.length > 0 ? renderBadgeChips(chips) : undefined}
+        badges={chips.length > 0 ? renderBadgeChips(chips) : undefined}
         onClick={() => (locked ? onViewRuns(row) : onEdit(row))}
         menuItems={menuItems}
       />


### PR DESCRIPTION
## What

Mail filter and record rule cards rendered their status chips (`Suggested` / `Stops here` / `Disabled`, `Managed` / `Disabled`) in the title row's top-right `headerEnd` slot. They now go through `ListCard`'s `badges` slot, so they sit in the card footer like every other card grid in the app.

Both sections render through `RuleListSection`, so this is a single change in the shared component — no other consumers.

## Note

Cards that have chips now always render a footer, which moves the three-dot menu from its floating bottom-right position into the footer row beside the badges. Cards without chips (most enabled rules) keep the floating menu, so menu placement varies per card within a grid. Happy to always emit a footer node if we want that uniform.

The mail-filter order number stays as the leading badge inside the title — that's `leadingBadge`, not a chip.