### PR TITLE
feat(workflow): migrate the webhook and webhook-endpoint nodes to the catalog

### DIFF
--- a/apps/web/src/components/workflow/nodes/core/webhook-trigger/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/webhook-trigger/schema.ts
@@ -1,106 +1,31 @@
 // apps/web/src/components/workflow/nodes/core/webhook-trigger/schema.ts
 
-import { WorkflowTriggerType } from '@auxx/lib/workflow-engine/client'
-import { z } from 'zod'
-import {
-  NodeCategory,
-  type NodeDefinition,
-  type ValidationResult,
-} from '~/components/workflow/types'
-import { baseNodeDataSchema } from '~/components/workflow/types/node-base'
-import { NodeType } from '~/components/workflow/types/node-types'
-import { BaseType, type UnifiedVariable } from '~/components/workflow/types/variable-types'
-import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
+import { type NodeManifest, webhookEndpointManifest } from '@auxx/lib/workflow-engine/client'
+import type { NodeDefinition } from '~/components/workflow/types'
+import { defineFromManifest } from '../../define-from-manifest'
 import type { WebhookTriggerNodeData } from './types'
 
-/**
- * Zod schema for the webhook endpoint trigger node (flattened structure).
- */
-export const webhookTriggerNodeDataSchema = baseNodeDataSchema.extend({
-  webhookEndpointId: z.string().min(1, 'Webhook endpoint is required'),
-  // Optional — blank matches every delivery (endpoints with no topicSource extract topic '').
-  topic: z.string().default(''),
-  webhookEndpointName: z.string().optional(),
-})
-
-export const createWebhookTriggerDefaultData = (): Partial<WebhookTriggerNodeData> => ({
-  title: 'Webhook Endpoint',
-  desc: 'Select a webhook endpoint',
-  webhookEndpointId: '',
-  topic: '',
-})
-
-export const webhookTriggerDefaultData = createWebhookTriggerDefaultData()
-
-/**
- * Validate connection webhook trigger node data.
- */
-export function validateWebhookTriggerData(data: WebhookTriggerNodeData): ValidationResult {
-  try {
-    webhookTriggerNodeDataSchema.parse(data)
-    return { isValid: true, errors: [] }
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return {
-        isValid: false,
-        errors: error.issues.map((e) => ({
-          field: e.path.join('.'),
-          message: e.message,
-          type: 'error' as const,
-        })),
-      }
-    }
-    return {
-      isValid: false,
-      errors: [{ field: 'general', message: 'Invalid configuration', type: 'error' as const }],
-    }
-  }
-}
-
-/**
- * Output variables exposed by the webhook endpoint trigger: the topic, the
- * endpoint id, and the raw verified payload (`body`).
- */
-function getWebhookTriggerOutputVariables(
-  _data: WebhookTriggerNodeData,
-  nodeId: string
-): UnifiedVariable[] {
-  return [
-    createUnifiedOutputVariable({
-      nodeId,
-      path: 'topic',
-      type: BaseType.STRING,
-      description: 'The topic that fired this workflow',
-    }),
-    createUnifiedOutputVariable({
-      nodeId,
-      path: 'webhookEndpointId',
-      type: BaseType.STRING,
-      description: 'The webhook endpoint id that received the delivery',
-    }),
-    createUnifiedOutputVariable({
-      nodeId,
-      path: 'body',
-      type: BaseType.OBJECT,
-      description: 'The verified webhook payload',
-    }),
-  ]
-}
+// The data half (schema, defaults, validator, output resolver) lives in the
+// node catalog (`@auxx/lib/workflow-engine/catalog/nodes/webhook-endpoint`).
+// This file is the merge site: manifest + the React parts.
 
 /**
  * Webhook endpoint trigger node definition.
  */
-export const webhookTriggerDefinition: NodeDefinition<WebhookTriggerNodeData> = {
-  id: NodeType.WEBHOOK_ENDPOINT,
-  category: NodeCategory.TRIGGER,
-  displayName: 'Webhook Endpoint',
-  description: 'Trigger when a webhook endpoint receives a delivery',
-  icon: 'webhook',
-  color: '#10b981', // TRIGGER category color
-  schema: webhookTriggerNodeDataSchema,
-  defaultData: webhookTriggerDefaultData,
-  canRunSingle: false, // Triggers cannot be run individually
-  triggerType: WorkflowTriggerType.WEBHOOK_ENDPOINT,
-  validator: validateWebhookTriggerData,
-  outputVariables: getWebhookTriggerOutputVariables as any,
-}
+export const webhookTriggerDefinition: NodeDefinition<WebhookTriggerNodeData> = defineFromManifest(
+  webhookEndpointManifest as unknown as NodeManifest<WebhookTriggerNodeData>,
+  {}
+)
+
+// Back-compat re-exports so no consumer import churns. The catalog names them
+// after the node type (`webhook-endpoint`); the historical web names are kept
+// as aliases.
+export {
+  validateWebhookEndpointData as validateWebhookTriggerData,
+  webhookEndpointNodeDataSchema as webhookTriggerNodeDataSchema,
+} from '@auxx/lib/workflow-engine/client'
+
+export const createWebhookTriggerDefaultData = (): Partial<WebhookTriggerNodeData> =>
+  webhookEndpointManifest.defaultData() as Partial<WebhookTriggerNodeData>
+
+export const webhookTriggerDefaultData = createWebhookTriggerDefaultData()

--- a/apps/web/src/components/workflow/nodes/core/webhook-trigger/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/webhook-trigger/types.ts
@@ -1,21 +1,22 @@
 // apps/web/src/components/workflow/nodes/core/webhook-trigger/types.ts
 
-import type { BaseNodeData, SpecificNode } from '~/components/workflow/types/node-base'
+import type { CatalogWebhookEndpointNodeData } from '@auxx/lib/workflow-engine/client'
+import type { SpecificNode } from '~/components/workflow/types/node-base'
+import type { NodeType } from '~/components/workflow/types/node-types'
+
+// The data half moved to the node catalog
+// (`@auxx/lib/workflow-engine/catalog/nodes/webhook-endpoint`); this narrows
+// `type` to the web `NodeType` enum.
 
 /**
  * Data interface for the Webhook Endpoint trigger node. Fires the workflow on a verified
  * delivery to a generic inbound `WebhookEndpoint` (`webhookEndpointId`), optionally scoped
  * to a `topic`. The cached endpoint name keeps the node + panel readable without
  * re-querying. The save path persists `webhookEndpointId`/`topic` to the workflow's
- * `triggerWebhookEndpointId`/`triggerTopic` (see workflow-service `update`).
+ * `triggerWebhookEndpointId`/`triggerTopic` (see `deriveTriggerLinks`).
  */
-export interface WebhookTriggerNodeData extends BaseNodeData {
-  /** Id of the WebhookEndpoint whose deliveries fire this workflow. */
-  webhookEndpointId: string
-  /** Optional topic to scope deliveries (matched against the endpoint's extracted topic). */
-  topic: string
-  /** Cached endpoint display name (for the node label + panel). */
-  webhookEndpointName?: string
+export interface WebhookTriggerNodeData extends CatalogWebhookEndpointNodeData {
+  type: NodeType
 }
 
 /**

--- a/apps/web/src/components/workflow/nodes/core/webhook/schema.ts
+++ b/apps/web/src/components/workflow/nodes/core/webhook/schema.ts
@@ -1,143 +1,29 @@
 // apps/web/src/components/workflow/nodes/core/webhook/schema.ts
 
-import { WorkflowTriggerType } from '@auxx/lib/workflow-engine/client'
-import { z } from 'zod'
-import {
-  NodeCategory,
-  type NodeDefinition,
-  type ValidationResult,
-} from '~/components/workflow/types'
-import { baseNodeDataSchema } from '~/components/workflow/types/node-base'
-import { NodeType } from '~/components/workflow/types/node-types'
-import { BaseType, type UnifiedVariable } from '~/components/workflow/types/variable-types'
-import { schemaToUnifiedVariable } from '~/components/workflow/utils/schema-to-variable'
-import { createUnifiedOutputVariable } from '~/components/workflow/utils/variable-conversion'
+import { type NodeManifest, webhookManifest } from '@auxx/lib/workflow-engine/client'
+import type { NodeDefinition } from '~/components/workflow/types'
+import { defineFromManifest } from '../../define-from-manifest'
 import type { WebhookNodeData } from './types'
 
-/**
- * Zod schema for webhook node data (flattened structure)
- */
-export const webhookNodeDataSchema = baseNodeDataSchema.extend({
-  method: z.enum(['GET', 'POST']).default('POST'),
-  bodySchema: z
-    .object({ enabled: z.boolean().default(false), schema: z.any().optional() })
-    .optional(),
-})
-
-/**
- * Create default data for webhook node (flattened structure)
- */
-export const createWebhookDefaultData = (): Partial<WebhookNodeData> => ({
-  title: 'Webhook Trigger',
-  desc: 'Trigger workflow via HTTP webhook',
-  method: 'POST',
-  bodySchema: { enabled: false, schema: undefined },
-})
-
-export const webhookDefaultData = createWebhookDefaultData()
-
-/**
- * Validate webhook node data (flattened structure)
- */
-export function validateWebhookData(data: WebhookNodeData): ValidationResult {
-  try {
-    webhookNodeDataSchema.parse(data)
-    return { isValid: true, errors: [] }
-  } catch (error) {
-    console.error('Webhook validation error:', error)
-    if (error instanceof z.ZodError) {
-      return {
-        isValid: false,
-        errors: error.issues.map((e) => ({
-          field: e.path.join('.'),
-          message: e.message,
-          type: 'error' as const,
-        })),
-      }
-    }
-    return {
-      isValid: false,
-      errors: [{ field: 'general', message: 'Invalid configuration', type: 'error' as const }],
-    }
-  }
-}
-
-/**
- * Define output variables for webhook node (supports both config and flattened structure)
- */
-function getWebhookOutputVariables(data: WebhookNodeData, nodeId: string): UnifiedVariable[] {
-  // Support both old config structure and new flattened structure
-  // const data = 'config' in configOrData ? configOrData.config : configOrData
-  const variables: UnifiedVariable[] = []
-
-  // Method variable
-  variables.push(
-    createUnifiedOutputVariable({
-      nodeId,
-      path: 'method', // Changed from 'name' to 'path'
-      type: BaseType.STRING,
-      description: 'HTTP method of the webhook request (GET or POST)',
-    })
-  )
-
-  // Headers variable
-  variables.push(
-    createUnifiedOutputVariable({
-      nodeId,
-      path: 'headers', // Changed from 'name' to 'path'
-      type: BaseType.OBJECT,
-      description: 'HTTP headers from the webhook request',
-    })
-  )
-
-  // Query parameters
-  variables.push(
-    createUnifiedOutputVariable({
-      nodeId,
-      path: 'query', // Changed from 'name' to 'path'
-      type: BaseType.OBJECT,
-      description: 'Query parameters from the webhook URL',
-    })
-  )
-
-  // Body variable (only for POST requests)
-  if (data.method === 'POST') {
-    // If body schema is defined, use it to generate structured output variables
-    if (data.bodySchema?.enabled && data.bodySchema.schema) {
-      // schemaToUnifiedVariable now handles nested paths correctly
-      const bodyVar = schemaToUnifiedVariable(data.bodySchema.schema, nodeId, 'body')
-      bodyVar.description = 'Structured request body based on the defined schema'
-      variables.push(bodyVar)
-    } else {
-      // Otherwise, provide a generic object variable
-      variables.push(
-        createUnifiedOutputVariable({
-          nodeId,
-          path: 'body', // Changed from 'name' to 'path'
-          type: BaseType.OBJECT,
-          description: 'JSON body content from the webhook request',
-        })
-      )
-    }
-  }
-
-  return variables
-}
+// The data half (schema, defaults, validator, output resolver) lives in the
+// node catalog (`@auxx/lib/workflow-engine/catalog/nodes/webhook`). This file
+// is the merge site: manifest + the React parts.
 
 /**
  * Webhook node definition
  */
-export const webhookDefinition: NodeDefinition<WebhookNodeData> = {
-  id: NodeType.WEBHOOK,
-  category: NodeCategory.TRIGGER,
-  displayName: 'Webhook',
-  description: 'Trigger workflow via HTTP webhook',
-  icon: 'webhook',
-  color: '#10b981', // TRIGGER category color
-  schema: webhookNodeDataSchema,
-  defaultData: webhookDefaultData,
-  canRunSingle: false, // Triggers cannot be run individually
-  triggerType: WorkflowTriggerType.WEBHOOK,
-  validator: validateWebhookData,
-  outputVariables: getWebhookOutputVariables as any,
-}
+export const webhookDefinition: NodeDefinition<WebhookNodeData> = defineFromManifest(
+  webhookManifest as unknown as NodeManifest<WebhookNodeData>,
+  {}
+)
+
+// Back-compat re-exports so no consumer import churns:
+export { validateWebhookData, webhookNodeDataSchema } from '@auxx/lib/workflow-engine/client'
+
+/**
+ * Create default data for webhook node (flattened structure)
+ */
+export const createWebhookDefaultData = (): Partial<WebhookNodeData> =>
+  webhookManifest.defaultData() as Partial<WebhookNodeData>
+
+export const webhookDefaultData = createWebhookDefaultData()

--- a/apps/web/src/components/workflow/nodes/core/webhook/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/webhook/types.ts
@@ -1,7 +1,15 @@
 // apps/web/src/components/workflow/nodes/core/webhook/types.ts
 
-import type { BaseNodeData, SpecificNode } from '~/components/workflow/types/node-base'
+import type { CatalogWebhookNodeData } from '@auxx/lib/workflow-engine/client'
+import type { SpecificNode } from '~/components/workflow/types/node-base'
+import type { NodeType } from '~/components/workflow/types/node-types'
 import type { SchemaRoot } from '~/components/workflow/ui/json-schema-types'
+
+// The data half moved to the node catalog
+// (`@auxx/lib/workflow-engine/catalog/nodes/webhook`). The node data narrows
+// `type` to the web NodeType enum and `bodySchema.schema` to the schema
+// editor's `SchemaRoot` (the catalog keeps that member loose for exactly this
+// reason). `WebhookTestEvent` below is web-only and stays.
 
 /**
  * Represents a webhook test event that is captured and stored for debugging
@@ -28,17 +36,9 @@ export interface WebhookTestEvent {
 /**
  * Data interface for the Webhook node (flattened structure)
  */
-export interface WebhookNodeData extends BaseNodeData {
-  // Webhook-specific fields (previously in config)
-  method: 'GET' | 'POST'
+export interface WebhookNodeData extends CatalogWebhookNodeData {
+  type: NodeType
   bodySchema?: { enabled: boolean; schema?: SchemaRoot }
-  authType?: 'bearer' | 'apiKey' | 'hmac' | null
-  authConfig?: { secret?: string; headerName?: string }
-  responseConfig?: {
-    statusCode: number
-    body?: string // Can include variables
-    headers?: Record<string, string>
-  }
 }
 
 /**

--- a/apps/web/src/components/workflow/parity/catalog-coverage.test.ts
+++ b/apps/web/src/components/workflow/parity/catalog-coverage.test.ts
@@ -115,8 +115,14 @@ describe('defineFromManifest', () => {
     expect(definition.validator?.({ title: 'ok' }).isValid).toBe(true)
   })
 
-  it('resolves migrated types and stays undefined-safe for unmigrated ones', () => {
+  it('resolves platform types and stays undefined-safe for everything else', () => {
     expect(getManifest('wait')?.displayName).toBe('Wait')
-    expect(getManifest('webhook')).toBeUndefined()
+    expect(getManifest('webhook')?.displayName).toBe('Webhook')
+    // NOT_YET_MIGRATED is empty now, so the undefined arm can no longer be
+    // pinned to an unmigrated platform type. It still matters: `getManifest`
+    // is core-only, and an app block (per-org data, reached through
+    // `buildManifestLookup`) must never resolve through it.
+    expect(getManifest('quickbooks:create-invoice')).toBeUndefined()
+    expect(getManifest('not-a-node-type')).toBeUndefined()
   })
 })

--- a/docs/core-workflow-architecture-guide.md
+++ b/docs/core-workflow-architecture-guide.md
@@ -61,9 +61,11 @@ because of what that cost.
 | `connection` | target/source handle rules, incl. `branches` |
 | `agentSchema?` / `fromAgentConfig?` / `agent?` | the friendly shape Kopilot authors against |
 
-`catalog/registry.ts` holds them (**26** manifests today);
-`catalog/not-yet-migrated.ts` lists node types that still live only in web
-(**3**: `webhook`, `webhook-endpoint`, `form-input`).
+`catalog/registry.ts` holds them (**29** manifests — every platform node type);
+`catalog/not-yet-migrated.ts` lists node types that still live only in web, and
+is **empty**: the migration is complete. It stays in the tree because of the
+coupling below — it is what makes adding a node type an explicit decision, not
+only migrating one. A NEW type may not be parked there; the list only shrinks.
 
 **The tracker and the `NodeType` enum are COUPLED.** `parity/catalog-coverage.test.ts`
 asserts exact set equality between the enum and {registered manifests ∪
@@ -615,9 +617,9 @@ Rules that are easy to get wrong:
   write that way sends the caller off to repair something that is already
   correct. The no-op check is guarded on `envVars`/`variables`/`icon`, which
   `set_workflow_details` and `apply_template` pass through the same seam.
-- **A node with no manifest is not an issue.** Uncatalogued nodes (app blocks,
-  not-yet-migrated types) are named once on `GraphSummary.readOnlyNodes`, never
-  as a per-node `info` issue — an un-actionable line repeated on every read
+- **A node with no manifest is not an issue.** Uncatalogued nodes (an app block
+  whose app was uninstalled, a retired type on a legacy graph) are named once on
+  `GraphSummary.readOnlyNodes`, never as a per-node `info` issue — an un-actionable line repeated on every read
   buries the issues that ARE actionable.
 - **Outputs are enrichment; they must never fail a write.**
   `resolveGraphOutputs` runs BEFORE `persistDraft`, so it returns

--- a/packages/lib/src/workflow-engine/catalog/derive-trigger.ts
+++ b/packages/lib/src/workflow-engine/catalog/derive-trigger.ts
@@ -61,9 +61,9 @@ export type DerivedTriggerLinks =
  * Pure graph-side half of the app/webhook trigger-column derivation — the
  * server-side branches `workflow-service.update` used to inline (HANDOFF item
  * 5). Unlike {@link deriveTriggerColumns}, `triggerType` is an INPUT here, not
- * derived: the save path trusts the caller-posted type, and the catalog cannot
- * yet resolve webhook / webhook-endpoint / app trigger types itself (they are
- * `NOT_YET_MIGRATED`).
+ * derived: the save path trusts the caller-posted type, and the catalog still
+ * cannot resolve the two dynamic APP trigger types itself (they are per-org
+ * data, synthesized by `buildManifestLookup`, never registered).
  *
  * The server-side composition that resolves the installation id lives in
  * `derive-trigger-server.ts` (server-only leaf module — do not fold it in
@@ -121,11 +121,10 @@ export interface DerivedTriggerColumns {
  *    `triggerType` at the generic RESOURCE_TRIGGER and no entity id.
  *
  * `resolveTriggerType` maps a node's `data.type` to its trigger type. The
- * default consults the catalog, which covers every migrated trigger; apps/web
- * passes its registry-backed resolver because the canvas can also hold
- * not-yet-migrated triggers (webhook, webhook-endpoint) and dynamic app
- * triggers (`appId:triggerId` → APP_TRIGGER / APP_POLLING_TRIGGER) the catalog
- * cannot see yet.
+ * default consults the catalog, which now covers every platform trigger;
+ * apps/web still passes its registry-backed resolver because the canvas can
+ * also hold dynamic app triggers (`appId:triggerId` → APP_TRIGGER /
+ * APP_POLLING_TRIGGER), which are per-org data the core registry never sees.
  */
 export function deriveTriggerColumns(
   nodes: readonly TriggerDerivationNode[],

--- a/packages/lib/src/workflow-engine/catalog/nodes/webhook-endpoint.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/webhook-endpoint.ts
@@ -1,0 +1,163 @@
+// packages/lib/src/workflow-engine/catalog/nodes/webhook-endpoint.ts
+
+import { z } from 'zod'
+import { BaseType, WorkflowTriggerType } from '../../core/types'
+import type { UnifiedVariable } from '../../types/unified-variable'
+import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
+import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+import { createUnifiedOutputVariable } from '../variable-conversion'
+
+/**
+ * The webhook-endpoint trigger node's catalog manifest — fires on a verified
+ * delivery to an existing org-level inbound `WebhookEndpoint`, optionally
+ * scoped to a topic. (The `webhook` node is the other one: the workflow's own
+ * ad-hoc inbound URL.)
+ *
+ * `webhookEndpointId` / `topic` are copied onto the workflow's
+ * `triggerWebhookEndpointId` / `triggerTopic` columns at save time — the
+ * derivation lives in `catalog/derive-trigger.ts` (`deriveTriggerLinks`), not
+ * in the save path.
+ */
+
+/**
+ * Data interface for the Webhook Endpoint trigger node.
+ */
+export interface WebhookEndpointNodeData extends BaseNodeData {
+  /** Id of the `WebhookEndpoint` whose deliveries fire this workflow. */
+  webhookEndpointId: string
+  /** Optional topic to scope deliveries (matched against the endpoint's extracted topic). */
+  topic: string
+  /** Cached endpoint display name (node label + panel only; never read at run time). */
+  webhookEndpointName?: string
+}
+
+/**
+ * Zod schema for the webhook endpoint trigger node (flattened structure).
+ *
+ * `webhookEndpointId` is NOT `.min(1)` here: a fresh node legitimately carries
+ * `''` until the user picks an endpoint, and a manifest's defaults must parse
+ * their own `configSchema`. Required-ness lives in {@link
+ * validateWebhookEndpointData} instead, with the same field and message.
+ */
+export const webhookEndpointNodeDataSchema = baseNodeDataSchema.extend({
+  webhookEndpointId: z.string().default(''),
+  // Optional — blank matches every delivery (endpoints with no topicSource extract topic '').
+  topic: z.string().default(''),
+  webhookEndpointName: z.string().optional(),
+})
+
+/**
+ * Validate webhook endpoint trigger node data.
+ */
+export function validateWebhookEndpointData(data: WebhookEndpointNodeData): NodeValidationResult {
+  const parsed = webhookEndpointNodeDataSchema.safeParse(data)
+  if (!parsed.success) {
+    return {
+      isValid: false,
+      errors: parsed.error.issues.map((e) => ({
+        field: e.path.join('.'),
+        message: e.message,
+        type: 'error' as const,
+      })),
+    }
+  }
+
+  // An unbound trigger never fires — the save path has no endpoint id to write
+  // to `Workflow.triggerWebhookEndpointId`. An ordinary error, not
+  // `blocksAuthoring`: a half-configured draft is legitimate and the user
+  // finishes it in the panel.
+  if (!data.webhookEndpointId) {
+    return {
+      isValid: false,
+      errors: [
+        {
+          field: 'webhookEndpointId',
+          message: 'Webhook endpoint is required',
+          type: 'error' as const,
+        },
+      ],
+    }
+  }
+
+  return { isValid: true, errors: [] }
+}
+
+/**
+ * Output variables exposed by the webhook endpoint trigger: the topic, the
+ * endpoint id, and the raw verified payload (`body`).
+ *
+ * `body` is typed OBJECT because that is the overwhelmingly common case, but
+ * the processor passes the payload through rather than coercing it — a sender
+ * may post an array or a scalar (`nodes/trigger-nodes/webhook-endpoint.ts`).
+ */
+function getWebhookEndpointOutputVariables(
+  _data: WebhookEndpointNodeData,
+  nodeId: string
+): UnifiedVariable[] {
+  return [
+    createUnifiedOutputVariable({
+      nodeId,
+      path: 'topic',
+      type: BaseType.STRING,
+      description: 'The topic that fired this workflow',
+    }),
+    createUnifiedOutputVariable({
+      nodeId,
+      path: 'webhookEndpointId',
+      type: BaseType.STRING,
+      description: 'The webhook endpoint id that received the delivery',
+    }),
+    createUnifiedOutputVariable({
+      nodeId,
+      path: 'body',
+      type: BaseType.OBJECT,
+      description: 'The verified webhook payload',
+    }),
+  ]
+}
+
+/**
+ * Webhook endpoint trigger node manifest.
+ */
+export const webhookEndpointManifest: NodeManifest<WebhookEndpointNodeData> = {
+  id: 'webhook-endpoint',
+  category: NodeCategory.TRIGGER,
+  displayName: 'Webhook Endpoint',
+  description: 'Trigger when a webhook endpoint receives a delivery',
+  icon: 'webhook',
+  color: '#10b981', // TRIGGER category color
+  triggerType: WorkflowTriggerType.WEBHOOK_ENDPOINT,
+  defaultData: () => ({
+    title: 'Webhook Endpoint',
+    desc: 'Select a webhook endpoint',
+    webhookEndpointId: '',
+    topic: '',
+  }),
+  configSchema: webhookEndpointNodeDataSchema as unknown as z.ZodType<WebhookEndpointNodeData>,
+  validate: validateWebhookEndpointData,
+  resolveOutputs: getWebhookEndpointOutputVariables,
+  connection: {
+    canRunSingle: false, // Triggers cannot be run individually
+  },
+  agent: {
+    authorable: true,
+    usage:
+      'Fires on a delivery to a webhook endpoint the org has ALREADY created (Settings → ' +
+      'Webhooks), not on a URL this workflow owns — for the latter use `webhook`. ' +
+      '`webhookEndpointId` is a `WebhookEndpoint` CUID: there is no tool that lists them, so ' +
+      'NEVER invent one. Add the node with `webhookEndpointId` left empty and tell the user to ' +
+      'pick the endpoint in the node panel; the validator will report it as unconfigured until ' +
+      'they do, and the workflow will not fire. `topic` is optional and scopes deliveries — ' +
+      'blank matches every delivery. The payload arrives verbatim as `body`.',
+    examples: [
+      {
+        description: 'Bound endpoint, scoped to one topic',
+        config: { webhookEndpointId: 'whe_abc123', topic: 'order.created' },
+      },
+      {
+        description: 'Endpoint left for the user to pick in the panel',
+        config: { webhookEndpointId: '', topic: '' },
+      },
+    ],
+  },
+}

--- a/packages/lib/src/workflow-engine/catalog/nodes/webhook.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/webhook.ts
@@ -1,0 +1,207 @@
+// packages/lib/src/workflow-engine/catalog/nodes/webhook.ts
+
+import { z } from 'zod'
+import { BaseType, WorkflowTriggerType } from '../../core/types'
+import type { UnifiedVariable } from '../../types/unified-variable'
+import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
+import { schemaToUnifiedVariable } from '../schema-to-variable'
+import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+import { createUnifiedOutputVariable } from '../variable-conversion'
+
+/**
+ * The webhook trigger node's catalog manifest — the workflow's own inbound URL
+ * (`/api/workflows/:workflowId/webhook`), as opposed to `webhook-endpoint`,
+ * which binds an existing org-level `WebhookEndpoint`.
+ *
+ * `bodySchema.schema` is typed loosely here (`type: string`) so apps/web can
+ * narrow it to the schema editor's `SchemaRoot` — whose `type` is a string-enum
+ * member, not the literal `'object'` — without a cast. Same treatment as
+ * `information-extractor.structured_output.schema`.
+ */
+
+/** A JSON Schema as the schema editor persists it. Loose on purpose (see above). */
+export interface WebhookBodySchema {
+  type: string // always 'object'; string so web's SchemaRoot narrows cleanly
+  properties: Record<string, any>
+  required?: string[]
+  additionalProperties?: boolean | Record<string, any>
+}
+
+/**
+ * Data interface for the webhook trigger node (flattened structure).
+ */
+export interface WebhookNodeData extends BaseNodeData {
+  method: 'GET' | 'POST'
+  /** Declared request-body shape. When enabled, its properties become the node's `body.*` variables. */
+  bodySchema?: { enabled: boolean; schema?: WebhookBodySchema }
+  /**
+   * Declared but NEVER enforced: no panel writes these and the route
+   * (`apps/web/src/app/api/workflows/[workflowId]/webhook/route.ts`) does not
+   * read them — the production path is deliberately unauthenticated, URL
+   * secrecy being the webhook contract. Kept on the type (legacy rows may
+   * carry them) and deliberately absent from `configSchema`, so nothing
+   * advertises an auth mode the endpoint does not actually apply.
+   */
+  authType?: 'bearer' | 'apiKey' | 'hmac' | null
+  authConfig?: { secret?: string; headerName?: string }
+  /** What the endpoint answers with. Read live by the route on both the run and the error path. */
+  responseConfig?: {
+    statusCode: number
+    body?: string
+    headers?: Record<string, string>
+  }
+}
+
+/**
+ * Zod schema for webhook node data (flattened structure).
+ *
+ * `responseConfig` is declared here where the pre-catalog builder schema left
+ * it out — the route reads all three of its members at run time, so leaving it
+ * undeclared meant the one persisted key with a live consumer was the one key
+ * neither the validator nor `describe_node_type` could see.
+ */
+export const webhookNodeDataSchema = baseNodeDataSchema.extend({
+  method: z.enum(['GET', 'POST']).default('POST'),
+  bodySchema: z
+    .object({ enabled: z.boolean().default(false), schema: z.any().optional() })
+    .optional(),
+  responseConfig: z
+    .object({
+      statusCode: z.number(),
+      body: z.string().optional(),
+      headers: z.record(z.string(), z.string()).optional(),
+    })
+    .optional(),
+})
+
+/**
+ * Validate webhook node data.
+ */
+export function validateWebhookData(data: WebhookNodeData): NodeValidationResult {
+  const parsed = webhookNodeDataSchema.safeParse(data)
+  if (parsed.success) {
+    return { isValid: true, errors: [] }
+  }
+  return {
+    isValid: false,
+    errors: parsed.error.issues.map((e) => ({
+      field: e.path.join('.'),
+      message: e.message,
+      type: 'error' as const,
+    })),
+  }
+}
+
+/**
+ * Define output variables for the webhook node.
+ *
+ * `method` / `headers` / `query` are always advertised; `body` only on POST,
+ * and it takes the declared schema's own nested paths when one is set. This
+ * matches what `WebhookProcessor` writes (`nodes/trigger-nodes/webhook-processor.ts`).
+ */
+function getWebhookOutputVariables(data: WebhookNodeData, nodeId: string): UnifiedVariable[] {
+  const variables: UnifiedVariable[] = []
+
+  variables.push(
+    createUnifiedOutputVariable({
+      nodeId,
+      path: 'method',
+      type: BaseType.STRING,
+      description: 'HTTP method of the webhook request (GET or POST)',
+    })
+  )
+
+  variables.push(
+    createUnifiedOutputVariable({
+      nodeId,
+      path: 'headers',
+      type: BaseType.OBJECT,
+      description: 'HTTP headers from the webhook request',
+    })
+  )
+
+  variables.push(
+    createUnifiedOutputVariable({
+      nodeId,
+      path: 'query',
+      type: BaseType.OBJECT,
+      description: 'Query parameters from the webhook URL',
+    })
+  )
+
+  // Body variable (only for POST requests)
+  if (data.method === 'POST') {
+    // If body schema is defined, use it to generate structured output variables
+    if (data.bodySchema?.enabled && data.bodySchema.schema) {
+      // schemaToUnifiedVariable handles nested paths
+      const bodyVar = schemaToUnifiedVariable(data.bodySchema.schema, nodeId, 'body')
+      bodyVar.description = 'Structured request body based on the defined schema'
+      variables.push(bodyVar)
+    } else {
+      variables.push(
+        createUnifiedOutputVariable({
+          nodeId,
+          path: 'body',
+          type: BaseType.OBJECT,
+          description: 'JSON body content from the webhook request',
+        })
+      )
+    }
+  }
+
+  return variables
+}
+
+/**
+ * Webhook trigger node manifest.
+ */
+export const webhookManifest: NodeManifest<WebhookNodeData> = {
+  id: 'webhook',
+  category: NodeCategory.TRIGGER,
+  displayName: 'Webhook',
+  description: 'Trigger workflow via HTTP webhook',
+  icon: 'webhook',
+  color: '#10b981', // TRIGGER category color
+  triggerType: WorkflowTriggerType.WEBHOOK,
+  defaultData: () => ({
+    title: 'Webhook Trigger',
+    desc: 'Trigger workflow via HTTP webhook',
+    method: 'POST',
+    bodySchema: { enabled: false, schema: undefined },
+  }),
+  configSchema: webhookNodeDataSchema as unknown as z.ZodType<WebhookNodeData>,
+  validate: validateWebhookData,
+  resolveOutputs: getWebhookOutputVariables,
+  connection: {
+    canRunSingle: false, // Triggers cannot be run individually
+  },
+  agent: {
+    authorable: true,
+    usage:
+      'The workflow gets its own inbound URL and starts when something POSTs (or GETs) to it — ' +
+      'use this for a generic "call my workflow over HTTP" trigger. The URL is shown in the ' +
+      'node panel; the endpoint is unauthenticated by design (URL secrecy is the contract), so ' +
+      'never promise the user bearer/HMAC verification. On POST, declare the payload shape in ' +
+      "`bodySchema` (`{ enabled: true, schema: <JSON Schema object> }`) and the schema's own " +
+      'properties become `body.*` variables downstream; without it `body` is one opaque object. ' +
+      'GET advertises no body at all. `responseConfig` sets what the caller gets back ' +
+      '(defaults to 200 "OK"). For deliveries from an existing org webhook endpoint, use ' +
+      '`webhook-endpoint` instead.',
+    examples: [
+      {
+        description: 'POST webhook with a declared body shape',
+        config: {
+          method: 'POST',
+          bodySchema: {
+            enabled: true,
+            schema: {
+              type: 'object',
+              properties: { orderId: { type: 'string' }, total: { type: 'number' } },
+              required: ['orderId'],
+            },
+          },
+        },
+      },
+    ],
+  },
+}

--- a/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
+++ b/packages/lib/src/workflow-engine/catalog/not-yet-migrated.ts
@@ -5,6 +5,10 @@
  * `apps/web/src/components/workflow/nodes/core/<type>/schema.ts` and have no
  * catalog manifest yet.
  *
+ * **The list is EMPTY: every builder `NodeType` now has a manifest.** The
+ * mechanism stays, because it is what makes the *next* change explicit rather
+ * than silent — see below.
+ *
  * This list is the migration tracker and it may ONLY SHRINK, for one of two
  * reasons:
  *  - **Migrated** — register its manifest in `registry.ts`, delete its entry here.
@@ -13,55 +17,22 @@
  *    asserts exact set equality between `NodeType` and {manifests ∪ this list}
  *    in both directions, so a half-done retirement fails the build.
  *
- * The catalog coverage test (apps/web parity suite) is what makes adding a node
- * type, migrating one, or retiring one always an explicit edit here, never
- * silent.
+ * A NEW node type may not be parked here — the list only shrinks. Land it with
+ * its manifest, which is the whole point of the catalog: adding a node type,
+ * migrating one, or retiring one is always an explicit edit the coverage test
+ * (apps/web parity suite) forces.
+ *
+ * Two retirements happened during the burn-down and are recorded here because
+ * nothing else explains why those enum members are absent:
+ *  - The six legacy per-resource triggers ('contact-created-trigger' …
+ *    'ticket-deleted-trigger') were RETIRED, not migrated: they never had a
+ *    schema, definition or processor, only enum members and a publish-time
+ *    normalization shim for old graphs that do not exist.
+ *  - 'number-input' / 'file-upload' were RETIRED alongside them. Neither was
+ *    ever implemented; file-upload behaviour is 'form-input' with
+ *    `inputType: 'file'`.
  *
  * Values are the persisted `data.type` strings (the builder's `NodeType` enum
- * values), listed in the enum's order.
+ * values).
  */
-export const NOT_YET_MIGRATED: readonly string[] = [
-  // Triggers
-  // 'message-received' — migrated (catalog/nodes/message-received.ts)
-  'webhook',
-  'webhook-endpoint',
-  // 'scheduled' — migrated (catalog/nodes/scheduled.ts)
-  // 'manual' — migrated (catalog/nodes/manual.ts)
-  // 'resource-trigger' — migrated (catalog/nodes/resource-trigger.ts)
-  // The six legacy per-resource triggers ('contact-created-trigger' …
-  // 'ticket-deleted-trigger') were RETIRED, not migrated: they never had a
-  // schema, definition or processor, only enum members and a publish-time
-  // normalization shim for old graphs that do not exist.
-  // Input nodes
-  // 'form-input' — migrated (catalog/nodes/form-input.ts)
-  // 'number-input' / 'file-upload' — RETIRED alongside the legacy triggers.
-  // Neither was ever implemented; file-upload behaviour is 'form-input' with
-  // `inputType: 'file'`.
-  // Condition nodes
-  // 'if-else' — migrated (catalog/nodes/if-else.ts)
-  // Action nodes
-  // 'answer' — migrated (catalog/nodes/answer.ts)
-  // 'ai' — migrated (catalog/nodes/ai.ts)
-  // 'find' — migrated (catalog/nodes/find.ts)
-  // 'http' — migrated (catalog/nodes/http.ts)
-  // 'crud' — migrated (catalog/nodes/crud.ts)
-  // 'document-extractor' — migrated (catalog/nodes/document-extractor.ts)
-  // 'chunker' — migrated (catalog/nodes/chunker.ts)
-  // 'dataset' — migrated (catalog/nodes/dataset.ts)
-  // 'knowledge-retrieval' — migrated (catalog/nodes/knowledge-retrieval.ts)
-  // Transform nodes
-  // 'code' — migrated (catalog/nodes/code.ts)
-  // 'text-classifier' — migrated (catalog/nodes/text-classifier.ts)
-  // 'information-extractor' — migrated (catalog/nodes/information-extractor.ts)
-  // 'var-assign' — migrated (catalog/nodes/var-assign.ts)
-  // 'date-time' — migrated (catalog/nodes/date-time.ts)
-  // 'list' — migrated (catalog/nodes/list.ts)
-  // 'format' — migrated (catalog/nodes/format.ts)
-  // Data nodes
-  // 'note' — migrated (catalog/nodes/note.ts)
-  // Control nodes
-  // 'end' — migrated (catalog/nodes/end.ts)
-  // 'wait' — migrated (catalog/nodes/wait.ts)
-  // 'loop' — migrated (catalog/nodes/loop.ts)
-  // 'human-confirmation' — migrated (catalog/nodes/human.ts)
-] as const
+export const NOT_YET_MIGRATED: readonly string[] = [] as const

--- a/packages/lib/src/workflow-engine/catalog/registry.ts
+++ b/packages/lib/src/workflow-engine/catalog/registry.ts
@@ -27,6 +27,8 @@ import { scheduledTriggerManifest } from './nodes/scheduled'
 import { textClassifierManifest } from './nodes/text-classifier'
 import { varAssignManifest } from './nodes/var-assign'
 import { waitManifest } from './nodes/wait'
+import { webhookManifest } from './nodes/webhook'
+import { webhookEndpointManifest } from './nodes/webhook-endpoint'
 import type { NodeManifest } from './types'
 
 /**
@@ -68,6 +70,8 @@ const ALL_MANIFESTS: NodeManifest<any>[] = [
   textClassifierManifest,
   varAssignManifest,
   waitManifest,
+  webhookManifest,
+  webhookEndpointManifest,
 ]
 
 const manifests = new Map<string, NodeManifest<any>>(ALL_MANIFESTS.map((m) => [m.id, m]))

--- a/packages/lib/src/workflow-engine/catalog/resolve-outputs.ts
+++ b/packages/lib/src/workflow-engine/catalog/resolve-outputs.ts
@@ -107,10 +107,12 @@ function resolveInTopoOrder(
     // that is `hasProcessor`'s fail-open, and it does not belong here (D8).
     const manifest = nodeType ? lookup(nodeType) : undefined
     if (!manifest?.resolveOutputs) {
-      // Not-yet-migrated or unknown type (`NOT_YET_MIGRATED` — `crud`/`find`
-      // today): no server-side resolver exists yet. Empty, not an error —
-      // same "nothing to report" the four context-reading resolvers give a
-      // node with no resource picked yet.
+      // Unknown type, or an app block this org does not have installed: no
+      // resolver to call. (`NOT_YET_MIGRATED` is empty now — every platform
+      // type carries one — but the guard stays, because the lookup also
+      // answers for per-org app blocks.) Empty, not an error — the same
+      // "nothing to report" the context-reading resolvers give a node with no
+      // resource picked yet.
       memo.set(nodeId, [])
       continue
     }

--- a/packages/lib/src/workflow-engine/catalog/types.ts
+++ b/packages/lib/src/workflow-engine/catalog/types.ts
@@ -10,8 +10,10 @@ import type { OutputResolver } from './output-context'
  * `registerFromManifest`), the engine processors, and — later — Kopilot's
  * authoring tools. Replaces the three drifting copies (builder
  * `NodeDefinition`, engine shadow interfaces, and the parity suite's static
- * extraction) one migrated node type at a time; `not-yet-migrated.ts` is the
- * tracker.
+ * extraction) one migrated node type at a time. The migration is COMPLETE —
+ * `not-yet-migrated.ts`, the tracker, is empty — but it stays, because the
+ * coverage test it anchors is what forces a NEW node type to be an explicit
+ * decision too.
  */
 
 /**
@@ -162,9 +164,9 @@ export interface NodeManifest<TConfig = unknown> {
 /**
  * How a caller resolves a node type to its manifest.
  *
- * The core registry (`getManifest`) answers for the 27 migrated platform types
- * and nothing else. App workflow blocks are **per-org data**, not platform
- * code — they are declared by an installed app's published catalog — so their
+ * The core registry (`getManifest`) answers for the 29 platform node types
+ * (every member of the builder's `NodeType` enum) and nothing else. App
+ * workflow blocks are **per-org data**, not platform code — they are declared by an installed app's published catalog — so their
  * manifests are synthesized per request (`buildManifestLookup`) and reach the
  * sync call sites through this function rather than through the registry Map.
  *

--- a/packages/lib/src/workflow-engine/client.ts
+++ b/packages/lib/src/workflow-engine/client.ts
@@ -404,6 +404,19 @@ export {
   waitManifest,
   waitNodeDataSchema,
 } from './catalog/nodes/wait'
+export {
+  validateWebhookData,
+  type WebhookBodySchema,
+  type WebhookNodeData as CatalogWebhookNodeData,
+  webhookManifest,
+  webhookNodeDataSchema,
+} from './catalog/nodes/webhook'
+export {
+  validateWebhookEndpointData,
+  type WebhookEndpointNodeData as CatalogWebhookEndpointNodeData,
+  webhookEndpointManifest,
+  webhookEndpointNodeDataSchema,
+} from './catalog/nodes/webhook-endpoint'
 export { NOT_YET_MIGRATED } from './catalog/not-yet-migrated'
 export {
   type OutputContext,

--- a/packages/lib/src/workflow-engine/nodes/trigger-nodes/webhook-endpoint.ts
+++ b/packages/lib/src/workflow-engine/nodes/trigger-nodes/webhook-endpoint.ts
@@ -1,22 +1,21 @@
 // packages/lib/src/workflow-engine/nodes/trigger-nodes/webhook-endpoint.ts
 
+import type { WebhookEndpointNodeData } from '../../catalog/nodes/webhook-endpoint'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type { NodeExecutionResult, ValidationResult, WorkflowNode } from '../../core/types'
 import { NodeRunningStatus, WorkflowNodeType } from '../../core/types'
 import { BaseNodeProcessor } from '../base-node'
 
 /**
- * Config (`node.data`) for the WEBHOOK_ENDPOINT trigger node, written by
- * `apps/web/src/components/workflow/nodes/core/webhook-trigger/panel.tsx`.
+ * The slice of the WEBHOOK_ENDPOINT node's persisted config this processor
+ * reads. The shape lives in the catalog (`catalog/nodes/webhook-endpoint`);
+ * this is a projection of it, widened to `Partial` because a legacy or
+ * half-configured node legitimately carries neither key and both reads below
+ * already fall back.
  */
-interface WebhookEndpointTriggerData {
-  /** Id of the `WebhookEndpoint` whose deliveries fire this workflow. */
-  webhookEndpointId?: string
-  /** Optional topic scope — blank matches every delivery. */
-  topic?: string
-  /** Cached endpoint display name (label only, never read at run time). */
-  webhookEndpointName?: string
-}
+type WebhookEndpointTriggerData = Partial<
+  Pick<WebhookEndpointNodeData, 'webhookEndpointId' | 'topic'>
+>
 
 /**
  * Platform provenance that `executeAppTriggeredWorkflow` nests under `_meta`
@@ -44,8 +43,8 @@ interface WebhookEndpointTriggerMeta {
  *   - `topic`             → `_meta.topic`, falling back to the configured topic
  *   - `webhookEndpointId` → `_meta.webhook_endpoint_id`, falling back to config
  *
- * which is exactly what the builder's `webhookTriggerDefinition.outputVariables`
- * advertises. `body` is typed OBJECT there because that is the overwhelmingly
+ * which is exactly what the catalog manifest's `resolveOutputs`
+ * (`catalog/nodes/webhook-endpoint.ts`) advertises. `body` is typed OBJECT there because that is the overwhelmingly
  * common case, but a sender may post an array or a non-JSON string and the
  * payload is passed through rather than coerced.
  */
@@ -90,7 +89,7 @@ export class WebhookEndpointTriggerProcessor extends BaseNodeProcessor {
       bodyType: Array.isArray(body) ? 'array' : typeof body,
     })
 
-    // Advertised output variables (see `webhook-trigger/schema.ts`)
+    // Advertised output variables (see `catalog/nodes/webhook-endpoint.ts`)
     contextManager.setNodeVariable(node.nodeId, 'topic', topic)
     contextManager.setNodeVariable(node.nodeId, 'webhookEndpointId', webhookEndpointId)
     contextManager.setNodeVariable(node.nodeId, 'body', body)

--- a/packages/lib/src/workflow-engine/nodes/trigger-nodes/webhook-processor.ts
+++ b/packages/lib/src/workflow-engine/nodes/trigger-nodes/webhook-processor.ts
@@ -1,20 +1,21 @@
 // packages/lib/src/workflow-engine/nodes/trigger-nodes/webhook-processor.ts
 
+import type { WebhookNodeData } from '../../catalog/nodes/webhook'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type { NodeExecutionResult, ValidationResult, WorkflowNode } from '../../core/types'
 import { NodeRunningStatus, WorkflowNodeType } from '../../core/types'
 import { BaseNodeProcessor } from '../base-node'
 
 /**
- * Data interface for webhook node
+ * The slice of the webhook node's persisted config this processor reads. The
+ * shape itself lives in the catalog (`catalog/nodes/webhook`) — this is a
+ * projection of it, not a second declaration.
+ *
+ * Note it is the NODE CONFIG, not the delivery: what the request actually
+ * carried (`headers`, `query`, `body`) arrives as `context.triggerData`, which
+ * the route builds and this processor republishes as node variables.
  */
-interface WebhookData {
-  method: 'GET' | 'POST'
-  bodySchema?: { schema: object; uiSchema?: object }
-  authType?: 'bearer' | 'apiKey' | 'hmac' | null
-  authConfig?: { secret?: string; headerName?: string }
-  responseConfig?: { statusCode: number; body?: string; headers?: Record<string, string> }
-}
+type WebhookConfig = Pick<WebhookNodeData, 'method'>
 
 /**
  * Processor for webhook trigger nodes
@@ -79,7 +80,7 @@ export class WebhookProcessor extends BaseNodeProcessor {
   protected async validateNodeConfig(node: WorkflowNode): Promise<ValidationResult> {
     const errors: string[] = []
     const warnings: string[] = []
-    const data = node.data as unknown as WebhookData
+    const data = node.data as unknown as WebhookConfig
 
     if (!data.method) {
       errors.push('HTTP method is required')

--- a/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
@@ -876,20 +876,23 @@ describe('updateNode / disconnectNodes', () => {
   })
 
   it('names uncatalogued nodes ONCE on the summary, not as an issue per read', async () => {
-    // Anything with no catalog manifest — an app block, or a not-yet-migrated
-    // type like `webhook` — used to emit an `info` issue on every read and
-    // every mutation result: un-actionable noise that buried the issues that
-    // WERE actionable. It is a fact about the graph, so it rides the summary.
+    // Anything with no catalog manifest — an app block whose app was
+    // uninstalled, or a retired core type still sitting on an old graph — used
+    // to emit an `info` issue on every read and every mutation result:
+    // un-actionable noise that buried the issues that WERE actionable. It is a
+    // fact about the graph, so it rides the summary.
     //
-    // `webhook` rather than an `appId:blockId` app block on purpose: a
-    // colon-shaped type sends `resolveGraphOutputs` into the org cache for the
-    // app-block lookup, which this suite's bare mock db cannot serve.
-    const readOnlyId = 'webhook-aaaaaaaaaaaaaaaaaa'
+    // `number-input` (retired during the catalog burn-down, and still
+    // persistable on a legacy graph) rather than an `appId:blockId` app block
+    // on purpose: a colon-shaped type sends `resolveGraphOutputs` into the org
+    // cache for the app-block lookup, which this suite's bare mock db cannot
+    // serve.
+    const readOnlyId = 'legacy-aaaaaaaaaaaaaaaaaa'
     const readOnly: GraphNode = {
       id: readOnlyId,
       type: 'standard',
       position: { x: 900, y: 100 },
-      data: { id: readOnlyId, type: 'webhook', title: 'Incoming Webhook' },
+      data: { id: readOnlyId, type: 'number-input', title: 'Incoming Webhook' },
     }
     const graph: DraftGraph = { nodes: [triggerNode(), loopNode(), readOnly], edges: [] }
     const result = await updateNode(makeDb(graph), {


### PR DESCRIPTION
Closes the node-catalog migration. `NOT_YET_MIGRATED` is now **empty** and all 29 builder `NodeType` members carry a manifest — `webhook` and `webhook-endpoint` were the last two.

| | before | after |
|---|---|---|
| `NodeType` enum | 29 | 29 |
| registered manifests | 27 | **29** |
| `NOT_YET_MIGRATED` | 2 | **0** |

## What moved

- **`catalog/nodes/webhook.ts`** — the workflow's own inbound URL (`/api/workflows/:workflowId/webhook`).
- **`catalog/nodes/webhook-endpoint.ts`** — deliveries to an existing org-level `WebhookEndpoint`. Named for the node type; the web directory keeps its historical name `nodes/core/webhook-trigger/`, so the two merge-site re-exports are aliased (`validateWebhookEndpointData as validateWebhookTriggerData`, same for the schema).
- Each carries the full data half: types, zod schema, `defaultData()`, validator, `resolveOutputs`, agent docs — both `authorable`. Registry + `client.ts` barrel + tracker updated.
- Web merge sites: both `schema.ts` → `defineFromManifest` + back-compat re-exports; both `types.ts` → `type: NodeType` narrowing (`webhook` additionally narrows `bodySchema.schema` to the schema editor's `SchemaRoot`, the same treatment `information-extractor` gets).
- **Zero-diff panels held** — `git diff --stat` on both dirs shows only `schema.ts` and `types.ts`.
- Engine shadow-interface sweep: `WebhookProcessor`'s five-field `WebhookData` → `Pick<WebhookNodeData, 'method'>` (it only ever read `method`); the webhook-endpoint processor's → `Partial<Pick<…, 'webhookEndpointId' | 'topic'>>`.

## Three judgement calls

**1. `webhook.responseConfig` is now on the configSchema**, where the pre-catalog builder schema left it out. It is the one webhook key with a live runtime consumer — the route reads `statusCode`, `body` and `headers` on both the run and the error path — and it was the one key neither the validator nor `describe_node_type` could see. Drift found during a move gets fixed in the move (D4). Deliberate side effect: Kopilot can now author the webhook's response.

**2. `webhook.authType` / `authConfig` stay OFF the schema**, on the type only with a docblock. Nothing writes them and nothing reads them — the production webhook path is deliberately unauthenticated (URL secrecy is the contract). Declaring them would teach `describe_node_type` to advertise an auth mode the endpoint does not apply, which is worse than letting legacy rows round-trip untouched. The agent `usage` string says so explicitly.

**3. `webhookEndpointId` lost its `.min(1)`**, moved to the validator with the identical field and message. `defaultData()` ships `''` and a manifest's defaults must parse their own `configSchema`. It is an ordinary `error`, **not** `blocksAuthoring` — a half-configured draft is legitimate and `validateNodeConfigs` is tier-2 and never blocks. So Kopilot can place the node and hand the endpoint choice to the user, which is the only honest option: no tool lists `WebhookEndpoint` rows, so the agent cannot resolve an id and its `usage` tells it never to invent one.

## Two knock-on test edits

- `catalog-coverage.test.ts` pinned its undefined arm to `getManifest('webhook')` — the sentinel for "unmigrated". There is no unmigrated platform type left to point at, so it now pins what `getManifest` must still refuse: an `appId:blockId` app block (per-org data, reached only through `buildManifestLookup`) and a garbage string.
- `graph-edit/__tests__/ops.test.ts` used a `webhook` node as its stand-in for "no catalog manifest" in the read-only-summary test. Swapped to `number-input` — retired in #1638, so still the right shape (a type an old graph can carry that the catalog does not know) and still not colon-shaped, which that test's own comment warns against.

## Docs

`derive-trigger.ts`, `resolve-outputs.ts`, `catalog/types.ts` and `docs/core-workflow-architecture-guide.md` all claimed the catalog "cannot yet resolve webhook / webhook-endpoint / app trigger types". Only the two dynamic **app** trigger types are outside the registry now, and always will be — they are per-org data. The tracker's own docblock now spells out that it may not be used to park a *new* type: the list only shrinks, and the exact-set-equality test it anchors is why it stays in the tree at zero entries.

## Verification

- lib `src/workflow-engine` — 1247/1247
- lib `src/workflows` + `src/ai/kopilot` — 1025/1025
- web `src/components/workflow` — 162/162
- typecheck ratchets — lib 29/29 baseline, web 0/0
- biome clean on every touched file
