### PR TITLE
feat(events): buffer in-transaction writes and replay their doors post-commit

### DIFF
--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -51,6 +51,12 @@ import {
   getRealtimeService,
   publishFieldValueUpdates,
 } from '../realtime'
+import {
+  getAmbientTxWriteScope,
+  isTxWriteCreated,
+  recordTxWriteChange,
+  type TxWriteScope,
+} from '../resources/crud/tx-write-scope'
 import { getModelType, isRecordId, parseRecordId, toRecordId } from '../resources/resource-id'
 import { applyAiMarker } from './ai-commit'
 import { shortCircuitAiGenerate } from './ai-enqueue'
@@ -61,6 +67,7 @@ import {
   canonicalizeRelationshipRecordId,
   canonicalizeRelationshipValue,
   type FieldValueContext,
+  flattenTypedFieldValue,
   getField,
   getInverseInfoFromField,
   type InverseFieldInfo,
@@ -154,6 +161,33 @@ export function buildPublishEntry(args: {
     return { key, value: values }
   }
   return { key, value: values.length > 0 ? values[0] : null }
+}
+
+/**
+ * Divert one field write into the open transaction write scope instead of
+ * publishing it (plan 04 §6.3). Two things are captured, both plain values:
+ *
+ * - `{ o, n }` under the manifest's output key (`systemAttribute ?? fieldId`),
+ *   because post-commit the pre-write value no longer exists anywhere;
+ * - the `fieldValues:updated` entry the inline lane would have published,
+ *   shaped here where the typed values are in hand, so the flush replays a frame
+ *   that is byte-identical to the inline one.
+ */
+function bufferFieldChange(
+  scope: TxWriteScope,
+  publishRecordId: RecordId,
+  field: CachedField | undefined,
+  fieldId: string,
+  oldValue: TypedFieldValue | TypedFieldValue[] | null,
+  newValue: TypedFieldValue | TypedFieldValue[] | null,
+  entry: FieldValueUpdateEntry
+): void {
+  recordTxWriteChange(scope, {
+    recordId: publishRecordId,
+    outputKey: field?.systemAttribute ?? fieldId,
+    change: { o: flattenTypedFieldValue(oldValue), n: flattenTypedFieldValue(newValue) },
+    entry,
+  })
 }
 
 // =============================================================================
@@ -2255,14 +2289,22 @@ export async function setValueWithBuiltIn(
     })
   }
 
-  const {
-    recordId,
-    fieldId: rawFieldId,
-    value,
-    publishEvents = true,
-    skipInverseSync = false,
-    collectRealtime,
-  } = params
+  const { recordId, fieldId: rawFieldId, value, skipInverseSync = false, collectRealtime } = params
+
+  // Plan 04 §6.2. An explicit `publishEvents: false` is the C3 escape hatch —
+  // "an aggregator one frame up announces this" — and stays absolute: it
+  // suppresses buffering too, or the aggregator's own publish would be doubled.
+  // Otherwise a buffered write session diverts the fan-out into its scope, to be
+  // replayed once the transaction commits.
+  const requestedPublish = params.publishEvents ?? true
+  const bufferedScope = requestedPublish ? getAmbientTxWriteScope(ctx.session) : undefined
+  const publishEvents = requestedPublish && bufferedScope === undefined
+  // T-1: a record being CREATED in this same scope absorbs its own field writes
+  // — they are its initial state, not changes to it — so there is nothing worth
+  // capturing, and skipping here also spares the old-value read per field on
+  // every composed child record.
+  const txScope =
+    bufferedScope && !isTxWriteCreated(bufferedScope, recordId) ? bufferedScope : undefined
 
   // Parse RecordId to get both parts
   const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
@@ -2393,9 +2435,10 @@ export async function setValueWithBuiltIn(
     publishEvents &&
     ctx.userId !== undefined &&
     (hasEntityFieldChangeHooks(entitySlug) || hasFieldTypeChangeHooks(field.type as FieldType))
-  const oldValue: TypedFieldValue | TypedFieldValue[] | null = willFirePostHook
-    ? await getValue(ctx, { recordId, fieldId })
-    : null
+  // A buffered write needs `o` too, and needs it NOW: post-commit the pre-write
+  // value is gone (plan 04 §6.3).
+  const oldValue: TypedFieldValue | TypedFieldValue[] | null =
+    willFirePostHook || txScope ? await getValue(ctx, { recordId, fieldId }) : null
 
   // Closure so set + clear branches fire the post-hook chain identically.
   // Resolves snapshots once per write so handlers (timeline writer especially)
@@ -2455,7 +2498,7 @@ export async function setValueWithBuiltIn(
     }
     await deleteValue(ctx, { recordId, fieldId })
     await maybeUpdateDisplayValue(ctx, recordId, field, null)
-    if (publishEvents) {
+    if (publishEvents || txScope) {
       // Routed through buildPublishEntry like the set branch below — this
       // publishes `[]` (not `null`) for array-return fields, matching
       // setBulkValues' "cleared" signal (see helper doc).
@@ -2475,7 +2518,9 @@ export async function setValueWithBuiltIn(
         aiStatus: null,
         aiMetadata: null,
       }
-      if (collectRealtime) {
+      if (txScope) {
+        bufferFieldChange(txScope, publishRecordId, field, fieldId, oldValue, null, entry)
+      } else if (collectRealtime) {
         collectRealtime.push(entry)
       } else {
         publishFieldValueUpdates(getRealtimeService(), ctx.organizationId, [entry], {
@@ -2531,7 +2576,7 @@ export async function setValueWithBuiltIn(
   // RELATIONSHIP, multi-ACTOR) always publish arrays so subscribers can write
   // directly to the store without guessing. Single-value fields publish the
   // single value.
-  if (publishEvents && result.length > 0) {
+  if ((publishEvents || txScope) && result.length > 0) {
     const baseEntry = buildPublishEntry({
       publishRecordId,
       fieldId: fieldId as FieldId,
@@ -2545,7 +2590,17 @@ export async function setValueWithBuiltIn(
     const entry: FieldValueUpdateEntry = params.aiGeneration
       ? { ...baseEntry, aiStatus: 'result', aiMetadata: params.aiGeneration }
       : { ...baseEntry, aiStatus: null, aiMetadata: null }
-    if (collectRealtime) {
+    if (txScope) {
+      bufferFieldChange(
+        txScope,
+        publishRecordId,
+        field,
+        fieldId,
+        oldValue,
+        isArrayReturn ? result : (result[0] ?? null),
+        entry
+      )
+    } else if (collectRealtime) {
       collectRealtime.push(entry)
     } else {
       publishFieldValueUpdates(getRealtimeService(), ctx.organizationId, [entry], {
@@ -2696,7 +2751,13 @@ export async function setValuesForEntity(
           value: v.value,
           publishEvents,
           skipInverseSync,
-          collectRealtime: publishEvents ? collected : undefined,
+          // A buffered session captures per field inside `setValueWithBuiltIn`;
+          // handing it a collector as well would batch-publish the same frames
+          // mid-transaction.
+          collectRealtime:
+            publishEvents && getAmbientTxWriteScope(ctx.session) === undefined
+              ? collected
+              : undefined,
         })
 
         results.push({ fieldId: v.fieldId, ...result })

--- a/packages/lib/src/money/__tests__/line-copy-absorption.test.ts
+++ b/packages/lib/src/money/__tests__/line-copy-absorption.test.ts
@@ -1,0 +1,66 @@
+// packages/lib/src/money/__tests__/line-copy-absorption.test.ts
+//
+// T-1b (plans/events/04-in-transaction-write-semantics-plan.md §4): one of the
+// two sites that opt into create absorption. `copyLineOntoInvoice` must declare
+// the invoice it is copying onto — and must NOT thread a `publishEvents`
+// boolean any more (plan 04 §7.3, B-18: the ambient write session decides).
+
+import type { RecordId } from '@auxx/types/resource'
+import { describe, expect, it, vi } from 'vitest'
+import { copyLineOntoInvoice } from '../gather'
+
+const INVOICE_RECORD_ID = 'invoice:inv_1' as RecordId
+
+function fakeHandler() {
+  return {
+    getFieldValues: vi.fn(async () => new Map()),
+    create: vi.fn(async () => ({ instance: { id: 'line_copy_1' } })),
+  }
+}
+
+describe('copyLineOntoInvoice — T-1b', () => {
+  it('declares the invoice as the absorbing parent and passes no door boolean', async () => {
+    const handler = fakeHandler()
+
+    await copyLineOntoInvoice({
+      handler: handler as never,
+      fieldValueService: {} as never,
+      lineCf: {} as never,
+      lineFieldIds: [],
+      lineInstanceId: 'line_1',
+      invoiceRecordId: INVOICE_RECORD_ID,
+    })
+
+    expect(handler.create).toHaveBeenCalledTimes(1)
+    const [defId, , options] = handler.create.mock.calls[0] as unknown as [
+      string,
+      Record<string, unknown>,
+      Record<string, unknown>,
+    ]
+    expect(defId).toBe('line_item')
+    expect(options).toEqual({ absorbInto: INVOICE_RECORD_ID })
+    expect(options).not.toHaveProperty('skipEvents')
+  })
+
+  it('still stamps the invoice link on the copy', async () => {
+    const handler = fakeHandler()
+
+    await copyLineOntoInvoice({
+      handler: handler as never,
+      fieldValueService: {} as never,
+      lineCf: {} as never,
+      lineFieldIds: [],
+      lineInstanceId: 'line_1',
+      invoiceRecordId: INVOICE_RECORD_ID,
+      extraValues: { line_item_visit_id: 'visit_1' },
+    })
+
+    const [, values] = handler.create.mock.calls[0] as unknown as [
+      string,
+      Record<string, unknown>,
+      Record<string, unknown>,
+    ]
+    expect(values.line_item_invoice).toBe(INVOICE_RECORD_ID)
+    expect(values.line_item_visit_id).toBe('visit_1')
+  })
+})

--- a/packages/lib/src/money/billing-commands.ts
+++ b/packages/lib/src/money/billing-commands.ts
@@ -8,6 +8,8 @@ import { getOrgCache } from '../cache'
 import { BadRequestError } from '../errors'
 import { FieldValueService } from '../field-values/field-value-service'
 import { UnifiedCrudHandler } from '../resources/crud'
+import { flushTxWriteScope } from '../resources/crud/tx-write-flush'
+import { runInTxWrite, type TxWriteScope } from '../resources/crud/tx-write-scope'
 import { allocateProportionally, resolveFixedInvoiceAmount } from './billing-allocation-math'
 import {
   allocateInvoiceLine,
@@ -46,12 +48,33 @@ function databaseErrorCode(error: unknown): string | undefined {
     : undefined
 }
 
-async function withSerializableRetry<T>(operation: (db: Database) => Promise<T>): Promise<T> {
+/**
+ * Run `operation` in a serializable transaction, retrying the SQLSTATE 40001 /
+ * 40P01 arms, and hand back the transaction write scope its doors were buffered
+ * into (plan 04 §6.4).
+ *
+ * The per-attempt contract (T-5) is what this shape exists for. `runInTxWrite`
+ * mints the scope INSIDE the transaction callback and returns it by value, so:
+ * a retry runs a fresh callback and therefore a fresh, empty buffer; and an
+ * attempt that throws rejects without producing a scope at all, which makes it
+ * structurally impossible to flush writes a rollback undid. Nothing in this file
+ * — or reachable from it — can hold a scope across attempts, because nothing
+ * outside the callback ever has one to hold.
+ */
+async function withSerializableRetry<T>(
+  scopeArgs: { organizationId: string; userId: string },
+  operation: (db: Database) => Promise<T>
+): Promise<{ result: T; scope: TxWriteScope; owned: boolean }> {
   for (let attempt = 1; attempt <= MAX_SERIALIZABLE_ATTEMPTS; attempt++) {
     try {
-      return await database.transaction((tx) => operation(tx as unknown as Database), {
-        isolationLevel: 'serializable',
-      })
+      return await database.transaction(
+        (tx) =>
+          runInTxWrite(
+            { organizationId: scopeArgs.organizationId, actorUserId: scopeArgs.userId },
+            () => operation(tx as unknown as Database)
+          ),
+        { isolationLevel: 'serializable' }
+      )
     } catch (error) {
       const code = databaseErrorCode(error)
       if ((code !== '40001' && code !== '40P01') || attempt === MAX_SERIALIZABLE_ATTEMPTS) {
@@ -133,7 +156,6 @@ async function finishInvoice(input: {
     documentType: 'invoice',
     documentInstanceId: input.invoiceInstanceId,
     db: input.db,
-    publishEvents: !input.db,
   })
 
   // money 16-deposit-accounting.md §C.2 settle point — every invoice-creation command
@@ -142,8 +164,9 @@ async function finishInvoice(input: {
   // invoice's real `invoice_total` — the value `applyHeldDepositsToInvoice` needs to cap
   // allocation at (moved here from `createInvoiceShell`, which runs before any line is copied
   // and so never had a real total to cap against). Same `db` (the `withSerializableRetry`
-  // transaction every caller wraps this in) and the same `publishEvents: !input.db` threading as
-  // `recomputeTotals` just above. `workOrderInstanceId` is a required, non-nullable input on
+  // transaction every caller wraps this in) as `recomputeTotals` just above; door behavior is
+  // no longer threaded at all — the buffered session decides (plan 04 §7.3, B-18).
+  // `workOrderInstanceId` is a required, non-nullable input on
   // every one of these commands (`WorkOrderBillingCommandInput`) — same guarantee the old
   // shell-embedded call relied on, no extra guard needed.
   const totalsById = await batchReadSystemValues({
@@ -161,7 +184,6 @@ async function finishInvoice(input: {
     invoiceInstanceId: input.invoiceInstanceId,
     invoiceTotal,
     db: input.db,
-    publishEvents: !input.db,
   })
 
   return { recordId: input.invoiceRecordId, instanceId: input.invoiceInstanceId }
@@ -202,12 +224,33 @@ async function sumPriorFixedDiscounts(input: {
   return total
 }
 
-async function projectCommittedInvoice(input: {
+/**
+ * The post-commit settle step every invoice-creation command ends with. Two
+ * halves, in this order (O-9):
+ *
+ * 1. flush the transaction write scope — the invoice's own `record:created`,
+ *    carrying its full initial state, with the copied lines and the payment
+ *    mirror folded in (T-1b) and the composed field writes absorbed (T-1);
+ * 2. re-sync the two billing projections, which run events-ON.
+ *
+ * The order is load-bearing: a projection's `fieldValues:updated` for a
+ * brand-new invoice reaching clients before the `record:created` that says the
+ * record exists is a frame nobody can apply.
+ */
+async function settleInvoiceCommands(input: {
   organizationId: string
   userId: string
   workOrderInstanceId: string
+  scope: TxWriteScope
+  /** False when this command JOINED an outer scope — see {@link runInTxWrite}. */
+  owned: boolean
   result: CreateInvoiceFromWorkOrderResult
 }): Promise<CreateInvoiceFromWorkOrderResult> {
+  // Flush only what we own. A joined scope belongs to the outer composition,
+  // which flushes it once for everyone; draining it here would re-announce that
+  // composition's accumulated creates and, under a retry, replay rolled-back
+  // captures (T-5).
+  if (input.owned) await flushTxWriteScope(input.scope)
   try {
     await syncInvoiceBillingProjection({
       organizationId: input.organizationId,
@@ -230,7 +273,7 @@ async function projectCommittedInvoice(input: {
 export async function createFixedContractInvoice(
   input: CreateFixedContractInvoiceInput
 ): Promise<CreateInvoiceFromWorkOrderResult> {
-  const result = await withSerializableRetry(async (db) => {
+  const { result, scope, owned } = await withSerializableRetry(input, async (db) => {
     const projection = await computeWorkOrderBillingProjection({ ...input, db })
     if (projection.basis !== 'fixed_contract') {
       throw new BadRequestError('This work order does not use fixed-contract billing')
@@ -268,7 +311,7 @@ export async function createFixedContractInvoice(
       remainingValue: remaining.reduce((sum, line) => sum + line.amount, 0),
     })
     const allocations = allocateProportionally(remaining, selectedAmount)
-    const shell = await createInvoiceShell({ ...input, db, publishEvents: false })
+    const shell = await createInvoiceShell({ ...input, db })
     const service = new FieldValueService(input.organizationId, input.userId, db)
     if (shell.discountType === 'amount' && shell.discountValue) {
       const remainingValue = remaining.reduce((sum, line) => sum + line.amount, 0)
@@ -288,7 +331,6 @@ export async function createFixedContractInvoice(
       await service.setValuesForEntity({
         recordId: shell.recordId,
         values: [{ fieldId: 'invoice_discount_value', value: discountValue }],
-        publishEvents: false,
       })
     }
     for (const allocation of allocations) {
@@ -299,7 +341,6 @@ export async function createFixedContractInvoice(
         lineFieldIds: source.fieldIds,
         lineInstanceId: allocation.sourceLineItemId,
         invoiceRecordId: shell.recordId,
-        publishEvents: false,
         extraValues: {
           line_item_qty: 1,
           line_item_unit_price: allocation.amount,
@@ -330,7 +371,7 @@ export async function createFixedContractInvoice(
       invoiceRecordId: shell.recordId,
     })
   })
-  return projectCommittedInvoice({ ...input, result })
+  return settleInvoiceCommands({ ...input, scope, owned, result })
 }
 
 /** Create one allocation-backed invoice for selected visits — `'done'` only by default, or (with
@@ -339,7 +380,7 @@ export async function createVisitInvoice(
   input: CreateVisitInvoiceInput
 ): Promise<CreateInvoiceFromWorkOrderResult> {
   if (input.visitIds.length === 0) throw new BadRequestError('Select at least one visit')
-  const result = await withSerializableRetry(async (db) => {
+  const { result, scope, owned } = await withSerializableRetry(input, async (db) => {
     const projection = await computeWorkOrderBillingProjection({ ...input, db })
     if (projection.basis !== 'per_visit') {
       throw new BadRequestError('This work order does not use per-visit billing')
@@ -364,7 +405,7 @@ export async function createVisitInvoice(
     const source = await getSourceLines({ ...input, db })
     const templates = source.lines.filter((line) => !line.visitId && line.amount > 0)
     const additions = source.lines.filter((line) => line.visitId && line.amount > 0)
-    const shell = await createInvoiceShell({ ...input, db, publishEvents: false })
+    const shell = await createInvoiceShell({ ...input, db })
     const service = new FieldValueService(input.organizationId, input.userId, db)
     for (const visit of visits) {
       await allocateInvoiceVisit({
@@ -383,7 +424,6 @@ export async function createVisitInvoice(
           lineFieldIds: source.fieldIds,
           lineInstanceId: line.id,
           invoiceRecordId: shell.recordId,
-          publishEvents: false,
           extraValues: { line_item_visit_id: visit.id },
         })
         await allocateInvoiceLine({
@@ -406,14 +446,14 @@ export async function createVisitInvoice(
       invoiceRecordId: shell.recordId,
     })
   })
-  return projectCommittedInvoice({ ...input, result })
+  return settleInvoiceCommands({ ...input, scope, owned, result })
 }
 
 /** Create a recurring flat-rate invoice for one occurrence identity. */
 export async function createRecurringCharge(
   input: CreateRecurringChargeInput
 ): Promise<CreateInvoiceFromWorkOrderResult> {
-  const result = await withSerializableRetry(async (db) => {
+  const { result, scope, owned } = await withSerializableRetry(input, async (db) => {
     const projection = await computeWorkOrderBillingProjection({ ...input, db })
     if (projection.basis !== 'recurring_flat') {
       throw new BadRequestError('This work order does not use recurring flat-rate billing')
@@ -431,12 +471,7 @@ export async function createRecurringCharge(
     const templates = source.lines.filter((line) => !line.visitId && line.amount > 0)
     if (templates.length === 0)
       throw new BadRequestError('Add a billing-period line before invoicing')
-    const shell = await createInvoiceShell({
-      ...input,
-      issuedAt: occurrenceDate,
-      db,
-      publishEvents: false,
-    })
+    const shell = await createInvoiceShell({ ...input, issuedAt: occurrenceDate, db })
     await allocateScheduleOccurrence({
       db,
       organizationId: input.organizationId,
@@ -454,7 +489,6 @@ export async function createRecurringCharge(
         lineFieldIds: source.fieldIds,
         lineInstanceId: line.id,
         invoiceRecordId: shell.recordId,
-        publishEvents: false,
       })
       await allocateInvoiceLine({
         db,
@@ -474,14 +508,14 @@ export async function createRecurringCharge(
       invoiceRecordId: shell.recordId,
     })
   })
-  return projectCommittedInvoice({ ...input, result })
+  return settleInvoiceCommands({ ...input, scope, owned, result })
 }
 
 /** Create a separate invoice for additive visit work without consuming base visit pricing. */
 export async function createExtraWorkInvoice(
   input: CreateExtraWorkInvoiceInput
 ): Promise<CreateInvoiceFromWorkOrderResult> {
-  const result = await withSerializableRetry(async (db) => {
+  const { result, scope, owned } = await withSerializableRetry(input, async (db) => {
     const source = await getSourceLines({ ...input, db })
     const selected = source.lines.filter(
       (line) =>
@@ -518,7 +552,7 @@ export async function createExtraWorkInvoice(
     )
     if (eligible.length === 0)
       throw new BadRequestError('No selected extra work is ready to invoice')
-    const shell = await createInvoiceShell({ ...input, db, publishEvents: false })
+    const shell = await createInvoiceShell({ ...input, db })
     const service = new FieldValueService(input.organizationId, input.userId, db)
     for (const visitId of new Set(eligible.map((line) => line.visitId!))) {
       await allocateInvoiceVisit({
@@ -538,7 +572,6 @@ export async function createExtraWorkInvoice(
         lineFieldIds: source.fieldIds,
         lineInstanceId: line.id,
         invoiceRecordId: shell.recordId,
-        publishEvents: false,
         extraValues: { line_item_visit_id: line.visitId },
       })
       await allocateInvoiceLine({
@@ -560,14 +593,14 @@ export async function createExtraWorkInvoice(
       invoiceRecordId: shell.recordId,
     })
   })
-  return projectCommittedInvoice({ ...input, result })
+  return settleInvoiceCommands({ ...input, scope, owned, result })
 }
 
 /** Move unallocated visit additions into the fixed contract so future progress claims include them. */
 export async function addVisitExtrasToContract(
   input: AddVisitExtrasToContractInput
 ): Promise<void> {
-  await withSerializableRetry(async (db) => {
+  const { scope, owned } = await withSerializableRetry(input, async (db) => {
     const projection = await computeWorkOrderBillingProjection({ ...input, db })
     if (projection.basis !== 'fixed_contract') {
       throw new BadRequestError('Only fixed-contract extras can be added to the contract')
@@ -588,9 +621,13 @@ export async function addVisitExtrasToContract(
       await service.setValuesForEntity({
         recordId: toRecordId('line_item', line.id),
         values: [{ fieldId: 'line_item_visit_id', value: null }],
-        publishEvents: false,
       })
     }
   })
+  // The one genuine C2 site in money (plan 04 §2, leaf #7): these lines already
+  // existed and are already on someone's screen, and they are NOT in the scope's
+  // `created` set, so the flush replays their `fieldValues:updated` per line
+  // rather than absorbing them.
+  if (owned) await flushTxWriteScope(scope)
   await syncWorkOrderBillingProjection(input)
 }

--- a/packages/lib/src/money/gather.ts
+++ b/packages/lib/src/money/gather.ts
@@ -12,6 +12,8 @@ import { BadRequestError } from '../errors'
 import type { FileValue } from '../field-values/converters'
 import { FieldValueService } from '../field-values/field-value-service'
 import { UnifiedCrudHandler } from '../resources/crud'
+import { flushTxWriteScope } from '../resources/crud/tx-write-flush'
+import { runInTxWrite } from '../resources/crud/tx-write-scope'
 import { getOrganizationSetting } from '../settings/settings-service'
 import { allocateInvoiceLine, getActiveAllocatedAmounts } from './billing-allocations'
 import {
@@ -208,7 +210,6 @@ export async function createInvoiceShell(input: {
   issuedAt?: string
   extraValues?: Record<string, unknown>
   db?: Database
-  publishEvents?: boolean
 }) {
   const { organizationId, userId, workOrderInstanceId, issuedAt, extraValues, db } = input
   const handler = new UnifiedCrudHandler(organizationId, userId, db)
@@ -301,9 +302,10 @@ export async function createInvoiceShell(input: {
   if (taxName) invoiceValues.invoice_tax_name = taxName
   if (taxRate !== null) invoiceValues.invoice_tax_rate = taxRate
 
-  const createdInvoice = await handler.create('invoice', invoiceValues, {
-    skipEvents: input.publishEvents === false,
-  })
+  // No door options: the ambient write session decides (plan 04 §7.3). Inside a
+  // billing command's buffered scope this create is captured and announced once
+  // post-commit; on the inline path it announces itself as it always did.
+  const createdInvoice = await handler.create('invoice', invoiceValues)
 
   // NOTE: the money 16-deposit-accounting.md §C.2 deposit-settle call used to live here, but
   // `invoice_total` is `creatable: false` — it's written exactly once, by `recomputeTotals`,
@@ -346,17 +348,8 @@ export async function copyLineOntoInvoice(input: {
   lineInstanceId: string
   invoiceRecordId: RecordId
   extraValues?: Record<string, unknown>
-  publishEvents?: boolean
 }): Promise<{ instanceId: string }> {
-  const {
-    handler,
-    lineCf,
-    lineFieldIds,
-    lineInstanceId,
-    invoiceRecordId,
-    extraValues,
-    publishEvents,
-  } = input
+  const { handler, lineCf, lineFieldIds, lineInstanceId, invoiceRecordId, extraValues } = input
   const lineRecordId = toRecordId('line_item', lineInstanceId)
   const values = await handler.getFieldValues(lineRecordId, lineFieldIds)
   const get = (f?: { id: string } | null) => (f ? firstTyped(values.get(f.id)) : undefined)
@@ -401,8 +394,13 @@ export async function copyLineOntoInvoice(input: {
     copyValues.line_item_catalog_item = catalogItemTyped.recordId
   }
 
+  // T-1b: a copied line is STRUCTURAL to the invoice it is being copied onto.
+  // When that invoice is itself being created in the same buffered scope, its
+  // one `record:created` announces the whole composition and this line opens no
+  // door of its own. Inert everywhere else — a line added to an invoice that
+  // already exists is a genuine create and still announces itself.
   const created = await handler.create('line_item', copyValues, {
-    skipEvents: publishEvents === false,
+    absorbInto: invoiceRecordId,
   })
   return { instanceId: created.instance.id }
 }
@@ -418,6 +416,40 @@ export async function copyLineOntoInvoice(input: {
  * @returns `{ recordId, instanceId }` — the client opens `/app/invoices?id=<instanceId>`.
  */
 export async function createInvoiceFromWorkOrder(
+  input: CreateInvoiceFromWorkOrderInput
+): Promise<CreateInvoiceFromWorkOrderResult> {
+  const { organizationId, userId, workOrderInstanceId } = input
+
+  // B-17 (plan 04 §5 / O-2): this flow and the four `billing-commands.ts`
+  // builders compose the SAME invoice and used to announce it two different
+  // ways — ~N+1 creates plus ~6 field updates here, nothing at all there. Both
+  // now compose inside a buffered write scope, so both emit exactly one
+  // `record:created` for the invoice, carrying its full initial state. There is
+  // no transaction here (there never was); the scope is doing the door
+  // buffering, not the atomicity.
+  const { result, scope, owned } = await runInTxWrite(
+    { organizationId, actorUserId: userId },
+    async () => composeInvoiceFromWorkOrder(input)
+  )
+  // Flush only what we own — a joined scope is the outer composition's to drain
+  // (see `runInTxWrite`); draining it here duplicates its creates.
+  if (owned) await flushTxWriteScope(scope)
+
+  // Ordered AFTER the flush (O-9): a projection's `fieldValues:updated` for a
+  // brand-new invoice must not reach clients before the `record:created` that
+  // tells them the record exists.
+  await syncInvoiceBillingProjection({
+    organizationId,
+    userId,
+    invoiceInstanceId: result.instanceId,
+  })
+  await syncWorkOrderBillingProjection({ organizationId, userId, workOrderInstanceId })
+
+  return result
+}
+
+/** The composition half of {@link createInvoiceFromWorkOrder}, run inside the buffered scope. */
+async function composeInvoiceFromWorkOrder(
   input: CreateInvoiceFromWorkOrderInput
 ): Promise<CreateInvoiceFromWorkOrderResult> {
   const { organizationId, userId, workOrderInstanceId, lineInstanceIds } = input
@@ -518,10 +550,9 @@ export async function createInvoiceFromWorkOrder(
     invoiceTotal,
   })
 
-  await syncInvoiceBillingProjection({ organizationId, userId, invoiceInstanceId })
-  await syncWorkOrderBillingProjection({ organizationId, userId, workOrderInstanceId })
-
   // ─── Step 8: return ─────────────────────────────────────────────────────────
+  // The two billing projections are deliberately NOT here — they run
+  // events-on, post-flush, in the caller.
   return { recordId: invoiceRecordId, instanceId: invoiceInstanceId }
 }
 

--- a/packages/lib/src/money/payments/ledger.ts
+++ b/packages/lib/src/money/payments/ledger.ts
@@ -172,7 +172,7 @@ export async function listWorkOrderPayments(
  * precedent). Only writes fields that actually changed, to avoid no-op event churn.
  */
 export async function syncInvoicePaymentState(
-  input: SyncInvoicePaymentStateInput & { db?: Database; publishEvents?: boolean }
+  input: SyncInvoicePaymentStateInput & { db?: Database }
 ): Promise<void> {
   const { organizationId, userId, invoiceInstanceId } = input
   const db = input.db ?? database
@@ -231,11 +231,12 @@ export async function syncInvoicePaymentState(
   if (writes.length === 0) return
 
   const fieldValueService = new FieldValueService(organizationId, userId, db)
-  await fieldValueService.setValuesForEntity({
-    recordId: invoiceRecordId,
-    values: writes,
-    publishEvents: input.publishEvents ?? true,
-  })
+  // No `publishEvents` (plan 04 §7.3): the ambient write session decides. On the
+  // four Stripe rails these writes are and stay loud; reached from
+  // `recomputeInvoiceTotals` during a buffered billing composition they are
+  // captured and either absorbed into the invoice's `record:created` (T-1) or
+  // replayed post-commit for a pre-existing invoice (the O-8 cross-invoice case).
+  await fieldValueService.setValuesForEntity({ recordId: invoiceRecordId, values: writes })
 }
 
 /**
@@ -259,7 +260,6 @@ export async function syncTransaction(params: {
   userId: string
   transaction: PaymentTransactionEntity
   db?: Database
-  publishEvents?: boolean
 }): Promise<void> {
   const { organizationId, userId, transaction } = params
   const db = params.db ?? database
@@ -289,7 +289,12 @@ export async function syncTransaction(params: {
           payment_invoice: invoiceRecordId,
           payment_transaction_id: transaction.id,
         },
-        { skipEvents: params.publishEvents === false }
+        // T-1b: a payment mirror is STRUCTURAL to the invoice it mirrors onto.
+        // When that invoice is being created in the same buffered scope (a
+        // deposit settling onto a freshly composed invoice), its single
+        // `record:created` announces the mirror too. Inert otherwise — a
+        // payment against an existing invoice still announces itself.
+        { absorbInto: invoiceRecordId }
       )
 
       await db
@@ -303,13 +308,7 @@ export async function syncTransaction(params: {
     ...new Set(allocations.map((allocation) => allocation.invoiceInstanceId)),
   ]
   for (const invoiceInstanceId of invoiceInstanceIds) {
-    await syncInvoicePaymentState({
-      organizationId,
-      userId,
-      invoiceInstanceId,
-      db,
-      publishEvents: params.publishEvents,
-    })
+    await syncInvoicePaymentState({ organizationId, userId, invoiceInstanceId, db })
   }
 }
 
@@ -341,7 +340,6 @@ export async function applyHeldDepositsToInvoice(params: {
    * this call is then a structural no-op, which is correct: there's nothing to apply yet). */
   invoiceTotal: number
   db?: Database
-  publishEvents?: boolean
 }): Promise<void> {
   const { organizationId, userId, workOrderInstanceId, invoiceInstanceId, invoiceTotal } = params
   const db = params.db ?? database
@@ -403,13 +401,7 @@ export async function applyHeldDepositsToInvoice(params: {
   for (const transaction of depositCharges.filter((charge) =>
     plannedTransactionIds.has(charge.id)
   )) {
-    await syncTransaction({
-      organizationId,
-      userId,
-      transaction,
-      db,
-      publishEvents: params.publishEvents,
-    })
+    await syncTransaction({ organizationId, userId, transaction, db })
   }
 }
 

--- a/packages/lib/src/money/totals-hooks.ts
+++ b/packages/lib/src/money/totals-hooks.ts
@@ -77,7 +77,7 @@ export const INVOICE_TRIGGER_ATTRS = new Set<SystemAttribute>([
  * existing quote call sites keep compiling unchanged.
  */
 export async function recomputeTotals(
-  input: RecomputeTotalsInput & { db?: Database; publishEvents?: boolean }
+  input: RecomputeTotalsInput & { db?: Database }
 ): Promise<void> {
   const { organizationId, userId } = input
   const documentType = input.documentType ?? 'quote'
@@ -94,7 +94,6 @@ export async function recomputeTotals(
       userId,
       invoiceInstanceId: documentInstanceId,
       db: input.db,
-      publishEvents: input.publishEvents,
     })
     return
   }
@@ -222,9 +221,8 @@ async function recomputeInvoiceTotals(params: {
   userId: string
   invoiceInstanceId: string
   db?: Database
-  publishEvents?: boolean
 }): Promise<void> {
-  const { organizationId, userId, invoiceInstanceId, db, publishEvents = true } = params
+  const { organizationId, userId, invoiceInstanceId, db } = params
   const invoiceRecordId = toRecordId('invoice', invoiceInstanceId)
   const handler = new UnifiedCrudHandler(organizationId, userId, db)
   const cache = getOrgCache()
@@ -328,16 +326,9 @@ async function recomputeInvoiceTotals(params: {
       { fieldId: 'invoice_tax_total', value: totals.taxTotal },
       { fieldId: 'invoice_total', value: totals.total },
     ],
-    publishEvents,
   })
 
-  await syncInvoicePaymentState({
-    organizationId,
-    userId,
-    invoiceInstanceId,
-    db,
-    publishEvents,
-  })
+  await syncInvoicePaymentState({ organizationId, userId, invoiceInstanceId, db })
 }
 
 /**

--- a/packages/lib/src/resources/crud/__tests__/tx-write-scope.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/tx-write-scope.test.ts
@@ -1,0 +1,557 @@
+// packages/lib/src/resources/crud/__tests__/tx-write-scope.test.ts
+//
+// Phase A of plans/events/04-in-transaction-write-semantics-plan.md: the
+// transaction write scope and its flush.
+//
+// - sessionLane gains 'buffered'; `absorbed`/`quiet` resolve to 'silent'.
+// - T-5, the per-attempt contract: a scope is minted inside the callback,
+//   returned by value only on the resolving path, never reused by a retry,
+//   and joined (not stacked) when nested.
+// - T-4: a buffered effect is pure data; the flush asserts it.
+// - T-1 / T-1b: a created record absorbs its own field changes, and a create
+//   that DECLARES a created parent is absorbed into that parent's create.
+// - O-8: changes on a record that already existed replay as C2.
+// - T-6: the flush is best-effort.
+//
+// @auxx/database is globally mocked in src/test/setup.ts.
+
+import { err, ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => {
+  // Arg-typed so `mock.calls[n][i]` is legal for tsc — an untyped `vi.fn()`
+  // types its calls as an empty tuple (TS2493), the same note
+  // `door-conformance.test.ts` carries.
+  const publish = vi.fn<(room: unknown, event: string, data?: unknown) => Promise<void>>(
+    async () => {}
+  )
+  return {
+    publish,
+    publishLater: vi.fn<(event: { type: string; data: unknown }) => void>(() => {}),
+    publishFieldValueUpdates: vi.fn<
+      (service: unknown, org: string, entries: unknown[]) => Promise<void>
+    >(async () => {}),
+    publishRecordsInvalidated: vi.fn(async () => {}),
+    enqueueDuplicateScan: vi.fn(async () => 'job_1'),
+    getEntityInstance: vi.fn(async () => ok({ id: 'inst_1', displayName: 'Invoice 1' })),
+    findCachedResource: vi.fn(async () => ({ fields: [] })),
+    createEntityInstance: vi.fn(async () => ({ isOk: () => true, value: { id: 'inst_1' } })),
+    // A spy, not a plain arrow: the T-6 entry test needs it to throw once.
+    getRealtimeService: vi.fn<() => { publish: typeof publish }>(() => ({ publish })),
+  }
+})
+
+vi.mock('../../../realtime', () => ({
+  getRealtimeService: h.getRealtimeService,
+  rooms: { orgRecords: (org: string, def: string) => `records:${org}:${def}` },
+  publishFieldValueUpdates: h.publishFieldValueUpdates,
+  publishRecordsInvalidated: h.publishRecordsInvalidated,
+}))
+vi.mock('../../../events/publisher', () => ({
+  publisher: { publishLater: h.publishLater, publish: h.publishLater },
+}))
+vi.mock('../../../dedup/enqueue-scan', () => ({ enqueueDuplicateScan: h.enqueueDuplicateScan }))
+vi.mock('../../../cache', () => ({ findCachedResource: h.findCachedResource }))
+vi.mock('../../../entity-instances', () => ({
+  getEntityInstance: h.getEntityInstance,
+  createEntityInstance: h.createEntityInstance,
+  updateEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+  deleteEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+}))
+
+import type { RecordId } from '@auxx/types/resource'
+import { flushTxWriteScope } from '../tx-write-flush'
+import {
+  assertTxWriteScopePure,
+  createTxWriteScope,
+  getAmbientTxWriteScope,
+  isTxWriteCreated,
+  MAX_TX_WRITE_RECORDS,
+  recordTxWriteArchive,
+  recordTxWriteChange,
+  recordTxWriteCreate,
+  runInTxWrite,
+  type TxWriteScope,
+} from '../tx-write-scope'
+import { createEntity } from '../unified-handler-mutations'
+import { interactiveSession, seedSession, sessionLane, type WriteSession } from '../write-origin'
+import { getAmbientWriteSession } from '../write-session-als'
+
+const ORG = 'org_1'
+const USER = 'user_1'
+/** The def-uuid keyspace `handler.create` mints RecordIds in. */
+const INVOICE_DEF = 'def_invoice'
+const LINE_DEF = 'def_line_item'
+
+function scopeWithInvoice(): TxWriteScope {
+  const scope = createTxWriteScope(ORG, USER)
+  recordTxWriteCreate(scope, {
+    recordId: `${INVOICE_DEF}:inv_1` as RecordId,
+    entityDefinitionId: INVOICE_DEF,
+    entityType: 'invoice',
+    entitySlug: 'invoices',
+    values: { invoice_total: 4000 },
+  })
+  return scope
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  h.getEntityInstance.mockResolvedValue(ok({ id: 'inv_1', displayName: 'Invoice 1' }) as never)
+})
+
+describe('sessionLane — the buffered lane', () => {
+  it('reports buffered whatever the origin is', () => {
+    const scope = createTxWriteScope(ORG, USER)
+    expect(sessionLane({ ...interactiveSession(USER), mode: { kind: 'buffered', scope } })).toBe(
+      'buffered'
+    )
+    expect(sessionLane({ ...seedSession('reshape'), mode: { kind: 'buffered', scope } })).toBe(
+      'buffered'
+    )
+  })
+
+  it('absorbed and quiet resolve to the silent lane — documentation with a type', () => {
+    expect(
+      sessionLane({ ...interactiveSession(USER), mode: { kind: 'absorbed', by: 'setBulkValues' } })
+    ).toBe('silent')
+    expect(
+      sessionLane({ ...interactiveSession(USER), mode: { kind: 'quiet', reason: 'derivation' } })
+    ).toBe('silent')
+  })
+
+  it('leaves the origin-derived lanes untouched when no mode is set', () => {
+    expect(sessionLane(interactiveSession(USER))).toBe('inline')
+    expect(sessionLane(seedSession('reshape'))).toBe('silent')
+  })
+})
+
+describe('T-5 — the per-attempt contract', () => {
+  it('mints a fresh, empty scope per invocation', async () => {
+    const a = await runInTxWrite({ organizationId: ORG, actorUserId: USER }, async (s) => s)
+    const b = await runInTxWrite({ organizationId: ORG, actorUserId: USER }, async (s) => s)
+    expect(a.scope.attemptId).not.toBe(b.scope.attemptId)
+    expect(b.scope.created).toHaveLength(0)
+  })
+
+  it('exposes the scope ambiently for the duration of the callback only', async () => {
+    expect(getAmbientTxWriteScope()).toBeUndefined()
+    const { scope } = await runInTxWrite({ organizationId: ORG, actorUserId: USER }, async () => {
+      expect(getAmbientTxWriteScope()).toBeDefined()
+      return null
+    })
+    expect(scope).toBeDefined()
+    expect(getAmbientTxWriteScope()).toBeUndefined()
+  })
+
+  it('a throw out of the callback produces NO scope — a rollback takes its buffer with it', async () => {
+    let leaked: TxWriteScope | undefined
+    await expect(
+      runInTxWrite({ organizationId: ORG, actorUserId: USER }, async (scope) => {
+        leaked = scope
+        recordTxWriteCreate(scope, {
+          recordId: `${INVOICE_DEF}:inv_rolled_back` as RecordId,
+          entityDefinitionId: INVOICE_DEF,
+          entityType: 'invoice',
+          entitySlug: 'invoices',
+          values: {},
+        })
+        throw new Error('40001')
+      })
+    ).rejects.toThrow('40001')
+    // The rolled-back attempt's buffer exists only inside the callback frame:
+    // nothing that survives the rejection can reach it.
+    expect(leaked?.created).toHaveLength(1)
+  })
+
+  it('a retry cannot reuse the failed attempt’s buffer', async () => {
+    // The exact shape `withSerializableRetry` runs: the scope is minted inside
+    // the (retried) callback, so attempt 2 starts empty.
+    const scopes: TxWriteScope[] = []
+    let attempt = 0
+    const run = async () => {
+      for (let i = 1; i <= 3; i++) {
+        try {
+          return await runInTxWrite({ organizationId: ORG, actorUserId: USER }, async (scope) => {
+            scopes.push(scope)
+            attempt += 1
+            recordTxWriteCreate(scope, {
+              recordId: `${INVOICE_DEF}:inv_attempt_${attempt}` as RecordId,
+              entityDefinitionId: INVOICE_DEF,
+              entityType: 'invoice',
+              entitySlug: 'invoices',
+              values: {},
+            })
+            if (attempt === 1) throw new Error('40001')
+            return 'ok'
+          })
+        } catch {
+          if (i === 3) throw new Error('exhausted')
+        }
+      }
+      throw new Error('unreachable')
+    }
+
+    const settled = await run()
+    expect(settled.result).toBe('ok')
+    expect(scopes).toHaveLength(2)
+    expect(scopes[0]).not.toBe(scopes[1])
+    // The surviving scope carries attempt 2's create and ONLY attempt 2's.
+    expect(settled.scope.created.map((c) => c.recordId)).toEqual([`${INVOICE_DEF}:inv_attempt_2`])
+  })
+
+  it('nesting joins rather than stacks — one buffer per outermost transaction', async () => {
+    const { scope } = await runInTxWrite(
+      { organizationId: ORG, actorUserId: USER },
+      async (outer) => {
+        const inner = await runInTxWrite({ organizationId: ORG, actorUserId: USER }, async (s) => s)
+        expect(inner.scope).toBe(outer)
+        return null
+      }
+    )
+    expect(scope.created).toHaveLength(0)
+  })
+})
+
+describe('T-4 — a buffered effect is pure data', () => {
+  it('accepts a plain scope', () => {
+    expect(() => assertTxWriteScopePure(scopeWithInvoice())).not.toThrow()
+  })
+
+  it('throws on a poisoned scope carrying a closure', () => {
+    const scope = scopeWithInvoice() as TxWriteScope & { poison?: unknown }
+    scope.poison = () => 'a captured transaction handle lives here'
+    expect(() => assertTxWriteScopePure(scope)).toThrow(/non-cloneable/)
+  })
+
+  it('the flush refuses a poisoned scope before publishing anything', async () => {
+    const scope = scopeWithInvoice()
+    scope.created[0]!.values.db = { transaction: () => {} }
+    await expect(flushTxWriteScope(scope)).rejects.toThrow(/non-cloneable/)
+    expect(h.publishLater).not.toHaveBeenCalled()
+  })
+})
+
+describe('the flush — T-1, T-1b and the C2 replay', () => {
+  it('emits exactly one record:created for a composed invoice and absorbs its own field writes', async () => {
+    const scope = scopeWithInvoice()
+    // The ~6 composed field writes, addressed in the SLUG keyspace money uses.
+    for (const key of ['invoice_subtotal', 'invoice_tax_total', 'invoice_total']) {
+      recordTxWriteChange(scope, {
+        recordId: 'invoice:inv_1' as RecordId,
+        outputKey: key,
+        change: { o: null, n: 1 },
+        entry: { key: `invoice:inv_1:${key}` as never, value: 1 as never },
+      })
+    }
+
+    await flushTxWriteScope(scope)
+
+    expect(h.publishLater).toHaveBeenCalledTimes(1)
+    expect(h.publishLater.mock.calls[0]![0]).toMatchObject({
+      type: 'entity:created',
+      data: { recordId: `${INVOICE_DEF}:inv_1`, eventData: { invoice_total: 4000 } },
+    })
+    expect(h.publish).toHaveBeenCalledTimes(1)
+    expect(h.publish.mock.calls[0]![1]).toBe('record:created')
+    // T-1: no fieldValues:updated for values written before first visibility.
+    expect(h.publishFieldValueUpdates).not.toHaveBeenCalled()
+  })
+
+  it('T-1b: a create declaring a created parent opens no door of its own', async () => {
+    const scope = scopeWithInvoice()
+    for (let i = 0; i < 40; i++) {
+      recordTxWriteCreate(scope, {
+        recordId: `${LINE_DEF}:line_${i}` as RecordId,
+        entityDefinitionId: LINE_DEF,
+        entityType: 'line_item',
+        entitySlug: 'line-items',
+        values: {},
+        // Built in the SLUG keyspace, as `copyLineOntoInvoice` does — the
+        // absorption match is on the instance id, so the keyspaces still meet.
+        absorbInto: 'invoice:inv_1' as RecordId,
+      })
+    }
+
+    await flushTxWriteScope(scope)
+
+    expect(h.publishLater).toHaveBeenCalledTimes(1)
+    expect(h.publish).toHaveBeenCalledTimes(1)
+  })
+
+  it('T-1b is inert when the declared parent is NOT being created — the child announces itself', async () => {
+    const scope = createTxWriteScope(ORG, USER)
+    recordTxWriteCreate(scope, {
+      recordId: `${LINE_DEF}:line_1` as RecordId,
+      entityDefinitionId: LINE_DEF,
+      entityType: 'line_item',
+      entitySlug: 'line-items',
+      values: {},
+      absorbInto: 'invoice:pre_existing' as RecordId,
+    })
+
+    await flushTxWriteScope(scope)
+
+    expect(h.publishLater).toHaveBeenCalledTimes(1)
+    expect(h.publish).toHaveBeenCalledTimes(1)
+  })
+
+  it('O-8: changes on a record that already existed replay as fieldValues:updated', async () => {
+    const scope = scopeWithInvoice()
+    recordTxWriteChange(scope, {
+      recordId: 'line_item:pre_existing' as RecordId,
+      outputKey: 'line_item_visit_id',
+      change: { o: 'visit_1', n: null },
+      entry: { key: 'line_item:pre_existing:visit' as never, value: null as never },
+    })
+
+    await flushTxWriteScope(scope)
+
+    expect(h.publishFieldValueUpdates).toHaveBeenCalledTimes(1)
+    expect(h.publishFieldValueUpdates.mock.calls[0]![2]).toHaveLength(1)
+  })
+
+  it('replays archives last, with the payload the inline lane carried', async () => {
+    const scope = createTxWriteScope(ORG, USER)
+    recordTxWriteArchive(scope, {
+      recordId: `${LINE_DEF}:line_1` as RecordId,
+      entityDefinitionId: LINE_DEF,
+      entityType: 'line_item',
+      entitySlug: 'line-items',
+      realtimeEvent: 'record:archived',
+      eventData: { hardDelete: false },
+    })
+
+    await flushTxWriteScope(scope)
+
+    expect(h.publishLater).toHaveBeenCalledTimes(1)
+    expect(h.publishLater.mock.calls[0]![0]).toMatchObject({ type: 'entity:deleted' })
+    expect(h.publish.mock.calls[0]![1]).toBe('record:archived')
+  })
+
+  it('T-6: a publish failure never surfaces as a command failure', async () => {
+    h.publish.mockRejectedValueOnce(new Error('pusher down'))
+    await expect(flushTxWriteScope(scopeWithInvoice())).resolves.toBeUndefined()
+  })
+
+  it('T-6: a record the flush cannot re-read still gets its bus event', async () => {
+    h.getEntityInstance.mockResolvedValueOnce(err({ message: 'gone' }) as never)
+    await flushTxWriteScope(scopeWithInvoice())
+    expect(h.publishLater).toHaveBeenCalledTimes(1)
+    expect(h.publish).not.toHaveBeenCalled()
+  })
+
+  it('degrades to a coarse records:invalidated once the cap is hit', async () => {
+    const scope = createTxWriteScope(ORG, USER)
+    for (let i = 0; i <= MAX_TX_WRITE_RECORDS; i++) {
+      recordTxWriteCreate(scope, {
+        recordId: `${LINE_DEF}:line_${i}` as RecordId,
+        entityDefinitionId: LINE_DEF,
+        entityType: 'line_item',
+        entitySlug: 'line-items',
+        values: {},
+      })
+    }
+    expect(scope.truncated).toBe(true)
+    expect(scope.created).toHaveLength(MAX_TX_WRITE_RECORDS)
+
+    await flushTxWriteScope(scope)
+
+    expect(h.publishRecordsInvalidated).toHaveBeenCalledTimes(1)
+    expect(h.publishLater).not.toHaveBeenCalled()
+  })
+})
+
+describe('isTxWriteCreated — the dual-keyspace guard', () => {
+  it('matches on the instance id, so a slug-form id finds a def-uuid-form create', () => {
+    const scope = scopeWithInvoice()
+    expect(isTxWriteCreated(scope, 'invoice:inv_1' as RecordId)).toBe(true)
+    expect(isTxWriteCreated(scope, `${INVOICE_DEF}:inv_1` as RecordId)).toBe(true)
+    expect(isTxWriteCreated(scope, 'invoice:inv_2' as RecordId)).toBe(false)
+  })
+})
+
+describe('recordTxWriteChange — merge semantics', () => {
+  it('keeps the FIRST o and the LAST n, like the sync manifest fold', () => {
+    const scope = createTxWriteScope(ORG, USER)
+    const recordId = 'invoice:inv_9' as RecordId
+    recordTxWriteChange(scope, { recordId, outputKey: 'invoice_total', change: { o: 1, n: 2 } })
+    recordTxWriteChange(scope, { recordId, outputKey: 'invoice_total', change: { o: 2, n: 3 } })
+    expect(scope.changes[recordId]).toEqual({ invoice_total: { o: 1, n: 3 } })
+  })
+
+  it('keeps one realtime entry per field key — the last write wins', () => {
+    const scope = createTxWriteScope(ORG, USER)
+    const recordId = 'invoice:inv_9' as RecordId
+    const key = 'invoice:inv_9:total' as never
+    recordTxWriteChange(scope, {
+      recordId,
+      outputKey: 'invoice_total',
+      change: { n: 2 },
+      entry: { key, value: 2 as never },
+    })
+    recordTxWriteChange(scope, {
+      recordId,
+      outputKey: 'invoice_total',
+      change: { n: 3 },
+      entry: { key, value: 3 as never },
+    })
+    expect(scope.realtime[recordId]).toEqual([{ key, value: 3 }])
+  })
+})
+
+describe('ownership — the join must not drain a buffer it does not own', () => {
+  it('reports owned on the outermost scope and NOT owned on a join', async () => {
+    const outer = await runInTxWrite({ organizationId: ORG, actorUserId: USER }, async () => {
+      const inner = await runInTxWrite({ organizationId: ORG, actorUserId: USER }, async () => null)
+      expect(inner.owned).toBe(false)
+      return inner.owned
+    })
+    expect(outer.owned).toBe(true)
+  })
+
+  it('a joined caller honouring `owned` flushes once, not once per join', async () => {
+    // The shape `batch-invoicing.ts` would take if a batch wrapped the billing
+    // commands in one scope: each command joins, only the outermost drains.
+    const flushIfOwned = async (r: { scope: TxWriteScope; owned: boolean }) => {
+      if (r.owned) await flushTxWriteScope(r.scope)
+    }
+
+    const outer = await runInTxWrite({ organizationId: ORG, actorUserId: USER }, async (scope) => {
+      for (const n of [1, 2, 3]) {
+        const joined = await runInTxWrite({ organizationId: ORG, actorUserId: USER }, async (s) => {
+          recordTxWriteCreate(s, {
+            recordId: `${INVOICE_DEF}:inv_${n}` as RecordId,
+            entityDefinitionId: INVOICE_DEF,
+            entityType: 'invoice',
+            entitySlug: 'invoices',
+            values: {},
+          })
+          return null
+        })
+        expect(joined.scope).toBe(scope)
+        await flushIfOwned(joined)
+      }
+      // Nothing has been announced yet — the joins all deferred to the owner.
+      expect(h.publish).not.toHaveBeenCalled()
+      return null
+    })
+
+    await flushIfOwned(outer)
+
+    const creates = h.publish.mock.calls.filter((call) => call[1] === 'record:created')
+    expect(creates).toHaveLength(3)
+    // `record.recordId` comes from the buffer; `record.id` is the re-read
+    // instance, which this suite's mock pins to a single row.
+    expect(
+      creates.map((call) => (call[2] as { record: { recordId: string } }).record.recordId)
+    ).toEqual([`${INVOICE_DEF}:inv_1`, `${INVOICE_DEF}:inv_2`, `${INVOICE_DEF}:inv_3`])
+  })
+})
+
+describe('T-6 — the flush entry, not just its steps', () => {
+  it('swallows a failure acquiring the realtime service', async () => {
+    const scope = scopeWithInvoice()
+    const boom = new Error('realtime unavailable')
+    h.getRealtimeService.mockImplementationOnce(() => {
+      throw boom
+    })
+
+    // The transaction has already committed — this must not become a command
+    // failure, and it must not be left to callers who await it outside a try.
+    await expect(flushTxWriteScope(scope)).resolves.toBeUndefined()
+    expect(h.publish).not.toHaveBeenCalled()
+  })
+})
+
+describe('convergence through the REAL createEntity — B-17, the point of Phase A', () => {
+  /**
+   * A minimal `MutationContext`. `setFieldValues` is a spy rather than the real
+   * field-value layer, so this covers the CREATE half of the convergence — the
+   * field-absorption half (T-1) is covered by the flush tests above, and money's
+   * own orchestration is not exercised here.
+   */
+  function fakeCtx(session: WriteSession) {
+    return {
+      db: {} as never,
+      organizationId: ORG,
+      userId: USER,
+      session,
+      fieldValueService: {} as never,
+      resolveEntityDefinition: async (id: string) => ({
+        id,
+        entityType: id === INVOICE_DEF ? 'invoice' : 'line_item',
+        apiSlug: id === INVOICE_DEF ? 'invoices' : 'line-items',
+      }),
+      getFields: async () => [],
+      runPreHooks: async (_op: string, _def: unknown, values: Record<string, unknown>) => values,
+      validateUniqueFields: async () => {},
+      setFieldValues: vi.fn(async () => {}),
+    } as unknown as Parameters<typeof createEntity>[0]
+  }
+
+  it('a composed invoice plus 40 absorbed lines announces exactly ONE record:created', async () => {
+    let n = 0
+    h.createEntityInstance.mockImplementation(async () => ok({ id: `inst_${++n}` }) as never)
+
+    const { scope, owned } = await runInTxWrite(
+      { organizationId: ORG, actorUserId: USER },
+      async () => {
+        const ctx = fakeCtx(getAmbientWriteSession()!)
+        const invoice = await createEntity(ctx, INVOICE_DEF, { invoice_total: 4000 })
+        for (let i = 0; i < 40; i++) {
+          await createEntity(
+            ctx,
+            LINE_DEF,
+            { line_item_name: `line ${i}` },
+            {
+              absorbInto: invoice.recordId,
+            }
+          )
+        }
+        return invoice
+      }
+    )
+
+    // Nothing escaped mid-composition: 41 creates, zero doors opened.
+    expect(h.publish).not.toHaveBeenCalled()
+    expect(h.publishLater).not.toHaveBeenCalled()
+    expect(scope.created).toHaveLength(41)
+    expect(owned).toBe(true)
+
+    await flushTxWriteScope(scope)
+
+    const realtimeCreates = h.publish.mock.calls.filter((call) => call[1] === 'record:created')
+    expect(realtimeCreates).toHaveLength(1)
+    expect((realtimeCreates[0]?.[2] as { entityDefinitionId: string }).entityDefinitionId).toBe(
+      INVOICE_DEF
+    )
+    const busCreates = h.publishLater.mock.calls.filter((call) =>
+      String(call[0]?.type ?? '').endsWith(':created')
+    )
+    expect(busCreates).toHaveLength(1)
+  })
+
+  it('the same 40 lines WITHOUT a buffered scope announce themselves — 41 doors', async () => {
+    let n = 0
+    h.createEntityInstance.mockImplementation(async () => ok({ id: `inst_${++n}` }) as never)
+
+    const ctx = fakeCtx(interactiveSession(USER))
+    const invoice = await createEntity(ctx, INVOICE_DEF, { invoice_total: 4000 })
+    for (let i = 0; i < 40; i++) {
+      await createEntity(
+        ctx,
+        LINE_DEF,
+        { line_item_name: `line ${i}` },
+        {
+          absorbInto: invoice.recordId,
+        }
+      )
+    }
+
+    // T-1b is inert outside a scope, deliberately: a stray `absorbInto` must
+    // never silence a record on the inline path.
+    const realtimeCreates = h.publish.mock.calls.filter((call) => call[1] === 'record:created')
+    expect(realtimeCreates).toHaveLength(41)
+  })
+})

--- a/packages/lib/src/resources/crud/publish-record-event.ts
+++ b/packages/lib/src/resources/crud/publish-record-event.ts
@@ -1,0 +1,113 @@
+// packages/lib/src/resources/crud/publish-record-event.ts
+
+// The record lifecycle bus event, extracted from `unified-handler-mutations` so
+// two producers can share ONE shaping function: the inline mutation path, and
+// `tx-write-flush`'s post-commit replay of a buffered transaction write scope
+// (plan 04 §6.5). The replayed event must be byte-identical to the inline one,
+// which is exactly what a second copy of this logic would eventually stop being.
+//
+// Kept as a LEAF on purpose — `events/publisher` and `events/types` only — so
+// the flush can import it without pulling `unified-handler-mutations` (and with
+// it the org cache) into a composition site's static module graph.
+
+import { publisher } from '../../events/publisher'
+import type { Events } from '../../events/types'
+import type { RecordId } from '../resource-id'
+
+/**
+ * Parameters for publishing entity events
+ */
+export interface PublishEventParams {
+  recordId: RecordId
+  entityType: string | null
+  entityDefinitionId: string
+  entitySlug: string
+  action: 'created' | 'updated' | 'deleted'
+  organizationId: string
+  userId: string
+  eventData: Record<string, unknown>
+  relatedRecordId?: RecordId
+}
+
+/**
+ * The `<entityType>:<action>` event types that actually exist on the bus, split by payload shape.
+ *
+ * Composing the type from `entityDef.entityType` unchecked is not safe: most built-in resources
+ * (`part`, `quote`, `invoice`, `work_order`, `service_request`, …) have no per-type event and no
+ * entry in `EventHandlers`, so `publishEventJob` would find zero handlers and drop the event —
+ * no timeline entry, no record rules, no dispatch trigger. Anything not listed here falls back to
+ * the generic `entity:*` family, which is what the fallback was always documented to do.
+ */
+const PERSPECTIVE_EVENT_TYPES = [
+  'ticket:created',
+  'ticket:updated',
+  'ticket:deleted',
+  'contact:created',
+  'contact:updated',
+  'contact:deleted',
+] as const satisfies readonly Events[]
+
+/**
+ * The other half of the per-type events. Same trigger, different payload: these carry the
+ * definition identity rather than a second perspective.
+ */
+const DEFINITION_EVENT_TYPES = [
+  'company:created',
+  'company:deleted',
+  'stock_movement:created',
+  'stock_movement:deleted',
+  'vendor_part:created',
+  'vendor_part:deleted',
+  'subpart:created',
+  'subpart:deleted',
+] as const satisfies readonly Events[]
+
+type PerspectiveEventType = (typeof PERSPECTIVE_EVENT_TYPES)[number]
+type DefinitionEventType = (typeof DEFINITION_EVENT_TYPES)[number]
+
+function isPerspectiveEventType(type: string): type is PerspectiveEventType {
+  return (PERSPECTIVE_EVENT_TYPES as readonly string[]).includes(type)
+}
+
+function isDefinitionEventType(type: string): type is DefinitionEventType {
+  return (DEFINITION_EVENT_TYPES as readonly string[]).includes(type)
+}
+
+/**
+ * Publish entity event.
+ * Uses entity-type-specific event type when one exists (e.g., 'ticket:created'),
+ * falls back to generic 'entity:created' for everything else.
+ *
+ * @param params - Event parameters including recordId, eventData, etc.
+ */
+export function publishRecordLifecycleEvent(params: PublishEventParams): void {
+  const {
+    recordId,
+    entityType,
+    entityDefinitionId,
+    entitySlug,
+    action,
+    organizationId,
+    userId,
+    eventData,
+    relatedRecordId,
+  } = params
+
+  const specific = `${entityType}:${action}`
+  const base = { recordId, organizationId, userId, eventData }
+
+  // The ticket/contact family is the only one whose payload carries a second perspective
+  // (the contact-side timeline row keys off `relatedRecordId`).
+  if (isPerspectiveEventType(specific)) {
+    publisher.publishLater({
+      type: specific,
+      data: { ...base, ...(relatedRecordId && { relatedRecordId }) },
+    })
+    return
+  }
+
+  publisher.publishLater({
+    type: isDefinitionEventType(specific) ? specific : `entity:${action}`,
+    data: { ...base, entityDefinitionId, entitySlug },
+  })
+}

--- a/packages/lib/src/resources/crud/tx-write-flush.ts
+++ b/packages/lib/src/resources/crud/tx-write-flush.ts
@@ -1,0 +1,219 @@
+// packages/lib/src/resources/crud/tx-write-flush.ts
+
+// Phase A of plans/events/04-in-transaction-write-semantics-plan.md (§6.5):
+// replay a committed transaction's buffered doors, once, on the OUTER
+// non-transactional handle.
+//
+// Everything this file drives beyond the leaf `publish-record-event` is
+// LAZY-imported. That is deliberate, not stylistic: the flush's callers are
+// composition sites (money's billing commands and gather flow) that already sit
+// inside the org-cache / field-hooks import graph, and pulling `realtime`,
+// `entity-instances` and `dedup` into their STATIC graph re-orders module
+// evaluation across a cycle that runs through `@auxx/lib/cache` — which makes
+// `findCachedResource` resolve to a half-initialised module. The flush runs once
+// per committed transaction, so the dynamic-import cost is irrelevant, and this
+// is the same dodge `loadManifestCollector` uses for the record-rules cycle.
+
+import { createScopedLogger } from '@auxx/logger'
+import { parseRecordId, type RecordId } from '@auxx/types/resource'
+import { publishRecordLifecycleEvent } from './publish-record-event'
+import { assertTxWriteScopePure, type TxWriteCreate, type TxWriteScope } from './tx-write-scope'
+
+const logger = createScopedLogger('tx-write-flush')
+
+/**
+ * RecordIds reach this buffer in two keyspaces — `handler.create` builds them
+ * from the canonical `EntityDefinition.id`, while money's own writers build them
+ * from the type slug (`toRecordId('invoice', …)`), and the two strings never
+ * compare equal for the same record. Every membership test in the flush
+ * therefore runs on the entity INSTANCE id, which is unique on its own.
+ */
+function instanceIdOf(recordId: RecordId): string {
+  return parseRecordId(recordId).entityInstanceId
+}
+
+/**
+ * Replay a committed scope's doors. Order and rationale per §6.5:
+ *
+ * 1. drop the buffered field changes of records that are themselves in
+ *    `created` — those values are the record's initial state, not changes to it
+ *    (T-1);
+ * 2. drop creates whose declared `absorbInto` parent is also in `created` — the
+ *    parent's `record:created` announces them (T-1b). An `absorbInto` naming a
+ *    record that already existed is not an error: the child is a genuine create
+ *    and stays;
+ * 3. creates, in insertion order — the same fan-out the inline create path runs;
+ * 4. the surviving (C2) field changes, per record;
+ * 5. archives.
+ *
+ * Post-hooks are NEVER replayed (T-2): the composer already ran the ones that
+ * matter, in-tx, in order, against transactional state.
+ *
+ * BEST-EFFORT (T-6). The transaction has committed; a failure here must never
+ * surface as a command failure, so every step logs and continues — exactly what
+ * `projectCommittedInvoice` already did for the billing projections.
+ *
+ * "Never" means never IN PRODUCTION, and the guard below is the whole body, not
+ * just the per-step catches: acquiring the realtime module and its service can
+ * throw too, and callers await this OUTSIDE their own try (there is nothing
+ * useful they could do with the error anyway — the write is already durable).
+ *
+ * The one deliberate exception is {@link assertTxWriteScopePure}, which sits
+ * outside the guard and is a no-op in production. A poisoned scope is a
+ * programming error whose real failure mode — a post-commit write on a released
+ * transaction handle — is SILENT, so in dev and test it must be loud enough to
+ * stop the run.
+ */
+export async function flushTxWriteScope(scope: TxWriteScope): Promise<void> {
+  assertTxWriteScopePure(scope)
+  try {
+    await replayTxWriteScope(scope)
+  } catch (error) {
+    logFailure('flush', scope.attemptId, error)
+  }
+}
+
+async function replayTxWriteScope(scope: TxWriteScope): Promise<void> {
+  const realtime = await import('../../realtime')
+  const service = realtime.getRealtimeService()
+
+  if (scope.truncated) {
+    await flushTruncated(scope, realtime, service)
+    return
+  }
+
+  const createdInstanceIds = new Set(scope.created.map((create) => instanceIdOf(create.recordId)))
+  const changedRecordIds = Object.keys(scope.changes).filter(
+    (recordId) => !createdInstanceIds.has(instanceIdOf(recordId as RecordId))
+  )
+  const creates = scope.created.filter(
+    (create) => !create.absorbInto || !createdInstanceIds.has(instanceIdOf(create.absorbInto))
+  )
+
+  for (const create of creates) {
+    try {
+      await flushCreate(scope, create, realtime, service)
+    } catch (error) {
+      logFailure('create', create.recordId, error)
+    }
+  }
+
+  for (const recordId of changedRecordIds) {
+    const entries = scope.realtime[recordId as RecordId]
+    if (!entries || entries.length === 0) continue
+    await realtime
+      .publishFieldValueUpdates(service, scope.organizationId, entries)
+      .catch((error) => logFailure('change', recordId, error))
+  }
+
+  for (const archive of scope.archived) {
+    try {
+      publishRecordLifecycleEvent({
+        recordId: archive.recordId,
+        entityType: archive.entityType,
+        entityDefinitionId: archive.entityDefinitionId,
+        entitySlug: archive.entitySlug,
+        action: 'deleted',
+        organizationId: scope.organizationId,
+        userId: scope.actorUserId,
+        eventData: archive.eventData,
+      })
+      await service.publish(
+        realtime.rooms.orgRecords(scope.organizationId, archive.entityDefinitionId),
+        archive.realtimeEvent,
+        { recordId: archive.recordId, entityDefinitionId: archive.entityDefinitionId }
+      )
+    } catch (error) {
+      logFailure('archive', archive.recordId, error)
+    }
+  }
+}
+
+type RealtimeModule = typeof import('../../realtime')
+type RealtimeService = ReturnType<RealtimeModule['getRealtimeService']>
+
+/**
+ * Overflow lane (T-5 rule 6). The buffer stopped growing, so a per-record replay
+ * would announce a partial truth; tell every touched def to refetch instead.
+ */
+async function flushTruncated(
+  scope: TxWriteScope,
+  realtime: RealtimeModule,
+  service: RealtimeService
+): Promise<void> {
+  const entityDefinitionIds = [
+    ...new Set([
+      ...scope.created.map((create) => create.entityDefinitionId),
+      ...scope.archived.map((archive) => archive.entityDefinitionId),
+      ...Object.keys(scope.changes).map(
+        (recordId) => parseRecordId(recordId as RecordId).entityDefinitionId
+      ),
+    ]),
+  ]
+  await realtime
+    .publishRecordsInvalidated(service, scope.organizationId, { entityDefinitionIds })
+    .catch((error) => logFailure('truncated', entityDefinitionIds.join(','), error))
+}
+
+/** The inline create fan-out (`unified-handler-mutations` createEntity), post-commit. */
+async function flushCreate(
+  scope: TxWriteScope,
+  create: TxWriteCreate,
+  realtime: RealtimeModule,
+  service: RealtimeService
+): Promise<void> {
+  const [{ findRelatedRecordId }, { getEntityInstance }, dedup] = await Promise.all([
+    import('../events/extract-event-data'),
+    import('../../entity-instances'),
+    import('../../dedup/enqueue-scan'),
+  ])
+
+  publishRecordLifecycleEvent({
+    recordId: create.recordId,
+    entityType: create.entityType,
+    entityDefinitionId: create.entityDefinitionId,
+    entitySlug: create.entitySlug,
+    action: 'created',
+    organizationId: scope.organizationId,
+    userId: scope.actorUserId,
+    eventData: create.values,
+    relatedRecordId: findRelatedRecordId(create.entityType, create.values),
+  })
+
+  // The composed instance was not captured — display name, avatar and
+  // searchText are written by `setFieldValues` after the row exists, so the
+  // frame re-reads them here on the outer handle (§6.3).
+  const fresh = await getEntityInstance({
+    id: instanceIdOf(create.recordId),
+    organizationId: scope.organizationId,
+  })
+  if (fresh.isOk()) {
+    const instance = fresh.value
+    await service.publish(
+      realtime.rooms.orgRecords(scope.organizationId, create.entityDefinitionId),
+      'record:created',
+      {
+        entityDefinitionId: create.entityDefinitionId,
+        record: {
+          id: instance.id,
+          recordId: create.recordId,
+          displayName: instance.displayName,
+          avatarUrl: instance.avatarUrl,
+          secondaryDisplayValue: instance.secondaryDisplayValue,
+          createdAt: instance.createdAt,
+          updatedAt: instance.updatedAt,
+        },
+      }
+    )
+  }
+
+  await dedup.enqueueDuplicateScan(scope.organizationId, create.entityDefinitionId).catch(() => {})
+}
+
+function logFailure(step: string, recordId: string, error: unknown): void {
+  logger.error('Transaction write flush step failed', {
+    step,
+    recordId,
+    error: error instanceof Error ? error.message : String(error),
+  })
+}

--- a/packages/lib/src/resources/crud/tx-write-scope.ts
+++ b/packages/lib/src/resources/crud/tx-write-scope.ts
@@ -1,0 +1,286 @@
+// packages/lib/src/resources/crud/tx-write-scope.ts
+
+// Phase A of plans/events/04-in-transaction-write-semantics-plan.md (§6):
+// an in-transaction composition is a one-transaction sync run. The doors it
+// would have opened per write are captured here as PURE DATA and replayed once,
+// after the transaction commits, by `flushTxWriteScope`.
+//
+// The whole point of this file is the per-attempt contract (T-5). A buffer that
+// outlives one transaction attempt double-flushes writes a serializable retry
+// rolled back, so `runInTxWrite` mints the scope itself and hands it back only
+// on the resolving path. There is deliberately no API shape that lets a caller
+// open a scope, hold it, and pass it into a retry loop.
+//
+// NOT re-exported from `resources/crud/index.ts`, on purpose. This module and
+// `tx-write-flush` are imported by leaf path so the crud barrel's module
+// evaluation order stays exactly as it is — that order is load-bearing for the
+// import cycle that runs through `@auxx/lib/cache`.
+
+import { createScopedLogger } from '@auxx/logger'
+import { parseRecordId, type RecordId } from '@auxx/types/resource'
+import { generateId } from '@auxx/utils'
+import type { FieldValueUpdateEntry } from '../../realtime/events'
+import type { ManifestFieldChange } from '../../record-rules/sync-manifest-types'
+import type { WriteSession } from './write-origin'
+import { getAmbientWriteSession, runWithWriteSession } from './write-session-als'
+
+const logger = createScopedLogger('tx-write-scope')
+
+/**
+ * Cap on how many distinct records one scope buffers, per bucket (T-5 rule 6).
+ * Billing composes well under this; the cap is a guard against a runaway
+ * composition, not a lane. Overflow flips {@link TxWriteScope.truncated} and
+ * degrades that flush to a coarse `records:invalidated` per touched def.
+ */
+export const MAX_TX_WRITE_RECORDS = 500
+
+/** A create captured inside a buffered scope. Pure data — no handles, no closures. */
+export interface TxWriteCreate {
+  recordId: RecordId
+  /** Canonical `EntityDefinition.id` — the record-room keyspace. */
+  entityDefinitionId: string
+  entityType: string | null
+  entitySlug: string
+  /** `systemAttribute ?? fieldId` → raw value, exactly `extractEventData`'s shape. */
+  values: Record<string, unknown>
+  /**
+   * T-1b. Set by the composing site when this create is structural — the named
+   * parent announces it. Honoured ONLY if that parent is itself in
+   * {@link TxWriteScope.created}; otherwise this record announces itself as
+   * normal. Nothing is inferred from the def or the relationship graph.
+   */
+  absorbInto?: RecordId
+}
+
+/** An archive/delete captured inside a buffered scope. */
+export interface TxWriteArchive {
+  recordId: RecordId
+  entityDefinitionId: string
+  entityType: string | null
+  entitySlug: string
+  /** `record:archived` for a soft archive, `record:deleted` for a hard delete. */
+  realtimeEvent: 'record:archived' | 'record:deleted'
+  /** The `entity:deleted` payload the inline lane would have carried. */
+  eventData: Record<string, unknown>
+}
+
+/**
+ * The buffer for ONE transaction attempt (§6.3). Every member is a plain value:
+ * never a `FieldValueContext`, a `FieldValueService`, a `UnifiedCrudHandler`, an
+ * `EntityFieldChangeEvent`, or any closure — all of those hold `ctx.db`, which
+ * post-commit is a released transaction handle that fails silently (T-4).
+ * {@link assertTxWriteScopePure} enforces that in dev.
+ */
+export interface TxWriteScope {
+  /** Identity of THIS attempt. Never reused across retries. */
+  readonly attemptId: string
+  readonly organizationId: string
+  readonly actorUserId: string
+  readonly at: Date
+  readonly created: TxWriteCreate[]
+  /** RecordId → outputKey → `{ o?, n }` — `ManifestFieldChange`, verbatim. */
+  readonly changes: Record<RecordId, Record<string, ManifestFieldChange>>
+  /**
+   * The `fieldValues:updated` entries the inline lane would have published,
+   * shaped at the write (where the typed values are in hand) and replayed
+   * verbatim at flush. Keyed by the same RecordId as {@link changes}.
+   */
+  readonly realtime: Record<RecordId, FieldValueUpdateEntry[]>
+  readonly archived: TxWriteArchive[]
+  truncated: boolean
+}
+
+/**
+ * Mint an empty scope. Exported for tests and for {@link runInTxWrite}, which is
+ * the only supported production entry point — it owns the lifecycle so a retry
+ * is structurally unable to reuse a buffer (T-5 rules 1–3).
+ */
+export function createTxWriteScope(organizationId: string, actorUserId: string): TxWriteScope {
+  return {
+    attemptId: generateId(),
+    organizationId,
+    actorUserId,
+    at: new Date(),
+    created: [],
+    changes: {},
+    realtime: {},
+    archived: [],
+    truncated: false,
+  }
+}
+
+/**
+ * The buffered scope of the current async context, or undefined when the
+ * ambient session is not buffered. `session` (a handler's or a
+ * `FieldValueContext`'s own) wins over the ambient one, matching the S1
+ * resolution order.
+ */
+export function getAmbientTxWriteScope(session?: WriteSession): TxWriteScope | undefined {
+  const own = session?.mode
+  if (own?.kind === 'buffered') return own.scope
+  // Falls through rather than returning undefined on purpose: a service or
+  // handler CONSTRUCTED before the scope opened carries a non-buffered session
+  // of its own, and publishing from it mid-transaction is exactly the failure
+  // this lane exists to prevent.
+  const ambient = getAmbientWriteSession()?.mode
+  return ambient?.kind === 'buffered' ? ambient.scope : undefined
+}
+
+/**
+ * Run `fn` with a FRESH buffered scope as the ambient write session, and return
+ * the scope alongside the result — on the resolving path only (T-5 rule 3).
+ *
+ * Call this INSIDE the `database.transaction` callback, with `tx` already in
+ * hand. Rules it makes structural rather than disciplinary:
+ *
+ * 1. the scope is minted here, so no caller can open one before the callback;
+ * 2. one scope per invocation, so a serializable retry starts empty;
+ * 3. a throw takes the scope with it — a rejected promise carries no scope, so
+ *    `withSerializableRetry` can never flush a rolled-back attempt;
+ * 4. nesting JOINS: an already-buffered ambient session returns its own scope,
+ *    so there is one buffer and one flush per outermost transaction (rule 5).
+ *
+ * **`owned` is what makes rule 4 safe, and callers MUST honour it: flush only
+ * when `owned` is true.** A joined caller shares the outer buffer, so flushing
+ * it would (a) re-announce everything the outer composition has accumulated so
+ * far — N joined commands replaying an ever-growing buffer is O(N²) duplicate
+ * `record:created` — and (b) on a serializable retry inside a joined scope,
+ * replay the captures of an attempt that rolled back, which is exactly the
+ * failure T-5 exists to prevent, reached through the one path the per-attempt
+ * contract does not cover. The outermost owner flushes once, for everyone.
+ *
+ * Nesting is not reachable today (no caller of money's billing commands sits
+ * inside a buffered scope), but `batch-invoicing.ts` already loops those
+ * commands and plan 03's batch lane is about wrapping batches in a session.
+ *
+ * Known limitation while joined: a nested composition's own post-flush work
+ * (money's two billing projections, which run events-ON) still runs at the inner
+ * call site, so it lands BEFORE the outer flush and inverts O-9's ordering for
+ * that invoice. Acceptable only because nesting is unreachable; whoever makes it
+ * reachable owns fixing the ordering too.
+ */
+export async function runInTxWrite<T>(
+  args: { organizationId: string; actorUserId: string },
+  fn: (scope: TxWriteScope) => Promise<T>
+): Promise<{ result: T; scope: TxWriteScope; owned: boolean }> {
+  const existing = getAmbientTxWriteScope()
+  if (existing) {
+    return { result: await fn(existing), scope: existing, owned: false }
+  }
+
+  const ambient = getAmbientWriteSession()
+  const scope = createTxWriteScope(args.organizationId, args.actorUserId)
+  const session: WriteSession = {
+    origin: ambient?.origin ?? { kind: 'interactive', userId: args.actorUserId },
+    depth: ambient?.depth ?? 0,
+    mode: { kind: 'buffered', scope },
+  }
+  const result = await runWithWriteSession(session, () => fn(scope))
+  return { result, scope, owned: true }
+}
+
+/**
+ * Whether `recordId` is being created inside this scope — the T-1 absorption
+ * test, and the reason the field-value layer can skip capturing a composed
+ * record's own field writes altogether.
+ *
+ * Matched on the entity INSTANCE id, never the RecordId string: `handler.create`
+ * builds RecordIds from the canonical `EntityDefinition.id` while money's own
+ * writers build them from the type slug, and the two never compare equal for the
+ * same record.
+ */
+export function isTxWriteCreated(scope: TxWriteScope, recordId: RecordId): boolean {
+  const instanceId = parseRecordId(recordId).entityInstanceId
+  return scope.created.some(
+    (create) => parseRecordId(create.recordId).entityInstanceId === instanceId
+  )
+}
+
+function markTruncated(scope: TxWriteScope, what: string): void {
+  if (scope.truncated) return
+  scope.truncated = true
+  logger.warn('Transaction write scope truncated — cap hit', {
+    what,
+    attemptId: scope.attemptId,
+    created: scope.created.length,
+    changed: Object.keys(scope.changes).length,
+  })
+}
+
+/** Buffer a create. Silently drops (and flags `truncated`) past the cap. */
+export function recordTxWriteCreate(scope: TxWriteScope, create: TxWriteCreate): void {
+  if (scope.created.length >= MAX_TX_WRITE_RECORDS) {
+    markTruncated(scope, 'created records')
+    return
+  }
+  scope.created.push(create)
+}
+
+/** Buffer an archive/delete. Silently drops (and flags `truncated`) past the cap. */
+export function recordTxWriteArchive(scope: TxWriteScope, archive: TxWriteArchive): void {
+  if (scope.archived.length >= MAX_TX_WRITE_RECORDS) {
+    markTruncated(scope, 'archived records')
+    return
+  }
+  scope.archived.push(archive)
+}
+
+/**
+ * Buffer one field write: the `{ o, n }` tuple (the manifest's shape, captured
+ * in-tx because post-commit the pre-write value is gone) and the realtime entry
+ * the inline lane would have published. First `o` wins, last `n` wins — the same
+ * merge `sync-manifest-collector` applies, so a field written twice in one
+ * composition folds the way a sync run's would.
+ */
+export function recordTxWriteChange(
+  scope: TxWriteScope,
+  args: {
+    recordId: RecordId
+    outputKey: string
+    change: ManifestFieldChange
+    entry?: FieldValueUpdateEntry
+  }
+): void {
+  const { recordId, outputKey, change, entry } = args
+  let bucket = scope.changes[recordId]
+  if (!bucket) {
+    if (Object.keys(scope.changes).length >= MAX_TX_WRITE_RECORDS) {
+      markTruncated(scope, 'changed records')
+      return
+    }
+    bucket = {}
+    scope.changes[recordId] = bucket
+  }
+  const existing = bucket[outputKey]
+  bucket[outputKey] = existing
+    ? { n: change.n, ...('o' in existing ? { o: existing.o } : {}) }
+    : change
+
+  if (!entry) return
+  const entries = scope.realtime[recordId] ?? []
+  const at = entries.findIndex((candidate) => candidate.key === entry.key)
+  if (at >= 0) entries[at] = entry
+  else entries.push(entry)
+  scope.realtime[recordId] = entries
+}
+
+/**
+ * Dev-only T-4 enforcement: a buffered effect must survive `structuredClone`.
+ * A captured `Database`/`Transaction` handle, service instance or closure cannot
+ * — and the failure mode it prevents (a post-commit write on a released
+ * transaction) is SILENT in production, so it has to fail loudly here.
+ *
+ * @throws {Error} when the scope holds anything non-cloneable.
+ */
+export function assertTxWriteScopePure(scope: TxWriteScope): void {
+  if (process.env.NODE_ENV === 'production') return
+  try {
+    structuredClone(scope)
+  } catch (error) {
+    throw new Error(
+      `TxWriteScope holds non-cloneable state (T-4): a buffered effect must be a plain value, never a db handle, service or closure. ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+  }
+}

--- a/packages/lib/src/resources/crud/unified-handler-mutations.ts
+++ b/packages/lib/src/resources/crud/unified-handler-mutations.ts
@@ -16,8 +16,6 @@ import {
   updateEntityInstance,
 } from '../../entity-instances'
 import { UnprocessableEntityError } from '../../errors'
-import { publisher } from '../../events/publisher'
-import type { Events } from '../../events/types'
 import { getEntityPostDeleteHooks, getEntityPreDeleteHooks } from '../../field-hooks/registry'
 import type { FieldValueService } from '../../field-values'
 import {
@@ -35,6 +33,13 @@ import type { MergeEntitiesResult } from '../merge'
 import { EntityMergeService } from '../merge'
 import type { ResourceField } from '../registry/field-types'
 import { parseRecordId, type RecordId, toRecordId } from '../resource-id'
+import { publishRecordLifecycleEvent } from './publish-record-event'
+import {
+  getAmbientTxWriteScope,
+  recordTxWriteArchive,
+  recordTxWriteCreate,
+  type TxWriteScope,
+} from './tx-write-scope'
 import type { ResolvedEntityDefinition } from './types'
 import { sessionLane, type WriteSession } from './write-origin'
 
@@ -70,6 +75,19 @@ export interface CrudOptions {
    * hooks there would recompute a parent that is about to be deleted, once per child.
    */
   suppressPostDeleteHooks?: boolean
+  /**
+   * T-1b (plan 04 §4). Declares this create STRUCTURAL to the named parent: the
+   * parent's own `record:created` announces it, so no separate create door opens
+   * for this record.
+   *
+   * Honoured ONLY inside a buffered write scope AND only when that parent is
+   * itself being created in the same scope. Outside one there is no `created`
+   * set to check against, so a stray `absorbInto` is inert and the record
+   * announces itself as normal — deliberately, so this can never silence a
+   * record on the inline path. Nothing is inferred from the def or the
+   * relationship graph; the composing site says so or it does not happen.
+   */
+  absorbInto?: RecordId
 }
 
 /** Inferred type for CustomField select */
@@ -153,101 +171,14 @@ function derivePublishEvents(ctx: MutationContext, options: CrudOptions): boolea
 }
 
 /**
- * Parameters for publishing entity events
+ * The buffered scope this mutation should capture into, or undefined when its
+ * doors fire inline (or are suppressed outright). `'buffered'` differs from
+ * `'silent'` only here: a live collector keeps what `'silent'` throws away, so
+ * `flushTxWriteScope` can replay it once the transaction commits (plan 04 §6.2).
  */
-interface PublishEventParams {
-  recordId: RecordId
-  entityType: string | null
-  entityDefinitionId: string
-  entitySlug: string
-  action: 'created' | 'updated' | 'deleted'
-  organizationId: string
-  userId: string
-  eventData: Record<string, unknown>
-  relatedRecordId?: RecordId
-}
-
-/**
- * The `<entityType>:<action>` event types that actually exist on the bus, split by payload shape.
- *
- * Composing the type from `entityDef.entityType` unchecked is not safe: most built-in resources
- * (`part`, `quote`, `invoice`, `work_order`, `service_request`, …) have no per-type event and no
- * entry in `EventHandlers`, so `publishEventJob` would find zero handlers and drop the event —
- * no timeline entry, no record rules, no dispatch trigger. Anything not listed here falls back to
- * the generic `entity:*` family, which is what the fallback was always documented to do.
- */
-const PERSPECTIVE_EVENT_TYPES = [
-  'ticket:created',
-  'ticket:updated',
-  'ticket:deleted',
-  'contact:created',
-  'contact:updated',
-  'contact:deleted',
-] as const satisfies readonly Events[]
-
-/**
- * The other half of the per-type events. Same trigger, different payload: these carry the
- * definition identity rather than a second perspective.
- */
-const DEFINITION_EVENT_TYPES = [
-  'company:created',
-  'company:deleted',
-  'stock_movement:created',
-  'stock_movement:deleted',
-  'vendor_part:created',
-  'vendor_part:deleted',
-  'subpart:created',
-  'subpart:deleted',
-] as const satisfies readonly Events[]
-
-type PerspectiveEventType = (typeof PERSPECTIVE_EVENT_TYPES)[number]
-type DefinitionEventType = (typeof DEFINITION_EVENT_TYPES)[number]
-
-function isPerspectiveEventType(type: string): type is PerspectiveEventType {
-  return (PERSPECTIVE_EVENT_TYPES as readonly string[]).includes(type)
-}
-
-function isDefinitionEventType(type: string): type is DefinitionEventType {
-  return (DEFINITION_EVENT_TYPES as readonly string[]).includes(type)
-}
-
-/**
- * Publish entity event.
- * Uses entity-type-specific event type when one exists (e.g., 'ticket:created'),
- * falls back to generic 'entity:created' for everything else.
- *
- * @param params - Event parameters including recordId, eventData, etc.
- */
-function publishEvent(params: PublishEventParams): void {
-  const {
-    recordId,
-    entityType,
-    entityDefinitionId,
-    entitySlug,
-    action,
-    organizationId,
-    userId,
-    eventData,
-    relatedRecordId,
-  } = params
-
-  const specific = `${entityType}:${action}`
-  const base = { recordId, organizationId, userId, eventData }
-
-  // The ticket/contact family is the only one whose payload carries a second perspective
-  // (the contact-side timeline row keys off `relatedRecordId`).
-  if (isPerspectiveEventType(specific)) {
-    publisher.publishLater({
-      type: specific,
-      data: { ...base, ...(relatedRecordId && { relatedRecordId }) },
-    })
-    return
-  }
-
-  publisher.publishLater({
-    type: isDefinitionEventType(specific) ? specific : `entity:${action}`,
-    data: { ...base, entityDefinitionId, entitySlug },
-  })
+function deriveTxWriteScope(ctx: MutationContext, options: CrudOptions): TxWriteScope | undefined {
+  if (options.skipEvents === true) return undefined
+  return sessionLane(ctx.session) === 'buffered' ? getAmbientTxWriteScope(ctx.session) : undefined
 }
 
 /**
@@ -370,6 +301,7 @@ export async function createEntity(
 ): Promise<CreateEntityResult> {
   // S3: one derived boolean per call gates the whole per-write fan-out below.
   const publishEvents = derivePublishEvents(ctx, options)
+  const txScope = deriveTxWriteScope(ctx, options)
   const entityDef = await ctx.resolveEntityDefinition(entityDefinitionId)
 
   // Apply configured defaults for any creatable field the caller omitted.
@@ -416,10 +348,32 @@ export async function createEntity(
   // Build RecordId for field value operations
   const recordId = toRecordId(entityDef.id, instance.id)
 
+  // Buffered lane: register the create BEFORE its own field writes run. The
+  // ordering is load-bearing — a record in the scope's `created` set absorbs its
+  // own field changes (T-1), so the field-value layer can see it is already
+  // there and skip the old-value read and the realtime shaping entirely instead
+  // of buffering ~12 frames per copied line that the flush would only drop.
+  // `eventData` is the write's own values, so it needs no live handle (T-4).
+  if (txScope) {
+    recordTxWriteCreate(txScope, {
+      recordId,
+      entityDefinitionId: entityDef.id,
+      entityType: entityDef.entityType,
+      entitySlug: entityDef.apiSlug,
+      values: extractEventData(entityDef.entityType, entityFields, processedValues),
+      absorbInto: options.absorbInto,
+    })
+  }
+
   // Set field values using RecordId. Silent-lane writes (sync/seed sessions,
   // or the deprecated skipEvents alias) also suppress the field-value
-  // realtime + triggers end-to-end via publishEvents:false.
-  await ctx.setFieldValues(recordId, processedValues, undefined, { publishEvents })
+  // realtime + triggers end-to-end via publishEvents:false. The BUFFERED lane
+  // passes `true` here on purpose: the field-value layer resolves the scope
+  // itself and captures instead of publishing, so a `false` would be read as
+  // the C3 "an aggregator announces this" escape hatch and lose the writes.
+  await ctx.setFieldValues(recordId, processedValues, undefined, {
+    publishEvents: publishEvents || txScope !== undefined,
+  })
 
   // Re-read the instance so displayName / secondaryDisplayValue / avatarUrl
   // reflect what setFieldValues' maybeUpdateDisplayValue just wrote. The
@@ -438,7 +392,7 @@ export async function createEntity(
     const eventData = extractEventData(entityDef.entityType, fields, processedValues)
     const relatedRecordId = findRelatedRecordId(entityDef.entityType, eventData)
 
-    publishEvent({
+    publishRecordLifecycleEvent({
       recordId,
       entityType: entityDef.entityType,
       entityDefinitionId: entityDef.id,
@@ -531,8 +485,12 @@ export async function updateEntity(
 
   // Set field values using resolved RecordId. Per-field modes default to
   // 'set' when missing — today's behavior for every caller that omits modes.
-  // Silent-lane writes suppress the field-value realtime + triggers too.
-  await ctx.setFieldValues(resolvedRecordId, processedValues, modes, { publishEvents })
+  // Silent-lane writes suppress the field-value realtime + triggers too; the
+  // buffered lane passes `true` so the field-value layer captures rather than
+  // reading `false` as the C3 escape hatch (see the same note in createEntity).
+  await ctx.setFieldValues(resolvedRecordId, processedValues, modes, {
+    publishEvents: publishEvents || deriveTxWriteScope(ctx, options) !== undefined,
+  })
 
   // Re-read so displayName / secondaryDisplayValue / avatarUrl / updatedAt
   // reflect what setFieldValues just wrote. The `instance` captured at the
@@ -549,7 +507,7 @@ export async function updateEntity(
     const eventData = extractEventData(entityDef.entityType, fields, processedValues)
     const relatedRecordId = findRelatedRecordId(entityDef.entityType, eventData)
 
-    publishEvent({
+    publishRecordLifecycleEvent({
       recordId,
       entityType: entityDef.entityType,
       entityDefinitionId: entityDef.id,
@@ -635,7 +593,7 @@ export async function archiveEntity(
   unwrapResult(updateResult)
 
   if (publishEvents) {
-    publishEvent({
+    publishRecordLifecycleEvent({
       recordId,
       entityType: entityDef.entityType,
       entityDefinitionId: entityDef.id,
@@ -658,6 +616,19 @@ export async function archiveEntity(
         { excludeSocketId: ctx.socketId }
       )
       .catch(() => {})
+  }
+
+  // Buffered lane: replayed post-commit by `flushTxWriteScope`.
+  const txScope = deriveTxWriteScope(ctx, options)
+  if (txScope && !options.suppressRealtimeFrame) {
+    recordTxWriteArchive(txScope, {
+      recordId,
+      entityDefinitionId: entityDef.id,
+      entityType: entityDef.entityType,
+      entitySlug: entityDef.apiSlug,
+      realtimeEvent: 'record:archived',
+      eventData: { hardDelete: false },
+    })
   }
 
   // Duplicate-suggestion cleanup — deliberately OUTSIDE the `publishEvents`
@@ -712,7 +683,7 @@ export async function restoreEntity(
   unwrapResult(updateResult)
 
   if (publishEvents) {
-    publishEvent({
+    publishRecordLifecycleEvent({
       recordId,
       entityType: entityDef.entityType,
       entityDefinitionId: entityDef.id,
@@ -765,8 +736,9 @@ export async function deleteEntity(
     entityDef.apiSlug && !options.suppressPostDeleteHooks
       ? getEntityPostDeleteHooks(entityDef.apiSlug)
       : []
+  const txScope = deriveTxWriteScope(ctx, options)
   let eventData: Record<string, unknown> = { hardDelete: true }
-  if (publishEvents || preDeleteHooks.length > 0 || postDeleteHooks.length > 0) {
+  if (publishEvents || txScope || preDeleteHooks.length > 0 || postDeleteHooks.length > 0) {
     const fields = await ctx.getFields(entityDef.id)
     const captured = await captureEventData(ctx.fieldValueService, recordId, fields)
     eventData = { hardDelete: true, ...captured }
@@ -823,7 +795,7 @@ export async function deleteEntity(
   }
 
   if (publishEvents) {
-    publishEvent({
+    publishRecordLifecycleEvent({
       recordId,
       entityType: entityDef.entityType,
       entityDefinitionId: entityDef.id,
@@ -843,6 +815,18 @@ export async function deleteEntity(
         { excludeSocketId: ctx.socketId }
       )
       .catch(() => {})
+  }
+
+  // Buffered lane: replayed post-commit by `flushTxWriteScope`.
+  if (txScope) {
+    recordTxWriteArchive(txScope, {
+      recordId,
+      entityDefinitionId: entityDef.id,
+      entityType: entityDef.entityType,
+      entitySlug: entityDef.apiSlug,
+      realtimeEvent: 'record:deleted',
+      eventData,
+    })
   }
 }
 

--- a/packages/lib/src/resources/crud/write-origin.ts
+++ b/packages/lib/src/resources/crud/write-origin.ts
@@ -6,6 +6,7 @@
 // replacing the `skipEvents` boolean over time.
 
 import type { ManifestCollector } from '../../record-rules/sync-manifest-collector'
+import type { TxWriteScope } from './tx-write-scope'
 
 /**
  * What a write IS, declared by the writer (plan 03 §4). One of five kinds:
@@ -57,9 +58,26 @@ export type WriteOrigin =
  * guard over time (S9), so there is one cascade guard, not two. For this
  * slice it is carried but not yet enforced.
  */
+/**
+ * HOW a write's doors behave, orthogonal to {@link WriteOrigin} (which says what
+ * the write IS). Plan 04 §6.2 — every suppression names its announcer, so the
+ * door-conformance harness can check that announcer exists.
+ */
+export type WriteMode =
+  /** Default. Doors fire inline, per record, as the write happens. */
+  | { kind: 'fanout' }
+  /** C1/C2 (plan 04 §3). Doors are captured into `scope` and replayed after the tx commits. */
+  | { kind: 'buffered'; scope: TxWriteScope }
+  /** C3. Doors stay shut at the leaf; `by` names the aggregator that announces. */
+  | { kind: 'absorbed'; by: string }
+  /** C4/C5. Doors stay shut on purpose; `reason` is the decision, in prose. */
+  | { kind: 'quiet'; reason: string }
+
 export interface WriteSession {
   origin: WriteOrigin
   depth: number
+  /** Defaults to `{ kind: 'fanout' }` when absent. */
+  mode?: WriteMode
 }
 
 /** Build an interactive session — the default for a handler constructed with a userId. */
@@ -81,11 +99,32 @@ export function seedSession(reason: string): WriteSession {
  *   `skipEvents: true` semantics exactly — sync writers still feed the B2
  *   manifest collector, seed stays silent forever.
  *
+ * - `'buffered'` — the write is inside a transaction that has not committed, so
+ *   its doors are captured into the session's {@link TxWriteScope} and replayed
+ *   once afterwards (plan 04 §6). Differs from `'silent'` only in that a live
+ *   collector keeps what `'silent'` throws away.
+ *
  * The batched replay lane (accumulate against the run ref, finalize pipeline,
  * count-based small-run vs batch selection per D-12) arrives in Phase 4; until
  * then `sync` maps to `'silent'` so behavior is preserved.
+ *
+ * `derivePublishEvents` (`unified-handler-mutations.ts`) is the only production
+ * reader — no call site outside that seam needs to know which lane it is on.
  */
-export function sessionLane(session: WriteSession): 'inline' | 'silent' {
+export function sessionLane(session: WriteSession): 'inline' | 'silent' | 'buffered' {
+  // The mode is orthogonal to the origin: a buffered interactive write and a
+  // buffered automation write are both buffered. `absorbed`/`quiet` resolve to
+  // the same `publishEvents === false` the leaves produce today; they carry the
+  // reason, not new behavior.
+  switch (session.mode?.kind) {
+    case 'buffered':
+      return 'buffered'
+    case 'absorbed':
+    case 'quiet':
+      return 'silent'
+    default:
+      break
+  }
   switch (session.origin.kind) {
     case 'interactive':
     case 'api':


### PR DESCRIPTION
Phase A of `plans/events/04-in-transaction-write-semantics-plan.md` (S10). One phase, shipping alone as the plan sequences it.

## What this is

An in-transaction composition is a one-transaction sync run. The doors each write would have opened are captured as **pure data** and replayed **once**, after the transaction commits — rather than firing mid-transaction or being thrown away.

Adds `WriteMode` on `WriteSession`, the `TxWriteScope` buffer, `runInTxWrite` and `flushTxWriteScope`, and routes money's four billing commands plus the gather flow through them. Reuses the sync manifest's data shape and the small-lane replay; it does not touch capture, subscription gating, caps, or `claimManifest`.

## Closes B-17 — the same operation forked on fan-out

`createInvoiceFromWorkOrder` and the four billing commands compose the identical invoice and announced it two different ways: ~N+1 creates plus ~6 field updates on one path, **nothing at all** on the other.

Both now emit **exactly one** `record:created` carrying the invoice's full initial state.

| | before | after |
| --- | --- | --- |
| `createInvoiceFromWorkOrder` (40 lines, 1 deposit) | ~45 events | 1 |
| the four billing commands | 0 | 1 |

Composed field writes fold into that create (T-1). The copied lines and the payment mirror fold in where the composing site declares `absorbInto` (T-1b) — **nothing is inferred** from the def or the relationship graph. The rejected alternative (fold children on defs with `isVisible: false`) is argued out in the plan's T-1b: `isVisible` is a navigation flag, it was two samples, and the parent-in-`created` guard does all the work on its own.

## Closes B-18 — a second policy channel

The eleven hand-threaded `publishEvents` hops and seven signatures are gone. `publishEvents: !input.db` was dead conditionality — always `false`, and the wrong predicate besides, since a `Transaction` and a pooled `Database` are the same type at every call site in this graph. Fan-out is now derived from the ambient session at the single `derivePublishEvents` seam.

`SetValuesForEntityInput.publishEvents` / `SetValueWithBuiltInInput.publishEvents` **stay** — they are the C3 escape hatch `setBulkValues` legitimately uses to batch-publish. `CrudOptions.skipEvents` is untouched and dies on plan 03's schedule.

## The correctness core

**T-5, the per-attempt contract.** Billing retries up to 3 times on SQLSTATE 40001/40P01. A buffer that outlives one attempt double-flushes writes a rollback undid. `runInTxWrite` mints the scope itself and takes **no scope parameter**, so no caller can hold one across a retry; a throw rejects before the scope escapes. Nesting **joins** rather than stacks and returns `owned: false` — callers flush only what they own. Without that flag a joined caller would re-announce the outer composition's creates (N joins → O(N²) duplicates) and, under retry, replay rolled-back captures through the one path the contract does not otherwise cover. Not reachable today; `batch-invoicing.ts` already loops these commands, so it is one wrapper away.

**T-4, pure data.** A buffered effect is never a db handle, service, handler or closure — post-commit those hold a released transaction and fail **silently**. A dev-only `structuredClone` assertion enforces it, with a test proving it fires on a poisoned scope.

**T-6, best-effort.** The transaction has committed, so a flush failure must never surface as a command failure. The guard wraps the whole body, not just the per-step work, because callers await it outside their own try. `assertTxWriteScopePure` deliberately sits outside that guard and is a no-op in production.

**T-2.** Post-hooks are never replayed — the composer already ran them in-tx, in order, against transactional state.

## Deviations from the plan, both deliberate

1. §6.4's `createTxWriteScope(userId)` + `runInTxWrite(scope, fn)` shape leaves an API a caller *can* open early, contradicting T-5 rule 1. Creation is folded into `runInTxWrite` so the rule is structural rather than disciplinary.
2. Absorption matches on the entity **instance** id, not the RecordId string. `handler.create` mints RecordIds from the canonical `EntityDefinition.id` while money mints them from the type slug; the plan's RecordId-keyed membership test would have matched **nothing**. There is a test pinning this.

## Verification

- `packages/lib` full suite: **889 passed / 4 skipped**. Two failures on the last run were 10s timeouts in `resolve-resource-trigger-match` and `workflow-draft-cas`; both pass in isolation (one uses 4.9s of its 10s budget) and neither area is touched here.
- 29 new tests — the per-attempt contract including "a retry cannot reuse the failed attempt's buffer", the T-4 poisoned scope, T-1/T-1b absorption, the C2 replay, the T-6 entry, the cap, and the dual-keyspace guard.
- `packages/lib` typecheck: **0 `src/` errors**. Biome clean.

## Known limits, stated rather than discovered later

- `updateEntity` / `restoreEntity` / `bulk*` do not buffer their lifecycle doors inside a scope — only their field changes replay. No Phase A site reaches this.
- The C2 replay is `fieldValues:updated` only: no field triggers, no bus event, no record-rules replay. Narrower than the plan's §4 door table promises, which contradicts T-2; T-2 was followed. Those doors are `false` today at the one C2 site, so this is no regression. Worth settling in the plan before Phase B.
- While joined, a nested composition's own post-flush projections still run at the inner call site and would invert O-9's ordering. Acceptable only because nesting is unreachable; documented on `runInTxWrite`.

Phases B–E (declare the quiet, merge, meetings, the C5 realtime calls) are untouched.