### PR TITLE
feat(events): per-field timeline entries for small sync runs

### DIFF
--- a/packages/lib/src/events/handlers/sync-finalize.test.ts
+++ b/packages/lib/src/events/handlers/sync-finalize.test.ts
@@ -1,8 +1,9 @@
 // packages/lib/src/events/handlers/sync-finalize.test.ts
 // Phase 4 sync finalize (plan events/03 §8, D-12): count-based lane selection,
-// activity touch, collapsed timeline bulk insert, small-lane dispatch, tier-2
-// frames, and the never-throws contract. Boundaries (activity/cache/dispatch/
-// realtime/drizzle) mocked; the pure lane + count helpers run for real.
+// activity touch, timeline bulk insert (small lane: per-field replay; large
+// lane: collapsed per D-4), small-lane dispatch, tier-2 frames, and the
+// never-throws contract. Boundaries (activity/cache/dispatch/realtime/drizzle)
+// mocked; the pure lane + count helpers run for real.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SyncChangeManifest } from '../../record-rules/sync-manifest-types'
@@ -163,13 +164,14 @@ describe('runSyncFinalize — small lane', () => {
     expect([...ids].sort()).toEqual(['i1', 'i2', 'i3', 'i4'])
   })
 
-  it('bulk-inserts one collapsed timeline entry per record, attributed to the run actor', async () => {
+  it('bulk-inserts per-field rows for changed records + collapsed created/archived, attributed to the run actor', async () => {
     await runSyncFinalize(
       fakeDb({ connectorCreatedById: 'user_1' }),
       connectorInput(smallManifest())
     )
     const rows = insertedRows()
-    expect(rows).toHaveLength(5)
+    // 3 changed fields across i1 + i2, plus created i3/i4 and archived i5.
+    expect(rows).toHaveLength(6)
     const byId = new Map(rows.map((r) => [r.entityId, r]))
     expect(byId.get('i3')).toMatchObject({ eventType: 'entity:created', entityType: 'def_1' })
     // Slug-keyed def canonicalized for the timeline keyspace.
@@ -177,16 +179,43 @@ describe('runSyncFinalize — small lane', () => {
       eventType: 'entity:created',
       entityType: 'def_cuid_part',
     })
-    expect(byId.get('i1')).toMatchObject({
-      eventType: 'entity:updated',
+    expect(byId.get('i5')).toMatchObject({ eventType: 'entity:archived' })
+
+    // Per-field replay for i1: one `entity:field:updated` row per changed
+    // field, mirroring the inline mapFieldUpdated shape (related custom_field
+    // pointer, fieldId in eventData, raw o/n pair in `changes`).
+    const i1Rows = rows.filter((r) => r.entityId === 'i1')
+    expect(i1Rows).toHaveLength(2)
+    const byField = new Map(i1Rows.map((r) => [r.relatedEntityId, r]))
+    expect(byField.get('fld_a')).toMatchObject({
+      eventType: 'entity:field:updated',
+      entityType: 'def_1',
+      relatedEntityType: 'custom_field',
+      relatedEntityId: 'fld_a',
       eventData: expect.objectContaining({
-        changedFieldIds: ['fld_a', 'fld_b'],
-        changedFieldCount: 2,
+        recordId: 'def_1:i1',
+        entityDefinitionId: 'def_1',
+        fieldId: 'fld_a',
         syncSource: 'connector',
         syncRef: 'run_1',
       }),
+      changes: [{ field: 'fld_a', oldValue: 1, newValue: 2 }],
     })
-    expect(byId.get('i5')).toMatchObject({ eventType: 'entity:archived' })
+    // No captured old value → no oldValue key (absence, not null).
+    expect(byField.get('fld_b')).toMatchObject({
+      eventType: 'entity:field:updated',
+      changes: [{ field: 'fld_b', newValue: 'x' }],
+    })
+    expect((byField.get('fld_b')!.changes as Array<Record<string, unknown>>)[0]).not.toHaveProperty(
+      'oldValue'
+    )
+    // A captured null old value IS carried (o: null on i2's fld_a).
+    expect(byId.get('i2')).toMatchObject({
+      eventType: 'entity:field:updated',
+      changes: [{ field: 'fld_a', oldValue: null, newValue: 3 }],
+    })
+    // No collapsed entity:updated rows remain on the small lane.
+    expect(rows.some((r) => r.eventType === 'entity:updated')).toBe(false)
     for (const row of rows) {
       expect(row).toMatchObject({ actorType: 'user', actorId: 'user_1', organizationId: ORG })
     }
@@ -266,7 +295,16 @@ describe('runSyncFinalize — large lane', () => {
     })
     expect((guardInput.updatedIds as string[]).length).toBe(SYNC_SMALL_RUN_THRESHOLD + 1)
     expect(h.touchEntityActivity).toHaveBeenCalled()
-    expect(insertedRows()).toHaveLength(SYNC_SMALL_RUN_THRESHOLD + 1)
+    // The large lane keeps EXACTLY one collapsed entity:updated row per record
+    // (D-4) — the per-field replay is a small-lane upgrade only.
+    const rows = insertedRows()
+    expect(rows).toHaveLength(SYNC_SMALL_RUN_THRESHOLD + 1)
+    for (const row of rows) {
+      expect(row).toMatchObject({
+        eventType: 'entity:updated',
+        eventData: expect.objectContaining({ changedFieldIds: ['fld_a'], changedFieldCount: 1 }),
+      })
+    }
     expect(h.publishRecordsChanged).toHaveBeenCalledTimes(1)
   })
 

--- a/packages/lib/src/events/handlers/sync-finalize.ts
+++ b/packages/lib/src/events/handlers/sync-finalize.ts
@@ -9,7 +9,8 @@
 //
 // Doors executed here (per the door matrix in `resources/crud/door-matrix.ts`):
 //   - `lastActivityAt` batch bump, both lanes (D-1)
-//   - collapsed per-record timeline entries, both lanes (D-4 v1)
+//   - timeline entries: per-field `entity:field:updated` rows on the SMALL
+//     lane, collapsed per-record entries on the large lane (D-4)
 //   - per-record workflow/agent dispatch, SMALL lane only (D-2, fixes B-3);
 //     the large lane withholds dispatch pending the Phase 6 guard (D-3)
 //   - tier-2 `records:changed` delta frames, both lanes (plan §7b)
@@ -26,8 +27,11 @@
 
 import type { Database } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
-import { parseRecordId, type RecordId } from '@auxx/types/resource'
-import type { SyncChangeManifest } from '../../record-rules/sync-manifest-types'
+import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
+import type {
+  ManifestFieldChange,
+  SyncChangeManifest,
+} from '../../record-rules/sync-manifest-types'
 import { SYNC_SMALL_RUN_THRESHOLD } from '../../resources/crud/door-matrix'
 import { EntityInstanceEventType, TimelineActorType } from '../../timeline/event-types'
 
@@ -148,11 +152,12 @@ export async function runSyncFinalize(db: Database, input: SyncFinalizeInput): P
     // time (bookkeeping like this touch deliberately does not stamp it).
     await touchActivityDoor(db, organizationId, sets, { source, ref })
 
-    // D-4 v1: one collapsed timeline entry per record per run, both lanes.
-    // NOTE: small-lane per-field fidelity (matrix cell [R] — per-record
-    // `entity:field:updated` replay) is a later upgrade; v1 ships the
-    // collapsed shape for BOTH lanes.
-    await timelineDoor(db, organizationId, manifest, sets, {
+    // D-4: timeline entries. SMALL lane: per-field `entity:field:updated`
+    // replay for changed records (matrix cell [R] — shipped), mirroring the
+    // inline per-field row shape; created/archived stay collapsed. LARGE
+    // lane: one collapsed `entity:updated` entry per record per run — that
+    // IS decision D-4, not a pending upgrade.
+    await timelineDoor(db, organizationId, manifest, sets, lane, {
       source,
       ref,
       actorUserId,
@@ -306,19 +311,42 @@ async function touchActivityDoor(
 }
 
 /**
- * D-4 v1: bulk-insert collapsed per-record timeline entries. Rows match the
- * storage shape `@auxx/services/timeline` `createTimelineEvent` writes (the
- * single-entry helper is one INSERT + `.returning()` per row — looping it for
- * up to 15k manifest records is exactly the fan-out the batch lane exists to
- * avoid, so this is a chunked direct insert instead). No non-obvious
- * denormalizations exist on the table: `entityType`/`entityId` come from the
- * RecordId, everything else is literal columns.
+ * D-4: bulk-insert timeline entries. Rows match the storage shape
+ * `@auxx/services/timeline` `createTimelineEvent` writes (the single-entry
+ * helper is one INSERT + `.returning()` per row — looping it for up to 15k
+ * manifest records is exactly the fan-out the batch lane exists to avoid, so
+ * this is a chunked direct insert instead). No non-obvious denormalizations
+ * exist on the table: `entityType`/`entityId` come from the RecordId,
+ * everything else is literal columns.
+ *
+ * Changed records on the SMALL lane get per-field `entity:field:updated`
+ * rows (one per changed field) instead of the collapsed `entity:updated`
+ * entry — a run of ≤ SYNC_SMALL_RUN_THRESHOLD records × a handful of fields
+ * keeps the bulk insert trivially bounded. The large lane keeps the
+ * collapsed shape (that IS D-4). Created/archived records stay collapsed on
+ * both lanes.
+ *
+ * Honest deltas of the per-field rows vs the inline shape
+ * (`mapFieldUpdated` in `create-timeline-event.ts`), all limited by what the
+ * manifest carries (`ManifestFieldChange` is raw `{o, n}` keyed by
+ * outputKey = systemAttribute ?? fieldId):
+ * - `fieldId` / `relatedEntityId` / `changes[].field` hold the manifest
+ *   outputKey — for system fields that is the attribute key, not the
+ *   CustomField CUID, and never the display name the inline lane resolves.
+ * - `fieldName`, `fieldType`, `entitySlug`, and the resolved
+ *   `oldDisplay`/`newDisplay` snapshots are omitted, not fabricated — the
+ *   manifest does not capture them. `changes[]` carries the raw
+ *   `oldValue`/`newValue` pair instead (`oldValue` only when captured).
+ * - `eventType` is `entity:field:updated` for every def (the inline lane
+ *   maps contact/ticket to their prefixed variants) — consistent with the
+ *   collapsed rows already using the `entity:*` family for all defs.
  */
 async function timelineDoor(
   db: Database,
   organizationId: string,
   manifest: SyncChangeManifest,
   sets: ChangedSets,
+  lane: SyncFinalizeLane,
   ctx: {
     source: string
     ref: string
@@ -351,15 +379,50 @@ async function timelineDoor(
       })
     }
 
+    /** Small-lane per-field replay — see the honest-delta notes in the doc comment. */
+    const fieldRows = async (rid: RecordId, fieldChanges: Record<string, ManifestFieldChange>) => {
+      const { entityDefinitionId, entityInstanceId } = parseRecordId(rid)
+      const canonical = await ctx.canonicalDefId(entityDefinitionId)
+      const recordId = toRecordId(canonical, entityInstanceId)
+      for (const [fieldKey, change] of Object.entries(fieldChanges)) {
+        rows.push({
+          eventType: EntityInstanceEventType.FIELD_UPDATED,
+          startedAt: now,
+          entityType: canonical,
+          entityId: entityInstanceId,
+          // Inline: relatedRecordId = toRecordId('custom_field', fieldId).
+          relatedEntityType: 'custom_field',
+          relatedEntityId: fieldKey,
+          actorType,
+          actorId,
+          eventData: { recordId, entityDefinitionId: canonical, fieldId: fieldKey, ...syncMeta },
+          changes: [
+            {
+              field: fieldKey,
+              ...('o' in change ? { oldValue: change.o } : {}),
+              newValue: change.n,
+            },
+          ],
+          organizationId,
+          updatedAt: now,
+        })
+      }
+    }
+
     for (const rid of sets.createdIds) {
       await baseRow(rid, EntityInstanceEventType.CREATED, {})
     }
     for (const rid of sets.updatedIds) {
-      const changedFieldIds = Object.keys(manifest.changes[rid] ?? {})
-      await baseRow(rid, EntityInstanceEventType.UPDATED, {
-        changedFieldIds,
-        changedFieldCount: changedFieldIds.length,
-      })
+      const fieldChanges = manifest.changes[rid] ?? {}
+      const changedFieldIds = Object.keys(fieldChanges)
+      if (lane === 'small' && changedFieldIds.length > 0) {
+        await fieldRows(rid, fieldChanges)
+      } else {
+        await baseRow(rid, EntityInstanceEventType.UPDATED, {
+          changedFieldIds,
+          changedFieldCount: changedFieldIds.length,
+        })
+      }
     }
     for (const rid of sets.archivedIds) {
       await baseRow(rid, EntityInstanceEventType.ARCHIVED, {})

--- a/packages/lib/src/resources/crud/__tests__/door-conformance.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/door-conformance.test.ts
@@ -284,7 +284,9 @@ const DOOR_CONFORMANCE: Record<DoorId, DoorConformance> = {
     where:
       'field-value service (fieldValues:updated / entity:field:updated ride setValuesForEntity, ' +
       'gated by the same publishEvents boolean) — field-values tests; the sync-small per-record ' +
-      'cell is currently silent there too (B-2, Phase 4)',
+      'cell is executed at the sync finalize seam (per-field entity:field:updated replay off the ' +
+      'claimed manifest — events/handlers/sync-finalize.test.ts); sync-large stays folded into ' +
+      'the collapsed entry per D-4',
   },
   realtimeTier1: {
     kind: 'observed',
@@ -423,9 +425,9 @@ const VERIFIED_ELSEWHERE_CELLS: Array<{
     origin: 'sync-small',
     expectedFromMatrix: 'per-record',
     where:
-      'events/handlers/sync-finalize.test.ts — the D-12 finalize pass bulk-inserts one collapsed ' +
-      'timeline entry per changed/created/archived record (D-4 v1; small-lane per-FIELD fidelity ' +
-      'is a later upgrade, tracked on the perFieldTimeline row)',
+      'events/handlers/sync-finalize.test.ts — the D-12 finalize pass bulk-inserts per-field ' +
+      'entity:field:updated rows for changed records plus collapsed created/archived entries ' +
+      '(small-lane per-FIELD fidelity shipped; the large lane keeps the collapsed shape per D-4)',
   },
   {
     door: 'recordRules',


### PR DESCRIPTION
## Summary

The [R] fidelity upgrade the finalize pass (#1806) marked as future: on the **small lane**, each changed record's collapsed `entity:updated` timeline row becomes one `entity:field:updated` row per changed field — matching what the inline lane writes for an interactive edit, via the door's existing chunked bulk insert, actor resolution, and def-key canonicalization. Created/archived records keep their collapsed entries on both lanes; the **large lane keeps the collapsed shape exactly** (that IS decision D-4). Defensive fallback keeps the collapsed row for a zero-field manifest entry.

**Honest deltas vs the inline shape** (documented in the door comment, none fabricated):
- Field identifiers carry the manifest outputKey (`systemAttribute ?? fieldId`) rather than the CustomField CUID or display name.
- `fieldName`/`fieldType`/display snapshots omitted — the manifest carries only raw `{o, n}` (the timeline input makes the display pair optional).
- `oldValue` included only when the manifest captured `o` (absence ≠ fabricated null; a captured `o: null` IS carried).
- Event type stays the `entity:*` family for every def; the read path's 2-minute grouping renders a small run as one grouped block.
- Actor is the run actor (user or system) rather than inline's hardcoded USER.

Also corrects two conformance-harness classification strings that described the pre-upgrade state (text only, zero assertion changes; the matrix's `perFieldTimeline` row already declared `sync-small: per-record`).

## Test plan

Small-lane timeline test rewritten (6 rows for the fixture: 3 per-field + 2 created + 1 archived; oldValue-absence and captured-null both asserted; canonicalization preserved); large-lane test now pins every row to the collapsed shape. Suites `src/events` + `src/record-rules` + `src/resources/crud`: 447 passed / 10 intentional skips. One timeout flake in `resolve-resource-trigger-match.test.ts` under full-suite CPU load was proven pre-existing (fails identically on an untouched HEAD baseline; passes standalone). Scoped tsc: zero errors in touched files.