### PR TITLE
refactor(connectors): clean up provisionInventoryBridge leftovers

### DIFF
--- a/packages/lib/src/data-connectors/inventory-bridge-provisioning.test.ts
+++ b/packages/lib/src/data-connectors/inventory-bridge-provisioning.test.ts
@@ -16,6 +16,7 @@ vi.mock('../cache', () => ({ getCachedEntityDefId: h.getCachedEntityDefId }))
 vi.mock('../custom-fields', () => ({ createCustomField: h.createField }))
 vi.mock('./inventory-bridge-rule', () => ({ ensureInventoryDeductionRule: h.ensureRule }))
 
+import { ConflictError } from '../errors'
 import {
   INVENTORY_BRIDGE_EDGE_ATTR,
   provisionInventoryBridge,
@@ -49,9 +50,14 @@ describe('provisionInventoryBridge', () => {
     expect(fieldInput).toMatchObject({
       organizationId: ORG,
       entityDefinitionId: 'def_variants',
+      name: 'Part',
       type: 'RELATIONSHIP',
       systemAttribute: INVENTORY_BRIDGE_EDGE_ATTR,
-      relationship: { relatedResourceId: 'def_part', relationshipType: 'belongs_to' },
+      relationship: {
+        relatedResourceId: 'def_part',
+        relationshipType: 'belongs_to',
+        inverseName: 'Sold as variants',
+      },
     })
     expect(h.ensureRule).toHaveBeenCalledWith(db, ORG, {
       sourceDefId: 'def_variants',
@@ -74,8 +80,23 @@ describe('provisionInventoryBridge', () => {
     expect(r).toEqual({ relationshipFieldId: 'fld_existing' })
   })
 
-  it('createCustomField error ⇒ throws', async () => {
+  it('custom edge/inverse names override the defaults', async () => {
+    await provisionInventoryBridge(db, ORG, {
+      ...INPUT,
+      edgeName: 'Component',
+      inverseName: 'Sold as listings',
+    })
+
+    const [fieldInput] = h.createField.mock.calls[0]!
+    expect(fieldInput).toMatchObject({
+      name: 'Component',
+      relationship: expect.objectContaining({ inverseName: 'Sold as listings' }),
+    })
+  })
+
+  it('createCustomField error ⇒ throws ConflictError', async () => {
     h.createField.mockResolvedValue({ isErr: () => true, error: { message: 'boom' } })
+    await expect(provisionInventoryBridge(db, ORG, INPUT)).rejects.toThrow(ConflictError)
     await expect(provisionInventoryBridge(db, ORG, INPUT)).rejects.toThrow(/boom/)
     expect(h.ensureRule).not.toHaveBeenCalled()
   })

--- a/packages/lib/src/data-connectors/inventory-bridge-provisioning.ts
+++ b/packages/lib/src/data-connectors/inventory-bridge-provisioning.ts
@@ -12,11 +12,12 @@
 // See plans/data-connectors/v9/shopify-inventory-part-bridge-plan.md (Piece B1).
 
 import { type Database, schema } from '@auxx/database'
-import type { FieldType } from '@auxx/database/types'
+import { FieldType } from '@auxx/database/enums'
 import { createScopedLogger } from '@auxx/logger'
 import { and, eq } from 'drizzle-orm'
 import { getCachedEntityDefId } from '../cache'
 import { createCustomField } from '../custom-fields'
+import { ConflictError } from '../errors'
 import { ensureInventoryDeductionRule } from './inventory-bridge-rule'
 import { INVENTORY_BRIDGE_EDGE_ATTR } from './inventory-bridge-rule-consts'
 
@@ -35,6 +36,13 @@ export interface ProvisionInventoryBridgeInput {
   quantityFieldId: string
   /** App slug for the created field's provenance (optional). */
   appSlug?: string
+  /** Display name for the edge field on the source def. Defaults to 'Part'. */
+  edgeName?: string
+  /**
+   * Display name for the auto-created has_many inverse on `part`. Defaults to
+   * 'Sold as variants' (the Shopify caller's vocabulary) — other sources should pass their own.
+   */
+  inverseName?: string
 }
 
 /**
@@ -67,10 +75,8 @@ export async function provisionInventoryBridge(
       {
         organizationId,
         entityDefinitionId: input.sourceDefId,
-        name: 'Part',
-        // 'RELATIONSHIP' is the FieldType enum value (the enum object is a type-only
-        // export here, so the string literal is the runtime-safe way to pass it).
-        type: 'RELATIONSHIP' as FieldType,
+        name: input.edgeName ?? 'Part',
+        type: FieldType.RELATIONSHIP,
         systemAttribute: INVENTORY_BRIDGE_EDGE_ATTR,
         appSlug: input.appSlug,
         isCreatable: true,
@@ -78,15 +84,16 @@ export async function provisionInventoryBridge(
         relationship: {
           relatedResourceId: partDefId,
           relationshipType: 'belongs_to',
-          inverseName: 'Sold as variants',
+          inverseName: input.inverseName ?? 'Sold as variants',
         },
       },
       db
     )
     if (result.isErr()) {
-      // A name collision (field already present under a different attr) is benign — the
-      // config still needs writing, but we can't resolve an id here, so bail loudly.
-      throw new Error(`inventory bridge edge provisioning failed: ${result.error.message}`)
+      // Most likely a name collision — the def already has a field under this name but a
+      // different systemAttribute, so the idempotency lookup missed it and we cannot resolve
+      // an edge id. That is a provisioning failure the caller must see.
+      throw new ConflictError(`inventory bridge edge provisioning failed: ${result.error.message}`)
     }
     relationshipFieldId = result.value.id
     logger.info('provisioned inventory bridge edge', {


### PR DESCRIPTION
Behavior-preserving cleanup of five v9 leftovers in `provisionInventoryBridge`, per the products plan set (05):

1. The comment referencing the retired `INVENTORY_BRIDGE` setting era and contradicting itself ("benign … so bail loudly") now states the actual condition — a name collision the idempotency lookup cannot resolve — and why it must surface.
2. Bare `throw new Error` → `ConflictError` (lib code owes an `AuxxError`; message unchanged, so logs are stable).
3. `'Part'` / `'Sold as variants'` no longer hardcoded into a provider-agnostic bridge — optional `edgeName` / `inverseName` inputs with today's values as defaults; existing caller unchanged.
4. `'RELATIONSHIP' as FieldType` cast replaced with the runtime `FieldType` enum — the comment claiming the cast was necessary was factually wrong (the runtime const has existed all along).

The primitive extraction the plan originally proposed is deliberately **not** done — rescoped by R1: its justification was a second caller that contribute mode deleted.

Tests: existing suite extended (default names asserted, override-names case added, error test now asserts `ConflictError` specifically) — 5/5 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)