### PR TITLE
fix(dynamic-table): stop dnd keyboard sensor from swallowing dialog keys

### DIFF
--- a/apps/web/src/components/dynamic-table/components/drag-drop-row.tsx
+++ b/apps/web/src/components/dynamic-table/components/drag-drop-row.tsx
@@ -68,6 +68,7 @@ export function DragDropRow<TData>({
     attributes,
     listeners,
     setNodeRef: setDragRef,
+    setActivatorNodeRef,
     isDragging,
   } = useDraggable({
     id: `row-${row.id}`,
@@ -89,12 +90,22 @@ export function DragDropRow<TData>({
     disabled: !dragDropConfig.enabled || !canAcceptDrop,
   })
 
+  // The row div is drag source, drop target AND keyboard activator. The
+  // activator ref is what makes dnd-kit's KeyboardSensor check
+  // `event.target === activator` before starting a drag; with a null activator
+  // that guard short-circuits and every keydown that reaches `listeners`
+  // starts a row drag — including keystrokes from a dialog or popover opened
+  // inside a cell, which stay REACT children of this row even though Radix
+  // portals them to <body>. Keyboard drag still works when the row itself is
+  // focused (`attributes` puts tabIndex=0 on it); a Space pressed while a CELL
+  // has focus no longer drags the row, which is the correct behavior anyway.
   const combinedRef = useCallback(
     (node: HTMLDivElement | null) => {
       setDragRef(node)
       setDropRef(node)
+      setActivatorNodeRef(node)
     },
-    [setDragRef, setDropRef]
+    [setDragRef, setDropRef, setActivatorNodeRef]
   )
 
   const handleRowClick = useCallback(

--- a/apps/web/src/components/dynamic-table/components/header-cell-wrapper.tsx
+++ b/apps/web/src/components/dynamic-table/components/header-cell-wrapper.tsx
@@ -24,7 +24,15 @@ export function HeaderCellWrapper<TData>({ header }: HeaderCellWrapperProps<TDat
   const { disableColumnDnd } = useTableConfig()
 
   // Drag and drop functionality (disabled for checkbox column / widget tables)
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
     id: header.column.id,
     disabled: isCheckboxColumn || disableColumnDnd,
   })
@@ -43,6 +51,16 @@ export function HeaderCellWrapper<TData>({ header }: HeaderCellWrapperProps<TDat
       }}
       className={cn('relative shrink-0', isDragging && 'opacity-30 z-50')}>
       <div
+        // The activator node. dnd-kit's KeyboardSensor only starts a drag when
+        // `event.target` IS this element (core.cjs `KeyboardSensor.activators`);
+        // without the ref that guard short-circuits on a null activator and ANY
+        // keydown reaching `listeners.onKeyDown` starts a column drag. Header
+        // cells render dialogs (CustomFieldDialog) whose portal content is still
+        // a REACT child of this div, so typing Space in a dialog field was being
+        // preventDefault'd into a keyboard drag. Keyboard drag still works: the
+        // `attributes` spread puts tabIndex=0 here, so focusing the header and
+        // pressing Space targets this node directly.
+        ref={setActivatorNodeRef}
         // `contain: inline-size` isolates this wrapper's inline-axis sizing
         // from descendant min-content. Without it, unbreakable content like a
         // SmartBreadcrumb path (whitespace-nowrap segments) would inflate the

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -214,7 +214,16 @@ function DialogContent({
           // full-width card instead of centering it; otherwise keep the gutter.
           mobileFullHeight ? 'pb-6 max-sm:pb-0' : 'pb-6 max-sm:items-center'
         )}
-        onWheel={(e) => e.stopPropagation()}>
+        onWheel={(e) => e.stopPropagation()}
+        // React synthetic events propagate through the REACT tree, not the DOM
+        // tree, so a keystroke inside this portal still bubbles to whatever
+        // rendered <Dialog> — e.g. a dnd-kit KeyboardSensor `onKeyDown` on a
+        // table header cell, which swallows Space/Enter and then starts a
+        // keyboard drag while the user is typing in a dialog field. A modal
+        // owns its keys; nothing outside it should see them. Radix's own Escape
+        // handling is a native `document` listener in DismissableLayer, so
+        // dismissal is unaffected. Mirrors the `onWheel` stop above.
+        onKeyDown={(e) => e.stopPropagation()}>
         <DialogPrimitive.Content
           className={cn(
             dialogVariants({ variant, size, position, className }),


### PR DESCRIPTION
## The bug

Open a records table → header menu → **Edit field** → enable AI generation → type in the prompt editor. Space never inserts, Enter does nothing, and arrow keys shuffle the columns behind the dialog.

## Root cause

React synthetic events propagate through the **React tree**, not the DOM tree. `HeaderCell` renders `CustomFieldDialog` as a React child, so even though Radix portals the dialog into `<body>`, every keystroke inside it still bubbles up to `HeaderCellWrapper` — which spreads `useSortable`'s `listeners`, including dnd-kit's `onKeyDown` activator, onto an ancestor div.

dnd-kit's start codes are `Space` and `Enter`. The activator calls `event.preventDefault()` (so Space never types) and then instantiates a keyboard drag (so arrows move the column and the drag overlay mounts).

dnd-kit guards exactly this case:

```js
if (activator && event.target !== activator) return false
```

but the guard short-circuits when `activatorNode.current` is `null`, and neither drag site ever passed `setActivatorNodeRef`.

`virtual-table-row.tsx` spreads the row's `{...attributes, ...listeners}` onto the whole row div, so the same defect applies to any dialog or popover opened from inside a cell, via `row-dnd-provider`'s `KeyboardSensor`.

## Fix

**1. Wire `setActivatorNodeRef` at both drag sites** (`header-cell-wrapper.tsx`, `drag-drop-row.tsx`) — restores dnd-kit's own guard, and is the correct wiring regardless. Keyboard drag still works: `attributes` puts `tabIndex=0` on those elements, so focusing them and pressing Space targets them directly.

**2. Stop keydown at the dialog boundary** (`packages/ui/src/components/dialog.tsx`), next to the `onWheel` stop that was already there for the scroll-flavored version of this same bug. This covers every portaled child rather than just dnd — the AI prompt editor's field-picker popover included.

Neither alone is sufficient: fix 1 doesn't cover popovers/dropdowns rendered from the header, fix 2 doesn't cover non-Dialog portal hosts.

Radix's Escape handling is a native `document` listener in `DismissableLayer`, so stopping React synthetic propagation doesn't affect dismissal. A caller-supplied `onKeyDown` still lands on the inner `DialogPrimitive.Content`, below the stop.

## Behavior change

Pressing Space while a **cell** has focus no longer starts a row drag — the row itself must be focused. That is what the missing guard was there to enforce, and it's the behavior you'd want anyway, but it is a change.

## Verification

- Lint clean on all three files
- `@auxx/ui` typechecks clean; `apps/web` reports no errors in either changed file
- Manual check of the reported repro still wanted before merge