### PR TITLE
fix(workflow): give the webhook route the graph key the engine reads

### DIFF
--- a/apps/web/src/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/webhook/route.ts
@@ -212,13 +212,23 @@ async function handleWebhookRequest(
       userId: workflowApp.createdById || undefined,
     }
 
-    // Transform the workflow for the engine
+    // Transform the workflow for the engine.
+    //
+    // `graph` is the load-bearing key: `WorkflowGraphBuilder.buildGraph` reads
+    // `workflow.graph || { nodes: [], edges: [] }` and NOTHING else. Passing
+    // only the top-level `nodes`/`edges` (as this did) built an empty graph, so
+    // `findEntryNode` returned undefined, the engine threw "No entry point found
+    // in workflow", and the caller still got the configured 200 back — every
+    // published webhook workflow was a silent no-op. `executeWorkflow` takes
+    // `any` ("accept raw database format"), so nothing caught it at build time.
+    // The top-level pair stays because `toEngineFormat` sets both.
     const engineWorkflow = {
       id: workflow.id,
       organizationId: workflowApp.organizationId,
       name: workflow.name,
       version: workflow.version,
       triggerType: WorkflowTriggerType.WEBHOOK,
+      graph: { nodes: workflowGraph.nodes, edges: workflowGraph.edges || [] },
       nodes: workflowGraph.nodes,
       edges: workflowGraph.edges || [],
       enabled: true,

--- a/apps/web/src/app/api/workflows/[workflowId]/webhook/webhook-draft-test-window.test.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/webhook/webhook-draft-test-window.test.ts
@@ -238,6 +238,26 @@ describe('the PUBLISHED path is unaffected — with and without a window', () =>
     expect(executeWorkflow).toHaveBeenCalledTimes(1)
   })
 
+  /**
+   * The payload, not just the call count. `WorkflowGraphBuilder.buildGraph`
+   * reads `workflow.graph || { nodes: [], edges: [] }` and nothing else, so a
+   * payload carrying only top-level `nodes`/`edges` — which is what this route
+   * sent until the fix — builds an EMPTY graph: no entry node, the engine
+   * throws, the run comes back FAILED, and the caller still gets the configured
+   * 200. `executeWorkflow` takes `any`, so only a test can hold this contract.
+   * The builder-side half of it lives in
+   * `workflow-graph-builder.test.ts` → "reads the graph off `workflow.graph`".
+   */
+  it('hands the engine a payload the graph builder can actually read', async () => {
+    await POST(postRequest(false), params)
+
+    const payload = executeWorkflow.mock.calls[0]?.[0] as {
+      graph?: { nodes?: unknown[]; edges?: unknown[] }
+    }
+    expect(payload.graph?.nodes).toHaveLength(1)
+    expect(payload.graph?.edges).toEqual([])
+  })
+
   it('behaves identically while a window IS armed', async () => {
     arm()
     const res = await POST(postRequest(false), params)

--- a/packages/lib/src/workflow-engine/core/__tests__/workflow-graph-builder-input-shape.test.ts
+++ b/packages/lib/src/workflow-engine/core/__tests__/workflow-graph-builder-input-shape.test.ts
@@ -1,0 +1,69 @@
+// packages/lib/src/workflow-engine/core/__tests__/workflow-graph-builder-input-shape.test.ts
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { NodeProcessorRegistry } from '../node-processor-registry'
+import { NodeRunningStatus, WorkflowNodeType } from '../types'
+import { WorkflowGraphBuilder } from '../workflow-graph-builder'
+
+/**
+ * WHERE `buildGraph` looks for the graph — the one part of its contract the
+ * compiler cannot hold.
+ *
+ * It takes `any` ("accept raw database format") and reads
+ * `workflow.graph || { nodes: [], edges: [] }`, and nothing else. Hand it a
+ * workflow-shaped object with the nodes at the TOP level and it builds an empty
+ * graph in silence: `findEntryNode` returns undefined, the engine throws "No
+ * entry point found in workflow", the run comes back FAILED — and a caller that
+ * does not inspect `result.status` reports success.
+ *
+ * That is not hypothetical. The production webhook route
+ * (`apps/web/src/app/api/workflows/[workflowId]/webhook/route.ts`) passed
+ * exactly that shape, so every published `webhook`-triggered workflow was a
+ * silent no-op that still answered the caller 200. Four other `executeWorkflow`
+ * callers pass a database row and were unaffected.
+ *
+ * Kept in its own file, separate from the behavioural
+ * `workflow-graph-builder.test.ts`, because this pins an INPUT contract rather
+ * than graph-building behaviour — and because the route-side half of the same
+ * contract lives in another package
+ * (`webhook-draft-test-window.test.ts` → "hands the engine a payload the graph
+ * builder can actually read"). Neither test alone would have caught the bug.
+ */
+describe('WorkflowGraphBuilder input shape', () => {
+  const nodes = [
+    { id: 'node1', type: 'manual', data: { type: 'manual' } },
+    { id: 'node2', type: 'end', data: { type: 'end' } },
+  ]
+  const edges = [{ id: 'edge1', source: 'node1', target: 'node2' }]
+
+  beforeEach(() => {
+    const nodeRegistry = new NodeProcessorRegistry()
+    for (const type of [WorkflowNodeType.MANUAL, WorkflowNodeType.END]) {
+      nodeRegistry.registerProcessor({
+        type,
+        preprocessNode: async () => ({ inputs: {}, metadata: {} }),
+        execute: async (node) => ({
+          nodeId: node.nodeId,
+          status: NodeRunningStatus.Succeeded,
+          output: {},
+          executionTime: 0,
+        }),
+        validate: async () => ({ valid: true, errors: [], warnings: [] }),
+      })
+    }
+    WorkflowGraphBuilder.initialize(nodeRegistry)
+  })
+
+  it('builds from `workflow.graph`', () => {
+    const graph = WorkflowGraphBuilder.buildGraph({ id: 'wf', graph: { nodes, edges } })
+
+    expect(graph.nodes.size).toBe(2)
+    expect(graph.nodes.has('node1')).toBe(true)
+  })
+
+  it('builds NOTHING from top-level `nodes` / `edges`', () => {
+    const graph = WorkflowGraphBuilder.buildGraph({ id: 'wf', nodes, edges })
+
+    expect(graph.nodes.size).toBe(0)
+  })
+})


### PR DESCRIPTION
## The bug

`apps/web/src/app/api/workflows/[workflowId]/webhook/route.ts` built its engine workflow with `nodes`/`edges` at the **top level and no `graph` key**. `WorkflowGraphBuilder.buildGraph` reads `workflow.graph || { nodes: [], edges: [] }` and nothing else.

So every **published `webhook`-triggered workflow executed an empty graph**: `findEntryNode` returned `undefined`, the engine threw `No entry point found in workflow`, the run came back `FAILED` — and since the route never checks `result.status`, the external caller still got the node's configured **200**. A silent no-op that reports success.

Reproduced against the real builder before the fix:

```
ROUTE SHAPE  -> graph.nodes.size = 0 | entryNode = undefined
DB-ROW SHAPE -> graph.nodes.size = 2 | entryNode = n1
```

`executeWorkflow` takes `any` ("accept raw database format"), so the compiler had nothing to object to — the same shape as #1763.

## Blast radius

Only the generic `webhook` node: the route 404s on anything else, and the four other `executeWorkflow` callers all pass a database row. But it is the "Production" URL the webhook panel hands users, it fires on every inbound call, and a bundled template ships that shape (`Webhook-Triggered Order Notification`).

No dev evidence exists, for a sound reason: both dev workflows with a webhook node are unpublished, so the production branch 404s. Absence of evidence, not evidence of absence.

## The fix

One line — plus the top-level pair kept, since `toEngineFormat` sets both.

```ts
graph: { nodes: workflowGraph.nodes, edges: workflowGraph.edges || [] },
```

## Tests — both sides of the contract

Neither alone would have caught this.

- **Route side**: `webhook-draft-test-window.test.ts` now asserts the *payload*. It mocked `executeWorkflow` and checked only `toHaveBeenCalledTimes(1)`, which is exactly why the bug survived.
- **Builder side**: new `workflow-graph-builder-input-shape.test.ts` pins where `buildGraph` looks — builds from `workflow.graph`, builds **nothing** from top-level `nodes`/`edges`. Kept in its own file because it pins an *input contract* rather than graph-building behaviour.

Verified the route test fails without the fix (1 failed / 15 passed) and passes with it (16/16). Lib suites green.

## Deliberately NOT in this PR

Both filed in `plans/kopilot/workflow/23-graph-document-canonicalization.md` §8:

1. **`WorkflowGraphBuilder.lastTransformedWorkflow` is `private static`** — process-global across every engine instance. On a graph-cache hit, `this.currentWorkflow` (and therefore `sys.workflow`) can carry a *foreign* workflow's document, potentially another org's. Control flow read line-by-line and the static handoff demonstrated by probe, but the two-request sequence was not driven — worth its own look.
2. **This route never creates a `WorkflowRun`** — webhook runs are absent from run history and from usage metering, even with this fix.
