### PR TITLE
fix(workflow): publish the declared output contract for form-input nodes

### DIFF
--- a/packages/lib/src/workflow-engine/nodes/form-input/form-input-processor.ts
+++ b/packages/lib/src/workflow-engine/nodes/form-input/form-input-processor.ts
@@ -234,7 +234,14 @@ function setTypedOutputVariables(
       setFileOutputs(nodeId, value, typeOptions?.file?.allowMultiple ?? false, ctx)
       break
 
+    // TAGS and ARRAY are inherently multi-value. Both MUST land here: the
+    // catalog's `getFormInputOutputVariables` advertises `values`/`count` for
+    // the pair, so routing only TAGS left an ARRAY input publishing a scalar
+    // `value` while its declared contract promised an array — the exact
+    // mismatch that makes a downstream Loop fail with "Expected array but got
+    // undefined".
     case BaseType.TAGS:
+    case BaseType.ARRAY:
       setArrayOutputs(nodeId, value, ctx)
       break
 

--- a/packages/lib/src/workflow-engine/nodes/trigger-nodes/manual.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/trigger-nodes/manual.test.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/workflow-engine/nodes/trigger-nodes/manual.test.ts
 
 import { describe, expect, it, vi } from 'vitest'
+import { getFormInputOutputVariables } from '../../catalog/nodes/form-input'
 import { ExecutionContextManager } from '../../core/execution-context'
 import type { WorkflowNode } from '../../core/types'
 import { NodeRunningStatus, WorkflowNodeType } from '../../core/types'
@@ -114,16 +115,17 @@ describe('ManualTriggerProcessor', () => {
     contextManager.setVariable('sys.triggerData', { 'form-input-1': 'true' })
     // `inputType` / `typeOptions` are read off the FORM-INPUT node's data, which
     // its own panel writes — the manual trigger's data carries neither.
+    // Top-level `nodes` is the shape the engine really publishes — see
+    // `WorkflowGraphBuilder.transformNodes`. Asserting against `graph.nodes`
+    // here passed while production silently fell back to STRING.
     contextManager.setVariable('sys.workflow', {
-      graph: {
-        nodes: [
-          {
-            nodeId: 'form-input-1',
-            type: 'form-input',
-            data: { inputType: 'boolean', label: 'Confirm' },
-          },
-        ],
-      },
+      nodes: [
+        {
+          nodeId: 'form-input-1',
+          type: 'form-input',
+          data: { inputType: 'boolean', label: 'Confirm' },
+        },
+      ],
     })
 
     await run(contextManager)
@@ -141,28 +143,28 @@ describe('ManualTriggerProcessor', () => {
    * assert what an execution genuinely writes, which is what `{{...}}` resolves
    * against.
    */
-  const selectGraph = (multiple: boolean) => ({
-    graph: {
-      nodes: [
-        {
-          nodeId: 'form-input-1',
-          type: 'form-input',
-          data: {
-            inputType: 'enum',
-            label: 'Areas',
-            typeOptions: {
-              enum: {
-                multiple,
-                options: [
-                  { label: 'Billing', value: 'billing' },
-                  { label: 'Shipping', value: 'shipping' },
-                ],
-              },
-            },
-          },
+  const selectNode = (multiple: boolean) => ({
+    nodeId: 'form-input-1',
+    type: 'form-input',
+    data: {
+      inputType: 'enum',
+      label: 'Areas',
+      typeOptions: {
+        enum: {
+          multiple,
+          options: [
+            { label: 'Billing', value: 'billing' },
+            { label: 'Shipping', value: 'shipping' },
+          ],
         },
-      ],
+      },
     },
+  })
+
+  /** The engine's real shape: nodes at the top level, `graph` holding edges. */
+  const selectGraph = (multiple: boolean) => ({
+    nodes: [selectNode(multiple)],
+    graph: { edges: [] },
   })
 
   it('writes a scalar `value` for a single SELECT', async () => {
@@ -188,6 +190,65 @@ describe('ManualTriggerProcessor', () => {
     expect(await contextManager.getVariable('form-input-1.values')).toEqual(['billing', 'shipping'])
     expect(await contextManager.getVariable('form-input-1.count')).toBe(2)
     expect(await contextManager.getVariable('form-input-1.isEmpty')).toBe(false)
+  })
+
+  /**
+   * The regression behind a real "Expected array but got undefined for
+   * itemsSource: …values" failure: `sys.workflow` carries its nodes at the TOP
+   * level, but the lookup read `graph.nodes` only, so it returned null on every
+   * production run and the STRING fallback published `value` instead of
+   * `values`.
+   *
+   * Pinned to the transformed shape alone — the only one any writer produces.
+   */
+  it('resolves the form-input config off the transformed workflow', async () => {
+    const contextManager = runContext('user-1')
+    contextManager.setVariable('sys.triggerData', { 'form-input-1': ['billing'] })
+    contextManager.setVariable('sys.workflow', {
+      nodes: [selectNode(true)],
+      graph: { edges: [] },
+    })
+
+    await run(contextManager)
+
+    expect(await contextManager.getVariable('form-input-1.values')).toEqual(['billing'])
+    expect(await contextManager.getVariable('form-input-1.inputType')).toBe('enum')
+  })
+
+  /**
+   * Anti-drift: what the catalog ADVERTISES a node produces must be what an
+   * execution actually WRITES. The two live in different files
+   * (`getFormInputOutputVariables` vs `setTypedOutputVariables`) and had already
+   * drifted twice — a multi SELECT and an ARRAY input each promised
+   * `values`/`count` while the engine wrote a scalar `value`, which is what
+   * makes a downstream Loop fail with "Expected array but got undefined".
+   *
+   * Asserting the declared paths are all populated catches the next divergence
+   * without anyone having to remember both files exist.
+   */
+  it.each([
+    ['tags', undefined],
+    ['array', undefined],
+    ['enum', { enum: { multiple: true, options: [{ label: 'A', value: 'a' }] } }],
+  ])('writes every variable the catalog advertises for %s', async (inputType, typeOptions) => {
+    const data = { inputType, label: 'Areas', typeOptions } as never
+    const contextManager = runContext('user-1')
+    contextManager.setVariable('sys.triggerData', { 'form-input-1': ['a', 'b'] })
+    contextManager.setVariable('sys.workflow', {
+      nodes: [{ nodeId: 'form-input-1', type: 'form-input', data }],
+      graph: { edges: [] },
+    })
+
+    await run(contextManager)
+
+    const declared = getFormInputOutputVariables(data, 'form-input-1')
+    expect(declared.length).toBeGreaterThan(0)
+    for (const variable of declared) {
+      expect(
+        await contextManager.getVariable(variable.id),
+        `${inputType} declares ${variable.id} but the engine never wrote it`
+      ).toBeDefined()
+    }
   })
 
   /**

--- a/packages/lib/src/workflow-engine/nodes/trigger-nodes/manual.ts
+++ b/packages/lib/src/workflow-engine/nodes/trigger-nodes/manual.ts
@@ -130,9 +130,18 @@ export class ManualTriggerProcessor extends BaseNodeProcessor {
     contextManager: ExecutionContextManager
   ): Promise<{ inputType?: BaseType; typeOptions?: TypeOptions; label?: string } | null> {
     const workflow = (await contextManager.getVariable('sys.workflow')) as
-      | { graph?: { nodes?: Array<Record<string, any>> } }
+      | { nodes?: Array<Record<string, any>> }
       | undefined
-    const nodes = workflow?.graph?.nodes
+    // `sys.workflow` is the TRANSFORMED workflow (`WorkflowGraphBuilder`), whose
+    // `graph` is rebuilt as `{ edges }` alone — the nodes sit at the top level.
+    // Reading `graph.nodes` instead made this return null on every production
+    // run, so every non-STRING input silently fell back to the STRING contract
+    // and a multi-value field never published `values`/`count`.
+    //
+    // Top-level `nodes` is the ONLY shape any writer produces. The single-node
+    // executor sets a `{ id, name, workflowId }` stub with no nodes at all, and
+    // returning null there is correct: an isolated node run has no trigger form.
+    const nodes = workflow?.nodes
     if (!Array.isArray(nodes)) return null
 
     const formInputNode = nodes.find((candidate) => (candidate?.nodeId ?? candidate?.id) === nodeId)


### PR DESCRIPTION
Follow-up to #1762, found by actually running a workflow rather than trusting the unit tests.

## The failure

A multi-select Select feeding a Loop:

```
Node Failed: Loop
Expected array but got undefined for itemsSource: form-input-….values
```

## Root cause — the lookup never worked in production

A wired form-input is `NON_EXECUTABLE`, so `ManualTriggerProcessor` is what actually writes its variables. `findFormInputConfig` looked the node up in `sys.workflow.graph.nodes`, but the engine sets `sys.workflow` to the **transformed** workflow:

```js
lastTransformedWorkflow = { ...workflow, nodes: transformedNodes, graph: { edges: processedEdges } }
```

`graph` is rebuilt as edges only — the nodes are at the top level. So the lookup hit `if (!Array.isArray(nodes)) return null` on **every production run**, `inputType` fell back to `STRING`, and every non-string input published the wrong shape.

**This is not a Select bug.** It broke every non-string form input:

| Type | Declared | Actually written |
|---|---|---|
| TAGS | `values`, `count` | `value` |
| ADDRESS | `value.street1`… | `value` |
| CURRENCY | `value.amount`… | `value` |
| Select (multiple) | `values`, `count` | `value` |

Plain text worked by accident, because `STRING` is the fallback.

Fixed by reading top-level `nodes` — the only shape any writer produces (I checked all three: `workflow-engine.ts:210`, `:2102`, and the `single-node-executor.ts:105` stub). No speculative `graph.nodes` fallback: nothing produces that shape, and pinning it would block `sys.workflow` ever becoming `Workflow`-typed.

The single-node executor's `{ id, name, workflowId }` stub still resolves to `null`, which is correct — an isolated node run has no trigger form.

## Second divergence, same class

The catalog advertises `values`/`count` for **TAGS and ARRAY** (`catalog/nodes/form-input.ts`, with a passing test asserting it), but `setTypedOutputVariables` routed only TAGS to `setArrayOutputs`. So an ARRAY input promised an array and wrote a scalar — the identical failure, one input type over.

Reachable in practice: `array` is listed as a valid `inputType` in the manifest's `agent.usage`, so Kopilot can author one even though `BASE_TYPE_GROUPS` doesn't offer it in the picker.

## Tests

**The tests added in #1762 were wrong.** They passed while production was broken, because they hand-built `sys.workflow` in the shape the buggy code expected rather than the shape the engine emits. The pre-existing boolean test had the same flaw. All are now on the real shape.

Rather than just patch the two instances, added the test that catches the class: for each multi-value type, compute the catalog's declared variables and assert the engine wrote every one. Verified non-vacuous by reverting the ARRAY arm:

```
× writes every variable the catalog advertises for array
AssertionError: array declares form-input-1.values but the engine never wrote it
```

`getFormInputOutputVariables` and `setTypedOutputVariables` live in different files and must agree. Now something checks.

## Verified in the app

Multi Select of two options, after rebuilding `@auxx/lib`:

- **Run #5 SUCCEEDED**
- `sys.triggerData` → `["Option 1", "Option 2"]`
- Loop trace → `Iteration 1 of 2 succeeded`, `Iteration 2 of 2 succeeded`
- The node **inside the loop body** carries a green success check on both passes

1263 lib workflow-engine tests pass. Biome and `tsc --noEmit` clean.
