### PR TITLE
fix(ingest): gate thread:reopened behind historical-mail suppression

### DIFF
--- a/docs/channels-mail-architecture-guide.md
+++ b/docs/channels-mail-architecture-guide.md
@@ -537,8 +537,12 @@ from), the provider sets it on the ingest ctx, and `storeMessage` suppresses the
 inbound mail received before it — regardless of walker — until `messagesImportJob`'s first
 drain-to-IDLE stamps `metadata.initialBackfillCompletedAt`. Overlap mail (received ≥ cutoff)
 fires exactly once via the fresh-insert-only gate, whichever walker wins. Built as a shared
-ingest mechanism (`ctx.backfillCutoffAt`); only Outlook wires it so far — Gmail's polling path
-still has the walker-based hole (separate ticket).
+ingest mechanism (`ctx.backfillCutoffAt`); both Outlook and Gmail wire it. Outlook stamps the
+cutoff before seeding its delta cursor (same epoch); Gmail has no cursor-epoch constraint, so
+the provisioning hook stamps it only when the polling pipeline will actually run
+(`provisioning-hook.ts`) — a webhook-mode Gmail connect never drains the import cache, so
+stamping there would open a suppression window that never closes. Each provider reads the
+stamp into the ingest ctx on init (`google-provider.ts` / `outlook-provider.ts`).
 
 **Self-healing.** `pollingStaleCheckJob` (~15 min) resets channels stuck in an active stage past
 15 min — preserving the Redis import cache so recovery resumes importing rather than re-listing

--- a/packages/lib/src/ingest/__tests__/store-message-backfill-cutoff.test.ts
+++ b/packages/lib/src/ingest/__tests__/store-message-backfill-cutoff.test.ts
@@ -20,6 +20,8 @@ const h = vi.hoisted(() => ({
   published: [] as Array<{ type: string; data: Record<string, unknown> }>,
   senderIdentifier: 'customer@external.com',
   threadRow: {} as Record<string, unknown>,
+  personalInbox: false,
+  threadSetWrites: [] as Array<Record<string, unknown>>,
 }))
 
 vi.mock('../../cache', () => ({
@@ -50,7 +52,7 @@ vi.mock('../../events/publisher', () => ({
 vi.mock('../../permissions/visibility/audience', () => ({
   getFullLensAudienceForInbox: async () => [],
 }))
-vi.mock('../inbox-meta', () => ({ isPersonalInbox: async () => false }))
+vi.mock('../inbox-meta', () => ({ isPersonalInbox: async () => h.personalInbox }))
 vi.mock('../../inbox-record-ids', () => ({ toInboxRecordId: async () => 'inbox:i_1' }))
 
 vi.mock('../filtering/machine-mail', () => ({ detectMachineMail: () => null }))
@@ -92,6 +94,7 @@ vi.mock('drizzle-orm', () => {
   }
 })
 
+import { publishThreadUpdated } from '../../realtime'
 import { storeMessage } from '../store-message'
 
 const ORG = 'org_1'
@@ -128,6 +131,11 @@ function tx() {
         get(_t, prop) {
           if (prop === 'returning') return async () => returningFor(table)
           if (prop === 'then') return (res: (v: unknown[]) => unknown) => Promise.resolve(res([]))
+          if (prop === 'set' && table === 'Thread')
+            return (values: Record<string, unknown>) => {
+              h.threadSetWrites.push(values)
+              return obj
+            }
           return () => obj
         },
       }
@@ -191,6 +199,9 @@ beforeEach(() => {
   h.cachedChannels = []
   h.published = []
   h.senderIdentifier = 'customer@external.com'
+  h.personalInbox = false
+  h.threadSetWrites = []
+  vi.mocked(publishThreadUpdated).mockClear()
   h.threadRow = {
     id: 't_1',
     inboxId: INBOX_ID,
@@ -226,5 +237,67 @@ describe('storeMessage — backfill-cutoff suppression on message:received', () 
     expect(result.isNew).toBe(true)
     expect(h.published).toHaveLength(1)
     expect(h.published[0]).toMatchObject({ type: 'message:received' })
+  })
+})
+
+describe('storeMessage — thread:reopened rides the same historical-mail suppression', () => {
+  // Drive `didReopen`: personal inbox + existing (non-new) ARCHIVED thread +
+  // an incoming message carrying the INBOX label.
+  beforeEach(() => {
+    h.personalInbox = true
+    h.threadRow = {
+      id: 't_1',
+      inboxId: INBOX_ID,
+      status: 'ARCHIVED',
+      assigneeId: null,
+      messageCount: 2,
+      firstMessageAt: new Date('2026-08-01T00:00:00.000Z'),
+      lastMessageAt: BEFORE_CUTOFF,
+      participantCount: 1,
+    }
+  })
+
+  const reopenData = (receivedAt: Date) => messageData(receivedAt, { labelIds: ['INBOX'] })
+
+  it('does NOT publish thread:reopened for a historical (pre-cutoff) message, but still flips the status', async () => {
+    const result = await storeMessage(ctx(CUTOFF), reopenData(BEFORE_CUTOFF))
+
+    expect(result.isNew).toBe(true)
+    // Neither the reopen event nor message:received leaks for suppressed mail.
+    expect(h.published).toHaveLength(0)
+    // Non-publish reopen behavior is unchanged: the ARCHIVED -> OPEN state
+    // write in the transaction and the realtime patch both still happen.
+    expect(h.threadSetWrites).toContainEqual({ status: 'OPEN' })
+    expect(vi.mocked(publishThreadUpdated)).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT publish thread:reopened during initial sync, but still flips the status', async () => {
+    const initialSyncCtx = ctx(null)
+    initialSyncCtx.isInitialSync = true
+    const result = await storeMessage(initialSyncCtx, reopenData(AFTER_CUTOFF))
+
+    expect(result.isNew).toBe(true)
+    expect(h.published).toHaveLength(0)
+    expect(h.threadSetWrites).toContainEqual({ status: 'OPEN' })
+  })
+
+  it('publishes thread:reopened exactly as before for a post-cutoff message', async () => {
+    const result = await storeMessage(ctx(CUTOFF), reopenData(AFTER_CUTOFF))
+
+    expect(result.isNew).toBe(true)
+    expect(h.published).toHaveLength(2)
+    expect(h.published[0]).toMatchObject({
+      type: 'thread:reopened',
+      data: {
+        threadId: 't_1',
+        organizationId: ORG,
+        actorId: null,
+        source: { kind: 'system' },
+        visitorParticipantId: null,
+      },
+    })
+    expect(h.published[1]).toMatchObject({ type: 'message:received' })
+    expect(h.threadSetWrites).toContainEqual({ status: 'OPEN' })
+    expect(vi.mocked(publishThreadUpdated)).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/lib/src/ingest/store-message.ts
+++ b/packages/lib/src/ingest/store-message.ts
@@ -1029,7 +1029,12 @@ export async function storeMessage(
     // path as every other emitter. Null actor + system provenance — no human
     // reopened this, the inbound mail did. `didReopen` requires a personal
     // email channel, so there is never a chat visitor to fan out to.
-    if (didReopen) {
+    // Gated by the SAME historical-mail suppression as `message:received`
+    // below (`!isInitialSync` + the received-time cutoff): a backfilled
+    // historical message must not announce a reopen to realtime/outbound
+    // webhooks when the message itself is suppressed. The status flip in the
+    // transaction above still happens either way — only the event is gated.
+    if (didReopen && !ctx.isInitialSync && !suppressedByBackfillCutoff) {
       await publisher.publishLater({
         type: 'thread:reopened',
         data: {


### PR DESCRIPTION
## Summary

Closes gap **G4** from `docs/skip-events-history.md` §11: the `thread:reopened` bus publish (`store-message.ts:1032`) was unconditional — outside the cutoff check that suppresses `message:received` — so a backfilled historical message landing on an archived personal-inbox thread with an INBOX label published reopen to realtime AND outbound webhooks while the message itself was correctly suppressed as historical.

- The publish now rides the SAME two historical-mail suppression arms as `message:received`: `!ctx.isInitialSync && !suppressedByBackfillCutoff` (reusing the decision computed just above — the `isInbound` arm is a directionality gate, not historical suppression, and is deliberately not added).
- **Unchanged by design**: the transactional `Thread.status → OPEN` flip and the post-commit `publishThreadUpdated` socket patch + mail-count deltas (a different mechanism, not the G4 hole). The gap was the event fan-out, not the state.
- Also corrects `docs/channels-mail-architecture-guide.md:539-541`, which still claimed only Outlook wires `backfillCutoffAt` — verified against `provisioning-hook.ts:353-370` and `google-provider.ts:180-182`: Gmail is wired, stamping only when the polling pipeline will actually run (webhook-mode Gmail never drains the import cache, so stamping there would open a suppression window that never closes).

## Test plan

Extended the existing `store-message-backfill-cutoff.test.ts` (same fixtures): historical pre-cutoff reopen → zero events but status still flipped + socket patch still sent; initial-sync reopen → same; post-cutoff reopen → exactly `[thread:reopened, message:received]` with full payloads (proves `didReopen` is genuinely exercised, so the zero-publish assertions aren't vacuous). Ingest suite: 20 files / 230 tests pass, no unhandled errors.

**Branch base note**: branched from local main at #1809 (a concurrent in-flight change holds the #1810-touched harness file locally); files here are disjoint from #1810, so the merge is clean.