### PR TITLE
refactor(workflow): unify error strategy behind one manifest declaration

### DIFF
--- a/apps/web/src/components/workflow/nodes/core/crud/node.tsx
+++ b/apps/web/src/components/workflow/nodes/core/crud/node.tsx
@@ -2,12 +2,13 @@
 
 'use client'
 
+import { hasFailBranch as configHasFailBranch } from '@auxx/lib/workflow-engine/client'
 import type React from 'react'
 import { NodeSourceHandle } from '~/components/workflow/ui/node-handle'
 import { NodeTargetHandle } from '~/components/workflow/ui/node-handle/target-handle'
 import { useWorkflowResources } from '../../../providers'
 import { BaseNode } from '../../shared/base/base-node'
-import { CrudErrorStrategy, type CrudNodeData } from './types'
+import type { CrudNodeData } from './types'
 
 interface CrudNodeProps {
   id: string
@@ -24,7 +25,9 @@ export const CrudNode: React.FC<CrudNodeProps> = ({ id, data, selected }) => {
   const resource = getResourceById(resourceType)
 
   // Calculate total source handles based on error strategy
-  const hasFailBranch = error_strategy === CrudErrorStrategy.fail
+  // Same predicate the manifest's `connection.branches` uses, so the handle
+  // this renders and the branch the catalog declares can never disagree.
+  const hasFailBranch = configHasFailBranch({ error_strategy })
   const totalSourceHandles = hasFailBranch ? 2 : 1
 
   // Augment data with handle count for collapsed height calculation

--- a/apps/web/src/components/workflow/nodes/core/crud/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/crud/panel.tsx
@@ -40,7 +40,7 @@ import { BasePanel } from '../../shared/base/base-panel'
 import { DefaultValuesEditor } from './components/default-values-editor'
 import { RelationUpdateModeButton } from './components/relation-update-mode-button'
 import { getCrudNodeOutputVariables } from './output-variables'
-import { CrudErrorStrategy, type CrudNodeData } from './types'
+import { type CrudNodeData, ErrorStrategy } from './types'
 import { useCrudValidation } from './use-crud-validation'
 import { ValidationMessage } from './validation-message'
 
@@ -162,11 +162,11 @@ const CrudPanelComponent: React.FC<CrudPanelProps> = ({ nodeId, data }) => {
   )
 
   const handleErrorStrategyChange = useCallback(
-    (errorStrategy: CrudErrorStrategy) => {
+    (errorStrategy: ErrorStrategy) => {
       const newData = produce(nodeData, (draft) => {
         draft.error_strategy = errorStrategy
         draft.default_values =
-          errorStrategy === CrudErrorStrategy.default ? nodeData.default_values || [] : []
+          errorStrategy === ErrorStrategy.default ? nodeData.default_values || [] : []
       })
       setInputs(newData)
       if (!showValidation) setShowValidation(true)
@@ -484,29 +484,29 @@ const CrudPanelComponent: React.FC<CrudPanelProps> = ({ nodeId, data }) => {
 
       <Section
         title='Error Handling'
-        collapsible={nodeData.error_strategy === CrudErrorStrategy.default}
-        open={nodeData.error_strategy === CrudErrorStrategy.default}
+        collapsible={nodeData.error_strategy === ErrorStrategy.default}
+        open={nodeData.error_strategy === ErrorStrategy.default}
         className='[&>[data-slot=section]]:pb-0!'
         actions={
           <Select
-            value={nodeData.error_strategy || CrudErrorStrategy.fail}
+            value={nodeData.error_strategy || ErrorStrategy.fail}
             onValueChange={handleErrorStrategyChange}>
             <SelectTrigger size='sm'>
               <SelectValue placeholder='Select strategy' />
             </SelectTrigger>
             <SelectContent>
               <SelectItem
-                value={CrudErrorStrategy.fail}
+                value={ErrorStrategy.fail}
                 description='Stop workflow and route to fail branch'>
                 Fail
               </SelectItem>
               <SelectItem
-                value={CrudErrorStrategy.continue}
+                value={ErrorStrategy.continue}
                 description='Continue workflow with error information'>
                 Continue
               </SelectItem>
               <SelectItem
-                value={CrudErrorStrategy.default}
+                value={ErrorStrategy.default}
                 description='Use default values and continue'>
                 Default Values
               </SelectItem>
@@ -520,7 +520,7 @@ const CrudPanelComponent: React.FC<CrudPanelProps> = ({ nodeId, data }) => {
           />
         )}
 
-        {nodeData.error_strategy === CrudErrorStrategy.default && (
+        {nodeData.error_strategy === ErrorStrategy.default && (
           <Field title='Default Values' description='Fallback values to use when operations fail'>
             <DefaultValuesEditor
               defaultValues={nodeData.default_values || []}

--- a/apps/web/src/components/workflow/nodes/core/crud/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/crud/types.ts
@@ -10,9 +10,11 @@ import type { NodeType } from '~/components/workflow/types/node-types'
 // as BaseNodeData does over its lib counterpart.
 export {
   type CrudDefaultValue,
-  CrudErrorStrategy,
   createCrudNodeDefaultData,
   crudNodeDataSchema,
+  // One failure-policy vocabulary now (plan 21 §15.1) — `CrudErrorStrategy`
+  // and http's old `ErrorStrategy` were two enums for the same concern.
+  ErrorStrategy,
 } from '@auxx/lib/workflow-engine/client'
 
 /**

--- a/apps/web/src/components/workflow/nodes/core/http/components/error-handling.tsx
+++ b/apps/web/src/components/workflow/nodes/core/http/components/error-handling.tsx
@@ -2,6 +2,7 @@
 
 'use client'
 
+import { normalizeErrorStrategy } from '@auxx/lib/workflow-engine/client'
 import { InputGroup, InputGroupAddon } from '@auxx/ui/components/input-group'
 import {
   NumberInput,
@@ -39,8 +40,10 @@ function isErrorStrategy(value: string): value is ErrorStrategy {
 export function ErrorHandling({ nodeId, isReadOnly, config, onChange }: ErrorHandlingProps) {
   const { handleEdgeDeleteByDeleteBranch } = useEdgeInteractions()
 
-  // Use direct state for error strategy
-  const errorStrategy = config?.error_strategy
+  // Read through the normalizer: persisted http nodes carry `'none'`, the
+  // legacy spelling of `continue` (plan 21 §15.1), and an unset value runs
+  // under the unified default, `fail`. The alias is never written back.
+  const errorStrategy = normalizeErrorStrategy(config?.error_strategy)
 
   // Handle error strategy change and update target branches
   const setErrorStrategy = (newStrategy: string) => {
@@ -113,18 +116,15 @@ export function ErrorHandling({ nodeId, isReadOnly, config, onChange }: ErrorHan
   return (
     <Section
       title='Error handling'
-      initialOpen={errorStrategy !== ErrorStrategy.none}
-      enabled={errorStrategy !== ErrorStrategy.none}
+      initialOpen={errorStrategy !== ErrorStrategy.continue}
+      enabled={errorStrategy !== ErrorStrategy.continue}
       actions={
-        <Select
-          value={errorStrategy || 'default'}
-          onValueChange={setErrorStrategy}
-          disabled={isReadOnly}>
+        <Select value={errorStrategy} onValueChange={setErrorStrategy} disabled={isReadOnly}>
           <SelectTrigger variant='default' size='sm' className='mb-0'>
             <SelectValue placeholder='Select strategy' />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value={ErrorStrategy.none}>None</SelectItem>
+            <SelectItem value={ErrorStrategy.continue}>Continue</SelectItem>
             <SelectItem value={ErrorStrategy.default}>Default Values</SelectItem>
             <SelectItem value={ErrorStrategy.fail}>Fail branch</SelectItem>
           </SelectContent>

--- a/apps/web/src/components/workflow/nodes/core/http/node.tsx
+++ b/apps/web/src/components/workflow/nodes/core/http/node.tsx
@@ -2,15 +2,18 @@
 
 'use client'
 
+import { hasFailBranch as configHasFailBranch } from '@auxx/lib/workflow-engine/client'
 import { memo } from 'react'
 import { BaseNode } from '~/components/workflow/nodes/shared/base/base-node'
 import type { NodeProps } from '~/components/workflow/types'
 import { NodeSourceHandle, NodeTargetHandle } from '~/components/workflow/ui/node-handle'
-import { ErrorStrategy, type HttpNodeData } from './types'
+import type { HttpNodeData } from './types'
 
 export const HttpNode = memo<NodeProps<HttpNodeData>>(({ id, data, selected }) => {
   // Calculate total source handles based on error strategy
-  const hasFailBranch = data.error_strategy === ErrorStrategy.fail
+  // Same predicate the manifest's `connection.branches` uses, so the handle
+  // this renders and the branch the catalog declares can never disagree.
+  const hasFailBranch = configHasFailBranch(data)
   const totalSourceHandles = hasFailBranch ? 2 : 1
 
   // Augment data with handle count for collapsed height calculation

--- a/apps/web/src/components/workflow/utils/__tests__/calculate-target-branches.test.ts
+++ b/apps/web/src/components/workflow/utils/__tests__/calculate-target-branches.test.ts
@@ -1,0 +1,63 @@
+// apps/web/src/components/workflow/utils/__tests__/calculate-target-branches.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { FlowNode } from '../../types'
+import { NodeType } from '../../types/node-types'
+import { calculateTargetBranches } from '../workflow-initializer'
+
+/**
+ * `calculateTargetBranches` had four arms; two of them (`HTTP`, `CRUD`)
+ * existed only to add the `fail` branch and were two copies of one rule. They
+ * now read the manifest's `errorHandling` declaration through the same shared
+ * helper the catalog and the engine's graph builder use, so a type either
+ * declares failure handling everywhere or nowhere (plan 21 §15.4/§16.2).
+ */
+const dataFor = (data: Record<string, unknown>) => data as unknown as FlowNode['data']
+
+describe('calculateTargetBranches — failure policy comes off the manifest', () => {
+  it.each([
+    NodeType.HTTP,
+    NodeType.CRUD,
+  ])('%s gets a fail lane when error_strategy is fail', (type) => {
+    expect(calculateTargetBranches(dataFor({ type, error_strategy: 'fail' }))).toEqual([
+      { id: 'source', name: '', type: 'default' },
+      { id: 'fail', name: 'Fail', type: 'fail' },
+    ])
+  })
+
+  it.each([NodeType.HTTP, NodeType.CRUD])('%s gets source alone otherwise', (type) => {
+    for (const strategy of ['continue', 'default', undefined]) {
+      expect(calculateTargetBranches(dataFor({ type, error_strategy: strategy }))).toEqual([
+        { id: 'source', name: '', type: 'default' },
+      ])
+    }
+  })
+
+  it("reads http's legacy `none` as continue", () => {
+    // Persisted http nodes carry 'none'; it is the old spelling of `continue`
+    // and must never produce a lane.
+    expect(
+      calculateTargetBranches(dataFor({ type: NodeType.HTTP, error_strategy: 'none' }))
+    ).toEqual([{ id: 'source', name: '', type: 'default' }])
+  })
+
+  it('returns undefined for a type that declares no errorHandling', () => {
+    // Setting the field on a type that never opted in must not conjure a lane.
+    expect(
+      calculateTargetBranches(dataFor({ type: NodeType.AI, error_strategy: 'fail' }))
+    ).toBeUndefined()
+    expect(calculateTargetBranches(dataFor({ type: NodeType.WAIT }))).toBeUndefined()
+  })
+
+  it('leaves the genuinely type-specific arms alone', () => {
+    expect(
+      calculateTargetBranches(dataFor({ type: NodeType.IF_ELSE, cases: [{ case_id: 'true' }] }))
+    ).toEqual([
+      { id: 'true', name: 'IF', type: 'default' },
+      { id: 'false', name: 'ELSE', type: 'default' },
+    ])
+    expect(
+      calculateTargetBranches(dataFor({ type: NodeType.TEXT_CLASSIFIER, outputMode: 'variable' }))
+    ).toEqual([{ id: 'source', name: '', type: 'default' }])
+  })
+})

--- a/apps/web/src/components/workflow/utils/workflow-initializer.ts
+++ b/apps/web/src/components/workflow/utils/workflow-initializer.ts
@@ -1,10 +1,11 @@
 // apps/web/src/components/workflow/utils/workflow-initializer.ts
 
-import type { TargetBranch } from '@auxx/lib/workflow-engine/client'
+import {
+  errorHandlingBranches,
+  getManifest,
+  type TargetBranch,
+} from '@auxx/lib/workflow-engine/client'
 import { getConnectedEdges } from '@xyflow/react'
-import type { CrudNodeData } from '../nodes/core/crud/types'
-import type { HttpNodeData } from '../nodes/core/http/types'
-import { ErrorStrategy } from '../nodes/core/http/types'
 import type { IfElseNodeData } from '../nodes/core/if-else/types'
 import type { LoopNodeData } from '../nodes/core/loop/types'
 import type { TextClassifierNodeData } from '../nodes/core/text-classifier/types'
@@ -18,8 +19,9 @@ import { calculateZIndex } from './edge-utils'
  *
  * Derived state — `_targetBranches` is stripped on every save and rebuilt
  * here on load. The authoritative derivation is each manifest's
- * `connection.branches(config)`; these arms mirror it and should collapse
- * into it (see `catalog/derived-keys.ts`).
+ * `connection.branches(config)`; the remaining arms mirror it and should
+ * collapse into it (see `catalog/derived-keys.ts`). The failure-policy half
+ * already has: it reads the manifest rather than switching on a type.
  */
 export const calculateTargetBranches = (nodeData: FlowNode['data']): TargetBranch[] | undefined => {
   switch (nodeData.type) {
@@ -57,30 +59,26 @@ export const calculateTargetBranches = (nodeData: FlowNode['data']): TargetBranc
       return undefined
     }
 
-    case NodeType.HTTP: {
-      const httpData = nodeData as HttpNodeData
-      const branches: TargetBranch[] = [{ id: 'source', name: '', type: 'default' }]
-      // Add fail branch if error strategy is set to fail
-      if (httpData.error_strategy === ErrorStrategy.fail) {
-        branches.push({ id: 'fail', name: 'Fail', type: 'fail' })
-      }
-      return branches
+    default: {
+      // The HTTP and CRUD arms that used to live here existed ONLY to add the
+      // `fail` branch, and they were two copies of one rule — which is how
+      // crud's graph-builder arm came to be missing while every other surface
+      // declared the handle (plan 21 §7.3). Failure policy is now a
+      // manifest-declared concern: a type contributes a `fail` branch because
+      // its manifest says it handles failures, not because this switch has a
+      // case for it.
+      if (!getManifest(nodeData.type)?.errorHandling) return undefined
+      return [
+        { id: 'source', name: '', type: 'default' },
+        // `NodeBranch.kind` and `TargetBranch.type` are the same union under
+        // two names; this is the only place they meet.
+        ...errorHandlingBranches(nodeData).map((branch) => ({
+          id: branch.id,
+          name: branch.name,
+          type: branch.kind,
+        })),
+      ]
     }
-
-    case NodeType.CRUD: {
-      const crudData = nodeData as CrudNodeData
-      const branches: TargetBranch[] = [{ id: 'source', name: '', type: 'default' }]
-
-      // Add fail branch if error strategy is set to fail
-      if (`${crudData.error_strategy}` === 'fail') {
-        branches.push({ id: 'fail', name: 'Fail', type: 'fail' })
-      }
-
-      return branches
-    }
-
-    default:
-      return undefined
   }
 }
 

--- a/packages/lib/src/workflow-engine/catalog/error-handling.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/error-handling.test.ts
@@ -1,0 +1,165 @@
+// packages/lib/src/workflow-engine/catalog/error-handling.test.ts
+
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_ERROR_STRATEGY,
+  ErrorStrategy,
+  errorHandlingBranches,
+  hasFailBranch,
+  normalizeErrorStrategy,
+} from './error-handling'
+import { aiManifest } from './nodes/ai'
+import { crudManifest } from './nodes/crud'
+import { formatManifest } from './nodes/format'
+import { httpManifest } from './nodes/http'
+import { getManifest, listManifests } from './registry'
+
+/**
+ * The unified failure policy (plan 21 §15). There used to be two enums for one
+ * concern — http's `none | fail | default` (defaulting to `default`) and
+ * crud's `fail | continue | default` (defaulting to `fail`) — where http's
+ * `none` and crud's `continue` named the same behaviour and the defaults
+ * disagreed. These tests pin the three things that unification has to get
+ * right: the legacy alias still reads, the default is `fail` everywhere, and
+ * the branch comes from ONE helper driven by a manifest declaration.
+ */
+describe('normalizeErrorStrategy', () => {
+  it("reads http's legacy 'none' as `continue`", () => {
+    // Persisted http configs carry 'none'; it is accepted on read and never
+    // written again, which is the whole migration for this refactor.
+    expect(normalizeErrorStrategy('none')).toBe(ErrorStrategy.continue)
+  })
+
+  it('passes the three real policies through unchanged', () => {
+    expect(normalizeErrorStrategy('fail')).toBe(ErrorStrategy.fail)
+    expect(normalizeErrorStrategy('continue')).toBe(ErrorStrategy.continue)
+    expect(normalizeErrorStrategy('default')).toBe(ErrorStrategy.default)
+  })
+
+  it('resolves an absent or unrecognised value to the unified default, `fail`', () => {
+    expect(DEFAULT_ERROR_STRATEGY).toBe(ErrorStrategy.fail)
+    expect(normalizeErrorStrategy(undefined)).toBe(ErrorStrategy.fail)
+    expect(normalizeErrorStrategy(null)).toBe(ErrorStrategy.fail)
+    expect(normalizeErrorStrategy('')).toBe(ErrorStrategy.fail)
+    expect(normalizeErrorStrategy('swallow')).toBe(ErrorStrategy.fail)
+    expect(normalizeErrorStrategy(42)).toBe(ErrorStrategy.fail)
+  })
+
+  it('honours a per-type fallback when one is given', () => {
+    // A type whose manifest declares `defaultStrategy: continue` reads an
+    // unconfigured node as `continue`, not as the catalog-wide `fail`.
+    expect(normalizeErrorStrategy(undefined, ErrorStrategy.continue)).toBe(ErrorStrategy.continue)
+  })
+
+  it("has no member named 'none' any more", () => {
+    expect(Object.values(ErrorStrategy)).toEqual(['fail', 'continue', 'default'])
+  })
+})
+
+describe('errorHandlingBranches — the one site that turns a policy into a handle', () => {
+  const failBranch = { id: 'fail', name: 'Fail', kind: 'fail' }
+
+  it('contributes the fail branch for `fail`', () => {
+    expect(errorHandlingBranches({ error_strategy: 'fail' })).toEqual([failBranch])
+    expect(hasFailBranch({ error_strategy: 'fail' })).toBe(true)
+  })
+
+  it('contributes nothing for `continue` / legacy `none` / `default`', () => {
+    // These change the node's OUTPUT, not its ROUTING — they never touch the
+    // branch machinery at all (plan 21 §15.3).
+    expect(errorHandlingBranches({ error_strategy: 'continue' })).toEqual([])
+    expect(errorHandlingBranches({ error_strategy: 'none' })).toEqual([])
+    expect(errorHandlingBranches({ error_strategy: 'default' })).toEqual([])
+  })
+
+  it('contributes nothing when `error_strategy` is absent', () => {
+    // Deliberately NOT the `DEFAULT_ERROR_STRATEGY` fallback: every node.tsx
+    // renders its fail handle off the stored value, so synthesising a branch
+    // here would break the handle contract the parity suite asserts.
+    expect(errorHandlingBranches({})).toEqual([])
+    expect(errorHandlingBranches(undefined)).toEqual([])
+    expect(hasFailBranch(null)).toBe(false)
+  })
+})
+
+describe('manifest declarations', () => {
+  it('http and crud are the only types that declare errorHandling (step 4 opts in more)', () => {
+    const declaring = listManifests()
+      .filter((manifest) => manifest.errorHandling)
+      .map((manifest) => manifest.id)
+      .sort()
+    expect(declaring).toEqual(['crud', 'http'])
+  })
+
+  it.each([
+    ['http', httpManifest],
+    ['crud', crudManifest],
+  ])('%s declares all three strategies and defaults to fail', (_id, manifest) => {
+    expect(manifest.errorHandling).toEqual({
+      strategies: [ErrorStrategy.fail, ErrorStrategy.continue, ErrorStrategy.default],
+      defaultStrategy: ErrorStrategy.fail,
+    })
+  })
+
+  it.each([
+    ['http', httpManifest],
+    ['crud', crudManifest],
+  ])('%s derives its fail branch from the shared helper', (_id, manifest) => {
+    const branches = (config: Record<string, unknown>) =>
+      manifest.connection.branches?.(config as never) ?? []
+
+    expect(branches({ error_strategy: 'fail' })).toEqual([
+      { id: 'source', name: '', kind: 'default' },
+      { id: 'fail', name: 'Fail', kind: 'fail' },
+    ])
+    // Same source handle in every other case — only `fail` adds a branch.
+    for (const strategy of ['continue', 'none', 'default']) {
+      expect(branches({ error_strategy: strategy })).toEqual([
+        { id: 'source', name: '', kind: 'default' },
+      ])
+    }
+  })
+
+  it.each([
+    ['http', httpManifest],
+    ['crud', crudManifest],
+  ])('%s defaults an unconfigured node to fail', (_id, manifest) => {
+    // http used to ship `error_strategy: 'default'` with an empty
+    // `default_value`, which the processor's `default` arm rejects and so fell
+    // straight through to the fail return — the stored value disagreed with
+    // the behaviour, and `connection.branches` hid the handle the node already
+    // emitted (plan 21 §16.4).
+    const defaults = manifest.defaultData() as { error_strategy?: string }
+    expect(defaults.error_strategy).toBe(ErrorStrategy.fail)
+    expect(manifest.connection.branches?.(defaults as never)).toEqual([
+      { id: 'source', name: '', kind: 'default' },
+      { id: 'fail', name: 'Fail', kind: 'fail' },
+    ])
+  })
+
+  it('a type that does not declare errorHandling exposes no fail branch', () => {
+    // ABSENT means "a failure is fatal", which is the state every type but
+    // http and crud is in today. `format` failing IS a config bug; the ai node
+    // is the strongest step-4 candidate and still opted out here.
+    for (const manifest of [formatManifest, aiManifest]) {
+      expect(manifest.errorHandling).toBeUndefined()
+      // Even a config that carries the key gets nothing — the declaration is
+      // what grants the branch, not the presence of the field.
+      const branches = manifest.connection.branches?.({ error_strategy: 'fail' } as never)
+      expect(branches?.some((branch) => branch.id === 'fail') ?? false).toBe(false)
+    }
+  })
+
+  it('every declared defaultStrategy is one of the declared strategies', () => {
+    for (const manifest of listManifests()) {
+      const declaration = manifest.errorHandling
+      if (!declaration) continue
+      expect(declaration.strategies).toContain(declaration.defaultStrategy)
+    }
+  })
+
+  it('is reachable by type id, which is how the graph builder reads it', () => {
+    expect(getManifest('crud')?.errorHandling?.defaultStrategy).toBe(ErrorStrategy.fail)
+    expect(getManifest('wait')?.errorHandling).toBeUndefined()
+  })
+})

--- a/packages/lib/src/workflow-engine/catalog/error-handling.ts
+++ b/packages/lib/src/workflow-engine/catalog/error-handling.ts
@@ -1,0 +1,122 @@
+// packages/lib/src/workflow-engine/catalog/error-handling.ts
+
+import type { NodeBranch } from './types'
+
+/**
+ * The ONE failure-policy vocabulary for the node catalog.
+ *
+ * There used to be two, and they were not the same set: `ErrorStrategy`
+ * (`catalog/nodes/http.ts`) was `none | fail | default` defaulting to
+ * `default`, and `CrudErrorStrategy` (`catalog/nodes/crud.ts`) was
+ * `fail | continue | default` defaulting to `fail`. http's `none` and crud's
+ * `continue` are the SAME concept — succeed anyway, stay on `source`, carry
+ * the error in the output — under two names, neither node offered the other's
+ * name, and the two defaults disagreed, so "what happens when this node fails"
+ * depended on which node you dropped on the canvas (plan 21 §15.1).
+ *
+ * The reframe that makes this one concern (plan 21 §15.3): `error_strategy` is
+ * NOT "does this node have a fail branch". It is *what happens when this node
+ * fails*, and exactly ONE of its values produces a branch:
+ *
+ * | policy     | node status | outputHandle | output                        |
+ * |------------|-------------|--------------|-------------------------------|
+ * | `fail`     | Failed      | `fail`       | the error                     |
+ * | `continue` | Succeeded   | `source`     | error payload, `success:false` |
+ * | `default`  | Succeeded   | `source`     | the configured substitutes    |
+ *
+ * `continue` and `default` never touch the branch machinery at all — they
+ * change the node's *output*, not its *routing*.
+ */
+export enum ErrorStrategy {
+  /** Fail the node and leave via the declared, wireable `fail` branch. */
+  fail = 'fail',
+  /** Succeed anyway, stay on `source`, carry the error in the output. */
+  continue = 'continue',
+  /** Succeed anyway, stay on `source`, substitute the configured values. */
+  default = 'default',
+}
+
+/**
+ * What an unconfigured node does. Settled in plan 21 §18.1: it is crud's
+ * default today, it is what http *actually* does today (its stored
+ * `'default'` with an empty `default_value` falls straight through to the
+ * fail arm), and it is the only value that cannot silently swallow an error.
+ */
+export const DEFAULT_ERROR_STRATEGY = ErrorStrategy.fail
+
+/**
+ * Legacy persisted values that are read but never written again.
+ *
+ * `'none'` was http's name for `continue`. Existing http configs carry it, so
+ * every read path — the manifests' `connection.branches`, both processors, and
+ * the panel — must go through {@link normalizeErrorStrategy} rather than
+ * comparing the raw string.
+ */
+const LEGACY_ALIASES: Record<string, ErrorStrategy> = {
+  none: ErrorStrategy.continue,
+}
+
+const STRATEGY_VALUES = new Set<string>(Object.values(ErrorStrategy))
+
+/** A node type's declared failure-policy support, hung off its `NodeManifest`. */
+export interface NodeErrorHandling {
+  /** Which policies this type supports — a subset of fail | continue | default. */
+  strategies: ErrorStrategy[]
+  /** What an unconfigured node does. */
+  defaultStrategy: ErrorStrategy
+}
+
+/**
+ * Resolve a persisted `error_strategy` to a policy, applying the legacy
+ * aliases. An absent or unrecognised value resolves to `fallback`, which is
+ * what the node's manifest declares as its `defaultStrategy` (and, absent a
+ * manifest, {@link DEFAULT_ERROR_STRATEGY}).
+ *
+ * @param value the raw persisted value — may be `undefined`, `'none'`, …
+ * @param fallback the policy an unconfigured node runs under
+ */
+export function normalizeErrorStrategy(
+  value: unknown,
+  fallback: ErrorStrategy = DEFAULT_ERROR_STRATEGY
+): ErrorStrategy {
+  if (typeof value !== 'string') return fallback
+  if (STRATEGY_VALUES.has(value)) return value as ErrorStrategy
+  return LEGACY_ALIASES[value] ?? fallback
+}
+
+/**
+ * Does this config select the one policy that produces a branch?
+ *
+ * Deliberately answers `false` for an ABSENT `error_strategy` rather than
+ * falling back to `DEFAULT_ERROR_STRATEGY`: the branch question is about what
+ * the canvas renders and what an edge may address, and every `node.tsx`
+ * renders its `fail` handle on the stored value alone. Synthesising a wireable
+ * branch for a node that never rendered one would break the handle contract
+ * the parity suite asserts (`builder-rendered-handles.ts`).
+ */
+export function hasFailBranch(config: unknown): boolean {
+  if (!config || typeof config !== 'object') return false
+  const raw = (config as { error_strategy?: unknown }).error_strategy
+  if (typeof raw !== 'string') return false
+  return normalizeErrorStrategy(raw) === ErrorStrategy.fail
+}
+
+/**
+ * The branch a failure policy contributes — the single site that turns
+ * `error_strategy: 'fail'` into a handle.
+ *
+ * Returns `[]` for `continue` / `default` / unset. Node manifests spread this
+ * into their own branch list beside their `source` handle, so no node type
+ * re-implements the rule; the graph builder and the canvas's
+ * `calculateTargetBranches` call it too, which is what makes crud's missing
+ * graph-builder arm (plan 21 §7.3) unrepresentable rather than patched.
+ *
+ * Takes `unknown` rather than `{ error_strategy?: unknown }` because the four
+ * call sites hand it four different shapes of persisted node data — a catalog
+ * `TConfig`, the engine's `NodeData`, the canvas's `FlowNode['data']` union —
+ * and a parameter whose properties are all optional is a *weak type*, which TS
+ * rejects for any argument that shares none of them.
+ */
+export function errorHandlingBranches(config: unknown): NodeBranch[] {
+  return hasFailBranch(config) ? [{ id: 'fail', name: 'Fail', kind: 'fail' }] : []
+}

--- a/packages/lib/src/workflow-engine/catalog/nodes/crud.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/crud.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 import { generateCrudNodeVariablesFromFields } from '../../../resources/variable-generators'
 import { BaseType } from '../../core/types'
 import type { UnifiedVariable } from '../../types/unified-variable'
+import { ErrorStrategy, errorHandlingBranches } from '../error-handling'
 import type { BaseNodeData } from '../node-base'
 import type { OutputContext } from '../output-context'
 import { resolveResourceGeneratorInputs } from '../resource-meta'
@@ -17,22 +18,12 @@ import {
 import { extractFieldVariableIds, extractVarIdsFromString } from '../variable-inference'
 
 /**
- * The crud node's catalog manifest — resource-backed like find, plus a
- * `connection.branches` arm (a `fail` handle when `error_strategy` is
- * `'fail'`) mirroring the CRUD case of the canvas's `calculateTargetBranches`
- * (workflow-initializer.ts), which stays the derived-state writer — same
- * coexistence http.ts documents — until the branch consumers converge on the
- * manifests.
+ * The crud node's catalog manifest — resource-backed like find, plus the
+ * shared failure policy (`catalog/error-handling.ts`). The `CrudErrorStrategy`
+ * enum that used to live here was one of two divergent error-strategy sets;
+ * it is now the single `ErrorStrategy` (plan 21 §15.1) and crud's values are
+ * unchanged, since the unified set took crud's names and crud's default.
  */
-
-/**
- * CRUD error strategy enum
- */
-export enum CrudErrorStrategy {
-  fail = 'fail',
-  continue = 'continue',
-  default = 'default',
-}
 
 /**
  * CRUD default value configuration
@@ -59,7 +50,7 @@ export interface CrudNodeData extends BaseNodeData {
   fieldUpdateModeVars?: Record<string, string> // Dynamic mode variable per field
 
   // Error handling configuration
-  error_strategy: CrudErrorStrategy
+  error_strategy: ErrorStrategy
   default_values: CrudDefaultValue[]
 }
 
@@ -81,7 +72,7 @@ export const crudNodeDataSchema = z.object({
   fieldModes: z.record(z.string(), z.boolean()).optional(),
   fieldUpdateModes: z.record(z.string(), relationUpdateModeSchema).optional(),
   fieldUpdateModeVars: z.record(z.string(), z.string()).optional(),
-  error_strategy: z.enum(CrudErrorStrategy).default(CrudErrorStrategy.fail),
+  error_strategy: z.enum(ErrorStrategy).default(ErrorStrategy.fail),
   default_values: z
     .array(
       z.object({
@@ -108,7 +99,7 @@ export function createCrudNodeDefaultData(): Partial<CrudNodeData> {
     resourceType: 'contact',
     mode: 'create',
     data: {},
-    error_strategy: CrudErrorStrategy.fail,
+    error_strategy: ErrorStrategy.fail,
     default_values: [],
   }
 }
@@ -451,7 +442,7 @@ export function getCrudNodeOutputVariables(
     const variables = generateThreadActionVariables(nodeId)
 
     // Add strategy-specific variables if needed
-    if (nodeData.error_strategy === CrudErrorStrategy.default) {
+    if (nodeData.error_strategy === ErrorStrategy.default) {
       variables.push(
         {
           id: `${nodeId}.usedDefaults`,
@@ -512,7 +503,7 @@ export function getCrudNodeOutputVariables(
   }
 
   // Add strategy-specific variables if needed
-  if (nodeData.error_strategy === CrudErrorStrategy.default) {
+  if (nodeData.error_strategy === ErrorStrategy.default) {
     baseVariables.push(
       {
         id: `${nodeId}.usedDefaults`,
@@ -552,19 +543,18 @@ export const crudManifest: NodeManifest<CrudNodeData> = {
   connection: {
     canRunSingle: true,
     /**
-     * Succeeded results leave via 'source'; a 'fail' branch exists only when
-     * `error_strategy` is 'fail'. Mirrors the CRUD arm of the canvas's
-     * `calculateTargetBranches` (workflow-initializer.ts), which stays the
-     * derived-state writer until the branch consumers converge here — the
-     * same coexistence http.ts documents for its arm.
+     * Succeeded results leave via 'source'; the `fail` branch comes from the
+     * shared `errorHandlingBranches` helper — the same call http spreads, so
+     * the rule exists once (plan 21 §15.4).
      */
-    branches: (config): NodeBranch[] => {
-      const branches: NodeBranch[] = [{ id: 'source', name: '', kind: 'default' }]
-      if (config.error_strategy === CrudErrorStrategy.fail) {
-        branches.push({ id: 'fail', name: 'Fail', kind: 'fail' })
-      }
-      return branches
-    },
+    branches: (config): NodeBranch[] => [
+      { id: 'source', name: '', kind: 'default' },
+      ...errorHandlingBranches(config),
+    ],
+  },
+  errorHandling: {
+    strategies: [ErrorStrategy.fail, ErrorStrategy.continue, ErrorStrategy.default],
+    defaultStrategy: ErrorStrategy.fail,
   },
   agent: {
     authorable: true,

--- a/packages/lib/src/workflow-engine/catalog/nodes/http.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/http.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { HTTP_NODE_CONSTANTS } from '../../constants'
 import { BaseType } from '../../core/types'
 import type { UnifiedVariable } from '../../types/unified-variable'
+import { ErrorStrategy, errorHandlingBranches } from '../error-handling'
 import type { BaseNodeData } from '../node-base'
 import {
   type NodeBranch,
@@ -101,13 +102,6 @@ export type Authorization = {
   header?: string
   // For connection — bound Credential id, resolved + applied at execute time
   connectionId?: string
-}
-
-/** Error handling strategy (workflow-node only) */
-export enum ErrorStrategy {
-  none = 'none',
-  fail = 'fail',
-  default = 'default',
 }
 
 /** Timeout configuration (seconds in the builder; the engine converts to ms) */
@@ -449,9 +443,19 @@ export const httpManifest: NodeManifest<HttpNodeData> = {
       retry_interval: HTTP_NODE_CONSTANTS.RETRY_CONFIG.RETRY_INTERVAL.default,
     },
     ssl_verify: true,
-    error_strategy: ErrorStrategy.default,
+    // `fail` is the unified default (plan 21 §18.1). It is a no-op at run
+    // time: the old `ErrorStrategy.default` shipped with an empty
+    // `default_value`, and the processor's `default` arm requires
+    // `default_value.length > 0`, so it always fell straight through to the
+    // fail return. What DOES change is `connection.branches` — the `fail`
+    // branch is now visible on a default http node, which is the node telling
+    // the truth about the handle it already emits (§16.4).
+    error_strategy: ErrorStrategy.fail,
     default_value: [],
-    _targetBranches: [{ id: 'source', name: '', type: 'default' }],
+    _targetBranches: [
+      { id: 'source', name: '', type: 'default' },
+      { id: 'fail', name: 'Fail', type: 'fail' },
+    ],
   }),
   configSchema: httpNodeDataSchema as unknown as z.ZodType<HttpNodeData>,
   validate: validateHttpNodeData,
@@ -460,28 +464,29 @@ export const httpManifest: NodeManifest<HttpNodeData> = {
   connection: {
     canRunSingle: true,
     /**
-     * Succeeded results leave via 'source'; a 'fail' branch exists only when
-     * `error_strategy` is 'fail' — the handles the processor emits (#1560) and
-     * `builder-rendered-handles.ts` declares. Mirrors the HTTP arm of the
-     * canvas's `calculateTargetBranches` (workflow-initializer.ts), which stays
-     * the derived-state writer until the remaining branch-deriving types
-     * (text-classifier, crud) migrate and both converge here.
+     * Succeeded results leave via 'source'; the `fail` branch is contributed
+     * by the shared `errorHandlingBranches` helper, the single site that turns
+     * `error_strategy: 'fail'` into a handle for every type that declares
+     * `errorHandling`. crud spreads the identical call — neither re-implements
+     * the rule (plan 21 §15.4).
      */
-    branches: (config): NodeBranch[] => {
-      const branches: NodeBranch[] = [{ id: 'source', name: '', kind: 'default' }]
-      if (config.error_strategy === ErrorStrategy.fail) {
-        branches.push({ id: 'fail', name: 'Fail', kind: 'fail' })
-      }
-      return branches
-    },
+    branches: (config): NodeBranch[] => [
+      { id: 'source', name: '', kind: 'default' },
+      ...errorHandlingBranches(config),
+    ],
+  },
+  errorHandling: {
+    strategies: [ErrorStrategy.fail, ErrorStrategy.continue, ErrorStrategy.default],
+    defaultStrategy: ErrorStrategy.fail,
   },
   agent: {
     authorable: true,
     usage:
       '`url`, `headers` and `params` may contain {{…}} refs; headers/params are newline-separated ' +
       '`key: value` lines. `body.type` picks the encoding and `body.data` holds positional payload ' +
-      "items ({ key, value }). Set `error_strategy` to 'fail' to expose a wirable 'fail' branch " +
-      "handle; successful responses always leave via 'source' with status/headers/body/success outputs.",
+      "items ({ key, value }). `error_strategy` is fail (default — exposes a wirable 'fail' branch " +
+      'handle), continue (succeed with the error as output), or default (apply `default_value` on ' +
+      "failure); successful responses always leave via 'source' with status/headers/body/success outputs.",
     examples: [
       {
         description: 'GET an API with a bearer token from an upstream node',

--- a/packages/lib/src/workflow-engine/catalog/types.ts
+++ b/packages/lib/src/workflow-engine/catalog/types.ts
@@ -2,6 +2,7 @@
 
 import type { z } from 'zod'
 import type { WorkflowTriggerType } from '../core/types'
+import type { NodeErrorHandling } from './error-handling'
 import type { OutputResolver } from './output-context'
 
 /**
@@ -168,6 +169,23 @@ export interface NodeManifest<TConfig = unknown> {
   resolveOutputs?: OutputResolver<TConfig>
 
   connection: NodeConnectionRules<TConfig>
+
+  /**
+   * Failure policy this type opts into — *what happens when this node fails*,
+   * of which exactly one value (`fail`) produces a branch.
+   *
+   * ABSENT ⇒ a failure is fatal, exactly as today. That is the point: "not all
+   * nodes have error handling" becomes an explicit declaration instead of an
+   * accident of which processor happened to return a handle. Six authorable
+   * types emit `outputHandle: 'error'` today with nothing declaring it
+   * anywhere (plan 21 §7.4); they join by declaring this, not by growing a
+   * seventh special case in the graph builder.
+   *
+   * `strategies` is per type because `default` needs an output shape worth
+   * substituting — http has a response body, crud has a record; a chunker has
+   * no meaningful "default chunks" (plan 21 §15.4).
+   */
+  errorHandling?: NodeErrorHandling
   agent?: NodeAgentDocs
 }
 

--- a/packages/lib/src/workflow-engine/client.ts
+++ b/packages/lib/src/workflow-engine/client.ts
@@ -93,6 +93,14 @@ export {
   stripDerivedKeys,
 } from './catalog/derived-keys'
 export {
+  DEFAULT_ERROR_STRATEGY,
+  ErrorStrategy,
+  errorHandlingBranches,
+  hasFailBranch,
+  type NodeErrorHandling,
+  normalizeErrorStrategy,
+} from './catalog/error-handling'
+export {
   buildDownstreamMap,
   buildUpstreamMap,
   computeLoopAncestry,
@@ -163,7 +171,6 @@ export {
 } from './catalog/nodes/code'
 export {
   type CrudDefaultValue,
-  CrudErrorStrategy,
   type CrudNodeData as CatalogCrudNodeData,
   createCrudNodeDefaultData,
   crudManifest,
@@ -254,7 +261,6 @@ export {
   BodyPayloadValueType,
   BodyType,
   type DefaultValueItem,
-  ErrorStrategy,
   extractHttpVariableIds,
   getHttpOutputVariables,
   type HttpNodeData as CatalogHttpNodeData,

--- a/packages/lib/src/workflow-engine/core/__tests__/workflow-graph-builder.test.ts
+++ b/packages/lib/src/workflow-engine/core/__tests__/workflow-graph-builder.test.ts
@@ -637,3 +637,69 @@ describe('WorkflowGraphBuilder.getNodeHandles — crud declares a fail branch (p
     expect(handlesFor({ type: 'crud' })).toEqual(['source'])
   })
 })
+
+/**
+ * The fail handle is MANIFEST-DRIVEN, not a per-type `case`.
+ *
+ * `getNodeHandles` used to carry `case 'http':` / `case 'crud':` arms whose
+ * only job was this handle, and crud's was missing for a long time — which is
+ * exactly the failure mode a per-type switch invites (plan 21 §7.3). The
+ * handle now comes from the manifest's `errorHandling` declaration, so the
+ * omission is unrepresentable rather than patched.
+ */
+describe('WorkflowGraphBuilder.getNodeHandles — errorHandling is read off the manifest', () => {
+  beforeEach(() => {
+    const registry = new NodeProcessorRegistry()
+    for (const type of [
+      WorkflowNodeType.CRUD,
+      WorkflowNodeType.HTTP,
+      WorkflowNodeType.AI,
+      WorkflowNodeType.FORMAT,
+      WorkflowNodeType.WAIT,
+    ]) {
+      registry.registerProcessor({
+        type,
+        preprocessNode: async () => ({ inputs: {}, metadata: {} }),
+        execute: async (node) => ({
+          nodeId: node.nodeId,
+          status: NodeRunningStatus.Succeeded,
+          output: {},
+          executionTime: 0,
+        }),
+        validate: async () => ({ valid: true, errors: [], warnings: [] }),
+      })
+    }
+    WorkflowGraphBuilder.initialize(registry)
+  })
+
+  function handlesFor(data: Record<string, unknown>): string[] {
+    const graph = WorkflowGraphBuilder.buildGraph({
+      id: 'wf',
+      graph: { nodes: [{ id: 'n1', type: data.type as string, data }], edges: [] },
+    } as never)
+    return [...(graph.nodes.get('n1')?.outputHandles.keys() ?? [])]
+  }
+
+  it('registers the fail handle for every type that declares errorHandling', () => {
+    expect(handlesFor({ type: 'http', error_strategy: 'fail' })).toEqual(['source', 'fail'])
+    expect(handlesFor({ type: 'crud', error_strategy: 'fail' })).toEqual(['source', 'fail'])
+  })
+
+  it("reads http's legacy `none` spelling as continue, so no fail handle appears", () => {
+    expect(handlesFor({ type: 'http', error_strategy: 'none' })).toEqual(['source'])
+  })
+
+  it('gives NO fail handle to a type that does not declare errorHandling', () => {
+    // Neither `ai` nor `format` declares one, so a config that sets
+    // `error_strategy` anyway must not conjure a branch — the declaration is
+    // what grants the handle, not the presence of the field.
+    expect(handlesFor({ type: 'ai', error_strategy: 'fail' })).toEqual(['source'])
+    expect(handlesFor({ type: 'format', error_strategy: 'fail' })).toEqual(['source'])
+  })
+
+  it('leaves a type-specific arm alone when the type has no declaration', () => {
+    // `wait` keeps its own arm in the switch; the post-switch manifest pass is
+    // orthogonal to the branch-shape arms and adds nothing here.
+    expect(handlesFor({ type: 'wait', error_strategy: 'fail' })).toEqual(['source'])
+  })
+})

--- a/packages/lib/src/workflow-engine/core/workflow-graph-builder.ts
+++ b/packages/lib/src/workflow-engine/core/workflow-graph-builder.ts
@@ -1,6 +1,8 @@
 // packages/lib/src/workflow-engine/core/workflow-graph-builder.ts
 
 import { createScopedLogger } from '@auxx/logger'
+import { errorHandlingBranches } from '../catalog/error-handling'
+import { getManifest } from '../catalog/registry'
 import type { NodeProcessorRegistry } from './node-processor-registry'
 import type { ForkPointInfo, JoinPointInfo, Workflow, WorkflowEdge, WorkflowNode } from './types'
 import { WorkflowNodeType, WorkflowTriggerType } from './types'
@@ -512,24 +514,6 @@ export class WorkflowGraphBuilder {
         // Note: timeout handle could be added if wait nodes support timeout branching
         break
 
-      case 'http':
-      // `crud` declares the same pair everywhere else — its manifest
-      // (`catalog/nodes/crud.ts`), its `node.tsx`, `calculateTargetBranches`,
-      // and a processor that emits `outputHandle: 'fail'` — but had no arm
-      // here, so it fell to `default:` and registered `source` alone. Not a
-      // live routing bug (engine failures route through `findFailureEdge`,
-      // which reads the edges directly), but the derived metadata lied: a crud
-      // node with a wired fail branch reported `hasMultipleOutputs: false` and
-      // its fail edge was invisible to fork/parallel accounting
-      // (plan 21 §7.3).
-      case 'crud':
-        outputHandles.set('source', WorkflowGraphBuilder.createEmptyOutputInfo('source'))
-        // Add fail handle if error strategy is 'fail'
-        if (node.data.error_strategy === 'fail') {
-          outputHandles.set('fail', WorkflowGraphBuilder.createEmptyOutputInfo('fail'))
-        }
-        break
-
       case 'text-classifier': {
         if (node.data.outputMode === 'variable') {
           // Variable mode: single source handle, no branching
@@ -558,6 +542,21 @@ export class WorkflowGraphBuilder {
       default:
         // Standard nodes have "source" output
         outputHandles.set('source', WorkflowGraphBuilder.createEmptyOutputInfo('source'))
+    }
+
+    // Failure policy is a MANIFEST-DECLARED concern, not a per-type case here.
+    // `http` and `crud` each used to own an arm above; crud's was missing
+    // entirely, so it fell to `default:` and registered `source` alone while
+    // its manifest, its `node.tsx`, `calculateTargetBranches` and its
+    // processor all declared a `fail` handle — `hasMultipleOutputs` then lied
+    // and the fail edge was invisible to fork/parallel accounting (plan 21
+    // §7.3). Reading the declaration makes that omission unrepresentable: a
+    // type gets the handle because its manifest says it handles failures, not
+    // because someone remembered to add a `case`.
+    if (getManifest(node.type)?.errorHandling) {
+      for (const branch of errorHandlingBranches(node.data)) {
+        outputHandles.set(branch.id, WorkflowGraphBuilder.createEmptyOutputInfo(branch.id))
+      }
     }
 
     return { inputHandles, outputHandles }

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/crud.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/crud.ts
@@ -43,6 +43,7 @@ import {
 } from '../../../threads/links.service'
 import { ThreadMutationService, type ThreadUpdates } from '../../../threads/thread-mutation.service'
 import { UnreadService } from '../../../threads/unread-service'
+import { ErrorStrategy, normalizeErrorStrategy } from '../../catalog/error-handling'
 import type {
   CrudNodeData as CatalogCrudNodeData,
   CrudDefaultValue,
@@ -63,9 +64,9 @@ import { parseRelationInput } from './relation-utils'
 /**
  * Engine-side view of the CRUD node's persisted config — a `Pick` off the
  * catalog's `CrudNodeData` (imported directly, not via `client.ts`: engine
- * code never goes through the client barrel). `error_strategy` is now the
- * catalog's `CrudErrorStrategy` enum rather than a bare string union; the
- * string-literal comparisons below project it through a template literal
+ * code never goes through the client barrel). `error_strategy` is the shared
+ * `ErrorStrategy` enum (`catalog/error-handling.ts`); the string-literal
+ * comparisons below project it through a template literal
  * (`` `${config.error_strategy}` ``) where TS would otherwise reject the
  * enum-vs-literal comparison — no runtime behavior changes, since the enum's
  * values are the same strings the literals always were.
@@ -527,7 +528,7 @@ export class CrudNodeProcessor extends BaseNodeProcessor {
     // Validate error strategy
     if (
       config.error_strategy &&
-      !['fail', 'continue', 'default'].includes(`${config.error_strategy}`)
+      !['fail', 'continue', 'default', 'none'].includes(`${config.error_strategy}`)
     ) {
       errors.push('Error strategy must be fail, continue, or default')
     }
@@ -1356,8 +1357,11 @@ export class CrudNodeProcessor extends BaseNodeProcessor {
     contextManager.setNodeVariable(node.nodeId, 'errorDetails', errorDetails)
     contextManager.setNodeVariable(node.nodeId, 'operation', mode)
     contextManager.setNodeVariable(node.nodeId, 'resourceType', resourceType)
-    switch (`${config.error_strategy}`) {
-      case 'continue':
+    // Read through the normalizer: `'none'` is the legacy spelling of
+    // `continue` (plan 21 §15.1) and an absent value runs under the unified
+    // default, `fail` — which is where the `default:` arm below lands anyway.
+    switch (normalizeErrorStrategy(config.error_strategy)) {
+      case ErrorStrategy.continue:
         // Continue workflow with error information
         contextManager.log('WARN', node.name, `${mode} operation failed but continuing`, {
           error: message,
@@ -1381,7 +1385,7 @@ export class CrudNodeProcessor extends BaseNodeProcessor {
             continuedOnError: true,
           },
         }
-      case 'default':
+      case ErrorStrategy.default:
         // Use default values if configured
         if (config.default_values && config.default_values.length > 0) {
           const defaultResult = await this.processDefaultValues(
@@ -1426,7 +1430,7 @@ export class CrudNodeProcessor extends BaseNodeProcessor {
         contextManager.setNodeVariable(node.nodeId, 'usedDefaults', false)
         contextManager.setNodeVariable(node.nodeId, 'defaultValues', null)
       // Fall through to fail if no defaults configured
-      case 'fail':
+      case ErrorStrategy.fail:
       default:
         // Fail the workflow and route to fail branch
         return {

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/http.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/http.ts
@@ -17,11 +17,11 @@
 
 import { z } from 'zod'
 import { applyAuth, resolveConnectionForRuntime } from '../../../connections'
+import { ErrorStrategy, normalizeErrorStrategy } from '../../catalog/error-handling'
 import type {
   Authorization,
   Body,
   DefaultValueItem,
-  ErrorStrategy,
   HttpNodeData,
   Method,
   Timeout,
@@ -77,7 +77,9 @@ type HttpNodeConfig = Pick<
   method: `${Method}`
   body: HttpBodyConfig
   authorization: HttpAuthConfig
-  error_strategy: `${ErrorStrategy}`
+  // `'none'` is http's legacy spelling of `continue` and is still persisted on
+  // older nodes — read through `normalizeErrorStrategy`, never compared raw.
+  error_strategy: `${ErrorStrategy}` | 'none'
 }
 
 // Validation schema
@@ -111,7 +113,7 @@ const httpNodeConfigSchema = z.object({
     })
     .optional()
     .default({ retry_enabled: false, max_retries: 1, retry_interval: 100 }),
-  error_strategy: z.enum(['fail', 'none', 'default']).optional().default('fail'),
+  error_strategy: z.enum(['fail', 'none', 'continue', 'default']).optional().default('fail'),
   default_value: z.array(z.any()).optional().default([]),
 })
 
@@ -415,15 +417,21 @@ export class HttpProcessor extends BaseNodeProcessor {
       // Handle error based on strategy
       const config = node.data as unknown as HttpNodeConfig
 
-      if (config.error_strategy === 'none') {
+      // One vocabulary, read through the normalizer: `'none'` is the legacy
+      // spelling of `continue` that persisted http configs carry (plan 21
+      // §15.1), and an absent value runs under the unified default, `fail`.
+      const strategy = normalizeErrorStrategy(config.error_strategy)
+
+      if (strategy === ErrorStrategy.continue) {
         return {
           status: NodeRunningStatus.Succeeded,
-          // Continue on error: 'none' renders no fail handle in the builder, so
-          // execution proceeds down the success path with the error as output.
+          // Continue on error: `continue` renders no fail handle in the
+          // builder, so execution proceeds down the success path with the
+          // error as output.
           output: { error: errorMessage, status: 0 },
           outputHandle: 'source',
         }
-      } else if (config.error_strategy === 'default' && config.default_value.length > 0) {
+      } else if (strategy === ErrorStrategy.default && config.default_value.length > 0) {
         const defaultValues = await this.processDefaultValues(config.default_value, contextManager)
         this.storeOutputVariables(node.nodeId, defaultValues, contextManager)
 

--- a/packages/lib/src/workflow-engine/parity/crud.resolvability.test.ts
+++ b/packages/lib/src/workflow-engine/parity/crud.resolvability.test.ts
@@ -206,7 +206,8 @@ vi.mock('../../threads/thread-mutation.service', () => ({
 }))
 
 const { CrudNodeProcessor } = await import('../nodes/action-nodes/crud')
-const { crudManifest, CrudErrorStrategy } = await import('../catalog/nodes/crud')
+const { crudManifest } = await import('../catalog/nodes/crud')
+const { ErrorStrategy } = await import('../catalog/error-handling')
 
 function buildCrudNode(nodeId: string, data: Record<string, unknown>): WorkflowNode {
   return {
@@ -220,7 +221,7 @@ function buildCrudNode(nodeId: string, data: Record<string, unknown>): WorkflowN
       type: WorkflowNodeType.CRUD,
       title: 'CRUD',
       data: {},
-      error_strategy: CrudErrorStrategy.fail,
+      error_strategy: ErrorStrategy.fail,
       default_values: [],
       ...data,
     },
@@ -377,7 +378,7 @@ describe('CRUD node resolvability', () => {
       mode: 'update',
       resourceId: VENDOR_UPDATE_INSTANCE_ID,
       data: { name: 'Initech Supply' },
-      error_strategy: CrudErrorStrategy.default,
+      error_strategy: ErrorStrategy.default,
       default_values: [{ key: 'fallbackNote', type: 'string', value: 'applied fallback' }],
     })
 
@@ -424,7 +425,7 @@ describe('CRUD node resolvability', () => {
       mode: 'update',
       resourceId: VENDOR_UPDATE_INSTANCE_ID,
       data: { name: 'Initech Supply' },
-      error_strategy: CrudErrorStrategy.default,
+      error_strategy: ErrorStrategy.default,
       default_values: [],
     })
 

--- a/packages/lib/src/workflow-engine/parity/declaration-only.resolvability.test.ts
+++ b/packages/lib/src/workflow-engine/parity/declaration-only.resolvability.test.ts
@@ -23,8 +23,9 @@
  */
 
 import { describe, expect, it } from 'vitest'
+import { ErrorStrategy } from '../catalog/error-handling'
 import type { CrudNodeData } from '../catalog/nodes/crud'
-import { CrudErrorStrategy, crudManifest } from '../catalog/nodes/crud'
+import { crudManifest } from '../catalog/nodes/crud'
 import type { FindNodeData } from '../catalog/nodes/find'
 import { findManifest } from '../catalog/nodes/find'
 import { ALL_RESOURCES, EMPTY_FIELDS_DEF_ID, EMPTY_FIELDS_RESOURCE } from './fixtures'
@@ -69,7 +70,7 @@ describe('declaration-only: empty-fields status variables', () => {
       resourceType: EMPTY_FIELDS_DEF_ID,
       mode: 'create',
       data: {},
-      error_strategy: CrudErrorStrategy.fail,
+      error_strategy: ErrorStrategy.fail,
       default_values: [],
     } as unknown as CrudNodeData
     const ids = crudManifest.resolveOutputs!(data, 'crud_empty', emptyContext).map((v) => v.id)
@@ -93,7 +94,7 @@ describe('declaration-only: empty-fields status variables', () => {
       mode: 'delete',
       resourceId: 'whatever',
       data: {},
-      error_strategy: CrudErrorStrategy.fail,
+      error_strategy: ErrorStrategy.fail,
       default_values: [],
     } as unknown as CrudNodeData
     const ids = crudManifest.resolveOutputs!(data, 'crud_empty_delete', emptyContext).map(


### PR DESCRIPTION
Follows #1765. Pure refactor — **no behaviour change**.

## The problem

Two error-strategy enums existed and were not the same set:

| | values | default |
|---|---|---|
| `ErrorStrategy` (http) | `none` · `fail` · `default` | **`default`** |
| `CrudErrorStrategy` (crud) | `fail` · `continue` · `default` | **`fail`** |

http's `none` and crud's `continue` are the **same concept** — succeed anyway, stay on `source`, carry the error in the output — under two names. Neither node offered the other's. The defaults disagreed. And `ErrorStrategy.default = 'default'` is a member literally named `default` meaning *"substitute default values"*, which reads as *"the default strategy"* — and wasn't.

The consequence showed up as a class of bug: `crud` declared a `fail` branch in its manifest, rendered one, and emitted the handle — but `WorkflowGraphBuilder.getNodeHandles` had no `crud` arm, so it fell to `default:` and registered only `source`. #1765 patched that with a `case 'crud':`. This PR makes it unrepresentable instead.

## The reframe

`error_strategy` is not *"does this node have a fail branch"*. It is *"what happens when this node fails"*, and exactly **one** of its values produces a branch:

| policy | status | handle | output |
|---|---|---|---|
| `fail` | Failed | **`fail`** — a declared, wireable branch | the error |
| `continue` (was http's `none`) | Succeeded | `source` | error payload, `success: false` |
| `default` | Succeeded | `source` | the configured substitute values |

`continue` and `default` never touch the branch machinery at all — they change the node's *output*, not its *routing*. So the thing to generalise is the **policy**; the branch falls out of one value of it.

## What changed

- **One shared `ErrorStrategy { fail, continue, default }`** in `catalog/error-handling.ts`, with `normalizeErrorStrategy` accepting the legacy `'none'` as `continue` on read. Both local enums deleted.
- **`errorHandling: { strategies, defaultStrategy }` on `NodeManifest`**, declared on http and crud only. Absent means a failure is fatal, exactly as today — so *"not every node has error handling"* becomes an explicit declaration rather than an accident of which processor happened to return a handle.
- **`errorHandlingBranches` is the single site** that turns `error_strategy: 'fail'` into `{ id: 'fail', name: 'Fail', kind: 'fail' }`. http and crud spread it rather than re-implementing the rule; `node.tsx` renders on the same `hasFailBranch` predicate the manifest uses.
- **The graph builder's `case 'http':` and `case 'crud':` arms are deleted**, replaced by one manifest-driven pass. The genuinely type-specific arms (if-else case ids, classifier categories, loop, human-confirmation, end) are untouched.
- **The same two arms collapse out of `calculateTargetBranches`** in the canvas initializer.

The engine core now statically imports the catalog registry — no cycle materialised, with precedent in `core/execution-context.ts`.

## Tests

| | before | after |
|---|---|---|
| `packages/lib` (`src/workflows src/workflow-engine src/ai/kopilot`) | 162 files / 2347 | **164 files / 2371, 0 failed** |
| `apps/web` (`src/components/workflow`) | 24 files / 162 | **25 files / 169, 0 failed** |

**The acceptance criterion for a refactor of this shape is that no existing expectation changes, and none did.** `git diff` on test files touches three: 66 *added* lines in `workflow-graph-builder.test.ts` (a new `describe` with its own `beforeEach`), and the two parity tests changed only by the identifier rename `CrudErrorStrategy.x` → `ErrorStrategy.x` over identical string values. Nothing was re-baselined.

Typecheck ratchets unchanged: lib 29 (baseline 29, all pre-existing in `scripts/*`), web 0.

## Behaviour notes

- `defaultData()` for http now writes `fail` instead of `default`. At run time this is a no-op: the processor's `default` arm requires a non-empty `default_value`, and http shipped `default_value: []`, so it already fell straight through to the fail return. It affects **newly created** nodes only.
- New capability, no persisted config changes meaning: http now accepts `continue`, crud accepts `none`. Neither was writable from its panel before.

## Known, deliberately not closed here

An http node **already persisted** with `error_strategy: 'default'` and an empty `default_value` still routes to `'fail'` at run time while exposing no wireable `fail` branch — it emits an undeclared handle. `hasFailBranch` reads the stored value only, which is the conservative choice. Closing it is either a read-time rule (`'default'` + empty ⇒ `fail`) or a data migration row-rewrite; that decision is tracked and is not made silently here.

Also carried forward: `constants/nodes/crud.ts:49` still exports a dead `CrudErrorStrategy` type with zero importers, and `nodes/action-nodes/http.ts:198` still types `error_strategy` as a bare `z.string()`. Both are follow-ups, not regressions.