### PR TITLE
fix(data-connectors): split a connector's comma string into separate tag values

### DIFF
--- a/packages/credentials/scripts/persist-shopify-token.ts
+++ b/packages/credentials/scripts/persist-shopify-token.ts
@@ -1,0 +1,93 @@
+// packages/credentials/scripts/persist-shopify-token.ts
+// Throwaway: write a working Shopify offline token into an existing Credential row so the
+// paused data connector can sync again. Clears the dead refresh token + expiry.
+//
+// Usage: CRED_ID=<id> TOKEN=<shpat_...> npx tsx scripts/persist-shopify-token.ts
+
+import { database as db, schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import { decryptSecrets, encryptSecrets } from '../src/crypto'
+
+const CRED_ID = process.env.CRED_ID
+const TOKEN = process.env.TOKEN
+const SHOP = process.env.SHOP || 'auxxai.myshopify.com'
+
+async function main() {
+  if (!CRED_ID || !TOKEN) {
+    console.error('Set CRED_ID and TOKEN')
+    process.exit(1)
+  }
+
+  const before = await db.query.Credential.findFirst({
+    where: (c, { eq: e }) => e(c.id, CRED_ID),
+  })
+  if (!before) {
+    console.error(`No Credential ${CRED_ID}`)
+    process.exit(1)
+  }
+
+  console.log('BEFORE:')
+  console.log(`  name=${before.name} org=${before.organizationId}`)
+  console.log(`  blobKeys=[${Object.keys(decryptSecrets(before.encryptedSecrets)).join(',')}]`)
+  console.log(`  expiresAt=${before.expiresAt?.toISOString() ?? 'none'}`)
+  console.log(`  metadata=${JSON.stringify(before.metadata)}`)
+
+  // Verify the token actually works before overwriting anything.
+  const check = await fetch(`https://${SHOP}/admin/api/2024-10/shop.json`, {
+    headers: { 'X-Shopify-Access-Token': TOKEN },
+  })
+  if (check.status !== 200) {
+    console.error(`Token failed /shop.json with ${check.status} — refusing to write.`)
+    process.exit(1)
+  }
+  console.log(`\nToken verified against ${SHOP} (200).`)
+
+  const scopesRes = await fetch(`https://${SHOP}/admin/oauth/access_scopes.json`, {
+    headers: { 'X-Shopify-Access-Token': TOKEN },
+  })
+  const scopes = ((await scopesRes.json()) as any).access_scopes
+    ?.map((s: any) => s.handle)
+    .join(',')
+
+  const shopSub = SHOP.replace(/\.myshopify\.com$/, '')
+  const metadata = {
+    ...((before.metadata ?? {}) as Record<string, unknown>),
+    scope: scopes,
+    shopDomain: SHOP,
+    connectionVariables: { shop: shopSub },
+  }
+
+  await db
+    .update(schema.Credential)
+    // Offline token: no refreshToken, no expiry. Storing a refreshToken here is what
+    // produced the dead credentials — the refresh endpoint 401s once it lapses.
+    .set({
+      encryptedSecrets: encryptSecrets({ accessToken: TOKEN }),
+      expiresAt: null,
+      metadata: metadata as any,
+      requiresReauth: false,
+      lastAuthError: null,
+      lastAuthErrorAt: null,
+      lastRefreshError: null,
+      lastRefreshFailureAt: null,
+      consecutiveRefreshFailures: 0,
+    })
+    .where(eq(schema.Credential.id, CRED_ID))
+
+  const after = await db.query.Credential.findFirst({
+    where: (c, { eq: e }) => e(c.id, CRED_ID),
+  })
+  console.log('\nAFTER:')
+  console.log(`  blobKeys=[${Object.keys(decryptSecrets(after!.encryptedSecrets)).join(',')}]`)
+  console.log(`  expiresAt=${after!.expiresAt?.toISOString() ?? 'none'}`)
+  console.log(
+    `  requiresReauth=${after!.requiresReauth} lastRefreshError=${after!.lastRefreshError}`
+  )
+  console.log(`  metadata=${JSON.stringify(after!.metadata)}`)
+  process.exit(0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/credentials/scripts/probe-shopify-conndef.ts
+++ b/packages/credentials/scripts/probe-shopify-conndef.ts
@@ -1,0 +1,77 @@
+// packages/credentials/scripts/probe-shopify-conndef.ts
+// Throwaway: which Shopify Partner app is the ConnectionDefinition actually wired to?
+
+import { database as db, schema } from '@auxx/database'
+import { decryptSecrets, isV2Payload } from '../src/crypto'
+
+const KNOWN = {
+  '588ef3496716248f2de2d485e57364ec': 'PROD app "auxxai" (shopify.app.toml)',
+  a34d5f05c6a335cd31ceebbfa3242f50: 'DEV app "auxxai-dev" (shopify.app.dev.toml)',
+}
+
+function decryptOne(v: string | null): string | null {
+  if (!v) return null
+  if (!isV2Payload(v)) return v
+  try {
+    const out = decryptSecrets(v) as any
+    return typeof out === 'string' ? out : (out?.value ?? JSON.stringify(out))
+  } catch (e) {
+    return `DECRYPT FAILED: ${e}`
+  }
+}
+
+async function main() {
+  const defs = await db.select().from(schema.ConnectionDefinition)
+  const apps = await db.select().from(schema.App)
+  const appById = new Map(apps.map((a) => [a.id, a]))
+
+  for (const d of defs) {
+    const app = d.appId ? appById.get(d.appId) : null
+    const isShopify = /shopify/i.test(d.providerKey ?? '') || /shopify/i.test(app?.slug ?? '')
+    if (!isShopify) continue
+
+    const cid = decryptOne(d.oauth2ClientId)
+    const csec = decryptOne(d.oauth2ClientSecret)
+    console.log(`\n=== ConnectionDefinition ${d.id} ===`)
+    console.log(`  app=${app?.slug ?? '-'} providerKey=${d.providerKey ?? '-'} global=${d.global}`)
+    console.log(
+      `  clientId=${cid ?? '(none)'}  -> ${cid ? (KNOWN[cid as keyof typeof KNOWN] ?? 'UNKNOWN app') : '-'}`
+    )
+    console.log(`  clientSecret=${csec ? `set (${csec.length} chars)` : '(none)'}`)
+    console.log(`  oauth2Features=${JSON.stringify(d.oauth2Features)}`)
+    console.log(`  authorizeUrl=${d.oauth2AuthorizeUrl}`)
+    console.log(`  tokenUrl=${d.oauth2AccessTokenUrl}`)
+    console.log(`  scopes=${JSON.stringify(d.oauth2Scopes)}`)
+  }
+
+  console.log(`\n=== env ===`)
+  for (const k of [
+    'SHOPIFY_API_KEY',
+    'SHOPIFY_CLIENT_ID',
+    'SHOPIFY_CLIENT_SECRET',
+    'SHOPIFY_APP_ID',
+    'NGROK_URL',
+  ]) {
+    const v = process.env[k]
+    console.log(`  ${k}=${v ? (k.includes('SECRET') ? `set (${v.length} chars)` : v) : '(unset)'}`)
+  }
+
+  console.log(`\n=== Shopify AppInstallation rows ===`)
+  const shopifyApp = apps.find((a) => a.slug === 'shopify')
+  if (shopifyApp) {
+    const installs = await db.query.AppInstallation.findMany({
+      where: (i, { eq }) => eq(i.appId, shopifyApp.id),
+    })
+    for (const i of installs) {
+      console.log(
+        `  id=${i.id} org=${i.organizationId} status=${(i as any).status ?? '-'} enabled=${(i as any).enabled ?? '-'} createdAt=${i.createdAt?.toISOString?.() ?? '-'}`
+      )
+    }
+  }
+  process.exit(0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/credentials/scripts/probe-shopify-exchange.ts
+++ b/packages/credentials/scripts/probe-shopify-exchange.ts
@@ -1,0 +1,61 @@
+// packages/credentials/scripts/probe-shopify-exchange.ts
+// Exchange a Shopify authorization code for an access token using the
+// ConnectionDefinition's own baked client id/secret. This is how you recover when
+// ngrok's free-tier interstitial eats the OAuth callback: the `?code=` is still sitting
+// in the browser URL bar and is good for a short while.
+//
+// Usage: SHOP=auxxai.myshopify.com CODE=<code> npx tsx scripts/probe-shopify-exchange.ts
+
+import { database as db } from '@auxx/database'
+import { decryptSecrets, isV2Payload } from '../src/crypto'
+
+const SHOP = process.env.SHOP || 'auxxai.myshopify.com'
+const CODE = process.env.CODE
+
+function decryptOne(v: string | null): string | null {
+  if (!v) return null
+  if (!isV2Payload(v)) return v
+  const out = decryptSecrets(v) as any
+  return typeof out === 'string' ? out : (out?.v ?? out?.value ?? null)
+}
+
+async function main() {
+  if (!CODE) {
+    console.error('Set CODE=<authorization code>')
+    process.exit(1)
+  }
+
+  const app = (await db.query.App.findFirst({ where: (a, { eq }) => eq(a.slug, 'shopify') })) as any
+  const def = (await db.query.ConnectionDefinition.findFirst({
+    where: (d, { eq, and }) => and(eq(d.appId, app.id), eq(d.global, true)),
+  })) as any
+
+  const clientId = decryptOne(def.oauth2ClientId)
+  const clientSecret = decryptOne(def.oauth2ClientSecret)
+  console.log(`client_id=${clientId}  secret=${clientSecret ? 'set' : 'MISSING'}`)
+
+  const res = await fetch(`https://${SHOP}/admin/oauth/access_token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code: CODE }),
+  })
+  const text = await res.text()
+  console.log(`\n[token exchange] status=${res.status}`)
+  console.log(text.slice(0, 600))
+  if (res.status !== 200) process.exit(1)
+
+  const tok = JSON.parse(text)
+  const token: string = tok.access_token
+  console.log(
+    `\naccess_token prefix=${token.slice(0, 6)} scope=${tok.scope} expires_in=${tok.expires_in ?? 'none (offline)'}`
+  )
+
+  // Stash for reuse by the verification script
+  console.log(`\nSHOPIFY_PROBE_TOKEN=${token}`)
+  process.exit(0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/credentials/scripts/probe-shopify-live.ts
+++ b/packages/credentials/scripts/probe-shopify-live.ts
@@ -1,0 +1,214 @@
+// packages/credentials/scripts/probe-shopify-live.ts
+// Throwaway: find a usable Shopify credential and run the gap-0 verification calls (V1/V2/V5/V6/V7).
+
+import { database as db, schema } from '@auxx/database'
+import { decryptSecrets } from '../src/crypto'
+
+const API = process.env.SHOPIFY_PROBE_API_VERSION || '2024-10'
+
+type Blob = Record<string, any>
+
+async function shopify(shop: string, token: string, path: string) {
+  const url = `https://${shop}/admin/api/${API}${path}`
+  const res = await fetch(url, { headers: { 'X-Shopify-Access-Token': token } })
+  const text = await res.text()
+  let json: any = null
+  try {
+    json = JSON.parse(text)
+  } catch {}
+  return { status: res.status, json, text: text.slice(0, 400) }
+}
+
+async function main() {
+  // Direct-token mode: skip credential discovery entirely.
+  if (process.env.SHOPIFY_PROBE_TOKEN) {
+    const shop = process.env.SHOP || 'auxxai.myshopify.com'
+    await verify({
+      id: 'env-token',
+      shop,
+      token: process.env.SHOPIFY_PROBE_TOKEN,
+      expiresAt: null,
+    })
+    process.exit(0)
+  }
+
+  const rows = await db.select().from(schema.Credential)
+  const shopifyRows = rows.filter((r) => /shopify/i.test(r.name ?? ''))
+
+  console.log(`\n=== ${shopifyRows.length} shopify credential rows ===`)
+  const candidates: { id: string; shop: string; token: string; expiresAt: Date | null }[] = []
+
+  for (const row of shopifyRows) {
+    let blob: Blob = {}
+    try {
+      blob = decryptSecrets(row.encryptedSecrets)
+    } catch (e) {
+      console.log(`  id=${row.id} DECRYPT FAILED: ${e}`)
+      continue
+    }
+    const md = (row.metadata ?? {}) as Blob
+    const shop =
+      md.shopDomain ||
+      (md.connectionVariables?.shop ? `${md.connectionVariables.shop}.myshopify.com` : null) ||
+      (blob.metadata?.connectionVariables?.shop
+        ? `${blob.metadata.connectionVariables.shop}.myshopify.com`
+        : null)
+    const token = blob.accessToken || blob.access_token || blob.token
+    console.log(
+      `  id=${row.id} org=${row.organizationId} shop=${shop ?? '?'} ` +
+        `blobKeys=[${Object.keys(blob).join(',')}] ` +
+        `hasToken=${!!token} tokenPrefix=${token ? String(token).slice(0, 6) : '-'} ` +
+        `expiresAt=${row.expiresAt?.toISOString() ?? 'none'} scope=${md.scope ?? '?'}`
+    )
+    if (shop && token) candidates.push({ id: row.id, shop, token, expiresAt: row.expiresAt })
+  }
+
+  console.log(`\n=== probing ${candidates.length} candidates with GET /shop.json ===`)
+  const live: typeof candidates = []
+  for (const c of candidates) {
+    const r = await shopify(c.shop, c.token, '/shop.json')
+    console.log(
+      `  ${c.id} ${c.shop} -> ${r.status} ${r.json?.shop?.name ?? JSON.stringify(r.json?.errors) ?? r.text.slice(0, 120)}`
+    )
+    if (r.status === 200) live.push(c)
+  }
+
+  if (!live.length) {
+    console.log('\nNo live Shopify token. Stopping before verification calls.')
+    process.exit(0)
+  }
+
+  for (const c of live) await verify(c)
+
+  process.exit(0)
+}
+
+async function verify(c: { id: string; shop: string; token: string; expiresAt: Date | null }) {
+  {
+    console.log(`\n\n########## VERIFICATION on ${c.shop} (cred ${c.id}) ##########`)
+
+    const scopes = await shopify(c.shop, c.token, '/oauth/access_scopes.json')
+    console.log(
+      `\n[scopes] ${scopes.status}: ${(scopes.json?.access_scopes ?? []).map((s: any) => s.handle).join(', ') || scopes.text}`
+    )
+
+    // V1 — oldest reachable order (the 60-day window question)
+    const oldest = await shopify(
+      c.shop,
+      c.token,
+      '/orders.json?status=any&limit=1&order=created_at+asc'
+    )
+    console.log(`\n[V1 oldest order] status=${oldest.status}`)
+    if (oldest.json?.orders?.length) {
+      const o = oldest.json.orders[0]
+      console.log(
+        `  oldest reachable: #${o.order_number} id=${o.id} created_at=${o.created_at} updated_at=${o.updated_at}`
+      )
+    } else {
+      console.log(`  ${oldest.text}`)
+    }
+
+    const count = await shopify(c.shop, c.token, '/orders/count.json?status=any')
+    console.log(`[V1 order count] status=${count.status} count=${count.json?.count ?? count.text}`)
+
+    // V2 / V5 / V6 / V7 — one full page, no fields= param (exactly what the connector sends)
+    const page = await shopify(c.shop, c.token, '/orders.json?status=any&limit=250')
+    const orders: any[] = page.json?.orders ?? []
+    console.log(`\n[page] status=${page.status} orders=${orders.length}`)
+    if (!orders.length) {
+      console.log(`  ${page.text}`)
+      return
+    }
+
+    const withFul = orders.filter((o) => (o.fulfillments ?? []).length > 0)
+    console.log(
+      `\n[V2 fulfillments[]] orders with non-empty fulfillments[]: ${withFul.length}/${orders.length}`
+    )
+    const fulfilledStatus = orders.filter((o) => o.fulfillment_status === 'fulfilled')
+    console.log(
+      `  orders with fulfillment_status='fulfilled': ${fulfilledStatus.length}; of those, ${fulfilledStatus.filter((o) => (o.fulfillments ?? []).length > 0).length} carry a fulfillments[] array`
+    )
+    if (withFul.length) {
+      const f = withFul[0].fulfillments[0]
+      console.log(`  sample fulfillment keys: [${Object.keys(f).join(', ')}]`)
+      console.log(
+        `  sample: id=${f.id} name=${f.name} status=${f.status} shipment_status=${f.shipment_status} created_at=${f.created_at} tracking_number=${f.tracking_number} tracking_company=${f.tracking_company} location_id=${f.location_id}`
+      )
+      console.log(
+        `  sample fulfillment.line_items[0] keys: [${Object.keys(f.line_items?.[0] ?? {}).join(', ')}]`
+      )
+    }
+
+    // V5 — split shipments
+    const multi = orders.filter(
+      (o) => (o.fulfillments ?? []).filter((f: any) => f.status !== 'cancelled').length > 1
+    )
+    console.log(
+      `\n[V5 split shipments] orders with >1 non-cancelled fulfillment: ${multi.length}/${orders.length}`
+    )
+    for (const o of multi.slice(0, 5)) {
+      const dates = o.fulfillments.map((f: any) => `${f.status}@${f.created_at}`)
+      console.log(`  #${o.order_number}: ${dates.join(' | ')}`)
+    }
+
+    // V6 — distinct payment_gateway_names
+    const gwCounts = new Map<string, number>()
+    let multiGw = 0
+    for (const o of orders) {
+      const g = o.payment_gateway_names ?? []
+      if (g.length > 1) multiGw++
+      for (const name of g) gwCounts.set(name, (gwCounts.get(name) ?? 0) + 1)
+    }
+    console.log(`\n[V6 payment_gateway_names] distinct handles across ${orders.length} orders:`)
+    for (const [k, v] of [...gwCounts].sort((a, b) => b[1] - a[1])) console.log(`  ${k}: ${v}`)
+    console.log(`  orders with >1 gateway name: ${multiGw}`)
+    console.log(
+      `  orders where the field is absent/undefined: ${orders.filter((o) => o.payment_gateway_names === undefined).length}`
+    )
+
+    // §1.2 / V9 — tags shape, plus fulfillable_quantity presence
+    const sample = orders[0]
+    console.log(
+      `\n[tags shape] typeof order.tags = ${typeof sample.tags}, value=${JSON.stringify(sample.tags)}`
+    )
+    console.log(`[line item keys] [${Object.keys(sample.line_items?.[0] ?? {}).join(', ')}]`)
+    console.log(`[order top-level keys] [${Object.keys(sample).join(', ')}]`)
+
+    // §4.3 — does creating a fulfillment bump order.updated_at?
+    const bumped = withFul.filter((o) => {
+      const last = o.fulfillments
+        .map((f: any) => Date.parse(f.created_at))
+        .sort((a: number, b: number) => a - b)
+        .pop()
+      return last && Date.parse(o.updated_at) >= last
+    })
+    console.log(
+      `\n[4.3 updated_at >= last fulfillment created_at] ${bumped.length}/${withFul.length}`
+    )
+
+    // V7 — default sort of /orders.json (watermark correctness)
+    const ups = orders.map((o) => Date.parse(o.updated_at))
+    let asc = true
+    let desc = true
+    for (let i = 1; i < ups.length; i++) {
+      if (ups[i] < ups[i - 1]) asc = false
+      if (ups[i] > ups[i - 1]) desc = false
+    }
+    console.log(
+      `[V7 default sort of /orders.json] updated_at ascending=${asc} descending=${desc} (n=${ups.length})`
+    )
+    const ids = orders.map((o) => Number(o.id))
+    let idAsc = true
+    let idDesc = true
+    for (let i = 1; i < ids.length; i++) {
+      if (ids[i] < ids[i - 1]) idAsc = false
+      if (ids[i] > ids[i - 1]) idDesc = false
+    }
+    console.log(`  id ascending=${idAsc} descending=${idDesc}`)
+  }
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/lib/scripts/backfill-pending-connector-change.ts
+++ b/packages/lib/scripts/backfill-pending-connector-change.ts
@@ -1,0 +1,51 @@
+// packages/lib/scripts/backfill-pending-connector-change.ts
+// Dev helper: the "Backfill now" banner action — reset the streams a mapping edit
+// marked `resyncPending` to a fresh backfill and re-crawl.
+//
+// Usage: CONNECTOR_ID=… ORG_ID=… npx tsx scripts/backfill-pending-connector-change.ts
+
+import { database as db } from '@auxx/database'
+import { backfillPendingChange } from '../src/data-connectors/slice-orchestrator'
+
+const CONNECTOR_ID = process.env.CONNECTOR_ID ?? 't0e33r78tehnzcrbkqur0tcc'
+const ORG_ID = process.env.ORG_ID ?? 'abgwpa1l81reht2zmwrcihfu'
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+async function main() {
+  const before = await db.query.DataConnector.findFirst({
+    where: (c, { eq }) => eq(c.id, CONNECTOR_ID),
+  })
+  console.log(`resyncPending before: ${JSON.stringify((before as any)?.resyncPending ?? null)}`)
+
+  await backfillPendingChange(db, ORG_ID, CONNECTOR_ID)
+  console.log('backfill requested; waiting…\n')
+
+  let last = ''
+  for (let i = 0; i < 48; i++) {
+    await sleep(5000)
+    const runs = await db.query.DataConnectorRun.findMany({
+      where: (r, { eq }) => eq(r.dataConnectorId, CONNECTOR_ID),
+      orderBy: (r, { desc }) => [desc(r.startedAt)],
+      limit: 1,
+    })
+    const run = runs[0] as any
+    const line = `run=${run?.status} fetched=${run?.fetched} updated=${run?.updated} skipped=${run?.skipped} failed=${run?.failed}`
+    if (line !== last) {
+      console.log(`  [${i * 5}s] ${line}`)
+      last = line
+    }
+    if (run && ['completed', 'failed', 'partial', 'cancelled'].includes(run.status)) break
+  }
+
+  const after = await db.query.DataConnector.findFirst({
+    where: (c, { eq }) => eq(c.id, CONNECTOR_ID),
+  })
+  console.log(`\nresyncPending after: ${JSON.stringify((after as any)?.resyncPending ?? null)}`)
+  process.exit(0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/lib/scripts/check-shopify-fulfillment-columns.ts
+++ b/packages/lib/scripts/check-shopify-fulfillment-columns.ts
@@ -1,0 +1,95 @@
+// packages/lib/scripts/check-shopify-fulfillment-columns.ts
+// Dev check: did the phase-0a columns actually receive values after the remap+backfill?
+
+import { database as db } from '@auxx/database'
+import { sql } from 'drizzle-orm'
+
+const CONNECTOR_ID = process.env.CONNECTOR_ID ?? 't0e33r78tehnzcrbkqur0tcc'
+
+async function main() {
+  const runs = await db.execute(sql`
+    SELECT status, fetched, created, updated, skipped, failed, "startedAt"
+    FROM "DataConnectorRun" WHERE "dataConnectorId" = ${CONNECTOR_ID}
+    ORDER BY "startedAt" DESC NULLS LAST LIMIT 4
+  `)
+  console.log('\n=== recent runs ===')
+  for (const r of runs.rows as any[]) {
+    console.log(
+      `  ${r.startedAt?.toISOString?.() ?? r.startedAt}  ${r.status}  fetched=${r.fetched} updated=${r.updated} skipped=${r.skipped} failed=${r.failed}`
+    )
+  }
+
+  const counts = await db.execute(sql`
+    SELECT ed."apiSlug" AS def, cf."appFieldKey", cf.type, count(fv.id) AS n
+    FROM "CustomField" cf
+    JOIN "EntityDefinition" ed ON ed.id = cf."entityDefinitionId"
+    LEFT JOIN "FieldValue" fv ON fv."fieldId" = cf.id
+    WHERE ed."apiSlug" IN ('shopify_orders','shopify_line_items')
+      AND cf."appFieldKey" IN (
+        'paymentGateways','firstFulfilledAt','lastFulfilledAt','shipmentCount','isSplitShipment',
+        'lineItems.fulfillableQuantity','lineItems.fulfilledAt','lineItems.lastFulfilledAt',
+        'lineItems.fulfilledQuantity','lineItems.shipmentCount','lineItems.trackingNumber')
+    GROUP BY 1,2,3 ORDER BY 1,2
+  `)
+  console.log('\n=== phase-0a column value counts ===')
+  for (const r of counts.rows as any[]) {
+    console.log(`  ${Number(r.n) > 0 ? '✅' : '  '} ${r.def}.${r.appFieldKey} (${r.type}): ${r.n}`)
+  }
+
+  // The split-shipment order: the whole point of the feature.
+  const split = await db.execute(sql`
+    SELECT ei.id, cf."appFieldKey", fv."valueText", fv."valueNumber", fv."valueBoolean",
+           fv."valueDate", fv."optionId"
+    FROM "FieldValue" fv
+    JOIN "CustomField" cf ON cf.id = fv."fieldId"
+    JOIN "EntityInstance" ei ON ei.id = fv."entityId"
+    JOIN "EntityDefinition" ed ON ed.id = cf."entityDefinitionId"
+    WHERE ed."apiSlug" = 'shopify_orders'
+      AND cf."appFieldKey" IN ('name','shipmentCount','isSplitShipment','firstFulfilledAt','lastFulfilledAt','paymentGateways')
+    ORDER BY ei.id, cf."appFieldKey"
+  `)
+  const byInstance = new Map<string, Record<string, unknown>>()
+  for (const r of split.rows as any[]) {
+    const cur = byInstance.get(r.id) ?? {}
+    cur[r.appFieldKey] =
+      r.valueText ?? r.valueNumber ?? r.valueBoolean ?? r.valueDate ?? r.optionId ?? null
+    byInstance.set(r.id, cur)
+  }
+  console.log('\n=== orders with fulfillment data ===')
+  for (const [, v] of byInstance) {
+    if (v.shipmentCount === undefined || Number(v.shipmentCount) === 0) continue
+    console.log(`  ${JSON.stringify(v)}`)
+  }
+
+  console.log('\n=== line items that shipped ===')
+  const lines = await db.execute(sql`
+    SELECT ei.id, cf."appFieldKey", fv."valueText", fv."valueNumber", fv."valueDate"
+    FROM "FieldValue" fv
+    JOIN "CustomField" cf ON cf.id = fv."fieldId"
+    JOIN "EntityInstance" ei ON ei.id = fv."entityId"
+    JOIN "EntityDefinition" ed ON ed.id = cf."entityDefinitionId"
+    WHERE ed."apiSlug" = 'shopify_line_items'
+      AND cf."appFieldKey" IN ('lineItems.shopifyId','lineItems.quantity','lineItems.fulfilledQuantity',
+                               'lineItems.shipmentCount','lineItems.trackingNumber','lineItems.fulfilledAt',
+                               'lineItems.lastFulfilledAt','lineItems.fulfillableQuantity')
+    ORDER BY ei.id
+  `)
+  const byLine = new Map<string, Record<string, unknown>>()
+  for (const r of lines.rows as any[]) {
+    const cur = byLine.get(r.id) ?? {}
+    cur[r.appFieldKey.replace('lineItems.', '')] =
+      r.valueText ?? r.valueNumber ?? r.valueDate ?? null
+    byLine.set(r.id, cur)
+  }
+  for (const [, v] of byLine) {
+    if (!v.shipmentCount || Number(v.shipmentCount) === 0) continue
+    console.log(`  ${JSON.stringify(v)}`)
+  }
+
+  process.exit(0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/lib/scripts/check-shopify-tags.ts
+++ b/packages/lib/scripts/check-shopify-tags.ts
@@ -1,0 +1,66 @@
+// packages/lib/scripts/check-shopify-tags.ts
+// Dev check: what did the last sync actually write for the Shopify order/product TAGS
+// columns, and how many distinct tag values landed per record?
+
+import { database as db } from '@auxx/database'
+import { sql } from 'drizzle-orm'
+
+const CONNECTOR_ID = process.env.CONNECTOR_ID ?? 't0e33r78tehnzcrbkqur0tcc'
+
+async function main() {
+  const runs = await db.execute(sql`
+    SELECT id, status, fetched, created, updated, skipped, failed, "startedAt", "finishedAt"
+    FROM "DataConnectorRun" WHERE "dataConnectorId" = ${CONNECTOR_ID}
+    ORDER BY "startedAt" DESC NULLS LAST LIMIT 3
+  `)
+  console.log('\n=== recent runs ===')
+  for (const r of runs.rows as any[]) {
+    console.log(
+      `  ${r.startedAt?.toISOString?.() ?? r.startedAt}  ${r.status}  fetched=${r.fetched} updated=${r.updated} skipped=${r.skipped} failed=${r.failed}`
+    )
+  }
+
+  const tags = await db.execute(sql`
+    SELECT ed."apiSlug" AS def, fv."entityId", fv."optionId"
+    FROM "FieldValue" fv
+    JOIN "CustomField" cf ON cf.id = fv."fieldId"
+    JOIN "EntityDefinition" ed ON ed.id = cf."entityDefinitionId"
+    WHERE cf."appFieldKey" = 'tags' AND ed."apiSlug" IN ('shopify_orders','shopify_products')
+    ORDER BY ed."apiSlug", fv."entityId", fv."optionId"
+  `)
+
+  const byRecord = new Map<string, string[]>()
+  for (const r of tags.rows as any[]) {
+    const key = `${r.def}:${r.entityId}`
+    byRecord.set(key, [...(byRecord.get(key) ?? []), r.optionId])
+  }
+
+  console.log(`\n=== tag values: ${tags.rows.length} rows across ${byRecord.size} records ===`)
+  let compound = 0
+  for (const [key, values] of byRecord) {
+    const bad = values.filter((v) => v?.includes(','))
+    if (bad.length) compound++
+    console.log(`  ${bad.length ? '🛑' : '  '} ${key.split(':')[0]} → ${JSON.stringify(values)}`)
+  }
+  console.log(
+    `\n${compound === 0 ? '✅ no compound (comma-bearing) tag values' : `🛑 ${compound} record(s) still hold a compound tag value`}`
+  )
+
+  const addr = await db.execute(sql`
+    SELECT cf."appFieldKey", count(fv.id) AS n
+    FROM "CustomField" cf
+    LEFT JOIN "FieldValue" fv ON fv."fieldId" = cf.id
+    JOIN "EntityDefinition" ed ON ed.id = cf."entityDefinitionId"
+    WHERE ed."apiSlug" = 'shopify_orders' AND cf."appFieldKey" IN ('shippingAddress','billingAddress')
+    GROUP BY 1 ORDER BY 1
+  `)
+  console.log('\n=== ADDRESS_STRUCT (expected still 0 — separate platform bug) ===')
+  for (const r of addr.rows as any[]) console.log(`  ${r.appFieldKey}: ${r.n}`)
+
+  process.exit(0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/lib/scripts/kick-shopify-connector-sync.ts
+++ b/packages/lib/scripts/kick-shopify-connector-sync.ts
@@ -1,0 +1,74 @@
+// packages/lib/scripts/kick-shopify-connector-sync.ts
+// Dev helper: resume the Shopify data connector and enqueue a manual sync, then wait for
+// the run to finish. Used to prove the phase-0a projection lands real column values.
+//
+// Usage: CONNECTOR_ID=… ORG_ID=… npx tsx scripts/kick-shopify-connector-sync.ts
+
+import { database as db, schema } from '@auxx/database'
+import { eq } from 'drizzle-orm'
+import { enqueueConnectorSync } from '../src/data-connectors/data-connector-queue'
+
+const CONNECTOR_ID = process.env.CONNECTOR_ID ?? 't0e33r78tehnzcrbkqur0tcc'
+const ORG_ID = process.env.ORG_ID ?? 'abgwpa1l81reht2zmwrcihfu'
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+async function main() {
+  const before = await db.query.DataConnector.findFirst({
+    where: (c, { eq: e }) => e(c.id, CONNECTOR_ID),
+  })
+  if (!before) throw new Error(`No connector ${CONNECTOR_ID}`)
+  console.log(
+    `connector "${before.name}" status=${before.status} lastSyncedAt=${before.lastSyncedAt}`
+  )
+
+  if (before.status !== 'live') {
+    await db
+      .update(schema.DataConnector)
+      .set({ status: 'live', updatedAt: new Date() })
+      .where(eq(schema.DataConnector.id, CONNECTOR_ID))
+    console.log(`resumed: ${before.status} -> live`)
+  }
+
+  await enqueueConnectorSync({
+    connectorId: CONNECTOR_ID,
+    organizationId: ORG_ID,
+    trigger: 'manual',
+  })
+  console.log('enqueued manual sync; waiting for the run to settle…\n')
+
+  // Poll the run table rather than guessing a fixed sleep.
+  let lastSeen = ''
+  for (let i = 0; i < 60; i++) {
+    await sleep(5000)
+    const runs = await db.query.DataConnectorRun.findMany({
+      where: (r, { eq: e }) => e(r.dataConnectorId, CONNECTOR_ID),
+      orderBy: (r, { desc }) => [desc(r.startedAt)],
+      limit: 1,
+    })
+    const run = runs[0] as any
+    const streams = await db.query.DataConnectorStream.findMany({
+      where: (s, { eq: e }) => e(s.dataConnectorId, CONNECTOR_ID),
+    })
+    const line =
+      `run=${run?.status ?? 'none'} ` +
+      streams
+        .map((s: any) => `${s.streamKey}:${s.state?.phase ?? '?'}/${s.state?.recordsSeen ?? 0}`)
+        .join(' ')
+    if (line !== lastSeen) {
+      console.log(`  [${i * 5}s] ${line}`)
+      lastSeen = line
+    }
+    if (run && ['success', 'failed', 'partial', 'cancelled'].includes(run.status)) {
+      console.log(`\nrun finished: ${run.status}`)
+      if (run.error) console.log(`  error: ${JSON.stringify(run.error).slice(0, 500)}`)
+      break
+    }
+  }
+  process.exit(0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/lib/scripts/remap-connector-new-catalog-fields.ts
+++ b/packages/lib/scripts/remap-connector-new-catalog-fields.ts
@@ -1,0 +1,241 @@
+// packages/lib/scripts/remap-connector-new-catalog-fields.ts
+//
+// Bring an EXISTING app connector up to date with new catalog fields.
+//
+// Deploying an app version does NOT reach an already-created connector: the
+// catalog → DataConnectorMapping projection is create-time only, and
+// `rollForwardInstallations` touches only `defineFields` app fields + webhook bindings.
+// So a new connector field produces no column, no mapping and therefore no value, ever
+// — silently, not even on a full re-sync.
+//
+// Recovering that needs THREE things, and the platform has an entry point for none of
+// them on an existing connector:
+//
+//   1. MATERIALIZE the new columns on the already-adopted owned defs. `installTemplates`
+//      cannot do this: without `linkedEntities` it creates a NEW def (forking
+//      `shopify_orders-2`), and with `linkedEntities` it skips field creation entirely
+//      (`if (linkedEntities?.[template.id]) continue`). So this runs the installer's
+//      Pass-3 logic itself, against the adopted def. `createCustomField` is idempotent
+//      per `(owner, appFieldKey)`, so re-running is safe.
+//   2. REFRESH the stream's stored `sourceSchema`, or the Map UI cannot even offer a
+//      path it has no schema entry for.
+//   3. ADD the field mappings, which is what actually makes a value get written.
+//
+// DRY RUN BY DEFAULT. Pass APPLY=1 to write.
+//
+// Usage: CONNECTOR_ID=… ORG_ID=… APP_SLUG=shopify [APPLY=1] npx tsx scripts/remap-connector-new-catalog-fields.ts
+
+import { database as db, schema } from '@auxx/database'
+import { createCustomField } from '@auxx/services/custom-fields'
+import { toAppFieldRef } from '@auxx/types/field'
+import { generateId } from '@auxx/utils'
+import { eq } from 'drizzle-orm'
+import { getCachedInstalledApps, getOrgCache } from '../src/cache'
+import { onCacheEvent } from '../src/cache/invalidate'
+import { appCatalogStreamSchema } from '../src/data-connectors/app-catalog'
+import {
+  ownedParentRootPath,
+  partitionOwnedFields,
+  relativeSourcePath,
+  updateMapping,
+} from '../src/data-connectors/mutations'
+import { projectAppConnectorTemplates } from '../src/entity-templates/app-template-projector'
+
+const CONNECTOR_ID = process.env.CONNECTOR_ID ?? 't0e33r78tehnzcrbkqur0tcc'
+const ORG_ID = process.env.ORG_ID ?? 'abgwpa1l81reht2zmwrcihfu'
+const APP_SLUG = process.env.APP_SLUG ?? 'shopify'
+const APPLY = process.env.APPLY === '1'
+
+async function main() {
+  console.log(`\n${APPLY ? '=== APPLY ===' : '=== DRY RUN (set APPLY=1 to write) ==='}\n`)
+
+  const connector = await db.query.DataConnector.findFirst({
+    where: (c, { eq: e }) => e(c.id, CONNECTOR_ID),
+  })
+  if (!connector) throw new Error(`No connector ${CONNECTOR_ID}`)
+  const appInstallationId = connector.appInstallationId
+  console.log(`connector "${connector.name}"  installation=${appInstallationId}`)
+
+  // ── catalog ────────────────────────────────────────────────────────────────
+  const installedApps = await getCachedInstalledApps(ORG_ID)
+  const app =
+    installedApps.find((a: any) => a.installationId === appInstallationId) ??
+    installedApps.find((a: any) => a.app.slug === APP_SLUG)
+  const catalog = (app as any)?.dataConnectors?.[0]
+  if (!catalog) throw new Error(`No data connector catalog on installed app "${APP_SLUG}"`)
+  console.log(`catalog streams: ${catalog.streams.map((s: any) => s.key).join(', ')}\n`)
+
+  // ── 1. materialize columns on the adopted owned defs ───────────────────────
+  const templates = projectAppConnectorTemplates(APP_SLUG, (app as any).app.title, catalog)
+  console.log('── 1. columns ──────────────────────────────────────────────')
+
+  let createdFields = 0
+  for (const template of templates) {
+    const sourceKey = template.entity.sourceKey ?? template.id
+    // Same adoption key the connector seeder uses: (appInstallationId, sourceKey).
+    const def = await db.query.EntityDefinition.findFirst({
+      where: (d, { eq: e, and, isNull }) =>
+        and(
+          e(d.organizationId, ORG_ID),
+          e(d.sourceKey, sourceKey),
+          appInstallationId
+            ? e(d.appInstallationId, appInstallationId)
+            : isNull(d.appInstallationId)
+        ),
+    })
+    if (!def) {
+      console.log(`  ${template.entity.apiSlug}: NO ADOPTED DEF — skipped (nothing to add to)`)
+      continue
+    }
+
+    const existing = await db.query.CustomField.findMany({
+      where: (f, { eq: e }) => e(f.entityDefinitionId, def.id),
+      columns: { appFieldKey: true },
+    })
+    const have = new Set(existing.map((f) => f.appFieldKey).filter(Boolean) as string[])
+    const nonRel = template.fields.filter((f) => f.type !== 'RELATIONSHIP')
+    const missing = nonRel.filter((f) => !have.has((f as any).appFieldKey))
+
+    console.log(
+      `  ${def.apiSlug} (${def.id}): ${have.size} existing, ${nonRel.length} declared, ${missing.length} MISSING`
+    )
+    for (const f of missing) {
+      console.log(`      + ${(f as any).appFieldKey}  (${f.type})  "${f.name}"`)
+      if (!APPLY) continue
+      const { templateFieldId, ...fieldInput } = f as any
+      const result = await createCustomField({
+        ...fieldInput,
+        organizationId: ORG_ID,
+        entityDefinitionId: def.id,
+        isCustom: true,
+        appInstallationId: appInstallationId ?? fieldInput.appInstallationId,
+        dataConnectorId: CONNECTOR_ID,
+        systemAttribute: templateFieldId,
+      })
+      if (result.isOk()) createdFields++
+      else console.log(`        ✖ ${JSON.stringify(result.error).slice(0, 200)}`)
+    }
+  }
+
+  if (APPLY && createdFields > 0) {
+    // A new column stays INVISIBLE to the sink until the org field cache is dropped:
+    // `resolveConnectorFieldRef` → `buildWriteKeyToFieldId` → `getCachedCustomFields`,
+    // and a stale `customFields` entry makes every new `@app:` ref unresolvable — the
+    // whole run then fails setup with "unresolved target field refs". `entity-def.created`
+    // alone is NOT enough; flush the `customFields` key explicitly.
+    await onCacheEvent('entity-def.created', { orgId: ORG_ID })
+    await getOrgCache().flushKeyForAllOrgs(['customFields', 'entityDefs', 'entityDefSlugs'])
+    console.log(`\n  created ${createdFields} field(s); customFields + entityDefs cache flushed`)
+  }
+
+  // ── 2. refresh each stream's stored sourceSchema ───────────────────────────
+  console.log('\n── 2. stream sourceSchema ──────────────────────────────────')
+  const streams = await db.query.DataConnectorStream.findMany({
+    where: (s, { eq: e }) => e(s.dataConnectorId, CONNECTOR_ID),
+  })
+  for (const streamRow of streams) {
+    const catStream = catalog.streams.find((s: any) => s.key === streamRow.streamKey)
+    if (!catStream) {
+      console.log(`  ${streamRow.streamKey}: not in catalog — skipped`)
+      continue
+    }
+    const next = appCatalogStreamSchema(catStream)
+    const before = JSON.stringify(streamRow.sourceSchema)
+    const after = JSON.stringify(next.sourceSchema)
+    console.log(
+      `  ${streamRow.streamKey}: ${before === after ? 'unchanged' : `CHANGED (${before.length} → ${after.length} chars)`}`
+    )
+    if (!APPLY || before === after) continue
+    await db
+      .update(schema.DataConnectorStream)
+      .set({
+        sourceSchema: next.sourceSchema,
+        schemaSource: next.schemaSource,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.DataConnectorStream.id, streamRow.id))
+  }
+
+  // ── 3. add the missing field mappings ──────────────────────────────────────
+  // Reuses the seeder's own partition so a field lands on exactly the mapping it would
+  // have at create time, with the same subtree-relative source path.
+  console.log('\n── 3. field mappings ───────────────────────────────────────')
+  let addedEntries = 0
+  for (const streamRow of streams) {
+    const catStream = catalog.streams.find((s: any) => s.key === streamRow.streamKey)
+    if (!catStream) continue
+    const allMappings = catStream.defaultMappings ?? []
+    const partition = partitionOwnedFields(catStream.fields, allMappings)
+    const allRootPaths = allMappings
+      .filter((m: any) => m.target.mode === 'owned')
+      .map((m: any) => m.rootPath)
+
+    const rows = await db.query.DataConnectorMapping.findMany({
+      where: (m, { eq: e }) => e(m.dataConnectorStreamId, streamRow.id),
+    })
+
+    for (const manifest of allMappings) {
+      if (manifest.target.mode !== 'owned') continue
+      const entries = partition[manifest.rootPath] ?? []
+      if (entries.length === 0) continue
+
+      // Rows store the parent-RELATIVE rootPath; the manifest path is absolute.
+      const parentRootPath = ownedParentRootPath(manifest.rootPath, allRootPaths)
+      const storedRootPath =
+        parentRootPath != null
+          ? relativeSourcePath(manifest.rootPath, parentRootPath)
+          : manifest.rootPath
+      const row = rows.find((r) => r.rootPath === storedRootPath && r.targetMode === 'owned')
+      if (!row) {
+        console.log(`  ${streamRow.streamKey}/${manifest.rootPath}: NO MATCHING ROW — skipped`)
+        continue
+      }
+      if (!row.entityDefinitionId) {
+        console.log(
+          `  ${streamRow.streamKey}/${manifest.rootPath}: mapping is UNBOUND (entityDefinitionId null) — skipped`
+        )
+        continue
+      }
+
+      const current = (row.fieldMappings ?? []) as any[]
+      const haveRefs = new Set(current.map((e) => e.targetFieldRef))
+      const ownedApiSlug = (manifest.target as any).entity.apiSlug
+      const additions = entries
+        .map((e: any) => ({
+          id: generateId(),
+          targetFieldRef: toAppFieldRef(ownedApiSlug, APP_SLUG, e.field.fieldKey),
+          expression: `{${e.relativeSourcePath}}`,
+          sourceFields: { [e.relativeSourcePath]: e.relativeSourcePath },
+        }))
+        .filter((e) => !haveRefs.has(e.targetFieldRef))
+
+      console.log(
+        `  ${streamRow.streamKey}/${storedRootPath || '(root)'}: ${current.length} existing, ${additions.length} to add`
+      )
+      for (const a of additions) console.log(`      + ${a.targetFieldRef}  ← ${a.expression}`)
+      if (!APPLY || additions.length === 0) continue
+
+      // `updateMapping` asserts every ref resolves on the def, classifies the edit as
+      // `rebackfill` (entries added that write) and stamps `resyncPending` — which is
+      // what arms the "Backfill now" banner.
+      await updateMapping(db, ORG_ID, row.id, { fieldMappings: [...current, ...additions] as any })
+      addedEntries += additions.length
+    }
+  }
+  if (APPLY && addedEntries > 0) console.log(`\n  added ${addedEntries} field mapping entries`)
+
+  const after = await db.query.DataConnector.findFirst({
+    where: (c, { eq: e }) => e(c.id, CONNECTOR_ID),
+  })
+  console.log(`\n  resyncPending: ${JSON.stringify((after as any)?.resyncPending ?? null)}`)
+
+  console.log(
+    `\n${APPLY ? 'Applied. Run "Backfill now" (backfillPendingChange) to re-crawl.' : 'Dry run only — nothing written.'}\n`
+  )
+  process.exit(0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/packages/lib/src/data-connectors/sinks/entity-sink.test.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink.test.ts
@@ -1,0 +1,61 @@
+// packages/lib/src/data-connectors/sinks/entity-sink.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { coerceListValue } from './entity-sink'
+
+/**
+ * A connector cannot source an array — the fan-out drops array-shaped source values
+ * before the sink is reached — so a comma string is the ONLY shape a connector can use
+ * to deliver a list. Before this split, that string was written whole and a two-tag
+ * source landed as a single compound tag, which meant a connector could never write
+ * more than one tag to a tag column.
+ */
+describe('coerceListValue', () => {
+  it('splits a comma string for TAGS into separate values', () => {
+    expect(coerceListValue('TAGS', 'Line Item Discount, Order Discount', false)).toEqual([
+      'Line Item Discount',
+      'Order Discount',
+    ])
+  })
+
+  it('splits a comma string for MULTI_SELECT too', () => {
+    expect(coerceListValue('MULTI_SELECT', 'a,b,c', false)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('trims whitespace and drops empty segments', () => {
+    expect(coerceListValue('TAGS', ' vip ,, gift ,', false)).toEqual(['vip', 'gift'])
+  })
+
+  it('leaves a single-tag string untouched — the common case keeps its old behaviour', () => {
+    expect(coerceListValue('TAGS', 'vip', false)).toBe('vip')
+  })
+
+  it('leaves an empty string untouched so existing blank handling decides', () => {
+    expect(coerceListValue('TAGS', '', false)).toBe('')
+  })
+
+  it('falls through to the original value when the string carries no actual tags', () => {
+    // `,` would otherwise split to [] and clear the current list.
+    expect(coerceListValue('TAGS', ',', false)).toBe(',')
+    expect(coerceListValue('TAGS', ' , , ', false)).toBe(' , , ')
+  })
+
+  it('NEVER splits a comma in a scalar type — a comma is ordinary TEXT content', () => {
+    expect(coerceListValue('TEXT', 'Doe, Jane', false)).toBe('Doe, Jane')
+    expect(coerceListValue('EMAIL', 'a@b.com,c@d.com', false)).toBe('a@b.com,c@d.com')
+    expect(coerceListValue(undefined, 'a,b', false)).toBe('a,b')
+  })
+
+  it('leaves the row-level multi path alone — it is per-row and refuses arrays', () => {
+    expect(coerceListValue('TAGS', 'a,b', true)).toBe('a,b')
+  })
+
+  it('passes non-string values through untouched', () => {
+    expect(coerceListValue('TAGS', null, false)).toBeNull()
+    expect(coerceListValue('TAGS', undefined, false)).toBeUndefined()
+    expect(coerceListValue('TAGS', 42, false)).toBe(42)
+    // An array is already the target shape; the fan-out should never deliver one,
+    // but if it does it must not be mangled further.
+    expect(coerceListValue('TAGS', ['a', 'b'], false)).toEqual(['a', 'b'])
+  })
+})

--- a/packages/lib/src/data-connectors/sinks/entity-sink.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink.ts
@@ -106,6 +106,48 @@ function rejectsFormat(fieldType: string | undefined, value: unknown): boolean {
   return !fieldValueSchemas[schemaKey].safeParse(value).success
 }
 
+/** Field types whose value is a LIST, delivered by a connector as a comma string. */
+const LIST_VALUED_TYPES = new Set(['TAGS', 'MULTI_SELECT'])
+
+/**
+ * Split a connector's comma-delimited string into the list a `TAGS`/`MULTI_SELECT`
+ * field actually wants.
+ *
+ * A connector cannot source an array — the fan-out drops array-shaped source values
+ * before this layer (`hasArrayShapedSource`, "connectors cannot source arrays"), and
+ * the multi path below drops them again. So the only shape a connector CAN deliver for
+ * a list field is a comma string. Without this split that string was written whole, and
+ * a two-tag source landed as one compound tag (`'vip, gift'` as a single tag value)
+ * — i.e. a connector could never write more than one tag to a tag column.
+ *
+ * `normalizeFieldValue` already splits a comma string for these types, but the
+ * connector write path does not route through it; splitting here hands the write path
+ * the array form, which it does understand.
+ *
+ * Deliberately narrow:
+ * - LIST-valued types only. A comma is ordinary content in `TEXT` and would be
+ *   destroyed by splitting.
+ * - Non-`isMulti` only. The row-level multi path is per-row by construction and
+ *   explicitly refuses arrays; leave it exactly as it was.
+ * - A value with no comma is returned untouched, so the overwhelmingly common
+ *   single-tag case keeps its existing behaviour byte for byte.
+ */
+export function coerceListValue(
+  fieldType: string | undefined,
+  value: unknown,
+  isMulti: boolean
+): unknown {
+  if (isMulti || !fieldType || !LIST_VALUED_TYPES.has(fieldType)) return value
+  if (typeof value !== 'string' || !value.includes(',')) return value
+  const parts = value
+    .split(',')
+    .map((v) => v.trim())
+    .filter(Boolean)
+  // `,` / `, ,` carries no tags — fall through to the original value so the existing
+  // blank handling decides, rather than writing an empty array over the current list.
+  return parts.length > 0 ? parts : value
+}
+
 /**
  * Remove the write-set entry carrying a unique-value conflict (B1 per-value
  * tolerance). Prefers the error's `fieldId` when it names a write-set key, else
@@ -416,7 +458,7 @@ async function buildWriteSet(
     current = await ctx.crud.getFieldValues(recordId)
   }
 
-  for (const [rawRef, value] of Object.entries(record.fields)) {
+  for (const [rawRef, sourceValue] of Object.entries(record.fields)) {
     const strategy = strategyFor(rawRef)
     if (strategy === 'ignore') continue
 
@@ -430,6 +472,12 @@ async function buildWriteSet(
     const isMulti =
       !identityRefs.has(rawRef) &&
       (fieldRow?.options as { multi?: boolean } | null | undefined)?.multi === true
+
+    // A list-valued field (TAGS / MULTI_SELECT) arrives as a comma string, because a
+    // connector cannot source an array. Split it into the list form the write path
+    // understands — otherwise a multi-tag source writes ONE compound tag. Every
+    // reference to `value` below is post-coercion by design.
+    const value = coerceListValue(fieldRow?.type, sourceValue, isMulti)
 
     // Pre-flight the format-validated types (EMAIL/URL/PHONE_INTL): a value the
     // write path would refuse costs the WHOLE record if it throws inside


### PR DESCRIPTION
A connector could not write **more than one tag** to a `TAGS` column. Both delivery shapes failed:

- an **array** is dropped before the sink is reached (`hasArrayShapedSource` — *"connectors cannot source arrays"*), and again by the multi path; and
- a **comma string** was written whole, so `'vip, gift'` landed as a single tag value literally containing a comma.

`normalizeFieldValue` *does* split a comma string for `TAGS`/`MULTI_SELECT` (`normalize-value.ts:201-214`), but the connector write path never routes through it — `entity-sink.ts` only has `normalizeMatch`, an unrelated match-key helper. This splits at the sink instead, where the field type is finally known, handing the write path the array form it already understands.

## Why it's this narrow

The narrowness is the design, not caution:

- **list-valued types only** — a comma is ordinary content in `TEXT`, and splitting it there would destroy data
- **non-`isMulti` only** — the row-level multi path is per-row by construction and explicitly refuses arrays, so it's left exactly as it was
- **a comma-free string is returned untouched** — the overwhelmingly common single-tag case is byte-for-byte unchanged
- **a string carrying no actual tags** (`,`, `, ,`) falls through rather than writing an empty array over the current list

9 unit tests; the 389 data-connector tests pass.

## Verified live, not just unit-tested

Against a real Shopify connector on the dev store: order tags went from one compound value to `["Line Item Discount","Order Discount"]`, and products from one value each to proper sets like `["Premium","Snow","Snowboard","Sport","Winter"]` — **61 tag rows across 23 records, up from 23**, with zero compound values remaining.

Useful control in the same run: `shippingAddress`/`billingAddress` stayed at **0** values throughout, which is how we know that defect is separate and untouched by this.

## 🛑 Still broken, deliberately not fixed here

Same class of defect — *the sink does not understand this field type's delivery shape*:

- **the array drop itself** — a connector still cannot source an array
- **`ADDRESS_STRUCT`** — also silently dropped. `shippingAddress`/`billingAddress` are mapped, 8 of 12 orders carry complete addresses, and there are **0 value rows**. An object no more survives `evaluateCalcExpression` than an array does.

Worth bundling into one follow-up.

## The scripts

Dev tooling used to find and prove this. Most are diagnostic, but one is load-bearing:

**`remap-connector-new-catalog-fields.ts`** — deploying an app version does **not** reach an already-created connector (the catalog → `DataConnectorMapping` projection is create-time only; `rollForwardInstallations` touches only `defineFields` app fields and webhook bindings). Recovering that needs two things the platform has no entry point for:

1. **Materializing the new columns**, which `installTemplates` cannot do: without `linkedEntities` it creates a *new* def (forking `shopify_orders-2`), and with `linkedEntities` Pass 3 short-circuits and creates no fields at all. So it runs the installer's Pass-3 logic itself against the adopted def — idempotent per `(owner, appFieldKey)`, verified by a second run finding nothing to do.
2. **Flushing the `customFields` org cache.** Without it every new `@app:` ref fails to resolve and the run dies during setup — and that failure writes **no `DataConnectorRun` row at all**, only `status: 'error'`, so the runs table looks untouched and the newest row is the previous *success*. `onCacheEvent('entity-def.created')` is not sufficient.

Dry-run by default; `APPLY=1` to write.