### PR TITLE
feat(connectors): recommend app sources from published, verified apps

### DIFF
--- a/apps/web/src/components/apps/ui/app-install-button.tsx
+++ b/apps/web/src/components/apps/ui/app-install-button.tsx
@@ -3,7 +3,7 @@
 'use client'
 
 import { Badge } from '@auxx/ui/components/badge'
-import { Button } from '@auxx/ui/components/button'
+import { Button, type ButtonProps } from '@auxx/ui/components/button'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from '@auxx/ui/components/dropdown-menu'
 import { toastError } from '@auxx/ui/components/toast'
+import { cn } from '@auxx/ui/lib/utils'
 import { format } from 'date-fns'
 import { Check, ChevronDown, Code, Download } from 'lucide-react'
 import { useRouter } from 'next/navigation'
@@ -218,7 +219,13 @@ type InlineAppInstallButtonProps = {
    * state (e.g. Kopilot's install card moving on to Connect) without polling.
    */
   onInstalled?: () => void
-}
+  /**
+   * Everything else lands on the `Button`. A dialog footer needs to override the
+   * compact inline sizing and to carry `data-dialog-submit` (what `Dialog` keys
+   * Enter-to-submit off), neither of which this component can decide for itself.
+   * `onClick`/`loading` stay owned here — they ARE the install.
+   */
+} & Omit<ButtonProps, 'onClick' | 'loading' | 'loadingText' | 'children'>
 
 /**
  * Lightweight install button that self-determines install status.
@@ -228,6 +235,10 @@ export function InlineAppInstallButton({
   appSlug,
   children,
   onInstalled,
+  variant = 'outline',
+  size = 'sm',
+  className,
+  ...buttonProps
 }: InlineAppInstallButtonProps) {
   const { appInstallations, refreshInstallations } = useAppsContext()
   const utils = api.useUtils()
@@ -262,9 +273,13 @@ export function InlineAppInstallButton({
   return (
     <>
       <Button
-        variant='outline'
-        size='sm'
-        className='h-6 text-xs'
+        variant={variant}
+        size={size}
+        // Compact by default (this button usually sits inline in a sentence or a
+        // card row); `className` is twMerge'd, so a footer caller passing `h-7`
+        // gets the standard `size='sm'` height back.
+        className={cn('h-6 text-xs', className)}
+        {...buttonProps}
         onClick={(e) => {
           e.stopPropagation()
           if (isDemo) {

--- a/apps/web/src/components/data-connectors/ui/source-template-dialog.tsx
+++ b/apps/web/src/components/data-connectors/ui/source-template-dialog.tsx
@@ -10,6 +10,7 @@ import { Plug } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
 import { AppIcon } from '~/components/apps/ui/app-icon'
+import { InlineAppInstallButton } from '~/components/apps/ui/app-install-button'
 import { type TemplateGalleryCategory, TemplateGalleryDialog } from '~/components/templates/ui'
 import { api } from '~/trpc/react'
 
@@ -18,7 +19,12 @@ interface SourceTemplateDialogProps {
   onOpenChange: (open: boolean) => void
 }
 
-/** A selectable source — the blank REST builtin, a first-party template, or an app connector. */
+/**
+ * A selectable source — the blank REST builtin, a first-party template, an
+ * installed app's connector, or a `recommended-app` connector from a published,
+ * verified app this org has NOT installed yet (v9). The last one is the only arm
+ * that cannot create on click: the app has to exist first.
+ */
 type SourceItem = {
   id: string
   name: string
@@ -30,6 +36,15 @@ type SourceItem = {
   | { kind: 'builtin'; type: 'generic-rest' }
   | { kind: 'template'; templateId: string; requiresConnection: boolean }
   | { kind: 'app'; type: string; requiresConnection: boolean; appIconId: string }
+  | {
+      kind: 'recommended-app'
+      type: string
+      requiresConnection: boolean
+      appIconId: string
+      appSlug: string
+      appTitle: string
+      developerTitle: string | null
+    }
 )
 
 /**
@@ -123,7 +138,28 @@ export function SourceTemplateDialog({ open, onOpenChange }: SourceTemplateDialo
       requiresConnection: a.requiresConnection,
       appIconId: a.appIconId,
     }))
-    return [...(builtinItem ? [builtinItem] : []), ...templateItems, ...appItems]
+    // Appended AFTER the installed connectors so what the org already has always
+    // sorts first inside the Apps category.
+    const recommendedItems: SourceItem[] = data.recommended.map((r) => ({
+      id: `recommended:${r.appSlug}:${r.connectorId}`,
+      name: r.label,
+      description: r.description,
+      categories: ['apps'],
+      iconKey: r.iconKey,
+      kind: 'recommended-app',
+      type: r.type,
+      requiresConnection: r.requiresConnection,
+      appIconId: r.appIconId,
+      appSlug: r.appSlug,
+      appTitle: r.appTitle,
+      developerTitle: r.developerTitle,
+    }))
+    return [
+      ...(builtinItem ? [builtinItem] : []),
+      ...templateItems,
+      ...appItems,
+      ...recommendedItems,
+    ]
   }, [catalog.data])
 
   const categories = useMemo<TemplateGalleryCategory[]>(() => {
@@ -139,14 +175,16 @@ export function SourceTemplateDialog({ open, onOpenChange }: SourceTemplateDialo
   }, [items])
 
   /**
-   * Templates/apps create one-click (`'handled'` keeps the shell on the list);
-   * Custom REST falls through so the shell opens its detail page to name the source.
+   * Templates/installed apps create one-click (`'handled'` keeps the shell on the
+   * list). Custom REST and recommended (uninstalled) apps fall through so the
+   * shell opens their detail page — to name the source, and to install the app.
    */
   function handleSelect(item: SourceItem): 'handled' | undefined {
     if (item.kind === 'builtin') {
       setName(item.name)
       return undefined
     }
+    if (item.kind === 'recommended-app') return undefined
     setBusyItemId(item.id)
     if (item.kind === 'template') {
       create.mutate({ name: item.name, type: 'generic-rest', templateId: item.templateId })
@@ -154,6 +192,27 @@ export function SourceTemplateDialog({ open, onOpenChange }: SourceTemplateDialo
       create.mutate({ name: item.name, type: item.type })
     }
     return 'handled'
+  }
+
+  /**
+   * The install landed — turn the recommendation into the source the user came
+   * for, then let `create.onSuccess` route to the connector page (where the setup
+   * stepper owns the Connect step).
+   *
+   * The catalog invalidation matters even though we navigate away: if the create
+   * fails, the row must come back as an INSTALLED app connector, not as a
+   * recommendation to install something already installed.
+   *
+   * Ordering is safe on the server — `apps.install` emits `app.installed`, which
+   * busts the `installedApps` org cache, before it returns. `dataConnector.create`
+   * reads that cache to seed the connector's streams from the app's catalog, and
+   * a stale read there fails SILENTLY (it falls through to a bare connector with
+   * no streams rather than erroring), so the ordering is load-bearing.
+   */
+  function continueAfterInstall(item: Extract<SourceItem, { kind: 'recommended-app' }>) {
+    setBusyItemId(item.id)
+    void utils.dataConnector.catalog.invalidate()
+    create.mutate({ name: item.name, type: item.type })
   }
 
   function createBlankRest() {
@@ -175,57 +234,123 @@ export function SourceTemplateDialog({ open, onOpenChange }: SourceTemplateDialo
       renderIcon={(item) => (
         <div className='flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-lg border bg-background'>
           <AppIcon
-            iconId={item.kind === 'app' ? item.appIconId : (item.iconKey ?? DEFAULT_SOURCE_ICON)}
+            iconId={
+              item.kind === 'app' || item.kind === 'recommended-app'
+                ? item.appIconId
+                : (item.iconKey ?? DEFAULT_SOURCE_ICON)
+            }
             size='lg'
           />
         </div>
       )}
-      renderBadges={(item) =>
-        'requiresConnection' in item && item.requiresConnection ? (
-          <span className='flex items-center gap-1 text-[11px] text-muted-foreground'>
-            <Plug className='size-3' />
-            Needs a connection
-          </span>
-        ) : null
-      }
+      renderBadges={(item) => (
+        <>
+          {/* "Not installed" and "needs a connection" are independent facts — a
+              recommended row states both up front rather than surprising the user
+              with the second one after the install. */}
+          {item.kind === 'recommended-app' && (
+            <span className='rounded-md px-1.5 py-0.5 text-[11px] text-muted-foreground ring-1 ring-border'>
+              Not installed
+            </span>
+          )}
+          {'requiresConnection' in item && item.requiresConnection && (
+            <span className='flex items-center gap-1 text-[11px] text-muted-foreground'>
+              <Plug className='size-3' />
+              Needs a connection
+            </span>
+          )}
+        </>
+      )}
       onSelectItem={handleSelect}
       busyItemId={busyItemId}
       detailSize='lg'
-      detailCrumb={() => 'Custom REST API'}
+      detailCrumb={(item) => (item.kind === 'builtin' ? 'Custom REST API' : item.name)}
       detailBusy={create.isPending}
       onDetailExit={() => setName('')}
-      renderDetail={(item) =>
-        item.kind === 'builtin' ? (
-          <ScrollArea className='max-h-[60vh]'>
-            <div className='flex flex-col gap-4 p-5'>
-              <p className='text-sm text-muted-foreground'>{item.description}</p>
-              <div className='flex flex-col gap-1.5'>
-                <span className='text-xs font-medium text-muted-foreground'>Source name</span>
-                <Input
-                  autoFocus
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                  placeholder='Source name (e.g. Acme CRM)'
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') createBlankRest()
-                  }}
-                />
+      renderDetail={(item) => {
+        if (item.kind === 'builtin') {
+          return (
+            <ScrollArea className='max-h-[60vh]'>
+              <div className='flex flex-col gap-4 p-5'>
+                <p className='text-sm text-muted-foreground'>{item.description}</p>
+                <div className='flex flex-col gap-1.5'>
+                  <span className='text-xs font-medium text-muted-foreground'>Source name</span>
+                  <Input
+                    autoFocus
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder='Source name (e.g. Acme CRM)'
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') createBlankRest()
+                    }}
+                  />
+                </div>
               </div>
-            </div>
-          </ScrollArea>
-        ) : null
+            </ScrollArea>
+          )
+        }
+        if (item.kind === 'recommended-app') {
+          return (
+            <ScrollArea className='max-h-[60vh]'>
+              <div className='flex flex-col gap-4 p-5'>
+                <div className='flex items-center gap-3'>
+                  <div className='flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-lg border bg-background'>
+                    <AppIcon iconId={item.appIconId} size='lg' />
+                  </div>
+                  <div className='min-w-0'>
+                    <div className='truncate text-sm font-medium'>{item.appTitle}</div>
+                    {item.developerTitle && (
+                      <div className='truncate text-xs text-muted-foreground'>
+                        by {item.developerTitle}
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <p className='text-sm text-muted-foreground'>{item.description}</p>
+                <p className='text-xs text-muted-foreground'>
+                  Installing the {item.appTitle} app adds this source to your workspace.
+                  {item.requiresConnection
+                    ? ` You'll connect your ${item.appTitle} account on the next screen, before the first sync.`
+                    : ''}
+                </p>
+              </div>
+            </ScrollArea>
+          )
+        }
+        return null
+      }}
+      renderDetailFooter={(item) =>
+        item.kind === 'recommended-app' ? (
+          // Once the install lands, `InlineAppInstallButton` flips to its
+          // "Installed" badge — which would read as *finished* while the source is
+          // still being created. Keep a pending CTA in that window instead.
+          create.isPending ? (
+            <Button size='sm' variant='outline' loading loadingText='Adding source...' disabled>
+              Adding source...
+            </Button>
+          ) : (
+            <InlineAppInstallButton
+              appSlug={item.appSlug}
+              onInstalled={() => continueAfterInstall(item)}
+              // `h-7` undoes the component's compact inline sizing, restoring the
+              // standard `size='sm'` height the other gallery footers use.
+              className='h-7'
+              data-dialog-submit>
+              Install &amp; add source <KbdSubmit variant='outline' size='sm' />
+            </InlineAppInstallButton>
+          )
+        ) : (
+          <Button
+            size='sm'
+            variant='outline'
+            onClick={createBlankRest}
+            loading={create.isPending}
+            loadingText='Creating...'
+            data-dialog-submit>
+            Create <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        )
       }
-      renderDetailFooter={() => (
-        <Button
-          size='sm'
-          variant='outline'
-          onClick={createBlankRest}
-          loading={create.isPending}
-          loadingText='Creating...'
-          data-dialog-submit>
-          Create <KbdSubmit variant='outline' size='sm' />
-        </Button>
-      )}
     />
   )
 }

--- a/apps/web/src/server/api/routers/data-connectors.ts
+++ b/apps/web/src/server/api/routers/data-connectors.ts
@@ -26,6 +26,7 @@ import {
   getConnectorReadiness,
   getConnectorTemplateById,
   listConnectors,
+  listRecommendedAppConnectors,
   listRuns,
   listSharedOwnedDefIds,
   listStreams,
@@ -220,9 +221,19 @@ export const dataConnectorRouter = createTRPCRouter({
    * first-party templates, and every installed-app connector. The apps section
    * reads the `installedApps` org-cache (already projected with
    * `catalog.dataConnectors`) — no bundle eval, no extra query.
+   *
+   * `recommended` (v9) is the discovery half: connectors from published, verified
+   * apps the org has NOT installed. It is gated on `integrations.manage` — the
+   * dialog itself only needs `connectors.manage`, so a data-ops member without
+   * install authority would otherwise be shown rows whose only CTA 403s.
+   * `ctx.capabilities` is already resolved by `permissionProcedure`, so the check
+   * costs nothing.
    */
   catalog: permissionProcedure(PermissionKey.connectorsManage).query(async ({ ctx }) => {
     const installedApps = await getCachedInstalledApps(ctx.session.organizationId)
+    const recommended = ctx.capabilities.can(PermissionKey.integrationsManage)
+      ? await listRecommendedAppConnectors(ctx.db, ctx.session.organizationId)
+      : []
     const apps = installedApps.flatMap((app) =>
       (app.dataConnectors ?? []).map((dc) => ({
         type: `app:${app.app.slug}`,
@@ -251,6 +262,7 @@ export const dataConnectorRouter = createTRPCRouter({
       ],
       templates: getAllConnectorTemplates(),
       apps,
+      recommended,
     }
   }),
 

--- a/packages/lib/src/data-connectors/index.ts
+++ b/packages/lib/src/data-connectors/index.ts
@@ -179,6 +179,12 @@ export {
   type ReadinessStream,
 } from './readiness'
 export { type ConnectorSyncEventKind, publishConnectorSync } from './realtime'
+// Connect-a-source discovery (v9) — connectors from published, verified apps the org
+// hasn't installed yet.
+export {
+  listRecommendedAppConnectors,
+  type RecommendedAppConnector,
+} from './recommended-app-connectors'
 export { archiveExternalId, handleConnectorDelete, reconcileOrphans } from './reconciliation'
 export { resolveRelationships } from './relationship-pass'
 // Orchestrator + passes

--- a/packages/lib/src/data-connectors/recommended-app-connectors.test.ts
+++ b/packages/lib/src/data-connectors/recommended-app-connectors.test.ts
@@ -1,0 +1,194 @@
+// packages/lib/src/data-connectors/recommended-app-connectors.test.ts
+// The eligibility predicate behind the "Connect a source" recommendations
+// (v9): published AND verified AND has a published production deployment that
+// declares a connector AND isn't already installed. Every arm of that AND is a
+// case here, because dropping any one of them either advertises something the
+// org can't install or nags about something it already has.
+
+import type { Database } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getCachedPublishedApps = vi.fn()
+const getCachedInstalledApps = vi.fn()
+vi.mock('../cache', () => ({
+  getCachedPublishedApps: () => getCachedPublishedApps(),
+  getCachedInstalledApps: (orgId: string) => getCachedInstalledApps(orgId),
+}))
+
+import { listRecommendedAppConnectors } from './recommended-app-connectors'
+
+const ORG = 'org_1'
+
+function publishedApp(over: Record<string, unknown> = {}) {
+  return {
+    id: 'app_shopify',
+    slug: 'shopify',
+    title: 'Shopify',
+    description: 'Ecommerce platform',
+    avatarUrl: 'https://cdn.auxx.ai/shopify.png',
+    verified: true,
+    developerAccount: { title: 'Auxx', logoUrl: null },
+    latestDeployment: { id: 'dep_1', version: '1.0.0', status: 'published' },
+    ...over,
+  }
+}
+
+function declaredConnector(over: Record<string, unknown> = {}) {
+  return {
+    id: 'shopify',
+    label: 'Shopify Orders',
+    description: 'Sync orders into records',
+    requiresConnection: true,
+    iconKey: 'brand:shopify',
+    configJsonSchema: {},
+    streams: [],
+    ...over,
+  }
+}
+
+/** A db whose single `select().from().where()` chain resolves to `rows`. */
+function dbReturning(rows: unknown[]): Database {
+  return {
+    select: () => ({ from: () => ({ where: () => Promise.resolve(rows) }) }),
+  } as unknown as Database
+}
+
+function dbThrowing(): Database {
+  return {
+    select: () => ({ from: () => ({ where: () => Promise.reject(new Error('boom')) }) }),
+  } as unknown as Database
+}
+
+beforeEach(() => {
+  getCachedInstalledApps.mockResolvedValue([])
+})
+
+describe('listRecommendedAppConnectors', () => {
+  it('projects a published, verified app’s declared connector', async () => {
+    getCachedPublishedApps.mockResolvedValue([publishedApp()])
+    const db = dbReturning([{ id: 'dep_1', dataConnectors: [declaredConnector()] }])
+
+    const result = await listRecommendedAppConnectors(db, ORG)
+
+    expect(result).toEqual([
+      {
+        type: 'app:shopify',
+        appSlug: 'shopify',
+        appTitle: 'Shopify',
+        appIconId: 'https://cdn.auxx.ai/shopify.png',
+        developerTitle: 'Auxx',
+        connectorId: 'shopify',
+        label: 'Shopify Orders',
+        description: 'Sync orders into records',
+        iconKey: 'brand:shopify',
+        requiresConnection: true,
+        requestModel: 'fixed',
+      },
+    ])
+  })
+
+  it('excludes an unverified app', async () => {
+    // Not cosmetic: `apps.install` puts unverified apps behind the
+    // `unverifiedApps` feature gate, so this row's only CTA would dead-end.
+    getCachedPublishedApps.mockResolvedValue([publishedApp({ verified: false })])
+    const db = dbReturning([{ id: 'dep_1', dataConnectors: [declaredConnector()] }])
+
+    expect(await listRecommendedAppConnectors(db, ORG)).toEqual([])
+  })
+
+  it('excludes an app with no published production deployment', async () => {
+    getCachedPublishedApps.mockResolvedValue([publishedApp({ latestDeployment: null })])
+    const db = dbReturning([])
+
+    expect(await listRecommendedAppConnectors(db, ORG)).toEqual([])
+  })
+
+  it('excludes a deployment whose catalog declares no connectors', async () => {
+    getCachedPublishedApps.mockResolvedValue([publishedApp()])
+
+    expect(await listRecommendedAppConnectors(dbReturning([]), ORG)).toEqual([])
+    expect(
+      await listRecommendedAppConnectors(dbReturning([{ id: 'dep_1', dataConnectors: null }]), ORG)
+    ).toEqual([])
+    expect(
+      await listRecommendedAppConnectors(dbReturning([{ id: 'dep_1', dataConnectors: [] }]), ORG)
+    ).toEqual([])
+  })
+
+  it('excludes an app that is already installed — including a development install', async () => {
+    // Matching on slug rather than installation id is the point: an org running
+    // a dev build of Shopify must not be told to go install Shopify.
+    getCachedPublishedApps.mockResolvedValue([publishedApp()])
+    getCachedInstalledApps.mockResolvedValue([
+      { installationId: 'inst_1', app: { slug: 'shopify' }, installationType: 'development' },
+    ])
+    const db = dbReturning([{ id: 'dep_1', dataConnectors: [declaredConnector()] }])
+
+    expect(await listRecommendedAppConnectors(db, ORG)).toEqual([])
+  })
+
+  it('falls back to the app description, then to empty', async () => {
+    getCachedPublishedApps.mockResolvedValue([publishedApp()])
+    const db = dbReturning([
+      { id: 'dep_1', dataConnectors: [declaredConnector({ description: null })] },
+    ])
+    expect((await listRecommendedAppConnectors(db, ORG))[0]?.description).toBe('Ecommerce platform')
+
+    getCachedPublishedApps.mockResolvedValue([publishedApp({ description: null })])
+    expect((await listRecommendedAppConnectors(db, ORG))[0]?.description).toBe('')
+  })
+
+  it('emits one row per declared connector, sorted by app title', async () => {
+    getCachedPublishedApps.mockResolvedValue([
+      publishedApp(),
+      publishedApp({
+        id: 'app_github',
+        slug: 'github',
+        title: 'GitHub',
+        latestDeployment: { id: 'dep_2', version: '2.0.0', status: 'published' },
+      }),
+    ])
+    const db = dbReturning([
+      { id: 'dep_1', dataConnectors: [declaredConnector()] },
+      {
+        id: 'dep_2',
+        dataConnectors: [
+          declaredConnector({ id: 'github.issues', label: 'Issues' }),
+          declaredConnector({ id: 'github.prs', label: 'Pull requests' }),
+        ],
+      },
+    ])
+
+    const result = await listRecommendedAppConnectors(db, ORG)
+
+    expect(result.map((r) => r.label)).toEqual(['Issues', 'Pull requests', 'Shopify Orders'])
+  })
+
+  it('caps the list at 8', async () => {
+    getCachedPublishedApps.mockResolvedValue(
+      Array.from({ length: 12 }, (_, i) =>
+        publishedApp({
+          id: `app_${i}`,
+          slug: `app-${i}`,
+          title: `App ${String(i).padStart(2, '0')}`,
+          latestDeployment: { id: `dep_${i}`, version: '1.0.0', status: 'published' },
+        })
+      )
+    )
+    const db = dbReturning(
+      Array.from({ length: 12 }, (_, i) => ({
+        id: `dep_${i}`,
+        dataConnectors: [declaredConnector()],
+      }))
+    )
+
+    expect(await listRecommendedAppConnectors(db, ORG)).toHaveLength(8)
+  })
+
+  it('returns [] when the deployment read fails, instead of throwing', async () => {
+    // The installed half of the picker must keep working when discovery breaks.
+    getCachedPublishedApps.mockResolvedValue([publishedApp()])
+
+    await expect(listRecommendedAppConnectors(dbThrowing(), ORG)).resolves.toEqual([])
+  })
+})

--- a/packages/lib/src/data-connectors/recommended-app-connectors.ts
+++ b/packages/lib/src/data-connectors/recommended-app-connectors.ts
@@ -1,0 +1,130 @@
+// packages/lib/src/data-connectors/recommended-app-connectors.ts
+// Discovery read for the "Connect a source" picker: connectors an org could get by
+// installing a published, verified marketplace app it hasn't installed yet.
+// See plans/data-connectors/v9/recommended-app-sources-plan.md.
+
+import { type CatalogDataConnector, type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { inArray, sql } from 'drizzle-orm'
+import { getCachedInstalledApps, getCachedPublishedApps } from '../cache'
+
+const logger = createScopedLogger('data-connectors:recommended')
+
+/**
+ * Cap on how many recommendations the picker's Apps category will carry. The
+ * recommended rows sit alongside the org's installed connectors, so an
+ * unbounded list would bury what the org already has. If this ever truncates,
+ * that is the signal to build real curation (ranking, an editorial flag)
+ * instead of raising the number.
+ */
+const RECOMMENDED_CAP = 8
+
+/** One connector an org could get by installing a published, verified app. */
+export interface RecommendedAppConnector {
+  /** `app:<slug>` — the same `DataConnectorType` the installed path creates. */
+  type: string
+  appSlug: string
+  appTitle: string
+  /** App logo URL, or the generic `package` glyph. Same cascade as the installed branch. */
+  appIconId: string
+  developerTitle: string | null
+  connectorId: string
+  label: string
+  description: string
+  iconKey: string | null
+  requiresConnection: boolean
+  requestModel: 'builder' | 'fixed'
+}
+
+/**
+ * Connectors declared by published, **verified** apps this org has not installed.
+ *
+ * Eligibility is answered almost entirely from the `publishedApps` app cache,
+ * which already holds only `publicationStatus = 'published'` rows and projects
+ * both `verified` and `latestDeployment` (the newest `production`/`published`
+ * deployment). The only DB work left is reading those deployments' connector
+ * declarations.
+ *
+ * **Verified is not decoration here.** `apps.install` puts unverified apps behind
+ * the `unverifiedApps` feature gate, so recommending one would dead-end most orgs
+ * on a plan limit. And `verified` alone is not enough — an app can be verified but
+ * unpublished (excluded by the cache) or published but unverified (excluded here).
+ *
+ * **Production deployments only.** The install this recommendation leads to runs
+ * with no `deploymentId`, and `installApp` then defaults to the latest
+ * `production`/`published` deployment. Recommending a connector declared only on a
+ * development deployment would advertise a deployment the install would not pick.
+ *
+ * Never throws: this is a discovery nicety layered onto the connector picker, and
+ * a failure here must not take the whole dialog down with it.
+ */
+export async function listRecommendedAppConnectors(
+  db: Database,
+  organizationId: string
+): Promise<RecommendedAppConnector[]> {
+  try {
+    const [publishedApps, installedApps] = await Promise.all([
+      getCachedPublishedApps(),
+      getCachedInstalledApps(organizationId),
+    ])
+
+    // Match on slug, not installation id: an org running a DEVELOPMENT install of
+    // an app must not be told to go install it.
+    const installedSlugs = new Set(installedApps.map((a) => a.app.slug))
+
+    const candidates = publishedApps.filter(
+      (app) =>
+        app.verified &&
+        app.latestDeployment?.status === 'published' &&
+        !installedSlugs.has(app.slug)
+    )
+    if (candidates.length === 0) return []
+
+    const deploymentIds = candidates.map((app) => app.latestDeployment?.id).filter(Boolean)
+
+    // Project the `dataConnectors` subtree in SQL. A full catalog blob carries the
+    // app's whole tool/trigger/block/field registry; we want one key out of it and
+    // there is no reason to ship the rest. `inArray`, never `= ANY(…::text[])` —
+    // the latter matches nothing through Drizzle.
+    const rows = await db
+      .select({
+        id: schema.AppDeployment.id,
+        dataConnectors: sql<
+          CatalogDataConnector[] | null
+        >`${schema.AppDeployment.catalog} -> 'dataConnectors'`,
+      })
+      .from(schema.AppDeployment)
+      .where(inArray(schema.AppDeployment.id, deploymentIds as string[]))
+
+    const connectorsByDeployment = new Map(rows.map((r) => [r.id, r.dataConnectors ?? []]))
+
+    const recommended: RecommendedAppConnector[] = []
+    for (const app of candidates) {
+      const declared = connectorsByDeployment.get(app.latestDeployment?.id ?? '') ?? []
+      for (const dc of declared) {
+        recommended.push({
+          type: `app:${app.slug}`,
+          appSlug: app.slug,
+          appTitle: app.title,
+          appIconId: app.avatarUrl ?? 'package',
+          developerTitle: app.developerAccount?.title ?? null,
+          connectorId: dc.id,
+          label: dc.label,
+          // Connector-declared description, falling back to the app's own — the
+          // same cascade the installed branch uses, so a row reads identically
+          // before and after install.
+          description: dc.description ?? app.description ?? '',
+          iconKey: dc.iconKey,
+          requiresConnection: dc.requiresConnection,
+          requestModel: dc.requestModel ?? 'fixed',
+        })
+      }
+    }
+
+    recommended.sort((a, b) => a.appTitle.localeCompare(b.appTitle))
+    return recommended.slice(0, RECOMMENDED_CAP)
+  } catch (error) {
+    logger.warn('Failed to list recommended app connectors', { error, organizationId })
+    return []
+  }
+}


### PR DESCRIPTION
## What

"Connect a source" only listed app connectors for apps the org had **already installed**. A user who wants to sync Shopify orders had to know, unprompted, that the answer was "go install the Shopify app first, then come back here" — nothing in the dialog said so.

This adds a `recommended` half to the picker: connectors from published, verified apps the org hasn't installed, installable and creatable without leaving the dialog.

## The eligibility predicate

An app connector is recommendable when **all four** hold:

- `App.publicationStatus = 'published'`
- `App.verified = true`
- the app's latest **published production** deployment declares `catalog.dataConnectors[]`
- the app is **not** installed in this org

Every arm is load-bearing:

- **`verified` is not decoration.** `apps.install` puts unverified apps behind the `unverifiedApps` feature gate, so recommending one would dead-end most orgs on a plan limit.
- **`verified` alone is not enough.** In the dev DB, `test-app` is published + unverified and `hubspot` is verified + unpublished.
- **Production deployments only.** The install this leads to runs with no `deploymentId`, and `installApp` then defaults to the latest published production deployment. A connector declared only on a *development* deployment would advertise a deployment the install would not pick.
- **Installed check matches on slug**, not installation id — an org running a dev install of Shopify must not be told to install Shopify.

## Why it's cheap

`publishedApps` (app cache) already holds only published rows and projects both `verified` and `latestDeployment` — the newest production/published deployment. So eligibility is answered from cache, and the only DB work is a PK `inArray` over those deployment ids with the `dataConnectors` subtree extracted **in SQL**. A full catalog blob carries the app's whole tool/trigger/block/field registry; we want one key out of it.

No cache-key reshape: widening `publishedApps` to carry catalogs would version-bump a shared, globally cached key to serve a list capped at 8. Revisit if the marketplace grows.

The read **never throws** — discovery is layered onto the connector picker, and a failure here must not take the whole dialog down with it.

## Permissions

`recommended` is gated on `integrations.manage`. The dialog itself only needs `connectors.manage`, so a data-ops member without install authority would otherwise see rows whose only CTA 403s. `ctx.capabilities` is already resolved by `permissionProcedure`, so the check costs nothing.

## UI

Badge, not bucket: recommended rows sit in the existing **Apps** category, appended after installed ones, behind a `Not installed` badge (shown alongside `Needs a connection` — independent facts). Someone opening this dialog is hunting for *Shopify*, not browsing a shelf; a second category would make them guess which bucket their app is in and would split search results.

Clicking one drills into a detail page — installing an app grants scopes and can trip a plan gate, so it should not be a stray click while scanning a grid. Its footer CTA reads **"Install & add source"** and does exactly that: install, then create the connector, then route to `/app/connectors/:id` where the setup stepper owns the Connect step. The dialog is never navigated away from mid-flow.

`InlineAppInstallButton` gained an optional `size`/`className`/prop passthrough so it can sit in a dialog footer and carry `data-dialog-submit` (what `Dialog` keys Enter-to-submit off). Existing call sites pass nothing and keep today's compact look.

### One ordering hazard, documented at the call site

`dataConnector.create` resolves the app from `getCachedInstalledApps` to seed the connector's streams from the app's catalog. A stale read there fails **silently** — it falls through to a bare `createConnector` with no streams rather than erroring. It's safe today because `apps.install` emits `app.installed` (→ busts `installedApps`) before it returns, but the ordering is load-bearing and now says so.

## Testing

- `recommended-app-connectors.test.ts` — 9 cases, one per arm of the predicate plus the description cascade, per-connector fan-out, the cap, and the throw-returns-`[]` posture.
- `pnpm vitest run src/data-connectors` — 47 files / 398 tests pass.
- Scoped `tsc --noEmit` on `packages/lib` and `apps/web` — no errors in any touched file.
- Verified live at `/app/connectors`: `dataConnector.catalog` now returns the `recommended` key, and the picker renders the recommended row once a published production deployment carries a connector catalog.