### PR TITLE
fix(seed): stop dropping skipEvents in the modes slot and wire ingest handler deps

### DIFF
--- a/packages/lib/src/ingest/context.ts
+++ b/packages/lib/src/ingest/context.ts
@@ -119,7 +119,7 @@ export async function createIngestContext(
     db,
     logger: createScopedLogger(`ingest:${organizationId.slice(0, 8)}`),
     systemUserId,
-    crudHandler: new UnifiedCrudHandler(organizationId, systemUserId),
+    crudHandler: new UnifiedCrudHandler(organizationId, systemUserId, db, opts.socketId),
     reconciler: new MessageReconcilerService(organizationId, threadManager, db),
     threadManager,
     selectiveCache: opts.selectiveCache ?? new SelectiveModeCache(),

--- a/packages/seed/src/domains/crm.domain.ts
+++ b/packages/seed/src/domains/crm.domain.ts
@@ -894,9 +894,12 @@ export class CrmDomain {
       const companyId = companiesByDomain.get(domain)
       if (!companyId) continue
 
+      // Signature is update(recordId, values, modes?, options?) — the options
+      // object must go in the 4th slot or skipEvents is silently dropped.
       await handler.update(
         `${contactDefId}:${row.entityId}` as never,
         { contact_employer: `${companyDefId}:${companyId}` },
+        undefined,
         { skipEvents: true }
       )
       linkedEmployers++
@@ -911,6 +914,7 @@ export class CrmDomain {
       await handler.update(
         `${companyDefId}:${companyId}` as never,
         { company_primary_contact: `${contactDefId}:${contactId}` },
+        undefined,
         { skipEvents: true }
       )
       primaryContactsSet++


### PR DESCRIPTION
## Summary

Bugs B-8 and B-12 from `plans/events/03-write-context-and-batch-lane-plan.md` §7 — two small, independent fixes.

**B-8 — the seed arg-slot drop** (`docs/skip-events-history.md` §8 D1, the third recorded occurrence of this trap): `crm.domain.ts`'s two link writes called `handler.update(recordId, values, { skipEvents: true })`, but `update` takes options **fifth** (fourth positional, after `modes`) — the options object landed in the `modes` slot and `skipEvents` was silently dropped, so these seed writes fired the full event fan-out. Fixed with an explicit `undefined` modes argument + a comment naming the trap. A sweep of every seed domain found no other instances (`create`/`bulkCreate` take options third and were already correct). No regression test: `packages/seed` has no test infrastructure.

**B-12 — ingest handler missing db + socketId**: `ingest/context.ts` constructed its `UnifiedCrudHandler` with neither the context's `db` nor `socketId`. Consequences: every contact/company write from mail/chat ingest went to the global pool instead of `ctx.db` (a transaction hazard), and ingest `record:created`/`fieldValues:updated` frames were never self-echo-suppressed. Both are now passed through to the constructor, which forwards socketId into the handler's `FieldValueService`.

## Test plan

- `src/ingest` + `src/threads` suites: 30 files / 303 tests pass, no unhandled errors.
- Biome clean on both files.