### PR TITLE
feat(ai-autofill): widen eligible field types and fix options patch loss

### DIFF
--- a/apps/web/src/components/custom-fields/hooks/use-custom-field-mutations.tsx
+++ b/apps/web/src/components/custom-fields/hooks/use-custom-field-mutations.tsx
@@ -341,10 +341,33 @@ export function useCustomFieldMutations({ entityDefinitionId }: UseCustomFieldMu
       if (variables.sortOrder !== undefined) optimisticUpdates.sortOrder = variables.sortOrder
       if (variables.active !== undefined) optimisticUpdates.active = variables.active
       if (variables.options !== undefined) {
-        // Handle options - can be SelectOption[], file config, etc.
-        optimisticUpdates.options = Array.isArray(variables.options)
+        // MERGE, never replace. `updateCustomField` spreads the patch over the
+        // field's stored options, so a partial patch keeps every key it doesn't
+        // mention — `{ ai }` from the field form (TAGS and the other non-SELECT
+        // AI-eligible types send exactly that), a bare `SelectOption[]` from the
+        // tag picker. Replacing here made the untouched keys vanish from the UI
+        // the moment the mutation fired, and `confirmFieldUpdate` below promotes
+        // this object into `serverFieldMap`, so the gap outlived the refetch and
+        // only a reload brought the options back.
+        const current = (store.fieldMap[key]?.options ?? {}) as Record<string, unknown>
+        const incoming = Array.isArray(variables.options)
           ? { options: variables.options }
-          : variables.options
+          : (variables.options as Record<string, unknown>)
+        const merged: Record<string, unknown> = { ...current, ...incoming }
+
+        // Mirror the server's `ai` rule exactly (see update-field.ts): only an
+        // object-shaped patch addresses the AI block, and there it is
+        // authoritative — absent or disabled both clear it. An array patch is
+        // options-only and leaves `ai` alone.
+        if (!Array.isArray(variables.options)) {
+          if (incoming.ai) {
+            merged.ai = incoming.ai
+          } else {
+            delete merged.ai
+          }
+        }
+
+        optimisticUpdates.options = merged as ResourceField['options']
       }
 
       store.setFieldOptimistic(key, optimisticUpdates)

--- a/apps/web/src/components/custom-fields/ui/ai-options-section.tsx
+++ b/apps/web/src/components/custom-fields/ui/ai-options-section.tsx
@@ -21,6 +21,8 @@ export interface AiSectionState {
   enabled: boolean
   prompt: RichReferencePrompt
   triggerOn: AiTriggerOn
+  /** TAGS only — may the model mint tag options that do not exist yet? */
+  allowNewOptions: boolean
 }
 
 /**
@@ -33,6 +35,7 @@ export function parseAiOptions(options?: unknown): AiSectionState {
     enabled: ai?.enabled ?? false,
     prompt: ai?.prompt ?? emptyPromptDoc(),
     triggerOn: ai?.triggerOn ?? 'manual',
+    allowNewOptions: ai?.allowNewOptions ?? false,
   }
 }
 
@@ -47,6 +50,9 @@ export function formatAiOptions(state: AiSectionState): AiOptions | undefined {
     enabled: true,
     prompt: state.prompt,
     triggerOn: state.triggerOn,
+    // Omitted rather than stored as `false` — absent means "pick from my
+    // taxonomy", which is the default for every non-TAGS type too.
+    ...(state.allowNewOptions ? { allowNewOptions: true } : {}),
   }
 }
 
@@ -62,7 +68,7 @@ interface AiOptionsSectionProps {
   aiSiblingFieldIds?: string[]
   /** Selected field type — forwarded to the preview panel for json-schema generation. */
   fieldType: FieldType
-  /** Native options for the selected type (only SELECT/MULTI_SELECT supply any). */
+  /** Native options for the selected type (only SELECT/MULTI_SELECT/TAGS supply any). */
   fieldOptions?: { options: SelectOption[] }
   /** Field display name, threaded into the preview's system prompt. */
   fieldName?: string
@@ -128,9 +134,25 @@ export function AiOptionsSection({
         </RadioGroup>
       </div>
 
+      {fieldType === 'TAGS' && (
+        <ToggleCard
+          title='Let AI create new tags'
+          description="Off, the model picks from this field's existing tags. On, it may add tags that don't exist yet."
+          checked={state.allowNewOptions}
+          onCheckedChange={(allowNewOptions) => onChange({ ...state, allowNewOptions })}
+        />
+      )}
+
       <AiPreviewPanel
         type={fieldType}
-        options={fieldOptions}
+        options={
+          // The preview builds its schema from these options, so an open TAGS
+          // field has to carry `allowNewOptions` through or the dry run would
+          // enumerate the existing tags the live generation is free to grow.
+          fieldType === 'TAGS' && fieldOptions
+            ? { ...fieldOptions, ai: formatAiOptions(state) }
+            : fieldOptions
+        }
         prompt={state.prompt}
         name={fieldName}
         entityDefinitionId={entityDefinitionId}

--- a/apps/web/src/components/custom-fields/ui/ai-prompt-editor/ai-preview-panel.tsx
+++ b/apps/web/src/components/custom-fields/ui/ai-prompt-editor/ai-preview-panel.tsx
@@ -3,7 +3,7 @@
 'use client'
 
 import type { FieldType } from '@auxx/database/types'
-import type { RichReferencePrompt, SelectOption } from '@auxx/types/custom-field'
+import type { AiOptions, RichReferencePrompt, SelectOption } from '@auxx/types/custom-field'
 import { Button } from '@auxx/ui/components/button'
 import { AlertTriangle, Play, Sparkles } from 'lucide-react'
 import { useMemo, useState } from 'react'
@@ -14,10 +14,12 @@ interface AiPreviewPanelProps {
   /** The field type currently selected in the dialog. */
   type: FieldType
   /**
-   * Native options for the selected type — only SELECT/MULTI_SELECT supply any
-   * (the enum list the preview grounds its json-schema on).
+   * Native options for the selected type — only SELECT/MULTI_SELECT/TAGS supply
+   * any (the enum list the preview grounds its json-schema on). TAGS also
+   * carries the in-dialog `ai` block, because `allowNewOptions` decides whether
+   * the preview's schema is an enum or free-text.
    */
-  options?: { options: SelectOption[] }
+  options?: { options: SelectOption[]; ai?: AiOptions }
   /** TipTap prompt JSON the user is editing. */
   prompt: RichReferencePrompt
   /** Field name (used in the LLM system prompt). */

--- a/apps/web/src/components/custom-fields/ui/custom-field-form.tsx
+++ b/apps/web/src/components/custom-fields/ui/custom-field-form.tsx
@@ -531,7 +531,16 @@ export function CustomFieldForm({
       entityDefinitionId: effectiveEntityDefId,
     }
 
-    // Add type-specific options using format helpers
+    // Add type-specific options using format helpers.
+    //
+    // 🛑 TAGS is deliberately NOT here, even though it is a select type. This
+    // form renders no OptionsEditor for it (tags are grown from the record
+    // picker, not configured here), so `selectOptions` is only the snapshot
+    // taken when the dialog opened. Writing that back would clobber every tag
+    // added since — including ones `mintOrMatchTagOptions` appended under a row
+    // lock precisely to avoid a lost update. TAGS falls through to the `{ ai }`
+    // patch below, and the server preserves the stored option list because the
+    // patch never mentions it.
     if (values.type === FieldType.SINGLE_SELECT || values.type === FieldType.MULTI_SELECT) {
       const aiBlock = isAiEligible(values.type) ? formatAiOptions(aiState) : undefined
       submitObj.options = aiBlock ? { options: selectOptions, ai: aiBlock } : selectOptions
@@ -570,10 +579,11 @@ export function CustomFieldForm({
       submitObj.options = { ...submitObj.options, ...formattedDisplayOptions }
     }
 
-    // Merge AI options for AI-eligible non-SELECT types. SELECT types fold
-    // the ai block into `{ options, ai }` above since they also carry a
-    // choice list. When enabled=false, formatAiOptions returns undefined
-    // so we naturally skip / drop the key on toggle-off.
+    // Merge AI options for the remaining AI-eligible types. SINGLE_SELECT and
+    // MULTI_SELECT fold the ai block into `{ options, ai }` above since they
+    // also carry an editable choice list; TAGS lands here on purpose (see the
+    // note above). When enabled=false, formatAiOptions returns undefined so we
+    // naturally skip / drop the key on toggle-off.
     if (
       isAiEligible(values.type) &&
       values.type !== FieldType.SINGLE_SELECT &&
@@ -1055,7 +1065,8 @@ export function CustomFieldForm({
                 fieldType={selectedType}
                 fieldOptions={
                   selectedType === FieldType.SINGLE_SELECT ||
-                  selectedType === FieldType.MULTI_SELECT
+                  selectedType === FieldType.MULTI_SELECT ||
+                  selectedType === FieldType.TAGS
                     ? { options: selectOptions }
                     : undefined
                 }

--- a/packages/lib/src/custom-fields/ai.ts
+++ b/packages/lib/src/custom-fields/ai.ts
@@ -11,10 +11,11 @@ import { toFieldType } from '../field-values/stored-field-type'
 /**
  * Whether a field type is in the AI-generatable whitelist.
  *
- * v1 eligible: TEXT, NUMBER, CHECKBOX, DATE, URL, EMAIL, SINGLE_SELECT,
- * MULTI_SELECT. Source of truth is `AI_ELIGIBLE_FIELD_TYPES` in
- * `@auxx/types/custom-field`; the `canAiGenerate` flag on `fieldTypeOptions`
- * must stay in sync for the UI gating path.
+ * Source of truth is `AI_ELIGIBLE_FIELD_TYPES` in `@auxx/types/custom-field`,
+ * coupled by an exact-set-equality test to the per-type contract table
+ * `AI_TYPE_SPECS` in `field-values/ai-autofill/type-specs.ts`. This is the
+ * gate the create/edit dialog renders on and the one services validates saves
+ * against — there is no third list.
  */
 export function isAiEligible(type: FieldType): boolean {
   return isAiEligibleFieldType(type)

--- a/packages/lib/src/custom-fields/types.ts
+++ b/packages/lib/src/custom-fields/types.ts
@@ -148,13 +148,6 @@ export interface FieldTypeOption {
   description: string
   minWidth?: number // Optional minimum width for input popover (in pixels)
   maxWidth?: number // Optional maximum width for input popover (in pixels)
-  /**
-   * Whether this field type can have AI generation enabled via `options.ai`.
-   * When true, the edit dialog shows the AI generation toggle and the value
-   * pipeline accepts stage-1 AI requests. When false or absent, the field
-   * is never AI-generatable.
-   */
-  canAiGenerate?: boolean
 }
 export const customFieldFormSchema = z.object({
   name: z.string().min(1, 'Name is required'),
@@ -223,7 +216,6 @@ export const fieldTypeOptions: Record<FieldType, FieldTypeOption> = {
     label: 'Text',
     iconId: 'text',
     description: 'Simple text input for short text entries',
-    canAiGenerate: true,
   },
   [FieldTypeEnum.NAME]: {
     label: 'Name',
@@ -236,7 +228,6 @@ export const fieldTypeOptions: Record<FieldType, FieldTypeOption> = {
     description: 'Numeric values only',
     minWidth: 120,
     maxWidth: 120,
-    canAiGenerate: true,
   },
   [FieldTypeEnum.CURRENCY]: {
     label: 'Currency',
@@ -253,13 +244,11 @@ export const fieldTypeOptions: Record<FieldType, FieldTypeOption> = {
     label: 'Email',
     iconId: 'mail',
     description: 'Email address with validation',
-    canAiGenerate: true,
   },
   [FieldTypeEnum.URL]: {
     label: 'URL',
     iconId: 'link',
     description: 'Web address with validation',
-    canAiGenerate: true,
   },
   [FieldTypeEnum.DATE]: {
     label: 'Date',
@@ -267,7 +256,6 @@ export const fieldTypeOptions: Record<FieldType, FieldTypeOption> = {
     description: 'Date picker for selecting dates',
     minWidth: 240,
     maxWidth: 240,
-    canAiGenerate: true,
   },
   [FieldTypeEnum.DATETIME]: {
     label: 'Date & Time',
@@ -289,7 +277,6 @@ export const fieldTypeOptions: Record<FieldType, FieldTypeOption> = {
     description: 'Simple yes/no or true/false option',
     minWidth: 70,
     maxWidth: 70,
-    canAiGenerate: true,
   },
   [FieldTypeEnum.TAGS]: {
     label: 'Tags',
@@ -312,13 +299,11 @@ export const fieldTypeOptions: Record<FieldType, FieldTypeOption> = {
     label: 'Select',
     iconId: 'list',
     description: 'Choose one option from a list',
-    canAiGenerate: true,
   },
   [FieldTypeEnum.MULTI_SELECT]: {
     label: 'Multi-Select',
     iconId: 'list-checks',
     description: 'Choose multiple options from a list',
-    canAiGenerate: true,
   },
   [FieldTypeEnum.RICH_TEXT]: {
     label: 'Rich Text Editor',
@@ -421,29 +406,25 @@ export const phoneFieldOptionsSchema = baseFieldOptionsSchema.extend({
   country: z.string().optional(),
   format: z.string().optional(),
   phoneFormat: z.enum(['raw', 'national', 'international']).optional(),
+  ai: aiOptionsSchema.optional(),
 })
 export const checkboxFieldOptionsSchema = baseFieldOptionsSchema.extend({
   label: z.string().optional(),
   ai: aiOptionsSchema.optional(),
 })
-/**
- * Shared by SINGLE_SELECT, MULTI_SELECT, and TAGS. The `ai` block is schema-
- * permissive here; the runtime `canAiGenerate` gate blocks AI on TAGS.
- */
+/** Shared by SINGLE_SELECT, MULTI_SELECT, and TAGS — all three AI-eligible. */
 export const selectFieldOptionsSchema = baseFieldOptionsSchema.extend({
   options: z.array(selectOptionSchema).optional(),
   ai: aiOptionsSchema.optional(),
 })
 export const addressFieldOptionsSchema = baseFieldOptionsSchema.extend({
+  ai: aiOptionsSchema.optional(),
   addressComponents: z.array(z.string()).optional(),
   /** Editor variant: single free-text input (parsed + geocoder-normalized) vs.
    *  the separate structured sub-fields. Absent ⇒ `'single'`. */
   inputMode: z.enum(['single', 'structured']).optional(),
 })
-/**
- * Shared by DATE, DATETIME, and TIME. The `ai` block is schema-permissive
- * here; the runtime `canAiGenerate` gate blocks AI on DATETIME/TIME.
- */
+/** Shared by DATE, DATETIME, and TIME — all three AI-eligible. */
 export const dateFieldOptionsSchema = baseFieldOptionsSchema.extend({
   format: z.string().optional(),
   minDate: z.string().optional(),
@@ -458,6 +439,16 @@ export const emailFieldOptionsSchema = baseFieldOptionsSchema.extend({
 export const urlFieldOptionsSchema = baseFieldOptionsSchema.extend({
   ai: aiOptionsSchema.optional(),
 })
+
+/** NAME-specific options — dedicated schema so AI stays off other base-schema types. */
+export const nameFieldOptionsSchema = baseFieldOptionsSchema.extend({
+  ai: aiOptionsSchema.optional(),
+})
+
+/** RICH_TEXT-specific options — dedicated schema so AI stays off other base-schema types. */
+export const richTextFieldOptionsSchema = baseFieldOptionsSchema.extend({
+  ai: aiOptionsSchema.optional(),
+})
 export const relationshipFieldOptionsSchema = baseFieldOptionsSchema.extend({
   relationship: relationshipConfigSchema.optional(),
 })
@@ -468,6 +459,7 @@ export const currencyFieldOptionsSchema = baseFieldOptionsSchema.extend({
   decimals: z.number().int().min(0).max(10).optional(),
   useGrouping: z.boolean().optional(),
   currencyDisplay: z.enum(['symbol', 'code', 'name', 'compact']).optional(),
+  ai: aiOptionsSchema.optional(),
 })
 
 /** File field options schema */
@@ -520,7 +512,7 @@ export type ActorFieldOptions = z.infer<typeof actorFieldOptionsSchema>
  */
 export const fieldTypeOptionsSchemaMap: Record<FieldType, z.ZodTypeAny> = {
   [FieldTypeEnum.TEXT]: textFieldOptionsSchema,
-  [FieldTypeEnum.NAME]: baseFieldOptionsSchema,
+  [FieldTypeEnum.NAME]: nameFieldOptionsSchema,
   [FieldTypeEnum.NUMBER]: numberFieldOptionsSchema,
   [FieldTypeEnum.CURRENCY]: currencyFieldOptionsSchema,
   [FieldTypeEnum.PHONE_INTL]: phoneFieldOptionsSchema,
@@ -535,7 +527,7 @@ export const fieldTypeOptionsSchemaMap: Record<FieldType, z.ZodTypeAny> = {
   [FieldTypeEnum.ADDRESS_STRUCT]: addressFieldOptionsSchema,
   [FieldTypeEnum.SINGLE_SELECT]: selectFieldOptionsSchema,
   [FieldTypeEnum.MULTI_SELECT]: selectFieldOptionsSchema,
-  [FieldTypeEnum.RICH_TEXT]: baseFieldOptionsSchema,
+  [FieldTypeEnum.RICH_TEXT]: richTextFieldOptionsSchema,
   [FieldTypeEnum.FILE]: fileFieldOptionsSchema,
   [FieldTypeEnum.RELATIONSHIP]: relationshipFieldOptionsSchema,
   [FieldTypeEnum.CALC]: calcFieldOptionsSchema,

--- a/packages/lib/src/field-values/ai-autofill/__tests__/multi-field-gate.test.ts
+++ b/packages/lib/src/field-values/ai-autofill/__tests__/multi-field-gate.test.ts
@@ -45,8 +45,11 @@ describe('buildJsonSchema — multi-value defense in depth', () => {
   })
 
   it('still builds the scalar schema for single-value fields', async () => {
+    // EMAIL is nullable as of v2.1: a fabricated address is indistinguishable
+    // from a real one, so the schema admits `null` and the prompt tells the
+    // model to decline rather than invent.
     expect(buildJsonSchema(field({}))).toMatchObject({
-      schema: { properties: { value: { type: 'string' } } },
+      schema: { properties: { value: { type: ['string', 'null'] } } },
     })
   })
 })

--- a/packages/lib/src/field-values/ai-autofill/__tests__/tag-minting.test.ts
+++ b/packages/lib/src/field-values/ai-autofill/__tests__/tag-minting.test.ts
@@ -1,0 +1,58 @@
+// packages/lib/src/field-values/ai-autofill/__tests__/tag-minting.test.ts
+//
+// Open TAGS is the only phase of AI autofill that writes outside `FieldValue`,
+// so the match-before-mint rule is the safety property worth pinning: a label
+// that already exists must NEVER produce a second option. These cases exercise
+// it through the `dryRun` path, which runs the identical matcher without
+// touching the database.
+
+import type { CustomFieldEntity } from '@auxx/database/types'
+import { describe, expect, it } from 'vitest'
+import { mintOrMatchTagOptions } from '../tag-minting'
+
+const FIELD = {
+  id: 'fld_tags',
+  name: 'Tags',
+  type: 'TAGS',
+  options: {
+    options: [
+      { value: 'opt_ent', label: 'Enterprise' },
+      { value: 'opt_smb', label: 'Small Business' },
+    ],
+  },
+} as unknown as CustomFieldEntity
+
+async function match(labels: unknown[]): Promise<string[]> {
+  return await mintOrMatchTagOptions({
+    organizationId: 'org_1',
+    field: FIELD,
+    labels,
+    dryRun: true,
+  })
+}
+
+describe('mintOrMatchTagOptions — matching', () => {
+  it('collapses case and whitespace variants onto the existing option id', async () => {
+    expect(await match(['Enterprise'])).toEqual(['opt_ent'])
+    expect(await match(['enterprise'])).toEqual(['opt_ent'])
+    expect(await match(['  ENTERPRISE  '])).toEqual(['opt_ent'])
+    expect(await match(['Small   Business'])).toEqual(['opt_smb'])
+  })
+
+  it('dedupes labels that fold onto the same key within one generation', async () => {
+    expect(await match(['Enterprise', 'enterprise', ' Enterprise '])).toEqual(['opt_ent'])
+  })
+
+  it('drops blanks and non-strings the model may emit', async () => {
+    expect(await match(['', '   ', null, 42, { label: 'x' }, 'Enterprise'])).toEqual(['opt_ent'])
+    expect(await match([])).toEqual([])
+  })
+
+  it('never mints in dry-run mode — an unmatched label passes through verbatim', async () => {
+    expect(await match(['Enterprise', 'Nonprofit'])).toEqual(['opt_ent', 'Nonprofit'])
+  })
+
+  it('preserves the order the model produced', async () => {
+    expect(await match(['Small Business', 'Enterprise'])).toEqual(['opt_smb', 'opt_ent'])
+  })
+})

--- a/packages/lib/src/field-values/ai-autofill/__tests__/type-specs.test.ts
+++ b/packages/lib/src/field-values/ai-autofill/__tests__/type-specs.test.ts
@@ -1,0 +1,247 @@
+// packages/lib/src/field-values/ai-autofill/__tests__/type-specs.test.ts
+//
+// The AI-eligible type roster lives in exactly two places — the plain name Set
+// in `@auxx/types/custom-field` (which `@auxx/services` gates saves on and
+// cannot import from lib) and the per-type contract table in lib. This file is
+// the joint: an exact-set-equality test that makes them one atomic change,
+// plus per-type schema-shape assertions so a spec cannot quietly emit a shape
+// `validateSingleValue` would reject.
+
+import type { CustomFieldEntity } from '@auxx/database/types'
+import { AI_ELIGIBLE_FIELD_TYPES } from '@auxx/types/custom-field'
+import { describe, expect, it } from 'vitest'
+import { BadRequestError } from '../../../errors'
+import { buildJsonSchema } from '../json-schema-builder'
+import { AI_TYPE_SPECS } from '../type-specs'
+
+function field(overrides: Partial<CustomFieldEntity>): CustomFieldEntity {
+  return {
+    id: 'fld_1',
+    name: 'Test field',
+    type: 'TEXT',
+    options: {},
+    ...overrides,
+  } as CustomFieldEntity
+}
+
+/** The `value` sub-schema out of the `{ value: T }` envelope. */
+function valueSchema(f: CustomFieldEntity): Record<string, unknown> {
+  const built = buildJsonSchema(f) as {
+    schema: { properties: { value: Record<string, unknown> } }
+  }
+  return built.schema.properties.value
+}
+
+const OPTIONS = [
+  { id: 'opt_a', value: 'opt_a', label: 'Alpha' },
+  { id: 'opt_b', value: 'opt_b', label: 'Beta' },
+]
+
+describe('AI_TYPE_SPECS ↔ AI_ELIGIBLE_FIELD_TYPES', () => {
+  it('is an exact set equality — neither list may grow alone', () => {
+    const specTypes = new Set(Object.keys(AI_TYPE_SPECS))
+    const eligibleTypes = new Set(AI_ELIGIBLE_FIELD_TYPES)
+
+    const missingSpec = [...eligibleTypes].filter((t) => !specTypes.has(t))
+    const missingEligible = [...specTypes].filter((t) => !eligibleTypes.has(t))
+
+    expect(missingSpec).toEqual([])
+    expect(missingEligible).toEqual([])
+  })
+
+  it('gives every spec a schema and a shape hint', () => {
+    for (const [type, spec] of Object.entries(AI_TYPE_SPECS)) {
+      const f = field({ type: type as CustomFieldEntity['type'], options: { options: OPTIONS } })
+      expect(typeof spec?.schema(f), type).toBe('object')
+      expect(spec?.shapeHint(f).length, type).toBeGreaterThan(0)
+    }
+  })
+
+  it('produces a strict envelope with `value` required for every eligible type', () => {
+    for (const type of Object.keys(AI_TYPE_SPECS)) {
+      const built = buildJsonSchema(
+        field({ type: type as CustomFieldEntity['type'], options: { options: OPTIONS } })
+      )
+      expect(built, type).toMatchObject({
+        name: 'ai_autofill_result',
+        strict: true,
+        schema: { type: 'object', additionalProperties: false, required: ['value'] },
+      })
+    }
+  })
+})
+
+describe('nullable types', () => {
+  it.each([
+    'URL',
+    'EMAIL',
+    'PHONE_INTL',
+    'NAME',
+    'ADDRESS_STRUCT',
+  ] as const)('%s admits null so the model can decline instead of fabricating', (type) => {
+    expect(AI_TYPE_SPECS[type]?.nullable).toBe(true)
+    expect(valueSchema(field({ type })).type).toContain('null')
+  })
+
+  it.each([
+    'TEXT',
+    'NUMBER',
+    'CHECKBOX',
+    'DATE',
+    'CURRENCY',
+  ] as const)('%s stays non-nullable', (type) => {
+    expect(valueSchema(field({ type })).type).not.toContain('null')
+  })
+})
+
+describe('per-type schema shapes', () => {
+  it('CURRENCY is integer, never number — minor units are integral by definition', () => {
+    expect(valueSchema(field({ type: 'CURRENCY' }))).toEqual({ type: 'integer' })
+  })
+
+  it('CURRENCY names the resolved denomination and its exponent in the hint', () => {
+    const usd = AI_TYPE_SPECS.CURRENCY?.shapeHint(field({ type: 'CURRENCY' }), {
+      orgCurrencyCode: 'USD',
+    })
+    expect(usd).toContain('USD')
+    expect(usd).toContain('1999')
+
+    // Field code wins over the org code (field → org → USD).
+    const jpy = AI_TYPE_SPECS.CURRENCY?.shapeHint(
+      field({ type: 'CURRENCY', options: { currencyCode: 'JPY' } }),
+      { orgCurrencyCode: 'USD' }
+    )
+    expect(jpy).toContain('JPY')
+    expect(jpy).toContain('no minor unit')
+  })
+
+  it('DATETIME asks for a full timestamp, DATE for a calendar date', () => {
+    expect(valueSchema(field({ type: 'DATE' }))).toEqual({ type: 'string', format: 'date' })
+    expect(valueSchema(field({ type: 'DATETIME' }))).toEqual({
+      type: 'string',
+      format: 'date-time',
+    })
+  })
+
+  it('TIME constrains to bare HH:MM — the form its normalizer can anchor', () => {
+    const schema = valueSchema(field({ type: 'TIME' }))
+    expect(schema.type).toBe('string')
+    const pattern = new RegExp(schema.pattern as string)
+    expect(pattern.test('14:30')).toBe(true)
+    expect(pattern.test('00:00')).toBe(true)
+    expect(pattern.test('24:00')).toBe(false)
+    // Seconds are excluded on purpose: `parseTimeOfDay` only accepts HH:MM.
+    expect(pattern.test('14:30:00')).toBe(false)
+  })
+
+  it('NAME and ADDRESS_STRUCT put every member in `required` as a nullable string', () => {
+    const name = valueSchema(field({ type: 'NAME' }))
+    expect(name.required).toEqual(['firstName', 'lastName'])
+    const nameProps = name.properties as Record<string, { type: unknown }>
+    expect(nameProps.firstName?.type).toEqual(['string', 'null'])
+    expect(nameProps.lastName?.type).toEqual(['string', 'null'])
+
+    const address = valueSchema(field({ type: 'ADDRESS_STRUCT' }))
+    expect(address.required).toEqual(['street1', 'street2', 'city', 'state', 'zipCode', 'country'])
+    expect(address.additionalProperties).toBe(false)
+  })
+
+  it('select types enumerate their option ids', () => {
+    expect(valueSchema(field({ type: 'SINGLE_SELECT', options: { options: OPTIONS } }))).toEqual({
+      type: 'string',
+      enum: ['opt_a', 'opt_b'],
+    })
+    expect(valueSchema(field({ type: 'MULTI_SELECT', options: { options: OPTIONS } }))).toEqual({
+      type: 'array',
+      items: { type: 'string', enum: ['opt_a', 'opt_b'] },
+    })
+  })
+})
+
+describe('TAGS — constrained vs open', () => {
+  it('is byte-for-byte MULTI_SELECT when allowNewOptions is off', () => {
+    const tags = valueSchema(field({ type: 'TAGS', options: { options: OPTIONS } }))
+    const multiSelect = valueSchema(field({ type: 'MULTI_SELECT', options: { options: OPTIONS } }))
+    expect(tags).toEqual(multiSelect)
+  })
+
+  it('drops the enum and names existing labels in the prompt when open', () => {
+    const open = field({
+      type: 'TAGS',
+      options: { options: OPTIONS, ai: { enabled: true, allowNewOptions: true } },
+    })
+    expect(valueSchema(open)).toEqual({ type: 'array', items: { type: 'string' } })
+
+    const hint = AI_TYPE_SPECS.TAGS?.shapeHint(open)
+    expect(hint).toContain('Alpha')
+    expect(hint).toContain('Beta')
+  })
+
+  it('rejects a constrained TAGS field with no options, but allows an open one', () => {
+    expect(() => buildJsonSchema(field({ type: 'TAGS', options: { options: [] } }))).toThrow(
+      BadRequestError
+    )
+    expect(() =>
+      buildJsonSchema(
+        field({
+          type: 'TAGS',
+          options: { options: [], ai: { enabled: true, allowNewOptions: true } },
+        })
+      )
+    ).not.toThrow()
+  })
+})
+
+describe('normalizers', () => {
+  it('anchors a bare TIME onto a date the date validator can parse', () => {
+    const normalized = AI_TYPE_SPECS.TIME?.normalize?.('14:30', field({ type: 'TIME' }), {
+      organizationId: 'org_1',
+    }) as string
+
+    expect(Number.isNaN(new Date(normalized).getTime())).toBe(false)
+    // Mirrors the human picker: local clock time, seconds and ms zeroed.
+    const anchored = new Date(normalized)
+    expect(anchored.getHours()).toBe(14)
+    expect(anchored.getMinutes()).toBe(30)
+    expect(anchored.getSeconds()).toBe(0)
+    expect(anchored.getMilliseconds()).toBe(0)
+  })
+
+  it('clears rather than throws when the model returns an unusable TIME', () => {
+    expect(
+      AI_TYPE_SPECS.TIME?.normalize?.('half past two', field({ type: 'TIME' }), {
+        organizationId: 'org_1',
+      })
+    ).toBeNull()
+  })
+
+  it.each([
+    ['NAME', { firstName: 'Jane', lastName: null }, { firstName: 'Jane' }],
+    ['NAME', { firstName: null, lastName: null }, null],
+    [
+      'ADDRESS_STRUCT',
+      {
+        street1: '1 Main St',
+        street2: null,
+        city: 'Berlin',
+        state: null,
+        zipCode: '',
+        country: 'DE',
+      },
+      { street1: '1 Main St', city: 'Berlin', country: 'DE' },
+    ],
+  ] as const)('%s drops null members strict mode forced into `required`', (type, input, want) => {
+    expect(
+      AI_TYPE_SPECS[type]?.normalize?.(input, field({ type }), { organizationId: 'org_1' })
+    ).toEqual(want)
+  })
+
+  it('leaves types whose output already satisfies validateSingleValue alone', () => {
+    for (const type of ['TEXT', 'RICH_TEXT', 'NUMBER', 'CURRENCY', 'CHECKBOX', 'DATE'] as const) {
+      expect(AI_TYPE_SPECS[type]?.normalize, type).toBeUndefined()
+    }
+    // PHONE_INTL included: `validateSingleValue` already runs the shared E.164
+    // normalization, so a second coercion pass here could only disagree with it.
+    expect(AI_TYPE_SPECS.PHONE_INTL?.normalize).toBeUndefined()
+  })
+})

--- a/packages/lib/src/field-values/ai-autofill/generation-service.ts
+++ b/packages/lib/src/field-values/ai-autofill/generation-service.ts
@@ -11,10 +11,12 @@ import { isAiField } from '../../custom-fields/ai'
 import { extractFieldIdsFromString, formulaToString } from '../../custom-fields/formula-converters'
 import { BadRequestError } from '../../errors'
 import { createFieldValueContext, getField } from '../field-value-helpers'
+import { getOrgCurrencyCode } from '../org-currency'
 import { computeInputHash } from './input-hash'
 import { buildJsonSchema } from './json-schema-builder'
 import { buildPrompt } from './prompt-builder'
 import { resolveReferences } from './reference-resolver'
+import { type AiFieldContext, normalizeGeneratedValue } from './type-specs'
 
 const logger = createScopedLogger('ai-autofill:generation-service')
 
@@ -84,31 +86,38 @@ export async function generateFieldValue(params: {
   // 3. Resolve refs (sibling + 1-hop relationships in one batchGetValues call)
   const resolved = await resolveReferences(ctx, { recordId, fieldKeys })
 
-  // 4. Build final prompts
+  // 4. Resolve the org rung of the CURRENCY denomination chain (field → org →
+  //    USD) so the prompt can name the denomination the model must convert to.
+  //    Org-cache-backed, and only for the one type that reads it.
+  const fieldContext: AiFieldContext =
+    field.type === 'CURRENCY' ? { orgCurrencyCode: await getOrgCurrencyCode(orgId) } : {}
+
+  // 5. Build final prompts
   const { resolvedPrompt, systemPrompt, truncated } = buildPrompt({
     promptJson,
     resolved,
     field,
+    context: fieldContext,
   })
   if (truncated) {
     logger.warn('AI autofill prompt truncated at 32k chars', { fieldId, recordId })
   }
 
-  // 5. Build output schema from field.type + options
-  const jsonSchema = buildJsonSchema(field)
+  // 6. Build output schema from field.type + options
+  const jsonSchema = buildJsonSchema(field, fieldContext)
 
-  // 6. Compute input hash for stale-detection BEFORE the LLM call so the
+  // 7. Compute input hash for stale-detection BEFORE the LLM call so the
   //    hash is deterministic on success regardless of LLM output.
   const inputHash = computeInputHash({ promptJson, resolved })
 
-  // 7. Resolve default LLM for this org
+  // 8. Resolve default LLM for this org
   const systemModels = new SystemModelService(database, orgId)
   const def = await systemModels.getDefault(ModelType.LLM)
   if (!def) {
     throw new BadRequestError('No default LLM configured for this organization')
   }
 
-  // 8. Invoke. LLMOrchestrator handles quota enforcement + AiUsage tracking.
+  // 9. Invoke. LLMOrchestrator handles quota enforcement + AiUsage tracking.
   const orchestrator = new LLMOrchestrator(new UsageTrackingService(database), database)
   const response = await orchestrator.invoke({
     model: def.model,
@@ -125,12 +134,18 @@ export async function generateFieldValue(params: {
     context: { source: 'autofill', fieldId, recordId },
   })
 
-  // 9. Unwrap the `{ value: ... }` envelope produced by buildJsonSchema.
+  // 10. Unwrap the `{ value: ... }` envelope produced by buildJsonSchema, then
+  //     run the type's normalize step so the commit path sees exactly what
+  //     `validateSingleValue` accepts. A nullable decline arrives here as
+  //     `null` and stays `null` — `setValueWithBuiltIn` clears the value.
   const structured = response.structured_output
   if (!structured || !('value' in structured)) {
     throw new BadRequestError('AI response did not match the expected structured output shape')
   }
-  const value = (structured as { value: unknown }).value
+  const value = await normalizeGeneratedValue((structured as { value: unknown }).value, field, {
+    ...fieldContext,
+    organizationId: orgId,
+  })
 
   return {
     value,

--- a/packages/lib/src/field-values/ai-autofill/index.ts
+++ b/packages/lib/src/field-values/ai-autofill/index.ts
@@ -10,3 +10,13 @@ export { buildJsonSchema, type JsonSchema } from './json-schema-builder'
 export { type PreviewResult, previewFieldValue } from './preview-service'
 export { type BuiltPrompt, buildPrompt } from './prompt-builder'
 export { type ResolvedReference, resolveReferences } from './reference-resolver'
+export { mintOrMatchTagOptions } from './tag-minting'
+export {
+  AI_TYPE_SPECS,
+  type AiFieldContext,
+  type AiNormalizeContext,
+  type AiTypeSpec,
+  allowsNewTagOptions,
+  getAiTypeSpec,
+  normalizeGeneratedValue,
+} from './type-specs'

--- a/packages/lib/src/field-values/ai-autofill/json-schema-builder.ts
+++ b/packages/lib/src/field-values/ai-autofill/json-schema-builder.ts
@@ -4,19 +4,46 @@ import { FieldType as FieldTypeEnum } from '@auxx/database/enums'
 import type { CustomFieldEntity } from '@auxx/database/types'
 import type { FieldOptions } from '../../custom-fields/field-options'
 import { BadRequestError } from '../../errors'
+import {
+  type AiFieldContext,
+  allowsNewTagOptions,
+  getAiTypeSpec,
+  type JsonSchema,
+  selectOptionIds,
+} from './type-specs'
+
+export type { JsonSchema } from './type-specs'
 
 /**
- * Permissive JSON-schema shape — the LLM orchestrator passes this through
- * to the provider verbatim, so we only need enough typing to construct it.
+ * Widen a value schema to admit `null`, the strict-mode form of "the model may
+ * decline". `strict: true` forbids omitting `value`, so a nullable union is the
+ * only way a provider-enforced schema can express "no confident answer" — and
+ * without it the model is structurally unable to do anything but fabricate.
  */
-export type JsonSchema = Record<string, unknown>
+function applyNullable(valueSchema: JsonSchema): JsonSchema {
+  const next: JsonSchema = { ...valueSchema }
+
+  const type = next.type
+  if (typeof type === 'string') {
+    next.type = [type, 'null']
+  } else if (Array.isArray(type) && !type.includes('null')) {
+    next.type = [...type, 'null']
+  }
+
+  // An `enum` is exhaustive under strict mode, so `null` has to join it too.
+  if (Array.isArray(next.enum) && !next.enum.includes(null)) {
+    next.enum = [...next.enum, null]
+  }
+
+  return next
+}
 
 /**
  * Wrap a value schema in the `{ value: <schema> }` envelope the orchestrator's
  * `structuredOutput` path expects. Parsing the LLM's response then yields
  * `{ value: <generated value> }`, which `generation-service` unwraps.
  */
-function wrap(valueSchema: JsonSchema, description?: string): JsonSchema {
+function wrap(valueSchema: JsonSchema, opts?: { nullable?: boolean }): JsonSchema {
   return {
     name: 'ai_autofill_result',
     strict: true,
@@ -25,20 +52,21 @@ function wrap(valueSchema: JsonSchema, description?: string): JsonSchema {
       additionalProperties: false,
       required: ['value'],
       properties: {
-        value: description ? { ...valueSchema, description } : valueSchema,
+        value: opts?.nullable ? applyNullable(valueSchema) : valueSchema,
       },
     },
   }
 }
 
 /**
- * Build the `response_format.json_schema` for a field's native type.
- * The envelope is `{ value: T }` — the generation service reads `parsed.value`.
+ * Build the `response_format.json_schema` for a field's native type, from the
+ * type's entry in `AI_TYPE_SPECS`. The envelope is `{ value: T }` — the
+ * generation service reads `parsed.value`.
  *
  * Throws `BadRequestError` for non-AI-eligible types (caller should have
  * gated via `isAiEligible` before reaching here).
  */
-export function buildJsonSchema(field: CustomFieldEntity): JsonSchema {
+export function buildJsonSchema(field: CustomFieldEntity, ctx?: AiFieldContext): JsonSchema {
   const options = (field.options ?? {}) as FieldOptions
 
   // Multi-value scalar fields are gated off autofill entirely (`isAiField`):
@@ -48,51 +76,31 @@ export function buildJsonSchema(field: CustomFieldEntity): JsonSchema {
     throw new BadRequestError('AI generation is not supported for multi-value fields')
   }
 
-  switch (field.type) {
-    case FieldTypeEnum.TEXT:
-    case FieldTypeEnum.URL:
-    case FieldTypeEnum.EMAIL:
-      return wrap({ type: 'string' })
-
-    case FieldTypeEnum.NUMBER:
-      return wrap({ type: 'number' })
-
-    case FieldTypeEnum.CHECKBOX:
-      return wrap({ type: 'boolean' })
-
-    case FieldTypeEnum.DATE:
-      return wrap({ type: 'string', format: 'date' })
-
-    case FieldTypeEnum.SINGLE_SELECT: {
-      const ids = selectOptionIds(options)
-      if (ids.length === 0) {
-        throw new BadRequestError('SINGLE_SELECT field has no options to choose from')
-      }
-      return wrap({ type: 'string', enum: ids })
-    }
-
-    case FieldTypeEnum.MULTI_SELECT: {
-      const ids = selectOptionIds(options)
-      if (ids.length === 0) {
-        throw new BadRequestError('MULTI_SELECT field has no options to choose from')
-      }
-      return wrap({
-        type: 'array',
-        items: { type: 'string', enum: ids },
-      })
-    }
-
-    default:
-      throw new BadRequestError(`AI generation is not supported for field type ${field.type}`)
+  const spec = getAiTypeSpec(field.type)
+  if (!spec) {
+    throw new BadRequestError(`AI generation is not supported for field type ${field.type}`)
   }
+
+  assertEnumerable(field, options)
+
+  return wrap(spec.schema(field, ctx), { nullable: spec.nullable })
 }
 
 /**
- * Pull option ids out of a SELECT field's options. Falls back to `value`
- * when an option was defined without a stable `id` (older data shapes).
+ * Reject enum-backed types whose option list is empty before the schema is
+ * built — a `{ enum: [] }` is a schema no output can satisfy, so the provider
+ * error would surface as an opaque generation failure instead of a clear
+ * "this field has no options" message.
+ *
+ * An open TAGS field (`ai.allowNewOptions`) has no enum, so it is exempt.
  */
-function selectOptionIds(options: FieldOptions): string[] {
-  const opts = options.options
-  if (!Array.isArray(opts)) return []
-  return opts.map((o) => o.id ?? o.value).filter((id): id is string => Boolean(id))
+function assertEnumerable(field: CustomFieldEntity, options: FieldOptions): void {
+  const needsOptions =
+    field.type === FieldTypeEnum.SINGLE_SELECT ||
+    field.type === FieldTypeEnum.MULTI_SELECT ||
+    (field.type === FieldTypeEnum.TAGS && !allowsNewTagOptions(field))
+
+  if (needsOptions && selectOptionIds(options).length === 0) {
+    throw new BadRequestError(`${field.type} field has no options to choose from`)
+  }
 }

--- a/packages/lib/src/field-values/ai-autofill/preview-service.ts
+++ b/packages/lib/src/field-values/ai-autofill/preview-service.ts
@@ -11,9 +11,11 @@ import { UsageTrackingService } from '../../ai/usage/usage-tracking-service'
 import { extractFieldIdsFromString, formulaToString } from '../../custom-fields/formula-converters'
 import { BadRequestError } from '../../errors'
 import { createFieldValueContext } from '../field-value-helpers'
+import { getOrgCurrencyCode } from '../org-currency'
 import { buildJsonSchema } from './json-schema-builder'
 import { buildPrompt } from './prompt-builder'
 import { resolveReferences } from './reference-resolver'
+import { type AiFieldContext, normalizeGeneratedValue } from './type-specs'
 
 const logger = createScopedLogger('ai-autofill:preview-service')
 
@@ -78,27 +80,33 @@ export async function previewFieldValue(params: {
   const fieldKeys = extractFieldIdsFromString(promptStr)
   const resolved = await resolveReferences(ctx, { recordId: sampleRecordId, fieldKeys })
 
-  // 2. Build final prompts
+  // 2. Same org rung the worker resolves, so the preview's prompt names the
+  //    same denomination the committed generation will.
+  const fieldContext: AiFieldContext =
+    type === 'CURRENCY' ? { orgCurrencyCode: await getOrgCurrencyCode(orgId) } : {}
+
+  // 3. Build final prompts
   const { resolvedPrompt, systemPrompt, truncated } = buildPrompt({
     promptJson,
     resolved,
     field: syntheticField,
+    context: fieldContext,
   })
   if (truncated) {
     logger.warn('AI preview prompt truncated at 32k chars', { sampleRecordId })
   }
 
-  // 3. Build output schema from type + options
-  const jsonSchema = buildJsonSchema(syntheticField)
+  // 4. Build output schema from type + options
+  const jsonSchema = buildJsonSchema(syntheticField, fieldContext)
 
-  // 4. Resolve default LLM for this org
+  // 5. Resolve default LLM for this org
   const systemModels = new SystemModelService(database, orgId)
   const def = await systemModels.getDefault(ModelType.LLM)
   if (!def) {
     throw new BadRequestError('No default LLM configured for this organization')
   }
 
-  // 5. Invoke the orchestrator. Quota + AiUsage logging handled inside.
+  // 6. Invoke the orchestrator. Quota + AiUsage logging handled inside.
   const orchestrator = new LLMOrchestrator(new UsageTrackingService(database), database)
   const response = await orchestrator.invoke({
     model: def.model,
@@ -119,9 +127,22 @@ export async function previewFieldValue(params: {
     throw new BadRequestError('AI response did not match the expected structured output shape')
   }
 
+  // 7. Same normalize step the worker runs — but `dryRun`, so a normalizer
+  //    that would write outside `FieldValue` (open TAGS minting) stays inert:
+  //    previewing an unsaved field definition must not grow its taxonomy.
+  const value = await normalizeGeneratedValue(
+    (structured as { value: unknown }).value,
+    syntheticField,
+    {
+      ...fieldContext,
+      organizationId: orgId,
+      dryRun: true,
+    }
+  )
+
   return {
     resolvedPrompt,
-    value: (structured as { value: unknown }).value,
+    value,
     truncated,
     tokens: response.usage
       ? {

--- a/packages/lib/src/field-values/ai-autofill/prompt-builder.ts
+++ b/packages/lib/src/field-values/ai-autofill/prompt-builder.ts
@@ -3,6 +3,7 @@
 import type { CustomFieldEntity } from '@auxx/database/types'
 import { type FormulaNode, formulaToString } from '../../custom-fields/formula-converters'
 import type { ResolvedReference } from './reference-resolver'
+import { type AiFieldContext, getAiTypeSpec } from './type-specs'
 
 /** 32k char cap on the assembled user prompt (decision T4.5). */
 const MAX_USER_PROMPT_CHARS = 32_000
@@ -27,8 +28,10 @@ export function buildPrompt(params: {
   promptJson: FormulaNode
   resolved: Map<string, ResolvedReference>
   field: CustomFieldEntity
+  /** Values the shape hint cannot derive from the field alone (org currency). */
+  context?: AiFieldContext
 }): BuiltPrompt {
-  const { promptJson, resolved, field } = params
+  const { promptJson, resolved, field, context } = params
 
   const template = formulaToString(promptJson)
 
@@ -43,7 +46,7 @@ export function buildPrompt(params: {
 
   return {
     resolvedPrompt: text,
-    systemPrompt: buildSystemPrompt(field),
+    systemPrompt: buildSystemPrompt(field, context),
     truncated,
   }
 }
@@ -57,39 +60,24 @@ function truncateToCap(input: string, max: number): { text: string; truncated: b
 /**
  * Static system prompt tailored to the field's native type. Tells the model
  * how to format the value so the `json_schema` envelope parses cleanly.
+ *
+ * The shape line and the refusal line both come from the field type's entry in
+ * `AI_TYPE_SPECS`, so the natural-language contract cannot drift from the
+ * machine contract the provider enforces.
  */
-function buildSystemPrompt(field: CustomFieldEntity): string {
-  const typeHint = describeExpectedShape(field)
+function buildSystemPrompt(field: CustomFieldEntity, context?: AiFieldContext): string {
+  const spec = getAiTypeSpec(field.type)
   return [
     'You generate values for fields on business records.',
     'Read the user instructions carefully, honour any referenced field values,',
     'and return ONLY the JSON envelope requested by the response schema.',
     `Field name: "${field.name}"`,
-    typeHint,
-    'If you cannot produce a confident answer, return the most reasonable value',
-    'that fits the schema rather than refusing.',
+    spec?.shapeHint(field, context) ?? '',
+    // A nullable type's schema admits `null`, so "return the most reasonable
+    // value rather than refusing" would push the model into fabricating one —
+    // the exact failure the null branch exists to prevent.
+    spec?.nullable
+      ? 'If the instructions do not contain the information, return null. Never invent a value.'
+      : 'If you cannot produce a confident answer, return the most reasonable value\nthat fits the schema rather than refusing.',
   ].join('\n')
-}
-
-function describeExpectedShape(field: CustomFieldEntity): string {
-  switch (field.type) {
-    case 'TEXT':
-      return 'Produce concise plain text. No markdown, no quotation marks around the whole value.'
-    case 'NUMBER':
-      return 'Produce a numeric value. No units, no thousands separators.'
-    case 'CHECKBOX':
-      return 'Produce a boolean: true or false.'
-    case 'DATE':
-      return 'Produce an ISO calendar date in YYYY-MM-DD form.'
-    case 'URL':
-      return 'Produce a fully-qualified URL including the https:// scheme.'
-    case 'EMAIL':
-      return 'Produce a single RFC-5322 email address.'
-    case 'SINGLE_SELECT':
-      return 'Choose exactly one option id from the enumerated set in the schema.'
-    case 'MULTI_SELECT':
-      return 'Choose zero or more option ids from the enumerated set in the schema.'
-    default:
-      return ''
-  }
 }

--- a/packages/lib/src/field-values/ai-autofill/tag-minting.ts
+++ b/packages/lib/src/field-values/ai-autofill/tag-minting.ts
@@ -1,0 +1,161 @@
+// packages/lib/src/field-values/ai-autofill/tag-minting.ts
+
+import { database, schema } from '@auxx/database'
+import type { CustomFieldEntity } from '@auxx/database/types'
+import { createScopedLogger } from '@auxx/logger'
+import { generateId } from '@auxx/utils/generateId'
+import { and, eq } from 'drizzle-orm'
+import { onCacheEvent } from '../../cache/invalidate'
+import type { FieldOptions } from '../../custom-fields/field-options'
+
+const logger = createScopedLogger('ai-autofill:tag-minting')
+
+type SelectOptionRow = NonNullable<FieldOptions['options']>[number]
+
+/**
+ * Fold a tag label onto its match key. Case- and whitespace-insensitive, so
+ * `Enterprise`, `enterprise` and ` Enterprise ` all collapse onto one option.
+ */
+function matchKey(label: string): string {
+  return label.trim().replace(/\s+/g, ' ').toLowerCase()
+}
+
+/** The id a FieldValue stores for an option row: `id` when present, else `value`. */
+function optionId(option: SelectOptionRow): string | undefined {
+  return option.id ?? option.value
+}
+
+/** Index existing options by match key, first writer winning on a collision. */
+function indexByMatchKey(options: SelectOptionRow[]): Map<string, string> {
+  const index = new Map<string, string>()
+  for (const option of options) {
+    const id = optionId(option)
+    const label = option.label ?? option.value
+    if (!id || !label) continue
+    const key = matchKey(label)
+    if (!index.has(key)) index.set(key, id)
+  }
+  return index
+}
+
+/** Trim, drop blanks, and dedupe generated labels while preserving order. */
+function cleanLabels(labels: unknown[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const raw of labels) {
+    if (typeof raw !== 'string') continue
+    const label = raw.trim().replace(/\s+/g, ' ')
+    if (label === '') continue
+    const key = matchKey(label)
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(label)
+  }
+  return out
+}
+
+/**
+ * Map generated tag LABELS onto option ids for an open TAGS field
+ * (`options.ai.allowNewOptions`), minting only what genuinely does not exist.
+ *
+ * This is the **single writer** for AI-grown tag taxonomies, and the only place
+ * in AI autofill that writes outside `FieldValue`.
+ *
+ * 🛑 Never read-modify-write from the job. A bulk generate runs N parallel jobs
+ * against the same `options.options` array; two workers that each read, append
+ * and write would lose one another's tags and mint `Enterprise` twice under
+ * different ids. The append therefore happens inside a transaction that takes a
+ * row lock on the `CustomField` row and re-reads the option list under it, so
+ * the match-before-mint decision is made against committed state.
+ *
+ * @param params.field - The TAGS field. Its `options` may be stale; the
+ *   authoritative list is re-read under the lock.
+ * @param params.labels - Raw strings from the LLM.
+ * @param params.dryRun - Preview mode: match against what exists, never mint.
+ * @returns Option ids, in the order the model produced them.
+ */
+export async function mintOrMatchTagOptions(params: {
+  organizationId: string
+  field: CustomFieldEntity
+  labels: unknown[]
+  dryRun?: boolean
+}): Promise<string[]> {
+  const { organizationId, field, labels, dryRun = false } = params
+
+  const wanted = cleanLabels(labels)
+  if (wanted.length === 0) return []
+
+  // Preview never grows the taxonomy — a dry run on an unsaved field
+  // definition has no business editing the field it is previewing.
+  if (dryRun) {
+    const index = indexByMatchKey(((field.options ?? {}) as FieldOptions).options ?? [])
+    return wanted.map((label) => index.get(matchKey(label)) ?? label)
+  }
+
+  const { ids, minted } = await database.transaction(async (tx) => {
+    const [row] = await tx
+      .select({ options: schema.CustomField.options })
+      .from(schema.CustomField)
+      .where(
+        and(
+          eq(schema.CustomField.id, field.id),
+          eq(schema.CustomField.organizationId, organizationId)
+        )
+      )
+      .for('update')
+      .limit(1)
+
+    const current = ((row?.options ?? {}) as FieldOptions).options ?? []
+    const index = indexByMatchKey(current)
+
+    const appended: SelectOptionRow[] = []
+    const resolved: string[] = []
+    for (const label of wanted) {
+      const key = matchKey(label)
+      const existing = index.get(key)
+      if (existing) {
+        resolved.push(existing)
+        continue
+      }
+      // Same shape the human tag picker mints: `{ label, value: generateId() }`
+      // with no separate `id`, so `optionId` resolves through `value`.
+      const option: SelectOptionRow = { value: generateId(), label }
+      appended.push(option)
+      index.set(key, option.value)
+      resolved.push(option.value)
+    }
+
+    if (appended.length > 0) {
+      await tx
+        .update(schema.CustomField)
+        .set({
+          options: {
+            ...((row?.options ?? {}) as FieldOptions),
+            options: [...current, ...appended],
+          },
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(schema.CustomField.id, field.id),
+            eq(schema.CustomField.organizationId, organizationId)
+          )
+        )
+    }
+
+    return { ids: resolved, minted: appended.length }
+  })
+
+  if (minted > 0) {
+    // Without this, every later job in the batch reads a stale option list from
+    // the org cache and re-mints what a sibling just created.
+    await onCacheEvent('custom-field.updated', { orgId: organizationId })
+    logger.info('AI autofill minted tag options', {
+      organizationId,
+      fieldId: field.id,
+      minted,
+    })
+  }
+
+  return ids
+}

--- a/packages/lib/src/field-values/ai-autofill/type-specs.ts
+++ b/packages/lib/src/field-values/ai-autofill/type-specs.ts
@@ -1,0 +1,373 @@
+// packages/lib/src/field-values/ai-autofill/type-specs.ts
+
+import type { CustomFieldEntity, FieldType } from '@auxx/database/types'
+import { minorUnitExponent } from '@auxx/utils/currency'
+import { parseTimeOfDay } from '@auxx/utils/date'
+import type { FieldOptions } from '../../custom-fields/field-options'
+import { withOrgCurrency } from '../org-currency'
+import { mintOrMatchTagOptions } from './tag-minting'
+
+/**
+ * Permissive JSON-schema shape — the LLM orchestrator passes this through
+ * to the provider verbatim, so we only need enough typing to construct it.
+ */
+export type JsonSchema = Record<string, unknown>
+
+/**
+ * Read-only context threaded into schema + prompt construction.
+ *
+ * Only carries values that cannot be derived from the `CustomFieldEntity`
+ * alone — today that is the org rung of the CURRENCY denomination chain.
+ */
+export interface AiFieldContext {
+  /** Org's `organization.currency`, the middle rung of field → org → USD. */
+  orgCurrencyCode?: string
+}
+
+/** Context for the post-generation {@link AiTypeSpec.normalize} step. */
+export interface AiNormalizeContext extends AiFieldContext {
+  organizationId: string
+  /**
+   * True for the create/edit dialog's preview. Normalizers that would write
+   * outside `FieldValue` (open TAGS minting) must be inert in this mode —
+   * a dry run may not grow the field's taxonomy.
+   */
+  dryRun?: boolean
+}
+
+/**
+ * Everything the three coupled knobs need for one AI-eligible field type,
+ * colocated so they cannot silently disagree:
+ *
+ *  1. `schema`    — the machine contract the provider enforces.
+ *  2. `shapeHint` — the natural-language contract in the system prompt.
+ *  3. `normalize` — the bridge between the LLM's output space and the
+ *                   strict validator a human edit hits.
+ *
+ * Plus `nullable`, which lets the model decline instead of inventing a value.
+ */
+export interface AiTypeSpec {
+  /** Value schema (the `{ value: … }` envelope is added by `buildJsonSchema`). */
+  schema: (field: CustomFieldEntity, ctx?: AiFieldContext) => JsonSchema
+  /** One sentence appended to the system prompt describing the expected shape. */
+  shapeHint: (field: CustomFieldEntity, ctx?: AiFieldContext) => string
+  /**
+   * Map raw LLM output onto what `validateSingleValue` accepts. Returning
+   * `null` clears the value — always preferable to letting the strict
+   * validator throw, which surfaces as a red error cell.
+   */
+  normalize?: (
+    value: unknown,
+    field: CustomFieldEntity,
+    ctx: AiNormalizeContext
+  ) => unknown | Promise<unknown>
+  /**
+   * When true the schema admits `null` and the system prompt tells the model
+   * to decline rather than fabricate. Reserved for types where a plausible
+   * invented value is indistinguishable from a real one.
+   */
+  nullable?: boolean
+}
+
+/**
+ * Pull option ids out of a SELECT/TAGS field's options. Falls back to `value`
+ * when an option was defined without a stable `id` (older data shapes).
+ */
+export function selectOptionIds(options: FieldOptions): string[] {
+  const opts = options.options
+  if (!Array.isArray(opts)) return []
+  return opts.map((o) => o.id ?? o.value).filter((id): id is string => Boolean(id))
+}
+
+/** Human-readable option labels, for prompts that name the existing taxonomy. */
+function selectOptionLabels(options: FieldOptions): string[] {
+  const opts = options.options
+  if (!Array.isArray(opts)) return []
+  return opts.map((o) => o.label ?? o.value).filter((label): label is string => Boolean(label))
+}
+
+/** Field options, narrowed from the untyped jsonb column. */
+function fieldOptions(field: CustomFieldEntity): FieldOptions {
+  return (field.options ?? {}) as FieldOptions
+}
+
+/** Whether a TAGS field is allowed to grow its own taxonomy (default off). */
+export function allowsNewTagOptions(field: CustomFieldEntity): boolean {
+  const options = field.options as { ai?: { allowNewOptions?: boolean } } | null | undefined
+  return options?.ai?.allowNewOptions === true
+}
+
+/** Trimmed non-empty string, or null. */
+function toTrimmedString(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed === '' ? null : trimmed
+}
+
+/**
+ * Drop null/empty members from a generated object and return `null` when
+ * nothing survives.
+ *
+ * Strict mode forces every property into `required`, so "this member is
+ * unknown" can only be expressed as an explicit `null` — but the NAME and
+ * ADDRESS_STRUCT zod schemas use `.optional()` (which rejects `null`) and
+ * `.refine()` an at-least-one rule. Without this step a partially-known
+ * address throws instead of storing the part that IS known.
+ */
+function compactObject(value: unknown, keys: readonly string[]): Record<string, string> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const source = value as Record<string, unknown>
+  const out: Record<string, string> = {}
+  for (const key of keys) {
+    const str = toTrimmedString(source[key])
+    if (str !== null) out[key] = str
+  }
+  return Object.keys(out).length > 0 ? out : null
+}
+
+const ADDRESS_KEYS = ['street1', 'street2', 'city', 'state', 'zipCode', 'country'] as const
+const NAME_KEYS = ['firstName', 'lastName'] as const
+
+/** `{ type: ['string', 'null'] }` member of a strict-mode object schema. */
+function nullableString(description: string): JsonSchema {
+  return { type: ['string', 'null'], description }
+}
+
+/**
+ * Per-type AI generation contract, keyed by native field type.
+ *
+ * There are exactly TWO sources of AI eligibility and they are joined by an
+ * exact-set-equality test (`__tests__/type-specs.test.ts`):
+ *
+ *  - the plain name Set `AI_ELIGIBLE_FIELD_TYPES` in `@auxx/types/custom-field`,
+ *    which `@auxx/services` gates saves on and cannot import from `@auxx/lib`;
+ *  - this table, which stays in lib because CURRENCY's denomination resolves
+ *    through `getOrgCurrencyCode` — async, org-cache-backed, lib-only — and
+ *    open TAGS mints options against the database.
+ *
+ * Adding a type is therefore always a two-file change, and the test enforces it.
+ *
+ * 🛑 Do NOT hang this off `fieldTypeOptions` (`custom-fields/types.ts`): that
+ * record is imported directly by client components, and pulling the org cache
+ * into it would break the web bundle.
+ *
+ * A `normalize` entry is a last resort, not the default. The commit path runs
+ * `validateSingleValue` — the same strict validator a human edit hits — so the
+ * schema and the shape hint should already emit what it accepts. Every
+ * normalizer below carries the reason its type cannot.
+ */
+export const AI_TYPE_SPECS: Partial<Record<FieldType, AiTypeSpec>> = {
+  TEXT: {
+    schema: () => ({ type: 'string' }),
+    shapeHint: () =>
+      'Produce concise plain text. No markdown, no quotation marks around the whole value.',
+  },
+
+  RICH_TEXT: {
+    schema: () => ({ type: 'string' }),
+    shapeHint: () =>
+      'Produce a fragment of simple HTML using only <p>, <br>, <strong>, <em>, <u>, <s>, ' +
+      '<ul>/<ol>/<li>, <blockquote>, <code> and <a href> tags. No <html>, <head>, <body>, ' +
+      '<script> or <style>, no markdown, no code fences.',
+  },
+
+  NUMBER: {
+    schema: () => ({ type: 'number' }),
+    shapeHint: () => 'Produce a numeric value. No units, no thousands separators.',
+  },
+
+  CURRENCY: {
+    // Integer, not number: since #1782 a CURRENCY value is an integer count of
+    // minor units and `validateSingleValue` hard-rejects anything fractional.
+    // Strict mode enforcing `integer` is most of the fix; the prompt supplies
+    // the denomination the model needs to do the conversion itself.
+    //
+    // 🛑 Deliberately no scaling normalizer. Given `600` the server cannot know
+    // whether that is $6.00 or $600 — the undecidable guess that produced
+    // 100×-wrong stored data. The integrality check is the safety net.
+    schema: () => ({ type: 'integer' }),
+    shapeHint: (field, ctx) => {
+      const resolved = withOrgCurrency(fieldOptions(field), 'CURRENCY', ctx?.orgCurrencyCode)
+      const code = resolved?.currencyCode ?? 'USD'
+      const exponent = minorUnitExponent(code)
+      const unitNote =
+        exponent === 0
+          ? `${code} has no minor unit, so the integer IS the whole-unit amount`
+          : `1 ${code} = ${10 ** exponent} minor units, so 19.99 ${code} is ${Math.round(
+              19.99 * 10 ** exponent
+            )}`
+      return (
+        `Produce the amount in MINOR UNITS of ${code} as an integer (${unitNote}). ` +
+        'Do the conversion yourself: no decimal point, no thousands separators, no currency symbol.'
+      )
+    },
+  },
+
+  CHECKBOX: {
+    schema: () => ({ type: 'boolean' }),
+    shapeHint: () => 'Produce a boolean: true or false.',
+  },
+
+  DATE: {
+    schema: () => ({ type: 'string', format: 'date' }),
+    shapeHint: () => 'Produce an ISO calendar date in YYYY-MM-DD form.',
+  },
+
+  DATETIME: {
+    schema: () => ({ type: 'string', format: 'date-time' }),
+    shapeHint: () =>
+      'Produce an ISO-8601 timestamp with an explicit UTC offset, e.g. 2026-08-20T14:30:00Z.',
+  },
+
+  TIME: {
+    // `dateSchema` is `new Date(String(v))` and `new Date('14:30')` is Invalid
+    // Date, so a bare clock time cannot reach storage unanchored. The pattern
+    // is `HH:MM` exactly (no seconds) because that is what `parseTimeOfDay`
+    // accepts — the same helper the human time picker anchors through.
+    schema: () => ({ type: 'string', pattern: '^([01]\\d|2[0-3]):[0-5]\\d$' }),
+    shapeHint: () => 'Produce a 24-hour clock time in HH:MM form, e.g. 14:30.',
+    normalize: (value) => {
+      const raw = toTrimmedString(value)
+      if (raw === null) return null
+      // Mirrors `createDateWithTime` on the human path: today's date in the
+      // writer's local zone, local hour/minute setters, seconds+ms zeroed.
+      // 🛑 The writer here is the worker process, not the browser — a TIME
+      // generated server-side is anchored in the SERVER's timezone.
+      return parseTimeOfDay(raw)?.toISOString() ?? null
+    },
+  },
+
+  URL: {
+    schema: () => ({ type: 'string' }),
+    shapeHint: () =>
+      'Produce a fully-qualified URL including the https:// scheme, or null if the ' +
+      'instructions do not contain one — never invent a URL.',
+    nullable: true,
+  },
+
+  EMAIL: {
+    schema: () => ({ type: 'string' }),
+    shapeHint: () =>
+      'Produce a single RFC-5322 email address, or null if the instructions do not ' +
+      'contain one — never invent an address.',
+    nullable: true,
+  },
+
+  PHONE_INTL: {
+    schema: () => ({ type: 'string' }),
+    shapeHint: () =>
+      'Produce a phone number in E.164 form with a leading + and country code, or null ' +
+      'if the instructions do not contain a phone number — never invent one.',
+    nullable: true,
+    // No normalizer: `validateSingleValue`'s PHONE_INTL arm already runs the
+    // shared `formatPhoneNumber` E.164 normalization (#1629) and rejects what
+    // it cannot parse, exactly as it does for a human edit. Nullability — not
+    // a second coercion pass — is what stops the model inventing a number.
+  },
+
+  NAME: {
+    schema: () => ({
+      type: 'object',
+      additionalProperties: false,
+      required: [...NAME_KEYS],
+      properties: {
+        firstName: nullableString('Given name, or null if unknown.'),
+        lastName: nullableString('Family name, or null if unknown.'),
+      },
+    }),
+    shapeHint: () =>
+      'Produce an object with firstName and lastName. Use null for a part the ' +
+      'instructions do not state — never invent a name.',
+    nullable: true,
+    normalize: (value) => compactObject(value, NAME_KEYS),
+  },
+
+  ADDRESS_STRUCT: {
+    schema: () => ({
+      type: 'object',
+      additionalProperties: false,
+      required: [...ADDRESS_KEYS],
+      properties: {
+        street1: nullableString('Street address line 1, or null if unknown.'),
+        street2: nullableString('Street address line 2 (unit, suite), or null if unknown.'),
+        city: nullableString('City or locality, or null if unknown.'),
+        state: nullableString('State, province or region, or null if unknown.'),
+        zipCode: nullableString('Postal or ZIP code, or null if unknown.'),
+        country: nullableString('Country name or ISO code, or null if unknown.'),
+      },
+    }),
+    shapeHint: () =>
+      'Produce a structured address. Use null for any component the instructions do not ' +
+      'state — a partial address is useful, an invented one is not.',
+    nullable: true,
+    normalize: (value) => compactObject(value, ADDRESS_KEYS),
+  },
+
+  SINGLE_SELECT: {
+    schema: (field) => ({ type: 'string', enum: selectOptionIds(fieldOptions(field)) }),
+    shapeHint: () => 'Choose exactly one option id from the enumerated set in the schema.',
+  },
+
+  MULTI_SELECT: {
+    schema: (field) => ({
+      type: 'array',
+      items: { type: 'string', enum: selectOptionIds(fieldOptions(field)) },
+    }),
+    shapeHint: () => 'Choose zero or more option ids from the enumerated set in the schema.',
+  },
+
+  TAGS: {
+    // Two halves. Constrained (the default) is byte-for-byte MULTI_SELECT.
+    // Open (`ai.allowNewOptions`) drops the enum and takes free-text labels —
+    // strict mode cannot express "one of these ids OR any new string", so the
+    // existing labels go in the prompt and `mintOrMatchTagOptions` maps the
+    // answer back onto option ids, minting only what genuinely does not exist.
+    schema: (field) =>
+      allowsNewTagOptions(field)
+        ? { type: 'array', items: { type: 'string' } }
+        : { type: 'array', items: { type: 'string', enum: selectOptionIds(fieldOptions(field)) } },
+    shapeHint: (field) => {
+      if (!allowsNewTagOptions(field)) {
+        return 'Choose zero or more option ids from the enumerated set in the schema.'
+      }
+      const labels = selectOptionLabels(fieldOptions(field))
+      const existing =
+        labels.length > 0
+          ? ` Reuse an existing tag verbatim whenever one fits: ${labels.join(', ')}.`
+          : ''
+      return `Produce an array of short tag labels (1-3 words each).${existing}`
+    },
+    normalize: (value, field, ctx) => {
+      if (!allowsNewTagOptions(field)) return value
+      return mintOrMatchTagOptions({
+        organizationId: ctx.organizationId,
+        field,
+        labels: Array.isArray(value) ? value : [],
+        dryRun: ctx.dryRun === true,
+      })
+    },
+  },
+}
+
+/** Whether a field type has an AI generation contract in {@link AI_TYPE_SPECS}. */
+export function getAiTypeSpec(type: FieldType | string): AiTypeSpec | undefined {
+  return AI_TYPE_SPECS[type as FieldType]
+}
+
+/**
+ * Run the per-type normalize step on raw LLM output.
+ *
+ * Called from `generation-service` (worker commit) and `preview-service`
+ * (dialog dry run) right after the `{ value }` envelope is unwrapped, so both
+ * surfaces see the same value the strict validator will.
+ */
+export async function normalizeGeneratedValue(
+  value: unknown,
+  field: CustomFieldEntity,
+  ctx: AiNormalizeContext
+): Promise<unknown> {
+  if (value === null || value === undefined) return null
+  const spec = getAiTypeSpec(field.type)
+  if (!spec?.normalize) return value
+  return await spec.normalize(value, field, ctx)
+}

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -2235,12 +2235,22 @@ export async function setValueWithBuiltIn(
       // Routed through buildPublishEntry like the set branch below — this
       // publishes `[]` (not `null`) for array-return fields, matching
       // setBulkValues' "cleared" signal (see helper doc).
-      const entry = buildPublishEntry({
-        publishRecordId,
-        fieldId: fieldId as FieldId,
-        field,
-        values: [],
-      })
+      //
+      // `aiStatus: null` is load-bearing, not decoration. `deleteValue` drops
+      // the row and with it the persisted marker, but the client only clears
+      // its AI state when the entry CARRIES an `aiStatus` (`use-resource-sync`
+      // skips `undefined`). Without it, a nullable generation that declines
+      // leaves the cell spinning on `generating` until a reload.
+      const entry: FieldValueUpdateEntry = {
+        ...buildPublishEntry({
+          publishRecordId,
+          fieldId: fieldId as FieldId,
+          field,
+          values: [],
+        }),
+        aiStatus: null,
+        aiMetadata: null,
+      }
       if (collectRealtime) {
         collectRealtime.push(entry)
       } else {

--- a/packages/services/src/custom-fields/__tests__/update-field-ai-options.test.ts
+++ b/packages/services/src/custom-fields/__tests__/update-field-ai-options.test.ts
@@ -1,0 +1,186 @@
+// packages/services/src/custom-fields/__tests__/update-field-ai-options.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// `vi.mock` factories are hoisted above every top-level binding, so the mock's
+// shared state has to be hoisted with them.
+const mocks = vi.hoisted(() => ({
+  customFieldTable: { id: 'CustomField.id', organizationId: 'CustomField.organizationId' },
+  fieldValueTable: { fieldId: 'FieldValue.fieldId', organizationId: 'FieldValue.organizationId' },
+  /** The row `updateCustomField` reads before deciding what to write. */
+  currentRow: undefined as Record<string, unknown> | undefined,
+  /** Every `update(table).set(data)` the call made, in order. */
+  writes: [] as Array<{ table: unknown; data: Record<string, unknown> }>,
+}))
+
+const CUSTOM_FIELD_TABLE = mocks.customFieldTable
+const FIELD_VALUE_TABLE = mocks.fieldValueTable
+
+vi.mock('@auxx/database', () => ({
+  database: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: () => Promise.resolve(mocks.currentRow ? [mocks.currentRow] : []) }),
+      }),
+    }),
+    // The update terminal must be awaitable directly AND chainable with
+    // `.returning()`: `updateCustomField` awaits `.where(...)` on its own for
+    // the aiStatus clear, but calls `.where(...).returning()` for the field row.
+    update: (table: unknown) => ({
+      set: (data: Record<string, unknown>) => {
+        mocks.writes.push({ table, data })
+        return {
+          where: () => ({
+            returning: () => Promise.resolve([{ id: 'field_1', ...data }]),
+            // biome-ignore lint/suspicious/noThenProperty: a Drizzle query builder IS a thenable; the mock has to be one too
+            then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+              Promise.resolve(undefined).then(resolve, reject),
+          }),
+        }
+      },
+    }),
+  },
+  schema: { CustomField: mocks.customFieldTable, FieldValue: mocks.fieldValueTable },
+}))
+
+vi.mock('drizzle-orm', () => ({
+  and: (...args: unknown[]) => ({ and: args }),
+  eq: (col: unknown, val: unknown) => ({ col, val }),
+}))
+
+import { updateCustomField } from '../update-field'
+
+const PROMPT = {
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Categorise this record' }] }],
+}
+
+const STORED_AI = { enabled: true, prompt: PROMPT, triggerOn: 'manual', allowNewOptions: true }
+
+const OPTION_A = { value: 'opt_a', label: 'Enterprise' }
+const OPTION_B = { value: 'opt_b', label: 'SMB' }
+
+/** The write that targeted the CustomField row. */
+function fieldWrite() {
+  return mocks.writes.find((w) => w.table === CUSTOM_FIELD_TABLE)?.data
+}
+
+/** Whether the call cleared `aiStatus` on the field's values. */
+function clearedAiStatus() {
+  return mocks.writes.some((w) => w.table === FIELD_VALUE_TABLE && w.data.aiStatus === null)
+}
+
+function setStoredField(options: Record<string, unknown>, type = 'TAGS') {
+  mocks.currentRow = {
+    type,
+    options,
+    isUnique: false,
+    modelType: 'ENTITY_INSTANCE',
+    entityDefinitionId: 'def_1',
+    systemAttribute: null,
+    appInstallationId: null,
+  }
+}
+
+const BASE_INPUT = {
+  resourceFieldId: 'def_1:field_1' as never,
+  organizationId: 'org_1',
+}
+
+beforeEach(() => {
+  mocks.writes = []
+  mocks.currentRow = undefined
+})
+
+describe('updateCustomField — options.ai preservation', () => {
+  describe('options-only array patch (the record-side tag picker)', () => {
+    it('preserves the stored ai block when a tag is added', async () => {
+      setStoredField({ options: [OPTION_A], ai: STORED_AI })
+
+      const result = await updateCustomField({
+        ...BASE_INPUT,
+        options: [OPTION_A, OPTION_B],
+      })
+
+      expect(result.isOk()).toBe(true)
+      const written = fieldWrite()?.options as Record<string, unknown>
+      // The whole point: typing a new tag on a record must not destroy the
+      // field's AI configuration.
+      expect(written.ai).toEqual(STORED_AI)
+      expect(written.options).toEqual([OPTION_A, OPTION_B])
+    })
+
+    it('preserves the stored ai block when a tag is deleted', async () => {
+      setStoredField({ options: [OPTION_A, OPTION_B], ai: STORED_AI })
+
+      await updateCustomField({ ...BASE_INPUT, options: [OPTION_A] })
+
+      const written = fieldWrite()?.options as Record<string, unknown>
+      expect(written.ai).toEqual(STORED_AI)
+      expect(written.options).toEqual([OPTION_A])
+    })
+
+    it('does not clear the aiStatus marker on the field values', async () => {
+      setStoredField({ options: [OPTION_A], ai: STORED_AI })
+
+      await updateCustomField({ ...BASE_INPUT, options: [OPTION_A, OPTION_B] })
+
+      expect(clearedAiStatus()).toBe(false)
+    })
+
+    it('rejects emptying the option list of a constrained AI-enabled select', async () => {
+      setStoredField(
+        { options: [OPTION_A], ai: { ...STORED_AI, allowNewOptions: false } },
+        'SINGLE_SELECT'
+      )
+
+      const result = await updateCustomField({ ...BASE_INPUT, options: [] })
+
+      expect(result.isErr()).toBe(true)
+      expect(fieldWrite()).toBeUndefined()
+    })
+
+    it('allows emptying the option list of an open TAGS field', async () => {
+      // `allowNewOptions` means there is no enum to satisfy, so an empty list
+      // is a legitimate starting state.
+      setStoredField({ options: [OPTION_A], ai: STORED_AI })
+
+      const result = await updateCustomField({ ...BASE_INPUT, options: [] })
+
+      expect(result.isOk()).toBe(true)
+    })
+  })
+
+  describe('object-shaped patch (the field form)', () => {
+    it('preserves the stored option list when the patch carries only ai', async () => {
+      // TAGS renders no options editor in the field form, so enabling AI sends
+      // `{ ai }` alone — the tag taxonomy must survive it.
+      setStoredField({ options: [OPTION_A, OPTION_B], icon: 'tag' })
+
+      const result = await updateCustomField({
+        ...BASE_INPUT,
+        options: { ai: STORED_AI } as never,
+      })
+
+      expect(result.isOk()).toBe(true)
+      const written = fieldWrite()?.options as Record<string, unknown>
+      expect(written.options).toEqual([OPTION_A, OPTION_B])
+      expect(written.ai).toEqual(STORED_AI)
+    })
+
+    it('still strips the ai block on toggle-off', async () => {
+      setStoredField({ options: [OPTION_A], ai: STORED_AI }, 'MULTI_SELECT')
+
+      const result = await updateCustomField({
+        ...BASE_INPUT,
+        options: { options: [OPTION_A] } as never,
+      })
+
+      expect(result.isOk()).toBe(true)
+      const written = fieldWrite()?.options as Record<string, unknown>
+      expect(written.ai).toBeUndefined()
+      // Toggle-off also retires the per-value markers.
+      expect(clearedAiStatus()).toBe(true)
+    })
+  })
+})

--- a/packages/services/src/custom-fields/update-field.ts
+++ b/packages/services/src/custom-fields/update-field.ts
@@ -189,25 +189,52 @@ export async function updateCustomField(input: UpdateCustomFieldInput) {
   // Validate options.ai (if the caller is touching it). Uses the caller's
   // new options when present, else falls back to what's already stored —
   // so re-saving a field without touching AI doesn't re-validate it.
+  //
+  // 🛑 A bare `SelectOption[]` is an options-ONLY patch. The record-side tag
+  // picker sends exactly that on every create / rename / recolor / reorder /
+  // delete, and it says nothing about AI. Reading it as "the caller omitted
+  // `ai`, so clear it" silently destroyed the field's entire AI config the
+  // first time anyone typed a new tag on a record — and cleared the `aiStatus`
+  // marker on every one of its values on the way out. Only an object-shaped
+  // patch addresses `ai`; there it stays authoritative (absent or
+  // `enabled: false` both strip the marker).
+  const touchesAi = options !== undefined && !Array.isArray(options)
   const incomingAi = pickAiOptions(options)
   const currentAi = (currentField.options as { ai?: AiOptions } | null | undefined)?.ai
-  const effectiveAi = options !== undefined ? incomingAi : currentAi
+  const effectiveAi = touchesAi ? incomingAi : currentAi
   const aiWasEnabled = currentAi?.enabled === true
   const aiWillBeEnabled = effectiveAi?.enabled === true
 
-  if (options !== undefined) {
-    const selectOpts =
-      pickSelectOptions(options) ??
-      (currentField.options as { options?: SelectOption[] } | null | undefined)?.options
+  const nextSelectOptions =
+    (options !== undefined ? pickSelectOptions(options) : undefined) ??
+    (currentField.options as { options?: SelectOption[] } | null | undefined)?.options
+
+  if (touchesAi) {
     const aiValidation = await validateAiOptions({
       organizationId,
       type: fieldType,
       ai: incomingAi,
-      selectOptions: selectOpts,
+      selectOptions: nextSelectOptions,
       selfFieldId: id,
     })
     if (aiValidation.isErr()) {
       return aiValidation
+    }
+  } else if (options !== undefined && aiWillBeEnabled) {
+    // An options-only patch can still strand the AI config it preserves: an
+    // enum-backed schema over an empty option list is unsatisfiable. Only the
+    // count rule is re-checked here — the prompt was already validated when it
+    // was written, and re-running the AI-sibling scan would let an unrelated
+    // pre-existing conflict block someone from simply typing a tag.
+    const constrained =
+      fieldType === FieldTypeEnum.SINGLE_SELECT ||
+      fieldType === FieldTypeEnum.MULTI_SELECT ||
+      (fieldType === FieldTypeEnum.TAGS && effectiveAi?.allowNewOptions !== true)
+    if (constrained && (!nextSelectOptions || nextSelectOptions.length === 0)) {
+      return err({
+        code: 'VALIDATION_ERROR' as const,
+        message: 'AI-enabled select fields require at least one option',
+      })
     }
   }
 
@@ -292,10 +319,11 @@ export async function updateCustomField(input: UpdateCustomFieldInput) {
       Object.assign(fieldOptions, mergeDisplayOptions(fieldType, options, {}))
     }
 
-    // Handle options.ai: when caller provides options, incomingAi is the
-    // source of truth (undefined or enabled=false both strip the marker).
-    // When caller doesn't touch options at all, preserve whatever was stored.
-    if (options !== undefined) {
+    // Handle options.ai: when the caller sends an object-shaped patch,
+    // incomingAi is the source of truth (undefined or enabled=false both strip
+    // the marker). An options-only array patch and a call that doesn't touch
+    // options at all both preserve whatever was stored — see `touchesAi`.
+    if (touchesAi) {
       if (incomingAi) {
         fieldOptions.ai = incomingAi
       } else {

--- a/packages/services/src/custom-fields/validate-ai-options.ts
+++ b/packages/services/src/custom-fields/validate-ai-options.ts
@@ -26,8 +26,9 @@ export interface ValidateAiOptionsInput {
   /** `options.ai` parsed from the incoming create/update payload. `undefined`
    *  when the caller did not set an AI block — no validation runs. */
   ai: AiOptions | undefined
-  /** SINGLE_SELECT / MULTI_SELECT option set at save time. Empty or missing
-   *  on an AI-enabled select rejects. */
+  /** SINGLE_SELECT / MULTI_SELECT / TAGS option set at save time. Empty or
+   *  missing on an AI-enabled select rejects — except an open TAGS field
+   *  (`ai.allowNewOptions`), which is allowed to start from nothing. */
   selectOptions?: SelectOption[]
   /** Field id being updated, so we don't flag self-references against the
    *  updated field's own AI state. `undefined` on create. */
@@ -40,7 +41,8 @@ export interface ValidateAiOptionsInput {
  * Rules (per toggle-04 plan):
  *   1. `enabled=true` is only allowed on AI-eligible field types.
  *   2. Prompt must contain non-empty text or at least one field reference.
- *   3. SINGLE_SELECT / MULTI_SELECT require a non-empty options list.
+ *   3. SINGLE_SELECT / MULTI_SELECT / constrained TAGS require a non-empty
+ *      options list.
  *   4. Prompt may not reference any other AI-enabled field in the org
  *      (no AI→AI chains — decision T4.2).
  *
@@ -65,10 +67,15 @@ export async function validateAiOptions(
     return err({ code: 'VALIDATION_ERROR', message: 'AI prompt cannot be empty' })
   }
 
-  if (
-    (type === 'SINGLE_SELECT' || type === 'MULTI_SELECT') &&
-    (!selectOptions || selectOptions.length === 0)
-  ) {
+  // An enum-backed schema over an empty option list is unsatisfiable, so the
+  // generation would fail at the provider with an opaque error. Open TAGS is
+  // exempt: it has no enum, and inventing the first tags is the whole point.
+  const needsOptions =
+    type === 'SINGLE_SELECT' ||
+    type === 'MULTI_SELECT' ||
+    (type === 'TAGS' && ai.allowNewOptions !== true)
+
+  if (needsOptions && (!selectOptions || selectOptions.length === 0)) {
     return err({
       code: 'VALIDATION_ERROR',
       message: 'AI-enabled select fields require at least one option',

--- a/packages/types/custom-field/index.ts
+++ b/packages/types/custom-field/index.ts
@@ -157,25 +157,48 @@ export const aiOptionsSchema = z.object({
   enabled: z.boolean(),
   prompt: richReferencePromptSchema,
   triggerOn: aiTriggerOnSchema.default('manual'),
+  /**
+   * TAGS only. When true the model may invent tag labels and the commit path
+   * mints the ones that do not already exist; when absent/false it must pick
+   * from the field's existing options. Default OFF — "pick from my taxonomy"
+   * and "invent tags" are different features, and a curated tag set is exactly
+   * what you do not want an LLM growing behind your back.
+   */
+  allowNewOptions: z.boolean().optional(),
 })
 
 export type AiOptions = z.infer<typeof aiOptionsSchema>
 
 /**
- * Field types that accept an `options.ai` block. Must be kept in sync with
- * the `canAiGenerate` flag on `fieldTypeOptions` in
- * `packages/lib/src/custom-fields/types.ts` — both represent the same
- * whitelist, split only because services cannot import from lib.
+ * Field types that accept an `options.ai` block.
+ *
+ * 🛑 Exactly one other place knows this list: `AI_TYPE_SPECS` in
+ * `packages/lib/src/field-values/ai-autofill/type-specs.ts`, which holds the
+ * per-type schema / prompt / normalize contract. The two are joined by an
+ * exact-set-equality test, so they cannot drift.
+ *
+ * The split exists because `@auxx/services` gates field saves on this set and
+ * cannot import from `@auxx/lib`, while the specs need lib-only machinery
+ * (org currency resolution, tag minting). A plain name set is all services
+ * needs, so a plain name set is all that lives here.
  */
 export const AI_ELIGIBLE_FIELD_TYPES = new Set<string>([
   FieldTypeEnum.TEXT,
+  FieldTypeEnum.RICH_TEXT,
   FieldTypeEnum.NUMBER,
+  FieldTypeEnum.CURRENCY,
   FieldTypeEnum.CHECKBOX,
   FieldTypeEnum.DATE,
+  FieldTypeEnum.DATETIME,
+  FieldTypeEnum.TIME,
   FieldTypeEnum.URL,
   FieldTypeEnum.EMAIL,
+  FieldTypeEnum.PHONE_INTL,
+  FieldTypeEnum.NAME,
+  FieldTypeEnum.ADDRESS_STRUCT,
   FieldTypeEnum.SINGLE_SELECT,
   FieldTypeEnum.MULTI_SELECT,
+  FieldTypeEnum.TAGS,
 ])
 
 /** Whether a field type can carry an `options.ai` block. */


### PR DESCRIPTION
Implements `plans/custom-field/ai-autofill/v2-00-more-field-types.md`. Adds `CURRENCY`, `DATETIME`, `TIME`, `PHONE_INTL`, `RICH_TEXT`, `NAME`, `ADDRESS_STRUCT` and `TAGS` to AI autofill.

## Why the plan wasn't just "add types to a Set"

v1's eight types have contracts JSON Schema can fully express. None of the new ones do. Each needs three things to agree — the machine contract, the natural-language contract, and whatever bridges the LLM's output space to `validateSingleValue`, the same strict validator a human edit hits. The old shape scattered that across two switches, a Set in a third package, and a dead flag in a fourth.

**`AI_TYPE_SPECS`** (`type-specs.ts`) now colocates `schema` / `shapeHint` / optional `normalize` / `nullable`. The table stays in lib because CURRENCY's denomination resolves through the org cache; the name Set stays in `@auxx/types` because `@auxx/services` can't import lib. An **exact-set-equality test** keeps them from drifting — adding a type is a deliberate two-file change.

Deliberately **not** hung off `fieldTypeOptions`: that record is imported directly by client components, so pulling the org cache into it would break the web bundle. The dead `canAiGenerate` flag is deleted — nothing read it, though two comments claimed it was the UI gating path.

`normalize` is a last resort, not the default — the schema and prompt should already emit what the validator accepts. Only three survive, each documented against its `validateSingleValue` arm.

## Nullable results

`wrap()` emitted `strict: true` with no null branch, so the model was structurally unable to decline — while the system prompt told it to answer anyway. Fine for TEXT, a hallucination generator for `PHONE_INTL` and `ADDRESS_STRUCT`. Those types now admit `null` and get "return null, never invent" instead.

## CURRENCY

`{type: 'integer'}`, with the resolved code (field → org → USD) and its exponent named in the prompt, so a JPY field is told its integer *is* the whole-unit amount rather than being shown a ×100 example.

**No scaling normalizer, on purpose.** Given `600` the server can't tell $6.00 from $600 — the undecidable guess that produced the 100×-wrong connector data. The model converts; the integrality check stays a hard failure.

## Open TAGS

`allowNewOptions`, default off. `mintOrMatchTagOptions` is the single writer: match-before-mint on a case/whitespace-folded key, append inside a transaction that takes `SELECT … FOR UPDATE` and re-reads the option list under the lock, then invalidates the `customFields` org cache. A bulk generate is N parallel jobs against one jsonb array, so read-modify-write would lose tags and mint `Enterprise` twice.

**This is the only path here that writes outside `FieldValue`** — the thing to review hardest.

## Three latent bugs surfaced

All pre-existing; the new types were just the first callers to trip them.

- **`setValueWithBuiltIn`'s null-delete branch published no `aiStatus`**, and `use-resource-sync.ts:266` only clears AI state when the entry carries one. A declining generation — or a manual clear of an AI-generated value — left the cell spinning on `generating` until reload.
- **The field form's optimistic update replaced `options` wholesale.** A partial patch made untouched keys vanish the instant the mutation fired, and `onSuccess` promoted that stripped object into `serverFieldMap`, so a refetch didn't heal it — only a reload. Merges now.
- **`updateCustomField` read a bare `SelectOption[]` as "caller omitted `ai`, so clear it".** Typing a new tag on a record destroyed the field's entire AI config and cleared the `aiStatus` marker on every one of its values. Only an object-shaped patch addresses `ai` now.

## Design note

TAGS deliberately does **not** write its option list back from the field form. The form renders no options editor for it, so `selectOptions` is only the snapshot from when the dialog opened — submitting it would clobber every tag added since, including ones minted under the row lock. TAGS sends an `{ai}`-only patch and the server preserves the stored list because the patch never mentions it.

## Verification

- ai-autofill suite: 43 passed (4 files). `packages/services`: 13 passed.
- Biome clean on all 21 files.
- Typecheck: `@auxx/types` and `@auxx/services` clean; zero errors in any changed file in `packages/lib` or `apps/web`.

## Not verified

- **No live LLM call was made.** Schemas are asserted structurally. In particular, `pattern` and `format` under `strict: true` are *assumed* accepted by providers — precedent is the pre-existing `format: 'date'` on DATE. TIME degrades safely if `pattern` is ignored (normalizer returns `null`, clearing rather than throwing).
- **The tag-minting transaction is not integration-tested** — only the `dryRun` matcher is unit-tested. The lost-update guarantee rests on `FOR UPDATE` + re-read-under-lock, reviewed against the `agent-service.ts` pattern but never exercised against a real database.
- **An AI-generated TIME is anchored in the server's timezone**, not the viewer's. There's no per-field `timeZone` persisted and no server-side hook for one, so a non-UTC viewer sees a shifted clock time. Documented in a comment on the normalizer.
- **Open question for review:** the minting path writes the `CustomField` row directly. I looked for the protected-field guard this is said to bypass and could not find one in `services/custom-fields/update-field.ts` or the router, so the argument that no extra guard is needed rests on an unverified premise. There is a real app-field reconciler (`isManifestAppFieldRow`) in play. Worth settling before merge.