### PR TITLE
fix(files): four correctness bugs in the upload path

### DIFF
--- a/apps/web/src/components/file-upload/stores/__tests__/server-id-kind.test.ts
+++ b/apps/web/src/components/file-upload/stores/__tests__/server-id-kind.test.ts
@@ -1,0 +1,94 @@
+// apps/web/src/components/file-upload/stores/__tests__/server-id-kind.test.ts
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useUploadStore } from '../upload-store'
+
+/**
+ * `serverFileId` is parked with the UPLOAD SESSION nanoid at session-create time (it is what
+ * SSE correlates on) and used to be overwritten only when the completion payload carried an
+ * `assetId`. `FileProcessor` returns `{ fileId }` and no `assetId`, so for any entity type
+ * served by it — which, before the registry stopped defaulting, included `visit_qc_item` —
+ * `serverFileId` stayed the session nanoid and was then reported to callers as
+ * `metadata.assetId` (docs/files-upload-architecture-guide.md §11.3).
+ *
+ * So: derive `serverFileId` from `assetId ?? fileId`, and record WHICH kind it is.
+ */
+
+vi.mock('../../utils/direct-upload', () => ({
+  directUpload: () => ({
+    abort: () => {},
+    promise: Promise.resolve({ etag: 'etag-1' }),
+  }),
+}))
+
+const SESSION_NANOID = 'ses_nanoid_from_server'
+
+/** Stub the two endpoints `startUpload` hits, with `completion` as the /complete body. */
+function stubFetch(completion: Record<string, unknown>) {
+  const json = (body: unknown) =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve(body) } as Response)
+
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.endsWith('/complete')) return json(completion)
+    return json({
+      sessionId: SESSION_NANOID,
+      uploadMethod: 'single',
+      uploadType: 'PUT',
+      presignedUrl: 'https://example.test/put',
+      storageKey: 'org1/visit_qc_item/item1/photo.jpg',
+    })
+  })
+}
+
+async function uploadOne(completion: Record<string, unknown>) {
+  const store = useUploadStore.getState()
+  const sessionId = await store.createSession({
+    entityType: 'visit_qc_item',
+    entityId: 'qci_1',
+  })
+  const file = new File([new Uint8Array(4)], 'photo.jpg', { type: 'image/jpeg' })
+  const [fileId] = useUploadStore.getState().addFiles([file], sessionId)
+  if (!fileId) throw new Error('file was not added')
+
+  vi.stubGlobal('fetch', stubFetch(completion))
+  await useUploadStore.getState().startUpload()
+
+  const state = useUploadStore.getState().files[fileId]
+  if (!state) throw new Error('file state missing after upload')
+  return state
+}
+
+describe('serverFileId derivation on upload completion', () => {
+  beforeEach(() => {
+    useUploadStore.getState().reset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses assetId and marks the id as an asset when the processor made a MediaAsset', async () => {
+    const file = await uploadOne({ fileId: 'fil_1', assetId: 'ast_1', url: 'https://cdn/1' })
+
+    expect(file.serverFileId).toBe('ast_1')
+    expect(file.metadata?.serverIdKind).toBe('asset')
+  })
+
+  it('falls back to fileId and marks the id as a file when only a FolderFile was made', async () => {
+    const file = await uploadOne({ fileId: 'fil_1' })
+
+    expect(file.serverFileId).toBe('fil_1')
+    // The load-bearing half: a FolderFile id must not be indistinguishable from an asset id.
+    expect(file.metadata?.serverIdKind).toBe('file')
+  })
+
+  it('never reports the upload-session nanoid as an asset id', async () => {
+    const file = await uploadOne({})
+
+    // Nothing usable came back, so `serverFileId` is still the session nanoid — but it is
+    // labelled as such, so no consumer can mistake it for a MediaAsset id.
+    expect(file.serverFileId).toBe(SESSION_NANOID)
+    expect(file.metadata?.serverIdKind).toBe('session')
+  })
+})

--- a/apps/web/src/components/file-upload/stores/slices/orchestration-slice.ts
+++ b/apps/web/src/components/file-upload/stores/slices/orchestration-slice.ts
@@ -670,10 +670,15 @@ export const createEnhancedOrchestrationSlice: StateCreator<
             storageKey: string
           }
 
-          // Store server-side session ID for SSE correlation
+          // Store server-side session ID for SSE correlation. This is an UPLOAD SESSION
+          // nanoid, not a server record id — `serverIdKind` says so, so a consumer that
+          // needs a real `MediaAsset` id can tell it apart (see §11.3).
           set((state) => {
             const fs = state.files[file.id]
-            if (fs) fs.serverFileId = presignedConfig.sessionId // helps SSE correlation later
+            if (fs) {
+              fs.serverFileId = presignedConfig.sessionId // helps SSE correlation later
+              fs.metadata = { ...fs.metadata, serverIdKind: 'session' }
+            }
           })
 
           // 2. Upload file directly to storage
@@ -749,15 +754,29 @@ export const createEnhancedOrchestrationSlice: StateCreator<
             console.error('[orchestration] Failed to parse complete response:', e)
           }
 
+          // Which kind of server record the completion actually produced. An attachment/asset
+          // processor returns `assetId` (a `MediaAsset`); `FileProcessor` returns only
+          // `fileId` (a `FolderFile`). Recording the kind is what stops a `FolderFile` id —
+          // or, worse, the upload-session nanoid we parked in `serverFileId` at session-create
+          // time — from being reported downstream as an asset id (§11.3).
+          const serverIdKind: 'asset' | 'file' | 'session' = completionData?.assetId
+            ? 'asset'
+            : completionData?.fileId
+              ? 'file'
+              : 'session'
+          const serverId: string | undefined =
+            completionData?.assetId ?? completionData?.fileId ?? undefined
+
           // Atomic update: set serverFileId, url, and status together
           // This prevents race conditions where onComplete reads state before serverFileId is set
           set((state) => {
             const f = state.files[file.id]
             if (f) {
-              // Store assetId from server as serverFileId
-              if (completionData?.assetId) {
-                f.serverFileId = completionData.assetId
+              // Store the server record id (asset first, file second) as serverFileId
+              if (serverId) {
+                f.serverFileId = serverId
               }
+              f.metadata = { ...f.metadata, serverIdKind }
               // Store URL for previews
               if (completionData?.url) {
                 f.url = completionData.url

--- a/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
+++ b/apps/worker/src/workers/worker-definitions/maintenance-worker.ts
@@ -31,6 +31,7 @@ import {
   type OrgSeedJobData,
   oauth2TokenRefreshScannerJob,
   orphanedAppBundleCleanupJob,
+  orphanedStorageObjectJob,
   outlookSubscriptionHealthJob,
   quotaResetJob,
   reconcileRecordIdentitiesJob,
@@ -188,6 +189,12 @@ export const jobMappings = {
 
   // Storage cleanup (on-demand, enqueued by disconnect/delete flows)
   storageCleanupJob,
+
+  // Orphaned storage object compensation (on-demand, enqueued by the upload
+  // completion route when its inline delete throws). Carries the bucket, so a
+  // PUBLIC upload's object is deleted from the public bucket instead of 204ing
+  // against the private one.
+  orphanedStorageObjectJob,
 
   // Mail counts reconcile (on-demand, jobId-deduped; enqueued by stale
   // getCounts reads, interactive mutations, and bulk slow paths)

--- a/docs/files-upload-architecture-guide.md
+++ b/docs/files-upload-architecture-guide.md
@@ -1,0 +1,851 @@
+<!-- docs/files-upload-architecture-guide.md -->
+
+# Files & Upload Architecture Guide
+
+**Last Updated:** 2026-08-21
+**Scope:** *"A user picked a file. What happens?"* The complete path from a browser file picker
+through presigned S3, into `StorageLocation` / `MediaAsset` / `FolderFile` / `Attachment` rows, and
+back out through the download and thumbnail read paths. Plus the parallel doors that bypass this
+path, the cleanup jobs that are supposed to reap it, and an honest inventory of what is
+overbuilt, dead, or wrong.
+
+> Code under review: `apps/web/src/app/api/files/**`, `packages/lib/src/files/**`,
+> `apps/web/src/components/file-upload/**`.
+> **Remediation plan:** `plans/attachments/` (not tracked in git) — 11 phase docs covering the
+> Tier-1 fixes and the functional refactor. §13 below is its executive summary.
+> Companions: `lib-module-guide.md` (module shape this subsystem predates and violates),
+> `channels-mail-architecture-guide.md` (inbound mail attachments — a different door into the same
+> tables), `ui-design-guide.md`.
+> **Where this guide and the code disagree, the code is the truth.** Sections 10–12 are findings,
+> not descriptions: they say what is broken, not what exists.
+
+---
+
+## Table of Contents
+
+1. [Executive Overview](#1-executive-overview)
+2. [The Data Model](#2-the-data-model)
+3. [Entity Types & the Processor Registry](#3-entity-types--the-processor-registry)
+4. [Door 1 — the browser presigned flow (the main path)](#4-door-1--the-browser-presigned-flow-the-main-path)
+5. [The Storage Layer](#5-the-storage-layer)
+6. [The Front End](#6-the-front-end)
+7. [Door 2 & 3 — the parallel upload paths](#7-door-2--3--the-parallel-upload-paths)
+8. [The Read Path](#8-the-read-path)
+9. [Lifecycle, Quota & Cleanup](#9-lifecycle-quota--cleanup)
+10. [Transactions — what is actually happening](#10-transactions--what-is-actually-happening)
+11. [Correctness Findings](#11-correctness-findings)
+12. [Overcomplication & Dead Code](#12-overcomplication--dead-code)
+13. [A Target Design](#13-a-target-design)
+14. [Key Files](#14-key-files)
+
+---
+
+## 1. Executive Overview
+
+There is one intended upload path and two that grew alongside it.
+
+The intended path is **three HTTP round-trips against our server plus a direct PUT/POST to S3**:
+
+```
+BROWSER                         apps/web (Node)                    S3            POSTGRES
+   │
+   │ 1. POST /api/files/upload/sessions
+   │──────────────────────────────────▶ auth + files.manage gate
+   │                                    storage quota gate  ────────────────────────▶ (always 0 — §11.1)
+   │                                    ProcessorRegistry.getForEntityType(entityType)
+   │                                    processor.processConfig(init)
+   │                                      → storageKey, policy, uploadPlan,
+   │                                        visibility, bucket, ttl
+   │                                    SessionManager.createSessionFromConfig
+   │                                      → nanoid in Redis, TTL 10m
+   │                                    storageManager.generatePresignedUploadUrl
+   │                                      → presigned POST (or multipart init)
+   │◀───────────────────────────────────  { sessionId, presignedUrl, fields, … }
+   │
+   │ 2. POST/PUT the bytes straight to S3
+   │─────────────────────────────────────────────────────────────▶ object lands
+   │   (multipart: N × POST /upload/{id}/parts for a per-part URL,
+   │    then N × PUT — serial, one round-trip to us per part)
+   │
+   │ 3. POST /api/files/upload/{sessionId}/complete
+   │──────────────────────────────────▶ NO AUTH CHECK (§11.4)
+   │                                    completeMultipartUpload (if multipart)
+   │                                    headByKey  ──────────────▶ verify size/mime
+   │                                    processor.validateCompletedUpload
+   │                                    ┌── db.transaction ──────────────────────┐
+   │                                    │  buildExternalUrl (I/O, §10.2)         │
+   │                                    │  createStorageLocation                 │
+   │                                    │  processor.process → savepoints (§10.1)│
+   │                                    │    → MediaAsset + MediaAssetVersion    │
+   │                                    │      and/or FolderFile + FileVersion   │
+   │                                    │      and/or Attachment                 │
+   │                                    │    → sometimes BullMQ enqueue (§10.3)  │
+   │                                    └────────────────────────────────────────┘
+   │                                    post-commit: cache busts, thumbnail
+   │                                                 enqueue, download URL
+   │◀───────────────────────────────────  { assetId | fileId, attachmentId, url }
+```
+
+There is also an SSE channel (`GET /upload/{sessionId}/events`) and a Redis pub/sub progress
+publisher feeding it. **Nothing connects to it.** The client reads its result from the `complete`
+response body. See §12.1.
+
+The two other doors:
+
+- **Public workflow share uploads** — `/api/workflows/shared/[shareToken]/files/**`. A complete,
+  independent re-implementation: its own Redis keyspace, its own presign, no processor, no policy,
+  no transaction. It works.
+- **Server-side ingest** — inbound mail attachments, thumbnails, PDF renders, exports, recordings.
+  These call `StorageManager.uploadContent()` directly and then the services. They never touch
+  sessions or processors.
+
+---
+
+## 2. The Data Model
+
+Five tables carry a file. Understanding which combination a given upload produces is the single
+most important thing about this subsystem.
+
+| Table | What it is | Written by |
+| --- | --- | --- |
+| `StorageLocation` | The bytes. Provider + bucket + key + etag + size + mime. **Org-scoped, never soft-deleted by the upload path.** | `StorageManager.createStorageLocation` → `StorageLocationService.create` |
+| `MediaAsset` | A logical, versioned media object: `kind` (`USER_AVATAR`, `EMAIL_ATTACHMENT`, `INLINE_IMAGE`, `THUMBNAIL`, `DOCUMENT`, `TEMP_UPLOAD`), `purpose`, `isPrivate`, `currentVersionId`, `expiresAt`. | `MediaAssetService.createWithVersion` / `updateContent` |
+| `MediaAssetVersion` | One version of an asset → one `StorageLocation`. Thumbnails are **separate `MediaAsset`s** whose versions carry `derivedFromVersionId` + `preset`. | same |
+| `FolderFile` + `FileVersion` | The user-facing *file library* (folder tree, rename, move, versions). `FileVersion.fileId` FKs to **`FolderFile`**. | `FileService.createWithVersion` |
+| `Attachment` | The join from an asset to a host entity: `(entityType, entityId, assetId, role, title, caption)`. | `AttachmentService.create` |
+
+There is also a legacy **`File`** table (`packages/database/src/db/schema/file.ts`) that is
+**empty and unused** except by the workflow-file route and one broken query (§11.1). It is not
+`FolderFile`. The name collision is a live hazard.
+
+**Buckets.** Two: `S3_PUBLIC_BUCKET` and `S3_PRIVATE_BUCKET`, chosen by
+`getBucketForVisibility(visibility)` in `upload/util.ts`. Public objects get a durable CDN URL
+(`CDN_URL/{key}`) written into `StorageLocation.externalUrl`; private objects are only reachable
+through a presigned GET or our download route.
+
+**Storage key.** `deriveStorageKey`:
+`{orgId}/{entity-type-kebab}/{entityId ?? 'temp'}/{Date.now()}_{seed?}{sanitizedFileName}`.
+Org id first so `aws s3 rm s3://bucket/{orgId}/ --recursive` is a valid org delete.
+
+---
+
+## 3. Entity Types & the Processor Registry
+
+`ENTITY_TYPES` (`files/types/entities.ts`) is the dispatch key for the whole flow. The client sends
+an entity type; the registry maps it to exactly one processor; the processor decides everything
+else.
+
+| Entity type | Processor | Visibility | Max | Mime allow-list | Produces |
+| --- | --- | --- | --- | --- | --- |
+| `FILE` | `FileProcessor` | PRIVATE | — (`*/*`) | `*/*` | `FolderFile` + `FileVersion` |
+| `USER_PROFILE` | `UserProfileProcessor` | **PUBLIC** | 5 MB | jpeg/png/webp/gif | `MediaAsset` (versioned in place) + `User.avatarAssetId`/`image` |
+| `ARTICLE` | `ArticleProcessor` | PRIVATE (PUBLIC when `role=COVER`) | 10 MB | images (no SVG), pdf, text | `MediaAsset` + `Attachment` |
+| `KNOWLEDGE_BASE` | `KnowledgeBaseProcessor` | **PUBLIC** | 10 MB | jpeg/png/webp | `MediaAsset` + `Attachment` + `KnowledgeBase.logoLight/Dark` |
+| `CHAT_WIDGET` | `ChatWidgetProcessor` | **PUBLIC** | 10 MB | jpeg/png/webp | `MediaAsset` + `Attachment` + `ChatWidget.logoLight/Dark` |
+| `MESSAGE` | `MessageProcessor` | PRIVATE | 25 MB | `*/*` | `MediaAsset` + `Attachment` |
+| `COMMENT` | `CommentProcessor` | PRIVATE | 25 MB | image/text/pdf/doc | `MediaAsset` + `Attachment` |
+| `CUSTOM_FIELD` | `CustomFieldProcessor` | PRIVATE | 25 MB | `*/*`, narrowed by the field's `options.file` | `MediaAsset` + `Attachment` |
+| `WORKFLOW_RUN` | `WorkflowRunProcessor` | PRIVATE | 50 MB | `*/*` | `MediaAsset` + `Attachment` |
+| `DATASET` | `DatasetAssetProcessor` | `'private'` (lowercase — §11.6) | 50 MB | long explicit list | `MediaAsset` + `Document` + parse/embed queue |
+| `visit_qc_item` | **none — falls back to `FileProcessor`** | PRIVATE | `*/*` | `*/*` | `FolderFile` — **wrong, §11.3** |
+
+The class hierarchy is three deep:
+
+```
+BaseProcessor              processConfig(), validateCompletedUpload(), process()
+  └─ BaseAssetProcessor    + createAsset(), entity policy clamping, validateEntityAccess()
+       └─ BaseAttachmentProcessor  + createAttachment(), entityId required
+```
+
+`processConfig` is a **super-call chain**: each level widens or clamps `policy`,
+`uploadPlan`, `visibility`, `bucket`, and re-`Object.freeze`s the config. Tracing what a given
+entity type actually ends up with requires reading up to four `processConfig` overrides.
+
+**Registration** is imperative and lazy: `ensureProcessorsInitialized()` must be called by hand at
+the top of both routes before touching the registry. Miss it and you get a `logger.warn` and a
+still-working default processor — a silent, wrong `FolderFile` instead of a hard error.
+
+---
+
+## 4. Door 1 — the browser presigned flow (the main path)
+
+### 4.1 `POST /api/files/upload/sessions`
+
+`apps/web/src/app/api/files/upload/sessions/route.ts`
+
+1. `auth.api.getSession` → requires `defaultOrganizationId`.
+2. Zod-parse the body (`fileName`, `mimeType`, `expectedSize`, `entityType`, `entityId?`,
+   `provider?`, `metadata?`).
+3. **Layer-2 permission gate — only for `entityType === 'FILE'`** (`PermissionKey.filesManage`).
+   Every other entity type is deliberately left to its host surface's own gate plus the
+   processor's `validateEntityAccess`.
+4. **Storage quota gate** — `FeaturePermissionService.getLimit(org, 'storageGbHard')` vs
+   `calculateStorageUsage(org)`. Wrapped in a try/catch that **fails open**. It also always
+   measures zero (§11.1).
+5. `ensureProcessorsInitialized()` → `ProcessorRegistry.getForEntityType()` →
+   `processor.processConfig(init)` → frozen `UploadPreparedConfig`.
+6. `SessionManager.createSessionFromConfig(config)` — writes the whole config as JSON to
+   `upload:session:{nanoid}` in Redis with `SETEX config.ttlSec`. **Redis is mandatory**; there is
+   no fallback.
+7. Single vs multipart, decided by `config.uploadPlan.strategy`:
+   - **single** → `generatePresignedUploadUrl` → S3 **presigned POST** with
+     `content-length-range 0..expectedSize` and an exact `Content-Type` condition. Response carries
+     `presignedUrl` + `presignedFields`.
+   - **multipart** → `startMultipartUploadFromConfig` → `uploadId` +
+     `partPresignEndpoint: /api/files/upload/{sessionId}/parts`.
+8. `SessionManager.updateSession` writes the presign back onto the session (read-modify-write, no
+   CAS).
+
+### 4.2 `POST /api/files/upload/{sessionId}/parts`
+
+Looks up the session, `touchSession`es it (TTL → 600 s), and mints one presigned `UploadPart` URL.
+**No authentication.** No `ttlSec` forwarding (parts always get the adapter's 3600 s default). No
+bucket forwarding (§11.5).
+
+### 4.3 `POST /api/files/upload/{sessionId}/complete`
+
+`apps/web/src/app/api/files/upload/[sessionId]/complete/route.ts` — 324 lines, explicitly
+structured as three phases. **No authentication.**
+
+**Phase 1 — S3, outside the transaction**
+- `completeMultipartUploadOnly` if multipart. On failure: mark session `failed`, publish, 500.
+- `headByKey` — the real size/mime verification. This is the *only* enforcement that survives a
+  lying client on the multipart path.
+- `processor.validateCompletedUpload(session, head)` — exact size match, exact mime-family match,
+  entity max size, entity allow-list.
+- `updateSession` with the canonical size/mime.
+
+**Phase 2 — one `db.transaction`** (see §10 for why this is the problem area)
+- `buildExternalUrl` when `visibility === 'PUBLIC'` (I/O inside the tx).
+- `createStorageLocation(..., { tx })`.
+- `processor.process(session, storageLocationId, { tx })`.
+- On any throw: try `deleteByKey` immediately; if that throws, `cleanupService.scheduleCleanup`
+  (**a no-op stub**, §11.2); mark session failed; 500.
+
+**Phase 3 — post-commit**
+- `updateSession({status:'completed', storageLocationId})`.
+- `USER_PROFILE`: `DehydrationService().invalidateUser`, plus `onCacheEvent('agent.updated')`
+  when the target is an agent's synthetic user.
+- Compute a `downloadUrl` — with a hard-coded `USER_PROFILE` branch that enqueues/awaits an
+  `avatar-32` thumbnail before falling back to the original.
+- `ProgressPublisher.publishCompleted` → Redis pub/sub → nobody.
+- Return `{ assetId, fileId, attachmentId, documentId, url }`.
+
+### 4.4 `GET /api/files/upload/{sessionId}/events`
+
+SSE. Subscribes a dedicated Redis client to `upload:status:{sessionId}`, heartbeats every 30 s,
+closes 1 s after a terminal frame. **No authentication** — knowing a session id reveals its status.
+No client connects to it (§12.1).
+
+---
+
+## 5. The Storage Layer
+
+```
+StorageManager (2,512 lines, org-scoped)
+  ├── presign / multipart / head / delete-by-key      → adapter
+  ├── uploadFile / uploadContent / getContent / stream → adapter
+  ├── StorageLocation CRUD                            → StorageLocationService (global singleton)
+  ├── credential + bucket resolution                  → @auxx/credentials
+  ├── enforcePolicy(config)
+  ├── folders / search / webhooks / health / usage    → adapter
+  └── getAdapter(provider) → S3Adapter | (Drive, Dropbox, OneDrive, Box stubs)
+```
+
+`enforcePolicy` (storage-manager.ts:1338) checks four things against the **client-declared**
+`expectedSize` and `mimeType` before presigning: key prefix, TTL ceiling, content-length range,
+mime allow-list. For single uploads the size and content-type also become S3 POST-policy
+conditions, so S3 enforces them for real. For **multipart** they are advisory only — the actual
+enforcement is `headByKey` + `validateCompletedUpload` after the bytes are already paid for and
+stored.
+
+`StorageLocationService` is a **module-level singleton with no organization scope**
+(`export const storageLocationService = new StorageLocationService()`). `StorageManager` is
+org-scoped and passes `organizationId` into every call, so the scoping is by convention.
+
+---
+
+## 6. The Front End
+
+`apps/web/src/components/file-upload/` — 5,832 lines, a Zustand store split into five slices.
+
+```
+useFileUpload(options)                        hooks/use-file-upload.ts   (594)
+   └── useUploadStore                         stores/upload-store.ts
+         ├── session-slice     client-side session containers + SSE (unused)   (442)
+         ├── file-slice        per-file state machine                          (306)
+         ├── orchestration-slice  the actual upload driver                   (1,035)
+         ├── ui-slice                                                          (240)
+         └── entity-slice      deprecated global config                        (117)
+```
+
+The real work is `orchestration-slice.startUpload()`: build a pool of `maxConcurrentUploads`
+(default 3) workers, and per file do session-create → `directUpload` → complete, updating store
+state at each step.
+
+`utils/direct-upload.ts` does the browser-side transfer with `XMLHttpRequest` (for upload progress
+events). Multipart is **strictly serial**: 10 MB chunks, and each chunk costs a round-trip to our
+server for a presigned URL before the PUT.
+
+Consumers: avatar upload (settings, onboarding, agent hero, resources), record identity header,
+dataset documents, file library, custom-field FILE inputs, QC photo strip, file-select.
+
+Two structural smells on this side:
+
+- `startUploadForSession(sessionId)` works by **temporarily reassigning the global
+  `activeSessionId`**, calling `startUpload()`, then restoring it. Two concurrent uploaders in the
+  same tab race on that global.
+- `use-field-file-upload.ts` maintains a **module-level `Map` of completion handlers and a global
+  `useUploadStore.subscribe`**, with a 30-minute staleness sweep, because the store has no
+  per-uploader completion callback that survives a React unmount.
+
+---
+
+## 7. Door 2 & 3 — the parallel upload paths
+
+### 7.1 Public workflow share uploads
+
+`apps/web/src/app/api/workflows/shared/[shareToken]/files/{sessions,[sessionId]/complete}`
+
+A passport-token-authenticated re-implementation of the same flow for anonymous end users:
+Redis key `public-upload:{id}` (different keyspace, different shape), `headByKey`,
+`createStorageLocation`, `MediaAssetService.createWithVersion` with `purpose:
+'PUBLIC_WORKFLOW_INPUT'` and a 24 h `expiresAt`, then a download ref.
+
+**It does all of this with no transaction and no processor, and it is correct.** That is the most
+useful single data point about the main path's `db.transaction`.
+
+### 7.2 Server-side ingest
+
+Inbound mail (`email/inbound/attachment-ingest.service.ts`, `body-ingest.service.ts`), thumbnails
+(`thumbnail-service.ts`), PDF render/preview (`documents/`), exports and prints
+(`jobs/export/**`), recordings (`recording/`), remote image fetch (`fetch-remote-image.ts`), chat
+attachments (`apps/api/src/routes/chat/attachments.ts`). All bypass sessions/processors and call
+`StorageManager.uploadContent()` + the services directly.
+
+This is fine and should stay — but it means **the processor system is not the choke point for file
+creation**, only for browser uploads. Any invariant expressed only in a processor (`kind`,
+`expiresAt`, allow-lists, cache busts) is not enforced for these.
+
+---
+
+## 8. The Read Path
+
+Three different answers to "give me the bytes", with three different designs:
+
+| Route | Design | Auth |
+| --- | --- | --- |
+| `GET /api/files/download/[fileId]` | **Buffers the entire object into Node memory**, then slices for `Range`. Handles `asset:`/`file:` FileRefs. | session + `PermissionKey.filesView` |
+| `GET /api/attachments/[id]/content` | **302 to a presigned URL.** Inline only for png/jpeg/gif/webp. | session + `canViewAttachment` (mail-lens aware) |
+| `GET /api/attachments/[id]/{download,thumbnail}` | same redirect shape | same |
+
+The download route's `shouldRenderInline` carefully excludes `image/svg+xml` (stored XSS), which is
+right. What is not right is that it is the only content route that streams through us: a 2 GB video
+in the file library becomes a 2 GB `Buffer` in the web process before a single byte reaches the
+client, and `Range` requests do the full read every time. The attachment routes already show the
+correct pattern.
+
+Thumbnails are generated asynchronously (`Queues.thumbnailQueue` → `thumbnail-worker`) into
+**separate `MediaAsset` rows** linked by `MediaAssetVersion.derivedFromVersionId` + `preset`.
+Presets live in `thumbnail-types.ts` (`avatar-32/64/128/256`, `kb-logo-sm/lg`, …).
+
+---
+
+## 9. Lifecycle, Quota & Cleanup
+
+There are **two unrelated modules both named "cleanup service"**:
+
+- `files/cleanup/cleanup-service.ts` (256 lines) — the S3 compensation queue for the complete
+  route. Every persistence method is a `// TODO` that logs and returns. **It does nothing.**
+- `files/lifecycle/cleanup-service.ts` (496 lines) — the real reaper functions
+  (`deleteExpiredFiles`, `deleteOrphanedFiles`, `deleteEntityFiles`, `cleanupFailedUpload`, …).
+
+Scheduled in `apps/worker/src/workers/index.ts`: `orphanedFileCleanupJob`,
+`deletedFileCleanupJob`, `storageQuotaCheckJob`. **Not** scheduled: `quotaEnforcementCleanupJob`.
+
+`TEMP_UPLOAD` assets get an `expiresAt` stamped by the `MESSAGE` / `COMMENT` / `CUSTOM_FIELD` /
+`WORKFLOW_RUN` processors, and each of those then calls a private `scheduleCleanup()` that only
+logs. The reaping actually depends on `orphanedFileCleanupJob` → `deleteExpiredFiles`, which walks
+`FolderFile` — so **`MediaAsset` temp uploads are stamped with an expiry that nothing enforces.**
+
+---
+
+## 10. Transactions — what is actually happening
+
+This is the part worth rewriting.
+
+### 10.1 The transaction is three savepoints deep
+
+`BaseService.getTx()` claims to detect an existing transaction:
+
+```ts
+const client = this.db
+if (typeof client.transaction !== 'function') return callback(client)   // "already in a tx"
+return client.transaction((tx) => callback(tx))
+```
+
+In drizzle-orm 0.44, `NodePgTransaction.transaction()` **exists** and issues
+`SAVEPOINT sp{n}` (`node-postgres/session.js:206`). So the first branch is **unreachable dead
+code** and `getTx` always opens a nested savepoint.
+
+For an avatar upload, the actual statement sequence is:
+
+```
+BEGIN                                    ← route: db.transaction
+  INSERT StorageLocation                 ← createStorageLocation({tx})
+  SAVEPOINT sp1                          ← UserProfileProcessor: mediaAssetService.getTx()
+    SELECT MediaAsset …                    findExistingAsset
+    SAVEPOINT sp2                        ← createWithVersion → getTx()
+      INSERT MediaAsset
+      INSERT MediaAssetVersion
+    RELEASE sp2
+    UPDATE "User" SET avatarAssetId …
+  RELEASE sp1
+COMMIT
+```
+
+Nothing needs partial rollback anywhere in that tree. All three levels either succeed together or
+must fail together. Every savepoint is pure overhead and pure confusion.
+
+Compounding it, `BaseProcessor.process()` **mutates the instance** to bind the transaction:
+
+```ts
+this.mediaAssetService = this.mediaAssetService.withTx(opts.tx)   // permanent for this instance
+```
+
+…and then `createAsset` defensively wraps again (`tx ? this.mediaAssetService.withTx(tx) : …`).
+Double-binding is currently harmless because processors are constructed per-request by the
+registry factory — but it is a landmine the moment anyone caches a processor.
+
+### 10.2 Network I/O inside the transaction
+
+`buildExternalUrl` runs **inside** `db.transaction`. It resolves the adapter and, when
+`session.credentialId` is set, calls `getProviderAuth` → credential decryption. Whatever latency
+that has is latency the Postgres connection is held open for, on the hottest write path in the
+subsystem. Its result is only a string built from config; it has no reason to be there.
+
+### 10.3 BullMQ jobs enqueued inside the transaction — and they read stale data
+
+`UserProfileProcessor.executeProcess` has this comment:
+
+```ts
+// Generate thumbnails AFTER transaction commits
+await this.generateAvatarThumbnails(session, result.assetId)
+```
+
+That is **false**. It runs after `RELEASE sp1`, not after `COMMIT` — the route's transaction is
+still open. `generateAvatarThumbnails` → `ensureThumbnailPresets` → `new ThumbnailService(org,
+user)` with the **global `db`**, i.e. a different connection.
+
+Consequences, both real:
+
+- **First avatar upload:** `resolveVersion` cannot see the uncommitted `MediaAsset` and throws
+  `Asset not found: …`. Swallowed by the processor's try/catch and logged. Every one of the four
+  avatar presets is wasted work that always fails. The route's Phase-3 `avatar-32` enqueue is what
+  actually produces a thumbnail.
+- **Re-uploading an avatar:** the asset row exists but its `currentVersionId` still points at the
+  *previous* version outside the tx, so `findByVersionAndPreset` finds the old thumbnail and
+  returns `status: 'ready'`. **`avatar-64/128/256` silently keep showing the old image.**
+
+`KnowledgeBaseProcessor` has the identical structure and the identical staleness window.
+
+Beyond staleness: enqueueing a job inside an open transaction means a worker can pick it up before
+`COMMIT`, and the job survives a `ROLLBACK`. Jobs must be enqueued post-commit, from the route.
+
+### 10.4 The compensation path does not compensate
+
+On `db.transaction` failure the route tries `deleteByKey` and, if that throws,
+`cleanupService.scheduleCleanup` — which logs `"Would store cleanup task"` and returns.
+
+Worse, `deleteByKey` takes **no `bucket`**. `S3Adapter.deleteFile` resolves the target through the
+shared `parseS3Location` helper (s3-adapter.ts:867), whose fallback chain when the location carries
+no `metadata.bucket` and the `externalId` is a bare key is `auth.bucket → S3_PRIVATE_BUCKET` — and
+`auth.bucket` is itself `S3_PRIVATE_BUCKET`, because it comes from `resolvePlatformAuth()`. So for a
+**PUBLIC** upload (avatar, KB logo, chat-widget logo, article cover) the compensation deletes a
+nonexistent key in the *private* bucket, S3 answers 204, and the real object leaks with **no error
+and no log**.
+
+> `parseS3Location` is shared with `getMeta` / `fileExists` / `getDownloadRef`, so the fallback
+> cannot simply be removed — the read paths depend on it. `deleteFile` needs its own strict
+> resolver.
+
+### 10.5 What the transaction is actually protecting
+
+`StorageLocation` + `MediaAssetVersion` + `MediaAsset` (+ `Attachment`) + one host-row update.
+That is a genuine unit — but the *cost* of getting it wrong is one orphan row referencing a real
+S3 object, which the cleanup jobs already exist to sweep. Door 2 (§7.1) writes the same rows with
+no transaction at all and has never been reported as a problem.
+
+**Recommendation:** keep exactly one `BEGIN…COMMIT`, open it in one place, pass `tx` explicitly
+down as a parameter, and delete `getTx` entirely. Nothing below the route should be able to start
+a transaction.
+
+---
+
+## 11. Correctness Findings
+
+Ordered by impact. Each was verified against the code and, where noted, the dev database.
+
+### 11.1 The storage quota is always zero — the `storageGbHard` plan limit never fires
+
+`files/lifecycle/quota-cleanup.ts:23`:
+
+```ts
+.from(schema.FileVersion)
+.leftJoin(schema.File, eq(schema.FileVersion.fileId, schema.File.id))
+.where(and(eq(schema.File.organizationId, organizationId), isNull(schema.File.deletedAt)))
+```
+
+`FileVersion.fileId` FKs to **`FolderFile`**, not `File` (`schema/file-version.ts:29`). They are
+different tables with disjoint id spaces. The `LEFT JOIN` never matches, the `WHERE` on the right
+side then discards every row, `sum()` returns `NULL`, and `totalUsed` is `0`.
+
+Verified on the dev database:
+
+```
+File rows: 0     FolderFile rows: 1     FileVersion rows: 1
+FileVersion ⋈ File: 0        FileVersion ⋈ FolderFile: 1
+MediaAsset rows: 3,737       Σ MediaAssetVersion.size: 1,640,968,278 bytes (1.6 GB)
+```
+
+Two bugs stacked: the wrong table, **and** the query only ever considered `FolderFile` in the first
+place — every avatar, mail attachment, comment attachment, custom-field file, KB logo and dataset
+document is a `MediaAsset` and would be invisible even after fixing the join. The gate in
+`sessions/route.ts` is decorative, and `storageQuotaCheckJob` never warns anyone.
+
+This is a billing-surface bug, not a cosmetic one.
+
+### 11.2 Orphaned S3 objects leak silently on transaction failure
+
+§10.4. `scheduleCleanup` persists nothing, and `deleteByKey` targets the wrong bucket for every
+PUBLIC upload. Both halves of the compensation are non-functional for the public bucket.
+
+### 11.3 `visit_qc_item` uploads produce the wrong record and hand the client a fake asset id
+
+`ENTITY_TYPES.VISIT_QC_ITEM = 'visit_qc_item'` (note: the only lowercase value in the enum) has
+**no processor registered** in `processors/index.ts`, so `ProcessorRegistry.getForEntityType` falls
+through to `setDefaultProcessor(FileProcessor)`. That creates a `FolderFile`, not a
+`MediaAsset` + `Attachment`.
+
+The client then does:
+
+```ts
+// orchestration-slice.ts — set at session create
+f.serverFileId = presignedConfig.sessionId
+// …and only overwritten if the server returned an assetId
+if (completionData?.assetId) f.serverFileId = completionData.assetId
+```
+
+`FileProcessor` returns `{ fileId }`, no `assetId`. So `serverFileId` stays the **upload-session
+nanoid**, and `use-file-upload.ts:388` reports it as `metadata: { assetId: f.serverFileId }`.
+`qc-photo-strip.tsx` passes that to `addVisitQcItemPhoto` → `AttachmentService.create({ assetId })`
+with an id that is not a `MediaAsset`.
+
+Dev database corroborates: `Attachment` has rows for `MESSAGE`, `CUSTOM_FIELD`, `COMMENT`,
+`FIELD_VALUE`, `ARTICLE`, `KNOWLEDGE_BASE`, `CHAT_WIDGET` — and **zero for `visit_qc_item`**.
+
+(Separately: `FIELD_VALUE` appears in `Attachment.entityType` but is not in `ENTITY_TYPES` — a
+fourth writer outside the processor registry.)
+
+### 11.4 `complete`, `parts` and `events` have no authentication
+
+None of the three call `auth.api.getSession`. The session nanoid is the only credential. The
+`complete` route then performs DB writes attributed to `session.userId` and `session.organizationId`
+read out of Redis.
+
+This is a bearer-capability model, which is defensible — but it is nowhere documented, the token is
+never bound to the caller, and it means:
+
+- authorization is evaluated **only** at session-create time; a permission revoked mid-upload is
+  not re-checked at completion;
+- `parts` will mint presigned `UploadPart` URLs for arbitrary part numbers to anyone holding the id;
+- `events` discloses upload status for any known id;
+- there is no origin/CSRF consideration on a state-changing `POST`.
+
+Fix: re-authenticate on all three and assert `session.userId === caller.id` (and org match).
+
+### 11.5 Multipart parts and completion always target the private bucket
+
+`StorageManager.generatePartUploadUrl`, `completeMultipartUploadOnly` and `deleteByKey` do not
+accept or forward a `bucket`. `S3Adapter.presignPart` / `completeMultipart` fall back to
+`S3_PRIVATE_BUCKET`.
+
+`startMultipartUploadFromConfig` *does* pass `config.bucket`. So a multipart upload into the
+**public** bucket initiates in the public bucket and then presigns its parts against the private
+one — `NoSuchUpload`. Latent today only because every PUBLIC entity type caps below its multipart
+threshold (avatar 5 MB, KB/widget/article-cover 10 MB vs a 25–50 MB threshold). Raise any of those
+caps and it breaks.
+
+### 11.6 `SETEX` with a zero TTL on long multipart uploads
+
+`SessionManager.touchSession` resets the Redis TTL to `DEFAULT_TTL` (600 s) but **does not update
+`session.expiresAt`**. `SessionManager.updateSession` computes:
+
+```ts
+const remainingTtl = Math.max(0, Math.floor((session.expiresAt.getTime() - Date.now()) / 1000))
+await redis.setex(key, remainingTtl, …)
+```
+
+A multipart upload longer than `ttlSec` keeps the key alive via `touchSession` while `expiresAt`
+goes into the past. The next `updateSession` — which `complete` calls in Phase 1 — passes
+`remainingTtl = 0`, and ioredis surfaces `ERR invalid expire time in 'setex' command`. The upload
+completes to a 500 after the bytes are already in S3.
+
+### 11.7 Type-safety leaks in `DatasetAssetProcessor`
+
+`entityType = 'dataset'`, `fileVisibility = 'private'`, `preferredProvider = 'local'` — all
+lowercase, while `BaseAssetProcessor.processConfig` does `this.fileVisibility as 'PUBLIC' |
+'PRIVATE'` and `getBucketForVisibility` compares against `'PUBLIC'`. It lands in the private bucket
+by accident, not by intent. (`'local'` is not a `ProviderId` at all; `preferredProvider` is read
+nowhere — §12.3.)
+
+### 11.8 Empty and commented-out `validateEntityAccess`
+
+- `WorkflowRunProcessor.validateEntityAccess` — entire body commented out. Combined with `*/*` and
+  50 MB, any authenticated org member can upload anything against any `entityId`.
+- `CustomFieldProcessor.validateEntityAccess` — returns early for `field-`-prefixed ids and then
+  **falls off the end**, so every other id also passes.
+- `ArticleProcessor` / `CommentProcessor` check org membership of the entity only, with a
+  `// Add user access validation based on your business rules` TODO.
+
+Note these are *entity* checks, not the L2 permission gate — the host surfaces carry that. But the
+processor is the layer that claims to do it.
+
+### 11.9 Errors are classified by substring matching
+
+`packages/lib/src/files/**` throws bare `new Error(...)` everywhere — including in
+`processConfig`, where a mime rejection is a 400/415, not a 500. `UploadErrorHandler.categorizeError`
+then greps the message (`includes('storage')`, `includes('s3')`, `includes('bucket')`, …) to pick an
+HTTP status.
+
+This violates the repo rule (`CLAUDE.md` → *Error Handling*): lib throws `AuxxError` subclasses and
+the mapping is mechanical. It also forces `sessions/route.ts` to invent a fake session id
+(`temp-${Date.now()}`) just to satisfy the handler's signature, and to special-case the permission
+error by hand so the 403 survives.
+
+### 11.10 Smaller items
+
+- `deriveStorageKey` uses `Date.now()` with no random suffix. Two files with the same name for the
+  same entity in the same millisecond collide, and the second silently overwrites the first.
+- `SessionManager.updateSession` is read-modify-write with no CAS. The `parts` route touches the
+  same key concurrently with `complete`.
+- `SessionManager.completeUpload` stores a **storage key** in the `storageLocationId` field
+  ("Temporary, will be replaced"). Nothing calls it.
+- `presignUpload` passes upload metadata as raw S3 POST `Fields` rather than `x-amz-meta-*`, so the
+  `sessionId`/`orgId`/`uploader` tags do not land on the object as user metadata. Nothing reads
+  them back, so this is currently invisible — worth confirming before relying on object metadata.
+- The `complete` route hard-codes a `USER_PROFILE` branch (dehydration, agent cache bust, avatar-32
+  thumbnail) that belongs behind a processor hook.
+
+---
+
+## 12. Overcomplication & Dead Code
+
+Roughly **3,660 lines** of the subsystem are unreachable or stubbed.
+
+### 12.1 The entire progress/SSE stack is dead (~2,900 lines)
+
+| File | Lines | Status |
+| --- | --- | --- |
+| `upload/progress/enhanced-progress-tracker.ts` | 480 | no importer |
+| `upload/progress/sse-publisher.ts` | 425 | imported only by dead code |
+| `upload/progress/progress-tracker.ts` | 374 | " |
+| `upload/progress/event-types.ts` | 322 | " |
+| `upload/progress/event-schemas.ts` | 278 | " |
+| `upload/upload-session-service.ts` (`FileUploadSession`) | 453 | exported from `server.ts`, zero callers |
+| `upload/enhanced-types.ts` | 393 | barrel re-export only |
+| `upload/progress-publisher.ts` | 120 | writes to a channel nobody reads |
+| `apps/web/.../upload/[sessionId]/events/route.ts` | 109 | no client connects |
+| `components/file-upload/utils/sse-connection.ts` | 341 | `connectSSE` only called by `coordinateSSEEvents`, which nothing calls |
+
+`session-slice.ts:112` documents the reason in a comment: the client-side session id is not the
+server session id, so connecting SSE would 404 — *"If/when SSE is required, connect using the
+server-provided sessionId."* Nobody ever did. The `complete` response already returns everything
+the SSE frame would have carried.
+
+**Two competing session abstractions exist**: `SessionManager` (static, Redis, used) and
+`FileUploadSession` (instance, in-memory, with its own status machine, progress tracker and event
+publisher — dead). Both are exported side-by-side from `files/server.ts`.
+
+### 12.2 Two "cleanup services", one of which does nothing
+
+§9. `files/cleanup/` (all stubs, referenced by the hot path) vs `files/lifecycle/` (real,
+referenced by the worker). Same name, opposite reality.
+
+### 12.3 Ceremony that produces nothing
+
+- `preferredProvider` — an abstract field every processor must declare. Read nowhere; the provider
+  comes from `init.provider ?? 'S3'`.
+- `ProcessorMetadata` (`getMetadata()`, `supportsAssets/Files/Attachments`) — implemented by every
+  processor, called by nothing.
+- `processors/types.ts` declares `SessionMetadata`, `PreprocessResult`, `UploadPreferences`,
+  `CreateSessionRequest`, `ProcessorMetadata` — a whole parallel type vocabulary next to
+  `init-types.ts`'s `UploadInitConfig` / `UploadPreparedConfig`, which is what the code actually uses.
+- `ProcessorRegistry` has `unregisterProcessor`, `clear`, `getRegisteredTypes`,
+  `getProcessorCount`, `hasProcessor`, `isInitialized`, plus a separate module-level
+  `processorsInitialized` boolean shadowing the class's own `initialized` flag — for a map of ten
+  hard-coded entries built by one function.
+- `BaseService` (582 lines) defines ~15 CRUD methods whose implementation is
+  `throw new Error('… must be implemented by subclass')`, plus `bulkCreate`/`bulkUpdate`/`bulkDelete`
+  that loop over those throwing methods. It is an abstract class that provides `withTx`, `getTx`,
+  `buildBaseWhereClause`, `requireRow` — four useful things wrapped in 500 lines of scaffolding.
+
+### 12.4 God objects
+
+| File | Lines |
+| --- | --- |
+| `storage/storage-manager.ts` | 2,512 |
+| `core/file-service.ts` | 1,982 |
+| `core/folder-service.ts` | 1,945 |
+| `core/media-asset-service.ts` | 1,540 |
+| `core/filesystem-service.ts` | 1,427 |
+| `core/attachment-service.ts` | 1,386 |
+| `storage/storage-location-service.ts` | 1,016 |
+| `components/file-upload/stores/slices/orchestration-slice.ts` | 1,035 |
+
+`StorageManager` alone owns presigning, multipart, adapter loading, credential resolution, bucket
+routing, `StorageLocation` persistence, folder listing, provider search, webhook processing, health
+checks and usage statistics. Three of those (folders, search, webhooks) exist only for the
+Drive/Dropbox/OneDrive/Box adapters that are stubs.
+
+### 12.5 Module-shape violations vs `docs/lib-module-guide.md`
+
+The guide says: exported `async function`s with `db` first, no service classes,
+`Promise<Result<T, Error>>`, `AuxxError` subclasses, reads and writes in separate files, explicit
+named exports.
+
+`packages/lib/src/files/**` is the opposite on every axis: deep class hierarchies with constructor
+state, bare `Error`, `throw`-based control flow, `export *` in `processors/index.ts`, and
+`any`-typed `tx` parameters throughout. It predates the guide, but it is also the largest module in
+`lib`, so it is what people copy.
+
+### 12.6 `files/types` is a second, undeclared client entry point
+
+`CLAUDE.md` says client code imports from `@auxx/lib/<module>/client`. `files/client.ts` exports
+only file-type constants. Meanwhile the whole front end imports `@auxx/lib/files/types`, which is
+its own `exports` subpath and ships **runtime values** — `ENTITY_CONFIGS`, `getEntityConfig`,
+`FileUploadEventType`, `FileUploadEventValidator`, `DataTransforms`, `TypeGuards` — into the
+browser bundle. It happens to be server-dependency-free today; nothing enforces that.
+
+---
+
+## 13. A Target Design
+
+Not a rewrite — a sequence of independent, shippable changes, most valuable first.
+
+**Tier 1 — correctness (do these regardless of any refactor)**
+
+1. Fix `calculateStorageUsage`: join `FileVersion → FolderFile`, and `UNION` in
+   `MediaAssetVersion → MediaAsset`. Decide whether thumbnails count. (§11.1)
+2. Authenticate `complete`, `parts`, `events`; assert caller identity matches `session.userId`
+   and org. (§11.4)
+3. Move `ensureThumbnailPresets` out of every processor and into the route's Phase 3, after
+   `COMMIT`. Delete the misleading "AFTER transaction commits" comments. (§10.3)
+4. Thread `bucket` through `generatePartUploadUrl`, `completeMultipartUploadOnly` and
+   `deleteByKey`. (§11.5, §11.2)
+5. Have `touchSession` update `expiresAt` too, and floor `remainingTtl` at 1. (§11.6)
+6. Either register a `VisitQcItemProcessor` (attachment-producing) or remove the entity type and
+   the uploader. Meanwhile, make `getForEntityType` **throw** on an unregistered type instead of
+   silently defaulting to `FileProcessor`. (§11.3)
+7. Fill in `WorkflowRunProcessor.validateEntityAccess` and `CustomFieldProcessor`'s fall-through.
+   (§11.8)
+
+**Tier 2 — the transaction**
+
+8. Delete `BaseService.getTx()`. Every service method that writes takes `tx: Transaction` as an
+   explicit parameter. One `BEGIN…COMMIT`, opened by the route.
+9. Move `buildExternalUrl` out of the transaction — compute it in Phase 1 alongside `headByKey`.
+10. Change `BaseProcessor.process` to build tx-bound services into **locals**, never onto `this`.
+11. Make the compensation real: either implement `scheduleCleanup` on Redis/BullMQ, or delete it
+    and rely on a `deleteOrphanedStorageObjects` sweep job. Do not keep a stub on the hot path.
+
+**Tier 3 — deletion**
+
+12. Delete `upload/progress/**`, `upload/progress-publisher.ts`, `upload/upload-session-service.ts`,
+    `upload/enhanced-types.ts`, the `events` route, and `components/file-upload/utils/sse-connection.ts`
+    with its `session-slice` wiring. (~2,900 lines)
+13. Delete `files/cleanup/` once §11.2 is resolved; rename `files/lifecycle/cleanup-service.ts` to
+    something that says what it reaps.
+14. Delete `preferredProvider`, `getMetadata`/`ProcessorMetadata`, and the unused half of
+    `processors/types.ts`.
+
+**Tier 4 — shape**
+
+15. Errors: `AuxxError` subclasses from lib; delete `categorizeError`'s substring ladder and the
+    `temp-${Date.now()}` fake session id.
+16. Split `StorageManager`: `storage/presign.ts`, `storage/objects.ts`, `storage/locations.ts`,
+    `storage/providers.ts`. Drop folder/search/webhook until a non-stub adapter needs them.
+17. Move the `USER_PROFILE` branches out of `complete/route.ts` into a processor
+    `afterCommit(session, result)` hook, so the route stops knowing about avatars.
+18. Make `/api/files/download/[fileId]` redirect to a presigned URL like the attachment routes do,
+    instead of buffering. (§8)
+19. Promote what the front end needs from `files/types` into `files/client.ts` and make
+    `files/types` server-only.
+
+---
+
+## 14. Key Files
+
+**Routes**
+```
+apps/web/src/app/api/files/upload/sessions/route.ts               session create + gates
+apps/web/src/app/api/files/upload/[sessionId]/parts/route.ts      per-part presign
+apps/web/src/app/api/files/upload/[sessionId]/complete/route.ts   the 3-phase completion
+apps/web/src/app/api/files/upload/[sessionId]/events/route.ts     SSE (dead)
+apps/web/src/app/api/files/download/[fileId]/route.ts             buffered download
+apps/web/src/app/api/attachments/[attachmentId]/{content,download,thumbnail}/route.ts
+apps/web/src/app/api/workflows/shared/[shareToken]/files/**       parallel public flow
+```
+
+**Upload pipeline** (`packages/lib/src/files/upload/`)
+```
+session-manager.ts          Redis session CRUD (the live one)
+init-types.ts               UploadInitConfig / UploadPreparedConfig / UploadPolicy / UploadPlan
+util.ts                     deriveStorageKey, getBucketForVisibility, getPublicCdnUrl
+error-handling.ts           UploadErrorHandler (substring classification)
+processors/
+  processor-registry.ts     EntityType → factory
+  index.ts                  initializeProcessors() — the registration table
+  base-processor.ts         processConfig / validateCompletedUpload / process
+  base-asset-processor.ts   + createAsset, policy clamping
+  base-attachment-processor.ts + createAttachment
+  entity-processors.ts      the eight concrete entity processors
+  file-processor.ts         FolderFile fallback
+  dataset.ts                DATASET → MediaAsset + Document + parse queue
+```
+
+**Storage** (`packages/lib/src/files/storage/`, `adapters/`)
+```
+storage-manager.ts          god object; enforcePolicy at :1338
+storage-location-service.ts unscoped singleton, StorageLocation CRUD
+adapters/s3-adapter.ts      presignUpload / presignPart / completeMultipart / head / delete
+adapters/base-adapter.ts    StorageAdapter contract + ProviderId
+```
+
+**Core services** (`packages/lib/src/files/core/`)
+```
+base-service.ts             withTx / getTx / buildBaseWhereClause (+ 500 lines of throw-stubs)
+media-asset-service.ts      createWithVersion, updateContent, getDownloadRef/Url
+file-service.ts             FolderFile + FileVersion
+attachment-service.ts       Attachment
+folder-service.ts / filesystem-service.ts   the file-library tree
+thumbnail-service.ts / thumbnail-batch.ts / thumbnail-enqueue.ts
+```
+
+**Lifecycle**
+```
+packages/lib/src/files/cleanup/cleanup-service.ts     S3 compensation (all stubs)
+packages/lib/src/files/lifecycle/cleanup-service.ts   the real reapers
+packages/lib/src/files/lifecycle/orphaned-cleanup.ts  orphanedFileCleanupJob, deletedFileCleanupJob
+packages/lib/src/files/lifecycle/quota-cleanup.ts     calculateStorageUsage (broken), quota jobs
+apps/worker/src/workers/index.ts                      job scheduling
+```
+
+**Front end** (`apps/web/src/components/file-upload/`)
+```
+hooks/use-file-upload.ts               the public hook
+stores/slices/orchestration-slice.ts   startUpload — the real driver
+utils/direct-upload.ts                 XHR to S3, single + serial multipart
+stores/slices/session-slice.ts         client session containers + dead SSE wiring
+ui/{avatar-upload,file-queue-manager,file-item}.tsx
+```

--- a/packages/lib/src/files/adapters/base-adapter.ts
+++ b/packages/lib/src/files/adapters/base-adapter.ts
@@ -237,25 +237,38 @@ export interface StorageAdapter {
     key: string
     mimeType?: string
     metadata?: Record<string, string>
+    /** Explicit bucket override, for providers that are bucket-addressed. */
+    bucket?: string
+    /** Routes the upload to the provider's public or private bucket. */
+    visibility?: 'PUBLIC' | 'PRIVATE'
   }): Promise<MultipartUpload>
 
   /**
-   * Generate presigned URL for uploading a part
+   * Generate presigned URL for uploading a part.
+   *
+   * `bucket` MUST name the same bucket the multipart upload was initiated in.
+   * Presigning a part against a different bucket yields `NoSuchUpload`.
    */
   presignPart?(params: {
     key: string
     uploadId: string
     partNumber: number
     size?: number
+    /** Bucket the multipart upload was initiated in. Required for bucket-addressed providers. */
+    bucket?: string
   }): Promise<PresignedUpload>
 
   /**
-   * Complete multipart upload
+   * Complete multipart upload.
+   *
+   * `bucket` MUST name the same bucket the multipart upload was initiated in.
    */
   completeMultipart?(params: {
     key: string
     uploadId: string
     parts: Array<{ partNumber: number; etag: string }>
+    /** Bucket the multipart upload was initiated in. Required for bucket-addressed providers. */
+    bucket?: string
   }): Promise<{ etag: string; size?: number }>
 
   // ============= File Management (External Providers) =============
@@ -282,7 +295,12 @@ export interface StorageAdapter {
   }): Promise<{ id: string; rev?: string }>
 
   /**
-   * Delete a file from external storage
+   * Delete a file from external storage.
+   *
+   * For bucket-addressed providers the bucket travels on `loc.metadata.bucket`.
+   * Adapters must NOT silently fall back to a configured default bucket: S3
+   * answers 204 for a delete of a key that does not exist, so a wrong-bucket
+   * delete looks like a success while the real object leaks.
    */
   deleteFile?(loc: StorageLocationRef, auth?: ProviderAuth): Promise<void>
 

--- a/packages/lib/src/files/adapters/s3-adapter.ts
+++ b/packages/lib/src/files/adapters/s3-adapter.ts
@@ -540,7 +540,12 @@ export class S3Adapter extends BaseStorageAdapter {
   }
 
   /**
-   * Generate S3 presigned URL for multipart upload part
+   * Generate S3 presigned URL for multipart upload part.
+   *
+   * `params.bucket` is required and must name the bucket `startMultipart` used.
+   * There is deliberately no `S3_PRIVATE_BUCKET` fallback here: a PUBLIC upload
+   * that initiates in the public bucket and presigns its parts against the
+   * private one fails with `NoSuchUpload`.
    */
   async presignPart(params: {
     key: string
@@ -554,13 +559,10 @@ export class S3Adapter extends BaseStorageAdapter {
     this.requireCapability('presignUpload')
 
     try {
-      const bucket =
-        params.bucket ||
-        (params.auth as any)?.bucket ||
-        configService.get<string>('S3_PRIVATE_BUCKET')
+      const bucket = params.bucket
       if (!bucket) {
         throw new StorageAdapterError(
-          'S3 bucket name is required for part upload. Please provide a bucket via params, credentials, or configure S3_PRIVATE_BUCKET.',
+          'S3 bucket name is required for part upload. Pass the bucket the multipart upload was initiated in (upload session `bucket`) — presigning a part against a different bucket fails with NoSuchUpload.',
           this.id,
           'presignPart'
         )
@@ -590,7 +592,10 @@ export class S3Adapter extends BaseStorageAdapter {
   }
 
   /**
-   * Complete S3 multipart upload
+   * Complete S3 multipart upload.
+   *
+   * `params.bucket` is required and must name the bucket `startMultipart` used.
+   * See {@link presignPart} for why there is no configured-default fallback.
    */
   async completeMultipart(params: {
     key: string
@@ -602,13 +607,10 @@ export class S3Adapter extends BaseStorageAdapter {
     this.requireCapability('presignUpload')
 
     try {
-      const bucket =
-        params.bucket ||
-        (params.auth as any)?.bucket ||
-        configService.get<string>('S3_PRIVATE_BUCKET')
+      const bucket = params.bucket
       if (!bucket) {
         throw new StorageAdapterError(
-          'S3 bucket name is required to complete multipart upload. Please provide a bucket via params, credentials, or configure S3_PRIVATE_BUCKET.',
+          'S3 bucket name is required to complete multipart upload. Pass the bucket the multipart upload was initiated in (upload session `bucket`) — completing against a different bucket fails with NoSuchUpload.',
           this.id,
           'completeMultipart'
         )
@@ -711,11 +713,16 @@ export class S3Adapter extends BaseStorageAdapter {
   }
 
   /**
-   * Delete S3 object
+   * Delete S3 object.
+   *
+   * Unlike the read paths this does NOT fall back to the configured default
+   * bucket. S3 returns 204 when the key does not exist, so deleting from the
+   * wrong bucket succeeds silently while the real object leaks — the exact
+   * failure mode of the upload compensation path for PUBLIC uploads.
    */
   async deleteFile(loc: StorageLocationRef, auth?: ProviderAuth): Promise<void> {
     try {
-      const s3Location = this.parseS3Location(loc, auth)
+      const s3Location = this.resolveDeleteTarget(loc)
       const client = this.createS3Client(auth, s3Location)
 
       const command = new DeleteObjectCommand({
@@ -898,6 +905,34 @@ export class S3Adapter extends BaseStorageAdapter {
       `Invalid S3 location format: ${externalId}. Either provide s3://bucket/key format, bucket/key format, or configure S3_PRIVATE_BUCKET.`,
       this.id,
       'parseLocation'
+    )
+  }
+
+  /**
+   * Resolve the bucket + key for a delete, with no default-bucket fallback.
+   *
+   * The bucket must be explicit: on `loc.metadata.bucket` (what
+   * `StorageManager.deleteByKey` and `buildLocationRef` put there) or encoded in
+   * an `s3://bucket/key` externalId. Anything else is a programming error.
+   */
+  private resolveDeleteTarget(loc: StorageLocationRef): S3Metadata {
+    this.validateLocation(loc)
+
+    const metadata = loc.metadata as Partial<S3Metadata> | undefined
+
+    if (metadata?.bucket) {
+      return { ...metadata, bucket: metadata.bucket, key: metadata.key || loc.externalId }
+    }
+
+    if (loc.externalId.startsWith('s3://')) {
+      const url = new URL(loc.externalId)
+      return { ...metadata, bucket: url.hostname, key: url.pathname.slice(1) }
+    }
+
+    throw new StorageAdapterError(
+      `Cannot delete S3 object '${loc.externalId}': no bucket on the storage location. Pass \`bucket\` to StorageManager.deleteByKey, or persist it in StorageLocation.metadata.bucket. Deleting against a default bucket would 204 on a missing key and leak the real object.`,
+      this.id,
+      'deleteFile'
     )
   }
 

--- a/packages/lib/src/files/cleanup/cleanup-service.ts
+++ b/packages/lib/src/files/cleanup/cleanup-service.ts
@@ -1,256 +1,48 @@
 // packages/lib/src/files/cleanup/cleanup-service.ts
 
-import { createScopedLogger } from '@auxx/logger'
+import { enqueueOrphanedStorageObjectCleanup } from '../../jobs/maintenance/orphaned-storage-object-job'
 import type { ProviderId } from '../adapters/base-adapter'
-import { createStorageManager } from '../storage/storage-manager'
-
-const logger = createScopedLogger('cleanup-service')
 
 /**
- * Cleanup task for orphaned S3 objects
+ * Compensation shim for orphaned storage objects.
+ *
+ * This used to be a `CleanupService` whose every persistence method was a
+ * `// TODO` stub that logged and returned — `scheduleCleanup` persisted nothing,
+ * so a failed upload transaction leaked its S3 object forever
+ * (`docs/files-upload-architecture-guide.md` §11.2).
+ *
+ * It now forwards to a real BullMQ job on the maintenance queue. The object
+ * shape is kept only so the existing compensation call site in
+ * `apps/web/src/app/api/files/upload/[sessionId]/complete/route.ts` keeps
+ * compiling; new code should call {@link enqueueOrphanedStorageObjectCleanup}
+ * directly.
+ *
+ * @deprecated Call `enqueueOrphanedStorageObjectCleanup` from `@auxx/lib/jobs`.
  */
-export interface CleanupTask {
-  id: string
-  provider: ProviderId
-  storageKey: string
-  credentialId?: string
-  attempts: number
-  maxAttempts: number
-  nextAttempt: Date
-  createdAt: Date
-  reason: string
-  organizationId?: string
-}
-
-/**
- * Service for managing cleanup of orphaned storage objects
- * Handles compensation when DB transactions fail after S3 operations
- */
-export class CleanupService {
-  private readonly maxAttempts = 5
-  private readonly baseDelayMs = 1000 // 1 second base delay
-  private readonly maxDelayMs = 30 * 60 * 1000 // 30 minutes max delay
-
+export const cleanupService = {
   /**
-   * Schedule S3 object for deletion (compensation mechanism)
-   * Used when DB transaction fails after S3 upload completion
+   * Durably schedule deletion of an orphaned storage object.
+   *
+   * @param params.bucket - The bucket the object actually lives in (the upload
+   *   session's `bucket`). Without it the delete targets the provider default,
+   *   which for a PUBLIC upload is the wrong bucket — S3 answers 204 and the
+   *   real object leaks.
    */
   async scheduleCleanup(params: {
     provider: ProviderId
     storageKey: string
+    bucket?: string
     credentialId?: string
     reason: string
     organizationId?: string
   }): Promise<void> {
-    const task: Omit<CleanupTask, 'id'> = {
+    await enqueueOrphanedStorageObjectCleanup({
       provider: params.provider,
-      storageKey: params.storageKey,
+      bucket: params.bucket,
+      key: params.storageKey,
       credentialId: params.credentialId,
-      attempts: 0,
-      maxAttempts: this.maxAttempts,
-      nextAttempt: new Date(), // Immediate first attempt
-      createdAt: new Date(),
-      reason: params.reason,
       organizationId: params.organizationId,
-    }
-
-    try {
-      // For now, store in Redis (could be DB table for persistence)
-      // In production, use Redis or database storage
-      await this.storeCleanupTask(task)
-
-      logger.info('Scheduled cleanup task', {
-        provider: params.provider,
-        storageKey: params.storageKey,
-        reason: params.reason,
-      })
-    } catch (error) {
-      logger.error('Failed to schedule cleanup task', {
-        provider: params.provider,
-        storageKey: params.storageKey,
-        error: error instanceof Error ? error.message : String(error),
-      })
-      // Don't throw - cleanup is best-effort
-    }
-  }
-
-  /**
-   * Process pending cleanup tasks
-   * Should be called by background job/worker
-   */
-  async processCleanupTasks(): Promise<{
-    processed: number
-    succeeded: number
-    failed: number
-    errors: string[]
-  }> {
-    const tasks = await this.getPendingTasks()
-    const errors: string[] = []
-    let succeeded = 0
-    let failed = 0
-
-    for (const task of tasks) {
-      try {
-        const success = await this.executeCleanupTask(task)
-        if (success) {
-          succeeded++
-          await this.markTaskCompleted(task.id)
-        } else {
-          failed++
-          await this.handleTaskFailure(task)
-        }
-      } catch (error) {
-        failed++
-        const errorMessage = error instanceof Error ? error.message : String(error)
-        errors.push(`Task ${task.id}: ${errorMessage}`)
-
-        logger.error('Cleanup task execution failed', {
-          taskId: task.id,
-          provider: task.provider,
-          storageKey: task.storageKey,
-          error: errorMessage,
-        })
-
-        await this.handleTaskFailure(task)
-      }
-    }
-
-    logger.info('Cleanup batch processed', {
-      total: tasks.length,
-      succeeded,
-      failed,
-      errorCount: errors.length,
+      reason: params.reason,
     })
-
-    return {
-      processed: tasks.length,
-      succeeded,
-      failed,
-      errors,
-    }
-  }
-
-  /**
-   * Execute a single cleanup task
-   */
-  private async executeCleanupTask(task: CleanupTask): Promise<boolean> {
-    try {
-      // Create storage manager with organization ID from task (optional)
-      const storageManager = createStorageManager(task.organizationId)
-
-      await storageManager.deleteByKey({
-        provider: task.provider,
-        key: task.storageKey,
-        credentialId: task.credentialId,
-      })
-
-      logger.info('Successfully deleted orphaned object', {
-        provider: task.provider,
-        storageKey: task.storageKey,
-        attempts: task.attempts + 1,
-      })
-
-      return true
-    } catch (error) {
-      logger.warn('Failed to delete orphaned object', {
-        provider: task.provider,
-        storageKey: task.storageKey,
-        attempts: task.attempts + 1,
-        error: error instanceof Error ? error.message : String(error),
-      })
-
-      return false
-    }
-  }
-
-  /**
-   * Handle task failure (retry with exponential backoff or give up)
-   */
-  private async handleTaskFailure(task: CleanupTask): Promise<void> {
-    const newAttempts = task.attempts + 1
-
-    if (newAttempts >= task.maxAttempts) {
-      // Give up after max attempts
-      await this.markTaskFailed(task.id, 'Max attempts exceeded')
-
-      logger.warn('Cleanup task abandoned after max attempts', {
-        taskId: task.id,
-        provider: task.provider,
-        storageKey: task.storageKey,
-        attempts: newAttempts,
-      })
-    } else {
-      // Schedule retry with exponential backoff
-      const delayMs = Math.min(this.baseDelayMs * 2 ** (newAttempts - 1), this.maxDelayMs)
-
-      const nextAttempt = new Date(Date.now() + delayMs)
-
-      await this.updateTaskRetry(task.id, newAttempts, nextAttempt)
-
-      logger.info('Cleanup task scheduled for retry', {
-        taskId: task.id,
-        provider: task.provider,
-        storageKey: task.storageKey,
-        attempts: newAttempts,
-        nextAttempt: nextAttempt.toISOString(),
-      })
-    }
-  }
-
-  /**
-   * Get cleanup statistics
-   */
-  async getCleanupStats(): Promise<{
-    pendingTasks: number
-    completedTasks: number
-    failedTasks: number
-  }> {
-    // Implementation depends on storage backend
-    // For now, return dummy data
-    return {
-      pendingTasks: 0,
-      completedTasks: 0,
-      failedTasks: 0,
-    }
-  }
-
-  // ============= Storage Backend Methods =============
-  // These would be implemented with Redis or database
-
-  private async storeCleanupTask(task: Omit<CleanupTask, 'id'>): Promise<void> {
-    // TODO: Implement with Redis or database
-    // For now, log only (in production this would persist the task)
-    logger.info('Would store cleanup task', { task })
-  }
-
-  private async getPendingTasks(): Promise<CleanupTask[]> {
-    // TODO: Implement with Redis or database
-    // For now, return empty array
-    return []
-  }
-
-  private async markTaskCompleted(taskId: string): Promise<void> {
-    // TODO: Implement with Redis or database
-    logger.info('Would mark task completed', { taskId })
-  }
-
-  private async markTaskFailed(taskId: string, reason: string): Promise<void> {
-    // TODO: Implement with Redis or database
-    logger.warn('Would mark task failed', { taskId, reason })
-  }
-
-  private async updateTaskRetry(
-    taskId: string,
-    attempts: number,
-    nextAttempt: Date
-  ): Promise<void> {
-    // TODO: Implement with Redis or database
-    logger.info('Would update task retry', { taskId, attempts, nextAttempt })
-  }
+  },
 }
-
-// Export singleton instance
-export const cleanupService = new CleanupService()
-
-// Factory function for dependency injection
-export const createCleanupService = () => new CleanupService()

--- a/packages/lib/src/files/lifecycle/__tests__/orphaned-cleanup.test.ts
+++ b/packages/lib/src/files/lifecycle/__tests__/orphaned-cleanup.test.ts
@@ -1,0 +1,167 @@
+// packages/lib/src/files/lifecycle/__tests__/orphaned-cleanup.test.ts
+
+/**
+ * Regression test for `docs/files-upload-architecture-guide.md` §11.2.
+ *
+ * `deletedFileCleanupJob`'s Phase-2 StorageLocation sweep called
+ * `deleteByKey({ provider, key })` with no bucket, so it aimed at the provider
+ * default (private) bucket. S3 answers 204 for a key that is not there, so a
+ * PUBLIC-bucket object was counted as swept, its DB row hard-deleted, and the
+ * real object left behind with nothing left pointing at it.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({ db: null as any }))
+
+// Partial-mock the logger: `@auxx/logger/run-log` imports sink-registration
+// helpers from this barrel at load, so a full replacement breaks whichever
+// test file happens to load it first.
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+vi.mock('@auxx/database', async () => {
+  const { createSchemaMock } = await import('../../../test/database-mock')
+  return {
+    database: {
+      get query() {
+        return h.db.query
+      },
+      select: (...args: unknown[]) => h.db.select(...args),
+      delete: (...args: unknown[]) => h.db.delete(...args),
+    },
+    schema: createSchemaMock(),
+    IntegrationProviderTypeValues: ['google', 'outlook'],
+  }
+})
+
+vi.mock('../cleanup-service', () => ({
+  deleteExpiredFiles: vi.fn(async () => ({ deleted: 0, failed: 0 })),
+  deleteFilesByIds: vi.fn(async () => ({ deleted: 0, failed: 0 })),
+}))
+
+const mockDeleteByKey = vi.fn().mockResolvedValue(undefined)
+vi.mock('../../storage/storage-manager', () => ({
+  StorageManager: class {
+    deleteByKey = mockDeleteByKey
+  },
+}))
+
+import type { JobContext } from '../../../jobs/types'
+import { deletedFileCleanupJob } from '../orphaned-cleanup'
+
+type MarkedLocation = {
+  id: string
+  provider: string
+  externalId: string
+  organizationId: string | null
+  metadata?: Record<string, unknown> | null
+}
+
+/**
+ * Drizzle-shaped stub covering the two reads this job makes: the soft-deleted
+ * `FolderFile` scan (relational query) and the marked-`StorageLocation` sweep
+ * (`select(projection).from(...).where(...).limit(n)`). The projection is
+ * recorded because that is where a missing `metadata` column shows up.
+ */
+function createFakeDb(locations: MarkedLocation[]) {
+  const projections: Record<string, unknown>[] = []
+
+  return {
+    projections,
+    db: {
+      query: { FolderFile: { findMany: async () => [] } },
+      select: (projection: Record<string, unknown>) => {
+        projections.push(projection)
+        const shaped = locations.map((row) =>
+          Object.fromEntries(
+            Object.keys(projection).map((key) => [key, (row as Record<string, unknown>)[key]])
+          )
+        )
+        const chain: any = {
+          from: () => chain,
+          where: () => chain,
+          limit: async () => shaped,
+        }
+        return chain
+      },
+      delete: () => ({ where: async () => undefined }),
+    },
+  }
+}
+
+function ctx(): JobContext<{ batchSize?: number; dryRun?: boolean }> {
+  const data = { batchSize: 100, dryRun: false }
+  return {
+    job: { data, updateProgress: vi.fn() },
+    data,
+    jobId: 'job-1',
+  } as unknown as JobContext<{ batchSize?: number; dryRun?: boolean }>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.db = null
+})
+
+describe('deletedFileCleanupJob → StorageLocation sweep', () => {
+  it('deletes from the bucket recorded on the StorageLocation, not the provider default', async () => {
+    const fake = createFakeDb([
+      {
+        id: 'loc-public',
+        provider: 'S3',
+        externalId: 'org123/avatars/a.png',
+        organizationId: 'org123',
+        metadata: { bucket: 'test-public-bucket', key: 'org123/avatars/a.png' },
+      },
+    ])
+    h.db = fake.db
+
+    await deletedFileCleanupJob(ctx())
+
+    expect(mockDeleteByKey).toHaveBeenCalledTimes(1)
+    expect(mockDeleteByKey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'S3',
+        key: 'org123/avatars/a.png',
+        bucket: 'test-public-bucket',
+      })
+    )
+  })
+
+  it('selects the metadata column so the bucket is available at all', async () => {
+    const fake = createFakeDb([])
+    h.db = fake.db
+
+    await deletedFileCleanupJob(ctx())
+
+    expect(fake.projections[0]).toBeDefined()
+    expect(Object.keys(fake.projections[0]!)).toContain('metadata')
+  })
+
+  it('leaves the bucket undefined for a row that has none rather than inventing one', async () => {
+    const fake = createFakeDb([
+      {
+        id: 'loc-legacy',
+        provider: 'S3',
+        externalId: 'org123/legacy.bin',
+        organizationId: 'org123',
+        metadata: {},
+      },
+    ])
+    h.db = fake.db
+
+    await deletedFileCleanupJob(ctx())
+
+    expect(mockDeleteByKey).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'org123/legacy.bin', bucket: undefined })
+    )
+  })
+})

--- a/packages/lib/src/files/lifecycle/__tests__/quota-cleanup.test.ts
+++ b/packages/lib/src/files/lifecycle/__tests__/quota-cleanup.test.ts
@@ -1,0 +1,173 @@
+// packages/lib/src/files/lifecycle/__tests__/quota-cleanup.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({ db: null as any }))
+
+// Partial-mock the logger: `@auxx/logger/run-log` imports sink-registration
+// helpers from this barrel at load, so a full replacement breaks whichever
+// test file happens to load it first.
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+vi.mock('@auxx/database', async () => {
+  const { createSchemaMock } = await import('../../../test/database-mock')
+  return {
+    // `database` is only ever reached through the test-controlled stub below.
+    database: { select: (...args: unknown[]) => h.db.select(...args) },
+    // Auto-vivifying + memoized, so `schema.Foo === schema.Foo` and table
+    // references stay comparable by identity (columns remain `{}`).
+    schema: createSchemaMock(),
+    IntegrationProviderTypeValues: ['google', 'outlook'],
+  }
+})
+
+import { schema } from '@auxx/database'
+import { calculateStorageUsage } from '../quota-cleanup'
+
+type Lane = 'folder' | 'media'
+
+/** Aggregate row shape as node-postgres returns it: bigint sums arrive as strings. */
+type AggregateRow = { totalSize: string | null; count: string }
+
+/**
+ * Identify which storage lane a query walks purely from the table references it
+ * touched. Table identity is the one thing that IS assertable under this repo's
+ * vitest setup (columns resolve to `{}`), and it is exactly what the bug is
+ * about: the broken query joined `File` instead of `FolderFile`, and never
+ * looked at `MediaAsset` at all.
+ */
+function laneOf(tables: unknown[]): Lane | 'unknown' {
+  if (tables.includes(schema.FileVersion) && tables.includes(schema.FolderFile)) return 'folder'
+  if (tables.includes(schema.MediaAssetVersion) && tables.includes(schema.MediaAsset))
+    return 'media'
+  return 'unknown'
+}
+
+/**
+ * Minimal Drizzle-shaped stub. Sub-selects end at `.as()` and hand back a tagged
+ * marker; the outer aggregate that selects `.from(marker)` resolves to the rows
+ * canned for that lane. A query that reaches neither lane resolves to `[]`,
+ * which is what today's broken `FileVersion ⋈ File` join does in production.
+ */
+function createFakeDb(rows: Partial<Record<Lane, AggregateRow[]>>) {
+  const lanesSeen: Array<Lane | 'unknown'> = []
+  const tablesSeen: unknown[][] = []
+
+  const select = () => {
+    const tables: unknown[] = []
+    let lane: Lane | 'unknown' | undefined
+
+    const chain: any = {
+      from: (source: any) => {
+        if (source && typeof source === 'object' && '__lane' in source) lane = source.__lane
+        else tables.push(source)
+        return chain
+      },
+      innerJoin: (table: unknown) => {
+        tables.push(table)
+        return chain
+      },
+      leftJoin: (table: unknown) => {
+        tables.push(table)
+        return chain
+      },
+      where: () => chain,
+      groupBy: () => chain,
+      as: () => {
+        const resolved = laneOf(tables)
+        lanesSeen.push(resolved)
+        tablesSeen.push(tables)
+        return { __lane: resolved }
+      },
+      then: (resolve: (value: AggregateRow[]) => void) => {
+        if (lane === undefined) {
+          // Directly-awaited chain (no sub-select): record what it touched.
+          const resolved = laneOf(tables)
+          lanesSeen.push(resolved)
+          tablesSeen.push(tables)
+          resolve(resolved === 'unknown' ? [] : (rows[resolved] ?? []))
+          return
+        }
+        resolve(lane === 'unknown' ? [] : (rows[lane] ?? []))
+      },
+    }
+    return chain
+  }
+
+  return { db: { select }, lanesSeen, tablesSeen }
+}
+
+describe('calculateStorageUsage', () => {
+  beforeEach(() => {
+    h.db = null
+  })
+
+  it('counts MediaAsset-backed storage', async () => {
+    const fake = createFakeDb({
+      folder: [{ totalSize: null, count: '0' }],
+      media: [{ totalSize: '1640968278', count: '3737' }],
+    })
+    h.db = fake.db
+
+    const quota = await calculateStorageUsage('org-1')
+
+    expect(quota.totalUsed).toBe(1640968278)
+    expect(typeof quota.totalUsed).toBe('number')
+    expect(quota.fileCount).toBe(3737)
+    expect(quota.percentUsed).toBeGreaterThan(0)
+    expect(fake.lanesSeen).toContain('media')
+  })
+
+  it('counts FolderFile-backed storage and joins FolderFile, not the legacy File table', async () => {
+    const fake = createFakeDb({
+      folder: [{ totalSize: '4096', count: '1' }],
+      media: [{ totalSize: null, count: '0' }],
+    })
+    h.db = fake.db
+
+    const quota = await calculateStorageUsage('org-1')
+
+    expect(quota.totalUsed).toBe(4096)
+    expect(quota.fileCount).toBe(1)
+    expect(fake.lanesSeen).toContain('folder')
+
+    const folderTables = fake.tablesSeen.find((tables) => laneOf(tables) === 'folder')
+    expect(folderTables).toBeDefined()
+    expect(folderTables).not.toContain(schema.File)
+  })
+
+  it('sums both lanes', async () => {
+    const fake = createFakeDb({
+      folder: [{ totalSize: '4096', count: '1' }],
+      media: [{ totalSize: '1000', count: '2' }],
+    })
+    h.db = fake.db
+
+    const quota = await calculateStorageUsage('org-1')
+
+    expect(quota.totalUsed).toBe(5096)
+    expect(quota.fileCount).toBe(3)
+  })
+
+  it('reports zero for an organization with no stored objects', async () => {
+    const fake = createFakeDb({
+      folder: [{ totalSize: null, count: '0' }],
+      media: [{ totalSize: null, count: '0' }],
+    })
+    h.db = fake.db
+
+    const quota = await calculateStorageUsage('org-empty')
+
+    expect(quota.totalUsed).toBe(0)
+    expect(quota.fileCount).toBe(0)
+    expect(quota.percentUsed).toBe(0)
+  })
+})

--- a/packages/lib/src/files/lifecycle/quota-cleanup.ts
+++ b/packages/lib/src/files/lifecycle/quota-cleanup.ts
@@ -3,7 +3,7 @@
 import { database as db, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
-import { and, asc, eq, isNull, lt, sql } from 'drizzle-orm'
+import { and, asc, eq, isNotNull, isNull, lt, sql } from 'drizzle-orm'
 import type { JobContext } from '../../jobs/types'
 import type { StorageQuota } from './types'
 
@@ -17,22 +17,111 @@ const DEFAULT_QUOTAS = {
   enterprise: 500 * 1024 * 1024 * 1024, // 500 GB
 }
 
+/** Aggregate of stored bytes and stored objects for one storage lane. */
+type LaneUsage = { totalSize: number; count: number }
+
+/** `sum()`/`count()` over bigint come back from node-postgres as strings. */
+function toNumber(value: unknown): number {
+  const parsed = Number(value ?? 0)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
 /**
- * Calculate storage usage for an organization
+ * Bytes and object count for files living in folders (`FolderFile` → `FileVersion`).
+ *
+ * Deduplicated by `storageLocationId`: two version rows pointing at the same
+ * `StorageLocation` are one object in the bucket. Nothing in the current write
+ * path shares a location between versions, but neither table constrains it, so
+ * the grouping makes the invariant structural rather than assumed.
  */
-export async function calculateStorageUsage(organizationId: string): Promise<StorageQuota> {
-  // Get total file size for the organization
-  const [result] = await db
+async function sumFolderFileUsage(organizationId: string): Promise<LaneUsage> {
+  const locations = db
     .select({
-      totalSize: sql<number>`sum(${schema.FileVersion.size})`,
-      count: sql<number>`count(*)`,
+      locationId: schema.FileVersion.storageLocationId,
+      size: sql<number>`max(${schema.FileVersion.size})`.as('size'),
     })
     .from(schema.FileVersion)
-    .leftJoin(schema.File, eq(schema.FileVersion.fileId, schema.File.id))
-    .where(and(eq(schema.File.organizationId, organizationId), isNull(schema.File.deletedAt)))
+    .innerJoin(schema.FolderFile, eq(schema.FileVersion.fileId, schema.FolderFile.id))
+    .where(
+      and(eq(schema.FolderFile.organizationId, organizationId), isNull(schema.FolderFile.deletedAt))
+    )
+    .groupBy(schema.FileVersion.storageLocationId)
+    .as('folder_file_locations')
 
-  const totalUsed = result?.totalSize || 0
-  const fileCount = result?.count || 0
+  const [row] = await db
+    .select({
+      totalSize: sql<string>`coalesce(sum(${locations.size}), 0)`,
+      count: sql<string>`count(*)`,
+    })
+    .from(locations)
+
+  return { totalSize: toNumber(row?.totalSize), count: toNumber(row?.count) }
+}
+
+/**
+ * Bytes and object count for media assets (`MediaAsset` → `MediaAssetVersion`).
+ *
+ * This is where essentially all real usage lives: avatars, mail attachments,
+ * comment attachments, custom-field files, KB logos and dataset documents are
+ * all `MediaAsset` rows.
+ *
+ * Derived thumbnails are counted deliberately. They are separate
+ * `MediaAssetVersion` rows (linked by `derivedFromVersionId`/`preset`) holding
+ * real objects in the bucket that we really pay for, so excluding them would
+ * under-report the quota. Same `storageLocationId` grouping as above, which is
+ * what keeps a thumbnail and its source from ever being counted twice.
+ */
+async function sumMediaAssetUsage(organizationId: string): Promise<LaneUsage> {
+  const locations = db
+    .select({
+      locationId: schema.MediaAssetVersion.storageLocationId,
+      size: sql<number>`max(${schema.MediaAssetVersion.size})`.as('size'),
+    })
+    .from(schema.MediaAssetVersion)
+    .innerJoin(schema.MediaAsset, eq(schema.MediaAssetVersion.assetId, schema.MediaAsset.id))
+    .where(
+      and(
+        eq(schema.MediaAsset.organizationId, organizationId),
+        isNull(schema.MediaAsset.deletedAt),
+        isNull(schema.MediaAssetVersion.deletedAt),
+        isNotNull(schema.MediaAssetVersion.storageLocationId)
+      )
+    )
+    .groupBy(schema.MediaAssetVersion.storageLocationId)
+    .as('media_asset_locations')
+
+  const [row] = await db
+    .select({
+      totalSize: sql<string>`coalesce(sum(${locations.size}), 0)`,
+      count: sql<string>`count(*)`,
+    })
+    .from(locations)
+
+  return { totalSize: toNumber(row?.totalSize), count: toNumber(row?.count) }
+}
+
+/**
+ * Calculate storage usage for an organization.
+ *
+ * Sums both storage lanes — `FolderFile`/`FileVersion` and
+ * `MediaAsset`/`MediaAssetVersion` — restricted to rows whose owning record is
+ * not soft-deleted. Derived thumbnails count; they are real stored bytes.
+ *
+ * `fileCount` is the number of **distinct stored objects** (`StorageLocation`
+ * rows referenced by a live version), not the number of user-visible files: a
+ * file with N versions plus M generated thumbnails occupies N + M objects.
+ * That is the figure that lines up with `totalUsed`.
+ *
+ * @param organizationId Organization to measure.
+ */
+export async function calculateStorageUsage(organizationId: string): Promise<StorageQuota> {
+  const [folderFiles, mediaAssets] = await Promise.all([
+    sumFolderFileUsage(organizationId),
+    sumMediaAssetUsage(organizationId),
+  ])
+
+  const totalUsed = folderFiles.totalSize + mediaAssets.totalSize
+  const fileCount = folderFiles.count + mediaAssets.count
 
   // Get organization's quota limit (would need to be added to Organization model)
   // For now, using a default

--- a/packages/lib/src/files/storage/__tests__/multipart-bucket-routing.test.ts
+++ b/packages/lib/src/files/storage/__tests__/multipart-bucket-routing.test.ts
@@ -1,0 +1,189 @@
+// packages/lib/src/files/storage/__tests__/multipart-bucket-routing.test.ts
+
+/**
+ * Regression tests for `docs/files-upload-architecture-guide.md` §11.5 / §10.4.
+ *
+ * `startMultipartUploadFromConfig` forwards `config.bucket`, but the three
+ * follow-up calls (`generatePartUploadUrl`, `completeMultipartUploadOnly`,
+ * `deleteByKey`) took no bucket at all, so the S3 adapter fell back to
+ * `S3_PRIVATE_BUCKET`. A PUBLIC multipart upload therefore initiated in the
+ * public bucket and presigned its parts against the private one (`NoSuchUpload`),
+ * and the compensation delete removed a nonexistent key from the private bucket
+ * while the real public object leaked.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { StorageManager } from '../storage-manager'
+
+vi.mock('@auxx/credentials', () => ({
+  configService: {
+    get: vi.fn(),
+  },
+}))
+vi.mock('@auxx/credentials/store', () => ({
+  revealSecrets: vi.fn().mockResolvedValue({
+    isErr: () => false,
+    value: {
+      record: { metadata: { region: 'us-east-1', bucket: 'test-private-bucket' } },
+      secrets: { accessToken: 'mock-access-token' },
+    },
+  }),
+}))
+
+// Partial mock: `@auxx/logger/run-log` imports sink-registration helpers from this
+// barrel at module load, so a full replacement breaks whichever test file happens
+// to load it first.
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('../storage-location-service', () => ({
+  storageLocationService: {
+    get: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getStats: vi.fn(),
+    getLocationsByProvider: vi.fn(),
+    getLocationsByCredential: vi.fn(),
+    findByExternalId: vi.fn(),
+  },
+}))
+
+vi.mock('../../upload/util', () => ({
+  getBucketForVisibility: vi.fn((visibility: 'PUBLIC' | 'PRIVATE') =>
+    visibility === 'PUBLIC' ? 'test-public-bucket' : 'test-private-bucket'
+  ),
+}))
+
+const mockPresignPart = vi.fn().mockResolvedValue({
+  url: 'https://example.s3.amazonaws.com/part',
+  expiresAt: new Date(Date.now() + 3600_000),
+})
+
+const mockCompleteMultipart = vi.fn().mockResolvedValue({ etag: 'etag-123' })
+
+const mockDeleteFile = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../../adapters/s3-adapter', () => ({
+  default: class MockS3Adapter {
+    credentialProviderId = 'S3'
+
+    getCapabilities() {
+      return {
+        presignUpload: true,
+        presignDownload: true,
+        serverSideDownload: false,
+        versioning: false,
+        webhooks: false,
+        folders: false,
+        search: false,
+        metadata: true,
+        multipart: true,
+      }
+    }
+
+    resolvePlatformAuth() {
+      return {
+        region: 'us-east-1',
+        bucket: 'test-private-bucket',
+        publicBucket: 'test-public-bucket',
+      }
+    }
+
+    resolveBucket() {
+      return 'test-private-bucket'
+    }
+
+    presignPart = mockPresignPart
+    completeMultipart = mockCompleteMultipart
+    deleteFile = mockDeleteFile
+  },
+}))
+
+describe('StorageManager – bucket routing for multipart parts, completion and compensation', () => {
+  let manager: StorageManager
+
+  beforeEach(() => {
+    // Clear the private static adapter cache so each test starts fresh.
+    ;(StorageManager as any).adapterCache = new Map()
+    manager = new StorageManager('org123')
+    vi.clearAllMocks()
+  })
+
+  it('forwards the caller-supplied bucket to presignPart (§11.5)', async () => {
+    await manager.generatePartUploadUrl({
+      provider: 'S3',
+      key: 'org123/avatar.mp4',
+      uploadId: 'upload-1',
+      partNumber: 1,
+      size: 5 * 1024 * 1024,
+      bucket: 'test-public-bucket',
+    })
+
+    expect(mockPresignPart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'org123/avatar.mp4',
+        uploadId: 'upload-1',
+        partNumber: 1,
+        bucket: 'test-public-bucket',
+      })
+    )
+  })
+
+  it('forwards the caller-supplied bucket to completeMultipart (§11.5)', async () => {
+    await manager.completeMultipartUploadOnly({
+      provider: 'S3',
+      key: 'org123/avatar.mp4',
+      uploadId: 'upload-1',
+      parts: [{ partNumber: 1, etag: 'etag-1' }],
+      bucket: 'test-public-bucket',
+    })
+
+    expect(mockCompleteMultipart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'org123/avatar.mp4',
+        uploadId: 'upload-1',
+        bucket: 'test-public-bucket',
+      })
+    )
+  })
+
+  it('targets the caller-supplied bucket when compensating with deleteByKey (§10.4)', async () => {
+    await manager.deleteByKey({
+      provider: 'S3',
+      key: 'org123/avatar.png',
+      bucket: 'test-public-bucket',
+    })
+
+    expect(mockDeleteFile).toHaveBeenCalledTimes(1)
+    const [locationRef] = mockDeleteFile.mock.calls[0]!
+    expect(locationRef).toEqual(
+      expect.objectContaining({
+        provider: 'S3',
+        externalId: 'org123/avatar.png',
+        metadata: expect.objectContaining({
+          bucket: 'test-public-bucket',
+          key: 'org123/avatar.png',
+        }),
+      })
+    )
+  })
+
+  it('still resolves a bucket for legacy deleteByKey callers that pass none', async () => {
+    await manager.deleteByKey({
+      provider: 'S3',
+      key: 'org123/legacy.png',
+    })
+
+    expect(mockDeleteFile).toHaveBeenCalledTimes(1)
+    const [locationRef] = mockDeleteFile.mock.calls[0]!
+    expect(locationRef.metadata?.bucket).toBe('test-private-bucket')
+  })
+})

--- a/packages/lib/src/files/storage/storage-manager.ts
+++ b/packages/lib/src/files/storage/storage-manager.ts
@@ -681,16 +681,29 @@ export class StorageManager {
       throw new StorageFileNotFoundError('UNKNOWN' as ProviderId, locationId)
     }
 
+    // Load the adapter FIRST: `buildLocationRef` reads `adapter.resolveBucket()`
+    // out of the adapter cache to fill in `metadata.bucket` for rows persisted
+    // without one, and the adapter's delete no longer resolves a default itself.
+    const adapter = await this.getAdapter(storageLocation.provider as ProviderId)
+
     // Build location reference
     const locationRef = this.buildLocationRef(storageLocation)
-
-    // Get adapter for the provider
-    const adapter = await this.getAdapter(locationRef.provider)
 
     // Get authentication if credential ID provided
     let auth: ProviderAuth | undefined
     if (locationRef.credentialId) {
       auth = await this.getProviderAuth(locationRef.provider, locationRef.credentialId)
+    }
+
+    if (locationRef.provider === 'S3' && !locationRef.metadata?.bucket) {
+      const fallback = this.resolveFallbackBucket(adapter, auth, {
+        provider: locationRef.provider,
+        key: locationRef.externalId,
+        operation: 'deleteFile',
+      })
+      if (fallback) {
+        locationRef.metadata = { ...locationRef.metadata, bucket: fallback }
+      }
     }
 
     try {
@@ -997,6 +1010,33 @@ export class StorageManager {
     }
 
     return Object.keys(metadata).length > 0 ? metadata : undefined
+  }
+
+  /**
+   * Last-resort bucket resolution for callers that did not supply one.
+   *
+   * Adapters no longer fall back to a configured default (a wrong-bucket delete
+   * 204s and a wrong-bucket part presign fails with `NoSuchUpload`), so the
+   * fallback lives here where it can be logged. Every warn from this method is a
+   * caller that should be passing the upload session's `bucket`.
+   */
+  private resolveFallbackBucket(
+    adapter: StorageAdapter,
+    auth: ProviderAuth | undefined,
+    context: { provider: ProviderId; key: string; operation: string }
+  ): string | undefined {
+    // Providers that are not bucket-addressed have no `resolveBucket`; there is
+    // nothing to warn about for those.
+    if (!adapter.resolveBucket && !(auth as any)?.bucket) return undefined
+
+    const bucket = ((auth as any)?.bucket as string | undefined) || adapter.resolveBucket?.()
+
+    logger.warn('No bucket supplied; falling back to the provider default bucket', {
+      ...context,
+      bucket,
+    })
+
+    return bucket
   }
 
   /**
@@ -1486,6 +1526,10 @@ export class StorageManager {
   /**
    * Complete multipart upload without creating DB record
    * Returns S3 metadata only for use in transactions
+   *
+   * @param params.bucket - The bucket the multipart upload was initiated in
+   *   (the upload session's `bucket`). Completing against a different bucket
+   *   fails with `NoSuchUpload`.
    */
   async completeMultipartUploadOnly(params: {
     provider: ProviderId
@@ -1493,6 +1537,7 @@ export class StorageManager {
     uploadId: string
     parts: Array<{ partNumber: number; etag: string }>
     credentialId?: string
+    bucket?: string
   }): Promise<{ etag: string; size?: number }> {
     // Validate parameters
     this.validateStorageParams(params)
@@ -1504,6 +1549,14 @@ export class StorageManager {
     let auth: ProviderAuth | undefined
     auth = await this.getProviderAuth(params.provider, params.credentialId)
 
+    const bucket =
+      params.bucket ??
+      this.resolveFallbackBucket(adapter, auth, {
+        provider: params.provider,
+        key: params.key,
+        operation: 'completeMultipartUploadOnly',
+      })
+
     try {
       // Use adapter to complete multipart upload without creating DB record
       if ((adapter as any).completeMultipart) {
@@ -1511,6 +1564,7 @@ export class StorageManager {
           key: params.key,
           uploadId: params.uploadId,
           parts: params.parts,
+          bucket,
           auth,
         })
       } else {
@@ -1527,11 +1581,16 @@ export class StorageManager {
 
   /**
    * Delete by key for compensation (cleanup orphaned objects)
+   *
+   * @param params.bucket - The bucket the object actually lives in (the upload
+   *   session's `bucket`). Omitting it on a PUBLIC upload deletes a nonexistent
+   *   key from the private bucket — S3 answers 204 and the real object leaks.
    */
   async deleteByKey(params: {
     provider: ProviderId
     key: string
     credentialId?: string
+    bucket?: string
   }): Promise<void> {
     // Validate parameters
     this.validateStorageParams(params)
@@ -1554,12 +1613,23 @@ export class StorageManager {
       )
     }
 
+    const bucket =
+      params.bucket ??
+      this.resolveFallbackBucket(adapter, auth, {
+        provider: params.provider,
+        key: params.key,
+        operation: 'deleteByKey',
+      })
+
     try {
-      // Build location reference for adapter
-      const locationRef = {
+      // Build location reference for adapter. The bucket travels on metadata —
+      // adapters no longer resolve a default, so a missing bucket throws rather
+      // than silently deleting nothing.
+      const locationRef: StorageLocationRef = {
         provider: params.provider,
         externalId: params.key,
         credentialId: params.credentialId,
+        metadata: bucket ? { bucket, key: params.key } : undefined,
       }
 
       if (adapter.deleteFile) {
@@ -1666,6 +1736,10 @@ export class StorageManager {
 
   /**
    * Generate presigned URL for upload part
+   *
+   * @param params.bucket - The bucket the multipart upload was initiated in
+   *   (the upload session's `bucket`). Presigning a part against a different
+   *   bucket fails with `NoSuchUpload`.
    */
   async generatePartUploadUrl(params: {
     provider: ProviderId
@@ -1674,6 +1748,7 @@ export class StorageManager {
     partNumber: number
     size?: number
     credentialId?: string
+    bucket?: string
   }): Promise<PresignedUpload> {
     // Validate parameters
     this.validateStorageParams(params)
@@ -1695,6 +1770,14 @@ export class StorageManager {
     let auth: ProviderAuth | undefined
     auth = await this.getProviderAuth(params.provider, params.credentialId)
 
+    const bucket =
+      params.bucket ??
+      this.resolveFallbackBucket(adapter, auth, {
+        provider: params.provider,
+        key: params.key,
+        operation: 'generatePartUploadUrl',
+      })
+
     try {
       // Use adapter to generate part upload URL
       if ((adapter as any).presignPart) {
@@ -1703,6 +1786,7 @@ export class StorageManager {
           uploadId: params.uploadId,
           partNumber: params.partNumber,
           size: params.size,
+          bucket,
           auth,
         })
       } else {

--- a/packages/lib/src/files/upload/__tests__/session-manager-ttl.test.ts
+++ b/packages/lib/src/files/upload/__tests__/session-manager-ttl.test.ts
@@ -1,0 +1,160 @@
+// packages/lib/src/files/upload/__tests__/session-manager-ttl.test.ts
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { UploadPreparedConfig } from '../init-types'
+import { SessionManager } from '../session-manager'
+
+/**
+ * Map-backed Redis double that enforces the parts of the real ioredis SETEX
+ * contract this bug depends on:
+ *  - a TTL of 0 or less is an error (`ERR invalid expire time in 'setex' command`)
+ *  - keys actually expire, so `get` stops answering once the TTL elapses
+ */
+const { fakeRedis, getRedisClientMock } = vi.hoisted(() => {
+  type Entry = { value: string; expiresAtMs: number }
+
+  const store = new Map<string, Entry>()
+
+  const live = (key: string): Entry | undefined => {
+    const entry = store.get(key)
+    if (!entry) return undefined
+    if (entry.expiresAtMs <= Date.now()) {
+      store.delete(key)
+      return undefined
+    }
+    return entry
+  }
+
+  const client = {
+    reset() {
+      store.clear()
+    },
+    /** Remaining TTL in whole seconds, mirroring Redis `TTL` (-2 = no such key) */
+    ttlOf(key: string): number {
+      const entry = live(key)
+      if (!entry) return -2
+      return Math.ceil((entry.expiresAtMs - Date.now()) / 1000)
+    },
+    setex: vi.fn(async (key: string, ttl: number, value: string) => {
+      // ioredis rejects non-positive expiries — this is the failure under test.
+      if (!Number.isInteger(ttl) || ttl <= 0) {
+        throw new Error("ERR invalid expire time in 'setex' command")
+      }
+      store.set(key, { value, expiresAtMs: Date.now() + ttl * 1000 })
+      return 'OK'
+    }),
+    get: vi.fn(async (key: string) => live(key)?.value ?? null),
+    del: vi.fn(async (key: string) => (store.delete(key) ? 1 : 0)),
+  }
+
+  return { fakeRedis: client, getRedisClientMock: vi.fn(async () => client) }
+})
+
+vi.mock('@auxx/redis', () => ({
+  getRedisClient: getRedisClientMock,
+}))
+
+const SESSION_KEY = (id: string) => `upload:session:${id}`
+
+/** Minimal prepared config; only the TTL-relevant fields matter here. */
+function makeConfig(ttlSec: number): UploadPreparedConfig {
+  return {
+    organizationId: 'org123',
+    userId: 'user123',
+    fileName: 'big-video.mp4',
+    mimeType: 'video/mp4',
+    expectedSize: 512 * 1024 * 1024,
+    entityType: 'FILE',
+    provider: 'S3',
+    storageKey: 'org123/files/big-video.mp4',
+    ttlSec,
+    policy: {
+      keyPrefix: 'org123/files',
+      contentLengthRange: [1, 1024 * 1024 * 1024],
+      maxTtl: 3600,
+      allowedMimeTypes: ['video/mp4'],
+    },
+    uploadPlan: { strategy: 'multipart', partSize: 8 * 1024 * 1024 },
+    visibility: 'PRIVATE',
+    bucket: 'auxx-private',
+    metadata: {},
+  }
+}
+
+const T0 = new Date('2026-08-21T10:00:00.000Z').getTime()
+
+describe('SessionManager TTL handling', () => {
+  beforeEach(() => {
+    fakeRedis.reset()
+    fakeRedis.setex.mockClear()
+    vi.useFakeTimers()
+    vi.setSystemTime(T0)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('survives a multipart upload that outlives its original expiresAt', async () => {
+    // 15-minute session, as a multipart upload would get.
+    const session = await SessionManager.createSessionFromConfig(makeConfig(15 * 60))
+
+    // Parts keep arriving for 25 minutes; the parts route touches the session
+    // every 5 minutes, so the Redis key never expires.
+    for (let i = 0; i < 5; i++) {
+      vi.setSystemTime(T0 + (i + 1) * 5 * 60 * 1000)
+      await SessionManager.touchSession(session.id)
+    }
+
+    // The session is still live in Redis 25 minutes in...
+    expect(fakeRedis.ttlOf(SESSION_KEY(session.id))).toBeGreaterThan(0)
+    expect(await SessionManager.getSession(session.id)).not.toBeNull()
+
+    // ...so `complete` Phase 1 runs. On the buggy code the stored expiresAt is
+    // 10 minutes in the past, remainingTtl clamps to 0, and ioredis throws.
+    await expect(
+      SessionManager.updateSession(session.id, { status: 'processing' })
+    ).resolves.toBeUndefined()
+
+    // The key must come out of the update with a usable TTL, not a 1-second
+    // sliver that evaporates before the rest of completion runs.
+    expect(fakeRedis.ttlOf(SESSION_KEY(session.id))).toBeGreaterThanOrEqual(60)
+
+    const updated = await SessionManager.getSession(session.id)
+    expect(updated?.status).toBe('processing')
+  })
+
+  it('keeps the stored expiresAt in lockstep with the Redis key TTL on touch', async () => {
+    const session = await SessionManager.createSessionFromConfig(makeConfig(15 * 60))
+
+    vi.setSystemTime(T0 + 10 * 60 * 1000)
+    await SessionManager.touchSession(session.id)
+
+    const touched = await SessionManager.getSession(session.id)
+    const keyTtl = fakeRedis.ttlOf(SESSION_KEY(session.id))
+    const storedTtl = Math.round((touched!.expiresAt.getTime() - Date.now()) / 1000)
+
+    expect(touched!.expiresAt.getTime()).toBeGreaterThan(Date.now())
+    expect(storedTtl).toBe(keyTtl)
+  })
+
+  it("extends by the session's own ttlSec rather than shrinking to the 10-minute default", async () => {
+    // FileProcessor-style one-hour session.
+    const session = await SessionManager.createSessionFromConfig(makeConfig(60 * 60))
+
+    vi.setSystemTime(T0 + 5 * 60 * 1000)
+    await SessionManager.touchSession(session.id)
+
+    // A touch must never cut a long-lived session down to DEFAULT_TTL (600s).
+    expect(fakeRedis.ttlOf(SESSION_KEY(session.id))).toBe(60 * 60)
+  })
+
+  it('preserves remaining TTL on a normal in-window update', async () => {
+    const session = await SessionManager.createSessionFromConfig(makeConfig(15 * 60))
+
+    vi.setSystemTime(T0 + 5 * 60 * 1000)
+    await SessionManager.updateSession(session.id, { status: 'uploading' })
+
+    expect(fakeRedis.ttlOf(SESSION_KEY(session.id))).toBe(10 * 60)
+  })
+})

--- a/packages/lib/src/files/upload/__tests__/unified-upload-integration.test.ts
+++ b/packages/lib/src/files/upload/__tests__/unified-upload-integration.test.ts
@@ -201,6 +201,9 @@ describe('Unified Upload Integration Tests', () => {
     // Register processors using canonical EntityType values
     ProcessorRegistry.registerForEntity('FILE', (orgId) => new FileProcessor(orgId))
     ProcessorRegistry.registerForEntity('ARTICLE', (orgId) => new ArticleProcessor(orgId))
+    // `clear()` de-initializes the registry, and `getForEntityType` now refuses to serve an
+    // uninitialized one (§11.3) — this stands in for `ensureProcessorsInitialized()`.
+    ProcessorRegistry.markInitialized()
   })
 
   describe('Complete Upload Flow', () => {
@@ -464,7 +467,7 @@ describe('Unified Upload Integration Tests', () => {
     it('should handle processor registry errors', () => {
       expect(() => {
         ProcessorRegistry.getForEntityType('nonexistent' as any, 'org123')
-      }).toThrow('No processor found for entity type: nonexistent')
+      }).toThrow('No upload processor registered for entity type: nonexistent')
     })
 
     it('should handle validation failures', async () => {

--- a/packages/lib/src/files/upload/processors/__tests__/unified-processor-system.test.ts
+++ b/packages/lib/src/files/upload/processors/__tests__/unified-processor-system.test.ts
@@ -1,12 +1,15 @@
 // packages/lib/src/files/upload/processors/__tests__/unified-processor-system.test.ts
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BadRequestError } from '../../../../errors'
 import type { EntityType } from '../../../types/entities'
 import { ENTITY_TYPES } from '../../../types/entities'
 import type { UploadInitConfig } from '../../init-types'
 import { UserProfileProcessor, WorkflowRunProcessor } from '../entity-processors'
 import { FileProcessor } from '../file-processor'
+import { initializeProcessors } from '../index'
 import { ProcessorRegistry } from '../processor-registry'
+import { VisitQcItemProcessor } from '../visit-qc-processor'
 
 // Hoist mock variables to be accessible inside vi.mock factories
 const { ticketSelectRowsRef, workflowRunSelectRowsRef, createSelectBuilder } = vi.hoisted(() => {
@@ -162,22 +165,57 @@ describe('Unified Processor System', () => {
 
     it('should return processor instance for registered EntityType', () => {
       ProcessorRegistry.registerForEntity(ENTITY_TYPES.FILE, (orgId) => new FileProcessor(orgId))
+      ProcessorRegistry.markInitialized()
 
       const processor = ProcessorRegistry.getForEntityType(ENTITY_TYPES.FILE, 'org123')
       expect(processor).toBeInstanceOf(FileProcessor)
     })
 
     it('should throw error for unregistered EntityType with no default', () => {
+      ProcessorRegistry.markInitialized()
+
       expect(() => {
         ProcessorRegistry.getForEntityType('unknown:entity' as EntityType, 'org123')
-      }).toThrow('No processor found for entity type: unknown:entity')
+      }).toThrow('No upload processor registered for entity type: unknown:entity')
     })
 
-    it('should use default processor for unregistered EntityType', () => {
-      ProcessorRegistry.setDefaultProcessor((orgId) => new FileProcessor(orgId))
+    // Regression for §11.3 — an unregistered entity type used to fall through to
+    // `setDefaultProcessor(FileProcessor)`, silently producing a `FolderFile` (and no
+    // `assetId`) for entity types that need a `MediaAsset` + `Attachment`.
+    it('should throw for an unregistered EntityType even after full initialization', () => {
+      initializeProcessors()
 
-      const processor = ProcessorRegistry.getForEntityType('unknown:entity' as EntityType, 'org123')
-      expect(processor).toBeInstanceOf(FileProcessor)
+      expect(() =>
+        ProcessorRegistry.getForEntityType('some-unregistered-type' as EntityType, 'org123')
+      ).toThrow(BadRequestError)
+    })
+
+    it('should throw when the registry was never initialized', () => {
+      // `clear()` (run in beforeEach) leaves the registry uninitialized — a silently
+      // uninitialized registry used to only `logger.warn` and then hand back the default.
+      expect(() => ProcessorRegistry.getForEntityType(ENTITY_TYPES.FILE, 'org123')).toThrow(
+        /not initialized/i
+      )
+    })
+
+    // The guard that stops §11.3 recurring: adding a value to `ENTITY_TYPES` without
+    // registering a processor for it must fail here, not in production.
+    it('registers a processor for every ENTITY_TYPES value', () => {
+      initializeProcessors()
+
+      const missing = Object.values(ENTITY_TYPES).filter(
+        (entityType) => !ProcessorRegistry.hasProcessor(entityType)
+      )
+
+      expect(missing).toEqual([])
+    })
+
+    it('registers an attachment processor for visit_qc_item', () => {
+      initializeProcessors()
+
+      const processor = ProcessorRegistry.getForEntityType(ENTITY_TYPES.VISIT_QC_ITEM, 'org123')
+      expect(processor).toBeInstanceOf(VisitQcItemProcessor)
+      expect(processor.getMetadata().supportsAttachments).toBe(true)
     })
   })
 

--- a/packages/lib/src/files/upload/processors/index.ts
+++ b/packages/lib/src/files/upload/processors/index.ts
@@ -14,6 +14,7 @@ import {
 } from './entity-processors'
 import { FileProcessor } from './file-processor'
 import { ProcessorRegistry } from './processor-registry'
+import { VisitQcItemProcessor } from './visit-qc-processor'
 
 const logger = createScopedLogger('processors')
 
@@ -26,10 +27,16 @@ export * from './entity-processors'
 export * from './processor-registry'
 // Export all processors and types
 export * from './types'
+export * from './visit-qc-processor'
 export * from './workflow-processor'
 
 /**
- * Initialize and register all default processors using the simplified EntityType approach
+ * Initialize and register all default processors using the simplified EntityType approach.
+ *
+ * Every value of `ENTITY_TYPES` must be registered here — there is no default processor, so an
+ * unregistered type throws at the front door instead of silently producing a `FolderFile`
+ * (`docs/files-upload-architecture-guide.md` §11.3). The
+ * "registers a processor for every ENTITY_TYPES value" test is the guard.
  */
 export function initializeProcessors(): void {
   // Register processors directly by EntityType
@@ -46,9 +53,7 @@ export function initializeProcessors(): void {
     (orgId) => new KnowledgeBaseProcessor(orgId)
   )
   ProcessorRegistry.registerForEntity('CHAT_WIDGET', (orgId) => new ChatWidgetProcessor(orgId))
-
-  // Set default processor for unknown entity types
-  ProcessorRegistry.setDefaultProcessor((orgId) => new FileProcessor(orgId))
+  ProcessorRegistry.registerForEntity('visit_qc_item', (orgId) => new VisitQcItemProcessor(orgId))
 
   // Mark as initialized
   ProcessorRegistry.markInitialized()

--- a/packages/lib/src/files/upload/processors/processor-registry.ts
+++ b/packages/lib/src/files/upload/processors/processor-registry.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/files/upload/processors/processor-registry.ts
 
 import { createScopedLogger } from '@auxx/logger'
+import { BadRequestError } from '../../../errors'
 import type { EntityType } from '../../types/entities'
 import type { BaseProcessor } from './base-processor'
 
@@ -17,7 +18,6 @@ export type ProcessorFactory = (organizationId: string) => BaseProcessor
  */
 export class ProcessorRegistry {
   private static entityProcessors = new Map<EntityType, ProcessorFactory>()
-  private static defaultProcessorFactory: ProcessorFactory | null = null
   private static initialized = false
 
   /**
@@ -30,14 +30,6 @@ export class ProcessorRegistry {
 
     ProcessorRegistry.entityProcessors.set(entityType, factory)
     logger.info(`Registered processor for entity: ${entityType}`)
-  }
-
-  /**
-   * Set the default processor factory for unknown entity types
-   */
-  static setDefaultProcessor(factory: ProcessorFactory): void {
-    ProcessorRegistry.defaultProcessorFactory = factory
-    logger.info('Set default processor factory')
   }
 
   /**
@@ -55,22 +47,30 @@ export class ProcessorRegistry {
   }
 
   /**
-   * Get a processor instance for the given entity type and organization
+   * Get a processor instance for the given entity type and organization.
+   *
+   * There is deliberately **no default processor**: falling back to `FileProcessor` for an
+   * unregistered entity type silently produced a `FolderFile` (and no `assetId`) for entity
+   * types that need a `MediaAsset` + `Attachment` — see
+   * `docs/files-upload-architecture-guide.md` §11.3. An unregistered type is a programming
+   * error and must fail loudly at the front door.
+   *
+   * @throws {BadRequestError} when the registry is uninitialized or the entity type has no
+   *   registered processor.
    */
   static getForEntityType(entityType: EntityType, organizationId: string): BaseProcessor {
-    // Check if processors are initialized, if not, warn but continue
+    // A silently-uninitialized registry produces the wrong record type, so this is fatal
+    // rather than a warning.
     if (!ProcessorRegistry.initialized) {
-      logger.warn(
-        'Processors not initialized, this may cause issues. Call ensureProcessorsInitialized() first.'
+      throw new BadRequestError(
+        'Upload processors are not initialized. Call ensureProcessorsInitialized() first.'
       )
     }
 
-    const factory =
-      ProcessorRegistry.entityProcessors.get(entityType) ||
-      ProcessorRegistry.defaultProcessorFactory
+    const factory = ProcessorRegistry.entityProcessors.get(entityType)
 
     if (!factory) {
-      throw new Error(`No processor found for entity type: ${entityType}`)
+      throw new BadRequestError(`No upload processor registered for entity type: ${entityType}`)
     }
 
     try {
@@ -116,11 +116,13 @@ export class ProcessorRegistry {
   }
 
   /**
-   * Clear all registered processors
+   * Clear all registered processors. A cleared registry is by definition no longer
+   * initialized, so `getForEntityType` throws until it is populated again.
    */
   static clear(): void {
     const count = ProcessorRegistry.entityProcessors.size
     ProcessorRegistry.entityProcessors.clear()
+    ProcessorRegistry.initialized = false
     logger.info(`Cleared ${count} registered processors`)
   }
 }

--- a/packages/lib/src/files/upload/processors/visit-qc-processor.ts
+++ b/packages/lib/src/files/upload/processors/visit-qc-processor.ts
@@ -1,0 +1,67 @@
+// packages/lib/src/files/upload/processors/visit-qc-processor.ts
+
+import { database as db, schema } from '@auxx/database'
+import { and, eq } from 'drizzle-orm'
+import { NotFoundError } from '../../../errors'
+import type { AssetKind } from '../../core/types'
+import { BaseAttachmentProcessor } from './base-attachment-processor'
+
+/**
+ * Upload processor for `VisitQcItem` checklist photos (08-worker-surface.md §5, 37d §2).
+ *
+ * These are worker-captured job-site photos, so the upload must produce a `MediaAsset` **and**
+ * an `Attachment` (`entityType: 'visit_qc_item'`) — that `MediaAsset` id is what
+ * `qc-photo-strip.tsx` hands back to `add{My,Visit}VisitQcItemPhoto`. Before this processor
+ * existed the entity type had no registration at all and fell through to the registry's default
+ * `FileProcessor`, which produced a `FolderFile` and no `assetId`
+ * (`docs/files-upload-architecture-guide.md` §11.3).
+ */
+export class VisitQcItemProcessor extends BaseAttachmentProcessor {
+  protected readonly entityType = 'visit_qc_item'
+  protected readonly fileVisibility = 'PRIVATE'
+  protected readonly preferredProvider = 'S3'
+  protected readonly maxFileSize = 25 * 1024 * 1024 // 25MB
+  /**
+   * Images only, and no `image/*` wildcard — that would admit `image/svg+xml`, an XSS vector
+   * when uploaded files are served from our origin.
+   *
+   * HEIC/HEIF are included because the strip's input is `accept='image/*' capture='environment'`
+   * and does **not** run `convertHeicToJpeg` (`components/files/utils/convert-heic.ts`), which is
+   * in any case best-effort — it only decodes in Safari and otherwise hands back the original
+   * HEIC file. Rejecting HEIC here would drop iPhone camera captures on the floor.
+   */
+  protected readonly allowedMimeTypes = [
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+    'image/gif',
+    'image/heic',
+    'image/heif',
+  ]
+  protected readonly assetKind: AssetKind = 'INLINE_IMAGE'
+
+  /**
+   * Org-scoped existence check, mirroring `loadQcItemInOrg` in `lib/src/dispatch/qc.ts`.
+   *
+   * Assignee ownership is deliberately NOT checked here: the strip is shared by the worker
+   * surface and the office proof-of-work panel, and the two differ only in which attach
+   * mutation runs afterwards (`addMyVisitQcItemPhoto` re-guards on the visit's assignee,
+   * `addVisitQcItemPhoto` is org-scoped). Org scope is the guarantee this upload door owes.
+   */
+  protected async validateEntityAccess(entityId: string, organizationId: string): Promise<void> {
+    const [item] = await db
+      .select({ id: schema.VisitQcItem.id })
+      .from(schema.VisitQcItem)
+      .where(
+        and(
+          eq(schema.VisitQcItem.id, entityId),
+          eq(schema.VisitQcItem.organizationId, organizationId)
+        )
+      )
+      .limit(1)
+
+    if (!item) {
+      throw new NotFoundError('Quality check item not found')
+    }
+  }
+}

--- a/packages/lib/src/files/upload/session-manager.ts
+++ b/packages/lib/src/files/upload/session-manager.ts
@@ -15,6 +15,12 @@ const logger = createScopedLogger('session-manager')
 export class SessionManager {
   private static readonly SESSION_PREFIX = 'upload:session:'
   private static readonly DEFAULT_TTL = 10 * 60 // 10 minutes
+  /**
+   * Floor applied when rewriting a session's key. Redis rejects a SETEX of 0, and a
+   * one-second key would evaporate mid-completion, so an update on a session whose
+   * `expiresAt` has already passed buys enough time to finish the flow in progress.
+   */
+  private static readonly MIN_UPDATE_TTL = 60 // 1 minute
 
   /**
    * Resolve the Redis client. Upload sessions have no in-memory fallback, so an unavailable
@@ -105,7 +111,11 @@ export class SessionManager {
   }
 
   /**
-   * Update session with partial data, preserving TTL
+   * Update session with partial data, preserving TTL.
+   *
+   * The key is only rewritten for a session Redis still holds, so a floored TTL can
+   * never resurrect an evicted session — it only keeps a live one alive long enough
+   * for the caller (typically the completion route) to finish.
    */
   static async updateSession(
     sessionId: string,
@@ -116,8 +126,13 @@ export class SessionManager {
 
     const updatedSession = { ...session, ...updates }
 
-    // Preserve TTL: recompute remaining time from expiresAt
-    const remainingTtl = Math.max(0, Math.floor((session.expiresAt.getTime() - Date.now()) / 1000))
+    // Preserve TTL: recompute remaining time from expiresAt, never below the floor.
+    // SETEX rejects a non-positive expiry, which would fail an upload whose bytes are
+    // already stored.
+    const remainingTtl = Math.max(
+      SessionManager.MIN_UPDATE_TTL,
+      Math.floor((session.expiresAt.getTime() - Date.now()) / 1000)
+    )
 
     const redis = await SessionManager.getRedis()
     await redis.setex(
@@ -137,6 +152,10 @@ export class SessionManager {
 
   /**
    * Mark upload as completed and prepare for processing
+   *
+   * @deprecated No production caller. Only `__tests__/unified-upload-integration.test.ts`
+   * still exercises it, and the `storageLocationId` it writes is a storage key, not a
+   * `StorageLocation` id. Delete both together.
    */
   static async completeUpload(sessionId: string, completion: UploadCompletionData): Promise<void> {
     await SessionManager.updateSession(sessionId, {
@@ -146,18 +165,29 @@ export class SessionManager {
   }
 
   /**
-   * Extend session TTL during active upload
+   * Extend session TTL during active upload.
+   *
+   * Extends by the session's own `ttlSec` — the lifetime its processor asked for —
+   * so touching a long-lived session cannot shorten it to the 10-minute default.
+   * The refreshed `expiresAt` is written back with the key: the stored value and the
+   * Redis TTL must never disagree, or `updateSession` recomputes a remaining TTL from
+   * an `expiresAt` that has silently drifted into the past.
    */
   static async touchSession(sessionId: string): Promise<void> {
     const session = await SessionManager.getSession(sessionId)
     if (!session) return
 
-    // Extend TTL while actively uploading
+    const extendSec = session.ttlSec > 0 ? session.ttlSec : SessionManager.DEFAULT_TTL
+    const refreshed: PresignedUploadSession = {
+      ...session,
+      expiresAt: new Date(Date.now() + extendSec * 1000),
+    }
+
     const redis = await SessionManager.getRedis()
     await redis.setex(
       `${SessionManager.SESSION_PREFIX}${sessionId}`,
-      SessionManager.DEFAULT_TTL,
-      JSON.stringify(session)
+      extendSec,
+      JSON.stringify(refreshed)
     )
   }
 

--- a/packages/lib/src/jobs/index.ts
+++ b/packages/lib/src/jobs/index.ts
@@ -207,6 +207,11 @@ export {
   type OrgSeedScenario,
   orgSeedJob,
 } from './maintenance/org-seed-job'
+export {
+  enqueueOrphanedStorageObjectCleanup,
+  type OrphanedStorageObjectJobData,
+  orphanedStorageObjectJob,
+} from './maintenance/orphaned-storage-object-job'
 // Outlook Graph subscription health sweep (webhook-push-migration plan §3.2/Phase 4.3-4.4)
 export {
   type OutlookSubscriptionHealthJobData,

--- a/packages/lib/src/jobs/maintenance/__tests__/orphaned-storage-object-job.test.ts
+++ b/packages/lib/src/jobs/maintenance/__tests__/orphaned-storage-object-job.test.ts
@@ -1,0 +1,147 @@
+// packages/lib/src/jobs/maintenance/__tests__/orphaned-storage-object-job.test.ts
+
+/**
+ * Regression tests for `docs/files-upload-architecture-guide.md` §11.2 / §10.4(a).
+ *
+ * The upload-completion compensation path called `cleanupService.scheduleCleanup`,
+ * whose every persistence method was a `// TODO` stub that logged
+ * "Would store cleanup task" and returned. Nothing was ever persisted, enqueued
+ * or retried, so a failed transaction left the S3 object orphaned forever.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockQueueAdd = vi.fn().mockResolvedValue({ id: 'job-1' })
+const mockGetQueue = vi.fn(() => ({ add: mockQueueAdd }))
+
+vi.mock('../../queues', () => ({
+  getQueue: mockGetQueue,
+}))
+
+// Partial mock: `@auxx/logger/run-log` imports sink-registration helpers from this
+// barrel at module load, so a full replacement breaks whichever test file happens
+// to load it first.
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+const mockDeleteByKey = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../../../files/storage/storage-manager', () => ({
+  StorageManager: class {
+    deleteByKey = mockDeleteByKey
+  },
+  createStorageManager: () => ({ deleteByKey: mockDeleteByKey }),
+}))
+
+import { cleanupService } from '../../../files/cleanup/cleanup-service'
+import type { JobContext } from '../../types'
+import {
+  enqueueOrphanedStorageObjectCleanup,
+  type OrphanedStorageObjectJobData,
+  orphanedStorageObjectJob,
+} from '../orphaned-storage-object-job'
+
+function job(data: OrphanedStorageObjectJobData): JobContext<OrphanedStorageObjectJobData> {
+  return {
+    job: { data },
+    data,
+    jobId: 'job-1',
+  } as unknown as JobContext<OrphanedStorageObjectJobData>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('enqueueOrphanedStorageObjectCleanup', () => {
+  it('durably enqueues a maintenance job carrying the bucket', async () => {
+    await enqueueOrphanedStorageObjectCleanup({
+      provider: 'S3',
+      bucket: 'test-public-bucket',
+      key: 'org123/avatar.png',
+      organizationId: 'org123',
+      reason: 'DB transaction failed',
+    })
+
+    expect(mockGetQueue).toHaveBeenCalledWith('maintenance')
+    expect(mockQueueAdd).toHaveBeenCalledTimes(1)
+
+    const [name, data] = mockQueueAdd.mock.calls[0]!
+    expect(name).toBe('orphanedStorageObjectJob')
+    expect(data).toEqual(
+      expect.objectContaining({
+        provider: 'S3',
+        bucket: 'test-public-bucket',
+        key: 'org123/avatar.png',
+        organizationId: 'org123',
+        reason: 'DB transaction failed',
+      })
+    )
+  })
+})
+
+describe('orphanedStorageObjectJob', () => {
+  it('deletes the object from the bucket the payload names', async () => {
+    const result = await orphanedStorageObjectJob(
+      job({
+        provider: 'S3',
+        bucket: 'test-public-bucket',
+        key: 'org123/avatar.png',
+        organizationId: 'org123',
+        reason: 'DB transaction failed',
+      })
+    )
+
+    expect(mockDeleteByKey).toHaveBeenCalledWith({
+      provider: 'S3',
+      key: 'org123/avatar.png',
+      bucket: 'test-public-bucket',
+      credentialId: undefined,
+    })
+    expect(result).toEqual({ deleted: true })
+  })
+
+  it('rethrows so BullMQ retries when the delete fails', async () => {
+    mockDeleteByKey.mockRejectedValueOnce(new Error('S3 down'))
+
+    await expect(
+      orphanedStorageObjectJob(
+        job({
+          provider: 'S3',
+          bucket: 'test-public-bucket',
+          key: 'org123/avatar.png',
+          reason: 'DB transaction failed',
+        })
+      )
+    ).rejects.toThrow('S3 down')
+  })
+})
+
+describe('cleanupService.scheduleCleanup (compensation call site)', () => {
+  it('actually persists work instead of only logging', async () => {
+    await cleanupService.scheduleCleanup({
+      provider: 'S3',
+      storageKey: 'org123/avatar.png',
+      bucket: 'test-public-bucket',
+      reason: 'DB transaction failed',
+      organizationId: 'org123',
+    })
+
+    expect(mockQueueAdd).toHaveBeenCalledTimes(1)
+    const [name, data] = mockQueueAdd.mock.calls[0]!
+    expect(name).toBe('orphanedStorageObjectJob')
+    expect(data).toEqual(
+      expect.objectContaining({
+        key: 'org123/avatar.png',
+        bucket: 'test-public-bucket',
+      })
+    )
+  })
+})

--- a/packages/lib/src/jobs/maintenance/index.ts
+++ b/packages/lib/src/jobs/maintenance/index.ts
@@ -30,6 +30,11 @@ export { mailUnsubscribeSweepJob } from './mail-unsubscribe-sweep-job'
 export { cleanupExpiredMediaAssetsJob, getMediaAssetCleanupStats } from './media-asset-cleanup-job'
 export { type MidTrialStats, sendMidTrialEmailsJob } from './mid-trial-job'
 export { oauth2TokenRefreshScannerJob } from './oauth2-token-refresh-scanner-job'
+export {
+  enqueueOrphanedStorageObjectCleanup,
+  type OrphanedStorageObjectJobData,
+  orphanedStorageObjectJob,
+} from './orphaned-storage-object-job'
 export { type QuotaResetStats, quotaResetJob } from './quota-reset-job'
 export {
   type ReconcileRecordIdentitiesStats,

--- a/packages/lib/src/jobs/maintenance/orphaned-storage-object-job.ts
+++ b/packages/lib/src/jobs/maintenance/orphaned-storage-object-job.ts
@@ -1,0 +1,111 @@
+// packages/lib/src/jobs/maintenance/orphaned-storage-object-job.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import type { ProviderId } from '../../files/adapters/base-adapter'
+import { StorageManager } from '../../files/storage/storage-manager'
+import type { JobContext } from '../types/job-context'
+
+const logger = createScopedLogger('orphaned-storage-object-job')
+
+/**
+ * One orphaned storage object to delete.
+ *
+ * `bucket` is what makes this correct: the object of a PUBLIC upload lives in
+ * the public bucket, and a delete aimed at the private one returns 204 for the
+ * missing key while the real object leaks.
+ */
+export interface OrphanedStorageObjectJobData {
+  provider: ProviderId
+  bucket?: string
+  key: string
+  credentialId?: string
+  organizationId?: string
+  /** Why the object was orphaned, for the audit trail. */
+  reason: string
+}
+
+/**
+ * Delete one orphaned storage object.
+ *
+ * Compensation for an upload whose DB transaction failed after the bytes were
+ * already in the bucket. The route deletes inline first; this job is the
+ * durable retry for when that inline delete throws.
+ *
+ * Deliberately rethrows: BullMQ's retry/backoff is the whole point of moving
+ * this off the request path, and a swallowed error would put us back where the
+ * stubbed `CleanupService` was.
+ */
+export async function orphanedStorageObjectJob(
+  ctx: JobContext<OrphanedStorageObjectJobData>
+): Promise<{ deleted: true }> {
+  const { provider, bucket, key, credentialId, organizationId, reason } = ctx.data
+
+  logger.info('Deleting orphaned storage object', {
+    provider,
+    bucket,
+    key,
+    organizationId,
+    reason,
+    jobId: ctx.jobId,
+  })
+
+  const storageManager = new StorageManager(organizationId)
+
+  try {
+    await storageManager.deleteByKey({ provider, key, bucket, credentialId })
+  } catch (error) {
+    logger.error('Failed to delete orphaned storage object', {
+      provider,
+      bucket,
+      key,
+      organizationId,
+      reason,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    throw error
+  }
+
+  logger.info('Deleted orphaned storage object', { provider, bucket, key, organizationId })
+
+  return { deleted: true }
+}
+
+/**
+ * Enqueue an orphaned-object delete on the maintenance queue.
+ *
+ * Best-effort at the call site: compensation must never turn a failed upload
+ * into a failed request, so an enqueue failure is logged, not thrown.
+ */
+export async function enqueueOrphanedStorageObjectCleanup(
+  data: OrphanedStorageObjectJobData
+): Promise<void> {
+  try {
+    const { getQueue } = await import('../queues')
+    const { Queues } = await import('../queues/types')
+    const queue = getQueue(Queues.maintenanceQueue)
+
+    await queue.add('orphanedStorageObjectJob', data, {
+      // Same object from a retried completion is the same unit of work.
+      jobId: `orphaned-storage-object:${data.bucket ?? 'default'}:${data.key}`,
+      attempts: 5,
+      backoff: { type: 'exponential', delay: 5000 },
+      removeOnComplete: { count: 100 },
+      removeOnFail: { count: 500 },
+      priority: 10,
+    })
+
+    logger.info('Enqueued orphaned storage object cleanup', {
+      provider: data.provider,
+      bucket: data.bucket,
+      key: data.key,
+      reason: data.reason,
+    })
+  } catch (error) {
+    logger.error('Failed to enqueue orphaned storage object cleanup', {
+      provider: data.provider,
+      bucket: data.bucket,
+      key: data.key,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}


### PR DESCRIPTION
Four independent bugs in the file-upload path, each with a regression test that was confirmed red before its fix. One commit per bug, so they can be reviewed and reverted separately.

Found while mapping the subsystem for `docs/files-upload-architecture-guide.md` (added in the last commit here) — sections 10-12 of that guide are the source material.

## What's fixed

**1. The storage quota measured zero for every org.** `calculateStorageUsage` joined `FileVersion` to the legacy `File` table, but `FileVersion.fileId` is a foreign key to `FolderFile`. Disjoint id spaces, and `File` is empty — so the join never matched and `sum()` returned NULL. The `storageGbHard` plan limit enforced in `api/files/upload/sessions` has **never fired**.

Two more bugs were stacked behind it: the query only ever considered `FolderFile` (nearly everything here is a `MediaAsset` — 3,737 rows / ~1.64 GB invisible on dev), and `sum()` over `bigint` returns a *string* from node-postgres, so `totalUsed + expectedSize` in the route would have concatenated rather than added.

**2. Upload sessions could 500 after a successful upload.** `touchSession` reset the Redis TTL but not `expiresAt`, so a long multipart upload drifted `expiresAt` into the past while keeping the key alive; `updateSession` then computed `remainingTtl = 0` and ioredis rejected the `SETEX` — after the bytes were already in S3. Same method also extended by a 600s constant instead of the session's own `ttlSec`, cutting a 1-hour session to 10 minutes on first touch.

**3. Multipart and cleanup deletes went to the wrong bucket.** Parts and completion fell back to `S3_PRIVATE_BUCKET` while `startMultipartUploadFromConfig` passed the real bucket, so a PUBLIC multipart upload would `NoSuchUpload`. Worse, the failure-compensation delete targeted the private bucket for PUBLIC uploads — S3 answers 204 for a nonexistent key, so orphans leaked with no error and no log. And the compensation queue behind it was a stub: every persistence method in `files/cleanup/cleanup-service.ts` was a `// TODO` that logged and returned. Replaced with a real BullMQ job on the maintenance queue.

**4. Unregistered entity types silently produced the wrong record.** `visit_qc_item` had no processor, so it fell through to the default `FileProcessor` and created a `FolderFile` instead of a `MediaAsset` + `Attachment`. The client then reported the upload-session nanoid as an `assetId`. The dev database has **zero** `visit_qc_item` attachments despite the feature shipping with an uploader. The default fallback is removed, the registry now throws, and a test asserts every `ENTITY_TYPES` value resolves to a processor.

## Verification

- `packages/lib`: 152 tests green (was ~116)
- `apps/web` `src/components/file-upload`: 21 green
- `tsc --noEmit` clean for every touched file in both packages (large pre-existing baselines elsewhere are untouched)
- The fixed quota function was run against the dev database: it now reports real per-org figures summing to 1.637 GB, where every org previously returned 0

## Please look closely at

**The quota gate goes live with this.** It has never rejected an upload. Plan limits are Demo 0.1 GB / Free 1 GB / Starter 10 GB / Growth 50 GB / Enterprise unlimited. All 15 dev orgs are on Growth and the largest sits at 682 MB (1.4%), so nothing trips in dev — but **someone should confirm no production org on Demo or Free is already over its limit** before this merges. I could not query production.

**`storageQuotaCheckJob` still compares every org to a hard-coded 50 GB** (`DEFAULT_QUOTAS.professional`). Left deliberately out of scope here; it means that job will start emitting warnings against the wrong limit for Demo/Free/Starter orgs. Being fixed in the follow-up.

**`storageGbSoft` is defined on every plan and read by nothing** — it exists as a type field in `admin-billing-service.ts` and nowhere else. There is no warning tier; orgs go from no signal straight to a hard 403.

## Not in this PR

The remaining Tier-1 fixes are in flight on a follow-up branch: authenticating `complete` / `parts` / `events` (they currently have none — the session nanoid is the only credential), moving thumbnail generation after `COMMIT` (it currently runs inside the open transaction against a connection that cannot see the uncommitted rows), and wiring `bucket` at the four route call sites this PR made ready.