### PR TITLE
fix(workflow): make the hydration invariants test the policy that actually ships

### DIFF
--- a/packages/lib/scripts/check-graph-hydration-roundtrip.ts
+++ b/packages/lib/scripts/check-graph-hydration-roundtrip.ts
@@ -42,11 +42,30 @@ import {
   type GraphDocument,
   hydrateGraph,
 } from '../src/workflow-engine/catalog/graph-hydration'
+import {
+  DEHYDRATION_OPTIONS,
+  HYDRATION_OPTIONS,
+} from '../src/workflow-engine/catalog/hydration-policy'
 import { projectGraphSemantics } from '../src/workflows/graph-projection'
 
 const { Workflow, WorkflowRun, WorkflowTemplate } = schema
 
 const verbose = process.argv.includes('--verbose')
+
+/**
+ * `node.data` keys a canonical document is ALLOWED to drop: dead fields with no
+ * readers, plus the derived ones hydration rebuilds under a different name.
+ */
+const DROPPABLE_DATA_KEYS = new Set([
+  'isValid',
+  'errors',
+  'outputVariables',
+  'selected',
+  'description',
+  'inputNodes',
+  'isInLoop',
+  'loopId',
+])
 
 interface Row {
   source: string
@@ -148,12 +167,17 @@ async function main() {
 
   for (const row of rows) {
     const label = `${row.source} ${row.id}`
-    const h1 = hydrateGraph(row.graph)
-    const h2 = hydrateGraph(h1)
-    const d1 = dehydrateGraph(row.graph)
-    const d2 = dehydrateGraph(d1)
-    const canonical = dehydrateGraph(h1)
-    const roundTrip = hydrateGraph(canonical)
+    // THE SHIPPED POLICY, on both sides. Running these with no options
+    // validates the defaults-layer-ON configuration, which no seam uses — that
+    // is precisely why this script passed while the canvas save path was
+    // deleting node config (#1771). A green run under the wrong policy is not
+    // evidence about production.
+    const h1 = hydrateGraph(row.graph, HYDRATION_OPTIONS)
+    const h2 = hydrateGraph(h1, HYDRATION_OPTIONS)
+    const d1 = dehydrateGraph(row.graph, DEHYDRATION_OPTIONS)
+    const d2 = dehydrateGraph(d1, DEHYDRATION_OPTIONS)
+    const canonical = dehydrateGraph(h1, DEHYDRATION_OPTIONS)
+    const roundTrip = hydrateGraph(canonical, HYDRATION_OPTIONS)
 
     if (stable(h1) !== stable(h2)) {
       failures.push(`[1 hydrate idempotent] ${label}\n    ${diffPaths(h1, h2).join('\n    ')}`)
@@ -162,11 +186,36 @@ async function main() {
       failures.push(`[2 dehydrate idempotent] ${label}\n    ${diffPaths(d1, d2).join('\n    ')}`)
     }
     // 3 — a canonical document survives read/write byte for byte.
-    const reCanonical = dehydrateGraph(roundTrip)
+    const reCanonical = dehydrateGraph(roundTrip, DEHYDRATION_OPTIONS)
     if (stable(reCanonical) !== stable(canonical)) {
       failures.push(
         `[3 canonical round trip] ${label}\n    ${diffPaths(canonical, reCanonical).join('\n    ')}`
       )
+    }
+
+    // 6 — NO `node.data` KEY MAY VANISH through a read/write cycle. Invariant 5
+    // below uses `projectGraphSemantics`, which is symmetric under any single
+    // policy and so cannot see a key that both sides agree to drop. This one
+    // compares raw key sets against the stored row and is what would have caught
+    // the #1771 config amputation.
+    const storedKeys = new Map<string, Set<string>>()
+    for (const n of (row.graph.nodes ?? []) as Array<Record<string, any>>) {
+      storedKeys.set(String(n.id), new Set(Object.keys(n.data ?? {})))
+    }
+    for (const n of (roundTrip.nodes ?? []) as unknown as Array<Record<string, any>>) {
+      const before = storedKeys.get(String(n.id))
+      if (!before) continue
+      const after = new Set(Object.keys(n.data ?? {}))
+      const vanished = [...before].filter(
+        (k) =>
+          !after.has(k) &&
+          !k.startsWith('_') && // canvas-owned by convention; never persisted
+          !k.startsWith('$') &&
+          !DROPPABLE_DATA_KEYS.has(k)
+      )
+      if (vanished.length > 0) {
+        failures.push(`[6 data key vanished] ${label} node ${n.id}: ${vanished.join(', ')}`)
+      }
     }
 
     // 5 — no CONTENT is lost, judged by the same projection the save path uses.

--- a/packages/lib/src/workflow-engine/catalog/__tests__/graph-hydration.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/__tests__/graph-hydration.test.ts
@@ -649,6 +649,12 @@ describe('the read-time defaults layer', () => {
   })
 
   it('does NOT persist a defaulted value — a default is a read-time projection, never a write', () => {
+    // NOTE: this exercises the defaults layer ON, which is the layer's own unit
+    // contract — NOT the shipped configuration. Every seam runs
+    // `skipDefaults: true` (`hydration-policy.ts`), so in production neither
+    // half of this happens. The pairing that actually ships is pinned by
+    // `hydration-policy-pairing.test.ts`; running the two halves under
+    // DIFFERENT policies is what silently amputated node config in #1771.
     const stored = dehydrateGraph(hydrateGraph(stripped))
     const data = node(stored, 't1').data!
     expect(data).not.toHaveProperty('resourceType')
@@ -828,9 +834,12 @@ describe('dehydrateGraph must NOT strip', () => {
   })
 
   it('an authored value that happens to EQUAL its manifest default reads back unchanged', () => {
-    // Dehydration does drop it from the column — that is the exact inverse of
-    // the read-time defaults layer, and it is what keeps a stored document
-    // canonical. What matters is that no reader can tell.
+    // Dehydration does drop it from the column — the exact inverse of the
+    // read-time defaults layer, which is what keeps a stored document canonical.
+    // "No reader can tell" holds ONLY because both halves here run under the
+    // same policy. Under the shipped `skipDefaults: true` neither half runs; a
+    // reader on the other policy very much can tell, which is #1771. See
+    // `hydration-policy-pairing.test.ts`.
     const graph: GraphDocument = {
       nodes: [
         {

--- a/packages/lib/src/workflows/polling-trigger-service.ts
+++ b/packages/lib/src/workflows/polling-trigger-service.ts
@@ -65,7 +65,13 @@ export class PollingTriggerService {
           data: {
             workflowAppId: workflowApp.id,
             organizationId: workflowApp.organizationId,
-            nodeId: triggerNode.nodeId,
+            // `findPollingTriggerNode` returns a RAW canvas node off
+            // `workflow.graph.nodes`, which is keyed `id`. `nodeId` is the
+            // ENGINE node's field, so reading it here yielded `undefined` on
+            // every scheduled job (plan 23 §8 B-2). Latent rather than live —
+            // the job declares `nodeId: string` and never reads it — but the
+            // payload was lying about its own shape.
+            nodeId: triggerNode.id,
             appId: workflowApp.publishedWorkflow.triggerAppId,
             triggerId: workflowApp.publishedWorkflow.triggerTriggerId,
             installationId: workflowApp.publishedWorkflow.triggerInstallationId,

--- a/packages/lib/src/workflows/template-graph-transformer.ts
+++ b/packages/lib/src/workflows/template-graph-transformer.ts
@@ -217,6 +217,13 @@ export class TemplateGraphTransformer {
           // category and the branch can never be taken — the guard used to skip
           // exactly that edge (`edge.sourceHandle && ...`), i.e. it failed open
           // on its own worst input.
+          //
+          // REACHABILITY: this arm only fires on a RAW, un-hydrated graph.
+          // `resolve-template.ts` hydrates (filling `sourceHandle ?? 'source'`)
+          // before the install door calls this, so an install can never see an
+          // absent handle — the arm is for a template WRITE, which is not yet
+          // validated (plan 23 §7; `packages/services` is tier 2 and cannot
+          // import this module, so that seam needs the app-layer treatment).
           if (!edge.sourceHandle) {
             errors.push(`Edge ${edge.id}: no sourceHandle, so it routes to no classifier category`)
             continue


### PR DESCRIPTION
Follow-up to #1771, closing the gap that let it ship.

## Why #1771 got through

Nothing that tested the hydration pair ran the configuration that actually ships. `check-graph-hydration-roundtrip.ts` and the round-trip assertions in `graph-hydration.test.ts` both call `hydrateGraph`/`dehydrateGraph` **with no options** — the defaults layer ON, which no seam uses. Both were green across 1413 real stored graphs while the canvas save path was deleting node config.

A green run under the wrong policy was never evidence about production.

## What changed

**The script now runs the shipped policy on both sides**, and gains a sixth invariant: **no `node.data` key may vanish through a read/write cycle.**

Invariant 5 could not have caught this alone — it compares `projectGraphSemantics` of both sides, which is symmetric under any *single* policy and therefore structurally blind to a key both halves agree to drop. Invariant 6 compares raw key sets against the stored row instead.

**Verified non-vacuous.** Reintroducing the unpaired call reports real config vanishing on real rows across 16 stored graphs:

```
[6 data key vanished] node code-…: inputs, outputs, variables, code_language
[6 data key vanished] node end-…:  status
[6 data key vanished] node wait-…: waitType, durationUnit, isDurationConstant
[6 data key vanished] node dataset-…: mimeType, skipEmbedding
```

Under the paired policy: silent.

**The two misleading test justifications are corrected.** They asserted the strip was safe because "what matters is that no reader can tell" — true only because both halves ran under the same policy. They now say so explicitly and point at `hydration-policy-pairing.test.ts`.

## Two other findings from the same audit

**Plan 23 §8 B-2 fixed.** `polling-trigger-service` read `triggerNode.nodeId` off a raw canvas node, which is keyed `id` — every scheduled job carried `nodeId: undefined`. Latent (the job declares `nodeId: string` and never reads it), but the payload was lying about its own shape.

**`validateClassifierEdges`' absent-handle arm is documented as unreachable at the install door.** `resolve-template.ts` hydrates, filling `sourceHandle ?? 'source'`, before the validator runs — so an install can never see an absent handle. The arm is for a template *write*, which is still unvalidated (§7) because `packages/services` is tier 2 and cannot import the transformer. Left as a real follow-up rather than papered over.

## Verification

| check | result |
|---|---|
| `packages/lib` | 103 files / **1973 tests** |
| invariant script (shipped policy) | all hold across **1414 graphs / 4142 nodes** |
| invariant 6 non-vacuity | fails on 16 graphs when the mismatch is reintroduced |
