### PR TITLE
feat(events): unconditional two-tier sync capture (plan 07 PR 1, closes H-1)

### DIFF
--- a/packages/database/src/db/schema/data-connector-run.ts
+++ b/packages/database/src/db/schema/data-connector-run.ts
@@ -62,20 +62,35 @@ export const DataConnectorRun = pgTable(
     // live config. Null for legacy single-shot runs. See plans/data-connectors/v3.
     chainSnapshot: jsonb().$type<Record<string, unknown>>(),
     // B2 — sync-change manifest folded across this run's slices. The connector sink
-    // writes with `skipEvents: true` (no per-write fan-out); this captures the
-    // subscribed field writes (`{o,n}`) + created/archived ids so record rules can
-    // react at finalize. Structural mirror of `SyncChangeManifest` in
-    // `@auxx/lib/record-rules` (can't import across the tier boundary — keep the two
-    // in sync BY HAND, including literal types like `version: 1`). Null when the
-    // org has no enabled rules on any touched def (zero-cost path). See
-    // plans/events/b2-sync-change-manifest-plan.md.
-    manifest: jsonb().$type<{
-      version: 1
-      truncated: boolean
-      changes: Record<string, Record<string, { o?: unknown; n: unknown }>>
-      createdRecordIds: string[]
-      archivedRecordIds: string[]
-    }>(),
+    // writes on the silent `sync` lane (no per-write fan-out); this captures tier-1
+    // membership (touched records + field keys, unconditional) and tier-2 rule-
+    // subscribed `{o,n}` deltas + created/archived ids so record rules and the
+    // finalize doors can react at finalize. Structural mirror of `SyncChangeManifest`
+    // (v2) and `SyncChangeManifestV1` in `@auxx/lib/record-rules` (can't import
+    // across the tier boundary — keep in sync BY HAND, including literal `version`).
+    // Rows written before the v2 deploy hold the v1 shape — readers upgrade via
+    // `upgradeManifestV1` at the read edge. Null when nothing was captured. See
+    // plans/events/07-two-tier-sync-capture-plan.md.
+    manifest: jsonb().$type<
+      | {
+          version: 2
+          detailTruncated: boolean
+          membershipTruncated: boolean
+          touched: Record<string, string[] | 1>
+          deltas: Record<string, Record<string, { o?: unknown; n: unknown }>>
+          createdRecordIds: string[]
+          archivedRecordIds: string[]
+          createdValues?: Record<string, Record<string, unknown>>
+        }
+      | {
+          version: 1
+          truncated: boolean
+          changes: Record<string, Record<string, { o?: unknown; n: unknown }>>
+          createdRecordIds: string[]
+          archivedRecordIds: string[]
+          createdValues?: Record<string, Record<string, unknown>>
+        }
+    >(),
     // B2 — once-per-run consume claim for the manifest. The `sync:records:changed`
     // consumer atomically stamps this (`… WHERE manifestConsumedAt IS NULL RETURNING`)
     // before firing any rule action, so a redelivered event or a re-entered finalize

--- a/packages/database/src/db/schema/import-job.ts
+++ b/packages/database/src/db/schema/import-job.ts
@@ -67,18 +67,33 @@ export const ImportJob = pgTable(
     // { created, updated, skipped, failed, durationMs }
     statistics: jsonb(),
 
-    // B2 — sync-change manifest captured by the import's skipEvents writes, persisted
+    // B2 — sync-change manifest captured by the import's silent-lane writes, persisted
     // here so the `sync:records:changed` pointer event stays payload-free (same
-    // transport as DataConnectorRun.manifest — no inline cap, no truncation).
-    // Structural mirror of `SyncChangeManifest` in `@auxx/lib/record-rules` (can't
-    // import across the tier boundary — keep in sync BY HAND, incl. `version: 1`).
-    manifest: jsonb().$type<{
-      version: 1
-      truncated: boolean
-      changes: Record<string, Record<string, { o?: unknown; n: unknown }>>
-      createdRecordIds: string[]
-      archivedRecordIds: string[]
-    }>(),
+    // transport as DataConnectorRun.manifest — no inline cap, no silent truncation).
+    // Structural mirror of `SyncChangeManifest` (v2) and `SyncChangeManifestV1` in
+    // `@auxx/lib/record-rules` (can't import across the tier boundary — keep in sync
+    // BY HAND, incl. literal `version`). Rows written before the v2 deploy hold the
+    // v1 shape — readers upgrade via `upgradeManifestV1` at the read edge.
+    manifest: jsonb().$type<
+      | {
+          version: 2
+          detailTruncated: boolean
+          membershipTruncated: boolean
+          touched: Record<string, string[] | 1>
+          deltas: Record<string, Record<string, { o?: unknown; n: unknown }>>
+          createdRecordIds: string[]
+          archivedRecordIds: string[]
+          createdValues?: Record<string, Record<string, unknown>>
+        }
+      | {
+          version: 1
+          truncated: boolean
+          changes: Record<string, Record<string, { o?: unknown; n: unknown }>>
+          createdRecordIds: string[]
+          archivedRecordIds: string[]
+          createdValues?: Record<string, Record<string, unknown>>
+        }
+    >(),
     // B2 — once-per-import consume claim for the manifest (atomic
     // `… WHERE manifestConsumedAt IS NULL RETURNING` in the event consumer), so a
     // redelivered event can never double-fire rule actions.

--- a/packages/lib/src/data-connectors/__test-helpers.ts
+++ b/packages/lib/src/data-connectors/__test-helpers.ts
@@ -12,24 +12,21 @@
 // with nothing subscribed; pass overrides for whatever the case asserts on.
 
 import type { Database } from '@auxx/database'
-import type { ManifestCollector } from '../record-rules/sync-manifest-collector'
+import {
+  createManifestCollector,
+  type ManifestCollector,
+} from '../record-rules/sync-manifest-collector'
 import { newRecordFailureTally } from './record-failure-tally'
 import type { SyncCtx } from './sinks/types'
 
 /**
- * The no-op {@link ManifestCollector} — a structural copy of the `NOOP_COLLECTOR`
- * `createManifestCollector` returns when the org has no enabled record rules
- * (that constant is module-private, so it cannot be imported).
+ * A real, always-on {@link ManifestCollector} with ZERO rule subscriptions — exactly
+ * what production builds for an org with no enabled record rules (plan 07: the
+ * collector is always real; empty subscriptions just mean `subscriptionsFor` answers
+ * undefined for every def, so tier-2 delta capture never fires). Pure and DB-free.
  */
-export function noopManifestCollector(): ManifestCollector {
-  return {
-    enabled: false,
-    subscriptionsFor: () => undefined,
-    recordChange: () => {},
-    recordCreated: () => {},
-    recordArchived: () => {},
-    toJson: () => null,
-  }
+export function emptyManifestCollector(): ManifestCollector {
+  return createManifestCollector({})
 }
 
 /** A zeroed {@link SyncCtx.counters} — mirrors `newRunCounters()` in `./service`. */
@@ -63,7 +60,7 @@ export function makeSyncCtx(over: Partial<SyncCtx> = {}): SyncCtx {
     relationshipCrud: {} as SyncCtx['relationshipCrud'],
     counters: zeroRunCounters(),
     failureTally: newRecordFailureTally(),
-    manifest: noopManifestCollector(),
+    manifest: emptyManifestCollector(),
     touchedDefs: new Set<string>(),
     ...over,
   }

--- a/packages/lib/src/data-connectors/connector-sync-source-sweep-mode.test.ts
+++ b/packages/lib/src/data-connectors/connector-sync-source-sweep-mode.test.ts
@@ -7,18 +7,16 @@
 
 import { describe, expect, it, vi } from 'vitest'
 
-// buildCtx builds a B2 manifest collector (loadManifestCollector → cache/db). Stub it to
-// the no-op so this DB-free isolation test never reaches the org cache.
-vi.mock('../record-rules/sync-manifest-collector', () => ({
-  loadManifestCollector: async () => ({
-    enabled: false,
-    subscriptionsFor: () => undefined,
-    recordChange: () => {},
-    recordCreated: () => {},
-    recordArchived: () => {},
-    toJson: () => null,
-  }),
-}))
+// buildCtx builds a B2 manifest collector (loadManifestCollector → cache/db). Override
+// ONLY the loader to a zero-subscription real collector (pure, DB-free) so this
+// isolation test never reaches the org cache — everything else stays the real module.
+vi.mock('../record-rules/sync-manifest-collector', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../record-rules/sync-manifest-collector')>()
+  return {
+    ...actual,
+    loadManifestCollector: async () => actual.createManifestCollector({}),
+  }
+})
 
 import type { SyncSliceCtx } from '../sync-core/contracts'
 import type { ConnectorSyncSourceDeps, SyncSourceStream } from './connector-sync-source'

--- a/packages/lib/src/data-connectors/connector-sync-source.ts
+++ b/packages/lib/src/data-connectors/connector-sync-source.ts
@@ -389,18 +389,21 @@ class ConnectorStreamSyncSource implements ConnectorSyncSource {
     // Runs once per run (last stream, past the B1 latch), AFTER the finalize
     // writes, so the client's catch-up sees post-reconcile state. Per-def
     // changed counts come from the just-folded run manifest (one row read —
-    // `persistManifest` ran above), which holds the distinct changed/created/
-    // archived records per def. The manifest is subscription-gated, so a def
-    // with no enabled rules still ships count 0 ("changed, count unknown" per
-    // the event doc) — real counts for every def arrive with the Phase 3
-    // session collector. Defs: every mapped def plus whatever finalize itself
-    // touched (relationship resolution, orphan archival).
+    // `persistManifest` ran above), which holds the distinct touched/created/
+    // archived records per def — tier-1 membership is unconditional (plan 07),
+    // so the counts are real for every def, rules or no rules. Defs: every
+    // mapped def plus whatever finalize itself touched (relationship
+    // resolution, orphan archival). The just-folded row is v2 by construction;
+    // the upgrade shim covers a run row written before the v2 deploy.
     try {
       const defCounts: Record<string, number> = {}
       for (const mapping of allMappings) defCounts[mapping.entityDefinitionId] ??= 0
       for (const defId of syncCtx.touchedDefs) defCounts[defId] ??= 0
-      const runManifest = await getRunManifest(this.deps.db, this.deps.run.id)
-      if (runManifest) {
+      const storedManifest = await getRunManifest(this.deps.db, this.deps.run.id)
+      if (storedManifest) {
+        const { upgradeManifestV1 } = await import('../record-rules/sync-manifest-collector')
+        const runManifest =
+          storedManifest.version === 2 ? storedManifest : upgradeManifestV1(storedManifest)
         const { manifestDefCounts } = await import('../events/handlers/sync-finalize')
         for (const [defId, count] of Object.entries(manifestDefCounts(runManifest))) {
           defCounts[defId] = count

--- a/packages/lib/src/data-connectors/connector-webhook.test.ts
+++ b/packages/lib/src/data-connectors/connector-webhook.test.ts
@@ -101,17 +101,15 @@ vi.mock('./sink-source-record', () => ({
 vi.mock('./webhook-steer', () => ({
   resolveWebhookSteer: (...a: unknown[]) => resolveWebhookSteer(...a),
 }))
-// buildWebhookCtx builds a B2 manifest collector (cache/db) — stub to the no-op.
-vi.mock('../record-rules/sync-manifest-collector', () => ({
-  loadManifestCollector: async () => ({
-    enabled: false,
-    subscriptionsFor: () => undefined,
-    recordChange: () => {},
-    recordCreated: () => {},
-    recordArchived: () => {},
-    toJson: () => null,
-  }),
-}))
+// buildWebhookCtx builds a B2 manifest collector (cache/db) — override ONLY the loader
+// to a zero-subscription real collector (pure, DB-free); the rest of the module stays real.
+vi.mock('../record-rules/sync-manifest-collector', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../record-rules/sync-manifest-collector')>()
+  return {
+    ...actual,
+    loadManifestCollector: async () => actual.createManifestCollector({}),
+  }
+})
 
 import { runWebhookSteeredRun } from './connector-webhook'
 

--- a/packages/lib/src/data-connectors/service.ts
+++ b/packages/lib/src/data-connectors/service.ts
@@ -8,7 +8,7 @@ import { type Database, database as defaultDb, schema, type Transaction } from '
 import { createScopedLogger } from '@auxx/logger'
 import { and, asc, count, desc, eq, inArray, isNull, ne, sql } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
-import type { SyncChangeManifest } from '../record-rules/sync-manifest-types'
+import type { SyncChangeManifest, SyncChangeManifestV1 } from '../record-rules/sync-manifest-types'
 import type { SyncRunErrorSample } from '../sync-core/contracts'
 import { maxLevel } from './edit-impact'
 import type {
@@ -343,7 +343,12 @@ export async function foldRunManifest(
       .from(schema.DataConnectorRun)
       .where(eq(schema.DataConnectorRun.id, runId))
       .for('update')
-    const merged = mergeManifests((row?.manifest as SyncChangeManifest | null) ?? null, fragment)
+    // The stored base may still be a v1 row (written before the v2 deploy) —
+    // `mergeManifests` upgrades it internally and always writes back v2.
+    const merged = mergeManifests(
+      (row?.manifest as SyncChangeManifest | SyncChangeManifestV1 | null) ?? null,
+      fragment
+    )
     await tx
       .update(schema.DataConnectorRun)
       .set({ manifest: merged })
@@ -351,16 +356,20 @@ export async function foldRunManifest(
   })
 }
 
-/** Read the folded manifest from a run row (consumer + publish decision). */
+/**
+ * Read the folded manifest from a run row (consumer + publish decision). Returns the
+ * STORED shape — rows written before the v2 deploy are still v1; callers upgrade via
+ * `upgradeManifestV1` at their read edge (the two `sync:records:changed` consumers do).
+ */
 export async function getRunManifest(
   db: Database,
   runId: string
-): Promise<SyncChangeManifest | null> {
+): Promise<SyncChangeManifest | SyncChangeManifestV1 | null> {
   const row = await db.query.DataConnectorRun.findFirst({
     where: eq(schema.DataConnectorRun.id, runId),
     columns: { manifest: true },
   })
-  return (row?.manifest as SyncChangeManifest | null) ?? null
+  return (row?.manifest as SyncChangeManifest | SyncChangeManifestV1 | null) ?? null
 }
 
 /**
@@ -384,21 +393,26 @@ export async function claimRunManifestConsumed(db: Database, runId: string): Pro
 /**
  * B2 (F8): stamp a run's manifest as truncated after a slice's fold failed, so the
  * consumer + UI see "incomplete" instead of a silently full-looking manifest. Creates
- * a minimal empty-but-truncated manifest when no slice managed to fold at all.
+ * a minimal empty-but-truncated manifest when no slice managed to fold at all. A lost
+ * fold loses MEMBERSHIP, not just detail, so both v2 flags are set (membership
+ * truncation forces the large lane downstream); the legacy `truncated` key is stamped
+ * too so a still-v1 stored row (pre-deploy, one-release window) also reads degraded.
  */
 export async function markRunManifestDegraded(db: Database, runId: string): Promise<void> {
   const T = schema.DataConnectorRun
   const empty = JSON.stringify({
-    version: 1,
-    truncated: true,
-    changes: {},
+    version: 2,
+    detailTruncated: true,
+    membershipTruncated: true,
+    touched: {},
+    deltas: {},
     createdRecordIds: [],
     archivedRecordIds: [],
   })
   await db
     .update(T)
     .set({
-      manifest: sql`jsonb_set(coalesce(${T.manifest}, ${empty}::jsonb), '{truncated}', 'true'::jsonb)`,
+      manifest: sql`jsonb_set(jsonb_set(jsonb_set(coalesce(${T.manifest}, ${empty}::jsonb), '{detailTruncated}', 'true'::jsonb), '{membershipTruncated}', 'true'::jsonb), '{truncated}', 'true'::jsonb)`,
     })
     .where(eq(T.id, runId))
 }
@@ -424,6 +438,8 @@ export async function publishSyncRecordsChanged(
       data: {
         source: 'connector',
         organizationId: args.organizationId,
+        ref: args.runId,
+        // Deprecated duplicates, kept one release for in-flight consumers.
         runId: args.runId,
         dataConnectorId: args.dataConnectorId,
       },

--- a/packages/lib/src/data-connectors/sinks/entity-sink.ts
+++ b/packages/lib/src/data-connectors/sinks/entity-sink.ts
@@ -1043,12 +1043,17 @@ export const entitySink: EntitySink = {
           // per-record identity resolution, so there is no slice-level id list to batch
           // against — and the content-hash skip above means only genuinely changed
           // records pay it.
-          const captured = ctx.manifest?.enabled
-            ? await captureSubscribedChanges(ctx, mapping.entityDefinitionId, instanceId, {
-                ...writeSet,
-                ...rowPlan.captureSet,
-              })
-            : null
+          // The collector is always real now (plan 07) — the capture helper gates
+          // itself on `subscriptionsFor`, so no fast-path check is needed.
+          const captured = await captureSubscribedChanges(
+            ctx,
+            mapping.entityDefinitionId,
+            instanceId,
+            {
+              ...writeSet,
+              ...rowPlan.captureSet,
+            }
+          )
           // Shallow copy per attempt: a conflict retry mutates `writeSet`.
           // Event suppression comes from the handler's silent `sync` session
           // (plan 03 §3.4), not a per-call flag.
@@ -1066,30 +1071,30 @@ export const entitySink: EntitySink = {
             `${mapping.row.id}::${instanceId}`,
             record.externalId
           )
-          // B2: lifecycle-created + `set`-transition capture for synced creates.
-          if (ctx.manifest?.enabled) {
+          // B2: lifecycle-created + `set`-transition capture for synced creates
+          // (tier-2 producer capture — stays subscription-gated; tier-1 membership
+          // comes from the engine seams).
+          const subs = ctx.manifest.subscriptionsFor(mapping.entityDefinitionId)
+          if (subs) {
             const recordId = toRecordId(mapping.entityDefinitionId, instanceId)
-            const subs = ctx.manifest.subscriptionsFor(mapping.entityDefinitionId)
-            if (subs) {
-              if (subs.lifecycle.created) {
-                // Thread the raw created values so native entity-trigger lifecycle handlers
-                // (e.g. enrichCompanyOnCreate) can read them on the sync door without a DB
-                // refetch (Phase 9 / Option A). No DB read — writeSet is already in hand.
-                const createdValues = await buildCreatedValues(
-                  ctx,
-                  mapping.entityDefinitionId,
-                  writeSet
-                )
-                ctx.manifest.recordCreated(recordId, createdValues ?? undefined)
-              }
-              const entries = await buildCreateChangeEntries(
+            if (subs.lifecycle.created) {
+              // Thread the raw created values so native entity-trigger lifecycle handlers
+              // (e.g. enrichCompanyOnCreate) can read them on the sync door without a DB
+              // refetch (Phase 9 / Option A). No DB read — writeSet is already in hand.
+              const createdValues = await buildCreatedValues(
                 ctx,
                 mapping.entityDefinitionId,
-                writeSet,
-                subs.fieldIds
+                writeSet
               )
-              if (entries) ctx.manifest.recordChange(recordId, entries)
+              ctx.manifest.recordCreated(recordId, createdValues ?? undefined)
             }
+            const entries = await buildCreateChangeEntries(
+              ctx,
+              mapping.entityDefinitionId,
+              writeSet,
+              subs.fieldIds
+            )
+            if (entries) ctx.manifest.recordChange(recordId, entries)
           }
         }
         break
@@ -1198,11 +1203,11 @@ export const entitySink: EntitySink = {
         ctx.touchedDefs.add(item.entityDefinitionId)
         ctx.counters.archived += 1
         // B2: lifecycle-deleted capture for synced archives (soft-archive; the record
-        // still exists, so the consumer can snapshot last-known values).
-        if (
-          ctx.manifest?.enabled &&
-          ctx.manifest.subscriptionsFor(item.entityDefinitionId)?.lifecycle.deleted
-        ) {
+        // still exists, so the consumer can snapshot last-known values). Tier-2
+        // producer capture — the engine's archive seam records unconditional
+        // membership; this call stays for the one-PR window and is deduped on the
+        // instance id by the collector.
+        if (ctx.manifest.subscriptionsFor(item.entityDefinitionId)?.lifecycle.deleted) {
           ctx.manifest.recordArchived(recordId)
         }
       } catch (error) {

--- a/packages/lib/src/data-connectors/sinks/types.ts
+++ b/packages/lib/src/data-connectors/sinks/types.ts
@@ -71,10 +71,11 @@ export interface SyncCtx {
    */
   signal?: AbortSignal
   /**
-   * Sync-change manifest collector (B2). Accumulates subscribed field writes +
-   * lifecycle ids as the sink writes (which suppress per-write events via the
-   * silent `sync` write session), so record rules can react at finalize. The no-op stub when the org
-   * has no enabled rules — capture sites gate on `manifest.enabled`.
+   * Sync-change manifest collector (B2, always real since plan 07). Accumulates
+   * rule-subscribed tier-2 field deltas + lifecycle ids as the sink writes (which
+   * suppress per-write events via the silent `sync` write session); tier-1 touched
+   * membership is captured at the engine seams. Tier-2 capture sites gate on
+   * `subscriptionsFor`, not a collector flag.
    */
   manifest: ManifestCollector
   /** Entity definition ids touched this run — invalidated once at the end. */

--- a/packages/lib/src/events/handlers/finalize-integrity-passes.test.ts
+++ b/packages/lib/src/events/handlers/finalize-integrity-passes.test.ts
@@ -137,11 +137,29 @@ const FIELDS_BY_DEF: Record<string, Array<Record<string, unknown>>> = {
   def_ticket: [{ id: 'fld_subj', systemAttribute: 'ticket_subject', type: 'TEXT' }],
 }
 
-function manifest(changes: Record<string, Record<string, { o?: unknown; n: unknown }>>) {
+/** A fully rule-subscribed v2 manifest: touched keys derived from the delta buckets. */
+function manifest(deltas: Record<string, Record<string, { o?: unknown; n: unknown }>>) {
+  const touched: Record<string, string[]> = {}
+  for (const [rid, bucket] of Object.entries(deltas)) touched[rid] = Object.keys(bucket)
   return {
-    version: 1,
-    truncated: false,
-    changes,
+    version: 2,
+    detailTruncated: false,
+    membershipTruncated: false,
+    touched,
+    deltas,
+    createdRecordIds: [],
+    archivedRecordIds: [],
+  } as unknown as SyncChangeManifest
+}
+
+/** A tier-1-only v2 manifest: touched membership (keys or the ids-only `1`), no deltas. */
+function tier1Manifest(touched: Record<string, string[] | 1>) {
+  return {
+    version: 2,
+    detailTruncated: false,
+    membershipTruncated: false,
+    touched,
+    deltas: {},
     createdRecordIds: [],
     archivedRecordIds: [],
   } as unknown as SyncChangeManifest
@@ -335,6 +353,37 @@ describe('no matching work', () => {
     h.findCachedResource.mockResolvedValue(null)
     await run(manifest({ 'mystery:m1': { fld_addr: { n: { street1: 'x' } } } }))
     expect(h.runNormalize).not.toHaveBeenCalled()
+  })
+})
+
+// Plan 07: pass selection reads TIER-1 touched keys — a zero-rules run (empty deltas)
+// still selects, and an ids-only degraded record widens to "any pass may apply".
+describe('tier-1 selection (plan 07)', () => {
+  it('selects passes from touched keys even when no delta was captured', async () => {
+    await run(tier1Manifest({ 'contact:c1': ['fld_addr'] }))
+    expect(h.runNormalize).toHaveBeenCalledTimes(1)
+    const [event] = h.runNormalize.mock.calls[0]! as unknown as [Record<string, unknown>]
+    // No delta → the synthetic event's oldValue falls back to null.
+    expect(event.oldValue).toBeNull()
+    expect(event).toMatchObject({ recordId: 'def_contact:c1' })
+  })
+
+  it('treats an ids-only record (`1`) as "any pass may apply" — every wanted-type field targets', async () => {
+    h.lookupPhoneGeo.mockReturnValue({ city: 'LA' })
+    await run(tier1Manifest({ 'contact:c9': 1 }))
+    // The contact def carries one ADDRESS_STRUCT and one PHONE_INTL — both pass.
+    expect(h.runNormalize).toHaveBeenCalledTimes(1)
+    expect(h.fillBlankGeoFields).toHaveBeenCalledTimes(1)
+  })
+
+  it('an ids-only line item enters the totals arm with a line-total rewrite', async () => {
+    h.resolveLineParentDocument.mockResolvedValue({
+      documentType: 'invoice',
+      documentInstanceId: 'inv9',
+    })
+    await run(tier1Manifest({ 'line_item:li9': 1 }))
+    expect(h.recomputeLineTotal).toHaveBeenCalledTimes(1)
+    expect(h.recomputeTotals).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/lib/src/events/handlers/finalize-integrity-passes.ts
+++ b/packages/lib/src/events/handlers/finalize-integrity-passes.ts
@@ -14,10 +14,14 @@
 // cores (`money/totals-hooks.ts`, `geocoding/address-normalize-hook.ts`,
 // `phone-geo/derive-geo-hook.ts`) — no math or merge policy is reimplemented here.
 //
-// v1 fidelity note: the manifest is subscription-gated (`sync-manifest-collector.ts`
-// captures only fields some enabled rule watches), so these passes see what the manifest
-// saw — same bound the record-rules consumer accepts. Only `manifest.changes` is read:
-// created records appear there too (creates capture `{n}` entries).
+// Pass selection reads TIER-1 membership (`manifest.touched` — unconditional, every
+// changed record with its changed field keys), not the rule-gated tier-2 `deltas` —
+// reading deltas would under-select exactly the way B-1 described (an imported address
+// only geocoded when a rule happened to watch the field). Created records appear in
+// `touched` too (creates record their written keys). A record degraded to ids-only
+// (`touched[rid] === 1` — keys shed under the byte budget) is treated as "any pass may
+// apply": every field of the wanted type on its def becomes a target, and the totals
+// pass assumes its trigger attrs may have changed.
 //
 // Value freshness: the totals cores read every input from the store themselves; the
 // address and phone passes RE-READ the stored value per (record, field) instead of
@@ -83,7 +87,7 @@ export interface IntegrityPassesInput {
 export async function runIntegrityPasses(db: Database, input: IntegrityPassesInput): Promise<void> {
   const { organizationId, manifest } = input
   try {
-    if (Object.keys(manifest.changes).length === 0) return
+    if (Object.keys(manifest.touched).length === 0) return
 
     const resolveDef = await buildDefFieldResolver(organizationId)
     await totalsPass(db, organizationId, manifest, resolveDef)
@@ -158,31 +162,44 @@ interface FieldTypeTarget {
   entityType: string | null
   entitySlug: string
   field: CustomFieldEntity
-  change: ManifestFieldChange
+  /** Tier-2 delta when one was captured for this record+key — values are rule-gated. */
+  change?: ManifestFieldChange
 }
 
-/** Collect every (record, field) in the manifest whose resolved field is of `fieldType`. */
+/**
+ * Collect every touched (record, field) in the manifest whose resolved field is of
+ * `fieldType`. An ids-only touched record (`1`) contributes EVERY field of the wanted
+ * type on its def — its keys were shed, so any pass may apply.
+ */
 async function collectFieldTypeTargets(
   manifest: SyncChangeManifest,
   fieldType: string,
   resolveDef: DefFieldResolver
 ): Promise<FieldTypeTarget[]> {
   const targets: FieldTypeTarget[] = []
-  for (const [rid, bucket] of Object.entries(manifest.changes)) {
+  for (const [rid, touched] of Object.entries(manifest.touched)) {
     const { entityDefinitionId: rawDefId, entityInstanceId } = parseRecordId(rid as RecordId)
     const def = await resolveDef(rawDefId)
     if (!def) continue
-    for (const [key, change] of Object.entries(bucket)) {
-      const field = def.byOutputKey.get(key)
-      if (!field || field.type !== fieldType) continue
+    const deltas = manifest.deltas[rid as RecordId]
+    const push = (key: string, field: CustomFieldEntity) =>
       targets.push({
         recordId: toRecordId(def.entityDefinitionId, entityInstanceId),
         entityDefinitionId: def.entityDefinitionId,
         entityType: def.entityType,
         entitySlug: def.entitySlug,
         field,
-        change,
+        change: deltas?.[key],
       })
+    if (touched === 1) {
+      for (const [key, field] of def.byOutputKey) {
+        if (field.type === fieldType) push(key, field)
+      }
+      continue
+    }
+    for (const key of touched) {
+      const field = def.byOutputKey.get(key)
+      if (field && field.type === fieldType) push(key, field)
     }
   }
   return targets
@@ -202,7 +219,7 @@ function buildSyntheticEvent(
     entityType: target.entityType,
     entitySlug: target.entitySlug,
     field: target.field as unknown as CachedField,
-    oldValue: target.change.o ?? null,
+    oldValue: target.change?.o ?? null,
     newValue,
     oldDisplay: null,
     newDisplay: null,
@@ -261,26 +278,30 @@ async function totalsPass(
     const addParent = (documentType: 'quote' | 'invoice', documentInstanceId: string) =>
       parents.set(`${documentType}:${documentInstanceId}`, { documentType, documentInstanceId })
 
-    for (const [rid, bucket] of Object.entries(manifest.changes)) {
+    for (const [rid, touched] of Object.entries(manifest.touched)) {
       const { entityDefinitionId: rawDefId, entityInstanceId } = parseRecordId(rid as RecordId)
-      const keys = Object.keys(bucket)
+      // Ids-only degradation: the keys were shed, so any trigger attr may have
+      // changed — the record enters every arm its def qualifies for.
+      const idsOnly = touched === 1
+      const keys = idsOnly ? [] : touched
+      const hasTrigger = (set: ReadonlySet<SystemAttribute>) => idsOnly || hasAny(keys, set)
       const def = await resolveDef(rawDefId)
       // Def entityType, not systemAttribute alone, decides the arm — mirrors the hooks'
       // per-apiSlug registration and keeps a stray attr on another def from mis-writing.
       switch (def?.entityType) {
         case 'line_item':
-          if (hasAny(keys, totalsHooks.LINE_TRIGGER_ATTRS)) {
+          if (hasTrigger(totalsHooks.LINE_TRIGGER_ATTRS)) {
             lineWork.push({
               lineInstanceId: entityInstanceId,
-              rewriteLineTotal: hasAny(keys, totalsHooks.LINE_TOTAL_TRIGGER_ATTRS),
+              rewriteLineTotal: hasTrigger(totalsHooks.LINE_TOTAL_TRIGGER_ATTRS),
             })
           }
           break
         case 'quote':
-          if (hasAny(keys, totalsHooks.QUOTE_TRIGGER_ATTRS)) addParent('quote', entityInstanceId)
+          if (hasTrigger(totalsHooks.QUOTE_TRIGGER_ATTRS)) addParent('quote', entityInstanceId)
           break
         case 'invoice':
-          if (hasAny(keys, totalsHooks.INVOICE_TRIGGER_ATTRS)) {
+          if (hasTrigger(totalsHooks.INVOICE_TRIGGER_ATTRS)) {
             addParent('invoice', entityInstanceId)
           }
           break

--- a/packages/lib/src/events/handlers/handle-sync-duplicate-scan.test.ts
+++ b/packages/lib/src/events/handlers/handle-sync-duplicate-scan.test.ts
@@ -58,9 +58,11 @@ import { handleSyncRecordRules } from './handle-sync-record-rules'
 
 function manifest(over: Partial<SyncChangeManifest> = {}): SyncChangeManifest {
   return {
-    version: 1,
-    truncated: false,
-    changes: {},
+    version: 2,
+    detailTruncated: false,
+    membershipTruncated: false,
+    touched: {},
+    deltas: {},
     createdRecordIds: [],
     archivedRecordIds: [],
     ...over,
@@ -90,11 +92,12 @@ beforeEach(() => {
 })
 
 describe('handleSyncDuplicateScan', () => {
-  it('enqueues exactly one scan carrying the created + changed ids', async () => {
+  it('enqueues exactly one scan carrying the created + touched ids', async () => {
     h.getRunManifest.mockResolvedValue(
       manifest({
         createdRecordIds: ['def_1:a', 'def_1:b'] as never,
-        changes: { 'def_1:c': { f1: { o: 1, n: 2 } } } as never,
+        touched: { 'def_1:c': ['f1'] } as never,
+        deltas: { 'def_1:c': { f1: { o: 1, n: 2 } } } as never,
       })
     )
 
@@ -133,7 +136,10 @@ describe('handleSyncDuplicateScan', () => {
     // The real failure mode this guards: both consumers run off ONE event, and
     // whichever claims first starves the other. Rules MUST win the claim.
     h.getRunManifest.mockResolvedValue(
-      manifest({ changes: { 'def_1:c': { f1: { o: 1, n: 2 } } } as never })
+      manifest({
+        touched: { 'def_1:c': ['f1'] } as never,
+        deltas: { 'def_1:c': { f1: { o: 1, n: 2 } } } as never,
+      })
     )
     h.getCachedRecordRules.mockResolvedValue([
       {
@@ -190,5 +196,43 @@ describe('handleSyncDuplicateScan', () => {
   it('ignores events of other types', async () => {
     await handleSyncDuplicateScan({ data: { type: 'entity:created', data: {} } } as never)
     expect(h.getRunManifest).not.toHaveBeenCalled()
+  })
+
+  // The H-1 regression: tier-1 membership alone (zero rule subscriptions — empty
+  // deltas) must still enqueue the scan.
+  it('enqueues off touched membership alone, with no deltas captured', async () => {
+    h.getRunManifest.mockResolvedValue(
+      manifest({ touched: { 'def_1:t1': ['f1'], 'def_1:t2': 1 } as never })
+    )
+    await handleSyncDuplicateScan(connectorEvent())
+    const arg = firstEnqueue()
+    // Ids-only degraded records (`1`) are membership too — the scan needs no keys.
+    expect(arg.recordIds.sort()).toEqual(['def_1:t1', 'def_1:t2'])
+  })
+
+  it('prefers the `ref` pointer for resolution and the scope key', async () => {
+    h.getRunManifest.mockResolvedValue(manifest({ createdRecordIds: ['def_1:a'] as never }))
+    await handleSyncDuplicateScan({
+      data: {
+        type: 'sync:records:changed',
+        data: { source: 'connector', organizationId: 'org_1', ref: 'run_9' },
+      },
+    } as never)
+    expect(h.getRunManifest).toHaveBeenCalledWith(expect.anything(), 'run_9')
+    expect(firstEnqueue().scopeKey).toBe('run_9')
+  })
+
+  // One-release v1 shim: a stored v1 manifest is upgraded at the read edge.
+  it('upgrades a stored v1 manifest and enqueues its changed + created ids', async () => {
+    h.getRunManifest.mockResolvedValue({
+      version: 1,
+      truncated: false,
+      changes: { 'def_1:c': { f1: { o: 1, n: 2 } } },
+      createdRecordIds: ['def_1:a'],
+      archivedRecordIds: [],
+    } as never)
+    await handleSyncDuplicateScan(connectorEvent())
+    const arg = firstEnqueue()
+    expect(arg.recordIds.sort()).toEqual(['def_1:a', 'def_1:c'])
   })
 })

--- a/packages/lib/src/events/handlers/handle-sync-duplicate-scan.ts
+++ b/packages/lib/src/events/handlers/handle-sync-duplicate-scan.ts
@@ -11,24 +11,45 @@
 // they do for the record-rules consumer next door).
 
 import { createScopedLogger } from '@auxx/logger'
-import type { SyncChangeManifest } from '../../record-rules/sync-manifest-types'
+import type {
+  SyncChangeManifest,
+  SyncChangeManifestV1,
+} from '../../record-rules/sync-manifest-types'
 import type { AuxxEvent, SyncRecordsChangedEvent } from '../types'
 
 const logger = createScopedLogger('dedup-sync')
 
-/** Resolve the manifest a pointer event refers to (connector run row / import job row). */
+/**
+ * The event's manifest pointer: `ref` on new events, falling back to the deprecated
+ * per-source fields for in-flight legacy events (one-release window).
+ */
+function manifestRef(data: SyncRecordsChangedEvent['data']): string | undefined {
+  return data.ref ?? (data.source === 'connector' ? data.runId : data.importRef)
+}
+
+/**
+ * Resolve the manifest a pointer event refers to (connector run row / import job row),
+ * upgrading v1 rows written before the v2 deploy at this read edge (same shim as the
+ * record-rules consumer — delete with `SyncChangeManifestV1` after one release).
+ */
 async function resolveManifest(
   data: SyncRecordsChangedEvent['data']
 ): Promise<SyncChangeManifest | null> {
+  const ref = manifestRef(data)
+  if (!ref) return null
   const { database } = await import('@auxx/database')
+  let stored: SyncChangeManifest | SyncChangeManifestV1 | null
   if (data.source === 'connector') {
-    if (!data.runId) return null
     const { getRunManifest } = await import('../../data-connectors/service')
-    return getRunManifest(database, data.runId)
+    stored = await getRunManifest(database, ref)
+  } else {
+    const { getImportManifest } = await import('../../import')
+    stored = await getImportManifest(database, ref)
   }
-  if (!data.importRef) return null
-  const { getImportManifest } = await import('../../import')
-  return getImportManifest(database, data.importRef)
+  if (!stored) return null
+  if (stored.version === 2) return stored
+  const { upgradeManifestV1 } = await import('../../record-rules/sync-manifest-collector')
+  return upgradeManifestV1(stored)
 }
 
 /**
@@ -42,7 +63,8 @@ async function resolveManifest(
  * pair key, so even a duplicate delivery that slips past the jobId is a no-op
  * beyond a refreshed `updatedAt`.
  *
- * Scope is `createdRecordIds` + every record with captured field changes.
+ * Scope is `createdRecordIds` + every touched record (tier-1 membership — no
+ * rule subscriptions required, so a zero-rules org's runs are scanned too).
  * Archived ids are deliberately absent: an archived record is not a duplicate
  * subject, and `archiveEntity` already deleted its open pairs.
  */
@@ -65,22 +87,21 @@ export const handleSyncDuplicateScan = async ({ data: event }: { data: AuxxEvent
     if (!manifest) {
       logger.warn('sync:records:changed with no resolvable manifest — bailing', {
         source: data.source,
-        runId: data.runId,
-        importRef: data.importRef,
+        ref: manifestRef(data),
       })
       return
     }
 
     const recordIds = [
-      ...new Set<string>([...manifest.createdRecordIds, ...Object.keys(manifest.changes)]),
+      ...new Set<string>([...manifest.createdRecordIds, ...Object.keys(manifest.touched)]),
     ]
     if (recordIds.length === 0) return
 
     // Stable per-RUN id. A re-entered connector finalize re-publishes the pointer
     // event and BullMQ can redeliver the handler job; both collapse onto this.
-    const scopeKey = data.runId ?? data.importRef
+    const scopeKey = manifestRef(data)
     if (!scopeKey) {
-      logger.warn('sync:records:changed with neither runId nor importRef — bailing', {
+      logger.warn('sync:records:changed with no manifest ref — bailing', {
         organizationId,
         source: data.source,
       })
@@ -95,12 +116,13 @@ export const handleSyncDuplicateScan = async ({ data: event }: { data: AuxxEvent
       source: data.source,
       scopeKey,
       records: recordIds.length,
-      truncated: manifest.truncated,
+      detailTruncated: manifest.detailTruncated,
+      membershipTruncated: manifest.membershipTruncated,
     })
   } catch (error) {
     logger.error('Sync duplicate-scan enqueue failed', {
       organizationId,
-      runId: data.runId,
+      ref: manifestRef(data),
       error: error instanceof Error ? error.message : String(error),
     })
   }

--- a/packages/lib/src/events/handlers/handle-sync-record-rules.test.ts
+++ b/packages/lib/src/events/handlers/handle-sync-record-rules.test.ts
@@ -70,13 +70,24 @@ function rule(overrides: Partial<CachedRecordRule> = {}): CachedRecordRule {
 
 function manifest(over: Partial<SyncChangeManifest> = {}): SyncChangeManifest {
   return {
-    version: 1,
-    truncated: false,
-    changes: {},
+    version: 2,
+    detailTruncated: false,
+    membershipTruncated: false,
+    touched: {},
+    deltas: {},
     createdRecordIds: [],
     archivedRecordIds: [],
     ...over,
   } as SyncChangeManifest
+}
+
+/** Tier-2 deltas plus the tier-1 `touched` entries a real collector derives from them. */
+function fromDeltas(
+  deltas: Record<string, Record<string, { o?: unknown; n: unknown }>>
+): Partial<SyncChangeManifest> {
+  const touched: Record<string, string[]> = {}
+  for (const [rid, bucket] of Object.entries(deltas)) touched[rid] = Object.keys(bucket)
+  return { touched, deltas } as never
 }
 
 function connectorEvent(): { data: any } {
@@ -123,7 +134,7 @@ describe('handleSyncRecordRules', () => {
 
   it('fires a matched field transition with source: sync and {o,n}', async () => {
     h.getRunManifest.mockResolvedValue(
-      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+      manifest(fromDeltas({ 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } }))
     )
     h.getCachedRecordRules.mockResolvedValue([rule({ on: 'changed' })])
     await handleSyncRecordRules(connectorEvent() as never)
@@ -143,7 +154,7 @@ describe('handleSyncRecordRules', () => {
 
   it('does not fire when the transition does not match', async () => {
     h.getRunManifest.mockResolvedValue(
-      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'a' } } } as never })
+      manifest(fromDeltas({ 'def_1:i1': { fld_status: { o: 'a', n: 'a' } } }))
     )
     h.getCachedRecordRules.mockResolvedValue([rule({ on: 'changed' })])
     await handleSyncRecordRules(connectorEvent() as never)
@@ -152,7 +163,7 @@ describe('handleSyncRecordRules', () => {
 
   it('conditionless rule fires with no snapshot fetch', async () => {
     h.getRunManifest.mockResolvedValue(
-      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+      manifest(fromDeltas({ 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } }))
     )
     h.getCachedRecordRules.mockResolvedValue([rule({ condition: [] })])
     await handleSyncRecordRules(connectorEvent() as never)
@@ -162,7 +173,7 @@ describe('handleSyncRecordRules', () => {
 
   it('partial-snapshot fast path: condition refs all within changed keys → no fetch', async () => {
     h.getRunManifest.mockResolvedValue(
-      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+      manifest(fromDeltas({ 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } }))
     )
     h.getCachedRecordRules.mockResolvedValue([
       rule({
@@ -186,7 +197,7 @@ describe('handleSyncRecordRules', () => {
 
   it('bulk-fetch fallback: condition references an unchanged field → fetch once', async () => {
     h.getRunManifest.mockResolvedValue(
-      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+      manifest(fromDeltas({ 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } }))
     )
     h.fetchResourceSnapshots.mockResolvedValue(
       new Map([['def_1:i1', { id: 'i1', entityDefinitionId: 'def_1', fieldValues: {} }]]) as never
@@ -229,7 +240,7 @@ describe('handleSyncRecordRules', () => {
   it('import source: reads the manifest off the ImportJob row via importRef', async () => {
     h.getCachedRecordRules.mockResolvedValue([rule()])
     h.getImportManifest.mockResolvedValue(
-      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+      manifest(fromDeltas({ 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } }))
     )
     const evt = {
       data: {
@@ -248,7 +259,7 @@ describe('handleSyncRecordRules', () => {
   // finalize or redelivered handler job) and must no-op without firing anything.
   it('does not fire when the consume claim is already taken', async () => {
     h.getRunManifest.mockResolvedValue(
-      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+      manifest(fromDeltas({ 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } }))
     )
     h.getCachedRecordRules.mockResolvedValue([rule({ on: 'changed' })])
     h.claimRunManifestConsumed.mockResolvedValue(false)
@@ -258,7 +269,7 @@ describe('handleSyncRecordRules', () => {
 
   it('claims before firing on the happy path', async () => {
     h.getRunManifest.mockResolvedValue(
-      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+      manifest(fromDeltas({ 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } }))
     )
     h.getCachedRecordRules.mockResolvedValue([rule({ on: 'changed' })])
     await handleSyncRecordRules(connectorEvent() as never)
@@ -269,7 +280,7 @@ describe('handleSyncRecordRules', () => {
   // ── Phase 4 finalize integration (plan events/03 §8) ─────────────────────────
 
   it('runs the finalize pass after rules fire, on the claimed manifest', async () => {
-    const m = manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+    const m = manifest(fromDeltas({ 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } }))
     h.getRunManifest.mockResolvedValue(m)
     h.getCachedRecordRules.mockResolvedValue([rule({ on: 'changed' })])
     await handleSyncRecordRules(connectorEvent() as never)
@@ -293,7 +304,7 @@ describe('handleSyncRecordRules', () => {
   // redelivered event that loses the claim must skip it along with the rules.
   it('skips finalize on duplicate delivery (claim already taken)', async () => {
     h.getRunManifest.mockResolvedValue(
-      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+      manifest(fromDeltas({ 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } }))
     )
     h.getCachedRecordRules.mockResolvedValue([rule({ on: 'changed' })])
     h.claimRunManifestConsumed.mockResolvedValue(false)
@@ -313,7 +324,7 @@ describe('handleSyncRecordRules', () => {
   // run even when every rule was disabled between write and consume.
   it('still claims and finalizes when no rules are enabled', async () => {
     h.getRunManifest.mockResolvedValue(
-      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+      manifest(fromDeltas({ 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } }))
     )
     h.getCachedRecordRules.mockResolvedValue([])
     await handleSyncRecordRules(connectorEvent() as never)
@@ -324,7 +335,7 @@ describe('handleSyncRecordRules', () => {
 
   it('handler still succeeds when finalize rejects (rules already fired)', async () => {
     h.getRunManifest.mockResolvedValue(
-      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+      manifest(fromDeltas({ 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } }))
     )
     h.getCachedRecordRules.mockResolvedValue([rule({ on: 'changed' })])
     h.runSyncFinalize.mockRejectedValueOnce(new Error('finalize boom'))
@@ -335,7 +346,7 @@ describe('handleSyncRecordRules', () => {
   it('import source: finalize gets the importRef as its run ref', async () => {
     h.getCachedRecordRules.mockResolvedValue([rule()])
     h.getImportManifest.mockResolvedValue(
-      manifest({ changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } } as never })
+      manifest(fromDeltas({ 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } }))
     )
     const evt = {
       data: {
@@ -351,11 +362,53 @@ describe('handleSyncRecordRules', () => {
   // (empty → value) must fire off that shape.
   it('fires a set rule for a created-this-run entry (no o)', async () => {
     h.getRunManifest.mockResolvedValue(
-      manifest({ changes: { 'def_1:i1': { fld_status: { n: 'b' } } } as never })
+      manifest(fromDeltas({ 'def_1:i1': { fld_status: { n: 'b' } } }))
     )
     h.getCachedRecordRules.mockResolvedValue([rule({ on: 'set' })])
     await handleSyncRecordRules(connectorEvent() as never)
     expect(h.fireRecordRulesBatch).toHaveBeenCalledTimes(1)
     expect(firstEvent()).toMatchObject({ oldValue: undefined, newValue: 'b' })
+  })
+
+  // ── v1 → v2 read edge (one-release shim) ────────────────────────────────────
+
+  it('upgrades a stored v1 manifest at the read edge — rules fire and finalize sees v2', async () => {
+    h.getRunManifest.mockResolvedValue({
+      version: 1,
+      truncated: false,
+      changes: { 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } },
+      createdRecordIds: [],
+      archivedRecordIds: [],
+    } as never)
+    h.getCachedRecordRules.mockResolvedValue([rule({ on: 'changed' })])
+    await handleSyncRecordRules(connectorEvent() as never)
+
+    expect(h.fireRecordRulesBatch).toHaveBeenCalledTimes(1)
+    expect(firstEvent()).toMatchObject({ oldValue: 'a', newValue: 'b' })
+    // Finalize receives the UPGRADED v2 shape — touched derived from `changes`.
+    const passed = h.runSyncFinalize.mock.calls[0]?.[1]?.manifest as SyncChangeManifest
+    expect(passed.version).toBe(2)
+    expect(passed.touched).toEqual({ 'def_1:i1': ['fld_status'] })
+    expect(passed.deltas).toEqual({ 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } })
+    expect(passed.membershipTruncated).toBe(false)
+  })
+
+  // ── { source, ref } pointer shape ───────────────────────────────────────────
+
+  it('prefers `ref` and resolves without the deprecated per-source fields', async () => {
+    h.getRunManifest.mockResolvedValue(
+      manifest(fromDeltas({ 'def_1:i1': { fld_status: { o: 'a', n: 'b' } } }))
+    )
+    h.getCachedRecordRules.mockResolvedValue([rule({ on: 'changed' })])
+    const evt = {
+      data: {
+        type: 'sync:records:changed',
+        data: { source: 'connector', organizationId: 'org_1', ref: 'run_9' },
+      },
+    }
+    await handleSyncRecordRules(evt as never)
+    expect(h.getRunManifest).toHaveBeenCalledWith({}, 'run_9')
+    expect(h.claimRunManifestConsumed).toHaveBeenCalledWith({}, 'run_9')
+    expect(h.runSyncFinalize.mock.calls[0]?.[1]).toMatchObject({ ref: 'run_9' })
   })
 })

--- a/packages/lib/src/events/handlers/handle-sync-record-rules.ts
+++ b/packages/lib/src/events/handlers/handle-sync-record-rules.ts
@@ -13,25 +13,48 @@
 import { createScopedLogger } from '@auxx/logger'
 import { parseRecordId, type RecordId } from '@auxx/types/resource'
 import type { RecordSnapshot } from '../../record-rules/resolver'
-import type { SyncChangeManifest } from '../../record-rules/sync-manifest-types'
+import type {
+  SyncChangeManifest,
+  SyncChangeManifestV1,
+} from '../../record-rules/sync-manifest-types'
 import type { CachedRecordRule } from '../../record-rules/types'
 import type { AuxxEvent, SyncRecordsChangedEvent } from '../types'
 
 const logger = createScopedLogger('record-rules-sync')
 
-/** Resolve the manifest a pointer event refers to (connector run row / import job row). */
+/**
+ * The event's manifest pointer: `ref` on new events, falling back to the deprecated
+ * per-source fields for events published before the `{ source, ref }` shape landed
+ * (one-release window — delete the fallback with the deprecated fields).
+ */
+function manifestRef(data: SyncRecordsChangedEvent['data']): string | undefined {
+  return data.ref ?? (data.source === 'connector' ? data.runId : data.importRef)
+}
+
+/**
+ * Resolve the manifest a pointer event refers to (connector run row / import job row).
+ * This is the v1→v2 read edge: run rows written before the v2 deploy hold the v1 shape
+ * and are lifted through `upgradeManifestV1` here, so everything downstream sees v2
+ * only. Delete the shim with `SyncChangeManifestV1` after one release.
+ */
 async function resolveManifest(
   data: SyncRecordsChangedEvent['data']
 ): Promise<SyncChangeManifest | null> {
+  const ref = manifestRef(data)
+  if (!ref) return null
   const { database } = await import('@auxx/database')
+  let stored: SyncChangeManifest | SyncChangeManifestV1 | null
   if (data.source === 'connector') {
-    if (!data.runId) return null
     const { getRunManifest } = await import('../../data-connectors/service')
-    return getRunManifest(database, data.runId)
+    stored = await getRunManifest(database, ref)
+  } else {
+    const { getImportManifest } = await import('../../import')
+    stored = await getImportManifest(database, ref)
   }
-  if (!data.importRef) return null
-  const { getImportManifest } = await import('../../import')
-  return getImportManifest(database, data.importRef)
+  if (!stored) return null
+  if (stored.version === 2) return stored
+  const { upgradeManifestV1 } = await import('../../record-rules/sync-manifest-collector')
+  return upgradeManifestV1(stored)
 }
 
 /**
@@ -41,15 +64,15 @@ async function resolveManifest(
  * handler job. Exactly one claimant proceeds; everyone else no-ops.
  */
 async function claimManifest(data: SyncRecordsChangedEvent['data']): Promise<boolean> {
+  const ref = manifestRef(data)
+  if (!ref) return false
   const { database } = await import('@auxx/database')
   if (data.source === 'connector') {
-    if (!data.runId) return false
     const { claimRunManifestConsumed } = await import('../../data-connectors/service')
-    return claimRunManifestConsumed(database, data.runId)
+    return claimRunManifestConsumed(database, ref)
   }
-  if (!data.importRef) return false
   const { claimImportManifestConsumed } = await import('../../import')
-  return claimImportManifestConsumed(database, data.importRef)
+  return claimImportManifestConsumed(database, ref)
 }
 
 export const handleSyncRecordRules = async ({ data: event }: { data: AuxxEvent }) => {
@@ -62,15 +85,17 @@ export const handleSyncRecordRules = async ({ data: event }: { data: AuxxEvent }
     if (!manifest) {
       logger.warn('sync:records:changed with no resolvable manifest — bailing', {
         source: data.source,
-        runId: data.runId,
-        importRef: data.importRef,
+        ref: manifestRef(data),
       })
       return
     }
-    if (manifest.truncated) {
+    if (manifest.detailTruncated || manifest.membershipTruncated) {
       logger.warn('sync-change manifest truncated — some changes will not fire rules', {
         organizationId,
-        changed: Object.keys(manifest.changes).length,
+        detailTruncated: manifest.detailTruncated,
+        membershipTruncated: manifest.membershipTruncated,
+        touched: Object.keys(manifest.touched).length,
+        withDeltas: Object.keys(manifest.deltas).length,
         created: manifest.createdRecordIds.length,
         archived: manifest.archivedRecordIds.length,
       })
@@ -85,8 +110,7 @@ export const handleSyncRecordRules = async ({ data: event }: { data: AuxxEvent }
       logger.info('sync-change manifest already consumed — skipping duplicate delivery', {
         organizationId,
         source: data.source,
-        runId: data.runId,
-        importRef: data.importRef,
+        ref: manifestRef(data),
       })
       return
     }
@@ -127,7 +151,7 @@ export const handleSyncRecordRules = async ({ data: event }: { data: AuxxEvent }
       logger.info('sync:records:changed processed', {
         organizationId,
         source: data.source,
-        runId: data.runId,
+        ref: manifestRef(data),
         fired,
       })
     }
@@ -142,14 +166,14 @@ export const handleSyncRecordRules = async ({ data: event }: { data: AuxxEvent }
     await runSyncFinalize(database, {
       organizationId,
       source: data.source,
-      ref: (data.source === 'connector' ? data.runId : data.importRef) as string,
+      ref: manifestRef(data) as string,
       dataConnectorId: data.dataConnectorId,
       manifest,
     })
   } catch (error) {
     logger.error('Sync record-rule dispatch failed', {
       organizationId,
-      runId: data.runId,
+      ref: manifestRef(data),
       error: error instanceof Error ? error.message : String(error),
     })
   }
@@ -162,9 +186,11 @@ function push<T>(map: Map<string, T[]>, key: string, value: T): void {
 }
 
 /**
- * Field-transition firings. Per record → per rule on the changed field: match the
- * transition, then choose a snapshot (partial from the manifest when the rule's
- * condition refs all resolve within the record's changed keys, else a bulk fetch).
+ * Field-transition firings off the TIER-2 deltas (v1's `changes`, renamed — identical
+ * behavior; tier-1 `touched` carries no values, so rules never read it). Per record →
+ * per rule on the changed field: match the transition, then choose a snapshot (partial
+ * from the manifest when the rule's condition refs all resolve within the record's
+ * delta keys, else a bulk fetch).
  * Events are grouped per def and handed to `fireRecordRulesBatch` so native system-rule
  * actions get one batched invocation across the run (D11); non-native rules run per
  * record exactly as before.
@@ -174,7 +200,7 @@ async function fireFieldChanges(
   manifest: SyncChangeManifest,
   fieldRulesByDef: Map<string, CachedRecordRule[]>
 ): Promise<number> {
-  const recordIds = Object.keys(manifest.changes) as RecordId[]
+  const recordIds = Object.keys(manifest.deltas) as RecordId[]
   if (recordIds.length === 0 || fieldRulesByDef.size === 0) return 0
 
   const { getCachedResourceFields } = await import('../../cache')
@@ -202,7 +228,7 @@ async function fireFieldChanges(
     fieldId: string
     o: unknown
     n: unknown
-    changeBucket: SyncChangeManifest['changes'][RecordId]
+    changeBucket: SyncChangeManifest['deltas'][RecordId]
     needsSnapshot: boolean
     needsFull: boolean
   }
@@ -213,7 +239,7 @@ async function fireFieldChanges(
     const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
     const rulesForDef = fieldRulesByDef.get(entityDefinitionId)
     if (!rulesForDef) continue
-    const changeBucket = manifest.changes[recordId]
+    const changeBucket = manifest.deltas[recordId]
     if (!changeBucket) continue
     const changedKeys = new Set(Object.keys(changeBucket))
     const keyMap = await keyMapFor(entityDefinitionId)

--- a/packages/lib/src/events/handlers/sync-finalize.int.test.ts
+++ b/packages/lib/src/events/handlers/sync-finalize.int.test.ts
@@ -14,14 +14,14 @@
 // none of them. This file drives `runSyncFinalize` against real rows and asserts the
 // database afterwards.
 //
-// THE SUBSCRIPTION SIDESTEP. In production the manifest is built by
-// `record-rules/sync-manifest-collector.ts`, which is gated on ENABLED RECORD RULES: an
-// org with no rules gets `NOOP_COLLECTOR`, `toJson()` returns null, no
-// `sync:records:changed` is ever published and finalize never runs (the v1 bound
-// documented in `sync-finalize.ts`, item H-1 in the plan). That gate is a property of the
-// PRODUCER, not of finalize — so these tests hand `runSyncFinalize` a manifest directly
-// and exercise the consumer on its own terms. `sync-manifest-collector` keeps its own
-// unit coverage for the gating itself.
+// MANIFEST SHAPE. These tests hand `runSyncFinalize` a manifest directly and exercise
+// the consumer on its own terms; `sync-manifest-collector` keeps its own unit coverage
+// for capture. Since plan 07 the collector is ALWAYS real: tier-1 membership
+// (`touched` + lifecycle) is unconditional, tier-2 `deltas` stay rule-subscription-
+// gated. The `fromDeltas` fixtures model a fully rule-subscribed run; the
+// tier-1-only suite at the bottom models the zero-rules run this harness previously
+// could not express (the H-1 regression), and the v1 suite drives a pre-deploy
+// manifest through `upgradeManifestV1`.
 //
 // WHAT IS MOCKED, and why each one is a true external:
 //   - `../../cache`      — Redis-backed org cache. Re-implemented here against the test
@@ -214,13 +214,28 @@ async function instances(f: Fixture, count: number, lastActivityAt?: Date): Prom
 
 function manifest(over: Partial<SyncChangeManifest> = {}): SyncChangeManifest {
   return {
-    version: 1,
-    truncated: false,
-    changes: {},
+    version: 2,
+    detailTruncated: false,
+    membershipTruncated: false,
+    touched: {},
+    deltas: {},
     createdRecordIds: [],
     archivedRecordIds: [],
     ...over,
   } as SyncChangeManifest
+}
+
+/**
+ * Tier-2 deltas plus the tier-1 `touched` entries a real collector derives from them
+ * (`recordChange` implies `recordTouched` with the same keys) — the "every touched
+ * field also has a delta" fixture shape, i.e. a fully rule-subscribed run.
+ */
+function fromDeltas(
+  deltas: Record<string, Record<string, { o?: unknown; n: unknown }>>
+): Partial<SyncChangeManifest> {
+  const touched: Record<string, string[]> = {}
+  for (const [rid, bucket] of Object.entries(deltas)) touched[rid] = Object.keys(bucket)
+  return { touched, deltas } as never
 }
 
 /** Import manifests key RecordIds by SLUG — the keyspace finalize must canonicalize. */
@@ -266,15 +281,15 @@ describe('timeline door (D-4)', () => {
       db(),
       importInput(
         f,
-        manifest({
-          changes: {
+        manifest(
+          fromDeltas({
             [slugRid(f, a!)]: {
               first_name: { o: 'Bob', n: 'Robert' },
               email: { o: null, n: 'r@example.com' },
             },
             [slugRid(f, b!)]: { first_name: { n: 'Ada' } },
-          },
-        })
+          })
+        )
       )
     )
 
@@ -314,10 +329,10 @@ describe('timeline door (D-4)', () => {
     const f = await seed()
     const ids = await instances(f, SYNC_SMALL_RUN_THRESHOLD + 1)
 
-    const changes: Record<string, Record<string, { n: unknown }>> = {}
-    for (const id of ids) changes[slugRid(f, id)] = { first_name: { n: 'x' }, email: { n: 'y' } }
+    const deltas: Record<string, Record<string, { n: unknown }>> = {}
+    for (const id of ids) deltas[slugRid(f, id)] = { first_name: { n: 'x' }, email: { n: 'y' } }
 
-    await runSyncFinalize(db(), importInput(f, manifest({ changes } as never)))
+    await runSyncFinalize(db(), importInput(f, manifest(fromDeltas(deltas as never))))
 
     const rows = await timelineFor(f)
     // 101 records × 2 changed fields — collapsed, so 101 rows and not 202.
@@ -360,7 +375,7 @@ describe('timeline door (D-4)', () => {
         f,
         manifest({
           createdRecordIds: [slugRid(f, id!)],
-          changes: { [slugRid(f, id!)]: { first_name: { n: 'Ada' } } },
+          ...fromDeltas({ [slugRid(f, id!)]: { first_name: { n: 'Ada' } } }),
         })
       )
     )
@@ -400,7 +415,7 @@ describe('lastActivityAt door (D-1)', () => {
       importInput(
         f,
         manifest({
-          changes: { [slugRid(f, changed!)]: { first_name: { n: 'Ada' } } },
+          ...fromDeltas({ [slugRid(f, changed!)]: { first_name: { n: 'Ada' } } }),
           createdRecordIds: [slugRid(f, created!)],
           archivedRecordIds: [slugRid(f, archived!)],
         })
@@ -419,7 +434,7 @@ describe('lastActivityAt door (D-1)', () => {
 
     await runSyncFinalize(
       db(),
-      importInput(f, manifest({ changes: { [slugRid(f, id!)]: { first_name: { n: 'Ada' } } } }))
+      importInput(f, manifest(fromDeltas({ [slugRid(f, id!)]: { first_name: { n: 'Ada' } } })))
     )
 
     expect((await instanceRow(f, id!)).lastActivityAt?.getTime()).toBe(future.getTime())
@@ -432,7 +447,7 @@ describe('lastActivityAt door (D-1)', () => {
 
     await runSyncFinalize(
       db(),
-      importInput(f, manifest({ changes: { [slugRid(f, id!)]: { first_name: { n: 'Ada' } } } }))
+      importInput(f, manifest(fromDeltas({ [slugRid(f, id!)]: { first_name: { n: 'Ada' } } })))
     )
 
     expect((await instanceRow(f, id!)).updatedAt.getTime()).toBe(before.getTime())
@@ -447,9 +462,9 @@ describe('lane selection (D-12)', () => {
   it('takes the small lane at exactly the threshold and the large lane one over', async () => {
     const atThreshold = await seed()
     const ids = await instances(atThreshold, SYNC_SMALL_RUN_THRESHOLD)
-    const changes: Record<string, Record<string, { n: unknown }>> = {}
-    for (const id of ids) changes[slugRid(atThreshold, id)] = { first_name: { n: 'x' } }
-    await runSyncFinalize(db(), importInput(atThreshold, manifest({ changes } as never)))
+    const deltas: Record<string, Record<string, { n: unknown }>> = {}
+    for (const id of ids) deltas[slugRid(atThreshold, id)] = { first_name: { n: 'x' } }
+    await runSyncFinalize(db(), importInput(atThreshold, manifest(fromDeltas(deltas as never))))
 
     const smallRows = await timelineFor(atThreshold)
     expect(smallRows.every((r) => r.eventType === 'entity:field:updated')).toBe(true)
@@ -460,9 +475,9 @@ describe('lane selection (D-12)', () => {
 
     const over = await seed()
     const overIds = await instances(over, SYNC_SMALL_RUN_THRESHOLD + 1)
-    const overChanges: Record<string, Record<string, { n: unknown }>> = {}
-    for (const id of overIds) overChanges[slugRid(over, id)] = { first_name: { n: 'x' } }
-    await runSyncFinalize(db(), importInput(over, manifest({ changes: overChanges } as never)))
+    const overDeltas: Record<string, Record<string, { n: unknown }>> = {}
+    for (const id of overIds) overDeltas[slugRid(over, id)] = { first_name: { n: 'x' } }
+    await runSyncFinalize(db(), importInput(over, manifest(fromDeltas(overDeltas as never))))
 
     const largeRows = await timelineFor(over)
     expect(largeRows.every((r) => r.eventType === 'entity:updated')).toBe(true)
@@ -470,7 +485,7 @@ describe('lane selection (D-12)', () => {
     expect(h.triggerResourceDispatch).not.toHaveBeenCalled()
   })
 
-  it('a truncated manifest forces the large lane regardless of how few it captured', async () => {
+  it('a MEMBERSHIP-truncated manifest forces the large lane regardless of how few it captured', async () => {
     const f = await seed()
     const [id] = await instances(f, 1)
 
@@ -479,8 +494,8 @@ describe('lane selection (D-12)', () => {
       importInput(
         f,
         manifest({
-          truncated: true,
-          changes: { [slugRid(f, id!)]: { first_name: { n: 'Ada' } } },
+          membershipTruncated: true,
+          ...fromDeltas({ [slugRid(f, id!)]: { first_name: { n: 'Ada' } } }),
         })
       )
     )
@@ -488,6 +503,26 @@ describe('lane selection (D-12)', () => {
     const rows = await timelineFor(f)
     expect(rows[0]!.eventType).toBe('entity:updated')
     expect(h.triggerResourceDispatch).not.toHaveBeenCalled()
+  })
+
+  it('detail truncation alone keeps the honest count-based lane (small at a small count)', async () => {
+    const f = await seed()
+    const [id] = await instances(f, 1)
+
+    await runSyncFinalize(
+      db(),
+      importInput(
+        f,
+        manifest({
+          detailTruncated: true,
+          ...fromDeltas({ [slugRid(f, id!)]: { first_name: { n: 'Ada' } } }),
+        })
+      )
+    )
+
+    const rows = await timelineFor(f)
+    expect(rows[0]!.eventType).toBe('entity:field:updated')
+    expect(h.triggerResourceDispatch).toHaveBeenCalledTimes(1)
   })
 
   it('an empty manifest is a complete no-op — no rows, no frames, no dispatch', async () => {
@@ -515,10 +550,13 @@ describe('guarded dispatch (D-3 / D-13 / D-19)', () => {
   /** Force the large lane with `count` changed records, all matching `targets`. */
   async function largeRun(f: Fixture, count: number, targets: unknown[]) {
     const ids = await instances(f, count)
-    const changes: Record<string, Record<string, { n: unknown }>> = {}
-    for (const id of ids) changes[slugRid(f, id)] = { first_name: { n: 'x' } }
+    const deltas: Record<string, Record<string, { n: unknown }>> = {}
+    for (const id of ids) deltas[slugRid(f, id)] = { first_name: { n: 'x' } }
     h.matchResourceWorkflowTargets.mockResolvedValue({ match: {}, targets })
-    await runSyncFinalize(db(), importInput(f, manifest({ truncated: true, changes } as never)))
+    await runSyncFinalize(
+      db(),
+      importInput(f, manifest({ membershipTruncated: true, ...fromDeltas(deltas as never) }))
+    )
     return ids
   }
 
@@ -596,9 +634,9 @@ describe('guarded dispatch (D-3 / D-13 / D-19)', () => {
     // auto; 25 updated → at the threshold → held.
     const ids = await instances(f, WORKFLOW_AUTO_DISPATCH_THRESHOLD * 2 - 1)
     const createdIds = ids.slice(0, WORKFLOW_AUTO_DISPATCH_THRESHOLD - 1)
-    const changes: Record<string, Record<string, { n: unknown }>> = {}
+    const deltas: Record<string, Record<string, { n: unknown }>> = {}
     for (const id of ids.slice(WORKFLOW_AUTO_DISPATCH_THRESHOLD - 1)) {
-      changes[slugRid(f, id)] = { first_name: { n: 'x' } }
+      deltas[slugRid(f, id)] = { first_name: { n: 'x' } }
     }
 
     // `entity:created` matches wf_auto; `entity:updated` matches wf_held.
@@ -614,8 +652,8 @@ describe('guarded dispatch (D-3 / D-13 / D-19)', () => {
       importInput(
         f,
         manifest({
-          truncated: true,
-          changes,
+          membershipTruncated: true,
+          ...fromDeltas(deltas as never),
           createdRecordIds: createdIds.map((id) => slugRid(f, id)),
         } as never)
       )
@@ -689,7 +727,9 @@ describe('tier-2 frames (§7b)', () => {
       importInput(
         f,
         manifest({
-          changes: { [slugRid(f, changed!)]: { first_name: { n: 'Ada' }, email: { n: 'a@b.c' } } },
+          ...fromDeltas({
+            [slugRid(f, changed!)]: { first_name: { n: 'Ada' }, email: { n: 'a@b.c' } },
+          }),
           createdRecordIds: [slugRid(f, created!)],
           archivedRecordIds: [slugRid(f, archived!)],
         })
@@ -722,9 +762,7 @@ describe('never throws (finalize door contract)', () => {
         db(),
         importInput(
           f,
-          manifest({
-            changes: { [toRecordId('ghost_def', 'ghost_instance')]: { x: { n: 1 } } },
-          })
+          manifest(fromDeltas({ [toRecordId('ghost_def', 'ghost_instance')]: { x: { n: 1 } } }))
         )
       )
     ).resolves.toBeUndefined()
@@ -743,12 +781,127 @@ describe('never throws (finalize door contract)', () => {
     await expect(
       runSyncFinalize(
         db(),
-        importInput(f, manifest({ changes: { [slugRid(f, id!)]: { first_name: { n: 'Ada' } } } }))
+        importInput(f, manifest(fromDeltas({ [slugRid(f, id!)]: { first_name: { n: 'Ada' } } })))
       )
     ).resolves.toBeUndefined()
 
     // Realtime is the LAST door — the timeline and activity doors already committed.
     expect(await timelineFor(f)).toHaveLength(1)
     expect((await instanceRow(f, id!)).lastActivityAt).not.toBeNull()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Plan 07 — the H-1 zero-rules regression: tier-1 membership alone drives finalize
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('tier-1-only manifest (zero rule subscriptions)', () => {
+  it('drives every door with touched keys + lifecycle and EMPTY deltas', async () => {
+    const f = await seed()
+    const [changed, created] = await instances(f, 2)
+
+    // Exactly what a real collector with zero subscriptions emits: touched keys
+    // and lifecycle ids, no `{o, n}` values anywhere.
+    await runSyncFinalize(
+      db(),
+      importInput(
+        f,
+        manifest({
+          touched: {
+            [slugRid(f, changed!)]: ['first_name', 'email'],
+            [slugRid(f, created!)]: ['first_name'],
+          } as never,
+          createdRecordIds: [slugRid(f, created!)],
+        })
+      )
+    )
+
+    // Timeline: per-field rows for the changed record WITHOUT value pairs (the
+    // field name is tier-1 truth; values are tier-2 and were never captured),
+    // plus the collapsed created row.
+    const rows = await timelineFor(f)
+    const changedRows = rows.filter((r) => r.entityId === changed)
+    expect(changedRows).toHaveLength(2)
+    expect(new Set(changedRows.map((r) => r.relatedEntityId))).toEqual(
+      new Set(['first_name', 'email'])
+    )
+    for (const row of changedRows) {
+      expect(row.eventType).toBe('entity:field:updated')
+      expect(row.changes).toHaveLength(1)
+      expect(Object.keys((row.changes as Array<Record<string, unknown>>)[0]!)).toEqual(['field'])
+    }
+    expect(rows.find((r) => r.entityId === created)!.eventType).toBe('entity:created')
+
+    // Activity bumped for both.
+    expect((await instanceRow(f, changed!)).lastActivityAt).not.toBeNull()
+    expect((await instanceRow(f, created!)).lastActivityAt).not.toBeNull()
+
+    // Small-lane dispatch fired per record.
+    expect(h.triggerResourceDispatch).toHaveBeenCalledTimes(2)
+    const types = h.triggerResourceDispatch.mock.calls.map(([a]) => a.data.type).sort()
+    expect(types).toEqual(['entity:created', 'entity:updated'])
+
+    // Tier-2 frames carry the touched keys as fieldIds.
+    expect(h.publishRecordsChanged).toHaveBeenCalledTimes(1)
+    const [, , frameArgs] = h.publishRecordsChanged.mock.calls[0]!
+    const byRecord = Object.fromEntries(
+      frameArgs.entries.map((e) => [e.recordId as string, e.fieldIds])
+    )
+    expect(byRecord[changed!]).toEqual(['first_name', 'email'])
+    expect(byRecord[created!]).toBeUndefined()
+  })
+
+  it('collapses an ids-only degraded record (`touched[rid] === 1`) honestly', async () => {
+    const f = await seed()
+    const [id] = await instances(f, 1)
+
+    await runSyncFinalize(
+      db(),
+      importInput(f, manifest({ touched: { [slugRid(f, id!)]: 1 } as never }))
+    )
+
+    const rows = await timelineFor(f)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.eventType).toBe('entity:updated')
+    expect(rows[0]!.eventData).not.toHaveProperty('changedFieldIds')
+
+    const [, , frameArgs] = h.publishRecordsChanged.mock.calls[0]!
+    expect(frameArgs.entries).toEqual([{ recordId: id }])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// One-release v1 shim — a pre-deploy manifest still works end-to-end through
+// `upgradeManifestV1` (the shape `resolveManifest` hands finalize for a v1 row)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('v1 manifest through the upgrade shim', () => {
+  it('upgrades and drives the doors exactly like a natively-v2 manifest', async () => {
+    const f = await seed()
+    const [changed, created] = await instances(f, 2)
+
+    const { upgradeManifestV1 } = await import('../../record-rules/sync-manifest-collector')
+    const upgraded = upgradeManifestV1({
+      version: 1,
+      truncated: false,
+      changes: {
+        [slugRid(f, changed!)]: { first_name: { o: 'Bob', n: 'Robert' } },
+      } as never,
+      createdRecordIds: [slugRid(f, created!)] as never,
+      archivedRecordIds: [],
+    })
+
+    await runSyncFinalize(db(), importInput(f, upgraded))
+
+    const rows = await timelineFor(f)
+    const changedRow = rows.find((r) => r.entityId === changed)!
+    expect(changedRow.eventType).toBe('entity:field:updated')
+    // The delta survived the upgrade — value detail intact.
+    expect(changedRow.changes).toEqual([
+      { field: 'first_name', oldValue: 'Bob', newValue: 'Robert' },
+    ])
+    expect(rows.find((r) => r.entityId === created)!.eventType).toBe('entity:created')
+    expect((await instanceRow(f, changed!)).lastActivityAt).not.toBeNull()
+    expect(h.triggerResourceDispatch).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/lib/src/events/handlers/sync-finalize.test.ts
+++ b/packages/lib/src/events/handlers/sync-finalize.test.ts
@@ -68,13 +68,28 @@ const ORG = 'org_1'
 
 function manifest(over: Partial<SyncChangeManifest> = {}): SyncChangeManifest {
   return {
-    version: 1,
-    truncated: false,
-    changes: {},
+    version: 2,
+    detailTruncated: false,
+    membershipTruncated: false,
+    touched: {},
+    deltas: {},
     createdRecordIds: [],
     archivedRecordIds: [],
     ...over,
   } as SyncChangeManifest
+}
+
+/**
+ * Tier-2 deltas plus the tier-1 `touched` entries a real collector derives from them
+ * (`recordChange` implies `recordTouched` with the same keys) — the common "every
+ * touched field also has a delta" fixture shape.
+ */
+function fromDeltas(
+  deltas: Record<string, Record<string, { o?: unknown; n: unknown }>>
+): Partial<SyncChangeManifest> {
+  const touched: Record<string, string[]> = {}
+  for (const [rid, bucket] of Object.entries(deltas)) touched[rid] = Object.keys(bucket)
+  return { touched, deltas } as never
 }
 
 /** Fake Database with just the surfaces finalize touches. */
@@ -126,16 +141,23 @@ describe('selectSyncLane', () => {
     expect(selectSyncLane(manifest(), SYNC_SMALL_RUN_THRESHOLD + 1)).toBe('large')
   })
 
-  it('a truncated manifest is large unconditionally — the true count is unknown', () => {
-    expect(selectSyncLane(manifest({ truncated: true }), 1)).toBe('large')
+  it('MEMBERSHIP truncation is large unconditionally — the true count is unknown', () => {
+    expect(selectSyncLane(manifest({ membershipTruncated: true }), 1)).toBe('large')
+  })
+
+  it('detail truncation alone keeps the count-based lane — membership is complete', () => {
+    expect(selectSyncLane(manifest({ detailTruncated: true }), 1)).toBe('small')
+    expect(selectSyncLane(manifest({ detailTruncated: true }), SYNC_SMALL_RUN_THRESHOLD + 1)).toBe(
+      'large'
+    )
   })
 })
 
 describe('manifestDefCounts', () => {
-  it('counts distinct records per def across changes, created, and archived', () => {
+  it('counts distinct records per def across touched, created, and archived', () => {
     const counts = manifestDefCounts(
       manifest({
-        changes: { 'def_1:i1': { f: { n: 1 } }, 'def_1:i2': { f: { n: 1 } } } as never,
+        touched: { 'def_1:i1': ['f'], 'def_1:i2': ['f'] } as never,
         // i2 also created — must not double count.
         createdRecordIds: ['def_1:i2', 'part:i3'] as never,
         archivedRecordIds: ['part:i4'] as never,
@@ -148,10 +170,10 @@ describe('manifestDefCounts', () => {
 describe('runSyncFinalize — small lane', () => {
   const smallManifest = () =>
     manifest({
-      changes: {
+      ...fromDeltas({
         'def_1:i1': { fld_a: { o: 1, n: 2 }, fld_b: { n: 'x' } },
         'def_1:i2': { fld_a: { o: null, n: 3 } },
-      } as never,
+      }),
       createdRecordIds: ['def_1:i3', 'part:i4'] as never,
       archivedRecordIds: ['def_1:i5'] as never,
     })
@@ -226,7 +248,7 @@ describe('runSyncFinalize — small lane', () => {
       organizationId: ORG,
       source: 'import',
       ref: 'job_1',
-      manifest: manifest({ changes: { 'def_1:i1': { f: { n: 1 } } } as never }),
+      manifest: manifest(fromDeltas({ 'def_1:i1': { f: { n: 1 } } })),
     })
     expect(insertedRows()[0]).toMatchObject({ actorType: 'system', actorId: 'system' })
   })
@@ -273,13 +295,85 @@ describe('runSyncFinalize — small lane', () => {
   })
 })
 
+// The H-1 regression (plan 07): a collector with ZERO rule subscriptions still
+// produces tier-1 membership, and that alone must drive every finalize door.
+describe('runSyncFinalize — tier-1-only manifest (zero rule subscriptions)', () => {
+  const tier1Manifest = () =>
+    manifest({
+      // Touched keys but EMPTY deltas — nothing was rule-subscribed.
+      touched: { 'def_1:i1': ['fld_a', 'fld_b'], 'def_1:i2': ['fld_a'] } as never,
+      createdRecordIds: ['def_1:i3'] as never,
+      archivedRecordIds: ['def_1:i5'] as never,
+    })
+
+  it('drives every door off membership alone', async () => {
+    await runSyncFinalize(fakeDb(), connectorInput(tier1Manifest()))
+
+    // Activity bumped for touched + created (not archived).
+    const [ids] = h.touchEntityActivity.mock.calls[0]!
+    expect([...ids].sort()).toEqual(['i1', 'i2', 'i3'])
+
+    // Small-lane per-field rows land WITHOUT a value pair — the field name is
+    // tier-1 truth, `{o, n}` is tier-2 and was never captured.
+    const rows = insertedRows()
+    const i1Rows = rows.filter((r) => r.entityId === 'i1')
+    expect(i1Rows).toHaveLength(2)
+    for (const row of i1Rows) {
+      expect(row.eventType).toBe('entity:field:updated')
+      const changes = row.changes as Array<Record<string, unknown>>
+      expect(changes).toHaveLength(1)
+      expect(Object.keys(changes[0]!)).toEqual(['field'])
+    }
+    expect(rows.find((r) => r.entityId === 'i3')!.eventType).toBe('entity:created')
+    expect(rows.find((r) => r.entityId === 'i5')!.eventType).toBe('entity:archived')
+
+    // Integrity passes get the manifest (they select off touched keys).
+    expect(h.runIntegrityPasses).toHaveBeenCalledTimes(1)
+
+    // Dispatch: created + both updated records.
+    expect(h.triggerResourceDispatch).toHaveBeenCalledTimes(3)
+
+    // Tier-2 frames carry the touched keys as fieldIds.
+    const [, , frameArgs] = h.publishRecordsChanged.mock.calls[0]!
+    const byRecord = Object.fromEntries(
+      frameArgs.entries.map((e) => [e.recordId as string, e.fieldIds])
+    )
+    expect(byRecord.i1).toEqual(['fld_a', 'fld_b'])
+    expect(byRecord.i2).toEqual(['fld_a'])
+    expect(byRecord.i3).toBeUndefined()
+  })
+
+  it('an ids-only touched record (`1`) collapses instead of writing per-field rows', async () => {
+    await runSyncFinalize(
+      fakeDb(),
+      connectorInput(
+        manifest({
+          touched: { 'def_1:i1': 1, 'def_1:i2': ['fld_a'] } as never,
+        })
+      )
+    )
+    const rows = insertedRows()
+    const i1Row = rows.find((r) => r.entityId === 'i1')!
+    expect(i1Row.eventType).toBe('entity:updated')
+    // Honest collapse: no fabricated changedFieldIds for a record whose keys were shed.
+    expect(i1Row.eventData).not.toHaveProperty('changedFieldIds')
+    expect(rows.find((r) => r.entityId === 'i2')!.eventType).toBe('entity:field:updated')
+
+    // The frame for the ids-only record ships without fieldIds ("any field").
+    const [, , frameArgs] = h.publishRecordsChanged.mock.calls[0]!
+    const byRecord = Object.fromEntries(frameArgs.entries.map((e) => [e.recordId as string, e]))
+    expect(byRecord.i1).toEqual({ recordId: 'i1' })
+    expect(byRecord.i2).toEqual({ recordId: 'i2', fieldIds: ['fld_a'] })
+  })
+})
+
 describe('runSyncFinalize — large lane', () => {
   const largeManifest = () => {
-    const changes: Record<string, Record<string, { n: unknown }>> = {}
+    const deltas: Record<string, Record<string, { n: unknown }>> = {}
     for (let i = 0; i < SYNC_SMALL_RUN_THRESHOLD + 1; i++) {
-      changes[`def_1:r${i}`] = { fld_a: { n: i } }
+      deltas[`def_1:r${i}`] = { fld_a: { n: i } }
     }
-    return manifest({ changes: changes as never })
+    return manifest(fromDeltas(deltas))
   }
 
   it('routes dispatch through the Phase 6 guard (D-3) but still touches activity, timeline, and frames', async () => {
@@ -308,11 +402,14 @@ describe('runSyncFinalize — large lane', () => {
     expect(h.publishRecordsChanged).toHaveBeenCalledTimes(1)
   })
 
-  it('a truncated manifest takes the large lane even at a tiny observed count', async () => {
+  it('a MEMBERSHIP-truncated manifest takes the large lane even at a tiny observed count', async () => {
     await runSyncFinalize(
       fakeDb(),
       connectorInput(
-        manifest({ truncated: true, changes: { 'def_1:i1': { f: { n: 1 } } } as never })
+        manifest({
+          membershipTruncated: true,
+          ...fromDeltas({ 'def_1:i1': { f: { n: 1 } } }),
+        })
       )
     )
     expect(h.triggerResourceDispatch).not.toHaveBeenCalled()
@@ -320,10 +417,24 @@ describe('runSyncFinalize — large lane', () => {
     expect(h.publishRecordsChanged).toHaveBeenCalledTimes(1)
   })
 
+  it('a detail-truncated manifest stays on the small lane at a small observed count', async () => {
+    await runSyncFinalize(
+      fakeDb(),
+      connectorInput(
+        manifest({
+          detailTruncated: true,
+          ...fromDeltas({ 'def_1:i1': { f: { n: 1 } } }),
+        })
+      )
+    )
+    expect(h.runGuardedWorkflowDispatch).not.toHaveBeenCalled()
+    expect(h.triggerResourceDispatch).toHaveBeenCalledTimes(1)
+  })
+
   it('the small lane never touches the guard', async () => {
     await runSyncFinalize(
       fakeDb(),
-      connectorInput(manifest({ changes: { 'def_1:i1': { f: { n: 1 } } } as never }))
+      connectorInput(manifest(fromDeltas({ 'def_1:i1': { f: { n: 1 } } })))
     )
     expect(h.runGuardedWorkflowDispatch).not.toHaveBeenCalled()
     expect(h.triggerResourceDispatch).toHaveBeenCalledTimes(1)
@@ -334,7 +445,7 @@ describe('runSyncFinalize — integrity passes door (B-1)', () => {
   it('runs the integrity passes on the small lane, before dispatch', async () => {
     await runSyncFinalize(
       fakeDb(),
-      connectorInput(manifest({ changes: { 'def_1:i1': { f: { n: 1 } } } as never }))
+      connectorInput(manifest(fromDeltas({ 'def_1:i1': { f: { n: 1 } } })))
     )
     expect(h.runIntegrityPasses).toHaveBeenCalledTimes(1)
     const [, input] = h.runIntegrityPasses.mock.calls[0]!
@@ -345,11 +456,11 @@ describe('runSyncFinalize — integrity passes door (B-1)', () => {
   })
 
   it('runs the integrity passes on the large lane too', async () => {
-    const changes: Record<string, Record<string, { n: unknown }>> = {}
+    const deltas: Record<string, Record<string, { n: unknown }>> = {}
     for (let i = 0; i < SYNC_SMALL_RUN_THRESHOLD + 1; i++) {
-      changes[`def_1:r${i}`] = { fld_a: { n: i } }
+      deltas[`def_1:r${i}`] = { fld_a: { n: i } }
     }
-    await runSyncFinalize(fakeDb(), connectorInput(manifest({ changes: changes as never })))
+    await runSyncFinalize(fakeDb(), connectorInput(manifest(fromDeltas(deltas))))
     expect(h.runIntegrityPasses).toHaveBeenCalledTimes(1)
   })
 
@@ -357,7 +468,7 @@ describe('runSyncFinalize — integrity passes door (B-1)', () => {
     h.runIntegrityPasses.mockRejectedValueOnce(new Error('boom'))
     await runSyncFinalize(
       fakeDb(),
-      connectorInput(manifest({ changes: { 'def_1:i1': { f: { n: 1 } } } as never }))
+      connectorInput(manifest(fromDeltas({ 'def_1:i1': { f: { n: 1 } } })))
     )
     expect(h.triggerResourceDispatch).toHaveBeenCalledTimes(1)
     expect(h.publishRecordsChanged).toHaveBeenCalledTimes(1)
@@ -370,7 +481,7 @@ describe('runSyncFinalize — failure isolation', () => {
     await expect(
       runSyncFinalize(
         fakeDb(),
-        connectorInput(manifest({ changes: { 'def_1:i1': { f: { n: 1 } } } as never }))
+        connectorInput(manifest(fromDeltas({ 'def_1:i1': { f: { n: 1 } } })))
       )
     ).resolves.toBeUndefined()
     // Timeline failed, but dispatch and realtime still happened.
@@ -383,7 +494,7 @@ describe('runSyncFinalize — failure isolation', () => {
     await expect(
       runSyncFinalize(
         fakeDb(),
-        connectorInput(manifest({ changes: { 'def_1:i1': { f: { n: 1 } } } as never }))
+        connectorInput(manifest(fromDeltas({ 'def_1:i1': { f: { n: 1 } } })))
       )
     ).resolves.toBeUndefined()
     expect(h.publishRecordsChanged).toHaveBeenCalledTimes(1)

--- a/packages/lib/src/events/handlers/sync-finalize.ts
+++ b/packages/lib/src/events/handlers/sync-finalize.ts
@@ -15,11 +15,14 @@
 //     the large lane withholds dispatch pending the Phase 6 guard (D-3)
 //   - tier-2 `records:changed` delta frames, both lanes (plan §7b)
 //
-// v1 scope note: the changed-set is what the SUBSCRIPTION-GATED manifest
-// captured (`sync-manifest-collector.ts` only records fields/lifecycles some
-// enabled rule watches). Until the Phase 3 session collector captures every
-// write, finalize fidelity is bounded by rule subscriptions — an org with no
-// enabled rules produces no manifest and no finalize. Accepted for v1.
+// Manifest v2 (plan 07 §3): tier-1 membership (`touched` + lifecycle arrays)
+// is UNCONDITIONAL — every sync-session change reaches finalize, rules or no
+// rules. Tier-2 `deltas` stay rule-subscription-gated, so `{o, n}` detail is
+// present only where some enabled rule watches the field. Truncation only ever
+// drops detail, never membership: `detailTruncated` leaves the lane honest
+// (membership is complete, the count is real), `membershipTruncated` forces
+// the large lane. Per-record ids-only degradation (`touched[rid] === 1`)
+// collapses that record's timeline entry and widens its integrity selection.
 //
 // Keep top-level imports to types/logger/pure constants only; lazy-import
 // everything else (the events ↔ data-connectors ↔ cache boundaries break
@@ -54,9 +57,9 @@ export interface SyncFinalizeInput {
   manifest: SyncChangeManifest
 }
 
-/** The manifest's three record sets, deduped, with the created/changed overlap resolved. */
+/** The manifest's three record sets, deduped, with the created/touched overlap resolved. */
 interface ChangedSets {
-  /** Records with captured field changes that were NOT created this run. */
+  /** Touched records (tier-1 membership) that were NOT created this run. */
   updatedIds: RecordId[]
   createdIds: RecordId[]
   archivedIds: RecordId[]
@@ -67,9 +70,9 @@ interface ChangedSets {
 function collectChangedSets(manifest: SyncChangeManifest): ChangedSets {
   const createdSet = new Set<RecordId>(manifest.createdRecordIds)
   const archivedIds = [...new Set<RecordId>(manifest.archivedRecordIds)]
-  // A record created this run also appears in `changes` (creates capture `{n}`
-  // entries) — it collapses to ONE "created" entry, never created + updated.
-  const updatedIds = (Object.keys(manifest.changes) as RecordId[]).filter(
+  // A record created this run also appears in `touched` (creates record their
+  // written keys) — it collapses to ONE "created" entry, never created + updated.
+  const updatedIds = (Object.keys(manifest.touched) as RecordId[]).filter(
     (rid) => !createdSet.has(rid)
   )
   const all = new Set<RecordId>([...updatedIds, ...createdSet, ...archivedIds])
@@ -78,14 +81,16 @@ function collectChangedSets(manifest: SyncChangeManifest): ChangedSets {
 
 /**
  * Lane selection (D-12): decided at finalize from the OBSERVED changed-set
- * count, never declared by the writer. A truncated manifest means the true
- * count is unknown-but-large, so it takes the large lane unconditionally.
+ * count, never declared by the writer. Only MEMBERSHIP truncation forces the
+ * large lane — the true count is then unknown-but-large. `detailTruncated`
+ * alone means tier-2 deltas were capped while membership stayed complete, so
+ * the observed count is honest and the count-based decision stands.
  */
 export function selectSyncLane(
   manifest: SyncChangeManifest,
   changedCount: number
 ): SyncFinalizeLane {
-  if (manifest.truncated) return 'large'
+  if (manifest.membershipTruncated) return 'large'
   return changedCount <= SYNC_SMALL_RUN_THRESHOLD ? 'small' : 'large'
 }
 
@@ -103,7 +108,7 @@ export function manifestDefCounts(manifest: SyncChangeManifest): Record<string, 
     if (!set) byDef.set(entityDefinitionId, (set = new Set()))
     set.add(entityInstanceId)
   }
-  for (const rid of Object.keys(manifest.changes) as RecordId[]) add(rid)
+  for (const rid of Object.keys(manifest.touched) as RecordId[]) add(rid)
   for (const rid of manifest.createdRecordIds) add(rid)
   for (const rid of manifest.archivedRecordIds) add(rid)
   const counts: Record<string, number> = {}
@@ -124,13 +129,18 @@ export async function runSyncFinalize(db: Database, input: SyncFinalizeInput): P
     if (sets.total === 0) return
 
     const lane = selectSyncLane(manifest, sets.total)
-    if (manifest.truncated) {
-      logger.warn('sync finalize: manifest truncated — forcing large lane', {
+    if (manifest.membershipTruncated) {
+      logger.warn('sync finalize: manifest MEMBERSHIP truncated — forcing large lane', {
         organizationId,
         source,
         ref,
         changed: sets.total,
       })
+    } else if (manifest.detailTruncated) {
+      logger.info(
+        'sync finalize: manifest detail truncated — membership complete, lane stays count-based',
+        { organizationId, source, ref, changed: sets.total }
+      )
     }
     logger.info('sync finalize', { organizationId, source, ref, lane, changed: sets.total })
 
@@ -320,23 +330,28 @@ async function touchActivityDoor(
  * everything else is literal columns.
  *
  * Changed records on the SMALL lane get per-field `entity:field:updated`
- * rows (one per changed field) instead of the collapsed `entity:updated`
+ * rows (one per touched field key) instead of the collapsed `entity:updated`
  * entry — a run of ≤ SYNC_SMALL_RUN_THRESHOLD records × a handful of fields
  * keeps the bulk insert trivially bounded. The large lane keeps the
- * collapsed shape (that IS D-4). Created/archived records stay collapsed on
- * both lanes.
+ * collapsed shape (that IS D-4), counting fields from the touched key list.
+ * Created/archived records stay collapsed on both lanes, and so does a
+ * record degraded to ids-only (`touched[rid] === 1` — its keys were shed
+ * under the byte budget, so there is nothing to write per-field rows from).
  *
  * Honest deltas of the per-field rows vs the inline shape
  * (`mapFieldUpdated` in `create-timeline-event.ts`), all limited by what the
- * manifest carries (`ManifestFieldChange` is raw `{o, n}` keyed by
- * outputKey = systemAttribute ?? fieldId):
+ * manifest carries (tier-1 `touched` keys; tier-2 `ManifestFieldChange` raw
+ * `{o, n}` keyed by outputKey = systemAttribute ?? fieldId):
  * - `fieldId` / `relatedEntityId` / `changes[].field` hold the manifest
  *   outputKey — for system fields that is the attribute key, not the
  *   CustomField CUID, and never the display name the inline lane resolves.
  * - `fieldName`, `fieldType`, `entitySlug`, and the resolved
  *   `oldDisplay`/`newDisplay` snapshots are omitted, not fabricated — the
  *   manifest does not capture them. `changes[]` carries the raw
- *   `oldValue`/`newValue` pair instead (`oldValue` only when captured).
+ *   `oldValue`/`newValue` pair ONLY when a tier-2 delta exists for the
+ *   record+key (the existing "oldValue only when captured" contract,
+ *   extended: values as a whole are tier-2); a tier-1-only row still names
+ *   the field, with no value pair.
  * - `eventType` is `entity:field:updated` for every def (the inline lane
  *   maps contact/ticket to their prefixed variants) — consistent with the
  *   collapsed rows already using the `entity:*` family for all defs.
@@ -380,11 +395,18 @@ async function timelineDoor(
     }
 
     /** Small-lane per-field replay — see the honest-delta notes in the doc comment. */
-    const fieldRows = async (rid: RecordId, fieldChanges: Record<string, ManifestFieldChange>) => {
+    const fieldRows = async (
+      rid: RecordId,
+      touchedKeys: string[],
+      deltas: Record<string, ManifestFieldChange>
+    ) => {
       const { entityDefinitionId, entityInstanceId } = parseRecordId(rid)
       const canonical = await ctx.canonicalDefId(entityDefinitionId)
       const recordId = toRecordId(canonical, entityInstanceId)
-      for (const [fieldKey, change] of Object.entries(fieldChanges)) {
+      for (const fieldKey of touchedKeys) {
+        // `{o, n}` detail only when a tier-2 delta was captured for this
+        // record+key; a tier-1-only row names the field, with no value pair.
+        const change = deltas[fieldKey]
         rows.push({
           eventType: EntityInstanceEventType.FIELD_UPDATED,
           startedAt: now,
@@ -397,11 +419,13 @@ async function timelineDoor(
           actorId,
           eventData: { recordId, entityDefinitionId: canonical, fieldId: fieldKey, ...syncMeta },
           changes: [
-            {
-              field: fieldKey,
-              ...('o' in change ? { oldValue: change.o } : {}),
-              newValue: change.n,
-            },
+            change
+              ? {
+                  field: fieldKey,
+                  ...('o' in change ? { oldValue: change.o } : {}),
+                  newValue: change.n,
+                }
+              : { field: fieldKey },
           ],
           organizationId,
           updatedAt: now,
@@ -413,14 +437,19 @@ async function timelineDoor(
       await baseRow(rid, EntityInstanceEventType.CREATED, {})
     }
     for (const rid of sets.updatedIds) {
-      const fieldChanges = manifest.changes[rid] ?? {}
-      const changedFieldIds = Object.keys(fieldChanges)
-      if (lane === 'small' && changedFieldIds.length > 0) {
-        await fieldRows(rid, fieldChanges)
+      const touched = manifest.touched[rid]
+      if (touched === 1 || touched === undefined) {
+        // Ids-only degradation — keys were shed under the byte budget, so the
+        // collapsed entry is all that can honestly be written.
+        await baseRow(rid, EntityInstanceEventType.UPDATED, {})
+        continue
+      }
+      if (lane === 'small' && touched.length > 0) {
+        await fieldRows(rid, touched, manifest.deltas[rid] ?? {})
       } else {
         await baseRow(rid, EntityInstanceEventType.UPDATED, {
-          changedFieldIds,
-          changedFieldCount: changedFieldIds.length,
+          changedFieldIds: touched,
+          changedFieldCount: touched.length,
         })
       }
     }
@@ -539,11 +568,11 @@ async function guardedDispatchDoor(
 
 /**
  * §7b tier-2 `records:changed` frames, grouped per canonical def. Changed
- * records carry their manifest field keys as `fieldIds`; created and archived
- * records ship without `fieldIds` ("any field may have changed") — a client
- * refetch of the id surfaces both a new row and a vanished one. Ids only,
- * never values (D-18); `publishRecordsChanged` chunks and canonicalizes the
- * room key itself.
+ * records carry their touched field keys as `fieldIds`; created, archived,
+ * and ids-only-degraded records ship without `fieldIds` ("any field may have
+ * changed") — a client refetch of the id surfaces both a new row and a
+ * vanished one. Ids only, never values (D-18); `publishRecordsChanged`
+ * chunks and canonicalizes the room key itself.
  */
 async function realtimeDoor(
   organizationId: string,
@@ -569,7 +598,8 @@ async function realtimeDoor(
     }
 
     for (const rid of sets.updatedIds) {
-      await add(rid, Object.keys(manifest.changes[rid] ?? {}))
+      const touched = manifest.touched[rid]
+      await add(rid, touched === 1 || touched === undefined ? undefined : touched)
     }
     for (const rid of sets.createdIds) await add(rid)
     for (const rid of sets.archivedIds) await add(rid)

--- a/packages/lib/src/events/types.ts
+++ b/packages/lib/src/events/types.ts
@@ -934,8 +934,13 @@ export type SyncRecordsChangedEvent = AuxxEventGeneric<
   {
     source: 'connector' | 'import'
     organizationId: string
+    /** Manifest pointer: DataConnectorRun id (connector) or ImportJob id (import). */
+    ref?: string
+    /** @deprecated Use `ref` with `source: 'connector'`. Removed after one release. */
     runId?: string
+    /** @deprecated Derivable from the run row via `ref`. Removed after one release. */
     dataConnectorId?: string
+    /** @deprecated Use `ref` with `source: 'import'`. Removed after one release. */
     importRef?: string
   }
 >

--- a/packages/lib/src/field-values/__tests__/sync-capture.test.ts
+++ b/packages/lib/src/field-values/__tests__/sync-capture.test.ts
@@ -1,0 +1,446 @@
+// packages/lib/src/field-values/__tests__/sync-capture.test.ts
+//
+// Tier-1 sync capture at the field-value seams (plan 07 §4, PR 1): a write
+// under a sync-session origin records touched membership on the session's
+// manifest collector — but ONLY when the write actually changed something.
+// Guard short-circuits (D-6), delete-of-absent (B-14), and fully-deduped adds
+// record NOTHING (membership honesty, §4 property 1). Interactive, automation
+// and seed sessions never capture, and the inline lane's own doors are
+// untouched by capture.
+
+import { toRecordId } from '@auxx/types/resource'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ⚠️ Mock '../../realtime/publish-helpers' directly — NOT the '../../realtime'
+// barrel (see batched-realtime-publish.test.ts for the import-cycle rationale).
+vi.mock('../../realtime/publish-helpers', () => ({
+  publishFieldValueUpdates: vi.fn(),
+}))
+
+// '../../cache' is a large barrel with real DB/Redis-backed providers — mock it
+// wholesale, same entry points as the sibling set-idempotency suite.
+vi.mock('../../cache', () => ({
+  getCachedFieldMap: vi.fn(),
+  getCachedResource: vi.fn(),
+  getOrgCache: vi.fn(),
+  getAllCachedCustomFields: vi.fn(async () => []),
+  getCachedRecordRules: vi.fn(async () => []),
+}))
+
+// The field-hooks registry is imported (in the loaded graph) only by
+// field-value-mutations.ts — full replacement is safe here. Entity hooks are
+// "registered" so the inline lane's post-hook door is observable.
+vi.mock('../../field-hooks/registry', () => ({
+  hasEntityFieldChangeHooks: vi.fn(() => true),
+  hasFieldTypeChangeHooks: vi.fn(() => false),
+  hasFieldPreHooks: vi.fn(() => false),
+  getEntityFieldChangeHooks: vi.fn(() => []),
+  getFieldTypeChangeHooks: vi.fn(() => []),
+  getFieldPreHooks: vi.fn(() => []),
+}))
+
+vi.mock('../../field-hooks/collect-triggers', () => ({
+  collectTriggeredFields: vi.fn(async () => []),
+  deduplicateBySystemAttribute: vi.fn((fields: unknown[]) => fields),
+}))
+vi.mock('../../field-hooks/publish', () => ({
+  publishFieldTriggerEvents: vi.fn(async () => {}),
+  publishBatchFieldTriggerEvents: vi.fn(async () => {}),
+}))
+
+vi.mock('../timeline-snapshot', () => ({
+  preloadSnapshotCache: vi.fn(),
+  resolveFieldChangeSnapshotPair: vi.fn(async () => ({ oldDisplay: null, newDisplay: null })),
+  resolveFieldChangeSnapshotsBulk: vi.fn(async () => new Map()),
+}))
+
+// The production registry is empty (all models are EntityInstance-backed), so
+// the built-in branch is only reachable with a mocked registry.
+vi.mock('../../custom-fields/built-in-fields', () => ({
+  isBuiltInField: vi.fn(() => false),
+  getBuiltInFieldHandler: vi.fn(() => null),
+  getBuiltInFieldType: vi.fn(() => null),
+}))
+
+import { getCachedResource, getOrgCache } from '../../cache'
+import { getBuiltInFieldHandler, isBuiltInField } from '../../custom-fields/built-in-fields'
+import { getEntityFieldChangeHooks } from '../../field-hooks/registry'
+import { publishFieldValueUpdates } from '../../realtime/publish-helpers'
+import {
+  createManifestCollector,
+  type ManifestCollector,
+} from '../../record-rules/sync-manifest-collector'
+import {
+  interactiveSession,
+  seedSession,
+  type WriteSession,
+} from '../../resources/crud/write-origin'
+import { runWithWriteSession } from '../../resources/crud/write-session-als'
+import { createFieldValueContext, type FieldValueContext } from '../field-value-helpers'
+import { addValues, removeValues, setValueWithBuiltIn } from '../field-value-mutations'
+
+const mockedGetCachedResource = getCachedResource as unknown as ReturnType<typeof vi.fn>
+const mockedGetOrgCache = getOrgCache as unknown as ReturnType<typeof vi.fn>
+const mockedGetEntityHooks = getEntityFieldChangeHooks as unknown as ReturnType<typeof vi.fn>
+const mockedIsBuiltIn = vi.mocked(isBuiltInField)
+const mockedGetBuiltInHandler = vi.mocked(getBuiltInFieldHandler)
+const mockedPublish = vi.mocked(publishFieldValueUpdates)
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const recordId = toRecordId('widget', 'inst-1')
+
+function syncSession(collector: ManifestCollector): WriteSession {
+  return { origin: { kind: 'sync', source: 'connector', ref: 'run_1', collector }, depth: 0 }
+}
+
+/** Minimal CustomField-shaped fixture (same shape as the sibling suites). */
+function fieldFixture(id: string, type: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    type,
+    options: {},
+    entityDefinitionId: null,
+    entityDefinition: null,
+    entityType: null,
+    isUnique: false,
+    systemAttribute: null,
+    ...overrides,
+  }
+}
+
+const FIELD_TEXT = fieldFixture('field-text', 'TEXT')
+const FIELD_EMAIL = fieldFixture('field-email', 'EMAIL', { systemAttribute: 'primary_email' })
+const FIELD_TAGS = fieldFixture('field-tags', 'TAGS', { options: [] })
+
+/** A stored FieldValue row for (inst-1, fieldId) with payload overrides. */
+function existingRow(
+  id: string,
+  fieldId: string,
+  sortKey: string,
+  payload: Record<string, unknown>
+) {
+  return {
+    id,
+    entityId: 'inst-1',
+    entityDefinitionId: 'widget',
+    fieldId,
+    organizationId: 'org-1',
+    valueText: null,
+    valueNumber: null,
+    valueBoolean: null,
+    valueDate: null,
+    valueJson: null,
+    optionId: null,
+    relatedEntityId: null,
+    relatedEntityDefinitionId: null,
+    actorId: null,
+    aiStatus: null,
+    sortKey,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...payload,
+  }
+}
+
+/**
+ * Chainable `ctx.db` fake (see the sibling set-idempotency suite): reads
+ * resolve to `existingRows`; inserts echo their rows; a DELETE chain's
+ * `.returning()` resolves the seeded `deleteReturning` rows so removeValues'
+ * "did anything actually go" check is drivable per test.
+ */
+function makeFakeDb(existingRows: any[] = [], deleteReturning: any[] = []) {
+  let idSeq = 0
+  let pendingValues: any[] = []
+  let lastOp: 'insert' | 'delete' | null = null
+  const chain: any = {}
+  Object.assign(chain, {
+    transaction: async (fn: (tx: any) => Promise<any>) => fn(chain),
+    execute: async () => undefined, // pg_advisory_xact_lock
+    delete: () => {
+      lastOp = 'delete'
+      return chain
+    },
+    where: () => chain,
+    insert: () => {
+      lastOp = 'insert'
+      return chain
+    },
+    values: (rows: any) => {
+      pendingValues = Array.isArray(rows) ? rows : [rows]
+      return chain
+    },
+    onConflictDoUpdate: () => chain,
+    returning: () =>
+      Promise.resolve(
+        lastOp === 'delete'
+          ? deleteReturning
+          : pendingValues.map((row) => ({
+              id: `fv-new-${idSeq++}`,
+              createdAt: '2026-02-01T00:00:00.000Z',
+              updatedAt: '2026-02-01T00:00:00.000Z',
+              ...row,
+            }))
+      ),
+    select: () => chain,
+    from: () => chain,
+    orderBy: () => Promise.resolve(existingRows),
+    update: () => chain,
+    set: () => chain,
+  })
+  return chain
+}
+
+function makeCtx(
+  db: any,
+  fields: ReturnType<typeof fieldFixture>[],
+  session?: WriteSession
+): FieldValueContext {
+  const ctx = createFieldValueContext('org-1', 'user-1', db, 'socket-abc', { session })
+  for (const f of fields) ctx.fieldCache.set(f.id, f as any)
+  return ctx
+}
+
+const hookSpy = vi.fn(async (_event: unknown) => {})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockedGetCachedResource.mockResolvedValue(undefined)
+  mockedPublish.mockResolvedValue(undefined)
+  mockedGetEntityHooks.mockReturnValue([hookSpy])
+  mockedIsBuiltIn.mockReturnValue(false)
+  mockedGetBuiltInHandler.mockReturnValue(null)
+  mockedGetOrgCache.mockReturnValue({
+    from: () => ({ all: async () => ({}), byId: async () => undefined }),
+  })
+})
+
+// =============================================================================
+// Forward `set` — post-guard capture
+// =============================================================================
+
+describe('tier-1 capture — forward set', () => {
+  it('a real set on the silent lane captures the field output key and stays silent', async () => {
+    const collector = createManifestCollector({})
+    const rows = [existingRow('fv-1', 'field-text', 'a0', { valueText: 'hello' })]
+    const ctx = makeCtx(makeFakeDb(rows), [FIELD_TEXT], syncSession(collector))
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-text',
+      value: 'world',
+      publishEvents: false, // the handler-derived silent lane for sync sessions
+    })
+
+    const manifest = collector.toJson()
+    expect(manifest?.touched).toEqual({ [recordId]: ['field-text'] })
+    expect(manifest?.createdRecordIds).toEqual([])
+    // Capture is orthogonal to the fan-out — the silent lane stays silent.
+    expect(mockedPublish).not.toHaveBeenCalled()
+    expect(hookSpy).not.toHaveBeenCalled()
+  })
+
+  it('the output key is systemAttribute when the field carries one', async () => {
+    const collector = createManifestCollector({})
+    const ctx = makeCtx(makeFakeDb([]), [FIELD_EMAIL], syncSession(collector))
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-email',
+      value: 'a@b.co',
+      publishEvents: false,
+    })
+
+    expect(collector.toJson()?.touched).toEqual({ [recordId]: ['primary_email'] })
+  })
+
+  it('a guard-short-circuited identical set records NOTHING', async () => {
+    const collector = createManifestCollector({})
+    const rows = [existingRow('fv-1', 'field-text', 'a0', { valueText: 'hello' })]
+    const ctx = makeCtx(makeFakeDb(rows), [FIELD_TEXT], syncSession(collector))
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-text',
+      value: 'hello',
+      publishEvents: false,
+    })
+
+    expect(result.changed).toBe(false)
+    expect(collector.toJson()).toBeNull()
+  })
+
+  it('a delete-of-absent clear records NOTHING', async () => {
+    const collector = createManifestCollector({})
+    const ctx = makeCtx(makeFakeDb([]), [FIELD_TEXT], syncSession(collector))
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-text',
+      value: null,
+      publishEvents: false,
+    })
+
+    expect(result.changed).toBe(false)
+    expect(collector.toJson()).toBeNull()
+  })
+
+  it('a REAL clear captures', async () => {
+    const collector = createManifestCollector({})
+    const rows = [existingRow('fv-1', 'field-text', 'a0', { valueText: 'hello' })]
+    const ctx = makeCtx(makeFakeDb(rows), [FIELD_TEXT], syncSession(collector))
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-text',
+      value: null,
+      publishEvents: false,
+    })
+
+    expect(collector.toJson()?.touched).toEqual({ [recordId]: ['field-text'] })
+  })
+})
+
+// =============================================================================
+// Session narrowing — only the sync origin captures
+// =============================================================================
+
+describe('tier-1 capture — session narrowing', () => {
+  it('falls back to the ambient ALS session when the ctx carries none', async () => {
+    const collector = createManifestCollector({})
+    const ctx = makeCtx(makeFakeDb([]), [FIELD_TEXT]) // no ctx.session
+
+    await runWithWriteSession(syncSession(collector), () =>
+      setValueWithBuiltIn(ctx, {
+        recordId,
+        fieldId: 'field-text',
+        value: 'world',
+        publishEvents: false,
+      })
+    )
+
+    expect(collector.toJson()?.touched).toEqual({ [recordId]: ['field-text'] })
+  })
+
+  it('the ctx-carried session WINS over an ambient sync session (S1 order)', async () => {
+    const collector = createManifestCollector({})
+    for (const session of [interactiveSession('user-1'), seedSession('reshape')]) {
+      const ctx = makeCtx(makeFakeDb([]), [FIELD_TEXT], session)
+      await runWithWriteSession(syncSession(collector), () =>
+        setValueWithBuiltIn(ctx, {
+          recordId,
+          fieldId: 'field-text',
+          value: 'world',
+          publishEvents: false,
+        })
+      )
+    }
+    expect(collector.toJson()).toBeNull()
+  })
+
+  it('the inline lane is untouched: an interactive real change still fires its doors', async () => {
+    const rows = [existingRow('fv-1', 'field-text', 'a0', { valueText: 'hello' })]
+    const ctx = makeCtx(makeFakeDb(rows), [FIELD_TEXT], interactiveSession('user-1'))
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'field-text',
+      value: 'world',
+    })
+
+    expect(result.changed).toBe(true)
+    expect(hookSpy).toHaveBeenCalledTimes(1)
+    expect(mockedPublish).toHaveBeenCalledTimes(1)
+  })
+})
+
+// =============================================================================
+// Built-in branch — no guard, capture on every sync write
+// =============================================================================
+
+describe('tier-1 capture — built-in fields', () => {
+  it('captures the built-in key on a sync-session write (no no-op detection)', async () => {
+    const collector = createManifestCollector({})
+    const handler = vi.fn(async () => {})
+    mockedIsBuiltIn.mockImplementation((fieldId: string) => fieldId === 'builtin-status')
+    mockedGetBuiltInHandler.mockReturnValue(handler)
+    const ctx = makeCtx(makeFakeDb([]), [], syncSession(collector))
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: 'builtin-status',
+      value: 'open',
+      publishEvents: false,
+    })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(collector.toJson()?.touched).toEqual({ [recordId]: ['builtin-status'] })
+  })
+})
+
+// =============================================================================
+// add / remove — capture only on actual change
+// =============================================================================
+
+describe('tier-1 capture — addValues / removeValues', () => {
+  it('addValues that actually inserts captures once', async () => {
+    const collector = createManifestCollector({})
+    const rows = [existingRow('fv-a', 'field-tags', 'a0', { optionId: 'opt-a' })]
+    const ctx = makeCtx(makeFakeDb(rows), [FIELD_TAGS], syncSession(collector))
+
+    await addValues(ctx, {
+      recordId,
+      fieldId: 'field-tags',
+      values: ['opt-b'],
+      skipPublishEvents: true,
+    })
+
+    expect(collector.toJson()?.touched).toEqual({ [recordId]: ['field-tags'] })
+  })
+
+  it('addValues fully deduped against existing rows records NOTHING', async () => {
+    const collector = createManifestCollector({})
+    const rows = [existingRow('fv-a', 'field-tags', 'a0', { optionId: 'opt-a' })]
+    const ctx = makeCtx(makeFakeDb(rows), [FIELD_TAGS], syncSession(collector))
+
+    await addValues(ctx, {
+      recordId,
+      fieldId: 'field-tags',
+      values: ['opt-a'],
+      skipPublishEvents: true,
+    })
+
+    expect(collector.toJson()).toBeNull()
+  })
+
+  it('removeValues that actually deletes captures once', async () => {
+    const collector = createManifestCollector({})
+    const rows = [existingRow('fv-a', 'field-tags', 'a0', { optionId: 'opt-a' })]
+    const ctx = makeCtx(makeFakeDb(rows, [{ id: 'fv-a' }]), [FIELD_TAGS], syncSession(collector))
+
+    await removeValues(ctx, {
+      recordId,
+      fieldId: 'field-tags',
+      values: ['opt-a'],
+      skipPublishEvents: true,
+    })
+
+    expect(collector.toJson()?.touched).toEqual({ [recordId]: ['field-tags'] })
+  })
+
+  it('removeValues that matches no row records NOTHING', async () => {
+    const collector = createManifestCollector({})
+    const ctx = makeCtx(makeFakeDb([], []), [FIELD_TAGS], syncSession(collector))
+
+    await removeValues(ctx, {
+      recordId,
+      fieldId: 'field-tags',
+      values: ['opt-x'],
+      skipPublishEvents: true,
+    })
+
+    expect(collector.toJson()).toBeNull()
+  })
+})

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -51,6 +51,9 @@ import {
   getRealtimeService,
   publishFieldValueUpdates,
 } from '../realtime'
+// Type-only: the collector rides the sync origin (`write-origin.ts`); importing
+// the value module here would be harmless today but the type is all we need.
+import type { ManifestCollector } from '../record-rules/sync-manifest-collector'
 import {
   getAmbientTxWriteScope,
   isTxWriteCreated,
@@ -61,7 +64,12 @@ import {
 // functions, and routing it through `resources/crud/index.ts` would pull the
 // handler into this module's static graph (see `tx-write-flush.ts`'s header on
 // the org-cache cycle).
-import { absorbedSession, isDeclaredSilent } from '../resources/crud/write-origin'
+import {
+  absorbedSession,
+  isDeclaredSilent,
+  type WriteSession,
+} from '../resources/crud/write-origin'
+import { getAmbientWriteSession } from '../resources/crud/write-session-als'
 import { getModelType, isRecordId, parseRecordId, toRecordId } from '../resources/resource-id'
 import { applyAiMarker } from './ai-commit'
 import { shortCircuitAiGenerate } from './ai-enqueue'
@@ -126,6 +134,25 @@ import type {
 import { updateFieldValue } from './update-value'
 
 const logger = createScopedLogger('field-value-mutations')
+
+// =============================================================================
+// TIER-1 SYNC CAPTURE (plan 07 §4 — capture at the chokepoint, not the producers)
+// =============================================================================
+
+/**
+ * The effective write session's manifest collector when — and only when — its
+ * origin is `sync`. Every tier-1 capture seam narrows through here (this file's
+ * field seams and the lifecycle seams in `unified-handler-mutations.ts`), so
+ * the policy lives in one place: interactive/api/automation stay on the inline
+ * lane, seed stays silent forever, and only sync-session writes (connector /
+ * import / mail / retro) feed the sync-change manifest. The ctx-carried session
+ * wins over the ambient ALS one — the same S1 resolution order
+ * `getAmbientTxWriteScope` follows.
+ */
+export function syncCollectorOf(session?: WriteSession): ManifestCollector | null {
+  const effective = session ?? getAmbientWriteSession()
+  return effective?.origin.kind === 'sync' ? effective.origin.collector : null
+}
 
 // =============================================================================
 // REALTIME PUBLISH SHAPING
@@ -1628,6 +1655,10 @@ export async function addValues(
       .values(insertRows)
       .returning()) as unknown as FieldValueRow[]
 
+    // Tier-1 sync capture (plan 07 §4): at least one value actually landed —
+    // the all-duplicates path returned above and records nothing.
+    syncCollectorOf(ctx.session)?.recordTouched(recordId, [field.systemAttribute ?? fieldId])
+
     const allRows = [...existingRows, ...inserted]
     const allTyped = allRows.map((r) => rowToTypedValue(r, fieldType))
 
@@ -1740,7 +1771,10 @@ export async function removeValues(
 
   if (valueMatchClause === null) return
 
-  await ctx.db
+  // RETURNING (same single statement, no extra query) makes "did any row
+  // actually go" observable for the tier-1 sync capture below; the result was
+  // previously discarded.
+  const deleted = await ctx.db
     .delete(schema.FieldValue)
     .where(
       and(
@@ -1750,6 +1784,13 @@ export async function removeValues(
         valueMatchClause
       )
     )
+    .returning({ id: schema.FieldValue.id })
+
+  // Tier-1 sync capture (plan 07 §4): only when at least one row was removed —
+  // a remove matching nothing is a no-op and records nothing.
+  if (deleted.length > 0) {
+    syncCollectorOf(ctx.session)?.recordTouched(recordId, [field.systemAttribute ?? fieldId])
+  }
 
   // Publish the remaining array — empty is a valid "cleared" signal.
   const remaining = await getValue(ctx, { recordId, fieldId })
@@ -1951,6 +1992,18 @@ export async function addValuesBulk(
     }
   })
 
+  // Tier-1 sync capture (plan 07 §4): per record that actually received rows —
+  // fully-deduped records contribute no `insertedTypedByEntity` entry.
+  const bulkAddCollector = syncCollectorOf(ctx.session)
+  if (bulkAddCollector && insertedTypedByEntity.size > 0) {
+    const key = field.systemAttribute ?? fieldId
+    const ridByInstance = new Map(parsed.map((p, i) => [p.entityInstanceId, recordIds[i]!]))
+    for (const entityId of insertedTypedByEntity.keys()) {
+      const rid = ridByInstance.get(entityId)
+      if (rid) bulkAddCollector.recordTouched(rid, [key])
+    }
+  }
+
   // Field-change post-hooks for entities that actually received inserts.
   // Old display = pre-write rows; new display = pre-write rows + inserts.
   // Bulk renderer surfaces this as an "added" diff.
@@ -2065,6 +2118,17 @@ export async function removeValuesBulk(
       id: schema.FieldValue.id,
       entityId: schema.FieldValue.entityId,
     })) as Array<{ id: string; entityId: string }>
+
+  // Tier-1 sync capture (plan 07 §4): per record that actually lost rows.
+  const bulkRemoveCollector = syncCollectorOf(ctx.session)
+  if (bulkRemoveCollector && deleted.length > 0) {
+    const key = field.systemAttribute ?? fieldId
+    const ridByInstance = new Map(parsed.map((p, i) => [p.entityInstanceId, recordIds[i]!]))
+    for (const entityId of new Set(deleted.map((row) => row.entityId))) {
+      const rid = ridByInstance.get(entityId)
+      if (rid) bulkRemoveCollector.recordTouched(rid, [key])
+    }
+  }
 
   if (willDispatchFieldChange && deleted.length > 0) {
     const deletedIdsByEntity = new Map<string, Set<string>>()
@@ -2330,6 +2394,11 @@ export async function setValueWithBuiltIn(
     }
     await handler(ctx.db, entityInstanceId, value, ctx.organizationId)
 
+    // Tier-1 sync capture (plan 07 §4). Built-in writes carry no idempotency
+    // guard, so a sync-session re-assertion still counts as touched — that
+    // asymmetry is accepted for PR 1 (no cheap no-op detection exists here).
+    syncCollectorOf(ctx.session)?.recordTouched(recordId, [rawFieldId])
+
     // Create synthetic TypedFieldValue for frontend store
     const builtInFieldType = getBuiltInFieldType(rawFieldId, modelType)
     const performedAt = new Date().toISOString()
@@ -2538,6 +2607,11 @@ export async function setValueWithBuiltIn(
         }).catch(() => {})
       }
     }
+    // Tier-1 sync capture (plan 07 §4): a REAL clear — the B-14
+    // delete-of-absent no-op returned above and records nothing. Deliberately
+    // not tied to `publishEvents`/`firePostHook`: sync sessions run the silent
+    // lane, and capture must not be skipped with the fan-out.
+    syncCollectorOf(ctx.session)?.recordTouched(recordId, [field.systemAttribute ?? fieldId])
     await firePostHook(null)
     return { state: 'complete', performedAt: new Date().toISOString(), values: [], changed: true }
   }
@@ -2558,6 +2632,12 @@ export async function setValueWithBuiltIn(
     skipInverseSync,
     aiGeneration: params.aiGeneration,
   })
+
+  // Tier-1 sync capture (plan 07 §4): the step-3.55 guard already decided this
+  // is a REAL write — an identical re-assertion returned at 3.55 and records
+  // nothing (membership honesty, §4 property 1). Runs on the silent lane too:
+  // sync sessions skip `firePostHook`, capture must not be skipped with it.
+  syncCollectorOf(ctx.session)?.recordTouched(recordId, [field.systemAttribute ?? fieldId])
 
   // 7. Fire field-change post-hooks. For multi-value fields (MULTI_SELECT,
   // TAGS, RELATIONSHIP, FILE, or scalar types with options.multi=true) we

--- a/packages/lib/src/import/execution/track-progress.ts
+++ b/packages/lib/src/import/execution/track-progress.ts
@@ -5,7 +5,10 @@ import { schema } from '@auxx/database'
 import { and, eq, isNull } from 'drizzle-orm'
 // Type-only import — sync-manifest-types has no runtime, so this creates no
 // import ⇄ record-rules load edge.
-import type { SyncChangeManifest } from '../../record-rules/sync-manifest-types'
+import type {
+  SyncChangeManifest,
+  SyncChangeManifestV1,
+} from '../../record-rules/sync-manifest-types'
 import type { ImportStatistics } from '../types/job'
 
 /**
@@ -89,16 +92,20 @@ export async function saveImportManifest(
     .where(eq(schema.ImportJob.id, jobId))
 }
 
-/** B2: read a persisted import manifest (the `sync:records:changed` consumer). */
+/**
+ * B2: read a persisted import manifest (the `sync:records:changed` consumer). Returns
+ * the STORED shape — rows written before the v2 deploy are still v1; callers upgrade
+ * via `upgradeManifestV1` at their read edge.
+ */
 export async function getImportManifest(
   db: Database,
   jobId: string
-): Promise<SyncChangeManifest | null> {
+): Promise<SyncChangeManifest | SyncChangeManifestV1 | null> {
   const row = await db.query.ImportJob.findFirst({
     where: eq(schema.ImportJob.id, jobId),
     columns: { manifest: true },
   })
-  return (row?.manifest as SyncChangeManifest | null) ?? null
+  return (row?.manifest as SyncChangeManifest | SyncChangeManifestV1 | null) ?? null
 }
 
 /**

--- a/packages/lib/src/jobs/import/execute-plan-job.ts
+++ b/packages/lib/src/jobs/import/execute-plan-job.ts
@@ -112,8 +112,9 @@ export async function executePlanJob(ctx: JobContext<ExecutePlanJobProps>): Prom
     }))
 
     // B2: the import writes on the silent `sync` lane (below), so build a manifest
-    // collector to capture subscribed field/lifecycle changes for record rules. No-op
-    // stub (zero cost) when the org has no enabled rules on this def.
+    // collector. Always real (plan 07): tier-1 membership is captured unconditionally
+    // at the engine seams; tier-2 `{o, n}` capture below stays gated on rule
+    // subscriptions via `subscriptionsFor` (zero cost when nothing is subscribed).
     const { loadManifestCollector } = await import('../../record-rules/sync-manifest-collector')
     const manifest = await loadManifestCollector(organizationId)
 
@@ -204,7 +205,6 @@ export async function executePlanJob(ctx: JobContext<ExecutePlanJobProps>): Prom
           db,
           // Auto-created targets reach record rules the same way imported rows do.
           onCreated: (targetDefId, instanceId, data) => {
-            if (!manifest.enabled) return
             // Subscriptions are per-def, and the TARGET def (company) is not this
             // import's def (part), look it up rather than reusing the outer one.
             if (manifest.subscriptionsFor(targetDefId)?.lifecycle.created) {
@@ -289,32 +289,32 @@ export async function executePlanJob(ctx: JobContext<ExecutePlanJobProps>): Prom
       // (plan 03 §3.4), not a per-call flag.
       const created = await crudHandler.create(entityDefinitionId, mergedData)
 
-      // B2: capture lifecycle-created + `set`-transition field writes for record rules.
-      if (manifest.enabled) {
-        const subs = manifest.subscriptionsFor(entityDefinitionId)
-        if (subs) {
-          const rid = created.recordId
-          const { captureCreateFieldChanges, captureCreatedValues } = await import(
-            '../../record-rules/capture-field-changes'
-          )
-          if (subs.lifecycle.created) {
-            // Thread raw created values for native entity-trigger lifecycle handlers on the
-            // sync door (Phase 9 / Option A) — no DB read, mergedData is in hand.
-            const createdValues = await captureCreatedValues(
-              organizationId,
-              entityDefinitionId,
-              mergedData
-            )
-            manifest.recordCreated(rid, createdValues ?? undefined)
-          }
-          const entries = await captureCreateFieldChanges(
+      // B2: capture lifecycle-created + `set`-transition field writes for record rules
+      // (tier-2 producer capture — stays subscription-gated; tier-1 membership comes
+      // from the engine seams).
+      const subs = manifest.subscriptionsFor(entityDefinitionId)
+      if (subs) {
+        const rid = created.recordId
+        const { captureCreateFieldChanges, captureCreatedValues } = await import(
+          '../../record-rules/capture-field-changes'
+        )
+        if (subs.lifecycle.created) {
+          // Thread raw created values for native entity-trigger lifecycle handlers on the
+          // sync door (Phase 9 / Option A) — no DB read, mergedData is in hand.
+          const createdValues = await captureCreatedValues(
             organizationId,
             entityDefinitionId,
-            mergedData,
-            subs.fieldIds
+            mergedData
           )
-          if (entries) manifest.recordChange(rid, entries)
+          manifest.recordCreated(rid, createdValues ?? undefined)
         }
+        const entries = await captureCreateFieldChanges(
+          organizationId,
+          entityDefinitionId,
+          mergedData,
+          subs.fieldIds
+        )
+        if (entries) manifest.recordChange(rid, entries)
       }
 
       logger.debug('Created record', { id: created.instance.id, entityDefinitionId })
@@ -343,26 +343,25 @@ export async function executePlanJob(ctx: JobContext<ExecutePlanJobProps>): Prom
       const recordId = toRecordId(entityDefinitionId, id)
       logger.debug('Calling crudHandler.update', { recordId, entityDefinitionId, id })
 
-      // B2: read old values for subscribed written fields BEFORE the write.
+      // B2: read old values for subscribed written fields BEFORE the write (tier-2
+      // producer capture — stays subscription-gated).
       let captured: Record<
         string,
         import('../../record-rules/sync-manifest-types').ManifestFieldChange
       > | null = null
-      if (manifest.enabled) {
-        const subs = manifest.subscriptionsFor(entityDefinitionId)
-        if (subs?.fieldIds.size) {
-          const { captureUpdateFieldChanges } = await import(
-            '../../record-rules/capture-field-changes'
-          )
-          captured = await captureUpdateFieldChanges(
-            db,
-            organizationId,
-            entityDefinitionId,
-            id,
-            mergedData,
-            subs.fieldIds
-          )
-        }
+      const subs = manifest.subscriptionsFor(entityDefinitionId)
+      if (subs?.fieldIds.size) {
+        const { captureUpdateFieldChanges } = await import(
+          '../../record-rules/capture-field-changes'
+        )
+        captured = await captureUpdateFieldChanges(
+          db,
+          organizationId,
+          entityDefinitionId,
+          id,
+          mergedData,
+          subs.fieldIds
+        )
       }
 
       // Event suppression comes from the handler's silent `sync` session
@@ -464,6 +463,8 @@ export async function executePlanJob(ctx: JobContext<ExecutePlanJobProps>): Prom
           data: {
             source: 'import',
             organizationId,
+            ref: jobId,
+            // Deprecated duplicate, kept one release for in-flight consumers.
             importRef: jobId,
           },
         })

--- a/packages/lib/src/record-rules/index.ts
+++ b/packages/lib/src/record-rules/index.ts
@@ -57,11 +57,17 @@ export {
 export {
   createManifestCollector,
   loadManifestCollector,
+  MAX_DELTA_RECORDS,
+  MAX_TOUCHED_RECORDS,
   type ManifestCollector,
+  type ManifestCollectorCaps,
+  TOUCHED_KEYS_BYTE_BUDGET,
+  upgradeManifestV1,
 } from './sync-manifest-collector'
 export type {
   ManifestFieldChange,
   SyncChangeManifest,
+  SyncChangeManifestV1,
   SyncRecordsChangedEvent,
 } from './sync-manifest-types'
 export {

--- a/packages/lib/src/record-rules/sync-manifest-collector.test.ts
+++ b/packages/lib/src/record-rules/sync-manifest-collector.test.ts
@@ -2,8 +2,15 @@
 
 import { describe, expect, it } from 'vitest'
 import type { SyncRuleSubscriptions } from './subscriptions'
-import { createManifestCollector, mergeManifests } from './sync-manifest-collector'
-import type { SyncChangeManifest } from './sync-manifest-types'
+import {
+  createManifestCollector,
+  MAX_DELTA_RECORDS,
+  MAX_TOUCHED_RECORDS,
+  mergeManifests,
+  TOUCHED_KEYS_BYTE_BUDGET,
+  upgradeManifestV1,
+} from './sync-manifest-collector'
+import type { SyncChangeManifest, SyncChangeManifestV1 } from './sync-manifest-types'
 
 const RID = (s: string) => s as unknown as import('@auxx/types/resource').RecordId
 
@@ -15,23 +22,57 @@ function subs(overrides: SyncRuleSubscriptions = {}): SyncRuleSubscriptions {
 }
 
 describe('createManifestCollector', () => {
-  it('returns a zero-cost no-op stub when no subscriptions', () => {
-    const c = createManifestCollector({})
-    expect(c.enabled).toBe(false)
-    c.recordChange(RID('def_1:i1'), { fld_a: { n: 1 } })
-    c.recordCreated(RID('def_1:i1'))
-    expect(c.toJson()).toBeNull()
-    expect(c.subscriptionsFor('def_1')).toBeUndefined()
+  it('exports the plan 07 cap defaults', () => {
+    expect(MAX_TOUCHED_RECORDS).toBe(50_000)
+    expect(TOUCHED_KEYS_BYTE_BUDGET).toBe(2_000_000)
+    expect(MAX_DELTA_RECORDS).toBe(5_000)
   })
 
-  it('captures field changes keyed by RecordId → outputKey', () => {
+  // Plan 07 H-1: the NOOP-when-no-subscriptions gate is gone. Tier-1 membership is
+  // unconditional; zero subscriptions only means tier-2 never captures (producers gate
+  // on `subscriptionsFor`).
+  it('is always real: zero subscriptions still capture touched + lifecycle, zero deltas', () => {
+    const c = createManifestCollector({})
+    expect(c.enabled).toBe(true)
+    expect(c.subscriptionsFor('def_1')).toBeUndefined()
+    c.recordTouched(RID('def_1:i1'), ['fld_a'])
+    c.recordCreated(RID('def_1:i2'))
+    c.recordArchived(RID('def_1:i3'))
+    const m = c.toJson()!
+    expect(m.version).toBe(2)
+    expect(m.touched).toEqual({ 'def_1:i1': ['fld_a'] })
+    expect(m.createdRecordIds).toEqual(['def_1:i2'])
+    expect(m.archivedRecordIds).toEqual(['def_1:i3'])
+    expect(m.deltas).toEqual({})
+    expect(m.detailTruncated).toBe(false)
+    expect(m.membershipTruncated).toBe(false)
+  })
+
+  it('toJson is null when literally nothing was captured', () => {
+    const c = createManifestCollector(subs())
+    expect(c.toJson()).toBeNull()
+  })
+
+  it('recordTouched merges keys per record (set union)', () => {
+    const c = createManifestCollector(subs())
+    c.recordTouched(RID('def_1:i1'), ['fld_a', 'fld_b'])
+    c.recordTouched(RID('def_1:i1'), ['fld_b', 'fld_c'])
+    const m = c.toJson()!
+    expect(m.touched[RID('def_1:i1')]).toEqual(['fld_a', 'fld_b', 'fld_c'])
+  })
+
+  it('captures deltas keyed by RecordId → outputKey', () => {
     const c = createManifestCollector(subs())
     c.recordChange(RID('def_1:i1'), { fld_a: { o: 1, n: 2 }, fld_b: { n: 'x' } })
-    const m = c.toJson()
-    expect(m).not.toBeNull()
-    expect(m!.changes[RID('def_1:i1')]).toEqual({ fld_a: { o: 1, n: 2 }, fld_b: { n: 'x' } })
-    expect(m!.version).toBe(1)
-    expect(m!.truncated).toBe(false)
+    const m = c.toJson()!
+    expect(m.deltas[RID('def_1:i1')]).toEqual({ fld_a: { o: 1, n: 2 }, fld_b: { n: 'x' } })
+  })
+
+  it('recordChange implies touched membership with the delta keys', () => {
+    const c = createManifestCollector(subs())
+    c.recordChange(RID('def_1:i1'), { fld_a: { o: 1, n: 2 }, fld_b: { n: 'x' } })
+    const m = c.toJson()!
+    expect(m.touched[RID('def_1:i1')]).toEqual(['fld_a', 'fld_b'])
   })
 
   it('merges repeated writes: union keys, first o wins, last n wins', () => {
@@ -39,7 +80,7 @@ describe('createManifestCollector', () => {
     c.recordChange(RID('def_1:i1'), { fld_a: { o: 1, n: 2 } })
     c.recordChange(RID('def_1:i1'), { fld_a: { o: 99, n: 3 }, fld_b: { n: 'y' } })
     const m = c.toJson()!
-    expect(m.changes[RID('def_1:i1')]).toEqual({ fld_a: { o: 1, n: 3 }, fld_b: { n: 'y' } })
+    expect(m.deltas[RID('def_1:i1')]).toEqual({ fld_a: { o: 1, n: 3 }, fld_b: { n: 'y' } })
   })
 
   // F6: `o`-absence marks "created this run" — a later update in the same slice must
@@ -50,7 +91,7 @@ describe('createManifestCollector', () => {
     c.recordChange(RID('def_1:i1'), { fld_a: { n: 'v' } }) // create capture — no o
     c.recordChange(RID('def_1:i1'), { fld_a: { o: 'v', n: 'v2' } }) // update capture
     const m = c.toJson()!
-    expect(m.changes[RID('def_1:i1')]).toEqual({ fld_a: { n: 'v2' } })
+    expect(m.deltas[RID('def_1:i1')]).toEqual({ fld_a: { n: 'v2' } })
   })
 
   it('records created/archived lifecycle ids, dedup', () => {
@@ -63,12 +104,84 @@ describe('createManifestCollector', () => {
     expect(m.archivedRecordIds).toEqual(['def_1:i2'])
   })
 
-  it('enforces the changed-records cap + sets truncated', () => {
+  // The dual-keyspace trap (plan 04 §11.2): producers key RecordIds by slug for imports
+  // and by canonical EntityDefinition CUID elsewhere. Identity is the entity INSTANCE
+  // id — the same instance under two RecordId forms folds to ONE entry, first-seen
+  // RecordId form wins as the emitted key.
+  it('dedupes touched on the instance id across the two RecordId keyspaces', () => {
     const c = createManifestCollector(subs())
-    for (let i = 0; i < 5001; i++) c.recordChange(RID(`def_1:i${i}`), { fld_a: { n: i } })
+    c.recordTouched(RID('contact:inst1'), ['fld_a'])
+    c.recordTouched(RID('cuid_def_x:inst1'), ['fld_b'])
     const m = c.toJson()!
-    expect(Object.keys(m.changes).length).toBe(5000)
-    expect(m.truncated).toBe(true)
+    expect(Object.keys(m.touched)).toEqual(['contact:inst1'])
+    expect(m.touched[RID('contact:inst1')]).toEqual(['fld_a', 'fld_b'])
+  })
+
+  it('dedupes deltas and lifecycle on the instance id across keyspaces', () => {
+    const c = createManifestCollector(subs())
+    c.recordChange(RID('contact:inst1'), { fld_a: { o: 1, n: 2 } })
+    c.recordChange(RID('cuid_def_x:inst1'), { fld_a: { o: 99, n: 3 } })
+    c.recordCreated(RID('contact:inst2'))
+    c.recordCreated(RID('cuid_def_x:inst2'))
+    const m = c.toJson()!
+    expect(Object.keys(m.deltas)).toEqual(['contact:inst1'])
+    expect(m.deltas[RID('contact:inst1')]).toEqual({ fld_a: { o: 1, n: 3 } })
+    expect(m.createdRecordIds).toEqual(['contact:inst2'])
+  })
+
+  it('delta cap sets detailTruncated ONLY — membership stays complete', () => {
+    const c = createManifestCollector(subs(), { maxDeltaRecords: 3 })
+    for (let i = 0; i < 5; i++) c.recordChange(RID(`def_1:i${i}`), { fld_a: { n: i } })
+    const m = c.toJson()!
+    expect(Object.keys(m.deltas).length).toBe(3)
+    expect(m.detailTruncated).toBe(true)
+    expect(m.membershipTruncated).toBe(false)
+    // Every record still made tier-1 membership, keys intact.
+    expect(Object.keys(m.touched).length).toBe(5)
+    expect(m.touched[RID('def_1:i4')]).toEqual(['fld_a'])
+  })
+
+  it('membership cap sets membershipTruncated while captured deltas stay intact', () => {
+    const c = createManifestCollector(subs(), { maxTouchedRecords: 2 })
+    c.recordTouched(RID('def_1:i1'), ['fld_a'])
+    c.recordTouched(RID('def_1:i2'), ['fld_a'])
+    c.recordTouched(RID('def_1:i3'), ['fld_a']) // over the cap
+    c.recordCreated(RID('def_1:i4')) // membership union — also capped
+    // Deltas have their own cap; a membership-capped record still captures detail.
+    c.recordChange(RID('def_1:i5'), { fld_a: { o: 1, n: 2 } })
+    const m = c.toJson()!
+    expect(m.membershipTruncated).toBe(true)
+    expect(Object.keys(m.touched).sort()).toEqual(['def_1:i1', 'def_1:i2'])
+    expect(m.createdRecordIds).toEqual([])
+    expect(m.deltas[RID('def_1:i5')]).toEqual({ fld_a: { o: 1, n: 2 } })
+    expect(m.detailTruncated).toBe(false)
+  })
+
+  it('membership cap spans touched ∪ created ∪ archived, an existing member is free', () => {
+    const c = createManifestCollector(subs(), { maxTouchedRecords: 2 })
+    c.recordCreated(RID('def_1:i1'))
+    c.recordArchived(RID('def_1:i2'))
+    // i1 is already a member — touching it again is free, no truncation.
+    c.recordTouched(RID('def_1:i1'), ['fld_a'])
+    expect(c.toJson()!.membershipTruncated).toBe(false)
+    c.recordTouched(RID('def_1:i3'), ['fld_a'])
+    const m = c.toJson()!
+    expect(m.membershipTruncated).toBe(true)
+    expect(m.touched[RID('def_1:i1')]).toEqual(['fld_a'])
+  })
+
+  it('byte budget degrades NEW touched entries to ids-only; existing entries keep keys', () => {
+    const c = createManifestCollector(subs(), { touchedKeysByteBudget: 10 })
+    c.recordTouched(RID('def_1:i1'), ['abcdef']) // 6 bytes — under budget
+    c.recordTouched(RID('def_1:i2'), ['ghijkl']) // entry created at 6 < 10, now 12
+    c.recordTouched(RID('def_1:i3'), ['mn']) // 12 >= 10 — new entry goes ids-only
+    c.recordTouched(RID('def_1:i1'), ['op']) // existing entry keeps merging keys
+    const m = c.toJson()!
+    expect(m.touched[RID('def_1:i1')]).toEqual(['abcdef', 'op'])
+    expect(m.touched[RID('def_1:i2')]).toEqual(['ghijkl'])
+    expect(m.touched[RID('def_1:i3')]).toBe(1)
+    // Degradation is not truncation — membership is still complete.
+    expect(m.membershipTruncated).toBe(false)
   })
 
   it('empty recordChange entries are ignored', () => {
@@ -103,6 +216,19 @@ describe('createManifestCollector', () => {
 
 function manifest(over: Partial<SyncChangeManifest> = {}): SyncChangeManifest {
   return {
+    version: 2,
+    detailTruncated: false,
+    membershipTruncated: false,
+    touched: {},
+    deltas: {},
+    createdRecordIds: [],
+    archivedRecordIds: [],
+    ...over,
+  }
+}
+
+function manifestV1(over: Partial<SyncChangeManifestV1> = {}): SyncChangeManifestV1 {
+  return {
     version: 1,
     truncated: false,
     changes: {},
@@ -112,41 +238,110 @@ function manifest(over: Partial<SyncChangeManifest> = {}): SyncChangeManifest {
   }
 }
 
+describe('upgradeManifestV1', () => {
+  it('derives v2: touched from changes keys, deltas = changes, flags mapped', () => {
+    const v1 = manifestV1({
+      truncated: true,
+      changes: {
+        'd:1': { fa: { o: 1, n: 2 }, fb: { n: 'x' } },
+        'd:2': { fc: { n: 5 } },
+      } as never,
+      createdRecordIds: [RID('d:3')],
+      archivedRecordIds: [RID('d:4')],
+      createdValues: { [RID('d:3')]: { company_domain: 'a.com' } },
+    })
+    const v2 = upgradeManifestV1(v1)
+    expect(v2).toEqual({
+      version: 2,
+      detailTruncated: true,
+      membershipTruncated: false,
+      touched: { 'd:1': ['fa', 'fb'], 'd:2': ['fc'] },
+      deltas: v1.changes,
+      createdRecordIds: ['d:3'],
+      archivedRecordIds: ['d:4'],
+      createdValues: { 'd:3': { company_domain: 'a.com' } },
+    })
+  })
+
+  it('omits createdValues when the v1 manifest had none', () => {
+    expect(upgradeManifestV1(manifestV1()).createdValues).toBeUndefined()
+  })
+})
+
 describe('mergeManifests', () => {
-  it('returns the other side when one is null', () => {
+  it('returns the other side when one is null (v2 passes through by reference)', () => {
     const m = manifest({ createdRecordIds: [RID('d:1')] })
     expect(mergeManifests(null, m)).toBe(m)
     expect(mergeManifests(m, null)).toBe(m)
     expect(mergeManifests(null, null)).toBeNull()
   })
 
-  it('deep-merges changes: first o wins, last n wins, union keys/records', () => {
+  it('upgrades a lone v1 side to v2', () => {
+    const v1 = manifestV1({ changes: { 'd:1': { fa: { n: 2 } } } as never })
+    const merged = mergeManifests(v1, null)!
+    expect(merged.version).toBe(2)
+    expect(merged.touched).toEqual({ 'd:1': ['fa'] })
+    expect(merged.deltas).toEqual(v1.changes)
+  })
+
+  it('folds touched with key-set union', () => {
+    const base = manifest({ touched: { 'd:1': ['fa'], 'd:2': ['fb'] } as never })
+    const add = manifest({ touched: { 'd:1': ['fb', 'fc'], 'd:3': ['fd'] } as never })
+    const merged = mergeManifests(base, add)!
+    expect(merged.touched).toEqual({
+      'd:1': ['fa', 'fb', 'fc'],
+      'd:2': ['fb'],
+      'd:3': ['fd'],
+    })
+  })
+
+  it('folds touched with 1 winning downward — once ids-only, stays ids-only', () => {
+    const base = manifest({ touched: { 'd:1': ['fa'], 'd:2': 1 } as never })
+    const add = manifest({ touched: { 'd:1': 1, 'd:2': ['fb'] } as never })
+    const merged = mergeManifests(base, add)!
+    expect(merged.touched[RID('d:1')]).toBe(1)
+    expect(merged.touched[RID('d:2')]).toBe(1)
+  })
+
+  it('dedupes touched on the instance id across keyspaces through the fold', () => {
+    const base = manifest({ touched: { 'contact:inst1': ['fa'] } as never })
+    const add = manifest({ touched: { 'cuid_def_x:inst1': ['fb'] } as never })
+    const merged = mergeManifests(base, add)!
+    expect(Object.keys(merged.touched)).toEqual(['contact:inst1'])
+    expect(merged.touched[RID('contact:inst1')]).toEqual(['fa', 'fb'])
+  })
+
+  it('deep-merges deltas: first o wins, last n wins, union keys/records', () => {
     const base = manifest({
-      changes: { 'd:1': { fa: { o: 1, n: 2 } } } as never,
+      deltas: { 'd:1': { fa: { o: 1, n: 2 } } } as never,
     })
     const add = manifest({
-      changes: { 'd:1': { fa: { o: 99, n: 3 }, fb: { n: 'x' } }, 'd:2': { fc: { n: 5 } } } as never,
+      deltas: { 'd:1': { fa: { o: 99, n: 3 }, fb: { n: 'x' } }, 'd:2': { fc: { n: 5 } } } as never,
     })
     const merged = mergeManifests(base, add)!
-    expect(merged.changes['d:1' as never]).toEqual({ fa: { o: 1, n: 3 }, fb: { n: 'x' } })
-    expect(merged.changes['d:2' as never]).toEqual({ fc: { n: 5 } })
+    expect(merged.deltas['d:1' as never]).toEqual({ fa: { o: 1, n: 3 }, fb: { n: 'x' } })
+    expect(merged.deltas['d:2' as never]).toEqual({ fc: { n: 5 } })
   })
 
   // F6 across slices: create in slice 1, update in slice 2 — the fold preserves the
   // create's o-absence exactly like the in-slice merge.
   it('cross-slice create-then-update keeps o absent through the fold', () => {
-    const base = manifest({ changes: { 'd:1': { fa: { n: 'v' } } } as never })
-    const add = manifest({ changes: { 'd:1': { fa: { o: 'v', n: 'v2' } } } as never })
+    const base = manifest({ deltas: { 'd:1': { fa: { n: 'v' } } } as never })
+    const add = manifest({ deltas: { 'd:1': { fa: { o: 'v', n: 'v2' } } } as never })
     const merged = mergeManifests(base, add)!
-    expect(merged.changes['d:1' as never]).toEqual({ fa: { n: 'v2' } })
+    expect(merged.deltas['d:1' as never]).toEqual({ fa: { n: 'v2' } })
   })
 
-  it('unions lifecycle ids and ORs truncated', () => {
-    const base = manifest({ createdRecordIds: [RID('d:1')], truncated: false })
-    const add = manifest({ createdRecordIds: [RID('d:1'), RID('d:2')], truncated: true })
+  it('unions lifecycle ids and ORs both truncation flags', () => {
+    const base = manifest({ createdRecordIds: [RID('d:1')], detailTruncated: true })
+    const add = manifest({
+      createdRecordIds: [RID('d:1'), RID('d:2')],
+      membershipTruncated: true,
+    })
     const merged = mergeManifests(base, add)!
     expect(merged.createdRecordIds.sort()).toEqual(['d:1', 'd:2'])
-    expect(merged.truncated).toBe(true)
+    expect(merged.detailTruncated).toBe(true)
+    expect(merged.membershipTruncated).toBe(true)
   })
 
   it('unions createdValues, base wins on a duplicate id', () => {
@@ -168,29 +363,61 @@ describe('mergeManifests', () => {
     })
   })
 
-  it('enforces the run-level changed-records cap across the fold', () => {
-    // Two slices each below the per-slice cap still overflow the run when folded.
-    const changesFor = (start: number, count: number) => {
-      const changes: Record<string, { fa: { n: number } }> = {}
-      for (let i = start; i < start + count; i++) changes[`d:${i}`] = { fa: { n: i } }
-      return changes as never
-    }
-    const base = manifest({ changes: changesFor(0, 3000) })
-    const add = manifest({ changes: changesFor(3000, 3000) })
+  it('folds a v1 base with a v2 add (mixed run row Just Works)', () => {
+    const base = manifestV1({
+      truncated: true,
+      changes: { 'd:1': { fa: { o: 1, n: 2 } } } as never,
+      createdRecordIds: [RID('d:2')],
+    })
+    const add = manifest({
+      touched: { 'd:1': ['fb'], 'd:3': ['fc'] } as never,
+      deltas: { 'd:1': { fa: { o: 99, n: 3 } } } as never,
+      archivedRecordIds: [RID('d:4')],
+    })
     const merged = mergeManifests(base, add)!
-    expect(Object.keys(merged.changes).length).toBe(5000)
-    expect(merged.truncated).toBe(true)
+    expect(merged.version).toBe(2)
+    expect(merged.touched).toEqual({ 'd:1': ['fa', 'fb'], 'd:3': ['fc'] })
+    expect(merged.deltas['d:1' as never]).toEqual({ fa: { o: 1, n: 3 } })
+    expect(merged.createdRecordIds).toEqual(['d:2'])
+    expect(merged.archivedRecordIds).toEqual(['d:4'])
+    expect(merged.detailTruncated).toBe(true) // v1's truncated maps to detail
+    expect(merged.membershipTruncated).toBe(false)
   })
 
-  it('updating an already-present record past the cap is free', () => {
-    const changes: Record<string, { fa: { n: number } }> = {}
-    for (let i = 0; i < 5000; i++) changes[`d:${i}`] = { fa: { n: i } }
-    const base = manifest({ changes: changes as never })
+  it('enforces the delta cap across the fold — detail only, membership complete', () => {
+    const deltasFor = (start: number, count: number) => {
+      const deltas: Record<string, { fa: { n: number } }> = {}
+      for (let i = start; i < start + count; i++) deltas[`d:${i}`] = { fa: { n: i } }
+      return deltas as never
+    }
+    const base = manifest({ deltas: deltasFor(0, 3), touched: {} })
+    const add = manifest({ deltas: deltasFor(3, 3), touched: {} })
+    const merged = mergeManifests(base, add, { maxDeltaRecords: 5 })!
+    expect(Object.keys(merged.deltas).length).toBe(5)
+    expect(merged.detailTruncated).toBe(true)
+    expect(merged.membershipTruncated).toBe(false)
+    // Every record kept tier-1 membership (a delta implies touched).
+    expect(Object.keys(merged.touched).length).toBe(6)
+  })
+
+  it('enforces the membership cap across the fold', () => {
+    const base = manifest({ touched: { 'd:1': ['fa'], 'd:2': ['fa'] } as never })
+    const add = manifest({ touched: { 'd:3': ['fa'] } as never, createdRecordIds: [RID('d:4')] })
+    const merged = mergeManifests(base, add, { maxTouchedRecords: 2 })!
+    expect(Object.keys(merged.touched).sort()).toEqual(['d:1', 'd:2'])
+    expect(merged.createdRecordIds).toEqual([])
+    expect(merged.membershipTruncated).toBe(true)
+  })
+
+  it('re-touching an already-present record past the delta cap is free', () => {
+    const deltas: Record<string, { fa: { n: number } }> = {}
+    for (let i = 0; i < 3; i++) deltas[`d:${i}`] = { fa: { n: i } }
+    const base = manifest({ deltas: deltas as never })
     // `add` re-touches an existing record (no new key) — must merge, not truncate.
-    const add = manifest({ changes: { 'd:0': { fa: { n: 999 } } } as never })
-    const merged = mergeManifests(base, add)!
-    expect(Object.keys(merged.changes).length).toBe(5000)
-    expect(merged.truncated).toBe(false)
-    expect(merged.changes['d:0' as never]).toEqual({ fa: { n: 999 } })
+    const add = manifest({ deltas: { 'd:0': { fa: { n: 999 } } } as never })
+    const merged = mergeManifests(base, add, { maxDeltaRecords: 3 })!
+    expect(Object.keys(merged.deltas).length).toBe(3)
+    expect(merged.detailTruncated).toBe(false)
+    expect(merged.deltas['d:0' as never]).toEqual({ fa: { n: 999 } })
   })
 })

--- a/packages/lib/src/record-rules/sync-manifest-collector.ts
+++ b/packages/lib/src/record-rules/sync-manifest-collector.ts
@@ -1,26 +1,55 @@
 // packages/lib/src/record-rules/sync-manifest-collector.ts
-// Run/slice-scoped accumulator for a sync-change manifest. Bulk writers (connector
-// sink, import job) that write with `skipEvents: true` feed this so record rules can
-// still react to their writes (B2 plan D4). Subscription-aware: an org with no enabled
-// rules on the touched defs gets a zero-cost no-op stub — nothing is captured, no query
-// is issued at the write sites. See plans/events/b2-sync-change-manifest-plan.md.
+// Run/slice-scoped accumulator for a sync-change manifest (v2, plan 07 §3). Two tiers:
+// tier-1 membership (touched records + lifecycle) is captured UNCONDITIONALLY for every
+// sync session — the collector is always real, there is no no-op stub anymore. Tier-2
+// deltas stay gated on rule subscriptions via `subscriptionsFor` (empty subscriptions ⇒
+// undefined for every def ⇒ producers never capture values, at zero cost).
+// See plans/events/07-two-tier-sync-capture-plan.md.
 
 import { createScopedLogger } from '@auxx/logger'
-import type { RecordId } from '@auxx/types/resource'
+import { parseRecordId, type RecordId } from '@auxx/types/resource'
 import type { DefSubscriptions, SyncRuleSubscriptions } from './subscriptions'
-import type { ManifestFieldChange, SyncChangeManifest } from './sync-manifest-types'
+import type {
+  ManifestFieldChange,
+  SyncChangeManifest,
+  SyncChangeManifestV1,
+} from './sync-manifest-types'
 
 const logger = createScopedLogger('sync-manifest')
 
 /**
- * Run-level caps (D4). Enforced both per-collector (a single slice) AND across the fold
- * in `mergeManifests` — otherwise, since the deviation made collectors per-slice, an
- * N-slice run could accumulate N × these into one run row with no `truncated` flag and
- * blow the consumer's queue-blocking budget. Beyond these the manifest is flagged
- * `truncated` and stops growing.
+ * ONE membership cap across `touched ∪ created ∪ archived` (by entity instance id).
+ * Only overflowing THIS sets `membershipTruncated` — which forces the large lane and
+ * the tier-3 fallback downstream. Enforced per-collector AND across `mergeManifests`.
  */
-const MAX_CHANGED_RECORDS = 5000
-const MAX_LIFECYCLE_RECORDS = 10000
+export const MAX_TOUCHED_RECORDS = 50_000
+
+/**
+ * Approximate byte budget for stored touched keys (sum of key lengths). Past it, NEW
+ * touched entries degrade to the ids-only marker `1` instead of a key list; existing
+ * entries keep their keys. Ids-only membership still drives activity, dispatch tally,
+ * dedup, and tier-2 frames — only the key-needing doors degrade per record.
+ */
+export const TOUCHED_KEYS_BYTE_BUDGET = 2_000_000
+
+/**
+ * Tier-2 cap: distinct records carrying deltas (v1's changed-records cap, renamed).
+ * Overflow sets `detailTruncated` ONLY — membership for the record is still recorded.
+ */
+export const MAX_DELTA_RECORDS = 5_000
+
+/** Collector caps — constructor-injectable so tests can exercise overflow cheaply. */
+export interface ManifestCollectorCaps {
+  maxTouchedRecords: number
+  touchedKeysByteBudget: number
+  maxDeltaRecords: number
+}
+
+const DEFAULT_CAPS: ManifestCollectorCaps = {
+  maxTouchedRecords: MAX_TOUCHED_RECORDS,
+  touchedKeysByteBudget: TOUCHED_KEYS_BYTE_BUDGET,
+  maxDeltaRecords: MAX_DELTA_RECORDS,
+}
 
 /**
  * Union one outputKey's change entries: the FIRST fragment's `o`-state wins (value AND
@@ -44,214 +73,338 @@ function mergeFieldChange(
 }
 
 /**
- * Accumulates field changes + lifecycle ids for the subscribed defs of one run/slice.
- * All mutators are no-ops when `enabled` is false (no subscriptions) — producers still
- * call them unconditionally; the gating lives here.
+ * Accumulates tier-1 membership + tier-2 deltas for one run/slice. Always real — every
+ * mutator captures. Tier-2 gating lives at the producers via `subscriptionsFor`.
+ *
+ * All mutators are cheap: Map/Set pushes only, no queries.
  */
 export interface ManifestCollector {
-  /** False ⇒ the org has no enabled rules on any def — every mutator is a no-op. */
-  readonly enabled: boolean
+  /**
+   * Always true — the collector is always real now (plan 07). Kept as a literal so
+   * producer fast-path checks (`ctx.manifest?.enabled && ...`) stay truthful; delete
+   * with the next producer sweep.
+   */
+  readonly enabled: true
   /** Subscription buckets for a def, or undefined when nothing is subscribed for it. */
   subscriptionsFor(entityDefinitionId: string): DefSubscriptions | undefined
-  /** Merge field writes for a record. First `o` wins, last `n` wins per outputKey. */
+  /**
+   * Tier 1: record that a write actually changed `recordId`, with the changed field
+   * output keys. Merges keys per record (set union). Membership + keys are deduped on
+   * the entity INSTANCE id, not the RecordId string — the same instance captured under
+   * a slug-keyed and a CUID-keyed RecordId folds to one entry (first-seen form wins).
+   */
+  recordTouched(recordId: RecordId, keys: string[]): void
+  /**
+   * Tier 2: merge `{o, n}` field deltas for a record. First `o` wins, last `n` wins per
+   * outputKey. A delta implies touched — membership + keys are recorded even when the
+   * delta cap has overflowed.
+   */
   recordChange(recordId: RecordId, entries: Record<string, ManifestFieldChange>): void
   /**
-   * Record a created id (only captured when the def has lifecycle `created` rules).
-   * `values` (raw, systemAttribute-keyed) is stashed for native entity-trigger handlers on
-   * the sync door — only when the created id is actually accepted (not truncated).
+   * Record a created id — UNCONDITIONAL membership (no lifecycle-rule gating). `values`
+   * (raw, systemAttribute-keyed) is stashed for native entity-trigger handlers on the
+   * sync door — only when the created id is actually accepted (not capped out).
    */
   recordCreated(recordId: RecordId, values?: Record<string, unknown>): void
-  /** Record an archived id (only captured when the def has lifecycle `deleted` rules). */
+  /** Record an archived id — UNCONDITIONAL membership (no lifecycle-rule gating). */
   recordArchived(recordId: RecordId): void
-  /** Serialize; null when nothing was captured. */
+  /** Serialize; null when literally nothing was captured. */
   toJson(): SyncChangeManifest | null
 }
 
-class RealCollector implements ManifestCollector {
-  readonly enabled = true
-  private readonly changes = new Map<RecordId, Map<string, ManifestFieldChange>>()
-  private readonly created = new Set<RecordId>()
-  private readonly createdValues = new Map<RecordId, Record<string, unknown>>()
-  private readonly archived = new Set<RecordId>()
-  private truncated = false
+/** Internal touched entry: first-seen RecordId form + keys (or the ids-only marker). */
+interface TouchedEntry {
+  rid: RecordId
+  keys: Set<string> | 1
+}
 
-  constructor(private readonly subs: SyncRuleSubscriptions) {}
+/**
+ * The accumulation core, shared by the collector and `mergeManifests` so in-slice and
+ * cross-slice folding can never diverge. All state is keyed by entity INSTANCE id
+ * (parseRecordId) to defeat the dual-keyspace trap (slug-keyed import RecordIds vs
+ * CUID-keyed engine RecordIds for the same record — plan 04 §11.2).
+ */
+class ManifestAccumulator {
+  /** instanceId → touched entry. */
+  private readonly touched = new Map<string, TouchedEntry>()
+  /** instanceId → delta bucket. */
+  private readonly deltas = new Map<
+    string,
+    { rid: RecordId; fields: Map<string, ManifestFieldChange> }
+  >()
+  /** instanceId → first-seen RecordId form. */
+  private readonly created = new Map<string, RecordId>()
+  private readonly archived = new Map<string, RecordId>()
+  /** instanceId → raw create values (emitted under the created RecordId form). */
+  private readonly createdValues = new Map<string, Record<string, unknown>>()
+  /** Membership union (touched ∪ created ∪ archived) by instanceId — the ONE cap. */
+  private readonly membership = new Set<string>()
+  private keysBytes = 0
+  private detailTruncated = false
+  private membershipTruncated = false
 
-  subscriptionsFor(entityDefinitionId: string): DefSubscriptions | undefined {
-    return this.subs[entityDefinitionId]
+  constructor(private readonly caps: ManifestCollectorCaps) {}
+
+  /** True when `instanceId` is (or just became) a member; false when capped out. */
+  private admitMember(instanceId: string): boolean {
+    if (this.membership.has(instanceId)) return true
+    if (this.membership.size >= this.caps.maxTouchedRecords) {
+      if (!this.membershipTruncated) {
+        this.membershipTruncated = true
+        logger.warn('Sync-change manifest MEMBERSHIP truncated — cap hit', {
+          cap: this.caps.maxTouchedRecords,
+        })
+      }
+      return false
+    }
+    this.membership.add(instanceId)
+    return true
+  }
+
+  recordTouched(recordId: RecordId, keys: string[]): void {
+    const instanceId = parseRecordId(recordId).entityInstanceId
+    if (!this.admitMember(instanceId)) return
+    let entry = this.touched.get(instanceId)
+    if (!entry) {
+      entry = {
+        rid: recordId,
+        keys: this.keysBytes >= this.caps.touchedKeysByteBudget ? 1 : new Set(),
+      }
+      this.touched.set(instanceId, entry)
+    }
+    if (entry.keys === 1) return
+    for (const key of keys) {
+      if (!entry.keys.has(key)) {
+        entry.keys.add(key)
+        this.keysBytes += key.length
+      }
+    }
+  }
+
+  /** Fold in an ids-only touched entry (`1` wins downward — once ids-only, stays so). */
+  degradeTouched(recordId: RecordId): void {
+    const instanceId = parseRecordId(recordId).entityInstanceId
+    if (!this.admitMember(instanceId)) return
+    const entry = this.touched.get(instanceId)
+    if (!entry) {
+      this.touched.set(instanceId, { rid: recordId, keys: 1 })
+      return
+    }
+    if (entry.keys !== 1) {
+      for (const key of entry.keys) this.keysBytes -= key.length
+      entry.keys = 1
+    }
   }
 
   recordChange(recordId: RecordId, entries: Record<string, ManifestFieldChange>): void {
     const keys = Object.keys(entries)
     if (keys.length === 0) return
 
-    let bucket = this.changes.get(recordId)
+    // A delta implies touched — membership first, unconditionally.
+    this.recordTouched(recordId, keys)
+
+    const instanceId = parseRecordId(recordId).entityInstanceId
+    let bucket = this.deltas.get(instanceId)
     if (!bucket) {
       // Cap only applies to NEW records — updating an already-captured record is free.
-      if (this.changes.size >= MAX_CHANGED_RECORDS) {
-        this.markTruncated('changed records')
+      if (this.deltas.size >= this.caps.maxDeltaRecords) {
+        if (!this.detailTruncated) {
+          this.detailTruncated = true
+          logger.warn('Sync-change manifest DETAIL truncated — delta cap hit', {
+            cap: this.caps.maxDeltaRecords,
+          })
+        }
         return
       }
-      bucket = new Map()
-      this.changes.set(recordId, bucket)
+      bucket = { rid: recordId, fields: new Map() }
+      this.deltas.set(instanceId, bucket)
     }
-
     for (const key of keys) {
-      bucket.set(key, mergeFieldChange(bucket.get(key), entries[key]!))
+      bucket.fields.set(key, mergeFieldChange(bucket.fields.get(key), entries[key]!))
     }
   }
 
   recordCreated(recordId: RecordId, values?: Record<string, unknown>): void {
-    // Stash values only when the id is actually accepted (kept in lockstep with the cap so a
-    // truncated create never strands orphan values the consumer can't tie to a created id).
-    if (this.addLifecycle(this.created, recordId) && values) {
-      this.createdValues.set(recordId, values)
-    }
+    const instanceId = parseRecordId(recordId).entityInstanceId
+    if (this.created.has(instanceId)) return
+    if (!this.admitMember(instanceId)) return
+    this.created.set(instanceId, recordId)
+    // Stash values only when the id is actually accepted (kept in lockstep with the cap
+    // so a capped create never strands orphan values the consumer can't tie to an id).
+    if (values) this.createdValues.set(instanceId, values)
   }
 
   recordArchived(recordId: RecordId): void {
-    this.addLifecycle(this.archived, recordId)
+    const instanceId = parseRecordId(recordId).entityInstanceId
+    if (this.archived.has(instanceId)) return
+    if (!this.admitMember(instanceId)) return
+    this.archived.set(instanceId, recordId)
   }
 
-  /** Returns true when the id was newly added (false when a duplicate or capped out). */
-  private addLifecycle(set: Set<RecordId>, recordId: RecordId): boolean {
-    if (set.has(recordId)) return false
-    if (this.created.size + this.archived.size >= MAX_LIFECYCLE_RECORDS) {
-      this.markTruncated('lifecycle records')
-      return false
+  /** Fold a v2 manifest in (earlier fragments first — first `o` wins, last `n` wins). */
+  ingest(m: SyncChangeManifest): void {
+    for (const [rid, keys] of Object.entries(m.touched) as [RecordId, string[] | 1][]) {
+      if (keys === 1) this.degradeTouched(rid)
+      else this.recordTouched(rid, keys)
     }
-    set.add(recordId)
-    return true
-  }
-
-  private markTruncated(what: string): void {
-    if (!this.truncated) {
-      this.truncated = true
-      logger.warn('Sync-change manifest truncated — cap hit', {
-        what,
-        changed: this.changes.size,
-        lifecycle: this.created.size + this.archived.size,
-      })
+    for (const [rid, fields] of Object.entries(m.deltas) as [
+      RecordId,
+      Record<string, ManifestFieldChange>,
+    ][]) {
+      this.recordChange(rid, fields)
     }
+    for (const rid of m.createdRecordIds) this.recordCreated(rid, m.createdValues?.[rid])
+    for (const rid of m.archivedRecordIds) this.recordArchived(rid)
+    this.detailTruncated = this.detailTruncated || m.detailTruncated
+    this.membershipTruncated = this.membershipTruncated || m.membershipTruncated
   }
 
   toJson(): SyncChangeManifest | null {
-    if (this.changes.size === 0 && this.created.size === 0 && this.archived.size === 0) {
+    if (
+      this.touched.size === 0 &&
+      this.deltas.size === 0 &&
+      this.created.size === 0 &&
+      this.archived.size === 0 &&
+      !this.detailTruncated &&
+      !this.membershipTruncated
+    ) {
       return null
     }
-    const changes: SyncChangeManifest['changes'] = {}
-    for (const [recordId, bucket] of this.changes) {
-      changes[recordId] = Object.fromEntries(bucket)
+    const touched: SyncChangeManifest['touched'] = {}
+    for (const entry of this.touched.values()) {
+      touched[entry.rid] = entry.keys === 1 ? 1 : [...entry.keys]
+    }
+    const deltas: SyncChangeManifest['deltas'] = {}
+    for (const bucket of this.deltas.values()) {
+      deltas[bucket.rid] = Object.fromEntries(bucket.fields)
+    }
+    let createdValues: SyncChangeManifest['createdValues']
+    for (const [instanceId, values] of this.createdValues) {
+      const rid = this.created.get(instanceId)
+      if (!rid) continue
+      if (!createdValues) createdValues = {}
+      createdValues[rid] = values
     }
     return {
-      version: 1,
-      truncated: this.truncated,
-      changes,
-      createdRecordIds: [...this.created],
-      archivedRecordIds: [...this.archived],
-      ...(this.createdValues.size > 0
-        ? { createdValues: Object.fromEntries(this.createdValues) }
-        : {}),
+      version: 2,
+      detailTruncated: this.detailTruncated,
+      membershipTruncated: this.membershipTruncated,
+      touched,
+      deltas,
+      createdRecordIds: [...this.created.values()],
+      archivedRecordIds: [...this.archived.values()],
+      ...(createdValues ? { createdValues } : {}),
     }
   }
 }
 
-/** Shared no-op used whenever nothing is subscribed. All mutators do nothing. */
-const NOOP_COLLECTOR: ManifestCollector = {
-  enabled: false,
-  subscriptionsFor: () => undefined,
-  recordChange: () => {},
-  recordCreated: () => {},
-  recordArchived: () => {},
-  toJson: () => null,
+class RealCollector implements ManifestCollector {
+  readonly enabled = true as const
+  private readonly acc: ManifestAccumulator
+
+  constructor(
+    private readonly subs: SyncRuleSubscriptions,
+    caps: ManifestCollectorCaps
+  ) {
+    this.acc = new ManifestAccumulator(caps)
+  }
+
+  subscriptionsFor(entityDefinitionId: string): DefSubscriptions | undefined {
+    return this.subs[entityDefinitionId]
+  }
+
+  recordTouched(recordId: RecordId, keys: string[]): void {
+    this.acc.recordTouched(recordId, keys)
+  }
+
+  recordChange(recordId: RecordId, entries: Record<string, ManifestFieldChange>): void {
+    this.acc.recordChange(recordId, entries)
+  }
+
+  recordCreated(recordId: RecordId, values?: Record<string, unknown>): void {
+    this.acc.recordCreated(recordId, values)
+  }
+
+  recordArchived(recordId: RecordId): void {
+    this.acc.recordArchived(recordId)
+  }
+
+  toJson(): SyncChangeManifest | null {
+    return this.acc.toJson()
+  }
+}
+
+/**
+ * Derive a v2 manifest from a v1 run row written before the v2 deploy: `touched` from
+ * each `changes` bucket's key list, `deltas` = `changes` verbatim, `detailTruncated` =
+ * `truncated`, `membershipTruncated` = false (v1 never tracked membership overflow),
+ * lifecycle arrays copied. Pure. Delete with `SyncChangeManifestV1` after one release.
+ */
+export function upgradeManifestV1(m: SyncChangeManifestV1): SyncChangeManifest {
+  const touched: SyncChangeManifest['touched'] = {}
+  for (const [rid, fields] of Object.entries(m.changes)) {
+    touched[rid as RecordId] = Object.keys(fields)
+  }
+  return {
+    version: 2,
+    detailTruncated: m.truncated,
+    membershipTruncated: false,
+    touched,
+    deltas: m.changes,
+    createdRecordIds: [...m.createdRecordIds],
+    archivedRecordIds: [...m.archivedRecordIds],
+    ...(m.createdValues ? { createdValues: m.createdValues } : {}),
+  }
+}
+
+function asV2(m: SyncChangeManifest | SyncChangeManifestV1): SyncChangeManifest {
+  return m.version === 2 ? m : upgradeManifestV1(m)
 }
 
 /**
  * Merge a later manifest fragment into a base, for folding per-slice manifests into one
- * run row (B2 §3b — the sliced sync-core writes slices as separate jobs). Union changes
- * per RecordId → outputKey with FIRST `o` wins / LAST `n` wins (base is earlier, `add`
- * later), union lifecycle id sets, OR the truncated flags. Enforces the run-level caps
- * (a NEW record/lifecycle id past the cap is dropped and sets `truncated`; updating an
- * already-present record is always free). `base` is invariably ≤ cap (a single slice's
- * `toJson` or a prior merge), so copying it first can never itself overflow. Pure —
- * testable.
+ * run row (the sliced sync-core writes slices as separate jobs). Runs both fragments
+ * through the same accumulator the collector uses, so the two merge semantics can never
+ * diverge: touched key-sets union (the ids-only marker `1` wins downward), deltas fold
+ * with FIRST `o` wins / LAST `n` wins (base is earlier, `add` later), lifecycle ids
+ * union, truncation flags OR. Everything is deduped on the entity instance id, and the
+ * same caps apply across the fold (an N-slice run cannot accumulate N × cap into one
+ * row). Accepts v1 fragments and upgrades them first. Pure — testable.
+ *
+ * @param caps Test-only override of the run-level caps.
  */
 export function mergeManifests(
-  base: SyncChangeManifest | null | undefined,
-  add: SyncChangeManifest | null | undefined
+  base: SyncChangeManifest | SyncChangeManifestV1 | null | undefined,
+  add: SyncChangeManifest | SyncChangeManifestV1 | null | undefined,
+  caps?: Partial<ManifestCollectorCaps>
 ): SyncChangeManifest | null {
-  if (!base) return add ?? null
-  if (!add) return base
-
-  let truncated = base.truncated || add.truncated
-
-  const changes: SyncChangeManifest['changes'] = {}
-  for (const [rid, fields] of Object.entries(base.changes)) {
-    changes[rid as keyof typeof changes] = { ...fields }
-  }
-  for (const [rid, fields] of Object.entries(add.changes)) {
-    let bucket = changes[rid as keyof typeof changes]
-    if (!bucket) {
-      if (Object.keys(changes).length >= MAX_CHANGED_RECORDS) {
-        truncated = true
-        continue
-      }
-      bucket = changes[rid as keyof typeof changes] = {}
-    }
-    for (const [key, entry] of Object.entries(fields)) {
-      bucket[key] = mergeFieldChange(bucket[key], entry)
-    }
-  }
-
-  const created = new Set(base.createdRecordIds)
-  const archived = new Set(base.archivedRecordIds)
-  for (const rid of add.createdRecordIds) {
-    if (created.has(rid)) continue
-    if (created.size + archived.size >= MAX_LIFECYCLE_RECORDS) {
-      truncated = true
-      break
-    }
-    created.add(rid)
-  }
-  for (const rid of add.archivedRecordIds) {
-    if (archived.has(rid)) continue
-    if (created.size + archived.size >= MAX_LIFECYCLE_RECORDS) {
-      truncated = true
-      break
-    }
-    archived.add(rid)
-  }
-
-  // Union created values (base wins on the rare duplicate), keeping only ids that survived
-  // the lifecycle cap above so values never outlive their created id.
-  let createdValues: Record<RecordId, Record<string, unknown>> | undefined
-  const mergedCreatedValues = { ...add.createdValues, ...base.createdValues }
-  for (const [rid, vals] of Object.entries(mergedCreatedValues)) {
-    if (!created.has(rid as RecordId)) continue
-    if (!createdValues) createdValues = {}
-    createdValues[rid as RecordId] = vals
-  }
-
-  return {
-    version: 1,
-    truncated,
-    changes,
-    createdRecordIds: [...created],
-    archivedRecordIds: [...archived],
-    ...(createdValues ? { createdValues } : {}),
-  }
-}
-
-/** Build a collector from a pre-computed subscription index (pure — testable). */
-export function createManifestCollector(subs: SyncRuleSubscriptions): ManifestCollector {
-  if (Object.keys(subs).length === 0) return NOOP_COLLECTOR
-  return new RealCollector(subs)
+  if (!base) return add ? asV2(add) : null
+  if (!add) return asV2(base)
+  const acc = new ManifestAccumulator({ ...DEFAULT_CAPS, ...caps })
+  acc.ingest(asV2(base))
+  acc.ingest(asV2(add))
+  return acc.toJson()
 }
 
 /**
- * Load the org's rule subscriptions from the cache and build a collector. Returns the
- * zero-cost no-op stub when the org has no enabled rules. Lazy-imports the cache +
- * subscriptions helpers to stay clear of the record-rules ↔ cache import cycle.
+ * Build a collector from a pre-computed subscription index (pure — testable). Always
+ * returns a real collector: tier-1 membership is unconditional; empty subscriptions
+ * only mean `subscriptionsFor` answers undefined for every def, so tier-2 delta
+ * capture never happens, at zero cost.
+ *
+ * @param caps Test-only override of the capture caps.
+ */
+export function createManifestCollector(
+  subs: SyncRuleSubscriptions,
+  caps?: Partial<ManifestCollectorCaps>
+): ManifestCollector {
+  return new RealCollector(subs, { ...DEFAULT_CAPS, ...caps })
+}
+
+/**
+ * Load the org's rule subscriptions from the cache and build a collector. Always real
+ * (see `createManifestCollector`). Lazy-imports the cache + subscriptions helpers to
+ * stay clear of the record-rules ↔ cache import cycle.
  */
 export async function loadManifestCollector(organizationId: string): Promise<ManifestCollector> {
   const { getCachedRecordRules } = await import('../cache')

--- a/packages/lib/src/record-rules/sync-manifest-types.ts
+++ b/packages/lib/src/record-rules/sync-manifest-types.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/record-rules/sync-manifest-types.ts
 // Shapes for the sync-change manifest: what a bulk writer (connector sink, import job)
-// accumulates per run so record rules can react to skipEvents writes. Types only — no
-// runtime. See plans/events/b2-sync-change-manifest-plan.md.
+// accumulates per run so finalize doors and record rules can react to sync-session
+// writes. Types only — no runtime. See plans/events/07-two-tier-sync-capture-plan.md.
 
 import type { RecordId } from '@auxx/types/resource'
 
@@ -14,40 +14,91 @@ export interface ManifestFieldChange {
 }
 
 /**
+ * Manifest v2 (plan 07 §3) — two tiers with independent truncation:
+ *
+ * - **Tier 1 (membership)** — `touched` + the lifecycle id arrays. Unconditional for
+ *   sync sessions: EVERY changed record, no rule subscriptions required. Near-zero
+ *   capture cost (no pre-read, no values).
+ * - **Tier 2 (deltas)** — canonical `{o, n}` per field, still gated on rule
+ *   subscriptions exactly as v1's `changes` was.
+ *
+ * Truncation only ever drops detail, never membership (plan 06 I-4).
+ *
  * Persisted on DataConnectorRun.manifest (jsonb) for connector runs; import runs persist
- * per D10 (ledger row or inline under cap). Keys per D4 gating; ids per D7 — flat
- * RecordId keys, def derivable via parseRecordId. jsonb round-trip yields plain strings;
- * cast back with `as RecordId` at the read edge.
+ * per D10 (ledger row or inline under cap). Ids per D7 — flat RecordId keys, def
+ * derivable via parseRecordId. jsonb round-trip yields plain strings; cast back with
+ * `as RecordId` at the read edge.
  */
 export interface SyncChangeManifest {
-  version: 1
-  truncated: boolean
-  /** Field writes on subscribed fields. outputKey = systemAttribute ?? fieldId. */
-  changes: Record<RecordId, Record<string, ManifestFieldChange>>
-  /** Only populated when the def has enabled lifecycle `created` rules. */
+  version: 2
+  /** Tier-2 detail hit its cap — deltas incomplete; membership still complete. */
+  detailTruncated: boolean
+  /** Membership itself overflowed — forces the large lane + tier-3 fallback. */
+  membershipTruncated: boolean
+  /**
+   * Tier 1. EVERY record a sync-session write actually changed. Value = changed field
+   * output keys (outputKey = systemAttribute ?? fieldId), or the literal `1` when keys
+   * were shed under the byte budget (ids-only degradation — see
+   * `TOUCHED_KEYS_BYTE_BUDGET` in `sync-manifest-collector.ts`).
+   */
+  touched: Record<RecordId, string[] | 1>
+  /**
+   * Tier 2. Rule-subscribed deltas — exactly v1's `changes`, renamed. Keyed
+   * RecordId → outputKey. `o`-absence is meaningful: an entry without `o` means "this
+   * record+field first appeared as a create THIS run" (see `mergeFieldChange`).
+   */
+  deltas: Record<RecordId, Record<string, ManifestFieldChange>>
+  /** UNCONDITIONAL membership: every created record, not only lifecycle-ruled defs. */
   createdRecordIds: RecordId[]
-  /** Only populated when the def has enabled lifecycle `deleted` rules. */
+  /** UNCONDITIONAL membership: every archived record, not only lifecycle-ruled defs. */
   archivedRecordIds: RecordId[]
   /**
    * Raw create-time field values (systemAttribute-keyed) for created records whose def has
    * a lifecycle `created` rule that reads them — the sync-door source for native
    * entity-trigger handlers (`enrichCompanyOnCreate` needs `company_domain`, etc.). Same raw
-   * shape `extractEventData` produces on the interactive door. Absent when no such record was
-   * created. Keys are a subset of `createdRecordIds`. See Phase 9 / Option A plan Part 4.
+   * shape `extractEventData` produces on the interactive door. Still gated — no rules means
+   * no handler reads them. Absent when no such record was created. Keys are a subset of
+   * `createdRecordIds`. See Phase 9 / Option A plan Part 4.
    */
   createdValues?: Record<RecordId, Record<string, unknown>>
 }
 
-/** Bus event pointing at a persisted manifest — pointers only, no payload inline. */
+/**
+ * Manifest v1 — capture was gated on rule subscriptions end-to-end. Kept only so
+ * `upgradeManifestV1` can lift in-flight run rows written before the v2 deploy; delete
+ * with the shim after one release (run rows are short-lived).
+ */
+export interface SyncChangeManifestV1 {
+  version: 1
+  truncated: boolean
+  /** Field writes on subscribed fields. outputKey = systemAttribute ?? fieldId. */
+  changes: Record<RecordId, Record<string, ManifestFieldChange>>
+  createdRecordIds: RecordId[]
+  archivedRecordIds: RecordId[]
+  createdValues?: Record<RecordId, Record<string, unknown>>
+}
+
+/**
+ * Bus event pointing at a persisted manifest — pointers only, no payload inline.
+ *
+ * `{ source, ref }` is the target shape (plan 07 §3 / plan 03 H-2 finding 3): `ref` is
+ * the DataConnectorRun id for `source: 'connector'` and the ImportJob id for
+ * `source: 'import'`. `ref` is optional only for the one-release deprecation window —
+ * new publishers MUST set it; consumers fall back to the deprecated per-source fields
+ * for in-flight events.
+ */
 export interface SyncRecordsChangedEvent {
   type: 'sync:records:changed'
   data: {
     source: 'connector' | 'import'
     organizationId: string
-    /** connector: DataConnectorRun id (manifest lives on the run row). */
+    /** Manifest pointer: DataConnectorRun id (connector) or ImportJob id (import). */
+    ref?: string
+    /** @deprecated Use `ref` with `source: 'connector'`. Removed after one release. */
     runId?: string
+    /** @deprecated Derivable from the run row via `ref`. Removed after one release. */
     dataConnectorId?: string
-    /** import: ImportJob id (manifest lives on the job row). */
+    /** @deprecated Use `ref` with `source: 'import'`. Removed after one release. */
     importRef?: string
   }
 }

--- a/packages/lib/src/resources/crud/__tests__/door-conformance.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/door-conformance.test.ts
@@ -125,7 +125,7 @@ vi.mock('../../hooks', async (importOriginal) => ({
   getCommonHooks: () => ({}),
 }))
 
-import type { ManifestCollector } from '../../../record-rules/sync-manifest-collector'
+import { createManifestCollector } from '../../../record-rules/sync-manifest-collector'
 import type { RecordId } from '../../resource-id'
 import { UnifiedCrudHandler } from '../unified-handler'
 import type { CrudOptions } from '../unified-handler-mutations'
@@ -199,7 +199,10 @@ async function runScenario(
 // SCENARIOS — one real handler per write-origin kind (plus the alias lanes)
 // ═══════════════════════════════════════════════════════════════════════════
 
-const syncCollector = {} as ManifestCollector
+// A REAL collector: the tier-1 lifecycle seams (plan 07 §4) call
+// `recordCreated`/`recordArchived` on it during the sync scenario, so an
+// empty `{} as ManifestCollector` stub would crash the handler under test.
+const syncCollector = createManifestCollector({})
 const syncSession = (): WriteSession => ({
   origin: { kind: 'sync', source: 'import', ref: 'run_conformance', collector: syncCollector },
   depth: 0,

--- a/packages/lib/src/resources/crud/__tests__/sync-lifecycle-capture.test.ts
+++ b/packages/lib/src/resources/crud/__tests__/sync-lifecycle-capture.test.ts
@@ -1,0 +1,155 @@
+// packages/lib/src/resources/crud/__tests__/sync-lifecycle-capture.test.ts
+//
+// Tier-1 lifecycle capture at the unified-handler mutation seams (plan 07 §4,
+// PR 1): createEntity / archiveEntity / deleteEntity under a sync-session
+// origin record unconditional membership on the session's collector
+// (recordCreated / recordArchived, NO values — createdValues stays
+// producer-side in PR 1). Interactive and seed sessions record nothing, and
+// the inline lane's own doors are untouched.
+//
+// @auxx/database is globally mocked in src/test/setup.ts; the mutation-seam
+// mocks mirror write-session.test.ts (spread-preserving where the module has
+// more exports).
+
+import { ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  deleteOpenPairsForRecord: vi.fn(async () => ok(0)),
+  enqueueDuplicateScan: vi.fn(async () => 'job_1'),
+  publish: vi.fn(async () => {}),
+  publishLater: vi.fn(() => {}),
+  deleteCommentsByRecordId: vi.fn(async () => {}),
+}))
+
+vi.mock('../../../dedup/pairs', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  deleteOpenPairsForRecord: h.deleteOpenPairsForRecord,
+}))
+vi.mock('../../../dedup/enqueue-scan', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  enqueueDuplicateScan: h.enqueueDuplicateScan,
+}))
+vi.mock('../../../entity-instances', () => ({
+  getEntityInstance: vi.fn(async () => ok({ id: 'inst_1', archivedAt: null })),
+  updateEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+  createEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+  deleteEntityInstance: vi.fn(async () => ok({ id: 'inst_1' })),
+}))
+vi.mock('../../../realtime', () => ({
+  getRealtimeService: () => ({ publish: h.publish }),
+  publishRecordsChanged: vi.fn(async () => {}),
+  rooms: { orgRecords: () => 'room' },
+}))
+vi.mock('../../../events/publisher', () => ({
+  publisher: { publishLater: h.publishLater, publish: h.publishLater },
+}))
+vi.mock('../../../cache', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  findCachedResource: vi.fn(async () => undefined),
+}))
+vi.mock('../../../comments', () => ({
+  CommentService: class {
+    deleteCommentsByRecordId = h.deleteCommentsByRecordId
+  },
+}))
+
+import { toRecordId } from '@auxx/types/resource'
+import {
+  createManifestCollector,
+  type ManifestCollector,
+} from '../../../record-rules/sync-manifest-collector'
+import {
+  archiveEntity,
+  bulkArchiveEntities,
+  createEntity,
+  deleteEntity,
+  type MutationContext,
+} from '../unified-handler-mutations'
+import { interactiveSession, seedSession, type WriteSession } from '../write-origin'
+
+function syncSession(collector: ManifestCollector): WriteSession {
+  return { origin: { kind: 'sync', source: 'import', ref: 'import_1', collector }, depth: 0 }
+}
+
+function ctx(session: WriteSession): MutationContext {
+  return {
+    db: {} as never,
+    organizationId: 'org_1',
+    userId: 'user_1',
+    session,
+    fieldValueService: {} as never,
+    resolveEntityDefinition: async () => ({
+      id: 'def_1',
+      entityType: 'contact',
+      apiSlug: 'contacts',
+    }),
+    getFields: async () => [],
+    runPreHooks: async (_o, _d, values) => values,
+    validateUniqueFields: async () => {},
+    setFieldValues: async () => {},
+  }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('tier-1 lifecycle capture — sync sessions', () => {
+  it('createEntity records recordCreated with NO values, and stays silent', async () => {
+    const collector = createManifestCollector({})
+
+    await createEntity(ctx(syncSession(collector)), 'def_1', { first_name: 'Ada' })
+
+    const manifest = collector.toJson()
+    expect(manifest?.createdRecordIds).toEqual([toRecordId('def_1', 'inst_1')])
+    expect(manifest?.createdValues).toBeUndefined()
+    expect(manifest?.archivedRecordIds).toEqual([])
+    // The silent lane's doors stay shut — capture is not a door.
+    expect(h.publishLater).not.toHaveBeenCalled()
+    expect(h.publish).not.toHaveBeenCalled()
+  })
+
+  it('archiveEntity records recordArchived', async () => {
+    const collector = createManifestCollector({})
+
+    await archiveEntity(ctx(syncSession(collector)), 'def_1:inst_1' as never)
+
+    expect(collector.toJson()?.archivedRecordIds).toEqual(['def_1:inst_1'])
+    expect(h.publishLater).not.toHaveBeenCalled()
+  })
+
+  it('deleteEntity records recordArchived (hard delete is membership too)', async () => {
+    const collector = createManifestCollector({})
+
+    await deleteEntity(ctx(syncSession(collector)), 'def_1:inst_1' as never)
+
+    expect(collector.toJson()?.archivedRecordIds).toEqual(['def_1:inst_1'])
+    expect(h.publishLater).not.toHaveBeenCalled()
+  })
+
+  it('bulkArchiveEntities delegates per record — every id lands, once', async () => {
+    const collector = createManifestCollector({})
+
+    await bulkArchiveEntities(ctx(syncSession(collector)), [
+      'def_1:inst_1' as never,
+      // Same instance twice: the collector dedupes on the instance id.
+      'def_1:inst_1' as never,
+    ])
+
+    expect(collector.toJson()?.archivedRecordIds).toEqual(['def_1:inst_1'])
+  })
+})
+
+describe('tier-1 lifecycle capture — non-sync sessions record nothing', () => {
+  it('seed and interactive sessions never reach a collector', async () => {
+    // Nothing to capture INTO — the invariant here is that the ops run
+    // unchanged with no collector in the session (no throw, doors per lane).
+    await createEntity(ctx(seedSession('reshape')), 'def_1', {})
+    await archiveEntity(ctx(seedSession('reshape')), 'def_1:inst_1' as never)
+    expect(h.publishLater).not.toHaveBeenCalled()
+
+    await archiveEntity(ctx(interactiveSession('user_1')), 'def_1:inst_1' as never)
+    // Inline lane unchanged: bus event + realtime frame still fire.
+    expect(h.publishLater).toHaveBeenCalledTimes(1)
+    expect(h.publish).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/lib/src/resources/crud/unified-handler-mutations.ts
+++ b/packages/lib/src/resources/crud/unified-handler-mutations.ts
@@ -18,6 +18,10 @@ import {
 import { UnprocessableEntityError } from '../../errors'
 import { getEntityPostDeleteHooks, getEntityPreDeleteHooks } from '../../field-hooks/registry'
 import type { FieldValueService } from '../../field-values'
+// Leaf path on purpose (not the field-values barrel): the one shared narrowing
+// helper for tier-1 sync capture, so this file's lifecycle seams and the field
+// seams apply the identical sync-origin policy (plan 07 §4).
+import { syncCollectorOf } from '../../field-values/field-value-mutations'
 import {
   getRealtimeService,
   publishRecordsChanged,
@@ -348,6 +352,12 @@ export async function createEntity(
   // Build RecordId for field value operations
   const recordId = toRecordId(entityDef.id, instance.id)
 
+  // Tier-1 sync capture (plan 07 §4): unconditional lifecycle membership for
+  // sync sessions. NO values — `createdValues` stays producer-side in PR 1.
+  // Producers that also call recordCreated are fine: the collector dedupes on
+  // the entity instance id.
+  syncCollectorOf(ctx.session)?.recordCreated(recordId)
+
   // Buffered lane: register the create BEFORE its own field writes run. The
   // ordering is load-bearing — a record in the scope's `created` set absorbs its
   // own field changes (T-1), so the field-value layer can see it is already
@@ -592,6 +602,10 @@ export async function archiveEntity(
 
   unwrapResult(updateResult)
 
+  // Tier-1 sync capture (plan 07 §4): unconditional lifecycle membership for
+  // sync sessions (`bulkArchiveEntities` delegates here, so it is covered too).
+  syncCollectorOf(ctx.session)?.recordArchived(recordId)
+
   if (publishEvents) {
     publishRecordLifecycleEvent({
       recordId,
@@ -770,6 +784,11 @@ export async function deleteEntity(
   })
 
   unwrapResult(deleteResult)
+
+  // Tier-1 sync capture (plan 07 §4): a hard delete is membership too — the
+  // manifest has one archived set for both (`bulkDeleteEntities` delegates
+  // here, so it is covered too).
+  syncCollectorOf(ctx.session)?.recordArchived(recordId)
 
   // Post-delete hooks: deletes never fire field-change post-hooks, so this is where
   // projections that depend on the deleted record refresh (log-and-swallow, matching


### PR DESCRIPTION
## Summary

Closes **H-1**, the biggest open item of the events programme: the sync-change manifest was gated on record-rule subscriptions, so an org (or def, or field) with no enabled rules got **no manifest and no finalize at all** — connector syncs and CSV imports produced no timeline entries, no `lastActivityAt`, no tier-2 realtime frames, no dedup enqueue, no integrity passes, and no workflow dispatch. All the finalize machinery from #1806–#1810 existed but starved on one gate.

Design: `plans/events/07-two-tier-sync-capture-plan.md` (supersedes plan 06's receipt architecture — deliberately lightweight, accepted limitations + revival triggers recorded there in §6/§10).

### Two tiers

| Tier | What | Gate |
| --- | --- | --- |
| 1 — membership | record ids, lifecycle, changed field **keys** (no values) | **unconditional** for sync sessions |
| 2 — deltas | canonical `{o, n}` per field | rule subscriptions, unchanged |

### The pieces

- **Manifest v2** (`record-rules/`): `touched` / `deltas` split with separate caps (`MAX_TOUCHED_RECORDS = 50_000`, `MAX_DELTA_RECORDS = 5_000`, ~2MB key byte budget with ids-only degradation) — truncation only ever drops detail, never membership. Identity dedupes on `entityInstanceId` (dual-keyspace trap, pinned by tests). `upgradeManifestV1` at the read edges; `mergeManifests` folds mixed v1/v2.
- **Engine capture seams** (`field-value-mutations.ts`, `unified-handler-mutations.ts`): set/clear **post-idempotency-guard** (no-op writes record nothing — keeps `lastActivityAt` and D-12 lane counts honest), add/remove incl. bulk variants with actually-changed signals, built-ins, lifecycle create/archive/delete. Sync-origin sessions only; interactive/automation/seed record nothing; zero new queries.
- **Consumers**: finalize sets, timeline (per-field rows from touched keys, `{o,n}` only when a delta exists), integrity pass selection (fixes the under-selection where an imported address never geocoded unless a rule watched the field), dedup scope, and dispatch all drive off membership. Only `membershipTruncated` forces the large lane now — `detailTruncated` alone keeps the honest count.
- **Event + storage compat**: `sync:records:changed` carries `{ source, ref }` with the legacy fields deprecated for one release; run-row jsonb `$type` widened to the `v2 | v1` union — **type-only, no migration**.

Producer-side tier-2 capture stays in place this PR (double-recorded membership is absorbed by instance-id dedupe); PR 2 moves tier-2 to the seams and deletes the producer helpers.

## Test plan

- 1,196 unit + 23 integration tests green across `record-rules`, `events/handlers`, `data-connectors`, `jobs/import`, `field-values`, `resources/crud`
- **Zero-rules regression** (the point of the PR): an org with no record rules imports contacts → activity, timeline, tier-2 frames, dedup, dispatch tally all fire (unit + DB-backed int)
- Guard honesty: an all-no-op sync run produces an empty manifest, publishes nothing
- Lane honesty: `detailTruncated` alone stays small-lane; `membershipTruncated` forces large
- v1 compat: stored v1 manifest rows and in-flight legacy events resolve end-to-end through the upgrade shim
- `packages/lib` src + `@auxx/database` typecheck clean