### PR TITLE
fix(workflow): hydrate and dehydrate under one policy on both sides of the wire

### DIFF
--- a/apps/api/src/routes/workflows/public.ts
+++ b/apps/api/src/routes/workflows/public.ts
@@ -4,7 +4,7 @@
  * Public workflow routes (no authentication required)
  */
 
-import { hydrateGraph } from '@auxx/lib/workflow-engine/client'
+import { HYDRATION_OPTIONS, hydrateGraph } from '@auxx/lib/workflow-engine/client'
 import { getPublicWorkflowApp } from '@auxx/services/workflows'
 import { Hono } from 'hono'
 
@@ -100,7 +100,7 @@ publicWorkflows.get('/public/:id', async (c) => {
       // shape. `@auxx/services` is tier 2 and cannot import `@auxx/lib`, so the
       // hydration for this seam lives here at the app layer rather than in
       // `get-public-workflow-app.ts`.
-      graph: hydrateGraph(publishedWorkflow.graph as never),
+      graph: hydrateGraph(publishedWorkflow.graph as never, HYDRATION_OPTIONS),
       envVars: sanitizeEnvVarsForPublic(publishedWorkflow.envVars as EnvVar[] | null | undefined),
     },
   })

--- a/apps/api/src/routes/workflows/share/site.ts
+++ b/apps/api/src/routes/workflows/share/site.ts
@@ -4,7 +4,7 @@
  * Site info route for shared workflows
  */
 
-import { hydrateGraph } from '@auxx/lib/workflow-engine/client'
+import { HYDRATION_OPTIONS, hydrateGraph } from '@auxx/lib/workflow-engine/client'
 import { getSharedWorkflowByToken } from '@auxx/services/workflow-share'
 import { Hono } from 'hono'
 
@@ -76,7 +76,9 @@ siteRoute.get('/', async (c) => {
         // it: grey boxes, no handles) and the derived edge fields. `@auxx/services`
         // is tier 2 and cannot import `@auxx/lib`, so this seam hydrates at the
         // app layer. See plan 23 §4.2.
-        graph: workflow.graph ? hydrateGraph(workflow.graph as never) : workflow.graph,
+        graph: workflow.graph
+          ? hydrateGraph(workflow.graph as never, HYDRATION_OPTIONS)
+          : workflow.graph,
         icon: workflow.icon,
       },
     },

--- a/apps/web/src/components/workflow/providers/workflow-save-provider.tsx
+++ b/apps/web/src/components/workflow/providers/workflow-save-provider.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import {
+  DEHYDRATION_OPTIONS,
   dehydrateGraph,
   deriveTriggerColumns,
   stripDerivedKeys,
@@ -294,11 +295,20 @@ export function WorkflowSaveProvider({ children }: { children: React.ReactNode }
       // `graph` object, so posting the live camera would rewrite the authored
       // starting view on every save, and omitting the key would erase it.
       const authoredViewport = useWorkflowStore.getState().authoredViewport
-      const stored = dehydrateGraph({
-        nodes: cleanNodes,
-        edges: cleanEdges,
-        ...(authoredViewport ? { viewport: authoredViewport } : {}),
-      } as Parameters<typeof dehydrateGraph>[0])
+      // DEHYDRATION_OPTIONS is NOT optional here. Without it `skipDefaults`
+      // defaults to off, so the strip deletes every `node.data` key whose value
+      // equals its manifest default — while every server reader hydrates with
+      // `skipDefaults: true` and never puts it back. That silently amputates
+      // real config (`http.method`, `resource-trigger.operation`,
+      // `scheduled.config`, `wait.waitType`) on the first canvas save.
+      const stored = dehydrateGraph(
+        {
+          nodes: cleanNodes,
+          edges: cleanEdges,
+          ...(authoredViewport ? { viewport: authoredViewport } : {}),
+        } as Parameters<typeof dehydrateGraph>[0],
+        DEHYDRATION_OPTIONS
+      )
 
       payload.graph = stored
       payload.triggerType = triggerType

--- a/apps/web/src/components/workflow/store/workflow-history-provider.tsx
+++ b/apps/web/src/components/workflow/store/workflow-history-provider.tsx
@@ -26,12 +26,22 @@ export const WorkflowHistoryProvider: React.FC<WorkflowHistoryProviderProps> = (
 
     // Create a simple store wrapper for history manager. These setters are
     // ONLY reached by history restores (undo/redo/jumpToState) — they bypass
-    // the canvas interaction paths that normally mark the workflow dirty, so
-    // each restore marks dirty itself. Load-bearing for Kopilot edits: the
-    // realtime rehydrate records the edit as a history entry on a CLEAN
-    // canvas, and undoing it must leave a saveable (dirty) canvas rather than
-    // one the autosave/beacon paths silently skip.
-    const markRestoreDirty = () => useWorkflowStore.getState().markDirty()
+    // the canvas interaction paths that normally queue a save, so each restore
+    // queues one itself. Load-bearing for Kopilot edits: the realtime rehydrate
+    // records the edit as a history entry on a CLEAN canvas, and undoing it
+    // must leave a saveable canvas rather than one the save path skips.
+    //
+    // This MUST queue the `graph` key, not just `markDirty()`. Since phase D the
+    // pending set is the complete record of what needs writing, and `runSave`
+    // treats an empty set as "already up to date" — so a bare `markDirty()`
+    // leaves undo unsaved AND makes the explicit Save button report success
+    // without writing anything. The content guard still decides whether the
+    // request actually goes out.
+    const markRestoreDirty = () => {
+      const state = useWorkflowStore.getState()
+      state.markDirty()
+      state.queueSave?.({ graph: true })
+    }
     const workflowStore = {
       setNodes: (nodes: any[]) => {
         const { setNodes } = reactFlowStore.getState()

--- a/apps/web/src/components/workflow/utils/save-baseline.ts
+++ b/apps/web/src/components/workflow/utils/save-baseline.ts
@@ -25,6 +25,7 @@
  */
 
 import {
+  DEHYDRATION_OPTIONS,
   dehydrateGraph,
   type GraphDocument,
   projectGraphSemantics,
@@ -66,7 +67,12 @@ export const EMPTY_SAVE_BASELINE: WorkflowSaveBaseline = { graph: null, envText:
  * must land on the same string when they mean the same workflow.
  */
 export function projectGraph(graph: unknown): ProjectedGraph {
-  const projection = projectGraphSemantics(dehydrateGraph((graph ?? {}) as GraphDocument))
+  // Same policy as the write seam (see workflow-save-provider). A baseline
+  // built under a different `skipDefaults` than the payload would compare two
+  // different documents and either save constantly or never save at all.
+  const projection = projectGraphSemantics(
+    dehydrateGraph((graph ?? {}) as GraphDocument, DEHYDRATION_OPTIONS)
+  )
   return { projection, text: stableStringify(projection) }
 }
 

--- a/apps/web/src/components/workflow/utils/workflow-initializer.ts
+++ b/apps/web/src/components/workflow/utils/workflow-initializer.ts
@@ -4,6 +4,7 @@ import {
   errorHandlingBranches,
   type GraphDocument,
   getManifest,
+  HYDRATION_OPTIONS,
   hydrateGraph,
   type TargetBranch,
 } from '@auxx/lib/workflow-engine/client'
@@ -121,7 +122,9 @@ export const initializeWorkflow = (
   // while the document's is a plain string, so the two structural types are
   // not mutually assignable. The values are identical; only the declarations
   // disagree.
-  const hydrated = hydrateGraph({ nodes, edges } as unknown as GraphDocument)
+  // HYDRATION_OPTIONS: the builder must read under the SAME policy the server
+  // reads under, or the canvas sees manifest defaults the engine never will.
+  const hydrated = hydrateGraph({ nodes, edges } as unknown as GraphDocument, HYDRATION_OPTIONS)
   const hydratedNodes = hydrated.nodes as unknown as FlowNode[]
   const hydratedEdges = hydrated.edges as unknown as FlowEdge[]
 

--- a/packages/lib/src/workflow-engine/catalog/__tests__/hydration-policy-pairing.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/__tests__/hydration-policy-pairing.test.ts
@@ -1,0 +1,85 @@
+// packages/lib/src/workflow-engine/catalog/__tests__/hydration-policy-pairing.test.ts
+//
+// The pairing rule: `hydrateGraph` and `dehydrateGraph` MUST run under the same
+// `skipDefaults` policy on both sides of the wire.
+//
+// This exists because they did not. `workflow-save-provider.tsx` called
+// `dehydrateGraph(...)` with no options, so `skipDefaults` defaulted to OFF and
+// the strip deleted every `node.data` key whose value equalled its manifest
+// default — while every server reader hydrates with `skipDefaults: true` and
+// never put them back. An HTTP node stored as `{desc, title, type, url}` fails
+// `httpNodeConfigSchema.safeParse` (`method`/`body`/`authorization` have no zod
+// default), and a resource-trigger lost `operation`, which drops
+// `deriveTriggerColumns` to the generic `'resource-trigger'` that no dispatcher
+// matches — i.e. the workflow silently stops firing.
+import { describe, expect, it } from 'vitest'
+import { deriveTriggerColumns } from '../derive-trigger'
+import { dehydrateGraph, type GraphDocument, hydrateGraph } from '../graph-hydration'
+import { DEHYDRATION_OPTIONS, HYDRATION_OPTIONS } from '../hydration-policy'
+import { getManifest } from '../registry'
+
+/** Keys a stored document is allowed to lose — dead, derived, or canvas-only. */
+const DROPPABLE = new Set(['isValid', 'errors', 'outputVariables', 'selected', 'id', 'description'])
+
+const canvasNode = (type: string, extra: Record<string, unknown> = {}) => {
+  const manifest = getManifest(type as never)
+  if (!manifest) throw new Error(`no manifest for ${type}`)
+  const data = { ...(manifest.defaultData() as Record<string, unknown>), type, ...extra }
+  return { node: { id: `${type}-1`, type: 'standard', position: { x: 0, y: 0 }, data }, data }
+}
+
+/** Exactly what the builder does: hydrate on load, dehydrate on save. */
+const saveRoundTrip = (node: unknown): GraphDocument => {
+  const loaded = hydrateGraph(
+    { nodes: [node], edges: [] } as unknown as GraphDocument,
+    HYDRATION_OPTIONS
+  )
+  return dehydrateGraph(loaded, DEHYDRATION_OPTIONS)
+}
+
+describe('hydrate/dehydrate policy pairing', () => {
+  const types = ['http', 'resource-trigger', 'scheduled', 'wait', 'ai', 'crud', 'answer', 'end']
+
+  it.each(types)('a canvas save of a default-configured %s loses no authored config', (type) => {
+    const { node, data } = canvasNode(type)
+    const stored = saveRoundTrip(node)
+    const readBack = hydrateGraph(stored, HYDRATION_OPTIONS)
+    const survived = (readBack.nodes[0] as { data: Record<string, unknown> }).data
+
+    const lost = Object.keys(data).filter(
+      (k) => !(k in survived) && !k.startsWith('_') && !DROPPABLE.has(k)
+    )
+    expect(lost, `${type} lost config through a save`).toEqual([])
+  })
+
+  it('a resource-trigger still derives its trigger columns after a save', () => {
+    const { node } = canvasNode('resource-trigger', { entityDefinitionId: 'contact' })
+
+    const before = deriveTriggerColumns([node] as never)
+    const after = deriveTriggerColumns(saveRoundTrip(node).nodes as never)
+
+    // The failure mode: `{ triggerType: 'resource-trigger' }` with no entity id,
+    // which no dispatcher matches — the workflow stops firing, silently.
+    expect(after).toEqual(before)
+    expect(after).toMatchObject({ triggerType: 'created', entityDefinitionId: 'contact' })
+  })
+
+  it('MISMATCHED policies are what caused the loss — pinned so the hazard stays visible', () => {
+    const { node } = canvasNode('http')
+
+    // Browser dehydrating with defaults ON, server reading with them OFF.
+    const mismatched = dehydrateGraph(
+      hydrateGraph({ nodes: [node], edges: [] } as never),
+      undefined
+    )
+    const asServerSeesIt = hydrateGraph(mismatched, HYDRATION_OPTIONS)
+    const data = (asServerSeesIt.nodes[0] as { data: Record<string, unknown> }).data
+
+    expect(data).not.toHaveProperty('method')
+    expect(data).not.toHaveProperty('body')
+
+    // ...and the paired policy keeps them.
+    const paired = hydrateGraph(saveRoundTrip(node), HYDRATION_OPTIONS)
+    expect((paired.nodes[0] as { data: Record<string, unknown> }).data).toHaveProperty('method')
+  })
+})


### PR DESCRIPTION
Found by an independent audit of #1770. **Two data-affecting bugs, both introduced by that commit.**

## 1. The canvas save seam deleted node config from stored graphs

#1770 added `catalog/hydration-policy.ts` with this comment:

> *Exported so callers outside this package (apps/api's share + public routes, apps/web's builder) cannot end up hydrating under a different policy*

**Six call sites did exactly that**, including the write seam. `workflow-save-provider.tsx` called `dehydrateGraph(...)` with no options, so `skipDefaults` defaulted to OFF and the strip deleted every `node.data` key whose value equalled its manifest default — while every server reader hydrates with `skipDefaults: true` and never put them back.

Reproduced against real manifests (a canvas node with `data.type` set, which is how the manifest resolves):

| node | stored after one save | lost |
|---|---|---|
| `http` | `{desc, title, type, url}` | `method`, `authorization`, `body`, `headers`, `params`, `timeout`, `retry_config`, `ssl_verify`, `error_strategy` |
| `resource-trigger` | `{desc, entityDefinitionId, title, type}` | `resourceType`, `operation`, `filters` |
| `scheduled` | `{title, type}` | `config`, `isEnabled` |
| `wait` | `{time, title, type}` | `waitType`, `durationUnit`, `durationAmount` |

Consequences:

- **HTTP nodes stop executing.** `method`, `body` and `authorization` have no zod default and are not optional in `httpNodeConfigSchema`, so `safeParse` fails → `Invalid HTTP configuration`.
- **Resource-triggered workflows stop firing.** `deriveTriggerColumns` drops from `{triggerType: 'created', entityDefinitionId: 'contact'}` to the generic `{triggerType: 'resource-trigger'}`, which no dispatcher matches. `persistDraft` then writes `entityDefinitionId: null`. **This is verbatim the failure `hydration-policy.ts` was written to prevent**, delivered through the one seam that didn't use it.
- **Scheduled workflows are never registered** — `findScheduledTriggerNode` returns `null` without `config`.

It's silent: the canvas hydrates *with* defaults, so the builder still looks correct while the column degrades.

**Fix:** all five product call sites now pass the policy. `save-baseline.ts` matters as much as the write seam — a baseline built under a different `skipDefaults` than the payload compares two different documents, and the content guard would then either save constantly or never save at all.

## 2. Undo/redo stopped persisting, and Save reported success without writing

`workflow-history-provider.tsx` still calls bare `markDirty()`. Its own comment says it does so *because* otherwise the save path would "silently skip" it — but the fallback that made that true (`buildPayload`'s "pending empty but dirty → send the graph") was deleted in #1770.

Since phase D the pending set is the complete record of what needs writing, and `runSave` treats an empty set as already-up-to-date. So after an undo: nothing queued, no debounce armed, and the first `saveNow()` — the explicit Save button, and `use-run-single-node`'s save-before-run gate — called `markClean()` and returned `true`. **UI says saved, nothing was written, dirty flag cleared.** Only `pagehide` rescued the canvas, because its terminal request forces `graph: true`.

**Fix:** the restore queues the `graph` key like every other consumer. The content guard still decides whether a request actually goes out.

## Tests

New `hydration-policy-pairing.test.ts` (10 cases): the pairing rule across eight node types, an explicit assertion that a resource-trigger still derives its trigger columns after a save, and a test that keeps the *mismatched*-policy failure visible so the hazard can't quietly return.

| check | result |
|---|---|
| `packages/lib` | 116 files / **2058 tests** |
| `apps/web` workflow | 31 files / **245 tests** |
| typecheck | `apps/web`, `apps/api` clean |

## Still open from the same audit

Not fixed here, filed for follow-up: the invariant script and `graph-hydration.test.ts` both exercise the **defaults-ON** configuration, so neither could have caught this — they validate a policy no server seam uses. `validateClassifierEdges`' absent-handle branch is unreachable at both install doors (hydration fills the handle before the validator runs). And `23` §8 B-2 (`polling-trigger-service` `nodeId: undefined`) is still live.
