### PR TITLE
fix(dynamic-table): copy select cells as labels so cross-column paste matches

### DIFF
--- a/apps/web/src/components/dynamic-table/utils/cell-coercion.test.ts
+++ b/apps/web/src/components/dynamic-table/utils/cell-coercion.test.ts
@@ -1,0 +1,100 @@
+// apps/web/src/components/dynamic-table/utils/cell-coercion.test.ts
+
+import type { ResourceField } from '@auxx/lib/resources/client'
+import { toFieldId } from '@auxx/types/field'
+import { describe, expect, it } from 'vitest'
+import { coerceForPaste, optionLabel } from './cell-coercion'
+
+/**
+ * Two tag columns offering the SAME labels hold DIFFERENT option ids — ids are
+ * minted per field. This is the shape that produced "no matching option".
+ */
+const FAVORITE_COLOR_OPTIONS = [
+  { label: 'Blue', value: 'oum39u7ui3FXI0KSe9MDr' },
+  { label: 'Red', value: 'xcqDrNAB3NsGiGJmbqfPp' },
+]
+const TAGS_OPTIONS = [
+  { label: 'Red', value: 'z6XudI5z5agprmZ0Qdswb' },
+  { label: 'Blue', value: 'qZ70qtJNVuOOVUhZjjKXs' },
+]
+
+function selectField(
+  fieldType: 'TAGS' | 'MULTI_SELECT' | 'SINGLE_SELECT',
+  options: Array<{ id?: string; value: string; label: string }>
+): ResourceField {
+  return {
+    id: toFieldId('field1'),
+    key: 'field1',
+    label: 'Field 1',
+    type: 'string',
+    fieldType,
+    options: { options },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: true,
+    },
+  } as ResourceField
+}
+
+describe('optionLabel', () => {
+  it('resolves a stored option id to its label', () => {
+    expect(optionLabel('z6XudI5z5agprmZ0Qdswb', TAGS_OPTIONS)).toBe('Red')
+  })
+
+  it('matches on a stable id when the option carries one', () => {
+    expect(optionLabel('opt_1', [{ id: 'opt_1', value: 'RED', label: 'Red' }])).toBe('Red')
+  })
+
+  it('falls back to the id for free-form tag fields with no option set', () => {
+    expect(optionLabel('ad-hoc', undefined)).toBe('ad-hoc')
+    expect(optionLabel('unknown-id', TAGS_OPTIONS)).toBe('unknown-id')
+  })
+})
+
+describe('coerceForPaste — select across columns', () => {
+  it('lands tags in another tag column with the same labels but different ids', () => {
+    const result = coerceForPaste(
+      {
+        display: 'Red, Blue',
+        raw: ['z6XudI5z5agprmZ0Qdswb', 'qZ70qtJNVuOOVUhZjjKXs'],
+        fieldType: 'TAGS',
+      },
+      selectField('TAGS', FAVORITE_COLOR_OPTIONS),
+      { columnId: 'field1' }
+    )
+    expect(result).toEqual({
+      ok: true,
+      value: ['xcqDrNAB3NsGiGJmbqfPp', 'oum39u7ui3FXI0KSe9MDr'],
+    })
+  })
+
+  it('keeps the raw ids when pasting back into the source column', () => {
+    const result = coerceForPaste(
+      { display: 'Red', raw: ['z6XudI5z5agprmZ0Qdswb'], fieldType: 'TAGS' },
+      selectField('TAGS', TAGS_OPTIONS),
+      { columnId: 'field1' }
+    )
+    expect(result).toEqual({ ok: true, value: ['z6XudI5z5agprmZ0Qdswb'] })
+  })
+
+  it('resolves a single-select label into the target column id space', () => {
+    const result = coerceForPaste(
+      { display: 'Blue', raw: 'qZ70qtJNVuOOVUhZjjKXs', fieldType: 'SINGLE_SELECT' },
+      selectField('SINGLE_SELECT', FAVORITE_COLOR_OPTIONS),
+      { columnId: 'field1' }
+    )
+    expect(result).toEqual({ ok: true, value: 'oum39u7ui3FXI0KSe9MDr' })
+  })
+
+  it('still skips a label the target column does not offer', () => {
+    const result = coerceForPaste(
+      { display: 'Green', raw: ['whatever'], fieldType: 'TAGS' },
+      selectField('TAGS', FAVORITE_COLOR_OPTIONS),
+      { columnId: 'field1' }
+    )
+    expect(result).toEqual({ ok: false, reason: 'no-matching-option' })
+  })
+})

--- a/apps/web/src/components/dynamic-table/utils/cell-coercion.ts
+++ b/apps/web/src/components/dynamic-table/utils/cell-coercion.ts
@@ -341,3 +341,20 @@ function findOptionId(
   if (!match) return null
   return match.id ?? match.value
 }
+
+/**
+ * Resolve a stored option id to its human label using the field's own option set.
+ *
+ * Stored select values carry only `optionId`, and ids are minted PER FIELD — two
+ * tag columns both offering "Red" hold different ids. Copy must therefore emit the
+ * label, or a paste into the other column has nothing to match on. Falls back to
+ * the id itself for free-form tag fields, which have no option set.
+ */
+export function optionLabel(
+  optionId: string,
+  options: Array<{ id?: string; value: string; label: string }> | undefined
+): string {
+  if (!options || options.length === 0) return optionId
+  const option = options.find((o) => o.id === optionId || o.value === optionId)
+  return option?.label ?? optionId
+}

--- a/apps/web/src/components/kb/ui/articles/articles-view.tsx
+++ b/apps/web/src/components/kb/ui/articles/articles-view.tsx
@@ -27,6 +27,7 @@ import {
   type DynamicResourceViewHandle,
 } from '~/components/dynamic-table/dynamic-resource-view'
 import type { ExtendedColumnDef } from '~/components/dynamic-table/types'
+import { optionLabel } from '~/components/dynamic-table/utils/cell-coercion'
 import { resolveColumnField } from '~/components/dynamic-table/utils/column-id'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
 import { EmptyState } from '~/components/global/empty-state'
@@ -323,6 +324,25 @@ export function ArticlesView() {
             fieldType: field.fieldType,
             recordId,
             primaryDisplay: display,
+          }
+        }
+
+        // Select-ish: option ids are minted per field and no label is
+        // denormalized onto the stored value, so copy must emit the LABEL —
+        // see the same branch in records-view.
+        if (
+          field.fieldType === 'SINGLE_SELECT' ||
+          field.fieldType === 'MULTI_SELECT' ||
+          field.fieldType === 'TAGS'
+        ) {
+          const opts = field.options?.options
+          const optionIds = (Array.isArray(raw) ? raw : [raw])
+            .map((v) => converter.toRawValue(v) as string | null)
+            .filter((v): v is string => Boolean(v))
+          return {
+            display: optionIds.map((id) => optionLabel(id, opts)).join(', '),
+            raw: field.fieldType === 'SINGLE_SELECT' ? (optionIds[0] ?? null) : optionIds,
+            fieldType: field.fieldType,
           }
         }
 

--- a/apps/web/src/components/records/records-view.tsx
+++ b/apps/web/src/components/records/records-view.tsx
@@ -38,6 +38,7 @@ import {
   type DynamicResourceViewHandle,
 } from '~/components/dynamic-table/dynamic-resource-view'
 import { useTableViewRealtime } from '~/components/dynamic-table/hooks/use-table-view-realtime'
+import { optionLabel } from '~/components/dynamic-table/utils/cell-coercion'
 import { resolveColumnField } from '~/components/dynamic-table/utils/column-id'
 import { FavoriteToggleMenuItem } from '~/components/favorites/ui/favorite-toggle-menu-item'
 import { EmptyState } from '~/components/global/empty-state'
@@ -604,6 +605,25 @@ export function RecordsView({ slug, basePath, pageActions }: RecordsViewProps) {
             raw: actorId,
             fieldType,
             primaryDisplay: display,
+          }
+        }
+
+        // Select-ish: the stored typed value carries only `optionId`, and ids are
+        // minted PER FIELD — two tag columns both offering "Red" hold different
+        // ids, and no label is denormalized onto the value. Copy therefore emits
+        // the LABEL, which is the only thing a paste into another select column
+        // (or into Excel) can match on.
+        if (fieldType === 'SINGLE_SELECT' || fieldType === 'MULTI_SELECT' || fieldType === 'TAGS') {
+          const opts = field.options?.options
+          const optionIds = (Array.isArray(raw) ? raw : [raw])
+            .map((v) => converter.toRawValue(v) as string | null)
+            .filter((v): v is string => Boolean(v))
+          return {
+            display: optionIds.map((id) => optionLabel(id, opts)).join(', '),
+            // Scalar raw for SINGLE_SELECT, array for the multi types — that's
+            // the shape `coerceForPaste`'s lossless same-field path expects.
+            raw: fieldType === 'SINGLE_SELECT' ? (optionIds[0] ?? null) : optionIds,
+            fieldType,
           }
         }
 


### PR DESCRIPTION
## Problem

Copying a tag cell into a **different** tag column that offers the same labels skipped every cell with `Most common reason: no matching option`.

## Root cause

Stored select values carry only `optionId` — the read path (`field-value-helpers.ts:382`) builds `{ type: 'option', optionId }` and never fills the optional denormalized `label`. The grid *looked* fine because cell rendering resolves labels from `field.options.options` at render time, but `formatCellForCopy` went through `converter.toDisplayValue`, which falls back to the bare option id.

Option ids are minted **per field**. Two tag fields on the same def:

| Field | Red | Blue |
|---|---|---|
| `Favorite color1` | `xcqDrNAB3NsGiGJmbqfPp` | `oum39u7ui3FXI0KSe9MDr` |
| `Tags` | `z6XudI5z5agprmZ0Qdswb` | `qZ70qtJNVuOOVUhZjjKXs` |

So copy emitted `z6XudI5z5agprmZ0Qdswb` as `display`. `coerceForPaste` correctly refuses the lossless raw-id path across columns, then ran its label lookup against that same id string — no match.

## Fix

Both copy formatters (`records-view.tsx`, `articles-view.tsx`) now resolve option ids to **labels** before emitting, via a shared `optionLabel()` helper placed next to its inverse `findOptionId()` in `cell-coercion.ts` so the two stay in agreement on the `id ?? value` keyspace.

- `raw` stays scalar for `SINGLE_SELECT` and an array for `MULTI_SELECT`/`TAGS`, so the same-column lossless path (paste into the same field on another row) still short-circuits on ids.
- Fill-drag shares the formatter, so it's fixed there too.
- Side benefit: copying a tag cell into a spreadsheet now yields `Red, Blue` instead of nanoids.

## Not in scope

A TAGS field with an empty option set, or one declaring `allowNewOptions`, still can't mint a new option on paste — that needs a field-options mutation on the write path, like `tag-minting.ts` does for AI autofill.

## Testing

New `cell-coercion.test.ts` — 7 tests using the exact two-field fixture above, covering cross-column resolution, same-column id preservation, single-select, id-keyed options, free-form fallback, and that a genuinely absent label still skips. All passing; Biome clean.