### PR TITLE
feat(sdk): widen EntityRefKind with part and product

### DIFF
--- a/packages/sdk/src/root/tools/types.ts
+++ b/packages/sdk/src/root/tools/types.ts
@@ -55,6 +55,14 @@ export interface ToolActionContext {
  * Entity ref kinds for fence-resolvable id fields in tool outputs.
  * Maps to system semantics on EntityDefinition (entityType / standardType).
  * See plans/kopilot/apps/refs.md §3.
+ *
+ * Admission rule: an entity a user thinks about and could open — business
+ * records, not join rows or ledger lines. So no `line_item`, `subpart`,
+ * `stock_movement` or `build`. `order` joins when the native order entity
+ * ships (plans/products/03-order-entity.md) — adding it earlier would let an
+ * app declare a field that silently provisions nothing, since the provisioner
+ * warns-and-skips on a kind no org resolves. `quote` / `work_order` /
+ * `payment` would qualify under the rule but wait for a consumer.
  */
 export type EntityRefKind =
   | 'contact'
@@ -67,6 +75,8 @@ export type EntityRefKind =
   | 'thread'
   | 'invoice'
   | 'catalog_item'
+  | 'part'
+  | 'product'
 
 /**
  * Per-tool configuration. See plans/kopilot/apps/README.md §4.2.


### PR DESCRIPTION
Implements D10/D10a from the products plan set — a hard prerequisite for the Shopify contribute-mode mapping, since every Shopify-shaped value on `part`/`product` lands in an app field (`defineFields` path A), which is gated on this union.

- Adds `'part'` and `'product'` to `EntityRefKind` — the union's single definition site (`sdk/src/root/tools/types.ts`; investigation confirmed no platform mirror exists, contrary to the plan's assumption).
- Writes the admission rule into the doc comment (D10a): *an entity a user thinks about and could open — business records, not join rows or ledger lines.* `order` joins when the order entity ships; `quote`/`work_order`/`payment` would qualify but wait for a consumer.
- Deliberately **not** added: `catalog_item` (already a member) and `order` (a kind in no org would let an app author declare a field, see no error, and get nothing — the provisioning path warns-and-skips).
- Provisioning path verified unchanged: `app-field-provisioning.ts` resolves via `getCachedEntityDefId` and warns-and-skips on failure.

Tests: full SDK suite 41/41 green, `tsc` clean. Note: the SDK must be **republished** for app authors to see the widened type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)