### PR TITLE
feat(workflow): add builder-specific kopilot empty-chat suggestions

### DIFF
--- a/apps/web/src/components/workflow/panels/kopilot/workflow-kopilot-panel.tsx
+++ b/apps/web/src/components/workflow/panels/kopilot/workflow-kopilot-panel.tsx
@@ -16,6 +16,7 @@ import { useFreshSessionEstablished } from '~/components/kopilot/hooks/use-fresh
 import { KopilotChatProvider } from '~/components/kopilot/options'
 import { KopilotChat } from '~/components/kopilot/ui/kopilot-chat'
 import { SparkleIcon } from '~/components/kopilot/ui/sparkle-icon'
+import { WorkflowKopilotSuggestions } from '~/components/workflow/panels/kopilot/workflow-kopilot-suggestions'
 import { PanelFrameHeader } from '~/components/workflow/panels/panel-frame-chrome'
 import { usePanelStore } from '~/components/workflow/store/panel-store'
 import { useWorkflowStore } from '~/components/workflow/store/workflow-store'
@@ -83,6 +84,10 @@ export function WorkflowKopilotPanel({ workflowAppId }: WorkflowKopilotPanelProp
           activeWorkflowIsDirty={isDirty}
         />
       )}
+      {/* Builder-shaped empty-chat prompts. Any registered slice replaces the
+          generic inbox fallback wholesale, so this must stay mounted whenever
+          the chat itself can render. */}
+      {kopilotEnabled && workflowAppId && <WorkflowKopilotSuggestions />}
       <PanelFrameHeader
         icon={<SparkleIcon className='shrink-0' />}
         title='Kopilot'

--- a/apps/web/src/components/workflow/panels/kopilot/workflow-kopilot-suggestions.tsx
+++ b/apps/web/src/components/workflow/panels/kopilot/workflow-kopilot-suggestions.tsx
@@ -1,0 +1,72 @@
+// apps/web/src/components/workflow/panels/kopilot/workflow-kopilot-suggestions.tsx
+'use client'
+
+import { useStore } from '@xyflow/react'
+import { KopilotSuggestion } from '~/components/kopilot/suggestions'
+
+/**
+ * Empty-chat suggestions for the workflow builder panel.
+ *
+ * Registration is all-or-nothing in `KopilotEmptyState`: the moment ANY slice
+ * is registered the generic fallback list ("Summarize my open tickets", …)
+ * disappears. That is why both branches below register something — a builder
+ * chat must never offer inbox prompts.
+ *
+ * Mounted inside the panel (not the editor) so the slices unregister with the
+ * frame, and only while a workflow is actually loaded.
+ */
+export function WorkflowKopilotSuggestions() {
+  // React Flow is the only owner of the node list — the workflow store cannot
+  // reach it. A `.length` selector returns a primitive, so the subscription
+  // only re-renders on add/remove, not on every drag.
+  const nodeCount = useStore((s) => s.nodes.length)
+
+  // A fresh workflow is either empty or a lone seeded trigger — nothing to
+  // explain yet, so offer build prompts instead of audit prompts.
+  const isBlank = nodeCount <= 1
+
+  if (isBlank) {
+    return (
+      <>
+        <KopilotSuggestion
+          text='Build a workflow that tags new tickets by topic'
+          icon='workflow'
+          priority={3}
+          autoSubmit
+        />
+        <KopilotSuggestion
+          text='Send a Slack alert when a high-priority ticket arrives'
+          icon='sparkle'
+          priority={2}
+          autoSubmit
+        />
+        <KopilotSuggestion
+          text='Add a trigger for when a record is created'
+          icon='plus'
+          priority={1}
+          autoSubmit
+        />
+        <KopilotSuggestion text='What can you build in a workflow?' icon='list' autoSubmit />
+      </>
+    )
+  }
+
+  return (
+    <>
+      <KopilotSuggestion
+        text='Explain what this workflow does'
+        icon='sparkle'
+        priority={3}
+        autoSubmit
+      />
+      <KopilotSuggestion
+        text='Find problems in this workflow'
+        icon='search'
+        priority={2}
+        autoSubmit
+      />
+      <KopilotSuggestion text='Add an error branch to this workflow' icon='plus' priority={1} />
+      <KopilotSuggestion text='Add a condition after the trigger' icon='workflow' />
+    </>
+  )
+}


### PR DESCRIPTION
## Problem

The workflow Kopilot panel registered no suggestion slices. `KopilotEmptyState` is **all-or-nothing** — if no surface contributes a slice it renders its generic `FALLBACK` list — so an empty builder chat was offering inbox prompts: *"Summarize my open tickets"*, *"Find contacts from California"*, *"Draft a reply to the latest email"*. None of those mean anything in a workflow builder.

## Change

New `WorkflowKopilotSuggestions`, mounted inside the panel's `KopilotChatProvider` behind the same `kopilotEnabled && workflowAppId` gate as the chat itself. It reads node count off the React Flow store and branches:

- **Blank canvas** (`nodes.length <= 1` — an empty graph, or a lone seeded trigger like the resource-trigger `WorkflowService.create` writes): build prompts — *"Build a workflow that tags new tickets by topic"*, *"Send a Slack alert when a high-priority ticket arrives"*, *"Add a trigger for when a record is created"*, *"What can you build in a workflow?"*
- **Populated graph**: explain/audit prompts — *"Explain what this workflow does"*, *"Find problems in this workflow"*, *"Add an error branch to this workflow"*, *"Add a condition after the trigger"*

Both branches deliberately register something, so the inbox fallback can never leak back into the builder.

Follows the existing distributed-slice pattern (`<KopilotSuggestion>` renders `null` and registers a store slice for its lifetime; conditional rendering at the call site *is* the registration condition) — same as `thread-display.tsx`, `record-drawer.tsx`, and the closest analogue, `agent-docked-chat.tsx`.

## Notes

- The panel sits inside `ReactFlowProvider`, so `useStore` is available. The selector returns `s.nodes.length` — a primitive, so it re-renders on add/remove only, not on every drag.
- Read-only prompts `autoSubmit`; the two that edit the graph populate the composer instead so the user can adjust before firing.

## Testing

- Biome clean.
- `tsc --noEmit` in `apps/web` reports nothing on either file.
- Not manually exercised in the running app.