### PR TITLE
fix(workflow): make crud fail-only and redraw the substitutes editor

### DIFF
--- a/apps/web/src/components/workflow/nodes/core/ai/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/ai/panel.tsx
@@ -27,7 +27,6 @@ import {
   type ErrorStrategyUpdate,
 } from '~/components/workflow/nodes/shared/error-handling-section'
 import { BaseType } from '~/components/workflow/types'
-import Field from '~/components/workflow/ui/field'
 import {
   VarEditor,
   VarEditorField,
@@ -372,25 +371,21 @@ const AiPanelComponent: React.FC<AiPanelProps> = ({ nodeId, data }) => {
       {/* `default` is offered here and nowhere else in the step-4 set: the AI
           node HAS an output shape worth substituting — `text` is a plain
           string, so "if the classifier times out, use `unknown`" is
-          expressible (plan 21 §16.3). The editor is crud's, reused rather than
-          reinvented; plan 24 owns its redesign. */}
+          expressible (plan 21 §16.3). */}
       <ErrorHandlingSection
         nodeId={nodeId}
         nodeType='ai'
         errorStrategy={nodeData.error_strategy}
         onChange={handleErrorStrategyChange}>
-        <Field
-          title='Default Values'
-          description='Substitute output values to use when the model call fails'>
-          <DefaultValuesEditor
-            nodeId={nodeId}
-            declaredOutputs={aiOutputVariables}
-            errorHandling={getManifest('ai')?.errorHandling}
-            values={nodeData.default_values || []}
-            onChange={handleDefaultValuesChange}
-            isReadOnly={isReadOnly}
-          />
-        </Field>
+        <DefaultValuesEditor
+          nodeId={nodeId}
+          declaredOutputs={aiOutputVariables}
+          errorHandling={getManifest('ai')?.errorHandling}
+          values={nodeData.default_values || []}
+          onChange={handleDefaultValuesChange}
+          isReadOnly={isReadOnly}
+          description='Substitute output values to use when the model call fails'
+        />
       </ErrorHandlingSection>
 
       <OutputVariablesDisplay outputVariables={aiOutputVariables} initialOpen={false} />

--- a/apps/web/src/components/workflow/nodes/core/crud/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/crud/panel.tsx
@@ -4,7 +4,6 @@
 
 import { isMultiRelationship } from '@auxx/lib/field-values/client'
 import type { ResourceField } from '@auxx/lib/resources/client'
-import { getManifest } from '@auxx/lib/workflow-engine/client'
 import {
   getRelatedEntityDefinitionId,
   type RelationshipConfig,
@@ -24,7 +23,6 @@ import { memo, useCallback, useMemo } from 'react'
 import { ResourcePicker } from '~/components/pickers/resource-picker'
 import { useResource, useResourceFields } from '~/components/resources'
 import { useNodeCrud, useReadOnly } from '~/components/workflow/hooks'
-import { DefaultValuesEditor } from '~/components/workflow/nodes/shared/default-values-editor'
 import {
   ErrorHandlingSection,
   type ErrorStrategyUpdate,
@@ -45,7 +43,7 @@ import { useWorkflowResources } from '../../../providers'
 import { BasePanel } from '../../shared/base/base-panel'
 import { RelationUpdateModeButton } from './components/relation-update-mode-button'
 import { getCrudNodeOutputVariables } from './output-variables'
-import { type CrudNodeData, ErrorStrategy } from './types'
+import type { CrudNodeData } from './types'
 import { useCrudValidation } from './use-crud-validation'
 import { ValidationMessage } from './validation-message'
 
@@ -187,23 +185,15 @@ const CrudPanelComponent: React.FC<CrudPanelProps> = ({ nodeId, data }) => {
       const newData = produce(nodeData, (draft) => {
         draft.error_strategy = update.error_strategy
         draft._targetBranches = update._targetBranches
-        draft.default_values =
-          update.error_strategy === ErrorStrategy.default ? nodeData.default_values || [] : []
+        // Retiring a legacy `default` node is what this write is FOR: `fail`
+        // is the only strategy crud offers now, so any stored substitutes are
+        // dead weight the moment the author picks it.
+        draft.default_values = []
       })
       setInputs(newData)
       if (!showValidation) setShowValidation(true)
     },
     [nodeData, setInputs, showValidation, setShowValidation]
-  )
-
-  const handleDefaultValuesChange = useCallback(
-    (defaultValues: CrudNodeData['default_values']) => {
-      const newData = produce(nodeData, (draft) => {
-        draft.default_values = defaultValues
-      })
-      setInputs(newData)
-    },
-    [nodeData, setInputs]
   )
 
   /** Handle relation update mode change */
@@ -343,6 +333,7 @@ const CrudPanelComponent: React.FC<CrudPanelProps> = ({ nodeId, data }) => {
                 placeholder={field.placeholder}
                 allowConstant={true}
                 isConstantMode={getFieldMode(field.key)}
+                readOnly={isReadOnly}
                 hideClearButton
               />
             </div>
@@ -360,6 +351,7 @@ const CrudPanelComponent: React.FC<CrudPanelProps> = ({ nodeId, data }) => {
               placeholder={field.placeholder}
               allowConstant={true}
               isConstantMode={getFieldMode(field.key)}
+              readOnly={isReadOnly}
               hideClearButton
             />
           )}
@@ -380,6 +372,7 @@ const CrudPanelComponent: React.FC<CrudPanelProps> = ({ nodeId, data }) => {
       handleFieldUpdateModeChange,
       handleFieldUpdateModeVarChange,
       getFieldMode,
+      isReadOnly,
     ]
   )
 
@@ -504,10 +497,12 @@ const CrudPanelComponent: React.FC<CrudPanelProps> = ({ nodeId, data }) => {
         </Section>
       )}
 
-      {/* The selector is the SHARED control (plan 21 §15.4) — this panel used
-          to own an inline <Select> that duplicated http's with different
-          labels. Only the defaults editor is crud-specific, and plan 24 owns
-          its redesign, so it is passed through untouched. */}
+      {/* One declared policy, so this renders as copy rather than a <Select>
+          (`error-handling-section.tsx`) — a write other nodes read has no
+          honest fallback, see `catalog/nodes/crud.ts`'s `errorHandling`. The
+          panel used to own an inline <Select> that duplicated http's with
+          different labels, and a free-text key/type/value substitutes list;
+          both are gone. */}
       <ErrorHandlingSection
         nodeId={nodeId}
         nodeType='crud'
@@ -515,30 +510,25 @@ const CrudPanelComponent: React.FC<CrudPanelProps> = ({ nodeId, data }) => {
         onChange={handleErrorStrategyChange}
         className='[&>[data-slot=section]]:pb-0!'
         footer={
-          showValidation && getFieldErrorMessage('error_strategy') ? (
-            <ValidationMessage
-              type={hasFieldErrorOfType('error_strategy', 'error') ? 'error' : 'warning'}
-              message={getFieldErrorMessage('error_strategy')!}
-            />
-          ) : undefined
-        }>
-        <Field title='Default Values' description='Fallback values to use when operations fail'>
-          <DefaultValuesEditor
-            nodeId={nodeId}
-            declaredOutputs={crudOutputVariables}
-            errorHandling={getManifest('crud')?.errorHandling}
-            values={nodeData.default_values || []}
-            onChange={handleDefaultValuesChange}
-            isReadOnly={isReadOnly}
-          />
-          {showValidation && getFieldErrorMessage('default_values') && (
-            <ValidationMessage
-              type={hasFieldErrorOfType('default_values', 'error') ? 'error' : 'warning'}
-              message={getFieldErrorMessage('default_values')!}
-            />
-          )}
-        </Field>
-      </ErrorHandlingSection>
+          <>
+            {showValidation && getFieldErrorMessage('error_strategy') && (
+              <ValidationMessage
+                type={hasFieldErrorOfType('error_strategy', 'error') ? 'error' : 'warning'}
+                message={getFieldErrorMessage('error_strategy')!}
+              />
+            )}
+            {/* Only a node persisted under the retired `default` strategy can
+                still carry substitutes; `validate` reports them here so the
+                author sees what switching to `fail` discards. */}
+            {showValidation && getFieldErrorMessage('default_values') && (
+              <ValidationMessage
+                type={hasFieldErrorOfType('default_values', 'error') ? 'error' : 'warning'}
+                message={getFieldErrorMessage('default_values')!}
+              />
+            )}
+          </>
+        }
+      />
 
       <OutputVariablesDisplay outputVariables={crudOutputVariables} initialOpen={false} />
     </BasePanel>

--- a/apps/web/src/components/workflow/nodes/core/http/components/error-handling.tsx
+++ b/apps/web/src/components/workflow/nodes/core/http/components/error-handling.tsx
@@ -69,6 +69,7 @@ export function ErrorHandling({ nodeId, isReadOnly, config, onChange }: ErrorHan
         values={config?.default_values ?? config?.default_value ?? []}
         onChange={handleDefaultValuesChange}
         isReadOnly={isReadOnly}
+        description='Substitute response values to use when the request fails'
       />
     </ErrorHandlingSection>
   )

--- a/apps/web/src/components/workflow/nodes/shared/default-values-editor.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/default-values-editor.tsx
@@ -16,13 +16,13 @@ import {
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
 import { Plus } from 'lucide-react'
+import type { ReactNode } from 'react'
 import { useCallback, useMemo } from 'react'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { BaseType } from '~/components/workflow/types'
-import { Editor } from '~/components/workflow/ui/prompt-editor'
-
-/** The `BaseType`s whose substitutes are written as JSON rather than plain text. */
-const JSON_TYPES = new Set<BaseType>([BaseType.OBJECT, BaseType.ARRAY])
+import Field from '~/components/workflow/ui/field'
+import { VarEditor, varEditorText } from '~/components/workflow/ui/input-editor/var-editor'
+import { containsVariableReference } from '~/components/workflow/utils/variable-utils'
 
 /**
  * `default_values[].type` for a target's declared `BaseType`.
@@ -48,8 +48,46 @@ function defaultValueTypeFor(type: BaseType): ErrorDefaultValue['type'] {
   }
 }
 
+/**
+ * The `BaseType` whose constant input a row's persisted `type` deserves.
+ *
+ * The INVERSE of {@link defaultValueTypeFor}, and deliberately coarser than
+ * the target's declared type: a substitute is coerced by
+ * `coerceDefaultValue(row.type, …)`, which knows five kinds and nothing else.
+ * Driving the input off the declared type instead would offer a relation
+ * picker for a `RELATION` output whose substitute the runtime will hand
+ * straight through as a string, and would need `fieldOptions.fieldReference`
+ * — a resource binding this editor has no business resolving.
+ *
+ * The row ICON still shows the declared type, so the author can see they are
+ * writing a record id into a Relation while the box stays a text box.
+ */
+function constantInputTypeFor(type: ErrorDefaultValue['type']): BaseType {
+  switch (type) {
+    case 'number':
+      return BaseType.NUMBER
+    case 'boolean':
+      return BaseType.BOOLEAN
+    case 'object':
+      return BaseType.OBJECT
+    case 'array':
+      return BaseType.ARRAY
+    default:
+      return BaseType.STRING
+  }
+}
+
+/**
+ * Every declared output is an admissible source for every substitute, so the
+ * picker is deliberately UNFILTERED (`[ANY]` short-circuits
+ * `isTypeCompatible`). Both processors interpolate `{{…}}` textually and only
+ * then coerce per the row's `type`, so there is no variable a row cannot hold
+ * — a type filter here would forbid what the runtime already accepts.
+ */
+const UNFILTERED: BaseType[] = [BaseType.ANY]
+
 interface DefaultValuesEditorProps {
-  /** Canvas node id — the `{{…}}` picker needs it, and target paths are relative to it. */
+  /** Canvas node id — the variable picker needs it, and target paths are relative to it. */
   nodeId: string
   /** What the node's `resolveOutputs` returned. Targets are derived from this. */
   declaredOutputs: UnifiedVariable[]
@@ -58,6 +96,10 @@ interface DefaultValuesEditorProps {
   values: ErrorDefaultValue[]
   onChange: (values: ErrorDefaultValue[]) => void
   isReadOnly?: boolean
+  /** Overrides the `Field` header copy for a node whose failure reads differently. */
+  description?: string
+  /** Validation messages the panel wants under the rows. */
+  footer?: ReactNode
 }
 
 /**
@@ -83,17 +125,26 @@ interface DefaultValuesEditorProps {
  *   path. It used to write `status_code`, which landed at `body.status_code`
  *   while `{{Http.status}}` stayed hard-coded at 200 (§9.1).
  *
- * **Why the value input is an `Editor` and not a `FieldInputAdapter`.**
- * `docs/ui-design-guide.md` §5 says every input inside a `FieldPanelRow` goes
- * through the adapter, and that rule is right for typed field values. A
- * substitute is not one: it is persisted as a STRING that may carry `{{…}}`
- * refs and is coerced to the target's type at run time
- * (`coerceDefaultValue`). A `NUMBER` adapter cannot hold `{{Trigger.count}}`,
- * so an adapter here would remove a capability the runtime already has — both
- * processors interpolate. The row still uses `FieldPanel`/`FieldPanelRow` for
- * its chrome, and the declared `BaseType` drives the row icon so the author
- * can see what they are writing into. `message-received/panel.tsx` is the
- * precedent for a non-adapter input inside a workflow `FieldPanelRow`.
+ * **It is drawn as crud's Field Data section, because it is the same thing.**
+ * A `Field` whose `actions` slot holds the add control, over a `FieldPanel` of
+ * `FieldPanelRow`s, each holding a `VarEditor` — the identical construction as
+ * `crud/panel.tsx`'s `renderField`. Plan 24 shipped the chrome but left a bare
+ * prompt `Editor` in the row, which reads as a fat textarea beside crud's
+ * typed rows and forced `{{` where every other workflow input opens its picker
+ * on a single `{`.
+ *
+ * `VarEditor` is the right control precisely BECAUSE a substitute is not a
+ * typed field value: its toggle is the constant/variable distinction the
+ * feature already has. Variable mode keeps `{{…}}` refs (a `FieldInputAdapter`
+ * could not hold `{{Trigger.count}}` in a `NUMBER` row); constant mode gives
+ * the per-type input; and `varEditorText` serialises whichever one back to the
+ * string `ErrorDefaultValue.value` has always been.
+ *
+ * The toggle is UNCONTROLLED, seeded per row from the stored value. The mode
+ * is fully recoverable from the value — a substitute either carries a ref or
+ * it does not — so persisting it would add a key to `errorDefaultValueSchema`,
+ * and therefore to the graph document, to record something already written
+ * down.
  */
 export function DefaultValuesEditor({
   nodeId,
@@ -102,6 +153,8 @@ export function DefaultValuesEditor({
   values,
   onChange,
   isReadOnly = false,
+  description = 'Substitute these outputs and carry on when this node fails',
+  footer,
 }: DefaultValuesEditorProps) {
   const targets = useMemo(
     () => defaultValueTargets(declaredOutputs, nodeId, errorHandling),
@@ -136,14 +189,43 @@ export function DefaultValuesEditor({
   )
 
   return (
-    <div className='space-y-2'>
-      {values.length > 0 && (
-        <FieldPanel
-          orientation='responsive'
-          breakpoint='md'
-          resizeId='node-default-values'
-          className='p-0'>
-          {values.map((row) => {
+    <Field
+      title='Default values'
+      description={description}
+      actions={
+        isReadOnly ? undefined : (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild disabled={available.length === 0}>
+              <Button variant='ghost' size='xs'>
+                <Plus />
+                Add
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end' className='max-h-72 overflow-y-auto'>
+              {available.map((target) => (
+                <DropdownMenuItem key={target.path} onSelect={() => addRow(target.path)}>
+                  <span className='truncate'>{target.variable.label}</span>
+                  <span className='ms-2 truncate text-xs text-muted-foreground'>{target.path}</span>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )
+      }>
+      <FieldPanel
+        orientation='responsive'
+        breakpoint='md'
+        resizeId='node-default-values'
+        className='p-0'>
+        {values.length === 0 ? (
+          // Not a decorative placeholder: every processor's `default` arm is
+          // guarded on a non-empty list and otherwise falls through to `fail`,
+          // so an empty editor IS the fail policy (§9.2's warning).
+          <div className='px-2 py-1.5 text-sm text-primary-400'>
+            No substitutes — this node will fail instead.
+          </div>
+        ) : (
+          values.map((row) => {
             const target = targetByPath.get(row.key)
             return (
               <FieldPanelRow
@@ -152,7 +234,7 @@ export function DefaultValuesEditor({
                 key={row.key}
                 title={target?.variable.label ?? row.key}
                 description={target?.variable.description}
-                type={target?.variable.type}
+                type={target?.variable.type ?? BaseType.STRING}
                 showIcon
                 onClear={isReadOnly ? undefined : () => removeRow(row.key)}
                 // A key with no declared target can only be a row persisted
@@ -165,44 +247,24 @@ export function DefaultValuesEditor({
                     : `"${row.key}" is not one of this node's outputs. Nothing downstream can read it — remove the row.`
                 }
                 validationType='error'>
-                <Editor
-                  value={row.value}
-                  onChange={(value) => setValue(row.key, value)}
+                <VarEditor
                   nodeId={nodeId}
-                  trigger='{{'
+                  value={row.value}
+                  onChange={(value) => setValue(row.key, varEditorText(value))}
+                  varType={constantInputTypeFor(row.type)}
+                  allowedTypes={UNFILTERED}
+                  defaultIsConstantMode={!containsVariableReference(row.value)}
+                  placeholder='Use { for variables'
+                  placeholderConstant='Substitute value'
                   readOnly={isReadOnly}
-                  compact={!JSON_TYPES.has(target?.variable.type ?? BaseType.STRING)}
-                  minHeight={JSON_TYPES.has(target?.variable.type ?? BaseType.STRING) ? 80 : 32}
-                  placeholder={
-                    JSON_TYPES.has(target?.variable.type ?? BaseType.STRING)
-                      ? 'JSON, or {{variables}}…'
-                      : 'Substitute value, or {{variables}}…'
-                  }
+                  hideClearButton
                 />
               </FieldPanelRow>
             )
-          })}
-        </FieldPanel>
-      )}
-
-      {!isReadOnly && (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild disabled={available.length === 0}>
-            <Button variant='ghost' size='sm' className='w-full text-xs'>
-              <Plus />
-              {available.length === 0 ? 'All outputs have defaults' : 'Add default value'}
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align='start' className='max-h-72 overflow-y-auto'>
-            {available.map((target) => (
-              <DropdownMenuItem key={target.path} onSelect={() => addRow(target.path)}>
-                <span className='truncate'>{target.variable.label}</span>
-                <span className='ms-2 truncate text-xs text-muted-foreground'>{target.path}</span>
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
-    </div>
+          })
+        )}
+      </FieldPanel>
+      {footer}
+    </Field>
   )
 }

--- a/apps/web/src/components/workflow/nodes/shared/error-handling-section.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/error-handling-section.tsx
@@ -128,11 +128,29 @@ export function ErrorHandlingSection({
 
   if (!errorHandling) return null
 
+  // A strategy the manifest no longer declares but the node is still STORED
+  // under. Retiring one from a manifest does not retire it from a running
+  // graph: every processor switches on the persisted value, and
+  // `normalizeErrorStrategy` hands back any known strategy verbatim — its
+  // fallback only fires for an unrecognised string. Rendering the declared
+  // list alone would print "Fail branch" over a node the engine is running
+  // under `continue`, which is the lie plan 24 §6.5 left behind when it
+  // retired `continue` from five types, and would repeat it for the crud
+  // nodes persisted under `default`.
+  //
+  // So: offer it, flagged, and let the author retire it by picking something
+  // else. `setStrategy` still refuses to WRITE an undeclared strategy, so this
+  // is a one-way door out.
+  const isLegacyStrategy = !errorHandling.strategies.includes(current)
+  const selectable = isLegacyStrategy
+    ? [...errorHandling.strategies, current]
+    : errorHandling.strategies
+
   // A type that declares exactly one policy has nothing to pick — plan 24 §6.5
   // retired `continue` from every type whose outputs are the reason it exists,
   // so `[fail]` is now the common case. A one-item `<Select>` reads as a
   // choice that is being withheld; the copy alone is the honest rendering.
-  const onlyStrategy = errorHandling.strategies.length === 1 ? errorHandling.strategies[0] : null
+  const onlyStrategy = selectable.length === 1 ? selectable[0] : null
 
   return (
     <Section
@@ -149,18 +167,25 @@ export function ErrorHandlingSection({
               <SelectValue placeholder='Select strategy' />
             </SelectTrigger>
             <SelectContent>
-              {errorHandling.strategies.map((strategy) => (
+              {selectable.map((strategy) => (
                 <SelectItem
                   key={strategy}
                   value={strategy}
                   description={STRATEGY_COPY[strategy].description}>
                   {STRATEGY_COPY[strategy].label}
+                  {strategy === current && isLegacyStrategy ? ' (retired)' : ''}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
         )
       }>
+      {isLegacyStrategy && (
+        <div className='text-sm text-bad-500'>
+          {STRATEGY_COPY[current].label} is no longer available on this node. It still runs — pick
+          another policy to retire it.
+        </div>
+      )}
       {current === ErrorStrategy.default && children}
       {current === ErrorStrategy.fail && (
         <div className='text-sm text-primary-500'>Wire the Fail branch on the canvas.</div>

--- a/packages/lib/src/workflow-engine/catalog/__tests__/default-values.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/__tests__/default-values.test.ts
@@ -90,8 +90,16 @@ describe('defaultValueTargets', () => {
   })
 
   it('excludes the keys a manifest declares as defaultValueExclude', () => {
+    // Declared inline rather than read off a manifest: crud was the only type
+    // that carried a `defaultValueExclude`, and it lost the list along with
+    // the `default` strategy. The rule itself still has to hold for whichever
+    // type declares one next.
     const declared = [flat('id'), flat('record', BaseType.OBJECT), flat('success')]
-    const targets = defaultValueTargets(declared, NODE, crudManifest.errorHandling)
+    const targets = defaultValueTargets(declared, NODE, {
+      strategies: [ErrorStrategy.fail, ErrorStrategy.default],
+      defaultStrategy: ErrorStrategy.fail,
+      defaultValueExclude: ['success'],
+    })
     expect(targets.map((t) => t.path)).toEqual(['id', 'record'])
   })
 
@@ -208,7 +216,12 @@ describe('manifest validators surface the substitute findings', () => {
     expect(result.errors.filter((e) => e.field === 'default_values')).toEqual([])
   })
 
-  it('crud warns on `default` with an empty list', () => {
+  it('crud warns on a LEGACY `default` with an empty list', () => {
+    // crud no longer offers `default`, but the processor switches on the
+    // stored value, so a node persisted under it still runs that arm — and an
+    // empty list makes that arm a silent no-op. `validate` is the surface that
+    // says so; it is the only thing that reaches such a node now.
+
     const result = crudManifest.validate({
       title: 'Create contact',
       mode: 'create',

--- a/packages/lib/src/workflow-engine/catalog/error-handling.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/error-handling.test.ts
@@ -235,19 +235,34 @@ describe('manifest declarations', () => {
     })
   })
 
-  it('crud offers fail + default — it writes data others read', () => {
+  it('crud offers fail ALONE — it writes data others read', () => {
+    // Both escape hatches are retired here, for one reason. `continue` skips
+    // the write silently (§6.5); `default` substitutes an `id` or `record`
+    // that names nothing, so the next crud node updates a record that does not
+    // exist. Plan 24 O7 kept `default` on the strength of "pretend it made
+    // this record" (§10.2) and it did not survive contact — the phantom is
+    // §6.5's bug one node later, and worse for looking like it worked.
+    //
+    // No `defaultValueExclude` either: it named the keys a substitute may not
+    // target, and there is no substitute to exclude any more.
     expect(crudManifest.errorHandling).toEqual({
-      strategies: [ErrorStrategy.fail, ErrorStrategy.default],
+      strategies: [ErrorStrategy.fail],
       defaultStrategy: ErrorStrategy.fail,
       failOutputs: ['success', 'error', 'errorDetails', 'operation', 'resourceType'],
       failureOnlyOutputs: ['error', 'errorDetails'],
-      // Same five as `failOutputs`, different reason — `handleCrudError`
-      // writes the status block BEFORE the strategy switch, so substituting
-      // one is either overwritten or a lie (plan 24 §10.2). Do not collapse
-      // the two lists: http's `failOutputs` contains `status`, which is
-      // precisely the substitute its editor exists to set.
-      defaultValueExclude: ['success', 'error', 'errorDetails', 'operation', 'resourceType'],
     })
+  })
+
+  it('ai is the ONE type that keeps default — its substitute is never written back', () => {
+    // The line between crud and ai is not importance, it is whether the
+    // substitute reaches storage. `text` is read by the next node and written
+    // nowhere, so "if the classifier times out, use `unknown`" fabricates
+    // nothing. A crud `id` fabricates a record.
+    expect(aiManifest.errorHandling?.strategies).toEqual([
+      ErrorStrategy.fail,
+      ErrorStrategy.default,
+    ])
+    expect(crudManifest.errorHandling?.strategies).not.toContain(ErrorStrategy.default)
   })
 
   it('http is the ONE type that keeps continue', () => {

--- a/packages/lib/src/workflow-engine/catalog/error-handling.ts
+++ b/packages/lib/src/workflow-engine/catalog/error-handling.ts
@@ -150,13 +150,17 @@ export interface NodeErrorHandling {
    *
    * Only needed when a type's failure handler writes a key BEFORE the strategy
    * switch, so a configured substitute for it would either be silently
-   * overwritten or would let the author state something untrue. crud is the
-   * one such type today: `handleCrudError` writes the five-key status block
-   * unconditionally, and a `success: true` substitute on a failed create is a
-   * lie the rest of the graph would believe.
+   * overwritten or would let the author state something untrue.
    *
-   * NOT derivable from {@link failOutputs}, even though crud's two lists
-   * coincide. http's `failOutputs` is `['status', 'error', 'success']` and
+   * NO TYPE DECLARES ONE TODAY. crud was the only one — `handleCrudError`
+   * writes its five-key status block unconditionally, and a `success: true`
+   * substitute on a failed create is a lie the rest of the graph would believe
+   * — and it lost the list along with the `default` strategy itself. The field
+   * stays because the condition is a property of failure handlers, not of
+   * crud, and the next type to write before its strategy switch will need it.
+   *
+   * NOT derivable from {@link failOutputs}, even though crud's two lists used
+   * to coincide. http's `failOutputs` is `['status', 'error', 'success']` and
    * `status` is precisely the substitute the editor exists to set (plan 24
    * §9.1) — subtracting `failOutputs` here would break the headline fix.
    */

--- a/packages/lib/src/workflow-engine/catalog/nodes/crud.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/crud.ts
@@ -187,17 +187,18 @@ export const validateCrudNodeConfig = (data: CrudNodeData): NodeValidationResult
     })
   }
 
-  // `default` with nothing configured is a silent no-op: `handleCrudError`'s
-  // `default` arm is guarded on a non-empty list and otherwise falls straight
-  // through to the fail arm, with no log and nothing in the panel (plan 24
-  // §9.2). `panel.tsx` has always rendered a `default_values` error slot;
-  // until now nothing populated it.
+  // LEGACY ROWS ONLY. `default` is no longer offerable on crud (see
+  // `errorHandling` below), but the processor switches on the stored value, so
+  // a node persisted under it still runs that arm. This is the surface that
+  // says so: `default` with nothing configured is a silent no-op —
+  // `handleCrudError`'s `default` arm is guarded on a non-empty list and
+  // otherwise falls straight through to the fail arm, with no log (plan 24
+  // §9.2).
   //
   // `targets: undefined` because a manifest `validate` receives only `data` —
   // crud's declared outputs need an `OutputContext` carrying the resource, so
-  // the KEY check cannot run here. The panel, which has the resource, runs the
-  // full check. Passing an empty target list instead would report every key as
-  // unknown.
+  // the KEY check cannot run here. Passing an empty target list instead would
+  // report every key as unknown.
   errors.push(
     ...validateDefaultValues({
       strategy: normalizeErrorStrategy(data.error_strategy, ErrorStrategy.fail),
@@ -567,10 +568,28 @@ export const crudManifest: NodeManifest<CrudNodeData> = {
     ],
   },
   errorHandling: {
-    // No `continue`: this node WRITES data that downstream nodes read, so a
-    // silently-skipped write is a data-integrity bug, not an inconvenience
-    // (plan 24 §6.5). `default` covers "carry on with a stand-in" honestly.
-    strategies: [ErrorStrategy.fail, ErrorStrategy.default],
+    // `fail` ONLY. crud WRITES data that downstream nodes read, and neither
+    // escape hatch is honest on a node with that property:
+    //
+    // - `continue` skips the write silently, which is a data-integrity bug
+    //   rather than an inconvenience (plan 24 §6.5).
+    // - `default` was kept by plan 24 O7 on the strength of "if the create
+    //   fails, pretend it made this record" (§10.2). Retired after it: a
+    //   substituted `id` or `record` is a PHANTOM, so the next crud node
+    //   updates a record that does not exist or links a relation to nothing.
+    //   That is §6.5's bug one node later, and worse for looking like it
+    //   worked. Its defence was that `success` stays truthful so a downstream
+    //   if-else can catch it — but an author willing to branch would have
+    //   wired the fail branch in the first place.
+    //
+    // `ai` keeps `default` because substituting `text` fabricates nothing
+    // that anything writes. The distinction is "does the substitute get
+    // written back", not "is this node important".
+    //
+    // The processors still honour a PERSISTED `default` (they switch on the
+    // stored value, not on this list) — `ErrorHandlingSection` surfaces such a
+    // node as a legacy strategy rather than pretending it runs under `fail`.
+    strategies: [ErrorStrategy.fail],
     defaultStrategy: ErrorStrategy.fail,
     // The 5-key status block `handleCrudError` writes BEFORE the strategy
     // switch (`nodes/action-nodes/crud.ts`). `record`, `id`, `deleted` and the
@@ -580,16 +599,11 @@ export const crudManifest: NodeManifest<CrudNodeData> = {
     // Written as an explicit `null` on the success path, so under strategy
     // `fail` these two can never be anything else on `source` (§6.1a).
     // `success` deliberately stays on both: it is a real boolean rather than a
-    // null, and it is the discriminator under `default`.
+    // null.
     failureOnlyOutputs: ['error', 'errorDetails'],
-    // The same five, for a different reason — do not collapse the two lists.
-    // `handleCrudError` writes this block BEFORE the strategy switch, so a
-    // configured substitute for one of them is overwritten on the way past,
-    // and a `success: true` substitute on a failed create would state
-    // something untrue that the rest of the graph believes. What a `default`
-    // on crud is FOR is `id` / `record` / the record tree — "if the create
-    // fails, pretend it made this record" (plan 24 §10.2).
-    defaultValueExclude: ['success', 'error', 'errorDetails', 'operation', 'resourceType'],
+    // No `defaultValueExclude`: it named the keys a substitute may not target,
+    // and with `default` retired there is no substitute to exclude. Dead
+    // config on a retired strategy reads as "the strategy is still a thing".
   },
   agent: {
     authorable: true,
@@ -598,9 +612,9 @@ export const crudManifest: NodeManifest<CrudNodeData> = {
       'EntityDefinition id — resolve it, never guess); `thread` is special: it is action-based ' +
       "(status/subject/assignee/tags/…), not field-based, and only supports mode 'update'. " +
       '`mode` is create/update/delete; update and delete require `resourceId`. `data` holds field ' +
-      'values keyed by field name, which may be {{…}} refs. `error_strategy` is fail (default, wires ' +
-      "a 'fail' branch handle), continue (succeed with success:false), or default (apply " +
-      '`default_values` on failure).',
+      "values keyed by field name, which may be {{…}} refs. `error_strategy` is 'fail' and nothing " +
+      "else — it wires a 'fail' branch handle. A write other nodes read has no honest way to " +
+      'pretend it happened, so route the failure instead of swallowing it.',
     examples: [
       {
         description: 'Create a contact from trigger data',

--- a/packages/lib/src/workflow-engine/parity/crud.resolvability.test.ts
+++ b/packages/lib/src/workflow-engine/parity/crud.resolvability.test.ts
@@ -370,6 +370,10 @@ describe('CRUD node resolvability', () => {
     expect(await ctx.resolveVariablePath(`${nodeId}.errorDetails`)).toBeNull()
   })
 
+  // LEGACY CONFIG. crud's manifest no longer offers `default` — a substituted
+  // `id` names a record that was never created, and the next node writes to
+  // the phantom. The processor still switches on the stored value, though, so
+  // nodes persisted under it keep running this arm and it stays covered here.
   it('error_strategy "default" — usedDefaults/defaultValues resolve after a forced failure', async () => {
     updateValues.mockRejectedValueOnce(new Error('simulated update failure'))
     const nodeId = 'crud_vendor_update_default'


### PR DESCRIPTION
Two changes on one thread: crud loses the `default` failure policy, and the editor that policy uses gets redrawn to look like the rest of the panel.

## crud is `[fail]` alone

Plan 24 **O7** kept `default` on crud for *"if the create fails, pretend it made this record"* (§10.2). That doesn't survive contact — a substituted `id` or `record` is a **phantom**, so the next crud node updates a record that never existed or links a relation to nothing. It's the same data-integrity bug that retired `continue` (§6.5), one node later and worse for looking like it worked.

The defence was that `success` sits in `defaultValueExclude` and stays truthful, so a downstream if-else can catch it. But an author willing to branch on `success` would have wired the fail branch in the first place.

`ai` keeps `default`. **The line is whether the substitute gets written back**, not how important the node is — `ai`'s `text` is read downstream and stored nowhere, so "if the classifier times out, use `unknown`" fabricates nothing.

`defaultValueExclude` goes with it. The field survives on `NodeErrorHandling` for the next type that writes keys before its strategy switch; crud was its only declarer.

## Retiring a strategy doesn't retire it from a running graph

Every processor switches on the **stored** `error_strategy`, and `normalizeErrorStrategy` returns any known strategy verbatim — its `fallback` only fires for an unrecognised string. So a node persisted under a now-undeclared strategy keeps running that arm.

`ErrorHandlingSection` now appends an undeclared current strategy to the menu flagged `(retired)`, with a warning line, and `setStrategy` still refuses to *write* one — a one-way door out. Rendering the declared list alone printed "Fail branch" over a node the engine was running under `continue`, **which is the lie #1769 already shipped** for the five types it took `continue` from. This closes that too.

## The substitutes editor looks like the panel now

`DefaultValuesEditor` is drawn as crud's Field Data section, which is what it always was: a `Field` whose `actions` slot holds the target picker, over `FieldPanelRow`s each holding a `VarEditor`.

#1769 shipped that chrome but left a bare prompt `Editor` in the row — it reads as a fat textarea beside crud's typed rows, and it was the **only** `trigger='{{'` in the repo while every other workflow input opens its picker on a single `{`.

The constant/variable toggle is seeded per row from the stored value rather than persisted. A substitute either carries a ref or it doesn't, so a `mode` key would add a field to `errorDefaultValueSchema` — and therefore to the graph document — to record something already written down.

Row inputs are driven by the row's persisted `type` (the five `coerceDefaultValue` kinds), not the target's declared `BaseType`, so the editor and the engine agree exactly; the row icon still shows the declared type. The variable picker is deliberately unfiltered — interpolation is textual and coercion happens after, so no variable is inadmissible.

## Drive-by

Wires `readOnly` into crud's two field editors. The defaults editor was the only consumer of that panel's `isReadOnly`, so **its rows had never been gated at all**. Happy to split this out if you'd rather.

## Migration

None needed. No seeded template uses `error_strategy: "default"` (every one is `"fail"`), and plan 24 §12 measured zero live crud rows on it — the six were all http. Any that exist are handled by the `(retired)` path above.

## Verification

- `packages/lib` workflow-engine suite: **1497 passed** / 82 files
- graph-edit + parity: **287 passed** / 16 files
- Biome clean; `tsc --noEmit` clean in `packages/lib` and `apps/web` for these paths
