### PR TITLE
fix(files): render an uploaded image preview instead of blanking the avatar

### DIFF
--- a/apps/web/src/components/icons/__tests__/visual-icon.test.ts
+++ b/apps/web/src/components/icons/__tests__/visual-icon.test.ts
@@ -1,0 +1,37 @@
+// apps/web/src/components/icons/__tests__/visual-icon.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { parseVisualRef } from '../ui/visual-icon'
+
+describe('parseVisualRef', () => {
+  it('parses the explicit prefixes', () => {
+    expect(parseVisualRef('brand:shopify')).toEqual({ type: 'brand', slug: 'shopify' })
+    expect(parseVisualRef('url:https://a.test/x.png')).toEqual({
+      type: 'url',
+      value: 'https://a.test/x.png',
+    })
+    expect(parseVisualRef('color:blue')).toEqual({ type: 'color', color: 'blue' })
+    expect(parseVisualRef('icon:user:red')).toEqual({ type: 'icon', iconId: 'user', color: 'red' })
+  })
+
+  it('treats every <img src>-renderable string as a url ref', () => {
+    // Anything landing on `lucide` here resolves to an unknown icon id, and
+    // EntityIcon renders `null` for those — the avatar frame disappears.
+    for (const value of [
+      'https://cdn.auxx.ai/a.png',
+      'http://cdn.auxx.ai/a.png',
+      'blob:https://app.auxx.ai/0f0b-4c1a', // optimistic preview during upload
+      'data:image/png;base64,iVBORw0KGgo=',
+      '/api/files/download/asset:q4p0y2kdx6rpng9ztwbhblcr', // just-saved FILE field
+    ]) {
+      expect(parseVisualRef(value)).toEqual({ type: 'url', value })
+    }
+  })
+
+  it('still falls back to emoji and bare lucide ids', () => {
+    expect(parseVisualRef('🎉')).toEqual({ type: 'emoji', value: '🎉' })
+    expect(parseVisualRef('user')).toEqual({ type: 'lucide', value: 'user' })
+    expect(parseVisualRef(null)).toBeNull()
+    expect(parseVisualRef('')).toBeNull()
+  })
+})

--- a/apps/web/src/components/icons/ui/visual-icon.tsx
+++ b/apps/web/src/components/icons/ui/visual-icon.tsx
@@ -38,7 +38,22 @@ export function parseVisualRef(s: string | null | undefined): VisualRef | null {
     const [iconId, color] = s.slice(5).split(':')
     return { type: 'icon', iconId: iconId ?? '', color: color || undefined }
   }
-  if (s.startsWith('http://') || s.startsWith('https://')) return { type: 'url', value: s }
+  // Anything an <img src> can render directly is a url ref. `blob:` covers the
+  // optimistic preview an in-flight avatar upload writes to the record store,
+  // `data:` the inline form of base64, and a leading `/` the same-origin
+  // `/api/files/download/<ref>` URL a just-saved FILE field resolves to. Missing
+  // any of these fell through to the `lucide` branch below, where an unknown
+  // icon id makes EntityIcon render `null` — the whole avatar frame disappeared
+  // mid-upload instead of showing the picked image.
+  if (
+    s.startsWith('http://') ||
+    s.startsWith('https://') ||
+    s.startsWith('blob:') ||
+    s.startsWith('data:') ||
+    s.startsWith('/')
+  ) {
+    return { type: 'url', value: s }
+  }
   if (EMOJI_RE.test(s)) return { type: 'emoji', value: s }
   return { type: 'lucide', value: s }
 }

--- a/apps/web/src/trpc/vanilla.ts
+++ b/apps/web/src/trpc/vanilla.ts
@@ -1,10 +1,25 @@
 // apps/web/src/trpc/vanilla.ts
 
-import { WEBAPP_URL } from '@auxx/config/client'
 import { createTRPCClient, httpBatchLink } from '@trpc/client'
 import SuperJSON from 'superjson'
 import { getRealtimeSocketId } from '~/realtime/hooks'
 import type { AppRouter } from '~/server/api/root'
+
+/**
+ * Resolve the tRPC base URL.
+ *
+ * Must NOT use `WEBAPP_URL` from `@auxx/config`: that constant is resolved from
+ * `process.env.APP_URL` / `process.env.DOMAIN` through a *dynamic* `process.env[key]`
+ * read, which the Next bundler cannot inline (only `NEXT_PUBLIC_*` reaches the
+ * browser). In a browser bundle both reads return undefined and `WEBAPP_URL`
+ * silently collapses to its `http://localhost:3000` dev fallback — harmless
+ * locally, a hard "Failed to fetch" in production. Same origin as the page is
+ * both correct and what the React client (`~/trpc/react`) already uses.
+ */
+function getBaseUrl(): string {
+  if (typeof window !== 'undefined') return window.location.origin
+  return `http://localhost:${process.env.PORT ?? 3000}`
+}
 
 /**
  * Vanilla (non-React) tRPC client for use outside React lifecycle.
@@ -18,7 +33,7 @@ export const vanillaApi = createTRPCClient<AppRouter>({
   links: [
     httpBatchLink({
       transformer: SuperJSON,
-      url: `${WEBAPP_URL}/api/trpc`,
+      url: `${getBaseUrl()}/api/trpc`,
       headers: () => {
         const headers: Record<string, string> = {
           'x-trpc-source': 'nextjs-vanilla',


### PR DESCRIPTION
## What

Two bugs on the image/file upload path, both of which only show up once you actually pick a file.

### 1. `parseVisualRef` blanked the avatar mid-upload

`apps/web/src/components/icons/ui/visual-icon.tsx` only recognised `http://`/`https://` as a URL ref. Everything else fell through to the `lucide` branch — and an unknown lucide id makes `EntityIcon` render `null`, so the whole avatar frame disappeared instead of showing the picked image.

Three ref shapes hit that hole:

| Ref | Where it comes from |
| --- | --- |
| `blob:…` | the optimistic preview an in-flight upload writes to the record store |
| `data:…` | inline base64 |
| `/api/files/download/<ref>` | the same-origin URL a just-saved FILE field resolves to |

All three are things `<img src>` renders directly, so they're now parsed as `url` refs.

### 2. The vanilla tRPC client couldn't reach the server in production

`apps/web/src/trpc/vanilla.ts` — the client `use-field-file-upload` posts through, its only consumer — built its URL from `WEBAPP_URL`. That constant resolves through a **dynamic** `process.env[key]` read, which the Next bundler cannot inline (only `NEXT_PUBLIC_*` reaches the browser). In a browser bundle both reads return `undefined` and `WEBAPP_URL` silently collapses to its `http://localhost:3000` dev fallback: harmless locally, a hard `Failed to fetch` on every upload in production.

Now uses the page origin, the same thing the React client (`~/trpc/react`) already does.

## Test

New `apps/web/src/components/icons/__tests__/visual-icon.test.ts` pins the parse table — explicit prefixes, every `<img src>`-renderable string, and the emoji/lucide fallbacks. Passing locally.

The rest of the working tree (the BYO-OAuth-client gate) is deliberately not in this PR.