### PR TITLE
docs(files): announce the files/upload guide in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,39 @@ gated on inbox write alone (not `automationRules.manage`), treats
 `senderAuthenticated IS NULL` as *not* authenticated, and must never be recorded
 as `contact:unsubscribed`; dismissal is a status write, never a delete.
 
+## Files, Uploads & Storage
+
+**Before touching the upload routes, the processor registry, `StorageManager`,
+the adapters, `MediaAsset`/`FolderFile`/`Attachment`/`StorageLocation`, the
+thumbnail or cleanup jobs, or the front-end uploader, read
+`docs/files-upload-architecture-guide.md`.** It documents the three-round-trip
+presigned browser flow, the `EntityType` → processor dispatch, the five tables a
+file actually occupies, the two parallel upload doors that bypass the main path,
+and the read paths. §10–§12 are a critique, with each finding tagged FIXED or
+OPEN.
+
+Short version: a file is **`StorageLocation` (the bytes) + `MediaAsset`+version
+or `FolderFile`+version + optionally an `Attachment`** — which combination you
+get is decided by the `EntityType` the client sends, and picking the wrong one
+silently produces the wrong record; **`bucket` is never optional** anywhere in
+the storage layer, because S3 answers **204** for deleting a key that is not in
+the bucket you named, so a wrong bucket leaks objects with no error (this caused
+three separate production bugs); `MediaAsset` and `FolderFile` are different
+tables and the legacy **`File` table is empty and unused** — joining it is a
+silent no-op that once made the storage quota read zero forever; and post-commit
+work (thumbnails, cache busts) must be enqueued **after** `COMMIT`, never from
+inside a processor, because the enqueue resolves its source on a different
+connection and cannot see uncommitted rows.
+
+**New code in `packages/lib/src/files/**` uses the functional contract in
+`packages/lib/src/files/ctx.ts`** — `ctx: FilesCtx` first for db-touching
+functions, `tx: Transaction` positional-first for transaction-only ones, a
+narrowed `Pick<FilesDeps, …>` for collaborators, and never a service class.
+`assets/download.ts` and `storage/locations.ts` are the worked examples; the
+test doubles in `files/__tests__/support/` mean a new test needs **zero
+`vi.mock`**. The refactor converting the remaining service classes is planned in
+`plans/attachments/` (untracked).
+
 ## Duplicate Detection
 
 **Before touching the dedup engine, the duplicate scan job, `DuplicateSuggestion`

--- a/packages/lib/src/entity-instances/__tests__/archive-session-doors.int.test.ts
+++ b/packages/lib/src/entity-instances/__tests__/archive-session-doors.int.test.ts
@@ -1,0 +1,173 @@
+// packages/lib/src/entity-instances/__tests__/archive-session-doors.int.test.ts
+//
+// DB-backed behaviour test (vitest.integration.config.ts → auxx_test) for the archive/
+// restore row write's two door decisions in
+// plans/events/03-write-context-and-batch-lane-plan.md:
+//
+//   D-7 — `updatedAt` is stamped EXPLICITLY (the `$onUpdate` auto-bump is gone), so
+//         archive/restore must stamp it itself or the content change becomes invisible.
+//   D-1 × seed — archive/restore advances `lastActivityAt` because it IS activity,
+//         EXCEPT under a seed write session, where the door matrix says
+//         `lastActivityAt × seed = off` while `updatedAtStamp × seed = per-record`.
+//
+// WHY INTEGRATION. The claim is that ONE update statement writes a DIFFERENT COLUMN SET
+// depending on the ambient AsyncLocalStorage session — `updatedAt` always, `archivedAt`
+// when asked, `lastActivityAt` conditionally. `updated-at-stamp.test.ts` asserts that by
+// inspecting the object handed to a mocked `.set()`. This file asserts the stored row,
+// which is also the only way to catch the column set diverging from what the table
+// actually accepts.
+//
+// `updateEntityInstance` reads the module-level `database` singleton rather than an
+// injected db — under this config that singleton resolves from the same `.env.test`
+// DATABASE_URL the harness uses, and these tests confirm it by round-tripping rows
+// created through `getTestDb()`.
+
+import { type Database, schema } from '@auxx/database'
+import { createTestOrganization, getTestDb } from '@auxx/test-utils'
+import { eq } from 'drizzle-orm'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { interactiveSession, seedSession } from '../../resources/crud/write-origin'
+import { runWithWriteSession } from '../../resources/crud/write-session-als'
+import { updateEntityInstance } from '../update-entity-instance'
+
+const db = () => getTestDb() as never as Database
+
+interface Fixture {
+  orgId: string
+  defId: string
+}
+
+async function seed(): Promise<Fixture> {
+  const org = await createTestOrganization()
+  const [def] = await db()
+    .insert(schema.EntityDefinition)
+    .values({
+      organizationId: org.id,
+      entityType: 'contact',
+      apiSlug: 'contacts',
+      singular: 'contact',
+      plural: 'contacts',
+      updatedAt: new Date(),
+    })
+    .returning()
+  return { orgId: org.id, defId: def!.id }
+}
+
+/** An instance stamped an hour in the past, so any bump is unambiguous. */
+async function instance(f: Fixture, over: Record<string, unknown> = {}): Promise<string> {
+  const [row] = await db()
+    .insert(schema.EntityInstance)
+    .values({
+      organizationId: f.orgId,
+      entityDefinitionId: f.defId,
+      displayName: 'Ada',
+      updatedAt: new Date(Date.now() - 60 * 60 * 1000),
+      ...over,
+    })
+    .returning()
+  return row!.id
+}
+
+async function row(id: string) {
+  const [r] = await db()
+    .select()
+    .from(schema.EntityInstance)
+    .where(eq(schema.EntityInstance.id, id))
+  return r!
+}
+
+let f: Fixture
+beforeEach(async () => {
+  f = await seed()
+})
+
+describe('archive / restore row write', () => {
+  it('under an interactive session: archives, stamps updatedAt, advances lastActivityAt', async () => {
+    const id = await instance(f)
+    const before = await row(id)
+
+    const result = await runWithWriteSession(interactiveSession('user_1'), () =>
+      updateEntityInstance({ id, organizationId: f.orgId, data: { archivedAt: new Date() } })
+    )
+    expect(result.isOk()).toBe(true)
+
+    const after = await row(id)
+    expect(after.archivedAt).not.toBeNull()
+    expect(after.updatedAt.getTime()).toBeGreaterThan(before.updatedAt.getTime())
+    expect(after.lastActivityAt).not.toBeNull()
+  })
+
+  it('under a SEED session: archives and stamps updatedAt, but lastActivityAt stays untouched', async () => {
+    const id = await instance(f)
+    const before = await row(id)
+
+    const result = await runWithWriteSession(seedSession('fixture'), () =>
+      updateEntityInstance({ id, organizationId: f.orgId, data: { archivedAt: new Date() } })
+    )
+    expect(result.isOk()).toBe(true)
+
+    const after = await row(id)
+    expect(after.archivedAt).not.toBeNull()
+    // updatedAtStamp × seed = per-record — the content stamp still applies.
+    expect(after.updatedAt.getTime()).toBeGreaterThan(before.updatedAt.getTime())
+    // lastActivityAt × seed = off — seeded data is not activity.
+    expect(after.lastActivityAt).toBeNull()
+  })
+
+  it('a seed session does NOT rewind an existing lastActivityAt either', async () => {
+    const existing = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    const id = await instance(f, { lastActivityAt: existing })
+
+    await runWithWriteSession(seedSession('fixture'), () =>
+      updateEntityInstance({ id, organizationId: f.orgId, data: { archivedAt: new Date() } })
+    )
+
+    expect((await row(id)).lastActivityAt?.getTime()).toBe(existing.getTime())
+  })
+
+  it('restore is activity too — lastActivityAt advances on un-archive', async () => {
+    const id = await instance(f, { archivedAt: new Date(Date.now() - 60 * 60 * 1000) })
+
+    await runWithWriteSession(interactiveSession('user_1'), () =>
+      updateEntityInstance({ id, organizationId: f.orgId, data: { archivedAt: null } })
+    )
+
+    const after = await row(id)
+    expect(after.archivedAt).toBeNull()
+    expect(after.lastActivityAt).not.toBeNull()
+  })
+
+  it('with NO ambient session at all, it behaves as non-seed (the safe default)', async () => {
+    const id = await instance(f)
+
+    await updateEntityInstance({ id, organizationId: f.orgId, data: { archivedAt: new Date() } })
+
+    expect((await row(id)).lastActivityAt).not.toBeNull()
+  })
+
+  it('a non-archive update stamps updatedAt and leaves lastActivityAt alone', async () => {
+    const id = await instance(f)
+    const before = await row(id)
+
+    await runWithWriteSession(interactiveSession('user_1'), () =>
+      updateEntityInstance({ id, organizationId: f.orgId, data: {} })
+    )
+
+    const after = await row(id)
+    expect(after.updatedAt.getTime()).toBeGreaterThan(before.updatedAt.getTime())
+    // Only the `archivedAt` branch touches activity.
+    expect(after.lastActivityAt).toBeNull()
+  })
+
+  it('is org-scoped — a matching id under another org is not touched', async () => {
+    const other = await seed()
+    const id = await instance(f)
+
+    const result = await runWithWriteSession(interactiveSession('user_1'), () =>
+      updateEntityInstance({ id, organizationId: other.orgId, data: { archivedAt: new Date() } })
+    )
+
+    expect(result.isErr()).toBe(true)
+    expect((await row(id)).archivedAt).toBeNull()
+  })
+})

--- a/packages/lib/src/events/handlers/sync-finalize.int.test.ts
+++ b/packages/lib/src/events/handlers/sync-finalize.int.test.ts
@@ -1,0 +1,754 @@
+// packages/lib/src/events/handlers/sync-finalize.int.test.ts
+//
+// DB-backed behaviour test (vitest.integration.config.ts → auxx_test) for the Phase 4/5/6
+// sync finalize pass of plans/events/03-write-context-and-batch-lane-plan.md.
+//
+// WHY INTEGRATION, next to the existing `sync-finalize.test.ts`. That suite mocks the
+// db itself (`insert: vi.fn(() => ({ values: h.insertValues }))`), so every door is
+// asserted as "the spy was called with this shape". Nothing has ever verified that the
+// rows LAND: that the TimelineEvent insert satisfies its NOT NULL columns, that the
+// `lastActivityAt` UPDATE's monotonic `or(IS NULL, <)` predicate actually matches the
+// rows it should (and misses the ones it shouldn't), that `heldDispatches` round-trips
+// through the jsonb `$type` column, or that a `bulk-dispatch` ApprovalRequest survives
+// its own FK constraints. Those are predicate and constraint claims — a fake db proves
+// none of them. This file drives `runSyncFinalize` against real rows and asserts the
+// database afterwards.
+//
+// THE SUBSCRIPTION SIDESTEP. In production the manifest is built by
+// `record-rules/sync-manifest-collector.ts`, which is gated on ENABLED RECORD RULES: an
+// org with no rules gets `NOOP_COLLECTOR`, `toJson()` returns null, no
+// `sync:records:changed` is ever published and finalize never runs (the v1 bound
+// documented in `sync-finalize.ts`, item H-1 in the plan). That gate is a property of the
+// PRODUCER, not of finalize — so these tests hand `runSyncFinalize` a manifest directly
+// and exercise the consumer on its own terms. `sync-manifest-collector` keeps its own
+// unit coverage for the gating itself.
+//
+// WHAT IS MOCKED, and why each one is a true external:
+//   - `../../cache`      — Redis-backed org cache. Re-implemented here against the test
+//                          DB so canonicalization is REAL (slug-keyed import RecordIds →
+//                          the org's EntityDefinition CUID is the #1784 lesson this pass
+//                          re-applies, and it must be exercised, not stubbed).
+//   - `../../realtime`   — Redis pub/sub. Spied to capture tier-2 frames.
+//   - `./trigger-resource-dispatch` / `./trigger-resource-workflows` /
+//     `../../resources/resource-fetcher` — the workflow engine and BullMQ.
+// Everything else runs for real: the timeline insert, `touchEntityActivity`,
+// `runIntegrityPasses`, `createBulkDispatchRequest`, and `persistHeldDispatches`.
+
+import { type Database, schema } from '@auxx/database'
+import { createTestOrganization, createTestUser, getTestDb } from '@auxx/test-utils'
+import { toRecordId } from '@auxx/types/resource'
+import { and, eq } from 'drizzle-orm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SyncChangeManifest } from '../../record-rules/sync-manifest-types'
+import {
+  SYNC_SMALL_RUN_THRESHOLD,
+  WORKFLOW_AUTO_DISPATCH_THRESHOLD,
+} from '../../resources/crud/door-matrix'
+
+const db = () => getTestDb() as never as Database
+
+// ── Mocks: the true externals only ─────────────────────────────────────────────
+
+const h = vi.hoisted(() => ({
+  publishRecordsChanged:
+    vi.fn<
+      (
+        svc: unknown,
+        org: string,
+        args: { entityDefinitionId: string; entries: Array<Record<string, unknown>> }
+      ) => Promise<void>
+    >(),
+  triggerResourceDispatch:
+    vi.fn<(args: { data: { type: string; data: Record<string, unknown> } }) => Promise<void>>(),
+  matchResourceWorkflowTargets: vi.fn(),
+  enqueueWorkflowTriggerJobs: vi.fn(),
+  fetchResourceById: vi.fn(),
+  /** Set per test: userId → role, for the bulk-dispatch approval audience. */
+  roleMap: {} as Record<string, { userType: string; role: string }>,
+}))
+
+// Org cache, re-implemented against the test DB. `canonicalizeEntityDefinitionId`
+// resolves an EntityDefinition by id OR apiSlug — the real behaviour import manifests
+// depend on, since `ImportMapping.entityDefinitionId` is slug-keyed.
+vi.mock('../../cache', () => {
+  const tdb = () => getTestDb() as never as Database
+  const { eq: eqOp, and: andOp, or: orOp } = require('drizzle-orm')
+
+  const findDef = async (orgId: string, idOrSlug: string) => {
+    const [def] = await tdb()
+      .select()
+      .from(schema.EntityDefinition)
+      .where(
+        andOp(
+          eqOp(schema.EntityDefinition.organizationId, orgId),
+          orOp(
+            eqOp(schema.EntityDefinition.id, idOrSlug),
+            eqOp(schema.EntityDefinition.apiSlug, idOrSlug)
+          )
+        )
+      )
+    return def ?? null
+  }
+
+  return {
+    canonicalizeEntityDefinitionId: async (orgId: string, idOrSlug: string) =>
+      (await findDef(orgId, idOrSlug))?.id ?? idOrSlug,
+    findCachedResource: async (orgId: string, idOrSlug: string) => {
+      const def = await findDef(orgId, idOrSlug)
+      if (!def) return null
+      return {
+        id: def.id,
+        entityDefinitionId: def.id,
+        entityType: def.entityType,
+        apiSlug: def.apiSlug,
+      }
+    },
+    getCachedCustomFields: async (orgId: string, defId: string) =>
+      await tdb()
+        .select()
+        .from(schema.CustomField)
+        .where(
+          andOp(
+            eqOp(schema.CustomField.organizationId, orgId),
+            eqOp(schema.CustomField.entityDefinitionId, defId)
+          )
+        ),
+    getOrgCache: () => ({
+      get: async (_orgId: string, key: string) => (key === 'memberRoleMap' ? h.roleMap : {}),
+    }),
+  }
+})
+
+vi.mock('../../realtime', () => ({
+  getRealtimeService: () => ({ publish: vi.fn() }),
+  publishRecordsChanged: h.publishRecordsChanged,
+}))
+vi.mock('./trigger-resource-dispatch', () => ({
+  triggerResourceDispatch: h.triggerResourceDispatch,
+}))
+vi.mock('./trigger-resource-workflows', () => ({
+  matchResourceWorkflowTargets: h.matchResourceWorkflowTargets,
+  enqueueWorkflowTriggerJobs: h.enqueueWorkflowTriggerJobs,
+}))
+vi.mock('../../resources/resource-fetcher', () => ({
+  fetchResourceById: h.fetchResourceById,
+}))
+
+import { runSyncFinalize } from './sync-finalize'
+
+// ── Fixture ────────────────────────────────────────────────────────────────────
+
+interface Fixture {
+  orgId: string
+  userId: string
+  defId: string
+  defSlug: string
+  importJobId: string
+}
+
+/** An org with a `contacts` def and an ImportJob run row to hang the manifest off. */
+async function seed(): Promise<Fixture> {
+  const user = await createTestUser({ name: 'Importer' })
+  const org = await createTestOrganization({ createdById: user.id })
+
+  const [def] = await db()
+    .insert(schema.EntityDefinition)
+    .values({
+      organizationId: org.id,
+      entityType: 'contact',
+      apiSlug: 'contacts',
+      singular: 'contact',
+      plural: 'contacts',
+      updatedAt: new Date(),
+    })
+    .returning()
+
+  const [mapping] = await db()
+    .insert(schema.ImportMapping)
+    .values({
+      organizationId: org.id,
+      entityDefinitionId: def!.apiSlug,
+      title: 'Contacts CSV',
+      createdById: user.id,
+      updatedAt: new Date(),
+    })
+    .returning()
+
+  const [job] = await db()
+    .insert(schema.ImportJob)
+    .values({
+      organizationId: org.id,
+      importMappingId: mapping!.id,
+      sourceFileName: 'contacts.csv',
+      columnCount: 3,
+      rowCount: 500,
+      status: 'completed',
+      createdById: user.id,
+      updatedAt: new Date(),
+    })
+    .returning()
+
+  h.roleMap = { [user.id]: { userType: 'USER', role: 'OWNER' } }
+
+  return {
+    orgId: org.id,
+    userId: user.id,
+    defId: def!.id,
+    defSlug: def!.apiSlug,
+    importJobId: job!.id,
+  }
+}
+
+/** Insert `count` contact instances, returning their ids. */
+async function instances(f: Fixture, count: number, lastActivityAt?: Date): Promise<string[]> {
+  const rows = Array.from({ length: count }, (_, i) => ({
+    organizationId: f.orgId,
+    entityDefinitionId: f.defId,
+    displayName: `Contact ${i}`,
+    ...(lastActivityAt ? { lastActivityAt } : {}),
+    updatedAt: new Date(),
+  }))
+  const inserted = await db().insert(schema.EntityInstance).values(rows).returning()
+  return inserted.map((r) => r.id)
+}
+
+function manifest(over: Partial<SyncChangeManifest> = {}): SyncChangeManifest {
+  return {
+    version: 1,
+    truncated: false,
+    changes: {},
+    createdRecordIds: [],
+    archivedRecordIds: [],
+    ...over,
+  } as SyncChangeManifest
+}
+
+/** Import manifests key RecordIds by SLUG — the keyspace finalize must canonicalize. */
+const slugRid = (f: Fixture, instanceId: string) => toRecordId(f.defSlug, instanceId)
+
+function importInput(f: Fixture, m: SyncChangeManifest) {
+  return { organizationId: f.orgId, source: 'import' as const, ref: f.importJobId, manifest: m }
+}
+
+const timelineFor = async (f: Fixture) =>
+  await db()
+    .select()
+    .from(schema.TimelineEvent)
+    .where(eq(schema.TimelineEvent.organizationId, f.orgId))
+
+const instanceRow = async (f: Fixture, id: string) => {
+  const [row] = await db()
+    .select()
+    .from(schema.EntityInstance)
+    .where(and(eq(schema.EntityInstance.id, id), eq(schema.EntityInstance.organizationId, f.orgId)))
+  return row!
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.publishRecordsChanged.mockResolvedValue(undefined)
+  h.triggerResourceDispatch.mockResolvedValue(undefined)
+  h.matchResourceWorkflowTargets.mockResolvedValue({ match: {}, targets: [] })
+  h.enqueueWorkflowTriggerJobs.mockResolvedValue(undefined)
+  h.fetchResourceById.mockResolvedValue({ id: 'r', fields: {} })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// D-4 / [R] — timeline rows actually land, in the right shape, on the right lane
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('timeline door (D-4)', () => {
+  it('small lane writes one entity:field:updated row per changed field, with real deltas', async () => {
+    const f = await seed()
+    const [a, b] = await instances(f, 2)
+
+    await runSyncFinalize(
+      db(),
+      importInput(
+        f,
+        manifest({
+          changes: {
+            [slugRid(f, a!)]: {
+              first_name: { o: 'Bob', n: 'Robert' },
+              email: { o: null, n: 'r@example.com' },
+            },
+            [slugRid(f, b!)]: { first_name: { n: 'Ada' } },
+          },
+        })
+      )
+    )
+
+    const rows = await timelineFor(f)
+    expect(rows).toHaveLength(3)
+    expect(rows.every((r) => r.eventType === 'entity:field:updated')).toBe(true)
+
+    // entityType is the CANONICAL def CUID, never the slug the manifest carried.
+    expect(new Set(rows.map((r) => r.entityType))).toEqual(new Set([f.defId]))
+    expect(rows.every((r) => r.relatedEntityType === 'custom_field')).toBe(true)
+
+    const aRows = rows.filter((r) => r.entityId === a)
+    expect(new Set(aRows.map((r) => r.relatedEntityId))).toEqual(new Set(['first_name', 'email']))
+
+    const firstName = aRows.find((r) => r.relatedEntityId === 'first_name')!
+    expect(firstName.changes).toEqual([
+      { field: 'first_name', oldValue: 'Bob', newValue: 'Robert' },
+    ])
+    expect(firstName.eventData).toMatchObject({
+      recordId: toRecordId(f.defId, a!),
+      entityDefinitionId: f.defId,
+      fieldId: 'first_name',
+      origin: 'sync',
+      syncSource: 'import',
+      syncRef: f.importJobId,
+    })
+
+    // `oldValue` is omitted, not fabricated, when the manifest never captured it.
+    const bRow = rows.find((r) => r.entityId === b)!
+    expect(bRow.changes).toEqual([{ field: 'first_name', newValue: 'Ada' }])
+
+    // Actor is the ImportJob's createdById, resolved from the real row.
+    expect(rows.every((r) => r.actorType === 'user' && r.actorId === f.userId)).toBe(true)
+  })
+
+  it('large lane collapses to ONE entity:updated row per record (D-4, not an upgrade path)', async () => {
+    const f = await seed()
+    const ids = await instances(f, SYNC_SMALL_RUN_THRESHOLD + 1)
+
+    const changes: Record<string, Record<string, { n: unknown }>> = {}
+    for (const id of ids) changes[slugRid(f, id)] = { first_name: { n: 'x' }, email: { n: 'y' } }
+
+    await runSyncFinalize(db(), importInput(f, manifest({ changes } as never)))
+
+    const rows = await timelineFor(f)
+    // 101 records × 2 changed fields — collapsed, so 101 rows and not 202.
+    expect(rows).toHaveLength(SYNC_SMALL_RUN_THRESHOLD + 1)
+    expect(rows.every((r) => r.eventType === 'entity:updated')).toBe(true)
+    expect(rows[0]!.eventData).toMatchObject({
+      changedFieldCount: 2,
+      changedFieldIds: ['first_name', 'email'],
+    })
+  })
+
+  it('created and archived records collapse on BOTH lanes', async () => {
+    const f = await seed()
+    const [created, archived] = await instances(f, 2)
+
+    await runSyncFinalize(
+      db(),
+      importInput(
+        f,
+        manifest({
+          createdRecordIds: [slugRid(f, created!)],
+          archivedRecordIds: [slugRid(f, archived!)],
+        })
+      )
+    )
+
+    const rows = await timelineFor(f)
+    expect(rows).toHaveLength(2)
+    expect(rows.find((r) => r.entityId === created)!.eventType).toBe('entity:created')
+    expect(rows.find((r) => r.entityId === archived)!.eventType).toBe('entity:archived')
+  })
+
+  it('a record created AND changed this run collapses to created only, never both', async () => {
+    const f = await seed()
+    const [id] = await instances(f, 1)
+
+    await runSyncFinalize(
+      db(),
+      importInput(
+        f,
+        manifest({
+          createdRecordIds: [slugRid(f, id!)],
+          changes: { [slugRid(f, id!)]: { first_name: { n: 'Ada' } } },
+        })
+      )
+    )
+
+    const rows = await timelineFor(f)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.eventType).toBe('entity:created')
+  })
+
+  it('falls back to the system actor when the run has no attributable user', async () => {
+    const f = await seed()
+    await db()
+      .update(schema.ImportJob)
+      .set({ createdById: null })
+      .where(eq(schema.ImportJob.id, f.importJobId))
+    const [id] = await instances(f, 1)
+
+    await runSyncFinalize(db(), importInput(f, manifest({ createdRecordIds: [slugRid(f, id!)] })))
+
+    const rows = await timelineFor(f)
+    expect(rows[0]!.actorType).toBe('system')
+    expect(rows[0]!.actorId).toBe('system')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// D-1 — the lastActivityAt bump, and its monotonic predicate
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('lastActivityAt door (D-1)', () => {
+  it('bumps changed and created records but NOT archived ones — archival is not activity', async () => {
+    const f = await seed()
+    const [changed, created, archived] = await instances(f, 3)
+
+    await runSyncFinalize(
+      db(),
+      importInput(
+        f,
+        manifest({
+          changes: { [slugRid(f, changed!)]: { first_name: { n: 'Ada' } } },
+          createdRecordIds: [slugRid(f, created!)],
+          archivedRecordIds: [slugRid(f, archived!)],
+        })
+      )
+    )
+
+    expect((await instanceRow(f, changed!)).lastActivityAt).not.toBeNull()
+    expect((await instanceRow(f, created!)).lastActivityAt).not.toBeNull()
+    expect((await instanceRow(f, archived!)).lastActivityAt).toBeNull()
+  })
+
+  it('never rewinds a record whose lastActivityAt is already newer', async () => {
+    const f = await seed()
+    const future = new Date(Date.now() + 60 * 60 * 1000)
+    const [id] = await instances(f, 1, future)
+
+    await runSyncFinalize(
+      db(),
+      importInput(f, manifest({ changes: { [slugRid(f, id!)]: { first_name: { n: 'Ada' } } } }))
+    )
+
+    expect((await instanceRow(f, id!)).lastActivityAt?.getTime()).toBe(future.getTime())
+  })
+
+  it('does NOT stamp updatedAt — activity is bookkeeping, not record content (D-7)', async () => {
+    const f = await seed()
+    const [id] = await instances(f, 1)
+    const before = (await instanceRow(f, id!)).updatedAt
+
+    await runSyncFinalize(
+      db(),
+      importInput(f, manifest({ changes: { [slugRid(f, id!)]: { first_name: { n: 'Ada' } } } }))
+    )
+
+    expect((await instanceRow(f, id!)).updatedAt.getTime()).toBe(before.getTime())
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// D-12 — lane selection, decided at finalize from the OBSERVED count
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('lane selection (D-12)', () => {
+  it('takes the small lane at exactly the threshold and the large lane one over', async () => {
+    const atThreshold = await seed()
+    const ids = await instances(atThreshold, SYNC_SMALL_RUN_THRESHOLD)
+    const changes: Record<string, Record<string, { n: unknown }>> = {}
+    for (const id of ids) changes[slugRid(atThreshold, id)] = { first_name: { n: 'x' } }
+    await runSyncFinalize(db(), importInput(atThreshold, manifest({ changes } as never)))
+
+    const smallRows = await timelineFor(atThreshold)
+    expect(smallRows.every((r) => r.eventType === 'entity:field:updated')).toBe(true)
+    // Small lane fires per-record dispatch (D-2, fixes B-3).
+    expect(h.triggerResourceDispatch).toHaveBeenCalledTimes(SYNC_SMALL_RUN_THRESHOLD)
+
+    vi.clearAllMocks()
+
+    const over = await seed()
+    const overIds = await instances(over, SYNC_SMALL_RUN_THRESHOLD + 1)
+    const overChanges: Record<string, Record<string, { n: unknown }>> = {}
+    for (const id of overIds) overChanges[slugRid(over, id)] = { first_name: { n: 'x' } }
+    await runSyncFinalize(db(), importInput(over, manifest({ changes: overChanges } as never)))
+
+    const largeRows = await timelineFor(over)
+    expect(largeRows.every((r) => r.eventType === 'entity:updated')).toBe(true)
+    // Large lane withholds per-record dispatch — it routes through the guard.
+    expect(h.triggerResourceDispatch).not.toHaveBeenCalled()
+  })
+
+  it('a truncated manifest forces the large lane regardless of how few it captured', async () => {
+    const f = await seed()
+    const [id] = await instances(f, 1)
+
+    await runSyncFinalize(
+      db(),
+      importInput(
+        f,
+        manifest({
+          truncated: true,
+          changes: { [slugRid(f, id!)]: { first_name: { n: 'Ada' } } },
+        })
+      )
+    )
+
+    const rows = await timelineFor(f)
+    expect(rows[0]!.eventType).toBe('entity:updated')
+    expect(h.triggerResourceDispatch).not.toHaveBeenCalled()
+  })
+
+  it('an empty manifest is a complete no-op — no rows, no frames, no dispatch', async () => {
+    const f = await seed()
+
+    await runSyncFinalize(db(), importInput(f, manifest()))
+
+    expect(await timelineFor(f)).toHaveLength(0)
+    expect(h.publishRecordsChanged).not.toHaveBeenCalled()
+    expect(h.triggerResourceDispatch).not.toHaveBeenCalled()
+    // The tally is NOT written for an empty run — finalize returns before the doors.
+    const [job] = await db()
+      .select()
+      .from(schema.ImportJob)
+      .where(eq(schema.ImportJob.id, f.importJobId))
+    expect(job!.heldDispatches).toBeNull()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// D-3 / D-13 / D-19 — the guarded dispatcher's persisted tally and approvals
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('guarded dispatch (D-3 / D-13 / D-19)', () => {
+  /** Force the large lane with `count` changed records, all matching `targets`. */
+  async function largeRun(f: Fixture, count: number, targets: unknown[]) {
+    const ids = await instances(f, count)
+    const changes: Record<string, Record<string, { n: unknown }>> = {}
+    for (const id of ids) changes[slugRid(f, id)] = { first_name: { n: 'x' } }
+    h.matchResourceWorkflowTargets.mockResolvedValue({ match: {}, targets })
+    await runSyncFinalize(db(), importInput(f, manifest({ truncated: true, changes } as never)))
+    return ids
+  }
+
+  const target = (over: Record<string, unknown> = {}) => ({
+    workflowAppId: 'app_1',
+    workflowId: 'wf_1',
+    workflowName: 'Tag new contacts',
+    triggerType: 'updated',
+    jobEntityDefinitionId: 'contacts',
+    ...over,
+  })
+
+  it('holds a workflow at the threshold: no enqueue, a real approval row, tally on the run', async () => {
+    const f = await seed()
+    await largeRun(f, WORKFLOW_AUTO_DISPATCH_THRESHOLD, [target()])
+
+    expect(h.enqueueWorkflowTriggerJobs).not.toHaveBeenCalled()
+
+    const [job] = await db()
+      .select()
+      .from(schema.ImportJob)
+      .where(eq(schema.ImportJob.id, f.importJobId))
+    const entries = job!.heldDispatches!
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      workflowId: 'wf_1',
+      status: 'held',
+      count: WORKFLOW_AUTO_DISPATCH_THRESHOLD,
+      triggerType: 'updated',
+    })
+    // Held entries carry their record ids so an approval can enqueue them later.
+    expect(entries[0]!.recordIds).toHaveLength(WORKFLOW_AUTO_DISPATCH_THRESHOLD)
+
+    const approvals = await db()
+      .select()
+      .from(schema.ApprovalRequest)
+      .where(eq(schema.ApprovalRequest.organizationId, f.orgId))
+    expect(approvals).toHaveLength(1)
+    expect(approvals[0]).toMatchObject({ kind: 'bulk-dispatch', status: 'pending' })
+    expect(approvals[0]!.metadata).toMatchObject({
+      source: 'import',
+      ref: f.importJobId,
+      workflowId: 'wf_1',
+    })
+    expect(approvals[0]!.assigneeUsers).toEqual([f.userId])
+    // The entry points back at the request it filed.
+    expect(entries[0]!.approvalRequestId).toBe(approvals[0]!.id)
+  })
+
+  it('auto-dispatches below the threshold, and records the auto entry without record ids', async () => {
+    const f = await seed()
+    await largeRun(f, WORKFLOW_AUTO_DISPATCH_THRESHOLD - 1, [target()])
+
+    expect(h.enqueueWorkflowTriggerJobs).toHaveBeenCalledTimes(WORKFLOW_AUTO_DISPATCH_THRESHOLD - 1)
+
+    const [job] = await db()
+      .select()
+      .from(schema.ImportJob)
+      .where(eq(schema.ImportJob.id, f.importJobId))
+    expect(job!.heldDispatches![0]).toMatchObject({ status: 'auto' })
+    expect(job!.heldDispatches![0]!.recordIds).toBeUndefined()
+
+    const approvals = await db()
+      .select()
+      .from(schema.ApprovalRequest)
+      .where(eq(schema.ApprovalRequest.organizationId, f.orgId))
+    expect(approvals).toHaveLength(0)
+  })
+
+  it('decides per workflow, not per run (D-13) — one held, one auto, in the same run', async () => {
+    const f = await seed()
+    // The two sets must be DISJOINT: `collectChangedSets` subtracts created records out
+    // of `updatedIds` (a record created this run collapses to created, never both), so
+    // overlapping them would starve the updated arm. 24 created → below the threshold →
+    // auto; 25 updated → at the threshold → held.
+    const ids = await instances(f, WORKFLOW_AUTO_DISPATCH_THRESHOLD * 2 - 1)
+    const createdIds = ids.slice(0, WORKFLOW_AUTO_DISPATCH_THRESHOLD - 1)
+    const changes: Record<string, Record<string, { n: unknown }>> = {}
+    for (const id of ids.slice(WORKFLOW_AUTO_DISPATCH_THRESHOLD - 1)) {
+      changes[slugRid(f, id)] = { first_name: { n: 'x' } }
+    }
+
+    // `entity:created` matches wf_auto; `entity:updated` matches wf_held.
+    h.matchResourceWorkflowTargets.mockImplementation(async (event: never) => {
+      const type = (event as { type: string }).type
+      return type === 'entity:created'
+        ? { match: {}, targets: [target({ workflowId: 'wf_auto', triggerType: 'created' })] }
+        : { match: {}, targets: [target({ workflowId: 'wf_held' })] }
+    })
+
+    await runSyncFinalize(
+      db(),
+      importInput(
+        f,
+        manifest({
+          truncated: true,
+          changes,
+          createdRecordIds: createdIds.map((id) => slugRid(f, id)),
+        } as never)
+      )
+    )
+
+    const [job] = await db()
+      .select()
+      .from(schema.ImportJob)
+      .where(eq(schema.ImportJob.id, f.importJobId))
+    const byId = Object.fromEntries(job!.heldDispatches!.map((e) => [e.workflowId, e]))
+    expect(byId.wf_auto).toMatchObject({
+      status: 'auto',
+      count: WORKFLOW_AUTO_DISPATCH_THRESHOLD - 1,
+    })
+    expect(byId.wf_held).toMatchObject({
+      status: 'held',
+      count: WORKFLOW_AUTO_DISPATCH_THRESHOLD,
+    })
+    // Exactly one approval — the held workflow's. The auto one files nothing.
+    const approvals = await db()
+      .select()
+      .from(schema.ApprovalRequest)
+      .where(eq(schema.ApprovalRequest.organizationId, f.orgId))
+    expect(approvals).toHaveLength(1)
+    expect(approvals[0]!.metadata).toMatchObject({ workflowId: 'wf_held' })
+  })
+
+  it('writes an EMPTY tally when nothing matched — the trace that the door ran (D-3)', async () => {
+    const f = await seed()
+    await largeRun(f, 3, [])
+
+    const [job] = await db()
+      .select()
+      .from(schema.ImportJob)
+      .where(eq(schema.ImportJob.id, f.importJobId))
+    // Empty array, NOT null — null means "finalize predates Phase 6".
+    expect(job!.heldDispatches).toEqual([])
+  })
+
+  it('still persists the tally when the org has nobody to ask for approval', async () => {
+    const f = await seed()
+    h.roleMap = {} // no admins, and the actor is not a member
+    await db()
+      .update(schema.ImportJob)
+      .set({ createdById: null })
+      .where(eq(schema.ImportJob.id, f.importJobId))
+
+    await largeRun(f, WORKFLOW_AUTO_DISPATCH_THRESHOLD, [target()])
+
+    const [job] = await db()
+      .select()
+      .from(schema.ImportJob)
+      .where(eq(schema.ImportJob.id, f.importJobId))
+    expect(job!.heldDispatches![0]).toMatchObject({ status: 'held' })
+    expect(job!.heldDispatches![0]!.approvalRequestId).toBeUndefined()
+    expect(h.enqueueWorkflowTriggerJobs).not.toHaveBeenCalled()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// §7b — tier-2 records:changed frames
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('tier-2 frames (§7b)', () => {
+  it('groups by canonical def, carries fieldIds for changed and omits them elsewhere', async () => {
+    const f = await seed()
+    const [changed, created, archived] = await instances(f, 3)
+
+    await runSyncFinalize(
+      db(),
+      importInput(
+        f,
+        manifest({
+          changes: { [slugRid(f, changed!)]: { first_name: { n: 'Ada' }, email: { n: 'a@b.c' } } },
+          createdRecordIds: [slugRid(f, created!)],
+          archivedRecordIds: [slugRid(f, archived!)],
+        })
+      )
+    )
+
+    expect(h.publishRecordsChanged).toHaveBeenCalledTimes(1)
+    const [, org, args] = h.publishRecordsChanged.mock.calls[0]!
+    expect(org).toBe(f.orgId)
+    // The slug-keyed manifest resolved to the org's CUID before it reached the room key.
+    expect(args.entityDefinitionId).toBe(f.defId)
+
+    const byRecord = Object.fromEntries(args.entries.map((e) => [e.recordId as string, e.fieldIds]))
+    expect(byRecord[changed!]).toEqual(['first_name', 'email'])
+    expect(byRecord[created!]).toBeUndefined()
+    expect(byRecord[archived!]).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// The never-throws contract, against real failures rather than rejected spies
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('never throws (finalize door contract)', () => {
+  it('survives a manifest naming records and defs that do not exist', async () => {
+    const f = await seed()
+
+    await expect(
+      runSyncFinalize(
+        db(),
+        importInput(
+          f,
+          manifest({
+            changes: { [toRecordId('ghost_def', 'ghost_instance')]: { x: { n: 1 } } },
+          })
+        )
+      )
+    ).resolves.toBeUndefined()
+
+    // The row still lands — the timeline does not verify the record exists.
+    const rows = await timelineFor(f)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.entityType).toBe('ghost_def')
+  })
+
+  it('completes the remaining doors when the realtime publish fails', async () => {
+    const f = await seed()
+    const [id] = await instances(f, 1)
+    h.publishRecordsChanged.mockRejectedValue(new Error('redis down'))
+
+    await expect(
+      runSyncFinalize(
+        db(),
+        importInput(f, manifest({ changes: { [slugRid(f, id!)]: { first_name: { n: 'Ada' } } } }))
+      )
+    ).resolves.toBeUndefined()
+
+    // Realtime is the LAST door — the timeline and activity doors already committed.
+    expect(await timelineFor(f)).toHaveLength(1)
+    expect((await instanceRow(f, id!)).lastActivityAt).not.toBeNull()
+  })
+})

--- a/packages/lib/src/field-values/__tests__/write-idempotency-stamps.int.test.ts
+++ b/packages/lib/src/field-values/__tests__/write-idempotency-stamps.int.test.ts
@@ -1,0 +1,366 @@
+// packages/lib/src/field-values/__tests__/write-idempotency-stamps.int.test.ts
+//
+// DB-backed behaviour test (vitest.integration.config.ts → auxx_test) for the two
+// coupled decisions at the bottom of plans/events/03-write-context-and-batch-lane-plan.md:
+//
+//   D-6 — the idempotency guard on the forward `set` path. An identical write must not
+//         DELETE+INSERT. "Don't suppress the event, suppress the write."
+//   D-7 — `EntityInstance.updatedAt` lost its `$onUpdate` and is stamped EXPLICITLY, once
+//         per record write, only when at least one field really changed.
+//
+// WHY INTEGRATION. The existing `set-idempotency.test.ts` and
+// `instance-updated-at-stamp.test.ts` mock the db, so they assert D-6 as "the delete spy
+// was not called" and D-7 as "the update spy was called once". Both claims are really
+// claims about ROW IDENTITY over time — that the stored FieldValue row is the SAME row
+// afterwards, not an identical-looking replacement, and that a no-op write leaves the
+// instance's `updatedAt` byte-for-byte alone. A fake db cannot distinguish "row survived"
+// from "row deleted and re-inserted with the same values", which is precisely the
+// distinction D-6 exists to make: the DELETE+INSERT is what re-dirties the dedup
+// watermark and what D-1's `lastActivityAt` bump would otherwise ride on.
+//
+// The org cache is mocked wholesale against the test DB (same approach as
+// `email-uniqueness-doors.int.test.ts` next door); realtime and the hook registry are
+// mocked because they are Redis / cross-module externals, not part of the claim.
+
+import { type Database, schema } from '@auxx/database'
+import { createTestOrganization, getTestDb } from '@auxx/test-utils'
+import type { RecordId } from '@auxx/types/resource'
+import { and, eq } from 'drizzle-orm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createFieldValueContext, type FieldValueContext } from '../field-value-helpers'
+import { setValuesForEntity } from '../field-value-mutations'
+
+const db = () => getTestDb() as never as Database
+
+// ── Mocks: Redis-backed cache + the cross-module externals ─────────────────────
+
+vi.mock('../../realtime/publish-helpers', () => ({
+  publishFieldValueUpdates: vi.fn(async () => {}),
+}))
+
+vi.mock('../../field-hooks/registry', () => ({
+  hasEntityFieldChangeHooks: vi.fn(() => false),
+  hasFieldTypeChangeHooks: vi.fn(() => false),
+  hasFieldPreHooks: vi.fn(() => false),
+  getEntityFieldChangeHooks: vi.fn(() => []),
+  getFieldTypeChangeHooks: vi.fn(() => []),
+  getFieldPreHooks: vi.fn(() => []),
+}))
+
+vi.mock('../../field-hooks/collect-triggers', () => ({
+  collectTriggeredFields: vi.fn(async () => []),
+  deduplicateBySystemAttribute: vi.fn((fields: unknown[]) => fields),
+}))
+
+vi.mock('../../cache', () => {
+  const tdb = () => getTestDb() as never as Database
+  const { eq: eqOp, and: andOp } = require('drizzle-orm')
+
+  const fieldsForOrg = async (orgId: string) =>
+    await tdb()
+      .select()
+      .from(schema.CustomField)
+      .where(eqOp(schema.CustomField.organizationId, orgId))
+
+  const resourceFor = async (orgId: string, defId: string) => {
+    const [def] = await tdb()
+      .select()
+      .from(schema.EntityDefinition)
+      .where(
+        andOp(
+          eqOp(schema.EntityDefinition.id, defId),
+          eqOp(schema.EntityDefinition.organizationId, orgId)
+        )
+      )
+    if (!def) return null
+    return {
+      id: def.id,
+      entityDefinitionId: def.id,
+      apiSlug: def.apiSlug,
+      entityType: def.entityType,
+      display: { primaryDisplayField: null, secondaryDisplayField: null, avatarField: null },
+    }
+  }
+
+  return {
+    getOrgCache: () => ({
+      from: (orgId: string) => ({
+        all: async () => {
+          const grouped: Record<string, unknown[]> = {}
+          for (const f of await fieldsForOrg(orgId)) {
+            const key = f.entityDefinitionId ?? '_'
+            grouped[key] = grouped[key] ?? []
+            grouped[key]!.push(f)
+          }
+          return grouped
+        },
+        byId: async (fieldId: string) =>
+          (await fieldsForOrg(orgId)).find((f) => f.id === fieldId) ?? null,
+        bySystemAttribute: async (attr: string) =>
+          (await fieldsForOrg(orgId)).find((f) => f.systemAttribute === attr) ?? null,
+      }),
+    }),
+    getCachedResource: resourceFor,
+    findCachedResource: resourceFor,
+    getCachedResources: async () => [],
+    getCachedFieldMap: async (orgId: string) =>
+      new Map((await fieldsForOrg(orgId)).map((f) => [f.id, f])),
+    getCachedEntityDefId: async (_orgId: string, slugOrId: string) => slugOrId,
+    requireCachedEntityDefId: async (_orgId: string, slugOrId: string) => slugOrId,
+    getAllCachedCustomFields: fieldsForOrg,
+    getCachedRecordRules: async () => [],
+    getCachedResourceFields: async () => [],
+    getCachedUserInstanceGrants: async () => [],
+    getCachedMembersByUserIds: async () => [],
+    getCachedAgentsByUserIds: async () => [],
+  }
+})
+
+// ── Fixture ────────────────────────────────────────────────────────────────────
+
+interface Fixture {
+  orgId: string
+  defId: string
+  nameFieldId: string
+  noteFieldId: string
+  instanceId: string
+  ctx: FieldValueContext
+}
+
+async function seed(): Promise<Fixture> {
+  const org = await createTestOrganization()
+
+  const [def] = await db()
+    .insert(schema.EntityDefinition)
+    .values({
+      organizationId: org.id,
+      entityType: 'contact',
+      apiSlug: 'contacts',
+      singular: 'contact',
+      plural: 'contacts',
+      updatedAt: new Date(),
+    })
+    .returning()
+
+  const field = async (name: string, systemAttribute: string, sortOrder: string) => {
+    const [f] = await db()
+      .insert(schema.CustomField)
+      .values({
+        organizationId: org.id,
+        entityDefinitionId: def!.id,
+        modelType: 'contact',
+        name,
+        type: 'TEXT',
+        systemAttribute,
+        sortOrder,
+        isCustom: false,
+        updatedAt: new Date(),
+      })
+      .returning()
+    return f!.id
+  }
+
+  const nameFieldId = await field('First Name', 'first_name', 'a1')
+  const noteFieldId = await field('Note', 'note', 'a2')
+
+  const [inst] = await db()
+    .insert(schema.EntityInstance)
+    .values({
+      organizationId: org.id,
+      entityDefinitionId: def!.id,
+      displayName: 'Ada',
+      // Deliberately in the past, so any stamp is unambiguous.
+      updatedAt: new Date(Date.now() - 60 * 60 * 1000),
+    })
+    .returning()
+
+  return {
+    orgId: org.id,
+    defId: def!.id,
+    nameFieldId,
+    noteFieldId,
+    instanceId: inst!.id,
+    // No userId → the post-hook / trigger branches stay off; the guard does not.
+    ctx: createFieldValueContext(org.id, undefined, db()),
+  }
+}
+
+const recordIdOf = (f: Fixture) => `${f.defId}:${f.instanceId}` as RecordId
+
+/** The stored FieldValue rows for one field — id and updatedAt are the identity proof. */
+async function valueRows(f: Fixture, fieldId: string) {
+  return await db()
+    .select()
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, f.orgId),
+        eq(schema.FieldValue.entityId, f.instanceId),
+        eq(schema.FieldValue.fieldId, fieldId)
+      )
+    )
+}
+
+async function instanceUpdatedAt(f: Fixture): Promise<Date> {
+  const [row] = await db()
+    .select()
+    .from(schema.EntityInstance)
+    .where(eq(schema.EntityInstance.id, f.instanceId))
+  return row!.updatedAt
+}
+
+const setName = (f: Fixture, value: unknown) =>
+  setValuesForEntity(f.ctx, {
+    recordId: recordIdOf(f),
+    values: [{ fieldId: f.nameFieldId, value: value as never }],
+  })
+
+let f: Fixture
+beforeEach(async () => {
+  vi.clearAllMocks()
+  f = await seed()
+})
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// D-6 — the guard, proven by row identity rather than by an unfired spy
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('idempotency guard (D-6)', () => {
+  it('re-asserting the same value leaves the SAME FieldValue row in place', async () => {
+    const [first] = await setName(f, 'Robert')
+    expect(first!.changed).toBe(true)
+
+    const after = await valueRows(f, f.nameFieldId)
+    expect(after).toHaveLength(1)
+    const original = after[0]!
+
+    const [second] = await setName(f, 'Robert')
+    expect(second!.changed).toBe(false)
+
+    const rows = await valueRows(f, f.nameFieldId)
+    expect(rows).toHaveLength(1)
+    // The row IDENTITY survived — this is what a DELETE+INSERT would destroy and
+    // what a fake db cannot tell apart from an identical replacement.
+    expect(rows[0]!.id).toBe(original.id)
+    expect(rows[0]!.updatedAt.getTime()).toBe(original.updatedAt.getTime())
+    expect(rows[0]!.createdAt.getTime()).toBe(original.createdAt.getTime())
+  })
+
+  it('a real change DOES rewrite the row', async () => {
+    await setName(f, 'Robert')
+    const original = (await valueRows(f, f.nameFieldId))[0]!
+
+    const [result] = await setName(f, 'Bob')
+    expect(result!.changed).toBe(true)
+
+    const rows = await valueRows(f, f.nameFieldId)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.valueText).toBe('Bob')
+    // Either a new row id or a moved updatedAt — the write really landed.
+    const rewritten =
+      rows[0]!.id !== original.id || rows[0]!.updatedAt.getTime() !== original.updatedAt.getTime()
+    expect(rewritten).toBe(true)
+  })
+
+  it('clearing an already-absent value is a no-op (B-14 delete-of-absent)', async () => {
+    const [result] = await setName(f, null)
+    expect(result!.changed).toBe(false)
+    expect(await valueRows(f, f.nameFieldId)).toHaveLength(0)
+  })
+
+  it('clearing a present value is a real change, and the row goes', async () => {
+    await setName(f, 'Robert')
+    const [result] = await setName(f, null)
+    expect(result!.changed).toBe(true)
+    expect(await valueRows(f, f.nameFieldId)).toHaveLength(0)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// D-7 — one explicit stamp per record write, only on a real change
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('EntityInstance.updatedAt stamping (D-7)', () => {
+  it('stamps on a real change', async () => {
+    const before = await instanceUpdatedAt(f)
+    await setName(f, 'Robert')
+    expect((await instanceUpdatedAt(f)).getTime()).toBeGreaterThan(before.getTime())
+  })
+
+  it('does NOT stamp on an idempotent re-assertion — the D-6/D-7 coupling', async () => {
+    await setName(f, 'Robert')
+    const afterRealWrite = await instanceUpdatedAt(f)
+
+    await setName(f, 'Robert')
+
+    // Unchanged to the millisecond. A bump here would re-dirty the dedup
+    // watermark on every re-asserting nightly sync — the exact trap D-7 closes.
+    expect((await instanceUpdatedAt(f)).getTime()).toBe(afterRealWrite.getTime())
+  })
+
+  it('does NOT stamp on a delete-of-absent', async () => {
+    const before = await instanceUpdatedAt(f)
+    await setName(f, null)
+    expect((await instanceUpdatedAt(f)).getTime()).toBe(before.getTime())
+  })
+
+  it('stamps ONCE for a multi-field write, and only because one field changed', async () => {
+    // Seed both fields, then re-assert `first_name` while changing `note`.
+    await setValuesForEntity(f.ctx, {
+      recordId: recordIdOf(f),
+      values: [
+        { fieldId: f.nameFieldId, value: 'Robert' as never },
+        { fieldId: f.noteFieldId, value: 'first' as never },
+      ],
+    })
+    const nameRow = (await valueRows(f, f.nameFieldId))[0]!
+    const afterSeed = await instanceUpdatedAt(f)
+
+    const results = await setValuesForEntity(f.ctx, {
+      recordId: recordIdOf(f),
+      values: [
+        { fieldId: f.nameFieldId, value: 'Robert' as never }, // identical — guarded
+        { fieldId: f.noteFieldId, value: 'second' as never }, // real change
+      ],
+    })
+
+    expect(results.map((r) => r.changed)).toEqual([false, true])
+    // The guarded field's row is untouched even though its sibling wrote.
+    const nameAfter = (await valueRows(f, f.nameFieldId))[0]!
+    expect(nameAfter.id).toBe(nameRow.id)
+    expect(nameAfter.updatedAt.getTime()).toBe(nameRow.updatedAt.getTime())
+    // And the record was stamped, because SOMETHING changed.
+    expect((await instanceUpdatedAt(f)).getTime()).toBeGreaterThan(afterSeed.getTime())
+  })
+
+  it('does NOT stamp when every field in a multi-field write is a no-op', async () => {
+    await setValuesForEntity(f.ctx, {
+      recordId: recordIdOf(f),
+      values: [
+        { fieldId: f.nameFieldId, value: 'Robert' as never },
+        { fieldId: f.noteFieldId, value: 'first' as never },
+      ],
+    })
+    const afterSeed = await instanceUpdatedAt(f)
+
+    const results = await setValuesForEntity(f.ctx, {
+      recordId: recordIdOf(f),
+      values: [
+        { fieldId: f.nameFieldId, value: 'Robert' as never },
+        { fieldId: f.noteFieldId, value: 'first' as never },
+      ],
+    })
+
+    expect(results.every((r) => !r.changed)).toBe(true)
+    expect((await instanceUpdatedAt(f)).getTime()).toBe(afterSeed.getTime())
+  })
+
+  it('never bumps lastActivityAt — that is finalize’s door (D-1), not the write path’s', async () => {
+    await setName(f, 'Robert')
+    const [row] = await db()
+      .select()
+      .from(schema.EntityInstance)
+      .where(eq(schema.EntityInstance.id, f.instanceId))
+    expect(row!.lastActivityAt).toBeNull()
+  })
+})


### PR DESCRIPTION
One file. CLAUDE.md announces six architecture guides — agents, channels/mail, mail-suggestions, dedup, workflows, UI — but not `docs/files-upload-architecture-guide.md`, which landed in #1816. Since CLAUDE.md is what loads automatically, a fresh session currently has no way to discover that guide exists.

That's not hypothetical: the reason several Tier-1 bugs survived as long as they did is that nothing pointed at where the invariants were written down.

Follows the existing entry format — what to read before touching the subsystem, then the short version of the invariants that actually bite:

- which of the five tables a file occupies, and that the `EntityType` the client sends decides it (picking wrong silently produces the wrong record — that was #1816's `visit_qc_item` bug)
- `bucket` is never optional, because S3 answers **204** for deleting a key that isn't in the bucket you named, so a wrong bucket leaks with no error (three separate production bugs)
- `MediaAsset` and `FolderFile` are different tables and the legacy `File` table is empty, so joining it is a silent no-op (this made the storage quota read zero forever)
- post-commit work must be enqueued after `COMMIT`, never from inside a processor, because the enqueue resolves its source on a different connection

Also records that new code under `packages/lib/src/files/**` uses the functional contract in `files/ctx.ts` rather than a service class, and names the two worked examples from #1820.