### PR TITLE
fix(files): resolve avatar thumbnails at save time and harden file downloads

### DIFF
--- a/apps/web/src/app/(public)/quote/[token]/pdf/route.ts
+++ b/apps/web/src/app/(public)/quote/[token]/pdf/route.ts
@@ -1,5 +1,6 @@
 // apps/web/src/app/(public)/quote/[token]/pdf/route.ts
 
+import { encodeContentDisposition } from '@auxx/lib/files/server'
 import { getQuotePdfByToken } from '@auxx/lib/money'
 import { NextResponse } from 'next/server'
 
@@ -19,7 +20,9 @@ export async function GET(_request: Request, { params }: { params: Promise<{ tok
   return new NextResponse(new Uint8Array(result.buffer), {
     headers: {
       'Content-Type': result.contentType,
-      'Content-Disposition': `attachment; filename="${result.filename}"`,
+      // A quote filename carries the customer/quote name — one non-Latin-1
+      // character in it would throw on Response construction. See RFC 6266.
+      'Content-Disposition': encodeContentDisposition('attachment', result.filename),
       'Content-Length': result.buffer.length.toString(),
     },
   })

--- a/apps/web/src/app/api/files/download/[fileId]/route.ts
+++ b/apps/web/src/app/api/files/download/[fileId]/route.ts
@@ -105,6 +105,46 @@ async function resolveFile(
   return { content, name: file.name, mimeType: file.mimeType, size: file.size }
 }
 
+/** Media the browser paints in place rather than saving to disk. */
+const INLINE_MIME_PREFIXES = ['image/', 'video/', 'audio/']
+
+/**
+ * Whether to answer with `Content-Disposition: inline`.
+ *
+ * This route is the ONLY URL the app has for a FILE field's content — every
+ * `<img src>` that shows an attached photo points here (`file-picker`,
+ * `display-file`, `line-photo-popover`, and the stable avatar URL a just-saved
+ * FILE field resolves to). It used to hard-code `inline: false`, so each of those
+ * requests answered `Content-Disposition: attachment`, which no browser paints
+ * into an `<img>`: the request succeeded, logged, and returned bytes, and the
+ * image silently rendered as nothing. For an avatar that meant `AvatarImage`
+ * failing and Radix showing `AvatarFallback` — the record's own icon — which
+ * reads exactly like the upload never happened.
+ *
+ * `video/` and `audio/` join images because the range-request branch in
+ * `createFileDownloadResponse` only means anything to a `<video>`/`<audio>`
+ * element, and those never load from an attachment either.
+ *
+ * Everything else (PDFs, archives, documents) keeps saving to disk, and
+ * `?download=1` forces that for any type. `<a download>` already overrides
+ * disposition for same-origin links, so the existing download buttons are
+ * unaffected either way.
+ *
+ * `image/svg+xml` is the one image type deliberately EXCLUDED. An SVG is an XML
+ * document that can carry `<script>`, and FILE custom fields accept any mime by
+ * default — served inline, an uploaded SVG navigated to directly would execute
+ * with the viewer's session on the app origin (`nosniff` is no help when the
+ * declared type IS svg; `ArticleProcessor` documents the same hazard).
+ * Attachment disposition is what prevented that before this route learned
+ * inline, so SVGs keep it — an inline SVG preview is not worth a stored XSS.
+ */
+function shouldRenderInline(mimeType: string | null, request: NextRequest): boolean {
+  if (request.nextUrl.searchParams.get('download') === '1') return false
+  if (!mimeType) return false
+  if (mimeType === 'image/svg+xml') return false
+  return INLINE_MIME_PREFIXES.some((prefix) => mimeType.startsWith(prefix))
+}
+
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
     const { fileId } = await params
@@ -134,7 +174,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       },
       {
         range: range || undefined,
-        inline: false,
+        inline: shouldRenderInline(resolved.mimeType, request),
       }
     )
 
@@ -148,7 +188,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   }
 }
 
-export async function HEAD(_request: NextRequest, { params }: RouteParams) {
+export async function HEAD(request: NextRequest, { params }: RouteParams) {
   try {
     const { fileId } = await params
 
@@ -164,13 +204,25 @@ export async function HEAD(_request: NextRequest, { params }: RouteParams) {
       return new Response('File not found', { status: 404 })
     }
 
-    return new Response(null, {
-      status: 200,
-      headers: {
-        'Content-Type': resolved.mimeType || 'application/octet-stream',
-        'Content-Length': resolved.size?.toString() || '0',
-        'Content-Disposition': `attachment; filename="${resolved.name}"`,
+    // Same header construction as GET, body omitted. HEAD used to hand-roll its
+    // own headers — hard-coded `attachment`, no `?download=1`, no Accept-Ranges,
+    // no Cache-Control — so a client preflighting with HEAD (a video player
+    // probing range support, a link-preview service checking disposition) was
+    // told the resource is a non-rangeable attachment that the subsequent GET
+    // then serves inline. Per RFC 9110 the two methods must agree.
+    const downloadResponse = createFileDownloadResponse(
+      resolved.content,
+      {
+        name: resolved.name,
+        mimeType: resolved.mimeType,
+        size: resolved.size,
       },
+      { inline: shouldRenderInline(resolved.mimeType, request) }
+    )
+
+    return new Response(null, {
+      status: downloadResponse.status,
+      headers: downloadResponse.headers,
     })
   } catch (error) {
     logger.error('Error checking file:', error)

--- a/apps/web/src/components/fields/displays/display-file.tsx
+++ b/apps/web/src/components/fields/displays/display-file.tsx
@@ -4,8 +4,12 @@ import type { FileValue } from '@auxx/lib/field-values/client'
 import { type FileRef, getFileRefDownloadUrl } from '@auxx/types/file-ref'
 import { Badge } from '@auxx/ui/components/badge'
 import { Skeleton } from '@auxx/ui/components/skeleton'
-import { EyeOff } from 'lucide-react'
+import { EyeOff, Loader2 } from 'lucide-react'
 import { useMemo } from 'react'
+import {
+  type FieldUploadingFile,
+  useFieldUploadingFiles,
+} from '~/components/fields/inputs/hooks/use-field-uploading-files'
 import { FileIcon } from '~/components/files/utils/file-icon'
 import { useFileRefs } from '~/components/resources'
 import { type ItemsListItem, ItemsListView } from '~/components/ui/items-list-view'
@@ -29,7 +33,16 @@ interface DisplayFileItem extends ItemsListItem {
  * ARRAY_RETURN_FIELD_TYPES).
  */
 export function DisplayFile() {
-  const { value } = useFieldContext()
+  const ctx = useFieldContext()
+  const { value, field } = ctx
+  // `DisplayOnlyProvider` carries no record (previews, exports). No record means no
+  // upload session, so the hook is handed an id that can never match one.
+  const recordId = 'recordId' in ctx ? ctx.recordId : ''
+
+  // In-flight uploads render a badge IMMEDIATELY — their names come from the local
+  // `File`, so nothing waits on the value round-trip or on `resolveFileRefs`.
+  // Without this, picking a file showed nothing at all until both had landed.
+  const uploadingFiles = useFieldUploadingFiles(recordId, field?.id ?? '')
 
   // Extract refs + envelope metadata from the multi-value array
   const envelopes = useMemo(() => {
@@ -57,6 +70,9 @@ export function DisplayFile() {
     return (
       <DisplayWrapper>
         <div className='flex flex-wrap gap-1.5'>
+          {uploadingFiles.map((f) => (
+            <UploadingBadge key={f.id} file={f} />
+          ))}
           {refs.map((ref) => (
             <div
               key={ref}
@@ -70,10 +86,29 @@ export function DisplayFile() {
     )
   }
 
-  if (fileItems.length === 0) return null
+  // An upload with no saved value yet still owns a row.
+  if (fileItems.length === 0) {
+    if (uploadingFiles.length === 0) return null
+    return (
+      <DisplayWrapper>
+        <div className='flex flex-wrap gap-1.5'>
+          {uploadingFiles.map((f) => (
+            <UploadingBadge key={f.id} file={f} />
+          ))}
+        </div>
+      </DisplayWrapper>
+    )
+  }
 
   return (
     <DisplayWrapper>
+      {uploadingFiles.length > 0 && (
+        <div className='mb-1.5 flex flex-wrap gap-1.5'>
+          {uploadingFiles.map((f) => (
+            <UploadingBadge key={f.id} file={f} />
+          ))}
+        </div>
+      )}
       <ItemsListView
         items={fileItems}
         renderItem={(itemValue) => {
@@ -127,5 +162,25 @@ function PhotoThumbnail({ item }: { item: DisplayFileItem }) {
         <span className='truncate text-[11px] text-muted-foreground'>{item.caption}</span>
       )}
     </div>
+  )
+}
+
+/**
+ * The badge an upload owns while it is still in flight.
+ *
+ * Deliberately the same pill shape a saved file gets, so the row does not reflow
+ * when the real item replaces it — only the spinner and the muted name change.
+ */
+function UploadingBadge({ file }: { file: FieldUploadingFile }) {
+  return (
+    <Badge variant='pill' shape='tag' className='flex items-center gap-1.5' title={file.name}>
+      <Loader2 className='size-3 shrink-0 animate-spin text-muted-foreground' />
+      <span className='max-w-32 truncate text-muted-foreground'>{file.name}</span>
+      {file.progress > 0 && file.progress < 100 && (
+        <span className='tabular-nums text-[10px] text-muted-foreground'>
+          {Math.round(file.progress)}%
+        </span>
+      )}
+    </Badge>
   )
 }

--- a/apps/web/src/components/fields/inputs/hooks/use-field-file-upload.ts
+++ b/apps/web/src/components/fields/inputs/hooks/use-field-file-upload.ts
@@ -13,16 +13,15 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import type { FileOptions } from '~/components/custom-fields/ui/file-options-editor'
 import type { FileState } from '~/components/file-upload/stores'
-import { useUploadStore } from '~/components/file-upload/stores'
+import { isFileInFlight, useUploadStore } from '~/components/file-upload/stores'
 import type { FileItem } from '~/components/files/files-store'
 import { convertHeicFiles } from '~/components/files/utils/convert-heic'
 import { useFileRefs } from '~/components/resources/hooks/use-file-refs'
-import {
-  buildFieldValueKey,
-  useFieldValueStore,
-} from '~/components/resources/store/field-value-store'
+import { useFieldValueStore } from '~/components/resources/store/field-value-store'
+import { getFileRefStoreState } from '~/components/resources/store/file-ref-store'
 import { useRecordStore } from '~/components/resources/store/record-store'
 import { useResourceStore } from '~/components/resources/store/resource-store'
+import { buildCanonicalFieldValueKey } from '~/components/resources/utils/canonicalize-field-ref'
 import { api } from '~/trpc/react'
 import { vanillaApi } from '~/trpc/vanilla'
 
@@ -84,7 +83,10 @@ function initGlobalSubscription() {
       if (files.length === 0) continue
       if (session.uploading) continue
 
-      const allDone = files.every((f) => f.status === 'completed' || f.status === 'failed')
+      // "Done" is any terminal state, cancelled included — one cancelled file in a
+      // multi-pick must not hold the whole session's completion (and the saved
+      // values of its siblings) hostage forever.
+      const allDone = files.every((f) => !isFileInFlight(f.status))
       if (!allDone) continue
       if (session.metadata?.__fieldNotifiedComplete) continue
 
@@ -185,7 +187,7 @@ function scheduleBlobRevoke(blobUrl: string, delayMs = 10_000): void {
 interface ApplyContext {
   recordId: string
   fieldRef: string
-  storeKey: ReturnType<typeof buildFieldValueKey>
+  storeKey: ReturnType<typeof buildCanonicalFieldValueKey>['key']
   allowMultiple: boolean
 }
 
@@ -231,7 +233,8 @@ async function handleUploadCompletion(
   const pendingAvatar = pendingAvatarByKey.get(uploaderId)
 
   if (successFiles.length === 0) {
-    // Upload failed entirely — rollback any optimistic avatar write and clean up.
+    // Upload failed (or was cancelled) entirely — rollback any optimistic avatar
+    // write and clean up.
     if (pendingAvatar) {
       useRecordStore
         .getState()
@@ -243,6 +246,7 @@ async function handleUploadCompletion(
       if (pendingAvatar.blobUrl) scheduleBlobRevoke(pendingAvatar.blobUrl, 0)
       pendingAvatarByKey.delete(uploaderId)
     }
+    useUploadStore.getState().removeFiles(files.map((f) => f.id))
     completionHandlers.delete(uploaderId)
     return
   }
@@ -250,11 +254,31 @@ async function handleUploadCompletion(
   try {
     const filesToApply = handler.allowMultiple ? successFiles : [successFiles[0]!]
     const refs = filesToApply.map((f) => `asset:${f.serverFileId!}`)
+
+    // Seed the ref store with what we ALREADY know, before the value write.
+    //
+    // `resolveFileRefs` would tell us name/mimeType/size — all three of which we
+    // have had in hand since the picker closed. Waiting for it opened a window
+    // where the ref existed but its detail did not, and every surface handled that
+    // window differently: the picker dropped the row, then showed a literal
+    // "Unknown file", then the image; the field row rendered skeletons. Seeding
+    // closes the window to zero, so a file goes from uploading to fully rendered in
+    // one transition, with its actions, and never round-trips for data it owns.
+    getFileRefStoreState().completeBatch(
+      filesToApply.map((f, i) => ({
+        ref: refs[i]!,
+        name: f.name,
+        mimeType: f.mimeType ?? null,
+        size: f.size ?? null,
+      })),
+      refs
+    )
+
     await applyPendingFileRefs(
       {
         recordId: handler.recordId,
         fieldRef: handler.fieldRef,
-        storeKey: handler.storeKey as ReturnType<typeof buildFieldValueKey>,
+        storeKey: handler.storeKey as ReturnType<typeof buildCanonicalFieldValueKey>['key'],
         allowMultiple: handler.allowMultiple,
       },
       refs
@@ -290,6 +314,14 @@ async function handleUploadCompletion(
       description: error instanceof Error ? error.message : 'Unknown error',
     })
   } finally {
+    // Release this pick's settled files from the session. A session lives for
+    // the whole life of its uploader and nothing else empties `fileIds`, so
+    // leaving them meant the NEXT pick's completion collected this pick's
+    // completed files too — and a single-file field applies `successFiles[0]`,
+    // re-saving the OLD ref instead of the newly picked one. The field values
+    // (and the ref-store details backing the badges) are already written by this
+    // point, so nothing still renders from these entries.
+    useUploadStore.getState().removeFiles(files.map((f) => f.id))
     pendingAvatarByKey.delete(uploaderId)
     completionHandlers.delete(uploaderId)
   }
@@ -408,12 +440,18 @@ export function useFieldFileUpload({
   // Deterministic uploaderId — same across mount/unmount cycles
   const uploaderId = `field-upload:${recordId}:${fieldRef}`
 
-  // Pre-compute store key.
-  // `fieldRef` arrives as a plain string (a bare FieldId or an already-scoped
-  // ResourceFieldId); `buildFieldValueKey` re-discriminates it at runtime via
-  // `normalizeFieldRef`, so the brand is only a compile-time marker here.
-  const storeKey = useMemo(
-    () => buildFieldValueKey(recordId as RecordId, fieldRef as FieldReference),
+  // Pre-compute the store key — through the CANONICAL builder, the same one
+  // `useFieldValue` subscribes with.
+  //
+  // `buildFieldValueKey` normalizes the field ref but nothing else. It leaves an
+  // alias definition prefix (`parts:…` rather than the def CUID) and a static-key
+  // or systemAttribute field half exactly as given, so an upload writing through
+  // it landed on a slot no subscriber reads: the drawer header updated (it reads
+  // `avatarUrl` from the record store) while the FILE field row below kept showing
+  // the previous photo until a reload. `buildCanonicalFieldValueKey` rewrites both
+  // halves — that is precisely the disagreement it exists to prevent.
+  const { key: storeKey } = useMemo(
+    () => buildCanonicalFieldValueKey(recordId as RecordId, fieldRef as FieldReference),
     [recordId, fieldRef]
   )
 
@@ -422,13 +460,25 @@ export function useFieldFileUpload({
     initGlobalSubscription()
   }, [])
 
-  // Clean up completion handler on unmount (only if not actively uploading)
+  // Clean up completion handler on unmount — but NEVER while work is outstanding.
+  // Closing the popover mid-upload must leave the handler registered so the field
+  // value still lands, and so reopening reattaches to the same session and shows the
+  // progress already in flight. `session.uploading` alone is too narrow a test: it
+  // only flips inside `startUploadForSession`, so a pick that has been added but not
+  // yet started reads as idle, and unmounting in that window dropped the handler and
+  // silently lost the upload. Ask the files instead of the flag.
   useEffect(() => {
     return () => {
       const state = useUploadStore.getState()
       const sessionId = state.uploaderSessions?.[uploaderId]
       const session = sessionId ? state.sessions[sessionId] : null
-      if (!session?.uploading) {
+      const hasOutstandingWork =
+        session?.uploading ||
+        (session?.fileIds ?? []).some((id) => {
+          const f = state.files[id]
+          return f !== undefined && isFileInFlight(f.status)
+        })
+      if (!hasOutstandingWork) {
         completionHandlers.delete(uploaderId)
       }
     }
@@ -474,28 +524,36 @@ export function useFieldFileUpload({
   // Build display files by joining fileRefs with details
   const displayFiles = useMemo(() => {
     if (fileRefs.length === 0) return []
-    // Nothing resolved yet — render nothing rather than a row of "Unknown file"
-    // placeholders (matches the old `!fileDetails` guard).
-    if (isResolvingRefs && fileDetails.length === 0) return []
 
+    // NOTE: no early return while resolving. Bailing out here blanked the list for
+    // the whole `resolveFileRefs` round-trip, so a file that had just finished
+    // uploading vanished and then reappeared — the "takes time to show the badge"
+    // gap. A ref we hold is a file that exists; render its row immediately and let
+    // the name fill in. The `isResolvingRefs` arm of the filter below already keeps
+    // unresolved rows alive, which is exactly this case.
     const detailMap = new Map(fileDetails.map((d) => [d.ref, d]))
     return (
       fileRefs
+        // Drop refs that resolved to nothing (deleted file, another org), but keep
+        // ones still resolving so a freshly uploaded file doesn't blink out.
+        .filter((fr) => detailMap.has(fr.ref) || isResolvingRefs)
         .map((fr) => {
           const detail = detailMap.get(fr.ref)
           return {
             id: fr.fieldValueId,
             ref: fr.ref as FileRef,
-            name: detail?.name ?? 'Unknown file',
+            // Empty, NOT 'Unknown file'. That sentinel doubled as the drop test
+            // above, so it had to be a real string — and every renderer happily
+            // printed it at the user during the resolve window. The filter is now
+            // an explicit map lookup, freeing the name to say "not known yet" and
+            // letting renderers show a skeleton instead of a scary label.
+            name: detail?.name ?? '',
             mimeType: detail?.mimeType ?? null,
             size: detail?.size ?? null,
             caption: fr.caption,
             internal: fr.internal,
           }
         })
-        // Drop refs that resolved to nothing (deleted file), but keep the ones
-        // still in flight so a freshly uploaded file doesn't blink out.
-        .filter((f) => f.name !== 'Unknown file' || isResolvingRefs)
     )
   }, [fileRefs, fileDetails, isResolvingRefs])
 
@@ -524,7 +582,7 @@ export function useFieldFileUpload({
     const parts: string[] = []
     for (const id of session.fileIds) {
       const f = state.files[id]
-      if (!f || f.status === 'failed') continue
+      if (!f) continue
       // Keep completed files in fingerprint until absorbed
       if (f.status === 'completed') {
         if (f.serverFileId && !absorbedAssetIds.has(f.serverFileId)) {
@@ -532,6 +590,8 @@ export function useFieldFileUpload({
         }
         continue
       }
+      // failed, cancelled and deleting files own no row
+      if (!isFileInFlight(f.status)) continue
       parts.push(`${f.id}:${f.status}:${f.progress ?? 0}`)
     }
     return parts.join('|')
@@ -549,12 +609,11 @@ export function useFieldFileUpload({
       .map((id) => state.files[id])
       .filter((f): f is FileState => f !== undefined)
       .filter((f) => {
-        if (f.status === 'failed') return false
         // Keep completed files visible until displayFiles absorbs them
         if (f.status === 'completed') {
           return f.serverFileId ? !absorbedAssetIds.has(f.serverFileId) : false
         }
-        return true
+        return isFileInFlight(f.status)
       })
       .map(
         (f): UploadingFile => ({
@@ -663,31 +722,71 @@ export function useFieldFileUpload({
           // constraint above (see `convert-heic.ts`).
           const files = isImagesOnly ? await convertHeicFiles(rawFiles) : rawFiles
 
-          // Optimistic avatar preview: show the locally-selected image instantly
-          // via a blob URL. `handleUploadCompletion` swaps to a stable download
-          // URL on server success, or rolls back on failure.
-          if (isAvatarField(recordId, fieldRef) && files[0]) {
-            const blobUrl = URL.createObjectURL(files[0])
-            const { priorAvatarUrl } = optimisticallyWriteAvatar(recordId, blobUrl)
-            pendingAvatarByKey.set(uploaderId, {
-              recordId,
-              priorAvatarUrl,
-              blobUrl,
-            })
-          }
-
           try {
             const storeNow = useUploadStore.getState()
             const addResult = await storeNow.addFilesWithValidation(files, uploaderId, {
               maxFiles: effectiveSlots,
             })
+
+            // A pick that only re-selected files already uploading in this session
+            // is a no-op, not a failure — the in-flight upload's own completion
+            // lands the value. Erroring here rolled back the optimistic avatar and
+            // toasted "Upload failed" over a perfectly healthy upload.
+            if (addResult.addedFileIds.length === 0 && addResult.validationErrors.length === 0) {
+              return
+            }
+
+            // A rejected pick adds nothing, so `startUploadForSession` would be a
+            // silent no-op: nothing throws and the completion sweep never fires.
+            // Fail the pick here instead — same shape as the `catch` below, and the
+            // same contract `useFileUpload` already honours.
+            if (addResult.addedFileIds.length === 0) {
+              throw new Error(
+                addResult.validationErrors[0] ?? 'The selected file could not be added.'
+              )
+            }
+
+            // Some added, some rejected — the upload proceeds, but say what was dropped.
             if (addResult.validationErrors.length > 0) {
-              console.error('[useFieldFileUpload] validation errors:', addResult.validationErrors)
+              toastError({
+                title: 'Some files were skipped',
+                description: addResult.validationErrors.join('; '),
+              })
+            }
+
+            // Re-arm the completion sweep. `__fieldNotifiedComplete` is a one-shot
+            // latch set when a previous pick's completion fired, and the session
+            // lives for the whole life of its uploader — without this reset the
+            // sweep skipped the session forever, so every pick after the first
+            // uploaded fine but never saved its value.
+            useUploadStore.setState((s) => {
+              const sess = s.sessions[sessionId]
+              if (sess?.metadata) sess.metadata.__fieldNotifiedComplete = false
+            })
+
+            // Optimistic avatar preview: show the locally-selected image instantly
+            // via a blob URL. `handleUploadCompletion` swaps to a stable download
+            // URL on server success, or rolls back on failure. Deliberately AFTER
+            // the add — a pick that adds nothing (all duplicates, all rejected)
+            // must not overwrite the pending-avatar state a still-uploading pick
+            // registered under this uploaderId.
+            if (isAvatarField(recordId, fieldRef) && files[0]) {
+              const blobUrl = URL.createObjectURL(files[0])
+              const { priorAvatarUrl } = optimisticallyWriteAvatar(recordId, blobUrl)
+              pendingAvatarByKey.set(uploaderId, {
+                recordId,
+                priorAvatarUrl,
+                blobUrl,
+              })
             }
 
             await storeNow.startUploadForSession(sessionId)
           } catch (err) {
             console.error('[useFieldFileUpload] upload error:', err)
+            toastError({
+              title: 'Upload failed',
+              description: err instanceof Error ? err.message : 'Unknown error',
+            })
             // Upload failed to start — rollback optimistic avatar.
             const pending = pendingAvatarByKey.get(uploaderId)
             if (pending) {

--- a/apps/web/src/components/fields/inputs/hooks/use-field-uploading-files.ts
+++ b/apps/web/src/components/fields/inputs/hooks/use-field-uploading-files.ts
@@ -1,0 +1,130 @@
+// apps/web/src/components/fields/inputs/hooks/use-field-uploading-files.ts
+
+'use client'
+
+import type { RecordId } from '@auxx/lib/resources/client'
+import type { FieldReference } from '@auxx/types/field'
+import type { JsonFieldValue, TypedFieldValue } from '@auxx/types/field-value'
+import { useMemo } from 'react'
+import { isFileInFlight, useUploadStore } from '~/components/file-upload/stores'
+import { useFieldValueStore } from '~/components/resources/store/field-value-store'
+import { buildCanonicalFieldValueKey } from '~/components/resources/utils/canonicalize-field-ref'
+
+/** One in-flight file, in the shape a badge needs. Names come from the local
+ *  `File`, so they are known the instant the picker closes — no server roundtrip. */
+export interface FieldUploadingFile {
+  id: string
+  name: string
+  mimeType: string | null
+  progress: number
+  status: string
+}
+
+/**
+ * In-flight uploads for one record+field, readable from ANY component.
+ *
+ * `useFieldFileUpload` already derives this, but it also registers pickers,
+ * completion handlers and mutations — far too much for a read-only display that
+ * only wants to render a badge. The uploaderId is the same deterministic key, so
+ * both see the same session.
+ *
+ * Exists because the badge used to appear only once the value round-tripped AND
+ * `file.resolveFileRefs` answered for it. Until then an upload in progress showed
+ * nothing at all, so picking a file looked like it had done nothing.
+ *
+ * A `completed` file stays badge-worthy until its `asset:` ref shows up in the
+ * field-value store — the store flips `status: 'completed'` the moment the bytes
+ * land, but the completion handler still has to round-trip `fieldValue.set/add`
+ * before the value the display renders from exists. Dropping the badge on the
+ * status flip made every file blink out for that whole window (sequential adds
+ * make it seconds on multi-file fields) and reappear. This is the read-only twin
+ * of `useFieldFileUpload`'s `absorbedAssetIds` settling logic; the ref-store
+ * details are seeded before the mutation, so once the ref lands the real item
+ * renders in the same frame the badge unmounts.
+ */
+export function useFieldUploadingFiles(
+  recordId: RecordId | string,
+  fieldRef: string
+): FieldUploadingFile[] {
+  const uploaderId = `field-upload:${recordId}:${fieldRef}`
+
+  // Same canonical key `useFieldValue` subscribes with. A display-only context
+  // hands in an empty recordId — no record, no session, no saved values.
+  const storeKey = useMemo(() => {
+    if (!recordId || !fieldRef) return null
+    try {
+      return buildCanonicalFieldValueKey(recordId as RecordId, fieldRef as FieldReference).key
+    } catch {
+      return null
+    }
+  }, [recordId, fieldRef])
+
+  // Refs already saved on the field — a completed upload whose ref is in here has
+  // been absorbed and owns no badge any more. A cheap string fingerprint, same
+  // reasoning as below.
+  const savedRefs = useFieldValueStore((state) => {
+    if (!storeKey) return ''
+    const val = state.values[storeKey]
+    if (!val) return ''
+    const arr = Array.isArray(val) ? (val as TypedFieldValue[]) : [val as TypedFieldValue]
+    return arr
+      .map((tv) => (tv.type === 'json' ? ((tv as JsonFieldValue).value?.ref ?? '') : ''))
+      .filter(Boolean)
+      .join('|')
+  })
+
+  // Subscribe to a cheap string fingerprint, not to object identities — the store
+  // rewrites file objects on every progress tick.
+  const fingerprint = useUploadStore((state) => {
+    const sessionId = state.uploaderSessions?.[uploaderId]
+    if (!sessionId) return ''
+    const session = state.sessions[sessionId]
+    if (!session) return ''
+    const savedRefSet = new Set(savedRefs.split('|'))
+    const parts: string[] = []
+    for (const id of session.fileIds) {
+      const f = state.files[id]
+      if (!f || !ownsBadge(f.status, f.serverFileId, savedRefSet)) continue
+      parts.push(`${f.id}:${f.status}:${Math.round(f.progress ?? 0)}`)
+    }
+    return parts.join('|')
+  })
+
+  return useMemo(() => {
+    if (!fingerprint) return EMPTY
+    const state = useUploadStore.getState()
+    const sessionId = state.uploaderSessions?.[uploaderId]
+    if (!sessionId) return EMPTY
+    const session = state.sessions[sessionId]
+    if (!session) return EMPTY
+    const savedRefSet = new Set(savedRefs.split('|'))
+
+    return session.fileIds
+      .map((id) => state.files[id])
+      .filter(
+        (f): f is NonNullable<typeof f> =>
+          f !== undefined && ownsBadge(f.status, f.serverFileId, savedRefSet)
+      )
+      .map((f) => ({
+        id: f.id,
+        name: f.name,
+        mimeType: f.mimeType ?? null,
+        progress: f.status === 'completed' ? 100 : (f.progress ?? 0),
+        status: f.status,
+      }))
+  }, [fingerprint, savedRefs, uploaderId])
+}
+
+/** Failed/cancelled files vanish; completed ones hold their badge until absorbed. */
+function ownsBadge(
+  status: Parameters<typeof isFileInFlight>[0],
+  serverFileId: string | undefined,
+  savedRefSet: Set<string>
+): boolean {
+  if (status === 'completed') {
+    return !!serverFileId && !savedRefSet.has(`asset:${serverFileId}`)
+  }
+  return isFileInFlight(status)
+}
+
+const EMPTY: FieldUploadingFile[] = []

--- a/apps/web/src/components/file-upload/stores/__tests__/slot-accounting.test.ts
+++ b/apps/web/src/components/file-upload/stores/__tests__/slot-accounting.test.ts
@@ -1,0 +1,207 @@
+// apps/web/src/components/file-upload/stores/__tests__/slot-accounting.test.ts
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useUploadStore } from '../upload-store'
+
+/**
+ * A session is reused for the whole life of its uploader and nothing empties
+ * `fileIds`, so `maxFiles` must be charged against files that are still IN FLIGHT.
+ * Counting every entry made each completed upload consume a slot permanently: a
+ * single-file field accepted exactly one pick per page load and then rejected every
+ * later one with "Maximum 1 files allowed" — while the caller had already absorbed
+ * that file into its own value list, which is what it derives `maxFiles` from.
+ */
+
+/**
+ * `reset()` clears sessions and files but leaves `uploaderSessions`, and
+ * `createSessionWithGuard` reuses whatever that map points at — so every test
+ * mints its own uploader id rather than sharing one.
+ */
+let seq = 0
+function nextUploader(): string {
+  seq += 1
+  return `field-upload:rec_${seq}:fld_1`
+}
+
+function makeFile(name = 'shot.png', type = 'image/png', bytes = 4): File {
+  return new File([new Uint8Array(bytes)], name, { type })
+}
+
+async function createSession(uploaderId: string): Promise<string> {
+  return useUploadStore.getState().createSessionWithGuard(uploaderId, {
+    entityType: 'CUSTOM_FIELD',
+    entityId: 'field-fld_1',
+    behaviorConfig: { allowMultiple: false, autoStart: false },
+  })
+}
+
+/** Drive a file to a terminal state the way the upload pipeline would. */
+function settle(fileId: string, status: 'completed' | 'failed'): void {
+  useUploadStore.getState().updateFileStatus(fileId, status)
+}
+
+function add(files: File[], uploaderId: string, maxFiles: number, sessionId: string) {
+  return useUploadStore.getState().addFilesWithValidation(files, uploaderId, {
+    maxFiles,
+    sessionId,
+  })
+}
+
+describe('maxFiles slot accounting', () => {
+  beforeEach(() => {
+    useUploadStore.getState().reset()
+  })
+
+  it('lets a single-file uploader pick again after the previous upload completed', async () => {
+    const uploader = nextUploader()
+    const sessionId = await createSession(uploader)
+
+    const first = await add([makeFile()], uploader, 1, sessionId)
+    expect(first.addedFileIds).toHaveLength(1)
+    expect(first.validationErrors).toEqual([])
+
+    settle(first.addedFileIds[0]!, 'completed')
+
+    // The session still holds the completed file — that retention is the regression.
+    expect(useUploadStore.getState().sessions[sessionId]!.fileIds).toHaveLength(1)
+
+    const second = await add([makeFile('other.png')], uploader, 1, sessionId)
+    expect(second.validationErrors).toEqual([])
+    expect(second.addedFileIds).toHaveLength(1)
+  })
+
+  it('still refuses a second file while the first is in flight', async () => {
+    const uploader = nextUploader()
+    const sessionId = await createSession(uploader)
+
+    const first = await add([makeFile()], uploader, 1, sessionId)
+    expect(first.addedFileIds).toHaveLength(1)
+
+    // No settle() — the file is still pending, so it owns the only slot.
+    const second = await add([makeFile('other.png')], uploader, 1, sessionId)
+    expect(second.addedFileIds).toEqual([])
+    expect(second.validationErrors).toEqual(['Maximum 1 files allowed'])
+  })
+
+  it('does not charge a cancelled file against the cap', async () => {
+    // `cancelFile` only flips status — the file stays in the session's fileIds,
+    // so an in-flight predicate that misses 'cancelled' eats the slot forever.
+    const uploader = nextUploader()
+    const sessionId = await createSession(uploader)
+
+    const first = await add([makeFile()], uploader, 1, sessionId)
+    useUploadStore.getState().cancelFile(first.addedFileIds[0]!)
+
+    const second = await add([makeFile('other.png')], uploader, 1, sessionId)
+    expect(second.validationErrors).toEqual([])
+    expect(second.addedFileIds).toHaveLength(1)
+  })
+
+  it('reports an in-flight duplicate as skipped, not as a validation error', async () => {
+    const uploader = nextUploader()
+    const sessionId = await createSession(uploader)
+
+    const first = await add([makeFile()], uploader, 2, sessionId)
+    expect(first.addedFileIds).toHaveLength(1)
+
+    // Same name/size/type while the first is still pending — the dedupe drops it,
+    // and callers must be able to tell that apart from a rejected pick.
+    const dupe = await add([makeFile()], uploader, 2, sessionId)
+    expect(dupe.addedFileIds).toEqual([])
+    expect(dupe.validationErrors).toEqual([])
+    expect(dupe.skippedDuplicates).toEqual(['shot.png'])
+  })
+
+  it('does not charge a failed file against the cap', async () => {
+    const uploader = nextUploader()
+    const sessionId = await createSession(uploader)
+
+    const first = await add([makeFile()], uploader, 1, sessionId)
+    settle(first.addedFileIds[0]!, 'failed')
+
+    const retry = await add([makeFile('retry.png')], uploader, 1, sessionId)
+    expect(retry.addedFileIds).toHaveLength(1)
+  })
+
+  it('counts in-flight files across repeated picks on a multi-file uploader', async () => {
+    const uploader = nextUploader()
+    const sessionId = await createSession(uploader)
+
+    const a = await add([makeFile('a.png')], uploader, 2, sessionId)
+    const b = await add([makeFile('b.png')], uploader, 2, sessionId)
+    expect(a.addedFileIds).toHaveLength(1)
+    expect(b.addedFileIds).toHaveLength(1)
+
+    // Two in flight, cap of two — the third is refused.
+    const c = await add([makeFile('c.png')], uploader, 2, sessionId)
+    expect(c.addedFileIds).toEqual([])
+    expect(c.validationErrors).toEqual(['Maximum 2 files allowed'])
+  })
+
+  it('frees the slots again once the in-flight files complete', async () => {
+    const uploader = nextUploader()
+    const sessionId = await createSession(uploader)
+
+    const a = await add([makeFile('a.png')], uploader, 2, sessionId)
+    const b = await add([makeFile('b.png')], uploader, 2, sessionId)
+    settle(a.addedFileIds[0]!, 'completed')
+    settle(b.addedFileIds[0]!, 'completed')
+
+    const c = await add([makeFile('c.png')], uploader, 2, sessionId)
+    expect(c.addedFileIds).toHaveLength(1)
+  })
+})
+
+describe('identical-file dedupe', () => {
+  beforeEach(() => {
+    useUploadStore.getState().reset()
+  })
+
+  it('drops a byte-identical file already in flight in the same session', async () => {
+    const sessionId = await createSession(nextUploader())
+
+    expect(useUploadStore.getState().addFiles([makeFile()], sessionId)).toHaveLength(1)
+    expect(useUploadStore.getState().addFiles([makeFile()], sessionId)).toEqual([])
+  })
+
+  it('accepts the same file again once the first one settled', async () => {
+    const sessionId = await createSession(nextUploader())
+
+    const first = useUploadStore.getState().addFiles([makeFile()], sessionId)
+    settle(first[0]!, 'completed')
+
+    // Re-picking the same image to replace a value is a real upload, not a dupe.
+    expect(useUploadStore.getState().addFiles([makeFile()], sessionId)).toHaveLength(1)
+  })
+
+  it('accepts the same file again after the first one was cancelled', async () => {
+    const sessionId = await createSession(nextUploader())
+
+    const first = useUploadStore.getState().addFiles([makeFile()], sessionId)
+    useUploadStore.getState().cancelFile(first[0]!)
+
+    // Cancelling then re-picking the same image is a fresh upload, not a dupe.
+    expect(useUploadStore.getState().addFiles([makeFile()], sessionId)).toHaveLength(1)
+  })
+
+  it('accepts the same file in a different session', async () => {
+    const sessionA = await createSession(nextUploader())
+    const sessionB = await createSession(nextUploader())
+    expect(sessionA).not.toBe(sessionB)
+
+    expect(useUploadStore.getState().addFiles([makeFile()], sessionA)).toHaveLength(1)
+    // The same image on a second record must not be swallowed.
+    expect(useUploadStore.getState().addFiles([makeFile()], sessionB)).toHaveLength(1)
+  })
+
+  it('does not confuse two different files that share a name', async () => {
+    const sessionId = await createSession(nextUploader())
+
+    expect(
+      useUploadStore.getState().addFiles([makeFile('shot.png', 'image/png', 4)], sessionId)
+    ).toHaveLength(1)
+    expect(
+      useUploadStore.getState().addFiles([makeFile('shot.png', 'image/png', 9)], sessionId)
+    ).toHaveLength(1)
+  })
+})

--- a/apps/web/src/components/file-upload/stores/file-status.ts
+++ b/apps/web/src/components/file-upload/stores/file-status.ts
@@ -1,0 +1,22 @@
+// apps/web/src/components/file-upload/stores/file-status.ts
+
+import type { FileState } from './types'
+
+/**
+ * True while a file still owns work — and therefore a `maxFiles` slot, a dedupe
+ * claim, an uploading badge, and a completion-handler hold.
+ *
+ * One predicate on purpose. Its call sites each hand-rolled
+ * `status !== 'completed' && status !== 'failed'`, which treated `cancelled`
+ * (and `deleting`) as in-flight forever: `cancelFile` only flips status and
+ * never removes the file from its session's `fileIds`, so a single cancelled
+ * upload permanently consumed a `maxFiles: 1` field's only slot, blocked
+ * re-picking the same file via the dedupe, spun the field's uploading badge
+ * indefinitely, and kept the unmount cleanup from ever releasing its
+ * completion handler.
+ */
+export function isFileInFlight(status: FileState['status']): boolean {
+  return (
+    status !== 'completed' && status !== 'failed' && status !== 'cancelled' && status !== 'deleting'
+  )
+}

--- a/apps/web/src/components/file-upload/stores/index.ts
+++ b/apps/web/src/components/file-upload/stores/index.ts
@@ -11,6 +11,8 @@ export {
   calculateQueueStats as getQueueStats,
   validateFile,
 } from '../utils'
+// Shared status predicate
+export { isFileInFlight } from './file-status'
 // Selectors
 export * from './selectors'
 export type { FileSlice } from './slices/file-slice'

--- a/apps/web/src/components/file-upload/stores/slices/file-slice.ts
+++ b/apps/web/src/components/file-upload/stores/slices/file-slice.ts
@@ -4,6 +4,7 @@ import type { EntityType, UploadProgress } from '@auxx/lib/files/types'
 import { getEntityConfig } from '@auxx/lib/files/types'
 import { generateId } from '@auxx/utils/generateId'
 import type { StateCreator } from 'zustand'
+import { isFileInFlight } from '../file-status'
 import type { FileState, UploadStore } from '../types'
 
 export interface FileSlice {
@@ -43,10 +44,28 @@ export const createFileSlice: StateCreator<
       const entityType: EntityType = session?.entityType || 'FILE'
 
       for (const file of files) {
-        // Dedupe by name+size+type
-        const exists = Object.values(state.files).some(
-          (f) => f.name === file.name && f.size === file.size && f.type === file.type
-        )
+        // Dedupe an identical file that is still in flight IN THIS SESSION.
+        //
+        // Deliberately narrow on both axes. It used to scan `state.files` globally —
+        // every file added anywhere on the page — which would silently drop the same
+        // image uploaded to a second record or a second field. And it compared
+        // `f.type` to `file.type`: `FileState.type` is the literal `'file'` (see its
+        // declaration) while `File.type` is a MIME string, so the guard never once
+        // fired. Widening the scope while fixing the comparison would have turned
+        // dead code straight into dropped uploads, so the scope narrows with it.
+        // Terminal entries (completed, failed, cancelled) are skipped too:
+        // re-picking the same image to replace a value — or after cancelling the
+        // first attempt — is a legitimate upload, not a duplicate.
+        const exists = (session?.fileIds ?? []).some((id) => {
+          const f = state.files[id]
+          return (
+            f !== undefined &&
+            isFileInFlight(f.status) &&
+            f.name === file.name &&
+            f.size === file.size &&
+            f.mimeType === file.type
+          )
+        })
         if (exists) continue
 
         const id = generateId()

--- a/apps/web/src/components/file-upload/stores/slices/orchestration-slice.ts
+++ b/apps/web/src/components/file-upload/stores/slices/orchestration-slice.ts
@@ -5,6 +5,7 @@ import { getEntityConfig } from '@auxx/lib/files/types'
 import type { StateCreator } from 'zustand'
 import { validateFile } from '../../utils'
 import { directUpload } from '../../utils/direct-upload'
+import { isFileInFlight } from '../file-status'
 import type { CreateSessionOptions, UploadStore } from '../types'
 
 /**
@@ -54,7 +55,18 @@ export interface OrchestrationSlice {
       allowedMimeTypes?: string[]
       sessionId?: string // Optional sessionId to use
     }
-  ) => Promise<{ addedFileIds: string[]; validationErrors: string[] }>
+  ) => Promise<{
+    addedFileIds: string[]
+    validationErrors: string[]
+    /**
+     * Names of files silently deduped because a byte-identical upload is already
+     * in flight in this session. Not validation failures — nothing is wrong, the
+     * work is simply already happening — but callers need to tell "nothing added
+     * because nothing was needed" apart from "nothing added because everything
+     * was rejected" before treating an empty `addedFileIds` as an error.
+     */
+    skippedDuplicates: string[]
+  }>
   startUpload: () => Promise<BatchUploadResult>
   startUploadForSession: (sessionId: string) => Promise<BatchUploadResult>
   cancelUpload: () => void
@@ -254,6 +266,7 @@ export const createEnhancedOrchestrationSlice: StateCreator<
     const state = get()
     const errors: string[] = []
     const validFileIds: string[] = []
+    const skippedDuplicates: string[] = []
 
     // Get existing pending files for this uploader
     const existingPendingIds = state.pendingFileIds?.[uploaderId] || []
@@ -261,7 +274,21 @@ export const createEnhancedOrchestrationSlice: StateCreator<
 
     // Use provided sessionId or check if session exists for this uploader
     const sessionId = options?.sessionId || state.uploaderSessions?.[uploaderId]
-    const sessionFileCount = sessionId ? state.sessions[sessionId]?.fileIds.length || 0 : 0
+
+    // Only files still in flight consume a slot. A session is reused for the whole
+    // life of its uploader and nothing ever empties `fileIds`, so counting every
+    // entry charged each completed upload against `maxFiles` forever: a single-file
+    // field (`maxFiles: 1`) accepted exactly one pick per page load and rejected
+    // every later one with "Maximum 1 files allowed". Completed files have already
+    // been absorbed into the caller's own value list — which is what the caller
+    // derives `maxFiles` from — so counting them here double-charges the same file.
+    // Failed and cancelled files occupy nothing.
+    const sessionFileCount = sessionId
+      ? (state.sessions[sessionId]?.fileIds ?? []).filter((id) => {
+          const f = state.files[id]
+          return f !== undefined && isFileInFlight(f.status)
+        }).length
+      : 0
 
     const totalExisting = existingCount + sessionFileCount
 
@@ -316,6 +343,12 @@ export const createEnhancedOrchestrationSlice: StateCreator<
       const fileId = get().addFiles([file], sessionId)[0]
       if (fileId) {
         validFileIds.push(fileId)
+      } else {
+        // `addFiles` adds nothing only for its in-session duplicate dedupe (see
+        // file-slice) — the identical file is already uploading here. Report it
+        // separately from validation errors so callers don't turn a healthy
+        // in-flight upload into an "Upload failed" toast.
+        skippedDuplicates.push(file.name)
       }
     }
 
@@ -350,7 +383,7 @@ export const createEnhancedOrchestrationSlice: StateCreator<
       }
     }
 
-    return { addedFileIds: validFileIds, validationErrors: errors }
+    return { addedFileIds: validFileIds, validationErrors: errors, skippedDuplicates }
   },
 
   /**

--- a/apps/web/src/components/file-upload/stores/types.ts
+++ b/apps/web/src/components/file-upload/stores/types.ts
@@ -231,7 +231,13 @@ export interface UploadActions {
       /** Session to attach the files to; falls back to the uploader's session. */
       sessionId?: string
     }
-  ) => Promise<{ addedFileIds: string[]; validationErrors: string[] }>
+  ) => Promise<{
+    addedFileIds: string[]
+    validationErrors: string[]
+    /** Files silently deduped because an identical upload is already in flight —
+     *  not failures; see the orchestration slice. */
+    skippedDuplicates: string[]
+  }>
   startUpload: () => Promise<BatchUploadResult>
   startUploadForSession: (sessionId: string) => Promise<BatchUploadResult>
   createSessionWithGuard: (uploaderId: string, options: CreateSessionOptions) => Promise<string>

--- a/apps/web/src/components/icons/ui/visual-icon.tsx
+++ b/apps/web/src/components/icons/ui/visual-icon.tsx
@@ -155,11 +155,16 @@ export function VisualIcon({
   }
 
   if (ref.type === 'url' || ref.type === 'base64') {
-    const fitClass = fit === 'cover' ? 'object-cover' : 'object-contain'
+    // 'cover' means the photo IS the frame content: `data-fit=cover` exempts it
+    // from entityIconVariants' descendant img sizing (which pins imgs to ICON
+    // size so contain-fit logos float centered — at xl that rendered an avatar
+    // photo 20px inside its 40px frame), and `size-full` makes it fill the box.
+    const isCover = fit === 'cover'
+    const fitClass = isCover ? 'object-cover size-full' : 'object-contain'
     if (imageFallback) {
       return (
         <Avatar className={cn(frame, 'overflow-hidden')} {...props}>
-          <AvatarImage src={ref.value} className={fitClass} />
+          <AvatarImage src={ref.value} data-fit={fit} className={fitClass} />
           <AvatarFallback className='size-full'>
             <EntityIcon
               iconId={fallbackIconId ?? ''}
@@ -173,8 +178,8 @@ export function VisualIcon({
       )
     }
     return (
-      <div className={frame} style={style} {...props}>
-        <img src={ref.value} alt='' className={fitClass} draggable={false} />
+      <div className={cn(frame, isCover && 'overflow-hidden')} style={style} {...props}>
+        <img src={ref.value} alt='' data-fit={fit} className={fitClass} draggable={false} />
       </div>
     )
   }

--- a/apps/web/src/components/pickers/file-picker.tsx
+++ b/apps/web/src/components/pickers/file-picker.tsx
@@ -13,6 +13,7 @@ import {
   CommandPlaceholder,
   CommandSeparator,
 } from '@auxx/ui/components/command'
+import { Skeleton } from '@auxx/ui/components/skeleton'
 import { Camera, Download, EyeOff, File, FolderOpen, Pencil, Trash2, Upload } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import type { UploadingFile } from '~/components/fields/inputs/hooks/use-field-file-upload'
@@ -171,9 +172,16 @@ function FileItemRow({
 }: FileItemRowProps) {
   const isUploading = status === 'uploading' || status === 'processing'
   const isImage = !!mimeType?.startsWith('image/') && !!downloadUrl
+  // A ref whose details have not resolved yet. Normally zero-length now that a
+  // finished upload seeds the store from the local File, but a ref arriving from
+  // elsewhere (realtime, another tab) can still land here — show a skeleton rather
+  // than a placeholder word.
+  const isUnresolved = !name
 
   const icon = isImage ? (
     <img src={downloadUrl} alt='' className='size-6 shrink-0 rounded object-cover' loading='lazy' />
+  ) : isUnresolved ? (
+    <Skeleton className='size-4 shrink-0 rounded' />
   ) : (
     <File className='size-4 shrink-0 text-muted-foreground' />
   )
@@ -186,7 +194,11 @@ function FileItemRow({
       <div className='flex min-w-0 flex-1 items-center gap-2'>
         {icon}
         <div className='flex min-w-0 flex-col'>
-          <span className='truncate text-sm'>{name}</span>
+          {isUnresolved ? (
+            <Skeleton className='h-4 w-28 rounded' />
+          ) : (
+            <span className='truncate text-sm'>{name}</span>
+          )}
           {caption && <span className='truncate text-xs text-muted-foreground'>{caption}</span>}
         </div>
         {internal && (

--- a/apps/web/src/components/records/ui/record-identity-header.test.tsx
+++ b/apps/web/src/components/records/ui/record-identity-header.test.tsx
@@ -55,6 +55,8 @@ const h = vi.hoisted(() => ({
    * is derived from. An explicit `null` is "fetched, and genuinely empty".
    */
   values: {} as Record<string, unknown>,
+  /** Whether the field-value fetch is still in flight (drives the skeleton state). */
+  isValueLoading: false,
 }))
 
 // ── data layer ───────────────────────────────────────────────────────────────
@@ -80,7 +82,7 @@ vi.mock('~/components/resources', () => ({
 vi.mock('~/components/resources/hooks/use-field-values', () => ({
   useFieldValue: (_recordId: string, fieldRef: unknown) => ({
     value: fieldRef ? h.values[String(fieldRef)] : undefined,
-    isLoading: false,
+    isLoading: h.isValueLoading,
   }),
 }))
 
@@ -167,6 +169,7 @@ beforeEach(() => {
   h.primaryDisplayFieldId = null
   h.secondaryDisplayFieldId = null
   h.isRecordLoading = false
+  h.isValueLoading = false
   h.values = {}
   h.record = { id: ROW, displayName: null, secondaryDisplayValue: null, createdAt: new Date() }
 })
@@ -409,5 +412,164 @@ describe('RecordIdentityHeader — which editor the field type calls for', () =>
     const firstName = screen.getByLabelText('First Name')
     expect(screen.getByLabelText('Last Name')).toBeInTheDocument()
     expect(container.contains(firstName)).toBe(false)
+  })
+})
+
+// ── layout stability (CLS) ───────────────────────────────────────────────────
+//
+// The header used to step 56 → 72 → 76px as a record loaded, because its five
+// render exits disagreed on box height: the skeletons bypassed the shared box
+// entirely, and the shared box's 28px floor did not bind at the primary line's
+// `text-lg` (a 28px line box plus `DisplayWrapper`'s `py-[2px]` renders 32px).
+//
+// Each line now declares ONE height and every exit renders into it, marked with
+// `data-header-slot`. The assertions below are deliberately per-STATE rather
+// than per-pixel: jsdom computes no layout, so what can be pinned is that every
+// state of a slot emits exactly one box carrying that slot's height class.
+
+/** The settled height of each line — primary is 32px, secondary 28px. */
+const SLOT_HEIGHT = { primary: 'min-h-[32px]', secondary: 'min-h-[28px]' } as const
+
+/** The single box a line renders into, whatever state it is in. */
+function slotBox(container: HTMLElement, slot: keyof typeof SLOT_HEIGHT): Element {
+  const found = [...container.querySelectorAll(`[data-header-slot="${slot}"]`)]
+  expect(found).toHaveLength(1)
+  return found[0]!
+}
+
+function expectSlotHeight(container: HTMLElement, slot: keyof typeof SLOT_HEIGHT) {
+  expect(slotBox(container, slot).className).toContain(SLOT_HEIGHT[slot])
+}
+
+describe('RecordIdentityHeader — every render state of a line is the same height', () => {
+  // The states the primary line passes through on a cold drawer open, in order,
+  // plus the two it can settle into. Before the fix, (a) measured 24px, (b)/(c)
+  // 28px and (d)/(e) 32px.
+  it.each([
+    [
+      'a. skeleton, no configured field and no row value yet',
+      () => {
+        h.isRecordLoading = true
+      },
+    ],
+    [
+      'b. skeleton, configured field whose value is still in flight',
+      () => {
+        givenPrimary(makeField())
+        h.isValueLoading = true
+      },
+    ],
+    [
+      'c. row fallback, shown while the field value is unhydrated',
+      () => {
+        givenPrimary(makeField())
+        h.record = { ...h.record, displayName: 'Ada Lovelace' }
+      },
+    ],
+    [
+      'd. hydrated value',
+      () => {
+        givenPrimary(makeField(), textValue('Acme Corp'))
+      },
+    ],
+    [
+      'e. hydrated and empty, showing the Untitled placeholder',
+      () => {
+        givenPrimary(makeField(), null)
+      },
+    ],
+    [
+      'f. nothing configured and nothing to show — the line is still reserved',
+      () => {
+        h.record = { ...h.record, displayName: null }
+      },
+    ],
+  ])('primary line: %s', (_name, arrange) => {
+    arrange()
+
+    const { container } = render(<RecordIdentityHeader recordId={RECORD_ID} />)
+
+    expectSlotHeight(container, 'primary')
+  })
+
+  it('primary line: read-only renders the same box as the editable one', () => {
+    givenPrimary(makeField(), textValue('Acme Corp'))
+
+    const { container } = render(<RecordIdentityHeader recordId={RECORD_ID} readOnly />)
+
+    expectSlotHeight(container, 'primary')
+  })
+
+  // The one swap a user sees mid-interaction rather than mid-load.
+  it('primary line: opening the inline editor does not change the box', async () => {
+    givenPrimary(makeField(), textValue('Acme Corp'))
+
+    const { container } = render(<RecordIdentityHeader recordId={RECORD_ID} />)
+
+    const before = slotBox(container, 'primary').className
+    await userEvent.click(screen.getByText('Acme Corp'))
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+
+    // Still exactly one box, still the same height class — and the editor's own
+    // container matches it rather than falling back to the 28px floor.
+    expect(slotBox(container, 'primary').className).toBe(before)
+    expect(
+      container.querySelectorAll(`.${CSS.escape(SLOT_HEIGHT.primary)}`).length
+    ).toBeGreaterThan(1)
+  })
+
+  // The secondary line is `text-xs`, where the old 28px floor happened to bind —
+  // its regression was the two `return null` exits, which collapsed the line to
+  // zero and moved the primary line with it.
+  it.each([
+    [
+      'a. skeleton while the record row loads',
+      () => {
+        h.isRecordLoading = true
+      },
+    ],
+    [
+      'b. hydrated and empty, falling back to Created…',
+      () => {
+        const secondary = makeField({ id: SECONDARY_ID, key: 'company', label: 'Company' })
+        h.fields = [secondary]
+        h.secondaryDisplayFieldId = SECONDARY_ID
+        h.values[SECONDARY_ID] = null
+      },
+    ],
+    [
+      'c. hydrated and empty with no Created… to fall back to',
+      () => {
+        const secondary = makeField({ id: SECONDARY_ID, key: 'company', label: 'Company' })
+        h.fields = [secondary]
+        h.secondaryDisplayFieldId = SECONDARY_ID
+        h.values[SECONDARY_ID] = null
+        h.record = { ...h.record, createdAt: null }
+      },
+    ],
+    [
+      'd. no configured field and nothing to show at all',
+      () => {
+        h.record = { ...h.record, secondaryDisplayValue: null, createdAt: null }
+      },
+    ],
+  ])('secondary line: %s', (_name, arrange) => {
+    arrange()
+
+    const { container } = render(<RecordIdentityHeader recordId={RECORD_ID} />)
+
+    expectSlotHeight(container, 'secondary')
+  })
+
+  // The two lines are deliberately NOT the same height — the whole bug was one
+  // shared floor that could only be right for one of them.
+  it('the two lines declare different heights, and neither borrows the other', () => {
+    givenPrimary(makeField(), textValue('Acme Corp'))
+
+    const { container } = render(<RecordIdentityHeader recordId={RECORD_ID} />)
+
+    expect(SLOT_HEIGHT.primary).not.toBe(SLOT_HEIGHT.secondary)
+    expect(slotBox(container, 'primary').className).not.toContain(SLOT_HEIGHT.secondary)
+    expect(slotBox(container, 'secondary').className).not.toContain(SLOT_HEIGHT.primary)
   })
 })

--- a/apps/web/src/components/records/ui/record-identity-header.tsx
+++ b/apps/web/src/components/records/ui/record-identity-header.tsx
@@ -42,13 +42,30 @@ const HEADER_NON_EDITABLE_FIELD_TYPES = new Set<string>([
   FieldType.RICH_TEXT,
 ])
 
+/** The two lines of the header. Each declares its own settled box height. */
+type HeaderSlot = 'primary' | 'secondary'
+
 /**
- * The box every non-editing state renders into. Shared so the four states
- * (row fallback, hydrated value, empty placeholder, read-only) occupy the exact
- * same height and inset as each other AND as the inline editor — swapping
- * between them must never move the heading.
+ * The height a line reserves, in EVERY state.
+ *
+ * These are not round numbers, they are what the *settled* states actually
+ * measure. `DisplayWrapper`'s value slot pads `py-[2px]`, so a hydrated value
+ * — and the inline editor, which mirrors that padding — comes out at
+ * `lineHeight + 4`. At the secondary's `text-xs` that is 20px and a 28px floor
+ * binds; at the primary's `text-lg` the 28px line box renders **32px**, which
+ * OVERSHOOTS a 28px floor. A single shared floor therefore let the primary line
+ * settle 4px taller than its own static states, and a bare skeleton was shorter
+ * still — that disagreement is what stepped the header 56 → 72 → 76px as a
+ * record loaded. Declaring the real settled height per slot makes the floor
+ * bind at both font sizes.
  */
-const STATIC_VALUE_BOX = 'truncate min-w-0 px-1 min-h-[28px] flex items-center'
+const SLOT_MIN_HEIGHT: Record<HeaderSlot, string> = {
+  primary: 'min-h-[32px]',
+  secondary: 'min-h-[28px]',
+}
+
+/** Inset and truncation shared by every state's box; the height comes from the slot. */
+const VALUE_BOX_BASE = 'truncate min-w-0 px-1 flex items-center'
 
 /**
  * A stronger hover tint than a field row gets, scoped to this header.
@@ -64,6 +81,32 @@ const HEADER_HOVER_TINT = cn(
   '[&:hover_[data-slot=field-display-hover]]:!bg-primary-100',
   'dark:[&:hover_[data-slot=field-display-hover]]:!bg-foreground/12'
 )
+
+/**
+ * The box EVERY render state of a line goes into: skeleton, row fallback,
+ * hydrated value, empty placeholder, empty-fallback text, read-only, absent
+ * value, and the inline editor (which reuses `SLOT_MIN_HEIGHT` directly, since
+ * it needs a different base). They all occupy the identical height and inset,
+ * so nothing moves as the record hydrates or as the editor opens and closes.
+ *
+ * `data-header-slot` is the marker the height invariant is asserted on — every
+ * state must emit exactly one per line.
+ */
+function ValueBox({
+  slot,
+  className,
+  children,
+}: {
+  slot: HeaderSlot
+  className?: string
+  children?: ReactNode
+}) {
+  return (
+    <div data-header-slot={slot} className={cn(VALUE_BOX_BASE, SLOT_MIN_HEIGHT[slot], className)}>
+      {children}
+    </div>
+  )
+}
 
 /** Fold the header's own denylist into the field's existing read-only answer. */
 function applyHeaderEditability(field: PanelField | null): PanelField | null {
@@ -205,7 +248,7 @@ export function RecordIdentityHeader({
 }
 
 interface HeaderValueProps {
-  slot: 'primary' | 'secondary'
+  slot: HeaderSlot
   recordId: RecordId
   /** Null when the resource configures no display field for this slot. */
   field: PanelField | null
@@ -252,10 +295,22 @@ function HeaderValue({
   unregisterClose,
 }: HeaderValueProps) {
   if (!field) {
-    if (isRecordLoading && !fallback) return <Skeleton className={skeletonClassName} />
-    const text = fallback || placeholder
-    if (!text) return null
-    return <div className={cn('truncate min-w-0', className)}>{text}</div>
+    if (isRecordLoading && !fallback) {
+      return (
+        <ValueBox slot={slot}>
+          <Skeleton className={skeletonClassName} />
+        </ValueBox>
+      )
+    }
+    // An unconfigured slot with nothing to say still reserves its line. A line
+    // that collapses to nothing is the same layout shift as one that grows, and
+    // this is the state a record sits in for the whole window before the row
+    // lands.
+    return (
+      <ValueBox slot={slot} className={className}>
+        {fallback || placeholder}
+      </ValueBox>
+    )
   }
 
   return (
@@ -270,6 +325,7 @@ function HeaderValue({
       registerClose={registerClose}
       unregisterClose={unregisterClose}>
       <HeaderValueInner
+        slot={slot}
         fallback={fallback}
         useFallback={useFallback}
         emptyFallback={emptyFallback}
@@ -327,6 +383,7 @@ function HeaderMultiValue({
  * skeleton, empty, value) and mounts the editor the field type calls for.
  */
 function HeaderValueInner({
+  slot,
   fallback,
   useFallback,
   emptyFallback,
@@ -335,6 +392,7 @@ function HeaderValueInner({
   editorClassName,
   skeletonClassName,
 }: {
+  slot: HeaderSlot
   fallback: string | null
   useFallback: boolean
   emptyFallback: string | null
@@ -365,17 +423,35 @@ function HeaderValueInner({
   // so the header never flashes a placeholder on open. Not interactive in this
   // window — opening an editor over an unfetched value risks committing a blank.
   if (useFallback && fallback) {
-    return <div className={cn(STATIC_VALUE_BOX, className)}>{fallback}</div>
+    return (
+      <ValueBox slot={slot} className={className}>
+        {fallback}
+      </ValueBox>
+    )
   }
 
-  if (isLoading) return <Skeleton className={skeletonClassName} />
+  // The skeleton goes in the same box as everything else and keeps only its
+  // WIDTH from `skeletonClassName` — restating a height on it is how it ended up
+  // shorter than every state that replaces it.
+  if (isLoading) {
+    return (
+      <ValueBox slot={slot}>
+        <Skeleton className={skeletonClassName} />
+      </ValueBox>
+    )
+  }
 
   const isEmpty = isValueEmpty(value, field.fieldType)
 
-  // Hydrated and empty, with nothing worth offering as an edit target.
+  // Hydrated and empty, with nothing worth offering as an edit target. Still an
+  // occupied line: the secondary slot passes `placeholder=''`, so it lands here
+  // whenever its value is blank, and collapsing would move the row.
   if (isEmpty && !placeholder) {
-    if (!emptyFallback) return null
-    return <div className={cn(STATIC_VALUE_BOX, className)}>{emptyFallback}</div>
+    return (
+      <ValueBox slot={slot} className={className}>
+        {emptyFallback}
+      </ValueBox>
+    )
   }
 
   // Multi-value fields (options.multi) compress to primary + `+N` in the
@@ -389,7 +465,10 @@ function HeaderValueInner({
   const content = isEmpty ? (
     <div
       className={cn(
-        'rounded-md px-1 min-h-[28px] flex items-center text-neutral-300 dark:text-foreground/40',
+        'rounded-md px-1 flex items-center text-neutral-300 dark:text-foreground/40',
+        // Same slot height as a real value, so the placeholder's hover tint is
+        // the same size as the one a hydrated value paints.
+        SLOT_MIN_HEIGHT[slot],
         // Mirrors `EmptyField` in the panel: the placeholder IS the edit target,
         // so it has to advertise itself on hover the way a real value does.
         'group-hover/property-row:bg-neutral-200 group-hover/property-row:dark:bg-foreground/12'
@@ -403,7 +482,11 @@ function HeaderValueInner({
   )
 
   if (field.readOnly) {
-    return <div className={cn(STATIC_VALUE_BOX, className)}>{content}</div>
+    return (
+      <ValueBox slot={slot} className={className}>
+        {content}
+      </ValueBox>
+    )
   }
 
   const editMode = getEditModeForFieldType(field.fieldType, field.options)
@@ -414,14 +497,18 @@ function HeaderValueInner({
     <div
       className={cn(
         'group/property-row flex min-w-0 flex-1 cursor-pointer',
+        SLOT_MIN_HEIGHT[slot],
         HEADER_HOVER_TINT,
         className
       )}
       onClick={handleClick}
       onPointerDown={handlePointerDown}
+      data-header-slot={slot}
       data-slot='record-header-value'>
       {editMode === 'inline' ? (
-        <InlineHeaderEditor editorClassName={editorClassName}>{content}</InlineHeaderEditor>
+        <InlineHeaderEditor slot={slot} editorClassName={editorClassName}>
+          {content}
+        </InlineHeaderEditor>
       ) : (
         <FieldInput>{content}</FieldInput>
       )}
@@ -442,9 +529,11 @@ function HeaderValueInner({
  * heading that should fill its column.
  */
 function InlineHeaderEditor({
+  slot,
   children,
   editorClassName,
 }: {
+  slot: HeaderSlot
   children: ReactNode
   editorClassName?: string
 }) {
@@ -492,9 +581,10 @@ function InlineHeaderEditor({
     <div
       ref={containerRef}
       className={cn(
-        // Same box as `STATIC_VALUE_BOX`, so opening the editor swaps the
-        // content without moving it.
-        'flex w-full min-w-0 items-center min-h-[28px] rounded-md bg-background',
+        // Same box height as every other state of this slot, so opening the
+        // editor swaps the content without moving it.
+        'flex w-full min-w-0 items-center rounded-md bg-background',
+        SLOT_MIN_HEIGHT[slot],
         // `ring-1` marks the field as being edited. A ring paints outside the
         // border box, so it adds no height of its own.
         'ring-1 ring-blue-500',
@@ -504,10 +594,10 @@ function InlineHeaderEditor({
         // so normalize both here.
         //
         // `py-[2px]` is not arbitrary: it mirrors `DisplayWrapper`'s value slot
-        // exactly. That padding is what makes the display box `lineHeight + 4`,
-        // which OVERSHOOTS `min-h-[28px]` at heading sizes (text-lg's 28px line
-        // box renders 32px tall). Matching it is what keeps both boxes equal at
-        // every font size, instead of only at the sizes where the floor binds.
+        // exactly. That padding is what makes the display box `lineHeight + 4`
+        // — 32px at the primary's text-lg, which is why `SLOT_MIN_HEIGHT.primary`
+        // is 32 and not 28. Matching it is what keeps both boxes equal at every
+        // font size, instead of only at the sizes where the floor binds.
         '[&_textarea]:!px-1 [&_textarea]:!py-[2px] [&_input]:!px-1 [&_input]:!py-[2px]',
         // NUMBER/CURRENCY render an InputGroup that pins its own height
         // (`h-[27px]`, over a `h-8` default). Let the padded control size it

--- a/packages/lib/src/field-values/__tests__/avatar-interim-url.test.ts
+++ b/packages/lib/src/field-values/__tests__/avatar-interim-url.test.ts
@@ -1,0 +1,70 @@
+// packages/lib/src/field-values/__tests__/avatar-interim-url.test.ts
+
+import { getFileRefDownloadUrl } from '@auxx/types/file-ref'
+import { describe, expect, it } from 'vitest'
+import { DisplayFieldService } from '../display-field-service'
+
+/**
+ * `EntityInstance.avatarUrl` for a FILE avatar field must never be `null` while a
+ * ref exists.
+ *
+ * It used to be: the save path wrote `null` as an "interim" and left the CDN URL to
+ * the thumbnail job. But `ThumbnailService.ensureThumbnail` returns `ready` without
+ * queuing anything when the preset already exists, and the job was the only writer
+ * of `avatarUrl` — so on every re-pick of an already-thumbnailed asset the interim
+ * `null` was permanent and the record sat on its fallback icon. Even in the happy
+ * path it blanked the avatar for the whole generation window.
+ *
+ * The interim is now the app's own download URL, which always resolves. The
+ * thumbnail is an upgrade, not the only source of truth.
+ */
+
+const AVATAR_REF = 'asset:jjqnjnct2fg7vnblseqcqrsb'
+
+/** `computeDisplayValue` is private; these tests exercise it directly by design. */
+function computeAvatar(value: unknown): string | null {
+  const service = new DisplayFieldService('org-1')
+  return (
+    service as unknown as {
+      computeDisplayValue: (v: unknown, f: unknown, t: string, c?: string) => string | null
+    }
+  ).computeDisplayValue(value, { fieldType: 'FILE' }, 'avatar')
+}
+
+function jsonValue(v: Record<string, unknown>) {
+  return { type: 'json' as const, value: v }
+}
+
+describe('avatar display value for a FILE ref', () => {
+  it('resolves an asset ref to the download URL, never null', () => {
+    const result = computeAvatar(jsonValue({ ref: AVATAR_REF }))
+
+    expect(result).toBe(getFileRefDownloadUrl(AVATAR_REF as never))
+    expect(result).toBe(`/api/files/download/${AVATAR_REF}`)
+    expect(result).not.toBeNull()
+  })
+
+  it('resolves the ref when the value arrives as a multi-value array', () => {
+    const result = computeAvatar([jsonValue({ ref: AVATAR_REF })])
+    expect(result).toBe(`/api/files/download/${AVATAR_REF}`)
+  })
+
+  it('still prefers an explicit url over the ref', () => {
+    const result = computeAvatar(jsonValue({ url: 'https://cdn.auxx.ai/a.png', ref: AVATAR_REF }))
+    expect(result).toBe('https://cdn.auxx.ai/a.png')
+  })
+
+  it('leaves a non-asset ref alone', () => {
+    // Only `asset:` refs route through the download URL — a `file:` ref or a
+    // malformed one must not be handed to the avatar as if it resolved.
+    expect(computeAvatar(jsonValue({ ref: 'not-a-ref' }))).toBeNull()
+  })
+
+  it('returns null when there is no value at all', () => {
+    expect(computeAvatar(null)).toBeNull()
+  })
+
+  it('passes a text value through the visual-ref grammar untouched', () => {
+    expect(computeAvatar({ type: 'text', value: 'color:indigo' })).toBe('color:indigo')
+  })
+})

--- a/packages/lib/src/field-values/avatar-thumbnail.ts
+++ b/packages/lib/src/field-values/avatar-thumbnail.ts
@@ -1,0 +1,136 @@
+// packages/lib/src/field-values/avatar-thumbnail.ts
+
+import { type database, schema } from '@auxx/database'
+import { and, eq, inArray, sql } from 'drizzle-orm'
+import { createScopedLogger } from '../logger'
+import { toRecordId } from '../resources/resource-id'
+
+const logger = createScopedLogger('avatar-thumbnail')
+
+/** Minimal db surface these helpers need — `database` or an open transaction. */
+type Db = typeof database
+
+/**
+ * Affected instances plus the resolved CDN URL, carried out of any surrounding
+ * transaction so the realtime publish happens post-commit.
+ */
+export interface AvatarResolution {
+  cdnUrl: string
+  instances: Array<{ entityInstanceId: string; entityDefinitionId: string }>
+}
+
+/**
+ * Point every EntityInstance that uses `assetId` as its avatar at `cdnUrl`.
+ *
+ * Extracted from `generate-thumbnail-job` because the job was the ONLY writer of
+ * `EntityInstance.avatarUrl`, and it only ever runs when a thumbnail was actually
+ * queued. `ThumbnailService.ensureThumbnail` short-circuits with `status: 'ready'`
+ * whenever the asset version already has that preset — no job, therefore no write,
+ * therefore an avatar that stayed on its fallback icon forever. That happened on
+ * every re-pick of an already-thumbnailed asset: browsing to an existing file,
+ * clearing and re-setting the same image, or putting one image on a second record.
+ * The save path now calls this directly for the `ready`/`generated` answers.
+ *
+ * Returns `null` when nothing references the asset — which is also the shape the
+ * job's own lookup produces if it wins the race against the FieldValue write, so
+ * callers must not treat `null` as an error.
+ */
+export async function applyAvatarThumbnailUrl(
+  db: Db,
+  organizationId: string,
+  assetId: string,
+  cdnUrl: string
+): Promise<AvatarResolution | null> {
+  // The ref string FILE field values store.
+  const refValue = `asset:${assetId}`
+
+  // Join path: FieldValue → CustomField → EntityDefinition (avatarFieldId) → instance.
+  const instances = await db
+    .select({
+      entityInstanceId: schema.FieldValue.entityId,
+      entityDefinitionId: schema.EntityDefinition.id,
+    })
+    .from(schema.FieldValue)
+    .innerJoin(schema.CustomField, eq(schema.FieldValue.fieldId, schema.CustomField.id))
+    .innerJoin(
+      schema.EntityDefinition,
+      and(
+        eq(schema.CustomField.entityDefinitionId, schema.EntityDefinition.id),
+        eq(schema.EntityDefinition.avatarFieldId, schema.CustomField.id)
+      )
+    )
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, organizationId),
+        sql`${schema.FieldValue.valueJson}->'v'->>'ref' = ${refValue}`
+      )
+    )
+
+  if (instances.length === 0) return null
+
+  const instanceIds = instances.map((i: { entityInstanceId: string }) => i.entityInstanceId)
+  await db
+    .update(schema.EntityInstance)
+    .set({ avatarUrl: cdnUrl })
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        inArray(schema.EntityInstance.id, instanceIds)
+      )
+    )
+
+  logger.info('Updated entity avatar URLs from thumbnail', {
+    assetId,
+    instanceCount: instanceIds.length,
+  })
+
+  return { cdnUrl, instances }
+}
+
+/**
+ * Publish `record:updated` for each instance whose avatar was resolved.
+ *
+ * Always call this AFTER the transaction commits — publishing inside it risks
+ * announcing state that then rolls back.
+ */
+export async function publishAvatarResolved(params: {
+  organizationId: string
+  cdnUrl: string
+  instances: Array<{ entityInstanceId: string; entityDefinitionId: string }>
+}): Promise<void> {
+  const { organizationId, cdnUrl, instances } = params
+  try {
+    // Lazy — the realtime barrel forms an import cycle that breaks `vi.mock` in
+    // any test that pulls this module in transitively.
+    const { getRealtimeService, rooms } = await import('../realtime')
+    const realtime = getRealtimeService()
+    const updatedAt = new Date().toISOString()
+    await Promise.all(
+      instances.map(({ entityInstanceId, entityDefinitionId }) =>
+        realtime
+          .publish(
+            rooms.orgRecords(organizationId, entityDefinitionId),
+            'record:updated',
+            {
+              entityDefinitionId,
+              record: {
+                id: entityInstanceId,
+                recordId: toRecordId(entityDefinitionId, entityInstanceId),
+                avatarUrl: cdnUrl,
+                updatedAt,
+              },
+            },
+            {}
+          )
+          .catch(() => {})
+      )
+    )
+  } catch (error) {
+    // Never fail the caller over a missed notification — the value is committed,
+    // and the next read picks it up.
+    logger.warn('Failed to publish resolved avatar', {
+      instanceCount: instances.length,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    })
+  }
+}

--- a/packages/lib/src/field-values/display-field-service.ts
+++ b/packages/lib/src/field-values/display-field-service.ts
@@ -3,6 +3,7 @@
 import { type Database, database, schema } from '@auxx/database'
 import type { TypedFieldValue } from '@auxx/types'
 import { toResourceFieldId } from '@auxx/types/field'
+import { type FileRef, getFileRefDownloadUrl } from '@auxx/types/file-ref'
 import type { RecordId } from '@auxx/types/resource'
 import { and, eq } from 'drizzle-orm'
 import { getCachedResource } from '../cache'
@@ -131,6 +132,12 @@ export class DisplayFieldService {
       // 6. Compute display values using properly typed field
       const updates = new Map<string, string | null>()
 
+      // A Set, not an array: one image used as the avatar on many instances is
+      // ONE thumbnail. `resolveAvatarThumbnails` fans out per entry, and each entry
+      // costs two queries inside `ensureThumbnail`, so duplicates were paying that
+      // repeatedly to reach the same already-generated file.
+      const assetIdsToThumbnail = new Set<string>()
+
       // For RELATIONSHIP fields, batch-resolve related displayNames
       if (field.fieldType === 'RELATIONSHIP') {
         const recordIdsByInstance = new Map<string, RecordId>()
@@ -167,7 +174,6 @@ export class DisplayFieldService {
             ? await getOrgCurrencyCode(this.organizationId, this.db)
             : undefined
 
-        const assetIdsToThumbnail: string[] = []
         for (const instanceId of instanceIds) {
           const typedValue = valuesByEntity.get(instanceId) ?? null
           const displayValue = this.computeDisplayValue(
@@ -178,22 +184,23 @@ export class DisplayFieldService {
           )
           updates.set(instanceId, displayValue)
 
-          // Collect asset IDs that need avatar thumbnails during batch recalc
-          if (displayFieldType === 'avatar' && displayValue === null && typedValue) {
+          // Collect asset IDs that need avatar thumbnails during batch recalc.
+          // Keyed on the value being a FILE ref, NOT on `displayValue === null`:
+          // that sentinel disappeared when the interim became a real download URL,
+          // and keying on it would silently stop queueing every thumbnail.
+          if (displayFieldType === 'avatar' && typedValue) {
             const single = Array.isArray(typedValue) ? typedValue[0] : typedValue
             if (single?.type === 'json') {
               const json = single.value as Record<string, unknown>
-              if (typeof json?.ref === 'string') {
+              // `!json.url` keeps the set identical to what the old
+              // `displayValue === null` test collected: a value carrying an explicit
+              // url already has its avatar and needs no thumbnail.
+              if (typeof json?.ref === 'string' && typeof json?.url !== 'string') {
                 const assetId = (json.ref as string).match(/^asset:(.+)$/)?.[1]
-                if (assetId) assetIdsToThumbnail.push(assetId)
+                if (assetId) assetIdsToThumbnail.add(assetId)
               }
             }
           }
-        }
-
-        // Queue avatar thumbnails for FILE field refs (fire-and-forget)
-        if (assetIdsToThumbnail.length > 0) {
-          void this.queueAvatarThumbnails(assetIdsToThumbnail)
         }
       }
 
@@ -206,6 +213,14 @@ export class DisplayFieldService {
 
       if (result.isOk()) updated += result.value.updated
       processed += instanceIds.length
+
+      // 8. Resolve avatar thumbnails for FILE refs (fire-and-forget) — AFTER the
+      // batch write. The resolve pass upgrades `avatarUrl` to the CDN URL when the
+      // thumbnail already exists, so firing it before `batchUpdateDisplayValues`
+      // let the interim download URL overwrite the CDN URL it had just adopted.
+      if (assetIdsToThumbnail.size > 0) {
+        void this.resolveAvatarThumbnails([...assetIdsToThumbnail])
+      }
 
       if (instances.length < BATCH_SIZE) break
     }
@@ -273,8 +288,12 @@ export class DisplayFieldService {
   ): string | null {
     if (!typedValue) return null
 
-    // For avatar fields, extract URL directly or return null for FILE refs
-    // (FILE ref thumbnails are queued separately in the batch recalc loop)
+    // For avatar fields, extract the URL directly, or resolve a FILE ref to the
+    // app's own download URL. That URL always resolves, so it — not `null` — is the
+    // right interim while the CDN thumbnail is generated (and the right permanent
+    // answer if it never is). Returning `null` here blanked the avatar back to the
+    // record's fallback icon for the whole window, which on the `ready` short-circuit
+    // was forever. The recalc loop still queues the thumbnail as an upgrade.
     if (displayFieldType === 'avatar') {
       const single = Array.isArray(typedValue) ? typedValue[0] : typedValue
       if (!single) return null
@@ -285,9 +304,10 @@ export class DisplayFieldService {
       if (single.type === 'json') {
         const json = single.value as Record<string, unknown>
         if (typeof json?.url === 'string') return json.url
-        // FILE field: { ref: "asset:abc123" } — return null as interim
-        // The batch recalc loop handles thumbnail queuing
-        if (typeof json?.ref === 'string' && /^asset:.+/.test(json.ref as string)) return null
+        // FILE field: { ref: "asset:abc123" }
+        if (typeof json?.ref === 'string' && /^asset:.+/.test(json.ref as string)) {
+          return getFileRefDownloadUrl(json.ref as FileRef)
+        }
       }
       return null
     }
@@ -315,25 +335,58 @@ export class DisplayFieldService {
   }
 
   /**
-   * Queue avatar thumbnails for a batch of asset IDs.
-   * Fire-and-forget — the thumbnail job callback updates EntityInstance.avatarUrl.
+   * Ensure avatar thumbnails for a batch of asset IDs, adopting any that already
+   * exist as the referencing instances' `avatarUrl`.
+   *
+   * Queueing alone is not enough: `ensureThumbnail` answers `ready` WITHOUT
+   * queuing a job whenever the `avatar-128` preset already exists, and the job is
+   * the only other writer of `avatarUrl` — so a recalc that merely queued
+   * permanently downgraded every already-resolved CDN avatar to the interim
+   * download URL the batch write had just persisted. `ready`/`generated` answers
+   * have a URL in hand, so this pass writes it (and tells listening clients),
+   * exactly like the single-save path in `field-value-helpers`.
    */
-  private async queueAvatarThumbnails(assetIds: string[]): Promise<void> {
+  private async resolveAvatarThumbnails(assetIds: string[]): Promise<void> {
     try {
       const { ensureThumbnailPresets } = await import('../files/core/thumbnail-batch')
-      await Promise.all(
-        assetIds.map((assetId) =>
-          ensureThumbnailPresets({
-            organizationId: this.organizationId,
-            userId: 'system',
-            source: { type: 'asset', assetId },
-            presets: ['avatar-128'],
-            defaultOptions: { queue: true, visibility: 'PUBLIC' },
-          })
+      const { applyAvatarThumbnailUrl, publishAvatarResolved } = await import('./avatar-thumbnail')
+
+      for (const assetId of assetIds) {
+        const [result] = await ensureThumbnailPresets({
+          organizationId: this.organizationId,
+          userId: 'system',
+          source: { type: 'asset', assetId },
+          presets: ['avatar-128'],
+          defaultOptions: { queue: true, visibility: 'PUBLIC' },
+        })
+
+        // Queued: the job owns the write once it has generated the file.
+        if (!result || result.status === 'queued' || !result.storageLocationId) continue
+
+        const [location] = await this.db
+          .select({ externalUrl: schema.StorageLocation.externalUrl })
+          .from(schema.StorageLocation)
+          .where(eq(schema.StorageLocation.id, result.storageLocationId))
+          .limit(1)
+        const cdnUrl = location?.externalUrl
+        if (!cdnUrl) continue
+
+        const resolved = await applyAvatarThumbnailUrl(
+          this.db,
+          this.organizationId,
+          assetId,
+          cdnUrl
         )
-      )
+        if (resolved) {
+          await publishAvatarResolved({
+            organizationId: this.organizationId,
+            cdnUrl: resolved.cdnUrl,
+            instances: resolved.instances,
+          })
+        }
+      }
     } catch (error) {
-      console.warn('[avatar] Failed to queue batch avatar thumbnails', {
+      console.warn('[avatar] Failed to resolve batch avatar thumbnails', {
         count: assetIds.length,
         error,
       })

--- a/packages/lib/src/field-values/field-value-helpers.ts
+++ b/packages/lib/src/field-values/field-value-helpers.ts
@@ -34,6 +34,7 @@ import {
   mergeMeta,
   readEnvelope,
 } from '@auxx/types/field-value'
+import { type FileRef, getFileRefDownloadUrl } from '@auxx/types/file-ref'
 import { isEntityDefinitionType, type RecordId } from '@auxx/types/resource'
 import type { SystemAttribute } from '@auxx/types/system-attribute'
 import { and, eq, inArray } from 'drizzle-orm'
@@ -1167,13 +1168,31 @@ export async function maybeUpdateDisplayValue(
           if (typeof json?.url === 'string') {
             displayValue = json.url
           } else if (typeof json?.ref === 'string') {
-            // FILE field: { ref: "asset:abc123" } — queue avatar thumbnail
-            const assetId = (json.ref as string).match(/^asset:(.+)$/)?.[1]
+            // FILE field: { ref: "asset:abc123" }.
+            const ref = json.ref as string
+            const assetId = ref.match(/^asset:(.+)$/)?.[1]
             if (assetId) {
-              // Set null interim — thumbnail callback will set the CDN URL
-              displayValue = null
-              // Fire-and-forget: queue thumbnail generation in background
-              void queueAvatarThumbnail(ctx.organizationId, ctx.userId, assetId)
+              // Interim is the app's own download URL, NOT null. The thumbnail is
+              // an optimization — a smaller, CDN-served image — and treating it as
+              // the only source of truth meant every window where it had not landed
+              // (or never would, see `resolveAvatarThumbnailCdnUrl`) blanked the
+              // avatar back to the record's fallback icon. This URL always
+              // resolves, and it is exactly what the client already writes
+              // optimistically, so the server agrees with it instead of
+              // overwriting it with nothing.
+              //
+              // AWAITED, then written once below. If the thumbnail already exists
+              // (`ready` — the steady state for any re-pick of an existing image)
+              // the CDN URL goes straight into the column and the gated interim is
+              // never persisted; only a genuinely queued generation leaves the
+              // interim standing for `generate-thumbnail-job` to upgrade.
+              displayValue = getFileRefDownloadUrl(ref as FileRef)
+              const cdnUrl = await resolveAvatarThumbnailCdnUrl(
+                ctx.organizationId,
+                ctx.userId,
+                assetId
+              )
+              if (cdnUrl) displayValue = cdnUrl
             }
           }
         } else if (singleValue.type === 'text') {
@@ -1280,26 +1299,59 @@ function encodeAvatarRef(field: CachedField, rawText: string): string {
 // =============================================================================
 
 /**
- * Queue avatar thumbnail generation for a FILE field asset.
- * Fire-and-forget — the thumbnail job callback will update EntityInstance.avatarUrl.
+ * Resolve the CDN thumbnail URL for a FILE-field avatar asset, or `null` when
+ * one has to be generated first.
+ *
+ * `ensureThumbnail` answers `status: 'ready'` and queues nothing whenever the
+ * asset version already carries the `avatar-128` preset — the steady state for
+ * every re-pick of an already-thumbnailed asset (browsing to an existing file,
+ * clearing and re-setting the same image, putting one image on a second record).
+ * So the save path must adopt that URL itself; only `queued` defers the
+ * `avatarUrl` write to `generate-thumbnail-job`, which resolves every
+ * referencing instance once the file exists.
+ *
+ * Deliberately AWAITED by the caller, which then writes the returned URL through
+ * its own single `avatarUrl` update — this used to be a fire-and-forget task that
+ * did its own org-wide ref lookup and `EntityInstance` write on the global pool,
+ * which lost the upgrade two separate ways: inside `addValues`' transaction it
+ * could not see the uncommitted FieldValue row (zero matches, and `ready` queues
+ * no retry, so the CDN URL was silently never written), and it started BEFORE
+ * the caller's interim write with no ordering between the two connections, so a
+ * fast answer could be clobbered by the interim it was upgrading. Resolving
+ * first costs the avatar save three indexed reads and buys one write of the
+ * final URL.
  */
-async function queueAvatarThumbnail(
+async function resolveAvatarThumbnailCdnUrl(
   organizationId: string,
   userId: string | undefined,
   assetId: string
-): Promise<void> {
+): Promise<string | null> {
   try {
     const { ensureThumbnailPresets } = await import('../files/core/thumbnail-batch')
-    await ensureThumbnailPresets({
+    const [result] = await ensureThumbnailPresets({
       organizationId,
       userId: userId ?? 'system',
       source: { type: 'asset', assetId },
       presets: ['avatar-128'],
       defaultOptions: { queue: true, visibility: 'PUBLIC' },
     })
+
+    // Queued: the job owns the write once it has generated the file.
+    if (!result || result.status === 'queued' || !result.storageLocationId) return null
+
+    const { database, schema } = await import('@auxx/database')
+    const { eq } = await import('drizzle-orm')
+    const [location] = await database
+      .select({ externalUrl: schema.StorageLocation.externalUrl })
+      .from(schema.StorageLocation)
+      .where(eq(schema.StorageLocation.id, result.storageLocationId))
+      .limit(1)
+
+    return location?.externalUrl ?? null
   } catch (error) {
-    // Non-critical — avatar will show fallback icon until retry
-    console.warn('[avatar] Failed to queue avatar thumbnail', { assetId, error })
+    // Non-critical — the interim download URL keeps rendering the image either way.
+    console.warn('[avatar] Failed to resolve avatar thumbnail', { assetId, error })
+    return null
   }
 }
 

--- a/packages/lib/src/files/__tests__/download-response-filename.test.ts
+++ b/packages/lib/src/files/__tests__/download-response-filename.test.ts
@@ -1,0 +1,106 @@
+// packages/lib/src/files/__tests__/download-response-filename.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { createFileDownloadResponse, encodeContentDisposition } from '../utils/download-response'
+
+/**
+ * HTTP header values are ByteStrings. One code point above U+00FF makes
+ * `new Response(..., { headers })` throw, and the download route's catch turns that
+ * into a bare 500 — so a filename the user never chose could make their own upload
+ * permanently unreachable. macOS is the common case: every screenshot since macOS 13
+ * carries U+202F NARROW NO-BREAK SPACE before AM/PM.
+ */
+
+const MACOS_SCREENSHOT = 'Screenshot 2026-02-09 at 12.55.35 PM.JPEG'
+
+/** The real check — does the header survive Response construction? */
+function headerSurvivesResponse(value: string): boolean {
+  try {
+    new Response('x', { headers: { 'Content-Disposition': value } })
+    return true
+  } catch {
+    return false
+  }
+}
+
+describe('encodeContentDisposition', () => {
+  it('survives a macOS screenshot name (U+202F)', () => {
+    const value = encodeContentDisposition('inline', MACOS_SCREENSHOT)
+
+    expect(headerSurvivesResponse(value)).toBe(true)
+    // The raw interpolation this replaced does NOT — that was the 500.
+    expect(headerSurvivesResponse(`inline; filename="${MACOS_SCREENSHOT}"`)).toBe(false)
+  })
+
+  it('keeps the true name in filename* and an ASCII fallback in filename', () => {
+    const value = encodeContentDisposition('attachment', MACOS_SCREENSHOT)
+
+    expect(value).toContain(`filename*=UTF-8''${encodeURIComponent(MACOS_SCREENSHOT)}`)
+    expect(value).toContain('filename="Screenshot 2026-02-09 at 12.55.35_PM.JPEG"')
+  })
+
+  it.each([
+    ['emoji', 'holiday 🏖️ photo.png'],
+    ['CJK', '請求書.pdf'],
+    ['accents beyond Latin-1', 'Łódź-plan.pdf'],
+    ['curly quotes', '“quoted”.txt'],
+  ])('survives %s', (_label, name) => {
+    expect(headerSurvivesResponse(encodeContentDisposition('inline', name))).toBe(true)
+  })
+
+  it('strips quotes and backslashes so a name cannot inject a parameter', () => {
+    const value = encodeContentDisposition('attachment', 'evil"; download; x="a.txt')
+
+    // Exactly one quoted filename parameter, and no injected `download` token
+    // sitting outside the quotes.
+    expect(value.match(/filename="/g)).toHaveLength(1)
+    expect(value).toBe(
+      `attachment; filename="evil; download; x=a.txt"; filename*=UTF-8''${encodeURIComponent(
+        'evil"; download; x="a.txt'
+      )}`
+    )
+  })
+
+  it('sanitizes an all-non-ASCII name rather than emptying it', () => {
+    // Each replaced code UNIT becomes one underscore, so a surrogate pair yields
+    // two. Ugly but harmless — `filename*` carries the real name, and the fallback
+    // only has to be a legal quoted-string.
+    const value = encodeContentDisposition('inline', '🎉🎉')
+    expect(value).toContain('filename="____"')
+    expect(headerSurvivesResponse(value)).toBe(true)
+  })
+
+  it('falls back to a placeholder only when the name is empty', () => {
+    expect(encodeContentDisposition('inline', '')).toContain('filename="download"')
+  })
+
+  it("percent-encodes RFC 5987 non-attr-chars (!'()*) in filename*", () => {
+    // encodeURIComponent leaves all five bare; `'` is the ext-value delimiter
+    // itself, so strict parsers truncate the parameter at the stray quote.
+    const value = encodeContentDisposition('attachment', "it's report (v2)!*.pdf")
+
+    expect(value).toContain("filename*=UTF-8''it%27s%20report%20%28v2%29%21%2A.pdf")
+    const extValue = value.split("filename*=UTF-8''")[1]!
+    expect(extValue).not.toMatch(/[!'()*]/)
+  })
+})
+
+describe('createFileDownloadResponse disposition', () => {
+  const body = Buffer.from('x')
+
+  it('produces a header a Response accepts, for any filename', () => {
+    const res = createFileDownloadResponse(
+      body,
+      { name: MACOS_SCREENSHOT, mimeType: 'image/jpeg', size: 1 },
+      { inline: true }
+    )
+
+    expect(res.headers['Content-Disposition']).toMatch(/^inline;/)
+    expect(headerSurvivesResponse(res.headers['Content-Disposition']!)).toBe(true)
+  })
+
+  it('still defaults to attachment when inline is not requested', () => {
+    const res = createFileDownloadResponse(body, { name: 'plain.pdf', mimeType: 'application/pdf' })
+    expect(res.headers['Content-Disposition']).toMatch(/^attachment;/)
+  })
+})

--- a/packages/lib/src/files/adapters/s3-adapter.ts
+++ b/packages/lib/src/files/adapters/s3-adapter.ts
@@ -2,6 +2,7 @@
 
 import { Readable } from 'node:stream'
 import { configService } from '@auxx/credentials'
+import { encodeRFC5987ValueChars } from '@auxx/utils'
 import {
   AbortMultipartUploadCommand,
   CompleteMultipartUploadCommand,
@@ -308,7 +309,9 @@ export class S3Adapter extends BaseStorageAdapter {
   ): string {
     const fileName = keyOrFilename.split('/').pop() || 'file'
     const quoted = fileName.replace(/"/g, '')
-    const encoded = encodeURIComponent(fileName)
+    // RFC 5987 ext-value encoding — bare encodeURIComponent leaves !'()* unencoded,
+    // and ' is the ext-value delimiter itself.
+    const encoded = encodeRFC5987ValueChars(fileName)
 
     // Include both filename and filename* for UTF-8 compliance
     return `${disposition}; filename="${quoted}"; filename*=UTF-8''${encoded}`

--- a/packages/lib/src/files/core/thumbnail-batch.ts
+++ b/packages/lib/src/files/core/thumbnail-batch.ts
@@ -25,9 +25,22 @@ export interface EnsureThumbnailPresetsParams {
 /**
  * Enqueue a set of thumbnails. Returns an array of results in preset order.
  */
-export async function ensureThumbnailPresets(
-  params: EnsureThumbnailPresetsParams
-): Promise<Array<{ preset: PresetKey; status: 'queued' | 'ready' | 'generated'; jobId?: string }>> {
+export async function ensureThumbnailPresets(params: EnsureThumbnailPresetsParams): Promise<
+  Array<{
+    preset: PresetKey
+    status: 'queued' | 'ready' | 'generated'
+    jobId?: string
+    /**
+     * Present for `ready`/`generated`. Callers that need the public URL of a
+     * thumbnail that already existed have no job to wait on and no other way to
+     * find it — dropping this is what let an already-thumbnailed avatar strand
+     * on `EntityInstance.avatarUrl = null` forever.
+     */
+    assetId?: string
+    assetVersionId?: string
+    storageLocationId?: string
+  }>
+> {
   const { organizationId, userId, source, presets, defaultOptions, perPreset } = params
   const service = new ThumbnailService(organizationId, userId)
 
@@ -43,7 +56,13 @@ export async function ensureThumbnailPresets(
       if (res.status === 'queued') {
         return { preset, status: 'queued' as const, jobId: res.jobId }
       }
-      return { preset, status: res.status }
+      return {
+        preset,
+        status: res.status,
+        assetId: res.assetId,
+        assetVersionId: res.assetVersionId,
+        storageLocationId: res.storageLocationId,
+      }
     })
   )
 

--- a/packages/lib/src/files/index.ts
+++ b/packages/lib/src/files/index.ts
@@ -173,7 +173,11 @@ export {
 } from './upload/validators'
 
 // Selected utilities re-exported for convenience
-export { createFileDownloadResponse, parseRangeHeader } from './utils'
+export {
+  createFileDownloadResponse,
+  encodeContentDisposition,
+  parseRangeHeader,
+} from './utils'
 
 // ============= FILE TYPE CONSTANTS =============
 

--- a/packages/lib/src/files/server.ts
+++ b/packages/lib/src/files/server.ts
@@ -31,4 +31,8 @@ export { ensureProcessorsInitialized, ProcessorRegistry } from './upload/process
 export { ProgressPublisher } from './upload/progress-publisher'
 // Upload/session orchestration (no image processing)
 export { FileUploadSession, SessionManager } from './upload/session-index'
-export { createFileDownloadResponse, parseRangeHeader } from './utils'
+export {
+  createFileDownloadResponse,
+  encodeContentDisposition,
+  parseRangeHeader,
+} from './utils'

--- a/packages/lib/src/files/utils/download-response.ts
+++ b/packages/lib/src/files/utils/download-response.ts
@@ -5,6 +5,8 @@
  * Shared helpers for creating consistent file download responses across all file types
  */
 
+import { encodeRFC5987ValueChars } from '@auxx/utils'
+
 export interface FileInfo {
   name: string
   mimeType?: string | null
@@ -20,6 +22,31 @@ export interface FileDownloadResponse {
   buffer: Buffer
   status: number
   headers: Record<string, string>
+}
+
+/**
+ * Build an RFC 6266 `Content-Disposition` value that survives any filename.
+ *
+ * HTTP header values are ByteStrings: a single code point above U+00FF makes
+ * `new Response(..., { headers })` throw `TypeError: Cannot convert argument to a
+ * ByteString`, which the route's catch turns into a bare 500. Interpolating the raw
+ * name meant EVERY macOS screenshot was undownloadable — since macOS 13 those names
+ * carry U+202F NARROW NO-BREAK SPACE before AM/PM — along with anything containing
+ * emoji, CJK, curly quotes, or accents outside Latin-1.
+ *
+ * So: a sanitized ASCII `filename` for old clients, plus the real name in
+ * `filename*` as UTF-8 percent-encoding, which every current browser prefers.
+ * Quotes and backslashes are stripped from the fallback rather than escaped — they
+ * are what lets a crafted name break out of the quoted-string and inject a header
+ * parameter. The `filename*` half goes through {@link encodeRFC5987ValueChars},
+ * not bare `encodeURIComponent` — RFC 5987 attr-char excludes `!'()*`, and `'`
+ * is the ext-value delimiter itself.
+ */
+export function encodeContentDisposition(disposition: string, name: string): string {
+  const asciiFallback =
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping controls is the point
+    name.replace(/[^\x20-\x7E]/g, '_').replace(/["\\]/g, '') || 'download'
+  return `${disposition}; filename="${asciiFallback}"; filename*=UTF-8''${encodeRFC5987ValueChars(name)}`
 }
 
 /**
@@ -40,18 +67,21 @@ export function createFileDownloadResponse(
   let status = 200
   const headers: Record<string, string> = {}
 
+  // Advertise range support for streamable media on EVERY response, not only the
+  // 206 — a player probes with a plain GET or HEAD first, and an answer without
+  // `Accept-Ranges` tells it seeking is unavailable.
+  if (supportsRangeRequests(fileInfo.mimeType)) {
+    headers['Accept-Ranges'] = 'bytes'
+  }
+
   // Handle range requests for video/audio streaming
-  if (
-    range &&
-    (fileInfo.mimeType?.startsWith('video/') || fileInfo.mimeType?.startsWith('audio/'))
-  ) {
+  if (range && supportsRangeRequests(fileInfo.mimeType)) {
     const start = range.start
     const end = range.end ?? fileContent.length - 1
 
     buffer = fileContent.subarray(start, end + 1)
     status = 206 // Partial Content
     headers['Content-Range'] = `bytes ${start}-${end}/${fileContent.length}`
-    headers['Accept-Ranges'] = 'bytes'
   }
 
   // Set content headers
@@ -60,7 +90,7 @@ export function createFileDownloadResponse(
 
   // Set disposition (inline for images/videos, attachment for downloads)
   const disposition = inline ? 'inline' : 'attachment'
-  headers['Content-Disposition'] = `${disposition}; filename="${fileInfo.name}"`
+  headers['Content-Disposition'] = encodeContentDisposition(disposition, fileInfo.name)
 
   // Set cache control
   headers['Cache-Control'] = cacheControl

--- a/packages/lib/src/jobs/maintenance/generate-thumbnail-job.ts
+++ b/packages/lib/src/jobs/maintenance/generate-thumbnail-job.ts
@@ -2,8 +2,13 @@
 
 import { database as db, schema } from '@auxx/database'
 import { getRedisClient } from '@auxx/redis'
-import { and, eq, inArray, isNull, sql } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import { z } from 'zod'
+import {
+  type AvatarResolution,
+  applyAvatarThumbnailUrl,
+  publishAvatarResolved,
+} from '../../field-values/avatar-thumbnail'
 import { MediaAssetService } from '../../files/core/media-asset-service'
 import {
   getMimeTypeForFormat,
@@ -19,8 +24,6 @@ import type {
 } from '../../files/core/thumbnail-types'
 import { createStorageManager } from '../../files/storage/storage-manager'
 import { createScopedLogger } from '../../logger'
-import { getRealtimeService, rooms } from '../../realtime'
-import { toRecordId } from '../../resources/resource-id'
 import type { JobContext } from '../types'
 
 /**
@@ -265,7 +268,7 @@ export const generateThumbnailJob = async (ctx: JobContext): Promise<void> => {
     // Post-commit: push the resolved avatar CDN URL to any listening clients.
     if (avatarResolved) {
       await publishAvatarResolved({
-        orgId,
+        organizationId: orgId,
         cdnUrl: avatarResolved.cdnUrl,
         instances: avatarResolved.instances,
       })
@@ -418,24 +421,18 @@ async function updateKBLogoIfApplicable(params: {
 }
 
 /**
- * Affected instances + the resolved CDN URL from an avatar-128 thumbnail run,
- * carried out of the transaction so the realtime publish happens post-commit.
- */
-interface AvatarResolution {
-  cdnUrl: string
-  instances: Array<{ entityInstanceId: string; entityDefinitionId: string }>
-}
-
-/**
  * Updates EntityInstance.avatarUrl when an avatar-128 preset thumbnail is generated.
- * Follows the KB logo callback pattern: looks up which EntityInstances reference
- * the source asset via their avatar field, then sets avatarUrl to the public CDN URL.
  *
- * Returns the affected (instanceId, entityDefinitionId) pairs + cdnUrl so the
- * caller can publish `record:updated` realtime events AFTER the transaction
- * commits — publishing inside the tx risks firing before the DB state is
- * durable, and if the tx rolls back we would have announced a state that
- * was never saved.
+ * The lookup, the write and the realtime publish all live in
+ * `field-values/avatar-thumbnail` because this job is NOT the only path that
+ * resolves an avatar: `ThumbnailService.ensureThumbnail` answers `ready` without
+ * queuing anything when the preset already exists, and the save path has to do the
+ * same write itself in that case. Keeping one implementation is what stops the two
+ * from drifting.
+ *
+ * Returns the affected pairs + cdnUrl so the caller can publish AFTER the
+ * transaction commits — publishing inside it risks firing before the DB state is
+ * durable, and a rollback would have announced state that was never saved.
  */
 async function updateEntityAvatarIfApplicable(params: {
   tx: any
@@ -453,91 +450,5 @@ async function updateEntityAvatarIfApplicable(params: {
   const assetId = sourceVersion.assetId
   if (!assetId) return null
 
-  // Build the ref string that FILE field values store
-  const refValue = `asset:${assetId}`
-
-  // Find EntityInstances whose avatar field value references this asset.
-  // Join path: FieldValue → CustomField → EntityDefinition (avatarFieldId) → EntityInstance
-  const instances = await tx
-    .select({
-      entityInstanceId: schema.FieldValue.entityId,
-      entityDefinitionId: schema.EntityDefinition.id,
-    })
-    .from(schema.FieldValue)
-    .innerJoin(schema.CustomField, eq(schema.FieldValue.fieldId, schema.CustomField.id))
-    .innerJoin(
-      schema.EntityDefinition,
-      and(
-        eq(schema.CustomField.entityDefinitionId, schema.EntityDefinition.id),
-        eq(schema.EntityDefinition.avatarFieldId, schema.CustomField.id)
-      )
-    )
-    .where(
-      and(
-        eq(schema.FieldValue.organizationId, orgId),
-        sql`${schema.FieldValue.valueJson}->'v'->>'ref' = ${refValue}`
-      )
-    )
-
-  if (instances.length === 0) return null
-
-  // Update all matching EntityInstances with the CDN URL
-  const instanceIds = instances.map((i: { entityInstanceId: string }) => i.entityInstanceId)
-  await tx
-    .update(schema.EntityInstance)
-    .set({ avatarUrl: cdnUrl })
-    .where(
-      and(
-        eq(schema.EntityInstance.organizationId, orgId),
-        inArray(schema.EntityInstance.id, instanceIds)
-      )
-    )
-
-  logger.info('Updated entity avatar URLs from thumbnail', {
-    preset,
-    assetId,
-    instanceCount: instanceIds.length,
-  })
-
-  return { cdnUrl, instances }
-}
-
-/**
- * Publish `record:updated` for each EntityInstance whose avatarUrl was
- * resolved by the thumbnail job. Runs after the transaction commits so
- * clients never see an event for state that might still roll back.
- */
-async function publishAvatarResolved(params: {
-  orgId: string
-  cdnUrl: string
-  instances: Array<{ entityInstanceId: string; entityDefinitionId: string }>
-}): Promise<void> {
-  const { orgId, cdnUrl, instances } = params
-  try {
-    const realtime = getRealtimeService()
-    const updatedAt = new Date().toISOString()
-    await Promise.all(
-      instances.map(({ entityInstanceId, entityDefinitionId }) =>
-        realtime
-          .publish(
-            rooms.orgRecords(orgId, entityDefinitionId),
-            'record:updated',
-            {
-              entityDefinitionId,
-              record: {
-                id: entityInstanceId,
-                recordId: toRecordId(entityDefinitionId, entityInstanceId),
-                avatarUrl: cdnUrl,
-                updatedAt,
-              },
-            },
-            {}
-          )
-          .catch(() => {})
-      )
-    )
-  } catch {
-    // non-critical — thumbnail succeeded; the DB state is correct and a
-    // page refresh will surface it even if the push dropped.
-  }
+  return applyAvatarThumbnailUrl(tx, orgId, assetId, cdnUrl)
 }

--- a/packages/ui/src/components/icons.tsx
+++ b/packages/ui/src/components/icons.tsx
@@ -159,11 +159,16 @@ export const entityIconVariants = cva('flex items-center justify-center shrink-0
       bare: 'text-current',
     },
     size: {
-      xs: 'size-4 [&_svg]:size-2.5! [&_img]:size-2.5! [&_>span]:text-[10px]',
-      sm: 'size-5 [&_svg]:size-3.5! [&_img]:size-3.5! [&_>span]:text-[14px]',
-      default: 'size-6 [&_svg]:size-4! [&_img]:size-4! [&_>span]:text-[16px]',
-      lg: 'size-8 [&_svg]:size-4 [&_img]:size-4 [&_>span]:text-[16px]',
-      xl: 'size-10 [&_svg]:size-5 [&_img]:size-5 [&_>span]:text-[20px]',
+      // The `img` rules size a mark FLOATING in the frame (brand/url logos, fit
+      // 'contain'). A cover-fit photo must fill the frame instead — VisualIcon
+      // stamps those `data-fit=cover`, which the :not() exempts; fighting this
+      // with specificity from the outside is not winnable because the small
+      // sizes are `!important`.
+      xs: 'size-4 [&_svg]:size-2.5! [&_img:not([data-fit=cover])]:size-2.5! [&_>span]:text-[10px]',
+      sm: 'size-5 [&_svg]:size-3.5! [&_img:not([data-fit=cover])]:size-3.5! [&_>span]:text-[14px]',
+      default: 'size-6 [&_svg]:size-4! [&_img:not([data-fit=cover])]:size-4! [&_>span]:text-[16px]',
+      lg: 'size-8 [&_svg]:size-4 [&_img:not([data-fit=cover])]:size-4 [&_>span]:text-[16px]',
+      xl: 'size-10 [&_svg]:size-5 [&_img:not([data-fit=cover])]:size-5 [&_>span]:text-[20px]',
     },
   },
   defaultVariants: {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -128,6 +128,7 @@ export {
   encodeBase64WithLineBreaks,
   encodeQuotedPrintable,
   encodeRFC2231Filename,
+  encodeRFC5987ValueChars,
   ensureCRLF,
   foldMimeHeader,
   generateMimeBoundary,

--- a/packages/utils/src/mime.ts
+++ b/packages/utils/src/mime.ts
@@ -25,6 +25,21 @@ export function foldMimeHeader(header: string, maxLength: number = 998): string 
 }
 
 /**
+ * Percent-encode a string for an RFC 5987 `ext-value` (the `filename*` parameter).
+ *
+ * `encodeURIComponent` alone is not enough: it leaves `!`, `'`, `(`, `)` and `*`
+ * bare, none of which are attr-char — and `'` is the ext-value delimiter itself,
+ * so a name like `it's report (v2).pdf` produced a header strict parsers truncate
+ * at the stray quote or reject, falling back to the underscore-mangled ASCII name.
+ */
+export function encodeRFC5987ValueChars(value: string): string {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+  )
+}
+
+/**
  * RFC 2231 compliant filename encoding for MIME headers
  * Handles non-ASCII characters in attachment filenames
  */
@@ -36,7 +51,7 @@ export function encodeRFC2231Filename(filename: string): string {
 
   // Encode using RFC 2231 for non-ASCII
   const asciiSafe = filename.replace(/[^\x20-\x7E]/g, '_')
-  return `filename="${asciiSafe}"; filename*=utf-8''${encodeURIComponent(filename)}`
+  return `filename="${asciiSafe}"; filename*=utf-8''${encodeRFC5987ValueChars(filename)}`
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #1794: renders uploaded avatars/files reliably, then fixes the 10 bugs an adversarial review of the diff confirmed, plus two completion-flow bugs found while fixing.

### Avatar pipeline
- The interim avatar URL is the app's own download route instead of `null`, so an avatar never blanks while (or because) no thumbnail exists.
- The save path now **awaits** the CDN resolution and writes the final URL in its single `avatarUrl` update — this removes the fire-and-forget race (rows invisible inside `addValues`' transaction; the interim write clobbering the CDN write) and the per-save org-wide jsonb scan. Steady-state saves (`ready`) persist the CDN URL directly and never expose the session-gated interim.
- Batch recalc (`DisplayFieldService`) adopts `ready`/`generated` thumbnails **after** the batch write instead of discarding the result — recalculated avatars are no longer permanently stranded on the interim URL.
- `generate-thumbnail-job` and the save path share one `applyAvatarThumbnailUrl`/`publishAvatarResolved` implementation.

### Download route
- `image/*`, `video/*`, `audio/*` render inline; **`image/svg+xml` deliberately keeps `attachment`** — an SVG can carry `<script>`, and serving it inline is stored XSS on the app origin.
- `HEAD` builds its headers through the same path as `GET` (disposition, `?download=1`, `Accept-Ranges`, `Cache-Control`), per RFC 9110.
- `filename*` uses proper RFC 5987 encoding via a shared `encodeRFC5987ValueChars` across all three Content-Disposition builders (download response, MIME headers, S3 adapter).

### Upload UX
- New shared `isFileInFlight` predicate: cancelled/deleting files free their `maxFiles` slot, dedupe claim, uploading badge, and completion hold (previously a cancelled upload consumed a single-file field's slot forever).
- `maxFiles` slot accounting charges only in-flight files; a pick that is entirely in-flight duplicates is a silent no-op instead of an "Upload failed" toast + avatar rollback.
- The completion latch (`__fieldNotifiedComplete`) re-arms per pick and settled files are released from the session — previously every pick after the first uploaded fine but **never saved its value**, and would have re-applied the old ref if it had.
- Field badges persist until the saved ref lands in the field-value store, so files no longer blink out during the mutation round-trip.

### Header avatar
- Cover-fit photos fill their frame: `data-fit=cover` exempts them from `entityIconVariants`' icon-size img constraint (a 40px header frame was rendering the photo at 20px).

## Testing
- New: `slot-accounting.test.ts` (12), `avatar-interim-url.test.ts` (6), `download-response-filename.test.ts` (12)
- Full sweep green: utils (217), lib files+field-values (319), web file-upload/fields/icons/records (261)
- `tsc` clean for every changed file in utils, lib, and web