### PR TITLE
feat(workflow): name the node in history entries, with a reusable node badge

### DIFF
--- a/apps/web/src/components/workflow/hooks/use-node-addition.ts
+++ b/apps/web/src/components/workflow/hooks/use-node-addition.ts
@@ -22,7 +22,11 @@ import {
   type Size,
 } from '../utils/node-layout'
 import { createResizedParentNode } from '../utils/node-resize-utils'
-import { useWorkflowHistory, WorkflowHistoryEvent } from './use-save-to-history'
+import {
+  type SaveHistoryOptions,
+  useWorkflowHistory,
+  WorkflowHistoryEvent,
+} from './use-save-to-history'
 import { useWorkflowSave } from './use-workflow-save'
 // Variable syncing now handled automatically by VarStoreSyncProvider
 
@@ -298,7 +302,7 @@ export const useNodeAddition = () => {
 
         // Save and history
         debouncedSave()
-        saveStateToHistory(WorkflowHistoryEvent.NodeAdd)
+        saveStateToHistory(WorkflowHistoryEvent.NodeAdd, { nodeId: newNode.id })
 
         return newNode.id
       } catch (error) {
@@ -370,7 +374,7 @@ function handleReplaceNode(
   edges: FlowEdge[],
   store: any,
   debouncedSave: () => void,
-  saveStateToHistory: (event: WorkflowHistoryEvent) => void
+  saveStateToHistory: (event: WorkflowHistoryEvent, options?: SaveHistoryOptions) => void
 ): string {
   const nodeToReplace = nodes.find((n) => n.id === replaceNodeId)
   if (!nodeToReplace) {
@@ -453,7 +457,7 @@ function handleReplaceNode(
 
   // Save and history
   debouncedSave()
-  saveStateToHistory(WorkflowHistoryEvent.NodeAdd)
+  saveStateToHistory(WorkflowHistoryEvent.NodeAdd, { nodeId: newNode.id })
 
   return newNode.id
 }

--- a/apps/web/src/components/workflow/hooks/use-node-data-update.ts
+++ b/apps/web/src/components/workflow/hooks/use-node-data-update.ts
@@ -55,6 +55,7 @@ export const useNodeDataUpdate = () => {
       // finer, but `setInputs` hands over a whole data object, so which field
       // moved is not knowable here.
       saveStateToHistory(WorkflowHistoryEvent.NodeChange, {
+        nodeId: payload.id,
         coalesceKey: `NodeChange:${payload.id}`,
       })
     },

--- a/apps/web/src/components/workflow/hooks/use-node-interactions.ts
+++ b/apps/web/src/components/workflow/hooks/use-node-interactions.ts
@@ -138,7 +138,7 @@ export const useNodesInteractions = () => {
 
           // Sync and save to history
           debouncedSave()
-          saveStateToHistory(WorkflowHistoryEvent.NodeAdd)
+          saveStateToHistory(WorkflowHistoryEvent.NodeAdd, { nodeId: newNodeId })
         }
       } else if (connectionParams.nextNodeId) {
         // Adding node before target
@@ -190,7 +190,7 @@ export const useNodesInteractions = () => {
 
           // Sync and save to history
           debouncedSave()
-          saveStateToHistory(WorkflowHistoryEvent.NodeAdd)
+          saveStateToHistory(WorkflowHistoryEvent.NodeAdd, { nodeId: newNodeId })
         }
       }
     },
@@ -384,8 +384,12 @@ export const useNodesInteractions = () => {
         setEdges([...edges, ...edgesToPaste])
       }
 
-      // Save to history
-      saveStateToHistory(WorkflowHistoryEvent.NodePaste)
+      // Save to history. One pasted node gets named; several get counted,
+      // because naming one of them is worse than naming none.
+      saveStateToHistory(WorkflowHistoryEvent.NodePaste, {
+        nodeId: nodesToPaste.length === 1 ? nodesToPaste[0]?.id : undefined,
+        count: nodesToPaste.length,
+      })
       debouncedSave()
 
       // Show success toast
@@ -488,7 +492,7 @@ export const useNodesInteractions = () => {
 
       debouncedSave()
 
-      saveStateToHistory(WorkflowHistoryEvent.NodeDelete)
+      saveStateToHistory(WorkflowHistoryEvent.NodeDelete, { nodeId })
 
       closeDrawer()
     },
@@ -677,6 +681,7 @@ export const useNodesInteractions = () => {
       // undo step; the event type is part of it, so a resize and a drag of the
       // same node can never merge.
       saveStateToHistory(WorkflowHistoryEvent.NodeResize, {
+        nodeId,
         coalesceKey: `NodeResize:${nodeId}`,
       })
     },
@@ -812,7 +817,18 @@ export const useNodesInteractions = () => {
         // origin. `positionChanged` above is the correct test, and it covers
         // multi-select too: every selected node moves by the delta of the
         // GRABBED node, so a zero delta on that one is a zero delta on all.
-        saveStateToHistory(WorkflowHistoryEvent.NodeDragStop)
+        //
+        // How many nodes actually moved is recomputed the same way
+        // `handleNodeDrag` decides it — `draggedNodeIds` lives in drag START's
+        // scope and a ref would only restate what the store already knows.
+        const { nodes } = store.getState()
+        const selected = nodes.filter((n) => n.selected)
+        const isMultiDrag = selected.length > 1 && selected.some((n) => n.id === node.id)
+
+        saveStateToHistory(WorkflowHistoryEvent.NodeDragStop, {
+          nodeId: isMultiDrag ? undefined : node.id,
+          count: isMultiDrag ? selected.length : 1,
+        })
       }
       handleClearHelpline()
 
@@ -826,7 +842,7 @@ export const useNodesInteractions = () => {
 
       endDragWindow()
     },
-    [getNodesReadOnly, debouncedSave, handleClearHelpline, saveStateToHistory]
+    [getNodesReadOnly, store, debouncedSave, handleClearHelpline, saveStateToHistory]
   )
 
   const handleNodeSelect = useCallback(
@@ -1220,7 +1236,10 @@ export const useNodesInteractions = () => {
 
       setNodes(newNodes)
       debouncedSave()
-      saveStateToHistory(WorkflowHistoryEvent.NodeCollapse)
+      saveStateToHistory(WorkflowHistoryEvent.NodeCollapse, {
+        nodeId: targetNodeIds.length === 1 ? targetNodeIds[0] : undefined,
+        count: targetNodeIds.length,
+      })
     },
     [getNodesReadOnly, store, debouncedSave, saveStateToHistory]
   )

--- a/apps/web/src/components/workflow/hooks/use-save-to-history.ts
+++ b/apps/web/src/components/workflow/hooks/use-save-to-history.ts
@@ -2,9 +2,9 @@
 
 import { useStoreApi } from '@xyflow/react'
 import { useCallback, useState } from 'react'
-import type { RecordOptions } from '../store/history-manager'
 import { useHistoryManager } from '../store/workflow-store-provider'
 import type { FlowEdge, FlowNode } from '../types'
+import { describeHistoryEntry } from '../utils/history-description'
 import { snapshotGraph } from '../utils/history-snapshot'
 
 /**
@@ -35,13 +35,47 @@ export enum WorkflowHistoryEvent {
 }
 
 /**
- * The popover's wording for an event.
+ * The bare verb for an event, used when the entry names a node and the popover
+ * renders `<badge> <verb>` instead of a sentence.
  *
- * Deliberately coarse. A label family per node *type* (the old `Note*` members)
- * costs one special case per verb and changes nothing about what is undoable,
- * and a per-*field* label is not derivable at all: `useNodeCrud.setInputs`
- * hands the update path a whole data object, so a title edit and a duration
- * edit are indistinguishable by the time they get here.
+ * `undefined` for events with no single node subject — edges and layout — which
+ * keep the sentence from {@link getHistoryLabel}. Edge endpoints are
+ * deliberately not named: two badges per row does not fit the popover, and
+ * "which edge" is not a question the timeline is good at answering anyway.
+ */
+export function getHistoryVerb(event: WorkflowHistoryEvent): string | undefined {
+  switch (event) {
+    case WorkflowHistoryEvent.NodeAdd:
+      return 'added'
+    case WorkflowHistoryEvent.NodeChange:
+      return 'changed'
+    case WorkflowHistoryEvent.NodeDelete:
+      return 'deleted'
+    case WorkflowHistoryEvent.NodePaste:
+      return 'pasted'
+    case WorkflowHistoryEvent.NodeDragStop:
+      return 'moved'
+    case WorkflowHistoryEvent.NodeResize:
+      return 'resized'
+    case WorkflowHistoryEvent.NodeCollapse:
+      return 'collapsed'
+    case WorkflowHistoryEvent.EdgeAdd:
+    case WorkflowHistoryEvent.EdgeDelete:
+    case WorkflowHistoryEvent.EdgeDeleteByDeleteBranch:
+    case WorkflowHistoryEvent.LayoutOrganize:
+      return undefined
+  }
+}
+
+/**
+ * The sentence for an event when nothing more specific is known — an untitled
+ * node, an edge, a layout command.
+ *
+ * Deliberately coarse *per node type*: a label family per type (the old `Note*`
+ * members) costs one special case per verb and changes nothing about what is
+ * undoable. Per *field* is a different question, and `describeHistoryEntry`
+ * answers the one part of it that matters — rename — by diffing graphs rather
+ * than by asking the call site, which genuinely cannot tell.
  */
 export function getHistoryLabel(event: WorkflowHistoryEvent): string {
   switch (event) {
@@ -67,6 +101,16 @@ export function getHistoryLabel(event: WorkflowHistoryEvent): string {
     case WorkflowHistoryEvent.LayoutOrganize:
       return 'Layout organized'
   }
+}
+
+/** Extra facts a call site can supply so its entry names what it acted on. */
+export interface SaveHistoryOptions {
+  /** See `RecordOptions.coalesceKey`. */
+  coalesceKey?: string
+  /** The node this action is about, when it is exactly one. */
+  nodeId?: string
+  /** Nodes affected, when more than one — suppresses the badge in favour of a count. */
+  count?: number
 }
 
 /**
@@ -108,19 +152,39 @@ export const useWorkflowHistory = () => {
    * buttons and the history popover are correct the instant the edit lands.
    * High-frequency callers (panel typing, resize) pass a `coalesceKey` so their
    * burst collapses into a single entry; see `HistoryManager.record`.
+   *
+   * Callers that act on one node pass its `nodeId` so the entry can name it.
+   * The id is enough — the title and type are resolved here, from the new graph
+   * or, for a delete, from the one being recorded over.
    */
   const saveStateToHistory = useCallback(
-    (event: WorkflowHistoryEvent, options?: RecordOptions) => {
+    (event: WorkflowHistoryEvent, options: SaveHistoryOptions = {}) => {
       const { nodes, edges } = store.getState()
+      const { coalesceKey, nodeId, count } = options
+      const fallbackLabel = getHistoryLabel(event)
 
       historyManager.record(
         {
           action: 'workflow_event',
           store: 'workflow',
           data: snapshotGraph(event, nodes, edges),
-          label: getHistoryLabel(event),
+          label: fallbackLabel,
         },
-        options
+        {
+          coalesceKey,
+          describe: (baseline) =>
+            describeHistoryEntry(
+              {
+                verb: getHistoryVerb(event),
+                fallbackLabel,
+                nodeId,
+                count,
+                detectRename: event === WorkflowHistoryEvent.NodeChange,
+                nodes,
+              },
+              baseline
+            ),
+        }
       )
     },
     [store, historyManager]

--- a/apps/web/src/components/workflow/store/__tests__/history-coalescing.test.ts
+++ b/apps/web/src/components/workflow/store/__tests__/history-coalescing.test.ts
@@ -241,3 +241,100 @@ describe('HistoryManager batching', () => {
     expect(manager.getHistory()[0].label).toBe('Layout organization')
   })
 })
+
+// The description half. `describe` exists so a label can be derived against the
+// state the entry is recorded ON TOP OF — the only way a delete can name what it
+// deleted, and the only way a rename can be spotted at all. Which entry counts
+// as "on top of" differs between a push and a merge, and getting that wrong is
+// what would make a rename label drift with every keystroke.
+describe('HistoryManager.record — describe', () => {
+  it('passes the current top as the baseline on a push', () => {
+    const manager = new HistoryManager()
+    const seen: (string | undefined)[] = []
+
+    manager.record(entry('first'))
+    manager.record(entry('second'), {
+      describe: (baseline) => {
+        seen.push(baseline?.label)
+        return { label: 'described' }
+      },
+    })
+
+    expect(seen).toEqual(['first'])
+    expect(manager.getHistory()[1].label).toBe('described')
+  })
+
+  it('passes the entry BELOW the merge target as the baseline on a merge', () => {
+    const manager = new HistoryManager()
+    const seen: (string | undefined)[] = []
+    const watch = (tag: string) => ({
+      coalesceKey: 'NodeChange:n1',
+      describe: (baseline: { label?: string } | undefined) => {
+        seen.push(baseline?.label)
+        return { label: tag }
+      },
+    })
+
+    manager.record(entry('pre-session'))
+    manager.record(entry('typing-1'), watch('described-1'))
+    manager.record(entry('typing-2'), watch('described-2'))
+    manager.record(entry('typing-3'), watch('described-3'))
+
+    // Every call sees the state the session STARTED from, not the partially
+    // typed entry it is about to overwrite. That is what makes a rename label
+    // converge on the final title instead of chasing each keystroke.
+    expect(seen).toEqual(['pre-session', 'pre-session', 'pre-session'])
+    expect(manager.getHistory()).toHaveLength(2)
+    expect(manager.getHistory()[1].label).toBe('described-3')
+  })
+
+  it('passes undefined on the very first record', () => {
+    const manager = new HistoryManager()
+    let called = false
+
+    manager.record(entry('first'), {
+      describe: (baseline) => {
+        called = true
+        expect(baseline).toBeUndefined()
+        return {}
+      },
+    })
+
+    expect(called).toBe(true)
+  })
+
+  it('replaces subject and verb on a merge, and CLEARS a rename that was undone', () => {
+    const manager = new HistoryManager()
+    manager.record(entry('pre-session'))
+
+    manager.record(entry('renamed'), {
+      coalesceKey: 'NodeChange:n1',
+      describe: () => ({
+        label: 'A renamed to B',
+        verb: 'renamed to',
+        subject: { id: 'n1', title: 'A' },
+        renamedTo: 'B',
+      }),
+    })
+    expect(manager.getHistory()[1].renamedTo).toBe('B')
+
+    // Typed the original name back: the entry must stop claiming a rename.
+    manager.record(entry('renamed-back'), {
+      coalesceKey: 'NodeChange:n1',
+      describe: () => ({ label: 'A changed', verb: 'changed', subject: { id: 'n1', title: 'A' } }),
+    })
+
+    const top = manager.getHistory()[1]
+    expect(top.renamedTo).toBeUndefined()
+    expect(top.verb).toBe('changed')
+    expect(top.label).toBe('A changed')
+  })
+
+  it('keeps the plain label when no describe is given', () => {
+    const manager = new HistoryManager()
+    manager.record(entry('plain'))
+
+    expect(manager.getHistory()[0].label).toBe('plain')
+    expect(manager.getHistory()[0].subject).toBeUndefined()
+  })
+})

--- a/apps/web/src/components/workflow/store/history-manager.ts
+++ b/apps/web/src/components/workflow/store/history-manager.ts
@@ -2,7 +2,7 @@
 
 import { v4 as uuidv4 } from 'uuid'
 import { storeEventBus } from './event-bus'
-import type { HistoryEntry } from './types'
+import type { HistoryDescription, HistoryEntry } from './types'
 
 interface HistoryManagerOptions {
   maxHistorySize?: number
@@ -37,6 +37,23 @@ export interface RecordOptions {
    * which is what stops two unrelated edits collapsing into a single entry.
    */
   coalesceKey?: string
+
+  /**
+   * Describe the entry against the state it is being recorded ON TOP OF.
+   *
+   * On a push, `baseline` is the current top of the stack. On a MERGE it is the
+   * entry *below* the one being overwritten — the state the coalescing session
+   * began from — and the result replaces the merged entry's description. Both
+   * halves matter:
+   *
+   * - The baseline is how a description can name something the new graph no
+   *   longer has, which is the only way a delete knows what it deleted.
+   * - Re-describing on every merge is how a rename converges. Typing `O`,
+   *   `Ou`, `Out`, `Output` re-diffs each time against the PRE-SESSION title,
+   *   so the entry settles on "Node 1 renamed to Output" instead of freezing at
+   *   the first keystroke or drifting to "Out renamed to Output".
+   */
+  describe?: (baseline: HistoryEntry | undefined) => HistoryDescription
 }
 
 /**
@@ -94,20 +111,29 @@ export class HistoryManager {
    * always current, and unrelated edits can never merge into one entry.
    */
   record(entry: Omit<HistoryEntry, 'id' | 'timestamp'>, options: RecordOptions = {}): void {
-    const { coalesceKey } = options
+    const { coalesceKey, describe } = options
     const top = this.undoStack[this.undoStack.length - 1]
     const now = Date.now()
 
-    if (
-      coalesceKey &&
-      top?.coalesceKey === coalesceKey &&
-      now - top.timestamp < this.coalesceWindow
-    ) {
+    const willCoalesce =
+      !!coalesceKey && top?.coalesceKey === coalesceKey && now - top.timestamp < this.coalesceWindow
+
+    // The state this entry is recorded on top of. When merging, the entry being
+    // overwritten is NOT that state — the one below it is.
+    const baseline = this.undoStack[this.undoStack.length - (willCoalesce ? 2 : 1)]
+    const described = describe?.(baseline)
+
+    if (willCoalesce) {
       // The same logical edit continuing: replace the snapshot in place. Undo
       // still lands on the state from before the session began, because that
       // one lives in the PREVIOUS entry.
       top.data = entry.data
-      top.label = entry.label ?? top.label
+      top.label = described?.label ?? entry.label ?? top.label
+      top.subject = described?.subject ?? top.subject
+      top.verb = described?.verb ?? top.verb
+      // Assigned unconditionally: a session that renames and then renames BACK
+      // must drop the claim, not keep the stale one.
+      top.renamedTo = described?.renamedTo
       top.timestamp = now
 
       // A coalesced write is a new action just as much as a pushed one, so it
@@ -124,9 +150,10 @@ export class HistoryManager {
 
     const historyEntry: HistoryEntry = {
       ...entry,
+      ...described,
       id: uuidv4(),
       timestamp: now,
-      label: entry.label ?? this.currentBatch?.label,
+      label: described?.label ?? entry.label ?? this.currentBatch?.label,
       batch: this.currentBatch?.id,
       coalesceKey,
     }

--- a/apps/web/src/components/workflow/store/types.ts
+++ b/apps/web/src/components/workflow/store/types.ts
@@ -36,6 +36,15 @@ export type FlowEdge = BaseFlowEdge
 /**
  * History entry for undo/redo functionality
  */
+/** The workflow node a history entry is about, named as it was AT THAT TIME. */
+export interface HistorySubject {
+  id: string
+  /** Title when the entry was recorded — not a live lookup. */
+  title: string
+  /** Node type, for the badge icon. */
+  nodeType?: string
+}
+
 export interface HistoryEntry {
   id: string
   timestamp: number
@@ -50,7 +59,22 @@ export interface HistoryEntry {
    * `HistoryManager.record`.
    */
   coalesceKey?: string
+  /**
+   * The node this entry acted on. Present only when the entry is about exactly
+   * one node, so the popover can render it as a badge instead of a sentence.
+   */
+  subject?: HistorySubject
+  /** New title, when this entry renamed {@link subject}. */
+  renamedTo?: string
+  /** Bare verb for badge rendering — `added`, `changed`, `moved`. */
+  verb?: string
 }
+
+/**
+ * The descriptive half of an entry, recomputed on every coalesced merge so a
+ * label converges with the session instead of freezing at its first keystroke.
+ */
+export type HistoryDescription = Pick<HistoryEntry, 'label' | 'subject' | 'renamedTo' | 'verb'>
 
 /**
  * User presence information for collaboration

--- a/apps/web/src/components/workflow/ui/history-command-popover.tsx
+++ b/apps/web/src/components/workflow/ui/history-command-popover.tsx
@@ -19,6 +19,41 @@ import { Tooltip } from '~/components/global/tooltip'
 import { storeEventBus } from '~/components/workflow/store/event-bus'
 import type { NavigationHistoryEntry } from '~/components/workflow/store/history-manager'
 import { useHistoryManager } from '~/components/workflow/store/workflow-store-provider'
+import { NodeBadge } from './node-badge'
+
+/**
+ * One entry's description: a badge for the node it acted on, or the plain
+ * sentence when it acted on no single node (edges, layout, a Kopilot edit, a
+ * version restore).
+ *
+ * A rename renders BOTH names — old badge, verb, new badge — with the second
+ * one iconless, so it reads as one node changing name rather than two nodes.
+ * Titles come from the entry, never a live lookup: the point of the row is what
+ * the node was called at the time.
+ */
+function HistoryEntryDescription({ entry }: { entry: NavigationHistoryEntry }) {
+  if (!entry.subject || !entry.verb) {
+    return <span className='text-sm truncate'>{entry.actionDescription}</span>
+  }
+
+  return (
+    // `min-w-0` at every level, or the badges' `truncate` cannot shrink and the
+    // row pushes the step counter off the popover instead.
+    <span className='flex min-w-0 items-center gap-1.5'>
+      <NodeBadge
+        size='sm'
+        className='min-w-0'
+        nodeId={entry.subject.id}
+        title={entry.subject.title}
+        nodeType={entry.subject.nodeType}
+      />
+      <span className='shrink-0 text-sm'>{entry.verb}</span>
+      {entry.renamedTo && (
+        <NodeBadge size='sm' className='min-w-0' title={entry.renamedTo} showIcon={false} />
+      )}
+    </span>
+  )
+}
 
 interface HistoryCommandPopoverProps {
   open: boolean
@@ -84,13 +119,13 @@ export function HistoryCommandPopover({ open, onOpenChange }: HistoryCommandPopo
                     key={entry.id}
                     onSelect={() => handleJumpToState(entry.id)}
                     className={cn(
-                      'flex items-center gap-3 justify-between cursor-pointer data-[selected=true]:bg-info/10'
+                      'flex min-w-0 items-center gap-3 justify-between cursor-pointer data-[selected=true]:bg-info/10'
                       // entry.relativePosition === 0 && 'bg-accent/50 font-medium'
                     )}>
-                    <span className='text-sm'>{entry.actionDescription}</span>
+                    <HistoryEntryDescription entry={entry} />
                     <span
                       className={cn(
-                        'text-xs',
+                        'text-xs shrink-0',
                         entry.relativePosition === 0
                           ? 'text-blue-500 font-medium'
                           : 'text-muted-foreground'

--- a/apps/web/src/components/workflow/ui/node-badge.tsx
+++ b/apps/web/src/components/workflow/ui/node-badge.tsx
@@ -1,0 +1,79 @@
+// apps/web/src/components/workflow/ui/node-badge.tsx
+
+'use client'
+
+import { cn } from '@auxx/ui/lib/utils'
+import { useStore as useReactFlowStore } from '@xyflow/react'
+import type { VariantProps } from 'class-variance-authority'
+import { recordBadgeVariants } from '~/components/resources/ui/record-badge'
+import { unifiedNodeRegistry } from '../nodes/unified-registry'
+
+interface NodeBadgeProps extends VariantProps<typeof recordBadgeVariants> {
+  /** Node id, resolved against the live canvas when `title`/`nodeType` are not given. */
+  nodeId?: string
+  /**
+   * Pre-resolved title. Skips the canvas lookup, and is the ONLY way to name a
+   * node the canvas no longer has — a history entry for a deleted node, a run
+   * trace for a node since removed. When both are present this wins, so a
+   * historical name stays the name it had at the time.
+   */
+  title?: string
+  /** Pre-resolved node type, for the icon. Same precedence as `title`. */
+  nodeType?: string
+  /** Whether to show the node-type icon (default: true). */
+  showIcon?: boolean
+  className?: string
+}
+
+/**
+ * Inline pill for a workflow node. Nodes are not records, so this composes
+ * `recordBadgeVariants` with the node-type icon, the same shape `ChannelBadge`
+ * uses for integrations.
+ *
+ * **Must be rendered inside a `ReactFlowProvider`** whenever it has to resolve
+ * anything — nodes live in React Flow's context store, not a global zustand one
+ * (`store/node-store.ts` is an empty stub). Passing `title` and `nodeType`
+ * avoids the *lookup* but not the subscription, so an out-of-provider caller
+ * needs a presentational split rather than these props.
+ *
+ * @example
+ * // Live node on the canvas — name and icon follow renames.
+ * <NodeBadge nodeId={nodeId} />
+ *
+ * @example
+ * // Historical reference — the name it had then, even if since renamed or deleted.
+ * <NodeBadge nodeId={entry.subject.id} title={entry.subject.title} nodeType={entry.subject.nodeType} />
+ */
+export function NodeBadge({
+  nodeId,
+  title,
+  nodeType,
+  showIcon = true,
+  className,
+  variant,
+  size,
+}: NodeBadgeProps) {
+  // Skip the subscription entirely when the caller already knows both facts.
+  const liveNode = useReactFlowStore((state) =>
+    nodeId && !(title && nodeType) ? state.nodes.find((node) => node.id === nodeId) : undefined
+  )
+
+  const resolvedTitle = title ?? (liveNode?.data?.title as string | undefined)
+  const resolvedType = nodeType ?? (liveNode?.data?.type as string | undefined)
+  const color = resolvedType ? unifiedNodeRegistry.getColor(resolvedType) : undefined
+
+  return (
+    <span data-slot='node-badge' className={cn(recordBadgeVariants({ variant, size }), className)}>
+      {showIcon && resolvedType && (
+        <span
+          className='flex size-4 shrink-0 items-center justify-center rounded'
+          style={{ backgroundColor: color ? `${color}20` : undefined, color }}>
+          {unifiedNodeRegistry.getNodeIcon(resolvedType, 'size-3', liveNode?.data)}
+        </span>
+      )}
+      <span data-slot='record-display' className='truncate max-w-[160px]'>
+        {resolvedTitle || 'Unknown node'}
+      </span>
+    </span>
+  )
+}

--- a/apps/web/src/components/workflow/utils/__tests__/history-description.test.ts
+++ b/apps/web/src/components/workflow/utils/__tests__/history-description.test.ts
@@ -1,0 +1,165 @@
+// apps/web/src/components/workflow/utils/__tests__/history-description.test.ts
+//
+// What a history row says about the node it acted on. Two of the three
+// derivations here are only possible against the graph the entry is recorded
+// ON TOP OF, which is why `describeHistoryEntry` takes a baseline:
+//
+//   - a delete has to name a node the new graph no longer contains
+//   - a rename is a title diff, and the call site cannot supply one because
+//     `setInputs` hands over a whole data object
+
+import { describe, expect, it } from 'vitest'
+import type { HistoryEntry } from '../../store/types'
+import type { FlowNode } from '../../types'
+import { describeHistoryEntry } from '../history-description'
+
+function node(id: string, title?: string, type = 'ai'): FlowNode {
+  return { id, position: { x: 0, y: 0 }, data: { title, type } } as unknown as FlowNode
+}
+
+function baselineOf(nodes: FlowNode[]): HistoryEntry {
+  return {
+    id: 'baseline',
+    timestamp: 0,
+    action: 'workflow_event',
+    store: 'workflow',
+    data: { event: 'NodeChange', nodes, edges: [] },
+  }
+}
+
+describe('describeHistoryEntry — naming the subject', () => {
+  it('names the node and carries its type for the badge icon', () => {
+    const result = describeHistoryEntry(
+      { verb: 'added', fallbackLabel: 'Node added', nodeId: 'n1', nodes: [node('n1', 'Output')] },
+      undefined
+    )
+
+    expect(result.subject).toEqual({ id: 'n1', title: 'Output', nodeType: 'ai' })
+    expect(result.verb).toBe('added')
+    expect(result.label).toBe('Output added')
+  })
+
+  it('names a DELETED node from the baseline, since the new graph has lost it', () => {
+    const result = describeHistoryEntry(
+      { verb: 'deleted', fallbackLabel: 'Node deleted', nodeId: 'n1', nodes: [] },
+      baselineOf([node('n1', 'Output')])
+    )
+
+    expect(result.subject?.title).toBe('Output')
+    expect(result.label).toBe('Output deleted')
+  })
+
+  it('falls back to the plain sentence for an untitled node', () => {
+    const result = describeHistoryEntry(
+      { verb: 'added', fallbackLabel: 'Node added', nodeId: 'n1', nodes: [node('n1')] },
+      undefined
+    )
+
+    expect(result.subject).toBeUndefined()
+    expect(result.label).toBe('Node added')
+  })
+
+  it('falls back for events with no node subject at all', () => {
+    const result = describeHistoryEntry({ fallbackLabel: 'Edge added', nodes: [] }, undefined)
+
+    expect(result.subject).toBeUndefined()
+    expect(result.label).toBe('Edge added')
+  })
+
+  it('counts instead of naming when more than one node moved', () => {
+    const result = describeHistoryEntry(
+      { verb: 'pasted', fallbackLabel: 'Node pasted', count: 3, nodes: [] },
+      undefined
+    )
+
+    expect(result.subject).toBeUndefined()
+    expect(result.label).toBe('3 nodes pasted')
+  })
+
+  it('names the node when the count is exactly one', () => {
+    const result = describeHistoryEntry(
+      {
+        verb: 'moved',
+        fallbackLabel: 'Node position changed',
+        nodeId: 'n1',
+        count: 1,
+        nodes: [node('n1', 'Output')],
+      },
+      undefined
+    )
+
+    expect(result.label).toBe('Output moved')
+  })
+})
+
+describe('describeHistoryEntry — rename', () => {
+  it('reports a changed title as a rename, with both names', () => {
+    const result = describeHistoryEntry(
+      {
+        verb: 'changed',
+        fallbackLabel: 'Node changed',
+        nodeId: 'n1',
+        detectRename: true,
+        nodes: [node('n1', 'Output')],
+      },
+      baselineOf([node('n1', 'Node 1')])
+    )
+
+    expect(result.verb).toBe('renamed to')
+    expect(result.subject?.title).toBe('Node 1') // the name it had…
+    expect(result.renamedTo).toBe('Output') // …and the one it got
+    expect(result.label).toBe('Node 1 renamed to Output')
+  })
+
+  it('is a plain change when some other field moved', () => {
+    const before = node('n1', 'Output')
+    const after = { ...node('n1', 'Output'), data: { title: 'Output', type: 'ai', prompt: 'hi' } }
+
+    const result = describeHistoryEntry(
+      {
+        verb: 'changed',
+        fallbackLabel: 'Node changed',
+        nodeId: 'n1',
+        detectRename: true,
+        nodes: [after as FlowNode],
+      },
+      baselineOf([before])
+    )
+
+    expect(result.renamedTo).toBeUndefined()
+    expect(result.label).toBe('Output changed')
+  })
+
+  it('never claims a rename for an event that is not a data change', () => {
+    // A drag carries no `detectRename`, so even a title that differs between
+    // snapshots (it cannot, but the guard is what makes that true) reads as a move.
+    const result = describeHistoryEntry(
+      {
+        verb: 'moved',
+        fallbackLabel: 'Node position changed',
+        nodeId: 'n1',
+        nodes: [node('n1', 'Output')],
+      },
+      baselineOf([node('n1', 'Node 1')])
+    )
+
+    expect(result.verb).toBe('moved')
+    expect(result.renamedTo).toBeUndefined()
+  })
+
+  it('does not claim a rename when the node is newly added', () => {
+    const result = describeHistoryEntry(
+      {
+        verb: 'changed',
+        fallbackLabel: 'Node changed',
+        nodeId: 'n1',
+        detectRename: true,
+        nodes: [node('n1', 'Output')],
+      },
+      baselineOf([]) // node did not exist before
+    )
+
+    expect(result.renamedTo).toBeUndefined()
+    expect(result.label).toBe('Output changed')
+  })
+})

--- a/apps/web/src/components/workflow/utils/history-description.ts
+++ b/apps/web/src/components/workflow/utils/history-description.ts
@@ -1,0 +1,97 @@
+// apps/web/src/components/workflow/utils/history-description.ts
+
+import type { HistoryDescription, HistoryEntry } from '../store/types'
+import type { FlowNode } from '../types'
+
+/**
+ * Turns "which event, on which node" into what the history popover shows.
+ *
+ * Kept out of the hook and off the manager because the interesting half is a
+ * pure comparison of two graphs, and because `HistoryManager` has no business
+ * knowing what a workflow node is.
+ *
+ * ## Why the baseline is a parameter
+ *
+ * Two of the three things this derives are only knowable against the state the
+ * entry is recorded ON TOP OF:
+ *
+ * - **Delete.** The node is gone from the new graph, so the baseline is the
+ *   only place its name still exists.
+ * - **Rename.** `useNodeCrud.setInputs` hands the update path a whole data
+ *   object, so the *call site* genuinely cannot say which field moved — but
+ *   `prior.title !== current.title` is one lookup away for anything holding
+ *   both graphs. This is the case the coarse-label decision (no
+ *   `NodeTitleChange` member) was right to give up on at the call site and
+ *   wrong to give up on entirely.
+ */
+export interface DescribeHistoryInput {
+  /** Bare verb — `added`, `changed`, `moved`. Absent for events with no node subject. */
+  verb?: string
+  /** Sentence used when there is no single named subject: `Node added`. */
+  fallbackLabel: string
+  /** The node this action is about, when it is exactly one. */
+  nodeId?: string
+  /** Nodes affected, when more than one. Suppresses the subject. */
+  count?: number
+  /** Report a changed title as a rename. `NodeChange` only. */
+  detectRename?: boolean
+  /** The graph as it is AFTER the action. */
+  nodes: readonly FlowNode[]
+}
+
+/** A node's display title, matching `useNodeTitle`'s precedence. */
+function titleOf(node: FlowNode | undefined): string | undefined {
+  const data = node?.data as { title?: unknown; label?: unknown } | undefined
+  const title = data?.title ?? data?.label
+  return typeof title === 'string' && title.trim() ? title : undefined
+}
+
+function typeOf(node: FlowNode | undefined): string | undefined {
+  const type = (node?.data as { type?: unknown } | undefined)?.type
+  return typeof type === 'string' ? type : undefined
+}
+
+export function describeHistoryEntry(
+  input: DescribeHistoryInput,
+  baseline: HistoryEntry | undefined
+): HistoryDescription {
+  const { verb, fallbackLabel, nodeId, count, detectRename, nodes } = input
+
+  // More than one node moved: there is no single thing to badge, and naming one
+  // of several is worse than naming none.
+  if (count !== undefined && count > 1) {
+    return { label: `${count} nodes ${verb ?? 'changed'}` }
+  }
+
+  if (!verb || !nodeId) return { label: fallbackLabel }
+
+  const current = nodes.find((node) => node.id === nodeId)
+  const priorNodes = (baseline?.data?.nodes ?? undefined) as FlowNode[] | undefined
+  const prior = priorNodes?.find((node) => node.id === nodeId)
+
+  const node = current ?? prior
+  const title = titleOf(current) ?? titleOf(prior)
+  // An untitled node has nothing worth badging; the plain sentence is honest.
+  if (!node || !title) return { label: fallbackLabel }
+
+  const nodeType = typeOf(node)
+
+  if (detectRename && current && prior) {
+    const before = titleOf(prior)
+    const after = titleOf(current)
+    if (before && after && before !== after) {
+      return {
+        verb: 'renamed to',
+        subject: { id: nodeId, title: before, nodeType },
+        renamedTo: after,
+        label: `${before} renamed to ${after}`,
+      }
+    }
+  }
+
+  return {
+    verb,
+    subject: { id: nodeId, title, nodeType },
+    label: `${title} ${verb}`,
+  }
+}


### PR DESCRIPTION
Follow-up to #1775, which shipped the coalescing rewrite this builds on.

"Node changed" three rows in a row tells you nothing about *which* node, so the popover was hardest to use for exactly the case it exists for. Every node event now names its subject and renders it as a badge.

| Before | After |
|---|---|
| Node added | `[Output] added` |
| Node changed | `[Output] changed` |
| Node changed | `[Node 1] renamed to [Output]` |
| Node position changed | `[Send Email] moved` / `3 nodes moved` |
| Node pasted | `[Fetch Order] pasted` / `3 nodes pasted` |
| Edge added / Layout organized | unchanged — no single node subject |

## `NodeBadge`

New `ui/node-badge.tsx`, built on `recordBadgeVariants` like `ChannelBadge` / `ToolBadge` / `ThreadBadge`. Takes `nodeId` plus optional `title` / `nodeType`, with `variant` and `size` from the shared variants.

**The pre-resolved pair wins over the canvas lookup, and that's load-bearing rather than an optimization.** A history entry for a *deleted* node has nothing to look up, and an entry for a since-renamed node has to keep the name it had at the time — a live lookup would silently rewrite history. Passing both also skips the store subscription entirely, so historical rows don't re-run a `.find()` over the node array on every drag frame.

One constraint worth knowing: nodes live in React Flow's **context** store — `store/node-store.ts` is an empty stub with zero exports — so the badge must render inside a `ReactFlowProvider` to resolve anything. That's unlike `ChannelBadge`, whose `useChannelStore` is global. Documented on the component.

## Rename, and why it was worth the extra mechanism

This looked impossible from the call site, and isn't. `useNodeCrud.setInputs` hands the update path a whole data object, so the **dispatcher** genuinely cannot say which field moved — that part of the earlier reasoning for dropping `NodeTitleChange` stands. But `prior.title !== current.title` is one lookup away for anything holding both graphs. So the derivation moved to where both snapshots are: `record()` gains a `describe(baseline)` callback.

**Which entry is the baseline differs by path, and that's the subtle part:**

- On a **push**, it's the current top of the stack.
- On a **merge**, it's the entry *below* the one being overwritten — the state the coalescing session began from.

Re-describing against that fixed point on every merge is what makes a rename converge. Typing `O`, `Ou`, `Out`, `Output` re-diffs against the pre-session title each time and settles on `Node 1 renamed to Output`, rather than freezing at the first keystroke (`Node 1 renamed to O`) or drifting (`Out renamed to Output`).

`renamedTo` is assigned unconditionally on a merge, so a session that renames and then types the original name back **drops** the claim instead of keeping a stale one.

The same baseline is what lets a **delete** name what it deleted — the node is gone from the new graph, so the entry being recorded over is the only place its name still exists.

## Judgement calls

- **Multi-node actions count instead of naming** (`3 nodes pasted`). Naming one of several is worse than naming none.
- **Rename wins the headline** when a coalesced session both renames and edits another field. The name is the identifying fact and undo reverts both regardless — the label is a hint, not a contract.
- **No edge endpoint names.** Two badges plus a step counter doesn't fit a 320px popover, and "which edge" isn't a question a timeline answers well.
- **Untitled nodes fall back to the plain sentence** rather than badging "Unknown node".

## Tests

- `utils/__tests__/history-description.test.ts` — 10 tests: naming, delete-resolved-from-baseline, rename, rename vs ordinary field change, newly-added node (no false rename), counts, untitled fallback.
- `store/__tests__/history-coalescing.test.ts` — 5 more: baseline is the top on a push, the entry *below* on a merge (asserted across three consecutive merges — the invariant the rename story rests on), `undefined` on the first record, and that a merge clears an undone rename.

285 workflow tests pass except one pre-existing parity failure unrelated to this branch — see note below. `apps/web` typecheck: same 10 pre-existing errors, none from these commits.

> **Note on the parity test.** `builder-engine-parity.test.ts > emits only handles the builder renders` reports `handle:if-else.true` as an *unexpected pass* in my local run. That is a concurrent session's uncommitted work on `workflow-engine/nodes/condition-nodes/if-else.ts` (it removed the `conditionResult ? 'true' : 'false'` fallback, which is what the allowlist entry recorded), bleeding into a shared working tree. Nothing on this branch touches node schemas, handles, or the engine, and none of those files are staged here. It should be green in CI.
