### PR TITLE
feat(seed): declare seed and ingest write sessions, retire skipEvents there

### DIFF
--- a/packages/lib/src/ingest/context.ts
+++ b/packages/lib/src/ingest/context.ts
@@ -119,7 +119,14 @@ export async function createIngestContext(
     db,
     logger: createScopedLogger(`ingest:${organizationId.slice(0, 8)}`),
     systemUserId,
-    crudHandler: new UnifiedCrudHandler(organizationId, systemUserId, db, opts.socketId),
+    // Steady-state ingest is `automation` (plan 03 §3.3): inline lane, so
+    // fan-out is identical to before — the session exists for attribution.
+    // During initial mail backfill this becomes a `sync` session keyed off the
+    // channel's `backfillCutoffAt` state (plan 03 Phase 7, D-8) — not in this
+    // slice.
+    crudHandler: new UnifiedCrudHandler(organizationId, systemUserId, db, opts.socketId, {
+      session: { origin: { kind: 'automation', actor: systemUserId }, depth: 0 },
+    }),
     reconciler: new MessageReconcilerService(organizationId, threadManager, db),
     threadManager,
     selectiveCache: opts.selectiveCache ?? new SelectiveModeCache(),

--- a/packages/lib/src/seed/ai-category-tags.test.ts
+++ b/packages/lib/src/seed/ai-category-tags.test.ts
@@ -26,32 +26,44 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+type StubSession = { origin: { kind: string; reason?: string }; depth: number }
+
 const h = vi.hoisted(() => ({
   creates: [] as { entityType: string; values: Record<string, unknown> }[],
   constructorOptions: [] as unknown[],
   createImpl: null as null | ((values: Record<string, unknown>) => void),
-  /** Every `update` in call order, each tagged with the bypass set its handler carried. */
+  /**
+   * Every `update` in call order, each tagged with the bypass set AND the write
+   * session its handler carried — suppression now rides the session, not a
+   * per-call flag.
+   */
   updates: [] as {
     recordId: string
     values: Record<string, unknown>
     bypass: string[]
+    session?: { origin: { kind: string; reason?: string }; depth: number }
     modes?: Record<string, 'set' | 'add' | 'remove'>
     options?: Record<string, unknown>
   }[],
 }))
 
 vi.mock('../resources/crud', () => ({
+  // Mirrors the real helper: a seed session's lane is 'silent', which is what
+  // replaced the per-call `skipEvents: true`.
+  seedSession: (reason: string) => ({ origin: { kind: 'seed', reason }, depth: 0 }),
   UnifiedCrudHandler: class {
     private bypass: string[]
+    private session?: StubSession
     constructor(
       _orgId: string,
       _userId: string,
       _db: unknown,
       _socketId: unknown,
-      options?: { bypassFieldGuards?: Set<string> }
+      options?: { bypassFieldGuards?: Set<string>; session?: StubSession }
     ) {
       h.constructorOptions.push(options)
       this.bypass = [...(options?.bypassFieldGuards ?? [])]
+      this.session = options?.session
     }
     async create(entityType: string, values: Record<string, unknown>) {
       h.creates.push({ entityType, values })
@@ -71,7 +83,14 @@ vi.mock('../resources/crud', () => ({
       modes?: Record<string, 'set' | 'add' | 'remove'>,
       options?: Record<string, unknown>
     ) {
-      h.updates.push({ recordId, values, bypass: this.bypass, modes, options })
+      h.updates.push({
+        recordId,
+        values,
+        bypass: this.bypass,
+        session: this.session,
+        modes,
+        options,
+      })
       return { instance: { id: recordId }, recordId, values }
     }
   },
@@ -395,8 +414,17 @@ describe('seedAiCategoryTags', () => {
     const { db } = makeDb(queue())
     return seedAiCategoryTags(db, ORG, 'user_1').then(() => {
       expect(h.constructorOptions).toHaveLength(1)
-      const options = h.constructorOptions[0] as { bypassFieldGuards: Set<string> }
+      const options = h.constructorOptions[0] as {
+        bypassFieldGuards: Set<string>
+        session?: StubSession
+      }
       expect([...options.bypassFieldGuards].sort()).toEqual(['is_system_tag', 'tag_template_key'])
+      // The handler is constructed under a seed session — the silent lane that
+      // replaced the per-call `skipEvents: true`.
+      expect(options.session).toEqual({
+        origin: { kind: 'seed', reason: 'ai category tag seeding' },
+        depth: 0,
+      })
     })
   })
 
@@ -550,10 +578,15 @@ describe('seedAiCategoryTags — adopting legacy system starters', () => {
     expect(retune.values.tag_description).toBe(
       AI_CATEGORY_CORE_TAGS.find((t) => t.title === 'Sales')?.description
     )
-    // Options ride in the FOURTH arg; third is the array-mode map and must stay empty.
+    // Suppression rides the handler's seed session now — no per-call flags at
+    // all: the array-mode map stays empty and no options object is passed.
     for (const call of [unfreeze, retune]) {
       expect(call.modes).toBeUndefined()
-      expect(call.options).toEqual({ skipEvents: true })
+      expect(call.options).toBeUndefined()
+      expect(call.session).toEqual({
+        origin: { kind: 'seed', reason: 'ai category tag seeding' },
+        depth: 0,
+      })
     }
   })
 

--- a/packages/lib/src/seed/ai-category-tags.ts
+++ b/packages/lib/src/seed/ai-category-tags.ts
@@ -44,7 +44,7 @@
 import { type Database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq, inArray, isNull } from 'drizzle-orm'
-import { UnifiedCrudHandler } from '../resources/crud'
+import { seedSession, UnifiedCrudHandler } from '../resources/crud'
 import { type RecordId, toRecordId } from '../resources/resource-id'
 
 const logger = createScopedLogger('ai-category-tags')
@@ -344,35 +344,31 @@ async function adoptLegacySystemStarter(
   if (flagRow?.valueBoolean !== true) return 'left-alone'
 
   const recordId = toRecordId(tagDefId, instanceId)
-  const seedOpts = { skipEvents: true }
+  // Both handlers run under a seed session: the silent lane suppresses events
+  // exactly as the per-call `skipEvents: true` used to.
+  const session = seedSession('ai category tag seeding')
 
   // 1. Unfreeze. Needs the same bypass the create path uses, because `is_system_tag` is
   //    `creatable: false` and `dropUnauthorizedSystemFlag` drops unauthorized writes.
   const unfreeze = new UnifiedCrudHandler(organizationId, userId, db, undefined, {
     bypassFieldGuards: new Set(['is_system_tag']),
+    session,
   })
-  // NB `update` is (recordId, values, MODES, options) — options is the FOURTH
-  // arg, unlike `create`. Passing seedOpts third silently lands in the
-  // array-field mode map.
-  await unfreeze.update(recordId, { is_system_tag: false }, undefined, seedOpts)
+  await unfreeze.update(recordId, { is_system_tag: false })
 
   // 2. Now an ordinary tag, so `rejectIfSystemTag` lets the description through. The only
   //    bypass here is the one `tag_template_key` structurally requires.
   const handler = new UnifiedCrudHandler(organizationId, userId, db, undefined, {
     bypassFieldGuards: new Set(['tag_template_key']),
+    session,
   })
-  await handler.update(
-    recordId,
-    {
-      tag_description: seed.description,
-      tag_parent: parentRecordId,
-      tag_scope: THREAD_SCOPE,
-      tag_ai_classify: true,
-      tag_template_key: seed.templateKey,
-    },
-    undefined,
-    seedOpts
-  )
+  await handler.update(recordId, {
+    tag_description: seed.description,
+    tag_parent: parentRecordId,
+    tag_scope: THREAD_SCOPE,
+    tag_ai_classify: true,
+    tag_template_key: seed.templateKey,
+  })
 
   logger.info('Adopted legacy system tag as an AI category starter', {
     organizationId,
@@ -510,12 +506,12 @@ export async function seedAiCategoryTags(
     // with the bypass. Scoped to this handler: it documents the privilege boundary, and writing
     // `is_system_tag: false` explicitly (rather than leaning on the default) is what makes
     // "these are ORDINARY tags" a fact in the data rather than an omission.
+    // The seed session's silent lane suppresses events — no active users to notify during
+    // a seed, and each invalidation costs seconds on Lambda when Redis is slow.
     const handler = new UnifiedCrudHandler(organizationId, userId, db, undefined, {
       bypassFieldGuards: new Set(['is_system_tag', 'tag_template_key']),
+      session: seedSession('ai category tag seeding'),
     })
-    // No active users to notify during a seed, and each invalidation costs seconds on Lambda
-    // when Redis is slow.
-    const seedOpts = { skipEvents: true }
 
     const existingParentId = existingByTitle.get(AI_CATEGORY_PARENT_TAG.title)
 
@@ -524,21 +520,17 @@ export async function seedAiCategoryTags(
       parentRecordId = toRecordId(tagDef.id, existingParentId)
       skipped.push(AI_CATEGORY_PARENT_TAG.title)
     } else {
-      const parent = await handler.create(
-        TAG_DEF,
-        {
-          title: AI_CATEGORY_PARENT_TAG.title,
-          tag_description: AI_CATEGORY_PARENT_TAG.description,
-          tag_emoji: AI_CATEGORY_PARENT_TAG.emoji,
-          tag_color: AI_CATEGORY_PARENT_TAG.color,
-          tag_scope: THREAD_SCOPE,
-          // The container is not a label the classifier may apply.
-          tag_ai_classify: false,
-          tag_template_key: AI_CATEGORY_PARENT_TAG.templateKey,
-          is_system_tag: false,
-        },
-        seedOpts
-      )
+      const parent = await handler.create(TAG_DEF, {
+        title: AI_CATEGORY_PARENT_TAG.title,
+        tag_description: AI_CATEGORY_PARENT_TAG.description,
+        tag_emoji: AI_CATEGORY_PARENT_TAG.emoji,
+        tag_color: AI_CATEGORY_PARENT_TAG.color,
+        tag_scope: THREAD_SCOPE,
+        // The container is not a label the classifier may apply.
+        tag_ai_classify: false,
+        tag_template_key: AI_CATEGORY_PARENT_TAG.templateKey,
+        is_system_tag: false,
+      })
       parentRecordId = parent.recordId
       created.push(AI_CATEGORY_PARENT_TAG.title)
     }
@@ -562,21 +554,17 @@ export async function seedAiCategoryTags(
         continue
       }
 
-      await handler.create(
-        TAG_DEF,
-        {
-          title: tag.title,
-          tag_description: tag.description,
-          tag_emoji: tag.emoji,
-          tag_color: tag.color,
-          tag_parent: parentRecordId,
-          tag_scope: THREAD_SCOPE,
-          tag_ai_classify: true,
-          tag_template_key: tag.templateKey,
-          is_system_tag: false,
-        },
-        seedOpts
-      )
+      await handler.create(TAG_DEF, {
+        title: tag.title,
+        tag_description: tag.description,
+        tag_emoji: tag.emoji,
+        tag_color: tag.color,
+        tag_parent: parentRecordId,
+        tag_scope: THREAD_SCOPE,
+        tag_ai_classify: true,
+        tag_template_key: tag.templateKey,
+        is_system_tag: false,
+      })
       created.push(tag.title)
     }
 

--- a/packages/lib/src/seed/organization-seeder.ts
+++ b/packages/lib/src/seed/organization-seeder.ts
@@ -15,7 +15,7 @@ import { KBService } from '../kb'
 import { seedSuggestedMailFilters } from '../mail-filters'
 import { ensureSystemProfiles } from '../permissions/profiles'
 import { seedSuggestedRecordRules } from '../record-rules'
-import { UnifiedCrudHandler } from '../resources/crud'
+import { seedSession, UnifiedCrudHandler } from '../resources/crud'
 import { seedClientNotificationSequences } from '../sequences'
 import { seedDocumentBusinessFromProfile } from '../settings'
 import { buildSystemSnippetTemplates } from '../snippets'
@@ -438,13 +438,13 @@ export class OrganizationSeeder {
     // pre-hook drops any write of this flag unless the caller is in the
     // bypass set. Keeping the bypass scoped to this block (rather than the
     // whole seed run) documents the privilege boundary.
+    // The seed session's silent lane skips snapshot invalidation and events —
+    // no active users to notify, and each invalidation attempt costs 5s on
+    // Lambda when Redis is slow/unavailable.
     const handler = new UnifiedCrudHandler(organizationId, this.userId, this.db, undefined, {
       bypassFieldGuards: new Set(['is_system_tag']),
+      session: seedSession('org seeding - tag bootstrap'),
     })
-
-    // Skip snapshot invalidation and events during seeding — no active users to notify,
-    // and each invalidation attempt costs 5s on Lambda when Redis is slow/unavailable
-    const seedOpts = { skipEvents: true }
 
     // Priority and segment. No parent, so these can go in parallel — there is no
     // inverse (`tag_children`) sync to race on sortKey.
@@ -461,7 +461,7 @@ export class OrganizationSeeder {
     ]
 
     await Promise.all(
-      independentTags.map((tag) => handler.create('tag', { ...tag, is_system_tag: true }, seedOpts))
+      independentTags.map((tag) => handler.create('tag', { ...tag, is_system_tag: true }))
     )
 
     // The core mail categories, under their own parent. Ordinary (editable,

--- a/packages/seed/src/domains/crm.domain.ts
+++ b/packages/seed/src/domains/crm.domain.ts
@@ -584,7 +584,11 @@ export class CrmDomain {
 
     // Seed for each target organization
     for (const org of this.organizations) {
-      const handler = new UnifiedCrudHandler(org.id, org.ownerId, db)
+      // Seed session: silent lane — same suppression the per-call
+      // `skipEvents: true` used to provide, declared once at construction.
+      const handler = new UnifiedCrudHandler(org.id, org.ownerId, db, undefined, {
+        session: { origin: { kind: 'seed', reason: 'demo CRM seed data' }, depth: 0 },
+      })
 
       // Companies first (contacts reference company domains via email).
       const companiesByDomain = await this.seedCompanies(handler)
@@ -640,7 +644,7 @@ export class CrmDomain {
       company_headquarters: c.headquarters,
     }))
 
-    const { created, errors } = await handler.bulkCreate('company', values, { skipEvents: true })
+    const { created, errors } = await handler.bulkCreate('company', values)
 
     if (errors.length > 0) {
       console.log(`⚠️  ${errors.length} company creation errors:`)
@@ -743,9 +747,7 @@ export class CrmDomain {
     }
 
     if (newContactValues.length > 0) {
-      const { created, errors } = await handler.bulkCreate('contact', newContactValues, {
-        skipEvents: true,
-      })
+      const { created, errors } = await handler.bulkCreate('contact', newContactValues)
 
       if (errors.length > 0) {
         console.log(`⚠️  ${errors.length} contact creation errors:`)
@@ -894,14 +896,9 @@ export class CrmDomain {
       const companyId = companiesByDomain.get(domain)
       if (!companyId) continue
 
-      // Signature is update(recordId, values, modes?, options?) — the options
-      // object must go in the 4th slot or skipEvents is silently dropped.
-      await handler.update(
-        `${contactDefId}:${row.entityId}` as never,
-        { contact_employer: `${companyDefId}:${companyId}` },
-        undefined,
-        { skipEvents: true }
-      )
+      await handler.update(`${contactDefId}:${row.entityId}` as never, {
+        contact_employer: `${companyDefId}:${companyId}`,
+      })
       linkedEmployers++
 
       if (!firstContactByCompany.has(companyId)) {
@@ -911,12 +908,9 @@ export class CrmDomain {
 
     let primaryContactsSet = 0
     for (const [companyId, contactId] of firstContactByCompany) {
-      await handler.update(
-        `${companyDefId}:${companyId}` as never,
-        { company_primary_contact: `${contactDefId}:${contactId}` },
-        undefined,
-        { skipEvents: true }
-      )
+      await handler.update(`${companyDefId}:${companyId}` as never, {
+        company_primary_contact: `${contactDefId}:${contactId}`,
+      })
       primaryContactsSet++
     }
 

--- a/packages/seed/src/domains/organization.domain.ts
+++ b/packages/seed/src/domains/organization.domain.ts
@@ -100,7 +100,14 @@ export class OrganizationDomain {
   ): Promise<void> {
     console.log('✍️  Generating signatures via UnifiedCrudHandler...')
 
-    const handler = new UnifiedCrudHandler(organizationId, ownerId, db)
+    // Seed session: silent lane — same suppression the per-call
+    // `skipEvents: true` used to provide, declared once at construction.
+    const handler = new UnifiedCrudHandler(organizationId, ownerId, db, undefined, {
+      session: {
+        origin: { kind: 'seed', reason: 'org bootstrap - no live users to notify' },
+        depth: 0,
+      },
+    })
 
     // Skip if signatures already exist (additive mode)
     const existing = await handler.list('signature', { limit: 1 })
@@ -126,14 +133,10 @@ export class OrganizationDomain {
           // nothing and silently produced field-less instances. `is_default` and
           // `visibility` are gone entirely — plan 36 replaced visibility with
           // `ResourceAccess` rows and made "default" a per-user `UserSetting`.
-          const result = await handler.create(
-            'signature',
-            {
-              signature_name: name,
-              signature_body: this.generateSignatureContent(user.email, isPrimary),
-            },
-            { skipEvents: true }
-          )
+          const result = await handler.create('signature', {
+            signature_name: name,
+            signature_body: this.generateSignatureContent(user.email, isPrimary),
+          })
           // `signature` is `baselineAtCreate: true`, so a seeded signature with
           // no owner row is invisible to EVERYONE but the org OWNER. The handler
           // acts as `ownerId`, so that is the `createdById` this row grants.

--- a/packages/seed/src/domains/ticket.domain.ts
+++ b/packages/seed/src/domains/ticket.domain.ts
@@ -108,7 +108,11 @@ export class TicketDomain {
   ): Promise<void> {
     console.log('🎫 Generating tickets via UnifiedCrudHandler...')
 
-    const handler = new UnifiedCrudHandler(organizationId, userId, db)
+    // Seed session: silent lane — same suppression the per-call
+    // `skipEvents: true` used to provide, declared once at construction.
+    const handler = new UnifiedCrudHandler(organizationId, userId, db, undefined, {
+      session: { origin: { kind: 'seed', reason: 'demo ticket seed data' }, depth: 0 },
+    })
 
     // Get existing contact EntityInstances for linking (need both definitionId and instanceId for RecordId format)
     const contacts = await db
@@ -158,9 +162,7 @@ export class TicketDomain {
     }
 
     if (ticketValues.length > 0) {
-      const { created, errors } = await handler.bulkCreate('ticket', ticketValues, {
-        skipEvents: true,
-      })
+      const { created, errors } = await handler.bulkCreate('ticket', ticketValues)
 
       if (errors.length > 0) {
         console.log(`⚠️  ${errors.length} ticket creation errors:`)


### PR DESCRIPTION
## Summary

Phase 3 slices (c-groundwork) + (d) of `plans/events/03-write-context-and-batch-lane-plan.md`.

- **Seeders → `seed` sessions.** All six seed files that passed `skipEvents: true` (org/crm/ticket domains, `organization-seeder`, `ai-category-tags`) now construct their handlers with `{ kind: 'seed', reason: '…' }` — the reason lives inline at the construction site (D-2.4 of the original design: greppable, reviewable). Suppression is identical: seed lane is `'silent'`, the same result `skipEvents: true` produced at the `derivePublishEvents` seam. Every per-call flag and `seedOpts` constant is deleted — including the `undefined, { skipEvents: true }` tails from the recent arg-slot fix, which the session makes unnecessary. Bypass sets (`is_system_tag`, `tag_template_key`) are preserved unchanged.
- **Ingest → `automation` session** with the system actor. Inline lane — ingest fan-out is byte-identical today; this is the attribution groundwork. A comment marks where the initial-backfill flip to a `sync` session (keyed off `backfillCutoffAt`, plan Phase 7 / D-8) will land.
- Deliberately untouched: `user-seeder` (passes no `skipEvents` today — a seed session would newly silence it), the frozen 076 data migration, and the caller-controlled money sites (S10).

Grep-verified: zero live `skipEvents` occurrences remain in the converted files.

## Test plan

- `ai-category-tags.test.ts` updated to prove the same suppression through the session (options/modes undefined, session asserted on calls and constructor) — no assertion weakened.
- `src/seed` + `src/ingest`: 21 files / 261 tests pass (ingest change confirmed inert); the 076 test suite (55 tests) passes.
- Combined run with the two sibling PRs' changes: 157 files / 1516 tests pass.