### PR TITLE
fix(entity-instances): seed archives skip lastActivityAt; reconcile door ledger

### DIFF
--- a/packages/lib/src/entity-instances/__tests__/updated-at-stamp.test.ts
+++ b/packages/lib/src/entity-instances/__tests__/updated-at-stamp.test.ts
@@ -70,6 +70,8 @@ vi.mock('@auxx/services/shared/utils', () => ({
   },
 }))
 
+import { seedSession } from '../../resources/crud/write-origin'
+import { runWithWriteSession } from '../../resources/crud/write-session-als'
 import { touchEntityActivity, touchEntityInteraction } from '../activity'
 import { updateEntityInstance } from '../update-entity-instance'
 
@@ -94,6 +96,54 @@ describe('D-7 stamp-or-not decisions', () => {
     expect(payload.archivedAt).toEqual(new Date('2026-08-21T10:00:00Z'))
     // Archive/restore also advances lastActivityAt (staleness scanner).
     expect(payload.lastActivityAt).toBeInstanceOf(Date)
+  })
+
+  it('archive under an ambient SEED session stamps updatedAt but NOT lastActivityAt', async () => {
+    // Door matrix: lastActivityAt × seed = off ("seeded data is not activity"),
+    // while updatedAtStamp × seed stays per-record — the content stamp survives.
+    const result = await runWithWriteSession(seedSession('updated-at-stamp-test'), () =>
+      updateEntityInstance({
+        id: 'inst-1',
+        organizationId: ORG,
+        data: { archivedAt: new Date('2026-08-21T10:00:00Z') },
+      })
+    )
+
+    expect(result.isOk()).toBe(true)
+    expect(h.setPayloads).toHaveLength(1)
+    const payload = h.setPayloads[0]!
+    expect(payload.updatedAt).toBeInstanceOf(Date)
+    expect(payload.archivedAt).toEqual(new Date('2026-08-21T10:00:00Z'))
+    expect('lastActivityAt' in payload).toBe(false)
+  })
+
+  it('restore under an ambient SEED session also skips lastActivityAt', async () => {
+    await runWithWriteSession(seedSession('updated-at-stamp-test'), () =>
+      updateEntityInstance({ id: 'inst-1', organizationId: ORG, data: { archivedAt: null } })
+    )
+
+    expect(h.setPayloads).toHaveLength(1)
+    expect(h.setPayloads[0]!.updatedAt).toBeInstanceOf(Date)
+    expect(h.setPayloads[0]!.archivedAt).toBeNull()
+    expect('lastActivityAt' in h.setPayloads[0]!).toBe(false)
+  })
+
+  it('archive under a non-seed ambient session bumps lastActivityAt like no session', async () => {
+    // Sync's finalize pass also bumps at the end of the run — the double bump
+    // is monotonic and harmless, so every non-seed origin keeps the inline bump.
+    await runWithWriteSession(
+      { origin: { kind: 'automation', actor: 'system_user' }, depth: 0 },
+      () =>
+        updateEntityInstance({
+          id: 'inst-1',
+          organizationId: ORG,
+          data: { archivedAt: new Date('2026-08-21T10:00:00Z') },
+        })
+    )
+
+    expect(h.setPayloads).toHaveLength(1)
+    expect(h.setPayloads[0]!.updatedAt).toBeInstanceOf(Date)
+    expect(h.setPayloads[0]!.lastActivityAt).toBeInstanceOf(Date)
   })
 
   it('restore stamps updatedAt explicitly', async () => {

--- a/packages/lib/src/entity-instances/update-entity-instance.ts
+++ b/packages/lib/src/entity-instances/update-entity-instance.ts
@@ -4,6 +4,10 @@ import { database, schema } from '@auxx/database'
 import { fromDatabase } from '@auxx/services/shared/utils'
 import { and, eq } from 'drizzle-orm'
 import { err, ok } from 'neverthrow'
+// Leaf-file import on purpose: the crud barrel pulls in UnifiedCrudHandler,
+// which imports this package's barrel — write-session-als itself only touches
+// node:async_hooks, so no runtime cycle this way.
+import { getAmbientWriteSession } from '../resources/crud/write-session-als'
 
 /** Parameters for updating an entity instance */
 export interface UpdateEntityInstanceParams {
@@ -32,7 +36,12 @@ export async function updateEntityInstance(params: UpdateEntityInstanceParams) {
     updateData.archivedAt = data.archivedAt
     // Archive/restore is meaningful activity — advance lastActivityAt so the
     // staleness scanner doesn't flag a freshly-restored entity as stale.
-    updateData.lastActivityAt = now
+    // EXCEPT under a seed write session: seeded data is not activity (door
+    // matrix, lastActivityAt × seed = off). The updatedAt content stamp above
+    // still applies (updatedAtStamp × seed = per-record).
+    if (getAmbientWriteSession()?.origin.kind !== 'seed') {
+      updateData.lastActivityAt = now
+    }
   }
 
   const dbResult = await fromDatabase(

--- a/packages/lib/src/resources/crud/__tests__/door-conformance.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/door-conformance.test.ts
@@ -27,6 +27,15 @@
 // today, the mismatch is encoded — never papered over — in `KNOWN_DEVIATIONS`
 // below, each entry carrying the plan reference for the phase that closes it.
 // A deviation that stops deviating fails its test, forcing the entry's removal.
+//
+// A fourth, per-CELL state exists since the sync finalize pass merged
+// (`events/handlers/sync-finalize.ts`): a door observed at THIS seam for most
+// origins can have individual (door, origin) cells whose truth-point is the
+// finalize seam instead — the handler stays silent BY DESIGN and finalize
+// executes the door off the claimed manifest. Those cells live in
+// `VERIFIED_ELSEWHERE_CELLS`, enforced both ways like the deviations: the
+// conformance loop skips them, and a dedicated test asserts the seam is STILL
+// silent (inline firing would double-execute the door against finalize).
 
 import { ok } from 'neverthrow'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
@@ -283,8 +292,12 @@ const DOOR_CONFORMANCE: Record<DoorId, DoorConformance> = {
   },
   realtimeTier2: {
     kind: 'deferred',
-    status: 'unverifiable',
-    where: 'tier-2 batched delta frames do not exist yet — plan 03 §7b / Phase 4 (D-18)',
+    status: 'verified-elsewhere',
+    where:
+      'sync finalize pass (events/handlers/sync-finalize.test.ts) — records:changed frames, ' +
+      'ids+fieldIds per D-18, emitted for BOTH sync lanes (on sync-small as the tier-1 ' +
+      'substitute; see the realtimeTier1 deviation). Interactive/automation bulk-shaped delta ' +
+      'frames are still future (plan 03 §7b)',
   },
   realtimeTier3: {
     kind: 'deferred',
@@ -357,10 +370,11 @@ const DOOR_CONFORMANCE: Record<DoorId, DoorConformance> = {
     kind: 'deferred',
     status: 'verified-elsewhere',
     where:
-      'entity-instances layer (create stamps it; updateEntityInstance bumps on archive/restore; ' +
-      'activity.ts bumpActivity for hooks). NOTE current nuances vs the matrix, not observable ' +
-      'at this seam: sync content writes never bump (B-5, Phase 4 / D-1), and a seed ARCHIVE ' +
-      'does bump today inside updateEntityInstance despite the seed cell being off',
+      'entity-instances layer (create stamps it; updateEntityInstance bumps on archive/restore ' +
+      'EXCEPT under a seed session — it reads the ambient write session and skips the bump, so ' +
+      'the seed cell holds; entity-instances updated-at-stamp tests) plus the sync finalize pass ' +
+      '(D-1 batched bump for both sync lanes — sync-finalize.test.ts). Sync content writes still ' +
+      'skip the inline bump; finalize catches them up at run end',
   },
   updatedAtStamp: {
     kind: 'observed',
@@ -378,14 +392,73 @@ const DOOR_CONFORMANCE: Record<DoorId, DoorConformance> = {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// VERIFIED-ELSEWHERE CELLS — silent at this seam BY DESIGN, executed at finalize
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Individual (door, origin) cells of doors otherwise observed at this seam
+ * whose truth-point is the sync finalize seam (PR #1806): the handler stays
+ * silent by design, and `handle-sync-record-rules` → `runSyncFinalize`
+ * executes the door off the claimed manifest at run end. Enforced BOTH ways
+ * like the deviations: the conformance loop skips these cells, and a dedicated
+ * test asserts the handler seam is STILL silent — inline firing would
+ * double-execute the door against finalize, so a cell that starts firing here
+ * fails its test and forces the entry's removal.
+ */
+const VERIFIED_ELSEWHERE_CELLS: Array<{
+  door: DoorId
+  origin: WriteOriginKind
+  /** Defaults to every op the door observes. */
+  ops?: Op[]
+  expectedFromMatrix: string
+  /** The suite where this cell's conformance actually lives. */
+  where: string
+}> = [
+  {
+    door: 'timelineEntry',
+    origin: 'sync-small',
+    expectedFromMatrix: 'per-record',
+    where:
+      'events/handlers/sync-finalize.test.ts — the D-12 finalize pass bulk-inserts one collapsed ' +
+      'timeline entry per changed/created/archived record (D-4 v1; small-lane per-FIELD fidelity ' +
+      'is a later upgrade, tracked on the perFieldTimeline row)',
+  },
+  {
+    door: 'recordRules',
+    origin: 'sync-small',
+    expectedFromMatrix: 'per-record',
+    where:
+      'events/handlers/handle-sync-record-rules.test.ts — the B2 manifest route fires field + ' +
+      'lifecycle rules per record off the claimed manifest (D-5); the inline bus route stays ' +
+      'silent for sync so rules never run twice',
+  },
+  {
+    door: 'workflowDispatch',
+    origin: 'sync-small',
+    expectedFromMatrix: 'per-record',
+    where:
+      'events/handlers/sync-finalize.test.ts — the finalize dispatch door fires ' +
+      'triggerResourceDispatch per record on the small lane (D-2, fixes B-3); the large lane ' +
+      'withholds pending the Phase 6 guard (D-3)',
+  },
+]
+
+function findVerifiedElsewhere(door: DoorId, origin: WriteOriginKind, op: Op) {
+  return VERIFIED_ELSEWHERE_CELLS.find(
+    (c) => c.door === door && c.origin === origin && (c.ops === undefined || c.ops.includes(op))
+  )
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // KNOWN DEVIATIONS — the matrix (desired) vs the implementation (today)
 // ═══════════════════════════════════════════════════════════════════════════
 
 /**
- * Every place where DOOR_MATRIX and the current handler-level implementation
- * disagree. Each entry is enforced BOTH ways: the conformance loop skips these
- * cells, and a dedicated test asserts the deviation is still real — so fixing
- * the implementation (or editing the cell) forces the entry's removal.
+ * Every place where DOOR_MATRIX and the current implementation — handler seam
+ * AND finalize pass combined — still disagree. Each entry is enforced BOTH
+ * ways: the conformance loop skips these cells, and a dedicated test asserts
+ * the deviation is still real — so fixing the implementation (or editing the
+ * cell) forces the entry's removal.
  */
 const KNOWN_DEVIATIONS: Array<{
   door: DoorId
@@ -397,41 +470,24 @@ const KNOWN_DEVIATIONS: Array<{
   ref: string
 }> = [
   {
-    door: 'timelineEntry',
-    origin: 'sync-small',
-    expectedFromMatrix: 'per-record',
-    observed: 'silent',
-    ref: 'plan 03 §7 B-2 — sync maps to the silent lane until Phase 4 lands the D-12 count-based small-run replay',
-  },
-  {
-    door: 'recordRules',
-    origin: 'sync-small',
-    expectedFromMatrix: 'per-record',
-    observed: 'silent',
-    ref:
-      'plan 03 §7 / D-5 — the inline bus route is silent for sync; rules DO run today via the ' +
-      'B2 sync-manifest route (source: sync), just not per-record. Phase 4 (D-12) splits the lanes',
-  },
-  {
-    door: 'workflowDispatch',
-    origin: 'sync-small',
-    expectedFromMatrix: 'per-record',
-    observed: 'silent',
-    ref: 'plan 03 §7 B-3 / D-2 — workflow triggers dead on incremental sync; Phase 6',
-  },
-  {
     door: 'notifications',
     origin: 'sync-small',
     expectedFromMatrix: 'per-record',
     observed: 'silent',
-    ref: 'plan 03 Phase 4 — the silent lane suppresses notifications for all sync writes today',
+    ref:
+      'plan 03 Phase 4 — the finalize pass (PR #1806) has NO notifications door: the matrix cell ' +
+      'says per-record but nothing implements it at either seam, so sync writes still notify no one',
   },
   {
     door: 'realtimeTier1',
     origin: 'sync-small',
     expectedFromMatrix: 'per-record',
     observed: 'silent',
-    ref: 'plan 03 §7b — the importer/connector realtime gap; Phase 4',
+    ref:
+      'plan 03 §7b — the finalize pass emits tier-2 records:changed frames (ids + fieldIds) for ' +
+      'BOTH sync lanes as a substitute, but the cell asks for tier-1 per-record ' +
+      'record:created|updated|archived frames and nothing emits those for sync; either finalize ' +
+      'grows a small-lane tier-1 replay or the cell is argued down to tier-2',
   },
   {
     door: 'updatedAtStamp',
@@ -440,8 +496,9 @@ const KNOWN_DEVIATIONS: Array<{
     expectedFromMatrix: 'batched',
     observed: 'fires-inline',
     ref:
-      'plan 03 §8 — no finalize pipeline yet, so the archive row write (updateEntityInstance, ' +
-      'which stamps updatedAt per D-7) runs inline for every origin, sync-large included',
+      'plan 03 §8 — the finalize pass deliberately has no updatedAt door (the D-7 write ' +
+      'chokepoint stamps at write time), so the archive row write (updateEntityInstance) still ' +
+      'runs inline for every origin, sync-large included',
   },
 ]
 
@@ -481,6 +538,7 @@ describe('door-matrix conformance at the handler seam', () => {
           const policy = entry.policies[origin]
           for (const op of conf.ops) {
             if (findDeviation(doorId as DoorId, origin, op)) continue // enforced below
+            if (findVerifiedElsewhere(doorId as DoorId, origin, op)) continue // enforced below
             const fired = conf.fired(observations[origin][op])
             if (fired !== expectsInline(policy)) {
               failures.push(
@@ -498,6 +556,46 @@ describe('door-matrix conformance at the handler seam', () => {
     it('api behaves exactly like interactive (the matrix folds them into one column)', () => {
       expect(observations.api).toEqual(observations.interactive)
     })
+  })
+
+  describe('VERIFIED-ELSEWHERE CELLS — silent at this seam, executed at finalize', () => {
+    it('every verified-elsewhere cell points at an observed door, a real origin, and a suite', () => {
+      for (const c of VERIFIED_ELSEWHERE_CELLS) {
+        expect(DOOR_CONFORMANCE[c.door].kind).toBe('observed')
+        expect(WRITE_ORIGIN_KINDS).toContain(c.origin)
+        expect(c.where).toMatch(/\.test\.ts/)
+      }
+    })
+
+    it('a cell is either a deviation or verified-elsewhere, never both', () => {
+      for (const c of VERIFIED_ELSEWHERE_CELLS) {
+        const conf = DOOR_CONFORMANCE[c.door]
+        if (conf.kind !== 'observed') throw new Error('verified-elsewhere on a deferred door')
+        for (const op of c.ops ?? conf.ops) {
+          expect(findDeviation(c.door, c.origin, op), `${c.door}/${c.origin}/${op}`).toBeUndefined()
+        }
+      }
+    })
+
+    for (const c of VERIFIED_ELSEWHERE_CELLS) {
+      it(`${c.door} / ${c.origin}: matrix '${c.expectedFromMatrix}', handler silent — lives in ${c.where.split(' ')[0]}`, () => {
+        const conf = DOOR_CONFORMANCE[c.door]
+        if (conf.kind !== 'observed') throw new Error('verified-elsewhere on a deferred door')
+        const policy = DOOR_MATRIX[c.door].policies[c.origin]
+        // The cell must still say what the entry claims it says…
+        expect(fmtPolicy(policy).startsWith(c.expectedFromMatrix)).toBe(true)
+        // …and the handler seam must STILL be silent: finalize owns this cell,
+        // so an inline fire would double-execute the door. When this fails, the
+        // handler grew an inline path — remove the entry (and the finalize door).
+        for (const op of c.ops ?? conf.ops) {
+          const fired = conf.fired(observations[c.origin][op])
+          expect(
+            fired,
+            `${c.door}/${c.origin}/${op} fired inline — it would double-execute against finalize`
+          ).toBe(false)
+        }
+      })
+    }
   })
 
   describe('KNOWN DEVIATIONS — matrix (desired) vs implementation (today)', () => {


### PR DESCRIPTION
## Summary

Two follow-ups from the conformance harness (#1808) and the finalize pass (#1806).

**Seed archives skip `lastActivityAt`** (matrix: `lastActivityAt` × seed = off). `updateEntityInstance` reads the ambient write session via a cycle-safe leaf import of the ALS module (deliberately not the `resources/crud` barrel, which would cycle back through `unified-handler`) and suppresses only the `lastActivityAt` key when the origin is `seed` — the `updatedAt` content stamp stays, and every non-seed origin is byte-identical (pinned by the pre-existing tests plus three new cases: seed archive, seed restore, ambient-automation archive).

**Ledger reconciliation.** The harness gains a fourth per-cell state, `VERIFIED_ELSEWHERE_CELLS`, with the same two-way enforcement as the deviations ledger: each moved cell asserts the matrix still says `per-record` AND the handler seam is **still silent** — an inline fire would double-execute the door against finalize, and the failure message says so. Moves: `timelineEntry`, `recordRules`, `workflowDispatch` × sync-small (verified at the finalize/manifest seams). Stays deviating, honestly:
- `notifications` × sync-small — nothing implements it at either seam.
- `realtimeTier1` × sync-small — finalize emits tier-2 `records:changed`, a different frame vocabulary from per-record `record:*`; the entry now states the closing path (small-lane tier-1 replay at finalize, or argue the matrix cell down to tier-2 — a product call).

Also corrects two stale classifications (`realtimeTier2` now verified at finalize; `lastActivityAt`'s note reflects the D-1 finalize bump and this PR's seed fix).

## Test plan

Full `src/resources/crud` + `src/entity-instances`: 19 files, 185 passed / 10 intentional deferred-door skips, 0 failed. Combined with the sibling PR: 988 passed / 10 skipped.