### PR TITLE
chore: disclose ai providers and tighten the limited use allowlist

### DIFF
--- a/apps/homepage/src/app/privacy-policy/page.tsx
+++ b/apps/homepage/src/app/privacy-policy/page.tsx
@@ -29,7 +29,7 @@ export default function PrivacyPolicyPage() {
 
                 <div className='prose prose-gray dark:prose-invert max-w-none space-y-8'>
                   <section>
-                    <p className='text-sm text-gray-500'>Last updated: April 26, 2026</p>
+                    <p className='text-sm text-gray-500'>Last updated: August 20, 2026</p>
                     <p className='mt-4'>
                       This Privacy Policy describes how {config.shortName} ("we," "us," or "our")
                       collects, uses, and shares your personal information when you use our website,
@@ -195,10 +195,11 @@ export default function PrivacyPolicyPage() {
 
                     <h3 className='text-xl font-semibold mt-4'>Use of AI in the Service</h3>
                     <p>
-                      The Service uses large language models (currently provided by OpenAI and
-                      Anthropic) to draft replies, classify tickets, and surface suggested actions
-                      to your support agents. By default, AI-drafted replies appear as drafts that a
-                      human reviews and sends from the {config.shortName} inbox.
+                      The Service uses large language models (provided by OpenAI and Anthropic by
+                      default, or by another provider your workspace configures with its own API
+                      key) to draft replies, classify tickets, and surface suggested actions to your
+                      support agents. By default, AI-drafted replies appear as drafts that a human
+                      reviews and sends from the {config.shortName} inbox.
                     </p>
                     <p className='mt-2'>
                       The Service also offers a <strong>workflow builder</strong> that lets the
@@ -293,10 +294,23 @@ export default function PrivacyPolicyPage() {
 
                     <h3 className='text-xl font-semibold mt-4'>Data Sharing</h3>
                     <p>
-                      Google user data is not sold to third parties. We share the minimum data
-                      necessary with AI service providers (such as OpenAI and Anthropic) solely for
-                      the purpose of generating customer support responses. No other third parties
-                      receive your Google user data unless required by law.
+                      Google user data is not sold to third parties. To generate customer support
+                      responses and to build search indexes within your workspace, we transmit the
+                      minimum necessary data to the AI providers we use: OpenAI, Anthropic and
+                      Voyage AI. Each of these providers is contractually bound not to use data
+                      submitted through their APIs to train their models. We do not route data
+                      through any AI aggregator, gateway or model hub, and we do not operate any
+                      self-hosted model. No other third parties receive your Google user data unless
+                      required by law.
+                    </p>
+                    <p className='mt-2'>
+                      A workspace may instead configure its own key for a different AI provider, in
+                      which case data is sent to that provider at the workspace operator's
+                      direction. Where a workspace has a Google account connected,{' '}
+                      {config.shortName} permits only providers whose API terms forbid training on
+                      submitted data to be selected or configured; providers whose terms permit
+                      training on submitted data cannot be used by that workspace at all, including
+                      through a customer-supplied key.
                     </p>
 
                     <h3 className='text-xl font-semibold mt-4'>
@@ -314,7 +328,10 @@ export default function PrivacyPolicyPage() {
                       </a>
                       , including the Limited Use requirements. We only use Google user data to
                       provide and improve the user-facing features that are visible and prominent in
-                      our application's user interface.
+                      our application's user interface. Google user data is never used to create,
+                      train, or improve any generalized or foundational artificial intelligence or
+                      machine learning model, whether our own or a third party's. This applies to
+                      raw, aggregated, anonymized, and derived data alike.
                     </p>
 
                     <h3 className='text-xl font-semibold mt-4'>Revoking Access</h3>
@@ -460,7 +477,8 @@ export default function PrivacyPolicyPage() {
                       </li>
                       <li>
                         <strong>AI providers:</strong> OpenAI (US), Anthropic (US) — generating
-                        AI-drafted ticket replies.
+                        AI-drafted ticket replies; Voyage AI (US) — text embeddings for in-workspace
+                        search. None of these providers train their models on data we submit.
                       </li>
                       <li>
                         <strong>Email delivery:</strong> Mailgun / Amazon SES (US) — transactional

--- a/packages/lib/src/ai/providers/__tests__/limited-use-gate.test.ts
+++ b/packages/lib/src/ai/providers/__tests__/limited-use-gate.test.ts
@@ -94,6 +94,7 @@ describe('assertProviderAllowed', () => {
   })
 
   it.each([
+    'groq',
     'deepseek',
     'qwen',
     'kimi',
@@ -106,6 +107,7 @@ describe('assertProviderAllowed', () => {
   })
 
   it.each([
+    'groq',
     'deepseek',
     'qwen',
     'kimi',

--- a/packages/lib/src/ai/providers/config/context.ts
+++ b/packages/lib/src/ai/providers/config/context.ts
@@ -30,7 +30,7 @@ export const SYSTEM_ELIGIBLE_PROVIDERS = new Set(['anthropic', 'openai'])
  * `google` belongs here only on the PAID Gemini tier; the free AI Studio tier trains on
  * prompts. Re-check before adding a provider — this list is a compliance assertion.
  */
-export const LIMITED_USE_SAFE_PROVIDERS = new Set(['openai', 'anthropic', 'google', 'groq'])
+export const LIMITED_USE_SAFE_PROVIDERS = new Set(['openai', 'anthropic', 'google'])
 
 /**
  * Whether a provider is blocked for an org, given the org's already-resolved gate state.


### PR DESCRIPTION
Two changes for the round-3 Google OAuth verification reply, both in the AI/ML Limited Use section Trust & Safety added this round.

## Privacy policy

`/privacy-policy` named only OpenAI and Anthropic, said nothing about training, and omitted **Voyage AI** — which receives ticket bodies as embeddings and is therefore a recipient of derived Workspace data.

- **Data Sharing** now names all three, states that none of them train on submitted data, and rules out aggregators, gateways, model hubs and self-hosted models (Google asks about "Multi-Model Services & Downstream Models" directly).
- A second paragraph covers the BYO-key path honestly: with a customer-supplied key, data goes to that provider at the operator's direction, and a workspace with a connected Google account can only reach providers whose terms forbid training. Claiming an exhaustive three-provider list would have been false while BYO exists.
- **Limited Use** gains the never-used-to-train-any-model sentence, covering raw, aggregated, anonymized and derived data alike.
- Subprocessor list and the "Use of AI in the Service" section updated so the page doesn't contradict itself.

## Groq

`LIMITED_USE_SAFE_PROVIDERS` is a compliance assertion — a Google-connected org can reach only what's on it. Groq was there on the strength of its stated no-training position, a weaker basis than the contractual API terms the others carry. It's now `openai`, `anthropic`, `google`.

**Customer-visible:** an org with a Google channel connected loses Groq from its model picker. Orgs without one are unaffected and keep it, so the internal test path is intact. Worth checking prod for orgs holding both a Google channel and a BYO Groq key before this deploys.

## Test plan

- [x] `limited-use-gate.test.ts` — 27/27 pass, groq asserted blocked on a gated org and allowed without one
- [x] `apps/homepage` typecheck clean
- [ ] Confirm the new text is live on https://auxx.ai/privacy-policy after deploy — the reviewer fetches the URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)