### PR TITLE
fix(workflow): meter public-share runs through createWorkflowRun

### DIFF
--- a/apps/web/src/app/api/workflows/shared/[shareToken]/run/public-share-run-accounting.test.ts
+++ b/apps/web/src/app/api/workflows/shared/[shareToken]/run/public-share-run-accounting.test.ts
@@ -1,0 +1,205 @@
+// apps/web/src/app/api/workflows/shared/[shareToken]/run/public-share-run-accounting.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The public-share door and the `workflowRuns` meter.
+ *
+ * This route used to hand-insert its own `WorkflowRun` row, duplicating the
+ * sequence-number query, the node count and the system-user resolution that
+ * `createWorkflowRun` already owns — and skipping the one thing only
+ * `createWorkflowRun` does: consume `workflowRuns` quota. So a public share
+ * link executed production workflows (AI nodes, HTTP calls, CRUD writes) for
+ * free, forever. Same class as the webhook hole #1774 closed, but this door is
+ * the one anonymous end users are *meant* to reach: the only thing in front of
+ * it is `checkWorkflowRateLimit`, whose config is author-set and may be null.
+ *
+ * What is asserted here is that the route goes through the shared door and
+ * hands it the two things that door could not previously express — the
+ * `PUBLIC_SHARE` source and the `endUserId`. That the door itself meters and
+ * writes those columns is asserted against the real `createWorkflowRun` in
+ * `packages/lib/src/jobs/workflow/scheduled-trigger-job.test.ts`.
+ */
+
+const { findFirst, createWorkflowRun, incrementEndUserRunCount, updateSet, subscribe } = vi.hoisted(
+  () => ({
+    findFirst: vi.fn(),
+    createWorkflowRun: vi.fn(),
+    incrementEndUserRunCount: vi.fn(async () => undefined),
+    updateSet: vi.fn(),
+    subscribe: vi.fn(async () => 'handler_1'),
+  })
+)
+
+vi.mock('@auxx/database', async () =>
+  (await import('~/test/database-mock')).mockAuxxDatabase({
+    database: {
+      query: { WorkflowApp: { findFirst } },
+      update: () => ({
+        set: (values: unknown) => {
+          updateSet(values)
+          return { where: async () => undefined }
+        },
+      }),
+    },
+  })
+)
+vi.mock('@auxx/logger', async () => (await import('~/test/logger-mock')).mockAuxxLogger())
+vi.mock('@auxx/lib/workflows', () => ({ createWorkflowRun }))
+vi.mock('@auxx/lib/utils/rate-limiter', () => ({
+  getApiRateLimiter: () => ({
+    getAvailableTokens: async () => 10,
+    acquire: async () => undefined,
+  }),
+  getClientIp: () => '203.0.113.7',
+}))
+vi.mock('@auxx/lib/workflow-engine', () => ({
+  checkWorkflowRateLimit: async () => ({ isOk: () => true, value: { isLimited: false } }),
+  validateFormInputs: () => ({ valid: true, errors: [] }),
+  safeJsonStringify: (value: unknown) => JSON.stringify(value),
+  RedisWorkflowExecutionReporter: class {
+    constructor(readonly workflowRunId: string) {}
+  },
+  WorkflowEngine: class {
+    getNodeRegistry() {
+      return { initializeWithDefaults: async () => undefined }
+    }
+    executeWorkflow = vi.fn(async () => ({ status: 'completed', context: { variables: {} } }))
+  },
+  WorkflowEventType: { RUN_CREATED: 'run-created', ERROR: 'error' },
+  WorkflowExecutionStatus: { COMPLETED: 'completed' },
+  WorkflowPausedException: class extends Error {},
+  WorkflowTriggerType: { MANUAL: 'manual' },
+}))
+vi.mock('@auxx/redis', () => ({
+  RedisEventRouter: {
+    getInstance: () => ({
+      subscribeToWorkflowEvents: subscribe,
+      unsubscribe: async () => undefined,
+    }),
+  },
+}))
+vi.mock('@auxx/services/workflow-share', () => ({
+  verifyWorkflowPassport: async () => ({
+    isErr: () => false,
+    value: { shareToken: SHARE_TOKEN, endUserId: END_USER_ID },
+  }),
+  getSharedWorkflowByToken: async () => ({
+    isErr: () => false,
+    value: {
+      id: APP_ID,
+      organizationId: ORG_ID,
+      rateLimit: null,
+      config: {},
+    },
+  }),
+  incrementEndUserRunCount,
+}))
+
+const SHARE_TOKEN = 'shr_token00000000000000'
+const END_USER_ID = 'eus_cuid00000000000000000'
+const APP_ID = 'wfa_cuid00000000000000000'
+const ORG_ID = 'org_cuid000000000000000000000'
+const RUN_ID = 'wfr_cuid00000000000000000'
+
+const { UsageLimitError } = await import('@auxx/lib/errors')
+const { WorkflowTriggerSource } = await import('@auxx/database/enums')
+const { POST } = await import('./route')
+
+const publishedWorkflow = {
+  id: 'wfv_published000000000000',
+  workflowAppId: APP_ID,
+  triggerType: 'form',
+  version: 4,
+  graph: { nodes: [{ id: 'n1', data: { type: 'start' } }], edges: [] },
+}
+
+const request = (inputs: Record<string, unknown> = { name: 'ada' }) =>
+  new Request(`http://localhost/api/workflows/shared/${SHARE_TOKEN}/run`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer passport', 'content-type': 'application/json' },
+    body: JSON.stringify({ inputs }),
+    // biome-ignore lint/suspicious/noExplicitAny: NextRequest shape is not needed here
+  }) as any
+
+const params = { params: Promise.resolve({ shareToken: SHARE_TOKEN }) }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  findFirst.mockResolvedValue({ id: APP_ID, totalRuns: 3, publishedWorkflow })
+  createWorkflowRun.mockResolvedValue({
+    id: RUN_ID,
+    status: 'running',
+    sequenceNumber: 4,
+    createdBy: 'usr_org_system0000000000',
+    createdAt: new Date(),
+  })
+  subscribe.mockResolvedValue('handler_1')
+})
+
+describe('a public-share run goes through the metered door', () => {
+  it('creates it with `createWorkflowRun`, as a headless production run', async () => {
+    await POST(request(), params)
+
+    expect(createWorkflowRun).toHaveBeenCalledTimes(1)
+    expect(createWorkflowRun.mock.calls[0]?.[1]).toMatchObject({
+      workflow: publishedWorkflow,
+      organizationId: ORG_ID,
+      mode: 'production',
+      // An anonymous visitor is not a `User` — the door resolves the org system
+      // user for `createdBy`, and a placeholder id here would break that FK.
+      userId: null,
+      triggeredFrom: WorkflowTriggerSource.PUBLIC_SHARE,
+      // The column the hand-insert existed for.
+      endUserId: END_USER_ID,
+    })
+  })
+
+  it('passes the submitted inputs as the run inputs', async () => {
+    await POST(request({ email: 'ada@example.com' }), params)
+
+    expect(createWorkflowRun.mock.calls[0]?.[1]).toMatchObject({
+      inputs: { email: 'ada@example.com' },
+    })
+  })
+
+  it('counts the run against the end user and the app once created', async () => {
+    const res = await POST(request(), params)
+
+    expect(res.headers.get('X-Run-Id')).toBe(RUN_ID)
+    expect(incrementEndUserRunCount).toHaveBeenCalledWith({ endUserId: END_USER_ID })
+    expect(updateSet).toHaveBeenCalledWith(expect.objectContaining({ totalRuns: 4 }))
+  })
+})
+
+describe('an org over its plan limit', () => {
+  beforeEach(() => {
+    createWorkflowRun.mockRejectedValue(
+      new UsageLimitError({ metric: 'workflowRuns', current: 10, limit: 10 })
+    )
+  })
+
+  it('is refused with 503, and no counter moves', async () => {
+    const res = await POST(request(), params)
+
+    expect(res.status).toBe(503)
+    expect(incrementEndUserRunCount).not.toHaveBeenCalled()
+    expect(updateSet).not.toHaveBeenCalled()
+  })
+
+  it('tells the visitor nothing about the org’s plan', async () => {
+    const res = await POST(request(), params)
+    const body = (await res.json()) as { error: string }
+
+    // The caller is a stranger on the internet, not the org. The real metric,
+    // current and limit go to the log; the page gets a neutral sentence.
+    expect(body.error).not.toMatch(/limit|upgrade|plan|quota/i)
+    expect(body.error).toMatch(/unavailable/i)
+  })
+
+  it('does not swallow a real failure as a refusal', async () => {
+    createWorkflowRun.mockRejectedValue(new Error('database is on fire'))
+
+    await expect(POST(request(), params)).rejects.toThrow('database is on fire')
+  })
+})

--- a/apps/web/src/app/api/workflows/shared/[shareToken]/run/route.ts
+++ b/apps/web/src/app/api/workflows/shared/[shareToken]/run/route.ts
@@ -3,7 +3,7 @@
 import type { WorkflowShareConfig } from '@auxx/database'
 import { database, schema } from '@auxx/database'
 import { WorkflowRunStatus, WorkflowTriggerSource } from '@auxx/database/enums'
-import { SystemUserService } from '@auxx/lib/users'
+import { UsageLimitError } from '@auxx/lib/errors'
 import { getApiRateLimiter, getClientIp } from '@auxx/lib/utils/rate-limiter'
 import {
   checkWorkflowRateLimit,
@@ -13,12 +13,12 @@ import {
   WorkflowEngine,
   WorkflowEventType,
   WorkflowExecutionStatus,
-  WorkflowGraphBuilder,
   WorkflowPausedException,
   type WorkflowRateLimitConfig,
   type WorkflowTriggerEvent,
   WorkflowTriggerType,
 } from '@auxx/lib/workflow-engine'
+import { createWorkflowRun } from '@auxx/lib/workflows'
 import { createScopedLogger } from '@auxx/logger'
 import { RedisEventRouter } from '@auxx/redis'
 import {
@@ -26,7 +26,7 @@ import {
   incrementEndUserRunCount,
   verifyWorkflowPassport,
 } from '@auxx/services/workflow-share'
-import { desc, eq } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import { type NextRequest, NextResponse } from 'next/server'
 
 const logger = createScopedLogger('shared-workflow-run-api')
@@ -174,47 +174,49 @@ export async function POST(
     )
   }
 
-  // Get next sequence number for workflow runs
-  const [lastRun] = await database
-    .select({ sequenceNumber: schema.WorkflowRun.sequenceNumber })
-    .from(schema.WorkflowRun)
-    .where(eq(schema.WorkflowRun.workflowAppId, sharedWorkflow.id))
-    .orderBy(desc(schema.WorkflowRun.sequenceNumber))
-    .limit(1)
-  const sequenceNumber = (lastRun?.sequenceNumber ?? 0) + 1
-
-  // Build graph to count nodes for progress tracking
-  const graph = WorkflowGraphBuilder.buildGraph(publishedWorkflow)
-  const nodeCount = graph.nodes.size
-
-  // Get system user for this organization (public runs don't have authenticated users)
-  const systemUserId = await SystemUserService.getSystemUserForActions(
-    sharedWorkflow.organizationId
-  )
-
-  // Create workflow run record with PUBLIC_SHARE trigger source
-  const [workflowRun] = await database
-    .insert(schema.WorkflowRun)
-    .values({
+  // Every door that starts a production run goes through `createWorkflowRun` —
+  // it owns the sequence number, the node count, the system-user resolution AND
+  // the `workflowRuns` usage guard. This route used to hand-insert the row, so a
+  // public share link executed production workflows — AI nodes, HTTP calls, CRUD
+  // writes — without ever consuming the org's quota. Same hole #1774 closed for
+  // webhooks, and this door is the one anonymous end users can reach.
+  let workflowRun: Awaited<ReturnType<typeof createWorkflowRun>>
+  try {
+    workflowRun = await createWorkflowRun(database, {
+      workflow: publishedWorkflow,
       organizationId: sharedWorkflow.organizationId,
-      workflowAppId: sharedWorkflow.id,
-      workflowId: publishedWorkflow.id,
-      sequenceNumber,
-      type: publishedWorkflow.triggerType || WorkflowTriggerType.MANUAL,
-      triggeredFrom: WorkflowTriggerSource.PUBLIC_SHARE,
-      version: publishedWorkflow.version.toString(),
-      graph: publishedWorkflow.graph || {},
       inputs,
-      status: WorkflowRunStatus.RUNNING,
-      totalTokens: 0,
-      totalSteps: nodeCount,
-      createdBy: systemUserId,
+      mode: 'production',
+      // Anonymous end user — not a `User`. `createWorkflowRun` resolves the org's
+      // system user for `createdBy`; the end user is recorded in `endUserId`.
+      userId: null,
+      triggeredFrom: WorkflowTriggerSource.PUBLIC_SHARE,
       endUserId: passport.endUserId,
     })
-    .returning()
+  } catch (error) {
+    // A run the org has no quota for is a refusal, not a server fault — but the
+    // caller here is a stranger on the internet, not the org. Log the real
+    // numbers; tell the visitor nothing about the org's plan. 503, because the
+    // caller is not unauthorized (403) and nothing they do changes the outcome
+    // this month (429).
+    if (error instanceof UsageLimitError) {
+      logger.warn('Public share run refused — plan limit reached', {
+        shareToken,
+        workflowAppId: sharedWorkflow.id,
+        metric: error.metric,
+        current: error.current,
+        limit: error.limit,
+      })
+      return NextResponse.json(
+        { error: 'This workflow is temporarily unavailable. Please try again later.' },
+        { status: 503 }
+      )
+    }
+    throw error
+  }
 
   logger.info('Created shared workflow run', {
-    workflowRunId: workflowRun!.id,
+    workflowRunId: workflowRun.id,
     workflowAppId: sharedWorkflow.id,
     endUserId: passport.endUserId,
     shareToken,
@@ -313,22 +315,22 @@ export async function POST(
         // Send initial run-created event
         send({
           event: WorkflowEventType.RUN_CREATED,
-          workflowRunId: workflowRun!.id,
+          workflowRunId: workflowRun.id,
           timestamp: new Date().toISOString(),
           data: {
-            id: workflowRun!.id,
-            status: workflowRun!.status,
-            sequenceNumber: workflowRun!.sequenceNumber,
+            id: workflowRun.id,
+            status: workflowRun.status,
+            sequenceNumber: workflowRun.sequenceNumber,
           },
         })
 
         // Set up Redis event subscription
         router = RedisEventRouter.getInstance('shared-workflow-sse')
         logger.info('Setting up Redis event subscription for shared workflow', {
-          workflowRunId: workflowRun!.id,
+          workflowRunId: workflowRun.id,
         })
 
-        handlerId = await router.subscribeToWorkflowEvents(workflowRun!.id, (event: any) => {
+        handlerId = await router.subscribeToWorkflowEvents(workflowRun.id, (event: any) => {
           try {
             // Filter events based on showWorkflowDetails setting
             const filteredEvent = filterEventForPublic(event)
@@ -353,13 +355,13 @@ export async function POST(
           } catch (error) {
             logger.error('Error handling shared workflow event', {
               error: error instanceof Error ? error.message : String(error),
-              workflowRunId: workflowRun!.id,
+              workflowRunId: workflowRun.id,
             })
           }
         })
 
         // Create reporter for SSE events
-        const reporter = new RedisWorkflowExecutionReporter(workflowRun!.id)
+        const reporter = new RedisWorkflowExecutionReporter(workflowRun.id)
 
         // Initialize and execute workflow engine
         const workflowEngine = new WorkflowEngine()
@@ -372,7 +374,8 @@ export async function POST(
           data: inputs,
           timestamp: new Date(),
           organizationId: sharedWorkflow.organizationId,
-          userId: systemUserId,
+          // `createWorkflowRun` resolved the org's system user for `createdBy`.
+          userId: workflowRun.createdBy ?? undefined,
         }
 
         // Execute workflow asynchronously
@@ -380,7 +383,7 @@ export async function POST(
           .executeWorkflow(publishedWorkflow, triggerEvent, {
             debug: false,
             organizationId: sharedWorkflow.organizationId,
-            workflowRunId: workflowRun!.id,
+            workflowRunId: workflowRun.id,
             workflowAppId: sharedWorkflow.id,
             reporter,
           })
@@ -395,10 +398,10 @@ export async function POST(
                     ? WorkflowRunStatus.SUCCEEDED
                     : WorkflowRunStatus.FAILED,
                 error: result.error,
-                elapsedTime: (Date.now() - new Date(workflowRun!.createdAt).getTime()) / 1000,
+                elapsedTime: (Date.now() - new Date(workflowRun.createdAt).getTime()) / 1000,
                 finishedAt: new Date(),
               })
-              .where(eq(schema.WorkflowRun.id, workflowRun!.id))
+              .where(eq(schema.WorkflowRun.id, workflowRun.id))
           })
           .catch(async (error) => {
             // Handle workflow pause — expected behavior, not an error
@@ -410,10 +413,10 @@ export async function POST(
                   pausedAt: new Date(),
                   pausedNodeId: error.state.currentNodeId,
                 })
-                .where(eq(schema.WorkflowRun.id, workflowRun!.id))
+                .where(eq(schema.WorkflowRun.id, workflowRun.id))
 
               logger.info('Shared workflow execution paused', {
-                workflowRunId: workflowRun!.id,
+                workflowRunId: workflowRun.id,
                 nodeId: error.state.currentNodeId,
                 reason: error.state.pauseReason?.type,
               })
@@ -422,7 +425,7 @@ export async function POST(
 
             logger.error('Shared workflow execution failed', {
               error: error instanceof Error ? error.message : String(error),
-              workflowRunId: workflowRun!.id,
+              workflowRunId: workflowRun.id,
             })
 
             // Update workflow run with error
@@ -433,11 +436,11 @@ export async function POST(
                 error: error instanceof Error ? error.message : 'Workflow execution failed',
                 finishedAt: new Date(),
               })
-              .where(eq(schema.WorkflowRun.id, workflowRun!.id))
+              .where(eq(schema.WorkflowRun.id, workflowRun.id))
 
             send({
               event: WorkflowEventType.ERROR,
-              workflowRunId: workflowRun!.id,
+              workflowRunId: workflowRun.id,
               timestamp: new Date().toISOString(),
               data: {
                 message: error instanceof Error ? error.message : 'Workflow execution failed',
@@ -490,7 +493,7 @@ export async function POST(
 
         send({
           event: WorkflowEventType.ERROR,
-          workflowRunId: workflowRun?.id || 'unknown',
+          workflowRunId: workflowRun.id,
           timestamp: new Date().toISOString(),
           data: {
             message: error instanceof Error ? error.message : 'Failed to start workflow',
@@ -509,7 +512,7 @@ export async function POST(
       'Cache-Control': 'no-cache',
       Connection: 'keep-alive',
       'X-Accel-Buffering': 'no',
-      'X-Run-Id': workflowRun?.id || '',
+      'X-Run-Id': workflowRun.id,
     },
   })
 }

--- a/apps/web/src/components/workflow/share/hooks/use-workflow-run.ts
+++ b/apps/web/src/components/workflow/share/hooks/use-workflow-run.ts
@@ -5,6 +5,7 @@ import { WorkflowEventType } from '@auxx/lib/workflow-engine/client'
 import type { ContentSegment } from '@auxx/lib/workflow-engine/types/content-segment'
 import { usePassport } from '@auxx/ui/passport'
 import { useCallback, useRef } from 'react'
+import { readErrorMessage } from '../utils/error-message'
 import { useWorkflowShareStore } from '../workflow-share-provider'
 
 /**
@@ -171,8 +172,8 @@ export function useWorkflowRun(shareToken: string) {
         })
 
         if (!response.ok) {
-          const error = await response.json().catch(() => ({ message: 'Failed to start workflow' }))
-          throw new Error(error.message || 'Failed to start workflow')
+          const body = await response.json().catch(() => null)
+          throw new Error(readErrorMessage(body, 'Failed to start workflow'))
         }
 
         // Get run ID from header

--- a/apps/web/src/components/workflow/share/hooks/use-workflow-share.ts
+++ b/apps/web/src/components/workflow/share/hooks/use-workflow-share.ts
@@ -2,6 +2,7 @@
 
 import { useCallback } from 'react'
 import { useEnv } from '~/providers/dehydrated-state-provider'
+import { readErrorMessage } from '../utils/error-message'
 
 /**
  * Shared workflow site info from API
@@ -54,8 +55,8 @@ export function useWorkflowShare(shareToken: string) {
   const fetchSiteInfo = useCallback(async (): Promise<WorkflowSiteInfo> => {
     const res = await fetch(`${apiUrl}/workflows/share/${shareToken}/site`)
     if (!res.ok) {
-      const error = await res.json().catch(() => ({ message: 'Failed to fetch site info' }))
-      throw new Error(error.message || 'Failed to fetch site info')
+      const body = await res.json().catch(() => null)
+      throw new Error(readErrorMessage(body, 'Failed to fetch site info'))
     }
     const { data } = await res.json()
     return data
@@ -72,8 +73,8 @@ export function useWorkflowShare(shareToken: string) {
         },
       })
       if (!res.ok) {
-        const error = await res.json().catch(() => ({ message: 'Failed to fetch run status' }))
-        throw new Error(error.message || 'Failed to fetch run status')
+        const body = await res.json().catch(() => null)
+        throw new Error(readErrorMessage(body, 'Failed to fetch run status'))
       }
       const { data } = await res.json()
       return data

--- a/apps/web/src/components/workflow/share/utils/error-message.ts
+++ b/apps/web/src/components/workflow/share/utils/error-message.ts
@@ -1,0 +1,25 @@
+// apps/web/src/components/workflow/share/utils/error-message.ts
+
+/**
+ * Read a human-readable message out of a failed share-API response body.
+ *
+ * The public share surface talks to two APIs that disagree on the shape of an
+ * error: the Next.js route handlers answer `{ error: 'message' }`, the Hono API
+ * answers `{ success: false, error: { code, message } }`. Every caller here used
+ * to read `body.message`, which neither of them sets — so every failure on the
+ * public page rendered its generic fallback, whatever the server actually said.
+ */
+export function readErrorMessage(body: unknown, fallback: string): string {
+  if (typeof body !== 'object' || body === null) return fallback
+
+  const { error, message } = body as { error?: unknown; message?: unknown }
+
+  if (typeof error === 'string' && error) return error
+  if (typeof error === 'object' && error !== null) {
+    const nested = (error as { message?: unknown }).message
+    if (typeof nested === 'string' && nested) return nested
+  }
+  if (typeof message === 'string' && message) return message
+
+  return fallback
+}

--- a/apps/web/src/components/workflow/share/workflow-share-provider.tsx
+++ b/apps/web/src/components/workflow/share/workflow-share-provider.tsx
@@ -7,6 +7,7 @@ import { createContext, type ReactNode, useCallback, useContext, useRef } from '
 import { createStore, type StoreApi, useStore } from 'zustand'
 import { useEnv } from '~/providers/dehydrated-state-provider'
 import type { WorkflowSiteInfo } from './hooks/use-workflow-share'
+import { readErrorMessage } from './utils/error-message'
 
 const WORKFLOW_PASSPORT_STORAGE_PREFIX = 'auxx_passport_workflow_'
 
@@ -158,10 +159,8 @@ export function WorkflowShareProvider({ shareToken, children }: WorkflowSharePro
         credentials: 'include',
       })
       if (!res.ok) {
-        const error = await res
-          .json()
-          .catch(() => ({ message: 'You dont have access to this workflow' }))
-        throw new Error(error.message || 'You dont have access to this workflow')
+        const body = await res.json().catch(() => null)
+        throw new Error(readErrorMessage(body, 'You dont have access to this workflow'))
       }
       const { data } = await res.json()
       return {

--- a/packages/lib/scripts/set-workflow-runs-limit.ts
+++ b/packages/lib/scripts/set-workflow-runs-limit.ts
@@ -1,0 +1,136 @@
+// packages/lib/scripts/set-workflow-runs-limit.ts
+/**
+ * Dev lever for testing the `workflowRuns` quota refusal on a real org.
+ *
+ * `PlanSubscription.customFeatureLimits` is the purpose-built per-org override —
+ * `features-provider` merges it over the plan's map LAST and unconditionally, so
+ * it works whatever the subscription's plan or status. Writing it is only half
+ * the job: the `features` org-cache key is already warm in the running web/worker
+ * processes, so the write is invisible until `onCacheEvent('plan.changed')` busts
+ * it. Both halves are here.
+ *
+ * The usage counter itself lives in Redis at
+ * `usage:<orgId>:workflowRuns:<YYYY-MM>` — `--reset-usage` clears it so a
+ * scenario can be re-run without waiting for the month to roll over.
+ *
+ * This is the same thing the admin UI does
+ * (`/admin/organizations/<id>` → Features → Save Custom Limits, which calls
+ * `admin.billing.configureCustomLimits`). Use the UI when you have a superadmin
+ * session; use this when you want it scripted or repeatable.
+ *
+ * Run (from repo root):
+ *   npx dotenv -- npx tsx packages/lib/scripts/set-workflow-runs-limit.ts <org> <limit|clear> [--reset-usage]
+ *
+ *   <org>    organization id, or a case-insensitive name fragment
+ *   <limit>  monthly hard cap to force (soft is set to the same), or `clear`
+ *            to remove both keys and fall back to the plan
+ *
+ * Examples:
+ *   … set-workflow-runs-limit.ts 'Koko Enterprise' 1 --reset-usage
+ *   … set-workflow-runs-limit.ts 'Koko Enterprise' clear --reset-usage
+ */
+
+import { database } from '@auxx/database'
+import { getRedisClient } from '@auxx/redis'
+import { onCacheEvent } from '../src/cache'
+
+const HARD = 'workflowRunsPerMonthHard'
+const SOFT = 'workflowRunsPerMonthSoft'
+
+function monthKey(): string {
+  const now = new Date()
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+}
+
+async function resolveOrg(needle: string): Promise<{ id: string; name: string }> {
+  const byId = await database.$client.query(
+    'SELECT id, name FROM "Organization" WHERE id = $1 LIMIT 1',
+    [needle]
+  )
+  if (byId.rows.length > 0) return byId.rows[0]
+
+  const byName = await database.$client.query(
+    'SELECT id, name FROM "Organization" WHERE name ILIKE $1 ORDER BY name LIMIT 5',
+    [`%${needle}%`]
+  )
+  if (byName.rows.length === 0) throw new Error(`No organization matches "${needle}"`)
+  if (byName.rows.length > 1) {
+    throw new Error(
+      `"${needle}" matches ${byName.rows.length} orgs: ${byName.rows
+        .map((r: { name: string; id: string }) => `${r.name} (${r.id})`)
+        .join(', ')}`
+    )
+  }
+  return byName.rows[0]
+}
+
+async function main() {
+  const [orgArg, limitArg, ...flags] = process.argv.slice(2)
+  if (!orgArg || !limitArg) {
+    console.error('usage: set-workflow-runs-limit.ts <org id|name> <limit|clear> [--reset-usage]')
+    process.exit(1)
+  }
+
+  const clearing = limitArg === 'clear'
+  const limit = clearing ? null : Number(limitArg)
+  if (!clearing && (!Number.isInteger(limit) || (limit as number) < 0)) {
+    throw new Error(`<limit> must be a non-negative integer or "clear", got "${limitArg}"`)
+  }
+
+  const org = await resolveOrg(orgArg)
+  console.log(`org: ${org.name} (${org.id})`)
+
+  const sub = await database.$client.query(
+    'SELECT id, status, "customFeatureLimits" FROM "PlanSubscription" WHERE "organizationId" = $1 LIMIT 1',
+    [org.id]
+  )
+  if (sub.rows.length === 0) {
+    throw new Error(
+      `${org.name} has no PlanSubscription row — nothing to override. Its features come ` +
+        `from the demo/free fallback plan; give it a subscription first.`
+    )
+  }
+
+  const raw = sub.rows[0].customFeatureLimits
+  const current: Record<string, unknown> = (typeof raw === 'string' ? JSON.parse(raw) : raw) ?? {}
+  console.log(`subscription: ${sub.rows[0].id} (${sub.rows[0].status})`)
+  console.log(`before: ${JSON.stringify(current)}`)
+
+  const next = { ...current }
+  if (clearing) {
+    delete next[HARD]
+    delete next[SOFT]
+  } else {
+    next[HARD] = limit
+    next[SOFT] = limit
+  }
+
+  const isEmpty = Object.keys(next).length === 0
+  await database.$client.query(
+    'UPDATE "PlanSubscription" SET "customFeatureLimits" = $1 WHERE "organizationId" = $2',
+    [isEmpty ? null : JSON.stringify(next), org.id]
+  )
+  console.log(`after:  ${isEmpty ? 'null' : JSON.stringify(next)}`)
+
+  // The write is invisible to a warm process until the `features` key is busted.
+  await onCacheEvent('plan.changed', { orgId: org.id })
+  console.log("busted the org's `features` cache key")
+
+  const redis = await getRedisClient(true)
+  const usageKey = `usage:${org.id}:workflowRuns:${monthKey()}`
+  if (redis) {
+    if (flags.includes('--reset-usage')) {
+      await redis.del(usageKey)
+      console.log(`usage:  reset ${usageKey} → 0`)
+    } else {
+      console.log(`usage:  ${usageKey} = ${(await redis.get(usageKey)) ?? '0'}`)
+    }
+  }
+
+  process.exit(0)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/packages/lib/src/jobs/workflow/scheduled-trigger-job.test.ts
+++ b/packages/lib/src/jobs/workflow/scheduled-trigger-job.test.ts
@@ -126,8 +126,14 @@ vi.mock('../../users/system-user-service', () => ({
   SystemUserService: { getSystemUserForActions },
 }))
 
-// No plan/quota lookup — the guard needs a live database and is not what is under test.
-vi.mock('../../usage/create-usage-guard', () => ({ createUsageGuard: async () => null }))
+/**
+ * The guard needs a live database, so it is faked. `null` is the real fail-open
+ * shape (Redis unavailable) and is the default for every test here that is not
+ * about metering; the metering tests swap in a stub for the call they assert on.
+ */
+const consume = vi.fn(async () => ({ allowed: true, current: 1, limit: 10 }))
+let usageGuard: { consume: typeof consume } | null = null
+vi.mock('../../usage/create-usage-guard', () => ({ createUsageGuard: async () => usageGuard }))
 
 vi.mock('../../workflow-engine', () => ({
   RedisWorkflowExecutionReporter: class {
@@ -272,7 +278,10 @@ describe('createWorkflowRun — the sink that owns the resolution', () => {
     graph,
   }
 
-  async function create(userId: string | null | undefined) {
+  async function create(
+    userId: string | null | undefined,
+    extra: { endUserId?: string | null } = {}
+  ) {
     const { createWorkflowRun } = await import('../../workflows/workflow-execution-service')
     const { database } = await import('@auxx/database')
     responses = [{ from: 'WorkflowRun', rows: [] }]
@@ -282,8 +291,15 @@ describe('createWorkflowRun — the sink that owns the resolution', () => {
       inputs: {},
       mode: 'production',
       userId,
+      ...extra,
     })
   }
+
+  beforeEach(() => {
+    usageGuard = null
+    consume.mockClear()
+    consume.mockResolvedValue({ allowed: true, current: 1, limit: 10 })
+  })
 
   it.each([
     ['null', null],
@@ -300,5 +316,59 @@ describe('createWorkflowRun — the sink that owns the resolution', () => {
 
     expect(insertSpy.values?.createdBy).toBe(AUTHOR)
     expect(getSystemUserForActions).not.toHaveBeenCalled()
+  })
+
+  /**
+   * `endUserId` is an FK to `EndUser.id`, not `User.id`, and exists for exactly
+   * one door: a public share link. The public-share route used to hand-insert
+   * its own row *because* this parameter did not exist — which is how that door
+   * skipped the metering below. Every other door must keep writing `null`.
+   */
+  describe('endUserId', () => {
+    it('is null when the caller does not pass one', async () => {
+      await create(AUTHOR)
+
+      expect(insertSpy.values?.endUserId).toBeNull()
+    })
+
+    it('is written through for a public-share run', async () => {
+      await create(null, { endUserId: 'eus_1' })
+
+      expect(insertSpy.values?.endUserId).toBe('eus_1')
+      // Still the system user — an end user is not a `User`.
+      expect(insertSpy.values?.createdBy).toBe(SYSTEM_USER)
+    })
+  })
+
+  /**
+   * The metering every production door inherits by coming through here. This is
+   * the whole reason a door may not hand-insert its own `WorkflowRun`.
+   */
+  describe('the usage guard', () => {
+    it('consumes one `workflowRuns` before inserting', async () => {
+      usageGuard = { consume }
+
+      await create(AUTHOR)
+
+      expect(consume).toHaveBeenCalledWith(ORG, 'workflowRuns', { userId: AUTHOR })
+      expect(insertSpy.values).toBeDefined()
+    })
+
+    it('refuses over the limit — UsageLimitError, and no row', async () => {
+      usageGuard = { consume }
+      consume.mockResolvedValue({ allowed: false, current: 10, limit: 10 })
+      const { UsageLimitError } = await import('../../errors')
+
+      await expect(create(AUTHOR)).rejects.toBeInstanceOf(UsageLimitError)
+      expect(insertSpy.values).toBeUndefined()
+    })
+
+    it('meters an anonymous public-share run against the org, with no user', async () => {
+      usageGuard = { consume }
+
+      await create(null, { endUserId: 'eus_1' })
+
+      expect(consume).toHaveBeenCalledWith(ORG, 'workflowRuns', { userId: undefined })
+    })
   })
 })

--- a/packages/lib/src/workflows/index.ts
+++ b/packages/lib/src/workflows/index.ts
@@ -48,7 +48,11 @@ export {
   WorkflowExecutionEvents,
   workflowExecutionEvents,
 } from './workflow-execution-events'
-export { WorkflowExecutionService } from './workflow-execution-service'
+export {
+  type CreatedWorkflowRun,
+  createWorkflowRun,
+  WorkflowExecutionService,
+} from './workflow-execution-service'
 // Export all services
 export { toWorkflowAppResponse, WorkflowService } from './workflow-service'
 export { WorkflowStatsService } from './workflow-stats-service'

--- a/packages/lib/src/workflows/workflow-execution-service.ts
+++ b/packages/lib/src/workflows/workflow-execution-service.ts
@@ -132,6 +132,12 @@ export async function createWorkflowRun(
      * share) pass their own so run history can tell them apart.
      */
     triggeredFrom?: (typeof WorkflowTriggerSource)[keyof typeof WorkflowTriggerSource]
+    /**
+     * The `EndUser` who triggered this run, for public-share runs. Omit for
+     * every other door — an internal run has no end user, and this is an FK to
+     * `EndUser.id`, not `User.id`.
+     */
+    endUserId?: string | null
   }
 ) {
   const { workflow, organizationId, inputs, mode, userId } = params
@@ -194,6 +200,7 @@ export async function createWorkflowRun(
       totalTokens: 0,
       totalSteps: nodeCount,
       createdBy: effectiveUserId,
+      endUserId: params.endUserId ?? null,
     })
     .returning({
       id: schema.WorkflowRun.id,


### PR DESCRIPTION
Closes the last hand-rolled `WorkflowRun` insert. #1774 closed the webhook door; this closes the public-share one.

## The hole

`apps/web/src/app/api/workflows/shared/[shareToken]/run/route.ts` hand-inserted its own run row. It duplicated the sequence-number query, the node count and the system-user resolution `createWorkflowRun` already owns — and skipped the one thing only `createWorkflowRun` does:

```ts
if (mode === 'production') {
  const guard = await createUsageGuard(db)
  if (guard) { /* consume 'workflowRuns' or throw UsageLimitError */ }
}
```

So a public share link executed production workflows — AI nodes, HTTP calls, CRUD writes — without ever consuming quota. The run row was written, run history showed it, `WorkflowApp.totalRuns` incremented; the meter never moved.

Worse than the webhook door: a webhook URL is a semi-secret string handed to a known sender. A share link is *meant* to be handed to anonymous end users, and the only thing in front of it is `checkWorkflowRateLimit`, whose config (`WorkflowApp.rateLimit`) is author-set and may be `null` — free-running. All five seeded plans define `workflowRunsPerMonthHard` (Demo 10 → Enterprise unlimited), so a Demo org could serve unlimited public runs on a 10-run plan.

After this, `insert(schema.WorkflowRun)` appears exactly once in non-test source.

## Why it wasn't a one-liner

`createWorkflowRun` had **no `endUserId` parameter** — an FK to `EndUser.id`, and the entire reason this route hand-inserted. It also wasn't exported from the workflows barrel, only reachable by relative import from inside lib. Both fixed; `endUserId` defaults to `null`, so no other door changes. `CreatedWorkflowRun` and the `.returning()` projection are untouched.

## The refusal is 503, not 403

`UsageLimitError` is a 403 whose message names the org's plan posture. The webhook route returns it verbatim, which is right there — the caller is the org's own integration. Here the caller is a stranger on the internet, so: real metric/current/limit to `logger.warn`, neutral sentence to the visitor. 503 because the caller is not unauthorized (403) and nothing they do changes the outcome this month (429).

## Drive-by: the public page never showed a real error

Every share-surface fetch read `body.message`. The Next routes answer `{ error: 'msg' }`; the Hono share API answers `{ success: false, error: { code, message } }`. Neither sets `message`, so the page had **always** rendered its generic fallback — for bad passports, missing workflows, rate limits, everything. One helper (`share/utils/error-message.ts`) now reads all three shapes, used by `use-workflow-run`, `use-workflow-share` (x2) and `workflow-share-provider`. The two `public-file-input.tsx` sites already read `err.error` and were left alone.

## Verification

Driven live against the dev org, with the share `rateLimit` null and the cap forced to 1:

| | run 1 | run 2 |
|---|---|---|
| HTTP | 200 | **503** |
| page | `Completed / "We ran."` | *"This workflow is temporarily unavailable. Please try again later."* |
| `WorkflowRun` | created — `triggeredFrom: PUBLIC_SHARE`, `endUserId` preserved, `createdBy` = org system user, seq 1, `totalSteps` 2 | none |
| `WorkflowApp.totalRuns` | 1 | still 1 |

Log on the refusal: `Public share run refused — plan limit reached {metric: workflowRuns, current: 1, limit: 1}` — and the response body names no plan detail.

Tests: 6 new for the route, 7 new for the sink (real `createWorkflowRun`) covering `endUserId` default/passthrough and the guard consuming, refusing without inserting, and metering an anonymous run against the org with no user. Typecheck ratchet clean (lib 29/29, web 0/0).

## One thing to check before merge

Whether live orgs with a share link enabled carry a `workflowRunsPerMonthHard` **`Feature` row**. Without one, `getLimit` returns `null`, `consume` reports `featureNotAvailable`, and every public run on that org is refused. All five seeded plans define the key, so this only bites orgs whose features predate it. `packages/lib/scripts/set-workflow-runs-limit.ts` (included) is the lever for checking and overriding per-org.