### PR TITLE
feat(data-connectors): construct sync write sessions for connector and importer

### DIFF
--- a/packages/lib/src/data-connectors/__test-helpers.ts
+++ b/packages/lib/src/data-connectors/__test-helpers.ts
@@ -60,6 +60,7 @@ export function makeSyncCtx(over: Partial<SyncCtx> = {}): SyncCtx {
     runId: 'run1',
     crud: {} as SyncCtx['crud'],
     ownedCrud: {} as SyncCtx['ownedCrud'],
+    relationshipCrud: {} as SyncCtx['relationshipCrud'],
     counters: zeroRunCounters(),
     failureTally: newRecordFailureTally(),
     manifest: noopManifestCollector(),

--- a/packages/lib/src/data-connectors/connector-sync-source.ts
+++ b/packages/lib/src/data-connectors/connector-sync-source.ts
@@ -23,6 +23,7 @@ import type { Database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { RuntimeConnectionData } from '../connections/resolve-connection-for-runtime'
 import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
+import type { WriteSession } from '../resources/crud/write-origin'
 import type { SliceResult, SyncRunCounters, SyncSliceCtx, SyncSource } from '../sync-core/contracts'
 import { runAsyncExportSlice } from './async-export'
 import { flattenConnectionMeta } from './connection-meta'
@@ -145,9 +146,6 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
   /** Per-record upstream last-modified path (`incremental.watermarkField`) → the
    *  `upstreamUpdatedAt` version stamp the sink's out-of-order guard reads (§9 Q7). */
   private readonly updatedAtPath?: string
-  /** Cache the cache-warmed crud handlers across this instance's calls. */
-  private crud?: UnifiedCrudHandler
-  private ownedCrud?: UnifiedCrudHandler
   private readonly warmedDefs = new Set<string>()
   /** Bound connection's plaintext metadata (`connectionAppFields` source), loaded once. */
   private connectionMeta?: Record<string, unknown> | null
@@ -234,8 +232,8 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
    * Refresh the grid for the slice just written: mark each touched def's query
    * emit ONE coarse `records:invalidated` per def.
    *
-   * Per-record realtime is suppressed for connector writes (the sink passes
-   * `skipEvents`), so this coarse event is what tells an open grid to refetch
+   * Per-record realtime is suppressed for connector writes (the sink's silent
+   * `sync` write session), so this coarse event is what tells an open grid to refetch
    * instead of the per-record firehose that 403s Pusher at backfill scale. The
    * grid's refetch pages straight from SQL, so it always sees the fresh rows.
    */
@@ -415,7 +413,7 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
       })
     }
 
-    // v9 inventory→part bridge: post-sink (the sink writes with skipEvents, so no
+    // v9 inventory→part bridge: post-sink (the sink writes on the silent sync lane, so no
     // per-record hook fired) compare synced quantities to the watermark and deduct
     // linked parts. Best-effort — a bridge failure must never fail the sync run.
     // Lazy import: the pass pulls the cache/settings/crud barrels, which break the
@@ -443,39 +441,65 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
     signal?: AbortSignal
   ): Promise<SyncCtx> {
     const userId = this.deps.connector.createdById ?? 'system'
-    if (!this.crud)
-      this.crud = new UnifiedCrudHandler(this.deps.organizationId, userId, this.deps.db)
-    if (!this.ownedCrud) {
-      this.ownedCrud = new UnifiedCrudHandler(
-        this.deps.organizationId,
-        userId,
-        this.deps.db,
-        undefined,
-        {
-          bypassFieldGuards: OWNED_BYPASS,
-        }
-      )
+    // B2: build a subscription-aware manifest collector (zero-cost no-op stub when the
+    // org has no enabled record rules). Lazy-imported — crosses into record-rules.
+    const { loadManifestCollector } = await import('../record-rules/sync-manifest-collector')
+    const manifest = await loadManifestCollector(this.deps.organizationId)
+    // Plan 03 §3.4/§4b S1: sink writes run under a `sync` session — its silent
+    // lane is what `skipEvents: true` used to declare per call. Handlers are
+    // built per ctx (cheap, no I/O) so the session's collector is THIS ctx's
+    // collector; def-cache warmth lives in the org cache and is unaffected.
+    const session: WriteSession = {
+      origin: {
+        kind: 'sync',
+        source: 'connector',
+        ref: this.deps.run.id,
+        collector: manifest,
+      },
+      depth: 0,
     }
+    const crud = new UnifiedCrudHandler(this.deps.organizationId, userId, this.deps.db, undefined, {
+      session,
+    })
+    const ownedCrud = new UnifiedCrudHandler(
+      this.deps.organizationId,
+      userId,
+      this.deps.db,
+      undefined,
+      {
+        bypassFieldGuards: OWNED_BYPASS,
+        session,
+      }
+    )
+    // The relationship pass keeps firing per-write events (deliberate — see
+    // relationship-pass.ts), so it gets an inline-lane `automation` handler.
+    // Phase 4 folds these writes into the sync collector's finalize replay.
+    const relationshipCrud = new UnifiedCrudHandler(
+      this.deps.organizationId,
+      userId,
+      this.deps.db,
+      undefined,
+      {
+        session: { origin: { kind: 'automation', actor: userId }, depth: 0 },
+      }
+    )
     for (const m of mappings) {
       if (this.warmedDefs.has(m.entityDefinitionId)) continue
-      await this.crud.warmCache(m.entityDefinitionId)
-      await this.ownedCrud.warmCache(m.entityDefinitionId)
+      await crud.warmCache(m.entityDefinitionId)
+      await ownedCrud.warmCache(m.entityDefinitionId)
       this.warmedDefs.add(m.entityDefinitionId)
     }
     if (this.connectionMeta === undefined) {
       this.connectionMeta = await this.loadConnectionMeta()
     }
-    // B2: build a subscription-aware manifest collector (zero-cost no-op stub when the
-    // org has no enabled record rules). Lazy-imported — crosses into record-rules.
-    const { loadManifestCollector } = await import('../record-rules/sync-manifest-collector')
-    const manifest = await loadManifestCollector(this.deps.organizationId)
     return {
       db: this.deps.db,
       orgId: this.deps.organizationId,
       connector: this.deps.connector,
       runId: this.deps.run.id,
-      crud: this.crud,
-      ownedCrud: this.ownedCrud,
+      crud,
+      ownedCrud,
+      relationshipCrud,
       counters,
       failureTally: newRecordFailureTally(),
       signal,

--- a/packages/lib/src/data-connectors/connector-webhook.ts
+++ b/packages/lib/src/data-connectors/connector-webhook.ts
@@ -15,6 +15,7 @@ import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
 import { UnifiedCrudHandler } from '../resources/crud/unified-handler'
+import type { WriteSession } from '../resources/crud/write-origin'
 import { flattenConnectionMeta } from './connection-meta'
 import { prepareConnectorFetch } from './connector-runtime'
 import { ConnectorRateLimitError } from './connectors'
@@ -229,9 +230,26 @@ async function buildWebhookCtx(
   counters: RunCounters
 ): Promise<SyncCtx> {
   const userId = connector.createdById ?? 'system'
-  const crud = new UnifiedCrudHandler(organizationId, userId, db)
+  // B2: subscription-aware manifest collector for the steered run's writes.
+  const { loadManifestCollector } = await import('../record-rules/sync-manifest-collector')
+  const manifest = await loadManifestCollector(organizationId)
+  // Plan 03 §3.4/§4b S1: sink writes run under a `sync` session — its silent
+  // lane is what `skipEvents: true` used to declare per call. `ref` is the
+  // steered run's REAL run id: that is the row this ctx's collector folds onto.
+  const session: WriteSession = {
+    origin: { kind: 'sync', source: 'connector', ref: runId, collector: manifest },
+    depth: 0,
+  }
+  const crud = new UnifiedCrudHandler(organizationId, userId, db, undefined, { session })
   const ownedCrud = new UnifiedCrudHandler(organizationId, userId, db, undefined, {
     bypassFieldGuards: new Set<never>(),
+    session,
+  })
+  // The relationship pass keeps firing per-write events (deliberate — see
+  // relationship-pass.ts), so it gets an inline-lane `automation` handler.
+  // Phase 4 folds these writes into the sync collector's finalize replay.
+  const relationshipCrud = new UnifiedCrudHandler(organizationId, userId, db, undefined, {
+    session: { origin: { kind: 'automation', actor: userId }, depth: 0 },
   })
   const defs = new Set(streams.flatMap((s) => s.mappings.map((m) => m.entityDefinitionId)))
   for (const defId of defs) {
@@ -252,9 +270,6 @@ async function buildWebhookCtx(
       })
     }
   }
-  // B2: subscription-aware manifest collector for the steered run's writes.
-  const { loadManifestCollector } = await import('../record-rules/sync-manifest-collector')
-  const manifest = await loadManifestCollector(organizationId)
   return {
     db,
     orgId: organizationId,
@@ -262,6 +277,7 @@ async function buildWebhookCtx(
     runId,
     crud,
     ownedCrud,
+    relationshipCrud,
     counters,
     failureTally: newRecordFailureTally(),
     manifest,

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -1300,6 +1300,10 @@ export async function deleteConnector(
       // realtime (`record:archived` / `record:deleted`) events. Lazy-imported so the
       // pure-helper exports of this module stay loadable without the crud chain.
       const { UnifiedCrudHandler } = await import('../resources/crud/unified-handler')
+      // Deliberately NOT a `sync` session yet (plan 03 B-11): declaring teardown
+      // sync would silence its per-record fan-out, and the finalize compensation
+      // (batched replay) has to land first — until then a large disconnect keeps
+      // today's full fan-out rather than losing it.
       const crud = new UnifiedCrudHandler(organizationId, userId, db)
       const recordIds = created.map((r) => toRecordId(r.defId, r.id))
       if (behavior === 'archive') {

--- a/packages/lib/src/data-connectors/relationship-pass.test.ts
+++ b/packages/lib/src/data-connectors/relationship-pass.test.ts
@@ -73,11 +73,15 @@ function item(pending: PendingRelation[], linked: string[] = []): DataConnectorI
   } as unknown as DataConnectorItemRow
 }
 
-/** A ctx whose `crud.update` is the spy every case asserts on. */
+/**
+ * A ctx whose `relationshipCrud.update` is the spy every case asserts on — the
+ * pass writes through the inline-lane handler (events on), never `ctx.crud`
+ * (silent sync session).
+ */
 function ctx(): SyncCtx {
   return makeSyncCtx({
     orgId: ORG,
-    crud: { update: h.update } as unknown as SyncCtx['crud'],
+    relationshipCrud: { update: h.update } as unknown as SyncCtx['relationshipCrud'],
   })
 }
 

--- a/packages/lib/src/data-connectors/relationship-pass.ts
+++ b/packages/lib/src/data-connectors/relationship-pass.ts
@@ -13,8 +13,12 @@
 // `entity:field:updated` fan-out (timeline entry, activity touch, record rules) for
 // each. The fix suppresses the WRITE, not the event: one bulk pre-read of the current
 // targets, and an edge that already points where it should is left alone. A genuine
-// edge change still fires everything it fires today — deliberately NOT `skipEvents`,
-// which would take record rules and field triggers down with it.
+// edge change still fires everything it fires today — deliberately NOT silent,
+// which would take record rules and field triggers down with it. Since `ctx.crud`
+// now runs under the run's silent `sync` session (plan 03 §3.4), this pass writes
+// through `ctx.relationshipCrud`, an inline-lane `automation`-session handler, so
+// events keep firing; Phase 4 folds these writes into the sync collector's
+// finalize replay instead.
 
 import { createScopedLogger } from '@auxx/logger'
 import { toRecordId } from '../resources/resource-id'
@@ -55,7 +59,7 @@ export async function resolveRelationships(ctx: SyncCtx): Promise<void> {
       // is one we previously set.
       if (rel.targetExternalId === null) {
         try {
-          await ctx.crud.update(parentRecordId, { [rel.fieldKey]: null }, undefined, {})
+          await ctx.relationshipCrud.update(parentRecordId, { [rel.fieldKey]: null }, undefined, {})
           ctx.touchedDefs.add(item.entityDefinitionId)
           if (linked.delete(rel.fieldKey)) linkedChanged = true
         } catch (error) {
@@ -111,7 +115,12 @@ export async function resolveRelationships(ctx: SyncCtx): Promise<void> {
         // Write the RELATIONSHIP value by addressing the parent's relationship
         // field (by its systemAttribute/key) with the target RecordId. The
         // FieldValueService converter accepts a RecordId; the inverse syncs.
-        await ctx.crud.update(parentRecordId, { [rel.fieldKey]: targetRecordId }, undefined, {})
+        await ctx.relationshipCrud.update(
+          parentRecordId,
+          { [rel.fieldKey]: targetRecordId },
+          undefined,
+          {}
+        )
         ctx.touchedDefs.add(item.entityDefinitionId)
         if (!linked.has(rel.fieldKey)) {
           linked.add(rel.fieldKey)

--- a/packages/lib/src/data-connectors/sinks/entity-sink.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink.ts
@@ -1050,17 +1050,13 @@ export const entitySink: EntitySink = {
               })
             : null
           // Shallow copy per attempt: a conflict retry mutates `writeSet`.
-          await handler.update(recordId, { ...writeSet }, undefined, {
-            skipEvents: true,
-          })
+          // Event suppression comes from the handler's silent `sync` session
+          // (plan 03 §3.4), not a per-call flag.
+          await handler.update(recordId, { ...writeSet })
           ctx.counters.updated += 1
           if (captured) ctx.manifest.recordChange(recordId, captured)
         } else {
-          const created = await handler.create(
-            mapping.entityDefinitionId,
-            { ...writeSet },
-            { skipEvents: true }
-          )
+          const created = await handler.create(mapping.entityDefinitionId, { ...writeSet })
           instanceId = created.instance.id
           justCreated = true
           ctx.counters.created += 1
@@ -1198,9 +1194,7 @@ export const entitySink: EntitySink = {
       }
       const recordId = toRecordId(item.entityDefinitionId, item.entityInstanceId)
       try {
-        await ctx.ownedCrud.archive(recordId, {
-          skipEvents: true,
-        })
+        await ctx.ownedCrud.archive(recordId)
         ctx.touchedDefs.add(item.entityDefinitionId)
         ctx.counters.archived += 1
         // B2: lifecycle-deleted capture for synced archives (soft-archive; the record

--- a/packages/lib/src/data-connectors/sinks/row-level-writes.ts
+++ b/packages/lib/src/data-connectors/sinks/row-level-writes.ts
@@ -331,11 +331,12 @@ export async function executeRowLevelWrites(
     // Append at the end via the multi-value primitive (never a whole-field set):
     // `add` dedupes, runs hooks and honors the value cap.
     try {
+      // Event suppression comes from the handler's silent `sync` session
+      // (plan 03 §3.4), not a per-call flag.
       await handler.update(
         recordId,
         { [action.write.writeKey]: [action.flatValue] },
-        { [action.write.writeKey]: 'add' },
-        { skipEvents: true }
+        { [action.write.writeKey]: 'add' }
       )
     } catch (error) {
       if (error instanceof UniqueValueConflictError) {

--- a/packages/lib/src/data-connectors/sinks/types.ts
+++ b/packages/lib/src/data-connectors/sinks/types.ts
@@ -47,6 +47,14 @@ export interface SyncCtx {
   crud: UnifiedCrudHandler
   /** Owned-mode handler with field-guard bypass (writes read-only connector fields). */
   ownedCrud: UnifiedCrudHandler
+  /**
+   * Inline-lane handler for the relationship pass ONLY (plan 03 §3.4). `crud`/
+   * `ownedCrud` run under the run's silent `sync` session; a genuine edge change
+   * must keep firing `entity:field:updated`, the activity touch, and record
+   * rules, so the pass writes through this `automation`-session handler instead.
+   * Phase 4 folds these writes into the sync collector's finalize replay.
+   */
+  relationshipCrud: UnifiedCrudHandler
   /** Mutable run counters. */
   counters: RunCounters
   /**
@@ -64,8 +72,8 @@ export interface SyncCtx {
   signal?: AbortSignal
   /**
    * Sync-change manifest collector (B2). Accumulates subscribed field writes +
-   * lifecycle ids as the sink writes (which suppress per-write events via
-   * `skipEvents`), so record rules can react at finalize. The no-op stub when the org
+   * lifecycle ids as the sink writes (which suppress per-write events via the
+   * silent `sync` write session), so record rules can react at finalize. The no-op stub when the org
    * has no enabled rules — capture sites gate on `manifest.enabled`.
    */
   manifest: ManifestCollector

--- a/packages/lib/src/import/resolution/materialize-relation-creates.ts
+++ b/packages/lib/src/import/resolution/materialize-relation-creates.ts
@@ -16,7 +16,7 @@ const logger = createScopedLogger('materialize-relation-creates')
  * Writes a record into the relation TARGET's definition.
  *
  * Supply the job's own manifest-aware writer, not a fresh one. The importer
- * writes with `skipEvents: true` and captures record-rule changes through a
+ * writes on the silent `sync` lane and captures record-rule changes through a
  * manifest collector (`execute-plan-job.ts`); a writer that bypasses that
  * contract creates records no rule ever sees and no open grid ever refetches.
  * {@link createRelationTargetWriter} builds a conforming one.
@@ -239,12 +239,15 @@ export interface RelationTargetWriterOptions {
 
 /**
  * Build a {@link RelationTargetWriter} that writes through the same CRUD path
- * and the same `skipEvents: true` contract the importer uses for its own rows.
+ * and the same silent-lane contract the importer uses for its own rows: the
+ * handler is constructed with no explicit session, so it inherits the job's
+ * ambient `sync` session (plan 03 §4b S1 — `execute-plan-job.ts` wraps the
+ * calls in `runWithWriteSession`).
  *
- * `skipEvents` is not an optimisation here, it is what keeps a 500-row import
- * from putting 500 `record:created` frames on the def channel. The coarse
- * `records:invalidated` frame the job already publishes covers the target def
- * too, provided the caller includes it (see the report notes).
+ * The silent lane is not an optimisation here, it is what keeps a 500-row
+ * import from putting 500 `record:created` frames on the def channel. The
+ * coarse `records:invalidated` frame the job already publishes covers the
+ * target def too, provided the caller includes it (see the report notes).
  *
  * @param options - Org, actor, and an optional manifest hook
  */
@@ -253,12 +256,12 @@ export function createRelationTargetWriter(
 ): RelationTargetWriter {
   const { organizationId, userId, db, onCreated } = options
   // Lazy: `UnifiedCrudHandler` drags the whole resources graph in, and most
-  // imports have nothing to create.
+  // imports have nothing to create. Constructed on first call — inside the
+  // job's `runWithWriteSession` wrap — so the ambient sync session binds.
   let handlerPromise: Promise<{
     create: (
       defId: string,
-      values: Record<string, unknown>,
-      opts: { skipEvents: boolean }
+      values: Record<string, unknown>
     ) => Promise<{ instance: { id: string } }>
   }> | null = null
 
@@ -267,7 +270,7 @@ export function createRelationTargetWriter(
       (m) => new m.UnifiedCrudHandler(organizationId, userId, db)
     )
     const handler = await handlerPromise
-    const created = await handler.create(entityDefinitionId, data, { skipEvents: true })
+    const created = await handler.create(entityDefinitionId, data)
     onCreated?.(entityDefinitionId, created.instance.id, data)
     return { id: created.instance.id }
   }

--- a/packages/lib/src/jobs/import/execute-plan-job.ts
+++ b/packages/lib/src/jobs/import/execute-plan-job.ts
@@ -21,6 +21,8 @@ import {
 import type { FieldWriteModes, ImportMappingProperty, ImportPlan } from '../../import/types'
 import { getRealtimeService, publishRecordsInvalidated, publishRunCompleted } from '../../realtime'
 import { UnifiedCrudHandler } from '../../resources/crud/unified-handler'
+import type { WriteSession } from '../../resources/crud/write-origin'
+import { runWithWriteSession } from '../../resources/crud/write-session-als'
 import { getFieldOutputKey } from '../../resources/registry/field-types'
 import type { JobContext } from '../types'
 
@@ -30,7 +32,7 @@ const logger = createScopedLogger('execute-plan-job')
  * Minimum gap between the coarse `records:invalidated` frames published while
  * rows land. Progress fires once per 50-row batch, so an unthrottled publish
  * would put hundreds of frames on the def channel for a large file — the same
- * firehose the `skipEvents` guard exists to avoid.
+ * firehose the silent `sync` write session exists to avoid.
  */
 const INVALIDATE_THROTTLE_MS = 2_000
 
@@ -109,8 +111,24 @@ export async function executePlanJob(ctx: JobContext<ExecutePlanJobProps>): Prom
       updatedAt: p.updatedAt,
     }))
 
+    // B2: the import writes on the silent `sync` lane (below), so build a manifest
+    // collector to capture subscribed field/lifecycle changes for record rules. No-op
+    // stub (zero cost) when the org has no enabled rules on this def.
+    const { loadManifestCollector } = await import('../../record-rules/sync-manifest-collector')
+    const manifest = await loadManifestCollector(organizationId)
+
+    // Plan 03 §3.4/§4b S1: one `sync` session for the whole import — its silent
+    // lane is what `skipEvents: true` used to declare per call. The plan
+    // execution below also runs inside `runWithWriteSession(session, …)` so
+    // handlers constructed downstream (the relation-target writer) inherit it
+    // ambiently.
+    const session: WriteSession = {
+      origin: { kind: 'sync', source: 'import', ref: jobId, collector: manifest },
+      depth: 0,
+    }
+
     // Create CRUD handler and pre-warm caches
-    const crudHandler = new UnifiedCrudHandler(organizationId, userId, db)
+    const crudHandler = new UnifiedCrudHandler(organizationId, userId, db, undefined, { session })
     const entityDefinitionId = importJob.importMapping.entityDefinitionId
 
     // Pre-warm caches once for entire import (avoids N queries for N records)
@@ -166,37 +184,36 @@ export async function executePlanJob(ctx: JobContext<ExecutePlanJobProps>): Prom
       .filter((m) => !!m.targetFieldKey && identifierFieldKeys.includes(m.targetFieldKey))
       .map((m) => m.customFieldId ?? m.targetFieldKey!)
 
-    // B2: the import writes with `skipEvents: true` (below), so build a manifest
-    // collector to capture subscribed field/lifecycle changes for record rules. No-op
-    // stub (zero cost) when the org has no enabled rules on this def.
-    const { loadManifestCollector } = await import('../../record-rules/sync-manifest-collector')
-    const manifest = await loadManifestCollector(organizationId)
-
     // Relation auto-create (`onNoMatch: 'create'`) is a TWO-PHASE design:
     // planning only records the intent, so abandoning the wizard at the preview
     // leaves no orphan records behind. This is phase two, mint the targets and
     // rewrite their resolutions to real record ids, BEFORE the resolutions are
     // read below. Distinct values are deduped, so 500 rows naming "Acme" (or
     // "ACME") produce exactly one company.
-    const relationCreates = await materializeRelationCreates(db, {
-      organizationId,
-      jobId,
-      userId,
-      createRecord: createRelationTargetWriter({
+    // Wrapped in the session so the writer's lazily constructed handler inherits
+    // it ambiently (S1 resolution) — that inheritance is what keeps auto-created
+    // targets on the silent lane now that the writer passes no `skipEvents`.
+    const relationCreates = await runWithWriteSession(session, () =>
+      materializeRelationCreates(db, {
         organizationId,
+        jobId,
         userId,
-        db,
-        // Auto-created targets reach record rules the same way imported rows do.
-        onCreated: (targetDefId, instanceId, data) => {
-          if (!manifest.enabled) return
-          // Subscriptions are per-def, and the TARGET def (company) is not this
-          // import's def (part), look it up rather than reusing the outer one.
-          if (manifest.subscriptionsFor(targetDefId)?.lifecycle.created) {
-            manifest.recordCreated(toRecordId(targetDefId, instanceId), data)
-          }
-        },
-      }),
-    })
+        createRecord: createRelationTargetWriter({
+          organizationId,
+          userId,
+          db,
+          // Auto-created targets reach record rules the same way imported rows do.
+          onCreated: (targetDefId, instanceId, data) => {
+            if (!manifest.enabled) return
+            // Subscriptions are per-def, and the TARGET def (company) is not this
+            // import's def (part), look it up rather than reusing the outer one.
+            if (manifest.subscriptionsFor(targetDefId)?.lifecycle.created) {
+              manifest.recordCreated(toRecordId(targetDefId, instanceId), data)
+            }
+          },
+        }),
+      })
+    )
     if (relationCreates.created > 0 || relationCreates.failures.length > 0) {
       logger.info('Materialized relation auto-creates', {
         jobId,
@@ -211,7 +228,7 @@ export async function executePlanJob(ctx: JobContext<ExecutePlanJobProps>): Prom
     const resolutions = await getAllJobResolutions(db, jobId)
     logger.debug('Loaded resolutions', { jobId, count: resolutions.size })
 
-    // The import writes with `skipEvents: true`, so no `record:created` /
+    // The import writes on the silent `sync` lane, so no `record:created` /
     // `record:updated` / `fieldValues:updated` frame ever reaches an open grid.
     // Publish the same coarse signal the connector sync path uses instead — one
     // `records:invalidated` per def, which the client turns into a single list
@@ -268,10 +285,9 @@ export async function executePlanJob(ctx: JobContext<ExecutePlanJobProps>): Prom
         ...data.customFields,
       }
 
-      // Use UnifiedCrudHandler with skipEvents
-      const created = await crudHandler.create(entityDefinitionId, mergedData, {
-        skipEvents: true,
-      })
+      // Event suppression comes from the handler's silent `sync` session
+      // (plan 03 §3.4), not a per-call flag.
+      const created = await crudHandler.create(entityDefinitionId, mergedData)
 
       // B2: capture lifecycle-created + `set`-transition field writes for record rules.
       if (manifest.enabled) {
@@ -349,12 +365,11 @@ export async function executePlanJob(ctx: JobContext<ExecutePlanJobProps>): Prom
         }
       }
 
-      // Use UnifiedCrudHandler with skipEvents. `data.modes` routes multi-value
-      // scalar fields through the 'add' bucket (append + server-side dedup);
-      // unlisted fields fall through to 'set' as before.
-      const instance = await crudHandler.update(recordId, mergedData, data.modes, {
-        skipEvents: true,
-      })
+      // Event suppression comes from the handler's silent `sync` session
+      // (plan 03 §3.4). `data.modes` routes multi-value scalar fields through
+      // the 'add' bucket (append + server-side dedup); unlisted fields fall
+      // through to 'set' as before.
+      const instance = await crudHandler.update(recordId, mergedData, data.modes)
       if (captured) manifest.recordChange(recordId, captured)
 
       logger.debug('Updated record', { recordId, entityDefinitionId })
@@ -370,40 +385,44 @@ export async function executePlanJob(ctx: JobContext<ExecutePlanJobProps>): Prom
       createdAt: plan.createdAt,
     }
 
-    const result = await executePlan({
-      db,
-      organizationId,
-      userId,
-      jobId,
-      plan: planData,
-      entityDefinitionId: importJob.importMapping.entityDefinitionId,
-      mappings,
-      resolutions,
-      fieldModes,
-      identifierKeys,
-      createRecord,
-      updateRecord,
-      onRowWarning: async (rowIndex, message) => {
-        await publishEvent({ type: 'row:warning', rowIndex, message })
-      },
-      onProgress: async (progress) => {
-        const percentage = Math.round((progress.processed / progress.total) * 100)
-        await job.updateProgress(percentage)
+    // Ambient session for the whole plan execution (plan 03 §4b S1): any handler
+    // constructed downstream without an explicit session inherits this one.
+    const result = await runWithWriteSession(session, () =>
+      executePlan({
+        db,
+        organizationId,
+        userId,
+        jobId,
+        plan: planData,
+        entityDefinitionId: importJob.importMapping.entityDefinitionId,
+        mappings,
+        resolutions,
+        fieldModes,
+        identifierKeys,
+        createRecord,
+        updateRecord,
+        onRowWarning: async (rowIndex, message) => {
+          await publishEvent({ type: 'row:warning', rowIndex, message })
+        },
+        onProgress: async (progress) => {
+          const percentage = Math.round((progress.processed / progress.total) * 100)
+          await job.updateProgress(percentage)
 
-        await publishEvent({
-          type: 'execution:progress',
-          strategyId: progress.strategyId,
-          strategy: progress.strategy,
-          processed: progress.processed,
-          total: progress.total,
-          succeeded: progress.succeeded,
-          failed: progress.failed,
-        })
+          await publishEvent({
+            type: 'execution:progress',
+            strategyId: progress.strategyId,
+            strategy: progress.strategy,
+            processed: progress.processed,
+            total: progress.total,
+            succeeded: progress.succeeded,
+            failed: progress.failed,
+          })
 
-        // Keep every open grid live while the import runs, not just at the end.
-        await invalidateRecords()
-      },
-    })
+          // Keep every open grid live while the import runs, not just at the end.
+          await invalidateRecords()
+        },
+      })
+    )
 
     // Mark job as completed
     await markJobCompleted(db, jobId, result.statistics)


### PR DESCRIPTION
## Summary

Phase 3 slice (b) of `plans/events/03-write-context-and-batch-lane-plan.md`: the connector sink, connector webhook, and CSV importer now construct real `{ kind: 'sync', source, ref, collector }` WriteSessions, and every `skipEvents: true` in these paths is deleted. Behavior-preserving: a sync session's lane is `'silent'`, which `derivePublishEvents` maps to exactly what the flag produced.

- **Connector** (`buildCtx` / `buildWebhookCtx`): collector is loaded first, then `crud`/`ownedCrud` are constructed per ctx with the session (`ref` = the real `DataConnectorRun.id` the manifest folds onto — session identity and manifest identity agree). The instance-level handler cache had to go: a fresh collector is built per slice, and a cached handler would have carried the first slice's collector forever. Handler construction is I/O-free; `warmedDefs` stays instance-level.
- **Relationship pass**: keeps its deliberate events-on behavior via a new `ctx.relationshipCrud` bound to an `automation` session (inline lane) — the semantics are now expressed rather than inferred from an empty options object. Comments note Phase 4 folds these writes into the collector's finalize replay.
- **Importer**: one session for the whole job (`ref` = jobId); `materializeRelationCreates` and `executePlan` run inside `runWithWriteSession`, so the lazily-constructed relation-target writer inherits the session ambiently — its explicit `skipEvents` plumbing is deleted as dead.
- **Teardown** (`mutations.ts` bulkArchive/bulkDelete): deliberately NOT converted — comment cites B-11 (declaring teardown sync requires the finalize compensation first).

## Test plan

- `src/data-connectors`: 49 files / 419 tests pass. `relationship-pass.test.ts` assertion bodies unchanged (still proves events-on + no skipEvents), only its fixture points at `relationshipCrud`.
- `src/import` + `src/jobs`: 31 files / 300 tests pass.
- Combined run with the two sibling PRs' changes: 157 files / 1516 tests pass. Scoped tsc: zero errors in touched files.