### PR TITLE
feat(connections): gate bring-your-own OAuth client on a feature key

### DIFF
--- a/apps/web/src/app/api/apps/[slug]/oauth2/authorize/route.ts
+++ b/apps/web/src/app/api/apps/[slug]/oauth2/authorize/route.ts
@@ -5,15 +5,18 @@ import type { OAuth2Features } from '@auxx/database'
 import { database as db } from '@auxx/database'
 import { resolveAppConnectionForRuntime } from '@auxx/lib/apps'
 import { resolveAppSlug } from '@auxx/lib/cache'
-import { resolveOAuth2Client, resolveOwnClientRequirement } from '@auxx/lib/connections'
+import {
+  appOAuthCallbackUrl,
+  resolveOAuth2Client,
+  resolveOwnClientGateForOrg,
+  stripUnentitledOwnClientVars,
+} from '@auxx/lib/connections'
 import { AuxxError } from '@auxx/lib/errors'
 import { PermissionKey, requirePermission } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
 import { interpolateConnectionFields } from '@auxx/services/app-connections'
 import crypto from 'crypto'
-
-const OAUTH_REDIRECT_BASE = process.env.NGROK_URL || WEBAPP_URL
 
 import { headers } from 'next/headers'
 import { type NextRequest, NextResponse } from 'next/server'
@@ -187,8 +190,14 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       }
     }
 
+    // Own-client gate (§3.1), org-aware: only a genuinely absent platform client forces BYO
+    // id/secret. A platform client pending verification is optional-BYO — the platform
+    // kickoff proceeds and the provider (e.g. Google) applies its own unverified-app
+    // gating. A verified platform client offers BYO only to orgs holding `byoOAuthClient`.
+    const ownClient = await resolveOwnClientGateForOrg(organizationId, connDef)
+
     // Extract connection variables from query params (allowlisted by definitions)
-    const connectionVariables: Record<string, string> = {}
+    const rawVariables: Record<string, string> = {}
     const connectionVarDefs = connDef.connectionVariables ?? []
     for (const varDef of connectionVarDefs) {
       const value = searchParams.get(`var_${varDef.key}`) ?? storedVariables[varDef.key]
@@ -198,13 +207,19 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
           { status: 400 }
         )
       }
-      if (value) connectionVariables[varDef.key] = value
+      if (value) rawVariables[varDef.key] = value
     }
 
-    // Own-client gate (§3.1): only a genuinely absent platform client forces BYO id/secret.
-    // A platform client pending verification is optional-BYO — the platform kickoff proceeds
-    // and the provider (e.g. Google) applies its own unverified-app gating.
-    const ownClient = resolveOwnClientRequirement(connDef)
+    // The connect dialog hides the BYO fields when the gate offers no BYO path, but this
+    // route takes them off the query string — drop caller-supplied client credentials so an
+    // org cannot opt itself into another OAuth client by appending `var_clientId`. Already
+    // stored values survive, so revoking the feature never repoints a live connection.
+    const connectionVariables = stripUnentitledOwnClientVars(
+      rawVariables,
+      ownClient,
+      storedVariables
+    )
+
     if (
       ownClient.requiresOwnClient &&
       !(connectionVariables.clientId && connectionVariables.clientSecret)
@@ -246,16 +261,14 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       })
     )
 
-    // Resolve callback base URL (per-connection override or global default)
-    const callbackBase = features.callbackBaseUrl || OAUTH_REDIRECT_BASE
-
     const scopes = connDef.oauth2Scopes || []
     const googleParams = getGoogleOfflineParams(resolved.authorizeUrl)
 
     // Build OAuth authorization URL
     const authUrl = new URL(resolved.authorizeUrl)
     authUrl.searchParams.set('client_id', resolvedClientId)
-    authUrl.searchParams.set('redirect_uri', `${callbackBase}/api/apps/${slug}/oauth2/callback`)
+    // Same builder the connect dialog shows to a BYO user — they register exactly one URI.
+    authUrl.searchParams.set('redirect_uri', appOAuthCallbackUrl(slug, features.callbackBaseUrl))
     const scopeSeparator = features.scopeSeparator || ' '
     authUrl.searchParams.set('scope', scopes.join(scopeSeparator))
     authUrl.searchParams.set('state', state)

--- a/apps/web/src/app/api/apps/[slug]/oauth2/callback/route.ts
+++ b/apps/web/src/app/api/apps/[slug]/oauth2/callback/route.ts
@@ -4,12 +4,10 @@ import { WEBAPP_URL } from '@auxx/config/urls'
 import { database as db } from '@auxx/database'
 import { saveAppConnection } from '@auxx/lib/apps'
 import { resolveAppSlug } from '@auxx/lib/cache'
-import { resolveOAuth2Client } from '@auxx/lib/connections'
+import { appOAuthCallbackUrl, resolveOAuth2Client } from '@auxx/lib/connections'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
 import { interpolateConnectionFields } from '@auxx/services/app-connections'
-
-const OAUTH_REDIRECT_BASE = process.env.NGROK_URL || WEBAPP_URL
 
 import { type NextRequest, NextResponse } from 'next/server'
 
@@ -206,9 +204,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       throw new Error('Connection definition not found')
     }
 
-    // Resolve callback base URL (must match what was sent in the authorize request)
     const features = (connDef.oauth2Features as Record<string, any>) ?? {}
-    const callbackBase = features.callbackBaseUrl || OAUTH_REDIRECT_BASE
 
     // Interpolate connection fields with stored variables
     const connectionVariables: Record<string, string> = metadata.connectionVariables ?? {}
@@ -225,7 +221,8 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       code,
       client_id: oauthClientId,
       client_secret: oauthClientSecret,
-      redirect_uri: `${callbackBase}/api/apps/${slug}/oauth2/callback`,
+      // Must byte-match the authorize redirect_uri — same builder, same inputs.
+      redirect_uri: appOAuthCallbackUrl(slug, features.callbackBaseUrl),
       grant_type: 'authorization_code',
     }
 

--- a/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/authorize/route.ts
+++ b/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/authorize/route.ts
@@ -5,9 +5,11 @@ import type { OAuth2Features } from '@auxx/database'
 import { database as db } from '@auxx/database'
 import { supportsPersonalChannelConnection } from '@auxx/lib/channels'
 import {
+  providerOAuthCallbackUrl,
   resolveConnectionForRuntime,
   resolveOAuth2Client,
-  resolveOwnClientRequirement,
+  resolveOwnClientGateForOrg,
+  stripUnentitledOwnClientVars,
 } from '@auxx/lib/connections'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
@@ -16,8 +18,6 @@ import crypto from 'crypto'
 import { headers } from 'next/headers'
 import { type NextRequest, NextResponse } from 'next/server'
 import { auth } from '~/auth/server'
-
-const OAUTH_REDIRECT_BASE = process.env.NGROK_URL || WEBAPP_URL
 
 const logger = createScopedLogger('connection-oauth-authorize')
 
@@ -139,8 +139,17 @@ export async function GET(
       }
     }
 
+    // Approval gate (§3.1), org-aware: only a genuinely absent platform client
+    // (`requiresOwnClient`, reason `no-platform-client`) forces BYO id/secret — enforce
+    // that server-side, never trusting the dialog. A platform client pending verification
+    // yields `requiresOwnClient: false` (BYO is optional), so the platform kickoff
+    // proceeds here and Google shows its own unverified-app gating; BYO vars, when
+    // supplied, still win in `resolveOAuth2Client`. A verified platform client offers BYO
+    // only to orgs holding `byoOAuthClient`.
+    const ownClient = await resolveOwnClientGateForOrg(organizationId, connDef)
+
     // Extract connection variables from query params (allowlisted by the definition)
-    const connectionVariables: Record<string, string> = {}
+    const rawVariables: Record<string, string> = {}
     for (const varDef of connDef.connectionVariables ?? []) {
       const value = searchParams.get(`var_${varDef.key}`) ?? storedVariables[varDef.key]
       if (!value && varDef.required !== false) {
@@ -149,16 +158,18 @@ export async function GET(
           { status: 400 }
         )
       }
-      if (value) connectionVariables[varDef.key] = value
+      if (value) rawVariables[varDef.key] = value
     }
 
-    // Approval gate (§3.1): only a genuinely absent platform client (`requiresOwnClient`,
-    // reason `no-platform-client`) forces BYO id/secret — enforce that server-side, never
-    // trusting the dialog. A platform client pending verification yields
-    // `requiresOwnClient: false` (BYO is optional), so the platform kickoff proceeds here
-    // and Google shows its own unverified-app gating; BYO vars, when supplied, still win in
-    // `resolveOAuth2Client`.
-    const ownClient = resolveOwnClientRequirement(connDef)
+    // The dialog hides the BYO fields when the gate offers no BYO path, but this route
+    // takes them off the query string — drop caller-supplied client credentials so an org
+    // cannot opt itself into another OAuth client by appending `var_clientId`.
+    const connectionVariables = stripUnentitledOwnClientVars(
+      rawVariables,
+      ownClient,
+      storedVariables
+    )
+
     if (
       ownClient.requiresOwnClient &&
       !(connectionVariables.clientId && connectionVariables.clientSecret)
@@ -200,15 +211,16 @@ export async function GET(
       })
     )
 
-    const callbackBase = features.callbackBaseUrl || OAUTH_REDIRECT_BASE
     const scopes = [...new Set([...(connDef.oauth2Scopes || []), ...scopeAdd])]
+
+    // Pinned to the definition's providerKey, never `defParam`: the lookup above accepts
+    // an id OR a providerKey, so echoing the raw param would make the redirect URI depend
+    // on which spelling the caller used. A BYO user registers exactly one URI.
+    const redirectUri = providerOAuthCallbackUrl(connDef, features.callbackBaseUrl)
 
     const authUrl = new URL(resolved.authorizeUrl)
     authUrl.searchParams.set('client_id', clientId)
-    authUrl.searchParams.set(
-      'redirect_uri',
-      `${callbackBase}/api/connections/${defParam}/oauth2/callback`
-    )
+    authUrl.searchParams.set('redirect_uri', redirectUri)
     authUrl.searchParams.set('scope', scopes.join(features.scopeSeparator || ' '))
     authUrl.searchParams.set('state', state)
     authUrl.searchParams.set('response_type', 'code')

--- a/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/callback/route.ts
+++ b/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/callback/route.ts
@@ -2,13 +2,16 @@
 
 import { WEBAPP_URL } from '@auxx/config/urls'
 import { database as db } from '@auxx/database'
-import { resolveOAuth2Client, runPostConnectHook, saveConnection } from '@auxx/lib/connections'
+import {
+  providerOAuthCallbackUrl,
+  resolveOAuth2Client,
+  runPostConnectHook,
+  saveConnection,
+} from '@auxx/lib/connections'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
 import { interpolateConnectionFields } from '@auxx/services/app-connections'
 import { type NextRequest, NextResponse } from 'next/server'
-
-const OAUTH_REDIRECT_BASE = process.env.NGROK_URL || WEBAPP_URL
 
 const logger = createScopedLogger('connection-oauth-callback')
 
@@ -172,7 +175,6 @@ export async function GET(
     }
 
     const features = (connDef.oauth2Features as Record<string, any>) ?? {}
-    const callbackBase = features.callbackBaseUrl || OAUTH_REDIRECT_BASE
     const connectionVariables: Record<string, string> = metadata.connectionVariables ?? {}
     const resolved = interpolateConnectionFields(connDef, connectionVariables)
     // Client id/secret follow the §3.2 precedence — must match the client that minted
@@ -184,7 +186,8 @@ export async function GET(
       code,
       client_id: clientId,
       client_secret: clientSecret,
-      redirect_uri: `${callbackBase}/api/connections/${defParam}/oauth2/callback`,
+      // Must byte-match the authorize redirect_uri — same builder, pinned to providerKey.
+      redirect_uri: providerOAuthCallbackUrl(connDef, features.callbackBaseUrl),
       grant_type: 'authorization_code',
     }
 

--- a/apps/web/src/components/apps/hooks/use-connect-flow.tsx
+++ b/apps/web/src/components/apps/hooks/use-connect-flow.tsx
@@ -45,7 +45,9 @@ export interface ConnectFlowDefinition {
   /** OAuth own-client gate (§3.1) — threaded into the connect dialog's banner + fields. */
   requiresOwnClient?: boolean
   ownClientOptional?: boolean
-  ownClientReason?: 'no-platform-client' | 'pending-approval' | null
+  ownClientReason?: 'no-platform-client' | 'pending-approval' | 'byo-entitled' | null
+  /** Server-built OAuth redirect URI, surfaced for bring-your-own-client users. */
+  oauthCallbackUrl?: string | null
 }
 
 export interface ConnectTarget {
@@ -507,6 +509,7 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
       requiresOwnClient: activeDef.requiresOwnClient,
       ownClientOptional: activeDef.ownClientOptional,
       ownClientReason: activeDef.ownClientReason,
+      oauthCallbackUrl: activeDef.oauthCallbackUrl,
     }
   }, [args, activeDef])
 

--- a/apps/web/src/components/apps/ui/app-account-picker.tsx
+++ b/apps/web/src/components/apps/ui/app-account-picker.tsx
@@ -84,11 +84,17 @@ export function AppAccountPicker({
       },
       title: installation.app.title,
       connectionDefinitions: installation.connectionDefinitions ?? {},
+      // Gate fields must ride along — `useConnectFlow` resolves the dialog's method from
+      // `target.methods`, and without them the BYO disclosure cannot render here.
       methods: (installation.methods ?? []).map((m) => ({
         id: m.id,
         connectionType: m.connectionType,
         description: m.description ?? undefined,
         connectionVariables: m.connectionVariables,
+        requiresOwnClient: m.requiresOwnClient,
+        ownClientOptional: m.ownClientOptional,
+        ownClientReason: m.ownClientReason,
+        oauthCallbackUrl: m.oauthCallbackUrl,
       })),
     }
   }, [installation, appId])

--- a/apps/web/src/components/apps/ui/app-connections.tsx
+++ b/apps/web/src/components/apps/ui/app-connections.tsx
@@ -97,6 +97,7 @@ function AppConnections({ app, returnTo, scope, onConnectionCreated }: Props) {
       requiresOwnClient: m.requiresOwnClient,
       ownClientOptional: m.ownClientOptional,
       ownClientReason: m.ownClientReason,
+      oauthCallbackUrl: m.oauthCallbackUrl,
     })),
   }
   const personalMethods = methods.filter((m) => !m.global)

--- a/apps/web/src/components/channels/ui/channel-gallery-dialog.tsx
+++ b/apps/web/src/components/channels/ui/channel-gallery-dialog.tsx
@@ -17,6 +17,7 @@ import {
   type ConnectFlowDefinition,
   useConnectFlow,
 } from '~/components/apps/hooks/use-connect-flow'
+import { OwnClientCallbackNotice } from '~/components/connections/ui/own-client-callback-notice'
 import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import { TemplateGalleryDialog } from '~/components/templates/ui'
@@ -194,10 +195,13 @@ export function ChannelGalleryDialog({
   }
 
   // `requiresOwnClient` → BYO mandatory (no platform client). `ownClientOptional` →
-  // platform login works but the app is pending Google verification, so BYO is offered
-  // as an alternative the user can opt into via the advanced section.
+  // platform login works and BYO is offered as an alternative the user can opt into via
+  // the advanced section, either because the app is pending provider verification
+  // (`pending-approval`) or because the org holds `byoOAuthClient` (`byo-entitled`).
   const needsOwnClient = !!prep.data?.requiresOwnClient
   const ownClientOptional = !!prep.data?.ownClientOptional
+  const ownClientReason = prep.data?.ownClientReason ?? null
+  const oauthCallbackUrl = prep.data?.oauthCallbackUrl ?? null
   // BYO fields are active (must be filled to connect) when mandatory, or opted-in.
   const byoActive = needsOwnClient || (ownClientOptional && useOwnClient)
   const ownClientReady = !byoActive || (!!clientId.trim() && !!clientSecret.trim())
@@ -316,6 +320,7 @@ export function ChannelGalleryDialog({
           <p className='text-xs text-muted-foreground'>
             No platform app is configured — enter your own OAuth client credentials.
           </p>
+          <OwnClientCallbackNotice callbackUrl={oauthCallbackUrl} />
           {renderClientCredFields()}
         </>
       )
@@ -324,9 +329,9 @@ export function ChannelGalleryDialog({
       return (
         <div className='flex flex-col gap-2'>
           <p className='text-xs text-muted-foreground'>
-            This app's platform OAuth client is pending provider verification — during sign-in you
-            may see an "unverified app" warning (and access can be limited to test accounts). You
-            can continue with it, or use your own OAuth client below.
+            {ownClientReason === 'pending-approval'
+              ? `This app's platform OAuth client is pending provider verification — during sign-in you may see an "unverified app" warning (and access can be limited to test accounts). You can continue with it, or use your own OAuth client below.`
+              : 'Connect with our platform OAuth app, or use your own OAuth client below.'}
           </p>
           <Button
             type='button'
@@ -337,7 +342,12 @@ export function ChannelGalleryDialog({
             {useOwnClient ? <ChevronDown /> : <ChevronRight />}
             Use your own OAuth client (advanced)
           </Button>
-          {useOwnClient && renderClientCredFields()}
+          {useOwnClient && (
+            <>
+              <OwnClientCallbackNotice callbackUrl={oauthCallbackUrl} />
+              {renderClientCredFields()}
+            </>
+          )}
         </div>
       )
     }

--- a/apps/web/src/components/connections/ui/connection-detail-page.tsx
+++ b/apps/web/src/components/connections/ui/connection-detail-page.tsx
@@ -11,6 +11,7 @@ import { cn } from '@auxx/ui/lib/utils'
 import { ChevronDown, ChevronRight, KeyRound, Plug } from 'lucide-react'
 import { ConnectionVariableFields } from '~/components/connections/ui/connection-variable-fields'
 import { FieldPanel } from '~/components/global/forms/field-panel'
+import { OwnClientCallbackNotice } from './own-client-callback-notice'
 
 /** One connect method an item exposes (the detail page renders + collects input for it). */
 export interface DetailMethod {
@@ -23,9 +24,14 @@ export interface DetailMethod {
   connectionVariables?: ConnectionVariable[] | null
   /** OAuth approval gate (§3.1): this connection must bring its own client id/secret. */
   requiresOwnClient?: boolean
-  /** Platform client works but is pending verification — BYO offered as an optional alternative. */
+  /**
+   * BYO is offered as an optional alternative to the platform client — either because the
+   * platform app is pending verification, or because the org holds `byoOAuthClient`.
+   */
   ownClientOptional?: boolean
-  ownClientReason?: 'no-platform-client' | 'pending-approval' | null
+  ownClientReason?: 'no-platform-client' | 'pending-approval' | 'byo-entitled' | null
+  /** Server-built OAuth redirect URI, shown so a BYO user can register it. */
+  oauthCallbackUrl?: string | null
 }
 
 /** Copy for the mandatory BYO-client banner (§3.1) — shown only when `requiresOwnClient`. */
@@ -34,6 +40,9 @@ const OWN_CLIENT_COPY: Record<NonNullable<DetailMethod['ownClientReason']>, stri
     'Our platform app for this provider is pending verification — connect with your own OAuth app for now.',
   'no-platform-client':
     'No platform OAuth app is configured for this provider — connect with your own OAuth app.',
+  // Never reached as a banner: `byo-entitled` is always optional, and the banner renders
+  // only for `requiresOwnClient`. Present so the record stays exhaustive.
+  'byo-entitled': 'Connect with the platform OAuth app, or supply your own.',
 }
 
 interface ConnectionDetailPageProps {
@@ -187,16 +196,19 @@ export function ConnectionDetailPage({
         </div>
       )}
       {chosen?.requiresOwnClient && chosen.ownClientReason && (
-        <div className='rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400'>
-          {OWN_CLIENT_COPY[chosen.ownClientReason]}
+        <div className='flex flex-col gap-2'>
+          <div className='rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400'>
+            {OWN_CLIENT_COPY[chosen.ownClientReason]}
+          </div>
+          <OwnClientCallbackNotice callbackUrl={chosen.oauthCallbackUrl} />
         </div>
       )}
       {chosen && methodOffersOwnClient(chosen) && (
         <div className='flex flex-col gap-2'>
           <div className='rounded-md border px-3 py-2 text-xs text-muted-foreground'>
-            This app's platform OAuth client is pending provider verification — you can continue
-            with it (you may see an "unverified app" warning during sign-in), or use your own OAuth
-            client.
+            {chosen.ownClientReason === 'pending-approval'
+              ? `This app's platform OAuth client is pending provider verification — you can continue with it (you may see an "unverified app" warning during sign-in), or use your own OAuth client.`
+              : 'Connect with our platform OAuth app, or use your own OAuth client.'}
           </div>
           {onByoOpenChange && (
             <Button
@@ -210,6 +222,7 @@ export function ConnectionDetailPage({
               Use your own OAuth client (advanced)
             </Button>
           )}
+          {byoOpen && <OwnClientCallbackNotice callbackUrl={chosen.oauthCallbackUrl} />}
         </div>
       )}
       {chosen && methodNeedsFields(chosen) && (

--- a/apps/web/src/components/connections/ui/connection-targets.ts
+++ b/apps/web/src/components/connections/ui/connection-targets.ts
@@ -50,11 +50,18 @@ export function appTarget(inst: AppInstallation): ConnectFlowArgs['target'] {
     },
     title: inst.app.title,
     connectionDefinitions: inst.connectionDefinitions ?? {},
+    // The gate fields must ride along: `useConnectFlow` resolves the dialog's method from
+    // `target.methods`, and dropping them here made the same app render its BYO client
+    // fields inline through this surface while the app detail tab showed the disclosure.
     methods: (inst.methods ?? []).map((m) => ({
       id: m.id,
       connectionType: m.connectionType,
       description: m.description ?? undefined,
       connectionVariables: m.connectionVariables,
+      requiresOwnClient: m.requiresOwnClient,
+      ownClientOptional: m.ownClientOptional,
+      ownClientReason: m.ownClientReason,
+      oauthCallbackUrl: m.oauthCallbackUrl,
     })),
   }
 }

--- a/apps/web/src/components/connections/ui/credential-template-dialog.tsx
+++ b/apps/web/src/components/connections/ui/credential-template-dialog.tsx
@@ -39,7 +39,8 @@ type Method = {
   requiresOwnClient?: boolean
   /** Platform client works but is pending verification — BYO offered as an optional alternative. */
   ownClientOptional?: boolean
-  ownClientReason?: 'no-platform-client' | 'pending-approval' | null
+  ownClientReason?: 'no-platform-client' | 'pending-approval' | 'byo-entitled' | null
+  oauthCallbackUrl?: string | null
 }
 
 /** A gallery row — either an installed app or a platform provider — carrying its source. */
@@ -212,6 +213,7 @@ export function CredentialTemplateDialog({
         requiresOwnClient: p.requiresOwnClient,
         ownClientOptional: p.ownClientOptional,
         ownClientReason: p.ownClientReason,
+        oauthCallbackUrl: p.oauthCallbackUrl,
       },
     ]
   }

--- a/apps/web/src/components/connections/ui/own-client-callback-notice.tsx
+++ b/apps/web/src/components/connections/ui/own-client-callback-notice.tsx
@@ -1,0 +1,36 @@
+// apps/web/src/components/connections/ui/own-client-callback-notice.tsx
+'use client'
+
+import { CopyButton } from '@auxx/ui/components/button-copy'
+
+interface OwnClientCallbackNoticeProps {
+  /** Server-built redirect URI. Null/empty renders nothing. */
+  callbackUrl?: string | null
+}
+
+/**
+ * The redirect URI a bring-your-own-client user must register in **their** provider app.
+ *
+ * Without it every BYO connect dies at the provider with `redirect_uri_mismatch` — an
+ * error the user sees on the provider's own page, with nothing in our UI to explain it.
+ * The string comes from the server (`providerOAuthCallbackUrl` / `appOAuthCallbackUrl`),
+ * the same builder the authorize and callback routes use, so what is shown here is byte
+ * -for-byte what we will send.
+ *
+ * Render this only inside an opened BYO section — it is noise for a platform connect.
+ */
+export function OwnClientCallbackNotice({ callbackUrl }: OwnClientCallbackNoticeProps) {
+  if (!callbackUrl) return null
+
+  return (
+    <div className='flex flex-col gap-1 rounded-md border border-border bg-muted/40 p-2'>
+      <p className='text-xs text-muted-foreground'>
+        Add this redirect URI to your OAuth app before connecting:
+      </p>
+      <div className='flex items-center gap-1'>
+        <code className='min-w-0 flex-1 truncate font-mono text-xs'>{callbackUrl}</code>
+        <CopyButton text={callbackUrl} />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/lib/urls.ts
+++ b/apps/web/src/lib/urls.ts
@@ -1,0 +1,45 @@
+// apps/web/src/lib/urls.ts
+//
+// Client-side URL resolution.
+//
+// The `WEBAPP_URL` / `API_URL` / ... constants from `@auxx/config` MUST NOT be imported
+// into browser code. They resolve through a *dynamic* `process.env[key]` read, which no
+// bundler can inline, and Next only ships `NEXT_PUBLIC_*` to the browser anyway — so in a
+// client bundle both reads return undefined and the constant silently collapses to its
+// `http://localhost:<port>` dev fallback. Harmless locally, a hard failure in production.
+//
+// The server-resolved values are already shipped to the browser: `buildEnvironment()`
+// computes them where the env actually exists and the layouts inject them in a
+// `beforeInteractive` script, so `window.AUXX_DEHYDRATED_STATE` is populated before any
+// client module runs (same guarantee `resource-store.ts` relies on). These helpers read
+// that, never the config constants.
+
+/**
+ * Base URL for requests back to **this** app — tRPC, REST routes, uploads.
+ *
+ * Deliberately same-origin. A configured absolute URL would send these cross-origin the
+ * moment the app is reached on any other host (preview deploy, domain alias, ngrok), and
+ * the session cookie would stop riding along. Same origin as the page is both correct and
+ * what the React tRPC client already uses.
+ */
+export function getBaseUrl(): string {
+  if (typeof window !== 'undefined') return window.location.origin
+  return `http://localhost:${process.env.PORT ?? 3000}`
+}
+
+/**
+ * The canonical, configured app URL — the client-side equivalent of `WEBAPP_URL`.
+ *
+ * Use this for URLs that **leave the browser**: share links, copied URLs, anything pasted
+ * into an email or handed to a third party, where the canonical host matters more than
+ * whichever host this particular viewer happened to use. For calling our own API, use
+ * {@link getBaseUrl} instead.
+ *
+ * Falls back to the current origin when the dehydrated state is absent (SSR, or a route
+ * whose layout does not inject it) — a same-origin URL is always safer than the localhost
+ * fallback the config constant would have produced.
+ */
+export function getWebappUrl(): string {
+  if (typeof window === 'undefined') return getBaseUrl()
+  return window.AUXX_DEHYDRATED_STATE?.environment?.appUrl || window.location.origin
+}

--- a/apps/web/src/server/api/routers/apps.ts
+++ b/apps/web/src/server/api/routers/apps.ts
@@ -13,7 +13,13 @@ import {
   uninstallApp,
 } from '@auxx/lib/apps'
 import { getCachedAppBySlug, getOrgCache, onCacheEvent } from '@auxx/lib/cache'
-import { mintClientCredentialToken } from '@auxx/lib/connections'
+import {
+  appOAuthCallbackUrl,
+  gateConnectionVariables,
+  mintClientCredentialToken,
+  NO_OWN_CLIENT_GATE,
+  resolveOwnClientGateForOrg,
+} from '@auxx/lib/connections'
 import { resolveConnectorConfigOptions } from '@auxx/lib/data-connectors'
 import {
   FeatureKey,
@@ -116,14 +122,51 @@ export const appsRouter = createTRPCRouter({
         ? installedApps.filter((a) => a.installationType === input.type)
         : installedApps
 
-      // Rehydrate dates for SuperJSON compatibility
-      const installations = filtered.map((app) => ({
-        ...app,
-        installedAt: new Date(app.installedAt),
-        currentDeployment: app.currentDeployment
-          ? { ...app.currentDeployment, createdAt: new Date(app.currentDeployment.createdAt) }
-          : null,
-      }))
+      // Resolve the own-client gate HERE, not in the cache provider: it depends on the
+      // org's `byoOAuthClient` feature, and the cached blob is deliberately gate-free (see
+      // `CachedInstalledApp['methods']`). Applying it at read means a feature grant takes
+      // effect on the next call with no `installedApps` invalidation to get wrong.
+      const installations = await Promise.all(
+        filtered.map(async (app) => ({
+          ...app,
+          installedAt: new Date(app.installedAt),
+          currentDeployment: app.currentDeployment
+            ? { ...app.currentDeployment, createdAt: new Date(app.currentDeployment.createdAt) }
+            : null,
+          methods: await Promise.all(
+            (app.methods ?? []).map(async (m) => {
+              const gate =
+                m.connectionType === 'oauth2-code'
+                  ? await resolveOwnClientGateForOrg(organizationId, {
+                      oauth2ClientId: m.oauth2ClientId,
+                      oauth2ClientSecret: m.oauth2ClientSecret,
+                      platformClientApproved: m.platformClientApproved,
+                    })
+                  : NO_OWN_CLIENT_GATE
+              return {
+                id: m.id,
+                key: m.key,
+                label: m.label,
+                description: m.description,
+                connectionType: m.connectionType,
+                global: m.global,
+                connectionVariables: gateConnectionVariables(
+                  m.connectionType,
+                  m.connectionVariables,
+                  gate
+                ),
+                requiresOwnClient: gate.requiresOwnClient,
+                ownClientOptional: gate.ownClientOptional,
+                ownClientReason: gate.reason,
+                // Shown to a BYO user so they can register it in their own OAuth app.
+                // Server-built: `WEBAPP_URL` collapses to localhost in a browser bundle.
+                oauthCallbackUrl:
+                  m.connectionType === 'oauth2-code' ? appOAuthCallbackUrl(app.app.slug) : null,
+              }
+            })
+          ),
+        }))
+      )
 
       return { installations }
     }),

--- a/apps/web/src/server/api/routers/channel.ts
+++ b/apps/web/src/server/api/routers/channel.ts
@@ -36,7 +36,11 @@ import {
   type UpdateChatWidgetInput,
   updateChatWidget,
 } from '@auxx/lib/chat-widget/config'
-import { findPendingSelectionForUser, resolveOwnClientRequirement } from '@auxx/lib/connections'
+import {
+  findPendingSelectionForUser,
+  providerOAuthCallbackUrl,
+  resolveOwnClientGateForOrg,
+} from '@auxx/lib/connections'
 import { getUserOrganizationId } from '@auxx/lib/email'
 import { SyncMessages } from '@auxx/lib/messages'
 import {
@@ -159,7 +163,10 @@ export const channelRouter = createTRPCRouter({
         })
       }
 
-      const gate = resolveOwnClientRequirement(def)
+      // Org-aware (§3.1): the def's verification state decides first, and the
+      // `byoOAuthClient` feature adds the BYO option on top of an already-verified
+      // platform client. Orgs without the feature see the one-click platform flow only.
+      const gate = await resolveOwnClientGateForOrg(organizationId, def)
       return {
         providerKey,
         connectionDefinitionId: def.id,
@@ -167,6 +174,9 @@ export const channelRouter = createTRPCRouter({
         requiresOwnClient: gate.requiresOwnClient,
         ownClientOptional: gate.ownClientOptional,
         ownClientReason: gate.reason,
+        // Shown to a BYO user so they can register it in their own OAuth app. Built here,
+        // not in the browser: `WEBAPP_URL` collapses to localhost in a client bundle.
+        oauthCallbackUrl: providerOAuthCallbackUrl({ providerKey }),
         supportsPersonalConnection: supportsPersonal,
       }
     }),

--- a/apps/web/src/server/api/routers/connections.ts
+++ b/apps/web/src/server/api/routers/connections.ts
@@ -13,8 +13,10 @@ import { getOrgCache } from '@auxx/lib/cache'
 import {
   gateConnectionVariables,
   mintClientCredentialToken,
+  NO_OWN_CLIENT_GATE,
+  providerOAuthCallbackUrl,
   refreshCredentialTokens,
-  resolveOwnClientRequirement,
+  resolveOwnClientGateForOrg,
   runPostConnectHook,
   saveConnection,
 } from '@auxx/lib/connections'
@@ -168,6 +170,7 @@ export const connectionsRouter = createTRPCRouter({
    * OAuth route + `save` resolve a providerKey as the id).
    */
   listProviders: protectedProcedure.query(async ({ ctx }) => {
+    const { organizationId } = ctx.session
     // The approval gate (§3.1) is DB-derived: a platform client is "present" only if its
     // env was set at seed time (column non-blank), and `platformClientApproved` carries
     // the verification flag. Join the catalog (icons/labels) with the platform
@@ -181,23 +184,32 @@ export const connectionsRouter = createTRPCRouter({
         platformClientApproved: true,
       },
     })
+    // Org-aware: `byoOAuthClient` can offer BYO on top of a verified platform client.
+    // Resolved per row but the feature read behind it is one cached org lookup, not N.
     const gateByKey = new Map(
-      defRows.map((d) => [
-        d.providerKey as string,
-        resolveOwnClientRequirement({
-          oauth2ClientId: d.oauth2ClientId,
-          oauth2ClientSecret: d.oauth2ClientSecret,
-          platformClientApproved: d.platformClientApproved,
-        }),
-      ])
+      await Promise.all(
+        defRows.map(
+          async (d) =>
+            [
+              d.providerKey as string,
+              await resolveOwnClientGateForOrg(organizationId, {
+                oauth2ClientId: d.oauth2ClientId,
+                oauth2ClientSecret: d.oauth2ClientSecret,
+                platformClientApproved: d.platformClientApproved,
+              }),
+            ] as const
+        )
+      )
     )
     return getAllProviders().map((p) => {
       // The BYO-client gate is an authorization-code concept (platform redirect app +
       // approval). Secret/client-credentials defs have no platform OAuth client, so the
       // gate would wrongly read as `no-platform-client` — only consult it for oauth2-code.
-      const gate = p.connectionType === 'oauth2-code' ? gateByKey.get(p.providerKey) : undefined
-      const requiresOwnClient = gate?.requiresOwnClient ?? false
-      const ownClientOptional = gate?.ownClientOptional ?? false
+      const gate =
+        p.connectionType === 'oauth2-code'
+          ? (gateByKey.get(p.providerKey) ?? NO_OWN_CLIENT_GATE)
+          : NO_OWN_CLIENT_GATE
+      const { requiresOwnClient, ownClientOptional } = gate
       return {
         providerKey: p.providerKey,
         label: p.label,
@@ -225,7 +237,12 @@ export const connectionsRouter = createTRPCRouter({
         // providers (no DB gate) and secret defs.
         requiresOwnClient,
         ownClientOptional,
-        ownClientReason: gate?.reason ?? null,
+        ownClientReason: gate.reason,
+        // Server-built so a BYO user can register it in their own OAuth app.
+        oauthCallbackUrl:
+          p.connectionType === 'oauth2-code'
+            ? providerOAuthCallbackUrl({ providerKey: p.providerKey })
+            : null,
       }
     })
   }),

--- a/apps/web/src/trpc/vanilla.ts
+++ b/apps/web/src/trpc/vanilla.ts
@@ -2,24 +2,9 @@
 
 import { createTRPCClient, httpBatchLink } from '@trpc/client'
 import SuperJSON from 'superjson'
+import { getBaseUrl } from '~/lib/urls'
 import { getRealtimeSocketId } from '~/realtime/hooks'
 import type { AppRouter } from '~/server/api/root'
-
-/**
- * Resolve the tRPC base URL.
- *
- * Must NOT use `WEBAPP_URL` from `@auxx/config`: that constant is resolved from
- * `process.env.APP_URL` / `process.env.DOMAIN` through a *dynamic* `process.env[key]`
- * read, which the Next bundler cannot inline (only `NEXT_PUBLIC_*` reaches the
- * browser). In a browser bundle both reads return undefined and `WEBAPP_URL`
- * silently collapses to its `http://localhost:3000` dev fallback — harmless
- * locally, a hard "Failed to fetch" in production. Same origin as the page is
- * both correct and what the React client (`~/trpc/react`) already uses.
- */
-function getBaseUrl(): string {
-  if (typeof window !== 'undefined') return window.location.origin
-  return `http://localhost:${process.env.PORT ?? 3000}`
-}
 
 /**
  * Vanilla (non-React) tRPC client for use outside React lifecycle.

--- a/packages/lib/src/apps/get-app-details.ts
+++ b/packages/lib/src/apps/get-app-details.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/apps/get-app-details.ts
 
-import { gateConnectionVariables, resolveOwnClientRequirement } from '@auxx/credentials/connections'
+import { gateConnectionVariables } from '@auxx/credentials/connections'
 import type { CatalogPayload, Database } from '@auxx/database'
 import {
   type ConnectionDefinitionSummary,
@@ -9,6 +9,8 @@ import {
   listAppConnectionDefinitions,
 } from '@auxx/services/app-connections'
 import { getCachedAppBySlug } from '../cache/app-cache-helpers'
+import { appOAuthCallbackUrl } from '../connections/oauth-callback-url'
+import { resolveOwnClientGateForOrg } from '../connections/own-client-gate'
 
 /**
  * Input parameters for getAppWithInstallationStatus
@@ -51,9 +53,11 @@ export interface AppCapabilitySummary {
 export interface OwnClientGate {
   /** BYO client id/secret are mandatory (def has no platform client). */
   requiresOwnClient: boolean
-  /** Platform client pending verification — BYO offered as an optional alternative. */
+  /** BYO offered as an optional alternative — pending verification, or `byoOAuthClient`. */
   ownClientOptional: boolean
-  ownClientReason: 'no-platform-client' | 'pending-approval' | null
+  ownClientReason: 'no-platform-client' | 'pending-approval' | 'byo-entitled' | null
+  /** OAuth redirect URI a BYO user must register in their own provider app. */
+  oauthCallbackUrl: string | null
 }
 
 export type GatedConnectionMethod = ConnectionMethod & OwnClientGate
@@ -215,25 +219,34 @@ export async function getAppWithInstallationStatus(
     requiresOwnClient: false,
     ownClientOptional: false,
     ownClientReason: null,
+    oauthCallbackUrl: null,
   }
-  const gateFor = (row: (typeof gateRows)[number] | undefined, connectionType: string) => {
+  // Org-aware (§3.1): the def's verification state decides first, and `byoOAuthClient`
+  // adds the BYO option on top of an already-verified platform client.
+  const gateFor = async (
+    row: (typeof gateRows)[number] | undefined,
+    connectionType: string
+  ): Promise<OwnClientGate> => {
     if (!row || connectionType !== 'oauth2-code') return NO_GATE
-    const gate = resolveOwnClientRequirement(row)
+    const gate = await resolveOwnClientGateForOrg(organizationId, row)
     return {
       requiresOwnClient: gate.requiresOwnClient,
       ownClientOptional: gate.ownClientOptional,
       ownClientReason: gate.reason,
+      oauthCallbackUrl: appOAuthCallbackUrl(cachedApp.slug),
     }
   }
 
-  const methods: GatedConnectionMethod[] = rawMethods.map((m) => {
-    const gate = gateFor(gateRowById.get(m.id), m.connectionType)
-    return {
-      ...m,
-      ...gate,
-      connectionVariables: gateConnectionVariables(m.connectionType, m.connectionVariables, gate),
-    }
-  })
+  const methods: GatedConnectionMethod[] = await Promise.all(
+    rawMethods.map(async (m) => {
+      const gate = await gateFor(gateRowById.get(m.id), m.connectionType)
+      return {
+        ...m,
+        ...gate,
+        connectionVariables: gateConnectionVariables(m.connectionType, m.connectionVariables, gate),
+      }
+    })
+  )
 
   if (installation) {
     const [userConnDef, orgConnDef] = await Promise.all([
@@ -250,7 +263,7 @@ export async function getAppWithInstallationStatus(
       )
     if (userConnDef.isOk() && userConnDef.value) {
       const def = userConnDef.value
-      const gate = gateForScope(false, def.connectionType)
+      const gate = await gateForScope(false, def.connectionType)
       connectionDefinitions.user = {
         ...def,
         ...gate,
@@ -263,7 +276,7 @@ export async function getAppWithInstallationStatus(
     }
     if (orgConnDef.isOk() && orgConnDef.value) {
       const def = orgConnDef.value
-      const gate = gateForScope(true, def.connectionType)
+      const gate = await gateForScope(true, def.connectionType)
       connectionDefinitions.organization = {
         ...def,
         ...gate,

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -500,11 +500,18 @@ export interface CachedInstalledApp {
     description: string | null
     connectionType: string
     global: boolean
+    /**
+     * RAW connect-form variables, exactly as the definition declares them. NOT shaped by
+     * `gateConnectionVariables` — the own-client gate is org-dependent (`byoOAuthClient`)
+     * and is applied at READ time in `apps.listInstalled`, never baked here. Shaping at
+     * compute would strip the BYO descriptors irrecoverably and go stale on a feature
+     * grant, since `plan.changed` does not invalidate `installedApps`.
+     */
     connectionVariables: ConnectionVariable[]
-    /** OAuth own-client gate (§3.1): whether BYO client id/secret is required or offered. */
-    requiresOwnClient: boolean
-    ownClientOptional: boolean
-    ownClientReason: 'no-platform-client' | 'pending-approval' | null
+    /** Own-client gate INPUTS (§3.1). The gate itself is resolved per-org at read time. */
+    oauth2ClientId: string | null
+    oauth2ClientSecret: string | null
+    platformClientApproved: boolean
   }[]
 
   /**
@@ -855,7 +862,12 @@ export const ORG_CACHE_KEY_CONFIG: Record<
   // v5: + methods[] (multi-connection-per-app). See plans/connections/multi-connection-per-app.md.
   // v6: workflowBlocks carry `ops[]` (toolMap → catalog.tools join) so the server
   //     can resolve what an app block produces. See plans/kopilot/workflow/17-*.md §4 A2.
-  installedApps: { prefix: 'org:installed-apps:v6', ttlSeconds: 900 },
+  // v7: `methods[]` dropped the baked own-client gate for the RAW variables + the three
+  // gate inputs (gating moved to read time in `apps.listInstalled`). A v6 blob carries no
+  // `oauth2ClientId`/`platformClientApproved`, so the read-time gate would read it as
+  // "no platform client" and demand BYO credentials for EVERY installed app until the TTL
+  // expired. The bump is what makes this deploy safe.
+  installedApps: { prefix: 'org:installed-apps:v7', ttlSeconds: 900 },
   mcpServers: { prefix: 'org:mcpServers', ttlSeconds: ONE_DAY },
   // Read per CRUD event by trigger dispatch; changes only on admin edits →
   // 5 s local window (dispatch enqueues jobs, so peer staleness is benign).

--- a/packages/lib/src/cache/providers/installed-apps-provider.ts
+++ b/packages/lib/src/cache/providers/installed-apps-provider.ts
@@ -1,6 +1,5 @@
 // packages/lib/src/cache/providers/installed-apps-provider.ts
 
-import { gateConnectionVariables, resolveOwnClientRequirement } from '@auxx/credentials/connections'
 import type { CatalogBlock, CatalogTool } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
@@ -218,31 +217,24 @@ export const installedAppsProvider: CacheProvider<CachedInstalledApp[]> = {
               createdAt: inst.currentDeployment.createdAt.toISOString(),
             }
           : null,
-        methods: (methodsByAppId.get(inst.app.id) ?? []).map((def) => {
-          // Own-client gate (§3.1): reused verbatim from the platform-provider path so the
-          // connect dialog renders the same platform-primary + optional-BYO UI for apps.
-          const gate = resolveOwnClientRequirement({
-            oauth2ClientId: def.oauth2ClientId,
-            oauth2ClientSecret: def.oauth2ClientSecret,
-            platformClientApproved: def.platformClientApproved,
-          })
-          return {
-            id: def.id,
-            key: def.key,
-            label: def.label,
-            description: def.description,
-            connectionType: def.connectionType,
-            global: def.global ?? false,
-            connectionVariables: gateConnectionVariables(
-              def.connectionType,
-              def.connectionVariables ?? [],
-              gate
-            ),
-            requiresOwnClient: gate.requiresOwnClient,
-            ownClientOptional: gate.ownClientOptional,
-            ownClientReason: gate.reason,
-          }
-        }),
+        // The own-client gate is deliberately NOT resolved here. It depends on the org's
+        // `byoOAuthClient` feature, and a cache-compute path must not read the org cache;
+        // baking an org-dependent gate would also go stale, because `plan.changed`
+        // invalidates `features` but not `installedApps`. So the blob carries the RAW
+        // variables plus the three gate inputs, and `apps.listInstalled` gates on the way
+        // out — the same read-time shape the limited-use provider gate uses.
+        methods: (methodsByAppId.get(inst.app.id) ?? []).map((def) => ({
+          id: def.id,
+          key: def.key,
+          label: def.label,
+          description: def.description,
+          connectionType: def.connectionType,
+          global: def.global ?? false,
+          connectionVariables: def.connectionVariables ?? [],
+          oauth2ClientId: def.oauth2ClientId,
+          oauth2ClientSecret: def.oauth2ClientSecret,
+          platformClientApproved: def.platformClientApproved,
+        })),
         connectionDefinitions: (() => {
           const defs = connDefsByAppId.get(inst.app.id) ?? {}
           const toCached = (def: (typeof connectionDefs)[0] | undefined) =>

--- a/packages/lib/src/connections/__tests__/own-client-gate.test.ts
+++ b/packages/lib/src/connections/__tests__/own-client-gate.test.ts
@@ -1,0 +1,147 @@
+// packages/lib/src/connections/__tests__/own-client-gate.test.ts
+//
+// The org-aware own-client gate. The definition's verification state decides first and is
+// never overridden by the feature; `byoOAuthClient` only adds the third case — a verified
+// platform client whose org may substitute its own app. The strip helper is the server-side
+// half: it drops caller-supplied client credentials when the gate offers no BYO path.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const hasAccess = vi.fn<(orgId: string, key: string) => Promise<boolean>>()
+
+vi.mock('../../permissions/feature-permission-service', () => ({
+  FeaturePermissionService: class {
+    hasAccess = hasAccess
+  },
+}))
+
+const { resolveOwnClientGateForOrg, stripUnentitledOwnClientVars } = await import(
+  '../own-client-gate'
+)
+
+/** A verified platform client — the case the feature actually changes. */
+const APPROVED = {
+  oauth2ClientId: 'platform-id',
+  oauth2ClientSecret: 'platform-secret',
+  platformClientApproved: true,
+}
+
+describe('resolveOwnClientGateForOrg', () => {
+  beforeEach(() => {
+    hasAccess.mockReset()
+  })
+
+  it('offers nothing for a verified platform client when the org lacks the feature', async () => {
+    hasAccess.mockResolvedValue(false)
+    expect(await resolveOwnClientGateForOrg('org-1', APPROVED)).toEqual({
+      requiresOwnClient: false,
+      ownClientOptional: false,
+      reason: null,
+    })
+  })
+
+  it('offers BYO for a verified platform client when the org holds the feature', async () => {
+    hasAccess.mockResolvedValue(true)
+    expect(await resolveOwnClientGateForOrg('org-1', APPROVED)).toEqual({
+      requiresOwnClient: false,
+      ownClientOptional: true,
+      reason: 'byo-entitled',
+    })
+  })
+
+  it('keeps BYO mandatory when there is no platform client, without reading the feature', async () => {
+    hasAccess.mockResolvedValue(false)
+    const gate = await resolveOwnClientGateForOrg('org-1', {
+      oauth2ClientId: null,
+      oauth2ClientSecret: null,
+      platformClientApproved: true,
+    })
+    expect(gate).toEqual({
+      requiresOwnClient: true,
+      ownClientOptional: false,
+      reason: 'no-platform-client',
+    })
+    // The feature must never be able to un-require BYO — the org could not connect at all.
+    expect(hasAccess).not.toHaveBeenCalled()
+  })
+
+  it('keeps the pending-approval reason (and its warning copy) over byo-entitled', async () => {
+    hasAccess.mockResolvedValue(true)
+    const gate = await resolveOwnClientGateForOrg('org-1', {
+      ...APPROVED,
+      platformClientApproved: false,
+    })
+    expect(gate).toEqual({
+      requiresOwnClient: false,
+      ownClientOptional: true,
+      reason: 'pending-approval',
+    })
+    expect(hasAccess).not.toHaveBeenCalled()
+  })
+})
+
+describe('oauth callback urls', () => {
+  it('pins the provider segment to the providerKey, not a caller-supplied id', async () => {
+    const { providerOAuthCallbackUrl } = await import('../oauth-callback-url')
+    // The authorize route resolves its path param as `id OR providerKey`. Both spellings
+    // must produce ONE redirect URI — a BYO user registers exactly one string.
+    const byKey = providerOAuthCallbackUrl({ providerKey: 'gmail', id: 'cuid_abc' })
+    const byIdOnly = providerOAuthCallbackUrl({ providerKey: 'gmail' })
+    expect(byKey).toBe(byIdOnly)
+    expect(byKey).toContain('/api/connections/gmail/oauth2/callback')
+  })
+
+  it('falls back to the definition id when there is no providerKey (app/mcp rows)', async () => {
+    const { providerOAuthCallbackUrl } = await import('../oauth-callback-url')
+    expect(providerOAuthCallbackUrl({ providerKey: null, id: 'cuid_abc' })).toContain(
+      '/api/connections/cuid_abc/oauth2/callback'
+    )
+  })
+
+  it('gives one app callback url per slug, shared by every method', async () => {
+    const { appOAuthCallbackUrl } = await import('../oauth-callback-url')
+    expect(appOAuthCallbackUrl('gog-calendar')).toContain('/api/apps/gog-calendar/oauth2/callback')
+  })
+
+  it('honours a definition-level callbackBaseUrl override', async () => {
+    const { appOAuthCallbackUrl } = await import('../oauth-callback-url')
+    expect(appOAuthCallbackUrl('shopify', 'https://tunnel.example')).toBe(
+      'https://tunnel.example/api/apps/shopify/oauth2/callback'
+    )
+  })
+})
+
+describe('stripUnentitledOwnClientVars', () => {
+  const CLOSED = { requiresOwnClient: false, ownClientOptional: false, reason: null } as const
+  const OPEN = {
+    requiresOwnClient: false,
+    ownClientOptional: true,
+    reason: 'byo-entitled',
+  } as const
+
+  it('drops query-supplied client credentials when the gate offers no BYO path', () => {
+    expect(
+      stripUnentitledOwnClientVars({ clientId: 'x', clientSecret: 'y', shop: 'acme' }, CLOSED)
+    ).toEqual({ shop: 'acme' })
+  })
+
+  it('keeps them when the gate offers BYO', () => {
+    const vars = { clientId: 'x', clientSecret: 'y' }
+    expect(stripUnentitledOwnClientVars(vars, OPEN)).toEqual(vars)
+  })
+
+  it('leaves already-stored credentials alone so revoking the feature cannot repoint a live connection', () => {
+    expect(
+      stripUnentitledOwnClientVars({ clientId: 'stored', clientSecret: 'stored-secret' }, CLOSED, {
+        clientId: 'stored',
+        clientSecret: 'stored-secret',
+      })
+    ).toEqual({ clientId: 'stored', clientSecret: 'stored-secret' })
+  })
+
+  it('does not mutate the input', () => {
+    const vars = { clientId: 'x' }
+    stripUnentitledOwnClientVars(vars, CLOSED)
+    expect(vars).toEqual({ clientId: 'x' })
+  })
+})

--- a/packages/lib/src/connections/index.ts
+++ b/packages/lib/src/connections/index.ts
@@ -41,6 +41,19 @@ export {
   resolveHostedProvisionHandler,
 } from './hosted-provision'
 export {
+  appOAuthCallbackUrl,
+  oauthCallbackBase,
+  providerOAuthCallbackUrl,
+} from './oauth-callback-url'
+export {
+  NO_OWN_CLIENT_GATE,
+  type OwnClientGate,
+  type OwnClientGateDefinition,
+  type OwnClientReason,
+  resolveOwnClientGateForOrg,
+  stripUnentitledOwnClientVars,
+} from './own-client-gate'
+export {
   clearPendingSelection,
   deleteSupersededPendingCredentials,
   findPendingSelectionForUser,

--- a/packages/lib/src/connections/oauth-callback-url.ts
+++ b/packages/lib/src/connections/oauth-callback-url.ts
@@ -1,0 +1,47 @@
+// packages/lib/src/connections/oauth-callback-url.ts
+//
+// The single builder for OAuth2 redirect URIs. The authorize route, the callback route,
+// and the connect UI that SHOWS the URL to a bring-your-own-client user must all produce
+// the same string — a BYO user registers exactly one redirect URI in their provider app,
+// and any disagreement surfaces only as an opaque `redirect_uri_mismatch` at the provider.
+
+import { WEBAPP_URL } from '@auxx/config/server'
+
+/**
+ * Public base URL a provider redirects back to after consent.
+ *
+ * `NGROK_URL` points at the tunnel in dev (providers reject localhost redirect URIs);
+ * unset in production, where `WEBAPP_URL` applies. A definition may override the base
+ * entirely via `oauth2Features.callbackBaseUrl`. Server-side only — `WEBAPP_URL` resolves
+ * through a dynamic `process.env[key]` read and collapses to localhost in a browser
+ * bundle, which is why the connect surfaces receive this string from the server rather
+ * than building it themselves.
+ */
+export function oauthCallbackBase(callbackBaseUrl?: string | null): string {
+  return callbackBaseUrl || process.env.NGROK_URL || WEBAPP_URL
+}
+
+/**
+ * Redirect URI for a platform-provider connection.
+ *
+ * The path segment is the provider key, NOT the caller-supplied route param. The route
+ * resolves its param as `id OR providerKey`, so echoing the raw param back would make the
+ * redirect URI depend on which spelling the caller happened to use — survivable with the
+ * platform client (register both), fatal for BYO. Pinning it here keeps authorize,
+ * callback, and the displayed URL in agreement by construction.
+ */
+export function providerOAuthCallbackUrl(
+  def: { providerKey?: string | null; id?: string | null },
+  callbackBaseUrl?: string | null
+): string {
+  const segment = def.providerKey ?? def.id ?? ''
+  return `${oauthCallbackBase(callbackBaseUrl)}/api/connections/${segment}/oauth2/callback`
+}
+
+/**
+ * Redirect URI for an app connection. One per app slug, shared by every connection method
+ * the app exposes (e.g. `gog-calendar`'s personal and workspace defs both land here).
+ */
+export function appOAuthCallbackUrl(appSlug: string, callbackBaseUrl?: string | null): string {
+  return `${oauthCallbackBase(callbackBaseUrl)}/api/apps/${appSlug}/oauth2/callback`
+}

--- a/packages/lib/src/connections/own-client-gate.ts
+++ b/packages/lib/src/connections/own-client-gate.ts
@@ -1,0 +1,94 @@
+// packages/lib/src/connections/own-client-gate.ts
+// Org-aware wrapper around `resolveOwnClientRequirement`. The pure gate in
+// `@auxx/credentials` answers "does this DEFINITION's platform client work?"; this
+// answers "may THIS ORG bring its own OAuth client?" by folding in the
+// `byoOAuthClient` feature. Every surface that renders or enforces the BYO choice
+// resolves it here so the dialog, the provider list, and the authorize route agree.
+
+import { resolveOwnClientRequirement } from '@auxx/credentials/connections'
+import { FeaturePermissionService } from '../permissions/feature-permission-service'
+import { FeatureKey } from '../permissions/types'
+
+/**
+ * Why a connection is offering (or demanding) its own OAuth client.
+ *
+ * - `no-platform-client` — the def has no platform client at all; BYO is mandatory.
+ * - `pending-approval` — a platform client exists but its app is not yet verified;
+ *   BYO is offered alongside it, and the surface warns about the provider's
+ *   unverified-app screen.
+ * - `byo-entitled` — the platform client is fine and verified; BYO is offered purely
+ *   because the org holds `FeatureKey.byoOAuthClient`. No unverified-app warning.
+ */
+export type OwnClientReason = 'no-platform-client' | 'pending-approval' | 'byo-entitled' | null
+
+export interface OwnClientGate {
+  /** BYO client id/secret are mandatory — there is no usable platform client. */
+  requiresOwnClient: boolean
+  /** BYO is offered as an alternative to the platform client, but not required. */
+  ownClientOptional: boolean
+  reason: OwnClientReason
+}
+
+/** The definition columns the gate reads. */
+export interface OwnClientGateDefinition {
+  oauth2ClientId: string | null
+  oauth2ClientSecret: string | null
+  platformClientApproved: boolean
+}
+
+/** A gate that offers nothing — for non-OAuth defs, which have no platform client concept. */
+export const NO_OWN_CLIENT_GATE: OwnClientGate = {
+  requiresOwnClient: false,
+  ownClientOptional: false,
+  reason: null,
+}
+
+/**
+ * Resolve the own-client gate for one organization.
+ *
+ * The verification state decides first and is never overridden: a def with no platform
+ * client still *requires* BYO regardless of the feature (otherwise the org could not
+ * connect at all), and a pending-approval def already offers BYO with the warning copy
+ * the surfaces key off. The feature only adds the third case — a verified platform
+ * client whose org is nonetheless allowed to substitute its own app.
+ *
+ * `hasAccess` reads a missing key as `false`, so an org whose plan row predates this
+ * feature stays on the platform-only flow until the key is granted.
+ */
+export async function resolveOwnClientGateForOrg(
+  organizationId: string,
+  def: OwnClientGateDefinition
+): Promise<OwnClientGate> {
+  const base = resolveOwnClientRequirement(def)
+  if (base.requiresOwnClient || base.ownClientOptional) return base
+
+  const entitled = await new FeaturePermissionService().hasAccess(
+    organizationId,
+    FeatureKey.byoOAuthClient
+  )
+  if (!entitled) return base
+
+  return { requiresOwnClient: false, ownClientOptional: true, reason: 'byo-entitled' }
+}
+
+/**
+ * Drop caller-supplied BYO client credentials when the gate offers no BYO path.
+ *
+ * The connect dialog hides the fields, but the authorize route takes them off the query
+ * string — so without this an org could opt itself into a different OAuth client simply
+ * by appending `var_clientId`/`var_clientSecret`. Values that were already **stored** on
+ * the connection are left alone: revoking the feature must not silently repoint an
+ * existing BYO connection at the platform client mid-reconnect.
+ */
+export function stripUnentitledOwnClientVars(
+  variables: Record<string, string>,
+  gate: OwnClientGate,
+  storedVariables: Record<string, string> = {}
+): Record<string, string> {
+  if (gate.requiresOwnClient || gate.ownClientOptional) return variables
+  const out = { ...variables }
+  for (const key of ['clientId', 'clientSecret']) {
+    if (out[key] && !storedVariables[key]) delete out[key]
+  }
+  return out
+}

--- a/packages/lib/src/permissions/types.ts
+++ b/packages/lib/src/permissions/types.ts
@@ -56,6 +56,13 @@ export enum FeatureKey {
    * account. Absent MUST be read as `false` — see `plans/google-limited-use-provider-gate.md`.
    */
   unrestrictedAiProviders = 'unrestrictedAiProviders',
+  /**
+   * Offer the "use your own OAuth client" option on OAuth2 connect surfaces even when
+   * the platform client is verified. Not a purchasable feature: `false` on every plan
+   * tier, granted per-org. Absent MUST read as `false` — see
+   * `plans/allow-platform-and-byo-oauth-client.md`.
+   */
+  byoOAuthClient = 'byoOAuthClient',
 
   // ── Static limits (count of things, not time-based) ──
   teammates = 'teammates',
@@ -240,6 +247,17 @@ export const FEATURE_REGISTRY: FeatureMetadata[] = [
     description:
       'Allow AI providers whose terms permit training on submitted data. Off for every plan; enable only for organizations with no connected Google account.',
     group: 'AI',
+  },
+  {
+    key: FeatureKey.byoOAuthClient,
+    type: 'boolean',
+    // Ops control, not a plan feature. OFF everywhere by default; granted per-org so a
+    // customer can point a channel at their own Google/Microsoft OAuth app. Kept off by
+    // default so an OAuth reviewer driving the product only ever sees the platform flow.
+    label: 'Own OAuth Client',
+    description:
+      'Let this organization connect OAuth channels with its own OAuth client id/secret instead of the platform client. Off for every plan; enable per organization.',
+    group: 'Integrations',
   },
 
   // ── Static limits ──

--- a/packages/seed/src/domains/billing.domain.ts
+++ b/packages/seed/src/domains/billing.domain.ts
@@ -140,6 +140,12 @@ const STATIC_LIMITS = {
  * purchasable. Do not promote it to a paid tier, and do not read it through a helper that
  * treats a missing key as permitted: the read site inverts the usual default so that
  * absent means restricted. See `plans/google-limited-use-provider-gate.md`.
+ *
+ * `byoOAuthClient` is the same shape: an ops control, `false` on every tier, granted
+ * per-org. It offers the "use your own OAuth client" path on OAuth2 connect surfaces
+ * even once the platform client is verified. Default-off rather than default-on so an
+ * OAuth reviewer driving the product — in whatever org they happen to create — only ever
+ * sees the platform flow. See `plans/allow-platform-and-byo-oauth-client.md`.
  */
 const BOOLEAN_GATES = {
   demo: {
@@ -181,6 +187,9 @@ const BOOLEAN_GATES = {
     // Google Workspace Limited Use gate. OFF on every tier by design — see the note
     // above `BOOLEAN_GATES`. Flip per-org only for an org with no Google connection.
     unrestrictedAiProviders: false,
+    // Own-OAuth-client offer. OFF on every tier by design — see the note above
+    // `BOOLEAN_GATES`. Granted per-org for customers who bring their own OAuth app.
+    byoOAuthClient: false,
   },
   free: {
     knowledgeBase: true,
@@ -207,6 +216,9 @@ const BOOLEAN_GATES = {
     sequences: false,
     granularPermissions: false,
     unrestrictedAiProviders: false,
+    // Own-OAuth-client offer. OFF on every tier by design — see the note above
+    // `BOOLEAN_GATES`. Granted per-org for customers who bring their own OAuth app.
+    byoOAuthClient: false,
   },
   starter: {
     knowledgeBase: true,
@@ -234,6 +246,9 @@ const BOOLEAN_GATES = {
     sequences: true,
     granularPermissions: false,
     unrestrictedAiProviders: false,
+    // Own-OAuth-client offer. OFF on every tier by design — see the note above
+    // `BOOLEAN_GATES`. Granted per-org for customers who bring their own OAuth app.
+    byoOAuthClient: false,
   },
   growth: {
     knowledgeBase: true,
@@ -260,6 +275,9 @@ const BOOLEAN_GATES = {
     sequences: true,
     granularPermissions: true,
     unrestrictedAiProviders: false,
+    // Own-OAuth-client offer. OFF on every tier by design — see the note above
+    // `BOOLEAN_GATES`. Granted per-org for customers who bring their own OAuth app.
+    byoOAuthClient: false,
   },
   enterprise: {
     knowledgeBase: true,
@@ -286,6 +304,9 @@ const BOOLEAN_GATES = {
     sequences: true,
     granularPermissions: true,
     unrestrictedAiProviders: false,
+    // Own-OAuth-client offer. OFF on every tier by design — see the note above
+    // `BOOLEAN_GATES`. Granted per-org for customers who bring their own OAuth app.
+    byoOAuthClient: false,
   },
 } as const
 


### PR DESCRIPTION
## Why

The bring-your-own-OAuth-client option was only reachable by setting a definition's `platformClientApproved = false`. That flag means "our platform app is not verified yet" — it renders the unverified-app warning and applies to **every** org. So a customer who wanted to point a Gmail channel or an app at their own OAuth client could only get there if we un-approved that client for everyone.

`FeatureKey.byoOAuthClient` splits the two concerns.

## The gate

`resolveOwnClientGateForOrg` wraps the pure `resolveOwnClientRequirement` (which stays org-free in `@auxx/credentials`). Verification state decides first and is never overridden:

| def state | feature | gate | reason |
|---|---|---|---|
| no platform client | *not read* | `requiresOwnClient` | `no-platform-client` |
| pending approval | *not read* | `ownClientOptional` | `pending-approval` |
| verified | off | neither — one-click platform | `null` |
| verified | **on** | `ownClientOptional` | **`byo-entitled`** |

The feature can only ever *add* the option, so it cannot un-require BYO on a client-less def (that org could not connect at all) and cannot suppress the unverified-app warning. `byo-entitled` is a new reason value; the surfaces branch on it to show neutral copy instead of the pending-verification text.

## Default off, granted per-org

`false` on every plan tier, same shape as `unrestrictedAiProviders` — an ops control, not a purchasable feature. Grant it at **/admin/organizations/[id] → Features → Own OAuth Client**; that writes `customFeatureLimits` and fires `plan.changed`, so it takes effect immediately. The toggle renders itself from `FEATURE_REGISTRY`, so no admin UI change was needed.

Default-off rather than default-on specifically because of OAuth review: a reviewer signs in wherever they like, so "on for everyone, off for the one review org" only holds while they stay in the org we hand them. And a BYO-client demo recording gets a verification submission rejected.

## Migrations

**No schema migration and no data migration.** `hasAccess` reads a missing boolean as `false`, which is exactly the intended default, so plan rows that predate this are already correct. (The usual "billing.domain.ts is only a seeder" trap is about *numeric* limits, which fail open through `requireLimit`; booleans fail closed.)

**One cache version bump, and it is load-bearing.** `installedApps` goes `v6 → v7`. The blob's `methods[]` dropped the baked gate for the raw variables plus the three gate inputs. A v6 blob has no `oauth2ClientId`/`platformClientApproved`, so the new read-time gate would read it as "no platform client" and demand BYO credentials for **every installed app** until the 900s TTL expired. The bump is what makes this deploy safe.

## Why apps gate at read

`installed-apps-provider` is a cache-**compute** path, which must not read the org cache — and `plan.changed` invalidates `features` but not `installedApps`, so a baked org-dependent gate would go stale the moment the feature was granted. The blob now carries the raw truth and `apps.listInstalled` gates on the way out. Same shape the limited-use provider gate uses. Rejected the alternative (bake it, add `installedApps` to the three plan events) because it recomputes a multi-join projection on every plan change and still has compute reading the cache.

## Server-side enforcement

`stripUnentitledOwnClientVars` drops caller-supplied `var_clientId` / `var_clientSecret` when the gate offers no BYO path, in both the provider and app authorize routes — hiding the fields in the dialog is not the only thing between an org and a different OAuth client. Values already **stored** on a connection survive, so revoking the feature never silently repoints a live BYO connection at the platform client mid-reconnect. The callback routes need no change: they read the variables the authorize route wrote to Redis.

## Redirect URI

A BYO user must register our callback URL in *their* provider app. Nothing said so, and without it every BYO connect dies at the provider with an opaque `redirect_uri_mismatch`. `OwnClientCallbackNotice` shows it with a copy button inside the BYO section only.

One builder (`oauth-callback-url.ts`) now produces the URI for all four OAuth routes and the UI, replacing four copies of `OAUTH_REDIRECT_BASE`. The path segment is pinned to `providerKey ?? id` rather than the raw route param — the provider route resolves its param as *either* spelling and echoed it straight back, so the redirect URI depended on which one the caller used. Survivable with the platform client (register both); fatal for BYO, where the user registers exactly one string.

## Two latent bugs fixed

`connection-targets.ts`'s `appTarget` and `app-account-picker.tsx` both dropped the gate fields when building a connect target, so the BYO disclosure could not render through the connections gallery or the account picker even with the gate open. Invisible today only because app defs all carry `connectionVariables: []`.

## Not covered

`pickDef`'s fallback to `target.connectionDefinitions[scope]` still resolves an ungated definition for a single-method caller passing no `definitionId`. Every current caller passes one or has methods, so it is latent.

## Second commit

`refactor(web): share the client-side URL helpers` — extracts `getBaseUrl` out of `vanilla.ts` unchanged and adds `getWebappUrl`, which reads the server-resolved `appUrl` from the dehydrated state. Independent of the feature; grouped here because it is the same underlying fact (config URL constants collapse to localhost in a browser bundle) that forced the callback URL to be server-built.

## Verification

- `own-client-gate.test.ts` — 12 tests: the four gate cases, that the feature is not read when the def already decides, the four strip behaviours, and callback-URL construction including segment pinning
- `packages/lib` `src/connections` + `src/cache`: 123 passing
- `packages/lib/src`, `apps/api`, `packages/seed` typecheck clean; `apps/web` typecheck has no errors in any touched file
- Biome clean

Manual check worth doing on a preview: grant the feature to one org, confirm an approved app (e.g. GitHub) shows platform-primary plus the advanced disclosure with the right redirect URI, and that an unentitled org still connects one-click and ignores a hand-appended `var_clientId`.
