### PR TITLE
refactor(files): the FilesCtx contract, plus two pilots proving it

### DIFF
--- a/docs/files-upload-architecture-guide.md
+++ b/docs/files-upload-architecture-guide.md
@@ -51,7 +51,7 @@ BROWSER                         apps/web (Node)                    S3           
    │
    │ 1. POST /api/files/upload/sessions
    │──────────────────────────────────▶ auth + files.manage gate
-   │                                    storage quota gate  ────────────────────────▶ (always 0 — §11.1)
+   │                                    storage quota gate  ────────────────────────▶ real bytes (§11.1, fixed)
    │                                    ProcessorRegistry.getForEntityType(entityType)
    │                                    processor.processConfig(init)
    │                                      → storageKey, policy, uploadPlan,
@@ -68,18 +68,19 @@ BROWSER                         apps/web (Node)                    S3           
    │    then N × PUT — serial, one round-trip to us per part)
    │
    │ 3. POST /api/files/upload/{sessionId}/complete
-   │──────────────────────────────────▶ NO AUTH CHECK (§11.4)
+   │──────────────────────────────────▶ authorizeUploadSession (§11.4, fixed)
    │                                    completeMultipartUpload (if multipart)
    │                                    headByKey  ──────────────▶ verify size/mime
    │                                    processor.validateCompletedUpload
    │                                    ┌── db.transaction ──────────────────────┐
-   │                                    │  buildExternalUrl (I/O, §10.2)         │
+   │                                    │  buildExternalUrl (I/O — §10.2, OPEN)  │
    │                                    │  createStorageLocation                 │
-   │                                    │  processor.process → savepoints (§10.1)│
+   │                                    │  processor.process → savepoints (§10.1,│
+   │                                    │                             still OPEN) │
    │                                    │    → MediaAsset + MediaAssetVersion    │
    │                                    │      and/or FolderFile + FileVersion   │
    │                                    │      and/or Attachment                 │
-   │                                    │    → sometimes BullMQ enqueue (§10.3)  │
+   │                                    │    (BullMQ enqueue moved out — §10.3)  │
    │                                    └────────────────────────────────────────┘
    │                                    post-commit: cache busts, thumbnail
    │                                                 enqueue, download URL
@@ -423,6 +424,20 @@ registry factory — but it is a landmine the moment anyone caches a processor.
 `session.credentialId` is set, calls `getProviderAuth` → credential decryption. Whatever latency
 that has is latency the Postgres connection is held open for, on the hottest write path in the
 subsystem. Its result is only a string built from config; it has no reason to be there.
+
+**There is a second credential fetch in the same transaction, and it is worse.** Found during the
+Phase-2 write pilot, not the original survey: `createStorageLocation` →
+`prepareLocationMetadata` (storage-manager.ts:~999) → `resolveS3BucketForLocation` →
+`getProviderAuth` → **`revealSecrets(credentialId, orgId)`** — a database read *plus* a decrypt,
+wrapped in a `try/catch` that swallows failure into a `logger.warn`. It exists solely to **guess a
+bucket** when the caller did not supply one.
+
+So the completion transaction holds its connection open across two independent credential
+resolutions, one of which is a fallback for information the caller already had. Requiring `bucket`
+on the input **deletes** that path rather than moving it — which is what
+`files/storage/locations.ts` does. The pure remainder is: merge caller metadata, write `bucket`
+last (so an inherited `metadata.bucket` cannot beat the bucket actually uploaded to), default `key`
+from `externalId`.
 
 ### 10.3 ~~BullMQ jobs enqueued inside the transaction — and they read stale data~~ — FIXED (#1818)
 

--- a/docs/lib-module-guide.md
+++ b/docs/lib-module-guide.md
@@ -160,6 +160,22 @@ export async function grantSequenceCreatorAccess(
 ): Promise<void>
 ```
 
+### `files/` diverges: `ctx: FilesCtx` first, not `db`
+
+`packages/lib/src/files/**` deliberately does **not** use the `db`-first
+positional style above. Db-touching exports take `ctx: FilesCtx`
+(`{ db, organizationId, userId }`) first, because nearly every function there
+needs all three *plus* a bundle of injected collaborators (`FilesDeps`:
+`storage`, `queue`, `cache`, `now`) that `snippets/`/`sequences/`/`dashboards/`
+have no equivalent of — as positionals that is five arguments before the real
+input. Transaction-only functions still take `tx: Transaction` positionally
+first, separate from `ctx`, so a pool cannot typecheck into the slot. A function
+that needs only some collaborators takes a `Pick<FilesDeps, …>` rather than the
+whole bundle, so its signature still states what it cannot do
+(`getAssetDownloadRef` in `files/assets/download.ts` is the worked example).
+This is a scoped exception, not a repo-wide convention change. See
+`packages/lib/src/files/ctx.ts` and `plans/attachments/02-target-module-shape.md` §2.1.
+
 ---
 
 ## 5. File layout

--- a/packages/lib/src/files/__tests__/support-kit.test.ts
+++ b/packages/lib/src/files/__tests__/support-kit.test.ts
@@ -1,0 +1,217 @@
+// packages/lib/src/files/__tests__/support-kit.test.ts
+
+/**
+ * Proves the `files/` support kit works — and, more importantly, proves the
+ * property the whole refactor is for: **this file calls `vi.mock` zero times.**
+ *
+ * The two functions under test are written to the `ctx.ts` contract but live
+ * here rather than in `src/`, because the contract is what is being tested, not
+ * any particular piece of production behaviour.
+ */
+
+import type { Database, Transaction } from '@auxx/database'
+import { schema } from '@auxx/database'
+import type { MediaAssetEntity } from '@auxx/database/types'
+import { and, eq } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import { describe, expect, it } from 'vitest'
+import type { AuxxError } from '../../errors'
+import { NotFoundError } from '../../errors'
+import type { FilesCtx, FilesDeps } from '../ctx'
+import { guard } from '../guard'
+import {
+  anAsset,
+  makeCachePort,
+  makeClock,
+  makeCtx,
+  makeDb,
+  makeDeps,
+  makeJournal,
+  makeQueuePort,
+  makeStoragePort,
+  TEST_BUCKETS,
+  TEST_IDS,
+} from './support'
+
+// ============= Functions written to the ctx.ts contract =============
+
+/**
+ * Signature shape 2 — database-touching, plus collaborators.
+ *
+ * Reads an asset, renders its public URL, and records the read downstream. Note
+ * it never opens a transaction: `ctx.db` may already be one.
+ */
+async function describeDemoAsset(
+  ctx: FilesCtx,
+  deps: FilesDeps,
+  input: { assetId: string; bucket: string }
+): Promise<Result<{ url: string; seenAt: Date }, AuxxError>> {
+  return guard(
+    async () => {
+      const asset = (await ctx.db.query.MediaAsset.findFirst({
+        where: and(
+          eq(schema.MediaAsset.id, input.assetId),
+          eq(schema.MediaAsset.organizationId, ctx.organizationId)
+        ),
+      })) as MediaAssetEntity | undefined
+
+      if (!asset) throw new NotFoundError(`Asset ${input.assetId} not found`)
+
+      const url = deps.storage.buildExternalUrl({
+        provider: 'S3',
+        bucket: input.bucket,
+        key: asset.name ?? asset.id,
+      })
+
+      await deps.cache.bust('files:asset.viewed', { assetId: asset.id })
+
+      return { url, seenAt: deps.now() }
+    },
+    'Failed to describe demo asset',
+    { assetId: input.assetId }
+  )
+}
+
+/**
+ * Signature shape 3 — transaction-only. `tx` is positional and first, so a pool
+ * cannot be handed to it.
+ */
+async function markDemoAssetArchived(
+  tx: Transaction,
+  ctx: FilesCtx,
+  input: { assetId: string; at: Date }
+): Promise<void> {
+  await tx
+    .update(schema.MediaAsset)
+    .set({ deletedAt: input.at, updatedAt: input.at })
+    .where(
+      and(
+        eq(schema.MediaAsset.id, input.assetId),
+        eq(schema.MediaAsset.organizationId, ctx.organizationId)
+      )
+    )
+}
+
+// ============= Tests =============
+
+describe('files test-support kit', () => {
+  it('drives a ctx + deps function with plain objects and records every call', async () => {
+    const journal = makeJournal()
+    const db = makeDb({
+      query: { MediaAsset: [anAsset({ name: 'photo.png' })] },
+      tables: { MediaAsset: schema.MediaAsset },
+      journal,
+    })
+    const storage = makeStoragePort({
+      journal,
+      results: { buildExternalUrl: 'https://cdn.test/photo.png' },
+    })
+    const cache = makeCachePort({ journal })
+    const clock = makeClock('2026-03-04T05:06:07.000Z')
+
+    const ctx = makeCtx({ db: db.db })
+    const deps = makeDeps({ storage: storage.port, cache: cache.port, now: clock.now })
+
+    const result = await describeDemoAsset(ctx, deps, {
+      assetId: TEST_IDS.assetId,
+      bucket: TEST_BUCKETS.public,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toEqual({
+      url: 'https://cdn.test/photo.png',
+      seenAt: new Date('2026-03-04T05:06:07.000Z'),
+    })
+
+    // The port double recorded the bucket it was given — the assertion that
+    // #1816/#1817/#1818 were invisible without.
+    expect(storage.callsTo('buildExternalUrl')[0]?.params).toEqual({
+      provider: 'S3',
+      bucket: TEST_BUCKETS.public,
+      key: 'photo.png',
+    })
+    expect(cache.events()).toEqual(['files:asset.viewed'])
+    expect(journal.ops()).toEqual(['query.findFirst', 'buildExternalUrl', 'bust'])
+  })
+
+  it('converts a thrown AuxxError into an err() through guard', async () => {
+    const ctx = makeCtx({ db: makeDb({ query: { MediaAsset: [] } }).db })
+
+    const result = await describeDemoAsset(ctx, makeDeps(), {
+      assetId: 'ast_missing',
+      bucket: TEST_BUCKETS.private,
+    })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+    expect(result._unsafeUnwrapErr().message).toBe('Asset ast_missing not found')
+  })
+
+  it('interleaves db statements and port calls so BEGIN..COMMIT can be asserted', async () => {
+    const journal = makeJournal()
+    const db = makeDb({ tables: { MediaAsset: schema.MediaAsset }, journal })
+    const queue = makeQueuePort({ journal, jobIds: ['job_cleanup'] })
+    const cache = makeCachePort({ journal })
+    const clock = makeClock()
+
+    const ctx = makeCtx({ db: db.db })
+
+    // The caller owns the transaction; lib functions never open one, because
+    // `ctx.db` may already be inside one.
+    await (db.db as Database).transaction(async (tx) => {
+      await markDemoAssetArchived(
+        tx,
+        { ...ctx, db: tx },
+        {
+          assetId: TEST_IDS.assetId,
+          at: clock.now(),
+        }
+      )
+    })
+
+    // Side effects strictly after COMMIT.
+    const jobId = await queue.port.enqueueStorageCleanup({
+      provider: 'S3',
+      bucket: TEST_BUCKETS.private,
+      key: 'photo.png',
+      reason: 'asset archived',
+    })
+    await cache.port.bust('files:asset.archived', { assetId: TEST_IDS.assetId })
+
+    expect(jobId).toBe('job_cleanup')
+    expect(journal.ops()).toEqual(['begin', 'update', 'commit', 'enqueueStorageCleanup', 'bust'])
+
+    // The Phase 6 assertion, in one line: nothing but SQL inside the transaction.
+    expect(journal.between('begin', 'commit').every((e) => e.channel === 'db')).toBe(true)
+
+    // `tableName` resolved the real name despite Drizzle tables being `{}` under Vitest.
+    expect(db.updates).toEqual([
+      {
+        table: 'MediaAsset',
+        values: { deletedAt: clock.now(), updatedAt: clock.now() },
+      },
+    ])
+    expect(db.transactions).toBe(1)
+  })
+
+  it('records a rollback when the transaction body throws', async () => {
+    const journal = makeJournal()
+    const db = makeDb({ journal })
+
+    await expect(
+      (db.db as Database).transaction(async () => {
+        throw new NotFoundError('boom')
+      })
+    ).rejects.toThrow('boom')
+
+    expect(journal.ops('db')).toEqual(['begin', 'rollback'])
+  })
+
+  it('gives a deterministic, advanceable clock without fake timers', () => {
+    const clock = makeClock('2026-01-01T00:00:00.000Z')
+    expect(clock.now().toISOString()).toBe('2026-01-01T00:00:00.000Z')
+    clock.advance(90_000)
+    expect(clock.now().toISOString()).toBe('2026-01-01T00:01:30.000Z')
+    expect(clock.millis()).toBe(new Date('2026-01-01T00:01:30.000Z').getTime())
+  })
+})

--- a/packages/lib/src/files/__tests__/support/cache.ts
+++ b/packages/lib/src/files/__tests__/support/cache.ts
@@ -1,0 +1,57 @@
+// packages/lib/src/files/__tests__/support/cache.ts
+
+/**
+ * A recording {@link CachePort} double.
+ *
+ * The assertion this exists for is a timing one: caches must be busted *after*
+ * the transaction commits, never inside it, because a mid-transaction
+ * invalidation repopulates from a snapshot the commit has not reached yet.
+ * Sharing a {@link Journal} with `makeDb` turns that into a one-line check.
+ */
+
+import type { CachePort } from '../../storage/ports'
+import type { Journal } from './db'
+import { makeJournal } from './db'
+
+/** One recorded bust, in journal order. */
+export interface CacheBust {
+  event: string
+  payload: Record<string, unknown>
+}
+
+export interface MakeCachePortOptions {
+  /** Share ordering with `makeDb` and the other doubles. */
+  journal?: Journal
+  /** Full override, for tests that need a bust to throw. */
+  impl?: Partial<CachePort>
+}
+
+export interface FakeCachePort {
+  /** Pass this as `FilesDeps.cache`. */
+  port: CachePort
+  busts: CacheBust[]
+  journal: Journal
+  /** The event names that were busted, in order. */
+  events(): string[]
+}
+
+/** Build a cache double that records every bust and does nothing else. */
+export function makeCachePort(options: MakeCachePortOptions = {}): FakeCachePort {
+  const journal = options.journal ?? makeJournal()
+  const busts: CacheBust[] = []
+
+  const port: CachePort = {
+    bust: async (event, payload) => {
+      journal.record('cache', 'bust', { event, payload })
+      busts.push({ event, payload })
+      await options.impl?.bust?.(event, payload)
+    },
+  }
+
+  return {
+    port,
+    busts,
+    journal,
+    events: () => busts.map((b) => b.event),
+  }
+}

--- a/packages/lib/src/files/__tests__/support/clock.ts
+++ b/packages/lib/src/files/__tests__/support/clock.ts
@@ -1,0 +1,48 @@
+// packages/lib/src/files/__tests__/support/clock.ts
+
+/**
+ * A deterministic `() => Date` for {@link FilesDeps.now}.
+ *
+ * `deriveStorageKey` puts `Date.now()` straight into the storage key and every
+ * `expiresAt` is computed from it, so asserting on either meant `vi.useFakeTimers()`
+ * — which is process-global and leaks into anything else the test touches. A
+ * clock passed as a parameter has neither problem, and `advance` lets a test
+ * step across a TTL boundary explicitly instead of sleeping.
+ */
+
+/** The default instant, chosen to be obviously fake in a failure diff. */
+export const DEFAULT_TEST_INSTANT = '2026-01-01T00:00:00.000Z'
+
+export interface FakeClock {
+  /** Pass this as `FilesDeps.now`. Returns a fresh `Date` each call, never a shared one. */
+  now: () => Date
+  /** Move the clock forward (or back, with a negative value) by milliseconds. */
+  advance(ms: number): void
+  /** Jump to an absolute instant. */
+  set(iso: string): void
+  /** The current instant in milliseconds, for building expected values. */
+  millis(): number
+}
+
+/** Build a clock frozen at `iso` until a test advances it. */
+export function makeClock(iso: string = DEFAULT_TEST_INSTANT): FakeClock {
+  let millis = new Date(iso).getTime()
+  if (Number.isNaN(millis)) {
+    throw new Error(`makeClock received an unparseable instant: ${iso}`)
+  }
+
+  return {
+    now: () => new Date(millis),
+    advance: (ms) => {
+      millis += ms
+    },
+    set: (next) => {
+      const parsed = new Date(next).getTime()
+      if (Number.isNaN(parsed)) {
+        throw new Error(`makeClock().set received an unparseable instant: ${next}`)
+      }
+      millis = parsed
+    },
+    millis: () => millis,
+  }
+}

--- a/packages/lib/src/files/__tests__/support/ctx.ts
+++ b/packages/lib/src/files/__tests__/support/ctx.ts
@@ -1,0 +1,62 @@
+// packages/lib/src/files/__tests__/support/ctx.ts
+
+/**
+ * Builders for the two ambient objects every `files/` function takes.
+ *
+ * These exist so the first line of a test is the scenario, not thirty lines of
+ * scaffolding. Both take overrides and build working defaults, so a test that
+ * only cares about one collaborator passes only that one:
+ *
+ * ```ts
+ * const journal = makeJournal()
+ * const db = makeDb({ query: { MediaAsset: [anAsset()] }, journal })
+ * const storage = makeStoragePort({ journal })
+ *
+ * const ctx = makeCtx({ db: db.db })
+ * const deps = makeDeps({ storage: storage.port })
+ * ```
+ *
+ * The journal is threaded explicitly rather than hidden inside a bundle: which
+ * doubles share ordering is exactly what a Phase-6 ordering assertion depends
+ * on, so it should be visible in the test.
+ */
+
+import type { FilesCtx, FilesDeps } from '../../ctx'
+import { makeCachePort } from './cache'
+import { makeClock } from './clock'
+import { makeDb } from './db'
+import { TEST_IDS } from './fixtures'
+import { makeQueuePort } from './queue'
+import { makeStoragePort } from './storage'
+
+/**
+ * A `FilesCtx` whose `db` is an empty recording stub unless one is supplied.
+ *
+ * The default `db` answers every read with "no rows", which is the correct
+ * default for a test that is not exercising a read — it fails loudly rather
+ * than returning a fixture nobody asked for.
+ */
+export function makeCtx(overrides: Partial<FilesCtx> = {}): FilesCtx {
+  return {
+    db: makeDb().db,
+    organizationId: TEST_IDS.organizationId,
+    ...overrides,
+  }
+}
+
+/**
+ * A `FilesDeps` with recording doubles and a frozen clock.
+ *
+ * Supply the fakes you intend to assert on (`makeStoragePort().port`, …) so you
+ * keep a handle on their recorders; the ones you omit are inert doubles that
+ * simply record and return benign values.
+ */
+export function makeDeps(overrides: Partial<FilesDeps> = {}): FilesDeps {
+  return {
+    storage: makeStoragePort().port,
+    queue: makeQueuePort().port,
+    cache: makeCachePort().port,
+    now: makeClock().now,
+    ...overrides,
+  }
+}

--- a/packages/lib/src/files/__tests__/support/db.ts
+++ b/packages/lib/src/files/__tests__/support/db.ts
@@ -1,0 +1,286 @@
+// packages/lib/src/files/__tests__/support/db.ts
+
+/**
+ * A recording, Drizzle-*shaped* database stub — and the shared journal that
+ * makes cross-collaborator ordering assertable.
+ *
+ * **This is a stub, not a Drizzle emulator.** It records the calls made against
+ * it and returns rows the test queued, in call order. It deliberately does not
+ * look at a `where` clause, a `limit`, or a join: the moment a test needs the
+ * fake to *interpret* SQL, that test wants a pure function or a real database
+ * instead, and pretending otherwise produces a fake that passes while the query
+ * is wrong. Keep it dumb.
+ */
+
+import type { Database, Transaction } from '@auxx/database'
+
+// ============= Journal =============
+
+/** Which collaborator produced an entry. `db` covers BEGIN/COMMIT as well as statements. */
+export type JournalChannel = 'db' | 'storage' | 'queue' | 'cache'
+
+/** One recorded interaction, stamped with a monotonic sequence number. */
+export interface JournalEntry {
+  seq: number
+  channel: JournalChannel
+  op: string
+  detail?: Record<string, unknown>
+}
+
+/**
+ * A single monotonic recorder shared by the db stub and the port doubles.
+ *
+ * This exists for one assertion the refactor turns on: *no storage call, queue
+ * write or cache bust may happen between `BEGIN` and `COMMIT`*. That question is
+ * unanswerable if each double keeps its own call list, because there is nothing
+ * to interleave them by. Hand the same journal to every double in a test and
+ * {@link Journal.between} answers it directly.
+ */
+export interface Journal {
+  /** Every entry, in the order it happened. */
+  readonly entries: JournalEntry[]
+  /** Append an entry and return it. Doubles call this; tests normally read instead. */
+  record(channel: JournalChannel, op: string, detail?: Record<string, unknown>): JournalEntry
+  /** The `op` strings, optionally narrowed to one channel — the readable form for `toEqual`. */
+  ops(channel?: JournalChannel): string[]
+  /** Entries strictly between the first `from` and the first `to` that follows it. */
+  between(from: string, to: string): JournalEntry[]
+  /** Drop everything recorded so far. */
+  reset(): void
+}
+
+/** Create a journal. Pass the same instance to `makeDb`, `makeStoragePort`, `makeQueuePort`, `makeCachePort`. */
+export function makeJournal(): Journal {
+  const entries: JournalEntry[] = []
+  let seq = 0
+
+  return {
+    entries,
+    record(channel, op, detail) {
+      seq += 1
+      const entry: JournalEntry = { seq, channel, op, ...(detail && { detail }) }
+      entries.push(entry)
+      return entry
+    },
+    ops(channel) {
+      return entries.filter((e) => !channel || e.channel === channel).map((e) => e.op)
+    },
+    between(from, to) {
+      const start = entries.findIndex((e) => e.op === from)
+      if (start === -1) return []
+      const end = entries.findIndex((e, i) => i > start && e.op === to)
+      return entries.slice(start + 1, end === -1 ? entries.length : end)
+    },
+    reset() {
+      entries.length = 0
+      seq = 0
+    },
+  }
+}
+
+// ============= The repo gotcha =============
+
+/**
+ * Best-effort name for a Drizzle table reference.
+ *
+ * Under Vitest this package's setup replaces `@auxx/database`'s `schema` with a
+ * memoised proxy handing out bare `{}` objects, so `schema.MediaAsset._.name` is
+ * `undefined` and the table cannot name itself. Identity is still stable, which
+ * is why {@link MakeDbOptions.tables} exists — register the tables a test cares
+ * about and the journal carries real names instead of `'table'`.
+ *
+ * Lives here once so no `files/` test has to re-derive it (the reference test
+ * `snippets/__tests__/snippet-folder-mutations.test.ts` carries a local copy).
+ */
+export function tableName(table: unknown, registry?: ReadonlyMap<unknown, string>): string {
+  if (table === undefined || table === null) return 'unknown'
+  const registered = registry?.get(table)
+  if (registered) return registered
+  const named = (table as { _?: { name?: unknown } })._?.name
+  return typeof named === 'string' ? named : 'table'
+}
+
+// ============= The db stub =============
+
+/**
+ * Rows a test queues up, per surface. Each entry is consumed by one call, in
+ * order; running out yields `undefined` (relational) or `[]` (builder chains),
+ * which is what a real miss looks like.
+ */
+export interface MakeDbOptions {
+  /** Results for `db.query.<Table>.findFirst` / `.findMany`, keyed by table name. */
+  query?: Record<string, unknown[]>
+  /** Results for each awaited `db.select()` chain, in call order. */
+  select?: unknown[][]
+  /** Results for each awaited `db.insert()` chain. Defaults to the inserted values. */
+  insert?: unknown[][]
+  /** Results for each awaited `db.update()` chain. Defaults to the `set` payload. */
+  update?: unknown[][]
+  /** Results for each awaited `db.delete()` chain. Defaults to `[]`. */
+  delete?: unknown[][]
+  /** Register real table references so journal entries carry names, not `'table'`. */
+  tables?: Record<string, unknown>
+  /** Share ordering with the port doubles. One is created if omitted. */
+  journal?: Journal
+}
+
+/** What a test asserts against after driving the code under test. */
+export interface FakeDb {
+  /** Pass this as `FilesCtx.db`. */
+  db: Database
+  journal: Journal
+  inserts: Array<{ table: string; values: unknown }>
+  updates: Array<{ table: string; values: unknown }>
+  deletes: Array<{ table: string }>
+  /** How many `db.transaction(...)` calls were opened, including nested ones. */
+  transactions: number
+}
+
+type Chain = PromiseLike<unknown[]> & Record<string, (...args: unknown[]) => unknown>
+
+/** Builder methods that just return the chain. Awaiting anywhere resolves the queued rows. */
+const CHAIN_METHODS = [
+  'from',
+  'where',
+  'orderBy',
+  'groupBy',
+  'having',
+  'limit',
+  'offset',
+  'for',
+  'innerJoin',
+  'leftJoin',
+  'rightJoin',
+  'fullJoin',
+  'onConflictDoNothing',
+  'onConflictDoUpdate',
+  'returning',
+  'prepare',
+  'execute',
+  'as',
+] as const
+
+function makeChain(resolve: () => unknown[]): Chain {
+  const chain = {
+    // biome-ignore lint/suspicious/noThenProperty: a Drizzle query builder IS thenable — `await db.select().from(t).where(w)` is the shape every call site uses, so the stub has to be too.
+    then: (onFulfilled?: unknown, onRejected?: unknown) =>
+      Promise.resolve()
+        .then(() => resolve())
+        .then(onFulfilled as (v: unknown[]) => unknown, onRejected as (e: unknown) => unknown),
+  } as unknown as Chain
+  for (const method of CHAIN_METHODS) {
+    chain[method] = () => chain
+  }
+  return chain
+}
+
+/**
+ * Build a db stub that records what was asked of it and hands back queued rows.
+ *
+ * `db.transaction(cb)` records `begin` then `commit` (or `rollback` if `cb`
+ * throws) on the journal, and hands `cb` the same recording surface — so the
+ * "nothing but SQL between BEGIN and COMMIT" assertion is a one-liner.
+ */
+export function makeDb(options: MakeDbOptions = {}): FakeDb {
+  const journal = options.journal ?? makeJournal()
+  const registry = new Map<unknown, string>(
+    Object.entries(options.tables ?? {}).map(([name, ref]) => [ref, name])
+  )
+
+  const queryQueues = new Map<string, unknown[]>(
+    Object.entries(options.query ?? {}).map(([table, rows]) => [table, [...rows]])
+  )
+  const selectQueue = [...(options.select ?? [])]
+  const insertQueue = [...(options.insert ?? [])]
+  const updateQueue = [...(options.update ?? [])]
+  const deleteQueue = [...(options.delete ?? [])]
+
+  const fake: FakeDb = {
+    db: undefined as unknown as Database,
+    journal,
+    inserts: [],
+    updates: [],
+    deletes: [],
+    transactions: 0,
+  }
+
+  const name = (table: unknown) => tableName(table, registry)
+
+  function buildSurface(): Record<string, unknown> {
+    const surface: Record<string, unknown> = {
+      query: new Proxy(
+        {},
+        {
+          get: (_target, tableKey: string) => ({
+            findFirst: async (...args: unknown[]) => {
+              journal.record('db', 'query.findFirst', { table: tableKey, args: args[0] })
+              return queryQueues.get(tableKey)?.shift()
+            },
+            findMany: async (...args: unknown[]) => {
+              journal.record('db', 'query.findMany', { table: tableKey, args: args[0] })
+              return queryQueues.get(tableKey)?.shift() ?? []
+            },
+          }),
+        }
+      ),
+
+      select: (...args: unknown[]) => {
+        journal.record('db', 'select', { projection: args[0] })
+        return makeChain(() => selectQueue.shift() ?? [])
+      },
+
+      insert: (table: unknown) => {
+        let lastInsertValues: unknown[] = []
+        const chain = makeChain(() => insertQueue.shift() ?? lastInsertValues)
+        chain.values = (values: unknown) => {
+          journal.record('db', 'insert', { table: name(table) })
+          fake.inserts.push({ table: name(table), values })
+          lastInsertValues = Array.isArray(values) ? values : [values]
+          return chain
+        }
+        return chain
+      },
+
+      update: (table: unknown) => {
+        let lastSetPayload: unknown[] = []
+        const chain = makeChain(() => updateQueue.shift() ?? lastSetPayload)
+        chain.set = (values: unknown) => {
+          journal.record('db', 'update', { table: name(table) })
+          fake.updates.push({ table: name(table), values })
+          lastSetPayload = [values]
+          return chain
+        }
+        return chain
+      },
+
+      delete: (table: unknown) => {
+        journal.record('db', 'delete', { table: name(table) })
+        fake.deletes.push({ table: name(table) })
+        return makeChain(() => deleteQueue.shift() ?? [])
+      },
+
+      execute: (...args: unknown[]) => {
+        journal.record('db', 'execute', { sql: args[0] })
+        return makeChain(() => [])
+      },
+    }
+
+    surface.transaction = async (cb: (tx: Transaction) => Promise<unknown>) => {
+      fake.transactions += 1
+      journal.record('db', 'begin')
+      try {
+        const result = await cb(buildSurface() as unknown as Transaction)
+        journal.record('db', 'commit')
+        return result
+      } catch (error) {
+        journal.record('db', 'rollback')
+        throw error
+      }
+    }
+
+    return surface
+  }
+
+  fake.db = buildSurface() as unknown as Database
+  return fake
+}

--- a/packages/lib/src/files/__tests__/support/fixtures.ts
+++ b/packages/lib/src/files/__tests__/support/fixtures.ts
@@ -1,0 +1,115 @@
+// packages/lib/src/files/__tests__/support/fixtures.ts
+
+/**
+ * Row and id fixtures for `files/` tests.
+ *
+ * Every builder takes a partial override and spreads it last, so a test states
+ * only the field under test and the rest is plausible-but-obviously-fake. The
+ * asset and storage-location builders return the **real** Drizzle entity types,
+ * so a schema change breaks the fixture at compile time rather than letting
+ * tests assert against a shape the database no longer has.
+ */
+
+import type { MediaAssetEntity, StorageLocationEntity } from '@auxx/database/types'
+import { DEFAULT_TEST_INSTANT } from './clock'
+
+/** The ids every fixture defaults to, exported so assertions can name them. */
+export const TEST_IDS = {
+  organizationId: 'org_test',
+  userId: 'usr_test',
+  assetId: 'ast_test',
+  versionId: 'ver_test',
+  storageLocationId: 'loc_test',
+  credentialId: 'cred_test',
+} as const
+
+/** The bucket names fixtures use. Distinct on purpose: a wrong-bucket bug must be visible in a diff. */
+export const TEST_BUCKETS = {
+  private: 'test-private-bucket',
+  public: 'test-public-bucket',
+} as const
+
+const AT = new Date(DEFAULT_TEST_INSTANT)
+
+/**
+ * The minimum of an organization that `files/` code ever reads.
+ *
+ * Deliberately not `OrganizationEntity`: nothing under `files/` touches an org
+ * row beyond its id, and a full 20-field fixture would be noise that drifts.
+ */
+export interface TestOrg {
+  id: string
+  name: string
+}
+
+/** Same reasoning as {@link TestOrg} — `files/` only ever needs the actor's id. */
+export interface TestUser {
+  id: string
+  name: string
+  email: string
+}
+
+/** An organization, defaulting to {@link TEST_IDS}.organizationId. */
+export function anOrg(overrides: Partial<TestOrg> = {}): TestOrg {
+  return { id: TEST_IDS.organizationId, name: 'Test Org', ...overrides }
+}
+
+/** A user, defaulting to {@link TEST_IDS}.userId. */
+export function aUser(overrides: Partial<TestUser> = {}): TestUser {
+  return { id: TEST_IDS.userId, name: 'Test User', email: 'test@example.com', ...overrides }
+}
+
+/**
+ * A `MediaAsset` row.
+ *
+ * Defaults to private (`isPrivate: true`) because that is the safe default the
+ * production code assumes, and to a live row (`deletedAt: null`) so a
+ * soft-delete test has to opt in to the deleted case explicitly.
+ */
+export function anAsset(overrides: Partial<MediaAssetEntity> = {}): MediaAssetEntity {
+  return {
+    id: TEST_IDS.assetId,
+    organizationId: TEST_IDS.organizationId,
+    kind: 'IMAGE',
+    name: 'test-image.png',
+    mimeType: 'image/png',
+    size: 1024,
+    isPrivate: true,
+    deletedAt: null,
+    currentVersionId: TEST_IDS.versionId,
+    createdById: TEST_IDS.userId,
+    createdAt: AT,
+    updatedAt: AT,
+    expiresAt: null,
+    purpose: 'ORIGINAL',
+    ...overrides,
+  }
+}
+
+/**
+ * A `StorageLocation` row.
+ *
+ * `metadata.bucket` is populated because that is where every adapter looks for
+ * it, and a fixture that left it out would let a test pass against code that
+ * silently falls back to the configured default bucket.
+ */
+export function aStorageLocation(
+  overrides: Partial<StorageLocationEntity> = {}
+): StorageLocationEntity {
+  const key = `${TEST_IDS.organizationId}/media-asset/${TEST_IDS.assetId}/test-image.png`
+  return {
+    id: TEST_IDS.storageLocationId,
+    provider: 'S3',
+    externalId: key,
+    externalUrl: `https://cdn.test/${key}`,
+    externalRev: 'etag-test',
+    organizationId: TEST_IDS.organizationId,
+    credentialId: null,
+    size: 1024,
+    mimeType: 'image/png',
+    createdAt: AT,
+    deletedAt: null,
+    metadata: { bucket: TEST_BUCKETS.private, key },
+    ...overrides,
+  }
+}

--- a/packages/lib/src/files/__tests__/support/index.ts
+++ b/packages/lib/src/files/__tests__/support/index.ts
@@ -1,0 +1,38 @@
+// packages/lib/src/files/__tests__/support/index.ts
+
+/**
+ * The `files/` test support kit.
+ *
+ * One import for every double a `files/` test needs, so no test re-derives the
+ * Drizzle-shaped stub or the `tableName` workaround. Explicit named exports, no
+ * `export *` — a kit whose surface is implicit is a kit that grows silently.
+ *
+ * The property this kit exists to make possible: **a `files/` test calls
+ * `vi.mock` zero times.** Every collaborator arrives as a parameter, so there is
+ * nothing left to intercept at module scope.
+ */
+
+export type { CacheBust, FakeCachePort, MakeCachePortOptions } from './cache'
+export { makeCachePort } from './cache'
+export type { FakeClock } from './clock'
+export { DEFAULT_TEST_INSTANT, makeClock } from './clock'
+export { makeCtx, makeDeps } from './ctx'
+export type {
+  FakeDb,
+  Journal,
+  JournalChannel,
+  JournalEntry,
+  MakeDbOptions,
+} from './db'
+export { makeDb, makeJournal, tableName } from './db'
+export type { TestOrg, TestUser } from './fixtures'
+export { anAsset, anOrg, aStorageLocation, aUser, TEST_BUCKETS, TEST_IDS } from './fixtures'
+export type { FakeQueuePort, MakeQueuePortOptions, QueueCall } from './queue'
+export { makeQueuePort } from './queue'
+export type {
+  FakeStoragePort,
+  MakeStoragePortOptions,
+  StorageCall,
+  StorageResults,
+} from './storage'
+export { makeStoragePort } from './storage'

--- a/packages/lib/src/files/__tests__/support/queue.ts
+++ b/packages/lib/src/files/__tests__/support/queue.ts
@@ -1,0 +1,83 @@
+// packages/lib/src/files/__tests__/support/queue.ts
+
+/**
+ * A recording {@link QueuePort} double.
+ *
+ * The thing this replaces is `getQueue(Queues.thumbnailQueue)` called from
+ * inside a service method — a live BullMQ/Redis connection opened as a side
+ * effect of the code under test. Here the enqueue is just a recorded call, so a
+ * test can assert *what* was scheduled and, via the shared {@link Journal},
+ * *when* relative to the surrounding transaction.
+ */
+
+import type { QueuePort } from '../../storage/ports'
+import type { Journal } from './db'
+import { makeJournal } from './db'
+
+/** One enqueued job, in journal order. */
+export interface QueueCall<K extends keyof QueuePort = keyof QueuePort> {
+  method: K
+  params: Parameters<QueuePort[K]>[0]
+  /** The job id handed back to the caller. */
+  jobId: string
+}
+
+export interface MakeQueuePortOptions {
+  /** Share ordering with `makeDb` and the other doubles. */
+  journal?: Journal
+  /** Job ids to hand out, in call order. Defaults to `job_1`, `job_2`, … */
+  jobIds?: string[]
+  /** Full per-method override, for tests that need an enqueue to throw. */
+  impl?: Partial<QueuePort>
+}
+
+export interface FakeQueuePort {
+  /** Pass this as `FilesDeps.queue`. */
+  port: QueuePort
+  calls: QueueCall[]
+  journal: Journal
+  callsTo<K extends keyof QueuePort>(method: K): Array<QueueCall<K>>
+}
+
+/** Build a queue double that records every enqueue and returns a deterministic job id. */
+export function makeQueuePort(options: MakeQueuePortOptions = {}): FakeQueuePort {
+  const journal = options.journal ?? makeJournal()
+  const calls: QueueCall[] = []
+  const jobIds = [...(options.jobIds ?? [])]
+  let issued = 0
+
+  function nextJobId(): string {
+    issued += 1
+    return jobIds.shift() ?? `job_${issued}`
+  }
+
+  /**
+   * Journals the enqueue BEFORE running any override, so an override that
+   * throws still leaves the ordering evidence a Phase-6 assertion needs.
+   */
+  async function record<K extends keyof QueuePort>(
+    method: K,
+    params: Parameters<QueuePort[K]>[0],
+    override: ((p: never) => Promise<string>) | undefined
+  ): Promise<string> {
+    const entry = journal.record('queue', method, { params: params as Record<string, unknown> })
+    const jobId = (await override?.(params as never)) ?? nextJobId()
+    entry.detail = { ...entry.detail, jobId }
+    calls.push({ method, params, jobId })
+    return jobId
+  }
+
+  const port: QueuePort = {
+    enqueueThumbnail: (p) => record('enqueueThumbnail', p, options.impl?.enqueueThumbnail),
+    enqueueStorageCleanup: (p) =>
+      record('enqueueStorageCleanup', p, options.impl?.enqueueStorageCleanup),
+  }
+
+  return {
+    port,
+    calls,
+    journal,
+    callsTo: <K extends keyof QueuePort>(method: K) =>
+      calls.filter((c): c is QueueCall<K> => c.method === method),
+  }
+}

--- a/packages/lib/src/files/__tests__/support/storage.ts
+++ b/packages/lib/src/files/__tests__/support/storage.ts
@@ -1,0 +1,144 @@
+// packages/lib/src/files/__tests__/support/storage.ts
+
+/**
+ * A recording {@link StoragePort} double — the replacement for
+ * `vi.mock('../storage/storage-manager')`.
+ *
+ * Everything here is typed *against the real port* rather than restated, so a
+ * change to `StoragePort` breaks this file at compile time instead of letting a
+ * test keep asserting a signature production no longer has.
+ */
+
+import { Readable } from 'node:stream'
+import type { StoragePort } from '../../storage/ports'
+import type { Journal } from './db'
+import { makeJournal } from './db'
+
+/** One recorded port call, in journal order. */
+export interface StorageCall<K extends keyof StoragePort = keyof StoragePort> {
+  method: K
+  params: Parameters<StoragePort[K]>[0]
+}
+
+/**
+ * Canned return values, keyed by method and typed from the port itself.
+ *
+ * `Awaited<ReturnType<...>>` means a test writes the real result shape — an
+ * invented one will not compile.
+ */
+export type StorageResults = Partial<{
+  [K in keyof StoragePort]: Awaited<ReturnType<StoragePort[K]>>
+}>
+
+export interface MakeStoragePortOptions {
+  /** Share ordering with `makeDb` and the other doubles. */
+  journal?: Journal
+  /** What each method returns. Anything omitted returns a benign default. */
+  results?: StorageResults
+  /** Full per-method override, for tests that need to throw or vary per call. */
+  impl?: Partial<StoragePort>
+}
+
+export interface FakeStoragePort {
+  /** Pass this as `FilesDeps.storage`. */
+  port: StoragePort
+  calls: StorageCall[]
+  journal: Journal
+  /** Calls to one method, narrowed so `params` is that method's parameter type. */
+  callsTo<K extends keyof StoragePort>(method: K): Array<StorageCall<K>>
+}
+
+const EXPIRES = new Date('2026-01-01T01:00:00.000Z')
+
+/**
+ * Benign defaults, built fresh per call so a stream default is never consumed
+ * twice across two calls in one test.
+ */
+const DEFAULTS: { [K in keyof StoragePort]: () => Awaited<ReturnType<StoragePort[K]>> } = {
+  presignUpload: () => ({ url: 'https://s3.test/upload', method: 'PUT', expiresAt: EXPIRES }),
+  presignPart: () => ({ url: 'https://s3.test/part', method: 'PUT', expiresAt: EXPIRES }),
+  completeMultipart: () => ({ etag: 'etag-complete', size: 1024 }),
+  head: () => ({ name: 'file.bin', size: 1024, mimeType: 'application/octet-stream' }),
+  putObject: () => ({ etag: 'etag-put', size: 1024 }),
+  getObject: () => Buffer.from('fake-object-body'),
+  streamObject: () => Readable.from([Buffer.from('fake-object-body')]),
+  deleteObject: () => undefined,
+  presignDownload: () => ({ type: 'url', url: 'https://s3.test/download', expiresAt: EXPIRES }),
+  buildExternalUrl: () => 'https://cdn.test/object',
+}
+
+/**
+ * Build a storage double that records every call and returns whatever the test
+ * queued for that method.
+ *
+ * `buildExternalUrl` stays synchronous here too — a double that returned a
+ * promise would let code under test `await` something production cannot, and
+ * the sync signature is what keeps I/O out of an open transaction.
+ */
+export function makeStoragePort(options: MakeStoragePortOptions = {}): FakeStoragePort {
+  const journal = options.journal ?? makeJournal()
+  const calls: StorageCall[] = []
+
+  function record<K extends keyof StoragePort>(method: K, params: unknown) {
+    journal.record('storage', method, { params: params as Record<string, unknown> })
+    calls.push({ method, params: params as Parameters<StoragePort[K]>[0] })
+  }
+
+  function resultFor<K extends keyof StoragePort>(method: K): Awaited<ReturnType<StoragePort[K]>> {
+    const queued = options.results?.[method]
+    return (queued === undefined ? DEFAULTS[method]() : queued) as Awaited<
+      ReturnType<StoragePort[K]>
+    >
+  }
+
+  const port: StoragePort = {
+    presignUpload: async (p) => {
+      record('presignUpload', p)
+      return options.impl?.presignUpload?.(p) ?? resultFor('presignUpload')
+    },
+    presignPart: async (p) => {
+      record('presignPart', p)
+      return options.impl?.presignPart?.(p) ?? resultFor('presignPart')
+    },
+    completeMultipart: async (p) => {
+      record('completeMultipart', p)
+      return options.impl?.completeMultipart?.(p) ?? resultFor('completeMultipart')
+    },
+    head: async (p) => {
+      record('head', p)
+      return options.impl?.head?.(p) ?? resultFor('head')
+    },
+    putObject: async (p) => {
+      record('putObject', p)
+      return options.impl?.putObject?.(p) ?? resultFor('putObject')
+    },
+    getObject: async (p) => {
+      record('getObject', p)
+      return options.impl?.getObject?.(p) ?? resultFor('getObject')
+    },
+    streamObject: async (p) => {
+      record('streamObject', p)
+      return options.impl?.streamObject?.(p) ?? resultFor('streamObject')
+    },
+    deleteObject: async (p) => {
+      record('deleteObject', p)
+      await options.impl?.deleteObject?.(p)
+    },
+    presignDownload: async (p) => {
+      record('presignDownload', p)
+      return options.impl?.presignDownload?.(p) ?? resultFor('presignDownload')
+    },
+    buildExternalUrl: (p) => {
+      record('buildExternalUrl', p)
+      return options.impl?.buildExternalUrl?.(p) ?? resultFor('buildExternalUrl')
+    },
+  }
+
+  return {
+    port,
+    calls,
+    journal,
+    callsTo: <K extends keyof StoragePort>(method: K) =>
+      calls.filter((c): c is StorageCall<K> => c.method === method),
+  }
+}

--- a/packages/lib/src/files/assets/__tests__/download.test.ts
+++ b/packages/lib/src/files/assets/__tests__/download.test.ts
@@ -1,0 +1,331 @@
+// packages/lib/src/files/assets/__tests__/download.test.ts
+
+/**
+ * `getAssetDownloadRef` — the Phase-2 READ pilot.
+ *
+ * The property this file exists to demonstrate, beyond the behaviour it
+ * asserts: **it calls `vi.mock` zero times.** Every collaborator arrives as a
+ * parameter (`ctx.db`, `deps.storage`), so there is nothing left to intercept
+ * at module scope. The equivalent test against `MediaAssetService` needed
+ * ~100 lines of `vi.mock('../storage/storage-manager')` plus a database mock.
+ */
+
+import { schema } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import {
+  anAsset,
+  aStorageLocation,
+  makeCtx,
+  makeDb,
+  makeJournal,
+  makeStoragePort,
+  TEST_BUCKETS,
+  TEST_IDS,
+} from '../../__tests__/support'
+import { getAssetDownloadRef } from '../download'
+
+/** A version row shaped the way the relational query returns it (location joined in). */
+function aVersion(
+  overrides: {
+    id?: string
+    assetId?: string
+    versionNumber?: number
+    storageLocationId?: string | null
+    storageLocation?: ReturnType<typeof aStorageLocation> | null
+  } = {}
+) {
+  const storageLocation =
+    overrides.storageLocation === undefined ? aStorageLocation() : overrides.storageLocation
+  return {
+    id: overrides.id ?? TEST_IDS.versionId,
+    assetId: overrides.assetId ?? TEST_IDS.assetId,
+    versionNumber: overrides.versionNumber ?? 1,
+    size: 1024,
+    mimeType: 'image/png',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    storageLocationId:
+      overrides.storageLocationId === undefined
+        ? (storageLocation?.id ?? null)
+        : overrides.storageLocationId,
+    deletedAt: null,
+    derivedFromVersionId: null,
+    preset: null,
+    metadata: {},
+    status: 'READY' as const,
+    storageLocation,
+  }
+}
+
+const TABLES = { MediaAsset: schema.MediaAsset, MediaAssetVersion: schema.MediaAssetVersion }
+
+describe('getAssetDownloadRef', () => {
+  it('returns the durable external URL for a public asset and never touches storage', async () => {
+    const journal = makeJournal()
+    const db = makeDb({
+      query: {
+        MediaAsset: [anAsset({ isPrivate: false })],
+        MediaAssetVersion: [
+          aVersion({
+            storageLocation: aStorageLocation({ externalUrl: 'https://cdn.test/og.png' }),
+          }),
+        ],
+      },
+      tables: TABLES,
+      journal,
+    })
+    const storage = makeStoragePort({ journal })
+
+    const result = await getAssetDownloadRef(
+      makeCtx({ db: db.db }),
+      { storage: storage.port },
+      TEST_IDS.assetId
+    )
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toEqual({ type: 'url', url: 'https://cdn.test/og.png' })
+    // No expiry: an OG crawler caches this for days, and a presigned URL would 403.
+    expect(result._unsafeUnwrap()).not.toHaveProperty('expiresAt')
+    expect(storage.calls).toEqual([])
+    expect(journal.ops('storage')).toEqual([])
+  })
+
+  it('presigns a private asset with the bucket from the StorageLocation row', async () => {
+    const db = makeDb({
+      query: {
+        MediaAsset: [
+          anAsset({ isPrivate: true, name: 'invoice.pdf', mimeType: 'application/pdf' }),
+        ],
+        MediaAssetVersion: [
+          aVersion({
+            storageLocation: aStorageLocation({
+              externalId: 'org_test/media-asset/ast_test/invoice.pdf',
+              credentialId: TEST_IDS.credentialId,
+              metadata: { bucket: TEST_BUCKETS.public, key: 'ignored' },
+            }),
+          }),
+        ],
+      },
+      tables: TABLES,
+    })
+    const storage = makeStoragePort({
+      results: {
+        presignDownload: { type: 'url', url: 'https://s3.test/signed', expiresAt: new Date(0) },
+      },
+    })
+
+    const result = await getAssetDownloadRef(
+      makeCtx({ db: db.db }),
+      { storage: storage.port },
+      TEST_IDS.assetId,
+      { disposition: 'attachment', ttlSec: 900 }
+    )
+
+    expect(result._unsafeUnwrap()).toEqual({
+      type: 'url',
+      url: 'https://s3.test/signed',
+      expiresAt: new Date(0),
+    })
+    // The bucket came off the row, not from config — the assertion #1816/#1817/#1818 lacked.
+    expect(storage.callsTo('presignDownload')[0]?.params).toEqual({
+      provider: 'S3',
+      bucket: TEST_BUCKETS.public,
+      key: 'org_test/media-asset/ast_test/invoice.pdf',
+      credentialId: TEST_IDS.credentialId,
+      ttlSec: 900,
+      disposition: 'attachment',
+      filename: 'invoice.pdf',
+      mimeType: 'application/pdf',
+    })
+  })
+
+  it('presigns a public asset whose storage location has no external URL', async () => {
+    const db = makeDb({
+      query: {
+        MediaAsset: [anAsset({ isPrivate: false })],
+        MediaAssetVersion: [aVersion({ storageLocation: aStorageLocation({ externalUrl: '' }) })],
+      },
+      tables: TABLES,
+    })
+    const storage = makeStoragePort()
+
+    const result = await getAssetDownloadRef(
+      makeCtx({ db: db.db }),
+      { storage: storage.port },
+      TEST_IDS.assetId
+    )
+
+    expect(result.isOk()).toBe(true)
+    expect(storage.callsTo('presignDownload')).toHaveLength(1)
+  })
+
+  it('serves an explicitly requested version', async () => {
+    const journal = makeJournal()
+    const db = makeDb({
+      query: {
+        MediaAsset: [anAsset({ isPrivate: true })],
+        MediaAssetVersion: [
+          aVersion({
+            id: 'ver_old',
+            versionNumber: 3,
+            storageLocation: aStorageLocation({ id: 'loc_old', externalId: 'keys/old.png' }),
+          }),
+        ],
+      },
+      tables: TABLES,
+      journal,
+    })
+    const storage = makeStoragePort({ journal })
+
+    const result = await getAssetDownloadRef(
+      makeCtx({ db: db.db }),
+      { storage: storage.port },
+      TEST_IDS.assetId,
+      { versionId: 'ver_old' }
+    )
+
+    expect(result.isOk()).toBe(true)
+    expect(storage.callsTo('presignDownload')[0]?.params.key).toBe('keys/old.png')
+    expect(journal.ops()).toEqual(['query.findFirst', 'query.findFirst', 'presignDownload'])
+  })
+
+  it('returns NotFoundError when the asset does not exist', async () => {
+    const db = makeDb({ query: { MediaAsset: [] }, tables: TABLES })
+    const storage = makeStoragePort()
+
+    const result = await getAssetDownloadRef(
+      makeCtx({ db: db.db }),
+      { storage: storage.port },
+      'ast_missing'
+    )
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+    expect(result._unsafeUnwrapErr().message).toBe('Asset ast_missing not found')
+    expect(storage.calls).toEqual([])
+  })
+
+  it('scopes the asset read to the caller org and the version read to the asset', async () => {
+    const db = makeDb({
+      query: { MediaAsset: [anAsset()], MediaAssetVersion: [aVersion()] },
+      tables: TABLES,
+    })
+
+    await getAssetDownloadRef(
+      makeCtx({ db: db.db, organizationId: 'org_other' }),
+      { storage: makeStoragePort().port },
+      TEST_IDS.assetId
+    )
+
+    // The stub does not interpret SQL, so assert the predicate was BUILT — the
+    // org filter and the soft-delete filter are what stop a cross-tenant read.
+    // Column references serialize as `null` here: under Vitest this package's
+    // setup replaces `schema` with a proxy of bare `{}` objects, so a Drizzle
+    // table cannot name its own columns. The bound VALUES and the operators
+    // survive, which is enough to prove the predicate was built.
+    const [assetRead, versionRead] = db.journal.entries.filter((e) => e.op === 'query.findFirst')
+    const assetSql = JSON.stringify((assetRead?.detail?.args as { where?: unknown })?.where)
+    expect(assetSql).toContain('org_other')
+    expect(assetSql).toContain(TEST_IDS.assetId)
+    expect(assetSql).toContain(' is null')
+    expect(JSON.stringify((versionRead?.detail?.args as { where?: unknown })?.where)).toContain(
+      TEST_IDS.assetId
+    )
+  })
+
+  it('returns NotFoundError, not a leak, for an asset in another organization', async () => {
+    // The org-scoped WHERE means the row simply is not there.
+    const db = makeDb({ query: { MediaAsset: [] }, tables: TABLES })
+    const storage = makeStoragePort()
+
+    const result = await getAssetDownloadRef(
+      makeCtx({ db: db.db, organizationId: 'org_other' }),
+      { storage: storage.port },
+      TEST_IDS.assetId
+    )
+
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+    // The message must not confirm the id exists elsewhere.
+    expect(result._unsafeUnwrapErr().message).toBe(`Asset ${TEST_IDS.assetId} not found`)
+    expect(storage.calls).toEqual([])
+  })
+
+  it('returns NotFoundError when the asset has no version at all', async () => {
+    const db = makeDb({
+      query: { MediaAsset: [anAsset({ currentVersionId: null })], MediaAssetVersion: [] },
+      tables: TABLES,
+    })
+
+    const result = await getAssetDownloadRef(
+      makeCtx({ db: db.db }),
+      { storage: makeStoragePort().port },
+      TEST_IDS.assetId
+    )
+
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+    expect(result._unsafeUnwrapErr().message).toBe(`No version found for asset ${TEST_IDS.assetId}`)
+  })
+
+  it('returns NotFoundError when the version has no storageLocationId', async () => {
+    const db = makeDb({
+      query: {
+        MediaAsset: [anAsset()],
+        MediaAssetVersion: [aVersion({ storageLocationId: null, storageLocation: null })],
+      },
+      tables: TABLES,
+    })
+    const storage = makeStoragePort()
+
+    const result = await getAssetDownloadRef(
+      makeCtx({ db: db.db }),
+      { storage: storage.port },
+      TEST_IDS.assetId
+    )
+
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+    expect(result._unsafeUnwrapErr().message).toBe(
+      `No storage location found for asset ${TEST_IDS.assetId}`
+    )
+    expect(storage.calls).toEqual([])
+  })
+
+  it('treats a soft-deleted asset as missing', async () => {
+    // `deletedAt IS NULL` is in the WHERE, so the real database returns nothing;
+    // the stub models that by having no row queued.
+    const db = makeDb({ query: { MediaAsset: [] }, tables: TABLES })
+    const storage = makeStoragePort()
+
+    const result = await getAssetDownloadRef(
+      makeCtx({ db: db.db }),
+      { storage: storage.port },
+      TEST_IDS.assetId
+    )
+
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+    expect(storage.calls).toEqual([])
+  })
+
+  it('fails loudly rather than guessing when the storage location has no bucket', async () => {
+    const db = makeDb({
+      query: {
+        MediaAsset: [anAsset({ isPrivate: true })],
+        MediaAssetVersion: [
+          aVersion({ storageLocation: aStorageLocation({ metadata: { key: 'k' } }) }),
+        ],
+      },
+      tables: TABLES,
+    })
+    const storage = makeStoragePort()
+
+    const result = await getAssetDownloadRef(
+      makeCtx({ db: db.db }),
+      { storage: storage.port },
+      TEST_IDS.assetId
+    )
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().statusCode).toBe(500)
+    expect(result._unsafeUnwrapErr().message).toContain('has no metadata.bucket')
+    // Never presign against a guessed bucket: a wrong-bucket delete 204s.
+    expect(storage.calls).toEqual([])
+  })
+})

--- a/packages/lib/src/files/assets/download.ts
+++ b/packages/lib/src/files/assets/download.ts
@@ -1,0 +1,193 @@
+// packages/lib/src/files/assets/download.ts
+
+/**
+ * Resolving a `MediaAsset` to something a browser can fetch.
+ *
+ * This is the Phase-2 pilot: the first `files/` read written to the
+ * {@link FilesCtx} contract, proving the seam works end to end before phases
+ * 3-5 move the rest. `MediaAssetService.getDownloadRef` / `.getDownloadUrl`
+ * delegate here; no call site moved.
+ */
+
+import { schema } from '@auxx/database'
+import type {
+  MediaAssetEntity,
+  MediaAssetVersionEntity,
+  StorageLocationEntity,
+} from '@auxx/database/types'
+import { and, desc, eq, isNull } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import { AuxxError, NotFoundError } from '../../errors'
+import type { DownloadRef } from '../adapters/base-adapter'
+import type { FilesCtx, FilesDeps } from '../ctx'
+import { guard } from '../guard'
+
+/**
+ * The collaborators this read needs — storage, and nothing else.
+ *
+ * Deliberately a `Pick` of {@link FilesDeps} rather than the whole bundle. A
+ * caller that already holds a `FilesDeps` passes it unchanged (structural
+ * typing), but the signature still states the truth: this function cannot
+ * enqueue a job, bust a cache, or read the clock. Widening it to `FilesDeps`
+ * would make every caller of a pure read construct a queue port — i.e. bind a
+ * live Redis connection — to presign a URL.
+ */
+export type DownloadDeps = Pick<FilesDeps, 'storage'>
+
+/** Knobs for {@link getAssetDownloadRef}. `disposition`/`ttlSec` reach only the presigned branch. */
+export interface GetAssetDownloadRefOptions {
+  /** Target a specific version instead of the asset's current one. */
+  versionId?: string
+  /** How the browser should treat the response. Ignored for durable public URLs. */
+  disposition?: 'inline' | 'attachment'
+  /** Presigned-URL lifetime. Ignored for durable public URLs, which never expire. */
+  ttlSec?: number
+}
+
+/** A version row with its `StorageLocation` joined in, which is the only shape this read uses. */
+type VersionWithLocation = MediaAssetVersionEntity & {
+  storageLocation: StorageLocationEntity | null
+}
+
+/**
+ * Load the asset, scoped to the caller's org and to live rows.
+ *
+ * Both filters are load-bearing. Dropping the org filter turns a 404 into a
+ * cross-tenant read; dropping `deletedAt IS NULL` hands out a presigned URL for
+ * an object the purge job may already have removed. The old service applied
+ * them inconsistently across its six download entry points — this is the one
+ * place that decides now.
+ */
+async function loadAsset(ctx: FilesCtx, assetId: string): Promise<MediaAssetEntity> {
+  const asset = (await ctx.db.query.MediaAsset.findFirst({
+    where: and(
+      eq(schema.MediaAsset.id, assetId),
+      eq(schema.MediaAsset.organizationId, ctx.organizationId),
+      isNull(schema.MediaAsset.deletedAt)
+    ),
+  })) as MediaAssetEntity | undefined
+
+  // Same error for "does not exist" and "belongs to another org": the caller
+  // must not be able to probe for ids outside its tenant.
+  if (!asset) throw new NotFoundError(`Asset ${assetId} not found`)
+  return asset
+}
+
+/**
+ * Resolve which version to serve.
+ *
+ * An explicit `versionId` is always additionally constrained by `assetId`, so a
+ * version id belonging to a different asset (possibly another org's) cannot be
+ * served through an asset the caller can see.
+ */
+async function resolveVersion(
+  ctx: FilesCtx,
+  asset: MediaAssetEntity,
+  versionId?: string
+): Promise<VersionWithLocation> {
+  const where = versionId
+    ? and(
+        eq(schema.MediaAssetVersion.id, versionId),
+        eq(schema.MediaAssetVersion.assetId, asset.id)
+      )
+    : asset.currentVersionId
+      ? and(
+          eq(schema.MediaAssetVersion.id, asset.currentVersionId),
+          eq(schema.MediaAssetVersion.assetId, asset.id)
+        )
+      : eq(schema.MediaAssetVersion.assetId, asset.id)
+
+  const version = (await ctx.db.query.MediaAssetVersion.findFirst({
+    where,
+    // Only meaningful for the no-`currentVersionId` fallback; harmless otherwise.
+    orderBy: desc(schema.MediaAssetVersion.versionNumber),
+    with: { storageLocation: true },
+  })) as VersionWithLocation | undefined
+
+  if (!version) {
+    throw new NotFoundError(
+      versionId
+        ? `Version ${versionId} not found for asset ${asset.id}`
+        : `No version found for asset ${asset.id}`
+    )
+  }
+  return version
+}
+
+/**
+ * Read the bucket off the `StorageLocation` row, and refuse to invent one.
+ *
+ * Bugs #1816/#1817/#1818 all ended the same way: no bucket at the call site, a
+ * fallback to `S3_PRIVATE_BUCKET`, and S3 answering `204 No Content` for a
+ * delete aimed at a key that was never in the bucket we named — so objects
+ * leaked with no error anywhere. A row with no bucket is a data defect, and a
+ * 500 that names the row is strictly better than a signed URL for the wrong
+ * bucket, which fails later, elsewhere, and looks like an auth problem.
+ */
+function requireBucket(location: StorageLocationEntity, assetId: string): string {
+  const bucket = (location.metadata as { bucket?: unknown } | null)?.bucket
+  if (typeof bucket !== 'string' || bucket.length === 0) {
+    throw new AuxxError(
+      `StorageLocation ${location.id} has no metadata.bucket; refusing to fall back to a configured default`,
+      { storageLocationId: location.id, assetId }
+    )
+  }
+  return bucket
+}
+
+/**
+ * Resolve one asset to a {@link DownloadRef} — the single download entry point
+ * that replaces `getDownloadRef` / `getDownloadRefForVersion` / `getDownloadUrl`
+ * / `getDownloadUrls` / `getDownloadInfo` / `downloadUrlFor`. Callers read
+ * `.url` off the result.
+ *
+ * The public shortcut is the part worth not breaking: a non-private asset whose
+ * `StorageLocation` carries an `externalUrl` returns that durable URL with no
+ * expiry. OG-image and link-preview crawlers cache what they fetch for days, so
+ * handing them a presigned URL means every cached copy 403s once the signature
+ * lapses. Anything else is presigned through the {@link FilesDeps.storage}
+ * port, with the bucket taken from the row rather than from config.
+ *
+ * @param ctx Scope. `ctx.db` may be a pool or a transaction; this function never opens one.
+ * @param deps Storage only — see {@link DownloadDeps}.
+ * @param assetId Asset to resolve, interpreted within `ctx.organizationId`.
+ * @param opts Optional version target and presign knobs.
+ * @returns `err(NotFoundError)` when the asset, version, or storage location is
+ *   missing in this org; `err(AuxxError)` when the row cannot name its bucket.
+ */
+export async function getAssetDownloadRef(
+  ctx: FilesCtx,
+  deps: DownloadDeps,
+  assetId: string,
+  opts: GetAssetDownloadRefOptions = {}
+): Promise<Result<DownloadRef, AuxxError>> {
+  return guard(
+    async () => {
+      const asset = await loadAsset(ctx, assetId)
+      const version = await resolveVersion(ctx, asset, opts.versionId)
+
+      const location = version.storageLocation
+      if (!version.storageLocationId || !location) {
+        throw new NotFoundError(`No storage location found for asset ${asset.id}`)
+      }
+
+      // Durable public URL: no signature, so no expiry to outlive.
+      if (!asset.isPrivate && location.externalUrl) {
+        return { type: 'url', url: location.externalUrl } satisfies DownloadRef
+      }
+
+      return deps.storage.presignDownload({
+        provider: location.provider,
+        bucket: requireBucket(location, asset.id),
+        key: location.externalId,
+        credentialId: location.credentialId ?? undefined,
+        ttlSec: opts.ttlSec,
+        disposition: opts.disposition,
+        filename: asset.name ?? undefined,
+        mimeType: asset.mimeType ?? undefined,
+      })
+    },
+    'Failed to resolve asset download ref',
+    { assetId, versionId: opts.versionId, organizationId: ctx.organizationId }
+  )
+}

--- a/packages/lib/src/files/assets/index.ts
+++ b/packages/lib/src/files/assets/index.ts
@@ -1,0 +1,10 @@
+// packages/lib/src/files/assets/index.ts
+
+/**
+ * Asset reads and writes written to the `files/` {@link ../ctx.FilesCtx}
+ * contract. Explicit named exports only — an implicit surface is how
+ * `media-asset-service.ts` reached 1,540 lines.
+ */
+
+export type { DownloadDeps, GetAssetDownloadRefOptions } from './download'
+export { getAssetDownloadRef } from './download'

--- a/packages/lib/src/files/core/media-asset-service.ts
+++ b/packages/lib/src/files/core/media-asset-service.ts
@@ -25,6 +25,8 @@ import {
 } from 'drizzle-orm'
 import type { PgColumn } from 'drizzle-orm/pg-core'
 import type { DownloadRef } from '../adapters/base-adapter'
+import { type DownloadDeps, getAssetDownloadRef } from '../assets/download'
+import type { FilesCtx } from '../ctx'
 import { BaseService, type DatabaseClient, defaultDatabase } from './base-service'
 import { purgeMediaAssets } from './media-asset-purge'
 import type { ContentAccessible } from './mixins/content-accessible'
@@ -55,6 +57,8 @@ export class MediaAssetService
   implements ContentAccessible, Versioned
 {
   private _storageManager?: any
+
+  private _filesDownloadDeps?: DownloadDeps
 
   private static _columns?: Record<string, PgColumn>
 
@@ -955,36 +959,26 @@ export class MediaAssetService
   }
 
   /**
-   * Get a download URL with expiry information
+   * Get a download URL with expiry information.
+   *
+   * @deprecated Facade over
+   * {@link import('../assets/download').getAssetDownloadRef}. Call that
+   * directly with a `FilesCtx` and a `StoragePort`; this wrapper exists only so
+   * the ~15 existing call sites keep working while the function becomes the
+   * real implementation, and is deleted with the rest of `MediaAssetService`
+   * in Phase 5.
+   *
+   * Behaviour is unchanged except for the error type: it now throws an
+   * `AuxxError` subclass (`NotFoundError` for a missing asset/version/location)
+   * instead of a bare `Error`, so `auxxErrorMiddleware` can map it to a real
+   * status instead of a 500.
    */
   async getDownloadRef(id: string): Promise<DownloadRef> {
-    const entity = await this.get(id)
-    if (!entity) {
-      throw new Error(`${this.getEntityName()} not found`)
+    const result = await getAssetDownloadRef(this.filesCtx(), await this.filesDownloadDeps(), id)
+    if (result.isErr()) {
+      throw result.error
     }
-
-    const currentVersion = await this.getCurrentVersion(id)
-
-    if (!currentVersion || !currentVersion.storageLocationId) {
-      throw new Error(`No storage location found for ${this.getEntityName()}`)
-    }
-
-    // For public assets with external URLs, return the durable URL directly
-    if (!entity.isPrivate && currentVersion.storageLocation?.externalUrl) {
-      return {
-        type: 'url',
-        url: currentVersion.storageLocation.externalUrl,
-        expiresAt: undefined, // Durable URLs don't expire
-      }
-    }
-
-    // Otherwise, get presigned URL from storage manager
-    const storageManager = await this.getStorageManager()
-    return await storageManager.getDownloadRef({
-      locationId: currentVersion.storageLocationId,
-      filename: entity.name || undefined,
-      mimeType: entity.mimeType || undefined,
-    })
+    return result.value
   }
 
   /**
@@ -1059,15 +1053,25 @@ export class MediaAssetService
   }
 
   /**
-   * Get download URL as string (convenience method)
+   * Get download URL as string (convenience method).
+   *
+   * @deprecated Facade over
+   * {@link import('../assets/download').getAssetDownloadRef}. Call that
+   * directly and read `.url` off the {@link DownloadRef}; deleted with the rest
+   * of `MediaAssetService` in Phase 5.
+   *
+   * Returns `null` on every failure, exactly as before — this is a
+   * best-effort convenience used to fill avatar/thumbnail URLs into list
+   * payloads, and a throw there would fail a whole page for one broken row.
    */
   async getDownloadUrl(id: string): Promise<string | null> {
     try {
-      const entity = await this.get(id)
-      if (!entity) return null
-      const currentVersion = await this.resolveCurrentVersion(entity)
-      return this.downloadUrlFor(entity, currentVersion)
-    } catch (error) {
+      const result = await getAssetDownloadRef(this.filesCtx(), await this.filesDownloadDeps(), id)
+      if (result.isErr()) return null
+      return result.value.type === 'url' ? result.value.url : null
+    } catch {
+      // `filesCtx()` throws when the service has no organization context; the
+      // documented contract of this method is null-on-failure, so swallow it.
       return null
     }
   }
@@ -1224,6 +1228,46 @@ export class MediaAssetService
       throw new Error(`${this.getEntityName()} not found`)
     }
     return this.resolveCurrentVersion(entity)
+  }
+
+  // ============= Bridge to the functional `files/` surface =============
+
+  /**
+   * Build the {@link FilesCtx} the extracted `files/` functions take, from the
+   * scope this service already carries.
+   *
+   * `FilesCtx` carries no actor, so `this.userId` is deliberately not forwarded
+   * — a function that records one takes it in its own `input` instead. That
+   * matters here: many production sites construct `new MediaAssetService(orgId)`
+   * with no actor at all (a worker resolving a thumbnail URL, for one), and an
+   * earlier draft of this facade had to fabricate `''` to satisfy the type.
+   *
+   * `organizationId` is the opposite case: it is in the `WHERE` clause, so a
+   * missing one must throw rather than silently widen the query to every tenant.
+   */
+  private filesCtx(): FilesCtx {
+    return {
+      db: this.db,
+      organizationId: this.requireOrganization(),
+    }
+  }
+
+  /**
+   * The storage collaborator for the extracted download read, lazily built and
+   * cached per service instance.
+   *
+   * Imported dynamically for the same reason {@link getStorageManager} is:
+   * `storage/ports.ts` reaches `storage-location-service.ts`, which holds a
+   * module-scope `import { database as db }` named binding, and pulling that
+   * into this file's static import graph re-arms the collection hazard
+   * documented on `base-service.ts`.
+   */
+  private async filesDownloadDeps(): Promise<DownloadDeps> {
+    if (!this._filesDownloadDeps) {
+      const { createS3StoragePort } = await import('../storage/ports')
+      this._filesDownloadDeps = { storage: createS3StoragePort(this.requireOrganization()) }
+    }
+    return this._filesDownloadDeps
   }
 
   /**

--- a/packages/lib/src/files/ctx.ts
+++ b/packages/lib/src/files/ctx.ts
@@ -1,0 +1,163 @@
+// packages/lib/src/files/ctx.ts
+
+/**
+ * The ambient contract every `files/` function is written against.
+ *
+ * This file exists because `files/core/base-service.ts` binds its database at
+ * module scope (`constructor(orgId?, userId?, db = defaultDatabase())`), which
+ * makes it impossible to hand a function a transaction, a different pool, or a
+ * stub. Everything below is the seam that replaces it.
+ *
+ * ## The three signature shapes
+ *
+ * Pick by what the function actually needs — the signature is the documentation.
+ *
+ * **1. Pure — no `ctx`, no `db`, no `deps`.**
+ * ```ts
+ * export function buildUploadConfig(
+ *   handler: UploadHandler,
+ *   init: UploadInitConfig,
+ *   now: () => Date
+ * ): UploadPreparedConfig
+ * ```
+ * Data in, data out. Roughly a third of the new surface. `now` is threaded in
+ * rather than read from `Date.now()` so the function stays pure.
+ *
+ * **2. Database-touching — `fn(ctx: FilesCtx, ...)`.**
+ * ```ts
+ * export async function getAsset(
+ *   ctx: FilesCtx,
+ *   assetId: string
+ * ): Promise<Result<MediaAssetEntity | null, AuxxError>>
+ * ```
+ * `ctx` carries `db` plus the org/user scope. A function that also needs to
+ * enqueue a job or touch storage takes `deps: FilesDeps` as its second
+ * parameter — the split is the point (see {@link FilesDeps}).
+ *
+ * **3. Transaction-only — `fn(tx: Transaction, ctx: FilesCtx, ...)`.**
+ * ```ts
+ * export async function createAssetVersion(
+ *   tx: Transaction,
+ *   ctx: FilesCtx,
+ *   input: CreateVersionInput
+ * ): Promise<MediaAssetVersionEntity>
+ * ```
+ * `tx` is positional and **first**, kept separate from `ctx`. This is not
+ * stylistic: `FilesCtx.db` is `Database | Transaction`, so it cannot express
+ * "must be inside a transaction" — a pool typechecks into it and the multi-row
+ * invariant silently stops being atomic. A bare `Transaction` slot rejects a
+ * pool at compile time.
+ *
+ * ## The rule that goes with shape 3
+ *
+ * A caller already inside a transaction passes `{ ...ctx, db: tx }` to every
+ * nested `ctx`-taking read:
+ *
+ * ```ts
+ * await db.transaction(async (tx) => {
+ *   const txCtx = { ...ctx, db: tx }
+ *   const asset = await getAsset(txCtx, assetId)   // sees uncommitted rows
+ *   await createAssetVersion(tx, txCtx, input)
+ * })
+ * ```
+ *
+ * Reusing the outer `ctx` inside the body reintroduces exactly the stale-read
+ * bug this refactor exists to kill: a collaborator bound to the app pool cannot
+ * see rows the open transaction has written but not committed.
+ *
+ * ## Where the `Result` boundary sits
+ *
+ * Exported functions return `Promise<Result<T, AuxxError>>` via the module-local
+ * {@link ../files/guard.guard | guard}. Internal helpers throw. Only
+ * `AuxxError` subclasses, never bare `Error` and never `TRPCError`.
+ */
+
+import type { Database, Transaction } from '@auxx/database'
+import type { CachePort, QueuePort, StoragePort } from './storage/ports'
+
+/**
+ * Ambient scope every db-touching `files/` function needs.
+ *
+ * `db` is typed `Database | Transaction` so the same function body works on a
+ * pool and inside a transaction without a runtime `getTx()` guess. It is never
+ * optional and never defaulted — a defaulted `db` is what bound all ~124
+ * `BaseService` construction sites to the app pool.
+ *
+ * Routers build this in one line from what tRPC already hands them:
+ * `{ db: ctx.db, organizationId: ctx.session.organizationId }`.
+ *
+ * ## There is deliberately no `userId` here
+ *
+ * An earlier draft carried `userId: string`. Both Phase-2 pilots — one read
+ * (`assets/download.ts`) and one write (`storage/locations.ts`) — independently
+ * reported the same failure: neither needed an actor, so both facades had to
+ * fabricate `''` to satisfy the type. Lib performs **zero access checks**
+ * (`docs/lib-module-guide.md` §6), so `ctx.userId` has no reader on a read path,
+ * and many legitimate construction sites have no actor at all
+ * (`new MediaAssetService(orgId)` in `file-context-service.ts`,
+ * `document-service.ts`, `document-processor.ts`; `(orgId, undefined)` in
+ * `message-sender.service.ts`, `resolve-cover-urls.ts`, and
+ * `apps/api/src/routes/chat/attachments.ts`).
+ *
+ * Making it `userId?: string` would only move the sentinel: an optional field
+ * invites `ctx.userId!` or `ctx.userId ?? ''`, and one of those eventually
+ * reaches a NOT NULL `createdById`.
+ *
+ * So: **a function that records an actor takes it in its own `input`, where it
+ * is required and unmissable.** `createAssetWithVersion(tx, ctx, { createdById,
+ * … })`, not `ctx.userId`. Attribution then appears in the signature of exactly
+ * the functions that attribute, and nowhere else.
+ */
+export interface FilesCtx {
+  db: Database | Transaction
+  organizationId: string
+}
+
+/**
+ * Side-effecting collaborators, injected rather than constructed.
+ *
+ * Kept as a **separate object from {@link FilesCtx}** on purpose: a read that
+ * only touches the database takes `ctx` alone, and its signature then says it
+ * *cannot* write to S3, enqueue a job, or bust a cache. Merging the two would
+ * throw that guarantee away for one fewer parameter.
+ *
+ * An injectable `db` alone does not make this module testable — a function that
+ * still does `new ThumbnailService(...)` or `getQueue(Queues.thumbnailQueue)`
+ * internally is just as welded to its collaborators as before. These four
+ * fields are that escape hatch, and their test doubles are plain objects, so no
+ * `vi.mock` is involved on either side.
+ *
+ * `now` is here because `deriveStorageKey` and every `expiresAt` computation
+ * call `Date.now()` directly today, which makes them untestable without fake
+ * timers leaking into unrelated assertions.
+ */
+export interface FilesDeps {
+  storage: StoragePort
+  queue: QueuePort
+  cache: CachePort
+  now: () => Date
+}
+
+/**
+ * **Take a narrowed slice of {@link FilesDeps}, not the whole bundle.**
+ *
+ * Established by the Phase-2 read pilot. `getAssetDownloadRef` needs only
+ * `storage`, so it declares `deps: Pick<FilesDeps, 'storage'>`. A full
+ * `FilesDeps` parameter would *lie* — it says the function may enqueue a job or
+ * bust a cache — and it has a production cost: every caller of a pure read would
+ * have to construct a `QueuePort`, binding a live Redis connection, just to
+ * presign a URL.
+ *
+ * A real `FilesDeps` still passes structurally, so callers are unaffected, while
+ * the signature enumerates exactly what the function is allowed to do. Widen the
+ * `Pick` per function; never reach for the bundle as a shortcut.
+ *
+ * The rejected alternative was `opts.storage?: StoragePort` defaulting to
+ * `createS3StoragePort(...)`. That is the same defaulting this phase exists to
+ * delete: `BaseService`'s `db = defaultDatabase()` was *also* "trivially
+ * overridable", and all ~124 call sites still bound to the app pool. A test that
+ * forgets to pass a port must fail loudly, not silently reach real config.
+ */
+export type FilesDepsSlice<K extends keyof FilesDeps> = Pick<FilesDeps, K>
+
+export type { CachePort, QueuePort, StoragePort } from './storage/ports'

--- a/packages/lib/src/files/guard.ts
+++ b/packages/lib/src/files/guard.ts
@@ -1,0 +1,31 @@
+// packages/lib/src/files/guard.ts
+
+import { createScopedLogger } from '@auxx/logger'
+import { err, ok, type Result } from 'neverthrow'
+import { AuxxError } from '../errors'
+
+const logger = createScopedLogger('files')
+
+/**
+ * Run an imperative helper body that may `throw` an {@link AuxxError} for known
+ * business-rule failures, and convert the outcome into a neverthrow `Result`.
+ *
+ * - Thrown `AuxxError`s are returned as `err(error)` and mapped to the right
+ *   HTTP/tRPC code by the router's `auxxErrorMiddleware`.
+ * - Any other (unexpected) error is logged and surfaced as a generic 500.
+ */
+export async function guard<T>(
+  fn: () => Promise<T>,
+  logMessage: string,
+  meta: Record<string, unknown> = {}
+): Promise<Result<T, AuxxError>> {
+  try {
+    return ok(await fn())
+  } catch (error) {
+    if (error instanceof AuxxError) {
+      return err(error)
+    }
+    logger.error(logMessage, { error, ...meta })
+    return err(new AuxxError('Internal error'))
+  }
+}

--- a/packages/lib/src/files/storage/__tests__/locations.test.ts
+++ b/packages/lib/src/files/storage/__tests__/locations.test.ts
@@ -1,0 +1,252 @@
+// packages/lib/src/files/storage/__tests__/locations.test.ts
+
+/**
+ * The Phase-2 **write pilot** test.
+ *
+ * Two properties are the real deliverable here, and Phase 6 needs exactly them
+ * at scale:
+ *
+ * 1. `createStorageLocation` performs **no** storage, queue or cache call. The
+ *    ports share one {@link makeJournal} with the db stub, so "only database
+ *    statements happened" is a single assertion over one monotonic sequence
+ *    rather than three separate call lists nobody can interleave.
+ * 2. `createStorageLocation` never opens a transaction of its own. The journal
+ *    records `begin`/`commit`, so "exactly one pair, and the test opened it" is
+ *    assertable directly — which is what `BaseService.getTx()` made impossible,
+ *    since it decided at runtime and silently issued a `SAVEPOINT` every time.
+ *
+ * And, as with every test written to the `files/` contract: **`vi.mock` is
+ * called zero times in this file.** (`src/test/setup.ts` still mocks
+ * `@auxx/database` package-wide — pre-existing, and separately tracked.)
+ */
+
+import type { Database, Transaction } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import {
+  anOrg,
+  aStorageLocation,
+  makeCachePort,
+  makeCtx,
+  makeDb,
+  makeJournal,
+  makeQueuePort,
+  makeStoragePort,
+  TEST_BUCKETS,
+  TEST_IDS,
+} from '../../__tests__/support'
+import { type CreateStorageLocationInput, createStorageLocation } from '../locations'
+
+const KEY = 'org_test/media-asset/ast_test/photo.png'
+
+/**
+ * Borrow the db stub as a `Transaction`.
+ *
+ * `makeDb` hands out one recording surface and types it `Database`, because
+ * that is what `FilesCtx.db` wants. Tests that are not asserting on a real
+ * `BEGIN`/`COMMIT` pair still need something in the `tx` slot, and the cast is
+ * confined to this one line so it can never be mistaken for the production
+ * shortcut the signature exists to forbid. The transaction tests below take the
+ * genuine `Transaction` from `db.transaction(...)` instead.
+ */
+const asTx = (db: Database): Transaction => db as unknown as Transaction
+
+/** A valid input, so each test states only the field it is about. */
+function anInput(overrides: Partial<CreateStorageLocationInput> = {}): CreateStorageLocationInput {
+  return {
+    provider: 'S3',
+    externalId: KEY,
+    bucket: TEST_BUCKETS.public,
+    externalUrl: `https://cdn.test/${KEY}`,
+    externalRev: 'etag-test',
+    size: 1024,
+    mimeType: 'image/png',
+    ...overrides,
+  }
+}
+
+/** `makeDb` with the table registered, so journal entries carry the real name. */
+function aDb(options: Parameters<typeof makeDb>[0] = {}) {
+  return makeDb({
+    tables: { StorageLocation: schema.StorageLocation },
+    insert: [[aStorageLocation()]],
+    ...options,
+  })
+}
+
+describe('createStorageLocation', () => {
+  it('scopes the row to ctx.organizationId, never to anything on the input', async () => {
+    const db = aDb()
+    const otherOrg = anOrg({ id: 'org_actually_acting_for' })
+    const ctx = makeCtx({ db: db.db, organizationId: otherOrg.id })
+
+    // The input type has no `organizationId` at all; smuggling one in as an
+    // excess property must not reach the INSERT.
+    const smuggled = { ...anInput(), organizationId: 'org_attacker' } as CreateStorageLocationInput
+
+    const result = await createStorageLocation(asTx(db.db), ctx, smuggled)
+
+    expect(result.isOk()).toBe(true)
+    expect(db.inserts).toHaveLength(1)
+    const values = db.inserts[0]?.values as Record<string, unknown>
+    expect(db.inserts[0]?.table).toBe('StorageLocation')
+    expect(values.organizationId).toBe('org_actually_acting_for')
+  })
+
+  it('lands the bucket in the persisted metadata', async () => {
+    const db = aDb()
+    const ctx = makeCtx({ db: db.db })
+
+    await createStorageLocation(asTx(db.db), ctx, anInput({ bucket: TEST_BUCKETS.public }))
+
+    const values = db.inserts[0]?.values as { metadata: Record<string, unknown> }
+    // The whole reason for the pilot: a row without this is undeletable by key,
+    // because `deleteByKey` falls back to `S3_PRIVATE_BUCKET` and S3 answers
+    // 204 for a key that is not in the bucket you named. Bugs #1816/#1817/#1818.
+    expect(values.metadata.bucket).toBe(TEST_BUCKETS.public)
+    expect(values.metadata.key).toBe(KEY)
+  })
+
+  it('lets the caller-supplied bucket win over one inherited from metadata', async () => {
+    const db = aDb()
+    const ctx = makeCtx({ db: db.db })
+
+    await createStorageLocation(
+      asTx(db.db),
+      ctx,
+      anInput({
+        bucket: TEST_BUCKETS.public,
+        metadata: { bucket: TEST_BUCKETS.private, source: 'upstream-payload' },
+      })
+    )
+
+    const values = db.inserts[0]?.values as { metadata: Record<string, unknown> }
+    expect(values.metadata.bucket).toBe(TEST_BUCKETS.public)
+    expect(values.metadata.source).toBe('upstream-payload')
+  })
+
+  it('rejects a missing bucket instead of writing an undeletable row', async () => {
+    const db = aDb()
+    const ctx = makeCtx({ db: db.db })
+
+    const result = await createStorageLocation(asTx(db.db), ctx, anInput({ bucket: '' }))
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().statusCode).toBe(400)
+    expect(result._unsafeUnwrapErr().message).toContain('without a bucket')
+    // Rejected before the statement, not after it.
+    expect(db.inserts).toHaveLength(0)
+    expect(db.journal.ops('db')).toEqual([])
+  })
+
+  it('rejects a provider that has no adapter', async () => {
+    const db = aDb()
+    const ctx = makeCtx({ db: db.db })
+
+    const result = await createStorageLocation(asTx(db.db), ctx, anInput({ provider: 'DROPBOX' }))
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().statusCode).toBe(400)
+    expect(db.inserts).toHaveLength(0)
+  })
+
+  it('performs no storage, queue or cache call — only database statements', async () => {
+    const journal = makeJournal()
+    const db = aDb({ journal })
+    // The ports are wired to the same journal even though the function takes no
+    // `FilesDeps`: that is the assertion. If a later edit reaches for a port,
+    // a foreign channel appears in this sequence and this test fails.
+    const storage = makeStoragePort({ journal })
+    const queue = makeQueuePort({ journal })
+    const cache = makeCachePort({ journal })
+    const ctx = makeCtx({ db: db.db })
+
+    const result = await createStorageLocation(asTx(db.db), ctx, anInput())
+
+    expect(result.isOk()).toBe(true)
+    expect(journal.entries.every((e) => e.channel === 'db')).toBe(true)
+    expect(journal.ops()).toEqual(['insert'])
+    expect(storage.calls).toEqual([])
+    expect(queue.calls).toEqual([])
+    expect(cache.busts).toEqual([])
+  })
+
+  it('never opens a transaction of its own — the caller owns the boundary', async () => {
+    const journal = makeJournal()
+    const db = aDb({ journal })
+    const storage = makeStoragePort({ journal })
+    const queue = makeQueuePort({ journal })
+    const cache = makeCachePort({ journal })
+    const ctx = makeCtx({ db: db.db })
+
+    // The test opens the one and only transaction, exactly as a route would.
+    // Note `{ ...ctx, db: tx }`: a stale ctx holding the pool must never leak in.
+    await (db.db as Database).transaction(async (tx) => {
+      const result = await createStorageLocation(tx, { ...ctx, db: tx }, anInput())
+      expect(result.isOk()).toBe(true)
+    })
+
+    // One BEGIN…COMMIT pair, opened by the test. `BaseService.getTx()` would
+    // have added a SAVEPOINT here, because `NodePgTransaction.transaction()`
+    // exists in drizzle-orm 0.44 and its "am I already in a transaction?"
+    // detection branch is therefore unreachable.
+    expect(db.transactions).toBe(1)
+    expect(journal.ops('db')).toEqual(['begin', 'insert', 'commit'])
+
+    // And nothing but SQL between the two — the Phase 6 assertion, in one line.
+    expect(journal.between('begin', 'commit').every((e) => e.channel === 'db')).toBe(true)
+    expect(storage.calls).toEqual([])
+    expect(queue.calls).toEqual([])
+    expect(cache.busts).toEqual([])
+  })
+
+  it('rolls the caller transaction back by throwing, never by returning err()', async () => {
+    const journal = makeJournal()
+    const db = aDb({ journal })
+    const ctx = makeCtx({ db: db.db })
+
+    // The footgun this file's header documents: `db.transaction` rolls back on
+    // THROW. An `err()` is an ordinary resolved value, so a body that returns
+    // one commits the rows it just told the caller had failed. A caller that
+    // wants rollback has to convert — and here it does.
+    await expect(
+      (db.db as Database).transaction(async (tx) => {
+        const result = await createStorageLocation(tx, { ...ctx, db: tx }, anInput({ bucket: '' }))
+        if (result.isErr()) throw result.error
+      })
+    ).rejects.toThrow('without a bucket')
+
+    expect(journal.ops('db')).toEqual(['begin', 'rollback'])
+    expect(db.inserts).toHaveLength(0)
+  })
+
+  it('returns the persisted row on success', async () => {
+    const persisted = aStorageLocation({ id: 'loc_written' })
+    const db = aDb({ insert: [[persisted]] })
+    const ctx = makeCtx({ db: db.db })
+
+    const result = await createStorageLocation(asTx(db.db), ctx, anInput())
+
+    expect(result._unsafeUnwrap().id).toBe('loc_written')
+    expect(result._unsafeUnwrap().organizationId).toBe(TEST_IDS.organizationId)
+  })
+})
+
+describe('the transaction-only signature', () => {
+  /**
+   * The convention this whole pilot rests on, checked by `tsc` rather than by
+   * Vitest (which does not typecheck).
+   *
+   * `FilesCtx.db` is `Database | Transaction`, so a `ctx`-only signature would
+   * accept a connection pool and the write would silently stop being part of
+   * the caller's unit of work. A bare `Transaction` slot must reject a pool —
+   * if `Database` ever becomes assignable to it, this constant's type flips to
+   * `false` and the assignment below stops compiling.
+   */
+  it('rejects a Database in the tx slot at compile time', () => {
+    type TxSlot = Parameters<typeof createStorageLocation>[0]
+    const poolIsRejected: Database extends TxSlot ? false : true = true
+
+    expect(poolIsRejected).toBe(true)
+  })
+})

--- a/packages/lib/src/files/storage/locations.ts
+++ b/packages/lib/src/files/storage/locations.ts
@@ -1,0 +1,214 @@
+// packages/lib/src/files/storage/locations.ts
+
+/**
+ * `StorageLocation` writes.
+ *
+ * This is the Phase-2 **write pilot**: the worked example of the third
+ * signature shape in `files/ctx.ts` (`fn(tx, ctx, input)`), and the single
+ * place a `StorageLocation` row may be created from.
+ *
+ * ## Why `tx` is positional, first, and separate from `ctx`
+ *
+ * `FilesCtx.db` is `Database | Transaction`. That union is what lets a *read*
+ * run unchanged on a pool or inside a transaction — and it is exactly why a
+ * `ctx` alone **cannot** express "this must be inside a transaction": a
+ * connection pool satisfies the union and typechecks into it, and the
+ * multi-statement invariant the caller thought it had silently stops existing.
+ *
+ * A bare `tx: Transaction` slot rejects a pool at compile time. That is the
+ * entire reason for the extra parameter, and it is the property this pilot
+ * exists to demonstrate. Callers inside a transaction body pass
+ * `{ ...ctx, db: tx }` for any nested `ctx`-taking read, so a stale pool can
+ * never leak into the body either.
+ *
+ * ## This function never opens a transaction
+ *
+ * No `getTx`, no `tx.transaction(...)`, no savepoints. The caller owns the
+ * `BEGIN…COMMIT` boundary (`plans/attachments/06-transactions-and-jobs.md`
+ * §6.1). `BaseService.getTx()` tried to *detect* whether it was already inside
+ * one; in drizzle-orm 0.44 `NodePgTransaction.transaction()` exists and issues
+ * `SAVEPOINT`, so the detection branch is unreachable and an avatar upload
+ * really runs `BEGIN → INSERT → SAVEPOINT → SAVEPOINT → RELEASE → RELEASE →
+ * COMMIT` for work where nothing needs partial rollback.
+ *
+ * ## This function performs no non-database I/O
+ *
+ * No S3 call, no queue write, no cache bust, no credential fetch — which is why
+ * it takes no `FilesDeps` at all. The signature is the guarantee: there is
+ * nothing here to call. `StorageManager.prepareLocationMetadata`, the code this
+ * replaces, could reach `getProviderAuth()` → `revealSecrets()` (a database
+ * read plus a decrypt) to guess a bucket, *while holding an open write
+ * transaction*. Requiring `bucket` on the input deletes that path rather than
+ * moving it.
+ *
+ * ## `Result` and rollback do not compose — the guard sits at the boundary
+ *
+ * `db.transaction` rolls back on **throw**. Returning `err()` does **not** roll
+ * back: an `err()` is an ordinary resolved value, the transaction body
+ * completes normally, and the caller commits the very rows it was told failed
+ * to write.
+ *
+ * So the body below throws `AuxxError` subclasses, and {@link guard} converts
+ * at the exported boundary — *outside* any transaction the caller opened. Never
+ * push the guard inward into a transaction body, and never return `err()` from
+ * inside one. This is the single easiest way to reintroduce a bug in this file.
+ */
+
+import type { Transaction } from '@auxx/database'
+import { schema } from '@auxx/database'
+import type { StorageLocationEntity } from '@auxx/database/types'
+import type { Result } from 'neverthrow'
+import { AuxxError, BadRequestError } from '../../errors'
+import type { ProviderId } from '../adapters/base-adapter'
+import type { FilesCtx } from '../ctx'
+import { guard } from '../guard'
+
+/**
+ * Providers a `StorageLocation` may be created for.
+ *
+ * Mirrors `StorageManager.adapters` — the registry `isProviderAvailable()`
+ * consults — which today contains `S3` alone; the other five `StorageProvider`
+ * enum members are commented out there and have no adapter. Kept as a local
+ * constant rather than reaching into `StorageManager` because that would mean
+ * constructing a collaborator to answer a question that is pure data. Phase 3
+ * should lift the registry to a module-level const both can read; until then
+ * the drift risk is real and is recorded here deliberately.
+ */
+const SUPPORTED_PROVIDERS: ReadonlySet<ProviderId> = new Set<ProviderId>(['S3'])
+
+/**
+ * Everything needed to persist one `StorageLocation` row.
+ *
+ * Two fields are deliberately shaped against the legacy request type this
+ * replaces (`CreateStorageLocationRequest`):
+ *
+ * - **`bucket` is required.** Bugs #1816/#1817/#1818 were all one bug: the
+ *   bucket was optional, a write door omitted it, and the row was persisted
+ *   without it. `deleteByKey` then falls back to `S3_PRIVATE_BUCKET`, S3 answers
+ *   `204 No Content` for a delete of a key that is not in the bucket you named,
+ *   and the object leaks with no error anywhere. A row you cannot delete by key
+ *   is not a row worth writing, so the type refuses to describe one.
+ * - **There is no `organizationId`.** Scope comes from `ctx.organizationId` and
+ *   is never taken from the input, so a caller cannot write a row into an
+ *   organization it is not acting for.
+ *
+ * There is no `visibility` either: it existed solely to *guess* a bucket when
+ * none was supplied, and a required `bucket` makes it dead weight.
+ */
+export interface CreateStorageLocationInput {
+  provider: ProviderId
+  /** Provider-side identifier — for S3, the object key. */
+  externalId: string
+  /**
+   * The bucket the object actually lives in. Required: see the type's docs.
+   * Lands in the persisted `metadata`, which is where every adapter reads it.
+   */
+  bucket: string
+  /** Public URL, when the object has one. Empty string when it does not. */
+  externalUrl?: string
+  /** Provider revision marker — for S3, the ETag. */
+  externalRev?: string
+  /** Credential the object was written with. Absent means platform storage. */
+  credentialId?: string
+  size?: number
+  mimeType?: string
+  /** Provider-specific extras. `bucket` and `key` are normalised over the top. */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Normalise the metadata blob that gets persisted with the row.
+ *
+ * `bucket` is written last and unconditionally, so an inherited
+ * `metadata.bucket` from an upstream payload can never win over the bucket the
+ * caller actually uploaded to — that mismatch is what a wrong-bucket delete
+ * looks like from the database side.
+ *
+ * `key` is defaulted from `externalId` because that is where the adapters look
+ * for it, and every S3 location has had it since `prepareLocationMetadata`
+ * started adding it.
+ */
+function normalizeLocationMetadata(input: CreateStorageLocationInput): Record<string, unknown> {
+  const metadata: Record<string, unknown> = { ...(input.metadata ?? {}) }
+  metadata.bucket = input.bucket
+  if (metadata.key === undefined) metadata.key = input.externalId
+  return metadata
+}
+
+/**
+ * Validate the input. Throws — never returns `Result` — so that a failure
+ * inside a caller's transaction body rolls the transaction back.
+ */
+function assertValidInput(input: CreateStorageLocationInput): void {
+  if (!SUPPORTED_PROVIDERS.has(input.provider)) {
+    throw new BadRequestError(`Storage provider ${input.provider} is not available`)
+  }
+  if (!input.externalId) {
+    throw new BadRequestError('Storage location externalId is required')
+  }
+  if (!input.bucket) {
+    throw new BadRequestError(
+      `Storage location for ${input.externalId} was created without a bucket; ` +
+        'a bucket-less row cannot be deleted by key (S3 answers 204 for a key that is not there)'
+    )
+  }
+  if (input.size !== undefined && input.size < 0) {
+    throw new BadRequestError('Storage location size must be non-negative')
+  }
+}
+
+/**
+ * Create one `StorageLocation` row inside a transaction the caller owns.
+ *
+ * Replaces `StorageManager.createStorageLocation` + `StorageLocationService.create`,
+ * which together validated the provider, normalised metadata, and inserted —
+ * except that the bucket was optional the whole way down, so two write doors
+ * (`users/user-avatar-service.ts` and `StorageLocationService.create`/`bulkCreate`)
+ * routinely produced rows nothing could delete by key. Requiring `bucket` on
+ * {@link CreateStorageLocationInput} is what closes that, and the reason this
+ * function is the only sanctioned way to write the row.
+ *
+ * @param tx Positional and first **on purpose**, and deliberately not folded
+ *   into `ctx`: `FilesCtx.db` is `Database | Transaction`, so a pool would
+ *   typecheck into a `ctx`-only signature and the write would silently stop
+ *   being part of the caller's unit of work. A bare `Transaction` slot rejects
+ *   a pool at compile time. This function never calls `tx.transaction(...)`.
+ * @param ctx Scope only. `ctx.db` is ignored here — the statement runs on `tx`,
+ *   which is the whole point — and `ctx.organizationId` is the row's owner.
+ * @param input The row to write. See {@link CreateStorageLocationInput}.
+ */
+export async function createStorageLocation(
+  tx: Transaction,
+  ctx: FilesCtx,
+  input: CreateStorageLocationInput
+): Promise<Result<StorageLocationEntity, AuxxError>> {
+  return guard(
+    async () => {
+      assertValidInput(input)
+
+      const [location] = await tx
+        .insert(schema.StorageLocation)
+        .values({
+          provider: input.provider,
+          externalId: input.externalId,
+          externalUrl: input.externalUrl ?? '',
+          externalRev: input.externalRev ?? '',
+          // Scope is the caller's, never the payload's.
+          organizationId: ctx.organizationId,
+          credentialId: input.credentialId ?? null,
+          size: input.size ?? null,
+          mimeType: input.mimeType ?? null,
+          metadata: normalizeLocationMetadata(input),
+        })
+        .returning()
+
+      if (!location) {
+        throw new AuxxError('Storage location insert returned no row')
+      }
+
+      return location
+    },
+    'Failed to create storage location',
+    { provider: input.provider, externalId: input.externalId, bucket: input.bucket }
+  )
+}

--- a/packages/lib/src/files/storage/ports.ts
+++ b/packages/lib/src/files/storage/ports.ts
@@ -1,0 +1,355 @@
+// packages/lib/src/files/storage/ports.ts
+
+/**
+ * The side-effecting seams of `files/`, expressed as interfaces.
+ *
+ * Every port here is something a `files/` function used to *construct* for
+ * itself (`new StorageManager()`, `getQueue(Queues.thumbnailQueue)`), which is
+ * why nothing in this subsystem could be tested without `vi.mock`. They arrive
+ * as {@link FilesDeps} instead, so a test supplies a plain object literal and a
+ * production caller supplies the wiring below.
+ *
+ * ## `bucket` is required, everywhere it can be known
+ *
+ * Every parameter type that addresses an object carries a **required**
+ * `bucket`. This is not tidiness. Bugs #1816/#1817/#1818 all had the same
+ * shape: `bucket` was optional, the call site omitted it, and the resolver fell
+ * back to `S3_PRIVATE_BUCKET`. S3 answers `204 No Content` for a delete of a key
+ * that is not in the bucket you named, and `NoSuchUpload` for a part presigned
+ * against the wrong bucket — so a PUBLIC upload's object leaked with no error
+ * anywhere. An optional `bucket` on a port method is a regression.
+ */
+
+import { revealSecrets } from '@auxx/credentials/store'
+import { BadRequestError, UnauthorizedError } from '../../errors'
+import type { OrphanedStorageObjectJobData } from '../../jobs/maintenance/orphaned-storage-object-job'
+import type {
+  DownloadRef,
+  FileMetadata,
+  PresignedUpload,
+  ProviderAuth,
+  ProviderId,
+  StorageLocationRef,
+} from '../adapters/base-adapter'
+import { S3Adapter } from '../adapters/s3-adapter'
+import type { GenerateThumbnailPayload } from '../core/thumbnail-types'
+import type { UploadPreparedConfig } from '../upload/init-types'
+import { createStorageManager } from './storage-manager'
+
+// ============= Parameter types =============
+
+/**
+ * Addresses exactly one object in a bucket-addressed provider.
+ *
+ * The base of every object-identifying param type, so `bucket` cannot be
+ * forgotten on a new one. `credentialId` stays optional because platform
+ * storage has none — the adapter resolves it from config instead.
+ */
+export interface ObjectRef {
+  provider: ProviderId
+  /** Required: a wrong-bucket delete 204s and a wrong-bucket part presign fails. */
+  bucket: string
+  key: string
+  credentialId?: string
+}
+
+/**
+ * The full prepared upload config, because presigning is where the upload
+ * policy is enforced (key prefix, TTL ceiling, size range, mime allow-list).
+ *
+ * Deliberately not an {@link ObjectRef}: `UploadPreparedConfig` already carries
+ * `provider`, a required `bucket`, and the key under its own name
+ * (`storageKey`), and re-shaping it here would mean two vocabularies for one
+ * object. The pure `buildUploadConfig` produces this value; the port consumes
+ * it unchanged.
+ */
+export type PresignUploadParams = UploadPreparedConfig & {
+  /** Extra S3 object metadata, merged over the org/uploader/entity trio. */
+  metadata?: Record<string, string>
+}
+
+/** One part of an in-flight multipart upload. `bucket` must be the bucket the upload was started in. */
+export interface PresignPartParams extends ObjectRef {
+  uploadId: string
+  partNumber: number
+  size?: number
+}
+
+/** Finalises a multipart upload. `bucket` must be the bucket the upload was started in. */
+export interface CompleteMultipartParams extends ObjectRef {
+  uploadId: string
+  parts: Array<{ partNumber: number; etag: string }>
+}
+
+/** Metadata probe. `versionId` targets a specific object version where the provider has them. */
+export interface HeadParams extends ObjectRef {
+  versionId?: string
+}
+
+/** Provider-neutral object metadata. Aliased so call sites read as storage, not adapter, vocabulary. */
+export type HeadResult = FileMetadata
+
+/** Server-side write of content the server itself produced (thumbnails, generated PDFs). */
+export interface PutObjectParams extends ObjectRef {
+  content: Buffer | NodeJS.ReadableStream
+  mimeType?: string
+  size?: number
+  metadata?: Record<string, string>
+}
+
+/** What the provider reports back about a written object. */
+export interface PutResult {
+  etag?: string
+  versionId?: string
+  size?: number
+}
+
+/** Server-side read, whole-object. `versionId` targets a specific object version. */
+export interface GetObjectParams extends ObjectRef {
+  versionId?: string
+}
+
+/**
+ * Compensation / lifecycle delete.
+ *
+ * No `versionId`: the underlying `deleteByKey` path addresses the current
+ * object only, and a silently-ignored `versionId` would be worse than not
+ * offering one.
+ */
+export type DeleteParams = ObjectRef
+
+/** Presigned client download, with the disposition the browser should honour. */
+export interface DownloadParams extends ObjectRef {
+  versionId?: string
+  ttlSec?: number
+  disposition?: 'inline' | 'attachment'
+  filename?: string
+  mimeType?: string
+}
+
+/**
+ * Everything needed to render a public URL for an object.
+ *
+ * `region` is optional and exists so the caller — which has already read the
+ * `StorageLocation` row — can supply it instead of the port going and fetching
+ * a credential. That is what keeps {@link StoragePort.buildExternalUrl}
+ * synchronous.
+ */
+export interface ExternalUrlParams {
+  provider: ProviderId
+  bucket: string
+  key: string
+  region?: string
+}
+
+/** The thumbnail queue's job payload, reused verbatim so the port cannot drift from the worker. */
+export type EnqueueThumbnailParams = GenerateThumbnailPayload
+
+/** The orphaned-object cleanup job payload, with `bucket` promoted to required. */
+export type EnqueueStorageCleanupParams = Omit<OrphanedStorageObjectJobData, 'bucket'> & {
+  /** Required here even though the job accepts it optionally: see the file header. */
+  bucket: string
+}
+
+// ============= Ports =============
+
+/**
+ * Object storage, addressed by bucket + key. Knows nothing about the database.
+ *
+ * Every method is bucket/key-addressed rather than `storageLocationId`-addressed
+ * (which is how `StorageManager` mostly reads today) precisely so this port
+ * cannot do a database read behind the caller's back. Resolving a
+ * `StorageLocation` row into a bucket and key is the caller's job, on `ctx.db`.
+ */
+export interface StoragePort {
+  presignUpload(p: PresignUploadParams): Promise<PresignedUpload>
+  presignPart(p: PresignPartParams): Promise<PresignedUpload>
+  completeMultipart(p: CompleteMultipartParams): Promise<{ etag: string; size?: number }>
+  head(p: HeadParams): Promise<HeadResult>
+  putObject(p: PutObjectParams): Promise<PutResult>
+  getObject(p: GetObjectParams): Promise<Buffer>
+  streamObject(p: GetObjectParams): Promise<NodeJS.ReadableStream>
+  deleteObject(p: DeleteParams): Promise<void>
+  presignDownload(p: DownloadParams): Promise<DownloadRef>
+  /**
+   * Synchronous on purpose.
+   *
+   * This is called **inside** an open `db.transaction` on the upload-complete
+   * path. A `Promise`-returning version invites an adapter lookup or a
+   * credential fetch there, which is network I/O holding a write transaction
+   * open. For S3 it is pure string work over config (`CDN_URL`, else
+   * virtual-hosted style), so the sync signature costs nothing and forecloses
+   * the mistake. A future adapter that genuinely needs I/O must expose its own
+   * async method, and the caller resolves it *before* opening the transaction.
+   */
+  buildExternalUrl(p: ExternalUrlParams): string
+}
+
+/**
+ * Background work, so a function that needs a job enqueued does not reach for
+ * `getQueue(...)` and bind itself to a live Redis connection.
+ *
+ * Both methods return the job id, which is what lets a test assert *which* job
+ * was scheduled without a queue running.
+ */
+export interface QueuePort {
+  enqueueThumbnail(p: EnqueueThumbnailParams): Promise<string>
+  enqueueStorageCleanup(p: EnqueueStorageCleanupParams): Promise<string>
+}
+
+/**
+ * Post-commit invalidation and realtime notification.
+ *
+ * Intentionally one stringly-typed method rather than a per-event surface: the
+ * ports exist to make ordering assertable ("no bust between BEGIN and COMMIT"),
+ * not to type the event catalogue, which lives with the events module.
+ */
+export interface CachePort {
+  bust(event: string, payload: Record<string, unknown>): Promise<void>
+}
+
+// ============= Production implementation =============
+
+/**
+ * The S3 {@link StoragePort}, wired to the existing adapter and
+ * `StorageManager`.
+ *
+ * This is the proof the interface is implementable against real code rather
+ * than a shape invented for tests. It delegates rather than reimplements:
+ *
+ * - Policy-enforcing upload operations go through `StorageManager`, because the
+ *   policy check (`enforcePolicy`) lives there and must not be bypassed.
+ * - `deleteObject` goes through `StorageManager.deleteByKey`, because that is
+ *   where the "no bucket supplied" fallback is logged.
+ * - Object reads/writes go straight to the adapter, because every
+ *   `StorageManager` equivalent (`getFileMetadata`, `getContent`,
+ *   `uploadContent`) is `storageLocationId`-addressed and does its own database
+ *   work — exactly what this port must not do.
+ *
+ * @param organizationId Required only when a call passes a `credentialId`;
+ *   platform storage resolves its auth from config and needs no org.
+ */
+export function createS3StoragePort(organizationId?: string): StoragePort {
+  const manager = createStorageManager(organizationId)
+  const adapter = new S3Adapter()
+
+  /**
+   * Resolve provider auth with the bucket pinned to the caller's choice.
+   *
+   * Pinning is the whole trick: the adapter's `parseS3Location`,
+   * `createS3Client` and `buildExternalUrl` all read `auth.bucket`, and leaving
+   * it to resolve from config is how objects ended up in — and deletes aimed
+   * at — the wrong bucket.
+   */
+  async function resolveAuth(bucket: string, credentialId?: string): Promise<ProviderAuth> {
+    if (credentialId) {
+      if (!organizationId) {
+        throw new BadRequestError(
+          `credentialId '${credentialId}' was supplied but the storage port has no organizationId`
+        )
+      }
+      const revealed = await revealSecrets(credentialId, organizationId)
+      if (revealed.isErr()) {
+        throw new UnauthorizedError(
+          `Failed to load S3 credential '${credentialId}': ${revealed.error.message}`
+        )
+      }
+      const { record, secrets } = revealed.value
+      return { ...record.metadata, ...secrets, bucket } as ProviderAuth
+    }
+
+    const platformAuth = adapter.resolvePlatformAuth()
+    if (!platformAuth) {
+      throw new BadRequestError(
+        'S3 platform storage is not configured (set S3_REGION and S3_PRIVATE_BUCKET) and no credentialId was supplied'
+      )
+    }
+    return { ...platformAuth, bucket }
+  }
+
+  /** Build the adapter's location shape with the bucket on metadata, where the adapter looks for it. */
+  function locationRef(p: ObjectRef & { versionId?: string }): StorageLocationRef {
+    return {
+      provider: p.provider,
+      externalId: p.key,
+      credentialId: p.credentialId,
+      metadata: { bucket: p.bucket, key: p.key, ...(p.versionId && { versionId: p.versionId }) },
+    }
+  }
+
+  return {
+    presignUpload: (p) => manager.generatePresignedUploadUrl(p),
+
+    presignPart: (p) =>
+      manager.generatePartUploadUrl({
+        provider: p.provider,
+        key: p.key,
+        uploadId: p.uploadId,
+        partNumber: p.partNumber,
+        size: p.size,
+        credentialId: p.credentialId,
+        bucket: p.bucket,
+      }),
+
+    completeMultipart: (p) =>
+      manager.completeMultipartUploadOnly({
+        provider: p.provider,
+        key: p.key,
+        uploadId: p.uploadId,
+        parts: p.parts,
+        credentialId: p.credentialId,
+        bucket: p.bucket,
+      }),
+
+    deleteObject: (p) =>
+      manager.deleteByKey({
+        provider: p.provider,
+        key: p.key,
+        credentialId: p.credentialId,
+        bucket: p.bucket,
+      }),
+
+    head: async (p) => adapter.getMeta(locationRef(p), await resolveAuth(p.bucket, p.credentialId)),
+
+    putObject: async (p) =>
+      adapter.putObject({
+        key: p.key,
+        content: p.content,
+        mimeType: p.mimeType,
+        size: p.size,
+        metadata: p.metadata,
+        bucket: p.bucket,
+        auth: await resolveAuth(p.bucket, p.credentialId),
+      }),
+
+    streamObject: async (p) =>
+      adapter.openDownloadStream(locationRef(p), await resolveAuth(p.bucket, p.credentialId)),
+
+    getObject: async (p) => {
+      const stream = await adapter.openDownloadStream(
+        locationRef(p),
+        await resolveAuth(p.bucket, p.credentialId)
+      )
+      const chunks: Buffer[] = []
+      return new Promise<Buffer>((resolve, reject) => {
+        stream.on('data', (chunk: Buffer) => chunks.push(chunk))
+        stream.on('end', () => resolve(Buffer.concat(chunks)))
+        stream.on('error', reject)
+      })
+    },
+
+    presignDownload: async (p) =>
+      adapter.getDownloadRef(locationRef(p), await resolveAuth(p.bucket, p.credentialId), {
+        ttlSec: p.ttlSec,
+        disposition: p.disposition,
+        filename: p.filename,
+        mimeType: p.mimeType,
+      }),
+
+    buildExternalUrl: (p) =>
+      adapter.buildExternalUrl(p.key, {
+        bucket: p.bucket,
+        ...(p.region && { region: p.region }),
+      } as ProviderAuth),
+  }
+}

--- a/packages/lib/src/files/storage/storage-location-service.ts
+++ b/packages/lib/src/files/storage/storage-location-service.ts
@@ -1,5 +1,5 @@
 // packages/lib/src/files/storage/location-service.ts
-import { type Database, database as db, schema } from '@auxx/database'
+import { type Database, database as db, schema, type Transaction } from '@auxx/database'
 import type {
   CreateStorageLocationInput,
   StorageLocationEntity,
@@ -7,6 +7,16 @@ import type {
 } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { and, count, desc, eq, inArray, isNotNull, isNull, lt, sql, sum } from 'drizzle-orm'
+import { BadRequestError } from '../../errors'
+import type { ProviderId } from '../adapters/base-adapter'
+// Aliased because `CreateStorageLocationInput` is already taken in this file by
+// Drizzle's `$inferInsert` type for the same table — two different "create
+// input" names for one row is exactly the rot the lib guide warns about, and it
+// resolves when this legacy file is deleted.
+import {
+  type CreateStorageLocationInput as CreateStorageLocationParams,
+  createStorageLocation,
+} from './locations'
 
 // NOTE: StorageLocationService focuses only on database operations
 const logger = createScopedLogger('storage-location-service')
@@ -250,6 +260,12 @@ export class StorageLocationService {
    *
    * @see {@link validate} for validation rules
    * @see {@link update} for modifying existing locations
+   *
+   * @deprecated Use `createStorageLocation(tx, ctx, input)` from
+   * `files/storage/locations.ts`. This method is a strangler facade kept only
+   * so existing call sites keep compiling; it is deleted in Phase 6 (PR 6a).
+   * The new function requires a `bucket` and takes its organization scope from
+   * `ctx`, which is what this signature cannot express.
    */
   async create(
     data: CreateStorageLocationRequest,
@@ -259,36 +275,59 @@ export class StorageLocationService {
       provider: data.provider,
       hasCredential: !!data.credentialId,
     })
-    // Validate required fields based on provider
-    const validation = StorageLocationService.validate(data)
-    if (!validation.isValid) {
-      throw new Error(`Invalid storage location data: ${validation.errors.join(', ')}`)
+
+    // The legacy request type carries the bucket buried in `metadata` and the
+    // organization as an optional field. Both are required by the function
+    // below, so the facade is where the shapes have to meet.
+    const metadata = (data.metadata ?? {}) as Record<string, unknown>
+    const bucket = typeof metadata.bucket === 'string' ? metadata.bucket : ''
+    if (!data.organizationId) {
+      throw new BadRequestError(
+        `Storage location for ${data.externalId} was created without an organizationId`
+      )
     }
-    try {
-      const dbToUse = dbInstance || db
-      const [location] = await dbToUse
-        .insert(schema.StorageLocation)
-        .values({
-          provider: data.provider,
-          externalId: data.externalId,
-          externalUrl: data.externalUrl,
-          organizationId: data.organizationId || null,
-          credentialId: data.credentialId,
-          size: data.size || null,
-          mimeType: data.mimeType || null,
-          metadata: data.metadata || {},
-          externalRev: data.externalRev,
-        })
-        .returning()
-      if (!location) {
-        throw new Error('Storage location insert returned no row')
-      }
-      logger.info('Storage location created successfully', { id: location.id })
-      return location
-    } catch (error) {
-      logger.error('Failed to create storage location', { error, data })
-      throw error
+
+    const input: CreateStorageLocationParams = {
+      provider: data.provider as ProviderId,
+      externalId: data.externalId,
+      bucket,
+      externalUrl: data.externalUrl,
+      externalRev: data.externalRev,
+      credentialId: data.credentialId,
+      size: data.size,
+      mimeType: data.mimeType,
+      metadata,
     }
+    // `userId` is `''` because this legacy request shape has no actor to give
+    // and the function does not record one. `FilesCtx` requires the field, so
+    // the facade has to invent it — one more reason this shim is temporary.
+    const ctx = { db: dbInstance ?? db, organizationId: data.organizationId, userId: '' }
+
+    // Two branches, because the optional `dbInstance` cannot be reconciled with
+    // a required `Transaction` any other way:
+    //
+    // - Nothing supplied: open a transaction. Honest, no cast, and semantically
+    //   identical to the single implicit transaction a bare INSERT already ran.
+    // - Something supplied: production reaches this through
+    //   `StorageManager.createStorageLocation(params, { tx })`, where `tx` is
+    //   typed `any` and is a real `NodePgTransaction` at runtime — but the
+    //   parameter here is typed `Database`, so the compiler cannot see that.
+    //   The cast is the receipt for that unsoundness, and it is the honest
+    //   answer: the legacy signature IS unsound, and no arrangement of the
+    //   facade makes it sound. The alternative — calling `.transaction()` on it
+    //   — issues a `SAVEPOINT` on the hottest write path in the app, which is
+    //   precisely the noise Phase 6 exists to delete. The cast disappears with
+    //   this method.
+    const result = dbInstance
+      ? await createStorageLocation(dbInstance as unknown as Transaction, ctx, input)
+      : await db.transaction((tx) => createStorageLocation(tx, { ...ctx, db: tx }, input))
+
+    if (result.isErr()) {
+      logger.error('Failed to create storage location', { error: result.error, data })
+      throw result.error
+    }
+    logger.info('Storage location created successfully', { id: result.value.id })
+    return result.value
   }
   /**
    * Get a storage location by ID

--- a/packages/lib/src/files/storage/storage-manager.ts
+++ b/packages/lib/src/files/storage/storage-manager.ts
@@ -802,6 +802,27 @@ export class StorageManager {
 
   /**
    * Create a new storage location record (enhanced to support transactions)
+   *
+   * @deprecated Use `createStorageLocation(tx, ctx, input)` from
+   * `files/storage/locations.ts`, which requires a `bucket` and takes its
+   * organization scope from `ctx`. This method is a strangler facade, deleted
+   * in Phase 6 (PR 6a) together with the route call sites that still pass
+   * `{ tx }`.
+   *
+   * **The delegation is transitive**, not direct: this still calls
+   * `storageLocationService.create`, which is now itself a thin facade over the
+   * new function. That is not a preference — `__tests__/policy-enforcement.test.ts`
+   * replaces the whole `storage-location-service` module with `vi.mock` and
+   * asserts `storageLocationService.create` was called from `uploadContent`, and
+   * `src/test/setup.ts` mocks `@auxx/database` package-wide with
+   * `transaction: vi.fn()`, so a direct call could neither be observed nor even
+   * run there. One implementation, two facades in front of it; the middle hop
+   * goes away with them.
+   *
+   * Everything below the `prepareLocationMetadata` call is now redundant with
+   * the new function's own validation, and is kept only so this method's
+   * throw-shape (`StorageAdapterError` via `handleStorageError`) is unchanged
+   * for its existing callers.
    */
   async createStorageLocation(
     params: {

--- a/packages/lib/vitest.config.ts
+++ b/packages/lib/vitest.config.ts
@@ -46,6 +46,11 @@ export default defineConfig(({ mode }) => {
         'src/test/setup.ts',
         'src/test/utils.ts',
         '**/*.config.*',
+        // Shared test doubles/fixtures that live under a `__tests__/` folder.
+        // The second `include` pattern above matches every file in such a
+        // folder, so without this a helper module is collected as a suite and
+        // fails with "No test suite found in file".
+        'src/**/__tests__/support/**',
         // DB-backed integration tests — run via vitest.integration.config.ts
         // (this config mocks @auxx/database, so they can't work here).
         'src/**/*.int.test.*',


### PR DESCRIPTION
Phase 2 of the `files/` refactor. **No existing service is converted** — this is the seam phases 3–5 are written against, plus two pilots that prove it works before 100+ call sites copy the shape.

## Why

`packages/lib/src/files/**` binds `db` at module scope via `BaseService.defaultDatabase()`, and its services construct their own collaborators (`new StorageManager()`, `getQueue(...)`). Nothing is injectable. The measurable cost: **157 files** in this repo reach for `vi.mock('@auxx/database')`, and testing anything here runs 90–120 lines of hoisted Drizzle-chain mocks before the first assertion.

Both pilot tests here add **zero `vi.mock` calls**. Neither imports `vi` at all.

## What's in it

`ctx.ts` — `FilesCtx { db, organizationId }`, `FilesDeps`, and the three signature shapes documented in the one place people will look. `guard.ts` — the neverthrow wrapper, copied from `snippets/` per the lib guide. `storage/ports.ts` — the ports plus `createS3StoragePort`, a **real** implementation, because an interface nothing implements isn't proven implementable. `__tests__/support/` — recording doubles typed off the real interfaces so they can't drift.

Two decisions worth review:

**`bucket` is structurally unforgettable.** Every object-addressing param extends an `ObjectRef` with `bucket` required. Three production bugs (#1816/#1817/#1818) came from it being optional and falling back to `S3_PRIVATE_BUCKET` — and S3 answers **204** for deleting a key that isn't in the bucket you named, so objects leaked with no error at all. A param type added in phase 5 can't quietly omit it now.

**`makeJournal()` solves phase 6's hardest assertion up front.** One monotonic sequence shared by the db stub and all three port doubles, so `journal.between('begin','commit')` proves no storage, queue or cache call happened inside a transaction.

## The pilots earned their keep

They were briefed that a friction report counts as success. Three findings changed the contract:

**`FilesCtx.userId` is gone.** Both pilots — one read, one write — independently had to fabricate `''` to satisfy it. Lib performs zero access checks, so a read has no reader for an actor, and many production sites construct `MediaAssetService(orgId)` with none at all. `userId?: string` would only move the sentinel behind a `?` until something wrote it to a NOT NULL `createdById`. A function that records an actor now takes it in its own `input`, where it's required and unmissable.

**`deps` is a narrowed slice, not the bundle.** `Pick<FilesDeps, 'storage'>`. A full `FilesDeps` lies — this read can't enqueue a job — and it would cost production a `QueuePort`, i.e. a live Redis connection, just to presign a URL. The rejected alternative (`opts.storage` defaulting to `createS3StoragePort`) is the same defaulting this phase exists to delete: `BaseService`'s `db = defaultDatabase()` was *also* "trivially overridable", and all ~124 call sites stayed on the pool.

**The transaction slot genuinely holds.** Passing a `Database` where `Transaction` is required is rejected with TS2345 — neither arm of `Database` has `rollback()`, so it isn't structurally a `PgTransaction`. The whole convention rests on that, so the test file carries a tsc-checked guard: if it ever stops being true, the build breaks rather than the convention dying silently.

## A bug the write pilot found

Requiring `bucket` **deletes** a path rather than porting it. `prepareLocationMetadata` → `resolveS3BucketForLocation` → `getProviderAuth` → `revealSecrets` is a database read **plus a decrypt**, swallowed into a `logger.warn` on failure — performed solely to *guess* a bucket the caller usually already had, while the upload-completion transaction is open. §10.2 documented one credential fetch in that transaction; this is a second one it missed. The new function does no I/O at all.

## Behaviour changes

- `StorageLocationService.create` now **throws** instead of writing a bucket-less (undeletable) row. The only reachable caller that omitted one is `completeMultipartUpload`, which has **zero callers repo-wide**; both live routes pass a bucket.
- It also throws on a missing `organizationId` rather than writing `null`.

## Known compromises, stated plainly

- The legacy facade's optional-transaction parameter is **unsound**, and one cast marks it: the handle is typed `Database` but is a real transaction at runtime. Calling `.transaction()` on it instead would add a `SAVEPOINT` to the upload-complete route — the exact noise phase 6 removes — so a localised, commented cast in a `@deprecated` method was the better trade. It disappears with the method.
- `StorageManager.createStorageLocation` delegates **transitively** through `StorageLocationService`, not directly, because `policy-enforcement.test.ts` asserts on the latter being called. Direct delegation needs that assertion moved first.
- No production `QueuePort`/`CachePort` yet — deliberate. The two existing thumbnail-enqueue sites *disagree* on job options (one uses a deterministic `jobId` plus a Redis thundering-herd latch, the other doesn't), and picking one is a phase-5 policy call, not something to decide silently here.

## Phase-3 prerequisites this surfaced

- **`storage-location-service.ts` must take its `db` before any other facade is written.** `ports.ts` can't be statically imported from `core/` because it reaches that file's module-scope `import { database as db }` — the collection hazard documented on `base-service.ts`. The read facade needed a cached dynamic import; every future facade repeats that dance until it's fixed.
- Extract `storage/auth.ts` — `getProviderAuth`/`getAdapter` are private, so `createS3StoragePort` duplicates ~20 lines of auth resolution.
- Lift the provider registry to a module-level const — `isProviderAvailable` reads a `private static`, so the write pilot duplicated it as a local set. Real drift risk.

## Verification

189 tests green in `packages/lib` (`src/files` + `src/jobs/maintenance`), up from 163. `tsc --noEmit` clean for every file in `files/`; the 29 remaining errors are the pre-existing baseline in `scripts/` and `vitest.integration.config.ts`.

One config change outside `files/`: `packages/lib/vitest.config.ts` gains a single `exclude` for `src/**/__tests__/support/**`, because the existing `__tests__/**` include pattern collects helper modules as suites and fails them with "No test suite found in file".