### PR TITLE
chore(events): d-7 archive stamps, stale doc fixes, exported seedSession

### DIFF
--- a/docs/duplicate-detection-architecture-guide.md
+++ b/docs/duplicate-detection-architecture-guide.md
@@ -583,11 +583,13 @@ Surname rarity is memoized per definition scan, keyed on the *scanned* record's 
 
 ### 7.3 The watermark stamp
 
-⚠️ **`stampWatermark` MUST be raw SQL touching exactly one column.** `EntityInstance.updatedAt`
-carries `$onUpdate`, so a Drizzle `.update().set({ lastDuplicateScanAt })` bumps `updatedAt` **in the
-same statement**, instantly re-dirtying the record against its own fresh watermark — and the scanner
-re-scans it forever. Pinned by integration test. (Note this is the *same* mechanism §9 relies on for
-restore self-healing, with the opposite consequence.)
+`stampWatermark` is raw SQL touching exactly one column. Historically this was load-bearing:
+`EntityInstance.updatedAt` carried `$onUpdate`, so a Drizzle `.update().set({ lastDuplicateScanAt })`
+bumped `updatedAt` **in the same statement**, instantly re-dirtying the record against its own fresh
+watermark — and the scanner re-scanned it forever. Since D-7 removed `$onUpdate` (content changes now
+stamp `updatedAt` explicitly), bookkeeping writes like the watermark stamp no longer move `updatedAt`
+and cannot re-dirty the record; the raw single-column statement remains fine and is still pinned by
+integration test, but it is no longer the only safe shape.
 
 ⚠️ **Stamp the OBSERVED watermark, not `now()`.** The dirty select returns
 `GREATEST(ei."updatedAt", max(fv."updatedAt"))` and that value is written back, bound as **text** so
@@ -720,9 +722,10 @@ argument rests on a path users cannot reach: `api.record.restore` has exactly on
 whole app, and it is the tag list. Meanwhile the cost — `open` rows accumulating forever behind a
 join that exists purely to hide them — is real.
 
-**No restore hook is needed.** `EntityInstance.updatedAt` carries `$onUpdate`, so restoring
-re-dirties the record against `lastDuplicateScanAt` and the next watermark scan recreates any pair
-that still qualifies. Self-healing.
+**No restore hook is needed.** Archive/restore is a content change, so the restore write stamps
+`updatedAt` explicitly (D-7 — `$onUpdate` is gone, content stamps are explicit), which re-dirties the
+record against `lastDuplicateScanAt` and the next watermark scan recreates any pair that still
+qualifies. Self-healing.
 
 ### 9.4 Merge
 
@@ -961,9 +964,10 @@ Two durable guards came out of it:
    duplicate twice.
 2. **Deletion is how an `open` pair goes away.** `dismissed` and `merged` are the only persisted
    terminal states. Never invent a `closed` status, and never stamp a synthetic `dismissed`.
-3. **The watermark stamp must be raw SQL touching exactly one column**, and must write the OBSERVED
-   watermark rather than `now()`. `$onUpdate` on `EntityInstance.updatedAt` otherwise loops the
-   scanner forever.
+3. **The watermark stamp must write the OBSERVED watermark rather than `now()`.** It stays a raw
+   single-column SQL statement; since D-7 removed `$onUpdate` from `EntityInstance.updatedAt`
+   (content stamps are explicit), a bookkeeping write can no longer re-dirty the record against its
+   own fresh watermark, so the raw-SQL shape is hygiene rather than loop prevention.
 4. **The `sync:records:changed` consumer must never claim the manifest** — the claim is the
    record-rules consumer's once-only latch and a second claimant starves it. Rely on the per-run
    jobId plus idempotent upserts.

--- a/docs/skip-events-history.md
+++ b/docs/skip-events-history.md
@@ -146,6 +146,16 @@ This half matters as much as the first, and is routinely forgotten:
 - **`managedByConnectorId`** is not a CRUD concern, the connector sink stamps it
   itself after the write (`sinks/entity-sink.ts:562-600`).
 
+> **Correction (2026-08-21, D-7 / #1805):** the `EntityInstance.updatedAt` bullet above
+> describes the pre-D-7 world. `$onUpdate` has been **removed** from
+> `EntityInstance.updatedAt`; nothing auto-bumps it anymore. Content changes (including
+> archive/restore and handler-mediated field writes) now stamp `updatedAt` explicitly,
+> while bookkeeping writes (watermark stamps, `lastSuggestionScanAt`,
+> activity/interaction touches) deliberately do not. Raw writers that bypass the handler
+> still only move `FieldValue.updatedAt`, so the dedup scanner's
+> `GREATEST(ei."updatedAt", max(fv."updatedAt"))` arm remains load-bearing — see the
+> schema comment at `entity-instance.ts` (`lastDuplicateScanAt`).
+
 ---
 
 ## 4. The contract

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -132,7 +132,9 @@ async function applyMappingEditSafety(
         if (it.entityInstanceId) {
           await tx
             .update(schema.EntityInstance)
-            .set({ archivedAt: now })
+            // D-7 explicit content stamp: archive is a content change and
+            // `updatedAt` no longer auto-bumps (`$onUpdate` removed).
+            .set({ archivedAt: now, updatedAt: now })
             .where(eq(schema.EntityInstance.id, it.entityInstanceId))
         }
       }
@@ -1881,9 +1883,12 @@ export async function removeMapping(
         // Archive the owned instances bound through this mapping before the cascade
         // strips their `DataConnectorItem` rows (which would set-null the back-link).
         // Single bulk update over a subselect of the bound instance ids.
+        const now = new Date()
         await tx
           .update(schema.EntityInstance)
-          .set({ archivedAt: new Date() })
+          // D-7 explicit content stamp: archive is a content change and
+          // `updatedAt` no longer auto-bumps (`$onUpdate` removed).
+          .set({ archivedAt: now, updatedAt: now })
           .where(
             inArray(
               schema.EntityInstance.id,

--- a/packages/lib/src/jobs/dedup/duplicate-scan-job.ts
+++ b/packages/lib/src/jobs/dedup/duplicate-scan-job.ts
@@ -889,10 +889,12 @@ function toDirtyRecords(result: unknown): DirtyRecord[] {
 /**
  * Stamp `lastDuplicateScanAt` with the watermark this scan OBSERVED.
  *
- * ⚠️ Raw SQL on purpose. `EntityInstance.updatedAt` carries `$onUpdate`, so a
- * Drizzle `.update()` would bump `updatedAt` in the same statement — instantly
- * re-dirtying the record against its own fresh watermark and looping the scanner
- * forever. This statement touches exactly one column.
+ * Raw single-column SQL. Historically this was load-bearing: `updatedAt` carried
+ * `$onUpdate`, so a Drizzle `.update()` would bump it in the same statement and
+ * re-dirty the record against its own fresh watermark, looping the scanner. D-7
+ * removed `$onUpdate` (content stamps are explicit now), so a Drizzle update
+ * would no longer loop — but touching exactly one column remains the right shape
+ * for a bookkeeping write.
  */
 async function stampWatermark(organizationId: string, record: DirtyRecord): Promise<void> {
   await database.execute(sql`

--- a/packages/lib/src/resources/index.ts
+++ b/packages/lib/src/resources/index.ts
@@ -26,14 +26,20 @@ export type {
   UpdateRecordOptions,
 } from './crud'
 // CRUD service and handlers
+// Write-origin sessions (plan 03 §4) — exposed here so packages/seed can build
+// seed sessions via the constructors instead of inline literals.
 export {
   fromDbResult,
   hasChanges,
+  interactiveSession,
   isNotFound,
   parseTags,
+  seedSession,
   setCustomFields,
   trackChanges,
   UnifiedCrudHandler,
+  type WriteOrigin,
+  type WriteSession,
 } from './crud'
 // The per-row record write gate (plan v3/03 §5.3)
 export type { StampedRow } from './crud/record-row-access'

--- a/packages/lib/src/resources/merge/merge-service.ts
+++ b/packages/lib/src/resources/merge/merge-service.ts
@@ -648,9 +648,12 @@ export class EntityMergeService {
 
   /** Archive source instances after merge */
   private async archiveSourceInstances(tx: Transaction, sourceIds: string[]): Promise<void> {
+    const now = new Date()
     await tx
       .update(schema.EntityInstance)
-      .set({ archivedAt: new Date() })
+      // D-7 explicit content stamp: archive is a content change and
+      // `updatedAt` no longer auto-bumps (`$onUpdate` removed).
+      .set({ archivedAt: now, updatedAt: now })
       .where(
         and(
           inArray(schema.EntityInstance.id, sourceIds),

--- a/packages/seed/src/domains/crm.domain.ts
+++ b/packages/seed/src/domains/crm.domain.ts
@@ -580,14 +580,14 @@ export class CrmDomain {
    */
   async insertDirectly(db: any): Promise<void> {
     const { schema } = await import('@auxx/database')
-    const { UnifiedCrudHandler } = await import('@auxx/lib/resources')
+    const { UnifiedCrudHandler, seedSession } = await import('@auxx/lib/resources')
 
     // Seed for each target organization
     for (const org of this.organizations) {
       // Seed session: silent lane — same suppression the per-call
       // `skipEvents: true` used to provide, declared once at construction.
       const handler = new UnifiedCrudHandler(org.id, org.ownerId, db, undefined, {
-        session: { origin: { kind: 'seed', reason: 'demo CRM seed data' }, depth: 0 },
+        session: seedSession('demo CRM seed data'),
       })
 
       // Companies first (contacts reference company domains via email).

--- a/packages/seed/src/domains/organization.domain.ts
+++ b/packages/seed/src/domains/organization.domain.ts
@@ -63,7 +63,7 @@ export class OrganizationDomain {
    */
   async insertDirectly(db: any): Promise<void> {
     const { schema } = await import('@auxx/database')
-    const { UnifiedCrudHandler } = await import('@auxx/lib/resources')
+    const { UnifiedCrudHandler, seedSession } = await import('@auxx/lib/resources')
     const users = [...this.context.auth.testUsers, ...this.context.auth.randomUsers]
 
     if (users.length === 0) {
@@ -73,7 +73,15 @@ export class OrganizationDomain {
     // Seed for each target organization
     for (const org of this.organizations) {
       // Generate and insert Signatures via UnifiedCrudHandler
-      await this.seedSignatures(db, schema, org.id, org.ownerId, users, UnifiedCrudHandler)
+      await this.seedSignatures(
+        db,
+        schema,
+        org.id,
+        org.ownerId,
+        users,
+        UnifiedCrudHandler,
+        seedSession
+      )
 
       // Generate and insert Snippet Folders first, then Snippets (so snippets can reference folders)
       const folderIds = await this.seedSnippetFolders(db, schema, org.id, users)
@@ -89,6 +97,7 @@ export class OrganizationDomain {
    * @param ownerId - Organization owner user ID
    * @param users - Array of user records
    * @param UnifiedCrudHandler - The handler class
+   * @param seedSession - The seed-session constructor from `@auxx/lib/resources`
    */
   private async seedSignatures(
     db: any,
@@ -96,17 +105,15 @@ export class OrganizationDomain {
     organizationId: string,
     ownerId: string,
     users: Array<{ id: string; email: string }>,
-    UnifiedCrudHandler: any
+    UnifiedCrudHandler: any,
+    seedSession: (reason: string) => unknown
   ): Promise<void> {
     console.log('✍️  Generating signatures via UnifiedCrudHandler...')
 
     // Seed session: silent lane — same suppression the per-call
     // `skipEvents: true` used to provide, declared once at construction.
     const handler = new UnifiedCrudHandler(organizationId, ownerId, db, undefined, {
-      session: {
-        origin: { kind: 'seed', reason: 'org bootstrap - no live users to notify' },
-        depth: 0,
-      },
+      session: seedSession('org bootstrap - no live users to notify'),
     })
 
     // Skip if signatures already exist (additive mode)

--- a/packages/seed/src/domains/ticket.domain.ts
+++ b/packages/seed/src/domains/ticket.domain.ts
@@ -83,12 +83,12 @@ export class TicketDomain {
    */
   async insertDirectly(db: any): Promise<void> {
     const { schema } = await import('@auxx/database')
-    const { UnifiedCrudHandler } = await import('@auxx/lib/resources')
+    const { UnifiedCrudHandler, seedSession } = await import('@auxx/lib/resources')
     const organizationId = this.services.organizations[0]!.id
     const userId = this.services.organizations[0]!.ownerId
 
     // Seed tickets via UnifiedCrudHandler
-    await this.seedTickets(db, schema, organizationId, userId, UnifiedCrudHandler)
+    await this.seedTickets(db, schema, organizationId, userId, UnifiedCrudHandler, seedSession)
   }
 
   /**
@@ -98,20 +98,22 @@ export class TicketDomain {
    * @param organizationId - Organization ID to associate tickets with
    * @param userId - User ID for the handler
    * @param UnifiedCrudHandler - The handler class
+   * @param seedSession - The seed-session constructor from `@auxx/lib/resources`
    */
   private async seedTickets(
     db: any,
     schema: any,
     organizationId: string,
     userId: string,
-    UnifiedCrudHandler: any
+    UnifiedCrudHandler: any,
+    seedSession: (reason: string) => unknown
   ): Promise<void> {
     console.log('🎫 Generating tickets via UnifiedCrudHandler...')
 
     // Seed session: silent lane — same suppression the per-call
     // `skipEvents: true` used to provide, declared once at construction.
     const handler = new UnifiedCrudHandler(organizationId, userId, db, undefined, {
-      session: { origin: { kind: 'seed', reason: 'demo ticket seed data' }, depth: 0 },
+      session: seedSession('demo ticket seed data'),
     })
 
     // Get existing contact EntityInstances for linking (need both definitionId and instanceId for RecordId format)


### PR DESCRIPTION
## Summary

Small follow-ups flagged by #1800/#1803/#1805.

- **Archive `updatedAt` stamps (D-7)**: the three `archivedAt`-setting `EntityInstance` updates that predated explicit stamping now stamp `updatedAt` — connector rebind teardown and `removeMapping` bulk archive (`data-connectors/mutations.ts`), and merge source archival (`merge-service.ts`). Deliberately no `lastActivityAt` bump: teardown/merge archives aren't user activity, and archived rows exit the staleness scan anyway.
- **Stale `$onUpdate` docs**: the watermark stamp's "must be raw SQL" warning in `duplicate-scan-job.ts` is now historical (the hazard died with #1805); `docs/duplicate-detection-architecture-guide.md` updated in three places to the explicit-stamp contract; `docs/skip-events-history.md` gets a dated correction blockquote appended in its own §1 style — history preserved, correction recorded.
- **`seedSession` reachable from `packages/seed`**: the helper and write-origin types are re-exported from the already-exported `@auxx/lib/resources` subpath (`pnpm generate:exports --check`: unchanged, 261 entries), and the three seed domains now import it instead of inline `{ kind: 'seed', … }` literals. Resolution verified from `packages/seed` under the worker runtime; plain `tsx` seed runs pick it up after the next lib build (standard stale-dist rule).

## Test plan

- `src/resources/merge` (12 tests) and the data-connectors mutations-area tests (62 tests) pass.
- Integration (real DB): `duplicate-scan-job.int.test.ts` + `merge-duplicate-resolution.int.test.ts` — 23/23 pass, including the watermark pins.
- Combined with sibling PRs: 1150 passed / 10 skipped.