### PR TITLE
fix(files): repair multipart uploads, and extract presign and object ops

### DIFF
--- a/packages/lib/src/files/__tests__/support/storage.ts
+++ b/packages/lib/src/files/__tests__/support/storage.ts
@@ -56,6 +56,7 @@ const EXPIRES = new Date('2026-01-01T01:00:00.000Z')
  */
 const DEFAULTS: { [K in keyof StoragePort]: () => Awaited<ReturnType<StoragePort[K]>> } = {
   presignUpload: () => ({ url: 'https://s3.test/upload', method: 'PUT', expiresAt: EXPIRES }),
+  startMultipart: () => ({ uploadId: 'upload-1', expiresAt: EXPIRES }),
   presignPart: () => ({ url: 'https://s3.test/part', method: 'PUT', expiresAt: EXPIRES }),
   completeMultipart: () => ({ etag: 'etag-complete', size: 1024 }),
   head: () => ({ name: 'file.bin', size: 1024, mimeType: 'application/octet-stream' }),
@@ -95,6 +96,10 @@ export function makeStoragePort(options: MakeStoragePortOptions = {}): FakeStora
     presignUpload: async (p) => {
       record('presignUpload', p)
       return options.impl?.presignUpload?.(p) ?? resultFor('presignUpload')
+    },
+    startMultipart: async (p) => {
+      record('startMultipart', p)
+      return options.impl?.startMultipart?.(p) ?? resultFor('startMultipart')
     },
     presignPart: async (p) => {
       record('presignPart', p)

--- a/packages/lib/src/files/storage/__tests__/objects.test.ts
+++ b/packages/lib/src/files/storage/__tests__/objects.test.ts
@@ -1,0 +1,205 @@
+// packages/lib/src/files/storage/__tests__/objects.test.ts
+
+/**
+ * `storage/objects.ts` against a fake {@link StoragePort}. **Zero `vi.mock`.**
+ *
+ * These five functions are thin by design, so the assertions are about the two
+ * things that are not thin: the bucket reaching the port unchanged (the
+ * #1816/#1817/#1818 family of bugs), and the error mapping that keeps a
+ * not-found from arriving at a caller as "Internal error".
+ */
+
+import { Readable } from 'node:stream'
+import { describe, expect, it } from 'vitest'
+import { makeStoragePort, TEST_BUCKETS, TEST_IDS } from '../../__tests__/support'
+import {
+  StorageAdapterError,
+  StorageAuthError,
+  StorageFileNotFoundError,
+} from '../../adapters/base-adapter'
+import { deleteObject, getObject, headObject, putObject, streamObject } from '../objects'
+
+const KEY = `${TEST_IDS.organizationId}/media-asset/ast_test/test-image.png`
+
+describe('putObject', () => {
+  it('forwards content, bucket and metadata, and returns what the provider reported', async () => {
+    const storage = makeStoragePort({ results: { putObject: { etag: 'e1', size: 4 } } })
+
+    const result = await putObject(storage.port, {
+      provider: 'S3',
+      bucket: TEST_BUCKETS.public,
+      key: KEY,
+      content: Buffer.from('test'),
+      mimeType: 'image/png',
+      size: 4,
+      metadata: { organizationId: TEST_IDS.organizationId },
+    })
+
+    expect(result._unsafeUnwrap()).toEqual({ etag: 'e1', size: 4 })
+    const params = storage.callsTo('putObject')[0]?.params
+    expect(params?.bucket).toBe(TEST_BUCKETS.public)
+    expect(params?.metadata).toEqual({ organizationId: TEST_IDS.organizationId })
+  })
+
+  it('passes a stream body through untouched', async () => {
+    const storage = makeStoragePort()
+    const body = Readable.from([Buffer.from('chunk')])
+
+    await putObject(storage.port, {
+      provider: 'S3',
+      bucket: TEST_BUCKETS.private,
+      key: KEY,
+      content: body,
+    })
+
+    expect(storage.callsTo('putObject')[0]?.params.content).toBe(body)
+  })
+})
+
+describe('getObject', () => {
+  it('returns the buffer the port produced', async () => {
+    const storage = makeStoragePort({ results: { getObject: Buffer.from('hello') } })
+
+    const result = await getObject(storage.port, {
+      provider: 'S3',
+      bucket: TEST_BUCKETS.private,
+      key: KEY,
+    })
+
+    expect(result._unsafeUnwrap().toString()).toBe('hello')
+  })
+
+  it('forwards versionId when the caller targets one', async () => {
+    const storage = makeStoragePort()
+
+    await getObject(storage.port, {
+      provider: 'S3',
+      bucket: TEST_BUCKETS.private,
+      key: KEY,
+      versionId: 'v2',
+    })
+
+    expect(storage.callsTo('getObject')[0]?.params.versionId).toBe('v2')
+  })
+
+  it('maps a missing object to NotFoundError rather than a generic 500', async () => {
+    const storage = makeStoragePort({
+      impl: {
+        getObject: () => {
+          throw new StorageFileNotFoundError('S3', KEY)
+        },
+      },
+    })
+
+    const error = (
+      await getObject(storage.port, { provider: 'S3', bucket: TEST_BUCKETS.private, key: KEY })
+    )._unsafeUnwrapErr()
+
+    expect(error.statusCode).toBe(404)
+    expect(error.message).toBe(`File not found: ${KEY}`)
+  })
+})
+
+describe('streamObject', () => {
+  it('returns the stream unbuffered', async () => {
+    const stream = Readable.from([Buffer.from('a'), Buffer.from('b')])
+    const storage = makeStoragePort({ results: { streamObject: stream } })
+
+    const result = await streamObject(storage.port, {
+      provider: 'S3',
+      bucket: TEST_BUCKETS.private,
+      key: KEY,
+    })
+
+    expect(result._unsafeUnwrap()).toBe(stream)
+  })
+
+  it('maps an auth failure to UnauthorizedError', async () => {
+    const storage = makeStoragePort({
+      impl: {
+        streamObject: () => {
+          throw new StorageAuthError('S3', 'openDownloadStream')
+        },
+      },
+    })
+
+    const error = (
+      await streamObject(storage.port, { provider: 'S3', bucket: TEST_BUCKETS.private, key: KEY })
+    )._unsafeUnwrapErr()
+
+    expect(error.statusCode).toBe(401)
+  })
+})
+
+describe('headObject', () => {
+  it('returns provider metadata verbatim', async () => {
+    const storage = makeStoragePort({
+      results: {
+        head: { name: 'test-image.png', size: 4096, mimeType: 'image/png', etagOrRev: 'e9' },
+      },
+    })
+
+    const result = await headObject(storage.port, {
+      provider: 'S3',
+      bucket: TEST_BUCKETS.public,
+      key: KEY,
+    })
+
+    expect(result._unsafeUnwrap()).toEqual({
+      name: 'test-image.png',
+      size: 4096,
+      mimeType: 'image/png',
+      etagOrRev: 'e9',
+    })
+  })
+
+  it('heads the bucket it was given, not a configured default', async () => {
+    const storage = makeStoragePort()
+
+    await headObject(storage.port, { provider: 'S3', bucket: TEST_BUCKETS.public, key: KEY })
+
+    expect(storage.callsTo('head')[0]?.params.bucket).toBe(TEST_BUCKETS.public)
+  })
+})
+
+describe('deleteObject', () => {
+  it('deletes from the bucket it was given', async () => {
+    const storage = makeStoragePort()
+
+    const result = await deleteObject(storage.port, {
+      provider: 'S3',
+      bucket: TEST_BUCKETS.public,
+      key: KEY,
+      credentialId: TEST_IDS.credentialId,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(storage.callsTo('deleteObject')[0]?.params).toEqual({
+      provider: 'S3',
+      bucket: TEST_BUCKETS.public,
+      key: KEY,
+      credentialId: TEST_IDS.credentialId,
+    })
+  })
+
+  it('reports a refused delete instead of resolving quietly', async () => {
+    // The adapter throws when the location cannot name a bucket, precisely so a
+    // wrong-bucket delete cannot 204 its way to looking successful.
+    const storage = makeStoragePort({
+      impl: {
+        deleteObject: () => {
+          throw new StorageAdapterError(
+            `Cannot delete S3 object '${KEY}': no bucket on the storage location.`,
+            'S3',
+            'deleteFile'
+          )
+        },
+      },
+    })
+
+    const result = await deleteObject(storage.port, { provider: 'S3', bucket: '', key: KEY })
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('no bucket on the storage location')
+  })
+})

--- a/packages/lib/src/files/storage/__tests__/policy-enforcement.test.ts
+++ b/packages/lib/src/files/storage/__tests__/policy-enforcement.test.ts
@@ -112,7 +112,11 @@ vi.mock('../../adapters/s3-adapter', () => ({
     }
 
     presignUpload = mockPresignUpload
-    startMultipartUpload = mockStartMultipartUpload
+    // The adapter method is `startMultipart`. Until PR 3d `StorageManager` called
+    // `(adapter as any).startMultipartUpload` — a name S3Adapter has never had —
+    // and this double happily grew the wrong name to match, so the test passed
+    // while every real multipart upload threw. The `as any` was what hid it.
+    startMultipart = mockStartMultipartUpload
     putObject = mockPutObject
   },
 }))
@@ -464,7 +468,7 @@ describe('StorageManager – enforcePolicy via generatePresignedUploadUrl', () =
       await expect(manager.generatePresignedUploadUrl(config)).resolves.toBeDefined()
     })
 
-    it('passes visibility and bucket through to the adapter', async () => {
+    it('passes the explicit bucket through to the adapter, and only the bucket', async () => {
       const config = buildConfig({
         visibility: 'PUBLIC',
         bucket: 'my-public-bucket',
@@ -472,12 +476,13 @@ describe('StorageManager – enforcePolicy via generatePresignedUploadUrl', () =
 
       await expect(manager.generatePresignedUploadUrl(config)).resolves.toBeDefined()
 
-      expect(mockPresignUpload).toHaveBeenCalledWith(
-        expect.objectContaining({
-          visibility: 'PUBLIC',
-          bucket: 'my-public-bucket',
-        })
-      )
+      const [params] = mockPresignUpload.mock.calls[0]!
+      expect(params).toEqual(expect.objectContaining({ bucket: 'my-public-bucket' }))
+      // `visibility` is deliberately NOT forwarded since PR 3d. The adapter would
+      // re-derive a bucket from it, which is a second resolution for one object
+      // that can disagree with the first — the shape of #1816/#1817/#1818.
+      // `UploadPreparedConfig.bucket` is required, so there is nothing to guess.
+      expect(params).not.toHaveProperty('visibility')
     })
 
     it('passes orgId and uploader metadata to the adapter', async () => {
@@ -501,7 +506,11 @@ describe('StorageManager – enforcePolicy via generatePresignedUploadUrl', () =
           id: 'loc_123',
           provider: 'S3',
           externalId: 'thumbs/avatar.webp',
-          externalUrl: 'https://test-public-bucket.s3.amazonaws.com/thumbs/avatar.webp',
+          // Rendered by `storage/buckets.ts` since PR 3d, not by
+          // `adapter.buildExternalUrl` — one URL builder for the port, the
+          // adapter and this facade. `configService.get` is a bare `vi.fn()`
+          // here, so `S3_REGION` is undefined and the module default applies.
+          externalUrl: 'https://test-public-bucket.s3.us-west-1.amazonaws.com/thumbs/avatar.webp',
           externalRev: 'etag-123',
           credentialId: null,
           size: BigInt(4),
@@ -525,19 +534,28 @@ describe('StorageManager – enforcePolicy via generatePresignedUploadUrl', () =
         })
       ).resolves.toBeDefined()
 
-      expect(mockPutObject).toHaveBeenCalledWith(
+      // The bucket is resolved ONCE, by the facade, and the same value reaches
+      // the object write, the external URL and the persisted row. `visibility`
+      // no longer travels to the adapter for it to re-derive.
+      const [putParams] = mockPutObject.mock.calls[0]!
+      expect(putParams).toEqual(
         expect.objectContaining({
           key: 'thumbs/avatar.webp',
-          visibility: 'PUBLIC',
+          bucket: 'test-public-bucket',
         })
       )
+      expect(putParams).not.toHaveProperty('visibility')
 
       expect(createStorageLocation).toHaveBeenCalledWith(
         // tx, then ctx — the scope comes from the manager, never from the input.
         expect.anything(),
         expect.objectContaining({ organizationId: 'org123' }),
         expect.objectContaining({
-          externalUrl: 'https://test-public-bucket.s3.amazonaws.com/thumbs/avatar.webp',
+          // Rendered by `storage/buckets.ts` since PR 3d, not by
+          // `adapter.buildExternalUrl` — one URL builder for the port, the
+          // adapter and this facade. `configService.get` is a bare `vi.fn()`
+          // here, so `S3_REGION` is undefined and the module default applies.
+          externalUrl: 'https://test-public-bucket.s3.us-west-1.amazonaws.com/thumbs/avatar.webp',
           // The bucket is now a required top-level field, not something a reader
           // has to dig out of `metadata` — that is the #1816/#1817/#1818 fix.
           bucket: 'test-public-bucket',

--- a/packages/lib/src/files/storage/__tests__/presign.test.ts
+++ b/packages/lib/src/files/storage/__tests__/presign.test.ts
@@ -1,0 +1,241 @@
+// packages/lib/src/files/storage/__tests__/presign.test.ts
+
+/**
+ * `storage/presign.ts` against a fake {@link StoragePort}. **Zero `vi.mock`.**
+ *
+ * What these four functions are *for* is the policy gate and the bucket that
+ * travels with a multipart upload, so that is what is asserted: which calls
+ * reach the port at all, what they carry, and what a port failure turns into.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { makeStoragePort, TEST_BUCKETS, TEST_IDS } from '../../__tests__/support'
+import {
+  StorageAdapterError,
+  StorageAuthError,
+  StorageFileNotFoundError,
+} from '../../adapters/base-adapter'
+import type { UploadPreparedConfig } from '../../upload/init-types'
+import type { PresignUploadParams } from '../ports'
+import { completeMultipart, presignPart, presignUpload, startMultipartUpload } from '../presign'
+
+function aPlan(overrides: Partial<UploadPreparedConfig> = {}): PresignUploadParams {
+  return {
+    organizationId: TEST_IDS.organizationId,
+    userId: TEST_IDS.userId,
+    fileName: 'report.pdf',
+    mimeType: 'application/pdf',
+    expectedSize: 1024,
+    entityType: 'FILE',
+    entityId: 'ent_1',
+    provider: 'S3',
+    storageKey: `${TEST_IDS.organizationId}/file/report.pdf`,
+    ttlSec: 600,
+    visibility: 'PRIVATE',
+    bucket: TEST_BUCKETS.private,
+    policy: {
+      keyPrefix: `${TEST_IDS.organizationId}/`,
+      contentLengthRange: [0, 10 * 1024 * 1024],
+      maxTtl: 3600,
+      allowedMimeTypes: ['application/pdf'],
+    },
+    uploadPlan: { strategy: 'single' },
+    ...overrides,
+  }
+}
+
+describe('presignUpload', () => {
+  it('forwards the whole prepared config to the port and returns its answer', async () => {
+    const storage = makeStoragePort()
+    const plan = aPlan()
+
+    const result = await presignUpload(storage.port, plan)
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap().url).toBe('https://s3.test/upload')
+    expect(storage.callsTo('presignUpload')).toHaveLength(1)
+    expect(storage.callsTo('presignUpload')[0]?.params).toEqual(plan)
+  })
+
+  it('enforces the policy BEFORE the port is touched', async () => {
+    const storage = makeStoragePort()
+
+    const result = await presignUpload(storage.port, aPlan({ storageKey: 'someone-else/x.pdf' }))
+
+    expect(result.isErr()).toBe(true)
+    expect(result._unsafeUnwrapErr().message).toContain('Key must start with')
+    // The point of the ordering: a rejected upload must never be signed.
+    expect(storage.calls).toHaveLength(0)
+  })
+
+  it('maps a not-found adapter error to NotFoundError, keeping the message', async () => {
+    const storage = makeStoragePort({
+      impl: {
+        presignUpload: () => {
+          throw new StorageFileNotFoundError('S3', 'org_test/file/report.pdf')
+        },
+      },
+    })
+
+    const result = await presignUpload(storage.port, aPlan())
+
+    const error = result._unsafeUnwrapErr()
+    expect(error.statusCode).toBe(404)
+    expect(error.message).toBe('File not found: org_test/file/report.pdf')
+    // The original is still reachable, which is what keeps StorageManager's
+    // throw shape unchanged for its legacy callers.
+    expect(error.cause).toBeInstanceOf(StorageFileNotFoundError)
+  })
+
+  it('maps an auth adapter error to UnauthorizedError', async () => {
+    const storage = makeStoragePort({
+      impl: {
+        presignUpload: () => {
+          throw new StorageAuthError('S3', 'presignUpload')
+        },
+      },
+    })
+
+    const error = (await presignUpload(storage.port, aPlan()))._unsafeUnwrapErr()
+    expect(error.statusCode).toBe(401)
+    expect(error.message).toBe('Authentication failed for S3')
+  })
+
+  it('maps a generic adapter error to a 500 that still names the failure', async () => {
+    const storage = makeStoragePort({
+      impl: {
+        presignUpload: () => {
+          throw new StorageAdapterError('S3 presignUpload failed: boom', 'S3', 'presignUpload')
+        },
+      },
+    })
+
+    const error = (await presignUpload(storage.port, aPlan()))._unsafeUnwrapErr()
+    expect(error.statusCode).toBe(500)
+    // The plain `files/guard.ts` would have flattened this to 'Internal error'.
+    expect(error.message).toBe('S3 presignUpload failed: boom')
+  })
+})
+
+describe('startMultipartUpload', () => {
+  it('enforces the same policy and forwards to the port', async () => {
+    const storage = makeStoragePort()
+    const plan = aPlan({ uploadPlan: { strategy: 'multipart' } })
+
+    const result = await startMultipartUpload(storage.port, plan)
+
+    expect(result._unsafeUnwrap().uploadId).toBe('upload-1')
+    expect(storage.callsTo('startMultipart')[0]?.params).toEqual(plan)
+  })
+
+  it('rejects a MIME the policy does not allow, without opening an upload', async () => {
+    const storage = makeStoragePort()
+
+    const result = await startMultipartUpload(
+      storage.port,
+      aPlan({ mimeType: 'application/x-msdownload', uploadPlan: { strategy: 'multipart' } })
+    )
+
+    expect(result._unsafeUnwrapErr().message).toContain("MIME 'application/x-msdownload'")
+    expect(storage.calls).toHaveLength(0)
+  })
+
+  it('carries the plan bucket, which every later part and the completion must reuse', async () => {
+    const storage = makeStoragePort()
+    const plan = aPlan({ bucket: TEST_BUCKETS.public, visibility: 'PUBLIC' })
+
+    await startMultipartUpload(storage.port, plan)
+
+    expect(storage.callsTo('startMultipart')[0]?.params.bucket).toBe(TEST_BUCKETS.public)
+  })
+})
+
+describe('presignPart', () => {
+  it('forwards the part descriptor verbatim', async () => {
+    const storage = makeStoragePort()
+
+    const result = await presignPart(storage.port, {
+      provider: 'S3',
+      bucket: TEST_BUCKETS.public,
+      key: 'org_test/file/big.mp4',
+      uploadId: 'upl_1',
+      partNumber: 3,
+      size: 5 * 1024 * 1024,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(storage.callsTo('presignPart')[0]?.params).toEqual({
+      provider: 'S3',
+      bucket: TEST_BUCKETS.public,
+      key: 'org_test/file/big.mp4',
+      uploadId: 'upl_1',
+      partNumber: 3,
+      size: 5 * 1024 * 1024,
+    })
+  })
+
+  it('applies no policy — there is none on a part', async () => {
+    const storage = makeStoragePort()
+
+    // A part far larger than any upload policy would allow still presigns:
+    // nothing bounds a multipart upload's bytes until the post-completion head.
+    const result = await presignPart(storage.port, {
+      provider: 'S3',
+      bucket: TEST_BUCKETS.private,
+      key: 'org_test/file/big.mp4',
+      uploadId: 'upl_1',
+      partNumber: 1,
+      size: 4 * 1024 * 1024 * 1024,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(storage.callsTo('presignPart')).toHaveLength(1)
+  })
+})
+
+describe('completeMultipart', () => {
+  it('forwards the parts list and returns the etag', async () => {
+    const storage = makeStoragePort({ results: { completeMultipart: { etag: 'final', size: 42 } } })
+
+    const result = await completeMultipart(storage.port, {
+      provider: 'S3',
+      bucket: TEST_BUCKETS.public,
+      key: 'org_test/file/big.mp4',
+      uploadId: 'upl_1',
+      parts: [
+        { partNumber: 1, etag: 'a' },
+        { partNumber: 2, etag: 'b' },
+      ],
+    })
+
+    expect(result._unsafeUnwrap()).toEqual({ etag: 'final', size: 42 })
+    expect(storage.callsTo('completeMultipart')[0]?.params.parts).toHaveLength(2)
+    expect(storage.callsTo('completeMultipart')[0]?.params.bucket).toBe(TEST_BUCKETS.public)
+  })
+
+  it('surfaces NoSuchUpload as a 500 that names the bucket mismatch', async () => {
+    const storage = makeStoragePort({
+      impl: {
+        completeMultipart: () => {
+          throw new StorageAdapterError(
+            'S3 completeMultipart failed: NoSuchUpload (errorCode: NoSuchUpload)',
+            'S3',
+            'completeMultipart'
+          )
+        },
+      },
+    })
+
+    const error = (
+      await completeMultipart(storage.port, {
+        provider: 'S3',
+        bucket: TEST_BUCKETS.private,
+        key: 'org_test/file/big.mp4',
+        uploadId: 'upl_1',
+        parts: [{ partNumber: 1, etag: 'a' }],
+      })
+    )._unsafeUnwrapErr()
+
+    expect(error.message).toContain('NoSuchUpload')
+  })
+})

--- a/packages/lib/src/files/storage/__tests__/upload-policy.test.ts
+++ b/packages/lib/src/files/storage/__tests__/upload-policy.test.ts
@@ -1,0 +1,216 @@
+// packages/lib/src/files/storage/__tests__/upload-policy.test.ts
+
+/**
+ * `enforceUploadPolicy` — the whole upload gate, table-driven, zero mocks.
+ *
+ * This is the Phase-3 exit criterion (`plans/attachments/03-storage-layer.md`,
+ * "Exit criteria"). The same rules used to be `StorageManager.enforcePolicy`, a
+ * `private` method reachable only by constructing a `StorageManager`, mocking
+ * `@auxx/credentials`, `@auxx/credentials/store`, `@auxx/logger`, the S3 adapter
+ * *and* `storage/locations.ts`, and then calling `generatePresignedUploadUrl` —
+ * six `vi.mock` calls to test four `if` statements. `policy-enforcement.test.ts`
+ * still does exactly that, because it is testing the facade's forwarding.
+ *
+ * This file calls `vi.mock` zero times, because there is nothing to intercept:
+ * the function takes data and returns nothing.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { BadRequestError } from '../../../errors'
+import type { UploadPolicy } from '../../upload/init-types'
+import { enforceUploadPolicy, type UploadCandidate } from '../presign'
+
+const POLICY: UploadPolicy = {
+  keyPrefix: 'org123/',
+  contentLengthRange: [100, 10 * 1024 * 1024],
+  maxTtl: 3600,
+  allowedMimeTypes: ['application/pdf', 'image/*'],
+}
+
+const CANDIDATE: UploadCandidate = {
+  storageKey: 'org123/file/report.pdf',
+  ttlSec: 600,
+  expectedSize: 1024,
+  mimeType: 'application/pdf',
+}
+
+/** A candidate that differs from the compliant baseline in exactly one way. */
+function candidate(overrides: Partial<UploadCandidate> = {}): UploadCandidate {
+  return { ...CANDIDATE, ...overrides }
+}
+
+function policy(overrides: Partial<UploadPolicy> = {}): UploadPolicy {
+  return { ...POLICY, ...overrides }
+}
+
+describe('enforceUploadPolicy', () => {
+  it('accepts a candidate that satisfies every rule', () => {
+    expect(() => enforceUploadPolicy(POLICY, CANDIDATE)).not.toThrow()
+  })
+
+  describe.each<[string, UploadPolicy, UploadCandidate]>([
+    ['key exactly at the prefix', POLICY, candidate({ storageKey: 'org123/' })],
+    ['ttl exactly at the ceiling', POLICY, candidate({ ttlSec: 3600 })],
+    ['size exactly at the floor', POLICY, candidate({ expectedSize: 100 })],
+    ['size exactly at the ceiling', POLICY, candidate({ expectedSize: 10 * 1024 * 1024 })],
+    [
+      'zero floor admits a zero-byte upload',
+      policy({ contentLengthRange: [0, 10] }),
+      candidate({ expectedSize: 0 }),
+    ],
+    ['family wildcard matches its family', POLICY, candidate({ mimeType: 'image/png' })],
+    [
+      'family wildcard matches a parameterised type',
+      POLICY,
+      candidate({ mimeType: 'image/svg+xml' }),
+    ],
+    [
+      'universal wildcard matches anything',
+      policy({ allowedMimeTypes: ['*/*'] }),
+      candidate({ mimeType: 'application/x-msdownload' }),
+    ],
+    [
+      'exact match wins even with no wildcards',
+      policy({ allowedMimeTypes: ['text/csv'] }),
+      candidate({ mimeType: 'text/csv' }),
+    ],
+    [
+      'an empty prefix admits any key',
+      policy({ keyPrefix: '' }),
+      candidate({ storageKey: 'anything/at/all' }),
+    ],
+  ])('accepts: %s', (_name, p, c) => {
+    it('does not throw', () => {
+      expect(() => enforceUploadPolicy(p, c)).not.toThrow()
+    })
+  })
+
+  describe.each<[string, UploadPolicy, UploadCandidate, string]>([
+    [
+      'key outside the org prefix',
+      POLICY,
+      candidate({ storageKey: 'org456/file/report.pdf' }),
+      "Key must start with 'org123/'",
+    ],
+    [
+      'key missing the prefix entirely',
+      POLICY,
+      candidate({ storageKey: 'report.pdf' }),
+      "Key must start with 'org123/'",
+    ],
+    [
+      'prefix match is case sensitive',
+      POLICY,
+      candidate({ storageKey: 'ORG123/report.pdf' }),
+      "Key must start with 'org123/'",
+    ],
+    ['ttl one second over', POLICY, candidate({ ttlSec: 3601 }), 'TTL exceeds 3600s'],
+    ['ttl absurdly over', POLICY, candidate({ ttlSec: 86400 * 365 }), 'TTL exceeds 3600s'],
+    [
+      'size below the floor',
+      POLICY,
+      candidate({ expectedSize: 99 }),
+      `Size 99 outside [100, ${10 * 1024 * 1024}]`,
+    ],
+    [
+      'size above the ceiling',
+      POLICY,
+      candidate({ expectedSize: 10 * 1024 * 1024 + 1 }),
+      `Size ${10 * 1024 * 1024 + 1} outside [100, ${10 * 1024 * 1024}]`,
+    ],
+    [
+      'MAX_SAFE_INTEGER size',
+      POLICY,
+      candidate({ expectedSize: Number.MAX_SAFE_INTEGER }),
+      `Size ${Number.MAX_SAFE_INTEGER} outside [100, ${10 * 1024 * 1024}]`,
+    ],
+    [
+      'disallowed mime type',
+      POLICY,
+      candidate({ mimeType: 'application/x-msdownload' }),
+      "MIME 'application/x-msdownload' not allowed",
+    ],
+    [
+      'wrong family for a family wildcard',
+      policy({ allowedMimeTypes: ['image/*'] }),
+      candidate({ mimeType: 'video/mp4' }),
+      "MIME 'video/mp4' not allowed",
+    ],
+    [
+      'empty allow-list admits nothing',
+      policy({ allowedMimeTypes: [] }),
+      candidate({ mimeType: 'application/pdf' }),
+      "MIME 'application/pdf' not allowed",
+    ],
+    [
+      'a charset parameter defeats an exact match',
+      policy({ allowedMimeTypes: ['text/html'] }),
+      candidate({ mimeType: 'text/html; charset=utf-8' }),
+      "MIME 'text/html; charset=utf-8' not allowed",
+    ],
+  ])('rejects: %s', (_name, p, c, message) => {
+    it(`throws BadRequestError "${message}"`, () => {
+      expect(() => enforceUploadPolicy(p, c)).toThrow(BadRequestError)
+      expect(() => enforceUploadPolicy(p, c)).toThrow(message)
+    })
+  })
+
+  describe('order of the checks', () => {
+    it('reports the key before the TTL, size or MIME', () => {
+      expect(() =>
+        enforceUploadPolicy(
+          POLICY,
+          candidate({
+            storageKey: 'other/x.exe',
+            ttlSec: 99999,
+            expectedSize: 0,
+            mimeType: 'application/x-msdownload',
+          })
+        )
+      ).toThrow("Key must start with 'org123/'")
+    })
+
+    it('reports the TTL before the size or MIME', () => {
+      expect(() =>
+        enforceUploadPolicy(
+          POLICY,
+          candidate({ ttlSec: 99999, expectedSize: 0, mimeType: 'application/x-msdownload' })
+        )
+      ).toThrow('TTL exceeds 3600s')
+    })
+
+    it('reports the size before the MIME', () => {
+      expect(() =>
+        enforceUploadPolicy(
+          POLICY,
+          candidate({ expectedSize: 0, mimeType: 'application/x-msdownload' })
+        )
+      ).toThrow('Size 0 outside [100')
+    })
+  })
+
+  describe('documented non-guarantees', () => {
+    /**
+     * The prefix rule is `startsWith`, not path containment. This is not a bug
+     * to fix here: S3 object keys are opaque strings and `..` has no traversal
+     * meaning to them, so the key below addresses a literal object named
+     * `org123/../../../etc/passwd` inside the org's own prefix. The test exists
+     * so nobody reads `keyPrefix` as a path-containment guarantee.
+     */
+    it('does not canonicalise the key, so `..` segments pass the prefix rule', () => {
+      expect(() =>
+        enforceUploadPolicy(POLICY, candidate({ storageKey: 'org123/../../../etc/passwd' }))
+      ).not.toThrow()
+    })
+
+    /**
+     * `expectedSize` and `mimeType` are what the *client* declared. For a
+     * single-shot upload S3 re-enforces both through the presigned POST policy;
+     * for a multipart upload nothing does, until the `headObject` after
+     * completion. See the header of `storage/presign.ts`.
+     */
+    it('judges the declared size, not the delivered one', () => {
+      expect(() => enforceUploadPolicy(POLICY, candidate({ expectedSize: 1024 }))).not.toThrow()
+    })
+  })
+})

--- a/packages/lib/src/files/storage/errors.ts
+++ b/packages/lib/src/files/storage/errors.ts
@@ -1,0 +1,101 @@
+// packages/lib/src/files/storage/errors.ts
+
+/**
+ * Translating adapter throws into `AuxxError`s, without losing them.
+ *
+ * `files/guard.ts` returns `err(error)` only for an {@link AuxxError} and
+ * flattens everything else to `AuxxError('Internal error')`. That is right for a
+ * database read, where anything unexpected really is a 500 — but every failure a
+ * `StoragePort` call can produce is an *adapter* error (`StorageAdapterError`,
+ * `StorageAuthError`, `StorageFileNotFoundError`), and none of those extend
+ * `AuxxError`. Wrapping `port.head(...)` in the plain guard would therefore turn
+ * `File not found: org-1/x.pdf` into `Internal error` for every caller —
+ * including the upload-complete route, which puts `String(err)` straight into
+ * the failure it publishes to the client.
+ *
+ * So the storage functions use {@link storageGuard}, which maps the adapter's
+ * three classes onto the matching `AuxxError` subclasses **verbatim**: same
+ * message, and the original hung off `cause` so a caller that needs the adapter
+ * type back can have it. `StorageManager.handleStorageError` uses exactly that
+ * to keep its legacy throw shape byte-for-byte.
+ *
+ * Anything that is not an adapter error and not an `AuxxError` still goes
+ * through `guard` and is still logged and flattened — an unknown throw from
+ * inside `files/storage` is a bug, not a business rule.
+ */
+
+import type { Result } from 'neverthrow'
+import { AuxxError, NotFoundError, UnauthorizedError } from '../../errors'
+import {
+  StorageAdapterError,
+  StorageAuthError,
+  StorageFileNotFoundError,
+} from '../adapters/base-adapter'
+import { guard } from '../guard'
+
+/**
+ * The adapter error a mapped {@link AuxxError} came from, if any.
+ *
+ * The one supported way back to the adapter class. `StorageManager` uses it so
+ * its callers keep seeing `StorageFileNotFoundError` rather than a `NotFoundError`
+ * they have never handled.
+ */
+export function storageErrorCause(error: unknown): StorageAdapterError | undefined {
+  const cause = (error as { cause?: unknown } | null | undefined)?.cause
+  return cause instanceof StorageAdapterError ? cause : undefined
+}
+
+/** Attach `original` as the cause without widening the return type. */
+function withCause<E extends AuxxError>(mapped: E, original: Error): E {
+  mapped.cause = original
+  return mapped
+}
+
+/**
+ * Map a storage adapter error onto the `AuxxError` subclass with the right
+ * status, or `undefined` when it is not an adapter error at all.
+ *
+ * Ordered most-specific first: `StorageAuthError` and `StorageFileNotFoundError`
+ * both extend `StorageAdapterError`, so the base class must be tested last.
+ */
+export function toStorageAuxxError(error: unknown): AuxxError | undefined {
+  if (error instanceof AuxxError) return error
+  if (error instanceof StorageFileNotFoundError) {
+    return withCause(new NotFoundError(error.message), error)
+  }
+  if (error instanceof StorageAuthError) {
+    return withCause(new UnauthorizedError(error.message), error)
+  }
+  if (error instanceof StorageAdapterError) {
+    // Deliberately the base `AuxxError` (500), not `BadRequestError`: a generic
+    // adapter failure is a network fault or an unsupported operation, and
+    // neither is the caller's input being wrong.
+    return withCause(new AuxxError(error.message), error)
+  }
+  return undefined
+}
+
+/**
+ * {@link guard}, plus the adapter-error mapping above.
+ *
+ * Use this for any function whose body calls a {@link StoragePort}. Use the
+ * plain `guard` for database-only functions — mapping there would claim a
+ * meaning the error does not have.
+ */
+export async function storageGuard<T>(
+  fn: () => Promise<T>,
+  logMessage: string,
+  meta: Record<string, unknown> = {}
+): Promise<Result<T, AuxxError>> {
+  return guard(
+    async () => {
+      try {
+        return await fn()
+      } catch (error) {
+        throw toStorageAuxxError(error) ?? error
+      }
+    },
+    logMessage,
+    meta
+  )
+}

--- a/packages/lib/src/files/storage/objects.ts
+++ b/packages/lib/src/files/storage/objects.ts
@@ -1,0 +1,148 @@
+// packages/lib/src/files/storage/objects.ts
+
+/**
+ * Server-side object I/O: put, get, stream, head, delete.
+ *
+ * Five functions over a {@link StoragePort}, and nothing else. No database, no
+ * `FilesCtx`, no transaction — a function here cannot read a `StorageLocation`
+ * row, and that is the property worth having: resolving a row into a bucket and
+ * a key is the *caller's* job, on `ctx.db`, where the org scope is applied.
+ * `StorageManager`'s equivalents (`getContent(locationId)`,
+ * `streamFileContent(locationId)`, `deleteFile(locationId)`) each do their own
+ * unscoped read behind the caller's back; these deliberately cannot.
+ *
+ * ## Every parameter type carries a required `bucket`
+ *
+ * Inherited from {@link ObjectRef} in `ports.ts`, and it is the whole point.
+ * Bugs #1816/#1817/#1818 were one bug three times: `bucket` was optional, a call
+ * site omitted it, the resolver fell back to `S3_PRIVATE_BUCKET`, and S3
+ * answered `204 No Content` for a delete of a key that was never in the bucket
+ * we named — so a PUBLIC upload's object leaked with no error and no log
+ * anywhere. There is no bucket-less overload here and there must not be one.
+ *
+ * ## Errors keep their meaning
+ *
+ * These bodies do exactly one thing that can fail — call the port — and the
+ * failure is always an adapter error. {@link storageGuard} maps
+ * `StorageFileNotFoundError` to `NotFoundError`, `StorageAuthError` to
+ * `UnauthorizedError` and the rest to `AuxxError`, preserving the message and
+ * hanging the original off `cause`. The plain `files/guard.ts` would flatten all
+ * three to `Internal error`; see `storage/errors.ts`.
+ */
+
+import type { Result } from 'neverthrow'
+import type { AuxxError } from '../../errors'
+import { storageGuard } from './errors'
+import type {
+  DeleteParams,
+  GetObjectParams,
+  HeadParams,
+  HeadResult,
+  PutObjectParams,
+  PutResult,
+  StoragePort,
+} from './ports'
+
+/**
+ * Write content the server itself produced (a thumbnail, a rendered PDF, an
+ * export) straight to storage.
+ *
+ * This writes **only the object**. It does not create a `StorageLocation` row —
+ * `storage/locations.ts` does that, inside the caller's transaction, and the two
+ * halves are separate because the object write must happen *before* the
+ * transaction opens rather than inside it.
+ *
+ * @param p `bucket` is required. Pass the bucket the visibility routes to
+ *   (`bucketForVisibility`), never a configured default.
+ */
+export async function putObject(
+  port: StoragePort,
+  p: PutObjectParams
+): Promise<Result<PutResult, AuxxError>> {
+  return storageGuard(async () => port.putObject(p), 'Failed to put object', {
+    provider: p.provider,
+    key: p.key,
+    bucket: p.bucket,
+    size: p.size,
+  })
+}
+
+/**
+ * Read a whole object into memory.
+ *
+ * Buffers the entire body, so it is for content the caller genuinely needs in
+ * one piece (parsing, hashing, re-encoding). Use {@link streamObject} for
+ * anything that is being forwarded to a response.
+ */
+export async function getObject(
+  port: StoragePort,
+  p: GetObjectParams
+): Promise<Result<Buffer, AuxxError>> {
+  return storageGuard(async () => port.getObject(p), 'Failed to get object', {
+    provider: p.provider,
+    key: p.key,
+    bucket: p.bucket,
+  })
+}
+
+/**
+ * Open a read stream over an object.
+ *
+ * There is no range parameter, matching the port: `StorageManager.streamFileContent`
+ * accepts one, logs `'Range support not yet implemented'` and returns the full
+ * stream anyway. A parameter that is silently ignored is worse than one that
+ * does not exist, so this signature does not offer it. Range support belongs on
+ * the port and the adapter when something needs it.
+ */
+export async function streamObject(
+  port: StoragePort,
+  p: GetObjectParams
+): Promise<Result<NodeJS.ReadableStream, AuxxError>> {
+  return storageGuard(async () => port.streamObject(p), 'Failed to open object stream', {
+    provider: p.provider,
+    key: p.key,
+    bucket: p.bucket,
+  })
+}
+
+/**
+ * Read an object's metadata without downloading it.
+ *
+ * This is the upload pipeline's real verification step: for a multipart upload
+ * the presign-time policy is advisory (see `storage/presign.ts`), and the `size`
+ * and `mimeType` that come back from here are the first numbers S3 itself
+ * vouches for.
+ */
+export async function headObject(
+  port: StoragePort,
+  p: HeadParams
+): Promise<Result<HeadResult, AuxxError>> {
+  return storageGuard(async () => port.head(p), 'Failed to head object', {
+    provider: p.provider,
+    key: p.key,
+    bucket: p.bucket,
+  })
+}
+
+/**
+ * Delete one object.
+ *
+ * Used for compensation (an upload whose transaction rolled back) and for
+ * lifecycle sweeps. The `bucket` must be the bucket the object actually lives
+ * in: S3 answers `204 No Content` for a delete of a key that is not in the
+ * bucket you named, so a wrong-bucket delete looks exactly like a successful
+ * one.
+ *
+ * Deleting the `StorageLocation` row is a separate step, and it comes second —
+ * the row is the only pointer to the bytes, so dropping it first loses them.
+ */
+export async function deleteObject(
+  port: StoragePort,
+  p: DeleteParams
+): Promise<Result<void, AuxxError>> {
+  return storageGuard(async () => port.deleteObject(p), 'Failed to delete object', {
+    provider: p.provider,
+    key: p.key,
+    bucket: p.bucket,
+  })
+}

--- a/packages/lib/src/files/storage/ports.ts
+++ b/packages/lib/src/files/storage/ports.ts
@@ -24,16 +24,17 @@ import type { OrphanedStorageObjectJobData } from '../../jobs/maintenance/orphan
 import type {
   DownloadRef,
   FileMetadata,
+  MultipartUpload,
   PresignedUpload,
   ProviderId,
   StorageLocationRef,
 } from '../adapters/base-adapter'
-import { S3Adapter } from '../adapters/s3-adapter'
+import type { S3Adapter } from '../adapters/s3-adapter'
 import type { GenerateThumbnailPayload } from '../core/thumbnail-types'
 import type { UploadPreparedConfig } from '../upload/init-types'
 import { resolveProviderAuth } from './auth'
 import { buildExternalUrl } from './buckets'
-import { createStorageManager } from './storage-manager'
+import { getStorageAdapter } from './providers'
 
 // ============= Parameter types =============
 
@@ -161,7 +162,13 @@ export type EnqueueStorageCleanupParams = Omit<OrphanedStorageObjectJobData, 'bu
  * `StorageLocation` row into a bucket and key is the caller's job, on `ctx.db`.
  */
 export interface StoragePort {
+  /**
+   * Signs whatever it is handed — it does **not** enforce the upload policy.
+   * `storage/presign.ts` is the door that does; call that, not this.
+   */
   presignUpload(p: PresignUploadParams): Promise<PresignedUpload>
+  /** Opens a multipart upload. Policy-free for the same reason as {@link presignUpload}. */
+  startMultipart(p: PresignUploadParams): Promise<MultipartUpload>
   presignPart(p: PresignPartParams): Promise<PresignedUpload>
   completeMultipart(p: CompleteMultipartParams): Promise<{ etag: string; size?: number }>
   head(p: HeadParams): Promise<HeadResult>
@@ -210,27 +217,30 @@ export interface CachePort {
 // ============= Production implementation =============
 
 /**
- * The S3 {@link StoragePort}, wired to the existing adapter and
- * `StorageManager`.
+ * The S3 {@link StoragePort}, wired straight to the S3 adapter.
  *
  * This is the proof the interface is implementable against real code rather
- * than a shape invented for tests. It delegates rather than reimplements:
+ * than a shape invented for tests.
  *
- * - Policy-enforcing upload operations go through `StorageManager`, because the
- *   policy check (`enforcePolicy`) lives there and must not be bypassed.
- * - `deleteObject` goes through `StorageManager.deleteByKey`, because that is
- *   where the "no bucket supplied" fallback is logged.
- * - Object reads/writes go straight to the adapter, because every
- *   `StorageManager` equivalent (`getFileMetadata`, `getContent`,
- *   `uploadContent`) is `storageLocationId`-addressed and does its own database
- *   work — exactly what this port must not do.
+ * **Since PR 3d it no longer routes anything through `StorageManager`.** It used
+ * to, for the four policy- or bucket-sensitive operations, on the grounds that
+ * `enforcePolicy` and the "no bucket supplied" warn lived there. Both have since
+ * moved out — the policy to `storage/presign.ts` (which calls *this* port, so
+ * the old arrangement would now be a cycle), the bucket fallback to the facade's
+ * own legacy shim. What is left here is one uniform rule: **every method is a
+ * single adapter call against a bucket the caller named.** Nothing in this file
+ * reads a database row, resolves a bucket, or judges an upload.
+ *
+ * The adapter comes from `storage/providers.ts` rather than `new S3Adapter()`,
+ * so every port instance shares the one cached adapter — and therefore its
+ * `S3Client` cache. A per-port adapter would rebuild a client per request.
  *
  * @param organizationId Required only when a call passes a `credentialId`;
  *   platform storage resolves its auth from config and needs no org.
  */
 export function createS3StoragePort(organizationId?: string): StoragePort {
-  const manager = createStorageManager(organizationId)
-  const adapter = new S3Adapter()
+  /** The one cached S3 adapter. Cast is sound: `providers.ts` only ever loads `S3Adapter` for `'S3'`. */
+  const s3 = async () => (await getStorageAdapter('S3')) as S3Adapter
 
   /**
    * Resolve provider auth with the bucket pinned to the caller's choice.
@@ -254,42 +264,73 @@ export function createS3StoragePort(organizationId?: string): StoragePort {
     }
   }
 
-  return {
-    presignUpload: (p) => manager.generatePresignedUploadUrl(p),
+  /**
+   * The S3 object metadata every presigned upload carries.
+   *
+   * Built here rather than by the caller so the org/uploader/entity trio cannot
+   * be forgotten on a new door; caller-supplied `metadata` is merged last and
+   * may override.
+   */
+  const uploadMetadata = (p: PresignUploadParams): Record<string, string> => ({
+    orgId: p.organizationId,
+    uploader: p.userId,
+    entityType: p.entityType,
+    entityId: p.entityId ?? '',
+    ...p.metadata,
+  })
 
-    presignPart: (p) =>
-      manager.generatePartUploadUrl({
-        provider: p.provider,
+  return {
+    presignUpload: async (p) =>
+      (await s3()).presignUpload({
+        key: p.storageKey,
+        mimeType: p.mimeType,
+        size: p.expectedSize,
+        ttlSec: p.ttlSec,
+        metadata: uploadMetadata(p),
+        // Explicit bucket only. `visibility` is deliberately NOT forwarded: the
+        // adapter would re-derive a bucket from it, giving two resolutions for
+        // one object that can disagree. `UploadPreparedConfig.bucket` is
+        // required, so there is nothing to fall back to.
+        bucket: p.bucket,
+        auth: await resolveAuth(p.bucket, p.credentialId),
+      }),
+
+    startMultipart: async (p) =>
+      (await s3()).startMultipart({
+        key: p.storageKey,
+        mimeType: p.mimeType,
+        metadata: uploadMetadata(p),
+        bucket: p.bucket,
+        auth: await resolveAuth(p.bucket, p.credentialId),
+      }),
+
+    presignPart: async (p) =>
+      (await s3()).presignPart({
         key: p.key,
         uploadId: p.uploadId,
         partNumber: p.partNumber,
         size: p.size,
-        credentialId: p.credentialId,
         bucket: p.bucket,
+        auth: await resolveAuth(p.bucket, p.credentialId),
       }),
 
-    completeMultipart: (p) =>
-      manager.completeMultipartUploadOnly({
-        provider: p.provider,
+    completeMultipart: async (p) =>
+      (await s3()).completeMultipart({
         key: p.key,
         uploadId: p.uploadId,
         parts: p.parts,
-        credentialId: p.credentialId,
         bucket: p.bucket,
+        auth: await resolveAuth(p.bucket, p.credentialId),
       }),
 
-    deleteObject: (p) =>
-      manager.deleteByKey({
-        provider: p.provider,
-        key: p.key,
-        credentialId: p.credentialId,
-        bucket: p.bucket,
-      }),
+    deleteObject: async (p) =>
+      (await s3()).deleteFile(locationRef(p), await resolveAuth(p.bucket, p.credentialId)),
 
-    head: async (p) => adapter.getMeta(locationRef(p), await resolveAuth(p.bucket, p.credentialId)),
+    head: async (p) =>
+      (await s3()).getMeta(locationRef(p), await resolveAuth(p.bucket, p.credentialId)),
 
     putObject: async (p) =>
-      adapter.putObject({
+      (await s3()).putObject({
         key: p.key,
         content: p.content,
         mimeType: p.mimeType,
@@ -300,10 +341,10 @@ export function createS3StoragePort(organizationId?: string): StoragePort {
       }),
 
     streamObject: async (p) =>
-      adapter.openDownloadStream(locationRef(p), await resolveAuth(p.bucket, p.credentialId)),
+      (await s3()).openDownloadStream(locationRef(p), await resolveAuth(p.bucket, p.credentialId)),
 
     getObject: async (p) => {
-      const stream = await adapter.openDownloadStream(
+      const stream = await (await s3()).openDownloadStream(
         locationRef(p),
         await resolveAuth(p.bucket, p.credentialId)
       )
@@ -316,7 +357,7 @@ export function createS3StoragePort(organizationId?: string): StoragePort {
     },
 
     presignDownload: async (p) =>
-      adapter.getDownloadRef(locationRef(p), await resolveAuth(p.bucket, p.credentialId), {
+      (await s3()).getDownloadRef(locationRef(p), await resolveAuth(p.bucket, p.credentialId), {
         ttlSec: p.ttlSec,
         disposition: p.disposition,
         filename: p.filename,

--- a/packages/lib/src/files/storage/presign.ts
+++ b/packages/lib/src/files/storage/presign.ts
@@ -1,0 +1,212 @@
+// packages/lib/src/files/storage/presign.ts
+
+/**
+ * Handing a client permission to write bytes — and the policy that bounds it.
+ *
+ * Four functions: the single-shot presign, the multipart trio's start / part /
+ * complete, and the pure {@link enforceUploadPolicy} they are all built on.
+ * Every one takes a {@link StoragePort} rather than constructing an adapter, so
+ * a test supplies a plain object literal (`files/__tests__/support/storage.ts`)
+ * and calls `vi.mock` zero times.
+ *
+ * ## The policy is enforced HERE, not on the port
+ *
+ * `StoragePort.presignUpload` and `StoragePort.startMultipart` are raw adapter
+ * calls: they sign whatever they are handed. {@link presignUpload} and
+ * {@link startMultipartUpload} are the sanctioned doors, because they call
+ * {@link enforceUploadPolicy} first. Reaching for `deps.storage.presignUpload(...)`
+ * directly from a route or a processor skips the key-prefix, TTL, size and MIME
+ * checks — do not.
+ *
+ * ## Single uploads are re-enforced by S3. Multipart uploads are NOT.
+ *
+ * This asymmetry is the reason `validateCompletedUpload` exists, and it was
+ * undocumented until now:
+ *
+ * - **Single.** `S3Adapter.presignUpload` signs a *presigned POST* whose policy
+ *   document carries `['content-length-range', 0, size]` and a `Content-Type`
+ *   condition. S3 itself rejects the upload if the client sends more bytes or a
+ *   different type, so for this path {@link enforceUploadPolicy} is a real gate:
+ *   whatever it allows is what S3 will accept, and nothing wider. (The
+ *   zero-`size` branch signs a plain PUT instead, which carries no
+ *   content-length condition — so even "single" is only as strong as the
+ *   `expectedSize` the caller declared.)
+ *
+ * - **Multipart.** `CreateMultipartUpload` takes no policy document at all.
+ *   `presignPart` signs `UploadPart` for one part number and S3 enforces only
+ *   the 5 GiB per-part ceiling; nothing constrains the *total* size or the
+ *   actual content type. A client that declares a 2 MB `image/png`, gets a
+ *   multipart plan, and then pushes 4 GB of anything will succeed at every S3
+ *   call. For this path {@link enforceUploadPolicy} is **advisory** — it bounds
+ *   what we agreed to, not what can happen.
+ *
+ * The real gate for multipart is therefore the `headObject` the completion route
+ * runs *after* the bytes land: `size` and `mimeType` come back from S3 itself,
+ * and `validateCompletedUpload` is what makes the client's declaration binding —
+ * `BaseUploadProcessor` fails the completion when the head disagrees with the
+ * session's `expectedSize`/`mimeType`, and `BaseAssetProcessor` additionally
+ * re-checks the processor's own size ceiling and MIME allow-list. Removing that
+ * check does not lose a redundant validation; it loses the only one multipart
+ * has.
+ */
+
+import type { Result } from 'neverthrow'
+import { type AuxxError, BadRequestError } from '../../errors'
+import type { MultipartUpload, PresignedUpload } from '../adapters/base-adapter'
+import type { UploadPolicy } from '../upload/init-types'
+import { storageGuard } from './errors'
+import type {
+  CompleteMultipartParams,
+  PresignPartParams,
+  PresignUploadParams,
+  StoragePort,
+} from './ports'
+
+/**
+ * The four facts {@link enforceUploadPolicy} judges.
+ *
+ * A structural subset of `UploadPreparedConfig`, so the prepared config passes
+ * unchanged and no caller has to project it. Named separately because the policy
+ * check must not be able to read anything else — it has no business knowing the
+ * organization, the entity, or the bucket.
+ */
+export interface UploadCandidate {
+  /** The full object key the client will write to. */
+  storageKey: string
+  /** Requested signature lifetime, in seconds. */
+  ttlSec: number
+  /** Size the client declared. For multipart this is a claim, not a constraint. */
+  expectedSize: number
+  /** Content type the client declared. Same caveat. */
+  mimeType: string
+}
+
+/** What multipart completion reports back. S3 returns no size, hence the optional. */
+export interface MultipartCompletion {
+  etag: string
+  size?: number
+}
+
+/**
+ * Check an upload against its policy. Pure: no `ctx`, no `deps`, no clock, no
+ * `Result` — there is nothing here that can fail for any reason other than the
+ * data it was handed.
+ *
+ * Throws on the first violation rather than collecting them, matching the
+ * `StorageManager.enforcePolicy` it replaces: the client gets one reason, and
+ * the checks are ordered cheapest-first.
+ *
+ * The key check is a plain `startsWith`, **not** a canonicalised path compare.
+ * `org123/../../../etc/passwd` passes it. That is deliberate and defence in
+ * depth lives at the adapter/S3 layer, where the key is an opaque object name
+ * and `..` has no meaning — but it means this function must never be described
+ * as path containment.
+ *
+ * MIME matching supports `type/subtype`, a `type/*` family wildcard, and `*​/*`.
+ *
+ * @throws {BadRequestError} on the first rule the candidate breaks.
+ */
+export function enforceUploadPolicy(policy: UploadPolicy, candidate: UploadCandidate): void {
+  if (!candidate.storageKey.startsWith(policy.keyPrefix)) {
+    throw new BadRequestError(`Key must start with '${policy.keyPrefix}'`)
+  }
+
+  if (candidate.ttlSec > policy.maxTtl) {
+    throw new BadRequestError(`TTL exceeds ${policy.maxTtl}s`)
+  }
+
+  const [min, max] = policy.contentLengthRange
+  if (candidate.expectedSize < min || candidate.expectedSize > max) {
+    throw new BadRequestError(`Size ${candidate.expectedSize} outside [${min}, ${max}]`)
+  }
+
+  const allowed = policy.allowedMimeTypes.some((entry) => {
+    if (entry === '*/*') return true
+    if (entry.endsWith('/*')) return candidate.mimeType.startsWith(entry.slice(0, -2))
+    return candidate.mimeType === entry
+  })
+
+  if (!allowed) {
+    throw new BadRequestError(`MIME '${candidate.mimeType}' not allowed`)
+  }
+}
+
+/**
+ * Presign a single-shot upload, after enforcing the plan's own policy.
+ *
+ * @param port Storage. The port signs; it does not judge — see the file header.
+ * @param plan The prepared upload config. It carries its `policy`, so there is
+ *   no way to presign against a policy other than the one the processor chose.
+ */
+export async function presignUpload(
+  port: StoragePort,
+  plan: PresignUploadParams
+): Promise<Result<PresignedUpload, AuxxError>> {
+  return storageGuard(
+    async () => {
+      enforceUploadPolicy(plan.policy, plan)
+      return port.presignUpload(plan)
+    },
+    'Failed to presign upload',
+    { provider: plan.provider, storageKey: plan.storageKey, bucket: plan.bucket }
+  )
+}
+
+/**
+ * Open a multipart upload, after enforcing the plan's own policy.
+ *
+ * The policy is advisory from here on — see the file header. The bucket this
+ * starts in is the bucket every later {@link presignPart} and
+ * {@link completeMultipart} must name, or S3 answers `NoSuchUpload`.
+ */
+export async function startMultipartUpload(
+  port: StoragePort,
+  plan: PresignUploadParams
+): Promise<Result<MultipartUpload, AuxxError>> {
+  return storageGuard(
+    async () => {
+      enforceUploadPolicy(plan.policy, plan)
+      return port.startMultipart(plan)
+    },
+    'Failed to start multipart upload',
+    { provider: plan.provider, storageKey: plan.storageKey, bucket: plan.bucket }
+  )
+}
+
+/**
+ * Presign one part of an in-flight multipart upload.
+ *
+ * No policy check: there is no policy on this call. The part's size is bounded
+ * only by S3's own 5 GiB per-part limit, and the upload's total size is bounded
+ * by nothing until `headObject` after completion.
+ *
+ * @param p `bucket` must be the bucket the upload was started in.
+ */
+export async function presignPart(
+  port: StoragePort,
+  p: PresignPartParams
+): Promise<Result<PresignedUpload, AuxxError>> {
+  return storageGuard(async () => port.presignPart(p), 'Failed to presign upload part', {
+    provider: p.provider,
+    key: p.key,
+    bucket: p.bucket,
+    partNumber: p.partNumber,
+  })
+}
+
+/**
+ * Finalise a multipart upload. Writes no database row — the caller does that
+ * inside its own transaction, from the `headObject` that follows.
+ *
+ * @param p `bucket` must be the bucket the upload was started in.
+ */
+export async function completeMultipart(
+  port: StoragePort,
+  p: CompleteMultipartParams
+): Promise<Result<MultipartCompletion, AuxxError>> {
+  return storageGuard(
+    async () => port.completeMultipart(p),
+    'Failed to complete multipart upload',
+    { provider: p.provider, key: p.key, bucket: p.bucket, parts: p.parts.length }
+  )
+}

--- a/packages/lib/src/files/storage/storage-manager.ts
+++ b/packages/lib/src/files/storage/storage-manager.ts
@@ -3,6 +3,8 @@
 import type { Transaction } from '@auxx/database'
 import type { StorageLocationEntity as StorageLocation } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
+import type { Result } from 'neverthrow'
+import type { AuxxError } from '../../errors'
 import type {
   DownloadRef,
   MultipartUpload,
@@ -22,8 +24,12 @@ import type { FilesCtx } from '../ctx'
 import type { UploadPreparedConfig } from '../upload/init-types'
 import { resolveProviderAuth } from './auth'
 import { bucketForVisibility, buildExternalUrl, type StorageVisibility } from './buckets'
+import { storageErrorCause } from './errors'
 import { getStorageLocation } from './location-queries'
 import { createStorageLocation, deleteStorageLocation } from './locations'
+import { deleteObject, headObject, putObject } from './objects'
+import { createS3StoragePort, type StoragePort } from './ports'
+import { completeMultipart, presignPart, presignUpload, startMultipartUpload } from './presign'
 import { getCachedStorageAdapter, getStorageAdapter, isProviderAvailable } from './providers'
 
 const logger = createScopedLogger('storage-manager')
@@ -54,7 +60,7 @@ export interface StorageContentUploadParams {
   metadata?: Record<string, string>
   credentialId?: string
   organizationId?: string
-  visibility?: 'PUBLIC' | 'PRIVATE' // Route to correct bucket
+  visibility?: StorageVisibility // Route to correct bucket
   bucket?: string // Explicit bucket override
 }
 
@@ -80,77 +86,82 @@ export interface StorageDownloadParams {
 }
 
 /**
- * Enhanced StorageManager - Unified Multi-Provider Storage Orchestrator
+ * The legacy storage facade — kept alive for its remaining call sites, not for
+ * new work.
  *
- * The StorageManager provides a single, consistent interface for managing files across
- * multiple storage providers (S3, Google Drive, Dropbox, etc.). It handles provider
- * abstraction, authentication, error handling, and advanced features like multipart
- * uploads and webhooks.
+ * @deprecated Use the `files/storage/*` functions directly. Deleted in the
+ * Phase-10 consumer sweep (`plans/attachments/10-rollout-checklist.md`).
  *
- * ## Key Features
- * - **Multi-Provider Support**: S3, Google Drive, Dropbox, OneDrive, Box, and URL providers
- * - **Dynamic Adapter Loading**: Lazy-loaded adapters with caching for optimal performance
- * - **Authentication Management**: Seamless credential handling across all providers
- * - **Advanced Upload Features**: Presigned URLs, multipart uploads, progress tracking
- * - **Monitoring & Analytics**: Health checks, usage statistics, webhook processing
- * - **Database Integration**: Full StorageLocation lifecycle management
+ * ## What is left in here, and why
  *
- * ## Architecture
- * ```
- * StorageManager (Orchestration Layer)
- *     ↓
- * Dynamic Adapter Loading & Caching
- *     ↓
- * Provider-Specific Adapters (S3, GDrive, etc.)
- *     ↓
- * External Storage APIs
- * ```
+ * Two kinds of method, and the difference is the whole map of this file:
  *
- * ## Usage Examples
+ * 1. **Delegates.** `generatePresignedUploadUrl`, `startMultipartUploadFromConfig`,
+ *    `generatePartUploadUrl`, `completeMultipartUploadOnly`, `headByKey`,
+ *    `deleteByKey` and the object half of `uploadContent` are now one call into
+ *    `storage/presign.ts` or `storage/objects.ts` through a {@link StoragePort},
+ *    plus {@link StorageManager.run} to turn the `Result` back into a throw. The
+ *    behaviour lives in those modules; this class only adapts the calling
+ *    convention.
  *
- * ### Basic File Upload
- * ```typescript
- * const manager = new StorageManager('org_123')
+ * 2. **Composites this PR did not move.** `getDownloadRef`, `getContent`,
+ *    `streamFileContent` and `deleteFile` are addressed by `storageLocationId`,
+ *    so each one reads a database row *and* touches storage. Splitting them
+ *    needs a `FilesCtx` at every call site (24 of them) and a decision about
+ *    what the row's `metadata` is allowed to carry into the adapter — the row
+ *    can hold `region` and `endpoint`, which the bucket/key-only port does not
+ *    accept. That is Phase 4/5 work, and `assets/download.ts` is the shape it
+ *    takes; doing it here would be a behaviour change smuggled into an
+ *    extraction PR.
  *
- * const result = await manager.uploadFile({
- *   provider: 'S3',
- *   key: 'documents/report.pdf',
- *   content: fileBuffer,
- *   mimeType: 'application/pdf',
- *   credentialId: 'aws_cred_123'
- * })
- * ```
+ * ## One organization, one provider
  *
- * ### Large File Upload with Progress
- * ```typescript
- * const result = await manager.uploadLargeFile(
- *   {
- *     provider: 'S3',
- *     key: 'videos/large-video.mp4',
- *     content: videoStream,
- *     partSize: 50 * 1024 * 1024 // 50MB parts
- *   },
- *   (progress) => console.log(`Progress: ${progress.percentage}%`)
- * )
- * ```
- *
- * ### Provider Health Monitoring
- * ```typescript
- * const healthChecks = await manager.performHealthCheck()
- * healthChecks.forEach(check => {
- *   console.log(`${check.provider}: ${check.healthy ? 'OK' : 'FAILED'}`)
- * })
- * ```
+ * {@link StorageManager.port} is an S3 port. Every method still takes a
+ * `provider`, and {@link StorageManager.validateStorageParams} rejects anything
+ * without an adapter — which today is everything except `'S3'`. When a second
+ * adapter lands, the port must be selected per call rather than per instance.
  *
  * @see {@link StorageAdapter} for provider-specific implementations
  * @see `files/storage/locations.ts` / `location-queries.ts` for `StorageLocation` persistence
- * @since 1.0.0
  */
 export class StorageManager {
   protected readonly organizationId?: string
 
   constructor(organizationId?: string) {
     this.organizationId = organizationId
+  }
+
+  /**
+   * The {@link StoragePort} every delegate runs through.
+   *
+   * Built once per manager. `createS3StoragePort` is cheap — it closes over the
+   * shared, cached adapter from `storage/providers.ts` rather than constructing
+   * one — but building it per call would still allocate a fresh closure set on
+   * the hottest paths in the upload flow.
+   */
+  private cachedPort?: StoragePort
+
+  private get port(): StoragePort {
+    this.cachedPort ??= createS3StoragePort(this.organizationId)
+    return this.cachedPort
+  }
+
+  /**
+   * Turn a `Result`-returning storage function back into the throw the legacy
+   * callers of this class expect.
+   *
+   * `handleStorageError` restores the original adapter error class where there
+   * is one (`storage/errors.ts` hangs it off `cause`), so a caller that used to
+   * catch `StorageFileNotFoundError` still catches `StorageFileNotFoundError`.
+   */
+  private async run<T>(
+    operation: Promise<Result<T, AuxxError>>,
+    name: string,
+    provider: ProviderId
+  ): Promise<T> {
+    const result = await operation
+    if (result.isErr()) this.handleStorageError(result.error, name, provider)
+    return result.value
   }
 
   /**
@@ -208,11 +219,21 @@ export class StorageManager {
   // ============= Core Storage Operations =============
 
   /**
-   * Upload content directly to storage from server
+   * Upload content directly to storage from server, and record it.
    *
-   * This method handles server-side uploads where content is already
-   * available in memory or as a stream. Unlike presigned URLs, this
-   * uploads content directly through the server.
+   * **This is a composite, not an object write.** It puts the bytes *and*
+   * creates the `StorageLocation` row, which is why it stayed on the facade when
+   * PR 3d moved `putObject` out: the object half is `storage/objects.ts`, the
+   * row half is `storage/locations.ts`, and gluing them together needs a
+   * transaction and a `FilesCtx` that its 13 call sites do not have yet. Phase 6
+   * owns that seam; until then this method is the glue.
+   *
+   * The bucket is now resolved **once**, here, and used for all three of the
+   * object write, the external URL and the persisted row. It used to be resolved
+   * three times independently — `S3Adapter.putObject` re-derived it from
+   * `visibility`, `withResolvedS3Bucket` derived it again for the URL, and
+   * `prepareLocationMetadata` a third time for the row — so the object could
+   * land in one bucket while the row claimed another.
    *
    * @param params - Upload parameters including content and metadata
    * @returns Promise resolving to the created StorageLocation record
@@ -228,38 +249,29 @@ export class StorageManager {
    *   content: thumbnailBuffer,
    *   mimeType: 'image/jpeg',
    *   size: thumbnailBuffer.length,
-   *   metadata: { preset: 'medium', originalId: 'file123' }
+   *   visibility: 'PRIVATE',
    * })
    * ```
    */
   async uploadContent(params: StorageContentUploadParams): Promise<StorageLocation> {
-    // Validate parameters
     this.validateStorageParams(params)
 
-    // Get adapter for the provider
-    const adapter = await getStorageAdapter(params.provider)
+    const bucket =
+      params.provider === 'S3'
+        ? await this.resolveS3BucketForLocation({
+            bucket: params.bucket,
+            metadata: params.metadata ?? {},
+            credentialId: params.credentialId,
+            visibility: params.visibility,
+          })
+        : params.bucket
 
-    // Check if adapter supports direct uploads
-    if (!adapter.putObject) {
-      throw new StorageAdapterError(
-        `Provider ${params.provider} does not support direct server uploads`,
-        params.provider,
-        'uploadContent'
-      )
-    }
-
-    // Get authentication if credential ID provided
-    let auth: ProviderAuth | undefined
-    auth = await resolveProviderAuth({
-      provider: params.provider,
-      organizationId: this.organizationId,
-      credentialId: params.credentialId,
-    })
-
-    try {
-      // Upload content using adapter
-      const result = await adapter.putObject({
+    const result = await this.run(
+      putObject(this.port, {
+        provider: params.provider,
+        bucket: bucket ?? '',
         key: params.key,
+        credentialId: params.credentialId,
         content: params.content,
         mimeType: params.mimeType,
         size: params.size,
@@ -267,27 +279,21 @@ export class StorageManager {
           ...params.metadata,
           organizationId: params.organizationId! || this.organizationId!,
         },
-        visibility: params.visibility, // Route to correct bucket
-        bucket: params.bucket, // Explicit bucket override
-        auth,
+      }),
+      'uploadContent',
+      params.provider
+    )
+
+    try {
+      // Synchronous, and off the same bucket the bytes just went to.
+      const externalUrl = buildExternalUrl({
+        provider: params.provider,
+        key: params.key,
+        bucket,
+        visibility: params.visibility,
       })
 
-      // Build external URL using adapter if it supports it
-      const externalUrlAuth =
-        params.provider === 'S3'
-          ? this.withResolvedS3Bucket({
-              auth,
-              bucket: params.bucket,
-              visibility: params.visibility,
-            })
-          : auth
-
-      const externalUrl = adapter.buildExternalUrl
-        ? adapter.buildExternalUrl(params.key, externalUrlAuth)
-        : params.key
-
-      // Create storage location record
-      const storageLocation = await this.createStorageLocation({
+      return await this.createStorageLocation({
         provider: params.provider,
         externalId: params.key,
         externalUrl,
@@ -300,11 +306,9 @@ export class StorageManager {
           etag: result.etag,
           versionId: result.versionId,
         },
-        bucket: params.bucket,
+        bucket,
         visibility: params.visibility,
       })
-
-      return storageLocation
     } catch (error) {
       this.handleStorageError(error, 'uploadContent', params.provider)
     }
@@ -323,18 +327,6 @@ export class StorageManager {
    *
    * @throws {StorageFileNotFoundError} When storage location doesn't exist
    * @throws {StorageAdapterError} When provider doesn't support download URLs
-   *
-   * @example
-   * ```typescript
-   * // Get a 1-hour download URL
-   * const downloadRef = await manager.getDownloadRef({
-   *   locationId: 'loc_abc123',
-   *   ttlSec: 3600
-   * })
-   *
-   * // Use URL for client download
-   * window.open(downloadUrl)
-   * ```
    *
    * @see {@link getContent} for direct content retrieval
    * @see {@link streamFileContent} for streaming access
@@ -413,14 +405,6 @@ export class StorageManager {
    * @throws {StorageFileNotFoundError} When storage location doesn't exist
    * @throws {StorageAdapterError} When provider doesn't support content retrieval
    *
-   * @example
-   * ```typescript
-   * // Download file content for processing
-   * const content = await manager.getContent('loc_abc123')
-   * const text = content.toString('utf-8')
-   * console.log(`File contains: ${text.substring(0, 100)}...`)
-   * ```
-   *
    * @see {@link streamFileContent} for streaming large files
    * @see {@link getDownloadRef} for client-side downloads
    */
@@ -484,7 +468,7 @@ export class StorageManager {
         // For now, return full stream - range support would require
         // adapter-specific implementation for HTTP Range headers
         if (range) {
-          console.warn('Range support not yet implemented - returning full stream')
+          logger.warn('Range support not yet implemented - returning full stream', { locationId })
         }
 
         return stream
@@ -587,14 +571,6 @@ export class StorageManager {
    * @param opts.bucket - The bucket the object lives in. Wins over `visibility`.
    * @param opts.visibility - Picks a configured bucket when `bucket` is absent.
    * @param opts.region - Overrides `S3_REGION` for the virtual-hosted-style URL.
-   *
-   * @example
-   * ```typescript
-   * const externalUrl = storageManager.buildExternalUrl('S3', 'org-123/file.pdf', {
-   *   bucket: session.bucket,
-   *   visibility: session.visibility,
-   * })
-   * ```
    */
   buildExternalUrl(
     provider: ProviderId,
@@ -643,7 +619,7 @@ export class StorageManager {
       mimeType?: string
       metadata?: Record<string, any>
       bucket?: string
-      visibility?: 'PUBLIC' | 'PRIVATE'
+      visibility?: StorageVisibility
     },
     opts?: { tx?: any }
   ): Promise<StorageLocation> {
@@ -657,7 +633,7 @@ export class StorageManager {
         )
       }
 
-      const metadata = (await this.prepareLocationMetadata(params)) ?? {}
+      const metadata = await this.prepareLocationMetadata(params)
       // `prepareLocationMetadata` is where the bucket gets resolved, and
       // `CreateStorageLocationInput.bucket` is required, so it has to be read
       // back out rather than left buried in the blob. An unresolved bucket
@@ -713,11 +689,9 @@ export class StorageManager {
     credentialId?: string
     metadata?: Record<string, any>
     bucket?: string
-    visibility?: 'PUBLIC' | 'PRIVATE'
-  }): Promise<Record<string, any> | undefined> {
-    const metadata: Record<string, any> = {
-      ...(params.metadata ?? {}),
-    }
+    visibility?: StorageVisibility
+  }): Promise<Record<string, any>> {
+    const metadata: Record<string, any> = { ...(params.metadata ?? {}) }
 
     if (params.provider === 'S3') {
       const bucket = await this.resolveS3BucketForLocation({
@@ -741,7 +715,7 @@ export class StorageManager {
       }
     }
 
-    return Object.keys(metadata).length > 0 ? metadata : undefined
+    return metadata
   }
 
   /**
@@ -772,13 +746,56 @@ export class StorageManager {
   }
 
   /**
+   * The bucket for a key-addressed call whose caller supplied none.
+   *
+   * The single legacy shim behind `headByKey`, `deleteByKey`,
+   * `generatePartUploadUrl` and `completeMultipartUploadOnly`. Those four have
+   * an optional `bucket` that the functional layer does not: every parameter
+   * type in `storage/ports.ts` requires one, on the reasoning in that file's
+   * header. Rather than reintroduce the optional downstream, the facade resolves
+   * it here — loudly, so the warn names the call site that should be passing the
+   * upload session's `bucket`.
+   *
+   * Auth failures are swallowed on purpose: this is only computing a *fallback*,
+   * and the port resolves auth again for the real call, where the same failure
+   * surfaces properly.
+   */
+  private async legacyFallbackBucket(
+    params: { provider: ProviderId; key: string; credentialId?: string },
+    operation: string
+  ): Promise<string | undefined> {
+    const adapter = await getStorageAdapter(params.provider)
+
+    let auth: ProviderAuth | undefined
+    try {
+      auth = await resolveProviderAuth({
+        provider: params.provider,
+        organizationId: this.organizationId,
+        credentialId: params.credentialId,
+      })
+    } catch (error) {
+      logger.warn('Failed to resolve provider auth while picking a fallback bucket', {
+        provider: params.provider,
+        operation,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+
+    return this.resolveFallbackBucket(adapter, auth, {
+      provider: params.provider,
+      key: params.key,
+      operation,
+    })
+  }
+
+  /**
    * Determine S3 bucket for storage metadata
    */
   private async resolveS3BucketForLocation(params: {
     bucket?: string
     metadata: Record<string, any>
     credentialId?: string
-    visibility?: 'PUBLIC' | 'PRIVATE'
+    visibility?: StorageVisibility
   }): Promise<string | undefined> {
     let bucket =
       params.bucket ||
@@ -813,7 +830,7 @@ export class StorageManager {
       }
     }
 
-    // Platform bucket resolution now happens via getProviderAuth → adapter.resolvePlatformAuth(),
+    // Platform bucket resolution now happens via resolveProviderAuth → adapter.resolvePlatformAuth(),
     // which returns auth.bucket from configService. No separate configService fallback needed.
 
     return bucket || undefined
@@ -824,7 +841,7 @@ export class StorageManager {
    */
   private resolveS3BucketFromAuth(
     auth?: ProviderAuth,
-    visibility?: 'PUBLIC' | 'PRIVATE'
+    visibility?: StorageVisibility
   ): string | undefined {
     if (!auth) {
       return undefined
@@ -856,193 +873,38 @@ export class StorageManager {
     )
   }
 
-  /**
-   * Ensure S3 URL generation uses the bucket that matches the requested visibility.
-   */
-  private withResolvedS3Bucket(params: {
-    auth?: ProviderAuth
-    bucket?: string
-    visibility?: 'PUBLIC' | 'PRIVATE'
-  }): ProviderAuth | undefined {
-    let bucket = params.bucket
-
-    if (!bucket && params.visibility) {
-      bucket = bucketForVisibility(params.visibility) || undefined
-    }
-
-    if (!bucket) {
-      bucket = this.resolveS3BucketFromAuth(params.auth, params.visibility)
-    }
-
-    if (!bucket) {
-      return params.auth
-    }
-
-    return {
-      ...(params.auth ?? {}),
-      bucket,
-    }
-  }
-
-  // ============= File Operations =============
-
   // ============= Presigned URLs =============
 
   /**
-   * Centralized policy enforcement for upload operations
-   */
-  private enforcePolicy(config: UploadPreparedConfig) {
-    if (!config.storageKey.startsWith(config.policy.keyPrefix)) {
-      throw new StorageAdapterError(
-        `Key must start with '${config.policy.keyPrefix}'`,
-        config.provider,
-        'presign'
-      )
-    }
-
-    if (config.ttlSec > config.policy.maxTtl) {
-      throw new StorageAdapterError(
-        `TTL exceeds ${config.policy.maxTtl}s`,
-        config.provider,
-        'presign'
-      )
-    }
-
-    const [min, max] = config.policy.contentLengthRange
-    if (config.expectedSize < min || config.expectedSize > max) {
-      throw new StorageAdapterError(
-        `Size ${config.expectedSize} outside [${min}, ${max}]`,
-        config.provider,
-        'presign'
-      )
-    }
-
-    // MIME: support exact and wildcard families (image/*)
-    const allowed = config.policy.allowedMimeTypes.some((allowed) => {
-      if (allowed === '*/*') return true
-      if (allowed.endsWith('/*')) return config.mimeType.startsWith(allowed.slice(0, -2))
-      return config.mimeType === allowed
-    })
-
-    if (!allowed) {
-      throw new StorageAdapterError(
-        `MIME '${config.mimeType}' not allowed`,
-        config.provider,
-        'presign'
-      )
-    }
-  }
-
-  /**
-   * Generate presigned upload URL with policy enforcement (New Unified API)
+   * Generate a presigned upload URL, with the upload policy enforced.
    *
-   * This method enforces upload policies defined by processors and provides
-   * centralized security validation. This is the new API that replaces the
-   * basic generatePresignedUploadUrl for all upload flows.
+   * Delegates to `storage/presign.ts`, which is where the policy check lives
+   * since PR 3d — {@link StoragePort.presignUpload} signs whatever it is handed,
+   * so this is the only door that must be used.
    */
   async generatePresignedUploadUrl(
     config: UploadPreparedConfig & { metadata?: Record<string, string> }
   ): Promise<PresignedUpload> {
-    // Validate storage parameters
     this.validateStorageParams({ provider: config.provider })
-
-    this.enforcePolicy(config) // ✅ Add policy enforcement
-
-    // Get adapter for the provider
-    const adapter = await getStorageAdapter(config.provider)
-
-    // Check if adapter supports presigned uploads
-    const capabilities = adapter.getCapabilities()
-    if (!capabilities.presignUpload) {
-      throw new StorageAdapterError(
-        `Provider ${config.provider} does not support presigned uploads`,
-        config.provider,
-        'generatePresignedUploadUrl'
-      )
-    }
-
-    // Get authentication if credential ID provided
-    let auth: ProviderAuth | undefined
-    auth = await resolveProviderAuth({
-      provider: config.provider,
-      organizationId: this.organizationId,
-      credentialId: config.credentialId,
-    })
-
-    try {
-      // Use adapter to generate presigned upload URL
-      return await (adapter as any).presignUpload({
-        key: config.storageKey,
-        mimeType: config.mimeType,
-        size: config.expectedSize,
-        ttlSec: config.ttlSec,
-        metadata: {
-          orgId: config.organizationId,
-          uploader: config.userId,
-          entityType: config.entityType,
-          entityId: config.entityId ?? '',
-          ...config.metadata,
-        },
-        visibility: config.visibility, // Route to correct bucket
-        bucket: config.bucket, // Explicit bucket override
-        auth,
-      })
-    } catch (error) {
-      this.handleStorageError(error, 'generatePresignedUploadUrl', config.provider)
-    }
+    return this.run(presignUpload(this.port, config), 'generatePresignedUploadUrl', config.provider)
   }
 
   /**
-   * Start multipart upload with policy enforcement
+   * Start a multipart upload, with the upload policy enforced.
+   *
+   * The policy is *advisory* from here on — nothing constrains the total size or
+   * the real content type of a multipart upload until the `headByKey` that
+   * follows completion. `storage/presign.ts` documents the asymmetry in full.
    */
   async startMultipartUploadFromConfig(
     config: UploadPreparedConfig & { metadata?: Record<string, string> }
   ): Promise<MultipartUpload> {
-    // Validate storage parameters
     this.validateStorageParams({ provider: config.provider })
-
-    this.enforcePolicy(config) // ✅ Add policy enforcement
-
-    // Get adapter for the provider
-    const adapter = await getStorageAdapter(config.provider)
-
-    // Check if adapter supports multipart uploads
-    const capabilities = adapter.getCapabilities()
-    if (!capabilities.multipart) {
-      throw new StorageAdapterError(
-        `Provider ${config.provider} does not support multipart uploads`,
-        config.provider,
-        'startMultipartUploadFromConfig'
-      )
-    }
-
-    // Get authentication if credential ID provided
-    let auth: ProviderAuth | undefined
-    auth = await resolveProviderAuth({
-      provider: config.provider,
-      organizationId: this.organizationId,
-      credentialId: config.credentialId,
-    })
-
-    try {
-      // Use adapter to start multipart upload
-      return await (adapter as any).startMultipartUpload({
-        key: config.storageKey,
-        mimeType: config.mimeType,
-        metadata: {
-          orgId: config.organizationId,
-          uploader: config.userId,
-          entityType: config.entityType,
-          entityId: config.entityId ?? '',
-          ...config.metadata,
-        },
-        visibility: config.visibility, // Route to correct bucket
-        bucket: config.bucket, // Explicit bucket override
-        auth,
-      })
-    } catch (error) {
-      this.handleStorageError(error, 'startMultipartUploadFromConfig', config.provider)
-    }
+    return this.run(
+      startMultipartUpload(this.port, config),
+      'startMultipartUploadFromConfig',
+      config.provider
+    )
   }
 
   // ============= S3-Only Operations (No Persistence) =============
@@ -1053,7 +915,8 @@ export class StorageManager {
    *
    * @param params.bucket - The bucket the multipart upload was initiated in
    *   (the upload session's `bucket`). Completing against a different bucket
-   *   fails with `NoSuchUpload`.
+   *   fails with `NoSuchUpload`. Omitting it falls back — loudly — to the
+   *   provider default, which is almost always wrong for a PUBLIC upload.
    */
   async completeMultipartUploadOnly(params: {
     provider: ProviderId
@@ -1063,48 +926,22 @@ export class StorageManager {
     credentialId?: string
     bucket?: string
   }): Promise<{ etag: string; size?: number }> {
-    // Validate parameters
     this.validateStorageParams(params)
-
-    // Get adapter for the provider
-    const adapter = await getStorageAdapter(params.provider)
-
-    // Get authentication if credential ID provided
-    let auth: ProviderAuth | undefined
-    auth = await resolveProviderAuth({
-      provider: params.provider,
-      organizationId: this.organizationId,
-      credentialId: params.credentialId,
-    })
-
     const bucket =
-      params.bucket ??
-      this.resolveFallbackBucket(adapter, auth, {
-        provider: params.provider,
-        key: params.key,
-        operation: 'completeMultipartUploadOnly',
-      })
+      params.bucket ?? (await this.legacyFallbackBucket(params, 'completeMultipartUploadOnly'))
 
-    try {
-      // Use adapter to complete multipart upload without creating DB record
-      if ((adapter as any).completeMultipart) {
-        return await (adapter as any).completeMultipart({
-          key: params.key,
-          uploadId: params.uploadId,
-          parts: params.parts,
-          bucket,
-          auth,
-        })
-      } else {
-        throw new StorageAdapterError(
-          `Provider ${params.provider} does not support multipart upload completion`,
-          params.provider,
-          'completeMultipartUploadOnly'
-        )
-      }
-    } catch (error) {
-      this.handleStorageError(error, 'completeMultipartUploadOnly', params.provider)
-    }
+    return this.run(
+      completeMultipart(this.port, {
+        provider: params.provider,
+        bucket: bucket ?? '',
+        key: params.key,
+        credentialId: params.credentialId,
+        uploadId: params.uploadId,
+        parts: params.parts,
+      }),
+      'completeMultipartUploadOnly',
+      params.provider
+    )
   }
 
   /**
@@ -1120,68 +957,25 @@ export class StorageManager {
     credentialId?: string
     bucket?: string
   }): Promise<void> {
-    // Validate parameters
     this.validateStorageParams(params)
+    const bucket = params.bucket ?? (await this.legacyFallbackBucket(params, 'deleteByKey'))
 
-    // Get adapter for the provider
-    const adapter = await getStorageAdapter(params.provider)
-
-    // Get authentication if credential ID provided
-    let auth: ProviderAuth | undefined
-    try {
-      auth = await resolveProviderAuth({
+    await this.run(
+      deleteObject(this.port, {
         provider: params.provider,
-        organizationId: this.organizationId,
-        credentialId: params.credentialId,
-      })
-    } catch (error) {
-      // Log but don't fail - some adapters might work without explicit credentials
-      logger.warn(
-        'Failed to get provider authentication for deleteByKey, continuing without auth',
-        {
-          provider: params.provider,
-          error: error instanceof Error ? error.message : String(error),
-        }
-      )
-    }
-
-    const bucket =
-      params.bucket ??
-      this.resolveFallbackBucket(adapter, auth, {
-        provider: params.provider,
+        bucket: bucket ?? '',
         key: params.key,
-        operation: 'deleteByKey',
-      })
-
-    try {
-      // Build location reference for adapter. The bucket travels on metadata —
-      // adapters no longer resolve a default, so a missing bucket throws rather
-      // than silently deleting nothing.
-      const locationRef: StorageLocationRef = {
-        provider: params.provider,
-        externalId: params.key,
         credentialId: params.credentialId,
-        metadata: bucket ? { bucket, key: params.key } : undefined,
-      }
-
-      if (adapter.deleteFile) {
-        await adapter.deleteFile(locationRef, auth)
-      } else {
-        throw new StorageAdapterError(
-          `Provider ${params.provider} does not support file deletion`,
-          params.provider,
-          'deleteByKey'
-        )
-      }
-    } catch (error) {
-      this.handleStorageError(error, 'deleteByKey', params.provider)
-    }
+      }),
+      'deleteByKey',
+      params.provider
+    )
   }
 
-  // ============= Multipart Uploads (Legacy) =============
+  // ============= Multipart Uploads =============
 
   /**
-   * Generate presigned URL for upload part
+   * Generate presigned URL for uploading one part.
    *
    * @param params.bucket - The bucket the multipart upload was initiated in
    *   (the upload session's `bucket`). Presigning a part against a different
@@ -1196,66 +990,24 @@ export class StorageManager {
     credentialId?: string
     bucket?: string
   }): Promise<PresignedUpload> {
-    // Validate parameters
     this.validateStorageParams(params)
-
-    // Get adapter for the provider
-    const adapter = await getStorageAdapter(params.provider)
-
-    // Check if adapter supports multipart uploads
-    const capabilities = adapter.getCapabilities()
-    if (!capabilities.presignUpload) {
-      throw new StorageAdapterError(
-        `Provider ${params.provider} does not support part upload URLs`,
-        params.provider,
-        'generatePartUploadUrl'
-      )
-    }
-
-    // Get authentication if credential ID provided
-    let auth: ProviderAuth | undefined
-    auth = await resolveProviderAuth({
-      provider: params.provider,
-      organizationId: this.organizationId,
-      credentialId: params.credentialId,
-    })
-
     const bucket =
-      params.bucket ??
-      this.resolveFallbackBucket(adapter, auth, {
+      params.bucket ?? (await this.legacyFallbackBucket(params, 'generatePartUploadUrl'))
+
+    return this.run(
+      presignPart(this.port, {
         provider: params.provider,
+        bucket: bucket ?? '',
         key: params.key,
-        operation: 'generatePartUploadUrl',
-      })
-
-    try {
-      // Use adapter to generate part upload URL
-      if ((adapter as any).presignPart) {
-        return await (adapter as any).presignPart({
-          key: params.key,
-          uploadId: params.uploadId,
-          partNumber: params.partNumber,
-          size: params.size,
-          bucket,
-          auth,
-        })
-      } else {
-        throw new StorageAdapterError(
-          `Provider ${params.provider} does not support part upload URLs`,
-          params.provider,
-          'generatePartUploadUrl'
-        )
-      }
-    } catch (error) {
-      this.handleStorageError(error, 'generatePartUploadUrl', params.provider)
-    }
+        credentialId: params.credentialId,
+        uploadId: params.uploadId,
+        partNumber: params.partNumber,
+        size: params.size,
+      }),
+      'generatePartUploadUrl',
+      params.provider
+    )
   }
-
-  // ============= Provider Operations =============
-
-  // ============= Webhook Processing =============
-
-  // ============= Monitoring & Health =============
 
   // ============= Utility Methods =============
 
@@ -1340,33 +1092,17 @@ export class StorageManager {
   /**
    * Get file metadata by provider key without downloading (HEAD request)
    *
-   * Use this method for direct storage verification when you have provider/key
-   * but no storage location record. For files with existing location records,
-   * use getFileMetadata() instead for full metadata.
+   * Use this when you have provider/key but no `StorageLocation` row — upload
+   * verification, integrity checking. It is also the **only** real size and
+   * content-type check a multipart upload ever gets: see `storage/presign.ts`.
    *
-   * This is essential for upload verification and integrity checking before
-   * creating storage location records.
-   *
-   * @param params - Parameters for the head request
-   *   bucket (optional) provides an explicit S3 bucket, bypassing environment resolution
+   * @param params.bucket - The bucket the object lives in. Omitting it falls
+   *   back — loudly — to the provider default.
    * @returns Promise resolving to basic file metadata (size, mimeType, etagOrRev)
    *
    * @throws {StorageFileNotFoundError} When file doesn't exist
    * @throws {StorageAuthError} When authentication is invalid
    * @throws {StorageAdapterError} When operation fails
-   *
-   * @example
-   * ```typescript
-   * const metadata = await manager.headByKey({
-   *   provider: 'S3',
-   *   key: 'org-123/file.pdf',
-   *   credentialId: 's3_cred_id'
-   * })
-   *
-   * console.log(`File size: ${metadata.size} bytes`)
-   * console.log(`MIME type: ${metadata.mimeType}`)
-   * console.log(`ETag: ${metadata.etagOrRev}`)
-   * ```
    */
   async headByKey(params: {
     provider: ProviderId
@@ -1374,67 +1110,24 @@ export class StorageManager {
     credentialId?: string
     bucket?: string
   }): Promise<{ size: number; mimeType: string; etagOrRev: string }> {
-    // Validate parameters
     this.validateStorageParams(params)
+    const bucket = params.bucket ?? (await this.legacyFallbackBucket(params, 'headByKey'))
 
-    // Get adapter for the provider
-    const adapter = await getStorageAdapter(params.provider)
-
-    // Always try to get authentication (credential manager handles system credential fallback)
-    let auth: ProviderAuth | undefined
-    try {
-      auth = await resolveProviderAuth({
+    const metadata = await this.run(
+      headObject(this.port, {
         provider: params.provider,
-        organizationId: this.organizationId,
+        bucket: bucket ?? '',
+        key: params.key,
         credentialId: params.credentialId,
-      })
-    } catch (error) {
-      // Log but don't fail - adapter might work without explicit credentials
-      logger.warn('Failed to get provider authentication for headByKey, continuing without auth', {
-        provider: params.provider,
-        error: error instanceof Error ? error.message : String(error),
-      })
-    }
+      }),
+      'headByKey',
+      params.provider
+    )
 
-    try {
-      // Use adapter's getMeta method (equivalent to HEAD operation)
-      if ((adapter as any).getMeta) {
-        // ✅ CRITICAL FIX: Construct StorageLocationRef with the key as externalId
-        // The adapter (especially S3) will handle bucket resolution internally
-        // Never try to parse bucket from the key - always use configured bucket
-        const locationRef = {
-          provider: params.provider,
-          externalId: params.key, // This is the storage key, NOT bucket/key format
-          credentialId: params.credentialId,
-          metadata: params.bucket
-            ? {
-                bucket: params.bucket,
-                key: params.key,
-              }
-            : undefined,
-        }
-
-        const metadata = await (adapter as any).getMeta(locationRef, auth)
-
-        return {
-          size: metadata.size || 0,
-          mimeType: metadata.mimeType || 'application/octet-stream',
-          etagOrRev:
-            metadata.etagOrRev ||
-            metadata.etag ||
-            metadata.revision ||
-            metadata.lastModified?.toISOString() ||
-            '',
-        }
-      } else {
-        throw new StorageAdapterError(
-          `Provider ${params.provider} does not support metadata retrieval`,
-          params.provider,
-          'headByKey'
-        )
-      }
-    } catch (error) {
-      this.handleStorageError(error, 'headByKey', params.provider)
+    return {
+      size: metadata.size || 0,
+      mimeType: metadata.mimeType || 'application/octet-stream',
+      etagOrRev: metadata.etagOrRev || metadata.updatedAt?.toISOString() || '',
     }
   }
 
@@ -1445,6 +1138,12 @@ export class StorageManager {
    * error handling across all storage operations. Preserves existing storage
    * errors and wraps unknown errors in StorageAdapterError.
    *
+   * The `cause` unwrap is what keeps this facade's throw shape unchanged now
+   * that the delegates return `Result<T, AuxxError>`: `storage/errors.ts` maps
+   * an adapter error onto an `AuxxError` subclass and hangs the original off
+   * `cause`, so a caller that used to catch `StorageFileNotFoundError` still
+   * does.
+   *
    * @param error - The original error that occurred
    * @param operation - The operation that was being performed
    * @param provider - The provider where the error occurred
@@ -1453,6 +1152,10 @@ export class StorageManager {
    * @internal
    */
   private handleStorageError(error: any, operation: string, provider: ProviderId): never {
+    // An adapter error that `storageGuard` mapped on its way out. Restore it.
+    const adapterError = storageErrorCause(error)
+    if (adapterError) throw adapterError
+
     // If it's already a storage error, re-throw it
     if (
       error instanceof StorageAdapterError ||
@@ -1471,9 +1174,6 @@ export class StorageManager {
     )
   }
 }
-
-// Export singleton instance (with no specific organization)
-// export const storageManager = new StorageManager()
 
 // Factory function to create service instances for specific organizations
 export const createStorageManager = (organizationId?: string) => new StorageManager(organizationId)


### PR DESCRIPTION
PR 3d — the last of Phase 3 (`plans/attachments/03-storage-layer.md` §3.6). **The extraction found a
live bug, so this is a fix first and a refactor second.**

## Multipart uploads were completely broken

`StorageManager.startMultipartUploadFromConfig` called:

```ts
return await (adapter as any).startMultipartUpload({ ... })
```

**No adapter has ever had a method by that name.** `S3Adapter` defines `startMultipart`; the
`StorageAdapter` interface declares only `startMultipart?`. The single other occurrence of
`startMultipartUpload` in the repo is the mock adapter in `policy-enforcement.test.ts`, which had
grown the *wrong* name to match the call — which is precisely why the suite stayed green over it.

So every multipart upload threw
`Storage operation failed: (adapter as any).startMultipartUpload is not a function`, reached from
`POST /api/files/upload/sessions` (line ~183) whenever a file crossed the multipart threshold.

The typed `StoragePort` is what surfaced it — the `as any` was the only thing holding the call
together. This is the strongest argument yet for the refactor: an extraction PR found a production
outage that a green test suite was actively concealing.

**Worth deciding:** whether this warrants a note to anyone who has hit large-file upload failures.

## New modules

- **`storage/presign.ts`** — `enforceUploadPolicy` (pure, throws), plus `presignUpload`,
  `startMultipartUpload`, `presignPart`, `completeMultipart` over a `StoragePort`.
- **`storage/objects.ts`** — `putObject`, `getObject`, `streamObject`, `headObject`, `deleteObject`.
- **`storage/errors.ts`** — *not in the plan, and it is load-bearing.* `files/guard.ts` returns
  `err(e)` only for `AuxxError` and flattens everything else to `'Internal error'`. But every
  `StoragePort` failure is a `StorageAdapterError` / `StorageAuthError` / `StorageFileNotFoundError`,
  none of which extend `AuxxError`. Wrapping the port in the plain guard would have turned
  `File not found: org/x.pdf` into `Internal error` for every caller — including the upload-complete
  route, which puts `String(err)` into what it publishes to the client. `storageGuard` maps the three
  onto `NotFoundError`/`UnauthorizedError`/`AuxxError`, message verbatim, original on `cause`.
  *(`assets/download.ts` from Phase 2 has the same latent flattening on `presignDownload`; left
  alone as out of scope, but it should be fixed.)*

The **single-vs-multipart asymmetry** §3.6 asked to document is at the top of `presign.ts`, corrected
against the actual code: a presigned POST carries `content-length-range` and a `Content-Type`
condition so S3 re-enforces — **except on the `size === 0` branch, which signs a plain PUT with no
condition at all**. Multipart has no policy document, and `presignPart` bounds only one part, so
nothing constrains total size or true content type until `headObject`. That is why
`validateCompletedUpload` exists.

## `uploadContent` stays on the facade

It composes `putObject` + `buildExternalUrl` + `createStorageLocation`. It spans the port **and** the
database, and `objects.ts` is defined by what it cannot do — no `ctx`, no `db`, no transaction.
Putting a row-writing function there would destroy the property that makes the file worth having. Its
proper shape is `fn(tx, ctx, deps, input)`, and none of its 13 call sites has a `FilesCtx` or an open
transaction to give it. That is Phase 6's seam.

One fix taken while there: **the bucket is now resolved once** and reused for the object write, the
external URL and the persisted row. It was previously derived three independent times — three chances
to disagree, which is exactly the shape of #1816/#1817/#1818.

## Behaviour changes beyond extraction

1. Multipart start actually works (above).
2. `visibility` no longer reaches the adapter on presign/start/put — only the explicit `bucket`.
   `UploadPreparedConfig.bucket` is required, so nothing is lost.
3. `uploadContent`'s external URL comes from `storage/buckets.ts`, so an auth-derived `region` no
   longer feeds it. **Inert in practice** — none of the 13 call sites passes a `credentialId`, so auth
   is always platform auth whose region *is* `S3_REGION`. Same accepted change as 3b.
4. Policy violations surface as `Storage operation failed: Key must start with '…'` (BadRequestError
   through `handleStorageError`). Adapter errors stay byte-identical via the `cause` unwrap.
5. `deleteByKey`/`headByKey` no longer tolerate unresolvable provider auth — they used to log and
   continue with `auth: undefined`, letting the SDK fall back to env/IAM. Only fires when platform S3
   is unconfigured, where the call would have failed anyway, but it is a real change on a
   compensation path.
6. `headByKey`'s etag fallback lost three dead `as any` branches (`metadata.etag`/`.revision`/
   `.lastModified` — none exist on `FileMetadata`, all evaluated to `undefined`).

## `storage-manager.ts`: 1,479 → 1,179, not 400

The exit criterion asks for under 400. **Roughly 850 of the remaining 1,179 lines is code the plan
itself assigns to phases 4–6** — the location-addressed composites (`getDownloadRef`, `getContent`,
`streamFileContent`, `deleteFile`; 24 external call sites) and the legacy optional-`bucket` shims.

Moving the composites now would be a behaviour-change PR wearing an extraction PR's clothes, and it
turns on a real question: `buildLocationRef` spreads the row's entire `metadata` into
`parseS3Location` → `createS3Client`, so a row carrying `region` or `endpoint` currently steers the
S3 client. The bucket/key-only port drops that. Nothing writes those keys today, but historical rows
may carry them. That deserves its own PR, not a footnote in this one.

## Verification

- `packages/lib` typecheck **clean** (zero errors under `src/`); `apps/web`, `apps/api`,
  `apps/worker` clean against their known baselines.
- `src/files`: **244 passed / 22 files** (was 193/19 — +51 tests, +3 files).
- Full `packages/lib`: 11,246 passed, 1 failed — the known `resolve-resource-trigger-match` timeout.
- `apps/web` full: 3,818 passed, 5 failed — exactly the known set (`app-oauth-authorize-access` ×4,
  `mock-completeness` ×1). No new failures.
- New tests contain **zero `vi.mock`** (verified): `upload-policy.test.ts` (28 table-driven cases),
  `presign.test.ts` (12), `objects.test.ts` (11).
- `generate:exports`: no diff.

## Where the plan was wrong

- **§3.6 omits the multipart *start* entirely** — and that gap is exactly where the live bug was
  hiding. `StoragePort` had no `startMultipart` either; left as written, the multipart entry point
  would have stayed on the facade with a duplicated policy call, bug intact.
- **§3.6's `completeMultipart` return type is wrong.** It says `Result<HeadResult, …>`, but
  `CompleteMultipartUpload` returns `{etag, size?}` and S3 does not report size there. Returns
  `Result<MultipartCompletion, AuxxError>`.
- **§3.6's parameter type names are inventions** (`UploadPlanInput`, `PartInput`, `CompleteInput`);
  the real ones shipped in #1820.
- **§3.6 does not account for error translation at all** — hence `errors.ts`.
- **The "under 400 lines" criterion is not reachable within Phase 3's scope** and should be restated
  against the phase that owns the composites.

## Note for reviewers

Edits in `packages/lib` need a rebuild before `apps/*` see them (known repo footgun).