### PR TITLE
refactor(files): extract bucket routing, provider auth and the adapter registry

### DIFF
--- a/apps/web/src/app/api/files/upload/[sessionId]/complete/post-commit-thumbnails.test.ts
+++ b/apps/web/src/app/api/files/upload/[sessionId]/complete/post-commit-thumbnails.test.ts
@@ -44,7 +44,10 @@ const {
   onCacheEvent: vi.fn(),
   headByKey: vi.fn(async () => ({ size: 1024, mimeType: 'image/png', etagOrRev: 'etag-b' })),
   createStorageLocation: vi.fn(async () => ({ id: 'stl_cuid00000000000000000000' })),
-  buildExternalUrl: vi.fn(async () => 'https://cdn.example/avatar.png'),
+  // Synchronous, matching the port contract: `buildExternalUrl` runs inside the
+  // route's open transaction, so a promise-returning double would let the code
+  // under test await something production cannot.
+  buildExternalUrl: vi.fn(() => 'https://cdn.example/avatar.png'),
   validateCompletedUpload: vi.fn(),
   processorProcess: vi.fn(),
   dbTransaction: vi.fn(),

--- a/apps/web/src/app/api/files/upload/[sessionId]/complete/route.ts
+++ b/apps/web/src/app/api/files/upload/[sessionId]/complete/route.ts
@@ -176,15 +176,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         let externalUrl = ''
         try {
           if (session.visibility === 'PUBLIC') {
-            externalUrl = await storageManager.buildExternalUrl(
-              session.provider,
-              session.storageKey,
-              session.credentialId,
-              {
-                bucket: session.bucket,
-                visibility: session.visibility,
-              }
-            )
+            // Synchronous since PR 3b: this runs inside the open transaction,
+            // and the async version could reach the credential store from here
+            // just to learn a bucket the session already carries.
+            externalUrl = storageManager.buildExternalUrl(session.provider, session.storageKey, {
+              bucket: session.bucket,
+              visibility: session.visibility,
+            })
           }
         } catch (urlErr) {
           logger.warn('Failed to build external URL', {

--- a/packages/lib/src/files/adapters/base-adapter.ts
+++ b/packages/lib/src/files/adapters/base-adapter.ts
@@ -43,13 +43,7 @@ export interface ProviderAuth {
 export interface StorageCapabilities {
   presignUpload: boolean // Can generate presigned upload URLs
   presignDownload: boolean // Can generate presigned download URLs
-  serverSideDownload: boolean // Must proxy downloads through server
-  versioning: boolean // Supports file versioning
-  webhooks: boolean // Supports real-time change notifications
-  folders: boolean // Supports folder organization
-  search: boolean // Supports file search
-  metadata: boolean // Supports custom metadata
-  multipart: boolean
+  multipart: boolean // Supports multipart upload
 }
 
 /**
@@ -108,17 +102,6 @@ export interface PresignedUpload {
 export interface MultipartUpload {
   uploadId: string
   expiresAt: Date
-}
-
-/**
- * File revision information
- * Used for providers that support versioning
- */
-export interface FileRevision {
-  id: string
-  createdAt: Date
-  size?: number
-  etagOrRev?: string
 }
 
 // ============= Storage Adapter Interface =============
@@ -252,29 +235,6 @@ export interface StorageAdapter {
     bucket?: string
   }): Promise<{ etag: string; size?: number }>
 
-  // ============= File Management (External Providers) =============
-
-  /**
-   * Create a new file in external storage
-   */
-  createFile?(params: {
-    name: string
-    parentFolderId?: string
-    content: NodeJS.ReadableStream | Buffer
-    mimeType?: string
-    auth: ProviderAuth
-  }): Promise<{ id: string; name: string }>
-
-  /**
-   * Update an existing file in external storage
-   */
-  updateFile?(params: {
-    fileId: string
-    content?: NodeJS.ReadableStream | Buffer
-    name?: string
-    auth: ProviderAuth
-  }): Promise<{ id: string; rev?: string }>
-
   /**
    * Delete a file from external storage.
    *
@@ -284,22 +244,6 @@ export interface StorageAdapter {
    * delete looks like a success while the real object leaks.
    */
   deleteFile?(loc: StorageLocationRef, auth?: ProviderAuth): Promise<void>
-
-  // ============= Versioning (Providers with Version Support) =============
-
-  /**
-   * List all revisions of a file
-   */
-  listRevisions?(loc: StorageLocationRef, auth?: ProviderAuth): Promise<FileRevision[]>
-
-  /**
-   * Get a specific revision of a file
-   */
-  getRevision?(
-    loc: StorageLocationRef,
-    revisionId: string,
-    auth?: ProviderAuth
-  ): Promise<NodeJS.ReadableStream>
 
   // ============= Platform Auth Resolution =============
 
@@ -315,18 +259,6 @@ export interface StorageAdapter {
    * Used by StorageManager to enrich StorageLocationRef metadata.
    */
   resolveBucket?(): string | undefined
-
-  // ============= Authentication Management =============
-
-  /**
-   * Refresh expired authentication tokens
-   */
-  refreshAuth?(auth: ProviderAuth): Promise<ProviderAuth>
-
-  /**
-   * Validate authentication credentials
-   */
-  validateAuth?(auth: ProviderAuth): Promise<boolean>
 }
 
 // ============= Base Adapter Class =============
@@ -351,16 +283,6 @@ export abstract class BaseStorageAdapter implements StorageAdapter {
     if (loc.provider !== this.id) {
       throw new Error(`Invalid provider ${loc.provider} for ${this.id} adapter`)
     }
-  }
-
-  /**
-   * Validate authentication for operations that require it
-   */
-  public validateAuth(auth?: ProviderAuth): Promise<boolean> {
-    if (!auth) {
-      throw new Error(`Authentication required for ${this.name}`)
-    }
-    return Promise.resolve(true)
   }
 
   /**

--- a/packages/lib/src/files/adapters/index.ts
+++ b/packages/lib/src/files/adapters/index.ts
@@ -2,7 +2,6 @@
 
 export type {
   FileMetadata,
-  FileRevision,
   MultipartUpload,
   PresignedUpload,
   ProviderAuth,

--- a/packages/lib/src/files/adapters/s3-adapter.ts
+++ b/packages/lib/src/files/adapters/s3-adapter.ts
@@ -4,7 +4,6 @@ import { Readable } from 'node:stream'
 import { configService } from '@auxx/credentials'
 import { encodeRFC5987ValueChars } from '@auxx/utils'
 import {
-  AbortMultipartUploadCommand,
   CompleteMultipartUploadCommand,
   CreateMultipartUploadCommand,
   DeleteObjectCommand,
@@ -19,11 +18,11 @@ import {
 } from '@aws-sdk/client-s3'
 import { createPresignedPost } from '@aws-sdk/s3-presigned-post'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+import { assertBucket, bucketForVisibility, buildExternalUrl } from '../storage/buckets'
 import {
   BaseStorageAdapter,
   type DownloadRef,
   type FileMetadata,
-  type FileRevision,
   type MultipartUpload,
   type PresignedUpload,
   type ProviderAuth,
@@ -103,12 +102,6 @@ export class S3Adapter extends BaseStorageAdapter {
     return {
       presignUpload: true,
       presignDownload: true,
-      serverSideDownload: true,
-      versioning: true,
-      webhooks: false, // S3 events require SNS/SQS setup
-      folders: false, // S3 uses prefixes, not true folders
-      search: false, // No native search, requires external indexing
-      metadata: true,
       multipart: true,
     }
   }
@@ -153,21 +146,17 @@ export class S3Adapter extends BaseStorageAdapter {
 
   /**
    * Build external URL for S3 object.
-   * Prefers CDN URL if configured, then falls back to AWS virtual-hosted-style URL.
+   *
+   * Delegates to `storage/buckets.ts` so the adapter, the `StoragePort` and the
+   * `StorageManager` facade all render the same URL from the same rules.
    */
   buildExternalUrl(key: string, auth?: ProviderAuth): string {
-    const cdnUrl = configService.get<string>('CDN_URL')
-    if (cdnUrl) {
-      return `${cdnUrl}/${key}`
-    }
-
-    const bucket = (auth as any)?.bucket || configService.get<string>('S3_PUBLIC_BUCKET')
-    if (bucket) {
-      const region = (auth as any)?.region || configService.get<string>('S3_REGION') || 'us-west-1'
-      return `https://${bucket}.s3.${region}.amazonaws.com/${key}`
-    }
-
-    return key
+    return buildExternalUrl({
+      provider: this.id,
+      key,
+      bucket: (auth as any)?.bucket,
+      region: (auth as any)?.region,
+    })
   }
 
   /**
@@ -333,26 +322,13 @@ export class S3Adapter extends BaseStorageAdapter {
   }): Promise<PresignedUpload> {
     this.requireCapability('presignUpload')
     try {
-      // Determine bucket: explicit > visibility-based > auth > env default
-      let bucket = params.bucket
-
-      if (!bucket && params.visibility) {
-        // Import getBucketForVisibility dynamically
-        const { getBucketForVisibility } = await import('../upload/util')
-        bucket = getBucketForVisibility(params.visibility)
-      }
-
-      if (!bucket) {
-        bucket = (params.auth as any)?.bucket
-      }
-
-      if (!bucket) {
-        throw new StorageAdapterError(
-          'S3 bucket name is required for presigned upload. Please provide a bucket via params, credentials, or set S3_BUCKET environment variable.',
-          this.id,
-          'presignUpload'
-        )
-      }
+      // Determine bucket: explicit > visibility-based > auth. No configured default.
+      const bucket = assertBucket(
+        params.bucket ||
+          (params.visibility ? bucketForVisibility(params.visibility) : '') ||
+          (params.auth as any)?.bucket,
+        'S3 presignUpload'
+      )
 
       const client = this.createS3Client(params.auth)
       const ttlSec = params.ttlSec || 3600
@@ -431,25 +407,14 @@ export class S3Adapter extends BaseStorageAdapter {
     size?: number
   }> {
     try {
-      // Determine bucket: explicit > visibility-based > auth > env default
-      let bucket = params.bucket
-
-      if (!bucket && params.visibility) {
-        const { getBucketForVisibility } = await import('../upload/util')
-        bucket = getBucketForVisibility(params.visibility)
-      }
-
-      if (!bucket) {
-        bucket = (params.auth as any)?.bucket || configService.get<string>('S3_PRIVATE_BUCKET')
-      }
-
-      if (!bucket) {
-        throw new StorageAdapterError(
-          'S3 bucket name is required for direct upload. Please provide a bucket via params, credentials, or configure S3_PRIVATE_BUCKET.',
-          this.id,
-          'putObject'
-        )
-      }
+      // Determine bucket: explicit > visibility-based > auth. No configured default:
+      // a wrong-bucket write is invisible and the object leaks (#1816/#1817/#1818).
+      const bucket = assertBucket(
+        params.bucket ||
+          (params.visibility ? bucketForVisibility(params.visibility) : '') ||
+          (params.auth as any)?.bucket,
+        'S3 putObject'
+      )
 
       const client = this.createS3Client(params.auth)
 
@@ -490,25 +455,15 @@ export class S3Adapter extends BaseStorageAdapter {
     this.requireCapability('presignUpload')
 
     try {
-      // Determine bucket: explicit > visibility-based > auth > env default
-      let bucket = params.bucket
-
-      if (!bucket && params.visibility) {
-        const { getBucketForVisibility } = await import('../upload/util')
-        bucket = getBucketForVisibility(params.visibility)
-      }
-
-      if (!bucket) {
-        bucket = (params.auth as any)?.bucket || configService.get<string>('S3_PRIVATE_BUCKET')
-      }
-
-      if (!bucket) {
-        throw new StorageAdapterError(
-          'S3 bucket name is required for multipart upload. Please provide a bucket via params, credentials, or configure S3_PRIVATE_BUCKET.',
-          this.id,
-          'startMultipart'
-        )
-      }
+      // Determine bucket: explicit > visibility-based > auth. No configured default:
+      // parts and completion are presigned against whatever bucket this picks, and
+      // a mismatch surfaces only as `NoSuchUpload` much later.
+      const bucket = assertBucket(
+        params.bucket ||
+          (params.visibility ? bucketForVisibility(params.visibility) : '') ||
+          (params.auth as any)?.bucket,
+        'S3 startMultipart'
+      )
 
       const client = this.createS3Client(params.auth)
 
@@ -558,14 +513,7 @@ export class S3Adapter extends BaseStorageAdapter {
     this.requireCapability('presignUpload')
 
     try {
-      const bucket = params.bucket
-      if (!bucket) {
-        throw new StorageAdapterError(
-          'S3 bucket name is required for part upload. Pass the bucket the multipart upload was initiated in (upload session `bucket`) — presigning a part against a different bucket fails with NoSuchUpload.',
-          this.id,
-          'presignPart'
-        )
-      }
+      const bucket = assertBucket(params.bucket, 'S3 presignPart')
 
       const client = this.createS3Client(params.auth)
       const ttlSec = params.ttlSec || 3600
@@ -606,14 +554,7 @@ export class S3Adapter extends BaseStorageAdapter {
     this.requireCapability('presignUpload')
 
     try {
-      const bucket = params.bucket
-      if (!bucket) {
-        throw new StorageAdapterError(
-          'S3 bucket name is required to complete multipart upload. Pass the bucket the multipart upload was initiated in (upload session `bucket`) — completing against a different bucket fails with NoSuchUpload.',
-          this.id,
-          'completeMultipart'
-        )
-      }
+      const bucket = assertBucket(params.bucket, 'S3 completeMultipart')
 
       const client = this.createS3Client(params.auth)
 
@@ -640,76 +581,7 @@ export class S3Adapter extends BaseStorageAdapter {
     }
   }
 
-  /**
-   * Abort S3 multipart upload
-   */
-  async abortMultipart(params: {
-    key: string
-    uploadId: string
-    bucket?: string
-    auth?: ProviderAuth
-  }): Promise<void> {
-    try {
-      const bucket =
-        params.bucket ||
-        (params.auth as any)?.bucket ||
-        configService.get<string>('S3_PRIVATE_BUCKET')
-      if (!bucket) {
-        throw new StorageAdapterError(
-          'S3 bucket name is required to abort multipart upload. Please provide a bucket via params, credentials, or configure S3_PRIVATE_BUCKET.',
-          this.id,
-          'abortMultipart'
-        )
-      }
-
-      const client = this.createS3Client(params.auth)
-
-      const command = new AbortMultipartUploadCommand({
-        Bucket: bucket,
-        Key: params.key,
-        UploadId: params.uploadId,
-      })
-
-      await client.send(command)
-    } catch (error) {
-      this.handleS3Error(error, 'abortMultipart')
-    }
-  }
-
   // ============= File Management =============
-
-  /**
-   * Create S3 object
-   */
-  async createFile(params: {
-    name: string
-    parentFolderId?: string
-    content: NodeJS.ReadableStream | Buffer
-    mimeType?: string
-    auth: ProviderAuth
-  }): Promise<{ id: string; name: string }> {
-    await this.validateAuth(params.auth)
-
-    // TODO: Implement S3 PutObjectCommand
-    // Handle parentFolderId as key prefix
-    throw new Error('Not implemented')
-  }
-
-  /**
-   * Update S3 object
-   */
-  async updateFile(params: {
-    fileId: string
-    content?: NodeJS.ReadableStream | Buffer
-    name?: string
-    auth: ProviderAuth
-  }): Promise<{ id: string; rev?: string }> {
-    await this.validateAuth(params.auth)
-
-    // TODO: Implement S3 object update
-    // S3 doesn't have true updates, requires PUT with new content
-    throw new Error('Not implemented')
-  }
 
   /**
    * Delete S3 object.
@@ -738,75 +610,7 @@ export class S3Adapter extends BaseStorageAdapter {
 
   // ============= Versioning =============
 
-  /**
-   * List S3 object versions
-   */
-  async listRevisions(loc: StorageLocationRef, auth?: ProviderAuth): Promise<FileRevision[]> {
-    this.validateLocation(loc)
-    this.requireCapability('versioning')
-
-    // TODO: Implement S3 ListObjectVersionsCommand
-    throw new Error('Not implemented')
-  }
-
-  /**
-   * Get specific S3 object version
-   */
-  async getRevision(
-    loc: StorageLocationRef,
-    revisionId: string,
-    auth?: ProviderAuth
-  ): Promise<NodeJS.ReadableStream> {
-    this.validateLocation(loc)
-    this.requireCapability('versioning')
-
-    // TODO: Implement S3 GetObjectCommand with VersionId
-    throw new Error('Not implemented')
-  }
-
   // ============= Authentication Management =============
-
-  /**
-   * Refresh S3 credentials (if using STS)
-   */
-  async refreshAuth(auth: ProviderAuth): Promise<ProviderAuth> {
-    // For most S3 use cases, credentials don't need refreshing
-    // STS token refresh would be handled by the credential provider
-    // This is more relevant for OAuth-based providers like Google Drive
-    return auth
-  }
-
-  /**
-   * Validate S3 authentication
-   */
-  async validateAuth(auth?: ProviderAuth): Promise<boolean> {
-    try {
-      const client = this.createS3Client(auth)
-
-      // Try a simple operation to test credentials
-      // Use ListBuckets as a lightweight test
-      const { ListBucketsCommand } = await import('@aws-sdk/client-s3')
-      const command = new ListBucketsCommand({})
-
-      await client.send(command)
-      return true
-    } catch (error: any) {
-      // If it's an auth error, return false
-      const errorCode = error.name || error.Code || error.$metadata?.errorCode
-      if (
-        [
-          'AccessDenied',
-          'InvalidAccessKeyId',
-          'SignatureDoesNotMatch',
-          'TokenRefreshRequired',
-        ].includes(errorCode)
-      ) {
-        return false
-      }
-      // Re-throw other errors (network, etc.)
-      throw error
-    }
-  }
 
   // ============= Helper Methods =============
 
@@ -837,24 +641,17 @@ export class S3Adapter extends BaseStorageAdapter {
       }
     }
 
-    // ✅ ALWAYS use configured bucket - don't try to parse bucket from key
-    // The externalId is the storage key, not bucket/key format
-    // Priority: auth.bucket > S3_PRIVATE_BUCKET config
-    const bucket = (auth as any)?.bucket || configService.get<string>('S3_PRIVATE_BUCKET')
+    // Never parse a bucket out of the key — the externalId IS the storage key.
+    // The bucket comes from the pinned auth and nowhere else: falling back to
+    // `S3_PRIVATE_BUCKET` here is what made a PUBLIC object read/head against
+    // the private bucket and report a phantom 404.
+    const bucket = assertBucket((auth as any)?.bucket, `S3 parseLocation for '${externalId}'`)
 
-    if (bucket) {
-      return {
-        bucket,
-        key: externalId, // ✅ Use full externalId as the key
-        ...loc.metadata,
-      }
+    return {
+      bucket,
+      key: externalId,
+      ...loc.metadata,
     }
-
-    throw new StorageAdapterError(
-      `Invalid S3 location format: ${externalId}. Either provide s3://bucket/key format, bucket/key format, or configure S3_PRIVATE_BUCKET.`,
-      this.id,
-      'parseLocation'
-    )
   }
 
   /**

--- a/packages/lib/src/files/index.ts
+++ b/packages/lib/src/files/index.ts
@@ -56,7 +56,6 @@ export { assertPublicHost, fetchAndStoreRemoteImage } from './fetch-remote-image
 
 export type {
   FileMetadata,
-  FileRevision,
   MultipartUpload,
   PresignedUpload,
   ProviderAuth,

--- a/packages/lib/src/files/storage/__tests__/buckets.test.ts
+++ b/packages/lib/src/files/storage/__tests__/buckets.test.ts
@@ -1,0 +1,172 @@
+// packages/lib/src/files/storage/__tests__/buckets.test.ts
+
+/**
+ * The pure half of the storage layer, tested the way this refactor says pure
+ * code should be: **`vi.mock` is called zero times in this file.**
+ *
+ * These four functions used to be a method on `S3Adapter` and three exports in
+ * `upload/util.ts`, reachable only by constructing an adapter or a
+ * `StorageManager`. Everything below is a table over strings.
+ *
+ * The one ambient input is `configService`, which resolves `process.env` at
+ * call time (not at import time), so {@link withConfig} sets the four keys per
+ * case and restores them afterwards. That is deliberately not a mock: the real
+ * resolution order — env, then the registry's own defaults — is part of what is
+ * under test, and a `vi.mock('@auxx/credentials')` would assert against a
+ * fiction. Every case sets every key it depends on, so an ambient `.env` on a
+ * developer machine cannot change an outcome.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { assertBucket, bucketForVisibility, buildExternalUrl, publicCdnUrl } from '../buckets'
+
+const CONFIG_KEYS = ['CDN_URL', 'S3_PUBLIC_BUCKET', 'S3_PRIVATE_BUCKET', 'S3_REGION'] as const
+type ConfigKey = (typeof CONFIG_KEYS)[number]
+
+const originals = new Map<ConfigKey, string | undefined>(
+  CONFIG_KEYS.map((key) => [key, process.env[key]])
+)
+
+/** Set exactly the keys named; `undefined` unsets, falling back to the registry default. */
+function withConfig(values: Partial<Record<ConfigKey, string | undefined>>): void {
+  for (const key of CONFIG_KEYS) {
+    const value = values[key]
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+}
+
+afterEach(() => {
+  for (const [key, value] of originals) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+})
+
+describe('bucketForVisibility', () => {
+  it.each([
+    ['PUBLIC' as const, 'cfg-public'],
+    ['PRIVATE' as const, 'cfg-private'],
+  ])('routes %s to the configured bucket', (visibility, expected) => {
+    withConfig({ S3_PUBLIC_BUCKET: 'cfg-public', S3_PRIVATE_BUCKET: 'cfg-private' })
+
+    expect(bucketForVisibility(visibility)).toBe(expected)
+  })
+
+  it('never returns the private bucket for a PUBLIC object', () => {
+    // The bug this union exists to prevent: `DatasetAssetProcessor` declared
+    // lowercase `'private'`, which is neither branch, so it fell through to the
+    // PUBLIC arm. A misspelling is now a compile error, and the two arms must
+    // stay distinguishable at runtime too.
+    withConfig({ S3_PUBLIC_BUCKET: 'cfg-public', S3_PRIVATE_BUCKET: 'cfg-private' })
+
+    expect(bucketForVisibility('PUBLIC')).not.toBe(bucketForVisibility('PRIVATE'))
+  })
+})
+
+describe('buildExternalUrl', () => {
+  it('prefers CDN_URL over every bucket input', () => {
+    withConfig({ CDN_URL: 'https://cdn.test', S3_PUBLIC_BUCKET: 'cfg-public' })
+
+    expect(
+      buildExternalUrl({
+        provider: 'S3',
+        key: 'org_1/a.png',
+        bucket: 'explicit',
+        region: 'eu-west-1',
+      })
+    ).toBe('https://cdn.test/org_1/a.png')
+  })
+
+  it.each([
+    {
+      name: 'explicit bucket wins over visibility',
+      input: { bucket: 'explicit-bucket', visibility: 'PUBLIC' as const },
+      expected: 'https://explicit-bucket.s3.eu-west-1.amazonaws.com/org_1/a.png',
+    },
+    {
+      name: 'visibility picks the configured bucket when none is passed',
+      input: { visibility: 'PRIVATE' as const },
+      expected: 'https://cfg-private.s3.eu-west-1.amazonaws.com/org_1/a.png',
+    },
+    {
+      name: 'falls back to the public bucket with neither',
+      input: {},
+      expected: 'https://cfg-public.s3.eu-west-1.amazonaws.com/org_1/a.png',
+    },
+  ])('$name', ({ input, expected }) => {
+    withConfig({
+      S3_PUBLIC_BUCKET: 'cfg-public',
+      S3_PRIVATE_BUCKET: 'cfg-private',
+      S3_REGION: 'eu-west-1',
+    })
+
+    expect(buildExternalUrl({ provider: 'S3', key: 'org_1/a.png', ...input })).toBe(expected)
+  })
+
+  it('lets the caller-supplied region win over S3_REGION', () => {
+    // This is what keeps the function synchronous: the caller has already read
+    // the StorageLocation row, so the port never has to fetch a credential to
+    // learn a region while a write transaction is open.
+    withConfig({ S3_PUBLIC_BUCKET: 'cfg-public', S3_REGION: 'eu-west-1' })
+
+    expect(buildExternalUrl({ provider: 'S3', key: 'a.png', region: 'ap-south-1' })).toBe(
+      'https://cfg-public.s3.ap-south-1.amazonaws.com/a.png'
+    )
+  })
+
+  it('returns the bare key for a provider that is not bucket-addressed', () => {
+    withConfig({ S3_PUBLIC_BUCKET: 'cfg-public', S3_REGION: 'eu-west-1' })
+
+    expect(buildExternalUrl({ provider: 'DROPBOX', key: 'org_1/a.png' })).toBe('org_1/a.png')
+  })
+
+  it('is synchronous', () => {
+    withConfig({ CDN_URL: 'https://cdn.test' })
+
+    // Not `await`-ed anywhere: a Promise here would mean the upload-complete
+    // route could hold its transaction open on I/O. See `StoragePort`.
+    const url: string = buildExternalUrl({ provider: 'S3', key: 'a.png' })
+    expect(url).toBe('https://cdn.test/a.png')
+    expect(url).not.toBeInstanceOf(Promise)
+  })
+})
+
+describe('publicCdnUrl', () => {
+  it('uses CDN_URL when configured', () => {
+    withConfig({ CDN_URL: 'https://cdn.test' })
+
+    expect(publicCdnUrl('org_1/a.png')).toBe('https://cdn.test/org_1/a.png')
+  })
+
+  it('falls back to the public bucket, never the private one', () => {
+    withConfig({
+      S3_PUBLIC_BUCKET: 'cfg-public',
+      S3_PRIVATE_BUCKET: 'cfg-private',
+      S3_REGION: 'eu-west-1',
+    })
+
+    expect(publicCdnUrl('org_1/a.png')).toBe(
+      'https://cfg-public.s3.eu-west-1.amazonaws.com/org_1/a.png'
+    )
+  })
+})
+
+describe('assertBucket', () => {
+  it('returns the bucket when there is one', () => {
+    expect(assertBucket('some-bucket', 'S3 putObject')).toBe('some-bucket')
+  })
+
+  it.each([[undefined], ['']])('throws a 400 naming the operation for %p', (bucket) => {
+    // The whole point: no configured default is substituted. S3 answers 204 for
+    // a delete of a key that is not in the bucket you named, so a fallback here
+    // is a silent object leak (#1816/#1817/#1818).
+    try {
+      assertBucket(bucket, 'S3 deleteFile')
+      expect.unreachable('assertBucket must throw without a bucket')
+    } catch (error) {
+      expect((error as { statusCode: number }).statusCode).toBe(400)
+      expect((error as Error).message).toContain('S3 deleteFile')
+    }
+  })
+})

--- a/packages/lib/src/files/storage/__tests__/multipart-bucket-routing.test.ts
+++ b/packages/lib/src/files/storage/__tests__/multipart-bucket-routing.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearStorageAdapterCache } from '../providers'
 import { StorageManager } from '../storage-manager'
 
 vi.mock('@auxx/credentials', () => ({
@@ -54,12 +55,6 @@ vi.mock('../storage-location-service', () => ({
     getLocationsByCredential: vi.fn(),
     findByExternalId: vi.fn(),
   },
-}))
-
-vi.mock('../../upload/util', () => ({
-  getBucketForVisibility: vi.fn((visibility: 'PUBLIC' | 'PRIVATE') =>
-    visibility === 'PUBLIC' ? 'test-public-bucket' : 'test-private-bucket'
-  ),
 }))
 
 const mockPresignPart = vi.fn().mockResolvedValue({
@@ -111,8 +106,10 @@ describe('StorageManager – bucket routing for multipart parts, completion and 
   let manager: StorageManager
 
   beforeEach(() => {
-    // Clear the private static adapter cache so each test starts fresh.
-    ;(StorageManager as any).adapterCache = new Map()
+    // Clear the adapter cache so each test starts fresh. It is a module-level
+    // map in `storage/providers.ts` since PR 3b, with an exported test seam
+    // instead of a private static reached through `as any`.
+    clearStorageAdapterCache()
     manager = new StorageManager('org123')
     vi.clearAllMocks()
   })

--- a/packages/lib/src/files/storage/__tests__/policy-enforcement.test.ts
+++ b/packages/lib/src/files/storage/__tests__/policy-enforcement.test.ts
@@ -2,6 +2,7 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { UploadPreparedConfig } from '../../upload/init-types'
+import { clearStorageAdapterCache } from '../providers'
 import { storageLocationService } from '../storage-location-service'
 import { StorageManager } from '../storage-manager'
 
@@ -47,13 +48,6 @@ vi.mock('../storage-location-service', () => ({
     getLocationsByCredential: vi.fn(),
     findByExternalId: vi.fn(),
   },
-}))
-
-// Mock getBucketForVisibility (imported at module level by storage-manager)
-vi.mock('../../upload/util', () => ({
-  getBucketForVisibility: vi.fn((visibility: 'PUBLIC' | 'PRIVATE') =>
-    visibility === 'PUBLIC' ? 'test-public-bucket' : 'test-private-bucket'
-  ),
 }))
 
 const mockPresignUpload = vi.fn().mockResolvedValue({
@@ -147,9 +141,10 @@ describe('StorageManager – enforcePolicy via generatePresignedUploadUrl', () =
   let manager: StorageManager
 
   beforeEach(() => {
-    // Clear the static adapter cache so each test starts fresh.
-    // The cache is a private static Map; we access it via bracket notation.
-    ;(StorageManager as any).adapterCache = new Map()
+    // Clear the adapter cache so each test starts fresh. It is a module-level
+    // map in `storage/providers.ts` since PR 3b, with an exported test seam
+    // instead of a private static reached through `as any`.
+    clearStorageAdapterCache()
 
     manager = new StorageManager('org123')
     vi.clearAllMocks()

--- a/packages/lib/src/files/storage/__tests__/providers.test.ts
+++ b/packages/lib/src/files/storage/__tests__/providers.test.ts
@@ -1,0 +1,38 @@
+// packages/lib/src/files/storage/__tests__/providers.test.ts
+
+/**
+ * The provider registry, which was a `private static` on `StorageManager`.
+ *
+ * `vi.mock` is called zero times here: the registry is pure data and its
+ * loaders are `import()` expressions, so asking "is `DROPBOX` supported?"
+ * touches nothing. That is the property the Phase-2 write pilot wanted when it
+ * duplicated the set as a local `SUPPORTED_PROVIDERS` rather than construct a
+ * `StorageManager` to answer it — `storage/locations.ts` now reads this.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { ProviderId } from '../../adapters/base-adapter'
+import { AVAILABLE_PROVIDERS, isProviderAvailable } from '../providers'
+
+describe('isProviderAvailable', () => {
+  it('accepts S3, the only provider with an adapter today', () => {
+    expect(isProviderAvailable('S3')).toBe(true)
+  })
+
+  it.each<ProviderId>([
+    'GOOGLE_DRIVE',
+    'DROPBOX',
+    'ONEDRIVE',
+    'BOX',
+    'GENERIC_URL',
+  ])('rejects %s, whose adapter is still a commented-out stub', (provider) => {
+    expect(isProviderAvailable(provider)).toBe(false)
+  })
+
+  it('agrees with the exported set', () => {
+    expect([...AVAILABLE_PROVIDERS]).toEqual(['S3'])
+    for (const provider of AVAILABLE_PROVIDERS) {
+      expect(isProviderAvailable(provider)).toBe(true)
+    }
+  })
+})

--- a/packages/lib/src/files/storage/auth.ts
+++ b/packages/lib/src/files/storage/auth.ts
@@ -1,0 +1,97 @@
+// packages/lib/src/files/storage/auth.ts
+
+/**
+ * Provider credential resolution — the single implementation.
+ *
+ * There were two. `StorageManager.getProviderAuth` was `private`, so
+ * `createS3StoragePort` in `ports.ts` could not reach it and reimplemented the
+ * same twenty lines with different error classes and a different bucket policy.
+ * Two copies of "which credential does this object use" is exactly the drift
+ * `plans/attachments/03-storage-layer.md` §3.0.1 flagged: the port pinned
+ * `auth.bucket` to the caller's bucket, the manager did not, and which one you
+ * got depended on which door you came through.
+ *
+ * ## `bucket` is pinned, not resolved
+ *
+ * `S3Adapter.parseS3Location`, `createS3Client` and `buildExternalUrl` all read
+ * `auth.bucket`. Leaving it to come from the credential record (or from
+ * `S3_PRIVATE_BUCKET` via `resolvePlatformAuth`) is how a PUBLIC upload's
+ * object ended up addressed against the private bucket. Callers that know the
+ * bucket — which after Phase 1 is all of them on the object paths — pass it and
+ * it overwrites whatever the credential said.
+ *
+ * ## Errors are `AuxxError`, not `StorageAuthError`
+ *
+ * `StorageAuthError` extends `StorageAdapterError extends Error`, so a router
+ * seeing one produces a generic 500. Per `docs/lib-module-guide.md` lib throws
+ * `AuxxError` subclasses; `StorageManager.handleStorageError` still re-wraps
+ * these into `StorageAdapterError` for its own legacy callers, so the facade's
+ * throw shape is unchanged.
+ */
+
+import { revealSecrets } from '@auxx/credentials/store'
+import { BadRequestError, UnauthorizedError } from '../../errors'
+import type { ProviderAuth, ProviderId } from '../adapters/base-adapter'
+import { getStorageAdapter } from './providers'
+
+export interface ResolveProviderAuthParams {
+  provider: ProviderId
+  /** Required only when `credentialId` is set — platform storage has no org. */
+  organizationId?: string
+  /** A user-connected credential. Absent means platform storage. */
+  credentialId?: string
+  /**
+   * Overwrites `auth.bucket` on the resolved credential. Pass it whenever the
+   * bucket is known: see the file header for why.
+   */
+  bucket?: string
+}
+
+/**
+ * Resolve the credential a storage operation should run under.
+ *
+ * 1. `credentialId` → the org's own connected provider, via the credential store.
+ * 2. otherwise → platform storage, via `adapter.resolvePlatformAuth()`.
+ *
+ * @throws {BadRequestError} when a `credentialId` is supplied without an
+ *   organization, or when neither a credential nor platform config is available.
+ * @throws {UnauthorizedError} when the credential exists but cannot be revealed.
+ */
+export async function resolveProviderAuth(
+  params: ResolveProviderAuthParams
+): Promise<ProviderAuth> {
+  const { provider, organizationId, credentialId, bucket } = params
+
+  if (credentialId) {
+    if (!organizationId) {
+      throw new BadRequestError(
+        `credentialId '${credentialId}' was supplied for ${provider} but no organizationId was`
+      )
+    }
+
+    const revealed = await revealSecrets(credentialId, organizationId)
+    if (revealed.isErr()) {
+      throw new UnauthorizedError(
+        `Failed to load ${provider} credential '${credentialId}': ${revealed.error.message}`
+      )
+    }
+
+    const { record, secrets } = revealed.value
+    return {
+      ...(record.metadata as Record<string, unknown>),
+      ...secrets,
+      ...(bucket && { bucket }),
+    } as ProviderAuth
+  }
+
+  const adapter = await getStorageAdapter(provider)
+  const platformAuth = adapter.resolvePlatformAuth?.()
+  if (!platformAuth) {
+    throw new BadRequestError(
+      `No credentials available for ${provider}. Configure platform storage ` +
+        '(for S3: S3_REGION and S3_PRIVATE_BUCKET) or supply a credentialId.'
+    )
+  }
+
+  return { ...platformAuth, ...(bucket && { bucket }) }
+}

--- a/packages/lib/src/files/storage/buckets.ts
+++ b/packages/lib/src/files/storage/buckets.ts
@@ -1,0 +1,140 @@
+// packages/lib/src/files/storage/buckets.ts
+
+/**
+ * Bucket routing and public-URL formatting — the pure half of the storage layer.
+ *
+ * Everything here is data in, string out: it reads `configService` and formats
+ * a URL. No database, no adapter, no credential fetch, no `Promise`. That is
+ * deliberate and it is the point of the file:
+ *
+ * - **Zero mocks to test.** These four functions used to live on `S3Adapter`
+ *   and in `upload/util.ts`, reachable only by constructing an adapter or a
+ *   `StorageManager`. As free functions they are a table-driven test.
+ * - **`buildExternalUrl` is synchronous.** It is called *inside* the open
+ *   `db.transaction` on the upload-complete path. The async version it replaces
+ *   (`StorageManager.buildExternalUrl`) could reach `getProviderAuth()` →
+ *   `revealSecrets()` — a database read plus a decrypt — while holding a write
+ *   transaction open, purely to learn a bucket the caller already knew. The
+ *   sync signature forecloses that; a caller that genuinely needs a
+ *   credential-derived `region` resolves it *before* opening the transaction
+ *   and passes it in. Same contract as {@link StoragePort.buildExternalUrl}.
+ *
+ * ## Visibility is a strict union, not a `string`
+ *
+ * {@link StorageVisibility} exists because `BaseAssetProcessor` declared
+ * `fileVisibility: string` and cast it at the one call site
+ * (`this.fileVisibility as 'PUBLIC' | 'PRIVATE'`). `DatasetAssetProcessor`
+ * therefore compiled with lowercase `'private'`, which matched neither branch:
+ * dataset uploads routed to the *public* bucket and `isAssetPrivate()` — a
+ * `=== 'PRIVATE'` comparison — answered `false`. A named union on the field
+ * turns both of those into compile errors.
+ */
+
+import { configService } from '@auxx/credentials'
+import { BadRequestError } from '../../errors'
+import type { ProviderId } from '../adapters/base-adapter'
+
+/**
+ * Which of the platform's two buckets an object belongs in.
+ *
+ * Uppercase, matching the `FileVisibility` database enum and
+ * `UploadPreparedConfig.visibility`. The lowercase `'public' | 'private'` in
+ * `upload/types.ts` is a *request* vocabulary and never reaches this module —
+ * `toStorageVisibility` maps it.
+ */
+export type StorageVisibility = 'PUBLIC' | 'PRIVATE'
+
+/** Everything needed to render an object's public URL. */
+export interface ExternalUrlInput {
+  provider: ProviderId
+  /** The object key. Returned unchanged for providers that have no URL form. */
+  key: string
+  /** The bucket the object actually lives in. Wins over `visibility`. */
+  bucket?: string
+  /** Used to pick a bucket only when `bucket` is absent. */
+  visibility?: StorageVisibility
+  /**
+   * Supplied by the caller — which has already read the `StorageLocation` row
+   * — rather than fetched from a credential. That is what keeps this function
+   * synchronous. Falls back to `S3_REGION`.
+   */
+  region?: string
+}
+
+/** Region used when neither the caller nor `S3_REGION` supplies one. */
+const DEFAULT_REGION = 'us-west-1'
+
+/**
+ * The configured bucket for a visibility.
+ *
+ * Returns `''` when the bucket is not configured, matching the behaviour of the
+ * `getBucketForVisibility` it replaces: callers treat the empty string as
+ * "unknown" and fall through to their own resolution. Use {@link assertBucket}
+ * at the point where a bucket stops being optional.
+ */
+export function bucketForVisibility(visibility: StorageVisibility): string {
+  const key = visibility === 'PUBLIC' ? 'S3_PUBLIC_BUCKET' : 'S3_PRIVATE_BUCKET'
+  return configService.get<string>(key) || ''
+}
+
+/**
+ * The public URL for an object in the public bucket.
+ *
+ * Prefers `CDN_URL`; otherwise renders a virtual-hosted-style S3 URL against
+ * the public bucket.
+ */
+export function publicCdnUrl(storageKey: string): string {
+  return buildExternalUrl({ provider: 'S3', key: storageKey, visibility: 'PUBLIC' })
+}
+
+/**
+ * Render the external (public) URL for an object.
+ *
+ * Resolution order, unchanged from `S3Adapter.buildExternalUrl` +
+ * `StorageManager.withResolvedS3Bucket` which it replaces:
+ * `CDN_URL` → explicit `bucket` → `visibility`'s configured bucket →
+ * `S3_PUBLIC_BUCKET` → the bare key.
+ *
+ * Non-bucket-addressed providers have no URL form here and get the key back,
+ * which is what `StorageManager.buildExternalUrl` did for any adapter without a
+ * `buildExternalUrl`.
+ */
+export function buildExternalUrl(p: ExternalUrlInput): string {
+  const cdnUrl = configService.get<string>('CDN_URL')
+  if (cdnUrl) return `${cdnUrl}/${p.key}`
+
+  if (p.provider !== 'S3') return p.key
+
+  const bucket =
+    p.bucket ||
+    (p.visibility ? bucketForVisibility(p.visibility) : '') ||
+    configService.get<string>('S3_PUBLIC_BUCKET')
+
+  if (!bucket) return p.key
+
+  const region = p.region || configService.get<string>('S3_REGION') || DEFAULT_REGION
+  return `https://${bucket}.s3.${region}.amazonaws.com/${p.key}`
+}
+
+/**
+ * Require a bucket, naming the operation that needs one.
+ *
+ * The single replacement for the six near-identical "S3 bucket name is
+ * required…" throws that used to sit behind an `S3_PRIVATE_BUCKET` fallback in
+ * `S3Adapter`. Bugs #1816/#1817/#1818 were all that fallback: S3 answers
+ * `204 No Content` for a delete of a key that is not in the bucket you named,
+ * and `NoSuchUpload` for a part presigned against a bucket the upload did not
+ * start in — so the wrong-bucket call succeeded and the real object leaked.
+ *
+ * @throws {BadRequestError} when no bucket was supplied.
+ */
+export function assertBucket(bucket: string | undefined, op: string): string {
+  if (!bucket) {
+    throw new BadRequestError(
+      `${op} requires an explicit bucket. Pass the bucket the object lives in ` +
+        '(the upload session `bucket`). Resolving a configured default instead is how a ' +
+        'wrong-bucket delete 204s and a wrong-bucket part presign fails with NoSuchUpload.'
+    )
+  }
+  return bucket
+}

--- a/packages/lib/src/files/storage/locations.ts
+++ b/packages/lib/src/files/storage/locations.ts
@@ -62,19 +62,7 @@ import { AuxxError, BadRequestError } from '../../errors'
 import type { ProviderId } from '../adapters/base-adapter'
 import type { FilesCtx } from '../ctx'
 import { guard } from '../guard'
-
-/**
- * Providers a `StorageLocation` may be created for.
- *
- * Mirrors `StorageManager.adapters` — the registry `isProviderAvailable()`
- * consults — which today contains `S3` alone; the other five `StorageProvider`
- * enum members are commented out there and have no adapter. Kept as a local
- * constant rather than reaching into `StorageManager` because that would mean
- * constructing a collaborator to answer a question that is pure data. Phase 3
- * should lift the registry to a module-level const both can read; until then
- * the drift risk is real and is recorded here deliberately.
- */
-const SUPPORTED_PROVIDERS: ReadonlySet<ProviderId> = new Set<ProviderId>(['S3'])
+import { isProviderAvailable } from './providers'
 
 /**
  * Everything needed to persist one `StorageLocation` row.
@@ -140,7 +128,7 @@ function normalizeLocationMetadata(input: CreateStorageLocationInput): Record<st
  * inside a caller's transaction body rolls the transaction back.
  */
 function assertValidInput(input: CreateStorageLocationInput): void {
-  if (!SUPPORTED_PROVIDERS.has(input.provider)) {
+  if (!isProviderAvailable(input.provider)) {
     throw new BadRequestError(`Storage provider ${input.provider} is not available`)
   }
   if (!input.externalId) {

--- a/packages/lib/src/files/storage/ports.ts
+++ b/packages/lib/src/files/storage/ports.ts
@@ -20,20 +20,19 @@
  * anywhere. An optional `bucket` on a port method is a regression.
  */
 
-import { revealSecrets } from '@auxx/credentials/store'
-import { BadRequestError, UnauthorizedError } from '../../errors'
 import type { OrphanedStorageObjectJobData } from '../../jobs/maintenance/orphaned-storage-object-job'
 import type {
   DownloadRef,
   FileMetadata,
   PresignedUpload,
-  ProviderAuth,
   ProviderId,
   StorageLocationRef,
 } from '../adapters/base-adapter'
 import { S3Adapter } from '../adapters/s3-adapter'
 import type { GenerateThumbnailPayload } from '../core/thumbnail-types'
 import type { UploadPreparedConfig } from '../upload/init-types'
+import { resolveProviderAuth } from './auth'
+import { buildExternalUrl } from './buckets'
 import { createStorageManager } from './storage-manager'
 
 // ============= Parameter types =============
@@ -239,33 +238,11 @@ export function createS3StoragePort(organizationId?: string): StoragePort {
    * Pinning is the whole trick: the adapter's `parseS3Location`,
    * `createS3Client` and `buildExternalUrl` all read `auth.bucket`, and leaving
    * it to resolve from config is how objects ended up in — and deletes aimed
-   * at — the wrong bucket.
+   * at — the wrong bucket. The resolution itself lives in `storage/auth.ts`,
+   * which is also what `StorageManager` uses, so the two doors cannot drift.
    */
-  async function resolveAuth(bucket: string, credentialId?: string): Promise<ProviderAuth> {
-    if (credentialId) {
-      if (!organizationId) {
-        throw new BadRequestError(
-          `credentialId '${credentialId}' was supplied but the storage port has no organizationId`
-        )
-      }
-      const revealed = await revealSecrets(credentialId, organizationId)
-      if (revealed.isErr()) {
-        throw new UnauthorizedError(
-          `Failed to load S3 credential '${credentialId}': ${revealed.error.message}`
-        )
-      }
-      const { record, secrets } = revealed.value
-      return { ...record.metadata, ...secrets, bucket } as ProviderAuth
-    }
-
-    const platformAuth = adapter.resolvePlatformAuth()
-    if (!platformAuth) {
-      throw new BadRequestError(
-        'S3 platform storage is not configured (set S3_REGION and S3_PRIVATE_BUCKET) and no credentialId was supplied'
-      )
-    }
-    return { ...platformAuth, bucket }
-  }
+  const resolveAuth = (bucket: string, credentialId?: string) =>
+    resolveProviderAuth({ provider: 'S3', organizationId, credentialId, bucket })
 
   /** Build the adapter's location shape with the bucket on metadata, where the adapter looks for it. */
   function locationRef(p: ObjectRef & { versionId?: string }): StorageLocationRef {
@@ -347,9 +324,6 @@ export function createS3StoragePort(organizationId?: string): StoragePort {
       }),
 
     buildExternalUrl: (p) =>
-      adapter.buildExternalUrl(p.key, {
-        bucket: p.bucket,
-        ...(p.region && { region: p.region }),
-      } as ProviderAuth),
+      buildExternalUrl({ provider: p.provider, key: p.key, bucket: p.bucket, region: p.region }),
   }
 }

--- a/packages/lib/src/files/storage/providers.ts
+++ b/packages/lib/src/files/storage/providers.ts
@@ -1,0 +1,114 @@
+// packages/lib/src/files/storage/providers.ts
+
+/**
+ * The storage provider registry — one source of truth for "does this provider
+ * have an adapter?", plus the lazy loader that produces it.
+ *
+ * This was a `private static` on `StorageManager`, which meant a pure-data
+ * question ("is `DROPBOX` supported?") could only be asked by constructing a
+ * manager. The Phase-2 write pilot refused to do that and duplicated the set as
+ * a local `SUPPORTED_PROVIDERS` in `storage/locations.ts`, recording the drift
+ * risk in a comment. Both now read {@link isProviderAvailable}.
+ *
+ * ## Why this is not in `auth.ts`
+ *
+ * `storage/auth.ts` imports `@auxx/credentials/store` at module scope for
+ * `revealSecrets`. `storage/locations.ts` is a pure database module whose test
+ * calls `vi.mock` zero times, and it needs nothing but the provider set — so
+ * the registry lives in its own leaf module with no runtime dependencies at
+ * all. The adapter loaders are `import()` expressions, so nothing in
+ * `@aws-sdk/*` is pulled into the graph until an adapter is actually asked for.
+ */
+
+import type { ProviderId, StorageAdapter } from '../adapters/base-adapter'
+import { StorageAdapterError } from '../adapters/base-adapter'
+
+/**
+ * Provider id → adapter loader.
+ *
+ * Adding a provider is one line here; the five commented entries are the
+ * historical stubs and are kept as documentation of the intended shape.
+ *
+ * @example
+ * ```ts
+ * DROPBOX: async () => (await import('../adapters/dropbox-adapter')).DropboxAdapter,
+ * ```
+ */
+const ADAPTER_LOADERS = {
+  S3: async () => (await import('../adapters/s3-adapter')).default,
+  // GOOGLE_DRIVE: async () => (await import('../adapters/google-drive-adapter')).GoogleDriveAdapter,
+  // DROPBOX: async () => (await import('../adapters/dropbox-adapter')).DropboxAdapter,
+  // ONEDRIVE: async () => (await import('../adapters/onedrive-adapter')).OneDriveAdapter,
+  // BOX: async () => (await import('../adapters/box-adapter')).BoxAdapter,
+  // GENERIC_URL: async () => (await import('../adapters/url-adapter')).UrlAdapter,
+} as const
+
+/** The subset of {@link ProviderId} that actually has an adapter today. */
+export type AvailableProviderId = keyof typeof ADAPTER_LOADERS
+
+/** The same set as a value, for callers that want to enumerate rather than test. */
+export const AVAILABLE_PROVIDERS: ReadonlySet<ProviderId> = new Set(
+  Object.keys(ADAPTER_LOADERS) as ProviderId[]
+)
+
+/** Whether `provider` has an adapter. Narrows, so a caller can use the loader map. */
+export function isProviderAvailable(provider: ProviderId): provider is AvailableProviderId {
+  return AVAILABLE_PROVIDERS.has(provider)
+}
+
+/**
+ * Adapter instance cache.
+ *
+ * Module-level rather than a static, so it is per-module-graph: a Vitest file
+ * gets its own, and {@link clearStorageAdapterCache} exists for tests that swap
+ * the adapter mid-file.
+ */
+const adapterCache = new Map<ProviderId, StorageAdapter>()
+
+/**
+ * Load (and cache) the adapter for a provider.
+ *
+ * @throws {StorageAdapterError} when the provider has no adapter, or the
+ *   dynamic import fails.
+ */
+export async function getStorageAdapter(provider: ProviderId): Promise<StorageAdapter> {
+  const cached = adapterCache.get(provider)
+  if (cached) return cached
+
+  if (!isProviderAvailable(provider)) {
+    throw new StorageAdapterError(
+      `No adapter available for provider: ${provider}`,
+      provider,
+      'getStorageAdapter'
+    )
+  }
+
+  try {
+    const AdapterClass = await ADAPTER_LOADERS[provider]()
+    const adapter = new AdapterClass()
+    adapterCache.set(provider, adapter)
+    return adapter
+  } catch (error) {
+    throw new StorageAdapterError(
+      `Failed to load adapter for provider ${provider}: ${error}`,
+      provider,
+      'getStorageAdapter',
+      error as Error
+    )
+  }
+}
+
+/**
+ * The already-loaded adapter, or `undefined`.
+ *
+ * For synchronous paths that want an adapter's opinion but must not await one
+ * (`StorageManager.buildLocationRef` reads `resolveBucket()` this way).
+ */
+export function getCachedStorageAdapter(provider: ProviderId): StorageAdapter | undefined {
+  return adapterCache.get(provider)
+}
+
+/** Drop every cached adapter instance. Test seam. */
+export function clearStorageAdapterCache(): void {
+  adapterCache.clear()
+}

--- a/packages/lib/src/files/storage/storage-manager.ts
+++ b/packages/lib/src/files/storage/storage-manager.ts
@@ -1,6 +1,5 @@
 // packages/lib/src/files/storage/storage-manager.ts
 
-import { revealSecrets } from '@auxx/credentials/store'
 import type { StorageLocationEntity as StorageLocation } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import type {
@@ -18,7 +17,9 @@ import {
   StorageFileNotFoundError,
 } from '../adapters/base-adapter'
 import type { UploadPreparedConfig } from '../upload/init-types'
-import { getBucketForVisibility } from '../upload/util'
+import { resolveProviderAuth } from './auth'
+import { bucketForVisibility, buildExternalUrl, type StorageVisibility } from './buckets'
+import { getCachedStorageAdapter, getStorageAdapter, isProviderAvailable } from './providers'
 import { storageLocationService } from './storage-location-service'
 
 const logger = createScopedLogger('storage-manager')
@@ -180,7 +181,7 @@ export class StorageManager {
     this.validateStorageParams(params)
 
     // Get adapter for the provider
-    const adapter = await this.getAdapter(params.provider)
+    const adapter = await getStorageAdapter(params.provider)
 
     // Check if adapter supports direct uploads
     if (!adapter.putObject) {
@@ -193,7 +194,11 @@ export class StorageManager {
 
     // Get authentication if credential ID provided
     let auth: ProviderAuth | undefined
-    auth = await this.getProviderAuth(params.provider, params.credentialId)
+    auth = await resolveProviderAuth({
+      provider: params.provider,
+      organizationId: this.organizationId,
+      credentialId: params.credentialId,
+    })
 
     try {
       // Upload content using adapter
@@ -289,11 +294,15 @@ export class StorageManager {
     const locationRef = this.buildLocationRef(storageLocation)
 
     // Get adapter for the provider
-    const adapter = await this.getAdapter(locationRef.provider)
+    const adapter = await getStorageAdapter(locationRef.provider)
 
     // Get authentication if credential ID provided
     let auth: ProviderAuth | undefined
-    auth = await this.getProviderAuth(locationRef.provider, locationRef.credentialId)
+    auth = await resolveProviderAuth({
+      provider: locationRef.provider,
+      organizationId: this.organizationId,
+      credentialId: locationRef.credentialId,
+    })
 
     const metadata = (storageLocation.metadata as Record<string, any>) || {}
     const inferredFileName =
@@ -404,12 +413,16 @@ export class StorageManager {
     const locationRef = this.buildLocationRef(storageLocation)
 
     // Get adapter for the provider
-    const adapter = await this.getAdapter(locationRef.provider)
+    const adapter = await getStorageAdapter(locationRef.provider)
 
     // Get authentication if credential ID provided
     let auth: ProviderAuth | undefined
     if (locationRef.credentialId) {
-      auth = await this.getProviderAuth(locationRef.provider, locationRef.credentialId)
+      auth = await resolveProviderAuth({
+        provider: locationRef.provider,
+        organizationId: this.organizationId,
+        credentialId: locationRef.credentialId,
+      })
     }
 
     try {
@@ -450,7 +463,7 @@ export class StorageManager {
     // Load the adapter FIRST: `buildLocationRef` reads `adapter.resolveBucket()`
     // out of the adapter cache to fill in `metadata.bucket` for rows persisted
     // without one, and the adapter's delete no longer resolves a default itself.
-    const adapter = await this.getAdapter(storageLocation.provider as ProviderId)
+    const adapter = await getStorageAdapter(storageLocation.provider as ProviderId)
 
     // Build location reference
     const locationRef = this.buildLocationRef(storageLocation)
@@ -458,7 +471,11 @@ export class StorageManager {
     // Get authentication if credential ID provided
     let auth: ProviderAuth | undefined
     if (locationRef.credentialId) {
-      auth = await this.getProviderAuth(locationRef.provider, locationRef.credentialId)
+      auth = await resolveProviderAuth({
+        provider: locationRef.provider,
+        organizationId: this.organizationId,
+        credentialId: locationRef.credentialId,
+      })
     }
 
     if (locationRef.provider === 'S3' && !locationRef.metadata?.bucket) {
@@ -494,76 +511,47 @@ export class StorageManager {
   // ============= Storage Location Management =============
 
   /**
-   * Build external URL for a storage location
+   * Build the external (public) URL for an object.
    *
-   * This method provides a public API for building external URLs for storage locations
-   * without exposing internal adapter or auth methods.
+   * **Synchronous since PR 3b, deliberately.** The `apps/web` upload-complete
+   * route calls this *inside* an open `db.transaction`, and the async version
+   * could reach `getProviderAuth()` → `revealSecrets()` — a database read plus a
+   * decrypt — from in there, purely to learn a bucket the caller already had on
+   * the upload session. `storage/buckets.ts` does the whole job over config, so
+   * there is nothing left to await. A caller that needs a credential-derived
+   * `region` resolves it before opening the transaction and passes it in
+   * `opts.region`.
    *
    * @param provider - The storage provider ID
    * @param key - The storage key/path
-   * @param credentialId - Optional credential ID for authentication
-   * @returns Promise resolving to the external URL
+   * @param opts.bucket - The bucket the object lives in. Wins over `visibility`.
+   * @param opts.visibility - Picks a configured bucket when `bucket` is absent.
+   * @param opts.region - Overrides `S3_REGION` for the virtual-hosted-style URL.
    *
    * @example
    * ```typescript
-   * const externalUrl = await storageManager.buildExternalUrl(
-   *   'S3',
-   *   'org-123/file.pdf',
-   *   's3_cred_id'
-   * )
+   * const externalUrl = storageManager.buildExternalUrl('S3', 'org-123/file.pdf', {
+   *   bucket: session.bucket,
+   *   visibility: session.visibility,
+   * })
    * ```
    */
-  async buildExternalUrl(
+  buildExternalUrl(
     provider: ProviderId,
     key: string,
-    credentialId?: string,
     opts?: {
       bucket?: string
-      visibility?: 'PUBLIC' | 'PRIVATE'
+      visibility?: StorageVisibility
+      region?: string
     }
-  ): Promise<string> {
-    // Get adapter for the provider
-    const adapter = await this.getAdapter(provider)
-
-    // Check if adapter supports building external URLs
-    if (!adapter.buildExternalUrl) {
-      // Return the key as a fallback for providers without URL building
-      return key
-    }
-
-    // Get authentication if credential ID provided
-    let auth: ProviderAuth | undefined
-    if (credentialId) {
-      try {
-        auth = await this.getProviderAuth(provider, credentialId)
-      } catch (error) {
-        logger.warn('Failed to get auth for building external URL', {
-          provider,
-          error: error instanceof Error ? error.message : String(error),
-        })
-      }
-    }
-
-    try {
-      // Use adapter to build external URL
-      const externalUrlAuth =
-        provider === 'S3'
-          ? this.withResolvedS3Bucket({
-              auth,
-              bucket: opts?.bucket,
-              visibility: opts?.visibility,
-            })
-          : auth
-
-      return adapter.buildExternalUrl(key, externalUrlAuth)
-    } catch (error) {
-      logger.warn('Failed to build external URL, returning key as fallback', {
-        provider,
-        key,
-        error: error instanceof Error ? error.message : String(error),
-      })
-      return key
-    }
+  ): string {
+    return buildExternalUrl({
+      provider,
+      key,
+      bucket: opts?.bucket,
+      visibility: opts?.visibility,
+      region: opts?.region,
+    })
   }
 
   /**
@@ -607,7 +595,7 @@ export class StorageManager {
   ): Promise<StorageLocation> {
     try {
       // Validate provider
-      if (!this.isProviderAvailable(params.provider)) {
+      if (!isProviderAvailable(params.provider)) {
         throw new StorageAdapterError(
           `Provider ${params.provider} is not available`,
           params.provider,
@@ -635,55 +623,6 @@ export class StorageManager {
     } catch (error) {
       this.handleStorageError(error, 'createStorageLocation', params.provider)
     }
-  }
-
-  // ============= Provider Authentication =============
-
-  /**
-   * Get provider authentication for a specific adapter.
-   * 1. Explicit credentialId → user-connected provider (via the credential store)
-   * 2. No credentialId → platform storage (via adapter.resolvePlatformAuth)
-   */
-  private async getProviderAuth(
-    adapterId: ProviderId,
-    credentialId?: string
-  ): Promise<ProviderAuth> {
-    // 1. Explicit credential → user-connected provider (Dropbox, user's own S3, etc.)
-    if (credentialId) {
-      if (!this.organizationId) {
-        throw new StorageAuthError(
-          adapterId,
-          'getProviderAuth',
-          new Error(`credentialId '${credentialId}' provided but organizationId is missing.`)
-        )
-      }
-      const revealed = await revealSecrets(credentialId, this.organizationId)
-      if (revealed.isErr()) {
-        throw new StorageAuthError(
-          adapterId,
-          'getProviderAuth',
-          new Error(`Failed to load credential for ${adapterId}: ${revealed.error.message}.`)
-        )
-      }
-      const { record, secrets } = revealed.value
-      return { ...record.metadata, ...secrets } as ProviderAuth
-    }
-
-    // 2. Platform storage → ask adapter to resolve its own config
-    const adapter = await this.getAdapter(adapterId)
-    const platformAuth = adapter.resolvePlatformAuth?.()
-    if (platformAuth) {
-      return platformAuth
-    }
-
-    // 3. No auth available
-    throw new StorageAuthError(
-      adapterId,
-      'getProviderAuth',
-      new Error(
-        `No credentials available for ${adapterId}. Configure platform storage (e.g. S3_REGION, S3_PRIVATE_BUCKET) or provide a credentialId.`
-      )
-    )
   }
 
   /**
@@ -775,13 +714,17 @@ export class StorageManager {
 
     if (!bucket) {
       if (visibility === 'PUBLIC' || visibility === 'PRIVATE') {
-        bucket = getBucketForVisibility(visibility)
+        bucket = bucketForVisibility(visibility)
       }
     }
 
     if (!bucket) {
       try {
-        const auth = await this.getProviderAuth('S3', params.credentialId)
+        const auth = await resolveProviderAuth({
+          provider: 'S3',
+          organizationId: this.organizationId,
+          credentialId: params.credentialId,
+        })
         bucket = this.resolveS3BucketFromAuth(auth, visibility)
       } catch (error) {
         logger.warn('Failed to resolve bucket from provider auth', {
@@ -845,7 +788,7 @@ export class StorageManager {
     let bucket = params.bucket
 
     if (!bucket && params.visibility) {
-      bucket = getBucketForVisibility(params.visibility) || undefined
+      bucket = bucketForVisibility(params.visibility) || undefined
     }
 
     if (!bucket) {
@@ -860,103 +803,6 @@ export class StorageManager {
       ...(params.auth ?? {}),
       bucket,
     }
-  }
-
-  // ============= Credential Management Integration =============
-
-  // ============= Adapter Management =============
-
-  /**
-   * Check if provider is available
-   */
-  isProviderAvailable(provider: ProviderId): boolean {
-    return this.hasAdapter(provider)
-  }
-
-  // ============= Adapter Registry =============
-
-  /**
-   * Dynamic adapter loading registry with lazy loading and caching
-   *
-   * This registry maps provider IDs to their adapter loading functions.
-   * Adapters are loaded lazily when first requested and then cached for
-   * performance. This allows the system to only load the adapters that
-   * are actually used.
-   *
-   * @example Adding a new provider:
-   * ```typescript
-   * // In the adapters object:
-   * DROPBOX: async () => (await import('../adapters/dropbox-adapter')).DropboxAdapter,
-   * ```
-   *
-   * @internal
-   */
-  private static adapters = {
-    S3: async () => (await import('../adapters/s3-adapter')).default,
-    // GOOGLE_DRIVE: async () => (await import('../adapters/google-drive-adapter')).GoogleDriveAdapter,
-    // DROPBOX: async () => (await import('../adapters/dropbox-adapter')).DropboxAdapter,
-    // ONEDRIVE: async () => (await import('../adapters/onedrive-adapter')).OneDriveAdapter,
-    // BOX: async () => (await import('../adapters/box-adapter')).BoxAdapter,
-    // GENERIC_URL: async () => (await import('../adapters/url-adapter')).UrlAdapter,
-  } as const
-
-  /**
-   * Adapter instance cache
-   */
-  private static adapterCache = new Map<ProviderId, StorageAdapter>()
-
-  /**
-   * Get storage adapter for provider
-   *
-   * Retrieves or loads the adapter for a specific storage provider.
-   * Implements lazy loading and caching to optimize performance.
-   *
-   * @param provider - The provider ID to get adapter for
-   * @returns Promise resolving to the storage adapter instance
-   *
-   * @throws {StorageAdapterError} When adapter is not available or fails to load
-   *
-   * @internal
-   */
-  private async getAdapter(provider: ProviderId): Promise<StorageAdapter> {
-    // Return cached adapter if available
-    if (StorageManager.adapterCache.has(provider)) {
-      return StorageManager.adapterCache.get(provider)!
-    }
-
-    // Load adapter dynamically
-    const adapterLoader = StorageManager.adapters[provider as keyof typeof StorageManager.adapters]
-    if (!adapterLoader) {
-      throw new StorageAdapterError(
-        `No adapter available for provider: ${provider}`,
-        provider,
-        'getAdapter'
-      )
-    }
-
-    try {
-      const AdapterClass = await adapterLoader()
-      const adapter = new AdapterClass()
-
-      // Cache the adapter instance
-      StorageManager.adapterCache.set(provider, adapter)
-
-      return adapter
-    } catch (error) {
-      throw new StorageAdapterError(
-        `Failed to load adapter for provider ${provider}: ${error}`,
-        provider,
-        'getAdapter',
-        error as Error
-      )
-    }
-  }
-
-  /**
-   * Check if adapter is available for a provider
-   */
-  hasAdapter(provider: ProviderId): boolean {
-    return provider in StorageManager.adapters
   }
 
   // ============= File Operations =============
@@ -1024,7 +870,7 @@ export class StorageManager {
     this.enforcePolicy(config) // ✅ Add policy enforcement
 
     // Get adapter for the provider
-    const adapter = await this.getAdapter(config.provider)
+    const adapter = await getStorageAdapter(config.provider)
 
     // Check if adapter supports presigned uploads
     const capabilities = adapter.getCapabilities()
@@ -1038,7 +884,11 @@ export class StorageManager {
 
     // Get authentication if credential ID provided
     let auth: ProviderAuth | undefined
-    auth = await this.getProviderAuth(config.provider, config.credentialId)
+    auth = await resolveProviderAuth({
+      provider: config.provider,
+      organizationId: this.organizationId,
+      credentialId: config.credentialId,
+    })
 
     try {
       // Use adapter to generate presigned upload URL
@@ -1075,7 +925,7 @@ export class StorageManager {
     this.enforcePolicy(config) // ✅ Add policy enforcement
 
     // Get adapter for the provider
-    const adapter = await this.getAdapter(config.provider)
+    const adapter = await getStorageAdapter(config.provider)
 
     // Check if adapter supports multipart uploads
     const capabilities = adapter.getCapabilities()
@@ -1089,7 +939,11 @@ export class StorageManager {
 
     // Get authentication if credential ID provided
     let auth: ProviderAuth | undefined
-    auth = await this.getProviderAuth(config.provider, config.credentialId)
+    auth = await resolveProviderAuth({
+      provider: config.provider,
+      organizationId: this.organizationId,
+      credentialId: config.credentialId,
+    })
 
     try {
       // Use adapter to start multipart upload
@@ -1134,11 +988,15 @@ export class StorageManager {
     this.validateStorageParams(params)
 
     // Get adapter for the provider
-    const adapter = await this.getAdapter(params.provider)
+    const adapter = await getStorageAdapter(params.provider)
 
     // Get authentication if credential ID provided
     let auth: ProviderAuth | undefined
-    auth = await this.getProviderAuth(params.provider, params.credentialId)
+    auth = await resolveProviderAuth({
+      provider: params.provider,
+      organizationId: this.organizationId,
+      credentialId: params.credentialId,
+    })
 
     const bucket =
       params.bucket ??
@@ -1187,12 +1045,16 @@ export class StorageManager {
     this.validateStorageParams(params)
 
     // Get adapter for the provider
-    const adapter = await this.getAdapter(params.provider)
+    const adapter = await getStorageAdapter(params.provider)
 
     // Get authentication if credential ID provided
     let auth: ProviderAuth | undefined
     try {
-      auth = await this.getProviderAuth(params.provider, params.credentialId)
+      auth = await resolveProviderAuth({
+        provider: params.provider,
+        organizationId: this.organizationId,
+        credentialId: params.credentialId,
+      })
     } catch (error) {
       // Log but don't fail - some adapters might work without explicit credentials
       logger.warn(
@@ -1259,7 +1121,7 @@ export class StorageManager {
     this.validateStorageParams(params)
 
     // Get adapter for the provider
-    const adapter = await this.getAdapter(params.provider)
+    const adapter = await getStorageAdapter(params.provider)
 
     // Check if adapter supports multipart uploads
     const capabilities = adapter.getCapabilities()
@@ -1273,7 +1135,11 @@ export class StorageManager {
 
     // Get authentication if credential ID provided
     let auth: ProviderAuth | undefined
-    auth = await this.getProviderAuth(params.provider, params.credentialId)
+    auth = await resolveProviderAuth({
+      provider: params.provider,
+      organizationId: this.organizationId,
+      credentialId: params.credentialId,
+    })
 
     const bucket =
       params.bucket ??
@@ -1331,7 +1197,7 @@ export class StorageManager {
     let metadata = rawMetadata ? { ...rawMetadata } : undefined
 
     if (location.provider === 'S3') {
-      const adapter = StorageManager.adapterCache.get('S3')
+      const adapter = getCachedStorageAdapter('S3')
       const bucketCandidate =
         metadata?.bucket ||
         metadata?.Bucket ||
@@ -1383,7 +1249,7 @@ export class StorageManager {
       )
     }
 
-    if (!this.isProviderAvailable(params.provider)) {
+    if (!isProviderAvailable(params.provider)) {
       throw new StorageAdapterError(
         `Provider ${params.provider} is not available`,
         params.provider,
@@ -1433,12 +1299,16 @@ export class StorageManager {
     this.validateStorageParams(params)
 
     // Get adapter for the provider
-    const adapter = await this.getAdapter(params.provider)
+    const adapter = await getStorageAdapter(params.provider)
 
     // Always try to get authentication (credential manager handles system credential fallback)
     let auth: ProviderAuth | undefined
     try {
-      auth = await this.getProviderAuth(params.provider, params.credentialId)
+      auth = await resolveProviderAuth({
+        provider: params.provider,
+        organizationId: this.organizationId,
+        credentialId: params.credentialId,
+      })
     } catch (error) {
       // Log but don't fail - adapter might work without explicit credentials
       logger.warn('Failed to get provider authentication for headByKey, continuing without auth', {

--- a/packages/lib/src/files/upload/processors/base-asset-processor.ts
+++ b/packages/lib/src/files/upload/processors/base-asset-processor.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/files/upload/processors/base-asset-processor.ts
 
 import type { AssetKind, CreateAssetRequest } from '../../core/types'
+import { bucketForVisibility, type StorageVisibility } from '../../storage/buckets'
 import type { ProcessorConfigResult, UploadInitConfig } from '../init-types'
 import type { PresignedUploadSession } from '../session-types'
 import { BaseProcessor } from './base-processor'
@@ -14,7 +15,18 @@ import type { ProcessorMetadata, ProcessorResult } from './types'
 export abstract class BaseAssetProcessor extends BaseProcessor {
   // Entity-specific configuration (override in subclasses)
   protected abstract entityType: string
-  protected abstract fileVisibility: string
+  /**
+   * Which bucket this entity's uploads belong in.
+   *
+   * A **strict union**, not `string`. It was `string`, and `processConfig` cast
+   * it (`this.fileVisibility as 'PUBLIC' | 'PRIVATE'`) at the one place it
+   * mattered — so `DatasetAssetProcessor` compiled with lowercase `'private'`,
+   * which matched neither branch of `bucketForVisibility` and made
+   * `isAssetPrivate()` (a `=== 'PRIVATE'` comparison) answer `false`. Dataset
+   * documents were routed to the public bucket and recorded as non-private.
+   * The union turns that into a compile error.
+   */
+  protected abstract fileVisibility: StorageVisibility
   protected abstract preferredProvider: string
   protected abstract maxFileSize: number
   protected abstract allowedMimeTypes: string[]
@@ -53,9 +65,6 @@ export abstract class BaseAssetProcessor extends BaseProcessor {
    * Process upload configuration for asset processors
    */
   async processConfig(init: UploadInitConfig): Promise<ProcessorConfigResult> {
-    // Import the utility function
-    const { getBucketForVisibility } = await import('../util')
-
     // Call super first
     const baseResult = await super.processConfig(init)
 
@@ -90,8 +99,8 @@ export abstract class BaseAssetProcessor extends BaseProcessor {
     }
 
     // Determine visibility and bucket
-    const visibility = this.fileVisibility as 'PUBLIC' | 'PRIVATE'
-    const bucket = getBucketForVisibility(visibility)
+    const visibility = this.fileVisibility
+    const bucket = bucketForVisibility(visibility)
 
     return {
       config: Object.freeze({

--- a/packages/lib/src/files/upload/processors/base-processor.ts
+++ b/packages/lib/src/files/upload/processors/base-processor.ts
@@ -4,6 +4,7 @@ import { createScopedLogger } from '@auxx/logger'
 import { AttachmentService } from '../../core/attachment-service'
 import { FileService } from '../../core/file-service'
 import { MediaAssetService } from '../../core/media-asset-service'
+import { bucketForVisibility, type StorageVisibility } from '../../storage/buckets'
 import type {
   ProcessorConfigResult,
   UploadInitConfig,
@@ -15,7 +16,6 @@ import type { PresignedUploadSession } from '../session-types'
 import {
   clamp,
   deriveStorageKey,
-  getBucketForVisibility,
   getDefaultKeyPrefix,
   normalizeMimeType,
   shouldUseMultipart,
@@ -110,8 +110,8 @@ export abstract class BaseProcessor implements FileProcessor {
       : { strategy: 'single' }
 
     // Default visibility and bucket (will be overridden by entity processors)
-    const visibility: 'PUBLIC' | 'PRIVATE' = 'PRIVATE'
-    const bucket = getBucketForVisibility(visibility)
+    const visibility: StorageVisibility = 'PRIVATE'
+    const bucket = bucketForVisibility(visibility)
 
     // Create immutable config
     const config: UploadPreparedConfig = Object.freeze({

--- a/packages/lib/src/files/upload/processors/dataset.ts
+++ b/packages/lib/src/files/upload/processors/dataset.ts
@@ -19,7 +19,10 @@ const logger = createScopedLogger('dataset-asset-processor')
  */
 export class DatasetAssetProcessor extends BaseAssetProcessor {
   protected entityType = 'dataset'
-  protected fileVisibility = 'private'
+  // Was lowercase `'private'`, which matched neither branch of the bucket
+  // selector: dataset documents were presigned into the PUBLIC bucket and
+  // `isAssetPrivate()` returned false for every one of them.
+  protected fileVisibility = 'PRIVATE' as const
   protected preferredProvider = 'local' // or 's3' based on config
   protected maxFileSize = 50 * 1024 * 1024 // 50MB
   protected assetKind = 'DOCUMENT' as const

--- a/packages/lib/src/files/upload/processors/entity-processors.ts
+++ b/packages/lib/src/files/upload/processors/entity-processors.ts
@@ -7,6 +7,7 @@ import { isMember } from '../../../members'
 import { isAdminOrOwner } from '../../../members/member-queries'
 import type { AssetKind } from '../../core/types'
 import { type FileTypeCategory, getMimePatternsForCategories } from '../../file-type-constants'
+import { bucketForVisibility } from '../../storage/buckets'
 import type { ProcessorConfigResult, UploadInitConfig } from '../init-types'
 import type { PresignedUploadSession } from '../session-types'
 import { BaseAssetProcessor } from './base-asset-processor'
@@ -228,12 +229,11 @@ export class ArticleProcessor extends BaseAttachmentProcessor {
       )
     }
     if (init.metadata?.role === 'COVER') {
-      const { getBucketForVisibility } = await import('../util')
       return {
         config: Object.freeze({
           ...base.config,
           visibility: 'PUBLIC',
-          bucket: getBucketForVisibility('PUBLIC'),
+          bucket: bucketForVisibility('PUBLIC'),
         }),
         warnings,
       }

--- a/packages/lib/src/files/upload/util.ts
+++ b/packages/lib/src/files/upload/util.ts
@@ -1,10 +1,12 @@
-// packages/lib/src/files/upload/util.ts
-import { configService } from '@auxx/credentials'
-import type { FileVisibility } from './types'
-
 /**
  * Utility functions for the unified processor system
  * Pure functions with no side effects for configuration processing
+ *
+ * Bucket routing and public-URL formatting used to live here too
+ * (`getBucketForVisibility`, `getPublicCdnUrl`). They moved to
+ * `files/storage/buckets.ts` in PR 3b, next to `buildExternalUrl` and
+ * `assertBucket`, so there is one place that decides which bucket an object
+ * belongs in.
  */
 
 /**
@@ -55,42 +57,6 @@ export const deriveStorageKey = (
   // Simple, consistent format for all entity types:
   // {orgId}/{entity-type}/{entityId}/{timestamp}_{seed}{filename}
   return `${orgId}/${entityPrefix}/${options.entityId}/${ts}_${seed}${sanitized}`
-}
-
-/**
- * Map the lowercase upload-request visibility onto the uppercase storage bucket selector.
- * The two vocabularies never matched, so passing a raw `FileVisibility` straight through
- * silently routed public uploads into the private bucket.
- */
-export const toStorageVisibility = (
-  visibility: FileVisibility | undefined
-): 'PUBLIC' | 'PRIVATE' | undefined => {
-  if (visibility === undefined) return undefined
-  return visibility === 'public' ? 'PUBLIC' : 'PRIVATE'
-}
-
-/**
- * Get bucket name based on file visibility
- */
-export const getBucketForVisibility = (visibility: 'PUBLIC' | 'PRIVATE'): string => {
-  if (visibility === 'PUBLIC') {
-    return configService.get<string>('S3_PUBLIC_BUCKET') || ''
-  }
-  return configService.get<string>('S3_PRIVATE_BUCKET') || ''
-}
-
-/**
- * Generate public CDN URL for public files
- */
-export const getPublicCdnUrl = (storageKey: string): string => {
-  const cdnBase = configService.get<string>('CDN_URL')
-  if (!cdnBase) {
-    // Fallback to direct S3 URL
-    const bucket = getBucketForVisibility('PUBLIC')
-    const region = configService.get<string>('S3_REGION') || 'us-west-1'
-    return `https://${bucket}.s3.${region}.amazonaws.com/${storageKey}`
-  }
-  return `${cdnBase}/${storageKey}`
 }
 
 /**


### PR DESCRIPTION
Phase 3, **PR 3b** (`plans/attachments/03-storage-layer.md` §3.4 + §3.0.1).

**+767 / −686** across 21 files. `s3-adapter.ts` 985 → 782 · `base-adapter.ts` 440 → 362 ·
`storage-manager.ts` 1,530 → 1,400.

## Three new leaf modules, not two

- **`storage/buckets.ts`** — the pure half of the storage layer: data in, string out.
  `bucketForVisibility`, `publicCdnUrl`, `assertBucket`, and a **synchronous** `buildExternalUrl`.
- **`storage/auth.ts`** — the single `resolveProviderAuth`. `ports.ts` no longer carries its own
  ~25-line copy of that resolution (§3.0.1).
- **`storage/providers.ts`** — the adapter registry, lifted out of the `private static` on
  `StorageManager` (§3.0.1).

The registry is **deliberately not in `auth.ts`**: `auth.ts` imports `@auxx/credentials/store` at
module scope, and `locations.ts` — whose test calls `vi.mock` **zero** times — needs only the
provider set. Folding them together would drag the credential store into that graph and cost us the
property the whole refactor is chasing.

## `buildExternalUrl` is now synchronous

Not cosmetic. It is called *inside* the open `db.transaction` on the upload-complete path, and the
async version could reach `getProviderAuth()` → `revealSecrets()` — a database read plus a decrypt —
while holding a write transaction open, purely to learn a bucket the caller already knew. A caller
that genuinely needs a credential-derived `region` now resolves it before opening the transaction
and passes it in.

## The visibility bug is worse than the plan recorded

§3.4 describes it as a bucket-routing casing bug. It is also a **data** bug.
`BaseAssetProcessor` declared `fileVisibility: string` and cast it at its one use
(`this.fileVisibility as 'PUBLIC' | 'PRIVATE'`), so `DatasetAssetProcessor` compiled with lowercase
`'private'`. That matched neither branch of the bucket selector **and** made `isAssetPrivate()` — a
`=== 'PRIVATE'` comparison whose result is written to `isPrivate` on the created asset — answer
`false`.

So every dataset document was **recorded as non-private *and* presigned into the PUBLIC bucket**.

Typing the field as a named `StorageVisibility` union turns both into compile errors. `dataset.ts`
was the only wrong declaration; the other nine were already uppercase.

## `S3_PRIVATE_BUCKET`

Four real fallbacks (`putObject`, `startMultipart`, `abortMultipart`, `parseS3Location`) are now
`assertBucket` throws. **Two config reads survive on purpose**, so the exit criterion is partial
rather than met:

- `resolvePlatformAuth()` is not a fallback but the *definition* of platform auth
  (`if (!region || !bucket) return null`). Making it throw kills platform storage for `ports.ts` and
  for `jobs/maintenance/app-bundle-cleanup-job.ts`, which branches on `if (!auth)`.
- `resolveBucket()` is a declared adapter capability that **#1817 deliberately centralised so it
  could be logged**.

## Deleted as unused

Each verified zero-caller before removal — this closes the item #1825 parked:

- The seven generic `StorageAdapter` methods: `createFile`, `updateFile`, `listRevisions`,
  `getRevision`, `refreshAuth`, `validateAuth`, `abortMultipart`, plus
  `BaseStorageAdapter.validateAuth` and the `FileRevision` type they were the only users of.
- **Six of the nine `StorageCapabilities` flags.** Only `presignUpload`, `presignDownload` and
  `multipart` are read anywhere; `serverSideDownload`, `versioning`, `webhooks`, `folders`, `search`
  and `metadata` were declared and dutifully set by `S3Adapter.getCapabilities()` and consulted by
  nothing. (`versioning` only became dead once `listRevisions`/`getRevision` went.)
- `toStorageVisibility` and the `isProviderAvailable` / `hasAdapter` facade delegates.

## Verification

- `packages/lib` typecheck clean on `files/`; `apps/web` clean on files/storage.
- `packages/lib` `src/files`: **178 passed / 18 files** (was 156/16 — +15 `buckets.test.ts`,
  +7 `providers.test.ts`, both with **zero mocks**).
- Web files/storage (`file*`, `folder*`, `attachment*`, `app/api/files`, `mock-completeness`):
  **60 passed**, only the known #1818 `mock-completeness` guard failing.
- `pnpm --filter @auxx/lib generate:exports` produces no diff — no new public subpath.

## Still open, flagged rather than taken

- `bucketForVisibility` returns `''` when unconfigured rather than throwing; three callers treat
  `''` as "unknown" and fall through, so changing it is a behaviour change beyond 3b. Worth deciding
  when `enforceUploadPolicy` lands in 3d.
- The upload-complete route no longer derives `region` from `session.credentialId`. `CDN_URL`
  short-circuits before region matters in production and `ExternalUrlInput.region` is the escape
  hatch, but it is a real if narrow behaviour change.

## Note for reviewers

Edits in `packages/lib` need a rebuild before `apps/*` see them (known repo footgun).