### PR TITLE
fix(connectors): bind contributing mappings under named array roots

### DIFF
--- a/packages/lib/src/data-connectors/app-catalog.test.ts
+++ b/packages/lib/src/data-connectors/app-catalog.test.ts
@@ -290,13 +290,110 @@ describe('buildContributingFieldBindings', () => {
     expect(bindings).toHaveLength(0)
   })
 
-  it('drops everything for an array-rooted mapping', () => {
+  // A named array root relativizes deterministically ('variants[].sku' → 'sku'), the
+  // same rule the owned partitioner syncs on; only a NESTED array leaves a digit-less
+  // `[]` that `mapRecord.getByPath` cannot resolve, and that is skipped PER FIELD.
+  // Worked example from plans/products/02-shopify-mapping.md §1.4.
+  const partFields: ContributingTargetField[] = [
+    { id: 'f_sku', name: 'SKU', systemAttribute: 'part_sku', type: 'TEXT' },
+    { id: 'f_price', name: 'Price', systemAttribute: null, type: 'CURRENCY' },
+    { id: 'f_inventory', name: 'Inventory', systemAttribute: null, type: 'NUMBER' },
+  ]
+  const variantSourceFields = [
+    { fieldKey: 'variants.sku', sourcePath: 'variants[].sku', type: 'TEXT', name: 'SKU' },
+    { fieldKey: 'variants.price', sourcePath: 'variants[].price', type: 'CURRENCY', name: 'Price' },
+    {
+      fieldKey: 'variants.inventory_quantity',
+      sourcePath: 'variants[].inventory_quantity',
+      type: 'NUMBER',
+      name: 'Inventory quantity',
+    },
+    {
+      fieldKey: 'variants.option_value',
+      sourcePath: 'variants[].options[].value',
+      type: 'TEXT',
+      name: 'Option value',
+    },
+    { fieldKey: 'variants.id', sourcePath: 'variants[].id', type: 'TEXT', name: 'Variant ID' },
+  ]
+
+  it('binds declared fieldBindings under a named array root, subtree-relative (02 §1.4)', () => {
+    const bindings = buildContributingFieldBindings(
+      'def_part',
+      'shopify',
+      'variants[]',
+      [
+        { sourceFieldKey: 'variants.sku', targetKey: 'sku' },
+        { sourceFieldKey: 'variants.price', targetKey: 'price' },
+        { sourceFieldKey: 'variants.inventory_quantity', targetKey: 'inventory' },
+      ],
+      variantSourceFields,
+      partFields
+    )
+    expect(bindings.map((b) => b.targetFieldRef)).toEqual([
+      'def_part:f_sku',
+      'def_part:f_price',
+      'def_part:f_inventory',
+    ])
+    expect(bindings[0]).toMatchObject({
+      expression: '{sku}', // 'variants[].' stripped
+      sourceFields: { sku: 'sku' },
+    })
+    expect(bindings[1]!.expression).toBe('{price}')
+    expect(bindings[2]!.expression).toBe('{inventory_quantity}')
+  })
+
+  it('skips a NESTED array path per field, keeping its array-root siblings', () => {
+    const bindings = buildContributingFieldBindings(
+      'def_part',
+      'shopify',
+      'variants[]',
+      [
+        { sourceFieldKey: 'variants.sku', targetKey: 'sku' },
+        // 'options[].value' keeps a digit-less `[]` after stripping — unresolvable.
+        { sourceFieldKey: 'variants.option_value', targetKey: 'price' },
+      ],
+      variantSourceFields,
+      partFields
+    )
+    expect(bindings).toHaveLength(1)
+    expect(bindings[0]!.targetFieldRef).toBe('def_part:f_sku')
+  })
+
+  it('stamps identityRole externalId for an identity targetAppField under an array root', () => {
+    const bindings = buildContributingFieldBindings(
+      'def_part',
+      'shopify',
+      'variants[]',
+      [{ sourceFieldKey: 'variants.id', targetAppField: 'variantId' }],
+      variantSourceFields,
+      [
+        {
+          id: 'cf_variant_id',
+          name: 'Shopify variant ID',
+          systemAttribute: null,
+          type: 'TEXT',
+          appFieldKey: 'variantId',
+          appSlug: 'shopify',
+          isIdentity: true,
+        },
+      ]
+    )
+    expect(bindings).toHaveLength(1)
+    expect(bindings[0]).toMatchObject({
+      targetFieldRef: 'def_part:@app:shopify:variantId',
+      expression: '{id}',
+      identityRole: { kind: 'externalId' },
+    })
+  })
+
+  it('does NOT claim a source outside the root subtree boundary (customer vs customer_notes)', () => {
     const bindings = buildContributingFieldBindings(
       'def_contact',
       'shopify',
-      'line_items[]',
-      [{ sourceFieldKey: 'first_name', targetKey: 'first_name' }],
-      sourceFields,
+      'customer',
+      [{ sourceFieldKey: 'note_body', targetKey: 'first_name' }],
+      [{ fieldKey: 'note_body', sourcePath: 'customer_notes.body', type: 'TEXT', name: 'Note' }],
       defFields
     )
     expect(bindings).toHaveLength(0)
@@ -582,7 +679,9 @@ describe('buildContributingAutoBindings (zero-config heuristic)', () => {
     })
   })
 
-  it('drops everything for an array-rooted mapping', () => {
+  it('binds direct leaves under a named array root, still skipping nested-array leaves', () => {
+    // 'line_items[].first_name' relativizes to 'first_name' — deterministic, binds;
+    // 'line_items[].options[].value' keeps a digit-less `[]` — skipped per field.
     const bindings = buildContributingAutoBindings(
       'def_contact',
       'line_items[]',
@@ -593,9 +692,20 @@ describe('buildContributingAutoBindings (zero-config heuristic)', () => {
           type: 'TEXT',
           name: 'First Name',
         },
+        {
+          fieldKey: 'optionValue',
+          sourcePath: 'line_items[].options[].value',
+          type: 'TEXT',
+          name: 'Option value',
+        },
       ],
       contactFields
     )
-    expect(bindings).toHaveLength(0)
+    expect(bindings).toHaveLength(1)
+    expect(bindings[0]).toMatchObject({
+      targetFieldRef: 'def_contact:f_first',
+      expression: '{first_name}',
+      sourceFields: { first_name: 'first_name' },
+    })
   })
 })

--- a/packages/lib/src/data-connectors/app-catalog.ts
+++ b/packages/lib/src/data-connectors/app-catalog.ts
@@ -8,6 +8,7 @@ import type { CatalogDataConnector } from '@auxx/database'
 import { toAppFieldRef, toResourceFieldId } from '@auxx/types/field'
 import { generateId } from '@auxx/utils'
 import { inferJsonSchema, STRUCT_FIELD_TYPE_KEYWORD } from '../json-schema'
+import { isBoundaryPrefix, relativeSourcePath } from './source-paths'
 import type { FieldMapping, IdentityNormalize } from './types'
 
 /** A catalog source field's declared type → the JSON-schema scalar type it carries. */
@@ -123,13 +124,15 @@ function isWritableTarget(field: ContributingTargetField): boolean {
  * existing contact by `email`). Pure (caller supplies `defFields`) so it's unit-testable
  * without the org cache. A key binds only when it resolves UNAMBIGUOUSLY on both sides:
  *   - source — a declared stream field whose absolute `sourcePath` is the key under
- *     the mapping's `rootPath` (`customer` + `email` → `customer.email`); the stored
- *     `sourceFields` path is subtree-relative (`email`), matching how `mapRecord`
- *     evaluates a rooted mapping;
+ *     the mapping's `rootPath` (`customer` + `email` → `customer.email`; an array
+ *     root relativizes the same way — `variants[]` + `sku` → `variants[].sku`); the
+ *     stored `sourceFields` path is subtree-relative (`email`, `sku`), matching how
+ *     `mapRecord` evaluates a rooted mapping;
  *   - target — a field on the contributing def keyed by that match key (its
  *     `systemAttribute`, name, or normalized name).
- * Unresolved or array-rooted keys are dropped (the row stays a `needs-mapping` draft).
- * See multi-stream-setup-plan §5.2.
+ * Unresolved keys, and keys whose subtree-relative path crosses a NESTED array
+ * (a digit-less `[]` that `mapRecord.getByPath` cannot resolve), are dropped
+ * (the row stays a `needs-mapping` draft). See multi-stream-setup-plan §5.2.
  */
 export function buildContributingMatchBindings(
   entityDefinitionId: string,
@@ -139,21 +142,20 @@ export function buildContributingMatchBindings(
   defFields: ContributingTargetField[]
 ): FieldMapping[] {
   if (matchFieldKeys.length === 0) return []
-  // Identity match lives on a nested object (e.g. `customer`); array roots have no
-  // single deterministic source path for a key, so skip auto-binding them.
-  if (rootPath.includes('[]')) return []
 
   const fieldByKey = buildTargetFieldIndex(defFields)
-  const prefix = rootPath ? `${rootPath}.` : ''
   const bindings: FieldMapping[] = []
   for (const key of matchFieldKeys) {
+    // The key IS the subtree-relative path; one crossing a further array
+    // (`options[].value`) keeps a `[]` no per-record path can resolve — skip it.
+    if (key.includes('[]')) continue
     const target = fieldByKey.get(key) ?? fieldByKey.get(normalizeFieldKey(key))
     if (!target) continue
-    const absolutePath = `${prefix}${key}`
+    const absolutePath = rootPath ? `${rootPath}.${key}` : key
     const sourceField = sourceFields.find((f) => f.sourcePath === absolutePath)
     if (!sourceField) continue
     bindings.push(
-      bindSourceToTarget(entityDefinitionId, prefix, sourceField, target, {
+      bindSourceToTarget(entityDefinitionId, rootPath, sourceField, target, {
         kind: 'match',
         normalize: deriveNormalizeFromType(target.type),
       })
@@ -178,7 +180,8 @@ export function buildContributingMatchBindings(
  *     connection-scoped) via `toAppFieldRef`. A `targetAppField` binding whose app
  *     field is `identity: true` auto-stamps `identityRole: { kind: 'externalId' }`
  *     (the `isExternalId` mechanism, extended to contributing).
- * Array-rooted mappings and unresolved bindings are dropped (the row keeps whatever
+ * Unresolved bindings, sources outside the mapping's subtree, and sources whose
+ * subtree-relative path crosses a NESTED array are dropped (the row keeps whatever
  * draft state remains). The external id is never bound via `targetKey`.
  */
 export function buildContributingFieldBindings(
@@ -190,17 +193,20 @@ export function buildContributingFieldBindings(
   defFields: ContributingTargetField[]
 ): FieldMapping[] {
   if (fieldBindings.length === 0) return []
-  // An array root has no single deterministic subtree-relative path, same as match keys.
-  if (rootPath.includes('[]')) return []
 
   const fieldByKey = buildTargetFieldIndex(defFields)
-  const prefix = rootPath ? `${rootPath}.` : ''
   const bindings: FieldMapping[] = []
   for (const { sourceFieldKey, targetKey, targetAppField } of fieldBindings) {
     const sourceField = sourceFields.find((f) => f.fieldKey === sourceFieldKey)
-    // The source field must live under this mapping's subtree (its sourcePath starts
-    // with the rootPath prefix), else its relative path is undefined for this root.
-    if (!sourceField || (prefix && !sourceField.sourcePath.startsWith(prefix))) continue
+    // The source field must live under this mapping's subtree at a PATH BOUNDARY
+    // (`customer` must not claim `customer_notes.body`), and its subtree-relative
+    // path must not cross a further array — `variants[].options[].value` under root
+    // `variants[]` relativizes to `options[].value`, a digit-less `[]` that
+    // `mapRecord.getByPath` cannot resolve. A named array ROOT itself is fine:
+    // `variants[].sku` → `sku`, same as the owned partitioner.
+    if (!sourceField || !isBoundaryPrefix(sourceField.sourcePath, rootPath)) continue
+    const relative = relativeSourcePath(sourceField.sourcePath, rootPath)
+    if (relative === '' || relative.includes('[]')) continue
 
     if (targetAppField) {
       // App fields are CONNECTION-SCOPED — an org with multiple connections of the same
@@ -225,7 +231,7 @@ export function buildContributingFieldBindings(
           entityDefinitionId,
           appSlug,
           targetAppField,
-          prefix,
+          rootPath,
           sourceField,
           isIdentityField ? { kind: 'externalId' } : undefined
         )
@@ -235,7 +241,7 @@ export function buildContributingFieldBindings(
     if (!targetKey) continue
     const target = fieldByKey.get(targetKey) ?? fieldByKey.get(normalizeFieldKey(targetKey))
     if (!target) continue
-    bindings.push(bindSourceToTarget(entityDefinitionId, prefix, sourceField, target))
+    bindings.push(bindSourceToTarget(entityDefinitionId, rootPath, sourceField, target))
   }
   return bindings
 }
@@ -287,10 +293,7 @@ export function buildContributingAutoBindings(
   sourceFields: CatalogDataConnector['streams'][number]['fields'],
   defFields: ContributingTargetField[]
 ): FieldMapping[] {
-  if (rootPath.includes('[]')) return []
-
   const fieldByKey = buildTargetFieldIndex(defFields)
-  const prefix = rootPath ? `${rootPath}.` : ''
 
   // Group candidates by resolved target id so a target claimed by 2+ sources is ambiguous.
   const byTarget = new Map<
@@ -301,11 +304,10 @@ export function buildContributingAutoBindings(
     }[]
   >()
   for (const sourceField of sourceFields) {
-    const path = sourceField.sourcePath
-    if (prefix && !path.startsWith(prefix)) continue
-    const relative = prefix ? path.slice(prefix.length) : path
+    if (!isBoundaryPrefix(sourceField.sourcePath, rootPath)) continue
+    const relative = relativeSourcePath(sourceField.sourcePath, rootPath)
     // Only leaf fields directly on the root object — skip nested + array-element paths.
-    if (relative.includes('.') || relative.includes('[]')) continue
+    if (relative === '' || relative.includes('.') || relative.includes('[]')) continue
     const target = fieldByKey.get(relative) ?? fieldByKey.get(normalizeFieldKey(relative))
     if (!target || !isWritableTarget(target)) continue
     const list = byTarget.get(target.id) ?? []
@@ -317,7 +319,7 @@ export function buildContributingAutoBindings(
   for (const candidates of byTarget.values()) {
     if (candidates.length !== 1) continue // ambiguous → skip
     const { source, target } = candidates[0]!
-    bindings.push(bindSourceToTarget(entityDefinitionId, prefix, source, target))
+    bindings.push(bindSourceToTarget(entityDefinitionId, rootPath, source, target))
   }
   return bindings
 }
@@ -340,18 +342,19 @@ function buildTargetFieldIndex(
 
 /**
  * Construct one `FieldMapping` binding a resolved source field to a resolved target,
- * computing the subtree-relative source path (strip the `rootPath` prefix — `mapRecord`
- * evaluates a rooted mapping against subtree-relative paths). Pass `identityRole` to
- * flag it a secondary-identity match; omit for a plain value binding.
+ * computing the subtree-relative source path via {@link relativeSourcePath} (`mapRecord`
+ * evaluates a rooted mapping against subtree-relative paths — for an array root,
+ * against each extracted element). Pass `identityRole` to flag it a
+ * secondary-identity match; omit for a plain value binding.
  */
 function bindSourceToTarget(
   entityDefinitionId: string,
-  prefix: string,
+  rootPath: string,
   sourceField: CatalogDataConnector['streams'][number]['fields'][number],
   target: ContributingTargetField,
   identityRole?: FieldMapping['identityRole']
 ): FieldMapping {
-  const relativePath = prefix ? sourceField.sourcePath.slice(prefix.length) : sourceField.sourcePath
+  const relativePath = relativeSourcePath(sourceField.sourcePath, rootPath)
   return {
     id: generateId(),
     targetFieldRef: toResourceFieldId(entityDefinitionId, target.id),
@@ -372,11 +375,11 @@ function bindSourceToAppField(
   entityDefinitionId: string,
   appSlug: string,
   appFieldKey: string,
-  prefix: string,
+  rootPath: string,
   sourceField: CatalogDataConnector['streams'][number]['fields'][number],
   identityRole?: FieldMapping['identityRole']
 ): FieldMapping {
-  const relativePath = prefix ? sourceField.sourcePath.slice(prefix.length) : sourceField.sourcePath
+  const relativePath = relativeSourcePath(sourceField.sourcePath, rootPath)
   return {
     id: generateId(),
     targetFieldRef: toAppFieldRef(entityDefinitionId, appSlug, appFieldKey),

--- a/packages/lib/src/data-connectors/contributing-match-bindings.test.ts
+++ b/packages/lib/src/data-connectors/contributing-match-bindings.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { buildContributingMatchBindings, type ContributingTargetField } from './app-catalog'
 
 const DEF = 'def_contact'
+const DEF_PART = 'def_part'
 
 /** A contact def carrying a system email field (systemAttribute differs from the key). */
 const CONTACT_FIELDS: ContributingTargetField[] = [
@@ -19,6 +20,23 @@ const ORDER_FIELDS = [
     sourcePath: 'customer.email',
     type: 'EMAIL',
     name: 'Customer Email',
+  },
+]
+
+/** A part def carrying an sku field, matched by normalized name. */
+const PART_FIELDS: ContributingTargetField[] = [
+  { id: 'fld_sku', name: 'SKU', systemAttribute: 'part_sku', type: 'TEXT' },
+  { id: 'fld_option', name: 'Option value', systemAttribute: null, type: 'TEXT' },
+]
+
+/** The Shopify `product` stream's variant subtree (subset) — 02 §1.4's worked example. */
+const PRODUCT_VARIANT_FIELDS = [
+  { fieldKey: 'variants.sku', sourcePath: 'variants[].sku', type: 'TEXT', name: 'SKU' },
+  {
+    fieldKey: 'variants.option_value',
+    sourcePath: 'variants[].options[].value',
+    type: 'TEXT',
+    name: 'Option value',
   },
 ]
 
@@ -56,9 +74,40 @@ describe('buildContributingMatchBindings', () => {
     ).toEqual([])
   })
 
-  it('skips array roots (no single deterministic source path)', () => {
+  // A named array root relativizes deterministically ('variants[].sku' under
+  // 'variants[]' is 'sku') — the same rule the owned partitioner syncs on. Only a
+  // NESTED array (a `[]` surviving in the subtree-relative path) is unresolvable
+  // per record, because `mapRecord.getByPath` only matches indexed `[digit]` segments.
+  // See plans/products/06-contributing-array-root-binding.md and 02 §1.4.
+
+  it('binds a match key under a named array root (variants[] + sku)', () => {
+    const [binding, ...rest] = buildContributingMatchBindings(
+      DEF_PART,
+      'variants[]',
+      ['sku'],
+      PRODUCT_VARIANT_FIELDS,
+      PART_FIELDS
+    )
+    expect(rest).toHaveLength(0)
+    expect(binding).toMatchObject({
+      targetFieldRef: toResourceFieldId(DEF_PART, 'fld_sku'),
+      // Stored subtree-relative — 'sku', not 'variants[].sku'.
+      expression: '{sku}',
+      sourceFields: { sku: 'sku' },
+      identityRole: { kind: 'match', normalize: 'none' },
+    })
+  })
+
+  it('skips a key whose subtree-relative path crosses a NESTED array', () => {
+    // 'options[].value' under 'variants[]' keeps a digit-less `[]` — unresolvable.
     expect(
-      buildContributingMatchBindings(DEF, 'line_items[]', ['email'], ORDER_FIELDS, CONTACT_FIELDS)
+      buildContributingMatchBindings(
+        DEF_PART,
+        'variants[]',
+        ['options[].value'],
+        PRODUCT_VARIANT_FIELDS,
+        PART_FIELDS
+      )
     ).toEqual([])
   })
 

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -52,6 +52,7 @@ import {
   loadConnector,
   stampResyncPending,
 } from './service'
+import { isBoundaryPrefix, relativeSourcePath } from './source-paths'
 import type {
   ConnectorTemplate,
   ConnectorTemplateFieldMapping,
@@ -612,31 +613,9 @@ export async function restampWebhookBindingsForDeployment(
   }
 }
 
-/**
- * Is `prefix` a path-boundary prefix of `path`? `''` prefixes everything; an exact
- * match counts; otherwise `path` must continue at a boundary (`.` or `[`) so
- * `line_items[]` matches `line_items[].sku` but NOT `line_items_extra[]`.
- */
-function isBoundaryPrefix(path: string, prefix: string): boolean {
-  if (prefix === '') return true
-  if (!path.startsWith(prefix)) return false
-  if (path.length === prefix.length) return true
-  const next = path[prefix.length]
-  return next === '.' || next === '['
-}
-
-/**
- * Strip a `rootPath` prefix off a `path`, leaving it relative to that subtree —
- * `('line_items[].sku', 'line_items[]') → 'sku'`. Used both to relativize a field's
- * sourcePath against its owning mapping AND to relativize a nested child mapping's
- * own (payload-absolute, manifest) rootPath against its parent's rootPath before it
- * is stored (`absolutePrefix`/`subtreeUnder`/`mapRecord` all expect parent-relative).
- * `rootPath` must be a boundary-prefix of `path` (the caller resolves it that way).
- */
-export function relativeSourcePath(sourcePath: string, rootPath: string): string {
-  if (rootPath === '') return sourcePath
-  return sourcePath.slice(rootPath.length).replace(/^\./, '')
-}
+// Path helpers live in `./source-paths` (leaf module — `app-catalog.ts` needs them too,
+// and importing `mutations` back would form a cycle). Re-exported for existing importers.
+export { isBoundaryPrefix, relativeSourcePath } from './source-paths'
 
 /**
  * The parent of `rootPath` among `all` is the mapping whose rootPath is the longest

--- a/packages/lib/src/data-connectors/source-paths.ts
+++ b/packages/lib/src/data-connectors/source-paths.ts
@@ -1,0 +1,31 @@
+// packages/lib/src/data-connectors/source-paths.ts
+// Leaf path helpers shared by the owned-mapping partitioner (`mutations.ts`) and the
+// contributing auto-binders (`app-catalog.ts`). Lives in its own dependency-free module
+// because `mutations.ts` already imports `app-catalog.ts` — importing back would form a
+// cycle and drag drizzle/bullmq into the deliberately dependency-light `app-catalog.ts`.
+
+/**
+ * Is `prefix` a path-boundary prefix of `path`? `''` prefixes everything; an exact
+ * match counts; otherwise `path` must continue at a boundary (`.` or `[`) so
+ * `line_items[]` matches `line_items[].sku` but NOT `line_items_extra[]`.
+ */
+export function isBoundaryPrefix(path: string, prefix: string): boolean {
+  if (prefix === '') return true
+  if (!path.startsWith(prefix)) return false
+  if (path.length === prefix.length) return true
+  const next = path[prefix.length]
+  return next === '.' || next === '['
+}
+
+/**
+ * Strip a `rootPath` prefix off a `path`, leaving it relative to that subtree —
+ * `('line_items[].sku', 'line_items[]') → 'sku'`. Used both to relativize a field's
+ * sourcePath against its owning mapping AND to relativize a nested child mapping's
+ * own (payload-absolute, manifest) rootPath against its parent's rootPath before it
+ * is stored (`absolutePrefix`/`subtreeUnder`/`mapRecord` all expect parent-relative).
+ * `rootPath` must be a boundary-prefix of `path` (the caller resolves it that way).
+ */
+export function relativeSourcePath(sourcePath: string, rootPath: string): string {
+  if (rootPath === '') return sourcePath
+  return sourcePath.slice(rootPath.length).replace(/^\./, '')
+}


### PR DESCRIPTION
Implements the platform fix from the products plan set (prerequisite for one-click contribute mode; benefits every app connector).

## The bug

All three contributing auto-binders bailed on `rootPath.includes('[]')`, so a contributing mapping rooted at `variants[]` auto-bound **nothing** — field bindings, match keys, and the external-id stamp all silently dropped — while the stream still badged ready (`.some()` across mappings). Every merchant would have had to hand-bind five leaves in the mapping editor.

## The fix

The guard's premise was false for a *named* array root — the subtree-relative path is deterministic, and the owned path already relativizes with the exported `relativeSourcePath` helper in production (`('line_items[].sku', 'line_items[]') → 'sku'`). The guard is now **per-field**: skip only when the relative path still contains `[]` after stripping (a genuinely unresolvable nested array). Containment moves from bare `startsWith` to `isBoundaryPrefix`, so a root can no longer claim a sibling subtree by prefix luck (`customer` vs `customer_notes`).

Both helpers move to a new leaf module `source-paths.ts` (importing them from `mutations.ts` back into `app-catalog.ts` would form a cycle); `mutations.ts` re-exports them, so existing importers are untouched.

## Tests

The array-roots-bind-nothing fixtures are inverted; new coverage runs the worked `variants[]` example (sku/price/quantity + match key + identity stamp all bind) and the nested-array skip. **49 files, 424 tests green** in `src/data-connectors`.

## Caveat

This repairs the *builders*, not already-created connectors — an existing connector keeps its empty `fieldMappings` rows. That set is empty today (the live Shopify variants mapping is owned-mode), which is why now is the cheap moment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)