### PR TITLE
fix(files): pass the recorded bucket when sweeping orphaned storage objects

### DIFF
--- a/packages/lib/src/files/lifecycle/orphaned-cleanup.ts
+++ b/packages/lib/src/files/lifecycle/orphaned-cleanup.ts
@@ -12,6 +12,24 @@ import type { OrphanedFileCleanupJobData, OrphanedFileCleanupResult } from './ty
 const logger = createScopedLogger('orphaned-file-cleanup')
 
 /**
+ * The bucket an object actually lives in, as recorded on its `StorageLocation`.
+ *
+ * `StorageManager.prepareLocationMetadata` stamps `metadata.bucket` on every S3
+ * location it writes, so this is the only trustworthy source for a sweep — the
+ * provider default is the PRIVATE bucket, and a delete aimed there for a PUBLIC
+ * object 204s on the missing key while the real object leaks.
+ *
+ * Returns `undefined` for rows written outside `StorageManager` (see
+ * `users/user-avatar-service.ts`) or before the bucket was persisted. Guessing
+ * one would be worse than the fallback: `deleteByKey` then warns loudly, and the
+ * adapter throws rather than silently deleting nothing.
+ */
+function bucketOf(metadata: unknown): string | undefined {
+  const bucket = (metadata as { bucket?: unknown } | null | undefined)?.bucket
+  return typeof bucket === 'string' && bucket.length > 0 ? bucket : undefined
+}
+
+/**
  * Job to clean up orphaned files that were uploaded but never attached to entities
  * Runs hourly to delete files where status = 'PENDING' and expiresAt < now
  */
@@ -153,6 +171,7 @@ export async function deletedFileCleanupJob(
         provider: schema.StorageLocation.provider,
         externalId: schema.StorageLocation.externalId,
         organizationId: schema.StorageLocation.organizationId,
+        metadata: schema.StorageLocation.metadata,
       })
       .from(schema.StorageLocation)
       .where(
@@ -175,6 +194,7 @@ export async function deletedFileCleanupJob(
               await storageManager.deleteByKey({
                 provider: loc.provider as any,
                 key: loc.externalId,
+                bucket: bucketOf(loc.metadata),
               })
             } catch (s3Error) {
               logger.warn('Failed to delete S3 object during sweep, continuing', {


### PR DESCRIPTION
**Unbreaks `main`.** #1816 landed `packages/lib/src/files/lifecycle/__tests__/orphaned-cleanup.test.ts` without the implementation it covers, so its three tests fail on main right now. This is the missing half — a single file, no other changes.

My mistake, and worth recording so it doesn't recur: I staged that test's directory (`git add .../lifecycle/__tests__`) rather than naming the file, and a parallel agent had written a second test into it after the branch was cut. The test passed locally because the implementation was present in my working tree as an uncommitted change — only the test got committed. A directory-level `git add` in a tree with concurrent writers is what caused it.

## The bug this restores the fix for

`deletedFileCleanupJob`'s phase-2 sweep called:

```ts
await storageManager.deleteByKey({ provider: loc.provider, key: loc.externalId })
```

No bucket, so it aimed at the provider default — the private bucket. S3 returns **204 for a key that isn't there**, so a PUBLIC-bucket object was counted as successfully swept, its `StorageLocation` row hard-deleted, and the object left in the bucket forever. No error, no log, and the DB row that pointed at it is gone, so nothing can find it again.

Same class of bug as the compensation-path leak fixed in #1816, in the sweep job rather than the upload path.

## The fix

The projection now selects `metadata`, and the call passes `bucket: metadata?.bucket`.

A row with **no** recorded bucket resolves to `undefined` rather than an invented one. `deleteByKey` then warns, and `S3Adapter.resolveDeleteTarget` throws inside the existing per-location `catch` — which is the correct loud failure. A guessed bucket would be worse than none: it would resume silently 204-ing.

## Known gap, tracked separately

Two write paths currently create `StorageLocation` rows without `metadata.bucket`, so their rows will hit the warn-and-skip branch until backfilled:

- `packages/lib/src/users/user-avatar-service.ts` inserts `StorageLocation` directly, bypassing `StorageManager` entirely
- `packages/lib/src/files/storage/storage-location-service.ts` `create()`/`bulkCreate()` pass `data.metadata` through with no normalisation

Both are follow-ups. The `user-avatar-service` one is worth a look on its own — it also calls `putObject` with neither `bucket` nor `visibility`, so OAuth-imported avatars (a PUBLIC entity type) appear to be landing in the **private** bucket.

## Verification

`packages/lib` `src/files/lifecycle`: 15 tests green, including the three that fail on main.