### PR TITLE
refactor(files): attachment queries and mutations as functions

### DIFF
--- a/packages/lib/src/files/attachments/__tests__/attachment-mutations.test.ts
+++ b/packages/lib/src/files/attachments/__tests__/attachment-mutations.test.ts
@@ -1,0 +1,302 @@
+// packages/lib/src/files/attachments/__tests__/attachment-mutations.test.ts
+
+/**
+ * `attachments/attachment-mutations.ts` — the write half of what
+ * `AttachmentService` was. **Zero `vi.mock` calls**, as with every test written
+ * to the `files/` contract.
+ *
+ * The assertions worth having here are the ones the legacy code could not make:
+ * the file/asset XOR is a `BadRequestError` rather than a bare `Error`, the
+ * organization on the row comes from `ctx` and never from the payload, and the
+ * update path writes a closed set of columns instead of spreading an `any`.
+ */
+
+import { schema } from '@auxx/database'
+import type { AttachmentEntity } from '@auxx/database/types'
+import { describe, expect, it } from 'vitest'
+import { BadRequestError, NotFoundError } from '../../../errors'
+import { makeCtx, makeDb, TEST_IDS } from '../../__tests__/support'
+import {
+  assertExactlyOneTarget,
+  createAttachment,
+  deleteAttachment,
+  updateAttachment,
+} from '../attachment-mutations'
+
+const TABLES = { Attachment: schema.Attachment }
+
+const AT = new Date('2026-01-01T00:00:00.000Z')
+
+function anAttachment(overrides: Partial<AttachmentEntity> = {}): AttachmentEntity {
+  return {
+    id: 'att_1',
+    organizationId: TEST_IDS.organizationId,
+    entityType: 'MESSAGE',
+    entityId: 'msg_1',
+    role: 'ATTACHMENT',
+    title: 'invoice.pdf',
+    caption: null,
+    sort: 1,
+    fileId: null,
+    fileVersionId: null,
+    assetId: TEST_IDS.assetId,
+    assetVersionId: null,
+    contentId: null,
+    createdById: TEST_IDS.userId,
+    createdAt: AT,
+    ...overrides,
+  }
+}
+
+describe('assertExactlyOneTarget', () => {
+  it('refuses both sides at once', () => {
+    expect(() =>
+      assertExactlyOneTarget({
+        entityType: 'MESSAGE',
+        entityId: 'msg_1',
+        fileId: 'ff_1',
+        assetId: 'ast_1',
+      })
+    ).toThrow(BadRequestError)
+  })
+
+  it('refuses neither side', () => {
+    expect(() => assertExactlyOneTarget({ entityType: 'MESSAGE', entityId: 'msg_1' })).toThrow(
+      BadRequestError
+    )
+  })
+
+  it('refuses a version id without its own parent id', () => {
+    expect(() =>
+      assertExactlyOneTarget({
+        entityType: 'MESSAGE',
+        entityId: 'msg_1',
+        fileVersionId: 'fv_1',
+      })
+    ).toThrow(BadRequestError)
+    expect(() =>
+      assertExactlyOneTarget({
+        entityType: 'MESSAGE',
+        entityId: 'msg_1',
+        assetVersionId: 'av_1',
+      })
+    ).toThrow(BadRequestError)
+  })
+
+  it('accepts one side with its version pinned', () => {
+    expect(() =>
+      assertExactlyOneTarget({
+        entityType: 'MESSAGE',
+        entityId: 'msg_1',
+        assetId: 'ast_1',
+        assetVersionId: 'av_1',
+      })
+    ).not.toThrow()
+  })
+})
+
+describe('createAttachment', () => {
+  it('takes the organization from ctx, never from the payload', async () => {
+    const db = makeDb({ select: [[]], insert: [[anAttachment()]], tables: TABLES })
+
+    await createAttachment(makeCtx({ db: db.db, organizationId: 'org_owner' }), {
+      entityType: 'MESSAGE',
+      entityId: 'msg_1',
+      assetId: 'ast_1',
+    })
+
+    expect(db.inserts[0]?.values).toMatchObject({ organizationId: 'org_owner' })
+  })
+
+  it('defaults role to ATTACHMENT and picks the next sort position', async () => {
+    const db = makeDb({ select: [[{ sort: 7 }]], insert: [[anAttachment()]], tables: TABLES })
+
+    await createAttachment(makeCtx({ db: db.db }), {
+      entityType: 'MESSAGE',
+      entityId: 'msg_1',
+      assetId: 'ast_1',
+    })
+
+    expect(db.inserts[0]?.values).toMatchObject({ role: 'ATTACHMENT', sort: 8 })
+  })
+
+  it('starts sort at 1 on a host with no attachments yet', async () => {
+    const db = makeDb({ select: [[]], insert: [[anAttachment()]], tables: TABLES })
+
+    await createAttachment(makeCtx({ db: db.db }), {
+      entityType: 'COMMENT',
+      entityId: 'cmt_1',
+      fileId: 'ff_1',
+    })
+
+    expect(db.inserts[0]?.values).toMatchObject({ sort: 1 })
+  })
+
+  it('skips the sort lookup when the caller supplies a position', async () => {
+    const db = makeDb({ insert: [[anAttachment()]], tables: TABLES })
+
+    await createAttachment(makeCtx({ db: db.db }), {
+      entityType: 'MESSAGE',
+      entityId: 'msg_1',
+      assetId: 'ast_1',
+      sort: 3,
+    })
+
+    expect(db.journal.ops('db')).toEqual(['insert'])
+  })
+
+  it('scopes the sort lookup to the organization and the host', async () => {
+    const db = makeDb({ select: [[]], insert: [[anAttachment()]], tables: TABLES })
+
+    await createAttachment(makeCtx({ db: db.db, organizationId: 'org_owner' }), {
+      entityType: 'MESSAGE',
+      entityId: 'msg_1',
+      assetId: 'ast_1',
+    })
+
+    const where = JSON.stringify(db.wheres[0]?.predicate)
+    expect(where).toContain('org_owner')
+    expect(where).toContain('msg_1')
+  })
+
+  it('honours a caller-supplied id, for deterministic inbound-mail creation', async () => {
+    const db = makeDb({ select: [[]], insert: [[anAttachment()]], tables: TABLES })
+
+    await createAttachment(makeCtx({ db: db.db }), {
+      id: 'att_deterministic',
+      entityType: 'MESSAGE',
+      entityId: 'msg_1',
+      assetId: 'ast_1',
+    })
+
+    expect(db.inserts[0]?.values).toMatchObject({ id: 'att_deterministic' })
+  })
+
+  it('omits id entirely when none is supplied, so the column default applies', async () => {
+    const db = makeDb({ select: [[]], insert: [[anAttachment()]], tables: TABLES })
+
+    await createAttachment(makeCtx({ db: db.db }), {
+      entityType: 'MESSAGE',
+      entityId: 'msg_1',
+      assetId: 'ast_1',
+    })
+
+    expect(Object.hasOwn(db.inserts[0]?.values as object, 'id')).toBe(false)
+  })
+
+  it('is a 400, not a 500, when the target is malformed', async () => {
+    const db = makeDb({ tables: TABLES })
+
+    const result = await createAttachment(makeCtx({ db: db.db }), {
+      entityType: 'MESSAGE',
+      entityId: 'msg_1',
+      fileId: 'ff_1',
+      assetId: 'ast_1',
+    })
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+    // Rejected before anything was written.
+    expect(db.inserts).toEqual([])
+  })
+
+  it('names the target when the insert returns nothing, which means a foreign key failure', async () => {
+    const db = makeDb({ select: [[]], insert: [[]], tables: TABLES })
+
+    const result = await createAttachment(makeCtx({ db: db.db }), {
+      entityType: 'MESSAGE',
+      entityId: 'msg_1',
+      assetId: 'ast_missing',
+    })
+
+    expect(result._unsafeUnwrapErr().message).toContain("MediaAsset 'ast_missing'")
+  })
+})
+
+describe('updateAttachment', () => {
+  it('writes only the fields the input names', async () => {
+    const db = makeDb({
+      select: [[anAttachment()]],
+      update: [[anAttachment({ caption: 'front door' })]],
+      tables: TABLES,
+    })
+
+    await updateAttachment(makeCtx({ db: db.db }), 'att_1', { caption: 'front door' })
+
+    expect(db.updates[0]?.values).toEqual({ caption: 'front door' })
+  })
+
+  it('treats caption null as a clear and caption undefined as untouched', async () => {
+    const cleared = makeDb({
+      select: [[anAttachment()]],
+      update: [[anAttachment()]],
+      tables: TABLES,
+    })
+    await updateAttachment(makeCtx({ db: cleared.db }), 'att_1', { caption: null })
+    expect(cleared.updates[0]?.values).toEqual({ caption: null })
+
+    const untouched = makeDb({
+      select: [[anAttachment()]],
+      update: [[anAttachment()]],
+      tables: TABLES,
+    })
+    await updateAttachment(makeCtx({ db: untouched.db }), 'att_1', { title: 'renamed' })
+    expect(untouched.updates[0]?.values).toEqual({ title: 'renamed' })
+  })
+
+  it('refuses an empty patch rather than emitting SET with nothing in it', async () => {
+    const db = makeDb({ select: [[anAttachment()]], tables: TABLES })
+
+    const result = await updateAttachment(makeCtx({ db: db.db }), 'att_1', {})
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+    expect(db.updates).toEqual([])
+  })
+
+  it('scopes both the existence check and the UPDATE to the organization', async () => {
+    const db = makeDb({
+      select: [[anAttachment()]],
+      update: [[anAttachment()]],
+      tables: TABLES,
+    })
+
+    await updateAttachment(makeCtx({ db: db.db, organizationId: 'org_owner' }), 'att_1', {
+      sort: 4,
+    })
+
+    expect(JSON.stringify(db.wheres[0]?.predicate)).toContain('org_owner')
+    expect(JSON.stringify(db.wheres[1]?.predicate)).toContain('org_owner')
+  })
+
+  it('is a 404 for a row in another organization', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+
+    const result = await updateAttachment(makeCtx({ db: db.db }), 'att_elsewhere', { sort: 1 })
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+  })
+})
+
+describe('deleteAttachment', () => {
+  it('deletes with the organization in the predicate, not the id alone', async () => {
+    // The legacy `detachFromEntity` deleted on `eq(id, …)` with no organization
+    // filter at all — a cross-tenant delete to anyone holding an id. That method
+    // is gone; this is the only delete path left, and it is scoped.
+    const db = makeDb({ select: [[anAttachment()]], tables: TABLES })
+
+    await deleteAttachment(makeCtx({ db: db.db, organizationId: 'org_owner' }), 'att_1')
+
+    expect(db.deletes).toEqual([{ table: 'Attachment' }])
+    const where = JSON.stringify(db.wheres.at(-1)?.predicate)
+    expect(where).toContain('org_owner')
+    expect(where).toContain('att_1')
+  })
+
+  it('is a 404 for a row that does not exist, and writes nothing', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+
+    const result = await deleteAttachment(makeCtx({ db: db.db }), 'att_missing')
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+    expect(db.deletes).toEqual([])
+  })
+})

--- a/packages/lib/src/files/attachments/__tests__/attachment-queries.test.ts
+++ b/packages/lib/src/files/attachments/__tests__/attachment-queries.test.ts
@@ -1,0 +1,404 @@
+// packages/lib/src/files/attachments/__tests__/attachment-queries.test.ts
+
+/**
+ * `attachments/attachment-queries.ts` — the read half of what
+ * `AttachmentService` was.
+ *
+ * As with every test written to the `files/` contract, **`vi.mock` is called
+ * zero times in this file**: `ctx.db` is a parameter, so there is nothing left
+ * to intercept at module scope.
+ *
+ * Two properties matter beyond "it returns rows":
+ *
+ * 1. **Organization scope is in the statement.** The db stub does not interpret
+ *    SQL, but it stores the predicate the code built and the bound values
+ *    survive `JSON.stringify`, which is enough to prove the filter is present.
+ *    It is *not* enough to prove which column each condition names — this
+ *    package's `@auxx/database` mock hands out `{}` for every table — and that
+ *    distinction belongs to the integration lane.
+ * 2. **`fetchAttachmentsForEntities` stays one statement.** It is the mail and
+ *    comment list read path; a regression to one query per entity would be
+ *    invisible in a unit test that only checked the returned map, so the
+ *    statement count is asserted directly off the journal.
+ */
+
+import { schema } from '@auxx/database'
+import type { AttachmentEntity } from '@auxx/database/types'
+import { describe, expect, it } from 'vitest'
+import { BadRequestError, NotFoundError } from '../../../errors'
+import { makeCtx, makeDb, TEST_IDS } from '../../__tests__/support'
+import {
+  fetchAttachmentsForEntities,
+  getAttachment,
+  getEntityAttachments,
+  requireAttachment,
+  resolveAttachmentVersion,
+} from '../attachment-queries'
+
+const TABLES = {
+  Attachment: schema.Attachment,
+  FileVersion: schema.FileVersion,
+  FolderFile: schema.FolderFile,
+  MediaAsset: schema.MediaAsset,
+  MediaAssetVersion: schema.MediaAssetVersion,
+}
+
+const AT = new Date('2026-01-01T00:00:00.000Z')
+
+function anAttachment(overrides: Partial<AttachmentEntity> = {}): AttachmentEntity {
+  return {
+    id: 'att_1',
+    organizationId: TEST_IDS.organizationId,
+    entityType: 'MESSAGE',
+    entityId: 'msg_1',
+    role: 'ATTACHMENT',
+    title: 'invoice.pdf',
+    caption: null,
+    sort: 1,
+    fileId: null,
+    fileVersionId: null,
+    assetId: TEST_IDS.assetId,
+    assetVersionId: null,
+    contentId: null,
+    createdById: TEST_IDS.userId,
+    createdAt: AT,
+    ...overrides,
+  }
+}
+
+/** The `where` predicate handed to the n-th builder chain, stringified. */
+function whereOf(db: ReturnType<typeof makeDb>, index: number): string {
+  return JSON.stringify(db.wheres[index]?.predicate)
+}
+
+describe('getAttachment', () => {
+  it('returns the row and scopes the read to the caller organization', async () => {
+    const db = makeDb({ select: [[anAttachment()]], tables: TABLES })
+
+    const result = await getAttachment(makeCtx({ db: db.db, organizationId: 'org_other' }), 'att_1')
+
+    expect(result._unsafeUnwrap()).toEqual(anAttachment())
+    const where = whereOf(db, 0)
+    expect(where).toContain('org_other')
+    expect(where).toContain('att_1')
+  })
+
+  it('returns ok(null) rather than an error when nothing matches', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+
+    const result = await getAttachment(makeCtx({ db: db.db }), 'att_missing')
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toBeNull()
+  })
+
+  it('scopes unconditionally — there is no "no organization" branch left', async () => {
+    // The legacy body reached `requireOrganization()`, which threw; the extracted
+    // read takes a required `ctx.organizationId`, so the filter is always in the
+    // statement and no construction site can widen it.
+    const db = makeDb({ select: [[anAttachment()]], tables: TABLES })
+
+    await getAttachment(makeCtx({ db: db.db }), 'att_1')
+
+    expect(whereOf(db, 0)).toContain(TEST_IDS.organizationId)
+  })
+})
+
+describe('getEntityAttachments', () => {
+  it('scopes on organization, entity type and entity id together', async () => {
+    const db = makeDb({ select: [[anAttachment()]], tables: TABLES })
+
+    const result = await getEntityAttachments(makeCtx({ db: db.db }), 'MESSAGE', 'msg_1')
+
+    expect(result._unsafeUnwrap()).toHaveLength(1)
+    const where = whereOf(db, 0)
+    expect(where).toContain(TEST_IDS.organizationId)
+    expect(where).toContain('MESSAGE')
+    expect(where).toContain('msg_1')
+  })
+
+  it('returns an empty array rather than an error for a host with nothing on it', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+
+    const result = await getEntityAttachments(makeCtx({ db: db.db }), 'COMMENT', 'cmt_1')
+
+    expect(result._unsafeUnwrap()).toEqual([])
+  })
+})
+
+describe('fetchAttachmentsForEntities', () => {
+  it('issues exactly one statement no matter how many entities are asked for', async () => {
+    // The regression this guards: routing the batch through the single-entity
+    // helper turns one query into N. Two hundred message ids is a realistic mail
+    // page, and the count below must stay 1.
+    const entityIds = Array.from({ length: 200 }, (_, i) => `msg_${i}`)
+    const db = makeDb({ select: [[]], tables: TABLES })
+
+    await fetchAttachmentsForEntities(makeCtx({ db: db.db }), 'MESSAGE', entityIds)
+
+    expect(db.journal.ops('db')).toEqual(['select'])
+  })
+
+  it('touches the database not at all for an empty id list', async () => {
+    const db = makeDb({ tables: TABLES })
+
+    const result = await fetchAttachmentsForEntities(makeCtx({ db: db.db }), 'MESSAGE', [])
+
+    expect(result._unsafeUnwrap().size).toBe(0)
+    expect(db.journal.ops('db')).toEqual([])
+  })
+
+  it('joins both libraries in one statement rather than resolving them per row', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+
+    await fetchAttachmentsForEntities(makeCtx({ db: db.db }), 'MESSAGE', ['msg_1'])
+
+    // Both `leftJoin`s ride the single chain; a second `select` would mean the
+    // asset or file lookup had been pulled out into its own round trip.
+    expect(db.journal.entries.filter((e) => e.op === 'select')).toHaveLength(1)
+    const projection = db.journal.entries[0]?.detail?.projection as Record<string, unknown>
+    expect(Object.keys(projection).sort()).toEqual([
+      'assetId',
+      'assetMimeType',
+      'assetName',
+      'assetSize',
+      'createdAt',
+      'entityId',
+      'fileId',
+      'fileMimeType',
+      'fileName',
+      'fileSize',
+      'id',
+      'role',
+      'sort',
+      'title',
+    ])
+  })
+
+  it('scopes the batch to the caller organization', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+
+    await fetchAttachmentsForEntities(
+      makeCtx({ db: db.db, organizationId: 'org_other' }),
+      'MESSAGE',
+      ['msg_1', 'msg_2']
+    )
+
+    const where = whereOf(db, 0)
+    expect(where).toContain('org_other')
+    expect(where).toContain('msg_1')
+    expect(where).toContain('msg_2')
+  })
+
+  it('groups by host and flattens the asset side onto fileId', async () => {
+    const db = makeDb({
+      select: [
+        [
+          {
+            id: 'att_1',
+            entityId: 'msg_1',
+            role: 'ATTACHMENT',
+            title: 'invoice.pdf',
+            sort: 1,
+            createdAt: AT,
+            assetId: 'ast_1',
+            fileId: null,
+            assetName: 'invoice.pdf',
+            assetMimeType: 'application/pdf',
+            assetSize: 2048,
+            fileName: null,
+            fileMimeType: null,
+            fileSize: null,
+          },
+          {
+            id: 'att_2',
+            entityId: 'msg_1',
+            role: 'INLINE',
+            title: null,
+            sort: 2,
+            createdAt: AT,
+            assetId: null,
+            fileId: 'ff_1',
+            assetName: null,
+            assetMimeType: null,
+            assetSize: null,
+            fileName: 'logo.png',
+            fileMimeType: 'image/png',
+            fileSize: 512,
+          },
+          {
+            id: 'att_3',
+            entityId: 'msg_2',
+            role: 'ATTACHMENT',
+            title: null,
+            sort: 1,
+            createdAt: AT,
+            assetId: null,
+            fileId: 'ff_2',
+            assetName: null,
+            assetMimeType: null,
+            assetSize: null,
+            fileName: null,
+            fileMimeType: null,
+            fileSize: null,
+          },
+        ],
+      ],
+      tables: TABLES,
+    })
+
+    const grouped = (
+      await fetchAttachmentsForEntities(makeCtx({ db: db.db }), 'MESSAGE', [
+        'msg_1',
+        'msg_2',
+        'msg_3',
+      ])
+    )._unsafeUnwrap()
+
+    expect([...grouped.keys()].sort()).toEqual(['msg_1', 'msg_2'])
+    expect(grouped.get('msg_1')).toEqual([
+      {
+        id: 'att_1',
+        role: 'ATTACHMENT',
+        title: 'invoice.pdf',
+        sort: 1,
+        createdAt: AT,
+        type: 'asset',
+        fileId: 'ast_1',
+        name: 'invoice.pdf',
+        mimeType: 'application/pdf',
+        size: 2048,
+      },
+      {
+        id: 'att_2',
+        role: 'INLINE',
+        title: null,
+        sort: 2,
+        createdAt: AT,
+        type: 'file',
+        fileId: 'ff_1',
+        name: 'logo.png',
+        mimeType: 'image/png',
+        size: 512,
+      },
+    ])
+    // A host with no rows is absent from the map, not present-and-empty.
+    expect(grouped.has('msg_3')).toBe(false)
+    // A dangling join falls back to the placeholder name rather than throwing.
+    expect(grouped.get('msg_2')?.[0]?.name).toBe('Untitled')
+  })
+})
+
+describe('requireAttachment', () => {
+  it('throws NotFoundError so a failure inside a caller transaction rolls it back', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+
+    await expect(requireAttachment(makeCtx({ db: db.db }), 'att_missing')).rejects.toBeInstanceOf(
+      NotFoundError
+    )
+  })
+})
+
+describe('resolveAttachmentVersion', () => {
+  it('reads the pinned asset version directly, without asking the asset', async () => {
+    const db = makeDb({
+      select: [
+        [anAttachment({ assetVersionId: TEST_IDS.versionId })],
+        [
+          {
+            id: TEST_IDS.versionId,
+            mimeType: 'application/pdf',
+            size: 2048,
+            storageLocationId: TEST_IDS.storageLocationId,
+          },
+        ],
+      ],
+      tables: TABLES,
+    })
+
+    const resolved = (
+      await resolveAttachmentVersion(makeCtx({ db: db.db }), 'att_1')
+    )._unsafeUnwrap()
+
+    expect(resolved).toEqual({
+      attachment: anAttachment({ assetVersionId: TEST_IDS.versionId }),
+      side: 'asset',
+      isPinned: true,
+      versionId: TEST_IDS.versionId,
+      storageLocationId: TEST_IDS.storageLocationId,
+      mimeType: 'application/pdf',
+      size: 2048,
+    })
+    // Two statements: the attachment, then the version. The pinned branch never
+    // touches `MediaAsset`.
+    expect(db.journal.ops('db')).toEqual(['select', 'select'])
+  })
+
+  it('reports versionId as null on the unpinned branch, because the projection has none', async () => {
+    // The unpinned lookups join `FolderFile`/`MediaAsset` to their current
+    // version and select only mime/size/location — no `id`. The legacy `any`
+    // let callers read `version.id` there and silently get `undefined`.
+    const db = makeDb({
+      select: [
+        [anAttachment({ assetId: 'ast_1' })],
+        [{ mimeType: 'image/png', size: 512, storageLocationId: TEST_IDS.storageLocationId }],
+      ],
+      tables: TABLES,
+    })
+
+    const resolved = (
+      await resolveAttachmentVersion(makeCtx({ db: db.db }), 'att_1')
+    )._unsafeUnwrap()
+
+    expect(resolved.isPinned).toBe(false)
+    expect(resolved.versionId).toBeNull()
+    expect(resolved.side).toBe('asset')
+  })
+
+  it('resolves the file side through FolderFile.currentVersionId', async () => {
+    const db = makeDb({
+      select: [
+        [anAttachment({ assetId: null, fileId: 'ff_1' })],
+        [{ mimeType: 'text/csv', size: 99, storageLocationId: TEST_IDS.storageLocationId }],
+      ],
+      tables: TABLES,
+    })
+
+    const resolved = (
+      await resolveAttachmentVersion(makeCtx({ db: db.db }), 'att_1')
+    )._unsafeUnwrap()
+
+    expect(resolved.side).toBe('file')
+    expect(resolved.mimeType).toBe('text/csv')
+  })
+
+  it('is a 400, not a 500, when the row references neither library', async () => {
+    const db = makeDb({
+      select: [[anAttachment({ assetId: null, fileId: null })]],
+      tables: TABLES,
+    })
+
+    const result = await resolveAttachmentVersion(makeCtx({ db: db.db }), 'att_1')
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+  })
+
+  it('is a 400 when the resolved version has no storage location', async () => {
+    const db = makeDb({
+      select: [[anAttachment()], [{ mimeType: null, size: null, storageLocationId: null }]],
+      tables: TABLES,
+    })
+
+    const result = await resolveAttachmentVersion(makeCtx({ db: db.db }), 'att_1')
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+  })
+
+  it('is a 404, not a 500, when the attachment does not exist', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+
+    const result = await resolveAttachmentVersion(makeCtx({ db: db.db }), 'att_missing')
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+  })
+})

--- a/packages/lib/src/files/attachments/attachment-mutations.ts
+++ b/packages/lib/src/files/attachments/attachment-mutations.ts
@@ -1,0 +1,285 @@
+// packages/lib/src/files/attachments/attachment-mutations.ts
+
+/**
+ * `Attachment` writes.
+ *
+ * Reads live in `attachments/attachment-queries.ts` —
+ * `docs/lib-module-guide.md` §5.
+ *
+ * ## Scope comes from `ctx`, never from the payload
+ *
+ * The legacy `processCreateData` read `data.organizationId` first and only fell
+ * back to the service's own scope, so a caller could write a row into an
+ * organization it was not acting for. Following `assets/asset-mutations.ts` and
+ * `storage/locations.ts`, {@link CreateAttachmentInput} carries no
+ * `organizationId` at all.
+ *
+ * ## No authorization here
+ *
+ * `AttachmentService` took an optional `Authorizer` callback and awaited it at
+ * the top of eleven methods. No production site ever passed one, so every one of
+ * those awaits was a no-op — and a permission hook below the router is exactly
+ * what `docs/lib-module-guide.md` §6 forbids. The callback is gone; the router
+ * asserts (`attachmentRouter` already runs `assertFieldValueHostsWritable`).
+ *
+ * ## `Attachment` has no `updatedAt` and no `deletedAt`
+ *
+ * So no write here takes a `now` (nothing to stamp) and `deleteAttachment` is a
+ * real `DELETE`, not a soft delete.
+ */
+
+import { schema } from '@auxx/database'
+import type { AttachmentEntity } from '@auxx/database/types'
+import { and, desc, eq } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import type { AuxxError } from '../../errors'
+import { BadRequestError, NotFoundError } from '../../errors'
+import type { AttachmentRole, EntityType } from '../core/types'
+import type { FilesCtx } from '../ctx'
+import { guard } from '../guard'
+import { requireAttachment } from './attachment-queries'
+
+/**
+ * Everything needed to persist one `Attachment` row.
+ *
+ * Exactly one of the file pair (`fileId`, optionally `fileVersionId`) or the
+ * asset pair (`assetId`, optionally `assetVersionId`) must be supplied — see
+ * {@link assertExactlyOneTarget}.
+ */
+export interface CreateAttachmentInput {
+  /** Caller-supplied id, for deterministic inbound-mail attachment creation. */
+  id?: string
+  entityType: EntityType
+  entityId: string
+  /** Defaults to `'ATTACHMENT'`, matching the column default. */
+  role?: AttachmentRole
+  title?: string
+  caption?: string
+  /** Explicit display position. Defaults to one past the host's current highest. */
+  sort?: number
+  /** MIME content id, for `cid:` inline resolution in mail bodies. */
+  contentId?: string | null
+  /** The actor to attribute the row to. Optional: several production writers have no actor. */
+  createdById?: string
+  fileId?: string
+  fileVersionId?: string
+  assetId?: string
+  assetVersionId?: string
+}
+
+/**
+ * The mutable fields of an `Attachment`.
+ *
+ * Deliberately a closed set rather than the legacy `.set({ ...(data as any) })`,
+ * which accepted any object and would happily have moved a row to a different
+ * `organizationId`, `entityId` or target file. Re-targeting an attachment is a
+ * delete plus a create, not an update.
+ *
+ * `caption: null` clears the caption; omitting it leaves the caption alone.
+ */
+export interface UpdateAttachmentInput {
+  role?: AttachmentRole
+  title?: string | null
+  caption?: string | null
+  sort?: number
+  fileVersionId?: string | null
+  assetVersionId?: string | null
+}
+
+/**
+ * Create one `Attachment` row.
+ *
+ * A single `INSERT` (plus one `SELECT` for the default sort position), so it
+ * takes `ctx` rather than a `Transaction`. A caller already inside one passes
+ * `{ ...ctx, db: tx }` — which is what `comments/comment-service.ts` and the
+ * upload processors do today via the facade's `withTx`.
+ *
+ * @param ctx Scope and database. `ctx.organizationId` owns the row.
+ * @param input The row to write. See {@link CreateAttachmentInput}.
+ */
+export async function createAttachment(
+  ctx: FilesCtx,
+  input: CreateAttachmentInput
+): Promise<Result<AttachmentEntity, AuxxError>> {
+  return guard(
+    async () => {
+      assertExactlyOneTarget(input)
+
+      const sort = input.sort ?? (await nextSort(ctx, input.entityType, input.entityId))
+
+      const [created] = await ctx.db
+        .insert(schema.Attachment)
+        .values({
+          ...(input.id ? { id: input.id } : {}),
+          organizationId: ctx.organizationId,
+          entityType: input.entityType,
+          entityId: input.entityId,
+          role: input.role ?? 'ATTACHMENT',
+          title: input.title,
+          caption: input.caption,
+          sort,
+          contentId: input.contentId ?? null,
+          fileId: input.fileId,
+          fileVersionId: input.fileVersionId,
+          assetId: input.assetId,
+          assetVersionId: input.assetVersionId,
+          createdById: input.createdById ?? null,
+        })
+        .returning()
+
+      if (!created) {
+        // `RETURNING` on a successful single-row insert cannot be empty, so
+        // reaching here means the statement was rejected — in practice a foreign
+        // key violation on the target. Name the target: the legacy message did,
+        // and it is the difference between a five-minute and a one-hour debug.
+        const target = input.fileId
+          ? `FolderFile '${input.fileId}'`
+          : `MediaAsset '${input.assetId}'`
+        throw new BadRequestError(
+          `Failed to create attachment: no row returned. Verify that ${target} exists and belongs to organization '${ctx.organizationId}'.`
+        )
+      }
+
+      return created as AttachmentEntity
+    },
+    'Failed to create attachment',
+    {
+      entityType: input.entityType,
+      entityId: input.entityId,
+      organizationId: ctx.organizationId,
+    }
+  )
+}
+
+/**
+ * Update the mutable fields of one attachment.
+ *
+ * Org-scoped on both the existence check and the `UPDATE` itself. Returns
+ * `err(NotFoundError)` for a row that does not exist or belongs to another
+ * organization, and `err(BadRequestError)` when the input names no field —
+ * `UPDATE … SET` with nothing to set is a Drizzle runtime error, so it is
+ * refused up front instead.
+ */
+export async function updateAttachment(
+  ctx: FilesCtx,
+  attachmentId: string,
+  input: UpdateAttachmentInput
+): Promise<Result<AttachmentEntity, AuxxError>> {
+  return guard(
+    async () => {
+      await requireAttachment(ctx, attachmentId)
+
+      const values: Record<string, unknown> = {}
+      if (input.role !== undefined) values.role = input.role
+      if (input.title !== undefined) values.title = input.title
+      if (input.caption !== undefined) values.caption = input.caption
+      if (input.sort !== undefined) values.sort = input.sort
+      if (input.fileVersionId !== undefined) values.fileVersionId = input.fileVersionId
+      if (input.assetVersionId !== undefined) values.assetVersionId = input.assetVersionId
+
+      if (Object.keys(values).length === 0) {
+        throw new BadRequestError('No attachment fields to update')
+      }
+
+      const [updated] = await ctx.db
+        .update(schema.Attachment)
+        .set(values)
+        .where(
+          and(
+            eq(schema.Attachment.id, attachmentId),
+            eq(schema.Attachment.organizationId, ctx.organizationId)
+          )
+        )
+        .returning()
+
+      if (!updated) throw new NotFoundError(`Attachment ${attachmentId} not found`)
+      return updated as AttachmentEntity
+    },
+    'Failed to update attachment',
+    { attachmentId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Delete one attachment.
+ *
+ * A hard delete — `Attachment` has no `deletedAt`. The row is the *link*, not
+ * the file: removing it detaches the file from its host and leaves both the
+ * `FolderFile`/`MediaAsset` and its stored bytes intact.
+ *
+ * Returns `err(NotFoundError)` when the row does not exist or belongs to another
+ * organization, so a caller cannot use this to probe for ids outside its tenant.
+ */
+export async function deleteAttachment(
+  ctx: FilesCtx,
+  attachmentId: string
+): Promise<Result<void, AuxxError>> {
+  return guard(
+    async () => {
+      await requireAttachment(ctx, attachmentId)
+      await ctx.db
+        .delete(schema.Attachment)
+        .where(
+          and(
+            eq(schema.Attachment.id, attachmentId),
+            eq(schema.Attachment.organizationId, ctx.organizationId)
+          )
+        )
+    },
+    'Failed to delete attachment',
+    { attachmentId, organizationId: ctx.organizationId }
+  )
+}
+
+// ============= Internal helpers (throw; the guard converts at the boundary) =============
+
+/**
+ * Enforce the file/asset XOR the `Attachment` table encodes but cannot check.
+ *
+ * Four nullable columns can express "both" and "neither"; only "exactly one
+ * side, and a version id only alongside its own parent id" is meaningful. The
+ * legacy `validateTarget` threw bare `Error`s here, which
+ * `auxxErrorMiddleware` mapped to 500; these are caller mistakes, so they are
+ * `BadRequestError` (400).
+ */
+export function assertExactlyOneTarget(input: CreateAttachmentInput): void {
+  const fileSide = !!(input.fileId || input.fileVersionId)
+  const assetSide = !!(input.assetId || input.assetVersionId)
+  if (fileSide === assetSide) {
+    throw new BadRequestError(
+      'Provide exactly one of fileId/fileVersionId or assetId/assetVersionId'
+    )
+  }
+  if (input.fileVersionId && !input.fileId) {
+    throw new BadRequestError('fileVersionId requires fileId')
+  }
+  if (input.assetVersionId && !input.assetId) {
+    throw new BadRequestError('assetVersionId requires assetId')
+  }
+}
+
+/**
+ * One past the highest `sort` currently on the host entity.
+ *
+ * Read-then-write, so two concurrent creates on the same host can pick the same
+ * position. That is the behaviour `AttachmentService.nextSort` has always had
+ * and it is benign: `sort` only orders a display list, ties break on
+ * `createdAt`, and there is no unique constraint to violate. Documented rather
+ * than fixed, because fixing it means a sequence or a lock, which is a
+ * behaviour decision this refactor is not the place to make.
+ */
+async function nextSort(ctx: FilesCtx, entityType: EntityType, entityId: string): Promise<number> {
+  const [row] = await ctx.db
+    .select({ sort: schema.Attachment.sort })
+    .from(schema.Attachment)
+    .where(
+      and(
+        eq(schema.Attachment.organizationId, ctx.organizationId),
+        eq(schema.Attachment.entityType, entityType),
+        eq(schema.Attachment.entityId, entityId)
+      )
+    )
+    .orderBy(desc(schema.Attachment.sort))
+    .limit(1)
+  return (row?.sort ?? 0) + 1
+}

--- a/packages/lib/src/files/attachments/attachment-queries.ts
+++ b/packages/lib/src/files/attachments/attachment-queries.ts
@@ -1,0 +1,427 @@
+// packages/lib/src/files/attachments/attachment-queries.ts
+
+/**
+ * `Attachment` reads.
+ *
+ * Split from `attachments/attachment-mutations.ts` per
+ * `docs/lib-module-guide.md` §5 — "a file that both queries and mutates is the
+ * first step back toward a service class", which is how
+ * `core/attachment-service.ts` reached 1,386 lines.
+ *
+ * ## What `Attachment` is
+ *
+ * A polymorphic join row: `(entityType, entityId)` names the host — a message, a
+ * comment, a field value, a QC checklist item — and exactly one of `fileId`
+ * (file library) or `assetId` (media library) names the target. The optional
+ * `fileVersionId` / `assetVersionId` **pins** the attachment to one version
+ * instead of tracking whichever version is current.
+ *
+ * ## Two things the schema settles, so no read below has to guess
+ *
+ * - `Attachment.organizationId` is `NOT NULL`, so `eq(...)` scoping hides no
+ *   rows. Unlike `StorageLocation` (nullable for backfill compatibility), there
+ *   is no pre-backfill population to keep visible, and every read here is
+ *   org-scoped unconditionally. The legacy bodies called `requireOrganization()`
+ *   which *threw* when a service had no org — several production sites construct
+ *   one without an actor but always with an org, so this is parity, not a
+ *   loosening.
+ * - **There is no `deletedAt` column.** Attachments are hard-deleted, so no read
+ *   here filters one, and `deleteAttachment` really removes the row.
+ */
+
+import { schema } from '@auxx/database'
+import type { AttachmentEntity } from '@auxx/database/types'
+import { and, asc, eq, inArray } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import type { AuxxError } from '../../errors'
+import { BadRequestError, NotFoundError } from '../../errors'
+import type { EntityType } from '../core/types'
+import type { FilesCtx } from '../ctx'
+import { guard } from '../guard'
+
+/**
+ * The display shape {@link fetchAttachmentsForEntities} groups rows into.
+ *
+ * Flattens the file/asset split away: `type` says which side the row came from
+ * and `fileId` carries that side's id, so a renderer never has to branch on two
+ * nullable columns. Re-exported by the deprecated `AttachmentService` facade
+ * because `messages/attachment-transformers.ts` imports it from there.
+ */
+export interface GroupedAttachmentInfo {
+  id: string
+  role: string
+  title?: string | null
+  sort: number
+  createdAt: Date
+  type: 'file' | 'asset'
+  /** The `MediaAsset.id` when `type` is `'asset'`, the `FolderFile.id` when it is `'file'`. */
+  fileId: string
+  name: string
+  mimeType?: string | null
+  size?: number | null
+}
+
+/** Which library an attachment points at. */
+export type AttachmentSide = 'file' | 'asset'
+
+/**
+ * The bytes an attachment currently resolves to.
+ *
+ * **This type is the point of the extraction.** The legacy `resolveVersion`
+ * returned `{ attachment, version: any, storageLocationId, side, isPinned }`,
+ * and the `any` hid a live defect: two of its four branches project a version
+ * row *without* an `id` column and none of them project a `name`, yet
+ * `getDownloadInfo` read `version.name` for the download filename. It was always
+ * `undefined`, so every unpinned download fell through to the literal
+ * `'attachment'`. A named shape refuses to compile that read, which is how the
+ * bug surfaced. `versionId` is `null` on the unpinned branches for the same
+ * reason — the projection genuinely does not fetch it.
+ */
+export interface ResolvedAttachmentVersion {
+  attachment: AttachmentEntity
+  side: AttachmentSide
+  /** True when the attachment pins a version rather than tracking the current one. */
+  isPinned: boolean
+  /** The pinned version's id. `null` when the attachment tracks the current version. */
+  versionId: string | null
+  storageLocationId: string
+  mimeType: string | null
+  size: number | null
+}
+
+/**
+ * Load one attachment, scoped to the caller's organization.
+ *
+ * Returns `ok(null)` when the row does not exist or belongs to another
+ * organization — the two collapse into one answer so a caller cannot probe for
+ * ids outside its tenant.
+ *
+ * @param ctx Scope and database. Runs unchanged on a pool or inside a caller's
+ *   transaction, because `FilesCtx.db` is `Database | Transaction`.
+ * @param attachmentId The `Attachment.id` to load.
+ */
+export async function getAttachment(
+  ctx: FilesCtx,
+  attachmentId: string
+): Promise<Result<AttachmentEntity | null, AuxxError>> {
+  return guard(
+    async () => {
+      const [row] = await ctx.db
+        .select()
+        .from(schema.Attachment)
+        .where(
+          and(
+            eq(schema.Attachment.id, attachmentId),
+            eq(schema.Attachment.organizationId, ctx.organizationId)
+          )
+        )
+        .limit(1)
+      return (row as AttachmentEntity | undefined) ?? null
+    },
+    'Failed to get attachment',
+    { attachmentId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Every attachment on one host entity, in display order.
+ *
+ * Ordered `sort` then `createdAt`, the order the legacy `getEntityAttachments`
+ * used and the one the UI renders in. `sort` is `NOT NULL DEFAULT 0`, so rows
+ * written without an explicit position tie and fall back to creation order.
+ */
+export async function getEntityAttachments(
+  ctx: FilesCtx,
+  entityType: EntityType,
+  entityId: string
+): Promise<Result<AttachmentEntity[], AuxxError>> {
+  return guard(
+    async () => {
+      const rows = await ctx.db
+        .select()
+        .from(schema.Attachment)
+        .where(
+          and(
+            eq(schema.Attachment.organizationId, ctx.organizationId),
+            eq(schema.Attachment.entityType, entityType),
+            eq(schema.Attachment.entityId, entityId)
+          )
+        )
+        .orderBy(asc(schema.Attachment.sort), asc(schema.Attachment.createdAt))
+      return rows as AttachmentEntity[]
+    },
+    'Failed to list entity attachments',
+    { entityType, entityId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * The batch loader on the mail read path: attachments for many hosts at once.
+ *
+ * **One statement, whatever `entityIds.length` is.** A single `SELECT` over
+ * `Attachment` with the two libraries `LEFT JOIN`ed in, filtered by
+ * `entityId IN (…)`, grouped in memory afterwards. `messages/` calls this once
+ * per page of messages and `comments/` once per page of comments, so turning it
+ * into a per-entity loop would multiply every mail list render by its page size.
+ * The join shape, the projection, the `WHERE` and the `ORDER BY` are carried
+ * over verbatim from `AttachmentService.fetchAttachmentsForEntities`.
+ *
+ * An empty `entityIds` short-circuits to an empty map without touching the
+ * database — `inArray(col, [])` is not a query worth issuing.
+ *
+ * Entities with no attachments are simply absent from the map rather than
+ * present with an empty array; callers already treat a miss as "none".
+ *
+ * @param ctx Scope and database.
+ * @param entityType The host kind every id in `entityIds` belongs to.
+ * @param entityIds The hosts to load for.
+ */
+export async function fetchAttachmentsForEntities(
+  ctx: FilesCtx,
+  entityType: EntityType,
+  entityIds: string[]
+): Promise<Result<Map<string, GroupedAttachmentInfo[]>, AuxxError>> {
+  return guard(
+    async () => {
+      if (entityIds.length === 0) return new Map<string, GroupedAttachmentInfo[]>()
+
+      const rows = await ctx.db
+        .select({
+          id: schema.Attachment.id,
+          entityId: schema.Attachment.entityId,
+          role: schema.Attachment.role,
+          title: schema.Attachment.title,
+          sort: schema.Attachment.sort,
+          createdAt: schema.Attachment.createdAt,
+          assetId: schema.Attachment.assetId,
+          fileId: schema.Attachment.fileId,
+          // Asset info
+          assetName: schema.MediaAsset.name,
+          assetMimeType: schema.MediaAsset.mimeType,
+          assetSize: schema.MediaAsset.size,
+          // File info
+          fileName: schema.FolderFile.name,
+          fileMimeType: schema.FolderFile.mimeType,
+          fileSize: schema.FolderFile.size,
+        })
+        .from(schema.Attachment)
+        .leftJoin(schema.MediaAsset, eq(schema.Attachment.assetId, schema.MediaAsset.id))
+        .leftJoin(schema.FolderFile, eq(schema.Attachment.fileId, schema.FolderFile.id))
+        .where(
+          and(
+            eq(schema.Attachment.entityType, entityType),
+            inArray(schema.Attachment.entityId, entityIds),
+            eq(schema.Attachment.organizationId, ctx.organizationId)
+          )
+        )
+        .orderBy(asc(schema.Attachment.sort), asc(schema.Attachment.createdAt))
+
+      const grouped = new Map<string, GroupedAttachmentInfo[]>()
+      for (const row of rows) {
+        const bucket = grouped.get(row.entityId) ?? []
+        bucket.push({
+          id: row.id,
+          role: row.role,
+          title: row.title,
+          sort: row.sort,
+          createdAt: row.createdAt,
+          type: row.assetId ? 'asset' : 'file',
+          // Non-null by the XOR invariant `createAttachment` enforces at write
+          // time; a row with neither could only come from a direct database
+          // write. Kept as the legacy `!` had it rather than dropped, because
+          // silently filtering rows would be a behaviour change under cover of
+          // a refactor.
+          fileId: (row.assetId ?? row.fileId) as string,
+          name: row.assetName || row.fileName || 'Untitled',
+          mimeType: row.assetMimeType || row.fileMimeType,
+          size: row.assetSize || row.fileSize,
+        })
+        grouped.set(row.entityId, bucket)
+      }
+      return grouped
+    },
+    'Failed to fetch attachments for entities',
+    { entityType, entityCount: entityIds.length, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Resolve which stored bytes an attachment currently points at.
+ *
+ * Four branches, one per (side, pinned?) combination:
+ *
+ * | side  | pinned | resolves through                                   |
+ * | ----- | ------ | -------------------------------------------------- |
+ * | file  | yes    | `FileVersion` by `fileVersionId`                    |
+ * | file  | no     | `FolderFile.currentVersionId` → `FileVersion`       |
+ * | asset | yes    | `MediaAssetVersion` by `assetVersionId`             |
+ * | asset | no     | `MediaAsset.currentVersionId` → `MediaAssetVersion` |
+ *
+ * The version and library lookups are keyed by ids read off the attachment row,
+ * which was already org-scoped by {@link requireAttachment}, so they need no
+ * organization filter of their own — a foreign tenant's version id is not
+ * reachable without first holding that tenant's attachment.
+ *
+ * Throws `NotFoundError` for a missing attachment, `BadRequestError` for a row
+ * that references neither library or whose target has no storage location.
+ */
+export async function resolveAttachmentVersion(
+  ctx: FilesCtx,
+  attachmentId: string
+): Promise<Result<ResolvedAttachmentVersion, AuxxError>> {
+  return guard(
+    async () => requireResolvedVersion(ctx, attachmentId),
+    'Failed to resolve attachment version',
+    { attachmentId, organizationId: ctx.organizationId }
+  )
+}
+
+// ============= Internal helpers (throw; the guard converts at the boundary) =============
+
+/**
+ * Load an attachment or throw `NotFoundError`.
+ *
+ * Exported for `attachment-mutations.ts`, which needs the same org-scoped
+ * existence check before it writes and must throw rather than return `err()` so
+ * a failure inside a caller's transaction rolls it back.
+ */
+export async function requireAttachment(
+  ctx: FilesCtx,
+  attachmentId: string
+): Promise<AttachmentEntity> {
+  const [row] = await ctx.db
+    .select()
+    .from(schema.Attachment)
+    .where(
+      and(
+        eq(schema.Attachment.id, attachmentId),
+        eq(schema.Attachment.organizationId, ctx.organizationId)
+      )
+    )
+    .limit(1)
+  if (!row) throw new NotFoundError(`Attachment ${attachmentId} not found`)
+  return row as AttachmentEntity
+}
+
+/** {@link resolveAttachmentVersion}'s body, throwing rather than wrapped. */
+export async function requireResolvedVersion(
+  ctx: FilesCtx,
+  attachmentId: string
+): Promise<ResolvedAttachmentVersion> {
+  const attachment = await requireAttachment(ctx, attachmentId)
+
+  if (attachment.fileId) {
+    const target = attachment.fileVersionId
+      ? await loadFileVersionById(ctx, attachment.fileVersionId)
+      : await loadCurrentFileVersion(ctx, attachment.fileId)
+    return finish(attachment, 'file', !!attachment.fileVersionId, target)
+  }
+
+  if (attachment.assetId) {
+    const target = attachment.assetVersionId
+      ? await loadAssetVersionById(ctx, attachment.assetVersionId)
+      : await loadCurrentAssetVersion(ctx, attachment.assetId)
+    return finish(attachment, 'asset', !!attachment.assetVersionId, target)
+  }
+
+  throw new BadRequestError('Attachment has no valid file or asset reference')
+}
+
+/** What every branch of {@link requireResolvedVersion} narrows down to. */
+interface VersionTarget {
+  versionId: string | null
+  storageLocationId: string | null
+  mimeType: string | null
+  size: number | null
+}
+
+function finish(
+  attachment: AttachmentEntity,
+  side: AttachmentSide,
+  isPinned: boolean,
+  target: VersionTarget | null
+): ResolvedAttachmentVersion {
+  if (!target?.storageLocationId) {
+    throw new BadRequestError('No storage location available for attachment')
+  }
+  return {
+    attachment,
+    side,
+    isPinned,
+    versionId: target.versionId,
+    storageLocationId: target.storageLocationId,
+    mimeType: target.mimeType,
+    size: target.size,
+  }
+}
+
+async function loadFileVersionById(
+  ctx: FilesCtx,
+  fileVersionId: string
+): Promise<VersionTarget | null> {
+  const [row] = await ctx.db
+    .select({
+      id: schema.FileVersion.id,
+      mimeType: schema.FileVersion.mimeType,
+      size: schema.FileVersion.size,
+      storageLocationId: schema.FileVersion.storageLocationId,
+    })
+    .from(schema.FileVersion)
+    .where(eq(schema.FileVersion.id, fileVersionId))
+    .limit(1)
+  return row ? { ...row, versionId: row.id } : null
+}
+
+async function loadCurrentFileVersion(
+  ctx: FilesCtx,
+  fileId: string
+): Promise<VersionTarget | null> {
+  const [row] = await ctx.db
+    .select({
+      mimeType: schema.FileVersion.mimeType,
+      size: schema.FileVersion.size,
+      storageLocationId: schema.FileVersion.storageLocationId,
+    })
+    .from(schema.FolderFile)
+    .innerJoin(schema.FileVersion, eq(schema.FolderFile.currentVersionId, schema.FileVersion.id))
+    .where(eq(schema.FolderFile.id, fileId))
+    .limit(1)
+  return row ? { ...row, versionId: null } : null
+}
+
+async function loadAssetVersionById(
+  ctx: FilesCtx,
+  assetVersionId: string
+): Promise<VersionTarget | null> {
+  const [row] = await ctx.db
+    .select({
+      id: schema.MediaAssetVersion.id,
+      mimeType: schema.MediaAssetVersion.mimeType,
+      size: schema.MediaAssetVersion.size,
+      storageLocationId: schema.MediaAssetVersion.storageLocationId,
+    })
+    .from(schema.MediaAssetVersion)
+    .where(eq(schema.MediaAssetVersion.id, assetVersionId))
+    .limit(1)
+  return row ? { ...row, versionId: row.id } : null
+}
+
+async function loadCurrentAssetVersion(
+  ctx: FilesCtx,
+  assetId: string
+): Promise<VersionTarget | null> {
+  const [row] = await ctx.db
+    .select({
+      mimeType: schema.MediaAssetVersion.mimeType,
+      size: schema.MediaAssetVersion.size,
+      storageLocationId: schema.MediaAssetVersion.storageLocationId,
+    })
+    .from(schema.MediaAsset)
+    .innerJoin(
+      schema.MediaAssetVersion,
+      eq(schema.MediaAsset.currentVersionId, schema.MediaAssetVersion.id)
+    )
+    .where(eq(schema.MediaAsset.id, assetId))
+    .limit(1)
+  return row ? { ...row, versionId: null } : null
+}

--- a/packages/lib/src/files/attachments/index.ts
+++ b/packages/lib/src/files/attachments/index.ts
@@ -1,0 +1,32 @@
+// packages/lib/src/files/attachments/index.ts
+
+/**
+ * `Attachment` reads and writes written to the `files/` {@link ../ctx.FilesCtx}
+ * contract. Explicit named exports only — an implicit surface is how
+ * `core/attachment-service.ts` reached 1,386 lines across 39 methods, only 12
+ * of which anything called.
+ */
+
+export type {
+  CreateAttachmentInput,
+  UpdateAttachmentInput,
+} from './attachment-mutations'
+export {
+  assertExactlyOneTarget,
+  createAttachment,
+  deleteAttachment,
+  updateAttachment,
+} from './attachment-mutations'
+export type {
+  AttachmentSide,
+  GroupedAttachmentInfo,
+  ResolvedAttachmentVersion,
+} from './attachment-queries'
+export {
+  fetchAttachmentsForEntities,
+  getAttachment,
+  getEntityAttachments,
+  requireAttachment,
+  requireResolvedVersion,
+  resolveAttachmentVersion,
+} from './attachment-queries'

--- a/packages/lib/src/files/core/attachment-service.ts
+++ b/packages/lib/src/files/core/attachment-service.ts
@@ -1,466 +1,187 @@
 // packages/lib/src/files/core/attachment-service.ts
-import { database as db, schema } from '@auxx/database'
+
+/**
+ * @deprecated A thin, deprecated facade over `files/attachments/`.
+ *
+ * Every method below delegates to a function in
+ * `files/attachments/attachment-queries.ts` or `attachment-mutations.ts`. The
+ * class survives only because it has 15 external construction sites;
+ * **PR 5h / Phase 10 move those and delete this file.** Do not add a method
+ * here — add a function to `files/attachments/` and call it with a `FilesCtx`.
+ *
+ * What changed for callers of this class, and nothing else did:
+ *
+ * - **Errors are `AuxxError` subclasses**, not bare `Error`. A missing
+ *   attachment is a `NotFoundError` (404) and a malformed create a
+ *   `BadRequestError` (400), so `auxxErrorMiddleware` maps them instead of
+ *   returning 500 for everything.
+ * - **The `Authorizer` constructor parameter is gone.** No production site ever
+ *   passed one, so the eleven `await this.ensureAuth(…)` calls were no-ops — and
+ *   a permission hook below the router is what `docs/lib-module-guide.md` §6
+ *   forbids outright. `attachmentRouter` already asserts per host.
+ * - **`create` no longer accepts `idempotencyKey`.** See {@link create}.
+ * - **`getDownloadInfo`'s filename no longer reads a column that was never
+ *   selected.** See {@link getDownloadInfo}.
+ *
+ * ## Deleted outright rather than ported, all verified zero-caller
+ *
+ * Six were `throw new Error('Not implemented')` stubs: `attachAssetToEntity`,
+ * `attachAssetVersionToEntity`, `bulkAttachFiles`, `bulkAttachAssets`,
+ * `bulkDetachFromEntity`, `bulkUpdateRoles`.
+ *
+ * Seven were implemented but unreachable *and* defective, so porting would have
+ * laundered the defect into the new module:
+ *
+ * - `detachFromEntity` and `reorderAttachments` wrote with
+ *   `where(eq(Attachment.id, …))` and **no organization filter** — a
+ *   cross-tenant delete and a cross-tenant update to anyone holding an id.
+ * - `fixAttachmentSortOrders` and `copyAttachmentsToEntity` issued one statement
+ *   per row; `getEntityAttachmentStats` issued four per attachment (it called
+ *   `resolveVersion` in a loop); `getAttachmentStats` and `getAttachmentUsage`
+ *   loaded or grouped every attachment row in the organization with no `LIMIT`.
+ * - `getWithRelations` returned the base row `as unknown as
+ *   AttachmentWithRelations` — the relations were never loaded, so every field
+ *   the type promised was `undefined`.
+ *
+ * The rest were simply unreachable: `attachFileVersionToEntity`,
+ * `moveAttachmentsToEntity`, `getAttachmentsByRole`, `getRecentAttachments`,
+ * `getAttachmentsByCreator`, `search`, `getContent`, `streamContent`,
+ * `getEntityAttachmentsByRole`.
+ *
+ * `cleanupOrphanedAttachments` and `validateAttachmentIntegrity` moved to
+ * `files/lifecycle/attachment-maintenance.ts` — whole-organization sweeps, not
+ * request-path API.
+ */
+
+import { database as db } from '@auxx/database'
 import type { AttachmentEntity as Attachment } from '@auxx/database/types'
-import { createScopedLogger } from '@auxx/logger'
-import {
-  and,
-  asc,
-  count as dCount,
-  desc,
-  eq,
-  gte,
-  ilike,
-  inArray,
-  isNotNull,
-  isNull,
-  or,
-  sql,
-} from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import type { AuxxError } from '../../errors'
+import { BadRequestError } from '../../errors'
 import type { DownloadRef } from '../adapters/base-adapter'
+import type { CreateAttachmentInput } from '../attachments/attachment-mutations'
+import {
+  createAttachment,
+  deleteAttachment,
+  updateAttachment,
+} from '../attachments/attachment-mutations'
+import type { ResolvedAttachmentVersion } from '../attachments/attachment-queries'
+import {
+  fetchAttachmentsForEntities,
+  getAttachment,
+  getEntityAttachments,
+  resolveAttachmentVersion,
+} from '../attachments/attachment-queries'
+import type { FilesCtx } from '../ctx'
 import { BaseService, type DatabaseClient } from './base-service'
 import type {
   AttachmentRole,
-  AttachmentSearchResult,
   AttachmentWithRelations,
-  BulkOperationOptions,
-  BulkOperationResult,
   CreateAttachmentRequest,
   EntityType,
   FileDownloadInfo,
-  SearchOptions,
   UpdateAttachmentRequest,
 } from './types'
 
-const logger = createScopedLogger('attachment-service')
+export type { GroupedAttachmentInfo } from '../attachments/attachment-queries'
+
 /**
- * Grouped attachment information for display
- */
-export interface GroupedAttachmentInfo {
-  id: string
-  role: string
-  title?: string | null
-  sort: number
-  createdAt: Date
-  type: 'file' | 'asset'
-  fileId: string
-  name: string
-  mimeType?: string | null
-  size?: number | null
-}
-/**
- * Authorization callback for entity access control
- */
-type Authorizer = (args: {
-  organizationId: string
-  entityType: EntityType
-  entityId: string
-  userId?: string
-}) => Promise<boolean> | boolean
-/**
- * Download descriptor for content access
- */
-export interface AttachmentDownloadDescriptor {
-  url?: string
-  stream?: NodeJS.ReadableStream
-  filename: string
-  mimeType?: string
-  size?: number
-  expiresAt?: Date
-}
-/**
- * Service for unified attachment system handling both FolderFile and MediaAsset
- * Manages attachment CRUD operations, entity relationships, and bulk operations
+ * @deprecated See the file header. Delegates to `files/attachments/`; deleted in Phase 10.
  */
 export class AttachmentService extends BaseService<
   Attachment,
   AttachmentWithRelations,
   CreateAttachmentRequest,
   UpdateAttachmentRequest,
-  AttachmentSearchResult
+  never
 > {
-  private readonly logger = createScopedLogger('attachment-service')
-  constructor(
-    organizationId?: string,
-    userId?: string,
-    dbInstance: DatabaseClient = db,
-    private authorize?: Authorizer
-  ) {
+  constructor(organizationId?: string, userId?: string, dbInstance: DatabaseClient = db) {
     super(organizationId, userId, dbInstance)
   }
+
   protected getEntityName(): string {
     return 'attachment'
   }
+
   /**
-   * Get relation includes for attachment entities
+   * @deprecated Unused. Creation runs through
+   * `attachments/attachment-mutations.ts`, which validates the file/asset XOR
+   * and picks the default sort position itself. Present only because
+   * `BaseService` declares this abstract.
    */
-  protected getRelationIncludes(): any {
-    return {
-      // Drizzle path uses explicit joins in callers; includes retained for compatibility
-    }
+  protected async processCreateData(
+    data: CreateAttachmentRequest
+  ): Promise<CreateAttachmentRequest> {
+    return data
   }
+
+  // ============= CRUD =============
+
   /**
-   * Get searchable fields for attachment search
+   * @deprecated Use `createAttachment(ctx, input)`.
+   *
+   * **`idempotencyKey` is no longer honoured, and never was.** The legacy branch
+   * it gated matched on `(organizationId, entityType, entityId, title, fileId,
+   * assetId)` and never compared the key to anything — it was only logged — so
+   * it deduplicated by payload, not by key, and returned a partial row (a
+   * fifteen-column projection cast to `Attachment`) on a hit. Nothing in the
+   * repository has ever passed the field, so rather than port a dedup rule
+   * nobody asked for, it is dropped here and recorded on
+   * `CreateAttachmentRequest`. This is the same call PR 5a made on
+   * `findAssetByChecksum`.
    */
-  protected getSearchFields(): string[] {
-    return ['title', 'caption']
-  }
-  protected async processCreateData(data: CreateAttachmentRequest): Promise<any> {
-    const orgId = data.organizationId || this.requireOrganization()
-    const userId = data.createdById ?? this.userId ?? null
-    this.validateTarget(data)
-    await this.ensureAuth(data.entityType, data.entityId)
-    const sort = data.sort ?? (await this.nextSort(data.entityType, data.entityId))
-    return {
-      ...(data.id ? { id: data.id } : {}),
-      organizationId: orgId,
+  async create(data: CreateAttachmentRequest, dbClient?: DatabaseClient): Promise<Attachment> {
+    const input: CreateAttachmentInput = {
+      id: data.id,
       entityType: data.entityType,
       entityId: data.entityId,
-      role: data.role || 'ATTACHMENT',
+      role: data.role,
       title: data.title,
       caption: data.caption,
-      sort,
-      contentId: data.contentId ?? null,
+      sort: data.sort,
+      contentId: data.contentId,
+      createdById: data.createdById ?? this.userId,
       fileId: data.fileId,
       fileVersionId: data.fileVersionId,
       assetId: data.assetId,
       assetVersionId: data.assetVersionId,
-      createdById: userId,
     }
+    return this.unwrap(await createAttachment(this.filesCtx(dbClient, data.organizationId), input))
   }
-  // ============= Private Helper Methods =============
-  /**
-   * Ensure user has access to the target entity
-   */
-  private async ensureAuth(entityType: EntityType, entityId: string): Promise<void> {
-    if (!this.authorize) return
-    const ok = await this.authorize({
-      organizationId: this.requireOrganization(),
-      entityType,
-      entityId,
-      userId: this.userId,
-    })
-    if (!ok) {
-      throw new Error('Forbidden: Access denied to entity')
-    }
-  }
-  /**
-   * Validate XOR constraint: exactly one of fileId or assetId
-   */
-  private validateTarget(data: CreateAttachmentRequest): void {
-    const fileSide = !!(data.fileId || data.fileVersionId)
-    const assetSide = !!(data.assetId || data.assetVersionId)
-    if (fileSide === assetSide) {
-      throw new Error('Provide exactly one of file* or asset*')
-    }
-    if (data.fileVersionId && !data.fileId) {
-      throw new Error('fileVersionId requires fileId')
-    }
-    if (data.assetVersionId && !data.assetId) {
-      throw new Error('assetVersionId requires assetId')
-    }
-  }
-  /**
-   * Resolve the effective version for content access: pinned → current
-   */
-  private async resolveVersion(attachmentId: string): Promise<{
-    attachment: AttachmentWithRelations
-    version: any
-    storageLocationId: string
-    side: 'file' | 'asset'
-    isPinned: boolean
-  }> {
-    const orgId = this.requireOrganization()
-    // Fetch attachment core fields
-    const [attachment] = await this.db
-      .select({
-        id: schema.Attachment.id,
-        organizationId: schema.Attachment.organizationId,
-        entityType: schema.Attachment.entityType,
-        entityId: schema.Attachment.entityId,
-        role: schema.Attachment.role,
-        title: schema.Attachment.title,
-        caption: schema.Attachment.caption,
-        sort: schema.Attachment.sort,
-        fileId: schema.Attachment.fileId,
-        fileVersionId: schema.Attachment.fileVersionId,
-        assetId: schema.Attachment.assetId,
-        assetVersionId: schema.Attachment.assetVersionId,
-        contentId: schema.Attachment.contentId,
-        createdById: schema.Attachment.createdById,
-        createdAt: schema.Attachment.createdAt,
-      })
-      .from(schema.Attachment)
-      .where(
-        and(eq(schema.Attachment.id, attachmentId), eq(schema.Attachment.organizationId, orgId))
-      )
-      .limit(1)
-    // const attachment = attRow as unknown as AttachmentWithRelations | null
-    if (!attachment) {
-      throw new Error('Attachment not found')
-    }
-    // Determine which side (file or asset) and if pinned
-    let side: 'file' | 'asset'
-    let isPinned: boolean
-    let version: any
-    if (attachment.fileId) {
-      side = 'file'
-      isPinned = !!attachment.fileVersionId
-      if (attachment.fileVersionId) {
-        const [fv] = await this.db
-          .select({
-            id: schema.FileVersion.id,
-            mimeType: schema.FileVersion.mimeType,
-            size: schema.FileVersion.size,
-            storageLocationId: schema.FileVersion.storageLocationId,
-          })
-          .from(schema.FileVersion)
-          .where(eq(schema.FileVersion.id, attachment.fileVersionId as string))
-          .limit(1)
-        version = fv
-      } else {
-        const [row] = await this.db
-          .select({
-            mimeType: schema.FileVersion.mimeType,
-            size: schema.FileVersion.size,
-            storageLocationId: schema.FileVersion.storageLocationId,
-          })
-          .from(schema.FolderFile)
-          .innerJoin(
-            schema.FileVersion,
-            eq(schema.FolderFile.currentVersionId, schema.FileVersion.id)
-          )
-          .where(eq(schema.FolderFile.id, attachment.fileId as string))
-          .limit(1)
-        version = row
-      }
-    } else if (attachment.assetId) {
-      side = 'asset'
-      isPinned = !!attachment.assetVersionId
-      if (attachment.assetVersionId) {
-        const [av] = await this.db
-          .select({
-            id: schema.MediaAssetVersion.id,
-            mimeType: schema.MediaAssetVersion.mimeType,
-            size: schema.MediaAssetVersion.size,
-            storageLocationId: schema.MediaAssetVersion.storageLocationId,
-          })
-          .from(schema.MediaAssetVersion)
-          .where(eq(schema.MediaAssetVersion.id, attachment.assetVersionId as string))
-          .limit(1)
-        version = av
-      } else {
-        const [row] = await this.db
-          .select({
-            mimeType: schema.MediaAssetVersion.mimeType,
-            size: schema.MediaAssetVersion.size,
-            storageLocationId: schema.MediaAssetVersion.storageLocationId,
-          })
-          .from(schema.MediaAsset)
-          .innerJoin(
-            schema.MediaAssetVersion,
-            eq(schema.MediaAsset.currentVersionId, schema.MediaAssetVersion.id)
-          )
-          .where(eq(schema.MediaAsset.id, attachment.assetId as string))
-          .limit(1)
-        version = row
-      }
-    } else {
-      throw new Error('Attachment has no valid file or asset reference')
-    }
-    if (!version || !(version as any).storageLocationId) {
-      throw new Error('No storage location available for attachment')
-    }
-    return {
-      attachment,
-      version,
-      storageLocationId: (version as any).storageLocationId,
-      side,
-      isPinned,
-    }
-  }
-  /**
-   * Calculate next sort order for entity attachments
-   */
-  private async nextSort(entityType: EntityType, entityId: string): Promise<number> {
-    const orgId = this.requireOrganization()
-    const [row] = await this.db
-      .select({ sort: schema.Attachment.sort })
-      .from(schema.Attachment)
-      .where(
-        and(
-          eq(schema.Attachment.organizationId, orgId),
-          eq(schema.Attachment.entityType, entityType),
-          eq(schema.Attachment.entityId, entityId)
-        )
-      )
-      .orderBy(desc(schema.Attachment.sort))
-      .limit(1)
-    return ((row?.sort as number | undefined) ?? 0) + 1
-  }
-  // ============= Attachment CRUD Operations =============
-  /**
-   * Create a new attachment with idempotency support
-   */
-  async create(data: CreateAttachmentRequest): Promise<Attachment> {
-    const orgId = data.organizationId || this.requireOrganization()
-    // Check for existing attachment if idempotency key provided
-    if (data.idempotencyKey) {
-      const [existing] = await this.db
-        .select({
-          id: schema.Attachment.id,
-          role: schema.Attachment.role,
-          title: schema.Attachment.title,
-          caption: schema.Attachment.caption,
-          sort: schema.Attachment.sort,
-          fileId: schema.Attachment.fileId,
-          fileVersionId: schema.Attachment.fileVersionId,
-          assetId: schema.Attachment.assetId,
-          assetVersionId: schema.Attachment.assetVersionId,
-          entityId: schema.Attachment.entityId,
-          entityType: schema.Attachment.entityType,
-          createdAt: schema.Attachment.createdAt,
-          createdById: schema.Attachment.createdById,
-        })
-        .from(schema.Attachment)
-        .where(
-          and(
-            eq(schema.Attachment.organizationId, orgId),
-            eq(schema.Attachment.entityType, data.entityType),
-            eq(schema.Attachment.entityId, data.entityId),
-            sql`coalesce(${schema.Attachment.title}, '') = ${data.title ?? ''}`,
-            sql`coalesce(${schema.Attachment.fileId}, '') = ${data.fileId ?? ''}`,
-            sql`coalesce(${schema.Attachment.assetId}, '') = ${data.assetId ?? ''}`
-          )
-        )
-        .limit(1)
-      if (existing) {
-        this.logger.info('Returning existing attachment for idempotency key', {
-          attachmentId: (existing as any).id,
-          idempotencyKey: data.idempotencyKey,
-        })
-        return existing as unknown as Attachment
-      }
-    }
-    const processed = await this.processCreateData(data)
-    const [created] = await this.db.insert(schema.Attachment).values(processed).returning()
 
-    // Safety check: If insert fails, provide clear error
-    if (!created) {
-      const target = data.fileId
-        ? `FolderFile '${data.fileId}'`
-        : data.assetId
-          ? `MediaAsset '${data.assetId}'`
-          : 'unknown target'
-      throw new Error(
-        `Failed to create attachment: Database insert returned no data. ` +
-          `This usually indicates a foreign key constraint violation. ` +
-          `Please verify that ${target} exists and belongs to organization '${orgId}'.`
-      )
-    }
+  /** @deprecated Use `getAttachment(ctx, attachmentId)`. */
+  async get(id: string, dbClient?: DatabaseClient): Promise<Attachment | null> {
+    return this.unwrap(await getAttachment(this.filesCtx(dbClient), id))
+  }
 
-    return created as unknown as Attachment
+  /** @deprecated Use `updateAttachment(ctx, attachmentId, input)`. */
+  async update(
+    id: string,
+    data: UpdateAttachmentRequest,
+    dbClient?: DatabaseClient
+  ): Promise<Attachment> {
+    return this.unwrap(await updateAttachment(this.filesCtx(dbClient), id, data))
   }
-  /**
-   * Get an attachment by ID with organization scoping
-   */
-  async get(id: string): Promise<Attachment | null> {
-    const [row] = await this.db
-      .select()
-      .from(schema.Attachment)
-      .where(
-        and(
-          eq(schema.Attachment.id, id),
-          eq(schema.Attachment.organizationId, this.requireOrganization())
-        )
-      )
-      .limit(1)
-    return (row as unknown as Attachment) || null
+
+  /** @deprecated Use `deleteAttachment(ctx, attachmentId)`. */
+  async delete(id: string, dbClient?: DatabaseClient): Promise<void> {
+    this.unwrap(await deleteAttachment(this.filesCtx(dbClient), id))
   }
-  /**
-   * Get an attachment with all populated relations
-   */
-  async getWithRelations(id: string): Promise<AttachmentWithRelations | null> {
-    // Minimal implementation returns base row; callers should join explicitly if needed
-    const base = await this.get(id)
-    return (base as unknown as AttachmentWithRelations) || null
-  }
-  /**
-   * Update an existing attachment
-   */
-  async update(id: string, data: UpdateAttachmentRequest): Promise<Attachment> {
-    const orgId = this.requireOrganization()
-    // Ensure attachment exists and is accessible
-    const existing = await this.get(id)
-    if (!existing) {
-      throw new Error('Attachment not found')
-    }
-    await this.ensureAuth(existing.entityType as EntityType, existing.entityId)
-    const [updated] = await this.db
-      .update(schema.Attachment)
-      .set({ ...(data as any) })
-      .where(and(eq(schema.Attachment.id, id), eq(schema.Attachment.organizationId, orgId)))
-      .returning()
-    return updated as unknown as Attachment
-  }
-  /**
-   * Delete an attachment
-   */
-  async delete(id: string): Promise<void> {
-    const orgId = this.requireOrganization()
-    // Get attachment to check authorization
-    const attachment = await this.get(id)
-    if (!attachment) {
-      throw new Error('Attachment not found')
-    }
-    await this.ensureAuth(attachment.entityType as EntityType, attachment.entityId)
-    await this.db
-      .delete(schema.Attachment)
-      .where(and(eq(schema.Attachment.id, id), eq(schema.Attachment.organizationId, orgId)))
-  }
-  // ============= Entity Attachment Management =============
-  /**
-   * Get all attachments for a specific entity
-   */
+
+  // ============= Entity attachment management =============
+
+  /** @deprecated Use `getEntityAttachments(ctx, entityType, entityId)`. */
   async getEntityAttachments(entityType: EntityType, entityId: string): Promise<Attachment[]> {
-    await this.ensureAuth(entityType, entityId)
-    const rows = await this.db
-      .select()
-      .from(schema.Attachment)
-      .where(
-        and(
-          eq(schema.Attachment.organizationId, this.requireOrganization()),
-          eq(schema.Attachment.entityType, entityType),
-          eq(schema.Attachment.entityId, entityId)
-        )
-      )
-      .orderBy(asc(schema.Attachment.sort), asc(schema.Attachment.createdAt))
-    return rows as unknown as Attachment[]
+    return this.unwrap(await getEntityAttachments(this.filesCtx(), entityType, entityId))
   }
+
   /**
-   * Get attachments for entity with specific role
-   */
-  async getEntityAttachmentsByRole(
-    entityType: EntityType,
-    entityId: string,
-    role: AttachmentRole
-  ): Promise<Attachment[]> {
-    await this.ensureAuth(entityType, entityId)
-    const rows = await this.db
-      .select()
-      .from(schema.Attachment)
-      .where(
-        and(
-          eq(schema.Attachment.organizationId, this.requireOrganization()),
-          eq(schema.Attachment.entityType, entityType),
-          eq(schema.Attachment.entityId, entityId),
-          eq(schema.Attachment.role, role)
-        )
-      )
-      .orderBy(asc(schema.Attachment.sort), asc(schema.Attachment.createdAt))
-    return rows as unknown as Attachment[]
-  }
-  /**
-   * Attach a file to an entity
+   * @deprecated Use `createAttachment(ctx, { fileId, entityType, entityId, … })`.
+   *
+   * A named-argument spelling of {@link create} for the file side, kept because
+   * `comments/comment-service.ts` and `messages/message-attachment.service.ts`
+   * still call it. It has no counterpart in `files/attachments/` on purpose:
+   * an argument shuffle is not worth a second exported name.
    */
   async attachFileToEntity(
     fileId: string,
@@ -468,919 +189,135 @@ export class AttachmentService extends BaseService<
     entityId: string,
     createdById: string,
     role: AttachmentRole = 'ATTACHMENT',
-    options?: {
-      title?: string
-      caption?: string
-      sort?: number
-    }
-  ) {
-    return this.create({
-      entityType,
-      entityId,
-      role,
-      title: options?.title,
-      caption: options?.caption,
-      fileId,
-      createdById,
-      sort: options?.sort,
-    })
-  }
-  /**
-   * Attach a specific file version to an entity
-   */
-  async attachFileVersionToEntity(
-    fileId: string,
-    fileVersionId: string,
-    entityType: EntityType,
-    entityId: string,
-    createdById: string,
-    role: AttachmentRole = 'ATTACHMENT',
-    options?: {
-      title?: string
-      caption?: string
-      sort?: number
-    }
-  ) {
-    return this.create({
-      entityType,
-      entityId,
-      role,
-      title: options?.title,
-      caption: options?.caption,
-      fileId,
-      fileVersionId,
-      createdById,
-      sort: options?.sort,
-    })
-  }
-  /**
-   * Attach a media asset to an entity
-   */
-  async attachAssetToEntity(
-    assetId: string,
-    entityType: EntityType,
-    entityId: string,
-    createdById: string,
-    role?: AttachmentRole,
-    options?: {
-      title?: string
-      caption?: string
-      sort?: number
-    }
+    options?: { title?: string; caption?: string; sort?: number }
   ): Promise<Attachment> {
-    // TODO: Implement asset attachment to entity
-    throw new Error('Not implemented')
+    return this.unwrap(
+      await createAttachment(this.filesCtx(), {
+        entityType,
+        entityId,
+        role,
+        title: options?.title,
+        caption: options?.caption,
+        sort: options?.sort,
+        fileId,
+        createdById,
+      })
+    )
   }
-  /**
-   * Attach a specific asset version to an entity
-   */
-  async attachAssetVersionToEntity(
-    assetId: string,
-    assetVersionId: string,
-    entityType: EntityType,
-    entityId: string,
-    createdById: string,
-    role?: AttachmentRole,
-    options?: {
-      title?: string
-      caption?: string
-      sort?: number
-    }
-  ): Promise<Attachment> {
-    // TODO: Implement asset version attachment to entity
-    throw new Error('Not implemented')
-  }
-  /**
-   * Detach a specific attachment from an entity
-   */
-  async detachFromEntity(
-    entityType: EntityType,
-    entityId: string,
-    attachmentId: string
-  ): Promise<void> {
-    await this.ensureAuth(entityType, entityId)
-    await this.db.delete(schema.Attachment).where(eq(schema.Attachment.id, attachmentId))
-  }
-  // ============= Bulk Operations =============
-  /**
-   * Attach multiple files to an entity
-   */
-  async bulkAttachFiles(
-    fileIds: string[],
-    entityType: EntityType,
-    entityId: string,
-    createdById: string,
-    role?: AttachmentRole,
-    options?: BulkOperationOptions
-  ): Promise<BulkOperationResult<Attachment>> {
-    // TODO: Implement bulk file attachment
-    throw new Error('Not implemented')
-  }
-  /**
-   * Attach multiple assets to an entity
-   */
-  async bulkAttachAssets(
-    assetIds: string[],
-    entityType: EntityType,
-    entityId: string,
-    createdById: string,
-    role?: AttachmentRole,
-    options?: BulkOperationOptions
-  ): Promise<BulkOperationResult<Attachment>> {
-    // TODO: Implement bulk asset attachment
-    throw new Error('Not implemented')
-  }
-  /**
-   * Remove all attachments from an entity
-   */
-  async bulkDetachFromEntity(entityType: EntityType, entityId: string): Promise<void> {
-    // TODO: Implement bulk attachment removal
-    throw new Error('Not implemented')
-  }
-  /**
-   * Reorder attachments for an entity
-   */
-  async reorderAttachments(
-    entityType: EntityType,
-    entityId: string,
-    attachmentIds: string[]
-  ): Promise<void> {
-    await this.ensureAuth(entityType, entityId)
-    const orgId = this.requireOrganization()
 
-    // Update each attachment's sort order
-    for (const [idx, attachmentId] of attachmentIds.entries()) {
-      await this.db
-        .update(schema.Attachment)
-        .set({ sort: idx + 1 })
-        .where(eq(schema.Attachment.id, attachmentId))
-    }
-
-    logger.info('Reordered attachments', {
-      entityType,
-      entityId,
-      count: attachmentIds.length,
-      organizationId: orgId,
-    })
-  }
   /**
-   * Update attachment roles in bulk
+   * @deprecated Use `fetchAttachmentsForEntities(ctx, entityType, entityIds)`.
+   *
+   * Still one query for the whole batch — see the note on the extracted
+   * function. This is the mail and comment list read path.
    */
-  async bulkUpdateRoles(
-    attachmentIds: string[],
-    newRole: AttachmentRole,
-    options?: BulkOperationOptions
-  ): Promise<BulkOperationResult<Attachment>> {
-    // TODO: Implement bulk role updates
-    throw new Error('Not implemented')
+  async fetchAttachmentsForEntities(entityType: EntityType, entityIds: string[]) {
+    return this.unwrap(await fetchAttachmentsForEntities(this.filesCtx(), entityType, entityIds))
   }
-  // ============= Attachment Content & Access =============
+
+  // ============= Content & access =============
+
   /**
-   * Get download reference for an attachment
+   * @deprecated Awaiting PR 5c (`folder-files/`), which is where the unpinned
+   * branches below belong.
+   *
+   * A pinned attachment presigns its own `StorageLocation` directly. An unpinned
+   * one has to ask the owning library which version is current *and* how that
+   * library's download policy resolves (public URL vs presign), which is
+   * `FileService` / `MediaAssetService` today. Once `folder-files/` exists this
+   * collapses into one `getAttachmentDownloadRef(ctx, deps, attachmentId)` the
+   * way `assets/download.ts` collapsed six accessors into one.
    */
   async getDownloadRef(id: string): Promise<DownloadRef> {
-    const { attachment, storageLocationId, version } = await this.resolveVersion(id)
-    // If attachment is pinned to a specific version, get download ref directly from storage
-    if (attachment.fileVersionId || attachment.assetVersionId) {
+    const resolved = await this.resolveVersion(id)
+    const { attachment } = resolved
+
+    if (resolved.isPinned) {
       const { createStorageManager } = await import('../storage/storage-manager')
       const storageManager = createStorageManager(this.requireOrganization())
       return await storageManager.getDownloadRef({
-        locationId: storageLocationId,
+        locationId: resolved.storageLocationId,
         filename: attachment.title || undefined,
-        mimeType: (version as any)?.mimeType || undefined,
+        mimeType: resolved.mimeType || undefined,
       })
     }
-    // Otherwise delegate to appropriate service for current version
+
     if (attachment.fileId) {
       const { FileService } = await import('./file-service')
       const fileService = new FileService(this.requireOrganization(), this.userId, this.db)
       return await fileService.getDownloadRef(attachment.fileId)
     }
-    if (attachment.assetId) {
-      const { MediaAssetService } = await import('./media-asset-service')
-      const assetService = new MediaAssetService(this.requireOrganization(), this.userId, this.db)
-      return await assetService.getDownloadRef(attachment.assetId)
-    }
-    throw new Error('Attachment has no valid file or asset reference')
+
+    const { MediaAssetService } = await import('./media-asset-service')
+    const assetService = new MediaAssetService(this.requireOrganization(), this.userId, this.db)
+    return await assetService.getDownloadRef(attachment.assetId as string)
   }
-  /**
-   * Get download URL for an attachment (legacy method)
-   */
+
+  /** @deprecated Read `.url` off {@link getDownloadRef} instead. */
   async getDownloadUrl(id: string): Promise<string> {
     const downloadRef = await this.getDownloadRef(id)
-    if (downloadRef.type === 'url') {
-      return downloadRef.url
-    }
-    throw new Error('Attachment content is not available via URL')
+    if (downloadRef.type === 'url') return downloadRef.url
+    throw new BadRequestError('Attachment content is not available via URL')
   }
+
   /**
-   * Get detailed download information for an attachment
+   * @deprecated Awaiting PR 5c, with {@link getDownloadRef}.
+   *
+   * **The filename changed shape, not value.** The legacy body computed
+   * `attachment.title || version.name || 'attachment'`, but `version` was typed
+   * `any` and none of `resolveVersion`'s four projections ever selected a `name`
+   * column — so the middle term was always `undefined` and the expression was
+   * already `title || 'attachment'`. `ResolvedAttachmentVersion` refuses to
+   * compile the dead read, which is how it surfaced.
    */
   async getDownloadInfo(id: string): Promise<FileDownloadInfo> {
-    const { attachment, version } = await this.resolveVersion(id)
+    const resolved = await this.resolveVersion(id)
     const downloadRef = await this.getDownloadRef(id)
     return {
       kind: downloadRef.type,
       url: downloadRef.type === 'url' ? downloadRef.url : undefined,
-      filename: attachment.title || version.name || 'attachment',
-      mimeType: version.mimeType || undefined,
-      size: version.size || undefined,
+      filename: resolved.attachment.title || 'attachment',
+      mimeType: resolved.mimeType || undefined,
+      size: resolved.size || undefined,
       expiresAt: downloadRef.type === 'url' ? downloadRef.expiresAt : undefined,
     }
   }
-  /**
-   * Get attachment content as Buffer
-   */
-  async getContent(id: string): Promise<Buffer> {
-    const { attachment, storageLocationId } = await this.resolveVersion(id)
-    // If attachment is pinned to a specific version, get content directly from storage
-    if (attachment.fileVersionId || attachment.assetVersionId) {
-      const { createStorageManager } = await import('../storage/storage-manager')
-      const storageManager = createStorageManager(this.requireOrganization())
-      return storageManager.getContent(storageLocationId)
-    }
-    // Otherwise delegate to appropriate service for current version
-    if (attachment.fileId) {
-      const { FileService } = await import('./file-service')
-      const fileService = new FileService(this.requireOrganization(), this.userId, this.db)
-      return fileService.getContent(attachment.fileId)
-    }
-    if (attachment.assetId) {
-      const { MediaAssetService } = await import('./media-asset-service')
-      const assetService = new MediaAssetService(this.requireOrganization(), this.userId, this.db)
-      return assetService.getContent(attachment.assetId)
-    }
-    throw new Error('Attachment has no valid file or asset reference')
-  }
-  /**
-   * Stream attachment content
-   */
-  async streamContent(id: string): Promise<NodeJS.ReadableStream> {
-    const { attachment, storageLocationId } = await this.resolveVersion(id)
-    // If attachment is pinned to a specific version, stream content directly from storage
-    if (attachment.fileVersionId || attachment.assetVersionId) {
-      const { createStorageManager } = await import('../storage/storage-manager')
-      const storageManager = createStorageManager(this.requireOrganization())
-      return storageManager.streamFileContent(storageLocationId)
-    }
-    // Otherwise delegate to appropriate service for current version
-    if (attachment.fileId) {
-      const { FileService } = await import('./file-service')
-      const fileService = new FileService(this.requireOrganization(), this.userId, this.db)
-      return fileService.streamContent(attachment.fileId)
-    }
-    if (attachment.assetId) {
-      const { MediaAssetService } = await import('./media-asset-service')
-      const assetService = new MediaAssetService(this.requireOrganization(), this.userId, this.db)
-      return assetService.streamContent(attachment.assetId)
-    }
-    throw new Error('Attachment has no valid file or asset reference')
-  }
-  // ============= Entity Operations =============
-  /**
-   * Copy all attachments from one entity to another
-   */
-  async copyAttachmentsToEntity(
-    sourceEntityType: EntityType,
-    sourceEntityId: string,
-    targetEntityType: EntityType,
-    targetEntityId: string,
-    createdById: string
-  ): Promise<Attachment[]> {
-    await this.ensureAuth(sourceEntityType, sourceEntityId)
-    await this.ensureAuth(targetEntityType, targetEntityId)
-    const sourceAttachments = await this.getEntityAttachments(sourceEntityType, sourceEntityId)
-    const copiedAttachments: Attachment[] = []
-    for (const sourceAttachment of sourceAttachments) {
-      const newAttachment = await this.create({
-        entityType: targetEntityType,
-        entityId: targetEntityId,
-        role: sourceAttachment.role as AttachmentRole,
-        title: sourceAttachment.title || undefined,
-        caption: sourceAttachment.caption || undefined,
-        fileId: sourceAttachment.fileId || undefined,
-        fileVersionId: sourceAttachment.fileVersionId || undefined,
-        assetId: sourceAttachment.assetId || undefined,
-        assetVersionId: sourceAttachment.assetVersionId || undefined,
-        createdById,
-      })
-      copiedAttachments.push(newAttachment)
-    }
-    return copiedAttachments
-  }
-  /**
-   * Move all attachments from one entity to another
-   */
-  async moveAttachmentsToEntity(
-    sourceEntityType: EntityType,
-    sourceEntityId: string,
-    targetEntityType: EntityType,
-    targetEntityId: string
-  ): Promise<Attachment[]> {
-    await this.ensureAuth(sourceEntityType, sourceEntityId)
-    await this.ensureAuth(targetEntityType, targetEntityId)
-    const orgId = this.requireOrganization()
 
-    // Get all attachments for the source entity
-    const attachments = await this.db
-      .select()
-      .from(schema.Attachment)
-      .where(
-        and(
-          eq(schema.Attachment.organizationId, orgId),
-          eq(schema.Attachment.entityType, sourceEntityType),
-          eq(schema.Attachment.entityId, sourceEntityId)
-        )
-      )
+  // ============= Internals =============
 
-    // Update all attachments to the target entity
-    const updatedAttachments: Attachment[] = []
-    for (const attachment of attachments) {
-      const [updated] = await this.db
-        .update(schema.Attachment)
-        .set({
-          entityType: targetEntityType,
-          entityId: targetEntityId,
-        })
-        .where(eq(schema.Attachment.id, attachment.id))
-        .returning()
-
-      if (updated) {
-        updatedAttachments.push(updated as unknown as Attachment)
-      }
-    }
-
-    return updatedAttachments
+  /** @deprecated Use `resolveAttachmentVersion(ctx, attachmentId)`. */
+  private async resolveVersion(id: string): Promise<ResolvedAttachmentVersion> {
+    return this.unwrap(await resolveAttachmentVersion(this.filesCtx(), id))
   }
+
   /**
-   * Get attachment statistics for an entity (uses exact resolved versions for accurate sizes)
+   * Build the `FilesCtx` the extracted functions take.
+   *
+   * `requireOrganization()` throws when the service was constructed without one,
+   * which is the legacy behaviour on every path — `FilesCtx.organizationId` is
+   * required, so the "no organization means no filter" branch that widened
+   * queries across tenants cannot be expressed any more.
    */
-  async getEntityAttachmentStats(
-    entityType: EntityType,
-    entityId: string
-  ): Promise<{
-    totalAttachments: number
-    totalSize: number
-    attachmentsByRole: Record<string, number>
-    fileAttachments: number
-    assetAttachments: number
-  }> {
-    await this.ensureAuth(entityType, entityId)
-    const orgId = this.requireOrganization()
-    const attachments = await this.db
-      .select()
-      .from(schema.Attachment)
-      .where(
-        and(
-          eq(schema.Attachment.organizationId, orgId),
-          eq(schema.Attachment.entityType, entityType),
-          eq(schema.Attachment.entityId, entityId)
-        )
-      )
-    let totalSize = 0
-    const attachmentsByRole: Record<string, number> = {}
-    let fileAttachments = 0
-    let assetAttachments = 0
-    // Process attachments in batches to avoid overwhelming the system
-    const batchSize = 10
-    for (let i = 0; i < attachments.length; i += batchSize) {
-      const batch = attachments.slice(i, i + batchSize)
-      // Process batch in parallel
-      const resolvedVersions = await Promise.all(
-        batch.map(async (attachment) => {
-          try {
-            const { version, side } = await this.resolveVersion(attachment.id)
-            return { attachment, version, side }
-          } catch {
-            // Handle cases where attachment might be broken/orphaned
-            return { attachment, version: null, side: null }
-          }
-        })
-      )
-      for (const { attachment, version, side } of resolvedVersions) {
-        // Count by role
-        attachmentsByRole[attachment.role] = (attachmentsByRole[attachment.role] || 0) + 1
-        // Count by type and accumulate exact size
-        if (side === 'file') {
-          fileAttachments++
-        } else if (side === 'asset') {
-          assetAttachments++
-        }
-        if (version?.size) {
-          totalSize += Number(version.size)
-        }
-      }
-    }
+  private filesCtx(dbClient?: DatabaseClient, organizationId?: string): FilesCtx {
     return {
-      totalAttachments: attachments.length,
-      totalSize,
-      attachmentsByRole,
-      fileAttachments,
-      assetAttachments,
+      db: (dbClient ?? this.db) as FilesCtx['db'],
+      organizationId: organizationId ?? this.requireOrganization(),
     }
   }
-  // ============= Search & Query =============
+
   /**
-   * Search attachments by title or caption
+   * Unwrap a `Result` into the throw-based contract this class has always had.
+   *
+   * The thrown value is an `AuxxError` subclass rather than the bare `Error` the
+   * old bodies threw, which is the one deliberate change to this facade's
+   * behaviour.
    */
-  async search(query: string, options?: SearchOptions): Promise<AttachmentSearchResult[]> {
-    const orgId = this.requireOrganization()
-    const limit = options?.limit || 50
-    const offset = options?.offset || 0
-
-    const results = await this.db
-      .select({
-        id: schema.Attachment.id,
-        organizationId: schema.Attachment.organizationId,
-        entityType: schema.Attachment.entityType,
-        entityId: schema.Attachment.entityId,
-        role: schema.Attachment.role,
-        title: schema.Attachment.title,
-        caption: schema.Attachment.caption,
-        sort: schema.Attachment.sort,
-        fileId: schema.Attachment.fileId,
-        fileVersionId: schema.Attachment.fileVersionId,
-        assetId: schema.Attachment.assetId,
-        assetVersionId: schema.Attachment.assetVersionId,
-        createdById: schema.Attachment.createdById,
-        createdAt: schema.Attachment.createdAt,
-      })
-      .from(schema.Attachment)
-      .where(
-        and(
-          eq(schema.Attachment.organizationId, orgId),
-          or(
-            ilike(schema.Attachment.title, `%${query}%`),
-            ilike(schema.Attachment.caption, `%${query}%`)
-          )
-        )
-      )
-      .orderBy(desc(schema.Attachment.createdAt))
-      .limit(limit)
-      .offset(offset)
-
-    return results
-      .map((attachment): AttachmentSearchResult => {
-        let relevance = 0
-        const matchedFields: string[] = []
-        if (attachment.title?.toLowerCase().includes(query.toLowerCase())) {
-          relevance += attachment.title.toLowerCase() === query.toLowerCase() ? 10 : 5
-          matchedFields.push('title')
-        }
-        if (attachment.caption?.toLowerCase().includes(query.toLowerCase())) {
-          relevance += attachment.caption.toLowerCase() === query.toLowerCase() ? 8 : 3
-          matchedFields.push('caption')
-        }
-        return {
-          attachment: attachment as unknown as Attachment,
-          relevance: Math.max(relevance, 1),
-          matchedFields,
-          snippet:
-            [attachment.title, attachment.caption].filter(Boolean).join(' | ') || 'Attachment',
-        }
-      })
-      .sort((a, b) => b.relevance - a.relevance)
-  }
-  /**
-   * Get attachments by role across organization
-   */
-  async getAttachmentsByRole(role: AttachmentRole): Promise<Attachment[]> {
-    const results = await this.db
-      .select()
-      .from(schema.Attachment)
-      .where(
-        and(
-          eq(schema.Attachment.organizationId, this.requireOrganization()),
-          eq(schema.Attachment.role, role)
-        )
-      )
-      .orderBy(desc(schema.Attachment.createdAt))
-
-    return results as unknown as Attachment[]
-  }
-  /**
-   * Get recent attachments for organization
-   */
-  async getRecentAttachments(limit = 50): Promise<Attachment[]> {
-    const results = await this.db
-      .select()
-      .from(schema.Attachment)
-      .where(eq(schema.Attachment.organizationId, this.requireOrganization()))
-      .orderBy(desc(schema.Attachment.createdAt))
-      .limit(limit)
-
-    return results as unknown as Attachment[]
-  }
-  /**
-   * Get attachments by creator
-   */
-  async getAttachmentsByCreator(userId: string): Promise<Attachment[]> {
-    const results = await this.db
-      .select()
-      .from(schema.Attachment)
-      .where(
-        and(
-          eq(schema.Attachment.organizationId, this.requireOrganization()),
-          eq(schema.Attachment.createdById, userId)
-        )
-      )
-      .orderBy(desc(schema.Attachment.createdAt))
-
-    return results as unknown as Attachment[]
-  }
-  // ============= Maintenance Operations =============
-  /**
-   * Clean up orphaned attachments (no valid entity reference)
-   */
-  async cleanupOrphanedAttachments(): Promise<number> {
-    const orgId = this.requireOrganization()
-
-    // Find attachments with file references but no corresponding file
-    const orphanedFileAttachments = await this.db
-      .select({ id: schema.Attachment.id })
-      .from(schema.Attachment)
-      .leftJoin(schema.FolderFile, eq(schema.Attachment.fileId, schema.FolderFile.id))
-      .where(
-        and(
-          eq(schema.Attachment.organizationId, orgId),
-          isNotNull(schema.Attachment.fileId),
-          isNull(schema.FolderFile.id)
-        )
-      )
-
-    // Find attachments with asset references but no corresponding asset
-    const orphanedAssetAttachments = await this.db
-      .select({ id: schema.Attachment.id })
-      .from(schema.Attachment)
-      .leftJoin(schema.MediaAsset, eq(schema.Attachment.assetId, schema.MediaAsset.id))
-      .where(
-        and(
-          eq(schema.Attachment.organizationId, orgId),
-          isNotNull(schema.Attachment.assetId),
-          isNull(schema.MediaAsset.id)
-        )
-      )
-
-    const allOrphanedIds = [
-      ...orphanedFileAttachments.map((a) => a.id),
-      ...orphanedAssetAttachments.map((a) => a.id),
-    ]
-
-    if (allOrphanedIds.length === 0) {
-      return 0
-    }
-
-    // Delete orphaned attachments
-    await this.db.delete(schema.Attachment).where(inArray(schema.Attachment.id, allOrphanedIds))
-
-    this.logger.info('Cleaned up orphaned attachments', {
-      count: allOrphanedIds.length,
-      organizationId: orgId,
-    })
-    return allOrphanedIds.length
-  }
-  /**
-   * Fix attachment sort orders
-   */
-  async fixAttachmentSortOrders(entityType: EntityType, entityId: string): Promise<number> {
-    await this.ensureAuth(entityType, entityId)
-    const orgId = this.requireOrganization()
-
-    const attachments = await this.db
-      .select({
-        id: schema.Attachment.id,
-        sort: schema.Attachment.sort,
-      })
-      .from(schema.Attachment)
-      .where(
-        and(
-          eq(schema.Attachment.organizationId, orgId),
-          eq(schema.Attachment.entityType, entityType),
-          eq(schema.Attachment.entityId, entityId)
-        )
-      )
-      .orderBy(asc(schema.Attachment.sort), asc(schema.Attachment.createdAt))
-
-    if (attachments.length === 0) {
-      return 0
-    }
-
-    // Check if reordering is needed
-    const needsReordering = attachments.some((attachment, index) => attachment.sort !== index + 1)
-    if (!needsReordering) {
-      return 0
-    }
-
-    // Fix sort orders
-    for (const [index, target] of attachments.entries()) {
-      await this.db
-        .update(schema.Attachment)
-        .set({ sort: index + 1 })
-        .where(eq(schema.Attachment.id, target.id))
-    }
-
-    this.logger.info('Fixed attachment sort orders', {
-      entityType,
-      entityId,
-      count: attachments.length,
-      organizationId: orgId,
-    })
-    return attachments.length
-  }
-  /**
-   * Validate attachment integrity
-   */
-  async validateAttachmentIntegrity(): Promise<{
-    validAttachments: number
-    invalidAttachments: number
-    errors: string[]
-  }> {
-    const orgId = this.requireOrganization()
-    const errors: string[] = []
-
-    // Get all attachments with their related entities
-    const attachments = await this.db
-      .select({
-        id: schema.Attachment.id,
-        fileId: schema.Attachment.fileId,
-        fileVersionId: schema.Attachment.fileVersionId,
-        assetId: schema.Attachment.assetId,
-        assetVersionId: schema.Attachment.assetVersionId,
-        fileExists: schema.FolderFile.id,
-        assetExists: schema.MediaAsset.id,
-        fileVersionExists: schema.FileVersion.id,
-        assetVersionExists: schema.MediaAssetVersion.id,
-      })
-      .from(schema.Attachment)
-      .leftJoin(schema.FolderFile, eq(schema.Attachment.fileId, schema.FolderFile.id))
-      .leftJoin(schema.MediaAsset, eq(schema.Attachment.assetId, schema.MediaAsset.id))
-      .leftJoin(schema.FileVersion, eq(schema.Attachment.fileVersionId, schema.FileVersion.id))
-      .leftJoin(
-        schema.MediaAssetVersion,
-        eq(schema.Attachment.assetVersionId, schema.MediaAssetVersion.id)
-      )
-      .where(eq(schema.Attachment.organizationId, orgId))
-
-    let validAttachments = 0
-    let invalidAttachments = 0
-
-    for (const attachment of attachments) {
-      let isValid = true
-
-      // Check XOR constraint
-      const hasFile = !!(attachment.fileId || attachment.fileVersionId)
-      const hasAsset = !!(attachment.assetId || attachment.assetVersionId)
-      if (hasFile === hasAsset) {
-        errors.push(`Attachment ${attachment.id}: Must have exactly one of file or asset reference`)
-        isValid = false
-      }
-
-      // Check file version consistency
-      if (attachment.fileVersionId && !attachment.fileId) {
-        errors.push(`Attachment ${attachment.id}: fileVersionId requires fileId`)
-        isValid = false
-      }
-
-      // Check asset version consistency
-      if (attachment.assetVersionId && !attachment.assetId) {
-        errors.push(`Attachment ${attachment.id}: assetVersionId requires assetId`)
-        isValid = false
-      }
-
-      // Check if referenced entities exist
-      if (attachment.fileId && !attachment.fileExists) {
-        errors.push(`Attachment ${attachment.id}: Referenced file ${attachment.fileId} not found`)
-        isValid = false
-      }
-      if (attachment.assetId && !attachment.assetExists) {
-        errors.push(`Attachment ${attachment.id}: Referenced asset ${attachment.assetId} not found`)
-        isValid = false
-      }
-      if (attachment.fileVersionId && !attachment.fileVersionExists) {
-        errors.push(
-          `Attachment ${attachment.id}: Referenced file version ${attachment.fileVersionId} not found`
-        )
-        isValid = false
-      }
-      if (attachment.assetVersionId && !attachment.assetVersionExists) {
-        errors.push(
-          `Attachment ${attachment.id}: Referenced asset version ${attachment.assetVersionId} not found`
-        )
-        isValid = false
-      }
-
-      if (isValid) {
-        validAttachments++
-      } else {
-        invalidAttachments++
-      }
-    }
-
-    return {
-      validAttachments,
-      invalidAttachments,
-      errors,
-    }
-  }
-  // ============= Batch Operations for Entities =============
-  /**
-   * Fetch and group attachments for multiple entities using efficient query
-   * Replaces the specific fetchAttachmentsForComments method from CommentService
-   */
-  async fetchAttachmentsForEntities(
-    entityType: EntityType,
-    entityIds: string[]
-  ): Promise<Map<string, GroupedAttachmentInfo[]>> {
-    if (entityIds.length === 0) return new Map()
-    const orgId = this.requireOrganization()
-
-    // Use Drizzle query with joins to get all attachment data efficiently
-    const attachments = await this.db
-      .select({
-        id: schema.Attachment.id,
-        entityId: schema.Attachment.entityId,
-        role: schema.Attachment.role,
-        title: schema.Attachment.title,
-        sort: schema.Attachment.sort,
-        createdAt: schema.Attachment.createdAt,
-        assetId: schema.Attachment.assetId,
-        fileId: schema.Attachment.fileId,
-        // Asset info
-        assetName: schema.MediaAsset.name,
-        assetMimeType: schema.MediaAsset.mimeType,
-        assetSize: schema.MediaAsset.size,
-        // File info
-        fileName: schema.FolderFile.name,
-        fileMimeType: schema.FolderFile.mimeType,
-        fileSize: schema.FolderFile.size,
-      })
-      .from(schema.Attachment)
-      .leftJoin(schema.MediaAsset, eq(schema.Attachment.assetId, schema.MediaAsset.id))
-      .leftJoin(schema.FolderFile, eq(schema.Attachment.fileId, schema.FolderFile.id))
-      .where(
-        and(
-          eq(schema.Attachment.entityType, entityType),
-          inArray(schema.Attachment.entityId, entityIds),
-          eq(schema.Attachment.organizationId, orgId)
-        )
-      )
-      .orderBy(asc(schema.Attachment.sort), asc(schema.Attachment.createdAt))
-
-    // Group by entity ID and transform to GroupedAttachmentInfo
-    const attachmentMap = new Map<string, GroupedAttachmentInfo[]>()
-    for (const attachment of attachments) {
-      if (!attachmentMap.has(attachment.entityId)) {
-        attachmentMap.set(attachment.entityId, [])
-      }
-      const info: GroupedAttachmentInfo = {
-        id: attachment.id,
-        role: attachment.role,
-        title: attachment.title,
-        sort: attachment.sort,
-        createdAt: attachment.createdAt,
-        type: attachment.assetId ? 'asset' : 'file',
-        fileId: attachment.assetId || attachment.fileId!,
-        name: attachment.assetName || attachment.fileName || 'Untitled',
-        mimeType: attachment.assetMimeType || attachment.fileMimeType,
-        size: attachment.assetSize || attachment.fileSize,
-      }
-      attachmentMap.get(attachment.entityId)!.push(info)
-    }
-    return attachmentMap
-  }
-  // ============= Statistics & Analytics =============
-  /**
-   * Get attachment statistics for organization
-   */
-  async getAttachmentStats(): Promise<{
-    totalAttachments: number
-    attachmentsByEntityType: Record<string, number>
-    attachmentsByRole: Record<string, number>
-    fileAttachments: number
-    assetAttachments: number
-    averageAttachmentsPerEntity: number
-  }> {
-    const orgId = this.requireOrganization()
-    const attachments = await this.db
-      .select()
-      .from(schema.Attachment)
-      .where(eq(schema.Attachment.organizationId, orgId))
-    const attachmentsByEntityType: Record<string, number> = {}
-    const attachmentsByRole: Record<string, number> = {}
-    let fileAttachments = 0
-    let assetAttachments = 0
-    const entityIds = new Set<string>()
-    for (const attachment of attachments) {
-      // Count by entity type
-      attachmentsByEntityType[attachment.entityType] =
-        (attachmentsByEntityType[attachment.entityType] || 0) + 1
-      // Count by role
-      attachmentsByRole[attachment.role] = (attachmentsByRole[attachment.role] || 0) + 1
-      // Count by type
-      if (attachment.fileId) fileAttachments++
-      if (attachment.assetId) assetAttachments++
-      // Track unique entities
-      entityIds.add(`${attachment.entityType}:${attachment.entityId}`)
-    }
-    return {
-      totalAttachments: attachments.length,
-      attachmentsByEntityType,
-      attachmentsByRole,
-      fileAttachments,
-      assetAttachments,
-      averageAttachmentsPerEntity: entityIds.size > 0 ? attachments.length / entityIds.size : 0,
-    }
-  }
-  /**
-   * Get attachment usage analytics
-   */
-  async getAttachmentUsage(days = 30): Promise<{
-    newAttachments: number
-    deletedAttachments: number
-    mostUsedEntityTypes: Array<{
-      entityType: string
-      count: number
-    }>
-    mostUsedRoles: Array<{
-      role: string
-      count: number
-    }>
-  }> {
-    const orgId = this.requireOrganization()
-    const cutoffDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
-    // Count new attachments
-    const [newAttachmentsResult] = await this.db
-      .select({ count: dCount() })
-      .from(schema.Attachment)
-      .where(
-        and(
-          eq(schema.Attachment.organizationId, orgId),
-          gte(schema.Attachment.createdAt, cutoffDate)
-        )
-      )
-    const newAttachments = newAttachmentsResult?.count || 0
-
-    // Note: We can't easily track deletions without audit logs
-    // This would require a separate deletion tracking system
-    const deletedAttachments = 0
-
-    // Get usage by entity type
-    const entityTypeUsage = await this.db
-      .select({
-        entityType: schema.Attachment.entityType,
-        count: dCount(),
-      })
-      .from(schema.Attachment)
-      .where(
-        and(
-          eq(schema.Attachment.organizationId, orgId),
-          gte(schema.Attachment.createdAt, cutoffDate)
-        )
-      )
-      .groupBy(schema.Attachment.entityType)
-      .orderBy(desc(dCount()))
-      .limit(10)
-
-    // Get usage by role
-    const roleUsage = await this.db
-      .select({
-        role: schema.Attachment.role,
-        count: dCount(),
-      })
-      .from(schema.Attachment)
-      .where(
-        and(
-          eq(schema.Attachment.organizationId, orgId),
-          gte(schema.Attachment.createdAt, cutoffDate)
-        )
-      )
-      .groupBy(schema.Attachment.role)
-      .orderBy(desc(dCount()))
-      .limit(10)
-    return {
-      newAttachments,
-      deletedAttachments,
-      mostUsedEntityTypes: entityTypeUsage.map((item) => ({
-        entityType: item.entityType,
-        count: item.count,
-      })),
-      mostUsedRoles: roleUsage.map((item) => ({
-        role: item.role,
-        count: item.count,
-      })),
-    }
+  private unwrap<T>(result: Result<T, AuxxError>): T {
+    if (result.isErr()) throw result.error
+    return result.value
   }
 }
-// Export factory functions for creating service instances
-export const createAttachmentService = (
-  organizationId?: string,
-  userId?: string,
-  authorize?: (args: {
-    organizationId: string
-    entityType: EntityType
-    entityId: string
-    userId?: string
-  }) => Promise<boolean> | boolean
-) => new AttachmentService(organizationId, userId, db, authorize)
-// Export singleton instance (with default db, no specific organization)
-// export const attachmentService = new AttachmentService()
+
+/** @deprecated Construct a `FilesCtx` and call `files/attachments/` directly. */
+export const createAttachmentService = (organizationId?: string, userId?: string) =>
+  new AttachmentService(organizationId, userId, db)

--- a/packages/lib/src/files/core/types.ts
+++ b/packages/lib/src/files/core/types.ts
@@ -123,8 +123,12 @@ export interface CreateAttachmentRequest {
   fileVersionId?: string
   assetId?: string
   assetVersionId?: string
-  // Optional idempotency key to avoid duplicates on retries
-  idempotencyKey?: string
+  /**
+   * Removed in PR 5b. Nothing ever passed it, and the branch it gated
+   * deduplicated on `(organizationId, entityType, entityId, title, fileId,
+   * assetId)` while never comparing the key itself — see `AttachmentService`.
+   */
+  idempotencyKey?: never
 }
 /**
  * Request to update an existing Attachment

--- a/packages/lib/src/files/lifecycle/attachment-maintenance.ts
+++ b/packages/lib/src/files/lifecycle/attachment-maintenance.ts
@@ -1,0 +1,183 @@
+// packages/lib/src/files/lifecycle/attachment-maintenance.ts
+
+/**
+ * Whole-organization `Attachment` sweeps.
+ *
+ * These two moved off `AttachmentService` because they are not part of the
+ * attachment read/write API: neither is reachable from a router, both scan every
+ * attachment row in an organization, and both exist for an operator running
+ * maintenance rather than for a request. `plans/attachments/05-core-services.md`
+ * §5.3 puts them here for exactly that reason.
+ *
+ * **Both are unbounded**, inherited from the legacy bodies: no `LIMIT`, no
+ * cursor, one round trip that materialises every matching row. That is fine at
+ * current data volumes and is called out here so a future scheduled job adds
+ * paging deliberately rather than discovering the scan in production.
+ */
+
+import { schema } from '@auxx/database'
+import { and, eq, inArray, isNotNull, isNull } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import type { AuxxError } from '../../errors'
+import type { FilesCtx } from '../ctx'
+import { guard } from '../guard'
+
+/** What {@link validateAttachmentIntegrity} found. */
+export interface AttachmentIntegrityReport {
+  validAttachments: number
+  invalidAttachments: number
+  /** One human-readable line per violation, prefixed with the attachment id. */
+  errors: string[]
+}
+
+/**
+ * Delete attachments whose target row no longer exists.
+ *
+ * Two anti-join scans — one for `fileId` rows with no `FolderFile`, one for
+ * `assetId` rows with no `MediaAsset` — then a single `DELETE … WHERE id IN (…)`.
+ * Three statements total regardless of how many orphans there are.
+ *
+ * Note this only catches a *hard*-deleted target. `FolderFile` and `MediaAsset`
+ * are soft-deleted, and the joins here do not filter `deletedAt`, so an
+ * attachment pointing at a soft-deleted file is deliberately left alone — its
+ * target can still be restored. Parity with the legacy body.
+ *
+ * @param ctx Scope and database.
+ * @returns The number of attachment rows deleted.
+ */
+export async function cleanupOrphanedAttachments(
+  ctx: FilesCtx
+): Promise<Result<number, AuxxError>> {
+  return guard(
+    async () => {
+      const orphanedFileAttachments = await ctx.db
+        .select({ id: schema.Attachment.id })
+        .from(schema.Attachment)
+        .leftJoin(schema.FolderFile, eq(schema.Attachment.fileId, schema.FolderFile.id))
+        .where(
+          and(
+            eq(schema.Attachment.organizationId, ctx.organizationId),
+            isNotNull(schema.Attachment.fileId),
+            isNull(schema.FolderFile.id)
+          )
+        )
+
+      const orphanedAssetAttachments = await ctx.db
+        .select({ id: schema.Attachment.id })
+        .from(schema.Attachment)
+        .leftJoin(schema.MediaAsset, eq(schema.Attachment.assetId, schema.MediaAsset.id))
+        .where(
+          and(
+            eq(schema.Attachment.organizationId, ctx.organizationId),
+            isNotNull(schema.Attachment.assetId),
+            isNull(schema.MediaAsset.id)
+          )
+        )
+
+      const orphanedIds = [
+        ...orphanedFileAttachments.map((row) => row.id),
+        ...orphanedAssetAttachments.map((row) => row.id),
+      ]
+      if (orphanedIds.length === 0) return 0
+
+      // Org-scoped as well as id-scoped. The legacy body deleted on the id list
+      // alone; the ids came from org-scoped selects so it was never a live hole,
+      // but a sweep is the last place to rely on that.
+      await ctx.db
+        .delete(schema.Attachment)
+        .where(
+          and(
+            eq(schema.Attachment.organizationId, ctx.organizationId),
+            inArray(schema.Attachment.id, orphanedIds)
+          )
+        )
+
+      return orphanedIds.length
+    },
+    'Failed to clean up orphaned attachments',
+    { organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Report every attachment in the organization that violates its own invariants.
+ *
+ * Read-only — it never repairs anything. One `SELECT` with four `LEFT JOIN`s
+ * establishes whether each referenced row exists; the rules checked in memory
+ * afterwards are the same three the write path enforces
+ * (`assertExactlyOneTarget`) plus "the thing it points at is still there".
+ *
+ * @param ctx Scope and database.
+ */
+export async function validateAttachmentIntegrity(
+  ctx: FilesCtx
+): Promise<Result<AttachmentIntegrityReport, AuxxError>> {
+  return guard(
+    async () => {
+      const rows = await ctx.db
+        .select({
+          id: schema.Attachment.id,
+          fileId: schema.Attachment.fileId,
+          fileVersionId: schema.Attachment.fileVersionId,
+          assetId: schema.Attachment.assetId,
+          assetVersionId: schema.Attachment.assetVersionId,
+          fileExists: schema.FolderFile.id,
+          assetExists: schema.MediaAsset.id,
+          fileVersionExists: schema.FileVersion.id,
+          assetVersionExists: schema.MediaAssetVersion.id,
+        })
+        .from(schema.Attachment)
+        .leftJoin(schema.FolderFile, eq(schema.Attachment.fileId, schema.FolderFile.id))
+        .leftJoin(schema.MediaAsset, eq(schema.Attachment.assetId, schema.MediaAsset.id))
+        .leftJoin(schema.FileVersion, eq(schema.Attachment.fileVersionId, schema.FileVersion.id))
+        .leftJoin(
+          schema.MediaAssetVersion,
+          eq(schema.Attachment.assetVersionId, schema.MediaAssetVersion.id)
+        )
+        .where(eq(schema.Attachment.organizationId, ctx.organizationId))
+
+      const errors: string[] = []
+      let validAttachments = 0
+      let invalidAttachments = 0
+
+      for (const row of rows) {
+        const before = errors.length
+
+        const hasFile = !!(row.fileId || row.fileVersionId)
+        const hasAsset = !!(row.assetId || row.assetVersionId)
+        if (hasFile === hasAsset) {
+          errors.push(`Attachment ${row.id}: Must have exactly one of file or asset reference`)
+        }
+        if (row.fileVersionId && !row.fileId) {
+          errors.push(`Attachment ${row.id}: fileVersionId requires fileId`)
+        }
+        if (row.assetVersionId && !row.assetId) {
+          errors.push(`Attachment ${row.id}: assetVersionId requires assetId`)
+        }
+        if (row.fileId && !row.fileExists) {
+          errors.push(`Attachment ${row.id}: Referenced file ${row.fileId} not found`)
+        }
+        if (row.assetId && !row.assetExists) {
+          errors.push(`Attachment ${row.id}: Referenced asset ${row.assetId} not found`)
+        }
+        if (row.fileVersionId && !row.fileVersionExists) {
+          errors.push(
+            `Attachment ${row.id}: Referenced file version ${row.fileVersionId} not found`
+          )
+        }
+        if (row.assetVersionId && !row.assetVersionExists) {
+          errors.push(
+            `Attachment ${row.id}: Referenced asset version ${row.assetVersionId} not found`
+          )
+        }
+
+        if (errors.length === before) validAttachments += 1
+        else invalidAttachments += 1
+      }
+
+      return { validAttachments, invalidAttachments, errors }
+    },
+    'Failed to validate attachment integrity',
+    { organizationId: ctx.organizationId }
+  )
+}

--- a/packages/lib/src/files/lifecycle/cleanup-service.ts
+++ b/packages/lib/src/files/lifecycle/cleanup-service.ts
@@ -3,11 +3,15 @@
 import { database, schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { eq, exists, not, sql } from 'drizzle-orm'
-import { createAttachmentService } from '../core/attachment-service'
 import { createFileService } from '../core/file-service'
 import { purgeMediaAssets } from '../core/media-asset-purge'
 import { createMediaAssetService } from '../core/media-asset-service'
 import { ThumbnailService } from '../core/thumbnail-service'
+import type { AttachmentIntegrityReport } from './attachment-maintenance'
+import {
+  validateAttachmentIntegrity as auditAttachmentIntegrity,
+  cleanupOrphanedAttachments as sweepOrphanedAttachments,
+} from './attachment-maintenance'
 
 const logger = createScopedLogger('file-cleanup-utils')
 
@@ -360,46 +364,41 @@ export async function deleteExpiredFiles(
 }
 
 /**
- * Clean up orphaned attachments using AttachmentService
+ * Clean up orphaned attachments.
+ *
+ * Thin `{ deleted, failed, errors }` adapter over
+ * `lifecycle/attachment-maintenance.ts`, which holds the query. Kept in that
+ * legacy shape because it is the shape every other sweep in this file reports.
  */
 export async function cleanupOrphanedAttachments(
   organizationId: string
 ): Promise<{ deleted: number; failed: number; errors: Error[] }> {
   logger.info('Cleaning up orphaned attachments')
 
-  try {
-    const attachmentService = createAttachmentService(organizationId)
-    const deletedCount = await attachmentService.cleanupOrphanedAttachments()
-
-    logger.info(`Cleaned up ${deletedCount} orphaned attachments`)
-
-    return {
-      deleted: deletedCount,
-      failed: 0,
-      errors: [],
-    }
-  } catch (error) {
-    logger.error('Failed to cleanup orphaned attachments:', error)
-    return {
-      deleted: 0,
-      failed: 1,
-      errors: [error as Error],
-    }
+  const result = await sweepOrphanedAttachments({ db: database, organizationId })
+  if (result.isErr()) {
+    logger.error('Failed to cleanup orphaned attachments:', result.error)
+    return { deleted: 0, failed: 1, errors: [result.error] }
   }
+
+  logger.info(`Cleaned up ${result.value} orphaned attachments`)
+  return { deleted: result.value, failed: 0, errors: [] }
 }
 
 /**
- * Validate attachment integrity using AttachmentService
+ * Validate attachment integrity.
+ *
+ * Adapter over `lifecycle/attachment-maintenance.ts`; throws the `AuxxError` the
+ * sweep produced rather than swallowing it, matching the legacy body.
  */
-export async function validateAttachmentIntegrity(organizationId: string): Promise<{
-  validAttachments: number
-  invalidAttachments: number
-  errors: string[]
-}> {
+export async function validateAttachmentIntegrity(
+  organizationId: string
+): Promise<AttachmentIntegrityReport> {
   logger.info('Validating attachment integrity')
 
-  const attachmentService = createAttachmentService(organizationId)
-  return await attachmentService.validateAttachmentIntegrity()
+  const result = await auditAttachmentIntegrity({ db: database, organizationId })
+  if (result.isErr()) throw result.error
+  return result.value
 }
 
 /**


### PR DESCRIPTION
PR 5b of Phase 5 (`plans/attachments/05-core-services.md` §5.3).

`AttachmentService` **1,386 → 323 lines** (deprecated facade). Reads and writes move into
`files/attachments/`; the two maintenance sweeps move to `lifecycle/attachment-maintenance.ts`.
**No consumer outside `files/` changes.**

## Most of what §5.3 asked for was dead

All ten methods the plan lists for deletion had zero callers — and **four were
`throw new Error('Not implemented')` stubs**, including three that §5.3's own scope block asks 5b to
*create*. Thirteen more went with them.

Two are worth naming because they were latent holes, not merely unused. I verified both against
committed code:

- **`detachFromEntity` deleted by bare id** — `delete(Attachment).where(eq(Attachment.id, id))`, no
  organization filter. Anyone holding an attachment id could remove another tenant's row. Its
  `ensureAuth` guard was **inert**: the `Authorizer` constructor parameter it consulted was never
  supplied by any production site, so all eleven auth calls were no-ops. Zero callers, so not
  exploitable — but it would have been the moment someone wired it up.
- **`getWithRelations` returned the base row cast to `AttachmentWithRelations`** without loading a
  single relation, so every promised field was `undefined`. The body's own comment admits it.

The `Authorizer` parameter is deleted outright: a permission hook below the router is what the lib
guide forbids, and this one never ran.

Others deleted for cause rather than disuse: `reorderAttachments` (same missing org filter, plus one
statement per id), `getEntityAttachmentStats` (up to 4 queries *per attachment*, in a loop),
`getAttachmentStats` / `getAttachmentUsage` (unbounded full-org scan, no `LIMIT`).

**Nothing on the list turned out to still have callers** — no `getStorageManager`-style surprise this
time.

## `idempotencyKey` not ported

Nothing ever passed it, and the branch it gated matched on the *payload*
(`org, entityType, entityId, title, fileId, assetId`) while never comparing the key, then returned a
partial 15-column projection cast to `Attachment`. Left off the new module on the
`findAssetByChecksum` precedent from 5a — **porting a bug launders it into the new code.**

## The hot batch is preserved

`fetchAttachmentsForEntities` is the mail read path. Query shape carried over verbatim: one `SELECT`
over `Attachment` with `MediaAsset` and `FolderFile` `LEFT JOIN`ed, same 14-column projection, same
`ORDER BY sort, createdAt`, grouping still in memory, empty-list short-circuit kept.

Three tests pin it so a future refactor cannot quietly regress it into N queries:
200 ids in → `journal.ops('db')` asserts exactly `['select']`; an empty id list touches the database
not at all; and the full projection key set is asserted, so pulling either library into its own round
trip fails.

(5a hit the analogous trap — routing `getDownloadUrls` through the single-item helper would have made
3 queries into 3N.)

## Other behaviour changes

- **Errors are `AuxxError` subclasses.** Missing attachment → 404, malformed target / no storage
  location → 400. Previously every one was a 500.
- **`updateAttachment` writes a closed column set.** The old `.set({ ...(data as any) })` would
  happily have moved a row to another `organizationId` or `entityId`. An empty patch is now a 400
  rather than a Drizzle crash.
- **`cleanupOrphanedAttachments`' DELETE is org-scoped** — defence in depth; ids already came from
  org-scoped selects.
- `deleteAttachment` on a foreign-org id is a 404 rather than a silent no-op.

`Attachment.organizationId` is `NOT NULL` and the table has **no `deletedAt`**, so unlike
`StorageLocation` an `eq()` filter hides nothing and delete is genuinely hard.

## What the typed contract refused

`resolveVersion` returned `version: any`. Two of its four projections select no `id`, and **none
selects `name`** — yet `getDownloadInfo` computed `attachment.title || version.name || 'attachment'`.
The middle term was always `undefined`, so in production the expression had already collapsed to
`title || 'attachment'`. Naming the shape (`ResolvedAttachmentVersion`) refuses to compile that read,
which is how it surfaced. **Value unchanged; the lie is gone.**

`fetchAttachmentsForEntities`' `attachment.assetId || attachment.fileId!` is preserved verbatim
behind a documented cast — dropping XOR-violating rows would be a silent behaviour change.

## Where the plan is wrong

1. **§5.3's scope block is largely a list of dead code** (see above). Only `getAttachment`,
   `getEntityAttachments`, `fetchAttachmentsForEntities` and `createAttachment` earned a home.
   Followed §5.1 over §5.3 and deleted the rest.
2. **§5.3 omits the whole download/content path**, which is where the real call volume is:
   `getDownloadRef` (3 callers), `getDownloadUrl` (1), `getDownloadInfo` (1) — plus `update`,
   `delete` and `attachFileToEntity`, all with callers. Same failure mode §5.2 flagged for
   `getContent`.
3. **§5.2's open "no content-read function anywhere" gap narrows:** `AttachmentService` has no
   `getContent`/`streamContent` caller, so it is a `FileService`/`MediaAssetService` problem —
   **PR 5c's**, not 5b's.
4. **The `Authorizer` callback was a permission check inside lib** and §5.3 never mentions it.
   §5.9's "confirm nothing slipped into lib" audit should have caught it two PRs ago.

## Honest caveats

- `getDownloadRef` / `getDownloadUrl` / `getDownloadInfo` **remain on the facade with their
  `await import('./file-service')` bodies intact.** Collapsing them the way `assets/download.ts` did
  needs `folder-files/` to exist — deliberately left for 5c. That is the one part of this area not
  yet on the `FilesCtx` contract.
- The two `lifecycle/` wrappers rewired here are themselves zero-caller and not exported from
  `lifecycle/index.ts`. Kept because §5.3 says "move to `lifecycle/`" and the sweeps are real
  capability — but **nothing schedules them today.**
- `nextSort` is still read-then-write, so two concurrent creates can pick the same position.
  Documented in place rather than fixed: display ordering only, ties break on `createdAt`, no unique
  constraint.

## Verification

- `packages/lib` typecheck: **0 errors** under `src/files`, `src/comments`, `src/messages`,
  `src/dispatch`, `src/email`, `src/workflow-engine`.
- `src/files/attachments`: **37 passed / 2 files**, **zero `vi.mock`**. Whole `src/files` suite green.
- `src/comments src/messages src/email src/dispatch src/workflow-engine`: 1,672 passed / 103 files.
- `apps/web` named paths: only the documented #1818 `mock-completeness` guard fails.
  `mail-router-front-door.test.ts`: 77 passed.

**Note:** a concurrent session has in-flight `SyncChangeManifest` work in `data-connectors/` and
`events/` that currently fails typecheck and two test files repo-wide. Unrelated to this PR — those
files are untouched here.

## Note for reviewers

Edits in `packages/lib` need a rebuild before `apps/*` see them (known repo footgun).