### PR TITLE
fix(import): live-refresh records during import via records:invalidated

### DIFF
--- a/apps/web/src/components/resources/hooks/use-resource-sync.ts
+++ b/apps/web/src/components/resources/hooks/use-resource-sync.ts
@@ -164,6 +164,92 @@ export function useResourceSync() {
   const removeRecord = useRecordStore((s) => s.removeRecord)
   const invalidateLists = useRecordStore((s) => s.invalidateLists)
 
+  // ─── CATCH-UP ON (RE)SUBSCRIBE ──────────────────────────────────────────
+  //
+  // Pusher replays nothing to a channel you were not on, and a record channel
+  // cannot bind until `resource.list` resolves (its key needs the def id). So
+  // anything published between mount and that handshake — and between a
+  // dropped connection and its resubscribe — is simply never delivered.
+  //
+  // The SUBSCRIBE lane is scoped by `hasMaterializedState`: only defs this client
+  // had already loaded when the channel bound can hold stale data, which on a cold
+  // page load is nothing at all (the list query needs the same catalog the
+  // channel key does) and after that is just what is on screen. So it is one
+  // def, not the 20–40 the client subscribes to.
+  //
+  // `records:invalidated` reuses the same three lanes without that guard — see
+  // `handleRecordsInvalidated`. It is unconditional because a def with no
+  // materialized state costs nothing here: lane 1 invalidates an unloaded query
+  // and lanes 2–3 short-circuit on an empty id list.
+  //
+  // Both lanes below overwrite in place instead of dropping. Dropping is not
+  // an option for values: the subscriber hooks dedupe per key for the lifetime
+  // of the mount, so an invalidated cell would never be re-requested.
+  const catchUpDefsRef = useRef<Set<string>>(new Set())
+  const catchUpTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const runCatchUp = useCallback(
+    (entityDefinitionIds: string[]) => {
+      for (const entityDefinitionId of entityDefinitionIds) {
+        // 1. Row membership — creates/deletes/archives/bulk invalidations. The
+        //    tRPC data stays cached while it refetches, so rows do not blank.
+        invalidateLists(entityDefinitionId)
+        utils.record.listFiltered.invalidate({ entityDefinitionId })
+
+        const ids = cachedRecordIdsForDef(entityDefinitionId, CATCH_UP_RECORD_CAP)
+        if (ids.length === 0) continue
+
+        // 2. Record meta — a missed `record:updated` (display name, avatar).
+        //    `updateRecord` patches rows we already hold and ignores the rest.
+        utils.record.getByIds
+          .fetch({ items: ids.map((id) => toRecordId(entityDefinitionId, id)) }, { staleTime: 0 })
+          .then((data) => {
+            for (const item of Object.values(data ?? {})) {
+              updateRecord(entityDefinitionId, item.id, {
+                displayName: item.displayName,
+                secondaryInfo: item.secondaryInfo,
+                avatarUrl: item.avatarUrl,
+                // A missed grant/revoke changes the row-effective rung, not the
+                // row (plan v3/03 §5.2) — so the catch-up must carry `_access`
+                // or a member whose share was revoked keeps the edit affordance
+                // until the row is evicted.
+                _access: item._access,
+              })
+            }
+          })
+          .catch(() => {
+            /* best-effort; the next subscribe or refresh retries */
+          })
+
+        // 3. Cell values — a missed `fieldValues:updated`. Refreshes exactly
+        //    the cells already in the store, in one batched request.
+        const requests = cachedValueRequests(entityDefinitionId, new Set(ids))
+        if (requests.length > 0) fieldValueFetchQueue.refetch(requests)
+      }
+    },
+    [invalidateLists, updateRecord, utils]
+  )
+
+  /**
+   * Coalesce a def into the next catch-up pass. Two callers: a record channel
+   * (re)binding, and a `records:invalidated` frame from a bulk write — both
+   * mean "this def may hold stale rows AND stale cells", which is all three
+   * lanes, not just the list.
+   */
+  const scheduleCatchUp = useCallback(
+    (entityDefinitionId: string) => {
+      catchUpDefsRef.current.add(entityDefinitionId)
+      if (catchUpTimerRef.current) return
+      catchUpTimerRef.current = setTimeout(() => {
+        catchUpTimerRef.current = null
+        const defIds = [...catchUpDefsRef.current]
+        catchUpDefsRef.current.clear()
+        runCatchUp(defIds)
+      }, CATCH_UP_COALESCE_MS)
+    },
+    [runCatchUp]
+  )
+
   // Merge fieldValues:updated into the store. An entry with `value` present
   // goes through `setValues` (which preserves the pending-optimistic skip).
   // An entry with `aiStatus` present writes the AI marker — `null` clears it.
@@ -244,17 +330,23 @@ export function useResourceSync() {
     [invalidateLists, utils]
   )
 
-  // Coarse refresh from a bulk write (data-connector slice). Per-record realtime
-  // is suppressed for those writes, so a single invalidate per def per slice
-  // re-pulls the visible list (records + field values) without the firehose.
-  // Same body as handleRecordArchived — invalidate lists + listFiltered.
+  // Coarse refresh from a bulk write (data-connector slice, import execution).
+  // Per-record realtime is suppressed for those writes, so this one frame per
+  // def per slice is the only signal the client gets.
+  //
+  // It runs the FULL catch-up, not just the list invalidate. `listFiltered`
+  // returns ids only, and `use-record-list` fetches a record solely when the id
+  // is absent from the store — so a list-only refresh surfaces rows a bulk write
+  // CREATED and shows nothing for the rows it UPDATED. An import whose strategy
+  // is `update` matches existing records by definition, which is exactly the case
+  // a list invalidate cannot see. Lanes 2 and 3 refresh the cached record meta
+  // and the cached cells, which is where an update actually lands.
   const handleRecordsInvalidated = useCallback(
     (raw: unknown) => {
       const data = raw as RecordsInvalidatedEvent['data']
-      invalidateLists(data.entityDefinitionId)
-      utils.record.listFiltered.invalidate({ entityDefinitionId: data.entityDefinitionId })
+      scheduleCatchUp(data.entityDefinitionId)
     },
-    [invalidateLists, utils]
+    [scheduleCatchUp]
   )
 
   // A resource (entity DEFINITION) was created / renamed / removed elsewhere —
@@ -298,67 +390,6 @@ export function useResourceSync() {
     ]
   )
 
-  // ─── CATCH-UP ON (RE)SUBSCRIBE ──────────────────────────────────────────
-  //
-  // Pusher replays nothing to a channel you were not on, and a record channel
-  // cannot bind until `resource.list` resolves (its key needs the def id). So
-  // anything published between mount and that handshake — and between a
-  // dropped connection and its resubscribe — is simply never delivered.
-  //
-  // The catch-up is scoped by `hasMaterializedState`: only defs this client had
-  // already loaded when the channel bound can hold stale data, which on a cold
-  // page load is nothing at all (the list query needs the same catalog the
-  // channel key does) and after that is just what is on screen. So it is one
-  // def, not the 20–40 the client subscribes to.
-  //
-  // Both lanes below overwrite in place instead of dropping. Dropping is not
-  // an option for values: the subscriber hooks dedupe per key for the lifetime
-  // of the mount, so an invalidated cell would never be re-requested.
-  const catchUpDefsRef = useRef<Set<string>>(new Set())
-  const catchUpTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const runCatchUp = useCallback(
-    (entityDefinitionIds: string[]) => {
-      for (const entityDefinitionId of entityDefinitionIds) {
-        // 1. Row membership — creates/deletes/archives/bulk invalidations. The
-        //    tRPC data stays cached while it refetches, so rows do not blank.
-        invalidateLists(entityDefinitionId)
-        utils.record.listFiltered.invalidate({ entityDefinitionId })
-
-        const ids = cachedRecordIdsForDef(entityDefinitionId, CATCH_UP_RECORD_CAP)
-        if (ids.length === 0) continue
-
-        // 2. Record meta — a missed `record:updated` (display name, avatar).
-        //    `updateRecord` patches rows we already hold and ignores the rest.
-        utils.record.getByIds
-          .fetch({ items: ids.map((id) => toRecordId(entityDefinitionId, id)) }, { staleTime: 0 })
-          .then((data) => {
-            for (const item of Object.values(data ?? {})) {
-              updateRecord(entityDefinitionId, item.id, {
-                displayName: item.displayName,
-                secondaryInfo: item.secondaryInfo,
-                avatarUrl: item.avatarUrl,
-                // A missed grant/revoke changes the row-effective rung, not the
-                // row (plan v3/03 §5.2) — so the catch-up must carry `_access`
-                // or a member whose share was revoked keeps the edit affordance
-                // until the row is evicted.
-                _access: item._access,
-              })
-            }
-          })
-          .catch(() => {
-            /* best-effort; the next subscribe or refresh retries */
-          })
-
-        // 3. Cell values — a missed `fieldValues:updated`. Refreshes exactly
-        //    the cells already in the store, in one batched request.
-        const requests = cachedValueRequests(entityDefinitionId, new Set(ids))
-        if (requests.length > 0) fieldValueFetchQueue.refetch(requests)
-      }
-    },
-    [invalidateLists, updateRecord, utils]
-  )
-
   // The decision of WHETHER a def needs catching up is made here, at subscribe
   // time — not when the coalesced pass runs. Otherwise a list that resolves
   // during the coalesce window (the normal cold-load ordering) would look like
@@ -366,16 +397,9 @@ export function useResourceSync() {
   const handleDefSubscribed = useCallback(
     (entityDefinitionId: string) => {
       if (!hasMaterializedState(entityDefinitionId)) return
-      catchUpDefsRef.current.add(entityDefinitionId)
-      if (catchUpTimerRef.current) return
-      catchUpTimerRef.current = setTimeout(() => {
-        catchUpTimerRef.current = null
-        const defIds = [...catchUpDefsRef.current]
-        catchUpDefsRef.current.clear()
-        runCatchUp(defIds)
-      }, CATCH_UP_COALESCE_MS)
+      scheduleCatchUp(entityDefinitionId)
     },
-    [runCatchUp]
+    [scheduleCatchUp]
   )
 
   useEffect(

--- a/packages/lib/src/jobs/import/execute-plan-job.ts
+++ b/packages/lib/src/jobs/import/execute-plan-job.ts
@@ -5,7 +5,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { getPublishingClient } from '@auxx/redis'
 import { toRecordId } from '@auxx/types/resource'
 import { eq } from 'drizzle-orm'
-import { getCachedResource } from '../../cache'
+import { canonicalizeEntityDefinitionId, getCachedResource } from '../../cache'
 import {
   createEventPublisher,
   executePlan,
@@ -15,11 +15,20 @@ import {
   markJobFailed,
 } from '../../import'
 import type { FieldWriteModes, ImportMappingProperty, ImportPlan } from '../../import/types'
+import { getRealtimeService, publishRecordsInvalidated } from '../../realtime'
 import { UnifiedCrudHandler } from '../../resources/crud/unified-handler'
 import { getFieldOutputKey } from '../../resources/registry/field-types'
 import type { JobContext } from '../types'
 
 const logger = createScopedLogger('execute-plan-job')
+
+/**
+ * Minimum gap between the coarse `records:invalidated` frames published while
+ * rows land. Progress fires once per 50-row batch, so an unthrottled publish
+ * would put hundreds of frames on the def channel for a large file — the same
+ * firehose the `skipEvents` guard exists to avoid.
+ */
+const INVALIDATE_THROTTLE_MS = 2_000
 
 /** Job payload for executing an import plan */
 export interface ExecutePlanJobProps {
@@ -140,6 +149,35 @@ export async function executePlanJob(ctx: JobContext<ExecutePlanJobProps>): Prom
     // stub (zero cost) when the org has no enabled rules on this def.
     const { loadManifestCollector } = await import('../../record-rules/sync-manifest-collector')
     const manifest = await loadManifestCollector(organizationId)
+
+    // The import writes with `skipEvents: true`, so no `record:created` /
+    // `record:updated` / `fieldValues:updated` frame ever reaches an open grid.
+    // Publish the same coarse signal the connector sync path uses instead — one
+    // `records:invalidated` per def, which the client turns into a single list
+    // refetch. Without it the grid stays stale until a manual reload.
+    //
+    // Only this import's def is touched: relation lookups resolve against
+    // existing records and auto-create is not implemented (`resolve-relation-lookups`),
+    // so no other def receives writes.
+    //
+    // The room key MUST be canonicalized. `ImportMapping.entityDefinitionId` holds
+    // either keyspace — for a def-backed system type it is the bare entityType slug
+    // (`part`), while the client subscribes with `Resource.entityDefinitionId`, which
+    // is always the org's EntityDefinition CUID. `crudHandler` hides the difference
+    // because it resolves the def and publishes with `entityDef.id`; publishing the
+    // raw mapping value here addressed `…-records-part` while every browser sat on
+    // `…-records-<cuid>`, so the frame was delivered to nobody.
+    const roomDefId = await canonicalizeEntityDefinitionId(organizationId, entityDefinitionId)
+
+    let lastInvalidateAt = 0
+    const invalidateRecords = async (force = false) => {
+      const now = Date.now()
+      if (!force && now - lastInvalidateAt < INVALIDATE_THROTTLE_MS) return
+      lastInvalidateAt = now
+      await publishRecordsInvalidated(getRealtimeService(), organizationId, {
+        entityDefinitionIds: [roomDefId],
+      }).catch(() => {})
+    }
 
     const createRecord = async (data: {
       standardFields: Record<string, unknown>
@@ -285,11 +323,18 @@ export async function executePlanJob(ctx: JobContext<ExecutePlanJobProps>): Prom
           succeeded: progress.succeeded,
           failed: progress.failed,
         })
+
+        // Keep every open grid live while the import runs, not just at the end.
+        await invalidateRecords()
       },
     })
 
     // Mark job as completed
     await markJobCompleted(db, jobId, result.statistics)
+
+    // Final frame, unthrottled: the last batch's progress publish may have been
+    // swallowed by the throttle, and it is the one carrying the tail of the rows.
+    await invalidateRecords(true)
 
     // B2: persist the captured manifest on the ImportJob row and publish ONE pointer
     // event — the same row-transport the connector path uses (no inline cap, no silent

--- a/packages/lib/src/realtime/events.ts
+++ b/packages/lib/src/realtime/events.ts
@@ -135,12 +135,16 @@ export interface RecordArchivedEvent {
 }
 
 /**
- * Coarse "refresh this entity def" signal. Emitted ONCE per touched def per
- * bulk-write slice (data-connector sync) in place of the thousands of per-record
- * `record:created` / `fieldValues:updated` events those writes suppress. The
- * client invalidates the def's visible list + `listFiltered` query — a single
- * refetch that re-pulls records + field values — instead of the per-record
- * firehose that 403s Pusher at backfill scale.
+ * Coarse "refresh this entity def" signal. Emitted per touched def per bulk-write
+ * slice — data-connector sync, and import execution (throttled) — in place of the
+ * thousands of per-record `record:created` / `fieldValues:updated` events those
+ * writes suppress via `skipEvents`, which would 403 Pusher at backfill scale.
+ *
+ * The client runs its full three-lane catch-up for the def: invalidate the list +
+ * `listFiltered`, refresh cached record meta, refetch cached cell values. All three
+ * are required — `listFiltered` returns ids only and the record fetcher skips ids
+ * already in the store, so a list-only refresh reveals CREATED rows and misses
+ * UPDATED ones entirely.
  */
 export interface RecordsInvalidatedEvent {
   event: 'records:invalidated'


### PR DESCRIPTION
## Problem

Imported records never showed up in an open records grid until a manual reload.

The import worker writes through `UnifiedCrudHandler` with `skipEvents: true`, which suppresses `record:created`, `record:updated` **and** `fieldValues:updated`. Nothing reached the client. The only refresh was a client-local `record.listFiltered.invalidate()` in the tab that started the import, fired once on `execution:complete` — hence "all at once at the end, and only in that tab".

## Fixes

**1. Publish the coarse bulk-write signal (`execute-plan-job.ts`)**

The worker now emits `records:invalidated` — the event added for connector sync in #945 for exactly this situation — once per 50-row batch (throttled to 2s), plus one unthrottled frame after `markJobCompleted` since the last batch's frame is usually swallowed by the throttle.

Removing `skipEvents` was not an option: per-record realtime at import scale is the firehose that guard exists to prevent.

**2. Canonicalize the room key**

`ImportMapping.entityDefinitionId` stores the bare **entityType slug** for def-backed system types, while clients subscribe with `Resource.entityDefinitionId`, always the org's EntityDefinition **CUID**:

```sql
EntityDefinition → id = 'x5hzr4xbn1fhznih3u74gtza', entityType = 'part'
ImportMapping    → entityDefinitionId = 'part'
```

`crudHandler` hides the mismatch because it resolves the def and publishes with `entityDef.id`. Publishing the raw mapping value addressed `…-records-part` while every browser sat on `…-records-<cuid>` — two frames from one import, on two rooms:

```
event: record:updated       roomKey: org-…-records-x5hzr4xbn1fhznih3u74gtza
event: records:invalidated  roomKey: org-…-records-part          ← nobody
```

Fixed with the existing `canonicalizeEntityDefinitionId` helper, which is gated on `isEntityDefinitionType` so a custom-def CUID passes through untouched. Audited the other five `rooms.orgRecords(...)` producers — all source their def id from `EntityInstance.entityDefinitionId` or `entityDef.id`; the import mapping was the only slug-keyed outlier.

**3. Make `records:invalidated` refresh cells, not just the list (`use-resource-sync.ts`)**

The handler only invalidated the list + `listFiltered`. But `listFiltered` returns **ids only**, and `use-record-list` fetches a record solely when its id is absent from the store — so a list-only refresh surfaces rows a bulk write CREATED and shows nothing for rows it UPDATED. That is every row of an import whose strategy is `update`.

It now runs the same three-lane catch-up already used on channel re-subscribe (list → record meta → cached cell values). `scheduleCatchUp` was extracted so both callers share the 250ms coalescing; the catch-up block moved above the handlers to avoid a TDZ on the dep array. **This fixes the same hole on the data-connector sync path.**

Also corrected the `RecordsInvalidatedEvent` doc, which claimed the client refetch "re-pulls records + field values" — it did not, and that claim is what made the gap easy to miss.

## Verification

Reproduced and confirmed fixed against the local stack. Post-fix worker log:

```
18:39:31 records:invalidated  org-abgwpa…-records-x5hzr4xbn1fhznih3u74gtza
```

Grid now updates live during import. `publish-record-channels` and `use-resource-sync-catch-up` suites pass; typecheck clean on `@auxx/lib` and `apps/web`.