### PR TITLE
feat(database): stamp EntityInstance.updatedAt explicitly instead of $onUpdate

### DIFF
--- a/packages/database/src/db/schema/entity-instance.ts
+++ b/packages/database/src/db/schema/entity-instance.ts
@@ -22,10 +22,19 @@ export const EntityInstance = pgTable(
       .notNull()
       .$defaultFn(() => createId()),
     createdAt: timestamp({ precision: 3 }).defaultNow().notNull(),
-    updatedAt: timestamp({ precision: 3 })
-      .defaultNow()
-      .notNull()
-      .$onUpdate(() => new Date()),
+    /**
+     * "Record CONTENT changed" — stamped EXPLICITLY by the write paths (D-7,
+     * plans/events/03-write-context-and-batch-lane-plan.md §1). Deliberately
+     * NO `$onUpdate`: the old auto-bump moved on every physical row write,
+     * so bookkeeping writes (`lastActivityAt`, interaction stamps, scan
+     * watermarks, connector ownership stamps, metadata counters) re-dirtied
+     * records into dedup rescan loops. Now: `defaultNow()` stamps creates;
+     * archive/restore stamps in `update-entity-instance.ts`; a field-value
+     * write that performs at least one REAL change stamps once via
+     * `setValuesForEntity` (idempotent no-ops don't); bookkeeping writes
+     * simply don't stamp.
+     */
+    updatedAt: timestamp({ precision: 3 }).defaultNow().notNull(),
     archivedAt: timestamp({ precision: 3, withTimezone: true }),
 
     /** Reference to the entity definition this is an instance of */
@@ -100,11 +109,11 @@ export const EntityInstance = pgTable(
     /**
      * Set by the duplicate scanner every time it blocks + scores this record.
      * The dirty predicate is deliberately NOT `lastActivityAt` (which the
-     * suggestion scanner uses): `skipEvents` / userId-less writes — connector
-     * syncs, CSV imports — leave BOTH `updatedAt` and `lastActivityAt`
-     * untouched, so the scan compares this against
-     * `GREATEST(ei."updatedAt", max(fv."updatedAt"))`. `FieldValue.updatedAt` is
-     * the only timestamp that always moves.
+     * suggestion scanner uses): the scan compares this against
+     * `GREATEST(ei."updatedAt", max(fv."updatedAt"))`. Since D-7, `updatedAt`
+     * is stamped explicitly on content changes (including handler-mediated
+     * field writes), but raw writers that bypass the handler still only move
+     * `FieldValue.updatedAt` — the `GREATEST` arm stays load-bearing for those.
      */
     lastDuplicateScanAt: timestamp({ precision: 3 }),
 
@@ -183,7 +192,10 @@ export const EntityInstance = pgTable(
     // for dedup is `GREATEST(ei."updatedAt", max(fv."updatedAt")) >
     // "lastDuplicateScanAt"`. EVERY scan door runs this query (the mutation
     // seam, the sync-manifest consumer, and the 6h sweep all share one
-    // watermark-driven handler), not just the sweep.
+    // watermark-driven handler), not just the sweep. Since D-7 removed
+    // `$onUpdate`, bookkeeping writes (watermark stamps, `lastSuggestionScanAt`,
+    // activity/interaction touches) no longer bump `updatedAt`, so they can no
+    // longer re-dirty a record against its own fresh watermark.
     index('EntityInstance_org_def_dup_scan_idx')
       .on(
         table.organizationId,

--- a/packages/lib/src/entity-instances/__tests__/updated-at-stamp.test.ts
+++ b/packages/lib/src/entity-instances/__tests__/updated-at-stamp.test.ts
@@ -1,0 +1,128 @@
+// packages/lib/src/entity-instances/__tests__/updated-at-stamp.test.ts
+//
+// D-7 (plans/events/03-write-context-and-batch-lane-plan.md §1):
+// `EntityInstance.updatedAt` carries no `$onUpdate` anymore — it means
+// "record CONTENT changed" and is stamped explicitly. These tests pin the
+// stamp-or-not decisions in this directory: archive/restore STAMPS
+// (updateEntityInstance), the activity/interaction touches are bookkeeping
+// and must NOT include `updatedAt` in their write payloads.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  /** Every `update(...).set(payload)` this file's code under test issues. */
+  setPayloads: [] as Array<Record<string, unknown>>,
+}))
+
+vi.mock('../../cache/singletons', () => ({
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async () => ({ contact_employer: null }),
+    }),
+  }),
+}))
+
+vi.mock('drizzle-orm', () => {
+  const passthrough = (...a: unknown[]) => a
+  return {
+    and: passthrough,
+    or: passthrough,
+    eq: passthrough,
+    inArray: passthrough,
+    isNotNull: passthrough,
+    sql: Object.assign(passthrough, { raw: passthrough }),
+  }
+})
+
+vi.mock('@auxx/database', async () => {
+  const { createSchemaMock } = await import('../../test/database-mock')
+  const schema = createSchemaMock()
+
+  const database = {
+    update: () => ({
+      set: (payload: Record<string, unknown>) => {
+        h.setPayloads.push(payload)
+        return {
+          where: () => {
+            // `updateEntityInstance` chains `.returning()`; the touches await
+            // `.where()` directly — a settled promise carrying a `returning`
+            // method supports both shapes without a hand-rolled thenable.
+            const settled = Promise.resolve(undefined) as Promise<undefined> & {
+              returning: () => Promise<unknown[]>
+            }
+            settled.returning = () => Promise.resolve([{ id: 'inst-1', ...payload }])
+            return settled
+          },
+        }
+      },
+    }),
+  }
+
+  return { database, schema, Database: class {}, Transaction: class {} }
+})
+
+// `updateEntityInstance` wraps its query in `fromDatabase` — reduce it to a
+// pass-through Result so the fake chain's `.returning()` rows come back as-is.
+vi.mock('@auxx/services/shared/utils', () => ({
+  fromDatabase: async (query: Promise<unknown>) => {
+    const value = await query
+    return { isErr: () => false, isOk: () => true, value }
+  },
+}))
+
+import { touchEntityActivity, touchEntityInteraction } from '../activity'
+import { updateEntityInstance } from '../update-entity-instance'
+
+const ORG = 'org_1'
+
+beforeEach(() => {
+  h.setPayloads.length = 0
+})
+
+describe('D-7 stamp-or-not decisions', () => {
+  it('archive stamps updatedAt explicitly', async () => {
+    const result = await updateEntityInstance({
+      id: 'inst-1',
+      organizationId: ORG,
+      data: { archivedAt: new Date('2026-08-21T10:00:00Z') },
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(h.setPayloads).toHaveLength(1)
+    const payload = h.setPayloads[0]!
+    expect(payload.updatedAt).toBeInstanceOf(Date)
+    expect(payload.archivedAt).toEqual(new Date('2026-08-21T10:00:00Z'))
+    // Archive/restore also advances lastActivityAt (staleness scanner).
+    expect(payload.lastActivityAt).toBeInstanceOf(Date)
+  })
+
+  it('restore stamps updatedAt explicitly', async () => {
+    await updateEntityInstance({
+      id: 'inst-1',
+      organizationId: ORG,
+      data: { archivedAt: null },
+    })
+
+    expect(h.setPayloads).toHaveLength(1)
+    expect(h.setPayloads[0]!.updatedAt).toBeInstanceOf(Date)
+    expect(h.setPayloads[0]!.archivedAt).toBeNull()
+  })
+
+  it('touchEntityActivity does NOT stamp updatedAt (bookkeeping)', async () => {
+    await touchEntityActivity(['inst-1'], ORG, new Date('2026-08-21T10:00:00Z'))
+
+    expect(h.setPayloads).toHaveLength(1)
+    expect(h.setPayloads[0]).toEqual({ lastActivityAt: new Date('2026-08-21T10:00:00Z') })
+    expect('updatedAt' in h.setPayloads[0]!).toBe(false)
+  })
+
+  it('touchEntityInteraction does NOT stamp updatedAt (bookkeeping)', async () => {
+    await touchEntityInteraction(['inst-1'], ORG, 'msg-1', new Date('2026-08-21T10:00:00Z'))
+
+    // Two UPDATEs: first-wins pair and last-wins pair — neither carries updatedAt.
+    expect(h.setPayloads).toHaveLength(2)
+    for (const payload of h.setPayloads) {
+      expect('updatedAt' in payload).toBe(false)
+    }
+  })
+})

--- a/packages/lib/src/entity-instances/activity.ts
+++ b/packages/lib/src/entity-instances/activity.ts
@@ -71,6 +71,9 @@ export async function touchEntityActivity(
   const db = tx ?? database
 
   try {
+    // Deliberately does NOT stamp `updatedAt` (D-7): activity is bookkeeping,
+    // not record content — the old `$onUpdate` auto-bump here re-dirtied
+    // records into dedup rescans.
     await db
       .update(schema.EntityInstance)
       .set({ lastActivityAt: at })
@@ -131,6 +134,8 @@ export async function touchEntityInteraction(
   const db = tx ?? database
 
   try {
+    // Like the activity touch, interaction stamps are bookkeeping and
+    // intentionally leave `updatedAt` alone (D-7).
     await db
       .update(schema.EntityInstance)
       .set({ firstInteractionAt: sentAt, firstInteractionMessageId: messageId })

--- a/packages/lib/src/entity-instances/batch-update-display-values.ts
+++ b/packages/lib/src/entity-instances/batch-update-display-values.ts
@@ -19,6 +19,11 @@ export interface BatchUpdateDisplayValuesInput {
 /**
  * Batch update display values for multiple EntityInstances.
  * Thin DB operation - business logic lives in lib package.
+ *
+ * Deliberately does NOT stamp `updatedAt` (D-7): callers are definition-level
+ * display-field reconfigurations (`display-field-service.ts`) recomputing a
+ * derived column across every instance — the records' own content didn't
+ * change, and stamping would re-dirty the whole definition into a dedup rescan.
  */
 export async function batchUpdateDisplayValues(input: BatchUpdateDisplayValuesInput) {
   const { organizationId, updates, column } = input
@@ -71,6 +76,8 @@ export interface ClearDisplayValuesInput {
 /**
  * Clear display values for all instances of an entity definition.
  * Used when display field is set to null.
+ *
+ * No `updatedAt` stamp — same D-7 rationale as `batchUpdateDisplayValues`.
  */
 export async function clearDisplayValues(input: ClearDisplayValuesInput) {
   const { entityDefinitionId, organizationId, column } = input

--- a/packages/lib/src/entity-instances/update-entity-instance.ts
+++ b/packages/lib/src/entity-instances/update-entity-instance.ts
@@ -24,6 +24,8 @@ export async function updateEntityInstance(params: UpdateEntityInstanceParams) {
 
   const now = new Date()
   const updateData: Record<string, unknown> = {
+    // D-7 explicit content stamp: archive/restore is a record content change,
+    // and `updatedAt` no longer auto-bumps (`$onUpdate` removed).
     updatedAt: now,
   }
   if ('archivedAt' in data) {

--- a/packages/lib/src/field-values/__tests__/instance-updated-at-stamp.test.ts
+++ b/packages/lib/src/field-values/__tests__/instance-updated-at-stamp.test.ts
@@ -1,0 +1,280 @@
+// packages/lib/src/field-values/__tests__/instance-updated-at-stamp.test.ts
+//
+// D-7 (plans/events/03-write-context-and-batch-lane-plan.md §1):
+// `EntityInstance.updatedAt` lost its `$onUpdate` and is stamped EXPLICITLY.
+// `setValuesForEntity` is the chokepoint for handler-mediated field writes:
+// a record write that performs at least one REAL change stamps `updatedAt`
+// exactly once; an idempotent no-op (D-6 guard) or delete-of-absent (B-14)
+// stamps nothing — that is the whole point, a bookkeeping-shaped write must
+// not re-dirty the dedup watermark.
+
+import { toRecordId } from '@auxx/types/resource'
+
+// ⚠️ Mock '../../realtime/publish-helpers' directly — NOT the '../../realtime'
+// barrel (see batched-realtime-publish.test.ts for the import-cycle rationale).
+vi.mock('../../realtime/publish-helpers', () => ({
+  publishFieldValueUpdates: vi.fn(),
+}))
+
+// '../../cache' is a large barrel with real DB/Redis-backed providers. Mock it
+// wholesale (same set as set-idempotency.test.ts).
+vi.mock('../../cache', () => ({
+  getCachedFieldMap: vi.fn(),
+  getCachedResource: vi.fn(),
+  getOrgCache: vi.fn(),
+  getAllCachedCustomFields: vi.fn(async () => []),
+  getCachedRecordRules: vi.fn(async () => []),
+}))
+
+vi.mock('../../field-hooks/registry', () => ({
+  hasEntityFieldChangeHooks: vi.fn(() => false),
+  hasFieldTypeChangeHooks: vi.fn(() => false),
+  hasFieldPreHooks: vi.fn(() => false),
+  getEntityFieldChangeHooks: vi.fn(() => []),
+  getFieldTypeChangeHooks: vi.fn(() => []),
+  getFieldPreHooks: vi.fn(() => []),
+}))
+
+vi.mock('../../field-hooks/collect-triggers', () => ({
+  collectTriggeredFields: vi.fn(async () => []),
+  deduplicateBySystemAttribute: vi.fn((fields: unknown[]) => fields),
+}))
+vi.mock('../../field-hooks/publish', () => ({
+  publishFieldTriggerEvents: vi.fn(async () => {}),
+  publishBatchFieldTriggerEvents: vi.fn(async () => {}),
+}))
+
+vi.mock('../timeline-snapshot', () => ({
+  preloadSnapshotCache: vi.fn(),
+  resolveFieldChangeSnapshotPair: vi.fn(async () => ({ oldDisplay: null, newDisplay: null })),
+  resolveFieldChangeSnapshotsBulk: vi.fn(async () => new Map()),
+}))
+
+import { schema } from '@auxx/database'
+import { getCachedFieldMap, getCachedResource, getOrgCache } from '../../cache'
+import { publishFieldValueUpdates } from '../../realtime/publish-helpers'
+import { createFieldValueContext, type FieldValueContext } from '../field-value-helpers'
+import { setValuesForEntity } from '../field-value-mutations'
+
+const mockedGetCachedFieldMap = getCachedFieldMap as unknown as ReturnType<typeof vi.fn>
+const mockedGetCachedResource = getCachedResource as unknown as ReturnType<typeof vi.fn>
+const mockedGetOrgCache = getOrgCache as unknown as ReturnType<typeof vi.fn>
+const mockedPublish = vi.mocked(publishFieldValueUpdates)
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const recordId = toRecordId('widget', 'inst-1')
+
+/** Minimal CustomField-shaped fixture (same shape as the sibling suites). */
+function fieldFixture(id: string, type: string, options: Record<string, unknown> = {}) {
+  return {
+    id,
+    type,
+    options,
+    entityDefinitionId: null,
+    entityDefinition: null,
+    entityType: null,
+    isUnique: false,
+    systemAttribute: null,
+  }
+}
+
+const FIELD_A = fieldFixture('field-a', 'TEXT')
+const FIELD_B = fieldFixture('field-b', 'TEXT')
+
+/** A stored FieldValue row for (inst-1, fieldId) with payload overrides. */
+function existingRow(id: string, fieldId: string, payload: Record<string, unknown>) {
+  return {
+    id,
+    entityId: 'inst-1',
+    entityDefinitionId: 'widget',
+    fieldId,
+    organizationId: 'org-1',
+    valueText: null,
+    valueNumber: null,
+    valueBoolean: null,
+    valueDate: null,
+    valueJson: null,
+    optionId: null,
+    relatedEntityId: null,
+    relatedEntityDefinitionId: null,
+    actorId: null,
+    aiStatus: null,
+    sortKey: 'a0',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...payload,
+  }
+}
+
+/**
+ * Chainable `ctx.db` fake in the style of set-idempotency.test.ts, extended to
+ * CAPTURE `update(table).set(payload)` pairs — the D-7 stamp is an
+ * `update(schema.EntityInstance).set({ updatedAt })`, and the global setup
+ * proxy memoizes `schema.*` so the table is comparable by reference.
+ * FieldValue reads resolve per-field from `rowsByField`.
+ */
+function makeFakeDb(rowsByField: Record<string, any[]> = {}) {
+  let idSeq = 0
+  let pendingValues: any[] = []
+  const state = {
+    deleteCalls: 0,
+    insertCalls: 0,
+    updates: [] as Array<{ table: unknown; set: Record<string, unknown> }>,
+  }
+  let currentUpdateTable: unknown = null
+  const chain: any = {}
+  Object.assign(chain, {
+    delete: () => {
+      state.deleteCalls++
+      return chain
+    },
+    where: () => chain,
+    insert: () => {
+      state.insertCalls++
+      return chain
+    },
+    values: (rows: any) => {
+      pendingValues = Array.isArray(rows) ? rows : [rows]
+      return chain
+    },
+    onConflictDoUpdate: () => chain,
+    returning: () =>
+      Promise.resolve(
+        pendingValues.map((row) => ({
+          id: `fv-new-${idSeq++}`,
+          createdAt: '2026-02-01T00:00:00.000Z',
+          updatedAt: '2026-02-01T00:00:00.000Z',
+          ...row,
+        }))
+      ),
+    select: () => chain,
+    from: () => chain,
+    // The reads this path performs (loadExistingRowsForSet, oldValue fetch)
+    // are always scoped to one fieldId, but the fake ignores conditions —
+    // flatten every field's rows; the guard comparison keys on fieldId anyway.
+    orderBy: () => Promise.resolve(Object.values(rowsByField).flat()),
+    update: (table: unknown) => {
+      currentUpdateTable = table
+      return chain
+    },
+    set: (payload: Record<string, unknown>) => {
+      state.updates.push({ table: currentUpdateTable, set: payload })
+      return chain
+    },
+  })
+  return { db: chain, state }
+}
+
+function makeCtx(db: any, fields: ReturnType<typeof fieldFixture>[]): FieldValueContext {
+  const ctx = createFieldValueContext('org-1', 'user-1', db, 'socket-abc')
+  for (const f of fields) ctx.fieldCache.set(f.id, f as any)
+  return ctx
+}
+
+/** The D-7 chokepoint stamps: EntityInstance updates carrying `updatedAt`. */
+function stampWrites(state: ReturnType<typeof makeFakeDb>['state']) {
+  return state.updates.filter((u) => u.table === schema.EntityInstance && 'updatedAt' in u.set)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockedPublish.mockResolvedValue(undefined)
+  mockedGetCachedResource.mockResolvedValue(undefined)
+  mockedGetCachedFieldMap.mockResolvedValue(
+    new Map([
+      [FIELD_A.id, FIELD_A],
+      [FIELD_B.id, FIELD_B],
+    ])
+  )
+  mockedGetOrgCache.mockReturnValue({
+    from: () => ({ all: async () => ({}), byId: async () => undefined }),
+  })
+})
+
+// =============================================================================
+// D-7 — explicit `EntityInstance.updatedAt` stamp
+// =============================================================================
+
+describe('setValuesForEntity D-7 updatedAt stamp', () => {
+  it('a real field change stamps EntityInstance.updatedAt exactly once', async () => {
+    const { db, state } = makeFakeDb({
+      'field-a': [existingRow('fv-a', 'field-a', { valueText: 'old' })],
+    })
+    const ctx = makeCtx(db, [FIELD_A])
+
+    const results = await setValuesForEntity(ctx, {
+      recordId,
+      values: [{ fieldId: 'field-a', value: 'new' }],
+    })
+
+    expect(results).toHaveLength(1)
+    expect(results[0]!.changed).toBe(true)
+    expect(state.deleteCalls).toBe(1)
+    expect(state.insertCalls).toBe(1)
+
+    const stamps = stampWrites(state)
+    expect(stamps).toHaveLength(1)
+    expect(stamps[0]!.set.updatedAt).toBeInstanceOf(Date)
+    // The stamp is a pure freshness write — it must not smuggle other columns.
+    expect(Object.keys(stamps[0]!.set)).toEqual(['updatedAt'])
+  })
+
+  it('an idempotent no-op set (D-6 guard hit) does NOT stamp', async () => {
+    const { db, state } = makeFakeDb({
+      'field-a': [existingRow('fv-a', 'field-a', { valueText: 'same' })],
+    })
+    const ctx = makeCtx(db, [FIELD_A])
+
+    const results = await setValuesForEntity(ctx, {
+      recordId,
+      values: [{ fieldId: 'field-a', value: 'same' }],
+    })
+
+    expect(results[0]!.changed).toBe(false)
+    expect(state.deleteCalls).toBe(0)
+    expect(state.insertCalls).toBe(0)
+    expect(stampWrites(state)).toHaveLength(0)
+  })
+
+  it('delete-of-absent (B-14) does NOT stamp', async () => {
+    const { db, state } = makeFakeDb({})
+    const ctx = makeCtx(db, [FIELD_A])
+
+    const results = await setValuesForEntity(ctx, {
+      recordId,
+      values: [{ fieldId: 'field-a', value: null }],
+    })
+
+    expect(results[0]!.changed).toBe(false)
+    expect(state.deleteCalls).toBe(0)
+    expect(stampWrites(state)).toHaveLength(0)
+  })
+
+  it('mixed write (one changed, one unchanged) stamps exactly once', async () => {
+    const { db, state } = makeFakeDb({
+      'field-a': [existingRow('fv-a', 'field-a', { valueText: 'same' })],
+    })
+    const ctx = makeCtx(db, [FIELD_A, FIELD_B])
+
+    const results = await setValuesForEntity(ctx, {
+      recordId,
+      values: [
+        // field-a re-asserts the stored value (no-op)…
+        { fieldId: 'field-a', value: 'same' },
+        // …field-b is a real change. NOTE: the fake serves field-a's stored
+        // row for BOTH guard reads (it ignores where-conditions), but the
+        // guard compares by fieldId+value, so field-b still registers as
+        // changed against a row belonging to a different field.
+        { fieldId: 'field-b', value: 'brand-new' },
+      ],
+    })
+
+    const byField = new Map(results.map((r) => [r.fieldId, r]))
+    expect(byField.get('field-a')!.changed).toBe(false)
+    expect(byField.get('field-b')!.changed).toBe(true)
+    expect(stampWrites(state)).toHaveLength(1)
+  })
+})

--- a/packages/lib/src/field-values/avatar-thumbnail.ts
+++ b/packages/lib/src/field-values/avatar-thumbnail.ts
@@ -69,6 +69,9 @@ export async function applyAvatarThumbnailUrl(
   if (instances.length === 0) return null
 
   const instanceIds = instances.map((i: { entityInstanceId: string }) => i.entityInstanceId)
+  // No `updatedAt` stamp (D-7): this background job upgrades an interim
+  // download URL to the CDN thumbnail — a derived artifact of a field write
+  // that already stamped the record. Not a content change.
   await db
     .update(schema.EntityInstance)
     .set({ avatarUrl: cdnUrl })

--- a/packages/lib/src/field-values/field-value-helpers.ts
+++ b/packages/lib/src/field-values/field-value-helpers.ts
@@ -1090,6 +1090,35 @@ async function publishRecordColumnUpdate(
 }
 
 /**
+ * D-7 explicit content stamp: bump `EntityInstance.updatedAt` for a record
+ * whose field values just performed at least one REAL change. `updatedAt`
+ * carries no `$onUpdate` anymore — this is the single stamp site for
+ * handler-mediated field writes, called once per record write from
+ * `setValuesForEntity`. Best-effort like the other denormalized touches:
+ * a failed stamp must never fail the write (dedup's
+ * `GREATEST(ei.updatedAt, max(fv.updatedAt))` watermark still catches up
+ * via `FieldValue.updatedAt`).
+ */
+export async function stampEntityInstanceUpdatedAt(
+  ctx: Pick<FieldValueContext, 'db' | 'organizationId'>,
+  entityInstanceId: string
+): Promise<void> {
+  try {
+    await ctx.db
+      .update(schema.EntityInstance)
+      .set({ updatedAt: new Date() })
+      .where(
+        and(
+          eq(schema.EntityInstance.id, entityInstanceId),
+          eq(schema.EntityInstance.organizationId, ctx.organizationId)
+        )
+      )
+  } catch {
+    // Best-effort freshness marker — never break the calling write path.
+  }
+}
+
+/**
  * Update EntityInstance display columns if field is a display field.
  * Handles primary (displayName), secondary (secondaryDisplayValue), and avatar (avatarUrl).
  */
@@ -1119,9 +1148,11 @@ export async function maybeUpdateDisplayValue(
   if (!column && entityDef.primaryDisplayFieldId) {
     const result = await resolveNameFieldDisplayValue(ctx, recordId, entityDef, field, value)
     if (result !== undefined) {
+      // D-7: a display-source field changed, so this is record content — stamp
+      // `updatedAt` in the same statement as the denormalized column.
       await ctx.db
         .update(schema.EntityInstance)
-        .set({ displayName: result })
+        .set({ displayName: result, updatedAt: new Date() })
         .where(
           and(
             eq(schema.EntityInstance.id, entityInstanceId),
@@ -1247,10 +1278,12 @@ export async function maybeUpdateDisplayValue(
     }
   }
 
-  // Update the appropriate column
+  // Update the appropriate column. D-7: this runs only on the real-change path
+  // (the D-6 idempotency guard short-circuits identical sets before display
+  // recompute), so the display write doubles as a content stamp on `updatedAt`.
   await ctx.db
     .update(schema.EntityInstance)
-    .set({ [column]: displayValue })
+    .set({ [column]: displayValue, updatedAt: new Date() })
     .where(
       and(
         eq(schema.EntityInstance.id, entityInstanceId),

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -68,6 +68,7 @@ import {
   preBatchValidateRelationships,
   resolveFieldIds,
   rowToTypedValue,
+  stampEntityInstanceUpdatedAt,
   validateAndConvertValue,
 } from './field-value-helpers'
 import { getValue } from './field-value-queries'
@@ -2292,11 +2293,11 @@ export async function setValueWithBuiltIn(
           updatedAt: performedAt,
           ...typedInput,
         } as TypedFieldValue
-        return { state: 'complete', performedAt, values: [syntheticValue] }
+        return { state: 'complete', performedAt, values: [syntheticValue], changed: true }
       }
     }
 
-    return { state: 'complete', performedAt, values: [] }
+    return { state: 'complete', performedAt, values: [], changed: true }
   }
 
   // 2. Normalize systemAttribute / ResourceFieldId forms to a real FieldId —
@@ -2344,7 +2345,7 @@ export async function setValueWithBuiltIn(
     entityType,
   })
   if (hookOutcome.kind === 'drop') {
-    return { state: 'complete', performedAt: new Date().toISOString(), values: [] }
+    return { state: 'complete', performedAt: new Date().toISOString(), values: [], changed: false }
   }
   const typedValue = hookOutcome.value
 
@@ -2375,7 +2376,12 @@ export async function setValueWithBuiltIn(
       value: typedValue,
     })
     if (unchanged !== null) {
-      return { state: 'complete', performedAt: new Date().toISOString(), values: unchanged }
+      return {
+        state: 'complete',
+        performedAt: new Date().toISOString(),
+        values: unchanged,
+        changed: false,
+      }
     }
   }
 
@@ -2440,7 +2446,12 @@ export async function setValueWithBuiltIn(
     // is nothing to change. Skipped when the guard is bypassed/disabled
     // (`guardRows === null`), falling through to the old behavior.
     if (guardRows !== null && guardRows.length === 0) {
-      return { state: 'complete', performedAt: new Date().toISOString(), values: [] }
+      return {
+        state: 'complete',
+        performedAt: new Date().toISOString(),
+        values: [],
+        changed: false,
+      }
     }
     await deleteValue(ctx, { recordId, fieldId })
     await maybeUpdateDisplayValue(ctx, recordId, field, null)
@@ -2473,7 +2484,7 @@ export async function setValueWithBuiltIn(
       }
     }
     await firePostHook(null)
-    return { state: 'complete', performedAt: new Date().toISOString(), values: [] }
+    return { state: 'complete', performedAt: new Date().toISOString(), values: [], changed: true }
   }
 
   // 4. Uniqueness is enforced inside setValueWithType (step 6) — one gate
@@ -2548,6 +2559,7 @@ export async function setValueWithBuiltIn(
     state: 'complete',
     performedAt: new Date().toISOString(),
     values: result,
+    changed: true,
   }
 }
 
@@ -2598,9 +2610,12 @@ export async function setValuesForEntity(
   // simply stays empty and the flush below is a no-op.
   const collected: FieldValueUpdateEntry[] = []
 
-  // Handle built-in fields
+  // Handle built-in fields. Built-in writes carry no idempotency guard, so
+  // `changed` reflects "a handler performed a write" — same semantics the old
+  // `$onUpdate` bump had for this lane.
   for (const v of builtIns) {
     const handler = getBuiltInFieldHandler(v.fieldId, modelType)
+    const wrote = !!handler
     if (handler) {
       await handler(ctx.db, entityInstanceId, v.value, ctx.organizationId)
     }
@@ -2625,6 +2640,7 @@ export async function setValuesForEntity(
           state: 'complete',
           performedAt,
           values: [syntheticValue],
+          changed: wrote,
         })
         continue
       }
@@ -2635,6 +2651,7 @@ export async function setValuesForEntity(
       state: 'complete',
       performedAt: new Date().toISOString(),
       values: [],
+      changed: wrote,
     })
   }
 
@@ -2692,6 +2709,7 @@ export async function setValuesForEntity(
           state: 'failed',
           performedAt: new Date().toISOString(),
           values: [],
+          changed: false,
         })
       }
     }
@@ -2704,6 +2722,18 @@ export async function setValuesForEntity(
     publishFieldValueUpdates(getRealtimeService(), ctx.organizationId, collected, {
       excludeSocketId: ctx.socketId,
     }).catch(() => {})
+  }
+
+  // D-7: one explicit `EntityInstance.updatedAt` stamp per record write when
+  // at least one field performed a REAL change. This is THE chokepoint for
+  // handler-mediated writes — create/update/updateValues and the handler's
+  // multi-field `setFieldValues` all funnel their `set` entries here, and it
+  // sits below the handler so direct service callers stamp too. Idempotent
+  // re-assertions (D-6 guard), delete-of-absent (B-14), pre-hook drops, and
+  // failed fields all report `changed: false` and never stamp — a pure no-op
+  // write must not re-dirty the dedup watermark.
+  if (results.some((r) => r.changed)) {
+    await stampEntityInstanceUpdatedAt(ctx, entityInstanceId)
   }
 
   return results

--- a/packages/lib/src/field-values/types.ts
+++ b/packages/lib/src/field-values/types.ts
@@ -212,6 +212,14 @@ export interface SetValueResult {
    * normally identify cells via `(recordId, fieldId)`, so this is optional.
    */
   jobId?: string
+  /**
+   * `true` when the write performed a REAL change (rows written or deleted).
+   * `false`/absent for no-ops: the D-6 idempotency guard (identical set),
+   * B-14 delete-of-absent, pre-hook drops, and AI stage-1 short-circuits.
+   * Surfaced additively for the D-7 `EntityInstance.updatedAt` stamp — a
+   * record write stamps once iff at least one field actually changed.
+   */
+  changed?: boolean
 }
 
 /**
@@ -222,6 +230,8 @@ export interface SetValuesResult {
   state: SetValueState
   performedAt: string
   values: TypedFieldValue[]
+  /** See {@link SetValueResult.changed} — real change vs idempotent no-op. */
+  changed?: boolean
 }
 
 /**

--- a/packages/lib/src/resources/crud/unified-handler.ts
+++ b/packages/lib/src/resources/crud/unified-handler.ts
@@ -1241,6 +1241,13 @@ export class UnifiedCrudHandler {
    * @param modes - Optional per-field write mode. Fields not listed default
    *   to `'set'`. `'add'` / `'remove'` route to the multi-value primitives;
    *   they throw `BadRequestError` on single-value fields.
+   *
+   * D-7 note: the explicit `EntityInstance.updatedAt` content stamp for the
+   * `set` lane lives inside `setValuesForEntity` (one stamp per record write,
+   * only when at least one field reported `changed`). The `add`/`remove`
+   * lanes don't stamp — dedup's `GREATEST(ei.updatedAt, max(fv.updatedAt))`
+   * watermark covers additions via `FieldValue.updatedAt`, matching the
+   * pre-D-7 behavior for those paths.
    */
   private async setFieldValues(
     recordId: RecordId,


### PR DESCRIPTION
## Summary

Decision D-7 of `plans/events/03-write-context-and-batch-lane-plan.md`: remove `$onUpdate` from `EntityInstance.updatedAt` and stamp it explicitly, so `updatedAt` means "record content changed" rather than "row physically written".

**Why**: the auto-bump was too eager and not eager enough at once. Too eager: any bookkeeping row write re-dirtied records into the dedup scanner's watermark — the AI next-action stale-scanner's `lastSuggestionScanAt` stamp did this on **every suggestion scan** (a silent win from this PR), and the watermark stamp itself needed a raw-SQL-only rule to avoid an infinite rescan loop. Not eager enough: a pure field-value write never moved it, which is why dedup keys off `GREATEST(ei.updatedAt, max(fv.updatedAt))`.

**No SQL migration** — verified against the Drizzle snapshot: `$onUpdate` is runtime-only, the column DDL is byte-identical.

**Every `EntityInstance` write site got an explicit decision**:
- STAMP (content change): archive/restore, the display-column denormalization writes, and the new `setFieldValues` chokepoint.
- NO STAMP (bookkeeping, each commented): `touchEntityActivity`/`touchEntityInteraction`, definition-level display recomputes (stamping would re-dirty a whole def into dedup rescan), avatar-thumbnail upgrades, raw searchText writes, dependent-display cascades.
- Out-of-scope sites (connector `managedByConnectorId` stamp, inbox def moves, group metadata) now correctly stop bumping with no edit needed. Two small follow-ups flagged: `archivedAt` writes in connector mutations and merge-service lack a stamp (low-stakes — archived rows exit dedup anyway).

**New behavior**: a `setFieldValues` call that performs ≥1 REAL change stamps the instance once, in `setValuesForEntity` (the genuine funnel — create/update/updateValues/bulk and direct service callers all pass through it). The signal is an additive `changed?: boolean` on the set results, reported by the merged idempotency guard — so a no-op write provably does not stamp. The dedup `GREATEST` watermark is untouched (still needed for handler-bypassing raw writers; simplification is future work).

## Test plan

- New `instance-updated-at-stamp.test.ts` (real change stamps exactly once with a pure `{updatedAt}` payload; D-6 no-op and B-14 delete-of-absent don't; mixed write stamps once) and `updated-at-stamp.test.ts` (archive/restore stamp; activity/interaction touches don't).
- Unit: crud + field-values + entity-instances + dedup — 51 files / 506 tests pass. Integration (real DB): dedup 77 pass including the watermark-loop pin; field-values 11 pass.
- `@auxx/database` typecheck clean; combined run with the two sibling PRs' changes: 157 files / 1516 tests pass.