### PR TITLE
feat(parts): show which supplier the part cost came from

### DIFF
--- a/apps/web/src/components/drawers/tabs/part-subparts-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/part-subparts-tab.tsx
@@ -23,17 +23,34 @@ import {
   TableRow,
 } from '@auxx/ui/components/table'
 import { toastError } from '@auxx/ui/components/toast'
+import { pluralize } from '@auxx/utils'
 import { formatCurrency } from '@auxx/utils/currency'
-import { Edit, MoreHorizontal, Package, PlusCircle, Trash2 } from 'lucide-react'
+import { CircleAlert, Edit, MoreHorizontal, Package, PlusCircle, Trash2 } from 'lucide-react'
 import Link from 'next/link'
 import { useCallback, useMemo, useState } from 'react'
+import { Tooltip } from '~/components/global/tooltip'
 import { SubpartDialog } from '~/components/manufacturing/parts/subpart-dialog'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import type { DrawerTabProps } from '../drawer-tab-registry'
+
+/** What the assembly-level unpriced check reads off each subpart row. */
+const SUBPART_CHILD_ATTRIBUTES = ['subpart_child_part'] as const
+/** ...and off each child part it points at. */
+const CHILD_COST_ATTRIBUTES = ['part_cost'] as const
+/** The assembly's own cost — a blank one is what the banner explains. */
+const ASSEMBLY_COST_ATTRIBUTES = ['part_cost'] as const
+
+/** Unwrap a RELATIONSHIP value into the related instance id. */
+function relatedInstanceId(raw: unknown): string | undefined {
+  const first = Array.isArray(raw) ? raw[0] : raw
+  if (typeof first !== 'string') return undefined
+  return isRecordId(first) ? getInstanceId(first) : first
+}
 
 /** Subparts tab content for parts drawer */
 export function PartSubpartsTab({ recordId }: DrawerTabProps) {
@@ -110,6 +127,73 @@ export function PartSubpartsTab({ recordId }: DrawerTabProps) {
   })
 
   const isLoading = isLoadingSubparts || isLoadingParents
+
+  const partDefId = useResourceProperty('part', 'id')
+
+  // ── Which direct components have no cost ──────────────────────────────
+  //
+  // Two lifted reads, because the answer spans the list: the subpart rows say
+  // WHICH parts are components, and those parts say whether they are priced.
+  // A row subscribing to its own values can only ever answer for itself.
+  const subpartRecordIds = useMemo(
+    () => (subpartDefId ? subpartRecords.map((record) => toRecordId(subpartDefId, record.id)) : []),
+    [subpartRecords, subpartDefId]
+  )
+
+  const { valuesById: subpartValues } = useSystemValuesForRecords(
+    subpartRecordIds,
+    SUBPART_CHILD_ATTRIBUTES,
+    { autoFetch: true, enabled: subpartRecordIds.length > 0 }
+  )
+
+  const childPartRecordIds = useMemo(() => {
+    if (!partDefId) return []
+    const ids: RecordId[] = []
+    for (const subpartRecordId of subpartRecordIds) {
+      const childId = relatedInstanceId(subpartValues[subpartRecordId]?.subpart_child_part)
+      if (childId) ids.push(toRecordId(partDefId, childId))
+    }
+    return ids
+  }, [subpartRecordIds, subpartValues, partDefId])
+
+  const { valuesById: childCosts, loadedById: childCostsLoaded } = useSystemValuesForRecords(
+    childPartRecordIds,
+    CHILD_COST_ATTRIBUTES,
+    { autoFetch: true, enabled: childPartRecordIds.length > 0 }
+  )
+
+  const { values: assemblyValues } = useSystemValues(recordId, ASSEMBLY_COST_ATTRIBUTES, {
+    autoFetch: true,
+  })
+  const assemblyCost = assemblyValues.part_cost as number | null | undefined
+
+  /**
+   * Direct components with no cost of their own.
+   *
+   * **Direct children only.** The calculator tracks the transitive set of
+   * unpriced leaves, which is the right thing for it — but here the user is
+   * looking at one assembly's component list, and pointing at a part three
+   * levels down that is not on this screen would be worse than saying nothing.
+   * The copy says "component" to match what is listed.
+   *
+   * Only children whose cost has actually been READ are counted. An unfetched
+   * value and a genuinely absent one both surface as `undefined`, so counting
+   * without `loadedById` would report every component as uncosted on first
+   * paint and then correct itself — a wrong number is worse than a late one.
+   */
+  const unpricedChildIds = useMemo(() => {
+    const unpriced = new Set<string>()
+    for (const childRecordId of childPartRecordIds) {
+      if (!childCostsLoaded[childRecordId]?.part_cost) continue
+      if (childCosts[childRecordId]?.part_cost == null) unpriced.add(childRecordId)
+    }
+    return unpriced
+  }, [childPartRecordIds, childCosts, childCostsLoaded])
+
+  // Only explains a blank assembly cost. A costed assembly with an unpriced
+  // component is a real state (a vendor price won), but it is not this
+  // banner's job — nothing is missing from the number on screen.
+  const showUnpricedBanner = assemblyCost == null && unpricedChildIds.size > 0
 
   // Delete via entity system
   const deleteRecord = api.record.delete.useMutation({
@@ -192,30 +276,46 @@ export function PartSubpartsTab({ recordId }: DrawerTabProps) {
             <p className='text-xs text-muted-foreground'>Add components that make up this part</p>
           </div>
         ) : (
-          <div className='rounded-md border'>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Part</TableHead>
-                  <TableHead className='text-right'>Qty</TableHead>
-                  <TableHead className='text-right'>Cost</TableHead>
-                  <TableHead className='w-10'></TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {subpartRecords.map((record) => (
-                  <SubpartRow
-                    key={record.id}
-                    recordId={toRecordId(subpartDefId!, record.id)}
-                    relatedPartField='subpart_child_part'
-                    linkTab='subparts'
-                    showActions
-                    onEdit={() => handleEditSubpart(record.id)}
-                    onDelete={() => handleDeleteSubpart(record.id)}
-                  />
-                ))}
-              </TableBody>
-            </Table>
+          <div className='space-y-2'>
+            {showUnpricedBanner && (
+              <div className='flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5'>
+                <CircleAlert className='mt-0.5 size-4 shrink-0 text-amber-600' />
+                <p className='text-xs text-muted-foreground'>
+                  <span className='font-medium text-foreground'>
+                    {unpricedChildIds.size} {pluralize(unpricedChildIds.size, 'component')}{' '}
+                    {unpricedChildIds.size === 1 ? 'has' : 'have'} no cost
+                  </span>
+                  , so this assembly has none either. Add a supplier price or a bill of materials to
+                  each one below.
+                </p>
+              </div>
+            )}
+            <div className='rounded-md border'>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Part</TableHead>
+                    <TableHead className='text-right'>Qty</TableHead>
+                    <TableHead className='text-right'>Cost</TableHead>
+                    <TableHead className='w-10'></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {subpartRecords.map((record) => (
+                    <SubpartRow
+                      key={record.id}
+                      recordId={toRecordId(subpartDefId!, record.id)}
+                      relatedPartField='subpart_child_part'
+                      linkTab='subparts'
+                      showActions
+                      unpricedChildIds={unpricedChildIds}
+                      onEdit={() => handleEditSubpart(record.id)}
+                      onDelete={() => handleDeleteSubpart(record.id)}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
           </div>
         )}
       </Section>
@@ -272,6 +372,12 @@ interface SubpartRowProps {
   relatedPartField: 'subpart_child_part' | 'subpart_parent_part'
   linkTab: string
   showActions?: boolean
+  /**
+   * Component part `RecordId`s the assembly found to have no cost. Computed
+   * once by the tab so every row agrees with the banner above them, rather
+   * than each row deciding for itself.
+   */
+  unpricedChildIds?: ReadonlySet<string>
   onEdit?: () => void
   onDelete?: () => void
 }
@@ -281,6 +387,7 @@ function SubpartRow({
   relatedPartField,
   linkTab,
   showActions,
+  unpricedChildIds,
   onEdit,
   onDelete,
 }: SubpartRowProps) {
@@ -318,7 +425,11 @@ function SubpartRow({
       {showActions && (
         <>
           <TableCell className='text-right'>
-            {relatedPartId ? <PartCostCell partId={relatedPartId} /> : '—'}
+            {relatedPartId ? (
+              <PartCostCell partId={relatedPartId} unpricedChildIds={unpricedChildIds} />
+            ) : (
+              '—'
+            )}
           </TableCell>
           <TableCell>
             {canEdit && (
@@ -368,8 +479,20 @@ function PartNameCell({ partId, linkTab }: { partId: string; linkTab: string }) 
   )
 }
 
-/** Resolves and displays part cost from entity system */
-function PartCostCell({ partId }: { partId: string }) {
+/**
+ * A component's cost, marked when it has none.
+ *
+ * A blank cell already said "no cost"; what it never said is that this blank is
+ * why the assembly above has no cost either. The marker only appears for parts
+ * the tab counted, so a row can never disagree with the banner.
+ */
+function PartCostCell({
+  partId,
+  unpricedChildIds,
+}: {
+  partId: string
+  unpricedChildIds?: ReadonlySet<string>
+}) {
   const partDefId = useResourceProperty('part', 'id')
   const partRecordId = partDefId ? toRecordId(partDefId, partId) : ('' as RecordId)
   const { values } = useSystemValues(partRecordId || undefined, PART_COST_ATTRIBUTES, {
@@ -378,5 +501,18 @@ function PartCostCell({ partId }: { partId: string }) {
   })
   const cost = values.part_cost as number | null | undefined
 
-  return cost ? formatCurrency(cost) : <span className='text-muted-foreground'>—</span>
+  if (cost != null) return <>{formatCurrency(cost)}</>
+
+  if (partRecordId && unpricedChildIds?.has(partRecordId)) {
+    return (
+      <Tooltip content='This component has no cost, so it contributes nothing to the assembly'>
+        <span className='inline-flex items-center gap-1 text-amber-600'>
+          <CircleAlert className='size-3.5' />
+          No cost
+        </span>
+      </Tooltip>
+    )
+  }
+
+  return <span className='text-muted-foreground'>—</span>
 }

--- a/apps/web/src/components/drawers/tabs/part-vendors-tab-row.tsx
+++ b/apps/web/src/components/drawers/tabs/part-vendors-tab-row.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/drawers/tabs/part-vendors-tab-row.tsx
 'use client'
 
+import { computeLandedBreakdown, type LandedCostBreakdown } from '@auxx/lib/bom/client'
 import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
 import { Button } from '@auxx/ui/components/button'
 import {
@@ -13,54 +14,99 @@ import {
 import { TableCell, TableRow } from '@auxx/ui/components/table'
 import { pluralize } from '@auxx/utils'
 import { formatCurrency } from '@auxx/utils/currency'
-import { Edit, MoreHorizontal, Star, Trash2 } from 'lucide-react'
+import { BadgeCheck, Edit, MoreHorizontal, Star, Trash2 } from 'lucide-react'
 import { Tooltip } from '~/components/global/tooltip'
-import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import { RecordBadge } from '~/components/resources/ui/record-badge'
 import { useAccess } from '~/providers/capabilities-provider'
 
-const VENDOR_PART_ATTRIBUTES = [
-  'vendor_part_vendor_sku',
-  'vendor_part_unit_price',
-  'vendor_part_shipping_cost',
-  'vendor_part_tariff_rate',
-  'vendor_part_other_cost',
-  'vendor_part_lead_time',
-  'vendor_part_is_preferred',
-  'vendor_part_contact',
-] as const
+/**
+ * One supplier offer, already read by the parent tab.
+ *
+ * The row is presentational on purpose. It used to own a `useSystemValues`
+ * subscription, which meant no row could see its siblings — and "which offer
+ * wins" is only answerable across the whole list. The tab now reads every row's
+ * values in one batched subscription and hands them down.
+ */
+export interface VendorPartRowValues {
+  vendorSku?: string
+  unitPrice: number | null
+  shippingCost: number | null
+  tariffRate: number | null
+  otherCost: number | null
+  leadTime: number | null
+  isPreferred: boolean
+  /** Supplier `RecordId` (encodes the company entity def); `RecordBadge` resolves it. */
+  supplierRecordId?: RecordId
+}
 
 interface VendorPartRowProps {
   recordId: RecordId
+  values: VendorPartRowValues
+  /**
+   * Whether this offer is the one the part's Cost actually came from.
+   *
+   * Distinct from `isPreferred`, and both can be true at once: preference is
+   * one input to the rule, not the rule. With nothing preferred the cheapest
+   * landed offer wins, and before this marker existed nothing on screen said so.
+   */
+  isWinner: boolean
   onEdit: () => void
   onDelete: () => void
   onSetPreferred: () => void
 }
 
-/** A single vendor part row that subscribes to its own field values */
-export function VendorPartRow({ recordId, onEdit, onDelete, onSetPreferred }: VendorPartRowProps) {
-  const { values } = useSystemValues(recordId, VENDOR_PART_ATTRIBUTES, { autoFetch: true })
-  // const { resource: contactResource } = useResource('contacts')
+/**
+ * The landed cost, itemized.
+ *
+ * Every line is a whole minor unit and the four components sum to the total
+ * exactly — see `computeLandedBreakdown`, which rounds the one term that can
+ * carry a fraction. The tariff shows both its rate and the money that rate
+ * produced, because "10%" alone does not answer where the tariff went.
+ */
+function LandedBreakdown({ breakdown }: { breakdown: LandedCostBreakdown }) {
+  const rows: { label: string; value: number }[] = [
+    { label: 'Unit price', value: breakdown.unitPrice },
+    { label: 'Shipping', value: breakdown.shipping },
+    { label: `Tariff (${breakdown.tariffRate}%)`, value: breakdown.tariff },
+    { label: 'Other', value: breakdown.other },
+  ]
+
+  return (
+    <div className='min-w-44 space-y-1'>
+      {rows.map((row) => (
+        <div key={row.label} className='flex justify-between gap-4 text-xs'>
+          <span className='text-muted-foreground'>{row.label}</span>
+          <span className='tabular-nums'>{row.value === 0 ? '—' : formatCurrency(row.value)}</span>
+        </div>
+      ))}
+      <div className='flex justify-between gap-4 border-t pt-1 text-xs font-medium'>
+        <span>Landed</span>
+        <span className='tabular-nums'>{formatCurrency(breakdown.landed)}</span>
+      </div>
+    </div>
+  )
+}
+
+/** A single supplier offer for a part. */
+export function VendorPartRow({
+  recordId,
+  values,
+  isWinner,
+  onEdit,
+  onDelete,
+  onSetPreferred,
+}: VendorPartRowProps) {
   // Read-only viewers of the vendor_part definition get the row without its
   // actions menu — every item in it (edit, set preferred, remove) is a write.
   const { canEditEntity } = useAccess()
   const canEdit = canEditEntity(parseRecordId(recordId).entityDefinitionId)
 
-  const vendorSku = values.vendor_part_vendor_sku as string | undefined
-  const unitPrice = values.vendor_part_unit_price as number | null | undefined
-  const shippingCost = values.vendor_part_shipping_cost as number | null | undefined
-  const tariffRate = values.vendor_part_tariff_rate as number | null | undefined
-  const otherCost = values.vendor_part_other_cost as number | null | undefined
-  const leadTime = values.vendor_part_lead_time as number | null | undefined
-  const isPreferred = values.vendor_part_is_preferred as boolean | undefined
-  // Supplier RecordId (encodes the company entity def); RecordBadge resolves it.
-  const supplierRecordId = (values.vendor_part_contact as RecordId[] | undefined)?.[0]
+  const { vendorSku, unitPrice, leadTime, isPreferred, supplierRecordId } = values
 
-  // Compute landed cost inline: unit_price + shipping + (unit_price * tariff / 100) + other
-  const landedCost =
-    unitPrice != null
-      ? unitPrice + (shippingCost ?? 0) + unitPrice * ((tariffRate ?? 0) / 100) + (otherCost ?? 0)
-      : null
+  // One definition of the formula, shared with the cost calculator that
+  // actually persists this number.
+  const breakdown = computeLandedBreakdown({ id: recordId, ...values })
+
   return (
     <TableRow>
       <TableCell className='font-medium'>
@@ -71,21 +117,40 @@ export function VendorPartRow({ recordId, onEdit, onDelete, onSetPreferred }: Ve
             <span className='text-muted-foreground'>—</span>
           )}
           {isPreferred && (
-            <Tooltip content='Preferred Supplier'>
+            <Tooltip content='Preferred supplier'>
               <div className='text-amber-500'>
                 <Star className='size-3 fill-current' />
+              </div>
+            </Tooltip>
+          )}
+          {isWinner && (
+            <Tooltip content="This supplier's landed cost is the part's Cost">
+              <div className='text-emerald-600'>
+                <BadgeCheck className='size-3.5' />
               </div>
             </Tooltip>
           )}
         </div>
       </TableCell>
       <TableCell className='font-mono text-sm'>{vendorSku ?? '—'}</TableCell>
-      <TableCell className='text-right'>
-        {unitPrice ? formatCurrency(unitPrice) : <span className='text-muted-foreground'>—</span>}
+      <TableCell className='text-right tabular-nums'>
+        {unitPrice != null ? (
+          formatCurrency(unitPrice)
+        ) : (
+          <span className='text-muted-foreground'>—</span>
+        )}
       </TableCell>
-      <TableCell className='text-right'>
-        {landedCost != null && landedCost !== unitPrice ? (
-          formatCurrency(landedCost)
+      <TableCell className='text-right tabular-nums'>
+        {breakdown ? (
+          // Always shown when there is a price. It previously rendered a dash
+          // whenever landed equalled the unit price, which is most rows — a
+          // supplier with no shipping, tariff or other costs still HAS a landed
+          // cost, and it is that supplier's unit price.
+          <Tooltip contentComponent={<LandedBreakdown breakdown={breakdown} />}>
+            <span className='underline decoration-dotted underline-offset-4'>
+              {formatCurrency(breakdown.landed)}
+            </span>
+          </Tooltip>
         ) : (
           <span className='text-muted-foreground'>—</span>
         )}

--- a/apps/web/src/components/drawers/tabs/part-vendors-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/part-vendors-tab.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/drawers/tabs/part-vendors-tab.tsx
 'use client'
 
+import { selectWinningVendor } from '@auxx/lib/bom/client'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
 import type { ResourceFieldId } from '@auxx/types/field'
@@ -15,11 +16,39 @@ import { useCallback, useMemo, useState } from 'react'
 import { VendorPartDialog } from '~/components/manufacturing/parts/vendor-part-dialog'
 import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
+import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
 import { useConfirm } from '~/hooks/use-confirm'
 import { useAccess } from '~/providers/capabilities-provider'
 import { api } from '~/trpc/react'
 import type { DrawerTabProps } from '../drawer-tab-registry'
-import { VendorPartRow } from './part-vendors-tab-row'
+import { VendorPartRow, type VendorPartRowValues } from './part-vendors-tab-row'
+
+/** Everything a supplier row renders, and everything the winner rule needs. */
+const VENDOR_PART_ATTRIBUTES = [
+  'vendor_part_vendor_sku',
+  'vendor_part_unit_price',
+  'vendor_part_shipping_cost',
+  'vendor_part_tariff_rate',
+  'vendor_part_other_cost',
+  'vendor_part_lead_time',
+  'vendor_part_is_preferred',
+  'vendor_part_contact',
+] as const
+
+/** Narrow one record's raw system values into the row's shape. */
+function toRowValues(values: Record<string, unknown> | undefined): VendorPartRowValues {
+  const contact = values?.vendor_part_contact as RecordId[] | undefined
+  return {
+    vendorSku: values?.vendor_part_vendor_sku as string | undefined,
+    unitPrice: (values?.vendor_part_unit_price as number | null | undefined) ?? null,
+    shippingCost: (values?.vendor_part_shipping_cost as number | null | undefined) ?? null,
+    tariffRate: (values?.vendor_part_tariff_rate as number | null | undefined) ?? null,
+    otherCost: (values?.vendor_part_other_cost as number | null | undefined) ?? null,
+    leadTime: (values?.vendor_part_lead_time as number | null | undefined) ?? null,
+    isPreferred: (values?.vendor_part_is_preferred as boolean | undefined) ?? false,
+    supplierRecordId: contact?.[0],
+  }
+}
 
 /** Vendors tab content for parts drawer */
 export function PartVendorsTab({ recordId }: DrawerTabProps) {
@@ -61,6 +90,34 @@ export function PartVendorsTab({ recordId }: DrawerTabProps) {
     filters,
     enabled: !!partId && !!vendorPartDefId,
   })
+
+  const rowRecordIds = useMemo(
+    () => (vendorPartDefId ? records.map((record) => toRecordId(vendorPartDefId, record.id)) : []),
+    [records, vendorPartDefId]
+  )
+
+  // Lifted out of the rows: the winner is a property of the LIST, so no row can
+  // compute it from its own subscription. One batched read serves both.
+  const { valuesById } = useSystemValuesForRecords(rowRecordIds, VENDOR_PART_ATTRIBUTES, {
+    autoFetch: true,
+    enabled: rowRecordIds.length > 0,
+  })
+
+  /**
+   * Which offer the part's Cost came from.
+   *
+   * Computed with the same function the server-side calculator uses, never by
+   * matching rows against the stored `part_purchase_cost`: that value is a
+   * float produced by `unitPrice * (tariffRate / 100)`, and equality on it is
+   * not a safe key.
+   */
+  const winningRecordId = useMemo(() => {
+    const offers = rowRecordIds.map((recordId) => ({
+      id: recordId,
+      ...toRowValues(valuesById[recordId]),
+    }))
+    return selectWinningVendor(offers)?.id ?? null
+  }, [rowRecordIds, valuesById])
 
   // Delete via entity system
   const deleteRecord = api.record.delete.useMutation({
@@ -166,15 +223,20 @@ export function PartVendorsTab({ recordId }: DrawerTabProps) {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {records.map((record) => (
-                  <VendorPartRow
-                    key={record.id}
-                    recordId={toRecordId(vendorPartDefId!, record.id)}
-                    onEdit={() => handleEditVendorPart(record.id)}
-                    onDelete={() => handleDeleteVendorPart(record.id)}
-                    onSetPreferred={() => handleSetPreferred(record.id)}
-                  />
-                ))}
+                {records.map((record, index) => {
+                  const rowRecordId = rowRecordIds[index] as RecordId
+                  return (
+                    <VendorPartRow
+                      key={record.id}
+                      recordId={rowRecordId}
+                      values={toRowValues(valuesById[rowRecordId])}
+                      isWinner={rowRecordId === winningRecordId}
+                      onEdit={() => handleEditVendorPart(record.id)}
+                      onDelete={() => handleDeleteVendorPart(record.id)}
+                      onSetPreferred={() => handleSetPreferred(record.id)}
+                    />
+                  )
+                })}
               </TableBody>
             </Table>
           </div>

--- a/apps/web/src/components/resources/hooks/use-system-values-for-records.ts
+++ b/apps/web/src/components/resources/hooks/use-system-values-for-records.ts
@@ -1,0 +1,205 @@
+// apps/web/src/components/resources/hooks/use-system-values-for-records.ts
+
+import { formatToRawValue, isMultiValueFieldType } from '@auxx/lib/field-values/client'
+import type { RecordId } from '@auxx/lib/resources/client'
+import { getDefinitionId } from '@auxx/lib/resources/client'
+import type { FieldReference, FieldValueKey } from '@auxx/types/field'
+import { useLayoutEffect, useMemo, useRef } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { fieldValueFetchQueue } from '../store/field-value-fetch-queue'
+import { type CustomFieldValueState, useFieldValueStore } from '../store/field-value-store'
+import { useResourceStore } from '../store/resource-store'
+import { buildCanonicalFieldValueKey } from '../utils/canonicalize-field-ref'
+import { useNormalizedRecordIds, usePrefixEpoch } from '../utils/normalize-record-id'
+import { resolveSystemAttributeRef } from '../utils/resolve-system-attribute'
+
+/** Options for {@link useSystemValuesForRecords}. */
+interface UseSystemValuesForRecordsOptions {
+  /** When true, batch-fetch any values missing from the store. */
+  autoFetch?: boolean
+  /** When false, skips all lookups and returns empty. */
+  enabled?: boolean
+}
+
+/** Empty results, shared so a disabled hook returns stable references. */
+const EMPTY_VALUES: Record<string, Record<string, unknown>> = {}
+const EMPTY_LOADED: Record<string, Partial<Record<string, boolean>>> = {}
+
+/**
+ * The plural of `useSystemValues`: read the same system attributes across MANY
+ * records in one subscription.
+ *
+ * Exists because some answers are only visible across a whole list. The
+ * Suppliers tab has to know which supplier offer wins to mark it, and a row
+ * that subscribes to its own values can never see its siblings; the same is
+ * true of "how many components have no cost" on the Subparts tab. Calling
+ * `useSystemValues` in a loop is not an option — hooks cannot be called per
+ * item — so the read has to be lifted to the owner of the list.
+ *
+ * This is strictly cheaper than the per-row hooks it replaces, not an extra
+ * cost: every value already lives in one zustand store keyed by
+ * `FieldValueKey`, so this is a single shallow subscription over N keys instead
+ * of N subscriptions over one key each, and the auto-fetch goes out as one
+ * batch rather than N queued singles.
+ *
+ * Attributes resolve against **each record's own definition**, exactly as the
+ * singular hook does — a bare name can belong to two definitions, and resolving
+ * without one reads the wrong field.
+ *
+ * @returns `valuesById`, keyed by the record's normalized `RecordId`, plus
+ * `loadedById` — see below, it is the difference between "no value" and "not
+ * fetched yet".
+ */
+export function useSystemValuesForRecords<T extends string>(
+  recordIds: RecordId[],
+  systemAttributes: readonly T[],
+  options: UseSystemValuesForRecordsOptions = {}
+): {
+  valuesById: Record<string, Record<T, unknown>>
+  /**
+   * Whether a given (record, attribute) has actually been READ, as opposed to
+   * having no value.
+   *
+   * Both arrive as `undefined` in `valuesById`, and the difference matters
+   * whenever absence is the signal: counting "components with no cost" off
+   * unfetched values reports every component as uncosted on first paint. The
+   * fetch queue null-backfills every key it requests, so a raw `undefined`
+   * means not-yet-fetched and a raw `null` means genuinely empty — this map is
+   * that distinction, surfaced.
+   */
+  loadedById: Record<string, Partial<Record<T, boolean>>>
+  isLoading: boolean
+} {
+  const { autoFetch = false, enabled = true } = options
+
+  const systemAttributeMap = useResourceStore((state) => state.systemAttributeMap)
+  const systemAttributeByDef = useResourceStore((state) => state.systemAttributeByDef)
+  const ambiguousSystemAttributes = useResourceStore((state) => state.ambiguousSystemAttributes)
+  const fieldMap = useResourceStore((state) => state.fieldMap)
+
+  const normalizedIds = useNormalizedRecordIds(recordIds)
+  const epoch = usePrefixEpoch()
+
+  // Callers pass inline array literals, which are new references every render.
+  // Key the memos on contents so a re-render does not rebuild every canonical
+  // key and re-trigger the batch fetch.
+  const attrsKey = JSON.stringify(systemAttributes)
+  const idsKey = normalizedIds.join(',')
+
+  /**
+   * One entry per (record, resolvable attribute), carrying the canonical store
+   * key to subscribe on. Attributes that do not resolve for a record are
+   * dropped rather than represented as undefined — the caller sees a missing
+   * key, which is the same thing the singular hook does.
+   */
+  // biome-ignore lint/correctness/useExhaustiveDependencies: attrsKey/idsKey stand in for the arrays; epoch invalidates store-derived results
+  const entries = useMemo(() => {
+    if (!enabled) return []
+    const maps = { systemAttributeMap, systemAttributeByDef, ambiguousSystemAttributes }
+    const result: {
+      recordId: RecordId
+      attr: T
+      key: FieldValueKey
+      canonicalRecordId: RecordId
+      canonicalRef: FieldReference
+      fieldType: string
+      options?: unknown
+    }[] = []
+
+    for (const recordId of normalizedIds) {
+      const entityDefinitionId = getDefinitionId(recordId)
+      for (const attr of systemAttributes) {
+        const resourceFieldId = resolveSystemAttributeRef(maps, attr, entityDefinitionId)
+        if (!resourceFieldId) continue
+        const field = fieldMap[resourceFieldId]
+        if (!field?.fieldType) continue
+        const canonical = buildCanonicalFieldValueKey(recordId, resourceFieldId)
+        if (!canonical.key) continue
+        result.push({
+          recordId,
+          attr,
+          key: canonical.key,
+          canonicalRecordId: canonical.recordId,
+          canonicalRef: canonical.fieldRef,
+          fieldType: field.fieldType,
+          options: field.options,
+        })
+      }
+    }
+    return result
+  }, [
+    enabled,
+    attrsKey,
+    idsKey,
+    epoch,
+    systemAttributeMap,
+    systemAttributeByDef,
+    ambiguousSystemAttributes,
+    fieldMap,
+  ])
+
+  // One shallow subscription across every key, so the list re-renders when any
+  // of its records changes — including a realtime push from another session.
+  const rawValues = useFieldValueStore(
+    useShallow((state: CustomFieldValueState) => {
+      const result: Record<string, unknown> = {}
+      for (const entry of entries) {
+        result[entry.key] = state.values[entry.key]
+      }
+      return result
+    })
+  )
+
+  const isLoading = useFieldValueStore((state: CustomFieldValueState) => {
+    for (const entry of entries) {
+      if (entry.key in state.fetchingKeys) return true
+    }
+    return false
+  })
+
+  // Batch-queue once per (records + attributes + prefix-map) combination. The
+  // queue deduplicates internally, so overlapping lists cost nothing extra.
+  const queuedKeyRef = useRef<string>('')
+
+  useLayoutEffect(() => {
+    if (!autoFetch || entries.length === 0) return
+
+    const requestKey = `${idsKey}:${attrsKey}:${epoch}`
+    if (queuedKeyRef.current === requestKey) return
+    queuedKeyRef.current = requestKey
+
+    fieldValueFetchQueue.queueFetchBatch(
+      entries.map((entry) => ({ recordId: entry.canonicalRecordId, fieldRef: entry.canonicalRef }))
+    )
+  }, [autoFetch, entries, idsKey, attrsKey, epoch])
+
+  const { valuesById, loadedById } = useMemo(() => {
+    if (entries.length === 0) {
+      return {
+        valuesById: EMPTY_VALUES as Record<string, Record<T, unknown>>,
+        loadedById: EMPTY_LOADED as Record<string, Partial<Record<T, boolean>>>,
+      }
+    }
+    const result: Record<string, Record<T, unknown>> = {}
+    const loaded: Record<string, Partial<Record<T, boolean>>> = {}
+    for (const entry of entries) {
+      const bucket = (result[entry.recordId] ??= {} as Record<T, unknown>)
+      const loadedBucket = (loaded[entry.recordId] ??= {})
+      const raw = rawValues[entry.key]
+      loadedBucket[entry.attr] = raw !== undefined
+      const formatted =
+        raw !== undefined ? formatToRawValue(raw as never, entry.fieldType as never) : undefined
+      // Same collapse the singular hook applies: SINGLE_SELECT and single-value
+      // ACTOR arrive as one-element arrays for uniform UI handling, so scalar
+      // consumers get a scalar back. Genuinely multi-value types keep arrays.
+      bucket[entry.attr] =
+        Array.isArray(formatted) &&
+        !isMultiValueFieldType(entry.fieldType as never, entry.options as never)
+          ? formatted[0]
+          : formatted
+    }
+    return { valuesById: result, loadedById: loaded }
+  }, [entries, rawValues])
+
+  return { valuesById, loadedById, isLoading }
+}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -196,6 +196,12 @@
       "import": "./dist/availability/client.mjs",
       "default": "./src/availability/client.ts"
     },
+    "./bom/client": {
+      "types": "./src/bom/client.ts",
+      "source": "./src/bom/client.ts",
+      "import": "./dist/bom/client.mjs",
+      "default": "./src/bom/client.ts"
+    },
     "./cache": {
       "types": "./src/cache/index.ts",
       "source": "./src/cache/index.ts",

--- a/packages/lib/src/bom/client.ts
+++ b/packages/lib/src/bom/client.ts
@@ -1,0 +1,20 @@
+// packages/lib/src/bom/client.ts
+
+/**
+ * Client-safe surface of the BOM module.
+ *
+ * The drawer's Suppliers tab needs the landed-cost formula and the
+ * winning-supplier rule; it must NOT reach for `bom/index.ts`, which pulls the
+ * cost calculator and with it drizzle, the org cache and the realtime service.
+ *
+ * No `'use client'` directive here on purpose — server code imports these
+ * functions too (the calculator itself does), and the directive would turn
+ * every export into a client-reference proxy on that side.
+ */
+
+export type { LandedCostBreakdown, VendorCostRow } from './vendor-cost'
+export {
+  computeLandedBreakdown,
+  computeLandedCost,
+  selectWinningVendor,
+} from './vendor-cost'

--- a/packages/lib/src/bom/cost-calculator.test.ts
+++ b/packages/lib/src/bom/cost-calculator.test.ts
@@ -101,6 +101,7 @@ vi.mock('../money/catalog-pricing', () => ({
 
 import {
   calculateAllCosts,
+  loadOrgPricingData,
   recalculateAffectedParts,
   recalculateAllPartCosts,
 } from './cost-calculator'
@@ -504,5 +505,25 @@ describe('calculateAllCosts — the unpriced-components signal', () => {
     // unpriced leaves are not enumerable, so nothing is claimed.
     expect(results.get(A)!.unpricedDescendantIds).toEqual([])
     expect(results.get(B)!.unpricedDescendantIds).toEqual([])
+  })
+})
+
+describe('loadOrgPricingData — the offer id the tiebreak depends on', () => {
+  it("carries each vendor part's OWN instance id, not just the part it prices", async () => {
+    // `selectWinningVendor` breaks an exact tie on `id`. If the loader stopped
+    // populating it the comparison would silently be `undefined < undefined`,
+    // and the winner would go back to depending on Postgres row order — which
+    // is exactly the non-determinism the tiebreak exists to remove. Nothing
+    // else in this suite fails if that happens, so it is asserted directly.
+    h.queryQueue = [
+      [...vendorPartRows('vp_acme', MOTOR, 4000), ...vendorPartRows('vp_bolt', MOTOR, 4000)],
+      [],
+    ]
+
+    const { vendorPrices } = await loadOrgPricingData(ORG)
+
+    expect(vendorPrices.map((row) => row.id).sort()).toEqual(['vp_acme', 'vp_bolt'])
+    // ...and the part id stays a separate field rather than being overwritten.
+    expect(new Set(vendorPrices.map((row) => row.partInstanceId))).toEqual(new Set([MOTOR]))
   })
 })

--- a/packages/lib/src/bom/cost-calculator.ts
+++ b/packages/lib/src/bom/cost-calculator.ts
@@ -16,18 +16,21 @@ import {
   getRealtimeService,
   publishFieldValueUpdates,
 } from '../realtime'
+import { computeLandedCost, selectWinningVendor, type VendorCostRow } from './vendor-cost'
 
 const logger = createScopedLogger('bom:cost-calculator')
 
 // ─── Types ───────────────────────────────────────────────────────────
 
-interface VendorPriceRow {
+/**
+ * A `vendor_part` row as the calculator sees it.
+ *
+ * Extends the shared {@link VendorCostRow} — which carries the offer's own
+ * `id` and its four cost components — with the PART the offer is for, which is
+ * the calculator's grouping key and means nothing to the pure winner rule.
+ */
+interface VendorPriceRow extends VendorCostRow {
   partInstanceId: string
-  unitPrice: number | null
-  shippingCost: number | null
-  tariffRate: number | null
-  otherCost: number | null
-  isPreferred: boolean
 }
 
 interface VendorCostMaps {
@@ -234,9 +237,12 @@ async function loadOrgPricingData(orgId: string): Promise<OrgPricingData> {
       }
     }
 
-    for (const entry of byInstance.values()) {
+    for (const [instanceId, entry] of byInstance) {
       if (entry.partInstanceId) {
         vendorPrices.push({
+          // The offer's OWN id, not the part's — it is the deterministic
+          // tiebreak in `selectWinningVendor`.
+          id: instanceId,
           partInstanceId: entry.partInstanceId,
           unitPrice: entry.unitPrice,
           shippingCost: entry.shippingCost,
@@ -336,20 +342,12 @@ async function loadAllPartIds(orgId: string, partDefId: string): Promise<string[
 // ─── Graph Building ──────────────────────────────────────────────────
 
 /**
- * Compute landed cost for a vendor part row.
- * Formula: unit_price + shipping_cost + (unit_price * tariff_rate / 100) + other_cost
- */
-function computeLandedCost(row: VendorPriceRow): number | null {
-  if (row.unitPrice == null) return null
-  const shipping = row.shippingCost ?? 0
-  const tariff = row.unitPrice * ((row.tariffRate ?? 0) / 100)
-  const other = row.otherCost ?? 0
-  return row.unitPrice + shipping + tariff + other
-}
-
-/**
- * Best vendor per part: preferred first, then cheapest landed cost.
- * Returns the winning row's computed landed cost per part.
+ * The winning supplier's landed cost, per part.
+ *
+ * Both halves of the rule — the landed formula and which offer wins — live in
+ * `vendor-cost.ts` so the Suppliers drawer tab can mark the same row this
+ * function silently reduced to a number. See {@link selectWinningVendor} for
+ * the ordering, including why an exact tie now breaks on the offer's id.
  */
 function buildVendorCostMaps(vendorPrices: VendorPriceRow[]): VendorCostMaps {
   const landedCostMap = new Map<string, number>()
@@ -364,17 +362,11 @@ function buildVendorCostMaps(vendorPrices: VendorPriceRow[]): VendorCostMaps {
   }
 
   for (const [partId, rows] of byPart) {
-    // Preferred vendors first, then sort by landed cost ascending
-    const sorted = rows.sort((a, b) => {
-      if (a.isPreferred !== b.isPreferred) return a.isPreferred ? -1 : 1
-      return (computeLandedCost(a) ?? 0) - (computeLandedCost(b) ?? 0)
-    })
-    const best = sorted[0]
-    if (best?.unitPrice != null) {
-      const landed = computeLandedCost(best)
-      if (landed != null) {
-        landedCostMap.set(partId, landed)
-      }
+    const winner = selectWinningVendor(rows)
+    if (!winner) continue
+    const landed = computeLandedCost(winner)
+    if (landed != null) {
+      landedCostMap.set(partId, landed)
     }
   }
 

--- a/packages/lib/src/bom/index.ts
+++ b/packages/lib/src/bom/index.ts
@@ -1,3 +1,9 @@
 // packages/lib/src/bom/index.ts
 
 export { recalculateAffectedParts, recalculateAllPartCosts } from './cost-calculator'
+export type { LandedCostBreakdown, VendorCostRow } from './vendor-cost'
+export {
+  computeLandedBreakdown,
+  computeLandedCost,
+  selectWinningVendor,
+} from './vendor-cost'

--- a/packages/lib/src/bom/vendor-cost.test.ts
+++ b/packages/lib/src/bom/vendor-cost.test.ts
@@ -1,0 +1,177 @@
+// packages/lib/src/bom/vendor-cost.test.ts
+//
+// The landed formula and the winner rule are now shared between the cost
+// calculator and the Suppliers drawer tab, so their contract is tested here
+// once rather than asserted indirectly through `persistCosts`' writes.
+
+import { describe, expect, it } from 'vitest'
+import {
+  computeLandedBreakdown,
+  computeLandedCost,
+  selectWinningVendor,
+  type VendorCostRow,
+} from './vendor-cost'
+
+/** A priced offer; every cost is in minor units and `tariffRate` is a percent. */
+function offer(id: string, overrides: Partial<VendorCostRow> = {}): VendorCostRow {
+  return {
+    id,
+    unitPrice: 4000,
+    shippingCost: null,
+    tariffRate: null,
+    otherCost: null,
+    isPreferred: false,
+    ...overrides,
+  }
+}
+
+describe('computeLandedCost', () => {
+  it('adds shipping, the tariff the rate produces, and other costs', () => {
+    // $40.00 + $5.00 shipping + 10% of $40.00 + $1.00 other = $50.00
+    expect(
+      computeLandedCost(offer('a', { shippingCost: 500, tariffRate: 10, otherCost: 100 }))
+    ).toBe(5000)
+  })
+
+  it('treats every absent component as zero, not as unknown', () => {
+    expect(computeLandedCost(offer('a'))).toBe(4000)
+  })
+
+  it('is null for an unpriced offer rather than zero', () => {
+    // An unpriced supplier row is not a free supplier — it cannot compete.
+    expect(computeLandedCost(offer('a', { unitPrice: null }))).toBeNull()
+  })
+
+  it('keeps sub-minor-unit precision instead of rounding', () => {
+    // This exact value is what gets persisted as part_cost; rounding here would
+    // silently move every stored cost.
+    expect(computeLandedCost(offer('a', { unitPrice: 4133, tariffRate: 7.5 }))).toBeCloseTo(
+      4442.975,
+      6
+    )
+  })
+})
+
+describe('computeLandedBreakdown', () => {
+  it('splits the landed cost into components that sum to its own total', () => {
+    const breakdown = computeLandedBreakdown(
+      offer('a', { shippingCost: 500, tariffRate: 10, otherCost: 100 })
+    )
+
+    expect(breakdown).toEqual({
+      unitPrice: 4000,
+      shipping: 500,
+      tariff: 400,
+      tariffRate: 10,
+      other: 100,
+      landed: 5000,
+    })
+  })
+
+  it('reports the tariff as currency, keeping the rate alongside it', () => {
+    // "10%" without "$4.00" does not answer where the tariff went.
+    const breakdown = computeLandedBreakdown(offer('a', { tariffRate: 10 }))
+    expect(breakdown?.tariff).toBe(400)
+    expect(breakdown?.tariffRate).toBe(10)
+  })
+
+  it('rounds a fractional tariff to a whole minor unit', () => {
+    // 4133 * 7.5% = 309.975 -> 310
+    const breakdown = computeLandedBreakdown(offer('a', { unitPrice: 4133, tariffRate: 7.5 }))
+    expect(breakdown?.tariff).toBe(310)
+    expect(breakdown?.landed).toBe(4443)
+  })
+
+  it('lands on the same whole minor unit as the exact total, for any rate', () => {
+    // The guarantee the tooltip depends on: only the tariff term can be
+    // fractional, so rounding it alone and summing equals rounding the sum.
+    for (const unitPrice of [1, 7, 99, 4133, 12345, 999999]) {
+      for (const tariffRate of [0, 2.5, 7.5, 10, 12.375, 33.333]) {
+        const row = offer('a', { unitPrice, tariffRate, shippingCost: 517, otherCost: 89 })
+        const exact = computeLandedCost(row)
+        const breakdown = computeLandedBreakdown(row)
+        expect(breakdown?.landed).toBe(Math.round(exact as number))
+        expect(
+          (breakdown as { unitPrice: number }).unitPrice +
+            (breakdown as { shipping: number }).shipping +
+            (breakdown as { tariff: number }).tariff +
+            (breakdown as { other: number }).other
+        ).toBe(breakdown?.landed)
+      }
+    }
+  })
+
+  it('is null for an unpriced offer', () => {
+    expect(computeLandedBreakdown(offer('a', { unitPrice: null }))).toBeNull()
+  })
+})
+
+describe('selectWinningVendor', () => {
+  it('picks the cheapest LANDED offer, not the cheapest sticker price', () => {
+    // Sticker order is bolt < acme < cheap; landed order is the exact reverse.
+    const acme = offer('acme', { unitPrice: 4000, shippingCost: 500, tariffRate: 10 }) // 4900
+    const bolt = offer('bolt', { unitPrice: 3800, shippingCost: 1500 }) // 5300
+    const cheap = offer('cheap', { unitPrice: 4200, otherCost: 100 }) // 4300
+
+    expect(selectWinningVendor([acme, bolt, cheap])?.id).toBe('cheap')
+  })
+
+  it('lets a preferred offer beat a cheaper one', () => {
+    // Preference short-circuits the comparison; it is not a tiebreak.
+    const acme = offer('acme', { unitPrice: 4900, isPreferred: true })
+    const cheap = offer('cheap', { unitPrice: 4300 })
+
+    expect(selectWinningVendor([acme, cheap])?.id).toBe('acme')
+  })
+
+  it('falls back to cheapest landed WITHIN the preferred group', () => {
+    // Nothing enforces a single preferred row, so two can be preferred at once.
+    const dear = offer('dear', { unitPrice: 5000, isPreferred: true })
+    const near = offer('near', { unitPrice: 4700, isPreferred: true })
+    const cheapest = offer('cheapest', { unitPrice: 100 })
+
+    expect(selectWinningVendor([dear, near, cheapest])?.id).toBe('near')
+  })
+
+  it('excludes unpriced offers from the contest entirely', () => {
+    const unpriced = offer('unpriced', { unitPrice: null, shippingCost: 1 })
+    const priced = offer('priced', { unitPrice: 9999 })
+
+    expect(selectWinningVendor([unpriced, priced])?.id).toBe('priced')
+  })
+
+  it('is null when nothing is priced', () => {
+    expect(selectWinningVendor([offer('a', { unitPrice: null })])).toBeNull()
+  })
+
+  it('is null for no offers at all', () => {
+    expect(selectWinningVendor([])).toBeNull()
+  })
+
+  it('breaks an exact tie on id, regardless of input order', () => {
+    // Without this the winner depended on Postgres row order (the query has no
+    // ORDER BY), so the UI marker would hop between two identical rows.
+    const first = offer('bbb', { unitPrice: 4000 })
+    const second = offer('aaa', { unitPrice: 4000 })
+
+    expect(selectWinningVendor([first, second])?.id).toBe('aaa')
+    expect(selectWinningVendor([second, first])?.id).toBe('aaa')
+  })
+
+  it('applies the id tiebreak only within the winning preference group', () => {
+    // 'aaa' sorts first by id but is not preferred, so it must still lose.
+    const plain = offer('aaa', { unitPrice: 4000 })
+    const preferred = offer('zzz', { unitPrice: 4000, isPreferred: true })
+
+    expect(selectWinningVendor([plain, preferred])?.id).toBe('zzz')
+  })
+
+  it('does not mutate the caller array', () => {
+    const rows = [offer('b', { unitPrice: 100 }), offer('a', { unitPrice: 900 })]
+    const order = rows.map((r) => r.id)
+
+    selectWinningVendor(rows)
+
+    expect(rows.map((r) => r.id)).toEqual(order)
+  })
+})

--- a/packages/lib/src/bom/vendor-cost.ts
+++ b/packages/lib/src/bom/vendor-cost.ts
@@ -1,0 +1,186 @@
+// packages/lib/src/bom/vendor-cost.ts
+
+/**
+ * The landed-cost formula and the winning-supplier rule — the single definition
+ * of both, shared by the server-side cost calculator and the drawer UI.
+ *
+ * This file is pure: no `db`, no cache, no logger, nothing server-only. That is
+ * deliberate and load-bearing. Before it existed the landed formula lived twice
+ * — in `cost-calculator.ts` and hand-copied into the Suppliers tab's row
+ * component — and the winner rule lived only server-side, so the tab could not
+ * say which supplier a part's cost actually came from. It marked *preferred*
+ * instead, which is a different thing (see {@link selectWinningVendor}).
+ *
+ * Re-exported to the client through `bom/client.ts`; never import this module's
+ * neighbours from here.
+ */
+
+/**
+ * One supplier's priced offer for a part.
+ *
+ * Structural, not a database row: the calculator builds these from `FieldValue`
+ * rows and the UI builds them from its field-value store, and neither should
+ * have to know the other's shape.
+ */
+export interface VendorCostRow {
+  /**
+   * The `vendor_part` instance id. Carried solely so ordering is total — see
+   * the tiebreak note on {@link selectWinningVendor}.
+   */
+  id: string
+  /** Minor units (cents for USD). `null` means this offer is not priced. */
+  unitPrice: number | null
+  /** Minor units. */
+  shippingCost: number | null
+  /** A PERCENTAGE, not minor units — `10` means 10%. */
+  tariffRate: number | null
+  /** Minor units. */
+  otherCost: number | null
+  isPreferred: boolean
+}
+
+/**
+ * A landed cost split into the four things that produced it, every field in
+ * whole minor units.
+ *
+ * `tariff` is the CURRENCY the rate produced, not the rate — a breakdown that
+ * shows "10%" without "$4.00" does not answer *where did the tariff go*.
+ * `tariffRate` is carried alongside so a UI can show both without recomputing.
+ *
+ * **The components sum to `landed` exactly.** See {@link computeLandedBreakdown}.
+ */
+export interface LandedCostBreakdown {
+  unitPrice: number
+  shipping: number
+  /** The tariff in minor units, rounded to a whole unit. */
+  tariff: number
+  /** The percentage that produced {@link tariff}, for display. */
+  tariffRate: number
+  other: number
+  /** `unitPrice + shipping + tariff + other`, exact by construction. */
+  landed: number
+}
+
+/**
+ * The exact landed cost: `unit + shipping + (unit x rate/100) + other`.
+ *
+ * **Unrounded on purpose.** This is what the calculator persists as
+ * `part_purchase_cost` / `part_cost`, and it is what {@link selectWinningVendor}
+ * orders on. A sub-minor-unit fraction is real here — `4133` at `7.5%` yields
+ * `4442.975` — and rounding it at this level would silently change every stored
+ * cost. {@link computeLandedBreakdown} is the rounded, display-facing view.
+ *
+ * Returns `null` for an unpriced offer: an unpriced supplier row is not a
+ * zero-cost supplier, it is a row that cannot compete at all.
+ */
+export function computeLandedCost(row: VendorCostRow): number | null {
+  if (row.unitPrice == null) return null
+  const shipping = row.shippingCost ?? 0
+  const tariff = row.unitPrice * ((row.tariffRate ?? 0) / 100)
+  const other = row.otherCost ?? 0
+  return row.unitPrice + shipping + tariff + other
+}
+
+/**
+ * The landed cost split into displayable, whole-minor-unit components.
+ *
+ * **Why the components are guaranteed to add up.** `unitPrice`, `shippingCost`
+ * and `otherCost` are stored as integer minor units; only the tariff term can
+ * carry a fraction, because it is the one value computed rather than stored. So
+ * for integers a, b, c and a single fractional term f:
+ *
+ *     round(a + b + f + c) === a + b + c + round(f)
+ *
+ * Rounding the tariff alone and summing therefore lands on exactly the same
+ * whole minor unit as rounding {@link computeLandedCost}'s exact total. A
+ * breakdown whose lines do not visibly sum to its own total is worse than no
+ * breakdown, and this is why this one always does.
+ *
+ * Returns `null` when the offer has no unit price, matching
+ * {@link computeLandedCost}.
+ */
+export function computeLandedBreakdown(row: VendorCostRow): LandedCostBreakdown | null {
+  if (row.unitPrice == null) return null
+
+  const unitPrice = row.unitPrice
+  const shipping = row.shippingCost ?? 0
+  const tariffRate = row.tariffRate ?? 0
+  const other = row.otherCost ?? 0
+  const tariff = Math.round(unitPrice * (tariffRate / 100))
+
+  return {
+    unitPrice,
+    shipping,
+    tariff,
+    tariffRate,
+    other,
+    landed: unitPrice + shipping + tariff + other,
+  }
+}
+
+/**
+ * The supplier offer that a part's cost actually comes from, or `null` when no
+ * offer is priced.
+ *
+ * The rule, in order:
+ *
+ * 1. **Only priced offers compete.** A supplier row with a lead time and a
+ *    shipping cost but no unit price is skipped entirely — it still renders in
+ *    the Suppliers tab and can never win.
+ * 2. **Any preferred offer beats any non-preferred offer.** This is not a
+ *    tiebreak, it short-circuits the comparison: a preferred supplier wins even
+ *    when a cheaper one exists, and nothing today enforces that only one row is
+ *    preferred, so the preferred *group* wins and rule 3 settles it within that
+ *    group.
+ * 3. **Cheapest landed wins** — landed, not the sticker unit price. The two
+ *    orderings routinely disagree: a $38 offer with $15 shipping loses to a $42
+ *    offer with $1 of other costs.
+ * 4. **Ties break on `id`**, ascending.
+ *
+ * Rule 4 is the only behaviour this function adds over the original inline sort.
+ * Without it a tie was resolved by whatever order Postgres happened to return,
+ * because the underlying query has no `ORDER BY`. That was harmless while the
+ * winner was only ever reduced to a number — both rows produce the same landed
+ * cost — but the moment a UI marks *which row* won, a non-deterministic winner
+ * makes the marker hop between two identical rows for no reason the user can see.
+ *
+ * Does not mutate `rows`.
+ */
+export function selectWinningVendor<T extends VendorCostRow>(rows: readonly T[]): T | null {
+  let best: T | null = null
+  let bestLanded = 0
+
+  for (const row of rows) {
+    const landed = computeLandedCost(row)
+    if (landed == null) continue
+
+    if (best === null) {
+      best = row
+      bestLanded = landed
+      continue
+    }
+
+    if (isBetterOffer(row, landed, best, bestLanded)) {
+      best = row
+      bestLanded = landed
+    }
+  }
+
+  return best
+}
+
+/**
+ * Whether `row` outranks `best` under the rule documented on
+ * {@link selectWinningVendor}. Split out so the ordering is stated once and the
+ * selection loop stays a loop.
+ */
+function isBetterOffer(
+  row: VendorCostRow,
+  rowLanded: number,
+  best: VendorCostRow,
+  bestLanded: number
+): boolean {
+  if (row.isPreferred !== best.isPreferred) return row.isPreferred
+  if (rowLanded !== bestLanded) return rowLanded < bestLanded
+  return row.id < best.id
+}


### PR DESCRIPTION
Phase 4 of the part-cost provenance plan, on top of #1830. Three surfaces
plus one piece of deduplication.

## The Suppliers tab marked the wrong thing

It marked the **preferred** row. That is not the row that wins. The rule is
preferred-group-first, *then* cheapest landed — so with nothing starred, the
cheapest-landed supplier silently drives `part_cost` and nothing on screen
said which one. Worse, the ordering inverts in practice:

| Supplier | Unit | Shipping | Tariff | Other | Landed |
| --- | --- | --- | --- | --- | --- |
| Acme | $40.00 | $5.00 | 10% | — | $49.00 |
| Bolt Co | $38.00 | $15.00 | — | — | $53.00 |
| Cheap Parts | $42.00 | — | — | $1.00 | **$43.00** |

Cheapest sticker price is the worst actual deal. Cheap Parts wins, and the
most prominent number on the old screen was Bolt's $38.00.

Now there is a distinct winner marker (emerald `BadgeCheck`, separate from
the amber preferred `Star` — both can show at once), and hovering the landed
figure itemizes it. That is the answer to *"where did the tariff go"*, which
§1.3 of the plan flagged and nothing has answered until now.

## One landed formula, not three

It lived in `computeLandedCost` **and** hand-copied inside the tab row. The
tab needed the winner rule too, which would have made three. `bom/vendor-cost.ts`
now states the arithmetic and the selection rule once; the calculator and the
tab both consume it, client-safe through a new `bom/client` subpath. The tab
cannot drift from what `part_purchase_cost` actually stores.

Deliberately **not** done by matching rows against the stored
`part_purchase_cost` — float equality on a value produced by
`unitPrice * (tariffRate / 100)` is not a safe key.

## Deterministic tiebreak

Two offers with identical preference and identical landed cost were ordered
by whatever Postgres returned. The *value* was identical either way, so
nothing was wrong — but a marker keyed on it could hop between rows between
renders. Ordering is now `(isPreferred desc, landed asc, id asc)`, which
needed each offer's own instance id threaded through: `VendorPriceRow`
carried the *part* id, never its own.

## Landed column bug

`landedCost !== unitPrice ? formatCurrency(landedCost) : '—'` — a supplier
with no shipping, tariff or other costs still *has* a landed cost, and that
is most rows. They rendered a dash in a column labelled Landed.

## Why the breakdown adds up

`unitPrice`, `shippingCost` and `otherCost` are stored integer minor units;
the tariff is the only computed, possibly-fractional term. For integers a, b,
c and one fractional f, `round(a+b+f+c) === a+b+c+round(f)`. So rounding the
tariff alone and summing lands on exactly the same minor unit as rounding the
exact total. Tooltip lines sum to the tooltip total, and that total equals the
Landed cell. `computeLandedCost` itself stays unrounded, so nothing persisted
moves. A test asserts the identity across 36 unit-price/rate combinations.

## Subparts tab — why a blank cost is blank

After #1830 an assembly with an unpriced descendant correctly shows no cost,
with no explanation. Components with no cost are now marked, and a banner
counts them.

It counts **direct children**, matching what the table lists. The calculator's
transitive leaf set is the right answer for the server, but pointing at a part
three levels down that is not on screen would be worse than silence.

## Lifting the row state

Each row subscribed to its own values, so no row could see its siblings and
the winner could not be computed inside one. Values are lifted with a new
`useSystemValuesForRecords`. It is **cheaper** than what it replaces, not
additive: values already live in one zustand store keyed by `FieldValueKey`,
so this is one shallow subscription over N keys instead of N subscriptions
over one key, and auto-fetch goes out as a single batch instead of N singles.
Same store, same keys — realtime is untouched. Rows became presentational.

Counting is gated on whether a child's cost was actually **read**. An
unfetched value and a genuinely absent one both surface as `undefined`, so an
ungated count reports every component as uncosted on first paint and then
corrects itself. A wrong number is worse than a late one.

## Verification

- `src/bom`: 2 files, 36 tests, 0 failures.
- `packages/lib` tsc: zero errors in any file this branch touches.
- `apps/web` tsc: 10 errors, all in `command-palette.tsx` and
  `workflow/nodes/core/human/panel.tsx`, neither touched here. Pre-existing.
- Biome clean on all 11 files.

**Gap worth knowing:** no UI tests. The load-bearing logic is in
`vendor-cost.ts` and is covered there, but the tab wiring itself is verified
only by typecheck — nobody has rendered these tabs. Reviewer eyes on the two
drawer tabs would be worth more than usual here.
