### PR TITLE
fix(data-connectors): stop the relationship pass rewriting unchanged edges

### DIFF
--- a/packages/lib/src/data-connectors/read-relationship-targets.test.ts
+++ b/packages/lib/src/data-connectors/read-relationship-targets.test.ts
@@ -1,0 +1,113 @@
+// packages/lib/src/data-connectors/read-relationship-targets.test.ts
+// `readRelationshipTargets` (service.ts) — the relationship two-pass's idempotency
+// input (v10 relationship-pass-idempotency, Phase 1).
+//
+// The contract under test is its ASYMMETRY: absence from the returned map always
+// means "the caller must write". Only a cell holding exactly one row with a non-null
+// target is reported as already-correct — a 2+ row cell is a genuine collapse target
+// that `set` would legitimately reduce, so reporting it would silently drop a real
+// write. The db is a chain stub; only the grouping logic is exercised.
+
+import type { Database } from '@auxx/database'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readRelationshipTargets } from './service'
+
+const ORG = 'org_1'
+
+type Row = { entityId: string; fieldId: string; relatedEntityId: string | null }
+
+/**
+ * Chain stub for `db.select({...}).from(...).where(...)` — `where` is the thenable.
+ * `stats` is returned by reference so a case can read the query count AFTER awaiting.
+ */
+function makeDb(rows: Row[]): { db: Database; stats: { whereCalls: number } } {
+  const stats = { whereCalls: 0 }
+  const chain: Record<string, unknown> = {
+    from: () => chain,
+    where: () => {
+      stats.whereCalls++
+      return Promise.resolve(rows)
+    },
+  }
+  return { db: { select: () => chain } as unknown as Database, stats }
+}
+
+const row = (entityId: string, fieldId: string, relatedEntityId: string | null): Row => ({
+  entityId,
+  fieldId,
+  relatedEntityId,
+})
+
+describe('readRelationshipTargets', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns no map and issues no query for an empty pair list', async () => {
+    const { db, stats } = makeDb([])
+    const out = await readRelationshipTargets(db, ORG, [])
+    expect(out.size).toBe(0)
+    expect(stats.whereCalls).toBe(0)
+  })
+
+  it('reports a cell holding exactly one row with a non-null target', async () => {
+    const { db } = makeDb([row('e1', 'f1', 't1')])
+    const out = await readRelationshipTargets(db, ORG, [{ entityInstanceId: 'e1', fieldId: 'f1' }])
+    expect(out.get('e1::f1')).toBe('t1')
+  })
+
+  it('OMITS a cell holding two rows — a collapse is a real change', async () => {
+    const { db } = makeDb([row('e1', 'f1', 't1'), row('e1', 'f1', 't2')])
+    const out = await readRelationshipTargets(db, ORG, [{ entityInstanceId: 'e1', fieldId: 'f1' }])
+    expect(out.has('e1::f1')).toBe(false)
+  })
+
+  it('OMITS a cell whose single row has a null target', async () => {
+    const { db } = makeDb([row('e1', 'f1', null)])
+    const out = await readRelationshipTargets(db, ORG, [{ entityInstanceId: 'e1', fieldId: 'f1' }])
+    expect(out.has('e1::f1')).toBe(false)
+  })
+
+  it('OMITS a cell with no rows at all', async () => {
+    const { db } = makeDb([])
+    const out = await readRelationshipTargets(db, ORG, [{ entityInstanceId: 'e1', fieldId: 'f1' }])
+    expect(out.has('e1::f1')).toBe(false)
+  })
+
+  it('discards rows outside the requested pairs — the query is a cross-product superset', async () => {
+    // Asking for (e1,f1) and (e2,f2) filters on {e1,e2} × {f1,f2}, so (e1,f2) and
+    // (e2,f1) come back from the db and must not leak into the map.
+    const { db } = makeDb([
+      row('e1', 'f1', 't1'),
+      row('e1', 'f2', 'tX'),
+      row('e2', 'f1', 'tY'),
+      row('e2', 'f2', 't2'),
+    ])
+    const out = await readRelationshipTargets(db, ORG, [
+      { entityInstanceId: 'e1', fieldId: 'f1' },
+      { entityInstanceId: 'e2', fieldId: 'f2' },
+    ])
+    expect([...out.entries()].sort()).toEqual([
+      ['e1::f1', 't1'],
+      ['e2::f2', 't2'],
+    ])
+  })
+
+  it('keeps distinct cells independent — one multi-row cell does not poison another', async () => {
+    const { db } = makeDb([row('e1', 'f1', 't1'), row('e1', 'f1', 't2'), row('e2', 'f1', 't3')])
+    const out = await readRelationshipTargets(db, ORG, [
+      { entityInstanceId: 'e1', fieldId: 'f1' },
+      { entityInstanceId: 'e2', fieldId: 'f1' },
+    ])
+    expect(out.has('e1::f1')).toBe(false)
+    expect(out.get('e2::f1')).toBe('t3')
+  })
+
+  it('deduplicates the id lists so one field across N entities is a single query', async () => {
+    const { db, stats } = makeDb([])
+    await readRelationshipTargets(db, ORG, [
+      { entityInstanceId: 'e1', fieldId: 'f1' },
+      { entityInstanceId: 'e2', fieldId: 'f1' },
+      { entityInstanceId: 'e3', fieldId: 'f1' },
+    ])
+    expect(stats.whereCalls).toBe(1)
+  })
+})

--- a/packages/lib/src/data-connectors/relationship-pass.test.ts
+++ b/packages/lib/src/data-connectors/relationship-pass.test.ts
@@ -1,0 +1,265 @@
+// packages/lib/src/data-connectors/relationship-pass.test.ts
+// The relationship two-pass, with its `./service` reads/writes and the write-key
+// resolver mocked (Drizzle column refs are undefined under vitest — project memory),
+// so only the pass's decision logic is exercised.
+//
+// The cases that matter are the idempotency guard's (v10 relationship-pass-idempotency,
+// Phase 2): an edge that already points where it should must produce NO `crud.update`,
+// NO event, and NO `touchedDefs` entry — while every other shape still writes exactly
+// as it did before. The guard is an optimization, so every uncertain input must fall
+// through to the write.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { makeSyncCtx } from './__test-helpers'
+import type { DataConnectorItemRow, PendingRelation } from './service'
+import type { SyncCtx } from './sinks/types'
+
+const h = vi.hoisted(() => ({
+  listItems: vi.fn(),
+  findItemByDef: vi.fn(),
+  readTargets: vi.fn(),
+  setRelationState: vi.fn(async () => {}),
+  buildWriteKeyToFieldId: vi.fn(),
+  // Params mirror `UnifiedCrudHandler.update` so `mock.calls[n]` destructures as the
+  // real tuple instead of an empty one.
+  update: vi.fn(
+    async (
+      _recordId: string,
+      _values: Record<string, unknown>,
+      _modes?: Record<string, 'set' | 'add' | 'remove'>,
+      _options?: Record<string, unknown>
+    ) => ({})
+  ),
+}))
+
+// Partial-mock: `./service` is shared and fully replacing it dies at collection.
+vi.mock('./service', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./service')>()),
+  listItemsWithPendingRelations: h.listItems,
+  findItemByDef: h.findItemByDef,
+  readRelationshipTargets: h.readTargets,
+  setItemRelationState: h.setRelationState,
+}))
+vi.mock('./field-id-resolver', () => ({ buildWriteKeyToFieldId: h.buildWriteKeyToFieldId }))
+
+import { resolveRelationships } from './relationship-pass'
+
+const ORG = 'org_1'
+const ORDER_DEF = 'def_order'
+const CONTACT_DEF = 'def_contact'
+const ORDER_INSTANCE = 'inst_order_1'
+const CONTACT_INSTANCE = 'inst_contact_1'
+/** The concrete `CustomField.id` behind the `customer` write-key. */
+const CUSTOMER_FIELD_ID = 'fld_customer'
+
+const setEdge = (fieldKey = 'customer'): PendingRelation => ({
+  fieldKey,
+  targetDef: CONTACT_DEF,
+  targetExternalId: 'ext_c1',
+})
+const clearEdge = (fieldKey = 'customer'): PendingRelation => ({
+  fieldKey,
+  targetDef: null,
+  targetExternalId: null,
+})
+
+function item(pending: PendingRelation[], linked: string[] = []): DataConnectorItemRow {
+  return {
+    id: 'item_1',
+    entityInstanceId: ORDER_INSTANCE,
+    entityDefinitionId: ORDER_DEF,
+    pendingRelations: pending,
+    linkedRelations: linked.length > 0 ? linked : null,
+  } as unknown as DataConnectorItemRow
+}
+
+/** A ctx whose `crud.update` is the spy every case asserts on. */
+function ctx(): SyncCtx {
+  return makeSyncCtx({
+    orgId: ORG,
+    crud: { update: h.update } as unknown as SyncCtx['crud'],
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.setRelationState.mockResolvedValue(undefined)
+  h.update.mockResolvedValue({})
+  h.buildWriteKeyToFieldId.mockResolvedValue(new Map([['customer', CUSTOMER_FIELD_ID]]))
+  h.findItemByDef.mockResolvedValue({
+    entityInstanceId: CONTACT_INSTANCE,
+    entityDefinitionId: CONTACT_DEF,
+  })
+  h.readTargets.mockResolvedValue(new Map<string, string>())
+})
+
+describe('resolveRelationships — idempotency guard', () => {
+  it('writes nothing when the edge already points at the resolved target', async () => {
+    h.listItems.mockResolvedValue([item([setEdge()])])
+    h.readTargets.mockResolvedValue(
+      new Map([[`${ORDER_INSTANCE}::${CUSTOMER_FIELD_ID}`, CONTACT_INSTANCE]])
+    )
+    const c = ctx()
+
+    await resolveRelationships(c)
+
+    expect(h.update).not.toHaveBeenCalled()
+    // The pending entry is still consumed, and the field stays recorded as linked.
+    expect(h.setRelationState).toHaveBeenCalledWith(expect.anything(), 'item_1', {
+      pendingRelations: [],
+      linkedRelations: ['customer'],
+    })
+    // Nothing moved on this def — a no-op must not force a records:invalidated refetch.
+    expect([...c.touchedDefs]).toEqual([])
+    expect(c.counters.relationshipWarnings).toBe(0)
+  })
+
+  it('leaves `linkedRelations` untouched when the edge was already recorded as linked', async () => {
+    h.listItems.mockResolvedValue([item([setEdge()], ['customer'])])
+    h.readTargets.mockResolvedValue(
+      new Map([[`${ORDER_INSTANCE}::${CUSTOMER_FIELD_ID}`, CONTACT_INSTANCE]])
+    )
+
+    await resolveRelationships(ctx())
+
+    expect(h.update).not.toHaveBeenCalled()
+    // `linkedChanged` stayed false, but the pending list shrank, so state is persisted.
+    expect(h.setRelationState).toHaveBeenCalledWith(expect.anything(), 'item_1', {
+      pendingRelations: [],
+      linkedRelations: ['customer'],
+    })
+  })
+
+  it('writes when the edge points at a DIFFERENT target, without suppressing events', async () => {
+    h.listItems.mockResolvedValue([item([setEdge()], ['customer'])])
+    h.readTargets.mockResolvedValue(
+      new Map([[`${ORDER_INSTANCE}::${CUSTOMER_FIELD_ID}`, 'inst_contact_OLD']])
+    )
+    const c = ctx()
+
+    await resolveRelationships(c)
+
+    expect(h.update).toHaveBeenCalledTimes(1)
+    expect(h.update).toHaveBeenCalledWith(
+      `${ORDER_DEF}:${ORDER_INSTANCE}`,
+      { customer: `${CONTACT_DEF}:${CONTACT_INSTANCE}` },
+      undefined,
+      {}
+    )
+    // A genuine edge change must keep firing entity:field:updated, the activity touch,
+    // and record rules — the options object carries no `skipEvents`.
+    expect(h.update.mock.calls[0]![3]).not.toHaveProperty('skipEvents')
+    expect([...c.touchedDefs]).toEqual([ORDER_DEF])
+  })
+
+  it('writes on first resolution — the field currently has no row', async () => {
+    h.listItems.mockResolvedValue([item([setEdge()])])
+    h.readTargets.mockResolvedValue(new Map<string, string>())
+
+    await resolveRelationships(ctx())
+
+    expect(h.update).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes when the cell holds two rows — a collapse is a real change', async () => {
+    // `readRelationshipTargets` reports a multi-row cell as ABSENT (a `set` would
+    // legitimately reduce it to one), so the guard must fall through to the write.
+    h.listItems.mockResolvedValue([item([setEdge()])])
+    h.readTargets.mockResolvedValue(new Map<string, string>())
+
+    await resolveRelationships(ctx())
+
+    expect(h.update).toHaveBeenCalledTimes(1)
+  })
+
+  it('writes when the fieldKey does not resolve to a concrete field id', async () => {
+    // Fallback ref form (bare app key / stale cache): the guard is disabled rather
+    // than silently dropping the edge.
+    h.buildWriteKeyToFieldId.mockResolvedValue(new Map())
+    h.listItems.mockResolvedValue([item([setEdge()])])
+    // Even a map that WOULD match must not be consulted for an unresolved key.
+    h.readTargets.mockResolvedValue(
+      new Map([[`${ORDER_INSTANCE}::${CUSTOMER_FIELD_ID}`, CONTACT_INSTANCE]])
+    )
+
+    await resolveRelationships(ctx())
+
+    expect(h.update).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not read targets at all when every pending edge is a clear', async () => {
+    h.listItems.mockResolvedValue([item([clearEdge()], ['customer'])])
+
+    await resolveRelationships(ctx())
+
+    // No pairs collected ⇒ the bulk read short-circuits on an empty list.
+    expect(h.readTargets).toHaveBeenCalledWith(expect.anything(), ORG, [])
+  })
+
+  it('resolves the write-key map once per def across many items', async () => {
+    h.listItems.mockResolvedValue([
+      item([setEdge()]),
+      { ...item([setEdge()]), id: 'item_2', entityInstanceId: 'inst_order_2' },
+    ])
+
+    await resolveRelationships(ctx())
+
+    expect(h.buildWriteKeyToFieldId).toHaveBeenCalledTimes(1)
+    expect(h.buildWriteKeyToFieldId).toHaveBeenCalledWith(ORG, ORDER_DEF)
+  })
+})
+
+describe('resolveRelationships — unchanged behavior', () => {
+  it('applies a CLEAR exactly once and shrinks `linkedRelations`', async () => {
+    h.listItems.mockResolvedValue([item([clearEdge()], ['customer'])])
+    const c = ctx()
+
+    await resolveRelationships(c)
+
+    expect(h.update).toHaveBeenCalledTimes(1)
+    expect(h.update).toHaveBeenCalledWith(
+      `${ORDER_DEF}:${ORDER_INSTANCE}`,
+      { customer: null },
+      undefined,
+      {}
+    )
+    expect(h.setRelationState).toHaveBeenCalledWith(expect.anything(), 'item_1', {
+      pendingRelations: [],
+      linkedRelations: [],
+    })
+    expect([...c.touchedDefs]).toEqual([ORDER_DEF])
+  })
+
+  it('defers an unsynced target and counts a relationship warning', async () => {
+    h.findItemByDef.mockResolvedValue(null)
+    h.listItems.mockResolvedValue([item([setEdge()])])
+    const c = ctx()
+
+    await resolveRelationships(c)
+
+    expect(h.update).not.toHaveBeenCalled()
+    expect(c.counters.relationshipWarnings).toBe(1)
+    // Nothing resolved and nothing linked ⇒ no state write at all.
+    expect(h.setRelationState).not.toHaveBeenCalled()
+  })
+
+  it('keeps a failed write pending and counts a warning', async () => {
+    h.update.mockRejectedValue(new Error('boom'))
+    h.listItems.mockResolvedValue([item([setEdge()])])
+    const c = ctx()
+
+    await resolveRelationships(c)
+
+    expect(c.counters.relationshipWarnings).toBe(1)
+    expect(h.setRelationState).not.toHaveBeenCalled()
+  })
+
+  it('skips items with no bound instance', async () => {
+    h.listItems.mockResolvedValue([{ ...item([setEdge()]), entityInstanceId: null }])
+
+    await resolveRelationships(ctx())
+
+    expect(h.update).not.toHaveBeenCalled()
+    expect(h.readTargets).toHaveBeenCalledWith(expect.anything(), ORG, [])
+  })
+})

--- a/packages/lib/src/data-connectors/relationship-pass.ts
+++ b/packages/lib/src/data-connectors/relationship-pass.ts
@@ -5,13 +5,25 @@
 // inverse edge syncs automatically). Build-order independent (no frozen mapping
 // pointer). Unresolved targets (not yet synced) stay pending and resolve on a later
 // run; each unresolved edge increments relationshipWarnings.
+//
+// IDEMPOTENT (v10 relationship-pass-idempotency): the sink re-queues every non-clear
+// edge on every run — `linkedRelations` records WHICH field carries an edge, never
+// WHAT it points at — so without a guard this pass rewrote the connector's entire edge
+// set every 15 minutes, DELETE+INSERTing identical `FieldValue` rows and firing a full
+// `entity:field:updated` fan-out (timeline entry, activity touch, record rules) for
+// each. The fix suppresses the WRITE, not the event: one bulk pre-read of the current
+// targets, and an edge that already points where it should is left alone. A genuine
+// edge change still fires everything it fires today — deliberately NOT `skipEvents`,
+// which would take record rules and field triggers down with it.
 
 import { createScopedLogger } from '@auxx/logger'
 import { toRecordId } from '../resources/resource-id'
+import { buildWriteKeyToFieldId } from './field-id-resolver'
 import {
   findItemByDef,
   listItemsWithPendingRelations,
   type PendingRelation,
+  readRelationshipTargets,
   setItemRelationState,
 } from './service'
 import type { SyncCtx } from './sinks/types'
@@ -25,6 +37,7 @@ const logger = createScopedLogger('data-connector-relationship-pass')
  */
 export async function resolveRelationships(ctx: SyncCtx): Promise<void> {
   const items = await listItemsWithPendingRelations(ctx.db, ctx.connector.id)
+  const { currentTargets, concreteFieldIds } = await readCurrentEdges(ctx, items)
 
   for (const item of items) {
     if (!item.entityInstanceId) continue
@@ -70,6 +83,29 @@ export async function resolveRelationships(ctx: SyncCtx): Promise<void> {
         continue
       }
 
+      // IDEMPOTENCY GUARD: the edge already points at the resolved target, so writing
+      // it again would DELETE+INSERT an identical row and fire the whole field-change
+      // fan-out for a no-op. Clear the pending entry, keep the `linkedRelations`
+      // bookkeeping, and touch nothing.
+      //
+      // Deliberately does NOT `ctx.touchedDefs.add(...)`: nothing changed on this def
+      // from this pass, so it must not force a `records:invalidated` refetch.
+      //
+      // `currentTargets` is a snapshot taken before any write in this pass. That cannot
+      // hide a write from itself: `mergePending` keys pending edges by `fieldKey`, so
+      // one item carries at most one pending entry per field.
+      const concreteFieldId = concreteFieldIds.get(`${item.id}::${rel.fieldKey}`)
+      const currentTarget = concreteFieldId
+        ? currentTargets.get(`${item.entityInstanceId}::${concreteFieldId}`)
+        : undefined
+      if (currentTarget === target.entityInstanceId) {
+        if (!linked.has(rel.fieldKey)) {
+          linked.add(rel.fieldKey)
+          linkedChanged = true
+        }
+        continue
+      }
+
       const targetRecordId = toRecordId(target.entityDefinitionId, target.entityInstanceId)
       try {
         // Write the RELATIONSHIP value by addressing the parent's relationship
@@ -99,4 +135,56 @@ export async function resolveRelationships(ctx: SyncCtx): Promise<void> {
       })
     }
   }
+}
+
+/**
+ * Pre-read for the idempotency guard: resolve every non-clear pending edge's
+ * `fieldKey` to a concrete `CustomField.id`, then read all their current targets in
+ * one bulk query (chunked inside `readRelationshipTargets`).
+ *
+ * A `fieldKey` that does not resolve is simply absent from `concreteFieldIds`, which
+ * disables the guard for that edge and writes exactly as before. The guard is an
+ * optimization — an unresolvable key must never silently drop an edge.
+ *
+ * CLEAR edges are excluded on purpose: they are terminal (applied once, never
+ * retained) and the sink already drops a clear whose field has no live edge. Guarding
+ * them would risk re-introducing the fire-once bug.
+ */
+async function readCurrentEdges(
+  ctx: SyncCtx,
+  items: Awaited<ReturnType<typeof listItemsWithPendingRelations>>
+): Promise<{
+  /** `${entityInstanceId}::${fieldId}` → current single target. */
+  currentTargets: Map<string, string>
+  /** `${itemId}::${fieldKey}` → concrete `CustomField.id`. */
+  concreteFieldIds: Map<string, string>
+}> {
+  // The edge field lives on the item's OWN def; memoize per def so N items on one def
+  // resolve the map once. Same map `entity-sink`'s drift detection keys off.
+  const writeKeyMaps = new Map<string, Promise<Map<string, string>>>()
+  const writeKeyMap = (defId: string): Promise<Map<string, string>> => {
+    let m = writeKeyMaps.get(defId)
+    if (!m) {
+      m = buildWriteKeyToFieldId(ctx.orgId, defId)
+      writeKeyMaps.set(defId, m)
+    }
+    return m
+  }
+
+  const concreteFieldIds = new Map<string, string>()
+  const pairs: Array<{ entityInstanceId: string; fieldId: string }> = []
+
+  for (const item of items) {
+    if (!item.entityInstanceId) continue
+    for (const rel of (item.pendingRelations ?? []) as PendingRelation[]) {
+      if (rel.targetExternalId === null) continue
+      const fieldId = (await writeKeyMap(item.entityDefinitionId)).get(rel.fieldKey)
+      if (!fieldId) continue
+      concreteFieldIds.set(`${item.id}::${rel.fieldKey}`, fieldId)
+      pairs.push({ entityInstanceId: item.entityInstanceId, fieldId })
+    }
+  }
+
+  const currentTargets = await readRelationshipTargets(ctx.db, ctx.orgId, pairs)
+  return { currentTargets, concreteFieldIds }
 }

--- a/packages/lib/src/data-connectors/service.ts
+++ b/packages/lib/src/data-connectors/service.ts
@@ -928,6 +928,78 @@ export async function setItemRelationState(
     .where(eq(schema.DataConnectorItem.id, itemId))
 }
 
+/**
+ * Current single-valued relationship targets for a set of `(entityInstanceId, fieldId)`
+ * pairs — the two-pass's idempotency input (v10 relationship-pass-idempotency, Phase 1).
+ *
+ * Returns an entry ONLY for a field holding EXACTLY ONE row with a non-null
+ * `relatedEntityId`. A belongs_to cell holding 2+ rows is a genuine collapse target —
+ * `set` semantics would legitimately reduce it to one — so it must NOT be reported as
+ * "already correct". Zero rows and a null target are likewise absent, so the caller
+ * writes. Absence from the map always means "write"; presence means "compare".
+ *
+ * Compares on `relatedEntityId` (the instance uuid) alone: the pass resolves its target
+ * through `findItemByDef`, so the def is already pinned by construction.
+ *
+ * @returns `${entityInstanceId}::${fieldId}` → `relatedEntityId`
+ */
+export async function readRelationshipTargets(
+  db: Database,
+  organizationId: string,
+  pairs: Array<{ entityInstanceId: string; fieldId: string }>
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>()
+  if (pairs.length === 0) return out
+
+  // Only the exact pairs are of interest, but the query filters on the two id sets
+  // independently (the cross product is a superset) and narrows in JS below.
+  const wanted = new Set(pairs.map((p) => `${p.entityInstanceId}::${p.fieldId}`))
+  const entityIds = [...new Set(pairs.map((p) => p.entityInstanceId))]
+  const fieldIds = [...new Set(pairs.map((p) => p.fieldId))]
+
+  // `${entityInstanceId}::${fieldId}` → the single target, or null once a second row
+  // (or a null target) disqualifies the group.
+  const byPair = new Map<string, string | null>()
+
+  const CHUNK = 500
+  for (let i = 0; i < entityIds.length; i += CHUNK) {
+    const entityChunk = entityIds.slice(i, i + CHUNK)
+    for (let j = 0; j < fieldIds.length; j += CHUNK) {
+      const fieldChunk = fieldIds.slice(j, j + CHUNK)
+      const rows = await db
+        .select({
+          entityId: schema.FieldValue.entityId,
+          fieldId: schema.FieldValue.fieldId,
+          relatedEntityId: schema.FieldValue.relatedEntityId,
+        })
+        .from(schema.FieldValue)
+        .where(
+          and(
+            eq(schema.FieldValue.organizationId, organizationId),
+            inArray(schema.FieldValue.entityId, entityChunk),
+            inArray(schema.FieldValue.fieldId, fieldChunk)
+          )
+        )
+
+      for (const row of rows) {
+        const key = `${row.entityId}::${row.fieldId}`
+        if (!wanted.has(key)) continue
+        if (byPair.has(key)) {
+          // A second row for this cell — multi-valued, so `set` would collapse it.
+          byPair.set(key, null)
+          continue
+        }
+        byPair.set(key, row.relatedEntityId)
+      }
+    }
+  }
+
+  for (const [key, target] of byPair) {
+    if (target !== null) out.set(key, target)
+  }
+  return out
+}
+
 /** Mark an item archived (set archivedAt). */
 export async function markItemArchived(
   db: Database,

--- a/packages/lib/src/data-connectors/sinks/entity-sink-merge-pending.test.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink-merge-pending.test.ts
@@ -59,4 +59,16 @@ describe('mergePending', () => {
     const out = mergePending([clear('customer')], [set('customer', 'm', 'c2')], new Set())
     expect(out).toEqual([set('customer', 'm', 'c2')])
   })
+
+  // REGRESSION GUARD (v10 relationship-pass-idempotency): a non-clear edge is
+  // re-queued on EVERY run even when it is already linked and unchanged. That looks
+  // like the obvious place to stop the churn — it is not. `linkedRelations` records
+  // WHICH field carries an edge, never WHAT it points at, so suppressing here would
+  // reintroduce the stale-target bug the merge comment warns about (a target that
+  // moves upstream would never be re-resolved). Suppression belongs in the
+  // relationship pass, which compares against the stored `FieldValue`.
+  it("re-queues an already-linked, unchanged set edge — suppression is the PASS's job", () => {
+    const out = mergePending([], [set('customer', 'm', 'c1')], new Set(['customer']))
+    expect(out).toEqual([set('customer', 'm', 'c1')])
+  })
 })


### PR DESCRIPTION
## The symptom

Every scheduled run (15-min cadence) rewrote **every relationship edge the connector manages** — 50 `FieldValue` rows on the dev Shopify connector — even with nothing changed upstream. Each rewrite is a DELETE+INSERT of an identical row plus a full `entity:field:updated` fan-out, so an order's timeline showed a "Customer" change every 15 minutes with old and new value identical:

```
entity:field:updated  Customer
  oldValue [{ id: 'd7wsyyfcul1w7ktxeocayhnm', recordId: 'mzxt…:aelua…', sortKey: 'a0' }]
  newValue [{ id: 'g86emwg6pgxrkq36kv14oowg', recordId: 'mzxt…:aelua…', sortKey: 'a0' }]
  oldDisplay [{ label: 'Russell Winfield' }]   newDisplay [{ label: 'Russell Winfield' }]
```

Same target, same sortKey, same label — only the row id differs. ~1,200 spurious `TimelineEvent` rows/day for one org, against 12–39/day before the connector went live, every one attributed to the human in `DataConnector.createdById`.

Collateral beyond the noise: `FieldValue.createdAt` reset every 15 min, `aiStatus`/`aiMetadata` markers wiped each run, and the two global `'*'` hooks (`touchActivityOnFieldChange`, `handleRecordRulesOnFieldChange`) dispatched 50×/run.

## Root cause

Three links. The sink re-queues every non-clear edge on every run *by design* (so a later-arriving target still resolves) and **cannot do better**: `DataConnectorItem.linkedRelations` is `string[]` — it records *which field* carries an edge, never *what it points at*. The pass then wrote it unconditionally with no read of the current value. And the field-value `set` path deletes before it compares, so an identical write still churns the row and fires the post-hook.

## The fix — suppress the write, not the event

`resolveRelationships` pre-reads the current targets in one bulk query and skips an edge that already points where it should. A genuine edge change still fires everything it fires today.

**Deliberately not `skipEvents`.** It's one coarse boolean (`CrudOptions` has no `skipTimeline`/`skipRules`), and what it silences is load-bearing — record rules and the native field-trigger door (BOM cost recalc, stock status, the v9 inventory→part deduction) would stop firing for a *real* edge change. Its B2 contract also requires feeding `sync-manifest-collector`, which this pass doesn't touch. Visible noise traded for silent data-driven breakage is a bad trade.

## Design note: compare against the stored value, not bookkeeping

The alternative was widening `linkedRelations` to remember the target. Reading the actual `FieldValue` costs one bulk query per run but is a true idempotency guard rather than a cache — it detects a hand-edited edge and re-asserts (matching how `driftedInstances` treats overwrite cells), self-heals a row deleted out of band, and needs no schema change.

## Failing open, on purpose

`readRelationshipTargets` reports a cell **only** when it holds exactly one row with a non-null target. Absence always means "write":

- **2+ rows** — a genuine collapse target that `set` would legitimately reduce, so it must not be reported as already-correct
- **null target / no rows** — first resolution
- **unresolvable `fieldKey`** — the fallback ref forms (bare app key, stale cache) disable the guard rather than risk dropping an edge

The skip path also deliberately does **not** `ctx.touchedDefs.add(...)` — nothing moved on that def, so a no-op must not force a `records:invalidated` refetch.

CLEAR edges are excluded from the guard entirely: they're terminal, and the sink already drops a clear whose field has no live edge. Guarding them would risk reintroducing the fire-once bug.

## Expected result

Steady-state run: one bulk read, zero writes, zero timeline rows. Spurious `TimelineEvent` inserts for this org drop from ~1,200/day to ~0 until an edge genuinely moves.

## Tests

- `relationship-pass.test.ts` (12 cases, new) — already-correct edge writes nothing and leaves `touchedDefs` empty; different target writes once **and** the options arg carries no `skipEvents`; no-row / two-row / unresolvable-key all fall through to the write; CLEAR, deferral, and write-failure behavior unchanged
- `read-relationship-targets.test.ts` (8 cases, new) — the grouping asymmetry, including that one multi-row cell doesn't poison another and that the cross-product superset is narrowed to the requested pairs
- `entity-sink-merge-pending.test.ts` — regression guard that `mergePending` **still** re-queues an already-linked unchanged edge, with a comment on why suppressing at the sink would reintroduce the stale-target bug

`pnpm exec vitest run src/data-connectors` → 49 files / 419 tests green. Biome and `packages/lib` typecheck clean on all touched files.

## Not in this PR

- **The shared equality guard.** Any identical `set` still churns for every other caller (Kopilot record tools, workflow CRUD, form re-posts, the importer — heavier since #1793). It's a hot shared path and wants its own plan and test matrix. One note for whoever takes it: the pre-read already exists — `oldValue` is read at `field-value-mutations.ts:2182` and `setValueWithType` isn't called until step 6, so the comparison goes between them at zero extra query cost.
- **Actor attribution.** A real edge change still lands as `actorType: 'user'` with the connector creator's id. Rare now rather than constant; belongs with the ACTOR/system-user work.
- **Live-run verification.** Not yet done — needs two scheduled runs to confirm the `TimelineEvent` count holds and the `FieldValue.id` is the *same row*, plus that the orthogonal `updated: 7 / skipped: 76` is unmasked.
