### PR TITLE
feat(billing): turn on ai + procedure feature gates by default

### DIFF
--- a/packages/seed/src/domains/billing.domain.ts
+++ b/packages/seed/src/domains/billing.domain.ts
@@ -155,25 +155,25 @@ const BOOLEAN_GATES = {
     unverifiedApps: false,
     kopilot: true,
     callRecordings: false,
-    todayInbox: false,
-    learnedMemory: false,
-    // Duplicate suggestions. `false` on every tier while the engine rolls out —
-    // flipped per-org through the admin feature override. A missing key reads as
-    // no-access on both the server (`FeaturePermissionService.hasAccess`) and the
-    // client (`useFeatureFlags().hasAccess`), so orgs whose cached feature blob
-    // predates this seed behave identically to a seeded `false`.
-    duplicateDetection: false,
+    todayInbox: true,
+    learnedMemory: true,
+    // Duplicate suggestions. On for every tier now that the engine has rolled out.
+    // A missing key still reads as no-access on both the server
+    // (`FeaturePermissionService.hasAccess`) and the client
+    // (`useFeatureFlags().hasAccess`), so an org whose plan row predates this seed
+    // stays off until "Update Feature Limits" is pressed on /admin/plans — turning it
+    // off again for a single org is an admin feature override, not a seed change.
+    duplicateDetection: true,
     agents: true,
-    agentProcedures: false,
-    mcp: false,
+    agentProcedures: true,
+    mcp: true,
     dataConnectors: true,
     dashboards: true,
-    dispatch: false,
-    // Sequences is metered by `sequencesLimit`, not bundled with `dispatch` — the
-    // dispatch-triggered client-notification templates stay unreachable without the
-    // `dispatch` gate (see client-notifications-settings-page.tsx, which requires
-    // both), but manual/CRM outbound cadences are the general-purpose half and demo
-    // should show them off.
+    dispatch: true,
+    // Sequences is metered by `sequencesLimit`, not bundled with `dispatch`. Demo
+    // now carries both gates, so the dispatch-triggered client-notification templates
+    // are reachable here too (see client-notifications-settings-page.tsx, which
+    // requires both) alongside the manual/CRM outbound cadences.
     sequences: true,
     // Demo carried `mailPermissions: true` before plan v3/03 §7.6 folded that key
     // into this one, so the demo org keeps demoing sharing (D9).
@@ -195,12 +195,12 @@ const BOOLEAN_GATES = {
     unverifiedApps: true,
     kopilot: true,
     callRecordings: false,
-    todayInbox: false,
-    learnedMemory: false,
-    duplicateDetection: false,
+    todayInbox: true,
+    learnedMemory: true,
+    duplicateDetection: true,
     agents: true,
-    agentProcedures: false,
-    mcp: false,
+    agentProcedures: true,
+    mcp: true,
     dataConnectors: true,
     dashboards: true,
     dispatch: false,
@@ -221,12 +221,12 @@ const BOOLEAN_GATES = {
     unverifiedApps: true,
     kopilot: true,
     callRecordings: false,
-    todayInbox: false,
-    learnedMemory: false,
-    duplicateDetection: false,
+    todayInbox: true,
+    learnedMemory: true,
+    duplicateDetection: true,
     agents: true,
-    agentProcedures: false,
-    mcp: false,
+    agentProcedures: true,
+    mcp: true,
     dataConnectors: true,
     dashboards: true,
     dispatch: false,
@@ -248,12 +248,12 @@ const BOOLEAN_GATES = {
     unverifiedApps: true,
     kopilot: true,
     callRecordings: false,
-    todayInbox: false,
-    learnedMemory: false,
-    duplicateDetection: false,
+    todayInbox: true,
+    learnedMemory: true,
+    duplicateDetection: true,
     agents: true,
-    agentProcedures: false,
-    mcp: false,
+    agentProcedures: true,
+    mcp: true,
     dataConnectors: true,
     dashboards: true,
     dispatch: true,
@@ -274,12 +274,12 @@ const BOOLEAN_GATES = {
     unverifiedApps: true,
     kopilot: true,
     callRecordings: false,
-    todayInbox: false,
-    learnedMemory: false,
-    duplicateDetection: false,
+    todayInbox: true,
+    learnedMemory: true,
+    duplicateDetection: true,
     agents: true,
-    agentProcedures: false,
-    mcp: false,
+    agentProcedures: true,
+    mcp: true,
     dataConnectors: true,
     dashboards: true,
     dispatch: true,


### PR DESCRIPTION
## What

Flips five boolean gates in `BOOLEAN_GATES` (`packages/seed/src/domains/billing.domain.ts`) from `false` to `true` on **every** plan tier, plus one demo-only flip:

| Key | demo | free | starter | growth | enterprise |
|---|---|---|---|---|---|
| `duplicateDetection` | ✓ | ✓ | ✓ | ✓ | ✓ |
| `learnedMemory` | ✓ | ✓ | ✓ | ✓ | ✓ |
| `todayInbox` | ✓ | ✓ | ✓ | ✓ | ✓ |
| `agentProcedures` | ✓ | ✓ | ✓ | ✓ | ✓ |
| `mcp` | ✓ | ✓ | ✓ | ✓ | ✓ |
| `dispatch` | ✓ (new) | ✗ | ✗ | ✓ | ✓ |

## Why

All five are fully shipped — engine, jobs, routers and UI — and were only seeded `false` while they rolled out. `dispatch` on demo lets the demo org show work orders and the dispatch-triggered client-notification templates.

**No feature keys are removed.** Every gate still exists and is still enforced; only the seeded default changes.

## Rollout

No data migration. Editing this file alone does nothing for existing plan rows — apply it with the **"Update Feature Limits"** button on `/admin/plans` (`admin.plans.updatePlanFeatureLimits` → `BillingDomain.updateFeatureLimitsOnly`), which reads `PLAN_DEFINITIONS` directly, matches plans by name, and then invalidates `plans`/`planMap` and flushes `features`/`subscription`/`overages` for every org.

Two things to know before pressing it:

- It overwrites `featureLimits` wholesale, plus `trialFeatureLimits` and `shopifyPlanHandle` — hand-edits made in the plan editor on the five seeded plans are discarded.
- It matches on `Plan.name`, so custom/renamed plans get nothing.

`apps/web` dynamic-imports `@auxx/seed`, whose `import` condition resolves to `dist/index.mjs`, so the button only sees this after seed rebuilds (automatic under `pnpm dev` and in the Docker build).

Per-plan **Edit → Update** will *not* apply this — that form loads `plan.featureLimits` from the DB row and writes it back unchanged.

## Also

Refreshed two comments that the flips made untrue: the `duplicateDetection` block still said "false on every tier while the engine rolls out", and demo's `sequences` note explained why the client-notification templates were unreachable *because* demo lacked `dispatch`.

## Not in this PR

- `FeatureKey.agentProcedures` still labels itself "(beta)" in `FEATURE_REGISTRY` (`packages/lib/src/permissions/types.ts`). That string is user-visible.
- Free now has `agentProcedures: true` but `agentsLimit: 0`, so there is nothing to attach a procedure to on that tier.