### PR TITLE
fix(field-values): skip no-op set writes and delete-of-absent clears

### DIFF
--- a/packages/lib/src/field-values/__tests__/batched-realtime-publish.test.ts
+++ b/packages/lib/src/field-values/__tests__/batched-realtime-publish.test.ts
@@ -168,7 +168,24 @@ function makeFakeDb() {
       ),
     select: () => chain,
     from: () => chain,
-    orderBy: () => Promise.resolve([]),
+    // One pre-existing stored row (payload matches nothing this suite
+    // writes): keeps every `set` here a REAL change and every clear a REAL
+    // delete under the D-6/B-14 set-idempotency guard — with zero rows a
+    // clear is now a silent no-op and publishes no frame at all
+    // (set-idempotency.test.ts covers those no-op paths).
+    orderBy: () =>
+      Promise.resolve([
+        {
+          id: 'fv-seed',
+          entityId: 'inst-1',
+          fieldId: 'seed',
+          organizationId: 'org-1',
+          valueText: '__seed__',
+          sortKey: 'a0',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ]),
     update: () => chain,
     set: () => chain,
   })

--- a/packages/lib/src/field-values/__tests__/set-idempotency.test.ts
+++ b/packages/lib/src/field-values/__tests__/set-idempotency.test.ts
@@ -1,0 +1,437 @@
+// packages/lib/src/field-values/__tests__/set-idempotency.test.ts
+//
+// D-6 idempotency guard on the forward `set` path + B-14 delete-of-absent
+// (plans/events/03-write-context-and-batch-lane-plan.md Phase 2;
+// docs/skip-events-history.md §8 D3): an identical `set` must not
+// DELETE+INSERT, must not fire the post-hook chain, must not publish
+// realtime, and must not collect native field triggers — while any real
+// change (including an AI stage-2 commit re-asserting the same value)
+// keeps the old behavior exactly.
+
+import type { FieldId } from '@auxx/types/field'
+import { toRecordId } from '@auxx/types/resource'
+
+// ⚠️ Mock '../../realtime/publish-helpers' directly — NOT the '../../realtime'
+// barrel (see batched-realtime-publish.test.ts for the import-cycle rationale).
+vi.mock('../../realtime/publish-helpers', () => ({
+  publishFieldValueUpdates: vi.fn(),
+}))
+
+// '../../cache' is a large barrel with real DB/Redis-backed providers. Mock it
+// wholesale; the entry points this suite's code path touches are
+// `getCachedFieldMap`/`getCachedResource` (field-value-mutations),
+// `getOrgCache` (resolveFieldIds), and `getAllCachedCustomFields`/
+// `getCachedRecordRules` (collectTriggeredFields — reached on the changed path
+// because `ctx.userId` is set so the post-hook/trigger branches run).
+vi.mock('../../cache', () => ({
+  getCachedFieldMap: vi.fn(),
+  getCachedResource: vi.fn(),
+  getOrgCache: vi.fn(),
+  getAllCachedCustomFields: vi.fn(async () => []),
+  getCachedRecordRules: vi.fn(async () => []),
+}))
+
+// The field-hooks registry is imported (in the loaded graph) only by
+// field-value-mutations.ts, so a full-replacement mock is safe here. Entity
+// hooks are "registered" so `willFirePostHook` is true and the guard's
+// hook-suppression is actually observable; pre-hooks stay empty so the write
+// value passes through untransformed.
+vi.mock('../../field-hooks/registry', () => ({
+  hasEntityFieldChangeHooks: vi.fn(() => true),
+  hasFieldTypeChangeHooks: vi.fn(() => false),
+  hasFieldPreHooks: vi.fn(() => false),
+  getEntityFieldChangeHooks: vi.fn(() => []),
+  getFieldTypeChangeHooks: vi.fn(() => []),
+  getFieldPreHooks: vi.fn(() => []),
+}))
+
+// Native field-trigger collection (step 8 of setValueWithBuiltIn). Mocked so
+// the no-op assertions can distinguish "collected but empty" from "never
+// collected at all".
+vi.mock('../../field-hooks/collect-triggers', () => ({
+  collectTriggeredFields: vi.fn(async () => []),
+  deduplicateBySystemAttribute: vi.fn((fields: unknown[]) => fields),
+}))
+vi.mock('../../field-hooks/publish', () => ({
+  publishFieldTriggerEvents: vi.fn(async () => {}),
+  publishBatchFieldTriggerEvents: vi.fn(async () => {}),
+}))
+
+// Snapshot resolution runs inside `firePostHook`; its ref-lookups are
+// irrelevant here, so stub it to fixed displays.
+vi.mock('../timeline-snapshot', () => ({
+  preloadSnapshotCache: vi.fn(),
+  resolveFieldChangeSnapshotPair: vi.fn(async () => ({ oldDisplay: null, newDisplay: null })),
+  resolveFieldChangeSnapshotsBulk: vi.fn(async () => new Map()),
+}))
+
+import { getCachedResource, getOrgCache } from '../../cache'
+import { collectTriggeredFields } from '../../field-hooks/collect-triggers'
+import { getEntityFieldChangeHooks } from '../../field-hooks/registry'
+import { publishFieldValueUpdates } from '../../realtime/publish-helpers'
+import { createFieldValueContext, type FieldValueContext } from '../field-value-helpers'
+import { setValueWithBuiltIn } from '../field-value-mutations'
+
+const mockedGetCachedResource = getCachedResource as unknown as ReturnType<typeof vi.fn>
+const mockedGetOrgCache = getOrgCache as unknown as ReturnType<typeof vi.fn>
+const mockedGetEntityHooks = getEntityFieldChangeHooks as unknown as ReturnType<typeof vi.fn>
+const mockedCollectTriggers = vi.mocked(collectTriggeredFields)
+const mockedPublish = vi.mocked(publishFieldValueUpdates)
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const recordId = toRecordId('widget', 'inst-1')
+
+/** Minimal CustomField-shaped fixture (same shape as the sibling suites). */
+function fieldFixture(id: string, type: string, options: Record<string, unknown> = {}) {
+  return {
+    id,
+    type,
+    options,
+    entityDefinitionId: null,
+    entityDefinition: null,
+    entityType: null,
+    isUnique: false,
+    systemAttribute: null,
+  }
+}
+
+const FIELD_TEXT = fieldFixture('field-text', 'TEXT')
+const FIELD_TAGS = fieldFixture('field-tags', 'TAGS')
+const FIELD_JSON = fieldFixture('field-json', 'JSON')
+
+/** A stored FieldValue row for (inst-1, fieldId) with payload overrides. */
+function existingRow(
+  id: string,
+  fieldId: string,
+  sortKey: string,
+  payload: Record<string, unknown>
+) {
+  return {
+    id,
+    entityId: 'inst-1',
+    entityDefinitionId: 'widget',
+    fieldId,
+    organizationId: 'org-1',
+    valueText: null,
+    valueNumber: null,
+    valueBoolean: null,
+    valueDate: null,
+    valueJson: null,
+    optionId: null,
+    relatedEntityId: null,
+    relatedEntityDefinitionId: null,
+    actorId: null,
+    aiStatus: null,
+    sortKey,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...payload,
+  }
+}
+
+/**
+ * Hand-rolled chainable `ctx.db` fake (Drizzle's `schema.*` column refs are
+ * `{}` under this repo's vitest setup — see project memory — so the fake
+ * ignores every `where()` argument). All `select(...).from(...).where(...)
+ * .orderBy(...)` reads resolve to `existingRows` (given already in sortKey
+ * order); `delete`/`insert` calls are counted so tests can assert the
+ * DELETE+INSERT did or did not run.
+ */
+function makeFakeDb(existingRows: any[] = []) {
+  let idSeq = 0
+  let pendingValues: any[] = []
+  const state = { deleteCalls: 0, insertCalls: 0, insertedRows: [] as any[] }
+  const chain: any = {}
+  Object.assign(chain, {
+    delete: () => {
+      state.deleteCalls++
+      return chain
+    },
+    where: () => chain,
+    insert: () => {
+      state.insertCalls++
+      return chain
+    },
+    values: (rows: any) => {
+      pendingValues = Array.isArray(rows) ? rows : [rows]
+      state.insertedRows.push(...pendingValues)
+      return chain
+    },
+    onConflictDoUpdate: () => chain,
+    returning: () =>
+      Promise.resolve(
+        pendingValues.map((row) => ({
+          id: `fv-new-${idSeq++}`,
+          createdAt: '2026-02-01T00:00:00.000Z',
+          updatedAt: '2026-02-01T00:00:00.000Z',
+          ...row,
+        }))
+      ),
+    select: () => chain,
+    from: () => chain,
+    orderBy: () => Promise.resolve(existingRows),
+    update: () => chain,
+    set: () => chain,
+  })
+  return { db: chain, state }
+}
+
+/** Context with a REAL userId so the post-hook / field-trigger gates are open. */
+function makeCtx(db: any, fields: ReturnType<typeof fieldFixture>[]): FieldValueContext {
+  const ctx = createFieldValueContext('org-1', 'user-1', db, 'socket-abc')
+  for (const f of fields) ctx.fieldCache.set(f.id, f as any)
+  return ctx
+}
+
+const hookSpy = vi.fn(async (_event: unknown) => {})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockedGetCachedResource.mockResolvedValue(undefined)
+  mockedPublish.mockResolvedValue(undefined)
+  mockedCollectTriggers.mockResolvedValue([])
+  mockedGetEntityHooks.mockReturnValue([hookSpy])
+  // resolveFieldIds needs `.from(orgId, 'customFields').all()`; getField's
+  // cache-miss fallback needs `.byId()` (never hit — fieldCache is pre-warmed).
+  mockedGetOrgCache.mockReturnValue({
+    from: () => ({ all: async () => ({}), byId: async () => undefined }),
+  })
+})
+
+// =============================================================================
+// D-6 — forward set
+// =============================================================================
+
+describe('set idempotency guard (D-6)', () => {
+  it('identical scalar set: no DELETE+INSERT, no post-hook, no realtime, existing row ids preserved', async () => {
+    const rows = [existingRow('fv-existing-1', 'field-text', 'a0', { valueText: 'hello' })]
+    const { db, state } = makeFakeDb(rows)
+    const ctx = makeCtx(db, [FIELD_TEXT])
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-text',
+      value: 'hello',
+    })
+
+    expect(result.state).toBe('complete')
+    expect(result.values).toHaveLength(1)
+    expect(result.values[0]!.id).toBe('fv-existing-1')
+    expect((result.values[0] as any).value).toBe('hello')
+
+    expect(state.deleteCalls).toBe(0)
+    expect(state.insertCalls).toBe(0)
+    expect(hookSpy).not.toHaveBeenCalled()
+    expect(mockedPublish).not.toHaveBeenCalled()
+    expect(mockedCollectTriggers).not.toHaveBeenCalled()
+  })
+
+  it('changed scalar set: normal path — DELETE+INSERT runs and the post-hook fires', async () => {
+    const rows = [existingRow('fv-existing-1', 'field-text', 'a0', { valueText: 'hello' })]
+    const { db, state } = makeFakeDb(rows)
+    const ctx = makeCtx(db, [FIELD_TEXT])
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-text',
+      value: 'world',
+    })
+
+    expect(result.state).toBe('complete')
+    expect((result.values[0] as any).value).toBe('world')
+
+    expect(state.deleteCalls).toBe(1)
+    expect(state.insertCalls).toBe(1)
+    expect(hookSpy).toHaveBeenCalledTimes(1)
+    const event = hookSpy.mock.calls[0]![0] as any
+    expect(event.newValue).toMatchObject({ type: 'text', value: 'world' })
+    expect(mockedPublish).toHaveBeenCalledTimes(1)
+  })
+
+  it('multi-value set, same values in the same sortKey order: no-op', async () => {
+    const rows = [
+      existingRow('fv-a', 'field-tags', 'a0', { optionId: 'opt-a' }),
+      existingRow('fv-b', 'field-tags', 'a1', { optionId: 'opt-b' }),
+    ]
+    const { db, state } = makeFakeDb(rows)
+    const ctx = makeCtx(db, [FIELD_TAGS])
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-tags',
+      value: ['opt-a', 'opt-b'],
+    })
+
+    expect(result.state).toBe('complete')
+    expect(result.values.map((v) => v.id)).toEqual(['fv-a', 'fv-b'])
+    expect(state.deleteCalls).toBe(0)
+    expect(state.insertCalls).toBe(0)
+    expect(hookSpy).not.toHaveBeenCalled()
+    expect(mockedPublish).not.toHaveBeenCalled()
+  })
+
+  it('multi-value set, same values in a DIFFERENT order: writes', async () => {
+    const rows = [
+      existingRow('fv-a', 'field-tags', 'a0', { optionId: 'opt-a' }),
+      existingRow('fv-b', 'field-tags', 'a1', { optionId: 'opt-b' }),
+    ]
+    const { db, state } = makeFakeDb(rows)
+    const ctx = makeCtx(db, [FIELD_TAGS])
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-tags',
+      value: ['opt-b', 'opt-a'],
+    })
+
+    expect(state.deleteCalls).toBe(1)
+    expect(state.insertCalls).toBe(1)
+    expect(state.insertedRows.map((r) => r.optionId)).toEqual(['opt-b', 'opt-a'])
+    expect(hookSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('multi-value set with a different row COUNT: writes', async () => {
+    const rows = [existingRow('fv-a', 'field-tags', 'a0', { optionId: 'opt-a' })]
+    const { db, state } = makeFakeDb(rows)
+    const ctx = makeCtx(db, [FIELD_TAGS])
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-tags',
+      value: ['opt-a', 'opt-b'],
+    })
+
+    expect(state.deleteCalls).toBe(1)
+    expect(state.insertCalls).toBe(1)
+  })
+
+  it('JSON value identical modulo object key order: no-op', async () => {
+    const rows = [
+      existingRow('fv-json-1', 'field-json', 'a0', {
+        // Stored envelope form, keys in one order…
+        valueJson: { v: { b: { d: 2, c: [1, 2] }, a: 1 } },
+      }),
+    ]
+    const { db, state } = makeFakeDb(rows)
+    const ctx = makeCtx(db, [FIELD_JSON])
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-json',
+      // …incoming value structurally equal with keys in another order.
+      value: { a: 1, b: { c: [1, 2], d: 2 } },
+    })
+
+    expect(result.values[0]!.id).toBe('fv-json-1')
+    expect(state.deleteCalls).toBe(0)
+    expect(state.insertCalls).toBe(0)
+    expect(hookSpy).not.toHaveBeenCalled()
+    expect(mockedPublish).not.toHaveBeenCalled()
+  })
+
+  it('JSON value with a real difference: writes', async () => {
+    const rows = [
+      existingRow('fv-json-1', 'field-json', 'a0', {
+        valueJson: { v: { a: 1, b: 2 } },
+      }),
+    ]
+    const { db, state } = makeFakeDb(rows)
+    const ctx = makeCtx(db, [FIELD_JSON])
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-json',
+      value: { a: 1, b: 3 },
+    })
+
+    expect(state.deleteCalls).toBe(1)
+    expect(state.insertCalls).toBe(1)
+  })
+
+  it('identical set WITH aiGeneration metadata: guard bypassed, write proceeds', async () => {
+    const rows = [existingRow('fv-existing-1', 'field-text', 'a0', { valueText: 'hello' })]
+    const { db, state } = makeFakeDb(rows)
+    const ctx = makeCtx(db, [FIELD_TEXT])
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-text',
+      value: 'hello',
+      aiGeneration: { model: 'test-model' } as any,
+    })
+
+    expect(result.state).toBe('complete')
+    expect(state.deleteCalls).toBe(1)
+    expect(state.insertCalls).toBe(1)
+    // The committed row carries the AI marker.
+    expect(state.insertedRows[0]).toMatchObject({ aiStatus: 'result' })
+  })
+
+  it('identical value but the stored row carries an AI marker: writes (manual set must clear it)', async () => {
+    const rows = [
+      existingRow('fv-existing-1', 'field-text', 'a0', {
+        valueText: 'hello',
+        aiStatus: 'result',
+        valueJson: { meta: { ai: { model: 'test-model' } } },
+      }),
+    ]
+    const { db, state } = makeFakeDb(rows)
+    const ctx = makeCtx(db, [FIELD_TEXT])
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-text',
+      value: 'hello',
+    })
+
+    expect(state.deleteCalls).toBe(1)
+    expect(state.insertCalls).toBe(1)
+  })
+})
+
+// =============================================================================
+// B-14 — delete-of-absent
+// =============================================================================
+
+describe('null/clear set (B-14)', () => {
+  it('clear with NO existing rows: complete no-op — no delete, no hook, no realtime', async () => {
+    const { db, state } = makeFakeDb([])
+    const ctx = makeCtx(db, [FIELD_TEXT])
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-text',
+      value: null,
+    })
+
+    expect(result).toMatchObject({ state: 'complete', values: [] })
+    expect(state.deleteCalls).toBe(0)
+    expect(state.insertCalls).toBe(0)
+    expect(hookSpy).not.toHaveBeenCalled()
+    expect(mockedPublish).not.toHaveBeenCalled()
+  })
+
+  it('clear with existing rows: deletes, fires the post-hook, publishes the clear', async () => {
+    const rows = [existingRow('fv-existing-1', 'field-text', 'a0', { valueText: 'hello' })]
+    const { db, state } = makeFakeDb(rows)
+    const ctx = makeCtx(db, [FIELD_TEXT])
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-text',
+      value: null,
+    })
+
+    expect(result).toMatchObject({ state: 'complete', values: [] })
+    expect(state.deleteCalls).toBe(1)
+    expect(hookSpy).toHaveBeenCalledTimes(1)
+    const event = hookSpy.mock.calls[0]![0] as any
+    expect(event.newValue).toBeNull()
+    expect(mockedPublish).toHaveBeenCalledTimes(1)
+    const [, , entries] = mockedPublish.mock.calls[0]! as any[]
+    expect(entries[0]).toMatchObject({ value: null, aiStatus: null })
+  })
+})

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -22,6 +22,7 @@ import {
   nextKeyAfter,
   nKeysAfter,
 } from '@auxx/utils/fractional-indexing'
+import { stableStringify } from '@auxx/utils/json'
 import { and, asc, eq, inArray, sql } from 'drizzle-orm'
 import { getCachedFieldMap, getCachedResource } from '../cache'
 import {
@@ -2052,6 +2053,182 @@ export async function removeValuesBulk(
 }
 
 // =============================================================================
+// SET-PATH IDEMPOTENCY GUARD (docs/skip-events-history.md §8 D3; plan 03 D-6/B-14)
+// =============================================================================
+
+/** Existing row plus the AI marker column `FieldValueRow` doesn't declare. */
+type ExistingSetRow = FieldValueRow & { aiStatus?: string | null }
+
+/**
+ * Load the existing FieldValue rows for one (record, field), ordered by
+ * sortKey — the same shape/order `getValue` reads, but raw rows and with NO
+ * mail-lens gate (the guard must see what is actually stored, never a
+ * viewer-shaped answer). Returns `null` when the load fails for any reason:
+ * a false "unchanged" would silently drop a real write, so "couldn't look"
+ * always means "assume changed" and the normal write path runs.
+ */
+async function loadExistingRowsForSet(
+  ctx: FieldValueContext,
+  entityInstanceId: string,
+  fieldId: string
+): Promise<ExistingSetRow[] | null> {
+  try {
+    const rows = await ctx.db
+      .select()
+      .from(schema.FieldValue)
+      .where(
+        and(
+          eq(schema.FieldValue.entityId, entityInstanceId),
+          eq(schema.FieldValue.fieldId, fieldId),
+          eq(schema.FieldValue.organizationId, ctx.organizationId)
+        )
+      )
+      .orderBy(asc(schema.FieldValue.sortKey))
+    return rows as unknown as ExistingSetRow[]
+  } catch (error) {
+    logger.warn('Set idempotency guard: existing-row load failed; writing normally', {
+      fieldId,
+      entityId: entityInstanceId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}
+
+/**
+ * TOTAL, conservative payload equality between one stored row and the row the
+ * write would insert (`buildFieldValueRow` output). Every value column is
+ * compared; any uncertainty (unparseable date, non-finite number, JSON that
+ * fails to serialize) answers "changed", so the worst a wrong answer can cost
+ * is the old DELETE+INSERT behavior.
+ */
+function existingRowMatchesInsert(
+  existing: ExistingSetRow,
+  insert: typeof schema.FieldValue.$inferInsert
+): boolean {
+  // Text-like columns: null-safe strict equality, no normalization.
+  if ((existing.valueText ?? null) !== (insert.valueText ?? null)) return false
+  if ((existing.optionId ?? null) !== (insert.optionId ?? null)) return false
+  if ((existing.relatedEntityId ?? null) !== (insert.relatedEntityId ?? null)) return false
+  if ((existing.relatedEntityDefinitionId ?? null) !== (insert.relatedEntityDefinitionId ?? null)) {
+    return false
+  }
+  if ((existing.actorId ?? null) !== (insert.actorId ?? null)) return false
+  if ((existing.valueBoolean ?? null) !== (insert.valueBoolean ?? null)) return false
+
+  // Numbers: compare numerically; anything non-finite is "changed".
+  const existingNum = existing.valueNumber ?? null
+  const insertNum = insert.valueNumber ?? null
+  if ((existingNum === null) !== (insertNum === null)) return false
+  if (existingNum !== null && insertNum !== null) {
+    const a = Number(existingNum)
+    const b = Number(insertNum)
+    if (!Number.isFinite(a) || !Number.isFinite(b) || a !== b) return false
+  }
+
+  // Dates: `valueDate` is a `mode: 'string'` timestamp, so the stored pg text
+  // form and a fresh `toISOString()` differ textually for the same instant —
+  // compare by parsed instant, and treat unparseable as "changed".
+  const existingDate = existing.valueDate ?? null
+  const insertDate = insert.valueDate ?? null
+  if ((existingDate === null) !== (insertDate === null)) return false
+  if (existingDate !== null && insertDate !== null) {
+    const a = Date.parse(existingDate)
+    const b = Date.parse(insertDate)
+    if (Number.isNaN(a) || Number.isNaN(b) || a !== b) return false
+  }
+
+  // JSON: jsonb does not preserve object key order, so compare both envelope
+  // halves via `stableStringify` (the repo's canonical jsonb comparison).
+  // `meta` must match too — the DELETE+INSERT this guard replaces would drop
+  // stored metadata the incoming write doesn't re-assert, so an envelope
+  // carrying extra meta is a REAL change, not a no-op.
+  const existingJson = existing.valueJson ?? null
+  const insertJson = (insert.valueJson as unknown) ?? null
+  if ((existingJson === null) !== (insertJson === null)) return false
+  if (existingJson !== null && insertJson !== null) {
+    try {
+      const a = readEnvelope(existingJson)
+      const b = readEnvelope(insertJson)
+      if (stableStringify(a.v ?? null) !== stableStringify(b.v ?? null)) return false
+      if (stableStringify(a.meta ?? null) !== stableStringify(b.meta ?? null)) return false
+    } catch {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * D-6 idempotency guard core: decide whether a forward `set` write is a pure
+ * re-assertion of what is already stored — same row count, same sortKey
+ * order (stored rows in sortKey order must equal the incoming values in
+ * array order), same discriminated payload per row — and return the stored
+ * rows as `TypedFieldValue`s when it is, `null` when anything differs or
+ * cannot be verified.
+ *
+ * Callers must NOT invoke this for `aiGeneration` (stage-2 AI commit)
+ * writes: those must always write so the rows gain `aiStatus='result'` +
+ * metadata even when the value is identical.
+ */
+async function findUnchangedSetResult(
+  ctx: FieldValueContext,
+  args: {
+    existingRows: ExistingSetRow[]
+    fieldType: FieldType
+    entityDefinitionId: string
+    entityInstanceId: string
+    fieldId: string
+    value: TypedFieldValueInput | TypedFieldValueInput[]
+  }
+): Promise<TypedFieldValue[] | null> {
+  try {
+    const { existingRows, fieldType } = args
+
+    // Canonicalize relationship recordIds exactly as setValueWithType will,
+    // so an alias-form id ('contact:<inst>') compares against the stored
+    // definition CUID instead of falsely reading as changed.
+    const value =
+      fieldType === 'RELATIONSHIP'
+        ? await canonicalizeRelationshipValue(ctx, args.value)
+        : args.value
+    if (value === null) return null
+
+    const values = Array.isArray(value) ? value : [value]
+    if (values.length !== existingRows.length) return null
+
+    for (let i = 0; i < values.length; i++) {
+      const row = existingRows[i]!
+      // A manual set clears any persisted AI marker via its DELETE+INSERT
+      // cycle, so an existing marker makes even an identical value a REAL
+      // write (the marker must go away).
+      if (row.aiStatus != null) return null
+      const insert = buildFieldValueRow({
+        organizationId: ctx.organizationId,
+        entityId: args.entityInstanceId,
+        entityDefinitionId: args.entityDefinitionId,
+        fieldId: args.fieldId,
+        value: values[i]!,
+        // Payload-only comparison target; the row's own key keeps
+        // `buildFieldValueRow` honest without comparing sortKeys themselves.
+        sortKey: row.sortKey,
+      })
+      if (!existingRowMatchesInsert(row, insert)) return null
+    }
+
+    return existingRows.map((row) => rowToTypedValue(row, fieldType))
+  } catch (error) {
+    logger.warn('Set idempotency guard: comparison failed; writing normally', {
+      fieldId: args.fieldId,
+      entityId: args.entityInstanceId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}
+
+// =============================================================================
 // HIGH-LEVEL MUTATIONS
 // =============================================================================
 
@@ -2171,6 +2348,37 @@ export async function setValueWithBuiltIn(
   }
   const typedValue = hookOutcome.value
 
+  // 3.55. Idempotency guard (docs/skip-events-history.md §8 D3): load the
+  // stored rows once, BEFORE the destructive DELETE+INSERT. Used by both the
+  // null/clear branch below (B-14: delete-of-absent is a no-op) and the
+  // forward set branch (D-6: identical write → no write, no hooks, no
+  // events). AI stage-2 commits (`aiGeneration`) bypass the guard entirely —
+  // re-asserting an identical value must still write so the rows gain
+  // `aiStatus='result'` + metadata. `null` = guard disabled for this write
+  // (bypass, or the load failed) — the normal path runs unconditionally.
+  const guardRows = params.aiGeneration
+    ? null
+    : await loadExistingRowsForSet(ctx, entityInstanceId, fieldId)
+
+  // D-6: a confirmed re-assertion returns the stored rows untouched — no
+  // DELETE+INSERT, no oldValue pre-fetch, no display recompute, no
+  // post-hooks, no field triggers, no realtime entry. Any uncertainty in
+  // the comparison answers `null` and the normal write path below runs
+  // unchanged.
+  if (guardRows !== null && typedValue !== null) {
+    const unchanged = await findUnchangedSetResult(ctx, {
+      existingRows: guardRows,
+      fieldType: field.type as FieldType,
+      entityDefinitionId,
+      entityInstanceId,
+      fieldId,
+      value: typedValue,
+    })
+    if (unchanged !== null) {
+      return { state: 'complete', performedAt: new Date().toISOString(), values: unchanged }
+    }
+  }
+
   // 3.6. Capture oldValue BEFORE the null-delete branch — both set and clear
   // paths need it to fire post-hooks identically. Gated on
   // `hasEntityFieldChangeHooks`/`hasFieldTypeChangeHooks` so writes nobody
@@ -2226,6 +2434,14 @@ export async function setValueWithBuiltIn(
 
   // Handle null values (deletion)
   if (typedValue === null) {
+    // B-14: delete-of-absent is a no-op. A clear against a field with no
+    // stored rows (e.g. ingest writing `last_name: null` for single-word
+    // names) must not delete, publish, or fire the post-hook chain — there
+    // is nothing to change. Skipped when the guard is bypassed/disabled
+    // (`guardRows === null`), falling through to the old behavior.
+    if (guardRows !== null && guardRows.length === 0) {
+      return { state: 'complete', performedAt: new Date().toISOString(), values: [] }
+    }
     await deleteValue(ctx, { recordId, fieldId })
     await maybeUpdateDisplayValue(ctx, recordId, field, null)
     if (publishEvents) {
@@ -2263,6 +2479,9 @@ export async function setValueWithBuiltIn(
   // 4. Uniqueness is enforced inside setValueWithType (step 6) — one gate
   // site, running just before the destructive delete, so hook-transformed
   // values are what get checked and a conflict leaves existing rows intact.
+
+  // 5. Idempotency was already decided at step 3.55 — reaching here means
+  // the write is a real change (or the guard was bypassed/disabled).
 
   // 6. Set the value
   const result = await setValueWithType(ctx, {


### PR DESCRIPTION
## Summary

Phase 2 of `plans/events/03-write-context-and-batch-lane-plan.md` (D-6 + B-14): the **idempotency guard on the forward `set` path** — "don't suppress the event, suppress the write" becomes engine behavior instead of caller discipline.

**The defect** (`docs/skip-events-history.md` §8 D3): an identical `set` was a DELETE+INSERT firing the full post-hook chain, realtime frame, and field triggers unconditionally — `oldValue`/`newValue` were never compared. The `'add'` path already dedupes; inverse sync already diffs; only `set` was unguarded. This is what made the relationship-pass re-assertions (#1797) expensive rather than merely redundant, and it's load-bearing for the upcoming count-based lane selection (a fallback full sync re-asserting unchanged data must observe ~0 actual changes).

**The guard**, at `setValueWithBuiltIn` step 3.55 (the funnel every set-shaped write passes through):
- Loads stored rows once, before the destructive path (raw select, deliberately not the lens-gated `getValue`).
- Total, conservative comparison: same row count, stored sortKey order vs incoming array order, per-type payload equality — dates by parsed instant, JSON via sorted-key `stableStringify` on both `v` AND `meta`, relationship ids canonicalized first. **Any uncertainty answers "changed"** — a wrong answer can only cost the old behavior, never a dropped write.
- On a confirmed re-assertion: return the stored rows untouched — no DELETE+INSERT, no oldValue pre-fetch, no display recompute, no post-hooks, no field triggers, no realtime entry.
- `aiGeneration` commits bypass the guard entirely (re-asserting an identical value must still stamp `aiStatus` + metadata), and a stored AI marker forces a real write (the marker must be cleared).
- **B-14**: a clear against zero stored rows is now a no-op — previously ingest writing `last_name: null` for single-word names fired the whole chain with `newValue = null`.

**Known cost:** non-AI set writes pay one extra indexed SELECT for the guard's row load. Natural follow-up: reuse those rows for the oldValue pre-fetch at step 3.6 instead of the separate `getValue` — deliberately not done here to keep the change minimal.

## Test plan

- New `src/field-values/__tests__/set-idempotency.test.ts`: 11 tests — identical scalar/multi-value/JSON-modulo-key-order no-ops, changed value / reordered multi-value / count mismatch write, delete-of-absent no-op vs delete-of-present, `aiGeneration` bypass, stored-AI-marker forces write.
- Full `src/field-values` suite: 25 files / 229 tests pass; adjacent suites exercising the set path (phone-geo, geocoding, threads, kopilot entity tools): 23 files / 247 tests pass. No unhandled errors.
- One pre-existing fixture updated (`batched-realtime-publish.test.ts`): its clear-frame shaping test ran clears against a fake db with zero stored rows, which is now correctly a silent no-op — seeded one stored row so the clears stay real.