### PR TITLE
feat(workflow): let more node types handle their own failures

### DIFF
--- a/apps/web/src/components/workflow/nodes/core/ai/node.tsx
+++ b/apps/web/src/components/workflow/nodes/core/ai/node.tsx
@@ -2,15 +2,27 @@
 
 import { memo } from 'react'
 import { BaseNode } from '~/components/workflow/nodes/shared/base/base-node'
+import {
+  hasFailBranch as hasFailBranchFor,
+  NodeFailBranch,
+} from '~/components/workflow/nodes/shared/node-fail-branch'
 import type { NodeProps } from '~/components/workflow/types'
 import ModelNodeView from '~/components/workflow/ui/model-parameter/model-node-view'
 import { NodeSourceHandle, NodeTargetHandle } from '~/components/workflow/ui/node-handle'
 import type { AiNodeData } from './types'
 
 export const AiNode = memo<NodeProps<AiNodeData>>(({ id, data, selected }) => {
+  // The fail lane renders off the STORED `error_strategy` — the same predicate
+  // `connection.branches` uses, so the handle this renders and the branch the
+  // catalog declares can never disagree. A node that predates the step-4
+  // opt-in carries no key and renders exactly what it always did.
+  const hasFailBranch = hasFailBranchFor(data)
+  const totalSourceHandles = hasFailBranch ? 2 : 1
+  const augmentedData = { ...data, _sourceHandleCount: totalSourceHandles }
+
   return (
-    <BaseNode id={id} data={data} selected={selected}>
-      <NodeTargetHandle id={id} data={{ ...data, selected }} handleId='target' />
+    <BaseNode id={id} data={augmentedData} selected={selected}>
+      <NodeTargetHandle id={id} data={{ ...augmentedData, selected }} handleId='target' />
 
       <div className='px-2 pb-2'>
         <div className='space-y-1'>
@@ -35,10 +47,13 @@ export const AiNode = memo<NodeProps<AiNodeData>>(({ id, data, selected }) => {
 
       <NodeSourceHandle
         id={id}
-        data={{ ...data, selected }}
+        data={{ ...augmentedData, selected }}
         handleId='source'
         handleClassName='!bottom-5'
+        handleIndex={0}
+        handleTotal={totalSourceHandles}
       />
+      {hasFailBranch && <NodeFailBranch id={id} data={augmentedData} selected={selected} />}
     </BaseNode>
   )
 })

--- a/apps/web/src/components/workflow/nodes/core/ai/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/ai/panel.tsx
@@ -20,7 +20,13 @@ import { DEFAULT_TABS } from '~/components/editor/inline-picker'
 import type { ReferenceTab } from '~/components/editor/inline-picker/nodes/reference-picker-node'
 import { SchemaEditorDialog } from '~/components/schema-editor/ui/schema-editor-dialog'
 import { useModelCapabilities, useNodeCrud, useReadOnly } from '~/components/workflow/hooks'
+import { ErrorDefaultValuesEditor } from '~/components/workflow/nodes/shared/error-default-values-editor'
+import {
+  ErrorHandlingSection,
+  type ErrorStrategyUpdate,
+} from '~/components/workflow/nodes/shared/error-handling-section'
 import { BaseType } from '~/components/workflow/types'
+import Field from '~/components/workflow/ui/field'
 import {
   VarEditor,
   VarEditorField,
@@ -61,6 +67,18 @@ const AiPanelComponent: React.FC<AiPanelProps> = ({ nodeId, data }) => {
 
   // Use CRUD operations for the node data
   const { inputs: nodeData, setInputs: setNodeData } = useNodeCrud<AiNodeData>(nodeId, data)
+
+  /** Failure policy — the shared control, driven by the manifest declaration. */
+  const handleErrorStrategyChange = useCallback(
+    (update: ErrorStrategyUpdate) => setNodeData({ ...nodeData, ...update }),
+    [nodeData, setNodeData]
+  )
+
+  const handleDefaultValuesChange = useCallback(
+    (defaultValues: AiNodeData['default_values']) =>
+      setNodeData({ ...nodeData, default_values: defaultValues }),
+    [nodeData, setNodeData]
+  )
 
   // Capability gating — a feature is unsupported ONLY when the flag is
   // explicitly false (unknown/custom models fail open, same as runtime).
@@ -341,6 +359,26 @@ const AiPanelComponent: React.FC<AiPanelProps> = ({ nodeId, data }) => {
           )}
         </div>
       </Section>
+      {/* `default` is offered here and nowhere else in the step-4 set: the AI
+          node HAS an output shape worth substituting — `text` is a plain
+          string, so "if the classifier times out, use `unknown`" is
+          expressible (plan 21 §16.3). The editor is crud's, reused rather than
+          reinvented; plan 24 owns its redesign. */}
+      <ErrorHandlingSection
+        nodeId={nodeId}
+        nodeType='ai'
+        errorStrategy={nodeData.error_strategy}
+        onChange={handleErrorStrategyChange}>
+        <Field
+          title='Default Values'
+          description='Substitute output values to use when the model call fails'>
+          <ErrorDefaultValuesEditor
+            defaultValues={nodeData.default_values || []}
+            onChange={handleDefaultValuesChange}
+          />
+        </Field>
+      </ErrorHandlingSection>
+
       <OutputVariablesDisplay
         outputVariables={
           aiDefinition.outputVariables?.(nodeData, nodeId, staticOutputVariableContext) || []

--- a/apps/web/src/components/workflow/nodes/core/chunker/node.tsx
+++ b/apps/web/src/components/workflow/nodes/core/chunker/node.tsx
@@ -4,6 +4,10 @@
 
 import { memo } from 'react'
 import { BaseNode } from '~/components/workflow/nodes/shared/base/base-node'
+import {
+  hasFailBranch as hasFailBranchFor,
+  NodeFailBranch,
+} from '~/components/workflow/nodes/shared/node-fail-branch'
 import type { NodeProps } from '~/components/workflow/types'
 import { NodeSourceHandle, NodeTargetHandle } from '~/components/workflow/ui/node-handle'
 import VariableTag from '~/components/workflow/ui/variables/variable-tag'
@@ -36,9 +40,17 @@ export const ChunkerNode = memo<NodeProps<ChunkerNodeData>>(({ id, data, selecte
   const chunkOverlapValue = typeof data.chunkOverlap === 'number' ? data.chunkOverlap : 50
   const delimiterValue = data.delimiter || '\\n\\n'
 
+  // The fail lane renders off the STORED `error_strategy` — the same predicate
+  // `connection.branches` uses, so the handle this renders and the branch the
+  // catalog declares can never disagree. A node that predates the step-4
+  // opt-in carries no key and renders exactly what it always did.
+  const hasFailBranch = hasFailBranchFor(data)
+  const totalSourceHandles = hasFailBranch ? 2 : 1
+  const augmentedData = { ...data, _sourceHandleCount: totalSourceHandles }
+
   return (
-    <BaseNode id={id} data={data} selected={selected} width={244} height='auto'>
-      <NodeTargetHandle id={id} data={{ ...data, selected }} handleId='target' />
+    <BaseNode id={id} data={augmentedData} selected={selected} width={244} height='auto'>
+      <NodeTargetHandle id={id} data={{ ...augmentedData, selected }} handleId='target' />
       <div className='space-y-1 pb-2'>
         <div className='relative px-2'>
           {hasContent ? (
@@ -82,12 +94,13 @@ export const ChunkerNode = memo<NodeProps<ChunkerNodeData>>(({ id, data, selecte
           <NodeSourceHandle
             handleId='source'
             id={id}
-            data={{ ...data, selected }}
+            data={{ ...augmentedData, selected }}
             handleClassName='!bottom-5'
             handleIndex={0}
-            handleTotal={1}
+            handleTotal={totalSourceHandles}
           />
         </div>
+        {hasFailBranch && <NodeFailBranch id={id} data={augmentedData} selected={selected} />}
       </div>
     </BaseNode>
   )

--- a/apps/web/src/components/workflow/nodes/core/chunker/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/chunker/panel.tsx
@@ -6,6 +6,10 @@ import { produce } from 'immer'
 import type React from 'react'
 import { memo, useCallback } from 'react'
 import { useNodeCrud } from '~/components/workflow/hooks'
+import {
+  ErrorHandlingSection,
+  type ErrorStrategyUpdate,
+} from '~/components/workflow/nodes/shared/error-handling-section'
 import { BaseType, VAR_MODE } from '~/components/workflow/types'
 import {
   VarEditor,
@@ -31,6 +35,12 @@ interface ChunkerPanelProps {
  */
 const ChunkerPanelComponent: React.FC<ChunkerPanelProps> = ({ nodeId, data }) => {
   const { inputs: nodeData, setInputs } = useNodeCrud<ChunkerNodeData>(nodeId, data)
+
+  /** Failure policy — the shared control, driven by the manifest declaration. */
+  const handleErrorStrategyChange = useCallback(
+    (update: ErrorStrategyUpdate) => setInputs({ ...nodeData, ...update }),
+    [nodeData, setInputs]
+  )
 
   /**
    * Handle content change
@@ -305,6 +315,13 @@ const ChunkerPanelComponent: React.FC<ChunkerPanelProps> = ({ nodeId, data }) =>
           </VarEditorFieldRow>
         </VarEditorField>
       </Section>
+
+      <ErrorHandlingSection
+        nodeId={nodeId}
+        nodeType='chunker'
+        errorStrategy={nodeData.error_strategy}
+        onChange={handleErrorStrategyChange}
+      />
 
       <OutputVariablesDisplay
         outputVariables={getChunkerOutputVariables(nodeData, nodeId)}

--- a/apps/web/src/components/workflow/nodes/core/crud/components/default-values-editor.tsx
+++ b/apps/web/src/components/workflow/nodes/core/crud/components/default-values-editor.tsx
@@ -2,17 +2,8 @@
 
 'use client'
 
-import { Button } from '@auxx/ui/components/button'
-import { Input } from '@auxx/ui/components/input'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@auxx/ui/components/select'
-import { Plus, Trash2 } from 'lucide-react'
 import type React from 'react'
+import { ErrorDefaultValuesEditor } from '~/components/workflow/nodes/shared/error-default-values-editor'
 import type { CrudDefaultValue } from '../types'
 
 interface DefaultValuesEditorProps {
@@ -21,88 +12,16 @@ interface DefaultValuesEditorProps {
 }
 
 /**
- * Component for editing default values in CRUD nodes
- * Used when error strategy is set to 'default'
+ * Component for editing default values in CRUD nodes.
+ * Used when error strategy is set to 'default'.
+ *
+ * The implementation moved to `nodes/shared/error-default-values-editor.tsx`
+ * unchanged when the `ai` node opted into the `default` policy and needed the
+ * same control — it was already generic over `{ key, type, value }`. This stays
+ * as crud's typed entry point so no crud caller churns; plan 24, which owns the
+ * defaults-editor redesign, has one implementation to replace rather than two.
  */
 export const DefaultValuesEditor: React.FC<DefaultValuesEditorProps> = ({
   defaultValues,
   onChange,
-}) => {
-  const addDefaultValue = () => {
-    const newValue: CrudDefaultValue = {
-      key: '',
-      type: 'string',
-      value: '',
-    }
-    onChange([...defaultValues, newValue])
-  }
-
-  const updateDefaultValue = (index: number, updates: Partial<CrudDefaultValue>) => {
-    const updated = defaultValues.map((value, i) =>
-      i === index ? { ...value, ...updates } : value
-    )
-    onChange(updated)
-  }
-
-  const removeDefaultValue = (index: number) => {
-    onChange(defaultValues.filter((_, i) => i !== index))
-  }
-
-  return (
-    <div className='space-y-2'>
-      {defaultValues.map((defaultValue, index) => (
-        <div key={index} className='flex gap-2 items-end'>
-          <div className='flex-1'>
-            <Input
-              placeholder='Key'
-              value={defaultValue.key}
-              onChange={(e) => updateDefaultValue(index, { key: e.target.value })}
-              className='text-xs'
-            />
-          </div>
-
-          <div className='w-24'>
-            <Select
-              value={defaultValue.type}
-              onValueChange={(value: CrudDefaultValue['type']) =>
-                updateDefaultValue(index, { type: value })
-              }>
-              <SelectTrigger className='text-xs'>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value='string'>String</SelectItem>
-                <SelectItem value='number'>Number</SelectItem>
-                <SelectItem value='boolean'>Boolean</SelectItem>
-                <SelectItem value='object'>Object</SelectItem>
-                <SelectItem value='array'>Array</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className='flex-1'>
-            <Input
-              placeholder='Default value'
-              value={defaultValue.value}
-              onChange={(e) => updateDefaultValue(index, { value: e.target.value })}
-              className='text-xs'
-            />
-          </div>
-
-          <Button
-            variant='ghost'
-            size='sm'
-            onClick={() => removeDefaultValue(index)}
-            className='px-2'>
-            <Trash2 className='h-3 w-3' />
-          </Button>
-        </div>
-      ))}
-
-      <Button variant='ghost' size='sm' onClick={addDefaultValue} className='w-full text-xs'>
-        <Plus className='h-3 w-3 mr-1' />
-        Add Default Value
-      </Button>
-    </div>
-  )
-}
+}) => <ErrorDefaultValuesEditor defaultValues={defaultValues} onChange={onChange} />

--- a/apps/web/src/components/workflow/nodes/core/crud/node.tsx
+++ b/apps/web/src/components/workflow/nodes/core/crud/node.tsx
@@ -2,8 +2,11 @@
 
 'use client'
 
-import { hasFailBranch as configHasFailBranch } from '@auxx/lib/workflow-engine/client'
 import type React from 'react'
+import {
+  hasFailBranch as hasFailBranchFor,
+  NodeFailBranch,
+} from '~/components/workflow/nodes/shared/node-fail-branch'
 import { NodeSourceHandle } from '~/components/workflow/ui/node-handle'
 import { NodeTargetHandle } from '~/components/workflow/ui/node-handle/target-handle'
 import { useWorkflowResources } from '../../../providers'
@@ -27,7 +30,7 @@ export const CrudNode: React.FC<CrudNodeProps> = ({ id, data, selected }) => {
   // Calculate total source handles based on error strategy
   // Same predicate the manifest's `connection.branches` uses, so the handle
   // this renders and the branch the catalog declares can never disagree.
-  const hasFailBranch = configHasFailBranch({ error_strategy })
+  const hasFailBranch = hasFailBranchFor({ error_strategy })
   const totalSourceHandles = hasFailBranch ? 2 : 1
 
   // Augment data with handle count for collapsed height calculation
@@ -73,25 +76,7 @@ export const CrudNode: React.FC<CrudNodeProps> = ({ id, data, selected }) => {
         </div>
 
         {/* Fail branch display - conditional on error strategy */}
-        {hasFailBranch && (
-          <div className='relative px-2'>
-            <div className='flex items-center justify-between rounded-md bg-primary-100 p-1 text-xs'>
-              <div className='h-4 rounded-md px-1 font-semibold uppercase bg-bad-100 text-bad-500 whitespace-pre-line'>
-                On Failure
-              </div>
-              <div className='text-primary-500'>Fail Branch</div>
-            </div>
-            <NodeSourceHandle
-              id={id}
-              handleId='fail'
-              type='fail'
-              data={{ ...augmentedData, selected }}
-              handleClassName='!bottom-5'
-              handleIndex={1}
-              handleTotal={totalSourceHandles}
-            />
-          </div>
-        )}
+        {hasFailBranch && <NodeFailBranch id={id} data={augmentedData} selected={selected} />}
       </div>
     </BaseNode>
   )

--- a/apps/web/src/components/workflow/nodes/core/crud/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/crud/panel.tsx
@@ -23,6 +23,10 @@ import { memo, useCallback, useMemo } from 'react'
 import { ResourcePicker } from '~/components/pickers/resource-picker'
 import { useResource, useResourceFields } from '~/components/resources'
 import { useNodeCrud } from '~/components/workflow/hooks'
+import {
+  ErrorHandlingSection,
+  type ErrorStrategyUpdate,
+} from '~/components/workflow/nodes/shared/error-handling-section'
 import { BaseType, VAR_MODE } from '~/components/workflow/types'
 import Field from '~/components/workflow/ui/field'
 import type { FieldOptions } from '~/components/workflow/ui/input-editor/get-input-component'
@@ -162,11 +166,12 @@ const CrudPanelComponent: React.FC<CrudPanelProps> = ({ nodeId, data }) => {
   )
 
   const handleErrorStrategyChange = useCallback(
-    (errorStrategy: ErrorStrategy) => {
+    (update: ErrorStrategyUpdate) => {
       const newData = produce(nodeData, (draft) => {
-        draft.error_strategy = errorStrategy
+        draft.error_strategy = update.error_strategy
+        draft._targetBranches = update._targetBranches
         draft.default_values =
-          errorStrategy === ErrorStrategy.default ? nodeData.default_values || [] : []
+          update.error_strategy === ErrorStrategy.default ? nodeData.default_values || [] : []
       })
       setInputs(newData)
       if (!showValidation) setShowValidation(true)
@@ -482,59 +487,37 @@ const CrudPanelComponent: React.FC<CrudPanelProps> = ({ nodeId, data }) => {
         </Section>
       )}
 
-      <Section
-        title='Error Handling'
-        collapsible={nodeData.error_strategy === ErrorStrategy.default}
-        open={nodeData.error_strategy === ErrorStrategy.default}
+      {/* The selector is the SHARED control (plan 21 §15.4) — this panel used
+          to own an inline <Select> that duplicated http's with different
+          labels. Only the defaults editor is crud-specific, and plan 24 owns
+          its redesign, so it is passed through untouched. */}
+      <ErrorHandlingSection
+        nodeId={nodeId}
+        nodeType='crud'
+        errorStrategy={nodeData.error_strategy}
+        onChange={handleErrorStrategyChange}
         className='[&>[data-slot=section]]:pb-0!'
-        actions={
-          <Select
-            value={nodeData.error_strategy || ErrorStrategy.fail}
-            onValueChange={handleErrorStrategyChange}>
-            <SelectTrigger size='sm'>
-              <SelectValue placeholder='Select strategy' />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem
-                value={ErrorStrategy.fail}
-                description='Stop workflow and route to fail branch'>
-                Fail
-              </SelectItem>
-              <SelectItem
-                value={ErrorStrategy.continue}
-                description='Continue workflow with error information'>
-                Continue
-              </SelectItem>
-              <SelectItem
-                value={ErrorStrategy.default}
-                description='Use default values and continue'>
-                Default Values
-              </SelectItem>
-            </SelectContent>
-          </Select>
-        }>
-        {showValidation && getFieldErrorMessage('error_strategy') && (
-          <ValidationMessage
-            type={hasFieldErrorOfType('error_strategy', 'error') ? 'error' : 'warning'}
-            message={getFieldErrorMessage('error_strategy')!}
-          />
-        )}
-
-        {nodeData.error_strategy === ErrorStrategy.default && (
-          <Field title='Default Values' description='Fallback values to use when operations fail'>
-            <DefaultValuesEditor
-              defaultValues={nodeData.default_values || []}
-              onChange={handleDefaultValuesChange}
+        footer={
+          showValidation && getFieldErrorMessage('error_strategy') ? (
+            <ValidationMessage
+              type={hasFieldErrorOfType('error_strategy', 'error') ? 'error' : 'warning'}
+              message={getFieldErrorMessage('error_strategy')!}
             />
-            {showValidation && getFieldErrorMessage('default_values') && (
-              <ValidationMessage
-                type={hasFieldErrorOfType('default_values', 'error') ? 'error' : 'warning'}
-                message={getFieldErrorMessage('default_values')!}
-              />
-            )}
-          </Field>
-        )}
-      </Section>
+          ) : undefined
+        }>
+        <Field title='Default Values' description='Fallback values to use when operations fail'>
+          <DefaultValuesEditor
+            defaultValues={nodeData.default_values || []}
+            onChange={handleDefaultValuesChange}
+          />
+          {showValidation && getFieldErrorMessage('default_values') && (
+            <ValidationMessage
+              type={hasFieldErrorOfType('default_values', 'error') ? 'error' : 'warning'}
+              message={getFieldErrorMessage('default_values')!}
+            />
+          )}
+        </Field>
+      </ErrorHandlingSection>
 
       <OutputVariablesDisplay
         outputVariables={getCrudNodeOutputVariables(nodeData, nodeId, {

--- a/apps/web/src/components/workflow/nodes/core/dataset/node.tsx
+++ b/apps/web/src/components/workflow/nodes/core/dataset/node.tsx
@@ -4,6 +4,10 @@
 
 import { memo } from 'react'
 import { BaseNode } from '~/components/workflow/nodes/shared/base/base-node'
+import {
+  hasFailBranch as hasFailBranchFor,
+  NodeFailBranch,
+} from '~/components/workflow/nodes/shared/node-fail-branch'
 import type { NodeProps } from '~/components/workflow/types'
 import { NodeSourceHandle, NodeTargetHandle } from '~/components/workflow/ui/node-handle'
 import VariableTag from '~/components/workflow/ui/variables/variable-tag'
@@ -33,9 +37,17 @@ export const DatasetNode = memo<NodeProps<DatasetNodeData>>(({ id, data, selecte
   // Get display values for constants
   const documentTitleValue = data.documentTitle || 'Untitled'
 
+  // The fail lane renders off the STORED `error_strategy` — the same predicate
+  // `connection.branches` uses, so the handle this renders and the branch the
+  // catalog declares can never disagree. A node that predates the step-4
+  // opt-in carries no key and renders exactly what it always did.
+  const hasFailBranch = hasFailBranchFor(data)
+  const totalSourceHandles = hasFailBranch ? 2 : 1
+  const augmentedData = { ...data, _sourceHandleCount: totalSourceHandles }
+
   return (
-    <BaseNode id={id} data={data} selected={selected} width={244} height='auto'>
-      <NodeTargetHandle id={id} data={{ ...data, selected }} handleId='target' />
+    <BaseNode id={id} data={augmentedData} selected={selected} width={244} height='auto'>
+      <NodeTargetHandle id={id} data={{ ...augmentedData, selected }} handleId='target' />
       <div className='space-y-1 pb-2'>
         <div className='relative px-2'>
           {hasDataset || hasChunks ? (
@@ -94,12 +106,13 @@ export const DatasetNode = memo<NodeProps<DatasetNodeData>>(({ id, data, selecte
           <NodeSourceHandle
             handleId='source'
             id={id}
-            data={{ ...data, selected }}
+            data={{ ...augmentedData, selected }}
             handleClassName='!bottom-5'
             handleIndex={0}
-            handleTotal={1}
+            handleTotal={totalSourceHandles}
           />
         </div>
+        {hasFailBranch && <NodeFailBranch id={id} data={augmentedData} selected={selected} />}
       </div>
     </BaseNode>
   )

--- a/apps/web/src/components/workflow/nodes/core/dataset/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/dataset/panel.tsx
@@ -8,6 +8,10 @@ import { produce } from 'immer'
 import type React from 'react'
 import { memo, useCallback } from 'react'
 import { useNodeCrud } from '~/components/workflow/hooks'
+import {
+  ErrorHandlingSection,
+  type ErrorStrategyUpdate,
+} from '~/components/workflow/nodes/shared/error-handling-section'
 import { BaseType, VAR_MODE } from '~/components/workflow/types'
 import Field from '~/components/workflow/ui/field'
 import {
@@ -58,6 +62,12 @@ const BOOLEAN_FIELD_DEFAULTS: Record<BooleanField, boolean> = {
  */
 const DatasetPanelComponent: React.FC<DatasetPanelProps> = ({ nodeId, data }) => {
   const { inputs: nodeData, setInputs } = useNodeCrud<DatasetNodeData>(nodeId, data)
+
+  /** Failure policy — the shared control, driven by the manifest declaration. */
+  const handleErrorStrategyChange = useCallback(
+    (update: ErrorStrategyUpdate) => setInputs({ ...nodeData, ...update }),
+    [nodeData, setInputs]
+  )
 
   /**
    * Generic handler for string field changes
@@ -421,6 +431,13 @@ const DatasetPanelComponent: React.FC<DatasetPanelProps> = ({ nodeId, data }) =>
           </VarEditorFieldRow>
         </VarEditorField>
       </Section>
+
+      <ErrorHandlingSection
+        nodeId={nodeId}
+        nodeType='dataset'
+        errorStrategy={nodeData.error_strategy}
+        onChange={handleErrorStrategyChange}
+      />
 
       <OutputVariablesDisplay
         outputVariables={getDatasetOutputVariables(nodeData, nodeId)}

--- a/apps/web/src/components/workflow/nodes/core/document-extractor/node.tsx
+++ b/apps/web/src/components/workflow/nodes/core/document-extractor/node.tsx
@@ -5,6 +5,10 @@
 import { FileText, Link } from 'lucide-react'
 import { memo } from 'react'
 import { BaseNode } from '~/components/workflow/nodes/shared/base/base-node'
+import {
+  hasFailBranch as hasFailBranchFor,
+  NodeFailBranch,
+} from '~/components/workflow/nodes/shared/node-fail-branch'
 import type { NodeProps } from '~/components/workflow/types'
 import { NodeSourceHandle, NodeTargetHandle } from '~/components/workflow/ui/node-handle'
 import VariableTag from '~/components/workflow/ui/variables/variable-tag'
@@ -29,9 +33,17 @@ export const DocumentExtractorNode = memo<NodeProps<DocumentExtractorNodeData>>(
       typeof sourceValue === 'string' &&
       isNodeVariable(sourceValue)
 
+    // The fail lane renders off the STORED `error_strategy` — the same predicate
+    // `connection.branches` uses, so the handle this renders and the branch the
+    // catalog declares can never disagree. A node that predates the step-4
+    // opt-in carries no key and renders exactly what it always did.
+    const hasFailBranch = hasFailBranchFor(data)
+    const totalSourceHandles = hasFailBranch ? 2 : 1
+    const augmentedData = { ...data, _sourceHandleCount: totalSourceHandles }
+
     return (
-      <BaseNode id={id} data={data} selected={selected} width={244} height='auto'>
-        <NodeTargetHandle id={id} data={{ ...data, selected }} handleId='target' />
+      <BaseNode id={id} data={augmentedData} selected={selected} width={244} height='auto'>
+        <NodeTargetHandle id={id} data={{ ...augmentedData, selected }} handleId='target' />
         <div className='space-y-1 pb-2'>
           <div className='relative px-2'>
             <div className='flex items-start justify-start rounded-md bg-primary-100 p-1'>
@@ -59,12 +71,13 @@ export const DocumentExtractorNode = memo<NodeProps<DocumentExtractorNodeData>>(
             <NodeSourceHandle
               handleId='source'
               id={id}
-              data={{ ...data, selected }}
+              data={{ ...augmentedData, selected }}
               handleClassName='!bottom-5'
               handleIndex={0}
-              handleTotal={1}
+              handleTotal={totalSourceHandles}
             />
           </div>
+          {hasFailBranch && <NodeFailBranch id={id} data={augmentedData} selected={selected} />}
         </div>
       </BaseNode>
     )

--- a/apps/web/src/components/workflow/nodes/core/document-extractor/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/document-extractor/panel.tsx
@@ -14,6 +14,10 @@ import { FileText, Link } from 'lucide-react'
 import type React from 'react'
 import { memo, useCallback } from 'react'
 import { useNodeCrud } from '~/components/workflow/hooks'
+import {
+  ErrorHandlingSection,
+  type ErrorStrategyUpdate,
+} from '~/components/workflow/nodes/shared/error-handling-section'
 import { BaseType, VAR_MODE } from '~/components/workflow/types'
 import Field from '~/components/workflow/ui/field'
 import {
@@ -43,6 +47,12 @@ const DocumentExtractorPanelComponent: React.FC<DocumentExtractorPanelProps> = (
   data,
 }) => {
   const { inputs: nodeData, setInputs } = useNodeCrud<DocumentExtractorNodeData>(nodeId, data)
+
+  /** Failure policy — the shared control, driven by the manifest declaration. */
+  const handleErrorStrategyChange = useCallback(
+    (update: ErrorStrategyUpdate) => setInputs({ ...nodeData, ...update }),
+    [nodeData, setInputs]
+  )
 
   /**
    * Handle source type change (file/url)
@@ -283,6 +293,13 @@ const DocumentExtractorPanelComponent: React.FC<DocumentExtractorPanelProps> = (
           </VarEditorFieldRow>
         </VarEditorField>
       </Section>
+
+      <ErrorHandlingSection
+        nodeId={nodeId}
+        nodeType='document-extractor'
+        errorStrategy={nodeData.error_strategy}
+        onChange={handleErrorStrategyChange}
+      />
 
       <OutputVariablesDisplay
         outputVariables={getDocumentExtractorOutputVariables(nodeData, nodeId)}

--- a/apps/web/src/components/workflow/nodes/core/http/components/error-handling.tsx
+++ b/apps/web/src/components/workflow/nodes/core/http/components/error-handling.tsx
@@ -11,18 +11,13 @@ import {
   NumberInputIncrement,
   NumberInputScrubber,
 } from '@auxx/ui/components/input-number'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@auxx/ui/components/select'
 import { useCallback } from 'react'
 import { CodeEditor } from '~/components/schema-editor/ui/code-editor'
-import { useEdgeInteractions } from '~/components/workflow/hooks'
+import {
+  ErrorHandlingSection,
+  type ErrorStrategyUpdate,
+} from '~/components/workflow/nodes/shared/error-handling-section'
 import { Editor } from '~/components/workflow/ui/prompt-editor'
-import Section from '~/components/workflow/ui/section'
 import { type DefaultValueItem, ErrorStrategy, type HttpNodeData } from '../types'
 
 interface ErrorHandlingProps {
@@ -32,38 +27,22 @@ interface ErrorHandlingProps {
   onChange: (updates: Partial<HttpNodeData>) => void
 }
 
-/** Radix's `onValueChange` hands back a bare string; narrow it before storing. */
-function isErrorStrategy(value: string): value is ErrorStrategy {
-  return (Object.values(ErrorStrategy) as string[]).includes(value)
-}
-
+/**
+ * http's failure-policy panel.
+ *
+ * The strategy selector itself is the SHARED `ErrorHandlingSection`, driven by
+ * `manifest.errorHandling.strategies` — this file used to own a bespoke
+ * `<Select>` that duplicated crud's with different labels (plan 21 §15.4/§20.2).
+ * What is left here is only the part that is genuinely http-specific: the
+ * status/body/headers fields that make up the `default` substitute response.
+ *
+ * That defaults editor is deliberately NOT redesigned — plan 24 owns it.
+ */
 export function ErrorHandling({ nodeId, isReadOnly, config, onChange }: ErrorHandlingProps) {
-  const { handleEdgeDeleteByDeleteBranch } = useEdgeInteractions()
-
   // Read through the normalizer: persisted http nodes carry `'none'`, the
-  // legacy spelling of `continue` (plan 21 §15.1), and an unset value runs
-  // under the unified default, `fail`. The alias is never written back.
+  // legacy spelling of `continue` (plan 21 §15.1). The alias is never written
+  // back.
   const errorStrategy = normalizeErrorStrategy(config?.error_strategy)
-
-  // Handle error strategy change and update target branches
-  const setErrorStrategy = (newStrategy: string) => {
-    if (!isErrorStrategy(newStrategy)) return
-
-    const branches =
-      newStrategy === ErrorStrategy.fail
-        ? [
-            { id: 'source', name: '', type: 'default' as const },
-            { id: 'fail', name: 'Fail Branch', type: 'fail' as const },
-          ]
-        : [{ id: 'source', name: '', type: 'default' as const }]
-
-    onChange({ error_strategy: newStrategy, _targetBranches: branches })
-
-    // If changing from fail to something else, delete the fail branch edges
-    if (errorStrategy === ErrorStrategy.fail && newStrategy !== ErrorStrategy.fail) {
-      handleEdgeDeleteByDeleteBranch(nodeId, 'fail')
-    }
-  }
 
   // Helper function to get default value by key
   const getDefaultValue = (key: string): string => {
@@ -88,6 +67,11 @@ export function ErrorHandling({ nodeId, isReadOnly, config, onChange }: ErrorHan
 
     onChange({ default_value: newDefaults })
   }
+
+  const handleStrategyChange = useCallback(
+    (update: ErrorStrategyUpdate) => onChange(update as Partial<HttpNodeData>),
+    [onChange]
+  )
 
   const handleStatusCodeChange = useCallback(
     (value: number | undefined) => {
@@ -114,22 +98,11 @@ export function ErrorHandling({ nodeId, isReadOnly, config, onChange }: ErrorHan
   )
 
   return (
-    <Section
-      title='Error handling'
-      initialOpen={errorStrategy !== ErrorStrategy.continue}
-      enabled={errorStrategy !== ErrorStrategy.continue}
-      actions={
-        <Select value={errorStrategy} onValueChange={setErrorStrategy} disabled={isReadOnly}>
-          <SelectTrigger variant='default' size='sm' className='mb-0'>
-            <SelectValue placeholder='Select strategy' />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={ErrorStrategy.continue}>Continue</SelectItem>
-            <SelectItem value={ErrorStrategy.default}>Default Values</SelectItem>
-            <SelectItem value={ErrorStrategy.fail}>Fail branch</SelectItem>
-          </SelectContent>
-        </Select>
-      }>
+    <ErrorHandlingSection
+      nodeId={nodeId}
+      nodeType='http'
+      errorStrategy={config?.error_strategy}
+      onChange={handleStrategyChange}>
       {errorStrategy === ErrorStrategy.default && (
         <div className='space-y-3'>
           {/* Status Code */}
@@ -182,9 +155,6 @@ export function ErrorHandling({ nodeId, isReadOnly, config, onChange }: ErrorHan
           </div>
         </div>
       )}
-      {errorStrategy === ErrorStrategy.fail && (
-        <div className='text-sm text-primary-500'>Configure a 'Fail branch' below.</div>
-      )}
-    </Section>
+    </ErrorHandlingSection>
   )
 }

--- a/apps/web/src/components/workflow/nodes/core/http/node.tsx
+++ b/apps/web/src/components/workflow/nodes/core/http/node.tsx
@@ -2,9 +2,12 @@
 
 'use client'
 
-import { hasFailBranch as configHasFailBranch } from '@auxx/lib/workflow-engine/client'
 import { memo } from 'react'
 import { BaseNode } from '~/components/workflow/nodes/shared/base/base-node'
+import {
+  hasFailBranch as hasFailBranchFor,
+  NodeFailBranch,
+} from '~/components/workflow/nodes/shared/node-fail-branch'
 import type { NodeProps } from '~/components/workflow/types'
 import { NodeSourceHandle, NodeTargetHandle } from '~/components/workflow/ui/node-handle'
 import type { HttpNodeData } from './types'
@@ -13,7 +16,7 @@ export const HttpNode = memo<NodeProps<HttpNodeData>>(({ id, data, selected }) =
   // Calculate total source handles based on error strategy
   // Same predicate the manifest's `connection.branches` uses, so the handle
   // this renders and the branch the catalog declares can never disagree.
-  const hasFailBranch = configHasFailBranch(data)
+  const hasFailBranch = hasFailBranchFor(data)
   const totalSourceHandles = hasFailBranch ? 2 : 1
 
   // Augment data with handle count for collapsed height calculation
@@ -40,25 +43,7 @@ export const HttpNode = memo<NodeProps<HttpNodeData>>(({ id, data, selected }) =
             handleTotal={totalSourceHandles}
           />
         </div>
-        {hasFailBranch && (
-          <div className='relative px-2'>
-            <div className='flex items-center justify-between rounded-md bg-primary-100 p-1 text-xs'>
-              <div className='h-4 rounded-md px-1 font-semibold uppercase bg-bad-100 text-bad-500 whitespace-pre-line'>
-                On Failure
-              </div>
-              <div className='text-primary-500'>Fail Branch</div>
-            </div>
-            <NodeSourceHandle
-              id={id}
-              handleId='fail'
-              type='fail'
-              data={{ ...augmentedData, selected }}
-              handleClassName='!bottom-5'
-              handleIndex={1}
-              handleTotal={totalSourceHandles}
-            />
-          </div>
-        )}
+        {hasFailBranch && <NodeFailBranch id={id} data={augmentedData} selected={selected} />}
       </div>
     </BaseNode>
   )

--- a/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/node.tsx
+++ b/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/node.tsx
@@ -4,6 +4,10 @@
 
 import { memo } from 'react'
 import { BaseNode } from '~/components/workflow/nodes/shared/base/base-node'
+import {
+  hasFailBranch as hasFailBranchFor,
+  NodeFailBranch,
+} from '~/components/workflow/nodes/shared/node-fail-branch'
 import type { NodeProps } from '~/components/workflow/types'
 import { NodeSourceHandle, NodeTargetHandle } from '~/components/workflow/ui/node-handle'
 import VariableTag from '~/components/workflow/ui/variables/variable-tag'
@@ -34,9 +38,17 @@ export const KnowledgeRetrievalNode = memo<NodeProps<KnowledgeRetrievalNodeData>
             ? 'Full-Text'
             : 'Hybrid'
 
+    // The fail lane renders off the STORED `error_strategy` — the same predicate
+    // `connection.branches` uses, so the handle this renders and the branch the
+    // catalog declares can never disagree. A node that predates the step-4
+    // opt-in carries no key and renders exactly what it always did.
+    const hasFailBranch = hasFailBranchFor(data)
+    const totalSourceHandles = hasFailBranch ? 2 : 1
+    const augmentedData = { ...data, _sourceHandleCount: totalSourceHandles }
+
     return (
-      <BaseNode id={id} data={data} selected={selected} width={244} height='auto'>
-        <NodeTargetHandle id={id} data={{ ...data, selected }} handleId='target' />
+      <BaseNode id={id} data={augmentedData} selected={selected} width={244} height='auto'>
+        <NodeTargetHandle id={id} data={{ ...augmentedData, selected }} handleId='target' />
         <div className='space-y-1 pb-2'>
           <div className='relative px-2'>
             {hasQuery || hasSources ? (
@@ -86,12 +98,13 @@ export const KnowledgeRetrievalNode = memo<NodeProps<KnowledgeRetrievalNodeData>
             <NodeSourceHandle
               handleId='source'
               id={id}
-              data={{ ...data, selected }}
+              data={{ ...augmentedData, selected }}
               handleClassName='!bottom-5'
               handleIndex={0}
-              handleTotal={1}
+              handleTotal={totalSourceHandles}
             />
           </div>
+          {hasFailBranch && <NodeFailBranch id={id} data={augmentedData} selected={selected} />}
         </div>
       </BaseNode>
     )

--- a/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/knowledge-retrieval/panel.tsx
@@ -16,6 +16,10 @@ import { BookOpen, Database, Plus, Trash2 } from 'lucide-react'
 import type React from 'react'
 import { memo, useCallback } from 'react'
 import { useNodeCrud, useReadOnly } from '~/components/workflow/hooks'
+import {
+  ErrorHandlingSection,
+  type ErrorStrategyUpdate,
+} from '~/components/workflow/nodes/shared/error-handling-section'
 import { BaseType, VAR_MODE } from '~/components/workflow/types'
 import {
   VarEditor,
@@ -56,6 +60,12 @@ const KnowledgeRetrievalPanelComponent: React.FC<KnowledgeRetrievalPanelProps> =
   data,
 }) => {
   const { inputs: nodeData, setInputs } = useNodeCrud<KnowledgeRetrievalNodeData>(nodeId, data)
+
+  /** Failure policy — the shared control, driven by the manifest declaration. */
+  const handleErrorStrategyChange = useCallback(
+    (update: ErrorStrategyUpdate) => setInputs({ ...nodeData, ...update }),
+    [nodeData, setInputs]
+  )
   const { isReadOnly } = useReadOnly()
 
   const sources = nodeData.sources || []
@@ -390,6 +400,13 @@ const KnowledgeRetrievalPanelComponent: React.FC<KnowledgeRetrievalPanelProps> =
           </VarEditorFieldRow>
         </VarEditorField>
       </Section>
+
+      <ErrorHandlingSection
+        nodeId={nodeId}
+        nodeType='knowledge-retrieval'
+        errorStrategy={nodeData.error_strategy}
+        onChange={handleErrorStrategyChange}
+      />
 
       <OutputVariablesDisplay
         outputVariables={getKnowledgeRetrievalOutputVariables(nodeData, nodeId)}

--- a/apps/web/src/components/workflow/nodes/core/list/node.tsx
+++ b/apps/web/src/components/workflow/nodes/core/list/node.tsx
@@ -3,6 +3,10 @@
 import type { ResourceFieldId } from '@auxx/types/field'
 import { type FC, memo, useMemo } from 'react'
 import { useFields } from '~/components/resources/hooks/use-field'
+import {
+  hasFailBranch as hasFailBranchFor,
+  NodeFailBranch,
+} from '~/components/workflow/nodes/shared/node-fail-branch'
 import type { NodeProps } from '~/components/workflow/types'
 import VariableTag from '~/components/workflow/ui/variables/variable-tag'
 import { getIcon } from '~/components/workflow/utils/icon-helper'
@@ -71,9 +75,17 @@ export const ListNode: FC<NodeProps<ListNodeData>> = memo((props) => {
 
   const operationSummary = getOperationSummary()
 
+  // The fail lane renders off the STORED `error_strategy` — the same predicate
+  // `connection.branches` uses, so the handle this renders and the branch the
+  // catalog declares can never disagree. A node that predates the step-4
+  // opt-in carries no key and renders exactly what it always did.
+  const hasFailBranch = hasFailBranchFor(data)
+  const totalSourceHandles = hasFailBranch ? 2 : 1
+  const augmentedData = { ...data, _sourceHandleCount: totalSourceHandles }
+
   return (
     <BaseNode {...props} data={data} id={id} selected={selected}>
-      <NodeTargetHandle id={id} data={{ ...data, selected }} handleId='target' />
+      <NodeTargetHandle id={id} data={{ ...augmentedData, selected }} handleId='target' />
       <div className='relative'>
         {/* Operation display */}
         <div className='px-3 py-2 space-y-2'>
@@ -103,10 +115,13 @@ export const ListNode: FC<NodeProps<ListNodeData>> = memo((props) => {
 
         <NodeSourceHandle
           id={id}
-          data={{ ...data, selected }}
+          data={{ ...augmentedData, selected }}
           handleId='source'
-          handleClassName='!top-1/2 !-right-[0px]'
+          handleClassName={hasFailBranch ? '!bottom-5' : '!top-1/2 !-right-[0px]'}
+          handleIndex={0}
+          handleTotal={totalSourceHandles}
         />
+        {hasFailBranch && <NodeFailBranch id={id} data={augmentedData} selected={selected} />}
       </div>
     </BaseNode>
   )

--- a/apps/web/src/components/workflow/nodes/core/list/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/list/panel.tsx
@@ -16,6 +16,10 @@ import { v4 as generateId } from 'uuid'
 import { useNodeCrud, useReadOnly } from '~/components/workflow/hooks'
 import { useVariable } from '~/components/workflow/hooks/use-var-store-sync'
 import { BasePanel } from '~/components/workflow/nodes/shared/base/base-panel'
+import {
+  ErrorHandlingSection,
+  type ErrorStrategyUpdate,
+} from '~/components/workflow/nodes/shared/error-handling-section'
 import { useVarStore } from '~/components/workflow/store/use-var-store'
 import { BaseType, VAR_MODE } from '~/components/workflow/types'
 import Field from '~/components/workflow/ui/field'
@@ -44,6 +48,12 @@ interface ListPanelProps {
 const ListPanelComponent: React.FC<ListPanelProps> = ({ nodeId, data }) => {
   const { isReadOnly } = useReadOnly()
   const { inputs: nodeData, setInputs: setNodeData } = useNodeCrud<ListNodeData>(nodeId, data)
+
+  /** Failure policy — the shared control, driven by the manifest declaration. */
+  const handleErrorStrategyChange = useCallback(
+    (update: ErrorStrategyUpdate) => setNodeData({ ...nodeData, ...update }),
+    [nodeData, setNodeData]
+  )
 
   // Extract variable ID from inputList (format: "{{variableId}}" or "variableId")
   const inputVariableId = useMemo(() => {
@@ -258,6 +268,13 @@ const ListPanelComponent: React.FC<ListPanelProps> = ({ nodeId, data }) => {
       </Section>
 
       {/* Output Variables */}
+      <ErrorHandlingSection
+        nodeId={nodeId}
+        nodeType='list'
+        errorStrategy={nodeData.error_strategy}
+        onChange={handleErrorStrategyChange}
+      />
+
       <OutputVariablesDisplay outputVariables={outputVariables} initialOpen={false} />
     </BasePanel>
   )

--- a/apps/web/src/components/workflow/nodes/shared/error-default-values-editor.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/error-default-values-editor.tsx
@@ -1,0 +1,106 @@
+// apps/web/src/components/workflow/nodes/shared/error-default-values-editor.tsx
+
+'use client'
+
+import type { ErrorDefaultValue } from '@auxx/lib/workflow-engine/client'
+import { Button } from '@auxx/ui/components/button'
+import { Input } from '@auxx/ui/components/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
+import { Plus, Trash2 } from 'lucide-react'
+import type React from 'react'
+
+interface ErrorDefaultValuesEditorProps {
+  defaultValues: ErrorDefaultValue[]
+  onChange: (values: ErrorDefaultValue[]) => void
+}
+
+/**
+ * Editor for the `{ key, type, value }` substitutes applied when a node's
+ * failure policy is `default`.
+ *
+ * Lifted VERBATIM out of `core/crud/components/default-values-editor.tsx` when
+ * the `ai` node opted in and needed the same control — it was already generic
+ * over the item shape, and crud's file is now a thin typed wrapper over this.
+ * Deliberately NOT redesigned: plan 24 owns the defaults editor, and it should
+ * find one implementation to replace rather than two copies.
+ */
+export const ErrorDefaultValuesEditor: React.FC<ErrorDefaultValuesEditorProps> = ({
+  defaultValues,
+  onChange,
+}) => {
+  const addDefaultValue = () => {
+    onChange([...defaultValues, { key: '', type: 'string', value: '' }])
+  }
+
+  const updateDefaultValue = (index: number, updates: Partial<ErrorDefaultValue>) => {
+    onChange(defaultValues.map((value, i) => (i === index ? { ...value, ...updates } : value)))
+  }
+
+  const removeDefaultValue = (index: number) => {
+    onChange(defaultValues.filter((_, i) => i !== index))
+  }
+
+  return (
+    <div className='space-y-2'>
+      {defaultValues.map((defaultValue, index) => (
+        <div key={index} className='flex gap-2 items-end'>
+          <div className='flex-1'>
+            <Input
+              placeholder='Key'
+              value={defaultValue.key}
+              onChange={(e) => updateDefaultValue(index, { key: e.target.value })}
+              className='text-xs'
+            />
+          </div>
+
+          <div className='w-24'>
+            <Select
+              value={defaultValue.type}
+              onValueChange={(value: ErrorDefaultValue['type']) =>
+                updateDefaultValue(index, { type: value })
+              }>
+              <SelectTrigger className='text-xs'>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value='string'>String</SelectItem>
+                <SelectItem value='number'>Number</SelectItem>
+                <SelectItem value='boolean'>Boolean</SelectItem>
+                <SelectItem value='object'>Object</SelectItem>
+                <SelectItem value='array'>Array</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className='flex-1'>
+            <Input
+              placeholder='Default value'
+              value={defaultValue.value}
+              onChange={(e) => updateDefaultValue(index, { value: e.target.value })}
+              className='text-xs'
+            />
+          </div>
+
+          <Button
+            variant='ghost'
+            size='sm'
+            onClick={() => removeDefaultValue(index)}
+            className='px-2'>
+            <Trash2 className='h-3 w-3' />
+          </Button>
+        </div>
+      ))}
+
+      <Button variant='ghost' size='sm' onClick={addDefaultValue} className='w-full text-xs'>
+        <Plus className='h-3 w-3 mr-1' />
+        Add Default Value
+      </Button>
+    </div>
+  )
+}

--- a/apps/web/src/components/workflow/nodes/shared/error-handling-section.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/error-handling-section.tsx
@@ -1,0 +1,161 @@
+// apps/web/src/components/workflow/nodes/shared/error-handling-section.tsx
+
+'use client'
+
+import {
+  ErrorStrategy,
+  getManifest,
+  normalizeErrorStrategy,
+  type TargetBranch,
+} from '@auxx/lib/workflow-engine/client'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@auxx/ui/components/select'
+import type { ReactNode } from 'react'
+import { useCallback } from 'react'
+import { useEdgeInteractions, useReadOnly } from '~/components/workflow/hooks'
+import Section from '~/components/workflow/ui/section'
+
+/** What the node persists when a strategy is picked. */
+export interface ErrorStrategyUpdate {
+  error_strategy: ErrorStrategy
+  _targetBranches: TargetBranch[]
+}
+
+export interface ErrorHandlingSectionProps {
+  /** Canvas node id — needed to drop fail-branch edges when the policy changes. */
+  nodeId: string
+  /** The persisted `data.type`, i.e. the manifest id whose declaration drives this. */
+  nodeType: string
+  /** Raw persisted `error_strategy` — may be absent, or the legacy `'none'`. */
+  errorStrategy: unknown
+  /** Persist the picked strategy and the branches it derives. */
+  onChange: (update: ErrorStrategyUpdate) => void
+  /** The node's own defaults editor, rendered only under the `default` policy. */
+  children?: ReactNode
+  /** Extra content shown under every policy (validation messages, hints). */
+  footer?: ReactNode
+  className?: string
+}
+
+/** Copy for each policy. Written once so every node type says the same thing. */
+const STRATEGY_COPY: Record<ErrorStrategy, { label: string; description: string }> = {
+  [ErrorStrategy.fail]: {
+    label: 'Fail branch',
+    description: 'Stop this path and route to the fail branch',
+  },
+  [ErrorStrategy.continue]: {
+    label: 'Continue',
+    description: 'Carry on with the error as this node’s output',
+  },
+  [ErrorStrategy.default]: {
+    label: 'Default values',
+    description: 'Substitute the values below and carry on',
+  },
+}
+
+/**
+ * The one failure-policy control, driven by `manifest.errorHandling.strategies`.
+ *
+ * Plan 21 §15.4 asked for this and steps 1–3 deliberately skipped it, so until
+ * PR B there were two bespoke selectors — http's `components/error-handling.tsx`
+ * and crud's inline `<Select>` in `panel.tsx` — offering different labels for
+ * the same three values, and the six node types opted in by step 4 had no way
+ * to be configured at all.
+ *
+ * It renders only the policies the manifest declares, which is the point of the
+ * declaration being per type: `default` needs an output shape worth
+ * substituting (http has a response body, `ai` has `text`), and a chunker has
+ * no meaningful "default chunks", so the option simply never appears there.
+ *
+ * A type with no `errorHandling` declaration renders NOTHING — that absence is
+ * the explicit statement "a failure here is fatal", not an oversight.
+ *
+ * Built on `Section` + `<Select>` in the `actions` slot, matching the two
+ * selectors it replaces and the rest of the node panels. It is not a
+ * `FieldPanelRow`, so the `FieldInputAdapter` rule (`docs/ui-design-guide.md`
+ * §5) does not apply — the workflow panels' own primitive is `Section`/`Field`.
+ *
+ * The per-node defaults editors are passed as `children` and are deliberately
+ * NOT touched here: plan 24 owns their redesign.
+ */
+export function ErrorHandlingSection({
+  nodeId,
+  nodeType,
+  errorStrategy,
+  onChange,
+  children,
+  footer,
+  className,
+}: ErrorHandlingSectionProps) {
+  const { isReadOnly } = useReadOnly()
+  const { handleEdgeDeleteByDeleteBranch } = useEdgeInteractions()
+  const errorHandling = getManifest(nodeType)?.errorHandling
+
+  // Read through the normalizer: persisted http nodes carry `'none'`, the
+  // legacy spelling of `continue` (plan 21 §15.1), and an unset value runs
+  // under whatever the manifest declares as its `defaultStrategy`.
+  const current = normalizeErrorStrategy(errorStrategy, errorHandling?.defaultStrategy)
+
+  const setStrategy = useCallback(
+    (raw: string) => {
+      const next = raw as ErrorStrategy
+      if (!errorHandling?.strategies.includes(next)) return
+
+      onChange({
+        error_strategy: next,
+        _targetBranches:
+          next === ErrorStrategy.fail
+            ? [
+                { id: 'source', name: '', type: 'default' },
+                { id: 'fail', name: 'Fail', type: 'fail' },
+              ]
+            : [{ id: 'source', name: '', type: 'default' }],
+      })
+
+      // Leaving `fail` retires the branch, so any edge on it would dangle on a
+      // handle the node no longer renders.
+      if (current === ErrorStrategy.fail && next !== ErrorStrategy.fail) {
+        handleEdgeDeleteByDeleteBranch(nodeId, 'fail')
+      }
+    },
+    [current, errorHandling, handleEdgeDeleteByDeleteBranch, nodeId, onChange]
+  )
+
+  if (!errorHandling) return null
+
+  return (
+    <Section
+      className={className}
+      title='Error handling'
+      collapsible={current === ErrorStrategy.default}
+      open={current === ErrorStrategy.default}
+      actions={
+        <Select value={current} onValueChange={setStrategy} disabled={isReadOnly}>
+          <SelectTrigger variant='default' size='sm' className='mb-0'>
+            <SelectValue placeholder='Select strategy' />
+          </SelectTrigger>
+          <SelectContent>
+            {errorHandling.strategies.map((strategy) => (
+              <SelectItem
+                key={strategy}
+                value={strategy}
+                description={STRATEGY_COPY[strategy].description}>
+                {STRATEGY_COPY[strategy].label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      }>
+      {current === ErrorStrategy.default && children}
+      {current === ErrorStrategy.fail && (
+        <div className='text-sm text-primary-500'>Wire the Fail branch on the canvas.</div>
+      )}
+      {footer}
+    </Section>
+  )
+}

--- a/apps/web/src/components/workflow/nodes/shared/node-fail-branch.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/node-fail-branch.tsx
@@ -1,0 +1,59 @@
+// apps/web/src/components/workflow/nodes/shared/node-fail-branch.tsx
+
+'use client'
+
+import { hasFailBranch } from '@auxx/lib/workflow-engine/client'
+import { NodeSourceHandle } from '~/components/workflow/ui/node-handle'
+
+interface NodeFailBranchProps {
+  /** Canvas node id. */
+  id: string
+  /** The node's data, already augmented with `_sourceHandleCount`. */
+  data: Record<string, unknown>
+  /** React Flow hands this back optional; the handle only needs the flag. */
+  selected?: boolean
+}
+
+/**
+ * The `fail` lane a node renders when its stored `error_strategy` is `fail`.
+ *
+ * One component for all eight types that can render it. http and crud each
+ * carried a byte-identical copy of this block; step 4 added six more types that
+ * would have made eight, and a rendered handle that drifts from what the
+ * processor emits is the exact bug family the parity suite exists to catch
+ * (plan 21 §7.4).
+ *
+ * Callers must render this SECOND (index 1 of 2) — the plain `source` handle is
+ * always index 0 — and set `_sourceHandleCount` on the data they pass to
+ * `BaseNode` so the collapsed-height calculation accounts for both.
+ */
+export function NodeFailBranch({ id, data, selected }: NodeFailBranchProps) {
+  return (
+    <div className='relative px-2'>
+      <div className='flex items-center justify-between rounded-md bg-primary-100 p-1 text-xs'>
+        <div className='h-4 rounded-md px-1 font-semibold uppercase bg-bad-100 text-bad-500 whitespace-pre-line'>
+          On Failure
+        </div>
+        <div className='text-primary-500'>Fail Branch</div>
+      </div>
+      <NodeSourceHandle
+        id={id}
+        handleId='fail'
+        type='fail'
+        data={{ ...data, selected } as never}
+        handleClassName='!bottom-5'
+        handleIndex={1}
+        handleTotal={2}
+      />
+    </div>
+  )
+}
+
+/**
+ * Whether this node's stored config selects the one policy that renders a lane.
+ *
+ * Re-exported from the catalog so a `node.tsx` never re-implements the
+ * predicate: the handle this renders and the branch `connection.branches`
+ * declares read the same function, so they cannot disagree.
+ */
+export { hasFailBranch }

--- a/apps/web/src/components/workflow/parity/builder-engine-parity.test.ts
+++ b/apps/web/src/components/workflow/parity/builder-engine-parity.test.ts
@@ -268,12 +268,16 @@ describe('engine reader — attributes a .data read to the right node and the ri
 
 describe('engine reader — extracts the outputHandle values a processor can emit', () => {
   it('collects both arms of a conditional emission', () => {
-    // document-extractor.ts:294 `outputHandle: extractionResult.success ?
-    // 'source' : 'error'` — one expression, two emittable handles. A reader
-    // that only accepted a bare literal would see neither.
-    expect(ENGINE.get('document-extractor')?.outputHandles).toEqual(
-      expect.arrayContaining(['error', 'source'])
-    )
+    // `execute.ts` `hasErrors && stopOnError !== false ? undefined : 'source'`
+    // and `crud.ts`'s success/fail returns are the shape this pins: one
+    // expression, more than one emittable handle. A reader that only accepted a
+    // bare literal would see neither arm.
+    //
+    // The founding example WAS document-extractor's `success ? 'source' :
+    // 'error'`; plan 21 step 4 replaced the `'error'` arm with a call to the
+    // node's failure-policy helper, so the ternary is gone from that file. The
+    // reader capability is unchanged, only the specimen moved.
+    expect(ENGINE.get('crud')?.outputHandles).toEqual(expect.arrayContaining(['fail', 'source']))
   })
 
   it('does not read a ternary CONDITION literal as an emission', () => {

--- a/apps/web/src/components/workflow/parity/builder-rendered-handles.ts
+++ b/apps/web/src/components/workflow/parity/builder-rendered-handles.ts
@@ -31,9 +31,10 @@ import { NodeType } from '~/components/workflow/types/node-types'
  * ── WHAT AN ENTRY MEANS ─────────────────────────────────────────────────────
  * `sources` / `targets` are the LITERAL handle ids the node's component passes
  * to `<NodeSourceHandle>` / `<NodeTargetHandle>` (or raw `<Handle>`), including
- * ones rendered conditionally (crud/http render `fail` only when
- * `error_strategy === 'fail'`; the human node renders `timeout` only when a
- * timeout is configured) — a conditionally-rendered handle is still one the
+ * ones rendered conditionally (the eight types with a manifest `errorHandling`
+ * declaration render `fail` only when `error_strategy === 'fail'`, via the
+ * shared `nodes/shared/node-fail-branch.tsx`; the human node renders `timeout`
+ * only when a timeout is configured) — a conditionally-rendered handle is still one the
  * builder can produce an edge for, which is what the parity question needs.
  * `dynamicSources` documents branch handles whose ids are USER DATA (if-else
  * case ids, text-classifier category ids); they cannot be enumerated here, and
@@ -51,14 +52,17 @@ export interface RenderedHandles {
 }
 
 export const BUILDER_RENDERED_HANDLES: Record<string, RenderedHandles> = {
-  // nodes/core/ai/node.tsx:39 (source), :13 (target)
-  [NodeType.AI]: { sources: ['source'], targets: ['target'] },
+  // nodes/core/ai/node.tsx (source), (fail — rendered when `hasFailBranch`,
+  // i.e. error_strategy === 'fail'), (target). `ai` opted into failure policy
+  // in plan 21 step 4.
+  [NodeType.AI]: { sources: ['source', 'fail'], targets: ['target'] },
 
   // nodes/core/answer/node.tsx:13 (source), :12 (target)
   [NodeType.ANSWER]: { sources: ['source'], targets: ['target'] },
 
-  // nodes/core/chunker/node.tsx:83 (source), :41 (target)
-  [NodeType.CHUNKER]: { sources: ['source'], targets: ['target'] },
+  // nodes/core/chunker/node.tsx (source), (fail — rendered when
+  // `hasFailBranch`), :41 (target)
+  [NodeType.CHUNKER]: { sources: ['source', 'fail'], targets: ['target'] },
 
   // nodes/core/code/node.tsx:20 (source), :14 (target)
   [NodeType.CODE]: { sources: ['source'], targets: ['target'] },
@@ -67,14 +71,16 @@ export const BUILDER_RENDERED_HANDLES: Record<string, RenderedHandles> = {
   // `hasFailBranch`, i.e. error_strategy === 'fail'), :48 (target)
   [NodeType.CRUD]: { sources: ['source', 'fail'], targets: ['target'] },
 
-  // nodes/core/dataset/node.tsx:95 (source), :38 (target)
-  [NodeType.DATASET]: { sources: ['source'], targets: ['target'] },
+  // nodes/core/dataset/node.tsx (source), (fail — rendered when
+  // `hasFailBranch`), :38 (target)
+  [NodeType.DATASET]: { sources: ['source', 'fail'], targets: ['target'] },
 
   // nodes/core/date-time/node.tsx:53 (source), :42 (target)
   [NodeType.DATE_TIME]: { sources: ['source'], targets: ['target'] },
 
-  // nodes/core/document-extractor/node.tsx:60 (source), :34 (target)
-  [NodeType.DOCUMENT_EXTRACTOR]: { sources: ['source'], targets: ['target'] },
+  // nodes/core/document-extractor/node.tsx (source), (fail — rendered when
+  // `hasFailBranch`), :34 (target)
+  [NodeType.DOCUMENT_EXTRACTOR]: { sources: ['source', 'fail'], targets: ['target'] },
 
   // nodes/core/end/node.tsx:30 (source), :17 (target)
   [NodeType.END]: { sources: ['source'], targets: ['target'] },
@@ -114,11 +120,13 @@ export const BUILDER_RENDERED_HANDLES: Record<string, RenderedHandles> = {
   // nodes/core/information-extractor/node.tsx:67 (source), :25 (target)
   [NodeType.INFORMATION_EXTRACTOR]: { sources: ['source'], targets: ['target'] },
 
-  // nodes/core/knowledge-retrieval/node.tsx:87 (source), :39 (target)
-  [NodeType.KNOWLEDGE_RETRIEVAL]: { sources: ['source'], targets: ['target'] },
+  // nodes/core/knowledge-retrieval/node.tsx (source), (fail — rendered when
+  // `hasFailBranch`), :39 (target)
+  [NodeType.KNOWLEDGE_RETRIEVAL]: { sources: ['source', 'fail'], targets: ['target'] },
 
-  // nodes/core/list/node.tsx:107 (source), :76 (target)
-  [NodeType.LIST]: { sources: ['source'], targets: ['target'] },
+  // nodes/core/list/node.tsx (source), (fail — rendered when `hasFailBranch`),
+  // :76 (target)
+  [NodeType.LIST]: { sources: ['source', 'fail'], targets: ['target'] },
 
   // nodes/core/loop/node.tsx:36 (loop-start, into the loop body), :150 (source,
   // after the loop), :146 (target), :54 (loop-back — where the last node in the

--- a/apps/web/src/components/workflow/parity/contract-drift-allowlist.ts
+++ b/apps/web/src/components/workflow/parity/contract-drift-allowlist.ts
@@ -199,17 +199,13 @@ export const KNOWN_BROKEN_UNADVERTISED_WRITES: Record<string, string> = {
  * emission to a rendered handle (or rendering a handle) AND deleting its entry.
  */
 export const KNOWN_BROKEN_OUTPUT_HANDLES: Record<string, string> = {
-  'handle:chunker.error':
-    "chunker.ts:384 emits 'error' on failure; the UI renders only [source], so the error branch is unwirable.",
-  'handle:dataset.error': "dataset.ts:619 emits 'error' on failure; the UI renders only [source].",
-  'handle:document-extractor.error':
-    "document-extractor.ts:294/:319 emits 'error' on extraction failure; the UI renders only [source].",
-  'handle:format.error':
-    "format-processor.ts:429 emits 'error' on failure; the UI renders only [source].",
-  'handle:knowledge-retrieval.error':
-    "knowledge-retrieval.ts:394 emits 'error' on failure; the UI renders only [source].",
-  'handle:list.error':
-    "list-processor.ts:181 emits 'error' on failure; the UI renders only [source].",
+  // The six `handle:<type>.error` entries that stood here are GONE, not
+  // silenced. Plan 21 step 4 (PR B) took §14.4's option C: `document-extractor`,
+  // `chunker`, `dataset`, `knowledge-retrieval`, `list` and `ai` declare
+  // `errorHandling` on their manifests and now emit the DECLARED `fail` handle
+  // their `node.tsx` renders, while `format` (a format failure IS a config bug)
+  // and the engine-only `execute` emit no handle on failure at all. One error
+  // vocabulary, not two.
   'routing:engine-core.onError':
     "graph-navigation.ts `findFailureEdge` keeps 'onError' as a deliberate legacy fallback behind the emitted-handle lookup (#1560) — but no node's UI has ever rendered an onError handle, so the literal remains unrenderable. Listed until either a graph is shown to contain one (keep) or the fallback is retired (delete).",
 }

--- a/apps/web/src/components/workflow/utils/__tests__/calculate-target-branches.test.ts
+++ b/apps/web/src/components/workflow/utils/__tests__/calculate-target-branches.test.ts
@@ -14,18 +14,26 @@ import { calculateTargetBranches } from '../workflow-initializer'
  */
 const dataFor = (data: Record<string, unknown>) => data as unknown as FlowNode['data']
 
+const OPTED_IN = [
+  NodeType.HTTP,
+  NodeType.CRUD,
+  NodeType.AI,
+  NodeType.CHUNKER,
+  NodeType.DATASET,
+  NodeType.DOCUMENT_EXTRACTOR,
+  NodeType.KNOWLEDGE_RETRIEVAL,
+  NodeType.LIST,
+]
+
 describe('calculateTargetBranches — failure policy comes off the manifest', () => {
-  it.each([
-    NodeType.HTTP,
-    NodeType.CRUD,
-  ])('%s gets a fail lane when error_strategy is fail', (type) => {
+  it.each(OPTED_IN)('%s gets a fail lane when error_strategy is fail', (type) => {
     expect(calculateTargetBranches(dataFor({ type, error_strategy: 'fail' }))).toEqual([
       { id: 'source', name: '', type: 'default' },
       { id: 'fail', name: 'Fail', type: 'fail' },
     ])
   })
 
-  it.each([NodeType.HTTP, NodeType.CRUD])('%s gets source alone otherwise', (type) => {
+  it.each(OPTED_IN)('%s gets source alone otherwise', (type) => {
     for (const strategy of ['continue', 'default', undefined]) {
       expect(calculateTargetBranches(dataFor({ type, error_strategy: strategy }))).toEqual([
         { id: 'source', name: '', type: 'default' },
@@ -43,8 +51,10 @@ describe('calculateTargetBranches — failure policy comes off the manifest', ()
 
   it('returns undefined for a type that declares no errorHandling', () => {
     // Setting the field on a type that never opted in must not conjure a lane.
+    // `format` is the deliberate hold-out (a format failure IS a config bug);
+    // the example used to be `ai`, which opted in in plan 21 step 4.
     expect(
-      calculateTargetBranches(dataFor({ type: NodeType.AI, error_strategy: 'fail' }))
+      calculateTargetBranches(dataFor({ type: NodeType.FORMAT, error_strategy: 'fail' }))
     ).toBeUndefined()
     expect(calculateTargetBranches(dataFor({ type: NodeType.WAIT }))).toBeUndefined()
   })

--- a/packages/lib/src/workflow-engine/catalog/error-handling.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/error-handling.test.ts
@@ -9,9 +9,15 @@ import {
   normalizeErrorStrategy,
 } from './error-handling'
 import { aiManifest } from './nodes/ai'
+import { answerManifest } from './nodes/answer'
+import { chunkerManifest } from './nodes/chunker'
 import { crudManifest } from './nodes/crud'
+import { datasetManifest } from './nodes/dataset'
+import { documentExtractorManifest } from './nodes/document-extractor'
 import { formatManifest } from './nodes/format'
 import { httpManifest } from './nodes/http'
+import { knowledgeRetrievalManifest } from './nodes/knowledge-retrieval'
+import { listManifest } from './nodes/list'
 import { getManifest, listManifests } from './registry'
 
 /**
@@ -83,12 +89,49 @@ describe('errorHandlingBranches — the one site that turns a policy into a hand
 })
 
 describe('manifest declarations', () => {
-  it('http and crud are the only types that declare errorHandling (step 4 opts in more)', () => {
+  it('names exactly the types that opted in (plan 21 §16.3 + §18.1)', () => {
+    // An exact-set assertion, not a superset: opting a type in is a product
+    // decision, so a new entry here has to be a deliberate edit. `format` stays
+    // out because a format failure IS a config bug and routing around it hides
+    // the fix; `answer`, `information-extractor` and `text-classifier` are
+    // AI-backed but were never decided, so only `ai` itself is in.
     const declaring = listManifests()
       .filter((manifest) => manifest.errorHandling)
       .map((manifest) => manifest.id)
       .sort()
-    expect(declaring).toEqual(['crud', 'http'])
+    expect(declaring).toEqual([
+      'ai',
+      'chunker',
+      'crud',
+      'dataset',
+      'document-extractor',
+      'http',
+      'knowledge-retrieval',
+      'list',
+    ])
+  })
+
+  it.each([
+    ['document-extractor', documentExtractorManifest],
+    ['chunker', chunkerManifest],
+    ['dataset', datasetManifest],
+    ['knowledge-retrieval', knowledgeRetrievalManifest],
+    ['list', listManifest],
+  ])('%s offers fail + continue but never default', (_id, manifest) => {
+    // No `default`: none of these has an output shape worth substituting —
+    // there is no meaningful "default chunks" or default set of retrieved
+    // documents (plan 21 §15.4).
+    expect(manifest.errorHandling).toEqual({
+      strategies: [ErrorStrategy.fail, ErrorStrategy.continue],
+      defaultStrategy: ErrorStrategy.fail,
+    })
+  })
+
+  it('ai offers all three — it has a substitutable output shape', () => {
+    expect(aiManifest.errorHandling).toEqual({
+      strategies: [ErrorStrategy.fail, ErrorStrategy.continue, ErrorStrategy.default],
+      defaultStrategy: ErrorStrategy.fail,
+    })
   })
 
   it.each([
@@ -138,10 +181,10 @@ describe('manifest declarations', () => {
   })
 
   it('a type that does not declare errorHandling exposes no fail branch', () => {
-    // ABSENT means "a failure is fatal", which is the state every type but
-    // http and crud is in today. `format` failing IS a config bug; the ai node
-    // is the strongest step-4 candidate and still opted out here.
-    for (const manifest of [formatManifest, aiManifest]) {
+    // ABSENT means "a failure is fatal". `format` failing IS a config bug, so
+    // it stays out deliberately; `answer` is AI-backed and simply was not part
+    // of the §16.3 decision, so it stays out until it is.
+    for (const manifest of [formatManifest, answerManifest]) {
       expect(manifest.errorHandling).toBeUndefined()
       // Even a config that carries the key gets nothing — the declaration is
       // what grants the branch, not the presence of the field.
@@ -161,5 +204,58 @@ describe('manifest declarations', () => {
   it('is reachable by type id, which is how the graph builder reads it', () => {
     expect(getManifest('crud')?.errorHandling?.defaultStrategy).toBe(ErrorStrategy.fail)
     expect(getManifest('wait')?.errorHandling).toBeUndefined()
+  })
+})
+
+/**
+ * The step-4 acceptance criterion (plan 21, PR B): an EXISTING persisted node
+ * of a newly opted-in type — one with no `error_strategy` key, because no such
+ * row could have one — must keep behaving exactly as it did before the opt-in.
+ * On failure the run dies.
+ *
+ * The canvas half of that proof lives here: without the key the manifest
+ * exposes no `fail` branch, so no `node.tsx` renders the handle and no edge can
+ * ever address it. The engine half (the processor emits `'fail'`, which
+ * `findFailureEdge` cannot match, so `workflow-engine.ts` throws) is pinned per
+ * processor — `dataset/dataset-node-config.test.ts`,
+ * `transform-nodes/__tests__/list-processor.test.ts`,
+ * `action-nodes/__tests__/ai-v2.test.ts`.
+ */
+describe('step-4 opt-ins — behaviour preservation for existing rows', () => {
+  const OPTED_IN: Array<[string, { connection: { branches?: (config: never) => unknown } }]> = [
+    ['document-extractor', documentExtractorManifest],
+    ['chunker', chunkerManifest],
+    ['dataset', datasetManifest],
+    ['knowledge-retrieval', knowledgeRetrievalManifest],
+    ['list', listManifest],
+    ['ai', aiManifest],
+  ]
+
+  it.each(OPTED_IN)('%s exposes source alone for a config with no error_strategy', (_id, m) => {
+    // A legacy row carries no key at all. `hasFailBranch` reads the STORED
+    // value only (never the manifest's `defaultStrategy`), which is what keeps
+    // the branch off graphs that never had one.
+    expect(m.connection.branches?.({ title: 'legacy' } as never)).toEqual([
+      { id: 'source', name: '', kind: 'default' },
+    ])
+    expect(hasFailBranch({ title: 'legacy' })).toBe(false)
+  })
+
+  it.each(OPTED_IN)('%s exposes the fail branch once the key says fail', (_id, m) => {
+    expect(m.connection.branches?.({ error_strategy: 'fail' } as never)).toEqual([
+      { id: 'source', name: '', kind: 'default' },
+      { id: 'fail', name: 'Fail', kind: 'fail' },
+    ])
+  })
+
+  it.each(OPTED_IN)('%s writes error_strategy: fail on newly created nodes', (id, _m) => {
+    // Deliberately DIFFERENT from the legacy-row case above. `fail` is what an
+    // unset node already resolves to, so the processor emits `outputHandle:
+    // 'fail'` either way — persisting it on create is the node telling the
+    // truth about the handle it emits, instead of leaving new nodes in the
+    // undeclared-handle state this whole PR exists to remove (plan 21 §14.4).
+    const manifest = listManifests().find((entry) => entry.id === id)
+    const defaults = manifest?.defaultData() as { error_strategy?: string }
+    expect(defaults.error_strategy).toBe(ErrorStrategy.fail)
   })
 })

--- a/packages/lib/src/workflow-engine/catalog/error-handling.ts
+++ b/packages/lib/src/workflow-engine/catalog/error-handling.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/workflow-engine/catalog/error-handling.ts
 
+import { z } from 'zod'
 import type { NodeBranch } from './types'
 
 /**
@@ -120,3 +121,42 @@ export function hasFailBranch(config: unknown): boolean {
 export function errorHandlingBranches(config: unknown): NodeBranch[] {
   return hasFailBranch(config) ? [{ id: 'fail', name: 'Fail', kind: 'fail' }] : []
 }
+
+/**
+ * The persisted `error_strategy` field, for a node type's `configSchema`.
+ *
+ * Narrower than the `z.string()` `http` shipped with (plan 21 §20.2): an
+ * unrecognised string is a config bug, and letting one through means the panel
+ * renders an empty `<Select>` while the processor silently runs the `fail` arm.
+ *
+ * `'none'` is accepted because persisted http configs carry it — it is the
+ * legacy spelling of `continue` ({@link LEGACY_ALIASES}) — so a stored graph
+ * must still parse. It is never written again; every reader resolves it with
+ * {@link normalizeErrorStrategy}, which is why this stays a plain union rather
+ * than a `.transform()`: `configSchema` is the *shape* contract, and rewriting
+ * a value during validation would make the parsed config disagree with the row.
+ *
+ * Types opting in after http/crud use `errorStrategySchema.optional()`: no
+ * existing row of theirs carries the key, and an absent value is what
+ * {@link hasFailBranch} needs to see to render no branch.
+ */
+export const errorStrategySchema = z.union([z.enum(ErrorStrategy), z.literal('none')])
+
+/**
+ * A substitute value applied when the policy is `default` — `{ key, type,
+ * value }`, where `value` is a string representation parsed per `type` and may
+ * carry `{{…}}` refs.
+ *
+ * Declared here because two node types already ship the identical shape under
+ * two names (`http.default_value`, `crud.default_values`). The KEYS are not
+ * unified — that rename is plan 24's — but a third type does not get to invent
+ * a third item shape.
+ */
+export const errorDefaultValueSchema = z.object({
+  key: z.string(),
+  type: z.enum(['string', 'number', 'boolean', 'object', 'array']),
+  value: z.string(),
+})
+
+/** A substitute value applied when the policy is `default`. */
+export type ErrorDefaultValue = z.infer<typeof errorDefaultValueSchema>

--- a/packages/lib/src/workflow-engine/catalog/nodes/ai.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/ai.ts
@@ -6,8 +6,20 @@ import { collectVariableIds, isNonEmptyDoc, type TiptapDoc } from '../../../tipt
 import { AI_NODE_CONSTANTS } from '../../constants'
 import { BaseType } from '../../core/types'
 import type { UnifiedVariable } from '../../types/unified-variable'
+import {
+  type ErrorDefaultValue,
+  ErrorStrategy,
+  errorDefaultValueSchema,
+  errorHandlingBranches,
+  errorStrategySchema,
+} from '../error-handling'
 import type { BaseNodeData } from '../node-base'
-import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+import {
+  type NodeBranch,
+  NodeCategory,
+  type NodeManifest,
+  type NodeValidationResult,
+} from '../types'
 import { createUnifiedOutputVariable } from '../variable-conversion'
 import { containsVariableReference, extractVarIdsFromString } from '../variable-inference'
 
@@ -128,6 +140,24 @@ export interface AiNodeData extends BaseNodeData {
   approvalMode?: 'auto'
   /** Default 10 for AI node; agent default is 30. */
   maxIterations?: number
+
+  /**
+   * What happens when the model call fails — `fail`, `continue`, or `default`
+   * (substitute {@link AiNodeData.default_values} and carry on). Optional: no
+   * node persisted before plan 21 step 4 carries the key.
+   */
+  error_strategy?: ErrorStrategy
+  /**
+   * Substitute output variables applied when `error_strategy` is `default`.
+   * Keys are the node's own output names — `text`, `content`,
+   * `structured_output` — so `{{<node>.text}}` still resolves downstream
+   * ("if the classifier times out, use `unknown`", plan 21 §16.3).
+   *
+   * Named `default_values` to match crud rather than http's `default_value`;
+   * the two keys are a known wart and plan 24 owns the rename, so a third type
+   * joins the majority spelling instead of adding a third.
+   */
+  default_values?: ErrorDefaultValue[]
 }
 
 export const EMPTY_PROMPT_DOC: TiptapDoc = { type: 'doc', content: [{ type: 'paragraph' }] }
@@ -244,6 +274,9 @@ export const aiNodeDataSchema = z.object({
   appAccounts: appAccountsSchema.optional(),
   approvalMode: z.literal('auto').optional(),
   maxIterations: z.number().optional(),
+  // Failure policy — see `catalog/error-handling.ts`.
+  error_strategy: errorStrategySchema.optional(),
+  default_values: z.array(errorDefaultValueSchema).optional(),
 })
 
 /**
@@ -535,6 +568,16 @@ export const aiManifest: NodeManifest<AiNodeData> = {
     structured_output: { enabled: false },
     toolsEnabled: false,
     toolsets: [],
+    // Written on create for the same reason http/crud write it: `fail` is what
+    // an unset node ALREADY does, so the processor emits `outputHandle: 'fail'`
+    // on failure either way — persisting it is the node telling the truth about
+    // the handle it emits (plan 21 §14.4). Existing rows keep no key.
+    error_strategy: ErrorStrategy.fail,
+    default_values: [],
+    _targetBranches: [
+      { id: 'source', name: '', type: 'default' },
+      { id: 'fail', name: 'Fail', type: 'fail' },
+    ],
   }),
   configSchema: aiNodeDataSchema as unknown as z.ZodType<AiNodeData>,
   validate: validateAiData,
@@ -542,6 +585,29 @@ export const aiManifest: NodeManifest<AiNodeData> = {
   resolveOutputs: getAiOutputVariables,
   connection: {
     canRunSingle: true,
+    /**
+     * Successful runs leave via `source`; the `fail` branch comes from the
+     * shared helper, the single site that turns `error_strategy: 'fail'` into
+     * a handle (plan 21 §15.4).
+     */
+    branches: (config): NodeBranch[] => [
+      { id: 'source', name: '', kind: 'default' },
+      ...errorHandlingBranches(config),
+    ],
+  },
+  /**
+   * All three policies (Markus, plan 21 §18.1). A model call fails transiently
+   * far more often than a transform does, and unlike the RAG cluster the AI
+   * node HAS an output shape worth substituting — `text` is a plain string, so
+   * "if the classifier times out, use `unknown`" is expressible.
+   *
+   * Scoped to the `ai` type only. `answer`, `information-extractor` and
+   * `text-classifier` are AI-backed too but were never decided; they stay out
+   * until they are.
+   */
+  errorHandling: {
+    strategies: [ErrorStrategy.fail, ErrorStrategy.continue, ErrorStrategy.default],
+    defaultStrategy: ErrorStrategy.fail,
   },
   agent: {
     authorable: true,
@@ -550,7 +616,11 @@ export const aiManifest: NodeManifest<AiNodeData> = {
       'normalizer converts plain text with {{…}} refs into that shape; do not author raw Tiptap. ' +
       'Leave `model.useDefault: true` unless the user names a model. Enable `structured_output` ' +
       'with a JSON schema to get typed outputs at `{{<node>.structured_output.<key>}}`; the plain ' +
-      'response is always at `{{<node>.text}}`.',
+      'response is always at `{{<node>.text}}`. ' +
+      '`error_strategy` is fail (the default — exposes a wirable "fail" branch handle), ' +
+      'continue (succeed on "source" carrying the error) or default (substitute ' +
+      '`default_values`, a list of { key, type, value } keyed by this node’s own outputs, ' +
+      'e.g. key "text").',
     examples: [
       {
         description: 'Summarize an inbound message with the org default model',

--- a/packages/lib/src/workflow-engine/catalog/nodes/chunker.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/chunker.ts
@@ -3,8 +3,14 @@
 import { z } from 'zod'
 import { BaseType } from '../../core/types'
 import type { UnifiedVariable } from '../../types/unified-variable'
+import { ErrorStrategy, errorHandlingBranches, errorStrategySchema } from '../error-handling'
 import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
-import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+import {
+  type NodeBranch,
+  NodeCategory,
+  type NodeManifest,
+  type NodeValidationResult,
+} from '../types'
 import { createNestedVariable } from '../variable-conversion'
 import { extractFieldVariableIds, isVariableMode } from '../variable-inference'
 
@@ -71,6 +77,13 @@ export interface ChunkerNodeData extends BaseNodeData {
 
   /** Track constant/variable mode per field */
   fieldModes?: Record<string, boolean>
+  /**
+   * What happens when this node fails — `fail` (route to the wireable `fail`
+   * branch) or `continue` (succeed on `source` with `success: false` and the
+   * error in the output). Optional: no node persisted before plan 21 step 4
+   * carries the key, and an absent value renders no branch.
+   */
+  error_strategy?: ErrorStrategy
 }
 
 /**
@@ -98,6 +111,9 @@ export const chunkerNodeDataSchema = baseNodeDataSchema.extend({
 
   // Field modes
   fieldModes: z.record(z.string(), z.boolean()).optional(),
+
+  // Failure policy — see `catalog/error-handling.ts`.
+  error_strategy: errorStrategySchema.optional(),
 })
 
 /**
@@ -110,6 +126,17 @@ export const chunkerDefaultData = (): Partial<ChunkerNodeData> => ({
   chunkOverlap: CHUNKER_DEFAULT_CHUNK_OVERLAP,
   delimiter: CHUNKER_DEFAULT_DELIMITER,
   normalizeWhitespace: true,
+  // Written on create for the same reason http/crud write it: `fail` is what
+  // an unset node ALREADY does (`normalizeErrorStrategy(undefined)`), so the
+  // processor emits `outputHandle: 'fail'` on failure either way — persisting
+  // it is the node telling the truth about the handle it emits instead of
+  // recreating the undeclared-handle defect this opt-in exists to remove
+  // (plan 21 §14.4). Existing rows keep no key, and therefore no branch.
+  error_strategy: ErrorStrategy.fail,
+  _targetBranches: [
+    { id: 'source', name: '', type: 'default' },
+    { id: 'fail', name: 'Fail', type: 'fail' },
+  ],
   removeUrlsAndEmails: false,
   fieldModes: {},
 })
@@ -368,6 +395,23 @@ export const chunkerManifest: NodeManifest<ChunkerNodeData> = {
   resolveOutputs: getChunkerOutputVariables,
   connection: {
     canRunSingle: true,
+    /**
+     * Successful runs leave via `source`; the `fail` branch comes from the
+     * shared helper, the single site that turns `error_strategy: 'fail'` into
+     * a handle (plan 21 §15.4).
+     */
+    branches: (config): NodeBranch[] => [
+      { id: 'source', name: '', kind: 'default' },
+      ...errorHandlingBranches(config),
+    ],
+  },
+  /**
+   * Same shape as document-extractor (plan 21 §16.3): one bad input should be
+   * skippable. No `default` — there is no meaningful substitute set of chunks.
+   */
+  errorHandling: {
+    strategies: [ErrorStrategy.fail, ErrorStrategy.continue],
+    defaultStrategy: ErrorStrategy.fail,
   },
   agent: {
     authorable: true,
@@ -377,7 +421,10 @@ export const chunkerManifest: NodeManifest<ChunkerNodeData> = {
       '`content`). `chunkOverlap` must be smaller than `chunkSize`, and the step between ' +
       'chunks (`chunkSize - chunkOverlap`) must stay above 20% of `chunkSize` or the run ' +
       'fails. `delimiter` is stored ESCAPED — write "\\\\n\\\\n", not a real newline. Feed ' +
-      "this node's `chunks` output into a Dataset node.",
+      "this node's `chunks` output into a Dataset node. " +
+      '`error_strategy` is fail (the default — exposes a wirable "fail" branch handle; ' +
+      'leaving it unwired just means the run dies, which is the normal shape) or continue ' +
+      '(succeed on "source" with `success: false` and the error in the output).',
     examples: [
       {
         description: 'Chunk an extracted document with the defaults',

--- a/packages/lib/src/workflow-engine/catalog/nodes/dataset.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/dataset.ts
@@ -5,8 +5,14 @@ import { z } from 'zod'
 import { DATASET_NODE_CONSTANTS } from '../../constants'
 import { BaseType } from '../../core/types'
 import type { UnifiedVariable } from '../../types/unified-variable'
+import { ErrorStrategy, errorHandlingBranches, errorStrategySchema } from '../error-handling'
 import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
-import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+import {
+  type NodeBranch,
+  NodeCategory,
+  type NodeManifest,
+  type NodeValidationResult,
+} from '../types'
 import { createNestedVariable } from '../variable-conversion'
 import {
   extractFieldVariableIds,
@@ -75,6 +81,13 @@ export interface DatasetNodeData extends BaseNodeData {
 
   /** Track constant/variable mode per field */
   fieldModes?: Record<string, boolean>
+  /**
+   * What happens when this node fails — `fail` (route to the wireable `fail`
+   * branch) or `continue` (succeed on `source` with `success: false` and the
+   * error in the output). Optional: no node persisted before plan 21 step 4
+   * carries the key, and an absent value renders no branch.
+   */
+  error_strategy?: ErrorStrategy
 }
 
 /**
@@ -115,6 +128,9 @@ export const datasetNodeDataSchema = baseNodeDataSchema.extend({
 
   // Field modes
   fieldModes: z.record(z.string(), z.boolean()).optional(),
+
+  // Failure policy — see `catalog/error-handling.ts`.
+  error_strategy: errorStrategySchema.optional(),
 })
 
 /**
@@ -138,6 +154,17 @@ export const datasetDefaultData = (): Partial<DatasetNodeData> => ({
     waitForEmbeddings: true,
     embeddingTimeoutMinutes: true,
   },
+  // Written on create for the same reason http/crud write it: `fail` is what
+  // an unset node ALREADY does (`normalizeErrorStrategy(undefined)`), so the
+  // processor emits `outputHandle: 'fail'` on failure either way — persisting
+  // it is the node telling the truth about the handle it emits instead of
+  // recreating the undeclared-handle defect this opt-in exists to remove
+  // (plan 21 §14.4). Existing rows keep no key, and therefore no branch.
+  error_strategy: ErrorStrategy.fail,
+  _targetBranches: [
+    { id: 'source', name: '', type: 'default' },
+    { id: 'fail', name: 'Fail', type: 'fail' },
+  ],
 })
 
 /**
@@ -370,6 +397,23 @@ export const datasetManifest: NodeManifest<DatasetNodeData> = {
   resolveOutputs: getDatasetOutputVariables,
   connection: {
     canRunSingle: true,
+    /**
+     * Successful runs leave via `source`; the `fail` branch comes from the
+     * shared helper, the single site that turns `error_strategy: 'fail'` into
+     * a handle (plan 21 §15.4).
+     */
+    branches: (config): NodeBranch[] => [
+      { id: 'source', name: '', kind: 'default' },
+      ...errorHandlingBranches(config),
+    ],
+  },
+  /**
+   * A dataset write that failed has nothing to substitute (plan 21 §16.3), so
+   * `fail` or `continue` only.
+   */
+  errorHandling: {
+    strategies: [ErrorStrategy.fail, ErrorStrategy.continue],
+    defaultStrategy: ErrorStrategy.fail,
   },
   agent: {
     authorable: true,
@@ -380,7 +424,10 @@ export const datasetManifest: NodeManifest<DatasetNodeData> = {
       'not text. `waitForEmbeddings` defaults to true and is what makes a later ' +
       'knowledge-retrieval node in the SAME run able to see this document; turning it off ' +
       'reports success while the dataset still holds no vectors. The wait is bounded by ' +
-      '`embeddingTimeoutMinutes` (1–120, clamped).',
+      '`embeddingTimeoutMinutes` (1–120, clamped). ' +
+      '`error_strategy` is fail (the default — exposes a wirable "fail" branch handle; ' +
+      'leaving it unwired just means the run dies, which is the normal shape) or continue ' +
+      '(succeed on "source" with `success: false` and the error in the output).',
     examples: [
       {
         description: 'Store an extracted, chunked document and wait for its embeddings',

--- a/packages/lib/src/workflow-engine/catalog/nodes/document-extractor.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/document-extractor.ts
@@ -3,8 +3,14 @@
 import { z } from 'zod'
 import { BaseType } from '../../core/types'
 import type { UnifiedVariable } from '../../types/unified-variable'
+import { ErrorStrategy, errorHandlingBranches, errorStrategySchema } from '../error-handling'
 import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
-import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+import {
+  type NodeBranch,
+  NodeCategory,
+  type NodeManifest,
+  type NodeValidationResult,
+} from '../types'
 import { createNestedVariable } from '../variable-conversion'
 import { extractFieldVariableIds, isVariableMode } from '../variable-inference'
 
@@ -69,6 +75,14 @@ export interface DocumentExtractorNodeData extends BaseNodeData {
 
   /** Track constant/variable mode per field */
   fieldModes?: Record<string, boolean>
+
+  /**
+   * What happens when extraction fails — `fail` (route to the wireable `fail`
+   * branch) or `continue` (succeed on `source` with `success: false` and the
+   * error in the output). Optional: no node persisted before plan 21 step 4
+   * carries the key, and an absent value renders no branch.
+   */
+  error_strategy?: ErrorStrategy
 }
 
 /**
@@ -96,6 +110,9 @@ export const documentExtractorNodeDataSchema = baseNodeDataSchema.extend({
 
   // Field modes
   fieldModes: z.record(z.string(), z.boolean()).optional(),
+
+  // Failure policy — see `catalog/error-handling.ts`.
+  error_strategy: errorStrategySchema.optional(),
 })
 
 /**
@@ -108,6 +125,17 @@ export const documentExtractorDefaultData = (): Partial<DocumentExtractorNodeDat
   preserveFormatting: false,
   extractImages: false,
   fieldModes: {},
+  // Written on create for the same reason http/crud write it: `fail` is what
+  // an unset node ALREADY does (`normalizeErrorStrategy(undefined)`), so the
+  // processor emits `outputHandle: 'fail'` on failure either way — persisting
+  // it is the node telling the truth about the handle it emits instead of
+  // recreating the undeclared-handle defect this opt-in exists to remove
+  // (plan 21 §14.4). Existing rows keep no key, and therefore no branch.
+  error_strategy: ErrorStrategy.fail,
+  _targetBranches: [
+    { id: 'source', name: '', type: 'default' },
+    { id: 'fail', name: 'Fail', type: 'fail' },
+  ],
 })
 
 /**
@@ -343,6 +371,24 @@ export const documentExtractorManifest: NodeManifest<DocumentExtractorNodeData> 
   resolveOutputs: getDocumentExtractorOutputVariables,
   connection: {
     canRunSingle: true,
+    /**
+     * Successful extractions leave via `source`; the `fail` branch comes from
+     * the shared helper, the single site that turns `error_strategy: 'fail'`
+     * into a handle (plan 21 §15.4).
+     */
+    branches: (config): NodeBranch[] => [
+      { id: 'source', name: '', kind: 'default' },
+      ...errorHandlingBranches(config),
+    ],
+  },
+  /**
+   * "This one PDF was corrupt, keep going" is the canonical need here (plan 21
+   * §16.3). No `default`: there is no meaningful substitute for the text of a
+   * document that could not be read.
+   */
+  errorHandling: {
+    strategies: [ErrorStrategy.fail, ErrorStrategy.continue],
+    defaultStrategy: ErrorStrategy.fail,
   },
   agent: {
     authorable: true,
@@ -351,7 +397,10 @@ export const documentExtractorManifest: NodeManifest<DocumentExtractorNodeData> 
       '`fileId`, a MediaAsset id — normally an upstream variable such as an attachment) or ' +
       '"url" (needs `url`, which must start with http:// or https://). The `metadata` output ' +
       'differs between the two: a file run exposes `fileSize`, a URL run exposes `sourceUrl` ' +
-      'and `contentLength`. Feed `content` into a Chunker node.',
+      'and `contentLength`. Feed `content` into a Chunker node. ' +
+      '`error_strategy` is fail (the default — exposes a wirable "fail" branch handle; ' +
+      'leaving it unwired just means the run dies, which is the normal shape) or continue ' +
+      '(succeed on "source" with `success: false` and the error in the output).',
     examples: [
       {
         description: 'Extract an uploaded attachment',

--- a/packages/lib/src/workflow-engine/catalog/nodes/http.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/http.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 import { HTTP_NODE_CONSTANTS } from '../../constants'
 import { BaseType } from '../../core/types'
 import type { UnifiedVariable } from '../../types/unified-variable'
-import { ErrorStrategy, errorHandlingBranches } from '../error-handling'
+import { ErrorStrategy, errorHandlingBranches, errorStrategySchema } from '../error-handling'
 import type { BaseNodeData } from '../node-base'
 import {
   type NodeBranch,
@@ -195,7 +195,11 @@ export const httpNodeDataSchema = z.object({
       .max(HTTP_NODE_CONSTANTS.RETRY_CONFIG.RETRY_INTERVAL.max),
   }),
   ssl_verify: z.boolean(),
-  error_strategy: z.string(),
+  // Narrowed from the bare `z.string()` this shipped with (plan 21 §20.2): an
+  // unrecognised value renders an empty <Select> in the panel while the
+  // processor silently runs the `fail` arm. `'none'` still parses — persisted
+  // http configs carry it as the legacy spelling of `continue`.
+  error_strategy: errorStrategySchema,
   default_value: z.array(z.object({ key: z.string(), type: z.string(), value: z.string() })),
   // `_targetBranches` is DERIVED (canvas-owned) state and is deliberately not
   // declared here — see catalog/derived-keys.ts. It used to be REQUIRED, which

--- a/packages/lib/src/workflow-engine/catalog/nodes/knowledge-retrieval.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/knowledge-retrieval.ts
@@ -3,8 +3,14 @@
 import { z } from 'zod'
 import { BaseType } from '../../core/types'
 import type { UnifiedVariable } from '../../types/unified-variable'
+import { ErrorStrategy, errorHandlingBranches, errorStrategySchema } from '../error-handling'
 import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
-import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+import {
+  type NodeBranch,
+  NodeCategory,
+  type NodeManifest,
+  type NodeValidationResult,
+} from '../types'
 import { createNestedVariable } from '../variable-conversion'
 import { extractFieldVariableIds, isVariableMode } from '../variable-inference'
 
@@ -100,6 +106,13 @@ export interface KnowledgeRetrievalNodeData extends BaseNodeData {
 
   /** Track constant/variable mode per field */
   fieldModes?: Record<string, boolean>
+  /**
+   * What happens when this node fails — `fail` (route to the wireable `fail`
+   * branch) or `continue` (succeed on `source` with `success: false` and the
+   * error in the output). Optional: no node persisted before plan 21 step 4
+   * carries the key, and an absent value renders no branch.
+   */
+  error_strategy?: ErrorStrategy
 }
 
 /**
@@ -144,6 +157,9 @@ export const knowledgeRetrievalNodeDataSchema = baseNodeDataSchema.extend({
 
   // Field modes
   fieldModes: z.record(z.string(), z.boolean()).optional(),
+
+  // Failure policy — see `catalog/error-handling.ts`.
+  error_strategy: errorStrategySchema.optional(),
 })
 
 /**
@@ -166,6 +182,17 @@ export const knowledgeRetrievalDefaultData = (): Partial<KnowledgeRetrievalNodeD
     similarityThreshold: true,
     dedupePerDocument: true,
   },
+  // Written on create for the same reason http/crud write it: `fail` is what
+  // an unset node ALREADY does (`normalizeErrorStrategy(undefined)`), so the
+  // processor emits `outputHandle: 'fail'` on failure either way — persisting
+  // it is the node telling the truth about the handle it emits instead of
+  // recreating the undeclared-handle defect this opt-in exists to remove
+  // (plan 21 §14.4). Existing rows keep no key, and therefore no branch.
+  error_strategy: ErrorStrategy.fail,
+  _targetBranches: [
+    { id: 'source', name: '', type: 'default' },
+    { id: 'fail', name: 'Fail', type: 'fail' },
+  ],
 })
 
 /**
@@ -502,6 +529,23 @@ export const knowledgeRetrievalManifest: NodeManifest<KnowledgeRetrievalNodeData
   resolveOutputs: getKnowledgeRetrievalOutputVariables,
   connection: {
     canRunSingle: true,
+    /**
+     * Successful runs leave via `source`; the `fail` branch comes from the
+     * shared helper, the single site that turns `error_strategy: 'fail'` into
+     * a handle (plan 21 §15.4).
+     */
+    branches: (config): NodeBranch[] => [
+      { id: 'source', name: '', kind: 'default' },
+      ...errorHandlingBranches(config),
+    ],
+  },
+  /**
+   * A substitute set of retrieved documents is not a coherent thing; an empty
+   * result with `success: false` is (plan 21 §16.3). So no `default`.
+   */
+  errorHandling: {
+    strategies: [ErrorStrategy.fail, ErrorStrategy.continue],
+    defaultStrategy: ErrorStrategy.fail,
   },
   agent: {
     authorable: true,
@@ -511,7 +555,10 @@ export const knowledgeRetrievalManifest: NodeManifest<KnowledgeRetrievalNodeData
       '— at least one is required, and there is no implicit "all knowledge bases". `query` is ' +
       'required and usually references an upstream variable. Set `dedupePerDocument` to return ' +
       'one best passage per article rather than raw segments. `limit` is capped at 25 because ' +
-      'passages are prose and feed the next prompt untruncated.',
+      'passages are prose and feed the next prompt untruncated. ' +
+      '`error_strategy` is fail (the default — exposes a wirable "fail" branch handle; ' +
+      'leaving it unwired just means the run dies, which is the normal shape) or continue ' +
+      '(succeed on "source" with `success: false` and the error in the output).',
     examples: [
       {
         description: 'Search one knowledge base for text from an inbound email',

--- a/packages/lib/src/workflow-engine/catalog/nodes/list.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/list.ts
@@ -5,9 +5,15 @@ import { z } from 'zod'
 import type { Condition } from '../../../conditions/client'
 import { BaseType } from '../../core/types'
 import type { UnifiedVariable } from '../../types/unified-variable'
+import { ErrorStrategy, errorHandlingBranches, errorStrategySchema } from '../error-handling'
 import type { BaseNodeData } from '../node-base'
 import type { OutputContext } from '../output-context'
-import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../types'
+import {
+  type NodeBranch,
+  NodeCategory,
+  type NodeManifest,
+  type NodeValidationResult,
+} from '../types'
 import { assignVariableIds, cloneAndRewriteVariableIds } from '../variable-cloning'
 import { extractVarIdsFromString, inferPluckOutputType } from '../variable-inference'
 
@@ -123,6 +129,13 @@ export interface ListNodeData extends BaseNodeData {
   uniqueConfig?: UniqueConfig
   joinConfig?: JoinConfig
   pluckConfig?: PluckConfig
+
+  /**
+   * What happens when the operation fails — `fail` (route to the wireable
+   * `fail` branch) or `continue` (succeed on `source` with a null `result`).
+   * Optional: no node persisted before plan 21 step 4 carries the key.
+   */
+  error_strategy?: ErrorStrategy
 }
 
 /**
@@ -276,6 +289,8 @@ export const listNodeDataSchema = z.object({
   uniqueConfig: uniqueConfigSchema.optional(),
   joinConfig: joinConfigSchema.optional(),
   pluckConfig: pluckConfigSchema.optional(),
+  // Failure policy — see `catalog/error-handling.ts`.
+  error_strategy: errorStrategySchema.optional(),
 })
 
 /** Validation function for list node data */
@@ -688,6 +703,15 @@ export const listManifest: NodeManifest<ListNodeData> = {
       conditions: [],
       logic: 'AND',
     },
+    // Written on create for the same reason http/crud write it: `fail` is what
+    // an unset node ALREADY does, so the processor emits `outputHandle: 'fail'`
+    // on failure either way — persisting it is the node telling the truth about
+    // the handle it emits (plan 21 §14.4). Existing rows keep no key.
+    error_strategy: ErrorStrategy.fail,
+    _targetBranches: [
+      { id: 'source', name: '', type: 'default' },
+      { id: 'fail', name: 'Fail', type: 'fail' },
+    ],
   }),
   configSchema: listNodeDataSchema as unknown as z.ZodType<ListNodeData>,
   validate: validateListNodeData,
@@ -695,6 +719,27 @@ export const listManifest: NodeManifest<ListNodeData> = {
   resolveOutputs: computeListOutputVariables,
   connection: {
     canRunSingle: true,
+    /**
+     * Successful runs leave via `source`; the `fail` branch comes from the
+     * shared helper, the single site that turns `error_strategy: 'fail'` into
+     * a handle (plan 21 §15.4).
+     */
+    branches: (config): NodeBranch[] => [
+      { id: 'source', name: '', kind: 'default' },
+      ...errorHandlingBranches(config),
+    ],
+  },
+  /**
+   * The weakest case in plan 21 §16.3 — a list failure is usually a config bug
+   * and routing around it hides the fix. Opted in anyway because a list
+   * operating on data from a preceding API/retrieval step can fail on the DATA
+   * rather than on the config (a `pluck` over a field an upstream response
+   * omitted), which is the same "keep going" need the RAG cluster has. No
+   * `default`: a substitute list is a config value, not an error recovery.
+   */
+  errorHandling: {
+    strategies: [ErrorStrategy.fail, ErrorStrategy.continue],
+    defaultStrategy: ErrorStrategy.fail,
   },
   agent: {
     authorable: true,
@@ -702,7 +747,10 @@ export const listManifest: NodeManifest<ListNodeData> = {
       'Pick `operation` and fill its matching config (`filter`→filterConfig, `sort`→sortConfig, ' +
       '`slice`→sliceConfig, `unique`→uniqueConfig, `pluck`→pluckConfig; `join` defaults its ' +
       'delimiter and `reverse` needs none). `inputList` is a {{…}} ref to an upstream array. ' +
-      'Field references are a single `resource:field` id or an array for relationship traversal.',
+      'Field references are a single `resource:field` id or an array for relationship traversal. ' +
+      '`error_strategy` is fail (the default — exposes a wirable "fail" branch handle; ' +
+      'leaving it unwired just means the run dies, which is the normal shape) or continue ' +
+      '(succeed on "source" with `success: false` and the error in the output).',
     examples: [
       {
         description: 'Keep only open tickets from an upstream find',

--- a/packages/lib/src/workflow-engine/client.ts
+++ b/packages/lib/src/workflow-engine/client.ts
@@ -94,8 +94,11 @@ export {
 } from './catalog/derived-keys'
 export {
   DEFAULT_ERROR_STRATEGY,
+  type ErrorDefaultValue,
   ErrorStrategy,
+  errorDefaultValueSchema,
   errorHandlingBranches,
+  errorStrategySchema,
   hasFailBranch,
   type NodeErrorHandling,
   normalizeErrorStrategy,

--- a/packages/lib/src/workflow-engine/constants/nodes/crud.ts
+++ b/packages/lib/src/workflow-engine/constants/nodes/crud.ts
@@ -13,9 +13,6 @@ export const CRUD_NODE_CONSTANTS = {
   // Operation modes
   OPERATION_MODES: ['create', 'update', 'delete'] as const,
 
-  // Error strategies
-  ERROR_STRATEGIES: ['fail', 'continue', 'default'] as const,
-
   // Default values
   DEFAULT_VALUES: {
     MAX_COUNT: 20,
@@ -46,7 +43,10 @@ export const CRUD_NODE_CONSTANTS = {
 // Type exports for better type inference
 export type CrudResourceType = (typeof CRUD_NODE_CONSTANTS.RESOURCE_TYPES)[number]
 export type CrudOperationMode = (typeof CRUD_NODE_CONSTANTS.OPERATION_MODES)[number]
-export type CrudErrorStrategy = (typeof CRUD_NODE_CONSTANTS.ERROR_STRATEGIES)[number]
+// `CrudErrorStrategy` used to be declared here over `ERROR_STRATEGIES` — a
+// THIRD copy of the failure-policy vocabulary with zero importers (plan 21
+// §20.2). The one vocabulary is `ErrorStrategy` in
+// `catalog/error-handling.ts`; import that.
 
 // Helper type for default values
 export interface CrudDefaultValueConfig {

--- a/packages/lib/src/workflow-engine/core/__tests__/workflow-graph-builder.test.ts
+++ b/packages/lib/src/workflow-engine/core/__tests__/workflow-graph-builder.test.ts
@@ -689,12 +689,24 @@ describe('WorkflowGraphBuilder.getNodeHandles — errorHandling is read off the 
     expect(handlesFor({ type: 'http', error_strategy: 'none' })).toEqual(['source'])
   })
 
+  it('registers it for the step-4 opt-ins too, with no new arm', () => {
+    // `ai` joined in PR B (plan 21 §18.1) and needed no code here — declaring
+    // `errorHandling` on the manifest is the whole change.
+    expect(handlesFor({ type: 'ai', error_strategy: 'fail' })).toEqual(['source', 'fail'])
+  })
+
   it('gives NO fail handle to a type that does not declare errorHandling', () => {
-    // Neither `ai` nor `format` declares one, so a config that sets
-    // `error_strategy` anyway must not conjure a branch — the declaration is
-    // what grants the handle, not the presence of the field.
-    expect(handlesFor({ type: 'ai', error_strategy: 'fail' })).toEqual(['source'])
+    // `format` deliberately stays out (a format failure IS a config bug), so a
+    // config that sets `error_strategy` anyway must not conjure a branch — the
+    // declaration is what grants the handle, not the presence of the field.
     expect(handlesFor({ type: 'format', error_strategy: 'fail' })).toEqual(['source'])
+  })
+
+  it('gives NO fail handle to an opted-in type whose node carries no key', () => {
+    // The behaviour-preservation case: every persisted `ai` row predates the
+    // opt-in and has no `error_strategy`, so it must register exactly the
+    // handles it always did.
+    expect(handlesFor({ type: 'ai' })).toEqual(['source'])
   })
 
   it('leaves a type-specific arm alone when the type has no declaration', () => {

--- a/packages/lib/src/workflow-engine/core/workflow-graph-builder.ts
+++ b/packages/lib/src/workflow-engine/core/workflow-graph-builder.ts
@@ -862,8 +862,20 @@ export class WorkflowGraphBuilder {
 /**
  * Output handles that signal a failure/error outcome. Used to log loudly when
  * such a handle has no wired edge and routing falls back to the success path.
+ *
+ * `'error'` came OUT in plan 21 step 4. This set is keyed on what a processor
+ * EMITS, and after the step-4 opt-ins no processor emits `'error'` any more —
+ * the six that did now emit the declared `'fail'` (or, for `format` and the
+ * engine-only `execute`, no handle at all). Leaving it in would have kept a
+ * defensive arm for a case the authoring layer has been made unable to produce.
+ *
+ * `'onError'` STAYS, and is deliberately not symmetric: no processor emits it
+ * either, but it is still a live STORED-edge vocabulary — `findFailureEdge`
+ * (`core/graph-navigation.ts`) keeps it as the legacy back-compat lookup, and
+ * `contract-drift-allowlist.ts` tracks it as an open question. Retiring it is
+ * that entry's decision, not this one's.
  */
-const ERROR_LIKE_HANDLES = new Set(['fail', 'error', 'onError'])
+const ERROR_LIKE_HANDLES = new Set(['fail', 'onError'])
 
 /**
  * Helper functions for working with the workflow graph

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/ai-v2.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/__tests__/ai-v2.test.ts
@@ -420,6 +420,98 @@ describe('AIProcessorV2', () => {
     })
   })
 
+  /**
+   * Failure policy (plan 21 step 4 / §18.1). The AI node has always signalled
+   * failure by THROWING, which is why it never appeared in §7.4's
+   * `outputHandle: 'error'` hunt — but a model call fails transiently far more
+   * often than a transform does, so it is opted in with all three strategies.
+   *
+   * The acceptance criterion is behaviour preservation: an `ai` node with no
+   * stored `error_strategy` — every row that predates the opt-in — must keep
+   * killing the run. It does, by RE-THROWING: `fail` is the resolved default,
+   * and the throw is exactly what happened before.
+   */
+  describe('failure policy', () => {
+    const failingBase = (proc: AIProcessorV2) =>
+      vi
+        .spyOn(Object.getPrototypeOf(Object.getPrototypeOf(proc)), 'executeNode')
+        .mockRejectedValue(new Error('model timed out'))
+
+    const node = (data: Record<string, unknown> = {}) =>
+      aiNode({
+        model: { provider: 'openai', name: 'gpt-4' },
+        prompt_template: [pt('user', 'hi')],
+        toolsEnabled: false,
+        ...data,
+      })
+
+    it('re-throws for a node with no stored error_strategy', async () => {
+      const proc = new AIProcessorV2()
+      const spy = failingBase(proc)
+      await expect((proc as any).executeNode(node(), mockContextManager)).rejects.toThrow(
+        'model timed out'
+      )
+      spy.mockRestore()
+    })
+
+    it('re-throws for an explicit `fail` too — the branch is the wiring, not the swallow', async () => {
+      // `fail` does NOT mean "return a Failed result and hope"; the engine's
+      // own `findFailureEdge` routing is what a wired fail branch uses, and an
+      // UNWIRED one must still kill the run.
+      const proc = new AIProcessorV2()
+      const spy = failingBase(proc)
+      await expect(
+        (proc as any).executeNode(node({ error_strategy: 'fail' }), mockContextManager)
+      ).rejects.toThrow('model timed out')
+      spy.mockRestore()
+    })
+
+    it('`continue` succeeds on `source` and keeps `text` addressable', async () => {
+      const proc = new AIProcessorV2()
+      const spy = failingBase(proc)
+      const result = await (proc as any).executeNode(
+        node({ error_strategy: 'continue' }),
+        mockContextManager
+      )
+      expect(result.outputHandle).toBe('source')
+      expect(result.output).toMatchObject({ text: '', success: false, error: 'model timed out' })
+      expect(mockContextManager.setNodeVariable).toHaveBeenCalledWith('node_1', 'text', '')
+      spy.mockRestore()
+    })
+
+    it("`default` substitutes the configured values onto the node's own outputs", async () => {
+      // "If the classifier times out, use `unknown`" (plan 21 §16.3) — the
+      // reason `default` is offered here and nowhere else in the step-4 set.
+      const proc = new AIProcessorV2()
+      const spy = failingBase(proc)
+      const result = await (proc as any).executeNode(
+        node({
+          error_strategy: 'default',
+          default_values: [{ key: 'text', type: 'string', value: 'unknown' }],
+        }),
+        mockContextManager
+      )
+      expect(result.outputHandle).toBe('source')
+      expect(result.output).toMatchObject({ text: 'unknown', usedDefaults: true })
+      expect(mockContextManager.setNodeVariable).toHaveBeenCalledWith('node_1', 'text', 'unknown')
+      spy.mockRestore()
+    })
+
+    it('`default` with nothing configured falls through to fatal', async () => {
+      // Substituting nothing cannot succeed. Same shape as http's and crud's
+      // `default` arms, which both require a non-empty list.
+      const proc = new AIProcessorV2()
+      const spy = failingBase(proc)
+      await expect(
+        (proc as any).executeNode(
+          node({ error_strategy: 'default', default_values: [] }),
+          mockContextManager
+        )
+      ).rejects.toThrow('model timed out')
+      spy.mockRestore()
+    })
+  })
+
   // Integration tests for the tools-enabled path live in plan §6 tests 2–5.
   // They require either a real workflow run harness or mocking the
   // `runWorkflowAiTurn` runner end-to-end; both are out of scope for this

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/ai-v2.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/ai-v2.ts
@@ -6,6 +6,11 @@ import { LLMClient } from '../../../ai/clients/base/llm-client'
 import type { Message, MultiModalContent } from '../../../ai/clients/base/types'
 import { buildInstructionReferenceResolver } from '../../../ai/kopilot/prompts/resolve-instruction-references'
 import { collectVariableIds, docToText } from '../../../tiptap'
+import {
+  type ErrorDefaultValue,
+  ErrorStrategy,
+  normalizeErrorStrategy,
+} from '../../catalog/error-handling'
 import type { AiNodeData } from '../../catalog/nodes/ai'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type {
@@ -64,7 +69,14 @@ export interface AiToolsetEntry {
  */
 type AiNodeConfig = Pick<
   AiNodeData,
-  'title' | 'desc' | 'toolsEnabled' | 'appAccounts' | 'approvalMode' | 'maxIterations'
+  | 'title'
+  | 'desc'
+  | 'toolsEnabled'
+  | 'appAccounts'
+  | 'approvalMode'
+  | 'maxIterations'
+  | 'error_strategy'
+  | 'default_values'
 > & {
   model: AiModelConfig
   prompt_template: PromptTemplate[]
@@ -273,19 +285,139 @@ export class AIProcessorV2 extends BaseAiNodeProcessor {
   ): Promise<Partial<NodeExecutionResult>> {
     // `NodeData` carries the builder-only fields; the config is its payload half.
     const config = node.data as unknown as AiNodeConfig
-    if (!config?.toolsEnabled) {
-      const gates = await this.resolveGates(node, config, contextManager)
-      const result = await super.executeNode(
-        this.applyCapabilityGates(node, config, gates),
-        contextManager,
-        preprocessedData
-      )
-      if (gates.warnings.length > 0) {
-        result.output = { ...result.output, _warnings: gates.warnings }
+    try {
+      if (!config?.toolsEnabled) {
+        const gates = await this.resolveGates(node, config, contextManager)
+        const result = await super.executeNode(
+          this.applyCapabilityGates(node, config, gates),
+          contextManager,
+          preprocessedData
+        )
+        if (gates.warnings.length > 0) {
+          result.output = { ...result.output, _warnings: gates.warnings }
+        }
+        return result
       }
-      return result
+      return await this.executeNodeWithTools(node, config, contextManager)
+    } catch (error) {
+      return await this.applyFailurePolicy(node, config, contextManager, error)
     }
-    return this.executeNodeWithTools(node, config, contextManager)
+  }
+
+  /**
+   * Apply the node's failure policy (`catalog/error-handling.ts`).
+   *
+   * The AI node has always signalled failure by THROWING (`base-ai-node.ts`
+   * re-throws, `base-node.ts` wraps it in a `WorkflowNodeError`), which is why
+   * it never appeared in the `outputHandle: 'error'` divergence hunt — plan 21
+   * §7.4's six types are the ones that returned a handle. It is opted in
+   * anyway (§18.1): a model call fails transiently far more often than a
+   * transform does.
+   *
+   * Behaviour is preserved exactly for a node with no stored `error_strategy`:
+   * it resolves to `fail`, so this returns a Failed result on the declared
+   * `fail` handle. That node never rendered the handle, so no edge can address
+   * it, `findFailureEdge` returns undefined and `workflow-engine.ts` throws —
+   * the same fatal run, one frame later.
+   *
+   * Scoped to `AIProcessorV2`, i.e. the `ai` node type. `text-classifier`
+   * shares `BaseAiNodeProcessor` and is deliberately untouched: it was never
+   * decided (§16.3 lists only `ai`), and catching there would change three
+   * types on one undiscussed line.
+   *
+   * The `'fail'` literal stays inline for the same reason as the RAG cluster's:
+   * the builder↔engine parity reader extracts emitted handles per processor
+   * FILE.
+   */
+  private async applyFailurePolicy(
+    node: WorkflowNode,
+    config: AiNodeConfig,
+    contextManager: ExecutionContextManager,
+    error: unknown
+  ): Promise<Partial<NodeExecutionResult>> {
+    const message = error instanceof Error ? error.message : String(error)
+    const strategy = normalizeErrorStrategy(config?.error_strategy)
+    if (strategy === ErrorStrategy.fail) throw error
+
+    if (strategy === ErrorStrategy.default) {
+      const defaults = config?.default_values ?? []
+      if (defaults.length > 0) {
+        const substitutes = await this.resolveDefaultValues(defaults, contextManager)
+        for (const [key, value] of Object.entries(substitutes)) {
+          contextManager.setNodeVariable(node.nodeId, key, value)
+        }
+        contextManager.log('WARN', node.name, 'AI node failed, substituting default values', {
+          error: message,
+          defaultValueCount: defaults.length,
+        })
+        return {
+          status: NodeRunningStatus.Succeeded,
+          output: { ...substitutes, success: false, error: message, usedDefaults: true },
+          outputHandle: 'source',
+        }
+      }
+      // `default` with nothing configured substitutes nothing, so it cannot
+      // succeed — fall through to the fatal arm rather than reporting a success
+      // with an empty output. Same shape as http's and crud's `default` arms.
+      throw error
+    }
+
+    // `continue`: succeed on `source` carrying the error. `text` is published
+    // so `{{<node>.text}}` still resolves downstream instead of dangling.
+    //
+    // ONLY `text`. `content` is written by `storeAIResponse` on the success
+    // path too, but the picker never advertises it — a bulk `setNodeVariables`
+    // hides that from the builder↔engine parity reader, and publishing it from
+    // a literal here made the drift visible as a NEW failure. Fixing that
+    // advertisement is a separate question; this arm must not widen it.
+    contextManager.log('WARN', node.name, 'AI node failed but continuing', { error: message })
+    contextManager.setNodeVariable(node.nodeId, 'text', '')
+    return {
+      status: NodeRunningStatus.Succeeded,
+      output: { text: '', content: '', success: false, error: message },
+      outputHandle: 'source',
+    }
+  }
+
+  /**
+   * Parse `{ key, type, value }` substitutes into the values the `default`
+   * policy publishes, interpolating `{{…}}` refs first.
+   *
+   * A near-copy of crud's `processDefaultValues` — deliberately not shared:
+   * plan 24 owns the defaults editor and the `default_value`/`default_values`
+   * key split, and unifying the runtime half now would have to be unpicked by
+   * that work.
+   */
+  private async resolveDefaultValues(
+    defaultValues: ErrorDefaultValue[],
+    contextManager: ExecutionContextManager
+  ): Promise<Record<string, unknown>> {
+    const interpolated = await Promise.all(
+      defaultValues.map((dv) => this.interpolateVariables(dv.value, contextManager))
+    )
+    const result: Record<string, unknown> = {}
+    defaultValues.forEach((dv, index) => {
+      const value = interpolated[index] ?? ''
+      switch (dv.type) {
+        case 'number':
+          result[dv.key] = parseFloat(value) || 0
+          break
+        case 'boolean':
+          result[dv.key] = value.toLowerCase() === 'true'
+          break
+        case 'object':
+        case 'array':
+          try {
+            result[dv.key] = JSON.parse(value)
+          } catch {
+            result[dv.key] = value
+          }
+          break
+        default:
+          result[dv.key] = value
+      }
+    })
+    return result
   }
 
   /**

--- a/packages/lib/src/workflow-engine/nodes/action-nodes/execute.ts
+++ b/packages/lib/src/workflow-engine/nodes/action-nodes/execute.ts
@@ -151,8 +151,13 @@ export class ExecuteProcessor extends BaseNodeProcessor {
         executionResults.filter((r) => r.status === 'proposed').length
       )
 
-      // Determine output handle based on success/failure
-      const outputHandle = hasErrors && config.stopOnError !== false ? 'error' : 'source'
+      // On failure this emitted `'error'` — a handle no manifest declares and
+      // no canvas renders (plan 21 §14.2). `WorkflowNodeType.EXECUTE` is
+      // engine-only: it has no catalog manifest, it is not in the palette and
+      // Kopilot cannot author it, so there is nothing to opt into a failure
+      // policy. It simply stops naming a handle; a Failed result with no handle
+      // is the same fatal outcome, honestly spelled.
+      const outputHandle = hasErrors && config.stopOnError !== false ? undefined : 'source'
 
       const status =
         hasErrors && config.stopOnError !== false

--- a/packages/lib/src/workflow-engine/nodes/dataset/chunker.ts
+++ b/packages/lib/src/workflow-engine/nodes/dataset/chunker.ts
@@ -6,6 +6,7 @@ import { z } from 'zod'
 import { TextChunker } from '../../../datasets/processors/text-chunker'
 import type { DocumentChunk } from '../../../datasets/types'
 import { DocumentProcessor } from '../../../datasets/workers/document-processor'
+import { ErrorStrategy, normalizeErrorStrategy } from '../../catalog/error-handling'
 import {
   type ChunkerNodeData as CatalogChunkerNodeData,
   CHUNKER_DEFAULT_CHUNK_OVERLAP,
@@ -379,13 +380,39 @@ export class ChunkerProcessor extends BaseNodeProcessor {
       }
       this.storeOutputVariables(node.nodeId, errorOutput, contextManager)
 
-      return {
-        status: NodeRunningStatus.Failed,
-        error: errorMessage,
-        output: errorOutput,
-        outputHandle: 'error',
-      }
+      return this.failureResult(node, errorOutput, errorMessage)
     }
+  }
+
+  /**
+   * Apply the node's failure policy (`catalog/error-handling.ts`).
+   *
+   * Replaces the `outputHandle: 'error'` this used to emit — a handle no
+   * manifest declared, no `node.tsx` rendered and no edge could ever address,
+   * so the run died anyway (plan 21 §14.2). Behaviour is preserved exactly for
+   * a node with no stored `error_strategy`: it resolves to `fail`, emits the
+   * declared `fail` handle, `findFailureEdge` finds nothing (the node never
+   * rendered the handle, so no edge can exist) and the engine throws — the
+   * same fatal outcome, now over a vocabulary an author can actually wire.
+   *
+   * The `'fail'` literal stays inline in every opted-in processor rather than
+   * moving to a shared helper: the builder↔engine parity reader
+   * (`apps/web/.../parity/engine-write-scrape.ts`) extracts emitted handles by
+   * reading each processor FILE, so a handle emitted from a util would drop out
+   * of the contract it is supposed to be pinned by.
+   */
+  private failureResult(
+    node: WorkflowNode,
+    output: ChunkerOutput,
+    error: string
+  ): Partial<NodeExecutionResult> {
+    const strategy = normalizeErrorStrategy(
+      (node.data as { error_strategy?: unknown }).error_strategy
+    )
+    if (strategy === ErrorStrategy.continue) {
+      return { status: NodeRunningStatus.Succeeded, output, outputHandle: 'source' }
+    }
+    return { status: NodeRunningStatus.Failed, error, output, outputHandle: 'fail' }
   }
 
   // NOTE: No local preprocessContent or interpretEscapeSequences methods needed!

--- a/packages/lib/src/workflow-engine/nodes/dataset/dataset-node-config.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/dataset/dataset-node-config.test.ts
@@ -816,3 +816,100 @@ describe('DocumentExtractorProcessor boolean binding', () => {
     expect(required).toContain('settings_1.images')
   })
 })
+
+/**
+ * The step-4 acceptance criterion (plan 21, PR B): a node of a newly opted-in
+ * type that carries NO stored `error_strategy` — which is every row that
+ * existed before the opt-in — must behave exactly as it did before.
+ *
+ * Before: the processor returned `status: Failed` with `outputHandle: 'error'`,
+ * a handle no manifest declared and no canvas could wire, so `findFailureEdge`
+ * found nothing and `workflow-engine.ts` threw.
+ *
+ * After: the same node resolves to `fail` (the catalog-wide default), emits the
+ * DECLARED `fail` handle — and because it never rendered that handle, no edge
+ * can address it, so `findFailureEdge` still finds nothing and the run still
+ * dies. Same fatal outcome, over a vocabulary an author can now opt into.
+ */
+describe('failure policy — behaviour preservation for the step-4 opt-ins', () => {
+  const failingNode = (type: WorkflowNodeType) =>
+    createNode(type, { title: 'Legacy node' /* no error_strategy key */ })
+
+  it('chunker fails onto the declared `fail` handle', async () => {
+    const processor = new ChunkerProcessor()
+    // No preprocessed inputs — the processor's own guard throws, which is the
+    // failure path without reaching any I/O.
+    const result = await (processor as any).executeNode(
+      failingNode(WorkflowNodeType.CHUNKER),
+      createContext(),
+      undefined
+    )
+    expect(result.status).toBe('failed')
+    expect(result.outputHandle).toBe('fail')
+  })
+
+  it('dataset fails onto the declared `fail` handle', async () => {
+    const processor = new DatasetProcessor()
+    const result = await (processor as any).executeNode(
+      failingNode(WorkflowNodeType.DATASET),
+      createContext(),
+      undefined
+    )
+    expect(result.status).toBe('failed')
+    expect(result.outputHandle).toBe('fail')
+  })
+
+  it('knowledge-retrieval fails onto the declared `fail` handle', async () => {
+    const processor = new KnowledgeRetrievalProcessor()
+    const result = await (processor as any).executeNode(
+      failingNode(WorkflowNodeType.KNOWLEDGE_RETRIEVAL),
+      createContext(),
+      undefined
+    )
+    expect(result.status).toBe('failed')
+    expect(result.outputHandle).toBe('fail')
+  })
+
+  it('document-extractor fails onto the declared `fail` handle', async () => {
+    const processor = new DocumentExtractorProcessor()
+    const context = createContext()
+    vi.spyOn(context, 'getVariable').mockRejectedValue(new Error('context unavailable'))
+    const result = await (processor as any).executeNode(
+      failingNode(WorkflowNodeType.DOCUMENT_EXTRACTOR),
+      context,
+      undefined
+    )
+    expect(result.status).toBe('failed')
+    expect(result.outputHandle).toBe('fail')
+  })
+
+  it('`continue` succeeds on `source` instead, carrying the error in the output', async () => {
+    // The capability the opt-in exists for: "this one document was corrupt,
+    // keep going" (plan 21 §14.3). Only reachable once the author sets the key.
+    const processor = new ChunkerProcessor()
+    const result = await (processor as any).executeNode(
+      createNode(WorkflowNodeType.CHUNKER, { error_strategy: 'continue' }),
+      createContext(),
+      undefined
+    )
+    expect(result.status).toBe('succeeded')
+    expect(result.outputHandle).toBe('source')
+    expect(result.output).toMatchObject({ success: false })
+  })
+
+  it('no processor in the cluster emits the undeclared `error` handle any more', async () => {
+    // The whole point of §14.4 option C: one error vocabulary, not two.
+    for (const [type, processor] of [
+      [WorkflowNodeType.CHUNKER, new ChunkerProcessor()],
+      [WorkflowNodeType.DATASET, new DatasetProcessor()],
+      [WorkflowNodeType.KNOWLEDGE_RETRIEVAL, new KnowledgeRetrievalProcessor()],
+    ] as const) {
+      const result = await (processor as any).executeNode(
+        failingNode(type),
+        createContext(),
+        undefined
+      )
+      expect(result.outputHandle).not.toBe('error')
+    }
+  })
+})

--- a/packages/lib/src/workflow-engine/nodes/dataset/dataset.ts
+++ b/packages/lib/src/workflow-engine/nodes/dataset/dataset.ts
@@ -7,6 +7,7 @@ import { eq } from 'drizzle-orm'
 import { z } from 'zod'
 import type { DocumentChunk } from '../../../datasets/types'
 import { createDocumentProcessingFlow } from '../../../jobs/flows/document-processing-flow'
+import { ErrorStrategy, normalizeErrorStrategy } from '../../catalog/error-handling'
 import type { DatasetNodeData as CatalogDatasetNodeData } from '../../catalog/nodes/dataset'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type {
@@ -609,13 +610,39 @@ export class DatasetProcessor extends BaseNodeProcessor {
       }
       this.storeOutputVariables(node.nodeId, errorOutput, contextManager)
 
-      return {
-        status: NodeRunningStatus.Failed,
-        error: errorMessage,
-        output: errorOutput,
-        outputHandle: 'error',
-      }
+      return this.failureResult(node, errorOutput, errorMessage)
     }
+  }
+
+  /**
+   * Apply the node's failure policy (`catalog/error-handling.ts`).
+   *
+   * Replaces the `outputHandle: 'error'` this used to emit — a handle no
+   * manifest declared, no `node.tsx` rendered and no edge could ever address,
+   * so the run died anyway (plan 21 §14.2). Behaviour is preserved exactly for
+   * a node with no stored `error_strategy`: it resolves to `fail`, emits the
+   * declared `fail` handle, `findFailureEdge` finds nothing (the node never
+   * rendered the handle, so no edge can exist) and the engine throws — the
+   * same fatal outcome, now over a vocabulary an author can actually wire.
+   *
+   * The `'fail'` literal stays inline in every opted-in processor rather than
+   * moving to a shared helper: the builder↔engine parity reader
+   * (`apps/web/.../parity/engine-write-scrape.ts`) extracts emitted handles by
+   * reading each processor FILE, so a handle emitted from a util would drop out
+   * of the contract it is supposed to be pinned by.
+   */
+  private failureResult(
+    node: WorkflowNode,
+    output: DatasetOutput,
+    error: string
+  ): Partial<NodeExecutionResult> {
+    const strategy = normalizeErrorStrategy(
+      (node.data as { error_strategy?: unknown }).error_strategy
+    )
+    if (strategy === ErrorStrategy.continue) {
+      return { status: NodeRunningStatus.Succeeded, output, outputHandle: 'source' }
+    }
+    return { status: NodeRunningStatus.Failed, error, output, outputHandle: 'fail' }
   }
 
   /**

--- a/packages/lib/src/workflow-engine/nodes/dataset/document-extractor.ts
+++ b/packages/lib/src/workflow-engine/nodes/dataset/document-extractor.ts
@@ -4,6 +4,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { z } from 'zod'
 import { ExtractorFactory } from '../../../datasets/extractors/extractor-factory'
 import { createFileService } from '../../../files/core/file-service'
+import { ErrorStrategy, normalizeErrorStrategy } from '../../catalog/error-handling'
 import {
   type DocumentExtractorNodeData as CatalogDocumentExtractorNodeData,
   DocumentSourceType,
@@ -277,12 +278,14 @@ export class DocumentExtractorProcessor extends BaseNodeProcessor {
         executionTime,
       })
 
-      return {
-        status: extractionResult.success ? NodeRunningStatus.Succeeded : NodeRunningStatus.Failed,
-        output: extractionResult,
-        outputHandle: extractionResult.success ? 'source' : 'error',
-        error: extractionResult.error,
+      if (extractionResult.success) {
+        return {
+          status: NodeRunningStatus.Succeeded,
+          output: extractionResult,
+          outputHandle: 'source',
+        }
       }
+      return this.failureResult(node, extractionResult, extractionResult.error)
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Document extraction failed'
 
@@ -301,13 +304,39 @@ export class DocumentExtractorProcessor extends BaseNodeProcessor {
       }
       this.storeOutputVariables(node.nodeId, errorOutput, contextManager)
 
-      return {
-        status: NodeRunningStatus.Failed,
-        error: errorMessage,
-        output: errorOutput,
-        outputHandle: 'error',
-      }
+      return this.failureResult(node, errorOutput, errorMessage)
     }
+  }
+
+  /**
+   * Apply the node's failure policy (`catalog/error-handling.ts`).
+   *
+   * Replaces the `outputHandle: 'error'` this used to emit — a handle no
+   * manifest declared, no `node.tsx` rendered and no edge could ever address,
+   * so the run died anyway (plan 21 §14.2). Behaviour is preserved exactly for
+   * a node with no stored `error_strategy`: it resolves to `fail`, emits the
+   * declared `fail` handle, `findFailureEdge` finds nothing (the node never
+   * rendered the handle, so no edge can exist) and the engine throws — the
+   * same fatal outcome, now over a vocabulary an author can actually wire.
+   *
+   * The `'fail'` literal stays inline in every opted-in processor rather than
+   * moving to a shared helper: the builder↔engine parity reader
+   * (`apps/web/.../parity/engine-write-scrape.ts`) extracts emitted handles by
+   * reading each processor FILE, so a handle emitted from a util would drop out
+   * of the contract it is supposed to be pinned by.
+   */
+  private failureResult(
+    node: WorkflowNode,
+    output: ExtractionOutput,
+    error?: string
+  ): Partial<NodeExecutionResult> {
+    const strategy = normalizeErrorStrategy(
+      (node.data as { error_strategy?: unknown }).error_strategy
+    )
+    if (strategy === ErrorStrategy.continue) {
+      return { status: NodeRunningStatus.Succeeded, output, outputHandle: 'source' }
+    }
+    return { status: NodeRunningStatus.Failed, error, output, outputHandle: 'fail' }
   }
 
   /**

--- a/packages/lib/src/workflow-engine/nodes/dataset/knowledge-retrieval.ts
+++ b/packages/lib/src/workflow-engine/nodes/dataset/knowledge-retrieval.ts
@@ -7,6 +7,7 @@ import type { KnowledgeTarget } from '../../../datasets/resolve-knowledge-target
 import { resolveKnowledgeDatasetIds } from '../../../datasets/resolve-knowledge-targets'
 import { SearchService } from '../../../datasets/services/search.service'
 import type { SearchQuery, SearchResult, SearchType } from '../../../datasets/types/search.types'
+import { ErrorStrategy, normalizeErrorStrategy } from '../../catalog/error-handling'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type {
   NodeExecutionResult,
@@ -667,13 +668,39 @@ export class KnowledgeRetrievalProcessor extends BaseNodeProcessor {
       }
       this.storeOutputVariables(node.nodeId, errorOutput, contextManager)
 
-      return {
-        status: NodeRunningStatus.Failed,
-        error: errorMessage,
-        output: errorOutput,
-        outputHandle: 'error',
-      }
+      return this.failureResult(node, errorOutput, errorMessage)
     }
+  }
+
+  /**
+   * Apply the node's failure policy (`catalog/error-handling.ts`).
+   *
+   * Replaces the `outputHandle: 'error'` this used to emit — a handle no
+   * manifest declared, no `node.tsx` rendered and no edge could ever address,
+   * so the run died anyway (plan 21 §14.2). Behaviour is preserved exactly for
+   * a node with no stored `error_strategy`: it resolves to `fail`, emits the
+   * declared `fail` handle, `findFailureEdge` finds nothing (the node never
+   * rendered the handle, so no edge can exist) and the engine throws — the
+   * same fatal outcome, now over a vocabulary an author can actually wire.
+   *
+   * The `'fail'` literal stays inline in every opted-in processor rather than
+   * moving to a shared helper: the builder↔engine parity reader
+   * (`apps/web/.../parity/engine-write-scrape.ts`) extracts emitted handles by
+   * reading each processor FILE, so a handle emitted from a util would drop out
+   * of the contract it is supposed to be pinned by.
+   */
+  private failureResult(
+    node: WorkflowNode,
+    output: KnowledgeRetrievalOutput,
+    error: string
+  ): Partial<NodeExecutionResult> {
+    const strategy = normalizeErrorStrategy(
+      (node.data as { error_strategy?: unknown }).error_strategy
+    )
+    if (strategy === ErrorStrategy.continue) {
+      return { status: NodeRunningStatus.Succeeded, output, outputHandle: 'source' }
+    }
+    return { status: NodeRunningStatus.Failed, error, output, outputHandle: 'fail' }
   }
 
   /**

--- a/packages/lib/src/workflow-engine/nodes/transform-nodes/__tests__/list-processor.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/transform-nodes/__tests__/list-processor.test.ts
@@ -1190,7 +1190,7 @@ describe('ListProcessor - the operation surface is exactly what the builder offe
 
     expect(result.status).toBe(NodeRunningStatus.Failed)
     expect(result.error).toContain(`Unknown operation: ${operation}`)
-    expect(result.outputHandle).toBe('error')
+    expect(result.outputHandle).toBe('fail')
   })
 
   it('no longer treats findConfig as a source of required variables', async () => {
@@ -1233,5 +1233,33 @@ describe('ListProcessor - the operation surface is exactly what the builder offe
       createMockListNode('unique', { uniqueConfig: { by: 'field' } })
     )
     expect(invalid.errors).toContain('Unique field is required when deduplicating by field')
+  })
+})
+
+/**
+ * The step-4 acceptance criterion (plan 21, PR B). `list` used to return
+ * `outputHandle: 'error'` on failure — a handle no manifest declared and no
+ * canvas could wire, so the run died. A `list` node with no stored
+ * `error_strategy` (every row that predates the opt-in) must still die.
+ */
+describe('ListProcessor - failure policy', () => {
+  it('a node with no stored error_strategy fails onto the declared `fail` handle', async () => {
+    // `fail` resolves from the catalog-wide default. The node never rendered
+    // the handle, so no edge can address it, `findFailureEdge` finds nothing
+    // and `workflow-engine.ts` throws — the pre-opt-in outcome exactly.
+    const { result } = await runOperation('nope', {}, [{ id: 'a' }])
+    expect(result.status).toBe(NodeRunningStatus.Failed)
+    expect(result.outputHandle).toBe('fail')
+  })
+
+  it('`continue` succeeds on `source` with a null result instead', async () => {
+    const { result, variable } = await runOperation('nope', { error_strategy: 'continue' }, [
+      { id: 'a' },
+    ])
+    expect(result.status).toBe(NodeRunningStatus.Succeeded)
+    expect(result.outputHandle).toBe('source')
+    // `result` is published so `{{list_1.result}}` still resolves downstream
+    // rather than dangling; it is the only variable this node advertises.
+    expect(await variable('result')).toBeNull()
   })
 })

--- a/packages/lib/src/workflow-engine/nodes/transform-nodes/format-processor.ts
+++ b/packages/lib/src/workflow-engine/nodes/transform-nodes/format-processor.ts
@@ -423,10 +423,15 @@ export class FormatProcessor extends BaseNodeProcessor {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error'
       contextManager.log('ERROR', node.name, `Format operation failed: ${errorMessage}`)
+      // No `outputHandle` on failure. `format` deliberately does NOT opt into a
+      // failure policy (plan 21 §16.3): a format failure IS a config bug, and
+      // routing around it hides the fix. It used to emit `'error'`, a handle no
+      // manifest declared and no canvas could wire — inert, but it read like a
+      // feature (§14.2). Omitting the handle is the honest form of the same
+      // fatal outcome: `findFailureEdge` skips the lookup and the engine throws.
       return {
         status: NodeRunningStatus.Failed,
         error: errorMessage,
-        outputHandle: 'error',
       }
     }
   }

--- a/packages/lib/src/workflow-engine/nodes/transform-nodes/list-processor.ts
+++ b/packages/lib/src/workflow-engine/nodes/transform-nodes/list-processor.ts
@@ -10,6 +10,7 @@ import {
 import { getCachedResourceFields } from '../../../cache'
 import { evaluateOperator, isKnownOperator } from '../../../conditions/evaluate-operator'
 import type { ResourceField } from '../../../resources/registry/field-types'
+import { ErrorStrategy, normalizeErrorStrategy } from '../../catalog/error-handling'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type { NodeExecutionResult, ValidationResult, WorkflowNode } from '../../core/types'
 import { NodeRunningStatus, WorkflowNodeType } from '../../core/types'
@@ -175,10 +176,34 @@ export class ListProcessor extends BaseNodeProcessor {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error'
       contextManager.log('ERROR', node.name, `List operation failed: ${errorMessage}`)
 
+      // Apply the node's failure policy (`catalog/error-handling.ts`). This
+      // replaces the `outputHandle: 'error'` it used to emit — a handle no
+      // manifest declared, no `node.tsx` rendered and no edge could address, so
+      // the run died anyway (plan 21 §14.2). Behaviour is preserved exactly for
+      // a node with no stored `error_strategy`: it resolves to `fail`, and
+      // `findFailureEdge` still finds nothing to route to.
+      //
+      // The `'fail'` literal stays inline here rather than in a shared helper:
+      // the builder↔engine parity reader extracts emitted handles per processor
+      // FILE, so a handle emitted from a util would drop out of the contract.
+      const strategy = normalizeErrorStrategy(
+        (node.data as { error_strategy?: unknown }).error_strategy
+      )
+      if (strategy === ErrorStrategy.continue) {
+        // `result` is the only variable this node advertises, so it is the only
+        // one the continue arm may write — publishing an `error` variable here
+        // would advertise an address the builder's picker never offers.
+        contextManager.setNodeVariable(node.nodeId, 'result', null)
+        return {
+          status: NodeRunningStatus.Succeeded,
+          output: { result: null, error: errorMessage },
+          outputHandle: 'source',
+        }
+      }
       return {
         status: NodeRunningStatus.Failed,
         error: errorMessage,
-        outputHandle: 'error', // Error output handle
+        outputHandle: 'fail',
       }
     }
   }

--- a/packages/lib/src/workflows/graph-edit/__tests__/branch-authoring.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/branch-authoring.test.ts
@@ -419,6 +419,38 @@ describe('T5 — an unwired branch is reported', () => {
     expect(issues.map((i) => i.message).join()).not.toContain('ELSE')
   })
 
+  it('stays silent on an unwired `fail` branch, for the ELSE reason', () => {
+    // An unwired fail branch means "let it fail" — the legitimate default
+    // behaviour of every node with no failure policy at all.
+    //
+    // #1766 made http's `defaultData()` write `error_strategy: 'fail'`, so from
+    // that commit every newly created http node rendered a fail branch and
+    // immediately warned about its own defaults. Pure noise, and it fired on
+    // the most-used action node in the palette.
+    const httpId = 'http-aaaaaaaaaaaaaaaaaaaaaaa'
+    const graph: DraftGraph = {
+      nodes: [
+        {
+          id: httpId,
+          type: 'standard',
+          position: { x: 100, y: 200 },
+          width: 244,
+          height: 100,
+          data: {
+            id: httpId,
+            type: 'http',
+            title: 'Call API',
+            method: 'get',
+            url: 'https://example.com',
+            error_strategy: 'fail',
+          },
+        } as GraphNode,
+      ],
+      edges: [],
+    }
+    expect(validateBranchWiring(graph, coreLookup)).toEqual([])
+  })
+
   it('says nothing once every branch is wired', () => {
     const graph: DraftGraph = {
       nodes: [ifElseNode([carrierCase('carrier-fedex', 'fedex')]), carrierNode()],

--- a/packages/lib/src/workflows/graph-edit/validate.ts
+++ b/packages/lib/src/workflows/graph-edit/validate.ts
@@ -475,7 +475,7 @@ function describeBranchRef(branch: { id: string; name: string }): string {
  * gate (plan 21 §7.6). This is that backstop: it surfaces on every mutation
  * result and in `validate_workflow`, before the agent writes its summary.
  *
- * Two deliberate exclusions:
+ * Three deliberate exclusions:
  *  - **Fallback branches** (`false`/`default`/`unmatched`) are silent. Leaving
  *    "nothing matched" unwired is the normal shape of an if-else, not an
  *    oversight, and warning on it would fire on nearly every branching node in
@@ -483,6 +483,15 @@ function describeBranchRef(branch: { id: string; name: string }): string {
  *  - **The plain `source` handle** is silent for the same reason: a terminal
  *    node is a legitimate end of a graph, and `source` is an output, not a
  *    branch anybody chose.
+ *  - **`fail` branches** (`kind === 'fail'`) are silent, for exactly the ELSE
+ *    reason. An unwired fail branch means *"let it fail"* — the run dies, which
+ *    is the legitimate default behaviour of every node that has no failure
+ *    policy at all. #1766 made http's `defaultData()` write
+ *    `error_strategy: 'fail'`, so from that commit every newly created http
+ *    node rendered a fail branch and immediately warned "has nothing wired" on
+ *    its own defaults. That was pure noise. Keyed on `kind`, not on the id
+ *    string, because the id is a per-manifest choice and the kind is the
+ *    contract (`NodeBranch.kind`, `catalog/types.ts`).
  *
  * Severity is `warning` — a half-built branch is a legitimate intermediate
  * state and blocking it would break incremental building. The one `error` is a
@@ -503,6 +512,7 @@ export function validateBranchWiring(graph: DraftGraph, lookup: ManifestLookup):
     const ref = formatNodeRef(graph.nodes, node.id)
 
     for (const branch of branches) {
+      if (branch.kind === 'fail') continue
       if (FALLBACK_BRANCH_IDS.has(branch.id) || branch.id === 'source') continue
       const wired = graph.edges.some(
         (edge) => edge.source === node.id && edgeSourceHandle(edge) === branch.id


### PR DESCRIPTION
Follows #1766, which made failure policy a manifest declaration (`errorHandling: { strategies, defaultStrategy }`). That PR declared it on `http` and `crud` only. This one opts more types in — and retires the undeclared `error` handle that had been standing in for a real failure policy.

## Why

Six processors returned `status: Failed` with `outputHandle: 'error'` — a handle **no manifest declared, no `node.tsx` rendered, and no builder arm registered**. It was inert: `findFailureEdge` could never match it, so the run died anyway. But the code was written *as if* those types could route their own failures, and they could not: an agent asking to wire it got *"Node X has no branches"*, which is accurate about the manifest and wrong about the node.

`ai` was worse — it never returned a handle at all, it **threw**. That's why it never showed up in the original divergence hunt.

## What changed

**Opt-ins.** `document-extractor`, `chunker`, `dataset`, `knowledge-retrieval`, `list` → `fail`/`continue`. `ai` → `fail`/`continue`/`default`. **`format` stays out on purpose**: a format failure is a config bug, and routing around it hides the fix.

Opting a type in was not a one-line declaration — none of these had an `error_strategy` key at all. Each gained: the key in its zod schema, a value in `defaultData()`, `connection.branches` + `errorHandling` on the manifest, an `agent.usage` sentence, a fail lane on the canvas, a panel control, and **a processor that actually branches on the strategy**.

**`'error'` is gone.** All six emit `'fail'` (or succeed on `source`); `format-processor` and `execute` emit no handle on failure. The handle also leaves `ERROR_LIKE_HANDLES` — that set is keyed on what processors *emit*, and nothing emits it any more. `'onError'` stays: nothing emits it either, but it remains a live *stored-edge* vocabulary that `findFailureEdge` honours. The six `KNOWN_BROKEN_OUTPUT_HANDLES` entries are **deleted, not silenced**.

**Shared UI.** New `nodes/shared/error-handling-section.tsx` (driven by `manifest.errorHandling.strategies`, renders `null` for a type that declares none), `node-fail-branch.tsx` (the "On Failure" lane, previously duplicated byte-for-byte in http and crud), and `error-default-values-editor.tsx` (crud's editor lifted verbatim; crud's own file is now a thin typed wrapper). **No defaults editor was redesigned** — that belongs to a separate plan, which now finds one implementation instead of two.

**An unwired `fail` branch no longer warns.** #1765 added an unwired-branch warning and treated `fail` as warnable; #1766 then made http default to `fail`. Net effect on main today: **every newly created http node warns about its own defaults.** An unwired fail branch means *"let it fail"* — the same legitimate choice as an unwired ELSE. Keyed on `kind`, not on the id string.

**Cleanups.** Dead `CrudErrorStrategy` deleted from `constants/nodes/crud.ts` along with the now-unused array behind it. http's `error_strategy: z.string()` narrowed to the shared schema.

## Behaviour preservation — the acceptance criterion

An **existing persisted node** of a newly opted-in type, with no stored `error_strategy`, must fail exactly as it does today. Proven per type, in both halves:

- **canvas** — a config with no key resolves to `[source]` only and `hasFailBranch` is false, so no handle renders and no edge can exist (`catalog/error-handling.test.ts`)
- **engine** — driving the real processors: four in `nodes/dataset/dataset-node-config.test.ts`, `list` in `list-processor.test.ts`, `ai` in `ai-v2.test.ts`

`defaultData()` sets `error_strategy: 'fail'` on all six. The effective strategy of an unset node is already `fail`, so the processor emits `'fail'` on failure whether or not the key is stored — rendering the handle is the node telling the truth about the handle it emits, and *not* rendering it would recreate exactly the undeclared-handle state this PR exists to remove. It also gives the whole catalog one rule instead of "the two original types persist it, the six new ones don't".

## Tests

| | before | after |
|---|---|---|
| `packages/lib` (`workflows` + `workflow-engine` + `ai/kopilot`) | 164 files / 2371 | **164 files / 2412, 0 failed** |
| `apps/web` (`components/workflow`) | 25 files / 169 | **25 files / 181, 0 failed** |

Typecheck: lib 29 errors (baseline 29, all pre-existing in `scripts/*`). Web has 10 pre-existing errors in `kbar/command-palette.tsx` and `human/panel.tsx` — untouched files, clean `git diff`, present before the first edit here.

### Existing expectations changed

The handle rename accounts for most: `list-processor.test.ts` (`'error'` → `'fail'`), and three tests whose *negative example* was `ai` — now opted in — repointed at `format` or `answer` (`error-handling.test.ts`, `workflow-graph-builder.test.ts`, `calculate-target-branches.test.ts`).

One needs justifying: `builder-engine-parity.test.ts`'s `'collects both arms of a conditional emission'` asserted `document-extractor` emits `['error','source']` from a `success ? 'source' : 'error'` ternary. That ternary no longer exists. The test is about the **reader's** ability to see both arms of a conditional, so the specimen was repointed at `crud` — the capability under test is unchanged, only the example moved.

## Judgement calls worth a reviewer's eye

- **`list` is the weakest opt-in.** Its failure surface is mostly `Unknown operation` and thrown config errors — a config bug, the same reason `format` was excluded. The case that isn't: a `pluck`/`filter` over data from an upstream HTTP or retrieval step can fail on the *data*, which is the same "keep going" need as the RAG cluster. Its `continue` arm is also the thinnest — the other five build a `{ success: false, error }` output, whereas `list` publishes `result: null`.
- **`ai`'s `fail` is a re-throw, not a `Failed` result**, because throwing is what it has always done — that is the shape that preserves its behaviour.
- **The sibling AI types are deliberately NOT included.** `text-classifier` is the obvious next one (it shares `BaseAiNodeProcessor` with `ai` and `default` is arguably more useful there), but catching in the base class would have opted three types in on one undiscussed line, so the catch is in `AIProcessorV2.executeNode`. `answer` and `information-extractor` extend `BaseNodeProcessor` and would each need their own arm.

## Not in scope

Branch-scoped outputs (a node downstream of a `fail` branch still sees the producer's success outputs), the defaults-editor redesign, the `default_value`/`default_values` key rename, and the open question about http nodes already persisted with `'default'` + an empty list.