### PR TITLE
fix(import): make sku a usable identifier in every org

### DIFF
--- a/packages/lib/src/data-migrations/migrations/097-part-sku-unique.ts
+++ b/packages/lib/src/data-migrations/migrations/097-part-sku-unique.ts
@@ -1,0 +1,151 @@
+// packages/lib/src/data-migrations/migrations/097-part-sku-unique.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { sql } from 'drizzle-orm'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-097')
+
+/**
+ * Enforce uniqueness on a part's SKU for orgs whose seed predates the fix.
+ *
+ * **The drift.** `PART_FIELDS.sku` has always declared
+ * `capabilities.unique: true` and the description "Stock Keeping Unit - must be
+ * unique", and the entity seeder maps that onto `CustomField.isUnique`. The
+ * seeder was corrected on 2026-04-08, but `create-fields.ts` inserts and never
+ * updates, so a re-seed does not catch existing orgs up: every org created
+ * before that date still carries `isUnique = false`. In the dev fleet the split
+ * is exactly 14/14 on the date boundary.
+ *
+ * **Why it mattered.** Until D6, `mergeSystemAndCustomFields` derived the
+ * resource's `isIdentifier` from this column alone, so in the drifted orgs SKU
+ * was not offered as an import match key at all — the wizard's only option was
+ * `Record ID`, which no supplier CSV carries. Re-importing a parts file created
+ * a second copy of every row instead of updating it, which is how `DemoOrg1`
+ * ended up with two `m400l` and two `m400r`.
+ *
+ * D6 already fixed the *identifier* half by promoting `isIdentifier` from the
+ * static registry. This pass fixes the *constraint* half, so a second record
+ * claiming a live SKU is refused at the write path rather than merely
+ * discouraged in the picker.
+ *
+ * **Scoped through EntityDefinition.** Matched on `entityType = 'part'` joined
+ * to the field's def, not on `systemAttribute` alone: the attribute column is
+ * free text and a drifted or hand-created row elsewhere carrying `part_sku`
+ * must not be swept up.
+ *
+ * **Guarded per org, deliberately.** Flipping the flag does not retro-fail
+ * existing duplicates, but it makes the NEXT write to either row throw
+ * `UniqueValueConflictError` — a landmine planted in data the migration never
+ * looked at. The `NOT EXISTS` skips any org whose part SKUs are not already
+ * distinct, and the skipped orgs are logged with their duplicate values so the
+ * cleanup is a known task rather than a support ticket months later. The dev
+ * fleet is clean at time of writing, but "clean in dev" is not evidence about
+ * anywhere else.
+ *
+ * The duplicate probe mirrors the constraint it is protecting:
+ * `checkUniqueValueTyped` compares `valueText` with a bare `eq` (case- and
+ * whitespace-sensitive) and excludes archived instances via its
+ * `EntityInstance` join. Grouping any more loosely here would skip orgs the
+ * constraint would in fact have accepted.
+ *
+ * **Cache clear is required and is ours.** The data-migration runner does not
+ * invalidate org caches, and `customFields` / `resources` are cached per org —
+ * without the flush a warm org keeps serving `unique: false` until the key
+ * expires.
+ *
+ * **Not `vendor_part_vendor_sku`.** A vendor SKU is the supplier's own part
+ * number: unique *within that supplier*, never org-wide. `checkUniqueValueTyped`
+ * takes no entity or relationship scope (see its docblock — the scope was
+ * removed because a mismatched predicate silently emptied the query), so marking
+ * it unique would make supplier A's "A100" block supplier B's "A100". Vendor
+ * part identity is the `(part, supplier)` pair, and `vendorSku` is payload.
+ *
+ * Idempotent: the `WHERE` only matches rows still sitting at `false`, so a
+ * re-run after a partial failure updates nothing. One row per organization, so
+ * unbatched on purpose.
+ */
+export const migration097PartSkuUnique: DataMigrationDef = {
+  id: '097-part-sku-unique',
+  description: 'Enforce unique part SKUs on orgs seeded before the 2026-04-08 seeder fix',
+  async run(db: Database): Promise<void> {
+    // Report first: the same predicate the UPDATE will skip on, so the log names
+    // every org left behind rather than leaving a silent gap in the counts.
+    const skipped = await db.execute<{
+      organizationId: string
+      duplicates: number
+      samples: string[]
+    }>(sql`
+      SELECT
+        cf."organizationId",
+        count(*)::int AS duplicates,
+        (array_agg(dupes."valueText" ORDER BY dupes."valueText"))[1:5] AS samples
+      FROM "CustomField" cf
+      JOIN "EntityDefinition" ed ON ed.id = cf."entityDefinitionId"
+      JOIN LATERAL (
+        SELECT fv."valueText"
+        FROM "FieldValue" fv
+        JOIN "EntityInstance" ei ON ei.id = fv."entityId"
+        WHERE fv."fieldId" = cf.id
+          AND ei."archivedAt" IS NULL
+          AND fv."valueText" IS NOT NULL
+        GROUP BY fv."valueText"
+        HAVING count(*) > 1
+      ) AS dupes ON true
+      WHERE ed."entityType" = 'part'
+        AND cf."systemAttribute" = 'part_sku'
+        AND cf."isUnique" = false
+      GROUP BY cf."organizationId"
+    `)
+
+    for (const row of skipped.rows) {
+      logger.warn('Skipped org with duplicate part SKUs — resolve then re-run this migration', {
+        organizationId: row.organizationId,
+        duplicateSkus: row.duplicates,
+        samples: row.samples,
+      })
+    }
+
+    const result = await db.execute<{ organizationId: string }>(sql`
+      UPDATE "CustomField" cf
+      SET "isUnique" = true, "updatedAt" = now()
+      FROM "EntityDefinition" ed
+      WHERE ed.id = cf."entityDefinitionId"
+        AND ed."entityType" = 'part'
+        AND cf."systemAttribute" = 'part_sku'
+        AND cf."isUnique" = false
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "FieldValue" fv
+          JOIN "EntityInstance" ei ON ei.id = fv."entityId"
+          WHERE fv."fieldId" = cf.id
+            AND ei."archivedAt" IS NULL
+            AND fv."valueText" IS NOT NULL
+          GROUP BY fv."valueText"
+          HAVING count(*) > 1
+        )
+      RETURNING cf."organizationId"
+    `)
+
+    const organizationIds = [...new Set(result.rows.map((r) => r.organizationId))]
+
+    if (organizationIds.length > 0) {
+      // Lazy so the data-migration graph does not pull the cache barrel (and its
+      // Redis client) into every migration run.
+      const { getOrgCache } = await import('../../cache')
+      const cache = getOrgCache()
+      await Promise.all(
+        organizationIds.map((organizationId) =>
+          cache.invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+        )
+      )
+    }
+
+    logger.info('Part SKU uniqueness enforced', {
+      fieldsUpdated: result.rows.length,
+      organizationsAffected: organizationIds.length,
+      organizationsSkipped: skipped.rows.length,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -61,6 +61,7 @@ import { migration093BackfillSocialWebhookRouteKey } from './migrations/093-back
 import { migration094StripeAccountCutover } from './migrations/094-stripe-account-cutover'
 import { migration095DropIfElseCaseLegacyId } from './migrations/095-drop-if-else-case-legacy-id'
 import { migration096CurrencyMinorUnits } from './migrations/096-currency-minor-units'
+import { migration097PartSkuUnique } from './migrations/097-part-sku-unique'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -148,6 +149,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration094StripeAccountCutover,
     migration095DropIfElseCaseLegacyId,
     migration096CurrencyMinorUnits,
+    migration097PartSkuUnique,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/import/__tests__/importable-fields.test.ts
+++ b/packages/lib/src/import/__tests__/importable-fields.test.ts
@@ -1,0 +1,98 @@
+// packages/lib/src/import/__tests__/importable-fields.test.ts
+
+import { toFieldId } from '@auxx/types/field'
+import { describe, expect, it } from 'vitest'
+import type { ResourceField } from '../../resources/registry/field-types'
+import type { Resource } from '../../resources/registry/types'
+import { getImportableFields } from '../fields/get-importable-fields'
+
+/**
+ * A creatable field that is ALSO an identifier (SKU, Ticket #, Email) used to be
+ * emitted twice by `getImportableFields` — once by the identifier pass and once
+ * by the scalar pass — so the picker listed it under two headings. That was
+ * mostly invisible while `isIdentifier` came from `CustomField.isUnique` and
+ * almost nothing carried it; promoting identifiers from the static registry made
+ * it universal, so the passes now dedupe by output key.
+ */
+
+function resourceField(overrides: Partial<ResourceField> = {}): ResourceField {
+  return {
+    id: toFieldId('sku'),
+    key: 'sku',
+    label: 'SKU',
+    type: 'string',
+    isSystem: true,
+    systemAttribute: 'part_sku',
+    isIdentifier: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+      required: true,
+    },
+    ...overrides,
+  } as ResourceField
+}
+
+const resourceWith = (fields: ResourceField[]): Resource => ({ fields }) as unknown as Resource
+
+describe('getImportableFields — identifier / scalar overlap', () => {
+  it('emits a creatable identifier exactly once, as the identifier entry', () => {
+    const fields = getImportableFields(resourceWith([resourceField()]), {
+      includeIdentifiers: true,
+    })
+
+    const sku = fields.filter((f) => f.key === 'part_sku')
+    expect(sku).toHaveLength(1)
+    expect(sku[0]?.isIdentifier).toBe(true)
+    expect(sku[0]?.group).toBe('identifier')
+  })
+
+  it('keeps `required` and `options` on the surviving identifier entry', () => {
+    // The scalar pass used to be the only carrier of these; dropping it must not
+    // quietly turn a required SKU into an optional one, or blank a select's
+    // option list (which `select:value` resolution needs to match against).
+    const fields = getImportableFields(
+      resourceWith([
+        resourceField({
+          options: { options: [{ value: 'a', label: 'A' }] } as ResourceField['options'],
+        }),
+      ]),
+      { includeIdentifiers: true }
+    )
+
+    const sku = fields.find((f) => f.key === 'part_sku')
+    expect(sku?.required).toBe(true)
+    expect(sku?.options).toEqual([{ value: 'a', label: 'A' }])
+  })
+
+  it('still emits a non-identifier creatable field from the scalar pass', () => {
+    const fields = getImportableFields(
+      resourceWith([
+        resourceField(),
+        resourceField({
+          id: toFieldId('title'),
+          key: 'title',
+          label: 'Title',
+          systemAttribute: 'part_title',
+          isIdentifier: false,
+        }),
+      ]),
+      { includeIdentifiers: true }
+    )
+
+    expect(fields.filter((f) => f.key === 'part_title')).toHaveLength(1)
+    expect(fields.find((f) => f.key === 'part_title')?.isIdentifier).toBe(false)
+  })
+
+  it('emits the field once from the scalar pass when identifiers are excluded', () => {
+    const fields = getImportableFields(resourceWith([resourceField()]), {
+      includeIdentifiers: false,
+    })
+
+    expect(fields.filter((f) => f.key === 'part_sku')).toHaveLength(1)
+    expect(fields[0]?.isIdentifier).toBe(false)
+  })
+})

--- a/packages/lib/src/import/fields/get-identifiable-fields.ts
+++ b/packages/lib/src/import/fields/get-identifiable-fields.ts
@@ -40,11 +40,17 @@ export function getIdentifiableFields(resource: Resource): ImportableField[] {
         id: isCustomField ? field.id : undefined,
         label: outputKey === 'id' ? 'Record ID' : field.label,
         type: field.type,
-        required: false,
+        // `required` and `options` ride along because a field can be BOTH an
+        // identifier and an ordinary mapping target (a required SKU, a select).
+        // `getImportableFields` now emits one entry per key and keeps this one,
+        // so anything omitted here is lost rather than picked up by the scalar
+        // pass — as `required: false` and a missing option list used to be.
+        required: field.capabilities.required ?? false,
         isRelation: !!field.relationship,
         isIdentifier: true,
         multi: !field.relationship && field.options?.multi === true,
         group: 'identifier' as const,
+        options: field.options?.options,
       }
     })
 }

--- a/packages/lib/src/import/fields/get-importable-fields.ts
+++ b/packages/lib/src/import/fields/get-importable-fields.ts
@@ -65,11 +65,20 @@ export function getImportableFields(
     fields.push(...identifierFields)
   }
 
-  // 2. Add creatable scalar fields (excluding hidden system fields)
+  // 2. Add creatable scalar fields (excluding hidden system fields).
+  //
+  // Keys already emitted by the identifier pass are skipped: an identifier is
+  // usually creatable too (SKU, Ticket #, Email), so without this the same key
+  // is pushed twice — once as `group: 'identifier'` and once as
+  // `'system'`/`'custom'` — and the picker lists it under both headings. The
+  // identifier entry wins because it carries `isIdentifier`, which is what the
+  // picker groups on and what the identifier selector reads.
+  const emittedKeys = new Set(fields.map((f) => f.key))
   const scalarFields = resource.fields
     .filter(
       (field) => field.capabilities.creatable && !field.capabilities.hidden && !field.relationship
     )
+    .filter((field) => !emittedKeys.has(getFieldOutputKey(field)))
     .map((field) => {
       const isCustomField = !field.isSystem
       return {

--- a/packages/lib/src/resources/registry/identifier-fields.test.ts
+++ b/packages/lib/src/resources/registry/identifier-fields.test.ts
@@ -1,0 +1,55 @@
+// packages/lib/src/resources/registry/identifier-fields.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { RESOURCE_FIELD_REGISTRY } from './field-registry'
+import type { ResourceField } from './field-types'
+
+/**
+ * Registry invariants behind `mergeSystemAndCustomFields`' `isIdentifier` rung.
+ *
+ * That merge coalesces `staticField.isIdentifier ?? dbField.isIdentifier`, where
+ * the DB side is `CustomField.isUnique`. The coalesce is only sufficient because
+ * of the two rules pinned here — a registry field that declares uniqueness but
+ * forgets `isIdentifier`, or declares `isIdentifier` while unfilterable, is
+ * dropped somewhere downstream with no error.
+ *
+ * Both rules are cheap to satisfy and were violated by nobody at the time of
+ * writing; the point is that the NEXT field added cannot break them silently.
+ */
+
+const allFields = (): Array<{ resource: string; key: string; field: ResourceField }> =>
+  Object.entries(RESOURCE_FIELD_REGISTRY).flatMap(([resource, fields]) =>
+    Object.entries(fields ?? {}).map(([key, field]) => ({
+      resource,
+      key,
+      field: field as ResourceField,
+    }))
+  )
+
+describe('registry identifier declarations', () => {
+  it('every unique field is also declared an identifier', () => {
+    // A field the product enforces as unique is by definition a usable import
+    // match key. If the registry declares `unique` without `isIdentifier`, the
+    // merge's coalesce still promotes it via `CustomField.isUnique` — but ONLY in
+    // orgs whose seeded row actually carries the flag. `part_sku` drifted exactly
+    // that way (orgs before 2026-04-08 seeded `isUnique: false`), which left the
+    // import wizard with no usable identifier and duplicated every re-imported row.
+    // Declaring both makes the registry, not the seed date, the source of truth.
+    const offenders = allFields()
+      .filter(({ field }) => field.capabilities.unique === true && field.isIdentifier !== true)
+      .map(({ resource, key }) => `${resource}.${key}`)
+
+    expect(offenders).toEqual([])
+  })
+
+  it('every identifier field is filterable', () => {
+    // `getIdentifiableFields` rejects non-filterable fields before it ever looks
+    // at `isIdentifier`, so an unfilterable identifier is silently absent from
+    // the import picker rather than rejected loudly.
+    const offenders = allFields()
+      .filter(({ field }) => field.isIdentifier === true && !field.capabilities.filterable)
+      .map(({ resource, key }) => `${resource}.${key}`)
+
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/lib/src/resources/registry/resource-registry-service.ts
+++ b/packages/lib/src/resources/registry/resource-registry-service.ts
@@ -923,6 +923,28 @@ export class ResourceRegistryService {
             ...dbField.capabilities,
             hidden: staticField.capabilities.hidden,
           },
+          // Whether a field can MATCH an existing record on import is a product
+          // fact, not a per-org one — so the static registry may promote it.
+          //
+          // `mapCustomFieldsToResourceFields` derives `isIdentifier` from
+          // `CustomField.isUnique` alone, which fuses two different things: an
+          // enforced-unique WRITE CONSTRAINT and an import LOOKUP KEY. A field can
+          // be a fine match key without the constraint being switched on, and the
+          // seeder drifted — orgs created before 2026-04-08 carry
+          // `part_sku.isUnique = false` while their SKUs are de-facto unique. In
+          // those orgs the import wizard offered no usable identifier at all, so
+          // re-importing a parts file duplicated every row instead of updating it.
+          //
+          // Coalesced, never overridden: the registry can PROMOTE a field to an
+          // identifier, but a DB row that is genuinely unique keeps its identifier
+          // status even when the registry is silent. Uniqueness still implies a
+          // valid match key; this only stops the absence of it from denying one.
+          //
+          // Deliberately NOT applied to `isUnique`/`capabilities.unique`:
+          // enforcement reads the raw CustomField rows (`validateUniqueFields` →
+          // `getCachedCustomFields`), so promoting here cannot make an existing
+          // write start throwing on data that already has duplicates.
+          isIdentifier: staticField.isIdentifier ?? dbField.isIdentifier,
           // Merge relationship config — DB object exists but inverseResourceFieldId may be null
           // when the seeder linker couldn't resolve it. Fall back to static definition.
           relationship: baseRelationship


### PR DESCRIPTION
## The bug

The import wizard offered no usable match key for parts in **half the orgs**, so re-importing a parts file created a second copy of every row instead of updating it. Reproduced live: two test imports into a dev org, each planning every row as `create`, the second re-creating `m400l` and `m400r`.

Two independent causes — one on the read path, one in the data.

## Read path — `isIdentifier` never reached a running org

`mergeSystemAndCustomFields` copies a **closed allow-list** of static properties onto the DB `CustomField` row (`key`, `dbColumn`, `placeholder`, `nullable`, `capabilities.hidden`, …). `isIdentifier` was not in it, so `mapCustomFieldsToResourceFields` derived it from `CustomField.isUnique` alone:

```ts
// Import identifier
isIdentifier: field.isUnique,
```

`PART_FIELDS.sku` has declared `isIdentifier: true` — alongside `capabilities.unique` and a *"Stock Keeping Unit - must be unique"* description — since the initial commit. None of it could reach a running org.

The merge now carries it, **coalesced rather than overridden**: the registry may *promote* a field to an identifier, and a DB row that is genuinely unique keeps its status when the registry is silent.

`isUnique` is deliberately **not** promoted. Enforcement reads the raw `CustomField` rows (`validateUniqueFields` → `getCachedCustomFields`), so this change cannot make an existing write start throwing on data that already carries duplicates.

## Data — the seeder drifted and was never backfilled

The seeder maps `capabilities.unique` → `CustomField.isUnique` correctly (`entity-seeder/utils.ts:69`), but `create-fields.ts` inserts and never updates, so its 2026-04-08 correction never reached earlier orgs. The dev fleet splits **14/14 on that date boundary**.

Migration `097-part-sku-unique` flips the column:

- **Scoped through `EntityDefinition.entityType = 'part'`**, not `systemAttribute` alone — that column is free text and a drifted row elsewhere must not be swept up.
- **Guarded per org.** Flipping the flag does not retro-fail existing duplicates, but it makes the *next* write to either row throw `UniqueValueConflictError`. Any org whose SKUs are not already distinct is skipped and logged with sample values. The dev fleet is clean, but that is not evidence about anywhere else.
- The duplicate probe **mirrors the constraint exactly** — bare `valueText` equality (case- and whitespace-sensitive), archived instances excluded — matching `checkUniqueValueTyped`, so it cannot skip an org the constraint would have accepted.
- Clears `customFields` / `resources` org cache for the orgs it touched (the data-migration runner does not).

Modelled on `078-ticket-type-updatable`, which is the same shape.

### Not applied to `vendor_part_vendor_sku`

A vendor SKU is the supplier's own part number — unique *within* that supplier, never org-wide. `checkUniqueValueTyped` carries no entity or relationship scope, so marking it unique would make supplier A's `A100` block supplier B's `A100`. Vendor part identity is the `(part, supplier)` pair.

## A latent duplicate this made universal

`getImportableFields` pushed identifier fields *and* creatable scalars without deduping, so a creatable identifier came out twice — once as `group: 'identifier'`, once as `'system'`/`'custom'` — and the picker listed it under both headings. Only visible where `isUnique` happened to be true; promoting identifiers everywhere would have made it universal.

The scalar pass now skips keys the identifier pass already emitted. That meant moving `required` and `options` onto the identifier entry, since it is now the surviving one — otherwise a required SKU silently becomes optional and a select loses the option list `select:value` matches against.

## Tests

- `identifier-fields.test.ts` — registry drift guard: every field declaring `capabilities.unique` also declares `isIdentifier`, and every identifier is `filterable` (`getIdentifiableFields` rejects non-filterable fields *before* checking `isIdentifier`, so an unfilterable one vanishes silently). Both hold today; the point is the next field added cannot break them.
- `importable-fields.test.ts` — the dedupe, including that `required` / `options` survive.

`packages/lib`: 95 tests pass across `src/import` + `src/resources/registry`, 280 across `src/data-migrations`. `tsc --noEmit` clean on every touched file.

## Scope

Effect: `part_sku` is an identifier in all 28 orgs rather than the 14 seeded after 2026-04-08 — as are Ticket #, contact Email, and the quote/invoice number fields, all previously gated on a per-org boolean.

**This does not yet enable update-on-import.** The identifier is now *selectable*; it is still *selected* nowhere, because `ImportMapping.identifierFieldKey` has no writer anywhere in the codebase. Imports remain create-only. That, plus an ordering bug in `generate-plan.ts` that silently drops matched rows, is separate follow-up work.

## Migration

`097-part-sku-unique` has **not been run** against any database.