### PR TITLE
fix(uploads): authenticate the session routes, and finish the Tier-1 fixes

### DIFF
--- a/apps/web/src/app/api/files/download/[fileId]/file-download-permission.test.ts
+++ b/apps/web/src/app/api/files/download/[fileId]/file-download-permission.test.ts
@@ -96,7 +96,13 @@ function signedIn(capabilities: InstanceType<typeof CapabilitySet>) {
   getCapabilities.mockResolvedValue(capabilities)
 }
 
-const request = () => ({ headers: new Headers() }) as never
+// `nextUrl` is required, not decorative: `shouldRenderInline` reads
+// `request.nextUrl.searchParams` to honour `?download=1`. Without it the route
+// threw a TypeError into its outer catch and every happy-path case answered 500
+// instead of 200 — a fixture gap left by the inline-disposition change, not a
+// route bug.
+const request = (url = 'http://localhost/api/files/download/f') =>
+  ({ headers: new Headers(), nextUrl: new URL(url) }) as never
 const params = (fileId: string) => ({ params: Promise.resolve({ fileId }) })
 
 const fileRow = { id: FILE_ID, name: 'contract.pdf', mimeType: 'application/pdf', size: 2048 }
@@ -120,10 +126,17 @@ beforeEach(() => {
       getContent = assetGetContent
     } as never
   )
+  // Mirror what the real `createFileDownloadResponse` builds, or the header
+  // assertions below only ever test this literal. Content-Length is the BUFFER
+  // length (download-response.ts:89), not the row's declared `size`.
   createFileDownloadResponse.mockReset().mockReturnValue({
     buffer: Buffer.from('file-bytes'),
     status: 200,
-    headers: { 'Content-Type': 'application/pdf' },
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Length': String(Buffer.byteLength('file-bytes')),
+      'Content-Disposition': 'attachment; filename="contract.pdf"',
+    },
   })
 })
 
@@ -272,7 +285,10 @@ describe('HEAD /api/files/download/[fileId] — the metadata half of the same ho
     const res = await HEAD(request(), params(FILE_ID))
     expect(res.status).toBe(200)
     expect(res.headers.get('Content-Type')).toBe('application/pdf')
-    expect(res.headers.get('Content-Length')).toBe('2048')
+    // Content-Length tracks the buffer, not `fileRow.size` — the two agree in
+    // production but not in this fixture. The old '2048' expectation had never
+    // run: every happy path here 500'd on the missing `nextUrl` above.
+    expect(res.headers.get('Content-Length')).toBe(String(Buffer.byteLength('file-bytes')))
     expect(res.headers.get('Content-Disposition')).toBe('attachment; filename="contract.pdf"')
   })
 

--- a/apps/web/src/app/api/files/upload/[sessionId]/authorize-upload-session.ts
+++ b/apps/web/src/app/api/files/upload/[sessionId]/authorize-upload-session.ts
@@ -1,0 +1,65 @@
+// apps/web/src/app/api/files/upload/[sessionId]/authorize-upload-session.ts
+
+import { SessionManager } from '@auxx/lib/files/server'
+import { headers } from 'next/headers'
+import { NextResponse } from 'next/server'
+import { auth } from '~/auth/server'
+
+/** The Redis-backed upload session, as `SessionManager` hands it back. */
+type UploadSession = NonNullable<Awaited<ReturnType<typeof SessionManager.getSession>>>
+
+export interface AuthorizedUploadSession {
+  session: UploadSession
+  caller: { id: string; organizationId: string }
+}
+
+/**
+ * Body shape matches `UploadErrorHandler`'s so every failure on this surface
+ * looks the same to the client, whichever layer produced it.
+ */
+function deny(status: number, code: string, errorType: string, message: string): Response {
+  return NextResponse.json({ error: message, errorType, retryable: false, code }, { status })
+}
+
+/**
+ * Authenticate the caller and bind them to an upload session.
+ *
+ * `complete`, `parts` and `events` used to treat the session nanoid as the only
+ * credential, so anyone holding it could finish someone else's upload, mint
+ * presigned part URLs for arbitrary part numbers, or read upload status
+ * (`docs/files-upload-architecture-guide.md` §11.4). This re-resolves the caller
+ * from the auth cookie and asserts the session belongs to them, which also
+ * re-evaluates authorization at completion time rather than only at session
+ * create.
+ *
+ * Order is deliberate: authentication is checked **before** Redis is touched, so
+ * an unauthenticated caller gets 401 whether or not the session id exists and
+ * cannot use the endpoint to probe for live sessions.
+ *
+ * @param sessionId - The upload session nanoid from the route segment.
+ * @returns `{ session, caller }` when the caller owns the session, otherwise a
+ *   `Response` to return as-is (401 unauthenticated, 404 unknown session, 403
+ *   session owned by another user or organization).
+ */
+export async function authorizeUploadSession(
+  sessionId: string
+): Promise<AuthorizedUploadSession | Response> {
+  const authSession = await auth.api.getSession({ headers: await headers() })
+  const callerId = authSession?.user?.id
+  const callerOrgId = authSession?.user?.defaultOrganizationId
+
+  if (!callerId || !callerOrgId) {
+    return deny(401, 'UNAUTHORIZED', 'authentication', 'User session required')
+  }
+
+  const session = await SessionManager.getSession(sessionId)
+  if (!session) {
+    return deny(404, 'SESSION_NOT_FOUND', 'validation', 'Upload session not found or expired')
+  }
+
+  if (session.userId !== callerId || session.organizationId !== callerOrgId) {
+    return deny(403, 'FORBIDDEN', 'permission', 'Upload session does not belong to this user')
+  }
+
+  return { session, caller: { id: callerId, organizationId: callerOrgId } }
+}

--- a/apps/web/src/app/api/files/upload/[sessionId]/complete/post-commit-thumbnails.test.ts
+++ b/apps/web/src/app/api/files/upload/[sessionId]/complete/post-commit-thumbnails.test.ts
@@ -1,0 +1,211 @@
+// apps/web/src/app/api/files/upload/[sessionId]/complete/post-commit-thumbnails.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Plan §1.3 / guide §10.3. Thumbnail presets used to be enqueued by the entity
+ * PROCESSOR, which runs inside the route's still-open `db.transaction`. The
+ * enqueue resolves the source asset on the GLOBAL `db`, so it read the
+ * PRE-transaction `currentVersionId`: on a re-upload `avatar-64/128/256` found
+ * the previous version's thumbnail, returned `ready`, and kept serving the OLD
+ * image. Only the route's own `avatar-32` enqueue — the one already in Phase 3 —
+ * ever saw the new version.
+ *
+ * So the whole preset set has to be enqueued from Phase 3, after the transaction
+ * returns. `versionStore` models the global connection: it only advances when
+ * `db.transaction` resolves.
+ */
+
+const {
+  getSession,
+  getUploadSession,
+  updateSession,
+  enqueueEnsureThumbnail,
+  publishCompleted,
+  getDownloadUrl,
+  getWithRelations,
+  invalidateUser,
+  onCacheEvent,
+  headByKey,
+  createStorageLocation,
+  buildExternalUrl,
+  validateCompletedUpload,
+  processorProcess,
+  dbTransaction,
+} = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getUploadSession: vi.fn(),
+  updateSession: vi.fn(),
+  enqueueEnsureThumbnail: vi.fn(),
+  publishCompleted: vi.fn(),
+  getDownloadUrl: vi.fn(async () => 'https://cdn.example/avatar.png'),
+  getWithRelations: vi.fn(async () => ({ currentVersion: { storageLocation: { id: 'stl_1' } } })),
+  invalidateUser: vi.fn(),
+  onCacheEvent: vi.fn(),
+  headByKey: vi.fn(async () => ({ size: 1024, mimeType: 'image/png', etagOrRev: 'etag-b' })),
+  createStorageLocation: vi.fn(async () => ({ id: 'stl_cuid00000000000000000000' })),
+  buildExternalUrl: vi.fn(async () => 'https://cdn.example/avatar.png'),
+  validateCompletedUpload: vi.fn(),
+  processorProcess: vi.fn(),
+  dbTransaction: vi.fn(),
+}))
+
+vi.mock('@auxx/logger', async () => (await import('~/test/logger-mock')).mockAuxxLogger())
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+vi.mock('~/server/api/trpc', () => ({ isAuxxError: () => false }))
+vi.mock('@auxx/database', () => ({ database: { transaction: dbTransaction }, schema: {} }))
+vi.mock('@auxx/lib/dehydration', () => ({
+  DehydrationService: class {
+    invalidateUser = invalidateUser
+  },
+}))
+vi.mock('@auxx/lib/cache', () => ({ onCacheEvent }))
+vi.mock('@auxx/lib/files/server', () => ({
+  SessionManager: { getSession: getUploadSession, updateSession, touchSession: vi.fn() },
+  createStorageManager: () => ({
+    headByKey,
+    createStorageLocation,
+    buildExternalUrl,
+    deleteByKey: vi.fn(),
+    completeMultipartUploadOnly: vi.fn(),
+  }),
+  ensureProcessorsInitialized: vi.fn(),
+  ProcessorRegistry: {
+    getForEntityType: () => ({ validateCompletedUpload, process: processorProcess }),
+  },
+  ProgressPublisher: { publishFailed: vi.fn(), publishCompleted },
+  UploadErrorHandler: {
+    handleUploadError: vi.fn(async () => new Response('{}', { status: 500 })),
+    validationError: vi.fn(() => new Response('{}', { status: 400 })),
+    sessionNotFound: vi.fn(() => new Response('{}', { status: 404 })),
+    unauthorized: vi.fn(() => new Response('{}', { status: 401 })),
+  },
+  cleanupService: { scheduleCleanup: vi.fn() },
+  MediaAssetService: class {
+    getWithRelations = getWithRelations
+    getDownloadUrl = getDownloadUrl
+  },
+  enqueueEnsureThumbnail,
+}))
+
+const { POST } = await import('./route')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const ASSET_ID = 'ast_cuid000000000000000000000'
+const SESSION_ID = 'sess_nanoid_000000000000'
+
+const params = { params: Promise.resolve({ sessionId: SESSION_ID }) }
+
+/** The global connection's view of the asset's current version. */
+let versionStore = { current: 'ver_A' }
+let committed = false
+/** What each enqueue observed at the moment it ran. */
+let observed: Array<{ preset?: string; version: string; committed: boolean; opts: any }> = []
+
+function uploadSession(entityType: string) {
+  getUploadSession.mockResolvedValue({
+    version: 2,
+    id: SESSION_ID,
+    organizationId: ORG_ID,
+    userId: USER_ID,
+    entityType,
+    entityId: entityType === 'USER_PROFILE' ? USER_ID : 'kb_cuid00000000000000000000',
+    fileName: 'logo.png',
+    mimeType: 'image/png',
+    expectedSize: 1024,
+    provider: 'S3',
+    storageKey: 'org/logo.png',
+    isMultipart: false,
+    uploadMethod: 'PUT',
+    status: 'uploading',
+    createdAt: new Date(),
+    expiresAt: new Date(Date.now() + 600_000),
+    ttlSec: 600,
+    metadata: {},
+    policy: {},
+    uploadPlan: { strategy: 'single' },
+    bucket: 'auxx-public',
+    visibility: 'PUBLIC',
+  })
+}
+
+const request = () =>
+  new Request('http://localhost/api/files/upload/x/complete', {
+    method: 'POST',
+    body: JSON.stringify({ size: 1024, mimeType: 'image/png' }),
+  }) as any
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  versionStore = { current: 'ver_A' }
+  committed = false
+  observed = []
+
+  getSession.mockResolvedValue({ user: { id: USER_ID, defaultOrganizationId: ORG_ID } })
+
+  // The upload writes version B; the global connection only sees it at COMMIT.
+  processorProcess.mockImplementation(async () => ({ assetId: ASSET_ID }))
+  dbTransaction.mockImplementation(async (cb: (tx: any) => Promise<any>) => {
+    const out = await cb({})
+    versionStore.current = 'ver_B'
+    committed = true
+    return out
+  })
+
+  enqueueEnsureThumbnail.mockImplementation(async ({ opts }: any) => {
+    observed.push({ preset: opts.preset, version: versionStore.current, committed, opts })
+    return { status: 'queued', jobId: `job-${opts.preset}` }
+  })
+})
+
+describe('POST complete — thumbnail presets are enqueued post-commit', () => {
+  it('enqueues all four avatar presets against the COMMITTED version', async () => {
+    uploadSession('USER_PROFILE')
+
+    const res = await POST(request(), params)
+    expect(res.status).toBe(200)
+
+    expect(observed.map((o) => o.preset).sort()).toEqual([
+      'avatar-128',
+      'avatar-256',
+      'avatar-32',
+      'avatar-64',
+    ])
+    for (const call of observed) {
+      expect(call.committed).toBe(true)
+      expect(call.version).toBe('ver_B')
+    }
+  })
+
+  it('keeps `updateUser` on avatar-64 only', async () => {
+    uploadSession('USER_PROFILE')
+
+    await POST(request(), params)
+
+    expect(observed.find((o) => o.preset === 'avatar-64')?.opts.updateUser).toBe(true)
+    expect(observed.find((o) => o.preset === 'avatar-32')?.opts.updateUser).toBeUndefined()
+  })
+
+  it('enqueues both KB logo presets against the COMMITTED version', async () => {
+    uploadSession('KNOWLEDGE_BASE')
+
+    const res = await POST(request(), params)
+    expect(res.status).toBe(200)
+
+    expect(observed.map((o) => o.preset).sort()).toEqual(['kb-logo-lg', 'kb-logo-sm'])
+    for (const call of observed) {
+      expect(call.committed).toBe(true)
+      expect(call.version).toBe('ver_B')
+    }
+  })
+
+  it('enqueues nothing for an entity type with no presets', async () => {
+    uploadSession('MESSAGE')
+
+    await POST(request(), params)
+
+    expect(observed).toEqual([])
+  })
+})

--- a/apps/web/src/app/api/files/upload/[sessionId]/complete/route.ts
+++ b/apps/web/src/app/api/files/upload/[sessionId]/complete/route.ts
@@ -2,7 +2,6 @@
 
 import { database as db } from '@auxx/database'
 import {
-  cleanupService,
   createStorageManager,
   ensureProcessorsInitialized,
   ProcessorRegistry,
@@ -13,6 +12,8 @@ import {
 import { createScopedLogger } from '@auxx/logger'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
+import { isAuxxError } from '~/server/api/trpc'
+import { authorizeUploadSession } from '../authorize-upload-session'
 
 const logger = createScopedLogger('api-upload-complete')
 
@@ -37,6 +38,39 @@ interface RouteParams {
 }
 
 /**
+ * Derived thumbnails to enqueue once the upload transaction has COMMITTED.
+ *
+ * These used to be enqueued by the entity processors, under a comment claiming
+ * they ran after the commit. They did not — a processor runs inside the
+ * transaction opened below, and the enqueue resolves its source asset on the
+ * global `db`, a different connection that still sees the PRE-transaction
+ * `currentVersionId`. A first upload therefore threw `Asset not found` and a
+ * re-upload silently kept serving the previous image
+ * (`docs/files-upload-architecture-guide.md` §10.3).
+ */
+const POST_COMMIT_THUMBNAIL_PRESETS = {
+  USER_PROFILE: ['avatar-32', 'avatar-64', 'avatar-128', 'avatar-256'],
+  KNOWLEDGE_BASE: ['kb-logo-sm', 'kb-logo-lg'],
+} as const
+
+type ThumbnailPreset =
+  (typeof POST_COMMIT_THUMBNAIL_PRESETS)[keyof typeof POST_COMMIT_THUMBNAIL_PRESETS][number]
+
+/** `updateUser` writes `User.image` when the preset lands — avatar-64 only. */
+const AVATAR_USER_IMAGE_PRESET: ThumbnailPreset = 'avatar-64'
+
+/** The tiny avatar the SSE payload prefers when it is already generated. */
+const AVATAR_PREVIEW_PRESET: ThumbnailPreset = 'avatar-32'
+
+function postCommitPresetsFor(entityType: string): readonly ThumbnailPreset[] {
+  const table = POST_COMMIT_THUMBNAIL_PRESETS as Record<
+    string,
+    readonly ThumbnailPreset[] | undefined
+  >
+  return table[entityType] ?? []
+}
+
+/**
  * Complete presigned upload and trigger processing
  * Implements three-phase approach: S3 operations -> DB transaction -> post-commit actions
  */
@@ -44,10 +78,16 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   const { sessionId } = await params
 
   try {
-    const completion = CompletionSchema.parse(await request.json())
-    const session = await SessionManager.getSession(sessionId)
+    // Authenticate FIRST: the session nanoid used to be the only credential on
+    // this endpoint, so anyone holding one could complete someone else's upload
+    // (`docs/files-upload-architecture-guide.md` §11.4). This also re-evaluates
+    // authorization at completion time, which session-create alone never does.
+    const authorized = await authorizeUploadSession(sessionId)
+    if (authorized instanceof Response) return authorized
+    const { session } = authorized
 
-    if (!session) return UploadErrorHandler.sessionNotFound(sessionId)
+    const completion = CompletionSchema.parse(await request.json())
+
     if (!['created', 'uploading'].includes(session.status)) {
       return UploadErrorHandler.validationError('Invalid session status for completion', {
         currentStatus: session.status,
@@ -76,6 +116,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           uploadId: completion.uploadId,
           parts: completion.parts,
           credentialId: session.credentialId,
+          bucket: session.bucket,
         })
       } catch (err) {
         await SessionManager.updateSession(sessionId, { status: 'failed' })
@@ -191,6 +232,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           provider: session.provider,
           key: session.storageKey,
           credentialId: session.credentialId,
+          // Without this a PUBLIC upload's compensation deletes a nonexistent
+          // key from the PRIVATE bucket, S3 answers 204, and the real object
+          // leaks with no error and no log (guide §10.4).
+          bucket: session.bucket,
         })
       } catch (cleanupErr) {
         logger.warn('Immediate S3 cleanup failed; scheduling for background cleanup', {
@@ -198,10 +243,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           cleanupErr: String(cleanupErr),
         })
 
-        // Schedule cleanup via background service
-        await cleanupService.scheduleCleanup({
+        // Durable retry on the maintenance queue. Lazy — this is the cold path.
+        const { enqueueOrphanedStorageObjectCleanup } = await import('@auxx/lib/jobs')
+        await enqueueOrphanedStorageObjectCleanup({
           provider: session.provider,
-          storageKey: session.storageKey,
+          key: session.storageKey,
+          bucket: session.bucket,
           credentialId: session.credentialId,
           reason: `DB transaction failed: ${String(err)}`,
           organizationId: session.organizationId,
@@ -237,46 +284,54 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
     }
 
-    // 3.3 Compute download URL for SSE
+    // 3.3 Enqueue derived thumbnails. This is the ONLY place they are enqueued,
+    // and it sits after `db.transaction` has returned so the enqueue's own
+    // connection resolves the version this upload just created.
+    const thumbnails = new Map<ThumbnailPreset, { status: string; assetId?: string }>()
+    const presets = postCommitPresetsFor(session.entityType)
+    if (result.assetId && presets.length > 0) {
+      const { enqueueEnsureThumbnail } = await import('@auxx/lib/files/server')
+      for (const preset of presets) {
+        try {
+          const enq = await enqueueEnsureThumbnail({
+            organizationId: session.organizationId,
+            userId: session.userId,
+            source: { type: 'asset', assetId: result.assetId },
+            opts: {
+              preset,
+              visibility: 'PUBLIC',
+              queue: true,
+              ...(preset === AVATAR_USER_IMAGE_PRESET ? { updateUser: true } : {}),
+            },
+          })
+          thumbnails.set(preset, enq as { status: string; assetId?: string })
+        } catch (thumbErr) {
+          // A derived image must never fail an upload whose bytes and rows are
+          // already durable.
+          logger.error('Failed to enqueue thumbnail preset', {
+            sessionId,
+            assetId: result.assetId,
+            preset,
+            error: String(thumbErr),
+          })
+        }
+      }
+    }
+
+    // 3.4 Compute download URL for SSE
     let downloadUrl: string | null = null
     try {
-      if (session.entityType === 'USER_PROFILE' && result.assetId) {
-        // For user avatars, try to get the tiny thumbnail URL first
+      if (result.assetId) {
         const { MediaAssetService } = await import('@auxx/lib/files/server')
         const assetService = new MediaAssetService(session.organizationId, session.userId)
 
-        // Try to generate and get tiny avatar thumbnail URL
-        const asset = await assetService.getWithRelations(result.assetId)
-        if (asset?.currentVersion?.storageLocation) {
-          // Ensure thumbnail is generated (won't reprocess if already exists)
-          const { enqueueEnsureThumbnail } = await import('@auxx/lib/files/server')
-          try {
-            const enq = await enqueueEnsureThumbnail({
-              organizationId: session.organizationId,
-              userId: session.userId,
-              source: { type: 'asset', assetId: result.assetId },
-              opts: { preset: 'avatar-32', visibility: 'PUBLIC', queue: true },
-            })
-            if ((enq as any).status === 'ready' && (enq as any).assetId) {
-              downloadUrl = await assetService.getDownloadUrl((enq as any).assetId)
-            } else {
-              downloadUrl = await assetService.getDownloadUrl(result.assetId)
-            }
-          } catch (thumbErr) {
-            // If thumbnail generation fails, just use main asset
-            logger.warn('Failed to ensure thumbnail, using main asset', {
-              sessionId,
-              assetId: result.assetId,
-              error: String(thumbErr),
-            })
-            downloadUrl = await assetService.getDownloadUrl(result.assetId)
-          }
-        }
-      } else if (result.assetId) {
-        // For other entity types, get the main asset URL
-        const { MediaAssetService } = await import('@auxx/lib/files/server')
-        const assetService = new MediaAssetService(session.organizationId, session.userId)
-        downloadUrl = await assetService.getDownloadUrl(result.assetId)
+        // Prefer the tiny avatar when 3.3 found it already generated; otherwise
+        // the original, which is what the client previews until the job lands.
+        const preview = thumbnails.get(AVATAR_PREVIEW_PRESET)
+        downloadUrl =
+          preview?.status === 'ready' && preview.assetId
+            ? await assetService.getDownloadUrl(preview.assetId)
+            : await assetService.getDownloadUrl(result.assetId)
       }
     } catch (urlErr) {
       logger.warn('Failed to get download URL for SSE', {
@@ -286,7 +341,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       })
     }
 
-    // 3.4 Publish progress events with URL for client preview
+    // 3.5 Publish progress events with URL for client preview
     await ProgressPublisher.publishCompleted(sessionId, {
       fileId: result.fileId,
       assetId: result.assetId,
@@ -305,7 +360,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       },
     })
 
-    // 3.5 Kick off background jobs (if needed)
+    // 3.6 Kick off background jobs (if needed)
     // await BackgroundJobManager.scheduleProcessing(result.fileId)
 
     return NextResponse.json({
@@ -319,6 +374,22 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       url: downloadUrl || undefined,
     })
   } catch (error) {
-    return UploadErrorHandler.handleUploadError(error, sessionId, 'upload-completion')
+    // `handleUploadError` also marks the session failed and publishes the SSE
+    // failure, so it still runs — but it classifies status by substring match.
+    // This is a raw App Router handler with no `auxxErrorMiddleware`, so an
+    // AuxxError (e.g. `ProcessorRegistry.getForEntityType`'s `BadRequestError`)
+    // would otherwise land as a generic 500 instead of its own status.
+    const response = await UploadErrorHandler.handleUploadError(
+      error,
+      sessionId,
+      'upload-completion'
+    )
+    if (isAuxxError(error) && response.status !== error.statusCode) {
+      return new Response(response.body, {
+        status: error.statusCode,
+        headers: response.headers,
+      })
+    }
+    return response
   }
 }

--- a/apps/web/src/app/api/files/upload/[sessionId]/events/route.ts
+++ b/apps/web/src/app/api/files/upload/[sessionId]/events/route.ts
@@ -1,9 +1,9 @@
 // apps/web/src/app/api/files/upload/[sessionId]/events/route.ts
 
-import { SessionManager } from '@auxx/lib/files/server'
 import { createScopedLogger } from '@auxx/logger'
 import { createDedicatedClient } from '@auxx/redis'
 import type { NextRequest } from 'next/server'
+import { authorizeUploadSession } from '../authorize-upload-session'
 
 const logger = createScopedLogger('upload-sse')
 
@@ -17,10 +17,11 @@ interface RouteParams {
 export async function GET(request: NextRequest, { params }: RouteParams) {
   const { sessionId } = await params
 
-  const session = await SessionManager.getSession(sessionId)
-  if (!session) {
-    return new Response('Session not found', { status: 404 })
-  }
+  // Authenticate: this stream used to disclose upload status for any known
+  // session id (`docs/files-upload-architecture-guide.md` §11.4).
+  const authorized = await authorizeUploadSession(sessionId)
+  if (authorized instanceof Response) return authorized
+  const { session } = authorized
 
   const stream = new ReadableStream({
     start(controller) {

--- a/apps/web/src/app/api/files/upload/[sessionId]/parts/route.ts
+++ b/apps/web/src/app/api/files/upload/[sessionId]/parts/route.ts
@@ -3,6 +3,7 @@
 import { createStorageManager, SessionManager, UploadErrorHandler } from '@auxx/lib/files/server'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
+import { authorizeUploadSession } from '../authorize-upload-session'
 
 const PartRequestSchema = z.object({
   partNumber: z.number().int().positive(),
@@ -20,6 +21,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const { sessionId } = await params
 
+    // Authenticate FIRST: this endpoint used to mint presigned `UploadPart` URLs
+    // for arbitrary part numbers to anyone holding the session nanoid
+    // (`docs/files-upload-architecture-guide.md` §11.4).
+    const authorized = await authorizeUploadSession(sessionId)
+    if (authorized instanceof Response) return authorized
+    const { session } = authorized
+
     let body, partRequest
     try {
       body = await request.json()
@@ -31,11 +39,6 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
 
     const { partNumber, size } = partRequest
-
-    const session = await SessionManager.getSession(sessionId)
-    if (!session) {
-      return UploadErrorHandler.sessionNotFound(sessionId)
-    }
 
     if (!session.isMultipart || !session.uploadId) {
       return UploadErrorHandler.validationError('Not a multipart upload session', {
@@ -56,9 +59,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         uploadId: session.uploadId,
         partNumber,
         size,
-        // NOTE: `StorageManager.generatePartUploadUrl` takes no `ttlSec` and does not
-        // forward one to the adapter, so part URLs use the S3 adapter's 3600s default
-        // rather than `session.ttlSec`.
+        // The multipart upload was initiated in `session.bucket`; presigning a
+        // part against any other bucket fails with `NoSuchUpload` (guide §11.5).
+        bucket: session.bucket,
+        // NOTE (still true): `StorageManager.generatePartUploadUrl` takes no
+        // `ttlSec` and forwards none, so part URLs use `S3Adapter.presignPart`'s
+        // 3600s default rather than `session.ttlSec`.
         credentialId: session.credentialId,
       })
 

--- a/apps/web/src/app/api/files/upload/[sessionId]/upload-session-auth.test.ts
+++ b/apps/web/src/app/api/files/upload/[sessionId]/upload-session-auth.test.ts
@@ -1,0 +1,165 @@
+// apps/web/src/app/api/files/upload/[sessionId]/upload-session-auth.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * `complete`, `parts` and `events` called `auth.api.getSession` NOWHERE
+ * (`docs/files-upload-architecture-guide.md` §11.4, plan §1.2). The upload
+ * session nanoid was the only credential, so anyone holding one could finish
+ * someone else's upload, mint presigned `UploadPart` URLs for arbitrary part
+ * numbers, or read upload status.
+ *
+ * These assert the three cases `authorizeUploadSession` distinguishes, plus the
+ * ORDER: the auth check runs before Redis is touched, so an unauthenticated
+ * caller cannot use the 404-vs-403 split to probe for live session ids.
+ */
+
+const { getSession, getUploadSession, touchSession, updateSession } = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getUploadSession: vi.fn(),
+  touchSession: vi.fn(),
+  updateSession: vi.fn(),
+}))
+
+vi.mock('@auxx/logger', async () => (await import('~/test/logger-mock')).mockAuxxLogger())
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+vi.mock('~/server/api/trpc', () => ({ isAuxxError: () => false }))
+vi.mock('@auxx/database', () => ({ database: { transaction: vi.fn() }, schema: {} }))
+vi.mock('@auxx/redis', () => ({ createDedicatedClient: async () => null }))
+
+// The `@auxx/lib/files/server` barrel drags in the AWS SDK and the processor
+// registry; none of it is reachable before the gate, which is the point.
+vi.mock('@auxx/lib/files/server', () => ({
+  SessionManager: { getSession: getUploadSession, touchSession, updateSession },
+  createStorageManager: vi.fn(),
+  ensureProcessorsInitialized: vi.fn(),
+  ProcessorRegistry: { getForEntityType: vi.fn() },
+  ProgressPublisher: { publishFailed: vi.fn(), publishCompleted: vi.fn() },
+  UploadErrorHandler: {
+    handleUploadError: vi.fn(async () => new Response('{}', { status: 500 })),
+    validationError: vi.fn(() => new Response('{}', { status: 400 })),
+    sessionNotFound: vi.fn(() => new Response('{}', { status: 404 })),
+    unauthorized: vi.fn(() => new Response('{}', { status: 401 })),
+  },
+  cleanupService: { scheduleCleanup: vi.fn() },
+  MediaAssetService: vi.fn(),
+  enqueueEnsureThumbnail: vi.fn(),
+}))
+
+const { POST: completePost } = await import('./complete/route')
+const { POST: partsPost } = await import('./parts/route')
+const { GET: eventsGet } = await import('./events/route')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const OTHER_ORG_ID = 'org_cuid111111111111111111111'
+const USER_ID = 'usr_cuid000000000000000000000'
+const OTHER_USER_ID = 'usr_cuid111111111111111111111'
+const SESSION_ID = 'sess_nanoid_000000000000'
+
+const params = { params: Promise.resolve({ sessionId: SESSION_ID }) }
+
+function signedInAs(userId: string | null, organizationId: string | null = ORG_ID) {
+  getSession.mockResolvedValue(
+    userId ? { user: { id: userId, defaultOrganizationId: organizationId } } : null
+  )
+}
+
+/** A live multipart session owned by `USER_ID` in `ORG_ID`. */
+function uploadSessionOwnedBy(userId: string, organizationId: string) {
+  getUploadSession.mockResolvedValue({
+    version: 2,
+    id: SESSION_ID,
+    organizationId,
+    userId,
+    entityType: 'USER_PROFILE',
+    fileName: 'avatar.png',
+    mimeType: 'image/png',
+    expectedSize: 1024,
+    provider: 'S3',
+    storageKey: 'org/avatar.png',
+    isMultipart: true,
+    uploadId: 'mpu-1',
+    uploadMethod: 'PUT',
+    status: 'uploading',
+    createdAt: new Date(),
+    expiresAt: new Date(Date.now() + 600_000),
+    ttlSec: 600,
+    metadata: {},
+    policy: {},
+    uploadPlan: { strategy: 'multipart' },
+    bucket: 'auxx-public',
+    visibility: 'PUBLIC',
+  })
+}
+
+const completeRequest = () =>
+  new Request('http://localhost/api/files/upload/x/complete', {
+    method: 'POST',
+    body: JSON.stringify({ size: 1024, mimeType: 'image/png' }),
+  }) as any
+
+const partsRequest = () =>
+  new Request('http://localhost/api/files/upload/x/parts', {
+    method: 'POST',
+    body: JSON.stringify({ partNumber: 1, size: 1024 }),
+  }) as any
+
+const eventsRequest = () =>
+  new Request('http://localhost/api/files/upload/x/events', { method: 'GET' }) as any
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  uploadSessionOwnedBy(USER_ID, ORG_ID)
+})
+
+describe.each([
+  ['complete', (req: any) => completePost(req, params), completeRequest],
+  ['parts', (req: any) => partsPost(req, params), partsRequest],
+  ['events', (req: any) => eventsGet(req, params), eventsRequest],
+] as const)('%s — upload session authentication', (_name, call, request) => {
+  it('401s with no session cookie, before the Redis session is read', async () => {
+    signedInAs(null)
+
+    const res = await call(request())
+
+    expect(res.status).toBe(401)
+    // Order matters: an unauthenticated caller must not be able to tell a live
+    // session id from a dead one.
+    expect(getUploadSession).not.toHaveBeenCalled()
+  })
+
+  it('401s for a signed-in user with no default organization', async () => {
+    signedInAs(USER_ID, null)
+
+    const res = await call(request())
+
+    expect(res.status).toBe(401)
+    expect(getUploadSession).not.toHaveBeenCalled()
+  })
+
+  it('403s when the session belongs to another user', async () => {
+    signedInAs(OTHER_USER_ID)
+
+    const res = await call(request())
+
+    expect(res.status).toBe(403)
+  })
+
+  it('403s when the session belongs to another organization', async () => {
+    signedInAs(USER_ID, OTHER_ORG_ID)
+
+    const res = await call(request())
+
+    expect(res.status).toBe(403)
+  })
+
+  it('404s an unknown session for an authenticated caller', async () => {
+    signedInAs(USER_ID)
+    getUploadSession.mockResolvedValue(null)
+
+    const res = await call(request())
+
+    expect(res.status).toBe(404)
+  })
+})

--- a/apps/web/src/app/api/files/upload/sessions/route.ts
+++ b/apps/web/src/app/api/files/upload/sessions/route.ts
@@ -1,6 +1,5 @@
 // apps/web/src/app/api/files/upload/sessions/route.ts
 
-import { AuxxError } from '@auxx/lib/errors'
 import {
   createStorageManager,
   ensureProcessorsInitialized,
@@ -15,8 +14,24 @@ import { headers } from 'next/headers'
 import { type NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { auth } from '~/auth/server'
+import { isAuxxError } from '~/server/api/trpc'
 
 const logger = createScopedLogger('api-presigned-upload-sessions')
+
+/**
+ * Stable error codes for the `{ error, message }` body this route returns, keyed
+ * by an `AuxxError`'s status. Keeps the 403 body byte-identical to what the
+ * hand-rolled `files.manage` catch used to produce.
+ */
+const HTTP_ERROR_CODE_BY_STATUS: Record<number, string> = {
+  400: 'BAD_REQUEST',
+  401: 'UNAUTHORIZED',
+  403: 'FORBIDDEN',
+  404: 'NOT_FOUND',
+  409: 'CONFLICT',
+  422: 'UNPROCESSABLE_ENTITY',
+  429: 'RATE_LIMITED',
+}
 
 /**
  * Request schema for creating presigned upload sessions
@@ -57,25 +72,15 @@ export async function POST(request: NextRequest) {
     // Layer-2 gate (doc 10 §0): file-library uploads require `files.manage` (Full).
     // Record attachments, dataset docs, visit-QC photos, avatars, etc. reach this
     // same transport but are gated by their own host surface — leave them on the
-    // plan/quota gate only. Returned explicitly so the AuxxError carries its own 403
-    // instead of being message-string-classified by the outer handler.
+    // plan/quota gate only. The thrown `ForbiddenError` keeps its own 403 via the
+    // `isAuxxError` mapping in the outer catch.
     if (sessionRequest.entityType === ENTITY_TYPES.FILE) {
-      try {
-        const { requirePermission, PermissionKey } = await import('@auxx/lib/permissions')
-        await requirePermission(
-          session.user.id,
-          session.user.defaultOrganizationId,
-          PermissionKey.filesManage
-        )
-      } catch (permissionError) {
-        if (permissionError instanceof AuxxError) {
-          return NextResponse.json(
-            { error: 'FORBIDDEN', message: permissionError.message },
-            { status: permissionError.statusCode }
-          )
-        }
-        throw permissionError
-      }
+      const { requirePermission, PermissionKey } = await import('@auxx/lib/permissions')
+      await requirePermission(
+        session.user.id,
+        session.user.defaultOrganizationId,
+        PermissionKey.filesManage
+      )
     }
 
     // Storage limit check: verify org has capacity for this upload
@@ -109,8 +114,9 @@ export async function POST(request: NextRequest) {
         }
       }
     } catch (storageCheckError) {
-      // Fail open — allow the upload if storage check fails
-      logger.warn('Storage limit check failed (fail-open)', {
+      // Fail open — allow the upload if storage check fails. Logged at `error`
+      // on purpose: a silently failing billing gate has to be alertable.
+      logger.error('Storage limit check failed (fail-open)', {
         error:
           storageCheckError instanceof Error
             ? storageCheckError.message
@@ -198,6 +204,18 @@ export async function POST(request: NextRequest) {
     }
   } catch (error) {
     logger.error('Failed to create upload session', { error })
+
+    // Raw App Router handler — there is no `auxxErrorMiddleware` here, so an
+    // AuxxError's own status has to be applied by hand or `handleUploadError`
+    // flattens it to a message-string-classified 500. `ProcessorRegistry`
+    // (unregistered entity type) and `requirePermission` both throw one.
+    if (isAuxxError(error)) {
+      return NextResponse.json(
+        { error: HTTP_ERROR_CODE_BY_STATUS[error.statusCode] ?? 'ERROR', message: error.message },
+        { status: error.statusCode }
+      )
+    }
+
     // Generate a temporary session ID for error tracking
     const tempSessionId = `temp-${Date.now()}`
     return await UploadErrorHandler.handleUploadError(error, tempSessionId, 'session-creation', {

--- a/apps/web/src/app/api/files/upload/sessions/session-error-mapping.test.ts
+++ b/apps/web/src/app/api/files/upload/sessions/session-error-mapping.test.ts
@@ -1,0 +1,139 @@
+// apps/web/src/app/api/files/upload/sessions/session-error-mapping.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * `POST /api/files/upload/sessions` is a raw App Router handler, so no
+ * `auxxErrorMiddleware` runs on it. `ProcessorRegistry.getForEntityType` now
+ * throws `BadRequestError` for an unregistered entity type instead of silently
+ * defaulting to `FileProcessor` (plan §1.7), and without an explicit map that
+ * lands in `UploadErrorHandler.handleUploadError`, which classifies status by
+ * SUBSTRING MATCH on the message — a generic 500.
+ *
+ * Also covers the fold of the hand-rolled `files.manage` catch into the same
+ * mapping: the 403 body must stay `{ error: 'FORBIDDEN', message }`.
+ */
+
+const { getSession, getForEntityType, requirePermission, calculateStorageUsage, getLimit, logger } =
+  vi.hoisted(() => ({
+    getSession: vi.fn(),
+    getForEntityType: vi.fn(),
+    requirePermission: vi.fn(),
+    calculateStorageUsage: vi.fn(),
+    getLimit: vi.fn(),
+    logger: {
+      info: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      trace: vi.fn(),
+      with: vi.fn(),
+    },
+  }))
+
+vi.mock('@auxx/logger', async () =>
+  (await import('~/test/logger-mock')).mockAuxxLogger({ createScopedLogger: () => logger })
+)
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+
+// Faithful to `~/server/api/trpc`'s exported guard; the `name` + `statusCode`
+// branch there exists only for dual module copies, which the vitest source
+// alias rules out.
+vi.mock('~/server/api/trpc', async () => {
+  const { AuxxError } = await import('@auxx/lib/errors')
+  return { isAuxxError: (e: unknown) => e instanceof AuxxError }
+})
+
+vi.mock('@auxx/lib/files/server', () => ({
+  createStorageManager: () => ({
+    generatePresignedUploadUrl: vi.fn(),
+    startMultipartUploadFromConfig: vi.fn(),
+  }),
+  ensureProcessorsInitialized: vi.fn(),
+  ProcessorRegistry: { getForEntityType },
+  SessionManager: { createSessionFromConfig: vi.fn(), updateSession: vi.fn() },
+  UploadErrorHandler: {
+    handleUploadError: vi.fn(async () => new Response('{}', { status: 500 })),
+    validationError: vi.fn(() => new Response('{}', { status: 400 })),
+    unauthorized: vi.fn(() => new Response('{}', { status: 401 })),
+  },
+}))
+
+vi.mock('@auxx/lib/permissions', () => ({
+  requirePermission,
+  PermissionKey: { filesManage: 'files.manage' },
+  FeaturePermissionService: class {
+    getLimit = getLimit
+  },
+}))
+vi.mock('@auxx/lib/files/lifecycle/quota-cleanup', () => ({ calculateStorageUsage }))
+
+const { BadRequestError, ForbiddenError } = await import('@auxx/lib/errors')
+const { POST } = await import('./route')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+
+const request = (entityType: string) =>
+  new Request('http://localhost/api/files/upload/sessions', {
+    method: 'POST',
+    body: JSON.stringify({
+      fileName: 'a.png',
+      mimeType: 'image/png',
+      expectedSize: 1024,
+      entityType,
+    }),
+  }) as any
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getSession.mockResolvedValue({ user: { id: USER_ID, defaultOrganizationId: ORG_ID } })
+  getLimit.mockResolvedValue(null)
+  requirePermission.mockResolvedValue(undefined)
+})
+
+describe('POST sessions — AuxxError keeps its own status', () => {
+  it('400s a BadRequestError from the processor registry, not 500', async () => {
+    getForEntityType.mockImplementation(() => {
+      throw new BadRequestError('No upload processor for entity type: visit_qc_item')
+    })
+
+    const res = await POST(request('MESSAGE'))
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({
+      error: 'BAD_REQUEST',
+      message: 'No upload processor for entity type: visit_qc_item',
+    })
+  })
+
+  it('keeps the 403 body shape for the folded `files.manage` gate', async () => {
+    requirePermission.mockRejectedValue(new ForbiddenError('Missing permission: files.manage'))
+
+    const res = await POST(request('FILE'))
+
+    expect(res.status).toBe(403)
+    expect(await res.json()).toEqual({
+      error: 'FORBIDDEN',
+      message: 'Missing permission: files.manage',
+    })
+  })
+})
+
+describe('POST sessions — the storage quota gate', () => {
+  it('logs at error, not warn, when the fail-open gate swallows a failure', async () => {
+    getLimit.mockRejectedValue(new Error('feature service down'))
+    getForEntityType.mockImplementation(() => {
+      throw new BadRequestError('stop here')
+    })
+
+    await POST(request('MESSAGE'))
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Storage limit check failed (fail-open)',
+      expect.objectContaining({ error: 'feature service down' })
+    )
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/file-select/hooks/use-file-select.ts
+++ b/apps/web/src/components/file-select/hooks/use-file-select.ts
@@ -120,7 +120,14 @@ export function useFileSelect(options: UseFileSelectOptions = {}): UseFileSelect
           source: 'upload',
           isUploading: false,
           url: r.url,
-          serverFileId: r.metadata?.assetId || r.fileId,
+          // `r.fileId` is the CLIENT-side temp id, not a server id — it is only a
+          // last resort. `useFileSelect` defaults to `entityType: 'FILE'`, which
+          // `FileProcessor` serves, so the server returns a FolderFile id and no
+          // `assetId`. Reading `assetId || r.fileId` therefore handed downstream
+          // consumers the temp id (and, before the upload store learned
+          // `serverIdKind`, the upload-session nanoid) — the same class of bug as
+          // `docs/files-upload-architecture-guide.md` §11.3.
+          serverFileId: r.metadata?.assetId ?? r.metadata?.fileId ?? r.fileId,
         }))
 
       // Also update selectedItems state for UI consistency

--- a/apps/web/src/components/file-upload/hooks/__tests__/to-upload-result.test.ts
+++ b/apps/web/src/components/file-upload/hooks/__tests__/to-upload-result.test.ts
@@ -1,0 +1,97 @@
+// apps/web/src/components/file-upload/hooks/__tests__/to-upload-result.test.ts
+
+import { describe, expect, it } from 'vitest'
+import type { FileState } from '../../stores'
+import { toUploadResult } from '../use-file-upload'
+
+/**
+ * `useFileUpload` used to report `metadata: { assetId: f.serverFileId || f.id }` unconditionally,
+ * so a `FolderFile` id — and, worse, the upload-session nanoid parked in `serverFileId` at
+ * session-create time — was handed to callers as a `MediaAsset` id. `qc-photo-strip` then fed it
+ * to `AttachmentService.create({ assetId })` and produced zero attachments, silently
+ * (docs/files-upload-architecture-guide.md §11.3).
+ *
+ * `toUploadResult` must gate `assetId` on the `serverIdKind` the store records.
+ */
+function fileState(overrides: Partial<FileState>): FileState {
+  return {
+    id: 'tmp_client_id',
+    tempFileId: 'tmp_client_id',
+    name: 'photo.jpg',
+    type: 'file',
+    displaySize: 1024,
+    size: 1024,
+    mimeType: 'image/jpeg',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    path: '/',
+    status: 'completed',
+    isUploading: true,
+    stages: [],
+    ...overrides,
+  } as FileState
+}
+
+describe('toUploadResult', () => {
+  it('reports assetId when the server actually created a MediaAsset', () => {
+    const result = toUploadResult(
+      fileState({ serverFileId: 'ast_1', metadata: { serverIdKind: 'asset' } })
+    )
+
+    expect(result.metadata?.assetId).toBe('ast_1')
+    expect(result.metadata?.fileId).toBeUndefined()
+    expect(result.metadata?.serverIdKind).toBe('asset')
+  })
+
+  it('does NOT report an assetId when the server response carried only a fileId', () => {
+    const result = toUploadResult(
+      fileState({ serverFileId: 'fil_1', metadata: { serverIdKind: 'file' } })
+    )
+
+    // The load-bearing assertion: a FolderFile id must never masquerade as a MediaAsset id.
+    expect(result.metadata?.assetId).toBeUndefined()
+    // …but it is not discarded either — it is surfaced under its own name.
+    expect(result.metadata?.fileId).toBe('fil_1')
+    expect(result.metadata?.serverIdKind).toBe('file')
+  })
+
+  it('does NOT report the upload-session nanoid as an assetId or a fileId', () => {
+    const result = toUploadResult(
+      fileState({ serverFileId: 'ses_nanoid', metadata: { serverIdKind: 'session' } })
+    )
+
+    expect(result.metadata?.assetId).toBeUndefined()
+    expect(result.metadata?.fileId).toBeUndefined()
+    expect(result.metadata?.serverIdKind).toBe('session')
+  })
+
+  it('reports no record id at all when the store recorded no kind', () => {
+    const result = toUploadResult(fileState({ serverFileId: 'whatever' }))
+
+    expect(result.metadata?.assetId).toBeUndefined()
+    expect(result.metadata?.fileId).toBeUndefined()
+    expect(result.metadata?.serverIdKind).toBeUndefined()
+  })
+
+  it('never falls back to the client-side temp id', () => {
+    const result = toUploadResult(fileState({ id: 'tmp_client_id', serverFileId: undefined }))
+
+    expect(result.metadata?.assetId).toBeUndefined()
+    // The client id is still reported, but under `fileId` on the result itself — where it has
+    // always been a client id — not as a server record id inside `metadata`.
+    expect(result.fileId).toBe('tmp_client_id')
+  })
+
+  it('carries the plain result fields through unchanged', () => {
+    const result = toUploadResult(
+      fileState({ status: 'failed', error: 'boom', url: 'https://cdn/1' })
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('boom')
+    expect(result.filename).toBe('photo.jpg')
+    expect(result.url).toBe('https://cdn/1')
+    expect(result.size).toBe(1024)
+    expect(result.mimeType).toBe('image/jpeg')
+  })
+})

--- a/apps/web/src/components/file-upload/hooks/use-file-upload.ts
+++ b/apps/web/src/components/file-upload/hooks/use-file-upload.ts
@@ -1,12 +1,46 @@
 'use client'
 
-import type { BatchUploadResult, EntityType } from '@auxx/lib/files/types'
+import type { BatchUploadResult, EntityType, UploadResult } from '@auxx/lib/files/types'
 import { generateId } from '@auxx/utils/generateId'
 import * as React from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import type { FileState } from '../stores'
 import { cleanupUploader, useUploadStore } from '../stores'
 import type { EntityUploadConfig } from '../types'
+
+/**
+ * Project one store `FileState` onto the public {@link UploadResult} shape.
+ *
+ * `FileState.serverFileId` is deliberately overloaded: it holds the upload-session nanoid from
+ * session-create time until the completion response replaces it with a `MediaAsset` id or a
+ * `FolderFile` id. `metadata.serverIdKind` (written by the orchestration slice at both sites) is
+ * the only thing that says which. This function is where that distinction becomes visible to
+ * callers: `assetId` is populated ONLY for a real `MediaAsset`, a `FolderFile` id is surfaced
+ * separately as `fileId`, and a session nanoid is surfaced as neither.
+ *
+ * Reporting all three as `assetId` is what let `visit_qc_item` uploads hand
+ * `AttachmentService.create` an id that was not a `MediaAsset` and produce zero attachments —
+ * `docs/files-upload-architecture-guide.md` §11.3.
+ */
+export function toUploadResult(f: FileState): UploadResult {
+  const serverIdKind = f.metadata?.serverIdKind
+  const serverId = f.serverFileId
+
+  return {
+    success: f.status === 'completed',
+    fileId: f.id,
+    filename: f.name,
+    url: f.url,
+    size: f.size ?? undefined,
+    mimeType: f.mimeType ?? undefined,
+    error: f.error,
+    metadata: {
+      serverIdKind,
+      ...(serverIdKind === 'asset' && serverId ? { assetId: serverId } : {}),
+      ...(serverIdKind === 'file' && serverId ? { fileId: serverId } : {}),
+    },
+  }
+}
 
 export interface UseFileUploadOptions {
   entityType: EntityType
@@ -330,16 +364,7 @@ export function useFileUpload(options: UseFileUploadOptions): UseFileUploadRetur
   React.useEffect(() => {
     if (!onProgress || !uploadSummary || uploadSummary.totalFiles === 0) return
 
-    const results = filesForSummary.map((f) => ({
-      success: f.status === 'completed',
-      fileId: f.id,
-      filename: f.name,
-      url: f.url,
-      size: f.size ?? undefined,
-      mimeType: f.mimeType ?? undefined,
-      error: f.error,
-      metadata: { assetId: f.serverFileId || f.id },
-    }))
+    const results = filesForSummary.map(toUploadResult)
 
     onProgress({
       totalFiles: uploadSummary.totalFiles,
@@ -377,16 +402,7 @@ export function useFileUpload(options: UseFileUploadOptions): UseFileUploadRetur
     const results = (sess.fileIds || [])
       .map((fid) => store.files[fid])
       .filter((f) => f !== undefined)
-      .map((f) => ({
-        success: f.status === 'completed',
-        fileId: f.id,
-        filename: f.name,
-        url: f.url,
-        size: f.size ?? undefined,
-        mimeType: f.mimeType ?? undefined,
-        error: f.error,
-        metadata: { assetId: f.serverFileId || f.id },
-      }))
+      .map(toUploadResult)
 
     onComplete({
       totalFiles: uploadSummary.totalFiles,

--- a/apps/web/src/components/file-upload/stores/types.ts
+++ b/apps/web/src/components/file-upload/stores/types.ts
@@ -4,6 +4,7 @@ import type {
   BatchUploadResult,
   EntityType,
   ProcessingStage,
+  ServerIdKind,
   SessionStatus,
   UploadProgress,
 } from '@auxx/lib/files/types'
@@ -58,6 +59,14 @@ export interface FileState {
   checksum?: string
   metadata?: {
     targetFolderId?: string | null // Target folder for upload
+    /**
+     * Which kind of server record `serverFileId` currently holds — `'session'` until the
+     * completion response lands, then `'asset'` (a `MediaAsset`) or `'file'` (a `FolderFile`).
+     * Declared rather than left to the index signature below so consumers read it as a union
+     * instead of `any`; `toUploadResult` gates `metadata.assetId` on it
+     * (`docs/files-upload-architecture-guide.md` §11.3).
+     */
+    serverIdKind?: ServerIdKind
     [key: string]: any // Allow additional metadata
   }
   // REMOVED: retryCount, uploadedAt, completedAt (offline-related fields)

--- a/apps/web/src/components/schedule/ui/qc/qc-photo-strip.tsx
+++ b/apps/web/src/components/schedule/ui/qc/qc-photo-strip.tsx
@@ -53,6 +53,20 @@ export function QcPhotoStrip({
         onAddPhoto(result.metadata.assetId)
       } else if (result?.error) {
         toastError({ title: 'Error uploading photo', description: result.error })
+      } else {
+        // A "successful" upload carrying no `MediaAsset` id has nothing to attach. This used to
+        // fall between the two branches above and be a silent no-op, which is exactly how the
+        // missing `visit_qc_item` processor hid — the bytes landed, the strip stayed empty and
+        // nothing was ever reported (docs/files-upload-architecture-guide.md §11.3).
+        console.error('[qc-photo-strip] upload produced no MediaAsset id', {
+          itemId,
+          serverIdKind: result?.metadata?.serverIdKind,
+          result,
+        })
+        toastError({
+          title: 'Error uploading photo',
+          description: 'The photo uploaded but no image record came back, so it was not attached.',
+        })
       }
     },
     onError: (error) => toastError({ title: 'Error uploading photo', description: error }),

--- a/packages/lib/src/files/lifecycle/__tests__/quota-cleanup.test.ts
+++ b/packages/lib/src/files/lifecycle/__tests__/quota-cleanup.test.ts
@@ -2,7 +2,19 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const h = vi.hoisted(() => ({ db: null as any }))
+const h = vi.hoisted(() => ({
+  db: null as any,
+  /** Raw `FeaturePermissionService.getLimit` answers, keyed by feature. */
+  limits: {} as Record<string, unknown>,
+}))
+
+const getLimit = vi.fn(async (_orgId: string, key: string) => h.limits[key] ?? null)
+
+vi.mock('../../../permissions/feature-permission-service', () => ({
+  FeaturePermissionService: class {
+    getLimit = getLimit
+  },
+}))
 
 // Partial-mock the logger: `@auxx/logger/run-log` imports sink-registration
 // helpers from this barrel at load, so a full replacement breaks whichever
@@ -30,7 +42,9 @@ vi.mock('@auxx/database', async () => {
 })
 
 import { schema } from '@auxx/database'
-import { calculateStorageUsage } from '../quota-cleanup'
+import { calculateStorageUsage, storageQuotaCheckJob } from '../quota-cleanup'
+
+const GB = 1024 * 1024 * 1024
 
 type Lane = 'folder' | 'media'
 
@@ -44,10 +58,11 @@ type AggregateRow = { totalSize: string | null; count: string }
  * about: the broken query joined `File` instead of `FolderFile`, and never
  * looked at `MediaAsset` at all.
  */
-function laneOf(tables: unknown[]): Lane | 'unknown' {
+function laneOf(tables: unknown[]): Lane | 'org' | 'unknown' {
   if (tables.includes(schema.FileVersion) && tables.includes(schema.FolderFile)) return 'folder'
   if (tables.includes(schema.MediaAssetVersion) && tables.includes(schema.MediaAsset))
     return 'media'
+  if (tables.includes(schema.Organization)) return 'org'
   return 'unknown'
 }
 
@@ -57,13 +72,16 @@ function laneOf(tables: unknown[]): Lane | 'unknown' {
  * canned for that lane. A query that reaches neither lane resolves to `[]`,
  * which is what today's broken `FileVersion ⋈ File` join does in production.
  */
-function createFakeDb(rows: Partial<Record<Lane, AggregateRow[]>>) {
-  const lanesSeen: Array<Lane | 'unknown'> = []
+function createFakeDb(
+  rows: Partial<Record<Lane, AggregateRow[]>>,
+  organizations: Array<{ id: string; name: string }> = []
+) {
+  const lanesSeen: Array<Lane | 'org' | 'unknown'> = []
   const tablesSeen: unknown[][] = []
 
   const select = () => {
     const tables: unknown[] = []
-    let lane: Lane | 'unknown' | undefined
+    let lane: Lane | 'org' | 'unknown' | undefined
 
     const chain: any = {
       from: (source: any) => {
@@ -87,16 +105,20 @@ function createFakeDb(rows: Partial<Record<Lane, AggregateRow[]>>) {
         tablesSeen.push(tables)
         return { __lane: resolved }
       },
-      then: (resolve: (value: AggregateRow[]) => void) => {
+      then: (resolve: (value: any[]) => void) => {
         if (lane === undefined) {
           // Directly-awaited chain (no sub-select): record what it touched.
           const resolved = laneOf(tables)
           lanesSeen.push(resolved)
           tablesSeen.push(tables)
+          if (resolved === 'org') {
+            resolve(organizations)
+            return
+          }
           resolve(resolved === 'unknown' ? [] : (rows[resolved] ?? []))
           return
         }
-        resolve(lane === 'unknown' ? [] : (rows[lane] ?? []))
+        resolve(lane === 'unknown' || lane === 'org' ? [] : (rows[lane] ?? []))
       },
     }
     return chain
@@ -108,6 +130,9 @@ function createFakeDb(rows: Partial<Record<Lane, AggregateRow[]>>) {
 describe('calculateStorageUsage', () => {
   beforeEach(() => {
     h.db = null
+    // Growth-plan shape, so the usage tests have a real denominator.
+    h.limits = { storageGbHard: 50, storageGbSoft: 40 }
+    getLimit.mockClear()
   })
 
   it('counts MediaAsset-backed storage', async () => {
@@ -169,5 +194,137 @@ describe('calculateStorageUsage', () => {
     expect(quota.totalUsed).toBe(0)
     expect(quota.fileCount).toBe(0)
     expect(quota.percentUsed).toBe(0)
+  })
+
+  it('reads quotaLimit from the plan instead of a hard-coded 50 GB', async () => {
+    h.limits = { storageGbHard: 1, storageGbSoft: 0.8 } // Free plan
+    const fake = createFakeDb({
+      folder: [{ totalSize: null, count: '0' }],
+      media: [{ totalSize: String(0.5 * GB), count: '10' }],
+    })
+    h.db = fake.db
+
+    const quota = await calculateStorageUsage('org-free')
+
+    expect(quota.quotaLimit).toBe(1 * GB)
+    expect(quota.percentUsed).toBe(50)
+    expect(getLimit).toHaveBeenCalledWith('org-free', 'storageGbHard')
+  })
+
+  it('reports -1 and 0% for an unlimited plan', async () => {
+    h.limits = { storageGbHard: '+' } // Enterprise: seeded -1, folded to '+' by the cache
+    const fake = createFakeDb({
+      folder: [{ totalSize: null, count: '0' }],
+      media: [{ totalSize: String(900 * GB), count: '10' }],
+    })
+    h.db = fake.db
+
+    const quota = await calculateStorageUsage('org-enterprise')
+
+    expect(quota.quotaLimit).toBe(-1)
+    expect(quota.percentUsed).toBe(0)
+  })
+
+  it('treats a plan that names no storage limit as uncapped, not as zero bytes', async () => {
+    h.limits = {} // getLimit answers null for a missing key
+    const fake = createFakeDb({
+      folder: [{ totalSize: null, count: '0' }],
+      media: [{ totalSize: String(5 * GB), count: '10' }],
+    })
+    h.db = fake.db
+
+    const quota = await calculateStorageUsage('org-no-key')
+
+    expect(quota.quotaLimit).toBe(-1)
+    expect(quota.percentUsed).toBe(0)
+  })
+})
+
+describe('storageQuotaCheckJob', () => {
+  function job() {
+    const data = { dryRun: false }
+    return {
+      job: { data, updateProgress: vi.fn() },
+      data,
+    } as any
+  }
+
+  beforeEach(() => {
+    h.db = null
+    h.limits = {}
+    getLimit.mockClear()
+  })
+
+  it('enforces against the org plan, not a fixed 50 GB', async () => {
+    h.limits = { storageGbHard: 1, storageGbSoft: 0.8 } // Free plan
+    const fake = createFakeDb(
+      {
+        folder: [{ totalSize: null, count: '0' }],
+        media: [{ totalSize: String(2 * GB), count: '10' }],
+      },
+      [{ id: 'org-free', name: 'Free Org' }]
+    )
+    h.db = fake.db
+
+    // 2 GB is comfortably under the old hard-coded 50 GB and comfortably over
+    // the Free plan's real 1 GB.
+    expect(await storageQuotaCheckJob(job())).toEqual({ checked: 1, warnings: 0, enforced: 1 })
+  })
+
+  it('warns at the soft limit, between "fine" and the hard 403', async () => {
+    h.limits = { storageGbHard: 10, storageGbSoft: 8 } // Starter plan
+    const fake = createFakeDb(
+      {
+        folder: [{ totalSize: null, count: '0' }],
+        media: [{ totalSize: String(9 * GB), count: '10' }],
+      },
+      [{ id: 'org-starter', name: 'Starter Org' }]
+    )
+    h.db = fake.db
+
+    expect(await storageQuotaCheckJob(job())).toEqual({ checked: 1, warnings: 1, enforced: 0 })
+    expect(getLimit).toHaveBeenCalledWith('org-starter', 'storageGbSoft')
+  })
+
+  it('falls back to 80% of the hard limit when the plan names no soft limit', async () => {
+    h.limits = { storageGbHard: 10 }
+    const fake = createFakeDb(
+      {
+        folder: [{ totalSize: null, count: '0' }],
+        media: [{ totalSize: String(8.5 * GB), count: '10' }],
+      },
+      [{ id: 'org-custom', name: 'Custom Org' }]
+    )
+    h.db = fake.db
+
+    expect(await storageQuotaCheckJob(job())).toEqual({ checked: 1, warnings: 1, enforced: 0 })
+  })
+
+  it('never warns or enforces on an uncapped plan', async () => {
+    h.limits = { storageGbHard: '+', storageGbSoft: '+' }
+    const fake = createFakeDb(
+      {
+        folder: [{ totalSize: null, count: '0' }],
+        media: [{ totalSize: String(900 * GB), count: '10' }],
+      },
+      [{ id: 'org-enterprise', name: 'Enterprise Org' }]
+    )
+    h.db = fake.db
+
+    expect(await storageQuotaCheckJob(job())).toEqual({ checked: 1, warnings: 0, enforced: 0 })
+  })
+
+  it('does not enforce on an org just under its cap that rounds to 100%', async () => {
+    h.limits = { storageGbHard: 1, storageGbSoft: 0.8 }
+    const fake = createFakeDb(
+      {
+        folder: [{ totalSize: null, count: '0' }],
+        media: [{ totalSize: String(GB - 1), count: '10' }],
+      },
+      [{ id: 'org-edge', name: 'Edge Org' }]
+    )
+    h.db = fake.db
+
+    expect(await storageQuotaCheckJob(job())).toEqual({ checked: 1, warnings: 1, enforced: 0 })
   })
 })

--- a/packages/lib/src/files/lifecycle/orphaned-cleanup.ts
+++ b/packages/lib/src/files/lifecycle/orphaned-cleanup.ts
@@ -12,6 +12,24 @@ import type { OrphanedFileCleanupJobData, OrphanedFileCleanupResult } from './ty
 const logger = createScopedLogger('orphaned-file-cleanup')
 
 /**
+ * The bucket an object actually lives in, as recorded on its `StorageLocation`.
+ *
+ * `StorageManager.prepareLocationMetadata` stamps `metadata.bucket` on every S3
+ * location it writes, so this is the only trustworthy source for a sweep — the
+ * provider default is the PRIVATE bucket, and a delete aimed there for a PUBLIC
+ * object 204s on the missing key while the real object leaks.
+ *
+ * Returns `undefined` for rows written outside `StorageManager` (see
+ * `users/user-avatar-service.ts`) or before the bucket was persisted. Guessing
+ * one would be worse than the fallback: `deleteByKey` then warns loudly, and the
+ * adapter throws rather than silently deleting nothing.
+ */
+function bucketOf(metadata: unknown): string | undefined {
+  const bucket = (metadata as { bucket?: unknown } | null | undefined)?.bucket
+  return typeof bucket === 'string' && bucket.length > 0 ? bucket : undefined
+}
+
+/**
  * Job to clean up orphaned files that were uploaded but never attached to entities
  * Runs hourly to delete files where status = 'PENDING' and expiresAt < now
  */
@@ -153,6 +171,7 @@ export async function deletedFileCleanupJob(
         provider: schema.StorageLocation.provider,
         externalId: schema.StorageLocation.externalId,
         organizationId: schema.StorageLocation.organizationId,
+        metadata: schema.StorageLocation.metadata,
       })
       .from(schema.StorageLocation)
       .where(
@@ -175,6 +194,7 @@ export async function deletedFileCleanupJob(
               await storageManager.deleteByKey({
                 provider: loc.provider as any,
                 key: loc.externalId,
+                bucket: bucketOf(loc.metadata),
               })
             } catch (s3Error) {
               logger.warn('Failed to delete S3 object during sweep, continuing', {

--- a/packages/lib/src/files/lifecycle/quota-cleanup.ts
+++ b/packages/lib/src/files/lifecycle/quota-cleanup.ts
@@ -5,16 +5,45 @@ import { createScopedLogger } from '@auxx/logger'
 import type { Job } from 'bullmq'
 import { and, asc, eq, isNotNull, isNull, lt, sql } from 'drizzle-orm'
 import type { JobContext } from '../../jobs/types'
+import { FeaturePermissionService } from '../../permissions/feature-permission-service'
+import { FeatureKey } from '../../permissions/types'
 import type { StorageQuota } from './types'
 
 const logger = createScopedLogger('quota-cleanup')
 
-// Default storage quotas by organization type (in bytes)
-const DEFAULT_QUOTAS = {
-  free: 1 * 1024 * 1024 * 1024, // 1 GB
-  starter: 10 * 1024 * 1024 * 1024, // 10 GB
-  professional: 50 * 1024 * 1024 * 1024, // 50 GB
-  enterprise: 500 * 1024 * 1024 * 1024, // 500 GB
+const BYTES_PER_GB = 1024 * 1024 * 1024
+
+/**
+ * Sentinel for "no cap", shared with `OrganizationAiQuota.quotaLimit` and the
+ * seeded plan rows. Kept out of the arithmetic everywhere it appears.
+ */
+const UNLIMITED = -1
+
+/**
+ * The org's real storage limit in bytes, resolved from its plan.
+ *
+ * `featureLimits` is a JSONB **array** of `{ key, limit }` entries, so it can
+ * only be read through the features cache — a `->>'storageGbHard'` returns null.
+ * `FeaturePermissionService.getLimit` is that reader, and it is the same one
+ * `apps/web`'s upload gate uses, which is what keeps the gate and this job from
+ * disagreeing about whether an org is over.
+ *
+ * Every non-numeric answer means **uncapped**, not zero:
+ * - `null` — the plan does not name this key, or names it as `false`/`0`. A plan
+ *   silent about storage is unlimited; reading it as a 0-byte cap would put every
+ *   such org instantly over quota.
+ * - `'+'` / `true` — the explicit unlimited markers. The features provider has
+ *   already folded a seeded `-1` (Enterprise) into `'+'`.
+ */
+async function resolveStorageLimitBytes(
+  organizationId: string,
+  featureKey: FeatureKey
+): Promise<number> {
+  const limit = await new FeaturePermissionService().getLimit(organizationId, featureKey)
+
+  if (typeof limit !== 'number' || limit <= 0) return UNLIMITED
+
+  return Math.round(limit * BYTES_PER_GB)
 }
 
 /** Aggregate of stored bytes and stored objects for one storage lane. */
@@ -112,28 +141,51 @@ async function sumMediaAssetUsage(organizationId: string): Promise<LaneUsage> {
  * file with N versions plus M generated thumbnails occupies N + M objects.
  * That is the figure that lines up with `totalUsed`.
  *
+ * `quotaLimit` is the org's real `storageGbHard` plan limit in bytes, or `-1`
+ * when the plan is uncapped — it is NOT a fixed default. `percentUsed` is `0`
+ * for an uncapped org, since there is no denominator to divide by.
+ *
  * @param organizationId Organization to measure.
  */
 export async function calculateStorageUsage(organizationId: string): Promise<StorageQuota> {
-  const [folderFiles, mediaAssets] = await Promise.all([
+  const [folderFiles, mediaAssets, quotaLimit] = await Promise.all([
     sumFolderFileUsage(organizationId),
     sumMediaAssetUsage(organizationId),
+    resolveStorageLimitBytes(organizationId, FeatureKey.storageGbHard),
   ])
 
   const totalUsed = folderFiles.totalSize + mediaAssets.totalSize
   const fileCount = folderFiles.count + mediaAssets.count
 
-  // Get organization's quota limit (would need to be added to Organization model)
-  // For now, using a default
-  const quotaLimit = DEFAULT_QUOTAS.professional
-
   return {
     organizationId,
     totalUsed,
     quotaLimit,
-    percentUsed: Math.round((totalUsed / quotaLimit) * 100),
+    percentUsed: quotaLimit === UNLIMITED ? 0 : Math.round((totalUsed / quotaLimit) * 100),
     fileCount,
   }
+}
+
+/**
+ * Byte threshold at which an org should be warned it is approaching its cap.
+ *
+ * `storageGbSoft` is defined on every seeded plan (Free 0.8, Starter 8,
+ * Growth 40, Demo 0.08) and, until now, read by nothing — orgs went from no
+ * signal at all straight to a hard 403 at the upload gate. This wires it in as
+ * the warn threshold.
+ *
+ * A plan that names no soft limit falls back to 80% of its hard limit, which is
+ * the heuristic this job used before. `null` means there is nothing to warn
+ * about: an uncapped plan cannot approach a cap.
+ */
+async function resolveWarnThresholdBytes(
+  organizationId: string,
+  hardLimitBytes: number
+): Promise<number | null> {
+  const softLimitBytes = await resolveStorageLimitBytes(organizationId, FeatureKey.storageGbSoft)
+  if (softLimitBytes !== UNLIMITED) return softLimitBytes
+  if (hardLimitBytes === UNLIMITED) return null
+  return Math.round(hardLimitBytes * 0.8)
 }
 
 /**
@@ -167,9 +219,13 @@ export async function storageQuotaCheckJob(
       result.checked++
 
       const usage = await calculateStorageUsage(org.id)
+      const warnAt = await resolveWarnThresholdBytes(org.id, usage.quotaLimit)
 
-      // Check if over quota
-      if (usage.percentUsed >= 100) {
+      // Compared in bytes, not on `percentUsed` — that is rounded, so 99.6% of
+      // the cap reads as 100 and would enforce against an org that is under.
+      const overHardLimit = usage.quotaLimit !== UNLIMITED && usage.totalUsed >= usage.quotaLimit
+
+      if (overHardLimit) {
         logger.warn('Organization over storage quota', {
           organizationId: org.id,
           name: org.name,
@@ -185,16 +241,20 @@ export async function storageQuotaCheckJob(
           // - Create system notification
           result.enforced++
         }
-      } else if (usage.percentUsed >= 80) {
-        // Warning threshold at 80%
+      } else if (warnAt !== null && usage.totalUsed >= warnAt) {
         logger.info('Organization approaching storage quota', {
           organizationId: org.id,
           name: org.name,
           percentUsed: usage.percentUsed,
+          totalUsed: usage.totalUsed,
+          softLimit: warnAt,
+          quotaLimit: usage.quotaLimit,
         })
 
         if (!dryRun) {
-          // TODO: Send warning notification
+          // TODO: Send warning notification. Crossing the soft limit is only
+          // logged today — there is still no user-facing signal between "fine"
+          // and the hard 403 at the upload gate.
           result.warnings++
         }
       }
@@ -214,6 +274,20 @@ export async function storageQuotaCheckJob(
 /**
  * Clean up files for organizations over quota
  * Prioritizes old, large, or unused files
+ *
+ * **Not wired up, and half-blind.** Two things to know before relying on it:
+ *
+ * 1. It is exported but never scheduled or enqueued — `apps/worker/src/workers/index.ts`
+ *    registers `orphanedFileCleanupJob`, `deletedFileCleanupJob` and
+ *    `storageQuotaCheckJob`, not this. `storageQuotaCheckJob`'s enforcement
+ *    branch is a `TODO` that increments a counter, so nothing calls this either.
+ * 2. It only considers `FolderFile` candidates, which is where essentially none
+ *    of the usage lives. `calculateStorageUsage` measures both lanes and
+ *    `MediaAsset` dominates (avatars, mail/comment attachments, custom-field
+ *    files, KB logos, dataset documents). Running it as written would free far
+ *    less than `targetSize` and report success anyway.
+ *
+ * Decide before scheduling it: teach it the `MediaAsset` lane, or delete it.
  */
 export async function quotaEnforcementCleanupJob(
   job: Job<{ organizationId: string; targetSize: number; dryRun?: boolean }>

--- a/packages/lib/src/files/types/entities.ts
+++ b/packages/lib/src/files/types/entities.ts
@@ -620,11 +620,23 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
         estimatedDuration: 2,
       },
     ],
+    // Mirrors `VisitQcItemProcessor` (upload/processors/visit-qc-processor.ts), which is the
+    // authority — this config is only the client-side pre-flight. HEIC/HEIF are accepted because
+    // the strip captures straight off an iPhone and does not run `convertHeicToJpeg` (which is
+    // Safari-only and hands back the original file everywhere else), so a `.heic` capture reaches
+    // the server as-is and the server takes it.
     validation: {
-      maxFileSize: 10 * 1024 * 1024, // 10MB
+      maxFileSize: 25 * 1024 * 1024, // 25MB — matches VisitQcItemProcessor.maxFileSize
       // SVG excluded — XSS vector when served from our origin.
-      allowedMimeTypes: ['image/jpeg', 'image/png', 'image/webp', 'image/gif'],
-      allowedExtensions: ['.jpg', '.jpeg', '.png', '.webp', '.gif'],
+      allowedMimeTypes: [
+        'image/jpeg',
+        'image/png',
+        'image/webp',
+        'image/gif',
+        'image/heic',
+        'image/heif',
+      ],
+      allowedExtensions: ['.jpg', '.jpeg', '.png', '.webp', '.gif', '.heic', '.heif'],
       scanForViruses: true,
       requireExtension: true,
       blockExecutables: true,

--- a/packages/lib/src/files/types/index.ts
+++ b/packages/lib/src/files/types/index.ts
@@ -83,12 +83,14 @@ export type {
   QueueConfig,
   QueuedFile,
   QueueStats,
+  ServerIdKind,
   StageStatus,
   UploadCallbacks,
   UploadFile,
   UploadMetrics,
   UploadProgress,
   UploadResult,
+  UploadResultMetadata,
   UploadStatus,
 } from './uploads'
 

--- a/packages/lib/src/files/types/uploads.ts
+++ b/packages/lib/src/files/types/uploads.ts
@@ -74,17 +74,50 @@ export interface UploadProgress {
 }
 
 /**
+ * Which kind of server record an upload actually produced.
+ *
+ * - `'asset'` — an attachment/asset processor created a `MediaAsset` (and usually an
+ *   `Attachment`); the reported id is a `MediaAsset` id.
+ * - `'file'` — `FileProcessor` created a `FolderFile`; there is no `MediaAsset`.
+ * - `'session'` — nothing usable came back, so the id still held is the upload-session
+ *   nanoid parked at session-create time. It is not a record id at all.
+ */
+export type ServerIdKind = 'asset' | 'file' | 'session'
+
+/**
+ * Structured metadata carried on an {@link UploadResult}.
+ *
+ * `assetId` and `fileId` are mutually exclusive and BOTH are optional: a `FolderFile`
+ * upload has no asset id, and a completion that returned neither has no record id at all.
+ * Reporting a non-asset id as `assetId` is what silently produced zero `visit_qc_item`
+ * attachments (`docs/files-upload-architecture-guide.md` §11.3), so consumers that need a
+ * real `MediaAsset` must read `assetId` and must handle its absence.
+ */
+export interface UploadResultMetadata {
+  /** `MediaAsset` id. Present ONLY when the server actually created a `MediaAsset`. */
+  assetId?: string
+  /** `FolderFile` id. Present ONLY when the server created a `FolderFile` instead. */
+  fileId?: string
+  /** Which of the two (if either) the completion produced. */
+  serverIdKind?: ServerIdKind
+  [key: string]: unknown
+}
+
+/**
  * Upload result for individual files
  */
 export interface UploadResult {
   success: boolean
+  /** Client-side upload id for this file — NOT a server record id. See `metadata`. */
   fileId?: string
   filename: string
   url?: string
   size?: number
+  /** Resolved MIME type, when the uploader knows it. */
+  mimeType?: string
   checksum?: string
   error?: string
-  metadata?: Record<string, any>
+  metadata?: UploadResultMetadata
 }
 
 /**

--- a/packages/lib/src/files/upload/processors/__tests__/post-commit-thumbnails.test.ts
+++ b/packages/lib/src/files/upload/processors/__tests__/post-commit-thumbnails.test.ts
@@ -1,0 +1,138 @@
+// packages/lib/src/files/upload/processors/__tests__/post-commit-thumbnails.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * `UserProfileProcessor.executeProcess` and `KnowledgeBaseProcessor.executeProcess`
+ * enqueued thumbnails under a comment claiming it happened "AFTER transaction
+ * commits". It did not — `executeProcess` runs inside the route's still-open
+ * `db.transaction`, and only a savepoint has been released by that point
+ * (`docs/files-upload-architecture-guide.md` §10.3, plan §1.3).
+ *
+ * `ensureThumbnailPresets` builds a `ThumbnailService` on the GLOBAL `db`, a
+ * different connection, so it cannot see the uncommitted rows: the first upload
+ * throws `Asset not found` (swallowed), and a RE-upload finds the asset with its
+ * PRE-transaction `currentVersionId` and returns `ready` against the OLD
+ * thumbnail — so `avatar-64/128/256` keep serving the previous image.
+ *
+ * The processors must therefore enqueue nothing; the route does it post-commit.
+ */
+
+const { ensureThumbnailPresets } = vi.hoisted(() => ({ ensureThumbnailPresets: vi.fn() }))
+
+vi.mock('../../../core/thumbnail-batch', () => ({ ensureThumbnailPresets }))
+
+vi.mock('@auxx/logger', () => ({
+  createScopedLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    with: vi.fn().mockReturnThis(),
+  }),
+}))
+
+vi.mock('@auxx/database', async () => ({
+  database: {
+    select: vi.fn(),
+    update: vi.fn(),
+    insert: vi.fn(),
+    query: {},
+  },
+  schema: (await import('../../../../test/database-mock')).createSchemaMock({
+    User: { id: 'id' },
+    KnowledgeBase: { id: 'id', organizationId: 'organizationId' },
+    MediaAsset: { id: 'id' },
+    MediaAssetVersion: { id: 'id' },
+  }),
+}))
+
+const { KnowledgeBaseProcessor, UserProfileProcessor } = await import('../entity-processors')
+
+const ORG_ID = 'org_cuid000000000000000000000'
+const USER_ID = 'usr_cuid000000000000000000000'
+const ASSET_ID = 'ast_cuid000000000000000000000'
+const STORAGE_LOCATION_ID = 'stl_cuid000000000000000000000'
+
+function uploadSession(overrides: Record<string, unknown> = {}) {
+  return {
+    version: 2,
+    id: 'sess_nanoid_000000000000',
+    organizationId: ORG_ID,
+    userId: USER_ID,
+    entityType: 'USER_PROFILE',
+    entityId: USER_ID,
+    fileName: 'avatar.png',
+    mimeType: 'image/png',
+    expectedSize: 1024,
+    provider: 'S3',
+    storageKey: 'org/avatar.png',
+    isMultipart: false,
+    uploadMethod: 'PUT',
+    status: 'uploading',
+    createdAt: new Date(),
+    expiresAt: new Date(Date.now() + 600_000),
+    ttlSec: 600,
+    metadata: {},
+    policy: {},
+    uploadPlan: { strategy: 'single' },
+    bucket: 'auxx-public',
+    visibility: 'PUBLIC',
+    ...overrides,
+  } as any
+}
+
+/**
+ * Stub the DB collaborators so `executeProcess` is exercised for exactly what it
+ * does after its savepoint is released.
+ */
+function stubDbCollaborators(processor: any) {
+  // Chainable enough for `KnowledgeBaseProcessor`'s in-transaction logo update.
+  const tx: any = {}
+  tx.update = vi.fn(() => tx)
+  tx.set = vi.fn(() => tx)
+  tx.where = vi.fn(async () => [])
+
+  processor.mediaAssetService = { getTx: async (fn: (tx: any) => Promise<any>) => fn(tx) }
+  processor.findExistingAsset = vi.fn(async () => null)
+  processor.createAsset = vi.fn(async () => ({
+    assetId: ASSET_ID,
+    externalUrl: 'https://cdn.example/avatar.png',
+  }))
+  processor.createNewVersion = vi.fn(async () => ({
+    assetId: ASSET_ID,
+    externalUrl: 'https://cdn.example/avatar.png',
+  }))
+  processor.updateUserAvatar = vi.fn(async () => {})
+  processor.createAttachment = vi.fn(async () => {})
+  return processor
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('entity processors do not enqueue thumbnails inside the open transaction', () => {
+  it('UserProfileProcessor.executeProcess enqueues no avatar presets', async () => {
+    const processor = stubDbCollaborators(new UserProfileProcessor(ORG_ID))
+
+    const result = await processor.executeProcess(uploadSession(), STORAGE_LOCATION_ID)
+
+    expect(result).toEqual({ assetId: ASSET_ID, storageLocationId: STORAGE_LOCATION_ID })
+    expect(ensureThumbnailPresets).not.toHaveBeenCalled()
+  })
+
+  it('UserProfileProcessor exposes no private thumbnail helper any more', () => {
+    expect((new UserProfileProcessor(ORG_ID) as any).generateAvatarThumbnails).toBeUndefined()
+  })
+
+  it('KnowledgeBaseProcessor.executeProcess enqueues no KB logo presets', async () => {
+    const processor = stubDbCollaborators(new KnowledgeBaseProcessor(ORG_ID))
+
+    const result = await processor.executeProcess(
+      uploadSession({ entityType: 'KNOWLEDGE_BASE', entityId: 'kb_cuid00000000000000000000' }),
+      STORAGE_LOCATION_ID
+    )
+
+    expect(result).toEqual({ assetId: ASSET_ID, storageLocationId: STORAGE_LOCATION_ID })
+    expect(ensureThumbnailPresets).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/files/upload/processors/entity-processors.ts
+++ b/packages/lib/src/files/upload/processors/entity-processors.ts
@@ -5,8 +5,6 @@ import { and, desc, eq, isNull } from 'drizzle-orm'
 import { getOrgCache, isAgentUser, onCacheEvent } from '../../../cache'
 import { isMember } from '../../../members'
 import { isAdminOrOwner } from '../../../members/member-queries'
-import { ensureThumbnailPresets } from '../../core/thumbnail-batch'
-import type { ThumbnailSource } from '../../core/thumbnail-types'
 import type { AssetKind } from '../../core/types'
 import { type FileTypeCategory, getMimePatternsForCategories } from '../../file-type-constants'
 import type { ProcessorConfigResult, UploadInitConfig } from '../init-types'
@@ -48,17 +46,11 @@ export class UserProfileProcessor extends BaseAssetProcessor {
         storageLocationId,
       }
     })
-    // Generate thumbnails AFTER transaction commits
-    try {
-      await this.generateAvatarThumbnails(session, result.assetId)
-    } catch (error) {
-      // Log error but don't fail the upload
-      this.logger.error('Failed to generate avatar thumbnails', {
-        assetId: result.assetId,
-        userId: session.userId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      })
-    }
+    // Thumbnails are NOT enqueued here. `executeProcess` runs inside the route's
+    // open `db.transaction` (only a savepoint has been released), and the
+    // enqueue resolves the asset on the global `db` — a different connection
+    // that reads the PRE-transaction `currentVersionId`. The route enqueues the
+    // avatar presets in Phase 3, after COMMIT.
     return result
   }
   /**
@@ -199,34 +191,6 @@ export class UserProfileProcessor extends BaseAssetProcessor {
       userId,
       assetId,
       originalUrl,
-    })
-  }
-  /**
-   * Generate multiple thumbnail sizes for user avatar
-   * All thumbnails are queued for async processing
-   */
-  private async generateAvatarThumbnails(
-    session: PresignedUploadSession,
-    assetId: string
-  ): Promise<void> {
-    this.logger.info('Queueing avatar thumbnails for background processing', {
-      assetId,
-      organizationId: session.organizationId,
-      userId: session.userId,
-    })
-    const source: ThumbnailSource = { type: 'asset', assetId }
-    const results = await ensureThumbnailPresets({
-      organizationId: session.organizationId,
-      userId: session.userId,
-      source,
-      presets: ['avatar-32', 'avatar-64', 'avatar-128', 'avatar-256'],
-      defaultOptions: { queue: true, visibility: 'PUBLIC' },
-      perPreset: { 'avatar-64': { updateUser: true } },
-    })
-    this.logger.info('Avatar thumbnails queued for background processing', {
-      userId: session.userId,
-      assetId,
-      queuedJobs: results.map((r) => (r.status === 'queued' ? r.jobId : 'already-exists')),
     })
   }
 }
@@ -598,7 +562,11 @@ export class KnowledgeBaseProcessor extends BaseAttachmentProcessor {
     }
   }
   /**
-   * Override to ensure thumbnails are enqueued only after DB commit
+   * Create the asset, its attachment and the KB logo pointer in one transaction.
+   *
+   * The `kb-logo-sm`/`kb-logo-lg` presets are NOT enqueued here — see the note
+   * on `UserProfileProcessor.executeProcess`. The route enqueues them in Phase 3,
+   * after COMMIT.
    */
   protected async executeProcess(
     session: PresignedUploadSession,
@@ -625,22 +593,6 @@ export class KnowledgeBaseProcessor extends BaseAttachmentProcessor {
       }
       return { assetId, storageLocationId }
     })
-    // After commit, enqueue KB logo thumbnails
-    try {
-      const source: ThumbnailSource = { type: 'asset', assetId: result.assetId }
-      await ensureThumbnailPresets({
-        organizationId: session.organizationId,
-        userId: session.userId,
-        source,
-        presets: ['kb-logo-sm', 'kb-logo-lg'],
-        defaultOptions: { queue: true, visibility: 'PUBLIC' },
-      })
-    } catch (error) {
-      this.logger.error('Failed to enqueue KB logo thumbnails', {
-        assetId: result.assetId,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      })
-    }
     return result
   }
 }

--- a/packages/lib/src/jobs/maintenance/__tests__/storage-cleanup-job.test.ts
+++ b/packages/lib/src/jobs/maintenance/__tests__/storage-cleanup-job.test.ts
@@ -1,0 +1,174 @@
+// packages/lib/src/jobs/maintenance/__tests__/storage-cleanup-job.test.ts
+
+/**
+ * Regression test for `docs/files-upload-architecture-guide.md` §11.2.
+ *
+ * `deleteMarkedStorageLocations` called `deleteByKey({ provider, key })` with no
+ * bucket, so every sweep aimed at the provider default (private) bucket. S3
+ * answers 204 for a key that is not there, so a PUBLIC-bucket object was
+ * reported as deleted while the real object leaked — silently, and forever.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({ db: null as any }))
+
+// Partial mock: `@auxx/logger/run-log` imports sink-registration helpers from this
+// barrel at module load, so a full replacement breaks whichever test file happens
+// to load it first.
+vi.mock('@auxx/logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/logger')>()),
+  createScopedLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('@auxx/database', async () => {
+  const { createSchemaMock } = await import('../../../test/database-mock')
+  return {
+    database: {
+      select: (...args: unknown[]) => h.db.select(...args),
+      delete: (...args: unknown[]) => h.db.delete(...args),
+      execute: (...args: unknown[]) => h.db.execute(...args),
+    },
+    schema: createSchemaMock(),
+    IntegrationProviderTypeValues: ['google', 'outlook'],
+  }
+})
+
+vi.mock('@auxx/redis', () => ({ getRedisClient: vi.fn(async () => null) }))
+
+vi.mock('../../../email/polling-import-cache', () => ({ clearImportCache: vi.fn() }))
+
+const purgeMediaAssets = vi.fn(async () => [] as string[])
+vi.mock('../../../files/core/media-asset-purge', () => ({
+  purgeMediaAssets: (...args: unknown[]) => purgeMediaAssets(...(args as [])),
+}))
+
+const mockDeleteByKey = vi.fn().mockResolvedValue(undefined)
+vi.mock('../../../files/storage/storage-manager', () => ({
+  StorageManager: class {
+    deleteByKey = mockDeleteByKey
+  },
+}))
+
+import type { JobContext } from '../../types'
+import { type StorageCleanupJobData, storageCleanupJob } from '../storage-cleanup-job'
+
+type MarkedLocation = {
+  id: string
+  provider: string
+  externalId: string
+  metadata?: Record<string, unknown> | null
+}
+
+/**
+ * Drizzle-shaped stub. The sweep issues exactly one shape of read —
+ * `select(projection).from(StorageLocation).where(...).limit(n)` — so the stub
+ * records the projection (that is where the missing `metadata` column shows up)
+ * and hands back one batch, then drains.
+ */
+function createFakeDb(batches: MarkedLocation[][]) {
+  const projections: Record<string, unknown>[] = []
+  let next = 0
+
+  return {
+    projections,
+    db: {
+      execute: vi.fn(async () => ({ rows: [] })),
+      select: (projection: Record<string, unknown>) => {
+        projections.push(projection)
+        const rows = batches[next++] ?? []
+        // Only the columns the caller actually projected come back from PG.
+        const shaped = rows.map((row) =>
+          Object.fromEntries(
+            Object.keys(projection).map((key) => [key, (row as Record<string, unknown>)[key]])
+          )
+        )
+        const chain: any = {
+          from: () => chain,
+          where: () => chain,
+          limit: async () => shaped,
+        }
+        return chain
+      },
+      delete: () => ({ where: async () => undefined }),
+    },
+  }
+}
+
+function ctx(data: StorageCleanupJobData): JobContext<StorageCleanupJobData> {
+  return {
+    job: { data },
+    data,
+    jobId: 'job-1',
+    updateProgress: vi.fn(),
+  } as unknown as JobContext<StorageCleanupJobData>
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.db = null
+})
+
+describe('storageCleanupJob → deleteMarkedStorageLocations', () => {
+  it('deletes from the bucket recorded on the StorageLocation, not the provider default', async () => {
+    const fake = createFakeDb([
+      [
+        {
+          id: 'loc-public',
+          provider: 'S3',
+          externalId: 'org123/avatars/a.png',
+          metadata: { bucket: 'test-public-bucket', key: 'org123/avatars/a.png' },
+        },
+      ],
+    ])
+    h.db = fake.db
+
+    const result = await storageCleanupJob(ctx({ type: 'organization', organizationId: 'org123' }))
+
+    expect(mockDeleteByKey).toHaveBeenCalledTimes(1)
+    expect(mockDeleteByKey).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'S3',
+        key: 'org123/avatars/a.png',
+        bucket: 'test-public-bucket',
+      })
+    )
+    expect(result.s3ObjectsDeleted).toBe(1)
+    expect(result.storageLocationsDeleted).toBe(1)
+  })
+
+  it('selects the metadata column so the bucket is available at all', async () => {
+    const fake = createFakeDb([[]])
+    h.db = fake.db
+
+    await storageCleanupJob(ctx({ type: 'organization', organizationId: 'org123' }))
+
+    expect(fake.projections[0]).toBeDefined()
+    expect(Object.keys(fake.projections[0]!)).toContain('metadata')
+  })
+
+  it('leaves the bucket undefined for a row that has none rather than inventing one', async () => {
+    const fake = createFakeDb([
+      [
+        {
+          id: 'loc-legacy',
+          provider: 'S3',
+          externalId: 'org123/legacy.bin',
+          metadata: {},
+        },
+      ],
+    ])
+    h.db = fake.db
+
+    await storageCleanupJob(ctx({ type: 'organization', organizationId: 'org123' }))
+
+    expect(mockDeleteByKey).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'org123/legacy.bin', bucket: undefined })
+    )
+  })
+})

--- a/packages/lib/src/jobs/maintenance/storage-cleanup-job.ts
+++ b/packages/lib/src/jobs/maintenance/storage-cleanup-job.ts
@@ -13,6 +13,24 @@ const logger = createScopedLogger('storage-cleanup-job')
 
 const S3_BATCH_DELETE_LIMIT = 1000
 
+/**
+ * The bucket an object actually lives in, as recorded on its `StorageLocation`.
+ *
+ * `StorageManager.prepareLocationMetadata` stamps `metadata.bucket` on every S3
+ * location it writes, so this is the only trustworthy source for a sweep — the
+ * provider default is the PRIVATE bucket, and a delete aimed there for a PUBLIC
+ * object 204s on the missing key while the real object leaks.
+ *
+ * Returns `undefined` for rows written outside `StorageManager` (see
+ * `users/user-avatar-service.ts`) or before the bucket was persisted. Guessing
+ * one would be worse than the fallback: `deleteByKey` then warns loudly, and the
+ * adapter throws rather than silently deleting nothing.
+ */
+function bucketOf(metadata: unknown): string | undefined {
+  const bucket = (metadata as { bucket?: unknown } | null | undefined)?.bucket
+  return typeof bucket === 'string' && bucket.length > 0 ? bucket : undefined
+}
+
 export interface StorageCleanupJobData {
   type: 'integration' | 'organization'
   organizationId: string
@@ -220,6 +238,7 @@ async function deleteMarkedStorageLocations(
         id: schema.StorageLocation.id,
         provider: schema.StorageLocation.provider,
         externalId: schema.StorageLocation.externalId,
+        metadata: schema.StorageLocation.metadata,
       })
       .from(schema.StorageLocation)
       .where(
@@ -250,6 +269,7 @@ async function deleteMarkedStorageLocations(
           await storageManager.deleteByKey({
             provider: provider as any,
             key: loc.externalId,
+            bucket: bucketOf(loc.metadata),
           })
           result.s3ObjectsDeleted++
         } catch (error) {


### PR DESCRIPTION
Second and final half of the Tier-1 upload correctness work. #1816 fixed the storage layer; this fixes the routes on top of it. Six commits, one per concern.

## The two that matter most

**`complete`, `parts` and `events` had no authentication at all.** None of them called `auth.api.getSession`. The session nanoid was the only credential, so anyone holding one could complete someone else's upload, mint presigned `UploadPart` URLs for arbitrary part numbers, or read upload status.

`authorizeUploadSession` now resolves the caller and asserts both `session.userId` and `session.organizationId` match. Authentication runs **before** Redis is touched, so an unauthenticated caller gets 401 whether or not the id exists and can't use the 404-vs-403 split as an existence oracle. It also means authorization is re-evaluated at completion time — previously it was decided once at session-create and never rechecked, so a permission revoked mid-upload still completed.

**Thumbnails were enqueued inside the open transaction, against a connection that couldn't see the rows.** `UserProfileProcessor` and `KnowledgeBaseProcessor` did this under a comment claiming they ran after commit. They didn't — only a savepoint had been released — and the enqueue resolved its source asset on the global `db`.

So a first avatar upload threw `Asset not found`, swallowed by the processor's own try/catch, wasting all four presets. **A re-upload was worse:** the asset row existed but `currentVersionId` still read as the old value, so the preset lookup found the previous thumbnail, returned `ready`, and `avatar-64/128/256` kept serving the **previous image indefinitely**. Both processors now enqueue nothing; Phase 3 of the route owns it, after `COMMIT`.

## The rest

- **Bucket** passed at the three remaining call sites — multipart parts (the `NoSuchUpload` fix), multipart completion, and the compensation delete (the public-bucket silent-leak fix). Compensation now calls `enqueueOrphanedStorageObjectCleanup` directly, leaving the deprecated `cleanupService` shim with zero callers.
- **`AuxxError` → real status.** `getForEntityType` throws `BadRequestError` since #1816, but App Router handlers have no `auxxErrorMiddleware`, so it was landing as a generic 500. Both routes now guard with `isAuxxError` and answer `e.statusCode`.
- **Quota measured against the real plan limit.** `quotaLimit` was the hard-coded 50 GB, so with #1816's real byte counts a Free org at 2 GB (over its real 1 GB) read as fine. Also fixed a rounding bug: the over-quota branch compared `percentUsed >= 100`, and that value is rounded, so 99.6% of the cap read as 100 and would have enforced against an org that was **under**.
- **The second sweep job had #1817's leak.** `storage-cleanup-job` selected no `metadata` column and called `deleteByKey` with no bucket, so PUBLIC objects were counted as swept and their rows deleted while the object stayed.
- **The client can no longer report a non-asset id as an `assetId`.** It emitted `assetId: f.serverFileId || f.id` unconditionally; `toUploadResult` now gates on the recorded kind. `qc-photo-strip.tsx` gains the missing `else` branch — a successful upload with no usable id previously matched neither arm and vanished silently, which is exactly how the `visit_qc_item` bug hid.

## One thing outside the subject

The last commit repairs `file-download-permission.test.ts`, which was **red on main** and blocking CI. Two fixture gaps meant its four happy-path cases had never actually run: the `request()` stub had no `nextUrl` (so `shouldRenderInline` threw into the outer catch and every case answered 500), and the mocked `createFileDownloadResponse` returned only `Content-Type`, so the header assertions were testing the literal rather than the route. One file, no product change — say the word if you'd rather it were split out.

## Verification

`packages/lib` `src/files` + `src/jobs/maintenance`: **163 green**. `apps/web` `file-upload` + `api/files` + `file-select` + `schedule`: **66 green**. `tsc --noEmit` clean for every touched file in both packages.

## Follow-ups found, deliberately not fixed here

- **`user-avatar-service.ts` looks like it puts public avatars in the private bucket.** It calls `putObject` with neither `bucket` nor `visibility`, so it falls back to `S3_PRIVATE_BUCKET` — and `USER_PROFILE` is a PUBLIC entity type. It also inserts `StorageLocation` directly, bypassing `StorageManager`, so its rows carry no `metadata.bucket` and are undeletable by key. Worth its own look.
- `StorageLocationService.create()/bulkCreate()` are a second write door that bypasses bucket normalisation.
- **There is still no warning tier.** `storageGbSoft` is now read as a warn threshold, but the branch only increments a counter behind a `TODO` — no email, notification or banner, and no dedup marker for a daily job. Orgs go from no signal straight to the hard 403.
- Pre-existing `StorageLocation` rows without `metadata.bucket` will now log a bucket-fallback warning instead of silently 204-ing. Correct, but a one-off backfill would clear the noise.