### PR TITLE
fix(providers): give imap the full backfill suppression the oauth lanes have

### DIFF
--- a/apps/web/src/server/api/routers/channel.ts
+++ b/apps/web/src/server/api/routers/channel.ts
@@ -923,6 +923,15 @@ export const channelRouter = createTRPCRouter({
           syncMode: 'auto',
           syncStage: 'IDLE',
           syncStatus: 'NOT_SYNCED',
+          // Received-time trigger cutoff (webhook-push-migration plan Phase 2.5,
+          // same stamp `channels/provisioning-hook.ts` writes for Gmail/Outlook):
+          // the first folder walk imports the mailbox's full history, and without
+          // this every historical message would fire `message:received` —
+          // workflows, billed classification, filters, signals. Mail received
+          // before the connect instant is historical; `ImapProvider.initialize`
+          // arms the cutoff while `initialBackfillCompletedAt` is unset, and the
+          // polling jobs stamp completion when the walk drains.
+          metadata: { backfillCutoffAt: new Date().toISOString() },
           updatedAt: new Date(),
         })
         .returning()

--- a/packages/lib/src/data-migrations/migrations/099-imap-backfill-stamps.test.ts
+++ b/packages/lib/src/data-migrations/migrations/099-imap-backfill-stamps.test.ts
@@ -1,0 +1,155 @@
+// packages/lib/src/data-migrations/migrations/099-imap-backfill-stamps.test.ts
+//
+// Pre-fix IMAP channels carry neither backfill stamp, and the consume side now
+// fails CLOSED (#1721) — so without this migration every existing IMAP channel
+// would open a fresh suppression window at its next poll. The planner is the
+// decision worth testing: already-backfilled channels get a CLOSED window
+// (both stamps — leaving `initialBackfillCompletedAt` unset would suppress
+// `message:received` forever), never-synced channels get an OPEN one (cutoff
+// alone), and any row already carrying a stamp is untouched (insert-only — a
+// migration re-run must never reopen a closed window).
+
+import type { Database } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import { migration099ImapBackfillStamps, planImapBackfillStamps } from './099-imap-backfill-stamps'
+
+interface StoredIntegration {
+  id: string
+  metadata: unknown
+  lastSuccessfulSync: Date | null
+}
+
+const integration = (over: Partial<StoredIntegration> = {}): StoredIntegration => ({
+  id: 'int-1',
+  metadata: { email: 'ops@example.com' },
+  lastSuccessfulSync: new Date('2026-08-01T00:00:00.000Z'),
+  ...over,
+})
+
+/** Walk a built Drizzle condition / SQL object for any of the ids we know about. */
+function findRowId(condition: unknown, ids: string[], depth = 0): string | null {
+  if (depth > 8 || condition === null || condition === undefined) return null
+  if (typeof condition === 'string') return ids.includes(condition) ? condition : null
+  if (typeof condition !== 'object') return null
+  for (const value of Object.values(condition as Record<string, unknown>)) {
+    const found = findRowId(value, ids, depth + 1)
+    if (found) return found
+  }
+  return null
+}
+
+/** Collect every literal string inside a Drizzle SQL object (template chunks). */
+function sqlText(node: unknown, out: string[] = [], depth = 0): string {
+  if (depth > 10 || node === null || node === undefined) return out.join(' ')
+  if (typeof node === 'string') {
+    out.push(node)
+    return out.join(' ')
+  }
+  if (typeof node === 'object') {
+    for (const value of Object.values(node as Record<string, unknown>)) {
+      sqlText(value, out, depth + 1)
+    }
+  }
+  return out.join(' ')
+}
+
+function createFakeDb(rows: StoredIntegration[]) {
+  const updates: Array<{ id: string | null; patch: Record<string, unknown> }> = []
+
+  const selectChain: Record<string, unknown> = {}
+  for (const method of ['from', 'where', 'limit', 'orderBy']) {
+    selectChain[method] = () => selectChain
+  }
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable query-builder mock
+  selectChain.then = (onOk: (v: StoredIntegration[]) => unknown, onErr: (e: unknown) => unknown) =>
+    Promise.resolve(rows.map((r) => ({ ...r }))).then(onOk, onErr)
+
+  const db = {
+    select: () => selectChain,
+    update: () => ({
+      set: (patch: Record<string, unknown>) => ({
+        where: async (condition: unknown) => {
+          updates.push({
+            id: findRowId(
+              condition,
+              rows.map((r) => r.id)
+            ),
+            patch,
+          })
+        },
+      }),
+    }),
+  } as unknown as Database
+
+  return { db, updates }
+}
+
+describe('planImapBackfillStamps', () => {
+  it('closes the window for a channel that already completed a sync', () => {
+    expect(planImapBackfillStamps(integration())).toBe('both')
+  })
+
+  it('opens a window (cutoff only) for a channel that never synced', () => {
+    expect(planImapBackfillStamps(integration({ lastSuccessfulSync: null }))).toBe('cutoff-only')
+  })
+
+  it('never rewrites an existing stamp (insert-only)', () => {
+    expect(
+      planImapBackfillStamps(
+        integration({ metadata: { backfillCutoffAt: '2026-08-20T10:00:00.000Z' } })
+      )
+    ).toBe('skip')
+    expect(
+      planImapBackfillStamps(
+        integration({ metadata: { initialBackfillCompletedAt: '2026-08-20T10:00:00.000Z' } })
+      )
+    ).toBe('skip')
+  })
+
+  it('tolerates malformed metadata', () => {
+    expect(planImapBackfillStamps(integration({ metadata: null }))).toBe('both')
+    expect(planImapBackfillStamps(integration({ metadata: 'garbage' }))).toBe('both')
+    expect(
+      planImapBackfillStamps(integration({ metadata: ['array'], lastSuccessfulSync: null }))
+    ).toBe('cutoff-only')
+  })
+})
+
+describe('migration 099 run', () => {
+  it('stamps both fields for a synced channel and only the cutoff for a never-synced one', async () => {
+    const fake = createFakeDb([
+      integration({ id: 'int-synced' }),
+      integration({ id: 'int-fresh', lastSuccessfulSync: null }),
+      integration({
+        id: 'int-stamped',
+        metadata: { backfillCutoffAt: '2026-08-20T10:00:00.000Z' },
+      }),
+    ])
+
+    await migration099ImapBackfillStamps.run(fake.db)
+
+    expect(fake.updates.map((u) => u.id)).toEqual(['int-synced', 'int-fresh'])
+
+    const synced = sqlText(fake.updates[0]!.patch.metadata)
+    expect(synced).toContain('backfillCutoffAt')
+    expect(synced).toContain('initialBackfillCompletedAt')
+
+    const fresh = sqlText(fake.updates[1]!.patch.metadata)
+    expect(fresh).toContain('backfillCutoffAt')
+    expect(fresh).not.toContain('initialBackfillCompletedAt')
+  })
+
+  it('is a no-op when every row already carries a stamp', async () => {
+    const fake = createFakeDb([
+      integration({ id: 'int-1', metadata: { initialBackfillCompletedAt: '2026-08-20' } }),
+    ])
+
+    await migration099ImapBackfillStamps.run(fake.db)
+
+    expect(fake.updates).toEqual([])
+  })
+
+  it('exposes the migration under the id the ledger reserved', () => {
+    expect(migration099ImapBackfillStamps.id).toBe('099-imap-backfill-stamps')
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/099-imap-backfill-stamps.ts
+++ b/packages/lib/src/data-migrations/migrations/099-imap-backfill-stamps.ts
@@ -1,0 +1,102 @@
+// packages/lib/src/data-migrations/migrations/099-imap-backfill-stamps.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, isNull, sql } from 'drizzle-orm'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-099')
+
+/** What to stamp on one pre-fix IMAP channel row. */
+export type ImapStampPlan = 'both' | 'cutoff-only' | 'skip'
+
+/**
+ * Decide the stamps for one IMAP `Integration` row. Insert-only, mirroring the
+ * stamps' contract everywhere else (a reconnect must never reopen a closed
+ * window): any row that already carries either key is left untouched.
+ *
+ * - A channel that has ever completed a sync (`lastSuccessfulSync` set)
+ *   already imported its history with full fan-out — there is no backfill left
+ *   to suppress, so it gets BOTH stamps (a closed window), exactly like
+ *   migration 080 did for polling Outlook channels. Leaving
+ *   `initialBackfillCompletedAt` unset would suppress `message:received` for
+ *   this channel forever under the fail-closed consume side (#1721).
+ * - A channel that never completed a sync still owes its first walk: it gets
+ *   the cutoff alone (an OPEN window — everything in the mailbox right now is
+ *   history), and the walk-end completion stamp closes it.
+ */
+export function planImapBackfillStamps(row: {
+  metadata: unknown
+  lastSuccessfulSync: Date | null
+}): ImapStampPlan {
+  const meta =
+    row.metadata && typeof row.metadata === 'object' && !Array.isArray(row.metadata)
+      ? (row.metadata as Record<string, unknown>)
+      : {}
+  if (meta.backfillCutoffAt || meta.initialBackfillCompletedAt) return 'skip'
+  return row.lastSuccessfulSync ? 'both' : 'cutoff-only'
+}
+
+/**
+ * Stamp the backfill-window metadata onto IMAP channels connected before the
+ * IMAP backfill-suppression fix (skip-events-history §11 G1).
+ *
+ * IMAP channels never had `backfillCutoffAt` / `initialBackfillCompletedAt`.
+ * The fix makes `ImapProvider.initialize` resolve the window FAIL-CLOSED
+ * (neither stamp ⇒ suppress from now, #1721), so without this migration every
+ * existing IMAP channel would enter a fresh suppression window at its next
+ * poll. Stamping per {@link planImapBackfillStamps} keeps already-backfilled
+ * channels fully live and gives never-synced ones a correct open window.
+ *
+ * Disabled channels are included on purpose: disable is pause-and-catch-up
+ * (credentials and cursors kept), and a re-enabled channel with a closed
+ * window resolves to no suppression — its catch-up mail fires normally.
+ *
+ * Raw Drizzle jsonb merge on purpose (data-migration convention, and the
+ * provider's own metadata writes are jsonb merges too, so read-modify-replace
+ * could clobber a concurrent write).
+ */
+export const migration099ImapBackfillStamps: DataMigrationDef = {
+  id: '099-imap-backfill-stamps',
+  description: 'Stamp backfill-window metadata onto pre-fix IMAP channels',
+  async run(db: Database): Promise<void> {
+    const rows = await db
+      .select({
+        id: schema.Integration.id,
+        metadata: schema.Integration.metadata,
+        lastSuccessfulSync: schema.Integration.lastSuccessfulSync,
+      })
+      .from(schema.Integration)
+      .where(and(eq(schema.Integration.provider, 'imap'), isNull(schema.Integration.deletedAt)))
+
+    const summary = { both: 0, cutoffOnly: 0, skipped: 0 }
+
+    for (const row of rows) {
+      const plan = planImapBackfillStamps(row)
+      if (plan === 'skip') {
+        summary.skipped++
+        continue
+      }
+
+      const epochIso = new Date().toISOString()
+      const patch =
+        plan === 'both'
+          ? sql`COALESCE(${schema.Integration.metadata}, '{}'::jsonb) || jsonb_build_object(
+              'backfillCutoffAt', ${epochIso}::text,
+              'initialBackfillCompletedAt', ${epochIso}::text
+            )`
+          : sql`COALESCE(${schema.Integration.metadata}, '{}'::jsonb) || jsonb_build_object('backfillCutoffAt', ${epochIso}::text)`
+
+      await db
+        .update(schema.Integration)
+        .set({ metadata: patch, updatedAt: new Date() })
+        .where(eq(schema.Integration.id, row.id))
+
+      if (plan === 'both') summary.both++
+      else summary.cutoffOnly++
+    }
+
+    logger.info('IMAP backfill stamps complete', summary)
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -63,6 +63,7 @@ import { migration095DropIfElseCaseLegacyId } from './migrations/095-drop-if-els
 import { migration096CurrencyMinorUnits } from './migrations/096-currency-minor-units'
 import { migration097PartSkuUnique } from './migrations/097-part-sku-unique'
 import { migration098PruneOrphanedOptionValues } from './migrations/098-prune-orphaned-option-values'
+import { migration099ImapBackfillStamps } from './migrations/099-imap-backfill-stamps'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -152,6 +153,7 @@ function buildRegistry(): DataMigrationDef[] {
     migration096CurrencyMinorUnits,
     migration097PartSkuUnique,
     migration098PruneOrphanedOptionValues,
+    migration099ImapBackfillStamps,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/jobs/polling/__tests__/messages-import-job.imap.test.ts
+++ b/packages/lib/src/jobs/polling/__tests__/messages-import-job.imap.test.ts
@@ -1,0 +1,210 @@
+// packages/lib/src/jobs/polling/__tests__/messages-import-job.imap.test.ts
+//
+// Two IMAP-specific behaviors of the polling import jobs (skip-events history
+// §11 G1):
+//
+// 1. `imapImportBatchJob` (the folder walk) imports through
+//    `importMessagesInSyncBatch` when the provider offers it — the walk is a
+//    backfill, and per-message realtime must collapse into one
+//    `inbox:syncCompleted` per touched inbox.
+// 2. The `initialBackfillCompletedAt` stamp on the cache-drain path is gated
+//    on the folder walk being complete for IMAP. An IMAP first walk carries
+//    its work in `imapImportBatchJob` payloads, not the Redis cache, so
+//    `messagesImportJob` can drain to IDLE mid-walk — stamping completion
+//    there would reopen `message:received` for the rest of the historical
+//    import. Non-IMAP providers keep the plain drain-to-IDLE stamp.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  selectResults: [] as unknown[][],
+  updates: [] as Array<{ patch: Record<string, unknown>; condition: unknown }>,
+  provider: {} as Record<string, unknown>,
+  claimResult: [] as string[],
+  cacheSize: 0,
+}))
+
+vi.mock('@auxx/database', () => {
+  const makeSelectChain = () => {
+    const chain: Record<string, unknown> = {}
+    for (const method of ['from', 'where', 'leftJoin', 'innerJoin', 'orderBy', 'limit']) {
+      chain[method] = () => chain
+    }
+    // biome-ignore lint/suspicious/noThenProperty: intentional thenable query-builder mock
+    chain.then = (onOk: (v: unknown[]) => unknown, onErr: (e: unknown) => unknown) =>
+      Promise.resolve(h.selectResults.shift() ?? []).then(onOk, onErr)
+    return chain
+  }
+  const column = (name: string) => ({ columnName: name })
+  return {
+    database: {
+      select: () => makeSelectChain(),
+      update: () => ({
+        set: (patch: Record<string, unknown>) => ({
+          where: async (condition: unknown) => {
+            h.updates.push({ patch, condition })
+          },
+        }),
+      }),
+    },
+    schema: {
+      Integration: {
+        id: column('Integration.id'),
+        metadata: column('Integration.metadata'),
+        syncStage: column('Integration.syncStage'),
+        syncStatus: column('Integration.syncStatus'),
+        syncStageStartedAt: column('Integration.syncStageStartedAt'),
+        throttleFailureCount: column('Integration.throttleFailureCount'),
+        throttleRetryAfter: column('Integration.throttleRetryAfter'),
+        lastSyncedAt: column('Integration.lastSyncedAt'),
+        lastSuccessfulSync: column('Integration.lastSuccessfulSync'),
+        updatedAt: column('Integration.updatedAt'),
+        deletedAt: column('Integration.deletedAt'),
+      },
+      Label: {
+        id: column('Label.id'),
+        integrationId: column('Label.integrationId'),
+        enabled: column('Label.enabled'),
+        syncCheckpoint: column('Label.syncCheckpoint'),
+        updatedAt: column('Label.updatedAt'),
+      },
+    },
+  }
+})
+
+vi.mock('../../../email/polling-import-cache', () => ({
+  claimImportBatch: vi.fn(async () => h.claimResult),
+  acknowledgeImportBatch: vi.fn(async () => {}),
+  getImportCacheSize: vi.fn(async () => h.cacheSize),
+  recoverProcessingBatch: vi.fn(async () => 0),
+}))
+
+vi.mock('../../../providers/provider-registry-service', () => ({
+  ProviderRegistryService: class {
+    async getProvider() {
+      return h.provider
+    }
+  },
+}))
+
+vi.mock('../../queues', () => ({ getQueue: () => ({ add: vi.fn(async () => {}) }) }))
+
+import { imapImportBatchJob, messagesImportJob } from '../messages-import-job'
+
+/** Every literal string inside a built Drizzle SQL / condition object. */
+function flatten(node: unknown, out: string[] = [], depth = 0): string {
+  if (depth > 10 || node === null || node === undefined) return out.join(' ')
+  if (typeof node === 'string') {
+    out.push(node)
+    return out.join(' ')
+  }
+  if (typeof node === 'object') {
+    for (const value of Object.values(node as Record<string, unknown>)) {
+      flatten(value, out, depth + 1)
+    }
+  }
+  return out.join(' ')
+}
+
+const stampUpdates = () =>
+  h.updates.filter((u) => flatten(u.patch.metadata).includes('initialBackfillCompletedAt'))
+
+const activeCheckpoint = JSON.stringify({
+  runId: 'run-1',
+  phase: 'importing',
+  activeWindowBatchCount: 5,
+  activeWindowCompletedBatches: 0,
+  snapshotHighestUid: 5000,
+  importedMessageCount: 0,
+  failedMessageCount: 0,
+  candidateCursor: '1:5000',
+})
+
+const jobCtx = (data: Record<string, unknown>) =>
+  ({
+    job: { id: 'job-1', data, opts: { attempts: 1 }, attemptsMade: 0 },
+    signal: undefined,
+  }) as never
+
+beforeEach(() => {
+  h.selectResults.length = 0
+  h.updates.length = 0
+  h.claimResult = []
+  h.cacheSize = 0
+  h.provider = {}
+})
+
+describe('imapImportBatchJob — folder walk enters the sync batch', () => {
+  const batchData = {
+    runId: 'run-1',
+    integrationId: 'int-1',
+    organizationId: 'org-1',
+    provider: 'imap',
+    labelId: 'label-1',
+    folderPath: 'INBOX',
+    externalIds: ['uid-1', 'uid-2'],
+  }
+
+  it('prefers importMessagesInSyncBatch over importMessages', async () => {
+    const importMessages = vi.fn(async () => ({ imported: 2, failed: 0 }))
+    const importMessagesInSyncBatch = vi.fn(async () => ({ imported: 2, failed: 0 }))
+    h.provider = { importMessages, importMessagesInSyncBatch }
+    // Label checkpoint fetch (mid-walk), then the idle-transition label scan.
+    h.selectResults.push(
+      [{ syncCheckpoint: activeCheckpoint }],
+      [{ syncCheckpoint: activeCheckpoint }]
+    )
+
+    await imapImportBatchJob(jobCtx(batchData))
+
+    expect(importMessagesInSyncBatch).toHaveBeenCalledWith(['uid-1', 'uid-2'])
+    expect(importMessages).not.toHaveBeenCalled()
+  })
+
+  it('falls back to importMessages when the batched method is absent', async () => {
+    const importMessages = vi.fn(async () => ({ imported: 2, failed: 0 }))
+    h.provider = { importMessages }
+    h.selectResults.push(
+      [{ syncCheckpoint: activeCheckpoint }],
+      [{ syncCheckpoint: activeCheckpoint }]
+    )
+
+    await imapImportBatchJob(jobCtx(batchData))
+
+    expect(importMessages).toHaveBeenCalledWith(['uid-1', 'uid-2'])
+  })
+})
+
+describe('messagesImportJob — IMAP completion stamp is walk-gated', () => {
+  const importData = { integrationId: 'int-1', organizationId: 'org-1', provider: 'imap' }
+
+  it('does NOT stamp completion on a cache drain while the folder walk is mid-flight', async () => {
+    h.claimResult = [] // cache drained -> IDLE transition
+    // stampBackfillCompletedIfWalkDone's label scan: one folder still importing.
+    h.selectResults.push([{ syncCheckpoint: activeCheckpoint }])
+
+    await messagesImportJob(jobCtx(importData))
+
+    expect(stampUpdates()).toEqual([])
+  })
+
+  it('stamps completion once the walk is done', async () => {
+    h.claimResult = []
+    h.selectResults.push([{ syncCheckpoint: null }])
+
+    await messagesImportJob(jobCtx(importData))
+
+    expect(stampUpdates()).toHaveLength(1)
+  })
+
+  it('keeps the plain drain-to-IDLE stamp for non-IMAP providers', async () => {
+    h.claimResult = []
+    // No label scan happens for google — any queued select result would go unused.
+
+    await messagesImportJob(
+      jobCtx({ integrationId: 'int-1', organizationId: 'org-1', provider: 'google' })
+    )
+
+    expect(stampUpdates()).toHaveLength(1)
+  })
+})

--- a/packages/lib/src/jobs/polling/message-list-fetch-job.ts
+++ b/packages/lib/src/jobs/polling/message-list-fetch-job.ts
@@ -15,6 +15,7 @@ import { ProviderRegistryService } from '../../providers/provider-registry-servi
 import { getQueue } from '../queues'
 import { Queues } from '../queues/types'
 import type { JobContext } from '../types'
+import { stampInitialBackfillCompleted } from './messages-import-job'
 
 const logger = createScopedLogger('job:message-list-fetch')
 
@@ -403,6 +404,12 @@ async function handleImapListFetch(
           updatedAt: now,
         })
         .where(eq(schema.Integration.id, integrationId))
+
+      // A walk with nothing to import (empty mailbox, or all folders already
+      // cursored) never runs an import job, so this is its only completion
+      // point — close the `message:received` suppression window opened at
+      // connect (no-op unless a cutoff is stamped and completion is not).
+      await stampInitialBackfillCompleted(integrationId, now)
 
       logger.info('IMAP list fetch complete, all folders synced, transitioning to IDLE', {
         integrationId,

--- a/packages/lib/src/jobs/polling/messages-import-job.ts
+++ b/packages/lib/src/jobs/polling/messages-import-job.ts
@@ -14,6 +14,7 @@ import {
   PROVIDER_IMPORT_BATCH_SIZE,
 } from '../../providers/channel-provider.interface'
 import type { ImapFolderCheckpoint, ImapImportBatchJobData } from '../../providers/imap/types'
+import { isImapWalkComplete } from '../../providers/imap/utils/walk-complete'
 import { ProviderRegistryService } from '../../providers/provider-registry-service'
 import { getQueue } from '../queues'
 import { Queues } from '../queues/types'
@@ -36,9 +37,16 @@ const BASE_THROTTLE_BACKOFF_MS = 30_000
  * Guarded to a no-op unless the row has a cutoff stamp and no completion stamp
  * yet, so ordinary polling cycles (every later IDLE transition) never rewrite
  * it. Provider-agnostic on purpose — only rows a provider has actually stamped
- * `backfillCutoffAt` on (Outlook always; Gmail on its polling path) ever match.
+ * `backfillCutoffAt` on (Outlook always; Gmail on its polling path; IMAP at
+ * connect / fail-closed initialize) ever match.
+ *
+ * Exported for the IMAP completion points (`maybeTransitionImapToIdle` below
+ * and the zero-message walk in `message-list-fetch-job.ts`).
  */
-async function stampInitialBackfillCompleted(integrationId: string, now: Date): Promise<void> {
+export async function stampInitialBackfillCompleted(
+  integrationId: string,
+  now: Date
+): Promise<void> {
   await db
     .update(schema.Integration)
     .set({
@@ -52,6 +60,30 @@ async function stampInitialBackfillCompleted(integrationId: string, now: Date): 
         sql`NOT jsonb_exists(COALESCE(${schema.Integration.metadata}, '{}'::jsonb), 'initialBackfillCompletedAt')`
       )
     )
+}
+
+/**
+ * IMAP-aware wrapper for the completion stamp. The cache-drain path can hit
+ * IDLE while an IMAP folder walk is still mid-flight — an IMAP first walk
+ * carries its work in `imapImportBatchJob` payloads, not the Redis cache, so
+ * `claimImportBatch` returning empty proves nothing about the walk. Stamping
+ * `initialBackfillCompletedAt` at that moment would reopen `message:received`
+ * for the remainder of the historical walk. For every other provider the
+ * cache IS the backfill, so drain-to-IDLE remains the completion point.
+ */
+async function stampBackfillCompletedIfWalkDone(
+  integrationId: string,
+  provider: string,
+  now: Date
+): Promise<void> {
+  if (provider === 'imap') {
+    const labels = await db
+      .select({ syncCheckpoint: schema.Label.syncCheckpoint })
+      .from(schema.Label)
+      .where(and(eq(schema.Label.integrationId, integrationId), eq(schema.Label.enabled, true)))
+    if (!isImapWalkComplete(labels)) return
+  }
+  await stampInitialBackfillCompleted(integrationId, now)
 }
 
 export interface MessagesImportJobData {
@@ -107,7 +139,7 @@ export const messagesImportJob = async (ctx: JobContext<MessagesImportJobData>) 
           updatedAt: now,
         })
         .where(eq(schema.Integration.id, integrationId))
-      await stampInitialBackfillCompleted(integrationId, now)
+      await stampBackfillCompletedIfWalkDone(integrationId, provider, now)
 
       logger.info('No IDs remaining in import cache, transitioning to IDLE', { integrationId })
       return
@@ -167,7 +199,7 @@ export const messagesImportJob = async (ctx: JobContext<MessagesImportJobData>) 
           updatedAt: now,
         })
         .where(eq(schema.Integration.id, integrationId))
-      await stampInitialBackfillCompleted(integrationId, now)
+      await stampBackfillCompletedIfWalkDone(integrationId, provider, now)
 
       logger.info('All IDs imported, transitioning to IDLE', { integrationId })
     }
@@ -274,7 +306,14 @@ export const imapImportBatchJob = async (ctx: JobContext<ImapImportBatchJobData>
       throw new Error('IMAP provider does not support importMessages')
     }
 
-    const result = await providerInstance.importMessages(externalIds)
+    // The folder walk is a backfill: import inside the realtime sync batch
+    // (`ctx.inSyncBatch`) so N historical messages emit one
+    // `inbox:syncCompleted` per touched inbox instead of N socket frames.
+    // Steady-state IMAP mail routes through `messagesImportJob` (Redis cache)
+    // and keeps `importMessages`' per-message realtime.
+    const result = providerInstance.importMessagesInSyncBatch
+      ? await providerInstance.importMessagesInSyncBatch(externalIds)
+      : await providerInstance.importMessages(externalIds)
 
     logger.info('IMAP import batch completed', {
       integrationId,
@@ -472,13 +511,7 @@ async function maybeTransitionImapToIdle(integrationId: string, now: Date): Prom
     .from(schema.Label)
     .where(and(eq(schema.Label.integrationId, integrationId), eq(schema.Label.enabled, true)))
 
-  const hasActiveCheckpoints = labels.some((l) => {
-    if (!l.syncCheckpoint) return false
-    const cp: ImapFolderCheckpoint = JSON.parse(l.syncCheckpoint)
-    return cp.phase !== 'done'
-  })
-
-  if (!hasActiveCheckpoints) {
+  if (isImapWalkComplete(labels)) {
     // Check if there's still incremental work in the Redis cache
     const remaining = await getImportCacheSize(integrationId)
 
@@ -500,6 +533,11 @@ async function maybeTransitionImapToIdle(integrationId: string, now: Date): Prom
         updatedAt: now,
       })
       .where(eq(schema.Integration.id, integrationId))
+
+    // The walk end is IMAP's backfill completion point — close the
+    // `message:received` suppression window opened at connect (no-op unless
+    // the row has a cutoff and no completion stamp yet).
+    await stampInitialBackfillCompleted(integrationId, now)
 
     logger.info('All IMAP folders synced, transitioning to IDLE', { integrationId })
   }

--- a/packages/lib/src/providers/channel-provider.interface.ts
+++ b/packages/lib/src/providers/channel-provider.interface.ts
@@ -286,6 +286,18 @@ export interface ChannelProvider {
   importMessages?(externalIds: string[]): Promise<{ imported: number; failed: number }>
 
   /**
+   * Same contract as `importMessages`, but run inside a realtime sync batch:
+   * per-message realtime publishes are suppressed and one `inbox:syncCompleted`
+   * per touched inbox is emitted at the end (`ctx.inSyncBatch`). Backfill
+   * walkers that carry their work outside the Redis import cache (IMAP's
+   * windowed folder walk) call this so a first scan does not fan out one
+   * socket frame per historical message. Optional — providers whose
+   * `importMessages` already enters the batch context internally (Gmail /
+   * Outlook via `storeBatchWithIngest`) don't need it.
+   */
+  importMessagesInSyncBatch?(externalIds: string[]): Promise<{ imported: number; failed: number }>
+
+  /**
    * Discover labels/folders from the provider for sync.
    * Returns discovered labels to be upserted against the Label table.
    * Optional — providers that don't implement this skip label sync.

--- a/packages/lib/src/providers/imap/__tests__/imap-backfill-cutoff.test.ts
+++ b/packages/lib/src/providers/imap/__tests__/imap-backfill-cutoff.test.ts
@@ -1,0 +1,74 @@
+// packages/lib/src/providers/imap/__tests__/imap-backfill-cutoff.test.ts
+//
+// The fail-closed backfill-window resolver for IMAP channels (skip-events
+// history §11 G1 / the #1721 rule). The dangerous reading is the old
+// `backfillCutoffAt && !initialBackfillCompletedAt`, which hands a channel
+// with NEITHER stamp no suppression at all — so a first folder walk would
+// publish `message:received` (workflows, billed classification, filters,
+// signals) for every historical message. The resolver must suppress from
+// "now" instead, and flag that the computed cutoff needs a durable stamp so
+// the completion stamp can ever close the window (#1587).
+
+import { describe, expect, it } from 'vitest'
+import { resolveImapBackfillCutoff } from '../imap-backfill-cutoff'
+
+describe('resolveImapBackfillCutoff', () => {
+  it('arms the stored cutoff while the backfill is incomplete', () => {
+    const stamped = '2026-08-20T10:00:00.000Z'
+    const window = resolveImapBackfillCutoff({ backfillCutoffAt: stamped })
+
+    expect(window.cutoff).toEqual(new Date(stamped))
+    // Already durable — initialize must not rewrite it (insert-only stamp).
+    expect(window.needsDurableStamp).toBe(false)
+  })
+
+  it('opens the gate only on an explicit completion stamp', () => {
+    const window = resolveImapBackfillCutoff({
+      backfillCutoffAt: '2026-08-20T10:00:00.000Z',
+      initialBackfillCompletedAt: '2026-08-20T11:00:00.000Z',
+    })
+
+    expect(window.cutoff).toBeNull()
+    expect(window.needsDurableStamp).toBe(false)
+  })
+
+  it('fails CLOSED for a channel with neither stamp — cutoff "now", to be stamped durably', () => {
+    const before = Date.now()
+    const window = resolveImapBackfillCutoff({ email: 'ops@example.com' })
+    const after = Date.now()
+
+    expect(window.cutoff).not.toBeNull()
+    expect(window.cutoff!.getTime()).toBeGreaterThanOrEqual(before)
+    expect(window.cutoff!.getTime()).toBeLessThanOrEqual(after)
+    // Without the durable write-back the completion stamp (guarded on
+    // `backfillCutoffAt` existing) could never land, and the window would
+    // drift forward forever — the #1587 incident class.
+    expect(window.needsDurableStamp).toBe(true)
+  })
+
+  it('treats completed-without-cutoff as a closed window', () => {
+    // Migration 099 stamps both, but insert-only history means a row could in
+    // principle carry only the completion stamp — completion always wins.
+    const window = resolveImapBackfillCutoff({
+      initialBackfillCompletedAt: '2026-08-20T11:00:00.000Z',
+    })
+
+    expect(window.cutoff).toBeNull()
+    expect(window.needsDurableStamp).toBe(false)
+  })
+
+  it('fails closed on missing or malformed metadata', () => {
+    for (const metadata of [null, undefined, 'garbage', 42, ['not', 'an', 'object'], {}]) {
+      const window = resolveImapBackfillCutoff(metadata)
+      expect(window.cutoff).toBeInstanceOf(Date)
+      expect(window.needsDurableStamp).toBe(true)
+    }
+  })
+
+  it('ignores a non-string cutoff value rather than arming an Invalid Date', () => {
+    const window = resolveImapBackfillCutoff({ backfillCutoffAt: { nested: true } })
+    expect(window.cutoff).toBeInstanceOf(Date)
+    expect(Number.isNaN(window.cutoff!.getTime())).toBe(false)
+    expect(window.needsDurableStamp).toBe(true)
+  })
+})

--- a/packages/lib/src/providers/imap/__tests__/imap-provider-sync-batch.test.ts
+++ b/packages/lib/src/providers/imap/__tests__/imap-provider-sync-batch.test.ts
@@ -1,0 +1,51 @@
+// packages/lib/src/providers/imap/__tests__/imap-provider-sync-batch.test.ts
+//
+// `importMessagesInSyncBatch` is the seam that puts the IMAP folder walk into
+// the realtime sync-batch context (`ctx.inSyncBatch`) — the same
+// `runInSyncBatch` Gmail/Outlook enter via their ingestors — so a 5,000-message
+// first scan emits one `inbox:syncCompleted` per touched inbox instead of
+// 5,000 per-message socket frames. The steady-state path keeps calling
+// `importMessages` directly, so live IMAP mail retains per-message realtime.
+
+import { describe, expect, it, vi } from 'vitest'
+
+// Keep the module graph light: the ImapProvider class file pulls in imapflow /
+// ldap / nodemailer service classes and the ingest pipeline via
+// MessageStorageService — none of which this seam test needs.
+vi.mock('../imap-client-provider', () => ({ ImapClientProvider: class {} }))
+vi.mock('../imap-get-message-list', () => ({ ImapGetMessageListService: class {} }))
+vi.mock('../imap-get-messages', () => ({ ImapGetMessagesService: class {} }))
+vi.mock('../imap-get-all-folders', () => ({ ImapGetAllFoldersService: class {} }))
+vi.mock('../imap-send-message', () => ({ ImapSmtpSendService: class {} }))
+vi.mock('../ldap-auth-service', () => ({ LdapAuthService: class {} }))
+vi.mock('../../../email/email-storage', () => ({ MessageStorageService: class {} }))
+vi.mock('@auxx/credentials/store', () => ({ revealSecrets: vi.fn() }))
+
+import { ImapProvider } from '../imap-provider'
+
+describe('ImapProvider.importMessagesInSyncBatch', () => {
+  it('runs importMessages inside runInSyncBatch for this org and returns its result', async () => {
+    const provider = new ImapProvider('org_1')
+    const events: string[] = []
+
+    const runInSyncBatch = vi.fn(async (organizationId: string, fn: () => Promise<unknown>) => {
+      events.push(`enter:${organizationId}`)
+      const out = await fn()
+      events.push('exit')
+      return out
+    })
+    ;(provider as unknown as { storageService: unknown }).storageService = { runInSyncBatch }
+
+    vi.spyOn(provider, 'importMessages').mockImplementation(async (externalIds: string[]) => {
+      events.push(`import:${externalIds.join(',')}`)
+      return { imported: externalIds.length, failed: 0 }
+    })
+
+    const result = await provider.importMessagesInSyncBatch(['uid-1', 'uid-2'])
+
+    expect(result).toEqual({ imported: 2, failed: 0 })
+    // The import ran INSIDE the batch context — realtime suppression covers
+    // every storeMessage of the batch, and the flush happens after.
+    expect(events).toEqual(['enter:org_1', 'import:uid-1,uid-2', 'exit'])
+  })
+})

--- a/packages/lib/src/providers/imap/imap-backfill-cutoff.ts
+++ b/packages/lib/src/providers/imap/imap-backfill-cutoff.ts
@@ -1,0 +1,49 @@
+// packages/lib/src/providers/imap/imap-backfill-cutoff.ts
+//
+// The consume half of the received-time backfill cutoff for IMAP channels —
+// the same contract Google/Outlook arm in their `initialize()` and the social
+// providers resolve via `resolveSocialBackfillCutoff`. Like the social
+// resolver (#1721), this FAILS CLOSED: a channel with neither
+// `metadata.backfillCutoffAt` nor `metadata.initialBackfillCompletedAt` gets a
+// cutoff of "now" rather than no suppression at all. The two failure modes are
+// not symmetric — suppressing when we did not need to costs missed trigger
+// fires on messages that are history by definition; not suppressing when we
+// needed to fires thousands of workflow runs and billed classifications at
+// real customer mail.
+
+/** What `ImapProvider.initialize` should do about the backfill window. */
+export interface ImapBackfillWindow {
+  /**
+   * The received-time cutoff to arm on the storage service, or `null` when the
+   * initial backfill has completed (only an explicit
+   * `initialBackfillCompletedAt` opens the gate).
+   */
+  cutoff: Date | null
+  /**
+   * True when the channel had NEITHER stamp and the computed "now" cutoff must
+   * be written back onto `Integration.metadata`. A merely-computed cutoff would
+   * drift forward on every `initialize()` — suppressing mail that arrived
+   * between poll cycles — and the completion stamp
+   * (`stampInitialBackfillCompleted`) is guarded on `backfillCutoffAt`
+   * existing, so an unstamped window could never close (the #1587 incident
+   * class). The caller stamps it durably, after which the window closes at the
+   * next full drain.
+   */
+  needsDurableStamp: boolean
+}
+
+/**
+ * Resolve the backfill window from `Integration.metadata`. Pure — the caller
+ * owns the durable stamp write when `needsDurableStamp` is set.
+ */
+export function resolveImapBackfillCutoff(metadata: unknown): ImapBackfillWindow {
+  const meta =
+    metadata && typeof metadata === 'object' && !Array.isArray(metadata)
+      ? (metadata as Record<string, unknown>)
+      : {}
+  if (meta.initialBackfillCompletedAt) return { cutoff: null, needsDurableStamp: false }
+  if (typeof meta.backfillCutoffAt === 'string' && meta.backfillCutoffAt) {
+    return { cutoff: new Date(meta.backfillCutoffAt), needsDurableStamp: false }
+  }
+  return { cutoff: new Date(), needsDurableStamp: true }
+}

--- a/packages/lib/src/providers/imap/imap-provider.ts
+++ b/packages/lib/src/providers/imap/imap-provider.ts
@@ -4,7 +4,7 @@ import { revealSecrets } from '@auxx/credentials/store'
 import { database as db, schema } from '@auxx/database'
 import { IdentifierType as IdentifierTypeEnum, IntegrationProviderType } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import { MessageStorageService } from '../../email/email-storage'
 import { NotFoundError } from '../../errors'
 import type {
@@ -15,6 +15,7 @@ import type {
 } from '../channel-provider.interface'
 import { BaseMessageProvider, type MessageProvider } from '../message-provider-interface'
 import { getProviderCapabilities, type ProviderCapabilities } from '../provider-capabilities'
+import { resolveImapBackfillCutoff } from './imap-backfill-cutoff'
 import { ImapClientProvider } from './imap-client-provider'
 import { ImapGetAllFoldersService } from './imap-get-all-folders'
 import { ImapGetMessageListService } from './imap-get-message-list'
@@ -133,6 +134,31 @@ export class ImapProvider extends BaseMessageProvider implements ChannelProvider
       this.storageService.setOwnIdentities({ [IdentifierTypeEnum.EMAIL]: [integration.email] })
     }
 
+    // Received-time trigger cutoff (webhook-push-migration plan Phase 2.5,
+    // extended to IMAP): while the initial backfill is incomplete, ingest
+    // suppresses `message:received` for mail received before the cutoff —
+    // regardless of which sync walker ingested it (invariant 25). Resolution
+    // fails CLOSED (#1721): a channel with neither stamp gets a cutoff of
+    // "now", written back durably so the completion stamp in
+    // `messages-import-job.ts` can find the window and close it at the next
+    // full drain — a merely-computed cutoff would drift forward on every
+    // initialize and the window could never close (#1587).
+    const backfillWindow = resolveImapBackfillCutoff(integration.metadata)
+    if (backfillWindow.needsDurableStamp && backfillWindow.cutoff) {
+      await db
+        .update(schema.Integration)
+        .set({
+          metadata: sql`COALESCE(${schema.Integration.metadata}, '{}'::jsonb) || jsonb_build_object('backfillCutoffAt', ${backfillWindow.cutoff.toISOString()}::text)`,
+          updatedAt: new Date(),
+        })
+        .where(eq(schema.Integration.id, integrationId))
+      logger.warn('IMAP channel had no backfillCutoffAt — stamping one before syncing', {
+        integrationId,
+        cutoffAt: backfillWindow.cutoff.toISOString(),
+      })
+    }
+    this.storageService.setBackfillCutoff(backfillWindow.cutoff)
+
     logger.info(`ImapProvider initialized for ${integration.email}`)
   }
 
@@ -186,6 +212,23 @@ export class ImapProvider extends BaseMessageProvider implements ChannelProvider
     }
 
     return { imported, failed }
+  }
+
+  /**
+   * Folder-walk import: same contract as `importMessages`, but run inside a
+   * realtime sync batch — per-message `message:created`/`thread:created`
+   * publishes are suppressed and one `inbox:syncCompleted` per touched inbox
+   * (plus a stale-count mark) is emitted at the end, so a 5,000-message walk
+   * does not fan out 5,000 socket frames. Used by `imapImportBatchJob` (the
+   * windowed full sync); the steady-state cache path keeps calling
+   * `importMessages` directly so live mail retains per-message realtime.
+   */
+  async importMessagesInSyncBatch(
+    externalIds: string[]
+  ): Promise<{ imported: number; failed: number }> {
+    return this.storageService.runInSyncBatch(this.organizationId, () =>
+      this.importMessages(externalIds)
+    )
   }
 
   async discoverLabels(): Promise<

--- a/packages/lib/src/providers/imap/utils/__tests__/walk-complete.test.ts
+++ b/packages/lib/src/providers/imap/utils/__tests__/walk-complete.test.ts
@@ -1,0 +1,37 @@
+// packages/lib/src/providers/imap/utils/__tests__/walk-complete.test.ts
+//
+// The walk-complete predicate gates BOTH the IDLE transition and the
+// `initialBackfillCompletedAt` stamp. The stamp side is the one with teeth:
+// an IMAP first walk carries its work in `imapImportBatchJob` payloads, not
+// the Redis import cache, so the cache-drain path can go IDLE mid-walk — and
+// stamping completion at that moment would reopen `message:received` for the
+// rest of the historical import.
+
+import { describe, expect, it } from 'vitest'
+import { isImapWalkComplete } from '../walk-complete'
+
+const checkpoint = (phase: 'listing' | 'importing' | 'done') =>
+  JSON.stringify({ runId: 'run-1', phase })
+
+describe('isImapWalkComplete', () => {
+  it('is complete when no label carries a checkpoint', () => {
+    expect(isImapWalkComplete([])).toBe(true)
+    expect(isImapWalkComplete([{ syncCheckpoint: null }])).toBe(true)
+  })
+
+  it('is complete when every checkpoint is done', () => {
+    expect(
+      isImapWalkComplete([{ syncCheckpoint: checkpoint('done') }, { syncCheckpoint: null }])
+    ).toBe(true)
+  })
+
+  it('is incomplete while any folder is still listing or importing', () => {
+    expect(
+      isImapWalkComplete([
+        { syncCheckpoint: checkpoint('done') },
+        { syncCheckpoint: checkpoint('listing') },
+      ])
+    ).toBe(false)
+    expect(isImapWalkComplete([{ syncCheckpoint: checkpoint('importing') }])).toBe(false)
+  })
+})

--- a/packages/lib/src/providers/imap/utils/walk-complete.ts
+++ b/packages/lib/src/providers/imap/utils/walk-complete.ts
@@ -1,0 +1,24 @@
+// packages/lib/src/providers/imap/utils/walk-complete.ts
+
+import type { ImapFolderCheckpoint } from '../types'
+
+/**
+ * Whether the IMAP windowed full sync ("folder walk") has finished for every
+ * folder: no enabled label carries a checkpoint whose phase is not `'done'`.
+ * A committed folder has its checkpoint cleared entirely (`null`), which also
+ * counts as complete.
+ *
+ * Shared by `maybeTransitionImapToIdle` (which flips the integration to IDLE)
+ * and the backfill completion stamp in `messagesImportJob` — the cache-drain
+ * path can go IDLE while folder-walk batches are still in flight (an IMAP
+ * first walk carries its work in `imapImportBatchJob` payloads, not the Redis
+ * cache), and stamping `initialBackfillCompletedAt` at that moment would
+ * reopen `message:received` for the rest of the historical walk.
+ */
+export function isImapWalkComplete(labels: Array<{ syncCheckpoint: string | null }>): boolean {
+  return !labels.some((label) => {
+    if (!label.syncCheckpoint) return false
+    const checkpoint: ImapFolderCheckpoint = JSON.parse(label.syncCheckpoint)
+    return checkpoint.phase !== 'done'
+  })
+}


### PR DESCRIPTION
## Summary

Closes gap **G1** from `docs/skip-events-history.md` §11: IMAP had none of the mail lane's three backfill-suppression mechanisms — a first folder scan fired `message:received` per historical message (workflow triggers, billed classification, mail filters, signals) AND one realtime publish per message. All three mechanisms are now wired, reusing the existing machinery, no parallel inventions.

- **`backfillCutoffAt`**: stamped at IMAP's actual provisioning point — the `connectImap` mutation (`channel.ts:934`; IMAP never passes through the OAuth `provisioning-hook.ts`, verified against all 9 Integration insert sites). Consume side fails closed per #1721 (`resolveImapBackfillCutoff`, mirroring the social resolver: neither stamp ⇒ suppress from now), with a durable self-heal stamp at `initialize` so an unstamped window can neither drift forward per-initialize nor stay open forever (the #1587 class).
- **`initialBackfillCompletedAt`**: stamped where IMAP's walk *genuinely* completes — walk end, the zero-message walk (empty mailbox goes straight to IDLE without an import job), and the cache-drain path now **gated on walk completion for IMAP**: IMAP's backfill bypasses the Redis import cache, so an empty cache proves nothing and the old drain-to-IDLE stamp would have fired mid-walk, reopening `message:received` for the rest of the historical import. Non-IMAP providers keep byte-identical behavior. The stamp's SQL guard makes every site idempotent.
- **`inSyncBatch`**: a new optional `importMessagesInSyncBatch` on the provider interface, implemented by IMAP as `runInSyncBatch(...)` around the walk imports — one `inbox:syncCompleted` + stale-count mark per touched inbox instead of per-message frames. Steady-state IMAP mail keeps per-message behavior; `isInitialSync` is never touched (invariant 25 — suppression stays received-time-based).
- **Migration `099-imap-backfill-stamps`** (next free id across both migration id spaces): previously-synced channels get BOTH stamps (closed window — the migration-080 rationale: leaving completion unset suppresses forever under fail-closed); never-synced get the cutoff only (window closes at walk end). Disabled channels included — disable is pause-and-catch-up, and a closed window lets their catch-up mail fire normally.

## Test plan

5 new test files / 29 tests: fail-closed resolver matrix, walk-complete predicate, provider batch delegation, job-level (batched import preferred + fallback; mid-walk drain does NOT stamp; walk-done drain stamps; Google path unchanged), migration planner + idempotent re-run. Full `src/channels`, `src/providers`, `src/ingest`, `src/data-migrations`, `src/jobs` suites: 1,139+ tests, 0 failed. Scoped tsc: zero errors in touched files. Requires `pnpm db:migrate`-style data-migration run on deploy as usual (migration 099 is a DataMigration, runner-executed).