### PR TITLE
fix(money): stop the pricing engine writing to archived and inactive catalog items

### DIFF
--- a/packages/lib/src/money/catalog-pricing.test.ts
+++ b/packages/lib/src/money/catalog-pricing.test.ts
@@ -9,6 +9,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const h = vi.hoisted(() => ({
   queryQueue: [] as unknown[][],
+  /** One entry per `.innerJoin(table, on)` call: `{ table, on, where }` (where filled on execution). */
+  joins: [] as Array<{ table: unknown; on: unknown; where: unknown }>,
   setValueWithType: vi.fn(async (_ctx: unknown, _params: unknown) => [] as unknown[]),
   createFieldValueContext: vi.fn((organizationId: string) => ({ organizationId })),
   getRealtimeService: vi.fn(() => ({})),
@@ -27,6 +29,16 @@ vi.mock('@auxx/database', () => ({
     select: () => ({
       from: () => ({
         where: () => Promise.resolve(nextRows()),
+        innerJoin: (table: unknown, on: unknown) => {
+          const join = { table, on, where: undefined as unknown }
+          h.joins.push(join)
+          return {
+            where: (clause: unknown) => {
+              join.where = clause
+              return Promise.resolve(nextRows())
+            },
+          }
+        },
       }),
     }),
   },
@@ -37,6 +49,12 @@ vi.mock('@auxx/database', () => ({
       relatedEntityId: 'relatedEntityId',
       organizationId: 'organizationId',
       valueNumber: 'valueNumber',
+      valueBoolean: 'valueBoolean',
+    },
+    EntityInstance: {
+      id: 'ei.id',
+      organizationId: 'ei.organizationId',
+      archivedAt: 'ei.archivedAt',
     },
   },
 }))
@@ -64,6 +82,7 @@ vi.mock('../realtime', () => ({
   publishFieldValueUpdates: h.publishFieldValueUpdates,
 }))
 
+import { schema } from '@auxx/database'
 import type { EntityFieldChangeEvent } from '../field-hooks/types'
 import {
   computeMarkupPrice,
@@ -79,6 +98,22 @@ const ALL_CATALOG_FIELDS = {
   catalog_item_cost: { id: 'f_cost', type: 'CURRENCY' },
   catalog_item_markup: { id: 'f_markup', type: 'NUMBER' },
   catalog_item_default_unit_price: { id: 'f_price', type: 'CURRENCY' },
+  catalog_item_active: { id: 'f_active', type: 'CHECKBOX' },
+}
+
+/** Queue entries for `isCatalogItemSyncable` (the single-item hook guard): instance row, then active FieldValue row. */
+const SYNCABLE_GUARD_ROWS: unknown[][] = [
+  [{ archivedAt: null }], // EntityInstance exists, not archived
+  [], // no stored catalog_item_active row — absence means active
+]
+
+/** Recursively search a mocked drizzle SQL clause for a mock column-name string. */
+function clauseContains(value: unknown, needle: string, seen = new Set<object>()): boolean {
+  if (typeof value === 'string') return value === needle
+  if (value == null || typeof value !== 'object') return false
+  if (seen.has(value)) return false
+  seen.add(value)
+  return Object.values(value).some((inner) => clauseContains(inner, needle, seen))
 }
 
 function buildEvent(overrides: Record<string, unknown>): EntityFieldChangeEvent {
@@ -101,6 +136,7 @@ function buildEvent(overrides: Record<string, unknown>): EntityFieldChangeEvent 
 beforeEach(() => {
   vi.clearAllMocks()
   h.queryQueue = []
+  h.joins = []
   h.bySystemAttributes.mockResolvedValue(ALL_CATALOG_FIELDS)
   h.bySystemAttribute.mockResolvedValue({ id: 'f_partcost', type: 'CURRENCY' })
 })
@@ -230,6 +266,71 @@ describe('syncCatalogItemPricing', () => {
     expect(h.setValueWithType).not.toHaveBeenCalled()
     expect(h.publishFieldValueUpdates).not.toHaveBeenCalled()
   })
+
+  it('drives off an EntityInstance join that filters archived items in SQL', async () => {
+    h.queryQueue = [[]] // joined driving query — an archived item never comes back
+    await syncCatalogItemPricing('org_1', ['part1'])
+
+    expect(h.joins).toHaveLength(1)
+    const join = h.joins[0]
+    expect(join?.table).toBe(schema.EntityInstance)
+    expect(clauseContains(join?.where, 'ei.archivedAt')).toBe(true)
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('skips an explicitly-inactive item but still syncs its active sibling', async () => {
+    h.queryQueue = [
+      [
+        { catalogInstanceId: 'cat1', partInstanceId: 'part1' }, // inactive
+        { catalogInstanceId: 'cat2', partInstanceId: 'part1' },
+      ],
+      [{ entityId: 'part1', valueNumber: 500 }],
+      [
+        { entityId: 'cat1', fieldId: 'f_cost', valueNumber: 300 },
+        { entityId: 'cat1', fieldId: 'f_active', valueBoolean: false },
+        { entityId: 'cat2', fieldId: 'f_cost', valueNumber: 300 },
+      ],
+    ]
+
+    await syncCatalogItemPricing('org_1', ['part1'])
+
+    expect(h.setValueWithType).toHaveBeenCalledTimes(1)
+    const write = h.setValueWithType.mock.calls[0]?.[1] as { recordId: string; value: unknown }
+    expect(write.recordId).toBe('catalog_item_def:cat2')
+    expect(write.value).toEqual({ type: 'number', value: 500 })
+  })
+
+  it('syncs an item with NO stored active row (absence means active, never "explicitly true")', async () => {
+    h.queryQueue = [
+      [{ catalogInstanceId: 'cat1', partInstanceId: 'part1' }],
+      [{ entityId: 'part1', valueNumber: 500 }],
+      [{ entityId: 'cat1', fieldId: 'f_cost', valueNumber: 300 }], // no f_active row at all
+    ]
+
+    await syncCatalogItemPricing('org_1', ['part1'])
+
+    expect(h.setValueWithType).toHaveBeenCalledTimes(1)
+    const write = h.setValueWithType.mock.calls[0]?.[1] as { recordId: string; value: unknown }
+    expect(write.recordId).toBe('catalog_item_def:cat1')
+    expect(write.value).toEqual({ type: 'number', value: 500 })
+  })
+
+  it('syncs an item whose active row is explicitly true, same as before', async () => {
+    h.queryQueue = [
+      [{ catalogInstanceId: 'cat1', partInstanceId: 'part1' }],
+      [{ entityId: 'part1', valueNumber: 500 }],
+      [
+        { entityId: 'cat1', fieldId: 'f_cost', valueNumber: 300 },
+        { entityId: 'cat1', fieldId: 'f_active', valueBoolean: true },
+      ],
+    ]
+
+    await syncCatalogItemPricing('org_1', ['part1'])
+
+    expect(h.setValueWithType).toHaveBeenCalledTimes(1)
+    const write = h.setValueWithType.mock.calls[0]?.[1] as { value: unknown }
+    expect(write.value).toEqual({ type: 'number', value: 500 })
+  })
 })
 
 // ─── Interactive triggers (§3) ────────────────────────────────────────
@@ -243,8 +344,51 @@ describe('syncCatalogCostOnPartChange', () => {
     expect(h.bySystemAttributes).not.toHaveBeenCalled()
   })
 
+  it('archived catalog item: no-op (no reads past the guard, no writes)', async () => {
+    h.queryQueue = [
+      [{ archivedAt: new Date('2026-08-01') }], // EntityInstance guard: archived
+    ]
+    const event = buildEvent({
+      newValue: [{ type: 'relationship', recordId: 'part:part1' }],
+    })
+    await syncCatalogCostOnPartChange(event)
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+    expect(h.queryQueue).toHaveLength(0) // archived check consumed; nothing else queried
+  })
+
+  it('explicitly-inactive catalog item: no-op', async () => {
+    h.queryQueue = [
+      [{ archivedAt: null }], // not archived
+      [{ valueBoolean: false }], // catalog_item_active stored false
+    ]
+    const event = buildEvent({
+      newValue: [{ type: 'relationship', recordId: 'part:part1' }],
+    })
+    await syncCatalogCostOnPartChange(event)
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+
+  it('no stored active row: still syncs (absence means active)', async () => {
+    h.queryQueue = [
+      ...SYNCABLE_GUARD_ROWS, // active row absent — guard passes
+      [], // current cost (none yet)
+      [{ valueNumber: 500 }], // the linked part's current part_cost
+      [], // current markup (none)
+    ]
+    const event = buildEvent({
+      newValue: [{ type: 'relationship', recordId: 'part:part1' }],
+    })
+    await syncCatalogCostOnPartChange(event)
+
+    expect(h.setValueWithType).toHaveBeenCalledTimes(1)
+    const write = h.setValueWithType.mock.calls[0]?.[1] as { fieldId: string; value: unknown }
+    expect(write.fieldId).toBe('f_cost')
+    expect(write.value).toEqual({ type: 'number', value: 500 })
+  })
+
   it('part set: writes cost, and recomputes price when markup is already set', async () => {
     h.queryQueue = [
+      ...SYNCABLE_GUARD_ROWS,
       [], // current cost on the catalog item (none yet)
       [{ valueNumber: 500 }], // the linked part's current part_cost
       [{ valueNumber: 50 }], // current markup on the catalog item
@@ -262,7 +406,7 @@ describe('syncCatalogCostOnPartChange', () => {
   })
 
   it('part cleared: clears cost, keeps markup untouched', async () => {
-    h.queryQueue = [[{ valueNumber: 500 }]] // existing cost present
+    h.queryQueue = [...SYNCABLE_GUARD_ROWS, [{ valueNumber: 500 }]] // existing cost present
     const event = buildEvent({ newValue: null })
     await syncCatalogCostOnPartChange(event)
 
@@ -273,7 +417,7 @@ describe('syncCatalogCostOnPartChange', () => {
   })
 
   it('part cleared with no existing cost: no-op', async () => {
-    h.queryQueue = [[]] // no current cost
+    h.queryQueue = [...SYNCABLE_GUARD_ROWS, []] // no current cost
     const event = buildEvent({ newValue: null })
     await syncCatalogCostOnPartChange(event)
     expect(h.setValueWithType).not.toHaveBeenCalled()

--- a/packages/lib/src/money/catalog-pricing.ts
+++ b/packages/lib/src/money/catalog-pricing.ts
@@ -16,7 +16,7 @@ import { createScopedLogger } from '@auxx/logger'
 import type { TypedFieldValue } from '@auxx/types'
 import { buildFieldValueKey, type FieldId, type FieldValueKey } from '@auxx/types/field'
 import { parseRecordId, type RecordId, toRecordId } from '@auxx/types/resource'
-import { and, eq, inArray } from 'drizzle-orm'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
 import { getOrgCache, requireCachedEntityDefId } from '../cache'
 import type { EntityFieldChangeHandler } from '../field-hooks/types'
 import { createFieldValueContext } from '../field-values/field-value-helpers'
@@ -57,12 +57,15 @@ interface CatalogPricingFields {
   cost: { id: string; type: FieldType }
   markup: { id: string; type: FieldType } | null
   price: { id: string; type: FieldType } | null
+  /** Read-only guard field (`catalog_item_active`) — never written by this module. */
+  active: { id: string } | null
 }
 
 /**
- * Resolve the four catalog-item pricing fields via the org cache. Returns `null`
+ * Resolve the catalog-item pricing fields via the org cache. Returns `null`
  * (after logging) when the org hasn't run migration 044 yet — `part`/`cost` are the
- * load-bearing pair; `markup`/`price` are optional so the sync still runs cost-only.
+ * load-bearing pair; `markup`/`price` are optional so the sync still runs cost-only,
+ * and `active` is optional so orgs without the field simply skip the inactive guard.
  */
 async function resolveCatalogPricingFields(
   organizationId: string
@@ -74,6 +77,7 @@ async function resolveCatalogPricingFields(
       'catalog_item_cost',
       'catalog_item_markup',
       'catalog_item_default_unit_price',
+      'catalog_item_active',
     ] as const)
 
   if (!cf.catalog_item_part || !cf.catalog_item_cost) {
@@ -98,7 +102,51 @@ async function resolveCatalogPricingFields(
           type: cf.catalog_item_default_unit_price.type as FieldType,
         }
       : null,
+    active: cf.catalog_item_active ? { id: cf.catalog_item_active.id } : null,
   }
+}
+
+/**
+ * Archived/inactive guard for the single-item hook path (`syncCatalogCostOnPartChange`).
+ * The batch engine applies the same two skips inline in its own queries.
+ *
+ * `catalog_item_active` defaults true and older items may have NO stored FieldValue row
+ * at all — absence means ACTIVE, so the check is "not explicitly false", never
+ * "explicitly true". A just-reactivated item may carry a stale cost until the next
+ * part-cost change re-syncs it (acceptable — the drawer shows part cost live).
+ */
+async function isCatalogItemSyncable(
+  organizationId: string,
+  entityInstanceId: string,
+  activeFieldId: string | null
+): Promise<boolean> {
+  const instanceRows = await database
+    .select({ archivedAt: schema.EntityInstance.archivedAt })
+    .from(schema.EntityInstance)
+    .where(
+      and(
+        eq(schema.EntityInstance.id, entityInstanceId),
+        eq(schema.EntityInstance.organizationId, organizationId)
+      )
+    )
+  const instance = instanceRows[0]
+  if (!instance || instance.archivedAt != null) return false
+
+  if (activeFieldId) {
+    const activeRows = await database
+      .select({ valueBoolean: schema.FieldValue.valueBoolean })
+      .from(schema.FieldValue)
+      .where(
+        and(
+          eq(schema.FieldValue.entityId, entityInstanceId),
+          eq(schema.FieldValue.fieldId, activeFieldId),
+          eq(schema.FieldValue.organizationId, organizationId)
+        )
+      )
+    if (activeRows[0]?.valueBoolean === false) return false
+  }
+
+  return true
 }
 
 interface CatalogFieldWrite {
@@ -231,18 +279,29 @@ export async function syncCatalogItemPricing(
   const fields = await resolveCatalogPricingFields(organizationId)
   if (!fields) return
 
-  // ── Step 2: ONE query — catalog items currently linked to a changed part ──
+  // ── Step 2: ONE query — non-archived catalog items currently linked to a changed part ──
+  // The EntityInstance join drops archived items in SQL; explicitly-inactive items are
+  // dropped in the write loop below (their `catalog_item_active` value rides along with
+  // the step-3b read, because absence of the row must still count as active).
   const linkRows = await database
     .select({
       catalogInstanceId: schema.FieldValue.entityId,
       partInstanceId: schema.FieldValue.relatedEntityId,
     })
     .from(schema.FieldValue)
+    .innerJoin(
+      schema.EntityInstance,
+      and(
+        eq(schema.EntityInstance.id, schema.FieldValue.entityId),
+        eq(schema.EntityInstance.organizationId, schema.FieldValue.organizationId)
+      )
+    )
     .where(
       and(
         eq(schema.FieldValue.fieldId, fields.part.id),
         eq(schema.FieldValue.organizationId, organizationId),
-        inArray(schema.FieldValue.relatedEntityId, changedPartIds)
+        inArray(schema.FieldValue.relatedEntityId, changedPartIds),
+        isNull(schema.EntityInstance.archivedAt)
       )
     )
 
@@ -274,15 +333,18 @@ export async function syncCatalogItemPricing(
     }
   }
 
-  // ── Step 3b: each affected item's current cost/markup/price ──
+  // ── Step 3b: each affected item's current cost/markup/price + active flag ──
   const catalogIds = linkRows.map((row) => row.catalogInstanceId)
-  const currentFieldIds = [fields.cost.id, fields.markup?.id, fields.price?.id].filter(
-    (id): id is string => id != null
-  )
+  const currentFieldIds = [
+    fields.cost.id,
+    fields.markup?.id,
+    fields.price?.id,
+    fields.active?.id,
+  ].filter((id): id is string => id != null)
 
   const current = new Map<
     string,
-    { cost: number | null; markup: number | null; price: number | null }
+    { cost: number | null; markup: number | null; price: number | null; active: boolean | null }
   >()
   if (currentFieldIds.length > 0) {
     const rows = await database
@@ -290,6 +352,7 @@ export async function syncCatalogItemPricing(
         entityId: schema.FieldValue.entityId,
         fieldId: schema.FieldValue.fieldId,
         valueNumber: schema.FieldValue.valueNumber,
+        valueBoolean: schema.FieldValue.valueBoolean,
       })
       .from(schema.FieldValue)
       .where(
@@ -300,10 +363,16 @@ export async function syncCatalogItemPricing(
         )
       )
     for (const row of rows) {
-      const entry = current.get(row.entityId) ?? { cost: null, markup: null, price: null }
+      const entry = current.get(row.entityId) ?? {
+        cost: null,
+        markup: null,
+        price: null,
+        active: null,
+      }
       if (row.fieldId === fields.cost.id) entry.cost = row.valueNumber
       else if (fields.markup && row.fieldId === fields.markup.id) entry.markup = row.valueNumber
       else if (fields.price && row.fieldId === fields.price.id) entry.price = row.valueNumber
+      else if (fields.active && row.fieldId === fields.active.id) entry.active = row.valueBoolean
       current.set(row.entityId, entry)
     }
   }
@@ -320,7 +389,19 @@ export async function syncCatalogItemPricing(
     // longer has one, which is the same defect one level down.
     const newCost = partCosts.get(partInstanceId) ?? null
 
-    const existing = current.get(catalogInstanceId) ?? { cost: null, markup: null, price: null }
+    const existing = current.get(catalogInstanceId) ?? {
+      cost: null,
+      markup: null,
+      price: null,
+      active: null,
+    }
+
+    // `catalog_item_active` defaults true and older items may have NO stored FieldValue
+    // row — absence means ACTIVE, so only an explicit `false` skips. A just-reactivated
+    // item may carry a stale cost until the next part-cost change re-syncs it
+    // (acceptable — the drawer shows part cost live).
+    if (existing.active === false) continue
+
     const recordId = toRecordId(catalogDefId, catalogInstanceId) as RecordId
 
     if (existing.cost !== newCost) {
@@ -374,6 +455,13 @@ export const syncCatalogCostOnPartChange: EntityFieldChangeHandler = async (even
   const { organizationId, recordId } = event
   const fields = await resolveCatalogPricingFields(organizationId)
   if (!fields) return
+
+  // Archived or explicitly-inactive items must not receive pricing writes (same guard
+  // as the batch engine's driving query).
+  const { entityInstanceId } = parseRecordId(recordId)
+  if (!(await isCatalogItemSyncable(organizationId, entityInstanceId, fields.active?.id ?? null))) {
+    return
+  }
 
   const partInstanceId = relationshipEntityInstanceId(event.newValue)
   const currentCost = await readCurrentNumber(organizationId, recordId, fields.cost.id)


### PR DESCRIPTION
Fixes the live defect found during the products plan-set verification (02 §5.1): `syncCatalogItemPricing` and `syncCatalogCostOnPartChange` drove off raw `FieldValue` scans with **no lifecycle predicate** — an archived or inactive catalog item kept getting `catalog_item_cost` (and, with a markup set, its price) rewritten on every part-cost change, forever. It ships now because the Sellable toggle (sibling PR) makes inactive items an everyday state.

- **Batch engine**: the driving query joins `EntityInstance` with `archivedAt IS NULL` (archived items never enter the write loop); `catalog_item_active` is read in the existing batched value read and explicitly-false items skip in the loop.
- **Interactive hook**: guards up front — one instance read, one active-value read — before any pricing work.
- **Absence means active**: the field defaults true and older items never stored a value, so both paths test "not explicitly false", never "explicitly true".
- A just-reactivated item keeps a stale cost until the next part-cost change — accepted and commented; the cheap upgrade (a `false → true` field-change handler at the existing `register-hooks.ts` catalog-items site) is noted, not built.

Tests: 16 files / 337 green across `src/money` + `src/bom`, including archived-skipped, inactive-skipped, no-value-still-synced, and SQL-join assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)