### PR TITLE
fix(workflow): address branches by id so agent wiring stops guessing

### DIFF
--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/list-node-types.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/list-node-types.test.ts
@@ -1,0 +1,73 @@
+// packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/list-node-types.test.ts
+
+/**
+ * `list_node_types` discovery
+ * (`plans/kopilot/workflow/21-branch-authoring-reliability.md` F6).
+ *
+ * Two defects, one turn. The search was a plain substring match over
+ * `id | displayName | description | category`, so `"if else"` (space) missed
+ * both `if-else` (hyphen) and `IF/ELSE` (slash), `"switch"` missed entirely,
+ * and `category: 'flow_control'` returned only `loop` because if-else is
+ * `condition`. And an empty result came back `success: false`, which reads as a
+ * TOOL FAILURE, so the model reworded instead of accepting the answer — four
+ * iterations before it landed on the one-character query `"if"`.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { createListNodeTypesTool } from '../list-node-types'
+
+const tool = createListNodeTypesTool(() => ({}) as never)
+
+async function search(args: Record<string, unknown>) {
+  const result = await tool.execute(args, {} as never)
+  return result as { success: boolean; output: { types: Array<{ type: string }>; note?: string } }
+}
+
+/** The type ids a query returns. */
+async function typesFor(query: string): Promise<string[]> {
+  return (await search({ query })).output.types.map((t) => t.type)
+}
+
+describe('list_node_types — the natural branching queries hit', () => {
+  it.each([
+    'if else',
+    'if/else',
+    'IF ELSE',
+    'switch',
+    'branch',
+    'route',
+    'condition',
+    'if',
+  ])('query %j finds if-else', async (query) => {
+    expect(await typesFor(query)).toContain('if-else')
+  })
+
+  it('finds the other branching types by the words people use for them', async () => {
+    expect(await typesFor('classify')).toContain('text-classifier')
+    expect(await typesFor('for each')).toContain('loop')
+    expect(await typesFor('approval')).toContain('human-confirmation')
+  })
+
+  it('does not display synonyms — they are a search key, not output', async () => {
+    const rows = (await search({ query: 'switch' })).output.types
+    expect(rows.every((row) => !('synonyms' in row))).toBe(true)
+  })
+})
+
+describe('list_node_types — an empty result is an ANSWER, not a failure', () => {
+  it('returns success with an empty list and a terminal note', async () => {
+    const result = await search({ query: 'quantum-blockchain' })
+    expect(result.success).toBe(true)
+    expect(result.output.types).toEqual([])
+    expect(result.output.note).toContain('quantum-blockchain')
+    expect(result.output.note).toContain('a reworded query will not change the answer')
+    expect(result.output.note).toContain('list_app_blocks')
+  })
+
+  it('keeps the digest honest for an empty result', () => {
+    expect(tool.buildDigest?.({ types: [] })).toEqual({
+      label: 'Node types listed',
+      resultCount: 0,
+    })
+  })
+})

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
@@ -621,11 +621,18 @@ describe('discovery tools', () => {
     expect((byCategory.output as { types: Array<{ type: string }> }).types).toHaveLength(1)
   })
 
-  it('list_node_types reports an actionable error when filters match nothing', async () => {
+  it('list_node_types answers an empty match with success, not a tool failure', async () => {
+    // `success: false` read as a FAILED CALL and models reworded the query
+    // instead of accepting the answer — one logged turn burned four iterations
+    // before finding `if-else` (plan 21 §3.3). Same fix plan 19 applied to
+    // `list_app_blocks`.
     const result = await run(tool('list_node_types'), { query: 'quantum-blockchain' })
-    expect(result.success).toBe(false)
-    expect(result.error).toContain('quantum-blockchain')
-    expect(result.error).toContain('without filters')
+    expect(result.success).toBe(true)
+    const output = result.output as { types: unknown[]; note: string }
+    expect(output.types).toEqual([])
+    expect(output.note).toContain('quantum-blockchain')
+    expect(output.note).toContain('a reworded query will not change the answer')
+    expect(output.note).toContain('list_app_blocks')
   })
 
   it('read and discovery tools build compact count digests', () => {
@@ -661,6 +668,27 @@ describe('discovery tools', () => {
     expect(out.type).toBe('wait')
     expect(out.configSchema).toBeTruthy()
     expect(out.connection).toBeTruthy()
+  })
+
+  it('describe_node_type keeps branch IDS and states the case_id contract', async () => {
+    // The ids used to be stripped, leaving `{name, kind}` — and the id is the
+    // ADDRESS. For an if-else the NAME is derived from array position and
+    // renames itself as cases are added, so a name handed out here is stale by
+    // the time the node exists (plan 21 §3.1/§10.2).
+    const result = await run(tool('describe_node_type'), { type: 'if-else' })
+    expect(result.success).toBe(true)
+    const out = result.output as {
+      connection: { branches: Array<{ id: string; name: string; kind: string }> }
+      branchesNote: string
+    }
+    expect(out.connection.branches).toEqual([
+      { id: 'true', name: 'IF', kind: 'default' },
+      { id: 'false', name: 'ELSE', kind: 'default' },
+    ])
+    expect(out.branchesNote).toContain('`case_id`')
+    expect(out.branchesNote).toContain('may NOT be `false`')
+    expect(out.branchesNote).toContain('must be unique')
+    expect(out.branchesNote).toContain('ACTUAL branches')
   })
 
   it('describe_node_type refuses an unknown type honestly, naming it', async () => {

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/add-node.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/add-node.ts
@@ -23,7 +23,7 @@ export function createAddNodeTool(getDeps: GetToolDeps): AgentToolDefinition {
     displayName: 'Add workflow node',
     surfaces: ['builder'],
     description:
-      'Add one node to the open workflow draft. Connect it with `after` (predecessor title) and optionally `branch` (branch NAME of the predecessor); place it inside a loop with `inside` (loop title); attach an input node (form-input) to a trigger’s run form with `inputFor` (trigger title). Do not send coordinates — layout is automatic. The result returns the node, its resolved outputs (wire `{{Title.path}}` refs from these), and any issues.',
+      'Add one node to the open workflow draft. Connect it with `after` (predecessor title) and optionally `branch` (branch id or name of the predecessor — for an if-else, the `case_id` you authored); place it inside a loop with `inside` (loop title); attach an input node (form-input) to a trigger’s run form with `inputFor` (trigger title). Do not send coordinates — layout is automatic. The result returns the node, its `branches` when it has any (id, name, and what is wired to each), its resolved outputs (wire `{{Title.path}}` refs from these), and any issues.',
     parameters: {
       type: 'object',
       properties: {
@@ -40,7 +40,13 @@ export function createAddNodeTool(getDeps: GetToolDeps): AgentToolDefinition {
             'Friendly config per describe_node_type — `{{Title.path}}` refs, resource slugs, plain prompts.',
         },
         after: { type: 'string', description: 'Predecessor node (title) to connect from.' },
-        branch: { type: 'string', description: 'Branch NAME of `after` to leave on.' },
+        branch: {
+          type: 'string',
+          description:
+            'Branch of `after` to leave on — its `id` (preferred: stable across config edits, ' +
+            'and for an if-else it is the `case_id` you authored) or its display name. Every ' +
+            "node read and write returns the node's `branches`; take the address from there.",
+        },
         inside: { type: 'string', description: 'Loop node (title) to place this node inside.' },
         inputFor: {
           type: 'string',

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/connect-nodes.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/connect-nodes.ts
@@ -10,7 +10,7 @@ import {
 } from './graph-tool-helpers'
 import { optionalString, resolveWorkflowWrite } from './write-tool-helpers'
 
-/** Connect two nodes — branch handles resolved by NAME through the manifest. */
+/** Connect two nodes — branch handles resolved by id (or name) through the manifest. */
 export function createConnectNodesTool(getDeps: GetToolDeps): AgentToolDefinition {
   return {
     name: 'connect_nodes',
@@ -18,13 +18,19 @@ export function createConnectNodesTool(getDeps: GetToolDeps): AgentToolDefinitio
     displayName: 'Connect workflow nodes',
     surfaces: ['builder'],
     description:
-      'Connect two nodes of the open workflow draft. For a branching source (if-else etc.), pass the branch NAME. Connecting a loop child back to its own loop wires the loop-back edge automatically.',
+      'Connect two nodes of the open workflow draft. For a branching source (if-else etc.), pass `branch` — the branch id (for an if-else, the `case_id` you authored) or its display name. Connecting a loop child back to its own loop wires the loop-back edge automatically.',
     parameters: {
       type: 'object',
       properties: {
         from: { type: 'string', description: 'Source node title.' },
         to: { type: 'string', description: 'Target node title.' },
-        branch: { type: 'string', description: 'Branch NAME of `from` to leave on.' },
+        branch: {
+          type: 'string',
+          description:
+            'Branch of `from` to leave on — its `id` (preferred: stable across config edits, ' +
+            'and for an if-else it is the `case_id` you authored) or its display name. Every ' +
+            "node read and write returns the node's `branches`; take the address from there.",
+        },
       },
       required: ['from', 'to'],
       additionalProperties: false,

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/describe-node-type.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/describe-node-type.ts
@@ -7,6 +7,31 @@ import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
 import { assertWorkflowAreaAccess } from './workflow-authoring-guard'
 
+/**
+ * The branch counterpart of `outputsNote`, and it exists for the same reason:
+ * the list above is computed from `defaultData()`, so it describes a node the
+ * caller is about to configure differently. The old docblock claimed "every
+ * mutation result reflects the node's actual branches" while nothing did
+ * (plan 21 §3.1); `NodeSummary.branches` made that true, and this is where the
+ * caller is told to use it.
+ */
+function branchesNote(type: string): string {
+  const shared =
+    ' Address a branch by its `id`, not its display name. Every add_node/update_node/get_node ' +
+    "result returns this node's ACTUAL branches with what is wired to each — read them from there."
+  if (type === 'if-else') {
+    return (
+      'Branches depend on configuration: each `cases[]` entry is one branch, addressed by its ' +
+      '`case_id`, plus the reserved `false` ELSE branch for "nothing matched". A `case_id` may ' +
+      'NOT be `false` and must be unique across cases. Because you author `case_id` yourself, ' +
+      'you know a branch address before the node exists — you can create the node and wire its ' +
+      'branches in the same batch.' +
+      shared
+    )
+  }
+  return `Branches depend on configuration — the list above is for the DEFAULT config.${shared}`
+}
+
 /** Agent-facing config schema as JSON Schema — `agentSchema ?? configSchema`. */
 function configJsonSchema(manifest: NodeManifest<unknown>): Record<string, unknown> {
   const source = manifest.agentSchema ?? manifest.configSchema
@@ -101,12 +126,20 @@ export function createDescribeNodeTypeTool(getDeps: GetToolDeps): AgentToolDefin
         }
       }
 
-      // Branch names for the default config — branch handles can be config-
-      // dependent (if-else cases), so this is a starting point; every mutation
-      // result reflects the node's actual branches.
-      let branches: Array<{ name: string; kind: string }> | undefined
+      // Branches for the DEFAULT config — a starting point only, because branch
+      // handles are config-dependent (if-else cases, a classifier's categories,
+      // http/crud's gated `fail`). The node's real branches ride every
+      // add_node/update_node/get_node result via `NodeSummary.branches`.
+      //
+      // The `id` is kept. It used to be stripped, leaving `{name, kind}` — and
+      // the id is the ADDRESS, the thing `branch` resolves to and the thing
+      // `graphSummary.edges[].branch` renders, while the name for an if-else is
+      // derived from array position and renames itself as cases are added
+      // (plan 21 §3.1/§10.2).
+      let branches: Array<{ id: string; name: string; kind: string }> | undefined
       try {
         branches = manifest.connection.branches?.(manifest.defaultData()).map((b) => ({
+          id: b.id,
           name: b.name,
           kind: b.kind,
         }))
@@ -140,6 +173,7 @@ export function createDescribeNodeTypeTool(getDeps: GetToolDeps): AgentToolDefin
           ...(manifest.agent?.examples?.length ? { examples: manifest.agent.examples } : {}),
           outputsNote:
             'Outputs depend on configuration — every add_node/update_node result (and get_node) returns this node’s resolved outputs; wire references from those.',
+          ...(branches && branches.length > 0 ? { branchesNote: branchesNote(manifest.id) } : {}),
         },
       }
     },

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/list-node-types.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/list-node-types.ts
@@ -5,6 +5,21 @@ import type { AgentToolDefinition } from '../../../../agent-framework/types'
 import type { GetToolDeps } from '../../types'
 
 /**
+ * Search key: lowercased, every non-alphanumeric run collapsed to one space.
+ *
+ * A plain substring match over the raw strings is why `"if else"` missed
+ * `if-else` (hyphen) and `IF/ELSE` (slash) — the two spellings that ARE the
+ * answer. Normalizing both sides makes punctuation irrelevant, and `synonyms`
+ * covers the words that share no substring at all ("switch", "route").
+ */
+function searchNormalize(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+/**
  * Compact node-type catalog — progressive disclosure (04 §1): this is the only
  * node list in the prompt path; `describe_node_type` carries the schemas.
  * Static product data, identical for every org, so no authorization gate.
@@ -48,14 +63,14 @@ export function createListNodeTypesTool(getDeps: GetToolDeps): AgentToolDefiniti
     execute: async (args) => {
       const category = typeof args.category === 'string' ? args.category : undefined
       const query = typeof args.query === 'string' ? args.query.trim() : ''
-      const normalizedQuery = query.toLowerCase()
+      const normalizedQuery = searchNormalize(query)
       const types = listManifests()
         .filter((m) => !category || m.category === category)
         .filter(
           (m) =>
             !normalizedQuery ||
-            [m.id, m.displayName, m.description, m.category].some((value) =>
-              value.toLowerCase().includes(normalizedQuery)
+            [m.id, m.displayName, m.description, m.category, ...(m.synonyms ?? [])].some((value) =>
+              searchNormalize(value).includes(normalizedQuery)
             )
         )
         .map((m) => ({
@@ -72,10 +87,25 @@ export function createListNodeTypesTool(getDeps: GetToolDeps): AgentToolDefiniti
           ...(query ? [`query "${query}"`] : []),
           ...(category ? [`category "${category}"`] : []),
         ].join(' and ')
+        // `success: true`, deliberately. An empty result is a complete ANSWER,
+        // not a failed call — and returning `success: false` made models read
+        // it as a tool failure and reword: one logged turn burned four
+        // iterations before finding `if-else` via the one-character query
+        // "if" (plan 21 §3.3). Same fix plan 19 applied to `list_app_blocks`
+        // after 33 reworded calls in a single turn. The note ends by saying
+        // the answer is complete, because a note that only describes the world
+        // leaves "maybe a different word finds it" open.
         return {
-          success: false,
-          output: null,
-          error: `No CORE node types match ${filter || 'the supplied filters'}. Call list_node_types without filters to see the full catalog — and list_app_blocks for blocks contributed by installed apps, which are not in it.`,
+          success: true,
+          output: {
+            types: [],
+            note:
+              `No CORE node type matches ${filter || 'the supplied filters'}. This search covers ` +
+              'every core type and their synonyms, so a reworded query will not change the ' +
+              'answer — do not call this again with different words. Call list_node_types with ' +
+              'no filters to see the whole catalog, or list_app_blocks for blocks contributed ' +
+              'by installed apps, which are never in this list.',
+          },
         }
       }
       return { success: true, output: { types } }

--- a/packages/lib/src/ai/kopilot/prompts/sections/__tests__/workflow-builder.test.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/__tests__/workflow-builder.test.ts
@@ -66,6 +66,27 @@ describe('buildWorkflowBuilderPromptSection', () => {
     expect(prompt).toContain('{"recordIds": []}')
   })
 
+  it('teaches branch IDS, not the unstable derived names', () => {
+    // The old paragraph taught branch NAMES and used `branch: "High"` — a
+    // text-classifier-shaped name an if-else can never produce. Its names are
+    // derived from array position, so `IF` becomes `CASE 1` the moment a second
+    // case is authored, and the branch vocabulary the agent was handed one
+    // iteration earlier no longer exists (plan 21 §3.2/§12.2).
+    const prompt = buildWorkflowBuilderPromptSection()
+
+    expect(prompt).toContain('Address a branch by its **id**')
+    expect(prompt).toContain('the branch id IS the `case_id` you authored')
+    expect(prompt).toContain('same batch')
+    expect(prompt).toContain('`connectedTo`')
+    expect(prompt).toContain('`false` is the reserved ELSE handle')
+    // The doctrine that steered the model off the only stable address it has.
+    expect(prompt).not.toContain('never invent handle ids')
+    expect(prompt).not.toContain('branch: "High"')
+    // The honesty rules it must NOT have taken down with it.
+    expect(prompt).toContain('Never invent an output name')
+    expect(prompt).toContain('Never invent node ids, output names, template ids, or node types')
+  })
+
   it('stays static — no per-org content leaks into the cached section', () => {
     // The section is cached as one static block; naming an org's apps here
     // would drop it out of that block on every turn.

--- a/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
+++ b/packages/lib/src/ai/kopilot/prompts/sections/workflow-builder.ts
@@ -25,8 +25,13 @@ export function buildWorkflowBuilderPromptSection(): string {
     // Loops.
     "Loops: nodes go inside a loop via `add_node`'s `inside` parameter, not by drawing an edge into the container. Loop item references are NODE-SCOPED ONLY: `{{Loop Title.item}}`, `{{Loop Title.index}}`, `{{Loop Title.count}}` (using the loop node's own title). Never write bare `{{item}}` or `{{index}}` (one global slot — clobbered by nested loops) and never `{{loop.index}}` (builder-only vocabulary the engine does not write).",
 
-    // Branches.
-    'Branches: an `if-else` (and other branching nodes) is wired by branch NAME via the `branch` parameter on `connect_nodes` / `add_node` — e.g. `connect_nodes(from: "Check Priority", branch: "High", to: "Post To Webhook")`. Branch names come from the node\'s outputs/`describe_node_type`; never invent handle ids.',
+    // Branches. The old wording taught branch NAMES and an example
+    // (`branch: "High"`) that only a text-classifier can produce — an if-else
+    // can only ever be named IF/ELSE/CASE n, and those names are derived from
+    // array POSITION, so authoring a second case silently renames the first.
+    // A logged turn wired one branch of a two-way carrier router and reported
+    // the workflow built (plan 21 §3.2/§12).
+    "Branches: a branching node (`if-else`, `text-classifier`, `human`, a `fail` branch on `http`/`crud`, a loop's `loop-start`) is wired via the `branch` parameter on `connect_nodes` / `add_node`. Address a branch by its **id**, which every node read and write returns on the node's `branches` — each entry has `id` (the address), `name` (display only) and `connectedTo` (what is already wired). For an `if-else` the branch id IS the `case_id` you authored, plus the reserved `false` ELSE branch, so you know every address BEFORE the node exists and can create the node and wire its branches in the same batch. Give each case a `case_id` naming what it matches (`carrier-fedex`, `priority-high`); never `true`/`false`, never a duplicate — `false` is the reserved ELSE handle and is refused. Display names are unstable for an if-else (`IF` becomes `CASE 1` the moment a second case is added), so read the id, not the label.",
 
     // Workflow shape.
     'Workflow shape: a FINISHED workflow has exactly one trigger; while building incrementally, having no trigger yet is fine (it reports as a warning, not an error). Graphs read left to right; parallel branches stack vertically.',
@@ -72,7 +77,8 @@ export function buildWorkflowBuilderPromptSection(): string {
     // Worked examples.
     [
       'Worked examples:',
-      '  - add_node(type: "http", title: "Post To Webhook", description: "Notify the fulfillment system about high-priority orders", after: "Check Priority", branch: "High", config: { url: "https://example.com/hook", method: "POST" })',
+      '  - add_node(type: "if-else", title: "Check Carrier", description: "Route the tracking lookup to the right carrier", after: "Manual Trigger", config: { cases: [{ case_id: "carrier-fedex", logical_operator: "and", conditions: [{ variableId: "Carrier.value", comparison_operator: "is", value: "fedex" }] }, { case_id: "carrier-ups", logical_operator: "and", conditions: [{ variableId: "Carrier.value", comparison_operator: "is", value: "ups" }] }] })',
+      '  - add_node(type: "http", title: "Track FedEx", description: "Ask FedEx for the shipment status", after: "Check Carrier", branch: "carrier-fedex", config: { url: "https://example.com/fedex", method: "POST" })',
       '  - update_node(ref: "Send Email", config: { subject: "Order {{Find Order.record.number}} update" })',
       '  - get_node(ref: "AI Agent") → update_node(ref: "AI Agent", expectedConfigHash: "<returned configHash>", patches: [{ op: "set", path: ["model", "completion_params", "temperature"], value: 0.2 }])',
       '  - add_node(type: "crud", title: "Create Task", inside: "For Each Line Item", config: { … "{{For Each Line Item.item.name}}" … })',

--- a/packages/lib/src/workflow-engine/catalog/if-else.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/if-else.test.ts
@@ -1,0 +1,191 @@
+// packages/lib/src/workflow-engine/catalog/if-else.test.ts
+
+/**
+ * The `if-else` manifest's branch contract
+ * (`plans/kopilot/workflow/21-branch-authoring-reliability.md` §13.1, F1/F4).
+ *
+ * `case_id` is not a label — it IS the branch handle edges leave on, the
+ * address `connect_nodes`/`add_node` resolve, and the key the engine routes on.
+ * Two authored ids therefore have to be refused rather than merely reported:
+ * `false` (the reserved ELSE handle — a case claiming it collapses into ELSE,
+ * so a matched case and a nothing-matched fall-through leave on the same edge),
+ * and any duplicate. Both were writable through the tools and neither was
+ * checked anywhere; the logged 2026-08-18 turn wrote `case_id: 'false'` and
+ * finished reporting `publishable: true` with half the workflow missing.
+ *
+ * The derivation is separately pinned as TOTAL: it used to throw for fewer than
+ * two branches, which is what `cases: []` produces, and both production call
+ * sites are on READ paths.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  branchNameCorrect,
+  extractIfElseVariableIds,
+  type IfElseNodeData,
+  ifElseManifest,
+  unwrapBracedVariableId,
+  validateIfElseConfig,
+} from './nodes/if-else'
+
+function ifElseData(cases: unknown[]): IfElseNodeData {
+  return {
+    id: 'n1',
+    type: 'if-else',
+    title: 'Check Carrier',
+    desc: 'Route by carrier',
+    cases,
+  } as unknown as IfElseNodeData
+}
+
+function oneCase(caseId: string) {
+  return {
+    id: `c-${caseId}`,
+    case_id: caseId,
+    logical_operator: 'and',
+    conditions: [{ id: 'x', variableId: 'Carrier.value', comparison_operator: 'is', value: 'ups' }],
+  }
+}
+
+/** The `blocksAuthoring` errors a config reports — what refuses a write. */
+function blockers(data: IfElseNodeData) {
+  return validateIfElseConfig(data).errors.filter((e) => e.blocksAuthoring === true)
+}
+
+describe('validateIfElseConfig — case_id is the branch address (F1)', () => {
+  it("refuses case_id 'false' — the reserved ELSE handle", () => {
+    const found = blockers(ifElseData([oneCase('carrier-ups'), oneCase('false')]))
+    expect(found).toHaveLength(1)
+    expect(found[0]?.field).toBe('cases.1.case_id')
+    expect(found[0]?.message).toContain('reserved ELSE handle')
+    expect(found[0]?.message).toContain('carrier-ups')
+    expect(found[0]?.type).toBe('error')
+  })
+
+  it('refuses duplicate case_ids across cases', () => {
+    const found = blockers(ifElseData([oneCase('carrier-ups'), oneCase('carrier-ups')]))
+    expect(found).toHaveLength(1)
+    expect(found[0]?.field).toBe('cases.1.case_id')
+    expect(found[0]?.message).toContain('Duplicate case_id "carrier-ups"')
+  })
+
+  it('accepts distinct, meaningful case_ids', () => {
+    expect(blockers(ifElseData([oneCase('carrier-fedex'), oneCase('carrier-ups')]))).toEqual([])
+  })
+
+  it("still accepts the shipped default 'true'", () => {
+    // No migration is owed: every shipped template uses `true` or a descriptive
+    // `case_*` id, and `defaultData()` ships one `true` case.
+    expect(blockers(ifElseData([oneCase('true')]))).toEqual([])
+  })
+
+  it('survives a case with no conditions array at all', () => {
+    // A throwing validator returns NO blockers (`authoringBlockers` swallows
+    // it), so the reserved-handle rule would silently stop firing on exactly
+    // the half-built config it exists to catch.
+    const data = ifElseData([{ id: 'c1', case_id: 'false', logical_operator: 'and' }])
+    expect(() => validateIfElseConfig(data)).not.toThrow()
+    expect(blockers(data)).toHaveLength(1)
+  })
+})
+
+describe('branchNameCorrect — total, never throws (F4)', () => {
+  it('returns just the ELSE branch when there are no cases', () => {
+    expect(branchNameCorrect([{ id: 'false', name: '' }])).toEqual([{ id: 'false', name: 'ELSE' }])
+  })
+
+  it('returns an empty list for an empty list', () => {
+    expect(branchNameCorrect([])).toEqual([])
+  })
+
+  it('keeps IF/ELSE for two branches and CASE n/ELSE for three or more', () => {
+    expect(
+      branchNameCorrect([
+        { id: 'true', name: '' },
+        { id: 'false', name: '' },
+      ])
+    ).toEqual([
+      { id: 'true', name: 'IF' },
+      { id: 'false', name: 'ELSE' },
+    ])
+    expect(
+      branchNameCorrect([
+        { id: 'a', name: '' },
+        { id: 'b', name: '' },
+        { id: 'false', name: '' },
+      ]).map((b) => b.name)
+    ).toEqual(['CASE 1', 'CASE 2', 'ELSE'])
+  })
+})
+
+describe('ifElseManifest.connection.branches', () => {
+  it('derives one branch per case plus the reserved ELSE', () => {
+    const branches = ifElseManifest.connection.branches?.(
+      ifElseData([oneCase('carrier-fedex'), oneCase('carrier-ups')])
+    )
+    expect(branches).toEqual([
+      { id: 'carrier-fedex', name: 'CASE 1', kind: 'default' },
+      { id: 'carrier-ups', name: 'CASE 2', kind: 'default' },
+      { id: 'false', name: 'ELSE', kind: 'default' },
+    ])
+  })
+
+  it('does not throw for cases: [] or absent cases — it degrades to ELSE', () => {
+    expect(ifElseManifest.connection.branches?.(ifElseData([]))).toEqual([
+      { id: 'false', name: 'ELSE', kind: 'default' },
+    ])
+    expect(
+      ifElseManifest.connection.branches?.({ id: 'n1', type: 'if-else' } as IfElseNodeData)
+    ).toEqual([{ id: 'false', name: 'ELSE', kind: 'default' }])
+  })
+})
+
+describe('agent docs', () => {
+  it('teaches case_id as the address and never authors a `false` or `true` case', () => {
+    const usage = ifElseManifest.agent?.usage ?? ''
+    expect(usage).toContain('case_id')
+    expect(usage).toContain('UNIQUE')
+    expect(usage).toContain('reserved')
+    // The old wording — "The ELSE branch handle is always 'false'" — read as an
+    // instruction to NAME the else case `false`, and the model followed it.
+    expect(usage).not.toContain("always 'false'")
+
+    const authored = (ifElseManifest.agent?.examples ?? []).flatMap((example) =>
+      ((example.config as { cases?: Array<{ case_id: string }> }).cases ?? []).map((c) => c.case_id)
+    )
+    expect(authored.length).toBeGreaterThan(0)
+    expect(authored).not.toContain('true')
+    expect(authored).not.toContain('false')
+    expect(authored).toContain('carrier-fedex')
+    // Every example must survive its own validator.
+    for (const example of ifElseManifest.agent?.examples ?? []) {
+      expect(blockers(ifElseData((example.config as { cases: unknown[] }).cases))).toEqual([])
+    }
+  })
+
+  it('carries the search synonyms the natural queries use', () => {
+    expect(ifElseManifest.synonyms).toEqual(
+      expect.arrayContaining(['if else', 'switch', 'branch', 'route'])
+    )
+  })
+})
+
+describe('variableId brace tolerance (F5, read side)', () => {
+  it('strips one surrounding {{ }} and leaves a bare path alone', () => {
+    expect(unwrapBracedVariableId('{{Carrier.value}}')).toBe('Carrier.value')
+    expect(unwrapBracedVariableId('{{ Carrier.value }}')).toBe('Carrier.value')
+    expect(unwrapBracedVariableId('Carrier.value')).toBe('Carrier.value')
+  })
+
+  it('extracts the unwrapped path, so ref-check never sees quadruple braces', () => {
+    const data = ifElseData([
+      {
+        id: 'c1',
+        case_id: 'carrier-ups',
+        logical_operator: 'and',
+        conditions: [{ id: 'x', variableId: '{{Carrier.value}}', comparison_operator: 'is' }],
+      },
+    ])
+    expect(extractIfElseVariableIds(data)).toEqual(['Carrier.value'])
+  })
+})

--- a/packages/lib/src/workflow-engine/catalog/nodes/human.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/human.ts
@@ -250,6 +250,16 @@ export const humanConfirmationManifest: NodeManifest<HumanConfirmationNodeData> 
   displayName: 'Human Review',
   description: 'Pause workflow and wait for human approval',
   icon: 'user-check',
+  /** Extra `list_node_types` search words — never displayed (see NodeManifest.synonyms). */
+  synonyms: [
+    'approval',
+    'approve',
+    'human in the loop',
+    'confirmation',
+    'sign off',
+    'review',
+    'wait for a person',
+  ],
   color: '#f59e0b', // CONDITION category color
   defaultData: () => ({
     title: 'Human Review',

--- a/packages/lib/src/workflow-engine/catalog/nodes/if-else.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/if-else.ts
@@ -112,12 +112,19 @@ export const ifElseNodeDataSchema = z.object({
  * branch is always the ELSE. Generic over the branch shape so callers that carry
  * extra fields (e.g. `type`) keep them on the result.
  * (Relocated from apps/web utils/branch-name-correct.ts, which re-exports it.)
+ *
+ * TOTAL — never throws. It used to throw `if-else node branch number must than
+ * 2` for fewer than two branches, which is exactly what a `cases: []` config
+ * produces (the manifest appends only the reserved ELSE). Both production call
+ * sites read it from a READ path (`validateGraphStructure`, which `readDraft`
+ * runs, and `resolveConnectionSpec`), so a config-shape mistake 500'd
+ * `get_workflow`, `get_node`, `validate_workflow` and every mutation at once —
+ * the agent could not even read the workflow to see what it had done
+ * (plan 21 §2.5). A degenerate config now degrades to the branches it can
+ * name; the validator is what reports it.
  */
 export const branchNameCorrect = <T extends { id: string; name: string }>(branches: T[]): T[] => {
-  const branchLength = branches.length
-  if (branchLength < 2) throw new Error('if-else node branch number must than 2')
-
-  if (branchLength === 2) {
+  if (branches.length < 3) {
     return branches.map((branch) => {
       return { ...branch, name: branch.id === 'false' ? 'ELSE' : 'IF' }
     })
@@ -132,7 +139,7 @@ export const branchNameCorrect = <T extends { id: string; name: string }>(branch
  * Validation function for if-else configuration
  */
 export const validateIfElseConfig = (data: IfElseNodeData): NodeValidationResult => {
-  const errors: Array<{ field: string; message: string; type?: 'warning' | 'error' }> = []
+  const errors: NodeValidationResult['errors'] = []
 
   // Support both old config format and new flattened format
   const dataToValidate = 'config' in data ? (data as any).config : data
@@ -148,16 +155,49 @@ export const validateIfElseConfig = (data: IfElseNodeData): NodeValidationResult
   }
 
   // Validate each case
+  const seenCaseIds = new Set<string>()
   dataToValidate.cases?.forEach((caseItem: any, index: number) => {
-    if (!caseItem.case_id?.trim()) {
+    const caseId = typeof caseItem.case_id === 'string' ? caseItem.case_id.trim() : ''
+    if (!caseId) {
       errors.push({
         field: `cases.${index}.case_id`,
         message: 'Case ID is required',
         type: 'error',
       })
+    } else if (caseId === 'false') {
+      // `false` is the reserved ELSE handle this node ALWAYS appends. A case
+      // claiming it does not create a second branch — it collapses into ELSE
+      // (`WorkflowGraphBuilder.getNodeHandles` sets one Map entry per case_id
+      // and then unconditionally sets `false`), so at run time a matched case
+      // and a nothing-matched fall-through leave on the SAME edge with nothing
+      // distinguishing them. That is a silent mis-route, which is why this
+      // blocks authoring rather than merely warning (plan 21 §2.3/§2.4: the
+      // logged turn wrote `case_id: 'false'` because the old usage string read
+      // as an instruction to).
+      errors.push({
+        field: `cases.${index}.case_id`,
+        message:
+          `case_id "false" is not allowed — "false" is the reserved ELSE handle this node ` +
+          `always exposes. Name the case for what it matches instead (e.g. "carrier-ups").`,
+        type: 'error',
+        blocksAuthoring: true,
+      })
+    } else if (seenCaseIds.has(caseId)) {
+      // Duplicate ids are *members* of the allowed handle set, so the
+      // structural handle check passes them; the collision only shows up at
+      // run time as two cases sharing one edge.
+      errors.push({
+        field: `cases.${index}.case_id`,
+        message:
+          `Duplicate case_id "${caseId}" — every case needs its own id, because case_id IS ` +
+          `the branch handle edges leave on. Two cases sharing one id share one branch.`,
+        type: 'error',
+        blocksAuthoring: true,
+      })
     }
+    if (caseId) seenCaseIds.add(caseId)
 
-    if (caseItem.conditions.length === 0) {
+    if (!caseItem.conditions || caseItem.conditions.length === 0) {
       errors.push({
         field: `cases.${index}.conditions`,
         message: 'At least one condition is required',
@@ -166,7 +206,7 @@ export const validateIfElseConfig = (data: IfElseNodeData): NodeValidationResult
     }
 
     // Validate conditions
-    caseItem.conditions.forEach((condition: any, condIndex: number) => {
+    caseItem.conditions?.forEach((condition: any, condIndex: number) => {
       if (!condition.variableId) {
         errors.push({
           field: `cases.${index}.conditions.${condIndex}.variable_selector`,
@@ -195,6 +235,22 @@ export const validateIfElseConfig = (data: IfElseNodeData): NodeValidationResult
   return { isValid: errors.filter((e) => e.type === 'error').length === 0, errors }
 }
 
+/**
+ * Strip one surrounding `{{ }}` from a condition's `variableId`.
+ *
+ * `variableId` is a BARE dotted path — the only such field in the whole builder
+ * vocabulary, where every other reference is `{{Title.path}}`. An author who
+ * writes the form they were taught everywhere else used to get a quadruple-brace
+ * error naming neither the field nor the rule (plan 21 §3.4), so the braced form
+ * is accepted here and unwrapped. The graph-edit normalizer does the same on the
+ * WRITE path and reports a warning; this is the read-side net under graphs that
+ * never went through it (templates, hand-written `replace_graph` payloads).
+ */
+export function unwrapBracedVariableId(variableId: string): string {
+  const match = /^\s*\{\{\s*([^{}]+?)\s*\}\}\s*$/.exec(variableId)
+  return match?.[1] ?? variableId
+}
+
 export function extractIfElseVariableIds(data: IfElseNodeData): string[] {
   const uniqueVariableIds = new Set<string>()
 
@@ -205,8 +261,8 @@ export function extractIfElseVariableIds(data: IfElseNodeData): string[] {
   dataToUse.cases?.forEach((caseItem: any) => {
     caseItem.conditions?.forEach((condition: any) => {
       // Add variable ID from condition
-      if (condition.variableId) {
-        uniqueVariableIds.add(condition.variableId)
+      if (typeof condition.variableId === 'string' && condition.variableId) {
+        uniqueVariableIds.add(unwrapBracedVariableId(condition.variableId))
       }
       // Extract variable IDs from condition.value editor content
       if (condition.value) {
@@ -256,6 +312,11 @@ export const ifElseManifest: NodeManifest<IfElseNodeData> = {
   description: 'Branch workflow based on conditions',
   icon: 'git-branch',
   color: '#f59e0b', // CONDITION category color
+  // `list_node_types` is a substring search, and none of the words a model
+  // actually reaches for hit `if-else` / `IF/ELSE` / `condition`. A logged turn
+  // burned four iterations on "condition if else branch", "flow_control" and
+  // "if" before finding this type (plan 21 §3.3).
+  synonyms: ['if else', 'switch', 'branch', 'route', 'routing', 'conditional', 'case', 'else'],
   defaultData: () => ({
     title: 'IF/ELSE',
     desc: 'Branch based on conditions',
@@ -294,18 +355,58 @@ export const ifElseManifest: NodeManifest<IfElseNodeData> = {
   agent: {
     authorable: true,
     usage:
-      'Each entry in `cases` is one branch: `case_id` is the edge handle, conditions join via ' +
-      '`logical_operator`. Every condition reads a `variableId` (bare dotted path) with a ' +
-      '`comparison_operator` from the shared operator registry. The ELSE branch handle is ' +
-      "always 'false'. Wire edges by branch id.",
+      'Each entry in `cases` is one branch, and `case_id` IS that branch\u2019s address: it is the ' +
+      'edge handle, it is what you pass as `branch` to `connect_nodes`/`add_node`, and because ' +
+      'YOU author it you already know it before the node exists \u2014 so you can create the node and ' +
+      'wire its branches in the same batch. Name each case for what it matches ' +
+      '(e.g. "carrier-fedex", "priority-high"), never "true"/"false". Every `case_id` must be ' +
+      'UNIQUE, and none may be "false": this node ALWAYS exposes a reserved "false" ELSE branch ' +
+      'for "nothing matched", and a case claiming that id collapses into it, so a matched case ' +
+      'and a fall-through leave on the same edge. Conditions inside a case join via ' +
+      '`logical_operator`. Every condition reads a `variableId` \u2014 a BARE dotted path such as ' +
+      '"Check Order.record.carrier", the one field in this vocabulary that is NOT wrapped in ' +
+      '{{\u2026}} \u2014 with a `comparison_operator` from the shared operator registry.',
     examples: [
       {
-        description: 'Branch on a high-priority ticket',
+        description: 'Route by carrier — one case per carrier, ELSE catches the rest',
         config: {
           cases: [
             {
               id: 'c1',
-              case_id: 'true',
+              case_id: 'carrier-fedex',
+              logical_operator: 'and',
+              conditions: [
+                {
+                  id: 'cond1',
+                  variableId: 'Carrier.value',
+                  comparison_operator: 'is',
+                  value: 'fedex',
+                },
+              ],
+            },
+            {
+              id: 'c2',
+              case_id: 'carrier-ups',
+              logical_operator: 'and',
+              conditions: [
+                {
+                  id: 'cond2',
+                  variableId: 'Carrier.value',
+                  comparison_operator: 'is',
+                  value: 'ups',
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        description: 'Single condition — wire the match on "priority-high", the rest on "false"',
+        config: {
+          cases: [
+            {
+              id: 'c1',
+              case_id: 'priority-high',
               logical_operator: 'and',
               conditions: [
                 {

--- a/packages/lib/src/workflow-engine/catalog/nodes/loop.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/loop.ts
@@ -173,6 +173,8 @@ export const loopManifest: NodeManifest<LoopNodeData> = {
   displayName: 'Loop',
   description: 'Iterate over each item in a list',
   icon: 'repeat',
+  /** Extra `list_node_types` search words — never displayed (see NodeManifest.synonyms). */
+  synonyms: ['for each', 'foreach', 'iterate', 'iteration', 'repeat', 'each', 'map over'],
   color: '#8B5CF6', // Purple
   defaultData: () => ({
     title: 'Loop',

--- a/packages/lib/src/workflow-engine/catalog/nodes/text-classifier.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/text-classifier.ts
@@ -304,6 +304,17 @@ export const textClassifierManifest: NodeManifest<TextClassifierNodeData> = {
   displayName: 'Text Classifier',
   description: 'Classify text into predefined categories using AI',
   icon: 'tags',
+  /** Extra `list_node_types` search words — never displayed (see NodeManifest.synonyms). */
+  synonyms: [
+    'classify',
+    'classifier',
+    'categorize',
+    'category',
+    'triage',
+    'route',
+    'branch',
+    'switch',
+  ],
   color: '#f59e0b', // CONDITION category color
   defaultData: () => ({
     title: 'Text Classifier',

--- a/packages/lib/src/workflow-engine/catalog/types.ts
+++ b/packages/lib/src/workflow-engine/catalog/types.ts
@@ -124,6 +124,16 @@ export interface NodeManifest<TConfig = unknown> {
   /** Dynamic icon name based on config (optional). */
   getIcon?: (config: TConfig) => string
 
+  /**
+   * Extra words `list_node_types` searches, beyond id/displayName/description/
+   * category. NOT displayed anywhere — this exists only so the natural query
+   * finds the type. `if-else` is the motivating case: "if else", "switch",
+   * "branch" and "route" all missed `if-else`/`IF/ELSE`/`condition`, and a
+   * logged turn spent four iterations rewording before it landed on `"if"`
+   * (plan 21 §3.3).
+   */
+  synonyms?: string[]
+
   /** Only set for trigger nodes. */
   triggerType?: WorkflowTriggerType
   defaultData: () => Partial<TConfig>

--- a/packages/lib/src/workflow-engine/core/__tests__/workflow-graph-builder.test.ts
+++ b/packages/lib/src/workflow-engine/core/__tests__/workflow-graph-builder.test.ts
@@ -590,3 +590,50 @@ describe('WorkflowGraphBuilder', () => {
     })
   })
 })
+
+describe('WorkflowGraphBuilder.getNodeHandles — crud declares a fail branch (plan 21 §7.3)', () => {
+  beforeEach(() => {
+    const registry = new NodeProcessorRegistry()
+    for (const type of [WorkflowNodeType.CRUD, WorkflowNodeType.HTTP]) {
+      registry.registerProcessor({
+        type,
+        preprocessNode: async () => ({ inputs: {}, metadata: {} }),
+        execute: async (node) => ({
+          nodeId: node.nodeId,
+          status: NodeRunningStatus.Succeeded,
+          output: {},
+          executionTime: 0,
+        }),
+        validate: async () => ({ valid: true, errors: [], warnings: [] }),
+      })
+    }
+    WorkflowGraphBuilder.initialize(registry)
+  })
+
+  /** The handle ids the builder registered for the one node in this workflow. */
+  function handlesFor(data: Record<string, unknown>): string[] {
+    const graph = WorkflowGraphBuilder.buildGraph({
+      id: 'wf',
+      graph: {
+        nodes: [{ id: 'n1', type: data.type as string, data }],
+        edges: [],
+      },
+    } as never)
+    return [...(graph.nodes.get('n1')?.outputHandles.keys() ?? [])]
+  }
+
+  it("registers `fail` for crud with error_strategy 'fail', mirroring http", () => {
+    // `crud` declares this branch in its manifest, renders it in node.tsx, gets
+    // it from calculateTargetBranches and emits `outputHandle: 'fail'` from its
+    // processor — but had no arm here, so it fell to `default:` and registered
+    // `source` alone. The derived metadata then lied: `hasMultipleOutputs:
+    // false` and the fail edge invisible to fork/parallel accounting.
+    expect(handlesFor({ type: 'crud', error_strategy: 'fail' })).toEqual(['source', 'fail'])
+    expect(handlesFor({ type: 'http', error_strategy: 'fail' })).toEqual(['source', 'fail'])
+  })
+
+  it('registers `source` alone when the fail branch is not enabled', () => {
+    expect(handlesFor({ type: 'crud', error_strategy: 'continue' })).toEqual(['source'])
+    expect(handlesFor({ type: 'crud' })).toEqual(['source'])
+  })
+})

--- a/packages/lib/src/workflow-engine/core/workflow-graph-builder.ts
+++ b/packages/lib/src/workflow-engine/core/workflow-graph-builder.ts
@@ -513,6 +513,16 @@ export class WorkflowGraphBuilder {
         break
 
       case 'http':
+      // `crud` declares the same pair everywhere else — its manifest
+      // (`catalog/nodes/crud.ts`), its `node.tsx`, `calculateTargetBranches`,
+      // and a processor that emits `outputHandle: 'fail'` — but had no arm
+      // here, so it fell to `default:` and registered `source` alone. Not a
+      // live routing bug (engine failures route through `findFailureEdge`,
+      // which reads the edges directly), but the derived metadata lied: a crud
+      // node with a wired fail branch reported `hasMultipleOutputs: false` and
+      // its fail edge was invisible to fork/parallel accounting
+      // (plan 21 §7.3).
+      case 'crud':
         outputHandles.set('source', WorkflowGraphBuilder.createEmptyOutputInfo('source'))
         // Add fail handle if error strategy is 'fail'
         if (node.data.error_strategy === 'fail') {

--- a/packages/lib/src/workflows/graph-edit/__tests__/branch-authoring.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/branch-authoring.test.ts
@@ -1,0 +1,521 @@
+// packages/lib/src/workflows/graph-edit/__tests__/branch-authoring.test.ts
+
+/**
+ * Branch authoring reliability
+ * (`plans/kopilot/workflow/21-branch-authoring-reliability.md` §13.1).
+ *
+ * The failure this pins: an agent must commit to a branch address inside the
+ * SAME tool batch that creates the branches, before any result can be read. So
+ * the address has to be the `case_id` the agent itself authors (T2), the write
+ * has to refuse an address that collides with the reserved ELSE handle (F1),
+ * every read and write has to report the node's real branches and what is wired
+ * to each (T1), an unwired branch has to be said out loud (T5), and none of it
+ * may throw out of a read path when the config is degenerate (F4).
+ */
+
+import { ok as okResult } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Partial mocks only — the cache barrel is imported by half of lib and a
+// wholesale replacement dies at collection.
+const getCachedResources = vi.fn()
+vi.mock('../../../cache', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../cache')>()),
+  getCachedResources: (...args: unknown[]) => getCachedResources(...args),
+  // Core node types only: the manifest lookup must resolve to the registry.
+  getCachedInstalledApps: async () => [],
+}))
+
+// The persist seam — replaced so no engine/queue module graph loads.
+const serviceUpdate = vi.fn()
+vi.mock('../../workflow-service', () => ({
+  WorkflowService: class {
+    update(...args: unknown[]) {
+      return serviceUpdate(...args)
+    }
+  },
+}))
+
+// Output resolution is a collaborator here, not the thing under test. An empty
+// map makes `ref-check` skip its path check (nothing declared proves nothing)
+// while still enforcing node existence and the upstream rule — which is what
+// the `{{…}}`-in-`variableId` case needs to prove it resolved to a NODE.
+const resolveGraphOutputs = vi.fn(async () => okResult(new Map()))
+vi.mock('../../../workflow-engine/catalog/resolve-outputs', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../workflow-engine/catalog/resolve-outputs')>()
+  return { ...actual, resolveGraphOutputs: () => resolveGraphOutputs() }
+})
+
+vi.mock('../../mail-trigger-guard', () => ({
+  assertMailTriggerNotPersonal: async () => {},
+}))
+
+const { addNode, connectNodes, updateNode } = await import('../ops')
+const { readDraft } = await import('../read')
+const { resolveConnectionSpec } = await import('../normalize/connection')
+const { validateGraphStructure, validateBranchWiring } = await import('../validate')
+
+import { getManifest } from '../../../workflow-engine/catalog/registry'
+import type { DraftGraph, GraphEdge, GraphNode, Issue, NodeSummary } from '../types'
+
+const ORG = 'org_1'
+const APP = 'wfapp_1'
+const TRIGGER_ID = 'scheduled-aaaaaaaaaaaaaaaaaaaaa'
+const CARRIER_ID = 'wait-aaaaaaaaaaaaaaaaaaaaaaa'
+const IFELSE_ID = 'ifelse-aaaaaaaaaaaaaaaaaaaaa'
+const HUMAN_ID = 'human-aaaaaaaaaaaaaaaaaaaaaa'
+
+/** The core registry alone — no app installed in these fixtures. */
+const coreLookup = getManifest
+
+function triggerNode(): GraphNode {
+  return {
+    id: TRIGGER_ID,
+    type: 'standard',
+    position: { x: 100, y: 200 },
+    width: 244,
+    height: 100,
+    data: {
+      id: TRIGGER_ID,
+      type: 'scheduled',
+      title: 'Every Morning',
+      config: {
+        triggerInterval: 'days',
+        timeBetweenTriggers: { days: 1, isConstant: true },
+        timezone: 'UTC',
+      },
+      isEnabled: true,
+    },
+  }
+}
+
+/** A plain single-`source` node, and the upstream a condition can read. */
+function carrierNode(): GraphNode {
+  return {
+    id: CARRIER_ID,
+    type: 'standard',
+    position: { x: 400, y: 200 },
+    width: 244,
+    height: 100,
+    data: { id: CARRIER_ID, type: 'wait', title: 'Carrier' },
+  }
+}
+
+function ifElseNode(cases: unknown[]): GraphNode {
+  return {
+    id: IFELSE_ID,
+    type: 'standard',
+    position: { x: 700, y: 200 },
+    width: 244,
+    height: 100,
+    data: { id: IFELSE_ID, type: 'if-else', title: 'Check Carrier', cases },
+  }
+}
+
+function humanNode(): GraphNode {
+  return {
+    id: HUMAN_ID,
+    type: 'standard',
+    position: { x: 700, y: 200 },
+    width: 244,
+    height: 100,
+    data: {
+      id: HUMAN_ID,
+      type: 'human-confirmation',
+      title: 'Approve Refund',
+      message: 'Approve?',
+      assignees: { actorIds: ['user:u1'] },
+    },
+  }
+}
+
+function carrierCase(caseId: string, value: string, variableId = 'Carrier.value') {
+  return {
+    id: `c-${caseId}`,
+    case_id: caseId,
+    logical_operator: 'and',
+    conditions: [{ id: `cond-${caseId}`, variableId, comparison_operator: 'is', value }],
+  }
+}
+
+function edge(source: string, sourceHandle: string, target: string): GraphEdge {
+  return {
+    id: `${source}-${sourceHandle}-${target}`,
+    source,
+    sourceHandle,
+    target,
+    targetHandle: 'target',
+  }
+}
+
+function makeDb(graph: DraftGraph) {
+  const app = {
+    id: APP,
+    name: 'My Flow',
+    organizationId: ORG,
+    draftWorkflow: {
+      id: 'wf_draft',
+      name: 'My Flow (Draft)',
+      graph,
+      triggerType: 'scheduled',
+      entityDefinitionId: null,
+      organizationId: ORG,
+      version: 3,
+    },
+  }
+  return {
+    query: { WorkflowApp: { findFirst: vi.fn(async () => app) } },
+  } as unknown as import('@auxx/database').Database
+}
+
+/** The graph the pipeline persisted (last WorkflowService.update input). */
+function persistedGraph(): DraftGraph {
+  const call = serviceUpdate.mock.calls.at(-1)
+  expect(call).toBeDefined()
+  return (call?.[1] as Record<string, unknown>).graph as DraftGraph
+}
+
+const scope = { workflowAppId: APP, organizationId: ORG }
+
+beforeEach(() => {
+  getCachedResources.mockReset()
+  getCachedResources.mockResolvedValue([])
+  serviceUpdate.mockReset()
+  serviceUpdate.mockImplementation(async (_org: string, input: Record<string, unknown>) => ({
+    graphHash: 'hash-after',
+    triggerType: input.triggerType ?? null,
+    entityDefinitionId: input.entityDefinitionId ?? null,
+  }))
+})
+
+/** trigger → Carrier, ready for an if-else to be added after `Carrier`. */
+function baseGraph(): DraftGraph {
+  return {
+    nodes: [triggerNode(), carrierNode()],
+    edges: [edge(TRIGGER_ID, 'source', CARRIER_ID)],
+  }
+}
+
+describe('F1 — case_id is refused when it collides or repeats', () => {
+  it("refuses an add_node whose case_id is the reserved 'false'", async () => {
+    const result = await addNode(makeDb(baseGraph()), {
+      ...scope,
+      type: 'if-else',
+      title: 'Check Carrier',
+      after: 'Carrier',
+      config: { cases: [carrierCase('carrier-ups', 'ups'), carrierCase('false', 'fedex')] },
+    })
+    const value = result._unsafeUnwrap()
+    expect(value.applied).toBe(false)
+    expect(serviceUpdate).not.toHaveBeenCalled()
+    expect(value.issues.map((i) => i.message).join('\n')).toContain('reserved ELSE handle')
+  })
+
+  it('refuses duplicate case_ids', async () => {
+    const result = await addNode(makeDb(baseGraph()), {
+      ...scope,
+      type: 'if-else',
+      title: 'Check Carrier',
+      after: 'Carrier',
+      config: { cases: [carrierCase('carrier-ups', 'ups'), carrierCase('carrier-ups', 'fedex')] },
+    })
+    const value = result._unsafeUnwrap()
+    expect(value.applied).toBe(false)
+    expect(value.issues.map((i) => i.message).join('\n')).toContain('Duplicate case_id')
+  })
+
+  it('applies meaningful, distinct case_ids', async () => {
+    const result = await addNode(makeDb(baseGraph()), {
+      ...scope,
+      type: 'if-else',
+      title: 'Check Carrier',
+      after: 'Carrier',
+      config: {
+        cases: [carrierCase('carrier-fedex', 'fedex'), carrierCase('carrier-ups', 'ups')],
+      },
+    })
+    expect(result._unsafeUnwrap().applied).toBe(true)
+  })
+})
+
+describe('T1 — branches ride every node read and write', () => {
+  const twoCase = () => ({
+    nodes: [
+      triggerNode(),
+      carrierNode(),
+      ifElseNode([carrierCase('carrier-fedex', 'fedex'), carrierCase('carrier-ups', 'ups')]),
+    ],
+    edges: [edge(TRIGGER_ID, 'source', CARRIER_ID), edge(CARRIER_ID, 'source', IFELSE_ID)],
+  })
+
+  it('add_node returns the new node’s branches with ids, names and empty targets', async () => {
+    const result = await addNode(makeDb(baseGraph()), {
+      ...scope,
+      type: 'if-else',
+      title: 'Check Carrier',
+      after: 'Carrier',
+      config: {
+        cases: [carrierCase('carrier-fedex', 'fedex'), carrierCase('carrier-ups', 'ups')],
+      },
+    })
+    expect(result._unsafeUnwrap().node?.branches).toEqual([
+      { id: 'carrier-fedex', name: 'CASE 1', kind: 'default', connectedTo: [] },
+      { id: 'carrier-ups', name: 'CASE 2', kind: 'default', connectedTo: [] },
+      { id: 'false', name: 'ELSE', kind: 'default', connectedTo: [] },
+    ])
+  })
+
+  it('OMITS the field entirely for a single-source node — never an empty array', async () => {
+    const result = await addNode(makeDb(baseGraph()), {
+      ...scope,
+      type: 'wait',
+      title: 'Then Wait',
+      after: 'Carrier',
+    })
+    const node = result._unsafeUnwrap().node as NodeSummary
+    expect(node.branches).toBeUndefined()
+    expect('branches' in node).toBe(false)
+  })
+
+  it('connect_nodes shows connectedTo grow on the branch it wired', async () => {
+    const graph = twoCase()
+    graph.nodes.push({
+      id: 'track-aaaaaaaaaaaaaaaaaaaaaa',
+      type: 'standard',
+      position: { x: 1000, y: 100 },
+      data: { id: 'track-aaaaaaaaaaaaaaaaaaaaaa', type: 'wait', title: 'Track FedEx' },
+    })
+    const result = await connectNodes(makeDb(graph), {
+      ...scope,
+      from: 'Check Carrier',
+      to: 'Track FedEx',
+      branch: 'carrier-fedex',
+    })
+    expect(result._unsafeUnwrap().applied).toBe(true)
+    const wired = persistedGraph().edges.find((e) => e.sourceHandle === 'carrier-fedex')
+    expect(wired?.target).toBe('track-aaaaaaaaaaaaaaaaaaaaaa')
+
+    const draft = await readDraft(makeDb(persistedGraph()), scope)
+    const summary = draft._unsafeUnwrap().nodes.find((n) => n.id === IFELSE_ID)
+    expect(summary?.branches?.find((b) => b.id === 'carrier-fedex')?.connectedTo).toEqual([
+      'Track FedEx',
+    ])
+  })
+
+  it('update_node returns the RECOMPUTED branch list after a case reshape', async () => {
+    const result = await updateNode(makeDb(twoCase()), {
+      ...scope,
+      ref: 'Check Carrier',
+      config: {
+        cases: [
+          carrierCase('carrier-fedex', 'fedex'),
+          carrierCase('carrier-ups', 'ups'),
+          carrierCase('carrier-dhl', 'dhl'),
+        ],
+      },
+    })
+    const branches = result._unsafeUnwrap().node?.branches
+    expect(branches?.map((b) => b.id)).toEqual([
+      'carrier-fedex',
+      'carrier-ups',
+      'carrier-dhl',
+      'false',
+    ])
+  })
+
+  it('readDraft carries branches on every node summary', async () => {
+    const draft = await readDraft(makeDb(twoCase()), scope)
+    const nodes = draft._unsafeUnwrap().nodes
+    expect(nodes.find((n) => n.id === IFELSE_ID)?.branches?.map((b) => b.id)).toEqual([
+      'carrier-fedex',
+      'carrier-ups',
+      'false',
+    ])
+    expect(nodes.find((n) => n.id === CARRIER_ID)?.branches).toBeUndefined()
+  })
+})
+
+describe('T2 — the address is knowable before the node exists', () => {
+  it('wires a branch by case_id in the same sequence that created the node', async () => {
+    // The logged failure: three calls in ONE batch, the second naming a branch
+    // of a node the first has not created yet. With `case_id` as the address
+    // the batch is correct as issued — nothing has to be read back.
+    let graph = baseGraph()
+    const created = await addNode(makeDb(graph), {
+      ...scope,
+      type: 'if-else',
+      title: 'Check Carrier',
+      after: 'Carrier',
+      config: {
+        cases: [carrierCase('carrier-fedex', 'fedex'), carrierCase('carrier-ups', 'ups')],
+      },
+    })
+    expect(created._unsafeUnwrap().applied).toBe(true)
+    graph = persistedGraph()
+
+    const wired = await addNode(makeDb(graph), {
+      ...scope,
+      type: 'wait',
+      title: 'Track FedEx',
+      after: 'Check Carrier',
+      branch: 'carrier-fedex', // authored above, never read back
+    })
+    expect(wired._unsafeUnwrap().applied).toBe(true)
+    const added = persistedGraph().nodes.find((n) => n.data?.title === 'Track FedEx')
+    const edgeToIt = persistedGraph().edges.find((e) => e.target === added?.id)
+    expect(edgeToIt?.sourceHandle).toBe('carrier-fedex')
+  })
+
+  it('a near-miss branch ref gets a "did you mean" over both names and ids', () => {
+    const nodes = [ifElseNode([carrierCase('true', 'x'), carrierCase('carrier-ups', 'ups')])]
+    const byName = resolveConnectionSpec(
+      nodes,
+      { after: 'Check Carrier', branch: 'CASE1' },
+      coreLookup
+    )
+    // Nearest first — "CASE 1" is one edit away, "CASE 2" two.
+    expect(byName._unsafeUnwrapErr().message).toContain(
+      'Did you mean "CASE 1" (true) or "CASE 2" (carrier-ups)?'
+    )
+
+    const byId = resolveConnectionSpec(
+      nodes,
+      { after: 'Check Carrier', branch: 'carrier-up' },
+      coreLookup
+    )
+    expect(byId._unsafeUnwrapErr().message).toContain('Did you mean "CASE 2" (carrier-ups)?')
+  })
+
+  it('lists every candidate with BOTH name and id, and points at the id', () => {
+    // The logged turn re-issued `branch: "IF"` verbatim after a flat rejection.
+    // "IF" is not a near miss of "CASE 1" by any edit distance, so the
+    // candidate list plus the addressing rule is what has to carry it.
+    const nodes = [ifElseNode([carrierCase('true', 'x'), carrierCase('carrier-ups', 'ups')])]
+    const message = resolveConnectionSpec(
+      nodes,
+      { after: 'Check Carrier', branch: 'IF' },
+      coreLookup
+    )._unsafeUnwrapErr().message
+    expect(message).toContain('No branch "IF" on node "Check Carrier"')
+    expect(message).toContain('Available branches: "CASE 1" (true), "CASE 2" (carrier-ups)')
+    expect(message).toContain('"ELSE" (false)')
+    expect(message).toContain('Address a branch by its id')
+  })
+})
+
+describe('T5 — an unwired branch is reported', () => {
+  it('warns per unwired non-fallback branch, and stays silent on ELSE', () => {
+    const graph: DraftGraph = {
+      nodes: [
+        ifElseNode([carrierCase('carrier-fedex', 'fedex'), carrierCase('carrier-ups', 'ups')]),
+      ],
+      edges: [],
+    }
+    const issues = validateBranchWiring(graph, coreLookup)
+    expect(issues.map((i) => i.severity)).toEqual(['warning', 'warning'])
+    expect(issues.map((i) => i.field)).toEqual(['branches', 'branches'])
+    expect(issues[0]?.message).toContain('"CASE 1" (carrier-fedex)')
+    expect(issues.map((i) => i.message).join()).not.toContain('ELSE')
+  })
+
+  it('says nothing once every branch is wired', () => {
+    const graph: DraftGraph = {
+      nodes: [ifElseNode([carrierCase('carrier-fedex', 'fedex')]), carrierNode()],
+      edges: [edge(IFELSE_ID, 'carrier-fedex', CARRIER_ID)],
+    }
+    expect(validateBranchWiring(graph, coreLookup)).toEqual([])
+  })
+
+  it('errors for `human`, which has no default output to fall through to', () => {
+    const issues = validateBranchWiring({ nodes: [humanNode()], edges: [] }, coreLookup)
+    expect(issues).toHaveLength(3)
+    expect(new Set(issues.map((i) => i.severity))).toEqual(new Set(['error']))
+    expect(issues[0]?.message).toContain('dead-ends')
+  })
+
+  it('is NOT a structural error, so it never refuses a mutation', async () => {
+    // Tier 2, not tier 1: a half-wired approval must stay editable.
+    expect(
+      validateGraphStructure({ nodes: [humanNode()], edges: [] }, { lookup: coreLookup }).filter(
+        (i) => i.severity === 'error'
+      )
+    ).toEqual([])
+
+    const result = await addNode(makeDb({ nodes: [humanNode()], edges: [] }), {
+      ...scope,
+      type: 'wait',
+      title: 'Then Wait',
+      after: 'Approve Refund',
+      branch: 'approved',
+    })
+    expect(result._unsafeUnwrap().applied).toBe(true)
+  })
+
+  it('surfaces on the mutation result and in readDraft', async () => {
+    const graph: DraftGraph = {
+      nodes: [triggerNode(), carrierNode(), ifElseNode([carrierCase('carrier-ups', 'ups')])],
+      edges: [edge(TRIGGER_ID, 'source', CARRIER_ID), edge(CARRIER_ID, 'source', IFELSE_ID)],
+    }
+    const draft = await readDraft(makeDb(graph), scope)
+    const branchIssues = draft._unsafeUnwrap().issues.filter((i: Issue) => i.field === 'branches')
+    expect(branchIssues).toHaveLength(1)
+    expect(branchIssues[0]?.nodeRef).toBe('Check Carrier')
+  })
+})
+
+describe('F4 — a degenerate cases config never throws out of a read path', () => {
+  const emptyCases = (): DraftGraph => ({
+    nodes: [triggerNode(), ifElseNode([]), carrierNode()],
+    edges: [edge(TRIGGER_ID, 'source', IFELSE_ID), edge(IFELSE_ID, 'false', CARRIER_ID)],
+  })
+
+  it('validateGraphStructure does not throw and accepts the ELSE handle', () => {
+    const issues = validateGraphStructure(emptyCases(), { lookup: coreLookup })
+    expect(issues.filter((i) => i.severity === 'error')).toEqual([])
+  })
+
+  it('resolveConnectionSpec does not throw', () => {
+    const nodes = emptyCases().nodes
+    expect(
+      resolveConnectionSpec(nodes, { after: 'Check Carrier' }, coreLookup)._unsafeUnwrap()
+    ).toEqual({ sourceNodeId: IFELSE_ID, sourceHandle: 'false' })
+  })
+
+  it('readDraft returns rather than 500s, and reports the config problem', async () => {
+    const draft = await readDraft(makeDb(emptyCases()), scope)
+    expect(draft.isOk()).toBe(true)
+    const value = draft._unsafeUnwrap()
+    expect(value.nodes.find((n) => n.id === IFELSE_ID)?.branches).toEqual([
+      { id: 'false', name: 'ELSE', kind: 'default', connectedTo: ['Carrier'] },
+    ])
+    expect(value.issues.map((i) => i.message).join('\n')).toContain('At least one case is required')
+  })
+})
+
+describe('F5 — a braced variableId is accepted and unwrapped', () => {
+  it('strips the braces, resolves the node ref, and warns naming the field', async () => {
+    const result = await addNode(makeDb(baseGraph()), {
+      ...scope,
+      type: 'if-else',
+      title: 'Check Carrier',
+      after: 'Carrier',
+      config: { cases: [carrierCase('carrier-ups', 'ups', '{{Carrier.value}}')] },
+    })
+    const value = result._unsafeUnwrap()
+    expect(value.applied).toBe(true)
+
+    const persisted = persistedGraph().nodes.find((n) => n.data?.title === 'Check Carrier')
+    const cases = persisted?.data?.cases as Array<{ conditions: Array<{ variableId: string }> }>
+    // The braces are gone AND the bare path still normalized to the node id.
+    expect(cases[0]?.conditions[0]?.variableId).toBe(`${CARRIER_ID}.value`)
+
+    const warning = value.issues.find((i) => i.field?.endsWith('variableId'))
+    expect(warning?.severity).toBe('warning')
+    expect(warning?.field).toBe('cases.0.conditions.0.variableId')
+    expect(warning?.message).toContain('BARE dotted path')
+
+    // And crucially: no quadruple-brace ref error.
+    expect(value.issues.map((i) => i.message).join('\n')).not.toContain('{{{{')
+  })
+})

--- a/packages/lib/src/workflows/graph-edit/branches.ts
+++ b/packages/lib/src/workflows/graph-edit/branches.ts
@@ -1,0 +1,79 @@
+// packages/lib/src/workflows/graph-edit/branches.ts
+
+/**
+ * A node's outgoing branches, as the agent surface reports them — pure,
+ * browser-safe.
+ *
+ * `manifest.connection.branches(config)` is the single source for the handle
+ * ids the canvas renders, the engine routes on and edges leave on. Everything
+ * here is a thin, TOTAL wrapper over it:
+ *
+ * - {@link safeBranches} never throws. A derivation is a function of
+ *   agent-authored config, so a config-shape mistake can make it blow up
+ *   (`if-else` with `cases: []` did exactly that until plan 21 F4), and every
+ *   caller here is on a READ path — `validateGraphStructure` runs inside
+ *   `readDraft`, so one bad node used to 500 `get_workflow`, `get_node`,
+ *   `validate_workflow` AND every mutation at once. A degenerate config must
+ *   report as an issue, never as a thrown read.
+ * - {@link buildBranchSummaries} joins the derived branches against the graph's
+ *   edges so every node read and write can say what a branch is CALLED, what
+ *   its address is, and what is already wired to it. Before this, the only way
+ *   an agent learned a node's real branch vocabulary was to guess wrong and
+ *   read the error message (plan 21 §3.1).
+ */
+
+import type { NodeBranch, NodeManifest } from '../../workflow-engine/catalog/types'
+import { formatNodeRef } from './refs'
+import type { DraftGraph, GraphNode, NodeBranchSummary } from './types'
+
+/**
+ * Branch ids that mean "nothing else matched". Mirrors `isFallback` in
+ * `workflow-engine/core/workflow-graph-builder.ts` — leaving one of these
+ * unwired is a legitimate, common authoring choice, not an oversight.
+ */
+export const FALLBACK_BRANCH_IDS: ReadonlySet<string> = new Set(['false', 'default', 'unmatched'])
+
+/** The plain output handle every non-branching node exposes. */
+export const DEFAULT_SOURCE_HANDLE = 'source'
+
+/** The branches a manifest derives for this config — `[]` on absence OR on throw. */
+export function safeBranches(
+  manifest: NodeManifest<any> | undefined,
+  config: unknown
+): NodeBranch[] {
+  try {
+    return manifest?.connection.branches?.(config) ?? []
+  } catch {
+    return []
+  }
+}
+
+/** The handle an edge leaves on, defaulted the way every writer defaults it. */
+export function edgeSourceHandle(edge: { sourceHandle?: string | null }): string {
+  return edge.sourceHandle ?? DEFAULT_SOURCE_HANDLE
+}
+
+/**
+ * This node's branches with their current targets, or `undefined` for a node
+ * that has none.
+ *
+ * `undefined` rather than `[]` on purpose: an empty array reads as "this node
+ * has branches and none are wired", which is a different and alarming claim
+ * about the ~23 single-`source` node types.
+ */
+export function buildBranchSummaries(
+  graph: DraftGraph,
+  node: GraphNode,
+  manifest: NodeManifest<any> | undefined
+): NodeBranchSummary[] | undefined {
+  const branches = safeBranches(manifest, node.data)
+  if (branches.length === 0) return undefined
+  return branches.map((branch) => ({
+    id: branch.id,
+    name: branch.name,
+    kind: branch.kind,
+    connectedTo: graph.edges
+      .filter((edge) => edge.source === node.id && edgeSourceHandle(edge) === branch.id)
+      .map((edge) => formatNodeRef(graph.nodes, edge.target)),
+  }))
+}

--- a/packages/lib/src/workflows/graph-edit/index.ts
+++ b/packages/lib/src/workflows/graph-edit/index.ts
@@ -18,6 +18,15 @@
  */
 
 export {
+  buildBranchSummaries,
+  FALLBACK_BRANCH_IDS,
+  safeBranches,
+} from './branches'
+export {
+  type BarePathUnwrapResult,
+  unwrapBracedBarePaths,
+} from './normalize/bare-path-fields'
+export {
   type ConnectionSpec,
   resolveConnectionSpec,
 } from './normalize/connection'
@@ -139,6 +148,7 @@ export type {
   GraphSummary,
   Issue,
   IssueSeverity,
+  NodeBranchSummary,
   NodeMeta,
   NodeRef,
   NodeSummary,
@@ -151,6 +161,7 @@ export {
   hasBlockingIssues,
   isTriggerNode,
   nodeType,
+  validateBranchWiring,
   validateGraphStructure,
   validateNodeConfigs,
 } from './validate'

--- a/packages/lib/src/workflows/graph-edit/normalize/bare-path-fields.ts
+++ b/packages/lib/src/workflows/graph-edit/normalize/bare-path-fields.ts
@@ -1,0 +1,80 @@
+// packages/lib/src/workflows/graph-edit/normalize/bare-path-fields.ts
+
+/**
+ * The one field in the builder vocabulary that takes a BARE dotted path —
+ * pure, browser-safe.
+ *
+ * `if-else` conditions read `variableId: "Carrier.value"`. Everything else a
+ * model writes is `{{Title.path}}`, and that is what the prompt drills, so the
+ * taught form arrives here constantly. It used to be punished with a
+ * quadruple-brace error that named neither the field nor the rule —
+ * `normalizeFriendlyRefs` rewrote the INNER span to a node id and `ref-check`
+ * re-wrapped the whole value for its message, producing
+ * `Reference "{{{{form-input-xxx.value}}}}" points at unknown node
+ * "{{form-input-xxx"` and costing one refused mutation on essentially every
+ * first if-else an agent writes (plan 21 §3.4).
+ *
+ * So the braced form is ACCEPTED: the braces are stripped here, before
+ * `normalizeFriendlyRefs` sees the value, so the bare path resolves through the
+ * normal bare-ref gate. A `warning` names the field and the rule, because the
+ * rule is real — it is just the exception, and an exception has to be taught
+ * rather than enforced with a nonsense error.
+ */
+
+import { unwrapBracedVariableId } from '../../../workflow-engine/catalog/nodes/if-else'
+import type { Issue } from '../types'
+
+/** What {@link unwrapBracedBarePaths} returns: the corrected config plus findings. */
+export interface BarePathUnwrapResult {
+  config: Record<string, unknown>
+  issues: Issue[]
+}
+
+/**
+ * Strip a single surrounding `{{ }}` from every bare-path field in `config`,
+ * reporting one `warning` per corrected field. Returns `config` untouched (and
+ * no issues) when there is nothing to correct.
+ *
+ * Only `if-else` has such a field today. Keyed on type rather than walked
+ * blindly, because stripping braces anywhere else would silently turn a real
+ * reference into prose.
+ */
+export function unwrapBracedBarePaths(
+  type: string,
+  config: Record<string, unknown>
+): BarePathUnwrapResult {
+  if (type !== 'if-else') return { config, issues: [] }
+  const cases = config.cases
+  if (!Array.isArray(cases)) return { config, issues: [] }
+
+  const issues: Issue[] = []
+  const nextCases = cases.map((caseItem, caseIndex) => {
+    const conditions = (caseItem as Record<string, unknown> | null)?.conditions
+    if (!Array.isArray(conditions)) return caseItem
+    let changed = false
+    const nextConditions = conditions.map((condition, condIndex) => {
+      const record = condition as Record<string, unknown> | null
+      const variableId = record?.variableId
+      if (typeof variableId !== 'string') return condition
+      const unwrapped = unwrapBracedVariableId(variableId)
+      if (unwrapped === variableId) return condition
+      changed = true
+      issues.push({
+        severity: 'warning',
+        field: `cases.${caseIndex}.conditions.${condIndex}.variableId`,
+        ref: variableId,
+        message:
+          `Condition variableId "${variableId}" takes a BARE dotted path, not a {{…}} reference — ` +
+          `the braces were stripped and "${unwrapped}" used. if-else conditions are the one ` +
+          'field in the builder vocabulary that is not braced; write the path on its own.',
+      })
+      return { ...record, variableId: unwrapped }
+    })
+    return changed
+      ? { ...(caseItem as Record<string, unknown>), conditions: nextConditions }
+      : caseItem
+  })
+
+  if (issues.length === 0) return { config, issues: [] }
+  return { config: { ...config, cases: nextCases }, issues }
+}

--- a/packages/lib/src/workflows/graph-edit/normalize/connection.ts
+++ b/packages/lib/src/workflows/graph-edit/normalize/connection.ts
@@ -20,11 +20,9 @@
 import { err, ok, type Result } from 'neverthrow'
 import { type AuxxError, BadRequestError } from '../../../errors'
 import type { ManifestLookup, NodeBranch } from '../../../workflow-engine/catalog/types'
-import { describeNode, resolveNodeRef } from '../refs'
+import { DEFAULT_SOURCE_HANDLE, safeBranches } from '../branches'
+import { closestMatches, describeNode, resolveNodeRef } from '../refs'
 import type { NodeMeta } from '../types'
-
-/** The default source handle for a node with no branch handles. */
-const DEFAULT_SOURCE_HANDLE = 'source'
 
 /** A resolved `after`/`branch` pair, ready to become an edge. */
 export interface ConnectionSpec {
@@ -35,6 +33,27 @@ export interface ConnectionSpec {
 /** `Name (id)` / `id` — the candidate format branch errors use. */
 function describeBranch(branch: NodeBranch): string {
   return branch.name ? `"${branch.name}" (${branch.id})` : `"${branch.id}"`
+}
+
+/**
+ * "Did you mean" for a branch that missed — the same `closestMatches`
+ * tolerance a node ref already gets (`refs.ts`).
+ *
+ * Worth the few lines because a flat rejection is retried verbatim: the logged
+ * turn re-issued `branch: "IF"` unchanged after re-reading the whole workflow,
+ * because nothing in the rejection pointed at the branch that had taken `IF`'s
+ * place (plan 21 §9.2/§10.5). Names AND ids are candidates, since either is a
+ * legal address.
+ */
+function nearestBranches(branchRef: string, branches: NodeBranch[]): NodeBranch[] {
+  const candidates = branches.flatMap((b) => (b.name ? [b.name, b.id] : [b.id]))
+  const near = closestMatches(branchRef, candidates)
+  const matched: NodeBranch[] = []
+  for (const candidate of near) {
+    const branch = branches.find((b) => b.name === candidate || b.id === candidate)
+    if (branch && !matched.includes(branch)) matched.push(branch)
+  }
+  return matched
 }
 
 /**
@@ -59,7 +78,9 @@ export function resolveConnectionSpec(
 
   const nodeType: string | undefined = source.data?.type ?? source.type
   const manifest = nodeType ? lookup(nodeType) : undefined
-  const branches = manifest?.connection.branches?.(source.data) ?? []
+  // `safeBranches`, not a bare call: a degenerate config (an if-else with no
+  // cases) used to throw straight out of this read path (plan 21 §2.5).
+  const branches = safeBranches(manifest, source.data)
 
   const branchRef = params.branch?.trim()
   if (!branchRef) {
@@ -91,10 +112,14 @@ export function resolveConnectionSpec(
     branches.find((b) => b.name.toLowerCase() === needle) ??
     branches.find((b) => b.id.toLowerCase() === needle)
   if (!match) {
+    const near = nearestBranches(branchRef, branches)
     return err(
       new BadRequestError(
-        `No branch "${branchRef}" on node ${describeNode(source)}. Available branches: ` +
-          `${branches.map(describeBranch).join(', ')}.`
+        `No branch "${branchRef}" on node ${describeNode(source)}.` +
+          (near.length > 0 ? ` Did you mean ${near.map(describeBranch).join(' or ')}?` : '') +
+          ` Available branches: ${branches.map(describeBranch).join(', ')}.` +
+          ' Address a branch by its id (the value in parentheses) — every node read and write ' +
+          'returns the node\u2019s current `branches`.'
       )
     )
   }

--- a/packages/lib/src/workflows/graph-edit/ops.ts
+++ b/packages/lib/src/workflows/graph-edit/ops.ts
@@ -35,6 +35,7 @@ import { hashWorkflowGraph } from '../graph-hash'
 import { assertMailTriggerNotPersonal } from '../mail-trigger-guard'
 import { calculateContainerSize, getLayoutByDagre, getLayoutForChildNodes } from './layout'
 import { LAYOUT_SPACING, NODE_ADDITION_CONFIG } from './layout-constants'
+import { unwrapBracedBarePaths } from './normalize/bare-path-fields'
 import { resolveConnectionSpec } from './normalize/connection'
 import { checkConnectionBinding } from './normalize/connection-binding'
 import { normalizeFriendlyRefs, type ResourceAliasIndex } from './normalize/friendly-refs'
@@ -68,6 +69,7 @@ import {
   isInputNodePair,
   isTriggerNode,
   nodeType,
+  validateBranchWiring,
   validateGraphStructure,
   validateNodeConfigs,
 } from './validate'
@@ -198,6 +200,7 @@ async function runGraphMutation(
     ...plan.normalizeIssues,
     ...structural,
     ...validateNodeConfigs(graph, ctx.lookup),
+    ...validateBranchWiring(graph, ctx.lookup),
   ]
   let outputsMap: Map<string, UnifiedVariable[]> | undefined
   const refIssues: Issue[] = []
@@ -293,7 +296,9 @@ async function runGraphMutation(
     return ok({
       applied: true,
       unchanged: true,
-      ...(unchangedNode ? { node: buildNodeSummary(graph, unchangedNode, aliases) } : {}),
+      ...(unchangedNode
+        ? { node: buildNodeSummary(graph, unchangedNode, aliases, ctx.lookup) }
+        : {}),
       issues,
       graphSummary: buildGraphSummary(ctx.graph, ctx.lookup, ctx.triggerType),
     })
@@ -373,7 +378,7 @@ async function runGraphMutation(
     : undefined
   return ok({
     applied: true,
-    ...(touched ? { node: buildNodeSummary(graph, touched, aliases) } : {}),
+    ...(touched ? { node: buildNodeSummary(graph, touched, aliases, ctx.lookup) } : {}),
     ...(touched && outputsMap
       ? { outputs: renderFriendlyOutputs(graph, outputsMap.get(touched.id) ?? [], aliases) }
       : {}),
@@ -407,7 +412,11 @@ async function normalizeConfig(
       delete rest[key]
     }
   }
-  const friendly = normalizeFriendlyRefs(rest, { nodes, resourceAliases: aliases })
+  // BEFORE the friendly-ref pass: a `{{…}}`-wrapped bare-path field has to be
+  // unwrapped while it is still one span, or the rewriter maps the inner path
+  // and leaves the braces behind (plan 21 F5).
+  const bare = unwrapBracedBarePaths(type, rest)
+  const friendly = normalizeFriendlyRefs(bare.config, { nodes, resourceAliases: aliases })
   const resource = await normalizeResourceConfig(organizationId, type, friendly.data)
   // An app block's bound credential (plan 17 D2). Issues only — there is no
   // correct id to substitute, and an `error` here blocks the persist, which is
@@ -416,7 +425,7 @@ async function normalizeConfig(
   const binding = await checkConnectionBinding(organizationId, type, resource.config)
   return {
     config: { ...normalizeAiPromptConfig(type, resource.config), ...prose },
-    issues: [...friendly.issues, ...resource.issues, ...binding],
+    issues: [...bare.issues, ...friendly.issues, ...resource.issues, ...binding],
   }
 }
 

--- a/packages/lib/src/workflows/graph-edit/read.ts
+++ b/packages/lib/src/workflows/graph-edit/read.ts
@@ -22,6 +22,7 @@ import { resolveGraphOutputs } from '../../workflow-engine/catalog/resolve-outpu
 import type { ManifestLookup } from '../../workflow-engine/catalog/types'
 import type { UnifiedVariable } from '../../workflow-engine/types/unified-variable'
 import { hashWorkflowGraph } from '../graph-hash'
+import { buildBranchSummaries } from './branches'
 import { type ResourceAliasIndex, renderPersistedRefs } from './normalize/friendly-refs'
 import { checkVariableRefsAgainstOutputs } from './normalize/ref-check'
 import { buildResourceAliasIndex } from './normalize/resource-refs'
@@ -35,7 +36,12 @@ import type {
   Issue,
   NodeSummary,
 } from './types'
-import { nodeType, validateGraphStructure, validateNodeConfigs } from './validate'
+import {
+  nodeType,
+  validateBranchWiring,
+  validateGraphStructure,
+  validateNodeConfigs,
+} from './validate'
 
 /** Everything a mutation or read needs about the loaded draft. */
 export interface DraftContext {
@@ -148,11 +154,21 @@ export function hashNodeConfig(data: Record<string, unknown>): string {
   return hashWorkflowGraph(stripDerivedKeys(data))
 }
 
-/** One node's summary: friendly ref + friendly-rendered config. */
+/**
+ * One node's summary: friendly ref + friendly-rendered config + the node's
+ * actual branches.
+ *
+ * `lookup` is optional only because two internal callers read nothing but
+ * `config` off the result (the patch path's before-image). Pass it wherever the
+ * summary is RETURNED to a caller: without it `branches` is silently absent,
+ * and the whole point of the field is that a branching node never comes back
+ * without its vocabulary attached.
+ */
 export function buildNodeSummary(
   graph: DraftGraph,
   node: GraphNode,
-  aliases?: ResourceAliasIndex
+  aliases?: ResourceAliasIndex,
+  lookup?: ManifestLookup
 ): NodeSummary {
   const config: Record<string, unknown> = {}
   for (const [key, value] of Object.entries((node.data ?? {}) as Record<string, unknown>)) {
@@ -160,6 +176,7 @@ export function buildNodeSummary(
     config[key] = value
   }
   const container = node.parentId ?? (node.data?.loopId as string | undefined)
+  const branches = lookup ? buildBranchSummaries(graph, node, lookup(nodeType(node))) : undefined
   return {
     ref: formatNodeRef(graph.nodes, node.id),
     id: node.id,
@@ -169,6 +186,7 @@ export function buildNodeSummary(
     ...(container ? { inside: formatNodeRef(graph.nodes, container) } : {}),
     position: node.position ?? { x: 0, y: 0 },
     config: renderPersistedRefs(config, { nodes: graph.nodes, resourceAliases: aliases }),
+    ...(branches ? { branches } : {}),
   }
 }
 
@@ -244,6 +262,7 @@ export async function readDraft(
   const issues: Issue[] = [
     ...validateGraphStructure(ctx.graph, { lookup: ctx.lookup }),
     ...validateNodeConfigs(ctx.graph, ctx.lookup),
+    ...validateBranchWiring(ctx.graph, ctx.lookup),
   ]
 
   const outputs: Record<string, UnifiedVariable[]> = {}
@@ -269,7 +288,7 @@ export async function readDraft(
     workflowAppId: ctx.workflowAppId,
     name: ctx.appName,
     triggerType: ctx.triggerType,
-    nodes: ctx.graph.nodes.map((node) => buildNodeSummary(ctx.graph, node, aliases)),
+    nodes: ctx.graph.nodes.map((node) => buildNodeSummary(ctx.graph, node, aliases, ctx.lookup)),
     edges: buildGraphSummary(ctx.graph, ctx.lookup, ctx.triggerType).edges,
     outputs,
     issues,
@@ -303,6 +322,7 @@ export async function validateWorkflow(
   const issues: Issue[] = [
     ...validateGraphStructure(ctx.graph, { lookup: ctx.lookup }),
     ...validateNodeConfigs(ctx.graph, ctx.lookup),
+    ...validateBranchWiring(ctx.graph, ctx.lookup),
   ]
   const resolved = await resolveGraphOutputs(params.organizationId, { graph: ctx.graph })
   if (resolved.isOk()) {

--- a/packages/lib/src/workflows/graph-edit/types.ts
+++ b/packages/lib/src/workflows/graph-edit/types.ts
@@ -111,6 +111,28 @@ export interface DraftGraph {
 }
 
 /**
+ * One outgoing branch of a branching node, as every node read and write
+ * reports it.
+ *
+ * `id` is the ADDRESS: it is the edge handle, it is what `branch` on
+ * `add_node`/`connect_nodes` resolves to, and for `if-else` it is the
+ * `case_id` the caller itself authored — so a branch can be wired in the same
+ * batch that creates the node, with nothing to read back. `name` is a display
+ * label only, and for `if-else` it is derived from array POSITION, so it
+ * renames itself the moment another case is added (plan 21 §2.2). Address by
+ * `id`; show `name` to a human.
+ */
+export interface NodeBranchSummary {
+  /** Canonical address — pass this as `branch`. */
+  id: string
+  /** Display label. May be empty (e.g. `http`'s plain `source` handle). */
+  name: string
+  kind: 'default' | 'fail'
+  /** Friendly refs already wired on this branch. */
+  connectedTo: string[]
+}
+
+/**
  * One node, rendered for a caller: friendly `ref` (unique title, else id) and
  * `config` with every variable/resource reference in `{{Title.path}}` / slug
  * form — a model reading this never sees a raw node id or per-org CUID it
@@ -129,6 +151,17 @@ export interface NodeSummary {
   position: Point
   /** Node config, friendly-rendered, bookkeeping keys stripped. */
   config: Record<string, unknown>
+  /**
+   * This node's outgoing branches and what is wired to each — OMITTED entirely
+   * for a node with none (never an empty array; see `buildBranchSummaries`).
+   *
+   * Rides `get_node`, `readDraft` and EVERY mutation result, which is the
+   * point: an `update_node` that re-shapes `cases` returns the recomputed list,
+   * so a rename or an orphaned edge is visible in the result of the write that
+   * caused it. Until this existed, no read tool reported a node's branches at
+   * all and the only way to learn them was to guess wrong (plan 21 §3.1/§8.2).
+   */
+  branches?: NodeBranchSummary[]
 }
 
 /** One edge, rendered for a caller with friendly node refs. */

--- a/packages/lib/src/workflows/graph-edit/validate.ts
+++ b/packages/lib/src/workflows/graph-edit/validate.ts
@@ -29,6 +29,7 @@ import {
   NodeCategory,
   type NodeValidationResult,
 } from '../../workflow-engine/catalog/types'
+import { edgeSourceHandle, FALLBACK_BRANCH_IDS, safeBranches } from './branches'
 import { formatNodeRef } from './refs'
 import type { DraftGraph, GraphEdge, GraphNode, Issue } from './types'
 
@@ -273,8 +274,12 @@ export function validateGraphStructure(
 
     const sourceManifest = lookup(nodeType(source))
     if (sourceManifest) {
-      const branches = sourceManifest.connection.branches?.(source.data) ?? []
-      const handle = edge.sourceHandle ?? 'source'
+      // `safeBranches`, not a bare call: the derivation is a function of
+      // agent-authored config and this runs inside `readDraft`, so a throw here
+      // used to take out `get_workflow`/`get_node`/`validate_workflow` and every
+      // mutation at once (plan 21 §2.5).
+      const branches = safeBranches(sourceManifest, source.data)
+      const handle = edgeSourceHandle(edge)
       const allowed = branches.length > 0 ? branches.map((b) => b.id) : ['source']
       if (!allowed.includes(handle) && !isInputWiring(source, target, edge, lookup)) {
         issues.push({
@@ -445,6 +450,74 @@ export function validateNodeConfigs(graph: DraftGraph, lookup: ManifestLookup): 
       }
     } catch {
       // A validator crashing on half-built data must not take the pipeline down.
+    }
+  }
+  return issues
+}
+
+/**
+ * Node types with NO plain `source` handle — every way out is a branch, so an
+ * unwired one is a dead end rather than a merely unfinished path.
+ */
+const NO_DEFAULT_OUTPUT_TYPES = new Set(['human-confirmation'])
+
+/** `"Name" (id)` / `"id"` — how an unwired-branch issue names the branch. */
+function describeBranchRef(branch: { id: string; name: string }): string {
+  return branch.name ? `"${branch.name}" (${branch.id})` : `"${branch.id}"`
+}
+
+/**
+ * Tier-2, non-blocking: a branching node with a branch nothing is wired to.
+ *
+ * The logged 2026-08-18 turn finished with `publishable: true` and one whole
+ * carrier branch never connected, and NOTHING said so — there was no
+ * unwired-branch check in the structural tier, the config tier or the publish
+ * gate (plan 21 §7.6). This is that backstop: it surfaces on every mutation
+ * result and in `validate_workflow`, before the agent writes its summary.
+ *
+ * Two deliberate exclusions:
+ *  - **Fallback branches** (`false`/`default`/`unmatched`) are silent. Leaving
+ *    "nothing matched" unwired is the normal shape of an if-else, not an
+ *    oversight, and warning on it would fire on nearly every branching node in
+ *    every workflow.
+ *  - **The plain `source` handle** is silent for the same reason: a terminal
+ *    node is a legitimate end of a graph, and `source` is an output, not a
+ *    branch anybody chose.
+ *
+ * Severity is `warning` — a half-built branch is a legitimate intermediate
+ * state and blocking it would break incremental building. The one `error` is a
+ * node with no default output to fall through to (`human-confirmation`, whose
+ * three outcome handles are the only way out), where an unwired
+ * branch means the run dead-ends. It is still tier 2 and still NON-blocking:
+ * `runGraphMutation` blocks on the structural tier, not on this one, so a
+ * half-wired approval never refuses the next edit.
+ */
+export function validateBranchWiring(graph: DraftGraph, lookup: ManifestLookup): Issue[] {
+  const issues: Issue[] = []
+  for (const node of graph.nodes) {
+    const manifest = lookup(nodeType(node))
+    if (!manifest) continue
+    const branches = safeBranches(manifest, node.data)
+    if (branches.length < 2) continue // not a branching node for authoring purposes
+    const deadEnd = NO_DEFAULT_OUTPUT_TYPES.has(nodeType(node))
+    const ref = formatNodeRef(graph.nodes, node.id)
+
+    for (const branch of branches) {
+      if (FALLBACK_BRANCH_IDS.has(branch.id) || branch.id === 'source') continue
+      const wired = graph.edges.some(
+        (edge) => edge.source === node.id && edgeSourceHandle(edge) === branch.id
+      )
+      if (wired) continue
+      issues.push({
+        severity: deadEnd ? 'error' : 'warning',
+        nodeRef: ref,
+        field: 'branches',
+        message: deadEnd
+          ? `Branch ${describeBranchRef(branch)} has nothing wired and ${ref} has no default ` +
+            'output — the run dead-ends when this branch is taken.'
+          : `Branch ${describeBranchRef(branch)} has nothing wired — nothing runs when this ` +
+            `branch is taken. Connect it with connect_nodes(from: "${ref}", branch: "${branch.id}", to: …).`,
+      })
     }
   }
   return issues


### PR DESCRIPTION
## The failure

A logged builder turn (2026-08-18) wired **one** branch of a two-way carrier router and told the user the workflow was built. `validate_workflow` returned `publishable: true` with a whole branch missing.

The agent authored the two-case if-else the schema invites:

```json
{ "case_id": "true",  "conditions": [ "Carrier.value is fedex" ] }
{ "case_id": "false", "conditions": [ "Carrier.value is ups" ] }
```

`false` is the reserved ELSE handle. Three things broke at once:

1. **The branch vocabulary renamed itself.** Names are positional — one case is `IF`/`ELSE`, two or more is `CASE n`/`ELSE`. `describe_node_type` had handed the agent `IF`/`ELSE` one iteration earlier (it computes from `defaultData()`), and the agent's own write invalidated it. It retried `branch: "IF"` twice.
2. **Two branches ended up sharing the id `false`.** Nothing caught it — the schema accepts any string, the validator checked neither uniqueness nor reserved words, and the structural handle check passes because duplicates are still *members* of the allowed set.
3. **Silent mis-route at run time.** `WorkflowGraphBuilder` builds handles into a `Map`, so the UPS case collapses into the ELSE entry. A matched UPS lookup and an unrecognised carrier leave on the same handle.

Underneath: **no read tool reported a node's real branches** — not `get_node`, not `NodeSummary`, not any mutation result. The only way to learn a node's branch vocabulary was to guess wrong and read the error.

## What changed

**The load-bearing fix is that a branch is addressed by the `case_id` the agent itself wrote.** That is knowable at *plan* time, so a create-then-wire batch is correct as issued — which matters because the failing turn emitted all three calls in one batch, where no result can be read in between.

- **Reject `case_id: 'false'` and duplicate `case_id`s** (`blocksAuthoring`), and rewrite the manifest usage string that taught the collision (it said *"the ELSE branch handle is always 'false'"*, which reads as an instruction).
- **Report `branches` on `NodeSummary`** — `{ id, name, kind, connectedTo }`, joined against the graph's edges. Rides `get_node`, `readDraft` and every mutation result; omitted entirely (not `[]`) for single-source nodes.
- **Address by id** in the `branch` param on `add_node`/`connect_nodes` and in the builder prompt. Drops *"never invent handle ids"*, which steered the model off the only stable address, and replaces the `branch: "High"` worked example (a text-classifier-shaped name an if-else can never produce).
- **Warn on unwired non-fallback branches**; `error` for `human-confirmation`, which has no `source` handle to fall through to. Lives in its own `validateBranchWiring` so it can never enter the tier-1 blocking path or trip `run_node`'s single-node config check.
- **`branchNameCorrect` no longer throws below two branches.** `cases: []` used to throw out of `validateGraphStructure` — which `readDraft` runs — so one degenerate node 500'd `get_workflow`, `get_node`, `validate_workflow` and every mutation at once. `safeBranches` is the defensive second layer at both read-path call sites.
- **Accept and strip `{{…}}` on if-else `variableId`**, the one bare-path field in the whole vocabulary. Writing the universally-taught form previously produced `Reference "{{{{form-input-xxx.value}}}}" points at unknown node "{{form-input-xxx"`.
- **Add the missing `crud` arm** to `WorkflowGraphBuilder.getNodeHandles`. crud declares a `fail` branch in its manifest, renders one, and emits the handle — but fell to `default:` and registered only `source`, so its fail edge was invisible to fork/parallel accounting.
- **`list_node_types` returns success on an empty result** and matches punctuation-normalised text plus a new optional `synonyms` on `NodeManifest`. `"if else"`, `"switch"`, `"branch"` previously all missed `if-else` *and* returned `success: false`, so models reworded — one turn burned four iterations before finding it via the query `"if"`. Same fix `list_app_blocks` already got.
- `describe_node_type` stops stripping branch ids and gains a `branchesNote`.

## Tests

`pnpm vitest run src/workflows src/workflow-engine src/ai/kopilot` from `packages/lib`: **162 files, 2347 tests, 0 failed, 0 unhandled errors.**

New: `catalog/if-else.test.ts` (14), `graph-edit/__tests__/branch-authoring.test.ts` (20), `tools/__tests__/list-node-types.test.ts` (12). Extended: `workflow-graph-builder.test.ts`, `workflow-authoring-guard.test.ts`, `prompts/sections/__tests__/workflow-builder.test.ts`.

`tsc --noEmit` on `packages/lib`: 29 errors, all pre-existing, all in `scripts/*` and `vitest.integration.config.ts` — none in touched files.

## Deliberately not in scope

- **Authored branch *labels*.** if-else branch names are hardcoded in six places and the panel's rename affordance is wired to nothing (it writes to derived state that is stripped on save). Real bug, but UX — once branches are reported and addressed by id, the label costs the agent nothing.
- **Failure-policy generalization.** There are two divergent error-strategy enums (`none|fail|default` vs `fail|continue|default`, with different defaults), six node types emit an undeclared `'error'` handle, and http's *default* config emits an undeclared `'fail'`. That wants one shared `errorHandling` declaration on the manifest and is a follow-up.
- Parent-side branch wiring, `onOrphanedBranches`, and the eval cases.