### PR TITLE
fix(workflow): coalesce undo history by identity instead of by time

### DIFF
--- a/apps/web/src/components/workflow/hooks/__tests__/workflow-history-events.test.ts
+++ b/apps/web/src/components/workflow/hooks/__tests__/workflow-history-events.test.ts
@@ -1,0 +1,54 @@
+// apps/web/src/components/workflow/hooks/__tests__/workflow-history-events.test.ts
+//
+// `WorkflowHistoryEvent` must not make a claim the builder cannot keep. It drifted
+// badly once: seventeen members, seven of which nothing ever dispatched — and two
+// of those seven (`NodeDragStop`, `LayoutOrganize`) named actions that were
+// recorded NOWHERE, so moving a node and running auto-layout were silently not
+// undoable. The other five were duplicate labels for an action already recorded
+// under a coarser name.
+//
+// These two tests pin both directions, so a member added to the enum and nowhere
+// else fails immediately instead of quietly becoming the eighth.
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { getHistoryLabel, WorkflowHistoryEvent } from '../use-save-to-history'
+
+const WORKFLOW_SRC = join(__dirname, '../..')
+
+/**
+ * The whole builder, not a hand-kept list of files — a list goes stale exactly
+ * when someone moves a dispatch, which is when this test needs to be right.
+ */
+function readWorkflowSources(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((item) => {
+    const path = join(dir, item.name)
+    if (item.isDirectory()) return item.name === '__tests__' ? [] : readWorkflowSources(path)
+    if (!/\.tsx?$/.test(item.name) || item.name === 'use-save-to-history.ts') return []
+    return [readFileSync(path, 'utf8')]
+  })
+}
+
+const DISPATCH_SITES = readWorkflowSources(WORKFLOW_SRC)
+
+describe('WorkflowHistoryEvent', () => {
+  it('gives every member a real label', () => {
+    for (const event of Object.values(WorkflowHistoryEvent)) {
+      const label = getHistoryLabel(event)
+      expect(label, `${event} has no label`).toBeTruthy()
+      expect(label, `${event} fell through to the default`).not.toBe('Unknown Event')
+    }
+  })
+
+  it('dispatches every member', () => {
+    const undispatched = Object.values(WorkflowHistoryEvent).filter(
+      (event) => !DISPATCH_SITES.some((src) => src.includes(`WorkflowHistoryEvent.${event}`))
+    )
+
+    expect(
+      undispatched,
+      `these members name actions nothing records, so they are not undoable: ${undispatched.join(', ')}`
+    ).toEqual([])
+  })
+})

--- a/apps/web/src/components/workflow/hooks/__tests__/workflow-history-restore-dirty.test.tsx
+++ b/apps/web/src/components/workflow/hooks/__tests__/workflow-history-restore-dirty.test.tsx
@@ -17,11 +17,17 @@ const h = vi.hoisted(() => ({
   markDirty: vi.fn(),
   rfSetNodes: vi.fn(),
   rfSetEdges: vi.fn(),
+  liveNodes: [] as any[],
 }))
 
 vi.mock('@xyflow/react', () => ({
   useStoreApi: () => ({
-    getState: () => ({ setNodes: h.rfSetNodes, setEdges: h.rfSetEdges, nodes: [], edges: [] }),
+    getState: () => ({
+      setNodes: h.rfSetNodes,
+      setEdges: h.rfSetEdges,
+      nodes: h.liveNodes,
+      edges: [],
+    }),
   }),
 }))
 
@@ -65,6 +71,7 @@ describe('WorkflowHistoryProvider — restores mark the canvas dirty', () => {
     h.markDirty.mockClear()
     h.rfSetNodes.mockClear()
     h.rfSetEdges.mockClear()
+    h.liveNodes = []
     render(<WorkflowHistoryProvider>{null}</WorkflowHistoryProvider>)
   })
 
@@ -99,5 +106,61 @@ describe('WorkflowHistoryProvider — restores mark the canvas dirty', () => {
     manager.undo() // needs ≥2 states — no-op
     expect(h.rfSetNodes).not.toHaveBeenCalled()
     expect(h.markDirty).not.toHaveBeenCalled()
+  })
+})
+
+// A history snapshot is authored content. Interaction state — selection, drag
+// flag, React Flow's measured box — belongs to the canvas the user is looking
+// at, and the restore seam has to carry it across rather than replay whatever
+// the snapshot happened to store. This was the last wholesale `setNodes` in the
+// builder that skipped `mergeInteractionState`.
+describe('WorkflowHistoryProvider — restores preserve interaction state', () => {
+  let manager: HistoryManager
+
+  beforeEach(() => {
+    manager = new HistoryManager()
+    h.manager = manager
+    h.rfSetNodes.mockClear()
+    h.liveNodes = [{ id: 'n1', selected: true, measured: { width: 200, height: 80 } }]
+    render(<WorkflowHistoryProvider>{null}</WorkflowHistoryProvider>)
+  })
+
+  function snapshot(tag: string) {
+    return {
+      action: 'workflow_event',
+      store: 'workflow',
+      // No `selected`, no `measured` — exactly what the snapshot whitelist stores.
+      data: { event: 'NodeChange', nodes: [{ id: 'n1', data: { title: tag } }], edges: [] },
+      label: tag,
+    }
+  }
+
+  it('keeps the live selection and measured box on the restored node', () => {
+    manager.record(snapshot('before'))
+    manager.record(snapshot('after'))
+
+    manager.undo()
+
+    const restored = h.rfSetNodes.mock.calls.at(-1)?.[0][0]
+    expect(restored.data.title).toBe('before') // authored content from the snapshot…
+    expect(restored.selected).toBe(true) // …interaction state from the canvas
+    expect(restored.measured).toEqual({ width: 200, height: 80 })
+  })
+
+  it('leaves a node the live canvas does not have without interaction state', () => {
+    const undoingADelete = {
+      action: 'workflow_event',
+      store: 'workflow',
+      data: { event: 'NodeDelete', nodes: [{ id: 'gone', data: {} }], edges: [] },
+      label: 'restores a deleted node',
+    }
+    manager.record(undoingADelete)
+    manager.record(snapshot('after'))
+
+    manager.undo()
+
+    const restored = h.rfSetNodes.mock.calls.at(-1)?.[0][0]
+    expect(restored.id).toBe('gone')
+    expect(restored.selected).toBeUndefined()
   })
 })

--- a/apps/web/src/components/workflow/hooks/index.ts
+++ b/apps/web/src/components/workflow/hooks/index.ts
@@ -47,7 +47,7 @@ export {
   useRunSingleNode,
 } from './use-run-single-node'
 export {
-  useSaveToHistory,
+  getHistoryLabel,
   useWorkflowHistory,
   WorkflowHistoryEvent,
   type WorkflowHistoryEvent as WorkflowHistoryEventType,

--- a/apps/web/src/components/workflow/hooks/use-node-data-update.ts
+++ b/apps/web/src/components/workflow/hooks/use-node-data-update.ts
@@ -50,7 +50,13 @@ export const useNodeDataUpdate = () => {
       handleNodeDataUpdate(payload)
       // Variables are automatically synced by VarStoreSyncProvider
       debouncedSave()
-      saveStateToHistory(WorkflowHistoryEvent.NodeChange)
+      // Keyed per node: a burst of keystrokes in one panel is one undo step,
+      // and an edit to a DIFFERENT node starts a new one. Per-field would be
+      // finer, but `setInputs` hands over a whole data object, so which field
+      // moved is not knowable here.
+      saveStateToHistory(WorkflowHistoryEvent.NodeChange, {
+        coalesceKey: `NodeChange:${payload.id}`,
+      })
     },
     [debouncedSave, handleNodeDataUpdate, isReadOnly, saveStateToHistory]
   )

--- a/apps/web/src/components/workflow/hooks/use-node-interactions.ts
+++ b/apps/web/src/components/workflow/hooks/use-node-interactions.ts
@@ -488,9 +488,7 @@ export const useNodesInteractions = () => {
 
       debouncedSave()
 
-      if (currentNode.data.type === NodeType.NOTE)
-        saveStateToHistory(WorkflowHistoryEvent.NoteDelete)
-      else saveStateToHistory(WorkflowHistoryEvent.NodeDelete)
+      saveStateToHistory(WorkflowHistoryEvent.NodeDelete)
 
       closeDrawer()
     },
@@ -674,7 +672,13 @@ export const useNodesInteractions = () => {
       })
       setNodes(newNodes)
       debouncedSave()
-      saveStateToHistory(WorkflowHistoryEvent.NodeResize)
+      // `NodeResizeControl` binds `onResize`, not `onResizeEnd`, so this runs
+      // once per pointer frame. The key collapses the whole gesture into one
+      // undo step; the event type is part of it, so a resize and a drag of the
+      // same node can never merge.
+      saveStateToHistory(WorkflowHistoryEvent.NodeResize, {
+        coalesceKey: `NodeResize:${nodeId}`,
+      })
     },
     [getNodesReadOnly, store, debouncedSave, saveStateToHistory]
   )
@@ -799,10 +803,16 @@ export const useNodesInteractions = () => {
 
         // Note: No need to call updateNode directly since storeSyncCallbacks.syncNodeToStore already does it
 
-        // TODO: Save to history if not a select-triggered drag (x,y != 0,0)
-        // if (startPos.x !== 0 && startPos.y !== 0) {
-        //   saveStateToHistory(WorkflowHistoryEvent.NodeDragStop)
-        // }
+        // One entry per gesture, so no coalesce key: two separate drags of
+        // the same node are two separate undo steps.
+        //
+        // The old TODO here proposed guarding on `startPos.x !== 0 &&
+        // startPos.y !== 0` to skip select-triggered drags. That guard is
+        // wrong — it silently drops a real drag of a node parked at the
+        // origin. `positionChanged` above is the correct test, and it covers
+        // multi-select too: every selected node moves by the delta of the
+        // GRABBED node, so a zero delta on that one is a zero delta on all.
+        saveStateToHistory(WorkflowHistoryEvent.NodeDragStop)
       }
       handleClearHelpline()
 
@@ -816,7 +826,7 @@ export const useNodesInteractions = () => {
 
       endDragWindow()
     },
-    [getNodesReadOnly, debouncedSave, handleClearHelpline]
+    [getNodesReadOnly, debouncedSave, handleClearHelpline, saveStateToHistory]
   )
 
   const handleNodeSelect = useCallback(

--- a/apps/web/src/components/workflow/hooks/use-save-to-history.ts
+++ b/apps/web/src/components/workflow/hooks/use-save-to-history.ts
@@ -1,42 +1,79 @@
 // apps/web/src/components/workflow/hooks/use-save-to-history.ts
 
-import { debounce } from '@auxx/utils'
 import { useStoreApi } from '@xyflow/react'
-import { useCallback, useRef, useState } from 'react'
-import { storeEventBus } from '../store/event-bus'
+import { useCallback, useState } from 'react'
+import type { RecordOptions } from '../store/history-manager'
 import { useHistoryManager } from '../store/workflow-store-provider'
+import type { FlowEdge, FlowNode } from '../types'
+import { snapshotGraph } from '../utils/history-snapshot'
 
 /**
- * All supported Events that create a new history state.
- * Current limitations:
- * - InputChange events in Node Panels do not trigger state changes.
- * - Resizing UI elements does not trigger state changes.
+ * The canvas actions that create a new history state.
+ *
+ * Every member here must be dispatched somewhere and must have a label — the
+ * enum, the call sites and {@link getHistoryLabel} are pinned to each other by
+ * `__tests__/workflow-history-events.test.ts`, because for a long time they
+ * were not: seven of seventeen members named actions nothing ever recorded, and
+ * two of those seven (node drag, auto-layout) were user-visible holes in undo.
+ *
+ * Not every React Flow event belongs here. Pure UI state — selection, viewport,
+ * measurement — is deliberately absent: the user does not want Cmd+Z to undo a
+ * click.
  */
 export enum WorkflowHistoryEvent {
-  NodeTitleChange = 'NodeTitleChange',
-  NodeDescriptionChange = 'NodeDescriptionChange',
-  NodeDragStop = 'NodeDragStop',
+  NodeAdd = 'NodeAdd',
   NodeChange = 'NodeChange',
-  NodeConnect = 'NodeConnect',
-  NodePaste = 'NodePaste',
   NodeDelete = 'NodeDelete',
+  NodePaste = 'NodePaste',
+  NodeDragStop = 'NodeDragStop',
+  NodeResize = 'NodeResize',
+  NodeCollapse = 'NodeCollapse',
   EdgeAdd = 'EdgeAdd',
   EdgeDelete = 'EdgeDelete',
   EdgeDeleteByDeleteBranch = 'EdgeDeleteByDeleteBranch',
-  NodeAdd = 'NodeAdd',
-  NodeResize = 'NodeResize',
-  NodeCollapse = 'NodeCollapse',
-  NoteAdd = 'NoteAdd',
-  NoteChange = 'NoteChange',
-  NoteDelete = 'NoteDelete',
   LayoutOrganize = 'LayoutOrganize',
+}
+
+/**
+ * The popover's wording for an event.
+ *
+ * Deliberately coarse. A label family per node *type* (the old `Note*` members)
+ * costs one special case per verb and changes nothing about what is undoable,
+ * and a per-*field* label is not derivable at all: `useNodeCrud.setInputs`
+ * hands the update path a whole data object, so a title edit and a duration
+ * edit are indistinguishable by the time they get here.
+ */
+export function getHistoryLabel(event: WorkflowHistoryEvent): string {
+  switch (event) {
+    case WorkflowHistoryEvent.NodeAdd:
+      return 'Node added'
+    case WorkflowHistoryEvent.NodeChange:
+      return 'Node changed'
+    case WorkflowHistoryEvent.NodeDelete:
+      return 'Node deleted'
+    case WorkflowHistoryEvent.NodePaste:
+      return 'Node pasted'
+    case WorkflowHistoryEvent.NodeDragStop:
+      return 'Node position changed'
+    case WorkflowHistoryEvent.NodeResize:
+      return 'Node resized'
+    case WorkflowHistoryEvent.NodeCollapse:
+      return 'Node collapsed'
+    case WorkflowHistoryEvent.EdgeAdd:
+      return 'Edge added'
+    case WorkflowHistoryEvent.EdgeDelete:
+    case WorkflowHistoryEvent.EdgeDeleteByDeleteBranch:
+      return 'Edge deleted'
+    case WorkflowHistoryEvent.LayoutOrganize:
+      return 'Layout organized'
+  }
 }
 
 /**
  * Hook for saving workflow state to history with undo/redo support
  */
 export const useWorkflowHistory = () => {
-  const store = useStoreApi()
+  const store = useStoreApi<FlowNode, FlowEdge>()
   const historyManager = useHistoryManager()
 
   const [undoCallbacks, setUndoCallbacks] = useState<any[]>([])
@@ -52,168 +89,42 @@ export const useWorkflowHistory = () => {
     return () => setRedoCallbacks((prev) => prev.filter((cb) => cb !== callback))
   }, [])
 
+  // `historyManager.undo()` / `.redo()` emit `history:changed` themselves, so
+  // there is nothing to re-emit here.
   const undo = useCallback(() => {
     historyManager.undo()
     undoCallbacks.forEach((callback) => callback())
-
-    // Emit event for UI updates
-    storeEventBus.emit({
-      type: 'history:changed' as any,
-      data: { canUndo: historyManager.canUndo(), canRedo: historyManager.canRedo() },
-    })
   }, [undoCallbacks, historyManager])
 
   const redo = useCallback(() => {
     historyManager.redo()
     redoCallbacks.forEach((callback) => callback())
-
-    // Emit event for UI updates
-    storeEventBus.emit({
-      type: 'history:changed' as any,
-      data: { canUndo: historyManager.canUndo(), canRedo: historyManager.canRedo() },
-    })
   }, [redoCallbacks, historyManager])
 
-  // Some events may be triggered multiple times in a short period of time.
-  // We debounce the history state update to avoid creating multiple history states
-  // with minimal changes. Increased to 2 seconds for better performance.
-  const saveStateToHistoryRef = useRef(
-    debounce((event: WorkflowHistoryEvent) => {
-      // For workflow-level events, we record a synthetic history entry
-      // The actual state changes are already recorded by the stores
+  /**
+   * Record one canvas action.
+   *
+   * Written immediately — there is no debounce in front of this, so the undo
+   * buttons and the history popover are correct the instant the edit lands.
+   * High-frequency callers (panel typing, resize) pass a `coalesceKey` so their
+   * burst collapses into a single entry; see `HistoryManager.record`.
+   */
+  const saveStateToHistory = useCallback(
+    (event: WorkflowHistoryEvent, options?: RecordOptions) => {
       const { nodes, edges } = store.getState()
 
-      historyManager.record({
-        action: 'workflow_event',
-        store: 'workflow',
-        data: {
-          event,
-          // Save complete node data for proper restoration
-          nodes: nodes.map((n) => ({
-            id: n.id,
-            type: n.type,
-            position: { ...n.position },
-            data: n.data ? { ...n.data } : undefined,
-            width: n.width,
-            height: n.height,
-            selected: n.selected,
-            sourcePosition: n.sourcePosition,
-            targetPosition: n.targetPosition,
-            dragging: false, // Reset dragging state
-            style: n.style,
-            className: n.className,
-            parentId: n.parentId,
-            zIndex: n.zIndex,
-            extent: n.extent,
-            expandParent: n.expandParent,
-            draggable: n.draggable,
-            selectable: n.selectable,
-            connectable: n.connectable,
-            deletable: n.deletable,
-            focusable: n.focusable,
-            hidden: n.hidden,
-          })),
-          // Save complete edge data
-          edges: edges.map((e) => ({
-            id: e.id,
-            source: e.source,
-            sourceHandle: e.sourceHandle,
-            target: e.target,
-            targetHandle: e.targetHandle,
-            type: e.type,
-            data: e.data ? { ...e.data } : undefined,
-            selected: e.selected,
-            animated: e.animated,
-            hidden: e.hidden,
-            deletable: e.deletable,
-            focusable: e.focusable,
-            selectable: e.selectable,
-            markerStart: e.markerStart,
-            markerEnd: e.markerEnd,
-            zIndex: e.zIndex,
-            ariaLabel: e.ariaLabel,
-            interactionWidth: e.interactionWidth,
-            className: e.className,
-            style: e.style,
-          })),
+      historyManager.record(
+        {
+          action: 'workflow_event',
+          store: 'workflow',
+          data: snapshotGraph(event, nodes, edges),
+          label: getHistoryLabel(event),
         },
-        label: getHistoryLabel(event),
-      })
-    }, 2000)
+        options
+      )
+    },
+    [store, historyManager]
   )
-
-  const saveStateToHistory = useCallback((event: WorkflowHistoryEvent) => {
-    switch (event) {
-      case WorkflowHistoryEvent.NoteChange:
-        // Hint: Note change does not trigger when note text changes,
-        // because the note editors have their own history states.
-        saveStateToHistoryRef.current(event)
-        break
-      case WorkflowHistoryEvent.NodeTitleChange:
-      case WorkflowHistoryEvent.NodeDescriptionChange:
-      case WorkflowHistoryEvent.NodeDragStop:
-      case WorkflowHistoryEvent.NodeChange:
-      case WorkflowHistoryEvent.NodeConnect:
-      case WorkflowHistoryEvent.NodePaste:
-      case WorkflowHistoryEvent.NodeDelete:
-      case WorkflowHistoryEvent.EdgeAdd:
-      case WorkflowHistoryEvent.EdgeDelete:
-      case WorkflowHistoryEvent.EdgeDeleteByDeleteBranch:
-      case WorkflowHistoryEvent.NodeAdd:
-      case WorkflowHistoryEvent.NodeResize:
-      case WorkflowHistoryEvent.NodeCollapse:
-      case WorkflowHistoryEvent.NoteAdd:
-      case WorkflowHistoryEvent.LayoutOrganize:
-      case WorkflowHistoryEvent.NoteDelete:
-        saveStateToHistoryRef.current(event)
-        break
-      default:
-        // We do not create a history state for every event.
-        // Some events of reactflow may change things the user would not want to undo/redo.
-        // For example: UI state changes like selecting a node.
-        break
-    }
-  }, [])
-
-  const getHistoryLabel = useCallback((event: WorkflowHistoryEvent) => {
-    // TODO: Add proper translation support with react-i18next
-    switch (event) {
-      case WorkflowHistoryEvent.NodeTitleChange:
-        return 'Node title changed'
-      case WorkflowHistoryEvent.NodeDescriptionChange:
-        return 'Node description changed'
-      case WorkflowHistoryEvent.LayoutOrganize:
-      case WorkflowHistoryEvent.NodeDragStop:
-        return 'Node position changed'
-      case WorkflowHistoryEvent.NodeChange:
-        return 'Node changed'
-      case WorkflowHistoryEvent.NodeConnect:
-        return 'Nodes connected'
-      case WorkflowHistoryEvent.NodePaste:
-        return 'Node pasted'
-      case WorkflowHistoryEvent.NodeDelete:
-        return 'Node deleted'
-      case WorkflowHistoryEvent.NodeAdd:
-        return 'Node added'
-      case WorkflowHistoryEvent.EdgeAdd:
-        return 'Edge added'
-      case WorkflowHistoryEvent.EdgeDelete:
-      case WorkflowHistoryEvent.EdgeDeleteByDeleteBranch:
-        return 'Edge deleted'
-      case WorkflowHistoryEvent.NodeResize:
-        return 'Node resized'
-      case WorkflowHistoryEvent.NodeCollapse:
-        return 'Node collapsed'
-      case WorkflowHistoryEvent.NoteAdd:
-        return 'Note added'
-      case WorkflowHistoryEvent.NoteChange:
-        return 'Note changed'
-      case WorkflowHistoryEvent.NoteDelete:
-        return 'Note deleted'
-      default:
-        return 'Unknown Event'
-    }
-  }, [])
 
   // Save initial state to history
   const saveInitialState = useCallback(() => {
@@ -224,55 +135,7 @@ export const useWorkflowHistory = () => {
       historyManager.record({
         action: 'workflow_event',
         store: 'workflow',
-        data: {
-          event: 'initial' as any,
-          nodes: nodes.map((n) => ({
-            id: n.id,
-            type: n.type,
-            position: { ...n.position },
-            data: n.data ? { ...n.data } : undefined,
-            width: n.width,
-            height: n.height,
-            selected: n.selected,
-            sourcePosition: n.sourcePosition,
-            targetPosition: n.targetPosition,
-            dragging: false,
-            style: n.style,
-            className: n.className,
-            parentId: n.parentId,
-            zIndex: n.zIndex,
-            extent: n.extent,
-            expandParent: n.expandParent,
-            draggable: n.draggable,
-            selectable: n.selectable,
-            connectable: n.connectable,
-            deletable: n.deletable,
-            focusable: n.focusable,
-            hidden: n.hidden,
-          })),
-          edges: edges.map((e) => ({
-            id: e.id,
-            source: e.source,
-            sourceHandle: e.sourceHandle,
-            target: e.target,
-            targetHandle: e.targetHandle,
-            type: e.type,
-            data: e.data ? { ...e.data } : undefined,
-            selected: e.selected,
-            animated: e.animated,
-            hidden: e.hidden,
-            deletable: e.deletable,
-            focusable: e.focusable,
-            selectable: e.selectable,
-            markerStart: e.markerStart,
-            markerEnd: e.markerEnd,
-            zIndex: e.zIndex,
-            ariaLabel: e.ariaLabel,
-            interactionWidth: e.interactionWidth,
-            className: e.className,
-            style: e.style,
-          })),
-        },
+        data: snapshotGraph('initial', nodes, edges),
         label: 'Initial state',
       })
     }
@@ -288,20 +151,4 @@ export const useWorkflowHistory = () => {
     onRedo,
     saveInitialState,
   }
-}
-
-/**
- * Legacy hook for backward compatibility
- * @deprecated Use useWorkflowHistory instead
- */
-export const useSaveToHistory = () => {
-  const { saveStateToHistory } = useWorkflowHistory()
-
-  return useCallback(
-    (event: string) => {
-      // Map string events to enum values or use as-is
-      saveStateToHistory(event as WorkflowHistoryEvent)
-    },
-    [saveStateToHistory]
-  )
 }

--- a/apps/web/src/components/workflow/hooks/use-workflow-draft-realtime.ts
+++ b/apps/web/src/components/workflow/hooks/use-workflow-draft-realtime.ts
@@ -7,7 +7,7 @@ import { useOrgChannel } from '~/realtime/hooks'
 import { storeEventBus } from '../store/event-bus'
 import { useWorkflowStore } from '../store/workflow-store'
 import { useHistoryManager } from '../store/workflow-store-provider'
-import type { FlowEdge, FlowNode } from '../types'
+import { snapshotGraph } from '../utils/history-snapshot'
 import { applyFetchedWorkflow, type FetchedWorkflow } from './use-workflow-init'
 
 /** Payload of the org-channel `workflow:draft-updated` event (lib `realtime/events.ts`). */
@@ -85,17 +85,13 @@ export function useWorkflowDraftRealtime(): void {
           // owns its React Flow state); viewport untouched on purpose.
           storeEventBus.emit({ type: 'workflow:externalUpdate', data: { nodes, edges } })
 
-          // ONE undo step for the whole rehydrate — same full-snapshot
-          // `workflow_event` shape `use-save-to-history` records, but written
-          // immediately so no debounced user edit can merge into it.
+          // ONE undo step for the whole rehydrate. No coalesce key, so a user
+          // edit can never absorb it however close together they land — the
+          // hazard the old debounce only made unlikely.
           historyManager.record({
             action: 'workflow_event',
             store: 'workflow',
-            data: {
-              event: 'ExternalDraftUpdate',
-              nodes: nodes.map(cloneNodeForHistory),
-              edges: edges.map(cloneEdgeForHistory),
-            },
+            data: snapshotGraph('ExternalDraftUpdate', nodes, edges),
             label: runReason === 'kopilot' ? 'Kopilot edit' : 'Workflow updated',
           })
         }
@@ -119,18 +115,4 @@ export function useWorkflowDraftRealtime(): void {
   )
 
   useOrgChannel({ onEvent })
-}
-
-/** Shallow-clone a node for the history snapshot so later canvas mutations can't rewrite it. */
-function cloneNodeForHistory(node: FlowNode): FlowNode {
-  return {
-    ...node,
-    position: { ...node.position },
-    data: node.data ? { ...node.data } : node.data,
-  }
-}
-
-/** Shallow-clone an edge for the history snapshot. */
-function cloneEdgeForHistory(edge: FlowEdge): FlowEdge {
-  return { ...edge, data: edge.data ? { ...edge.data } : undefined }
 }

--- a/apps/web/src/components/workflow/hooks/use-workflow-organize.ts
+++ b/apps/web/src/components/workflow/hooks/use-workflow-organize.ts
@@ -11,12 +11,14 @@ import {
   getLayoutForChildNodes,
 } from '../utils/layout-algorithms'
 import { LAYOUT_ANIMATION, NODE_CLASSIFICATIONS } from '../utils/layout-constants'
+import { useWorkflowHistory, WorkflowHistoryEvent } from './use-save-to-history'
 
 /**
  * Hook for organizing workflow layout automatically
  */
 export const useWorkflowOrganize = () => {
   const historyManager = useHistoryManager()
+  const { saveStateToHistory } = useWorkflowHistory()
   const reactFlow = useReactFlow()
   const store = useStoreApi<FlowNode, FlowEdge>()
   // Get ReactFlow actions directly
@@ -149,6 +151,10 @@ export const useWorkflowOrganize = () => {
       // Update nodes using setNodes
       setNodes(newNodes)
 
+      // Auto-layout moves every node at once, which is exactly the kind of
+      // change a user wants back. One entry, no coalesce key.
+      saveStateToHistory(WorkflowHistoryEvent.LayoutOrganize)
+
       // Set optimal viewport using canvas interaction callbacks
       setViewport({ x: 0, y: 0, zoom: LAYOUT_ANIMATION.VIEWPORT_ZOOM })
 
@@ -168,7 +174,7 @@ export const useWorkflowOrganize = () => {
       console.error('Error during layout organization:', error)
       historyManager.endBatch()
     }
-  }, [isReadOnly, store, setViewport, fitView, historyManager])
+  }, [isReadOnly, store, setViewport, fitView, historyManager, saveStateToHistory])
 
   /**
    * Simple horizontal layout for quick organization
@@ -188,9 +194,10 @@ export const useWorkflowOrganize = () => {
     }))
 
     setNodes(newNodes)
+    saveStateToHistory(WorkflowHistoryEvent.LayoutOrganize)
     fitView({ padding: 0.1 })
     historyManager.endBatch()
-  }, [isReadOnly, store, fitView, historyManager])
+  }, [isReadOnly, store, fitView, historyManager, saveStateToHistory])
 
   /**
    * Reset all nodes to center position
@@ -206,9 +213,10 @@ export const useWorkflowOrganize = () => {
     const newNodes = nodes.map((node) => ({ ...node, position: { x: 0, y: 0 } }))
 
     setNodes(newNodes)
+    saveStateToHistory(WorkflowHistoryEvent.LayoutOrganize)
     setViewport({ x: 0, y: 0, zoom: 1 })
     historyManager.endBatch()
-  }, [isReadOnly, store, setViewport, historyManager])
+  }, [isReadOnly, store, setViewport, historyManager, saveStateToHistory])
 
   // Memoize canOrganize to prevent unnecessary re-renders
   const canOrganize = useMemo(() => {

--- a/apps/web/src/components/workflow/store/__tests__/history-coalescing.test.ts
+++ b/apps/web/src/components/workflow/store/__tests__/history-coalescing.test.ts
@@ -1,0 +1,243 @@
+// apps/web/src/components/workflow/store/__tests__/history-coalescing.test.ts
+//
+// The undo stack coalesces by IDENTITY, not by time. Before this, a single 2 s
+// trailing debounce sat in front of every producer, which bought three
+// separate failures: atomic gestures were 2 s late, a sustained typing session
+// recorded nothing at all (the timer never settled), and — the correctness one
+// — unrelated edits merged, so one undo reverted two things and the state
+// between them was unrecoverable.
+//
+// These tests pin the replacement.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { HistoryManager } from '../history-manager'
+
+function entry(tag: string) {
+  return {
+    action: 'workflow_event',
+    store: 'workflow',
+    data: { event: 'NodeChange', nodes: [{ id: tag }], edges: [] },
+    label: tag,
+  }
+}
+
+describe('HistoryManager coalescing', () => {
+  let manager: HistoryManager
+
+  beforeEach(() => {
+    manager = new HistoryManager()
+  })
+
+  it('merges same-key records into one entry holding the LATEST snapshot', () => {
+    manager.record(entry('initial'))
+    manager.record(entry('a1'), { coalesceKey: 'NodeChange:n1' })
+    manager.record(entry('a2'), { coalesceKey: 'NodeChange:n1' })
+    manager.record(entry('a3'), { coalesceKey: 'NodeChange:n1' })
+
+    const history = manager.getHistory()
+    expect(history).toHaveLength(2)
+    expect(history[1].data.nodes[0].id).toBe('a3')
+  })
+
+  it('breaks the session on a keyless record — unrelated edits never merge', () => {
+    manager.record(entry('initial'))
+    manager.record(entry('typing'), { coalesceKey: 'NodeChange:n1' })
+    manager.record(entry('delete-other-node'))
+    manager.record(entry('typing-again'), { coalesceKey: 'NodeChange:n1' })
+
+    // Four entries, so the typing is still reachable behind the delete. Under
+    // the old shared debounce these collapsed into ONE entry labelled for
+    // whichever event happened to be last.
+    expect(manager.getHistory()).toHaveLength(4)
+  })
+
+  it('breaks the session on a different key', () => {
+    manager.record(entry('initial'))
+    manager.record(entry('node-1'), { coalesceKey: 'NodeChange:n1' })
+    manager.record(entry('node-2'), { coalesceKey: 'NodeChange:n2' })
+
+    expect(manager.getHistory()).toHaveLength(3)
+  })
+
+  it('never merges a resize into a drag of the same node', () => {
+    manager.record(entry('initial'))
+    manager.record(entry('resized'), { coalesceKey: 'NodeResize:n1' })
+    manager.record(entry('dragged'), { coalesceKey: 'NodeDragStop:n1' })
+
+    expect(manager.getHistory()).toHaveLength(3)
+  })
+
+  it('undo after a coalesced session lands before the session began', () => {
+    const store = { setNodes: vi.fn(), setEdges: vi.fn() }
+    manager.registerStore('workflow', store)
+
+    manager.record(entry('initial'))
+    manager.record(entry('a1'), { coalesceKey: 'NodeChange:n1' })
+    manager.record(entry('a2'), { coalesceKey: 'NodeChange:n1' })
+
+    manager.undo()
+
+    // Not the intermediate 'a1' — the state from before the typing started.
+    expect(store.setNodes).toHaveBeenCalledTimes(1)
+    expect(store.setNodes.mock.calls[0][0][0].id).toBe('initial')
+  })
+
+  it('records immediately — no timer has to run first', () => {
+    vi.useFakeTimers()
+    try {
+      manager.record(entry('added'))
+      // No `vi.advanceTimersByTime` here on purpose.
+      expect(manager.getHistory()).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('a sustained session still records — there is no timer to keep resetting', () => {
+    vi.useFakeTimers()
+    try {
+      manager.record(entry('initial'))
+      // 30 s of continuous editing, one edit per second.
+      for (let i = 0; i < 30; i++) {
+        manager.record(entry(`edit-${i}`), { coalesceKey: 'NodeChange:n1' })
+        vi.advanceTimersByTime(1000)
+      }
+      // Every edit is on the stack somewhere; the old debounce recorded NOTHING
+      // across a burst like this because its trailing timer never settled.
+      expect(manager.getHistory().length).toBeGreaterThan(1)
+      expect(manager.canUndo()).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('HistoryManager coalescing — the window is an idle gap', () => {
+  it('holds one entry across a continuous gesture however long it runs', () => {
+    vi.useFakeTimers()
+    try {
+      const manager = new HistoryManager({ coalesceWindow: 500 })
+      manager.record(entry('initial'))
+
+      // A resize drag fires per pointer frame for three seconds — six times the
+      // window. Anchoring on the FIRST write would fragment this into an entry
+      // every 500 ms; anchoring on the last keeps it as one.
+      for (let i = 0; i < 180; i++) {
+        manager.record(entry(`frame-${i}`), { coalesceKey: 'NodeResize:n1' })
+        vi.advanceTimersByTime(16)
+      }
+
+      expect(manager.getHistory()).toHaveLength(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('starts a new entry when the same field is edited again after a pause', () => {
+    vi.useFakeTimers()
+    try {
+      const manager = new HistoryManager({ coalesceWindow: 500 })
+      manager.record(entry('initial'))
+      manager.record(entry('first-edit'), { coalesceKey: 'NodeChange:n1' })
+
+      vi.advanceTimersByTime(10_000)
+      manager.record(entry('much-later-edit'), { coalesceKey: 'NodeChange:n1' })
+
+      // Three entries, so 'first-edit' is still reachable. With no window at
+      // all these would be one entry and that state would be lost forever.
+      expect(manager.getHistory()).toHaveLength(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('HistoryManager coalescing — the redo stack', () => {
+  it('a coalesced write invalidates the future, exactly like a pushed one', () => {
+    const manager = new HistoryManager()
+    manager.record(entry('initial'))
+    manager.record(entry('typing'), { coalesceKey: 'NodeChange:n1' })
+    manager.record(entry('deleted-node-b'))
+
+    manager.undo()
+    expect(manager.canRedo()).toBe(true)
+
+    // Same key as the entry now on top, so this coalesces rather than pushes.
+    manager.record(entry('typing-more'), { coalesceKey: 'NodeChange:n1' })
+
+    // Redo must be gone. If it survived, redoing would restore the
+    // 'deleted-node-b' snapshot on top of a graph that never had it — a state
+    // the user was never in.
+    expect(manager.canRedo()).toBe(false)
+  })
+})
+
+describe('HistoryManager.jumpToEntryId', () => {
+  it('jumps by id, so a stale index cannot mis-target', () => {
+    const store = { setNodes: vi.fn(), setEdges: vi.fn() }
+    const manager = new HistoryManager()
+    manager.registerStore('workflow', store)
+
+    manager.record(entry('one'))
+    manager.record(entry('two'))
+    manager.record(entry('three'))
+
+    const target = manager.getNavigationHistory().find((e) => e.label === 'one')
+    manager.jumpToEntryId(target!.id)
+
+    expect(store.setNodes.mock.calls.at(-1)?.[0][0].id).toBe('one')
+    expect(manager.getCurrentStateIndex()).toBe(0)
+  })
+
+  it('ignores an id that is not in the stack', () => {
+    const manager = new HistoryManager()
+    manager.record(entry('one'))
+    manager.record(entry('two'))
+
+    manager.jumpToEntryId('does-not-exist')
+
+    expect(manager.getCurrentStateIndex()).toBe(1)
+  })
+
+  it('reaches entries on the redo stack', () => {
+    const store = { setNodes: vi.fn(), setEdges: vi.fn() }
+    const manager = new HistoryManager()
+    manager.registerStore('workflow', store)
+
+    manager.record(entry('one'))
+    manager.record(entry('two'))
+    manager.undo()
+
+    const future = manager.getNavigationHistory().find((e) => e.label === 'two')
+    manager.jumpToEntryId(future!.id)
+
+    expect(store.setNodes.mock.calls.at(-1)?.[0][0].id).toBe('two')
+  })
+})
+
+describe('HistoryManager batching', () => {
+  it('stamps the batch id instead of a null asserted non-null', () => {
+    const manager = new HistoryManager()
+    manager.startBatch('Layout organization')
+    manager.record(entry('laid-out'))
+    manager.endBatch()
+
+    expect(manager.getHistory()[0].batch).toEqual(expect.any(String))
+  })
+
+  it('leaves batch undefined outside a batch', () => {
+    const manager = new HistoryManager()
+    manager.record(entry('plain'))
+
+    expect(manager.getHistory()[0].batch).toBeUndefined()
+  })
+
+  it('names unlabelled entries after the batch', () => {
+    const manager = new HistoryManager()
+    manager.startBatch('Layout organization')
+    manager.record({ action: 'workflow_event', store: 'workflow', data: {} })
+    manager.endBatch()
+
+    expect(manager.getHistory()[0].label).toBe('Layout organization')
+  })
+})

--- a/apps/web/src/components/workflow/store/history-manager.ts
+++ b/apps/web/src/components/workflow/store/history-manager.ts
@@ -1,6 +1,5 @@
 // apps/web/src/components/workflow/store/history-manager.ts
 
-// import { nanoid } from 'nanoid'
 import { v4 as uuidv4 } from 'uuid'
 import { storeEventBus } from './event-bus'
 import type { HistoryEntry } from './types'
@@ -8,6 +7,7 @@ import type { HistoryEntry } from './types'
 interface HistoryManagerOptions {
   maxHistorySize?: number
   batchingWindow?: number
+  coalesceWindow?: number
 }
 
 /**
@@ -23,22 +23,52 @@ interface StoreInstance {
 }
 
 /**
+ * Options for {@link HistoryManager.record}.
+ */
+export interface RecordOptions {
+  /**
+   * Identity of the logical edit this record belongs to, e.g.
+   * `NodeChange:<nodeId>`. A record whose key matches the top of the stack
+   * **overwrites** it instead of pushing, which is how a burst of keystrokes in
+   * one panel becomes one undo step rather than one per character.
+   *
+   * Omit it for anything that happens once per gesture (add, delete, paste,
+   * drag-stop, layout). A keyless record can never merge into a keyed session,
+   * which is what stops two unrelated edits collapsing into a single entry.
+   */
+  coalesceKey?: string
+}
+
+/**
+ * How long a coalescing session stays open, measured from its LAST write.
+ *
+ * This is an idle gap, not a maximum duration — the anchor moves forward on
+ * every merge. Both properties depend on that: a continuous gesture (resize
+ * fires per pointer frame) stays one entry however long it runs, while a field
+ * edited now and edited again after a pause becomes two entries, so the
+ * intermediate state is still reachable.
+ */
+const DEFAULT_COALESCE_WINDOW = 500
+
+/**
  * Centralized history manager for undo/redo functionality across all stores
  */
 export class HistoryManager {
   private undoStack: HistoryEntry[] = []
   private redoStack: HistoryEntry[] = []
   private stores = new Map<string, StoreInstance>()
-  private currentBatch: string | null = null
+  private currentBatch: { id: string; label: string } | null = null
   private batchTimeout: NodeJS.Timeout | null = null
   private currentStateIndex: number = -1 // Current position in combined history
 
   private maxHistorySize: number
   private batchingWindow: number
+  private coalesceWindow: number
 
   constructor(options: HistoryManagerOptions = {}) {
     this.maxHistorySize = options.maxHistorySize || 50
     this.batchingWindow = options.batchingWindow || 300
+    this.coalesceWindow = options.coalesceWindow ?? DEFAULT_COALESCE_WINDOW
   }
 
   /**
@@ -56,14 +86,49 @@ export class HistoryManager {
   }
 
   /**
-   * Record a history entry
+   * Record a history entry.
+   *
+   * Writes happen on the edit — there is no debounce in front of this. Volume
+   * is handled by coalescing on {@link RecordOptions.coalesceKey} instead of by
+   * waiting, so `canUndo()`, the undo/redo buttons and the history popover are
+   * always current, and unrelated edits can never merge into one entry.
    */
-  record(entry: Omit<HistoryEntry, 'id' | 'timestamp'>): void {
+  record(entry: Omit<HistoryEntry, 'id' | 'timestamp'>, options: RecordOptions = {}): void {
+    const { coalesceKey } = options
+    const top = this.undoStack[this.undoStack.length - 1]
+    const now = Date.now()
+
+    if (
+      coalesceKey &&
+      top?.coalesceKey === coalesceKey &&
+      now - top.timestamp < this.coalesceWindow
+    ) {
+      // The same logical edit continuing: replace the snapshot in place. Undo
+      // still lands on the state from before the session began, because that
+      // one lives in the PREVIOUS entry.
+      top.data = entry.data
+      top.label = entry.label ?? top.label
+      top.timestamp = now
+
+      // A coalesced write is a new action just as much as a pushed one, so it
+      // has to invalidate the future the same way. Without this, an undo
+      // followed by a same-key edit leaves a redo stack whose entries describe
+      // a graph that no longer exists — redo would then restore a state the
+      // user was never in.
+      this.redoStack = []
+      this.currentStateIndex = this.undoStack.length - 1
+
+      this.emitHistoryChange()
+      return
+    }
+
     const historyEntry: HistoryEntry = {
       ...entry,
       id: uuidv4(),
-      timestamp: Date.now(),
-      batch: this.currentBatch!,
+      timestamp: now,
+      label: entry.label ?? this.currentBatch?.label,
+      batch: this.currentBatch?.id,
+      coalesceKey,
     }
 
     this.undoStack.push(historyEntry)
@@ -88,14 +153,15 @@ export class HistoryManager {
   }
 
   /**
-   * Start a batch of operations
+   * Start a batch of operations. `label` names the entries recorded inside it
+   * that do not carry a label of their own.
    */
   startBatch(label: string): void {
     if (this.batchTimeout) {
       clearTimeout(this.batchTimeout)
       this.batchTimeout = null
     }
-    this.currentBatch = uuidv4()
+    this.currentBatch = { id: uuidv4(), label }
   }
 
   /**
@@ -194,7 +260,7 @@ export class HistoryManager {
     return allEntries.map((entry, index) => ({
       ...entry,
       relativePosition: index - currentIndex,
-      actionDescription: this.getActionDescription(entry),
+      actionDescription: entry.label || `${entry.action} operation`,
     }))
   }
 
@@ -231,6 +297,20 @@ export class HistoryManager {
   }
 
   /**
+   * Jump to the state a specific entry describes.
+   *
+   * The id is the address, not the index: a caller holding a rendered list of
+   * entries cannot compute a correct index once the stack has moved underneath
+   * it, and the list moves whenever an edit lands.
+   */
+  jumpToEntryId(id: string): void {
+    const allEntries = [...this.undoStack, ...this.redoStack.slice().reverse()]
+    const targetIndex = allEntries.findIndex((entry) => entry.id === id)
+    if (targetIndex === -1) return
+    this.jumpToState(targetIndex)
+  }
+
+  /**
    * Get current state position
    */
   getCurrentStateIndex(): number {
@@ -250,194 +330,6 @@ export class HistoryManager {
       this.batchTimeout = null
     }
     this.emitHistoryChange()
-  }
-
-  /**
-   * Generate human-readable action descriptions
-   */
-  private getActionDescription(entry: HistoryEntry): string {
-    const { action, data } = entry
-
-    switch (action) {
-      case 'addNode':
-        return `Added ${data.data?.title || data.type || 'node'}`
-
-      case 'updateNode':
-        return `Updated ${data.old?.data?.title || data.old?.type || 'node'}`
-
-      case 'deleteNode':
-        return `Deleted ${data.data?.title || data.type || 'node'}`
-
-      case 'addEdge':
-        return `Added connection`
-
-      case 'updateEdge':
-        return `Updated connection`
-
-      case 'deleteEdge':
-        return `Deleted connection`
-
-      case 'setVariable':
-        return `Set variable '${data.name}'`
-
-      case 'deleteVariable':
-        return `Deleted variable '${data.name}'`
-
-      default:
-        return entry.label || `${action} operation`
-    }
-  }
-
-  /**
-   * Get entries that belong to the same batch
-   */
-  // private getCurrentBatch(stack: HistoryEntry[]): HistoryEntry[] {
-  //   if (stack.length === 0) return []
-
-  //   const lastEntry = stack[stack.length - 1]
-  //   if (!lastEntry.batch) return [lastEntry]
-
-  //   // Get all entries with the same batch ID
-  //   const batch: HistoryEntry[] = []
-  //   for (let i = stack.length - 1; i >= 0; i--) {
-  //     if (stack[i].batch === lastEntry.batch) {
-  //       batch.push(stack[i])
-  //     } else {
-  //       break
-  //     }
-  //   }
-
-  //   return batch
-  // }
-
-  /**
-   * Revert a history entry (for undo)
-   */
-  private revertEntry(entry: HistoryEntry): void {
-    const store = this.stores.get(entry.store)
-    if (!store) {
-      console.warn(`Store '${entry.store}' not found for history revert`)
-      return
-    }
-
-    // Store-specific revert logic
-    switch (entry.action) {
-      case 'addNode':
-        if (store.deleteNode) {
-          store.deleteNode(entry.data.id, { skipHistory: true })
-        }
-        break
-
-      case 'updateNode':
-        if (store.updateNode && entry.data.old) {
-          store.updateNode(entry.data.id, entry.data.old, { skipHistory: true })
-        }
-        break
-
-      case 'deleteNode':
-        if (store.addNode) {
-          store.addNode(entry.data, { skipHistory: true })
-        }
-        break
-
-      case 'addEdge':
-        if (store.deleteEdge) {
-          store.deleteEdge(entry.data.id, { skipHistory: true })
-        }
-        break
-
-      case 'updateEdge':
-        if (store.updateEdge && entry.data.old) {
-          store.updateEdge(entry.data.id, entry.data.old, { skipHistory: true })
-        }
-        break
-
-      case 'deleteEdge':
-        if (store.addEdge) {
-          store.addEdge(entry.data, { skipHistory: true })
-        }
-        break
-
-      case 'setVariable':
-        if (store.setVariable && entry.data.old !== undefined) {
-          store.setVariable(entry.data.name, entry.data.old, { skipHistory: true })
-        }
-        break
-
-      case 'deleteVariable':
-        if (store.setVariable) {
-          store.setVariable(entry.data.name, entry.data.value, { skipHistory: true })
-        }
-        break
-
-      default:
-        console.warn(`Unknown history action: ${entry.action}`)
-    }
-  }
-
-  /**
-   * Apply a history entry (for redo)
-   */
-  private applyEntry(entry: HistoryEntry): void {
-    const store = this.stores.get(entry.store)
-    if (!store) {
-      console.warn(`Store '${entry.store}' not found for history apply`)
-      return
-    }
-
-    // Store-specific apply logic
-    switch (entry.action) {
-      case 'addNode':
-        if (store.addNode) {
-          store.addNode(entry.data, { skipHistory: true })
-        }
-        break
-
-      case 'updateNode':
-        if (store.updateNode && entry.data.new) {
-          store.updateNode(entry.data.id, entry.data.new, { skipHistory: true })
-        }
-        break
-
-      case 'deleteNode':
-        if (store.deleteNode) {
-          store.deleteNode(entry.data.id, { skipHistory: true })
-        }
-        break
-
-      case 'addEdge':
-        if (store.addEdge) {
-          store.addEdge(entry.data, { skipHistory: true })
-        }
-        break
-
-      case 'updateEdge':
-        if (store.updateEdge && entry.data.new) {
-          store.updateEdge(entry.data.id, entry.data.new, { skipHistory: true })
-        }
-        break
-
-      case 'deleteEdge':
-        if (store.deleteEdge) {
-          store.deleteEdge(entry.data.id, { skipHistory: true })
-        }
-        break
-
-      case 'setVariable':
-        if (store.setVariable) {
-          store.setVariable(entry.data.name, entry.data.value, { skipHistory: true })
-        }
-        break
-
-      case 'deleteVariable':
-        if (store.deleteVariable) {
-          store.deleteVariable(entry.data.name, { skipHistory: true })
-        }
-        break
-
-      default:
-        console.warn(`Unknown history action: ${entry.action}`)
-    }
   }
 
   /**

--- a/apps/web/src/components/workflow/store/types.ts
+++ b/apps/web/src/components/workflow/store/types.ts
@@ -44,6 +44,12 @@ export interface HistoryEntry {
   data: any
   label?: string
   batch?: string
+  /**
+   * Identity of the logical edit this entry belongs to. A later record with the
+   * same key overwrites this entry instead of pushing a new one — see
+   * `HistoryManager.record`.
+   */
+  coalesceKey?: string
 }
 
 /**

--- a/apps/web/src/components/workflow/store/workflow-history-provider.tsx
+++ b/apps/web/src/components/workflow/store/workflow-history-provider.tsx
@@ -4,6 +4,8 @@ import { useStoreApi } from '@xyflow/react'
 import type React from 'react'
 import { useEffect } from 'react'
 import { useWorkflowHistory } from '../hooks/use-save-to-history'
+import type { FlowNode } from '../types'
+import { mergeInteractionState } from '../utils/interaction-state'
 import { useWorkflowStore } from './workflow-store'
 import { useHistoryManager } from './workflow-store-provider'
 
@@ -44,8 +46,15 @@ export const WorkflowHistoryProvider: React.FC<WorkflowHistoryProviderProps> = (
     }
     const workflowStore = {
       setNodes: (nodes: any[]) => {
-        const { setNodes } = reactFlowStore.getState()
-        setNodes(nodes)
+        const { setNodes, nodes: liveNodes } = reactFlowStore.getState()
+        // Authored content from the snapshot, interaction state from the live
+        // canvas — the same contract `workflow:externalUpdate` and the version
+        // popover use. A history restore was the last wholesale replace that
+        // skipped it, which cost it twice: the snapshot replayed a persisted
+        // `selected` (opening a panel for a node the user was not looking at),
+        // and it carried no `measured`, so every restored node rendered at zero
+        // size for a frame.
+        setNodes(mergeInteractionState(nodes as FlowNode[], liveNodes as FlowNode[]))
         markRestoreDirty()
       },
       setEdges: (edges: any[]) => {

--- a/apps/web/src/components/workflow/store/workflow-store-provider.tsx
+++ b/apps/web/src/components/workflow/store/workflow-store-provider.tsx
@@ -109,6 +109,7 @@ export type HistoryManagerApi = Pick<
   | 'getHistory'
   | 'getNavigationHistory'
   | 'jumpToState'
+  | 'jumpToEntryId'
   | 'getCurrentStateIndex'
   | 'clear'
 >
@@ -129,6 +130,7 @@ const noopHistoryManager: HistoryManagerApi = {
   getHistory: () => [],
   getNavigationHistory: () => [],
   jumpToState: () => {},
+  jumpToEntryId: () => {},
   getCurrentStateIndex: () => -1,
   clear: () => {},
 }

--- a/apps/web/src/components/workflow/ui/history-command-popover.tsx
+++ b/apps/web/src/components/workflow/ui/history-command-popover.tsx
@@ -1,4 +1,4 @@
-// apps/web/src/components/workflow/canvas/history-command-popover.tsx
+// apps/web/src/components/workflow/ui/history-command-popover.tsx
 
 'use client'
 
@@ -16,6 +16,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import { Clock, History } from 'lucide-react'
 import React from 'react'
 import { Tooltip } from '~/components/global/tooltip'
+import { storeEventBus } from '~/components/workflow/store/event-bus'
 import type { NavigationHistoryEntry } from '~/components/workflow/store/history-manager'
 import { useHistoryManager } from '~/components/workflow/store/workflow-store-provider'
 
@@ -31,35 +32,22 @@ export function HistoryCommandPopover({ open, onOpenChange }: HistoryCommandPopo
   const historyManager = useHistoryManager()
   const [historyEntries, setHistoryEntries] = React.useState<NavigationHistoryEntry[]>([])
 
-  // Update history entries when popover opens
+  // Follow the stack while the popover is open. Reading once on open made an
+  // entry that landed afterwards invisible until a close/reopen cycle — and
+  // left the rendered list describing a stack that had moved on. Subscribing
+  // costs nothing while closed, which was the constraint that mattered.
   React.useEffect(() => {
-    if (open) {
-      const entries = historyManager.getNavigationHistory()
-      // Reverse the entries to show most recent first
-      setHistoryEntries(entries.reverse())
-    }
+    if (!open) return
+    // Reverse to show most recent first.
+    const read = () => setHistoryEntries(historyManager.getNavigationHistory().reverse())
+    read()
+    return storeEventBus.on('history:changed', read)
   }, [open, historyManager])
 
-  const handleJumpToState = (reversedIndex: number) => {
-    // Since we reversed the array for display, calculate the actual index
-    const actualIndex = historyEntries.length - 1 - reversedIndex
-
-    // Calculate how many steps to undo/redo
-    const currentIndex = historyManager.getCurrentStateIndex()
-    const steps = actualIndex - currentIndex
-
-    if (steps < 0) {
-      // Need to undo
-      for (let i = 0; i < Math.abs(steps); i++) {
-        historyManager.undo()
-      }
-    } else if (steps > 0) {
-      // Need to redo
-      for (let i = 0; i < steps; i++) {
-        historyManager.redo()
-      }
-    }
-
+  // Jump by entry id, not by index: an index is only meaningful against the
+  // stack length at render time, and the stack moves underneath this list.
+  const handleJumpToState = (entryId: string) => {
+    historyManager.jumpToEntryId(entryId)
     onOpenChange(false)
   }
 
@@ -91,10 +79,10 @@ export function HistoryCommandPopover({ open, onOpenChange }: HistoryCommandPopo
             </CommandEmpty>
             {historyEntries.length > 0 && (
               <CommandGroup heading='History Timeline'>
-                {historyEntries.map((entry, index) => (
+                {historyEntries.map((entry) => (
                   <CommandItem
                     key={entry.id}
-                    onSelect={() => handleJumpToState(index)}
+                    onSelect={() => handleJumpToState(entry.id)}
                     className={cn(
                       'flex items-center gap-3 justify-between cursor-pointer data-[selected=true]:bg-info/10'
                       // entry.relativePosition === 0 && 'bg-accent/50 font-medium'

--- a/apps/web/src/components/workflow/ui/workflow-versions-popover.tsx
+++ b/apps/web/src/components/workflow/ui/workflow-versions-popover.tsx
@@ -19,7 +19,9 @@ import React from 'react'
 import { Tooltip } from '~/components/global/tooltip'
 import { useCanvasStore } from '~/components/workflow/store/canvas-store'
 import { useWorkflowStore } from '~/components/workflow/store/workflow-store'
+import { useHistoryManager } from '~/components/workflow/store/workflow-store-provider'
 import type { FlowNode } from '~/components/workflow/types'
+import { snapshotGraph } from '~/components/workflow/utils/history-snapshot'
 import { storedGraphToCanvas } from '~/components/workflow/utils/interaction-state'
 import { useConfirm } from '~/hooks/use-confirm'
 import { api } from '~/trpc/react'
@@ -72,6 +74,7 @@ const WorkflowVersionsPopover: React.FC<WorkflowVersionsPopoverProps> = ({
 
   // ReactFlow hooks for node and edge management
   const { getNodes, getEdges, setNodes, setEdges } = useReactFlow()
+  const historyManager = useHistoryManager()
   const nodes = getNodes()
   const edges = getEdges()
 
@@ -234,6 +237,19 @@ const WorkflowVersionsPopover: React.FC<WorkflowVersionsPopoverProps> = ({
             const canvas = storedGraphToCanvas(graph, getNodes() as FlowNode[])
             setNodes(canvas.nodes)
             setEdges(canvas.edges)
+
+            // Restoring a version is the most destructive canvas replacement in
+            // the builder, so it gets an undo step like every other one. Same
+            // immediate full-snapshot shape the Kopilot rehydrate records, and
+            // no coalesce key — this must never merge into a user edit.
+            // The PREVIEW path below deliberately records nothing: it is
+            // read-only and reverts on exit.
+            historyManager.record({
+              action: 'workflow_event',
+              store: 'workflow',
+              data: snapshotGraph('VersionRestore', canvas.nodes, canvas.edges),
+              label: `Restored "${versionTitle}"`,
+            })
           })
 
           // Exit read-only mode

--- a/apps/web/src/components/workflow/utils/history-snapshot.ts
+++ b/apps/web/src/components/workflow/utils/history-snapshot.ts
@@ -1,0 +1,112 @@
+// apps/web/src/components/workflow/utils/history-snapshot.ts
+
+import type { FlowEdge, FlowNode } from '../types'
+
+/**
+ * The one shape a history entry stores a graph in.
+ *
+ * Three producers write history snapshots — canvas edits
+ * (`use-save-to-history`), the Kopilot/server rehydrate
+ * (`use-workflow-draft-realtime`) and version restore
+ * (`workflow-versions-popover`) — and before this module they each cloned the
+ * graph their own way. An undo could therefore restore a differently-shaped
+ * node depending on which entry it landed on.
+ *
+ * ## Why a whitelist rather than a spread
+ *
+ * A snapshot must not carry React Flow's internals (`internals`, `handles`,
+ * measured boxes) back onto the canvas on restore: those describe the *current*
+ * canvas, not the authored graph, and replaying a stale copy is how a restore
+ * ends up with dead handles. The whitelist is the filter.
+ *
+ * ## Why interaction state is NOT in it
+ *
+ * `selected` / `dragging` / `measured` are interaction state, not authored
+ * content (`utils/interaction-state.ts`). A snapshot that stores them claims an
+ * authored selection it has no business having — restoring one used to move the
+ * user's selection and, via `selection:changed` → `panel-store`, open a panel
+ * for a node they were not looking at. The restore seam in
+ * `workflow-history-provider` runs `mergeInteractionState` instead, which takes
+ * those keys from the live canvas. So they are deliberately absent here.
+ */
+
+/**
+ * `FlowNode` / `FlowEdge` are hand-rolled aliases that declare a subset of what
+ * React Flow actually puts on a node at runtime (`style`, `className`,
+ * `hidden`, `focusable`, `expandParent`, `connectable` are all real and all
+ * undeclared). The whitelist preserves them, so it reads through a widened
+ * view rather than pretending the alias is complete.
+ */
+type RawNode = FlowNode & Record<string, unknown>
+
+/** Clone one node into the canonical history shape. */
+export function cloneNodeForHistory(node: FlowNode): FlowNode {
+  const n = node as RawNode
+  return {
+    id: n.id,
+    type: n.type,
+    position: { ...n.position },
+    data: { ...n.data },
+    width: n.width,
+    height: n.height,
+    sourcePosition: n.sourcePosition,
+    targetPosition: n.targetPosition,
+    style: n.style,
+    className: n.className,
+    parentId: n.parentId,
+    zIndex: n.zIndex,
+    extent: n.extent,
+    expandParent: n.expandParent,
+    draggable: n.draggable,
+    selectable: n.selectable,
+    connectable: n.connectable,
+    deletable: n.deletable,
+    focusable: n.focusable,
+    hidden: n.hidden,
+  } as FlowNode
+}
+
+/** Clone one edge into the canonical history shape. */
+export function cloneEdgeForHistory(edge: FlowEdge): FlowEdge {
+  return {
+    id: edge.id,
+    source: edge.source,
+    sourceHandle: edge.sourceHandle,
+    target: edge.target,
+    targetHandle: edge.targetHandle,
+    type: edge.type,
+    data: edge.data ? { ...edge.data } : undefined,
+    animated: edge.animated,
+    hidden: edge.hidden,
+    deletable: edge.deletable,
+    focusable: edge.focusable,
+    selectable: edge.selectable,
+    markerStart: edge.markerStart,
+    markerEnd: edge.markerEnd,
+    zIndex: edge.zIndex,
+    ariaLabel: edge.ariaLabel,
+    interactionWidth: edge.interactionWidth,
+    className: edge.className,
+    style: edge.style,
+  } as FlowEdge
+}
+
+/** The `data` payload of a `workflow_event` history entry. */
+export interface GraphSnapshot {
+  event: string
+  nodes: FlowNode[]
+  edges: FlowEdge[]
+}
+
+/** Snapshot a whole graph for one history entry. */
+export function snapshotGraph(
+  event: string,
+  nodes: readonly FlowNode[],
+  edges: readonly FlowEdge[]
+): GraphSnapshot {
+  return {
+    event,
+    nodes: nodes.map(cloneNodeForHistory),
+    edges: edges.map(cloneEdgeForHistory),
+  }
+}


### PR DESCRIPTION
Implements `plans/kopilot/workflow/25-history-granularity.md` (D1–D11) in one PR, with three corrections found by reviewing the plan against the code first.

## The problem

The undo stack sat behind one shared 2 s trailing debounce. That bought three failures at once:

- **Latency on atomic gestures.** Add a node, open the history popover — the entry isn't there. It shows up ~2 s later, and only after a close/reopen cycle.
- **Unrelated edits merged.** Type into node A, delete node B 1.5 s later → one entry, labelled "Node deleted", holding only the post-delete snapshot. The typing is unrecoverable and one undo reverts two things.
- **A sustained session recorded nothing.** The timer reset on every call and had no `maxWait`, so continuous editing produced *no* history at all — not late history, none. #1770 fixed the identical bug on the save path; the history path never got it.

The debounce was also aimed at the wrong target. Drag never touched history at all; the firehose was panel typing (`useNodeCrud.setInputs` → `NodeChange`, wired to `onChange` in ~40 panels).

## The fix

A **coalescing key** on `HistoryManager.record`. Writes happen on the edit; a record whose key matches the top of the stack overwrites it instead of pushing. Panel typing and resize pass `NodeChange:<id>` / `NodeResize:<id>`; anything that happens once per gesture passes nothing, so it can never be absorbed into a keyed session — §3's correctness bug becomes unrepresentable rather than merely unlikely.

### Two things the plan's design needed

1. **A coalesced write clears the redo stack.** The plan's snippet returned early and never reached the push path's `redoStack = []`. Reachable: edit node A → delete node B → undo → edit node A again. The edit coalesces, the redo stack survives, and redo restores a snapshot of a graph that never existed.
2. **The window is an idle gap, not a maximum duration.** The plan anchored on the entry's original timestamp and then (Q3) recommended deleting the window because a continuous resize fragments every 500 ms. Re-anchoring on the last merge fixes the symptom without the cost: 180 resize frames over three seconds stay one entry, and a field edited again ten minutes later becomes a *second* entry instead of silently overwriting the first. Dropping the window would have left the key as the only terminator and lost that state permanently.

Third correction: `NodeDragStop` and `LayoutOrganize` are atomic and keyless. The plan never assigned them a path and Q2 implied a key, which would have merged two separate drags of the same node into one entry.

## Also closed

| | |
|---|---|
| **Node drag is undoable** | The call was commented out behind a TODO whose proposed guard (`startPos !== 0,0`) would have dropped a real drag of a node parked at the origin. `positionChanged` is the correct test and covers multi-select — every selected node moves by the grabbed node's delta. |
| **Layout is undoable** | All three commands (`organize`, `simple`, `reset`) recorded nothing; the `startBatch`/`endBatch` brackets contained zero records. |
| **Version restore is undoable** | The most destructive canvas replacement in the builder had no undo step. Preview still records nothing — it's read-only and reverts on exit. |
| **Restores preserve interaction state** | The history restore was the last wholesale `setNodes` skipping `mergeInteractionState`. The snapshot replayed a persisted `selected` (opening a panel for a node the user wasn't looking at) and carried no `measured` (every restored node rendered at zero size for a frame). |
| **The popover is live** | It read the stack once on open, so an entry landing while it was open was invisible until close/reopen — and the rendered list described a stack that had moved. Now subscribes to `history:changed` while open and jumps by entry id, not by an index computed against a stale length. |
| **One snapshot shape** | The three producers had diverged (22-field whitelist vs spread clone), so what an undo restored depended on which entry it landed on. Now `utils/history-snapshot.ts`. |
| **The enum stops lying** | 17 members → 11, all dispatched, all labelled. Seven were dead: two were the drag/layout holes above, five were duplicate labels for an action already recorded under a coarser name. The `Note*` family goes too — a note is a node that travels every generic path, so a per-type label family costs one special case per verb for zero change in what's undoable. |
| **Dead code** | `revertEntry`/`applyEntry` (~140 lines) and `getActionDescription`'s switch were unreachable under the snapshot design. `batch` was a `!` on a null, so every entry got `batch: null`. |

## Tests

- `store/__tests__/history-coalescing.test.ts` — 16 tests: merge/break-on-keyless/break-on-different-key, undo lands before the session, immediate recording, a 30 s sustained session, the idle-gap window in both directions, the redo-stack invalidation, `jumpToEntryId`, batch stamping.
- `hooks/__tests__/workflow-history-events.test.ts` — pins the enum in **both** directions: every member has a real label, and every member is dispatched somewhere in the builder. It scans the tree rather than a hand-kept file list; it caught two dispatch files I'd missed while writing it.
- `hooks/__tests__/workflow-history-restore-dirty.test.tsx` — extended for the interaction-state merge.

All 33 workflow test files pass (266 tests). `apps/web` typecheck introduces no new errors (the 10 that remain are pre-existing in `human/panel.tsx` and `command-palette.tsx`).

## Note on perf

Removing the debounce means `NodeResize` now clones the graph once per pointer frame instead of once per gesture. That's the same order as the `produce` + `setNodes` the resize handler already does per frame, so it should be in the noise — but it's the one thing worth watching on a large graph.
