### PR TITLE
fix(parts): clear part cost and unit price when their source goes away

### DIFF
--- a/packages/lib/scripts/resweep-part-costs.ts
+++ b/packages/lib/scripts/resweep-part-costs.ts
@@ -1,0 +1,82 @@
+// packages/lib/scripts/resweep-part-costs.ts
+//
+// One-off cleanup for plans/parts/cost-provenance-and-stale-values.md §5.0.1.
+//
+// `persistCosts` used to be write-only: a part that lost its last vendor part (or its last
+// subpart) kept the number it had at the time, because a `null` was treated as "nothing to
+// do" rather than "clear it". The fix makes the persister authoritative, but it only repairs
+// a part the next time something touches it — a part frozen BEFORE the fix shipped stays
+// frozen until a recalc reaches it.
+//
+// `recalculateAllPartCosts` is NOT sufficient for that sweep: it persists only parts that
+// appear in the vendor/subpart graph, so a part with neither never gets looked at.
+// `recalculateAffectedParts` seeds its dirty set from the caller instead, so passing every
+// part id in the org makes it a complete authoritative pass over that org. (Plan §5.5 folds
+// this into `recalculateAllPartCosts` permanently; until then, this script is the sweep.)
+//
+// Idempotent — `persistCosts` writes only where the value actually differs, so a second run
+// changes nothing.
+//
+//   npx dotenv -- npx tsx packages/lib/scripts/resweep-part-costs.ts
+
+import { database as db, schema } from '@auxx/database'
+import { and, eq, isNull } from 'drizzle-orm'
+import { recalculateAffectedParts } from '../src/bom/cost-calculator'
+
+async function partIdsForOrg(organizationId: string): Promise<string[]> {
+  const defs = await db
+    .select({ id: schema.EntityDefinition.id })
+    .from(schema.EntityDefinition)
+    .where(
+      and(
+        eq(schema.EntityDefinition.organizationId, organizationId),
+        eq(schema.EntityDefinition.entityType, 'part'),
+        isNull(schema.EntityDefinition.archivedAt)
+      )
+    )
+  const partDefId = defs[0]?.id
+  if (!partDefId) return []
+
+  const rows = await db
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, organizationId),
+        eq(schema.EntityInstance.entityDefinitionId, partDefId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+  return rows.map((r) => r.id)
+}
+
+async function main() {
+  const orgs = await db.select({ id: schema.Organization.id }).from(schema.Organization)
+  console.log(`Found ${orgs.length} organizations`)
+
+  let swept = 0
+  let changed = 0
+  let failed = 0
+
+  for (const org of orgs) {
+    try {
+      const partIds = await partIdsForOrg(org.id)
+      if (partIds.length === 0) continue
+
+      const changedIds = await recalculateAffectedParts(org.id, partIds)
+      swept += partIds.length
+      changed += changedIds.length
+      if (changedIds.length > 0) {
+        console.log(`org ${org.id}: ${changedIds.length}/${partIds.length} parts corrected`)
+      }
+    } catch (error) {
+      failed++
+      console.error(`Failed to resweep part costs for org ${org.id}:`, error)
+    }
+  }
+
+  console.log(`Done. Swept ${swept} parts, corrected ${changed}, ${failed} orgs failed.`)
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+void main()

--- a/packages/lib/src/bom/cost-calculator.test.ts
+++ b/packages/lib/src/bom/cost-calculator.test.ts
@@ -1,0 +1,262 @@
+// packages/lib/src/bom/cost-calculator.test.ts
+//
+// Regression cover for plans/parts/cost-provenance-and-stale-values.md §1: `persistCosts`
+// used to be write-only, so a part that lost its last vendor part kept the number it had at
+// the time. Harness style follows `money/catalog-pricing.test.ts` and
+// `field-hooks/post/bom-cost-triggers.test.ts` — mock `@auxx/database` with a sequential
+// result queue and assert on the writer's calls rather than on drizzle column identity.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  queryQueue: [] as unknown[][],
+  setValueWithType: vi.fn(async (_ctx: unknown, _params: unknown) => [] as unknown[]),
+  createFieldValueContext: vi.fn((organizationId: string) => ({ organizationId })),
+  getRealtimeService: vi.fn(() => ({})),
+  publishFieldValueUpdates: vi.fn(async (_svc: unknown, _orgId: string, _entries: unknown[]) => {}),
+  syncCatalogItemPricing: vi.fn(async () => {}),
+}))
+
+function nextRows(): unknown[] {
+  return h.queryQueue.shift() ?? []
+}
+
+vi.mock('@auxx/database', () => ({
+  database: {
+    select: () => ({
+      from: () => ({
+        innerJoin: () => ({ where: () => Promise.resolve(nextRows()) }),
+        where: () => Promise.resolve(nextRows()),
+      }),
+    }),
+  },
+  schema: {
+    EntityInstance: {
+      id: 'id',
+      organizationId: 'organizationId',
+      entityDefinitionId: 'entityDefinitionId',
+      archivedAt: 'archivedAt',
+    },
+    FieldValue: {
+      entityId: 'entityId',
+      fieldId: 'fieldId',
+      organizationId: 'organizationId',
+      valueNumber: 'valueNumber',
+      valueBoolean: 'valueBoolean',
+      relatedEntityId: 'relatedEntityId',
+    },
+  },
+}))
+
+// Field ids the cache hands back, keyed by systemAttribute.
+const FIELD: Record<string, { id: string; type: string }> = {
+  vendor_part_part: { id: 'f_vp_part', type: 'RELATIONSHIP' },
+  vendor_part_unit_price: { id: 'f_vp_price', type: 'CURRENCY' },
+  vendor_part_is_preferred: { id: 'f_vp_pref', type: 'CHECKBOX' },
+  vendor_part_shipping_cost: { id: 'f_vp_ship', type: 'CURRENCY' },
+  vendor_part_tariff_rate: { id: 'f_vp_tariff', type: 'NUMBER' },
+  vendor_part_other_cost: { id: 'f_vp_other', type: 'CURRENCY' },
+  subpart_parent_part: { id: 'f_sp_parent', type: 'RELATIONSHIP' },
+  subpart_child_part: { id: 'f_sp_child', type: 'RELATIONSHIP' },
+  subpart_quantity: { id: 'f_sp_qty', type: 'NUMBER' },
+  part_cost: { id: 'f_part_cost', type: 'CURRENCY' },
+  part_unit_price: { id: 'f_part_unit_price', type: 'CURRENCY' },
+}
+
+vi.mock('../cache', () => ({
+  getOrgCache: () => ({
+    from: () => ({
+      bySystemAttributes: async (attrs: readonly string[]) =>
+        Object.fromEntries(attrs.map((a) => [a, FIELD[a] ?? null])),
+      bySystemAttribute: async (attr: string) => FIELD[attr] ?? null,
+    }),
+  }),
+  requireCachedEntityDefId: async (_orgId: string, entityType: string) => `${entityType}_def`,
+}))
+
+vi.mock('../field-values/field-value-helpers', () => ({
+  createFieldValueContext: h.createFieldValueContext,
+}))
+
+vi.mock('../field-values/field-value-mutations', () => ({
+  setValueWithType: h.setValueWithType,
+}))
+
+vi.mock('../field-values/stored-field-type', () => ({
+  toFieldType: (stored: string) => stored,
+}))
+
+vi.mock('../realtime', () => ({
+  getRealtimeService: h.getRealtimeService,
+  publishFieldValueUpdates: h.publishFieldValueUpdates,
+}))
+
+vi.mock('../money/catalog-pricing', () => ({
+  syncCatalogItemPricing: h.syncCatalogItemPricing,
+}))
+
+import { recalculateAffectedParts } from './cost-calculator'
+
+const ORG = 'org_1'
+const ASSEMBLY = 'part_assembly'
+const MOTOR = 'part_motor'
+
+/** A `vendor_part` instance priced at `unitPrice`, linked to `partId`. */
+function vendorPartRows(instanceId: string, partId: string, unitPrice: number) {
+  return [
+    {
+      instanceId,
+      fieldId: FIELD.vendor_part_part!.id,
+      valueNumber: null,
+      valueBoolean: null,
+      relatedEntityId: partId,
+    },
+    {
+      instanceId,
+      fieldId: FIELD.vendor_part_unit_price!.id,
+      valueNumber: unitPrice,
+      valueBoolean: null,
+      relatedEntityId: null,
+    },
+  ]
+}
+
+/** A `subpart` instance: `qty` of `childId` inside `parentId`. */
+function subpartRows(instanceId: string, parentId: string, childId: string, qty: number) {
+  return [
+    {
+      instanceId,
+      fieldId: FIELD.subpart_parent_part!.id,
+      valueNumber: null,
+      relatedEntityId: parentId,
+    },
+    {
+      instanceId,
+      fieldId: FIELD.subpart_child_part!.id,
+      valueNumber: null,
+      relatedEntityId: childId,
+    },
+    { instanceId, fieldId: FIELD.subpart_quantity!.id, valueNumber: qty, relatedEntityId: null },
+  ]
+}
+
+/** Existing `part_cost` / `part_unit_price` FieldValue rows. */
+function storedRows(entries: Array<{ partId: string; cost?: number; unitPrice?: number }>) {
+  const rows: unknown[] = []
+  for (const e of entries) {
+    if (e.cost != null)
+      rows.push({ entityId: e.partId, fieldId: FIELD.part_cost!.id, valueNumber: e.cost })
+    if (e.unitPrice != null)
+      rows.push({
+        entityId: e.partId,
+        fieldId: FIELD.part_unit_price!.id,
+        valueNumber: e.unitPrice,
+      })
+  }
+  return rows
+}
+
+/** The three queries `recalculateAffectedParts` runs, in order. */
+function queue(vendorParts: unknown[], subparts: unknown[], stored: unknown[]) {
+  h.queryQueue = [vendorParts, subparts, stored]
+}
+
+/** Every `setValueWithType` call for one field, as `{ recordId, value }`. */
+function writesFor(fieldId: string) {
+  return h.setValueWithType.mock.calls
+    .map((call) => call[1] as { recordId: string; fieldId: string; value: unknown })
+    .filter((params) => params.fieldId === fieldId)
+    .map(({ recordId, value }) => ({ recordId, value }))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.queryQueue = []
+})
+
+describe('recalculateAffectedParts — clearing values', () => {
+  it('clears a stale unit price when the part lost its last vendor, and falls back to the BOM cost', async () => {
+    // The AL400 case: assembly = 2 × motor @ $180.00, and a $50.00 unit price left behind by
+    // a vendor part that has since been deleted.
+    queue(
+      vendorPartRows('vp_motor', MOTOR, 18000),
+      subpartRows('sp_1', ASSEMBLY, MOTOR, 2),
+      storedRows([{ partId: ASSEMBLY, cost: 5000, unitPrice: 5000 }])
+    )
+
+    await recalculateAffectedParts(ORG, [ASSEMBLY])
+
+    expect(writesFor(FIELD.part_cost!.id)).toEqual([
+      { recordId: `part_def:${ASSEMBLY}`, value: { type: 'number', value: 36000 } },
+    ])
+    // The fix: `null` is written as a CLEAR, not skipped as "nothing to do".
+    expect(writesFor(FIELD.part_unit_price!.id)).toEqual([
+      { recordId: `part_def:${ASSEMBLY}`, value: null },
+    ])
+  })
+
+  it('publishes the clear as an explicit null so open clients blank the cell', async () => {
+    queue(
+      vendorPartRows('vp_motor', MOTOR, 18000),
+      subpartRows('sp_1', ASSEMBLY, MOTOR, 2),
+      storedRows([{ partId: ASSEMBLY, cost: 5000, unitPrice: 5000 }])
+    )
+
+    await recalculateAffectedParts(ORG, [ASSEMBLY])
+
+    const entries = h.publishFieldValueUpdates.mock.calls[0]?.[2] as Array<{
+      key: string
+      value: unknown
+    }>
+    // An OMITTED entry means "don't touch the store" (realtime/events.ts), so the cleared
+    // cell has to travel as `value: null` or the client keeps rendering the stale number.
+    const cleared = entries.find((e) => e.key.includes(FIELD.part_unit_price!.id))
+    expect(cleared).toBeDefined()
+    expect(cleared?.value).toBeNull()
+  })
+
+  it('clears the cost of a part that has neither a vendor nor a BOM', async () => {
+    // Nothing puts this part in the vendor/subpart graph at all — it is only reachable
+    // because the caller named it. The dirty set, not the graph, is the persist scope.
+    queue([], [], storedRows([{ partId: ASSEMBLY, cost: 5000 }]))
+
+    await recalculateAffectedParts(ORG, [ASSEMBLY])
+
+    expect(writesFor(FIELD.part_cost!.id)).toEqual([
+      { recordId: `part_def:${ASSEMBLY}`, value: null },
+    ])
+  })
+
+  it('writes nothing when the stored values already match', async () => {
+    queue(
+      vendorPartRows('vp_motor', MOTOR, 18000),
+      subpartRows('sp_1', ASSEMBLY, MOTOR, 2),
+      storedRows([{ partId: ASSEMBLY, cost: 36000 }])
+    )
+
+    await recalculateAffectedParts(ORG, [ASSEMBLY])
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+    expect(h.publishFieldValueUpdates).not.toHaveBeenCalled()
+  })
+
+  it('leaves parts outside the dirty set alone', async () => {
+    // The motor is a CHILD of the assembly, not an ancestor, so recalculating the assembly
+    // must not rewrite it — even though its cost is computed along the way.
+    queue(
+      vendorPartRows('vp_motor', MOTOR, 18000),
+      subpartRows('sp_1', ASSEMBLY, MOTOR, 2),
+      storedRows([
+        { partId: ASSEMBLY, cost: 5000 },
+        { partId: MOTOR, cost: 1 },
+      ])
+    )
+
+    await recalculateAffectedParts(ORG, [ASSEMBLY])
+
+    const touched = h.setValueWithType.mock.calls.map(
+      (call) => (call[1] as { recordId: string }).recordId
+    )
+    expect(new Set(touched)).toEqual(new Set([`part_def:${ASSEMBLY}`]))
+  })
+})

--- a/packages/lib/src/bom/cost-calculator.ts
+++ b/packages/lib/src/bom/cost-calculator.ts
@@ -413,13 +413,21 @@ async function loadCurrentPartValues(orgId: string): Promise<CurrentPartValues> 
 
 /**
  * Write calculated costs and unit prices back to each part's FieldValues.
- * Only writes parts whose values actually changed.
+ * Only touches parts whose values actually changed.
+ *
+ * **Authoritative, not additive.** A `null` in either map is a real answer — "this part
+ * has no calculated value" — and clears the stored FieldValue, rather than meaning "leave
+ * whatever is there". Without that, a part losing its last vendor (or its last subpart)
+ * keeps a frozen number that is visually indistinguishable from a fresh one; the caller
+ * must therefore map every part IN SCOPE, using `null` where there is no value, not only
+ * the parts that happen to have one.
+ *
  * Returns IDs of parts whose values changed.
  */
 async function persistCosts(
   orgId: string,
-  landedCosts: Map<string, number>,
-  unitPrices: Map<string, number>,
+  landedCosts: Map<string, number | null>,
+  unitPrices: Map<string, number | null>,
   previous: CurrentPartValues
 ): Promise<string[]> {
   const cache = getOrgCache()
@@ -482,24 +490,27 @@ async function persistCosts(
         const recordId = toRecordId(partDefId, entry.partId) as RecordId
         const writes: Promise<unknown>[] = []
 
-        if (entry.costChanged && entry.cost != null) {
+        // `value: null` IS the clear — `setValueWithType` deletes the field's rows and
+        // returns early. Same writer for set and clear, matching `catalog-pricing.ts`'s
+        // `writeCatalogNumberValues`; a raw `deleteValue` would skip `maybeUpdateDisplayValue`.
+        if (entry.costChanged) {
           writes.push(
             setValueWithType(ctx, {
               recordId,
               fieldId: costField.id,
               fieldType: toFieldType(costField.type),
-              value: { type: 'number', value: entry.cost },
+              value: entry.cost == null ? null : { type: 'number', value: entry.cost },
             })
           )
         }
 
-        if (entry.unitPriceChanged && unitPriceField && entry.unitPrice != null) {
+        if (entry.unitPriceChanged && unitPriceField) {
           writes.push(
             setValueWithType(ctx, {
               recordId,
               fieldId: unitPriceField.id,
               fieldType: toFieldType(unitPriceField.type),
-              value: { type: 'number', value: entry.unitPrice },
+              value: entry.unitPrice == null ? null : { type: 'number', value: entry.unitPrice },
             })
           )
         }
@@ -528,16 +539,20 @@ async function persistCosts(
       if (!changedPartIds.includes(entry.partId)) continue
       const recordId = toRecordId(partDefId, entry.partId) as RecordId
 
-      if (entry.costChanged && entry.cost != null) {
+      // A cleared cell publishes as `value: null`, NOT as an omitted entry: on
+      // `FieldValueUpdateEntry` an absent `value` means "don't touch the store"
+      // (realtime/events.ts), so skipping the entry would leave every open client
+      // rendering the stale number until a reload.
+      if (entry.costChanged) {
         entries.push({
           key: buildFieldValueKey(recordId, costField.id as FieldId),
-          value: { type: 'number', value: entry.cost },
+          value: entry.cost == null ? null : { type: 'number', value: entry.cost },
         })
       }
-      if (entry.unitPriceChanged && unitPriceField && entry.unitPrice != null) {
+      if (entry.unitPriceChanged && unitPriceField) {
         entries.push({
           key: buildFieldValueKey(recordId, unitPriceField.id as FieldId),
-          value: { type: 'number', value: entry.unitPrice },
+          value: entry.unitPrice == null ? null : { type: 'number', value: entry.unitPrice },
         })
       }
     }
@@ -603,14 +618,14 @@ export async function recalculateAffectedParts(
   // Calculate costs for all parts (memoized, so cheap)
   const allCosts = calculateAllCosts(landedCostMap, subpartGraph)
 
-  // Only persist values for the dirty set
-  const dirtyCosts = new Map<string, number>()
-  const dirtyUnitPrices = new Map<string, number>()
+  // Persist values for the dirty set — every member of it, `null` included. The dirty set
+  // IS the scope, so a part that no longer resolves to a cost or a vendor price maps to
+  // `null` and gets cleared, instead of dropping out of the map and keeping a frozen value.
+  const dirtyCosts = new Map<string, number | null>()
+  const dirtyUnitPrices = new Map<string, number | null>()
   for (const partId of dirtySet) {
-    const cost = allCosts.get(partId)
-    if (cost != null) dirtyCosts.set(partId, cost)
-    const up = unitPriceMap.get(partId)
-    if (up != null) dirtyUnitPrices.set(partId, up)
+    dirtyCosts.set(partId, allCosts.get(partId) ?? null)
+    dirtyUnitPrices.set(partId, unitPriceMap.get(partId) ?? null)
   }
 
   const previous = await loadCurrentPartValues(orgId)

--- a/packages/lib/src/money/catalog-pricing.ts
+++ b/packages/lib/src/money/catalog-pricing.ts
@@ -314,8 +314,11 @@ export async function syncCatalogItemPricing(
 
   for (const { catalogInstanceId, partInstanceId } of linkRows) {
     if (!partInstanceId) continue
-    const newCost = partCosts.get(partInstanceId)
-    if (newCost == null) continue
+    // `null` here is a real answer — the part has no cost, either because it never had one
+    // or because `persistCosts` just cleared it (a part that lost its last vendor and has no
+    // BOM). Skipping would leave the catalog item quoting a frozen cost for a part that no
+    // longer has one, which is the same defect one level down.
+    const newCost = partCosts.get(partInstanceId) ?? null
 
     const existing = current.get(catalogInstanceId) ?? { cost: null, markup: null, price: null }
     const recordId = toRecordId(catalogDefId, catalogInstanceId) as RecordId
@@ -329,7 +332,12 @@ export async function syncCatalogItemPricing(
       })
     }
 
-    if (fields.price && existing.markup != null) {
+    // Markup-driven price recomputes only against a real cost. When the cost goes away the
+    // price is LEFT ALONE and the markup KEPT — mirroring the unlink branch of
+    // `syncCatalogCostOnPartChange`: a markup is inert without a cost and resumes on re-link.
+    // Clearing the sell price here would take a product off the shelf because a supplier row
+    // was deleted.
+    if (fields.price && existing.markup != null && newCost != null) {
       const newPrice = computeMarkupPrice(newCost, existing.markup)
       if (existing.price !== newPrice) {
         writes.push({


### PR DESCRIPTION
## The defect

`persistCosts` was write-only. A `null` — *"this part has no calculated value"* — was read as *"nothing to do"* rather than *"clear it"*, by three separate guards: the two `!= null` filters building the dirty maps in `recalculateAffectedParts`, and the `!= null` conditions on the write and publish branches.

So a part that lost its last vendor part (or its last subpart) kept the number it had at the time — **visually indistinguishable from a fresh one**.

Live in dev, part `xpwlykdbqgbopiqsg4tpr6do` (AL400):

| field | stored | correct? |
|---|---|---|
| `part_cost` | `36000` = $360.00 | ✅ one subpart, Motor 400 @ `18000` × qty 2 |
| `part_unit_price` | `5000` = $50.00 | ❌ **frozen** — no vendor part exists |

The timestamps are the proof. `02:38:26` a vendor part is created, `part_unit_price` written $50.00. `02:39:51` it's deleted, recalc runs, `part_cost` correctly falls back to the BOM roll-up, and `part_unit_price` is not touched. The trigger wiring was always fine; only the write path was broken.

This is not only about deleted suppliers — every transition to nothing has the same shape: last subpart removed, vendor unit price cleared, BOM emptied.

## The fix

- **`persistCosts` is now authoritative.** The dirty set *is* the persist scope, so a part that no longer resolves to a value maps to `null` and gets cleared instead of dropping out of the map.
- **`setValueWithType(…, value: null)` is the clear** — it deletes the field's rows and returns early, which is exactly what `catalog-pricing.ts` already relies on for its unlink path. One writer for set and clear, rather than adding a `deleteValue` call that would skip `maybeUpdateDisplayValue`.
- **The realtime entry publishes `value: null` rather than being omitted.** An absent `value` on `FieldValueUpdateEntry` means *"don't touch the store"*, so skipping it would leave every open client rendering the stale number until a reload.

## `syncCatalogItemPricing` needed the same fix one level down

Newly reachable now that `part_cost` can be cleared: `if (newCost == null) continue` skipped the item entirely, leaving a catalog item quoting a frozen `catalog_item_cost` for a part that no longer has one.

**The sell price is deliberately left alone and the markup kept** — mirroring the documented unlink branch of `syncCatalogCostOnPartChange`, where a markup is inert without a cost and resumes on re-link. Clearing the price here would take a product off the shelf because a supplier row was deleted. Flag it if you'd rather it cleared.

## Tests

`cost-calculator.ts` had no test file. Adds one with 5 cases — **the three defect cases were verified to fail against the pre-fix code** and pass after; the other two are regression guards (no-op when values already match, don't touch parts outside the dirty set).

## Backfill — not run yet

`scripts/resweep-part-costs.ts` repairs parts frozen before this ships. `recalculateAllPartCosts` cannot do it: it persists only parts present in the vendor/subpart graph, so a part with neither is never looked at. The script passes every part id to `recalculateAffectedParts`, which seeds its dirty set from the caller. Idempotent.

**Blast radius is one cell.** Of the 9 parts carrying a `part_unit_price` in dev, 8 have a live vendor part and are correct; only AL400 is stale.

## Verification

- `tsc --noEmit` in `packages/lib` — 37 errors, all pre-existing, none in touched files
- 341 tests pass across `src/bom`, `src/money`, `src/field-hooks`
- Biome clean

## Follow-ups, not in this PR

This is Phase 0 of a larger plan (local notes, `plans/` is gitignored). Still open:

- **`part_cost` has no provenance** — it silently means *landed vendor cost* for a purchased part and *Σ(child × qty)* for an assembly, with nothing on the record saying which. A `purchaseCost` / `rollupCost` / `costSource` split would make a null meaningful and buy-vs-build visible.
- **`0` and "unknown" are the same value** — an unpriced leaf returns `0` and rolls straight up, so an assembly with unpriced components reports a confident $0.00. Latent today (0 of 15 costed parts sit at zero) but it's exactly what Gap C says must never reach a COGS posting.
- **`part_unit_price` is claimed by two plans for opposite things** — a computed *cost* today, a Shopify-seeded *sell price* in `plans/products/02 §5`. Needs a decision before that mapping ships.
- **Dangling inverse rows** — AL400 still carries two `part_vendor_parts` values pointing at deleted instances; `bom-cost-triggers.ts:70`'s *"soft-archive keeps FieldValue rows"* comment doesn't hold on that path.