### PR TITLE
feat(parts): split part cost into purchase, roll-up and source

### DIFF
--- a/packages/lib/src/bom/cost-calculator.test.ts
+++ b/packages/lib/src/bom/cost-calculator.test.ts
@@ -1,8 +1,9 @@
 // packages/lib/src/bom/cost-calculator.test.ts
 //
-// Regression cover for plans/parts/cost-provenance-and-stale-values.md §1: `persistCosts`
+// Cover for plans/parts/cost-provenance-and-stale-values.md §1, §5.3-§5.5: `persistCosts`
 // used to be write-only, so a part that lost its last vendor part kept the number it had at
-// the time. Harness style follows `money/catalog-pricing.test.ts` and
+// the time; and `part_cost` was one output with two silent meanings, so a NULL there carried
+// no information. Harness style follows `money/catalog-pricing.test.ts` and
 // `field-hooks/post/bom-cost-triggers.test.ts` — mock `@auxx/database` with a sequential
 // result queue and assert on the writer's calls rather than on drizzle column identity.
 
@@ -44,6 +45,7 @@ vi.mock('@auxx/database', () => ({
       valueNumber: 'valueNumber',
       valueBoolean: 'valueBoolean',
       relatedEntityId: 'relatedEntityId',
+      optionId: 'optionId',
     },
   },
 }))
@@ -60,7 +62,9 @@ const FIELD: Record<string, { id: string; type: string }> = {
   subpart_child_part: { id: 'f_sp_child', type: 'RELATIONSHIP' },
   subpart_quantity: { id: 'f_sp_qty', type: 'NUMBER' },
   part_cost: { id: 'f_part_cost', type: 'CURRENCY' },
-  part_unit_price: { id: 'f_part_unit_price', type: 'CURRENCY' },
+  part_purchase_cost: { id: 'f_part_purchase_cost', type: 'CURRENCY' },
+  part_rollup_cost: { id: 'f_part_rollup_cost', type: 'CURRENCY' },
+  part_cost_source: { id: 'f_part_cost_source', type: 'SINGLE_SELECT' },
 }
 
 vi.mock('../cache', () => ({
@@ -95,11 +99,16 @@ vi.mock('../money/catalog-pricing', () => ({
   syncCatalogItemPricing: h.syncCatalogItemPricing,
 }))
 
-import { recalculateAffectedParts } from './cost-calculator'
+import {
+  calculateAllCosts,
+  recalculateAffectedParts,
+  recalculateAllPartCosts,
+} from './cost-calculator'
 
 const ORG = 'org_1'
 const ASSEMBLY = 'part_assembly'
 const MOTOR = 'part_motor'
+const WIDGET = 'part_widget'
 
 /** A `vendor_part` instance priced at `unitPrice`, linked to `partId`. */
 function vendorPartRows(instanceId: string, partId: string, unitPrice: number) {
@@ -140,18 +149,25 @@ function subpartRows(instanceId: string, parentId: string, childId: string, qty:
   ]
 }
 
-/** Existing `part_cost` / `part_unit_price` FieldValue rows. */
-function storedRows(entries: Array<{ partId: string; cost?: number; unitPrice?: number }>) {
+interface StoredPart {
+  partId: string
+  cost?: number
+  purchaseCost?: number
+  rollupCost?: number
+  source?: string
+}
+
+/** Existing `part_cost` / `part_purchase_cost` / `part_rollup_cost` / source rows. */
+function storedRows(entries: StoredPart[]) {
   const rows: unknown[] = []
+  const push = (partId: string, fieldId: string, valueNumber: number | null, optionId?: string) =>
+    rows.push({ entityId: partId, fieldId, valueNumber, optionId: optionId ?? null })
+
   for (const e of entries) {
-    if (e.cost != null)
-      rows.push({ entityId: e.partId, fieldId: FIELD.part_cost!.id, valueNumber: e.cost })
-    if (e.unitPrice != null)
-      rows.push({
-        entityId: e.partId,
-        fieldId: FIELD.part_unit_price!.id,
-        valueNumber: e.unitPrice,
-      })
+    if (e.cost != null) push(e.partId, FIELD.part_cost!.id, e.cost)
+    if (e.purchaseCost != null) push(e.partId, FIELD.part_purchase_cost!.id, e.purchaseCost)
+    if (e.rollupCost != null) push(e.partId, FIELD.part_rollup_cost!.id, e.rollupCost)
+    if (e.source != null) push(e.partId, FIELD.part_cost_source!.id, null, e.source)
   }
   return rows
 }
@@ -159,6 +175,16 @@ function storedRows(entries: Array<{ partId: string; cost?: number; unitPrice?: 
 /** The three queries `recalculateAffectedParts` runs, in order. */
 function queue(vendorParts: unknown[], subparts: unknown[], stored: unknown[]) {
   h.queryQueue = [vendorParts, subparts, stored]
+}
+
+/** `recalculateAllPartCosts` inserts a scope query between the graph and the stored values. */
+function queueFullSweep(
+  vendorParts: unknown[],
+  subparts: unknown[],
+  partIds: string[],
+  stored: unknown[]
+) {
+  h.queryQueue = [vendorParts, subparts, partIds.map((id) => ({ id })), stored]
 }
 
 /** Every `setValueWithType` call for one field, as `{ recordId, value }`. */
@@ -169,19 +195,30 @@ function writesFor(fieldId: string) {
     .map(({ recordId, value }) => ({ recordId, value }))
 }
 
+/** Every field written for one part, keyed by field id. */
+function writesForPart(partId: string): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const call of h.setValueWithType.mock.calls) {
+    const params = call[1] as { recordId: string; fieldId: string; value: unknown }
+    if (params.recordId !== `part_def:${partId}`) continue
+    out[params.fieldId] = params.value
+  }
+  return out
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   h.queryQueue = []
 })
 
 describe('recalculateAffectedParts — clearing values', () => {
-  it('clears a stale unit price when the part lost its last vendor, and falls back to the BOM cost', async () => {
-    // The AL400 case: assembly = 2 × motor @ $180.00, and a $50.00 unit price left behind by
-    // a vendor part that has since been deleted.
+  it('clears a stale purchase cost when the part lost its last vendor, and falls back to the BOM cost', async () => {
+    // The AL400 case: assembly = 2 x motor @ $180.00, and a $50.00 purchase cost left behind
+    // by a vendor part that has since been deleted.
     queue(
       vendorPartRows('vp_motor', MOTOR, 18000),
       subpartRows('sp_1', ASSEMBLY, MOTOR, 2),
-      storedRows([{ partId: ASSEMBLY, cost: 5000, unitPrice: 5000 }])
+      storedRows([{ partId: ASSEMBLY, cost: 5000, purchaseCost: 5000, source: 'vendor' }])
     )
 
     await recalculateAffectedParts(ORG, [ASSEMBLY])
@@ -190,8 +227,24 @@ describe('recalculateAffectedParts — clearing values', () => {
       { recordId: `part_def:${ASSEMBLY}`, value: { type: 'number', value: 36000 } },
     ])
     // The fix: `null` is written as a CLEAR, not skipped as "nothing to do".
-    expect(writesFor(FIELD.part_unit_price!.id)).toEqual([
+    expect(writesFor(FIELD.part_purchase_cost!.id)).toEqual([
       { recordId: `part_def:${ASSEMBLY}`, value: null },
+    ])
+  })
+
+  it('flips cost source from vendor to bom when the last supplier goes away', async () => {
+    queue(
+      vendorPartRows('vp_motor', MOTOR, 18000),
+      subpartRows('sp_1', ASSEMBLY, MOTOR, 2),
+      storedRows([{ partId: ASSEMBLY, cost: 5000, purchaseCost: 5000, source: 'vendor' }])
+    )
+
+    await recalculateAffectedParts(ORG, [ASSEMBLY])
+
+    // Provenance is what makes the blank above readable: the number did not just
+    // change, it started coming from somewhere else.
+    expect(writesFor(FIELD.part_cost_source!.id)).toEqual([
+      { recordId: `part_def:${ASSEMBLY}`, value: { type: 'option', optionId: 'bom' } },
     ])
   })
 
@@ -199,7 +252,7 @@ describe('recalculateAffectedParts — clearing values', () => {
     queue(
       vendorPartRows('vp_motor', MOTOR, 18000),
       subpartRows('sp_1', ASSEMBLY, MOTOR, 2),
-      storedRows([{ partId: ASSEMBLY, cost: 5000, unitPrice: 5000 }])
+      storedRows([{ partId: ASSEMBLY, cost: 5000, purchaseCost: 5000, source: 'vendor' }])
     )
 
     await recalculateAffectedParts(ORG, [ASSEMBLY])
@@ -210,28 +263,29 @@ describe('recalculateAffectedParts — clearing values', () => {
     }>
     // An OMITTED entry means "don't touch the store" (realtime/events.ts), so the cleared
     // cell has to travel as `value: null` or the client keeps rendering the stale number.
-    const cleared = entries.find((e) => e.key.includes(FIELD.part_unit_price!.id))
+    const cleared = entries.find((e) => e.key.includes(FIELD.part_purchase_cost!.id))
     expect(cleared).toBeDefined()
     expect(cleared?.value).toBeNull()
   })
 
-  it('clears the cost of a part that has neither a vendor nor a BOM', async () => {
+  it('clears the cost of a part that has neither a vendor nor a BOM, and marks it not costed', async () => {
     // Nothing puts this part in the vendor/subpart graph at all — it is only reachable
     // because the caller named it. The dirty set, not the graph, is the persist scope.
-    queue([], [], storedRows([{ partId: ASSEMBLY, cost: 5000 }]))
+    queue([], [], storedRows([{ partId: ASSEMBLY, cost: 5000, source: 'vendor' }]))
 
     await recalculateAffectedParts(ORG, [ASSEMBLY])
 
-    expect(writesFor(FIELD.part_cost!.id)).toEqual([
-      { recordId: `part_def:${ASSEMBLY}`, value: null },
-    ])
+    expect(writesForPart(ASSEMBLY)).toEqual({
+      [FIELD.part_cost!.id]: null,
+      [FIELD.part_cost_source!.id]: { type: 'option', optionId: 'none' },
+    })
   })
 
   it('writes nothing when the stored values already match', async () => {
     queue(
       vendorPartRows('vp_motor', MOTOR, 18000),
       subpartRows('sp_1', ASSEMBLY, MOTOR, 2),
-      storedRows([{ partId: ASSEMBLY, cost: 36000 }])
+      storedRows([{ partId: ASSEMBLY, cost: 36000, rollupCost: 36000, source: 'bom' }])
     )
 
     await recalculateAffectedParts(ORG, [ASSEMBLY])
@@ -258,5 +312,197 @@ describe('recalculateAffectedParts — clearing values', () => {
       (call) => (call[1] as { recordId: string }).recordId
     )
     expect(new Set(touched)).toEqual(new Set([`part_def:${ASSEMBLY}`]))
+  })
+})
+
+describe('recalculateAffectedParts — provenance', () => {
+  it('records the roll-up cost even when a supplier price wins', async () => {
+    // The assembly can be bought for $100.00 or built from 2 x motor @ $180.00.
+    // Storing only the winner is what made buy-vs-build unaskable.
+    queue(
+      [...vendorPartRows('vp_motor', MOTOR, 18000), ...vendorPartRows('vp_asm', ASSEMBLY, 10000)],
+      subpartRows('sp_1', ASSEMBLY, MOTOR, 2),
+      []
+    )
+
+    await recalculateAffectedParts(ORG, [ASSEMBLY])
+
+    expect(writesForPart(ASSEMBLY)).toEqual({
+      [FIELD.part_cost!.id]: { type: 'number', value: 10000 },
+      [FIELD.part_purchase_cost!.id]: { type: 'number', value: 10000 },
+      [FIELD.part_rollup_cost!.id]: { type: 'number', value: 36000 },
+      [FIELD.part_cost_source!.id]: { type: 'option', optionId: 'vendor' },
+    })
+  })
+
+  it('blanks an assembly with one unpriced component instead of reporting a confident zero', async () => {
+    // Before null propagation the widget contributed 0 and the assembly reported a
+    // confident $180.00 — a number that silently understated the real cost. An
+    // incomplete bill of materials has no cost at all.
+    queue(
+      vendorPartRows('vp_motor', MOTOR, 18000),
+      [...subpartRows('sp_1', ASSEMBLY, MOTOR, 1), ...subpartRows('sp_2', ASSEMBLY, WIDGET, 1)],
+      storedRows([{ partId: ASSEMBLY, cost: 18000, rollupCost: 18000, source: 'bom' }])
+    )
+
+    await recalculateAffectedParts(ORG, [ASSEMBLY])
+
+    expect(writesForPart(ASSEMBLY)).toEqual({
+      [FIELD.part_cost!.id]: null,
+      [FIELD.part_rollup_cost!.id]: null,
+      [FIELD.part_cost_source!.id]: { type: 'option', optionId: 'none' },
+    })
+  })
+
+  it('marks an unpriced leaf as not costed rather than free', async () => {
+    queue([], subpartRows('sp_1', ASSEMBLY, WIDGET, 3), [])
+
+    await recalculateAffectedParts(ORG, [WIDGET])
+
+    expect(writesForPart(WIDGET)).toEqual({
+      [FIELD.part_cost_source!.id]: { type: 'option', optionId: 'none' },
+    })
+    // No numeric write at all: there was nothing stored and there is nothing to store.
+    expect(writesFor(FIELD.part_cost!.id)).toEqual([])
+  })
+})
+
+describe('recalculateAllPartCosts — scope is every part, not the graph', () => {
+  it('clears a frozen value on a part that appears nowhere in the vendor/subpart graph', async () => {
+    // This is the case a graph-derived sweep can never reach: no supplier, no BOM,
+    // so the part is in neither map — and the stale number survives every recalc.
+    queueFullSweep(
+      [],
+      [],
+      [ASSEMBLY],
+      storedRows([{ partId: ASSEMBLY, cost: 5000, purchaseCost: 5000, source: 'vendor' }])
+    )
+
+    await recalculateAllPartCosts(ORG)
+
+    expect(writesForPart(ASSEMBLY)).toEqual({
+      [FIELD.part_cost!.id]: null,
+      [FIELD.part_purchase_cost!.id]: null,
+      [FIELD.part_cost_source!.id]: { type: 'option', optionId: 'none' },
+    })
+  })
+
+  it('does not touch parts that are archived out of scope', async () => {
+    // MOTOR is priced and would be written by a graph-derived sweep, but it is not
+    // in the scope query, so it is not this sweep's business.
+    queueFullSweep(
+      vendorPartRows('vp_motor', MOTOR, 18000),
+      [],
+      [ASSEMBLY],
+      storedRows([{ partId: MOTOR, cost: 1 }])
+    )
+
+    await recalculateAllPartCosts(ORG)
+
+    const touched = h.setValueWithType.mock.calls.map(
+      (call) => (call[1] as { recordId: string }).recordId
+    )
+    expect(touched.every((id) => id === `part_def:${ASSEMBLY}`)).toBe(true)
+  })
+})
+
+describe('calculateAllCosts — the unpriced-components signal', () => {
+  // Tested against `calculateAllCosts` directly: the signal is derived and
+  // deliberately never persisted, so there is no FieldValue write to assert on.
+  const graph = (edges: Array<[string, string, number]>) => {
+    const map = new Map<string, { childId: string; qty: number }[]>()
+    for (const [parent, child, qty] of edges) {
+      map.set(parent, [...(map.get(parent) ?? []), { childId: child, qty }])
+    }
+    return map
+  }
+
+  it('names the unpriced component that blanked an assembly', () => {
+    const results = calculateAllCosts(
+      new Map([[MOTOR, 18000]]),
+      graph([
+        [ASSEMBLY, MOTOR, 1],
+        [ASSEMBLY, WIDGET, 1],
+      ])
+    )
+
+    const assembly = results.get(ASSEMBLY)!
+    expect(assembly.cost).toBeNull()
+    expect(assembly.source).toBe('none')
+    expect(assembly.unpricedDescendantIds).toEqual([WIDGET])
+  })
+
+  it('reports nothing for a fully costed assembly', () => {
+    const results = calculateAllCosts(new Map([[MOTOR, 18000]]), graph([[ASSEMBLY, MOTOR, 2]]))
+
+    const assembly = results.get(ASSEMBLY)!
+    expect(assembly.cost).toBe(36000)
+    expect(assembly.unpricedDescendantIds).toEqual([])
+  })
+
+  it('attributes the unpriced LEAF, not the intermediate subassembly', () => {
+    // top -> sub -> widget(unpriced). `sub` is uncosted too, but adding a
+    // supplier to `sub` is not what fixes this — pricing the widget is.
+    const TOP = 'part_top'
+    const SUB = 'part_sub'
+    const results = calculateAllCosts(
+      new Map(),
+      graph([
+        [TOP, SUB, 1],
+        [SUB, WIDGET, 4],
+      ])
+    )
+
+    expect(results.get(TOP)!.unpricedDescendantIds).toEqual([WIDGET])
+    expect(results.get(SUB)!.unpricedDescendantIds).toEqual([WIDGET])
+    // The leaf itself is the unpriced thing; it is not its own descendant.
+    expect(results.get(WIDGET)!.unpricedDescendantIds).toEqual([])
+    expect(results.get(WIDGET)!.source).toBe('none')
+  })
+
+  it('explains a missing roll-up on a part that IS costed by a vendor', () => {
+    // The assembly has a buy price, so `cost` is fine — but the build price is
+    // unavailable, and this is the only thing that says why.
+    const results = calculateAllCosts(new Map([[ASSEMBLY, 10000]]), graph([[ASSEMBLY, WIDGET, 1]]))
+
+    const assembly = results.get(ASSEMBLY)!
+    expect(assembly.cost).toBe(10000)
+    expect(assembly.source).toBe('vendor')
+    expect(assembly.rollupCost).toBeNull()
+    expect(assembly.unpricedDescendantIds).toEqual([WIDGET])
+  })
+
+  it('dedupes a leaf reached through two different paths', () => {
+    const TOP = 'part_top'
+    const LEFT = 'part_left'
+    const RIGHT = 'part_right'
+    const results = calculateAllCosts(
+      new Map(),
+      graph([
+        [TOP, LEFT, 1],
+        [TOP, RIGHT, 1],
+        [LEFT, WIDGET, 1],
+        [RIGHT, WIDGET, 2],
+      ])
+    )
+
+    expect(results.get(TOP)!.unpricedDescendantIds).toEqual([WIDGET])
+  })
+
+  it('terminates on a cycle instead of walking it forever', () => {
+    const A = 'part_a'
+    const B = 'part_b'
+    const results = calculateAllCosts(
+      new Map(),
+      graph([
+        [A, B, 1],
+        [B, A, 1],
+      ])
+    )
+
+    // The assertion that matters is that this returned at all. A cycle's
+    // unpriced leaves are not enumerable, so nothing is claimed.
+    expect(results.get(A)!.unpricedDescendantIds).toEqual([])
+    expect(results.get(B)!.unpricedDescendantIds).toEqual([])
   })
 })

--- a/packages/lib/src/bom/cost-calculator.ts
+++ b/packages/lib/src/bom/cost-calculator.ts
@@ -1,6 +1,7 @@
 // packages/lib/src/bom/cost-calculator.ts
 
 import { database, schema } from '@auxx/database'
+import type { CustomFieldEntity } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import { buildFieldValueKey, type FieldId } from '@auxx/types/field'
 import type { RecordId } from '@auxx/types/resource'
@@ -30,7 +31,6 @@ interface VendorPriceRow {
 }
 
 interface VendorCostMaps {
-  unitPriceMap: Map<string, number>
   landedCostMap: Map<string, number>
 }
 
@@ -43,6 +43,74 @@ interface SubpartRow {
 interface OrgPricingData {
   vendorPrices: VendorPriceRow[]
   subparts: SubpartRow[]
+}
+
+/**
+ * Which of the two stored numbers `part_cost` took. Mirrors `CostSource` in
+ * `resources/registry/enum-values.ts` — the option keyspace is the raw `value`
+ * string, because those option rows carry no `id` (see `optionKey`).
+ */
+type CostSourceValue = 'vendor' | 'bom' | 'none'
+
+/**
+ * One part's costs, with provenance.
+ *
+ * `purchaseCost` and `rollupCost` are the two candidate numbers; `cost` is the
+ * one that won and `source` names it. Crucially `rollupCost` is recorded EVEN
+ * WHEN a vendor wins — that is the whole buy-vs-build comparison, and storing
+ * only the winner is what made "is this assembly cheaper to build?" unaskable.
+ */
+interface PartCostResult {
+  cost: number | null
+  purchaseCost: number | null
+  rollupCost: number | null
+  source: CostSourceValue
+  /**
+   * The parts to go price, when this one has no roll-up.
+   *
+   * A blank cost provokes exactly one question — *which component is missing a
+   * price?* — and neither `cost: null` nor `source: 'none'` answers it. This
+   * does.
+   *
+   * **The TRANSITIVE set of unpriced LEAVES, not the direct children.** A leaf
+   * here is a part with neither a vendor price nor a bill of materials of its
+   * own: the thing a human actually has to go add a supplier to. Naming the
+   * intermediate subassembly instead would point at a part that is not itself
+   * fixable — its cost is missing only because something below it is.
+   *
+   * **Descendants only — never the part itself.** An unpriced leaf reports an
+   * empty set; its own `source: 'none'` already says it is the unpriced thing,
+   * and repeating that as its own descendant reads as nonsense in a UI.
+   *
+   * **Populated even when the part IS costed**, if its roll-up is not. A part
+   * bought from a vendor whose bill of materials is incomplete has a `cost` but
+   * a null `rollupCost`; this is what explains the missing buy-vs-build number.
+   *
+   * **Derived, never persisted.** It is unbounded in length and would be a
+   * fifth denormalized value to keep from going stale — the exact failure this
+   * whole plan exists to stop. It rides on the in-memory return value only.
+   *
+   * Empty (and shared) when there is nothing to report.
+   */
+  unpricedDescendantIds: readonly string[]
+}
+
+/** Shared empty set — never mutated, so it is safe to hand out repeatedly. */
+const NO_UNPRICED: readonly string[] = Object.freeze([])
+
+/**
+ * A part with no vendor price and no bill of materials.
+ *
+ * Not `cost: 0`. An unpriced part reporting a confident $0.00 is worse than a
+ * blank: it rolls silently up into every assembly above it and a zero-cost COGS
+ * posting is exactly what the build-event costing rules forbid.
+ */
+const UNCOSTED: PartCostResult = {
+  cost: null,
+  purchaseCost: null,
+  rollupCost: null,
+  source: 'none',
+  unpricedDescendantIds: NO_UNPRICED,
 }
 
 // ─── Data Loading ────────────────────────────────────────────────────
@@ -241,6 +309,30 @@ async function loadOrgPricingData(orgId: string): Promise<OrgPricingData> {
   return { vendorPrices, subparts }
 }
 
+/**
+ * Every non-archived `part` instance in the org.
+ *
+ * This is the persist SCOPE for a full sweep, and it is deliberately not derived
+ * from the vendor/subpart graph. A part with neither a supplier nor a bill of
+ * materials appears nowhere in that graph, so a graph-derived sweep skips it —
+ * which is exactly how a part that lost its last supplier before the write path
+ * became authoritative could keep a frozen number that no recalculation would
+ * ever reach. Scope decides what gets written; values only decide what it says.
+ */
+async function loadAllPartIds(orgId: string, partDefId: string): Promise<string[]> {
+  const rows = await database
+    .select({ id: schema.EntityInstance.id })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.organizationId, orgId),
+        eq(schema.EntityInstance.entityDefinitionId, partDefId),
+        isNull(schema.EntityInstance.archivedAt)
+      )
+    )
+  return rows.map((row) => row.id)
+}
+
 // ─── Graph Building ──────────────────────────────────────────────────
 
 /**
@@ -257,10 +349,9 @@ function computeLandedCost(row: VendorPriceRow): number | null {
 
 /**
  * Best vendor per part: preferred first, then cheapest landed cost.
- * Returns two maps: raw unit price and computed landed cost.
+ * Returns the winning row's computed landed cost per part.
  */
 function buildVendorCostMaps(vendorPrices: VendorPriceRow[]): VendorCostMaps {
-  const unitPriceMap = new Map<string, number>()
   const landedCostMap = new Map<string, number>()
 
   // Group by partInstanceId
@@ -280,7 +371,6 @@ function buildVendorCostMaps(vendorPrices: VendorPriceRow[]): VendorCostMaps {
     })
     const best = sorted[0]
     if (best?.unitPrice != null) {
-      unitPriceMap.set(partId, best.unitPrice)
       const landed = computeLandedCost(best)
       if (landed != null) {
         landedCostMap.set(partId, landed)
@@ -288,7 +378,7 @@ function buildVendorCostMaps(vendorPrices: VendorPriceRow[]): VendorCostMaps {
     }
   }
 
-  return { unitPriceMap, landedCostMap }
+  return { landedCostMap }
 }
 
 /** Adjacency list: parent → [{ childId, qty }] */
@@ -318,81 +408,214 @@ function buildParentGraph(subparts: SubpartRow[]): Map<string, string[]> {
 // ─── Cost Calculation ────────────────────────────────────────────────
 
 /**
- * Calculate costs for all parts in-memory using memoized DFS.
- * Vendor price takes priority over composite cost.
+ * Calculate costs for all parts in the graph using memoized DFS.
+ *
+ * Three things this does that a plain "vendor price beats BOM" walk does not:
+ *
+ *  1. **The roll-up is always computed**, even when a vendor price wins, so the
+ *     buy price and the build price are both stored and comparable.
+ *  2. **Nulls propagate.** A part with neither a vendor nor children has no
+ *     cost — not a cost of zero. An assembly with any unpriced descendant has
+ *     no cost either: an incomplete bill of materials cannot be priced, and a
+ *     confident $0.00 hides that where a blank surfaces it.
+ *  3. **Cycles are contained.** A back edge contributes 0 to its parent's
+ *     roll-up rather than poisoning every ancestor with a null, because a cycle
+ *     is a data defect in one place, not an unpriced part everywhere above it.
+ *     The cyclic part's own cost is genuinely unknowable and records `none`.
+ *  4. **A null says which parts caused it** — see
+ *     {@link PartCostResult.unpricedDescendantIds}. Blanking a cost without
+ *     naming the components responsible just moves the mystery.
  */
 function calculateAllCosts(
-  vendorPriceMap: Map<string, number>,
+  vendorLandedCosts: Map<string, number>,
   subpartGraph: Map<string, { childId: string; qty: number }[]>
-): Map<string, number> {
-  const costs = new Map<string, number>()
+): Map<string, PartCostResult> {
+  const results = new Map<string, PartCostResult>()
   const inProgress = new Set<string>()
+  /** Parts re-entered during the walk — their own cost is unknowable. */
+  const cyclic = new Set<string>()
+  /**
+   * Per part: the unpriced leaves to fix AT OR BELOW it, which is what its
+   * PARENT needs to union. Distinct from the public `unpricedDescendantIds`,
+   * which is strictly below — an unpriced leaf's closure is itself, but it is
+   * not its own descendant.
+   */
+  const closures = new Map<string, readonly string[]>()
 
-  function calc(partId: string): number {
-    if (costs.has(partId)) return costs.get(partId)!
+  /** What a PARENT should add for this child. See point 3 above. */
+  function contribution(partId: string, result: PartCostResult): number | null {
+    if (cyclic.has(partId)) return 0
+    return result.cost
+  }
+
+  function calc(partId: string): PartCostResult {
+    const memo = results.get(partId)
+    if (memo) return memo
+
     if (inProgress.has(partId)) {
       logger.warn('Circular reference detected in BOM, treating cost as 0', { partId })
-      costs.set(partId, 0)
-      return 0
+      cyclic.add(partId)
+      results.set(partId, UNCOSTED)
+      // Memoized BEFORE the recursion unwinds, which is also what stops the
+      // closure walk from looping. A cycle's unpriced leaves cannot be
+      // enumerated, so it reports none rather than a set that depends on which
+      // node the walk happened to enter from.
+      closures.set(partId, NO_UNPRICED)
+      return UNCOSTED
     }
     inProgress.add(partId)
 
-    // Vendor price takes priority
-    const vendorPrice = vendorPriceMap.get(partId)
-    if (vendorPrice != null) {
-      costs.set(partId, vendorPrice)
-      inProgress.delete(partId)
-      return vendorPrice
+    const purchaseCost = vendorLandedCosts.get(partId) ?? null
+
+    // Every child is visited even once the roll-up is known to be incomplete,
+    // so each one still gets memoized with its own answer rather than being
+    // left for a later top-level pass to rediscover.
+    const children = subpartGraph.get(partId) ?? []
+    let rollupCost: number | null = null
+    const unpriced = new Set<string>()
+    if (children.length > 0) {
+      let sum = 0
+      let complete = true
+      for (const child of children) {
+        const childCost = contribution(child.childId, calc(child.childId))
+        for (const id of closures.get(child.childId) ?? NO_UNPRICED) unpriced.add(id)
+        if (childCost == null) complete = false
+        else sum += childCost * child.qty
+      }
+      rollupCost = complete ? sum : null
     }
 
-    // Sum of (child cost × quantity)
-    const children = subpartGraph.get(partId) ?? []
-    const cost = children.reduce((sum, c) => sum + calc(c.childId) * c.qty, 0)
-    costs.set(partId, cost)
     inProgress.delete(partId)
-    return cost
+
+    // A cycle closed on THIS part while its own subtree was walking. The stub
+    // memoized above is the answer; do not overwrite it with a number derived
+    // from a graph that contradicts itself.
+    if (cyclic.has(partId)) return results.get(partId)!
+
+    const unpricedDescendantIds = unpriced.size > 0 ? [...unpriced] : NO_UNPRICED
+
+    let result: PartCostResult
+    if (purchaseCost != null) {
+      result = {
+        cost: purchaseCost,
+        purchaseCost,
+        rollupCost,
+        source: 'vendor',
+        unpricedDescendantIds,
+      }
+    } else if (rollupCost != null) {
+      result = {
+        cost: rollupCost,
+        purchaseCost: null,
+        rollupCost,
+        source: 'bom',
+        unpricedDescendantIds,
+      }
+    } else {
+      result = { ...UNCOSTED, unpricedDescendantIds }
+    }
+
+    results.set(partId, result)
+    // A costed part is nothing for an ancestor to fix, whatever sits under it.
+    // An uncosted LEAF is the fixable thing and names itself here (but not in
+    // its own `unpricedDescendantIds`). An uncosted assembly forwards what it
+    // found below.
+    closures.set(
+      partId,
+      result.cost != null ? NO_UNPRICED : children.length === 0 ? [partId] : unpricedDescendantIds
+    )
+    return result
   }
 
   // Collect all part IDs that appear anywhere in the graph
   const allPartIds = new Set([
-    ...vendorPriceMap.keys(),
+    ...vendorLandedCosts.keys(),
     ...subpartGraph.keys(),
     ...[...subpartGraph.values()].flatMap((children) => children.map((c) => c.childId)),
   ])
 
   for (const id of allPartIds) calc(id)
 
-  return costs
+  return results
 }
 
 // ─── Persistence ─────────────────────────────────────────────────────
 
 interface CurrentPartValues {
   costs: Map<string, number>
-  unitPrices: Map<string, number>
+  purchaseCosts: Map<string, number>
+  rollupCosts: Map<string, number>
+  sources: Map<string, string>
+}
+
+/** The four `part` fields `persistCosts` owns, resolved from the org cache. */
+interface CostFields {
+  cost: CustomFieldEntity
+  purchaseCost: CustomFieldEntity | null
+  rollupCost: CustomFieldEntity | null
+  costSource: CustomFieldEntity | null
 }
 
 /**
- * Load current cached cost and unit price values for all parts in the org.
+ * Resolve the four cost fields. Only `part_cost` is required — the other three
+ * are absent until migration `100` materializes them for the org, and a
+ * pre-migration org must still get its `part_cost` maintained.
  */
-async function loadCurrentPartValues(orgId: string): Promise<CurrentPartValues> {
-  const cache = getOrgCache()
-  const [costField, unitPriceField] = await Promise.all([
-    cache.from(orgId, 'customFields').bySystemAttribute('part_cost'),
-    cache.from(orgId, 'customFields').bySystemAttribute('part_unit_price'),
-  ])
+async function loadCostFields(orgId: string): Promise<CostFields | null> {
+  const fields = await getOrgCache()
+    .from(orgId, 'customFields')
+    .bySystemAttributes([
+      'part_cost',
+      'part_purchase_cost',
+      'part_rollup_cost',
+      'part_cost_source',
+    ] as const)
 
-  const costs = new Map<string, number>()
-  const unitPrices = new Map<string, number>()
+  if (!fields.part_cost) {
+    logger.warn('part_cost custom field not found, skipping cost persistence')
+    return null
+  }
 
-  const fieldIds = [costField?.id, unitPriceField?.id].filter(Boolean) as string[]
-  if (fieldIds.length === 0) return { costs, unitPrices }
+  return {
+    cost: fields.part_cost,
+    purchaseCost: fields.part_purchase_cost,
+    rollupCost: fields.part_rollup_cost,
+    costSource: fields.part_cost_source,
+  }
+}
+
+/**
+ * Load the currently stored cost values for every part in the org, so the write
+ * path only touches rows whose value actually changed.
+ *
+ * `part_cost_source` is a SINGLE_SELECT and lives in `FieldValue.optionId`, not
+ * in `valueNumber` — the registry's option rows carry no `id`, so the stored key
+ * is the raw option `value` ('vendor' / 'bom' / 'none').
+ */
+async function loadCurrentPartValues(
+  orgId: string,
+  fields: CostFields
+): Promise<CurrentPartValues> {
+  const current: CurrentPartValues = {
+    costs: new Map(),
+    purchaseCosts: new Map(),
+    rollupCosts: new Map(),
+    sources: new Map(),
+  }
+
+  const fieldIds = [
+    fields.cost.id,
+    fields.purchaseCost?.id,
+    fields.rollupCost?.id,
+    fields.costSource?.id,
+  ].filter((id): id is string => Boolean(id))
 
   const rows = await database
     .select({
       entityId: schema.FieldValue.entityId,
       fieldId: schema.FieldValue.fieldId,
       valueNumber: schema.FieldValue.valueNumber,
+      optionId: schema.FieldValue.optionId,
     })
     .from(schema.FieldValue)
     .where(
@@ -400,129 +623,140 @@ async function loadCurrentPartValues(orgId: string): Promise<CurrentPartValues> 
     )
 
   for (const row of rows) {
-    if (row.valueNumber == null) continue
-    if (costField && row.fieldId === costField.id) {
-      costs.set(row.entityId, row.valueNumber)
-    } else if (unitPriceField && row.fieldId === unitPriceField.id) {
-      unitPrices.set(row.entityId, row.valueNumber)
+    if (row.fieldId === fields.cost.id) {
+      if (row.valueNumber != null) current.costs.set(row.entityId, row.valueNumber)
+    } else if (fields.purchaseCost && row.fieldId === fields.purchaseCost.id) {
+      if (row.valueNumber != null) current.purchaseCosts.set(row.entityId, row.valueNumber)
+    } else if (fields.rollupCost && row.fieldId === fields.rollupCost.id) {
+      if (row.valueNumber != null) current.rollupCosts.set(row.entityId, row.valueNumber)
+    } else if (fields.costSource && row.fieldId === fields.costSource.id) {
+      if (row.optionId != null) current.sources.set(row.entityId, row.optionId)
     }
   }
 
-  return { costs, unitPrices }
+  return current
+}
+
+/** What `setValueWithType` and the realtime publish both carry for one field. */
+type CostFieldValue =
+  | { type: 'number'; value: number }
+  | { type: 'option'; optionId: string }
+  | null
+
+/** One field of one part that needs writing, already reduced to its new value. */
+interface PendingWrite {
+  field: CustomFieldEntity
+  value: CostFieldValue
 }
 
 /**
- * Write calculated costs and unit prices back to each part's FieldValues.
+ * The writes one part needs, or an empty list when nothing about it changed.
+ *
+ * Every field is compared against what is stored, so a recalculation that
+ * confirms the existing numbers costs nothing. A `null` is a real answer, not
+ * an absence — `part_cost_source` is the exception and is always one of the
+ * three option values, which is the point of having `none` at all.
+ */
+function diffPart(
+  result: PartCostResult,
+  partId: string,
+  fields: CostFields,
+  previous: CurrentPartValues
+): PendingWrite[] {
+  const writes: PendingWrite[] = []
+
+  const numeric: [CustomFieldEntity | null, number | null, Map<string, number>][] = [
+    [fields.cost, result.cost, previous.costs],
+    [fields.purchaseCost, result.purchaseCost, previous.purchaseCosts],
+    [fields.rollupCost, result.rollupCost, previous.rollupCosts],
+  ]
+
+  for (const [field, next, stored] of numeric) {
+    if (!field) continue
+    const prev = stored.get(partId) ?? null
+    if (next === prev) continue
+    writes.push({ field, value: next == null ? null : { type: 'number', value: next } })
+  }
+
+  if (fields.costSource) {
+    const prev = previous.sources.get(partId) ?? null
+    if (result.source !== prev) {
+      writes.push({ field: fields.costSource, value: { type: 'option', optionId: result.source } })
+    }
+  }
+
+  return writes
+}
+
+/**
+ * Write calculated costs back to each part's FieldValues.
  * Only touches parts whose values actually changed.
  *
- * **Authoritative, not additive.** A `null` in either map is a real answer — "this part
- * has no calculated value" — and clears the stored FieldValue, rather than meaning "leave
- * whatever is there". Without that, a part losing its last vendor (or its last subpart)
- * keeps a frozen number that is visually indistinguishable from a fresh one; the caller
- * must therefore map every part IN SCOPE, using `null` where there is no value, not only
- * the parts that happen to have one.
+ * **Authoritative, not additive.** A `null` in a result is a real answer — "this
+ * part has no calculated value" — and clears the stored FieldValue, rather than
+ * meaning "leave whatever is there". Without that, a part losing its last vendor
+ * (or its last subpart) keeps a frozen number that is visually indistinguishable
+ * from a fresh one; the caller must therefore pass every part IN SCOPE, using
+ * {@link UNCOSTED} where there is no value, not only the parts that have one.
  *
  * Returns IDs of parts whose values changed.
  */
 async function persistCosts(
   orgId: string,
-  landedCosts: Map<string, number | null>,
-  unitPrices: Map<string, number | null>,
+  scoped: Map<string, PartCostResult>,
+  fields: CostFields,
   previous: CurrentPartValues
 ): Promise<string[]> {
-  const cache = getOrgCache()
-  const [costField, unitPriceField] = await Promise.all([
-    cache.from(orgId, 'customFields').bySystemAttribute('part_cost'),
-    cache.from(orgId, 'customFields').bySystemAttribute('part_unit_price'),
-  ])
-
-  if (!costField) {
-    logger.warn('part_cost custom field not found, skipping cost persistence')
-    return []
-  }
-
   const partDefId = await requireCachedEntityDefId(orgId, 'part')
   const ctx = createFieldValueContext(orgId)
 
   logger.info('Persisting costs', {
-    costFieldId: costField.id,
-    unitPriceFieldId: unitPriceField?.id ?? null,
+    costFieldId: fields.cost.id,
+    purchaseCostFieldId: fields.purchaseCost?.id ?? null,
+    rollupCostFieldId: fields.rollupCost?.id ?? null,
+    costSourceFieldId: fields.costSource?.id ?? null,
     partDefId,
-    totalCosts: landedCosts.size,
-    totalUnitPrices: unitPrices.size,
+    scopedParts: scoped.size,
   })
 
-  // Collect parts with changed values (cost or unit price)
-  interface ChangedEntry {
-    partId: string
-    cost: number | null
-    unitPrice: number | null
-    costChanged: boolean
-    unitPriceChanged: boolean
-  }
-
-  const allPartIds = new Set([...landedCosts.keys(), ...unitPrices.keys()])
-  const changedEntries: ChangedEntry[] = []
-
-  for (const partId of allPartIds) {
-    const cost = landedCosts.get(partId) ?? null
-    const unitPrice = unitPrices.get(partId) ?? null
-    const prevCost = previous.costs.get(partId) ?? null
-    const prevUnitPrice = previous.unitPrices.get(partId) ?? null
-    const costChanged = cost !== prevCost
-    const unitPriceChanged = unitPrice !== prevUnitPrice
-
-    if (costChanged || unitPriceChanged) {
-      changedEntries.push({ partId, cost, unitPrice, costChanged, unitPriceChanged })
-    }
+  const changedEntries: { partId: string; writes: PendingWrite[] }[] = []
+  for (const [partId, result] of scoped) {
+    const writes = diffPart(result, partId, fields, previous)
+    if (writes.length > 0) changedEntries.push({ partId, writes })
   }
 
   logger.info('Parts with changed values', { count: changedEntries.length })
 
   // Write all changed values concurrently (bounded to avoid overwhelming the DB)
   const BATCH_SIZE = 20
-  const changedPartIds: string[] = []
+  const changedPartIds = new Set<string>()
 
   for (let i = 0; i < changedEntries.length; i += BATCH_SIZE) {
     const batch = changedEntries.slice(i, i + BATCH_SIZE)
     const results = await Promise.allSettled(
       batch.map(async (entry) => {
         const recordId = toRecordId(partDefId, entry.partId) as RecordId
-        const writes: Promise<unknown>[] = []
 
         // `value: null` IS the clear — `setValueWithType` deletes the field's rows and
         // returns early. Same writer for set and clear, matching `catalog-pricing.ts`'s
         // `writeCatalogNumberValues`; a raw `deleteValue` would skip `maybeUpdateDisplayValue`.
-        if (entry.costChanged) {
-          writes.push(
+        await Promise.all(
+          entry.writes.map((write) =>
             setValueWithType(ctx, {
               recordId,
-              fieldId: costField.id,
-              fieldType: toFieldType(costField.type),
-              value: entry.cost == null ? null : { type: 'number', value: entry.cost },
+              fieldId: write.field.id,
+              fieldType: toFieldType(write.field.type),
+              value: write.value,
             })
           )
-        }
-
-        if (entry.unitPriceChanged && unitPriceField) {
-          writes.push(
-            setValueWithType(ctx, {
-              recordId,
-              fieldId: unitPriceField.id,
-              fieldType: toFieldType(unitPriceField.type),
-              value: entry.unitPrice == null ? null : { type: 'number', value: entry.unitPrice },
-            })
-          )
-        }
-
-        await Promise.all(writes)
+        )
         return entry.partId
       })
     )
 
     for (const result of results) {
       if (result.status === 'fulfilled') {
-        changedPartIds.push(result.value)
+        changedPartIds.add(result.value)
       } else {
         logger.error('Failed to persist values for part', {
           error: result.reason instanceof Error ? result.reason.message : String(result.reason),
@@ -533,53 +767,62 @@ async function persistCosts(
   }
 
   // Publish cascaded changes to all clients
-  if (changedPartIds.length > 0) {
+  if (changedPartIds.size > 0) {
     const entries: FieldValueUpdateEntry[] = []
     for (const entry of changedEntries) {
-      if (!changedPartIds.includes(entry.partId)) continue
+      if (!changedPartIds.has(entry.partId)) continue
       const recordId = toRecordId(partDefId, entry.partId) as RecordId
 
       // A cleared cell publishes as `value: null`, NOT as an omitted entry: on
       // `FieldValueUpdateEntry` an absent `value` means "don't touch the store"
       // (realtime/events.ts), so skipping the entry would leave every open client
       // rendering the stale number until a reload.
-      if (entry.costChanged) {
+      for (const write of entry.writes) {
         entries.push({
-          key: buildFieldValueKey(recordId, costField.id as FieldId),
-          value: entry.cost == null ? null : { type: 'number', value: entry.cost },
-        })
-      }
-      if (entry.unitPriceChanged && unitPriceField) {
-        entries.push({
-          key: buildFieldValueKey(recordId, unitPriceField.id as FieldId),
-          value: entry.unitPrice == null ? null : { type: 'number', value: entry.unitPrice },
+          key: buildFieldValueKey(recordId, write.field.id as FieldId),
+          value: write.value,
         })
       }
     }
     publishFieldValueUpdates(getRealtimeService(), orgId, entries).catch(() => {})
   }
 
-  return changedPartIds
+  return [...changedPartIds]
 }
 
 // ─── Public API ──────────────────────────────────────────────────────
 
 /**
  * Recalculate costs for all parts in an organization.
- * Loads all vendor parts and subparts, builds the graph in memory,
- * and persists any changed cost values.
+ *
+ * The scope is every non-archived `part` in the org, NOT the parts reachable
+ * through the vendor/subpart graph — see {@link loadAllPartIds}. That makes a
+ * full sweep self-sufficient: it repairs a frozen value on a part that has
+ * neither a supplier nor a bill of materials, which a graph-derived sweep can
+ * never even visit.
  */
 export async function recalculateAllPartCosts(orgId: string): Promise<string[]> {
+  const fields = await loadCostFields(orgId)
+  if (!fields) return []
+
+  const partDefId = await requireCachedEntityDefId(orgId, 'part')
   const { vendorPrices, subparts } = await loadOrgPricingData(orgId)
-  const { unitPriceMap, landedCostMap } = buildVendorCostMaps(vendorPrices)
+  const { landedCostMap } = buildVendorCostMaps(vendorPrices)
   const subpartGraph = buildSubpartGraph(subparts)
-  const costs = calculateAllCosts(landedCostMap, subpartGraph)
-  const previous = await loadCurrentPartValues(orgId)
-  const changedIds = await persistCosts(orgId, costs, unitPriceMap, previous)
+  const allResults = calculateAllCosts(landedCostMap, subpartGraph)
+
+  const partIds = await loadAllPartIds(orgId, partDefId)
+  const scoped = new Map<string, PartCostResult>()
+  for (const partId of partIds) {
+    scoped.set(partId, allResults.get(partId) ?? UNCOSTED)
+  }
+
+  const previous = await loadCurrentPartValues(orgId, fields)
+  const changedIds = await persistCosts(orgId, scoped, fields, previous)
 
   logger.info('Recalculated all part costs', {
     orgId,
-    totalParts: costs.size,
+    totalParts: scoped.size,
     changedParts: changedIds.length,
   })
 
@@ -599,8 +842,11 @@ export async function recalculateAffectedParts(
   orgId: string,
   affectedPartIds: string[]
 ): Promise<string[]> {
+  const fields = await loadCostFields(orgId)
+  if (!fields) return []
+
   const { vendorPrices, subparts } = await loadOrgPricingData(orgId)
-  const { unitPriceMap, landedCostMap } = buildVendorCostMaps(vendorPrices)
+  const { landedCostMap } = buildVendorCostMaps(vendorPrices)
   const subpartGraph = buildSubpartGraph(subparts)
   const parentGraph = buildParentGraph(subparts)
 
@@ -616,20 +862,18 @@ export async function recalculateAffectedParts(
   for (const id of affectedPartIds) markDirty(id)
 
   // Calculate costs for all parts (memoized, so cheap)
-  const allCosts = calculateAllCosts(landedCostMap, subpartGraph)
+  const allResults = calculateAllCosts(landedCostMap, subpartGraph)
 
-  // Persist values for the dirty set — every member of it, `null` included. The dirty set
-  // IS the scope, so a part that no longer resolves to a cost or a vendor price maps to
-  // `null` and gets cleared, instead of dropping out of the map and keeping a frozen value.
-  const dirtyCosts = new Map<string, number | null>()
-  const dirtyUnitPrices = new Map<string, number | null>()
+  // The dirty set IS the persist scope, so a part that no longer resolves to a
+  // cost maps to `UNCOSTED` and gets cleared, instead of dropping out of the
+  // map and keeping a frozen value.
+  const scoped = new Map<string, PartCostResult>()
   for (const partId of dirtySet) {
-    dirtyCosts.set(partId, allCosts.get(partId) ?? null)
-    dirtyUnitPrices.set(partId, unitPriceMap.get(partId) ?? null)
+    scoped.set(partId, allResults.get(partId) ?? UNCOSTED)
   }
 
-  const previous = await loadCurrentPartValues(orgId)
-  const changedIds = await persistCosts(orgId, dirtyCosts, dirtyUnitPrices, previous)
+  const previous = await loadCurrentPartValues(orgId, fields)
+  const changedIds = await persistCosts(orgId, scoped, fields, previous)
 
   logger.info('Recalculated affected part costs', {
     orgId,
@@ -665,5 +909,18 @@ async function syncCatalogPricingSafely(orgId: string, changedPartIds: string[])
 
 // ─── Exported helpers for BomService ─────────────────────────────────
 
-export { loadOrgPricingData, buildVendorCostMaps, buildSubpartGraph, buildParentGraph }
-export type { VendorPriceRow, VendorCostMaps, SubpartRow, OrgPricingData }
+export {
+  loadOrgPricingData,
+  buildVendorCostMaps,
+  buildSubpartGraph,
+  buildParentGraph,
+  calculateAllCosts,
+}
+export type {
+  VendorPriceRow,
+  VendorCostMaps,
+  SubpartRow,
+  OrgPricingData,
+  PartCostResult,
+  CostSourceValue,
+}

--- a/packages/lib/src/resources/registry/enum-values.ts
+++ b/packages/lib/src/resources/registry/enum-values.ts
@@ -350,6 +350,44 @@ export const StockStatus = {
   ] satisfies FieldOptionItem[],
 } as const
 
+/**
+ * Cost Source Enum
+ * Entity-system field options for `part_cost_source` — which of the two stored
+ * numbers `part_cost` actually took.
+ *
+ * `none` is the point of the field: before it existed, "this part has no cost"
+ * was unrepresentable, so a part that lost its last supplier kept a frozen value
+ * that looked identical to a fresh one.
+ */
+export const CostSource = {
+  VENDOR: 'vendor',
+  BOM: 'bom',
+  NONE: 'none',
+
+  values: [
+    { value: 'vendor', label: 'Supplier', color: 'blue' },
+    { value: 'bom', label: 'Bill of Materials', color: 'teal' },
+    { value: 'none', label: 'Not costed', color: 'amber' },
+  ] satisfies FieldOptionItem[],
+} as const
+
+/**
+ * Part Kind Enum
+ * Entity-system field options for `part_kind` — how a part is classified for
+ * build/sell purposes. Human-set, not computed: NULL reads as `component`.
+ */
+export const PartKind = {
+  COMPONENT: 'component',
+  SUBASSEMBLY: 'subassembly',
+  FINISHED_GOOD: 'finished_good',
+
+  values: [
+    { value: 'component', label: 'Component', color: 'gray' },
+    { value: 'subassembly', label: 'Subassembly', color: 'blue' },
+    { value: 'finished_good', label: 'Finished Good', color: 'green' },
+  ] satisfies FieldOptionItem[],
+} as const
+
 export const VectorDbTypeEnum = {
   POSTGRESQL: 'POSTGRESQL',
   CHROMA: 'CHROMA',

--- a/packages/lib/src/resources/registry/resources/part-fields.ts
+++ b/packages/lib/src/resources/registry/resources/part-fields.ts
@@ -4,7 +4,7 @@ import { FieldType } from '@auxx/database/enums'
 import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
 import { BaseType } from '../../types'
 import { CREATED_BY_FIELD } from '../common-fields'
-import { StockStatus } from '../enum-values'
+import { CostSource, PartKind, StockStatus } from '../enum-values'
 import type { ResourceField } from '../field-types'
 
 /**
@@ -151,24 +151,81 @@ export const PART_FIELDS: Record<string, ResourceField> = {
     description: 'Category tags for this part',
   },
 
-  unitPrice: {
-    id: toFieldId('unitPrice'),
-    key: 'unitPrice',
-    label: 'Unit Price',
+  // ── Cost provenance ────────────────────────────────────────────────
+  // `part_cost` is one output with two meanings; these three name them, so a
+  // NULL carries information instead of being indistinguishable from a frozen
+  // value. All three are written ONLY by `persistCosts` (bom/cost-calculator.ts)
+  // and locked `computed` so no form, import or connector can become a second
+  // writer. None carries `dbColumn` — `cost`'s is a leftover from the pre-entity
+  // `Part` table, not a pattern to copy.
+
+  purchaseCost: {
+    id: toFieldId('purchaseCost'),
+    key: 'purchaseCost',
+    label: 'Purchase Cost',
     type: BaseType.CURRENCY,
     fieldType: FieldType.CURRENCY,
     isSystem: true,
-    systemAttribute: 'part_unit_price',
-    systemSortOrder: 'a5a',
+    systemAttribute: 'part_purchase_cost',
+    systemSortOrder: 'a5b',
+    showInTable: false, // diagnostic — `part_cost` stays the headline column in the parts list
     nullable: true,
     capabilities: {
       filterable: true,
       sortable: true,
       creatable: false,
       updatable: false,
+      computed: true,
       configurable: false,
     },
-    description: 'Raw supplier price from preferred vendor',
+    description:
+      'Landed cost of the winning vendor part, including shipping, tariff and other costs',
+  },
+
+  rollupCost: {
+    id: toFieldId('rollupCost'),
+    key: 'rollupCost',
+    label: 'Roll-up Cost',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'part_rollup_cost',
+    systemSortOrder: 'a5c',
+    showInTable: false, // diagnostic — `part_cost` stays the headline column in the parts list
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      computed: true,
+      configurable: false,
+    },
+    description:
+      'Sum of each subpart cost multiplied by its quantity. Recorded even when a supplier price wins, so buy-vs-build is comparable',
+  },
+
+  costSource: {
+    id: toFieldId('costSource'),
+    key: 'costSource',
+    label: 'Cost Source',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'part_cost_source',
+    systemSortOrder: 'a5d',
+    showInTable: false, // diagnostic — `part_cost` stays the headline column in the parts list
+    nullable: true,
+    options: { options: CostSource.values },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      computed: true,
+      configurable: false,
+    },
+    description: 'Which number Cost took: the supplier price, the bill of materials, or neither',
   },
 
   cost: {
@@ -189,7 +246,7 @@ export const PART_FIELDS: Record<string, ResourceField> = {
       updatable: false,
       configurable: false,
     },
-    description: 'Calculated from vendor parts and BOM',
+    description: 'Replacement cost — current landed cost from live vendor prices',
   },
 
   hsCode: {
@@ -212,6 +269,34 @@ export const PART_FIELDS: Record<string, ResourceField> = {
     },
     placeholder: 'Enter HS code',
     description: 'Harmonized System code for customs',
+  },
+
+  // Ships the FIELD only. `readPartKind` / `shouldExplodeOnSale` and the
+  // `adjustSubparts` change that consume it belong to Gap C and land with their
+  // consumer; an absent value reads NULL and every reader must treat NULL as
+  // `component`, preserving today's explode-on-sale behaviour for every
+  // unclassified part. No backfill.
+  partKind: {
+    id: toFieldId('partKind'),
+    key: 'partKind',
+    label: 'Part Kind',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'part_kind',
+    systemSortOrder: 'a4a',
+    nullable: true,
+    options: { options: PartKind.values },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select part kind',
+    description:
+      'How this part is classified for build and sell purposes. Unset reads as a component',
   },
 
   createdAt: {

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -63,6 +63,7 @@ import { migration059PersonalInboxDef } from './migrations/059-personal-inbox-de
 import { migration062RemoveInboxLensPersonalFields } from './migrations/062-remove-inbox-lens-personal-fields'
 import { migration074TagAiClassify } from './migrations/074-tag-ai-classify'
 import { migration075TagTemplateKey } from './migrations/075-tag-template-key'
+import { migration100PartCostProvenance } from './migrations/100-part-cost-provenance'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -169,6 +170,9 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // space is shared across both directories, so the gap is expected.
   migration074TagAiClassify,
   migration075TagTemplateKey,
+  // 076–099 are pure data migrations (`data-migrations/migrations/`) — the NNN id
+  // space is shared across both directories, so the gap is expected.
+  migration100PartCostProvenance,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/100-part-cost-provenance.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/100-part-cost-provenance.test.ts
@@ -1,0 +1,205 @@
+// packages/lib/src/seed/entity-migrations/migrations/100-part-cost-provenance.test.ts
+//
+// Covers `pruneViewConfigFields`, the one piece of migration 100 with real logic in it
+// (plans/parts/cost-provenance-and-stale-values.md §6.4). Everything else the migration
+// does is `ensureCustomFields` (already covered by its own helper) and a delete.
+//
+// The pruning exists because there is NO foreign key from `TableView` to `CustomField`:
+// deleting `part_unit_price` leaves its id sitting in user-editable jsonb. Two things make
+// that worth a test rather than a one-liner:
+//
+//  1. **There are two config shapes, not one.** Panel/dialog views store
+//     `fieldVisibility`/`fieldOrder`; table/kanban views store
+//     `columnVisibility`/`columnOrder`. The plan named only the first pair, and the two
+//     known dev rows are one of each — pruning one family would have left the other
+//     dangling.
+//  2. **A filter group emptied by pruning matches everything.** Dropping the last
+//     condition from a group reduces it to the bare org scope, so the group has to go
+//     with it. That is the same failure shape as an all-dropped condition set elsewhere
+//     in the product, and it is silent.
+
+import { describe, expect, it } from 'vitest'
+import { pruneViewConfigFields } from './100-part-cost-provenance'
+
+/** The two spellings the same field can appear under in a stored config. */
+const IDS = ['fld_unit_price', 'def_part:fld_unit_price']
+
+describe('pruneViewConfigFields — panel and dialog views', () => {
+  it('removes the field from fieldOrder and fieldVisibility', () => {
+    const { config, changed } = pruneViewConfigFields(
+      {
+        fieldOrder: ['def_part:fld_sku', 'def_part:fld_unit_price', 'def_part:fld_cost'],
+        fieldVisibility: {
+          'def_part:fld_sku': true,
+          'def_part:fld_unit_price': true,
+          'def_part:fld_cost': true,
+        },
+        showLabels: true,
+      },
+      IDS
+    )
+
+    expect(changed).toBe(true)
+    expect(config).toEqual({
+      fieldOrder: ['def_part:fld_sku', 'def_part:fld_cost'],
+      fieldVisibility: { 'def_part:fld_sku': true, 'def_part:fld_cost': true },
+      showLabels: true,
+    })
+  })
+
+  it('matches the bare field id as well as the composed resourceFieldId', () => {
+    // Which spelling a config holds depends on when and by what it was written.
+    const { config, changed } = pruneViewConfigFields(
+      { fieldOrder: ['fld_sku', 'fld_unit_price'], fieldVisibility: { fld_unit_price: false } },
+      IDS
+    )
+
+    expect(changed).toBe(true)
+    expect(config).toEqual({ fieldOrder: ['fld_sku'], fieldVisibility: {} })
+  })
+
+  it('prunes group membership and unsets an anchor pointing at the deleted field', () => {
+    const { config, changed } = pruneViewConfigFields(
+      {
+        fieldOrder: ['def_part:fld_cost'],
+        fieldVisibility: {},
+        fieldGroups: [
+          {
+            id: 'g1',
+            label: 'Pricing',
+            fieldIds: ['def_part:fld_unit_price', 'def_part:fld_cost'],
+            anchorFieldId: 'def_part:fld_unit_price',
+          },
+        ],
+      },
+      IDS
+    )
+
+    expect(changed).toBe(true)
+    const groups = (config as { fieldGroups: Array<Record<string, unknown>> }).fieldGroups
+    expect(groups[0]?.fieldIds).toEqual(['def_part:fld_cost'])
+    // Unset means "render at the end" — the schema's own fallback.
+    expect(groups[0]?.anchorFieldId).toBeUndefined()
+  })
+})
+
+describe('pruneViewConfigFields — table and kanban views', () => {
+  it('removes the field from every column key, not just order and visibility', () => {
+    const { config, changed } = pruneViewConfigFields(
+      {
+        viewType: 'table',
+        columnOrder: ['fld_sku', 'fld_unit_price'],
+        columnVisibility: { fld_sku: true, fld_unit_price: true },
+        columnLabels: { fld_unit_price: 'Unit Price' },
+        columnSizing: { fld_unit_price: 120 },
+        columnFormatting: { fld_unit_price: { style: 'currency' } },
+        columnPinning: { left: ['_checkbox', 'fld_unit_price'], right: [] },
+      },
+      IDS
+    )
+
+    expect(changed).toBe(true)
+    expect(config).toEqual({
+      viewType: 'table',
+      columnOrder: ['fld_sku'],
+      columnVisibility: { fld_sku: true },
+      columnLabels: {},
+      columnSizing: {},
+      columnFormatting: {},
+      columnPinning: { left: ['_checkbox'], right: [] },
+    })
+  })
+
+  it('drops a sort on the deleted field', () => {
+    const { config, changed } = pruneViewConfigFields(
+      {
+        sorting: [
+          { id: 'fld_unit_price', desc: false },
+          { id: 'fld_sku', desc: true },
+        ],
+      },
+      IDS
+    )
+
+    expect(changed).toBe(true)
+    expect((config as { sorting: unknown[] }).sorting).toEqual([{ id: 'fld_sku', desc: true }])
+  })
+
+  it('drops a condition on the deleted field but keeps the rest of its group', () => {
+    const { config, changed } = pruneViewConfigFields(
+      {
+        filters: [
+          {
+            id: 'g1',
+            logicalOperator: 'AND',
+            conditions: [
+              { id: 'c1', fieldId: 'fld_unit_price', operator: 'gt', value: 0 },
+              { id: 'c2', fieldId: 'fld_sku', operator: 'is', value: 'AL400' },
+            ],
+          },
+        ],
+      },
+      IDS
+    )
+
+    expect(changed).toBe(true)
+    const groups = (config as { filters: Array<{ conditions: unknown[] }> }).filters
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.conditions).toEqual([
+      { id: 'c2', fieldId: 'fld_sku', operator: 'is', value: 'AL400' },
+    ])
+  })
+
+  it('drops a filter group whose every condition referenced the deleted field', () => {
+    // Left in place with no conditions, the group reduces to the bare org scope and
+    // matches every row — turning a narrow saved view into "everything", silently.
+    const { config, changed } = pruneViewConfigFields(
+      {
+        filters: [
+          {
+            id: 'g1',
+            logicalOperator: 'AND',
+            conditions: [{ id: 'c1', fieldId: 'fld_unit_price', operator: 'gt', value: 0 }],
+          },
+        ],
+      },
+      IDS
+    )
+
+    expect(changed).toBe(true)
+    expect((config as { filters: unknown[] }).filters).toEqual([])
+  })
+})
+
+describe('pruneViewConfigFields — idempotency and tolerance', () => {
+  it('reports no change when nothing references the field', () => {
+    const original = {
+      fieldOrder: ['def_part:fld_sku'],
+      fieldVisibility: { 'def_part:fld_sku': true },
+    }
+
+    const { config, changed } = pruneViewConfigFields(original, IDS)
+
+    // `changed` is what gates the UPDATE, so a re-run of the migration touches no
+    // row and bumps no `updatedAt` — the config it hands back is unchanged either way.
+    expect(changed).toBe(false)
+    expect(config).toEqual(original)
+  })
+
+  it('is a no-op on a config that is not an object', () => {
+    expect(pruneViewConfigFields(null, IDS)).toEqual({ config: null, changed: false })
+    expect(pruneViewConfigFields('nonsense', IDS)).toEqual({ config: 'nonsense', changed: false })
+    expect(pruneViewConfigFields([1, 2], IDS)).toEqual({ config: [1, 2], changed: false })
+  })
+
+  it('leaves unmodelled keys untouched', () => {
+    // `TableView.config` is jsonb with no DB-level shape, and zod strips unknown keys on
+    // read — a pruner that rebuilt the blob from a parsed shape would drop them for real.
+    const { config } = pruneViewConfigFields(
+      { fieldOrder: ['fld_unit_price'], somethingNobodyModelled: { keep: 'me' } },
+      IDS
+    )
+
+    expect((config as Record<string, unknown>).somethingNobodyModelled).toEqual({ keep: 'me' })
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/100-part-cost-provenance.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/100-part-cost-provenance.ts
@@ -1,0 +1,403 @@
+// packages/lib/src/seed/entity-migrations/migrations/100-part-cost-provenance.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, inArray } from 'drizzle-orm'
+import { recalculateAllPartCosts } from '../../../bom'
+import { getOrgCache } from '../../../cache'
+import { PART_FIELDS } from '../../../resources/registry/resources/part-fields'
+import { ensureCustomFields, loadExistingState } from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:100')
+
+/**
+ * The retired field. `part_unit_price` exposed exactly one of the four
+ * components of a landed cost (raw supplier price, no shipping, tariff or other
+ * cost), had no reader anywhere in the product, and collided head-on with the
+ * Shopify variant price that wants the same slug for the opposite meaning —
+ * a SELL price written by a connector, not a COST written by the recalculator.
+ * Two writers on one column; the connector's price goes to an app field instead.
+ *
+ * `part_purchase_cost` replaces it with the better number: the winning vendor
+ * part's full landed cost.
+ */
+const REMOVED_ATTR = 'part_unit_price'
+
+/** The four fields this migration materializes, for the log line. */
+const ADDED_ATTRS = [
+  'part_purchase_cost',
+  'part_rollup_cost',
+  'part_cost_source',
+  'part_kind',
+] as const
+
+// ─── TableView pruning ───────────────────────────────────────────────
+
+/**
+ * A `TableView.config` blob. Deliberately loose: the column is `jsonb` with no
+ * DB-level shape, two different context families store two different key sets
+ * into it, and zod strips unknown keys on read — so a pruner that insisted on a
+ * parsed shape would drop whatever it did not model.
+ */
+type ViewConfigBlob = Record<string, unknown>
+
+/** Remove `id` from a `{ [resourceFieldId]: … }` map, in place-ish. */
+function pruneRecordKey(config: ViewConfigBlob, key: string, ids: Set<string>): boolean {
+  const value = config[key]
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+
+  const record = value as Record<string, unknown>
+  const survivors = Object.entries(record).filter(([k]) => !ids.has(k))
+  if (survivors.length === Object.keys(record).length) return false
+
+  config[key] = Object.fromEntries(survivors)
+  return true
+}
+
+/** Remove `id` from a `string[]` of resourceFieldIds. */
+function pruneStringArray(config: ViewConfigBlob, key: string, ids: Set<string>): boolean {
+  const value = config[key]
+  if (!Array.isArray(value)) return false
+
+  const survivors = value.filter((entry) => typeof entry !== 'string' || !ids.has(entry))
+  if (survivors.length === value.length) return false
+
+  config[key] = survivors
+  return true
+}
+
+/**
+ * Strip every reference to a deleted field from one `TableView.config`.
+ *
+ * **Why this is required and has no precedent to copy.** There is no foreign key
+ * from `TableView` to `CustomField`, so deleting the field leaves its
+ * `resourceFieldId` sitting in user-editable jsonb. `getOrgFieldView` returns
+ * the raw config and filters nothing — the tolerance lives downstream, where
+ * `mergeFieldOrder` drops ids with no matching registry field on read. But that
+ * merge result is what gets PERSISTED on the next view edit, so the ghost
+ * survives in the stored row until something rewrites it, and anyone reading the
+ * config directly still sees an id pointing at nothing. Clean the row.
+ *
+ * **Two key families, because there are two.** Panel and dialog views store
+ * `fieldVisibility` / `fieldOrder` / `fieldLabels` / `fieldGroups`; table and
+ * kanban views store `columnVisibility` / `columnOrder` / `columnLabels` /
+ * `columnSizing` / `columnFormatting` / `columnPinning`. Only the first pair was
+ * named in the plan; pruning one family would have left the "All Parts" table
+ * view dangling.
+ *
+ * **Filters and sorting are pruned too, and that is not cosmetic.** A condition
+ * on a field that no longer exists cannot compile, and the condition builder
+ * fails OPEN — it drops what it cannot compile, so the filter is already
+ * silently ineffective at query time. Removing it from the config makes the
+ * stored view agree with what the query already does, rather than showing the
+ * user a filter chip that does nothing. A filter GROUP left with no conditions
+ * is dropped as well: an empty group is the bare org scope, which matches
+ * everything.
+ *
+ * @param config - The stored `TableView.config` blob
+ * @param fieldIds - Every id spelling the deleted field can appear under
+ * @returns The pruned config and whether anything was actually removed
+ */
+export function pruneViewConfigFields(
+  config: unknown,
+  fieldIds: readonly string[]
+): { config: unknown; changed: boolean } {
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    return { config, changed: false }
+  }
+
+  const ids = new Set(fieldIds)
+  const next = { ...(config as ViewConfigBlob) }
+  let changed = false
+
+  const recordKeys = [
+    'fieldVisibility',
+    'fieldLabels',
+    'columnVisibility',
+    'columnLabels',
+    'columnSizing',
+    'columnFormatting',
+  ]
+  for (const key of recordKeys) {
+    if (pruneRecordKey(next, key, ids)) changed = true
+  }
+
+  for (const key of ['fieldOrder', 'columnOrder']) {
+    if (pruneStringArray(next, key, ids)) changed = true
+  }
+
+  // columnPinning: { left?: string[], right?: string[] }
+  const pinning = next.columnPinning
+  if (pinning && typeof pinning === 'object' && !Array.isArray(pinning)) {
+    const pinned = { ...(pinning as ViewConfigBlob) }
+    let pinnedChanged = false
+    for (const side of ['left', 'right']) {
+      if (pruneStringArray(pinned, side, ids)) pinnedChanged = true
+    }
+    if (pinnedChanged) {
+      next.columnPinning = pinned
+      changed = true
+    }
+  }
+
+  // fieldGroups: [{ fieldIds: string[], anchorFieldId?: string }]
+  if (Array.isArray(next.fieldGroups)) {
+    let groupsChanged = false
+    const groups = next.fieldGroups.map((group) => {
+      if (!group || typeof group !== 'object' || Array.isArray(group)) return group
+      const copy = { ...(group as ViewConfigBlob) }
+      if (pruneStringArray(copy, 'fieldIds', ids)) groupsChanged = true
+      if (typeof copy.anchorFieldId === 'string' && ids.has(copy.anchorFieldId)) {
+        // Unset means "render at the end" — the schema's own fallback.
+        copy.anchorFieldId = undefined
+        groupsChanged = true
+      }
+      return copy
+    })
+    if (groupsChanged) {
+      next.fieldGroups = groups
+      changed = true
+    }
+  }
+
+  // sorting: [{ id, desc }] — a sort on a field that no longer exists is inert.
+  if (Array.isArray(next.sorting)) {
+    const survivors = next.sorting.filter((entry) => {
+      if (!entry || typeof entry !== 'object') return true
+      const id = (entry as ViewConfigBlob).id
+      return typeof id !== 'string' || !ids.has(id)
+    })
+    if (survivors.length !== next.sorting.length) {
+      next.sorting = survivors
+      changed = true
+    }
+  }
+
+  // filters: [{ conditions: [{ fieldId }] }] — see the JSDoc note above.
+  if (Array.isArray(next.filters)) {
+    let filtersChanged = false
+    const groups: unknown[] = []
+    for (const group of next.filters) {
+      if (!group || typeof group !== 'object' || Array.isArray(group)) {
+        groups.push(group)
+        continue
+      }
+      const copy = { ...(group as ViewConfigBlob) }
+      if (Array.isArray(copy.conditions)) {
+        const survivors = copy.conditions.filter((condition) => {
+          if (!condition || typeof condition !== 'object') return true
+          const fieldId = (condition as ViewConfigBlob).fieldId
+          return typeof fieldId !== 'string' || !ids.has(fieldId)
+        })
+        if (survivors.length !== copy.conditions.length) {
+          filtersChanged = true
+          // A group with every condition dropped reduces to the bare org scope,
+          // which matches every row. Drop the group instead of widening the view.
+          if (survivors.length === 0) continue
+          copy.conditions = survivors
+        }
+      }
+      groups.push(copy)
+    }
+    if (filtersChanged) {
+      next.filters = groups
+      changed = true
+    }
+  }
+
+  return { config: next, changed }
+}
+
+// ─── Migration ───────────────────────────────────────────────────────
+
+/**
+ * Migration 100: give `part_cost` provenance, and retire `part_unit_price`.
+ *
+ * `part_cost` is one stored output with two silent meanings — the landed vendor
+ * cost of a purchased part, and the sum of its children for an assembly — with
+ * nothing on the record saying which. That is why a `NULL` there carried no
+ * information, and why a part that lost its last supplier could keep a frozen
+ * number indistinguishable from a fresh one. This migration materializes the
+ * fields that make the distinction expressible:
+ *
+ *  - `part_purchase_cost` — the winning vendor part's landed cost
+ *  - `part_rollup_cost`   — the bill-of-materials sum, recorded even when a
+ *                           vendor price wins, so buy-vs-build is comparable
+ *  - `part_cost_source`   — `vendor` / `bom` / `none`; `none` is the point,
+ *                           because "not costed" was previously unrepresentable
+ *  - `part_kind`          — human classification (`component` / `subassembly` /
+ *                           `finished_good`). The FIELD only: its consumers land
+ *                           with the build-event work. No backfill — an absent
+ *                           value reads NULL and every reader treats NULL as
+ *                           `component`, preserving today's behaviour.
+ *
+ * `part_cost` itself keeps its slug, its consumers and its position; the new
+ * fields sit underneath it.
+ *
+ * **No DDL.** Pure `CustomField` + `FieldValue` + registry, like every entity
+ * migration here.
+ *
+ * **No view rebuild, and none needed.** `ensureFieldViews` deliberately skips
+ * any entity/context that already has a view — those rows are user-editable and
+ * a migration must not reorder them. The new fields still surface everywhere,
+ * because both read paths merge against the LIVE registry rather than trusting
+ * the stored config: `mergeFieldOrder` (web) walks the baseline id list and
+ * splices any id missing from the stored `fieldOrder` in at its `sortOrder`
+ * anchor, so `a5b`/`a5c`/`a5d` land directly above `part_cost` (`a6`) instead of
+ * dead last; and `resolveFieldVisible` falls back to the registry default when a
+ * field has no explicit `fieldVisibility` entry. The three computed fields carry
+ * `showInTable: false`, so they join the panel but not the parts list — that is
+ * the registry's call, not this migration's.
+ *
+ * Idempotent — `ensureCustomFields` is insert-only, the delete finds no row on a
+ * re-run, and the view pruning is a no-op once nothing references the field.
+ */
+export const migration100PartCostProvenance: EntityMigration = {
+  id: '100-part-cost-provenance',
+  description:
+    'Add part cost provenance fields (purchase cost, roll-up cost, cost source) plus part kind, and remove the retired part_unit_price field',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const partDef = existing.entityDefs.get('part')
+    if (!partDef) {
+      return { ...state, alreadyUpToDate: true }
+    }
+
+    // ── 1. Materialize the four new fields ──
+    // Insert-only: every field already present is returned and skipped, so this
+    // creates exactly the ones missing.
+    await ensureCustomFields(db, organizationId, 'part', partDef.id, PART_FIELDS, existing, state)
+
+    // ── 2. Retire `part_unit_price` ──
+    const [retired] = await db
+      .select({ id: schema.CustomField.id })
+      .from(schema.CustomField)
+      .where(
+        and(
+          eq(schema.CustomField.organizationId, organizationId),
+          eq(schema.CustomField.entityDefinitionId, partDef.id),
+          eq(schema.CustomField.systemAttribute, REMOVED_ATTR)
+        )
+      )
+      .limit(1)
+
+    let valuesRemoved = 0
+    let viewsPruned = 0
+
+    if (retired) {
+      // `FieldValue_fieldId_CustomField_id_fk` is ON DELETE CASCADE, so this is
+      // belt-and-braces — but an explicit delete gives a countable result and
+      // matches how `057-remove-signature-visibility-field` does it.
+      const deleted = await db
+        .delete(schema.FieldValue)
+        .where(eq(schema.FieldValue.fieldId, retired.id))
+        .returning({ id: schema.FieldValue.id })
+      valuesRemoved = deleted.length
+
+      await db.delete(schema.CustomField).where(eq(schema.CustomField.id, retired.id))
+
+      viewsPruned = await pruneRetiredFieldFromViews(db, organizationId, partDef.id, retired.id)
+    }
+
+    const alreadyUpToDate = state.fieldsCreated === 0 && !retired && viewsPruned === 0
+
+    if (!alreadyUpToDate) {
+      logger.info('Migration 100 applied', {
+        organizationId,
+        addedAttrs: ADDED_ATTRS.length,
+        fieldsCreated: state.fieldsCreated,
+        removedField: retired?.id ?? null,
+        valuesRemoved,
+        viewsPruned,
+      })
+
+      await populateProvenance(organizationId)
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}
+
+/**
+ * Strip the retired field from every `TableView` belonging to the part def.
+ *
+ * Matches BOTH spellings an id can appear under: the bare `CustomField.id` and
+ * the composed `resourceFieldId` (`<entityDefinitionId>:<fieldId>`). Which one a
+ * given config holds depends on when and by what the view was written, so
+ * matching only one keyspace would silently leave half the rows dangling.
+ *
+ * @returns How many view rows were rewritten
+ */
+async function pruneRetiredFieldFromViews(
+  db: Database,
+  organizationId: string,
+  partDefId: string,
+  retiredFieldId: string
+): Promise<number> {
+  const spellings = [retiredFieldId, `${partDefId}:${retiredFieldId}`]
+
+  // Panel/dialog views key `tableId` on the bare def id; table/kanban views use
+  // the `entity-<defId>` form. Both are matched rather than parsed.
+  const views = await db
+    .select({ id: schema.TableView.id, config: schema.TableView.config })
+    .from(schema.TableView)
+    .where(
+      and(
+        eq(schema.TableView.organizationId, organizationId),
+        inArray(schema.TableView.tableId, [partDefId, `entity-${partDefId}`])
+      )
+    )
+
+  let pruned = 0
+  for (const view of views) {
+    const { config, changed } = pruneViewConfigFields(view.config, spellings)
+    if (!changed) continue
+    await db
+      .update(schema.TableView)
+      .set({ config, updatedAt: new Date() })
+      .where(eq(schema.TableView.id, view.id))
+    pruned++
+  }
+
+  return pruned
+}
+
+/**
+ * Fill the three computed provenance fields for every part in the org.
+ *
+ * A full authoritative sweep, which also clears anything already stale: the
+ * calculator's scope is every non-archived part, not the parts reachable through
+ * the vendor/subpart graph, so a part with neither a supplier nor a bill of
+ * materials is visited too. That is what makes a separate backfill pass
+ * unnecessary.
+ *
+ * **The cache has to be flushed first.** The migration runner recomputes
+ * `customFields` only AFTER `up()` returns, so the calculator would otherwise
+ * resolve its fields against a cached map that predates this migration — it
+ * would not see the three new fields at all, and would still see the one just
+ * deleted.
+ *
+ * **Failure is logged, not fatal.** The schema change above is the migration;
+ * populating derived numbers is a convenience that the next vendor-price or
+ * subpart edit would do anyway. Failing the migration over it would block every
+ * later migration for this org.
+ */
+async function populateProvenance(organizationId: string): Promise<void> {
+  try {
+    await getOrgCache().invalidateAndRecompute(organizationId, ['customFields', 'resources'])
+    const changed = await recalculateAllPartCosts(organizationId)
+    logger.info('Populated part cost provenance', {
+      organizationId,
+      partsUpdated: changed.length,
+    })
+  } catch (error) {
+    logger.error('Failed to populate part cost provenance — fields created, values not filled', {
+      organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -129,7 +129,16 @@ export const SYSTEM_ATTRIBUTES = [
   'part_image',
   'part_sku',
   'category',
-  'part_unit_price',
+  'part_kind',
+  // Cost provenance. `part_cost` keeps its meaning (replacement cost — the
+  // current landed cost from live vendor prices); the two below name the
+  // numbers it chooses BETWEEN, and `part_cost_source` says which one won.
+  // `part_unit_price` was removed here: it exposed 1 of the 4 landed-cost
+  // components, had no reader, and collided with Shopify's variant price —
+  // which lands in an app field instead.
+  'part_purchase_cost',
+  'part_rollup_cost',
+  'part_cost_source',
   'part_cost',
   'hs_code',
   'part_vendor_parts',


### PR DESCRIPTION
Phases 2 and 3 of the part-cost provenance plan. Phase 0 (the stale-value
defect) shipped in #1824; phase 1 was the decision to delete
`part_unit_price` rather than repurpose it.

## The problem

`part_cost` is one output with two silent meanings — the landed vendor cost
for a purchased part, and `sum(child cost x qty)` for an assembly — and
nothing on the record says which. `calc()` hardcodes *vendor always beats
BOM*, so a part with both reports the buy price and gives no hint a build
price exists.

Two consequences: a cleared value is indistinguishable from a real one
(there is no field whose nullity carries information), and buy-vs-build is
unaskable because only the winner is ever stored.

## What changes

**Three computed fields name the pieces.** `part_purchase_cost` is the
winning supplier's landed cost. `part_rollup_cost` is the BOM sum, recorded
**even when a supplier wins** — that is the whole comparison.
`part_cost_source` is `vendor` / `bom` / `none`. `none` is the point: it was
previously unrepresentable, which is why a stale value had nowhere to go.
All three are `computed: true, creatable: false, updatable: false` so no
form, import or connector can become a second writer.

**An unpriced part no longer reports $0.00.** An unpriced leaf yields `null`
with source `none` instead of `0`, and that null propagates — an assembly
with any unpriced descendant has no cost rather than a confidently wrong
one. A zero-cost COGS posting is exactly what build-event costing forbids.
`PartCostResult` also carries `unpricedDescendantIds` (derived, never
persisted) so a future surface can say *which* components are missing a
price rather than just going blank.

**`part_unit_price` is deleted.** It had no reader — only the calculator
that wrote it — and exposed 1 of the 4 landed-cost components.
`part_purchase_cost` replaces it with the better number. It also collided
with the Shopify variant price wanting the same slug for a *sell* price;
that goes to an app field instead, matching how `inventory_quantity`
already avoids `part_quantity_on_hand`. Two writers, one column, ledger
loses.

**Full sweeps are now self-sufficient.** `recalculateAllPartCosts` scopes to
every non-archived part in the org rather than to the ids reachable from
the vendor/subpart graph. A part with neither a supplier nor a BOM was
previously unreachable by a full sweep, so a frozen value on it could never
be repaired — that needed a one-off script. It doesn't now.

**`part_kind`** (component / subassembly / finished_good) ships as the field
only. `readPartKind` / `shouldExplodeOnSale` land with build-event costing.
Absent value reads NULL and is treated as `component`, so behaviour for
every unclassified part is unchanged.

## Migration 100

Materializes the four fields, deletes `part_unit_price` with its values,
prunes the dead id out of view configs, and resweeps costs. Two things
worth a reviewer's eye:

- **The prune covers both key families.** Panel views use
  `fieldOrder`/`fieldVisibility`; table and kanban use
  `columnOrder`/`columnVisibility`/etc. There is no FK from `TableView` to
  `CustomField`, so pruning one family would leave the other dangling — and
  the two rows in dev are one of each. It also prunes field groups, sorting
  and filters, dropping whole any filter group whose every condition
  referenced the deleted field, because an empty group collapses to the
  bare org scope and would then match every row.
- **The resweep invalidates the org cache first.** The runner only
  recomputes `customFields` *after* `up()` returns, so a recalc called from
  inside the migration would read a stale cache — not seeing the three new
  fields, still seeing the deleted one. Recalc failure is logged, not fatal.

New fields do surface in existing orgs without touching their saved views:
`mergeFieldOrder` returns the baseline ids and splices missing ones in at
their `sortOrder` anchor, and `resolveFieldVisible` defaults to visible
absent an explicit entry. The three computed fields carry
`showInTable: false` so they don't become new default columns in the parts
list; all four keep a panel row.

## Verification

- `src/bom` + `src/seed/entity-migrations`: 6 files, 54 tests, 0 failures.
- Wider `src/bom src/money src/field-hooks src/seed src/resources`: 962
  passed, 10 skipped, 0 failed.
- `tsc --noEmit` on `packages/lib`: zero errors in any file this branch
  touches. The pre-existing errors are all in `scripts/` and
  `vitest.integration.config.ts`.
- Biome clean on all 8 files.
- `resolve-resource-trigger-match.test.ts` flakes on a 10s timeout in large
  parallel runs. Confirmed pre-existing and unrelated: it reproduces under
  `src/workflow-engine`, which this branch never touches, and it burns 6.9s
  of its 10s budget in complete isolation on a cold dynamic import. Worth
  its own fix.

## Not in this PR

The drawer landed-cost breakdown on the Suppliers tab, and marking which
supplier row actually won. Today the tab stars *preferred*, which is not the
same thing — the rule is preferred-group-first, then cheapest landed — so
when nothing is starred the winner is invisible. Separately,
`part-vendors-tab-row.tsx` renders a dash in its Landed column whenever
landed equals unit price, which is most rows.

Behaviour note for review: any part currently reading `$0.00` because of the
old zero-rollup goes blank after this. Dev has none (0 of 15 costed parts
sit at zero); worth a look at prod before merge.
