### PR TITLE
fix(dynamic-table): make relationship-path columns read-only

### DIFF
--- a/apps/web/src/components/dynamic-table/dynamic-view.tsx
+++ b/apps/web/src/components/dynamic-table/dynamic-view.tsx
@@ -121,6 +121,7 @@ function DynamicViewInner<TData extends object>({
     tableId,
     enabled: cellSelectionConfig?.enabled ?? false,
     readOnly: cellSelectionConfig?.readOnly,
+    config: cellSelectionConfig,
     scrollContainerRef,
   })
 

--- a/apps/web/src/components/dynamic-table/hooks/use-cell-navigation.ts
+++ b/apps/web/src/components/dynamic-table/hooks/use-cell-navigation.ts
@@ -5,7 +5,7 @@ import type { Table } from '@tanstack/react-table'
 import type React from 'react'
 import { useCallback, useEffect, useRef } from 'react'
 import { useSelectionStore } from '../stores/selection-store'
-import type { CellRange, CellSelectionState, RangeEndpoint } from '../types'
+import type { CellRange, CellSelectionConfig, CellSelectionState, RangeEndpoint } from '../types'
 import { isSingleCell, singleRange } from '../utils/range'
 
 interface UseCellNavigationOptions<TData> {
@@ -14,6 +14,8 @@ interface UseCellNavigationOptions<TData> {
   enabled: boolean
   /** Read-only degrade — arrow/tab/copy navigation stays on, Enter-to-edit off. */
   readOnly?: boolean
+  /** Narrows Enter-to-edit per row and per field, same as the cell's own gates. */
+  config?: CellSelectionConfig
   scrollContainerRef: React.RefObject<HTMLDivElement | null>
 }
 
@@ -29,6 +31,7 @@ export function useCellNavigation<TData>({
   tableId,
   enabled,
   readOnly,
+  config,
   scrollContainerRef,
 }: UseCellNavigationOptions<TData>) {
   /** Track last known position for resuming navigation after Escape clears */
@@ -182,6 +185,17 @@ export function useCellNavigation<TData>({
           break
         case 'Enter':
           if (!currentRange || readOnly) return
+          // Same three gates `SelectableTableCell`'s double-click applies. This
+          // listener is on `document`, so a cell handler that bails on an
+          // un-editable cell does NOT stop it — without these, Enter is a second
+          // door into the editor that skips both the per-row grant check and the
+          // per-field one (which is what keeps a relationship-PATH column, whose
+          // terminal field belongs to another definition, from ever mounting an
+          // editor bound to this row's RecordId).
+          if (config?.isRowReadOnly?.(focusAddr.rowId)) return
+          if (config?.getFieldDefinition?.(focusAddr.columnId)?.capabilities.updatable === false) {
+            return
+          }
           e.preventDefault()
           store.setEditingCell(tableId, focusAddr)
           return
@@ -222,7 +236,7 @@ export function useCellNavigation<TData>({
       }
       scrollCellIntoView(newRow.id, newCol.id, direction)
     },
-    [table, tableId, editingCell, enabled, readOnly, scrollCellIntoView]
+    [table, tableId, editingCell, enabled, readOnly, config, scrollCellIntoView]
   )
 
   useEffect(() => {

--- a/apps/web/src/components/dynamic-table/utils/column-id.test.ts
+++ b/apps/web/src/components/dynamic-table/utils/column-id.test.ts
@@ -1,0 +1,85 @@
+// apps/web/src/components/dynamic-table/utils/column-id.test.ts
+
+import type { ResourceField } from '@auxx/lib/resources/client'
+import { type ResourceFieldId, toFieldId, toResourceFieldId } from '@auxx/types/field'
+import { describe, expect, it } from 'vitest'
+import { encodeFieldPathColumnId, resolveColumnField } from './column-id'
+
+const PART_DEF = 'hg48bniy1wotbt444j6jvbz1'
+const VENDOR_PART_DEF = 'tym2o1stmyjfa6h0ilkcf828'
+
+const PART_COST = toResourceFieldId(PART_DEF, toFieldId('m62867rj76kihokudxirma7r'))
+const PART_VENDOR_PARTS = toResourceFieldId(PART_DEF, toFieldId('we3e11h48os6hdbsl06trv6z'))
+const VENDOR_PART_OTHER_COST = toResourceFieldId(
+  VENDOR_PART_DEF,
+  toFieldId('mfv20k43ewmc54emq60plcgd')
+)
+
+function field(resourceFieldId: ResourceFieldId, overrides: Partial<ResourceField> = {}) {
+  const [, id] = resourceFieldId.split(':')
+  return {
+    id: toFieldId(id!),
+    resourceFieldId,
+    key: id!,
+    label: id!,
+    type: 'number',
+    fieldType: 'CURRENCY',
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: true,
+    },
+    ...overrides,
+  } as ResourceField
+}
+
+const FIELD_MAP: Record<ResourceFieldId, ResourceField> = {
+  [PART_COST]: field(PART_COST),
+  [PART_VENDOR_PARTS]: field(PART_VENDOR_PARTS, { fieldType: 'RELATIONSHIP', type: 'array' }),
+  [VENDOR_PART_OTHER_COST]: field(VENDOR_PART_OTHER_COST),
+}
+
+const PATH_COLUMN = encodeFieldPathColumnId([PART_VENDOR_PARTS, VENDOR_PART_OTHER_COST])
+
+describe('resolveColumnField', () => {
+  it('returns null for special columns', () => {
+    expect(resolveColumnField(FIELD_MAP, '_checkbox')).toBeNull()
+  })
+
+  it('returns a direct field untouched', () => {
+    const resolved = resolveColumnField(FIELD_MAP, PART_COST)
+    expect(resolved).toBe(FIELD_MAP[PART_COST])
+    expect(resolved?.capabilities.updatable).toBe(true)
+  })
+
+  it('returns the terminal field for a path column, so display + copy keep its metadata', () => {
+    const resolved = resolveColumnField(FIELD_MAP, PATH_COLUMN)
+    expect(resolved?.id).toBe(FIELD_MAP[VENDOR_PART_OTHER_COST]!.id)
+    expect(resolved?.fieldType).toBe('CURRENCY')
+  })
+
+  it('marks a path column non-updatable so no edit path can mount an editor', () => {
+    // Regression: the terminal field belongs to another definition, so an editor
+    // bound to THIS row's RecordId fetched `<thisDef>:<otherDefField>` and 500'd.
+    expect(resolveColumnField(FIELD_MAP, PATH_COLUMN)?.capabilities.updatable).toBe(false)
+  })
+
+  it('does not mutate the shared field object in the store map', () => {
+    resolveColumnField(FIELD_MAP, PATH_COLUMN)
+    expect(FIELD_MAP[VENDOR_PART_OTHER_COST]!.capabilities.updatable).toBe(true)
+  })
+
+  it('returns null when a path segment is unknown', () => {
+    const unknown = encodeFieldPathColumnId([
+      PART_VENDOR_PARTS,
+      toResourceFieldId(VENDOR_PART_DEF, toFieldId('doesnotexist')),
+    ])
+    expect(resolveColumnField(FIELD_MAP, unknown)).toBeNull()
+  })
+
+  it('returns null for an unknown direct field', () => {
+    expect(resolveColumnField(FIELD_MAP, toResourceFieldId(PART_DEF, toFieldId('nope')))).toBeNull()
+  })
+})

--- a/apps/web/src/components/dynamic-table/utils/column-id.ts
+++ b/apps/web/src/components/dynamic-table/utils/column-id.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/dynamic-table/utils/column-id.ts
 
+import type { ResourceField } from '@auxx/lib/resources/client'
 import type { FieldPath, ResourceFieldId } from '@auxx/types/field'
 
 /**
@@ -94,4 +95,51 @@ export function isDirectFieldColumnId(columnId: string): boolean {
  */
 export function isFieldColumnId(columnId: string): boolean {
   return columnId.includes(':')
+}
+
+/**
+ * Resolve the {@link ResourceField} a table column renders, for BOTH the
+ * display consumers (cell formatting, copy-to-clipboard) and the edit
+ * consumers (cell editors, paste, fill-drag) behind `getFieldDefinition`.
+ *
+ * A **path** column resolves to its TERMINAL field — the display side needs
+ * that field's `fieldType`/`options` to format the cell — but is returned with
+ * `capabilities.updatable: false`, because a path is a traversal, not a cell:
+ *
+ * 1. Its value is an aggregate over the 0..N related records the path reaches
+ *    (`mapResultsToSources` returns an array as soon as a hop fans out), so
+ *    there is nothing single-valued for an editor to bind to.
+ * 2. Its write target — if one existed — would be the RELATED record, never the
+ *    row the column is rendered on. Handing the terminal field to an editor
+ *    keyed by THIS row's RecordId is what produced
+ *    `Field "<relatedField>" not found in "<thisDef>"`: `PropertyProvider`
+ *    fetches by the bare `field.id`, and `normalizeFieldRef` then qualifies it
+ *    with the row's definition, fabricating a pair that cannot exist.
+ *
+ * Every consumer already honours `capabilities.updatable`, so the flag alone
+ * keeps editors from mounting (`selectable-table-cell`) and keeps paste /
+ * fill-drag writes filtered out (`saveCells`).
+ *
+ * @param fieldMap - `resourceStore.fieldMap`, keyed by canonical ResourceFieldId
+ * @param columnId - Column ID (direct ResourceFieldId, encoded path, or special)
+ * @returns The field, or `null` for special columns and unknown refs
+ */
+export function resolveColumnField(
+  fieldMap: Record<ResourceFieldId, ResourceField>,
+  columnId: string
+): ResourceField | null {
+  if (columnId.startsWith('_')) return null
+
+  const decoded = decodeColumnId(columnId)
+
+  if (decoded.type === 'path') {
+    // FieldPath is a non-empty tuple; `[0]` is the guaranteed fallback.
+    const terminal = decoded.fieldPath.at(-1) ?? decoded.fieldPath[0]
+    const field = fieldMap[terminal]
+    if (!field) return null
+    if (field.capabilities.updatable === false) return field
+    return { ...field, capabilities: { ...field.capabilities, updatable: false } }
+  }
+
+  return fieldMap[decoded.resourceFieldId] ?? null
 }

--- a/apps/web/src/components/kb/ui/articles/articles-view.tsx
+++ b/apps/web/src/components/kb/ui/articles/articles-view.tsx
@@ -27,7 +27,7 @@ import {
   type DynamicResourceViewHandle,
 } from '~/components/dynamic-table/dynamic-resource-view'
 import type { ExtendedColumnDef } from '~/components/dynamic-table/types'
-import { decodeColumnId } from '~/components/dynamic-table/utils/column-id'
+import { resolveColumnField } from '~/components/dynamic-table/utils/column-id'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
 import { EmptyState } from '~/components/global/empty-state'
 import { splitRecordSearch, useRecordsSearchStore } from '~/components/records/records-search-store'
@@ -264,16 +264,9 @@ export function ArticlesView() {
   const cellSelectionConfig: CellSelectionConfig = useMemo(() => {
     const isTagsColumn = (columnId: string) => columnId === TAGS_COLUMN_ID
 
-    const resolveField = (columnId: string): ResourceField | null => {
-      if (columnId.startsWith('_')) return null
-      const decoded = decodeColumnId(columnId)
-      if (decoded.type === 'path') {
-        // FieldPath is a non-empty tuple; `[0]` is the guaranteed fallback.
-        const last = decoded.fieldPath.at(-1) ?? decoded.fieldPath[0]
-        return fieldMap[last] ?? null
-      }
-      return fieldMap[decoded.resourceFieldId] ?? null
-    }
+    // Path columns come back non-updatable — see `resolveColumnField`.
+    const resolveField = (columnId: string): ResourceField | null =>
+      resolveColumnField(fieldMap, columnId)
 
     // A columnId IS a `fieldRefToKey` encoding, so it decodes straight back to
     // the FieldReference `getValue` expects. Every value the field-value store

--- a/apps/web/src/components/records/records-view.tsx
+++ b/apps/web/src/components/records/records-view.tsx
@@ -38,7 +38,7 @@ import {
   type DynamicResourceViewHandle,
 } from '~/components/dynamic-table/dynamic-resource-view'
 import { useTableViewRealtime } from '~/components/dynamic-table/hooks/use-table-view-realtime'
-import { decodeColumnId } from '~/components/dynamic-table/utils/column-id'
+import { resolveColumnField } from '~/components/dynamic-table/utils/column-id'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
 import { EmptyState } from '~/components/global/empty-state'
 import { MainPageLoading, MainPageNotFound } from '~/components/global/main-page-states'
@@ -491,16 +491,9 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
         | null
         | undefined
 
-    const resolveField = (columnId: string): ResourceField | null => {
-      if (columnId.startsWith('_')) return null
-      const decoded = decodeColumnId(columnId)
-      if (decoded.type === 'path') {
-        // FieldPath is a non-empty tuple; `[0]` is the guaranteed fallback.
-        const lastResourceFieldId = decoded.fieldPath.at(-1) ?? decoded.fieldPath[0]
-        return fieldMap[lastResourceFieldId] ?? null
-      }
-      return fieldMap[decoded.resourceFieldId] ?? null
-    }
+    // Path columns come back non-updatable — see `resolveColumnField`.
+    const resolveField = (columnId: string): ResourceField | null =>
+      resolveColumnField(fieldMap, columnId)
 
     return {
       enabled: true,


### PR DESCRIPTION
## Problem

Clicking into a drill-down ("path") column — e.g. Parts → **Vendor Parts → Other Cost** — opens a cell editor and 500s:

```
❌ tRPC failed on fieldValue.batchGet: Field "mfv20k43ewmc54emq60plcgd" not found in "hg48bniy1wotbt444j6jvbz1"
    at validateFieldReferences (packages/lib/src/field-values/field-value-helpers.ts:1332)
```

The two ids are from different definitions — `hg48…` is `part`, `mfv20k…` is `vendor_part`'s "Other Cost". That pair cannot exist.

**Display was never affected.** Captured from the live app:

```jsonc
// rendering the column — correct, full FieldPath
{"fieldReferences":[["hg48…:we3e11h48os6hdbsl06trv6z","tym2…:mfv20k43ewmc54emq60plcgd"]]}

// opening the editor — the failing request
{"fieldReferences":["hg48…:mfv20k43ewmc54emq60plcgd"]}
```

## Root cause

`getFieldDefinition` is dual-purpose: display/copy need the *terminal* field's `fieldType`/`options` to format a path cell, but edit consumers read the same value as "the field to write."

1. `resolveField` returned the terminal field — a `vendor_part` field.
2. `getRecordId` returned the row's own `part:…` RecordId.
3. `CellFieldEditor` handed both to `PropertyProvider`.
4. `PropertyProvider` calls `useFieldValue(recordId, field.id)` with the **bare cuid**.
5. `normalizeFieldRef` qualifies a colon-less ref with the *record's* definition → `part:<vendorPartField>`.

Step 5 is why this was silent at authoring time: a bare `FieldId` carries no definition half, so nothing can notice the field and the record disagree — the ref is fabricated, not validated.

## Why not just send the full FieldPath

A path is a traversal, not a cell:

- **"Vendor Parts" is `has_many` + `isInverse`**, so the path resolves to an aggregate over 0..N vendor-part rows. Nothing single-valued for an editor to bind to.
- **The write has no target.** `saveCells` sends `fieldId: c.columnId` — the whole `::`-joined string — against the Part record. Even with a target it'd be the *related* record, not this row.

## Fix

**Mark path columns non-updatable.** New shared `resolveColumnField` returns the terminal field (display/copy keep its metadata) with `capabilities.updatable: false`, on a copy so the store's field object is never mutated. Consumers already honour the flag: `selectable-table-cell` stops opening editors, `saveCells` filters paste and fill-drag writes, and the cell picks up the existing read-only styling and tooltip.

**Close the second door into edit mode.** The flag alone was *not* enough — two callers reach `setEditingCell` and only one consulted the field. `useCellNavigation`'s Enter handler binds on `document` and checked only the table-wide `readOnly`; the cell's own Enter branch returns *without* `preventDefault`, so Enter opened the editor regardless. `config` is now threaded in and the same gates applied.

> ⚠️ That also closes a **pre-existing, unrelated hole**: Enter bypassed `isRowReadOnly`, so a member without an edit grant on a row could open its editor. The write still failed server-side, but the affordance was wrong. Double-click already blocked it. Happy to split this out if you'd rather review it separately.

**De-duplicate.** The resolver was copied verbatim into both `records-view.tsx` and `articles-view.tsx`; both now call the shared helper.

## Introduced

`5f9e92f0a` (2026-01-19) changed `getFieldDefinition` from a def-scoped `customFields.find(...)` (path → `null` → no editor) to the global `fieldMap[lastResourceFieldId]`, while `getRecordId` stayed the row's record. `aaa60cdcb` the same day gave `PropertyProvider` `autoFetch: true`, turning the fabricated ref from a store miss into a request.

## Verification

Driven against the live dev app:

| Check | Result |
|---|---|
| Column still renders | ✅ full `FieldPath`, no bare ref |
| Double-click path cell | ✅ no editor, no request, `title="This field is read-only"` |
| Enter on path cell | ✅ no editor, no request |
| Direct column still editable | ✅ editor opens |
| `vitest run src/components/dynamic-table` | ✅ 25 passed (7 new) |
| `tsc --noEmit` (apps/web) | ✅ no errors in changed files |
| Biome | ✅ clean |

## Out of scope

Making path cells genuinely editable (resolve the target related record and write there) — undefined for a `has_many` hop; lookup columns are read-only in comparable products for the same reason.
