### PR TITLE
feat(events): add the sync finalize pass with count-based lane selection

### DIFF
--- a/packages/lib/src/data-connectors/connector-sync-source.ts
+++ b/packages/lib/src/data-connectors/connector-sync-source.ts
@@ -39,6 +39,7 @@ import {
   decrementConnectorBackfillLatch,
   finalizeConnector,
   foldRunManifest,
+  getRunManifest,
   markRunManifestDegraded,
   newRunCounters,
   parkConnectorSampleIfLastStream,
@@ -387,15 +388,24 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
     // §7b run-completion edge on the org channel, aligned with the importer's.
     // Runs once per run (last stream, past the B1 latch), AFTER the finalize
     // writes, so the client's catch-up sees post-reconcile state. Per-def
-    // changed counts are NOT cheaply available here — the run counters are
-    // aggregate across streams and a stream can map several defs — so each
-    // touched def ships count 0 ("changed, count unknown" per the event doc)
-    // rather than adding new bookkeeping. Defs: every mapped def plus whatever
-    // finalize itself touched (relationship resolution, orphan archival).
+    // changed counts come from the just-folded run manifest (one row read —
+    // `persistManifest` ran above), which holds the distinct changed/created/
+    // archived records per def. The manifest is subscription-gated, so a def
+    // with no enabled rules still ships count 0 ("changed, count unknown" per
+    // the event doc) — real counts for every def arrive with the Phase 3
+    // session collector. Defs: every mapped def plus whatever finalize itself
+    // touched (relationship resolution, orphan archival).
     try {
       const defCounts: Record<string, number> = {}
       for (const mapping of allMappings) defCounts[mapping.entityDefinitionId] ??= 0
       for (const defId of syncCtx.touchedDefs) defCounts[defId] ??= 0
+      const runManifest = await getRunManifest(this.deps.db, this.deps.run.id)
+      if (runManifest) {
+        const { manifestDefCounts } = await import('../events/handlers/sync-finalize')
+        for (const [defId, count] of Object.entries(manifestDefCounts(runManifest))) {
+          defCounts[defId] = count
+        }
+      }
       if (Object.keys(defCounts).length > 0) {
         // Lazy-import the realtime barrel — same cycle-avoidance as
         // `emitRecordsInvalidated`.

--- a/packages/lib/src/events/handlers/handle-sync-record-rules.test.ts
+++ b/packages/lib/src/events/handlers/handle-sync-record-rules.test.ts
@@ -27,6 +27,9 @@ const h = vi.hoisted(() => ({
     (rules: CachedRecordRule[], ctx: RecordRuleBatchContext) => Promise<void>
   >(async () => {}),
   fetchResourceSnapshots: vi.fn(async () => new Map()),
+  runSyncFinalize: vi.fn<(db: unknown, input: Record<string, unknown>) => Promise<void>>(
+    async () => {}
+  ),
 }))
 
 vi.mock('@auxx/database', () => ({ database: {} }))
@@ -46,6 +49,7 @@ vi.mock('../../record-rules/engine', () => ({ fireRecordRulesBatch: h.fireRecord
 vi.mock('../../record-rules/snapshot-fetcher', () => ({
   fetchResourceSnapshots: h.fetchResourceSnapshots,
 }))
+vi.mock('./sync-finalize', () => ({ runSyncFinalize: h.runSyncFinalize }))
 
 import { handleSyncRecordRules } from './handle-sync-record-rules'
 
@@ -260,6 +264,87 @@ describe('handleSyncRecordRules', () => {
     await handleSyncRecordRules(connectorEvent() as never)
     expect(h.claimRunManifestConsumed).toHaveBeenCalledWith({}, 'run_1')
     expect(h.fireRecordRulesBatch).toHaveBeenCalledTimes(1)
+  })
+
+  // ── Phase 4 finalize integration (plan events/03 §8) ─────────────────────────
+
+  it('runs the finalize pass after rules fire, on the claimed manifest', async () => {
+    const m = manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+    h.getRunManifest.mockResolvedValue(m)
+    h.getCachedRecordRules.mockResolvedValue([rule({ on: 'changed' })])
+    await handleSyncRecordRules(connectorEvent() as never)
+
+    expect(h.runSyncFinalize).toHaveBeenCalledTimes(1)
+    expect(h.runSyncFinalize.mock.calls[0]?.[1]).toMatchObject({
+      organizationId: 'org_1',
+      source: 'connector',
+      ref: 'run_1',
+      manifest: m,
+    })
+    // Claim before rules, rules before finalize.
+    const claimOrder = h.claimRunManifestConsumed.mock.invocationCallOrder[0]!
+    const fireOrder = h.fireRecordRulesBatch.mock.invocationCallOrder[0]!
+    const finalizeOrder = h.runSyncFinalize.mock.invocationCallOrder[0]!
+    expect(claimOrder).toBeLessThan(fireOrder)
+    expect(fireOrder).toBeLessThan(finalizeOrder)
+  })
+
+  // The at-most-once contract covers finalize too: it inserts timeline rows, so a
+  // redelivered event that loses the claim must skip it along with the rules.
+  it('skips finalize on duplicate delivery (claim already taken)', async () => {
+    h.getRunManifest.mockResolvedValue(
+      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+    )
+    h.getCachedRecordRules.mockResolvedValue([rule({ on: 'changed' })])
+    h.claimRunManifestConsumed.mockResolvedValue(false)
+    await handleSyncRecordRules(connectorEvent() as never)
+    expect(h.runSyncFinalize).not.toHaveBeenCalled()
+  })
+
+  it('skips finalize when the manifest is unresolvable', async () => {
+    h.getRunManifest.mockResolvedValue(null)
+    h.getCachedRecordRules.mockResolvedValue([rule()])
+    await handleSyncRecordRules(connectorEvent() as never)
+    expect(h.runSyncFinalize).not.toHaveBeenCalled()
+    expect(h.claimRunManifestConsumed).not.toHaveBeenCalled()
+  })
+
+  // The claim moved ahead of the zero-rules bail: finalize must run exactly once per
+  // run even when every rule was disabled between write and consume.
+  it('still claims and finalizes when no rules are enabled', async () => {
+    h.getRunManifest.mockResolvedValue(
+      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+    )
+    h.getCachedRecordRules.mockResolvedValue([])
+    await handleSyncRecordRules(connectorEvent() as never)
+    expect(h.claimRunManifestConsumed).toHaveBeenCalledTimes(1)
+    expect(h.fireRecordRulesBatch).not.toHaveBeenCalled()
+    expect(h.runSyncFinalize).toHaveBeenCalledTimes(1)
+  })
+
+  it('handler still succeeds when finalize rejects (rules already fired)', async () => {
+    h.getRunManifest.mockResolvedValue(
+      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+    )
+    h.getCachedRecordRules.mockResolvedValue([rule({ on: 'changed' })])
+    h.runSyncFinalize.mockRejectedValueOnce(new Error('finalize boom'))
+    await expect(handleSyncRecordRules(connectorEvent() as never)).resolves.toBeUndefined()
+    expect(h.fireRecordRulesBatch).toHaveBeenCalledTimes(1)
+  })
+
+  it('import source: finalize gets the importRef as its run ref', async () => {
+    h.getCachedRecordRules.mockResolvedValue([rule()])
+    h.getImportManifest.mockResolvedValue(
+      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+    )
+    const evt = {
+      data: {
+        type: 'sync:records:changed',
+        data: { source: 'import', organizationId: 'org_1', importRef: 'job_1' },
+      },
+    }
+    await handleSyncRecordRules(evt as never)
+    expect(h.runSyncFinalize.mock.calls[0]?.[1]).toMatchObject({ source: 'import', ref: 'job_1' })
   })
 
   // F6: a record created this run folds to an entry WITHOUT `o` — a `set` rule

--- a/packages/lib/src/events/handlers/handle-sync-record-rules.ts
+++ b/packages/lib/src/events/handlers/handle-sync-record-rules.ts
@@ -3,7 +3,9 @@
 // it resolves the persisted manifest, transition-matches each captured field write
 // against the org's enabled rules, and fires the engine with `source: 'sync'` — giving
 // record rules visibility into bulk writes the connector sink / import job suppressed
-// via `skipEvents`. Lifecycle (`created`/`deleted`) firings dispatch here too.
+// via `skipEvents`. Lifecycle (`created`/`deleted`) firings dispatch here too. After
+// the rules fire, the Phase 4 sync finalize pass (`./sync-finalize.ts`) runs on the
+// same once-only claim — see that module for the doors it executes.
 //
 // Keep top-level imports to types/logger only; lazy-import everything else (the
 // record-rules ↔ data-connectors ↔ cache boundaries break vi.mock otherwise).
@@ -74,12 +76,11 @@ export const handleSyncRecordRules = async ({ data: event }: { data: AuxxEvent }
       })
     }
 
-    const { getCachedRecordRules } = await import('../../cache')
-    const rules = (await getCachedRecordRules(organizationId)).filter((r) => r.enabled)
-    if (rules.length === 0) return
-
-    // Claim AFTER the cheap bail-outs, BEFORE any firing. At-most-once by design: a
-    // crash mid-fire loses the remainder rather than double-notifying on retry.
+    // Claim AFTER the manifest bail-out, BEFORE any firing. At-most-once by design: a
+    // crash mid-fire loses the remainder rather than double-notifying on retry. The
+    // claim now sits BEFORE the zero-rules check — the Phase 4 finalize pass below
+    // rides the same latch and must run exactly once per run even when every rule was
+    // disabled between write and consume.
     if (!(await claimManifest(data))) {
       logger.info('sync-change manifest already consumed — skipping duplicate delivery', {
         organizationId,
@@ -90,41 +91,60 @@ export const handleSyncRecordRules = async ({ data: event }: { data: AuxxEvent }
       return
     }
 
-    // Index rules per def for the three firing kinds.
-    const fieldRulesByDef = new Map<string, CachedRecordRule[]>()
-    const createdRulesByDef = new Map<string, CachedRecordRule[]>()
-    const deletedRulesByDef = new Map<string, CachedRecordRule[]>()
-    for (const rule of rules) {
-      if (rule.fieldId !== null) {
-        push(fieldRulesByDef, rule.entityDefinitionId, rule)
-      } else if (rule.on === 'created') {
-        push(createdRulesByDef, rule.entityDefinitionId, rule)
-      } else if (rule.on === 'deleted') {
-        push(deletedRulesByDef, rule.entityDefinitionId, rule)
+    const { getCachedRecordRules } = await import('../../cache')
+    const rules = (await getCachedRecordRules(organizationId)).filter((r) => r.enabled)
+    if (rules.length > 0) {
+      // Index rules per def for the three firing kinds.
+      const fieldRulesByDef = new Map<string, CachedRecordRule[]>()
+      const createdRulesByDef = new Map<string, CachedRecordRule[]>()
+      const deletedRulesByDef = new Map<string, CachedRecordRule[]>()
+      for (const rule of rules) {
+        if (rule.fieldId !== null) {
+          push(fieldRulesByDef, rule.entityDefinitionId, rule)
+        } else if (rule.on === 'created') {
+          push(createdRulesByDef, rule.entityDefinitionId, rule)
+        } else if (rule.on === 'deleted') {
+          push(deletedRulesByDef, rule.entityDefinitionId, rule)
+        }
       }
+
+      let fired = 0
+      fired += await fireFieldChanges(organizationId, manifest, fieldRulesByDef)
+      fired += await fireLifecycle(
+        organizationId,
+        manifest.createdRecordIds,
+        createdRulesByDef,
+        false,
+        manifest.createdValues
+      )
+      fired += await fireLifecycle(
+        organizationId,
+        manifest.archivedRecordIds,
+        deletedRulesByDef,
+        true
+      )
+
+      logger.info('sync:records:changed processed', {
+        organizationId,
+        source: data.source,
+        runId: data.runId,
+        fired,
+      })
     }
 
-    let fired = 0
-    fired += await fireFieldChanges(organizationId, manifest, fieldRulesByDef)
-    fired += await fireLifecycle(
-      organizationId,
-      manifest.createdRecordIds,
-      createdRulesByDef,
-      false,
-      manifest.createdValues
-    )
-    fired += await fireLifecycle(
-      organizationId,
-      manifest.archivedRecordIds,
-      deletedRulesByDef,
-      true
-    )
-
-    logger.info('sync:records:changed processed', {
+    // Phase 4 (plan events/03 §8, D-12): the sync finalize pass — activity bump,
+    // collapsed timeline, lane-gated dispatch, tier-2 frames. INSIDE the claimed
+    // branch, AFTER rules fire; `runSyncFinalize` catches its own errors (rules
+    // already fired — a finalize crash must not re-throw into a retry that can
+    // never re-claim).
+    const { runSyncFinalize } = await import('./sync-finalize')
+    const { database } = await import('@auxx/database')
+    await runSyncFinalize(database, {
       organizationId,
       source: data.source,
-      runId: data.runId,
-      fired,
+      ref: (data.source === 'connector' ? data.runId : data.importRef) as string,
+      dataConnectorId: data.dataConnectorId,
+      manifest,
     })
   } catch (error) {
     logger.error('Sync record-rule dispatch failed', {

--- a/packages/lib/src/events/handlers/sync-finalize.test.ts
+++ b/packages/lib/src/events/handlers/sync-finalize.test.ts
@@ -1,0 +1,288 @@
+// packages/lib/src/events/handlers/sync-finalize.test.ts
+// Phase 4 sync finalize (plan events/03 §8, D-12): count-based lane selection,
+// activity touch, collapsed timeline bulk insert, small-lane dispatch, tier-2
+// frames, and the never-throws contract. Boundaries (activity/cache/dispatch/
+// realtime/drizzle) mocked; the pure lane + count helpers run for real.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SyncChangeManifest } from '../../record-rules/sync-manifest-types'
+import { SYNC_SMALL_RUN_THRESHOLD } from '../../resources/crud/door-matrix'
+
+const h = vi.hoisted(() => ({
+  touchEntityActivity: vi.fn<
+    (ids: string[], org: string, at?: Date, tx?: unknown) => Promise<void>
+  >(async () => {}),
+  canonicalizeEntityDefinitionId: vi.fn(async (_org: string, defId: string) =>
+    defId === 'part' ? 'def_cuid_part' : defId
+  ),
+  triggerResourceDispatch: vi.fn<
+    (args: { data: { type: string; data: Record<string, unknown> } }) => Promise<void>
+  >(async () => {}),
+  publishRecordsChanged: vi.fn<
+    (
+      svc: unknown,
+      org: string,
+      args: { entityDefinitionId: string; entries: Array<Record<string, unknown>> }
+    ) => Promise<void>
+  >(async () => {}),
+  getRealtimeService: vi.fn(() => ({ publish: vi.fn() })),
+  insertValues: vi.fn<(rows: Array<Record<string, unknown>>) => Promise<void>>(async () => {}),
+}))
+
+vi.mock('../../entity-instances/activity', () => ({
+  touchEntityActivity: h.touchEntityActivity,
+}))
+vi.mock('../../cache', () => ({
+  canonicalizeEntityDefinitionId: h.canonicalizeEntityDefinitionId,
+}))
+vi.mock('./trigger-resource-dispatch', () => ({
+  triggerResourceDispatch: h.triggerResourceDispatch,
+}))
+vi.mock('../../realtime', () => ({
+  getRealtimeService: h.getRealtimeService,
+  publishRecordsChanged: h.publishRecordsChanged,
+}))
+// The finalize only uses `eq` for the actor lookups, against the shared setup's
+// column-less schema proxy — partial-mock it so undefined columns can't throw.
+vi.mock('drizzle-orm', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  eq: vi.fn(() => ({})),
+}))
+
+import { manifestDefCounts, runSyncFinalize, selectSyncLane } from './sync-finalize'
+
+const ORG = 'org_1'
+
+function manifest(over: Partial<SyncChangeManifest> = {}): SyncChangeManifest {
+  return {
+    version: 1,
+    truncated: false,
+    changes: {},
+    createdRecordIds: [],
+    archivedRecordIds: [],
+    ...over,
+  } as SyncChangeManifest
+}
+
+/** Fake Database with just the surfaces finalize touches. */
+function fakeDb(
+  over: { connectorCreatedById?: string | null; importCreatedById?: string | null } = {}
+) {
+  return {
+    query: {
+      DataConnectorRun: {
+        findFirst: vi.fn(async () => ({ dataConnectorId: 'conn_1' })),
+      },
+      DataConnector: {
+        findFirst: vi.fn(async () => ({ createdById: over.connectorCreatedById ?? 'user_1' })),
+      },
+      ImportJob: {
+        findFirst: vi.fn(async () => ({ createdById: over.importCreatedById ?? null })),
+      },
+    },
+    insert: vi.fn(() => ({ values: h.insertValues })),
+  } as never
+}
+
+function connectorInput(m: SyncChangeManifest) {
+  return {
+    organizationId: ORG,
+    source: 'connector' as const,
+    ref: 'run_1',
+    dataConnectorId: 'conn_1',
+    manifest: m,
+  }
+}
+
+/** All rows across every chunked insert call. */
+function insertedRows(): Array<Record<string, unknown>> {
+  return h.insertValues.mock.calls.flatMap(([rows]) => rows)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('selectSyncLane', () => {
+  it('takes the small lane at or below the threshold', () => {
+    expect(selectSyncLane(manifest(), SYNC_SMALL_RUN_THRESHOLD)).toBe('small')
+    expect(selectSyncLane(manifest(), 1)).toBe('small')
+  })
+
+  it('takes the large lane above the threshold', () => {
+    expect(selectSyncLane(manifest(), SYNC_SMALL_RUN_THRESHOLD + 1)).toBe('large')
+  })
+
+  it('a truncated manifest is large unconditionally — the true count is unknown', () => {
+    expect(selectSyncLane(manifest({ truncated: true }), 1)).toBe('large')
+  })
+})
+
+describe('manifestDefCounts', () => {
+  it('counts distinct records per def across changes, created, and archived', () => {
+    const counts = manifestDefCounts(
+      manifest({
+        changes: { 'def_1:i1': { f: { n: 1 } }, 'def_1:i2': { f: { n: 1 } } } as never,
+        // i2 also created — must not double count.
+        createdRecordIds: ['def_1:i2', 'part:i3'] as never,
+        archivedRecordIds: ['part:i4'] as never,
+      })
+    )
+    expect(counts).toEqual({ def_1: 2, part: 2 })
+  })
+})
+
+describe('runSyncFinalize — small lane', () => {
+  const smallManifest = () =>
+    manifest({
+      changes: {
+        'def_1:i1': { fld_a: { o: 1, n: 2 }, fld_b: { n: 'x' } },
+        'def_1:i2': { fld_a: { o: null, n: 3 } },
+      } as never,
+      createdRecordIds: ['def_1:i3', 'part:i4'] as never,
+      archivedRecordIds: ['def_1:i5'] as never,
+    })
+
+  it('bumps lastActivityAt for changed + created records (not archived)', async () => {
+    await runSyncFinalize(fakeDb(), connectorInput(smallManifest()))
+    expect(h.touchEntityActivity).toHaveBeenCalledTimes(1)
+    const [ids, org] = h.touchEntityActivity.mock.calls[0]!
+    expect(org).toBe(ORG)
+    expect([...ids].sort()).toEqual(['i1', 'i2', 'i3', 'i4'])
+  })
+
+  it('bulk-inserts one collapsed timeline entry per record, attributed to the run actor', async () => {
+    await runSyncFinalize(
+      fakeDb({ connectorCreatedById: 'user_1' }),
+      connectorInput(smallManifest())
+    )
+    const rows = insertedRows()
+    expect(rows).toHaveLength(5)
+    const byId = new Map(rows.map((r) => [r.entityId, r]))
+    expect(byId.get('i3')).toMatchObject({ eventType: 'entity:created', entityType: 'def_1' })
+    // Slug-keyed def canonicalized for the timeline keyspace.
+    expect(byId.get('i4')).toMatchObject({
+      eventType: 'entity:created',
+      entityType: 'def_cuid_part',
+    })
+    expect(byId.get('i1')).toMatchObject({
+      eventType: 'entity:updated',
+      eventData: expect.objectContaining({
+        changedFieldIds: ['fld_a', 'fld_b'],
+        changedFieldCount: 2,
+        syncSource: 'connector',
+        syncRef: 'run_1',
+      }),
+    })
+    expect(byId.get('i5')).toMatchObject({ eventType: 'entity:archived' })
+    for (const row of rows) {
+      expect(row).toMatchObject({ actorType: 'user', actorId: 'user_1', organizationId: ORG })
+    }
+  })
+
+  it('uses the system actor when the run has no attributable user (import)', async () => {
+    await runSyncFinalize(fakeDb({ importCreatedById: null }), {
+      organizationId: ORG,
+      source: 'import',
+      ref: 'job_1',
+      manifest: manifest({ changes: { 'def_1:i1': { f: { n: 1 } } } as never }),
+    })
+    expect(insertedRows()[0]).toMatchObject({ actorType: 'system', actorId: 'system' })
+  })
+
+  it('dispatches workflows/agents per record: created as entity:created, changed as entity:updated', async () => {
+    await runSyncFinalize(fakeDb(), connectorInput(smallManifest()))
+    expect(h.triggerResourceDispatch).toHaveBeenCalledTimes(4)
+    const events = h.triggerResourceDispatch.mock.calls.map(([args]) => args.data)
+    const created = events.filter((e) => e.type === 'entity:created')
+    const updated = events.filter((e) => e.type === 'entity:updated')
+    expect(created.map((e) => e.data.recordId).sort()).toEqual(['def_1:i3', 'def_cuid_part:i4'])
+    expect(updated.map((e) => e.data.recordId).sort()).toEqual(['def_1:i1', 'def_1:i2'])
+    expect(created[0]!.data).toMatchObject({ organizationId: ORG, userId: 'user_1' })
+    // Archived records are not dispatched in v1.
+    expect(events.some((e) => (e.data.recordId as string).endsWith(':i5'))).toBe(false)
+  })
+
+  it('publishes tier-2 records:changed frames grouped per canonical def', async () => {
+    await runSyncFinalize(fakeDb(), connectorInput(smallManifest()))
+    expect(h.publishRecordsChanged).toHaveBeenCalledTimes(2)
+    const byDef = new Map(
+      h.publishRecordsChanged.mock.calls.map(([, , args]) => [
+        args.entityDefinitionId,
+        args.entries,
+      ])
+    )
+    expect(byDef.get('def_1')).toEqual(
+      expect.arrayContaining([
+        { recordId: 'i1', fieldIds: ['fld_a', 'fld_b'] },
+        { recordId: 'i2', fieldIds: ['fld_a'] },
+        { recordId: 'i3' },
+        { recordId: 'i5' },
+      ])
+    )
+    expect(byDef.get('def_cuid_part')).toEqual([{ recordId: 'i4' }])
+  })
+
+  it('does nothing for an empty manifest', async () => {
+    await runSyncFinalize(fakeDb(), connectorInput(manifest()))
+    expect(h.touchEntityActivity).not.toHaveBeenCalled()
+    expect(h.insertValues).not.toHaveBeenCalled()
+    expect(h.triggerResourceDispatch).not.toHaveBeenCalled()
+    expect(h.publishRecordsChanged).not.toHaveBeenCalled()
+  })
+})
+
+describe('runSyncFinalize — large lane', () => {
+  const largeManifest = () => {
+    const changes: Record<string, Record<string, { n: unknown }>> = {}
+    for (let i = 0; i < SYNC_SMALL_RUN_THRESHOLD + 1; i++) {
+      changes[`def_1:r${i}`] = { fld_a: { n: i } }
+    }
+    return manifest({ changes: changes as never })
+  }
+
+  it('withholds workflow dispatch (D-3) but still touches activity, timeline, and frames', async () => {
+    await runSyncFinalize(fakeDb(), connectorInput(largeManifest()))
+    expect(h.triggerResourceDispatch).not.toHaveBeenCalled()
+    expect(h.touchEntityActivity).toHaveBeenCalled()
+    expect(insertedRows()).toHaveLength(SYNC_SMALL_RUN_THRESHOLD + 1)
+    expect(h.publishRecordsChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it('a truncated manifest takes the large lane even at a tiny observed count', async () => {
+    await runSyncFinalize(
+      fakeDb(),
+      connectorInput(
+        manifest({ truncated: true, changes: { 'def_1:i1': { f: { n: 1 } } } as never })
+      )
+    )
+    expect(h.triggerResourceDispatch).not.toHaveBeenCalled()
+    expect(h.publishRecordsChanged).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('runSyncFinalize — failure isolation', () => {
+  it('a failing door never rejects, and later doors still run', async () => {
+    h.insertValues.mockRejectedValueOnce(new Error('insert boom'))
+    await expect(
+      runSyncFinalize(
+        fakeDb(),
+        connectorInput(manifest({ changes: { 'def_1:i1': { f: { n: 1 } } } as never }))
+      )
+    ).resolves.toBeUndefined()
+    // Timeline failed, but dispatch and realtime still happened.
+    expect(h.triggerResourceDispatch).toHaveBeenCalledTimes(1)
+    expect(h.publishRecordsChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it('an activity failure never rejects', async () => {
+    h.touchEntityActivity.mockRejectedValueOnce(new Error('touch boom'))
+    await expect(
+      runSyncFinalize(
+        fakeDb(),
+        connectorInput(manifest({ changes: { 'def_1:i1': { f: { n: 1 } } } as never }))
+      )
+    ).resolves.toBeUndefined()
+    expect(h.publishRecordsChanged).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/lib/src/events/handlers/sync-finalize.ts
+++ b/packages/lib/src/events/handlers/sync-finalize.ts
@@ -1,0 +1,458 @@
+// packages/lib/src/events/handlers/sync-finalize.ts
+//
+// Phase 4 v1 of plans/events/03-write-context-and-batch-lane-plan.md: the sync
+// finalize pass with COUNT-based lane selection (D-12). Invoked by
+// `handle-sync-record-rules.ts` INSIDE its claimed branch, after rules fire —
+// the manifest claim (`claimManifest`) is the at-most-once latch for this pass
+// too, so a redelivered `sync:records:changed` that loses the claim skips both
+// rules AND finalize. No new latch, no schema column.
+//
+// Doors executed here (per the door matrix in `resources/crud/door-matrix.ts`):
+//   - `lastActivityAt` batch bump, both lanes (D-1)
+//   - collapsed per-record timeline entries, both lanes (D-4 v1)
+//   - per-record workflow/agent dispatch, SMALL lane only (D-2, fixes B-3);
+//     the large lane withholds dispatch pending the Phase 6 guard (D-3)
+//   - tier-2 `records:changed` delta frames, both lanes (plan §7b)
+//
+// v1 scope note: the changed-set is what the SUBSCRIPTION-GATED manifest
+// captured (`sync-manifest-collector.ts` only records fields/lifecycles some
+// enabled rule watches). Until the Phase 3 session collector captures every
+// write, finalize fidelity is bounded by rule subscriptions — an org with no
+// enabled rules produces no manifest and no finalize. Accepted for v1.
+//
+// Keep top-level imports to types/logger/pure constants only; lazy-import
+// everything else (the events ↔ data-connectors ↔ cache boundaries break
+// vi.mock otherwise — same rule as the two manifest consumers next door).
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { parseRecordId, type RecordId } from '@auxx/types/resource'
+import type { SyncChangeManifest } from '../../record-rules/sync-manifest-types'
+import { SYNC_SMALL_RUN_THRESHOLD } from '../../resources/crud/door-matrix'
+import { EntityInstanceEventType, TimelineActorType } from '../../timeline/event-types'
+
+const logger = createScopedLogger('sync-finalize')
+
+/** One batched UPDATE per this many ids for the activity touch. */
+const ACTIVITY_CHUNK_SIZE = 1000
+/** One bulk INSERT per this many timeline rows. */
+const TIMELINE_INSERT_CHUNK_SIZE = 500
+
+export type SyncFinalizeLane = 'small' | 'large'
+
+export interface SyncFinalizeInput {
+  organizationId: string
+  source: 'connector' | 'import'
+  /** Run identity: DataConnectorRun id (connector) or ImportJob id (import). */
+  ref: string
+  /** Carried by the connector pointer event — saves a run-row hop for actor resolution. */
+  dataConnectorId?: string
+  manifest: SyncChangeManifest
+}
+
+/** The manifest's three record sets, deduped, with the created/changed overlap resolved. */
+interface ChangedSets {
+  /** Records with captured field changes that were NOT created this run. */
+  updatedIds: RecordId[]
+  createdIds: RecordId[]
+  archivedIds: RecordId[]
+  /** Distinct records across all three sets. */
+  total: number
+}
+
+function collectChangedSets(manifest: SyncChangeManifest): ChangedSets {
+  const createdSet = new Set<RecordId>(manifest.createdRecordIds)
+  const archivedIds = [...new Set<RecordId>(manifest.archivedRecordIds)]
+  // A record created this run also appears in `changes` (creates capture `{n}`
+  // entries) — it collapses to ONE "created" entry, never created + updated.
+  const updatedIds = (Object.keys(manifest.changes) as RecordId[]).filter(
+    (rid) => !createdSet.has(rid)
+  )
+  const all = new Set<RecordId>([...updatedIds, ...createdSet, ...archivedIds])
+  return { updatedIds, createdIds: [...createdSet], archivedIds, total: all.size }
+}
+
+/**
+ * Lane selection (D-12): decided at finalize from the OBSERVED changed-set
+ * count, never declared by the writer. A truncated manifest means the true
+ * count is unknown-but-large, so it takes the large lane unconditionally.
+ */
+export function selectSyncLane(
+  manifest: SyncChangeManifest,
+  changedCount: number
+): SyncFinalizeLane {
+  if (manifest.truncated) return 'large'
+  return changedCount <= SYNC_SMALL_RUN_THRESHOLD ? 'small' : 'large'
+}
+
+/**
+ * Per-def distinct changed-record counts from a manifest — the real numbers for
+ * the `run:completed` frame's `defCounts` (the publisher canonicalizes def
+ * keys). Def ids come from the RecordId prefix, so they are in whatever
+ * keyspace the producer wrote (slug for imports, CUID for connectors).
+ */
+export function manifestDefCounts(manifest: SyncChangeManifest): Record<string, number> {
+  const byDef = new Map<string, Set<string>>()
+  const add = (rid: RecordId) => {
+    const { entityDefinitionId, entityInstanceId } = parseRecordId(rid)
+    let set = byDef.get(entityDefinitionId)
+    if (!set) byDef.set(entityDefinitionId, (set = new Set()))
+    set.add(entityInstanceId)
+  }
+  for (const rid of Object.keys(manifest.changes) as RecordId[]) add(rid)
+  for (const rid of manifest.createdRecordIds) add(rid)
+  for (const rid of manifest.archivedRecordIds) add(rid)
+  const counts: Record<string, number> = {}
+  for (const [defId, set] of byDef) counts[defId] = set.size
+  return counts
+}
+
+/**
+ * The sync finalize pass. NEVER throws — every door is individually guarded and
+ * logged. The caller (`handle-sync-record-rules`) has already fired rules off
+ * the claimed manifest; a finalize crash re-thrown into a BullMQ retry could
+ * never re-claim, so failing loudly here would only lose the log context.
+ */
+export async function runSyncFinalize(db: Database, input: SyncFinalizeInput): Promise<void> {
+  const { organizationId, source, ref, manifest } = input
+  try {
+    const sets = collectChangedSets(manifest)
+    if (sets.total === 0) return
+
+    const lane = selectSyncLane(manifest, sets.total)
+    if (manifest.truncated) {
+      logger.warn('sync finalize: manifest truncated — forcing large lane', {
+        organizationId,
+        source,
+        ref,
+        changed: sets.total,
+      })
+    }
+    logger.info('sync finalize', { organizationId, source, ref, lane, changed: sets.total })
+
+    // Actor: the same identity the run's writes carry today — the connector's
+    // `createdById` / the import job's `createdById` (the crud handlers were
+    // built with exactly this userId, falling back to 'system').
+    const actorUserId = await resolveRunActorUserId(db, input)
+
+    // Canonical def id per record — memoized per def. Import manifests carry
+    // slug-keyed RecordIds (`ImportMapping.entityDefinitionId` is slug-keyed),
+    // while timeline readers and realtime rooms use the org's EntityDefinition
+    // CUID; canonicalizing here is the #1784 lesson applied to this producer.
+    const canonicalDefId = await buildDefCanonicalizer(organizationId)
+
+    // D-1: `lastActivityAt` bump for changed + created records, one batched
+    // monotonic UPDATE per chunk. Archived records are excluded — archival is
+    // not activity. No `updatedAt` pass is needed here: the D-7 write
+    // chokepoint already stamped `updatedAt` for every real change at write
+    // time (bookkeeping like this touch deliberately does not stamp it).
+    await touchActivityDoor(db, organizationId, sets, { source, ref })
+
+    // D-4 v1: one collapsed timeline entry per record per run, both lanes.
+    // NOTE: small-lane per-field fidelity (matrix cell [R] — per-record
+    // `entity:field:updated` replay) is a later upgrade; v1 ships the
+    // collapsed shape for BOTH lanes.
+    await timelineDoor(db, organizationId, manifest, sets, {
+      source,
+      ref,
+      actorUserId,
+      canonicalDefId,
+    })
+
+    // D-2: workflows/agents fire per-record on a SMALL run (incremental sync
+    // is new activity — fixes B-3). The large lane withholds dispatch pending
+    // the Phase 6 guarded dispatcher (D-3: tally + thresholded hold), and
+    // deliberately computes nothing expensive here.
+    if (lane === 'small') {
+      await dispatchDoor(organizationId, sets, { actorUserId, canonicalDefId })
+    } else {
+      logger.info('sync finalize: workflow dispatch withheld on large lane (D-3)', {
+        organizationId,
+        source,
+        ref,
+        changed: sets.total,
+        note: 'pending the Phase 6 guarded dispatcher',
+      })
+    }
+
+    // §7b tier-2 delta frames, both lanes. The existing coarse
+    // `records:invalidated` publishes at the producers stay untouched.
+    await realtimeDoor(organizationId, manifest, sets, { canonicalDefId })
+  } catch (error) {
+    logger.error('sync finalize failed', {
+      organizationId,
+      source,
+      ref,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * Resolve the run's actor user id: connector → `DataConnector.createdById`
+ * (via the run row when the event didn't carry the connector id), import →
+ * `ImportJob.createdById`. Null means "no attributable user" → system actor.
+ */
+async function resolveRunActorUserId(
+  db: Database,
+  input: SyncFinalizeInput
+): Promise<string | null> {
+  try {
+    const { schema } = await import('@auxx/database')
+    const { eq } = await import('drizzle-orm')
+    if (input.source === 'connector') {
+      let connectorId = input.dataConnectorId
+      if (!connectorId) {
+        const run = await db.query.DataConnectorRun.findFirst({
+          where: eq(schema.DataConnectorRun.id, input.ref),
+          columns: { dataConnectorId: true },
+        })
+        connectorId = run?.dataConnectorId ?? undefined
+      }
+      if (!connectorId) return null
+      const connector = await db.query.DataConnector.findFirst({
+        where: eq(schema.DataConnector.id, connectorId),
+        columns: { createdById: true },
+      })
+      return connector?.createdById ?? null
+    }
+    const job = await db.query.ImportJob.findFirst({
+      where: eq(schema.ImportJob.id, input.ref),
+      columns: { createdById: true },
+    })
+    return job?.createdById ?? null
+  } catch (error) {
+    logger.warn('sync finalize: actor resolution failed — using system actor', {
+      source: input.source,
+      ref: input.ref,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}
+
+/** Memoizing canonicalizer for the RecordId def prefix (slug or CUID → org CUID). */
+async function buildDefCanonicalizer(
+  organizationId: string
+): Promise<(defId: string) => Promise<string>> {
+  const memo = new Map<string, Promise<string>>()
+  const { canonicalizeEntityDefinitionId } = await import('../../cache')
+  return (defId: string) => {
+    let pending = memo.get(defId)
+    if (!pending) {
+      // Fall back to the raw id on a cache hiccup — degraded keyspace beats a throw.
+      pending = canonicalizeEntityDefinitionId(organizationId, defId).catch(() => defId)
+      memo.set(defId, pending)
+    }
+    return pending
+  }
+}
+
+/** D-1: batched, monotonic `lastActivityAt` bump — reuses `touchEntityActivity`. */
+async function touchActivityDoor(
+  db: Database,
+  organizationId: string,
+  sets: ChangedSets,
+  ctx: { source: string; ref: string }
+): Promise<void> {
+  try {
+    const { touchEntityActivity } = await import('../../entity-instances/activity')
+    const instanceIds = [...sets.updatedIds, ...sets.createdIds].map(
+      (rid) => parseRecordId(rid).entityInstanceId
+    )
+    const at = new Date()
+    for (let i = 0; i < instanceIds.length; i += ACTIVITY_CHUNK_SIZE) {
+      await touchEntityActivity(
+        instanceIds.slice(i, i + ACTIVITY_CHUNK_SIZE),
+        organizationId,
+        at,
+        db
+      )
+    }
+  } catch (error) {
+    logger.error('sync finalize: activity touch failed', {
+      organizationId,
+      ...ctx,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * D-4 v1: bulk-insert collapsed per-record timeline entries. Rows match the
+ * storage shape `@auxx/services/timeline` `createTimelineEvent` writes (the
+ * single-entry helper is one INSERT + `.returning()` per row — looping it for
+ * up to 15k manifest records is exactly the fan-out the batch lane exists to
+ * avoid, so this is a chunked direct insert instead). No non-obvious
+ * denormalizations exist on the table: `entityType`/`entityId` come from the
+ * RecordId, everything else is literal columns.
+ */
+async function timelineDoor(
+  db: Database,
+  organizationId: string,
+  manifest: SyncChangeManifest,
+  sets: ChangedSets,
+  ctx: {
+    source: string
+    ref: string
+    actorUserId: string | null
+    canonicalDefId: (defId: string) => Promise<string>
+  }
+): Promise<void> {
+  try {
+    const { schema } = await import('@auxx/database')
+    const now = new Date()
+    const actorType = ctx.actorUserId ? TimelineActorType.USER : TimelineActorType.SYSTEM
+    const actorId = ctx.actorUserId ?? 'system'
+    const syncMeta = { origin: 'sync', syncSource: ctx.source, syncRef: ctx.ref }
+
+    type Row = typeof schema.TimelineEvent.$inferInsert
+    const rows: Row[] = []
+    const baseRow = async (rid: RecordId, eventType: string, extra: Record<string, unknown>) => {
+      const { entityDefinitionId, entityInstanceId } = parseRecordId(rid)
+      const canonical = await ctx.canonicalDefId(entityDefinitionId)
+      rows.push({
+        eventType,
+        startedAt: now,
+        entityType: canonical,
+        entityId: entityInstanceId,
+        actorType,
+        actorId,
+        eventData: { entityDefinitionId: canonical, ...syncMeta, ...extra },
+        organizationId,
+        updatedAt: now,
+      })
+    }
+
+    for (const rid of sets.createdIds) {
+      await baseRow(rid, EntityInstanceEventType.CREATED, {})
+    }
+    for (const rid of sets.updatedIds) {
+      const changedFieldIds = Object.keys(manifest.changes[rid] ?? {})
+      await baseRow(rid, EntityInstanceEventType.UPDATED, {
+        changedFieldIds,
+        changedFieldCount: changedFieldIds.length,
+      })
+    }
+    for (const rid of sets.archivedIds) {
+      await baseRow(rid, EntityInstanceEventType.ARCHIVED, {})
+    }
+
+    for (let i = 0; i < rows.length; i += TIMELINE_INSERT_CHUNK_SIZE) {
+      await db.insert(schema.TimelineEvent).values(rows.slice(i, i + TIMELINE_INSERT_CHUNK_SIZE))
+    }
+  } catch (error) {
+    logger.error('sync finalize: timeline insert failed', {
+      organizationId,
+      source: ctx.source,
+      ref: ctx.ref,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * D-2 (small lane): per-record workflow + agent dispatch through the existing
+ * combined CRUD door (`triggerResourceDispatch` memoizes the record fetch and
+ * runs both dispatchers — passing a synthesized event and letting it fetch
+ * `resourceData` itself is the supported shape). `entity:created` for created
+ * records, `entity:updated` for changed ones; archived records are not
+ * dispatched in v1 (`entity:deleted`-family sync firing is a later decision).
+ * The dispatcher canonicalizes def ids itself (`resolveResourceTriggerMatch`),
+ * but we hand it the canonical id so the synthesized payload matches what
+ * modern-shape events carry.
+ */
+async function dispatchDoor(
+  organizationId: string,
+  sets: ChangedSets,
+  ctx: { actorUserId: string | null; canonicalDefId: (defId: string) => Promise<string> }
+): Promise<void> {
+  try {
+    const { triggerResourceDispatch } = await import('./trigger-resource-dispatch')
+    const { toRecordId } = await import('@auxx/types/resource')
+    const userId = ctx.actorUserId ?? 'system'
+
+    const dispatchOne = async (rid: RecordId, type: 'entity:created' | 'entity:updated') => {
+      const { entityDefinitionId, entityInstanceId } = parseRecordId(rid)
+      const canonical = await ctx.canonicalDefId(entityDefinitionId)
+      const event = {
+        type,
+        data: {
+          recordId: toRecordId(canonical, entityInstanceId),
+          entityDefinitionId: canonical,
+          // The dispatchers never read the slug; carried for shape parity only.
+          entitySlug: entityDefinitionId,
+          organizationId,
+          userId,
+          eventData: {},
+        },
+      }
+      try {
+        await triggerResourceDispatch({ data: event as never })
+      } catch (error) {
+        logger.error('sync finalize: per-record dispatch failed', {
+          organizationId,
+          recordId: rid,
+          type,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+
+    for (const rid of sets.createdIds) await dispatchOne(rid, 'entity:created')
+    for (const rid of sets.updatedIds) await dispatchOne(rid, 'entity:updated')
+  } catch (error) {
+    logger.error('sync finalize: dispatch door failed', {
+      organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * §7b tier-2 `records:changed` frames, grouped per canonical def. Changed
+ * records carry their manifest field keys as `fieldIds`; created and archived
+ * records ship without `fieldIds` ("any field may have changed") — a client
+ * refetch of the id surfaces both a new row and a vanished one. Ids only,
+ * never values (D-18); `publishRecordsChanged` chunks and canonicalizes the
+ * room key itself.
+ */
+async function realtimeDoor(
+  organizationId: string,
+  manifest: SyncChangeManifest,
+  sets: ChangedSets,
+  ctx: { canonicalDefId: (defId: string) => Promise<string> }
+): Promise<void> {
+  try {
+    const { getRealtimeService, publishRecordsChanged } = await import('../../realtime')
+    const service = getRealtimeService()
+
+    const byDef = new Map<string, Array<{ recordId: string; fieldIds?: string[] }>>()
+    const add = async (rid: RecordId, fieldIds?: string[]) => {
+      const { entityDefinitionId, entityInstanceId } = parseRecordId(rid)
+      const canonical = await ctx.canonicalDefId(entityDefinitionId)
+      let entries = byDef.get(canonical)
+      if (!entries) byDef.set(canonical, (entries = []))
+      entries.push(
+        fieldIds && fieldIds.length > 0
+          ? { recordId: entityInstanceId, fieldIds }
+          : { recordId: entityInstanceId }
+      )
+    }
+
+    for (const rid of sets.updatedIds) {
+      await add(rid, Object.keys(manifest.changes[rid] ?? {}))
+    }
+    for (const rid of sets.createdIds) await add(rid)
+    for (const rid of sets.archivedIds) await add(rid)
+
+    for (const [entityDefinitionId, entries] of byDef) {
+      await publishRecordsChanged(service, organizationId, { entityDefinitionId, entries })
+    }
+  } catch (error) {
+    logger.error('sync finalize: records:changed publish failed', {
+      organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}


### PR DESCRIPTION
## Summary

Phase 4 v1 of `plans/events/03-write-context-and-batch-lane-plan.md`: the **sync finalize pass** — the first machinery that actually executes the door matrix's sync columns instead of leaving sync writes silent.

- **At-most-once via the existing claim**: `runSyncFinalize` is invoked inside `handle-sync-record-rules`' claimed branch, after rules fire — no new latch, no schema change. Redelivery: claim lost → both skip. The claim moved ahead of the zero-rules bail so finalize still runs when every rule was disabled between write and consume. Finalize never throws into the handler; every door is individually guarded and logged.
- **Count-based lane (D-12)**: distinct records across changes ∪ created ∪ archived (create/change overlap collapsed), compared against `SYNC_SMALL_RUN_THRESHOLD` imported from the door matrix. `truncated` manifests force the large lane with a warning.
- **`lastActivityAt` (D-1, both lanes)**: reuses `touchEntityActivity` (monotonic, set-based, no `updatedAt` side effects), chunked; archived records excluded — archival is not activity. No `updatedAt` pass exists because the D-7 write-time chokepoint already stamped real changes.
- **Timeline (D-4, both lanes)**: chunked bulk INSERT of collapsed entries (`created` / `updated N fields` with changed fieldIds / `archived`), attributed to the run's real actor (connector `createdById` / import `createdById` — the same identity the run's writes carried). Def ids canonicalized (the #1784 keyspace lesson) so import manifests' slug-keyed RecordIds land where timeline readers query. Small-lane per-field fidelity is marked as the later [R] upgrade.
- **Workflows (D-2 — closes B-3)**: small lane dispatches per record through the existing `triggerResourceDispatch` door, so `RECORD_UPDATED`/`RECORD_CREATED` workflow triggers finally fire for incremental connector syncs and small imports. Large lane: one log line that dispatch is withheld pending the Phase 6 guard (D-3) — nothing expensive computed.
- **Realtime**: ids-only `records:changed` tier-2 frames for both lanes, grouped per canonical def; created/archived entries id-only, changed entries carry fieldIds.
- **`run:completed` counts**: the connector now fills real per-def changed counts from the folded manifest (one row read) instead of zeros.

**Documented v1 bound**: finalize fidelity is limited to what the subscription-gated manifest captured — full capture arrives with the session collector.

## Test plan

- New `sync-finalize.test.ts` (14 tests): lane boundaries incl. truncated, per-door small-lane behavior (activity/timeline/dispatch/frames, slug→CUID canonicalization, actor attribution), large lane (101 records → no dispatch, everything else fires), door-failure isolation, never-rejects.
- `handle-sync-record-rules.test.ts` +6: invocation order after claim+rules, skip on lost claim / unresolvable manifest, claim+finalize with zero rules, handler success on finalize rejection, import ref threading.
- `src/events` + `src/record-rules` + connector/realtime suites: 23 files / 247 tests pass. Combined with sibling PRs: 1150 passed / 10 skipped. Scoped tsc: zero errors in touched files.