### PR TITLE
fix(workflow): account for webhook runs, canonicalize template writes, retire the graph-document legacy

### DIFF
--- a/apps/web/src/app/admin/workflows/[id]/page.tsx
+++ b/apps/web/src/app/admin/workflows/[id]/page.tsx
@@ -1,6 +1,11 @@
 // apps/web/src/app/admin/workflows/[id]/page.tsx
 'use client'
 
+import {
+  DEHYDRATION_OPTIONS,
+  dehydrateGraph,
+  type GraphDocument,
+} from '@auxx/lib/workflow-engine/client'
 import { Badge } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { IconPicker, type IconPickerValue } from '@auxx/ui/components/icon-picker'
@@ -221,11 +226,18 @@ export default function WorkflowTemplateEditorPage({
   /**
    * Export the current template as a `*.template.json` file definition that a
    * developer can commit into `packages/lib/src/workflows/templates/`.
+   *
+   * The graph is dehydrated first. The editor renders what `resolveTemplateById`
+   * HYDRATED, so exporting it verbatim commits derived state — `node.type`,
+   * `edge.data.sourceType`/`targetType`, filled handles, `selected`, measured
+   * `width`/`height` — into a bundled file permanently. The save path
+   * canonicalizes server-side (`canonicalizeTemplateGraph`); this is the same
+   * policy for the file door.
    */
   const handleExport = () => {
     let parsedGraph: unknown = {}
     try {
-      parsedGraph = JSON.parse(graphJson)
+      parsedGraph = dehydrateGraph(JSON.parse(graphJson) as GraphDocument, DEHYDRATION_OPTIONS)
     } catch {
       toastError({ title: 'Invalid JSON', description: 'Fix the graph JSON before exporting' })
       return

--- a/apps/web/src/app/api/workflows/[workflowId]/webhook/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/webhook/route.ts
@@ -1,12 +1,11 @@
 // apps/web/src/app/api/workflows/[workflowId]/webhook/route.ts
 
 import { database as db } from '@auxx/database'
-import { WorkflowEngine } from '@auxx/lib/workflow-engine'
-import {
-  WorkflowNodeType,
-  type WorkflowTriggerEvent,
-  WorkflowTriggerType,
-} from '@auxx/lib/workflow-engine/types'
+import { WorkflowTriggerSource } from '@auxx/database/enums'
+import { UsageLimitError } from '@auxx/lib/errors'
+import { RedisWorkflowExecutionReporter } from '@auxx/lib/workflow-engine'
+import { WorkflowNodeType } from '@auxx/lib/workflow-engine/types'
+import { WorkflowExecutionService } from '@auxx/lib/workflows'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
 import { filterSensitiveHeaders } from '@auxx/utils/headers'
@@ -21,10 +20,6 @@ import {
 } from '~/server/lib/webhook-test-window'
 
 const logger = createScopedLogger('api.webhook')
-
-// Initialize workflow engine
-const workflowEngine = new WorkflowEngine()
-const engineInitPromise = workflowEngine.getNodeRegistry().initializeWithDefaults()
 
 /**
  * Common webhook handler for both GET and POST requests.
@@ -192,48 +187,12 @@ async function handleWebhookRequest(
       }
     }
 
-    // Ensure the workflow engine is initialized
-    await engineInitPromise
-
     // Prepare trigger data - the data that will be available in the workflow
     const webhookData = {
       method,
       ...(method === 'POST' ? { body } : {}),
       query: Object.fromEntries(searchParams),
       headers: Object.fromEntries(req.headers.entries()),
-    }
-
-    // Create trigger event with webhook data
-    const triggerEvent: WorkflowTriggerEvent = {
-      type: WorkflowTriggerType.WEBHOOK,
-      data: webhookData,
-      timestamp: new Date(),
-      organizationId: workflowApp.organizationId,
-      userId: workflowApp.createdById || undefined,
-    }
-
-    // Transform the workflow for the engine.
-    //
-    // `graph` is the load-bearing key: `WorkflowGraphBuilder.buildGraph` reads
-    // `workflow.graph || { nodes: [], edges: [] }` and NOTHING else. Passing
-    // only the top-level `nodes`/`edges` (as this did) built an empty graph, so
-    // `findEntryNode` returned undefined, the engine threw "No entry point found
-    // in workflow", and the caller still got the configured 200 back — every
-    // published webhook workflow was a silent no-op. `executeWorkflow` takes
-    // `any` ("accept raw database format"), so nothing caught it at build time.
-    // The top-level pair stays because `toEngineFormat` sets both.
-    const engineWorkflow = {
-      id: workflow.id,
-      organizationId: workflowApp.organizationId,
-      name: workflow.name,
-      version: workflow.version,
-      triggerType: WorkflowTriggerType.WEBHOOK,
-      graph: { nodes: workflowGraph.nodes, edges: workflowGraph.edges || [] },
-      nodes: workflowGraph.nodes,
-      edges: workflowGraph.edges || [],
-      enabled: true,
-      createdAt: workflow.createdAt,
-      updatedAt: workflow.updatedAt,
     }
 
     // In test mode, skip execution and just capture the event
@@ -258,16 +217,45 @@ async function handleWebhookRequest(
       })
     }
 
-    // Production mode - execute workflow
-    const result = await workflowEngine.executeWorkflow(engineWorkflow, triggerEvent, {
-      debug: false,
-      variables: { workflowId: workflow.id, workflowAppId: workflowApp.id },
+    // Production mode — execute through the same door every other headless
+    // trigger uses. This route used to hand-build a workflow object and call
+    // `WorkflowEngine.executeWorkflow` directly, so a webhook execution created
+    // no `WorkflowRun` row: it never appeared in run history, never counted
+    // against the org's `workflowRuns` quota, and a paused node (wait, human
+    // confirmation) had no run to resume. `createRun` owns all three.
+    const executionService = new WorkflowExecutionService(db)
+    const workflowRun = await executionService.createRun({
+      workflowId: workflow.id,
+      inputs: webhookData,
+      mode: 'production',
+      // Headless: an external caller is not a user. `createWorkflowRun`
+      // resolves the org's system user — never substitute an id here.
+      userId: null,
+      organizationId: workflowApp.organizationId,
+      triggeredFrom: WorkflowTriggerSource.WEBHOOK,
+    })
+
+    // The reporter is what persists node executions and publishes progress; the
+    // old direct call passed none, so a webhook run had no per-node trace either.
+    const reporter = new RedisWorkflowExecutionReporter(workflowRun.id)
+
+    // Awaited, as before — the caller's response has always been sent after the
+    // workflow finished. A thrown execution error is recorded on the run row by
+    // `executeWorkflowAsync` before it rethrows; the caller still gets the
+    // author's configured response, because that response is the webhook's
+    // contract with the sender and a non-2xx makes senders like Shopify or
+    // Stripe retry a request that will fail again.
+    await executionService.executeWorkflowAsync(workflowRun, reporter).catch((error) => {
+      logger.error('Webhook workflow execution failed', {
+        workflowId,
+        workflowRunId: workflowRun.id,
+        error: error instanceof Error ? error.message : String(error),
+      })
     })
 
     logger.info('Webhook workflow executed', {
       workflowId,
-      executionId: result.executionId,
-      status: result.status,
+      workflowRunId: workflowRun.id,
     })
 
     // Return configured response or default
@@ -278,7 +266,23 @@ async function handleWebhookRequest(
       headers: responseConfig?.headers || {},
     })
   } catch (error) {
-    logger.error(`Error handling webhook ${method} request`, { error })
+    // A run the org has no quota for is a refusal, not a server fault. This
+    // route creates runs now, so it is the first webhook path that can hit the
+    // plan limit — answer with the error's own status so a sender can tell
+    // "you are over your limit" from "we broke".
+    const isUsageLimit = error instanceof UsageLimitError
+    const status = isUsageLimit ? error.statusCode : 500
+
+    if (isUsageLimit) {
+      logger.warn('Webhook workflow run refused — plan limit reached', {
+        workflowId,
+        metric: error.metric,
+        current: error.current,
+        limit: error.limit,
+      })
+    } else {
+      logger.error(`Error handling webhook ${method} request`, { error })
+    }
 
     // Store error event for test mode
     const { searchParams } = new URL(req.url)
@@ -288,7 +292,7 @@ async function handleWebhookRequest(
       const redis = await getRedisClient(true)
       if (redis) {
         // Update event with error response
-        webhookTestEvent.responseStatus = 500
+        webhookTestEvent.responseStatus = status
         webhookTestEvent.responseTime = Date.now() - startTime
 
         await redis.lpush(webhookTestEventsKey(workflowId), JSON.stringify(webhookTestEvent))
@@ -297,7 +301,10 @@ async function handleWebhookRequest(
       }
     }
 
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+    return NextResponse.json(
+      { error: isUsageLimit ? error.message : 'Internal server error' },
+      { status }
+    )
   }
 }
 

--- a/apps/web/src/app/api/workflows/[workflowId]/webhook/webhook-draft-test-window.test.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/webhook/webhook-draft-test-window.test.ts
@@ -25,41 +25,39 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  * resolved.
  */
 
-const { redis, getRedisClient, findFirst, executeWorkflow, initializeWithDefaults } = vi.hoisted(
-  () => {
-    const store = new Map<string, string | string[]>()
-    const client = {
-      store,
-      /** Flip to model an unreachable Redis (the fail-closed case). */
-      available: true,
-      set: vi.fn(async (key: string, value: string) => {
-        store.set(key, value)
-        return 'OK'
-      }),
-      exists: vi.fn(async (key: string) => (store.has(key) ? 1 : 0)),
-      lpush: vi.fn(async (key: string, ...values: string[]) => {
-        const list = (store.get(key) as string[] | undefined) ?? []
-        list.unshift(...values)
-        store.set(key, list)
-        return list.length
-      }),
-      ltrim: vi.fn(async () => 'OK'),
-      expire: vi.fn(async () => 1),
-    }
-    return {
-      redis: client,
-      // Mirrors the real contract: `required` throws, optional hands back undefined.
-      getRedisClient: vi.fn(async (required = true) => {
-        if (client.available) return client
-        if (required) throw new Error('Redis connection required but failed')
-        return undefined
-      }),
-      findFirst: vi.fn(),
-      executeWorkflow: vi.fn(async () => ({ executionId: 'exec_1', status: 'completed' })),
-      initializeWithDefaults: vi.fn(async () => undefined),
-    }
+const { redis, getRedisClient, findFirst, createRun, executeWorkflowAsync } = vi.hoisted(() => {
+  const store = new Map<string, string | string[]>()
+  const client = {
+    store,
+    /** Flip to model an unreachable Redis (the fail-closed case). */
+    available: true,
+    set: vi.fn(async (key: string, value: string) => {
+      store.set(key, value)
+      return 'OK'
+    }),
+    exists: vi.fn(async (key: string) => (store.has(key) ? 1 : 0)),
+    lpush: vi.fn(async (key: string, ...values: string[]) => {
+      const list = (store.get(key) as string[] | undefined) ?? []
+      list.unshift(...values)
+      store.set(key, list)
+      return list.length
+    }),
+    ltrim: vi.fn(async () => 'OK'),
+    expire: vi.fn(async () => 1),
   }
-)
+  return {
+    redis: client,
+    // Mirrors the real contract: `required` throws, optional hands back undefined.
+    getRedisClient: vi.fn(async (required = true) => {
+      if (client.available) return client
+      if (required) throw new Error('Redis connection required but failed')
+      return undefined
+    }),
+    findFirst: vi.fn(),
+    createRun: vi.fn(async () => ({ id: 'wfr_cuid00000000000000000' })),
+    executeWorkflowAsync: vi.fn(async () => undefined),
+  }
+})
 
 vi.mock('@auxx/redis', () => ({ getRedisClient }))
 vi.mock('@auxx/database', async () =>
@@ -69,16 +67,18 @@ vi.mock('@auxx/database', async () =>
 )
 vi.mock('@auxx/logger', async () => (await import('~/test/logger-mock')).mockAuxxLogger())
 vi.mock('@auxx/lib/workflow-engine', () => ({
-  WorkflowEngine: class {
-    getNodeRegistry() {
-      return { initializeWithDefaults }
-    }
-    executeWorkflow = executeWorkflow
+  RedisWorkflowExecutionReporter: class {
+    constructor(readonly workflowRunId: string) {}
+  },
+}))
+vi.mock('@auxx/lib/workflows', () => ({
+  WorkflowExecutionService: class {
+    createRun = createRun
+    executeWorkflowAsync = executeWorkflowAsync
   },
 }))
 vi.mock('@auxx/lib/workflow-engine/types', () => ({
   WorkflowNodeType: { WEBHOOK: 'webhook' },
-  WorkflowTriggerType: { WEBHOOK: 'webhook' },
 }))
 vi.mock('~/components/workflow/utils/schema-to-variable', () => ({
   validateAgainstSchema: vi.fn(() => true),
@@ -87,10 +87,13 @@ vi.mock('~/components/workflow/utils/schema-to-variable', () => ({
 const { webhookTestArmKey, webhookTestEventsKey, WEBHOOK_TEST_WINDOW_TTL_SECONDS } = await import(
   '~/server/lib/webhook-test-window'
 )
+const { UsageLimitError } = await import('@auxx/lib/errors')
+const { WorkflowTriggerSource } = await import('@auxx/database/enums')
 const { GET, POST } = await import('./route')
 
 const WF_ID = 'wf_cuid0000000000000000000'
 const ORG_ID = 'org_cuid000000000000000000000'
+const RUN_ID = 'wfr_cuid00000000000000000'
 
 const webhookNode = (method: 'GET' | 'POST', body: string, statusCode: number) => ({
   nodes: [{ id: 'n1', data: { type: 'webhook', method, responseConfig: { body, statusCode } } }],
@@ -152,7 +155,8 @@ beforeEach(() => {
   redis.exists.mockClear()
   redis.lpush.mockClear()
   getRedisClient.mockClear()
-  executeWorkflow.mockClear()
+  createRun.mockClear().mockResolvedValue({ id: RUN_ID })
+  executeWorkflowAsync.mockClear().mockResolvedValue(undefined)
   findFirst.mockReset().mockResolvedValue(workflowApp)
 })
 
@@ -235,27 +239,7 @@ describe('the PUBLISHED path is unaffected — with and without a window', () =>
     const res = await POST(postRequest(false), params)
     expect(res.status).toBe(200)
     await expect(res.text()).resolves.toBe('PUBLISHED-BODY')
-    expect(executeWorkflow).toHaveBeenCalledTimes(1)
-  })
-
-  /**
-   * The payload, not just the call count. `WorkflowGraphBuilder.buildGraph`
-   * reads `workflow.graph || { nodes: [], edges: [] }` and nothing else, so a
-   * payload carrying only top-level `nodes`/`edges` — which is what this route
-   * sent until the fix — builds an EMPTY graph: no entry node, the engine
-   * throws, the run comes back FAILED, and the caller still gets the configured
-   * 200. `executeWorkflow` takes `any`, so only a test can hold this contract.
-   * The builder-side half of it lives in
-   * `workflow-graph-builder.test.ts` → "reads the graph off `workflow.graph`".
-   */
-  it('hands the engine a payload the graph builder can actually read', async () => {
-    await POST(postRequest(false), params)
-
-    const payload = executeWorkflow.mock.calls[0]?.[0] as {
-      graph?: { nodes?: unknown[]; edges?: unknown[] }
-    }
-    expect(payload.graph?.nodes).toHaveLength(1)
-    expect(payload.graph?.edges).toEqual([])
+    expect(executeWorkflowAsync).toHaveBeenCalledTimes(1)
   })
 
   it('behaves identically while a window IS armed', async () => {
@@ -263,7 +247,7 @@ describe('the PUBLISHED path is unaffected — with and without a window', () =>
     const res = await POST(postRequest(false), params)
     expect(res.status).toBe(200)
     await expect(res.text()).resolves.toBe('PUBLISHED-BODY')
-    expect(executeWorkflow).toHaveBeenCalledTimes(1)
+    expect(executeWorkflowAsync).toHaveBeenCalledTimes(1)
   })
 
   it('never consults the arm key when there is no `test` param', async () => {
@@ -301,6 +285,94 @@ describe('an unavailable Redis fails CLOSED', () => {
     redis.available = false
     const res = await POST(postRequest(false), params)
     expect(res.status).toBe(200)
-    expect(executeWorkflow).toHaveBeenCalledTimes(1)
+    expect(executeWorkflowAsync).toHaveBeenCalledTimes(1)
+  })
+})
+
+/**
+ * The production path used to hand-build a workflow object and call
+ * `WorkflowEngine.executeWorkflow` directly. That created NO `WorkflowRun` row,
+ * so a webhook execution was invisible: absent from run history, absent from the
+ * `workflowRuns` usage counter, and — because a run id is what a paused node
+ * resumes against — unresumable. Every other headless trigger (scheduled,
+ * resource, message, polling, app) already went through `createRun`; this route
+ * was the one door that did not.
+ */
+describe('a production webhook hit creates a real run', () => {
+  /**
+   * This replaces the old "hands the engine a payload the graph builder can
+   * actually read" assertion. That guarded #1764: the route sent top-level
+   * `nodes`/`edges` with no `graph` key, and `WorkflowGraphBuilder.buildGraph`
+   * reads `workflow.graph` and nothing else, so the engine built an EMPTY graph.
+   * The route no longer builds a payload at all — `createRun` loads the
+   * `Workflow` row itself — so the shape is not expressible any more. The
+   * builder-side half of that contract still lives in
+   * `workflow-graph-builder.test.ts` → "reads the graph off `workflow.graph`".
+   */
+  it('creates it through `createRun`, as a headless production run', async () => {
+    await POST(postRequest(false), params)
+
+    expect(createRun).toHaveBeenCalledTimes(1)
+    expect(createRun.mock.calls[0]?.[0]).toMatchObject({
+      workflowId: workflowApp.publishedWorkflow.id,
+      organizationId: ORG_ID,
+      mode: 'production',
+      // Headless — an external caller is not a user. `createWorkflowRun`
+      // resolves the org system user; a placeholder id here would violate the
+      // `WorkflowRun.createdBy` FK.
+      userId: null,
+      triggeredFrom: WorkflowTriggerSource.WEBHOOK,
+    })
+  })
+
+  it('passes the webhook envelope as the run inputs', async () => {
+    await POST(postRequest(false, { hello: 'world' }), params)
+
+    const { inputs } = createRun.mock.calls[0]?.[0] as { inputs: Record<string, unknown> }
+    expect(inputs).toMatchObject({ method: 'POST', body: { hello: 'world' } })
+    expect(inputs).toHaveProperty('headers')
+    expect(inputs).toHaveProperty('query')
+  })
+
+  it('executes THAT run, with a reporter bound to its id', async () => {
+    await POST(postRequest(false), params)
+
+    const [run, reporter] = executeWorkflowAsync.mock.calls[0] as [
+      { id: string },
+      { workflowRunId: string },
+    ]
+    expect(run.id).toBe(RUN_ID)
+    // No reporter at all was passed before, so a webhook run had no per-node trace.
+    expect(reporter.workflowRunId).toBe(RUN_ID)
+  })
+
+  it('a failed execution still answers the author’s configured response', async () => {
+    // `executeWorkflowAsync` records the failure on the run row before it
+    // rethrows. The sender still gets its contract — a non-2xx would make
+    // senders like Shopify or Stripe retry a request that fails again.
+    executeWorkflowAsync.mockRejectedValue(new Error('node blew up'))
+
+    const res = await POST(postRequest(false), params)
+    expect(res.status).toBe(200)
+    await expect(res.text()).resolves.toBe('PUBLISHED-BODY')
+  })
+
+  it('an org over its plan limit is refused, and nothing executes', async () => {
+    createRun.mockRejectedValue(
+      new UsageLimitError({ metric: 'workflowRuns', current: 100, limit: 100 })
+    )
+
+    const res = await POST(postRequest(false), params)
+    expect(res.status).toBe(403)
+    await expect(res.json()).resolves.toMatchObject({ error: expect.stringContaining('limit') })
+    expect(executeWorkflowAsync).not.toHaveBeenCalled()
+  })
+
+  it('the ?test=true path creates no run and consumes no quota', async () => {
+    arm()
+    const res = await POST(postRequest(true), params)
+    expect(res.status).toBe(201)
+    expect(createRun).not.toHaveBeenCalled()
+    expect(executeWorkflowAsync).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/components/workflow/parity/builder-engine-parity.test.ts
+++ b/apps/web/src/components/workflow/parity/builder-engine-parity.test.ts
@@ -16,6 +16,7 @@ import {
   advertisedPath,
   isPathWritten,
   isWriteAdvertised,
+  readDefaultHandleComparisons,
   readEngineContracts,
   readEngineRoutedHandleLiterals,
 } from './engine-write-scrape'
@@ -600,5 +601,52 @@ describe('branch handles — every handle the engine can emit is one the builder
       KNOWN_BROKEN_OUTPUT_HANDLES,
       EXTRACTION_BLIND_SPOTS
     )
+  })
+
+  /**
+   * The census that keeps the default-handle strip safe.
+   *
+   * `DEHYDRATION_OPTIONS` strips `sourceHandle: 'source'` / `targetHandle:
+   * 'target'` on save, so the stored column does not carry them. A strict
+   * `=== 'source'` has no tolerance for that absence — unlike `?? 'source'` —
+   * and only works because every engine path reads the array
+   * `WorkflowGraphBuilder.build()` hydrated and normalised.
+   *
+   * Both sites below read that normalised array. A new comparison anywhere in
+   * the core fails this test on purpose: adding one means saying which array it
+   * reads, and adding it here.
+   *
+   * The runtime half of this contract is
+   * `packages/lib/src/workflow-engine/core/__tests__/loop-handle-stripping.test.ts`,
+   * which fails if the hydration boundary itself is ever removed.
+   */
+  it('compares against a default handle only where the array is already normalised', () => {
+    const ALLOWED: Record<string, { count: number; why: string }> = {
+      'core/workflow-graph-builder.ts': {
+        count: 2,
+        why:
+          "both read `edges`, built at :197-204 with `edge.sourceHandle || 'source'` — " +
+          ':757 is the loop-exit warning, :1106 is the join-point execution-flow filter',
+      },
+    }
+
+    const unexpected: string[] = []
+    for (const [file, count] of readDefaultHandleComparisons()) {
+      const allowed = ALLOWED[file]
+      if (!allowed) {
+        unexpected.push(
+          `${file}: ${count} strict comparison(s) against a default handle. A stored edge may ` +
+            'omit its handle — read the array `WorkflowGraphBuilder.build()` normalised, or use ' +
+            "`?? 'source'`."
+        )
+      } else if (count !== allowed.count) {
+        unexpected.push(
+          `${file}: ${count} strict comparison(s), expected ${allowed.count} (${allowed.why}). ` +
+            'If the new one reads the normalised array, raise the count here and say so.'
+        )
+      }
+    }
+
+    expect(unexpected).toEqual([])
   })
 })

--- a/apps/web/src/components/workflow/parity/engine-write-scrape.ts
+++ b/apps/web/src/components/workflow/parity/engine-write-scrape.ts
@@ -1003,6 +1003,38 @@ export function isPathWritten(path: string, writes: string[]): boolean {
  * normal result-routing and prove nothing either way, so only string-literal
  * comparisons are collected.
  */
+/**
+ * Every strict comparison in the engine core against a DEFAULT handle literal —
+ * `sourceHandle === 'source'` or `targetHandle === 'target'`.
+ *
+ * These are the comparisons that break when a stored edge omits its handle,
+ * because `===` against a literal has no tolerance for absence the way
+ * `edge.sourceHandle ?? 'source'` does. `DEHYDRATION_OPTIONS` now strips default
+ * handles on save, so the column will increasingly NOT carry them, and the only
+ * reason these still work is that every engine path reaches the document
+ * through `WorkflowGraphBuilder.build()`, which hydrates the handles back in
+ * (pinned by `core/__tests__/loop-handle-stripping.test.ts`).
+ *
+ * A NEW comparison is therefore only safe if it reads the normalised array. The
+ * parity suite holds a per-file census so adding one has to come here and say
+ * which array it reads.
+ *
+ * Grouped by file, since line numbers drift with every edit and a count is the
+ * part that carries the signal.
+ */
+export function readDefaultHandleComparisons(): Map<string, number> {
+  const coreDir = join(ENGINE_ROOT, 'core')
+  const census = new Map<string, number>()
+  for (const path of listSources(coreDir)) {
+    const source = stripComments(readFileSync(path, 'utf8'))
+    const hits = [
+      ...source.matchAll(/\b(?:sourceHandle|targetHandle)\s*===\s*'(?:source|target)'/g),
+    ].length
+    if (hits > 0) census.set(path.replace(`${ENGINE_ROOT}/`, ''), hits)
+  }
+  return census
+}
+
 export function readEngineRoutedHandleLiterals(): Array<{ handle: string; file: string }> {
   const coreDir = join(ENGINE_ROOT, 'core')
   const lookups: Array<{ handle: string; file: string }> = []

--- a/apps/web/src/components/workflow/providers/workflow-save-provider.tsx
+++ b/apps/web/src/components/workflow/providers/workflow-save-provider.tsx
@@ -295,12 +295,12 @@ export function WorkflowSaveProvider({ children }: { children: React.ReactNode }
       // `graph` object, so posting the live camera would rewrite the authored
       // starting view on every save, and omitting the key would erase it.
       const authoredViewport = useWorkflowStore.getState().authoredViewport
-      // DEHYDRATION_OPTIONS is NOT optional here. Without it `skipDefaults`
-      // defaults to off, so the strip deletes every `node.data` key whose value
-      // equals its manifest default — while every server reader hydrates with
-      // `skipDefaults: true` and never puts it back. That silently amputates
-      // real config (`http.method`, `resource-trigger.operation`,
-      // `scheduled.config`, `wait.waitType`) on the first canvas save.
+      // DEHYDRATION_OPTIONS is NOT optional here — it is the shared policy every
+      // reader is paired with, and passing nothing means storing a differently
+      // shaped document from every other writer. It used to be worse than a
+      // shape difference: the option it carried deleted real config
+      // (`http.method`, `resource-trigger.operation`) on the first canvas save
+      // (#1770 → #1771). That layer is deleted; the pairing discipline is not.
       const stored = dehydrateGraph(
         {
           nodes: cleanNodes,

--- a/apps/web/src/components/workflow/utils/node-layout/node-factory.ts
+++ b/apps/web/src/components/workflow/utils/node-layout/node-factory.ts
@@ -66,19 +66,27 @@ export class NodeFactory {
       })
     }
 
-    // Create flattened node data structure
+    // Create flattened node data structure.
+    //
+    // `isValid: true` / `errors: []` / `selected: false` used to be stamped here
+    // too. Nothing ever read them and nothing ever updated them — they were
+    // `true`/`[]`/`false` on 138 of 138 stored nodes — so they were bytes in the
+    // column that carried no information. `dehydrateGraph` strips all three.
+    //
+    // `id`, `isInLoop` and `loopId` stay because this builds a node for the LIVE
+    // React Flow store, which is the hydrated working shape; hydration writes
+    // exactly these on the next load, and dehydration removes them on save.
     const nodeData = {
       // Core properties
       id: nodeId,
       desc: definition.description,
-      isValid: true,
-      errors: [],
       disabled: false,
       isInLoop,
       loopId,
+      // Derived (`_`-prefixed, never persisted) but LIVE: the handle components
+      // read them to decide whether a handle renders as connected.
       _connectedSourceHandleIds: [],
       _connectedTargetHandleIds: [],
-      selected: false,
       // Spread all merged data
       ...mergedData,
       // type must come after spread so defaultData.type can't overwrite the definition ID

--- a/apps/web/src/components/workflow/utils/save-baseline.ts
+++ b/apps/web/src/components/workflow/utils/save-baseline.ts
@@ -67,9 +67,9 @@ export const EMPTY_SAVE_BASELINE: WorkflowSaveBaseline = { graph: null, envText:
  * must land on the same string when they mean the same workflow.
  */
 export function projectGraph(graph: unknown): ProjectedGraph {
-  // Same policy as the write seam (see workflow-save-provider). A baseline
-  // built under a different `skipDefaults` than the payload would compare two
-  // different documents and either save constantly or never save at all.
+  // Same policy as the write seam (see workflow-save-provider). A baseline built
+  // under a different policy than the payload would compare two different
+  // documents and either save constantly or never save at all.
   const projection = projectGraphSemantics(
     dehydrateGraph((graph ?? {}) as GraphDocument, DEHYDRATION_OPTIONS)
   )

--- a/apps/web/src/server/api/routers/admin-workflow-templates.ts
+++ b/apps/web/src/server/api/routers/admin-workflow-templates.ts
@@ -1,14 +1,14 @@
 // apps/web/src/server/api/routers/admin-workflow-templates.ts
 
 import { getAppCache } from '@auxx/lib/cache'
-import { isFileTemplateId, listFileTemplates, normalizeTemplateGraph } from '@auxx/lib/workflows'
 import {
   createTemplate,
   deleteTemplate,
   duplicateTemplate,
   getAllTemplates,
   updateTemplate,
-} from '@auxx/services/workflow-templates'
+} from '@auxx/lib/workflow-templates'
+import { isFileTemplateId, listFileTemplates, normalizeTemplateGraph } from '@auxx/lib/workflows'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { recordAuditFromCtx } from '~/server/api/audit-context'

--- a/apps/web/src/server/api/routers/instance-grant-overrides-area-none.test.ts
+++ b/apps/web/src/server/api/routers/instance-grant-overrides-area-none.test.ts
@@ -193,7 +193,7 @@ vi.mock('@auxx/services/workflows', () => ({
   getWorkflowAppsByTrigger: vi.fn(async () => ({ isErr: () => false, value: [] })),
 }))
 
-vi.mock('@auxx/services/workflow-templates', () => ({
+vi.mock('@auxx/lib/workflow-templates', () => ({
   getAllTemplates: vi.fn(async () => ({ isErr: () => false, value: [] })),
   getTemplateById: vi.fn(async () => ({ isErr: () => false, value: null })),
 }))

--- a/apps/web/src/server/api/routers/workflow-arm-webhook-test.test.ts
+++ b/apps/web/src/server/api/routers/workflow-arm-webhook-test.test.ts
@@ -79,7 +79,7 @@ vi.mock('@auxx/lib/workflow-engine', () => ({
 }))
 
 vi.mock('@auxx/services/workflows', () => ({ getWorkflowAppsByTrigger: vi.fn(async () => []) }))
-vi.mock('@auxx/services/workflow-templates', () => ({
+vi.mock('@auxx/lib/workflow-templates', () => ({
   getAllTemplates: vi.fn(async () => ({ isErr: () => false, value: [] })),
   getTemplateById: vi.fn(async () => ({ isErr: () => false, value: null })),
 }))

--- a/apps/web/src/server/api/routers/workflow-instance-access.test.ts
+++ b/apps/web/src/server/api/routers/workflow-instance-access.test.ts
@@ -173,7 +173,7 @@ vi.mock('@auxx/lib/workflow-engine', () => ({
 }))
 
 vi.mock('@auxx/services/workflows', () => ({ getWorkflowAppsByTrigger }))
-vi.mock('@auxx/services/workflow-templates', () => ({
+vi.mock('@auxx/lib/workflow-templates', () => ({
   getAllTemplates: vi.fn(async () => ({ isErr: () => false, value: [] })),
   getTemplateById: vi.fn(async () => ({ isErr: () => false, value: null })),
 }))

--- a/apps/web/src/server/api/routers/workflow-kopilot-turn-review.test.ts
+++ b/apps/web/src/server/api/routers/workflow-kopilot-turn-review.test.ts
@@ -80,7 +80,7 @@ vi.mock('@auxx/lib/workflow-engine', () => ({
 }))
 
 vi.mock('@auxx/services/workflows', () => ({ getWorkflowAppsByTrigger: vi.fn(async () => []) }))
-vi.mock('@auxx/services/workflow-templates', () => ({
+vi.mock('@auxx/lib/workflow-templates', () => ({
   getAllTemplates: vi.fn(async () => ({ isErr: () => false, value: [] })),
   getTemplateById: vi.fn(async () => ({ isErr: () => false, value: null })),
 }))

--- a/apps/web/src/server/api/routers/workflow-templates.ts
+++ b/apps/web/src/server/api/routers/workflow-templates.ts
@@ -1,8 +1,8 @@
 // apps/web/src/server/api/routers/workflow-templates.ts
 
 import { getAppCache } from '@auxx/lib/cache'
+import { getAllTemplates } from '@auxx/lib/workflow-templates'
 import { checkEntityReadiness, listFileTemplates, type RequiredEntity } from '@auxx/lib/workflows'
-import { getAllTemplates } from '@auxx/services/workflow-templates'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc'

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1534,6 +1534,12 @@
       "import": "./dist/workflow-engine/utils/serialization.mjs",
       "default": "./src/workflow-engine/utils/serialization.ts"
     },
+    "./workflow-templates": {
+      "types": "./src/workflow-templates/index.ts",
+      "source": "./src/workflow-templates/index.ts",
+      "import": "./dist/workflow-templates/index.mjs",
+      "default": "./src/workflow-templates/index.ts"
+    },
     "./workflows": {
       "types": "./src/workflows/index.ts",
       "source": "./src/workflows/index.ts",

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/__tests__/workflow-authoring-guard.test.ts
@@ -127,7 +127,7 @@ vi.mock('../../../../../../demo', () => ({
   DemoGuard: { requireNotDemo: vi.fn(async () => {}) },
 }))
 
-vi.mock('@auxx/services/workflow-templates', () => ({
+vi.mock('../../../../../../workflow-templates', () => ({
   getAllTemplates: vi.fn(async () => ok([])),
 }))
 

--- a/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/find-workflow-templates.ts
+++ b/packages/lib/src/ai/kopilot/capabilities/workflow-builder/tools/find-workflow-templates.ts
@@ -55,7 +55,7 @@ export function createFindWorkflowTemplatesTool(getDeps: GetToolDeps): AgentTool
         triggerType: string | null
       }> = []
       try {
-        const { getAllTemplates } = await import('@auxx/services/workflow-templates')
+        const { getAllTemplates } = await import('../../../../../workflow-templates')
         const result = await getAllTemplates({
           ...(search ? { search } : {}),
           status: 'public',

--- a/packages/lib/src/workflow-engine/catalog/__tests__/graph-hydration.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/__tests__/graph-hydration.test.ts
@@ -31,6 +31,7 @@ import {
   hydrateGraph,
 } from '../graph-hydration'
 import { buildUpstreamMap, type EdgeMeta, type NodeMeta } from '../graph-vars'
+import { DEHYDRATION_OPTIONS } from '../hydration-policy'
 import { getManifest } from '../registry'
 
 // ── fixtures ────────────────────────────────────────────────────────────────
@@ -617,9 +618,20 @@ describe('the loop arm', () => {
   })
 })
 
-// ── the read-time defaults layer (§2.4) ─────────────────────────────────────
+// ── the read-time defaults layer: DELETED ──────────────────────────────────
 
-describe('the read-time defaults layer', () => {
+/**
+ * `23` §2.4's read-time `manifest.defaultData()` projection was built, never
+ * enabled, and is gone — see `hydration-policy.ts` for the two structural
+ * reasons (no single manifest lookup across seams; four non-deterministic
+ * `defaultData()`s) and `26-hydration-defaults-and-handles.md` for the full
+ * evaluation.
+ *
+ * What survives from that block is the part that was never about the layer: a
+ * node's stored data is the whole of its content, and an unresolvable node type
+ * passes through untouched.
+ */
+describe('stored data is the whole of a node’s content', () => {
   const stripped: GraphDocument = {
     nodes: [
       {
@@ -632,81 +644,32 @@ describe('the read-time defaults layer', () => {
     edges: [],
   }
 
-  it('layers `manifest.defaultData()` UNDER stored data on read', () => {
+  it('does not invent config a node never stored', () => {
+    // The layer used to answer `'contact'`/`'created'` here. It no longer does,
+    // and the resource-trigger panel's mount backfill is what fills these in —
+    // save-neutral, because plan 22's content guard sees no semantic change.
     const data = node(hydrateGraph(stripped), 't1').data!
-    expect(data.resourceType).toBe('contact')
-    expect(data.operation).toBe('created')
-    expect(data.filters).toEqual([])
-  })
-
-  it('never overrides an authored value', () => {
-    const authored = structuredClone(stripped)
-    authored.nodes[0]!.data!.resourceType = 'ticket'
-    authored.nodes[0]!.data!.operation = 'updated'
-    const data = node(hydrateGraph(authored), 't1').data!
-    expect(data.resourceType).toBe('ticket')
-    expect(data.operation).toBe('updated')
-  })
-
-  it('does NOT persist a defaulted value — a default is a read-time projection, never a write', () => {
-    // NOTE: this exercises the defaults layer ON, which is the layer's own unit
-    // contract — NOT the shipped configuration. Every seam runs
-    // `skipDefaults: true` (`hydration-policy.ts`), so in production neither
-    // half of this happens. The pairing that actually ships is pinned by
-    // `hydration-policy-pairing.test.ts`; running the two halves under
-    // DIFFERENT policies is what silently amputated node config in #1771.
-    const stored = dehydrateGraph(hydrateGraph(stripped))
-    const data = node(stored, 't1').data!
     expect(data).not.toHaveProperty('resourceType')
     expect(data).not.toHaveProperty('operation')
     expect(data).not.toHaveProperty('filters')
-    // …and the reader still sees them.
-    expect(node(hydrateGraph(stored), 't1').data?.resourceType).toBe('contact')
   })
 
-  it('leaves `entityDefinitionId` alone — resolving it needs the org, not a guess', () => {
-    // The panel backfill this layer retires falls back to
-    // `currentResourceData?.entityDefinitionId || resourceType`. That fallback
-    // is deliberately NOT ported: for a custom entity `resourceType` is a slug
-    // (`entity_vendors`) while `entityDefinitionId` is a CUID, and this module
-    // has no resource list. Guessing would write a bogus
-    // `Workflow.entityDefinitionId` through `deriveTriggerColumns`.
-    expect(node(hydrateGraph(stripped), 't1').data).not.toHaveProperty('entityDefinitionId')
-  })
-
-  it('keeps an authored `entityDefinitionId` through the round trip', () => {
+  it('round-trips an authored value unchanged even when it equals a manifest default', () => {
+    // THE regression that made the layer's inverse unsafe: `resource-trigger`'s
+    // default operation is `'created'`, so a user who CHOSE "created" was
+    // byte-identical to one who never chose, and the strip deleted the key —
+    // dropping `Workflow.triggerType` to a value no dispatcher matches.
     const authored = structuredClone(stripped)
+    authored.nodes[0]!.data!.resourceType = 'contact'
+    authored.nodes[0]!.data!.operation = 'created'
     authored.nodes[0]!.data!.entityDefinitionId = 'clq1abc123'
-    const stored = dehydrateGraph(hydrateGraph(authored))
-    expect(node(stored, 't1').data?.entityDefinitionId).toBe('clq1abc123')
-  })
 
-  it('never layers `title`, `desc` or a derived key out of defaultData()', () => {
-    // `title` is the ADDRESS Kopilot resolves a node by, `desc` is validated as
-    // required by two manifests, and `if-else`'s defaultData() ships
-    // `_targetBranches` whose authority is `connection.branches(config)`.
-    const graph: GraphDocument = {
-      nodes: [
-        {
-          id: 'x',
-          type: 'standard',
-          position: { x: 0, y: 0 },
-          data: { id: 'x', type: 'if-else', title: 'Route' },
-        },
-      ],
-      edges: [],
-    }
-    const data = node(hydrateGraph(graph), 'x').data!
-    expect(data.title).toBe('Route')
-    expect(data).not.toHaveProperty('desc')
-    expect(data).not.toHaveProperty('_targetBranches')
-    expect(data).not.toHaveProperty('description')
-  })
-
-  it('is skippable, for a read-modify-write data migration', () => {
-    expect(node(hydrateGraph(stripped, { skipDefaults: true }), 't1').data).not.toHaveProperty(
-      'resourceType'
-    )
+    const stored = dehydrateGraph(hydrateGraph(authored), DEHYDRATION_OPTIONS)
+    expect(node(stored, 't1').data).toMatchObject({
+      resourceType: 'contact',
+      operation: 'created',
+      entityDefinitionId: 'clq1abc123',
+    })
   })
 
   it('leaves a node type it cannot resolve untouched', () => {
@@ -833,13 +796,14 @@ describe('dehydrateGraph must NOT strip', () => {
     expect(out.edges[0]).not.toHaveProperty('data')
   })
 
-  it('an authored value that happens to EQUAL its manifest default reads back unchanged', () => {
-    // Dehydration does drop it from the column — the exact inverse of the
-    // read-time defaults layer, which is what keeps a stored document canonical.
-    // "No reader can tell" holds ONLY because both halves here run under the
-    // same policy. Under the shipped `skipDefaults: true` neither half runs; a
-    // reader on the other policy very much can tell, which is #1771. See
-    // `hydration-policy-pairing.test.ts`.
+  it('an authored value that happens to EQUAL its manifest default', () => {
+    // The read-time defaults layer used to drop this key on the theory that no
+    // reader could tell. Readers could: "the user chose the default" and "the
+    // user chose nothing" are different facts, and collapsing them is what
+    // amputated a real row in #1771. Authored config is kept, full stop.
+    //
+    // `document-extractor`'s `sourceType` is also the name-collision trap:
+    // `edge.data.sourceType` IS derived, `node.data.sourceType` is authored.
     const graph: GraphDocument = {
       nodes: [
         {
@@ -851,9 +815,8 @@ describe('dehydrateGraph must NOT strip', () => {
       ],
       edges: [],
     }
-    const stored = dehydrateGraph(hydrateGraph(graph))
-    expect(stored.nodes[0]?.data).not.toHaveProperty('sourceType')
-    expect(hydrateGraph(stored).nodes[0]?.data?.sourceType).toBe('file')
+    const stored = dehydrateGraph(hydrateGraph(graph), DEHYDRATION_OPTIONS)
+    expect(stored.nodes[0]?.data?.sourceType).toBe('file')
   })
 
   it('`node.data.position` on form-input — a fractional run-form ORDER key, not a coordinate', () => {

--- a/packages/lib/src/workflow-engine/catalog/__tests__/hydration-policy-pairing.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/__tests__/hydration-policy-pairing.test.ts
@@ -1,17 +1,24 @@
 // packages/lib/src/workflow-engine/catalog/__tests__/hydration-policy-pairing.test.ts
 //
 // The pairing rule: `hydrateGraph` and `dehydrateGraph` MUST run under the same
-// `skipDefaults` policy on both sides of the wire.
+// policy on both sides of the wire.
 //
 // This exists because they did not. `workflow-save-provider.tsx` called
-// `dehydrateGraph(...)` with no options, so `skipDefaults` defaulted to OFF and
-// the strip deleted every `node.data` key whose value equalled its manifest
-// default — while every server reader hydrates with `skipDefaults: true` and
+// `dehydrateGraph(...)` with no options, so the read-time defaults layer's
+// inverse ran and deleted every `node.data` key whose value equalled its
+// manifest default — while every server reader hydrated with the layer OFF and
 // never put them back. An HTTP node stored as `{desc, title, type, url}` fails
-// `httpNodeConfigSchema.safeParse` (`method`/`body`/`authorization` have no zod
-// default), and a resource-trigger lost `operation`, which drops
-// `deriveTriggerColumns` to the generic `'resource-trigger'` that no dispatcher
-// matches — i.e. the workflow silently stops firing.
+// `httpNodeConfigSchema.safeParse`, and a resource-trigger lost `operation`,
+// which drops `deriveTriggerColumns` to the generic `'resource-trigger'` that no
+// dispatcher matches — i.e. the workflow silently stops firing.
+//
+// That layer is now deleted (`hydration-policy.ts` has the epitaph), so the
+// specific asymmetry is unrepresentable. The pairing rule outlived it: the
+// policy still carries `stripDefaultHandles`, and a caller that dehydrates
+// under a different policy than the reader hydrates under is still a bug. These
+// tests hold the surviving contract — a canvas round trip loses no authored
+// config, and the trigger columns still derive after one.
+
 import { describe, expect, it } from 'vitest'
 import { deriveTriggerColumns } from '../derive-trigger'
 import { dehydrateGraph, type GraphDocument, hydrateGraph } from '../graph-hydration'
@@ -64,22 +71,55 @@ describe('hydrate/dehydrate policy pairing', () => {
     expect(after).toMatchObject({ triggerType: 'created', entityDefinitionId: 'contact' })
   })
 
-  it('MISMATCHED policies are what caused the loss — pinned so the hazard stays visible', () => {
+  it('an UNPAIRED dehydrate is still a hazard — the handles, now that the defaults are gone', () => {
+    // The surviving half of the rule. `dehydrateGraph`'s own parameter default
+    // preserves handles (so a read-modify-write data migration sees stored
+    // bytes); `DEHYDRATION_OPTIONS` strips them. A writer that skips the shared
+    // policy therefore stores a document a different shape from every other
+    // writer's — harmless for handles specifically, because hydration restores
+    // them either way, but it is the same class of divergence that cost a row
+    // in #1771. Pinned so the asymmetry is visible rather than surprising.
     const { node } = canvasNode('http')
-
-    // Browser dehydrating with defaults ON, server reading with them OFF.
-    const mismatched = dehydrateGraph(
-      hydrateGraph({ nodes: [node], edges: [] } as never),
-      undefined
+    const hydrated = hydrateGraph(
+      {
+        nodes: [node],
+        edges: [{ id: 'e', source: 'http-1', target: 'http-1' }],
+      } as unknown as GraphDocument,
+      HYDRATION_OPTIONS
     )
-    const asServerSeesIt = hydrateGraph(mismatched, HYDRATION_OPTIONS)
-    const data = (asServerSeesIt.nodes[0] as { data: Record<string, unknown> }).data
 
-    expect(data).not.toHaveProperty('method')
-    expect(data).not.toHaveProperty('body')
+    const unpaired = dehydrateGraph(hydrated)
+    const paired = dehydrateGraph(hydrated, DEHYDRATION_OPTIONS)
 
-    // ...and the paired policy keeps them.
-    const paired = hydrateGraph(saveRoundTrip(node), HYDRATION_OPTIONS)
-    expect((paired.nodes[0] as { data: Record<string, unknown> }).data).toHaveProperty('method')
+    expect((unpaired.edges[0] as { sourceHandle?: string }).sourceHandle).toBe('source')
+    expect(paired.edges[0]).not.toHaveProperty('sourceHandle')
+
+    // Either way the config survives — that is what the deleted layer broke.
+    for (const stored of [unpaired, paired]) {
+      expect((stored.nodes[0] as { data: Record<string, unknown> }).data).toHaveProperty('method')
+    }
+  })
+
+  it('a canvas save keeps every non-default handle', () => {
+    // Non-default handles are CONTENT: branch ids, case ids, `loop-start`,
+    // `loop-back`, `fail`. 64 of 130 bundled-template edges carry one.
+    const { node } = canvasNode('if-else')
+    const withBranches = dehydrateGraph(
+      hydrateGraph(
+        {
+          nodes: [node],
+          edges: [
+            { id: 'e1', source: 'if-else-1', target: 'if-else-1', sourceHandle: 'case_abc' },
+            { id: 'e2', source: 'if-else-1', target: 'if-else-1', sourceHandle: 'false' },
+            { id: 'e3', source: 'if-else-1', target: 'if-else-1', targetHandle: 'loop-back' },
+          ],
+        } as unknown as GraphDocument,
+        HYDRATION_OPTIONS
+      ),
+      DEHYDRATION_OPTIONS
+    )
+    const handles = withBranches.edges.map((e) => (e as { sourceHandle?: string }).sourceHandle)
+    expect(handles).toEqual(['case_abc', 'false', undefined])
+    expect((withBranches.edges[2] as { targetHandle?: string }).targetHandle).toBe('loop-back')
   })
 })

--- a/packages/lib/src/workflow-engine/catalog/graph-hydration.ts
+++ b/packages/lib/src/workflow-engine/catalog/graph-hydration.ts
@@ -57,8 +57,6 @@
  */
 
 import { DEFAULT_SOURCE_HANDLE, DEFAULT_TARGET_HANDLE } from './graph-vars'
-import { getManifest } from './registry'
-import type { ManifestLookup } from './types'
 
 /** `data.type` of the container node whose children carry loop context. */
 const LOOP_TYPE = 'loop'
@@ -116,50 +114,46 @@ export interface GraphDocument {
   [key: string]: unknown
 }
 
-/** Options for {@link hydrateGraph}. */
-export interface HydrateGraphOptions {
-  /**
-   * How a node type resolves to its manifest, for the read-time defaults layer
-   * (§2.4). Defaults to the core registry, which answers for the ~29 platform
-   * types and nothing else.
-   *
-   * Pass `buildManifestLookup(...)` wherever app workflow blocks are visible.
-   * Omitting it does not produce a *wrong* default — an unresolved type simply
-   * gets no defaults layered, exactly as today — but it does mean an app
-   * block's declared defaults are invisible at that seam.
-   */
-  manifests?: ManifestLookup
-  /**
-   * Skip the read-time defaults layer entirely. For callers that must observe
-   * the stored bytes (a data migration doing read-modify-write).
-   */
-  skipDefaults?: boolean
-}
+/**
+ * Options for {@link hydrateGraph}.
+ *
+ * Empty on purpose. This carried a `manifests` lookup and a `skipDefaults`
+ * switch for a read-time `defaultData()` projection that was built, never
+ * enabled, and is now deleted — see `hydration-policy.ts` for why the premise
+ * was false. The interface stays so the signature does not churn if hydration
+ * ever needs a real option.
+ */
+// biome-ignore lint/suspicious/noEmptyInterface: named seam, see the doc above
+export interface HydrateGraphOptions {}
 
 /** Options for {@link dehydrateGraph}. */
 export interface DehydrateGraphOptions {
-  /** Same lookup as {@link HydrateGraphOptions.manifests}, for the defaults layer. */
-  manifests?: ManifestLookup
-  /** Mirror of {@link HydrateGraphOptions.skipDefaults} — keeps the pair symmetric. */
-  skipDefaults?: boolean
   /**
    * Drop `sourceHandle === 'source'` / `targetHandle === 'target'`, since
    * hydration restores them.
    *
-   * **DEFAULT `false`, AND IT MUST STAY FALSE UNTIL ONE ENGINE READER IS
-   * FIXED** (plan 23 §1.1 last row, §3.2 HR-1).
-   * `core/loop-execution-manager.ts:396-398` resolves the next node inside a
-   * loop body with
+   * **The FUNCTION default stays `false`; `DEHYDRATION_OPTIONS` turns it ON.**
+   * That asymmetry is deliberate: a data migration doing read-modify-write must
+   * keep seeing the stored bytes (`data-migrations/migrations/083-*.ts:17` says
+   * so in its own header), so byte-preservation is what you get by omission and
+   * the strip is what you get by opting into the shared policy.
    *
-   * ```ts
-   * const outputHandle = result.outputHandle || 'source'
-   * workflow.graph.edges.filter(e => e.source === node.nodeId && e.sourceHandle === outputHandle)
-   * ```
+   * Plan `23` originally blocked this on `core/loop-execution-manager.ts:398`,
+   * which resolves the next node inside a loop body with a strict
+   * `edge.sourceHandle === outputHandle` and no `?? 'source'` on the edge side.
+   * That comparison is safe, and always was: it filters
+   * `currentWorkflow.graph.edges`, which is `built.workflow.graph.edges`
+   * (`workflow-engine.ts:182`), which is `processedEdges` derived from
+   * `hydrateGraph`'s output at `workflow-graph-builder.ts:160`. Handles are
+   * filled before any routing runs. The independent proof is that
+   * sequence-compiled graphs have never written `sourceHandle` at all and 870
+   * such nodes execute in production.
    *
-   * — a strict comparison against the **raw** edge array, with no `?? 'source'`
-   * on the edge side. An edge that omits `sourceHandle` therefore matches
-   * nothing and the loop body silently ends after one node. 720 stored edges
-   * already omit it, so this is a live shape, not a hypothetical.
+   * Two tests hold that up, and both must keep passing:
+   * `core/__tests__/loop-handle-stripping.test.ts` walks a three-node loop body
+   * whose stored edges carry no handles (it fails if the hydration boundary is
+   * removed), and the parity suite's default-handle census fails if any new
+   * strict comparison appears in the engine core.
    *
    * Non-default handles are CONTENT and are never stripped at any flag
    * setting: if-else `case_id`s, text-classifier category ids, `loop-start`,
@@ -230,29 +224,6 @@ const DERIVED_EDGE_DATA_KEYS = [
 ] as const
 
 /**
- * Keys the read-time defaults layer never touches, whatever a manifest's
- * `defaultData()` returns.
- *
- * - `id` / `type` are identity, derived above.
- * - `title` is the ADDRESS Kopilot resolves nodes by (`formatNodeRef`), and
- *   `desc` is validated as *required* by `text-classifier.ts:229` and
- *   `if-else.ts:187`. Both are authored content (§1.3). Layering a manifest
- *   string under them would mean an edit to a manifest blurb silently
- *   rewriting every stored node's description.
- * - `description` is the vestigial alias §2.2 deletes; never resurrect it.
- * - the {@link DEAD_NODE_DATA_KEYS} are strip-and-do-NOT-re-derive, and
- *   several manifests still mint them in `defaultData()`.
- */
-const DEFAULTS_EXCLUDED_KEYS = new Set<string>([
-  'id',
-  'type',
-  'title',
-  'desc',
-  'description',
-  ...DEAD_NODE_DATA_KEYS,
-])
-
-/**
  * A stored row is not guaranteed to have both arrays: hydration sits at read
  * boundaries the engine and the builder both go through, and §4 is explicit
  * that a missed/malformed reader must degrade, never throw. A graph with no
@@ -277,55 +248,6 @@ function effectiveNodeType(node: GraphNodeDocument): string {
   const dataType = node.data?.type
   if (typeof dataType === 'string' && dataType.length > 0) return dataType
   return typeof node.type === 'string' ? node.type : ''
-}
-
-/** Structural deep equality, enough for JSON graph values. */
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true
-  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false
-  if (Array.isArray(a) !== Array.isArray(b)) return false
-  if (Array.isArray(a) && Array.isArray(b)) {
-    return a.length === b.length && a.every((item, index) => deepEqual(item, b[index]))
-  }
-  const left = a as Record<string, unknown>
-  const right = b as Record<string, unknown>
-  const leftKeys = Object.keys(left)
-  if (leftKeys.length !== Object.keys(right).length) return false
-  return leftKeys.every((key) => key in right && deepEqual(left[key], right[key]))
-}
-
-/**
- * The read-time default projection for one node type: `defaultData()` minus
- * everything {@link DEFAULTS_EXCLUDED_KEYS} and every derived key.
- *
- * `if-else`'s `defaultData()` ships `_targetBranches`; layering that in would
- * persist a stale branch list under a name whose authority is
- * `connection.branches(config)`.
- */
-function readTimeDefaults(
-  type: string,
-  lookup: ManifestLookup,
-  cache: Map<string, Record<string, unknown>>
-): Record<string, unknown> {
-  const cached = cache.get(type)
-  if (cached) return cached
-  let defaults: Record<string, unknown> = {}
-  try {
-    const manifest = lookup(type)
-    const raw = (manifest?.defaultData() ?? {}) as Record<string, unknown>
-    defaults = Object.fromEntries(
-      Object.entries(raw).filter(
-        ([key, value]) =>
-          value !== undefined && !DEFAULTS_EXCLUDED_KEYS.has(key) && !isDerivedKey(key)
-      )
-    )
-  } catch {
-    // A manifest whose defaults throw must never break a read. No defaults is
-    // a degradation; a thrown load boundary is an outage.
-    defaults = {}
-  }
-  cache.set(type, defaults)
-  return defaults
 }
 
 /**
@@ -385,7 +307,6 @@ function calculateZIndex(
  * | `edge.data.isLoopBackEdge` | `targetHandle === 'loop-back'` ∨ source parented in the target loop |
  * | `edge.zIndex` | `calculateZIndex` |
  * | `edge.sourceHandle` / `targetHandle` | the defaults, when absent |
- * | every unset `node.data` config key | `manifest.defaultData()`, layered UNDER stored data |
  *
  * **Hydration is AUTHORITATIVE over that set**: a stale stored value it cannot
  * re-derive is *deleted*, not preserved. That is what makes `dehydrateGraph`
@@ -401,16 +322,13 @@ function calculateZIndex(
  * changing.
  *
  * @param graph a stored (or already-hydrated) graph document
- * @param options manifest lookup for the defaults layer; see {@link HydrateGraphOptions}
+ * @param options see {@link HydrateGraphOptions} — currently empty
  * @returns a new graph — the input is never mutated
  */
 export function hydrateGraph<G extends GraphDocument>(
   graph: G,
   options: HydrateGraphOptions = {}
 ): G {
-  const lookup = options.manifests ?? getManifest
-  const defaultsCache = new Map<string, Record<string, unknown>>()
-
   const normalized = nodesOf(graph).map(normalizeLegacyAppTrigger)
 
   // Which containers are loops — read from `data.type`, the same rule
@@ -433,29 +351,25 @@ export function hydrateGraph<G extends GraphDocument>(
     }
     const type = effectiveNodeType(node)
 
-    // The defaults layer (§2.4): a default is a READ-TIME PROJECTION, never a
-    // write. Layered UNDER stored data, so anything authored always wins. This
-    // is what retires the resource-trigger panel's mount backfill and the app
-    // node's `appId`/`blockId` persist.
-    const layered: Record<string, unknown> =
-      options.skipDefaults === true
-        ? data
-        : { ...readTimeDefaults(type, lookup, defaultsCache), ...data }
+    // Stored data is the whole of a node's content — nothing is layered under
+    // it. Everything below this line is a DERIVATION the canvas and the engine
+    // would otherwise each recompute for themselves.
+    const content: Record<string, unknown> = data
 
-    layered.id = node.id
-    if (type.length > 0) layered.type = type
+    content.id = node.id
+    if (type.length > 0) content.type = type
 
     const loopId =
       node.parentId !== undefined && loopNodeIds.has(node.parentId) ? node.parentId : undefined
     if (loopId !== undefined) {
-      layered.isInLoop = true
-      layered.loopId = loopId
+      content.isInLoop = true
+      content.loopId = loopId
     } else {
-      delete layered.isInLoop
-      delete layered.loopId
+      delete content.isInLoop
+      delete content.loopId
     }
 
-    const hydrated: GraphNodeDocument = { ...node, data: layered }
+    const hydrated: GraphNodeDocument = { ...node, data: content }
     // Only when a type is actually known. A node carrying no type at either
     // level must not acquire one here — inventing `'standard'` would make
     // `dehydrate ∘ hydrate` unstable, since the next dehydration has no
@@ -575,24 +489,12 @@ export function dehydrateGraph<G extends GraphDocument>(
   graph: G,
   options: DehydrateGraphOptions = {}
 ): G {
-  const lookup = options.manifests ?? getManifest
-  const defaultsCache = new Map<string, Record<string, unknown>>()
-
   const nodes = nodesOf(graph).map((node) => {
     const type = effectiveNodeType(node)
     const data = stripLevel({ ...(node.data ?? {}) })
 
     for (const key of DERIVED_NODE_DATA_KEYS) delete data[key]
     for (const key of DEAD_NODE_DATA_KEYS) delete data[key]
-
-    // Exact inverse of hydration's defaults layer: a key whose value IS the
-    // manifest default is not content, and hydration will put it back.
-    if (options.skipDefaults !== true) {
-      const defaults = readTimeDefaults(type, lookup, defaultsCache)
-      for (const [key, value] of Object.entries(defaults)) {
-        if (key in data && deepEqual(data[key], value)) delete data[key]
-      }
-    }
 
     const stored = stripLevel(node) as GraphNodeDocument
     for (const key of EPHEMERAL_OBJECT_KEYS) delete stored[key]

--- a/packages/lib/src/workflow-engine/catalog/hydration-policy.ts
+++ b/packages/lib/src/workflow-engine/catalog/hydration-policy.ts
@@ -7,37 +7,47 @@ import type { DehydrateGraphOptions, HydrateGraphOptions } from './graph-hydrati
  * one constant so the two halves can never disagree, and so the decision below
  * has exactly one place to be reversed.
  *
- * ## Why the read-time defaults layer is OFF
- *
- * `plans/kopilot/workflow/23-graph-document-canonicalization.md` §2.4 wants
- * `manifest.defaultData()` layered under stored data at read, so a default is a
- * projection rather than a panel write. The hydrator implements it; this
- * rollout does not turn it on, for three reasons:
- *
- * 1. **It is not behaviour-neutral, and §6 phase 1 depends on that.** The read
- *    side ships before the write side precisely because hydration is a no-op
- *    against today's documents. With defaults layered it is not: a legacy `ai`
- *    or `crud` node carrying no `error_strategy` gains one, and
- *    `WorkflowGraphBuilder.getNodeHandles` then registers a `fail` handle the
- *    node never had — changing fork/join accounting on stored workflows.
- * 2. **The inverse of the layer deletes load-bearing stored keys.**
- *    `resource-trigger`'s `defaultData()` is `operation: 'created'`, so
- *    dehydration would strip `operation` from every stored resource trigger —
- *    and `deriveTriggerColumns`, which runs inside `persistDraft` over the
- *    CLEANED graph, sets `Workflow.triggerType`/`entityDefinitionId` only when
- *    BOTH `operation` and `entityDefinitionId` are present. The column would
- *    fall back to `'resource-trigger'`, which no dispatcher matches, and every
- *    resource-triggered workflow would silently stop firing. The same shape of
- *    hazard applies to any server-side derivation that reads the stored column
- *    without hydrating — and there are several.
- * 3. **Its beneficiaries are not in this change.** §2.4 exists to retire the
- *    resource-trigger and app-node panel backfills, which live in `apps/web`.
- *    Shipping the layer without them changes behaviour for no payoff.
- *
- * Turning it on is therefore its own step: retire the panel backfills, make
- * every stored-column derivation hydrate first, and re-run the §6 invariants.
+ * The read side has no options left. See {@link DEHYDRATION_OPTIONS} for the
+ * one decision that remains, and for the epitaph of the one that was removed.
  */
-export const HYDRATION_OPTIONS: HydrateGraphOptions = { skipDefaults: true }
+export const HYDRATION_OPTIONS: HydrateGraphOptions = {}
 
-/** The write-side mirror of {@link HYDRATION_OPTIONS} — the two MUST stay symmetric. */
-export const DEHYDRATION_OPTIONS: DehydrateGraphOptions = { skipDefaults: true }
+/**
+ * The write-side policy: strip handles that equal their default, because
+ * {@link hydrateGraph} restores them.
+ *
+ * Safe because every engine path reaches the document through
+ * `WorkflowGraphBuilder.build()`, which hydrates before anything routes. Two
+ * tests hold that up — `core/__tests__/loop-handle-stripping.test.ts` (a
+ * three-node loop body whose stored edges carry no handles) and the parity
+ * suite's default-handle census. `dehydrateGraph`'s own parameter default stays
+ * `false` so a data migration doing read-modify-write still sees stored bytes.
+ *
+ * ## The read-time defaults layer, and why it is gone
+ *
+ * `plans/kopilot/workflow/23-graph-document-canonicalization.md` §2.4 wanted
+ * `manifest.defaultData()` layered under stored data at read, so a default
+ * would be a projection rather than a panel write. It was built, never enabled,
+ * and is now deleted. `plans/kopilot/workflow/26-hydration-defaults-and-handles.md`
+ * has the full evaluation; the two structural reasons, neither of which is the
+ * "schema question" it was first diagnosed as:
+ *
+ * 1. **There is no single answer to "what is the default for this type."**
+ *    Kopilot resolves manifests through a per-org `buildManifestLookup(orgId)`
+ *    that sees app blocks; the browser, engine, org cache and public API use
+ *    the core registry, which does not. An app block's `defaultData()` returns
+ *    its `appId`/`appSlug`/`blockId`, so one writer would strip identity keys
+ *    that no reader could put back.
+ * 2. **Four manifests' `defaultData()` is not a pure function of the type.**
+ *    `scheduled` reads the ambient `Intl` timezone — different in a browser and
+ *    in a UTC worker — and three others mint a `generateId()`. A layer whose
+ *    projection differs per process cannot be an inverse of anything.
+ *
+ * It also had no beneficiary left: the two panel backfills §2.4 existed to
+ * retire both write keys the layer structurally cannot restore, and plan `22`'s
+ * content guard already makes those writes save-neutral.
+ *
+ * Enabling it once, briefly, stripped load-bearing config off a real row
+ * (#1770 → #1771). Do not rebuild it without answering both points above.
+ */
+export const DEHYDRATION_OPTIONS: DehydrateGraphOptions = { stripDefaultHandles: true }

--- a/packages/lib/src/workflow-engine/catalog/node-base.ts
+++ b/packages/lib/src/workflow-engine/catalog/node-base.ts
@@ -103,6 +103,14 @@ export interface NodeLoopContext {
 /**
  * Base data structure for all workflow nodes.
  * apps/web extends this with `type: NodeType` (its enum narrowing).
+ *
+ * `isValid`, `errors`, `outputVariables` and `selected` used to live here. All
+ * four were dead: `isValid`/`errors` were hardcoded `true`/`[]` by both writers
+ * and updated by nothing (138 of 138 stored nodes), `outputVariables` is
+ * answered by the manifest's `resolveOutputs`, and `data.selected` had zero
+ * readers repo-wide — React Flow owns selection at `node.selected`.
+ * `dehydrateGraph` strips all four, so declaring them here only invited a
+ * writer to keep minting them.
  */
 export interface BaseNodeData extends NodeRuntimeState, NodeLoopContext {
   // Core properties
@@ -115,13 +123,7 @@ export interface BaseNodeData extends NodeRuntimeState, NodeLoopContext {
   icon?: string
   color?: string
 
-  // Validation state
-  isValid?: boolean
-  errors?: string[]
   disabled?: boolean
-
-  // Output tracking
-  outputVariables?: string[]
 
   // Credential connection
   credentialId?: string | null
@@ -129,9 +131,6 @@ export interface BaseNodeData extends NodeRuntimeState, NodeLoopContext {
   // Error handling
   errorStrategy?: ErrorHandleType
   retryConfig?: WorkflowRetryConfig
-
-  // Selection state (from NodeHandleProps)
-  selected: boolean
 
   // Additional properties for React Flow compatibility
   [key: string]: any
@@ -152,13 +151,7 @@ export const baseNodeDataSchema = z.object({
   icon: z.string().optional(),
   color: z.string().optional(),
 
-  // Validation state
-  isValid: z.boolean().optional(),
-  errors: z.array(z.string()).optional(),
   disabled: z.boolean().optional(),
-
-  // Output tracking
-  outputVariables: z.array(z.string()).optional(),
 
   // Error handling
   errorStrategy: z.enum(ErrorHandleType).optional(),
@@ -169,9 +162,6 @@ export const baseNodeDataSchema = z.object({
       backoffMultiplier: z.number().optional(),
     })
     .optional(),
-
-  // Selection state
-  selected: z.boolean().default(false),
 
   collapsed: z.boolean().optional(),
 

--- a/packages/lib/src/workflow-engine/catalog/nodes/resource-trigger.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/resource-trigger.ts
@@ -129,10 +129,7 @@ export function createResourceTriggerDefaultData(
     desc: `Triggered when a record is ${operation}`,
     icon: getResourceTriggerIcon(resourceType, operation),
     variables: [],
-    isValid: true,
-    errors: [],
     disabled: false,
-    outputVariables: [],
     resourceType,
     operation: operation as 'created' | 'updated' | 'deleted' | 'manual',
     // No filter = fire on every record. The engine reads this key.

--- a/packages/lib/src/workflow-engine/core/__tests__/loop-handle-stripping.test.ts
+++ b/packages/lib/src/workflow-engine/core/__tests__/loop-handle-stripping.test.ts
@@ -1,0 +1,134 @@
+// packages/lib/src/workflow-engine/core/__tests__/loop-handle-stripping.test.ts
+//
+// THE invariant that makes `stripDefaultHandles` safe: the engine hydrates
+// before it routes.
+//
+// `LoopExecutionManager.resolveNextNodeForLoop` matches
+// `edge.sourceHandle === outputHandle` with `outputHandle` defaulting to
+// `'source'` — a strict comparison against a literal, with no `?? 'source'` on
+// the edge side. So an edge that stores NO `sourceHandle` at all is invisible
+// to it, and a loop body ends after its first node.
+//
+// That is not hypothetical: 720 stored edges omit the handle, and
+// sequence-compiled graphs have never written one. It works today only because
+// the array that comparison reads — `currentWorkflow.graph.edges` — is
+// `hydrateGraph`'s output, filled at `WorkflowGraphBuilder.build()`. Nothing
+// asserted that, which is why plan `23` left the strip disabled.
+//
+// This test is the assertion. It passes with the strip on or off; it fails if
+// anyone removes the hydration boundary at `workflow-graph-builder.ts:160-166`,
+// or adds a loop path that reads a stored row directly.
+//
+// Teeth verified by hand while writing: commenting out that `hydrateGraph` call
+// makes the three-node walk stop after one node.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ExecutionContextManager } from '../execution-context'
+import { LoopExecutionManager, type NodeExecutionCallback } from '../loop-execution-manager'
+import type { WorkflowExecutionOptions, WorkflowNode } from '../types'
+import { NodeRunningStatus } from '../types'
+import { WorkflowGraphBuilder } from '../workflow-graph-builder'
+
+/** A canvas/stored node — `data.type` only, no engine `type` field. */
+const storedNode = (id: string, type: string) => ({
+  id,
+  position: { x: 0, y: 0 },
+  data: { type, title: id },
+})
+
+/**
+ * The stored document, in the shape the column actually holds: the two handles
+ * that CARRY meaning (`loop-start`, `loop-back`) are written, and every edge
+ * that would default is simply absent — no `sourceHandle`, no `targetHandle`.
+ *
+ * loop-1 --loop-start--> body-1 -> body-2 -> body-3 --loop-back--> loop-1
+ */
+const storedWorkflow = {
+  id: 'wf-1',
+  organizationId: 'org-1',
+  name: 'Loop over three body nodes',
+  version: 1,
+  graph: {
+    nodes: [
+      storedNode('loop-1', 'loop'),
+      storedNode('body-1', 'code'),
+      storedNode('body-2', 'code'),
+      storedNode('body-3', 'code'),
+    ],
+    edges: [
+      { id: 'e1', source: 'loop-1', target: 'body-1', sourceHandle: 'loop-start' },
+      { id: 'e2', source: 'body-1', target: 'body-2' },
+      { id: 'e3', source: 'body-2', target: 'body-3' },
+      { id: 'e4', source: 'body-3', target: 'loop-1', targetHandle: 'loop-back' },
+    ],
+  },
+}
+
+describe('default handles survive the engine because build() hydrates', () => {
+  let manager: LoopExecutionManager
+  let executeNodeCallback: ReturnType<typeof vi.fn>
+  let contextManager: ExecutionContextManager
+
+  beforeEach(() => {
+    executeNodeCallback = vi.fn(async (node: WorkflowNode) => ({
+      nodeId: node.nodeId,
+      status: NodeRunningStatus.Succeeded,
+      output: { nodeId: node.nodeId },
+      executionTime: 1,
+    }))
+    manager = new LoopExecutionManager(executeNodeCallback as unknown as NodeExecutionCallback)
+    contextManager = new ExecutionContextManager('wf-1', 'exec-1', 'org-1', 'user-1')
+  })
+
+  it('fills every absent handle, so the routing comparison has something to match', () => {
+    const { workflow } = WorkflowGraphBuilder.build(storedWorkflow)
+
+    for (const edge of workflow.graph?.edges ?? []) {
+      expect(edge.sourceHandle, `edge ${edge.id} sourceHandle`).toBeDefined()
+      expect(edge.targetHandle, `edge ${edge.id} targetHandle`).toBeDefined()
+    }
+    // ...and the authored ones are not overwritten by the fill.
+    const byId = new Map((workflow.graph?.edges ?? []).map((e) => [e.id, e]))
+    expect(byId.get('e1')?.sourceHandle).toBe('loop-start')
+    expect(byId.get('e4')?.targetHandle).toBe('loop-back')
+  })
+
+  it('walks a three-node body whose edges stored no handles at all', async () => {
+    const { workflow } = WorkflowGraphBuilder.build(storedWorkflow)
+    const loopNode = workflow.nodes?.find((n) => n.nodeId === 'loop-1')
+    expect(loopNode).toBeDefined()
+
+    // The loop processor is what invokes the injected body callback; drive it
+    // directly so this test is about routing, not about loop-item resolution.
+    const processor: {
+      preprocessNode: ReturnType<typeof vi.fn>
+      execute: ReturnType<typeof vi.fn>
+      executeLoopBodyCallback?: (
+        node: WorkflowNode,
+        ctx: ExecutionContextManager
+      ) => Promise<unknown>
+    } = {
+      preprocessNode: vi.fn().mockResolvedValue({}),
+      execute: vi.fn().mockImplementation(async () => {
+        if (!processor.executeLoopBodyCallback) {
+          throw new Error('executeLoopBodyCallback was not injected onto the processor')
+        }
+        return processor.executeLoopBodyCallback(loopNode as WorkflowNode, contextManager)
+      }),
+    }
+
+    await manager.setupLoopExecution(
+      loopNode as WorkflowNode,
+      processor as never,
+      contextManager,
+      {} as WorkflowExecutionOptions,
+      workflow
+    )
+
+    // The failure mode this guards: body-1 executes, `resolveNextNodeForLoop`
+    // finds no edge whose `sourceHandle` equals `'source'`, and the body ends
+    // one node in. All three must run.
+    const executed = executeNodeCallback.mock.calls.map((c) => (c[0] as WorkflowNode).nodeId)
+    expect(executed).toEqual(['body-1', 'body-2', 'body-3'])
+  })
+})

--- a/packages/lib/src/workflow-templates/__tests__/canonicalize.test.ts
+++ b/packages/lib/src/workflow-templates/__tests__/canonicalize.test.ts
@@ -1,0 +1,127 @@
+// packages/lib/src/workflow-templates/__tests__/canonicalize.test.ts
+//
+// `WorkflowTemplate.graph` is one of the five graph storage locations (plan 23
+// §3.4) and was the last one with no opinion about what it may contain. Its
+// read boundary — `resolveTemplateById` — hydrates, the admin editor renders
+// THAT into its JSON textarea, and Save posts the textarea straight back. So
+// without a write-side canonicalizer, opening a clean template and pressing
+// Save was enough to store derived state as if an author had written it, and
+// "Export to file" turned the same blob into a committable `*.template.json`.
+
+import { describe, expect, it } from 'vitest'
+import { type GraphDocument, hydrateGraph } from '../../workflow-engine/catalog/graph-hydration'
+import { HYDRATION_OPTIONS } from '../../workflow-engine/catalog/hydration-policy'
+import { canonicalizeTemplateGraph } from '../canonicalize'
+
+/** A canonical stored template graph: authored config only. */
+const canonical = {
+  nodes: [
+    {
+      id: 'webhook-1',
+      position: { x: 0, y: 0 },
+      data: { type: 'webhook', title: 'Webhook', method: 'POST' },
+    },
+    {
+      id: 'end-1',
+      position: { x: 300, y: 0 },
+      data: { type: 'end', title: 'End', status: 'success' },
+    },
+  ],
+  // No handles: the defaults are stripped on write and restored on read.
+  edges: [{ id: 'e1', source: 'webhook-1', target: 'end-1' }],
+} as unknown as GraphDocument
+
+describe('canonicalizeTemplateGraph', () => {
+  it('undoes exactly what the read boundary added — the editor round trip', () => {
+    // What the admin editor is handed, and therefore what Save posts back.
+    const asTheEditorSeesIt = hydrateGraph(canonical, HYDRATION_OPTIONS)
+
+    expect(canonicalizeTemplateGraph(asTheEditorSeesIt)).toEqual(canonical)
+  })
+
+  it('is a no-op on a graph that is already canonical', () => {
+    // Idempotence is what makes it safe to run at every writer unconditionally,
+    // including on rows written before it existed.
+    expect(canonicalizeTemplateGraph(canonical)).toEqual(canonical)
+    expect(canonicalizeTemplateGraph(canonicalizeTemplateGraph(canonical))).toEqual(canonical)
+  })
+
+  it('strips the canvas state a builder export carries', () => {
+    // The §1 complaint in file form: a super-admin pastes a graph copied out of
+    // the builder. `selected: true` is not inert — React Flow replays it from a
+    // mount effect, which opens a panel and re-centres the canvas.
+    const builderExport = {
+      nodes: [
+        {
+          id: 'webhook-1',
+          type: 'standard',
+          position: { x: 0, y: 0 },
+          selected: true,
+          dragging: false,
+          width: 320,
+          height: 96,
+          data: {
+            type: 'webhook',
+            title: 'Webhook',
+            method: 'POST',
+            id: 'webhook-1',
+            isValid: true,
+            errors: [],
+          },
+        },
+      ],
+      edges: [],
+    } as unknown as GraphDocument
+
+    const stored = canonicalizeTemplateGraph(builderExport) as {
+      nodes: {
+        type?: unknown
+        selected?: unknown
+        width?: unknown
+        data: Record<string, unknown>
+      }[]
+    }
+
+    expect(stored.nodes[0]).not.toHaveProperty('selected')
+    expect(stored.nodes[0]).not.toHaveProperty('dragging')
+    expect(stored.nodes[0]).not.toHaveProperty('type')
+    expect(stored.nodes[0]?.data).not.toHaveProperty('isValid')
+    expect(stored.nodes[0]?.data).not.toHaveProperty('errors')
+    expect(stored.nodes[0]?.data).not.toHaveProperty('id')
+    // ...while the authored config survives untouched. `width`/`height` are
+    // authored too — `handleNodeResize` writes a container size a user chose —
+    // so they are deliberately KEPT, not canvas state.
+    expect(stored.nodes[0]?.data).toMatchObject({ type: 'webhook', method: 'POST' })
+    expect(stored.nodes[0]?.width).toBe(320)
+  })
+
+  it('strips a default handle and keeps every authored one', () => {
+    const hydrated = hydrateGraph(
+      {
+        nodes: [{ id: 'a', position: { x: 0, y: 0 }, data: { type: 'if-else' } }],
+        edges: [
+          { id: 'e1', source: 'a', target: 'a' },
+          { id: 'e2', source: 'a', target: 'a', sourceHandle: 'case_abc' },
+          { id: 'e3', source: 'a', target: 'a', targetHandle: 'loop-back' },
+        ],
+      } as unknown as GraphDocument,
+      HYDRATION_OPTIONS
+    )
+
+    const stored = canonicalizeTemplateGraph(hydrated) as {
+      edges: { sourceHandle?: string; targetHandle?: string }[]
+    }
+    // A default handle is not content — hydration restores it at every reader.
+    expect(stored.edges[0]).not.toHaveProperty('sourceHandle')
+    expect(stored.edges[0]).not.toHaveProperty('targetHandle')
+    // A branch id is. 64 of 130 bundled-template edges carry one; stripping
+    // those would destroy every branch route in the fleet.
+    expect(stored.edges[1]?.sourceHandle).toBe('case_abc')
+    expect(stored.edges[2]?.targetHandle).toBe('loop-back')
+  })
+
+  it('passes a non-object through — a null column, or "leave this field alone"', () => {
+    expect(canonicalizeTemplateGraph(undefined)).toBeUndefined()
+    expect(canonicalizeTemplateGraph(null)).toBeNull()
+  })
+})

--- a/packages/lib/src/workflow-templates/canonicalize.ts
+++ b/packages/lib/src/workflow-templates/canonicalize.ts
@@ -1,0 +1,32 @@
+// packages/lib/src/workflow-templates/canonicalize.ts
+
+import { dehydrateGraph, type GraphDocument } from '../workflow-engine/catalog/graph-hydration'
+import { DEHYDRATION_OPTIONS } from '../workflow-engine/catalog/hydration-policy'
+
+/**
+ * Canonicalize a template graph on its way into `WorkflowTemplate.graph`.
+ *
+ * This is the template half of what `persistDraft` does for `Workflow.graph`
+ * (plan 23 §4.2): every read boundary hydrates, so every write boundary must
+ * dehydrate under the paired policy or the derived keys hydration added get
+ * stored as if an author had written them.
+ *
+ * It is not hypothetical. `resolveTemplateById` hydrates, the admin editor
+ * renders THAT graph into its JSON textarea, and Save posts the textarea back —
+ * so before this existed, merely opening a clean template and saving it wrote
+ * `node.type: 'standard'`, `edge.data.sourceType`/`targetType`, filled handles,
+ * `selected`, `width`/`height` and a 16-digit-zoom viewport into the row. The
+ * same graph is what "Export to file" serialises into a `*.template.json` a
+ * developer then commits, which is how a fat blob becomes permanent.
+ *
+ * Dehydration is idempotent, so running it on an already-canonical graph is a
+ * no-op — that is what makes it safe to apply unconditionally at every writer.
+ *
+ * @param graph - A graph in any shape: hydrated, canonical, or absent.
+ * @returns The canonical stored form, or the input untouched when it is not an
+ *   object (a null column, or a caller passing `undefined` to mean "leave it").
+ */
+export function canonicalizeTemplateGraph<T>(graph: T): T {
+  if (graph == null || typeof graph !== 'object') return graph
+  return dehydrateGraph(graph as unknown as GraphDocument, DEHYDRATION_OPTIONS) as unknown as T
+}

--- a/packages/lib/src/workflow-templates/create-template.ts
+++ b/packages/lib/src/workflow-templates/create-template.ts
@@ -1,8 +1,9 @@
-// packages/services/src/workflow-templates/create-template.ts
+// packages/lib/src/workflow-templates/create-template.ts
 
 import { database, schema } from '@auxx/database'
+import { fromDatabase } from '@auxx/services/shared/utils'
 import { ok } from 'neverthrow'
-import { fromDatabase } from '../shared/utils'
+import { canonicalizeTemplateGraph } from './canonicalize'
 import type { CreateWorkflowTemplateInput, WorkflowTemplateDetail } from './types'
 
 /**
@@ -21,7 +22,7 @@ export async function createTemplate(input: CreateWorkflowTemplateInput) {
         categories: input.categories,
         imgUrl: input.imgUrl,
         icon: input.icon ?? null,
-        graph: input.graph,
+        graph: canonicalizeTemplateGraph(input.graph),
         version: input.version ?? 1,
         status: input.status ?? 'private',
         triggerType: input.triggerType,

--- a/packages/lib/src/workflow-templates/delete-template.ts
+++ b/packages/lib/src/workflow-templates/delete-template.ts
@@ -1,9 +1,9 @@
-// packages/services/src/workflow-templates/delete-template.ts
+// packages/lib/src/workflow-templates/delete-template.ts
 
 import { database, schema } from '@auxx/database'
+import { fromDatabase } from '@auxx/services/shared/utils'
 import { eq } from 'drizzle-orm'
 import { ok } from 'neverthrow'
-import { fromDatabase } from '../shared/utils'
 
 /**
  * Delete a workflow template

--- a/packages/lib/src/workflow-templates/duplicate-template.ts
+++ b/packages/lib/src/workflow-templates/duplicate-template.ts
@@ -1,8 +1,9 @@
-// packages/services/src/workflow-templates/duplicate-template.ts
+// packages/lib/src/workflow-templates/duplicate-template.ts
 
 import { database, schema } from '@auxx/database'
+import { fromDatabase } from '@auxx/services/shared/utils'
 import { ok } from 'neverthrow'
-import { fromDatabase } from '../shared/utils'
+import { canonicalizeTemplateGraph } from './canonicalize'
 import { getTemplateById } from './get-template-by-id'
 import type { WorkflowTemplateDetail } from './types'
 
@@ -31,7 +32,7 @@ export async function duplicateTemplate(id: string) {
         description: original.description,
         categories: original.categories,
         imgUrl: original.imgUrl,
-        graph: original.graph,
+        graph: canonicalizeTemplateGraph(original.graph),
         version: 1,
         status: 'private',
         triggerType: original.triggerType,

--- a/packages/lib/src/workflow-templates/get-all-templates.ts
+++ b/packages/lib/src/workflow-templates/get-all-templates.ts
@@ -1,9 +1,9 @@
-// packages/services/src/workflow-templates/get-all-templates.ts
+// packages/lib/src/workflow-templates/get-all-templates.ts
 
 import { database, schema } from '@auxx/database'
+import { fromDatabase } from '@auxx/services/shared/utils'
 import { and, desc, eq, ilike, or, sql } from 'drizzle-orm'
 import { ok } from 'neverthrow'
-import { fromDatabase } from '../shared/utils'
 import type { GetWorkflowTemplatesInput, WorkflowTemplateListItem } from './types'
 
 /**

--- a/packages/lib/src/workflow-templates/get-template-by-id.ts
+++ b/packages/lib/src/workflow-templates/get-template-by-id.ts
@@ -1,9 +1,9 @@
-// packages/services/src/workflow-templates/get-template-by-id.ts
+// packages/lib/src/workflow-templates/get-template-by-id.ts
 
 import { database, schema } from '@auxx/database'
+import { fromDatabase } from '@auxx/services/shared/utils'
 import { eq } from 'drizzle-orm'
 import { err, ok } from 'neverthrow'
-import { fromDatabase } from '../shared/utils'
 import type { WorkflowTemplateDetail } from './types'
 
 /**

--- a/packages/lib/src/workflow-templates/index.ts
+++ b/packages/lib/src/workflow-templates/index.ts
@@ -1,5 +1,6 @@
-// packages/services/src/workflow-templates/index.ts
+// packages/lib/src/workflow-templates/index.ts
 
+export { canonicalizeTemplateGraph } from './canonicalize'
 export { createTemplate } from './create-template'
 export { deleteTemplate } from './delete-template'
 export { duplicateTemplate } from './duplicate-template'

--- a/packages/lib/src/workflow-templates/types.ts
+++ b/packages/lib/src/workflow-templates/types.ts
@@ -1,4 +1,4 @@
-// packages/services/src/workflow-templates/types.ts
+// packages/lib/src/workflow-templates/types.ts
 
 /**
  * Input for querying workflow templates

--- a/packages/lib/src/workflow-templates/update-template.ts
+++ b/packages/lib/src/workflow-templates/update-template.ts
@@ -1,9 +1,10 @@
-// packages/services/src/workflow-templates/update-template.ts
+// packages/lib/src/workflow-templates/update-template.ts
 
 import { database, schema } from '@auxx/database'
+import { fromDatabase } from '@auxx/services/shared/utils'
 import { eq } from 'drizzle-orm'
 import { err, ok } from 'neverthrow'
-import { fromDatabase } from '../shared/utils'
+import { canonicalizeTemplateGraph } from './canonicalize'
 import type { UpdateWorkflowTemplateInput, WorkflowTemplateDetail } from './types'
 
 /**
@@ -22,7 +23,7 @@ export async function updateTemplate(input: UpdateWorkflowTemplateInput) {
   if (input.categories !== undefined) updateData.categories = input.categories
   if (input.imgUrl !== undefined) updateData.imgUrl = input.imgUrl
   if (input.icon !== undefined) updateData.icon = input.icon
-  if (input.graph !== undefined) updateData.graph = input.graph
+  if (input.graph !== undefined) updateData.graph = canonicalizeTemplateGraph(input.graph)
   if (input.version !== undefined) updateData.version = input.version
   if (input.status !== undefined) updateData.status = input.status
   if (input.triggerType !== undefined) updateData.triggerType = input.triggerType

--- a/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
@@ -477,11 +477,11 @@ describe('deleteNodes — reconnect bridging', () => {
     expect(result.isOk()).toBe(true)
     const persisted = persistedGraph()
     expect(persisted.edges).toHaveLength(1)
-    expect(persisted.edges[0]).toMatchObject({
-      source: TRIGGER_ID,
-      sourceHandle: 'source',
-      target: endId,
-    })
+    expect(persisted.edges[0]).toMatchObject({ source: TRIGGER_ID, target: endId })
+    // The bridge lands on the DEFAULT source handle, which the stored document
+    // does not spell out — `DEHYDRATION_OPTIONS` strips it and hydration puts it
+    // back. A non-default handle (a branch, a case id) would still be here.
+    expect(persisted.edges[0]).not.toHaveProperty('sourceHandle')
   })
 })
 
@@ -1601,11 +1601,15 @@ describe('app blocks — authoring (§5 B3 checkpoint)', () => {
       resource: 'record',
       operation: 'archive',
     })
-    // A plain downstream edge on the default source handle — app blocks
-    // declare no branches.
-    expect(persistedGraph().edges).toContainEqual(
-      expect.objectContaining({ source: APP_WAIT_ID, sourceHandle: 'source', target: added?.id })
+    // A plain downstream edge on the default source handle — app blocks declare
+    // no branches — so the stored edge carries no `sourceHandle` at all. The
+    // minted edge id still records which handle it was wired on.
+    const appEdge = persistedGraph().edges.find(
+      (e) => e.source === APP_WAIT_ID && e.target === added?.id
     )
+    expect(appEdge).toBeDefined()
+    expect(appEdge).not.toHaveProperty('sourceHandle')
+    expect(appEdge?.id).toContain('-source-')
   })
 
   it('refuses a node whose operation the block does not offer', async () => {

--- a/packages/lib/src/workflows/graph-edit/ops.ts
+++ b/packages/lib/src/workflows/graph-edit/ops.ts
@@ -293,10 +293,7 @@ async function runGraphMutation(
   // must not be short-circuited by an unchanged *graph*.
   const touchesOnlyGraph =
     plan.envVars === undefined && plan.variables === undefined && plan.icon === undefined
-  if (
-    touchesOnlyGraph &&
-    hashWorkflowGraph(cleanGraphForSave(graph, ctx.lookup)) === ctx.canonicalGraphHash
-  ) {
+  if (touchesOnlyGraph && hashWorkflowGraph(cleanGraphForSave(graph)) === ctx.canonicalGraphHash) {
     const unchangedNode = plan.touchedNodeId
       ? graph.nodes.find((n) => n.id === plan.touchedNodeId)
       : undefined
@@ -325,7 +322,6 @@ async function runGraphMutation(
 
   const persisted = await persistDraft(db, scope, {
     graph,
-    manifests: ctx.lookup,
     ...(ctx.graphHash !== undefined ? { expectedGraphHash: ctx.graphHash } : {}),
     fallbackTriggerType:
       plan.fallbackTriggerType !== undefined ? plan.fallbackTriggerType : ctx.triggerType,
@@ -582,13 +578,14 @@ function buildNodeData(
   config: Record<string, unknown>,
   extras: { title: string; loopId?: string }
 ): Record<string, unknown> {
+  // No `isValid`/`errors`/`selected`: they were `true`/`[]`/`false` on every
+  // stored node, nothing ever updated them, and `dehydrateGraph` strips all
+  // three on the way to the column. Minting them here only meant the agent's
+  // in-memory graph disagreed with the one it was about to write.
   return {
     id: nodeId,
     desc: manifest.description,
-    isValid: true,
-    errors: [],
     disabled: false,
-    selected: false,
     ...(extras.loopId ? { isInLoop: true, loopId: extras.loopId } : {}),
     ...(manifest.defaultData() as Record<string, unknown>),
     ...config,

--- a/packages/lib/src/workflows/graph-edit/persist.ts
+++ b/packages/lib/src/workflows/graph-edit/persist.ts
@@ -30,7 +30,6 @@ import { AuxxError, NotFoundError, UnprocessableEntityError } from '../../errors
 import { deriveTriggerColumns } from '../../workflow-engine/catalog/derive-trigger'
 import { dehydrateGraph, type GraphDocument } from '../../workflow-engine/catalog/graph-hydration'
 import { DEHYDRATION_OPTIONS } from '../../workflow-engine/catalog/hydration-policy'
-import type { ManifestLookup } from '../../workflow-engine/catalog/types'
 import { hashGraphSemantics } from '../graph-hash'
 import type { WorkflowTriggerType, WorkflowUpdateInput } from '../types'
 import type { GraphEditScope } from './read'
@@ -49,17 +48,9 @@ import type { DraftGraph, GraphEdge, GraphNode } from './types'
  * counts as an edit) plus the keys that never held information
  * (`isValid`/`errors`/`data.selected`/`outputVariables`).
  *
- * `lookup` must be the SAME manifest lookup the matching `hydrateGraph` used
- * (`ops.ts` passes `ctx.lookup`): the two calls have to see one vocabulary of
- * node types, or the pair stops being an exact inverse for app-block nodes.
- * It is inert while `DEHYDRATION_OPTIONS` keeps the defaults layer off, and
- * load-bearing the moment it is turned on.
  */
-export function cleanGraphForSave(graph: DraftGraph, lookup?: ManifestLookup): DraftGraph {
-  const stored = dehydrateGraph(graph as unknown as GraphDocument, {
-    ...DEHYDRATION_OPTIONS,
-    ...(lookup ? { manifests: lookup } : {}),
-  })
+export function cleanGraphForSave(graph: DraftGraph): DraftGraph {
+  const stored = dehydrateGraph(graph as unknown as GraphDocument, DEHYDRATION_OPTIONS)
   return {
     nodes: stored.nodes as unknown as GraphNode[],
     edges: stored.edges as unknown as GraphEdge[],
@@ -70,12 +61,6 @@ export function cleanGraphForSave(graph: DraftGraph, lookup?: ManifestLookup): D
 /** What a mutation hands the persist seam. */
 export interface PersistDraftInput {
   graph: DraftGraph
-  /**
-   * Manifest lookup for {@link cleanGraphForSave}. Pass the same one the graph
-   * was hydrated with (`DraftContext.lookup`); omitting it falls back to the
-   * core registry, which answers for the platform types and nothing else.
-   */
-  manifests?: ManifestLookup
   /** Optional WorkflowApp metadata to atomically restore with a failed AI turn. */
   name?: string
   description?: string | null
@@ -124,11 +109,19 @@ export async function persistDraft(
   scope: GraphEditScope,
   input: PersistDraftInput
 ): Promise<Result<PersistDraftOutcome, AuxxError>> {
-  const graph = cleanGraphForSave(input.graph, input.manifests)
+  // Derive the trigger columns from the HYDRATED graph, BEFORE the clean step.
+  //
+  // Order matters and this is the order the two other writers already use
+  // (`create-from-template.ts:105-124`, `workflow-save-provider.tsx:283`).
+  // `deriveTriggerColumns` sets the columns only when a resource trigger has
+  // BOTH `operation` and `entityDefinitionId`, so any future strip that removes
+  // either key from the cleaned document would drop `Workflow.triggerType` to
+  // the generic `'resource-trigger'` — which no dispatcher matches, meaning
+  // every resource-triggered workflow silently stops firing. Deriving first
+  // makes this seam indifferent to what the strip does.
+  const derived = deriveTriggerColumns(input.graph.nodes)
 
-  // Re-derive the trigger columns from the graph being written — the exact
-  // derivation (and fallbacks) the canvas save posts.
-  const derived = deriveTriggerColumns(graph.nodes)
+  const graph = cleanGraphForSave(input.graph)
   const triggerType = derived.triggerType ?? input.fallbackTriggerType ?? undefined
   // `null` is the explicit clear: a graph with no resource trigger must not
   // leave a stale entity id next to the new trigger type.

--- a/packages/lib/src/workflows/graph-edit/read.ts
+++ b/packages/lib/src/workflows/graph-edit/read.ts
@@ -99,18 +99,13 @@ export interface GraphEditScope {
  * Kopilot read boundary (plan 23 §4.2).
  *
  * {@link hydrateGraph} does the array guards itself, so a malformed row still
- * degrades to an empty document rather than throwing. The org-scoped `lookup`
- * is passed so this seam resolves an installed app block's type the same way
- * the canvas does, rather than seeing only the ~29 platform manifests.
+ * degrades to an empty document rather than throwing.
  *
  * ORDER (plan 23 §3.2): `loadDraftContext` mints `graphHash` from the RAW
  * column, never from this result — see the comment at its call site.
  */
-function toDraftGraph(raw: unknown, lookup: ManifestLookup): DraftGraph {
-  const graph = hydrateGraph((raw ?? {}) as GraphDocument, {
-    ...HYDRATION_OPTIONS,
-    manifests: lookup,
-  })
+function toDraftGraph(raw: unknown): DraftGraph {
+  const graph = hydrateGraph((raw ?? {}) as GraphDocument, HYDRATION_OPTIONS)
   return {
     nodes: graph.nodes as unknown as DraftGraph['nodes'],
     edges: graph.edges as unknown as DraftGraph['edges'],
@@ -143,7 +138,7 @@ export async function loadDraftContext(
   // The CAS token is minted from the RAW column and re-checked against the raw
   // column inside `WorkflowService.update`'s transaction (plan 23 §3.2). It
   // must never be taken from the hydrated `graph` below.
-  const graph = toDraftGraph(rawGraph, lookup)
+  const graph = toDraftGraph(rawGraph)
   return ok({
     workflowAppId,
     organizationId,
@@ -154,10 +149,7 @@ export async function loadDraftContext(
     ...(rawGraph ? { graphHash: hashWorkflowGraph(rawGraph) } : {}),
     // The no-op short-circuit's baseline — see `DraftContext.canonicalGraphHash`.
     canonicalGraphHash: hashWorkflowGraph(
-      dehydrateGraph(graph as unknown as GraphDocument, {
-        ...DEHYDRATION_OPTIONS,
-        manifests: lookup,
-      })
+      dehydrateGraph(graph as unknown as GraphDocument, DEHYDRATION_OPTIONS)
     ),
     triggerType: (draftRow?.triggerType as string | null | undefined) ?? null,
     lookup,

--- a/packages/lib/src/workflows/graph-edit/turn-snapshot.ts
+++ b/packages/lib/src/workflows/graph-edit/turn-snapshot.ts
@@ -379,7 +379,7 @@ export async function revertWorkflowTurn(
   // "the canvas moved on" for every Undo. Running the write seam's own cleanup
   // first puts both sides in the same shape.
   const liveSemanticHash = loaded.value.graph
-    ? hashGraphSemantics(cleanGraphForSave(loaded.value.graph, loaded.value.lookup))
+    ? hashGraphSemantics(cleanGraphForSave(loaded.value.graph))
     : undefined
   if (
     snapshot.postTurnGraphSemanticHash !== undefined &&
@@ -398,7 +398,6 @@ export async function revertWorkflowTurn(
 
   const persisted = await persistDraft(db, scope, {
     graph: snapshot.graph,
-    manifests: loaded.value.lookup,
     fallbackTriggerType: snapshot.triggerType,
     name: snapshot.name,
     description: snapshot.description,

--- a/packages/lib/src/workflows/resolve-template.ts
+++ b/packages/lib/src/workflows/resolve-template.ts
@@ -1,8 +1,8 @@
 // packages/lib/src/workflows/resolve-template.ts
 
-import { getTemplateById, type WorkflowTemplateDetail } from '@auxx/services/workflow-templates'
 import { type GraphDocument, hydrateGraph } from '../workflow-engine/catalog/graph-hydration'
 import { HYDRATION_OPTIONS } from '../workflow-engine/catalog/hydration-policy'
+import { getTemplateById, type WorkflowTemplateDetail } from '../workflow-templates'
 import { normalizeTemplateGraph } from './normalize-template-graph'
 import { getFileTemplateById, isFileTemplateId } from './templates'
 

--- a/packages/lib/src/workflows/templates/index.ts
+++ b/packages/lib/src/workflows/templates/index.ts
@@ -3,10 +3,7 @@
 // truth) and merged at read time with admin-created templates from the DB — they
 // are never written to the database. See plans/templates/file-and-admin-templates-plan.md.
 
-import type {
-  WorkflowTemplateDetail,
-  WorkflowTemplateListItem,
-} from '@auxx/services/workflow-templates'
+import type { WorkflowTemplateDetail, WorkflowTemplateListItem } from '../../workflow-templates'
 import { normalizeTemplateGraph } from '../normalize-template-graph'
 import fulfillmentFollowUp from './fulfillment-follow-up.template.json'
 import informationExtractionAutoReply from './information-extraction-auto-reply.template.json'

--- a/packages/lib/src/workflows/workflow-execution-service.ts
+++ b/packages/lib/src/workflows/workflow-execution-service.ts
@@ -126,6 +126,12 @@ export async function createWorkflowRun(
     error?: string
     finishedAt?: Date
     elapsedTime?: number
+    /**
+     * What started this run. Defaults from `mode` — `APP_RUN` in production,
+     * `DEBUGGING` in test. Doors that are neither (a webhook hit, a public
+     * share) pass their own so run history can tell them apart.
+     */
+    triggeredFrom?: (typeof WorkflowTriggerSource)[keyof typeof WorkflowTriggerSource]
   }
 ) {
   const { workflow, organizationId, inputs, mode, userId } = params
@@ -176,7 +182,8 @@ export async function createWorkflowRun(
       sequenceNumber,
       type: workflow.triggerType || WorkflowTriggerType.MANUAL,
       triggeredFrom:
-        mode === 'production' ? WorkflowTriggerSource.APP_RUN : WorkflowTriggerSource.DEBUGGING,
+        params.triggeredFrom ??
+        (mode === 'production' ? WorkflowTriggerSource.APP_RUN : WorkflowTriggerSource.DEBUGGING),
       version: workflow.version.toString(),
       graph: workflow.graph || {},
       inputs,
@@ -289,6 +296,8 @@ export class WorkflowExecutionService {
     organizationId: string
     userEmail?: string
     userName?: string
+    /** See {@link createWorkflowRun}. Omit unless this door is neither an app run nor a debug run. */
+    triggeredFrom?: (typeof WorkflowTriggerSource)[keyof typeof WorkflowTriggerSource]
   }): Promise<CreatedWorkflowRun> {
     const { workflowId, inputs, mode, userId, organizationId } = params
 
@@ -312,6 +321,7 @@ export class WorkflowExecutionService {
       inputs,
       mode,
       userId,
+      triggeredFrom: params.triggeredFrom,
     })
   }
 

--- a/packages/lib/src/workflows/workflow-service.ts
+++ b/packages/lib/src/workflows/workflow-service.ts
@@ -397,22 +397,22 @@ export class WorkflowService {
           id: nodeId,
           type: 'standard',
           position: { x: 0, y: 0 },
+          // Authored content only — this writes straight to the column, so it
+          // must already be in the shape `dehydrateGraph` would produce.
+          // `selected`, `isValid`, `errors`, `outputVariables` are dead keys the
+          // strip removes, and `description` is the vestigial `desc` alias no
+          // TypeScript interface declares and nothing reads.
           data: {
             id: nodeId,
             type: 'resource-trigger',
-            selected: false,
             resourceType: resource.id,
             entityDefinitionId,
             operation: 'manual',
             title: `${label} Manual`,
             desc: `Triggered manually on a ${label.toLowerCase()}`,
-            description: `Triggered manually on a ${label.toLowerCase()}`,
             icon: 'Play',
             variables: [],
-            isValid: true,
-            errors: [],
             disabled: false,
-            outputVariables: [],
           },
         },
       ],


### PR DESCRIPTION
Three related pieces of the draft-save / graph-document arc (`plans/kopilot/workflow/HANDOFF-save-path.md`), one per commit. Each stands alone; they share a branch because the last two both touch `graph-hydration.ts`.

## 1. Webhook runs create a real `WorkflowRun`

The production webhook path hand-built a workflow object and called `WorkflowEngine.executeWorkflow` directly, so an execution created **no run row at all**: absent from run history, absent from the `workflowRuns` quota, and — because a run id is what a paused node resumes against — a webhook workflow with a wait or human-confirmation node was **unresumable**. Every other headless trigger already went through `createRun`; this was the one door that did not.

It now uses `WorkflowExecutionService.createRun` + `executeWorkflowAsync` with a reporter (which also gives a webhook run per-node traces for the first time), stamped `WorkflowTriggerSource.WEBHOOK` — an enum member that previously had no writer.

Deliberately unchanged: the response is still awaited, and a failed execution still answers the author's configured response. A non-2xx makes senders like Shopify or Stripe retry a request that will fail again; the failure is recorded on the run row, which is what was missing. The one new refusal is an org over its plan limit → 403.

**Not fixed here, same class:** `shared/[shareToken]/run/route.ts:196` inserts its run by hand and skips the usage guard entirely — public-share runs are free.

## 2. Template writes canonicalize

`WorkflowTemplate.graph` was the last of the five graph storage locations with no opinion about its contents, and the way it got fat was a loop rather than a paste: `resolveTemplateById` **hydrates** → the admin editor renders that into its JSON textarea → Save posts it back. **Opening a clean bundled template and pressing Save was enough to fatten it**, and "Export to file" serialised the same blob into the committable `*.template.json`. Duplicating a `file:` template skipped normalisation entirely. `normalizeTemplateGraph` only rewrites AI prompt docs — it is not a canonicalizer.

`canonicalizeTemplateGraph` now runs in create/update/duplicate, and the export button dehydrates. Idempotent, so it is a no-op on already-canonical rows.

The module moved from `@auxx/services` to `packages/lib/src/workflow-templates` because it structurally could not do this where it was — services is tier 2, the hydrator is tier 3. Ten importers updated, services copy deleted, lib exports regenerated.

## 3. Default-handle strip on, defaults layer deleted, dead keys gone

Both of plan 23's deliberate omissions, revisited against the code — evaluation in `plans/kopilot/workflow/26-hydration-defaults-and-handles.md`. Both resolve the opposite way.

**`stripDefaultHandles` is ON.** The blocker was stale: `loop-execution-manager.ts:398` filters `currentWorkflow.graph.edges`, which is `hydrateGraph`'s output — handles are filled before anything routes. All 44 strict handle comparisons in the engine core swept, zero read an unhydrated array; sequence-compiled graphs have never written `sourceHandle` and 870 such nodes run in production. ~5 100 redundant keys leave the fleet on its next write cycle. The function default stays `false` so read-modify-write migrations still see stored bytes.

Two guards land first and the flip depends on them: a three-node loop-body test whose stored edges carry no handles (**teeth verified by hand** — commenting out the hydration call fails it), and a parity census that fails on any new strict default-handle comparison in the engine core.

**The read-time `defaultData` layer is deleted**, not left disabled. Its premise is false here: a read-time default projection needs one shared answer to "what is the default for this type", and there are two (Kopilot's per-org lookup sees app blocks; the browser/engine/cache/API registry does not, and an app block's `defaultData()` returns identity keys one writer would strip and no reader could restore). Four manifests' `defaultData()` is also not a pure function of the type. Enabling it once already amputated a real dev row (#1770 → #1771).

`persistDraft` now derives trigger columns from the **hydrated** graph, matching the two writers that already did — removes the ordering trap independently of the layer.

**Dead node-data keys removed** from `BaseNodeData`/`baseNodeDataSchema` and from all four writers: `isValid`/`errors` (hardcoded `true`/`[]`, updated by nothing), `outputVariables` (answered by `resolveOutputs`), `data.selected` (zero readers — React Flow owns `node.selected`), plus the vestigial `description` alias in `WorkflowService`'s hand-written trigger graph.

`_connectedSourceHandleIds`/`_connectedTargetHandleIds` **look** like the same class but are live — the handle components render off them. Left alone.

## Verification

- `packages/lib` 832 files / 10 508 tests · `apps/web` 253 files / 3 687 tests
- typecheck ratchet clean on lib and web; `apps/api` clean
- `check-graph-hydration-roundtrip.ts` against dev: *"All invariants hold across every stored graph"*, 1408 graphs / 4115 nodes

Two tests changed meaning rather than being deleted, because the stored shape changed: `ops.test.ts`'s reconnect-bridging and app-block cases now assert the default handle is **absent** from the persisted edge, and `hydration-policy-pairing.test.ts`'s mismatch case pins the surviving asymmetry, since the `skipDefaults` mismatch it was written for is no longer representable.

## Known flake, pre-existing

`workflow-draft-cas.test.ts` → "writes under FOR UPDATE…" failed once in five full runs. `WorkflowService.update` dynamic-imports `graph-edit`, ~1 668 modules vitest transforms on first call, ~8s against lib's 10s `testTimeout`. Unrelated to this branch — a timeout race under load. Worth a per-file timeout bump or a warmed import in a follow-up.