### PR TITLE
feat(events): declare why a silent write is silent, and enforce it

### DIFF
--- a/packages/lib/src/dispatch/mirror.ts
+++ b/packages/lib/src/dispatch/mirror.ts
@@ -2,7 +2,7 @@
 //
 // Visit → field mirror (01 §3, 07 §B.3) — the `meeting-entity-service.ts` recipe:
 // `getCachedCustomFields` (via `bySystemAttributes`) keyed by systemAttribute →
-// `FieldValueService.setValuesForEntity` with `publishEvents: false`. The dispatch service
+// `FieldValueService.setValuesForEntity` under `QUIET_VISIT_MIRROR`. The dispatch service
 // is the only writer of visits; after every mutation it mirrors onto the work order record
 // so table views/filters/dashboards/record rules/Kopilot keep working on plain fields.
 
@@ -13,6 +13,21 @@ import { toRecordId } from '@auxx/types/resource'
 import { and, asc, eq, gte, isNotNull, ne } from 'drizzle-orm'
 import { getOrgCache } from '../cache'
 import { FieldValueService } from '../field-values/field-value-service'
+import { quietSession } from '../resources/crud/write-origin'
+
+/**
+ * C5 (plan 04 §3): a system mirror of read-only fields onto the work order.
+ * The TIMELINE half of this is settled and correct — this is not a user edit.
+ * The REALTIME half is not: B-19 / O-4 record that the dispatch lane publishes
+ * `dispatch:visit-changed` on the org presence room, which every visit surface
+ * consumes but no work-order grid or drawer does, so a grid showing the mirrored
+ * columns never hears. O-4 decided this SHOULD publish a record-lane frame;
+ * that is plan 04 Phase E, not Phase B, and doing it turns this site from C5
+ * into C4.
+ */
+const QUIET_VISIT_MIRROR = quietSession(
+  'system mirror of read-only visit fields onto the work order — not a user edit, so no timeline entry. The missing record-lane realtime frame is B-19, decided in O-4 and pending Phase E'
+)
 
 type WorkOrderVisitRow = typeof schema.WorkOrderVisit.$inferSelect
 
@@ -67,7 +82,7 @@ async function resolveMirrorSourceVisit(
  * `startTime → work_order_scheduled_start`, `endTime → work_order_scheduled_end`,
  * `assigneeWorkerId → work_order_assignee` as a `worker:{workerId}` actor id — uniformly for
  * both individuals and teams (45-teams.md §1.E/§1.H, §5.6); `useActor` resolves an individual to
- * its user's identity/color, a team to its name + member avatar stack. `publishEvents: false` —
+ * its user's identity/color, a team to its name + member avatar stack. Declared quiet —
  * this is a system mirror of read-only fields (`work-order-fields.ts` marks them
  * `creatable:false/updatable:false`), not a user edit worth a timeline entry.
  */
@@ -85,7 +100,9 @@ export async function mirrorVisitOntoWorkOrder(
       'work_order_job_type',
     ] as const)
 
-  const fieldValueService = new FieldValueService(organizationId, userId)
+  const fieldValueService = new FieldValueService(organizationId, userId, undefined, undefined, {
+    session: QUIET_VISIT_MIRROR,
+  })
 
   let isRecurring = false
   if (cf.work_order_job_type) {
@@ -123,6 +140,5 @@ export async function mirrorVisitOntoWorkOrder(
   await fieldValueService.setValuesForEntity({
     recordId: toRecordId('work_order', workOrderId),
     values,
-    publishEvents: false,
   })
 }

--- a/packages/lib/src/documents/ensure-pdf.ts
+++ b/packages/lib/src/documents/ensure-pdf.ts
@@ -13,6 +13,19 @@ import { MediaAssetService } from '../files/core/media-asset-service'
 import { createStorageManager } from '../files/storage/storage-manager'
 import { getQueue, Queues } from '../jobs/queues'
 import { UnifiedCrudHandler } from '../resources/crud'
+import { quietSession } from '../resources/crud/write-origin'
+
+/**
+ * C5 (plan 04 §3): a machine-owned pointer to the rendered asset, written once
+ * when a NEW asset is minted (unchanged on cache hit or reuse). Not a user edit,
+ * so it stays off the timeline. Whether it should publish a realtime frame is
+ * open and deliberately unbundled from O-4/O-5 — see O-7 on why four samples do
+ * not establish a shared "system-owned field write" concept.
+ */
+const QUIET_PDF_POINTER = quietSession(
+  'machine-owned pointer to a freshly rendered PDF asset — not a user edit, so no timeline entry (realtime is open, plan 04 O-7)'
+)
+
 import type { DocumentPdfPayload } from './payload'
 import { getDocumentType, type RegisteredDocumentType } from './registry'
 import { renderDocumentPdf } from './render'
@@ -170,11 +183,12 @@ export async function ensureDocumentPdf(params: {
 
   // ─── Step 4: write the pointer (new asset only — unchanged on cache hit/reuse) ──
   if (!existingAssetId && pointerField) {
-    const fieldValueService = new FieldValueService(organizationId, actorId)
+    const fieldValueService = new FieldValueService(organizationId, actorId, undefined, undefined, {
+      session: QUIET_PDF_POINTER,
+    })
     await fieldValueService.setValuesForEntity({
       recordId,
       values: [{ fieldId: pointerField.id, value: assetId }],
-      publishEvents: false,
     })
   }
 

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -57,6 +57,11 @@ import {
   recordTxWriteChange,
   type TxWriteScope,
 } from '../resources/crud/tx-write-scope'
+// Leaf path, not the crud barrel: `write-origin` is pure types plus pure
+// functions, and routing it through `resources/crud/index.ts` would pull the
+// handler into this module's static graph (see `tx-write-flush.ts`'s header on
+// the org-cache cycle).
+import { absorbedSession, isDeclaredSilent } from '../resources/crud/write-origin'
 import { getModelType, isRecordId, parseRecordId, toRecordId } from '../resources/resource-id'
 import { applyAiMarker } from './ai-commit'
 import { shortCircuitAiGenerate } from './ai-enqueue'
@@ -2296,7 +2301,12 @@ export async function setValueWithBuiltIn(
   // suppresses buffering too, or the aggregator's own publish would be doubled.
   // Otherwise a buffered write session diverts the fan-out into its scope, to be
   // replayed once the transaction commits.
-  const requestedPublish = params.publishEvents ?? true
+  // Plan 04 Phase B: when the session DECLARES its silence (`quiet`/`absorbed`),
+  // that declaration is the default — it replaces the bare `publishEvents:
+  // false` the C4/C5 leaves used to pass with a comment. Narrower than
+  // `sessionLane`: a sync/seed ORIGIN is silent too, but it has never gated this
+  // layer and honoring it here would change behavior for every sync write.
+  const requestedPublish = params.publishEvents ?? !isDeclaredSilent(ctx.session)
   const bufferedScope = requestedPublish ? getAmbientTxWriteScope(ctx.session) : undefined
   const publishEvents = requestedPublish && bufferedScope === undefined
   // T-1: a record being CREATED in this same scope absorbs its own field writes
@@ -2630,7 +2640,15 @@ export async function setValuesForEntity(
   ctx: FieldValueContext,
   params: SetValuesForEntityInput
 ): Promise<SetValuesResult[]> {
-  const { recordId, values, publishEvents = true, skipInverseSync = false } = params
+  const {
+    recordId,
+    values,
+    // See `setValueWithBuiltIn` — a declared-silent session is the default here
+    // too, so a C4/C5 leaf declares its reason once instead of passing a bare
+    // boolean at every call.
+    publishEvents = !isDeclaredSilent(ctx.session),
+    skipInverseSync = false,
+  } = params
 
   // Parse RecordId to get both parts and derive modelType
   const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
@@ -2936,14 +2954,24 @@ export async function setBulkValues(
       )
     : null
 
-  // Set values for all entities in parallel
-  // Skip inverse sync here - we'll do bulk sync at the end
+  // Set values for all entities in parallel.
+  //
+  // C3 (plan 04 §3): the per-record doors stay shut because THIS function
+  // announces the whole operation below — one batched trigger dispatch, one
+  // `publishFieldValueUpdates` carrying every entry, and per-record field-change
+  // events sharing one `bulkOperationId` so the timeline can cite them as a
+  // single bulk action. 300 records x 3 fields becomes 1 frame and 1 grouped
+  // action instead of 900 loose events.
+  //
+  // Naming the aggregator is the point of declaring this rather than passing a
+  // bare `publishEvents: false`: B-16 is a site that suppressed every door while
+  // claiming an aggregator that did not exist, and only a named one is checkable.
+  const absorbedCtx = { ...ctx, session: absorbedSession('setBulkValues', ctx.session) }
   const results = await Promise.allSettled(
     recordIds.map((recordId) =>
-      setValuesForEntity(ctx, {
+      setValuesForEntity(absorbedCtx, {
         recordId,
         values: validValues,
-        publishEvents: false, // Don't spam events for bulk operations
         skipInverseSync: true, // Bulk sync handled separately below
       })
     )

--- a/packages/lib/src/geocoding/__tests__/address-normalize-hook.test.ts
+++ b/packages/lib/src/geocoding/__tests__/address-normalize-hook.test.ts
@@ -359,7 +359,7 @@ describe('normalizeAddressOnChange', () => {
     expect(mockedPublish).not.toHaveBeenCalled()
   })
 
-  it('writes back quietly via setValueWithBuiltIn with publishEvents: false', async () => {
+  it('writes back under a DECLARED quiet session, not a bare publishEvents flag', async () => {
     mockedGeocode.mockResolvedValue({
       lat: 1,
       lng: 2,
@@ -375,8 +375,13 @@ describe('normalizeAddressOnChange', () => {
     expect(mockedSetValue.mock.calls[0]![1]).toMatchObject({
       recordId,
       fieldId: 'field-address',
-      publishEvents: false,
     })
+    // Plan 04 Phase B: same suppression, but the reason now rides on the
+    // session where it can be checked, instead of a boolean plus a comment.
+    const ctx = mockedSetValue.mock.calls[0]![0]
+    expect(ctx.session?.mode?.kind).toBe('quiet')
+    expect(ctx.session?.mode?.reason ?? '').not.toHaveLength(0)
+    expect(mockedSetValue.mock.calls[0]![1]).not.toHaveProperty('publishEvents')
   })
 
   it('publishes the full composed value via realtime after a successful write-back', async () => {

--- a/packages/lib/src/geocoding/address-normalize-hook.ts
+++ b/packages/lib/src/geocoding/address-normalize-hook.ts
@@ -23,11 +23,23 @@ import { createFieldValueContext } from '../field-values/field-value-helpers'
 import { buildPublishEntry, setValueWithBuiltIn } from '../field-values/field-value-mutations'
 import { getValue } from '../field-values/field-value-queries'
 import { getRealtimeService, publishFieldValueUpdates } from '../realtime'
+import { quietSession } from '../resources/crud/write-origin'
 import { parseRecordId, toRecordId } from '../resources/resource-id'
 import { geocodeStructured } from './geocoder'
 import type { GeocodeStructuredResult } from './types'
 
 const logger = createScopedLogger('geocoding')
+
+/**
+ * C4 (plan 04 §3): the normalized address is written back onto the same field
+ * that triggered this hook, so the doors stay shut for two reasons — re-entrancy
+ * (this one WOULD recurse, unlike the phone-geo hook) and the fact that a
+ * normalization is not a user edit. The hook publishes its own realtime frame
+ * afterwards.
+ */
+const QUIET_NORMALIZED_ADDRESS = quietSession(
+  'a normalized address is not a user edit, and writing back onto the triggering field would re-enter this hook — this hook publishes its own realtime frame instead'
+)
 
 /** Struct's locality confidence threshold for the `'single'` merge mode (decision #11). */
 const RELEVANCE_THRESHOLD = 0.8
@@ -154,7 +166,7 @@ export const normalizeAddressOnChange: EntityFieldChangeHandler = async (event) 
 
   // Idempotence/recursion guard: skip when this write already carries a stamped geocode AND its
   // address components are unchanged from the pre-write value — a no-op resave (or, defensively,
-  // this hook's own write-back re-firing, though `publishEvents: false` on that write already
+  // this hook's own write-back re-firing, though `QUIET_NORMALIZED_ADDRESS` on that write already
   // prevents that structurally). Compares directly against `event.oldValue`/`newValue`, already
   // on the event — no extra struct key/storage needed.
   if (hasStampedGeocode(newStruct)) {
@@ -180,7 +192,7 @@ export const normalizeAddressOnChange: EntityFieldChangeHandler = async (event) 
 
 /**
  * The normalize core: geocode the struct, merge per the `_source` policy, quietly write the
- * result back (stale-write guarded, `publishEvents: false`, hand-rolled realtime frame), and
+ * result back (stale-write guarded, declared quiet, hand-rolled realtime frame), and
  * notify normalized-address listeners. The inline hook fire-and-forgets this; the finalize
  * integrity passes (`events/handlers/finalize-integrity-passes.ts`) await it under bounded
  * concurrency — there is no geocode job, so the batch pass IS the batching (plan events/03
@@ -266,7 +278,7 @@ function mergeAddress(
 }
 
 /**
- * Write the normalized struct back QUIETLY: `setValueWithBuiltIn` with `publishEvents: false`
+ * Write the normalized struct back QUIETLY: `setValueWithBuiltIn` under `QUIET_NORMALIZED_ADDRESS`
  * skips the field-change post-hook chain (so this can never re-fire itself), field triggers, and
  * the inline realtime publish — no timeline entry, no hook re-fire, no event storm. A skip-events
  * write does not bump `EntityInstance.updatedAt`; acceptable here (normalization is not a user
@@ -294,12 +306,15 @@ async function writeBack(
   )
   if (!current || componentHash(current) !== componentHash(original)) return false
 
-  const result = await setValueWithBuiltIn(ctx, {
-    recordId: event.recordId,
-    fieldId: event.field.id,
-    value: merged,
-    publishEvents: false,
-  })
+  // C4 (plan 04 §3) — see `QUIET_NORMALIZED_ADDRESS` for the reason.
+  const result = await setValueWithBuiltIn(
+    { ...ctx, session: QUIET_NORMALIZED_ADDRESS },
+    {
+      recordId: event.recordId,
+      fieldId: event.field.id,
+      value: merged,
+    }
+  )
 
   if (result.values.length === 0) return false
 

--- a/packages/lib/src/money/public-token.ts
+++ b/packages/lib/src/money/public-token.ts
@@ -15,11 +15,25 @@ import type {
 } from '../documents/resolve-settings'
 import { FieldValueService } from '../field-values/field-value-service'
 import { UnifiedCrudHandler } from '../resources/crud'
+import { quietSession } from '../resources/crud/write-origin'
 import { getOrganizationSetting } from '../settings/settings-service'
 import { getPaymentAccount } from './payments/account-state'
 import { getInvoiceDepositApplied } from './payments/allocation-reads'
 import { resolvePartialPaymentBounds } from './payments/partial'
 import type { DiscountType } from './types'
+
+/**
+ * C5 (plan 04 §3), and the silence here is LOAD-BEARING, not incidental (O-5).
+ * Tier-1 `fieldValues:updated` carries raw stored values to a room gated only on
+ * org membership plus `canViewEntity(defId)`. A public token is a bearer
+ * capability — the public resolver is org-agnostic by design — so broadcasting
+ * it to every member with def-level view on invoices is a WIDER audience than the
+ * read path grants. Un-suppressing this is a confidentiality regression, not a
+ * fidelity improvement.
+ */
+const QUIET_PUBLIC_TOKEN = quietSession(
+  'a public token is a bearer capability; tier-1 frames carry raw values to a def-room audience wider than the token read path grants (plan 04 O-5)'
+)
 
 /**
  * The public `/pay/{token}` capability-token machinery (money MP1 build spec §H/§I). Kept
@@ -73,11 +87,16 @@ export async function ensureInvoicePublicToken(
   if (existing) return existing
 
   const token = generateId()
-  const fieldValueService = new FieldValueService(organizationId, systemUserId)
+  const fieldValueService = new FieldValueService(
+    organizationId,
+    systemUserId,
+    undefined,
+    undefined,
+    { session: QUIET_PUBLIC_TOKEN }
+  )
   await fieldValueService.setValuesForEntity({
     recordId: invoiceRecordId,
     values: [{ fieldId: field.id, value: token }],
-    publishEvents: false,
   })
 
   return token

--- a/packages/lib/src/money/quote-public-token.ts
+++ b/packages/lib/src/money/quote-public-token.ts
@@ -16,10 +16,24 @@ import type {
 import { FieldValueService } from '../field-values/field-value-service'
 import { MediaAssetService } from '../files/core/media-asset-service'
 import { UnifiedCrudHandler } from '../resources/crud'
+import { quietSession } from '../resources/crud/write-origin'
 import { getPaymentAccount } from './payments/account-state'
 import { resolveQuoteDeposit } from './payments/deposit'
 import { isPaymentsConnected } from './public-token'
 import type { DiscountType } from './types'
+
+/**
+ * C5 (plan 04 §3), and the silence here is LOAD-BEARING, not incidental (O-5).
+ * Tier-1 `fieldValues:updated` carries raw stored values to a room gated only on
+ * org membership plus `canViewEntity(defId)`. A public token is a bearer
+ * capability — the public resolver is org-agnostic by design — so broadcasting
+ * it to every member with def-level view on quotes is a WIDER audience than the
+ * read path grants. Un-suppressing this is a confidentiality regression, not a
+ * fidelity improvement.
+ */
+const QUIET_PUBLIC_TOKEN = quietSession(
+  'a public token is a bearer capability; tier-1 frames carry raw values to a def-room audience wider than the token read path grants (plan 04 O-5)'
+)
 
 /**
  * The public `/quote/{token}` capability-token machinery (v5 build spec 01 — client-facing
@@ -73,11 +87,16 @@ export async function ensureQuotePublicToken(
   if (existing) return existing
 
   const token = generateId()
-  const fieldValueService = new FieldValueService(organizationId, systemUserId)
+  const fieldValueService = new FieldValueService(
+    organizationId,
+    systemUserId,
+    undefined,
+    undefined,
+    { session: QUIET_PUBLIC_TOKEN }
+  )
   await fieldValueService.setValuesForEntity({
     recordId: quoteRecordId,
     values: [{ fieldId: field.id, value: token }],
-    publishEvents: false,
   })
 
   return token

--- a/packages/lib/src/phone-geo/__tests__/derive-geo-hook.test.ts
+++ b/packages/lib/src/phone-geo/__tests__/derive-geo-hook.test.ts
@@ -101,8 +101,16 @@ describe('derivePhoneGeoOnChange', () => {
   it('writes quietly so the derivation never lands in the activity feed', async () => {
     await derivePhoneGeoOnChange(buildEvent('+13102030000'))
 
-    for (const [, params] of mockedSetValue.mock.calls) {
-      expect(params.publishEvents).toBe(false)
+    // Plan 04 Phase B: the suppression is DECLARED on the session — a quiet
+    // mode carrying its reason — rather than asserted by a bare
+    // `publishEvents: false` beside a comment. Assert the declaration, and that
+    // it actually carries a reason: an empty one would be the boolean again.
+    expect(mockedSetValue.mock.calls.length).toBeGreaterThan(0)
+    for (const [ctx, params] of mockedSetValue.mock.calls) {
+      expect(ctx.session?.mode?.kind).toBe('quiet')
+      expect(ctx.session?.mode?.reason ?? '').not.toHaveLength(0)
+      // The bare boolean is gone, not merely redundant.
+      expect(params).not.toHaveProperty('publishEvents')
     }
     // …but still pushes realtime itself, so an open drawer updates without a reload.
     expect(mockedPublish).toHaveBeenCalledTimes(1)

--- a/packages/lib/src/phone-geo/derive-geo-hook.ts
+++ b/packages/lib/src/phone-geo/derive-geo-hook.ts
@@ -23,11 +23,24 @@ import { buildPublishEntry, setValueWithBuiltIn } from '../field-values/field-va
 import { getValues } from '../field-values/field-value-queries'
 import type { CachedField } from '../field-values/types'
 import { getRealtimeService, publishFieldValueUpdates } from '../realtime'
+import { quietSession } from '../resources/crud/write-origin'
 import { parseRecordId, toRecordId } from '../resources/resource-id'
 import { lookupPhoneGeo } from './lookup'
 import type { PhoneGeo } from './types'
 
 const logger = createScopedLogger('phone-geo')
+
+/**
+ * C4 (plan 04 §3): this hook writes back a value it just derived. Recursion is
+ * structurally impossible anyway — it keys on PHONE_INTL and only ever writes
+ * TEXT fields — but the reason the doors stay shut is not re-entrancy, it is
+ * that a derivation is not a user edit and should not read as one in the
+ * activity feed. The hook publishes its own realtime frame afterwards, so an
+ * open contact drawer still updates.
+ */
+const QUIET_DERIVED_GEO = quietSession(
+  'a derived geo value is not a user edit — no timeline entry, no field triggers, no post-hook chain; this hook publishes its own realtime frame instead'
+)
 
 /** Target systemAttribute → the {@link PhoneGeo} key that feeds it. */
 const GEO_TARGETS = [
@@ -89,7 +102,7 @@ export const derivePhoneGeoOnChange: EntityFieldChangeHandler = async (event) =>
 
 /**
  * The derivation core: resolve the entity's geo target fields, fill only the BLANK ones from
- * `geo`, write quietly (`publishEvents: false`), and publish one hand-rolled realtime frame.
+ * `geo`, write quietly (declared via `QUIET_DERIVED_GEO`), and publish one hand-rolled realtime frame.
  * The inline hook wraps this in its own try/catch; the finalize integrity passes
  * (`events/handlers/finalize-integrity-passes.ts`) call it directly with a synthesized event —
  * only `organizationId`, `entityDefinitionId`, `userId`, `recordId`, and
@@ -139,16 +152,18 @@ export async function fillBlankGeoFields(
   const entries = []
 
   for (const write of writes) {
-    // Quiet write: `publishEvents: false` skips the post-hook chain, field triggers, the timeline
-    // entry and the inline realtime publish. Recursion is structurally impossible anyway (this
-    // hook keys on PHONE_INTL and only ever writes TEXT fields), but a derivation is not a user
-    // edit and should not read as one in the activity feed.
-    const result = await setValueWithBuiltIn(ctx, {
-      recordId: event.recordId,
-      fieldId: write.fieldId,
-      value: write.value,
-      publishEvents: false,
-    })
+    // C4 (plan 04 §3): the reason is declared on the session, not asserted in a
+    // comment beside a bare boolean. Same suppression as before — post-hook
+    // chain, field triggers, timeline entry and inline realtime publish all stay
+    // shut; this hook publishes its own frame below.
+    const result = await setValueWithBuiltIn(
+      { ...ctx, session: QUIET_DERIVED_GEO },
+      {
+        recordId: event.recordId,
+        fieldId: write.fieldId,
+        value: write.value,
+      }
+    )
     if (result.values.length === 0) continue
 
     let field: CachedField | undefined

--- a/packages/lib/src/resources/crud/__tests__/silent-write-conformance.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/silent-write-conformance.test.ts
@@ -1,0 +1,153 @@
+// packages/lib/src/resources/crud/__tests__/silent-write-conformance.test.ts
+//
+// SILENT-WRITE CONFORMANCE (plan 04 Phase B).
+//
+// A write that shuts its doors must SAY WHY, in a form something can check.
+// Before Phase B the reason lived in a comment beside a bare
+// `publishEvents: false`, which is unenforceable — and B-16 is what that costs:
+// `merge-service.ts` suppressed every door while claiming an aggregator that
+// does not exist, and nothing caught it for as long as the claim was prose.
+//
+// So the declaration is a `WriteMode` on the session — `quiet(reason)` or
+// `absorbed(by)` — and this file asserts the bare form has not come back.
+//
+// THE ALLOWLIST IS A LEDGER, NOT AN EXEMPTION. Every entry names the phase that
+// closes it. An entry that stops deviating FAILS here, forcing its removal —
+// the same discipline `door-conformance.test.ts` applies to `KNOWN_DEVIATIONS`.
+// A new bare `publishEvents: false` anywhere in `packages/lib/src` also fails,
+// which is the regression guard Phase A shipped the mechanism for but did not
+// install.
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  absorbedSession,
+  isDeclaredSilent,
+  quietSession,
+  seedSession,
+  sessionLane,
+} from '../write-origin'
+
+const LIB_SRC = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+
+/**
+ * Sites still passing a bare `publishEvents: false`, each with the plan phase
+ * that migrates it. These are NOT exempt — they are scheduled.
+ */
+const PENDING_SILENT_WRITES: Record<string, { why: string; closedBy: string }> = {
+  'resources/merge/merge-service.ts': {
+    why: 'C3 with a missing aggregator — merge is silent end to end (B-16), so declaring `absorbed` here would be a lie until the aggregator exists',
+    closedBy: 'plan 04 Phase C',
+  },
+  'recording/calendar/meeting-entity-service.ts': {
+    why: 'C1, but the record is created outside the handler (B-20), so there is no create door to declare against yet',
+    closedBy: 'plan 04 Phase D',
+  },
+  'recording/calendar/create-meeting-direct.ts': {
+    why: 'C1, same handler bypass as meeting-entity-service (B-20)',
+    closedBy: 'plan 04 Phase D',
+  },
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '__tests__' || entry === 'dist') continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else if (entry.endsWith('.ts') && !entry.endsWith('.test.ts')) out.push(full)
+  }
+  return out
+}
+
+/**
+ * Lines that PASS `publishEvents: false` as an argument, not lines that merely
+ * mention it. Prose about the old mechanism is documentation, not a door.
+ */
+function bareSuppressionSites(): string[] {
+  const hits: string[] = []
+  for (const file of walk(LIB_SRC)) {
+    const lines = readFileSync(file, 'utf8').split('\n')
+    lines.forEach((line, i) => {
+      if (!/publishEvents:\s*false/.test(line)) return
+      const trimmed = line.trim()
+      // Skip comment lines — `//`, and `*` / `/*` inside a JSDoc block.
+      if (trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) return
+      hits.push(`${relative(LIB_SRC, file).replace(/\\/g, '/')}:${i + 1}`)
+    })
+  }
+  return hits.sort()
+}
+
+describe('silent-write conformance — every shut door names its reason', () => {
+  it('no bare `publishEvents: false` outside the scheduled ledger', () => {
+    const found = bareSuppressionSites()
+    const unexpected = found.filter((site) => !(site.split(':')[0]! in PENDING_SILENT_WRITES))
+
+    // A new one here means somebody suppressed a door without saying why.
+    // Declare it instead: `quietSession(reason)` for C4/C5, or
+    // `absorbedSession(by)` for C3 — and `by` must name a real aggregator.
+    expect(unexpected).toEqual([])
+  })
+
+  it('every ledger entry is still deviating — a closed one must be removed', () => {
+    const files = new Set(bareSuppressionSites().map((site) => site.split(':')[0]!))
+    for (const [file, entry] of Object.entries(PENDING_SILENT_WRITES)) {
+      expect(
+        files.has(file),
+        `${file} no longer passes a bare publishEvents: false — ${entry.closedBy} appears done, so drop its PENDING_SILENT_WRITES entry`
+      ).toBe(true)
+    }
+  })
+
+  it('the ledger states, per entry, why it cannot be declared yet and what closes it', () => {
+    for (const [file, entry] of Object.entries(PENDING_SILENT_WRITES)) {
+      expect(entry.why.length, `${file} needs a reason`).toBeGreaterThan(20)
+      expect(entry.closedBy, `${file} needs a closing phase`).toMatch(/plan \d+ Phase [A-E]/)
+    }
+  })
+})
+
+describe('the declarations themselves', () => {
+  it('a quiet session is silent, and carries its reason', () => {
+    const session = quietSession('because the derivation is not a user edit')
+    expect(sessionLane(session)).toBe('silent')
+    expect(isDeclaredSilent(session)).toBe(true)
+    expect(session.mode).toEqual({
+      kind: 'quiet',
+      reason: 'because the derivation is not a user edit',
+    })
+  })
+
+  it('an absorbed session is silent, and names its aggregator', () => {
+    const session = absorbedSession('setBulkValues')
+    expect(sessionLane(session)).toBe('silent')
+    expect(isDeclaredSilent(session)).toBe(true)
+    expect(session.mode).toEqual({ kind: 'absorbed', by: 'setBulkValues' })
+  })
+
+  it('refuses an empty reason or an unnamed aggregator', () => {
+    // The whole mechanism is the reason. An empty one is the bare boolean again.
+    expect(() => quietSession('')).toThrow(/non-empty reason/)
+    expect(() => quietSession('   ')).toThrow(/non-empty reason/)
+    expect(() => absorbedSession('')).toThrow(/named aggregator/)
+  })
+
+  it('inherits origin and depth so a declaration does not reset provenance', () => {
+    const base = { origin: { kind: 'interactive' as const, userId: 'user_1' }, depth: 3 }
+    const session = quietSession('a reason', base)
+    expect(session.origin).toEqual(base.origin)
+    expect(session.depth).toBe(3)
+  })
+
+  it('is narrower than the silent LANE — a silent ORIGIN is not a declaration', () => {
+    // `isDeclaredSilent` gates the field-value layer, and it must stay narrower
+    // than `sessionLane`. A sync or seed ORIGIN is silent too, but it has never
+    // gated that layer; widening this to the whole lane would change behavior
+    // for every sync and seed write, which Phase B is explicitly not doing.
+    const seed = seedSession('reshape')
+    expect(sessionLane(seed)).toBe('silent')
+    expect(isDeclaredSilent(seed)).toBe(false)
+  })
+})

--- a/packages/lib/src/resources/crud/write-origin.ts
+++ b/packages/lib/src/resources/crud/write-origin.ts
@@ -135,3 +135,61 @@ export function sessionLane(session: WriteSession): 'inline' | 'silent' | 'buffe
       return 'silent'
   }
 }
+
+/**
+ * True when a session DECLARES its silence — `quiet` (C4/C5) or `absorbed`
+ * (C3), the two modes of plan 04 §3 that exist to carry a reason rather than
+ * new behavior.
+ *
+ * This is deliberately narrower than `sessionLane(...) === 'silent'`: a sync or
+ * seed ORIGIN is also silent, but it has never gated the field-value layer and
+ * turning that on here would be a behavior change across every sync write. The
+ * two declared modes are new in plan 04, so nothing sets them yet and honoring
+ * them is inert until a leaf opts in (plan 04 Phase B).
+ */
+export function isDeclaredSilent(session?: WriteSession): boolean {
+  const kind = session?.mode?.kind
+  return kind === 'quiet' || kind === 'absorbed'
+}
+
+/**
+ * Declare a write QUIET (plan 04 §3 C4/C5): its doors stay shut on purpose and
+ * `reason` is the decision, in prose, at the site that made it.
+ *
+ * Replaces a bare `publishEvents: false` plus a comment. Same lane, same
+ * suppression — the difference is that the intent is typed, greppable, and
+ * checkable by the door-conformance harness instead of living in a comment
+ * nobody can enforce.
+ *
+ * @param reason Why this write is deliberately silent. Required, non-empty.
+ * @param base The session to inherit origin and depth from, when there is one.
+ */
+export function quietSession(reason: string, base?: WriteSession): WriteSession {
+  if (!reason.trim()) throw new Error('quietSession requires a non-empty reason')
+  return {
+    origin: base?.origin ?? { kind: 'automation', actor: 'system' },
+    depth: base?.depth ?? 0,
+    mode: { kind: 'quiet', reason },
+  }
+}
+
+/**
+ * Declare a write ABSORBED (plan 04 §3 C3): its doors stay shut at the leaf
+ * because an aggregator one frame up announces the whole operation, and `by`
+ * names that aggregator.
+ *
+ * Naming it is the point. B-16 — merge suppressing every door while claiming an
+ * aggregator that does not exist — is exactly the defect a named announcer makes
+ * checkable.
+ *
+ * @param by The aggregator that announces on this write's behalf. Non-empty.
+ * @param base The session to inherit origin and depth from, when there is one.
+ */
+export function absorbedSession(by: string, base?: WriteSession): WriteSession {
+  if (!by.trim()) throw new Error('absorbedSession requires a named aggregator')
+  return {
+    origin: base?.origin ?? { kind: 'automation', actor: 'system' },
+    depth: base?.depth ?? 0,
+    mode: { kind: 'absorbed', by },
+  }
+}


### PR DESCRIPTION
Phase B of `plans/events/04-in-transaction-write-semantics-plan.md`. Follows #1826 (Phase A), which is merged.

**Zero behavior change.** The same doors stay shut. What moves is the *reason* — out of a comment beside a bare `publishEvents: false`, into a typed declaration something can check.

## Why bother

B-16 is what the comment form costs. `merge-service.ts` suppresses every door while claiming an aggregator that does not exist — no realtime, no timeline, no record rules, no workflows, no dedup rescan — and nothing caught it for as long as the claim was prose. A named announcer is checkable. A paragraph is not.

## What's declared

`quietSession(reason)` — C4/C5, doors shut on purpose.
`absorbedSession(by)` — C3, an aggregator one frame up announces.

Both throw on an empty reason or an unnamed aggregator, because an empty reason is the bare boolean again.

Seven leaves migrate:

| Site | Class | Declaration |
| --- | --- | --- |
| `phone-geo/derive-geo-hook.ts` | C4 | `QUIET_DERIVED_GEO` |
| `geocoding/address-normalize-hook.ts` | C4 | `QUIET_NORMALIZED_ADDRESS` |
| `dispatch/mirror.ts` | C5 | `QUIET_VISIT_MIRROR` |
| `money/public-token.ts` | C5 | `QUIET_PUBLIC_TOKEN` |
| `money/quote-public-token.ts` | C5 | `QUIET_PUBLIC_TOKEN` |
| `documents/ensure-pdf.ts` | C5 | `QUIET_PDF_POINTER` |
| `field-values/field-value-mutations.ts` (`setBulkValues`) | C3 | `absorbedSession('setBulkValues')` |

Each constant's JSDoc carries the **decision**, not a restatement of the mechanism — O-4's still-pending record-lane frame on the visit mirror (B-19), O-5's confidentiality argument on both token mints, O-7's deferral on the PDF pointer.

The token one is worth reading if you touch it later: a public token is a **bearer capability** and the public resolver is org-agnostic by design, so a tier-1 frame — which carries raw stored values to a room gated only on org membership plus `canViewEntity(defId)` — would reach a wider audience than the token read path grants. Un-suppressing it is a confidentiality regression, not a fidelity improvement. That is now written where someone about to "fix" the silence will see it.

## The plan's stated mechanism did not work

Worth flagging, because it would have been a live bug rather than a no-op.

The plan said: set `mode: { kind: 'quiet', reason }` and drop the boolean. But the field-value layer never consulted `sessionLane` — `requestedPublish = params.publishEvents ?? true` — and `ctx.session` was documented as *"carried only in this slice, no behavior gate reads it."* Doing it as written would have turned those doors **ON**, the exact opposite of the intent.

What ships adds `isDeclaredSilent(session)` as the default for `publishEvents`, deliberately **narrower than the silent lane**: a sync or seed *origin* is silent too, but it has never gated this layer, and widening to the full lane would change behavior for every sync and seed write — well outside a zero-behavior phase. Only the two declared modes count, and nothing set them before this phase, so honoring them was inert until each leaf opted in. There is a test pinning that narrowness specifically.

## The regression guard

`silent-write-conformance.test.ts` — the check Phase A shipped the mechanism for but did not install.

It scans `packages/lib/src` for `publishEvents: false` **passed as an argument** (prose mentioning it is documentation, not a door) and fails on any site not in `PENDING_SILENT_WRITES`. That list is a **ledger, not an exemption**: three entries, each naming the phase that closes it.

| Site | Why it cannot be declared yet | Closed by |
| --- | --- | --- |
| `resources/merge/merge-service.ts` | C3 with a missing aggregator (B-16) — declaring `absorbed` would be a lie until one exists | Phase C |
| `recording/calendar/meeting-entity-service.ts` | C1, but the record is created outside the handler (B-20), so there is no create door to declare against | Phase D |
| `recording/calendar/create-meeting-direct.ts` | same handler bypass | Phase D |

An entry that **stops** deviating also fails, forcing its removal — the same discipline `door-conformance.test.ts` applies to `KNOWN_DEVIATIONS`.

Verified by injecting a bare suppression into `ensure-pdf.ts` and confirming the guard failed naming the exact file and line, then reverting.

## Verification

- Full `packages/lib` suite: **892 passed / 4 skipped**. Two failures are 10s timeouts in `resolve-resource-trigger-match` and `workflow-draft-cas` — the same two flakes present before this change; both pass in isolation, neither area is touched here.
- Typecheck: **0 `src/` errors**. Biome clean.
- The conformance ledger was re-checked against this PR's base: exactly the three expected sites, no more.

**Two existing tests changed.** They asserted `params.publishEvents === false` — the mechanism, not the behavior. They now assert the declaration exists, carries a non-empty reason, and that the boolean is gone. That is the only test churn; no production behavior moved.

## Not in scope

Phases C (merge announces itself), D (meetings onto `handler.create`), and E (the C5 realtime calls, including B-19 on the visit mirror). Phase C additionally needs two prerequisites settled first — see §11.3 and §11.4 in the plan.