### PR TITLE
feat(products): add the product family entity

### DIFF
--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -140,6 +140,7 @@ export const ModelTypeValues = [
   'catalog_group',
   'invoice',
   'payment',
+  'product',
 ] as const
 
 /**
@@ -181,6 +182,7 @@ export const ModelTypes = {
   CATALOG_GROUP: 'catalog_group',
   INVOICE: 'invoice',
   PAYMENT: 'payment',
+  PRODUCT: 'product',
 } as const
 
 /**
@@ -457,6 +459,15 @@ export const ModelTypeMeta: Record<
     apiSlug: 'payments',
     dbTable: 'EntityInstance',
     hasDetailPage: false,
+  },
+  product: {
+    label: 'Product',
+    plural: 'Products',
+    icon: 'package-2',
+    color: 'teal',
+    apiSlug: 'products',
+    dbTable: 'EntityInstance',
+    hasDetailPage: true,
   },
 }
 
@@ -913,6 +924,7 @@ export const EntityTypeValues = [
   'payment',
   // See the `personal_inbox` note on `ModelTypeValues` above (plan 40 §3).
   'personal_inbox',
+  'product',
   'quote',
   'service_request',
   'signature',
@@ -1711,6 +1723,7 @@ export const EntityType = {
   PART: 'part',
   PAYMENT: 'payment',
   PERSONAL_INBOX: 'personal_inbox',
+  PRODUCT: 'product',
   QUOTE: 'quote',
   SERVICE_REQUEST: 'service_request',
   SIGNATURE: 'signature',

--- a/packages/lib/src/resources/registry/enum-values.ts
+++ b/packages/lib/src/resources/registry/enum-values.ts
@@ -388,6 +388,23 @@ export const PartKind = {
   ] satisfies FieldOptionItem[],
 } as const
 
+/**
+ * Product Status Enum
+ * Entity-system field options for `product_status` — the lifecycle of a
+ * product family (plans/products/01-product-family.md §1).
+ */
+export const ProductStatus = {
+  DRAFT: 'draft',
+  ACTIVE: 'active',
+  ARCHIVED: 'archived',
+
+  values: [
+    { value: 'draft', label: 'Draft', color: 'gray' },
+    { value: 'active', label: 'Active', color: 'green' },
+    { value: 'archived', label: 'Archived', color: 'amber' },
+  ] satisfies FieldOptionItem[],
+} as const
+
 export const VectorDbTypeEnum = {
   POSTGRESQL: 'POSTGRESQL',
   CHROMA: 'CHROMA',

--- a/packages/lib/src/resources/registry/field-registry.ts
+++ b/packages/lib/src/resources/registry/field-registry.ts
@@ -20,6 +20,7 @@ import { PART_FIELDS } from './resources/part-fields'
 import { PARTICIPANT_FIELDS } from './resources/participant-fields'
 import { PAYMENT_FIELDS } from './resources/payment-fields'
 import { PERSONAL_INBOX_FIELDS } from './resources/personal-inbox-fields'
+import { PRODUCT_FIELDS } from './resources/product-fields'
 import { QUOTE_FIELDS } from './resources/quote-fields'
 import { SERVICE_REQUEST_FIELDS } from './resources/service-request-fields'
 import { SIGNATURE_FIELDS } from './resources/signature-fields'
@@ -128,6 +129,7 @@ export const RESOURCE_FIELD_REGISTRY: ResourceFieldRegistry = {
   catalog_group: CATALOG_GROUP_FIELDS,
   invoice: INVOICE_FIELDS,
   payment: PAYMENT_FIELDS,
+  product: PRODUCT_FIELDS,
 }
 
 /**

--- a/packages/lib/src/resources/registry/resources/company-fields.ts
+++ b/packages/lib/src/resources/registry/resources/company-fields.ts
@@ -395,6 +395,32 @@ export const COMPANY_FIELDS: Record<string, ResourceField> = {
     description: 'Parts this company supplies',
   },
 
+  // Reverse relationship: products (one-to-many from product.vendor)
+  products: {
+    id: toFieldId('products'),
+    key: 'products',
+    label: 'Products',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'company_products',
+    systemSortOrder: 'aCd',
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'product:vendor' as ResourceFieldId,
+      relationshipType: 'has_many',
+      isInverse: true,
+    },
+    description: 'Product families this company is the vendor of',
+  },
+
   meetings: {
     id: toFieldId('meetings'),
     key: 'meetings',

--- a/packages/lib/src/resources/registry/resources/part-fields.ts
+++ b/packages/lib/src/resources/registry/resources/part-fields.ts
@@ -556,5 +556,39 @@ export const PART_FIELDS: Record<string, ResourceField> = {
     description: 'Catalog (product/service) entries backed by this part',
   },
 
+  // Optional place in a product family (plans/products/01-product-family.md §5).
+  // The only family edge: connectors and humans write the same relation.
+  product: {
+    id: toFieldId('product'),
+    key: 'product',
+    label: 'Product',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'part_product',
+    systemSortOrder: 'a9a',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'product:parts' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'product',
+      relationshipType: 'belongs_to',
+      inverseName: 'Parts',
+      inverseSystemAttribute: 'product_parts',
+    },
+    placeholder: 'Select product',
+    description: 'The product family this part belongs to',
+  },
+
   createdBy: CREATED_BY_FIELD,
 }

--- a/packages/lib/src/resources/registry/resources/product-fields.ts
+++ b/packages/lib/src/resources/registry/resources/product-fields.ts
@@ -1,0 +1,304 @@
+// packages/lib/src/resources/registry/resources/product-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { type ResourceFieldId, toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import { CREATED_BY_FIELD } from '../common-fields'
+import { ProductStatus } from '../enum-values'
+import type { ResourceField } from '../field-types'
+
+/**
+ * Field definitions for the Product resource (plans/products/01-product-family.md §1).
+ * A product is the family above `part` — a title, a description, an image, a brand,
+ * a grouping. Nothing Shopify-shaped lives here: provenance and store-specific
+ * columns arrive as app fields via the connector, never as system fields.
+ *
+ * Deliberately no option axis (§3) — the variant grid is a Shopify artifact with
+ * no native consumer in v1.
+ */
+export const PRODUCT_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'id',
+    systemSortOrder: 'a0',
+    showInPanel: false,
+    dbColumn: 'id',
+    nullable: false,
+    isIdentifier: true,
+    operatorOverrides: ['is', 'is not', 'in', 'not in'],
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique product identifier',
+  },
+
+  title: {
+    id: toFieldId('title'),
+    key: 'title',
+    label: 'Title',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'product_title',
+    systemSortOrder: 'a1',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      required: true,
+      configurable: false,
+    },
+    placeholder: 'Enter product title',
+  },
+
+  description: {
+    id: toFieldId('description'),
+    key: 'description',
+    label: 'Description',
+    type: BaseType.STRING,
+    fieldType: FieldType.RICH_TEXT,
+    isSystem: true,
+    systemAttribute: 'product_description',
+    systemSortOrder: 'a2',
+    nullable: true,
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter description',
+  },
+
+  image: {
+    id: toFieldId('image'),
+    key: 'image',
+    label: 'Image',
+    type: BaseType.FILE,
+    fieldType: FieldType.FILE,
+    isSystem: true,
+    systemAttribute: 'product_image',
+    systemSortOrder: 'a3',
+    nullable: true,
+    options: {
+      file: { allowMultiple: false, maxFiles: 1, allowedFileTypes: ['image'] },
+    },
+    capabilities: {
+      filterable: false,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'Product image used as the avatar',
+  },
+
+  // A relation, not a string (01 §2): a supplier is already a `company` —
+  // `vendor_part.contact` says so. The Shopify `vendor` brand string is a
+  // different fact and lands in an app field; a human links this relation,
+  // or it stays null.
+  vendor: {
+    id: toFieldId('vendor'),
+    key: 'vendor',
+    label: 'Vendor',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'product_vendor',
+    systemSortOrder: 'a4',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'company:products' as ResourceFieldId,
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    },
+    relationshipConfig: {
+      relatedEntityType: 'company',
+      relationshipType: 'belongs_to',
+      inverseName: 'Products',
+      inverseSystemAttribute: 'company_products',
+    },
+    placeholder: 'Select vendor',
+    description: 'The company behind this product family',
+  },
+
+  productType: {
+    id: toFieldId('productType'),
+    key: 'productType',
+    label: 'Product Type',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'product_type',
+    systemSortOrder: 'a5',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter product type',
+    description: 'Native category string for this product',
+  },
+
+  handle: {
+    id: toFieldId('handle'),
+    key: 'handle',
+    label: 'Handle',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'product_handle',
+    systemSortOrder: 'a6',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Enter handle',
+    description: 'URL-safe slug — the match key connectors use under contribute mode',
+  },
+
+  status: {
+    id: toFieldId('status'),
+    key: 'status',
+    label: 'Status',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'product_status',
+    systemSortOrder: 'a7',
+    nullable: true,
+    options: { options: ProductStatus.values },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Select status',
+    description: 'Draft, active, or archived',
+  },
+
+  // Same inline TAGS convention as `part.category` — the shared open-tag
+  // `category` systemAttribute, NOT a new `product_tags` vocabulary. Values
+  // live in FieldValue.optionId; options grow dynamically as users add tags.
+  tags: {
+    id: toFieldId('tags'),
+    key: 'tags',
+    label: 'Tags',
+    type: BaseType.TAGS,
+    fieldType: FieldType.TAGS,
+    isSystem: true,
+    systemAttribute: 'category',
+    systemSortOrder: 'a8',
+    nullable: true,
+    options: { options: [] },
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    placeholder: 'Add tags',
+    description: 'Tags for this product',
+  },
+
+  // Reverse relationship: parts (one-to-many from part.product). The single
+  // family edge (01 §5) — the same edge whether a part arrived from a connector
+  // or was typed by hand.
+  parts: {
+    id: toFieldId('parts'),
+    key: 'parts',
+    label: 'Parts',
+    type: BaseType.RELATION,
+    fieldType: FieldType.RELATIONSHIP,
+    isSystem: true,
+    systemAttribute: 'product_parts',
+    systemSortOrder: 'a9',
+    showInPanel: false,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    relationship: {
+      inverseResourceFieldId: 'part:product' as ResourceFieldId,
+      relationshipType: 'has_many',
+      isInverse: true,
+    },
+    description: 'Parts that belong to this product family',
+  },
+
+  createdAt: {
+    id: toFieldId('createdAt'),
+    key: 'createdAt',
+    label: 'Created',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'created_at',
+    systemSortOrder: 'b0',
+    dbColumn: 'createdAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically set when the product is created',
+  },
+
+  updatedAt: {
+    id: toFieldId('updatedAt'),
+    key: 'updatedAt',
+    label: 'Updated',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'updated_at',
+    systemSortOrder: 'b1',
+    dbColumn: 'updatedAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically updated when the product is modified',
+  },
+
+  createdBy: CREATED_BY_FIELD,
+}

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -64,6 +64,7 @@ import { migration062RemoveInboxLensPersonalFields } from './migrations/062-remo
 import { migration074TagAiClassify } from './migrations/074-tag-ai-classify'
 import { migration075TagTemplateKey } from './migrations/075-tag-template-key'
 import { migration100PartCostProvenance } from './migrations/100-part-cost-provenance'
+import { migration101ProductFamily } from './migrations/101-product-family'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -173,6 +174,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // 076–099 are pure data migrations (`data-migrations/migrations/`) — the NNN id
   // space is shared across both directories, so the gap is expected.
   migration100PartCostProvenance,
+  migration101ProductFamily,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/101-product-family.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/101-product-family.test.ts
@@ -1,0 +1,140 @@
+// packages/lib/src/seed/entity-migrations/migrations/101-product-family.test.ts
+//
+// Migration 101 is pure helper composition (the 030/040 recipe) — the helpers
+// have their own coverage. What CAN silently go wrong is the wiring the
+// migration depends on: a new entity type touches five hand-edited registries
+// (plans/products/01-product-family.md §1's checklist), and
+// `linkNewRelationships` resolves inverse pairs by string reference, so a typo
+// in either direction of `part.product ↔ product.parts` or
+// `product.vendor ↔ company.products` links nothing and logs only a debug
+// line. These tests pin that wiring.
+
+import { ModelTypeMeta, ModelTypeValues } from '@auxx/database/enums'
+import { isSystemAttribute } from '@auxx/types/system-attribute'
+import { describe, expect, it } from 'vitest'
+import { RESOURCE_FIELD_REGISTRY } from '../../../resources/registry/field-registry'
+import { COMPANY_FIELDS } from '../../../resources/registry/resources/company-fields'
+import { PART_FIELDS } from '../../../resources/registry/resources/part-fields'
+import { PRODUCT_FIELDS } from '../../../resources/registry/resources/product-fields'
+import { ALL_ENTITY_MIGRATIONS } from '../../entity-migrations'
+import { DISPLAY_FIELD_CONFIG, SYSTEM_ENTITIES } from '../../entity-seeder/constants'
+import { migration101ProductFamily } from './101-product-family'
+
+describe('migration 101 registration', () => {
+  it('is registered exactly once, after 100, with a unique id', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === '101-product-family')).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids.indexOf('101-product-family')).toBe(ids.indexOf('100-part-cost-provenance') + 1)
+    expect(migration101ProductFamily.id).toBe('101-product-family')
+  })
+})
+
+describe('product entity registration wiring', () => {
+  it('every PRODUCT_FIELDS systemAttribute is in the SystemAttribute union', () => {
+    for (const [key, field] of Object.entries(PRODUCT_FIELDS)) {
+      expect(field.systemAttribute, `${key} has no systemAttribute`).toBeTruthy()
+      expect(
+        isSystemAttribute(field.systemAttribute!),
+        `${key}: '${field.systemAttribute}' missing from @auxx/types/system-attribute`
+      ).toBe(true)
+    }
+  })
+
+  it('carries exactly the 01 §1 field set — no option axis, nothing Shopify-shaped', () => {
+    expect(Object.keys(PRODUCT_FIELDS).sort()).toEqual([
+      'createdAt',
+      'createdBy',
+      'description',
+      'handle',
+      'id',
+      'image',
+      'parts',
+      'productType',
+      'status',
+      'tags',
+      'title',
+      'updatedAt',
+      'vendor',
+    ])
+  })
+
+  it('tags reuses the shared open-tag `category` attribute, not a new vocabulary', () => {
+    expect(PRODUCT_FIELDS.tags?.systemAttribute).toBe('category')
+    expect(PRODUCT_FIELDS.tags?.systemAttribute).toBe(PART_FIELDS.category?.systemAttribute)
+  })
+
+  it('is registered in the field registry, ModelTypeValues and SYSTEM_ENTITIES', () => {
+    expect(RESOURCE_FIELD_REGISTRY.product).toBe(PRODUCT_FIELDS)
+    expect(ModelTypeValues).toContain('product')
+    expect(ModelTypeMeta.product).toEqual({
+      label: 'Product',
+      plural: 'Products',
+      icon: 'package-2',
+      color: 'teal',
+      apiSlug: 'products',
+      dbTable: 'EntityInstance',
+      hasDetailPage: true,
+    })
+
+    const entity = SYSTEM_ENTITIES.find((e) => e.entityType === 'product')
+    expect(entity).toMatchObject({
+      apiSlug: 'products',
+      singular: 'Product',
+      plural: 'Products',
+      icon: 'package-2', // `package` is taken by `part`
+      color: 'teal',
+      isVisible: true,
+    })
+  })
+
+  it('display fields resolve against real PRODUCT_FIELDS keys', () => {
+    const config = DISPLAY_FIELD_CONFIG.product
+    expect(config?.primaryDisplayField).toBe('title')
+    expect(config?.secondaryDisplayField).toBe('vendor')
+    for (const key of [config?.primaryDisplayField, config?.secondaryDisplayField]) {
+      expect(PRODUCT_FIELDS[key!], `display field '${key}' not in PRODUCT_FIELDS`).toBeDefined()
+    }
+  })
+})
+
+describe('relationship pairs', () => {
+  // `linkNewRelationships` looks the inverse up by this exact string in the
+  // merged field map — a mismatch on either side is a silent no-link.
+  it('part.product ↔ product.parts point at each other', () => {
+    expect(PART_FIELDS.product?.relationship).toMatchObject({
+      inverseResourceFieldId: 'product:parts',
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    })
+    expect(PRODUCT_FIELDS.parts?.relationship).toMatchObject({
+      inverseResourceFieldId: 'part:product',
+      relationshipType: 'has_many',
+      isInverse: true,
+    })
+    // The seeder pair config on the owning side names the inverse's attribute.
+    expect(PART_FIELDS.product?.relationshipConfig?.inverseSystemAttribute).toBe(
+      PRODUCT_FIELDS.parts?.systemAttribute
+    )
+    expect(PART_FIELDS.product?.systemAttribute).toBe('part_product')
+    expect(PART_FIELDS.product?.nullable).toBe(true)
+  })
+
+  it('product.vendor ↔ company.products point at each other', () => {
+    expect(PRODUCT_FIELDS.vendor?.relationship).toMatchObject({
+      inverseResourceFieldId: 'company:products',
+      relationshipType: 'belongs_to',
+      isInverse: false,
+    })
+    expect(COMPANY_FIELDS.products?.relationship).toMatchObject({
+      inverseResourceFieldId: 'product:vendor',
+      relationshipType: 'has_many',
+      isInverse: true,
+    })
+    expect(PRODUCT_FIELDS.vendor?.relationshipConfig?.inverseSystemAttribute).toBe(
+      COMPANY_FIELDS.products?.systemAttribute
+    )
+    expect(PRODUCT_FIELDS.vendor?.systemAttribute).toBe('product_vendor')
+    expect(PRODUCT_FIELDS.vendor?.nullable).toBe(true)
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/101-product-family.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/101-product-family.ts
@@ -1,0 +1,162 @@
+// packages/lib/src/seed/entity-migrations/migrations/101-product-family.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { FieldOptions } from '../../../custom-fields'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { COMPANY_FIELDS } from '../../../resources/registry/resources/company-fields'
+import { PART_FIELDS } from '../../../resources/registry/resources/part-fields'
+import { PRODUCT_FIELDS } from '../../../resources/registry/resources/product-fields'
+import { SystemUserService } from '../../../users/system-user-service'
+import { SYSTEM_ENTITIES } from '../../entity-seeder/constants'
+import {
+  ensureCustomFields,
+  ensureEntityDefinitions,
+  ensureFieldViews,
+  linkDisplayFields,
+  linkNewRelationships,
+  loadExistingState,
+} from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:101')
+
+/**
+ * Migration 101: the `product` entity — the family above `part`
+ * (plans/products/01-product-family.md §1, §2, §5, §7).
+ *
+ * Def + PRODUCT_FIELDS + the two new relationship pairs:
+ *
+ *   part.product     belongs_to → product  (`part_product`,    nullable)
+ *   product.parts    has_many   → part     (`product_parts`,   isInverse)
+ *   product.vendor   belongs_to → company  (`product_vendor`,  nullable)
+ *   company.products has_many   → product  (`company_products`, isInverse)
+ *
+ * `vendor` is a relation, not a string (01 §2): a supplier is already a
+ * `company`. The Shopify `vendor` brand string is a different fact and lands in
+ * an app field under contribute mode — this relation is linked by a human or
+ * stays null. Deliberately absent: any option-axis field (01 §3), any
+ * `product → catalog_item` edge (pricing stays on the part/catalog seam), and
+ * `partKind` — that shipped in migration 100 with the parts plan.
+ *
+ * **No DDL.** `EntityDefinition.entityType` is a `text()` column, so a new
+ * entity type is this migration plus the hand-edits to `enums.ts` /
+ * `constants.ts` / the system-attribute union. Mirrors the 030/040 recipe.
+ *
+ * Idempotent — every helper is insert-only or skips existing rows.
+ */
+export const migration101ProductFamily: EntityMigration = {
+  id: '101-product-family',
+  description:
+    'Add product as a system entity (product family above part) with vendor and part edges',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const entityDefIds = await ensureEntityDefinitions(
+      db,
+      organizationId,
+      SYSTEM_ENTITIES.filter((e) => e.entityType === 'product'),
+      existing,
+      state
+    )
+
+    // Pull the edge targets into the id map so linkNewRelationships can resolve
+    // both directions of each pair.
+    for (const type of ['part', 'company'] as const) {
+      const def = existing.entityDefs.get(type)
+      if (def) entityDefIds.set(type, def.id)
+    }
+
+    const allFieldMaps = new Map<
+      string,
+      { id: string; systemAttribute: string; options: FieldOptions; _fieldDef: ResourceField }
+    >()
+    const merge = (m: typeof allFieldMaps) => {
+      for (const [k, v] of m) allFieldMaps.set(k, v)
+    }
+
+    const productDefId = entityDefIds.get('product')
+    if (productDefId) {
+      merge(
+        await ensureCustomFields(
+          db,
+          organizationId,
+          'product',
+          productDefId,
+          PRODUCT_FIELDS,
+          existing,
+          state
+        )
+      )
+    }
+
+    // The `part_product` edge — part's only new field (01 §5).
+    const partDefId = entityDefIds.get('part')
+    if (partDefId) {
+      merge(
+        await ensureCustomFields(
+          db,
+          organizationId,
+          'part',
+          partDefId,
+          { product: PART_FIELDS.product! },
+          existing,
+          state
+        )
+      )
+    }
+
+    // The `company_products` inverse of `product_vendor` (01 §2).
+    const companyDefId = entityDefIds.get('company')
+    if (companyDefId) {
+      merge(
+        await ensureCustomFields(
+          db,
+          organizationId,
+          'company',
+          companyDefId,
+          { products: COMPANY_FIELDS.products! },
+          existing,
+          state
+        )
+      )
+    }
+
+    await linkNewRelationships(db, allFieldMaps, entityDefIds, state)
+    await linkDisplayFields(db, ['product'], entityDefIds, allFieldMaps)
+
+    const systemUserId = await SystemUserService.getSystemUserForActions(organizationId)
+    await ensureFieldViews(
+      db,
+      organizationId,
+      systemUserId,
+      [
+        {
+          entityType: 'product',
+          contextType: 'panel',
+          name: 'Default Panel View',
+          excludeFields: ['id', 'created_at', 'updated_at', 'created_by_id'],
+        },
+        {
+          entityType: 'product',
+          contextType: 'table',
+          name: 'Default Table View',
+          excludeFields: ['id', 'created_at', 'updated_at', 'created_by_id'],
+        },
+      ],
+      entityDefIds,
+      allFieldMaps
+    )
+
+    const alreadyUpToDate =
+      state.entityDefsCreated === 0 && state.fieldsCreated === 0 && state.relationshipsLinked === 0
+
+    if (!alreadyUpToDate) {
+      logger.info('Migration 101 applied', { organizationId, ...state })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}

--- a/packages/lib/src/seed/entity-seeder/constants.ts
+++ b/packages/lib/src/seed/entity-seeder/constants.ts
@@ -212,6 +212,15 @@ export const SYSTEM_ENTITIES: SystemEntityConfig[] = [
     color: 'emerald',
     isVisible: false, // Ledger mirror records, rendered only by the invoice drawer
   },
+  {
+    entityType: 'product',
+    apiSlug: 'products',
+    singular: 'Product',
+    plural: 'Products',
+    icon: 'package-2', // `package` is taken by `part`
+    color: 'teal',
+    isVisible: true,
+  },
 ]
 
 /**
@@ -311,6 +320,11 @@ export const DISPLAY_FIELD_CONFIG: Record<string, DisplayFieldConfig> = {
   payment: {
     primaryDisplayField: 'amount',
     secondaryDisplayField: undefined,
+  },
+  product: {
+    primaryDisplayField: 'title',
+    secondaryDisplayField: 'vendor',
+    avatarField: 'image',
   },
 }
 

--- a/packages/lib/src/seed/entity-seeder/create-fields.ts
+++ b/packages/lib/src/seed/entity-seeder/create-fields.ts
@@ -16,6 +16,7 @@ import { MEETING_FIELDS } from '../../resources/registry/resources/meeting-field
 import { PART_FIELDS } from '../../resources/registry/resources/part-fields'
 import { PAYMENT_FIELDS } from '../../resources/registry/resources/payment-fields'
 import { PERSONAL_INBOX_FIELDS } from '../../resources/registry/resources/personal-inbox-fields'
+import { PRODUCT_FIELDS } from '../../resources/registry/resources/product-fields'
 import { QUOTE_FIELDS } from '../../resources/registry/resources/quote-fields'
 import { SERVICE_REQUEST_FIELDS } from '../../resources/registry/resources/service-request-fields'
 import { SIGNATURE_FIELDS } from '../../resources/registry/resources/signature-fields'
@@ -58,6 +59,7 @@ const FIELD_REGISTRY: Record<string, Record<string, ResourceField>> = {
   catalog_group: CATALOG_GROUP_FIELDS,
   invoice: INVOICE_FIELDS,
   payment: PAYMENT_FIELDS,
+  product: PRODUCT_FIELDS,
 }
 
 /**

--- a/packages/types/resource/utils.ts
+++ b/packages/types/resource/utils.ts
@@ -155,6 +155,7 @@ export const ENTITY_DEFINITION_TYPES = [
   'catalog_group',
   'invoice',
   'payment',
+  'product',
 ] as const
 
 /** Type for system entity types stored in EntityDefinition */

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -145,6 +145,7 @@ export const SYSTEM_ATTRIBUTES = [
   'part_subparts',
   'part_used_in_assemblies',
   'part_catalog_items', // inverse of catalog_item_part
+  'part_product', // belongs_to product; inverse is product_parts
 
   // ─── Vendor Part fields ────────────────────────────────────────
   'vendor_part_part',
@@ -212,6 +213,7 @@ export const SYSTEM_ATTRIBUTES = [
   'company_vendor_parts',
   'company_meetings',
   'company_work_orders',
+  'company_products', // inverse of product_vendor
   'company_enriched_at',
   'company_enrichment_status',
 
@@ -339,6 +341,19 @@ export const SYSTEM_ATTRIBUTES = [
   'catalog_item_cost',
   'catalog_item_markup',
   'catalog_item_line_items', // inverse of line_item_catalog_item
+
+  // ─── Product fields ─────────────────────────────────────────────
+  // The family above `part` (plans/products/01-product-family.md §1).
+  // `tags` reuses the shared open-tag `category` attribute from the part
+  // block, not a new one.
+  'product_title',
+  'product_description',
+  'product_image',
+  'product_vendor', // belongs_to company; inverse is company_products
+  'product_type',
+  'product_handle',
+  'product_status',
+  'product_parts', // inverse of part_product
 
   // ─── Catalog Group fields ───────────────────────────────────────
   'catalog_group_name',


### PR DESCRIPTION
Implements phase 2 of the products plan set (01 §1, §2, §5, §7): the `product` entity — the family level above `part` that the Shopify contribute-mode mapping needs as its landing target, and the missing grouping for "Model 3000 Lift, 4t / 6t" style variants.

## What

- **`PRODUCT_FIELDS`**: title (required, primary display), description (RICH_TEXT), image (FILE, avatar), `vendor` as a **relation to company** (a supplier is already a `company`; Shopify's free-text vendor string lands in an app field instead), productType, handle (the connector's first-link match key), status (`draft|active|archived`), tags on the shared `category` attribute, `parts` has_many inverse. **No option axis** — deliberate (01 §3): nothing native reads option values until a variant-aware picker exists.
- **`part.product`** belongs_to (nullable — raw materials belong to no family) + `company.products` inverse.
- **Migration 101** (`101-product-family.ts` + tests): ensureEntityDefinitions → ensureCustomFields (product fields + both relationship pairs) → linkNewRelationships → linkDisplayFields → ensureFieldViews. Idempotent; id re-verified free across both migration directories. **Not yet run against any DB.**
- Registration: `enums.ts` (hand-edited — destructive generator), `SYSTEM_ENTITIES` (+ display map incl. avatar field), the seeder's own `FIELD_REGISTRY` (without which fresh orgs would seed a fieldless def), `product_*` systemAttributes, `ENTITY_DEFINITION_TYPES`.
- `partKind` is **not** here — it shipped in migration 100 (#1830).

## Tests

Migration test 8/8 (pins the inverse-pair string contracts that `linkNewRelationships` silently skips on mismatch); full registry + seed suites 147 green; `@auxx/database` + `@auxx/types` typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)