### PR TITLE
feat(catalog): relabel to Catalog Items and give the catalog a first-class route

### DIFF
--- a/apps/web/src/app/(protected)/app/catalog/layout.tsx
+++ b/apps/web/src/app/(protected)/app/catalog/layout.tsx
@@ -1,0 +1,34 @@
+// apps/web/src/app/(protected)/app/catalog/layout.tsx
+
+'use client'
+
+import {
+  MainPage,
+  MainPageBreadcrumb,
+  MainPageBreadcrumbItem,
+  MainPageHeader,
+} from '@auxx/ui/components/main-page'
+import { Tags } from 'lucide-react'
+
+const BASE_PATH = '/app/catalog'
+
+/**
+ * Catalog layout — the products-route recipe: a plain breadcrumb shell around
+ * the catalog surface (plans/products/01-product-family.md §6).
+ */
+export default function CatalogLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <MainPage>
+      <MainPageHeader>
+        <MainPageBreadcrumb>
+          <MainPageBreadcrumbItem
+            title='Catalog'
+            href={BASE_PATH}
+            icon={<Tags className='size-4' />}
+          />
+        </MainPageBreadcrumb>
+      </MainPageHeader>
+      {children}
+    </MainPage>
+  )
+}

--- a/apps/web/src/app/(protected)/app/catalog/page.tsx
+++ b/apps/web/src/app/(protected)/app/catalog/page.tsx
@@ -1,0 +1,9 @@
+// apps/web/src/app/(protected)/app/catalog/page.tsx
+
+'use client'
+
+import { CatalogPage } from '~/components/money/ui/catalog-page'
+
+export default function CatalogRoute() {
+  return <CatalogPage />
+}

--- a/apps/web/src/app/(protected)/app/dispatch/settings/layout.tsx
+++ b/apps/web/src/app/(protected)/app/dispatch/settings/layout.tsx
@@ -75,7 +75,7 @@ const DISPATCH_SETTINGS: SidebarProps[] = [
     items: [
       {
         id: 'dispatch-money-products',
-        label: 'Products & Services',
+        label: 'Catalog',
         slug: 'products',
         icon: <Tags />,
       },

--- a/apps/web/src/components/money/ui/catalog-page.tsx
+++ b/apps/web/src/components/money/ui/catalog-page.tsx
@@ -1,0 +1,204 @@
+// apps/web/src/components/money/ui/catalog-page.tsx
+'use client'
+
+import { FeatureKey, PermissionKey } from '@auxx/lib/permissions/client'
+import { DockableDrawer } from '@auxx/ui/components/dockable-drawer'
+import { MainPageContent } from '@auxx/ui/components/main-page'
+import { ResponsiveTabs } from '@auxx/ui/components/responsive-tabs'
+import { generateId } from '@auxx/utils'
+import { Boxes, Lock, Package } from 'lucide-react'
+import { useQueryState } from 'nuqs'
+import { useState } from 'react'
+import { EmptyState } from '~/components/global/empty-state'
+import { useMedia } from '~/hooks/use-media'
+import { useSettings } from '~/hooks/use-settings'
+import { useRequireCapability } from '~/providers/capabilities-provider'
+import { useFeatureFlags } from '~/providers/feature-flag-provider'
+import type { CatalogDraftHandle } from './settings/catalog-draft-types'
+import { GroupEditor } from './settings/group-editor'
+import { GroupsList } from './settings/groups-list'
+import { ProductEditor } from './settings/product-editor'
+import { ProductsList } from './settings/products-list'
+
+type CatalogTab = 'items' | 'groups'
+
+const TABS: { value: CatalogTab; label: string; icon: typeof Package }[] = [
+  { value: 'items', label: 'Catalog items', icon: Package },
+  { value: 'groups', label: 'Catalog groups', icon: Boxes },
+]
+
+/**
+ * First-class catalog surface at `/app/catalog`
+ * (plans/products/01-product-family.md §6 — surface promotion).
+ *
+ * Hosts the SAME list/editor components as the dispatch settings tab at
+ * `/app/dispatch/settings/products` — `ProductsList`/`ProductEditor` and
+ * `GroupsList`/`GroupEditor` — inside the `/app/products` route shell instead
+ * of the settings chrome. The settings tab keeps working unchanged (it also
+ * owns tax rates, which stay a settings concern); `catalog_item` and
+ * `catalog_group` stay `isVisible: false`, so this route plus its deliberate
+ * sidebar entry IS the promotion — not a visibility flip.
+ *
+ * The selection/draft orchestration mirrors `settings/products-services-page.tsx`
+ * (money 15-settings-phantom-editors.md phase 2): one phantom draft per tab,
+ * dropped when untouched on selecting another row or switching tabs.
+ */
+export function CatalogPage() {
+  useRequireCapability(PermissionKey.settingsManage)
+  const { hasAccess } = useFeatureFlags()
+
+  const [tab, setTab] = useQueryState('s', { defaultValue: 'items' as string })
+  const activeTab: CatalogTab = tab === 'groups' ? 'groups' : 'items'
+
+  const [selectedItemId, setSelectedItemId] = useState<string | null>(null)
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null)
+  const [itemDraft, setItemDraft] = useState<CatalogDraftHandle | null>(null)
+  const [groupDraft, setGroupDraft] = useState<CatalogDraftHandle | null>(null)
+
+  function handleSelectItem(id: string | null) {
+    if (itemDraft && id !== itemDraft.draftId && id !== itemDraft.recordId) {
+      setItemDraft(null)
+    }
+    setSelectedItemId(id)
+  }
+  function handleSelectGroup(id: string | null) {
+    if (groupDraft && id !== groupDraft.draftId && id !== groupDraft.recordId) {
+      setGroupDraft(null)
+    }
+    setSelectedGroupId(id)
+  }
+  function handleAddItemDraft() {
+    if (itemDraft && !itemDraft.recordId) {
+      setSelectedItemId(itemDraft.draftId)
+      return
+    }
+    const draftId = generateId('draft')
+    setItemDraft({ draftId, name: '' })
+    setSelectedItemId(draftId)
+  }
+  function handleAddGroupDraft() {
+    if (groupDraft && !groupDraft.recordId) {
+      setSelectedGroupId(groupDraft.draftId)
+      return
+    }
+    const draftId = generateId('draft')
+    setGroupDraft({ draftId, name: '' })
+    setSelectedGroupId(draftId)
+  }
+  function handleItemDraftNameChange(name: string) {
+    setItemDraft((prev) => (prev ? { ...prev, name } : prev))
+  }
+  function handleGroupDraftNameChange(name: string) {
+    setGroupDraft((prev) => (prev ? { ...prev, name } : prev))
+  }
+  // First create resolved: swap selection to the real id but KEEP the draft so
+  // the editor form stays mounted (mid-typing text + pending debounced commit).
+  function handleItemDraftCommitted(recordId: string) {
+    setItemDraft((prev) => (prev ? { ...prev, recordId } : prev))
+    setSelectedItemId(recordId)
+  }
+  function handleGroupDraftCommitted(recordId: string) {
+    setGroupDraft((prev) => (prev ? { ...prev, recordId } : prev))
+    setSelectedGroupId(recordId)
+  }
+  function handleTabChange(next: string) {
+    setTab(next)
+    if (itemDraft) setItemDraft(null)
+    if (groupDraft) setGroupDraft(null)
+  }
+
+  const { getSetting } = useSettings({ scope: 'GENERAL' })
+  const currency = (getSetting('organization.currency') as string) || 'USD'
+
+  const isDesktop = useMedia('(min-width: 1024px)')
+
+  if (!hasAccess(FeatureKey.dispatch)) {
+    return (
+      <MainPageContent>
+        <EmptyState
+          icon={Lock}
+          title='Catalog Not Available'
+          description='Upgrade your plan to use quoting and dispatch.'
+          button={<div className='h-12' />}
+        />
+      </MainPageContent>
+    )
+  }
+
+  const selectedId = activeTab === 'items' ? selectedItemId : selectedGroupId
+  const mobileDrawerOpen = !isDesktop && !!selectedId
+
+  const editorContent =
+    activeTab === 'items' ? (
+      <ProductEditor
+        selectedId={selectedItemId}
+        draft={itemDraft}
+        onDraftNameChange={handleItemDraftNameChange}
+        onDraftCommitted={handleItemDraftCommitted}
+      />
+    ) : (
+      <GroupEditor
+        selectedId={selectedGroupId}
+        currency={currency}
+        draft={groupDraft}
+        onDraftNameChange={handleGroupDraftNameChange}
+        onDraftCommitted={handleGroupDraftCommitted}
+      />
+    )
+
+  return (
+    <MainPageContent>
+      <div className='flex h-full min-h-0 flex-1 flex-col'>
+        <div className='border-b px-3 py-2.5'>
+          <ResponsiveTabs
+            value={activeTab}
+            onValueChange={handleTabChange}
+            size='sm'
+            items={TABS}
+          />
+        </div>
+        <div className='grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_420px]'>
+          <div className='min-w-0 overflow-y-auto'>
+            {activeTab === 'items' ? (
+              <ProductsList
+                selectedId={selectedItemId}
+                onSelect={handleSelectItem}
+                currency={currency}
+                draft={itemDraft}
+                onAddDraft={handleAddItemDraft}
+              />
+            ) : (
+              <GroupsList
+                selectedId={selectedGroupId}
+                onSelect={handleSelectGroup}
+                currency={currency}
+                draft={groupDraft}
+                onAddDraft={handleAddGroupDraft}
+              />
+            )}
+          </div>
+          <div className='hidden overflow-y-auto border-l lg:block'>{editorContent}</div>
+        </div>
+      </div>
+
+      <DockableDrawer
+        open={mobileDrawerOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedItemId(null)
+            setSelectedGroupId(null)
+            setItemDraft(null)
+            setGroupDraft(null)
+          }
+        }}
+        isDocked={false}
+        width={380}
+        onWidthChange={() => {}}
+        minWidth={320}
+        maxWidth={480}
+        title={activeTab === 'items' ? 'Edit item' : 'Edit group'}>
+        {editorContent}
+      </DockableDrawer>
+    </MainPageContent>
+  )
+}

--- a/apps/web/src/components/money/ui/settings/group-editor.tsx
+++ b/apps/web/src/components/money/ui/settings/group-editor.tsx
@@ -110,7 +110,7 @@ export function GroupEditor({
   const group = selectedId ? groupMap.get(selectedId) : undefined
 
   if (!group) {
-    return <div className='p-4 text-sm text-muted-foreground'>Select a product group to edit.</div>
+    return <div className='p-4 text-sm text-muted-foreground'>Select a catalog group to edit.</div>
   }
 
   return <GroupEditorForm key={group.id} group={group} currency={currency} />
@@ -904,7 +904,7 @@ function AddItemPopover({
           <CommandInput
             value={query}
             onValueChange={setQuery}
-            placeholder='Search products & services…'
+            placeholder='Search catalog items…'
           />
           <CommandList>
             {!hasAnyMatch && <CommandEmpty>No active items</CommandEmpty>}

--- a/apps/web/src/components/money/ui/settings/groups-list.tsx
+++ b/apps/web/src/components/money/ui/settings/groups-list.tsx
@@ -120,7 +120,7 @@ export function GroupsList({ selectedId, onSelect, currency, draft, onAddDraft }
         <InputSearch
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          placeholder='Search product groups...'
+          placeholder='Search catalog groups...'
         />
         <Button variant='outline' size='sm' onClick={onAddDraft} disabled={!entityDefinitionId}>
           <Plus />
@@ -132,7 +132,7 @@ export function GroupsList({ selectedId, onSelect, currency, draft, onAddDraft }
         <div className='p-4 text-center text-sm text-muted-foreground'>Loading…</div>
       ) : filtered.length === 0 && !draft ? (
         <div className='p-4 text-center text-sm text-muted-foreground'>
-          {search ? 'No matches' : 'No product groups yet — add your first one.'}
+          {search ? 'No matches' : 'No catalog groups yet — add your first one.'}
         </div>
       ) : (
         <div className='flex flex-col gap-0.5'>

--- a/apps/web/src/components/money/ui/settings/product-editor.tsx
+++ b/apps/web/src/components/money/ui/settings/product-editor.tsx
@@ -96,9 +96,7 @@ export function ProductEditor({
   const item = selectedId ? itemMap.get(selectedId) : undefined
 
   if (!item) {
-    return (
-      <div className='p-4 text-sm text-muted-foreground'>Select a product or service to edit.</div>
-    )
+    return <div className='p-4 text-sm text-muted-foreground'>Select a catalog item to edit.</div>
   }
 
   return <ProductEditorForm key={item.id} item={item} />

--- a/apps/web/src/components/money/ui/settings/products-list.tsx
+++ b/apps/web/src/components/money/ui/settings/products-list.tsx
@@ -110,7 +110,7 @@ export function ProductsList({
         <InputSearch
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          placeholder='Search products & services...'
+          placeholder='Search catalog items...'
         />
         <Button variant='outline' size='sm' onClick={onAddDraft} disabled={!entityDefinitionId}>
           <Plus />
@@ -122,7 +122,7 @@ export function ProductsList({
         <div className='p-4 text-center text-sm text-muted-foreground'>Loading…</div>
       ) : filtered.length === 0 && !draft ? (
         <div className='p-4 text-center text-sm text-muted-foreground'>
-          {search ? 'No matches' : 'No products or services yet — add your first item.'}
+          {search ? 'No matches' : 'No catalog items yet — add your first item.'}
         </div>
       ) : (
         <div className='flex flex-col gap-0.5'>

--- a/apps/web/src/components/money/ui/settings/products-services-page.tsx
+++ b/apps/web/src/components/money/ui/settings/products-services-page.tsx
@@ -26,8 +26,8 @@ import { TaxRatesList } from './tax-rates-list'
 type SettingsTab = 'products' | 'groups' | 'tax-rates'
 
 const TABS: { value: SettingsTab; label: string; icon: typeof Package }[] = [
-  { value: 'products', label: 'Products & Services', icon: Package },
-  { value: 'groups', label: 'Product groups', icon: Boxes },
+  { value: 'products', label: 'Catalog items', icon: Package },
+  { value: 'groups', label: 'Catalog groups', icon: Boxes },
   { value: 'tax-rates', label: 'Tax rates', icon: Percent },
 ]
 
@@ -133,12 +133,12 @@ export function ProductsServicesPage() {
 
   // No `/app/dispatch` module home yet (M2 brings it) — the trail stays local
   // to settings rather than linking a route that doesn't exist.
-  const breadcrumbs = [{ title: 'Dispatch Settings' }, { title: 'Products & Services' }]
+  const breadcrumbs = [{ title: 'Dispatch Settings' }, { title: 'Catalog' }]
 
   if (!hasAccess(FeatureKey.dispatch)) {
     return (
       <SettingsPage
-        title='Products & Services'
+        title='Catalog'
         description='Manage the catalog and tax rates used on quotes and invoices.'
         breadcrumbs={breadcrumbs}>
         <EmptyState
@@ -219,7 +219,7 @@ export function ProductsServicesPage() {
 
   return (
     <SettingsPage
-      title='Products & Services'
+      title='Catalog'
       description='Manage the catalog and tax rates used on quotes and invoices.'
       breadcrumbs={breadcrumbs}
       subHeader={

--- a/apps/web/src/constants/menu.tsx
+++ b/apps/web/src/constants/menu.tsx
@@ -31,6 +31,7 @@ import {
   ShieldCheck,
   Sparkles,
   Tag,
+  Tags,
   Trash2,
   Truck,
   UserCog,
@@ -182,6 +183,19 @@ export const SIDEBAR_MENU: SidebarProps[] = [
         icon: <Receipt />,
       },
     ],
+  },
+  {
+    // The sellable catalog's first-class entry (plans/products/01-product-family.md
+    // §6). Deliberate: `catalog_item`/`catalog_group` stay `isVisible: false`, so
+    // the entity sidebar never auto-links them — this entry is the promotion.
+    // Gates match the page's own (`useRequireCapability(settingsManage)` +
+    // `FeatureKey.dispatch` in catalog-page.tsx).
+    id: 'catalog',
+    label: 'Catalog',
+    slug: 'catalog',
+    icon: <Tags />,
+    featureKey: 'dispatch',
+    permissionKey: 'settings.manage',
   },
 
   {

--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -425,8 +425,8 @@ export const ModelTypeMeta: Record<
     hasDetailPage: false,
   },
   catalog_item: {
-    label: 'Product / Service',
-    plural: 'Products & Services',
+    label: 'Catalog Item',
+    plural: 'Catalog Items',
     icon: 'tags',
     color: 'teal',
     apiSlug: 'catalog-items',
@@ -434,8 +434,8 @@ export const ModelTypeMeta: Record<
     hasDetailPage: false,
   },
   catalog_group: {
-    label: 'Product Group',
-    plural: 'Product Groups',
+    label: 'Catalog Group',
+    plural: 'Catalog Groups',
     icon: 'boxes',
     color: 'teal',
     apiSlug: 'catalog-groups',

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -65,6 +65,7 @@ import { migration074TagAiClassify } from './migrations/074-tag-ai-classify'
 import { migration075TagTemplateKey } from './migrations/075-tag-template-key'
 import { migration100PartCostProvenance } from './migrations/100-part-cost-provenance'
 import { migration101ProductFamily } from './migrations/101-product-family'
+import { migration102CatalogRelabel } from './migrations/102-catalog-relabel'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -175,6 +176,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   // space is shared across both directories, so the gap is expected.
   migration100PartCostProvenance,
   migration101ProductFamily,
+  migration102CatalogRelabel,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/102-catalog-relabel.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/102-catalog-relabel.test.ts
@@ -1,0 +1,97 @@
+// packages/lib/src/seed/entity-migrations/migrations/102-catalog-relabel.test.ts
+//
+// Migration 102 is a pure label UPDATE, so what can silently go wrong is not
+// the write itself but the wiring around it: the seeder constants and the
+// hand-edited enums.ts display map must carry the SAME new labels the
+// migration writes (or fresh orgs and migrated orgs diverge), and the
+// customized-label guard must never clobber an org's own wording. These tests
+// pin both.
+
+import { ModelTypeMeta } from '@auxx/database/enums'
+import { describe, expect, it } from 'vitest'
+import { ALL_ENTITY_MIGRATIONS } from '../../entity-migrations'
+import { SYSTEM_ENTITIES } from '../../entity-seeder/constants'
+import { CATALOG_RELABELS, migration102CatalogRelabel, resolveRelabel } from './102-catalog-relabel'
+
+describe('migration 102 registration', () => {
+  it('is registered exactly once, after 101, with a unique id', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === '102-catalog-relabel')).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids.indexOf('102-catalog-relabel')).toBe(ids.indexOf('101-product-family') + 1)
+    expect(migration102CatalogRelabel.id).toBe('102-catalog-relabel')
+  })
+})
+
+describe('label sites agree with the migration', () => {
+  // Fresh orgs get their labels from SYSTEM_ENTITIES; existing orgs from this
+  // migration. If the two diverge, which label an org shows depends on when it
+  // signed up.
+  it('SYSTEM_ENTITIES seeds the new labels the migration writes', () => {
+    for (const spec of CATALOG_RELABELS) {
+      const entity = SYSTEM_ENTITIES.find((e) => e.entityType === spec.entityType)
+      expect(entity, `${spec.entityType} missing from SYSTEM_ENTITIES`).toBeDefined()
+      expect(entity).toMatchObject({
+        singular: spec.next.singular,
+        plural: spec.next.plural,
+      })
+    }
+  })
+
+  it('the enums.ts display map carries the new labels (hand-edited registry)', () => {
+    expect(ModelTypeMeta.catalog_item).toMatchObject({
+      label: 'Catalog Item',
+      plural: 'Catalog Items',
+    })
+    expect(ModelTypeMeta.catalog_group).toMatchObject({
+      label: 'Catalog Group',
+      plural: 'Catalog Groups',
+    })
+  })
+
+  it('relabels labels ONLY — slugs and entity types are untouched', () => {
+    expect(SYSTEM_ENTITIES.find((e) => e.entityType === 'catalog_item')?.apiSlug).toBe(
+      'catalog-items'
+    )
+    expect(SYSTEM_ENTITIES.find((e) => e.entityType === 'catalog_group')?.apiSlug).toBe(
+      'catalog-groups'
+    )
+    expect(ModelTypeMeta.catalog_item.apiSlug).toBe('catalog-items')
+    expect(ModelTypeMeta.catalog_group.apiSlug).toBe('catalog-groups')
+  })
+})
+
+describe('resolveRelabel (customized-label guard)', () => {
+  const spec = CATALOG_RELABELS[0]
+
+  it('updates a row still carrying both exact old seeded labels', () => {
+    expect(
+      resolveRelabel({ singular: 'Product / Service', plural: 'Products & Services' }, spec)
+    ).toBe('update')
+  })
+
+  it('no-ops a row already carrying the new labels (idempotent re-run)', () => {
+    expect(resolveRelabel({ singular: 'Catalog Item', plural: 'Catalog Items' }, spec)).toBe(
+      'up-to-date'
+    )
+  })
+
+  it('skips a fully customized row', () => {
+    expect(resolveRelabel({ singular: 'SKU', plural: 'SKUs' }, spec)).toBe('skip')
+  })
+
+  it('skips a half-customized row rather than half-migrating it', () => {
+    expect(resolveRelabel({ singular: 'Product / Service', plural: 'Store Items' }, spec)).toBe(
+      'skip'
+    )
+    expect(resolveRelabel({ singular: 'Offering', plural: 'Products & Services' }, spec)).toBe(
+      'skip'
+    )
+  })
+
+  it('skips a row mixing old and new labels (never treated as seeded)', () => {
+    expect(resolveRelabel({ singular: 'Catalog Item', plural: 'Products & Services' }, spec)).toBe(
+      'skip'
+    )
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/102-catalog-relabel.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/102-catalog-relabel.ts
@@ -1,0 +1,131 @@
+// packages/lib/src/seed/entity-migrations/migrations/102-catalog-relabel.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:102')
+
+/**
+ * The two catalog defs whose seeded labels change
+ * (plans/products/01-product-family.md §6). Labels ONLY — `entityType`,
+ * `apiSlug`, the `catalog_item_*` systemAttributes and every slug-keyed
+ * reference stay exactly as they are.
+ */
+export const CATALOG_RELABELS = [
+  {
+    entityType: 'catalog_item',
+    old: { singular: 'Product / Service', plural: 'Products & Services' },
+    next: { singular: 'Catalog Item', plural: 'Catalog Items' },
+  },
+  {
+    entityType: 'catalog_group',
+    old: { singular: 'Product Group', plural: 'Product Groups' },
+    next: { singular: 'Catalog Group', plural: 'Catalog Groups' },
+  },
+] as const
+
+export type CatalogRelabelSpec = (typeof CATALOG_RELABELS)[number]
+
+/**
+ * Decide what to do with one org's def row.
+ *
+ * - `update`     — both labels still carry the exact old seeded values.
+ * - `up-to-date` — both labels already carry the new values (re-run no-op).
+ * - `skip`       — anything else: the org customized at least one label, and a
+ *   customized label is theirs — the migration only replaces what the seeder
+ *   wrote. A half-old row (one label customized, one still seeded) is skipped
+ *   whole rather than half-migrated.
+ */
+export function resolveRelabel(
+  labels: { singular: string; plural: string },
+  spec: CatalogRelabelSpec
+): 'update' | 'up-to-date' | 'skip' {
+  if (labels.singular === spec.next.singular && labels.plural === spec.next.plural) {
+    return 'up-to-date'
+  }
+  if (labels.singular === spec.old.singular && labels.plural === spec.old.plural) {
+    return 'update'
+  }
+  return 'skip'
+}
+
+/**
+ * Migration 102: relabel the sellable catalog defs — `catalog_item` from
+ * "Product / Service" to "Catalog Item" and `catalog_group` from
+ * "Product Group" to "Catalog Group" (plans/products/01-product-family.md §6),
+ * so the word "Product" is freed up for the `product` family entity that
+ * migration 101 added.
+ *
+ * The seeder helpers are insert-only (`ensureEntityDefinitions` skips existing
+ * rows), so every org seeded before this change keeps the old labels forever
+ * without an explicit UPDATE. Only rows still carrying BOTH exact old seeded
+ * labels are touched; a def whose labels an org customized is left alone and
+ * the skip is logged ({@link resolveRelabel}).
+ *
+ * Idempotent — a re-run finds the new labels and reports `alreadyUpToDate`.
+ * Cache invalidation is handled by the runner: any org whose result is not
+ * `alreadyUpToDate` gets `entityDefs` / `entityDefSlugs` / `customFields` /
+ * `resources` recomputed.
+ */
+export const migration102CatalogRelabel: EntityMigration = {
+  id: '102-catalog-relabel',
+  description:
+    'Relabel catalog_item to "Catalog Item" and catalog_group to "Catalog Group" (labels only, seeded values only)',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+
+    const defs = await db
+      .select({
+        id: schema.EntityDefinition.id,
+        entityType: schema.EntityDefinition.entityType,
+        singular: schema.EntityDefinition.singular,
+        plural: schema.EntityDefinition.plural,
+      })
+      .from(schema.EntityDefinition)
+      .where(
+        and(
+          eq(schema.EntityDefinition.organizationId, organizationId),
+          inArray(
+            schema.EntityDefinition.entityType,
+            CATALOG_RELABELS.map((r) => r.entityType)
+          ),
+          isNull(schema.EntityDefinition.archivedAt)
+        )
+      )
+
+    let updated = 0
+    for (const spec of CATALOG_RELABELS) {
+      const def = defs.find((d) => d.entityType === spec.entityType)
+      // Org predates the def entirely — the seeder/migration that creates it
+      // already carries the new labels, so there is nothing to do here.
+      if (!def) continue
+
+      const action = resolveRelabel(def, spec)
+      if (action === 'up-to-date') continue
+      if (action === 'skip') {
+        logger.info('Catalog def labels customized — leaving them alone', {
+          organizationId,
+          entityType: spec.entityType,
+          singular: def.singular,
+          plural: def.plural,
+        })
+        continue
+      }
+
+      await db
+        .update(schema.EntityDefinition)
+        .set({ singular: spec.next.singular, plural: spec.next.plural })
+        .where(eq(schema.EntityDefinition.id, def.id))
+      updated += 1
+    }
+
+    if (updated > 0) {
+      logger.info('Migration 102 applied', { organizationId, defsRelabeled: updated })
+    }
+
+    return { ...state, alreadyUpToDate: updated === 0 }
+  },
+}

--- a/packages/lib/src/seed/entity-seeder/constants.ts
+++ b/packages/lib/src/seed/entity-seeder/constants.ts
@@ -161,8 +161,8 @@ export const SYSTEM_ENTITIES: SystemEntityConfig[] = [
   {
     entityType: 'catalog_item',
     apiSlug: 'catalog-items',
-    singular: 'Product / Service',
-    plural: 'Products & Services',
+    singular: 'Catalog Item',
+    plural: 'Catalog Items',
     icon: 'tags',
     color: 'teal',
     isVisible: false, // Internal entity, managed from dispatch settings (vendor_part recipe)
@@ -170,8 +170,8 @@ export const SYSTEM_ENTITIES: SystemEntityConfig[] = [
   {
     entityType: 'catalog_group',
     apiSlug: 'catalog-groups',
-    singular: 'Product Group',
-    plural: 'Product Groups',
+    singular: 'Catalog Group',
+    plural: 'Catalog Groups',
     icon: 'boxes',
     color: 'teal',
     isVisible: false, // Internal entity, managed from dispatch settings (catalog_item recipe)


### PR DESCRIPTION
Completes products/01 phase 4 (§6) together with the sibling Sellable-card PR — after this, plan 01 is fully shipped.

## Relabel (labels ONLY)

`catalog_item` "Product / Service" → **"Catalog Item"**, `catalog_group` → **"Catalog Group"** — freeing the word "Product" for the family entity (#1840). No `entityType`/`apiSlug` moves (slug-keyed across imports, systemAttributes, relationship ids). Changed at every label site: seeder constants, the `enums.ts` display map (hand-edited — destructive generator), and all settings UI copy (page title, tabs, placeholders, empty states).

**Migration 102** updates existing orgs' `EntityDefinition.singular/plural` — but only rows still carrying **both** exact old seeded values: a customized label is never clobbered; half-customized/mixed rows are skipped and logged. Idempotent (`alreadyUpToDate` on re-run). Id verified free across both migration directories.

## Surface promotion

- New **`/app/catalog`** route hosting the *same* list/editor components as the dispatch settings tab (phantom-draft orchestration, mobile drawer, capability + feature gates mirrored) — no rebuild.
- Top-level **Catalog** nav entry, deliberately outside the Dispatch group — the plan's point is findability by someone who doesn't think of themselves as configuring dispatch. Auto-joins the command palette via the existing menu consumers.
- The dispatch settings tab keeps working, relabeled "Catalog". The defs deliberately stay `isVisible: false` — this is routing, not a records-surface flip.

## Tests

Migration test 9/9 (guard branches, slug immutability, seeder↔enums agreement); full seed + data-migrations suites 101 green; money-UI + nav-asserting web tests 13 green; database/lib/web typechecks clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)