### PR TITLE
feat(parts): add a buy-vs-build costing card to the part drawer

### DIFF
--- a/apps/web/src/components/drawers/cards/part-costing-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-costing-card.tsx
@@ -1,0 +1,171 @@
+// apps/web/src/components/drawers/cards/part-costing-card.tsx
+'use client'
+
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { CostSource, parseRecordId } from '@auxx/lib/resources/client'
+import type { ResourceFieldId } from '@auxx/types/field'
+import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { formatCurrency } from '@auxx/utils/currency'
+import { useMemo } from 'react'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { Tooltip } from '~/components/global/tooltip'
+import { useRecordList, useResourceProperty } from '~/components/resources'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import type { DrawerTabProps } from '../drawer-tab-registry'
+
+/**
+ * The three provenance fields migration 100 added under `part_cost`, plus the
+ * cost itself. All computed by the cost calculator — this card is read-only.
+ */
+const PART_COSTING_ATTRIBUTES = [
+  'part_cost',
+  'part_purchase_cost',
+  'part_rollup_cost',
+  'part_cost_source',
+] as const
+
+/** `CostSource.values` keyed by option value, for badge label + color. */
+const COST_SOURCE_BY_VALUE = Object.fromEntries(CostSource.values.map((v) => [v.value, v]))
+
+/**
+ * The winning number gets this marker: `part_cost` is a copy of whichever of
+ * the two candidates `part_cost_source` names, and the badge makes that
+ * visible without asking the user to compare digits.
+ */
+function PartCostBadge({ source }: { source: string }) {
+  const meta = COST_SOURCE_BY_VALUE[source]
+  return (
+    <Tooltip content={`The part's cost carries this value (cost source: ${meta?.label ?? source})`}>
+      <Badge variant={(meta?.color ?? 'gray') as Variant} size='xs'>
+        Part cost
+      </Badge>
+    </Tooltip>
+  )
+}
+
+/**
+ * Buy-vs-build and the not-costed signal for the part drawer's overview.
+ *
+ * Renders nothing unless it has something to say:
+ *
+ * - **Both `part_purchase_cost` and `part_rollup_cost` present** — the
+ *   comparison: both numbers, which one `part_cost` took (the cost-source
+ *   badge), and which is cheaper by how much. This is the question the old
+ *   single-column model made unaskable — only the winner was ever stored.
+ * - **`part_cost_source` is `none`** — the cost is blank and this says WHY:
+ *   a part with a bill of materials has unpriced components (the Subparts tab
+ *   counts them); a leaf has neither a supplier price nor a bill of materials.
+ *
+ * A part with exactly one candidate number and a cost is the common case and
+ * shows nothing extra — the Details panel already carries `part_cost`.
+ *
+ * Values come through the same field-value store as every other drawer read
+ * (`useSystemValues`); the subpart-presence check reuses the record-list the
+ * Inventory card on this same tab already loads (same filter shape, limit 1),
+ * so it costs no extra round trip.
+ *
+ * Registered as the `part:costing` overview card (`drawer-config.ts` +
+ * `drawer-tab-registry.tsx`) — `TabCardSection` owns the "Costing" section
+ * header and hides it when this renders nothing.
+ */
+export function PartCostingCard({ recordId }: DrawerTabProps) {
+  const { entityInstanceId: partId } = parseRecordId(recordId)
+
+  const { values } = useSystemValues(recordId, PART_COSTING_ATTRIBUTES, { autoFetch: true })
+  const purchaseCost = values.part_purchase_cost as number | null | undefined
+  const rollupCost = values.part_rollup_cost as number | null | undefined
+  const costSource = values.part_cost_source as string | undefined
+
+  const hasComparison = purchaseCost != null && rollupCost != null
+  const isUncosted = costSource === CostSource.NONE
+
+  // Whether the part has a bill of materials at all — decides which "why" the
+  // uncosted state shows. Same filter shape as PartInventoryCard's hasSubparts
+  // check on this tab, so the list read is shared, not repeated.
+  const subpartDefId = useResourceProperty('subpart', 'id')
+  const subpartFilters: ConditionGroup[] = useMemo(
+    () => [
+      {
+        id: 'parent-filter',
+        logicalOperator: 'AND' as const,
+        conditions: [
+          {
+            id: 'parent-match',
+            fieldId: 'subpart:parentPart' as ResourceFieldId,
+            operator: 'is' as const,
+            value: partId,
+          },
+        ],
+      },
+    ],
+    [partId]
+  )
+  const { records: subpartRecords, isLoading: isLoadingSubparts } = useRecordList({
+    entityDefinitionId: subpartDefId ?? '',
+    filters: subpartFilters,
+    limit: 1,
+    enabled: isUncosted && !!partId && !!subpartDefId,
+  })
+  const hasSubparts = subpartRecords.length > 0
+
+  if (!hasComparison && !isUncosted) return null
+
+  const noneMeta = COST_SOURCE_BY_VALUE[CostSource.NONE]
+
+  return (
+    <FieldPanel resizeId='part-costing' defaultLabelWidth={130}>
+      {hasComparison ? (
+        <>
+          <FieldPanelRow title='Buy (supplier)'>
+            <div className='flex min-h-8 items-center gap-2 text-sm tabular-nums'>
+              {formatCurrency(purchaseCost)}
+              {costSource === CostSource.VENDOR && <PartCostBadge source={costSource} />}
+            </div>
+          </FieldPanelRow>
+          <FieldPanelRow title='Build (BOM)'>
+            <div className='flex min-h-8 items-center gap-2 text-sm tabular-nums'>
+              {formatCurrency(rollupCost)}
+              {costSource === CostSource.BOM && <PartCostBadge source={costSource} />}
+            </div>
+          </FieldPanelRow>
+          <FieldPanelRow title='Comparison'>
+            <div className='flex min-h-8 items-center text-sm text-muted-foreground'>
+              {formatComparison(purchaseCost, rollupCost)}
+            </div>
+          </FieldPanelRow>
+        </>
+      ) : (
+        <FieldPanelRow title='Cost'>
+          <div className='flex min-h-8 flex-wrap items-center gap-2 text-sm'>
+            <Badge variant={(noneMeta?.color ?? 'amber') as Variant} size='xs'>
+              {noneMeta?.label ?? 'Not costed'}
+            </Badge>
+            {/* The reason waits for the subpart-presence read so it can never
+                  flash "no bill of materials" at an assembly. */}
+            {!isLoadingSubparts && (
+              <span className='text-xs text-muted-foreground'>
+                {hasSubparts
+                  ? 'The bill of materials has unpriced components — the Subparts tab lists them.'
+                  : 'No supplier price and no bill of materials.'}
+              </span>
+            )}
+          </div>
+        </FieldPanelRow>
+      )}
+    </FieldPanel>
+  )
+}
+
+/**
+ * "Buying is $310.00 cheaper (86%)" — the percentage is the saving relative to
+ * the more expensive option, so it reads as "what you save by not picking the
+ * other one". Equal costs are a real (if rare) answer, not an error.
+ */
+function formatComparison(purchaseCost: number, rollupCost: number): string {
+  if (purchaseCost === rollupCost) return 'Buying and building cost the same'
+  const cheaperLabel = purchaseCost < rollupCost ? 'Buying' : 'Building'
+  const delta = Math.abs(purchaseCost - rollupCost)
+  const expensive = Math.max(purchaseCost, rollupCost)
+  const pct = expensive > 0 ? Math.round((delta / expensive) * 100) : 0
+  return `${cheaperLabel} is ${formatCurrency(delta)} cheaper${pct > 0 ? ` (${pct}%)` : ''}`
+}

--- a/apps/web/src/components/drawers/drawer-tab-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-tab-registry.tsx
@@ -111,6 +111,10 @@ export const DRAWER_TAB_CARD_COMPONENTS: Record<
   // ─────────────────────────────────────────────────────────────────
   'part:inventory': () =>
     import('./cards/part-inventory-tab').then((m) => ({ default: m.PartInventoryTab })),
+  // Buy-vs-build comparison + the not-costed signal — renders nothing for a
+  // part with a single cost candidate, hiding its whole section.
+  'part:costing': () =>
+    import('./cards/part-costing-card').then((m) => ({ default: m.PartCostingCard })),
 
   // ─────────────────────────────────────────────────────────────────
   // QUOTE OVERVIEW CARDS (shared with the quote detail-view sidebar —

--- a/packages/lib/src/resources/client.ts
+++ b/packages/lib/src/resources/client.ts
@@ -66,6 +66,7 @@ export type {
 } from './registry/drawer-config-types'
 // Enum values (for badge labels, select options, etc.)
 export {
+  CostSource,
   StockMovementType,
   StockStatus,
   TicketPriority,

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -62,7 +62,13 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
       { value: 'vendors', label: 'Suppliers', icon: 'truck', recordResource: 'vendor_part' },
     ],
     tabCards: {
-      overview: [{ value: 'inventory', label: 'Inventory' }],
+      overview: [
+        { value: 'inventory', label: 'Inventory' },
+        // Cost provenance: buy-vs-build comparison + the not-costed signal.
+        // The card renders nothing for a part with a single cost candidate
+        // (the common case), which hides the whole section.
+        { value: 'costing', label: 'Costing' },
+      ],
     },
   },
 


### PR DESCRIPTION
Completes the parts cost-provenance work (#1824, #1830, #1833) with the last UI surface: the comparison the provenance fields exist to make askable.

## What

A **Costing** card on the part drawer's overview, registered through the standard card registry (`drawer-config.ts` `tabCards` + `DRAWER_TAB_CARD_COMPONENTS`) — not a hardcoded conditional in the shared drawer.

- **Both candidates present** → both numbers, a cost-source badge marking which one `part_cost` took, and "Buying/Building is $X cheaper (Y%)".
- **`part_cost_source` = `none`** → amber "Not costed" plus *why*: an assembly points at its unpriced components (the Subparts tab from #1833 lists them); a leaf has neither a supplier price nor a BOM. The reason waits for the subpart-presence read so it never flashes the wrong why.
- **Single candidate + a cost** (the common case) → the card renders nothing and `TabCardSection`'s `:empty` rule hides the whole section.

## Notes

- Reads go through the standard drawer paths: `useSystemValues` for the four `part_*` cost fields; subpart presence reuses the Inventory card's exact filter shape with `limit: 1`. No new endpoints.
- `CostSource` added to the client enum exports in `resources/client.ts` (it wasn't client-exported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)