### PR TITLE
refactor(currency): store minor units, one denomination per field

### DIFF
--- a/apps/web/src/components/custom-fields/ui/custom-field-form.tsx
+++ b/apps/web/src/components/custom-fields/ui/custom-field-form.tsx
@@ -503,11 +503,14 @@ export function CustomFieldForm({
         form.setValue('isUnique', false)
       }
       // Reset displayOptions and close panel when type changes.
-      // CURRENCY seeds with USD/2-decimal defaults so the field saves with a
-      // currencyCode even if the user never opens the Display Options panel.
+      // CURRENCY seeds with a currencyCode so the field saves with one even if
+      // the user never opens the Display Options panel. `decimals` is
+      // deliberately NOT seeded: leaving it unset derives the fraction digits
+      // from the code, so a field later switched to JPY renders 0 decimals
+      // instead of keeping a baked-in 2.
       setDisplayOptions(
         selectedType === FieldType.CURRENCY
-          ? { currencyCode: 'USD', decimals: 2, useGrouping: true, currencyDisplay: 'symbol' }
+          ? { currencyCode: 'USD', useGrouping: true, currencyDisplay: 'symbol' }
           : {}
       )
       setShowDisplayOptions(selectedType === FieldType.CURRENCY)

--- a/apps/web/src/components/custom-fields/ui/formatting-editors/currency-formatting-editor.tsx
+++ b/apps/web/src/components/custom-fields/ui/formatting-editors/currency-formatting-editor.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import type { CurrencyFieldOptions } from '@auxx/lib/field-values/client'
+import { Button } from '@auxx/ui/components/button'
 import { Field, FieldGroup, FieldLabel } from '@auxx/ui/components/field'
 import {
   Select,
@@ -11,10 +12,18 @@ import {
   SelectValue,
 } from '@auxx/ui/components/select'
 import { CurrencyPicker } from '~/components/pickers/currency-picker'
+import { useOrgCurrency } from '~/hooks/use-org-currency'
 
 interface CurrencyFormattingEditorProps {
   options: CurrencyFieldOptions
   onChange: (options: CurrencyFieldOptions) => void
+  /**
+   * Where this editor is rendered. `'field'` (the default) owns the
+   * denomination and shows the picker; `'column'` shows it read-only, because a
+   * column override across exponents rescales the money instead of relabelling
+   * it. See `currencyFormattingSchema`.
+   */
+  scope?: 'field' | 'column'
 }
 
 /**
@@ -24,10 +33,24 @@ interface CurrencyFormattingEditorProps {
  * (Intl picks fraction digits and disables grouping in compact mode).
  * Used by both the field-default config dialog and column-formatting overrides.
  */
-export function CurrencyFormattingEditor({ options, onChange }: CurrencyFormattingEditorProps) {
-  const current: Required<CurrencyFieldOptions> = {
-    currencyCode: options.currencyCode ?? 'USD',
-    decimals: options.decimals ?? 2,
+export function CurrencyFormattingEditor({
+  options,
+  onChange,
+  scope = 'field',
+}: CurrencyFormattingEditorProps) {
+  const orgCurrency = useOrgCurrency()
+
+  // 🛑 `currencyCode` and `decimals` BOTH stay possibly-undefined.
+  //
+  // An absent code means INHERIT the org's, and it has to stay absent — the
+  // moment this seeds the picker with a concrete code, every unrelated edit
+  // (change the display mode, change the separators) spreads `current` back
+  // through `onChange` and STAMPS it, pinning a field that was following
+  // `organization.currency`. Undefined `decimals` likewise means "derive from
+  // the code", which is right for JPY (0) and KWD (3), not just USD (2).
+  const current: CurrencyFieldOptions = {
+    currencyCode: options.currencyCode,
+    decimals: options.decimals,
     useGrouping: options.useGrouping ?? true,
     currencyDisplay: options.currencyDisplay ?? 'symbol',
   }
@@ -37,10 +60,33 @@ export function CurrencyFormattingEditor({ options, onChange }: CurrencyFormatti
     <FieldGroup className='gap-3'>
       <Field>
         <FieldLabel>Currency</FieldLabel>
-        <CurrencyPicker
-          selected={current.currencyCode}
-          onChange={(code) => onChange({ ...current, currencyCode: code })}
-        />
+        {scope === 'column' ? (
+          <p className='text-muted-foreground text-xs'>
+            {current.currencyCode ?? orgCurrency} — set on the field. Changing a column's currency
+            would rescale the amounts, not just relabel them.
+          </p>
+        ) : (
+          <>
+            <CurrencyPicker
+              selected={current.currencyCode}
+              placeholder={`Organization default (${orgCurrency})`}
+              onChange={(code) => onChange({ ...current, currencyCode: code })}
+            />
+            {current.currencyCode ? (
+              <Button
+                variant='ghost'
+                size='sm'
+                className='h-auto self-start px-0 text-muted-foreground text-xs'
+                onClick={() => onChange({ ...current, currencyCode: undefined })}>
+                Use organization default ({orgCurrency})
+              </Button>
+            ) : (
+              <p className='text-muted-foreground text-xs'>
+                Follows the organization currency. Change it in Settings → General.
+              </p>
+            )}
+          </>
+        )}
       </Field>
 
       <Field>
@@ -69,12 +115,15 @@ export function CurrencyFormattingEditor({ options, onChange }: CurrencyFormatti
         <Field>
           <FieldLabel>Decimal Places</FieldLabel>
           <Select
-            value={String(current.decimals)}
-            onValueChange={(v) => onChange({ ...current, decimals: parseInt(v, 10) })}>
+            value={current.decimals === undefined ? 'auto' : String(current.decimals)}
+            onValueChange={(v) =>
+              onChange({ ...current, decimals: v === 'auto' ? undefined : Number.parseInt(v, 10) })
+            }>
             <SelectTrigger>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
+              <SelectItem value='auto'>Match the currency (recommended)</SelectItem>
               <SelectItem value='0'>No decimals (11)</SelectItem>
               <SelectItem value='2'>Two decimal places (10.99)</SelectItem>
             </SelectContent>

--- a/apps/web/src/components/custom-fields/ui/formatting-editors/display-options.test.ts
+++ b/apps/web/src/components/custom-fields/ui/formatting-editors/display-options.test.ts
@@ -1,0 +1,53 @@
+// apps/web/src/components/custom-fields/ui/formatting-editors/display-options.test.ts
+
+import { displayOptionsSchema } from '@auxx/types/custom-field'
+import { describe, expect, it } from 'vitest'
+import { formatDisplayOptions, parseDisplayOptions } from './index'
+
+/**
+ * Regression guard for the duplicated whitelist.
+ *
+ * These two functions filter display options in BOTH directions — `parse` on
+ * load, `format` on save. They used to filter against a hand-maintained
+ * web-local copy of the canonical key list, so any option the canonical schema
+ * gained but the copy did not simply evaporated: the switch flipped, marked the
+ * form dirty, saved, and the key never reached tRPC. Reopen, and it was off.
+ * Indistinguishable from "this toggle doesn't work".
+ *
+ * The list is derived from the schema now, so the failure mode is gone rather
+ * than patched for one key.
+ */
+describe('display option key list', () => {
+  it('covers every canonical display option except the nested ai block', () => {
+    const canonical = Object.keys(displayOptionsSchema.shape).filter((k) => k !== 'ai')
+    for (const key of canonical) {
+      const round = formatDisplayOptions({ [key]: 'x' } as never)
+      expect(round, `formatDisplayOptions dropped "${key}"`).toHaveProperty(key)
+      expect(
+        parseDisplayOptions({ [key]: 'x' } as never),
+        `parseDisplayOptions dropped "${key}"`
+      ).toHaveProperty(key)
+    }
+  })
+
+  it('round-trips the CURRENCY options through save and load', () => {
+    const options = {
+      currencyCode: 'JPY',
+      currencyDisplay: 'code',
+      useGrouping: false,
+    } as const
+    expect(parseDisplayOptions(formatDisplayOptions(options) as never)).toEqual(options)
+  })
+
+  it('keeps `decimals: undefined` out rather than stamping a default', () => {
+    // Undefined means "derive from the currency code". Round-tripping it as 2
+    // freezes a JPY column at two decimals.
+    expect(formatDisplayOptions({ currencyCode: 'JPY', decimals: undefined })).not.toHaveProperty(
+      'decimals'
+    )
+  })
+
+  it('never carries the nested ai block — custom-field-form owns that', () => {
+    expect(formatDisplayOptions({ ai: { enabled: true } } as never)).not.toHaveProperty('ai')
+  })
+})

--- a/apps/web/src/components/custom-fields/ui/formatting-editors/index.ts
+++ b/apps/web/src/components/custom-fields/ui/formatting-editors/index.ts
@@ -1,6 +1,9 @@
 // apps/web/src/components/custom-fields/ui/formatting-editors/index.ts
 
 import type { FieldOptions } from '@auxx/lib/field-values/client'
+import { type DisplayOptions, displayOptionsSchema } from '@auxx/types/custom-field'
+
+export type { DisplayOptions }
 
 export { BooleanFormattingEditor } from './boolean-formatting-editor'
 export { CurrencyFormattingEditor } from './currency-formatting-editor'
@@ -13,50 +16,21 @@ export { TimeFormattingEditor } from './time-formatting-editor'
 export { UrlFormattingEditor } from './url-formatting-editor'
 
 /**
- * Display options type for internal state.
- * Flat structure containing all display-related options.
+ * Keys that are display options (flat on `field.options`).
+ *
+ * 🛑 DERIVED from the canonical `displayOptionsSchema`, never hand-listed. This
+ * used to be a web-local copy of both the type and the key array, and it
+ * silently ate every option the canonical schema gained but the copy did not —
+ * a filter that runs on BOTH save and load, so the key vanished before tRPC and
+ * the switch read back off. Adding a key in `@auxx/types/custom-field` is now
+ * the whole change.
+ *
+ * `ai` is excluded on purpose: it is a nested block that `custom-field-form`
+ * assembles and strips itself, not a flat display option.
  */
-export interface DisplayOptions {
-  // NUMBER / CURRENCY options
-  decimals?: number
-  useGrouping?: boolean
-  displayAs?: 'number' | 'percentage' | 'compact' | 'bytes'
-  prefix?: string
-  suffix?: string
-  // CURRENCY options
-  currencyCode?: string
-  currencyDisplay?: 'symbol' | 'code' | 'name' | 'compact'
-  // DATE/DATETIME/TIME options
-  format?: 'short' | 'medium' | 'long' | 'relative' | 'iso' | 'time-only'
-  timeFormat?: '12h' | '24h'
-  // CHECKBOX options
-  trueLabel?: string
-  falseLabel?: string
-  // PHONE options
-  phoneFormat?: 'raw' | 'national' | 'international'
-  // URL options
-  urlDisplay?: 'link' | 'image'
-  // TEXT options
-  multiline?: boolean
-}
-
-/** Keys that are display options (flat on field.options) */
-const DISPLAY_OPTION_KEYS: (keyof DisplayOptions)[] = [
-  'decimals',
-  'useGrouping',
-  'displayAs',
-  'prefix',
-  'suffix',
-  'currencyCode',
-  'currencyDisplay',
-  'format',
-  'timeFormat',
-  'trueLabel',
-  'falseLabel',
-  'phoneFormat',
-  'urlDisplay',
-  'multiline',
-]
+const DISPLAY_OPTION_KEYS = (
+  Object.keys(displayOptionsSchema.shape) as (keyof DisplayOptions)[]
+).filter((key) => key !== 'ai')
 
 /**
  * Parse stored field options into display options state.

--- a/apps/web/src/components/dashboard/lib/format-value.ts
+++ b/apps/web/src/components/dashboard/lib/format-value.ts
@@ -4,11 +4,10 @@
 // the metric field's `FieldType` + `FieldOptions` so a dashboard renders numbers
 // exactly like the records table and field displays do — no bespoke formatter.
 //
-// The one wrinkle: CURRENCY is stored as CENTS across the app (see
-// `fields/displays/display-currency.tsx` + the table's `renderCurrencyValue`),
-// and `@auxx/utils`' `formatCurrency` expects cents — so currency routes through
-// `formatCurrency`, NOT `formatToDisplayValue` (whose currency converter assumes
-// dollars and would render 100× high). NUMBER/DATE reuse their converters.
+// CURRENCY is stored as integer MINOR UNITS across the app, and every reader
+// now agrees on that — so currency routes through the shared converter like
+// NUMBER/DATE. `formatCurrencyCompact` stays for axis ticks: that is a
+// precision-for-room trade, not a unit workaround.
 //
 // Field-less ops (count family) and dimensionless percent ops have no field to
 // inherit from, so they fall back to plain `Intl` number / `%`.
@@ -22,7 +21,6 @@ import {
 } from '@auxx/lib/field-values/client'
 import {
   type CurrencyDisplayOptions,
-  formatCurrency,
   formatCurrencyCompact,
   formatNumberCompact,
 } from '@auxx/utils'
@@ -49,7 +47,7 @@ const PERCENT_OPS: ReadonlySet<MetricOp> = new Set<MetricOp>(['percentEmpty', 'p
  * - `percent*` ops → `NN.N%` (value is already 0–100, not multiplied).
  * - `count*` ops → grouped integer.
  * - `sum`/`avg`/`min`/`max` → inherit the metric field's display:
- *   CURRENCY via `formatCurrency` (cents), NUMBER/DATE via their converters,
+ *   CURRENCY/NUMBER/DATE via their shared converters,
  *   all honoring the field's `FieldOptions`.
  * - No field metadata (e.g. a one-hop `FieldPath` metric, or before the field
  *   resolves) → plain grouped number.
@@ -71,8 +69,7 @@ export function formatMetricValue(value: number, op: MetricOp, meta?: MetricFiel
   const { fieldType, options } = meta ?? {}
 
   if (fieldType === 'CURRENCY') {
-    // Stored as cents — formatCurrency expects cents.
-    return formatCurrency(value, options as CurrencyDisplayOptions | undefined)
+    return String(converters.CURRENCY.toDisplayValue({ type: 'number', value }, options) ?? '')
   }
   if (fieldType === 'NUMBER') {
     return String(converters.NUMBER.toDisplayValue({ type: 'number', value }, options) ?? '')
@@ -106,7 +103,7 @@ export function formatMetricValueCompact(
   const { fieldType, options } = meta ?? {}
 
   if (fieldType === 'CURRENCY') {
-    // Stored as cents — formatCurrencyCompact expects cents.
+    // Minor units in, short string out — see the note at the top of the file.
     return formatCurrencyCompact(value, options as CurrencyDisplayOptions | undefined)
   }
   if (fieldType === 'DATE' || fieldType === 'DATETIME') {

--- a/apps/web/src/components/dynamic-table/components/dialogs/edit-column-formatting-dialog.tsx
+++ b/apps/web/src/components/dynamic-table/components/dialogs/edit-column-formatting-dialog.tsx
@@ -68,28 +68,38 @@ function numberDisplayOptionsToColumn(opts: NumberFieldOptions): NumberColumnFor
 }
 
 /**
- * Convert CurrencyColumnFormatting to CurrencyFieldOptions
+ * Convert CurrencyColumnFormatting to CurrencyFieldOptions.
+ *
+ * 🛑 `decimals` stays possibly-undefined on BOTH sides. Undefined means "derive
+ * from the currency code" — 0 for JPY, 3 for KWD — and a `?? 2` here would
+ * freeze every JPY column at `¥1,234.00` the first time anyone opened this
+ * dialog, while making the editor's own "Match the currency" option unreachable.
+ *
+ * No `currencyCode`: the denomination is the field's. See
+ * `currencyFormattingSchema`.
  */
 function columnToCurrencyDisplayOptions(
   formatting: CurrencyColumnFormatting | null,
-  defaults?: Partial<CurrencyColumnFormatting>
+  defaults?: Partial<CurrencyColumnFormatting>,
+  fieldCurrencyCode?: string
 ): CurrencyFieldOptions {
   return {
-    currencyCode: formatting?.currencyCode ?? defaults?.currencyCode ?? 'USD',
-    decimals: formatting?.decimals ?? defaults?.decimals ?? 2,
+    currencyCode: fieldCurrencyCode,
+    decimals: formatting?.decimals ?? defaults?.decimals,
     useGrouping: formatting?.useGrouping ?? defaults?.useGrouping ?? true,
     currencyDisplay: formatting?.currencyDisplay ?? defaults?.currencyDisplay ?? 'symbol',
   }
 }
 
 /**
- * Convert CurrencyFieldOptions to CurrencyColumnFormatting
+ * Convert CurrencyFieldOptions to CurrencyColumnFormatting.
+ *
+ * Drops `currencyCode` — the column never overrides the field's denomination.
  */
 function currencyDisplayOptionsToColumn(opts: CurrencyFieldOptions): CurrencyColumnFormatting {
   return {
     type: 'currency',
-    currencyCode: opts.currencyCode ?? 'USD',
-    decimals: opts.decimals ?? 2,
+    decimals: opts.decimals,
     useGrouping: opts.useGrouping ?? true,
     currencyDisplay: opts.currencyDisplay ?? 'symbol',
   }
@@ -174,6 +184,8 @@ interface EditColumnFormattingDialogProps {
   fieldType: FormattableFieldType
   currentFormatting: ColumnFormatting | undefined
   defaultFormatting?: Partial<ColumnFormatting>
+  /** The FIELD's currency code, shown read-only — a column cannot override it. */
+  fieldCurrencyCode?: string
   onSave: (formatting: ColumnFormatting | null) => void
 }
 
@@ -188,6 +200,7 @@ export function EditColumnFormattingDialog({
   fieldType,
   currentFormatting,
   defaultFormatting,
+  fieldCurrencyCode,
   onSave,
 }: EditColumnFormattingDialogProps) {
   const [formatting, setFormatting] = useState<ColumnFormatting | null>(null)
@@ -224,9 +237,11 @@ export function EditColumnFormattingDialog({
 
         {fieldType === 'CURRENCY' && (
           <CurrencyFormattingEditor
+            scope='column'
             options={columnToCurrencyDisplayOptions(
               formatting as CurrencyColumnFormatting | null,
-              defaultFormatting as Partial<CurrencyColumnFormatting>
+              defaultFormatting as Partial<CurrencyColumnFormatting>,
+              fieldCurrencyCode
             )}
             onChange={(opts) => setFormatting(currencyDisplayOptionsToColumn(opts))}
           />

--- a/apps/web/src/components/dynamic-table/components/formatted-cell.tsx
+++ b/apps/web/src/components/dynamic-table/components/formatted-cell.tsx
@@ -4,6 +4,7 @@
 
 import type { FieldOptions } from '@auxx/lib/field-values/client'
 import { memo } from 'react'
+import { useOrgCurrency } from '~/hooks/use-org-currency'
 import { useTableConfig } from '../context/table-config-context'
 import { useColumnFormatting } from '../stores/store-selectors'
 import type { ColumnFormatting } from '../types'
@@ -30,6 +31,12 @@ export interface CellConfig {
    * are themselves inside a hover card (e.g. `RecordHoverCardField`).
    */
   disableNestedHoverCard?: boolean
+  /**
+   * The org's ISO code — the middle rung of a CURRENCY field's chain
+   * (field → org → USD). Injected by `FormattedCell`, which can call a hook;
+   * the renderers are plain functions and cannot.
+   */
+  orgCurrencyCode?: string
 }
 
 /**
@@ -66,6 +73,10 @@ export const FormattedCell = memo(function FormattedCell({
 }: FormattedCellProps) {
   const type = fieldType ?? 'TEXT'
 
+  // Unconditional — a CURRENCY field that never picked its own code renders in
+  // the org's. Cheap: a read off already-hydrated state.
+  const orgCurrencyCode = useOrgCurrency()
+
   // Get formatting from store if available, explicit formatting takes precedence
   let formatting: ColumnFormatting | undefined = explicitFormatting
 
@@ -82,5 +93,5 @@ export const FormattedCell = memo(function FormattedCell({
     }
   }
 
-  return <>{renderCellValue(value, type, formatting, config)}</>
+  return <>{renderCellValue(value, type, formatting, { ...config, orgCurrencyCode })}</>
 })

--- a/apps/web/src/components/dynamic-table/components/header-cell.tsx
+++ b/apps/web/src/components/dynamic-table/components/header-cell.tsx
@@ -154,6 +154,7 @@ function HeaderCellOptionsDropdown<TData>({
   setPinnedColumn,
   effectiveFieldType,
   terminalDefaultFormatting,
+  fieldCurrencyCode,
   aiMenuEnabled,
   aiField,
   aiFieldRef,
@@ -181,6 +182,8 @@ function HeaderCellOptionsDropdown<TData>({
   effectiveFieldType: FieldType | undefined
   /** The terminal field's `options`, used as the formatting dialog's defaults. */
   terminalDefaultFormatting: FieldOptions | undefined
+  /** The FIELD's ISO code for a CURRENCY column — shown read-only, never overridden. */
+  fieldCurrencyCode: string | undefined
   aiMenuEnabled: boolean
   aiField: { id: FieldId; fieldType: FieldType } | null
   aiFieldRef: FieldReference | null
@@ -440,6 +443,7 @@ function HeaderCellOptionsDropdown<TData>({
           fieldType={effectiveFieldType as FormattableFieldType}
           currentFormatting={columnFormatting[column.id]}
           defaultFormatting={columnDef.defaultFormatting ?? terminalDefaultFormatting}
+          fieldCurrencyCode={fieldCurrencyCode}
           onSave={(formatting) => setColumnFormatting(column.id, formatting)}
         />
       )}
@@ -521,6 +525,16 @@ export function HeaderCell<TData>({ header, isDragging = false }: HeaderCellProp
 
   // Effective fieldType: from columnDef or terminal field for paths
   const effectiveFieldType = columnDef.fieldType ?? terminalFieldMeta?.fieldType
+
+  // A CURRENCY column shows its FIELD's denomination read-only — the column has
+  // no override, because changing the code rescales the money rather than
+  // relabelling it.
+  const fieldCurrencyCode = useMemo(() => {
+    const source = isPathColumn
+      ? terminalFieldMeta?.defaultFormatting
+      : (directField?.options as { currencyCode?: string } | null | undefined)
+    return (source as { currencyCode?: string } | null | undefined)?.currencyCode
+  }, [isPathColumn, terminalFieldMeta, directField?.options])
 
   // ─── AI MENU GATE ─────────────────────────────────────────────────────────
   // Hide the AI submenu unless this is a direct, AI-enabled custom field.
@@ -636,6 +650,7 @@ export function HeaderCell<TData>({ header, isDragging = false }: HeaderCellProp
             setPinnedColumn={setPinnedColumn}
             effectiveFieldType={effectiveFieldType}
             terminalDefaultFormatting={terminalFieldMeta?.defaultFormatting}
+            fieldCurrencyCode={fieldCurrencyCode}
             aiMenuEnabled={aiMenuEnabled}
             aiField={aiField}
             aiFieldRef={aiFieldRef}

--- a/apps/web/src/components/dynamic-table/utils/cell-renderers.tsx
+++ b/apps/web/src/components/dynamic-table/utils/cell-renderers.tsx
@@ -14,6 +14,8 @@ import {
   type NumberFieldOptions,
   type PhoneFieldOptions,
   type RecordId,
+  readCurrency,
+  resolveCurrencyCode,
 } from '@auxx/lib/field-values/client'
 import { type ActorId, isActorId, toActorId } from '@auxx/types/actor'
 import type { TypedFieldValue } from '@auxx/types/field-value'
@@ -336,18 +338,23 @@ export function renderCurrencyValue(
 ): React.ReactNode {
   if (value == null || value === '') return <EmptyCell />
 
-  const cents = typeof value === 'number' ? value : parseInt(value as string, 10)
-  if (Number.isNaN(cents)) return <EmptyCell />
+  // Minor units, as a number or a numeric string. `readCurrency` returns null
+  // rather than NaN for anything unreadable, so a bad cell renders empty.
+  const amount = readCurrency(value)
+  if (amount === null) return <EmptyCell />
 
   const fieldOptions = config?.options as CurrencyFieldOptions | undefined
   const options: CurrencyDisplayOptions = {
-    currencyCode: formatting?.currencyCode ?? fieldOptions?.currencyCode ?? 'USD',
-    decimals: formatting?.decimals ?? fieldOptions?.decimals ?? 2,
+    // field → org → USD. There is deliberately no COLUMN override: across
+    // exponents it would rescale the money, not relabel it.
+    currencyCode: resolveCurrencyCode(fieldOptions?.currencyCode, config?.orgCurrencyCode),
+    // Undefined derives fraction digits from the code (JPY 0, KWD 3).
+    decimals: formatting?.decimals ?? fieldOptions?.decimals,
     useGrouping: formatting?.useGrouping ?? fieldOptions?.useGrouping ?? true,
     currencyDisplay: formatting?.currencyDisplay ?? fieldOptions?.currencyDisplay ?? 'symbol',
   }
 
-  const formatted = formatCurrency(cents, options)
+  const formatted = formatCurrency(amount, options)
   return (
     <ExpandableCell mode='horizontal'>
       <span className='font-mono'>{formatted}</span>

--- a/apps/web/src/components/fields/displays/display-currency.tsx
+++ b/apps/web/src/components/fields/displays/display-currency.tsx
@@ -1,9 +1,18 @@
 // apps/web/src/components/fields/displays/display-currency.tsx
 'use client'
 
-import type { CurrencyFieldOptions } from '@auxx/lib/field-values/client'
-import { type CurrencyDisplayOptions, formatCurrency } from '@auxx/utils'
+import {
+  type CurrencyFieldOptions,
+  readCurrency,
+  resolveCurrencyCode,
+} from '@auxx/lib/field-values/client'
+import {
+  type CurrencyDisplayOptions,
+  formatCurrency,
+  minorToMajorString,
+} from '@auxx/utils/currency'
 import { useMemo } from 'react'
+import { useOrgCurrency } from '~/hooks/use-org-currency'
 import { useFieldContext } from './display-field'
 import DisplayWrapper from './display-wrapper'
 
@@ -13,25 +22,30 @@ import DisplayWrapper from './display-wrapper'
  */
 export function DisplayCurrency() {
   const { value, field } = useFieldContext()
+  const orgCurrency = useOrgCurrency()
+
+  const amount = useMemo(() => readCurrency(value), [value])
 
   const options: CurrencyDisplayOptions = useMemo(() => {
     const opts = field.options as CurrencyFieldOptions | undefined
     return {
-      currencyCode: opts?.currencyCode ?? 'USD',
-      decimals: opts?.decimals ?? 2,
+      // field → org → USD. A value never asserts its own.
+      currencyCode: resolveCurrencyCode(opts?.currencyCode, orgCurrency),
+      // Undefined derives the fraction digits from the code (JPY 0, KWD 3).
+      decimals: opts?.decimals,
       useGrouping: opts?.useGrouping ?? true,
       currencyDisplay: opts?.currencyDisplay ?? 'symbol',
     }
-  }, [field.options])
+  }, [field.options, orgCurrency])
 
-  const formattedValue = useMemo(() => {
-    if (value === null || value === undefined) return null
-    return formatCurrency(value, options)
-  }, [value, options])
+  const formattedValue = useMemo(
+    () => (amount === null ? null : formatCurrency(amount, options)),
+    [amount, options]
+  )
 
-  // For copy, use the plain number format (dollars, not cents)
-  const copyValue =
-    value !== null && value !== undefined ? (value / 100).toFixed(options.decimals ?? 2) : null
+  // For copy, use the plain major-unit number — no symbol, no grouping, so it
+  // round-trips back into an input.
+  const copyValue = amount === null ? null : minorToMajorString(amount, options.currencyCode)
 
   return <DisplayWrapper copyValue={copyValue}>{formattedValue || '-'}</DisplayWrapper>
 }

--- a/apps/web/src/components/fields/inputs/currency-input-field.tsx
+++ b/apps/web/src/components/fields/inputs/currency-input-field.tsx
@@ -1,7 +1,11 @@
 // apps/web/src/components/fields/inputs/currency-input-field.tsx
 'use client'
 
-import type { CurrencyFieldOptions } from '@auxx/lib/field-values/client'
+import {
+  type CurrencyFieldOptions,
+  readCurrency,
+  resolveCurrencyCode,
+} from '@auxx/lib/field-values/client'
 import {
   CurrencyInputField as BaseCurrencyInputField,
   CurrencyInput,
@@ -9,6 +13,7 @@ import {
 import { InputGroup } from '@auxx/ui/components/input-group'
 import { cn } from '@auxx/ui/lib/utils'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useOrgCurrency } from '~/hooks/use-org-currency'
 import { useFieldNavigationOptional } from '../field-navigation-context'
 import { usePropertyContext } from '../property-provider'
 
@@ -26,10 +31,17 @@ import { usePropertyContext } from '../property-provider'
  * Note: The UI component's blur handler calls onBlur BEFORE parsing the value
  * and calling onValueChange. So we use a ref flag to trigger save in onValueChange
  * instead of in onBlur directly.
+ *
+ * VALUE SHAPE. Read and write are both a BARE NUMBER of minor units — the
+ * denomination is the field's (`options.currencyCode`), asserted once and
+ * inherited by every value. Symmetry here is load-bearing: an asymmetric shape
+ * makes `hasValueChanged` compare a number against an object, which reports a
+ * change on every blur and commits a field nobody edited.
  */
 export function CurrencyInputField() {
   const { value, trackChange, commitValue, close, isSaving, field } = usePropertyContext()
   const nav = useFieldNavigationOptional()
+  const orgCurrency = useOrgCurrency()
 
   // Capture keys while open (arrows used for increment/decrement)
   useEffect(() => {
@@ -40,23 +52,24 @@ export function CurrencyInputField() {
   // Track if we should save on the next value change (set true on blur)
   const shouldSaveRef = useRef(false)
 
-  const options: Required<CurrencyFieldOptions> = useMemo(() => {
+  const options = useMemo(() => {
     const opts = field.options as CurrencyFieldOptions | undefined
     return {
-      currencyCode: opts?.currencyCode ?? 'USD',
-      decimals: opts?.decimals ?? 2,
-      useGrouping: opts?.useGrouping ?? true,
+      currencyCode: resolveCurrencyCode(opts?.currencyCode, orgCurrency),
+      // Undefined means "derive from the code" — right for JPY (0) and KWD (3),
+      // not just USD. Only an explicit field setting overrides it.
+      decimals: opts?.decimals,
       currencyDisplay: opts?.currencyDisplay ?? 'symbol',
     }
-  }, [field.options])
+  }, [field.options, orgCurrency])
 
   /**
-   * Handle value change from CurrencyInput (value is in cents)
-   * This is called AFTER the UI component parses the value on blur
+   * Handle value change from CurrencyInput.
+   * This is called AFTER the UI component parses the value on blur.
    */
   const handleValueChange = useCallback(
-    (cents: number | undefined) => {
-      const newValue = cents ?? null
+    (next: number | undefined) => {
+      const newValue = next ?? null
       trackChange(newValue)
 
       // If blur triggered this change, save now (fire-and-forget)
@@ -97,14 +110,13 @@ export function CurrencyInputField() {
 
   return (
     <CurrencyInput
-      value={value ?? undefined}
+      value={readCurrency(value)}
       onValueChange={handleValueChange}
       currencyCode={options.currencyCode}
       currencyDisplay={options.currencyDisplay === 'compact' ? 'symbol' : options.currencyDisplay}
-      decimalPlaces={options.decimals === 0 ? 'no-decimal' : 'two-places'}
+      decimals={options.decimals}
       disabled={isSaving}>
       <InputGroup className={cn('h-[27px] ring-0! border-0', isSaving ? 'opacity-70' : '')}>
-        {/* <InputGroup> */}
         <BaseCurrencyInputField
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
@@ -113,7 +125,6 @@ export function CurrencyInputField() {
           className='text-left pl-0!'
         />
       </InputGroup>
-      {/* </InputGroup> */}
     </CurrencyInput>
   )
 }

--- a/apps/web/src/components/fields/inputs/field-input-adapter.tsx
+++ b/apps/web/src/components/fields/inputs/field-input-adapter.tsx
@@ -3,7 +3,7 @@
 
 import { FieldType } from '@auxx/database/enums'
 import type { FieldOptions } from '@auxx/lib/field-values/client'
-import { isMultiRelationship } from '@auxx/lib/field-values/client'
+import { isMultiRelationship, resolveCurrencyCode } from '@auxx/lib/field-values/client'
 import { toRecordId } from '@auxx/lib/resources/client'
 import type { ActorId } from '@auxx/types/actor'
 import {
@@ -29,6 +29,7 @@ import {
   PhoneInput,
   StringInput,
 } from '~/components/workflow/nodes/shared/node-inputs'
+import { useOrgCurrency } from '~/hooks/use-org-currency'
 import { useAccess } from '~/providers/capabilities-provider'
 import { MultiValueFieldInput } from './multi-value-input-field'
 import { NameFieldInput, type NameValue } from './name-field-input'
@@ -172,6 +173,10 @@ export function FieldInputAdapter({
   // Read at the top because the RELATIONSHIP case below is inside a `switch` —
   // a hook may not be called from there.
   const { canEditEntity } = useAccess()
+
+  // Same reason: the CURRENCY case is inside the same `switch`. A field that
+  // never picked its own code inherits the org's (field → org → USD).
+  const orgCurrency = useOrgCurrency()
 
   /**
    * Adapter for NodeInputProps onChange
@@ -544,8 +549,9 @@ export function FieldInputAdapter({
         <FocusableInputWrapper open={open} onOpenChange={onOpenChange}>
           <CurrencyInput
             {...nodeInputProps}
-            currencyCode={fieldOptions?.currencyCode ?? 'USD'}
-            decimals={fieldOptions?.decimals ?? 2}
+            currencyCode={resolveCurrencyCode(fieldOptions?.currencyCode, orgCurrency)}
+            // Undefined derives the fraction digits from the code (JPY 0, KWD 3).
+            decimals={fieldOptions?.decimals}
             currencyDisplay={
               fieldOptions?.currencyDisplay === 'compact'
                 ? 'symbol'

--- a/apps/web/src/components/fields/property-provider.test.ts
+++ b/apps/web/src/components/fields/property-provider.test.ts
@@ -76,3 +76,53 @@ describe('isOrderSensitive', () => {
     expect(isOrderSensitive({ options: { multi: 'yes' } })).toBe(false)
   })
 })
+
+/**
+ * Regression guard for the currency write storm.
+ *
+ * `input-currency` calls `setValue` on EVERY blur, edited or not, and the table's
+ * inline editor force-blurs on outside click. That is harmless only while the
+ * comparator can tell "same value" from "different value". It could not, for one
+ * turn of this branch: `toRawValue` returned `{ code?, amount }` while the input
+ * committed a bare number, so both sides fell through to the `String(...)`
+ * branch and `"20000" !== "[object Object]"` was true forever. Every currency
+ * field committed on every blur, and the store re-extracted the object right
+ * back, so it never converged.
+ *
+ * The shape is symmetric again, and `normalizeByFieldType` collapses the
+ * asymmetric types generically — ACTOR is the one that is still asymmetric by
+ * design, so it is pinned here too.
+ */
+describe('hasValueChanged — read/write-asymmetric field types', () => {
+  it('CURRENCY: the same minor-unit amount is not a change', () => {
+    expect(hasValueChanged(20_000, 20_000, false, 'CURRENCY')).toBe(false)
+  })
+
+  it('CURRENCY: a legacy { amount } object compares equal to the bare number', () => {
+    expect(hasValueChanged(20_000, { amount: 20_000 }, false, 'CURRENCY')).toBe(false)
+    expect(hasValueChanged({ amount: 20_000 }, 20_000, false, 'CURRENCY')).toBe(false)
+  })
+
+  it('CURRENCY: a genuinely different amount still reports changed', () => {
+    expect(hasValueChanged(20_001, 20_000, false, 'CURRENCY')).toBe(true)
+    expect(hasValueChanged(null, 20_000, false, 'CURRENCY')).toBe(true)
+  })
+
+  it('ACTOR: the rich read object compares equal to the committed ActorId', () => {
+    const server = { actorType: 'user', id: 'abc', actorId: 'user:abc' }
+    expect(hasValueChanged('user:abc', server, false, 'ACTOR')).toBe(false)
+    expect(hasValueChanged('user:xyz', server, false, 'ACTOR')).toBe(true)
+  })
+
+  it('ACTOR: derives the ActorId when the read object carries none', () => {
+    expect(hasValueChanged('group:g1', { actorType: 'group', id: 'g1' }, false, 'ACTOR')).toBe(
+      false
+    )
+  })
+
+  it('NAME: symmetric already — the plain-object branch answers it', () => {
+    const name = { firstName: 'Ada', lastName: 'Lovelace' }
+    expect(hasValueChanged({ ...name }, name, false, 'NAME')).toBe(false)
+    expect(hasValueChanged({ ...name, lastName: 'Byron' }, name, false, 'NAME')).toBe(true)
+  })
+})

--- a/apps/web/src/components/fields/property-provider.tsx
+++ b/apps/web/src/components/fields/property-provider.tsx
@@ -2,8 +2,9 @@
 
 import { FieldType as FieldTypeEnum } from '@auxx/database/enums'
 import type { FieldType } from '@auxx/database/types'
-import { formatToRawValue } from '@auxx/lib/field-values/client'
+import { formatToRawValue, readCurrency } from '@auxx/lib/field-values/client'
 import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
+import { toActorId } from '@auxx/types/actor'
 import {
   createContext,
   type ReactNode,
@@ -159,6 +160,51 @@ function normalizeForComparison(val: any): any {
 }
 
 /**
+ * Collapse a field value to ONE canonical shape per field type, so the two
+ * sides of a comparison are the same KIND before they are compared.
+ *
+ * Some converters are deliberately asymmetric: `toRawValue` returns a rich
+ * object (what a renderer needs) while the input commits the narrow scalar the
+ * write path wants. CURRENCY reads `{ code?, amount }` and writes a bare number;
+ * ACTOR reads `{ actorType, id, actorId }` and writes an `ActorId` string.
+ * Without this collapse the comparator falls through to `String(...)` and
+ * "20000" !== "[object Object]" reports a change on EVERY blur, so an untouched
+ * field commits forever and never converges.
+ *
+ * NAME needs nothing here — it reads and writes the same `{firstName,lastName}`
+ * object, so the plain-object branch already answers correctly.
+ */
+function normalizeByFieldType(val: any, fieldType?: FieldType | string): any {
+  if (val === null || val === undefined) return val
+  if (!fieldType) return val
+
+  if (Array.isArray(val)) return val.map((entry) => normalizeByFieldType(entry, fieldType))
+
+  switch (fieldType) {
+    // Read `{ code?, amount }` vs write bare minor units.
+    case FieldTypeEnum.CURRENCY:
+      return readCurrency(val) ?? val
+
+    // Read `{ actorType, id, actorId }` vs write an `ActorId` string.
+    case FieldTypeEnum.ACTOR: {
+      if (typeof val === 'string') return val.trim()
+      if (typeof val === 'object') {
+        const obj = val as Record<string, unknown>
+        if (typeof obj.actorId === 'string') return obj.actorId
+        const actorType = (obj.actorType ?? obj.type) as string | undefined
+        if (actorType && typeof obj.id === 'string') {
+          return toActorId(actorType as Parameters<typeof toActorId>[0], obj.id)
+        }
+      }
+      return val
+    }
+
+    default:
+      return val
+  }
+}
+
+/**
  * Check if a value has changed compared to another value
  * Handles arrays, objects, and primitives
  * Treats empty strings and null/undefined as equivalent (no change)
@@ -166,11 +212,18 @@ function normalizeForComparison(val: any): any {
  * @param orderSensitive - When true, arrays that differ only in ORDER count as
  *   changed. Required for `options.multi` scalar fields (EMAIL/URL/PHONE), where
  *   position is data: index 0 IS the primary value. See {@link isOrderSensitive}.
+ * @param fieldType - Collapses read/write-asymmetric types (CURRENCY, ACTOR) to
+ *   one canonical shape on both sides first. See {@link normalizeByFieldType}.
  */
-export function hasValueChanged(newValue: any, originalVal: any, orderSensitive = false): boolean {
+export function hasValueChanged(
+  newValue: any,
+  originalVal: any,
+  orderSensitive = false,
+  fieldType?: FieldType | string
+): boolean {
   // Normalize both values - empty strings are treated as null
-  const normalizedNew = normalizeForComparison(newValue)
-  const normalizedOrig = normalizeForComparison(originalVal)
+  const normalizedNew = normalizeForComparison(normalizeByFieldType(newValue, fieldType))
+  const normalizedOrig = normalizeForComparison(normalizeByFieldType(originalVal, fieldType))
 
   // If both are null/empty, no change
   if (normalizedNew === null && normalizedOrig === null) return false
@@ -297,7 +350,7 @@ export function PropertyProvider({
   const commitValue = useCallback(
     (newValue: any) => {
       // Check if value actually changed
-      if (!hasValueChanged(newValue, serverValue, orderSensitive)) {
+      if (!hasValueChanged(newValue, serverValue, orderSensitive, field.fieldType)) {
         setIsDirty(false)
         return
       }
@@ -385,7 +438,7 @@ export function PropertyProvider({
    * Commit current dirty value and close popover.
    */
   const commitAndClose = useCallback(() => {
-    if (isDirty && hasValueChanged(currentValue, serverValue, orderSensitive)) {
+    if (isDirty && hasValueChanged(currentValue, serverValue, orderSensitive, field.fieldType)) {
       commitValue(currentValue)
     }
     setIsOpen(false)
@@ -403,7 +456,7 @@ export function PropertyProvider({
         return
       }
 
-      if (!hasValueChanged(newValue, serverValue, orderSensitive)) {
+      if (!hasValueChanged(newValue, serverValue, orderSensitive, field.fieldType)) {
         setIsDirty(false)
         setIsOpen(false)
         isOutsideClick.current = false
@@ -445,7 +498,10 @@ export function PropertyProvider({
         !Array.isArray(newValue) &&
         Object.keys(newValue).length === 0
 
-      if (!isEmptyObject && !hasValueChanged(newValue, serverValue, orderSensitive)) {
+      if (
+        !isEmptyObject &&
+        !hasValueChanged(newValue, serverValue, orderSensitive, field.fieldType)
+      ) {
         setIsDirty(false)
         return undefined
       }
@@ -497,7 +553,7 @@ export function PropertyProvider({
    * Close the popover (cancels if dirty via Esc key)
    */
   const close = useCallback(() => {
-    if (isDirty && hasValueChanged(currentValue, serverValue, orderSensitive)) {
+    if (isDirty && hasValueChanged(currentValue, serverValue, orderSensitive, field.fieldType)) {
       // Esc key was pressed while dirty - cancel instead of save
       setCurrentValue(serverValue)
       setIsDirty(false)

--- a/apps/web/src/components/mail/email-editor/quick-action-panel.tsx
+++ b/apps/web/src/components/mail/email-editor/quick-action-panel.tsx
@@ -689,10 +689,10 @@ function QuickActionCurrencyField({
   const shouldUpdateRef = useRef(false)
 
   const handleValueChange = useCallback(
-    (cents: number | undefined) => {
+    (next: number | undefined) => {
       if (shouldUpdateRef.current) {
         shouldUpdateRef.current = false
-        onChange(cents ?? undefined)
+        onChange(next)
       }
     },
     [onChange]
@@ -716,7 +716,7 @@ function QuickActionCurrencyField({
         value={value}
         onValueChange={handleValueChange}
         currencyCode={currencyCode}
-        decimalPlaces={decimalPlaces === 0 ? 'no-decimal' : 'two-places'}
+        decimals={decimalPlaces}
         disabled={disabled}>
         <InputGroup className='h-6 text-xs'>
           <CurrencyInputField

--- a/apps/web/src/components/money/ui/line-builder/catalog-picker.tsx
+++ b/apps/web/src/components/money/ui/line-builder/catalog-picker.tsx
@@ -24,6 +24,7 @@ import {
 } from '@auxx/ui/components/command'
 import { Popover, PopoverAnchor, PopoverContent } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
+import { formatCurrency } from '@auxx/utils/currency'
 import { Boxes, Package, Plus, Settings2 } from 'lucide-react'
 import Link from 'next/link'
 import { type ReactNode, useMemo, useState } from 'react'
@@ -32,12 +33,10 @@ import type { CatalogItem } from '~/components/money/hooks/use-catalog-items'
 import { useUser } from '~/hooks/use-user'
 import { resolveCatalogGroup, resolvedCatalogGroupTotal } from './catalog-group-resolver'
 
-/** `price` is integer cents (FieldType.CURRENCY storage convention). */
+/** `price` is integer MINOR UNITS (FieldType.CURRENCY storage convention). */
 function formatPrice(price: number | null, currencyCode: string): string {
   if (price === null) return 'No price'
-  return new Intl.NumberFormat(undefined, { style: 'currency', currency: currencyCode }).format(
-    price / 100
-  )
+  return formatCurrency(price, { currencyCode })
 }
 
 function titleCase(value: string): string {

--- a/apps/web/src/components/money/ui/line-builder/shared.ts
+++ b/apps/web/src/components/money/ui/line-builder/shared.ts
@@ -3,17 +3,19 @@
 // Shared formatting helpers for the line builder cluster
 // (line-builder.tsx, totals-footer.tsx).
 
+import { formatCurrency as formatCurrencyUtil } from '@auxx/utils/currency'
+
 /**
  * Format an amount in the org currency; em dash for unpriced values.
- * `value` is INTEGER CENTS — the FieldType.CURRENCY storage convention
- * (same contract as the platform DisplayCurrency renderer).
+ *
+ * `value` is INTEGER MINOR UNITS — the FieldType.CURRENCY storage convention.
+ * Delegates the formatting itself to `@auxx/utils` so the minor-unit exponent
+ * comes from the code (JPY 0, KWD 3) rather than a hardcoded /100. The only
+ * thing this wrapper adds is the em dash: an unpriced line is not `$0.00`.
  */
 export function formatCurrency(value: number | null | undefined, currencyCode: string): string {
   if (value === null || value === undefined) return '—'
-  return new Intl.NumberFormat(undefined, {
-    style: 'currency',
-    currency: currencyCode,
-  }).format(value / 100)
+  return formatCurrencyUtil(value, { currencyCode })
 }
 
 /** Capitalize a category value for chip display ('service' → 'Service'). */

--- a/apps/web/src/components/money/ui/settings/format-money.ts
+++ b/apps/web/src/components/money/ui/settings/format-money.ts
@@ -1,14 +1,15 @@
 // apps/web/src/components/money/ui/settings/format-money.ts
 
+import { formatCurrency } from '@auxx/utils/currency'
+
 /**
- * Format a CURRENCY field value (stored in cents, see `use-catalog-items.ts`)
+ * Format a CURRENCY field value (stored in MINOR UNITS, see `use-catalog-items.ts`)
  * for display using the org's currency code (`organization.currency` setting).
+ *
+ * Scale and fraction digits come from the code via `@auxx/utils`, so a
+ * zero-exponent currency renders `¥1,000` rather than `¥10.00`.
  */
-export function formatMoney(cents: number | null | undefined, currencyCode: string): string {
-  if (cents === null || cents === undefined) return '—'
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: currencyCode,
-    minimumFractionDigits: 2,
-  }).format(cents / 100)
+export function formatMoney(minorUnits: number | null | undefined, currencyCode: string): string {
+  if (minorUnits === null || minorUnits === undefined) return '—'
+  return formatCurrency(minorUnits, { currencyCode })
 }

--- a/apps/web/src/components/pickers/currency-picker.tsx
+++ b/apps/web/src/components/pickers/currency-picker.tsx
@@ -37,6 +37,10 @@ interface CurrencyPickerProps {
   selected?: string
   onChange: (selected: string) => void
   className?: string
+  /** Disable the trigger (e.g. while the field is saving). */
+  disabled?: boolean
+  /** Trigger text when nothing is selected. Default 'Select currency...'. */
+  placeholder?: string
   align?: 'start' | 'center' | 'end'
   side?: 'top' | 'right' | 'bottom' | 'left'
   sideOffset?: number
@@ -52,6 +56,8 @@ export function CurrencyPicker({
   selected,
   onChange,
   className,
+  disabled = false,
+  placeholder = 'Select currency...',
   align = 'start',
   children,
   ...props
@@ -103,7 +109,11 @@ export function CurrencyPicker({
     <Popover open={open} onOpenChange={onOpenChange}>
       <PopoverTrigger asChild>
         {children || (
-          <Button variant='input' size='default' className='w-full justify-between'>
+          <Button
+            variant='input'
+            size='default'
+            disabled={disabled}
+            className={cn('w-full justify-between', className)}>
             {selectedCurrency ? (
               <div className='flex items-center gap-2 truncate'>
                 <span className='truncate'>{selectedCurrency.label}</span>
@@ -112,7 +122,7 @@ export function CurrencyPicker({
                 </Badge>
               </div>
             ) : (
-              <span className='text-muted-foreground'>Select currency...</span>
+              <span className='text-muted-foreground'>{placeholder}</span>
             )}
             <ChevronDown className='size-4 shrink-0 opacity-50' />
           </Button>

--- a/apps/web/src/components/workflow/nodes/shared/node-inputs/currency-input.tsx
+++ b/apps/web/src/components/workflow/nodes/shared/node-inputs/currency-input.tsx
@@ -1,5 +1,6 @@
 // apps/web/src/components/workflow/nodes/shared/node-inputs/currency-input.tsx
 
+import { readCurrency } from '@auxx/lib/field-values/client'
 import {
   CurrencyInputField,
   CurrencyInput as CurrencyInputUi,
@@ -19,7 +20,7 @@ interface CurrencyInputProps extends NodeInputProps {
   placeholder?: string
   /** ISO 4217 currency code (default: 'USD') */
   currencyCode?: string
-  /** Number of decimal places (0 or 2) */
+  /** Fraction digits to render. Omit to derive from the currency code. */
   decimals?: number
   /** How to display currency (symbol, code, name, or compact) */
   currencyDisplay?: 'symbol' | 'code' | 'name' | 'compact'
@@ -28,8 +29,11 @@ interface CurrencyInputProps extends NodeInputProps {
 }
 
 /**
- * Currency input component for workflow nodes
- * Stores value as cents (integer), displays as decimal
+ * Currency input component for workflow nodes.
+ *
+ * Stores the value as INTEGER MINOR UNITS (cents for USD, whole yen for JPY),
+ * displayed as a major-unit decimal. The denomination comes from the node's
+ * config; a value never carries its own code.
  */
 export const CurrencyInput = createNodeInput<CurrencyInputProps>(
   ({
@@ -40,32 +44,28 @@ export const CurrencyInput = createNodeInput<CurrencyInputProps>(
     name,
     placeholder = '0.00',
     currencyCode = 'USD',
-    decimals = 2,
+    decimals,
     currencyDisplay = 'symbol',
   }) => {
     // Track if we should trigger onChange after blur parsing
     const shouldUpdateRef = useRef(false)
 
-    // Get value from inputs - stored as cents
-    const rawValue = inputs[name]
-    const value =
-      rawValue !== undefined && rawValue !== null && rawValue !== ''
-        ? typeof rawValue === 'number'
-          ? rawValue
-          : parseInt(String(rawValue), 10)
-        : undefined
+    // Node inputs arrive as numbers, numeric strings, or a connector's
+    // `{ amount }`. `readCurrency` narrows all three to minor units, or null —
+    // never `NaN`, which would blank the input with no error.
+    const value = readCurrency(inputs[name])
 
     /**
      * Handle value change from CurrencyInput (value is in cents)
      */
     const handleValueChange = useCallback(
-      (cents: number | undefined) => {
+      (next: number | undefined) => {
         onError(name, null)
 
         // Only update on blur (when shouldUpdateRef is true)
         if (shouldUpdateRef.current) {
           shouldUpdateRef.current = false
-          onChange(name, cents ?? null)
+          onChange(name, next ?? null)
         }
       },
       [name, onChange, onError]
@@ -94,7 +94,7 @@ export const CurrencyInput = createNodeInput<CurrencyInputProps>(
         onValueChange={handleValueChange}
         currencyCode={currencyCode}
         currencyDisplay={currencyDisplay === 'compact' ? 'symbol' : currencyDisplay}
-        decimalPlaces={decimals === 0 ? 'no-decimal' : 'two-places'}
+        decimals={decimals}
         disabled={isLoading}>
         <InputGroup className='bg-transparent dark:bg-transparent h-[28px] shadow-none ring-0 border-0 has-[[data-slot=input-group-control]:focus-visible]:ring-[0px]'>
           <CurrencyInputField

--- a/apps/web/src/components/workflow/ui/input-editor/get-input-component.ts
+++ b/apps/web/src/components/workflow/ui/input-editor/get-input-component.ts
@@ -195,7 +195,9 @@ export function getSpecificPropsForType(
       const currency = fieldOptions?.currency
       return {
         currencyCode: currency?.currencyCode ?? 'USD',
-        decimals: currency?.decimals ?? 2,
+        // Left undefined on purpose — the input derives fraction digits from
+        // the code, which is right for JPY (0) and KWD (3) as well as USD (2).
+        decimals: currency?.decimals,
         currencyDisplay: currency?.currencyDisplay ?? 'symbol',
         useGrouping: currency?.useGrouping ?? true,
       }

--- a/apps/web/src/hooks/use-org-currency.ts
+++ b/apps/web/src/hooks/use-org-currency.ts
@@ -1,0 +1,32 @@
+// apps/web/src/hooks/use-org-currency.ts
+'use client'
+
+import { normalizeCurrencyCode } from '@auxx/lib/field-values/client'
+import { useDehydratedSettingsOptional } from '~/providers/dehydrated-state-provider'
+
+/**
+ * The organization's ISO 4217 currency code — the middle rung of a CURRENCY
+ * field's denomination chain: **field → org → USD**.
+ *
+ * A CURRENCY field that never picked its own `currencyCode` renders in this
+ * one, so changing it at `/app/dispatch/settings/general` moves every such
+ * field at once. A field that DID pick one ignores it.
+ *
+ * 🛑 Never write the result back into `field.options.currencyCode`. An absent
+ * field code means INHERIT, and it has to stay absent — stamping the resolved
+ * code (including by pre-filling a picker that then saves) pins the field and
+ * it stops following the setting forever.
+ *
+ * Reads the dehydrated settings already hydrated on page load — no fetch, no
+ * suspense, no loading state. `getAllUserSettings` seeds every catalog key with
+ * its `defaultValue` before overlaying org rows, so this is `'USD'` for an org
+ * that has never touched the setting rather than undefined.
+ *
+ * Falls back to `'USD'` outside a `DehydratedStateProvider` (tests, isolated
+ * previews) rather than throwing — a money cell should render, not crash the
+ * tree, when there is no org in scope.
+ */
+export function useOrgCurrency(): string {
+  const settings = useDehydratedSettingsOptional()
+  return normalizeCurrencyCode(settings?.['organization.currency']) ?? 'USD'
+}

--- a/apps/web/src/providers/dehydrated-state-provider.tsx
+++ b/apps/web/src/providers/dehydrated-state-provider.tsx
@@ -207,6 +207,22 @@ export function useDehydratedSettings(): Record<string, any> {
 }
 
 /**
+ * Non-throwing variant of {@link useDehydratedSettings}.
+ *
+ * Returns `null` outside a `DehydratedStateProvider` instead of throwing, for
+ * the handful of leaf renderers (table cells, hover cards) that are also
+ * mounted in tests and isolated previews where no provider exists. Callers
+ * supply their own default.
+ */
+export function useDehydratedSettingsOptional(): Record<string, any> | null {
+  const ctx = useContext(DehydratedStateContext)
+  if (!ctx) return null
+  const { organizationId, organizations } = ctx.state
+  if (!organizationId) return null
+  return organizations.find((o) => o.id === organizationId)?.settings ?? null
+}
+
+/**
  * Hook to access the current organization's dehydrated subscription.
  * Returns null when there's no subscription row (fresh org) or no current org.
  */

--- a/packages/lib/src/conditions/view-config-currency.test.ts
+++ b/packages/lib/src/conditions/view-config-currency.test.ts
@@ -1,0 +1,50 @@
+// packages/lib/src/conditions/view-config-currency.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { columnFormattingSchema, currencyFormattingSchema } from './view-config'
+
+/**
+ * A column formats money; it does not denominate it.
+ *
+ * `currencyCode` was briefly a column override, and across exponents it does not
+ * relabel the amount — it RESCALES it. `formatCurrency` derives the divisor from
+ * the code, so a USD field holding 20000 ($200.00) rendered through a JPY
+ * override reads ¥20,000 (100x high) and through KWD reads KWD 20.000 (1000x
+ * low). `decimals`, `useGrouping` and `currencyDisplay` cannot do that.
+ */
+describe('currencyFormattingSchema', () => {
+  it('does NOT admit a currencyCode', () => {
+    expect(Object.keys(currencyFormattingSchema.shape)).not.toContain('currencyCode')
+  })
+
+  it('drops a legacy stored currencyCode instead of failing to parse', () => {
+    // No data migration: Zod strips undeclared keys, so configs written before
+    // the reversal still load and shed the key on their next write.
+    const parsed = currencyFormattingSchema.parse({
+      type: 'currency',
+      currencyCode: 'JPY',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'compact',
+    })
+    expect(parsed).not.toHaveProperty('currencyCode')
+    expect(parsed).toEqual({
+      type: 'currency',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'compact',
+    })
+  })
+
+  it('leaves decimals undefined so the code drives fraction digits', () => {
+    // Undefined means "derive from the code" — 0 for JPY, 3 for KWD. Stamping a
+    // `?? 2` anywhere in the dialog round-trip freezes a JPY column at ¥1,234.00.
+    const parsed = currencyFormattingSchema.parse({ type: 'currency', useGrouping: false })
+    expect(parsed.decimals).toBeUndefined()
+  })
+
+  it('still resolves through the columnFormatting union', () => {
+    const parsed = columnFormattingSchema.parse({ type: 'currency', currencyCode: 'EUR' })
+    expect(parsed).toEqual({ type: 'currency' })
+  })
+})

--- a/packages/lib/src/conditions/view-config.ts
+++ b/packages/lib/src/conditions/view-config.ts
@@ -7,10 +7,22 @@ import { conditionGroupSchema } from './schema'
 // COLUMN FORMATTING SCHEMAS
 // ============================================================================
 
-/** Currency formatting schema */
+/**
+ * Currency formatting schema — DRAWING only.
+ *
+ * 🛑 No `currencyCode`. A column override that changes the code does not relabel
+ * the money, it RESCALES it: `formatCurrency` derives the divisor from the code,
+ * so a USD field holding 20000 ($200.00) rendered through a JPY override reads
+ * ¥20,000 (100× high) and through KWD reads KWD 20.000 (1000× low). The three
+ * keys below round or restyle a number whose magnitude is fixed; the code sits
+ * on a different axis and belongs to the field, which one answer covers for
+ * table, CSV, PDF, placeholders, totals and the editor at once.
+ *
+ * Zod strips undeclared keys, so a stored config carrying a legacy
+ * `currencyCode` still parses and sheds it on the next write.
+ */
 export const currencyFormattingSchema = z.object({
   type: z.literal('currency'),
-  currencyCode: z.string().optional(),
   decimals: z.number().int().min(0).max(10).optional(),
   useGrouping: z.boolean().optional(),
   currencyDisplay: z.enum(['symbol', 'code', 'name', 'compact']).optional(),

--- a/packages/lib/src/custom-fields/check-unique-value-typed.ts
+++ b/packages/lib/src/custom-fields/check-unique-value-typed.ts
@@ -89,8 +89,10 @@ export async function checkUniqueValueTyped(
       )
       break
     case 'json':
-      // JSON fields are not typically unique, but support it anyway
-      valueCondition = sql`${schema.FieldValue.valueJson}::text = ${JSON.stringify(value.value)}`
+      // JSON fields are not typically unique, but support it anyway.
+      // `valueJson` is an envelope — compare `->'v'` (the value), and compare it
+      // as jsonb rather than ::text so key order does not decide equality.
+      valueCondition = sql`${schema.FieldValue.valueJson}->'v' = ${JSON.stringify(value.value)}::jsonb`
       break
   }
 

--- a/packages/lib/src/custom-fields/defaults.ts
+++ b/packages/lib/src/custom-fields/defaults.ts
@@ -27,10 +27,16 @@ export const DEFAULT_NUMBER_OPTIONS: NumberFieldOptions = {
   suffix: '',
 }
 
-/** Default options for CURRENCY fields */
+/**
+ * Default options for CURRENCY fields.
+ *
+ * `decimals` is deliberately ABSENT: undefined means "derive from the currency
+ * code", which is 0 for JPY and 3 for KWD, not 2. `currencyCode` is the
+ * last-resort rung only — a real field leaves it unset and inherits
+ * `organization.currency` (see `field-values/org-currency.ts`).
+ */
 export const DEFAULT_CURRENCY_OPTIONS: CurrencyFieldOptions = {
   currencyCode: 'USD',
-  decimals: 2,
   useGrouping: true,
   currencyDisplay: 'symbol',
 }

--- a/packages/lib/src/custom-fields/field-options.ts
+++ b/packages/lib/src/custom-fields/field-options.ts
@@ -68,6 +68,14 @@ export interface FieldOptions {
   // ─────────────────────────────────────────────────────────────
   // CURRENCY (flat — `decimals` and `useGrouping` are shared with NUMBER)
   // ─────────────────────────────────────────────────────────────
+  /**
+   * ISO 4217 code this field is denominated in. Asserted ONCE, on the field —
+   * there is deliberately no per-value override. `valueNumber` holds minor
+   * units in this denomination, so it is what SQL sorts, filters and sums; a
+   * per-row code would mix exponents inside a single SUM with no error. A
+   * genuinely multi-currency model pairs an amount field with its own currency
+   * field and an FX-converted base-currency field.
+   */
   currencyCode?: string
   currencyDisplay?: 'symbol' | 'code' | 'name' | 'compact'
 

--- a/packages/lib/src/data-migrations/migrations/096-currency-minor-units.ts
+++ b/packages/lib/src/data-migrations/migrations/096-currency-minor-units.ts
@@ -1,0 +1,239 @@
+// packages/lib/src/data-migrations/migrations/096-currency-minor-units.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { sql } from 'drizzle-orm'
+import { DisplayFieldService } from '../../field-values/display-field-service'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-096')
+
+/**
+ * Bring CURRENCY values onto one convention — integer minor units — and give
+ * `FieldValue.valueJson` a single unambiguous shape.
+ * (`plans/currency/06-per-value-metadata.md`, `07-value-implementation-steps.md`)
+ *
+ * FOUR ORDERED STEPS, one migration because they are one change and the order
+ * between them matters:
+ *
+ *   1. Wrap json-typed values into the `{ v, meta }` envelope.
+ *   2. Re-home the AI metadata bag under `meta.ai`.
+ *   3. Rescale Shopify-owned CURRENCY values from decimal dollars to minor units.
+ *   4. Recompute persisted display values for CURRENCY display fields.
+ *
+ * Step 4 MUST follow step 3: recompute first and the Shopify rows get rendered
+ * from data still in dollars, needing a second pass.
+ *
+ * Every step is individually idempotent, so re-running the whole migration is a
+ * no-op rather than a double-application. That is load-bearing, not incidental:
+ * a combined migration has one ledger id, so a partial failure re-runs the
+ * steps that already succeeded.
+ *
+ * Raw Drizzle on purpose — data migrations do not use the `ensure*` entity
+ * helpers.
+ */
+export const migration096CurrencyMinorUnits: DataMigrationDef = {
+  id: '096-currency-minor-units',
+  description:
+    'Wrap valueJson in the { v, meta } envelope, re-home AI metadata, rescale Shopify currency to minor units, recompute currency display values',
+  async run(db: Database): Promise<void> {
+    // ───────────────────────────────────────────────────────────────────────
+    // Step 1 — wrap json-typed values into the envelope
+    //
+    // `valueJson` had two owners and no discriminator: the VALUE for json-typed
+    // fields, and the AI metadata bag for any type carrying `aiStatus`. That was
+    // safe only because no AI-eligible field type writes its own value there — a
+    // coincidence of the type roster, not an invariant, and `applyAiMarker`
+    // replaced the whole column.
+    //
+    // 🛑 Five raw-SQL readers resolve the value out of `valueJson` (search-text's
+    // NAME/ADDRESS key lists, FILE remove, the thumbnail callback, the uniqueness
+    // check, json filters). A root read on an enveloped row — or an envelope read
+    // on a root-shaped one — returns NULL rather than raising. Those are the only
+    // failures in this change that are both silent and typecheck-clean.
+    // ───────────────────────────────────────────────────────────────────────
+
+    // The two owners must be disjoint: a row that is both json-typed AND
+    // AI-marked would be wrapped as a value by step 1 and as metadata by step 2,
+    // destroying one of them. That disjointness is exactly the coincidence the
+    // envelope exists to stop relying on, so assert it rather than assume it.
+    const overlap = await db.execute<{ count: number }>(sql`
+      SELECT count(*)::int AS count
+      FROM "FieldValue" fv
+      JOIN "CustomField" cf ON cf."id" = fv."fieldId"
+      WHERE fv."valueJson" IS NOT NULL
+        AND fv."aiStatus" IS NOT NULL
+        AND cf."type" IN ('FILE', 'NAME', 'ADDRESS_STRUCT', 'JSON')
+    `)
+    const overlapCount = overlap.rows[0]?.count ?? 0
+    if (overlapCount > 0) {
+      throw new Error(
+        `[096] ${overlapCount} FieldValue row(s) are BOTH json-typed and AI-marked. ` +
+          'The value and the AI bag are sharing one column with no discriminator, so ' +
+          'neither step can wrap them without destroying one of them. ' +
+          'Resolve these rows by hand before re-running.'
+      )
+    }
+
+    // Skips rows already carrying `v`/`meta`, so a re-run cannot double-wrap
+    // into `{ v: { v: … } }`.
+    const wrapped = await db.execute<{ id: string }>(sql`
+      UPDATE "FieldValue" fv
+      SET "valueJson" = jsonb_build_object('v', fv."valueJson")
+      FROM "CustomField" cf
+      WHERE cf."id" = fv."fieldId"
+        AND fv."valueJson" IS NOT NULL
+        AND cf."type" IN ('FILE', 'NAME', 'ADDRESS_STRUCT', 'JSON')
+        AND NOT (fv."valueJson" ? 'v' OR fv."valueJson" ? 'meta')
+      RETURNING fv."id"
+    `)
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Step 2 — re-home the AI metadata bag under `meta.ai`
+    //
+    // Scoped by `aiStatus IS NOT NULL`, which is precisely what `readAiMetadata`
+    // gates on: a row with no `aiStatus` never had its `valueJson` read as an AI
+    // bag, so there is nothing to move.
+    // ───────────────────────────────────────────────────────────────────────
+    const rehomed = await db.execute<{ id: string }>(sql`
+      UPDATE "FieldValue"
+      SET "valueJson" = jsonb_build_object('meta', jsonb_build_object('ai', "valueJson"))
+      WHERE "aiStatus" IS NOT NULL
+        AND "valueJson" IS NOT NULL
+        AND NOT ("valueJson" ? 'v' OR "valueJson" ? 'meta')
+      RETURNING "id"
+    `)
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Step 3 — rescale Shopify CURRENCY values to minor units
+    //
+    // Shopify reports money as a decimal string ("49.99"). The connector's
+    // `ConnectorFieldDecl` is a JSON path with no transform channel, so the
+    // projection passed those through untouched and they landed in `valueNumber`
+    // as dollars — in a column every other reader treats as minor units.
+    //
+    // Scope is the DEF, not `managedByConnectorId`: that column is NULL on every
+    // one of these rows, so it does not identify connector-written data.
+    //
+    // 🛑 The app-side fix (`decimalToMinorUnits` in the auxxai-apps Shopify
+    // connector) must be deployed in the same window. The connector write path is
+    // a DELETE+INSERT replace, so a sync from the old app re-writes dollars over
+    // the rescaled values.
+    // ───────────────────────────────────────────────────────────────────────
+    const scope = sql`
+      fv."valueNumber" IS NOT NULL
+      AND cf."type" = 'CURRENCY'
+      AND ed."apiSlug" LIKE 'shopify\\_%'
+    `
+
+    const survey = await db.execute<{ total: number; fractional: number }>(sql`
+      SELECT
+        count(*)::int AS total,
+        count(*) FILTER (WHERE fv."valueNumber" <> trunc(fv."valueNumber"))::int AS fractional
+      FROM "FieldValue" fv
+      JOIN "CustomField" cf ON cf."id" = fv."fieldId"
+      JOIN "EntityDefinition" ed ON ed."id" = cf."entityDefinitionId"
+      WHERE ${scope}
+    `)
+    const total = survey.rows[0]?.total ?? 0
+    const fractional = survey.rows[0]?.fractional ?? 0
+
+    let rescaled = 0
+    if (total === 0) {
+      logger.info('No Shopify CURRENCY values in scope — nothing to rescale')
+    } else if (fractional === 0) {
+      // A fractional value is definitive evidence the data is still in major
+      // units — minor units are integers for every ISO currency. With none, this
+      // cannot distinguish "already converted" from "a store whose prices happen
+      // to be round", so it refuses instead of risking a 100x over-scale.
+      logger.warn(
+        'Every Shopify CURRENCY value in scope is already a whole number — REFUSING to rescale. ' +
+          'Expected on a re-run; otherwise verify by hand.',
+        { total }
+      )
+    } else {
+      const result = await db.execute<{ id: string }>(sql`
+        UPDATE "FieldValue" fv
+        SET "valueNumber" = round(fv."valueNumber" * 100)
+        FROM "CustomField" cf, "EntityDefinition" ed
+        WHERE cf."id" = fv."fieldId"
+          AND ed."id" = cf."entityDefinitionId"
+          AND ${scope}
+        RETURNING fv."id"
+      `)
+      rescaled = result.rows.length
+    }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // Step 4 — recompute persisted CURRENCY display values
+    //
+    // `currencyConverter.toDisplayValue` used to do `Math.round(num * 100)`
+    // before handing the value to `formatCurrency`, which divides by 100 — the
+    // two cancel, so it rendered stored minor units as if they were major units.
+    // `display-field-service` writes that string into a real column, so the
+    // 100x-high text is DENORMALIZED INTO THE DATABASE and does not self-heal
+    // when the converter is fixed.
+    //
+    // Idempotent by construction: rewrites each column from the current field
+    // values rather than transforming the stored text.
+    // ───────────────────────────────────────────────────────────────────────
+    const targets = await db.execute<{
+      organizationId: string
+      entityDefinitionId: string
+      isPrimary: boolean
+      isSecondary: boolean
+    }>(sql`
+      SELECT
+        ed."organizationId"                            AS "organizationId",
+        ed."id"                                        AS "entityDefinitionId",
+        bool_or(cf."id" = ed."primaryDisplayFieldId")   AS "isPrimary",
+        bool_or(cf."id" = ed."secondaryDisplayFieldId") AS "isSecondary"
+      FROM "EntityDefinition" ed
+      JOIN "CustomField" cf
+        ON cf."id" IN (ed."primaryDisplayFieldId", ed."secondaryDisplayFieldId")
+      WHERE cf."type" = 'CURRENCY'
+        AND ed."archivedAt" IS NULL
+      GROUP BY ed."organizationId", ed."id"
+    `)
+
+    let recomputed = 0
+    let failed = 0
+    for (const target of targets.rows) {
+      const displayFieldTypes: ('primary' | 'secondary')[] = []
+      if (target.isPrimary) displayFieldTypes.push('primary')
+      if (target.isSecondary) displayFieldTypes.push('secondary')
+
+      try {
+        const service = new DisplayFieldService(target.organizationId, db)
+        await service.recalculateDisplayFields(target.entityDefinitionId, displayFieldTypes)
+        recomputed += 1
+      } catch (error) {
+        // One definition failing must not strand the rest — the remaining defs
+        // still carry 100x-high text. Count and report instead of aborting.
+        failed += 1
+        logger.error('Failed to recompute display values for entity definition', {
+          entityDefinitionId: target.entityDefinitionId,
+          organizationId: target.organizationId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+
+    logger.info('Currency minor-units migration complete', {
+      wrapped: wrapped.rows.length,
+      aiRehomed: rehomed.rows.length,
+      shopifyRescaled: rescaled,
+      displayDefinitions: targets.rows.length,
+      displayRecomputed: recomputed,
+      displayFailed: failed,
+    })
+
+    if (failed > 0) {
+      throw new Error(
+        `[096] ${failed} of ${targets.rows.length} entity definition(s) failed to recompute. ` +
+          'Their displayName/secondaryDisplayValue still hold 100x-high currency text. ' +
+          'Every other step already succeeded and is idempotent, so a re-run is safe.'
+      )
+    }
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -60,6 +60,7 @@ import { migration092ReseedPlatformProvidersMetaGlobal } from './migrations/092-
 import { migration093BackfillSocialWebhookRouteKey } from './migrations/093-backfill-social-webhook-route-key'
 import { migration094StripeAccountCutover } from './migrations/094-stripe-account-cutover'
 import { migration095DropIfElseCaseLegacyId } from './migrations/095-drop-if-else-case-legacy-id'
+import { migration096CurrencyMinorUnits } from './migrations/096-currency-minor-units'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -146,6 +147,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration093BackfillSocialWebhookRouteKey,
     migration094StripeAccountCutover,
     migration095DropIfElseCaseLegacyId,
+    migration096CurrencyMinorUnits,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/field-values/__tests__/currency-converter.test.ts
+++ b/packages/lib/src/field-values/__tests__/currency-converter.test.ts
@@ -1,0 +1,164 @@
+// packages/lib/src/field-values/__tests__/currency-converter.test.ts
+
+import type { NumberFieldValue } from '@auxx/types/field-value'
+import { describe, expect, it } from 'vitest'
+import {
+  currencyConverter,
+  normalizeCurrencyCode,
+  readCurrency,
+  resolveCurrencyCode,
+} from '../converters/currency'
+
+function typed(value: number): NumberFieldValue {
+  return { type: 'number', value } as NumberFieldValue
+}
+
+describe('currencyConverter.toRawValue', () => {
+  it('returns a BARE NUMBER of minor units, unscaled', () => {
+    expect(currencyConverter.toRawValue(typed(3229))).toBe(3229)
+  })
+
+  it('passes a bare number straight through', () => {
+    expect(currencyConverter.toRawValue(2000)).toBe(2000)
+  })
+
+  it('is SYMMETRIC with what the input commits', () => {
+    // Load-bearing, not cosmetic. When the read shape was `{ code?, amount }`
+    // and the write shape a bare number, `hasValueChanged` compared "20000"
+    // against "[object Object]" and reported a change on every blur — so an
+    // untouched field committed forever and never converged. It also turned
+    // every `=== null`, `> 0` and `+` downstream into a silent wrong answer.
+    const raw = currencyConverter.toRawValue(typed(20_000))
+    expect(typeof raw).toBe('number')
+    expect(currencyConverter.toTypedInput(raw)).toEqual({ type: 'number', value: 20_000 })
+  })
+
+  it('returns null rather than NaN for an unreadable value', () => {
+    expect(currencyConverter.toRawValue(null)).toBeNull()
+    expect(currencyConverter.toRawValue({ nope: 1 })).toBeNull()
+  })
+})
+
+describe('currencyConverter.toTypedInput', () => {
+  it('accepts a bare number', () => {
+    expect(currencyConverter.toTypedInput(10_000)).toEqual({ type: 'number', value: 10_000 })
+  })
+
+  it('accepts a numeric string without rescaling it', () => {
+    expect(currencyConverter.toTypedInput('2000')).toEqual({ type: 'number', value: 2000 })
+  })
+
+  it('IGNORES a currency code on the input — a value never carries one', () => {
+    // The denomination is the field's. A per-row code would let one column mix
+    // exponents inside a single SUM, sort and range filter, silently.
+    expect(currencyConverter.toTypedInput({ amount: 3229, currency: 'eur' })).toEqual({
+      type: 'number',
+      value: 3229,
+    })
+    expect(currencyConverter.toTypedInput({ code: 'JPY', amount: 500 })).toEqual({
+      type: 'number',
+      value: 500,
+    })
+  })
+
+  it('NEVER converts units — 600 stays 600, whatever it might have meant', () => {
+    // 600 could be $6.00 or $600 and the converter cannot know. Guessing is what
+    // produced 100x-wrong stored data.
+    expect(currencyConverter.toTypedInput(600)).toEqual({ type: 'number', value: 600 })
+  })
+
+  it('round-trips its own toRawValue output', () => {
+    const raw = currencyConverter.toRawValue(typed(3229))
+    expect(currencyConverter.toTypedInput(raw)).toEqual({ type: 'number', value: 3229 })
+  })
+})
+
+describe('currencyConverter.toDisplayValue', () => {
+  it('renders minor units without the historical 100x inflation', () => {
+    // The bug: toDisplayValue used to do Math.round(num * 100) before handing
+    // the value to formatCurrency, which divides by 100 — so 2000 rendered as
+    // $2,000.00 in every CSV, PDF and persisted display column.
+    expect(currencyConverter.toDisplayValue(typed(2000), { currencyCode: 'USD' })).toBe('$20.00')
+  })
+
+  it("takes the code from the FIELD's options", () => {
+    const out = currencyConverter.toDisplayValue(typed(2000), { currencyCode: 'EUR' })
+    expect(out).toContain('20.00')
+    expect(out).not.toContain('$')
+  })
+
+  it('derives fraction digits from the code when the field pins none', () => {
+    expect(currencyConverter.toDisplayValue(typed(100_000), { currencyCode: 'JPY' })).toBe(
+      '¥100,000'
+    )
+  })
+
+  it('falls back to USD for a malformed field code rather than throwing', () => {
+    expect(currencyConverter.toDisplayValue(typed(2000), { currencyCode: 'DOLLARS' })).toBe(
+      '$20.00'
+    )
+  })
+})
+
+describe('readCurrency', () => {
+  it('narrows the shapes that actually reach a render site', () => {
+    expect(readCurrency(2000)).toBe(2000)
+    expect(readCurrency('2000')).toBe(2000)
+    expect(readCurrency({ amount: 2000 })).toBe(2000)
+  })
+
+  it('returns null — an empty cell — rather than NaN', () => {
+    for (const bad of [null, undefined, '', 'abc', {}, { amount: 'x' }, Number.NaN]) {
+      expect(readCurrency(bad)).toBeNull()
+    }
+  })
+})
+
+describe('normalizeCurrencyCode', () => {
+  it('uppercases and validates ISO 4217 shape', () => {
+    expect(normalizeCurrencyCode('usd')).toBe('USD')
+    expect(normalizeCurrencyCode(' eur ')).toBe('EUR')
+  })
+
+  it('rejects anything that is not three letters', () => {
+    for (const bad of ['US', 'USDD', 'US1', '', 'DOLLARS', 42, null, undefined, {}]) {
+      expect(normalizeCurrencyCode(bad)).toBeNull()
+    }
+  })
+})
+
+/**
+ * The org rung: field → org → USD.
+ *
+ * `organization.currency` already resolves to 'USD' for every org without a
+ * settings row (`getAllUserSettings` seeds each catalog key from its
+ * `defaultValue`), so this rung is a no-op until someone changes the setting —
+ * and then it has to move every field that never picked a code, and no others.
+ */
+describe('resolveCurrencyCode', () => {
+  it('prefers the FIELD code over the org', () => {
+    expect(resolveCurrencyCode('EUR', 'JPY')).toBe('EUR')
+  })
+
+  it('falls back to the ORG code when the field asserted none', () => {
+    // This is the case that makes the setting worth having: the ~213 fields
+    // that never picked a code follow the org and move with it.
+    expect(resolveCurrencyCode(undefined, 'JPY')).toBe('JPY')
+    expect(resolveCurrencyCode(null, 'EUR')).toBe('EUR')
+  })
+
+  it('falls back to USD when neither asserts one', () => {
+    expect(resolveCurrencyCode(undefined, undefined)).toBe('USD')
+  })
+
+  it('normalizes case and whitespace at either rung', () => {
+    expect(resolveCurrencyCode('  eur ', undefined)).toBe('EUR')
+    expect(resolveCurrencyCode(undefined, 'jpy')).toBe('JPY')
+  })
+
+  it('falls THROUGH a malformed code rather than blanking the cell', () => {
+    // A bad setting must not take out every money cell in the org.
+    expect(resolveCurrencyCode('DOLLARS', 'EUR')).toBe('EUR')
+    expect(resolveCurrencyCode(undefined, 'DOLLARS')).toBe('USD')
+  })
+})

--- a/packages/lib/src/field-values/__tests__/org-currency.test.ts
+++ b/packages/lib/src/field-values/__tests__/org-currency.test.ts
@@ -1,0 +1,42 @@
+// packages/lib/src/field-values/__tests__/org-currency.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { withOrgCurrency } from '../org-currency'
+
+describe('withOrgCurrency', () => {
+  it('layers the org code under a CURRENCY field that picked none', () => {
+    expect(withOrgCurrency({ decimals: undefined }, 'CURRENCY', 'EUR')).toEqual({
+      decimals: undefined,
+      currencyCode: 'EUR',
+    })
+  })
+
+  it('leaves a field that DID pick a code alone', () => {
+    expect(withOrgCurrency({ currencyCode: 'JPY' }, 'CURRENCY', 'EUR')).toEqual({
+      currencyCode: 'JPY',
+    })
+  })
+
+  it('is a no-op for every other field type', () => {
+    // Display paths wrap unconditionally rather than branching per call site,
+    // so a NUMBER or TEXT field must come back untouched — including the same
+    // absent-vs-present key set.
+    const numberOptions = { decimals: 2, useGrouping: true }
+    expect(withOrgCurrency(numberOptions, 'NUMBER', 'EUR')).toBe(numberOptions)
+    expect(withOrgCurrency(undefined, 'TEXT', 'EUR')).toBeUndefined()
+  })
+
+  it('resolves to USD when the org code is missing or malformed', () => {
+    expect(withOrgCurrency({}, 'CURRENCY', undefined)).toEqual({ currencyCode: 'USD' })
+    expect(withOrgCurrency({}, 'CURRENCY', 'DOLLARS')).toEqual({ currencyCode: 'USD' })
+  })
+
+  it('never mutates the options it was handed', () => {
+    // The resolved code must not leak back into `field.options` — that is what
+    // would pin a field and stop it following the setting.
+    const options = { decimals: 0 }
+    withOrgCurrency(options, 'CURRENCY', 'EUR')
+    expect(options).toEqual({ decimals: 0 })
+    expect(options).not.toHaveProperty('currencyCode')
+  })
+})

--- a/packages/lib/src/field-values/__tests__/search-text.test.ts
+++ b/packages/lib/src/field-values/__tests__/search-text.test.ts
@@ -89,13 +89,21 @@ describe('searchTextExpressionSql', () => {
   const expression = searchTextExpressionSql('ei')
 
   it('reads valueJson only through the two closed-shape key allowlists', () => {
-    const jsonReads = expression.match(/fv\."valueJson"->>'(\w+)'/g) ?? []
+    // `valueJson` is the `{ v, meta }` envelope — every value read goes through
+    // `->'v'`. Reading the root would return NULL, silently and typecheck-clean.
+    const jsonReads = expression.match(/fv\."valueJson"->'v'->>'(\w+)'/g) ?? []
     const keys = jsonReads.map((m) => m.replace(/.*->>'(\w+)'/, '$1'))
 
     expect(keys.length).toBeGreaterThan(0)
     expect(new Set(keys)).toEqual(new Set(['firstName', 'lastName', ...SEARCH_TEXT_ADDRESS_KEYS]))
     // No blanket serialization of the document.
     expect(expression).not.toMatch(/fv\."valueJson"(::text|#>>|\s*::\s*text)/)
+  })
+
+  it('never reads a value at the envelope root', () => {
+    // A root read is the pre-envelope shape: it yields NULL for every row the
+    // migration wrapped, and nothing type-checks it.
+    expect(expression).not.toMatch(/fv\."valueJson"->>'/)
   })
 
   it('never reads geo coordinates out of a structured address', () => {

--- a/packages/lib/src/field-values/ai-autofill/input-hash.ts
+++ b/packages/lib/src/field-values/ai-autofill/input-hash.ts
@@ -7,7 +7,7 @@ import type { ResolvedReference } from './reference-resolver'
 /**
  * Compute a stable content hash over the resolved prompt inputs. Used for
  * stale detection: the cell overlay re-hashes on render and compares to
- * `valueJson.inputHash`; mismatch + `aiStatus='result'` means the source
+ * `valueJson.meta.ai.inputHash`; mismatch + `aiStatus='result'` means the source
  * inputs changed since the last generation.
  *
  * Hash inputs:

--- a/packages/lib/src/field-values/ai-commit.ts
+++ b/packages/lib/src/field-values/ai-commit.ts
@@ -7,6 +7,7 @@ import {
 } from '@auxx/services/field-values'
 import type { FieldId } from '@auxx/types/field'
 import { buildFieldValueKey } from '@auxx/types/field'
+import { mergeMeta, readMeta } from '@auxx/types/field-value'
 import { parseRecordId, type RecordId } from '@auxx/types/resource'
 import { generateKeyBetween } from '@auxx/utils/fractional-indexing'
 import { getRealtimeService } from '../realtime'
@@ -20,13 +21,18 @@ export type AiWriteState = 'generating' | 'result' | 'error'
 /**
  * Merge an AI marker onto a partial insert/update row builder. Used inside
  * `buildFieldValueRow` when `SetValueWithTypeInput.aiGeneration` is present.
+ *
+ * MERGES into `meta.ai` rather than replacing `valueJson`. The replacing form
+ * was safe only because no AI-eligible field type wrote its own value to
+ * `valueJson` — a coincidence of the type roster, not an invariant, and one
+ * line away from silently deleting user values.
  */
 export function applyAiMarker<T extends Record<string, unknown>>(
   row: T,
   meta: AiValueMetadata,
   state: AiWriteState = 'result'
 ): T & { aiStatus: AiWriteState; valueJson: unknown } {
-  return { ...row, aiStatus: state, valueJson: meta as unknown }
+  return { ...row, aiStatus: state, valueJson: mergeMeta(row.valueJson, 'ai', meta) }
 }
 
 /**
@@ -38,7 +44,7 @@ export function readAiMetadata(row: {
   valueJson?: unknown
 }): AiValueMetadata | null {
   if (!row.aiStatus) return null
-  return (row.valueJson ?? null) as AiValueMetadata | null
+  return (readMeta(row.valueJson).ai ?? null) as AiValueMetadata | null
 }
 
 /**
@@ -63,7 +69,7 @@ export async function writeAiError(
   if (existing.isErr() || !existing.value) return
 
   const failedAt = new Date().toISOString()
-  const prev = (existing.value.valueJson ?? {}) as Record<string, unknown>
+  const prev = (readMeta(existing.value.valueJson).ai ?? {}) as Record<string, unknown>
 
   // Drop metadata that belonged to the prior successful generation, keep
   // any unrelated keys future v2 types may add to valueJson.
@@ -77,13 +83,13 @@ export async function writeAiError(
     ...rest
   } = prev
 
-  const nextValueJson = { ...rest, errorMessage: params.errorMessage, failedAt }
+  const nextAi = { ...rest, errorMessage: params.errorMessage, failedAt }
 
   await updateAiMarker({
     id: existing.value.id,
     organizationId: ctx.organizationId,
     aiStatus: 'error',
-    valueJson: nextValueJson,
+    valueJson: mergeMeta(existing.value.valueJson, 'ai', nextAi),
   })
 
   const key = buildFieldValueKey(params.recordId, params.fieldId as FieldId)
@@ -123,7 +129,7 @@ export async function upsertGeneratingMarker(
     organizationId: ctx.organizationId,
   })
 
-  const valueJson: AiValueMetadata = {
+  const ai: AiValueMetadata = {
     jobId: params.jobId,
     requestedAt: params.requestedAt,
   }
@@ -133,7 +139,8 @@ export async function upsertGeneratingMarker(
       id: existing.value.id,
       organizationId: ctx.organizationId,
       aiStatus: 'generating',
-      valueJson,
+      // Merge: this row may already carry a value in `v` or another owner's meta key.
+      valueJson: mergeMeta(existing.value.valueJson, 'ai', ai),
     })
     return
   }
@@ -144,6 +151,6 @@ export async function upsertGeneratingMarker(
     organizationId: ctx.organizationId,
     sortKey: generateKeyBetween(null, null),
     aiStatus: 'generating',
-    valueJson,
+    valueJson: mergeMeta(null, 'ai', ai),
   })
 }

--- a/packages/lib/src/field-values/ai-enqueue.ts
+++ b/packages/lib/src/field-values/ai-enqueue.ts
@@ -5,6 +5,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { getExistingFieldValue } from '@auxx/services/field-values'
 import type { FieldId } from '@auxx/types/field'
 import { buildFieldValueKey } from '@auxx/types/field'
+import { readMeta } from '@auxx/types/field-value'
 import { parseRecordId, type RecordId } from '@auxx/types/resource'
 import { generateId } from '@auxx/utils/generateId'
 import { isAiField } from '../custom-fields/ai'
@@ -61,7 +62,10 @@ export async function shortCircuitAiGenerate(
   })
 
   if (existing.isOk() && existing.value?.aiStatus === 'generating') {
-    const meta = (existing.value.valueJson ?? {}) as { jobId?: string; requestedAt?: string }
+    const meta = (readMeta(existing.value.valueJson).ai ?? {}) as {
+      jobId?: string
+      requestedAt?: string
+    }
     const requestedAtMs = meta.requestedAt ? Date.parse(meta.requestedAt) : 0
     const isStale = !requestedAtMs || Date.now() - requestedAtMs > STALE_GENERATING_MS
     if (!isStale && meta.jobId) {

--- a/packages/lib/src/field-values/calc-resolver.ts
+++ b/packages/lib/src/field-values/calc-resolver.ts
@@ -8,6 +8,7 @@ import { getCalcOptions, getEffectiveFieldType } from '../custom-fields/calc'
 import { type FieldValueContext, getField } from './field-value-helpers'
 import { batchGetValues } from './field-value-queries'
 import { formatToDisplayValue, formatToTypedInput } from './formatter'
+import { getOrgCurrencyCode, withOrgCurrency } from './org-currency'
 
 /** Hard cap on CALC → CALC recursion depth. */
 const MAX_CALC_DEPTH = 5
@@ -105,8 +106,18 @@ export async function resolveCalcForRecord(
   // through the converters means future converter changes (e.g. a new
   // currency format option) flow into CALC display automatically.
   const typed = formatToTypedInput(computed, resultFieldType)
+  // A CALC whose result type is CURRENCY inherits the org's denomination just
+  // like a stored CURRENCY field does.
+  const options =
+    resultFieldType === 'CURRENCY'
+      ? withOrgCurrency(
+          field.options as never,
+          'CURRENCY',
+          await getOrgCurrencyCode(ctx.organizationId, ctx.db)
+        )
+      : ((field.options ?? undefined) as never)
   const formatted = typed
-    ? formatToDisplayValue(typed as never, resultFieldType, (field.options ?? undefined) as never)
+    ? formatToDisplayValue(typed as never, resultFieldType, options as never)
     : null
   const display =
     formatted === null || formatted === undefined

--- a/packages/lib/src/field-values/client.ts
+++ b/packages/lib/src/field-values/client.ts
@@ -18,6 +18,9 @@ export {
 // Converters (for direct access if needed)
 export { converters, type FileValue } from './converters'
 
+// Currency value narrowing — shared by every render/edit surface
+export { normalizeCurrencyCode, readCurrency, resolveCurrencyCode } from './converters/currency'
+
 // Re-export relationship type guards from converter (centralized location)
 export {
   isRelationshipFieldValue,

--- a/packages/lib/src/field-values/converters/currency.ts
+++ b/packages/lib/src/field-values/converters/currency.ts
@@ -1,0 +1,180 @@
+// packages/lib/src/field-values/converters/currency.ts
+
+import type {
+  NumberFieldValue,
+  TypedFieldValue,
+  TypedFieldValueInput,
+} from '@auxx/types/field-value'
+import { formatCurrency } from '@auxx/utils/currency'
+import { DEFAULT_CURRENCY_OPTIONS } from '../../custom-fields/defaults'
+import type { FieldOptions, FieldValueConverter } from './index'
+
+const ISO_4217 = /^[A-Z]{3}$/
+
+/** Last-resort code when neither the field nor the org asserts one. */
+const FALLBACK_CODE = DEFAULT_CURRENCY_OPTIONS.currencyCode ?? 'USD'
+
+/**
+ * Normalise an ISO 4217 code, or return null when it is absent/malformed.
+ *
+ * Used for FIELD OPTIONS, never for a per-value code — a CURRENCY value does
+ * not carry one. A malformed field option just falls through to the fallback.
+ */
+export function normalizeCurrencyCode(code: unknown): string | null {
+  if (typeof code !== 'string') return null
+  const upper = code.trim().toUpperCase()
+  return ISO_4217.test(upper) ? upper : null
+}
+
+/**
+ * Resolve the denomination for a CURRENCY field: **field → org → USD**.
+ *
+ * 🛑 An ABSENT `field.options.currencyCode` means INHERIT, and must stay
+ * distinguishable from an asserted one. That is the whole point of the org
+ * rung: the ~213 fields that never picked a code follow `organization.currency`
+ * and move with it, while a field that DID pick one is pinned. Stamping the
+ * resolved code back onto the field — in a cache, a default, or a pre-filled
+ * editor that then saves — collapses the two and freezes those fields forever.
+ *
+ * A malformed code at either rung falls through rather than throwing: a bad
+ * setting should not blank every money cell in the org.
+ */
+export function resolveCurrencyCode(fieldCurrencyCode: unknown, orgCurrencyCode?: unknown): string {
+  return (
+    normalizeCurrencyCode(fieldCurrencyCode) ??
+    normalizeCurrencyCode(orgCurrencyCode) ??
+    FALLBACK_CODE
+  )
+}
+
+/** Coerce an unknown to a finite number, or null. Never scales. */
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  if (typeof value === 'string') {
+    const cleaned = value.replace(/[$€£¥₹₩,\s]/g, '').trim()
+    if (cleaned === '') return null
+    const num = Number.parseFloat(cleaned)
+    return Number.isFinite(num) ? num : null
+  }
+  return null
+}
+
+/**
+ * Converter for the CURRENCY field type.
+ *
+ * Storage and shape are exactly NUMBER's — the integer minor-unit amount lives
+ * in `valueNumber`, which is what SQL sorts, filters and aggregates on. CURRENCY
+ * differs from NUMBER only in how it is DRAWN.
+ *
+ * 🛑 A value carries NO currency code. The denomination is the field's
+ * (`options.currencyCode`), asserted once and inherited by every value. That is
+ * what keeps `SUM(valueNumber)` meaningful: a per-row code would let one column
+ * mix exponents — USD cents, whole yen, KWD thousandths — inside a single sum,
+ * ordering and range filter, silently and with no way to detect it downstream.
+ * Real multi-currency is an amount field + its own currency field + an
+ * FX-converted base-currency field, not a code smuggled into each cell.
+ */
+export const currencyConverter: FieldValueConverter = {
+  /**
+   * Accepts a bare number or numeric string (every existing writer), an already
+   * typed value, or an object carrying an amount (`{ amount }` / `{ value }`) —
+   * the shape a connector or app sends. Any accompanying currency code is
+   * IGNORED, not stored: see the note on the converter above.
+   *
+   * 🛑 NEVER converts units. Given `600` it cannot know whether that is $6.00 or
+   * $600, and guessing is what produced 100×-wrong stored data. A provider that
+   * reports major units converts in its own projection.
+   */
+  toTypedInput(value: unknown): TypedFieldValueInput | null {
+    if (value === null || value === undefined) return null
+
+    if (typeof value === 'object') {
+      const obj = value as Record<string, unknown>
+
+      // Already-typed value passing back through.
+      if ('type' in obj) {
+        if (obj.type !== 'number') return null
+        return { type: 'number', value: (obj as unknown as NumberFieldValue).value }
+      }
+
+      const amount = toFiniteNumber(obj.amount ?? obj.value)
+      if (amount === null) return null
+      return { type: 'number', value: amount }
+    }
+
+    const num = toFiniteNumber(value)
+    if (num === null) return null
+    return { type: 'number', value: num }
+  },
+
+  /**
+   * Returns the bare integer minor-unit amount — the same shape NUMBER returns.
+   *
+   * Deliberately NOT an object. `{ code, amount }` was tried and reverted: an
+   * asymmetric read shape (object out, number in) breaks every `===`, `> 0`,
+   * `?? null` and arithmetic expression downstream without throwing, and it
+   * exists only to carry a per-value code the platform no longer has.
+   */
+  toRawValue(value: TypedFieldValue | TypedFieldValueInput | unknown): number | null {
+    if (value === null || value === undefined) return null
+
+    if (typeof value === 'object' && 'type' in (value as Record<string, unknown>)) {
+      const typed = value as NumberFieldValue
+      if (typed.type !== 'number') return null
+      if (typed.value === null || typed.value === undefined || Number.isNaN(typed.value))
+        return null
+      return typed.value
+    }
+
+    // Bare number passthrough — a value that never went through the typed layer.
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+
+    return null
+  },
+
+  /**
+   * Formats via `formatCurrency`, which takes minor units and derives the scale
+   * from the code.
+   *
+   * `options.currencyCode` is expected to be ALREADY RESOLVED through the org
+   * rung — see {@link resolveCurrencyCode}. Server callers wrap their field
+   * options with `withOrgCurrency()`; this falls back to USD only when nobody
+   * resolved anything, which is the same answer the rung would give for an org
+   * on the default setting.
+   */
+  toDisplayValue(value: TypedFieldValue | TypedFieldValueInput, options?: FieldOptions): string {
+    if (!value) return ''
+
+    const typed = value as NumberFieldValue
+    const num = typed.value
+
+    if (num === null || num === undefined || Number.isNaN(num)) return ''
+
+    return formatCurrency(num, {
+      currencyCode: normalizeCurrencyCode(options?.currencyCode) ?? FALLBACK_CODE,
+      decimals: options?.decimals,
+      useGrouping: options?.useGrouping ?? DEFAULT_CURRENCY_OPTIONS.useGrouping,
+      currencyDisplay: options?.currencyDisplay ?? DEFAULT_CURRENCY_OPTIONS.currencyDisplay,
+    })
+  },
+}
+
+/**
+ * Read whatever a CURRENCY read path handed us as an integer minor-unit amount,
+ * or null.
+ *
+ * `toRawValue` emits a bare number, but tolerant narrowing is still worth having
+ * at the edges: numeric strings arrive from workflow inputs and form state, and
+ * `{ amount }` objects from connector projections. Returns null — an empty cell
+ * — rather than `NaN` for anything unreadable.
+ */
+export function readCurrency(value: unknown): number | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  if (typeof value === 'string') return toFiniteNumber(value)
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>
+    return toFiniteNumber(obj.amount ?? obj.value)
+  }
+  return null
+}

--- a/packages/lib/src/field-values/converters/index.ts
+++ b/packages/lib/src/field-values/converters/index.ts
@@ -67,9 +67,15 @@ export interface FieldValueConverter {
 import { actorConverter } from './actor'
 import { booleanConverter } from './boolean'
 import { calcConverter } from './calc'
+import {
+  currencyConverter,
+  normalizeCurrencyCode,
+  readCurrency,
+  resolveCurrencyCode,
+} from './currency'
 import { dateConverter } from './date'
 import { type FileValue, fileConverter, jsonConverter, nameConverter } from './json'
-import { currencyConverter, numberConverter } from './number'
+import { numberConverter } from './number'
 import { phoneConverter } from './phone'
 import { relationshipConverter } from './relationship'
 import { selectConverter } from './select'
@@ -143,5 +149,8 @@ export {
   phoneConverter,
   calcConverter,
   actorConverter,
+  normalizeCurrencyCode,
+  readCurrency,
+  resolveCurrencyCode,
 }
 export type { FileValue }

--- a/packages/lib/src/field-values/converters/number.ts
+++ b/packages/lib/src/field-values/converters/number.ts
@@ -5,8 +5,7 @@ import type {
   TypedFieldValue,
   TypedFieldValueInput,
 } from '@auxx/types/field-value'
-import { formatCurrency } from '@auxx/utils/currency'
-import { DEFAULT_CURRENCY_OPTIONS, DEFAULT_NUMBER_OPTIONS } from '../../custom-fields/defaults'
+import { DEFAULT_NUMBER_OPTIONS } from '../../custom-fields/defaults'
 import type { FieldOptions, FieldValueConverter } from './index'
 
 /**
@@ -137,47 +136,4 @@ function formatBytesInternal(bytes: number, decimals: number = 0): string {
   const i = Math.floor(Math.log(bytes) / Math.log(k))
   const value = bytes / k ** i
   return `${value.toFixed(decimals)} ${sizes[i]}`
-}
-
-/**
- * Converter for CURRENCY field type.
- * Same storage as NUMBER but with currency-specific display options.
- * Uses formatCurrency() from @auxx/utils/currency for consistent formatting.
- */
-export const currencyConverter: FieldValueConverter = {
-  // Use same input conversion as number
-  toTypedInput: numberConverter.toTypedInput,
-
-  // Use same raw value extraction as number
-  toRawValue: numberConverter.toRawValue,
-
-  /**
-   * Convert TypedFieldValue to display string with currency formatting.
-   * Uses the centralized formatCurrency utility for consistent output.
-   */
-  toDisplayValue(value: TypedFieldValue, options?: FieldOptions): string {
-    if (!value) {
-      return ''
-    }
-
-    const typed = value as NumberFieldValue
-    const num = typed.value
-
-    if (num === null || num === undefined || Number.isNaN(num)) {
-      return ''
-    }
-
-    // Merge defaults with provided options (flat keys on field.options)
-    const opts = {
-      currencyCode: options?.currencyCode ?? DEFAULT_CURRENCY_OPTIONS.currencyCode,
-      decimals: options?.decimals ?? DEFAULT_CURRENCY_OPTIONS.decimals,
-      useGrouping: options?.useGrouping ?? DEFAULT_CURRENCY_OPTIONS.useGrouping,
-      currencyDisplay: options?.currencyDisplay ?? DEFAULT_CURRENCY_OPTIONS.currencyDisplay,
-    }
-
-    // formatCurrency expects cents, so convert dollars to cents
-    const cents = Math.round(num * 100)
-
-    return formatCurrency(cents, opts)
-  },
 }

--- a/packages/lib/src/field-values/display-field-service.ts
+++ b/packages/lib/src/field-values/display-field-service.ts
@@ -18,6 +18,7 @@ import {
 import { batchGetRelatedDisplayNames } from './field-value-helpers'
 import { FieldValueService } from './field-value-service'
 import { formatToDisplayValue } from './formatter'
+import { getOrgCurrencyCode, withOrgCurrency } from './org-currency'
 import { primaryValue } from './primary-value'
 import { updateSearchTextForEntityDefinition } from './search-text'
 
@@ -159,10 +160,22 @@ export class DisplayFieldService {
           }
         }
       } else {
+        // The org rung for CURRENCY — resolved ONCE for the batch, never per
+        // value inside the loop. A no-op for every other field type.
+        const orgCurrencyCode =
+          field.fieldType === 'CURRENCY'
+            ? await getOrgCurrencyCode(this.organizationId, this.db)
+            : undefined
+
         const assetIdsToThumbnail: string[] = []
         for (const instanceId of instanceIds) {
           const typedValue = valuesByEntity.get(instanceId) ?? null
-          const displayValue = this.computeDisplayValue(typedValue, field, displayFieldType)
+          const displayValue = this.computeDisplayValue(
+            typedValue,
+            field,
+            displayFieldType,
+            orgCurrencyCode
+          )
           updates.set(instanceId, displayValue)
 
           // Collect asset IDs that need avatar thumbnails during batch recalc
@@ -255,7 +268,8 @@ export class DisplayFieldService {
   private computeDisplayValue(
     typedValue: TypedFieldValue | TypedFieldValue[] | null,
     field: ResourceField,
-    displayFieldType: DisplayFieldType
+    displayFieldType: DisplayFieldType,
+    orgCurrencyCode?: string
   ): string | null {
     if (!typedValue) return null
 
@@ -288,8 +302,14 @@ export class DisplayFieldService {
     const single = primaryValue(typedValue)
     if (!single) return null
 
-    // Use centralized formatter with properly typed options
-    const displayValue = formatToDisplayValue(single, fieldType, field.options)
+    // Use centralized formatter with properly typed options. `withOrgCurrency`
+    // layers the org rung under a CURRENCY field that never picked a code, so a
+    // persisted display value follows `organization.currency`.
+    const displayValue = formatToDisplayValue(
+      single,
+      fieldType,
+      withOrgCurrency(field.options as never, fieldType, orgCurrencyCode)
+    )
 
     return typeof displayValue === 'string' ? displayValue : null
   }

--- a/packages/lib/src/field-values/field-value-helpers.ts
+++ b/packages/lib/src/field-values/field-value-helpers.ts
@@ -28,7 +28,12 @@ import {
   isResourceFieldId,
   parseResourceFieldId,
 } from '@auxx/types/field'
-import type { ActorFieldValue } from '@auxx/types/field-value'
+import {
+  type ActorFieldValue,
+  type FieldValueMeta,
+  mergeMeta,
+  readEnvelope,
+} from '@auxx/types/field-value'
 import { isEntityDefinitionType, type RecordId } from '@auxx/types/resource'
 import type { SystemAttribute } from '@auxx/types/system-attribute'
 import { and, eq, inArray } from 'drizzle-orm'
@@ -42,6 +47,7 @@ import { isRecordId, parseRecordId, toRecordId } from '../resources/resource-id'
 import { cascadeDependentDisplayNames, getDisplayFieldDeps } from './display-field-deps'
 import { FieldValueValidator, fieldValueSchemas } from './field-value-validator'
 import { formatToDisplayValue } from './formatter'
+import { getOrgCurrencyCode, withOrgCurrency } from './org-currency'
 import { MAX_MULTI_VALUES, primaryValue } from './primary-value'
 import type { InverseFieldInfo } from './relationship-sync'
 import { isSearchTextIndexedFieldType, updateSearchText } from './search-text'
@@ -356,14 +362,22 @@ export function rowToTypedValue(row: FieldValueRow, fieldType: FieldType): Typed
   switch (valueType) {
     case 'text':
       return { ...base, type: 'text', value: row.valueText ?? '' }
-    case 'number':
+    case 'number': {
+      // CURRENCY is NUMBER's shape exactly: an integer minor-unit amount in
+      // `valueNumber`. The denomination is the field's, resolved at the render
+      // site from `options.currencyCode` — a value never carries its own.
       return { ...base, type: 'number', value: row.valueNumber ?? 0 }
+    }
     case 'boolean':
       return { ...base, type: 'boolean', value: row.valueBoolean ?? false }
     case 'date':
       return { ...base, type: 'date', value: row.valueDate ?? '' }
     case 'json':
-      return { ...base, type: 'json', value: (row.valueJson as Record<string, unknown>) ?? {} }
+      return {
+        ...base,
+        type: 'json',
+        value: (readEnvelope(row.valueJson).v as Record<string, unknown>) ?? {},
+      }
     case 'option':
       return { ...base, type: 'option', optionId: row.optionId ?? '' }
     case 'relationship':
@@ -679,11 +693,49 @@ export async function validateSingleValue(
       return { type: 'text', value: result.data || '' }
     }
 
-    case 'NUMBER':
-    case 'CURRENCY': {
+    case 'NUMBER': {
       const result = ctx.validator.validateNumber(value)
       if (!result.success) throwValidationError(result)
       return { type: 'number', value: result.data ?? 0 }
+    }
+
+    /**
+     * CURRENCY does NOT fall through to NUMBER: it is the only field type whose
+     * stored number has a declared UNIT, so it is the only one that can assert
+     * a decidable integrality check on the way in.
+     *
+     * 🛑 Never converts units. Given `600` it cannot know whether that is $6.00
+     * or $600 — the undecidable guess that produced 100×-wrong stored data. A
+     * provider reporting decimal major units converts in its own projection.
+     *
+     * Any currency code on the input is IGNORED. The denomination is the
+     * field's; see `FieldOptions.currencyCode`.
+     */
+    case 'CURRENCY': {
+      let amount: unknown = value
+
+      if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+        const obj = value as Record<string, unknown>
+        if (!('type' in obj)) amount = obj.amount ?? obj.value
+      }
+
+      const result = ctx.validator.validateNumber(amount)
+      if (!result.success) throwValidationError(result)
+      const num = result.data ?? 0
+
+      // A fractional value in a minor-units field is ALWAYS wrong — cents, yen
+      // and thousandths of a dinar are integers for every ISO currency. This is
+      // decidable, unlike dollars-vs-cents on a whole number, and it is the
+      // single check that would have caught the connector passthrough bug at
+      // the first sync instead of months later.
+      if (!Number.isInteger(num)) {
+        throw new BadRequestError(
+          `CURRENCY values are integer minor units (cents for USD), but received ${num}. ` +
+            'A provider reporting decimal major units must scale in its own projection.'
+        )
+      }
+
+      return { type: 'number', value: num }
     }
 
     case 'CHECKBOX': {
@@ -1144,8 +1196,19 @@ export async function maybeUpdateDisplayValue(
       // maps over arrays, and writing that array into the display column
       // would corrupt `displayName`/`secondaryDisplayValue`.
       const primaryTyped = primaryValue(typedValue)
+      // `withOrgCurrency` layers the org rung under a CURRENCY field that never
+      // picked its own code, so the persisted display value follows
+      // `organization.currency`. A no-op for every other field type.
+      const options =
+        field.type === 'CURRENCY'
+          ? withOrgCurrency(
+              field.options as never,
+              'CURRENCY',
+              await getOrgCurrencyCode(ctx.organizationId, ctx.db)
+            )
+          : (field.options as never)
       displayValue = primaryTyped
-        ? (formatToDisplayValue(primaryTyped, toFieldType(field.type), field.options as any) as
+        ? (formatToDisplayValue(primaryTyped, toFieldType(field.type), options as any) as
             | string
             | null)
         : null

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -19,6 +19,7 @@ import {
 } from '@auxx/types'
 import { isSelfReferentialRelationship, type RelationshipConfig } from '@auxx/types/custom-field'
 import { buildFieldValueKey, type FieldId } from '@auxx/types/field'
+import { mergeMeta, readEnvelope, writeEnvelope } from '@auxx/types/field-value'
 import type { RecordId } from '@auxx/types/resource'
 import { isSystemAttribute } from '@auxx/types/system-attribute'
 import { generateId } from '@auxx/utils'
@@ -1350,14 +1351,16 @@ function serializeRowMatch(
   const raw = (row as unknown as Record<string, unknown>)[column]
   if (raw === null || raw === undefined) return null
   if (column === 'valueJson') {
+    // `valueJson` is the `{ v, meta }` envelope — identity is the VALUE half.
+    const inner = readEnvelope(raw).v
+    if (inner === null || inner === undefined) return null
     if (fieldType === FieldTypeEnum.FILE) {
-      const ref = (raw as { ref?: unknown }).ref
+      const ref = (inner as { ref?: unknown }).ref
       if (typeof ref === 'string') return ref
     }
-    return JSON.stringify(raw)
+    return JSON.stringify(inner)
   }
   if (column === 'valueBoolean') return String(raw)
-  if (column === 'valueNumber') return String(raw)
   return String(raw)
 }
 
@@ -1367,7 +1370,6 @@ function serializeRowMatch(
  */
 function matchKey(m: TypedColumnMatch, fieldType?: FieldType): string {
   if (m.column === 'valueBoolean') return String(m.value)
-  if (m.column === 'valueNumber') return String(m.value)
   if (m.column === 'valueJson' && fieldType === FieldTypeEnum.FILE) {
     try {
       const parsed = JSON.parse(m.value) as { ref?: unknown }
@@ -1683,7 +1685,7 @@ export async function removeValues(
           const refs = matches
             .map((m) => {
               // `column === 'valueJson'` (checked above) guarantees `m.value`
-              // is the stringified JSON envelope for every match here.
+              // is the stringified JSON value for every match here.
               try {
                 const parsed = JSON.parse(m.value as string) as { ref?: unknown }
                 return typeof parsed.ref === 'string' ? parsed.ref : null
@@ -1692,7 +1694,9 @@ export async function removeValues(
               }
             })
             .filter((ref): ref is string => ref !== null)
-          return refs.length > 0 ? inArray(sql`${schema.FieldValue.valueJson}->>'ref'`, refs) : null
+          return refs.length > 0
+            ? inArray(sql`${schema.FieldValue.valueJson}->'v'->>'ref'`, refs)
+            : null
         })()
       : buildMatchInClause(column, matches.map((m) => m.value) as any)
 
@@ -3282,6 +3286,8 @@ function buildInsertData(
     case 'text':
       return { valueText: value.value }
     case 'number':
+      // CURRENCY stores its amount in valueNumber exactly like NUMBER — the
+      // denomination is the field's, so nothing rides the envelope.
       return { valueNumber: value.value }
     case 'boolean':
       return { valueBoolean: value.value }
@@ -3290,7 +3296,7 @@ function buildInsertData(
         valueDate: value.value instanceof Date ? value.value.toISOString() : value.value,
       }
     case 'json':
-      return { valueJson: value.value }
+      return { valueJson: writeEnvelope(value.value) }
     case 'option':
       return { optionId: value.optionId }
     case 'relationship': {
@@ -3341,6 +3347,8 @@ function buildUpdateData(value: TypedFieldValueInput): {
     case 'text':
       return { valueText: value.value }
     case 'number':
+      // CURRENCY stores its amount in valueNumber exactly like NUMBER — the
+      // denomination is the field's, so nothing rides the envelope.
       return { valueNumber: value.value }
     case 'boolean':
       return { valueBoolean: value.value }
@@ -3349,7 +3357,7 @@ function buildUpdateData(value: TypedFieldValueInput): {
         valueDate: value.value instanceof Date ? value.value.toISOString() : value.value,
       }
     case 'json':
-      return { valueJson: value.value }
+      return { valueJson: writeEnvelope(value.value) }
     case 'option':
       return { optionId: value.optionId }
     case 'relationship': {
@@ -3419,7 +3427,7 @@ export function buildFieldValueRow(params: {
         valueDate: value.value instanceof Date ? value.value.toISOString() : value.value,
       }
     case 'json':
-      return { ...base, valueJson: value.value }
+      return { ...base, valueJson: writeEnvelope(value.value) }
     case 'option':
       return { ...base, optionId: value.optionId }
     case 'relationship': {

--- a/packages/lib/src/field-values/field-value-queries.ts
+++ b/packages/lib/src/field-values/field-value-queries.ts
@@ -600,9 +600,10 @@ async function categorizeFields(
 // =============================================================================
 
 /**
- * Explicit FieldValue projection. `valueJson` is heavy jsonb (file/currency/
- * address payloads, AI metadata) — it is only shipped when `valueJsonWhen`
- * matches; other rows get NULL. Pass `true` to always include it.
+ * Explicit FieldValue projection. `valueJson` is the `{ v, meta }` envelope —
+ * heavy jsonb (file/address payloads) plus small metadata facts — and is only
+ * shipped when `valueJsonWhen` matches; other rows get NULL. Pass `true` to
+ * always include it.
  */
 function fieldValueColumns(valueJsonWhen: SQL | true) {
   return {
@@ -642,16 +643,15 @@ async function fetchFieldValueResults(
   fieldTypeMap: Map<string, FieldType>,
   fieldOptionsMap: Map<string, FieldOptions | undefined>
 ): Promise<TypedFieldValueResult[]> {
-  // Only json-typed fields store their value in valueJson; AI metadata
-  // piggy-backs on valueJson for ANY type when aiStatus is set. Unknown types
-  // keep valueJson for safety.
-  const jsonFieldIds = fieldIds.filter((fieldId) => {
-    const fieldType = fieldTypeMap.get(fieldId)
-    return !fieldType || getValueType(fieldType) === 'json'
-  })
-  const valueJsonWhen = jsonFieldIds.length
-    ? or(isNotNull(schema.FieldValue.aiStatus), inArray(schema.FieldValue.fieldId, jsonFieldIds))!
-    : isNotNull(schema.FieldValue.aiStatus)
+  // `valueJson` is the `{ v, meta }` envelope: the value for json-typed fields,
+  // and metadata (AI provenance, a CURRENCY row's ISO code) for any type. Ship
+  // it exactly when a row has one.
+  //
+  // This is NARROWER than the fieldId-membership predicate it replaces — that
+  // form selected every row of a json-typed field, payload or not — while also
+  // covering the case membership missed: a scalar row carrying `meta` but no
+  // `aiStatus`, which is every currency value that asserts its own code.
+  const valueJsonWhen = isNotNull(schema.FieldValue.valueJson)
 
   const rows = await ctx.db
     .select(fieldValueColumns(valueJsonWhen))

--- a/packages/lib/src/field-values/field-value-scalar.ts
+++ b/packages/lib/src/field-values/field-value-scalar.ts
@@ -2,6 +2,24 @@
 // Pure, zero-dependency — safe to import from anywhere (no cache/db/realtime pull-in).
 
 /**
+ * The value half of a `valueJson` envelope (`{ v, meta }`). Inlined rather than
+ * imported so this module stays dependency-free.
+ *
+ * A CURRENCY row carries `{ meta: { currency } }` and NO `v` — it must coalesce
+ * to nothing here, so the row falls through to `valueNumber` above, which is
+ * where its amount actually lives.
+ */
+function unwrapEnvelopeValue(json: unknown): unknown {
+  if (json === null || json === undefined || typeof json !== 'object' || Array.isArray(json)) {
+    return json ?? null
+  }
+  const obj = json as Record<string, unknown>
+  if ('v' in obj) return obj.v
+  if ('meta' in obj) return null
+  return obj // legacy pre-envelope row: the object IS the value
+}
+
+/**
  * Coalesce a raw FieldValue row's typed columns to its flat scalar: the first
  * non-nullish of text/number/boolean/date/json values, then option/relationship/actor
  * refs, else null. `??` keeps falsy-but-set values (`false`, `0`, `''`) intact.
@@ -15,7 +33,7 @@ export function extractFieldValueScalar(fv: Record<string, unknown>): unknown {
     fv.valueNumber ??
     fv.valueBoolean ??
     fv.valueDate ??
-    fv.valueJson ??
+    unwrapEnvelopeValue(fv.valueJson) ??
     fv.optionId ??
     fv.relatedEntityId ??
     fv.actorId ??

--- a/packages/lib/src/field-values/org-currency.ts
+++ b/packages/lib/src/field-values/org-currency.ts
@@ -1,0 +1,59 @@
+// packages/lib/src/field-values/org-currency.ts
+
+import type { Database, Transaction } from '@auxx/database'
+import type { FieldType } from '@auxx/database/types'
+import type { FieldOptions } from '../custom-fields/field-options'
+import { getOrganizationSetting } from '../settings'
+import { resolveCurrencyCode } from './converters/currency'
+
+/**
+ * The org rung of the CURRENCY denomination chain: **field → org → USD**.
+ *
+ * A CURRENCY field that never picked a `currencyCode` inherits the org's, so
+ * one setting at `/app/dispatch/settings/general` moves every such field at
+ * once — in the table, the drawer, CSV, PDF, placeholders and search text
+ * alike. A field that DID pick one is pinned and ignores the setting.
+ *
+ * 🛑 The resolved code is never written back to `field.options`. Stamping it —
+ * in a cache, in a default, or via an editor that pre-fills the picker and then
+ * saves — makes an inherited code indistinguishable from an asserted one, and
+ * the field stops following the setting forever. Absent means inherit, and it
+ * has to stay absent.
+ */
+
+/**
+ * Read the org's currency code once, for a whole batch of display formatting.
+ *
+ * Backed by the `orgSettings` org-cache key, so this is a map lookup rather than
+ * a query — but it is still `async`, so resolve it ONCE per batch and hand the
+ * string down, never per field value inside a loop.
+ */
+export async function getOrgCurrencyCode(
+  organizationId: string,
+  db?: Database | Transaction
+): Promise<string> {
+  const value = await getOrganizationSetting({
+    key: 'organization.currency',
+    organizationId,
+    db,
+  })
+  return resolveCurrencyCode(undefined, value)
+}
+
+/**
+ * Layer the org rung under a CURRENCY field's options for one format call.
+ *
+ * A no-op for every other field type, so display paths can wrap unconditionally
+ * instead of branching on `fieldType` at each call site.
+ */
+export function withOrgCurrency(
+  options: FieldOptions | null | undefined,
+  fieldType: FieldType | string | null | undefined,
+  orgCurrencyCode: string | undefined
+): FieldOptions | undefined {
+  if (fieldType !== 'CURRENCY') return options ?? undefined
+  return {
+    ...(options ?? {}),
+    currencyCode: resolveCurrencyCode(options?.currencyCode, orgCurrencyCode),
+  }
+}

--- a/packages/lib/src/field-values/search-text.ts
+++ b/packages/lib/src/field-values/search-text.ts
@@ -215,9 +215,9 @@ function fieldValueTextSql(): string {
             fv."optionId")
           WHEN cf."type" = 'RELATIONSHIP' THEN rel."displayName"
           WHEN cf."type" = 'NAME'
-            THEN CONCAT_WS(' ', ${jsonKeyList('fv."valueJson"', SEARCH_TEXT_NAME_KEYS)})
+            THEN CONCAT_WS(' ', ${jsonKeyList(`fv."valueJson"->'v'`, SEARCH_TEXT_NAME_KEYS)})
           WHEN cf."type" = 'ADDRESS_STRUCT'
-            THEN CONCAT_WS(' ', ${jsonKeyList('fv."valueJson"', SEARCH_TEXT_ADDRESS_KEYS)})
+            THEN CONCAT_WS(' ', ${jsonKeyList(`fv."valueJson"->'v'`, SEARCH_TEXT_ADDRESS_KEYS)})
         END`
 }
 

--- a/packages/lib/src/field-values/timeline-snapshot.ts
+++ b/packages/lib/src/field-values/timeline-snapshot.ts
@@ -27,7 +27,8 @@ import {
   truncateForSnapshot,
 } from '../timeline/field-change-snapshot'
 import { booleanConverter } from './converters/boolean'
-import { currencyConverter, numberConverter } from './converters/number'
+import { currencyConverter } from './converters/currency'
+import { numberConverter } from './converters/number'
 import { phoneConverter } from './converters/phone'
 import type { CachedField } from './types'
 
@@ -490,6 +491,10 @@ function buildSnapshotSingle(
     case 'CURRENCY': {
       if (value.type !== 'number') return null
       const formatted = currencyConverter.toDisplayValue(value, field.options ?? undefined)
+      // Freeze the FIELD's code into the snapshot. A snapshot renders long after
+      // the field may have been switched to another currency, and it must keep
+      // reading as the money it was — this is the one place a code is copied
+      // next to an amount, because the row it describes no longer exists.
       const currency = (field.options as { currencyCode?: string } | null)?.currencyCode
       return {
         fieldType: 'CURRENCY',

--- a/packages/lib/src/field-values/typed-column-match.ts
+++ b/packages/lib/src/field-values/typed-column-match.ts
@@ -30,6 +30,8 @@ export function typedColumnMatch(value: TypedFieldValueInput): TypedColumnMatch 
     case 'text':
       return { column: 'valueText', value: value.value }
     case 'number':
+      // CURRENCY shares this column: the amount alone IS the key, because the
+      // denomination is the field's and every value on the field inherits it.
       return { column: 'valueNumber', value: value.value }
     case 'boolean':
       return { column: 'valueBoolean', value: value.value }

--- a/packages/lib/src/jobs/ai-autofill/ai-autofill-job.ts
+++ b/packages/lib/src/jobs/ai-autofill/ai-autofill-job.ts
@@ -3,6 +3,7 @@
 import { database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { getExistingFieldValue } from '@auxx/services/field-values'
+import { readMeta } from '@auxx/types/field-value'
 import type { RecordId } from '@auxx/types/resource'
 import { parseRecordId } from '@auxx/types/resource'
 import type { GenerationResult } from '../../field-values/ai-autofill/generation-service'
@@ -75,7 +76,7 @@ export async function aiAutofillJob(ctx: JobContext<AiAutofillJobData>) {
     return { dropped: 'no-row' as const }
   }
 
-  const currentMeta = (existing.value.valueJson ?? {}) as { jobId?: string }
+  const currentMeta = (readMeta(existing.value.valueJson).ai ?? {}) as { jobId?: string }
   if (existing.value.aiStatus !== 'generating' || currentMeta.jobId !== jobId) {
     logger.info('Dropping AI autofill — override detected', {
       jobId,

--- a/packages/lib/src/jobs/maintenance/generate-thumbnail-job.ts
+++ b/packages/lib/src/jobs/maintenance/generate-thumbnail-job.ts
@@ -475,7 +475,7 @@ async function updateEntityAvatarIfApplicable(params: {
     .where(
       and(
         eq(schema.FieldValue.organizationId, orgId),
-        sql`${schema.FieldValue.valueJson}->>'ref' = ${refValue}`
+        sql`${schema.FieldValue.valueJson}->'v'->>'ref' = ${refValue}`
       )
     )
 

--- a/packages/lib/src/placeholders/resolver.ts
+++ b/packages/lib/src/placeholders/resolver.ts
@@ -5,11 +5,11 @@ import type { FieldType } from '@auxx/database/types'
 import type { TypedFieldValue } from '@auxx/types'
 import { type FieldReference, fieldRefToKey } from '@auxx/types/field'
 import type { RecordId } from '@auxx/types/resource'
-import { formatCurrency } from '@auxx/utils/currency'
 import { getOrgCache, getUserCache } from '../cache'
 import type { FieldOptions } from '../custom-fields/field-options'
 import { FieldValueService } from '../field-values/field-value-service'
 import { formatToDisplayValue } from '../field-values/formatter'
+import { getOrgCurrencyCode, withOrgCurrency } from '../field-values/org-currency'
 import { decodeFallback, renderFallbackPayload } from './fallback-codec'
 import { decodePlaceholderFormat, getPlaceholderFormatOptions } from './format-codec'
 import {
@@ -298,6 +298,23 @@ export async function resolveFieldTokens(
     }
   }
 
+  // The org rung for CURRENCY, applied in one pass over the finished map.
+  // Doing it HERE is what keeps the HTML adapter and the structural document
+  // resolver identical — both consume this map, so a field that never picked
+  // its own code renders in `organization.currency` in an email and in a PDF
+  // alike. Skipped entirely when no currency token resolved.
+  const currencyIds = [...result].filter(([, r]) => r?.fieldType === 'CURRENCY').map(([id]) => id)
+  if (currencyIds.length > 0) {
+    const orgCurrencyCode = await getOrgCurrencyCode(ctx.organizationId, ctx.db)
+    for (const id of currencyIds) {
+      const resolved = result.get(id)!
+      result.set(id, {
+        ...resolved,
+        fieldOptions: withOrgCurrency(resolved.fieldOptions, 'CURRENCY', orgCurrencyCode),
+      })
+    }
+  }
+
   return result
 }
 
@@ -325,11 +342,7 @@ function formatDateOnly(d: Date): string {
  * `CURRENCY` total renders `$250.00` rather than the raw `25000`, dates render
  * `Jan 15, 2024`, options render their label, etc.
  *
- * Two deliberate deviations from `formatToDisplayValue`:
- * - `CURRENCY` is stored as integer **cents** by the money engine (`totals.ts`
- *   — `DisplayCurrency` renders `value / 100`), whereas the shared
- *   `currencyConverter` assumes dollars (`value * 100`). We format cents
- *   directly via `@auxx/utils/currency`'s `formatCurrency`.
+ * One deliberate deviation from `formatToDisplayValue`:
  * - `RELATIONSHIP` / `ACTOR` resolve to a human display name (the shared
  *   converter returns the raw id/object for frontend hydration, which is
  *   useless in an email).
@@ -353,17 +366,6 @@ function formatSingleForText(
   // Human-readable name for links/people — never the raw id.
   if (v.type === 'relationship') return v.displayName ?? v.recordId
   if (v.type === 'actor') return v.displayName ?? ''
-
-  // Money is integer cents (money-engine convention); the shared converter
-  // would multiply by 100 and be off by 100×.
-  if (fieldType === 'CURRENCY' && v.type === 'number') {
-    return formatCurrency(v.value, {
-      currencyCode: options?.currencyCode,
-      decimals: options?.decimals,
-      useGrouping: options?.useGrouping,
-      currencyDisplay: options?.currencyDisplay,
-    })
-  }
 
   const display = formatToDisplayValue(v, fieldType, options)
   return display === null || display === undefined ? '' : String(display)

--- a/packages/lib/src/resources/query-builder/entity-condition-builder.ts
+++ b/packages/lib/src/resources/query-builder/entity-condition-builder.ts
@@ -152,7 +152,7 @@ export class EntityConditionBuilder extends BaseConditionBuilder<EntityQueryCont
     const outerTableId = context.outerTable.id
 
     const valueSubquery = sql`(
-      SELECT "FieldValue".${sql.raw(`"${valueColumn}"`)}
+      SELECT ${this.typedValueRef('FieldValue', valueColumn)}
       FROM "FieldValue"
       WHERE "FieldValue"."entityId" = ${outerTableId}
         AND "FieldValue"."fieldId" = ${fieldIdForSql}
@@ -588,7 +588,7 @@ export class EntityConditionBuilder extends BaseConditionBuilder<EntityQueryCont
     rawValue: unknown,
     columnName: string
   ): SQL<unknown> | undefined {
-    const valueCol = sql.raw(`related."${columnName}"`)
+    const valueCol = this.typedValueRef('related', columnName)
 
     // Handle optionId fields (MULTI_SELECT, TAGS)
     if (columnName === 'optionId') {
@@ -797,6 +797,19 @@ export class EntityConditionBuilder extends BaseConditionBuilder<EntityQueryCont
    * as a SEPARATE FieldValue row with optionId. The EXISTS subquery will
    * match ANY row that satisfies the condition.
    */
+  /**
+   * A qualified SQL reference to a row's typed value column.
+   *
+   * `valueJson` is an ENVELOPE (`{ v, meta }`), so a json-typed comparison must
+   * target `->'v'` — the value — never the envelope. Comparing the envelope
+   * silently matches nothing, and the failure is typecheck-clean.
+   */
+  private typedValueRef(tableAlias: string, columnName: string): SQL<unknown> {
+    return columnName === 'valueJson'
+      ? sql.raw(`"${tableAlias}"."valueJson"->'v'`)
+      : sql.raw(`"${tableAlias}"."${columnName}"`)
+  }
+
   private getTypedColumnName(dbFieldType: string): string {
     const valueType = getValueType(dbFieldType)
     switch (valueType) {
@@ -924,7 +937,7 @@ export class EntityConditionBuilder extends BaseConditionBuilder<EntityQueryCont
     dbFieldType: string
   ): SQL<unknown> | undefined {
     const columnName = this.getTypedColumnName(dbFieldType)
-    const valueCol = sql.raw(`"FieldValue"."${columnName}"`)
+    const valueCol = this.typedValueRef('FieldValue', columnName)
 
     // Strip entityDefinitionId: prefix from RecordId values for RELATIONSHIP fields
     if (columnName === 'relatedEntityId') {

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -422,7 +422,8 @@ export const SETTINGS_CATALOG = {
     access: 'org',
     fieldType: 'TEXT',
     defaultValue: 'USD',
-    description: 'Organization-wide currency code — consumed by CURRENCY display + totals docs',
+    description:
+      'Organization-wide currency code — consumed by the money cluster, documents and Stripe rails (NOT the CURRENCY field layer, which reads options.currencyCode)',
   },
   'organization.weekStart': {
     scope: 'GENERAL',

--- a/packages/lib/src/workflow-engine/constants/nodes/format.ts
+++ b/packages/lib/src/workflow-engine/constants/nodes/format.ts
@@ -361,7 +361,7 @@ export const OPERATION_EXAMPLES: Record<FormatOperation, string> = {
   [FormatOperation.REPLACE]: '"hello world" → "hello earth"',
   [FormatOperation.REPLACE_REGEX]: '"abc 123" → "abc ***" (\\d+)',
   [FormatOperation.REMOVE]: '"hello world" → "hello "',
-  [FormatOperation.CURRENCY]: '1234.5 → $1,234.50',
+  [FormatOperation.CURRENCY]: '123450 → $1,234.50 (minor units in)',
   [FormatOperation.PERCENTAGE]: '0.156 → 16%',
   [FormatOperation.FIXED_DECIMALS]: '3.14159 → 3.14',
   [FormatOperation.ORDINAL]: '3 → 3rd',

--- a/packages/lib/src/workflow-engine/core/execution-context.ts
+++ b/packages/lib/src/workflow-engine/core/execution-context.ts
@@ -29,6 +29,7 @@ import {
 } from '../../field-values/field-value-helpers'
 import { batchGetValues } from '../../field-values/field-value-queries'
 import { formatToDisplayValue, formatToRawValue } from '../../field-values/formatter'
+import { getOrgCurrencyCode, withOrgCurrency } from '../../field-values/org-currency'
 import { primaryValue } from '../../field-values/primary-value'
 import { getFieldOutputKey, type ResourceField } from '../../resources/registry/field-types'
 import { fetchResourceWithRelationships } from '../../resources/resource-fetcher'
@@ -156,6 +157,8 @@ export class ExecutionContextManager implements ContextManager {
   // Record field cache: stores TypedFieldValues per record, keyed by RecordId
   // Unified cache for field value access — replaces per-field lazy loading for custom entities
   private recordFieldCache: Map<string, RecordFieldEntry> = new Map()
+  /** Memoized org currency for the run — see {@link getOrgCurrencyCode}. */
+  private orgCurrencyCodePromise?: Promise<string>
 
   constructor(
     workflowId: string,
@@ -977,6 +980,17 @@ export class ExecutionContextManager implements ContextManager {
    * @param refs - ResourceReference array (from findMany output)
    * @param fieldRefs - FieldReference array (direct fields or relationship paths)
    */
+  /**
+   * The org's currency code, memoized for the life of the run.
+   *
+   * A workflow run is a single point in time — re-reading the setting mid-run
+   * would let one execution format two currency fields under different codes.
+   */
+  private async getOrgCurrencyCode(): Promise<string> {
+    this.orgCurrencyCodePromise ??= getOrgCurrencyCode(this.context.organizationId)
+    return this.orgCurrencyCodePromise
+  }
+
   async prefetchFields(refs: ResourceReference[], fieldRefs: FieldReference[]): Promise<void> {
     if (refs.length === 0 || fieldRefs.length === 0) return
 
@@ -1001,6 +1015,18 @@ export class ExecutionContextManager implements ContextManager {
       })),
     })
 
+    // The org rung for CURRENCY, layered in as values enter the cache — one
+    // site covers every downstream read (display values, friendly values,
+    // materialized objects). A field that never picked a code follows
+    // `organization.currency`; one that did is untouched.
+    //
+    // Only read the setting when this batch ACTUALLY contains a currency field:
+    // most workflow prefetches touch none, and an unconditional read would put
+    // an org-cache hit on every one of them.
+    const orgCurrencyCode = result.values.some((v) => v.fieldType === 'CURRENCY')
+      ? await this.getOrgCurrencyCode()
+      : undefined
+
     // Store results in cache
     for (const entry of result.values) {
       const key = fieldRefToKey(entry.fieldRef)
@@ -1017,7 +1043,7 @@ export class ExecutionContextManager implements ContextManager {
       record.fields.set(key, {
         typed: entry.value,
         fieldType: entry.fieldType,
-        fieldOptions: entry.fieldOptions,
+        fieldOptions: withOrgCurrency(entry.fieldOptions, entry.fieldType, orgCurrencyCode),
       })
     }
   }
@@ -1068,7 +1094,10 @@ export class ExecutionContextManager implements ContextManager {
     const cached: CachedFieldValue = {
       typed: entry.value,
       fieldType: entry.fieldType,
-      fieldOptions: entry.fieldOptions,
+      fieldOptions:
+        entry.fieldType === 'CURRENCY'
+          ? withOrgCurrency(entry.fieldOptions, entry.fieldType, await this.getOrgCurrencyCode())
+          : entry.fieldOptions,
     }
     cacheEntry.fields.set(key, cached)
     return cached
@@ -1143,7 +1172,8 @@ export class ExecutionContextManager implements ContextManager {
         )
 
         // For field types where rawValue is an object (ACTOR, NAME), use the display
-        // string so String() calls in join/pluck produce readable output
+        // string so String() calls in join/pluck produce readable output.
+        // CURRENCY needs no special case: its raw value is a bare number.
         const fieldValue =
           rawValue !== null && typeof rawValue === 'object' && !Array.isArray(rawValue)
             ? displayStr
@@ -2135,6 +2165,12 @@ function stringifyDisplayValue(displayValue: unknown): string {
  * Get a friendly value from a cached field value.
  * For field types where formatToRawValue returns an object (ACTOR, NAME),
  * returns the display string instead so String() calls produce readable output.
+ *
+ * CURRENCY needs no special case: its raw value is the bare minor-unit number,
+ * which is what `if-else` must see. A workflow variable feeds numeric
+ * comparison — `evaluate-operator` coerces both sides with `Number()`, so an
+ * object there would stringify to `"$250.00"` -> `NaN` and a branch on
+ * `total > 1000` would silently stop firing.
  */
 function cachedToFriendlyValue(cached: CachedFieldValue): unknown {
   const raw = formatToRawValue(cached.typed, cached.fieldType)

--- a/packages/lib/src/workflow-engine/nodes/transform-nodes/__tests__/format-config-toggles.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/transform-nodes/__tests__/format-config-toggles.test.ts
@@ -117,8 +117,12 @@ describe('FormatProcessor — moded config fields', () => {
   })
 
   describe('currencyConfig.currencyCode', () => {
-    it('honours a constant code', async () => {
-      const node = createMockNode('currency', '1234.5', {
+    it('honours a constant code, treating the input as MINOR UNITS', async () => {
+      // The input is an integer count of minor units — the platform-wide
+      // CURRENCY convention. This op used to apply no scaling at all, so a
+      // stored value rendered 10^exponent high while every other reader
+      // divided.
+      const node = createMockNode('currency', '123450', {
         currencyConfig: { locale: 'en-US', currencyCode: 'USD' },
       })
       const result = await processor.execute(node, createMockContext())
@@ -126,8 +130,18 @@ describe('FormatProcessor — moded config fields', () => {
       expect(result.output?.result).toContain('$')
     })
 
+    it('takes the scale from the code, not a hardcoded 100', async () => {
+      // JPY has exponent 0: 1000 minor units is ¥1,000, not ¥10.00.
+      const node = createMockNode('currency', '1000', {
+        currencyConfig: { locale: 'en-US', currencyCode: 'JPY' },
+      })
+      const result = await processor.execute(node, createMockContext())
+      expect(result.output?.result).toContain('1,000')
+      expect(result.output?.result).not.toContain('10.00')
+    })
+
     it('resolves a bound variable', async () => {
-      const node = createMockNode('currency', '1234.5', {
+      const node = createMockNode('currency', '123450', {
         currencyConfig: { locale: 'en-US', currencyCode: 'shopify_get_order.order.currency' },
         fieldModes: { currencyCode: false },
       })

--- a/packages/lib/src/workflow-engine/nodes/transform-nodes/__tests__/format-processor.test.ts
+++ b/packages/lib/src/workflow-engine/nodes/transform-nodes/__tests__/format-processor.test.ts
@@ -256,8 +256,8 @@ describe('FormatProcessor', () => {
   // --- Number Formatting ---
 
   describe('Number Formatting', () => {
-    it('currency USD', async () => {
-      const node = createMockNode('currency', '1234.5', {
+    it('currency USD — input is integer MINOR UNITS', async () => {
+      const node = createMockNode('currency', '123450', {
         currencyConfig: { locale: 'en-US', currencyCode: 'USD' },
       })
       const result = await processor.execute(node, createMockContext())

--- a/packages/lib/src/workflow-engine/nodes/transform-nodes/format-processor.ts
+++ b/packages/lib/src/workflow-engine/nodes/transform-nodes/format-processor.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/workflow-engine/nodes/transform-nodes/format-processor.ts
 
+import { minorUnitExponent } from '@auxx/utils/currency'
 import type { ExecutionContextManager } from '../../core/execution-context'
 import type { NodeExecutionResult, ValidationResult, WorkflowNode } from '../../core/types'
 import { NodeRunningStatus, WorkflowNodeType } from '../../core/types'
@@ -266,7 +267,11 @@ export class FormatProcessor extends BaseNodeProcessor {
               'USD',
               ctx
             )
-            result = new Intl.NumberFormat(locale, { style: 'currency', currency }).format(num)
+            // The input is integer MINOR UNITS, the platform-wide CURRENCY
+            // convention — this node applied no scaling at all and rendered
+            // stored values 10^exponent high.
+            const major = num / 10 ** minorUnitExponent(currency)
+            result = new Intl.NumberFormat(locale, { style: 'currency', currency }).format(major)
           }
           break
         }

--- a/packages/types/field-value/index.ts
+++ b/packages/types/field-value/index.ts
@@ -116,7 +116,15 @@ export interface TextFieldValue extends BaseFieldValue {
   value: string
 }
 
-/** Numeric value for NUMBER, CURRENCY fields */
+/**
+ * Numeric value for NUMBER, CURRENCY fields.
+ *
+ * A CURRENCY row carries NO per-value ISO code. The denomination is the
+ * FIELD's (`options.currencyCode`), asserted once and inherited by every value.
+ * `value` is an integer count of minor units in that denomination, which is
+ * what makes `valueNumber` sortable, filterable and summable — a per-row code
+ * would silently mix exponents inside one SUM.
+ */
 export interface NumberFieldValue extends BaseFieldValue {
   type: 'number'
   value: number
@@ -206,6 +214,8 @@ export interface TextFieldValueInput {
 export interface NumberFieldValueInput {
   type: 'number'
   value: number
+  /** ISO 4217 code — CURRENCY only. Omit to inherit. */
+  currency?: string
 }
 
 /** Boolean value input */
@@ -512,4 +522,111 @@ export function createTypedValueInput(
     default:
       return null
   }
+}
+
+// =============================================================================
+// valueJson ENVELOPE
+// =============================================================================
+
+/**
+ * Metadata section of the `valueJson` envelope. ONE OWNER PER TOP-LEVEL KEY —
+ * a writer read-modify-writes only its own key and preserves the rest, and a
+ * reader treats an unknown key as opaque and carries it through any round-trip
+ * that rewrites the row.
+ *
+ * Keys hold SMALL SCALAR FACTS only; `meta` rides the hot read projection. A
+ * key whose value is a document belongs in its own column or table.
+ *
+ * Reserved-key registry — adding a key means adding a line here:
+ * | `ai`       | `field-values/ai-commit.ts`         | AI-eligible types |
+ * | `src`      | reserved, not built (connector cells)                   |
+ * | `unit`     | reserved by convention (NUMBER)                         |
+ */
+export interface FieldValueMeta {
+  /** AI autofill provenance: model, tokens, inputHash, … */
+  ai?: unknown
+  [key: string]: unknown
+}
+
+/**
+ * The shape of `FieldValue.valueJson`.
+ *
+ * `v` carries the field's OWN value and is present only for json-typed fields
+ * (FILE / NAME / ADDRESS_STRUCT / JSON). A scalar field's value lives in its
+ * own typed column and never appears here — a CURRENCY row keeps its integer
+ * minor-unit amount in `valueNumber`, and reaches the envelope only if it
+ * carries AI provenance.
+ *
+ * Wrapping (rather than a reserved key beside the value) is what keeps the two
+ * owners apart: `FieldType.JSON` stores arbitrary user data, so no reserved key
+ * exists that a user could not legitimately write.
+ */
+export interface FieldValueEnvelope {
+  v?: unknown
+  meta?: FieldValueMeta
+}
+
+/**
+ * Read a stored `valueJson` as an envelope.
+ *
+ * Tolerates a pre-envelope row: a json-typed row whose object IS the value, and
+ * a scalar row whose object is the legacy root-level AI bag. The `'v' in obj`
+ * probe is ambiguous for exactly one type — `FieldType.JSON`, where a user could
+ * legitimately store a top-level `v` — which is why the fallback is temporary
+ * and deleted the release after the migration runs.
+ */
+export function readEnvelope(json: unknown): FieldValueEnvelope {
+  if (json === null || json === undefined || typeof json !== 'object' || Array.isArray(json)) {
+    return {}
+  }
+  const obj = json as Record<string, unknown>
+  if ('v' in obj || 'meta' in obj) {
+    return {
+      v: obj.v,
+      meta: (obj.meta as FieldValueMeta | undefined) ?? undefined,
+    }
+  }
+  // Legacy row, pre-envelope: the object is the value itself.
+  return { v: obj }
+}
+
+/** Read just the metadata section of a stored `valueJson`. */
+export function readMeta(json: unknown): FieldValueMeta {
+  return readEnvelope(json).meta ?? {}
+}
+
+/**
+ * Build a `valueJson` payload, omitting the column entirely when there is
+ * neither a value nor any metadata to store — a currency row that never
+ * asserted a code stays `valueJson IS NULL`, keeping it out of the read
+ * projection.
+ */
+export function writeEnvelope(v: unknown, meta?: FieldValueMeta): FieldValueEnvelope | null {
+  const hasMeta = meta !== undefined && Object.keys(meta).length > 0
+  const hasValue = v !== undefined
+  if (!hasMeta && !hasValue) return null
+  const out: FieldValueEnvelope = {}
+  if (hasValue) out.v = v
+  if (hasMeta) out.meta = meta
+  return out
+}
+
+/**
+ * Merge one metadata key into an existing stored `valueJson`, preserving the
+ * value and every key this writer does not own. This is the ONLY sanctioned way
+ * to write metadata — never `valueJson = { … }` wholesale.
+ */
+export function mergeMeta(
+  existing: unknown,
+  key: string,
+  value: unknown
+): FieldValueEnvelope | null {
+  const env = readEnvelope(existing)
+  const meta = { ...(env.meta ?? {}) }
+  if (value === undefined) {
+    delete meta[key]
+  } else {
+    meta[key] = value
+  }
+  return writeEnvelope(env.v, meta)
 }

--- a/packages/ui/src/components/input-currency.tsx
+++ b/packages/ui/src/components/input-currency.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { cn } from '@auxx/ui/lib/utils'
+import { minorUnitExponent } from '@auxx/utils/currency'
 import * as React from 'react'
 import { clampValue, decrementValue, incrementValue } from './input-number-utils'
 
@@ -15,43 +16,44 @@ import { clampValue, decrementValue, incrementValue } from './input-number-utils
 export type CurrencyDisplayType = 'symbol' | 'code' | 'name'
 
 /**
- * Decimal places type for currency display
- */
-export type DecimalPlacesType = 'two-places' | 'no-decimal'
-
-/**
  * Context value provided by CurrencyInput to all child components
  */
 interface CurrencyInputContextValue {
-  /** Current value in cents (integer) */
+  /** Current value in MINOR UNITS (integer) */
   value: number | undefined
   /** Whether the input is disabled */
   disabled?: boolean
   /** Whether the input is read-only */
   readOnly?: boolean
-  /** Minimum allowed value in cents */
+  /** Minimum allowed value in minor units */
   min?: number
-  /** Maximum allowed value in cents */
+  /** Maximum allowed value in minor units */
   max?: number
   /** ISO 4217 currency code */
   currencyCode: string
   /** How to display the currency */
   currencyDisplay: CurrencyDisplayType
-  /** Decimal places for display */
-  decimalPlaces: DecimalPlacesType
+  /**
+   * Minor-unit exponent derived from `currencyCode` — 2 for USD, 0 for JPY,
+   * 3 for KWD. Also the number of fraction digits shown, unless `decimals`
+   * overrides it.
+   */
+  exponent: number
+  /** Fraction digits to render (defaults to `exponent`). */
+  decimals: number
   /** Locale for formatting */
   locale: string
-  /** Increment the value (by 100 cents = $1 by default) */
+  /** Increment the value by one major unit */
   increment: () => void
-  /** Decrement the value (by 100 cents = $1 by default) */
+  /** Decrement the value by one major unit */
   decrement: () => void
-  /** Set a new value (in cents) with validation and clamping */
+  /** Set a new value (in minor units) with validation and clamping */
   setValue: (value: number | undefined) => void
   /** Get the currency symbol */
   getCurrencySymbol: () => string
-  /** Format cents to display string */
-  formatValue: (cents: number) => string
-  /** Parse display string to cents */
+  /** Format minor units to display string */
+  formatValue: (minorUnits: number) => string
+  /** Parse display string to minor units */
   parseValue: (display: string) => number | null
 }
 
@@ -59,22 +61,29 @@ interface CurrencyInputContextValue {
  * Props for the CurrencyInput root component (context provider)
  */
 export interface CurrencyInputProps extends React.PropsWithChildren {
-  /** Controlled value in cents */
-  value?: number
-  /** Default value for uncontrolled mode (in cents) */
+  /** Controlled value: INTEGER MINOR UNITS, denominated in `currencyCode`. */
+  value?: number | null
+  /** Default value for uncontrolled mode (minor units) */
   defaultValue?: number
-  /** Callback when value changes (value is in cents) */
+  /**
+   * Callback when the amount changes. Always a BARE NUMBER of minor units — the
+   * FIELD defines the currency and a value never asserts one of its own.
+   */
   onValueChange?: (value: number | undefined) => void
-  /** Minimum allowed value in cents */
+  /** Minimum allowed value in minor units */
   min?: number
-  /** Maximum allowed value in cents */
+  /** Maximum allowed value in minor units */
   max?: number
   /** ISO 4217 currency code (default: 'USD') */
   currencyCode?: string
   /** How to display the currency (default: 'symbol') */
   currencyDisplay?: CurrencyDisplayType
-  /** Decimal places (default: 'two-places') */
-  decimalPlaces?: DecimalPlacesType
+  /**
+   * Fraction digits to render. Defaults to the code's minor-unit exponent —
+   * 2 for USD, 0 for JPY, 3 for KWD — so leaving it unset is correct for every
+   * currency. Pass a number only to deliberately override that.
+   */
+  decimals?: number
   /** Locale for formatting (default: 'en-US') */
   locale?: string
   /** Whether the input is disabled */
@@ -127,6 +136,11 @@ function useCurrencyInput() {
  * </CurrencyInput>
  * ```
  */
+function toMinorUnits(value: number | null | undefined): number | undefined {
+  if (value === null || value === undefined) return undefined
+  return Number.isFinite(value) ? value : undefined
+}
+
 function CurrencyInput({
   value: controlledValue,
   defaultValue,
@@ -135,23 +149,31 @@ function CurrencyInput({
   max,
   currencyCode = 'USD',
   currencyDisplay = 'symbol',
-  decimalPlaces = 'two-places',
+  decimals: decimalsProp,
   locale = 'en-US',
   disabled = false,
   readOnly = false,
   children,
 }: CurrencyInputProps) {
   // Determine if component is controlled
-  const isControlled = controlledValue !== undefined
+  const isControlled = controlledValue !== undefined && controlledValue !== null
 
   // Internal state for uncontrolled mode
-  const [uncontrolledValue, setUncontrolledValue] = React.useState<number | undefined>(defaultValue)
+  const [uncontrolledValue, setUncontrolledValue] = React.useState<number | undefined>(
+    toMinorUnits(defaultValue)
+  )
 
   // Use controlled value if provided, otherwise use internal state
-  const value = isControlled ? controlledValue : uncontrolledValue
+  const value = isControlled ? toMinorUnits(controlledValue) : uncontrolledValue
 
-  // Step is 100 cents ($1.00)
-  const step = 100
+  /**
+   * Scale comes from the CODE, never a hardcoded 100. USD 2, JPY 0, KWD 3.
+   */
+  const exponent = React.useMemo(() => minorUnitExponent(currencyCode), [currencyCode])
+  const decimals = decimalsProp ?? exponent
+
+  // One step is one MAJOR unit: $1.00 = 100 cents, ¥1 = 1 yen.
+  const step = 10 ** exponent
 
   /**
    * Get currency symbol using Intl
@@ -175,30 +197,33 @@ function CurrencyInput({
    * Format cents to display string (without currency symbol)
    */
   const formatValue = React.useCallback(
-    (cents: number): string => {
-      const dollars = cents / 100
-      if (decimalPlaces === 'no-decimal') {
-        return Math.round(dollars).toString()
-      }
-      return dollars.toFixed(2)
+    (minorUnits: number): string => {
+      const major = minorUnits / 10 ** exponent
+      return major.toFixed(decimals)
     },
-    [decimalPlaces]
+    [exponent, decimals]
   )
 
   /**
    * Parse display string to cents
    */
-  const parseValue = React.useCallback((display: string): number | null => {
-    // Remove currency symbols, commas, spaces
-    const cleaned = display.replace(/[$€£¥₹₩,\s]/g, '').trim()
-    if (!cleaned) return null
+  const parseValue = React.useCallback(
+    (display: string): number | null => {
+      // Strip anything that is not part of a number. Deliberately not a fixed
+      // symbol list — that only covered five currencies and mangled the rest.
+      const cleaned = display
+        .replace(/[^0-9.,-]/g, '')
+        .replace(/,/g, '')
+        .trim()
+      if (!cleaned) return null
 
-    const parsed = parseFloat(cleaned)
-    if (Number.isNaN(parsed)) return null
+      const parsed = Number.parseFloat(cleaned)
+      if (Number.isNaN(parsed)) return null
 
-    // Convert to cents
-    return Math.round(parsed * 100)
-  }, [])
+      return Math.round(parsed * 10 ** exponent)
+    },
+    [exponent]
+  )
 
   /**
    * Set value with validation and clamping
@@ -243,7 +268,8 @@ function CurrencyInput({
       max,
       currencyCode,
       currencyDisplay,
-      decimalPlaces,
+      exponent,
+      decimals,
       locale,
       increment,
       decrement,
@@ -260,7 +286,8 @@ function CurrencyInput({
       max,
       currencyCode,
       currencyDisplay,
-      decimalPlaces,
+      exponent,
+      decimals,
       locale,
       increment,
       decrement,
@@ -302,7 +329,7 @@ const CurrencyInputField = React.forwardRef<HTMLInputElement, CurrencyInputField
       readOnly,
       min,
       max,
-      decimalPlaces,
+      decimals,
       increment,
       decrement,
       setValue,
@@ -425,7 +452,7 @@ const CurrencyInputField = React.forwardRef<HTMLInputElement, CurrencyInputField
           onBlur={handleBlur}
           disabled={disabled}
           readOnly={readOnly}
-          step={decimalPlaces === 'no-decimal' ? '1' : '0.01'}
+          step={decimals === 0 ? '1' : (10 ** -decimals).toFixed(decimals)}
           className={cn(
             // Base styling
             'flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 focus-visible:outline-none focus:ring-0 focus:outline-none dark:bg-transparent',

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -183,7 +183,6 @@ export {
   CurrencyInputField,
   type CurrencyInputFieldProps,
   type CurrencyInputProps,
-  type DecimalPlacesType,
   useCurrencyInput,
 } from './components/input-currency'
 export {

--- a/packages/utils/src/__tests__/currency.test.ts
+++ b/packages/utils/src/__tests__/currency.test.ts
@@ -1,7 +1,13 @@
 // packages/utils/src/__tests__/currency.test.ts
 
 import { describe, expect, it } from 'vitest'
-import { formatCurrency, formatCurrencyCompact } from '../currency'
+import {
+  formatCurrency,
+  formatCurrencyCompact,
+  minorToMajorString,
+  minorUnitExponent,
+  parseMajorToMinor,
+} from '../currency'
 
 describe('formatCurrencyCompact', () => {
   it('drops cents on small values', () => {
@@ -30,5 +36,56 @@ describe('formatCurrencyCompact', () => {
     // The existing field display mode keeps `.00`; the axis variant must not.
     expect(formatCurrency(1_200_000, { currencyDisplay: 'compact' })).toBe('$12.00K')
     expect(formatCurrencyCompact(1_200_000)).toBe('$12K')
+  })
+})
+
+describe('minorUnitExponent', () => {
+  it('derives the ISO 4217 exponent from the code', () => {
+    expect(minorUnitExponent('USD')).toBe(2)
+    expect(minorUnitExponent('EUR')).toBe(2)
+    expect(minorUnitExponent('JPY')).toBe(0)
+    expect(minorUnitExponent('KWD')).toBe(3)
+  })
+
+  it('is case-insensitive and falls back to 2 for junk', () => {
+    expect(minorUnitExponent('usd')).toBe(2)
+    expect(minorUnitExponent('ZZZ')).toBe(2)
+    expect(minorUnitExponent(null)).toBe(2)
+  })
+})
+
+describe('formatCurrency scale follows the code', () => {
+  it('is unchanged for exponent-2 currencies', () => {
+    expect(formatCurrency(2000, { currencyCode: 'USD' })).toBe('$20.00')
+    expect(formatCurrency(3229, { currencyCode: 'USD' })).toBe('$32.29')
+  })
+
+  it('does not divide a zero-exponent currency by 100', () => {
+    // 100000 minor units of JPY is ¥100,000 — not ¥1,000.00
+    expect(formatCurrency(100_000, { currencyCode: 'JPY' })).toBe('¥100,000')
+  })
+
+  it('uses thousandths for a three-exponent currency', () => {
+    expect(formatCurrency(1234, { currencyCode: 'KWD' })).toContain('1.234')
+  })
+})
+
+describe('parseMajorToMinor / minorToMajorString', () => {
+  it('round-trips through the code exponent', () => {
+    expect(parseMajorToMinor('19.99', 'USD')).toBe(1999)
+    expect(parseMajorToMinor('1000', 'JPY')).toBe(1000)
+    expect(parseMajorToMinor('1.234', 'KWD')).toBe(1234)
+    expect(minorToMajorString(1999, 'USD')).toBe('19.99')
+    expect(minorToMajorString(1000, 'JPY')).toBe('1000')
+  })
+
+  it('strips currency symbols and grouping', () => {
+    expect(parseMajorToMinor('$1,234.56', 'USD')).toBe(123456)
+  })
+
+  it('returns null for junk rather than NaN', () => {
+    expect(parseMajorToMinor('', 'USD')).toBeNull()
+    expect(parseMajorToMinor('abc', 'USD')).toBeNull()
+    expect(parseMajorToMinor(null, 'USD')).toBeNull()
   })
 })

--- a/packages/utils/src/currency.ts
+++ b/packages/utils/src/currency.ts
@@ -4,7 +4,7 @@
 export interface CurrencyDisplayOptions {
   /** ISO 4217 currency code (default 'USD') */
   currencyCode?: string
-  /** Number of decimal places to render (default 2) */
+  /** Number of decimal places to render (default: the code's minor-unit exponent) */
   decimals?: number
   /** Whether to use thousand separators (default true) */
   useGrouping?: boolean
@@ -16,26 +16,56 @@ export interface CurrencyDisplayOptions {
   currencyDisplay?: 'symbol' | 'code' | 'name' | 'compact'
 }
 
+const exponentCache = new Map<string, number>()
+
 /**
- * Format cents to currency display string
- * @param cents - Value in cents (integer)
+ * ISO 4217 minor-unit exponent for a currency code — the power of ten between a
+ * minor unit and the major unit. USD/EUR → 2 (cents), JPY/CLP → 0 (the minor
+ * unit IS the yen/peso), KWD/BHD → 3 (thousandths of a dinar).
+ *
+ * Derived from `Intl`, never stored: a persisted copy is a second source of
+ * truth that can disagree with the formatter sitting next to it. Falls back to
+ * 2 for an unrecognised code, matching the platform's historical assumption.
+ */
+export function minorUnitExponent(currencyCode: string | null | undefined): number {
+  const code = (currencyCode || 'USD').toUpperCase()
+  const cached = exponentCache.get(code)
+  if (cached !== undefined) return cached
+
+  let exponent = 2
+  try {
+    exponent =
+      new Intl.NumberFormat('en-US', { style: 'currency', currency: code }).resolvedOptions()
+        .maximumFractionDigits ?? 2
+  } catch {
+    exponent = 2
+  }
+  exponentCache.set(code, exponent)
+  return exponent
+}
+
+/**
+ * Format an INTEGER COUNT OF MINOR UNITS as a currency string.
+ *
+ * `minorUnits` is cents for USD/EUR, whole yen for JPY, thousandths of a dinar
+ * for KWD — never a decimal major-unit amount. $32.29 is `3229`, never `32.29`.
+ * The scale comes from `currencyCode` via {@link minorUnitExponent}.
+ *
+ * @param minorUnits - Value in minor units (integer)
  * @param options - Currency display options
  * @returns Formatted currency string
  */
 export function formatCurrency(
-  cents: number | null | undefined,
+  minorUnits: number | null | undefined,
   options: CurrencyDisplayOptions = {}
 ): string {
-  if (cents === null || cents === undefined) return '-'
+  if (minorUnits === null || minorUnits === undefined) return '-'
 
-  const {
-    currencyCode = 'USD',
-    decimals = 2,
-    useGrouping = true,
-    currencyDisplay = 'symbol',
-  } = options
+  const { currencyCode = 'USD', useGrouping = true, currencyDisplay = 'symbol' } = options
 
-  const dollars = cents / 100
+  const exponent = minorUnitExponent(currencyCode)
+  const decimals = options.decimals ?? exponent
+  const major = minorUnits / 10 ** exponent
   const isCompact = currencyDisplay === 'compact'
 
   const formatOptions: Intl.NumberFormatOptions = isCompact
@@ -46,8 +76,8 @@ export function formatCurrency(
         compactDisplay: 'short',
         // Intl rejects 'compact' for currencyDisplay; symbol is the natural pick
         currencyDisplay: 'symbol',
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
       }
     : {
         style: 'currency',
@@ -59,27 +89,27 @@ export function formatCurrency(
       }
 
   try {
-    return new Intl.NumberFormat('en-US', formatOptions).format(dollars)
+    return new Intl.NumberFormat('en-US', formatOptions).format(major)
   } catch {
     return isCompact
-      ? `${currencyCode} ${dollars.toFixed(0)}`
-      : `${currencyCode} ${dollars.toFixed(decimals)}`
+      ? `${currencyCode} ${major.toFixed(0)}`
+      : `${currencyCode} ${major.toFixed(decimals)}`
   }
 }
 
 /**
  * Compact currency for space-constrained surfaces (chart axes, badges), from
- * cents: 36000 → "$360", 1200000 → "$12K", 230000000 → "$2.3M". Unlike
- * `formatCurrency`'s `'compact'` display mode (which keeps two decimals, e.g.
- * `$12.00K`), this clamps to at most one fraction digit and drops cents.
+ * minor units: 36000 → "$360", 1200000 → "$12K", 230000000 → "$2.3M". Unlike
+ * `formatCurrency`'s `'compact'` display mode (which keeps the code's full
+ * decimals, e.g. `$12.00K`), this clamps to at most one fraction digit.
  */
 export function formatCurrencyCompact(
-  cents: number | null | undefined,
+  minorUnits: number | null | undefined,
   options: Pick<CurrencyDisplayOptions, 'currencyCode'> = {}
 ): string {
-  if (cents === null || cents === undefined) return '-'
+  if (minorUnits === null || minorUnits === undefined) return '-'
   const { currencyCode = 'USD' } = options
-  const dollars = cents / 100
+  const major = minorUnits / 10 ** minorUnitExponent(currencyCode)
   try {
     return new Intl.NumberFormat('en-US', {
       style: 'currency',
@@ -88,60 +118,59 @@ export function formatCurrencyCompact(
       compactDisplay: 'short',
       minimumFractionDigits: 0,
       maximumFractionDigits: 1,
-    }).format(dollars)
+    }).format(major)
   } catch {
-    return `${currencyCode} ${dollars.toFixed(0)}`
+    return `${currencyCode} ${major.toFixed(0)}`
   }
 }
 
 /**
- * Parse display value to cents
- * @param value - Display value (string or number)
- * @returns Value in cents (integer)
+ * Parse a MAJOR-unit amount (what a human types, or what a provider returns as
+ * a decimal string like Shopify's `"49.99"`) into integer minor units.
+ *
+ * Deliberately explicit about the input unit. Its predecessor `parseToCents`
+ * guessed — `Number.isInteger(v) && Math.abs(v) > 100 ? v : v * 100` — which is
+ * the undecidable dollars-vs-cents guess that produced 100×-wrong stored data.
+ * If you do not know the unit of your input, you cannot call this.
+ *
+ * @example parseMajorToMinor('19.99', 'USD') // 1999
+ * @example parseMajorToMinor('1000', 'JPY')  // 1000  (exponent 0)
  */
-export function parseToCents(value: string | number): number | null {
+export function parseMajorToMinor(
+  value: string | number | null | undefined,
+  currencyCode = 'USD'
+): number | null {
+  if (value === null || value === undefined) return null
+
+  let major: number
   if (typeof value === 'number') {
-    // If already a number, check if it looks like cents or dollars
-    if (Number.isInteger(value) && Math.abs(value) > 100) {
-      // Likely already in cents
-      return value
-    }
-    // Convert dollars to cents
-    return Math.round(value * 100)
-  }
-
-  if (typeof value === 'string') {
-    // Remove currency symbols, commas, spaces
-    const cleaned = value.replace(/[$€£¥₹₩,\s]/g, '').trim()
+    major = value
+  } else {
+    const cleaned = value
+      .replace(/[^0-9.,-]/g, '')
+      .replace(/,/g, '')
+      .trim()
     if (!cleaned) return null
-
-    const parsed = parseFloat(cleaned)
-    if (Number.isNaN(parsed)) return null
-
-    // Convert to cents
-    return Math.round(parsed * 100)
+    major = Number.parseFloat(cleaned)
   }
 
-  return null
+  if (Number.isNaN(major)) return null
+  return Math.round(major * 10 ** minorUnitExponent(currencyCode))
 }
 
 /**
- * Convert cents to dollars for input display
- * @param cents - Value in cents
- * @returns Value in dollars (decimal)
+ * Render integer minor units as a plain major-unit decimal string — no symbol,
+ * no grouping. For text inputs and copy-to-clipboard, where a formatted string
+ * would not round-trip.
+ *
+ * @example minorToMajorString(1999, 'USD') // '19.99'
+ * @example minorToMajorString(1000, 'JPY') // '1000'
  */
-export function centsToDollars(cents: number | null | undefined): string {
-  if (cents === null || cents === undefined) return ''
-  return (cents / 100).toFixed(2)
-}
-
-/**
- * Convert price string to cents
- * @param priceString - Price as a string
- * @returns Value in cents (integer) or null
- * @example "19.99" -> 1999
- */
-export const convertToCents = (priceString: string | null): number | null => {
-  if (priceString === null) return null
-  return Math.round(parseFloat(priceString) * 100)
+export function minorToMajorString(
+  minorUnits: number | null | undefined,
+  currencyCode = 'USD'
+): string {
+  if (minorUnits === null || minorUnits === undefined) return ''
+  const exponent = minorUnitExponent(currencyCode)
+  return (minorUnits / 10 ** exponent).toFixed(exponent)
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -39,11 +39,11 @@ export { csvCell, toCsv } from './csv'
 // Currency utilities
 export {
   type CurrencyDisplayOptions,
-  centsToDollars,
-  convertToCents,
   formatCurrency,
   formatCurrencyCompact,
-  parseToCents,
+  minorToMajorString,
+  minorUnitExponent,
+  parseMajorToMinor,
 } from './currency'
 // Date utilities
 export {


### PR DESCRIPTION
## Why

CURRENCY had three problems that turned out to be one problem: it guessed its own scale, it let a value *and* a column each claim a different denomination, and its raw value was an object where everything downstream expected a number.

Every failure in that last class is silent — `NaN`, an empty cell, or a permanently-`false` branch, never a throw.

## Minor units, derived scale

Storage is now an integer count of **minor units**, and the scale comes from the ISO code via `Intl` (USD 2, JPY 0, KWD 3) rather than a hardcoded `/100`.

`parseToCents`'s `Number.isInteger(v) && Math.abs(v) > 100 ? v : v * 100` guess is gone — that undecidable dollars-vs-cents call is what produced 100×-wrong stored data. A provider reporting decimal major units (Shopify's `"600.00"`) scales in its own projection. The write path asserts integrality, which *is* decidable and would have caught the connector passthrough at the first sync.

`valueJson` gains a `{ v, meta }` envelope so the field's value and the AI metadata bag stop sharing one column with no discriminator.

## A value carries no currency code, and a column cannot override one

Both overrides are removed. The reasoning is the same at both layers:

- `valueNumber` is what SQL sorts, filters and aggregates. A **per-row** code means `SUM(valueNumber)` mixes exponents silently, ordering compares scales rather than amounts, and one range filter means three different things. Real multi-currency is an amount field + a currency field + an FX-converted base field — not a code smuggled into each cell.
- A **column** override does not relabel money, it *rescales* it. A USD field holding `20000` ($200.00) rendered through a JPY override reads `¥20,000`, 100× high; through KWD, `KWD 20.000`, 1000× low. `decimals`/`useGrouping`/`currencyDisplay` can't do that — they restyle a number whose magnitude is fixed.

Prior art: `FieldOptions.timeZone` is the one DATE option that reinterprets an instant, and it's deliberately absent from `dateFormattingSchema` for exactly this reason.

Honest counter-argument, recorded rather than dismissed: NUMBER column formatting *does* change meaning (`displayAs: 'percentage'` divides by 100, `prefix`/`suffix` are free text). The distinction relied on is that a NUMBER field asserts no unit, so a column supplying one fills a vacuum, whereas a CURRENCY field has *declared* its denomination.

## The denomination resolves field → org → USD

A field that never picked a code follows `organization.currency` and moves with it; a field that did is pinned. `organization.currency` already defaulted to `'USD'` for every org (`getAllUserSettings` seeds every catalog key from its `defaultValue`), so **no data migration and no org-creation change was needed** — the gap was that nothing in the field layer read it.

The ~213 codeless fields were deliberately **not** backfilled: stamping `'USD'` onto them would freeze exactly the constituency the setting exists to serve. The resolved code is likewise never written back into `field.options` — including by an editor that pre-fills its picker and then spreads that value through the next unrelated `onChange`, which was live.

Server reads are conditional on a CURRENCY field actually being present, and the workflow context memoizes per run so one execution can't format two fields under different codes.

## Bugs surfaced along the way

- **`hasValueChanged` is type-aware.** CURRENCY read an object and wrote a number, so both sides fell through to `String(...)`, `"20000" !== "[object Object]"` was true forever, and every currency field committed on every blur without ever converging. ACTOR is asymmetric by design and is covered by the same generic collapse.
- **The web-local `DISPLAY_OPTION_KEYS` duplicate is derived from the canonical schema.** It filtered on *both* save and load, so any option the canonical schema gained but the copy did not evaporated before tRPC and read back off — indistinguishable from "this toggle is broken". Deriving it also recovered `includeTime` and `checkboxStyle`.
- **`decimals ?? 2` stamping at four sites**, which froze JPY columns at two decimals and made the editor's own "Match the currency (recommended)" option unreachable.
- **The column-formatting dialog stamped `currencyCode ?? 'USD'` on any save** — on a EUR field, changing only *Currency Display* silently flipped the column to `$`.

## Migrations

No migration for the removed keys — Zod strips undeclared keys, so stored configs parse fine and shed them on the next write. Migration `096-currency-minor-units` wraps the envelope, re-homes AI metadata, rescales Shopify-owned values and recomputes display strings, in that order (recompute must follow rescale).

## Testing

- `packages/lib` 10,645 tests, `apps/web` 3,752, `packages/ui`, `packages/utils` — all pass.
- `tsc --noEmit` clean for `packages/{types,ui,utils,lib}` and `apps/web`. Biome clean.
- New regression tests: bare-number raw shape and read/write symmetry; `readCurrency` returning `null` rather than `NaN`; `resolveCurrencyCode` precedence and malformed-code fall-through; `withOrgCurrency` layering, no-op'ing for other types and never mutating its input; the CURRENCY/ACTOR/NAME comparator; legacy `currencyCode` dropping out of a stored column config; every canonical display option surviving the save→load round trip.

Not yet verified in a browser — worth a pass over inline currency editing, JPY column formatting, the quote/invoice totals footer, and flipping `organization.currency` to EUR to confirm codeless fields move and pinned ones don't.
