### PR TITLE
refactor(files): media asset queries, mutations and versions as functions

### DIFF
--- a/packages/lib/src/files/__tests__/support/db.ts
+++ b/packages/lib/src/files/__tests__/support/db.ts
@@ -265,6 +265,23 @@ export function makeDb(options: MakeDbOptions = {}): FakeDb {
         )
       },
 
+      // Drizzle exposes `selectDistinct` as a peer of `select`, not a chain
+      // method, so a call site that uses it (`deleteAssetVersion` walking
+      // `derivedFromVersionId`) would otherwise hit `undefined is not a
+      // function`. It shares `select`'s queue: the stub does not interpret SQL,
+      // so DISTINCT is not a distinction it could model anyway.
+      selectDistinct: (...args: unknown[]) => {
+        journal.record('db', 'selectDistinct', { projection: args[0] })
+        let from = 'unknown'
+        return makeChain(
+          () => selectQueue.shift() ?? [],
+          (method, arg) => {
+            if (method === 'from') from = name(arg)
+            if (method === 'where') fake.wheres.push({ table: from, predicate: arg })
+          }
+        )
+      },
+
       insert: (table: unknown) => {
         let lastInsertValues: unknown[] = []
         const chain = makeChain(() => insertQueue.shift() ?? lastInsertValues)

--- a/packages/lib/src/files/assets/__tests__/asset-mutations.test.ts
+++ b/packages/lib/src/files/assets/__tests__/asset-mutations.test.ts
@@ -1,0 +1,473 @@
+// packages/lib/src/files/assets/__tests__/asset-mutations.test.ts
+
+/**
+ * `assets/asset-mutations.ts` — the write half of what `MediaAssetService` was.
+ *
+ * Three properties this file exists to pin down, all of which the class made
+ * unassertable:
+ *
+ * 1. **Scope comes from `ctx`, never from the payload.** The legacy
+ *    `processCreateData` took `organizationId` off the request.
+ * 2. **Nothing opens a transaction of its own.** The db stub journals
+ *    `begin`/`commit`, so "exactly one pair, and the test opened it" is a
+ *    single assertion — which `BaseService.getTx()` made impossible, since it
+ *    decided at runtime and silently issued a `SAVEPOINT` every time.
+ * 3. **The thumbnail sweep is a parameter.** The legacy delete did
+ *    `await import('./thumbnail-service'); new ThumbnailService(...)` inside its
+ *    own body; here it is a plain object literal and `vi.mock` is called zero
+ *    times in this file.
+ */
+
+import type { Database, Transaction } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import {
+  anAsset,
+  aStorageLocation,
+  makeClock,
+  makeCtx,
+  makeDb,
+  TEST_IDS,
+} from '../../__tests__/support'
+import {
+  convertTempAssetToPermanent,
+  createAsset,
+  createAssetFromFolderFile,
+  createAssetWithVersion,
+  deleteAsset,
+  updateAsset,
+} from '../asset-mutations'
+import type { ThumbnailCleanupPort } from '../ports'
+
+const TABLES = {
+  MediaAsset: schema.MediaAsset,
+  MediaAssetVersion: schema.MediaAssetVersion,
+  StorageLocation: schema.StorageLocation,
+  FolderFile: schema.FolderFile,
+}
+
+/**
+ * Borrow the db stub as a `Transaction`.
+ *
+ * Confined to this one line so it can never be mistaken for the production
+ * shortcut the `tx`-first signature exists to forbid — the transaction test
+ * below takes a genuine `Transaction` from `db.transaction(...)`.
+ */
+const asTx = (db: Database): Transaction => db as unknown as Transaction
+
+const CLOCK = makeClock()
+const NOW = CLOCK.now()
+const deps = { now: CLOCK.now }
+
+/** A recording thumbnail sweep. No `vi.fn`, no module interception. */
+function makeThumbnails(): ThumbnailCleanupPort & { swept: string[] } {
+  const swept: string[] = []
+  return {
+    swept,
+    deleteThumbnailsForSource: async (sourceVersionId: string) => {
+      swept.push(sourceVersionId)
+    },
+  }
+}
+
+function aVersionRow(overrides: Record<string, unknown> = {}) {
+  return { id: TEST_IDS.versionId, assetId: TEST_IDS.assetId, versionNumber: 1, ...overrides }
+}
+
+describe('createAsset', () => {
+  it('writes the caller organization, never the payload', async () => {
+    const db = makeDb({ tables: TABLES })
+
+    await createAsset(makeCtx({ db: db.db, organizationId: 'org_caller' }), deps, {
+      kind: 'DOCUMENT',
+      purpose: 'ORIGINAL',
+      name: 'report.pdf',
+    })
+
+    expect(db.inserts).toHaveLength(1)
+    expect(db.inserts[0]?.values).toMatchObject({
+      organizationId: 'org_caller',
+      kind: 'DOCUMENT',
+      purpose: 'ORIGINAL',
+      name: 'report.pdf',
+    })
+  })
+
+  it('defaults isPrivate to true and stamps updatedAt from deps.now', async () => {
+    const db = makeDb({ tables: TABLES })
+
+    await createAsset(makeCtx({ db: db.db }), deps, { kind: 'DOCUMENT', purpose: 'ORIGINAL' })
+
+    // `MediaAsset.updatedAt` is NOT NULL with no database default, so an insert
+    // that forgets it fails at runtime. Reading the clock through `deps` is what
+    // makes that assertable without process-global fake timers.
+    expect(db.inserts[0]?.values).toMatchObject({ isPrivate: true, updatedAt: NOW })
+  })
+
+  it('rejects a kind the enum does not know with a 400, not a 500', async () => {
+    const db = makeDb({ tables: TABLES })
+
+    const result = await createAsset(makeCtx({ db: db.db }), deps, {
+      // The union is what production callers see; this is the runtime guard for
+      // the untyped edges (job payloads, request bodies) that reach it anyway.
+      kind: 'NOT_A_KIND' as 'DOCUMENT',
+      purpose: 'ORIGINAL',
+    })
+
+    expect(result._unsafeUnwrapErr().statusCode).toBe(400)
+    expect(db.inserts).toEqual([])
+  })
+
+  it('opens no transaction — a single INSERT does not need one', async () => {
+    const db = makeDb({ tables: TABLES })
+
+    await createAsset(makeCtx({ db: db.db }), deps, { kind: 'DOCUMENT', purpose: 'ORIGINAL' })
+
+    expect(db.transactions).toBe(0)
+    expect(db.journal.ops('db')).toEqual(['insert'])
+  })
+})
+
+describe('createAssetWithVersion', () => {
+  function aDb() {
+    return makeDb({
+      query: {
+        MediaAsset: [anAsset()],
+        MediaAssetVersion: [undefined],
+        StorageLocation: [aStorageLocation()],
+      },
+      insert: [[anAsset()], [aVersionRow()]],
+      tables: TABLES,
+    })
+  }
+
+  it('creates the asset and its first version, and points the asset at it', async () => {
+    const db = aDb()
+
+    const result = await createAssetWithVersion(asTx(db.db), makeCtx({ db: db.db }), deps, {
+      kind: 'DOCUMENT',
+      purpose: 'ORIGINAL',
+      storageLocationId: TEST_IDS.storageLocationId,
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(db.inserts.map((insert) => insert.table)).toEqual(['MediaAsset', 'MediaAssetVersion'])
+    expect(db.updates[0]).toMatchObject({
+      table: 'MediaAsset',
+      values: { currentVersionId: TEST_IDS.versionId },
+    })
+  })
+
+  it('never opens a transaction of its own — the caller owns the boundary', async () => {
+    const db = aDb()
+
+    await db.db.transaction(async (tx) => {
+      await createAssetWithVersion(tx, makeCtx({ db: tx }), deps, {
+        kind: 'DOCUMENT',
+        purpose: 'ORIGINAL',
+        storageLocationId: TEST_IDS.storageLocationId,
+      })
+    })
+
+    // Exactly one BEGIN/COMMIT pair, and the test opened it. The legacy
+    // `createWithVersion` called `getTx`, which in drizzle-orm 0.44 issues a
+    // SAVEPOINT even when already inside a transaction.
+    expect(db.transactions).toBe(1)
+    expect(db.journal.ops('db').filter((op) => op === 'begin')).toEqual(['begin'])
+  })
+
+  it('numbers the first version 1 when the asset has none', async () => {
+    const db = aDb()
+
+    await createAssetWithVersion(asTx(db.db), makeCtx({ db: db.db }), deps, {
+      kind: 'DOCUMENT',
+      purpose: 'ORIGINAL',
+      storageLocationId: TEST_IDS.storageLocationId,
+    })
+
+    expect(db.inserts[1]?.values).toMatchObject({ versionNumber: 1 })
+  })
+
+  it('inherits size and mimeType from the storage location when the input omits them', async () => {
+    const db = aDb()
+
+    await createAssetWithVersion(asTx(db.db), makeCtx({ db: db.db }), deps, {
+      kind: 'DOCUMENT',
+      purpose: 'ORIGINAL',
+      storageLocationId: TEST_IDS.storageLocationId,
+    })
+
+    // Behaviour change, deliberate: the legacy `createVersion` spread
+    // `{ size: undefined }` over the location's values and persisted NULL.
+    expect(db.inserts[1]?.values).toMatchObject({ size: 1024, mimeType: 'image/png' })
+  })
+
+  it('fails without inserting a version when the storage location is missing', async () => {
+    const db = makeDb({
+      query: { MediaAsset: [anAsset()], MediaAssetVersion: [undefined], StorageLocation: [] },
+      insert: [[anAsset()]],
+      tables: TABLES,
+    })
+
+    const result = await createAssetWithVersion(asTx(db.db), makeCtx({ db: db.db }), deps, {
+      kind: 'DOCUMENT',
+      purpose: 'ORIGINAL',
+      storageLocationId: 'loc_missing',
+    })
+
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+    expect(db.inserts.map((insert) => insert.table)).toEqual(['MediaAsset'])
+  })
+})
+
+describe('updateAsset', () => {
+  it('scopes the UPDATE to the caller organization and stamps updatedAt', async () => {
+    const db = makeDb({ update: [[anAsset()]], tables: TABLES })
+
+    await updateAsset(makeCtx({ db: db.db, organizationId: 'org_caller' }), deps, 'ast_1', {
+      name: 'renamed.png',
+    })
+
+    expect(db.updates[0]?.values).toMatchObject({ name: 'renamed.png', updatedAt: NOW })
+    const where = JSON.stringify(db.wheres[0]?.predicate)
+    expect(where).toContain('org_caller')
+    expect(where).toContain('ast_1')
+  })
+
+  it('returns NotFoundError when the UPDATE matched no row', async () => {
+    const db = makeDb({ update: [[]], tables: TABLES })
+
+    const result = await updateAsset(makeCtx({ db: db.db }), deps, 'ast_missing', { name: 'x' })
+
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+  })
+})
+
+describe('deleteAsset', () => {
+  function aDb() {
+    return makeDb({
+      query: {
+        MediaAsset: [anAsset()],
+        MediaAssetVersion: [[{ id: 'ver_a' }, { id: 'ver_b' }]],
+      },
+      tables: TABLES,
+    })
+  }
+
+  it('sweeps thumbnails for every version through the injected port', async () => {
+    const db = aDb()
+    const thumbnails = makeThumbnails()
+
+    await deleteAsset(
+      asTx(db.db),
+      makeCtx({ db: db.db }),
+      { ...deps, thumbnails },
+      TEST_IDS.assetId
+    )
+
+    expect(thumbnails.swept).toEqual(['ver_a', 'ver_b'])
+  })
+
+  it('clears dangling currentVersionId pointers within the organization only', async () => {
+    const db = aDb()
+
+    await deleteAsset(
+      asTx(db.db),
+      makeCtx({ db: db.db, organizationId: 'org_caller' }),
+      { ...deps, thumbnails: makeThumbnails() },
+      TEST_IDS.assetId
+    )
+
+    expect(db.updates[0]?.values).toEqual({ currentVersionId: null })
+    // The legacy `UPDATE MediaAsset SET currentVersionId = NULL WHERE
+    // currentVersionId IN (...)` carried no organization filter at all.
+    expect(JSON.stringify(db.wheres[0]?.predicate)).toContain('org_caller')
+  })
+
+  it('soft-deletes with deps.now and scopes the statement', async () => {
+    const db = aDb()
+
+    await deleteAsset(
+      asTx(db.db),
+      makeCtx({ db: db.db, organizationId: 'org_caller' }),
+      { ...deps, thumbnails: makeThumbnails() },
+      TEST_IDS.assetId
+    )
+
+    expect(db.updates[1]?.values).toEqual({ deletedAt: NOW })
+    const where = JSON.stringify(db.wheres[1]?.predicate)
+    expect(where).toContain('org_caller')
+    expect(where).toContain(TEST_IDS.assetId)
+  })
+
+  it('refuses an asset in another organization before touching anything', async () => {
+    const db = makeDb({ query: { MediaAsset: [] }, tables: TABLES })
+    const thumbnails = makeThumbnails()
+
+    const result = await deleteAsset(
+      asTx(db.db),
+      makeCtx({ db: db.db }),
+      { ...deps, thumbnails },
+      TEST_IDS.assetId
+    )
+
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+    expect(thumbnails.swept).toEqual([])
+    expect(db.updates).toEqual([])
+  })
+
+  it('skips the pointer sweep when the asset has no versions', async () => {
+    const db = makeDb({
+      query: { MediaAsset: [anAsset()], MediaAssetVersion: [[]] },
+      tables: TABLES,
+    })
+
+    await deleteAsset(
+      asTx(db.db),
+      makeCtx({ db: db.db }),
+      { ...deps, thumbnails: makeThumbnails() },
+      TEST_IDS.assetId
+    )
+
+    expect(db.updates).toHaveLength(1)
+    expect(db.updates[0]?.values).toEqual({ deletedAt: NOW })
+  })
+})
+
+describe('convertTempAssetToPermanent', () => {
+  it('promotes a temp upload and clears its expiry', async () => {
+    const db = makeDb({ query: { MediaAsset: [anAsset({ kind: 'TEMP_UPLOAD' })] }, tables: TABLES })
+
+    const result = await convertTempAssetToPermanent(
+      makeCtx({ db: db.db }),
+      TEST_IDS.assetId,
+      'EMAIL_ATTACHMENT'
+    )
+
+    expect(result.isOk()).toBe(true)
+    expect(db.updates[0]?.values).toEqual({ kind: 'EMAIL_ATTACHMENT', expiresAt: null })
+  })
+
+  it('is a no-op, not an error, for an asset that is already permanent', async () => {
+    const db = makeDb({ query: { MediaAsset: [anAsset({ kind: 'DOCUMENT' })] }, tables: TABLES })
+
+    const result = await convertTempAssetToPermanent(
+      makeCtx({ db: db.db }),
+      TEST_IDS.assetId,
+      'EMAIL_ATTACHMENT'
+    )
+
+    // Callers run this speculatively over ids an earlier request may already
+    // have converted, so "nothing to do" must not fail them.
+    expect(result.isOk()).toBe(true)
+    expect(db.updates).toEqual([])
+  })
+
+  it('is a no-op for an asset the caller cannot see', async () => {
+    const db = makeDb({ query: { MediaAsset: [] }, tables: TABLES })
+
+    const result = await convertTempAssetToPermanent(makeCtx({ db: db.db }), 'ast_x', 'DOCUMENT')
+
+    expect(result.isOk()).toBe(true)
+    expect(db.updates).toEqual([])
+  })
+})
+
+describe('createAssetFromFolderFile', () => {
+  const aFile = (overrides: Record<string, unknown> = {}) => ({
+    id: 'file_1',
+    organizationId: TEST_IDS.organizationId,
+    name: 'contract.pdf',
+    mimeType: 'application/pdf',
+    size: 2048,
+    createdById: TEST_IDS.userId,
+    currentVersion: { id: 'fver_1', storageLocationId: TEST_IDS.storageLocationId },
+    versions: undefined,
+    ...overrides,
+  })
+
+  it('scopes the FolderFile read to the caller organization', async () => {
+    const db = makeDb({
+      query: {
+        FolderFile: [aFile()],
+        MediaAsset: [anAsset()],
+        MediaAssetVersion: [undefined],
+        StorageLocation: [aStorageLocation()],
+      },
+      insert: [[anAsset()], [aVersionRow()]],
+      tables: TABLES,
+    })
+
+    await createAssetFromFolderFile(
+      asTx(db.db),
+      makeCtx({ db: db.db, organizationId: 'org_caller' }),
+      deps,
+      { fileId: 'file_1' }
+    )
+
+    // Behaviour change: the legacy body looked the file up by bare id, so any
+    // caller holding a file id could mint an asset over another tenant's bytes.
+    const read = db.journal.entries.find(
+      (entry) => (entry.detail as { table?: string })?.table === 'FolderFile'
+    )
+    expect(JSON.stringify((read?.detail?.args as { where?: unknown })?.where)).toContain(
+      'org_caller'
+    )
+  })
+
+  it('returns NotFoundError for a file outside the organization', async () => {
+    const db = makeDb({ query: { FolderFile: [] }, tables: TABLES })
+
+    const result = await createAssetFromFolderFile(asTx(db.db), makeCtx({ db: db.db }), deps, {
+      fileId: 'file_other',
+    })
+
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+    expect(db.inserts).toEqual([])
+  })
+
+  it('reuses an existing asset for the same storage location when asked to', async () => {
+    const existing = anAsset({ id: 'ast_existing' })
+    const db = makeDb({
+      query: {
+        FolderFile: [aFile()],
+        MediaAssetVersion: [[{ id: TEST_IDS.versionId }]],
+        MediaAsset: [existing],
+      },
+      tables: TABLES,
+    })
+
+    const result = await createAssetFromFolderFile(asTx(db.db), makeCtx({ db: db.db }), deps, {
+      fileId: 'file_1',
+      skipIfExists: true,
+    })
+
+    expect(result._unsafeUnwrap().id).toBe('ast_existing')
+    expect(db.inserts).toEqual([])
+  })
+
+  it('defaults the new asset to DOCUMENT and copies the file metadata', async () => {
+    const db = makeDb({
+      query: {
+        FolderFile: [aFile()],
+        MediaAsset: [anAsset()],
+        MediaAssetVersion: [undefined],
+        StorageLocation: [aStorageLocation()],
+      },
+      insert: [[anAsset()], [aVersionRow()]],
+      tables: TABLES,
+    })
+
+    await createAssetFromFolderFile(asTx(db.db), makeCtx({ db: db.db }), deps, { fileId: 'file_1' })
+
+    expect(db.inserts[0]?.values).toMatchObject({
+      kind: 'DOCUMENT',
+      purpose: 'ORIGINAL',
+      name: 'contract.pdf',
+      mimeType: 'application/pdf',
+      size: 2048,
+      isPrivate: true,
+      createdById: TEST_IDS.userId,
+    })
+  })
+})

--- a/packages/lib/src/files/assets/__tests__/asset-queries.test.ts
+++ b/packages/lib/src/files/assets/__tests__/asset-queries.test.ts
@@ -1,0 +1,313 @@
+// packages/lib/src/files/assets/__tests__/asset-queries.test.ts
+
+/**
+ * `assets/asset-queries.ts` — the read half of what `MediaAssetService` was.
+ *
+ * As with every test written to the `files/` contract, **`vi.mock` is called
+ * zero times in this file**: `ctx.db` is a parameter, so there is nothing left
+ * to intercept at module scope.
+ *
+ * The assertions that matter beyond "it returns rows" are the WHERE clauses.
+ * The db stub does not interpret SQL, but it stores the predicate the code
+ * built, and the bound values survive `JSON.stringify` — which is enough to
+ * prove an organization filter is present. It is not enough to prove *which
+ * column* each condition names (this package's `@auxx/database` mock hands out
+ * `{}` for every table, so column references serialize as `null`); that
+ * distinction belongs to the integration lane.
+ */
+
+import { schema } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import { anAsset, aStorageLocation, makeCtx, makeDb, TEST_IDS } from '../../__tests__/support'
+import {
+  findAssetsByKind,
+  findExpiredAssets,
+  getAsset,
+  getAssetCurrentVersion,
+  getAssetVersionByNumber,
+  getAssetVersions,
+  getAssetWithRelations,
+  getLatestAssetVersion,
+  listAssets,
+} from '../asset-queries'
+
+const TABLES = { MediaAsset: schema.MediaAsset, MediaAssetVersion: schema.MediaAssetVersion }
+
+function aVersion(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TEST_IDS.versionId,
+    assetId: TEST_IDS.assetId,
+    versionNumber: 1,
+    size: 1024,
+    mimeType: 'image/png',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    storageLocationId: TEST_IDS.storageLocationId,
+    deletedAt: null,
+    derivedFromVersionId: null,
+    preset: null,
+    metadata: {},
+    status: 'READY' as const,
+    storageLocation: aStorageLocation(),
+    ...overrides,
+  }
+}
+
+/** The `where` predicate handed to the n-th relational read, stringified. */
+function whereOf(db: ReturnType<typeof makeDb>, index: number): string {
+  const reads = db.journal.entries.filter(
+    (entry) => entry.op === 'query.findFirst' || entry.op === 'query.findMany'
+  )
+  return JSON.stringify((reads[index]?.detail?.args as { where?: unknown })?.where)
+}
+
+describe('getAsset', () => {
+  it('returns the row and scopes the read to the caller organization', async () => {
+    const db = makeDb({ query: { MediaAsset: [anAsset()] }, tables: TABLES })
+
+    const result = await getAsset(makeCtx({ db: db.db, organizationId: 'org_other' }), 'ast_1')
+
+    expect(result._unsafeUnwrap()).toEqual(anAsset())
+    const where = whereOf(db, 0)
+    expect(where).toContain('org_other')
+    expect(where).toContain('ast_1')
+    // `deletedAt IS NULL` — a soft-deleted asset must not come back.
+    expect(where).toContain(' is null')
+  })
+
+  it('returns ok(null) rather than an error when nothing matches', async () => {
+    const db = makeDb({ query: { MediaAsset: [] }, tables: TABLES })
+
+    const result = await getAsset(makeCtx({ db: db.db }), 'ast_missing')
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toBeNull()
+  })
+
+  it('scopes unconditionally — there is no "no organization" branch left', async () => {
+    // The legacy body was `if (this.organizationId) filters.push(...)`, so a
+    // service built without one queried every tenant. `FilesCtx.organizationId`
+    // is required, so the filter is always in the statement.
+    const db = makeDb({ query: { MediaAsset: [anAsset()] }, tables: TABLES })
+
+    await getAsset(makeCtx({ db: db.db, organizationId: TEST_IDS.organizationId }), 'ast_1')
+
+    expect(whereOf(db, 0)).toContain(TEST_IDS.organizationId)
+  })
+})
+
+describe('getAssetWithRelations', () => {
+  it('asks for the current version, all versions, attachments and the creator', async () => {
+    const db = makeDb({ query: { MediaAsset: [anAsset()] }, tables: TABLES })
+
+    await getAssetWithRelations(makeCtx({ db: db.db }), TEST_IDS.assetId)
+
+    const read = db.journal.entries.find((entry) => entry.op === 'query.findFirst')
+    const relations = (read?.detail?.args as { with?: Record<string, unknown> })?.with
+    expect(Object.keys(relations ?? {}).sort()).toEqual([
+      'attachments',
+      'createdBy',
+      'currentVersion',
+      'versions',
+    ])
+  })
+})
+
+describe('listAssets', () => {
+  it('reports hasMore when the page is full and total as the page size', async () => {
+    const db = makeDb({ query: { MediaAsset: [[anAsset(), anAsset()]] }, tables: TABLES })
+
+    const result = await listAssets(makeCtx({ db: db.db }), { limit: 2 })
+
+    // `total` is inherited verbatim from the legacy `list`, which never issued a
+    // count query. Documented on `AssetPage`, asserted here so a future "fix"
+    // is a deliberate change rather than a surprise.
+    expect(result._unsafeUnwrap()).toMatchObject({ total: 2, hasMore: true })
+  })
+
+  it('does not report hasMore on a short page', async () => {
+    const db = makeDb({ query: { MediaAsset: [[anAsset()]] }, tables: TABLES })
+
+    const result = await listAssets(makeCtx({ db: db.db }), { limit: 5 })
+
+    expect(result._unsafeUnwrap().hasMore).toBe(false)
+  })
+
+  it('keeps soft-deleted rows out unless asked for them', async () => {
+    const withDefault = makeDb({ query: { MediaAsset: [[]] }, tables: TABLES })
+    await listAssets(makeCtx({ db: withDefault.db }), {})
+    expect(whereOf(withDefault, 0)).toContain(' is null')
+
+    const withDeleted = makeDb({ query: { MediaAsset: [[]] }, tables: TABLES })
+    await listAssets(makeCtx({ db: withDeleted.db }), { includeDeleted: true })
+    expect(whereOf(withDeleted, 0)).not.toContain(' is null')
+  })
+
+  it('binds the kind and isPrivate filters into the statement', async () => {
+    const db = makeDb({ query: { MediaAsset: [[]] }, tables: TABLES })
+
+    await listAssets(makeCtx({ db: db.db }), { kind: 'THUMBNAIL', isPrivate: false })
+
+    const where = whereOf(db, 0)
+    expect(where).toContain('THUMBNAIL')
+    expect(where).toContain('false')
+  })
+})
+
+describe('findAssetsByKind', () => {
+  it('filters on kind, live rows and the caller organization', async () => {
+    const db = makeDb({ query: { MediaAsset: [[anAsset({ kind: 'DOCUMENT' })]] }, tables: TABLES })
+
+    const result = await findAssetsByKind(makeCtx({ db: db.db }), 'DOCUMENT')
+
+    expect(result._unsafeUnwrap()).toHaveLength(1)
+    const where = whereOf(db, 0)
+    expect(where).toContain('DOCUMENT')
+    expect(where).toContain(TEST_IDS.organizationId)
+  })
+})
+
+describe('findExpiredAssets', () => {
+  it('takes the cutoff as an instant instead of reading the clock', async () => {
+    const db = makeDb({ query: { MediaAsset: [[]] }, tables: TABLES })
+    const cutoff = new Date('2026-01-01T00:00:00.000Z')
+
+    await findExpiredAssets(makeCtx({ db: db.db }), cutoff)
+
+    const where = whereOf(db, 0)
+    expect(where).toContain('TEMP_UPLOAD')
+    expect(where).toContain('2026-01-01T00:00:00.000Z')
+  })
+
+  it('can sweep a kind other than TEMP_UPLOAD', async () => {
+    const db = makeDb({ query: { MediaAsset: [[]] }, tables: TABLES })
+
+    await findExpiredAssets(makeCtx({ db: db.db }), new Date(0), 'THUMBNAIL')
+
+    expect(whereOf(db, 0)).toContain('THUMBNAIL')
+  })
+})
+
+describe('getAssetCurrentVersion', () => {
+  it('follows currentVersionId when the asset has one', async () => {
+    const db = makeDb({
+      query: { MediaAsset: [anAsset()], MediaAssetVersion: [aVersion()] },
+      tables: TABLES,
+    })
+
+    const result = await getAssetCurrentVersion(makeCtx({ db: db.db }), TEST_IDS.assetId)
+
+    expect(result._unsafeUnwrap()?.id).toBe(TEST_IDS.versionId)
+    // The version read is constrained by BOTH the version id and the asset id,
+    // so a version belonging to another asset cannot be served through this one.
+    const where = whereOf(db, 1)
+    expect(where).toContain(TEST_IDS.versionId)
+    expect(where).toContain(TEST_IDS.assetId)
+  })
+
+  it('falls back to the highest version number when currentVersionId is null', async () => {
+    const db = makeDb({
+      query: {
+        MediaAsset: [anAsset({ currentVersionId: null })],
+        MediaAssetVersion: [aVersion({ versionNumber: 7 })],
+      },
+      tables: TABLES,
+    })
+
+    const result = await getAssetCurrentVersion(makeCtx({ db: db.db }), TEST_IDS.assetId)
+
+    expect(result._unsafeUnwrap()?.versionNumber).toBe(7)
+    expect(whereOf(db, 1)).not.toContain(TEST_IDS.versionId)
+  })
+
+  it('returns NotFoundError when the asset is missing, not ok(null)', async () => {
+    const db = makeDb({ query: { MediaAsset: [] }, tables: TABLES })
+
+    const result = await getAssetCurrentVersion(makeCtx({ db: db.db }), 'ast_missing')
+
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+  })
+
+  it('returns ok(null) when the asset exists but has no version', async () => {
+    const db = makeDb({
+      query: { MediaAsset: [anAsset({ currentVersionId: null })], MediaAssetVersion: [] },
+      tables: TABLES,
+    })
+
+    const result = await getAssetCurrentVersion(makeCtx({ db: db.db }), TEST_IDS.assetId)
+
+    expect(result._unsafeUnwrap()).toBeNull()
+  })
+})
+
+describe('getAssetVersions', () => {
+  it('resolves the asset first, so the listing is organization-scoped', async () => {
+    const db = makeDb({
+      query: { MediaAsset: [anAsset()], MediaAssetVersion: [[aVersion()]] },
+      tables: TABLES,
+    })
+
+    const result = await getAssetVersions(
+      makeCtx({ db: db.db, organizationId: 'org_owner' }),
+      TEST_IDS.assetId
+    )
+
+    expect(result._unsafeUnwrap()).toHaveLength(1)
+    expect(whereOf(db, 0)).toContain('org_owner')
+  })
+
+  it('refuses to list versions of an asset in another organization', async () => {
+    const db = makeDb({
+      query: { MediaAsset: [], MediaAssetVersion: [[aVersion()]] },
+      tables: TABLES,
+    })
+
+    const result = await getAssetVersions(makeCtx({ db: db.db }), TEST_IDS.assetId)
+
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+    // The version query never ran.
+    expect(db.journal.ops('db')).toEqual(['query.findFirst'])
+  })
+})
+
+describe('getAssetVersionByNumber', () => {
+  it('addresses the version by number, not by id', async () => {
+    const db = makeDb({
+      query: { MediaAsset: [anAsset()], MediaAssetVersion: [aVersion({ versionNumber: 3 })] },
+      tables: TABLES,
+    })
+
+    const result = await getAssetVersionByNumber(makeCtx({ db: db.db }), TEST_IDS.assetId, 3)
+
+    expect(result._unsafeUnwrap()?.versionNumber).toBe(3)
+    const where = whereOf(db, 1)
+    expect(where).toContain(TEST_IDS.assetId)
+    expect(where).toContain('3')
+  })
+})
+
+describe('getLatestAssetVersion', () => {
+  it('is organization-scoped, which the legacy getLatestVersion was not', async () => {
+    // The legacy method queried `MediaAssetVersion` by bare `assetId` and never
+    // loaded the asset, so no statement in it carried an organization filter.
+    const db = makeDb({
+      query: { MediaAsset: [], MediaAssetVersion: [aVersion()] },
+      tables: TABLES,
+    })
+
+    const result = await getLatestAssetVersion(makeCtx({ db: db.db }), TEST_IDS.assetId)
+
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+    expect(db.journal.ops('db')).toEqual(['query.findFirst'])
+  })
+
+  it('returns the newest version for an asset the caller owns', async () => {
+    const db = makeDb({
+      query: { MediaAsset: [anAsset()], MediaAssetVersion: [aVersion({ versionNumber: 9 })] },
+      tables: TABLES,
+    })
+
+    const result = await getLatestAssetVersion(makeCtx({ db: db.db }), TEST_IDS.assetId)
+
+    expect(result._unsafeUnwrap()?.versionNumber).toBe(9)
+  })
+})

--- a/packages/lib/src/files/assets/__tests__/version-mutations.test.ts
+++ b/packages/lib/src/files/assets/__tests__/version-mutations.test.ts
@@ -1,0 +1,329 @@
+// packages/lib/src/files/assets/__tests__/version-mutations.test.ts
+
+/**
+ * `assets/version-mutations.ts`.
+ *
+ * The `tx`-first signature is the load-bearing part here: creating a version is
+ * an INSERT plus a `currentVersionId` move, and a `ctx`-only signature would
+ * accept a pool and let the two drift apart. `vi.mock` is called zero times.
+ */
+
+import type { Database, Transaction } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import {
+  anAsset,
+  aStorageLocation,
+  makeClock,
+  makeCtx,
+  makeDb,
+  TEST_IDS,
+} from '../../__tests__/support'
+import type { ThumbnailCleanupPort } from '../ports'
+import {
+  createAssetVersion,
+  deleteAssetVersion,
+  restoreAssetVersion,
+  updateAssetContent,
+} from '../version-mutations'
+
+const TABLES = {
+  MediaAsset: schema.MediaAsset,
+  MediaAssetVersion: schema.MediaAssetVersion,
+  StorageLocation: schema.StorageLocation,
+}
+
+/** See `asset-mutations.test.ts` — the cast is confined to this one line. */
+const asTx = (db: Database): Transaction => db as unknown as Transaction
+
+const CLOCK = makeClock()
+const NOW = CLOCK.now()
+const deps = { now: CLOCK.now }
+
+function makeThumbnails(): ThumbnailCleanupPort & { swept: string[] } {
+  const swept: string[] = []
+  return {
+    swept,
+    deleteThumbnailsForSource: async (sourceVersionId: string) => {
+      swept.push(sourceVersionId)
+    },
+  }
+}
+
+function aVersionRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TEST_IDS.versionId,
+    assetId: TEST_IDS.assetId,
+    versionNumber: 1,
+    size: 1024,
+    mimeType: 'image/png',
+    storageLocationId: TEST_IDS.storageLocationId,
+    deletedAt: null,
+    derivedFromVersionId: null,
+    preset: null,
+    metadata: {},
+    status: 'READY' as const,
+    storageLocation: aStorageLocation(),
+    ...overrides,
+  }
+}
+
+describe('createAssetVersion', () => {
+  function aDb(options: Parameters<typeof makeDb>[0] = {}) {
+    return makeDb({
+      query: {
+        MediaAsset: [anAsset()],
+        MediaAssetVersion: [{ versionNumber: 4 }],
+        StorageLocation: [aStorageLocation()],
+      },
+      insert: [[aVersionRow({ versionNumber: 5 })]],
+      tables: TABLES,
+      ...options,
+    })
+  }
+
+  it('numbers the new version one past the highest existing one', async () => {
+    const db = aDb()
+
+    await createAssetVersion(asTx(db.db), makeCtx({ db: db.db }), {
+      assetId: TEST_IDS.assetId,
+      storageLocationId: TEST_IDS.storageLocationId,
+    })
+
+    expect(db.inserts[0]?.values).toMatchObject({ versionNumber: 5 })
+  })
+
+  it('moves currentVersionId within the caller organization', async () => {
+    const db = aDb()
+
+    await createAssetVersion(asTx(db.db), makeCtx({ db: db.db, organizationId: 'org_caller' }), {
+      assetId: TEST_IDS.assetId,
+      storageLocationId: TEST_IDS.storageLocationId,
+    })
+
+    expect(db.updates[0]?.values).toEqual({ currentVersionId: TEST_IDS.versionId })
+    // The legacy `UPDATE MediaAsset SET currentVersionId = ? WHERE id = ?`
+    // carried no organization filter.
+    expect(JSON.stringify(db.wheres.at(-1)?.predicate)).toContain('org_caller')
+  })
+
+  it('persists caller metadata alongside the location-derived fields', async () => {
+    const db = aDb()
+
+    await createAssetVersion(asTx(db.db), makeCtx({ db: db.db }), {
+      assetId: TEST_IDS.assetId,
+      storageLocationId: TEST_IDS.storageLocationId,
+      metadata: { contentHash: 'abc123' },
+    })
+
+    expect(db.inserts[0]?.values).toMatchObject({
+      metadata: { contentHash: 'abc123' },
+      size: 1024,
+      mimeType: 'image/png',
+    })
+  })
+
+  it('prefers explicit size and mimeType over the location row', async () => {
+    const db = aDb()
+
+    await createAssetVersion(asTx(db.db), makeCtx({ db: db.db }), {
+      assetId: TEST_IDS.assetId,
+      storageLocationId: TEST_IDS.storageLocationId,
+      size: 42,
+      mimeType: 'application/pdf',
+    })
+
+    expect(db.inserts[0]?.values).toMatchObject({ size: 42, mimeType: 'application/pdf' })
+  })
+
+  it('refuses an asset the caller cannot see, before reading anything else', async () => {
+    const db = aDb({ query: { MediaAsset: [] } })
+
+    const result = await createAssetVersion(asTx(db.db), makeCtx({ db: db.db }), {
+      assetId: TEST_IDS.assetId,
+      storageLocationId: TEST_IDS.storageLocationId,
+    })
+
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+    expect(db.inserts).toEqual([])
+  })
+
+  it('opens no transaction of its own', async () => {
+    const db = aDb()
+
+    await db.db.transaction(async (tx) => {
+      await createAssetVersion(tx, makeCtx({ db: tx }), {
+        assetId: TEST_IDS.assetId,
+        storageLocationId: TEST_IDS.storageLocationId,
+      })
+    })
+
+    expect(db.transactions).toBe(1)
+  })
+})
+
+describe('updateAssetContent', () => {
+  function aDb() {
+    return makeDb({
+      query: {
+        MediaAsset: [anAsset(), anAsset()],
+        MediaAssetVersion: [{ versionNumber: 1 }],
+        StorageLocation: [aStorageLocation()],
+      },
+      insert: [[aVersionRow({ versionNumber: 2 })]],
+      update: [[], [anAsset({ size: 99 })]],
+      tables: TABLES,
+    })
+  }
+
+  it('adds a version and updates only the asset fields the input names', async () => {
+    const db = aDb()
+
+    const result = await updateAssetContent(asTx(db.db), makeCtx({ db: db.db }), deps, {
+      assetId: TEST_IDS.assetId,
+      storageLocationId: TEST_IDS.storageLocationId,
+      size: 99,
+    })
+
+    expect(result.isOk()).toBe(true)
+    // First update is the `currentVersionId` move inside the version insert;
+    // the second is the asset metadata update.
+    expect(db.updates[1]?.values).toEqual({ size: 99, updatedAt: NOW })
+  })
+
+  it('still stamps updatedAt when no metadata field changes', async () => {
+    const db = aDb()
+
+    await updateAssetContent(asTx(db.db), makeCtx({ db: db.db }), deps, {
+      assetId: TEST_IDS.assetId,
+      storageLocationId: TEST_IDS.storageLocationId,
+    })
+
+    expect(db.updates[1]?.values).toEqual({ updatedAt: NOW })
+  })
+})
+
+describe('restoreAssetVersion', () => {
+  it('points the asset at the requested version number, org-scoped', async () => {
+    const db = makeDb({
+      query: {
+        MediaAsset: [anAsset()],
+        MediaAssetVersion: [aVersionRow({ id: 'ver_old', versionNumber: 2 })],
+      },
+      update: [[anAsset({ currentVersionId: 'ver_old' })]],
+      tables: TABLES,
+    })
+
+    const result = await restoreAssetVersion(
+      makeCtx({ db: db.db, organizationId: 'org_caller' }),
+      deps,
+      TEST_IDS.assetId,
+      2
+    )
+
+    expect(result.isOk()).toBe(true)
+    expect(db.updates[0]?.values).toEqual({ currentVersionId: 'ver_old', updatedAt: NOW })
+    // The legacy `restoreVersion` read the version org-scoped and then updated
+    // by bare id.
+    expect(JSON.stringify(db.wheres[0]?.predicate)).toContain('org_caller')
+  })
+
+  it('returns NotFoundError for a version number the asset does not have', async () => {
+    const db = makeDb({
+      query: { MediaAsset: [anAsset()], MediaAssetVersion: [] },
+      tables: TABLES,
+    })
+
+    const result = await restoreAssetVersion(makeCtx({ db: db.db }), deps, TEST_IDS.assetId, 9)
+
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+    expect(db.updates).toEqual([])
+  })
+})
+
+describe('deleteAssetVersion', () => {
+  it('refuses to delete the version the asset currently points at', async () => {
+    const db = makeDb({
+      query: {
+        MediaAsset: [anAsset({ currentVersionId: TEST_IDS.versionId }), anAsset()],
+        MediaAssetVersion: [aVersionRow()],
+      },
+      tables: TABLES,
+    })
+    const thumbnails = makeThumbnails()
+
+    const result = await deleteAssetVersion(
+      makeCtx({ db: db.db }),
+      { thumbnails },
+      TEST_IDS.assetId,
+      1
+    )
+
+    // 409, not a bare 500 — losing the current version leaves the asset
+    // pointing at nothing.
+    expect(result._unsafeUnwrapErr().statusCode).toBe(409)
+    expect(thumbnails.swept).toEqual([])
+    expect(db.deletes).toEqual([])
+  })
+
+  it('sweeps thumbnails through the port and then deletes the version row', async () => {
+    const db = makeDb({
+      query: {
+        MediaAsset: [anAsset({ currentVersionId: 'ver_current' }), anAsset()],
+        MediaAssetVersion: [aVersionRow({ id: 'ver_old', versionNumber: 1 })],
+      },
+      select: [[]],
+      tables: TABLES,
+    })
+    const thumbnails = makeThumbnails()
+
+    const result = await deleteAssetVersion(
+      makeCtx({ db: db.db }),
+      { thumbnails },
+      TEST_IDS.assetId,
+      1
+    )
+
+    expect(result.isOk()).toBe(true)
+    expect(thumbnails.swept).toEqual(['ver_old'])
+    expect(db.deletes.map((entry) => entry.table)).toEqual(['MediaAssetVersion'])
+  })
+
+  it('purges the derived thumbnail assets before deleting, or the FK blocks it', async () => {
+    const db = makeDb({
+      query: {
+        MediaAsset: [anAsset({ currentVersionId: 'ver_current' }), anAsset()],
+        MediaAssetVersion: [aVersionRow({ id: 'ver_old' })],
+      },
+      // `selectDistinct` shares the select queue: one derived asset found.
+      select: [[{ assetId: 'ast_thumb' }]],
+      tables: TABLES,
+    })
+
+    await deleteAssetVersion(
+      makeCtx({ db: db.db }),
+      { thumbnails: makeThumbnails() },
+      TEST_IDS.assetId,
+      1
+    )
+
+    // `purgeMediaAssets` runs raw statements; the journal proves it ran at all,
+    // which is the property that matters — a surviving derived row raises 23503.
+    expect(db.journal.ops('db')).toContain('execute')
+  })
+
+  it('refuses an asset the caller cannot see', async () => {
+    const db = makeDb({ query: { MediaAsset: [] }, tables: TABLES })
+    const thumbnails = makeThumbnails()
+
+    const result = await deleteAssetVersion(
+      makeCtx({ db: db.db }),
+      { thumbnails },
+      TEST_IDS.assetId,
+      1
+    )
+
+    expect(result._unsafeUnwrapErr().statusCode).toBe(404)
+    expect(thumbnails.swept).toEqual([])
+  })
+})

--- a/packages/lib/src/files/assets/asset-mutations.ts
+++ b/packages/lib/src/files/assets/asset-mutations.ts
@@ -1,0 +1,447 @@
+// packages/lib/src/files/assets/asset-mutations.ts
+
+/**
+ * `MediaAsset` writes.
+ *
+ * Reads live in `assets/asset-queries.ts`, version writes in
+ * `assets/version-mutations.ts` — `docs/lib-module-guide.md` §5, "a file that
+ * both queries and mutates is the first step back toward a service class".
+ *
+ * ## Scope comes from `ctx`, never from the payload
+ *
+ * The legacy `processCreateData` took `organizationId` off the request and only
+ * fell back to the service's own scope, so a caller could write a row into an
+ * organization it was not acting for. Following `storage/locations.ts`, the
+ * input types below carry no `organizationId` at all.
+ *
+ * ## Actors travel in the input, not in `ctx`
+ *
+ * `FilesCtx` deliberately has no `userId` (`files/ctx.ts`), so
+ * {@link CreateAssetInput.createdById} is where attribution appears — in the
+ * signature of exactly the function that attributes, and nowhere else.
+ */
+
+import type { Database, Transaction } from '@auxx/database'
+import { schema } from '@auxx/database'
+import type { MediaAssetEntity } from '@auxx/database/types'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import { AuxxError, BadRequestError, NotFoundError } from '../../errors'
+import type { AssetKind } from '../core/types'
+import { VALID_ASSET_KINDS } from '../core/types'
+import type { FilesCtx } from '../ctx'
+import { guard } from '../guard'
+import { requireAsset } from './asset-queries'
+import type { AssetDeleteDeps, AssetWriteDeps } from './ports'
+import type { CreatedAssetVersion } from './version-mutations'
+import { createAssetVersion } from './version-mutations'
+
+/** Everything needed to persist one `MediaAsset` row. See the file header for what is absent. */
+export interface CreateAssetInput {
+  kind: AssetKind
+  purpose: string
+  name?: string
+  mimeType?: string
+  size?: number
+  /** Defaults to `true`, matching the legacy "private unless told otherwise" default. */
+  isPrivate?: boolean
+  /** The actor to attribute the row to. Optional: several production writers have no actor. */
+  createdById?: string
+  /** Automatic-cleanup deadline for temporary assets. */
+  expiresAt?: Date
+}
+
+/** {@link CreateAssetInput} plus the storage location the first version points at. */
+export interface CreateAssetWithVersionInput extends CreateAssetInput {
+  storageLocationId: string
+}
+
+/** The mutable fields of a `MediaAsset`. */
+export interface UpdateAssetInput {
+  kind?: AssetKind
+  name?: string
+  isPrivate?: boolean
+  mimeType?: string
+  size?: number
+  expiresAt?: Date | null
+}
+
+/** Everything needed to mint a `MediaAsset` from an existing file-library row. */
+export interface CreateAssetFromFolderFileInput {
+  fileId: string
+  /** Pin a specific `FileVersion`. Defaults to the file's current version. */
+  fileVersionId?: string
+  /** Defaults to `DOCUMENT`, matching the legacy default. */
+  kind?: AssetKind
+  /**
+   * Return an existing asset that already points at the same storage location
+   * instead of minting a second one.
+   */
+  skipIfExists?: boolean
+}
+
+/**
+ * Create one `MediaAsset` row.
+ *
+ * A single `INSERT`, so it takes `ctx` rather than a `Transaction`. A caller
+ * that is already inside one passes `{ ...ctx, db: tx }`.
+ *
+ * @param ctx Scope and database. `ctx.organizationId` is the row's owner.
+ * @param deps `now`, for the `updatedAt` stamp — the column is `NOT NULL` with
+ *   no database default.
+ * @param input The row to write.
+ */
+export async function createAsset(
+  ctx: FilesCtx,
+  deps: AssetWriteDeps,
+  input: CreateAssetInput
+): Promise<Result<MediaAssetEntity, AuxxError>> {
+  return guard(async () => insertAsset(ctx.db, ctx, deps, input), 'Failed to create asset', {
+    kind: input.kind,
+    organizationId: ctx.organizationId,
+  })
+}
+
+/**
+ * Create an asset and its first version together, inside the caller's transaction.
+ *
+ * `tx` is positional and first because this is three statements — insert the
+ * asset, insert the version, move `currentVersionId` — and an asset that exists
+ * without a version is an asset nothing can download. The legacy
+ * `createWithVersion` opened its own `getTx` savepoint; here the caller owns the
+ * boundary (`plans/attachments/06-transactions-and-jobs.md` §6.1).
+ *
+ * @param tx The caller's transaction. Never `tx.transaction(…)`ed here.
+ * @param ctx Scope. `ctx.db` is ignored — every statement runs on `tx`.
+ * @param deps `now`, for the asset's `updatedAt` stamp.
+ * @param input Asset fields plus the storage location the first version points at.
+ */
+export async function createAssetWithVersion(
+  tx: Transaction,
+  ctx: FilesCtx,
+  deps: AssetWriteDeps,
+  input: CreateAssetWithVersionInput
+): Promise<Result<{ asset: MediaAssetEntity; version: CreatedAssetVersion }, AuxxError>> {
+  return guard(
+    async () => {
+      const { storageLocationId, ...assetInput } = input
+      const asset = await insertAsset(tx, ctx, deps, assetInput)
+
+      const version = await createAssetVersion(tx, ctx, {
+        assetId: asset.id,
+        storageLocationId,
+        size: input.size,
+        mimeType: input.mimeType,
+      })
+      // Rethrow rather than return: an `err()` here would resolve normally and
+      // the caller would commit an asset with no version.
+      if (version.isErr()) throw version.error
+
+      return { asset, version: version.value }
+    },
+    'Failed to create asset with version',
+    { kind: input.kind, storageLocationId: input.storageLocationId }
+  )
+}
+
+/**
+ * Update one asset's mutable fields.
+ *
+ * @param ctx Scope and database.
+ * @param deps `now`, for the `updatedAt` stamp.
+ * @param assetId The asset to update, interpreted within `ctx.organizationId`.
+ * @param input The fields to change. Absent fields are left alone.
+ */
+export async function updateAsset(
+  ctx: FilesCtx,
+  deps: AssetWriteDeps,
+  assetId: string,
+  input: UpdateAssetInput
+): Promise<Result<MediaAssetEntity, AuxxError>> {
+  return guard(
+    async () => {
+      const [asset] = await ctx.db
+        .update(schema.MediaAsset)
+        .set({ ...input, updatedAt: deps.now() })
+        .where(
+          and(
+            eq(schema.MediaAsset.id, assetId),
+            eq(schema.MediaAsset.organizationId, ctx.organizationId)
+          )
+        )
+        .returning()
+
+      if (!asset) throw new NotFoundError(`Asset ${assetId} not found`)
+      return asset
+    },
+    'Failed to update asset',
+    { assetId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Soft-delete an asset and everything that pointed at its versions.
+ *
+ * Three steps, all on `tx`, all of which have to land together:
+ *
+ * 1. sweep the thumbnails derived from every version of the asset;
+ * 2. null out any `currentVersionId` that referenced one of those versions —
+ *    **now organization-scoped**, which the legacy `UPDATE … WHERE
+ *    currentVersionId IN (…)` was not;
+ * 3. stamp `deletedAt` on the asset itself, also organization-scoped.
+ *
+ * The thumbnail sweep performs storage I/O while the transaction is open. That
+ * is inherited from the legacy `delete`, which ran the same sequence inside its
+ * own `getTx`; moving it outside the boundary is Phase 6's job, not this PR's.
+ *
+ * @param tx The caller's transaction.
+ * @param ctx Scope. `ctx.db` is ignored.
+ * @param deps The thumbnail sweep, plus `now` for the `deletedAt` stamp.
+ * @param assetId The asset to remove.
+ */
+export async function deleteAsset(
+  tx: Transaction,
+  ctx: FilesCtx,
+  deps: AssetDeleteDeps,
+  assetId: string
+): Promise<Result<void, AuxxError>> {
+  return guard(
+    async () => {
+      const txCtx: FilesCtx = { ...ctx, db: tx }
+      await requireAsset(txCtx, assetId)
+
+      const versions = await tx.query.MediaAssetVersion.findMany({
+        where: eq(schema.MediaAssetVersion.assetId, assetId),
+        columns: { id: true },
+      })
+
+      for (const version of versions) {
+        await deps.thumbnails.deleteThumbnailsForSource(version.id)
+      }
+
+      if (versions.length > 0) {
+        await tx
+          .update(schema.MediaAsset)
+          .set({ currentVersionId: null })
+          .where(
+            and(
+              inArray(
+                schema.MediaAsset.currentVersionId,
+                versions.map((version) => version.id)
+              ),
+              eq(schema.MediaAsset.organizationId, ctx.organizationId)
+            )
+          )
+      }
+
+      await tx
+        .update(schema.MediaAsset)
+        .set({ deletedAt: deps.now() })
+        .where(
+          and(
+            eq(schema.MediaAsset.id, assetId),
+            eq(schema.MediaAsset.organizationId, ctx.organizationId)
+          )
+        )
+    },
+    'Failed to delete asset',
+    { assetId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Promote a temporary upload to a permanent kind and clear its expiry.
+ *
+ * A no-op — `ok(undefined)`, not an error — when the asset is missing or already
+ * permanent, matching the legacy `convertTempToPermanent`. Every caller runs
+ * this speculatively over ids that may already have been converted by an earlier
+ * request, so "nothing to do" is not a failure.
+ *
+ * Kept `ctx`-shaped rather than `tx`-first even though it reads then writes:
+ * the legacy ran both statements on whatever client it was handed, including a
+ * bare pool, and its callers that *do* have a transaction pass
+ * `{ ...ctx, db: tx }`. Making the transaction mandatory here would change three
+ * call sites' atomicity, which is Phase 6's decision.
+ *
+ * @param ctx Scope and database.
+ * @param assetId The temporary asset to promote.
+ * @param newKind The kind to promote it to.
+ */
+export async function convertTempAssetToPermanent(
+  ctx: FilesCtx,
+  assetId: string,
+  newKind: AssetKind
+): Promise<Result<void, AuxxError>> {
+  return guard(
+    async () => {
+      assertAssetKind(newKind)
+
+      const asset = await ctx.db.query.MediaAsset.findFirst({
+        where: and(
+          eq(schema.MediaAsset.id, assetId),
+          eq(schema.MediaAsset.organizationId, ctx.organizationId)
+        ),
+      })
+
+      if (!asset || asset.kind !== 'TEMP_UPLOAD') return
+
+      await ctx.db
+        .update(schema.MediaAsset)
+        .set({ kind: newKind, expiresAt: null })
+        .where(
+          and(
+            eq(schema.MediaAsset.id, assetId),
+            eq(schema.MediaAsset.organizationId, ctx.organizationId)
+          )
+        )
+    },
+    'Failed to convert temporary asset',
+    { assetId, newKind, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Mint a `MediaAsset` that points at the same bytes as an existing file-library row.
+ *
+ * **Behaviour change:** the legacy `createFromFolderFile` looked the
+ * `FolderFile` up by bare id with no organization filter, so any caller holding
+ * a file id could mint an asset over another tenant's bytes. The read is
+ * org-scoped here, and the resulting asset is owned by `ctx.organizationId`
+ * rather than by whatever the file row happened to say.
+ *
+ * The `skipIfExists` lookup is two statements on purpose: a `where` inside a
+ * relational `with` only filters the included rows, never which asset comes
+ * back, so the storage-location match has to be part of the asset's own `WHERE`.
+ *
+ * @param tx The caller's transaction — {@link createAssetWithVersion} needs one.
+ * @param ctx Scope. `ctx.db` is ignored.
+ * @param deps `now`, for the new asset's `updatedAt` stamp.
+ * @param input Which file, which version, and whether to reuse.
+ */
+export async function createAssetFromFolderFile(
+  tx: Transaction,
+  ctx: FilesCtx,
+  deps: AssetWriteDeps,
+  input: CreateAssetFromFolderFileInput
+): Promise<Result<MediaAssetEntity, AuxxError>> {
+  return guard(
+    async () => {
+      const file = await tx.query.FolderFile.findFirst({
+        where: and(
+          eq(schema.FolderFile.id, input.fileId),
+          eq(schema.FolderFile.organizationId, ctx.organizationId)
+        ),
+        with: {
+          currentVersion: { with: { storageLocation: true } },
+          versions: input.fileVersionId
+            ? {
+                where: eq(schema.FileVersion.id, input.fileVersionId),
+                limit: 1,
+                with: { storageLocation: true },
+              }
+            : undefined,
+        },
+      })
+
+      if (!file) throw new NotFoundError(`File ${input.fileId} not found`)
+
+      const version =
+        input.fileVersionId && file.versions?.[0] ? file.versions[0] : file.currentVersion
+      if (!version) throw new NotFoundError(`File ${input.fileId} has no version`)
+
+      if (input.skipIfExists) {
+        const existing = await findAssetForStorageLocation(tx, ctx, version.storageLocationId)
+        if (existing) return existing
+      }
+
+      const created = await createAssetWithVersion(tx, ctx, deps, {
+        kind: input.kind ?? 'DOCUMENT',
+        purpose: 'ORIGINAL',
+        name: file.name,
+        mimeType: file.mimeType ?? 'application/octet-stream',
+        size: file.size ?? 0,
+        isPrivate: true,
+        createdById: file.createdById ?? undefined,
+        storageLocationId: version.storageLocationId,
+      })
+      if (created.isErr()) throw created.error
+
+      return created.value.asset
+    },
+    'Failed to create asset from folder file',
+    { fileId: input.fileId, organizationId: ctx.organizationId }
+  )
+}
+
+// ============= Internal helpers (throw; the guard converts at the boundary) =============
+
+/** Reject a kind the enum does not know, before it reaches a `text` column. */
+function assertAssetKind(kind: AssetKind): void {
+  if (!VALID_ASSET_KINDS.includes(kind)) {
+    throw new BadRequestError(`Invalid asset kind: ${kind}`)
+  }
+}
+
+/**
+ * The shared `INSERT` body. Takes the client explicitly so
+ * {@link createAssetWithVersion} can run it on `tx` without a second `ctx`.
+ */
+async function insertAsset(
+  client: Database | Transaction,
+  ctx: FilesCtx,
+  deps: AssetWriteDeps,
+  input: CreateAssetInput
+): Promise<MediaAssetEntity> {
+  assertAssetKind(input.kind)
+
+  const [asset] = await client
+    .insert(schema.MediaAsset)
+    .values({
+      kind: input.kind,
+      purpose: input.purpose,
+      name: input.name,
+      mimeType: input.mimeType,
+      size: input.size,
+      isPrivate: input.isPrivate ?? true,
+      createdById: input.createdById,
+      expiresAt: input.expiresAt,
+      // Scope is the caller's, never the payload's.
+      organizationId: ctx.organizationId,
+      updatedAt: deps.now(),
+    })
+    .returning()
+
+  if (!asset) throw new AuxxError('Asset insert returned no row')
+  return asset
+}
+
+/**
+ * Find a live asset in this organization whose current version already points at
+ * `storageLocationId`.
+ */
+async function findAssetForStorageLocation(
+  client: Database | Transaction,
+  ctx: FilesCtx,
+  storageLocationId: string
+): Promise<MediaAssetEntity | null> {
+  const matchingVersions = await client.query.MediaAssetVersion.findMany({
+    where: and(
+      eq(schema.MediaAssetVersion.storageLocationId, storageLocationId),
+      isNull(schema.MediaAssetVersion.deletedAt)
+    ),
+    columns: { id: true },
+  })
+  if (matchingVersions.length === 0) return null
+
+  const existing = await client.query.MediaAsset.findFirst({
+    where: and(
+      eq(schema.MediaAsset.organizationId, ctx.organizationId),
+      isNull(schema.MediaAsset.deletedAt),
+      inArray(
+        schema.MediaAsset.currentVersionId,
+        matchingVersions.map((version) => version.id)
+      )
+    ),
+  })
+  return (existing as MediaAssetEntity | undefined) ?? null
+}

--- a/packages/lib/src/files/assets/asset-queries.ts
+++ b/packages/lib/src/files/assets/asset-queries.ts
@@ -1,0 +1,395 @@
+// packages/lib/src/files/assets/asset-queries.ts
+
+/**
+ * `MediaAsset` reads.
+ *
+ * Split from `assets/asset-mutations.ts` and `assets/version-mutations.ts` per
+ * `docs/lib-module-guide.md` §5 — "a file that both queries and mutates is the
+ * first step back toward a service class", which is precisely how
+ * `core/media-asset-service.ts` reached 1,540 lines.
+ *
+ * ## Every read here is organization-scoped, unconditionally
+ *
+ * `MediaAssetService` scoped with `if (this.organizationId)`, so a service
+ * constructed without one — and several production sites do exactly that —
+ * silently widened every query to every tenant. `FilesCtx.organizationId` is
+ * required, so the filter is not conditional any more.
+ *
+ * `MediaAsset.organizationId` is `NOT NULL`, so an `eq(...)` filter hides no
+ * rows here; there is no nullable-scope trap of the kind `StorageLocation` had.
+ *
+ * ## Versions are scoped through their asset, never directly
+ *
+ * `MediaAssetVersion` carries no `organizationId` — its only tenant link is
+ * `assetId`. So every version read below first resolves the asset through
+ * {@link getAsset} (which is org-scoped) and constrains on `assetId`. The legacy
+ * `getLatestVersion` skipped that step and queried versions by bare `assetId`,
+ * which returned another tenant's version to anyone holding the id.
+ */
+
+import { schema } from '@auxx/database'
+import type {
+  MediaAssetEntity,
+  MediaAssetVersionEntity,
+  StorageLocationEntity,
+} from '@auxx/database/types'
+import { and, asc, desc, eq, isNull, lt, type SQL } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import type { AuxxError } from '../../errors'
+import { NotFoundError } from '../../errors'
+import type { AssetKind, MediaAssetWithRelations } from '../core/types'
+import type { FilesCtx } from '../ctx'
+import { guard } from '../guard'
+
+/**
+ * A version row with its `StorageLocation` joined in.
+ *
+ * Every consumer of a version in this module wants the location too (to
+ * presign, to copy, to purge), so the joined shape is the default rather than a
+ * second round-trip per caller.
+ */
+export type AssetVersionWithLocation = MediaAssetVersionEntity & {
+  storageLocation: StorageLocationEntity | null
+}
+
+/**
+ * Knobs for {@link listAssets}.
+ *
+ * Deliberately a closed set of filters instead of the legacy `filters?: any`,
+ * which was fed through a `getTableColumns(schema.MediaAsset)` lookup so any
+ * string key became a `WHERE`. That map is also what forced the memoised static
+ * getter on `MediaAssetService` (a static initializer ran `getTableColumns` at
+ * module evaluation and killed unrelated test files at collection). A closed
+ * union deletes both the injection surface and the hazard.
+ */
+export interface ListAssetsOptions {
+  kind?: AssetKind
+  isPrivate?: boolean
+  limit?: number
+  offset?: number
+  sortBy?: 'createdAt' | 'updatedAt' | 'name' | 'size'
+  sortOrder?: 'asc' | 'desc'
+  includeDeleted?: boolean
+}
+
+/**
+ * One page of assets.
+ *
+ * `total` is the size of the page, not a count of matching rows — inherited
+ * verbatim from `MediaAssetService.list`, which never issued a count query. It
+ * is preserved rather than fixed because changing it here would be a silent
+ * semantic change under cover of a refactor; `hasMore` is what callers should
+ * read.
+ */
+export interface AssetPage {
+  items: MediaAssetEntity[]
+  total: number
+  hasMore: boolean
+}
+
+const SORT_COLUMNS = {
+  createdAt: schema.MediaAsset.createdAt,
+  updatedAt: schema.MediaAsset.updatedAt,
+  name: schema.MediaAsset.name,
+  size: schema.MediaAsset.size,
+} as const
+
+/**
+ * Load one live asset, scoped to the caller's organization.
+ *
+ * Returns `ok(null)` when the asset does not exist, is soft-deleted, or belongs
+ * to another organization — the three collapse into one answer so a caller
+ * cannot probe for ids outside its tenant.
+ *
+ * @param ctx Scope and database. Runs unchanged on a pool or inside a caller's
+ *   transaction, because `FilesCtx.db` is `Database | Transaction`.
+ * @param assetId The `MediaAsset.id` to load.
+ */
+export async function getAsset(
+  ctx: FilesCtx,
+  assetId: string
+): Promise<Result<MediaAssetEntity | null, AuxxError>> {
+  return guard(
+    async () => {
+      const asset = await ctx.db.query.MediaAsset.findFirst({
+        where: and(
+          eq(schema.MediaAsset.id, assetId),
+          eq(schema.MediaAsset.organizationId, ctx.organizationId),
+          isNull(schema.MediaAsset.deletedAt)
+        ),
+      })
+      return (asset as MediaAssetEntity | undefined) ?? null
+    },
+    'Failed to get asset',
+    { assetId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Load one live asset with its versions, attachments and creator populated.
+ *
+ * The relation set matches `MediaAssetService.getRelationIncludes` exactly —
+ * current version (with location), all versions newest-first (with location),
+ * attachments, and the creator's id/name/email. Callers that only need the row
+ * should use {@link getAsset}: this issues a considerably wider query.
+ */
+export async function getAssetWithRelations(
+  ctx: FilesCtx,
+  assetId: string
+): Promise<Result<MediaAssetWithRelations | null, AuxxError>> {
+  return guard(
+    async () => {
+      const asset = await ctx.db.query.MediaAsset.findFirst({
+        where: and(
+          eq(schema.MediaAsset.id, assetId),
+          eq(schema.MediaAsset.organizationId, ctx.organizationId),
+          isNull(schema.MediaAsset.deletedAt)
+        ),
+        with: {
+          currentVersion: { with: { storageLocation: true } },
+          versions: {
+            with: { storageLocation: true },
+            orderBy: desc(schema.MediaAssetVersion.versionNumber),
+          },
+          attachments: true,
+          createdBy: { columns: { id: true, name: true, email: true } },
+        },
+      })
+      return (asset as MediaAssetWithRelations | undefined) ?? null
+    },
+    'Failed to get asset with relations',
+    { assetId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * List assets in the caller's organization.
+ *
+ * @param ctx Scope and database.
+ * @param options Filters, paging and sort. See {@link ListAssetsOptions} for why
+ *   the filter set is closed rather than an arbitrary column map.
+ */
+export async function listAssets(
+  ctx: FilesCtx,
+  options: ListAssetsOptions = {}
+): Promise<Result<AssetPage, AuxxError>> {
+  return guard(
+    async () => {
+      const filters: SQL[] = [eq(schema.MediaAsset.organizationId, ctx.organizationId)]
+      if (!options.includeDeleted) filters.push(isNull(schema.MediaAsset.deletedAt))
+      if (options.kind) filters.push(eq(schema.MediaAsset.kind, options.kind))
+      if (options.isPrivate !== undefined) {
+        filters.push(eq(schema.MediaAsset.isPrivate, options.isPrivate))
+      }
+
+      const sortColumn = SORT_COLUMNS[options.sortBy ?? 'createdAt']
+      const limit = options.limit ?? 50
+
+      const items = (await ctx.db.query.MediaAsset.findMany({
+        where: and(...filters),
+        limit,
+        offset: options.offset ?? 0,
+        orderBy: options.sortOrder === 'asc' ? asc(sortColumn) : desc(sortColumn),
+      })) as MediaAssetEntity[]
+
+      return { items, total: items.length, hasMore: items.length === limit }
+    },
+    'Failed to list assets',
+    { organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * All live assets of one kind in the organization, newest first.
+ */
+export async function findAssetsByKind(
+  ctx: FilesCtx,
+  kind: AssetKind
+): Promise<Result<MediaAssetEntity[], AuxxError>> {
+  return guard(
+    async () => {
+      const assets = await ctx.db.query.MediaAsset.findMany({
+        where: and(
+          eq(schema.MediaAsset.organizationId, ctx.organizationId),
+          isNull(schema.MediaAsset.deletedAt),
+          eq(schema.MediaAsset.kind, kind)
+        ),
+        orderBy: desc(schema.MediaAsset.createdAt),
+      })
+      return assets as MediaAssetEntity[]
+    },
+    'Failed to find assets by kind',
+    { kind, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Temporary uploads created before `createdBefore`, oldest first — the cleanup
+ * job's input.
+ *
+ * The cutoff arrives as a `Date` rather than the legacy `maxAgeHours = 24`,
+ * which computed `new Date(Date.now() - …)` inside the query. Reading the clock
+ * inside a read makes the function untestable without fake timers; the caller
+ * owns `now` (`FilesDeps.now`) and hands the instant in.
+ *
+ * @param ctx Scope and database.
+ * @param createdBefore Exclusive upper bound on `createdAt`.
+ * @param kind Which kind to sweep. Defaults to `TEMP_UPLOAD`, the only kind the
+ *   legacy method looked at.
+ */
+export async function findExpiredAssets(
+  ctx: FilesCtx,
+  createdBefore: Date,
+  kind: AssetKind = 'TEMP_UPLOAD'
+): Promise<Result<MediaAssetEntity[], AuxxError>> {
+  return guard(
+    async () => {
+      const assets = await ctx.db.query.MediaAsset.findMany({
+        where: and(
+          eq(schema.MediaAsset.organizationId, ctx.organizationId),
+          isNull(schema.MediaAsset.deletedAt),
+          eq(schema.MediaAsset.kind, kind),
+          lt(schema.MediaAsset.createdAt, createdBefore)
+        ),
+        orderBy: asc(schema.MediaAsset.createdAt),
+      })
+      return assets as MediaAssetEntity[]
+    },
+    'Failed to find expired assets',
+    { kind, createdBefore, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Resolve the current version of an asset, with its storage location.
+ *
+ * Prefers the asset's explicit `currentVersionId` and falls back to the highest
+ * `versionNumber` when the pointer is null — the same two-branch resolution
+ * `assets/download.ts` performs, kept identical so a download and a content read
+ * can never disagree about which bytes are current.
+ *
+ * Returns `ok(null)` when the asset has no version at all. Throws
+ * `NotFoundError` when the *asset* is missing, because "which version is current
+ * for an asset that does not exist" has no null answer worth returning.
+ */
+export async function getAssetCurrentVersion(
+  ctx: FilesCtx,
+  assetId: string
+): Promise<Result<AssetVersionWithLocation | null, AuxxError>> {
+  return guard(async () => {
+    const asset = await requireAsset(ctx, assetId)
+    return loadCurrentVersion(ctx, asset)
+  }, 'Failed to get current asset version')
+}
+
+/**
+ * Every version of an asset, newest version number first, locations joined in.
+ */
+export async function getAssetVersions(
+  ctx: FilesCtx,
+  assetId: string
+): Promise<Result<AssetVersionWithLocation[], AuxxError>> {
+  return guard(async () => {
+    await requireAsset(ctx, assetId)
+    const versions = await ctx.db.query.MediaAssetVersion.findMany({
+      where: eq(schema.MediaAssetVersion.assetId, assetId),
+      with: { storageLocation: true },
+      orderBy: desc(schema.MediaAssetVersion.versionNumber),
+    })
+    return versions as AssetVersionWithLocation[]
+  }, 'Failed to list asset versions')
+}
+
+/**
+ * One version of an asset by its human-facing version *number*.
+ *
+ * Note the two id spaces: `versionNumber` is the 1-based counter shown in the
+ * UI, while `MediaAssetVersion.id` is a cuid. `assets/download.ts` addresses
+ * versions by id; this addresses them by number, and the two must not be
+ * confused at a call site.
+ */
+export async function getAssetVersionByNumber(
+  ctx: FilesCtx,
+  assetId: string,
+  versionNumber: number
+): Promise<Result<AssetVersionWithLocation | null, AuxxError>> {
+  return guard(async () => {
+    await requireAsset(ctx, assetId)
+    const version = await ctx.db.query.MediaAssetVersion.findFirst({
+      where: and(
+        eq(schema.MediaAssetVersion.assetId, assetId),
+        eq(schema.MediaAssetVersion.versionNumber, versionNumber)
+      ),
+      with: { storageLocation: true },
+    })
+    return (version as AssetVersionWithLocation | undefined) ?? null
+  }, 'Failed to get asset version')
+}
+
+/**
+ * The highest-numbered version of an asset, regardless of `currentVersionId`.
+ *
+ * **Behaviour change:** the legacy `getLatestVersion` queried
+ * `MediaAssetVersion` by bare `assetId` and never loaded the asset, so it had no
+ * organization filter anywhere in the statement. This resolves the asset first,
+ * so a version belonging to another tenant is simply not reachable.
+ */
+export async function getLatestAssetVersion(
+  ctx: FilesCtx,
+  assetId: string
+): Promise<Result<AssetVersionWithLocation | null, AuxxError>> {
+  return guard(async () => {
+    await requireAsset(ctx, assetId)
+    const version = await ctx.db.query.MediaAssetVersion.findFirst({
+      where: eq(schema.MediaAssetVersion.assetId, assetId),
+      with: { storageLocation: true },
+      orderBy: desc(schema.MediaAssetVersion.versionNumber),
+    })
+    return (version as AssetVersionWithLocation | undefined) ?? null
+  }, 'Failed to get latest asset version')
+}
+
+// ============= Internal helpers (throw; the guard converts at the boundary) =============
+
+/**
+ * Load an asset or throw `NotFoundError`.
+ *
+ * Exported for the mutation modules, which all need the same org-scoped
+ * existence check before they write, and must throw rather than return `err()`
+ * so a failure inside a caller's transaction rolls it back.
+ */
+export async function requireAsset(ctx: FilesCtx, assetId: string): Promise<MediaAssetEntity> {
+  const asset = await ctx.db.query.MediaAsset.findFirst({
+    where: and(
+      eq(schema.MediaAsset.id, assetId),
+      eq(schema.MediaAsset.organizationId, ctx.organizationId),
+      isNull(schema.MediaAsset.deletedAt)
+    ),
+  })
+  if (!asset) throw new NotFoundError(`Asset ${assetId} not found`)
+  return asset as MediaAssetEntity
+}
+
+/**
+ * The `currentVersionId`-then-highest-number resolution, on an already-loaded
+ * asset. Exported for the mutation modules so neither re-fetches the asset.
+ */
+export async function loadCurrentVersion(
+  ctx: FilesCtx,
+  asset: MediaAssetEntity
+): Promise<AssetVersionWithLocation | null> {
+  const version = asset.currentVersionId
+    ? await ctx.db.query.MediaAssetVersion.findFirst({
+        where: and(
+          eq(schema.MediaAssetVersion.id, asset.currentVersionId),
+          eq(schema.MediaAssetVersion.assetId, asset.id)
+        ),
+        with: { storageLocation: true },
+      })
+    : await ctx.db.query.MediaAssetVersion.findFirst({
+        where: eq(schema.MediaAssetVersion.assetId, asset.id),
+        with: { storageLocation: true },
+        orderBy: desc(schema.MediaAssetVersion.versionNumber),
+      })
+  return (version as AssetVersionWithLocation | undefined) ?? null
+}

--- a/packages/lib/src/files/assets/download.ts
+++ b/packages/lib/src/files/assets/download.ts
@@ -45,7 +45,7 @@ export interface GetAssetDownloadRefOptions {
 }
 
 /** A version row with its `StorageLocation` joined in, which is the only shape this read uses. */
-type VersionWithLocation = MediaAssetVersionEntity & {
+export type VersionWithLocation = MediaAssetVersionEntity & {
   storageLocation: StorageLocationEntity | null
 }
 
@@ -165,29 +165,59 @@ export async function getAssetDownloadRef(
     async () => {
       const asset = await loadAsset(ctx, assetId)
       const version = await resolveVersion(ctx, asset, opts.versionId)
-
-      const location = version.storageLocation
-      if (!version.storageLocationId || !location) {
-        throw new NotFoundError(`No storage location found for asset ${asset.id}`)
-      }
-
-      // Durable public URL: no signature, so no expiry to outlive.
-      if (!asset.isPrivate && location.externalUrl) {
-        return { type: 'url', url: location.externalUrl } satisfies DownloadRef
-      }
-
-      return deps.storage.presignDownload({
-        provider: location.provider,
-        bucket: requireBucket(location, asset.id),
-        key: location.externalId,
-        credentialId: location.credentialId ?? undefined,
-        ttlSec: opts.ttlSec,
-        disposition: opts.disposition,
-        filename: asset.name ?? undefined,
-        mimeType: asset.mimeType ?? undefined,
-      })
+      return resolveAssetDownloadRef(deps, asset, version, opts)
     },
     'Failed to resolve asset download ref',
     { assetId, versionId: opts.versionId, organizationId: ctx.organizationId }
   )
+}
+
+/**
+ * The database-free tail of {@link getAssetDownloadRef}: asset + version in,
+ * {@link DownloadRef} out.
+ *
+ * Exported so a **batch** caller can keep its fixed number of round-trips. The
+ * legacy service resolved many asset ids at once (`getDownloadUrls`, one query
+ * for the assets and at most two for their versions) through a private
+ * `downloadUrlFor(entity, version)` helper; without a seam like this, collapsing
+ * that path onto `getAssetDownloadRef` would mean re-reading the asset and its
+ * version once per id — turning three queries into 3N. The URL policy stays in
+ * one place either way, which is the point of the collapse.
+ *
+ * Throws rather than returning `Result`: it is a helper, and its only callers
+ * are already inside a {@link guard}.
+ *
+ * @param deps Storage only — see {@link DownloadDeps}.
+ * @param asset The asset the caller has already loaded, org-scoped.
+ * @param version That asset's version, with `storageLocation` joined in.
+ * @param opts Presign knobs. Ignored for the durable public-URL branch.
+ * @throws NotFoundError when the version has no usable storage location.
+ * @throws AuxxError when the storage location cannot name its bucket.
+ */
+export async function resolveAssetDownloadRef(
+  deps: DownloadDeps,
+  asset: MediaAssetEntity,
+  version: VersionWithLocation,
+  opts: Pick<GetAssetDownloadRefOptions, 'disposition' | 'ttlSec'> = {}
+): Promise<DownloadRef> {
+  const location = version.storageLocation
+  if (!version.storageLocationId || !location) {
+    throw new NotFoundError(`No storage location found for asset ${asset.id}`)
+  }
+
+  // Durable public URL: no signature, so no expiry to outlive.
+  if (!asset.isPrivate && location.externalUrl) {
+    return { type: 'url', url: location.externalUrl } satisfies DownloadRef
+  }
+
+  return deps.storage.presignDownload({
+    provider: location.provider,
+    bucket: requireBucket(location, asset.id),
+    key: location.externalId,
+    credentialId: location.credentialId ?? undefined,
+    ttlSec: opts.ttlSec,
+    disposition: opts.disposition,
+    filename: asset.name ?? undefined,
+    mimeType: asset.mimeType ?? undefined,
+  })
 }

--- a/packages/lib/src/files/assets/index.ts
+++ b/packages/lib/src/files/assets/index.ts
@@ -6,5 +6,58 @@
  * `media-asset-service.ts` reached 1,540 lines.
  */
 
-export type { DownloadDeps, GetAssetDownloadRefOptions } from './download'
-export { getAssetDownloadRef } from './download'
+export type {
+  CreateAssetFromFolderFileInput,
+  CreateAssetInput,
+  CreateAssetWithVersionInput,
+  UpdateAssetInput,
+} from './asset-mutations'
+export {
+  convertTempAssetToPermanent,
+  createAsset,
+  createAssetFromFolderFile,
+  createAssetWithVersion,
+  deleteAsset,
+  updateAsset,
+} from './asset-mutations'
+export type {
+  AssetPage,
+  AssetVersionWithLocation,
+  ListAssetsOptions,
+} from './asset-queries'
+export {
+  findAssetsByKind,
+  findExpiredAssets,
+  getAsset,
+  getAssetCurrentVersion,
+  getAssetVersionByNumber,
+  getAssetVersions,
+  getAssetWithRelations,
+  getLatestAssetVersion,
+  listAssets,
+  loadCurrentVersion,
+  requireAsset,
+} from './asset-queries'
+export type {
+  DownloadDeps,
+  GetAssetDownloadRefOptions,
+  VersionWithLocation,
+} from './download'
+export { getAssetDownloadRef, resolveAssetDownloadRef } from './download'
+export type {
+  AssetDeleteDeps,
+  AssetVersionDeleteDeps,
+  AssetWriteDeps,
+  ThumbnailCleanupPort,
+} from './ports'
+export type {
+  CreateAssetVersionInput,
+  CreatedAssetVersion,
+  UpdateAssetContentInput,
+} from './version-mutations'
+export {
+  createAssetVersion,
+  deleteAssetVersion,
+  restoreAssetVersion,
+  updateAssetContent,
+} from './version-mutations'

--- a/packages/lib/src/files/assets/ports.ts
+++ b/packages/lib/src/files/assets/ports.ts
@@ -1,0 +1,50 @@
+// packages/lib/src/files/assets/ports.ts
+
+/**
+ * The dependency slices the asset write path declares.
+ *
+ * Two rules from `files/ctx.ts` meet here. First, **collaborators are
+ * parameters**: deleting an asset has to drop the thumbnails derived from it,
+ * and the legacy code reached for that collaborator inside the delete body
+ * (`await import('./thumbnail-service'); new ThumbnailService(org, user, db)`),
+ * which welds the function to it and leaves `vi.mock` as the only way a test can
+ * get at it. Second, **take a narrowed slice, never the whole bundle**: a write
+ * that stamps `updatedAt` needs `now` and nothing else, so that is all its
+ * signature asks for.
+ *
+ * When PR 5f lands `files/thumbnails/`, {@link ThumbnailCleanupPort} is what it
+ * implements — deliberately narrower than `ThumbnailService`, naming only the
+ * one method the asset write path uses.
+ */
+
+import type { FilesDeps } from '../ctx'
+
+export interface ThumbnailCleanupPort {
+  /**
+   * Drop every thumbnail derived from one source version.
+   *
+   * Soft-deletes the thumbnail rows and removes their storage objects. Must
+   * resolve, not throw, for a source version that has no thumbnails.
+   */
+  deleteThumbnailsForSource(sourceVersionId: string): Promise<void>
+}
+
+/**
+ * What a write that stamps a timestamp needs.
+ *
+ * `MediaAsset.updatedAt` is `NOT NULL` with no database default and no Drizzle
+ * `$onUpdate`, so every insert and every update has to supply it. Reading the
+ * clock inside the function is what made the legacy writes untestable without
+ * process-global fake timers.
+ */
+export type AssetWriteDeps = Pick<FilesDeps, 'now'>
+
+/** {@link AssetWriteDeps} plus the thumbnail closure a soft delete has to sweep. */
+export interface AssetDeleteDeps extends AssetWriteDeps {
+  thumbnails: ThumbnailCleanupPort
+}
+
+/** A version delete stamps nothing, so it needs the thumbnail sweep alone. */
+export interface AssetVersionDeleteDeps {
+  thumbnails: ThumbnailCleanupPort
+}

--- a/packages/lib/src/files/assets/version-mutations.ts
+++ b/packages/lib/src/files/assets/version-mutations.ts
@@ -1,0 +1,336 @@
+// packages/lib/src/files/assets/version-mutations.ts
+
+/**
+ * `MediaAssetVersion` writes.
+ *
+ * Separate from `assets/asset-mutations.ts` because the two have different
+ * atomicity requirements, not because of a naming convention: creating a version
+ * is *always* two statements (insert the row, move the asset's
+ * `currentVersionId`), so it can only be correct inside a transaction the caller
+ * owns. That is why {@link createAssetVersion} and {@link updateAssetContent}
+ * take `tx: Transaction` positionally first — a `ctx`-only signature would
+ * accept a pool and the pointer move would silently stop being atomic with the
+ * insert.
+ *
+ * ## These functions never open a transaction
+ *
+ * No `getTx`, no `tx.transaction(...)`. The legacy `createVersion` branched at
+ * runtime on whether it had been handed a client and opened a savepoint when it
+ * had not — and in drizzle-orm 0.44 the "already inside one" branch is
+ * unreachable, so an avatar upload really ran nested `SAVEPOINT`s for work
+ * nothing needed to partially roll back. Phase 6 owns the transaction
+ * boundaries; here the caller owns them.
+ *
+ * ## `Result` and rollback do not compose
+ *
+ * The bodies below throw `AuxxError` subclasses and {@link guard} converts at
+ * the exported boundary. Returning `err()` from inside a transaction body does
+ * **not** roll back — it is an ordinary resolved value, so the caller commits
+ * the rows it was just told failed to write.
+ */
+
+import type { Transaction } from '@auxx/database'
+import { schema } from '@auxx/database'
+import type {
+  MediaAssetEntity,
+  MediaAssetVersionEntity,
+  StorageLocationEntity,
+} from '@auxx/database/types'
+import { and, desc, eq, isNull } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import { AuxxError, ConflictError, NotFoundError } from '../../errors'
+import { purgeMediaAssets } from '../core/media-asset-purge'
+import type { FilesCtx } from '../ctx'
+import { guard } from '../guard'
+import { getAssetVersionByNumber, requireAsset } from './asset-queries'
+import type { AssetVersionDeleteDeps, AssetWriteDeps } from './ports'
+
+/** A version returned by a write, with the location it points at resolved. */
+export type CreatedAssetVersion = MediaAssetVersionEntity & {
+  storageLocation: StorageLocationEntity
+}
+
+/** Everything needed to add one version to an existing asset. */
+export interface CreateAssetVersionInput {
+  assetId: string
+  storageLocationId: string
+  /**
+   * Byte size. Defaults to the storage location's own `size` when omitted.
+   *
+   * **Behaviour change:** the legacy `createVersion` spread its `metadata`
+   * argument over `{ size, mimeType }` taken from the location, so a caller
+   * passing `{ size: undefined }` — which `createWithVersion` did whenever
+   * `CreateAssetRequest.size` was absent — overwrote the location's size with
+   * `undefined` and persisted `NULL`. Inheriting from the row is what the code
+   * plainly meant.
+   */
+  size?: number
+  /** MIME type. Defaults to the storage location's own `mimeType` when omitted. */
+  mimeType?: string
+  /** Provider-specific extras persisted on the version (e.g. `{ contentHash }`). */
+  metadata?: Record<string, unknown>
+}
+
+/** Everything needed to replace an asset's content with a new version. */
+export interface UpdateAssetContentInput {
+  assetId: string
+  storageLocationId: string
+  size?: number
+  mimeType?: string
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Add a version to an asset and make it current, inside the caller's transaction.
+ *
+ * Two statements plus the asset existence check, all on `tx`. The
+ * `currentVersionId` move is organization-scoped, which the legacy
+ * `UPDATE MediaAsset … WHERE id = ?` was not.
+ *
+ * ## The `StorageLocation` read is deliberately NOT organization-scoped
+ *
+ * `StorageLocation.organizationId` is nullable — the column was added for
+ * backfill compatibility and old rows carry `NULL`. An `eq(organizationId, …)`
+ * filter would make every one of those rows invisible, and a version could no
+ * longer be created against a location that predates the column. That is a
+ * reachability change this PR is not the place to make (`location-queries.ts`
+ * accepted the same trade in the other direction for *reads*, and said so).
+ * Stated here rather than left implicit: this lookup can resolve a location
+ * owned by nobody.
+ *
+ * @param tx Positional and first: `FilesCtx.db` is `Database | Transaction`, so
+ *   a `ctx`-only signature would accept a pool and the insert would stop being
+ *   atomic with the pointer move. This function never calls `tx.transaction(…)`.
+ * @param ctx Scope. `ctx.db` is ignored — every statement runs on `tx`.
+ * @param input The version to write.
+ */
+export async function createAssetVersion(
+  tx: Transaction,
+  ctx: FilesCtx,
+  input: CreateAssetVersionInput
+): Promise<Result<CreatedAssetVersion, AuxxError>> {
+  return guard(async () => insertVersion(tx, ctx, input), 'Failed to create asset version', {
+    assetId: input.assetId,
+    storageLocationId: input.storageLocationId,
+  })
+}
+
+/**
+ * Replace an asset's content: new version, asset metadata updated to match.
+ *
+ * The asset row's `size`/`mimeType` are only touched when the input names them,
+ * matching the legacy `updateContent`.
+ *
+ * @param tx Positional and first — three statements that have to land together.
+ * @param ctx Scope. `ctx.db` is ignored.
+ * @param deps `now`, for the asset's `updatedAt` stamp.
+ * @param input The new content.
+ */
+export async function updateAssetContent(
+  tx: Transaction,
+  ctx: FilesCtx,
+  deps: AssetWriteDeps,
+  input: UpdateAssetContentInput
+): Promise<Result<{ asset: MediaAssetEntity; version: CreatedAssetVersion }, AuxxError>> {
+  return guard(
+    async () => {
+      const txCtx: FilesCtx = { ...ctx, db: tx }
+      await requireAsset(txCtx, input.assetId)
+
+      const version = await insertVersion(tx, ctx, input)
+
+      const [asset] = await tx
+        .update(schema.MediaAsset)
+        .set({
+          ...(input.size !== undefined && { size: input.size }),
+          ...(input.mimeType !== undefined && { mimeType: input.mimeType }),
+          updatedAt: deps.now(),
+        })
+        .where(
+          and(
+            eq(schema.MediaAsset.id, input.assetId),
+            eq(schema.MediaAsset.organizationId, ctx.organizationId)
+          )
+        )
+        .returning()
+
+      if (!asset) throw new AuxxError(`Asset ${input.assetId} update affected no rows`)
+      return { asset, version }
+    },
+    'Failed to update asset content',
+    { assetId: input.assetId, storageLocationId: input.storageLocationId }
+  )
+}
+
+/**
+ * Point an asset back at one of its earlier versions.
+ *
+ * A single `UPDATE`, so it takes `ctx` rather than a `Transaction` — but the
+ * `WHERE` now carries the organization filter the legacy `restoreVersion`
+ * omitted (it read the version org-scoped and then updated by bare id).
+ *
+ * @param ctx Scope and database.
+ * @param deps `now`, for the `updatedAt` stamp.
+ * @param assetId The asset to move.
+ * @param versionNumber The 1-based version number to restore — not a version id.
+ */
+export async function restoreAssetVersion(
+  ctx: FilesCtx,
+  deps: AssetWriteDeps,
+  assetId: string,
+  versionNumber: number
+): Promise<Result<MediaAssetEntity, AuxxError>> {
+  return guard(
+    async () => {
+      const found = await getAssetVersionByNumber(ctx, assetId, versionNumber)
+      if (found.isErr()) throw found.error
+      const version = found.value
+      if (!version) {
+        throw new NotFoundError(`Version ${versionNumber} not found for asset ${assetId}`)
+      }
+
+      const [asset] = await ctx.db
+        .update(schema.MediaAsset)
+        .set({ currentVersionId: version.id, updatedAt: deps.now() })
+        .where(
+          and(
+            eq(schema.MediaAsset.id, assetId),
+            eq(schema.MediaAsset.organizationId, ctx.organizationId)
+          )
+        )
+        .returning()
+
+      if (!asset) throw new AuxxError(`Asset ${assetId} restore affected no rows`)
+      return asset
+    },
+    'Failed to restore asset version',
+    { assetId, versionNumber }
+  )
+}
+
+/**
+ * Hard-delete one non-current version of an asset.
+ *
+ * The order matters and is inherited unchanged:
+ *
+ * 1. the thumbnails derived from the version are swept through
+ *    {@link AssetVersionDeleteDeps.thumbnails}, which drops their objects but
+ *    only *soft*-deletes their rows;
+ * 2. those derived assets are then purged outright, because a thumbnail is its
+ *    own `MediaAsset` linked back through `MediaAssetVersion.derivedFromVersionId`
+ *    (a self-FK with NO ACTION), so a surviving row would block step 3 with FK
+ *    23503;
+ * 3. the version row itself goes.
+ *
+ * Refuses to delete the asset's current version — losing it would leave the
+ * asset pointing at nothing.
+ *
+ * @param ctx Scope and database. Kept `ctx`-shaped rather than `tx`-first
+ *   because the legacy method ran these statements on a bare pool; introducing
+ *   a transaction here would be a Phase-6 change made under cover of Phase 5.
+ * @param deps The thumbnail sweep.
+ */
+export async function deleteAssetVersion(
+  ctx: FilesCtx,
+  deps: AssetVersionDeleteDeps,
+  assetId: string,
+  versionNumber: number
+): Promise<Result<void, AuxxError>> {
+  return guard(
+    async () => {
+      const asset = await requireAsset(ctx, assetId)
+
+      const found = await getAssetVersionByNumber(ctx, assetId, versionNumber)
+      if (found.isErr()) throw found.error
+      const version = found.value
+      if (!version) {
+        throw new NotFoundError(`Version ${versionNumber} not found for asset ${assetId}`)
+      }
+      if (asset.currentVersionId === version.id) {
+        throw new ConflictError('Cannot delete the current version')
+      }
+
+      await deps.thumbnails.deleteThumbnailsForSource(version.id)
+
+      const derived = await ctx.db
+        .selectDistinct({ assetId: schema.MediaAssetVersion.assetId })
+        .from(schema.MediaAssetVersion)
+        .where(eq(schema.MediaAssetVersion.derivedFromVersionId, version.id))
+
+      if (derived.length > 0) {
+        await purgeMediaAssets(
+          ctx.db,
+          derived.map((row) => row.assetId)
+        )
+      }
+
+      await ctx.db
+        .delete(schema.MediaAssetVersion)
+        .where(eq(schema.MediaAssetVersion.id, version.id))
+    },
+    'Failed to delete asset version',
+    { assetId, versionNumber }
+  )
+}
+
+// ============= Internal helpers (throw; the guard converts at the boundary) =============
+
+/**
+ * The shared body of {@link createAssetVersion} and {@link updateAssetContent}.
+ *
+ * Throws rather than returning `Result`, so a failure inside the caller's
+ * transaction rolls it back.
+ */
+async function insertVersion(
+  tx: Transaction,
+  ctx: FilesCtx,
+  input: CreateAssetVersionInput
+): Promise<CreatedAssetVersion> {
+  const txCtx: FilesCtx = { ...ctx, db: tx }
+  await requireAsset(txCtx, input.assetId)
+
+  const last = await tx.query.MediaAssetVersion.findFirst({
+    where: eq(schema.MediaAssetVersion.assetId, input.assetId),
+    orderBy: desc(schema.MediaAssetVersion.versionNumber),
+    columns: { versionNumber: true },
+  })
+  const versionNumber = (last?.versionNumber ?? 0) + 1
+
+  // See the function docs: intentionally not organization-scoped, because
+  // `StorageLocation.organizationId` is nullable.
+  const storageLocation = await tx.query.StorageLocation.findFirst({
+    where: and(
+      eq(schema.StorageLocation.id, input.storageLocationId),
+      isNull(schema.StorageLocation.deletedAt)
+    ),
+  })
+  if (!storageLocation) {
+    throw new NotFoundError(`Storage location ${input.storageLocationId} not found`)
+  }
+
+  const [version] = await tx
+    .insert(schema.MediaAssetVersion)
+    .values({
+      assetId: input.assetId,
+      versionNumber,
+      storageLocationId: input.storageLocationId,
+      size: input.size ?? storageLocation.size,
+      mimeType: input.mimeType ?? storageLocation.mimeType,
+      ...(input.metadata !== undefined && { metadata: input.metadata }),
+    })
+    .returning()
+
+  if (!version) throw new AuxxError('Asset version insert returned no row')
+
+  await tx
+    .update(schema.MediaAsset)
+    .set({ currentVersionId: version.id })
+    .where(
+      and(
+        eq(schema.MediaAsset.id, input.assetId),
+        eq(schema.MediaAsset.organizationId, ctx.organizationId)
+      )
+    )
+
+  return { ...version, storageLocation }
+}

--- a/packages/lib/src/files/core/media-asset-service.ts
+++ b/packages/lib/src/files/core/media-asset-service.ts
@@ -1,51 +1,103 @@
 // packages/lib/src/files/core/media-asset-service.ts
 
+/**
+ * @deprecated A thin, deprecated facade over `files/assets/`.
+ *
+ * Every method below now delegates to a function in
+ * `files/assets/asset-queries.ts`, `asset-mutations.ts`,
+ * `version-mutations.ts` or `download.ts`. The class survives only because it
+ * has 41 external construction sites; **PR 5h / Phase 10 move those and delete
+ * this file.** Do not add a method here — add a function to `files/assets/` and
+ * call it directly with a `FilesCtx`.
+ *
+ * What changed for callers of this class, and nothing else did:
+ *
+ * - **Errors are `AuxxError` subclasses**, not bare `Error`. A missing asset or
+ *   version is a `NotFoundError` (404), an invalid kind a `BadRequestError`
+ *   (400), and deleting the current version a `ConflictError` (409), so
+ *   `auxxErrorMiddleware` maps them instead of returning 500 for everything.
+ * - **Organization scope is unconditional.** The old bodies scoped with
+ *   `if (this.organizationId)`, so a service constructed without one queried
+ *   every tenant; the delegated functions take a required `ctx.organizationId`,
+ *   and this facade throws if it has none.
+ * - **`getDownloadRefForVersion` returns the durable public URL** for a public
+ *   asset whose storage location has one, instead of always presigning. Same
+ *   rule `getDownloadRef` has followed since the Phase-2 pilot.
+ *
+ * Deleted outright rather than ported, all verified zero-caller:
+ * `processEmailAttachment`, `generateThumbnail`, `extractMetadata`,
+ * `findLargeAssets`, `findOrphanedAssets`, `findPublicAssets`, `convertKind`,
+ * `validateKindConversion`, `getDownloadInfo`, `copyVersions`, `search`,
+ * `count`, `listByKind`, `findByMimeType`.
+ */
+
+import type { Transaction } from '@auxx/database'
 import { schema } from '@auxx/database'
 import type {
   MediaAssetEntity as MediaAsset,
   MediaAssetVersionEntity as MediaAssetVersion,
   StorageLocationEntity as StorageLocation,
 } from '@auxx/database/types'
-import {
-  and,
-  asc,
-  desc,
-  eq,
-  getTableColumns,
-  gt,
-  gte,
-  ilike,
-  inArray,
-  isNull,
-  lt,
-  lte,
-  or,
-  type SQL,
-  sql,
-} from 'drizzle-orm'
-import type { PgColumn } from 'drizzle-orm/pg-core'
+import { and, desc, eq, inArray, isNull, type SQL } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import type { AuxxError } from '../../errors'
 import type { DownloadRef } from '../adapters/base-adapter'
-import { type DownloadDeps, getAssetDownloadRef } from '../assets/download'
+import {
+  convertTempAssetToPermanent,
+  createAsset,
+  createAssetFromFolderFile,
+  createAssetWithVersion,
+  deleteAsset,
+  updateAsset,
+} from '../assets/asset-mutations'
+import type { AssetVersionWithLocation } from '../assets/asset-queries'
+import {
+  findAssetsByKind,
+  findExpiredAssets,
+  getAsset,
+  getAssetCurrentVersion,
+  getAssetVersionByNumber,
+  getAssetVersions,
+  getAssetWithRelations,
+  getLatestAssetVersion,
+  listAssets,
+} from '../assets/asset-queries'
+import type { DownloadDeps, VersionWithLocation } from '../assets/download'
+import { getAssetDownloadRef, resolveAssetDownloadRef } from '../assets/download'
+import type { AssetWriteDeps, ThumbnailCleanupPort } from '../assets/ports'
+import {
+  createAssetVersion,
+  deleteAssetVersion,
+  restoreAssetVersion,
+  updateAssetContent,
+} from '../assets/version-mutations'
 import type { FilesCtx } from '../ctx'
 import { createS3StoragePort } from '../storage/ports'
 import { BaseService, type DatabaseClient, defaultDatabase } from './base-service'
-import { purgeMediaAssets } from './media-asset-purge'
 import type { ContentAccessible } from './mixins/content-accessible'
 import type { Versioned } from './mixins/versioned'
 import type {
-  AssetDownloadInfo,
   AssetKind,
   AssetSearchResult,
   CreateAssetRequest,
   MediaAssetWithRelations,
-  SearchOptions,
   UpdateAssetRequest,
 } from './types'
-import { VALID_ASSET_KINDS } from './types'
+
+/** The version shape the legacy `getDownloadRefForVersion` promised its callers. */
+export type AssetVersionDownloadRef = DownloadRef & {
+  filename: string
+  mimeType?: string
+  size?: number
+  expiresAt?: Date
+  versionNumber: number
+}
+
+/** How long a legacy `getDownloadRefForVersion` result claims to be valid when the ref carries no expiry. */
+const LEGACY_PREVIEW_TTL_MS = 10 * 60 * 1000
 
 /**
- * Enhanced service for managing MediaAsset operations
- * Directly extends BaseService and implements ContentAccessible and Versioned interfaces
+ * @deprecated See the file header. Delegates to `files/assets/`; deleted in Phase 10.
  */
 export class MediaAssetService
   extends BaseService<
@@ -61,28 +113,6 @@ export class MediaAssetService
 
   private _filesDownloadDeps?: DownloadDeps
 
-  private static _columns?: Record<string, PgColumn>
-
-  /**
-   * Column lookup used by the dynamic filter/sort paths.
-   *
-   * Memoized behind a getter rather than a static initializer, for the same
-   * reason `resources/search/record-search-sql.ts` uses a function instead of a
-   * module-level const: a static property initializer runs when the CLASS is
-   * DEFINED, i.e. at module evaluation. Under a test whose `@auxx/database`
-   * mock leaves `schema.MediaAsset` undefined, `getTableColumns` then throws
-   * `Cannot read properties of undefined (reading 'Symbol(drizzle:Columns)')`
-   * during collection — killing every test in the file before one runs, from an
-   * import-graph edge that has nothing to do with what the file is testing.
-   *
-   * The memoization is the point (one `getTableColumns` for the process, not
-   * one per query) — only the timing moved. Do not inline this back.
-   */
-  private static get columns(): Record<string, PgColumn> {
-    MediaAssetService._columns ??= getTableColumns(schema.MediaAsset)
-    return MediaAssetService._columns
-  }
-
   constructor(
     organizationId?: string,
     userId?: string,
@@ -95,84 +125,54 @@ export class MediaAssetService
     return 'asset'
   }
 
-  // ============= Base CRUD Implementation =============
-
   /**
-   * Create a new entity
+   * @deprecated Unused. Creation runs through `assets/asset-mutations.ts`, which
+   * validates the kind and stamps `updatedAt` itself. Present only because
+   * `BaseService` declares this abstract.
    */
+  protected async processCreateData(data: CreateAssetRequest): Promise<CreateAssetRequest> {
+    return data
+  }
+
+  // ============= Base CRUD =============
+
+  /** @deprecated Use `createAsset(ctx, deps, input)`. */
   async create(data: CreateAssetRequest, db?: DatabaseClient): Promise<MediaAsset> {
-    const processedData = await this.processCreateData(data)
-    const dbToUse = db || this.db
-
-    return this.requireRow(
-      await dbToUse.insert(schema.MediaAsset).values(processedData).returning(),
-      'create'
+    return this.unwrap(
+      await createAsset(this.filesCtx(db, data.organizationId), this.writeDeps(), {
+        kind: data.kind,
+        purpose: data.purpose,
+        name: data.name,
+        mimeType: data.mimeType,
+        size: data.size,
+        isPrivate: data.isPrivate,
+        createdById: data.createdById ?? this.userId,
+        expiresAt: data.expiresAt,
+      })
     )
   }
 
-  /**
-   * Get an entity by ID
-   */
+  /** @deprecated Use `getAsset(ctx, assetId)`. */
   async get(id: string, db?: DatabaseClient): Promise<MediaAsset | null> {
-    const dbToUse = db || this.db
-    const filters: SQL[] = [eq(schema.MediaAsset.id, id)]
-
-    if (this.organizationId) {
-      filters.push(eq(schema.MediaAsset.organizationId, this.organizationId))
-    }
-    filters.push(isNull(schema.MediaAsset.deletedAt))
-
-    const asset = await dbToUse.query.MediaAsset.findFirst({
-      where: and(...filters),
-    })
-    return asset ?? null
+    return this.unwrap(await getAsset(this.filesCtx(db), id))
   }
 
-  /**
-   * Get an entity with all relations
-   */
+  /** @deprecated Use `getAssetWithRelations(ctx, assetId)`. */
   async getWithRelations(id: string, db?: DatabaseClient): Promise<MediaAssetWithRelations | null> {
-    const dbToUse = db || this.db
-    const filters: SQL[] = [eq(schema.MediaAsset.id, id)]
-
-    if (this.organizationId) {
-      filters.push(eq(schema.MediaAsset.organizationId, this.organizationId))
-    }
-    filters.push(isNull(schema.MediaAsset.deletedAt))
-
-    const asset = await dbToUse.query.MediaAsset.findFirst({
-      where: and(...filters),
-      with: this.getRelationIncludes(),
-    })
-    return asset ?? null
+    return this.unwrap(await getAssetWithRelations(this.filesCtx(db), id))
   }
 
-  /**
-   * Update an entity
-   */
+  /** @deprecated Use `updateAsset(ctx, deps, assetId, input)`. */
   async update(id: string, data: UpdateAssetRequest, db?: DatabaseClient): Promise<MediaAsset> {
-    const dbToUse = db || this.db
-    const filters: SQL[] = [eq(schema.MediaAsset.id, id)]
-
-    if (this.organizationId) {
-      filters.push(eq(schema.MediaAsset.organizationId, this.organizationId))
-    }
-
-    return this.requireRow(
-      await dbToUse
-        .update(schema.MediaAsset)
-        .set({
-          ...data,
-          updatedAt: new Date(),
-        })
-        .where(and(...filters))
-        .returning(),
-      'update'
-    )
+    return this.unwrap(await updateAsset(this.filesCtx(db), this.writeDeps(), id, data))
   }
 
   /**
-   * List entities with pagination
+   * @deprecated Use `listAssets(ctx, options)`.
+   *
+   * The legacy `filters` bag was an arbitrary `Record<string, unknown>` resolved
+   * through `getTableColumns(schema.MediaAsset)`; only `kind` and `isPrivate`
+   * were ever passed, and only those two survive.
    */
   async list(
     options: {
@@ -180,407 +180,60 @@ export class MediaAssetService
       offset?: number
       sortBy?: string
       sortOrder?: 'asc' | 'desc'
-      filters?: any
+      filters?: { kind?: AssetKind; isPrivate?: boolean }
       includeDeleted?: boolean
     } = {}
   ): Promise<{ items: MediaAsset[]; total: number; hasMore: boolean }> {
-    const filters: SQL[] = []
+    const sortBy =
+      options.sortBy === 'createdAt' ||
+      options.sortBy === 'updatedAt' ||
+      options.sortBy === 'name' ||
+      options.sortBy === 'size'
+        ? options.sortBy
+        : undefined
 
-    if (this.organizationId) {
-      filters.push(eq(schema.MediaAsset.organizationId, this.organizationId))
-    }
-
-    if (!options.includeDeleted) {
-      filters.push(isNull(schema.MediaAsset.deletedAt))
-    }
-
-    // Apply additional filters
-    if (options.filters) {
-      for (const [key, value] of Object.entries(options.filters)) {
-        const column = MediaAssetService.columns[key]
-        if (column && value !== undefined && value !== null) {
-          filters.push(eq(column, value))
-        }
-      }
-    }
-
-    const sortColumn =
-      (options.sortBy ? MediaAssetService.columns[options.sortBy] : undefined) ??
-      schema.MediaAsset.createdAt
-    const orderBy = options.sortOrder === 'asc' ? asc(sortColumn) : desc(sortColumn)
-
-    const items = await this.db.query.MediaAsset.findMany({
-      where: and(...filters),
-      limit: options.limit || 50,
-      offset: options.offset || 0,
-      orderBy,
-    })
-
-    // For simplicity, not implementing total count - could be added with a separate query
-    return {
-      items,
-      total: items.length,
-      hasMore: items.length === (options.limit || 50),
-    }
+    return this.unwrap(
+      await listAssets(this.filesCtx(), {
+        kind: options.filters?.kind,
+        isPrivate: options.filters?.isPrivate,
+        limit: options.limit,
+        offset: options.offset,
+        sortBy,
+        sortOrder: options.sortOrder,
+        includeDeleted: options.includeDeleted,
+      })
+    )
   }
 
-  /**
-   * Count entities
-   */
-  async count(filters?: any): Promise<number> {
-    const whereFilters: SQL[] = []
+  // ============= Asset-specific operations =============
 
-    if (this.organizationId) {
-      whereFilters.push(eq(schema.MediaAsset.organizationId, this.organizationId))
-    }
-    whereFilters.push(isNull(schema.MediaAsset.deletedAt))
-
-    if (filters) {
-      for (const [key, value] of Object.entries(filters)) {
-        const column = MediaAssetService.columns[key]
-        if (column && value !== undefined && value !== null) {
-          whereFilters.push(eq(column, value))
-        }
-      }
-    }
-
-    const result = await this.db
-      .select({ count: sql`count(*)` })
-      .from(schema.MediaAsset)
-      .where(and(...whereFilters))
-
-    return Number(result[0]?.count || 0)
-  }
-
-  /**
-   * Process create data with asset-specific validation and defaults
-   */
-  protected async processCreateData(data: CreateAssetRequest): Promise<any> {
-    // Validate required fields
-    if (!data.kind) {
-      throw new Error('Asset kind is required')
-    }
-
-    // Validate asset kind
-    await this.validateAssetKind(data.kind)
-
-    const now = new Date()
-    return {
-      ...data,
-      organizationId: data.organizationId || this.requireOrganization(),
-      createdById: data.createdById || this.getUserId(),
-      isPrivate: data.isPrivate ?? true, // Default to private
-      updatedAt: now, // Set updatedAt to current time for new records
-    }
-  }
-
-  /**
-   * Get relation includes for asset entities
-   */
-  protected getRelationIncludes(): any {
-    return {
-      currentVersion: {
-        with: {
-          storageLocation: true,
-        },
-      },
-      versions: {
-        with: {
-          storageLocation: true,
-        },
-        orderBy: desc(schema.MediaAssetVersion.versionNumber),
-      },
-      attachments: true,
-      createdBy: {
-        columns: {
-          id: true,
-          name: true,
-          email: true,
-        },
-      },
-    }
-  }
-
-  /**
-   * Get searchable fields for asset search
-   */
-  protected getSearchFields(): string[] {
-    return ['name', 'kind', 'mimeType']
-  }
-
-  // ============= ContentAccessible Mixin Implementation =============
-
-  /**
-   * Get version table name for asset entities
-   */
-  protected getVersionTableName(): any {
-    return schema.MediaAssetVersion
-  }
-
-  /**
-   * Get entity ID field name in version table
-   */
-  protected getEntityIdFieldName(): string {
-    return 'assetId'
-  }
-
-  // ============= Asset-Specific Operations =============
-
-  /**
-   * Soft delete an asset and clean up currentVersionId references
-   */
+  /** @deprecated Use `deleteAsset(tx, ctx, deps, assetId)`. */
   async delete(id: string, db?: DatabaseClient): Promise<void> {
-    if (db) {
-      // Already in transaction, work directly
-      const asset = await this.get(id, db)
-      if (!asset) {
-        throw new Error('Asset not found')
-      }
-
-      // Get all versions to clean up thumbnails
-      const versions = await db.query.MediaAssetVersion.findMany({
-        where: eq(schema.MediaAssetVersion.assetId, id),
-        columns: { id: true },
-      })
-
-      // Clean up thumbnails for each version (soft delete)
-      // Import ThumbnailService if needed
-      const { ThumbnailService } = await import('./thumbnail-service')
-      const thumbnailService = new ThumbnailService(
-        this.organizationId!,
-        this.userId || 'system',
-        db
+    return this.inTransaction(db, async (tx) =>
+      this.unwrap(
+        await deleteAsset(
+          tx,
+          this.filesCtx(tx),
+          { ...this.writeDeps(), thumbnails: this.thumbnails(tx) },
+          id
+        )
       )
-
-      for (const version of versions) {
-        await thumbnailService.deleteThumbnailsForSource(version.id)
-      }
-
-      // First, remove any references to this asset's versions as current versions
-      if (versions.length > 0) {
-        await db
-          .update(schema.MediaAsset)
-          .set({
-            currentVersionId: null,
-          })
-          .where(
-            inArray(
-              schema.MediaAsset.currentVersionId,
-              versions.map((v) => v.id)
-            )
-          )
-      }
-
-      // Then soft delete the asset
-      await db
-        .update(schema.MediaAsset)
-        .set({
-          deletedAt: new Date(),
-        })
-        .where(eq(schema.MediaAsset.id, id))
-    } else {
-      // Not in transaction, create one
-      return this.getTx(async (tx) => {
-        return this.delete(id, tx)
-      })
-    }
+    )
   }
 
-  /**
-   * List assets with filtering by kind
-   */
-  async listByKind(
-    kind?: AssetKind,
-    options: {
-      limit?: number
-      offset?: number
-      sortBy?: string
-      sortOrder?: 'asc' | 'desc'
-      includePrivate?: boolean
-    } = {}
-  ): Promise<{
-    items: MediaAsset[]
-    total: number
-    hasMore: boolean
-  }> {
-    const filters: any = {}
-
-    if (kind) {
-      filters.kind = kind
-    }
-
-    if (options.includePrivate === false) {
-      filters.isPrivate = false
-    }
-
-    return this.list({
-      limit: options.limit,
-      offset: options.offset,
-      sortBy: options.sortBy || 'createdAt',
-      sortOrder: options.sortOrder || 'desc',
-      filters,
-    })
-  }
-
-  /**
-   * Enhanced search with asset-specific relevance scoring
-   */
-  async search(query: string, options?: SearchOptions): Promise<AssetSearchResult[]> {
-    const filters: SQL[] = []
-
-    // Base where clause with organization scoping
-    if (this.organizationId) {
-      filters.push(eq(schema.MediaAsset.organizationId, this.organizationId))
-    }
-    filters.push(isNull(schema.MediaAsset.deletedAt))
-
-    // Search conditions (OR logic)
-    const searchConditions: SQL[] = [
-      eq(schema.MediaAsset.name, query), // Exact name match
-      ilike(schema.MediaAsset.name, `%${query}%`), // Name contains query
-      ilike(schema.MediaAsset.mimeType, `%${query}%`), // MIME type match
-    ]
-
-    // Kind match (enum equality only)
-    if (this.isAssetKind(query)) {
-      searchConditions.push(eq(schema.MediaAsset.kind, query.toUpperCase() as AssetKind))
-    }
-
-    const searchClause = or(...searchConditions)
-    if (searchClause) {
-      filters.push(searchClause)
-    }
-
-    // Apply additional filters
-    if (options?.kinds) {
-      filters.push(inArray(schema.MediaAsset.kind, options.kinds))
-    }
-    if (options?.sizeLimits?.min) {
-      filters.push(gte(schema.MediaAsset.size, options.sizeLimits.min))
-    }
-    if (options?.sizeLimits?.max) {
-      filters.push(lte(schema.MediaAsset.size, options.sizeLimits.max))
-    }
-    if (options?.dateLimits?.createdAfter) {
-      filters.push(gte(schema.MediaAsset.createdAt, options.dateLimits.createdAfter))
-    }
-    if (options?.dateLimits?.createdBefore) {
-      filters.push(lte(schema.MediaAsset.createdAt, options.dateLimits.createdBefore))
-    }
-
-    // Support cursor-based pagination for large datasets
-    const queryOptions: any = {
-      where: and(...filters),
-      with: options?.includeContent ? this.getRelationIncludes() : undefined,
-      limit: options?.limit || 50,
-      orderBy: desc(schema.MediaAsset.updatedAt),
-    }
-
-    // Use cursor pagination if provided, otherwise fall back to offset
-    if (options?.cursor) {
-      queryOptions.where = and(...filters, gt(schema.MediaAsset.id, options.cursor))
-    } else if (options?.offset) {
-      queryOptions.offset = options.offset
-    }
-
-    const results = await this.db.query.MediaAsset.findMany(queryOptions)
-
-    // Calculate relevance scores
-    return results
-      .map((asset): AssetSearchResult => {
-        let relevance = 0
-        const matchedFields: string[] = []
-
-        // Exact name match
-        if (asset.name && asset.name.toLowerCase() === query.toLowerCase()) {
-          relevance += 10
-          matchedFields.push('name')
-        }
-        // Name contains query
-        else if (asset.name?.toLowerCase().includes(query.toLowerCase())) {
-          relevance += 5
-          matchedFields.push('name')
-        }
-
-        // Kind match (exact only for enums)
-        if (asset.kind.toLowerCase() === query.toLowerCase()) {
-          relevance += 3
-          matchedFields.push('kind')
-        }
-
-        // MIME type match
-        if (asset.mimeType?.toLowerCase().includes(query.toLowerCase())) {
-          relevance += 2
-          matchedFields.push('mimeType')
-        }
-
-        return {
-          asset,
-          relevance: Math.max(relevance, 1),
-          matchedFields,
-          snippet: this.generateSearchSnippet(asset, query),
-        }
-      })
-      .sort((a, b) => b.relevance - a.relevance)
-  }
-
-  /**
-   * Convert asset to different kind with validation
-   */
-  async convertKind(id: string, newKind: AssetKind): Promise<MediaAsset> {
-    const asset = await this.get(id)
-    if (!asset) {
-      throw new Error('Asset not found')
-    }
-
-    // Validate kind conversion
-    await this.validateKindConversion(asset.kind as AssetKind, newKind)
-
-    return this.update(id, {
-      kind: newKind,
-    })
-  }
-
-  /**
-   * Convert temporary upload to permanent attachment.
-   *
-   * @param tx Optional active tx — when called from inside a transaction
-   *   (e.g. comment creation), pass it through so the read+update share the
-   *   tx connection instead of grabbing fresh ones from the pool.
-   */
+  /** @deprecated Use `convertTempAssetToPermanent(ctx, assetId, kind)`. */
   async convertTempToPermanent(
     mediaAssetId: string,
     newKind: AssetKind,
     organizationId: string,
     tx?: DatabaseClient
   ): Promise<void> {
-    const dbOrTx = tx ?? this.db
-    const mediaAsset = await dbOrTx.query.MediaAsset.findFirst({
-      where: and(
-        eq(schema.MediaAsset.id, mediaAssetId),
-        eq(schema.MediaAsset.organizationId, organizationId)
-      ),
-    })
-
-    if (!mediaAsset || mediaAsset.kind !== 'TEMP_UPLOAD') {
-      return // Already permanent or doesn't exist
-    }
-
-    // Convert temp upload to permanent attachment
-    await dbOrTx
-      .update(schema.MediaAsset)
-      .set({
-        kind: newKind,
-        expiresAt: null, // Clear expiration for permanent files
-      })
-      .where(eq(schema.MediaAsset.id, mediaAssetId))
+    return this.unwrap(
+      await convertTempAssetToPermanent(this.filesCtx(tx, organizationId), mediaAssetId, newKind)
+    )
   }
 
-  // ============= Enhanced Asset Operations =============
-
-  /**
-   * Create asset with initial version (transactional)
-   */
+  /** @deprecated Use `createAssetWithVersion(tx, ctx, deps, input)`. */
   async createWithVersion(
     data: CreateAssetRequest,
     storageLocationId: string
@@ -588,29 +241,24 @@ export class MediaAssetService
     asset: MediaAsset
     version: MediaAssetVersion & { storageLocation: StorageLocation }
   }> {
-    return this.getTx(async (tx) => {
-      // Create the asset record
-      const asset = await this.create(data, tx)
-
-      // Create initial version
-      const version = await this.createVersion(
-        asset.id,
-        storageLocationId,
-        {
-          size: data.size,
+    return this.inTransaction(undefined, async (tx) =>
+      this.unwrap(
+        await createAssetWithVersion(tx, this.filesCtx(tx, data.organizationId), this.writeDeps(), {
+          kind: data.kind,
+          purpose: data.purpose,
+          name: data.name,
           mimeType: data.mimeType,
-        },
-        tx
+          size: data.size,
+          isPrivate: data.isPrivate,
+          createdById: data.createdById ?? this.userId,
+          expiresAt: data.expiresAt,
+          storageLocationId,
+        })
       )
-
-      return { asset, version }
-    })
+    )
   }
 
-  /**
-   * Create MediaAsset from existing FolderFile
-   * Reuses createWithVersion for consistency
-   */
+  /** @deprecated Use `createAssetFromFolderFile(tx, ctx, deps, input)`. */
   async createFromFolderFile(
     fileId: string,
     fileVersionId?: string,
@@ -619,82 +267,19 @@ export class MediaAssetService
       skipIfExists?: boolean
     }
   ): Promise<MediaAsset> {
-    // Get file with version
-    const file = await this.db.query.FolderFile.findFirst({
-      where: eq(schema.FolderFile.id, fileId),
-      with: {
-        currentVersion: {
-          with: { storageLocation: true },
-        },
-        versions: fileVersionId
-          ? {
-              where: eq(schema.FileVersion.id, fileVersionId),
-              limit: 1,
-              with: { storageLocation: true },
-            }
-          : undefined,
-      },
-    })
-
-    if (!file) {
-      throw new Error('File not found')
-    }
-
-    const version = fileVersionId && file.versions?.[0] ? file.versions[0] : file.currentVersion
-
-    if (!version) {
-      throw new Error('File version not found')
-    }
-
-    // Check for existing MediaAsset if requested
-    // Only return existing if it has a version pointing to the same storage location
-    if (options?.skipIfExists) {
-      // A `where` inside `with` only filters the included relation rows, never which asset is
-      // returned, so the storage-location match has to be part of the asset's own where clause.
-      const matchingVersions = await this.db.query.MediaAssetVersion.findMany({
-        where: and(
-          eq(schema.MediaAssetVersion.storageLocationId, version.storageLocationId),
-          isNull(schema.MediaAssetVersion.deletedAt)
-        ),
-        columns: { id: true },
-      })
-
-      if (matchingVersions.length > 0) {
-        const existing = await this.db.query.MediaAsset.findFirst({
-          where: and(
-            eq(schema.MediaAsset.organizationId, file.organizationId),
-            isNull(schema.MediaAsset.deletedAt),
-            inArray(
-              schema.MediaAsset.currentVersionId,
-              matchingVersions.map((v) => v.id)
-            )
-          ),
+    return this.inTransaction(undefined, async (tx) =>
+      this.unwrap(
+        await createAssetFromFolderFile(tx, this.filesCtx(tx), this.writeDeps(), {
+          fileId,
+          fileVersionId,
+          kind: options?.kind,
+          skipIfExists: options?.skipIfExists,
         })
-        if (existing) return existing
-      }
-    }
-
-    // Use existing createWithVersion method
-    const { asset } = await this.createWithVersion(
-      {
-        kind: options?.kind || 'DOCUMENT',
-        purpose: 'ORIGINAL',
-        name: file.name,
-        mimeType: file.mimeType || 'application/octet-stream',
-        size: file.size ?? 0,
-        isPrivate: true,
-        organizationId: file.organizationId,
-        createdById: file.createdById ?? undefined,
-      },
-      version.storageLocationId
+      )
     )
-
-    return asset
   }
 
-  /**
-   * Update asset content (creates new version, transactional)
-   */
+  /** @deprecated Use `updateAssetContent(tx, ctx, deps, input)`. */
   async updateContent(
     id: string,
     storageLocationId: string,
@@ -706,292 +291,107 @@ export class MediaAssetService
     asset: MediaAsset
     version: MediaAssetVersion & { storageLocation: StorageLocation }
   }> {
-    return this.getTx(async (tx) => {
-      const asset = await this.get(id, tx)
-      if (!asset) {
-        throw new Error('Asset not found')
-      }
-
-      // Create new version
-      const version = await this.createVersion(id, storageLocationId, metadata, tx)
-
-      // Update asset metadata if provided
-      const updatedAsset = await this.update(
-        id,
-        {
-          ...(metadata.size && { size: metadata.size }),
-          ...(metadata.mimeType && { mimeType: metadata.mimeType }),
-        },
-        tx
+    return this.inTransaction(undefined, async (tx) =>
+      this.unwrap(
+        await updateAssetContent(tx, this.filesCtx(tx), this.writeDeps(), {
+          assetId: id,
+          storageLocationId,
+          size: metadata.size,
+          mimeType: metadata.mimeType,
+        })
       )
-
-      return { asset: updatedAsset, version }
-    })
-  }
-
-  /**
-   * Get asset download info with metadata
-   */
-  async getDownloadInfo(id: string): Promise<AssetDownloadInfo> {
-    const asset = await this.getWithRelations(id)
-    if (!asset) {
-      throw new Error('Asset not found')
-    }
-
-    const downloadRef = await this.getDownloadRef(id)
-
-    return {
-      url: downloadRef.type === 'url' ? downloadRef.url : undefined,
-      filename: asset.name || undefined,
-      mimeType: asset.mimeType || undefined,
-      size: asset.size || undefined,
-      expiresAt: downloadRef.type === 'url' ? downloadRef.expiresAt : undefined,
-    }
-  }
-
-  // ============= Asset Queries =============
-
-  /**
-   * Find assets by kind
-   */
-  async findByKind(kind: AssetKind): Promise<MediaAsset[]> {
-    const filters: SQL[] = []
-
-    if (this.organizationId) {
-      filters.push(eq(schema.MediaAsset.organizationId, this.organizationId))
-    }
-    filters.push(isNull(schema.MediaAsset.deletedAt))
-    filters.push(eq(schema.MediaAsset.kind, kind))
-
-    return this.db.query.MediaAsset.findMany({
-      where: and(...filters),
-      orderBy: desc(schema.MediaAsset.createdAt),
-    })
-  }
-
-  /**
-   * Get assets by MIME type
-   */
-  async findByMimeType(mimeType: string): Promise<MediaAsset[]> {
-    const filters: SQL[] = []
-
-    if (this.organizationId) {
-      filters.push(eq(schema.MediaAsset.organizationId, this.organizationId))
-    }
-    filters.push(isNull(schema.MediaAsset.deletedAt))
-    filters.push(ilike(schema.MediaAsset.mimeType, `%${mimeType}%`))
-
-    return this.db.query.MediaAsset.findMany({
-      where: and(...filters),
-      orderBy: desc(schema.MediaAsset.createdAt),
-    })
-  }
-
-  /**
-   * Find temporary/expired assets for cleanup
-   */
-  async findExpired(maxAgeHours = 24): Promise<MediaAsset[]> {
-    const cutoffDate = new Date(Date.now() - maxAgeHours * 60 * 60 * 1000)
-    const filters: SQL[] = []
-
-    if (this.organizationId) {
-      filters.push(eq(schema.MediaAsset.organizationId, this.organizationId))
-    }
-    filters.push(isNull(schema.MediaAsset.deletedAt))
-    filters.push(eq(schema.MediaAsset.kind, 'TEMP_UPLOAD'))
-    filters.push(lt(schema.MediaAsset.createdAt, cutoffDate))
-
-    return this.db.query.MediaAsset.findMany({
-      where: and(...filters),
-      orderBy: asc(schema.MediaAsset.createdAt),
-    })
-  }
-
-  /**
-   * Get large assets (for cleanup)
-   */
-  async findLargeAssets(minSizeBytes: number): Promise<MediaAsset[]> {
-    const filters: SQL[] = []
-
-    if (this.organizationId) {
-      filters.push(eq(schema.MediaAsset.organizationId, this.organizationId))
-    }
-    filters.push(isNull(schema.MediaAsset.deletedAt))
-    filters.push(gte(schema.MediaAsset.size, minSizeBytes))
-
-    return this.db.query.MediaAsset.findMany({
-      where: and(...filters),
-      orderBy: desc(schema.MediaAsset.size),
-    })
-  }
-
-  /**
-   * Get orphaned assets (assets without a current version)
-   */
-  async findOrphanedAssets(): Promise<MediaAsset[]> {
-    const filters: SQL[] = []
-
-    if (this.organizationId) {
-      filters.push(eq(schema.MediaAsset.organizationId, this.organizationId))
-    }
-    filters.push(isNull(schema.MediaAsset.deletedAt))
-    filters.push(isNull(schema.MediaAsset.currentVersionId))
-
-    return this.db.query.MediaAsset.findMany({
-      where: and(...filters),
-    })
-  }
-
-  /**
-   * Get public assets
-   */
-  async findPublicAssets(): Promise<MediaAsset[]> {
-    const filters: SQL[] = []
-
-    if (this.organizationId) {
-      filters.push(eq(schema.MediaAsset.organizationId, this.organizationId))
-    }
-    filters.push(isNull(schema.MediaAsset.deletedAt))
-    filters.push(eq(schema.MediaAsset.isPrivate, false))
-
-    return this.db.query.MediaAsset.findMany({
-      where: and(...filters),
-      orderBy: desc(schema.MediaAsset.createdAt),
-    })
-  }
-
-  // ============= Specialized Asset Operations =============
-
-  /**
-   * Process email attachment assets
-   */
-  async processEmailAttachment(assetId: string): Promise<MediaAsset> {
-    const asset = await this.get(assetId)
-    if (!asset || asset.kind !== 'EMAIL_ATTACHMENT') {
-      throw new Error('Invalid email attachment asset')
-    }
-
-    // TODO: Implement virus scanning, content indexing, etc.
-    // This would integrate with external services for security scanning
-
-    // For now, just mark as processed by updating the timestamp
-    return this.update(assetId, {
-      // Could add metadata about processing status
-    })
-  }
-
-  /**
-   * Generate thumbnail for image/video assets
-   */
-  async generateThumbnail(
-    assetId: string,
-    _options: {
-      width?: number
-      height?: number
-      quality?: number
-    } = {}
-  ): Promise<MediaAsset> {
-    const asset = await this.get(assetId)
-    if (!asset) {
-      throw new Error('Asset not found')
-    }
-
-    // TODO: Implement actual thumbnail generation
-    // This would use image processing libraries like Sharp
-    // For now, throw an error since we can't create assets without storage
-    throw new Error(
-      'Thumbnail generation not yet implemented - requires actual file processing and storage upload'
     )
   }
 
-  /**
-   * Extract metadata from asset
-   */
-  async extractMetadata(assetId: string): Promise<Record<string, any>> {
-    const asset = await this.getWithRelations(assetId)
-    if (!asset) {
-      throw new Error('Asset not found')
-    }
+  // ============= Asset queries =============
 
-    const metadata: Record<string, any> = {
-      id: asset.id,
-      kind: asset.kind,
-      name: asset.name,
-      mimeType: asset.mimeType,
-      size: asset.size?.toString(),
-      isPrivate: asset.isPrivate,
-      createdAt: asset.createdAt,
-      updatedAt: asset.updatedAt,
-    }
-
-    // Add version information
-    if (asset.currentVersion) {
-      metadata.currentVersion = {
-        versionNumber: asset.currentVersion.versionNumber,
-        storageLocation: asset.currentVersion.storageLocation,
-      }
-    }
-
-    // TODO: Extract file-specific metadata (EXIF, document properties, etc.)
-    // This would use libraries like exifr for images, pdf-parse for PDFs, etc.
-
-    return metadata
+  /** @deprecated Use `findAssetsByKind(ctx, kind)`. */
+  async findByKind(kind: AssetKind): Promise<MediaAsset[]> {
+    return this.unwrap(await findAssetsByKind(this.filesCtx(), kind))
   }
 
-  // ============= ContentAccessible Implementation =============
+  /**
+   * @deprecated Use `findExpiredAssets(ctx, createdBefore)`.
+   *
+   * The cutoff is computed here rather than inside the query, because the
+   * extracted read takes an instant instead of reading the clock itself.
+   */
+  async findExpired(maxAgeHours = 24): Promise<MediaAsset[]> {
+    const createdBefore = new Date(this.writeDeps().now().getTime() - maxAgeHours * 60 * 60 * 1000)
+    return this.unwrap(await findExpiredAssets(this.filesCtx(), createdBefore))
+  }
 
   /**
-   * Get the binary content of an entity
+   * @deprecated Zero callers, and it never worked: `MediaAsset` has no checksum
+   * column, so the body below ignores its argument and returns whichever live
+   * asset the organization filter happens to yield first. It is kept only
+   * because `ContentAccessible` declares it (`FileService` has a real
+   * implementation — `FolderFile.checksum` exists) and is deleted with this
+   * class. It was deliberately NOT ported to `files/assets/`: porting it would
+   * launder the bug into the new module.
+   */
+  async findByChecksum(_checksum: string): Promise<MediaAsset | null> {
+    const asset = await this.db.query.MediaAsset.findFirst({
+      where: and(
+        eq(schema.MediaAsset.organizationId, this.requireOrganization()),
+        isNull(schema.MediaAsset.deletedAt)
+      ),
+    })
+    return (asset as MediaAsset | undefined) ?? null
+  }
+
+  // ============= Content access =============
+
+  /**
+   * @deprecated Still on `StorageManager` rather than the `StoragePort`.
+   *
+   * `assets/` has no content-read function yet: PR 5a's scope was the CRUD,
+   * version and download surface, and `getContent` / `streamContent` need
+   * `StoragePort.getObject` / `.streamObject` plus the bucket-from-the-row rule
+   * that `download.ts` implements. That is the next extraction, not this one —
+   * which is also why `getStorageManager` survives despite the plan listing it
+   * as deletable.
    */
   async getContent(id: string): Promise<Buffer> {
-    const entity = await this.get(id)
-    if (!entity) {
-      throw new Error(`${this.getEntityName()} not found`)
-    }
-
-    const storageManager = await this.getStorageManager()
     const currentVersion = await this.getCurrentVersion(id)
-
-    if (!currentVersion || !currentVersion.storageLocationId) {
+    if (!currentVersion?.storageLocationId) {
       throw new Error(`No storage location found for ${this.getEntityName()}`)
     }
-
+    const storageManager = await this.getStorageManager()
     return storageManager.getContent(currentVersion.storageLocationId)
   }
 
+  /** @deprecated Same caveat as {@link getContent}. */
+  async streamContent(id: string): Promise<NodeJS.ReadableStream> {
+    const currentVersion = await this.getCurrentVersion(id)
+    if (!currentVersion?.storageLocationId) {
+      throw new Error(`No storage location found for ${this.getEntityName()}`)
+    }
+    const storageManager = await this.getStorageManager()
+    return storageManager.streamContent(currentVersion.storageLocationId)
+  }
+
+  // ============= Download =============
+
   /**
-   * Get a download URL with expiry information.
-   *
-   * @deprecated Facade over
-   * {@link import('../assets/download').getAssetDownloadRef}. Call that
-   * directly with a `FilesCtx` and a `StoragePort`; this wrapper exists only so
-   * the ~15 existing call sites keep working while the function becomes the
-   * real implementation, and is deleted with the rest of `MediaAssetService`
-   * in Phase 5.
-   *
-   * Behaviour is unchanged except for the error type: it now throws an
-   * `AuxxError` subclass (`NotFoundError` for a missing asset/version/location)
-   * instead of a bare `Error`, so `auxxErrorMiddleware` can map it to a real
-   * status instead of a 500.
+   * @deprecated Use `getAssetDownloadRef(ctx, deps, assetId)` and read `.url`
+   * off the ref — it is the single accessor that replaced this method,
+   * `getDownloadRefForVersion`, `getDownloadUrl`, `getDownloadUrls`,
+   * `getDownloadInfo` and the private `downloadUrlFor`.
    */
   async getDownloadRef(id: string): Promise<DownloadRef> {
-    const result = await getAssetDownloadRef(this.filesCtx(), this.filesDownloadDeps(), id)
-    if (result.isErr()) {
-      throw result.error
-    }
-    return result.value
+    return this.unwrap(await getAssetDownloadRef(this.filesCtx(), this.filesDownloadDeps(), id))
   }
 
   /**
-   * Get download reference for a specific version with enhanced metadata
+   * @deprecated Use `getAssetDownloadRef(ctx, deps, assetId, { versionId })`.
    *
-   * Retrieves a download reference for a specific version of an asset with additional
-   * metadata needed for preview functionality. Supports different version specifiers.
-   *
-   * @param entityId - ID of the asset to get download reference for
-   * @param opts - Options including version specifier and disposition
-   * @returns Promise resolving to enhanced download reference with metadata
-   * @throws Error if asset not found, version not found, or no storage location available
+   * Two id spaces meet here and the extracted function only speaks one of them:
+   * this method addresses a version by its **number** (or the words `current` /
+   * `latest`), while `getAssetDownloadRef` takes a version **id**. So the
+   * number is resolved to a row first, and the row's id is what gets passed
+   * down. The extra metadata this returns — filename, size, `versionNumber` —
+   * is read off the rows that resolution already loaded.
    */
   async getDownloadRefForVersion(
     entityId: string,
@@ -999,71 +399,51 @@ export class MediaAssetService
       version?: number | 'latest' | 'current'
       disposition?: 'inline' | 'attachment'
     } = {}
-  ): Promise<
-    DownloadRef & {
-      filename: string
-      mimeType?: string
-      size?: number
-      expiresAt?: Date
-      versionNumber: number
-    }
-  > {
+  ): Promise<AssetVersionDownloadRef> {
     const { version = 'current', disposition = 'inline' } = opts
+    const ctx = this.filesCtx()
 
     const entity = await this.get(entityId)
     if (!entity) {
       throw new Error(`${this.getEntityName()} not found`)
     }
 
-    // Get the appropriate version based on the version parameter
-    let targetVersion: (MediaAssetVersion & { storageLocation: any }) | null = null
+    const targetVersion =
+      version === 'current'
+        ? this.unwrap(await getAssetCurrentVersion(ctx, entityId))
+        : version === 'latest'
+          ? this.unwrap(await getLatestAssetVersion(ctx, entityId))
+          : this.unwrap(await getAssetVersionByNumber(ctx, entityId, version))
 
-    if (version === 'current') {
-      targetVersion = await this.getCurrentVersion(entityId)
-    } else if (version === 'latest') {
-      targetVersion = await this.getLatestVersion(entityId)
-    } else if (typeof version === 'number') {
-      targetVersion = await this.getVersion(entityId, version)
-    }
-
-    if (!targetVersion || !targetVersion.storageLocationId) {
+    if (!targetVersion?.storageLocationId) {
       throw new Error(`Version ${version} not found for ${this.getEntityName()}`)
     }
 
-    const storageManager = await this.getStorageManager()
-    const downloadRef = await storageManager.getDownloadRef({
-      locationId: targetVersion.storageLocationId,
-      disposition,
-      filename: entity.name || undefined,
-      mimeType: entity.mimeType || undefined,
-    })
+    const downloadRef = this.unwrap(
+      await getAssetDownloadRef(ctx, this.filesDownloadDeps(), entityId, {
+        versionId: targetVersion.id,
+        disposition,
+      })
+    )
 
-    // Return enhanced download reference with metadata
+    const fallbackExpiry = new Date(this.writeDeps().now().getTime() + LEGACY_PREVIEW_TTL_MS)
     return {
       ...downloadRef,
       filename: entity.name || `${entity.kind.toLowerCase()}_${entity.id}`,
       mimeType: entity.mimeType || undefined,
       size: entity.size || undefined,
       versionNumber: targetVersion.versionNumber,
-      // Use existing expiresAt if it's a URL type, otherwise set a default expiration
       expiresAt:
-        downloadRef.type === 'url'
-          ? downloadRef.expiresAt || new Date(Date.now() + 10 * 60 * 1000) // 10 minutes default
-          : new Date(Date.now() + 10 * 60 * 1000),
+        downloadRef.type === 'url' ? (downloadRef.expiresAt ?? fallbackExpiry) : fallbackExpiry,
     }
   }
 
   /**
-   * Get download URL as string (convenience method).
+   * @deprecated Use `getAssetDownloadRef(...)` and read `.url`.
    *
-   * @deprecated Facade over
-   * {@link import('../assets/download').getAssetDownloadRef}. Call that
-   * directly and read `.url` off the {@link DownloadRef}; deleted with the rest
-   * of `MediaAssetService` in Phase 5.
-   *
-   * Returns `null` on every failure, exactly as before — this is a
-   * best-effort convenience used to fill avatar/thumbnail URLs into list
-   * payloads, and a throw there would fail a whole page for one broken row.
+   * Returns `null` on every failure, exactly as before — this is a best-effort
+   * convenience used to fill avatar/thumbnail URLs into list payloads, and a
+   * throw there would fail a whole page for one broken row.
    */
   async getDownloadUrl(id: string): Promise<string | null> {
     try {
@@ -1078,11 +458,17 @@ export class MediaAssetService
   }
 
   /**
-   * Batch-resolve download URLs for many asset ids in a fixed number of DB
-   * round-trips (one for assets, up to two for their versions) instead of the
-   * per-id `getDownloadUrl` fan-out. Returns a Map keyed by id; ids that are
-   * missing, deleted, or have no storage location resolve to null. Presigning
-   * stays per-asset but is an in-memory signing op, not a DB call.
+   * @deprecated Use `resolveAssetDownloadRef(deps, asset, version)` over rows
+   * the caller already batched.
+   *
+   * Resolves many asset ids in a fixed number of round-trips (one for the
+   * assets, up to two for their versions) instead of the per-id `getDownloadUrl`
+   * fan-out. The URL policy itself is no longer duplicated here: the private
+   * `downloadUrlFor` this used to call is gone, and each row now goes through
+   * `resolveAssetDownloadRef` — the same tail `getAssetDownloadRef` runs.
+   *
+   * Ids that are missing, deleted, or whose storage location cannot name its
+   * bucket resolve to `null`.
    */
   async getDownloadUrls(ids: string[]): Promise<Map<string, string | null>> {
     const result = new Map<string, string | null>()
@@ -1092,25 +478,25 @@ export class MediaAssetService
     const filters: SQL[] = [
       inArray(schema.MediaAsset.id, unique),
       isNull(schema.MediaAsset.deletedAt),
+      eq(schema.MediaAsset.organizationId, this.requireOrganization()),
     ]
-    if (this.organizationId) {
-      filters.push(eq(schema.MediaAsset.organizationId, this.organizationId))
-    }
-    const assets = await this.db.query.MediaAsset.findMany({ where: and(...filters) })
+    const assets = (await this.db.query.MediaAsset.findMany({
+      where: and(...filters),
+    })) as MediaAsset[]
 
     // Resolve every asset's current version in at most two queries: one by
     // explicit currentVersionId, one by assetId (latest) for assets without it.
-    const withCurrent = assets.filter((a) => (a as any).currentVersionId)
-    const withoutCurrent = assets.filter((a) => !(a as any).currentVersionId)
-    const versionById = new Map<string, any>()
-    const latestByAsset = new Map<string, any>()
+    const withCurrent = assets.filter((asset) => asset.currentVersionId)
+    const withoutCurrent = assets.filter((asset) => !asset.currentVersionId)
+    const versionById = new Map<string, VersionWithLocation>()
+    const latestByAsset = new Map<string, VersionWithLocation>()
 
     const [byId, byAsset] = await Promise.all([
       withCurrent.length
         ? this.db.query.MediaAssetVersion.findMany({
             where: inArray(
               schema.MediaAssetVersion.id,
-              withCurrent.map((a) => (a as any).currentVersionId as string)
+              withCurrent.map((asset) => asset.currentVersionId as string)
             ),
             with: { storageLocation: true },
           })
@@ -1119,116 +505,103 @@ export class MediaAssetService
         ? this.db.query.MediaAssetVersion.findMany({
             where: inArray(
               schema.MediaAssetVersion.assetId,
-              withoutCurrent.map((a) => a.id)
+              withoutCurrent.map((asset) => asset.id)
             ),
             orderBy: desc(schema.MediaAssetVersion.versionNumber),
             with: { storageLocation: true },
           })
         : Promise.resolve([]),
     ])
-    for (const v of byId) versionById.set(v.id, v)
-    for (const v of byAsset) {
+    for (const version of byId as VersionWithLocation[]) versionById.set(version.id, version)
+    for (const version of byAsset as VersionWithLocation[]) {
       // ordered by version desc → first seen per asset is the latest
-      if (!latestByAsset.has(v.assetId)) latestByAsset.set(v.assetId, v)
+      if (!latestByAsset.has(version.assetId)) latestByAsset.set(version.assetId, version)
     }
 
+    const deps = this.filesDownloadDeps()
     await Promise.all(
       assets.map(async (entity) => {
-        const version = (entity as any).currentVersionId
-          ? versionById.get((entity as any).currentVersionId)
+        const version = entity.currentVersionId
+          ? versionById.get(entity.currentVersionId)
           : latestByAsset.get(entity.id)
-        result.set(entity.id, await this.downloadUrlFor(entity, version))
+        if (!version) {
+          result.set(entity.id, null)
+          return
+        }
+        try {
+          const ref = await resolveAssetDownloadRef(deps, entity, version)
+          result.set(entity.id, ref.type === 'url' ? ref.url : null)
+        } catch {
+          result.set(entity.id, null)
+        }
       })
     )
     for (const id of unique) if (!result.has(id)) result.set(id, null)
     return result
   }
 
-  /**
-   * Turn an already-loaded asset + its current version into a download URL.
-   * Public assets with a durable external URL return it directly; otherwise a
-   * presigned URL is generated. Shared by `getDownloadUrl`/`getDownloadUrls`
-   * so neither re-fetches the entity or version.
-   */
-  private async downloadUrlFor(entity: MediaAsset, currentVersion: any): Promise<string | null> {
-    if (!currentVersion || !currentVersion.storageLocationId) return null
-    if (!entity.isPrivate && currentVersion.storageLocation?.externalUrl) {
-      return currentVersion.storageLocation.externalUrl
-    }
-    const storageManager = await this.getStorageManager()
-    const downloadRef = await storageManager.getDownloadRef({
-      locationId: currentVersion.storageLocationId,
-      filename: entity.name || undefined,
-      mimeType: entity.mimeType || undefined,
-    })
-    return downloadRef.type === 'url' ? downloadRef.url : null
+  // ============= Versions =============
+
+  /** @deprecated Use `getAssetCurrentVersion(ctx, assetId)`. */
+  async getCurrentVersion(entityId: string): Promise<AssetVersionWithLocation | null> {
+    return this.unwrap(await getAssetCurrentVersion(this.filesCtx(), entityId))
   }
 
-  /**
-   * Resolve the current version for an already-loaded asset without re-fetching
-   * the asset row (unlike `getCurrentVersion`, which re-`get`s by id).
-   */
-  private async resolveCurrentVersion(entity: MediaAsset): Promise<any> {
-    if ((entity as any).currentVersionId) {
-      return this.db.query.MediaAssetVersion.findFirst({
-        where: eq(schema.MediaAssetVersion.id, (entity as any).currentVersionId),
-        with: { storageLocation: true },
-      })
-    }
-    return this.db.query.MediaAssetVersion.findFirst({
-      where: eq(schema.MediaAssetVersion.assetId, entity.id),
-      orderBy: desc(schema.MediaAssetVersion.versionNumber),
-      with: { storageLocation: true },
-    })
+  /** @deprecated Use `createAssetVersion(tx, ctx, input)`. */
+  async createVersion(
+    entityId: string,
+    storageLocationId: string,
+    metadata: { size?: number; mimeType?: string; metadata?: Record<string, unknown> } = {},
+    db?: DatabaseClient
+  ): Promise<MediaAssetVersion & { storageLocation: StorageLocation }> {
+    return this.inTransaction(db, async (tx) =>
+      this.unwrap(
+        await createAssetVersion(tx, this.filesCtx(tx), {
+          assetId: entityId,
+          storageLocationId,
+          size: metadata.size,
+          mimeType: metadata.mimeType,
+          metadata: metadata.metadata,
+        })
+      )
+    )
   }
 
-  /**
-   * Stream the content of an entity
-   */
-  async streamContent(id: string): Promise<NodeJS.ReadableStream> {
-    const entity = await this.get(id)
-    if (!entity) {
-      throw new Error(`${this.getEntityName()} not found`)
-    }
-
-    const storageManager = await this.getStorageManager()
-    const currentVersion = await this.getCurrentVersion(id)
-
-    if (!currentVersion || !currentVersion.storageLocationId) {
-      throw new Error(`No storage location found for ${this.getEntityName()}`)
-    }
-
-    return storageManager.streamContent(currentVersion.storageLocationId)
+  /** @deprecated Use `getAssetVersions(ctx, assetId)`. */
+  async getVersions(entityId: string): Promise<AssetVersionWithLocation[]> {
+    return this.unwrap(await getAssetVersions(this.filesCtx(), entityId))
   }
 
-  /**
-   * Find entity by content checksum
-   */
-  async findByChecksum(checksum: string): Promise<MediaAsset | null> {
-    const filters: SQL[] = []
-
-    if (this.organizationId) {
-      filters.push(eq(schema.MediaAsset.organizationId, this.organizationId))
-    }
-    filters.push(isNull(schema.MediaAsset.deletedAt))
-    // Note: checksum field might need to be added to MediaAsset table or accessed via relations
-    // For now, keeping the logic but this may need adjustment based on actual schema
-
-    const asset = await this.db.query.MediaAsset.findFirst({
-      where: and(...filters),
-    })
-    return asset ?? null
+  /** @deprecated Use `getAssetVersionByNumber(ctx, assetId, versionNumber)`. */
+  async getVersion(
+    entityId: string,
+    versionNumber: number
+  ): Promise<AssetVersionWithLocation | null> {
+    return this.unwrap(await getAssetVersionByNumber(this.filesCtx(), entityId, versionNumber))
   }
 
-  /**
-   * Get the current version of an entity
-   */
-  async getCurrentVersion(entityId: string): Promise<any> {
-    const entity = await this.get(entityId)
-    if (!entity) {
-      throw new Error(`${this.getEntityName()} not found`)
-    }
-    return this.resolveCurrentVersion(entity)
+  /** @deprecated Use `getLatestAssetVersion(ctx, assetId)`. */
+  async getLatestVersion(entityId: string): Promise<AssetVersionWithLocation | null> {
+    return this.unwrap(await getLatestAssetVersion(this.filesCtx(), entityId))
+  }
+
+  /** @deprecated Use `restoreAssetVersion(ctx, deps, assetId, versionNumber)`. */
+  async restoreVersion(entityId: string, versionNumber: number): Promise<MediaAsset> {
+    return this.unwrap(
+      await restoreAssetVersion(this.filesCtx(), this.writeDeps(), entityId, versionNumber)
+    )
+  }
+
+  /** @deprecated Use `deleteAssetVersion(ctx, deps, assetId, versionNumber)`. */
+  async deleteVersion(entityId: string, versionNumber: number): Promise<void> {
+    return this.unwrap(
+      await deleteAssetVersion(
+        this.filesCtx(),
+        { thumbnails: this.thumbnails(this.db) },
+        entityId,
+        versionNumber
+      )
+    )
   }
 
   // ============= Bridge to the functional `files/` surface =============
@@ -1240,35 +613,56 @@ export class MediaAssetService
    * `FilesCtx` carries no actor, so `this.userId` is deliberately not forwarded
    * — a function that records one takes it in its own `input` instead. That
    * matters here: many production sites construct `new MediaAssetService(orgId)`
-   * with no actor at all (a worker resolving a thumbnail URL, for one), and an
-   * earlier draft of this facade had to fabricate `''` to satisfy the type.
+   * with no actor at all (a worker resolving a thumbnail URL, for one).
    *
    * `organizationId` is the opposite case: it is in the `WHERE` clause, so a
    * missing one must throw rather than silently widen the query to every tenant.
+   *
+   * @param db Override client — a transaction the caller already opened.
+   * @param organizationId Override scope, for the two methods that take one as
+   *   an argument rather than from the constructor.
    */
-  private filesCtx(): FilesCtx {
+  private filesCtx(db?: DatabaseClient, organizationId?: string): FilesCtx {
     return {
-      db: this.db,
-      organizationId: this.requireOrganization(),
+      db: db ?? this.db,
+      organizationId: organizationId ?? this.requireOrganization(),
     }
   }
 
   /**
-   * The storage collaborator for the extracted download read, lazily built and
-   * cached per service instance.
+   * The clock the extracted writes stamp `updatedAt` / `deletedAt` from.
    *
-   * Statically imported. It could not be, until PR 3a-prime: `storage/ports.ts`
-   * reaches `storage-location-service.ts`, which held a module-scope
-   * `import { database as db }` named binding, and pulling that into this
-   * file's static import graph re-armed the collection hazard documented on
-   * `base-service.ts`. #1823 replaced that binding with the same namespace
-   * accessor, and PR 3c deleted the file outright — nothing under
-   * `files/storage/**` reaches the database at module scope any more — so the
-   * edge is safe and the dynamic import, plus the `async` it forced onto every
-   * caller, is gone.
+   * A real `FilesDeps.now` here, so production behaviour is `new Date()` while
+   * the extracted functions stay testable with a frozen clock.
+   */
+  private writeDeps(): AssetWriteDeps {
+    return { now: () => new Date() }
+  }
+
+  /**
+   * The thumbnail sweep the delete paths take as a parameter.
    *
-   * Still lazy, but only to avoid resolving credentials for a service instance
-   * that never downloads anything.
+   * Still constructs a `ThumbnailService` — but *here*, at the composition site,
+   * rather than inside the delete body where it used to live. When PR 5f lands
+   * `files/thumbnails/`, only this method changes.
+   */
+  private thumbnails(db: DatabaseClient): ThumbnailCleanupPort {
+    const organizationId = this.requireOrganization()
+    const userId = this.userId || 'system'
+    return {
+      deleteThumbnailsForSource: async (sourceVersionId: string) => {
+        const { ThumbnailService } = await import('./thumbnail-service')
+        await new ThumbnailService(organizationId, userId, db).deleteThumbnailsForSource(
+          sourceVersionId
+        )
+      },
+    }
+  }
+
+  /**
+   * The storage collaborator for the extracted download reads, lazily built and
+   * cached per service instance, so a service that never downloads anything
+   * never resolves credentials.
    */
   private filesDownloadDeps(): DownloadDeps {
     if (!this._filesDownloadDeps) {
@@ -1278,7 +672,10 @@ export class MediaAssetService
   }
 
   /**
-   * Get storage manager for content operations (lazy singleton)
+   * Get storage manager for content operations (lazy singleton).
+   *
+   * Survives PR 5a because `getContent` / `streamContent` still go through it —
+   * see the note on {@link getContent}.
    */
   protected async getStorageManager(): Promise<any> {
     if (!this._storageManager) {
@@ -1290,302 +687,42 @@ export class MediaAssetService
     return this._storageManager
   }
 
-  // ============= Versioned Implementation =============
-
   /**
-   * Create a new version for an entity
+   * Unwrap a `Result` into the throw-based contract this class has always had.
+   *
+   * The thrown value is an `AuxxError` subclass rather than the bare `Error` the
+   * old bodies threw, which is the one deliberate change to this facade's
+   * behaviour.
    */
-  async createVersion(
-    entityId: string,
-    storageLocationId: string,
-    metadata: any = {},
-    db?: DatabaseClient
-  ): Promise<MediaAssetVersion & { storageLocation: StorageLocation }> {
-    if (db) {
-      // Already in transaction, work directly with it
-      const entity = await this.get(entityId, db)
-      if (!entity) {
-        throw new Error(`${this.getEntityName()} not found`)
-      }
-
-      // Get the next version number within transaction
-      const lastVersion = await db.query.MediaAssetVersion.findFirst({
-        where: eq(schema.MediaAssetVersion.assetId, entityId),
-        orderBy: desc(schema.MediaAssetVersion.versionNumber),
-        columns: { versionNumber: true },
-      })
-
-      const versionNumber = (lastVersion?.versionNumber || 0) + 1
-
-      // Get storage location details
-      const storageLocation = await db.query.StorageLocation.findFirst({
-        where: and(
-          eq(schema.StorageLocation.id, storageLocationId),
-          isNull(schema.StorageLocation.deletedAt)
-        ),
-      })
-
-      if (!storageLocation) {
-        throw new Error('Storage location not found')
-      }
-
-      // Create the new version
-      const version = this.requireRow(
-        await db
-          .insert(schema.MediaAssetVersion)
-          .values({
-            assetId: entityId,
-            versionNumber,
-            storageLocationId,
-            size: storageLocation.size,
-            mimeType: storageLocation.mimeType,
-            ...metadata,
-          })
-          .returning(),
-        'create version'
-      )
-
-      // Update the entity's current version reference
-      await db
-        .update(schema.MediaAsset)
-        .set({
-          currentVersionId: version.id,
-        })
-        .where(eq(schema.MediaAsset.id, entityId))
-
-      return { ...version, storageLocation }
-    } else {
-      // Not in transaction, create one
-      const entity = await this.get(entityId)
-      if (!entity) {
-        throw new Error(`${this.getEntityName()} not found`)
-      }
-
-      return this.getTx(async (tx) => {
-        return this.createVersion(entityId, storageLocationId, metadata, tx)
-      })
-    }
+  private unwrap<T>(result: Result<T, AuxxError>): T {
+    if (result.isErr()) throw result.error
+    return result.value
   }
 
   /**
-   * Get all versions for an entity
+   * Run `fn` inside a transaction, reproducing `BaseService.getTx` exactly.
+   *
+   * This is the one place the deprecated facade casts, and it is unavoidable
+   * here: `BaseService.db` and the legacy `db?` parameters are
+   * `Database | Transaction`, while the extracted writes require a real
+   * `Transaction` — which is the entire point of that parameter, since a pool in
+   * the slot silently stops a multi-statement write from being atomic. Isolating
+   * the cast to this method keeps every new call site honest, and Phase 6 deletes
+   * it along with `getTx`.
+   *
+   * @param client A client the caller says is already transactional; when
+   *   present, `fn` runs on it directly, matching the legacy `if (db) … else
+   *   getTx(…)` branch.
    */
-  async getVersions(entityId: string): Promise<(MediaAssetVersion & { storageLocation: any })[]> {
-    const entity = await this.get(entityId)
-    if (!entity) {
-      throw new Error(`${this.getEntityName()} not found`)
-    }
-
-    return this.db.query.MediaAssetVersion.findMany({
-      where: eq(schema.MediaAssetVersion.assetId, entityId),
-      with: {
-        storageLocation: true,
-      },
-      orderBy: desc(schema.MediaAssetVersion.versionNumber),
-    })
-  }
-
-  /**
-   * Get a specific version by number
-   */
-  async getVersion(
-    entityId: string,
-    versionNumber: number
-  ): Promise<(MediaAssetVersion & { storageLocation: any }) | null> {
-    const entity = await this.get(entityId)
-    if (!entity) {
-      throw new Error(`${this.getEntityName()} not found`)
-    }
-
-    const version = await this.db.query.MediaAssetVersion.findFirst({
-      where: and(
-        eq(schema.MediaAssetVersion.assetId, entityId),
-        eq(schema.MediaAssetVersion.versionNumber, versionNumber)
-      ),
-      with: {
-        storageLocation: true,
-      },
-    })
-    return version ?? null
-  }
-
-  /**
-   * Restore an entity to a specific version
-   */
-  async restoreVersion(entityId: string, versionNumber: number): Promise<MediaAsset> {
-    const version = await this.getVersion(entityId, versionNumber)
-    if (!version) {
-      throw new Error(`Version ${versionNumber} not found for ${this.getEntityName()}`)
-    }
-
-    return this.requireRow(
-      await this.db
-        .update(schema.MediaAsset)
-        .set({
-          currentVersionId: version.id,
-          updatedAt: new Date(),
-        })
-        .where(eq(schema.MediaAsset.id, entityId))
-        .returning(),
-      'restore version'
-    )
-  }
-
-  /**
-   * Delete a specific version (but not the current one)
-   */
-  async deleteVersion(entityId: string, versionNumber: number): Promise<void> {
-    const entity = await this.get(entityId)
-    if (!entity) {
-      throw new Error(`${this.getEntityName()} not found`)
-    }
-
-    const version = await this.getVersion(entityId, versionNumber)
-    if (!version) {
-      throw new Error(`Version ${versionNumber} not found`)
-    }
-
-    // Don't allow deletion of the current version
-    if ((entity as any).currentVersionId === version.id) {
-      throw new Error('Cannot delete the current version')
-    }
-
-    // Clean up thumbnails for this version before deleting
-    const { ThumbnailService } = await import('./thumbnail-service')
-    const thumbnailService = new ThumbnailService(
-      this.requireOrganization(),
-      this.userId || 'system',
-      this.db
-    )
-    await thumbnailService.deleteThumbnailsForSource(version.id)
-
-    // `deleteThumbnailsForSource` drops the S3 objects but only SOFT-deletes the rows,
-    // and a thumbnail is a separate MediaAsset pointing back here through
-    // `derivedFromVersionId` (NO ACTION) — so the version delete below would still be
-    // blocked by them. Purge the derived assets outright.
-    const derived = await this.db
-      .selectDistinct({ assetId: schema.MediaAssetVersion.assetId })
-      .from(schema.MediaAssetVersion)
-      .where(eq(schema.MediaAssetVersion.derivedFromVersionId, version.id))
-    if (derived.length > 0) {
-      await purgeMediaAssets(
-        this.db,
-        derived.map((d) => d.assetId)
-      )
-    }
-
-    await this.db
-      .delete(schema.MediaAssetVersion)
-      .where(eq(schema.MediaAssetVersion.id, version.id))
-  }
-
-  /**
-   * Get the latest version for an entity
-   */
-  async getLatestVersion(
-    entityId: string
-  ): Promise<(MediaAssetVersion & { storageLocation: any }) | null> {
-    const version = await this.db.query.MediaAssetVersion.findFirst({
-      where: eq(schema.MediaAssetVersion.assetId, entityId),
-      with: {
-        storageLocation: true,
-      },
-      orderBy: desc(schema.MediaAssetVersion.versionNumber),
-    })
-    return version ?? null
-  }
-
-  /**
-   * Copy all versions from one entity to another
-   */
-  async copyVersions(sourceEntityId: string, targetEntityId: string): Promise<MediaAssetVersion[]> {
-    const sourceVersions = await this.getVersions(sourceEntityId)
-    const copiedVersions: MediaAssetVersion[] = []
-
-    for (const sourceVersion of sourceVersions) {
-      // Versions without a storage location have no content to copy.
-      if (!sourceVersion.storageLocationId) continue
-
-      const copiedVersion = await this.createVersion(
-        targetEntityId,
-        sourceVersion.storageLocationId,
-        {
-          // Copy metadata but exclude entity-specific fields
-          size: sourceVersion.size,
-          mimeType: sourceVersion.mimeType,
-        }
-      )
-      copiedVersions.push(copiedVersion)
-    }
-
-    return copiedVersions
-  }
-
-  // ============= Helper Methods =============
-
-  /**
-   * Check if query string is a valid asset kind (proper type guard)
-   */
-  private isAssetKind(query: string): query is AssetKind {
-    return VALID_ASSET_KINDS.includes(query.toUpperCase() as AssetKind)
-  }
-
-  /**
-   * Validate asset kind
-   */
-  private async validateAssetKind(kind: AssetKind): Promise<void> {
-    if (!this.isAssetKind(kind)) {
-      throw new Error(`Invalid asset kind: ${kind}`)
-    }
-  }
-
-  /**
-   * Validate kind conversion
-   */
-  private async validateKindConversion(from: AssetKind, to: AssetKind): Promise<void> {
-    const allowedConversions: Record<AssetKind, AssetKind[]> = {
-      TEMP_UPLOAD: ['INLINE_IMAGE', 'EMAIL_ATTACHMENT', 'USER_AVATAR'],
-      EMAIL_ATTACHMENT: ['INLINE_IMAGE'],
-      INLINE_IMAGE: ['THUMBNAIL'],
-      USER_AVATAR: [],
-      THUMBNAIL: [],
-      SYSTEM_BLOB: [],
-      DOCUMENT: [],
-      VIDEO: [],
-      AUDIO: [],
-      STORYBOARD: [],
-    }
-
-    if (!allowedConversions[from]?.includes(to)) {
-      throw new Error(`Cannot convert ${from} to ${to}`)
-    }
-  }
-
-  /**
-   * Generate search snippet for search results
-   */
-  private generateSearchSnippet(asset: MediaAsset, query: string): string {
-    const parts: string[] = []
-
-    if (asset.name?.toLowerCase().includes(query.toLowerCase())) {
-      parts.push(`Name: ${asset.name}`)
-    }
-
-    if (asset.kind.toLowerCase().includes(query.toLowerCase())) {
-      parts.push(`Kind: ${asset.kind}`)
-    }
-
-    if (asset.mimeType?.toLowerCase().includes(query.toLowerCase())) {
-      parts.push(`Type: ${asset.mimeType}`)
-    }
-
-    return parts.join(' | ') || asset.name || `${asset.kind} asset`
+  private async inTransaction<T>(
+    client: DatabaseClient | undefined,
+    fn: (tx: Transaction) => Promise<T>
+  ): Promise<T> {
+    if (client) return fn(client as Transaction)
+    return this.getTx((tx) => fn(tx as Transaction))
   }
 }
 
 // Export factory functions for creating service instances
 export const createMediaAssetService = (organizationId?: string, userId?: string) =>
   new MediaAssetService(organizationId, userId)
-
-// Export singleton instance (with default db, no specific organization)
-// export const mediaAssetService = new MediaAssetService()


### PR DESCRIPTION
PR 5a, the first of Phase 5 (`plans/attachments/05-core-services.md` §5.2).

`MediaAssetService` goes **1,592 → 728 lines** (a deprecated facade); the behaviour moves into
`files/assets/` as `db`-first functions with reads split from writes. No consumer outside `files/`
changes. **512 passed / 27 files** (from 455 / 24).

## Org scope is now unconditional — and that closes three real holes

The legacy bodies were `if (this.organizationId) filters.push(...)`, so a service constructed
without an organization queried across tenants. I verified each of these against the committed code
rather than taking the report's word:

1. **`getLatestVersion` had no organization filter in any statement.** It queried
   `MediaAssetVersion` by bare `assetId` and never loaded the asset. Interface-only today — the
   other `getLatestVersion` hits in the repo are `FileService` and a workflow node, different
   classes — so this is hardening, not a live fix.
2. **`createFromFolderFile` looked the `FolderFile` up by bare id** (`where: eq(FolderFile.id, fileId)`),
   so a caller holding a file id could mint a `MediaAsset` over another tenant's bytes. **Its single
   caller pre-validates** — `document-service.ts` looks the file up with `id` *and* `organizationId`
   and bails when absent — so this was **defence-in-depth, not a live hole**. Worth knowing rather
   than overstating.
3. **`deleteAsset`'s `WHERE currentVersionId IN (...)` pointer sweep** had no scope at all, and the
   `currentVersionId` moves in `restoreAssetVersion` / `createAssetVersion` updated by bare id.

## Other behaviour changes

- **Errors are `AuxxError` subclasses** — `NotFoundError` (missing asset/version/location),
  `BadRequestError` (invalid kind), `ConflictError` (deleting the current version). All were bare
  `Error`, so every one surfaced as a 500.
- **Version `size`/`mimeType` inherit from the `StorageLocation` row when omitted.** The legacy
  spread `{ size: undefined }` over the location's values and persisted NULL.
- **`getDownloadRefForVersion` returns the durable public URL** for a public asset with an
  `externalUrl` instead of always presigning — the rule `getDownloadRef` has followed since Phase 2.
  The two used to disagree.

## Dead code

The nine methods §5.2 lists were each re-verified zero-caller and deleted. **Six more it does not
list** went too: `getDownloadInfo`, `copyVersions`, `search`, `count`, `listByKind`,
`findByMimeType`. Dropping `count`/`list`'s dynamic filter map also retires the memoised
`static get columns()` — and with it the `getTableColumns` collection hazard documented on that
getter.

## Where the plan is wrong

- **`getStorageManager` is not dead.** §5.2 lists it for deletion; it has four internal callers, two
  of which (`getContent`, 8 call sites, and `streamContent`) **survive this PR — because §5.2's
  `assets/` layout contains no content-read function at all.** §5.1 names `getContent` as part of
  the "real API", yet no Phase-5 PR gives it a home. That extraction needs one.
- **`findAssetByChecksum` should not exist.** `MediaAsset` has no checksum column (`FolderFile` does
  — this was copy-pasted from `FileService`), and the legacy body ignores its argument and returns
  whichever live asset the org filter yields first. Zero callers, but `ContentAccessible` declares
  it, so it stays on the facade **with the bug documented and deliberately not ported** — porting
  would launder a bug into the new module.
- **`copyAssetVersions` should not exist** — `MediaAssetService.copyVersions` has zero callers; the
  only `copyVersions` traffic is `FileService`'s.
- **Collapsing the six download accessors is not free.** `getDownloadUrls` is a deliberate 3-query
  batch; routing it through `getAssetDownloadRef` would make it 3N. Hence `resolveAssetDownloadRef`,
  the db-free tail both share. **5b and 5c will hit this too** — the plan should name the seam or
  they will duplicate the URL policy.
- **§5.2 omits the thumbnail collaborator.** Both delete paths did
  `await import('./thumbnail-service')` *inside the function body* — exactly what the `FilesCtx`
  contract forbids. Hence `assets/ports.ts`, which **PR 5f will need to implement**.

## Deliberately left open

- **`insertVersion`'s `StorageLocation` lookup is not org-scoped**, on purpose:
  `StorageLocation.organizationId` is nullable for backfill compatibility, so an equality filter
  would make every pre-backfill row invisible and version creation would start failing on legacy
  locations. `MediaAsset.organizationId` and `FolderFile.organizationId` are both `NOT NULL`, so
  scoping those hides nothing.
- **§5.6.1's open question stands:** `MediaAssetVersion.deletedAt` is still not filtered on read, so
  a soft-deleted current version is still presigned and served. That is a ~15-call-site behaviour
  change and was not decided here.
- `getContent`/`streamContent` remain on `StorageManager` rather than a port — unconverted, not
  converted-and-hidden.

## What a typed contract refused

`getDownloadRefForVersion` addresses versions by **number**; `getAssetDownloadRef` takes a version
**id**. The compiler refused `{ versionId: 3 }` — two id spaces the old class blurred behind
`version?: number | 'latest' | 'current'`. The facade now resolves number → row first.

`Database | Transaction` will not satisfy a `Transaction` slot, which every `db?: DatabaseClient`
facade parameter hit. The unavoidable cast is isolated in one private `inTransaction` method that
reproduces `BaseService.getTx` verbatim and is documented as what Phase 6 deletes. **There is no
cast anywhere in the new module.**

## Verification

- `packages/lib` typecheck **`src/` clean**; `apps/web`, `@auxx/worker`, `@auxx/api` clean against
  their baselines.
- `src/files`: **512 passed / 27 files**. New tests use **zero `vi.mock`**.
- Full `packages/lib`: 11,543 passed. Three failures, all pre-existing and all passing in isolation:
  the two known load-sensitive timeouts plus `utils/rate-limiter/__tests__/pacer.test.ts`, which is
  load-sensitive in the same way and untouched here.
- `apps/web` subset: 55 passed, 1 failed — the known #1818 `mock-completeness` guard.
  *"lets the files/ service graph import cleanly"* passes.

## Note for reviewers

Edits in `packages/lib` need a rebuild before `apps/*` see them (known repo footgun).