### PR TITLE
fix(connectors): project stored rootPaths and parent contributing mappings

### DIFF
--- a/apps/web/src/components/data-connectors/lib/bind-installed-owned-defs.test.ts
+++ b/apps/web/src/components/data-connectors/lib/bind-installed-owned-defs.test.ts
@@ -62,12 +62,19 @@ const OWNED_TARGETS: OwnedTargetMeta[] = [
     rootPath: '',
     templateId: 'app:shopify:products',
   },
-  // The reference mapping for the same product key, in the orders stream.
+  // The reference mapping for the same product key, in the orders stream. Its rootPath
+  // is the STORED parent-relative form (`product_id`, relativized against its
+  // `line_items[]` parent) — `projectConnectorOwnedTargets` emits exactly this via
+  // `storedRootPath`, matching what `seedAppOwnedMappings` writes. The absolute
+  // manifest form (`line_items[].product_id`) is NEVER stored, so a target carrying it
+  // would silently bind nothing (the production bug: every nested reference mapping
+  // sat with `entityDefinitionId: NULL`). Projector↔seeder consistency is covered in
+  // packages/lib/src/data-connectors/owned-mappings.test.ts.
   {
     ownedKey: 'products',
     apiSlug: 'shopify_products',
     streamKey: 'orders',
-    rootPath: 'line_items[].product_id',
+    rootPath: 'product_id',
     templateId: 'app:shopify:products',
   },
 ]
@@ -124,10 +131,12 @@ describe('bindInstalledOwnedDefs', () => {
         }),
       ]),
       stream('s_orders', 'orders', [
-        // The reference mapping owns no columns.
+        // The reference mapping owns no columns. Stored rootPath is PARENT-RELATIVE
+        // (`product_id`), the form the seeder writes — the binder's `===` match against
+        // the projected target must succeed on exactly this.
         ownedMapping({
           id: 'm_ref',
-          rootPath: 'line_items[].product_id',
+          rootPath: 'product_id',
           linkMode: 'reference',
           fieldMappings: [],
         }),

--- a/packages/database/src/db/schema/app-deployment.ts
+++ b/packages/database/src/db/schema/app-deployment.ts
@@ -271,7 +271,12 @@ export interface CatalogConnectorRelationshipDecl {
 /** A recommended fan-out mapping projected from a data connector's stream. */
 export interface CatalogConnectorDefaultMapping {
   rootPath: string
+  /** Explicit parent mapping's rootPath (payload-absolute) for the flat drilled child
+   *  (a second mapping over the parent's own subtree). Mirrors the SDK type. */
+  parentRootPath?: string
   linkMode?: 'upsert' | 'reference'
+  /** Bare key → `@app:` envelope; `'system:<systemAttribute>'` → pre-existing system
+   *  relationship field on the (contributing) parent def. Mirrors the SDK type. */
   relationshipFieldKey?: string
   /** Provisioning decl for the parent↔child edge — auto-creates the field at materialization. */
   relationship?: CatalogConnectorRelationshipDecl

--- a/packages/lib/scripts/backfill-owned-reference-bindings.ts
+++ b/packages/lib/scripts/backfill-owned-reference-bindings.ts
@@ -1,0 +1,180 @@
+// packages/lib/scripts/backfill-owned-reference-bindings.ts
+//
+// One-off repair for the owned-binder rootPath defect (plans/products/README.md,
+// "Verify before building"): `projectConnectorOwnedTargets` used to emit the ABSOLUTE
+// manifest rootPath (`line_items[].product_id`) while `seedAppOwnedMappings` stores the
+// PARENT-RELATIVE form (`product_id`), and the install-time binder matches with `===` —
+// so any owned mapping nested under a non-empty parent rootPath never got its
+// `entityDefinitionId` bound at template install, even though the def exists. Confirmed
+// live: both dev Shopify connectors carry `product_id` / `variant_id` reference
+// mappings with `entityDefinitionId: NULL`, so 15 synced `shopify_line_items` have
+// 0 Product/Variant edges.
+//
+// The code fix (relativize in the projector via `storedRootPath`) repairs future
+// installs only. This script repairs EXISTING connectors: it finds app-owned mappings
+// with `entityDefinitionId IS NULL` whose deployed catalog declares a matching target
+// (compared against the RELATIVIZED rootPath) AND whose owned def is already installed
+// for the same app installation, then binds them exactly the way the fixed binder
+// would — set `entityDefinitionId` + repoint the late-bound `@app:` field refs at the
+// installed def's actual apiSlug. Writes go through `updateMapping`, so the standard
+// edit safety runs (the def change stamps `resyncPending: rebind`; the mapping never
+// synced, so there are no items to neutralize).
+//
+// Idempotent — a bound mapping (`entityDefinitionId` set) is never touched again.
+// DRY-RUN by default; pass --write to apply.
+//
+// NOTE: binding alone does NOT create the missing edges on already-synced rows. After
+// --write, re-crawl the affected connector: the stamped `resyncPending` surfaces the
+// "Backfill now" banner (tRPC `dataConnector.backfillPendingChange`), or run
+// packages/lib/scripts/backfill-pending-connector-change.ts with CONNECTOR_ID/ORG_ID.
+//
+//   npx dotenv -- npx tsx packages/lib/scripts/backfill-owned-reference-bindings.ts [--write]
+
+import { type CatalogPayload, database as db, schema } from '@auxx/database'
+import { parseAppFieldRef, toAppFieldRef } from '@auxx/types/field'
+import { and, eq, isNull } from 'drizzle-orm'
+import { projectConnectorOwnedTargets, updateMapping } from '../src/data-connectors/mutations'
+import type { FieldMapping } from '../src/data-connectors/types'
+
+const WRITE = process.argv.includes('--write')
+
+/**
+ * Repoint an owned mapping's late-bound `@app:` refs at the installed def's ACTUAL
+ * apiSlug (it may carry a slug-conflict suffix) — mirror of the web binder's
+ * `rebindFieldMappings`. Refs stay late-bound; non-`@app:` and other-app refs pass
+ * through.
+ */
+function rebindFieldMappings(
+  fieldMappings: FieldMapping[],
+  appSlug: string,
+  installedApiSlug: string
+): FieldMapping[] {
+  return fieldMappings.map((fm) => {
+    const parts = fm.targetFieldRef ? parseAppFieldRef(fm.targetFieldRef) : null
+    if (!parts || parts.appSlug !== appSlug) return fm
+    return { ...fm, targetFieldRef: toAppFieldRef(installedApiSlug, appSlug, parts.appFieldKey) }
+  })
+}
+
+async function main() {
+  const connectors = await db.query.DataConnector.findMany({
+    where: eq(schema.DataConnector.definitionKind, 'app'),
+  })
+  console.log(`${WRITE ? 'WRITE' : 'DRY-RUN'} — ${connectors.length} app connectors`)
+
+  let bound = 0
+  let skipped = 0
+  let failed = 0
+
+  for (const connector of connectors) {
+    const orgId = connector.organizationId
+    const label = `org ${orgId} connector ${connector.id} (${connector.name})`
+    try {
+      if (!connector.appInstallationId || !connector.type.startsWith('app:')) {
+        console.log(`${label}: no app installation — skipping`)
+        continue
+      }
+      const appSlug = connector.type.slice('app:'.length)
+
+      // The deployed catalog for this connector's installation (same resolution the
+      // ownedTargets router uses: the installation's current deployment, first declared
+      // connector).
+      const installation = await db.query.AppInstallation.findFirst({
+        where: eq(schema.AppInstallation.id, connector.appInstallationId),
+        columns: { currentDeploymentId: true },
+      })
+      const deployment = installation?.currentDeploymentId
+        ? await db.query.AppDeployment.findFirst({
+            where: eq(schema.AppDeployment.id, installation.currentDeploymentId),
+            columns: { catalog: true },
+          })
+        : null
+      const catalog = (deployment?.catalog as CatalogPayload | null)?.dataConnectors?.[0]
+      if (!catalog) {
+        console.log(`${label}: no deployed catalog connector — skipping`)
+        continue
+      }
+
+      // Post-fix projection: rootPaths are RELATIVIZED, matching the stored rows.
+      const targets = projectConnectorOwnedTargets(appSlug, catalog)
+
+      const streams = await db.query.DataConnectorStream.findMany({
+        where: and(
+          eq(schema.DataConnectorStream.dataConnectorId, connector.id),
+          eq(schema.DataConnectorStream.organizationId, orgId)
+        ),
+      })
+      const streamByKey = new Map(streams.map((s) => [s.streamKey, s]))
+
+      for (const target of targets) {
+        const stream = streamByKey.get(target.streamKey)
+        if (!stream) continue
+        const mapping = await db.query.DataConnectorMapping.findFirst({
+          where: and(
+            eq(schema.DataConnectorMapping.dataConnectorStreamId, stream.id),
+            eq(schema.DataConnectorMapping.organizationId, orgId),
+            eq(schema.DataConnectorMapping.targetMode, 'owned'),
+            eq(schema.DataConnectorMapping.rootPath, target.rootPath),
+            isNull(schema.DataConnectorMapping.entityDefinitionId)
+          ),
+        })
+        if (!mapping) continue // already bound, or no such row — nothing to repair
+
+        // The installed def for this owned record type under the SAME app install —
+        // the strict adopt key (`sourceKey === ownedKey`), as `adoptSharedOwnedDefId`.
+        const def = await db.query.EntityDefinition.findFirst({
+          where: and(
+            eq(schema.EntityDefinition.organizationId, orgId),
+            eq(schema.EntityDefinition.appInstallationId, connector.appInstallationId),
+            eq(schema.EntityDefinition.sourceKey, target.ownedKey),
+            isNull(schema.EntityDefinition.archivedAt)
+          ),
+          columns: { id: true, apiSlug: true },
+        })
+        if (!def) {
+          skipped++
+          console.log(
+            `${label}: stream '${target.streamKey}' rootPath '${target.rootPath}' → def ` +
+              `'${target.ownedKey}' not installed — leaving unbound (binds at template install)`
+          )
+          continue
+        }
+
+        const fieldMappings = rebindFieldMappings(
+          (mapping.fieldMappings ?? []) as FieldMapping[],
+          appSlug,
+          def.apiSlug
+        )
+        console.log(
+          `${label}: stream '${target.streamKey}' rootPath '${target.rootPath}' → bind to ` +
+            `${def.id} (${def.apiSlug})${WRITE ? '' : ' [dry-run]'}`
+        )
+        if (WRITE) {
+          await updateMapping(db, orgId, mapping.id, {
+            entityDefinitionId: def.id,
+            fieldMappings,
+          })
+        }
+        bound++
+      }
+    } catch (error) {
+      failed++
+      console.error(`${label}: FAILED`, error)
+    }
+  }
+
+  console.log(
+    `\nDone. ${bound} mapping(s) ${WRITE ? 'bound' : 'would be bound'}, ` +
+      `${skipped} skipped (def not installed), ${failed} connector(s) failed.`
+  )
+  if (WRITE && bound > 0) {
+    console.log(
+      'Reminder: already-synced rows still lack their edges — trigger the "Backfill now" ' +
+        're-crawl per connector (resyncPending is stamped), e.g. ' +
+        'scripts/backfill-pending-connector-change.ts.'
+    )
+  }
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+void main()

--- a/packages/lib/src/data-connectors/contributing-parent-materialization.test.ts
+++ b/packages/lib/src/data-connectors/contributing-parent-materialization.test.ts
@@ -1,0 +1,256 @@
+// packages/lib/src/data-connectors/contributing-parent-materialization.test.ts
+// Contributing mappings parenting onto contributing siblings (full contribute mode):
+// `'' → product` parents `variants[] → part`, and a FLAT drilled child (explicit
+// `parentRootPath`, same subtree) contributes the part's `catalog_item` with a
+// pre-existing SYSTEM relationship edge (`system:part_catalog_items`) resolved at
+// install to the concrete `defId:fieldId` ref the manual editor stores. DB + org
+// cache are mocked; the assertions read the inserted `DataConnectorMapping` values.
+
+import type { CatalogDataConnector, Database } from '@auxx/database'
+import { toResourceFieldId } from '@auxx/types/field'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getCachedCustomFields, getCachedEntityDefId } from '../cache'
+import {
+  materializeAppContributingMappings,
+  resolveContributingRelationshipFieldKey,
+} from './mutations'
+
+vi.mock('../cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../cache')>()
+  return {
+    ...actual,
+    getCachedEntityDefId: vi.fn(),
+    getCachedCustomFields: vi.fn(),
+  }
+})
+
+const ORG = 'org_1'
+const STREAM_ID = 'stream_1'
+const APP = 'shopify'
+
+const DEF_IDS: Record<string, string> = {
+  product: 'def_product',
+  part: 'def_part',
+  catalog_item: 'def_catalog',
+}
+
+/** Minimal cached-field rows per def (id + systemAttribute drive resolution). */
+const DEF_FIELDS: Record<string, Array<Record<string, unknown>>> = {
+  def_product: [
+    { id: 'f_title', name: 'Title', systemAttribute: 'product_title', type: 'TEXT' },
+    { id: 'f_parts', name: 'Parts', systemAttribute: 'product_parts', type: 'RELATIONSHIP' },
+  ],
+  def_part: [
+    { id: 'f_sku', name: 'SKU', systemAttribute: 'part_sku', type: 'TEXT' },
+    {
+      id: 'f_ci',
+      name: 'Catalog Items',
+      systemAttribute: 'part_catalog_items',
+      type: 'RELATIONSHIP',
+    },
+  ],
+  def_catalog: [
+    {
+      id: 'f_price',
+      name: 'Default Unit Price',
+      systemAttribute: 'catalog_item_default_unit_price',
+      type: 'CURRENCY',
+    },
+  ],
+}
+
+/** Drizzle stub: `addMapping`'s stream-guard findFirst + insert().values().returning(). */
+function mockDb() {
+  const inserted: Array<Record<string, unknown>> = []
+  let n = 0
+  const db = {
+    query: {
+      DataConnectorStream: {
+        findFirst: vi.fn(async () => ({ id: STREAM_ID, organizationId: ORG })),
+      },
+    },
+    insert: vi.fn(() => ({
+      values: (v: Record<string, unknown>) => ({
+        returning: async () => {
+          const row = { id: `m_${++n}`, ...v }
+          inserted.push(row)
+          return [row]
+        },
+      }),
+    })),
+  }
+  return { db: db as unknown as Database, inserted }
+}
+
+/** The full-contribute-mode product stream: product root + part child + flat catalog_item. */
+const STREAM = {
+  key: 'product',
+  displayFieldKey: 'title',
+  fields: [
+    { fieldKey: 'title', sourcePath: 'title', type: 'TEXT', name: 'Title' },
+    { fieldKey: 'handle', sourcePath: 'handle', type: 'TEXT', name: 'Handle' },
+    { fieldKey: 'variants.sku', sourcePath: 'variants[].sku', type: 'TEXT', name: 'SKU' },
+    { fieldKey: 'variants.price', sourcePath: 'variants[].price', type: 'CURRENCY', name: 'Price' },
+  ],
+  defaultMappings: [
+    { rootPath: '', target: { mode: 'contributing', entityKind: 'product' } },
+    {
+      rootPath: 'variants[]',
+      relationshipFieldKey: 'system:product_parts',
+      target: {
+        mode: 'contributing',
+        entityKind: 'part',
+        fieldBindings: [{ sourceFieldKey: 'variants.sku', targetKey: 'part_sku' }],
+      },
+    },
+    // The flat drilled child: same subtree as the part mapping, explicit parent.
+    {
+      rootPath: 'variants[]',
+      parentRootPath: 'variants[]',
+      relationshipFieldKey: 'system:part_catalog_items',
+      target: {
+        mode: 'contributing',
+        entityKind: 'catalog_item',
+        fieldBindings: [
+          { sourceFieldKey: 'variants.price', targetKey: 'catalog_item_default_unit_price' },
+        ],
+      },
+    },
+  ],
+} as unknown as CatalogDataConnector['streams'][number]
+
+beforeEach(() => {
+  vi.mocked(getCachedEntityDefId).mockImplementation(async (_org, kind) => DEF_IDS[kind])
+  vi.mocked(getCachedCustomFields).mockImplementation(
+    async (_org, defId) => (DEF_FIELDS[defId] ?? []) as never
+  )
+})
+
+describe('materializeAppContributingMappings — contributing parents', () => {
+  it('chains product → part → catalog_item with correct parentMappingId + stored rootPaths', async () => {
+    const { db, inserted } = mockDb()
+    await materializeAppContributingMappings(db, ORG, STREAM_ID, STREAM, APP)
+
+    expect(inserted).toHaveLength(3)
+    const [product, part, catalog] = inserted
+
+    // Root: no parent, no edge.
+    expect(product).toMatchObject({
+      rootPath: '',
+      targetMode: 'contributing',
+      entityDefinitionId: 'def_product',
+      parentMappingId: null,
+      relationshipFieldKey: null,
+    })
+
+    // The part mapping parents onto the CONTRIBUTING product root (previously it
+    // could only parent onto an owned mapping and became an edge-less root).
+    expect(part).toMatchObject({
+      rootPath: 'variants[]',
+      entityDefinitionId: 'def_part',
+      parentMappingId: product?.id,
+    })
+    // Its system edge resolved on the PARENT (product) def to the concrete ref form.
+    expect(part?.relationshipFieldKey).toBe(toResourceFieldId('def_product', 'f_parts'))
+
+    // The flat child: explicit parentRootPath, stored rootPath '' (the drilled shape
+    // mapRecord fans out over the parent's own subtree), parented onto the part row.
+    expect(catalog).toMatchObject({
+      rootPath: '',
+      entityDefinitionId: 'def_catalog',
+      parentMappingId: part?.id,
+    })
+    expect(catalog?.relationshipFieldKey).toBe(toResourceFieldId('def_part', 'f_ci'))
+  })
+
+  it('binds declared field bindings subtree-relative on both siblings', async () => {
+    const { db, inserted } = mockDb()
+    await materializeAppContributingMappings(db, ORG, STREAM_ID, STREAM, APP)
+    const [, part, catalog] = inserted
+
+    const partFms = part?.fieldMappings as Array<Record<string, unknown>>
+    expect(partFms.some((fm) => fm.targetFieldRef === toResourceFieldId('def_part', 'f_sku'))).toBe(
+      true
+    )
+    expect(partFms.find((fm) => fm.targetFieldRef?.toString().endsWith('f_sku'))?.expression).toBe(
+      '{sku}'
+    )
+    const catFms = catalog?.fieldMappings as Array<Record<string, unknown>>
+    // The flat child's bindings relativize against its OWN manifest rootPath
+    // (`variants[]`), matching the parent subtree its stored `''` rootPath reads.
+    expect(catFms.find((fm) => fm.targetFieldRef?.toString().endsWith('f_price'))?.expression).toBe(
+      '{price}'
+    )
+  })
+
+  it('still parents a nested contributing branch onto an OWNED root, with the @app: envelope', async () => {
+    const { db, inserted } = mockDb()
+    const orderStream = {
+      key: 'orders',
+      displayFieldKey: 'name',
+      fields: [
+        { fieldKey: 'customer.email', sourcePath: 'customer.email', type: 'EMAIL', name: 'Email' },
+      ],
+      defaultMappings: [
+        {
+          rootPath: 'customer',
+          relationshipFieldKey: 'customer',
+          target: { mode: 'contributing', entityKind: 'contact' },
+        },
+      ],
+    } as unknown as CatalogDataConnector['streams'][number]
+    vi.mocked(getCachedEntityDefId).mockResolvedValue('def_contact')
+
+    await materializeAppContributingMappings(db, ORG, STREAM_ID, orderStream, APP, {
+      '': 'm_owned_root',
+    })
+
+    expect(inserted).toHaveLength(1)
+    // Owned parent wins; the bare key keeps the connection-late-bound @app: envelope
+    // (parentSlug falls back to the mapping's own entityKind — no parent manifest in
+    // the stream declares rootPath '' here, matching pre-change behavior).
+    expect(inserted[0]).toMatchObject({
+      rootPath: 'customer',
+      parentMappingId: 'm_owned_root',
+    })
+    expect(inserted[0]?.relationshipFieldKey).toContain(':@app:shopify:customer')
+  })
+})
+
+describe('resolveContributingRelationshipFieldKey', () => {
+  it('wraps a bare key in the @app: envelope (unchanged path)', async () => {
+    await expect(
+      resolveContributingRelationshipFieldKey(ORG, 'product', APP, 'shopify_line_items', null)
+    ).resolves.toBe('shopify_line_items:@app:shopify:product')
+  })
+
+  it('resolves system:<attr> against the parent def to the concrete editor-form ref', async () => {
+    await expect(
+      resolveContributingRelationshipFieldKey(
+        ORG,
+        'system:part_catalog_items',
+        APP,
+        'part',
+        'def_part'
+      )
+    ).resolves.toBe(toResourceFieldId('def_part', 'f_ci'))
+  })
+
+  it('drops a system edge with no contributing parent def (warn, edge-less mapping)', async () => {
+    await expect(
+      resolveContributingRelationshipFieldKey(ORG, 'system:part_catalog_items', APP, 'part', null)
+    ).resolves.toBeNull()
+  })
+
+  it('drops a system edge whose attribute does not exist on the parent def', async () => {
+    await expect(
+      resolveContributingRelationshipFieldKey(ORG, 'system:nope', APP, 'part', 'def_part')
+    ).resolves.toBeNull()
+  })
+
+  it('passes null/undefined through', async () => {
+    await expect(
+      resolveContributingRelationshipFieldKey(ORG, null, APP, 'x', null)
+    ).resolves.toBeNull()
+  })
+})

--- a/packages/lib/src/data-connectors/mutations.ts
+++ b/packages/lib/src/data-connectors/mutations.ts
@@ -629,6 +629,21 @@ export function ownedParentRootPath(rootPath: string, all: string[]): string | n
   return parents.reduce((longest, p) => (p.length > longest.length ? p : longest))
 }
 
+/**
+ * The STORED form of a manifest mapping's payload-absolute `rootPath`: relativized
+ * against its parent mapping's rootPath (the longest proper boundary-prefix among
+ * `allRootPaths`), unchanged for a root mapping. The seeder stores this form, and every
+ * consumer — `absolutePrefix`, `subtreeUnder`, the sync `mapRecord` subtree descent, and
+ * the install-time binder's `(streamKey, rootPath)` `===` match — expects it. Any
+ * projection of the manifest ({@link projectConnectorOwnedTargets}) MUST relativize
+ * through this same function, or its emitted rootPath silently never matches a stored
+ * row (the bug that left `line_items[].product_id` reference mappings unbound forever).
+ */
+export function storedRootPath(rootPath: string, allRootPaths: string[]): string {
+  const parentRootPath = ownedParentRootPath(rootPath, allRootPaths)
+  return parentRootPath != null ? relativeSourcePath(rootPath, parentRootPath) : rootPath
+}
+
 /** A stream field assigned to an owned mapping, with its subtree-relative source path. */
 export interface OwnedFieldEntry {
   field: CatalogDataConnector['streams'][number]['fields'][number]
@@ -773,13 +788,11 @@ async function seedAppOwnedMappings(
       // `ownedParentRootPath` can nest it: `'' ⊂ line_items[] ⊂ line_items[].product_id`),
       // but every consumer — `absolutePrefix`, `subtreeUnder`, and the sync `mapRecord`
       // subtree descent — treats a child's stored rootPath as relative to its parent.
-      // Relativize against the parent we just resolved; top-level children (parent `''`)
-      // are unchanged. NB: `mappingIdByRootPath` below stays keyed by the ABSOLUTE path,
-      // because parent detection nests on absolute paths.
-      rootPath:
-        parentRootPath != null
-          ? relativeSourcePath(mapping.rootPath, parentRootPath)
-          : mapping.rootPath,
+      // `storedRootPath` recomputes the same parent resolved above, so the stored form
+      // and `projectConnectorOwnedTargets`' emitted form agree by construction.
+      // NB: `mappingIdByRootPath` below stays keyed by the ABSOLUTE path, because
+      // parent detection nests on absolute paths.
+      rootPath: storedRootPath(mapping.rootPath, allRootPaths),
       linkMode,
       targetMode: 'owned' as TargetMode,
       entityDefinitionId,
@@ -912,7 +925,11 @@ export interface ConnectorOwnedTarget {
   apiSlug: string
   /** The stream this owned mapping lives in (matches `DraftStream.streamKey`). */
   streamKey: string
-  /** The owned mapping's rootPath within the stream (matches `DraftMapping.rootPath`). */
+  /**
+   * The owned mapping's STORED rootPath within the stream (matches
+   * `DraftMapping.rootPath`) — parent-relative via {@link storedRootPath}, exactly the
+   * form `seedAppOwnedMappings` writes (`product_id`, not `line_items[].product_id`).
+   */
   rootPath: string
   /** The installable template id (`app:<slug>:<ownedKey>`). */
   templateId: string
@@ -924,18 +941,82 @@ export function projectConnectorOwnedTargets(
 ): ConnectorOwnedTarget[] {
   const targets: ConnectorOwnedTarget[] = []
   for (const stream of catalog.streams) {
+    // Relativize each mapping's manifest (payload-absolute) rootPath the same way the
+    // seeder does — the binder matches `(streamKey, rootPath)` with `===` against the
+    // STORED rows, so emitting the absolute form here left every nested owned mapping
+    // (e.g. `line_items[].product_id`, stored as `product_id`) permanently unbound.
+    const ownedRootPaths = (stream.defaultMappings ?? [])
+      .filter((m) => m.target.mode === 'owned')
+      .map((m) => m.rootPath)
     for (const m of stream.defaultMappings ?? []) {
       if (m.target.mode !== 'owned') continue
       targets.push({
         ownedKey: m.target.entity.key,
         apiSlug: m.target.entity.apiSlug,
         streamKey: stream.key,
-        rootPath: m.rootPath,
+        rootPath: storedRootPath(m.rootPath, ownedRootPaths),
         templateId: `app:${appSlug}:${m.target.entity.key}`,
       })
     }
   }
   return targets
+}
+
+/**
+ * Prefix a manifest `relationshipFieldKey` may carry to name a PRE-EXISTING SYSTEM
+ * relationship field on the parent def by its `systemAttribute` — e.g.
+ * `'system:part_catalog_items'`. Used when parent and child both contribute into system
+ * defs whose edge already exists: nothing is provisioned for it, and the key resolves at
+ * install to the concrete `defId:fieldId` ref the manual editor stores. A bare key (no
+ * prefix) keeps the `@app:` envelope path ({@link appRelationshipFieldKey}).
+ */
+export const SYSTEM_RELATIONSHIP_PREFIX = 'system:'
+
+/**
+ * Resolve a contributing mapping's manifest `relationshipFieldKey` into the stored ref
+ * form. Two author-facing forms:
+ *   - bare app key (`'product'`) → the connection-late-bound `@app:` envelope — the
+ *     edge field is app-provisioned on the parent def at template install;
+ *   - `'system:<systemAttribute>'` → resolved NOW against the (contributing) parent
+ *     def's fields to the concrete `${defId}:${fieldId}` ref — the same form the manual
+ *     editor stores, so the sink's `resolveEdge` and the editor resolve it with zero new
+ *     machinery. Requires a contributing parent (its system def is known at install);
+ *     an owned/absent parent or an unknown attribute warns and drops the edge (the
+ *     mapping still lands, edge-less — the user can drill the edge by hand).
+ */
+export async function resolveContributingRelationshipFieldKey(
+  organizationId: string,
+  bareKey: string | null | undefined,
+  appSlug: string,
+  parentSlug: string,
+  /** The parent def id when the parent is a CONTRIBUTING mapping; null otherwise. */
+  parentDefId: string | null
+): Promise<string | null> {
+  if (!bareKey) return null
+  if (!bareKey.startsWith(SYSTEM_RELATIONSHIP_PREFIX)) {
+    return appRelationshipFieldKey(bareKey, appSlug, parentSlug)
+  }
+  const systemAttribute = bareKey.slice(SYSTEM_RELATIONSHIP_PREFIX.length)
+  if (!parentDefId) {
+    logger.warn('system relationshipFieldKey needs a contributing parent def — dropping edge', {
+      organizationId,
+      appSlug,
+      relationshipFieldKey: bareKey,
+    })
+    return null
+  }
+  const parentFields = await getCachedCustomFields(organizationId, parentDefId)
+  const field = parentFields.find((f) => f.systemAttribute === systemAttribute)
+  if (!field) {
+    logger.warn('system relationshipFieldKey does not resolve on parent def — dropping edge', {
+      organizationId,
+      appSlug,
+      parentDefId,
+      systemAttribute,
+    })
+    return null
+  }
+  return toResourceFieldId(parentDefId, field.id)
 }
 
 /**
@@ -949,8 +1030,17 @@ export function projectConnectorOwnedTargets(
  * setup overview flags it `needs-mapping` and the user authors it against the source
  * tree. A target def the org lacks (no system `contact`) is skipped, never failing
  * creation. See multi-stream-setup-plan §5.
+ *
+ * Parenting: a contributing mapping can hang off an OWNED mapping (the order stream's
+ * embedded `customer`) or a CONTRIBUTING sibling (full contribute mode: `'' → product`
+ * parents `variants[] → part`), derived from the longest boundary-prefix — owned wins
+ * when both sit at the same rootPath. The flat drilled child (a SECOND mapping over the
+ * parent's own subtree, e.g. `variants[] → catalog_item` under `variants[] → part`)
+ * can't be prefix-derived, so the manifest names it explicitly via `parentRootPath`;
+ * its stored rootPath relativizes to `''`, the shape the fan-out already supports.
+ * Exported for unit coverage (mocked db + cache).
  */
-async function materializeAppContributingMappings(
+export async function materializeAppContributingMappings(
   db: Database,
   organizationId: string,
   streamId: string,
@@ -961,7 +1051,22 @@ async function materializeAppContributingMappings(
   ownedMappingIdByRootPath: Record<string, string> = {}
 ): Promise<void> {
   const ownedRootPaths = Object.keys(ownedMappingIdByRootPath)
-  for (const mapping of stream.defaultMappings ?? []) {
+  // ABSOLUTE rootPath → the contributing row created for it, threaded as rows are
+  // written so later siblings can parent onto it. First-wins on a shared rootPath (the
+  // flat child never shadows the mapping it drilled from).
+  const contributingByRootPath: Record<string, { id: string; entityDefinitionId: string }> = {}
+  const contributing = (stream.defaultMappings ?? []).filter(
+    (m) => m.target.mode === 'contributing'
+  )
+  // Parents before children: shorter rootPaths first; among same-rootPath siblings the
+  // explicit `parentRootPath` declarer (the flat child) comes after its parent.
+  const ordered = [...contributing].sort(
+    (a, b) =>
+      a.rootPath.length - b.rootPath.length ||
+      (a.parentRootPath != null ? 1 : 0) - (b.parentRootPath != null ? 1 : 0)
+  )
+
+  for (const mapping of ordered) {
     if (mapping.target.mode !== 'contributing') continue
     const { entityKind, matchFieldKeys, fieldBindings, connectionAppFields } = mapping.target
 
@@ -1023,20 +1128,60 @@ async function materializeAppContributingMappings(
         ? [buildReferenceAnchor()]
         : [...matchBindings, ...valueBindings, ...connMetaBindings]
 
-    // A nested contributing branch (e.g. the order stream's embedded `customer`)
-    // hangs off the owned root it's drilled from. Wiring `parentMappingId` makes
-    // mapRecord emit the parent→child relation at sync; the edge field itself is
-    // created when the owned def is installed via the entity-template flow (v6) — the
-    // sink resolves the link def-keyed by `relationshipFieldKey`.
-    const parentRootPath = ownedParentRootPath(mapping.rootPath, ownedRootPaths)
-    const parentMappingId =
-      parentRootPath != null ? (ownedMappingIdByRootPath[parentRootPath] ?? null) : null
+    // A nested contributing branch hangs off the mapping it's drilled from — an owned
+    // root (the order stream's embedded `customer`) or a contributing sibling (full
+    // contribute mode). Wiring `parentMappingId` makes mapRecord emit the parent→child
+    // relation at sync; the edge field is either app-provisioned at template install
+    // (`@app:` envelope) or a pre-existing system field (`system:` prefix).
+    let parentRootPath: string | null
+    if (mapping.parentRootPath != null) {
+      // Explicit knob (the flat same-rootPath child). Must be a boundary prefix of —
+      // or equal to — this mapping's rootPath, or the stored relativization would
+      // corrupt; a bad declaration falls back to prefix derivation.
+      if (isBoundaryPrefix(mapping.rootPath, mapping.parentRootPath)) {
+        parentRootPath = mapping.parentRootPath
+      } else {
+        logger.warn('parentRootPath is not a boundary prefix of rootPath — deriving instead', {
+          streamId,
+          rootPath: mapping.rootPath,
+          parentRootPath: mapping.parentRootPath,
+        })
+        parentRootPath = ownedParentRootPath(mapping.rootPath, [
+          ...ownedRootPaths,
+          ...Object.keys(contributingByRootPath),
+        ])
+      }
+    } else {
+      parentRootPath = ownedParentRootPath(mapping.rootPath, [
+        ...ownedRootPaths,
+        ...Object.keys(contributingByRootPath),
+      ])
+    }
+    const ownedParentId = parentRootPath != null ? ownedMappingIdByRootPath[parentRootPath] : null
+    const contribParent =
+      parentRootPath != null && ownedParentId == null
+        ? contributingByRootPath[parentRootPath]
+        : undefined
+    const parentMappingId = ownedParentId ?? contribParent?.id ?? null
+    if (parentRootPath != null && mapping.parentRootPath != null && parentMappingId == null) {
+      logger.warn('parentRootPath names no materialized mapping — creating as a root', {
+        streamId,
+        rootPath: mapping.rootPath,
+        parentRootPath,
+      })
+    }
     // The edge field lives on the PARENT def — namespace the relationship key with the
     // parent's slug (cosmetic), falling back to this mapping's own entity for a top-level
-    // contributing reference.
+    // contributing reference. Exclude self so a flat child at the parent's own rootPath
+    // never resolves itself, and match the mode the parent id actually resolved from.
     const parentManifest =
       parentRootPath != null
-        ? (stream.defaultMappings ?? []).find((m) => m.rootPath === parentRootPath)
+        ? (stream.defaultMappings ?? []).find(
+            (m) =>
+              m !== mapping &&
+              m.rootPath === parentRootPath &&
+              (ownedParentId != null ? m.target.mode === 'owned' : m.target.mode === 'contributing')
+          )
         : undefined
     const parentSlug =
       parentManifest?.target.mode === 'owned'
@@ -1045,11 +1190,13 @@ async function materializeAppContributingMappings(
           ? parentManifest.target.entityKind
           : entityKind
 
-    await addMapping(db, organizationId, {
+    const row = await addMapping(db, organizationId, {
       dataConnectorStreamId: streamId,
       // STORE parent-relative (see `seedAppOwnedMappings`): only when a parent was
       // resolved — top-level contributing branches keep their absolute (== relative)
-      // path. `ownedMappingIdByRootPath` lookups stay keyed ABSOLUTE.
+      // path; a flat child (parent rootPath == own rootPath) stores `''`, the drilled
+      // shape mapRecord fans out. `ownedMappingIdByRootPath` /
+      // `contributingByRootPath` lookups stay keyed ABSOLUTE.
       rootPath:
         parentRootPath != null
           ? relativeSourcePath(mapping.rootPath, parentRootPath)
@@ -1058,14 +1205,17 @@ async function materializeAppContributingMappings(
       targetMode: 'contributing' as TargetMode,
       entityDefinitionId,
       parentMappingId,
-      relationshipFieldKey: appRelationshipFieldKey(
+      relationshipFieldKey: await resolveContributingRelationshipFieldKey(
+        organizationId,
         mapping.relationshipFieldKey,
         appSlug,
-        parentSlug
+        parentSlug,
+        contribParent?.entityDefinitionId ?? null
       ),
       fieldMappings,
       orphanBehavior: 'ignore' as OrphanBehavior,
     })
+    contributingByRootPath[mapping.rootPath] ??= { id: row.id, entityDefinitionId }
   }
 }
 

--- a/packages/lib/src/data-connectors/owned-mappings.test.ts
+++ b/packages/lib/src/data-connectors/owned-mappings.test.ts
@@ -14,6 +14,7 @@ import {
   partitionOwnedFields,
   projectConnectorOwnedTargets,
   relativeSourcePath,
+  storedRootPath,
 } from './mutations'
 
 type CatalogField = OwnedFieldEntry['field']
@@ -150,6 +151,19 @@ describe('projectConnectorOwnedTargets', () => {
           },
           // A contributing customer branch — NOT owned, must be skipped.
           { rootPath: 'customer', target: { mode: 'contributing', entityKind: 'contact' } },
+          // The owned line-item child — parent of the product reference below.
+          {
+            rootPath: 'line_items[]',
+            target: {
+              mode: 'owned',
+              entity: {
+                key: 'line_items',
+                apiSlug: 'shopify_line_items',
+                singular: 'L',
+                plural: 'Ls',
+              },
+            },
+          },
           // A `reference` owned mapping pointing at the SAME product key as the products
           // stream — both must surface so onComplete binds both to the one product def.
           {
@@ -168,8 +182,24 @@ describe('projectConnectorOwnedTargets', () => {
   const targets = projectConnectorOwnedTargets('shopify', catalog)
 
   it('emits one entry per owned mapping, skipping contributing branches', () => {
-    expect(targets).toHaveLength(3)
+    expect(targets).toHaveLength(4)
     expect(targets.some((t) => t.streamKey === 'orders' && t.rootPath === 'customer')).toBe(false)
+  })
+
+  it('emits the STORED (parent-relative) rootPath for a nested mapping, matching the seeder', () => {
+    // The seeder stores `line_items[].product_id` relativized against its parent
+    // `line_items[]` as `product_id` — the binder matches `(streamKey, rootPath)` with
+    // `===` against those stored rows, so the projector MUST emit the same form. The
+    // absolute manifest path here would never match anything (the production bug that
+    // left every product/variant reference mapping with `entityDefinitionId: NULL`).
+    const ref = targets.find((t) => t.ownedKey === 'products' && t.streamKey === 'orders')
+    expect(ref?.rootPath).toBe('product_id')
+    // And it agrees with the seeder's own derivation, shared via `storedRootPath`.
+    const ownedRootPaths = ['', 'line_items[]', 'line_items[].product_id']
+    expect(storedRootPath('line_items[].product_id', ownedRootPaths)).toBe('product_id')
+    // Top-level mappings are unchanged (absolute == relative).
+    const line = targets.find((t) => t.ownedKey === 'line_items')
+    expect(line?.rootPath).toBe('line_items[]')
   })
 
   it('stamps the app:<slug>:<ownedKey> templateId + (streamKey, rootPath)', () => {
@@ -186,8 +216,9 @@ describe('projectConnectorOwnedTargets', () => {
   it('surfaces the reference mapping under the same ownedKey as its upsert def', () => {
     const products = targets.filter((t) => t.ownedKey === 'products')
     expect(products).toHaveLength(2)
+    // The reference rootPath is the STORED parent-relative form (`product_id`).
     expect(products.map((t) => `${t.streamKey}:${t.rootPath}`).sort()).toEqual([
-      'orders:line_items[].product_id',
+      'orders:product_id',
       'products:',
     ])
     // Same templateId regardless of which stream/mapping declares it.

--- a/packages/lib/src/data-connectors/types.ts
+++ b/packages/lib/src/data-connectors/types.ts
@@ -384,8 +384,13 @@ export interface ConnectorFieldDecl {
 export interface ConnectorDefaultMapping {
   /** '' = root, else 'customer' / 'line_items[]'. */
   rootPath: string
+  /** Explicit parent mapping's rootPath (payload-absolute) for the flat drilled child
+   *  — a second mapping over the parent's own subtree, which prefix nesting can't
+   *  derive. Must be a boundary prefix of (or equal to) `rootPath`. See SDK mirror. */
+  parentRootPath?: string
   linkMode?: 'upsert' | 'reference'
-  /** Edge on the PARENT def. */
+  /** Edge on the PARENT def. Bare key → `@app:` envelope; `'system:<systemAttribute>'`
+   *  → a pre-existing system relationship field on the (contributing) parent def. */
   relationshipFieldKey?: string
   target:
     | { mode: 'owned'; entity: ConnectorEntityDecl }

--- a/packages/lib/src/entity-templates/app-template-projector.test.ts
+++ b/packages/lib/src/entity-templates/app-template-projector.test.ts
@@ -154,6 +154,46 @@ describe('projectAppConnectorTemplates', () => {
   })
 })
 
+describe('projectAppConnectorTemplates — system-edge contributing children', () => {
+  // A contributing child whose edge is a PRE-EXISTING system field
+  // (`relationshipFieldKey: 'system:…'`) must neither crash the projection nor emit a
+  // provisioning RELATIONSHIP entry — even when the manifest (wrongly) also declares a
+  // `relationship`. The mapping-side wiring resolves at install (mutations.ts), not here.
+  const CONNECTOR_WITH_SYSTEM_EDGE: CatalogDataConnector = {
+    ...CONNECTOR,
+    streams: [
+      {
+        ...CONNECTOR.streams[0]!,
+        defaultMappings: [
+          ...(CONNECTOR.streams[0]!.defaultMappings ?? []),
+          {
+            rootPath: 'line_items[].variant_id',
+            linkMode: 'reference',
+            relationshipFieldKey: 'system:line_item_part',
+            // Wrongly-declared provisioning decl — the guard must ignore it.
+            relationship: {
+              fieldKey: 'part',
+              name: 'Part',
+              cardinality: 'belongs_to',
+              inverseName: 'Line Items',
+              targetRef: { entityKind: 'part' },
+            },
+            target: { mode: 'contributing', entityKind: 'part' },
+          },
+        ],
+      },
+    ],
+  }
+
+  it('never provisions a RELATIONSHIP field for a system: edge, and does not crash', () => {
+    const templates = projectAppConnectorTemplates('shopify', 'Shopify', CONNECTOR_WITH_SYSTEM_EDGE)
+    const lineItems = templates.find((t) => t.id === 'app:shopify:line_items')
+    // Only the declared `product` edge survives — the system-edge child adds nothing.
+    const rels = lineItems?.fields.filter((f) => f.type === 'RELATIONSHIP') ?? []
+    expect(rels.map((f) => f.templateFieldId)).toEqual(['product'])
+  })
+})
+
 describe('projectAppConnectorTemplates — reference vs real owner dedup', () => {
   // `products` is REFERENCED by the order stream (link-only, no columns) AND OWNED by a
   // dedicated product stream (its real columns). The reference is declared first, so a

--- a/packages/lib/src/entity-templates/app-template-projector.ts
+++ b/packages/lib/src/entity-templates/app-template-projector.ts
@@ -10,7 +10,11 @@
 import type { CatalogDataConnector } from '@auxx/database'
 import type { FieldType } from '@auxx/database/types'
 import type { SelectOption } from '@auxx/types/custom-field'
-import { ownedParentRootPath, partitionOwnedFields } from '../data-connectors/mutations'
+import {
+  ownedParentRootPath,
+  partitionOwnedFields,
+  SYSTEM_RELATIONSHIP_PREFIX,
+} from '../data-connectors/mutations'
 import type { EntityTemplate, EntityTemplateField } from './types'
 
 type CatalogStream = CatalogDataConnector['streams'][number]
@@ -126,6 +130,10 @@ export function projectAppConnectorTemplates(
     // declares a `relationship` becomes a RELATIONSHIP field on THIS def.
     for (const child of mappings) {
       if (!child.relationship) continue
+      // A `system:`-prefixed relationshipFieldKey names a PRE-EXISTING system edge —
+      // never provision one for it, even when the manifest (wrongly) also declares a
+      // `relationship`. The mapping-side wiring resolves at install (mutations.ts).
+      if (child.relationshipFieldKey?.startsWith(SYSTEM_RELATIONSHIP_PREFIX)) continue
       if (ownedParentRootPath(child.rootPath, ownedRootPaths) !== rootPath) continue
       fields.push({
         templateFieldId: child.relationship.fieldKey,

--- a/packages/sdk/src/root/data-connectors/types.ts
+++ b/packages/sdk/src/root/data-connectors/types.ts
@@ -188,13 +188,29 @@ export interface ConnectorRelationshipDecl {
 export interface ConnectorDefaultMapping {
   /** `''` = root record, else a subtree path (`'customer'` / `'line_items[]'`). */
   rootPath: string
+  /**
+   * Explicitly name the PARENT mapping's `rootPath` (payload-absolute, like every
+   * rootPath here) when prefix nesting cannot derive it — the flat drilled child: a
+   * SECOND mapping over the same subtree as its parent. E.g. a `variants[]` mapping
+   * contributes the `part`, and a flat `variants[]` sibling with
+   * `parentRootPath: 'variants[]'` contributes that part's `catalog_item`, the edge
+   * stamped via `relationshipFieldKey` (`'system:part_catalog_items'`). Must be a
+   * boundary prefix of — or equal to — `rootPath`. Omit for ordinary nesting: the
+   * platform derives the parent from the longest boundary-prefix mapping (owned or
+   * contributing).
+   */
+  parentRootPath?: string
   /** Default: `upsert` for embedded data, `reference` for id-only branches. */
   linkMode?: 'upsert' | 'reference'
   /**
    * Runtime pointer the fan-out reads to find the edge field at write time. Keep it
    * equal to `relationship.fieldKey` when `relationship` is declared. A bare key (no
    * `relationship`) resolves against a PRE-EXISTING edge — e.g. a reference FK to a
-   * field the connector doesn't provision.
+   * field the connector doesn't provision. A `'system:<systemAttribute>'` value names
+   * a pre-existing SYSTEM relationship field on the parent def (e.g.
+   * `'system:part_catalog_items'`) — for a contributing child whose contributing
+   * parent's edge already exists as a system field; nothing is provisioned for it, so
+   * never pair it with a `relationship` declaration.
    */
   relationshipFieldKey?: string
   /**

--- a/packages/sdk/src/util/compile-and-extract-catalog.ts
+++ b/packages/sdk/src/util/compile-and-extract-catalog.ts
@@ -231,7 +231,10 @@ export interface CatalogConnectorRelationshipDecl {
 /** A recommended fan-out mapping projected from a data connector's stream. */
 export interface CatalogConnectorDefaultMapping {
   rootPath: string
+  /** Explicit parent mapping's rootPath for the flat drilled child — see root types. */
+  parentRootPath?: string
   linkMode?: 'upsert' | 'reference'
+  /** Bare app key, or `'system:<systemAttribute>'` for a pre-existing system edge. */
   relationshipFieldKey?: string
   relationship?: CatalogConnectorRelationshipDecl
   target:


### PR DESCRIPTION
Two install-path fixes with one root cause: the mapping materializer knew less than the runtime. Both were found and verified (code + live dev DB) during the products plan-set review.

## 1. Owned-binder rootPath mismatch — confirmed production break

The seeder stores **parent-relative** rootPaths; `projectConnectorOwnedTargets` emitted the **absolute** manifest path; the install-time binder matches with `===`. Result on both live Shopify connectors: the `line_items[].product_id` / `variant_id` reference mappings sat with `entityDefinitionId: NULL`, and 15 synced line items had **0** Product/Variant edges (vs 15 Order edges) — the COGS `line_item → variant` leg was broken in production.

- Seeder and projector now share one `storedRootPath` helper — consistent by construction.
- The binder test fixtures that encoded the absolute-path premise are inverted; a projector↔seeder consistency fixture added.
- **Backfill**: `packages/lib/scripts/backfill-owned-reference-bindings.ts` (dry-run default, `--write`) rebinds existing NULL-def mappings through `updateMapping`, which stamps `resyncPending` — the standard resync then repopulates the missing edges. **Not run yet; run after merge.**

## 2. Contributing mappings can now form parent/child chains

The materializer parented contributing mappings **only onto owned mappings** — under full contribute mode every mapping became an edge-less root: no product↔part link, no way to create a linked catalog item per variant (the runtime already supported all of this; only install couldn't express it).

- Parent derivation runs over owned ∪ contributing rootPaths, parents-first, owned wins ties.
- Flat children (second mapping over the same subtree) declare the new optional `parentRootPath` manifest field — additive across the SDK type and its lib/database/extractor mirrors.
- `relationshipFieldKey: 'system:part_catalog_items'` names a **system** edge: resolved at install against the parent def's fields into the concrete `defId:fieldId` ref the mapping editor already stores — sink and editor unchanged. Unresolvable declarations warn and degrade; bare keys keep the `@app:` envelope.
- The template projector never emits provisioning entries for `system:` edges (they already exist).

## Tests

53 files / 452 tests green across `src/data-connectors` + `src/entity-templates`; 5/5 web binder tests; sdk + touched lib areas `tsc`-clean.

## Follow-ups after merge

1. Backfill script `--write` + connector resync (repairs the two live connectors).
2. SDK republish (the `parentRootPath` type landed after 0.0.21).
3. The Shopify manifest adopts `parentRootPath` / `system:` keys when contribute mode (products/02) is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)