### PR TITLE
feat(crud): bulk archives emit tier-2 delta frames instead of per-record

### DIFF
--- a/packages/lib/src/resources/crud/__tests__/bulk-archive-records-changed.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/bulk-archive-records-changed.test.ts
@@ -1,0 +1,177 @@
+// packages/lib/src/resources/crud/__tests__/bulk-archive-records-changed.test.ts
+//
+// D-17/§7b realtime slice (plan events/03): `bulkArchiveEntities` is
+// bulk-shaped, so its realtime door is tier 2 — ONE `records:changed` delta
+// frame per def (ids only, publisher chunks at 100) instead of N per-record
+// `record:archived` frames. Everything else about the per-record loop is
+// unchanged: bus events (timeline / rules / workflows ride them) and
+// duplicate-pair cleanup still fire once per record, and the single-record
+// `archiveEntity` path keeps its tier-1 frame exactly as before.
+//
+// Under a silent lane (seed/sync session, or the deprecated `skipEvents`
+// alias) NOTHING is emitted — the per-record frames were already suppressed
+// there, and the finalize pass owns sync realtime, so no tier-2 frame either.
+
+import { ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  deleteOpenPairsForRecord: vi.fn(async () => ok(0)),
+  enqueueDuplicateScan: vi.fn(async () => 'job_1'),
+  publish: vi.fn(async () => {}),
+  publishLater: vi.fn(() => {}),
+  publishRecordsChanged: vi.fn(async () => {}),
+}))
+
+vi.mock('../../../dedup/pairs', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  deleteOpenPairsForRecord: h.deleteOpenPairsForRecord,
+}))
+vi.mock('../../../dedup/enqueue-scan', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  enqueueDuplicateScan: h.enqueueDuplicateScan,
+}))
+
+vi.mock('../../../entity-instances', () => ({
+  getEntityInstance: vi.fn(async () => ok({ id: 'inst_1', archivedAt: null })),
+  updateEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+  createEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+  deleteEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+}))
+vi.mock('../../../realtime', () => ({
+  getRealtimeService: () => ({ publish: h.publish }),
+  rooms: { orgRecords: () => 'room' },
+  publishRecordsChanged: h.publishRecordsChanged,
+}))
+vi.mock('../../../events/publisher', () => ({
+  publisher: { publishLater: h.publishLater, publish: h.publishLater },
+}))
+
+import {
+  archiveEntity,
+  bulkArchiveEntities,
+  type MutationContext,
+} from '../unified-handler-mutations'
+import { interactiveSession, seedSession, type WriteSession } from '../write-origin'
+
+function ctx(session: WriteSession = interactiveSession('user_1', 'sock_1')): MutationContext {
+  return {
+    db: {} as never,
+    organizationId: 'org_1',
+    userId: 'user_1',
+    socketId: 'sock_1',
+    session,
+    fieldValueService: {} as never,
+    resolveEntityDefinition: async (entityDefinitionId: string) => ({
+      id: entityDefinitionId,
+      entityType: 'contact',
+      apiSlug: 'contacts',
+    }),
+    getFields: async () => [],
+    runPreHooks: async (_o, _d, values) => values,
+    validateUniqueFields: async () => {},
+    setFieldValues: async () => {},
+  } as never
+}
+
+/** Every realtime frame name published through the tier-1 service spy. */
+const publishedFrames = () => h.publish.mock.calls.map((c) => String((c as unknown[])[1]))
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('bulkArchiveEntities — tier-2 records:changed (D-17/§7b)', () => {
+  it('emits zero record:archived frames and one records:changed publish carrying all ids', async () => {
+    const recordIds = ['def_1:inst_1', 'def_1:inst_2', 'def_1:inst_3'] as never[]
+    const result = await bulkArchiveEntities(ctx(), recordIds)
+
+    expect(result.count).toBe(3)
+    expect(publishedFrames()).not.toContain('record:archived')
+
+    expect(h.publishRecordsChanged).toHaveBeenCalledTimes(1)
+    const [, organizationId, args, options] = h.publishRecordsChanged.mock.calls[0] as [
+      unknown,
+      string,
+      { entityDefinitionId: string; entries: Array<{ recordId: string }> },
+      { excludeSocketId?: string },
+    ]
+    expect(organizationId).toBe('org_1')
+    expect(args.entityDefinitionId).toBe('def_1')
+    expect(args.entries.map((e) => e.recordId)).toEqual(['inst_1', 'inst_2', 'inst_3'])
+    // Same self-echo exclusion the per-record frames carried.
+    expect(options).toEqual({ excludeSocketId: 'sock_1' })
+  })
+
+  it('publishes one delta frame per def when the batch spans defs', async () => {
+    const recordIds = ['def_1:inst_1', 'def_2:inst_2', 'def_1:inst_3'] as never[]
+    await bulkArchiveEntities(ctx(), recordIds)
+
+    expect(h.publishRecordsChanged).toHaveBeenCalledTimes(2)
+    const byDef = new Map(
+      h.publishRecordsChanged.mock.calls.map((c) => {
+        const args = (c as unknown[])[2] as {
+          entityDefinitionId: string
+          entries: Array<{ recordId: string }>
+        }
+        return [args.entityDefinitionId, args.entries.map((e) => e.recordId)] as const
+      })
+    )
+    expect(byDef.get('def_1')).toEqual(['inst_1', 'inst_3'])
+    expect(byDef.get('def_2')).toEqual(['inst_2'])
+  })
+
+  it('keeps every other per-record door: bus events and pair cleanup fire once per record', async () => {
+    const recordIds = ['def_1:inst_1', 'def_1:inst_2', 'def_1:inst_3'] as never[]
+    await bulkArchiveEntities(ctx(), recordIds)
+
+    // Bus event (timeline / rules / workflow dispatch hang off it): per record.
+    expect(h.publishLater).toHaveBeenCalledTimes(3)
+    // Duplicate-pair cleanup (outside the event guard): per record.
+    expect(h.deleteOpenPairsForRecord).toHaveBeenCalledTimes(3)
+  })
+
+  it('emits NOTHING under a seed session — the silent lane stays silent', async () => {
+    await bulkArchiveEntities(ctx(seedSession('test')), ['def_1:inst_1', 'def_1:inst_2'] as never[])
+
+    expect(h.publish).not.toHaveBeenCalled()
+    expect(h.publishRecordsChanged).not.toHaveBeenCalled()
+    expect(h.publishLater).not.toHaveBeenCalled()
+    // Data hygiene is not an event: cleanup still runs per record.
+    expect(h.deleteOpenPairsForRecord).toHaveBeenCalledTimes(2)
+  })
+
+  it('emits NOTHING under the deprecated skipEvents alias either', async () => {
+    await bulkArchiveEntities(ctx(), ['def_1:inst_1'] as never[], { skipEvents: true })
+
+    expect(h.publish).not.toHaveBeenCalled()
+    expect(h.publishRecordsChanged).not.toHaveBeenCalled()
+  })
+
+  it('a failed record is skipped: not counted and not in the delta frame', async () => {
+    const { getEntityInstance } = await import('../../../entity-instances')
+    ;(getEntityInstance as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(ok({ id: 'inst_1', archivedAt: null }))
+      .mockRejectedValueOnce(new Error('boom'))
+
+    const result = await bulkArchiveEntities(ctx(), ['def_1:inst_1', 'def_1:inst_2'] as never[])
+    expect(result.count).toBe(1)
+    const args = (h.publishRecordsChanged.mock.calls[0] as unknown[])[2] as {
+      entries: Array<{ recordId: string }>
+    }
+    expect(args.entries.map((e) => e.recordId)).toEqual(['inst_1'])
+  })
+})
+
+describe('archiveEntity — single-record path is untouched', () => {
+  it('still publishes the per-record record:archived tier-1 frame', async () => {
+    await archiveEntity(ctx(), 'def_1:inst_1' as never)
+
+    expect(publishedFrames()).toContain('record:archived')
+    expect(h.publish).toHaveBeenCalledWith(
+      'room',
+      'record:archived',
+      { recordId: 'def_1:inst_1', entityDefinitionId: 'def_1' },
+      { excludeSocketId: 'sock_1' }
+    )
+    expect(h.publishRecordsChanged).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/resources/crud/__tests__/door-conformance.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/door-conformance.test.ts
@@ -283,8 +283,12 @@ const DOOR_CONFORMANCE: Record<DoorId, DoorConformance> = {
   },
   realtimeTier2: {
     kind: 'deferred',
-    status: 'unverifiable',
-    where: 'tier-2 batched delta frames do not exist yet — plan 03 §7b / Phase 4 (D-18)',
+    status: 'verified-elsewhere',
+    where:
+      'bulkArchive emits tier-2 records:changed for the inline lane (D-17/§7b slice) — ' +
+      'bulk-archive-records-changed.test.ts. This harness drives SINGLE-record ops, which are ' +
+      'not bulk-shaped, so the door has no observation point at this seam. The remaining ' +
+      'producers (bulkUpdate/applyBulk, sync throttled + finalize-round frames) are Phase 4',
   },
   realtimeTier3: {
     kind: 'deferred',

--- a/packages/lib/src/resources/crud/unified-handler-mutations.ts
+++ b/packages/lib/src/resources/crud/unified-handler-mutations.ts
@@ -20,7 +20,12 @@ import { publisher } from '../../events/publisher'
 import type { Events } from '../../events/types'
 import { getEntityPostDeleteHooks, getEntityPreDeleteHooks } from '../../field-hooks/registry'
 import type { FieldValueService } from '../../field-values'
-import { getRealtimeService, rooms } from '../../realtime'
+import {
+  getRealtimeService,
+  publishRecordsChanged,
+  type RecordChangedEntry,
+  rooms,
+} from '../../realtime'
 import {
   captureEventData,
   extractEventData,
@@ -594,12 +599,19 @@ export async function updateEntity(
  *
  * @param ctx - Mutation context
  * @param recordId - RecordId in format "entityDefinitionId:instanceId"
- * @param options - Optional CRUD options (skipEvents)
+ * @param options - Optional CRUD options (skipEvents). The extra
+ *   `suppressRealtimeFrame` flag is INTERNAL to this module: it exists only so
+ *   `bulkArchiveEntities` can swap the per-record tier-1 `record:archived`
+ *   frame for one tier-2 `records:changed` delta frame per def (plan events/03
+ *   §7b / D-17). It suppresses the realtime frame and NOTHING else — the bus
+ *   event, dedup-pair cleanup, and every other per-record door fire exactly as
+ *   on a single archive. Do not add it to `CrudOptions` and do not let it
+ *   spread to other mutations.
  */
 export async function archiveEntity(
   ctx: MutationContext,
   recordId: RecordId,
-  options: CrudOptions = {}
+  options: CrudOptions & { suppressRealtimeFrame?: boolean } = {}
 ) {
   // S3: one derived boolean per call gates the whole per-write fan-out below.
   const publishEvents = derivePublishEvents(ctx, options)
@@ -635,8 +647,9 @@ export async function archiveEntity(
     })
   }
 
-  // Publish record:archived realtime event
-  if (publishEvents) {
+  // Publish record:archived realtime event (skipped when the caller is a bulk
+  // archive — it publishes one tier-2 `records:changed` frame per def instead).
+  if (publishEvents && !options.suppressRealtimeFrame) {
     getRealtimeService()
       .publish(
         rooms.orgRecords(ctx.organizationId, entityDef.id),
@@ -918,18 +931,60 @@ export async function bulkArchiveEntities(
 ): Promise<{ count: number }> {
   if (recordIds.length === 0) return { count: 0 }
 
+  // D-17/§7b: origin decides policy, SIZE decides execution shape. A bulk
+  // archive is bulk-shaped, so its realtime door is tier 2 — one
+  // `records:changed` delta frame per def (ids only per D-18, chunked at 100
+  // by the publisher) instead of N per-record `record:archived` frames. This
+  // is a realtime-SHAPE change ONLY: client-side the per-record frame drives
+  // just a per-def list invalidate (`handleRecordArchived` in
+  // use-resource-sync — no in-place row removal, unlike `record:deleted`),
+  // and the `records:changed` handler runs the same coalesced list invalidate
+  // plus a targeted cached-row catch-up — behavior-equivalent for the UI while
+  // removing the N-frame fan-out. `bulkDeleteEntities` deliberately KEEPS its
+  // per-record `record:deleted` frames: the client removes those rows from
+  // the record store in place, which a delta frame would regress.
+  const publishEvents = derivePublishEvents(ctx, options)
+
   let count = 0
+  // Archived instance ids grouped by (possibly slug-keyed) def id — the
+  // publisher canonicalizes def keys itself.
+  const archivedByDef = new Map<string, RecordChangedEntry[]>()
   for (const recordId of recordIds) {
     try {
       // Delegates per record, so `archiveEntity`'s duplicate-pair cleanup covers
       // the bulk path too — including under `skipEvents`, where it sits outside
-      // the event guard precisely so this loop still cleans up.
+      // the event guard precisely so this loop still cleans up. Every other
+      // per-record door (bus event → timeline/rules/workflows, pair cleanup)
+      // fires exactly as on a single archive; only the tier-1 realtime frame is
+      // suppressed in favor of the tier-2 delta below.
       await archiveEntity(ctx, recordId, {
         skipEvents: options.skipEvents,
+        suppressRealtimeFrame: true,
       })
       count++
+      const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+      const entries = archivedByDef.get(entityDefinitionId) ?? []
+      entries.push({ recordId: entityInstanceId })
+      archivedByDef.set(entityDefinitionId, entries)
     } catch {
       // Skip failures
+    }
+  }
+
+  // Under a silent lane (sync/seed, or the deprecated `skipEvents` alias) the
+  // per-record frames were already suppressed before this change — emit no
+  // tier-2 frame there either: the finalize pass owns sync realtime.
+  if (publishEvents && count > 0) {
+    const realtimeService = getRealtimeService()
+    for (const [entityDefinitionId, entries] of archivedByDef) {
+      // Same self-echo exclusion the per-record frames carried. Fire-and-forget
+      // inside the publisher; a realtime hiccup never fails the archive.
+      await publishRecordsChanged(
+        realtimeService,
+        ctx.organizationId,
+        { entityDefinitionId, entries },
+        { excludeSocketId: ctx.socketId }
+      )
     }
   }
 


### PR DESCRIPTION
## Summary

The D-17/§7b slice for interactive bulk archives: **`bulkArchive` stops publishing one `record:archived` frame per record** and emits chunked ids-only `records:changed` delta frames (one per touched def) instead.

Why it's behavior-equivalent for the UI (verified against the web handlers, read-only): `record:archived` triggers list invalidation only — no in-place row removal — and the `records:changed` targeted catch-up list-invalidates too. `bulkDelete` deliberately KEEPS per-record frames: the client does in-place `removeRecord` on `record:deleted`, and losing that would regress open grids.

- Per-record everything else stays: bus events (timeline/rules/workflows), dedup-pair cleanup, row writes.
- The suppression knob is an inline internal option on `archiveEntity`, not public `CrudOptions` — commented as existing only for the bulk tier-2 shape, must not spread.
- Silent-lane sessions (sync/seed) and the deprecated `skipEvents` alias emit nothing of either kind — the finalize pass owns sync realtime.
- `excludeSocketId` honored on the delta frame, same as the per-record frames were.
- One honest residual (documented): `record:archived` also cleared the participant-name store per record; `records:changed` doesn't, so a remote tab may hold participant entries for archived records until its next patch — cosmetic, read-time-patched by design; a one-line client follow-up if desired.

Also in this PR (merge-resolution work):
- Reconciles the conformance harness with #1810's rewrite (this branch's `realtimeTier2` classification now also names the bulk-archive producer).
- **Fixes the typecheck red that rode in with #1810**: untyped `vi.fn()` types `mock.calls` as an empty tuple → TS2493 at the harness's frame accessor (+ TS7006/TS2352 in the new test). vitest doesn't typecheck, which is how it slipped through while tests stayed green. `Typecheck (lib)` should be back to baseline on this PR.

## Test plan

New `bulk-archive-records-changed.test.ts` (7 tests): zero archived frames + one delta publish with all N ids and socket exclusion; one frame per def on multi-def batches; per-record bus events + pair cleanup preserved; seed/`skipEvents` emit nothing; failed records excluded; single `archiveEntity` byte-identical. Full `src/resources/crud` + `src/entity-instances` on the merged state: 20 files, 192 passed / 10 intentional skips. Scoped tsc: zero diagnostics in touched files.