### PR TITLE
fix(ci): clear the typecheck and test-count ratchets on main

### DIFF
--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/list-app-blocks.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/list-app-blocks.test.ts
@@ -67,7 +67,7 @@ const installedApps = vi.fn(async (..._a: unknown[]) => [
 ])
 
 /** The global marketplace cache — no org scope, no DB read. */
-const publishedApps = vi.fn(async () => [
+const publishedApps = vi.fn(async (..._a: unknown[]) => [
   { id: 'appfedex', slug: 'fedex', title: 'Fedex', description: 'Track FedEx shipments' },
   { id: 'apphubspot-v2', slug: 'hubspot', title: 'HubSpot', description: 'CRM' },
   { id: 'appups', slug: 'ups', title: 'UPS', description: 'Track UPS shipments' },

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
@@ -166,7 +166,7 @@ const installedApps = vi.fn(async (..._a: unknown[]) => [
   },
 ])
 /** The global marketplace catalog `list_app_blocks` offers as installable. */
-const publishedApps = vi.fn(async () => [
+const publishedApps = vi.fn(async (..._a: unknown[]) => [
   { id: 'appfedex', slug: 'fedex', title: 'Fedex', description: 'Track FedEx shipments' },
   { id: 'appups', slug: 'ups', title: 'UPS', description: 'Track UPS shipments' },
 ])

--- a/packages/lib/src/connections/__tests__/pending-selection.test.ts
+++ b/packages/lib/src/connections/__tests__/pending-selection.test.ts
@@ -18,7 +18,7 @@ const captured: { sets: unknown[]; selects: unknown[] } = { sets: [], selects: [
 
 /** Controllable per-test: what the superseded-credential reference check finds. */
 const { integrationFindFirst, deleteCredential } = vi.hoisted(() => ({
-  integrationFindFirst: vi.fn(async (): Promise<unknown> => undefined),
+  integrationFindFirst: vi.fn(async (_args?: unknown): Promise<unknown> => undefined),
   deleteCredential: vi.fn(async () => ({ isErr: () => false })),
 }))
 

--- a/packages/lib/src/connections/__tests__/post-connect-hooks.test.ts
+++ b/packages/lib/src/connections/__tests__/post-connect-hooks.test.ts
@@ -19,7 +19,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  */
 
 const { publish, getRealtimeService } = vi.hoisted(() => {
-  const publish = vi.fn(async () => true)
+  const publish = vi.fn(async (_room: string, _event: string, _payload: unknown) => true)
   return { publish, getRealtimeService: vi.fn(() => ({ publish })) }
 })
 

--- a/packages/lib/src/ingest/contacts/identity-candidate.ts
+++ b/packages/lib/src/ingest/contacts/identity-candidate.ts
@@ -1,8 +1,10 @@
 // packages/lib/src/ingest/contacts/identity-candidate.ts
 
-import type { IdentifierTypeValue } from '@auxx/database/enums'
 import { IdentifierType as IdentifierTypeEnum } from '@auxx/database/enums'
-import type { ParticipantEntity as Participant } from '@auxx/database/types'
+import type {
+  IdentifierType as IdentifierTypeValue,
+  ParticipantEntity as Participant,
+} from '@auxx/database/types'
 import { formatPhoneNumber } from '@auxx/utils'
 import { metaExternalId } from './external-id'
 

--- a/packages/lib/src/providers/social/__tests__/attachments.test.ts
+++ b/packages/lib/src/providers/social/__tests__/attachments.test.ts
@@ -18,7 +18,7 @@ import {
 const CONTEXT = { platform: 'facebook' as const, messageId: 'msg_1' }
 
 function response(body: Buffer, headers: Record<string, string>, status = 200): Response {
-  return new Response(body, { status, headers })
+  return new Response(new Uint8Array(body), { status, headers })
 }
 
 afterEach(() => {

--- a/scripts/ci/test-count-baseline.json
+++ b/scripts/ci/test-count-baseline.json
@@ -466,7 +466,7 @@
     "packages/lib/src/conditions/evaluate.test.ts": 16,
     "packages/lib/src/conditions/operator-definitions.test.ts": 25,
     "packages/lib/src/connections/__tests__/auth-apply.test.ts": 15,
-    "packages/lib/src/connections/__tests__/platform-auth-apply.test.ts": 20,
+    "packages/lib/src/connections/__tests__/platform-auth-apply.test.ts": 18,
     "packages/lib/src/connections/__tests__/resolve-provider-key.test.ts": 7,
     "packages/lib/src/connections/__tests__/save-connection.test.ts": 6,
     "packages/lib/src/connections/transports/__tests__/http-pacing.test.ts": 7,


### PR DESCRIPTION
Three CI steps have been red on main since yesterday's merges ([run 32284850748](https://github.com/Auxx-Ai/auxx-ai/actions/runs/32284850748)). **None of them was a failing test** — all 1109 test files pass. Two of the three lanes were the typecheck ratchet; the third was the test-count ratchet catching a deliberate deletion.

## The one real source error

`packages/lib/src/ingest/contacts/identity-candidate.ts` imported a type named `IdentifierTypeValue` from `@auxx/database/enums`. That name has never existed there — the enums module exports `IdentifierTypeValues` (the `as const` array) and `IdentifierType` (the const object). It's a type-only import, so nothing broke at runtime; it just kept **both** the lib and the web lane red (this was web's only error). Now points at the `IdentifierType` type in `@auxx/database/types`, folded into the import already there.

## The six test-file errors

All the same shape: a `vi.fn` declared with no parameters, then called or indexed as if it had some. Vitest types `mock.calls[0]` as `[]` for a zero-arg mock.

| File | Fix |
| --- | --- |
| `list-app-blocks.test.ts`, `workflow-authoring-guard.test.ts` | `publishedApps` takes `(..._a: unknown[])`, so the `vi.mock` factory has somewhere to spread — matching `installedApps` directly above it in both files |
| `pending-selection.test.ts` | `integrationFindFirst` takes `(_args?: unknown)`, so `mock.calls[0]?.[0]` is indexable |
| `post-connect-hooks.test.ts` | `publish` declares `(_room, _event, _payload)`, which is exactly what its three `calls[0] as [string, string, any]` casts already assumed |
| `attachments.test.ts` | `new Response(new Uint8Array(body))` — Node's `Buffer<ArrayBufferLike>` isn't in `BodyInit` |

No behaviour changes: every assertion is untouched, only the mock signatures the assertions were already written against.

## The test-count ratchet

`platform-auth-apply.test.ts  20 -> 18`. This one caught a real deletion rather than the collection failure the ratchet exists for. The file derives its cases from the registry — `1 + PLATFORM_PROVIDER_DEFS.filter(d => d.authApply).length` — and #1700 ("delete dead facebook/instagram defs") removed `facebookOAuth2Api` and `instagramOAuth2Api`, both carrying `authApply: BEARER`. 18 is the correct count, so the baseline is re-recorded. Recorded via the script's own `--update` against a scoped run, so its merge semantics changed exactly that one line.

## Verification

- `node scripts/ci/typecheck-ratchet.js --package lib` → `no new type errors (29 total, baseline 29)`
- `node scripts/ci/typecheck-ratchet.js --package web` → `no new type errors (0 total, baseline 0)`
- The 6 affected test files: 101 tests, all passing
- Biome clean

The full lib suite was not run locally (~19 min); CI covers it here.
