### PR TITLE
fix(workflow): give an if-else case one identifier and defaultData one meaning

### DIFF
--- a/apps/web/src/components/conditions/__tests__/condition-context-add-group.test.tsx
+++ b/apps/web/src/components/conditions/__tests__/condition-context-add-group.test.tsx
@@ -1,0 +1,85 @@
+// apps/web/src/components/conditions/__tests__/condition-context-add-group.test.tsx
+
+import { act, render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ConditionProvider, useConditionActions } from '..'
+import type { ConditionGroup, ConditionSystemConfig } from '../types'
+
+type Actions = ReturnType<typeof useConditionActions>
+
+function renderProvider(config: ConditionSystemConfig, groups: ConditionGroup[] = []) {
+  const onGroupsChange = vi.fn()
+  let actions: Actions | null = null
+
+  function Capture() {
+    actions = useConditionActions()
+    return null
+  }
+
+  render(
+    <ConditionProvider
+      conditions={[]}
+      groups={groups}
+      config={config}
+      onConditionsChange={() => {}}
+      onGroupsChange={onGroupsChange}>
+      <Capture />
+    </ConditionProvider>
+  )
+
+  return {
+    onGroupsChange,
+    addGroup: () => act(() => actions?.addGroup?.()),
+  }
+}
+
+const baseConfig: ConditionSystemConfig = {
+  mode: 'variable',
+  fields: 'dynamic',
+  showGrouping: true,
+}
+
+describe('addGroupEnhanced', () => {
+  it('stamps config.newGroupMetadata onto the group it creates', () => {
+    const { onGroupsChange, addGroup } = renderProvider({
+      ...baseConfig,
+      newGroupMetadata: () => ({ case_id: 'minted-handle' }),
+    })
+
+    addGroup()
+
+    const [created] = onGroupsChange.mock.calls.at(-1) as [ConditionGroup[]]
+    expect(created).toHaveLength(1)
+    expect(created[0]?.metadata?.case_id).toBe('minted-handle')
+  })
+
+  it('mints a fresh value per created group', () => {
+    let n = 0
+    const { onGroupsChange, addGroup } = renderProvider({
+      ...baseConfig,
+      newGroupMetadata: () => ({ case_id: `handle-${++n}` }),
+    })
+
+    addGroup()
+    addGroup()
+
+    const seen = onGroupsChange.mock.calls.map(
+      ([groups]) => (groups as ConditionGroup[]).at(-1)?.metadata?.case_id
+    )
+    expect(seen).toEqual(['handle-1', 'handle-2'])
+  })
+
+  it('leaves group metadata untouched for surfaces that mint nothing', () => {
+    const { onGroupsChange, addGroup } = renderProvider(baseConfig)
+
+    addGroup()
+
+    const [created] = onGroupsChange.mock.calls.at(-1) as [ConditionGroup[]]
+    expect(created[0]?.metadata).toEqual({
+      name: 'Group',
+      description: '',
+      subtext: '',
+      collapsed: false,
+    })
+  })
+})

--- a/apps/web/src/components/conditions/condition-context.tsx
+++ b/apps/web/src/components/conditions/condition-context.tsx
@@ -6,10 +6,10 @@ import { getOperatorsForBaseType } from '@auxx/lib/conditions/client'
 import { getFieldOperators } from '@auxx/lib/resources/client'
 import { getRelatedEntityDefinitionId, type RelationshipConfig } from '@auxx/types/custom-field'
 import { parseResourceFieldId, type ResourceFieldId } from '@auxx/types/field'
+import { generateId } from '@auxx/utils/generateId'
 import { produce } from 'immer'
 import type React from 'react'
 import { createContext, useCallback, useContext, useMemo, useRef } from 'react'
-import { v4 as generateId } from 'uuid'
 import { useResourceStore } from '~/components/resources/store/resource-store'
 import type {
   Condition,
@@ -428,6 +428,14 @@ export const ConditionProvider: React.FC<ConditionProviderProps> = ({
       const defaultName = config.defaultGroupName || 'Group'
       const newGroupCount = groups.length + 1
 
+      // Identity is minted here, once, at creation — never derived downstream
+      // from array position, which collides the moment a group is deleted and
+      // another added. Explicit metadata from the caller wins over the seed.
+      const seeded: Partial<ConditionGroupMetadata> = {
+        ...config.newGroupMetadata?.(),
+        ...metadata,
+      }
+
       const newGroup: ConditionGroup = {
         id: generateId(),
         conditions: [],
@@ -435,11 +443,11 @@ export const ConditionProvider: React.FC<ConditionProviderProps> = ({
         order: groups.length,
         metadata: {
           name:
-            metadata?.name || (newGroupCount > 1 ? `${defaultName} ${newGroupCount}` : defaultName),
-          description: metadata?.description || '',
-          subtext: metadata?.subtext || '',
-          collapsed: metadata?.collapsed || false,
-          ...metadata,
+            seeded.name || (newGroupCount > 1 ? `${defaultName} ${newGroupCount}` : defaultName),
+          description: seeded.description || '',
+          subtext: seeded.subtext || '',
+          collapsed: seeded.collapsed || false,
+          ...seeded,
         },
       }
 

--- a/apps/web/src/components/conditions/types.ts
+++ b/apps/web/src/components/conditions/types.ts
@@ -138,6 +138,17 @@ export interface ConditionSystemConfig {
   onGroupNameChange?: (groupId: string, name: string) => void
   onGroupCollapse?: (groupId: string, collapsed: boolean) => void
   onGroupReorder?: (groupIds: string[]) => void
+  /**
+   * Seed metadata minted once, when a group is created. Called by
+   * `addGroupEnhanced`; the result is merged under any metadata the caller
+   * passes explicitly.
+   *
+   * This is how a surface whose group metadata carries an *identifier* mints it
+   * at creation instead of deriving it downstream — if-else stamps the
+   * `case_id` that becomes the node's branch handle. Surfaces that need no such
+   * identifier leave this unset and their stored groups stay untouched.
+   */
+  newGroupMetadata?: () => Partial<ConditionGroupMetadata>
 }
 
 /**

--- a/apps/web/src/components/workflow/nodes/core/if-else/adapters/__tests__/condition-adapter.test.tsx
+++ b/apps/web/src/components/workflow/nodes/core/if-else/adapters/__tests__/condition-adapter.test.tsx
@@ -1,0 +1,145 @@
+// apps/web/src/components/workflow/nodes/core/if-else/adapters/__tests__/condition-adapter.test.tsx
+
+import { act, render } from '@testing-library/react'
+import { useState } from 'react'
+import { describe, expect, it } from 'vitest'
+import { ConditionProvider, useConditionActions } from '~/components/conditions'
+import { NodeType } from '~/components/workflow/types/node-types'
+import type { IfElseNodeData } from '../../types'
+import { useIfElseConditionAdapter } from '../condition-adapter'
+
+/**
+ * `case_id` IS the branch handle — it is what `node.tsx` renders as `handleId`,
+ * what an edge stores as `sourceHandle`, and what the engine returns as
+ * `outputHandle`. Two cases sharing one handle is a state `validateIfElseConfig`
+ * refuses with `blocksAuthoring: true`, in a field with no editor.
+ *
+ * Deriving the handle from array position made that state reachable purely
+ * through the canvas: add, add, delete the first added, add again — the last add
+ * lands at the index the deleted case vacated and re-mints its neighbour's
+ * address.
+ */
+
+const seedData = (): IfElseNodeData => ({
+  type: NodeType.IF_ELSE,
+  cases: [{ case_id: 'true', logical_operator: 'and', conditions: [] }],
+})
+
+type Actions = ReturnType<typeof useConditionActions>
+
+interface Harness {
+  data: () => IfElseNodeData
+  actions: () => Actions
+}
+
+function renderAdapterHarness(): Harness {
+  let latestData: IfElseNodeData = seedData()
+  let latestActions: Actions | null = null
+
+  function Capture() {
+    latestActions = useConditionActions()
+    return null
+  }
+
+  function Host() {
+    const [data, setData] = useState<IfElseNodeData>(seedData)
+    latestData = data
+
+    const { groups, onGroupsChange, config } = useIfElseConditionAdapter({
+      nodeId: 'if-else-test',
+      data,
+      setInputs: setData,
+      readOnly: false,
+    })
+
+    return (
+      <ConditionProvider
+        conditions={[]}
+        groups={groups}
+        config={config}
+        onConditionsChange={() => {}}
+        onGroupsChange={onGroupsChange}
+        nodeId='if-else-test'
+        getFieldDefinition={() => undefined}>
+        <Capture />
+      </ConditionProvider>
+    )
+  }
+
+  render(<Host />)
+
+  return {
+    data: () => latestData,
+    actions: () => {
+      if (!latestActions) throw new Error('condition actions were never captured')
+      return latestActions
+    },
+  }
+}
+
+describe('useIfElseConditionAdapter — case_id identity', () => {
+  it('keeps every case_id distinct across add / add / delete / add', () => {
+    const harness = renderAdapterHarness()
+
+    act(() => harness.actions().addGroup?.())
+    act(() => harness.actions().addGroup?.())
+
+    expect(harness.data().cases).toHaveLength(3)
+
+    // Delete the FIRST added case, leaving the second in place.
+    const doomed = harness.data().cases[1]
+    expect(doomed).toBeDefined()
+    // `case_id` IS the group id now — the case has no other identifier.
+    act(() => harness.actions().removeGroup?.(doomed!.case_id))
+
+    expect(harness.data().cases).toHaveLength(2)
+
+    // The add that used to re-mint the surviving case's handle.
+    act(() => harness.actions().addGroup?.())
+
+    const caseIds = harness.data().cases.map((c) => c.case_id)
+    expect(caseIds).toHaveLength(3)
+    expect(new Set(caseIds).size).toBe(caseIds.length)
+  })
+
+  it('never derives a case_id from array position', () => {
+    const harness = renderAdapterHarness()
+
+    act(() => harness.actions().addGroup?.())
+    act(() => harness.actions().addGroup?.())
+
+    const added = harness.data().cases.slice(1)
+    for (const addedCase of added) {
+      expect(addedCase.case_id).toBeTruthy()
+      expect(addedCase.case_id).not.toMatch(/^case_\d+$/)
+    }
+  })
+
+  it('never rewrites an existing case_id when a sibling is added or removed', () => {
+    const harness = renderAdapterHarness()
+
+    act(() => harness.actions().addGroup?.())
+    const firstAdded = harness.data().cases[1]?.case_id
+    expect(firstAdded).toBeTruthy()
+
+    act(() => harness.actions().addGroup?.())
+    expect(harness.data().cases[1]?.case_id).toBe(firstAdded)
+
+    const doomed = harness.data().cases[2]
+    act(() => harness.actions().removeGroup?.(doomed!.case_id))
+    expect(harness.data().cases[1]?.case_id).toBe(firstAdded)
+    expect(harness.data().cases[0]?.case_id).toBe('true')
+  })
+
+  it('mirrors every case_id into _targetBranches beside the reserved else', () => {
+    const harness = renderAdapterHarness()
+
+    act(() => harness.actions().addGroup?.())
+    act(() => harness.actions().addGroup?.())
+
+    const branchIds = harness.data()._targetBranches?.map((b) => b.id) ?? []
+    const caseIds = harness.data().cases.map((c) => c.case_id)
+
+    expect(branchIds).toEqual([...caseIds, 'false'])
+  })
+})

--- a/apps/web/src/components/workflow/nodes/core/if-else/adapters/condition-adapter.tsx
+++ b/apps/web/src/components/workflow/nodes/core/if-else/adapters/condition-adapter.tsx
@@ -1,5 +1,6 @@
 // apps/web/src/components/workflow/nodes/core/if-else/adapters/condition-adapter.tsx
 
+import { generateId } from '@auxx/utils/generateId'
 import { useCallback, useMemo, useRef } from 'react'
 import type { Condition, ConditionGroup, ConditionSystemConfig } from '~/components/conditions'
 import type { TargetBranch } from '~/components/workflow/types'
@@ -37,7 +38,10 @@ export const useIfElseConditionAdapter = ({
     const totalCases = data.cases.length
     return data.cases.map((ifElseCase, index) => {
       return {
-        id: ifElseCase.id,
+        // The group's identity IS the branch handle. `case_id` is the only id a
+        // case has (plan 28 §3.1), so the group carries it in both slots and
+        // nothing downstream has to pick between two.
+        id: ifElseCase.case_id,
         conditions: ifElseCase.conditions.map(
           (condition): Condition => ({
             id: condition.id,
@@ -75,12 +79,21 @@ export const useIfElseConditionAdapter = ({
   const onGroupsChange = useCallback(
     (updatedGroups: ConditionGroup[]) => {
       const currentData = dataRef.current
-      const updatedCases: IfElseCase[] = updatedGroups.map((group, index) => {
-        const originalCase = currentData.cases.find((c) => c.id === group.id)
-
+      const updatedCases: IfElseCase[] = updatedGroups.map((group) => {
+        // `case_id` IS the branch handle — `node.tsx` renders it, an edge stores it
+        // as `sourceHandle`, the engine returns it as `outputHandle`. It is
+        // minted once, when the case is created (`config.newGroupMetadata`
+        // below), and from then on it only travels: carried on the group's
+        // metadata, or read off `group.id`, which the `groups` memo above sets
+        // to the case's own `case_id`. It is NEVER derived from array position —
+        // a positional address re-mints a surviving sibling's handle after a
+        // delete-then-add, and two cases on one handle is a state
+        // `validateIfElseConfig` refuses outright.
+        //
+        // A legacy stored case still carrying the retired node-local `id` loses
+        // it here, on the first save: it is simply not read and not written back.
         return {
-          id: group.id,
-          case_id: group.metadata?.case_id || originalCase?.case_id || `case_${index}`,
+          case_id: group.metadata?.case_id || group.id,
           logical_operator: group.logicalOperator.toLowerCase() as 'and' | 'or',
           conditions: group.conditions.map(
             (condition): IfElseCondition => ({
@@ -100,11 +113,12 @@ export const useIfElseConditionAdapter = ({
         }
       })
 
-      // Update _targetBranches with case names
+      // Branch ids come off the cases, not off the groups, so a branch can never
+      // advertise an address no case answers to.
       const updatedTargetBranches: TargetBranch[] = [
-        ...updatedGroups.map((group) => ({
-          id: group.metadata?.case_id || '',
-          name: group.metadata?.name || '',
+        ...updatedCases.map((updatedCase, index) => ({
+          id: updatedCase.case_id,
+          name: updatedGroups[index]?.metadata?.name || '',
           type: 'default' as const,
         })),
         { id: 'false', name: 'Else', type: 'default' as const },
@@ -157,6 +171,10 @@ export const useIfElseConditionAdapter = ({
 
       // State
       readOnly,
+
+      // Mint the branch handle when the case is created. Nothing downstream may
+      // invent one, so this is the only site that ever calls `generateId` for it.
+      newGroupMetadata: () => ({ case_id: generateId() }),
 
       // Callbacks - sync case names to _targetBranches
       onGroupNameChange: handleGroupNameChange,

--- a/apps/web/src/components/workflow/nodes/core/if-else/types.ts
+++ b/apps/web/src/components/workflow/nodes/core/if-else/types.ts
@@ -4,6 +4,7 @@ import type { Operator } from '@auxx/lib/conditions/client'
 import type {
   CatalogIfElseNodeData,
   NodeCondition as CatalogNodeCondition,
+  NodeCaseOf,
 } from '@auxx/lib/workflow-engine/client'
 import type { Node as FlowNode } from '@xyflow/react'
 import type { TargetBranch } from '~/components/workflow/types'
@@ -41,14 +42,14 @@ export interface IfElseCondition extends Omit<CatalogNodeCondition, 'value' | 'v
 }
 
 /**
- * Case definition for if-else nodes
+ * Case definition for if-else nodes.
+ *
+ * The skeleton (`case_id`, `logical_operator`) is declared ONCE, in the catalog
+ * — `case_id` is the sole identifier and IS the branch handle (plan 28 §3.1).
+ * Only the condition element is local, for the Tiptap/`BaseType` narrowings
+ * above.
  */
-export interface NodeCase {
-  id: string
-  case_id: string
-  logical_operator: 'and' | 'or'
-  conditions: IfElseCondition[]
-}
+export type NodeCase = NodeCaseOf<IfElseCondition>
 
 // Re-export from store types for backward compatibility
 export type IfElseCase = NodeCase

--- a/apps/web/src/components/workflow/nodes/core/scheduled/panel.tsx
+++ b/apps/web/src/components/workflow/nodes/core/scheduled/panel.tsx
@@ -1,4 +1,4 @@
-// apps/web/src/components/workflow/nodes/core/scheduled-trigger/panel.tsx
+// apps/web/src/components/workflow/nodes/core/scheduled/panel.tsx
 
 'use client'
 
@@ -165,7 +165,7 @@ const ScheduledTriggerPanelComponent: React.FC<ScheduledTriggerPanelProps> = ({ 
           {/* Timezone Selection */}
           <Field title='Timezone' description='Select the timezone for the schedule'>
             <TimeZonePicker
-              selected={previewConfig.timezone}
+              selected={previewConfig.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone}
               onChange={handleTimezoneChange}
               disabled={isReadOnly}
             />

--- a/apps/web/src/components/workflow/parity/contract-drift-allowlist.ts
+++ b/apps/web/src/components/workflow/parity/contract-drift-allowlist.ts
@@ -339,10 +339,6 @@ export const EXTRACTION_BLIND_SPOTS: Record<string, string> = {
   'config:wait.deliveryWindow':
     "By design, same origin: `buildSequenceGraph` emits it from the sequence's delivery window (publish.ts:99). A zero-delay wait node exists ONLY to carry it, which is why the pairing has to stay one-directional.",
 
-  // ── Handle the reader can see but production can never emit ───────────────
-  'handle:if-else.true':
-    "Dead arm, not drift: `outputHandle = conditionResult ? 'true' : 'false'` (if-else.ts:181) runs only when matchedCaseId is null, and buildExecutionResult is only ever called with (true, case_id, …) on a match (if-else.ts:138) or (false, null, …) on none (if-else.ts:150) — so the 'true' literal is unreachable. Production emits case ids and 'false', both rendered. The reachability hole in the reader's net (engine-write-scrape.ts header) seen from the other side: it proves a write EXISTS, never that it runs.",
-
   // ── Internal bookkeeping, deliberately not picker material ────────────────
   'written:ai._resolvedPromptVars':
     'By design: ai-v2.ts:165 stashes the resolved variable map for the run log ("for run-log + downstream uses"), underscore-named to mark it internal. Not a picker variable.',

--- a/packages/lib/src/data-migrations/migrations/095-drop-if-else-case-legacy-id.int.test.ts
+++ b/packages/lib/src/data-migrations/migrations/095-drop-if-else-case-legacy-id.int.test.ts
@@ -1,0 +1,299 @@
+// packages/lib/src/data-migrations/migrations/095-drop-if-else-case-legacy-id.int.test.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createTestOrganization, getTestDb } from '@auxx/test-utils'
+import { eq, sql } from 'drizzle-orm'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { migration095DropIfElseCaseLegacyId as migration } from './095-drop-if-else-case-legacy-id'
+
+/**
+ * The key drop against a real Postgres.
+ *
+ * Two things are actually at stake and neither is expressible against a mocked
+ * `db`. First, the migration rewrites three independent jsonb columns in three
+ * independent loops, so "idempotent" has to be proved three times. Second, the
+ * thing it must NOT do — move a branch handle — is only visible by reading the
+ * stored `case_id`s and `edge.sourceHandle`s back out of the column afterwards.
+ *
+ * Idempotency is asserted on Postgres's `xmin` (the transaction id stamped on
+ * every row version), not on column values. `Workflow.updatedAt` carries no
+ * `$onUpdate` and `WorkflowRun` has no `updatedAt` at all, so an UPDATE that
+ * writes an identical graph would be invisible to a value comparison. `xmin`
+ * changes on every physical row write, so an unchanged `xmin` is proof that the
+ * second pass issued no UPDATE — not merely that the values matched.
+ */
+
+/** A legacy if-else node: two ids per case, the readable one in the retired slot. */
+const legacyGraph = () => ({
+  nodes: [
+    { id: 'trigger-1', data: { type: 'manual', title: 'Start' } },
+    {
+      id: 'if-else-1',
+      data: {
+        type: 'if-else',
+        title: 'Check Order',
+        cases: [
+          {
+            id: 'case_has_order',
+            case_id: 'true',
+            logical_operator: 'and',
+            conditions: [{ id: 'c1', variableId: 'Order.id', comparison_operator: 'is_not_empty' }],
+          },
+          {
+            id: 'case_email_mismatch',
+            case_id: 'case_email_mismatch',
+            logical_operator: 'and',
+            conditions: [{ id: 'c2', variableId: 'Order.email', comparison_operator: 'is' }],
+          },
+        ],
+      },
+    },
+    { id: 'wait-1', data: { type: 'wait', title: 'Matched' } },
+    { id: 'wait-2', data: { type: 'wait', title: 'Mismatch' } },
+    { id: 'wait-3', data: { type: 'wait', title: 'Otherwise' } },
+  ],
+  edges: [
+    { id: 'e0', source: 'trigger-1', target: 'if-else-1', sourceHandle: 'source' },
+    { id: 'e1', source: 'if-else-1', target: 'wait-1', sourceHandle: 'true' },
+    { id: 'e2', source: 'if-else-1', target: 'wait-2', sourceHandle: 'case_email_mismatch' },
+    { id: 'e3', source: 'if-else-1', target: 'wait-3', sourceHandle: 'false' },
+  ],
+})
+
+/** A graph with no if-else node at all — the migration must not write it. */
+const unrelatedGraph = () => ({
+  nodes: [
+    { id: 'trigger-1', data: { type: 'manual', title: 'Start' } },
+    {
+      id: 'classifier-1',
+      data: { type: 'text-classifier', title: 'Sort', classes: [{ id: 'category-1', name: 'A' }] },
+    },
+  ],
+  edges: [{ id: 'e0', source: 'trigger-1', target: 'classifier-1' }],
+})
+
+type Graph = ReturnType<typeof legacyGraph>
+
+describe('migration 095 — drop the retired if-else cases[].id', () => {
+  let db: Database
+  let organizationId: string
+  let workflowAppId: string
+
+  beforeEach(async () => {
+    db = getTestDb() as unknown as Database
+    organizationId = (await createTestOrganization()).id
+
+    const [app] = await db
+      .insert(schema.WorkflowApp)
+      .values({ organizationId, name: 'Test App', updatedAt: new Date('2026-01-01T00:00:00.000Z') })
+      .returning({ id: schema.WorkflowApp.id })
+    workflowAppId = app!.id
+  })
+
+  const createWorkflow = async (graph: unknown): Promise<string> => {
+    const [row] = await db
+      .insert(schema.Workflow)
+      .values({
+        organizationId,
+        workflowAppId,
+        name: 'Order Lookup',
+        graph: graph as any,
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      })
+      .returning({ id: schema.Workflow.id })
+    return row!.id
+  }
+
+  const createTemplate = async (graph: unknown): Promise<string> => {
+    const [row] = await db
+      .insert(schema.WorkflowTemplate)
+      .values({
+        name: 'Order Lookup Template',
+        description: 'Admin-authored template',
+        graph: graph as any,
+        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      })
+      .returning({ id: schema.WorkflowTemplate.id })
+    return row!.id
+  }
+
+  const createRun = async (workflowId: string, graph: unknown): Promise<string> => {
+    const [row] = await db
+      .insert(schema.WorkflowRun)
+      .values({
+        organizationId,
+        workflowAppId,
+        workflowId,
+        sequenceNumber: 1,
+        type: 'workflow',
+        triggeredFrom: 'APP_RUN',
+        version: '1',
+        graph: graph as any,
+        inputs: {},
+        status: 'SUCCEEDED',
+      })
+      .returning({ id: schema.WorkflowRun.id })
+    return row!.id
+  }
+
+  const readGraph = async (table: any, id: string): Promise<Graph> => {
+    const [row] = await db.select({ graph: table.graph }).from(table).where(eq(table.id, id))
+    return row!.graph as Graph
+  }
+
+  /** The row-version stamp. Changes on every physical UPDATE, identical otherwise. */
+  const readXmin = async (table: any, id: string): Promise<string> => {
+    const [row] = await db
+      .select({ xmin: sql<string>`xmin::text` })
+      .from(table)
+      .where(eq(table.id, id))
+    return row!.xmin
+  }
+
+  const ifElseCases = (graph: Graph): Array<Record<string, unknown>> =>
+    (graph.nodes.find((n) => n.id === 'if-else-1')!.data as any).cases
+
+  // ── What it drops ───────────────────────────────────────────────────────────
+
+  describe('the key', () => {
+    it.each([
+      ['Workflow', () => schema.Workflow],
+      ['WorkflowTemplate', () => schema.WorkflowTemplate],
+      ['WorkflowRun', () => schema.WorkflowRun],
+    ])('drops cases[].id from a legacy if-else node in %s.graph', async (label, table) => {
+      const workflowId = await createWorkflow(legacyGraph())
+      const id =
+        label === 'Workflow'
+          ? workflowId
+          : label === 'WorkflowTemplate'
+            ? await createTemplate(legacyGraph())
+            : await createRun(workflowId, legacyGraph())
+
+      await migration.run(db)
+
+      const cases = ifElseCases(await readGraph(table(), id))
+      expect(cases).toHaveLength(2)
+      for (const caseItem of cases) expect(caseItem).not.toHaveProperty('id')
+    })
+
+    it('leaves every case_id exactly where it was', async () => {
+      // The readable string lived in the key being dropped; the ADDRESS is
+      // `case_id` and none of it may move, including the legacy `'true'`.
+      const id = await createWorkflow(legacyGraph())
+
+      await migration.run(db)
+
+      expect(ifElseCases(await readGraph(schema.Workflow, id)).map((c) => c.case_id)).toEqual([
+        'true',
+        'case_email_mismatch',
+      ])
+    })
+
+    it('leaves every edge on its original handle', async () => {
+      // The whole point of the direction chosen in plan 28 §2 decision 2: edges
+      // already store `case_id`, so there is zero edge migration. If a run of
+      // this could move a handle, it is wrong.
+      const before = legacyGraph().edges
+      const id = await createWorkflow(legacyGraph())
+
+      await migration.run(db)
+
+      expect((await readGraph(schema.Workflow, id)).edges).toEqual(before)
+    })
+
+    it('leaves conditions[].id alone — that one is still bookkeeping', async () => {
+      const id = await createWorkflow(legacyGraph())
+
+      await migration.run(db)
+
+      const cases = ifElseCases(await readGraph(schema.Workflow, id))
+      expect((cases[0]!.conditions as Array<{ id: string }>).map((c) => c.id)).toEqual(['c1'])
+      expect((cases[1]!.conditions as Array<{ id: string }>).map((c) => c.id)).toEqual(['c2'])
+    })
+  })
+
+  // ── What it must not touch ──────────────────────────────────────────────────
+
+  describe('scope', () => {
+    it('never writes a graph with no if-else node', async () => {
+      // `text-classifier` carries `classes[].id`, which IS its branch handle — a
+      // blanket "drop nested id" would destroy every classifier route.
+      const id = await createWorkflow(unrelatedGraph())
+      const before = await readXmin(schema.Workflow, id)
+
+      await migration.run(db)
+
+      expect(await readGraph(schema.Workflow, id)).toEqual(unrelatedGraph())
+      expect(await readXmin(schema.Workflow, id)).toBe(before)
+    })
+
+    it('never writes an if-else node that is already on the new shape', async () => {
+      const clean = legacyGraph()
+      for (const caseItem of ifElseCases(clean)) delete caseItem.id
+      const id = await createWorkflow(clean)
+      const before = await readXmin(schema.Workflow, id)
+
+      await migration.run(db)
+
+      expect(await readXmin(schema.Workflow, id)).toBe(before)
+    })
+
+    it('survives a row with a null or shapeless graph', async () => {
+      const nullGraph = await createWorkflow(null)
+      const noNodes = await createWorkflow({ edges: [] })
+
+      await expect(migration.run(db)).resolves.toBeUndefined()
+
+      expect(await readGraph(schema.Workflow, nullGraph)).toBeNull()
+      expect(await readGraph(schema.Workflow, noNodes)).toEqual({ edges: [] })
+    })
+  })
+
+  // ── Idempotency, per column ─────────────────────────────────────────────────
+
+  describe('idempotency', () => {
+    it('issues zero UPDATEs on a second run, on all three columns', async () => {
+      const workflowId = await createWorkflow(legacyGraph())
+      const templateId = await createTemplate(legacyGraph())
+      const runId = await createRun(workflowId, legacyGraph())
+
+      await migration.run(db)
+
+      const afterFirst = {
+        workflow: await readGraph(schema.Workflow, workflowId),
+        template: await readGraph(schema.WorkflowTemplate, templateId),
+        run: await readGraph(schema.WorkflowRun, runId),
+      }
+      const xminAfterFirst = {
+        workflow: await readXmin(schema.Workflow, workflowId),
+        template: await readXmin(schema.WorkflowTemplate, templateId),
+        run: await readXmin(schema.WorkflowRun, runId),
+      }
+
+      await migration.run(db)
+
+      expect(await readGraph(schema.Workflow, workflowId)).toEqual(afterFirst.workflow)
+      expect(await readGraph(schema.WorkflowTemplate, templateId)).toEqual(afterFirst.template)
+      expect(await readGraph(schema.WorkflowRun, runId)).toEqual(afterFirst.run)
+
+      expect(await readXmin(schema.Workflow, workflowId)).toBe(xminAfterFirst.workflow)
+      expect(await readXmin(schema.WorkflowTemplate, templateId)).toBe(xminAfterFirst.template)
+      expect(await readXmin(schema.WorkflowRun, runId)).toBe(xminAfterFirst.run)
+    })
+
+    it('leaves updatedAt alone even on the pass that rewrites the row', async () => {
+      // The key nothing reads is being dropped; nobody's view of the workflow
+      // changes, so a migration must not report itself as a user edit.
+      const id = await createWorkflow(legacyGraph())
+
+      await migration.run(db)
+
+      const [row] = await db
+        .select({ updatedAt: schema.Workflow.updatedAt })
+        .from(schema.Workflow)
+        .where(eq(schema.Workflow.id, id))
+      expect(row!.updatedAt).toEqual(new Date('2026-01-01T00:00:00.000Z'))
+    })
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/095-drop-if-else-case-legacy-id.ts
+++ b/packages/lib/src/data-migrations/migrations/095-drop-if-else-case-legacy-id.ts
@@ -1,0 +1,244 @@
+// packages/lib/src/data-migrations/migrations/095-drop-if-else-case-legacy-id.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { asc, eq, gt } from 'drizzle-orm'
+import type { WorkflowGraph } from '../../workflows/template-graph-transformer'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-095')
+
+/** Rows scanned per page. Graphs are jsonb documents, so keep the page small. */
+const BATCH_SIZE = 200
+
+/**
+ * Drop the retired node-local `id` from every `if-else` case in ONE graph.
+ *
+ * Mutates `graph` in place and returns the number of NODES whose cases changed —
+ * `0` means there is nothing to persist, which is what makes a second pass a
+ * no-op rather than a rewrite.
+ *
+ * The only key ever removed is `cases[].id`. `case_id` — the branch handle every
+ * edge's `sourceHandle` points at — is neither read nor written, and `graph.edges`
+ * is never looked at: this function is structurally incapable of moving a handle.
+ *
+ * Exported for the unit test — pure, no DB.
+ */
+export function dropLegacyCaseIdsInGraph(graph: WorkflowGraph): number {
+  if (!Array.isArray(graph.nodes) || graph.nodes.length === 0) return 0
+
+  let touched = 0
+  for (const node of graph.nodes) {
+    if (node?.data?.type !== 'if-else') continue
+    const cases = node.data.cases
+    if (!Array.isArray(cases)) continue
+
+    let nodeChanged = false
+    for (const caseItem of cases) {
+      if (caseItem && typeof caseItem === 'object' && 'id' in caseItem) {
+        delete (caseItem as Record<string, unknown>).id
+        nodeChanged = true
+      }
+    }
+    if (nodeChanged) touched++
+  }
+
+  return touched
+}
+
+/** Per-column tallies, so the log line says which of the three actually moved. */
+interface ColumnSummary {
+  scanned: number
+  rewritten: number
+  nodesRewritten: number
+}
+
+const emptySummary = (): ColumnSummary => ({ scanned: 0, rewritten: 0, nodesRewritten: 0 })
+
+/**
+ * Retire `cases[].id` from every stored if-else node
+ * (`plans/kopilot/workflow/28-case-identity-and-manifest-purity.md` §3.1a).
+ *
+ * **Why the key goes away.** An if-else case carried two identifiers and only one
+ * of them was an address. `case_id` IS the branch handle: it is what `node.tsx`
+ * renders, what an edge stores as `sourceHandle`, what the engine returns as
+ * `outputHandle` and what `resolveConnectionSpec` resolves a `branch` to. `id`
+ * addressed nothing, was validated by nothing, and was read by exactly two
+ * node-local sites. Worse, 47 of 53 stored cases parked the *readable* name in
+ * `id` (`case_has_order`) while the actual address read `true` — so the more
+ * address-looking of the two was the one that routed nothing.
+ *
+ * **Why this is migrated rather than left to rot.** Retiring a stored key
+ * normally means adding it to `NON_CONFIG_KEYS` (`graph-edit/read.ts`) and
+ * letting the data sit — that is how `inputNodes` and `description` were retired.
+ * That mechanism is unavailable here: `buildNodeSummary` applies the set over
+ * `Object.entries(node.data)`, TOP LEVEL ONLY, and `cases[].id` is one level
+ * down. Left in place it reaches the agent-facing `config` on every `get_node` of
+ * a legacy node — echoing exactly the two-id confusion the schema change deletes,
+ * at a moment when `describe_node_type` no longer documents `id` at all and
+ * `patch-config` does no schema-based path validation, so the model could write
+ * to it too.
+ *
+ * **Scope.** Three jsonb graph columns:
+ * - `Workflow.graph` — the draft AND every published version are independent rows
+ *   in that one table;
+ * - `WorkflowTemplate.graph` — admin-authored DB templates (the bundled
+ *   `*.template.json` files are never written to the DB and were re-authored in
+ *   the same change);
+ * - `WorkflowRun.graph` — the frozen graph a run executed against. Historical, but
+ *   it is what the run-detail trace renders from, so it gets the same shape.
+ *
+ * Each column is its own loop with its own cursor: three tables means three
+ * independent idempotency guarantees, and a shared cursor would couple them.
+ *
+ * **Safety.** Read-modify-write on the RAW column, never through `hydrateGraph` —
+ * hydration re-adds derived fields (`node.type`, `edge.data.sourceType`, filled
+ * handles) and would re-fatten every row plan 23's canonicalization slimmed.
+ * Nothing but `cases[].id` is touched; edges are never read or written.
+ *
+ * **`updatedAt` is deliberately not written.** Nothing reads the key being
+ * dropped, so no consumer's view of the workflow changes, and stamping "last
+ * edited" across the fleet would report a migration as a user edit. `Workflow`
+ * and `WorkflowRun` therefore keep theirs; `WorkflowTemplate.updatedAt` carries
+ * `$onUpdate`, so Drizzle stamps it whatever this code does — an admin-template
+ * row is not a "last edited by you" surface, so that is left as it is rather
+ * than fought with raw SQL. The save-path CAS token (`graphHash`) is derived
+ * from the stored graph at read time and is never persisted, so there is no
+ * stale token to invalidate — a builder tab left open across the migration
+ * simply re-reads.
+ *
+ * **Idempotent.** A row is only written when {@link dropLegacyCaseIdsInGraph}
+ * reports a node it actually changed, and after one pass no case carries the key,
+ * so a second run issues zero UPDATEs against any of the three columns.
+ *
+ * Raw Drizzle on purpose — the `ensure*` helpers are for entity migrations.
+ */
+export const migration095DropIfElseCaseLegacyId: DataMigrationDef = {
+  id: '095-drop-if-else-case-legacy-id',
+  description: 'Drop the retired cases[].id from stored if-else nodes (case_id is the sole id)',
+  async run(db: Database): Promise<void> {
+    const workflows = emptySummary()
+    const templates = emptySummary()
+    const runs = emptySummary()
+
+    // ── Workflow.graph ────────────────────────────────────────────────────────
+    let workflowCursor = ''
+    for (;;) {
+      const rows = await db
+        .select({ id: schema.Workflow.id, graph: schema.Workflow.graph })
+        .from(schema.Workflow)
+        .where(gt(schema.Workflow.id, workflowCursor))
+        .orderBy(asc(schema.Workflow.id))
+        .limit(BATCH_SIZE)
+
+      if (rows.length === 0) break
+
+      for (const row of rows) {
+        workflows.scanned++
+        workflowCursor = row.id
+
+        if (!row.graph || typeof row.graph !== 'object') continue
+        const graph = row.graph as unknown as WorkflowGraph
+
+        const touched = dropLegacyCaseIdsInGraph(graph)
+        if (touched === 0) continue
+
+        await db
+          .update(schema.Workflow)
+          .set({ graph: graph as any })
+          .where(eq(schema.Workflow.id, row.id))
+
+        workflows.rewritten++
+        workflows.nodesRewritten += touched
+        logger.info('Dropped legacy if-else case ids', {
+          table: 'Workflow',
+          rowId: row.id,
+          nodesTouched: touched,
+        })
+      }
+
+      if (rows.length < BATCH_SIZE) break
+    }
+
+    // ── WorkflowTemplate.graph ────────────────────────────────────────────────
+    let templateCursor = ''
+    for (;;) {
+      const rows = await db
+        .select({ id: schema.WorkflowTemplate.id, graph: schema.WorkflowTemplate.graph })
+        .from(schema.WorkflowTemplate)
+        .where(gt(schema.WorkflowTemplate.id, templateCursor))
+        .orderBy(asc(schema.WorkflowTemplate.id))
+        .limit(BATCH_SIZE)
+
+      if (rows.length === 0) break
+
+      for (const row of rows) {
+        templates.scanned++
+        templateCursor = row.id
+
+        if (!row.graph || typeof row.graph !== 'object') continue
+        const graph = row.graph as unknown as WorkflowGraph
+
+        const touched = dropLegacyCaseIdsInGraph(graph)
+        if (touched === 0) continue
+
+        await db
+          .update(schema.WorkflowTemplate)
+          .set({ graph: graph as any })
+          .where(eq(schema.WorkflowTemplate.id, row.id))
+
+        templates.rewritten++
+        templates.nodesRewritten += touched
+        logger.info('Dropped legacy if-else case ids', {
+          table: 'WorkflowTemplate',
+          rowId: row.id,
+          nodesTouched: touched,
+        })
+      }
+
+      if (rows.length < BATCH_SIZE) break
+    }
+
+    // ── WorkflowRun.graph ─────────────────────────────────────────────────────
+    let runCursor = ''
+    for (;;) {
+      const rows = await db
+        .select({ id: schema.WorkflowRun.id, graph: schema.WorkflowRun.graph })
+        .from(schema.WorkflowRun)
+        .where(gt(schema.WorkflowRun.id, runCursor))
+        .orderBy(asc(schema.WorkflowRun.id))
+        .limit(BATCH_SIZE)
+
+      if (rows.length === 0) break
+
+      for (const row of rows) {
+        runs.scanned++
+        runCursor = row.id
+
+        if (!row.graph || typeof row.graph !== 'object') continue
+        const graph = row.graph as unknown as WorkflowGraph
+
+        const touched = dropLegacyCaseIdsInGraph(graph)
+        if (touched === 0) continue
+
+        await db
+          .update(schema.WorkflowRun)
+          .set({ graph: graph as any })
+          .where(eq(schema.WorkflowRun.id, row.id))
+
+        runs.rewritten++
+        runs.nodesRewritten += touched
+        logger.info('Dropped legacy if-else case ids', {
+          table: 'WorkflowRun',
+          rowId: row.id,
+          nodesTouched: touched,
+        })
+      }
+
+      if (rows.length < BATCH_SIZE) break
+    }
+
+    logger.info('if-else legacy case id drop complete', { workflows, templates, runs })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -59,6 +59,7 @@ import { migration091BackfillParticipantDisplayName } from './migrations/091-bac
 import { migration092ReseedPlatformProvidersMetaGlobal } from './migrations/092-reseed-platform-providers-meta-global'
 import { migration093BackfillSocialWebhookRouteKey } from './migrations/093-backfill-social-webhook-route-key'
 import { migration094StripeAccountCutover } from './migrations/094-stripe-account-cutover'
+import { migration095DropIfElseCaseLegacyId } from './migrations/095-drop-if-else-case-legacy-id'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -144,6 +145,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration092ReseedPlatformProvidersMetaGlobal,
     migration093BackfillSocialWebhookRouteKey,
     migration094StripeAccountCutover,
+    migration095DropIfElseCaseLegacyId,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/workflow-engine/catalog/default-data-purity.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/default-data-purity.test.ts
@@ -1,0 +1,65 @@
+// packages/lib/src/workflow-engine/catalog/default-data-purity.test.ts
+
+import { isDeepStrictEqual } from 'node:util'
+import { expect, it, vi } from 'vitest'
+import { listManifests } from './registry'
+
+/**
+ * `defaultData()` must be a function of the node type and NOTHING else.
+ *
+ * Two distinct impurities break that, and only one of them is visible to a
+ * naive `defaultData() === defaultData()` comparison:
+ *
+ *  1. **Per-call minting** — `generateId()` returns a different string on every
+ *     call, so two calls in the same process already disagree.
+ *  2. **Ambient-environment reads** — `Intl.DateTimeFormat().resolvedOptions()
+ *     .timeZone` returns the SAME string on every call inside one process, so
+ *     two back-to-back calls agree and the site looks pure. It is the worst of
+ *     the two: the value silently differs between the browser (the user's zone)
+ *     and the worker (UTC), which is precisely a cross-process bug.
+ *
+ * Plan `26` §6 B1 specified the naive comparison and predicted it would fail on
+ * `scheduled`. It does not — `scheduled` sails through it, and `find` (which
+ * B1 never listed) fails. Hence the zone swap below: the second call runs under
+ * a different ambient IANA zone, which is the only way this test has teeth
+ * against failure mode 2.
+ */
+const REAL_DATE_TIME_FORMAT = Intl.DateTimeFormat
+
+const ZONE_A = 'America/Los_Angeles'
+const ZONE_B = 'Asia/Tokyo'
+
+/** Run `fn` with the ambient resolved IANA zone forced to `zone`. */
+function withAmbientZone<T>(zone: string, fn: () => T): T {
+  const spy = vi.spyOn(Intl, 'DateTimeFormat').mockImplementation(((...args: unknown[]) => {
+    const formatter = new (
+      REAL_DATE_TIME_FORMAT as unknown as new (
+        ...a: unknown[]
+      ) => Intl.DateTimeFormat
+    )(...args)
+    const resolved = formatter.resolvedOptions.bind(formatter)
+    formatter.resolvedOptions = () => ({ ...resolved(), timeZone: zone })
+    return formatter
+  }) as unknown as typeof Intl.DateTimeFormat)
+
+  try {
+    return fn()
+  } finally {
+    spy.mockRestore()
+  }
+}
+
+it('every manifest defaultData() is pure — no minted ids, no ambient reads', () => {
+  const first = withAmbientZone(ZONE_A, () =>
+    listManifests().map((manifest) => ({ id: manifest.id, data: manifest.defaultData() }))
+  )
+  const second = withAmbientZone(ZONE_B, () =>
+    listManifests().map((manifest) => ({ id: manifest.id, data: manifest.defaultData() }))
+  )
+
+  const offenders = first
+    .filter((entry, index) => !isDeepStrictEqual(entry.data, second[index]?.data))
+    .map((entry) => entry.id)
+
+  expect(offenders).toEqual([])
+})

--- a/packages/lib/src/workflow-engine/catalog/if-else.test.ts
+++ b/packages/lib/src/workflow-engine/catalog/if-else.test.ts
@@ -40,7 +40,6 @@ function ifElseData(cases: unknown[]): IfElseNodeData {
 
 function oneCase(caseId: string) {
   return {
-    id: `c-${caseId}`,
     case_id: caseId,
     logical_operator: 'and',
     conditions: [{ id: 'x', variableId: 'Carrier.value', comparison_operator: 'is', value: 'ups' }],
@@ -83,7 +82,7 @@ describe('validateIfElseConfig — case_id is the branch address (F1)', () => {
     // A throwing validator returns NO blockers (`authoringBlockers` swallows
     // it), so the reserved-handle rule would silently stop firing on exactly
     // the half-built config it exists to catch.
-    const data = ifElseData([{ id: 'c1', case_id: 'false', logical_operator: 'and' }])
+    const data = ifElseData([{ case_id: 'false', logical_operator: 'and' }])
     expect(() => validateIfElseConfig(data)).not.toThrow()
     expect(blockers(data)).toHaveLength(1)
   })
@@ -124,10 +123,25 @@ describe('ifElseManifest.connection.branches', () => {
       ifElseData([oneCase('carrier-fedex'), oneCase('carrier-ups')])
     )
     expect(branches).toEqual([
-      { id: 'carrier-fedex', name: 'CASE 1', kind: 'default' },
-      { id: 'carrier-ups', name: 'CASE 2', kind: 'default' },
+      { id: 'carrier-fedex', name: 'CASE 1', kind: 'default', positionalName: true },
+      { id: 'carrier-ups', name: 'CASE 2', kind: 'default', positionalName: true },
       { id: 'false', name: 'ELSE', kind: 'default' },
     ])
+  })
+
+  it('marks every case label positional, and the reserved ELSE not', () => {
+    // `CASE n` is recomputed from array position on every read, so it is a
+    // label and never an address (plan 28 §3.3). `ELSE` is derived from the
+    // `false` id instead, so it stays addressable by name.
+    const branches =
+      ifElseManifest.connection.branches?.(
+        ifElseData([oneCase('carrier-fedex'), oneCase('carrier-ups')])
+      ) ?? []
+    expect(branches.filter((b) => b.positionalName).map((b) => b.id)).toEqual([
+      'carrier-fedex',
+      'carrier-ups',
+    ])
+    expect(branches.find((b) => b.id === 'false')?.positionalName).toBeUndefined()
   })
 
   it('does not throw for cases: [] or absent cases — it degrades to ELSE', () => {
@@ -180,7 +194,6 @@ describe('variableId brace tolerance (F5, read side)', () => {
   it('extracts the unwrapped path, so ref-check never sees quadruple braces', () => {
     const data = ifElseData([
       {
-        id: 'c1',
         case_id: 'carrier-ups',
         logical_operator: 'and',
         conditions: [{ id: 'x', variableId: '{{Carrier.value}}', comparison_operator: 'is' }],

--- a/packages/lib/src/workflow-engine/catalog/nodes/find.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/find.ts
@@ -1,6 +1,5 @@
 // packages/lib/src/workflow-engine/catalog/nodes/find.ts
 
-import { generateId } from '@auxx/utils/generateId'
 import { z } from 'zod'
 import {
   type Condition,
@@ -98,7 +97,7 @@ export function createFindNodeDefaultData(): Partial<FindNodeData> {
     conditions: [], // Keep for backward compatibility
     conditionGroups: [
       {
-        id: generateId(),
+        id: 'group-1',
         conditions: [],
         logicalOperator: 'OR',
         order: 0,

--- a/packages/lib/src/workflow-engine/catalog/nodes/if-else.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/if-else.ts
@@ -1,6 +1,5 @@
 // packages/lib/src/workflow-engine/catalog/nodes/if-else.ts
 
-import { generateId } from '@auxx/utils/generateId'
 import { z } from 'zod'
 import { ALL_OPERATOR_KEYS, type Operator } from '../../../conditions/client'
 import { BaseType } from '../../core/types'
@@ -44,14 +43,33 @@ export interface IfElseCondition extends Omit<NodeCondition, 'value'> {
 }
 
 /**
- * Case definition for if-else nodes
+ * Case definition for if-else nodes — THE one declaration of a case's skeleton.
+ *
+ * `case_id` is the SOLE identifier — it is the branch handle `node.tsx` renders,
+ * what an edge stores as `sourceHandle`, what the engine returns as
+ * `outputHandle`, and what `resolveConnectionSpec` resolves a `branch` to. There
+ * used to be a second, node-local `id` beside it; it addressed nothing, nothing
+ * validated it, and 47 of 53 stored cases parked the readable name in it while
+ * the actual address read `true` (plan 28 §1.1/§1.3).
+ *
+ * Generic over the CONDITION element because the three layers genuinely disagree
+ * about that, and only that: the engine
+ * (`nodes/condition-nodes/if-else-types.ts`) requires `variableId` /
+ * `comparison_operator`, and the builder
+ * (`apps/web/.../core/if-else/types.ts`) narrows a condition's `value` to a
+ * Tiptap doc and its `varType` to `BaseType`. `case_id` and `logical_operator`
+ * are identical in all three, so they are declared HERE and nowhere else — the
+ * retired `id` lived in that shared half and had to be deleted from three files
+ * at once, which is the mistake this shape prevents recurring.
  */
-export interface NodeCase {
-  id: string
+export interface NodeCaseOf<TCondition> {
   case_id: string
   logical_operator: 'and' | 'or'
-  conditions: IfElseCondition[]
+  conditions: TCondition[]
 }
+
+/** A case as the CATALOG types it — the persisted/authored contract. */
+export type NodeCase = NodeCaseOf<IfElseCondition>
 
 /**
  * Node data for if-else nodes (flattened structure)
@@ -76,7 +94,6 @@ const conditionSchema = z.object({
  * Zod schema for if-else case
  */
 const caseSchema = z.object({
-  id: z.string(),
   case_id: z.string(),
   logical_operator: z.enum(['and', 'or']),
   conditions: z.array(conditionSchema),
@@ -322,7 +339,6 @@ export const ifElseManifest: NodeManifest<IfElseNodeData> = {
     desc: 'Branch based on conditions',
     cases: [
       {
-        id: generateId(),
         case_id: 'true',
         logical_operator: 'and',
         conditions: [],
@@ -345,12 +361,23 @@ export const ifElseManifest: NodeManifest<IfElseNodeData> = {
      * `calculateTargetBranches` (workflow-initializer.ts), which stays the
      * derived-state writer until the remaining branch-deriving types
      * (text-classifier, http, crud) migrate and both converge here.
+     *
+     * Every case branch is marked `positionalName`: `branchNameCorrect` derives
+     * `IF`/`CASE n` from ARRAY POSITION, so inserting a case renames every
+     * label after it and an address written against one of those labels would
+     * silently re-point (plan 28 §3.3). The reserved ELSE is exempt — its label
+     * is a function of the `false` id, not of where it sits — so `branch:
+     * "ELSE"` stays a legal address.
      */
     branches: (config): NodeBranch[] =>
       branchNameCorrect([
         ...(config.cases || []).map((c) => ({ id: c.case_id, name: '' })),
         { id: 'false', name: '' },
-      ]).map((b) => ({ ...b, kind: 'default' as const })),
+      ]).map((b) => ({
+        ...b,
+        kind: 'default' as const,
+        ...(b.id === 'false' ? {} : { positionalName: true }),
+      })),
   },
   agent: {
     authorable: true,
@@ -358,8 +385,11 @@ export const ifElseManifest: NodeManifest<IfElseNodeData> = {
       'Each entry in `cases` is one branch, and `case_id` IS that branch\u2019s address: it is the ' +
       'edge handle, it is what you pass as `branch` to `connect_nodes`/`add_node`, and because ' +
       'YOU author it you already know it before the node exists \u2014 so you can create the node and ' +
-      'wire its branches in the same batch. Name each case for what it matches ' +
-      '(e.g. "carrier-fedex", "priority-high"), never "true"/"false". Every `case_id` must be ' +
+      'wire its branches in the same batch. A branch\u2019s NAME ("IF", "CASE 2") is a ' +
+      'positional display label recomputed from case order \u2014 NEVER address a branch by it: ' +
+      'it names a different case as soon as one is added or removed. Name each case for what ' +
+      'it matches (e.g. "carrier-fedex", "priority-high"); "true" is the default handle of the ' +
+      'first case and is fine to keep. Every `case_id` must be ' +
       'UNIQUE, and none may be "false": this node ALWAYS exposes a reserved "false" ELSE branch ' +
       'for "nothing matched", and a case claiming that id collapses into it, so a matched case ' +
       'and a fall-through leave on the same edge. Conditions inside a case join via ' +
@@ -372,7 +402,6 @@ export const ifElseManifest: NodeManifest<IfElseNodeData> = {
         config: {
           cases: [
             {
-              id: 'c1',
               case_id: 'carrier-fedex',
               logical_operator: 'and',
               conditions: [
@@ -385,7 +414,6 @@ export const ifElseManifest: NodeManifest<IfElseNodeData> = {
               ],
             },
             {
-              id: 'c2',
               case_id: 'carrier-ups',
               logical_operator: 'and',
               conditions: [
@@ -405,7 +433,6 @@ export const ifElseManifest: NodeManifest<IfElseNodeData> = {
         config: {
           cases: [
             {
-              id: 'c1',
               case_id: 'priority-high',
               logical_operator: 'and',
               conditions: [

--- a/packages/lib/src/workflow-engine/catalog/nodes/scheduled.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/scheduled.ts
@@ -258,7 +258,6 @@ export const scheduledTriggerManifest: NodeManifest<ScheduledTriggerNodeData> = 
     config: {
       triggerInterval: 'hours',
       timeBetweenTriggers: { hours: 1, isConstant: true },
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     },
     isEnabled: true,
   }),

--- a/packages/lib/src/workflow-engine/catalog/nodes/text-classifier.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/text-classifier.ts
@@ -1,6 +1,5 @@
 // packages/lib/src/workflow-engine/catalog/nodes/text-classifier.ts
 
-import { generateId } from '@auxx/utils/generateId'
 import { z } from 'zod'
 import { AI_NODE_CONSTANTS } from '../../constants'
 import { BaseType } from '../../core/types'
@@ -329,7 +328,7 @@ export const textClassifierManifest: NodeManifest<TextClassifierNodeData> = {
     text: '',
     categories: [
       {
-        id: generateId(),
+        id: 'category-1',
         name: 'Category 1',
         description: '',
         text: '',

--- a/packages/lib/src/workflow-engine/catalog/nodes/var-assign.ts
+++ b/packages/lib/src/workflow-engine/catalog/nodes/var-assign.ts
@@ -1,6 +1,5 @@
 // packages/lib/src/workflow-engine/catalog/nodes/var-assign.ts
 
-import { generateId } from '@auxx/utils/generateId'
 import { z } from 'zod'
 import { BaseType } from '../../core/types'
 import type { UnifiedVariable } from '../../types/unified-variable'
@@ -219,7 +218,7 @@ export const varAssignManifest: NodeManifest<VarAssignNodeData> = {
   defaultData: () => ({
     title: 'Assign Variable',
     desc: 'Create custom variables for use in subsequent nodes',
-    variables: [{ id: generateId(), name: '', type: BaseType.STRING, value: '' }],
+    variables: [{ id: 'variable-1', name: '', type: BaseType.STRING, value: '' }],
     ignoreTypeError: false,
   }),
   configSchema: varAssignNodeDataSchema as unknown as z.ZodType<VarAssignNodeData>,

--- a/packages/lib/src/workflow-engine/catalog/types.ts
+++ b/packages/lib/src/workflow-engine/catalog/types.ts
@@ -76,6 +76,21 @@ export interface NodeBranch {
   id: string
   name: string
   kind: 'default' | 'fail'
+  /**
+   * This branch's `name` is a DISPLAY LABEL derived from its position in the
+   * branch array, so it is not an address: it renames itself the moment a
+   * sibling is added or removed, and the label a caller just read now belongs
+   * to a different branch.
+   *
+   * `resolveConnectionSpec` refuses to match `branch` against such a name and
+   * says why, instead of resolving `"CASE 2"` to whatever is second at that
+   * instant (plan 28 §3.3). Set it wherever the label is a function of order —
+   * `if-else`'s `IF`/`CASE n`, whose numbering `branchNameCorrect` recomputes on
+   * every read — and NOT where the name is stable: `text-classifier`'s
+   * categories are the user's own names, and `Fail`/`Approved`/`ELSE` are fixed
+   * per handle id.
+   */
+  positionalName?: boolean
 }
 
 /**

--- a/packages/lib/src/workflow-engine/client.ts
+++ b/packages/lib/src/workflow-engine/client.ts
@@ -331,6 +331,7 @@ export {
   ifElseManifest,
   ifElseNodeDataSchema,
   type NodeCase,
+  type NodeCaseOf,
   type NodeCondition,
   validateIfElseConfig,
 } from './catalog/nodes/if-else'

--- a/packages/lib/src/workflow-engine/nodes/condition-nodes/if-else-types.ts
+++ b/packages/lib/src/workflow-engine/nodes/condition-nodes/if-else-types.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/workflow-engine/nodes/condition-nodes/if-else-types.ts
 
 import type { Operator } from '../../../conditions/operator-definitions'
+import type { NodeCaseOf } from '../../catalog/nodes/if-else'
 import type { LogicalOperator } from '../../constants/nodes/if-else'
 /**
  * Types for if-else node condition evaluation
@@ -29,14 +30,14 @@ export interface NodeCondition {
 }
 
 /**
- * Case definition containing multiple conditions
+ * Case definition containing multiple conditions.
+ *
+ * The skeleton (`case_id`, `logical_operator`) is declared ONCE, in the catalog
+ * — `case_id` is the sole identifier and IS the branch handle (plan 28 §3.1).
+ * Only the condition element is local, because the engine requires `variableId`
+ * and `comparison_operator` where the authored contract leaves them optional.
  */
-export interface NodeCase {
-  id: string
-  case_id: string
-  logical_operator: LogicalOperator
-  conditions: NodeCondition[]
-}
+export type NodeCase = NodeCaseOf<NodeCondition>
 
 /**
  * If-else node configuration

--- a/packages/lib/src/workflow-engine/nodes/condition-nodes/if-else.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/condition-nodes/if-else.test.ts
@@ -52,7 +52,6 @@ describe('IfElseProcessor', () => {
       const result = await run(
         nodeWithCases([
           {
-            id: 'c1',
             case_id: 'true',
             logical_operator: 'and',
             conditions: [
@@ -79,7 +78,6 @@ describe('IfElseProcessor', () => {
       const result = await run(
         nodeWithCases([
           {
-            id: 'c1',
             case_id: 'true',
             logical_operator: 'and',
             conditions: [
@@ -106,7 +104,6 @@ describe('IfElseProcessor', () => {
       const result = await run(
         nodeWithCases([
           {
-            id: 'c1',
             case_id: 'case-high-value',
             logical_operator: 'and',
             conditions: [
@@ -132,7 +129,6 @@ describe('IfElseProcessor', () => {
       const result = await run(
         nodeWithCases([
           {
-            id: 'c1',
             case_id: 'true',
             logical_operator: 'and',
             conditions: [
@@ -159,7 +155,6 @@ describe('IfElseProcessor', () => {
       const result = await run(
         nodeWithCases([
           {
-            id: 'c1',
             case_id: 'true',
             logical_operator: 'and',
             conditions: [
@@ -183,7 +178,6 @@ describe('IfElseProcessor', () => {
       const result = await run(
         nodeWithCases([
           {
-            id: 'c1',
             case_id: 'true',
             logical_operator: 'and',
             conditions: [
@@ -208,7 +202,6 @@ describe('IfElseProcessor', () => {
       const result = await run(
         nodeWithCases([
           {
-            id: 'c1',
             case_id: 'true',
             logical_operator: 'and',
             conditions: [
@@ -237,7 +230,6 @@ describe('IfElseProcessor', () => {
     const orderGate = () =>
       nodeWithCases([
         {
-          id: 'c1',
           case_id: 'true',
           logical_operator: 'and',
           conditions: [
@@ -252,7 +244,6 @@ describe('IfElseProcessor', () => {
           ],
         },
         {
-          id: 'c2',
           case_id: 'case_email_mismatch',
           logical_operator: 'and',
           conditions: [{ id: 'c', variableId: 'order.name', comparison_operator: 'not empty' }],
@@ -290,11 +281,60 @@ describe('IfElseProcessor', () => {
     })
   })
 
+  describe('output handle — the only two states this node has (plan 28 §3.6)', () => {
+    /**
+     * `buildExecutionResult` used to end in `conditionResult ? 'true' : 'false'`,
+     * which read as though a boolean mode still existed. It does not: a match
+     * always carries a `case_id`, and no-match always arrives with
+     * `conditionResult: false`, so the `'true'` arm was unreachable. Pinned so
+     * nobody restores it — and so the ELSE handle stays literally `'false'`,
+     * which is what the manifest appends and what edges store.
+     */
+    const gate = (caseId: string) =>
+      nodeWithCases([
+        {
+          case_id: caseId,
+          logical_operator: 'and',
+          conditions: [{ id: 'a', variableId: 'order.name', comparison_operator: 'not empty' }],
+        },
+      ])
+
+    it("emits the reserved 'false' handle when nothing matched", async () => {
+      // No `order.name` set — the sole case fails.
+      const result = await run(gate('case-order-found'))
+      expect(result.outputHandle).toBe('false')
+      expect(result.output?.matched).toBe(false)
+      expect(result.output?.matchedCase).toBeNull()
+      expect(await contextManager.getNodeVariable('gate-1', 'matched_condition')).toBe('false')
+      expect(await contextManager.getNodeVariable('gate-1', 'branch_taken')).toBe('false')
+      expect(await contextManager.getNodeVariable('gate-1', 'condition_index')).toBe(-1)
+    })
+
+    it('emits the matched case_id, opaque or not', async () => {
+      contextManager.setVariable('order.name', '#1012')
+      const result = await run(gate('case-order-found'))
+      expect(result.outputHandle).toBe('case-order-found')
+      expect(await contextManager.getNodeVariable('gate-1', 'matched_condition')).toBe(
+        'case-order-found'
+      )
+      // `branch_taken` is NOT the handle — it reports whether a case matched,
+      // and stays boolean-shaped on purpose.
+      expect(await contextManager.getNodeVariable('gate-1', 'branch_taken')).toBe('true')
+      expect(await contextManager.getNodeVariable('gate-1', 'condition_index')).toBe(0)
+    })
+
+    it("emits 'true' only because that is the DEFAULT first case_id", async () => {
+      contextManager.setVariable('order.name', '#1012')
+      const result = await run(gate('true'))
+      expect(result.outputHandle).toBe('true')
+      expect(result.output?.matchedCase).toBe('true')
+    })
+  })
+
   describe('extractRequiredVariables', () => {
     it('declares variables referenced by the comparison value', async () => {
       const node = nodeWithCases([
         {
-          id: 'c1',
           case_id: 'true',
           logical_operator: 'and',
           conditions: [

--- a/packages/lib/src/workflow-engine/nodes/condition-nodes/if-else.ts
+++ b/packages/lib/src/workflow-engine/nodes/condition-nodes/if-else.ts
@@ -161,25 +161,22 @@ export class IfElseProcessor extends BaseNodeProcessor {
     contextManager: ExecutionContextManager,
     evaluatedCases: EvaluatedCase[]
   ): Partial<NodeExecutionResult> {
+    // `matchedCaseId ?? 'false'`, NOT a `conditionResult ? 'true' : 'false'`
+    // fallback. That ternary's `'true'` arm was unreachable and read as though
+    // this node still had a boolean mode: `executeNode` calls this exactly
+    // twice — with the matched case's `case_id` and `true`, or with `null` and
+    // `false` — so "no matched case" and "nothing matched" are the same state,
+    // and the handle for it is the reserved ELSE. `'true'` survives only as the
+    // DEFAULT first `case_id` a new node ships with, which arrives here as a
+    // `matchedCaseId` like any other (plan 28 §3.6).
+    const outputHandle = matchedCaseId ?? 'false'
+
     // Store output variables to match frontend schema
-    contextManager.setNodeVariable(
-      node.nodeId,
-      'matched_condition',
-      matchedCaseId || (conditionResult ? 'true' : 'false')
-    )
+    contextManager.setNodeVariable(node.nodeId, 'matched_condition', outputHandle)
     contextManager.setNodeVariable(node.nodeId, 'condition_index', matchedCaseIndex)
+    // Live, and deliberately still a boolean-shaped string: this reports
+    // WHETHER a case matched, not which handle it left on.
     contextManager.setNodeVariable(node.nodeId, 'branch_taken', conditionResult ? 'true' : 'false')
-
-    // Determine output handle based on result
-    let outputHandle: string
-
-    if (matchedCaseId) {
-      // For structured cases, use the case ID as the output handle
-      outputHandle = matchedCaseId
-    } else {
-      // For simple conditions, use 'true' or 'false'
-      outputHandle = conditionResult ? 'true' : 'false'
-    }
 
     contextManager.log('DEBUG', node.name, `If-else result: outputHandle=${outputHandle}`, {
       matchedCaseId,

--- a/packages/lib/src/workflow-engine/nodes/condition-nodes/operator-parity.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/condition-nodes/operator-parity.test.ts
@@ -251,7 +251,6 @@ async function evaluateOne(operator: string, fixture: Fixture): Promise<boolean>
 
   const cases: NodeCase[] = [
     {
-      id: 'c1',
       case_id: 'true',
       logical_operator: 'and',
       conditions: [

--- a/packages/lib/src/workflows/graph-edit/__tests__/branch-authoring.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/branch-authoring.test.ts
@@ -65,6 +65,7 @@ const TRIGGER_ID = 'scheduled-aaaaaaaaaaaaaaaaaaaaa'
 const CARRIER_ID = 'wait-aaaaaaaaaaaaaaaaaaaaaaa'
 const IFELSE_ID = 'ifelse-aaaaaaaaaaaaaaaaaaaaa'
 const HUMAN_ID = 'human-aaaaaaaaaaaaaaaaaaaaaa'
+const CLASSIFY_ID = 'classify-aaaaaaaaaaaaaaaaa'
 
 /** The core registry alone — no app installed in these fixtures. */
 const coreLookup = getManifest
@@ -367,18 +368,8 @@ describe('T2 — the address is knowable before the node exists', () => {
     expect(edgeToIt?.sourceHandle).toBe('carrier-fedex')
   })
 
-  it('a near-miss branch ref gets a "did you mean" over both names and ids', () => {
+  it('a near-miss branch ref gets a "did you mean" over ids and stable names', () => {
     const nodes = [ifElseNode([carrierCase('true', 'x'), carrierCase('carrier-ups', 'ups')])]
-    const byName = resolveConnectionSpec(
-      nodes,
-      { after: 'Check Carrier', branch: 'CASE1' },
-      coreLookup
-    )
-    // Nearest first — "CASE 1" is one edit away, "CASE 2" two.
-    expect(byName._unsafeUnwrapErr().message).toContain(
-      'Did you mean "CASE 1" (true) or "CASE 2" (carrier-ups)?'
-    )
-
     const byId = resolveConnectionSpec(
       nodes,
       { after: 'Check Carrier', branch: 'carrier-up' },
@@ -401,6 +392,109 @@ describe('T2 — the address is knowable before the node exists', () => {
     expect(message).toContain('Available branches: "CASE 1" (true), "CASE 2" (carrier-ups)')
     expect(message).toContain('"ELSE" (false)')
     expect(message).toContain('Address a branch by its id')
+  })
+})
+
+describe('E1 — a positional label is not an address (plan 28 §3.3)', () => {
+  /** Two categories the USER named — semantic, stable, and therefore addressable. */
+  function classifierNode(): GraphNode {
+    return {
+      id: CLASSIFY_ID,
+      type: 'standard',
+      position: { x: 700, y: 400 },
+      width: 244,
+      height: 100,
+      data: {
+        id: CLASSIFY_ID,
+        type: 'text-classifier',
+        title: 'Triage',
+        text: '{{Carrier.value}}',
+        outputMode: 'branches',
+        categories: [
+          { id: 'cat-billing', name: 'Billing', description: '' },
+          { id: 'cat-shipping', name: 'Shipping', description: '' },
+        ],
+      },
+    }
+  }
+
+  const ifElse = () => [
+    ifElseNode([carrierCase('carrier-fedex', 'fedex'), carrierCase('carrier-ups', 'ups')]),
+  ]
+
+  it('refuses an if-else branch addressed by its positional name, naming the id', () => {
+    // "CASE 2" is `branchNameCorrect`'s output for whatever sits second RIGHT
+    // NOW. Resolving it wired an edge that silently re-pointed the next time a
+    // case was inserted, and the rejection has to say that — a flat "no such
+    // branch" gets retried verbatim (plan 21 §9.2/§10.5).
+    const message = resolveConnectionSpec(
+      ifElse(),
+      { after: 'Check Carrier', branch: 'CASE 2' },
+      coreLookup
+    )._unsafeUnwrapErr().message
+    expect(message).toContain('"CASE 2" is a display label')
+    expect(message).toContain('numbers its branches by position')
+    expect(message).toContain('is currently "carrier-ups"')
+  })
+
+  it('diagnoses a near-miss of a positional label the same way', () => {
+    const message = resolveConnectionSpec(
+      ifElse(),
+      { after: 'Check Carrier', branch: 'CASE2' },
+      coreLookup
+    )._unsafeUnwrapErr().message
+    expect(message).toContain('display label')
+    expect(message).toContain('is currently "carrier-ups"')
+  })
+
+  it('keeps the "did you mean" for a near-miss on the ID', () => {
+    // The candidate set drops positional NAMES — suggesting "CASE 1" would hand
+    // back the one string that cannot be used — but ids are still matched, and
+    // every candidate is still rendered label-and-id so the transcript reads.
+    const message = resolveConnectionSpec(
+      ifElse(),
+      { after: 'Check Carrier', branch: 'carrier-fede' },
+      coreLookup
+    )._unsafeUnwrapErr().message
+    expect(message).toContain('Did you mean "CASE 1" (carrier-fedex)')
+    expect(message).toContain('Address a branch by its id')
+  })
+
+  it('still resolves the case id, and the ELSE label that is NOT positional', () => {
+    expect(
+      resolveConnectionSpec(
+        ifElse(),
+        { after: 'Check Carrier', branch: 'carrier-ups' },
+        coreLookup
+      )._unsafeUnwrap()
+    ).toEqual({ sourceNodeId: IFELSE_ID, sourceHandle: 'carrier-ups' })
+    // ELSE is a function of the reserved `false` id, not of position.
+    expect(
+      resolveConnectionSpec(
+        ifElse(),
+        { after: 'Check Carrier', branch: 'ELSE' },
+        coreLookup
+      )._unsafeUnwrap()
+    ).toEqual({ sourceNodeId: IFELSE_ID, sourceHandle: 'false' })
+  })
+
+  it('keeps NAME matching for a text-classifier — its labels are the user’s own', () => {
+    // The difference the flag encodes: a category name is authored, semantic
+    // and stable, so addressing a classifier branch by name is correct.
+    expect(
+      resolveConnectionSpec(
+        [classifierNode()],
+        { after: 'Triage', branch: 'Shipping' },
+        coreLookup
+      )._unsafeUnwrap()
+    ).toEqual({ sourceNodeId: CLASSIFY_ID, sourceHandle: 'cat-shipping' })
+    expect(
+      resolveConnectionSpec(
+        [classifierNode()],
+        { after: 'Triage', branch: 'cat-billing' },
+        coreLookup
+      )._unsafeUnwrap()
+    ).toEqual({ sourceNodeId: CLASSIFY_ID, sourceHandle: 'cat-billing' })
   })
 })
 

--- a/packages/lib/src/workflows/graph-edit/__tests__/normalize.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/normalize.test.ts
@@ -248,7 +248,10 @@ describe('resolveConnectionSpec', () => {
     })
   })
 
-  it('resolves a branch by display name through manifest.connection.branches', () => {
+  it('resolves a STABLE display name through manifest.connection.branches', () => {
+    // `ELSE` is derived from the reserved `false` id, not from position, so it
+    // stays a legal address. `IF`/`CASE n` do not — see the positional suite in
+    // `branch-authoring.test.ts`.
     expect(
       resolveConnectionSpec(
         nodes,
@@ -257,7 +260,11 @@ describe('resolveConnectionSpec', () => {
       )._unsafeUnwrap()
     ).toEqual({ sourceNodeId: 'if1aaaaaaaaaaaaaaaaaaa', sourceHandle: 'false' })
     expect(
-      resolveConnectionSpec(nodes, { after: 'Route It', branch: 'IF' }, coreLookup)._unsafeUnwrap()
+      resolveConnectionSpec(
+        nodes,
+        { after: 'Route It', branch: 'case-a' },
+        coreLookup
+      )._unsafeUnwrap()
     ).toEqual({ sourceNodeId: 'if1aaaaaaaaaaaaaaaaaaa', sourceHandle: 'case-a' })
   })
 

--- a/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
+++ b/packages/lib/src/workflows/graph-edit/__tests__/ops.test.ts
@@ -139,7 +139,7 @@ function ifElseNode(): GraphNode {
       id: IFELSE_ID,
       type: 'if-else',
       title: 'Check Priority',
-      cases: [{ id: 'c1', case_id: 'true', logical_operator: 'and', conditions: [] }],
+      cases: [{ case_id: 'true', logical_operator: 'and', conditions: [] }],
     },
   }
 }
@@ -244,14 +244,14 @@ describe('addNode — branch wiring (§6)', () => {
     edges: [edge(TRIGGER_ID, 'source', IFELSE_ID)],
   })
 
-  it('resolves a branch NAME to the case handle id from manifest.connection.branches', async () => {
+  it('resolves a branch by its case handle id from manifest.connection.branches', async () => {
     const result = await addNode(makeDb(base()), {
       workflowAppId: APP,
       organizationId: ORG,
       type: 'wait',
       title: 'Then Wait',
       after: 'Check Priority',
-      branch: 'IF',
+      branch: 'true', // the case's id — the ONLY address (plan 28 §3.3)
     })
     expect(result.isOk()).toBe(true)
     expect(result._unsafeUnwrap().applied).toBe(true)
@@ -261,7 +261,24 @@ describe('addNode — branch wiring (§6)', () => {
     expect(added).toBeDefined()
     const wired = graph.edges.find((e) => e.target === added?.id)
     expect(wired?.source).toBe(IFELSE_ID)
-    expect(wired?.sourceHandle).toBe('true') // the case's id, never the display name
+    expect(wired?.sourceHandle).toBe('true')
+  })
+
+  it("refuses the positional display name 'IF', naming the id that wears it", async () => {
+    // Used to resolve to whatever case was first at that instant. An if-else
+    // label is a function of array position, so inserting a case silently
+    // re-pointed the edge (plan 28 §3.3).
+    const result = await addNode(makeDb(base()), {
+      workflowAppId: APP,
+      organizationId: ORG,
+      type: 'wait',
+      title: 'Then Wait',
+      after: 'Check Priority',
+      branch: 'IF',
+    })
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('is currently "true"')
+    expect(serviceUpdate).not.toHaveBeenCalled()
   })
 
   it("wires the ELSE branch on the reserved 'false' handle", async () => {
@@ -495,7 +512,7 @@ describe('structural vs config blocking split (§5)', () => {
       workflowAppId: APP,
       organizationId: ORG,
       from: 'Check Priority',
-      branch: 'IF',
+      branch: 'true', // the case id — the positional label is not an address
       to: 'Every Morning',
     })
     expect(result.isOk()).toBe(true)
@@ -617,7 +634,7 @@ describe('replaceGraph', () => {
           type: 'if-else',
           title: 'Route',
           config: {
-            cases: [{ id: 'c1', case_id: 'true', logical_operator: 'and', conditions: [] }],
+            cases: [{ case_id: 'true', logical_operator: 'and', conditions: [] }],
           },
         },
         { type: 'wait', title: 'On Match' },
@@ -625,7 +642,7 @@ describe('replaceGraph', () => {
       ],
       edges: [
         { from: 'Daily', to: 'Route' },
-        { from: 'Route', to: 'On Match', branch: 'IF' },
+        { from: 'Route', to: 'On Match', branch: 'true' },
         { from: 'Route', to: 'Otherwise', branch: 'ELSE' },
       ],
     })
@@ -779,7 +796,7 @@ describe('updateNode / disconnectNodes', () => {
     expect(result.isOk()).toBe(true)
     const persisted = persistedGraph().nodes.find((node) => node.id === IFELSE_ID)
     expect(persisted?.data?.cases).toEqual([
-      { id: 'c1', case_id: 'true', logical_operator: 'or', conditions: [] },
+      { case_id: 'true', logical_operator: 'or', conditions: [] },
     ])
     expect(result._unsafeUnwrap().node?.configHash).not.toBe(configHash)
   })

--- a/packages/lib/src/workflows/graph-edit/normalize/connection.ts
+++ b/packages/lib/src/workflows/graph-edit/normalize/connection.ts
@@ -42,18 +42,49 @@ function describeBranch(branch: NodeBranch): string {
  * Worth the few lines because a flat rejection is retried verbatim: the logged
  * turn re-issued `branch: "IF"` unchanged after re-reading the whole workflow,
  * because nothing in the rejection pointed at the branch that had taken `IF`'s
- * place (plan 21 §9.2/§10.5). Names AND ids are candidates, since either is a
- * legal address.
+ * place (plan 21 §9.2/§10.5).
+ *
+ * Ids are always candidates; a name is one only if it is an address. A
+ * `positionalName` branch is offered by id alone — suggesting its label would
+ * hand back the very string that cannot be used, and acting on the suggestion
+ * re-introduces the position bug (plan 28 §3.3). Those get {@link
+ * positionalLabelHit} instead, which explains itself.
  */
 function nearestBranches(branchRef: string, branches: NodeBranch[]): NodeBranch[] {
-  const candidates = branches.flatMap((b) => (b.name ? [b.name, b.id] : [b.id]))
+  const candidates = branches.flatMap((b) =>
+    b.name && !b.positionalName ? [b.name, b.id] : [b.id]
+  )
   const near = closestMatches(branchRef, candidates)
   const matched: NodeBranch[] = []
   for (const candidate of near) {
-    const branch = branches.find((b) => b.name === candidate || b.id === candidate)
+    const branch = branches.find(
+      (b) => (b.name === candidate && !b.positionalName) || b.id === candidate
+    )
     if (branch && !matched.includes(branch)) matched.push(branch)
   }
   return matched
+}
+
+/**
+ * The branch whose POSITIONAL label the caller just tried to address, if any.
+ *
+ * Exact match first, then the same edit-distance tolerance the "did you mean"
+ * uses, so `"CASE2"` is diagnosed as the positional attempt it is rather than
+ * falling through to a generic candidate list. What comes back is the branch
+ * currently WEARING that label — the answer to "which one did I mean?" at this
+ * instant, and the id that must be used in its place.
+ */
+function positionalLabelHit(branchRef: string, branches: NodeBranch[]): NodeBranch | undefined {
+  const positional = branches.filter((b) => b.positionalName && b.name)
+  if (positional.length === 0) return undefined
+  const needle = branchRef.toLowerCase()
+  const exact = positional.find((b) => b.name.toLowerCase() === needle)
+  if (exact) return exact
+  const [nearest] = closestMatches(
+    branchRef,
+    positional.map((b) => b.name)
+  )
+  return nearest ? positional.find((b) => b.name === nearest) : undefined
 }
 
 /**
@@ -65,7 +96,9 @@ function nearestBranches(branchRef: string, branches: NodeBranch[]): NodeBranch[
  *   nodes with several (if-else cases, classifier categories) are an error
  *   naming every branch — never a guess.
  * - Branch given: matched against `manifest.connection.branches(config)` by
- *   name then id; no match is an error naming the candidates.
+ *   name then id; no match is an error naming the candidates. A branch whose
+ *   name is a positional label (`positionalName`) is addressable by id ONLY,
+ *   and trying its label is its own error saying so.
  */
 export function resolveConnectionSpec(
   nodes: NodeMeta[],
@@ -108,10 +141,28 @@ export function resolveConnectionSpec(
   }
 
   const needle = branchRef.toLowerCase()
+  // Ids beat names on a tie, and a `positionalName` label is not tried at all:
+  // an if-else label is a function of array position, so `"CASE 2"` used to
+  // resolve to whatever was second at that instant and an inserted case
+  // silently re-pointed the edge (plan 28 §3.3).
   const match =
-    branches.find((b) => b.name.toLowerCase() === needle) ??
+    branches.find((b) => !b.positionalName && b.name.toLowerCase() === needle) ??
     branches.find((b) => b.id.toLowerCase() === needle)
   if (!match) {
+    const positional = positionalLabelHit(branchRef, branches)
+    if (positional) {
+      // Named, not merely listed: the logged turn re-issued a label verbatim
+      // because the rejection never said the label was the problem.
+      return err(
+        new BadRequestError(
+          `"${branchRef}" is a display label on node ${describeNode(source)}, not a branch ` +
+            'address. This node numbers its branches by position, so the label moves to a ' +
+            'different branch as soon as a case is added or removed. Address it by id: the ' +
+            `branch labelled "${positional.name}" is currently "${positional.id}". ` +
+            `Available branches: ${branches.map(describeBranch).join(', ')}.`
+        )
+      )
+    }
     const near = nearestBranches(branchRef, branches)
     return err(
       new BadRequestError(

--- a/packages/lib/src/workflows/templates/fulfillment-follow-up.template.json
+++ b/packages/lib/src/workflows/templates/fulfillment-follow-up.template.json
@@ -132,7 +132,6 @@
           "desc": "Check if the order has been fulfilled/shipped",
           "cases": [
             {
-              "id": "case_fulfilled",
               "case_id": "true",
               "logical_operator": "and",
               "conditions": [

--- a/packages/lib/src/workflows/templates/kb-auto-responder.template.json
+++ b/packages/lib/src/workflows/templates/kb-auto-responder.template.json
@@ -101,7 +101,6 @@
           "desc": "Check if the knowledge base returned relevant results",
           "cases": [
             {
-              "id": "case_found",
               "case_id": "true",
               "logical_operator": "and",
               "conditions": [

--- a/packages/lib/src/workflows/templates/order-issue-triage.template.json
+++ b/packages/lib/src/workflows/templates/order-issue-triage.template.json
@@ -355,7 +355,6 @@
           "desc": "Check if a matching contact was found",
           "cases": [
             {
-              "id": "case-contact-found",
               "case_id": "case-contact-found",
               "logical_operator": "and",
               "conditions": [
@@ -519,7 +518,6 @@
           "desc": "Check if a matching order record was found",
           "cases": [
             {
-              "id": "case-order-found",
               "case_id": "case-order-found",
               "logical_operator": "and",
               "conditions": [
@@ -878,7 +876,6 @@
           "desc": "Check if order value exceeds the escalation threshold",
           "cases": [
             {
-              "id": "case-high-value",
               "case_id": "case-high-value",
               "logical_operator": "and",
               "conditions": [

--- a/packages/lib/src/workflows/templates/return-request-processor.template.json
+++ b/packages/lib/src/workflows/templates/return-request-processor.template.json
@@ -113,7 +113,6 @@
           "desc": "Check if an order number was found in the email",
           "cases": [
             {
-              "id": "case_has_order",
               "case_id": "true",
               "logical_operator": "and",
               "conditions": [
@@ -228,7 +227,6 @@
           "desc": "Check if the order meets return policy requirements",
           "cases": [
             {
-              "id": "case_eligible",
               "case_id": "true",
               "logical_operator": "and",
               "conditions": [

--- a/packages/lib/src/workflows/templates/shopify-order-lookup.template.json
+++ b/packages/lib/src/workflows/templates/shopify-order-lookup.template.json
@@ -106,7 +106,6 @@
           "desc": "Check if an order number was found in the email",
           "cases": [
             {
-              "id": "case_has_order",
               "case_id": "true",
               "logical_operator": "and",
               "conditions": [
@@ -194,7 +193,6 @@
           "desc": "The extracted number may not match a real order — and an order that does exist may belong to someone else. Only take the reply path when the order exists AND was placed from the address that emailed us. The order email is normalized upstream because this comparison is case-sensitive; the sender address is already lowercased at ingest.",
           "cases": [
             {
-              "id": "case_order_found",
               "case_id": "true",
               "logical_operator": "and",
               "conditions": [
@@ -215,7 +213,6 @@
               ]
             },
             {
-              "id": "case_email_mismatch",
               "case_id": "case_email_mismatch",
               "logical_operator": "and",
               "conditions": [
@@ -577,7 +574,6 @@
           "desc": "Only send if the AI decided a reply is warranted",
           "cases": [
             {
-              "id": "case_reply_order",
               "case_id": "true",
               "logical_operator": "and",
               "conditions": [
@@ -872,7 +868,6 @@
           "desc": "Only send if the AI decided a reply is warranted",
           "cases": [
             {
-              "id": "case_reply_mismatch",
               "case_id": "true",
               "logical_operator": "and",
               "conditions": [
@@ -1153,7 +1148,6 @@
           "desc": "Only send if the AI decided a reply is warranted",
           "cases": [
             {
-              "id": "case_reply_not_found",
               "case_id": "true",
               "logical_operator": "and",
               "conditions": [
@@ -1424,7 +1418,6 @@
           "desc": "Skip unrelated emails — only send when the AI marked respond true",
           "cases": [
             {
-              "id": "case_reply_no_order",
               "case_id": "true",
               "logical_operator": "and",
               "conditions": [

--- a/packages/lib/src/workflows/templates/sla-breach-escalation.template.json
+++ b/packages/lib/src/workflows/templates/sla-breach-escalation.template.json
@@ -153,7 +153,6 @@
           "desc": "Check if any open tickets were found",
           "cases": [
             {
-              "id": "case_found",
               "case_id": "true",
               "logical_operator": "and",
               "conditions": [

--- a/packages/lib/src/workflows/templates/webhook-order-notification.template.json
+++ b/packages/lib/src/workflows/templates/webhook-order-notification.template.json
@@ -129,7 +129,6 @@
           "desc": "Check if HTTP request was successful",
           "cases": [
             {
-              "id": "case_success",
               "case_id": "true",
               "logical_operator": "and",
               "conditions": [


### PR DESCRIPTION
## What

An if-else case carried **two identifiers and only one of them was an address**, the canvas derived that address from **array position**, and `defaultData()` was not a function of the node type. This closes all three, plus the `defaultData()` determinism item left open by #1774.

## The address

`case_id` IS the branch handle — `node.tsx`'s `handleId`, the edge's `sourceHandle`, `WorkflowGraphBuilder`'s handle-table key, the processor's `outputHandle`, and what `resolveConnectionSpec` resolves `branch` to. The sibling `id` addressed nothing and was read by two node-local sites. It is deleted from the type, the schema, the 12 bundled templates, and stored graphs (migration `095`).

The evidence for why it had to go rather than rot in place: `NON_CONFIG_KEYS` is what normally retires a key without a migration, and it is **top-level only** — so `cases[].id` reached the agent-facing config on every `get_node`, showing a model the readable name in the field that routes nothing.

## The corruption this fixes

The canvas has no `case_id` editor. `addGroupEnhanced` created a group with no id, so the adapter fell through to `` `case_${index}` ``:

| step | `case_id`s |
|---|---|
| new node | `true` |
| Add Case | `true`, `case_1` |
| Add Case | `true`, `case_1`, `case_2` |
| delete `case_1` | `true`, `case_2` |
| Add Case | `true`, `case_2`, **`case_2`** |

Two cases on one handle — a state `validateIfElseConfig` refuses with `blocksAuthoring`, reachable in five clicks, in a field with no editor. Already visible in stored data: one node carries `case_1`/`case_2`/`case_3`, another has a case on the reserved `false` ELSE handle.

`_targetBranches` had the same root cause and was advertising an **empty-string branch id** for a freshly added case.

## Labels

Unchanged — `IF`/`ELIF`/`ELSE` and `CASE n` are the standard vocabulary. But they are positional, so they stop being addressable: `NodeBranch.positionalName`, set on **case branches only** (ELSE's label derives from `id === 'false'`, not position, so `branch: 'ELSE'` stays legal). text-classifier keeps name matching — its names are the user's own category names.

## `defaultData()`

Five manifests were impure in two different ways. Four minted a `generateId()`; `scheduled` read the ambient `Intl` zone. The second kind returns the same string twice in one process, so a naive `defaultData() === defaultData()` test **passes it** while the value silently differs between the browser and a UTC worker. The new test varies the ambient zone, which is the only way it has teeth against that.

`scheduled`'s `timezone` is dropped: `scheduleWorkflowTriggers` never passes BullMQ a `tz`, so nothing on the server reads it, and stamping it recorded the timezone of whatever process built the node as though the user had picked it. The picker keeps its browser-zone fallback.

## Also

`NodeCase` was declared three times — catalog, engine, web — and all three carried the retired `id`. The skeleton is now one generic, `NodeCaseOf<TCondition>`; only the condition element stays per-layer, which is the one thing the three genuinely disagree about.

An unreachable ternary arm in the if-else processor is gone, along with the contract-drift allowlist entry that existed to excuse it.

## Verification

- `packages/lib` workflow suites — 1983 passed
- `apps/web` workflow + conditions — 288 passed
- `packages/lib` `tsc --noEmit` — zero errors under `src/`
- Migration hand-checked twice: a node round-tripped through the panel, and a node the migration touched but nobody opened. Every edge stayed on its original handle in both; second run rewrites 0 rows.

## Note for the reviewer

Migration `095` is already marked `applied` in the **dev** ledger (it ran mid-implementation), so it will be skipped there. Delete that row if you want the shipped code exercised in dev.
