### PR TITLE
feat(products): product detail page, family card and finished-good suggestion

### DIFF
--- a/apps/web/src/app/(protected)/app/products/[productId]/page.tsx
+++ b/apps/web/src/app/(protected)/app/products/[productId]/page.tsx
@@ -1,0 +1,18 @@
+// apps/web/src/app/(protected)/app/products/[productId]/page.tsx
+
+import { DetailView } from '~/components/detail-view'
+
+type Props = { params: Promise<{ productId: string }> }
+
+/**
+ * Product detail page using the universal DetailView component
+ * (plans/products/01-product-family.md phase 3, the quotes/[quoteId] recipe).
+ * `product` has `hasDetailPage: true` — a family is something you open and
+ * edit, not a ledger row.
+ */
+async function ProductDetailPage({ params }: Props) {
+  const { productId } = await params
+  return <DetailView apiSlug='product' instanceId={productId} backUrl='/app/products' />
+}
+
+export default ProductDetailPage

--- a/apps/web/src/app/(protected)/app/products/layout.tsx
+++ b/apps/web/src/app/(protected)/app/products/layout.tsx
@@ -1,0 +1,41 @@
+// apps/web/src/app/(protected)/app/products/layout.tsx
+
+'use client'
+
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageHeader,
+} from '@auxx/ui/components/main-page'
+import { Package2 } from 'lucide-react'
+import { usePathname } from 'next/navigation'
+
+const BASE_PATH = '/app/products'
+
+/**
+ * Products layout — the parts recipe: a plain breadcrumb shell for the list
+ * route only. Detail pages (via DetailView) render their own MainPage.
+ */
+export default function ProductsLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+
+  if (pathname !== BASE_PATH) {
+    return <>{children}</>
+  }
+
+  return (
+    <MainPage>
+      <MainPageHeader>
+        <MainPageBreadcrumb>
+          <MainPageBreadcrumbItem
+            title='Products'
+            href={BASE_PATH}
+            icon={<Package2 className='size-4' />}
+          />
+        </MainPageBreadcrumb>
+      </MainPageHeader>
+      {children}
+    </MainPage>
+  )
+}

--- a/apps/web/src/app/(protected)/app/products/page.tsx
+++ b/apps/web/src/app/(protected)/app/products/page.tsx
@@ -1,0 +1,9 @@
+// apps/web/src/app/(protected)/app/products/page.tsx
+
+'use client'
+
+import { RecordsView } from '~/components/records'
+
+export default function ProductsPage() {
+  return <RecordsView slug='products' basePath='/app/products' />
+}

--- a/apps/web/src/components/detail-view/detail-view-tab-registry.tsx
+++ b/apps/web/src/components/detail-view/detail-view-tab-registry.tsx
@@ -47,6 +47,12 @@ export const DETAIL_VIEW_TAB_COMPONENTS: Record<
     import('../drawers/tabs/part-inventory-tab').then((m) => ({ default: m.PartInventoryTab })),
 
   // ─────────────────────────────────────────────────────────────────
+  // PRODUCT TABS
+  // ─────────────────────────────────────────────────────────────────
+  'product:parts': () =>
+    import('../drawers/tabs/product-parts-tab').then((m) => ({ default: m.ProductPartsTab })),
+
+  // ─────────────────────────────────────────────────────────────────
   // QUOTE TABS
   // ─────────────────────────────────────────────────────────────────
   'quote:line-items': () =>

--- a/apps/web/src/components/drawers/cards/part-family-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-family-card.tsx
@@ -1,0 +1,228 @@
+// apps/web/src/components/drawers/cards/part-family-card.tsx
+'use client'
+
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import {
+  getInstanceId,
+  isRecordId,
+  PartKind,
+  ProductStatus,
+  parseRecordId,
+} from '@auxx/lib/resources/client'
+import type { ResourceFieldId } from '@auxx/types/field'
+import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { pluralize } from '@auxx/utils'
+import { Sparkles } from 'lucide-react'
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import {
+  toRecordId,
+  useRecordLink,
+  useRecordList,
+  useResourceProperty,
+} from '~/components/resources'
+import { useSaveSystemValues } from '~/components/resources/hooks/use-save-system-values'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import type { DrawerTabProps } from '../drawer-tab-registry'
+import { isPartKindUnset, shouldSuggestFinishedGood } from './part-family-suggestion'
+
+/** The part's own family-relevant fields. */
+const PART_FAMILY_ATTRIBUTES = ['part_product', 'part_kind'] as const
+/** ...and the product's, once the relation resolves. */
+const PRODUCT_ATTRIBUTES = ['product_title', 'product_status'] as const
+
+/** `ProductStatus.values` keyed by option value, for badge label + color. */
+const PRODUCT_STATUS_BY_VALUE = Object.fromEntries(ProductStatus.values.map((v) => [v.value, v]))
+
+/** Unwrap a RELATIONSHIP value into the related instance id. */
+function relatedInstanceId(raw: unknown): string | undefined {
+  const first = Array.isArray(raw) ? raw[0] : raw
+  if (typeof first !== 'string') return undefined
+  return isRecordId(first) ? getInstanceId(first) : first
+}
+
+/**
+ * Product-family membership for the part drawer's overview
+ * (plans/products/01-product-family.md phase 3).
+ *
+ * Renders NOTHING when the part has no `product` relation — most parts are raw
+ * materials with no family, and `TabCardSection` hides the whole "Family"
+ * section for them. When it has one: the product (click-through to its record),
+ * its status, and the sibling variants with the current part marked.
+ *
+ * Also hosts the `finished_good` suggestion (§4): a part that has a product
+ * and is nobody's subpart is almost certainly a finished good. One click
+ * writes `part_kind = 'finished_good'` through the SAME write path the
+ * Details panel's select uses (`useSaveSystemValues` → the field-value store
+ * mutation) — a suggestion the user confirms, never an auto-write, and never
+ * offered over an explicit human choice (`part_kind` set).
+ *
+ * Reads are the standard drawer paths: the relation via `useSystemValues`,
+ * siblings via `useRecordList` filtered on `part:product` (the same filter the
+ * product's Variants tab uses), and the "is nobody's subpart" check via a
+ * `subpart` list filtered by CHILD part, limit 1 — the child-side twin of
+ * part-costing-card's subpart-presence read.
+ */
+export function PartFamilyCard({ recordId }: DrawerTabProps) {
+  const { entityInstanceId: partId } = parseRecordId(recordId)
+
+  const { values } = useSystemValues(recordId, PART_FAMILY_ATTRIBUTES, { autoFetch: true })
+  const productId = relatedInstanceId(values.part_product)
+  const partKind = values.part_kind
+
+  const productDefId = useResourceProperty('product', 'id')
+  const partDefId = useResourceProperty('part', 'id')
+  const subpartDefId = useResourceProperty('subpart', 'id')
+
+  const productRecordId =
+    productDefId && productId ? toRecordId(productDefId, productId) : undefined
+  const { values: productValues } = useSystemValues(productRecordId, PRODUCT_ATTRIBUTES, {
+    autoFetch: true,
+    enabled: !!productRecordId,
+  })
+  const productTitle = productValues.product_title as string | undefined
+  const productStatus = productValues.product_status as string | undefined
+  const productLink = useRecordLink(productRecordId)
+
+  // Sibling variants: every part on the same family edge, this one included.
+  const siblingFilters: ConditionGroup[] = useMemo(
+    () => [
+      {
+        id: 'product-filter',
+        logicalOperator: 'AND' as const,
+        conditions: [
+          {
+            id: 'product-match',
+            fieldId: 'part:product' as ResourceFieldId,
+            operator: 'is' as const,
+            value: productId ?? '',
+          },
+        ],
+      },
+    ],
+    [productId]
+  )
+  const { records: siblings, isLoading: isLoadingSiblings } = useRecordList({
+    entityDefinitionId: partDefId ?? '',
+    filters: siblingFilters,
+    enabled: !!productId && !!partDefId,
+  })
+
+  // Finished-good condition (b): is this part anybody's subpart? Child-side
+  // filter (`subpart:childPart`), limit 1 — presence is the only question.
+  const partKindUnset = isPartKindUnset(partKind)
+  const usedInFilters: ConditionGroup[] = useMemo(
+    () => [
+      {
+        id: 'child-filter',
+        logicalOperator: 'AND' as const,
+        conditions: [
+          {
+            id: 'child-match',
+            fieldId: 'subpart:childPart' as ResourceFieldId,
+            operator: 'is' as const,
+            value: partId,
+          },
+        ],
+      },
+    ],
+    [partId]
+  )
+  const { records: usedInRecords, isLoading: isLoadingUsedIn } = useRecordList({
+    entityDefinitionId: subpartDefId ?? '',
+    filters: usedInFilters,
+    limit: 1,
+    enabled: !!productId && partKindUnset && !!partId && !!subpartDefId,
+  })
+
+  const { save, isPending } = useSaveSystemValues(recordId)
+
+  const suggestFinishedGood = shouldSuggestFinishedGood({
+    hasProduct: !!productId,
+    partKind,
+    subpartCheckLoaded: !isLoadingUsedIn,
+    isSubpartOfAssembly: usedInRecords.length > 0,
+  })
+
+  // No family → no card; TabCardSection hides the whole section.
+  if (!productId) return null
+
+  const statusMeta = productStatus ? PRODUCT_STATUS_BY_VALUE[productStatus] : undefined
+  const variantIndex = siblings.findIndex((record) => record.id === partId)
+
+  return (
+    <div className='space-y-2'>
+      <FieldPanel resizeId='part-family' defaultLabelWidth={130}>
+        <FieldPanelRow title='Product'>
+          <div className='flex min-h-8 flex-wrap items-center gap-2 text-sm'>
+            {productLink ? (
+              <Link href={productLink} className='truncate font-medium hover:underline'>
+                {productTitle ?? 'Loading...'}
+              </Link>
+            ) : (
+              <span className='truncate font-medium'>{productTitle ?? 'Loading...'}</span>
+            )}
+            {statusMeta && (
+              <Badge variant={(statusMeta.color ?? 'gray') as Variant} size='xs'>
+                {statusMeta.label}
+              </Badge>
+            )}
+          </div>
+        </FieldPanelRow>
+        <FieldPanelRow title='Variants'>
+          <div className='flex min-h-8 flex-col justify-center gap-0.5 py-1.5 text-sm'>
+            {isLoadingSiblings ? (
+              <span className='text-muted-foreground'>Loading...</span>
+            ) : (
+              <>
+                <span className='text-xs text-muted-foreground'>
+                  {variantIndex >= 0
+                    ? `Variant ${variantIndex + 1} of ${siblings.length}`
+                    : `${siblings.length} ${pluralize(siblings.length, 'variant')}`}
+                  {productTitle ? ` in ${productTitle}` : ''}
+                </span>
+                {siblings.map((sibling) =>
+                  sibling.id === partId ? (
+                    <span key={sibling.id} className='truncate font-medium'>
+                      {sibling.displayName ?? 'Untitled'}
+                      <span className='ms-1.5 text-xs font-normal text-muted-foreground'>
+                        (this part)
+                      </span>
+                    </span>
+                  ) : (
+                    <Link
+                      key={sibling.id}
+                      href={`/app/parts?id=${sibling.id}`}
+                      className='truncate hover:underline'>
+                      {sibling.displayName ?? 'Untitled'}
+                    </Link>
+                  )
+                )}
+              </>
+            )}
+          </div>
+        </FieldPanelRow>
+      </FieldPanel>
+
+      {suggestFinishedGood && (
+        <div className='flex items-center gap-2 rounded-md border border-green-500/40 bg-green-500/10 p-2.5'>
+          <Sparkles className='size-4 shrink-0 text-green-600' />
+          <p className='flex-1 text-xs text-muted-foreground'>
+            <span className='font-medium text-foreground'>Finished good?</span> This part heads a
+            product family and is not used in any assembly.
+          </p>
+          <Button
+            variant='outline'
+            size='xs'
+            loading={isPending}
+            loadingText='Saving...'
+            onClick={() => void save({ part_kind: PartKind.FINISHED_GOOD })}>
+            Set Finished Good
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/drawers/cards/part-family-suggestion.test.ts
+++ b/apps/web/src/components/drawers/cards/part-family-suggestion.test.ts
@@ -1,0 +1,71 @@
+// apps/web/src/components/drawers/cards/part-family-suggestion.test.ts
+//
+// The finished_good suggestion (plans/products/01-product-family.md §4) is
+// gated on ALL of: (a) the part HAS a product, (b) it is nobody's subpart,
+// (c) part_kind is unset — never over an explicit human choice. Gap C §3.2:
+// a suggestion the human confirms, never a derivation.
+
+import { describe, expect, it } from 'vitest'
+import { isPartKindUnset, shouldSuggestFinishedGood } from './part-family-suggestion'
+
+/** The all-conditions-met baseline each test perturbs one axis of. */
+const ELIGIBLE = {
+  hasProduct: true,
+  partKind: undefined as unknown,
+  subpartCheckLoaded: true,
+  isSubpartOfAssembly: false,
+}
+
+describe('shouldSuggestFinishedGood', () => {
+  it('suggests when the part has a product, is not a subpart, and part_kind is unset', () => {
+    expect(shouldSuggestFinishedGood(ELIGIBLE)).toBe(true)
+  })
+
+  it('(a) never suggests without a product', () => {
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, hasProduct: false })).toBe(false)
+  })
+
+  it('(b) never suggests for a part used as a subpart of an assembly', () => {
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, isSubpartOfAssembly: true })).toBe(false)
+  })
+
+  it('(b) waits for the subpart-presence read — no flash while the answer is unknown', () => {
+    expect(
+      shouldSuggestFinishedGood({
+        ...ELIGIBLE,
+        subpartCheckLoaded: false,
+        isSubpartOfAssembly: false,
+      })
+    ).toBe(false)
+  })
+
+  it('(c) never suggests over an explicit human choice — any set kind blocks it', () => {
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: 'component' })).toBe(false)
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: 'subassembly' })).toBe(false)
+    // Already finished_good: nothing to suggest.
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: 'finished_good' })).toBe(false)
+    // SINGLE_SELECT stored values are arrays on some read paths — same answer.
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: ['component'] })).toBe(false)
+  })
+
+  it('(c) array-shaped and empty select values still read as unset', () => {
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: null })).toBe(true)
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: '' })).toBe(true)
+    expect(shouldSuggestFinishedGood({ ...ELIGIBLE, partKind: [] })).toBe(true)
+  })
+})
+
+describe('isPartKindUnset', () => {
+  it('treats null, undefined, empty string, and empty array as unset', () => {
+    expect(isPartKindUnset(undefined)).toBe(true)
+    expect(isPartKindUnset(null)).toBe(true)
+    expect(isPartKindUnset('')).toBe(true)
+    expect(isPartKindUnset([])).toBe(true)
+    expect(isPartKindUnset([''])).toBe(true)
+  })
+
+  it('treats any concrete value as set, scalar or array-wrapped', () => {
+    expect(isPartKindUnset('component')).toBe(false)
+    expect(isPartKindUnset(['finished_good'])).toBe(false)
+  })
+})

--- a/apps/web/src/components/drawers/cards/part-family-suggestion.ts
+++ b/apps/web/src/components/drawers/cards/part-family-suggestion.ts
@@ -1,0 +1,53 @@
+// apps/web/src/components/drawers/cards/part-family-suggestion.ts
+
+/**
+ * Condition logic for the `finished_good` suggestion on the part drawer's
+ * Family card (plans/products/01-product-family.md §4).
+ *
+ * A part that has a `product` and sits at the top of its BOM is almost
+ * certainly a finished good — but Gap C §3.2 requires the value human-confirmed
+ * and auditable, so this only decides whether to OFFER the one-click chip.
+ * Never a derivation, never an auto-write.
+ */
+
+/**
+ * Whether `part_kind` counts as unset — the "never suggest over an explicit
+ * human choice" gate. `useSystemValues` collapses SINGLE_SELECT to a scalar,
+ * but stored select values are arrays on other read paths, so both shapes are
+ * handled: `null`/`undefined`, `''`, `[]`, and an array whose first entry is
+ * empty all read as unset; any concrete value (including an explicit
+ * `component`) is a human choice and blocks the suggestion.
+ */
+export function isPartKindUnset(value: unknown): boolean {
+  const first = Array.isArray(value) ? value[0] : value
+  return first == null || first === ''
+}
+
+interface SuggestFinishedGoodInput {
+  /** (a) The part HAS a product — it heads (or belongs to) a family. */
+  hasProduct: boolean
+  /** (c) Raw `part_kind` value — any set value blocks the suggestion. */
+  partKind: unknown
+  /**
+   * Whether the "is anybody's subpart?" read has actually completed. Until it
+   * has, the answer is unknown and the suggestion must not flash on.
+   */
+  subpartCheckLoaded: boolean
+  /**
+   * (b) Whether any `subpart` row names this part as its CHILD. Whether the
+   * part has its own BOM is deliberately NOT a condition — a spare sold as-is
+   * is also a finished good (Gap C §3.2's own example).
+   */
+  isSubpartOfAssembly: boolean
+}
+
+/**
+ * ALL required: (a) the part has a product, (b) it is nobody's subpart, and
+ * (c) `part_kind` is currently unset.
+ */
+export function shouldSuggestFinishedGood(input: SuggestFinishedGoodInput): boolean {
+  if (!input.hasProduct) return false
+  if (!isPartKindUnset(input.partKind)) return false
+  if (!input.subpartCheckLoaded) return false
+  return !input.isSubpartOfAssembly
+}

--- a/apps/web/src/components/drawers/drawer-tab-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-tab-registry.tsx
@@ -59,6 +59,12 @@ export const DRAWER_TAB_COMPONENTS: Record<
     import('./tabs/part-subparts-tab').then((m) => ({ default: m.PartSubpartsTab })),
   'part:vendors': () =>
     import('./tabs/part-vendors-tab').then((m) => ({ default: m.PartVendorsTab })),
+
+  // ─────────────────────────────────────────────────────────────────
+  // PRODUCT TABS
+  // ─────────────────────────────────────────────────────────────────
+  'product:parts': () =>
+    import('./tabs/product-parts-tab').then((m) => ({ default: m.ProductPartsTab })),
 }
 
 /**
@@ -115,6 +121,10 @@ export const DRAWER_TAB_CARD_COMPONENTS: Record<
   // part with a single cost candidate, hiding its whole section.
   'part:costing': () =>
     import('./cards/part-costing-card').then((m) => ({ default: m.PartCostingCard })),
+  // Product-family membership + the finished-good suggestion — renders nothing
+  // for a part with no `product` relation, hiding its whole section.
+  'part:family': () =>
+    import('./cards/part-family-card').then((m) => ({ default: m.PartFamilyCard })),
 
   // ─────────────────────────────────────────────────────────────────
   // QUOTE OVERVIEW CARDS (shared with the quote detail-view sidebar —

--- a/apps/web/src/components/drawers/tabs/product-parts-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/product-parts-tab.tsx
@@ -1,0 +1,149 @@
+// apps/web/src/components/drawers/tabs/product-parts-tab.tsx
+'use client'
+
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import type { RecordId } from '@auxx/lib/resources/client'
+import type { ResourceFieldId } from '@auxx/types/field'
+import { ScrollArea } from '@auxx/ui/components/scroll-area'
+import { Section } from '@auxx/ui/components/section'
+import { Skeleton } from '@auxx/ui/components/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@auxx/ui/components/table'
+import { formatCurrency } from '@auxx/utils/currency'
+import { Package } from 'lucide-react'
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import type { DrawerTabProps } from '../drawer-tab-registry'
+
+/** What each variant row shows — the company-parts-tab column recipe. */
+const VARIANT_ROW_ATTRIBUTES = [
+  'part_title',
+  'part_sku',
+  'part_cost',
+  'part_quantity_on_hand',
+] as const
+
+/**
+ * Variants tab for the product drawer AND detail page — the product's parts as
+ * rows via the single family edge (`part.product` / `product.parts`,
+ * plans/products/01-product-family.md §5). Rows are plain `part` records
+ * filtered on the belongs_to side (`part:product`), the same read the part
+ * drawer's Family card uses for siblings.
+ *
+ * Read-only by design: a part joins a family from its own Details panel
+ * (`product` relation field); this list has no create/detach affordance in v1.
+ */
+export function ProductPartsTab({ entityInstanceId }: DrawerTabProps) {
+  const partDefId = useResourceProperty('part', 'id')
+
+  // Parts belonging to this product family
+  const filters: ConditionGroup[] = useMemo(
+    () => [
+      {
+        id: 'product-filter',
+        logicalOperator: 'AND' as const,
+        conditions: [
+          {
+            id: 'product-match',
+            fieldId: 'part:product' as ResourceFieldId,
+            operator: 'is' as const,
+            value: entityInstanceId,
+          },
+        ],
+      },
+    ],
+    [entityInstanceId]
+  )
+
+  const { records, isLoading } = useRecordList({
+    entityDefinitionId: partDefId ?? '',
+    filters,
+    enabled: !!entityInstanceId && !!partDefId,
+  })
+
+  if (isLoading) {
+    return (
+      <div className='p-4 space-y-4'>
+        <Skeleton className='h-6 w-32' />
+        <Skeleton className='h-40 w-full' />
+      </div>
+    )
+  }
+
+  return (
+    <ScrollArea className='flex-1'>
+      <Section
+        title={`Variants (${records.length})`}
+        className='flex flex-col flex-1 min-h-0 w-full [&_[data-slot=section]]:flex-1 [&_[data-slot=section]]:border-b-0 [&_[data-slot=section-content]]:flex-1'
+        collapsible={false}
+        icon={<Package className='size-4 text-muted-foreground/50' />}>
+        {records.length === 0 ? (
+          <div className='flex h-24 flex-col items-center justify-center text-center border rounded-lg bg-muted/30'>
+            <Package className='mb-2 h-6 w-6 text-muted-foreground' />
+            <p className='text-sm text-muted-foreground'>No variants yet</p>
+            <p className='text-xs text-muted-foreground'>
+              Link parts to this product via the part&apos;s Product field
+            </p>
+          </div>
+        ) : (
+          <div className='rounded-md border'>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Part</TableHead>
+                  <TableHead className='text-right'>Cost</TableHead>
+                  <TableHead className='text-right'>On Hand</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {records.map((record) => (
+                  <ProductPartRow
+                    key={record.id}
+                    partId={record.id}
+                    recordId={toRecordId(partDefId!, record.id)}
+                  />
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </Section>
+    </ScrollArea>
+  )
+}
+
+/** One variant row: title + SKU (links to the part), cost, quantity on hand. */
+function ProductPartRow({ partId, recordId }: { partId: string; recordId: RecordId }) {
+  const { values } = useSystemValues(recordId, VARIANT_ROW_ATTRIBUTES, { autoFetch: true })
+  const title = values.part_title as string | undefined
+  const sku = values.part_sku as string | undefined
+  const cost = values.part_cost as number | null | undefined
+  const quantityOnHand = values.part_quantity_on_hand as number | null | undefined
+
+  return (
+    <TableRow>
+      <TableCell className='font-medium'>
+        <div className='flex flex-col'>
+          <Link href={`/app/parts?id=${partId}`} className='truncate hover:underline'>
+            {title ?? 'Loading...'}
+          </Link>
+          {sku && <span className='text-xs text-muted-foreground'>{sku}</span>}
+        </div>
+      </TableCell>
+      <TableCell className='text-right tabular-nums'>
+        {cost != null ? formatCurrency(cost) : <span className='text-muted-foreground'>—</span>}
+      </TableCell>
+      <TableCell className='text-right tabular-nums'>
+        {quantityOnHand != null ? quantityOnHand : <span className='text-muted-foreground'>—</span>}
+      </TableCell>
+    </TableRow>
+  )
+}

--- a/packages/lib/src/resources/client.ts
+++ b/packages/lib/src/resources/client.ts
@@ -67,6 +67,8 @@ export type {
 // Enum values (for badge labels, select options, etc.)
 export {
   CostSource,
+  PartKind,
+  ProductStatus,
   StockMovementType,
   StockStatus,
   TicketPriority,

--- a/packages/lib/src/resources/registry/detail-view-config-types.ts
+++ b/packages/lib/src/resources/registry/detail-view-config-types.ts
@@ -84,6 +84,7 @@ export type DetailViewEntityType =
   | 'company'
   | 'ticket'
   | 'part'
+  | 'product'
   | 'entity'
   | 'quote'
   | 'work_order'

--- a/packages/lib/src/resources/registry/detail-view-config.ts
+++ b/packages/lib/src/resources/registry/detail-view-config.ts
@@ -99,6 +99,22 @@ export const DETAIL_VIEW_CONFIG_REGISTRY: DetailViewConfigRegistry = {
     defaultSidebarTab: 'overview',
   },
 
+  product: {
+    entityType: 'product',
+    // The family page (plans/products/01-product-family.md phase 3): the
+    // variants list leads — a product IS its title/image plus a set of parts.
+    // The generic Details field panel lives in the sidebar overview like every
+    // other detail page; no sidebarCards needed.
+    mainTabs: [
+      { value: 'parts', label: 'Variants', icon: 'package', recordResource: 'part' },
+      { value: 'timeline', label: 'Timeline', icon: 'clock' },
+      { value: 'tasks', label: 'Tasks', icon: 'list-todo' },
+    ],
+    sidebarTabs: DEFAULT_SIDEBAR_TABS,
+    defaultTab: 'parts',
+    defaultSidebarTab: 'overview',
+  },
+
   quote: {
     entityType: 'quote',
     // Flipped to sections (dispatch M2 build spec §G — "flips to sections via

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -68,8 +68,22 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
         // The card renders nothing for a part with a single cost candidate
         // (the common case), which hides the whole section.
         { value: 'costing', label: 'Costing' },
+        // Product-family membership + the finished-good suggestion
+        // (plans/products/01-product-family.md phase 3). Renders nothing for a
+        // part with no `product` relation (most parts — raw materials), which
+        // hides the whole section.
+        { value: 'family', label: 'Family' },
       ],
     },
+  },
+
+  product: {
+    entityType: 'product',
+    // The family's parts (its variants) as rows — the same `part:product`
+    // edge the detail page's Variants tab lists.
+    additionalTabs: [
+      { value: 'parts', label: 'Variants', icon: 'package', recordResource: 'part' },
+    ],
   },
 
   service_request: {


### PR DESCRIPTION
Phase 3 of the products plan set (01 §8) — the product entity (#1840) gets its surface.

## What

- **`/app/products` + per-product detail page.** Default tab is the **Variants** list — the family's parts with SKU, cost, and on-hand — via the standard `DetailView` config registry; the product drawer gets the same tab. The route folder also fixes a latent 404: the entity sidebar already links every visible entity to `/app/<apiSlug>`, so "Products" would have led nowhere once migration 101 runs.
- **Family card** on the part drawer overview (registered `part:family`, same pattern as `part:costing`): hidden when the part has no family (raw materials — the common case), otherwise the product's title/status with click-through and "Variant N of M" with linked siblings.
- **`finished_good` suggestion**: offered only when the part **has a product**, is **nobody's subpart** (a spare sold as-is qualifies — no BOM required, per Gap C §3.2's own example), and `part_kind` is **genuinely unset** — never over an explicit human choice, with a no-flash guard on the subpart read. Apply writes `part_kind` through the identical field-save path as the Details panel's select (SINGLE_SELECT array semantics included). Suggestion, never derivation: the value decides a GL account (1310 vs 1330) and must be a stored human choice.

## Notes

- No new tRPC endpoints — all reads via `useSystemValues`/`useRecordList`, writes via the existing field-value save path.
- Config-only lib edits: `drawer-config.ts`, `detail-view-config.ts` (+ its exact-Record type union), and `PartKind`/`ProductStatus` added to the client enum exports.

## Tests

15/15 drawers (8 new for the suggestion conditions), 22/22 detail-view, scoped `tsc` clean on touched files, Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)