### PR TITLE
fix(kopilot): make the whole composer box focus the editor on click

### DIFF
--- a/apps/web/src/components/kopilot/ui/kopilot-composer.tsx
+++ b/apps/web/src/components/kopilot/ui/kopilot-composer.tsx
@@ -497,7 +497,15 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
           )}
           <EditorContent
             editor={editor}
-            className={cn('w-full flex flex-col px-3 py-2 text-sm flex-1 [&>.prose]:flex-1')}
+            className={cn(
+              'w-full flex flex-col text-sm flex-1',
+              // All padding lives on the ProseMirror element rather than this
+              // wrapper, so the contenteditable covers the full box and every
+              // click inside it focuses the caret instead of landing on dead
+              // gutter. `pb-9` reserves the height of the absolutely
+              // positioned toolbar below.
+              '[&>.prose]:flex-1 [&>.prose]:px-3 [&>.prose]:pt-2 [&>.prose]:pb-9'
+            )}
           />
           {/* Reference picker (@) — tabbed people/records/messages/articles */}
           {allowReferencePicker && (
@@ -567,8 +575,8 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
             </InlinePickerPopover>
           )}
         </div>
-        <div className='flex items-center justify-between p-1 '>
-          <div className='flex items-center gap-0.5 overflow-y-auto no-scrollbar overscroll-contain'>
+        <div className='pointer-events-none absolute inset-x-0 bottom-0 flex items-center justify-between p-1'>
+          <div className='pointer-events-auto flex items-center gap-0.5 overflow-y-auto no-scrollbar overscroll-contain'>
             {allowModelPicker && (
               <AiModelPicker
                 value={selectedModelId ?? systemLlmDefault}
@@ -594,7 +602,7 @@ export function KopilotComposer({ ref, page, onSend, contentClassName }: Kopilot
               />
             )}
           </div>
-          <div className='flex items-center gap-0.5 shrink-0'>
+          <div className='pointer-events-auto flex items-center gap-0.5 shrink-0'>
             {allowSlashCommands && (
               <Tooltip content='Insert prompt template' shortcut='/' allowInteraction>
                 <Button


### PR DESCRIPTION
## Problem

Clicking inside the Kopilot composer only focused the editor when you hit the text itself. Two causes:

- The toolbar row (model picker / agent picker / prompt-template / send) took flow height, so the editor's flex area stopped above it.
- `px-3 py-2` sat on the `EditorContent` **wrapper**, not on the contenteditable — so the left/right gutters and the top strip were outside ProseMirror.

Result: clicking the gutters, or the gap between the last line and the buttons, did nothing.

## Change

All in `apps/web/src/components/kopilot/ui/kopilot-composer.tsx`:

1. **Toolbar is an absolute overlay** — `pointer-events-none absolute inset-x-0 bottom-0`, with `pointer-events-auto` restored on the left and right button clusters so the empty gap between them falls through to the editor.
2. **Padding moved onto the ProseMirror element** — `[&>.prose]:px-3 [&>.prose]:pt-2`. The class hook is `.prose` because `useReferencePickerEditor` passes its `className` through `editorProps.attributes.class`.
3. **`pb-9` reserves the toolbar height** — measured, not guessed: `size='icon-sm'` is `size-7` (28px) + the bar's `p-1` (4+4) = 36px. The `AiModelPicker` trigger and both `SenderPicker` states are `h-7` too, so the row is uniform.

The contenteditable now spans the full interior of the rounded border, so every click inside places the caret.

## Notes

- The locked `SenderPicker` chip already carried `pointer-events-none`, so clicks on a pinned-responder chip now fall through and focus the editor instead of doing nothing. Intentional, but easy to revert if that reads wrong.
- `kopilot-composer.tsx` is shared by all four Kopilot surfaces — full page (`/app/kopilot/...`), the global dock, the workflow builder drawer, and the agent docked chat. Worth eyeballing the dock at its narrow width, where the two toolbar clusters sit closest together.

## Testing

CSS-only change; no logic touched. Verify by clicking the gutters and the strip above the toolbar in each of the four surfaces.