### PR TITLE
fix(build): unblock app review submission on connection oauth checks

### DIFF
--- a/apps/build/src/components/apps/publish-app-dialog.tsx
+++ b/apps/build/src/components/apps/publish-app-dialog.tsx
@@ -21,6 +21,7 @@ import {
   type ConnectionForPublishCheck,
   isConnectionsConfigComplete,
   isMainAppListingComplete,
+  isMintingConnection,
   isOAuthConfigComplete,
 } from '~/lib/publish-checks'
 import { api, type RouterOutputs } from '~/trpc/react'
@@ -281,13 +282,12 @@ export function PublishAppDialog({
     oauth2AccessTokenUrl: c.oauth2AccessTokenUrl,
     hasClientId: c.hasClientId,
     hasClientSecret: c.hasClientSecret,
-    oauth2Scopes: c.oauth2Scopes,
   }))
 
   // Compute checklist states
   const isListingComplete = publishCheckApp ? isMainAppListingComplete(publishCheckApp) : false
   const isOAuthComplete = publishCheckApp ? isOAuthConfigComplete(publishCheckApp) : false
-  const hasOAuthConnections = connectionCheckData.some((c) => c.connectionType === 'oauth2-code')
+  const hasMintingConnections = connectionCheckData.some(isMintingConnection)
   const isConnectionsComplete = isConnectionsConfigComplete(connectionCheckData)
   const hasDeploymentOrOAuth = hasProdDeployment || Boolean(app?.hasOauth)
 
@@ -313,8 +313,8 @@ export function PublishAppDialog({
           },
         ]
       : []),
-    // Only show connection OAuth check if at least one oauth2-code connection exists
-    ...(hasOAuthConnections
+    // Only show the connection check when a connection actually mints tokens
+    ...(hasMintingConnections
       ? [
           {
             id: 'connection-oauth',

--- a/apps/build/src/lib/publish-checks.ts
+++ b/apps/build/src/lib/publish-checks.ts
@@ -81,19 +81,32 @@ export interface ConnectionForPublishCheck {
   // Presence-only — credential values never ship on the list path
   hasClientId: boolean
   hasClientSecret: boolean
-  oauth2Scopes: string[] | null
+}
+
+/**
+ * Whether a connection mints its own tokens and therefore needs OAuth validation before publish.
+ * Types 'secret' and 'none' carry no OAuth config. Keep every publish surface on this predicate —
+ * a checklist row that disagrees with it blocks submission with nothing on screen to explain why.
+ */
+export function isMintingConnection(connection: ConnectionForPublishCheck): boolean {
+  return (
+    connection.connectionType === 'oauth2-code' ||
+    connection.connectionType === 'client-credentials'
+  )
 }
 
 /**
  * Check that all token-minting connections (oauth2-code, client-credentials) are fully configured.
  * Connections with type 'secret' or 'none' require no validation. `client-credentials` mints with
  * no browser step, so it needs the same fields as oauth2-code minus the Authorize URL.
+ *
+ * Scopes are deliberately NOT required: plenty of providers (UPS among them) take no scope on the
+ * authorize request, and the connections form already treats the field as optional. Demanding one
+ * here only forced developers to invent a placeholder that then gets sent to the provider.
  * @returns true if no minting connections exist, or all are properly configured
  */
 export function isConnectionsConfigComplete(connections: ConnectionForPublishCheck[]): boolean {
-  const mintingConnections = connections.filter(
-    (c) => c.connectionType === 'oauth2-code' || c.connectionType === 'client-credentials'
-  )
+  const mintingConnections = connections.filter(isMintingConnection)
   if (mintingConnections.length === 0) return true
 
   return mintingConnections.every((c) => {
@@ -104,7 +117,6 @@ export function isConnectionsConfigComplete(connections: ConnectionForPublishChe
       oauth2AccessTokenUrl: isValidStringField(c.oauth2AccessTokenUrl),
       oauth2ClientId: c.hasClientId,
       oauth2ClientSecret: c.hasClientSecret,
-      oauth2Scopes: (c.oauth2Scopes ?? []).length > 0,
     }
     return Object.values(checks).every((check) => check)
   })


### PR DESCRIPTION
## Problem

Two issues in the build portal's publish checklist (`PublishAppDialog`) prevented apps from being submitted for review, in one case with nothing on screen explaining why.

**1. `client-credentials` connections were invisible to the checklist.** The `connection-oauth` row rendered only when `connectionType === 'oauth2-code'`, but `isConnectionsConfigComplete` validates both `oauth2-code` *and* `client-credentials`. An app whose only minting connection was `client-credentials` had `canSubmitForReview === false` with no unchecked row pointing at the cause.

**2. The check required at least one OAuth scope.** The connections form already labels the field *"Comma-separated, optional"* and its `.refine` doesn't validate it — the publish gate was the only place demanding it. Providers that take no scope on the authorize request (UPS is one) could never satisfy it except by entering a placeholder, which then gets sent to the provider.

## Changes

- Export `isMintingConnection` from `publish-checks.ts` and use it for both the checklist row and `isConnectionsConfigComplete`, so the displayed reason and the submit gate can't drift apart again.
- Drop the `oauth2Scopes` requirement from `isConnectionsConfigComplete`, plus the now-unused `oauth2Scopes` field on `ConnectionForPublishCheck` and its mapping in the dialog. The column itself is untouched — form, router, and DB are unchanged.

## Verification

- `apps/build` typechecks clean (`tsc --noEmit`, exit 0)
- Biome clean
- No existing tests reference `publish-checks`

Verified against the UPS app, which prompted this: its connection has authorize URL, token URL, client ID and client secret, and an empty `oauth2Scopes` array — so it was blocked solely on the scope requirement. All four remaining sub-checks now pass. Submission still depends on the other gates in `canSubmitForReview` (`isListingComplete`, and `hasProdDeployment || (hasOauth && isOAuthComplete)`), which this PR doesn't change.