### PR TITLE
fix(workflow): let the edge be the only record of a manual trigger's inputs

### DIFF
--- a/apps/web/src/components/workflow/hooks/use-node-interactions.ts
+++ b/apps/web/src/components/workflow/hooks/use-node-interactions.ts
@@ -1049,20 +1049,13 @@ export const useNodesInteractions = () => {
       // newEdge.zIndex = calculateEdgeZIndex(newEdge as FlowEdge, nodes as FlowNode[])
 
       // 7. Update connected handles metadata
-      let updatedNodes = updateNodeConnectionMetadata(nodes, newEdge)
-
-      // NEW: Handle input connection metadata
-      if (targetHandle === 'input') {
-        // Update target node's input connections
-        updatedNodes = produce(updatedNodes, (draft) => {
-          const targetDraft = draft.find((n) => n.id === target)
-          if (!targetDraft) return
-          const inputNodes: string[] = targetDraft.data.inputNodes ?? []
-          if (!inputNodes.includes(source)) {
-            targetDraft.data.inputNodes = [...inputNodes, source]
-          }
-        })
-      }
+      //
+      // The `input`-handle wire used to ALSO be appended to the target's
+      // `data.inputNodes`. It no longer is: the edge is the only record of an
+      // input wiring. That list was append-only — the manual panel's Add
+      // button never wrote it and nothing pruned it on delete or disconnect —
+      // so it drifted, and nothing read it.
+      const updatedNodes = updateNodeConnectionMetadata(nodes, newEdge)
 
       // 8. Update state
       setNodes(updatedNodes)

--- a/packages/lib/src/workflow-engine/catalog/nodes/manual.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/manual.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/workflow-engine/catalog/nodes/manual.ts
 
-import { z } from 'zod'
+import type { z } from 'zod'
 import { BaseType, WorkflowTriggerType } from '../../core/types'
 import type { UnifiedVariable } from '../../types/unified-variable'
 import { type BaseNodeData, baseNodeDataSchema } from '../node-base'
@@ -8,18 +8,21 @@ import { NodeCategory, type NodeManifest, type NodeValidationResult } from '../t
 import { createUnifiedOutputVariable } from '../variable-conversion'
 
 /**
- * Manual trigger node data interface
+ * Manual trigger node data interface.
+ *
+ * No `inputNodes` list: what a manual trigger collects is the set of
+ * `form-input` nodes wired into its `input` handle, and the EDGE is the only
+ * record of that. A mirrored id list on the node was append-only canvas
+ * metadata — maintained by one of the two ways to author the wire, pruned by
+ * neither — so it drifted from the edges in 7 of the 8 dev workflows that had
+ * an input edge, and nothing read it.
  */
-export interface ManualNodeData extends BaseNodeData {
-  inputNodes?: string[] // Array of connected input node IDs
-}
+export type ManualNodeData = BaseNodeData
 
 /**
  * Zod schema for manual trigger node data
  */
-export const manualNodeDataSchema = baseNodeDataSchema.extend({
-  inputNodes: z.array(z.string()).optional(),
-})
+export const manualNodeDataSchema = baseNodeDataSchema
 
 /**
  * Validate manual trigger node data
@@ -100,7 +103,6 @@ export const manualManifest: NodeManifest<ManualNodeData> = {
   defaultData: () => ({
     title: 'Manual Trigger',
     desc: 'Manually trigger workflow with user inputs',
-    inputNodes: [],
   }),
   configSchema: manualNodeDataSchema as unknown as z.ZodType<ManualNodeData>,
   validate: validateManualData,
@@ -112,8 +114,9 @@ export const manualManifest: NodeManifest<ManualNodeData> = {
   agent: {
     authorable: true,
     usage:
-      'The workflow starts when a user runs it by hand. `inputNodes` lists connected ' +
-      'form/number/file input node ids; leave empty unless input nodes exist.',
-    examples: [{ description: 'Plain manual trigger', config: { inputNodes: [] } }],
+      'The workflow starts when a user runs it by hand. It takes no config. To collect ' +
+      'values from the user, add `form-input` nodes and connect them to this node — the ' +
+      'connection IS the declaration, and their values arrive under `inputs`.',
+    examples: [{ description: 'Plain manual trigger', config: {} }],
   },
 }

--- a/packages/lib/src/workflows/graph-edit/__tests__/input-wiring.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/input-wiring.test.ts
@@ -74,15 +74,26 @@ const FORM_ID = 'form-input-aaaaaaaaaaaaaaa'
 const WAIT_ID = 'wait-aaaaaaaaaaaaaaaaaaaaa'
 const SECOND_FORM_ID = 'form-input-bbbbbbbbbbbbbbb'
 
-function manualNode(inputNodes: string[] = []): GraphNode {
+function manualNode(): GraphNode {
   return {
     id: MANUAL_ID,
     type: 'standard',
     position: { x: 100, y: 300 },
     width: 244,
     height: 100,
-    data: { id: MANUAL_ID, type: 'manual', title: 'Manual Trigger', inputNodes },
+    data: { id: MANUAL_ID, type: 'manual', title: 'Manual Trigger' },
   }
+}
+
+/**
+ * The ids wired into the trigger's `input` handle, in edge order — the ONLY
+ * record of what a manual trigger collects. There is no mirrored
+ * `data.inputNodes` list any more (see `catalog/nodes/manual.ts`).
+ */
+function wiredSources(graph: DraftGraph): string[] {
+  return graph.edges
+    .filter((e) => e.target === MANUAL_ID && e.targetHandle === 'input')
+    .map((e) => e.source)
 }
 
 /** A form-input node — `NodeCategory.INPUT` in the catalog since PR 2. */
@@ -283,15 +294,11 @@ describe('edge handle resolution (§4a)', () => {
     const wired = persisted.edges.find((e) => e.source === SECOND_FORM_ID)
     expect(wired?.sourceHandle).toBe('input-output')
     expect(wired?.targetHandle).toBe('input')
-    // Canvas parity: the trigger's connected-input list gains the node id.
-    expect(persisted.nodes.find((n) => n.id === MANUAL_ID)?.data?.inputNodes).toEqual([
-      SECOND_FORM_ID,
-    ])
   })
 
-  it('a second form-input appends to inputNodes rather than replacing the first', async () => {
+  it('a second form-input is wired alongside the first, not in place of it', async () => {
     const graph: DraftGraph = {
-      nodes: [formInputNode(), secondFormInputNode(), manualNode([FORM_ID]), waitNode()],
+      nodes: [formInputNode(), secondFormInputNode(), manualNode(), waitNode()],
       edges: [inputEdge(FORM_ID, MANUAL_ID), edge(MANUAL_ID, 'source', WAIT_ID)],
     }
     const result = await connectNodes(makeDb(graph), {
@@ -303,11 +310,9 @@ describe('edge handle resolution (§4a)', () => {
     expect(result.isOk()).toBe(true)
     expect(result._unsafeUnwrap().applied).toBe(true)
 
+    // Both wires exist: the edges ARE the trigger's input list.
     const persisted = persistedGraph()
-    expect(persisted.nodes.find((n) => n.id === MANUAL_ID)?.data?.inputNodes).toEqual([
-      FORM_ID,
-      SECOND_FORM_ID,
-    ])
+    expect(wiredSources(persisted)).toEqual([FORM_ID, SECOND_FORM_ID])
   })
 
   /**
@@ -517,8 +522,10 @@ describe('addNode({ inputFor }) (§4b)', () => {
     expect(wired?.sourceHandle).toBe('input-output')
     expect(wired?.targetHandle).toBe('input')
 
-    // Canvas parity, and the graph the writer produced is one the validator accepts.
-    expect(persisted.nodes.find((n) => n.id === MANUAL_ID)?.data?.inputNodes).toEqual([created.id])
+    // The wire is the whole record: the trigger gains no config the model
+    // could later contradict. And the graph the writer produced is one the
+    // validator accepts.
+    expect(persisted.nodes.find((n) => n.id === MANUAL_ID)?.data).not.toHaveProperty('inputNodes')
     expect(errors(validateGraphStructure(persisted, { lookup: coreLookup }))).toEqual([])
   })
 
@@ -559,10 +566,7 @@ describe('addNode({ inputFor }) (§4b)', () => {
     expect(subjectPosition).not.toEqual(bodyPosition)
     expect(subjectPosition.localeCompare(bodyPosition)).toBeLessThan(0)
 
-    expect(afterSecond.nodes.find((n) => n.id === MANUAL_ID)?.data?.inputNodes).toEqual([
-      subject.id,
-      body.id,
-    ])
+    expect(wiredSources(afterSecond)).toEqual([subject.id, body.id])
     expect(errors(validateGraphStructure(afterSecond, { lookup: coreLookup }))).toEqual([])
   })
 
@@ -612,7 +616,7 @@ describe('addNode({ inputFor }) (§4b)', () => {
     // the upstream ref check one step later — with a message about references
     // that never names the real mistake. Refuse it where the fix can be said.
     const graph: DraftGraph = {
-      nodes: [formInputNode(), manualNode([FORM_ID]), waitNode()],
+      nodes: [formInputNode(), manualNode(), waitNode()],
       edges: [
         edge(FORM_ID, 'input-output', MANUAL_ID, 'input'),
         edge(MANUAL_ID, 'source', WAIT_ID),
@@ -638,7 +642,7 @@ describe('addNode({ inputFor }) (§4b)', () => {
     // The other half: the guard must reject the field, never the trigger that
     // owns it, or it would make a form-driven workflow unauthorable.
     const graph: DraftGraph = {
-      nodes: [formInputNode(), manualNode([FORM_ID])],
+      nodes: [formInputNode(), manualNode()],
       edges: [edge(FORM_ID, 'input-output', MANUAL_ID, 'input')],
     }
     const result = await addNode(makeDb(graph), {
@@ -668,7 +672,7 @@ describe('addNode({ inputFor }) (§4b)', () => {
 describe('runNode refusal for canRunSingle: false (§4)', () => {
   it('refuses to run a form-input node instead of handing it to the engine', async () => {
     const graph: DraftGraph = {
-      nodes: [formInputNode(), manualNode([FORM_ID]), waitNode()],
+      nodes: [formInputNode(), manualNode(), waitNode()],
       edges: [inputEdge(FORM_ID, MANUAL_ID), edge(MANUAL_ID, 'source', WAIT_ID)],
     }
     const result = await runNode(makeDb(graph), {
@@ -683,10 +687,16 @@ describe('runNode refusal for canRunSingle: false (§4)', () => {
   })
 })
 
-describe('inputNodes maintenance (§5)', () => {
-  it('deleteNodes on a form-input prunes it from the trigger inputNodes list', async () => {
+/**
+ * The edge is the whole contract. `ManualNodeData.inputNodes` used to mirror
+ * it and drifted in 7 of the 8 dev workflows that had an input edge — one of
+ * the two ways to author the wire maintained it, neither delete nor disconnect
+ * pruned it, and nothing read it. These tests pin that no writer resurrects it.
+ */
+describe('input wiring lives on the edge alone', () => {
+  it('deleteNodes on a form-input takes its wiring with it and writes no id list', async () => {
     const graph: DraftGraph = {
-      nodes: [formInputNode(), manualNode([FORM_ID, 'stale-input-node']), waitNode()],
+      nodes: [formInputNode(), manualNode(), waitNode()],
       edges: [inputEdge(FORM_ID, MANUAL_ID), edge(MANUAL_ID, 'source', WAIT_ID)],
     }
     const result = await deleteNodes(makeDb(graph), {
@@ -699,15 +709,13 @@ describe('inputNodes maintenance (§5)', () => {
 
     const persisted = persistedGraph()
     expect(persisted.nodes.map((n) => n.id)).toEqual([MANUAL_ID, WAIT_ID])
-    // Only the deleted id is pruned — an unrelated stale id is left alone.
-    expect(persisted.nodes.find((n) => n.id === MANUAL_ID)?.data?.inputNodes).toEqual([
-      'stale-input-node',
-    ])
+    expect(wiredSources(persisted)).toEqual([])
+    expect(persisted.nodes.find((n) => n.id === MANUAL_ID)?.data).not.toHaveProperty('inputNodes')
   })
 
-  it('disconnectNodes prunes the unwired input from the trigger inputNodes list', async () => {
+  it('disconnectNodes drops the wiring and writes no id list', async () => {
     const graph: DraftGraph = {
-      nodes: [formInputNode(), manualNode([FORM_ID]), waitNode()],
+      nodes: [formInputNode(), manualNode(), waitNode()],
       edges: [inputEdge(FORM_ID, MANUAL_ID), edge(MANUAL_ID, 'source', WAIT_ID)],
     }
     const result = await disconnectNodes(makeDb(graph), {
@@ -720,12 +728,16 @@ describe('inputNodes maintenance (§5)', () => {
 
     const persisted = persistedGraph()
     expect(persisted.edges.some((e) => e.source === FORM_ID)).toBe(false)
-    expect(persisted.nodes.find((n) => n.id === MANUAL_ID)?.data?.inputNodes).toEqual([])
+    expect(persisted.nodes.find((n) => n.id === MANUAL_ID)?.data).not.toHaveProperty('inputNodes')
+  })
+
+  it('defaultData mints no id list', () => {
+    expect(manualManifest.defaultData?.()).not.toHaveProperty('inputNodes')
   })
 
   it('manual advertises `inputs` with no connected inputs — the engine always writes it', () => {
     const variables = manualManifest.resolveOutputs?.(
-      { id: MANUAL_ID, type: 'manual', title: 'Manual Trigger', selected: false, inputNodes: [] },
+      { id: MANUAL_ID, type: 'manual', title: 'Manual Trigger', selected: false },
       MANUAL_ID,
       staticOutputContext
     )

--- a/packages/lib/src/workflows/graph-edit/ops.ts
+++ b/packages/lib/src/workflows/graph-edit/ops.ts
@@ -520,32 +520,10 @@ function resolveEdgeHandles(
 }
 
 /**
- * Canvas parity for `ManualNodeData.inputNodes` — the connected-input id list
- * the canvas maintains (`use-node-interactions.ts`) on any node whose
- * manifest sets `acceptsInputNodes`. Pure metadata: no output variable is
- * gated on it, so a drifted list is cosmetic, not a contract break.
- */
-function updateInputNodes(
-  nodes: GraphNode[],
-  update: (current: string[]) => string[],
-  opts: { lookup: ManifestLookup; onlyNodeId?: string }
-): GraphNode[] {
-  return nodes.map((node) => {
-    if (opts.onlyNodeId !== undefined && node.id !== opts.onlyNodeId) return node
-    if (opts.lookup(nodeType(node))?.connection.acceptsInputNodes !== true) return node
-    const current = Array.isArray(node.data?.inputNodes)
-      ? (node.data.inputNodes as unknown[]).filter((id): id is string => typeof id === 'string')
-      : []
-    const next = update(current)
-    if (next.length === current.length && next.every((id, i) => id === current[i])) return node
-    return { ...node, data: { ...node.data, inputNodes: next } }
-  })
-}
-
-/**
  * The nodes already wired into `targetId` on the input handle, in graph order.
- * Read off the EDGES rather than `data.inputNodes` — the edge is the contract
- * the validator and the engine both judge, the list is cosmetic parity.
+ * The EDGE is the whole contract — the one the validator and the engine both
+ * judge, and since the trigger no longer mirrors it into a `data.inputNodes`
+ * list, the only one there is.
  */
 function wiredInputNodes(nodes: GraphNode[], edges: GraphEdge[], targetId: string): GraphNode[] {
   const sources = new Set(
@@ -905,17 +883,9 @@ export async function addNode(
       newEdges.push(makeEdge(parent.id, LOOP_HANDLES.LOOP_START, nodeId, 'target'))
     }
 
-    let nextNodes = nodes.map((n) =>
+    const nextNodes = nodes.map((n) =>
       resizedParent && n.id === resizedParent.id ? resizedParent : n
     )
-    if (inputTarget) {
-      // Canvas parity: the target lists the input nodes wired into it.
-      nextNodes = updateInputNodes(
-        nextNodes as GraphNode[],
-        (current) => (current.includes(nodeId) ? current : [...current, nodeId]),
-        { lookup: ctx.lookup, onlyNodeId: inputTarget.id }
-      )
-    }
     return ok({
       graph: {
         nodes: [...nextNodes, newNode],
@@ -1157,11 +1127,7 @@ export async function deleteNodes(
 
     return ok({
       graph: {
-        nodes: updateInputNodes(
-          nodes.filter((n) => !toDelete.has(n.id)) as GraphNode[],
-          (current) => current.filter((id) => !toDelete.has(id)),
-          { lookup: ctx.lookup }
-        ),
+        nodes: nodes.filter((n) => !toDelete.has(n.id)),
         edges: [
           ...edges.filter((e) => !toDelete.has(e.source) && !toDelete.has(e.target)),
           ...bridged,
@@ -1224,18 +1190,8 @@ export async function connectNodes(
       )
     }
 
-    // Canvas parity: wiring an input node appends it to the target's list.
-    const nextNodes =
-      !isLoopBack && handles.targetHandle === INPUT_WIRING_HANDLES.targetHandle
-        ? updateInputNodes(
-            nodes as GraphNode[],
-            (current) => (current.includes(edge.source) ? current : [...current, edge.source]),
-            { lookup: ctx.lookup, onlyNodeId: targetNode.id }
-          )
-        : nodes
-
     return ok({
-      graph: { ...ctx.graph, nodes: nextNodes, edges: [...edges, edge] },
+      graph: { ...ctx.graph, nodes, edges: [...edges, edge] },
       touchedNodeId: targetNode.id,
       normalizeIssues: [],
     })
@@ -1271,23 +1227,8 @@ export async function disconnectNodes(
       )
     }
 
-    // Canvas parity: an input wiring that goes also leaves the target's list.
-    const droppedInputWiring = edges.some(
-      (e) =>
-        e.source === sourceId &&
-        e.target === targetId &&
-        (e.targetHandle ?? 'target') === INPUT_WIRING_HANDLES.targetHandle
-    )
-    const nextNodes = droppedInputWiring
-      ? updateInputNodes(
-          nodes as GraphNode[],
-          (current) => current.filter((id) => id !== sourceId),
-          { lookup: ctx.lookup, onlyNodeId: targetId }
-        )
-      : nodes
-
     return ok({
-      graph: { ...ctx.graph, nodes: nextNodes, edges: remaining },
+      graph: { ...ctx.graph, nodes, edges: remaining },
       normalizeIssues: [],
     })
   })
@@ -1538,17 +1479,6 @@ export async function replaceGraph(
             handles.targetHandle
           )
       if (!edges.some((e) => e.id === edge.id)) edges.push(edge)
-      // Canvas parity: an input wiring is also listed on the target node.
-      // `built` is mutated in place through the layout passes, so this writes
-      // straight onto the node object rather than rebuilding the array.
-      if (!isLoopBack && handles.targetHandle === INPUT_WIRING_HANDLES.targetHandle) {
-        const [updated] = updateInputNodes(
-          [targetNode],
-          (current) => (current.includes(edge.source) ? current : [...current, edge.source]),
-          { lookup: ctx.lookup }
-        )
-        if (updated) targetNode.data = updated.data
-      }
     }
 
     // Pass 4 — auto-layout: dagre for the top level (positions from centers,

--- a/packages/lib/src/workflows/graph-edit/read.ts
+++ b/packages/lib/src/workflows/graph-edit/read.ts
@@ -147,6 +147,12 @@ const NON_CONFIG_KEYS = new Set([
   'height',
   'variables',
   'outputVariables',
+  // Legacy only: the manual trigger's mirrored connected-input id list. No
+  // writer produces it any more (`catalog/nodes/manual.ts`) and it is gone from
+  // the schema, so `describe_node_type` no longer offers it — but stored rows
+  // still carry it, and echoing a list that drifted from the edges in 7 of 8
+  // workflows is exactly what made it worth deleting.
+  'inputNodes',
 ])
 
 /** Hash durable node data only; derived keys are regenerated and stripped on save. */


### PR DESCRIPTION
`ManualNodeData.inputNodes` mirrored the `input`-handle edges into an id list on the trigger node. It was append-only, and only one of the two ways to author the wire maintained it:

| how you wire a form-input to the trigger | edge | `inputNodes` |
|---|---|---|
| drag the wire onto the input handle | ✅ | appended |
| the manual panel's **Add** button (the normal route) | ✅ | untouched |

Nothing pruned it on delete or disconnect either. Across the dev DB it is wrong in **7 of the 8** workflows that have an input edge — always missing, never extra, the signature of an append-only writer with no maintenance — including two **published** versions.

## Nothing read it

Every surface that answers "what does this trigger collect?" reads the edges: the builder run panel, the public shared form, server-side submission validation, the engine, and `graph-edit`'s own `wiredInputNodes` — whose comment already said so. `manual.ts` advertises the `inputs` output variable unconditionally because gating it on this list broke in both directions (a stale id kept a variable advertised forever; an emptied list hid one that is always populated).

## What it cost

The model. `read.ts`'s `NON_CONFIG_KEYS` did not withhold it, so `describe_node_type` advertised it as writable and every node summary showed `inputNodes: []` on a trigger with a form visibly wired into it — while `agent.usage` told the model the field lists the connected input nodes. Kopilot was instructed to trust a field that is wrong 7 times out of 8.

That usage string also named `number-input` and `file-upload`, both **retired** in the catalog burn-down. `form-input` is the only `NodeCategory.INPUT` manifest left.

## The change

- `ManualNodeData` becomes a bare `type … = BaseNodeData`; `manualNodeDataSchema` is `baseNodeDataSchema` unextended.
- Field gone from `defaultData`, `agent.usage`, `examples`. The new usage text says the connection *is* the declaration.
- `updateInputNodes` and its five `ops.ts` call sites deleted; the canvas append in `use-node-interactions.ts` deleted.
- `acceptsInputNodes` **stays** — it is the capability `isInputNodePair` and `resolveEdgeHandles` read, and what keeps an app block off a trigger's `input` handle. `wiredInputNodes` stays; it was always the real contract.

## One thing deleting the writers does not fix

`buildNodeSummary` copies every `node.data` key not in `NON_CONFIG_KEYS`, so all 209 existing dev graphs would have gone on showing the stale list to the model — the exact cost this PR removes. `describe_node_type` fixes itself (it derives from `configSchema`); the summary does not. So `inputNodes` joins `NON_CONFIG_KEYS`.

Side effect, documented above that set: withheld keys are **durable**, because the patches path deletes only keys the summary showed. Legacy values are now invisible and inert; clearing them out of storage belongs to the graph-canonicalization work (`plans/kopilot/workflow/23` §2.1), not here.

## Tests

`input-wiring.test.ts`'s "inputNodes maintenance" block becomes "input wiring lives on the edge alone" — same four writers exercised (`addNode({inputFor})`, `connectNodes`, `disconnectNodes`, `deleteNodes`), asserting the wiring off the edges via a `wiredSources` helper and `not.toHaveProperty('inputNodes')` on the trigger, plus `defaultData` minting no list.

Green: `input-wiring.test.ts` (25), `src/workflows/graph-edit` (260), catalog + trigger-node + Kopilot workflow-builder suites, web parity suites and workflow hooks. `packages/lib` `tsc --noEmit` clean.
