### PR TITLE
feat(crud): bind a write session with origin to the unified handler

### DIFF
--- a/packages/lib/src/field-values/field-value-helpers.ts
+++ b/packages/lib/src/field-values/field-value-helpers.ts
@@ -43,6 +43,7 @@ import type { FieldOptions } from '../custom-fields/field-options'
 import { BadRequestError } from '../errors'
 import type { CapabilityView } from '../permissions/capabilities/capability-view'
 import { getRealtimeService, rooms } from '../realtime'
+import type { WriteSession } from '../resources/crud/write-origin'
 import type { ResourceRegistryService } from '../resources/registry/resource-registry-service'
 import { isRecordId, parseRecordId, toRecordId } from '../resources/resource-id'
 import { cascadeDependentDisplayNames, getDisplayFieldDeps } from './display-field-deps'
@@ -112,6 +113,15 @@ export interface FieldValueContext {
    * back would force a cast at every non-request caller.
    */
   capabilities?: CapabilityView
+  /**
+   * The write session this context's mutations run under (plan 03 §4b S4),
+   * threaded from `FieldValueService`'s constructor (which
+   * `UnifiedCrudHandler` feeds its own session). CARRIED ONLY in this slice —
+   * no behavior gate in `field-value-mutations.ts` reads it yet; the
+   * post-hook gate (S5) and batch-lane replay (S7) consume it in later
+   * phases.
+   */
+  session?: WriteSession
 }
 
 // =============================================================================
@@ -123,6 +133,8 @@ export interface CreateFieldValueContextOptions {
   bypassFieldGuards?: ReadonlySet<SystemAttribute>
   skipPreHooks?: boolean
   capabilities?: CapabilityView
+  /** See {@link FieldValueContext.session} — carried for later phases. */
+  session?: WriteSession
 }
 
 const EMPTY_BYPASS: ReadonlySet<SystemAttribute> = new Set()
@@ -148,6 +160,7 @@ export function createFieldValueContext(
     bypassFieldGuards: options.bypassFieldGuards ?? EMPTY_BYPASS,
     skipPreHooks: options.skipPreHooks,
     capabilities: options.capabilities,
+    session: options.session,
   }
 }
 

--- a/packages/lib/src/field-values/field-value-service.ts
+++ b/packages/lib/src/field-values/field-value-service.ts
@@ -6,6 +6,7 @@ import type { RecordId } from '@auxx/types/resource'
 import type { SystemAttribute } from '@auxx/types/system-attribute'
 import { getCachedResourceFields } from '../cache'
 import type { CapabilityView } from '../permissions/capabilities/capability-view'
+import type { WriteSession } from '../resources/crud/write-origin'
 import {
   type CachedField,
   createFieldValueContext,
@@ -68,6 +69,13 @@ export interface FieldValueServiceOptions {
    * path instead of being dropped.
    */
   capabilities?: CapabilityView
+  /**
+   * The write session this service's mutations run under (plan 03 §4b S4).
+   * Threaded onto {@link FieldValueContext.session} — carried for later
+   * phases, no behavior gate reads it in this slice. `UnifiedCrudHandler`
+   * passes its own session here.
+   */
+  session?: WriteSession
 }
 
 export class FieldValueService {
@@ -89,6 +97,7 @@ export class FieldValueService {
     this.ctx = createFieldValueContext(organizationId, userId, db, socketId, {
       bypassFieldGuards: options.bypassFieldGuards,
       capabilities: options.capabilities,
+      session: options.session,
     })
   }
 

--- a/packages/lib/src/resources/crud/__tests__/archive-duplicate-pair-cleanup.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/archive-duplicate-pair-cleanup.test.ts
@@ -48,12 +48,14 @@ vi.mock('../../../events/publisher', () => ({
 }))
 
 import { archiveEntity, type MutationContext } from '../unified-handler-mutations'
+import { interactiveSession } from '../write-origin'
 
 function ctx(): MutationContext {
   return {
     db: {} as never,
     organizationId: 'org_1',
     userId: 'user_1',
+    session: interactiveSession('user_1'),
     fieldValueService: {} as never,
     resolveEntityDefinition: async () => ({
       id: 'def_1',

--- a/packages/lib/src/resources/crud/__tests__/write-session.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/write-session.test.ts
@@ -1,0 +1,180 @@
+// packages/lib/src/resources/crud/__tests__/write-session.test.ts
+//
+// Phase 3 slice (a) of plans/events/03-write-context-and-batch-lane-plan.md:
+// WriteSession core plumbing, behavior-preserving.
+//
+// - S1: session resolution at handler construction (explicit → ambient →
+//   default interactive) and ALS inheritance across a hook-style re-entry
+//   (a handler constructed INSIDE a wrapped write inherits the session).
+// - sessionLane: interactive/api/automation → 'inline', sync/seed → 'silent'.
+// - S3: the derived `publishEvents` at the mutation seam — the deprecated
+//   `skipEvents: true` alias still suppresses, an interactive session still
+//   publishes, and a silent-lane (seed) session suppresses without the alias.
+//
+// @auxx/database is globally mocked in src/test/setup.ts; the mutation-seam
+// tests mock the same seams `archive-duplicate-pair-cleanup.test.ts` does
+// (spread-preserving where the module has more exports).
+
+import { ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  deleteOpenPairsForRecord: vi.fn(async () => ok(0)),
+  enqueueDuplicateScan: vi.fn(async () => 'job_1'),
+  publish: vi.fn(async () => {}),
+  publishLater: vi.fn(() => {}),
+}))
+
+vi.mock('../../../dedup/pairs', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  deleteOpenPairsForRecord: h.deleteOpenPairsForRecord,
+}))
+vi.mock('../../../dedup/enqueue-scan', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  enqueueDuplicateScan: h.enqueueDuplicateScan,
+}))
+vi.mock('../../../entity-instances', () => ({
+  getEntityInstance: vi.fn(async () => ok({ id: 'inst_1', archivedAt: null })),
+  updateEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+  createEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+  deleteEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+}))
+vi.mock('../../../realtime', () => ({
+  getRealtimeService: () => ({ publish: h.publish }),
+  rooms: { orgRecords: () => 'room' },
+}))
+vi.mock('../../../events/publisher', () => ({
+  publisher: { publishLater: h.publishLater, publish: h.publishLater },
+}))
+
+import type { ManifestCollector } from '../../../record-rules/sync-manifest-collector'
+import { UnifiedCrudHandler } from '../unified-handler'
+import { archiveEntity, type MutationContext } from '../unified-handler-mutations'
+import { interactiveSession, seedSession, sessionLane, type WriteSession } from '../write-origin'
+import { getAmbientWriteSession, runWithWriteSession } from '../write-session-als'
+
+/** The session a handler resolved, read through its (public) field-value ctx. */
+function sessionOf(handler: UnifiedCrudHandler): WriteSession | undefined {
+  return handler.fieldValueService.ctx.session
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('S1 — session resolution at handler construction', () => {
+  it('defaults to an interactive session built from the constructor userId + socketId', () => {
+    const handler = new UnifiedCrudHandler('org_1', 'user_1', {} as never, 'sock_1')
+    expect(sessionOf(handler)).toEqual({
+      origin: { kind: 'interactive', userId: 'user_1', socketId: 'sock_1' },
+      depth: 0,
+    })
+  })
+
+  it('an explicit session option wins over the ambient one', () => {
+    const explicit = seedSession('explicit-wins')
+    const handler = runWithWriteSession(
+      seedSession('ambient-loses'),
+      () => new UnifiedCrudHandler('org_1', 'user_1', {} as never, undefined, { session: explicit })
+    )
+    expect(sessionOf(handler)).toBe(explicit)
+  })
+
+  it('a handler constructed inside runWithWriteSession inherits the ambient session', () => {
+    const ambient = seedSession('x')
+    const handler = runWithWriteSession(
+      ambient,
+      () => new UnifiedCrudHandler('org_1', 'user_1', {} as never)
+    )
+    expect(sessionOf(handler)).toBe(ambient)
+  })
+
+  it('hook re-entry: a handler constructed DURING a wrapped write inherits the outer session', async () => {
+    const outerSession = seedSession('outer')
+    const outer = new UnifiedCrudHandler('org_1', 'user_1', {} as never, undefined, {
+      session: outerSession,
+    })
+
+    let ambientDuringWrite: WriteSession | undefined
+    let innerSession: WriteSession | undefined
+    // findByField runs inside findOrCreate's session wrap — the same position
+    // a field hook is in when it constructs its own handler mid-write.
+    vi.spyOn(outer, 'findByField').mockImplementation(async () => {
+      ambientDuringWrite = getAmbientWriteSession()
+      const inner = new UnifiedCrudHandler('org_1', 'system_user', {} as never)
+      innerSession = sessionOf(inner)
+      return { id: 'existing' } as never
+    })
+
+    await outer.findOrCreate('contact', { primary_email: 'a@b.co' })
+
+    expect(ambientDuringWrite).toBe(outerSession)
+    expect(innerSession).toBe(outerSession)
+  })
+})
+
+describe('sessionLane', () => {
+  const collector = {} as ManifestCollector
+
+  it('interactive, api and automation take the inline lane', () => {
+    expect(sessionLane(interactiveSession('user_1'))).toBe('inline')
+    expect(sessionLane({ origin: { kind: 'api', userId: 'user_1' }, depth: 0 })).toBe('inline')
+    expect(
+      sessionLane({
+        origin: { kind: 'automation', actor: 'system_user', cause: { type: 'rule', id: 'r1' } },
+        depth: 0,
+      })
+    ).toBe('inline')
+  })
+
+  it('sync and seed take the silent lane (matches skipEvents semantics until Phase 4)', () => {
+    expect(
+      sessionLane({
+        origin: { kind: 'sync', source: 'connector', ref: 'run_1', collector },
+        depth: 0,
+      })
+    ).toBe('silent')
+    expect(sessionLane(seedSession('reshape'))).toBe('silent')
+  })
+})
+
+describe('S3 — derived publishEvents at the mutation seam', () => {
+  function ctx(session: WriteSession): MutationContext {
+    return {
+      db: {} as never,
+      organizationId: 'org_1',
+      userId: 'user_1',
+      session,
+      fieldValueService: {} as never,
+      resolveEntityDefinition: async () => ({
+        id: 'def_1',
+        entityType: 'contact',
+        apiSlug: 'contacts',
+      }),
+      getFields: async () => [],
+      runPreHooks: async (_o, _d, values) => values,
+      validateUniqueFields: async () => {},
+      setFieldValues: async () => {},
+    }
+  }
+
+  it('an interactive session publishes the archive fan-out', async () => {
+    await archiveEntity(ctx(interactiveSession('user_1')), 'def_1:inst_1' as never)
+    expect(h.publishLater).toHaveBeenCalledTimes(1)
+    expect(h.publish).toHaveBeenCalledTimes(1)
+  })
+
+  it('the deprecated skipEvents: true alias still suppresses, even on an interactive session', async () => {
+    await archiveEntity(ctx(interactiveSession('user_1')), 'def_1:inst_1' as never, {
+      skipEvents: true,
+    })
+    expect(h.publishLater).not.toHaveBeenCalled()
+    expect(h.publish).not.toHaveBeenCalled()
+  })
+
+  it('a silent-lane (seed) session suppresses without the alias', async () => {
+    await archiveEntity(ctx(seedSession('reshape')), 'def_1:inst_1' as never)
+    expect(h.publishLater).not.toHaveBeenCalled()
+    expect(h.publish).not.toHaveBeenCalled()
+    // Data hygiene stays outside the event gate.
+    expect(h.deleteOpenPairsForRecord).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/lib/src/resources/crud/index.ts
+++ b/packages/lib/src/resources/crud/index.ts
@@ -57,3 +57,13 @@ export {
   setCustomFields,
   trackChanges,
 } from './utils'
+
+// Write session (plan 03 §4/§4b — Phase 3 slice a)
+export {
+  interactiveSession,
+  seedSession,
+  sessionLane,
+  type WriteOrigin,
+  type WriteSession,
+} from './write-origin'
+export { getAmbientWriteSession, runWithWriteSession } from './write-session-als'

--- a/packages/lib/src/resources/crud/types.ts
+++ b/packages/lib/src/resources/crud/types.ts
@@ -23,8 +23,6 @@ export interface CrudContext {
   userId: string
   /** Optional transaction for batching */
   tx?: Transaction
-  /** Skip event publishing (e.g., bulk imports) */
-  skipEvents?: boolean
 }
 
 /** Result of a CRUD operation - success case */

--- a/packages/lib/src/resources/crud/unified-handler-mutations.ts
+++ b/packages/lib/src/resources/crud/unified-handler-mutations.ts
@@ -31,6 +31,7 @@ import { EntityMergeService } from '../merge'
 import type { ResourceField } from '../registry/field-types'
 import { parseRecordId, type RecordId, toRecordId } from '../resource-id'
 import type { ResolvedEntityDefinition } from './types'
+import { sessionLane, type WriteSession } from './write-origin'
 
 const logger = createScopedLogger('unified-handler-mutations')
 
@@ -50,6 +51,11 @@ export interface CrudOptions {
    * so record rules still see the writes and fire with `source: 'sync'`. Seed writers
    * are the ONLY documented exemption (they stay silent forever). "Silent skipEvents"
    * therefore means seed-only — anything else is a bug.
+   *
+   * @deprecated Construct the handler with a `session` instead
+   * (`UnifiedCrudHandlerOptions.session`, plan 03 §4b S1); this alias maps to
+   * silent-lane behavior and will be removed once every §3 writer declares its
+   * origin. `skipEvents: true` still wins over the session-derived lane.
    */
   skipEvents?: boolean
   /**
@@ -74,6 +80,12 @@ export interface MutationContext {
   userId: string
   /** Pusher socket ID of the originating client — used for self-event exclusion in realtime sync. */
   socketId?: string
+  /**
+   * The write session this mutation runs under (plan 03 §4b S3). The
+   * per-write event fan-out (`publishEvents`) is derived from its lane via
+   * {@link derivePublishEvents} — the deprecated `skipEvents` alias still wins.
+   */
+  session: WriteSession
   fieldValueService: FieldValueService
   resolveEntityDefinition: (entityDefinitionId: string) => Promise<ResolvedEntityDefinition>
   getFields: (entityDefinitionId: string) => Promise<CustomFieldEntity[]>
@@ -120,6 +132,19 @@ function unwrapResult<T>(result: Result<T, { message: string; cause?: unknown }>
     throw new Error(result.error.message, { cause: result.error.cause })
   }
   return result.value
+}
+
+/**
+ * The S3 conversion seam (plan 03 §4b): ONE derived boolean per mutation call
+ * gates the whole per-write fan-out (bus event, realtime frames, dedup
+ * enqueue, event-data capture). The deprecated `skipEvents: true` alias still
+ * wins — behavior preserving; otherwise the session's lane decides:
+ * interactive/api/automation → publish, sync/seed → silent (exactly today's
+ * `skipEvents` semantics until the Phase 4 batch lane lands).
+ */
+function derivePublishEvents(ctx: MutationContext, options: CrudOptions): boolean {
+  if (options.skipEvents === true) return false
+  return sessionLane(ctx.session) === 'inline'
 }
 
 /**
@@ -338,6 +363,8 @@ export async function createEntity(
   values: Record<string, unknown>,
   options: CrudOptions = {}
 ): Promise<CreateEntityResult> {
+  // S3: one derived boolean per call gates the whole per-write fan-out below.
+  const publishEvents = derivePublishEvents(ctx, options)
   const entityDef = await ctx.resolveEntityDefinition(entityDefinitionId)
 
   // Apply configured defaults for any creatable field the caller omitted.
@@ -384,11 +411,10 @@ export async function createEntity(
   // Build RecordId for field value operations
   const recordId = toRecordId(entityDef.id, instance.id)
 
-  // Set field values using RecordId. Bulk writes (skipEvents) also suppress the
-  // field-value realtime + triggers end-to-end via publishEvents:false.
-  await ctx.setFieldValues(recordId, processedValues, undefined, {
-    publishEvents: !options.skipEvents,
-  })
+  // Set field values using RecordId. Silent-lane writes (sync/seed sessions,
+  // or the deprecated skipEvents alias) also suppress the field-value
+  // realtime + triggers end-to-end via publishEvents:false.
+  await ctx.setFieldValues(recordId, processedValues, undefined, { publishEvents })
 
   // Re-read the instance so displayName / secondaryDisplayValue / avatarUrl
   // reflect what setFieldValues' maybeUpdateDisplayValue just wrote. The
@@ -401,8 +427,8 @@ export async function createEntity(
   })
   const freshInstance = freshResult.isOk() ? freshResult.value : instance
 
-  // Publish event (unless skipped for bulk imports)
-  if (!options.skipEvents) {
+  // Publish event (unless suppressed by the silent lane)
+  if (publishEvents) {
     const fields = await ctx.getFields(entityDef.id)
     const eventData = extractEventData(entityDef.entityType, fields, processedValues)
     const relatedRecordId = findRelatedRecordId(entityDef.entityType, eventData)
@@ -421,7 +447,7 @@ export async function createEntity(
   }
 
   // Publish record:created realtime event
-  if (!options.skipEvents) {
+  if (publishEvents) {
     getRealtimeService()
       .publish(
         rooms.orgRecords(ctx.organizationId, entityDef.id),
@@ -474,6 +500,8 @@ export async function updateEntity(
   modes?: Record<string, 'set' | 'add' | 'remove'>,
   options: CrudOptions = {}
 ) {
+  // S3: one derived boolean per call gates the whole per-write fan-out below.
+  const publishEvents = derivePublishEvents(ctx, options)
   const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
 
   // Single fetch to verify existence
@@ -498,10 +526,8 @@ export async function updateEntity(
 
   // Set field values using resolved RecordId. Per-field modes default to
   // 'set' when missing — today's behavior for every caller that omits modes.
-  // Bulk writes (skipEvents) suppress the field-value realtime + triggers too.
-  await ctx.setFieldValues(resolvedRecordId, processedValues, modes, {
-    publishEvents: !options.skipEvents,
-  })
+  // Silent-lane writes suppress the field-value realtime + triggers too.
+  await ctx.setFieldValues(resolvedRecordId, processedValues, modes, { publishEvents })
 
   // Re-read so displayName / secondaryDisplayValue / avatarUrl / updatedAt
   // reflect what setFieldValues just wrote. The `instance` captured at the
@@ -512,8 +538,8 @@ export async function updateEntity(
   })
   const freshInstance = freshResult.isOk() ? freshResult.value : instance
 
-  // Publish event (unless skipped for bulk imports)
-  if (!options.skipEvents) {
+  // Publish event (unless suppressed by the silent lane)
+  if (publishEvents) {
     const fields = await ctx.getFields(entityDef.id)
     const eventData = extractEventData(entityDef.entityType, fields, processedValues)
     const relatedRecordId = findRelatedRecordId(entityDef.entityType, eventData)
@@ -534,7 +560,7 @@ export async function updateEntity(
   // Publish record:updated realtime event so other tabs can refresh the row's
   // denormalized metadata (displayName, etc). Field-value changes ride on
   // fieldValues:updated; this event is only for the record-level columns.
-  if (!options.skipEvents) {
+  if (publishEvents) {
     getRealtimeService()
       .publish(
         rooms.orgRecords(ctx.organizationId, entityDef.id),
@@ -575,6 +601,8 @@ export async function archiveEntity(
   recordId: RecordId,
   options: CrudOptions = {}
 ) {
+  // S3: one derived boolean per call gates the whole per-write fan-out below.
+  const publishEvents = derivePublishEvents(ctx, options)
   const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
 
   const instanceResult = await getEntityInstance({
@@ -594,7 +622,7 @@ export async function archiveEntity(
 
   unwrapResult(updateResult)
 
-  if (!options.skipEvents) {
+  if (publishEvents) {
     publishEvent({
       recordId,
       entityType: entityDef.entityType,
@@ -608,7 +636,7 @@ export async function archiveEntity(
   }
 
   // Publish record:archived realtime event
-  if (!options.skipEvents) {
+  if (publishEvents) {
     getRealtimeService()
       .publish(
         rooms.orgRecords(ctx.organizationId, entityDef.id),
@@ -619,9 +647,9 @@ export async function archiveEntity(
       .catch(() => {})
   }
 
-  // Duplicate-suggestion cleanup — deliberately OUTSIDE the `skipEvents` guard.
-  // Pair cleanup is data hygiene, not an event: a `skipEvents` bulk archive must
-  // still clean up after itself. Only `open` rows go; `dismissed` carries the
+  // Duplicate-suggestion cleanup — deliberately OUTSIDE the `publishEvents`
+  // guard. Pair cleanup is data hygiene, not an event: a silent-lane bulk
+  // archive must still clean up after itself. Only `open` rows go; `dismissed` carries the
   // band that governs reopen and `merged` is the audit trail.
   // (`bulkArchiveEntities` delegates here per record, so it is covered too.)
   try {
@@ -649,6 +677,8 @@ export async function restoreEntity(
   recordId: RecordId,
   options: CrudOptions = {}
 ) {
+  // S3: one derived boolean per call gates the whole per-write fan-out below.
+  const publishEvents = derivePublishEvents(ctx, options)
   const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
 
   const instanceResult = await getEntityInstance({
@@ -668,7 +698,7 @@ export async function restoreEntity(
 
   unwrapResult(updateResult)
 
-  if (!options.skipEvents) {
+  if (publishEvents) {
     publishEvent({
       recordId,
       entityType: entityDef.entityType,
@@ -697,6 +727,8 @@ export async function deleteEntity(
   recordId: RecordId,
   options: CrudOptions = {}
 ): Promise<void> {
+  // S3: one derived boolean per call gates the whole per-write fan-out below.
+  const publishEvents = derivePublishEvents(ctx, options)
   const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
 
   const instanceResult = await getEntityInstance({
@@ -721,7 +753,7 @@ export async function deleteEntity(
       ? getEntityPostDeleteHooks(entityDef.apiSlug)
       : []
   let eventData: Record<string, unknown> = { hardDelete: true }
-  if (!options.skipEvents || preDeleteHooks.length > 0 || postDeleteHooks.length > 0) {
+  if (publishEvents || preDeleteHooks.length > 0 || postDeleteHooks.length > 0) {
     const fields = await ctx.getFields(entityDef.id)
     const captured = await captureEventData(ctx.fieldValueService, recordId, fields)
     eventData = { hardDelete: true, ...captured }
@@ -777,7 +809,7 @@ export async function deleteEntity(
     }
   }
 
-  if (!options.skipEvents) {
+  if (publishEvents) {
     publishEvent({
       recordId,
       entityType: entityDef.entityType,

--- a/packages/lib/src/resources/crud/unified-handler.ts
+++ b/packages/lib/src/resources/crud/unified-handler.ts
@@ -71,6 +71,8 @@ import {
   querySystemResourceIdsPaged,
   resolveEntityIdFromCache,
 } from './unified-handler-queries'
+import { interactiveSession, type WriteSession } from './write-origin'
+import { getAmbientWriteSession, runWithWriteSession } from './write-session-als'
 
 type EntityInstanceEntity = typeof schema.EntityInstance.$inferSelect
 
@@ -160,6 +162,14 @@ export interface UnifiedCrudHandlerOptions {
    * {@link assertRequestScoped} turns the silent read into a loud 403.
    */
   requestPath?: boolean
+  /**
+   * The write session this handler's mutations run under (plan 03 §4b S1).
+   * Resolution order: this explicit option → the ambient session from
+   * {@link getAmbientWriteSession} (a hook or nested lib call inheriting its
+   * parent's session) → a default `interactive` session built from the
+   * constructor's `userId` + `socketId`.
+   */
+  session?: WriteSession
 }
 
 export class UnifiedCrudHandler {
@@ -170,6 +180,12 @@ export class UnifiedCrudHandler {
   private capabilities?: CapabilityView
   /** Per-handler memo of {@link recordScope}, keyed by canonical def id. */
   private scopeCache = new Map<string, Promise<RecordVisibilityScope>>()
+  /**
+   * The write session this handler's mutations run under (plan 03 §4b S1).
+   * Every public write method enters `runWithWriteSession(this.session, …)`,
+   * so hooks that construct their own handler mid-write inherit it ambiently.
+   */
+  private session: WriteSession
 
   constructor(
     private organizationId: string,
@@ -180,12 +196,19 @@ export class UnifiedCrudHandler {
   ) {
     this.db = db ?? defaultDatabase
     this.bypassFieldGuards = options.bypassFieldGuards ?? new Set()
+    // S1 resolution: explicit option → ambient (hook re-entry inherits its
+    // parent's session) → default interactive from the constructor identity.
+    this.session =
+      options.session ?? getAmbientWriteSession() ?? interactiveSession(userId, socketId)
     // §5.1: a request-path construction that forgot to thread `ctx.capabilities`
     // would read the whole org unscoped. Fail loudly instead.
     if (options.requestPath) assertRequestScoped(options.capabilities, 'UnifiedCrudHandler')
     this.capabilities = options.capabilities
     this.fieldValueService = new FieldValueService(organizationId, userId, this.db, socketId, {
       bypassFieldGuards: this.bypassFieldGuards,
+      // S4: the field-value layer carries the session for later phases; no
+      // behavior gate reads it yet.
+      session: this.session,
       // Forwarded since plan v3/03 §5.4. Without it this handler enforced
       // `canViewEntity` on its OWN reads while the FieldValueService it owns ran
       // unenforced — so `batchGetValues`' def/path filter and the relationship
@@ -205,6 +228,7 @@ export class UnifiedCrudHandler {
       organizationId: this.organizationId,
       userId: this.userId,
       socketId: this.socketId,
+      session: this.session,
       fieldValueService: this.fieldValueService,
       resolveEntityDefinition: this.resolveEntityDefinition.bind(this),
       getFields: this.getCustomFieldsCached.bind(this),
@@ -212,6 +236,17 @@ export class UnifiedCrudHandler {
       validateUniqueFields: this.validateUniqueFields.bind(this),
       setFieldValues: this.setFieldValues.bind(this),
     }
+  }
+
+  /**
+   * Enter this handler's write session for the duration of one public write
+   * method (plan 03 §4b S1). Everything downstream — including hooks that
+   * construct their own `UnifiedCrudHandler` mid-write — reads the ambient
+   * session via `getAmbientWriteSession()` and so inherits it without any
+   * signature change. Read methods stay unwrapped.
+   */
+  private inWriteSession<T>(fn: () => Promise<T>): Promise<T> {
+    return runWithWriteSession(this.session, fn)
   }
 
   /**
@@ -386,26 +421,28 @@ export class UnifiedCrudHandler {
     values: Record<string, unknown>,
     options: CrudOptions = {}
   ): Promise<CreateEntityResult> {
-    // Write enforcement (§2): absent capabilities ⇒ internal caller ⇒ unrestricted.
-    this.capabilities?.assertEditEntity(entityDefinitionId)
-    await this.warmCache(entityDefinitionId)
-    // The `external_id` ARRAY attribute is retired (contact/company). Its writers
-    // (browser extension) still send it under `values` as an array; peel it off
-    // and mirror each entry into the `RecordIdentity` index (app-less link)
-    // instead of a FieldValue. Gated on Array to leave `thread`'s scalar
-    // `external_id` dbColumn — a plain string — on the normal write path.
-    const isRetiredArray = Array.isArray(values.external_id)
-    const { external_id, ...rest } = values
-    const result = await createEntity(
-      this.getMutationContext(),
-      entityDefinitionId,
-      isRetiredArray ? rest : values,
-      options
-    )
-    if (isRetiredArray) {
-      await this.mirrorExternalIdentities(result.instance, external_id)
-    }
-    return result
+    return this.inWriteSession(async () => {
+      // Write enforcement (§2): absent capabilities ⇒ internal caller ⇒ unrestricted.
+      this.capabilities?.assertEditEntity(entityDefinitionId)
+      await this.warmCache(entityDefinitionId)
+      // The `external_id` ARRAY attribute is retired (contact/company). Its writers
+      // (browser extension) still send it under `values` as an array; peel it off
+      // and mirror each entry into the `RecordIdentity` index (app-less link)
+      // instead of a FieldValue. Gated on Array to leave `thread`'s scalar
+      // `external_id` dbColumn — a plain string — on the normal write path.
+      const isRetiredArray = Array.isArray(values.external_id)
+      const { external_id, ...rest } = values
+      const result = await createEntity(
+        this.getMutationContext(),
+        entityDefinitionId,
+        isRetiredArray ? rest : values,
+        options
+      )
+      if (isRetiredArray) {
+        await this.mirrorExternalIdentities(result.instance, external_id)
+      }
+      return result
+    })
   }
 
   /**
@@ -458,10 +495,12 @@ export class UnifiedCrudHandler {
     modes?: Record<string, 'set' | 'add' | 'remove'>,
     options: CrudOptions = {}
   ) {
-    const { entityDefinitionId } = parseRecordId(recordId)
-    await this.assertEditRows([recordId])
-    await this.warmCache(entityDefinitionId)
-    return updateEntity(this.getMutationContext(), recordId, values, modes, options)
+    return this.inWriteSession(async () => {
+      const { entityDefinitionId } = parseRecordId(recordId)
+      await this.assertEditRows([recordId])
+      await this.warmCache(entityDefinitionId)
+      return updateEntity(this.getMutationContext(), recordId, values, modes, options)
+    })
   }
 
   /**
@@ -587,16 +626,18 @@ export class UnifiedCrudHandler {
     findBy: Record<string, unknown>,
     createValues: Record<string, unknown> = {}
   ): Promise<{ instance: EntityInstanceEntity; created: boolean }> {
-    // Try to find by the findBy fields first
-    const [fieldKey, fieldValue] = Object.entries(findBy)[0]!
-    const existing = await this.findByField(entityDefinitionId, fieldKey, fieldValue)
+    return this.inWriteSession(async () => {
+      // Try to find by the findBy fields first
+      const [fieldKey, fieldValue] = Object.entries(findBy)[0]!
+      const existing = await this.findByField(entityDefinitionId, fieldKey, fieldValue)
 
-    if (existing) {
-      return { instance: existing, created: false }
-    }
+      if (existing) {
+        return { instance: existing, created: false }
+      }
 
-    const result = await this.create(entityDefinitionId, { ...findBy, ...createValues })
-    return { instance: result.instance, created: true }
+      const result = await this.create(entityDefinitionId, { ...findBy, ...createValues })
+      return { instance: result.instance, created: true }
+    })
   }
 
   /**
@@ -606,11 +647,13 @@ export class UnifiedCrudHandler {
    * @param options - Optional CRUD options (skipEvents)
    */
   async archive(recordId: RecordId, options: CrudOptions = {}) {
-    const { entityDefinitionId } = parseRecordId(recordId)
-    // Soft delete is an edit (§0.1) — judged at the row, not the def (§5.3).
-    await this.assertEditRows([recordId])
-    await this.warmCache(entityDefinitionId)
-    return archiveEntity(this.getMutationContext(), recordId, options)
+    return this.inWriteSession(async () => {
+      const { entityDefinitionId } = parseRecordId(recordId)
+      // Soft delete is an edit (§0.1) — judged at the row, not the def (§5.3).
+      await this.assertEditRows([recordId])
+      await this.warmCache(entityDefinitionId)
+      return archiveEntity(this.getMutationContext(), recordId, options)
+    })
   }
 
   /**
@@ -620,10 +663,12 @@ export class UnifiedCrudHandler {
    * @param options - Optional CRUD options (skipEvents)
    */
   async restore(recordId: RecordId, options: CrudOptions = {}) {
-    const { entityDefinitionId } = parseRecordId(recordId)
-    await this.assertEditRows([recordId])
-    await this.warmCache(entityDefinitionId)
-    return restoreEntity(this.getMutationContext(), recordId, options)
+    return this.inWriteSession(async () => {
+      const { entityDefinitionId } = parseRecordId(recordId)
+      await this.assertEditRows([recordId])
+      await this.warmCache(entityDefinitionId)
+      return restoreEntity(this.getMutationContext(), recordId, options)
+    })
   }
 
   /**
@@ -633,14 +678,16 @@ export class UnifiedCrudHandler {
    * @param options - Optional CRUD options (skipEvents)
    */
   async delete(recordId: RecordId, options: CrudOptions = {}): Promise<void> {
-    const { entityDefinitionId } = parseRecordId(recordId)
-    // Record delete is a write (§0.1); the router additionally asserts the
-    // per-row DELETE rule (`assertCanDeleteRows`) before it gets here. The edit
-    // floor must be read at the ROW too, or a row the router's stamp just
-    // cleared for deletion would be refused here by the def gate.
-    await this.assertEditRows([recordId])
-    await this.warmCache(entityDefinitionId)
-    return deleteEntity(this.getMutationContext(), recordId, options)
+    return this.inWriteSession(async () => {
+      const { entityDefinitionId } = parseRecordId(recordId)
+      // Record delete is a write (§0.1); the router additionally asserts the
+      // per-row DELETE rule (`assertCanDeleteRows`) before it gets here. The edit
+      // floor must be read at the ROW too, or a row the router's stamp just
+      // cleared for deletion would be refused here by the def gate.
+      await this.assertEditRows([recordId])
+      await this.warmCache(entityDefinitionId)
+      return deleteEntity(this.getMutationContext(), recordId, options)
+    })
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -660,9 +707,11 @@ export class UnifiedCrudHandler {
     options: CrudOptions = {}
   ): Promise<{ created: EntityInstanceEntity[]; errors: Array<{ index: number; error: string }> }> {
     if (items.length === 0) return { created: [], errors: [] }
-    this.capabilities?.assertEditEntity(entityDefinitionId)
-    await this.warmCache(entityDefinitionId)
-    return bulkCreateEntities(this.getMutationContext(), entityDefinitionId, items, options)
+    return this.inWriteSession(async () => {
+      this.capabilities?.assertEditEntity(entityDefinitionId)
+      await this.warmCache(entityDefinitionId)
+      return bulkCreateEntities(this.getMutationContext(), entityDefinitionId, items, options)
+    })
   }
 
   /**
@@ -676,10 +725,12 @@ export class UnifiedCrudHandler {
     options: CrudOptions = {}
   ): Promise<{ updated: number; errors: Array<{ recordId: RecordId; error: string }> }> {
     if (updates.length === 0) return { updated: 0, errors: [] }
-    await this.assertEditRows(updates.map((u) => u.recordId))
-    const { entityDefinitionId } = parseRecordId(updates[0]!.recordId)
-    await this.warmCache(entityDefinitionId)
-    return bulkUpdateEntities(this.getMutationContext(), updates, options)
+    return this.inWriteSession(async () => {
+      await this.assertEditRows(updates.map((u) => u.recordId))
+      const { entityDefinitionId } = parseRecordId(updates[0]!.recordId)
+      await this.warmCache(entityDefinitionId)
+      return bulkUpdateEntities(this.getMutationContext(), updates, options)
+    })
   }
 
   /**
@@ -690,10 +741,12 @@ export class UnifiedCrudHandler {
    */
   async bulkArchive(recordIds: RecordId[], options: CrudOptions = {}): Promise<{ count: number }> {
     if (recordIds.length === 0) return { count: 0 }
-    await this.assertEditRows(recordIds)
-    const { entityDefinitionId } = parseRecordId(recordIds[0]!)
-    await this.warmCache(entityDefinitionId)
-    return bulkArchiveEntities(this.getMutationContext(), recordIds, options)
+    return this.inWriteSession(async () => {
+      await this.assertEditRows(recordIds)
+      const { entityDefinitionId } = parseRecordId(recordIds[0]!)
+      await this.warmCache(entityDefinitionId)
+      return bulkArchiveEntities(this.getMutationContext(), recordIds, options)
+    })
   }
 
   /**
@@ -707,10 +760,12 @@ export class UnifiedCrudHandler {
     options: CrudOptions = {}
   ): Promise<{ count: number; errors: Array<{ recordId: RecordId; message: string }> }> {
     if (recordIds.length === 0) return { count: 0, errors: [] }
-    await this.assertEditRows(recordIds)
-    const { entityDefinitionId } = parseRecordId(recordIds[0]!)
-    await this.warmCache(entityDefinitionId)
-    return bulkDeleteEntities(this.getMutationContext(), recordIds, options)
+    return this.inWriteSession(async () => {
+      await this.assertEditRows(recordIds)
+      const { entityDefinitionId } = parseRecordId(recordIds[0]!)
+      await this.warmCache(entityDefinitionId)
+      return bulkDeleteEntities(this.getMutationContext(), recordIds, options)
+    })
   }
 
   /**
@@ -726,8 +781,10 @@ export class UnifiedCrudHandler {
     value: unknown
   ): Promise<{ count: number }> {
     if (recordIds.length === 0) return { count: 0 }
-    await this.assertEditRows(recordIds)
-    return bulkSetFieldValue(this.getMutationContext(), recordIds, fieldId, value)
+    return this.inWriteSession(async () => {
+      await this.assertEditRows(recordIds)
+      return bulkSetFieldValue(this.getMutationContext(), recordIds, fieldId, value)
+    })
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -1050,11 +1107,13 @@ export class UnifiedCrudHandler {
    * @param sourceRecordIds - RecordIds of instances to merge into target
    */
   async merge(targetRecordId: RecordId, sourceRecordIds: RecordId[]) {
-    // Merge writes the survivor and removes the sources — the edit floor is
-    // asserted per ROW (§5.3) on the target and every source; the router's
-    // `assertCanDeleteRows` carries the destruction half.
-    await this.assertEditRows([targetRecordId, ...sourceRecordIds])
-    return mergeEntities(this.getMutationContext(), targetRecordId, sourceRecordIds)
+    return this.inWriteSession(async () => {
+      // Merge writes the survivor and removes the sources — the edit floor is
+      // asserted per ROW (§5.3) on the target and every source; the router's
+      // `assertCanDeleteRows` carries the destruction half.
+      await this.assertEditRows([targetRecordId, ...sourceRecordIds])
+      return mergeEntities(this.getMutationContext(), targetRecordId, sourceRecordIds)
+    })
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -1069,9 +1128,11 @@ export class UnifiedCrudHandler {
    * @param values - Field values (fieldId -> value)
    */
   async createWithValues(entityDefinitionId: string, values: Record<string, unknown>) {
-    this.capabilities?.assertEditEntity(entityDefinitionId)
-    await this.warmCache(entityDefinitionId)
-    return createWithValuesImpl(this.getMutationContext(), entityDefinitionId, values)
+    return this.inWriteSession(async () => {
+      this.capabilities?.assertEditEntity(entityDefinitionId)
+      await this.warmCache(entityDefinitionId)
+      return createWithValuesImpl(this.getMutationContext(), entityDefinitionId, values)
+    })
   }
 
   /**
@@ -1082,21 +1143,23 @@ export class UnifiedCrudHandler {
    * @param values - Field values to update (fieldId -> value)
    */
   async updateValues(instanceId: string, values: Record<string, unknown>) {
-    // Only the instanceId is known here, so resolve its def to enforce — but
-    // solely when a request-scoped CapabilityView is present (internal callers
-    // skip the extra lookup entirely).
-    if (this.capabilities) {
-      const instance = await getEntityInstance({
-        id: instanceId,
-        organizationId: this.organizationId,
-      })
-      // Per row (§5.3), not per def — the RecordId is reconstructible once the
-      // def is known, so this lane gets the same gate as `update`.
-      if (instance.isOk()) {
-        await this.assertEditRows([toRecordId(instance.value.entityDefinitionId, instanceId)])
+    return this.inWriteSession(async () => {
+      // Only the instanceId is known here, so resolve its def to enforce — but
+      // solely when a request-scoped CapabilityView is present (internal callers
+      // skip the extra lookup entirely).
+      if (this.capabilities) {
+        const instance = await getEntityInstance({
+          id: instanceId,
+          organizationId: this.organizationId,
+        })
+        // Per row (§5.3), not per def — the RecordId is reconstructible once the
+        // def is known, so this lane gets the same gate as `update`.
+        if (instance.isOk()) {
+          await this.assertEditRows([toRecordId(instance.value.entityDefinitionId, instanceId)])
+        }
       }
-    }
-    return updateValuesImpl(this.getMutationContext(), instanceId, values)
+      return updateValuesImpl(this.getMutationContext(), instanceId, values)
+    })
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -1111,17 +1174,19 @@ export class UnifiedCrudHandler {
    * @param value - Value to set
    */
   async setFieldValue(recordId: RecordId, fieldId: string, value: unknown): Promise<void> {
-    const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
-    const entityDef = await this.resolveEntityDefinition(entityDefinitionId)
+    return this.inWriteSession(async () => {
+      const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+      const entityDef = await this.resolveEntityDefinition(entityDefinitionId)
 
-    // Use FieldValueService with RecordId (no modelType needed)
-    await this.fieldValueService.setValueWithBuiltIn({
-      recordId,
-      fieldId,
-      value,
+      // Use FieldValueService with RecordId (no modelType needed)
+      await this.fieldValueService.setValueWithBuiltIn({
+        recordId,
+        fieldId,
+        value,
+      })
+
+      await this.publishEvent('updated', entityDef, entityInstanceId, { [fieldId]: value })
     })
-
-    await this.publishEvent('updated', entityDef, entityInstanceId, { [fieldId]: value })
   }
 
   /**

--- a/packages/lib/src/resources/crud/write-origin.ts
+++ b/packages/lib/src/resources/crud/write-origin.ts
@@ -1,0 +1,98 @@
+// packages/lib/src/resources/crud/write-origin.ts
+
+// Phase 3 of plans/events/03-write-context-and-batch-lane-plan.md (§4):
+// writers declare what a write IS — never what to skip. The origin binds to a
+// WriteSession at handler construction and flows through the mutation layer,
+// replacing the `skipEvents` boolean over time.
+
+import type { ManifestCollector } from '../../record-rules/sync-manifest-collector'
+
+/**
+ * What a write IS, declared by the writer (plan 03 §4). One of five kinds:
+ *
+ * - `interactive` — a human in the product. Default when a handler is built
+ *   with a real userId + request path.
+ * - `api` — public API / SDK. Behaves like interactive; actor is the token owner.
+ * - `automation` — server-side automation: workflows, rules, agents, hooks,
+ *   steady-state ingest. Fires per-record; actor is a SYSTEM actor user id,
+ *   `cause` names what started it.
+ * - `sync` — connector / import / mail-backfill / retro jobs. NOTE: there is
+ *   deliberately no `phase` field — the small-run vs batch lane is decided at
+ *   finalize from the OBSERVED changed-set count (D-12), never declared by the
+ *   writer. `collector` is the B2 manifest contract as a type.
+ * - `seed` — seeders and data migrations. Silent forever (the documented
+ *   exemption).
+ */
+export type WriteOrigin =
+  /** A human in the product. Default when a handler is built with a real userId + request path. */
+  | { kind: 'interactive'; userId: string; socketId?: string }
+  /** Public API / SDK. Behaves like interactive; actor is the token owner. */
+  | { kind: 'api'; userId: string; tokenRef?: string }
+  /**
+   * Server-side automation: workflows, rules, agents, hooks, steady-state
+   * ingest. `actor` is a system actor user id; `cause` names what started it.
+   */
+  | { kind: 'automation'; actor: string; cause?: { type: string; id: string } }
+  /**
+   * Connector / import / mail-backfill / retro jobs. Deliberately carries no
+   * `phase` field — lane selection is count-based at finalize (D-12).
+   */
+  | {
+      kind: 'sync'
+      source: 'connector' | 'import' | 'mail' | 'retro'
+      /** runId | importJobId — the collector's identity. */
+      ref: string
+      /** REQUIRED: the B2 manifest contract as a type. */
+      collector: ManifestCollector
+    }
+  /** Seed / reshape. Silent forever. */
+  | { kind: 'seed'; reason: string }
+
+/**
+ * The origin plus cascade state, bound at handler construction (plan 03 §4b
+ * S1) and inherited by nested handlers via AsyncLocalStorage (see
+ * `write-session-als.ts`).
+ *
+ * `depth` will absorb the record-rules `ruleChain` ALS's depth/seen cascade
+ * guard over time (S9), so there is one cascade guard, not two. For this
+ * slice it is carried but not yet enforced.
+ */
+export interface WriteSession {
+  origin: WriteOrigin
+  depth: number
+}
+
+/** Build an interactive session — the default for a handler constructed with a userId. */
+export function interactiveSession(userId: string, socketId?: string): WriteSession {
+  return { origin: { kind: 'interactive', userId, socketId }, depth: 0 }
+}
+
+/** Build a seed session — silent forever (the documented exemption). */
+export function seedSession(reason: string): WriteSession {
+  return { origin: { kind: 'seed', reason }, depth: 0 }
+}
+
+/**
+ * The execution lane a session's writes take TODAY.
+ *
+ * - `'inline'` — per-record fan-out as it happens (bus event, realtime,
+ *   timeline, field-change hooks): interactive, api, automation.
+ * - `'silent'` — no per-write fan-out: sync, seed. This matches the current
+ *   `skipEvents: true` semantics exactly — sync writers still feed the B2
+ *   manifest collector, seed stays silent forever.
+ *
+ * The batched replay lane (accumulate against the run ref, finalize pipeline,
+ * count-based small-run vs batch selection per D-12) arrives in Phase 4; until
+ * then `sync` maps to `'silent'` so behavior is preserved.
+ */
+export function sessionLane(session: WriteSession): 'inline' | 'silent' {
+  switch (session.origin.kind) {
+    case 'interactive':
+    case 'api':
+    case 'automation':
+      return 'inline'
+    case 'sync':
+    case 'seed':
+      return 'silent'
+  }
+}

--- a/packages/lib/src/resources/crud/write-session-als.ts
+++ b/packages/lib/src/resources/crud/write-session-als.ts
@@ -1,0 +1,30 @@
+// packages/lib/src/resources/crud/write-session-als.ts
+
+// Ambient WriteSession propagation (plan 03 §4b S1). Modeled on the proven
+// `ruleChain` ALS in record-rules/engine.ts: the handler enters
+// `runWithWriteSession(session, ...)` around every public write method, so
+// hooks and nested lib calls that construct a fresh UnifiedCrudHandler
+// mid-write inherit the parent session (via S1's resolution order) instead of
+// silently resetting to interactive.
+
+import { AsyncLocalStorage } from 'node:async_hooks'
+import type { WriteSession } from './write-origin'
+
+const writeSessionAls = new AsyncLocalStorage<WriteSession>()
+
+/**
+ * Run `fn` with `session` as the ambient write session. Nested calls with the
+ * same session are harmless; a nested call with a different session shadows
+ * the outer one for its own subtree (standard ALS semantics).
+ */
+export function runWithWriteSession<T>(session: WriteSession, fn: () => T): T {
+  return writeSessionAls.run(session, fn)
+}
+
+/**
+ * The ambient write session of the current async context, or undefined when
+ * no write is in flight (e.g. a handler constructed at request setup time).
+ */
+export function getAmbientWriteSession(): WriteSession | undefined {
+  return writeSessionAls.getStore()
+}


### PR DESCRIPTION
## Summary

Phase 3 slice (a) of `plans/events/03-write-context-and-batch-lane-plan.md` (seams S1–S4): the **WriteSession/WriteOrigin core**, behavior-preserving.

- `write-origin.ts`: the `WriteOrigin` union — `interactive` / `api` / `automation` / `sync` / `seed`. The `sync` variant deliberately has **no phase field** (D-12: small-run vs batch lane is decided at finalize from the observed changed count, never declared by the walker) and requires a `collector` (the B2 contract as a type, type-only import so no runtime cycle). `sessionLane()` maps interactive/api/automation → inline, sync/seed → silent — matching today's `skipEvents` semantics exactly until the Phase 4 batched replay lands.
- `write-session-als.ts`: `AsyncLocalStorage<WriteSession>`, modeled on record-rules' `ruleChain` — the proven in-repo pattern that survives the `update → field-change hook → rule` chain.
- **S1**: the handler resolves its session explicit option → ambient ALS → interactive default, and wraps all 15 public write methods in the session scope — so every hook that constructs a fresh handler mid-write (totals, enrichment, billing — they all do) inherits the parent session instead of silently resetting to interactive.
- **S3**: `publishEvents` derived once per write from the session lane at the single conversion seam; `skipEvents` kept as a `@deprecated` alias that still wins. Since nothing constructs sync/seed sessions yet, every caller behaves exactly as today.
- Deletes the dead `CrudContext.skipEvents`; threads the session into `FieldValueContext`/`FieldValueService` (S4, carried only — no behavior gate below the seam changes in this slice).

## Test plan

- New `write-session.test.ts` (9 tests): default/explicit/ambient resolution, the hook-re-entry inheritance case, lane mapping, and the S3 seam (interactive publishes; `skipEvents: true` suppresses; a seed session suppresses without the alias while archive's dedup-pair cleanup still runs outside the guard).
- Full `src/resources/crud` + `src/field-values` suites: 41 files / 379 tests pass, zero expectation changes (one test needed setup-only plumbing for the new required `MutationContext.session`).
- Scoped `tsc --noEmit` on packages/lib: no errors in touched files.