### PR TITLE
refactor(files): config building as one pure function, plus handler records

### DIFF
--- a/packages/lib/src/files/upload/__tests__/handler-processor-parity.test.ts
+++ b/packages/lib/src/files/upload/__tests__/handler-processor-parity.test.ts
@@ -1,0 +1,139 @@
+// packages/lib/src/files/upload/__tests__/handler-processor-parity.test.ts
+
+/**
+ * The guard that makes it safe for PR 4a to ship {@link UPLOAD_HANDLERS} before
+ * PR 4d converts the processors.
+ *
+ * Until that conversion lands there are two statements of the same per-entity
+ * numbers: the handler records, and the `protected readonly` fields on the
+ * processor classes the routes still dispatch through. Two statements of one
+ * fact drift — that is what this file exists to prevent. It fails the moment
+ * someone edits a size ceiling, a MIME list, a bucket or an asset kind on one
+ * side only.
+ *
+ * PR 4d deletes the processors and this file with them.
+ *
+ * ## The cast
+ *
+ * The processors declare these fields `protected`, so reading them needs a cast.
+ * That is the *test* reaching into production, not production reaching around
+ * its own types — and it is the only way to compare the two declarations
+ * without constructing a database. `processConfig` is not usable for the
+ * comparison: `BaseAttachmentProcessor` requires an `entityId` and then runs
+ * `validateEntityAccess`, which queries. `FileProcessor` has neither, so it is
+ * the one processor compared end to end.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { makeClock } from '../../__tests__/support'
+import type { AssetKind } from '../../core/types'
+import type { StorageVisibility } from '../../storage/buckets'
+import { ENTITY_TYPES, type EntityType } from '../../types/entities'
+import { buildUploadConfig } from '../config'
+import { UPLOAD_HANDLERS } from '../handlers'
+import type { UploadInitConfig } from '../init-types'
+import type { BaseAssetProcessor } from '../processors/base-asset-processor'
+import { DatasetAssetProcessor } from '../processors/dataset'
+import {
+  ArticleProcessor,
+  ChatWidgetProcessor,
+  CommentProcessor,
+  CustomFieldProcessor,
+  KnowledgeBaseProcessor,
+  MessageProcessor,
+  UserProfileProcessor,
+  WorkflowRunProcessor,
+} from '../processors/entity-processors'
+import { FileProcessor } from '../processors/file-processor'
+import { VisitQcItemProcessor } from '../processors/visit-qc-processor'
+
+const ORG = 'org_parity'
+
+/** The four declarative fields `BaseAssetProcessor` subclasses carry. */
+interface DeclaredFields {
+  fileVisibility: StorageVisibility
+  maxFileSize: number
+  allowedMimeTypes: string[]
+  assetKind: AssetKind
+}
+
+/** Read the `protected readonly` block off a constructed processor. */
+function declaredFields(processor: BaseAssetProcessor): DeclaredFields {
+  return processor as unknown as DeclaredFields
+}
+
+const ASSET_PROCESSORS: ReadonlyArray<[EntityType, () => BaseAssetProcessor]> = [
+  [ENTITY_TYPES.DATASET, () => new DatasetAssetProcessor(ORG)],
+  [ENTITY_TYPES.ARTICLE, () => new ArticleProcessor(ORG)],
+  [ENTITY_TYPES.USER_PROFILE, () => new UserProfileProcessor(ORG)],
+  [ENTITY_TYPES.WORKFLOW_RUN, () => new WorkflowRunProcessor(ORG)],
+  [ENTITY_TYPES.COMMENT, () => new CommentProcessor(ORG)],
+  [ENTITY_TYPES.MESSAGE, () => new MessageProcessor(ORG)],
+  [ENTITY_TYPES.KNOWLEDGE_BASE, () => new KnowledgeBaseProcessor(ORG)],
+  [ENTITY_TYPES.CHAT_WIDGET, () => new ChatWidgetProcessor(ORG)],
+  [ENTITY_TYPES.CUSTOM_FIELD, () => new CustomFieldProcessor(ORG)],
+  [ENTITY_TYPES.VISIT_QC_ITEM, () => new VisitQcItemProcessor(ORG)],
+]
+
+describe.each(ASSET_PROCESSORS)('%s handler matches its processor', (entityType, construct) => {
+  const handler = UPLOAD_HANDLERS[entityType as keyof typeof UPLOAD_HANDLERS]
+  const fields = declaredFields(construct())
+
+  it('declares the same bucket routing', () => {
+    // `ARTICLE` is the only handler whose visibility is a function; its base
+    // answer has to equal the processor's field, and the COVER override is
+    // asserted in `upload-config.test.ts`.
+    const base =
+      typeof handler.visibility === 'function'
+        ? handler.visibility({ metadata: {} } as UploadInitConfig)
+        : handler.visibility
+    expect(base).toBe(fields.fileVisibility)
+  })
+
+  it('declares the same size ceiling', () => {
+    expect(handler.maxFileSize).toBe(fields.maxFileSize)
+  })
+
+  it('declares the same MIME allow-list', () => {
+    expect([...handler.allowedMimeTypes]).toEqual(fields.allowedMimeTypes)
+  })
+
+  it('declares the same asset kind', () => {
+    expect(handler.assetKind).toBe(fields.assetKind)
+  })
+})
+
+describe('FILE handler matches FileProcessor end to end', () => {
+  const clock = makeClock()
+
+  function init(overrides: Partial<UploadInitConfig> = {}): UploadInitConfig {
+    return {
+      organizationId: ORG,
+      userId: 'usr_parity',
+      fileName: 'archive.zip',
+      mimeType: 'application/zip',
+      expectedSize: 4096,
+      entityType: ENTITY_TYPES.FILE,
+      ...overrides,
+    }
+  }
+
+  it.each([
+    ['a small file', 4096],
+    ['one byte below the multipart threshold', 100 * 1024 * 1024 - 1],
+    ['exactly at the multipart threshold', 100 * 1024 * 1024],
+  ])('produces the same config for %s', async (_name, expectedSize) => {
+    const { config: fromProcessor } = await new FileProcessor(ORG).processConfig(
+      init({ expectedSize })
+    )
+    const fromHandler = buildUploadConfig(UPLOAD_HANDLERS.FILE, init({ expectedSize }), clock.now)
+
+    // The key embeds a timestamp and the processor reads the wall clock, so the
+    // two differ by construction; everything else must be identical.
+    const { storageKey: processorKey, ...processorRest } = fromProcessor
+    const { storageKey: handlerKey, ...handlerRest } = fromHandler
+
+    expect(handlerRest).toEqual(processorRest)
+    expect(handlerKey.replace(/\/\d+_/, '/_')).toBe(processorKey.replace(/\/\d+_/, '/_'))
+  })
+})

--- a/packages/lib/src/files/upload/__tests__/upload-config.test.ts
+++ b/packages/lib/src/files/upload/__tests__/upload-config.test.ts
@@ -1,0 +1,596 @@
+// packages/lib/src/files/upload/__tests__/upload-config.test.ts
+
+/**
+ * `buildUploadConfig` and `validateCompletedUpload`, over every entity type,
+ * with **`vi.mock` called zero times in this file**.
+ *
+ * This is the test the four-level `processConfig` chain could not have. Asking
+ * "what config does an article cover get?" used to mean constructing a
+ * processor — which constructs three services, each binding a database at
+ * module scope — and then mocking `@auxx/database`, `drizzle-orm`, `@auxx/redis`,
+ * `nanoid`, `@auxx/credentials` and the logger to keep the import graph alive.
+ * `unified-upload-integration.test.ts` still does exactly that, in 130 lines of
+ * hoisted fakes before its first assertion.
+ *
+ * Everything below is data in, data out. The two ambient inputs are the clock,
+ * which arrives as a parameter, and `configService`'s bucket names, which
+ * resolve `process.env` at call time and are pinned by the `beforeAll` below —
+ * not mocked, because the real resolution order is part of what is asserted.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { BadRequestError, UnprocessableEntityError } from '../../../errors'
+import { makeClock } from '../../__tests__/support'
+import type { AssetKind } from '../../core/types'
+import { ENTITY_TYPES, type EntityType } from '../../types/entities'
+import { buildUploadConfig, DEFAULT_TTL_SEC, MIN_TTL_SEC, validateCompletedUpload } from '../config'
+import { getUploadHandler, UPLOAD_HANDLERS } from '../handlers'
+import type { PersistStrategy } from '../handlers/types'
+import type { UploadInitConfig, UploadPolicy } from '../init-types'
+
+const MB = 1024 * 1024
+
+const BUCKETS = { public: 'test-public-bucket', private: 'test-private-bucket' } as const
+
+const CONFIG_KEYS = ['CDN_URL', 'S3_PUBLIC_BUCKET', 'S3_PRIVATE_BUCKET', 'S3_REGION'] as const
+const originals = new Map(CONFIG_KEYS.map((key) => [key, process.env[key]]))
+
+/**
+ * Pin the two bucket names and clear `CDN_URL` for the whole file.
+ *
+ * Every case asserts on the bucket, so an ambient `.env` on a developer machine
+ * must not be able to change an outcome.
+ */
+beforeAll(() => {
+  process.env.S3_PUBLIC_BUCKET = BUCKETS.public
+  process.env.S3_PRIVATE_BUCKET = BUCKETS.private
+  delete process.env.CDN_URL
+})
+
+afterAll(() => {
+  for (const [key, value] of originals) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+})
+
+const clock = makeClock('2026-03-04T05:06:07.000Z')
+const NOW_MS = clock.millis()
+
+const ORG = 'org_upload_cfg'
+const USER = 'usr_upload_cfg'
+
+function init(overrides: Partial<UploadInitConfig> & { entityType: EntityType }): UploadInitConfig {
+  return {
+    organizationId: ORG,
+    userId: USER,
+    fileName: 'report.pdf',
+    mimeType: 'application/pdf',
+    expectedSize: 1024,
+    entityId: 'ent_1',
+    ...overrides,
+  }
+}
+
+/**
+ * One row of the matrix.
+ *
+ * The numbers are restated here rather than read back off the handler on
+ * purpose: a test that computes its expectation from the same record it is
+ * checking asserts only that the code is self-consistent. These are the values
+ * the processor classes carry, written out by hand.
+ */
+interface ConfigCase {
+  entityType: EntityType
+  visibility: 'PUBLIC' | 'PRIVATE'
+  bucket: string
+  /** kebab-case segment `deriveStorageKey` puts in the key. */
+  keySegment: string
+  maxFileSize: number
+  maxTtlSec: number
+  persist: PersistStrategy
+  assetKind?: AssetKind
+  /** A type the handler admits. */
+  allowedMime: string
+  /** A type it refuses, or `null` when the handler admits everything. */
+  refusedMime: string | null
+  /**
+   * The smallest size planned as multipart, or `null` when the size ceiling sits
+   * below the threshold and multipart is therefore unreachable for this entity.
+   */
+  multipartAt: number | null
+}
+
+const CASES: readonly ConfigCase[] = [
+  {
+    entityType: ENTITY_TYPES.FILE,
+    visibility: 'PRIVATE',
+    bucket: BUCKETS.private,
+    keySegment: 'file',
+    maxFileSize: Number.MAX_SAFE_INTEGER,
+    maxTtlSec: 60 * 60,
+    persist: 'folder-file',
+    allowedMime: 'application/x-msdownload',
+    refusedMime: null,
+    multipartAt: 100 * MB,
+  },
+  {
+    entityType: ENTITY_TYPES.DATASET,
+    visibility: 'PRIVATE',
+    bucket: BUCKETS.private,
+    keySegment: 'dataset',
+    maxFileSize: 50 * MB,
+    maxTtlSec: 10 * 60,
+    persist: 'asset',
+    assetKind: 'DOCUMENT',
+    allowedMime: 'text/csv',
+    refusedMime: 'image/png',
+    multipartAt: 50 * MB,
+  },
+  {
+    entityType: ENTITY_TYPES.ARTICLE,
+    visibility: 'PRIVATE',
+    bucket: BUCKETS.private,
+    keySegment: 'article',
+    maxFileSize: 10 * MB,
+    maxTtlSec: 10 * 60,
+    persist: 'asset+attachment',
+    assetKind: 'INLINE_IMAGE',
+    allowedMime: 'image/png',
+    // No `image/*` wildcard on this handler, precisely so SVG is refused.
+    refusedMime: 'image/svg+xml',
+    multipartAt: null,
+  },
+  {
+    entityType: ENTITY_TYPES.USER_PROFILE,
+    visibility: 'PUBLIC',
+    bucket: BUCKETS.public,
+    keySegment: 'user-profile',
+    maxFileSize: 5 * MB,
+    maxTtlSec: 10 * 60,
+    persist: 'versioned-asset',
+    assetKind: 'USER_AVATAR',
+    allowedMime: 'image/webp',
+    refusedMime: 'application/pdf',
+    multipartAt: null,
+  },
+  {
+    entityType: ENTITY_TYPES.WORKFLOW_RUN,
+    visibility: 'PRIVATE',
+    bucket: BUCKETS.private,
+    keySegment: 'workflow-run',
+    maxFileSize: 50 * MB,
+    maxTtlSec: 10 * 60,
+    persist: 'asset+attachment',
+    assetKind: 'TEMP_UPLOAD',
+    allowedMime: 'application/zip',
+    refusedMime: null,
+    multipartAt: 25 * MB,
+  },
+  {
+    entityType: ENTITY_TYPES.COMMENT,
+    visibility: 'PRIVATE',
+    bucket: BUCKETS.private,
+    keySegment: 'comment',
+    maxFileSize: 25 * MB,
+    maxTtlSec: 10 * 60,
+    persist: 'asset+attachment',
+    assetKind: 'TEMP_UPLOAD',
+    allowedMime: 'image/gif',
+    refusedMime: 'video/mp4',
+    multipartAt: null,
+  },
+  {
+    entityType: ENTITY_TYPES.MESSAGE,
+    visibility: 'PRIVATE',
+    bucket: BUCKETS.private,
+    keySegment: 'message',
+    maxFileSize: 25 * MB,
+    maxTtlSec: 10 * 60,
+    persist: 'asset+attachment',
+    assetKind: 'EMAIL_ATTACHMENT',
+    allowedMime: 'application/vnd.ms-excel',
+    refusedMime: null,
+    multipartAt: null,
+  },
+  {
+    entityType: ENTITY_TYPES.KNOWLEDGE_BASE,
+    visibility: 'PUBLIC',
+    bucket: BUCKETS.public,
+    keySegment: 'knowledge-base',
+    maxFileSize: 10 * MB,
+    maxTtlSec: 10 * 60,
+    persist: 'asset+attachment',
+    assetKind: 'THUMBNAIL',
+    allowedMime: 'image/png',
+    refusedMime: 'image/svg+xml',
+    multipartAt: null,
+  },
+  {
+    entityType: ENTITY_TYPES.CHAT_WIDGET,
+    visibility: 'PUBLIC',
+    bucket: BUCKETS.public,
+    keySegment: 'chat-widget',
+    maxFileSize: 10 * MB,
+    maxTtlSec: 10 * 60,
+    persist: 'asset+attachment',
+    assetKind: 'THUMBNAIL',
+    allowedMime: 'image/jpeg',
+    refusedMime: 'application/pdf',
+    multipartAt: null,
+  },
+  {
+    entityType: ENTITY_TYPES.CUSTOM_FIELD,
+    visibility: 'PRIVATE',
+    bucket: BUCKETS.private,
+    keySegment: 'custom-field',
+    maxFileSize: 25 * MB,
+    maxTtlSec: 10 * 60,
+    persist: 'asset+attachment',
+    assetKind: 'TEMP_UPLOAD',
+    allowedMime: 'application/pdf',
+    // `*​/*` is the outer bound; the per-field narrowing arrives via `refineConfig`.
+    refusedMime: null,
+    multipartAt: null,
+  },
+  {
+    entityType: ENTITY_TYPES.VISIT_QC_ITEM,
+    visibility: 'PRIVATE',
+    bucket: BUCKETS.private,
+    keySegment: 'visit-qc-item',
+    maxFileSize: 25 * MB,
+    maxTtlSec: 10 * 60,
+    persist: 'asset+attachment',
+    assetKind: 'INLINE_IMAGE',
+    // Accepted because the capture strip does not convert HEIC off an iPhone.
+    allowedMime: 'image/heic',
+    refusedMime: 'application/pdf',
+    multipartAt: null,
+  },
+]
+
+describe('UPLOAD_HANDLERS', () => {
+  it('covers every EntityType and nothing else', () => {
+    expect(Object.keys(UPLOAD_HANDLERS).sort()).toEqual(Object.values(ENTITY_TYPES).sort())
+  })
+
+  it('the matrix below covers every EntityType', () => {
+    expect(CASES.map((c) => c.entityType).sort()).toEqual(Object.values(ENTITY_TYPES).sort())
+  })
+
+  it('names each handler with the key it is registered under', () => {
+    for (const [key, handler] of Object.entries(UPLOAD_HANDLERS)) {
+      expect(handler.entityType).toBe(key)
+    }
+  })
+
+  it('refuses an unknown entity type by name', () => {
+    expect(() => getUploadHandler('TICKET')).toThrow(BadRequestError)
+    expect(() => getUploadHandler('TICKET')).toThrow('No upload handler for entity type: TICKET')
+  })
+})
+
+describe.each(CASES)('buildUploadConfig: $entityType', (c) => {
+  const handler = UPLOAD_HANDLERS[c.entityType as keyof typeof UPLOAD_HANDLERS]
+
+  function build(overrides: Partial<UploadInitConfig> = {}) {
+    return buildUploadConfig(
+      handler,
+      init({ entityType: c.entityType, mimeType: c.allowedMime, ...overrides }),
+      clock.now
+    )
+  }
+
+  it('routes to the declared visibility and its bucket', () => {
+    const config = build()
+    expect(config.visibility).toBe(c.visibility)
+    expect(config.bucket).toBe(c.bucket)
+  })
+
+  it('emits the handler policy verbatim', () => {
+    expect(build().policy).toEqual<UploadPolicy>({
+      keyPrefix: `${ORG}/`,
+      contentLengthRange: [0, c.maxFileSize],
+      maxTtl: c.maxTtlSec,
+      allowedMimeTypes: [...handler.allowedMimeTypes],
+    })
+  })
+
+  it('derives an org-prefixed, entity-scoped, timestamped key', () => {
+    expect(build().storageKey).toBe(`${ORG}/${c.keySegment}/ent_1/${NOW_MS}_report.pdf`)
+  })
+
+  it('plans a small upload as single', () => {
+    expect(build({ expectedSize: 1024 }).uploadPlan).toEqual({ strategy: 'single' })
+  })
+
+  it('accepts a file exactly at the size ceiling', () => {
+    expect(() => build({ expectedSize: c.maxFileSize })).not.toThrow()
+  })
+
+  it('declares the persistence strategy and asset kind', () => {
+    expect(handler.persist).toBe(c.persist)
+    expect(handler.assetKind).toBe(c.assetKind)
+  })
+
+  if (c.maxFileSize < Number.MAX_SAFE_INTEGER) {
+    it('refuses a file one byte over the ceiling', () => {
+      expect(() => build({ expectedSize: c.maxFileSize + 1 })).toThrow(UnprocessableEntityError)
+      expect(() => build({ expectedSize: c.maxFileSize + 1 })).toThrow(
+        `Size ${c.maxFileSize + 1} outside [0, ${c.maxFileSize}]`
+      )
+    })
+  }
+
+  if (c.refusedMime) {
+    it(`refuses '${c.refusedMime}'`, () => {
+      expect(() => build({ mimeType: c.refusedMime as string })).toThrow(UnprocessableEntityError)
+      expect(() => build({ mimeType: c.refusedMime as string })).toThrow(
+        `MIME '${c.refusedMime}' not allowed`
+      )
+    })
+  } else {
+    it('admits any type', () => {
+      expect(() => build({ mimeType: 'application/x-msdownload' })).not.toThrow()
+    })
+  }
+
+  if (c.multipartAt === null) {
+    it('cannot reach multipart, because the size ceiling is below the threshold', () => {
+      // Worth stating: multipart carries no S3 policy document at all
+      // (`storage/presign.ts`), so an entity whose ceiling keeps every upload on
+      // the single-shot path is one whose policy S3 re-enforces for us.
+      expect(() => build({ expectedSize: c.maxFileSize })).not.toThrow()
+      expect(build({ expectedSize: c.maxFileSize }).uploadPlan).toEqual({ strategy: 'single' })
+    })
+  } else {
+    it('plans single one byte below the multipart threshold', () => {
+      expect(build({ expectedSize: (c.multipartAt as number) - 1 }).uploadPlan).toEqual({
+        strategy: 'single',
+      })
+    })
+
+    it('plans multipart at the threshold', () => {
+      expect(build({ expectedSize: c.multipartAt as number }).uploadPlan).toEqual({
+        strategy: 'multipart',
+      })
+    })
+  }
+
+  it('clamps a too-long TTL to the handler ceiling', () => {
+    expect(build({ ttlSec: 86_400 }).ttlSec).toBe(c.maxTtlSec)
+  })
+
+  it('clamps a too-short TTL to the floor', () => {
+    expect(build({ ttlSec: 1 }).ttlSec).toBe(MIN_TTL_SEC)
+  })
+
+  it('defaults the TTL, the provider, and freezes the result', () => {
+    const config = build()
+    expect(config.ttlSec).toBe(Math.min(DEFAULT_TTL_SEC, c.maxTtlSec))
+    expect(config.provider).toBe('S3')
+    expect(Object.isFrozen(config)).toBe(true)
+  })
+
+  it('never emits a config its own policy would refuse', () => {
+    // The invariant that makes the presign-time check unable to fail: whatever
+    // survives `buildUploadConfig` satisfies the policy it carries.
+    const config = build({ ttlSec: 86_400, expectedSize: c.maxFileSize })
+    expect(config.ttlSec).toBeLessThanOrEqual(config.policy.maxTtl)
+    expect(config.storageKey.startsWith(config.policy.keyPrefix)).toBe(true)
+    expect(config.expectedSize).toBeLessThanOrEqual(config.policy.contentLengthRange[1])
+  })
+})
+
+describe('buildUploadConfig: normalization', () => {
+  const article = UPLOAD_HANDLERS.ARTICLE
+
+  it('lowercases the MIME type and strips its parameters', () => {
+    const config = buildUploadConfig(
+      article,
+      init({ entityType: 'ARTICLE', mimeType: 'IMAGE/PNG; charset=binary' }),
+      clock.now
+    )
+    expect(config.mimeType).toBe('image/png')
+  })
+
+  it('judges the normalized type, not the raw one', () => {
+    // `BaseAssetProcessor` tested its allow-list against the RAW `init.mimeType`
+    // while emitting a policy built from the normalized one, so an uppercase
+    // type was refused at the door and admitted by the policy behind it.
+    expect(() =>
+      buildUploadConfig(article, init({ entityType: 'ARTICLE', mimeType: 'Image/PNG' }), clock.now)
+    ).not.toThrow()
+  })
+
+  it('sanitizes the filename into the key', () => {
+    const config = buildUploadConfig(
+      article,
+      init({ entityType: 'ARTICLE', mimeType: 'image/png', fileName: 'my report (v2)!.png' }),
+      clock.now
+    )
+    expect(config.storageKey).toBe(`${ORG}/article/ent_1/${NOW_MS}_my_report__v2__.png`)
+  })
+
+  it("addresses an entity-less upload under 'temp'", () => {
+    const config = buildUploadConfig(
+      UPLOAD_HANDLERS.FILE,
+      init({ entityType: 'FILE', entityId: undefined }),
+      clock.now
+    )
+    expect(config.storageKey).toBe(`${ORG}/file/temp/${NOW_MS}_report.pdf`)
+  })
+
+  it('uses the injected clock, so two builds a second apart differ', () => {
+    const moving = makeClock('2026-03-04T05:06:07.000Z')
+    const first = buildUploadConfig(UPLOAD_HANDLERS.FILE, init({ entityType: 'FILE' }), moving.now)
+    moving.advance(1000)
+    const second = buildUploadConfig(UPLOAD_HANDLERS.FILE, init({ entityType: 'FILE' }), moving.now)
+    expect(first.storageKey).not.toBe(second.storageKey)
+  })
+})
+
+describe('buildUploadConfig: request-dependent visibility', () => {
+  it('forces an article COVER to the public bucket', () => {
+    // Covers are read by OG crawlers that cache for hours; a presigned URL
+    // would answer 403 long before the cache expires.
+    const config = buildUploadConfig(
+      UPLOAD_HANDLERS.ARTICLE,
+      init({ entityType: 'ARTICLE', mimeType: 'image/png', metadata: { role: 'COVER' } }),
+      clock.now
+    )
+    expect(config.visibility).toBe('PUBLIC')
+    expect(config.bucket).toBe(BUCKETS.public)
+  })
+
+  it('leaves any other article role private', () => {
+    const config = buildUploadConfig(
+      UPLOAD_HANDLERS.ARTICLE,
+      init({ entityType: 'ARTICLE', mimeType: 'image/png', metadata: { role: 'ATTACHMENT' } }),
+      clock.now
+    )
+    expect(config.visibility).toBe('PRIVATE')
+    expect(config.bucket).toBe(BUCKETS.private)
+  })
+})
+
+describe('buildUploadConfig: normalizeInit', () => {
+  it('defaults a user-profile upload to the uploading user, in the key too', () => {
+    const config = buildUploadConfig(
+      UPLOAD_HANDLERS.USER_PROFILE,
+      init({ entityType: 'USER_PROFILE', mimeType: 'image/png', entityId: undefined }),
+      clock.now
+    )
+    expect(config.entityId).toBe(USER)
+    expect(config.storageKey).toBe(`${ORG}/user-profile/${USER}/${NOW_MS}_report.pdf`)
+  })
+
+  it('leaves an explicit user-profile target alone', () => {
+    const config = buildUploadConfig(
+      UPLOAD_HANDLERS.USER_PROFILE,
+      init({ entityType: 'USER_PROFILE', mimeType: 'image/png', entityId: 'usr_agent' }),
+      clock.now
+    )
+    expect(config.entityId).toBe('usr_agent')
+  })
+
+  it('copies a dataset upload’s entityId into metadata.datasetId', () => {
+    const config = buildUploadConfig(
+      UPLOAD_HANDLERS.DATASET,
+      init({ entityType: 'DATASET', mimeType: 'text/csv', entityId: 'ds_1' }),
+      clock.now
+    )
+    expect(config.metadata?.datasetId).toBe('ds_1')
+  })
+
+  it('does not drop metadata the client sent', () => {
+    const config = buildUploadConfig(
+      UPLOAD_HANDLERS.DATASET,
+      init({
+        entityType: 'DATASET',
+        mimeType: 'text/csv',
+        entityId: 'ds_1',
+        metadata: { documentName: 'Q3' },
+      }),
+      clock.now
+    )
+    expect(config.metadata).toEqual({ documentName: 'Q3', datasetId: 'ds_1' })
+  })
+})
+
+describe('validateCompletedUpload', () => {
+  const policy: UploadPolicy = {
+    keyPrefix: `${ORG}/`,
+    contentLengthRange: [0, 10 * MB],
+    maxTtl: 600,
+    allowedMimeTypes: ['image/png', 'application/pdf'],
+  }
+
+  const session = { expectedSize: 2048, mimeType: 'application/pdf', policy }
+
+  it('accepts a head that matches the declaration', () => {
+    expect(() =>
+      validateCompletedUpload(session, { size: 2048, mimeType: 'application/pdf' })
+    ).not.toThrow()
+  })
+
+  it('refuses a size the client did not declare', () => {
+    expect(() => validateCompletedUpload(session, { size: 2049 })).toThrow(UnprocessableEntityError)
+    expect(() => validateCompletedUpload(session, { size: 2049 })).toThrow(
+      'Size mismatch: expected 2048, got 2049'
+    )
+  })
+
+  it('refuses a type the client did not declare', () => {
+    expect(() => validateCompletedUpload(session, { size: 2048, mimeType: 'image/png' })).toThrow(
+      'MIME mismatch: expected application/pdf, got image/png'
+    )
+  })
+
+  it('ignores charset parameters on both sides of the comparison', () => {
+    expect(() =>
+      validateCompletedUpload(
+        { ...session, mimeType: 'text/html' },
+        { size: 2048, mimeType: 'TEXT/HTML; charset=utf-8' }
+      )
+    ).toThrow(/not allowed/)
+    expect(() =>
+      validateCompletedUpload(
+        { ...session, mimeType: 'text/html', policy: { ...policy, allowedMimeTypes: ['text/*'] } },
+        { size: 2048, mimeType: 'TEXT/HTML; charset=utf-8' }
+      )
+    ).not.toThrow()
+  })
+
+  it('skips the allow-list when the provider reported no content type', () => {
+    // A HEAD without `Content-Type` makes the type rule unanswerable, not
+    // violated — the same thing `BaseAssetProcessor`'s `if (head.mimeType && …)`
+    // did.
+    expect(() => validateCompletedUpload(session, { size: 2048 })).not.toThrow()
+  })
+
+  it('refuses bytes over the policy ceiling even when the client declared them', () => {
+    // The multipart hole: nothing bounded the total size until this ran, so a
+    // session that declared 20 MB against a 10 MB policy has to fail here.
+    // (`buildUploadConfig` would never have emitted such a session; a legacy one
+    // or a widened handler could.)
+    expect(() =>
+      validateCompletedUpload(
+        { ...session, expectedSize: 20 * MB },
+        { size: 20 * MB, mimeType: 'application/pdf' }
+      )
+    ).toThrow(`Size ${20 * MB} outside [0, ${10 * MB}]`)
+  })
+
+  it('judges the session policy, not a processor field', () => {
+    // Why this matters: `CUSTOM_FIELD` narrows its MIME list per field through
+    // `refineConfig`, and that narrowing is written into the session policy.
+    // The old override re-checked the processor's own `*​/*`, so the narrowing
+    // applied to the presign and to nothing else.
+    const narrowed = {
+      expectedSize: 2048,
+      mimeType: 'image/png',
+      policy: { ...policy, allowedMimeTypes: ['image/png'] },
+    }
+    expect(() =>
+      validateCompletedUpload(narrowed, { size: 2048, mimeType: 'image/png' })
+    ).not.toThrow()
+    expect(() =>
+      validateCompletedUpload(
+        { ...narrowed, mimeType: 'application/pdf' },
+        { size: 2048, mimeType: 'application/pdf' }
+      )
+    ).toThrow("MIME 'application/pdf' not allowed")
+  })
+
+  it('never fails on the key or the TTL, which are not facts about the bytes', () => {
+    // Re-judging the TTL here would fail every session signed under a ceiling
+    // that has since changed, for an upload that is otherwise perfectly fine.
+    expect(() =>
+      validateCompletedUpload(
+        { ...session, policy: { ...policy, keyPrefix: 'someone-else/', maxTtl: 1 } },
+        { size: 2048, mimeType: 'application/pdf' }
+      )
+    ).not.toThrow()
+  })
+})

--- a/packages/lib/src/files/upload/config.ts
+++ b/packages/lib/src/files/upload/config.ts
@@ -1,0 +1,252 @@
+// packages/lib/src/files/upload/config.ts
+
+/**
+ * Turning an upload request into the config the rest of the pipeline runs on —
+ * and checking, once, that a set of file facts satisfies a policy.
+ *
+ * ## The chain this replaces
+ *
+ * `processConfig` was a four-level `super` chain. `BaseProcessor` built a
+ * permissive config and froze it; `BaseAssetProcessor` spread it, clamped the
+ * policy, re-validated, and froze it again; `BaseAttachmentProcessor` spread it
+ * and required an `entityId`; each concrete processor spread it once more to
+ * change a bucket, a threshold or a MIME list. Reading four implementations
+ * across three files was the only way to learn what an article cover's config
+ * actually was, and every level could — and did — contradict the one below it.
+ *
+ * {@link buildUploadConfig} is that whole chain as one readable sequence:
+ * normalize the request → normalize the MIME type → resolve visibility →
+ * resolve the bucket → derive the storage key → clamp the TTL → build the
+ * policy → enforce it → choose single or multipart.
+ *
+ * ## Pure, and why that is worth the parameter
+ *
+ * No `ctx`, no `deps`, no `Result`, and `now` arrives as an argument rather than
+ * being read off `Date.now()` — the storage key embeds a timestamp, so a
+ * function that reads the clock cannot have its key asserted without
+ * process-global fake timers. It throws rather than returning a `Result`
+ * because nothing in it can fail for an I/O reason; the only failure is "the
+ * request breaks this entity's policy", which is the caller's 422.
+ *
+ * The one genuinely impure piece of configuration — `CUSTOM_FIELD` narrowing
+ * its MIME list from the org cache — is `UploadHandler.refineConfig`, applied by
+ * `prepareUpload` *after* this function. Keeping it out here is what makes the
+ * policy decision a table of data.
+ *
+ * ## The policy rules live in exactly one place
+ *
+ * {@link enforceUploadPolicy} (`storage/presign.ts`) is the rule engine, and it
+ * is called from here rather than reimplemented. That matters more than it
+ * looks: `BaseAssetProcessor` had its own size comparison and its own
+ * `isAllowedMimeType`, so the *declared* file was judged by one implementation
+ * and the *delivered* file by another, against lists that could differ. Both
+ * paths now go through the same function — {@link buildUploadConfig} passes the
+ * declared facts, {@link validateCompletedUpload} passes what `headObject`
+ * reported. That is the "one function, called twice" of the plan's §4.3.
+ *
+ * ## Why the post-upload check still exists
+ *
+ * Read the header of `storage/presign.ts`. A single-shot upload is signed as a
+ * presigned POST whose policy document re-enforces size and content type, so S3
+ * itself rejects a client that lies — except in the zero-`size` branch, which
+ * signs a plain PUT with no condition at all. A multipart upload carries **no**
+ * policy document: nothing bounds the total size or the true content type until
+ * the `headObject` after the bytes land. For that path
+ * {@link validateCompletedUpload} is not a redundant second opinion, it is the
+ * only opinion.
+ */
+
+import { BadRequestError, UnprocessableEntityError } from '../../errors'
+import { bucketForVisibility, type StorageVisibility } from '../storage/buckets'
+import { enforceUploadPolicy } from '../storage/presign'
+import type { UploadHandler } from './handlers/types'
+import type { UploadInitConfig, UploadPlan, UploadPolicy, UploadPreparedConfig } from './init-types'
+import type { PresignedUploadSession } from './session-types'
+import { clamp, deriveStorageKey, getDefaultKeyPrefix, normalizeMimeType } from './util'
+
+/** Size at or above which an upload is planned as multipart, absent a handler override. */
+export const DEFAULT_MULTIPART_THRESHOLD_BYTES = 50 * 1024 * 1024
+
+/** Signature lifetime used when the request does not ask for one. */
+export const DEFAULT_TTL_SEC = 10 * 60
+
+/** Floor on the signature lifetime. A signature too short to use is not a kindness. */
+export const MIN_TTL_SEC = 60
+
+/** The file facts a policy judges, once the bytes are either declared or delivered. */
+export interface UploadFacts {
+  /** Declared `expectedSize` before the upload; the `headObject` size after it. */
+  size: number
+  /**
+   * Declared content type before the upload; what the provider reported after
+   * it. Optional because not every provider returns a `Content-Type` on `HEAD`,
+   * and an absent one is not a violation.
+   */
+  mimeType?: string
+}
+
+/**
+ * Build the prepared config for one upload request.
+ *
+ * Pure. `now` is used for the timestamp embedded in the storage key and nothing
+ * else.
+ *
+ * @param handler The entity type's declared upload rules.
+ * @param init The client's request, already parsed and org-scoped.
+ * @param now The clock, injected so the derived key is reproducible.
+ * @throws {UnprocessableEntityError} when the request breaks the handler's policy.
+ */
+export function buildUploadConfig(
+  handler: UploadHandler,
+  init: UploadInitConfig,
+  now: () => Date
+): UploadPreparedConfig {
+  // 1. The handler's own pure rewrite of the request, first — the storage key,
+  //    the visibility function and the policy all read what it produces.
+  const request = handler.normalizeInit ? handler.normalizeInit(init) : init
+
+  // 2. Normalize the MIME type once, and judge the normalized value.
+  //    `BaseAssetProcessor` checked its allow-list against the RAW `init.mimeType`
+  //    while the policy it emitted carried the normalized one, so `Image/PNG`
+  //    was refused at the front door and accepted by the policy behind it.
+  const mimeType = normalizeMimeType(request.mimeType)
+
+  // 3. Visibility, then the bucket it implies.
+  const visibility: StorageVisibility =
+    typeof handler.visibility === 'function' ? handler.visibility(request) : handler.visibility
+
+  // `bucketForVisibility` answers '' when the bucket is not configured. That is
+  // not an error here: this is a *pre-storage* config, and `StorageManager`
+  // still resolves a bucket from the provider's credential for BYO-credential
+  // organizations that never set `S3_PUBLIC_BUCKET`. The rule that a bucket is
+  // never optional binds at the storage call itself, where `assertBucket` runs.
+  const bucket = bucketForVisibility(visibility)
+
+  // 4. The storage key: {orgId}/{entity-type}/{entityId}/{ts}_{seed}{filename}.
+  const storageKey = deriveStorageKey(request.organizationId, request.fileName, {
+    entityType: request.entityType,
+    entityId: request.entityId || 'temp',
+    keySeed: request.keySeed,
+    nowMs: now().getTime(),
+  })
+
+  // 5. Clamp the TTL to the handler's own ceiling.
+  //    The chain clamped to a fixed [60, 3600] and then wrote `maxTtl: 600` into
+  //    the policy, so any request asking for more than ten minutes on an
+  //    asset-backed entity produced a config that failed its own policy check at
+  //    presign time. Clamping to `maxTtlSec` makes that unrepresentable.
+  const ttlSec = clamp(request.ttlSec ?? DEFAULT_TTL_SEC, MIN_TTL_SEC, handler.maxTtlSec)
+
+  // 6. The policy, straight off the handler's declarative fields.
+  const policy: UploadPolicy = {
+    keyPrefix: getDefaultKeyPrefix(request.organizationId),
+    contentLengthRange: [0, handler.maxFileSize],
+    maxTtl: handler.maxTtlSec,
+    allowedMimeTypes: [...handler.allowedMimeTypes],
+  }
+
+  // 7. Enforce it against what was declared, using the same function the signer
+  //    will use. A prepared config that survives this cannot be refused later.
+  asUnprocessable(() =>
+    enforceUploadPolicy(policy, {
+      storageKey,
+      ttlSec,
+      expectedSize: request.expectedSize,
+      mimeType,
+    })
+  )
+
+  // 8. Single or multipart.
+  const threshold = handler.multipartThresholdBytes ?? DEFAULT_MULTIPART_THRESHOLD_BYTES
+  const uploadPlan: UploadPlan =
+    request.expectedSize >= threshold ? { strategy: 'multipart' } : { strategy: 'single' }
+
+  return Object.freeze({
+    ...request,
+    mimeType,
+    provider: request.provider ?? 'S3',
+    storageKey,
+    ttlSec,
+    policy,
+    uploadPlan,
+    visibility,
+    bucket,
+  })
+}
+
+/**
+ * Check a completed upload against what was promised for it.
+ *
+ * Two questions, in this order:
+ *
+ * 1. **Did we get the file we were told about?** An exact size match and a
+ *    parameter-insensitive MIME match against the session's own declaration.
+ * 2. **Is that file allowed at all?** The session's persisted `policy`, judged
+ *    by the same {@link enforceUploadPolicy} that judged the declaration.
+ *
+ * The second question used to be `BaseAssetProcessor`'s own re-implementation of
+ * the size and MIME rules, comparing against the *processor's* fields rather
+ * than the session's policy. Reading the policy instead is what makes a
+ * `CUSTOM_FIELD` upload's per-field MIME narrowing survive to the end of the
+ * upload rather than applying only to the presign.
+ *
+ * Pure, and deliberately not `async`: it has never had anything to await.
+ *
+ * @throws {UnprocessableEntityError} when the delivered file breaks either rule.
+ */
+export function validateCompletedUpload(
+  session: Pick<PresignedUploadSession, 'expectedSize' | 'mimeType' | 'policy'>,
+  head: UploadFacts
+): void {
+  if (typeof session.expectedSize === 'number' && head.size !== session.expectedSize) {
+    throw new UnprocessableEntityError(
+      `Size mismatch: expected ${session.expectedSize}, got ${head.size}`
+    )
+  }
+
+  const delivered = head.mimeType ? normalizeMimeType(head.mimeType) : undefined
+  const declared = session.mimeType ? normalizeMimeType(session.mimeType) : undefined
+  if (declared && delivered && declared !== delivered) {
+    throw new UnprocessableEntityError(`MIME mismatch: expected ${declared}, got ${delivered}`)
+  }
+
+  // Only the size and MIME rules describe the delivered bytes. The key was
+  // chosen by us and the TTL bounded the signature, so both are neutralised
+  // rather than re-judged — re-judging the TTL in particular would fail every
+  // session signed before the ceiling that produced it changed.
+  //
+  // A provider that reports no `Content-Type` on HEAD makes the allow-list
+  // unanswerable, not violated, so it is neutralised too. That matches what
+  // `BaseAssetProcessor` did: `if (head.mimeType && !isAllowedMimeType(...))`.
+  asUnprocessable(() =>
+    enforceUploadPolicy(
+      {
+        ...session.policy,
+        keyPrefix: '',
+        maxTtl: Number.MAX_SAFE_INTEGER,
+        allowedMimeTypes: delivered ? session.policy.allowedMimeTypes : ['*/*'],
+      },
+      { storageKey: '', ttlSec: 0, expectedSize: head.size, mimeType: delivered ?? '' }
+    )
+  )
+}
+
+/**
+ * Run a policy check and restate its refusal as a 422.
+ *
+ * The rules are not reimplemented here — the whole point is that there is one
+ * implementation — but the status differs by who is asking. `enforceUploadPolicy`
+ * answers a signer, for whom a bad request is a 400. These two functions answer
+ * an upload door, where the request is well-formed and the *file* is what cannot
+ * be processed, which is a 422 (plan §4.3).
+ */
+function asUnprocessable(check: () => void): void {
+  try {
+    check()
+  } catch (error) {
+    if (error instanceof BadRequestError) {
+      throw new UnprocessableEntityError(error.message)
+    }
+    throw error
+  }
+}

--- a/packages/lib/src/files/upload/handlers/index.ts
+++ b/packages/lib/src/files/upload/handlers/index.ts
@@ -1,0 +1,291 @@
+// packages/lib/src/files/upload/handlers/index.ts
+
+/**
+ * One record per `EntityType`, stating what that entity's uploads are allowed
+ * to be.
+ *
+ * These are the numbers the processor classes carry today, lifted verbatim.
+ * Nothing dispatches on them yet — the processors are still the live path — so
+ * until PR 4d converts them there are two statements of the same facts, and
+ * `__tests__/handler-parity.test.ts` fails the moment they disagree.
+ *
+ * `satisfies Record<EntityType, UploadHandler>` is the point of the record
+ * literal: adding an `EntityType` without a handler becomes a compile error
+ * instead of a silent fallback. `visit_qc_item` shipped with no registration at
+ * all, fell through to the default `FileProcessor`, and produced a `FolderFile`
+ * with no `assetId` for a surface that needed a `MediaAsset` + `Attachment`
+ * (`docs/files-upload-architecture-guide.md` §11.3).
+ */
+
+import { BadRequestError } from '../../../errors'
+import { ENTITY_TYPES, type EntityType } from '../../types/entities'
+import type { UploadHandler } from './types'
+
+const MB = 1024 * 1024
+
+/** Every asset-backed entity signs for at most ten minutes. `FILE` is the exception. */
+const ASSET_MAX_TTL_SEC = 10 * 60
+
+/**
+ * MIME types accepted for dataset documents.
+ *
+ * The empty string and `application/octet-stream` are both here on purpose:
+ * a browser that cannot type a file by extension sends one or the other, and
+ * dataset ingestion sniffs the content itself downstream.
+ */
+const DATASET_MIME_TYPES = [
+  'text/plain',
+  'text/markdown',
+  'text/x-markdown',
+  'application/x-markdown',
+  'text/x-web-markdown',
+  'text/csv',
+  'text/tab-separated-values',
+  'text/tsv',
+  'application/json',
+  'application/x-ndjson',
+  'application/jsonl',
+  'text/json',
+  'application/xml',
+  'text/xml',
+  'application/x-yaml',
+  'text/yaml',
+  'text/x-yaml',
+  'application/yaml',
+  'text/css',
+  'text/javascript',
+  'application/javascript',
+  'text/x-python',
+  'text/x-sql',
+  'text/x-log',
+  'text/log',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'application/vnd.ms-powerpoint',
+  'application/pdf',
+  'text/html',
+  'application/xhtml+xml',
+  'application/zip',
+  'application/x-zip-compressed',
+  'message/rfc822',
+  'application/vnd.ms-outlook',
+  'application/epub+zip',
+  'application/rtf',
+  '',
+  'application/octet-stream',
+] as const
+
+/**
+ * Raster images only, and never an `image/*` wildcard: that would admit
+ * `image/svg+xml`, and an uploaded SVG can carry `<script>` that runs in our
+ * origin when the object is opened directly.
+ */
+const LOGO_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const
+
+/** Generic user files. No `MediaAsset`, no entity, no MIME opinion. */
+const fileHandler: UploadHandler = {
+  entityType: ENTITY_TYPES.FILE,
+  visibility: 'PRIVATE',
+  // `FileProcessor` never clamped the base policy's permissive range, so a user
+  // file has no server-side ceiling here. The org's storage quota is the real
+  // limit and the route checks it before this runs.
+  maxFileSize: Number.MAX_SAFE_INTEGER,
+  allowedMimeTypes: ['*/*'],
+  maxTtlSec: 60 * 60,
+  multipartThresholdBytes: 100 * MB,
+  persist: 'folder-file',
+}
+
+/** Dataset documents: parsed, chunked and embedded after upload. */
+const datasetHandler: UploadHandler = {
+  entityType: ENTITY_TYPES.DATASET,
+  // `entityId` IS the dataset id for this entity type; the document writer reads
+  // it out of metadata, so it is copied across before the config is built.
+  normalizeInit: (init) => ({
+    ...init,
+    metadata: { ...init.metadata, datasetId: init.entityId },
+  }),
+  visibility: 'PRIVATE',
+  maxFileSize: 50 * MB,
+  allowedMimeTypes: DATASET_MIME_TYPES,
+  maxTtlSec: ASSET_MAX_TTL_SEC,
+  assetKind: 'DOCUMENT',
+  persist: 'asset',
+}
+
+/** Knowledge-base article bodies: inline images, covers, attached documents. */
+const articleHandler: UploadHandler = {
+  entityType: ENTITY_TYPES.ARTICLE,
+  // A cover is forced PUBLIC so its URL is durable: OG image crawlers cache for
+  // hours or days, by which point a presigned URL answers 403.
+  visibility: (init) => (init.metadata?.role === 'COVER' ? 'PUBLIC' : 'PRIVATE'),
+  maxFileSize: 10 * MB,
+  allowedMimeTypes: [
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+    'image/gif',
+    'application/pdf',
+    'text/plain',
+    'text/markdown',
+    'text/html',
+  ],
+  maxTtlSec: ASSET_MAX_TTL_SEC,
+  assetKind: 'INLINE_IMAGE',
+  persist: 'asset+attachment',
+}
+
+/** Avatars for real users and for the synthetic users backing agents. */
+const userProfileHandler: UploadHandler = {
+  entityType: ENTITY_TYPES.USER_PROFILE,
+  // The avatar's owner is the entity. A client that omits `entityId` means
+  // "mine", and the storage key has to say so before it is derived.
+  normalizeInit: (init) => ({ ...init, entityId: init.entityId || init.userId }),
+  visibility: 'PUBLIC',
+  maxFileSize: 5 * MB,
+  allowedMimeTypes: ['image/jpeg', 'image/png', 'image/webp', 'image/gif'],
+  maxTtlSec: ASSET_MAX_TTL_SEC,
+  assetKind: 'USER_AVATAR',
+  persist: 'versioned-asset',
+}
+
+/** Files handed to, or produced by, a workflow run. Temporary by nature. */
+const workflowRunHandler: UploadHandler = {
+  entityType: ENTITY_TYPES.WORKFLOW_RUN,
+  visibility: 'PRIVATE',
+  maxFileSize: 50 * MB,
+  allowedMimeTypes: ['*/*'],
+  maxTtlSec: ASSET_MAX_TTL_SEC,
+  multipartThresholdBytes: 25 * MB,
+  assetKind: 'TEMP_UPLOAD',
+  persist: 'asset+attachment',
+}
+
+/** Attachments on a comment, including ones uploaded before the comment exists. */
+const commentHandler: UploadHandler = {
+  entityType: ENTITY_TYPES.COMMENT,
+  visibility: 'PRIVATE',
+  maxFileSize: 25 * MB,
+  allowedMimeTypes: [
+    'image/*',
+    'text/*',
+    'application/pdf',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  ],
+  maxTtlSec: ASSET_MAX_TTL_SEC,
+  assetKind: 'TEMP_UPLOAD',
+  persist: 'asset+attachment',
+}
+
+/** Email attachments. 25 MB is the Gmail ceiling every provider is measured against. */
+const messageHandler: UploadHandler = {
+  entityType: ENTITY_TYPES.MESSAGE,
+  visibility: 'PRIVATE',
+  maxFileSize: 25 * MB,
+  allowedMimeTypes: ['*/*'],
+  maxTtlSec: ASSET_MAX_TTL_SEC,
+  assetKind: 'EMAIL_ATTACHMENT',
+  persist: 'asset+attachment',
+}
+
+/** Knowledge-base branding: the light and dark logo variants. */
+const knowledgeBaseHandler: UploadHandler = {
+  entityType: ENTITY_TYPES.KNOWLEDGE_BASE,
+  visibility: 'PUBLIC',
+  maxFileSize: 10 * MB,
+  allowedMimeTypes: LOGO_MIME_TYPES,
+  maxTtlSec: ASSET_MAX_TTL_SEC,
+  assetKind: 'THUMBNAIL',
+  persist: 'asset+attachment',
+}
+
+/** Embedded chat-widget branding. Rendered at one fixed size, so no presets. */
+const chatWidgetHandler: UploadHandler = {
+  entityType: ENTITY_TYPES.CHAT_WIDGET,
+  visibility: 'PUBLIC',
+  maxFileSize: 10 * MB,
+  allowedMimeTypes: LOGO_MIME_TYPES,
+  maxTtlSec: ASSET_MAX_TTL_SEC,
+  assetKind: 'THUMBNAIL',
+  persist: 'asset+attachment',
+}
+
+/**
+ * Files stored in a custom field of type `FILE`.
+ *
+ * `*​/*` is the outer bound only. The field's own `options.file` narrows it per
+ * field, which needs the org cache and therefore arrives through
+ * `refineConfig` rather than this record.
+ */
+const customFieldHandler: UploadHandler = {
+  entityType: ENTITY_TYPES.CUSTOM_FIELD,
+  visibility: 'PRIVATE',
+  maxFileSize: 25 * MB,
+  allowedMimeTypes: ['*/*'],
+  maxTtlSec: ASSET_MAX_TTL_SEC,
+  assetKind: 'TEMP_UPLOAD',
+  persist: 'asset+attachment',
+}
+
+/**
+ * Worker-captured job-site photos on a visit quality-check item.
+ *
+ * HEIC and HEIF are accepted because the capture strip's input is
+ * `accept='image/*' capture='environment'` and does not convert: `convertHeicToJpeg`
+ * only decodes in Safari and hands back the original file everywhere else, so an
+ * iPhone capture reaches us as HEIC or not at all.
+ */
+const visitQcItemHandler: UploadHandler = {
+  entityType: ENTITY_TYPES.VISIT_QC_ITEM,
+  visibility: 'PRIVATE',
+  maxFileSize: 25 * MB,
+  allowedMimeTypes: [
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+    'image/gif',
+    'image/heic',
+    'image/heif',
+  ],
+  maxTtlSec: ASSET_MAX_TTL_SEC,
+  assetKind: 'INLINE_IMAGE',
+  persist: 'asset+attachment',
+}
+
+/** Every entity type's upload handler. Exhaustive, and the compiler enforces it. */
+export const UPLOAD_HANDLERS = {
+  FILE: fileHandler,
+  DATASET: datasetHandler,
+  ARTICLE: articleHandler,
+  USER_PROFILE: userProfileHandler,
+  WORKFLOW_RUN: workflowRunHandler,
+  COMMENT: commentHandler,
+  MESSAGE: messageHandler,
+  KNOWLEDGE_BASE: knowledgeBaseHandler,
+  CHAT_WIDGET: chatWidgetHandler,
+  CUSTOM_FIELD: customFieldHandler,
+  visit_qc_item: visitQcItemHandler,
+} as const satisfies Record<EntityType, UploadHandler>
+
+/**
+ * The handler for an entity type.
+ *
+ * Takes a `string` rather than an `EntityType` because the caller is a route
+ * holding parsed JSON: an unknown value has to fail here, loudly, not be cast
+ * into the type and then dispatched on.
+ *
+ * @throws {BadRequestError} when no handler is registered for the type.
+ */
+export function getUploadHandler(entityType: string): UploadHandler {
+  const handler = (UPLOAD_HANDLERS as Record<string, UploadHandler | undefined>)[entityType]
+  if (!handler) {
+    throw new BadRequestError(`No upload handler for entity type: ${entityType}`)
+  }
+  return handler
+}
+
+export type { PersistStrategy, UploadHandler } from './types'

--- a/packages/lib/src/files/upload/handlers/types.ts
+++ b/packages/lib/src/files/upload/handlers/types.ts
@@ -1,0 +1,158 @@
+// packages/lib/src/files/upload/handlers/types.ts
+
+/**
+ * What an entity type declares about its uploads.
+ *
+ * This is the record that replaces the four-level `processConfig` super-chain
+ * (`BaseProcessor` → `BaseAssetProcessor` → `BaseAttachmentProcessor` → the ten
+ * concrete processors). Today answering "which bucket does an article cover land
+ * in?" means reading four `processConfig` implementations across three files,
+ * each of which spreads the previous config, mutates a field, and re-freezes it.
+ * A handler states the same facts once, as data.
+ *
+ * ## What is here, and what is deliberately not (PR 4a)
+ *
+ * PR 4a ships the **config half** of this contract and the declarative records
+ * that fill it, because {@link buildUploadConfig} cannot be tested against
+ * anything else — a test that invents its own handler literals only proves that
+ * the test agrees with itself.
+ *
+ * Present:
+ * - the fields {@link buildUploadConfig} reads (`normalizeInit`, `visibility`,
+ *   `maxFileSize`, `allowedMimeTypes`, `maxTtlSec`, `multipartThresholdBytes`),
+ * - the plain data the persistence step will need (`entityType`, `assetKind`,
+ *   `persist`),
+ * - the two hooks that run at the *prepare* boundary (`refineConfig`,
+ *   `validateEntity`).
+ *
+ * Absent, on purpose: `onPersist`, `afterCommit`, and the `PersistResult` they
+ * carry. Those describe the persistence path that PR 4d actually builds, and
+ * writing their signatures now would be guessing at a shape no caller exists
+ * for. PR 4d adds them here.
+ *
+ * ## Nothing dispatches on this yet
+ *
+ * The processor chain is still the live path. Until PR 4d converts it,
+ * {@link UPLOAD_HANDLERS} and the processors are two statements of the same
+ * per-entity numbers, and `handlers/__tests__/handler-parity.test.ts` is the
+ * guard that keeps them equal.
+ */
+
+import type { AssetKind } from '../../core/types'
+import type { FilesCtx } from '../../ctx'
+import type { StorageVisibility } from '../../storage/buckets'
+import type { EntityType } from '../../types/entities'
+import type { UploadInitConfig, UploadPreparedConfig } from '../init-types'
+import type { PresignedUploadSession } from '../session-types'
+
+/**
+ * Which rows a completed upload turns into.
+ *
+ * The distinction is not cosmetic: picking the wrong one silently produces the
+ * wrong record type. `visit_qc_item` had no registration at all and fell through
+ * to a `FolderFile` with no `assetId`, which is the bug `satisfies
+ * Record<EntityType, UploadHandler>` on {@link UPLOAD_HANDLERS} makes
+ * impossible to reintroduce.
+ */
+export type PersistStrategy =
+  /** `MediaAsset` + version. */
+  | 'asset'
+  /** …plus an `Attachment` to (`entityType`, `entityId`). */
+  | 'asset+attachment'
+  /** Find the entity's existing asset of this kind and add a version to it. */
+  | 'versioned-asset'
+  /** `FolderFile` + `FileVersion`. No `MediaAsset`, no `AssetKind`. */
+  | 'folder-file'
+
+/** Everything one entity type declares about its uploads. */
+export interface UploadHandler {
+  /** The `EntityType` this handler is registered under. */
+  entityType: EntityType
+
+  /**
+   * Pure rewrite of the incoming request, applied **before** anything else in
+   * {@link buildUploadConfig} — so it is visible to the storage key, the
+   * visibility function and the policy.
+   *
+   * Only two entity types need it, and both are rewrites the processors do
+   * today: `USER_PROFILE` defaults `entityId` to the uploading user, and
+   * `DATASET` copies `entityId` into `metadata.datasetId`. Anything that needs
+   * I/O belongs in {@link refineConfig}, not here.
+   */
+  normalizeInit?: (init: UploadInitConfig) => UploadInitConfig
+
+  /**
+   * Which bucket this entity's objects belong in.
+   *
+   * A function only where the answer genuinely depends on the request — today
+   * that is `ARTICLE`, whose covers are forced `PUBLIC` so the resulting CDN URL
+   * survives an OG crawler's cache (a presigned URL would 403 by then).
+   */
+  visibility: StorageVisibility | ((init: UploadInitConfig) => StorageVisibility)
+
+  /** Hard ceiling, in bytes. Becomes the policy's `contentLengthRange` upper bound. */
+  maxFileSize: number
+
+  /**
+   * The policy's MIME allow-list. `type/subtype`, `type/*` and `*​/*` are all
+   * honoured — see `enforceUploadPolicy`.
+   */
+  allowedMimeTypes: readonly string[]
+
+  /**
+   * Ceiling on the presigned signature's lifetime, in seconds, and the policy's
+   * `maxTtl`. The requested `ttlSec` is clamped to it, so a prepared config can
+   * never fail its own policy's TTL rule.
+   */
+  maxTtlSec: number
+
+  /**
+   * Size at or above which the upload is planned as multipart. Defaults to
+   * {@link DEFAULT_MULTIPART_THRESHOLD_BYTES}.
+   *
+   * Worth stating explicitly per entity: multipart uploads carry **no policy
+   * document at all** (`storage/presign.ts`), so raising this threshold is the
+   * cheapest way to keep an entity's uploads on the path S3 re-enforces.
+   */
+  multipartThresholdBytes?: number
+
+  /**
+   * The `MediaAsset.kind` this entity's uploads get.
+   *
+   * Optional because a `folder-file` handler creates no `MediaAsset` and has no
+   * kind to declare. The function form exists for the two entity types whose
+   * kind depends on the finished session (`ARTICLE` covers become `THUMBNAIL`,
+   * temp `MESSAGE` uploads become `TEMP_UPLOAD`); PR 4a populates only the plain
+   * values, which is what the processors' `assetKind` field states, and PR 4d
+   * moves `getAssetKind`'s logic across.
+   */
+  assetKind?: AssetKind | ((session: PresignedUploadSession) => AssetKind)
+
+  /** Which rows a completed upload turns into. */
+  persist: PersistStrategy
+
+  /**
+   * Escape hatch for configuration that needs I/O.
+   *
+   * Runs **after** {@link buildUploadConfig}, never inside it — the point of
+   * `buildUploadConfig` being pure is that the whole policy decision is a table
+   * of data, and a hook that can read the database would take that back. Exactly
+   * one entity type needs it: `CUSTOM_FIELD` narrows its MIME allow-list from
+   * the field's `options.file` in the org cache.
+   */
+  refineConfig?(
+    ctx: FilesCtx,
+    config: UploadPreparedConfig,
+    init: UploadInitConfig
+  ): Promise<UploadPreparedConfig>
+
+  /**
+   * Identity and integrity only — **never** a permission check.
+   *
+   * `packages/lib` performs zero access checks (`docs/lib-module-guide.md` §6);
+   * this answers "does this entity exist in this organization", so an upload
+   * cannot be aimed at another org's row. Who is allowed to upload is the
+   * calling surface's question.
+   */
+  validateEntity?(ctx: FilesCtx, entityId: string): Promise<void>
+}

--- a/packages/lib/src/files/upload/processors/base-asset-processor.ts
+++ b/packages/lib/src/files/upload/processors/base-asset-processor.ts
@@ -113,25 +113,15 @@ export abstract class BaseAssetProcessor extends BaseProcessor {
     }
   }
 
-  /**
-   * Override validation hook for attachment-specific checks
-   */
-  async validateCompletedUpload(
-    session: PresignedUploadSession,
-    head: { size: number; mimeType?: string }
-  ) {
-    await super.validateCompletedUpload(session, head)
-
-    if (head.size > this.maxFileSize) {
-      throw new Error(
-        `File exceeds allowed size of ${Math.round(this.maxFileSize / 1024 / 1024)}MB`
-      )
-    }
-
-    if (head.mimeType && !this.isAllowedMimeType(head.mimeType)) {
-      throw new Error(`Uploaded type '${head.mimeType}' not allowed`)
-    }
-  }
+  // `validateCompletedUpload` is deliberately NOT overridden. It used to
+  // re-check `head.size` against `this.maxFileSize` and `head.mimeType` against
+  // `this.allowedMimeTypes` — a second, hand-written copy of the rules the
+  // session's own `policy` already encodes, and one that judged the processor's
+  // fields rather than the policy that was actually signed. `BaseProcessor` now
+  // delegates to the shared `validateCompletedUpload` in `upload/config.ts`,
+  // which reads `session.policy`, so a `CUSTOM_FIELD` upload's per-field MIME
+  // narrowing survives to the end of the upload instead of applying only to the
+  // presign.
 
   // ============= Presigned Upload Implementation (Legacy) =============
 

--- a/packages/lib/src/files/upload/processors/base-processor.ts
+++ b/packages/lib/src/files/upload/processors/base-processor.ts
@@ -5,6 +5,7 @@ import { AttachmentService } from '../../core/attachment-service'
 import { FileService } from '../../core/file-service'
 import { MediaAssetService } from '../../core/media-asset-service'
 import { bucketForVisibility, type StorageVisibility } from '../../storage/buckets'
+import { validateCompletedUpload } from '../config'
 import type {
   ProcessorConfigResult,
   UploadInitConfig,
@@ -130,24 +131,25 @@ export abstract class BaseProcessor implements FileProcessor {
   }
 
   /**
-   * NEW: Post-upload validation hook
-   * Validates the completed upload against session expectations
+   * Post-upload validation: does the object S3 actually holds match what this
+   * session promised, and is it allowed at all?
+   *
+   * Both questions are answered by the pure {@link validateCompletedUpload} in
+   * `upload/config.ts`, which judges the session's own persisted `policy` with
+   * the same `enforceUploadPolicy` that judged the request. `BaseAssetProcessor`
+   * used to override this with a second, hand-written copy of the size and MIME
+   * rules; there is one implementation now, called once before the upload and
+   * once after it.
+   *
+   * This is not a redundant check. See the header of `storage/presign.ts`: a
+   * multipart upload carries no policy document, so nothing bounds its total
+   * size or true content type until the `headObject` that feeds this.
    */
   async validateCompletedUpload(
     session: PresignedUploadSession,
     head: { size: number; mimeType?: string }
   ): Promise<void> {
-    // Exact size check if we have a client-declared expectation
-    if (typeof session.expectedSize === 'number' && head.size !== session.expectedSize) {
-      throw new Error(`Size mismatch: expected ${session.expectedSize}, got ${head.size}`)
-    }
-
-    // Lenient MIME check if provider returns Content-Type
-    if (session.mimeType && head.mimeType) {
-      const a = (head.mimeType.split(';')[0] ?? '').toLowerCase()
-      const b = (session.mimeType.split(';')[0] ?? '').toLowerCase()
-      if (a !== b) throw new Error(`MIME mismatch: expected ${b}, got ${a}`)
-    }
+    validateCompletedUpload(session, head)
   }
 
   // ============= Protected Helper Methods =============

--- a/packages/lib/src/files/upload/util.ts
+++ b/packages/lib/src/files/upload/util.ts
@@ -39,6 +39,12 @@ export const normalizeEntityType = (entityType: string): string => {
  *
  * The entity processor determines the folder structure via entityType.
  * No special casing - simple, consistent paths for all entity types.
+ *
+ * `nowMs` exists so a caller that has a clock can stay pure. `buildUploadConfig`
+ * threads `FilesDeps.now` in, which is what lets a test assert on the whole key
+ * — including the timestamp — without `vi.useFakeTimers()` leaking into every
+ * other assertion in the process. Callers that omit it read the wall clock,
+ * exactly as before.
  */
 export const deriveStorageKey = (
   orgId: string,
@@ -47,9 +53,10 @@ export const deriveStorageKey = (
     entityType: string
     entityId: string
     keySeed?: string
+    nowMs?: number
   }
 ): string => {
-  const ts = Date.now()
+  const ts = options.nowMs ?? Date.now()
   const seed = options.keySeed ? `${options.keySeed}_` : ''
   const sanitized = sanitizeFileName(fileName)
   const entityPrefix = normalizeEntityType(options.entityType)


### PR DESCRIPTION
PR 4a, the first of Phase 4 (`plans/attachments/04-upload-pipeline.md` §4.3).

Replaces the four-level `processConfig` super-chain with **one pure function**:

```ts
buildUploadConfig(handler, init, now): UploadPreparedConfig   // throws UnprocessableEntityError
```

Readable as one sequence — normalize init → normalize mime → resolve visibility → resolve bucket →
derive key → clamp TTL → build policy → **call** `enforceUploadPolicy` → choose single/multipart.
The policy rules are never re-implemented; `enforceUploadPolicy` has been pure in
`storage/presign.ts` since #1832.

## `validateCompletedUpload` is now one function called twice

`buildUploadConfig` passes the **declared** facts; `validateCompletedUpload` passes the
**`headObject`** facts to the same rules, reading the persisted `session.policy` rather than
processor fields. `BaseAssetProcessor`'s hand-written copy of the size and mime rules is deleted.

Key and TTL are neutralised in the post-upload call — neither is a fact about the delivered bytes,
and re-judging TTL would fail every in-flight session signed under a ceiling that has since moved.

## Sequencing: the handler records ship here, not in 4d

§4.3's signature takes an `UploadHandler`, but §4.2 assigns `handlers/**` to 4d — so 4a cannot
compile without it. I asked for the type only; the agent pushed back with a better argument and I
agree: a test that invents its own handler literals proves only that the test agrees with itself.
That is *exactly* what the file this is meant to replace does —
`unified-upload-integration.test.ts` monkey-patches `StorageManager.prototype` with fake
`validatePolicyCompliance`/`validateSizeCompliance` implementations and then asserts against them.

So 4a ships the declarative fields only. **4d still owns the conversion.** `onPersist`, `afterCommit`
and `PersistResult` are deliberately *not* declared — writing signatures for callers that do not yet
exist is guessing.

The cost is one PR where the per-entity numbers exist twice. That is paid for by
`handler-processor-parity.test.ts`, which reads the fields off each constructed processor and fails
on any drift in visibility, size ceiling, mime list or asset kind — and compares `FILE` end to end
(`buildUploadConfig` vs `FileProcessor.processConfig`, field for field). It is deleted with the
processors in 4d.

`satisfies Record<EntityType, UploadHandler>` makes exhaustiveness a **compile error** — the
`visit_qc_item` class of bug becomes unrepresentable. Note there are **eleven** entity types, not the
ten §4.1 tabulates.

## Five behaviour changes, none pure extraction

1. **Mime is judged normalized.** `BaseAssetProcessor` checked its allow-list against the *raw*
   `init.mimeType` while emitting a policy built from the *normalized* one — so `Image/PNG` was
   refused at the door and admitted by the policy behind it.
2. **TTL clamps to the handler's own ceiling.** The chain clamped to a fixed `[60, 3600]` then wrote
   `maxTtl: 600` into the policy, so any request over 600s on an asset entity produced a config
   guaranteed to fail its own policy at presign. Unreachable today (no caller passes `ttlSec`); now
   unrepresentable.
3. **Policy violations are 422.** They were bare `Error`s run through `categorizeError`'s substring
   grep, where `"File exceeds allowed size of 10MB"` matched no branch and became a **500**, and
   `"File type 'x' not allowed"` matched `'not allowed'` and became a **403**.
4. **The post-upload check reads `session.policy`**, so `CUSTOM_FIELD`'s per-field mime narrowing
   survives to completion instead of applying only at presign — which matters most on multipart,
   where nothing else constrains true content type.
5. **The head mime is normalized before the allow-list check**, so `text/html; charset=utf-8` no
   longer fails a `text/html` allow-list.

## What the typed contract refused — one worth acting on

**`allowedFileExtensions` on a custom field enforces nothing server-side.** I verified this
independently:

- `entity-processors.ts:709` writes `(policy as any).allowedExtensions = fileOpts.allowedFileExtensions`.
- `UploadPolicy` has no such field, and `enforceUploadPolicy` never reads "extension" at all.
- The only extension checker, `upload/validators.ts:validateExtension`, is reachable only from
  `validateFile` in the same file — which is exported from `files/index.ts` and **called by nothing
  server-side**. (The `validateFile` hits in `apps/web` are a different, client-side function.)

So a custom field configured with allowed extensions is enforced in the browser and nowhere else.
**Not fixed here** — it needs a decision (drop the UI option, or add an extension rule to
`UploadPolicy` + `enforceUploadPolicy`), and that is not 4a's scope.

Two smaller ones: `DatasetAssetProcessor.entityType = 'dataset'` is lowercase while registered as
`'DATASET'` — same shape as the `fileVisibility: string` bug #1827 fixed, harmless today because the
field only feeds a dead `getMetadata()`, and now refused by `UploadHandler.entityType: EntityType`.
And `workflow-processor.ts` is dead *and* contradictory (claims 100MB/50MB where the registered
`WorkflowRunProcessor` has 50MB/25MB); it is never registered, only re-exported through `export *`.
4d deletes it — do not treat its numbers as a source of truth.

## `unified-upload-integration.test.ts` stays

It still carries `SessionManager` lifecycle (4b), `ProcessorRegistry` error behaviour (4d) and Redis
failure handling (4b). Coverage that cannot yet be replaced was not deleted.

Worth knowing: its "Policy Enforcement Integration" block (~75 lines) is worthless *today* — it
defines the validators it asserts against at the bottom of the same file. 4d deletes the file.

## Verification

- `packages/lib` typecheck: **`src/` clean** (the 29 remaining are the `scripts/` +
  `vitest.integration.config.ts` baseline). `apps/web`: baseline only.
- `src/files`: **455 passed / 24 files** (was 244 / 22).
- Full `packages/lib`: 11,479 passed, 2 failed — the two known load-sensitive timeouts.
- `apps/web` targeted: 60 passed, 1 failed — the known #1818 `mock-completeness` guard.
- Both new test files contain **zero `vi.mock`** (verified): `upload-config.test.ts` (168 cases),
  `handler-processor-parity.test.ts` (43).

## Where the plan is wrong

- **"all ten entity types" — there are eleven.** §4.1 omits `VISIT_QC_ITEM`, which has a real,
  registered processor. §4.6's "gets a real handler here if Tier-1 §1.7 chose to keep the feature"
  is stale; it was kept and shipped.
- **§4.2's `UploadHandler` cannot compile as written.** `assetKind` is required, but a `folder-file`
  handler creates no `MediaAsset`; `ttlSec?` conflates signature TTL (3600 for `FILE`, 600 elsewhere)
  with temp-asset expiry (24h, which is `onPersist` work).
- **§4.2 has no slot for the two pure init rewrites that exist today** — `USER_PROFILE` defaulting
  `entityId` to the uploader (which changes the storage key) and `DATASET` copying `entityId` into
  `metadata.datasetId`. Both must run before the key is derived; hence `normalizeInit`.
- **§4.3's `UnprocessableEntityError` and "don't duplicate `enforceUploadPolicy`" are in tension** —
  the rule engine throws `BadRequestError`. Resolved by calling it and restating the refusal as 422
  in one small wrapper, so the rules still exist exactly once.

## One uncertainty on the record

`handler-processor-parity.test.ts` reads `protected` fields through a cast. It is a test reaching
into production rather than the reverse, and it is the only way to compare the two declarations
without a database — but if 4d slips, that cast is what stands between two sources of truth.

## Note for reviewers

Edits in `packages/lib` need a rebuild before `apps/*` see them (known repo footgun).