### PR TITLE
fix(records): stop double header on tickets and parts import pages

### DIFF
--- a/apps/web/src/app/(protected)/app/parts/layout.tsx
+++ b/apps/web/src/app/(protected)/app/parts/layout.tsx
@@ -11,6 +11,8 @@ import {
 import { Package } from 'lucide-react'
 import { usePathname } from 'next/navigation'
 
+const BASE_PATH = '/app/parts'
+
 /**
  * Parts layout — a plain breadcrumb shell (not an `EntityRouteLayout`; parts
  * has no Dashboard tab). `RecordsView` (mounted by `parts/page.tsx`) renders
@@ -20,13 +22,9 @@ import { usePathname } from 'next/navigation'
 export default function PartsLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
 
-  // Detail pages have their own MainPage wrapper via DetailView
-  const isDetailPage =
-    /\/parts\/[^/]+$/.test(pathname) &&
-    !pathname.endsWith('/parts') &&
-    !pathname.includes('/import')
-
-  if (isDetailPage) {
+  // Detail pages (via DetailView) and import pages (via ImportPage) render their
+  // own MainPage — only the list route gets this breadcrumb shell.
+  if (pathname !== BASE_PATH) {
     return <>{children}</>
   }
 
@@ -36,7 +34,7 @@ export default function PartsLayout({ children }: { children: React.ReactNode })
         <MainPageBreadcrumb>
           <MainPageBreadcrumbItem
             title='Parts'
-            href='/app/parts'
+            href={BASE_PATH}
             icon={<Package className='size-4' />}
           />
         </MainPageBreadcrumb>

--- a/apps/web/src/app/(protected)/app/tickets/layout.tsx
+++ b/apps/web/src/app/(protected)/app/tickets/layout.tsx
@@ -6,6 +6,8 @@ import { Settings } from 'lucide-react'
 import { usePathname } from 'next/navigation'
 import { EntityRouteLayout } from '~/components/records'
 
+const BASE_PATH = '/app/tickets'
+
 /**
  * Shared layout for tickets section with conditional rendering
  * - For tabbed pages (list, dashboard, settings): renders EntityRouteLayout with
@@ -17,16 +19,14 @@ import { EntityRouteLayout } from '~/components/records'
 export default function TicketsLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
 
-  // Check if we're on a ticket detail page, create page, or import page
-  // These pages have their own MainPage wrapper or don't need the tabbed header
-  const isDetailOrSpecialPage =
-    /\/tickets\/[^/]+$/.test(pathname) &&
-    !pathname.endsWith('/tickets') &&
-    !pathname.includes('/dashboard') &&
-    !pathname.includes('/settings')
+  // Only the tabbed routes (list, dashboard, settings and their sub-pages) get the
+  // shared shell. Everything else — detail, create, import — owns its own MainPage.
+  const isTabbedPage =
+    pathname === BASE_PATH ||
+    pathname.startsWith(`${BASE_PATH}/dashboard`) ||
+    pathname.startsWith(`${BASE_PATH}/settings`)
 
-  // For detail/create/import pages, just render children (they have their own layout)
-  if (isDetailOrSpecialPage) {
+  if (!isTabbedPage) {
     return <>{children}</>
   }
 
@@ -34,9 +34,9 @@ export default function TicketsLayout({ children }: { children: React.ReactNode 
   return (
     <EntityRouteLayout
       slug='tickets'
-      basePath='/app/tickets'
+      basePath={BASE_PATH}
       extraTabs={[
-        { value: 'settings', label: 'Settings', icon: <Settings />, href: '/app/tickets/settings' },
+        { value: 'settings', label: 'Settings', icon: <Settings />, href: `${BASE_PATH}/settings` },
       ]}>
       {children}
     </EntityRouteLayout>


### PR DESCRIPTION
## Problem

`/app/tickets/import/new?step=upload` renders **two** headers stacked — the `EntityRouteLayout` shell (sidebar toggle + Tickets + List/Dashboard/Settings tabs) on top of the breadcrumb header `ImportPage` renders itself.

## Cause

The tickets layout decided "does this route own its own `MainPage`?" with a regex that only matches a **single** path segment after the base path:

```ts
/\/tickets\/[^/]+$/.test(pathname)
```

- `/app/tickets/import` → matches → children only → one header ✅
- `/app/tickets/import/new` → **doesn't match** (two segments) → shell renders → two headers ❌

`tickets/import/page.tsx` redirects to `/app/tickets/import/new?step=upload`, so the wizard is only ever reachable at the two-segment URL — it was never rendering correctly.

`parts/layout.tsx` had the identical regex, plus a `!pathname.includes('/import')` clause that *actively* forced the breadcrumb shell onto import routes.

## Not a regression

Both the regex and the redirect date to `8abb4b8ce` (initial commit), which is why this reproduces in production too. The only thing that changed is cosmetic: #1199 swapped the second header from a plain breadcrumb to `EntityRouteLayout`, so the duplicate started showing tabs and became obvious.

## Fix

Replace the depth-sensitive regex with an explicit list of the routes that actually want the shell:

```ts
const isTabbedPage =
  pathname === BASE_PATH ||
  pathname.startsWith(`${BASE_PATH}/dashboard`) ||
  pathname.startsWith(`${BASE_PATH}/settings`)

if (!isTabbedPage) return <>{children}</>
```

`startsWith` on dashboard/settings keeps sub-routes (`settings/domains`, `settings/format`, `settings/templates`) inside the shell. Parts has no tabbed sub-routes, so it reduces to `pathname !== BASE_PATH`.

## Verification (Chrome, local)

- `/app/tickets/import/new?step=upload` — one header ✅
- `/app/parts/import/new?step=upload` — one header ✅
- `/app/tickets/settings/domains` — tabs still render, settings nav intact ✅
- Ticket detail / create unchanged (both were already non-tabbed under the old regex)
- Biome clean

`contacts`, `companies`, `work-orders`, `invoices`, `quotes` and `service-requests` already used a simple equality check and were never affected.