### PR TITLE
refactor(files): folder queries, mutations and a pure tree core as functions (plan 5d)

### DIFF
--- a/packages/lib/src/files/core/folder-service.ts
+++ b/packages/lib/src/files/core/folder-service.ts
@@ -1,1945 +1,421 @@
 // packages/lib/src/files/core/folder-service.ts
 
-import { database, schema } from '@auxx/database'
+/**
+ * @deprecated A thin, deprecated facade over `files/folders/`.
+ *
+ * Every method below delegates to a function in `files/folders/folder-queries.ts`,
+ * `folder-mutations.ts` or `tree.ts`. The class survives only because it has 20
+ * external construction sites (23 in `folderRouter`, 4 in `FilesystemService`);
+ * **PR 5h / Phase 10 move those and delete this file.** Do not add a method
+ * here — add a function to `files/folders/` and call it with a `FilesCtx`.
+ *
+ * ## What changed for callers of this class, and nothing else did
+ *
+ * - **Errors are `AuxxError` subclasses**, not bare `Error`. A missing folder is
+ *   a `NotFoundError` (404), a name collision or an attempted cycle a
+ *   `ConflictError` (409), an illegal name a `BadRequestError` (400), so
+ *   `auxxErrorMiddleware` maps them instead of returning 500 for everything.
+ * - **Organization scope is in every statement**, including the `UPDATE`s and
+ *   the hard `DELETE`. See `folders/folder-mutations.ts`'s header for the five
+ *   statements that had no scope at all.
+ * - **The delete/restore/permanent-delete cascade selects files by `folderId`,
+ *   not by path prefix.** The legacy statements used
+ *   `ilike(FolderFile.path, `${folder.path}%`)` — no trailing slash, unescaped
+ *   `LIKE` metacharacters — so deleting `/Doc` also deleted every file under
+ *   `/Documents`, and `permanentDelete` erased them for good. This is the one
+ *   change here that alters what rows a production call touches, and it is a
+ *   fix.
+ * - **Cycle detection walks `parentId`, not `path`.** A stale path used to let a
+ *   folder be moved under its own descendant; `getAncestors` then looped
+ *   forever on the result, because it had no visited set.
+ * - **`getFolderTree` reports real file counts.** The legacy node builder read
+ *   `folder._count?.files`, a Prisma field Drizzle never produces, so every
+ *   `fileCount` and `totalSize` in the tree was `0` — while the query behind it
+ *   eagerly loaded every file row in the organization to compute them. It also
+ *   no longer drops folders whose parent is soft-deleted.
+ * - **`merge` refuses to merge a folder into its own subtree** rather than
+ *   creating the cycle.
+ * - **`getUsage().mostActiveSubfolder` is the subtree with the most recent file
+ *   activity**, not whichever direct child sorted last alphabetically (the
+ *   legacy ordered by `folders.name` descending, with a comment conceding it).
+ *
+ * ## Deleted outright rather than ported, all verified zero-caller
+ *
+ * `count`, `getStats`, `getFolderStats`, `getContents`, `getFolderPath`,
+ * `getRecent`, `getByCreator`, `findByPathPattern`, `isAncestor`,
+ * `checkCircularReference`, `validate`, `moveToParent`, and the `static
+ * computePath(folder)` that only read `folder.path ?? '/'`.
+ *
+ * Three were duplicate spellings of a survivor: `moveToParent` (== `move`),
+ * `checkCircularReference` (a one-line pass-through to the private
+ * `wouldCreateCircularReference`), and `static computePath` (which shares a name
+ * with, but is unrelated to, the real path computation).
+ *
+ * The `BaseService` scaffolding went with them: `processCreateData`,
+ * `getFolderSelectFields`, `getRelationIncludes` (already `@deprecated` and
+ * returning a `{ _isDrizzleQuery: true }` marker nothing read), `getSearchFields`,
+ * `buildScopedWhere`, and `buildFilterConditions` — 80 lines that translated a
+ * free-form `Record<string, any>` into Drizzle conditions by indexing
+ * `(schema.Folder as any)[key]`, for a `list()` whose only caller passes no
+ * arguments.
+ *
+ * `rebuildPaths`, `fixDepths` and `cleanupEmpty` are also zero-caller but were
+ * **kept**, rewritten on the pure core, in `files/folders/maintenance.ts` — see
+ * that file's header for why.
+ */
+
+import type { Transaction } from '@auxx/database'
+import { database as db } from '@auxx/database'
 import type { FolderEntity as Folder } from '@auxx/database/types'
+import type { Result } from 'neverthrow'
+import type { AuxxError } from '../../errors'
+import type { FilesCtx } from '../ctx'
+import { copyFileVersions } from '../folder-files'
 import {
-  and,
-  asc,
-  count,
-  desc,
-  eq,
-  gte,
-  ilike,
-  inArray,
-  isNull,
-  lte,
-  max,
-  type SQL,
-  sql,
-  sum,
-} from 'drizzle-orm'
-import { BaseService, type DatabaseClient } from './base-service'
-import { FileService } from './file-service'
+  copyFolder,
+  createFolder,
+  deleteFolder,
+  ensureFolderPath,
+  mergeFolders,
+  moveFolder,
+  permanentlyDeleteFolder,
+  renameFolder,
+  restoreFolder,
+  updateFolder,
+} from '../folders/folder-mutations'
 import type {
-  CreateFolderRequest,
-  FolderContents,
-  FolderSearchResult,
-  FolderTreeNode,
-  FolderWithRelations,
-  Nullish,
-  SearchOptions,
-  UpdateFolderRequest,
-  ValidationResult,
-} from './types'
+  FolderCounts,
+  FolderDetail,
+  FolderPage,
+  FolderSearchHit,
+  FolderUsage,
+} from '../folders/folder-queries'
+import {
+  getFolder,
+  getFolderAncestors,
+  getFolderCounts,
+  getFolderDescendants,
+  getFolderTree,
+  getFolderUsage,
+  getFolderWithRelations,
+  getSubfolders,
+  isFolderNameAvailable,
+  listFolders,
+  searchFolders,
+} from '../folders/folder-queries'
+import type { FileVersionCopyPort, FolderCopyDeps, FolderWriteDeps } from '../folders/ports'
+import type { FolderTreeNode } from '../folders/tree'
+import { BaseService, type DatabaseClient } from './base-service'
+import type { CreateFolderRequest, SearchOptions, UpdateFolderRequest } from './types'
+
+export type { FolderCounts, FolderDetail, FolderUsage } from '../folders/folder-queries'
 
 /**
- * Enhanced service for managing folder hierarchy and organization
- * Extends BaseService with specialized hierarchy management operations
+ * @deprecated See the file header. Delegates to `files/folders/`; deleted in Phase 10.
  */
 export class FolderService extends BaseService<
   Folder,
-  FolderWithRelations,
+  FolderDetail,
   CreateFolderRequest,
   UpdateFolderRequest,
-  FolderSearchResult
+  FolderSearchHit
 > {
-  /**
-   * Creates a new FolderService instance
-   * @param organizationId - Optional organization ID to scope operations to
-   * @param userId - Optional user ID for created/updated records
-   * @param dbInstance - Database instance to use (defaults to global db)
-   */
-  constructor(organizationId?: string, userId?: string, dbInstance: DatabaseClient = database) {
+  constructor(organizationId?: string, userId?: string, dbInstance: DatabaseClient = db) {
     super(organizationId, userId, dbInstance)
   }
 
-  /**
-   * Returns the entity name for this service
-   * @returns The entity name 'folder'
-   */
   protected getEntityName(): string {
     return 'folder'
   }
 
   /**
-   * Explicitly return the Folder schema so BaseService helpers scope correctly.
+   * @deprecated Unused. Creation runs through `folders/folder-mutations.ts`,
+   * which validates the name, resolves the parent and computes `path`/`depth`
+   * itself. Present only because `BaseService` declares this abstract.
    */
-  protected override getEntitySchema() {
-    return schema.Folder
+  protected async processCreateData(data: CreateFolderRequest): Promise<CreateFolderRequest> {
+    return data
   }
 
-  /**
-   * Build a scoped WHERE clause that always respects organization + soft delete rules.
-   */
-  private buildScopedWhere(conditions: SQL[] = [], includeDeleted = false): SQL {
-    // buildBaseWhereClause only returns undefined when there is nothing to filter on at all.
-    return super.buildBaseWhereClause(conditions, includeDeleted) ?? sql`true`
+  // ============= Reads =============
+
+  /** @deprecated Use `getFolder(ctx, folderId)`. */
+  async get(id: string, dbClient?: DatabaseClient): Promise<Folder | null> {
+    return this.unwrap(await getFolder(this.filesCtx(dbClient), id))
   }
 
-  /**
-   * Translate simple filter objects (parentId, name, etc.) into Drizzle conditions.
-   */
-  private buildFilterConditions(filters?: Record<string, any>): SQL[] {
-    if (!filters) return []
-
-    const conditions: SQL[] = []
-    for (const [key, rawValue] of Object.entries(filters)) {
-      if (rawValue === undefined) continue
-
-      const column = (schema.Folder as any)[key]
-      if (!column) continue
-
-      if (rawValue === null) {
-        conditions.push(isNull(column))
-        continue
-      }
-
-      if (Array.isArray(rawValue)) {
-        if (rawValue.length > 0) {
-          conditions.push(inArray(column, rawValue))
-        }
-        continue
-      }
-
-      if (typeof rawValue === 'object') {
-        const {
-          in: inValues,
-          equals,
-          contains,
-          mode,
-          gte: minValue,
-          lte: maxValue,
-        } = rawValue as Record<string, any>
-
-        let handled = false
-
-        if (inValues !== undefined) {
-          handled = true
-          if (Array.isArray(inValues) && inValues.length > 0) {
-            conditions.push(inArray(column, inValues))
-          }
-        }
-
-        if (equals !== undefined) {
-          handled = true
-          if (equals === null) {
-            conditions.push(isNull(column))
-          } else {
-            conditions.push(eq(column, equals))
-          }
-        }
-
-        if (contains !== undefined && contains !== null) {
-          handled = true
-          const value = String(contains)
-          if (value.length > 0) {
-            if (mode === 'insensitive') {
-              conditions.push(ilike(column, `%${value}%`))
-            } else {
-              conditions.push(sql`${column} LIKE ${'%' + value + '%'}`)
-            }
-          }
-        }
-
-        if (minValue !== undefined) {
-          handled = true
-          conditions.push(gte(column, minValue))
-        }
-
-        if (maxValue !== undefined) {
-          handled = true
-          conditions.push(lte(column, maxValue))
-        }
-
-        if (handled) continue
-      }
-
-      conditions.push(eq(column, rawValue))
-    }
-
-    return conditions
+  /** @deprecated Use `getFolderWithRelations(ctx, folderId)`. */
+  async getWithRelations(id: string, dbClient?: DatabaseClient): Promise<FolderDetail | null> {
+    return this.unwrap(await getFolderWithRelations(this.filesCtx(dbClient), id))
   }
 
-  /**
-   * Process create data with folder-specific validation and path computation
-   * Validates folder name, parent existence, name conflicts, and computes path and depth
-   * @param data - The folder creation data
-   * @returns Processed data with computed path, depth, organizationId, and createdById
-   * @throws Error if validation fails
-   */
-  protected async processCreateData(data: CreateFolderRequest): Promise<any> {
-    // Validate required fields
-    if (!data.name || data.name.trim().length === 0) {
-      throw new Error('Folder name is required')
-    }
-
-    // Validate parent folder exists if specified
-    if (data.parentId) {
-      const parent = await this.get(data.parentId)
-      if (!parent) {
-        throw new Error('Parent folder not found')
-      }
-    }
-
-    // Check for name conflicts
-    const existing = await this.findByNameAndParent(data.name, data.parentId)
-    if (existing) {
-      throw new Error('A folder with this name already exists in the parent folder')
-    }
-
-    // Compute path and depth
-    const path = await this.computeNewFolderPath(data.parentId, data.name)
-    const depth = data.parentId ? (await this.getParentDepth(data.parentId)) + 1 : 0
-
-    const now = new Date()
-
-    return {
-      ...data,
-      path,
-      depth,
-      organizationId: data.organizationId || this.requireOrganization(),
-      createdById: data.createdById || this.requireUserId(),
-      isArchived: false,
-      createdAt: now,
-      updatedAt: now,
-    }
+  /** @deprecated Use `listFolders(ctx, options)`. */
+  async list(options: { limit?: number; offset?: number } = {}): Promise<FolderPage> {
+    return this.unwrap(await listFolders(this.filesCtx(), options))
   }
 
-  /**
-   * Get field selection for folder entities with relations
-   *
-   * Defines which fields to select when querying folders with their relations.
-   * This replaces the Prisma include configuration with explicit field selection.
-   *
-   * @returns Object defining field selection for joins
-   * @protected
-   */
-  protected getFolderSelectFields() {
-    return {
-      // Folder fields
-      id: schema.Folder.id,
-      name: schema.Folder.name,
-      path: schema.Folder.path,
-      depth: schema.Folder.depth,
-      parentId: schema.Folder.parentId,
-      organizationId: schema.Folder.organizationId,
-      createdById: schema.Folder.createdById,
-      createdAt: schema.Folder.createdAt,
-      updatedAt: schema.Folder.updatedAt,
-      deletedAt: schema.Folder.deletedAt,
-    }
-  }
-
-  /**
-   * Legacy method for compatibility - now redirects to getFolderSelectFields
-   * @deprecated Use getFolderSelectFields() instead
-   */
-  protected getRelationIncludes(): any {
-    // For now, return a flag to indicate this is a Drizzle query
-    return { _isDrizzleQuery: true }
-  }
-
-  /**
-   * Get searchable fields for folder search
-   * @returns Array of field names that can be searched
-   */
-  protected getSearchFields(): string[] {
-    return ['name', 'path']
-  }
-
-  // ============= Base CRUD Implementation =============
-
-  /**
-   * Create a new folder using Drizzle.
-   */
-  async create(data: CreateFolderRequest, db?: any): Promise<Folder> {
-    const processed = await this.processCreateData(data)
-    const client = db || this.db
-
-    const [created] = await client.insert(schema.Folder).values(processed).returning()
-
-    return created as Folder
-  }
-
-  /**
-   * Fetch a single folder scoped to the current organization.
-   */
-  async get(id: string, db?: any): Promise<Folder | null> {
-    const client = db || this.db
-    const where = this.buildScopedWhere([eq(schema.Folder.id, id)])
-
-    const rows = await client.select().from(schema.Folder).where(where).limit(1)
-
-    return (rows[0] as Folder | undefined) ?? null
-  }
-
-  /**
-   * Fetch a folder with related parent, children, files, and creator details.
-   */
-  async getWithRelations(id: string, db?: any): Promise<FolderWithRelations | null> {
-    const client = db || this.db
-    const where = this.buildScopedWhere([eq(schema.Folder.id, id)])
-
-    const record = await (client as any).query.Folder.findFirst({
-      where,
-      with: {
-        parent: true,
-        children: {
-          where: (children: any, { isNull }: any) => isNull(children.deletedAt),
-          orderBy: (children: any, { asc }: any) => [asc(children.name)],
-        },
-        files: {
-          where: (files: any, { isNull }: any) => isNull(files.deletedAt),
-          orderBy: (files: any, { asc }: any) => [asc(files.name)],
-          limit: 50, // Limit files to prevent large queries
-        },
-        createdBy: {
-          columns: { id: true, name: true, email: true },
-        },
-      },
-    })
-
-    return (record as FolderWithRelations | null) ?? null
-  }
-
-  /**
-   * Count folders matching the provided filters.
-   */
-  async count(filters?: Record<string, any>): Promise<number> {
-    const where = this.buildScopedWhere(this.buildFilterConditions(filters))
-    const [result] = await this.db.select({ value: count() }).from(schema.Folder).where(where)
-
-    return Number(result?.value ?? 0)
-  }
-
-  /**
-   * Generic list implementation with pagination, sorting, and filtering.
-   */
-  async list(
-    options: {
-      limit?: number
-      offset?: number
-      sortBy?: string
-      sortOrder?: 'asc' | 'desc'
-      filters?: Record<string, any>
-      includeDeleted?: boolean
-    } = {}
-  ): Promise<{ items: Folder[]; total: number; hasMore: boolean }> {
-    const {
-      limit = 50,
-      offset = 0,
-      sortBy = 'name',
-      sortOrder = 'asc',
-      filters,
-      includeDeleted = false,
-    } = options
-
-    const where = this.buildScopedWhere(this.buildFilterConditions(filters), includeDeleted)
-
-    const sortableColumns: Record<string, any> = {
-      name: schema.Folder.name,
-      createdAt: schema.Folder.createdAt,
-      updatedAt: schema.Folder.updatedAt,
-      path: schema.Folder.path,
-      depth: schema.Folder.depth,
-    }
-
-    const orderColumn = sortableColumns[sortBy] ?? schema.Folder.name
-    const orderBy = sortOrder === 'asc' ? asc(orderColumn) : desc(orderColumn)
-
-    const [items, totalResult] = await Promise.all([
-      this.db
-        .select()
-        .from(schema.Folder)
-        .where(where)
-        .orderBy(orderBy)
-        .offset(offset)
-        .limit(limit),
-      this.db.select({ value: count() }).from(schema.Folder).where(where),
-    ])
-
-    const total = Number(totalResult[0]?.value ?? 0)
-    const hasMore = offset + items.length < total
-
-    return {
-      items: items as Folder[],
-      total,
-      hasMore,
-    }
-  }
-
-  /**
-   * Provide summary statistics for folders scoped to the organization.
-   */
-  async getStats(): Promise<{
-    total: number
-    byStatus: Record<string, number>
-    recentActivity: Array<{
-      id: string
-      name: string
-      updatedAt: Date
-      depth: number
-      parentId: string | null
-    }>
-  }> {
-    const total = await this.count()
-
-    const recent = await (this.db as any).query.Folder.findMany({
-      where: this.buildScopedWhere([], false),
-      columns: {
-        id: true,
-        name: true,
-        updatedAt: true,
-        depth: true,
-        parentId: true,
-      },
-      orderBy: (table: typeof schema.Folder) => [desc(table.updatedAt)],
-      limit: 10,
-    })
-
-    return {
-      total,
-      byStatus: {
-        active: total,
-      },
-      recentActivity: recent,
-    }
-  }
-
-  // ============= Enhanced Folder Operations =============
-
-  /**
-   * Enhanced update with path recalculation
-   * Updates folder properties and recalculates paths for hierarchy changes
-   * @param id - The folder ID to update
-   * @param data - The update data
-   * @returns Updated folder
-   * @throws Error if folder not found, name conflicts, or circular reference detected
-   */
-  async update(id: string, data: UpdateFolderRequest): Promise<Folder> {
-    const existing = await this.get(id)
-    if (!existing) {
-      throw new Error('Folder not found')
-    }
-
-    // Determine effective parent and name for conflict checking
-    const effectiveName = data.name !== undefined ? data.name : existing.name
-    const effectiveParentId = data.parentId !== undefined ? data.parentId : existing.parentId
-
-    // Check for name conflicts in the effective (target) parent
-    if (data.name !== undefined || data.parentId !== undefined) {
-      const conflict = await this.findByNameAndParent(effectiveName, effectiveParentId)
-      if (conflict && conflict.id !== id) {
-        throw new Error('A folder with this name already exists in the target parent folder')
-      }
-    }
-
-    // If parent is changing, validate and check for circular references
-    if (data.parentId !== undefined && data.parentId !== existing.parentId) {
-      if (data.parentId && (await this.wouldCreateCircularReference(id, data.parentId))) {
-        throw new Error('Move would create circular reference')
-      }
-    }
-
-    const updateData: any = { ...data }
-
-    // Recalculate path and depth if name or parent changed
-    if (data.name || data.parentId !== undefined) {
-      const newName = data.name || existing.name
-      const newParentId = data.parentId !== undefined ? data.parentId : existing.parentId
-
-      updateData.path = await this.computeNewFolderPath(newParentId, newName)
-      updateData.depth = newParentId ? (await this.getParentDepth(newParentId)) + 1 : 0
-    }
-
-    // Use transaction to update folder and descendant paths if necessary
-    return this.getTx(async (tx) => {
-      const updatedFolder = this.requireRow(
-        await tx
-          .update(schema.Folder)
-          .set({
-            ...updateData,
-            updatedAt: new Date(),
-          })
-          .where(eq(schema.Folder.id, id))
-          .returning(),
-        'update'
-      )
-
-      // Update descendant paths if path changed
-      if (updateData.path && updateData.path !== existing.path) {
-        await this.updateDescendantPaths(id, updateData.path, tx, existing.path || undefined)
-      }
-
-      return updatedFolder
-    })
-  }
-
-  /**
-   * Enhanced delete with cascading to subfolders and files
-   * Soft deletes a folder and all its descendant folders and files
-   * @param id - The folder ID to delete
-   * @throws Error if folder not found
-   */
-  async delete(id: string): Promise<void> {
-    const folder = await this.get(id)
-    if (!folder) {
-      throw new Error('Folder not found')
-    }
-
-    await this.getTx(async (tx) => {
-      // Soft delete all descendant folders
-      await tx
-        .update(schema.Folder)
-        .set({
-          deletedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(schema.Folder.organizationId, folder.organizationId),
-            ilike(schema.Folder.path, `${this.pathPrefix(folder.path)}%`),
-            isNull(schema.Folder.deletedAt)
-          )
-        )
-
-      // Soft delete all files in this folder and subfolders
-      await tx
-        .update(schema.FolderFile)
-        .set({
-          deletedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(schema.FolderFile.organizationId, folder.organizationId),
-            ilike(schema.FolderFile.path, `${folder.path || '/'}%`),
-            isNull(schema.FolderFile.deletedAt)
-          )
-        )
-
-      // Soft delete the folder itself
-      await tx
-        .update(schema.Folder)
-        .set({
-          deletedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(eq(schema.Folder.id, id))
-    })
-  }
-
-  /**
-   * Restore a soft-deleted folder and its contents
-   * Restores a soft-deleted folder and all its descendant folders and files
-   * @param id - The folder ID to restore
-   * @returns Restored folder
-   * @throws Error if folder not found
-   */
-  async restore(id: string): Promise<Folder> {
-    // Get folder including deleted ones
-    const folder = await this.db.query.Folder.findFirst({
-      where: (folders, { eq, and }) =>
-        and(eq(folders.id, id), eq(folders.organizationId, this.organizationId!)),
-    })
-
-    if (!folder) {
-      throw new Error('Folder not found')
-    }
-
-    if (!folder.deletedAt) {
-      return folder // Already restored
-    }
-
-    return this.getTx(async (tx) => {
-      // Restore the folder
-      const restoredFolder = this.requireRow(
-        await tx
-          .update(schema.Folder)
-          .set({
-            deletedAt: null,
-            updatedAt: new Date(),
-          })
-          .where(eq(schema.Folder.id, id))
-          .returning(),
-        'restore'
-      )
-
-      // Restore all descendant folders
-      await tx
-        .update(schema.Folder)
-        .set({
-          deletedAt: null,
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(schema.Folder.organizationId, folder.organizationId),
-            ilike(schema.Folder.path, `${this.pathPrefix(folder.path)}%`),
-            sql`${schema.Folder.deletedAt} IS NOT NULL`
-          )
-        )
-
-      // Restore all files in this folder and subfolders
-      await tx
-        .update(schema.FolderFile)
-        .set({
-          deletedAt: null,
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(schema.FolderFile.organizationId, folder.organizationId),
-            ilike(schema.FolderFile.path, `${folder.path || '/'}%`),
-            sql`${schema.FolderFile.deletedAt} IS NOT NULL`
-          )
-        )
-
-      return restoredFolder
-    })
-  }
-
-  /**
-   * Permanently delete a folder and all its contents
-   * Permanently removes a folder and all its descendant folders and files from the database
-   * @param id - The folder ID to permanently delete
-   * @throws Error if folder not found
-   */
-  async permanentDelete(id: string): Promise<void> {
-    const folder = await this.db.query.Folder.findFirst({
-      where: (folders, { eq, and }) =>
-        and(eq(folders.id, id), eq(folders.organizationId, this.organizationId!)),
-    })
-
-    if (!folder) {
-      throw new Error('Folder not found')
-    }
-
-    await this.getTx(async (tx) => {
-      // Delete all files in descendant folders
-      await tx
-        .delete(schema.FolderFile)
-        .where(
-          and(
-            eq(schema.FolderFile.organizationId, folder.organizationId),
-            ilike(schema.FolderFile.path, `${folder.path || '/'}%`)
-          )
-        )
-
-      // Delete all descendant folders
-      await tx
-        .delete(schema.Folder)
-        .where(
-          and(
-            eq(schema.Folder.organizationId, folder.organizationId),
-            ilike(schema.Folder.path, `${this.pathPrefix(folder.path)}%`)
-          )
-        )
-
-      // Delete the folder itself
-      await tx.delete(schema.Folder).where(eq(schema.Folder.id, id))
-    })
-  }
-
-  // ============= Hierarchy Management =============
-
-  /**
-   * Get the complete folder tree for an organization
-   * Returns a hierarchical tree structure of all folders
-   * @returns Array of root folder tree nodes with nested children
-   */
+  /** @deprecated Use `getFolderTree(ctx)`. */
   async getFolderTree(): Promise<FolderTreeNode[]> {
-    const folders = await this.db.query.Folder.findMany({
-      where: this.buildBaseWhereClause(),
-      with: {
-        files: {
-          where: (files, { isNull }) => isNull(files.deletedAt),
-        },
-        children: {
-          where: (children, { isNull }) => isNull(children.deletedAt),
-        },
-      },
-      orderBy: (folders, { asc }) => [asc(folders.depth), asc(folders.name)],
-    })
-
-    return this.buildTree(folders)
+    return this.unwrap(await getFolderTree(this.filesCtx()))
   }
 
-  /**
-   * Get immediate subfolders of a parent folder
-   * @param parentId - The parent folder ID, or null for root folders
-   * @returns Array of direct child folders
-   */
+  /** @deprecated Use `getSubfolders(ctx, parentId)`. */
   async getSubfolders(parentId: string | null): Promise<Folder[]> {
-    const conditions = parentId
-      ? [eq(schema.Folder.parentId, parentId)]
-      : [isNull(schema.Folder.parentId)]
-    return this.db.query.Folder.findMany({
-      where: this.buildBaseWhereClause(conditions),
-      orderBy: (folders, { asc }) => [asc(folders.name)],
-    })
+    return this.unwrap(await getSubfolders(this.filesCtx(), parentId))
   }
 
-  /**
-   * Get the full path string for a folder
-   * @param id - The folder ID
-   * @returns The full path string for the folder
-   * @throws Error if folder not found
-   */
-  async getFolderPath(id: string): Promise<string> {
-    const folder = await this.get(id)
-    if (!folder) {
-      throw new Error('Folder not found')
-    }
-    return folder.path ?? '/'
-  }
-
-  /**
-   * Move a folder to a new parent with path updates
-   * @param id - The folder ID to move
-   * @param newParentId - The new parent folder ID, or null for root level
-   * @returns Updated folder
-   * @throws Error if circular reference detected, folder not found, or name conflicts
-   */
-  async moveToParent(id: string, newParentId: string | null): Promise<Folder> {
-    // Normalize newParentId: convert 'root' string to null for root directory
-    const normalizedNewParentId = newParentId === 'root' ? null : newParentId
-
-    // Prevent circular references
-    if (
-      normalizedNewParentId &&
-      (await this.wouldCreateCircularReference(id, normalizedNewParentId))
-    ) {
-      throw new Error('Move would create circular reference')
-    }
-
-    const folder = await this.get(id)
-    if (!folder) {
-      throw new Error('Folder not found')
-    }
-
-    // Validate new parent exists
-    if (normalizedNewParentId) {
-      const newParent = await this.get(normalizedNewParentId)
-      if (!newParent) {
-        throw new Error('Target parent folder not found')
-      }
-    }
-
-    // Check for name conflicts in new parent
-    const conflict = await this.findByNameAndParent(folder.name, normalizedNewParentId)
-    if (conflict && conflict.id !== id) {
-      throw new Error('A folder with this name already exists in the target parent')
-    }
-
-    return this.update(id, { parentId: normalizedNewParentId })
-  }
-
-  /**
-   * Alias for moveToParent to maintain consistent interface with file service
-   * @param id - Folder ID to move
-   * @param newParentId - Target parent folder ID (null for root)
-   * @returns Promise that resolves to the updated folder
-   */
-  async move(id: string, newParentId: string | null): Promise<Folder> {
-    return this.moveToParent(id, newParentId)
-  }
-
-  /**
-   * Get all ancestor folders of a folder
-   * Returns the complete chain of parent folders from root to the folder's immediate parent
-   * @param id - The folder ID
-   * @returns Array of ancestor folders ordered from root to immediate parent
-   */
+  /** @deprecated Use `getFolderAncestors(ctx, folderId)`. */
   async getAncestors(id: string): Promise<Folder[]> {
-    const folder = await this.get(id)
-    if (!folder || !folder.parentId) {
-      return []
-    }
-
-    const ancestors: Folder[] = []
-    let currentId: string | null = folder.parentId
-
-    while (currentId) {
-      const ancestor = await this.get(currentId)
-      if (!ancestor) break
-
-      ancestors.unshift(ancestor) // Add to beginning for correct order
-      currentId = ancestor.parentId
-    }
-
-    return ancestors
+    return this.unwrap(await getFolderAncestors(this.filesCtx(), id))
   }
 
-  /**
-   * Get all descendant folders of a folder
-   * Returns all subfolders at any depth within the folder hierarchy
-   * @param id - The folder ID
-   * @returns Array of descendant folders ordered by path
-   * @throws Error if folder not found
-   */
+  /** @deprecated Use `getFolderDescendants(ctx, folderId)`. */
   async getDescendants(id: string): Promise<Folder[]> {
-    const folder = await this.get(id)
-    if (!folder) {
-      throw new Error('Folder not found')
-    }
+    return this.unwrap(await getFolderDescendants(this.filesCtx(), id))
+  }
 
-    return this.db.query.Folder.findMany({
-      where: (folders, { and, ilike }) =>
-        and(this.buildBaseWhereClause(), ilike(folders.path, `${this.pathPrefix(folder.path)}%`)),
-      orderBy: (folders, { asc }) => [asc(folders.path)],
-    })
+  /** @deprecated Use `searchFolders(ctx, query, options)`. */
+  async search(query: string, options?: SearchOptions): Promise<FolderSearchHit[]> {
+    return this.unwrap(
+      await searchFolders(this.filesCtx(), query, {
+        limit: options?.limit,
+        offset: options?.offset,
+        createdAfter: options?.dateLimits?.createdAfter,
+        createdBefore: options?.dateLimits?.createdBefore,
+      })
+    )
+  }
+
+  /** @deprecated Use `getFolderUsage(ctx, folderId)`. */
+  async getUsage(id: string): Promise<FolderUsage> {
+    return this.unwrap(await getFolderUsage(this.filesCtx(), id))
+  }
+
+  /** @deprecated Use `isFolderNameAvailable(ctx, name, parentId, excludeId)`. */
+  async validateName(name: string, parentId: string | null, excludeId?: string): Promise<boolean> {
+    return this.unwrap(await isFolderNameAvailable(this.filesCtx(), name, parentId, excludeId))
   }
 
   /**
-   * Check if one folder is an ancestor of another
-   * @param ancestorId - The potential ancestor folder ID
-   * @param descendantId - The potential descendant folder ID
-   * @returns True if ancestorId is an ancestor of descendantId, false otherwise
-   */
-  async isAncestor(ancestorId: string, descendantId: string): Promise<boolean> {
-    if (ancestorId === descendantId) {
-      return false // Folder cannot be ancestor of itself
-    }
-
-    const [ancestor, descendant] = await Promise.all([this.get(ancestorId), this.get(descendantId)])
-
-    if (!ancestor || !descendant) {
-      return false
-    }
-
-    return descendant.path?.startsWith(this.pathPrefix(ancestor.path)) || false
-  }
-
-  // ============= Folder Content =============
-
-  /**
-   * Get complete contents of a folder (subfolders + files)
-   * @param id - The folder ID
-   * @returns Complete folder contents including subfolders, files, counts, and total size
-   * @throws Error if folder not found
-   */
-  async getContents(id: string): Promise<FolderContents> {
-    const folder = await this.get(id)
-    if (!folder) {
-      throw new Error('Folder not found')
-    }
-
-    const [subfolders, files] = await Promise.all([
-      this.getSubfolders(id),
-      this.db.query.FolderFile.findMany({
-        where: (files, { eq, and, isNull }) =>
-          and(
-            eq(files.folderId, id),
-            eq(files.organizationId, this.organizationId!),
-            isNull(files.deletedAt)
-          ),
-        orderBy: (files, { asc }) => [asc(files.name)],
-      }),
-    ])
-
-    const totalSize = files.reduce((total, file) => total + (file.size ?? 0), 0)
-
-    return {
-      folder,
-      subfolders,
-      files,
-      totalFiles: files.length,
-      totalSize,
-    }
-  }
-
-  /**
-   * Get total size of all files in a folder (recursive)
-   * Calculates the total size of all files in the folder and its subfolders
-   * @param id - The folder ID
-   * @returns Total size in bytes
-   * @throws Error if folder not found
+   * @deprecated Use `getFolderCounts(ctx, folderId)`, which returns all four
+   * numbers from two statements.
+   *
+   * `folderRouter.getStats` calls the four accessors below in a `Promise.all`,
+   * so through this facade they run the pair of statements four times over.
+   * That is a **deliberate, transient** cost: the alternative is four separate
+   * exported functions that then have to be collapsed again in 5h, and the
+   * statements are indexed aggregates on one panel. PR 5h replaces the whole
+   * `Promise.all` with one `getFolderCounts` call and this note goes away with
+   * the class.
    */
   async getFolderSize(id: string): Promise<number> {
-    const folder = await this.get(id)
-    if (!folder) {
-      throw new Error('Folder not found')
-    }
-
-    const result = await this.db
-      .select({ totalSize: sum(schema.FolderFile.size) })
-      .from(schema.FolderFile)
-      .where(
-        and(
-          eq(schema.FolderFile.organizationId, this.organizationId!),
-          ilike(schema.FolderFile.path, `${folder.path || '/'}%`),
-          isNull(schema.FolderFile.deletedAt)
-        )
-      )
-
-    return Number(result[0]?.totalSize ?? 0)
+    return (await this.counts(id)).totalSize
   }
 
-  /**
-   * Get total count of files in a folder (recursive)
-   * Counts all files in the folder and its subfolders
-   * @param id - The folder ID
-   * @returns Total number of files
-   * @throws Error if folder not found
-   */
+  /** @deprecated See {@link getFolderSize}. */
   async getDeepFileCount(id: string): Promise<number> {
-    const folder = await this.get(id)
-    if (!folder) {
-      throw new Error('Folder not found')
-    }
-
-    const result = await this.db
-      .select({ count: count() })
-      .from(schema.FolderFile)
-      .where(
-        and(
-          eq(schema.FolderFile.organizationId, this.organizationId!),
-          ilike(schema.FolderFile.path, `${folder.path || '/'}%`),
-          isNull(schema.FolderFile.deletedAt)
-        )
-      )
-
-    return result[0]?.count ?? 0
+    return (await this.counts(id)).deepFileCount
   }
 
-  /**
-   * Get count of immediate files in a folder
-   * Counts only direct files, not in subfolders
-   * @param id - The folder ID
-   * @returns Number of direct files in the folder
-   */
+  /** @deprecated See {@link getFolderSize}. */
   async getDirectFileCount(id: string): Promise<number> {
-    const result = await this.db
-      .select({ count: count() })
-      .from(schema.FolderFile)
-      .where(
-        and(
-          eq(schema.FolderFile.folderId, id),
-          eq(schema.FolderFile.organizationId, this.organizationId!),
-          isNull(schema.FolderFile.deletedAt)
-        )
-      )
-
-    return result[0]?.count ?? 0
+    return (await this.counts(id)).directFileCount
   }
 
-  /**
-   * Get count of immediate subfolders
-   * Counts only direct child folders, not nested ones
-   * @param id - The folder ID
-   * @returns Number of direct subfolders
-   */
+  /** @deprecated See {@link getFolderSize}. */
   async getSubfolderCount(id: string): Promise<number> {
-    const conditions = [eq(schema.Folder.parentId, id)]
-    const result = await this.db
-      .select({ count: count() })
-      .from(schema.Folder)
-      .where(this.buildBaseWhereClause(conditions))
-
-    return result[0]?.count ?? 0
+    return (await this.counts(id)).subfolderCount
   }
 
-  // ============= Folder Operations =============
+  // ============= Writes =============
 
   /**
-   * Copy a folder and all its contents to a new parent
-   * Creates a complete copy of the folder with all subfolders and files
-   * @param sourceId - The source folder ID to copy
-   * @param targetParentId - The target parent folder ID, or null for root level
-   * @param newName - Optional new name for the copied folder
-   * @returns The newly created folder copy
-   * @throws Error if source not found, target parent not found, or name conflicts
+   * @deprecated Use `createFolder(ctx, input, deps)`.
+   *
+   * `data.organizationId` is ignored: scope comes from the service's own
+   * organization, closing the path where a caller could write a folder into an
+   * organization it was not acting for.
    */
-  async copy(sourceId: string, targetParentId: string | null, newName?: string): Promise<Folder> {
-    const sourceFolder = await this.getWithRelations(sourceId)
-    if (!sourceFolder) {
-      throw new Error('Source folder not found')
-    }
-
-    // Validate target parent if specified
-    if (targetParentId) {
-      const targetParent = await this.get(targetParentId)
-      if (!targetParent) {
-        throw new Error('Target parent folder not found')
-      }
-    }
-
-    const folderName = newName || `Copy of ${(sourceFolder as any).name}`
-
-    // Check for name conflicts
-    const conflict = await this.findByNameAndParent(folderName, targetParentId)
-    if (conflict) {
-      throw new Error('A folder with this name already exists in the target parent')
-    }
-
-    return this.getTx(async (tx) => {
-      // Create new folder
-      const newFolder = await this.create(
+  async create(data: CreateFolderRequest, dbClient?: DatabaseClient): Promise<Folder> {
+    return this.unwrap(
+      await createFolder(
+        this.filesCtx(dbClient),
         {
-          name: folderName,
-          parentId: targetParentId!,
-          organizationId: (sourceFolder as any).organizationId,
-          createdById: this.requireUserId(),
+          name: data.name,
+          parentId: data.parentId ?? null,
+          createdById: data.createdById ?? this.userId ?? null,
         },
-        tx
+        this.writeDeps()
       )
-
-      // Copy all subfolders and files recursively
-      await this.copyFolderContents(sourceFolder, newFolder.id, tx)
-
-      return newFolder
-    })
+    )
   }
 
-  /**
-   * Rename a folder with path updates
-   * Updates the folder name and recalculates all descendant paths
-   * @param id - The folder ID to rename
-   * @param newName - The new folder name
-   * @returns Updated folder
-   * @throws Error if folder not found, name is empty, or name conflicts
-   */
+  /** @deprecated Use `updateFolder(tx, ctx, folderId, input, deps)`. */
+  async update(id: string, data: UpdateFolderRequest): Promise<Folder> {
+    return this.inTransaction(undefined, async (tx) =>
+      this.unwrap(await updateFolder(tx, this.filesCtx(), id, data, this.writeDeps()))
+    )
+  }
+
+  /** @deprecated Use `renameFolder(tx, ctx, folderId, newName, deps)`. */
   async rename(id: string, newName: string): Promise<Folder> {
-    if (!newName || newName.trim().length === 0) {
-      throw new Error('Folder name cannot be empty')
-    }
-
-    const folder = await this.get(id)
-    if (!folder) {
-      throw new Error('Folder not found')
-    }
-
-    // Check for name conflicts
-    const conflict = await this.findByNameAndParent(newName, folder.parentId)
-    if (conflict && conflict.id !== id) {
-      throw new Error('A folder with this name already exists in the parent folder')
-    }
-
-    return this.update(id, { name: newName })
+    return this.inTransaction(undefined, async (tx) =>
+      this.unwrap(await renameFolder(tx, this.filesCtx(), id, newName, this.writeDeps()))
+    )
   }
 
   /**
-   * Merge two folders (move all contents from source to target)
-   * Moves all files and subfolders from source to target, then deletes source
-   * @param sourceId - The source folder ID to merge from
-   * @param targetId - The target folder ID to merge into
-   * @throws Error if folders not found or attempting to merge folder with itself
+   * @deprecated Use `moveFolder(tx, ctx, folderId, newParentId, deps)`.
+   *
+   * The legacy `moveToParent` alias is gone; this is the surviving name. The
+   * UI's `'root'` sentinel is still normalised to `null` — `FilesystemService`
+   * forwards it unnormalised from `fileRouter`.
    */
+  async move(id: string, newParentId: string | null): Promise<Folder> {
+    return this.inTransaction(undefined, async (tx) =>
+      this.unwrap(await moveFolder(tx, this.filesCtx(), id, newParentId, this.writeDeps()))
+    )
+  }
+
+  /** @deprecated Use `deleteFolder(tx, ctx, folderId, deps)`. */
+  async delete(id: string): Promise<void> {
+    await this.inTransaction(undefined, async (tx) =>
+      this.unwrap(await deleteFolder(tx, this.filesCtx(), id, this.writeDeps()))
+    )
+  }
+
+  /** @deprecated Use `restoreFolder(tx, ctx, folderId, deps)`. */
+  async restore(id: string): Promise<Folder> {
+    return this.inTransaction(undefined, async (tx) =>
+      this.unwrap(await restoreFolder(tx, this.filesCtx(), id, this.writeDeps()))
+    )
+  }
+
+  /** @deprecated Use `permanentlyDeleteFolder(tx, ctx, folderId)`. */
+  async permanentDelete(id: string): Promise<void> {
+    await this.inTransaction(undefined, async (tx) =>
+      this.unwrap(await permanentlyDeleteFolder(tx, this.filesCtx(), id))
+    )
+  }
+
+  /** @deprecated Use `copyFolder(tx, ctx, input, deps)`. */
+  async copy(sourceId: string, targetParentId: string | null, newName?: string): Promise<Folder> {
+    return this.inTransaction(undefined, async (tx) =>
+      this.unwrap(
+        await copyFolder(
+          tx,
+          this.filesCtx(),
+          { sourceId, targetParentId, newName, createdById: this.userId ?? null },
+          this.copyDeps(tx)
+        )
+      )
+    )
+  }
+
+  /** @deprecated Use `mergeFolders(tx, ctx, sourceId, targetId, deps)`. */
   async merge(sourceId: string, targetId: string): Promise<void> {
-    if (sourceId === targetId) {
-      throw new Error('Cannot merge folder with itself')
-    }
-
-    const [sourceFolder, targetFolder] = await Promise.all([
-      this.getWithRelations(sourceId),
-      this.get(targetId),
-    ])
-
-    if (!sourceFolder || !targetFolder) {
-      throw new Error('Source or target folder not found')
-    }
-
-    await this.getTx(async (tx) => {
-      // Get all files in source folder
-      const filesToMove = await tx.query.FolderFile.findMany({
-        where: (files, { eq, and, isNull }) =>
-          and(eq(files.folderId, sourceId), isNull(files.deletedAt)),
-      })
-
-      // Update each file individually with proper path recalculation
-      for (const file of filesToMove) {
-        const newPath = this.pathJoin(targetFolder.path, file.name)
-        await tx
-          .update(schema.FolderFile)
-          .set({
-            folderId: targetId,
-            path: newPath,
-            updatedAt: new Date(),
-          })
-          .where(eq(schema.FolderFile.id, file.id))
-      }
-
-      // Get all immediate subfolders in source folder
-      const subfoldersToMove = await tx.query.Folder.findMany({
-        where: (folders, { eq, and, isNull }) =>
-          and(eq(folders.parentId, sourceId), isNull(folders.deletedAt)),
-      })
-
-      // Update each subfolder with proper path recalculation
-      for (const subfolder of subfoldersToMove) {
-        const newPath = this.pathJoin(targetFolder.path, subfolder.name)
-        const newDepth = targetFolder.depth + 1
-
-        await tx
-          .update(schema.Folder)
-          .set({
-            parentId: targetId,
-            path: newPath,
-            depth: newDepth,
-            updatedAt: new Date(),
-          })
-          .where(eq(schema.Folder.id, subfolder.id))
-
-        // Update all descendant paths recursively
-        await this.updateDescendantPaths(subfolder.id, newPath, tx, subfolder.path || undefined)
-      }
-
-      // Delete the empty source folder
-      await tx
-        .update(schema.Folder)
-        .set({
-          deletedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(eq(schema.Folder.id, sourceId))
-    })
+    await this.inTransaction(undefined, async (tx) =>
+      this.unwrap(await mergeFolders(tx, this.filesCtx(), sourceId, targetId, this.writeDeps()))
+    )
   }
 
-  // ============= Validation & Utilities =============
-
-  /**
-   * Check if folder name is valid and unique within parent
-   * Validates name format and checks for uniqueness within the parent folder
-   * @param name - The folder name to validate
-   * @param parentId - The parent folder ID, or null for root level
-   * @param excludeId - Optional folder ID to exclude from uniqueness check
-   * @returns True if name is valid and unique, false otherwise
-   */
-  async validateName(name: string, parentId: string | null, excludeId?: string): Promise<boolean> {
-    // Basic name validation
-    if (!name || name.trim().length === 0) {
-      return false
-    }
-
-    // Check for invalid characters
-    const invalidChars = /[<>:"/\\|?*]/
-    if (invalidChars.test(name)) {
-      return false
-    }
-
-    // Check for uniqueness
-    const existing = await this.findByNameAndParent(name, parentId)
-    return !existing || existing.id === excludeId
-  }
-
-  /**
-   * Ensure a folder path exists, creating folders as needed
-   * Creates all necessary folders in the path if they don't exist
-   * @param path - The folder path to ensure (e.g., 'Documents/Projects/MyProject')
-   * @param userId - Optional user ID for folder creation
-   * @returns The final folder in the path
-   * @throws Error if path is invalid or folder creation fails
-   */
+  /** @deprecated Use `ensureFolderPath(ctx, path, deps, { createdById })`. */
   async ensurePath(path: string, userId?: string): Promise<Folder> {
-    const pathParts = path.split('/').filter((part) => part.length > 0)
-
-    if (pathParts.length === 0) {
-      throw new Error('Invalid path')
-    }
-
-    let currentParentId: string | null = null
-    let currentFolder: Folder | null = null
-
-    for (const folderName of pathParts) {
-      // Check if folder already exists
-      const existing = await this.findByNameAndParent(folderName, currentParentId)
-
-      if (existing) {
-        currentFolder = existing
-        currentParentId = existing.id
-      } else {
-        // Create the folder
-        currentFolder = await this.create({
-          name: folderName,
-          parentId: currentParentId!,
-          organizationId: this.requireOrganization(),
-          createdById: userId || this.requireUserId(),
-        })
-        currentParentId = currentFolder.id
-      }
-    }
-
-    if (!currentFolder) {
-      throw new Error('Failed to create path')
-    }
-
-    return currentFolder
-  }
-
-  /**
-   * Compute the full path string for a folder
-   * Static utility method to get the path from a folder object
-   * @param folder - The folder object
-   * @returns The full path string
-   */
-  static computePath(folder: Folder): string {
-    return folder.path || '/'
-  }
-
-  /**
-   * Enhanced validation for folder creation data
-   * Performs comprehensive validation including base validation and folder-specific checks
-   * @param data - The folder creation data to validate
-   * @returns Validation result with errors and warnings
-   */
-  async validate(data: CreateFolderRequest): Promise<ValidationResult> {
-    const errors: string[] = []
-    const warnings: string[] = []
-
-    // Call base validation
-    const baseValidation = await super.validate(data)
-    errors.push(...baseValidation.errors)
-    warnings.push(...baseValidation.warnings)
-
-    // Folder-specific validation
-    if (!data.name || data.name.trim().length === 0) {
-      errors.push('Folder name is required')
-    } else {
-      // Check name validity
-      if (!(await this.validateName(data.name, data.parentId!))) {
-        errors.push('Invalid folder name or name already exists')
-      }
-    }
-
-    // Validate parent folder
-    if (data.parentId) {
-      const parent = await this.get(data.parentId)
-      if (!parent) {
-        errors.push('Parent folder not found')
-      }
-    }
-
-    return {
-      isValid: errors.length === 0,
-      errors,
-      warnings,
-    }
-  }
-
-  /**
-   * Check for circular references in folder hierarchy
-   * Validates that moving a folder wouldn't create a circular reference
-   * @param folderId - The folder ID to check
-   * @param newParentId - The potential new parent folder ID
-   * @returns True if circular reference would be created, false otherwise
-   */
-  async checkCircularReference(folderId: string, newParentId: string): Promise<boolean> {
-    return this.wouldCreateCircularReference(folderId, newParentId)
-  }
-
-  // ============= Search & Query =============
-
-  /**
-   * Enhanced search folders with relevance scoring
-   * Searches folders by name and path with relevance-based ranking
-   * @param query - The search query string
-   * @param options - Optional search configuration (limit, offset, date filters)
-   * @returns Array of search results with relevance scores and matched fields
-   */
-  async search(query: string, options?: SearchOptions): Promise<FolderSearchResult[]> {
-    const filters: SQL[] = []
-
-    // Build search filters
-    filters.push(sql`(
-      LOWER(${schema.Folder.name}) = LOWER(${query}) OR
-      LOWER(${schema.Folder.name}) LIKE LOWER(${'%' + query + '%'}) OR
-      LOWER(${schema.Folder.path}) LIKE LOWER(${'%' + query + '%'})
-    )`)
-
-    // Add date filters if provided
-    if (options?.dateLimits?.createdAfter) {
-      filters.push(gte(schema.Folder.createdAt, options.dateLimits.createdAfter))
-    }
-    if (options?.dateLimits?.createdBefore) {
-      filters.push(lte(schema.Folder.createdAt, options.dateLimits.createdBefore))
-    }
-
-    // Build final where clause with base conditions
-    const whereClause = this.buildBaseWhereClause(filters)
-
-    const results = await this.db.query.Folder.findMany({
-      where: whereClause,
-      with: {
-        files: {
-          where: (files, { isNull }) => isNull(files.deletedAt),
-        },
-        children: {
-          where: (children, { isNull }) => isNull(children.deletedAt),
-        },
-      },
-      limit: options?.limit || 50,
-      offset: options?.offset || 0,
-      orderBy: (folders, { desc }) => [desc(folders.updatedAt)],
-    })
-
-    // Calculate relevance scores
-    return results
-      .map((folder): FolderSearchResult => {
-        let relevance = 0
-        const matchedFields: string[] = []
-
-        // Exact name match
-        if (folder.name.toLowerCase() === query.toLowerCase()) {
-          relevance += 10
-          matchedFields.push('name')
-        }
-        // Name contains query
-        else if (folder.name.toLowerCase().includes(query.toLowerCase())) {
-          relevance += 5
-          matchedFields.push('name')
-        }
-
-        // Path contains query
-        if (folder.path?.toLowerCase().includes(query.toLowerCase())) {
-          relevance += 3
-          matchedFields.push('path')
-        }
-
-        return {
-          folder,
-          relevance: Math.max(relevance, 1),
-          matchedFields,
-          snippet: this.generateSearchSnippet(folder, query),
-        }
+    return this.unwrap(
+      await ensureFolderPath(this.filesCtx(), path, this.writeDeps(), {
+        createdById: userId ?? this.userId ?? null,
       })
-      .sort((a, b) => b.relevance - a.relevance)
+    )
+  }
+
+  // ============= Internals =============
+
+  /** {@link getFolderSize} and its three siblings share one read. */
+  private async counts(id: string): Promise<FolderCounts> {
+    return this.unwrap(await getFolderCounts(this.filesCtx(), id))
   }
 
   /**
-   * Find folders by path pattern
-   * Searches for folders whose path contains the specified pattern
-   * @param pattern - The path pattern to search for
-   * @returns Array of matching folders ordered by path
+   * Build the `FilesCtx` the extracted functions take.
+   *
+   * `requireOrganization()` throws when the service was constructed without one,
+   * which is the legacy behaviour on every write path — and on the read paths it
+   * *replaces* `buildBaseWhereClause`'s silent "no organization means no
+   * filter", which returned rows from every tenant.
    */
-  async findByPathPattern(pattern: string): Promise<Folder[]> {
-    return this.db.query.Folder.findMany({
-      where: (folders, { and, ilike }) =>
-        and(this.buildBaseWhereClause(), ilike(folders.path, `%${pattern}%`)),
-      orderBy: (folders, { asc }) => [asc(folders.path)],
-    })
-  }
-
-  /**
-   * Get folders created by a specific user
-   * @param userId - The user ID to filter by
-   * @returns Array of folders created by the user, ordered by creation date (newest first)
-   */
-  async getByCreator(userId: string): Promise<Folder[]> {
-    const conditions = [eq(schema.Folder.createdById, userId)]
-    return this.db.query.Folder.findMany({
-      where: this.buildBaseWhereClause(conditions),
-      orderBy: (folders, { desc }) => [desc(folders.createdAt)],
-    })
-  }
-
-  /**
-   * Get recently created folders
-   * @param limit - Maximum number of folders to return (default: 20)
-   * @returns Array of recently created folders ordered by creation date (newest first)
-   */
-  async getRecent(limit = 20): Promise<Folder[]> {
-    return this.db.query.Folder.findMany({
-      where: this.buildBaseWhereClause(),
-      orderBy: (folders, { desc }) => [desc(folders.createdAt)],
-      limit: limit,
-    })
-  }
-
-  // ============= Statistics & Analytics =============
-
-  /**
-   * Get detailed folder statistics for organization
-   * Provides comprehensive analytics about folder usage and structure
-   * @returns Object containing folder statistics including counts, depth, and averages
-   */
-  async getFolderStats(): Promise<{
-    totalFolders: number
-    maxDepth: number
-    averageFilesPerFolder: number
-    emptyFolders: number
-  }> {
-    const where = this.buildBaseWhereClause()
-
-    const [totalFoldersResult, maxDepthResult, fileCountResult, emptyFoldersResult] =
-      await Promise.all([
-        this.db.select({ count: count() }).from(schema.Folder).where(where),
-        this.db
-          .select({ maxDepth: max(schema.Folder.depth) })
-          .from(schema.Folder)
-          .where(where),
-        this.db
-          .select({
-            folderId: schema.FolderFile.folderId,
-            count: count(schema.FolderFile.id),
-          })
-          .from(schema.FolderFile)
-          .where(
-            and(
-              eq(schema.FolderFile.organizationId, this.organizationId!),
-              isNull(schema.FolderFile.deletedAt)
-            )
-          )
-          .groupBy(schema.FolderFile.folderId),
-        // For empty folders, we need to use a subquery approach
-        this.db
-          .select({ count: count() })
-          .from(schema.Folder)
-          .where(
-            and(
-              where,
-              sql`NOT EXISTS (
-            SELECT 1 FROM ${schema.FolderFile}
-            WHERE ${schema.FolderFile.folderId} = ${schema.Folder.id}
-            AND ${schema.FolderFile.deletedAt} IS NULL
-          )`,
-              sql`NOT EXISTS (
-            SELECT 1 FROM ${schema.Folder} children
-            WHERE children.parent_id = ${schema.Folder.id}
-            AND children.deleted_at IS NULL
-          )`
-            )
-          ),
-      ])
-
-    const totalFolders = totalFoldersResult[0]?.count ?? 0
-
-    const averageFilesPerFolder =
-      fileCountResult.length > 0
-        ? fileCountResult.reduce((sum, group) => sum + (group.count || 0), 0) /
-          fileCountResult.length
-        : 0
-
+  private filesCtx(dbClient?: DatabaseClient): FilesCtx {
     return {
-      totalFolders,
-      maxDepth: maxDepthResult[0]?.maxDepth || 0,
-      averageFilesPerFolder,
-      emptyFolders: emptyFoldersResult[0]?.count ?? 0,
+      db: (dbClient ?? this.db) as FilesCtx['db'],
+      organizationId: this.requireOrganization(),
     }
   }
 
+  /** `Folder.updatedAt` has no default, so every write supplies a clock. */
+  private writeDeps(): FolderWriteDeps {
+    return { now: () => new Date() }
+  }
+
   /**
-   * Get folder usage analytics
-   * Provides detailed usage information for a specific folder
-   * @param id - The folder ID to analyze
-   * @returns Usage analytics including file count, size, activity, and most active subfolder
-   * @throws Error if folder not found
+   * {@link writeDeps} plus the file-version copier.
+   *
+   * `folders/` declares {@link FileVersionCopyPort} rather than importing
+   * `folder-files/`, so the two modules stay independent; this is the one place
+   * the port is bound to PR 5c's implementation. The legacy body did
+   * `new FileService(this.organizationId, this.userId, this.db)` **inside the
+   * per-file loop**, constructing a service per copied file.
    */
-  async getUsage(id: string): Promise<{
-    fileCount: number
-    totalSize: number
-    lastActivity: Date | null
-    mostActiveSubfolder: { id: string; name: string } | null
-  }> {
-    const folder = await this.get(id)
-    if (!folder) {
-      throw new Error('Folder not found')
-    }
-
-    const [fileCount, totalSize, lastActivityResult] = await Promise.all([
-      this.getDeepFileCount(id),
-      this.getFolderSize(id),
-      this.db.query.FolderFile.findFirst({
-        where: (files, { eq, and, isNull, ilike }) =>
-          and(
-            eq(files.organizationId, this.organizationId!),
-            ilike(files.path, `${folder.path || '/'}%`),
-            isNull(files.deletedAt)
-          ),
-        orderBy: (files, { desc }) => [desc(files.updatedAt)],
-        columns: { updatedAt: true },
-      }),
-    ])
-
-    // Find most active subfolder (most recently updated files)
-    const mostActiveResult = await this.db.query.Folder.findFirst({
-      where: (folders, { eq, and, isNull }) =>
-        and(eq(folders.parentId, id), isNull(folders.deletedAt)),
-      with: {
-        files: {
-          where: (files, { isNull }) => isNull(files.deletedAt),
-          orderBy: (files, { desc }) => [desc(files.updatedAt)],
-          limit: 1,
-          columns: { updatedAt: true },
-        },
+  private copyDeps(tx: Transaction): FolderCopyDeps {
+    const ctx = this.filesCtx(tx)
+    const files: FileVersionCopyPort = {
+      copyFileVersions: async (sourceFileId: string, targetFileId: string) => {
+        this.unwrap(await copyFileVersions(tx, ctx, sourceFileId, targetFileId))
       },
-      orderBy: (folders, { desc }) => [desc(folders.name)], // Simplified ordering since file count ordering is complex in Drizzle
-    })
-
-    return {
-      fileCount,
-      totalSize,
-      lastActivity: lastActivityResult?.updatedAt || null,
-      mostActiveSubfolder: mostActiveResult
-        ? { id: mostActiveResult.id, name: mostActiveResult.name }
-        : null,
     }
-  }
-
-  // ============= Maintenance Operations =============
-
-  /**
-   * Rebuild folder paths after hierarchy changes
-   * Maintenance operation to fix inconsistent folder paths and depths
-   * @returns Number of folders that were updated
-   */
-  async rebuildPaths(): Promise<number> {
-    const folders = await this.db.query.Folder.findMany({
-      where: this.buildBaseWhereClause(),
-      orderBy: (folders, { asc }) => [asc(folders.depth)],
-    })
-
-    let updatedCount = 0
-
-    for (const folder of folders) {
-      const correctPath = await this.computeNewFolderPath(folder.parentId, folder.name)
-      const correctDepth = folder.parentId ? (await this.getParentDepth(folder.parentId)) + 1 : 0
-
-      if (folder.path !== correctPath || folder.depth !== correctDepth) {
-        await this.db
-          .update(schema.Folder)
-          .set({
-            path: correctPath,
-            depth: correctDepth,
-            updatedAt: new Date(),
-          })
-          .where(eq(schema.Folder.id, folder.id))
-        updatedCount++
-      }
-    }
-
-    return updatedCount
+    return { ...this.writeDeps(), files }
   }
 
   /**
-   * Clean up empty folders
-   * Maintenance operation to soft-delete folders that contain no files or subfolders
-   * @returns Number of empty folders that were deleted
+   * Unwrap a `Result` into the throw-based contract this class has always had.
+   *
+   * The thrown value is an `AuxxError` subclass rather than the bare `Error` the
+   * old bodies threw, which is the one deliberate change to this facade's
+   * error behaviour.
    */
-  async cleanupEmpty(): Promise<number> {
-    const emptyFolders = await this.db
-      .select()
-      .from(schema.Folder)
-      .where(
-        and(
-          this.buildBaseWhereClause(),
-          sql`NOT EXISTS (
-          SELECT 1 FROM ${schema.FolderFile}
-          WHERE ${schema.FolderFile.folderId} = ${schema.Folder.id}
-          AND ${schema.FolderFile.deletedAt} IS NULL
-        )`,
-          sql`NOT EXISTS (
-          SELECT 1 FROM ${schema.Folder} children
-          WHERE children.parent_id = ${schema.Folder.id}
-          AND children.deleted_at IS NULL
-        )`
-        )
-      )
-
-    if (emptyFolders.length === 0) {
-      return 0
-    }
-
-    await this.db
-      .update(schema.Folder)
-      .set({
-        deletedAt: new Date(),
-        updatedAt: new Date(),
-      })
-      .where(
-        inArray(
-          schema.Folder.id,
-          emptyFolders.map((f) => f.id)
-        )
-      )
-
-    return emptyFolders.length
+  private unwrap<T>(result: Result<T, AuxxError>): T {
+    if (result.isErr()) throw result.error
+    return result.value
   }
 
   /**
-   * Fix folder depth calculations
-   * Maintenance operation to correct folder depth values based on hierarchy
-   * @returns Number of folders that had their depth corrected
+   * Run `fn` inside a transaction, reproducing `BaseService.getTx` exactly.
+   *
+   * This is the one place the facade casts, and it is unavoidable here:
+   * `BaseService.db` and the legacy `db?` parameters are
+   * `Database | Transaction`, while the extracted writes require a real
+   * `Transaction` — which is the entire point of that parameter, since a pool in
+   * the slot silently stops a multi-statement write from being atomic. Isolating
+   * the cast keeps every new call site honest, and Phase 6 deletes it along with
+   * `getTx`.
+   *
+   * `FilesystemService` constructs this class **on an open transaction** and
+   * then calls `move` / `rename`; `getTx` detects the missing `transaction`
+   * method and runs the body on that client, which is the behaviour those two
+   * call sites depend on.
    */
-  async fixDepths(): Promise<number> {
-    const folders = await this.db.query.Folder.findMany({
-      where: this.buildBaseWhereClause(),
-      orderBy: (folders, { asc }) => [asc(folders.depth)],
-    })
-
-    let fixedCount = 0
-
-    for (const folder of folders) {
-      const correctDepth = folder.parentId ? (await this.getParentDepth(folder.parentId)) + 1 : 0
-
-      if (folder.depth !== correctDepth) {
-        await this.db
-          .update(schema.Folder)
-          .set({
-            depth: correctDepth,
-            updatedAt: new Date(),
-          })
-          .where(eq(schema.Folder.id, folder.id))
-        fixedCount++
-      }
-    }
-
-    return fixedCount
-  }
-
-  // ============= Helper Methods =============
-
-  /**
-   * Safely join path components, handling root folder edge cases
-   * Combines parent path and folder name into a valid path string
-   * @param parentPath - The parent folder path (may be null, undefined, or '/')
-   * @param name - The folder name to append
-   * @returns The combined path string with proper formatting
-   */
-  private pathJoin(parentPath: string | null | undefined, name: string): string {
-    const parts = [parentPath === '/' || !parentPath ? '' : parentPath, name]
-      .join('/')
-      .replace(/\/+/g, '/')
-    return parts.startsWith('/') ? parts : `/${parts}`
-  }
-
-  /**
-   * Generate consistent path prefix for startsWith operations
-   * Ensures path ends with '/' for proper prefix matching
-   * @param p - The path to convert to a prefix
-   * @returns The path with trailing slash for prefix operations
-   */
-  private pathPrefix(p?: string | null): string {
-    if (!p || p === '/') return '/'
-    return `${p}/`
-  }
-
-  /**
-   * Escape special regex characters for safe string replacement
-   * Prevents regex injection by escaping special characters
-   * @param s - The string to escape
-   * @returns The escaped string safe for regex use
-   */
-  private escapeRegExp(s: string): string {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  }
-
-  /**
-   * Build folder tree from flat list
-   * Converts a flat array of folders into a hierarchical tree structure
-   * @param folders - Array of folder objects with counts
-   * @returns Array of root folder tree nodes with nested children
-   */
-  private buildTree(folders: any[]): FolderTreeNode[] {
-    // Create a map of nodes (not raw folders)
-    const nodeMap = new Map<string, FolderTreeNode>()
-    const rootFolders: FolderTreeNode[] = []
-
-    // First pass: create all nodes
-    folders.forEach((folder) => {
-      const node: FolderTreeNode = {
-        id: folder.id,
-        name: folder.name,
-        path: folder.path || '/',
-        depth: folder.depth,
-        parentId: folder.parentId,
-        children: [],
-        fileCount: folder._count?.files || 0,
-        totalSize: 0, // Would need separate calculation
-      }
-      nodeMap.set(folder.id, node)
-    })
-
-    // Second pass: build parent-child relationships
-    folders.forEach((folder) => {
-      const node = nodeMap.get(folder.id)
-      if (!node) return
-
-      if (!folder.parentId) {
-        rootFolders.push(node)
-      } else {
-        const parentNode = nodeMap.get(folder.parentId)
-        if (parentNode) {
-          parentNode.children.push(node)
-        }
-      }
-    })
-
-    return rootFolders
-  }
-
-  /**
-   * Check if move would create circular reference
-   * Uses path-based checking to detect circular references efficiently
-   * @param folderId - The folder ID being moved
-   * @param newParentId - The potential new parent folder ID
-   * @returns True if move would create circular reference, false otherwise
-   */
-  private async wouldCreateCircularReference(
-    folderId: string,
-    newParentId: string
-  ): Promise<boolean> {
-    // Early check: folder cannot be its own parent
-    if (folderId === newParentId) {
-      return true
-    }
-
-    // Get folder and potential new parent
-    const [folder, newParent] = await Promise.all([this.get(folderId), this.get(newParentId)])
-
-    if (!folder || !newParent) {
-      return false
-    }
-
-    // Use path-based check: new parent cannot be a descendant of the folder
-    // If new parent's path starts with folder's path, it's a descendant
-    return newParent.path?.startsWith(this.pathPrefix(folder.path)) || false
-  }
-
-  /**
-   * Compute new folder path
-   * Calculates the full path for a folder based on its parent and name
-   * @param parentId - The parent folder ID (may be null for root level)
-   * @param name - The folder name
-   * @returns The computed full path string
-   * @throws Error if parent folder not found
-   */
-  private async computeNewFolderPath(parentId: Nullish<string>, name: string): Promise<string> {
-    if (!parentId) return this.pathJoin('/', name)
-    const parent = await this.get(parentId)
-    if (!parent) throw new Error('Parent folder not found')
-    return this.pathJoin(parent.path, name)
-  }
-
-  /**
-   * Get parent folder depth
-   * Retrieves the depth value of a parent folder
-   * @param parentId - The parent folder ID
-   * @returns The parent folder's depth, or 0 if not found
-   */
-  private async getParentDepth(parentId: string): Promise<number> {
-    const parent = await this.get(parentId)
-    return parent?.depth || 0
-  }
-
-  /**
-   * Find folder by name and parent
-   * Searches for a folder with the given name under the specified parent
-   * @param name - The folder name to search for
-   * @param parentId - The parent folder ID (may be null for root level)
-   * @returns The matching folder or null if not found
-   */
-  private async findByNameAndParent(
-    name: string,
-    parentId: Nullish<string>
-  ): Promise<Folder | null> {
-    const conditions = [
-      eq(schema.Folder.name, name),
-      parentId ? eq(schema.Folder.parentId, parentId) : isNull(schema.Folder.parentId),
-    ]
-    const match = await this.db.query.Folder.findFirst({
-      where: this.buildBaseWhereClause(conditions),
-    })
-    return match ?? null
-  }
-
-  /**
-   * Update descendant paths recursively
-   * Updates all descendant folder and file paths when a folder is moved or renamed
-   * @param folderId - The folder ID whose descendants need updating
-   * @param newBasePath - The new base path for the folder
-   * @param tx - Database transaction instance
-   * @param oldBasePath - Optional old base path for more efficient querying
-   */
-  private async updateDescendantPaths(
-    folderId: string,
-    newBasePath: string,
-    tx: DatabaseClient,
-    oldBasePath?: string
-  ): Promise<void> {
-    // Get the old path to properly find descendants
-    const folderToUpdate = oldBasePath
-      ? { path: oldBasePath }
-      : await tx.query.Folder.findFirst({
-          where: (folders, { eq }) => eq(folders.id, folderId),
-          columns: { path: true },
-        })
-
-    if (!folderToUpdate?.path) return
-
-    const oldPath = folderToUpdate.path
-
-    // Find descendants using the OLD path
-    const descendants = await tx.query.Folder.findMany({
-      where: (folders, { eq, and, isNull, ilike }) =>
-        and(
-          eq(folders.organizationId, this.organizationId!),
-          ilike(folders.path, `${this.pathPrefix(oldPath)}%`),
-          isNull(folders.deletedAt)
-        ),
-    })
-
-    // Update each descendant's path
-    for (const descendant of descendants) {
-      if (!descendant.path) continue
-
-      // Replace old path prefix with new path prefix using proper regex escaping
-      const escapedOldPath = this.escapeRegExp(oldPath)
-      const newPath = descendant.path.replace(new RegExp(`^${escapedOldPath}`), newBasePath)
-
-      if (newPath !== descendant.path) {
-        await tx
-          .update(schema.Folder)
-          .set({
-            path: newPath,
-            updatedAt: new Date(),
-          })
-          .where(eq(schema.Folder.id, descendant.id))
-
-        // Update files in this descendant folder
-        const files = await tx.query.FolderFile.findMany({
-          where: (files, { eq, and, isNull }) =>
-            and(eq(files.folderId, descendant.id), isNull(files.deletedAt)),
-          columns: { id: true, path: true },
-        })
-
-        for (const f of files) {
-          if (!f.path) continue
-          const escapedOldPath = this.escapeRegExp(oldPath)
-          const updatedFilePath = f.path.replace(new RegExp(`^${escapedOldPath}`), newBasePath)
-          if (updatedFilePath !== f.path) {
-            await tx
-              .update(schema.FolderFile)
-              .set({ path: updatedFilePath, updatedAt: new Date() })
-              .where(eq(schema.FolderFile.id, f.id))
-          }
-        }
-      }
-    }
-  }
-
-  /**
-   * Copy folder contents recursively
-   * Copies all files and subfolders from source to target folder
-   * @param sourceFolder - The source folder object with relations
-   * @param targetFolderId - The target folder ID to copy into
-   * @param tx - Database transaction instance
-   */
-  private async copyFolderContents(
-    sourceFolder: FolderWithRelations,
-    targetFolderId: string,
-    tx: DatabaseClient
-  ): Promise<void> {
-    // Get target folder for path calculations
-    const targetFolder = await tx.query.Folder.findFirst({
-      where: (folders, { eq }) => eq(folders.id, targetFolderId),
-      columns: { path: true, depth: true },
-    })
-
-    if (!targetFolder) return
-
-    // Copy all files from source folder
-    const sourceFiles = await tx.query.FolderFile.findMany({
-      where: (files, { eq, and, isNull }) =>
-        and(eq(files.folderId, sourceFolder.id), isNull(files.deletedAt)),
-    })
-
-    for (const file of sourceFiles) {
-      const newPath = this.pathJoin(targetFolder.path, file.name)
-      const newFile = this.requireRow(
-        await tx
-          .insert(schema.FolderFile)
-          .values({
-            name: file.name,
-            path: newPath,
-            ext: file.ext,
-            mimeType: file.mimeType,
-            size: file.size,
-            organizationId: file.organizationId,
-            folderId: targetFolderId,
-            createdById: file.createdById,
-            createdAt: new Date(),
-            updatedAt: new Date(),
-          })
-          .returning(),
-        'copy file'
-      )
-
-      // Copy all versions using FileService
-      const fileService = new FileService(this.organizationId, this.userId, this.db)
-      await fileService.copyVersions(file.id, newFile.id)
-    }
-
-    // Copy all subfolders recursively
-    const subfolders = await tx.query.Folder.findMany({
-      where: (folders, { eq, and, isNull }) =>
-        and(eq(folders.parentId, sourceFolder.id), isNull(folders.deletedAt)),
-      with: {
-        files: {
-          where: (files, { isNull }) => isNull(files.deletedAt),
-        },
-      },
-    })
-
-    for (const subfolder of subfolders) {
-      const newPath = this.pathJoin(targetFolder.path, subfolder.name)
-      const newDepth = targetFolder.depth + 1
-
-      const newSubfolder = this.requireRow(
-        await tx
-          .insert(schema.Folder)
-          .values({
-            name: subfolder.name,
-            parentId: targetFolderId,
-            path: newPath,
-            depth: newDepth,
-            organizationId: subfolder.organizationId,
-            createdById: subfolder.createdById,
-            createdAt: new Date(),
-            updatedAt: new Date(),
-          })
-          .returning(),
-        'copy subfolder'
-      )
-
-      // Recursively copy contents of this subfolder
-      await this.copyFolderContents(subfolder, newSubfolder.id, tx)
-    }
-  }
-
-  /**
-   * Generate search snippet for search results
-   * Creates a descriptive snippet showing what matched in the search
-   * @param folder - The folder object
-   * @param query - The search query that was matched
-   * @returns A formatted snippet string describing the match
-   */
-  private generateSearchSnippet(folder: Folder, query: string): string {
-    const parts: string[] = []
-
-    if (folder.name.toLowerCase().includes(query.toLowerCase())) {
-      parts.push(`Name: ${folder.name}`)
-    }
-
-    if (folder.path?.toLowerCase().includes(query.toLowerCase())) {
-      parts.push(`Path: ${folder.path}`)
-    }
-
-    return parts.join(' | ') || folder.name
+  private async inTransaction<T>(
+    client: DatabaseClient | undefined,
+    fn: (tx: Transaction) => Promise<T>
+  ): Promise<T> {
+    if (client) return fn(client as Transaction)
+    return this.getTx((tx) => fn(tx as Transaction))
   }
 }
 
 /**
- * Factory function for creating folder service instances
- * @param organizationId - Optional organization ID to scope operations to
- * @param userId - Optional user ID for created/updated records
- * @returns New FolderService instance
+ * @deprecated Construct a `FilesCtx` and call `files/folders/` directly.
+ *
+ * @param organizationId - Organization to scope operations to
+ * @param userId - Actor recorded on created rows
  */
 export const createFolderService = (organizationId?: string, userId?: string) =>
-  new FolderService(organizationId, userId)
-
-/**
- * Singleton folder service instance with default database connection
- * Use this for operations that don't require specific organization/user scoping
- */
-// export const folderService = new FolderService()
+  new FolderService(organizationId, userId, db)

--- a/packages/lib/src/files/folders/__tests__/folder-mutations.test.ts
+++ b/packages/lib/src/files/folders/__tests__/folder-mutations.test.ts
@@ -1,0 +1,578 @@
+// packages/lib/src/files/folders/__tests__/folder-mutations.test.ts
+
+/**
+ * `folders/folder-mutations.ts` — the write half of what `FolderService` was.
+ *
+ * **`vi.mock` is called zero times in this file.** `tx` and `ctx.db` are
+ * parameters and the version copier arrives as a `FileVersionCopyPort`, so there
+ * is nothing left to intercept at module scope — where the legacy `copy` did
+ * `new FileService(this.organizationId, this.userId, this.db)` inside its loop.
+ *
+ * The assertions that matter are the three fixes the module header names:
+ *
+ * 1. **every `UPDATE` and `DELETE` carries the organization filter** — asserted
+ *    off the predicate the stub recorded, not off the return value;
+ * 2. **the cascade selects by `folderId`, never by a path prefix** — asserted by
+ *    showing a same-prefix sibling (`/Documents` next to `/Doc`) is *not* in the
+ *    id set;
+ * 3. **a move into a folder's own subtree is refused** with a `ConflictError`
+ *    rather than silently creating the cycle the legacy path check missed.
+ */
+
+import type { Transaction } from '@auxx/database'
+import { schema } from '@auxx/database'
+import type { FolderEntity, FolderFileEntity } from '@auxx/database/types'
+import { describe, expect, it, vi } from 'vitest'
+import { BadRequestError, ConflictError, NotFoundError } from '../../../errors'
+import { makeClock, makeCtx, makeDb, TEST_IDS } from '../../__tests__/support'
+import {
+  copyFolder,
+  createFolder,
+  deleteFolder,
+  ensureFolderPath,
+  mergeFolders,
+  moveFolder,
+  permanentlyDeleteFolder,
+  renameFolder,
+  restoreFolder,
+  updateFolder,
+} from '../folder-mutations'
+import type { FileVersionCopyPort } from '../ports'
+
+const TABLES = { Folder: schema.Folder, FolderFile: schema.FolderFile }
+const AT = new Date('2026-01-01T00:00:00.000Z')
+const clock = () => ({ now: makeClock(AT.toISOString()).now })
+
+function aFolder(overrides: Partial<FolderEntity> = {}): FolderEntity {
+  return {
+    id: 'fld_1',
+    organizationId: TEST_IDS.organizationId,
+    name: 'Docs',
+    parentId: null,
+    path: '/Docs',
+    depth: 0,
+    createdById: TEST_IDS.userId,
+    createdAt: AT,
+    updatedAt: AT,
+    deletedAt: null,
+    isArchived: false,
+    ...overrides,
+  }
+}
+
+function aFile(overrides: Partial<FolderFileEntity> = {}): FolderFileEntity {
+  return {
+    id: 'file_1',
+    organizationId: TEST_IDS.organizationId,
+    folderId: 'fld_1',
+    name: 'report.pdf',
+    path: '/Docs/report.pdf',
+    ext: 'pdf',
+    mimeType: 'application/pdf',
+    size: 100,
+    checksum: null,
+    currentVersionId: null,
+    isArchived: false,
+    deletedAt: null,
+    createdById: TEST_IDS.userId,
+    createdAt: AT,
+    updatedAt: AT,
+    provider: null,
+    ...overrides,
+  }
+}
+
+function aNode(id: string, parentId: string | null, name = id, path = `/${name}`, depth = 0) {
+  return { id, parentId, name, path, depth }
+}
+
+function asTx(db: ReturnType<typeof makeDb>): Transaction {
+  return db.db as unknown as Transaction
+}
+
+/** Every `where` predicate the stub recorded, stringified and concatenated. */
+function allWheres(db: ReturnType<typeof makeDb>): string {
+  return JSON.stringify(db.wheres.map((w) => w.predicate))
+}
+
+describe('createFolder', () => {
+  it('refuses an illegal name before touching the database', async () => {
+    const db = makeDb({ tables: TABLES })
+
+    const result = await createFolder(makeCtx({ db: db.db }), { name: 'a/b' }, clock())
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+    expect(db.journal.ops('db')).toEqual([])
+  })
+
+  it('writes the caller organization, never one from the payload', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+
+    const result = await createFolder(
+      makeCtx({ db: db.db, organizationId: 'org_actor' }),
+      { name: 'Docs', createdById: TEST_IDS.userId },
+      clock()
+    )
+
+    expect(result.isOk()).toBe(true)
+    expect(db.inserts[0]?.values).toMatchObject({
+      organizationId: 'org_actor',
+      name: 'Docs',
+      parentId: null,
+      path: '/Docs',
+      depth: 0,
+      createdAt: AT,
+      updatedAt: AT,
+    })
+  })
+
+  it('derives path and depth from the parent row', async () => {
+    const db = makeDb({
+      select: [[aFolder({ id: 'parent', path: '/Docs', depth: 2 })], []],
+      tables: TABLES,
+    })
+
+    await createFolder(makeCtx({ db: db.db }), { name: 'Invoices', parentId: 'parent' }, clock())
+
+    expect(db.inserts[0]?.values).toMatchObject({ path: '/Docs/Invoices', depth: 3 })
+  })
+
+  it('treats the UI root sentinel as no parent', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+    await createFolder(makeCtx({ db: db.db }), { name: 'Docs', parentId: 'root' }, clock())
+    expect(db.inserts[0]?.values).toMatchObject({ parentId: null, depth: 0 })
+    // No parent lookup was issued: the only select is the name-collision check.
+    expect(db.journal.ops('db')).toEqual(['select', 'insert'])
+  })
+
+  it('fails with ConflictError, not a generic 500, when the name is taken', async () => {
+    const db = makeDb({ select: [[aFolder({ id: 'other' })]], tables: TABLES })
+    const result = await createFolder(makeCtx({ db: db.db }), { name: 'Docs' }, clock())
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(ConflictError)
+  })
+
+  it('fails with NotFoundError when the parent is invisible to the caller', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+    const result = await createFolder(
+      makeCtx({ db: db.db }),
+      { name: 'Docs', parentId: 'gone' },
+      clock()
+    )
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+  })
+})
+
+describe('updateFolder', () => {
+  it('scopes the UPDATE to the organization, not just the pre-check', async () => {
+    const db = makeDb({
+      select: [[aFolder()], [], [aNode('fld_1', null, 'Docs', '/Docs')], []],
+      update: [[aFolder({ name: 'Papers', path: '/Papers' })]],
+      tables: TABLES,
+    })
+
+    const result = await updateFolder(
+      asTx(db),
+      makeCtx({ db: db.db, organizationId: 'org_actor' }),
+      'fld_1',
+      { name: 'Papers' },
+      clock()
+    )
+
+    expect(result.isOk()).toBe(true)
+    const updateWhere = db.wheres.find((w) => w.table === 'Folder' && w.predicate)
+    expect(JSON.stringify(updateWhere?.predicate)).toContain('org_actor')
+    expect(allWheres(db)).toContain('org_actor')
+  })
+
+  it('recomputes the path from the new name', async () => {
+    const db = makeDb({
+      select: [[aFolder()], [], [aNode('fld_1', null, 'Docs', '/Docs')], []],
+      update: [[aFolder({ name: 'Papers' })]],
+      tables: TABLES,
+    })
+
+    await updateFolder(asTx(db), makeCtx({ db: db.db }), 'fld_1', { name: 'Papers' }, clock())
+
+    expect(db.updates[0]?.values).toMatchObject({
+      name: 'Papers',
+      path: '/Papers',
+      depth: 0,
+      updatedAt: AT,
+    })
+  })
+
+  it('refuses a move into the folder own subtree with ConflictError', async () => {
+    const db = makeDb({
+      select: [
+        [aFolder({ id: 'a', name: 'A', path: '/A' })],
+        [],
+        [aNode('a', null, 'A', '/A'), aNode('b', 'a', 'B', '/A/B')],
+      ],
+      tables: TABLES,
+    })
+
+    const result = await updateFolder(
+      asTx(db),
+      makeCtx({ db: db.db }),
+      'a',
+      { parentId: 'b' },
+      clock()
+    )
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(ConflictError)
+    expect(db.updates).toEqual([])
+  })
+
+  it('detects the cycle even when every stored path is stale', async () => {
+    const db = makeDb({
+      select: [
+        [aFolder({ id: 'a', name: 'A', path: '/wrong' })],
+        [],
+        [aNode('a', null, 'A', '/wrong'), aNode('b', 'a', 'B', '/also-wrong')],
+      ],
+      tables: TABLES,
+    })
+
+    const result = await updateFolder(
+      asTx(db),
+      makeCtx({ db: db.db }),
+      'a',
+      { parentId: 'b' },
+      clock()
+    )
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(ConflictError)
+  })
+
+  it('fails with NotFoundError when the target parent is invisible', async () => {
+    const db = makeDb({
+      select: [[aFolder({ id: 'a' })], [], [aNode('a', null)]],
+      tables: TABLES,
+    })
+
+    const result = await updateFolder(
+      asTx(db),
+      makeCtx({ db: db.db }),
+      'a',
+      { parentId: 'other_org_folder' },
+      clock()
+    )
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+  })
+
+  it('rewrites descendant folders and their file paths', async () => {
+    const db = makeDb({
+      select: [
+        [aFolder({ id: 'a', name: 'A', path: '/A' })],
+        [],
+        [
+          aNode('a', null, 'A', '/A'),
+          aNode('b', 'a', 'B', '/A/B', 1),
+          aNode('c', 'b', 'C', '/A/B/C', 2),
+        ],
+        [aFile({ id: 'f1', folderId: 'b', name: 'x.pdf', path: '/A/B/x.pdf' })],
+      ],
+      update: [[aFolder({ id: 'a', name: 'Z', path: '/Z' })]],
+      tables: TABLES,
+    })
+
+    await updateFolder(asTx(db), makeCtx({ db: db.db }), 'a', { name: 'Z' }, clock())
+
+    const written = db.updates.map((u) => u.values as Record<string, unknown>)
+    expect(written[0]).toMatchObject({ path: '/Z' })
+    expect(written[1]).toMatchObject({ path: '/Z/B', depth: 1 })
+    expect(written[2]).toMatchObject({ path: '/Z/B/C', depth: 2 })
+    expect(written[3]).toMatchObject({ path: '/Z/B/x.pdf' })
+  })
+
+  it('leaves the subtree alone when nothing about the position changed', async () => {
+    const db = makeDb({
+      select: [[aFolder()], [aNode('fld_1', null, 'Docs', '/Docs')]],
+      update: [[aFolder()]],
+      tables: TABLES,
+    })
+
+    await updateFolder(asTx(db), makeCtx({ db: db.db }), 'fld_1', {}, clock())
+
+    expect(db.updates).toHaveLength(1)
+  })
+})
+
+describe('renameFolder / moveFolder', () => {
+  it('rename rejects an illegal name', async () => {
+    const db = makeDb({ select: [[aFolder()]], tables: TABLES })
+    const result = await renameFolder(asTx(db), makeCtx({ db: db.db }), 'fld_1', 'a/b', clock())
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+  })
+
+  it('move normalises the UI root sentinel to null', async () => {
+    const db = makeDb({
+      select: [
+        [aFolder({ id: 'a', parentId: 'p', name: 'A', path: '/P/A', depth: 1 })],
+        [],
+        [aNode('a', 'p', 'A', '/P/A', 1)],
+        [],
+      ],
+      update: [[aFolder({ id: 'a', parentId: null })]],
+      tables: TABLES,
+    })
+
+    await moveFolder(asTx(db), makeCtx({ db: db.db }), 'a', 'root', clock())
+
+    expect(db.updates[0]?.values).toMatchObject({ parentId: null, path: '/A', depth: 0 })
+  })
+})
+
+describe('deleteFolder', () => {
+  it('is two statements and names the subtree by id, not by path prefix', async () => {
+    const db = makeDb({
+      select: [
+        [aFolder({ id: 'doc', name: 'Doc', path: '/Doc' })],
+        [
+          aNode('doc', null, 'Doc', '/Doc'),
+          aNode('sub', 'doc', 'Sub', '/Doc/Sub'),
+          // The sibling whose name shares a prefix. `/Documents/report.pdf`
+          // matched `ilike(path, '/Doc%')` and was deleted with it.
+          aNode('documents', null, 'Documents', '/Documents'),
+        ],
+      ],
+      tables: TABLES,
+    })
+
+    const result = await deleteFolder(asTx(db), makeCtx({ db: db.db }), 'doc', clock())
+
+    expect(result.isOk()).toBe(true)
+    expect(db.journal.ops('db')).toEqual(['select', 'select', 'update', 'update'])
+    const wheres = allWheres(db)
+    expect(wheres).toContain('doc')
+    expect(wheres).toContain('sub')
+    expect(wheres).not.toContain('documents')
+    expect(wheres).not.toContain('/Doc%')
+  })
+
+  it('stamps both tables with the same instant', async () => {
+    const db = makeDb({
+      select: [[aFolder()], [aNode('fld_1', null)]],
+      tables: TABLES,
+    })
+
+    await deleteFolder(asTx(db), makeCtx({ db: db.db }), 'fld_1', clock())
+
+    expect(db.updates[0]?.values).toMatchObject({ deletedAt: AT, updatedAt: AT })
+    expect(db.updates[1]?.values).toMatchObject({ deletedAt: AT, updatedAt: AT })
+  })
+
+  it('fails with NotFoundError for a folder outside the organization', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+    const result = await deleteFolder(asTx(db), makeCtx({ db: db.db }), 'fld_1', clock())
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+    expect(db.updates).toEqual([])
+  })
+})
+
+describe('restoreFolder', () => {
+  it('returns the folder untouched when it was never deleted', async () => {
+    const db = makeDb({ select: [[aFolder({ deletedAt: null })]], tables: TABLES })
+
+    const result = await restoreFolder(asTx(db), makeCtx({ db: db.db }), 'fld_1', clock())
+
+    expect(result._unsafeUnwrap().id).toBe('fld_1')
+    expect(db.updates).toEqual([])
+  })
+
+  it('reads the hierarchy including deleted rows, or it would restore nothing', async () => {
+    const db = makeDb({
+      select: [[aFolder({ deletedAt: AT })], [aNode('fld_1', null), aNode('child', 'fld_1')]],
+      update: [[aFolder({ id: 'fld_1', deletedAt: null }), aFolder({ id: 'child' })]],
+      tables: TABLES,
+    })
+
+    const result = await restoreFolder(asTx(db), makeCtx({ db: db.db }), 'fld_1', clock())
+
+    expect(result._unsafeUnwrap().id).toBe('fld_1')
+    // Neither read asks for `deletedAt IS NULL`; both statements carry the org.
+    expect(allWheres(db)).toContain(TEST_IDS.organizationId)
+    expect(db.updates[0]?.values).toMatchObject({ deletedAt: null })
+    expect(db.updates[1]?.values).toMatchObject({ deletedAt: null })
+  })
+})
+
+describe('permanentlyDeleteFolder', () => {
+  it('scopes both hard DELETEs to the organization', async () => {
+    const db = makeDb({
+      select: [[aFolder({ deletedAt: AT })], [aNode('fld_1', null), aNode('child', 'fld_1')]],
+      tables: TABLES,
+    })
+
+    const result = await permanentlyDeleteFolder(
+      asTx(db),
+      makeCtx({ db: db.db, organizationId: 'org_actor' }),
+      'fld_1'
+    )
+
+    expect(result.isOk()).toBe(true)
+    expect(db.deletes.map((d) => d.table)).toEqual(['FolderFile', 'Folder'])
+    const deleteWheres = db.wheres.filter((w) => w.table === 'FolderFile' || w.table === 'Folder')
+    for (const where of deleteWheres) {
+      expect(JSON.stringify(where.predicate)).toContain('org_actor')
+    }
+  })
+})
+
+describe('mergeFolders', () => {
+  it('refuses to merge a folder with itself', async () => {
+    const db = makeDb({ tables: TABLES })
+    const result = await mergeFolders(asTx(db), makeCtx({ db: db.db }), 'a', 'a', clock())
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+    expect(db.journal.ops('db')).toEqual([])
+  })
+
+  it('refuses to merge into its own subtree — the legacy created the cycle', async () => {
+    const db = makeDb({
+      select: [
+        [aFolder({ id: 'a', name: 'A', path: '/A' })],
+        [aFolder({ id: 'b', name: 'B', path: '/A/B', parentId: 'a' })],
+        [aNode('a', null, 'A', '/A'), aNode('b', 'a', 'B', '/A/B', 1)],
+      ],
+      tables: TABLES,
+    })
+
+    const result = await mergeFolders(asTx(db), makeCtx({ db: db.db }), 'a', 'b', clock())
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(ConflictError)
+    expect(db.updates).toEqual([])
+  })
+
+  it('re-parents files and subfolders, then soft-deletes the source', async () => {
+    const db = makeDb({
+      select: [
+        [aFolder({ id: 'src', name: 'Src', path: '/Src' })],
+        [aFolder({ id: 'dst', name: 'Dst', path: '/Dst' })],
+        [
+          aNode('src', null, 'Src', '/Src'),
+          aNode('dst', null, 'Dst', '/Dst'),
+          aNode('child', 'src', 'Child', '/Src/Child', 1),
+        ],
+        [aFile({ id: 'f1', folderId: 'src', name: 'x.pdf', path: '/Src/x.pdf' })],
+        [],
+      ],
+      tables: TABLES,
+    })
+
+    const result = await mergeFolders(asTx(db), makeCtx({ db: db.db }), 'src', 'dst', clock())
+
+    expect(result.isOk()).toBe(true)
+    const written = db.updates.map((u) => u.values as Record<string, unknown>)
+    expect(written[0]).toMatchObject({ folderId: 'dst', path: '/Dst/x.pdf' })
+    expect(written[1]).toMatchObject({ parentId: 'dst', path: '/Dst/Child', depth: 1 })
+    expect(written.at(-1)).toMatchObject({ deletedAt: AT })
+  })
+})
+
+describe('copyFolder', () => {
+  function copyDeps(port: FileVersionCopyPort) {
+    return { now: makeClock(AT.toISOString()).now, files: port }
+  }
+
+  it('copies files through the port instead of constructing a FileService', async () => {
+    const copyFileVersions = vi.fn(async () => {})
+    const db = makeDb({
+      select: [
+        [aFolder({ id: 'src', name: 'Src', path: '/Src' })], // requireFolder(source)
+        [], // assertNameAvailable
+        [aNode('src', null, 'Src', '/Src')], // loadFolderNodes
+        [], // insertFolder -> assertNameAvailable (no parent)
+        [aFile({ id: 'f1', folderId: 'src', name: 'x.pdf', path: '/Src/x.pdf' })], // files
+      ],
+      insert: [
+        [aFolder({ id: 'copy', name: 'Copy of Src', path: '/Copy of Src' })],
+        [aFile({ id: 'f2', folderId: 'copy', name: 'x.pdf', path: '/Copy of Src/x.pdf' })],
+      ],
+      tables: TABLES,
+    })
+
+    const result = await copyFolder(
+      asTx(db),
+      makeCtx({ db: db.db }),
+      { sourceId: 'src', targetParentId: null },
+      copyDeps({ copyFileVersions })
+    )
+
+    expect(result._unsafeUnwrap().id).toBe('copy')
+    expect(copyFileVersions).toHaveBeenCalledExactlyOnceWith('f1', 'f2')
+    expect(db.inserts[1]?.values).toMatchObject({
+      folderId: 'copy',
+      path: '/Copy of Src/x.pdf',
+    })
+  })
+
+  it('defaults the copy name to "Copy of <source>"', async () => {
+    const db = makeDb({
+      select: [[aFolder({ id: 'src', name: 'Src' })], [], [aNode('src', null)], [], []],
+      insert: [[aFolder({ id: 'copy' })]],
+      tables: TABLES,
+    })
+
+    await copyFolder(
+      asTx(db),
+      makeCtx({ db: db.db }),
+      { sourceId: 'src', targetParentId: null },
+      copyDeps({ copyFileVersions: async () => {} })
+    )
+
+    expect(db.inserts[0]?.values).toMatchObject({ name: 'Copy of Src' })
+  })
+
+  it('refuses to copy a folder into its own subtree', async () => {
+    const db = makeDb({
+      select: [
+        [aFolder({ id: 'src', name: 'Src', path: '/Src' })],
+        [aFolder({ id: 'child', name: 'Child', path: '/Src/Child', parentId: 'src' })],
+        [],
+        [aNode('src', null, 'Src', '/Src'), aNode('child', 'src', 'Child', '/Src/Child', 1)],
+      ],
+      tables: TABLES,
+    })
+
+    const result = await copyFolder(
+      asTx(db),
+      makeCtx({ db: db.db }),
+      { sourceId: 'src', targetParentId: 'child' },
+      copyDeps({ copyFileVersions: async () => {} })
+    )
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(ConflictError)
+    expect(db.inserts).toEqual([])
+  })
+})
+
+describe('ensureFolderPath', () => {
+  it('rejects a path that names no folder', async () => {
+    const db = makeDb({ tables: TABLES })
+    const result = await ensureFolderPath(makeCtx({ db: db.db }), '///', clock())
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(BadRequestError)
+    expect(db.journal.ops('db')).toEqual([])
+  })
+
+  it('reuses an existing segment and creates only the missing one', async () => {
+    const db = makeDb({
+      select: [
+        [aFolder({ id: 'a', name: 'a', path: '/a' })], // 'a' exists
+        [], // 'b' does not
+        [aFolder({ id: 'a', name: 'a', path: '/a' })], // insertFolder -> parent lookup
+        [], // insertFolder -> name check
+      ],
+      insert: [[aFolder({ id: 'b', name: 'b', parentId: 'a', path: '/a/b', depth: 1 })]],
+      tables: TABLES,
+    })
+
+    const result = await ensureFolderPath(makeCtx({ db: db.db }), 'a/b', clock(), {
+      createdById: TEST_IDS.userId,
+    })
+
+    expect(result._unsafeUnwrap().id).toBe('b')
+    expect(db.inserts).toHaveLength(1)
+    expect(db.inserts[0]?.values).toMatchObject({ name: 'b', parentId: 'a', path: '/a/b' })
+  })
+})

--- a/packages/lib/src/files/folders/__tests__/folder-queries.test.ts
+++ b/packages/lib/src/files/folders/__tests__/folder-queries.test.ts
@@ -1,0 +1,439 @@
+// packages/lib/src/files/folders/__tests__/folder-queries.test.ts
+
+/**
+ * `folders/folder-queries.ts` — the read half of what `FolderService` was.
+ *
+ * **`vi.mock` is called zero times in this file**: `ctx.db` is a parameter, so
+ * there is nothing left to intercept at module scope.
+ *
+ * Three properties matter beyond "it returns rows":
+ *
+ * 1. **Organization scope is in every statement.** The db stub does not
+ *    interpret SQL, but it stores the predicate the code built and the bound
+ *    values survive `JSON.stringify`, which is enough to prove the filter is
+ *    present. It is *not* enough to prove which column each condition names —
+ *    this package's `@auxx/database` mock hands out `{}` for every table — and
+ *    that distinction belongs to the integration lane.
+ * 2. **Statement counts.** `getFolderTree` and `getFolderCounts` exist to
+ *    replace loops that issued a query per folder, so the count is asserted off
+ *    the journal rather than inferred from the return value.
+ * 3. **Subtree membership comes from `folderId`, not from a path prefix.** That
+ *    is the delete-cascade fix; here it shows up as the ids the aggregate query
+ *    was handed.
+ */
+
+import { schema } from '@auxx/database'
+import type { FolderEntity, FolderFileEntity } from '@auxx/database/types'
+import { describe, expect, it } from 'vitest'
+import { NotFoundError } from '../../../errors'
+import { makeCtx, makeDb, TEST_IDS } from '../../__tests__/support'
+import {
+  getFolder,
+  getFolderAncestors,
+  getFolderCounts,
+  getFolderDescendants,
+  getFolderTree,
+  getFolderUsage,
+  getFolderWithRelations,
+  getSubfolders,
+  isFolderNameAvailable,
+  listFolders,
+  loadFileAggregates,
+  searchFolders,
+} from '../folder-queries'
+
+const TABLES = {
+  Folder: schema.Folder,
+  FolderFile: schema.FolderFile,
+  User: schema.User,
+}
+
+const AT = new Date('2026-01-01T00:00:00.000Z')
+
+function aFolder(overrides: Partial<FolderEntity> = {}): FolderEntity {
+  return {
+    id: 'fld_1',
+    organizationId: TEST_IDS.organizationId,
+    name: 'Docs',
+    parentId: null,
+    path: '/Docs',
+    depth: 0,
+    createdById: TEST_IDS.userId,
+    createdAt: AT,
+    updatedAt: AT,
+    deletedAt: null,
+    isArchived: false,
+    ...overrides,
+  }
+}
+
+function aFile(overrides: Partial<FolderFileEntity> = {}): FolderFileEntity {
+  return {
+    id: 'file_1',
+    organizationId: TEST_IDS.organizationId,
+    folderId: 'fld_1',
+    name: 'report.pdf',
+    path: '/Docs/report.pdf',
+    ext: 'pdf',
+    mimeType: 'application/pdf',
+    size: 100,
+    checksum: null,
+    currentVersionId: null,
+    isArchived: false,
+    deletedAt: null,
+    createdById: TEST_IDS.userId,
+    createdAt: AT,
+    updatedAt: AT,
+    provider: null,
+    ...overrides,
+  }
+}
+
+/** The node projection `loadFolderNodes` selects, as the stub must hand it back. */
+function aNode(id: string, parentId: string | null, name = id) {
+  return { id, parentId, name, path: `/${name}`, depth: 0 }
+}
+
+/** The `where` predicate handed to the n-th builder chain, stringified. */
+function whereOf(db: ReturnType<typeof makeDb>, index: number): string {
+  return JSON.stringify(db.wheres[index]?.predicate)
+}
+
+describe('getFolder', () => {
+  it('returns the row and scopes the read to the caller organization', async () => {
+    const db = makeDb({ select: [[aFolder()]], tables: TABLES })
+
+    const result = await getFolder(makeCtx({ db: db.db, organizationId: 'org_other' }), 'fld_1')
+
+    expect(result._unsafeUnwrap()).toEqual(aFolder())
+    expect(whereOf(db, 0)).toContain('org_other')
+    expect(whereOf(db, 0)).toContain('fld_1')
+  })
+
+  it('returns ok(null) rather than an error when nothing matches', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+    const result = await getFolder(makeCtx({ db: db.db }), 'fld_missing')
+    expect(result._unsafeUnwrap()).toBeNull()
+  })
+})
+
+describe('getFolderWithRelations', () => {
+  it('short-circuits without loading relations when the folder is invisible', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+
+    const result = await getFolderWithRelations(makeCtx({ db: db.db }), 'fld_missing')
+
+    expect(result._unsafeUnwrap()).toBeNull()
+    expect(db.journal.ops('db')).toEqual(['select'])
+  })
+
+  it('assembles parent, children, files and creator', async () => {
+    const folder = aFolder({ id: 'fld_2', parentId: 'fld_1', path: '/Docs/Invoices' })
+    const db = makeDb({
+      select: [
+        [folder],
+        [aFolder()],
+        [aFolder({ id: 'fld_3', parentId: 'fld_2' })],
+        [aFile()],
+        [{ id: TEST_IDS.userId, name: 'Test User', email: 'test@example.com' }],
+      ],
+      tables: TABLES,
+    })
+
+    const detail = (await getFolderWithRelations(makeCtx({ db: db.db }), 'fld_2'))._unsafeUnwrap()
+
+    expect(detail?.id).toBe('fld_2')
+    expect(detail?.parent?.id).toBe('fld_1')
+    expect(detail?.children.map((c) => c.id)).toEqual(['fld_3'])
+    expect(detail?.files.map((f) => f.id)).toEqual(['file_1'])
+    expect(detail?.createdBy?.email).toBe('test@example.com')
+  })
+
+  it('scopes the children and files reads to the organization too', async () => {
+    const db = makeDb({
+      select: [[aFolder()], [], [], []],
+      tables: TABLES,
+    })
+
+    await getFolderWithRelations(makeCtx({ db: db.db, organizationId: 'org_x' }), 'fld_1')
+
+    // 0 = the folder, 1 = children, 2 = files. No parent read: `parentId` is null.
+    for (const index of [0, 1, 2]) {
+      expect(whereOf(db, index)).toContain('org_x')
+    }
+  })
+})
+
+describe('listFolders', () => {
+  it('reports the page and whether more rows follow', async () => {
+    const db = makeDb({
+      select: [[aFolder(), aFolder({ id: 'fld_2' })], [{ value: 5 }]],
+      tables: TABLES,
+    })
+
+    const page = (await listFolders(makeCtx({ db: db.db }), { limit: 2 }))._unsafeUnwrap()
+
+    expect(page.items).toHaveLength(2)
+    expect(page.total).toBe(5)
+    expect(page.hasMore).toBe(true)
+  })
+
+  it('has no more rows when the page reaches the total', async () => {
+    const db = makeDb({ select: [[aFolder()], [{ value: 1 }]], tables: TABLES })
+    const page = (await listFolders(makeCtx({ db: db.db }), {}))._unsafeUnwrap()
+    expect(page.hasMore).toBe(false)
+  })
+
+  it('applies a null parent filter as IS NULL rather than dropping it', async () => {
+    const db = makeDb({ select: [[], [{ value: 0 }]], tables: TABLES })
+    await listFolders(makeCtx({ db: db.db }), { parentId: null })
+    expect(whereOf(db, 0)).toContain('is null')
+  })
+})
+
+describe('getFolderTree', () => {
+  it('is two statements regardless of how many folders there are', async () => {
+    const nodes = Array.from({ length: 40 }, (_, i) => aNode(`n${i}`, i === 0 ? null : `n${i - 1}`))
+    const db = makeDb({ select: [nodes, []], tables: TABLES })
+
+    await getFolderTree(makeCtx({ db: db.db }))
+
+    expect(db.journal.ops('db')).toEqual(['select', 'select'])
+  })
+
+  it('folds real file counts into the nodes — the legacy always reported zero', async () => {
+    const db = makeDb({
+      select: [
+        [aNode('root', null), aNode('child', 'root')],
+        [{ folderId: 'root', fileCount: 2, totalSize: '4096' }],
+      ],
+      tables: TABLES,
+    })
+
+    const tree = (await getFolderTree(makeCtx({ db: db.db })))._unsafeUnwrap()
+
+    expect(tree[0]).toMatchObject({ id: 'root', fileCount: 2, totalSize: 4096 })
+    expect(tree[0]?.children[0]).toMatchObject({ id: 'child', fileCount: 0, totalSize: 0 })
+  })
+})
+
+describe('getSubfolders', () => {
+  it('asks for IS NULL at the root and for the id otherwise', async () => {
+    const rootDb = makeDb({ select: [[]], tables: TABLES })
+    await getSubfolders(makeCtx({ db: rootDb.db }), null)
+    expect(whereOf(rootDb, 0)).toContain('is null')
+
+    const childDb = makeDb({ select: [[]], tables: TABLES })
+    await getSubfolders(makeCtx({ db: childDb.db }), 'fld_1')
+    expect(whereOf(childDb, 0)).toContain('fld_1')
+  })
+})
+
+describe('getFolderAncestors', () => {
+  it('returns the chain root-first', async () => {
+    const db = makeDb({
+      select: [
+        [aNode('a', null), aNode('b', 'a'), aNode('c', 'b')],
+        [aFolder({ id: 'b', parentId: 'a' }), aFolder({ id: 'a' })],
+      ],
+      tables: TABLES,
+    })
+
+    const ancestors = (await getFolderAncestors(makeCtx({ db: db.db }), 'c'))._unsafeUnwrap()
+
+    expect(ancestors.map((f) => f.id)).toEqual(['a', 'b'])
+  })
+
+  it('fails with NotFoundError instead of returning [] for a folder outside the org', async () => {
+    const db = makeDb({ select: [[aNode('a', null)]], tables: TABLES })
+    const result = await getFolderAncestors(makeCtx({ db: db.db }), 'fld_other')
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+  })
+
+  it('does not query for rows when the folder is a root', async () => {
+    const db = makeDb({ select: [[aNode('a', null)]], tables: TABLES })
+    const ancestors = (await getFolderAncestors(makeCtx({ db: db.db }), 'a'))._unsafeUnwrap()
+    expect(ancestors).toEqual([])
+    expect(db.journal.ops('db')).toEqual(['select'])
+  })
+})
+
+describe('getFolderDescendants', () => {
+  it('returns the subtree breadth-first', async () => {
+    const db = makeDb({
+      select: [
+        [aNode('a', null), aNode('b', 'a'), aNode('c', 'a'), aNode('d', 'b')],
+        [aFolder({ id: 'd' }), aFolder({ id: 'c' }), aFolder({ id: 'b' })],
+      ],
+      tables: TABLES,
+    })
+
+    const descendants = (await getFolderDescendants(makeCtx({ db: db.db }), 'a'))._unsafeUnwrap()
+
+    expect(descendants.map((f) => f.id)).toEqual(['b', 'c', 'd'])
+  })
+
+  it('fails with NotFoundError for a folder outside the org', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+    const result = await getFolderDescendants(makeCtx({ db: db.db }), 'fld_1')
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+  })
+})
+
+describe('getFolderCounts', () => {
+  it('selects files by folderId over the whole subtree, never by path prefix', async () => {
+    const db = makeDb({
+      select: [
+        [aNode('doc', null, 'Doc'), aNode('sub', 'doc'), aNode('other', null, 'Documents')],
+        [
+          { folderId: 'doc', fileCount: 1, totalSize: '10' },
+          { folderId: 'sub', fileCount: 2, totalSize: '20' },
+        ],
+      ],
+      tables: TABLES,
+    })
+
+    const counts = (await getFolderCounts(makeCtx({ db: db.db }), 'doc'))._unsafeUnwrap()
+
+    expect(counts).toEqual({
+      totalSize: 30,
+      deepFileCount: 3,
+      directFileCount: 1,
+      subfolderCount: 1,
+    })
+
+    // The aggregate names the subtree ids and nothing else — in particular not
+    // the sibling folder whose name starts with the same characters.
+    const aggregateWhere = whereOf(db, 1)
+    expect(aggregateWhere).toContain('doc')
+    expect(aggregateWhere).toContain('sub')
+    expect(aggregateWhere).not.toContain('other')
+    expect(aggregateWhere).not.toContain('/Doc%')
+  })
+
+  it('is two statements, where the legacy was eight', async () => {
+    const db = makeDb({ select: [[aNode('doc', null)], []], tables: TABLES })
+    await getFolderCounts(makeCtx({ db: db.db }), 'doc')
+    expect(db.journal.ops('db')).toEqual(['select', 'select'])
+  })
+
+  it('fails with NotFoundError for a folder outside the org', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+    const result = await getFolderCounts(makeCtx({ db: db.db }), 'doc')
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError)
+  })
+})
+
+describe('getFolderUsage', () => {
+  it('credits activity deep in the subtree to the direct child it sits under', async () => {
+    const db = makeDb({
+      select: [
+        [aNode('root', null), aNode('branch', 'root'), aNode('leaf', 'branch')],
+        [{ folderId: 'leaf', fileCount: 1, totalSize: '5' }],
+        [{ updatedAt: AT }],
+        [{ folderId: 'leaf', lastActivity: AT }],
+      ],
+      tables: TABLES,
+    })
+
+    const usage = (await getFolderUsage(makeCtx({ db: db.db }), 'root'))._unsafeUnwrap()
+
+    expect(usage).toEqual({
+      fileCount: 1,
+      totalSize: 5,
+      lastActivity: AT,
+      mostActiveSubfolder: { id: 'branch', name: 'branch' },
+    })
+  })
+
+  it('reports no active subfolder when the only activity is in the folder itself', async () => {
+    const db = makeDb({
+      select: [
+        [aNode('root', null)],
+        [{ folderId: 'root', fileCount: 1, totalSize: '5' }],
+        [{ updatedAt: AT }],
+        [{ folderId: 'root', lastActivity: AT }],
+      ],
+      tables: TABLES,
+    })
+
+    const usage = (await getFolderUsage(makeCtx({ db: db.db }), 'root'))._unsafeUnwrap()
+    expect(usage.mostActiveSubfolder).toBeNull()
+  })
+})
+
+describe('isFolderNameAvailable', () => {
+  it('rejects an illegal name without touching the database', async () => {
+    const db = makeDb({ tables: TABLES })
+    const result = await isFolderNameAvailable(makeCtx({ db: db.db }), 'a/b', null)
+    expect(result._unsafeUnwrap()).toBe(false)
+    expect(db.journal.ops('db')).toEqual([])
+  })
+
+  it('lets a folder keep its own name', async () => {
+    const db = makeDb({ select: [[aFolder({ id: 'fld_1' })]], tables: TABLES })
+    const result = await isFolderNameAvailable(makeCtx({ db: db.db }), 'Docs', null, 'fld_1')
+    expect(result._unsafeUnwrap()).toBe(true)
+  })
+
+  it('reports a name taken by a different folder', async () => {
+    const db = makeDb({ select: [[aFolder({ id: 'fld_9' })]], tables: TABLES })
+    const result = await isFolderNameAvailable(makeCtx({ db: db.db }), 'Docs', null, 'fld_1')
+    expect(result._unsafeUnwrap()).toBe(false)
+  })
+})
+
+describe('searchFolders', () => {
+  it('ranks an exact name match above a path match', async () => {
+    const db = makeDb({
+      select: [
+        [
+          aFolder({ id: 'path-hit', name: 'Other', path: '/Docs/Other' }),
+          aFolder({ id: 'exact', name: 'Docs', path: '/Docs' }),
+        ],
+      ],
+      tables: TABLES,
+    })
+
+    const hits = (await searchFolders(makeCtx({ db: db.db }), 'Docs'))._unsafeUnwrap()
+
+    expect(hits.map((h) => h.folder.id)).toEqual(['exact', 'path-hit'])
+    expect(hits[0]?.relevance).toBe(13)
+    expect(hits[0]?.matchedFields).toEqual(['name', 'path'])
+    expect(hits[1]?.relevance).toBe(3)
+  })
+
+  it('never scores a hit below 1', async () => {
+    const db = makeDb({
+      select: [[aFolder({ name: 'Nope', path: '/Nope' })]],
+      tables: TABLES,
+    })
+    const hits = (await searchFolders(makeCtx({ db: db.db }), 'Docs'))._unsafeUnwrap()
+    expect(hits[0]?.relevance).toBe(1)
+    expect(hits[0]?.snippet).toBe('Nope')
+  })
+})
+
+describe('loadFileAggregates', () => {
+  it('does not query at all for an empty id list', async () => {
+    const db = makeDb({ tables: TABLES })
+    expect(await loadFileAggregates(makeCtx({ db: db.db }), [])).toEqual(new Map())
+    expect(db.journal.ops('db')).toEqual([])
+  })
+
+  it('drops rows with a null folderId, which belong to no folder total', async () => {
+    const db = makeDb({
+      select: [
+        [
+          { folderId: null, fileCount: 9, totalSize: '900' },
+          { folderId: 'fld_1', fileCount: 1, totalSize: '10' },
+        ],
+      ],
+      tables: TABLES,
+    })
+
+    const aggregates = await loadFileAggregates(makeCtx({ db: db.db }))
+
+    expect([...aggregates.keys()]).toEqual(['fld_1'])
+  })
+})

--- a/packages/lib/src/files/folders/__tests__/maintenance.test.ts
+++ b/packages/lib/src/files/folders/__tests__/maintenance.test.ts
@@ -1,0 +1,153 @@
+// packages/lib/src/files/folders/__tests__/maintenance.test.ts
+
+/**
+ * `folders/maintenance.ts` — the repair sweeps.
+ *
+ * These have no production caller yet (see the module header for why they were
+ * kept anyway), so the tests are what says they work. The property under test is
+ * the one the pure core bought: **a sweep writes only the rows that are actually
+ * wrong**, from one read rather than two queries per folder.
+ *
+ * `vi.mock` is called zero times.
+ */
+
+import { schema } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import { makeClock, makeCtx, makeDb, TEST_IDS } from '../../__tests__/support'
+import { cleanupEmptyFolders, fixFolderDepths, rebuildFolderPaths } from '../maintenance'
+
+const TABLES = { Folder: schema.Folder, FolderFile: schema.FolderFile }
+const AT = new Date('2026-01-01T00:00:00.000Z')
+const clock = () => ({ now: makeClock(AT.toISOString()).now })
+
+function aNode(id: string, parentId: string | null, name: string, path: string, depth: number) {
+  return { id, parentId, name, path, depth }
+}
+
+describe('rebuildFolderPaths', () => {
+  it('writes nothing when every path and depth already agrees with the edges', async () => {
+    const db = makeDb({
+      select: [
+        [aNode('a', null, 'Docs', '/Docs', 0), aNode('b', 'a', 'Invoices', '/Docs/Invoices', 1)],
+      ],
+      tables: TABLES,
+    })
+
+    const report = (await rebuildFolderPaths(makeCtx({ db: db.db }), clock()))._unsafeUnwrap()
+
+    expect(report).toEqual({ scanned: 2, repaired: 0 })
+    expect(db.updates).toEqual([])
+  })
+
+  it('repairs only the drifted rows, from a single read', async () => {
+    const db = makeDb({
+      select: [
+        [
+          aNode('a', null, 'Docs', '/Docs', 0),
+          aNode('b', 'a', 'Invoices', '/Stale/Invoices', 1),
+          aNode('c', 'b', '2026', '/Docs/Invoices/2026', 9),
+        ],
+      ],
+      tables: TABLES,
+    })
+
+    const report = (await rebuildFolderPaths(makeCtx({ db: db.db }), clock()))._unsafeUnwrap()
+
+    expect(report).toEqual({ scanned: 3, repaired: 2 })
+    expect(db.journal.ops('db')).toEqual(['select', 'update', 'update'])
+    expect(db.updates[0]?.values).toEqual({
+      path: '/Docs/Invoices',
+      depth: 1,
+      updatedAt: AT,
+    })
+    expect(db.updates[1]?.values).toEqual({
+      path: '/Docs/Invoices/2026',
+      depth: 2,
+      updatedAt: AT,
+    })
+  })
+
+  it('scopes every repair write to the organization', async () => {
+    const db = makeDb({
+      select: [[aNode('a', null, 'Docs', '/Stale', 0)]],
+      tables: TABLES,
+    })
+
+    await rebuildFolderPaths(makeCtx({ db: db.db, organizationId: 'org_actor' }), clock())
+
+    for (const where of db.wheres) {
+      expect(JSON.stringify(where.predicate)).toContain('org_actor')
+    }
+  })
+
+  it('re-roots a folder whose parent has gone', async () => {
+    const db = makeDb({
+      select: [[aNode('orphan', 'deleted', 'Orphan', '/Gone/Orphan', 3)]],
+      tables: TABLES,
+    })
+
+    await rebuildFolderPaths(makeCtx({ db: db.db }), clock())
+
+    expect(db.updates[0]?.values).toMatchObject({ path: '/Orphan', depth: 0 })
+  })
+})
+
+describe('fixFolderDepths', () => {
+  it('touches depth alone, never path', async () => {
+    const db = makeDb({
+      select: [[aNode('a', null, 'Docs', '/Docs', 0), aNode('b', 'a', 'Invoices', '/Anything', 7)]],
+      tables: TABLES,
+    })
+
+    const report = (await fixFolderDepths(makeCtx({ db: db.db }), clock()))._unsafeUnwrap()
+
+    expect(report).toEqual({ scanned: 2, repaired: 1 })
+    expect(db.updates[0]?.values).toEqual({ depth: 1, updatedAt: AT })
+    expect(db.updates[0]?.values).not.toHaveProperty('path')
+  })
+
+  it('ignores a drifted path when the depth is right', async () => {
+    const db = makeDb({
+      select: [[aNode('a', null, 'Docs', '/Stale', 0)]],
+      tables: TABLES,
+    })
+
+    const report = (await fixFolderDepths(makeCtx({ db: db.db }), clock()))._unsafeUnwrap()
+
+    expect(report.repaired).toBe(0)
+    expect(db.updates).toEqual([])
+  })
+})
+
+describe('cleanupEmptyFolders', () => {
+  it('does not issue an UPDATE when nothing is empty', async () => {
+    const db = makeDb({ select: [[]], tables: TABLES })
+
+    const report = (await cleanupEmptyFolders(makeCtx({ db: db.db }), clock()))._unsafeUnwrap()
+
+    expect(report).toEqual({ scanned: 0, repaired: 0 })
+    expect(db.journal.ops('db')).toEqual(['select'])
+  })
+
+  it('soft-deletes the empty set in one statement, org-scoped', async () => {
+    const db = makeDb({
+      select: [[{ id: 'e1' }, { id: 'e2' }]],
+      tables: TABLES,
+    })
+
+    const report = (
+      await cleanupEmptyFolders(
+        makeCtx({ db: db.db, organizationId: TEST_IDS.organizationId }),
+        clock()
+      )
+    )._unsafeUnwrap()
+
+    expect(report).toEqual({ scanned: 2, repaired: 2 })
+    expect(db.journal.ops('db')).toEqual(['select', 'update'])
+    expect(db.updates[0]?.values).toEqual({ deletedAt: AT, updatedAt: AT })
+    const where = JSON.stringify(db.wheres.at(-1)?.predicate)
+    expect(where).toContain(TEST_IDS.organizationId)
+    expect(where).toContain('e1')
+    expect(where).toContain('e2')
+  })
+})

--- a/packages/lib/src/files/folders/__tests__/tree.test.ts
+++ b/packages/lib/src/files/folders/__tests__/tree.test.ts
@@ -1,0 +1,563 @@
+// packages/lib/src/files/folders/__tests__/tree.test.ts
+
+/**
+ * `folders/tree.ts` — the pure hierarchy core.
+ *
+ * **This file builds no doubles at all**, not even the `files/` db stub: every
+ * function under test takes plain data and returns plain data
+ * (`plans/attachments/09-testing-strategy.md` §9.2, shape 1). That is the whole
+ * point of PR 5d — the same algorithms were reachable only through a `db`-bound
+ * service before, and the three defects asserted below had therefore never been
+ * exercised.
+ *
+ * The interesting cases are the pathological ones, so they get most of the file:
+ * self-parenting, two- and three-node cycles, a node moved under its own
+ * descendant, a chain deep enough to blow a recursive implementation, orphans
+ * whose parent is not in the set, duplicate sibling names, and names carrying
+ * unicode, whitespace and `LIKE` metacharacters.
+ *
+ * The last three `describe`s are property-style: a deterministic PRNG builds a
+ * random forest and the invariants are asserted over every node in it, rather
+ * than over one hand-picked example.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { FolderNode } from '../tree'
+import {
+  ancestorsOf,
+  buildFolderTree,
+  computePath,
+  computeTreeShape,
+  descendantsOf,
+  driftedShapes,
+  escapeLikePattern,
+  indexById,
+  indexByParent,
+  isAncestorOf,
+  isValidFolderName,
+  joinPath,
+  normalizeParentId,
+  pathPrefix,
+  ROOT_PATH,
+  wouldCreateCycle,
+} from '../tree'
+
+/** A node with plausible-but-obviously-fake path/depth unless overridden. */
+function node(
+  id: string,
+  parentId: string | null,
+  name = id,
+  overrides: Partial<FolderNode> = {}
+): FolderNode {
+  return { id, parentId, name, path: `/${id}`, depth: 0, ...overrides }
+}
+
+/** `a -> b -> c -> …`, `length` deep, rooted at `n0`. */
+function chain(length: number): FolderNode[] {
+  return Array.from({ length }, (_, i) => node(`n${i}`, i === 0 ? null : `n${i - 1}`))
+}
+
+// ============= Path arithmetic =============
+
+describe('joinPath', () => {
+  it.each([
+    [null, 'Docs', '/Docs'],
+    [undefined, 'Docs', '/Docs'],
+    ['/', 'Docs', '/Docs'],
+    ['', 'Docs', '/Docs'],
+    ['/Docs', 'Invoices', '/Docs/Invoices'],
+    ['/Docs/', 'Invoices', '/Docs/Invoices'],
+    ['/a//b', 'c', '/a/b/c'],
+    ['Docs', 'Invoices', '/Docs/Invoices'],
+    ['/Docs', 'Rechnungen für 2026', '/Docs/Rechnungen für 2026'],
+    ['/Docs', '発注書', '/Docs/発注書'],
+    ['/Docs', '100% off', '/Docs/100% off'],
+    ['/Docs', 'a_b', '/Docs/a_b'],
+  ])('joinPath(%p, %p) === %p', (parent, name, expected) => {
+    expect(joinPath(parent as string | null | undefined, name)).toBe(expected)
+  })
+
+  it('always produces an absolute path', () => {
+    for (const parent of [null, '', '/', 'x', '/x', '//x']) {
+      expect(joinPath(parent, 'child').startsWith('/')).toBe(true)
+    }
+  })
+})
+
+describe('pathPrefix', () => {
+  it.each([
+    [null, ROOT_PATH],
+    [undefined, ROOT_PATH],
+    ['/', ROOT_PATH],
+    ['/Doc', '/Doc/'],
+    ['/Documents', '/Documents/'],
+  ])('pathPrefix(%p) === %p', (path, expected) => {
+    expect(pathPrefix(path as string | null | undefined)).toBe(expected)
+  })
+
+  it('distinguishes a folder from a longer-named sibling — the delete-cascade bug', () => {
+    // `'/Documents/report.pdf'.startsWith('/Doc')` is true, which is what the
+    // legacy `ilike(FolderFile.path, `${folder.path}%`)` asked. With the
+    // trailing slash it is false, which is what it meant to ask.
+    expect('/Documents/report.pdf'.startsWith('/Doc')).toBe(true)
+    expect('/Documents/report.pdf'.startsWith(pathPrefix('/Doc'))).toBe(false)
+    expect('/Doc/report.pdf'.startsWith(pathPrefix('/Doc'))).toBe(true)
+  })
+})
+
+describe('escapeLikePattern', () => {
+  it.each([
+    ['plain', 'plain'],
+    ['100% off', '100\\% off'],
+    ['a_b', 'a\\_b'],
+    ['back\\slash', 'back\\\\slash'],
+    ['%_\\', '\\%\\_\\\\'],
+  ])('escapeLikePattern(%p) === %p', (input, expected) => {
+    expect(escapeLikePattern(input)).toBe(expected)
+  })
+})
+
+describe('isValidFolderName', () => {
+  it.each([
+    ['Docs', true],
+    ['Rechnungen für 2026', true],
+    ['発注書', true],
+    ['100% off', true],
+    ['a_b', true],
+    ['  padded  ', true],
+    ['', false],
+    ['   ', false],
+    ['a/b', false],
+    ['a\\b', false],
+    ['a:b', false],
+    ['a*b', false],
+    ['a?b', false],
+    ['a"b', false],
+    ['a<b', false],
+    ['a>b', false],
+    ['a|b', false],
+  ])('isValidFolderName(%p) === %p', (name, expected) => {
+    expect(isValidFolderName(name)).toBe(expected)
+  })
+})
+
+describe('normalizeParentId', () => {
+  it.each([
+    [undefined, null],
+    [null, null],
+    ['root', null],
+    ['fld_1', 'fld_1'],
+  ])('normalizeParentId(%p) === %p', (input, expected) => {
+    expect(normalizeParentId(input as string | null | undefined)).toBe(expected)
+  })
+})
+
+describe('computePath', () => {
+  it('is /name at the root', () => {
+    expect(computePath([], 'Docs')).toBe('/Docs')
+  })
+
+  it('concatenates the ancestor chain root-first', () => {
+    expect(computePath([{ name: 'a' }, { name: 'b' }], 'c')).toBe('/a/b/c')
+  })
+
+  it('handles a 500-deep chain without recursing', () => {
+    const ancestors = Array.from({ length: 500 }, (_, i) => ({ name: `n${i}` }))
+    const path = computePath(ancestors, 'leaf')
+    expect(path.startsWith('/n0/n1/n2/')).toBe(true)
+    expect(path.endsWith('/leaf')).toBe(true)
+    expect(path.split('/').filter(Boolean)).toHaveLength(501)
+  })
+
+  it('preserves unicode and metacharacters verbatim', () => {
+    expect(computePath([{ name: '発注書' }, { name: '100% off' }], 'a_b')).toBe(
+      '/発注書/100% off/a_b'
+    )
+  })
+
+  it('agrees with a fold over joinPath, which is how the mutations build it', () => {
+    const names = ['a', 'b', 'c', 'd']
+    const folded = names.reduce<string | null>((path, name) => joinPath(path, name), null)
+    expect(
+      computePath(
+        names.slice(0, -1).map((name) => ({ name })),
+        'd'
+      )
+    ).toBe(folded)
+  })
+})
+
+// ============= Walks =============
+
+describe('ancestorsOf', () => {
+  it('returns the chain root-first and excludes the node itself', () => {
+    const index = indexById(chain(4))
+    expect(ancestorsOf(index, 'n3').map((n) => n.id)).toEqual(['n0', 'n1', 'n2'])
+  })
+
+  it('is empty for a root', () => {
+    expect(ancestorsOf(indexById(chain(3)), 'n0')).toEqual([])
+  })
+
+  it('is empty for a node that is not in the index', () => {
+    expect(ancestorsOf(indexById(chain(3)), 'missing')).toEqual([])
+  })
+
+  it('stops at a parent that is not in the set, rather than throwing', () => {
+    // `n1`'s parent `n0` was filtered out by `deletedAt IS NULL`.
+    const index = indexById([node('n1', 'n0'), node('n2', 'n1')])
+    expect(ancestorsOf(index, 'n2').map((n) => n.id)).toEqual(['n1'])
+  })
+
+  it('terminates on a self-parenting node', () => {
+    const index = indexById([node('a', 'a')])
+    expect(ancestorsOf(index, 'a')).toEqual([])
+  })
+
+  it('terminates on a two-node cycle — the legacy loop did not', () => {
+    const index = indexById([node('a', 'b'), node('b', 'a')])
+    expect(ancestorsOf(index, 'a').map((n) => n.id)).toEqual(['b'])
+    expect(ancestorsOf(index, 'b').map((n) => n.id)).toEqual(['a'])
+  })
+
+  it('terminates on a three-node cycle', () => {
+    const index = indexById([node('a', 'c'), node('b', 'a'), node('c', 'b')])
+    expect(ancestorsOf(index, 'a').map((n) => n.id)).toEqual(['b', 'c'])
+  })
+
+  it('walks a 2,000-deep chain iteratively', () => {
+    const index = indexById(chain(2000))
+    expect(ancestorsOf(index, 'n1999')).toHaveLength(1999)
+  })
+})
+
+describe('descendantsOf', () => {
+  it('is breadth-first and excludes the node itself', () => {
+    const nodes = [
+      node('root', null),
+      node('a', 'root'),
+      node('b', 'root'),
+      node('a1', 'a'),
+      node('a2', 'a'),
+      node('a1x', 'a1'),
+    ]
+    expect(descendantsOf(nodes, 'root').map((n) => n.id)).toEqual(['a', 'b', 'a1', 'a2', 'a1x'])
+  })
+
+  it('is empty for a leaf', () => {
+    expect(descendantsOf(chain(3), 'n2')).toEqual([])
+  })
+
+  it('is empty for a node that is not in the set', () => {
+    expect(descendantsOf(chain(3), 'missing')).toEqual([])
+  })
+
+  it('visits each node once when a cycle sits below the start', () => {
+    const nodes = [node('root', null), node('a', 'root'), node('b', 'a'), node('c', 'b')]
+    // Close the loop: `a`'s parent becomes `c`, so a -> b -> c -> a.
+    const cyclic = nodes.map((n) => (n.id === 'a' ? { ...n, parentId: 'c' } : n))
+    expect(descendantsOf(cyclic, 'a').map((n) => n.id)).toEqual(['b', 'c'])
+  })
+
+  it('handles a 2,000-deep chain', () => {
+    expect(descendantsOf(chain(2000), 'n0')).toHaveLength(1999)
+  })
+
+  it('keeps duplicate sibling names as distinct nodes', () => {
+    const nodes = [node('root', null), node('x', 'root', 'Docs'), node('y', 'root', 'Docs')]
+    expect(descendantsOf(nodes, 'root').map((n) => n.id)).toEqual(['x', 'y'])
+  })
+})
+
+// ============= Cycle detection =============
+
+describe('wouldCreateCycle', () => {
+  const nodes = [
+    node('root', null),
+    node('a', 'root'),
+    node('b', 'a'),
+    node('c', 'b'),
+    node('other', 'root'),
+  ]
+
+  it('is false for a move to the root', () => {
+    expect(wouldCreateCycle(nodes, 'a', null)).toBe(false)
+  })
+
+  it('is true for self-parenting', () => {
+    expect(wouldCreateCycle(nodes, 'a', 'a')).toBe(true)
+  })
+
+  it('is true for a move under a direct child', () => {
+    expect(wouldCreateCycle(nodes, 'a', 'b')).toBe(true)
+  })
+
+  it('is true for a move under a distant descendant', () => {
+    expect(wouldCreateCycle(nodes, 'a', 'c')).toBe(true)
+  })
+
+  it('is false for a move under an unrelated branch', () => {
+    expect(wouldCreateCycle(nodes, 'a', 'other')).toBe(false)
+  })
+
+  it('is false for a move under an ancestor — a no-op, not a cycle', () => {
+    expect(wouldCreateCycle(nodes, 'c', 'a')).toBe(false)
+  })
+
+  it('is false for a target that does not exist', () => {
+    expect(wouldCreateCycle(nodes, 'a', 'missing')).toBe(false)
+  })
+
+  it('does not depend on the path column, which the legacy check did', () => {
+    // Every path is deliberately wrong; the answer must come from `parentId`.
+    const stale = nodes.map((n) => ({ ...n, path: '/wrong' }))
+    expect(wouldCreateCycle(stale, 'a', 'c')).toBe(true)
+    expect(wouldCreateCycle(stale, 'a', 'other')).toBe(false)
+  })
+
+  it('terminates when the graph already contains a cycle', () => {
+    const cyclic = [node('a', 'c'), node('b', 'a'), node('c', 'b'), node('z', null)]
+    expect(wouldCreateCycle(cyclic, 'z', 'b')).toBe(false)
+    expect(wouldCreateCycle(cyclic, 'a', 'b')).toBe(true)
+  })
+
+  it('accepts a prebuilt index as well as an array', () => {
+    expect(wouldCreateCycle(indexById(nodes), 'a', 'c')).toBe(true)
+  })
+
+  it('is false at every level of a 2,000-deep chain moved upward', () => {
+    const deep = chain(2000)
+    expect(wouldCreateCycle(deep, 'n1999', 'n0')).toBe(false)
+    expect(wouldCreateCycle(deep, 'n0', 'n1999')).toBe(true)
+  })
+})
+
+describe('isAncestorOf', () => {
+  const nodes = [node('root', null), node('a', 'root'), node('b', 'a')]
+
+  it.each([
+    ['root', 'b', true],
+    ['a', 'b', true],
+    ['b', 'a', false],
+    ['a', 'a', false],
+    ['missing', 'b', false],
+  ])('isAncestorOf(%p, %p) === %p', (ancestor, descendant, expected) => {
+    expect(isAncestorOf(nodes, ancestor, descendant)).toBe(expected)
+  })
+})
+
+// ============= Shape recomputation =============
+
+describe('computeTreeShape', () => {
+  it('derives path and depth from the parent chain', () => {
+    const nodes = [
+      node('root', null, 'Docs', { path: '/nonsense', depth: 9 }),
+      node('a', 'root', 'Invoices', { path: '/nonsense', depth: 9 }),
+      node('b', 'a', '2026', { path: '/nonsense', depth: 9 }),
+    ]
+    expect(computeTreeShape(nodes)).toEqual([
+      { id: 'root', path: '/Docs', depth: 0 },
+      { id: 'a', path: '/Docs/Invoices', depth: 1 },
+      { id: 'b', path: '/Docs/Invoices/2026', depth: 2 },
+    ])
+  })
+
+  it('treats a node whose parent is absent as a root', () => {
+    const nodes = [node('orphan', 'gone', 'Orphan', { path: '/x', depth: 4 })]
+    expect(computeTreeShape(nodes)).toEqual([{ id: 'orphan', path: '/Orphan', depth: 0 }])
+  })
+
+  it('terminates on a cycle', () => {
+    const nodes = [node('a', 'b', 'A'), node('b', 'a', 'B')]
+    const shapes = computeTreeShape(nodes)
+    expect(shapes).toHaveLength(2)
+    for (const shape of shapes) expect(shape.depth).toBe(1)
+  })
+})
+
+describe('driftedShapes', () => {
+  it('reports only the rows whose stored path or depth is wrong', () => {
+    const nodes = [
+      node('root', null, 'Docs', { path: '/Docs', depth: 0 }),
+      node('ok', 'root', 'Fine', { path: '/Docs/Fine', depth: 1 }),
+      node('badPath', 'root', 'Bad', { path: '/Docs/Stale', depth: 1 }),
+      node('badDepth', 'root', 'Deep', { path: '/Docs/Deep', depth: 7 }),
+    ]
+    expect(driftedShapes(nodes).map((s) => s.id)).toEqual(['badPath', 'badDepth'])
+  })
+
+  it('is empty for a consistent hierarchy', () => {
+    const nodes = [
+      node('root', null, 'Docs', { path: '/Docs', depth: 0 }),
+      node('a', 'root', 'A', { path: '/Docs/A', depth: 1 }),
+    ]
+    expect(driftedShapes(nodes)).toEqual([])
+  })
+})
+
+// ============= Tree assembly =============
+
+describe('buildFolderTree', () => {
+  it('nests children under their parent', () => {
+    const nodes = [node('root', null), node('a', 'root'), node('a1', 'a')]
+    const tree = buildFolderTree(nodes)
+    expect(tree).toHaveLength(1)
+    expect(tree[0]?.children.map((c) => c.id)).toEqual(['a'])
+    expect(tree[0]?.children[0]?.children.map((c) => c.id)).toEqual(['a1'])
+  })
+
+  it('folds in aggregates, and defaults to zero without them', () => {
+    const nodes = [node('root', null), node('a', 'root')]
+    const tree = buildFolderTree(nodes, new Map([['root', { fileCount: 3, totalSize: 900 }]]))
+    expect(tree[0]).toMatchObject({ fileCount: 3, totalSize: 900 })
+    expect(tree[0]?.children[0]).toMatchObject({ fileCount: 0, totalSize: 0 })
+  })
+
+  it('surfaces an orphan as a root instead of dropping it', () => {
+    // The legacy builder pushed to the roots only when `!folder.parentId`, so a
+    // folder whose parent had been soft-deleted appeared nowhere in the tree.
+    const nodes = [node('root', null), node('orphan', 'deleted-parent')]
+    expect(
+      buildFolderTree(nodes)
+        .map((n) => n.id)
+        .sort()
+    ).toEqual(['orphan', 'root'])
+  })
+
+  it('emits every input node exactly once', () => {
+    const nodes = [node('root', null), node('a', 'root'), node('b', 'a'), node('c', 'root')]
+    const seen: string[] = []
+    const walk = (list: { id: string; children: { id: string; children: unknown[] }[] }[]) => {
+      for (const n of list) {
+        seen.push(n.id)
+        walk(n.children as never)
+      }
+    }
+    walk(buildFolderTree(nodes) as never)
+    expect(seen.sort()).toEqual(['a', 'b', 'c', 'root'])
+  })
+
+  it('produces a serialisable forest from cyclic data', () => {
+    // A tRPC response is `JSON.stringify`d; a self-referential structure throws
+    // `TypeError: Converting circular structure to JSON` at that point, far from
+    // the cause.
+    const nodes = [node('a', 'b'), node('b', 'a'), node('c', null)]
+    const tree = buildFolderTree(nodes)
+    expect(() => JSON.stringify(tree)).not.toThrow()
+    const ids = JSON.stringify(tree).match(/"id":"(\w+)"/g)
+    expect(ids).toHaveLength(3)
+  })
+
+  it('keeps duplicate sibling names apart', () => {
+    const nodes = [node('root', null), node('x', 'root', 'Docs'), node('y', 'root', 'Docs')]
+    expect(buildFolderTree(nodes)[0]?.children.map((c) => c.name)).toEqual(['Docs', 'Docs'])
+  })
+
+  it('falls back to the root path for a null path column', () => {
+    expect(buildFolderTree([node('a', null, 'A', { path: null })])[0]?.path).toBe(ROOT_PATH)
+  })
+})
+
+describe('indexByParent', () => {
+  it('buckets roots under null and preserves input order', () => {
+    const nodes = [node('a', null), node('b', 'a'), node('c', 'a'), node('d', null)]
+    const index = indexByParent(nodes)
+    expect(index.get(null)?.map((n) => n.id)).toEqual(['a', 'd'])
+    expect(index.get('a')?.map((n) => n.id)).toEqual(['b', 'c'])
+  })
+})
+
+// ============= Property-style: invariants over generated forests =============
+
+/** Deterministic PRNG, so a failure is reproducible from the seed alone. */
+function mulberry32(seed: number): () => number {
+  let a = seed
+  return () => {
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/** A random acyclic forest: a node's parent is always an earlier node or null. */
+function randomForest(seed: number, size: number): FolderNode[] {
+  const random = mulberry32(seed)
+  const names = ['Docs', 'Docs', 'Rechnungen', '発注書', '100% off', 'a_b', 'x y']
+  const nodes: FolderNode[] = []
+  for (let i = 0; i < size; i++) {
+    const parentIndex = Math.floor(random() * (i + 1)) - 1
+    nodes.push(
+      node(
+        `n${i}`,
+        parentIndex >= 0 ? `n${parentIndex}` : null,
+        names[Math.floor(random() * names.length)] as string,
+        { path: '/stale', depth: -1 }
+      )
+    )
+  }
+  return nodes
+}
+
+const SEEDS = [1, 7, 42, 1337, 90210]
+
+describe('property: computeTreeShape agrees with the walks it is built from', () => {
+  it.each(SEEDS)('seed %i', (seed) => {
+    const nodes = randomForest(seed, 120)
+    const index = indexById(nodes)
+    for (const shape of computeTreeShape(nodes)) {
+      const chainToNode = ancestorsOf(index, shape.id)
+      expect(shape.depth).toBe(chainToNode.length)
+      expect(shape.path).toBe(computePath(chainToNode, index.get(shape.id)?.name as string))
+    }
+  })
+})
+
+describe('property: cycle detection matches the descendant set exactly', () => {
+  it.each(SEEDS)('seed %i', (seed) => {
+    const nodes = randomForest(seed, 80)
+    for (const subject of nodes) {
+      const descendants = new Set(descendantsOf(nodes, subject.id).map((n) => n.id))
+      for (const target of nodes) {
+        // Moving `subject` under `target` closes a loop exactly when `target` is
+        // `subject` itself or sits inside `subject`'s own subtree.
+        const expected = target.id === subject.id || descendants.has(target.id)
+        expect(wouldCreateCycle(nodes, subject.id, target.id)).toBe(expected)
+      }
+      expect(wouldCreateCycle(nodes, subject.id, null)).toBe(false)
+    }
+  })
+})
+
+describe('property: buildFolderTree is a partition of its input', () => {
+  it.each(SEEDS)('seed %i', (seed) => {
+    const nodes = randomForest(seed, 150)
+    const tree = buildFolderTree(nodes)
+
+    const seen = new Set<string>()
+    const stack = [...tree]
+    while (stack.length > 0) {
+      const current = stack.pop()
+      if (!current) continue
+      expect(seen.has(current.id)).toBe(false)
+      seen.add(current.id)
+      stack.push(...current.children)
+    }
+
+    expect(seen.size).toBe(nodes.length)
+    expect(() => JSON.stringify(tree)).not.toThrow()
+  })
+})
+
+describe('property: ancestor and descendant walks are inverses', () => {
+  it.each(SEEDS)('seed %i', (seed) => {
+    const nodes = randomForest(seed, 90)
+    const index = indexById(nodes)
+    for (const subject of nodes) {
+      for (const descendant of descendantsOf(nodes, subject.id)) {
+        expect(ancestorsOf(index, descendant.id).map((n) => n.id)).toContain(subject.id)
+        expect(isAncestorOf(nodes, subject.id, descendant.id)).toBe(true)
+      }
+    }
+  })
+})

--- a/packages/lib/src/files/folders/folder-mutations.ts
+++ b/packages/lib/src/files/folders/folder-mutations.ts
@@ -1,0 +1,770 @@
+// packages/lib/src/files/folders/folder-mutations.ts
+
+/**
+ * `Folder` writes.
+ *
+ * Reads live in `folders/folder-queries.ts`, the graph algorithms in
+ * `folders/tree.ts` — `docs/lib-module-guide.md` §5.
+ *
+ * ## Three defects this file fixes, deliberately and not silently
+ *
+ * **1. Every `UPDATE` and `DELETE` now carries the organization filter.** The
+ * legacy bodies pre-checked existence with an org-scoped `get(id)` and then
+ * wrote with `where(eq(Folder.id, id))` alone — `update`, `delete`, `restore`,
+ * `merge` and, worst, `permanentDelete`, which is a **hard** `DELETE`. The
+ * pre-check made none of them exploitable on their own, but "the guard is in a
+ * different statement from the write" is exactly the shape PR 5b found already
+ * broken on `AttachmentService.detachFromEntity`. Org scope is in the statement
+ * here, unconditionally.
+ *
+ * **2. The cascade no longer matches paths by prefix.** Delete, restore,
+ * permanent delete and the deep counts all used
+ * `ilike(FolderFile.path, `${folder.path}%`)` — **without a trailing slash**,
+ * while the sibling `Folder` statement in the same transaction used
+ * `pathPrefix()`, which adds one. So deleting `/Doc` soft-deleted every file
+ * under `/Documents` too, and `permanentDelete` erased them. `ilike` also made
+ * `%` and `_` in a folder name into wildcards. Membership is now
+ * `folderId IN (subtree)` / `id IN (subtree)`, computed from the `parentId`
+ * edges — a real foreign key, which cannot drift and has no metacharacters.
+ *
+ * **3. Cycle detection walks parent links, not paths.** See `tree.ts`.
+ *
+ * ## Transaction discipline
+ *
+ * Anything that writes more than one row takes `tx: Transaction` positionally
+ * first, per `files/ctx.ts`. The legacy code called `BaseService.getTx()`, which
+ * inspected `typeof db.transaction` at runtime to guess whether it was already
+ * inside one — Phase 6 §6.2. A function handed its transaction cannot guess,
+ * because the caller already decided.
+ *
+ * `createFolder` and `ensureFolderPath` take `ctx` instead: the first is a
+ * single `INSERT`, and the second is a sequence of them that the legacy
+ * `ensurePath` also ran without a transaction. Both are noted where they sit.
+ */
+
+import type { Transaction } from '@auxx/database'
+import { schema } from '@auxx/database'
+import type { FolderEntity, FolderFileEntity } from '@auxx/database/types'
+import { and, eq, inArray, isNotNull, isNull, type SQL } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import type { AuxxError } from '../../errors'
+import { BadRequestError, ConflictError, NotFoundError } from '../../errors'
+import type { FilesCtx } from '../ctx'
+import { guard } from '../guard'
+import {
+  findFolderByNameAndParent,
+  folderScope,
+  loadFolderNodes,
+  requireFolder,
+} from './folder-queries'
+import type { FolderCopyDeps, FolderWriteDeps } from './ports'
+import type { FolderNode } from './tree'
+import {
+  ancestorsOf,
+  computePath,
+  descendantsOf,
+  indexById,
+  isValidFolderName,
+  joinPath,
+  normalizeParentId,
+  wouldCreateCycle,
+} from './tree'
+
+// ============= Inputs =============
+
+/**
+ * Everything needed to create one folder.
+ *
+ * **No `organizationId`.** The legacy `processCreateData` read
+ * `data.organizationId || this.requireOrganization()`, so a caller could write a
+ * row into an organization it was not acting for. Scope comes from `ctx`, as in
+ * `assets/asset-mutations.ts` and `storage/locations.ts`.
+ */
+export interface CreateFolderInput {
+  name: string
+  /** `null`, `undefined` and the UI's `'root'` all mean "at the top level". */
+  parentId?: string | null
+  /** The actor to attribute the row to. `Folder.createdById` is nullable. */
+  createdById?: string | null
+}
+
+/**
+ * The mutable fields of a folder.
+ *
+ * `parentId: null` moves the folder to the root; **omitting `parentId` leaves
+ * the parent alone**. That distinction is load-bearing — `folderRouter.update`
+ * carries a comment about it — and a closed input type is what keeps it
+ * expressible, where the legacy `.set({ ...data })` would have accepted any key.
+ */
+export interface UpdateFolderInput {
+  name?: string
+  parentId?: string | null
+}
+
+/** Everything needed to copy a folder subtree. */
+export interface CopyFolderInput {
+  sourceId: string
+  targetParentId: string | null
+  /** Defaults to `Copy of <source name>`, matching the legacy `copy`. */
+  newName?: string
+  createdById?: string | null
+}
+
+// ============= Writes =============
+
+/**
+ * Create one folder.
+ *
+ * A single `INSERT`, so it takes `ctx` rather than a `Transaction`; a caller
+ * already inside one passes `{ ...ctx, db: tx }`.
+ *
+ * `path` and `depth` are derived from the parent's stored values, which is what
+ * the legacy `computeNewFolderPath` / `getParentDepth` pair did in two extra
+ * queries. If the parent's own path has drifted the child inherits the drift —
+ * that is what `maintenance.ts`'s `rebuildFolderPaths` is for, and paying a
+ * full-hierarchy read on every create to avoid it is not a trade worth making.
+ *
+ * Fails with `ConflictError` (409) rather than the legacy bare `Error` (500)
+ * when the name is taken, mirroring the
+ * `Folder_organizationId_parentId_name_key` unique index.
+ */
+export async function createFolder(
+  ctx: FilesCtx,
+  input: CreateFolderInput,
+  deps: FolderWriteDeps
+): Promise<Result<FolderEntity, AuxxError>> {
+  return guard(async () => insertFolder(ctx, input, deps), 'Failed to create folder', {
+    name: input.name,
+    organizationId: ctx.organizationId,
+  })
+}
+
+/**
+ * Rename and/or re-parent one folder, repairing the subtree's paths.
+ *
+ * The single write entry point behind {@link renameFolder} and
+ * {@link moveFolder}. Order of operations, all inside the caller's transaction:
+ *
+ * 1. existence, name validity, name-collision in the *target* parent
+ * 2. cycle check against the `parentId` graph
+ * 3. `UPDATE` the folder itself — org-scoped
+ * 4. recompute and `UPDATE` every descendant's `path` and `depth`, and every
+ *    file's `path`, from the new shape
+ *
+ * Step 4 recomputes rather than string-replacing. The legacy version built a
+ * `RegExp` from the old path (escaped, at least) and replaced the prefix, which
+ * silently no-ops when the stored path did not actually start with the prefix —
+ * so a subtree that had already drifted stayed drifted.
+ */
+export async function updateFolder(
+  tx: Transaction,
+  ctx: FilesCtx,
+  folderId: string,
+  input: UpdateFolderInput,
+  deps: FolderWriteDeps
+): Promise<Result<FolderEntity, AuxxError>> {
+  const txCtx: FilesCtx = { ...ctx, db: tx }
+  return guard(
+    async () => {
+      const folder = await requireFolder(txCtx, folderId)
+
+      const renaming = input.name !== undefined && input.name !== folder.name
+      const reparenting = input.parentId !== undefined
+      const nextName = input.name ?? folder.name
+      const nextParentId = reparenting ? normalizeParentId(input.parentId) : folder.parentId
+
+      if (renaming && !isValidFolderName(nextName)) {
+        throw new BadRequestError(`'${nextName}' is not a valid folder name`)
+      }
+
+      if (renaming || nextParentId !== folder.parentId) {
+        await assertNameAvailable(txCtx, nextName, nextParentId, folderId)
+      }
+
+      const nodes = await loadFolderNodes(txCtx)
+      const index = indexById(nodes)
+
+      if (nextParentId !== folder.parentId && nextParentId !== null) {
+        if (!index.has(nextParentId)) {
+          throw new NotFoundError(`Target parent folder ${nextParentId} not found`)
+        }
+        if (wouldCreateCycle(index, folderId, nextParentId)) {
+          throw new ConflictError('Move would place the folder inside its own subtree')
+        }
+      }
+
+      const now = deps.now()
+      const parentChain = nextParentId
+        ? [...ancestorsOf(index, nextParentId), index.get(nextParentId) as FolderNode]
+        : []
+      const path = computePath(parentChain, nextName)
+      const depth = parentChain.length
+
+      const [updated] = await tx
+        .update(schema.Folder)
+        .set({
+          name: nextName,
+          parentId: nextParentId,
+          path,
+          depth,
+          updatedAt: now,
+        })
+        .where(folderScope(txCtx, [eq(schema.Folder.id, folderId)]))
+        .returning()
+
+      if (!updated) throw new NotFoundError(`Folder ${folderId} not found`)
+
+      if (path !== folder.path || depth !== folder.depth) {
+        await reshapeSubtree(
+          tx,
+          txCtx,
+          nodes,
+          { ...(index.get(folderId) as FolderNode), name: nextName, parentId: nextParentId },
+          path,
+          depth,
+          now
+        )
+      }
+
+      return updated as FolderEntity
+    },
+    'Failed to update folder',
+    { folderId, organizationId: ctx.organizationId }
+  )
+}
+
+/** Rename a folder in place. A thin spelling of {@link updateFolder}. */
+export async function renameFolder(
+  tx: Transaction,
+  ctx: FilesCtx,
+  folderId: string,
+  newName: string,
+  deps: FolderWriteDeps
+): Promise<Result<FolderEntity, AuxxError>> {
+  return updateFolder(tx, ctx, folderId, { name: newName }, deps)
+}
+
+/**
+ * Move a folder under a new parent, or to the root with `null`.
+ *
+ * A thin spelling of {@link updateFolder}. The legacy class had **both**
+ * `move(id, parentId)` and `moveToParent(id, parentId)`, the former delegating
+ * to the latter — the `InboxService` two-names-for-one-operation rot the lib
+ * guide names. One survives.
+ */
+export async function moveFolder(
+  tx: Transaction,
+  ctx: FilesCtx,
+  folderId: string,
+  newParentId: string | null,
+  deps: FolderWriteDeps
+): Promise<Result<FolderEntity, AuxxError>> {
+  return updateFolder(tx, ctx, folderId, { parentId: normalizeParentId(newParentId) }, deps)
+}
+
+/**
+ * Soft-delete a folder, its whole subtree, and every file in it.
+ *
+ * Two statements regardless of subtree size (the legacy was three, one of which
+ * matched the wrong files — see the file header). Idempotent: rows already
+ * carrying a `deletedAt` are left alone, so a second delete does not restamp the
+ * timestamp and lose when the first delete happened.
+ */
+export async function deleteFolder(
+  tx: Transaction,
+  ctx: FilesCtx,
+  folderId: string,
+  deps: FolderWriteDeps
+): Promise<Result<void, AuxxError>> {
+  const txCtx: FilesCtx = { ...ctx, db: tx }
+  return guard(
+    async () => {
+      await requireFolder(txCtx, folderId)
+      const ids = await subtreeIds(txCtx, folderId)
+      const now = deps.now()
+
+      await tx
+        .update(schema.Folder)
+        .set({ deletedAt: now, updatedAt: now })
+        .where(folderScope(txCtx, [inArray(schema.Folder.id, ids)]))
+
+      await tx
+        .update(schema.FolderFile)
+        .set({ deletedAt: now, updatedAt: now })
+        .where(
+          and(
+            eq(schema.FolderFile.organizationId, txCtx.organizationId),
+            inArray(schema.FolderFile.folderId, ids),
+            isNull(schema.FolderFile.deletedAt)
+          )
+        )
+    },
+    'Failed to delete folder',
+    { folderId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Undo {@link deleteFolder} for a folder and everything beneath it.
+ *
+ * Reads the hierarchy with `includeDeleted: true` — the subtree is by definition
+ * soft-deleted, so an ordinary read returns an empty graph and would restore the
+ * folder alone. Returns the folder unchanged when it was never deleted, which is
+ * the legacy early return.
+ *
+ * This restores descendants that were deleted *before* their parent was, which
+ * the path-prefix version also did. Recording per-row delete provenance is the
+ * only way to do better and is out of scope for a refactor.
+ */
+export async function restoreFolder(
+  tx: Transaction,
+  ctx: FilesCtx,
+  folderId: string,
+  deps: FolderWriteDeps
+): Promise<Result<FolderEntity, AuxxError>> {
+  const txCtx: FilesCtx = { ...ctx, db: tx }
+  return guard(
+    async () => {
+      const folder = await requireFolder(txCtx, folderId, { includeDeleted: true })
+      if (!folder.deletedAt) return folder
+
+      const ids = await subtreeIds(txCtx, folderId, { includeDeleted: true })
+      const now = deps.now()
+
+      const restored = await tx
+        .update(schema.Folder)
+        .set({ deletedAt: null, updatedAt: now })
+        .where(
+          folderScope(txCtx, [inArray(schema.Folder.id, ids), isNotNull(schema.Folder.deletedAt)], {
+            includeDeleted: true,
+          })
+        )
+        .returning()
+
+      await tx
+        .update(schema.FolderFile)
+        .set({ deletedAt: null, updatedAt: now })
+        .where(
+          and(
+            eq(schema.FolderFile.organizationId, txCtx.organizationId),
+            inArray(schema.FolderFile.folderId, ids),
+            isNotNull(schema.FolderFile.deletedAt)
+          )
+        )
+
+      const self = (restored as FolderEntity[]).find((row) => row.id === folderId)
+      if (!self) throw new NotFoundError(`Folder ${folderId} not found`)
+      return self
+    },
+    'Failed to restore folder',
+    { folderId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Hard-delete a folder, its subtree, and every file row in it.
+ *
+ * Files first, then folders: `Folder.parentId` is `NO ACTION`, but both
+ * statements delete whole subtrees at once so the constraint is satisfied at
+ * statement end.
+ *
+ * **This is the statement the missing organization filter mattered most on.**
+ * The legacy body ran `tx.delete(Folder).where(eq(Folder.id, id))` with no scope
+ * at all; anyone holding a folder id could erase another tenant's folder if the
+ * pre-check were ever refactored away.
+ *
+ * Storage objects behind the deleted `FolderFile` rows are **not** collected
+ * here — the legacy did not either, and orphan sweeping is `lifecycle/`'s job.
+ */
+export async function permanentlyDeleteFolder(
+  tx: Transaction,
+  ctx: FilesCtx,
+  folderId: string
+): Promise<Result<void, AuxxError>> {
+  const txCtx: FilesCtx = { ...ctx, db: tx }
+  return guard(
+    async () => {
+      await requireFolder(txCtx, folderId, { includeDeleted: true })
+      const ids = await subtreeIds(txCtx, folderId, { includeDeleted: true })
+
+      await tx
+        .delete(schema.FolderFile)
+        .where(
+          and(
+            eq(schema.FolderFile.organizationId, txCtx.organizationId),
+            inArray(schema.FolderFile.folderId, ids)
+          )
+        )
+
+      await tx
+        .delete(schema.Folder)
+        .where(
+          and(
+            eq(schema.Folder.organizationId, txCtx.organizationId),
+            inArray(schema.Folder.id, ids)
+          )
+        )
+    },
+    'Failed to permanently delete folder',
+    { folderId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Copy a folder and everything under it to a new parent.
+ *
+ * Walks the source subtree breadth-first over an id map, so a folder is always
+ * created after its parent and the recursion the legacy `copyFolderContents`
+ * used — which re-queried the target folder on every level — is gone.
+ *
+ * File **versions** are copied through {@link FolderCopyDeps.files}, not by
+ * constructing a `FileService` inside the loop. Storage objects are shared, not
+ * duplicated, which is the behaviour `FileService.copyVersions` has always had.
+ */
+export async function copyFolder(
+  tx: Transaction,
+  ctx: FilesCtx,
+  input: CopyFolderInput,
+  deps: FolderCopyDeps
+): Promise<Result<FolderEntity, AuxxError>> {
+  const txCtx: FilesCtx = { ...ctx, db: tx }
+  return guard(
+    async () => {
+      const source = await requireFolder(txCtx, input.sourceId)
+      const targetParentId = normalizeParentId(input.targetParentId)
+      if (targetParentId) await requireFolder(txCtx, targetParentId)
+
+      const name = input.newName ?? `Copy of ${source.name}`
+      await assertNameAvailable(txCtx, name, targetParentId)
+
+      const nodes = await loadFolderNodes(txCtx)
+      if (targetParentId && wouldCreateCycle(indexById(nodes), input.sourceId, targetParentId)) {
+        throw new ConflictError('Cannot copy a folder into its own subtree')
+      }
+
+      const root = await insertFolder(
+        txCtx,
+        { name, parentId: targetParentId, createdById: input.createdById ?? source.createdById },
+        deps
+      )
+
+      // Breadth-first over the source subtree, so `idMap` always already holds
+      // the copy of the current node's parent.
+      const idMap = new Map<string, FolderEntity>([[source.id, root]])
+      for (const node of descendantsOf(nodes, source.id)) {
+        const parentCopy = node.parentId ? idMap.get(node.parentId) : undefined
+        if (!parentCopy) continue
+        idMap.set(
+          node.id,
+          await insertFolder(
+            txCtx,
+            { name: node.name, parentId: parentCopy.id, createdById: input.createdById },
+            deps
+          )
+        )
+      }
+
+      await copyFilesInto(tx, txCtx, idMap, deps)
+      return root
+    },
+    'Failed to copy folder',
+    { sourceId: input.sourceId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Move everything out of `sourceId` into `targetId`, then soft-delete the source.
+ *
+ * Refuses a merge into the source's own subtree with `ConflictError`. The legacy
+ * `merge` had no such check and would happily re-parent the target's ancestors
+ * under the target, producing exactly the cycle that then hung `getAncestors`.
+ */
+export async function mergeFolders(
+  tx: Transaction,
+  ctx: FilesCtx,
+  sourceId: string,
+  targetId: string,
+  deps: FolderWriteDeps
+): Promise<Result<void, AuxxError>> {
+  const txCtx: FilesCtx = { ...ctx, db: tx }
+  return guard(
+    async () => {
+      if (sourceId === targetId) throw new BadRequestError('Cannot merge a folder with itself')
+
+      await requireFolder(txCtx, sourceId)
+      const target = await requireFolder(txCtx, targetId)
+
+      const nodes = await loadFolderNodes(txCtx)
+      const index = indexById(nodes)
+      if (wouldCreateCycle(index, sourceId, targetId)) {
+        throw new ConflictError('Cannot merge a folder into its own subtree')
+      }
+
+      const now = deps.now()
+      const targetChain = [...ancestorsOf(index, targetId), index.get(targetId) as FolderNode]
+
+      const files = await loadFilesIn(txCtx, [sourceId])
+      for (const file of files) {
+        await tx
+          .update(schema.FolderFile)
+          .set({
+            folderId: targetId,
+            path: joinPath(target.path, file.name),
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(schema.FolderFile.id, file.id),
+              eq(schema.FolderFile.organizationId, txCtx.organizationId)
+            )
+          )
+      }
+
+      for (const child of nodes.filter((node) => node.parentId === sourceId)) {
+        const path = computePath(targetChain, child.name)
+        // `targetChain` is the target's ancestors *plus the target itself*, so
+        // its length is already the moved child's new depth.
+        const depth = targetChain.length
+        await tx
+          .update(schema.Folder)
+          .set({ parentId: targetId, path, depth, updatedAt: now })
+          .where(folderScope(txCtx, [eq(schema.Folder.id, child.id)]))
+        await reshapeSubtree(tx, txCtx, nodes, { ...child, parentId: targetId }, path, depth, now)
+      }
+
+      await tx
+        .update(schema.Folder)
+        .set({ deletedAt: now, updatedAt: now })
+        .where(folderScope(txCtx, [eq(schema.Folder.id, sourceId)]))
+    },
+    'Failed to merge folders',
+    { sourceId, targetId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Walk a `'a/b/c'` path, creating the folders that do not exist yet.
+ *
+ * Takes `ctx`, not a `Transaction`, matching the legacy `ensurePath` — the
+ * creates are independent and a partially-created path is a valid state that a
+ * repeat call completes. A caller that wants all-or-nothing passes
+ * `{ ...ctx, db: tx }`.
+ */
+export async function ensureFolderPath(
+  ctx: FilesCtx,
+  path: string,
+  deps: FolderWriteDeps,
+  opts: { createdById?: string | null } = {}
+): Promise<Result<FolderEntity, AuxxError>> {
+  return guard(
+    async () => {
+      const parts = path.split('/').filter((part) => part.length > 0)
+      if (parts.length === 0) throw new BadRequestError(`'${path}' names no folder`)
+
+      let parentId: string | null = null
+      let folder: FolderEntity | null = null
+
+      for (const name of parts) {
+        folder =
+          (await findFolderByNameAndParent(ctx, name, parentId)) ??
+          (await insertFolder(ctx, { name, parentId, createdById: opts.createdById }, deps))
+        parentId = folder.id
+      }
+
+      if (!folder) throw new BadRequestError(`'${path}' names no folder`)
+      return folder
+    },
+    'Failed to ensure folder path',
+    { path, organizationId: ctx.organizationId }
+  )
+}
+
+// ============= Internal helpers (throw; the guard converts at the boundary) =============
+
+/**
+ * Refuse a name that is already taken under `parentId`.
+ *
+ * `excludeId` lets a folder keep its own name through a rename or a no-op move.
+ * `ConflictError` (409), where every legacy path threw a bare `Error` and the
+ * router turned it into a 400 with the message pasted in.
+ */
+export async function assertNameAvailable(
+  ctx: FilesCtx,
+  name: string,
+  parentId: string | null,
+  excludeId?: string
+): Promise<void> {
+  const existing = await findFolderByNameAndParent(ctx, name, parentId)
+  if (existing && existing.id !== excludeId) {
+    throw new ConflictError(`A folder named '${name}' already exists here`)
+  }
+}
+
+/** The shared body of every folder create. Validates, then a single `INSERT`. */
+async function insertFolder(
+  ctx: FilesCtx,
+  input: CreateFolderInput,
+  deps: FolderWriteDeps
+): Promise<FolderEntity> {
+  if (!isValidFolderName(input.name)) {
+    throw new BadRequestError(`'${input.name}' is not a valid folder name`)
+  }
+
+  const parentId = normalizeParentId(input.parentId)
+  const parent = parentId ? await requireFolder(ctx, parentId) : null
+  await assertNameAvailable(ctx, input.name, parentId)
+
+  const now = deps.now()
+  const [created] = await ctx.db
+    .insert(schema.Folder)
+    .values({
+      organizationId: ctx.organizationId,
+      name: input.name,
+      parentId,
+      path: joinPath(parent?.path, input.name),
+      depth: parent ? parent.depth + 1 : 0,
+      createdById: input.createdById ?? null,
+      isArchived: false,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning()
+
+  if (!created) {
+    throw new BadRequestError(
+      `Failed to create folder '${input.name}': no row returned. Verify that parent '${parentId}' exists in organization '${ctx.organizationId}'.`
+    )
+  }
+  return created as FolderEntity
+}
+
+/** `[folderId, ...descendants]`, from the `parentId` edges. Never empty. */
+async function subtreeIds(
+  ctx: FilesCtx,
+  folderId: string,
+  opts: { includeDeleted?: boolean } = {}
+): Promise<string[]> {
+  const nodes = await loadFolderNodes(ctx, opts)
+  return [folderId, ...descendantsOf(nodes, folderId).map((node) => node.id)]
+}
+
+/**
+ * Rewrite the `path`/`depth` of everything under `moved`, and the `path` of
+ * their files.
+ *
+ * Takes the pre-move node list plus the moved node's *new* shape, recomputes
+ * each descendant's position from the `parentId` edges, and writes only the rows
+ * that actually changed. One `UPDATE` per changed folder and per changed file —
+ * the same statement count the legacy had, minus the per-descendant `findMany`
+ * it issued to fetch the files.
+ */
+async function reshapeSubtree(
+  tx: Transaction,
+  ctx: FilesCtx,
+  nodes: readonly FolderNode[],
+  moved: FolderNode,
+  movedPath: string,
+  movedDepth: number,
+  now: Date
+): Promise<void> {
+  const positions = new Map<string, { path: string; depth: number }>([
+    [moved.id, { path: movedPath, depth: movedDepth }],
+  ])
+  const byId = indexById(nodes)
+  const descendants = descendantsOf(nodes, moved.id)
+
+  for (const node of descendants) {
+    const parent = node.parentId ? positions.get(node.parentId) : undefined
+    // `descendantsOf` is breadth-first, so the parent's new position is already
+    // known unless the graph is cyclic — in which case leave the row alone
+    // rather than write a path derived from a partial walk.
+    if (!parent) continue
+    positions.set(node.id, {
+      path: joinPath(parent.path, node.name),
+      depth: parent.depth + 1,
+    })
+  }
+
+  const changed: string[] = []
+  for (const node of descendants) {
+    const next = positions.get(node.id)
+    const current = byId.get(node.id)
+    if (!next || !current) continue
+    if (current.path === next.path && current.depth === next.depth) continue
+    changed.push(node.id)
+    await tx
+      .update(schema.Folder)
+      .set({ path: next.path, depth: next.depth, updatedAt: now })
+      .where(folderScope(ctx, [eq(schema.Folder.id, node.id)]))
+  }
+
+  // Files hang off `folderId`, so only the folders that actually moved need
+  // their file paths rewritten — plus the moved folder itself.
+  const folderIds = [moved.id, ...changed]
+  for (const file of await loadFilesIn(ctx, folderIds)) {
+    const owner = file.folderId ? positions.get(file.folderId) : undefined
+    if (!owner) continue
+    const path = joinPath(owner.path, file.name)
+    if (path === file.path) continue
+    await tx
+      .update(schema.FolderFile)
+      .set({ path, updatedAt: now })
+      .where(
+        and(
+          eq(schema.FolderFile.id, file.id),
+          eq(schema.FolderFile.organizationId, ctx.organizationId)
+        )
+      )
+  }
+}
+
+/** Live files directly in each of `folderIds`. Returns `[]` for an empty list without querying. */
+async function loadFilesIn(ctx: FilesCtx, folderIds: string[]): Promise<FolderFileEntity[]> {
+  if (folderIds.length === 0) return []
+  const rows = await ctx.db
+    .select()
+    .from(schema.FolderFile)
+    .where(
+      and(
+        eq(schema.FolderFile.organizationId, ctx.organizationId),
+        inArray(schema.FolderFile.folderId, folderIds),
+        isNull(schema.FolderFile.deletedAt)
+      ) as SQL
+    )
+  return rows as FolderFileEntity[]
+}
+
+/** Duplicate every live file in the copied subtree into its counterpart folder. */
+async function copyFilesInto(
+  tx: Transaction,
+  ctx: FilesCtx,
+  idMap: ReadonlyMap<string, FolderEntity>,
+  deps: FolderCopyDeps
+): Promise<void> {
+  const files = await loadFilesIn(ctx, [...idMap.keys()])
+  const now = deps.now()
+
+  for (const file of files) {
+    const target = file.folderId ? idMap.get(file.folderId) : undefined
+    if (!target) continue
+
+    const [copy] = await tx
+      .insert(schema.FolderFile)
+      .values({
+        organizationId: ctx.organizationId,
+        folderId: target.id,
+        name: file.name,
+        path: joinPath(target.path, file.name),
+        ext: file.ext,
+        mimeType: file.mimeType,
+        size: file.size,
+        createdById: file.createdById,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+
+    if (!copy) throw new BadRequestError(`Failed to copy file '${file.name}'`)
+    await deps.files.copyFileVersions(file.id, (copy as FolderFileEntity).id)
+  }
+}

--- a/packages/lib/src/files/folders/folder-queries.ts
+++ b/packages/lib/src/files/folders/folder-queries.ts
@@ -1,0 +1,825 @@
+// packages/lib/src/files/folders/folder-queries.ts
+
+/**
+ * `Folder` reads.
+ *
+ * Writes live in `folders/folder-mutations.ts`, the graph algorithms in
+ * `folders/tree.ts` — `docs/lib-module-guide.md` §5. `core/folder-service.ts`
+ * mixed all three and reached 1,945 lines across 45 methods, 23 of which
+ * anything called.
+ *
+ * ## Organization scope is unconditional
+ *
+ * `BaseService.buildBaseWhereClause` added `eq(organizationId, …)` **only when
+ * the service happened to have been constructed with one** and returned
+ * `undefined` — no `WHERE` at all — otherwise. `Folder.organizationId` is
+ * `NOT NULL`, so there is no pre-backfill population to keep visible and the
+ * conditional bought nothing except a cross-tenant read whenever a construction
+ * site forgot its first argument. `FilesCtx.organizationId` is required, so that
+ * branch cannot be expressed here.
+ *
+ * ## The hierarchy is loaded once and walked in memory
+ *
+ * {@link loadFolderNodes} issues one narrow `SELECT` for an organization's whole
+ * folder graph and everything hierarchical is then a pure function over it
+ * (`tree.ts`). This replaces three different legacy strategies that disagreed
+ * with each other:
+ *
+ * - `getAncestors` walked upward one point query at a time, with no visited set
+ *   — unbounded on cyclic data.
+ * - `getDescendants`, the delete cascade and the deep counts matched
+ *   `path LIKE '<path>%'`, which is wrong whenever `path` has drifted (the
+ *   condition `rebuildPaths` exists to repair) and wrong again for any name
+ *   containing `%` or `_`.
+ * - `getFolderTree` eagerly loaded the `files` **and** `children` relations of
+ *   every folder in the organization to compute a `fileCount` it then read off
+ *   a Prisma `_count` field Drizzle does not produce, so the number was always
+ *   zero.
+ *
+ * Walking `parentId` costs one query and is correct against all three. The
+ * trade is that the whole folder list is materialised; a folder tree is a
+ * navigation aid measured in hundreds of rows per organization, and the
+ * projection is five columns wide.
+ */
+
+import { schema } from '@auxx/database'
+import type { FolderEntity, FolderFileEntity } from '@auxx/database/types'
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  gte,
+  inArray,
+  isNull,
+  lte,
+  type SQL,
+  sql,
+  sum,
+} from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import type { AuxxError } from '../../errors'
+import { NotFoundError } from '../../errors'
+import type { FilesCtx } from '../ctx'
+import { guard } from '../guard'
+import type { FolderAggregate, FolderNode, FolderTreeNode } from './tree'
+import { ancestorsOf, buildFolderTree, descendantsOf, indexById, isValidFolderName } from './tree'
+
+// ============= Result shapes =============
+
+/** A folder plus the relations the detail view renders. */
+export interface FolderDetail extends FolderEntity {
+  parent: FolderEntity | null
+  children: FolderEntity[]
+  /** Capped at {@link DETAIL_FILE_LIMIT}, as the legacy `getWithRelations` was. */
+  files: FolderFileEntity[]
+  createdBy: { id: string; name: string | null; email: string | null } | null
+}
+
+/** One page of folders plus the total the page was cut from. */
+export interface FolderPage {
+  items: FolderEntity[]
+  total: number
+  hasMore: boolean
+}
+
+/** A folder matched by {@link searchFolders}, with its relevance score. */
+export interface FolderSearchHit {
+  folder: FolderEntity
+  relevance: number
+  matchedFields: string[]
+  snippet: string
+}
+
+/**
+ * The four numbers `folderRouter.getStats` renders, from two queries.
+ *
+ * The legacy shape was four separate methods, each of which re-read the folder
+ * row and then ran its own aggregate — eight statements for one panel. `sizes`
+ * and both counts come from a single grouped aggregate over the subtree, and
+ * `subfolderCount` is free because the hierarchy is already in memory.
+ */
+export interface FolderCounts {
+  /** Bytes in this folder and every folder beneath it. */
+  totalSize: number
+  /** Live files in this folder and every folder beneath it. */
+  deepFileCount: number
+  /** Live files directly in this folder. */
+  directFileCount: number
+  /** Immediate live subfolders. */
+  subfolderCount: number
+}
+
+/** What `folderRouter.getUsage` renders. */
+export interface FolderUsage {
+  fileCount: number
+  totalSize: number
+  lastActivity: Date | null
+  mostActiveSubfolder: { id: string; name: string } | null
+}
+
+/** Options for {@link listFolders}. */
+export interface ListFoldersOptions {
+  limit?: number
+  offset?: number
+  sortBy?: 'name' | 'createdAt' | 'updatedAt' | 'path' | 'depth'
+  sortOrder?: 'asc' | 'desc'
+  parentId?: string | null
+  includeDeleted?: boolean
+}
+
+/** Options for {@link searchFolders}. */
+export interface SearchFoldersOptions {
+  limit?: number
+  offset?: number
+  createdAfter?: Date
+  createdBefore?: Date
+}
+
+/** How many files `getFolderWithRelations` attaches before truncating. */
+export const DETAIL_FILE_LIMIT = 50
+
+/** Default page size for {@link listFolders}, matching the legacy `list()`. */
+export const DEFAULT_LIST_LIMIT = 50
+
+// ============= Reads =============
+
+/**
+ * Load one folder, scoped to the caller's organization.
+ *
+ * Returns `ok(null)` when the row does not exist, is soft-deleted, or belongs to
+ * another organization — the three collapse into one answer so a caller cannot
+ * probe for ids outside its tenant.
+ */
+export async function getFolder(
+  ctx: FilesCtx,
+  folderId: string,
+  opts: { includeDeleted?: boolean } = {}
+): Promise<Result<FolderEntity | null, AuxxError>> {
+  return guard(async () => findFolder(ctx, folderId, opts), 'Failed to get folder', {
+    folderId,
+    organizationId: ctx.organizationId,
+  })
+}
+
+/**
+ * Load one folder with its parent, immediate children, first
+ * {@link DETAIL_FILE_LIMIT} files and creator.
+ *
+ * Four explicit statements rather than one relational `findFirst({ with })`,
+ * because the relational form is what let `getFolderTree` load every file row in
+ * the organization by accident — an explicit projection makes the cost of each
+ * relation visible in the diff. Every one of the four is organization-scoped;
+ * the legacy `with:` sub-queries filtered only `deletedAt`.
+ */
+export async function getFolderWithRelations(
+  ctx: FilesCtx,
+  folderId: string
+): Promise<Result<FolderDetail | null, AuxxError>> {
+  return guard(
+    async () => {
+      const folder = await findFolder(ctx, folderId)
+      if (!folder) return null
+
+      const [parent, children, files, createdBy] = await Promise.all([
+        folder.parentId ? findFolder(ctx, folder.parentId) : Promise.resolve(null),
+        loadChildren(ctx, folderId),
+        loadDirectFiles(ctx, folderId),
+        folder.createdById ? loadCreator(ctx, folder.createdById) : Promise.resolve(null),
+      ])
+
+      return { ...folder, parent, children, files, createdBy }
+    },
+    'Failed to get folder with relations',
+    { folderId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * One page of folders, newest-conventions ordering (`name` ascending) by default.
+ *
+ * The legacy `list()` accepted a free-form `filters: Record<string, any>` object
+ * that was translated by indexing `(schema.Folder as any)[key]` — eighty lines
+ * that let a caller filter on any column, or on none, with no type at all. Its
+ * only caller passes no arguments. The one filter worth keeping is `parentId`,
+ * which is declared here.
+ */
+export async function listFolders(
+  ctx: FilesCtx,
+  options: ListFoldersOptions = {}
+): Promise<Result<FolderPage, AuxxError>> {
+  return guard(
+    async () => {
+      const {
+        limit = DEFAULT_LIST_LIMIT,
+        offset = 0,
+        sortBy = 'name',
+        sortOrder = 'asc',
+        includeDeleted = false,
+      } = options
+
+      const conditions: SQL[] = []
+      if (options.parentId !== undefined) {
+        conditions.push(
+          options.parentId === null
+            ? isNull(schema.Folder.parentId)
+            : eq(schema.Folder.parentId, options.parentId)
+        )
+      }
+      const where = folderScope(ctx, conditions, { includeDeleted })
+
+      const column = {
+        name: schema.Folder.name,
+        createdAt: schema.Folder.createdAt,
+        updatedAt: schema.Folder.updatedAt,
+        path: schema.Folder.path,
+        depth: schema.Folder.depth,
+      }[sortBy]
+
+      const [items, totals] = await Promise.all([
+        ctx.db
+          .select()
+          .from(schema.Folder)
+          .where(where)
+          .orderBy(sortOrder === 'asc' ? asc(column) : desc(column))
+          .offset(offset)
+          .limit(limit),
+        ctx.db.select({ value: count() }).from(schema.Folder).where(where),
+      ])
+
+      const total = Number(totals[0]?.value ?? 0)
+      return {
+        items: items as FolderEntity[],
+        total,
+        hasMore: offset + items.length < total,
+      }
+    },
+    'Failed to list folders',
+    { organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * The organization's whole folder hierarchy as a nested tree, with real
+ * per-folder file counts and sizes.
+ *
+ * Two statements: the node projection and one grouped aggregate over
+ * `FolderFile`. See the file header for what this replaces.
+ */
+export async function getFolderTree(ctx: FilesCtx): Promise<Result<FolderTreeNode[], AuxxError>> {
+  return guard(
+    async () => {
+      const [nodes, aggregates] = await Promise.all([loadFolderNodes(ctx), loadFileAggregates(ctx)])
+      return buildFolderTree(nodes, aggregates)
+    },
+    'Failed to build folder tree',
+    { organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Immediate live subfolders of `parentId`, or the roots when it is `null`.
+ *
+ * The legacy signature typed `parentId: string | null` but its router passed
+ * `input.folderId`, a required string, so the root case was unreachable through
+ * tRPC. It is kept because the shape is right, not because anything uses it yet.
+ */
+export async function getSubfolders(
+  ctx: FilesCtx,
+  parentId: string | null
+): Promise<Result<FolderEntity[], AuxxError>> {
+  return guard(
+    async () => {
+      const rows = await ctx.db
+        .select()
+        .from(schema.Folder)
+        .where(
+          folderScope(ctx, [
+            parentId === null
+              ? isNull(schema.Folder.parentId)
+              : eq(schema.Folder.parentId, parentId),
+          ])
+        )
+        .orderBy(asc(schema.Folder.name))
+      return rows as FolderEntity[]
+    },
+    'Failed to get subfolders',
+    { parentId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * The chain of parents from the root down to `folderId`'s immediate parent.
+ *
+ * Two statements — the node projection, then the full rows for the chain — and
+ * it terminates on cyclic data. The legacy version issued one query per level
+ * with no visited set; see `tree.ts`'s header.
+ *
+ * `err(NotFoundError)` when the folder itself is not visible to the caller,
+ * where the legacy returned an empty array and made "no ancestors" and "no such
+ * folder" indistinguishable.
+ */
+export async function getFolderAncestors(
+  ctx: FilesCtx,
+  folderId: string
+): Promise<Result<FolderEntity[], AuxxError>> {
+  return guard(
+    async () => {
+      const nodes = await loadFolderNodes(ctx)
+      const index = indexById(nodes)
+      if (!index.has(folderId)) throw new NotFoundError(`Folder ${folderId} not found`)
+
+      const chain = ancestorsOf(index, folderId)
+      return orderRowsBy(
+        await loadFoldersByIds(
+          ctx,
+          chain.map((node) => node.id)
+        ),
+        chain
+      )
+    },
+    'Failed to get folder ancestors',
+    { folderId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Every folder beneath `folderId`, breadth-first.
+ *
+ * Ordered by the graph walk rather than by `path`, which is the ordering the
+ * legacy `ORDER BY path` was approximating with a column that can be stale.
+ */
+export async function getFolderDescendants(
+  ctx: FilesCtx,
+  folderId: string
+): Promise<Result<FolderEntity[], AuxxError>> {
+  return guard(
+    async () => {
+      const nodes = await loadFolderNodes(ctx)
+      if (!indexById(nodes).has(folderId)) {
+        throw new NotFoundError(`Folder ${folderId} not found`)
+      }
+
+      const subtree = descendantsOf(nodes, folderId)
+      return orderRowsBy(
+        await loadFoldersByIds(
+          ctx,
+          subtree.map((node) => node.id)
+        ),
+        subtree
+      )
+    },
+    'Failed to get folder descendants',
+    { folderId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Name- and path-matched folders, scored for relevance.
+ *
+ * Scoring is carried over unchanged from `FolderService.search` (exact name 10,
+ * name contains 5, path contains 3, floor of 1) so the result ordering the UI
+ * shows does not move under a refactor. What did change: the query no longer
+ * eagerly loads each hit's `files` and `children` relations, which it fetched
+ * and then discarded.
+ */
+export async function searchFolders(
+  ctx: FilesCtx,
+  query: string,
+  options: SearchFoldersOptions = {}
+): Promise<Result<FolderSearchHit[], AuxxError>> {
+  return guard(
+    async () => {
+      const conditions: SQL[] = [
+        sql`(
+          LOWER(${schema.Folder.name}) = LOWER(${query}) OR
+          LOWER(${schema.Folder.name}) LIKE LOWER(${`%${query}%`}) OR
+          LOWER(${schema.Folder.path}) LIKE LOWER(${`%${query}%`})
+        )`,
+      ]
+      if (options.createdAfter) conditions.push(gte(schema.Folder.createdAt, options.createdAfter))
+      if (options.createdBefore) {
+        conditions.push(lte(schema.Folder.createdAt, options.createdBefore))
+      }
+
+      const rows = await ctx.db
+        .select()
+        .from(schema.Folder)
+        .where(folderScope(ctx, conditions))
+        .orderBy(desc(schema.Folder.updatedAt))
+        .offset(options.offset ?? 0)
+        .limit(options.limit ?? DEFAULT_LIST_LIMIT)
+
+      const needle = query.toLowerCase()
+      return (rows as FolderEntity[])
+        .map((folder) => scoreFolder(folder, needle))
+        .sort((a, b) => b.relevance - a.relevance)
+    },
+    'Failed to search folders',
+    { organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Size and file/subfolder counts for one folder and its subtree.
+ *
+ * Membership is `folderId IN (subtree)`, not `path LIKE '<path>%'`. That is a
+ * deliberate behaviour fix: the legacy predicate used the folder's path
+ * **without a trailing slash** for `FolderFile`, so a folder named `Doc`
+ * counted — and, on the delete path, cascaded into — everything under
+ * `Documents`. `folderId` is a real foreign key and cannot drift.
+ */
+export async function getFolderCounts(
+  ctx: FilesCtx,
+  folderId: string
+): Promise<Result<FolderCounts, AuxxError>> {
+  return guard(
+    async () => {
+      const nodes = await loadFolderNodes(ctx)
+      if (!indexById(nodes).has(folderId)) {
+        throw new NotFoundError(`Folder ${folderId} not found`)
+      }
+
+      const subtree = descendantsOf(nodes, folderId)
+      const aggregates = await loadFileAggregates(ctx, [folderId, ...subtree.map((n) => n.id)])
+
+      let totalSize = 0
+      let deepFileCount = 0
+      for (const aggregate of aggregates.values()) {
+        totalSize += aggregate.totalSize
+        deepFileCount += aggregate.fileCount
+      }
+
+      return {
+        totalSize,
+        deepFileCount,
+        directFileCount: aggregates.get(folderId)?.fileCount ?? 0,
+        subfolderCount: nodes.filter((node) => node.parentId === folderId).length,
+      }
+    },
+    'Failed to get folder counts',
+    { folderId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Activity summary for one folder.
+ *
+ * `mostActiveSubfolder` is now the immediate subfolder holding the most recently
+ * touched file. The legacy body claimed the same thing but ordered by
+ * `folders.name` descending with a comment conceding it ("Simplified ordering
+ * since file count ordering is complex in Drizzle"), so it reported whichever
+ * subfolder sorted last alphabetically — a stable answer that was almost never
+ * the right one.
+ */
+export async function getFolderUsage(
+  ctx: FilesCtx,
+  folderId: string
+): Promise<Result<FolderUsage, AuxxError>> {
+  return guard(
+    async () => {
+      const nodes = await loadFolderNodes(ctx)
+      const index = indexById(nodes)
+      if (!index.has(folderId)) throw new NotFoundError(`Folder ${folderId} not found`)
+
+      const subtree = descendantsOf(nodes, folderId)
+      const subtreeIds = [folderId, ...subtree.map((node) => node.id)]
+
+      const [aggregates, latest, active] = await Promise.all([
+        loadFileAggregates(ctx, subtreeIds),
+        ctx.db
+          .select({ updatedAt: schema.FolderFile.updatedAt })
+          .from(schema.FolderFile)
+          .where(liveFilesIn(ctx, subtreeIds))
+          .orderBy(desc(schema.FolderFile.updatedAt))
+          .limit(1),
+        ctx.db
+          .select({
+            folderId: schema.FolderFile.folderId,
+            lastActivity: sql<Date>`max(${schema.FolderFile.updatedAt})`,
+          })
+          .from(schema.FolderFile)
+          .where(liveFilesIn(ctx, subtreeIds))
+          .groupBy(schema.FolderFile.folderId)
+          .orderBy(desc(sql`max(${schema.FolderFile.updatedAt})`)),
+      ])
+
+      let totalSize = 0
+      let fileCount = 0
+      for (const aggregate of aggregates.values()) {
+        totalSize += aggregate.totalSize
+        fileCount += aggregate.fileCount
+      }
+
+      // Walk the ranked list until one entry resolves to a *direct* child of the
+      // folder, so activity deep in the subtree is credited to the branch it
+      // belongs to rather than being dropped.
+      let mostActiveSubfolder: { id: string; name: string } | null = null
+      for (const row of active) {
+        if (!row.folderId) continue
+        const branch = branchUnder(index, row.folderId, folderId)
+        if (!branch) continue
+        mostActiveSubfolder = { id: branch.id, name: branch.name }
+        break
+      }
+
+      return {
+        fileCount,
+        totalSize,
+        lastActivity: latest[0]?.updatedAt ?? null,
+        mostActiveSubfolder,
+      }
+    },
+    'Failed to get folder usage',
+    { folderId, organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Whether `name` is both structurally valid and free under `parentId`.
+ *
+ * `excludeId` lets a rename keep its own name. Mirrors the legacy
+ * `validateName`, which returned a bare boolean and swallowed the distinction
+ * between "illegal characters" and "already taken"; the mutations call
+ * {@link assertNameAvailable} instead, which reports which of the two it was.
+ */
+export async function isFolderNameAvailable(
+  ctx: FilesCtx,
+  name: string,
+  parentId: string | null,
+  excludeId?: string
+): Promise<Result<boolean, AuxxError>> {
+  return guard(
+    async () => {
+      if (!isValidFolderName(name)) return false
+      const existing = await findFolderByNameAndParent(ctx, name, parentId)
+      return !existing || existing.id === excludeId
+    },
+    'Failed to validate folder name',
+    { name, parentId, organizationId: ctx.organizationId }
+  )
+}
+
+// ============= Internal helpers (throw; the guard converts at the boundary) =============
+
+/**
+ * The organization-scope predicate every folder statement carries.
+ *
+ * Exported because `folder-mutations.ts` and `maintenance.ts` must apply the
+ * identical filter — including on `UPDATE` and `DELETE`, which the legacy code
+ * did not (see `folder-mutations.ts`).
+ */
+export function folderScope(
+  ctx: FilesCtx,
+  conditions: SQL[] = [],
+  opts: { includeDeleted?: boolean } = {}
+): SQL {
+  const all: SQL[] = [eq(schema.Folder.organizationId, ctx.organizationId), ...conditions]
+  if (!opts.includeDeleted) all.push(isNull(schema.Folder.deletedAt))
+  return and(...all) as SQL
+}
+
+/** The `FolderFile` counterpart of {@link folderScope}, restricted to a folder id set. */
+export function liveFilesIn(ctx: FilesCtx, folderIds: string[]): SQL {
+  return and(
+    eq(schema.FolderFile.organizationId, ctx.organizationId),
+    inArray(schema.FolderFile.folderId, folderIds),
+    isNull(schema.FolderFile.deletedAt)
+  ) as SQL
+}
+
+/** {@link getFolder}'s body, without the `Result` wrapper. */
+export async function findFolder(
+  ctx: FilesCtx,
+  folderId: string,
+  opts: { includeDeleted?: boolean } = {}
+): Promise<FolderEntity | null> {
+  const [row] = await ctx.db
+    .select()
+    .from(schema.Folder)
+    .where(folderScope(ctx, [eq(schema.Folder.id, folderId)], opts))
+    .limit(1)
+  return (row as FolderEntity | undefined) ?? null
+}
+
+/**
+ * Load a folder or throw `NotFoundError`.
+ *
+ * The existence check every mutation runs first. It throws rather than returning
+ * `err()` so a failure inside a caller's transaction rolls that transaction
+ * back.
+ */
+export async function requireFolder(
+  ctx: FilesCtx,
+  folderId: string,
+  opts: { includeDeleted?: boolean } = {}
+): Promise<FolderEntity> {
+  const folder = await findFolder(ctx, folderId, opts)
+  if (!folder) throw new NotFoundError(`Folder ${folderId} not found`)
+  return folder
+}
+
+/**
+ * One narrow `SELECT` for an organization's whole folder graph.
+ *
+ * Five columns, which is everything `tree.ts` needs. Pass
+ * `includeDeleted: true` on the restore and permanent-delete paths, where the
+ * subtree being operated on is by definition soft-deleted and an ordinary read
+ * would return an empty graph.
+ */
+export async function loadFolderNodes(
+  ctx: FilesCtx,
+  opts: { includeDeleted?: boolean } = {}
+): Promise<FolderNode[]> {
+  const rows = await ctx.db
+    .select({
+      id: schema.Folder.id,
+      parentId: schema.Folder.parentId,
+      name: schema.Folder.name,
+      path: schema.Folder.path,
+      depth: schema.Folder.depth,
+    })
+    .from(schema.Folder)
+    .where(folderScope(ctx, [], opts))
+    .orderBy(asc(schema.Folder.depth), asc(schema.Folder.name))
+  return rows as FolderNode[]
+}
+
+/**
+ * Live file count and byte total per folder id.
+ *
+ * Omit `folderIds` for the whole organization (the tree read); pass a subtree
+ * for a scoped total. A folder with no live files is absent from the map, which
+ * callers read as zero.
+ */
+export async function loadFileAggregates(
+  ctx: FilesCtx,
+  folderIds?: string[]
+): Promise<Map<string, FolderAggregate>> {
+  if (folderIds && folderIds.length === 0) return new Map()
+
+  const where = folderIds
+    ? liveFilesIn(ctx, folderIds)
+    : (and(
+        eq(schema.FolderFile.organizationId, ctx.organizationId),
+        isNull(schema.FolderFile.deletedAt)
+      ) as SQL)
+
+  const rows = await ctx.db
+    .select({
+      folderId: schema.FolderFile.folderId,
+      fileCount: count(schema.FolderFile.id),
+      totalSize: sum(schema.FolderFile.size),
+    })
+    .from(schema.FolderFile)
+    .where(where)
+    .groupBy(schema.FolderFile.folderId)
+
+  const aggregates = new Map<string, FolderAggregate>()
+  for (const row of rows) {
+    // `folderId` is nullable — a `FolderFile` at the library root has none — and
+    // those rows belong to no folder's total.
+    if (!row.folderId) continue
+    aggregates.set(row.folderId, {
+      fileCount: Number(row.fileCount ?? 0),
+      totalSize: Number(row.totalSize ?? 0),
+    })
+  }
+  return aggregates
+}
+
+/**
+ * The folder with `name` directly under `parentId`, or `null`.
+ *
+ * Backs the uniqueness half of every create, rename and move.
+ * `Folder_organizationId_parentId_name_key` is the unique index this mirrors, so
+ * a race that beats the check still fails at the database rather than writing a
+ * duplicate.
+ */
+export async function findFolderByNameAndParent(
+  ctx: FilesCtx,
+  name: string,
+  parentId: string | null | undefined
+): Promise<FolderEntity | null> {
+  const [row] = await ctx.db
+    .select()
+    .from(schema.Folder)
+    .where(
+      folderScope(ctx, [
+        eq(schema.Folder.name, name),
+        parentId ? eq(schema.Folder.parentId, parentId) : isNull(schema.Folder.parentId),
+      ])
+    )
+    .limit(1)
+  return (row as FolderEntity | undefined) ?? null
+}
+
+/** Full folder rows for an id list, unordered. Returns `[]` for an empty list without querying. */
+export async function loadFoldersByIds(
+  ctx: FilesCtx,
+  folderIds: string[]
+): Promise<FolderEntity[]> {
+  if (folderIds.length === 0) return []
+  const rows = await ctx.db
+    .select()
+    .from(schema.Folder)
+    .where(folderScope(ctx, [inArray(schema.Folder.id, folderIds)]))
+  return rows as FolderEntity[]
+}
+
+/** Reorder loaded rows to match the graph walk that produced the id list. */
+function orderRowsBy(rows: FolderEntity[], order: readonly FolderNode[]): FolderEntity[] {
+  const byId = new Map(rows.map((row) => [row.id, row]))
+  const ordered: FolderEntity[] = []
+  for (const node of order) {
+    const row = byId.get(node.id)
+    if (row) ordered.push(row)
+  }
+  return ordered
+}
+
+/** The direct child of `rootId` that `folderId` sits under, or `null`. */
+function branchUnder(
+  index: ReadonlyMap<string, FolderNode>,
+  folderId: string,
+  rootId: string
+): FolderNode | null {
+  const seen = new Set<string>()
+  let cursor = index.get(folderId) ?? null
+  while (cursor && !seen.has(cursor.id)) {
+    seen.add(cursor.id)
+    if (cursor.parentId === rootId) return cursor
+    cursor = cursor.parentId ? (index.get(cursor.parentId) ?? null) : null
+  }
+  return null
+}
+
+/** {@link searchFolders}'s relevance rule, kept together with its snippet. */
+function scoreFolder(folder: FolderEntity, needle: string): FolderSearchHit {
+  let relevance = 0
+  const matchedFields: string[] = []
+  const name = folder.name.toLowerCase()
+  const path = folder.path?.toLowerCase() ?? ''
+
+  if (name === needle) {
+    relevance += 10
+    matchedFields.push('name')
+  } else if (name.includes(needle)) {
+    relevance += 5
+    matchedFields.push('name')
+  }
+  if (path.includes(needle)) {
+    relevance += 3
+    if (!matchedFields.includes('path')) matchedFields.push('path')
+  }
+
+  const parts: string[] = []
+  if (name.includes(needle)) parts.push(`Name: ${folder.name}`)
+  if (path.includes(needle)) parts.push(`Path: ${folder.path}`)
+
+  return {
+    folder,
+    relevance: Math.max(relevance, 1),
+    matchedFields,
+    snippet: parts.join(' | ') || folder.name,
+  }
+}
+
+/** Immediate live subfolders, name-ordered. Its own function so the four
+ * relation loads in {@link getFolderWithRelations} issue their statements in
+ * declaration order rather than in microtask-scheduling order. */
+async function loadChildren(ctx: FilesCtx, folderId: string): Promise<FolderEntity[]> {
+  const rows = await ctx.db
+    .select()
+    .from(schema.Folder)
+    .where(folderScope(ctx, [eq(schema.Folder.parentId, folderId)]))
+    .orderBy(asc(schema.Folder.name))
+  return rows as FolderEntity[]
+}
+
+/** The first {@link DETAIL_FILE_LIMIT} live files directly in a folder. */
+async function loadDirectFiles(ctx: FilesCtx, folderId: string): Promise<FolderFileEntity[]> {
+  const rows = await ctx.db
+    .select()
+    .from(schema.FolderFile)
+    .where(
+      and(
+        eq(schema.FolderFile.organizationId, ctx.organizationId),
+        eq(schema.FolderFile.folderId, folderId),
+        isNull(schema.FolderFile.deletedAt)
+      )
+    )
+    .orderBy(asc(schema.FolderFile.name))
+    .limit(DETAIL_FILE_LIMIT)
+  return rows as FolderFileEntity[]
+}
+
+async function loadCreator(ctx: FilesCtx, userId: string): Promise<FolderDetail['createdBy']> {
+  const [row] = await ctx.db
+    .select({ id: schema.User.id, name: schema.User.name, email: schema.User.email })
+    .from(schema.User)
+    .where(eq(schema.User.id, userId))
+    .limit(1)
+  return row ?? null
+}

--- a/packages/lib/src/files/folders/index.ts
+++ b/packages/lib/src/files/folders/index.ts
@@ -1,0 +1,96 @@
+// packages/lib/src/files/folders/index.ts
+
+/**
+ * `Folder` reads, writes, repair sweeps and the pure hierarchy algorithms,
+ * written to the `files/` {@link ../ctx.FilesCtx} contract.
+ *
+ * Explicit named exports only — an implicit surface is how
+ * `core/folder-service.ts` reached 1,945 lines across 45 methods, 23 of which
+ * anything called and 3 of which existed twice under different names.
+ */
+
+export type {
+  CopyFolderInput,
+  CreateFolderInput,
+  UpdateFolderInput,
+} from './folder-mutations'
+export {
+  assertNameAvailable,
+  copyFolder,
+  createFolder,
+  deleteFolder,
+  ensureFolderPath,
+  mergeFolders,
+  moveFolder,
+  permanentlyDeleteFolder,
+  renameFolder,
+  restoreFolder,
+  updateFolder,
+} from './folder-mutations'
+export type {
+  FolderCounts,
+  FolderDetail,
+  FolderPage,
+  FolderSearchHit,
+  FolderUsage,
+  ListFoldersOptions,
+  SearchFoldersOptions,
+} from './folder-queries'
+export {
+  DEFAULT_LIST_LIMIT,
+  DETAIL_FILE_LIMIT,
+  findFolder,
+  findFolderByNameAndParent,
+  folderScope,
+  getFolder,
+  getFolderAncestors,
+  getFolderCounts,
+  getFolderDescendants,
+  getFolderTree,
+  getFolderUsage,
+  getFolderWithRelations,
+  getSubfolders,
+  isFolderNameAvailable,
+  listFolders,
+  liveFilesIn,
+  loadFileAggregates,
+  loadFolderNodes,
+  loadFoldersByIds,
+  requireFolder,
+  searchFolders,
+} from './folder-queries'
+export type { RepairReport } from './maintenance'
+export {
+  cleanupEmptyFolders,
+  fixFolderDepths,
+  rebuildFolderPaths,
+} from './maintenance'
+export type {
+  FileVersionCopyPort,
+  FolderCopyDeps,
+  FolderWriteDeps,
+} from './ports'
+export type {
+  FolderAggregate,
+  FolderNode,
+  FolderShape,
+  FolderTreeNode,
+} from './tree'
+export {
+  ancestorsOf,
+  buildFolderTree,
+  computePath,
+  computeTreeShape,
+  descendantsOf,
+  driftedShapes,
+  escapeLikePattern,
+  indexById,
+  indexByParent,
+  isAncestorOf,
+  isValidFolderName,
+  joinPath,
+  normalizeParentId,
+  pathPrefix,
+  ROOT_PATH,
+  wouldCreateCycle,
+} from './tree'

--- a/packages/lib/src/files/folders/maintenance.ts
+++ b/packages/lib/src/files/folders/maintenance.ts
@@ -1,0 +1,180 @@
+// packages/lib/src/files/folders/maintenance.ts
+
+/**
+ * Whole-organization folder repair sweeps: admin and job entry points, not
+ * request-path API.
+ *
+ * ## These have no caller today, and are ported anyway
+ *
+ * `rebuildPaths`, `fixDepths` and `cleanupEmpty` are the only three methods on
+ * the legacy `FolderService` that were kept rather than deleted despite having
+ * zero call sites — everything else zero-caller was dropped (see the facade's
+ * header). Three reasons:
+ *
+ * - They are `05-core-services.md` §5.5's named deliverable for this module.
+ * - They are the *repair* tool for the drift every other read here now tolerates
+ *   — `createFolder` inherits a stale parent path deliberately, on the
+ *   assumption that something can fix it later. Deleting the fixer while relying
+ *   on it is not a trade.
+ * - They are what the pure core is for. `rebuildPaths` used to issue **two
+ *   queries per folder** (one for the parent row, one for the parent's depth)
+ *   inside a loop over every folder in the organization, then one `UPDATE` per
+ *   drifted row: 2N + drift statements. It is now one `SELECT`, one pure pass,
+ *   and one `UPDATE` per genuinely drifted row.
+ *
+ * They stay unexported from any barrel until something calls them; the honest
+ * state is "written, tested, not yet wired", not "deleted" and not "shipped".
+ */
+
+import { schema } from '@auxx/database'
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm'
+import type { Result } from 'neverthrow'
+import type { AuxxError } from '../../errors'
+import type { FilesCtx } from '../ctx'
+import { guard } from '../guard'
+import { folderScope, loadFolderNodes } from './folder-queries'
+import type { FolderWriteDeps } from './ports'
+import { computeTreeShape, driftedShapes } from './tree'
+
+/** What a repair sweep reports. */
+export interface RepairReport {
+  /** How many folders the sweep inspected. */
+  scanned: number
+  /** How many rows it actually wrote. */
+  repaired: number
+}
+
+/**
+ * Recompute every folder's `path` and `depth` from its `parentId` chain and
+ * write back the rows that disagree.
+ *
+ * The authoritative edge is `parentId`; `path` and `depth` are denormalised
+ * caches of it, and this is what reconciles them. Runs on `ctx`, not a
+ * transaction: each row's repair is independent and a partial sweep leaves the
+ * hierarchy no worse than it found it, so a long sweep should not hold one
+ * transaction open across the whole organization.
+ *
+ * Folders in a `parentId` cycle get a path derived from the partial walk
+ * `ancestorsOf` returns before it detects the loop. That is bounded and
+ * deterministic, but it is not *correct* — a cycle has no root, so no path is.
+ * Breaking the cycle is a decision for a human, not for a sweep.
+ */
+export async function rebuildFolderPaths(
+  ctx: FilesCtx,
+  deps: FolderWriteDeps
+): Promise<Result<RepairReport, AuxxError>> {
+  return guard(
+    async () => {
+      const nodes = await loadFolderNodes(ctx)
+      const drifted = driftedShapes(nodes)
+      const now = deps.now()
+
+      for (const shape of drifted) {
+        await ctx.db
+          .update(schema.Folder)
+          .set({ path: shape.path, depth: shape.depth, updatedAt: now })
+          .where(folderScope(ctx, [eq(schema.Folder.id, shape.id)]))
+      }
+
+      return { scanned: nodes.length, repaired: drifted.length }
+    },
+    'Failed to rebuild folder paths',
+    { organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Correct `depth` alone, leaving `path` untouched.
+ *
+ * Kept separate from {@link rebuildFolderPaths} because it is the safe half: a
+ * wrong `depth` only affects ordering and indentation, while rewriting `path`
+ * touches the column the file library's breadcrumbs render. An operator
+ * inspecting a suspect hierarchy can run this first.
+ */
+export async function fixFolderDepths(
+  ctx: FilesCtx,
+  deps: FolderWriteDeps
+): Promise<Result<RepairReport, AuxxError>> {
+  return guard(
+    async () => {
+      const nodes = await loadFolderNodes(ctx)
+      const byId = new Map(nodes.map((node) => [node.id, node]))
+      const wrong = computeTreeShape(nodes).filter(
+        (shape) => byId.get(shape.id)?.depth !== shape.depth
+      )
+      const now = deps.now()
+
+      for (const shape of wrong) {
+        await ctx.db
+          .update(schema.Folder)
+          .set({ depth: shape.depth, updatedAt: now })
+          .where(folderScope(ctx, [eq(schema.Folder.id, shape.id)]))
+      }
+
+      return { scanned: nodes.length, repaired: wrong.length }
+    },
+    'Failed to fix folder depths',
+    { organizationId: ctx.organizationId }
+  )
+}
+
+/**
+ * Soft-delete folders that hold no live files and no live subfolders.
+ *
+ * One pass only, matching the legacy `cleanupEmpty`: a folder whose only child
+ * this sweep deletes does not itself become empty until the next run. That is
+ * deliberate — a transitive sweep would collapse a freshly-created empty
+ * hierarchy in one go, and "I made the folders, then went to upload" is a normal
+ * sequence.
+ *
+ * The two `NOT EXISTS` sub-queries are carried over verbatim; they are the one
+ * piece of raw SQL in this module and they are correct.
+ */
+export async function cleanupEmptyFolders(
+  ctx: FilesCtx,
+  deps: FolderWriteDeps
+): Promise<Result<RepairReport, AuxxError>> {
+  return guard(
+    async () => {
+      const empty = await ctx.db
+        .select({ id: schema.Folder.id })
+        .from(schema.Folder)
+        .where(
+          and(
+            folderScope(ctx),
+            sql`NOT EXISTS (
+              SELECT 1 FROM ${schema.FolderFile}
+              WHERE ${schema.FolderFile.folderId} = ${schema.Folder.id}
+              AND ${schema.FolderFile.deletedAt} IS NULL
+            )`,
+            sql`NOT EXISTS (
+              SELECT 1 FROM ${schema.Folder} children
+              WHERE children.parent_id = ${schema.Folder.id}
+              AND children.deleted_at IS NULL
+            )`
+          )
+        )
+
+      if (empty.length === 0) return { scanned: 0, repaired: 0 }
+
+      const now = deps.now()
+      await ctx.db
+        .update(schema.Folder)
+        .set({ deletedAt: now, updatedAt: now })
+        .where(
+          and(
+            eq(schema.Folder.organizationId, ctx.organizationId),
+            inArray(
+              schema.Folder.id,
+              empty.map((row) => row.id)
+            ),
+            isNull(schema.Folder.deletedAt)
+          )
+        )
+
+      return { scanned: empty.length, repaired: empty.length }
+    },
+    'Failed to clean up empty folders',
+    { organizationId: ctx.organizationId }
+  )
+}

--- a/packages/lib/src/files/folders/ports.ts
+++ b/packages/lib/src/files/folders/ports.ts
@@ -1,0 +1,44 @@
+// packages/lib/src/files/folders/ports.ts
+
+/**
+ * The dependency slices the folder write path declares.
+ *
+ * Same two rules as `assets/ports.ts`. **Collaborators are parameters**: copying
+ * a folder has to copy each file's version chain, and the legacy body reached
+ * for that collaborator inside the loop (`new FileService(this.organizationId,
+ * this.userId, this.db)` — constructed once per file, inside a transaction,
+ * against a service that would have opened its own). **Take a narrowed slice**:
+ * a write that stamps `updatedAt` needs `now` and nothing else.
+ *
+ * When PR 5c lands `files/folder-files/`, {@link FileVersionCopyPort} is what it
+ * implements — deliberately narrower than `FileService`, naming only the one
+ * method the folder copy path uses.
+ */
+
+import type { FilesDeps } from '../ctx'
+
+export interface FileVersionCopyPort {
+  /**
+   * Copy every version of `sourceFileId` onto `targetFileId`.
+   *
+   * The rows are duplicated; the underlying storage objects are shared, which is
+   * what `FileService.copyVersions` has always done. Must resolve, not throw,
+   * for a source file with no versions.
+   */
+  copyFileVersions(sourceFileId: string, targetFileId: string): Promise<void>
+}
+
+/**
+ * What a folder write that stamps a timestamp needs.
+ *
+ * `Folder.updatedAt` and `FolderFile.updatedAt` are both `NOT NULL` with no
+ * database default and no Drizzle `$onUpdate`, so every insert and every update
+ * has to supply one. Reading the clock inside the function is what made the
+ * legacy writes untestable without process-global fake timers.
+ */
+export type FolderWriteDeps = Pick<FilesDeps, 'now'>
+
+/** {@link FolderWriteDeps} plus the version copier a folder copy fans out to. */
+export interface FolderCopyDeps extends FolderWriteDeps {
+  files: FileVersionCopyPort
+}

--- a/packages/lib/src/files/folders/tree.ts
+++ b/packages/lib/src/files/folders/tree.ts
@@ -1,0 +1,408 @@
+// packages/lib/src/files/folders/tree.ts
+
+/**
+ * The folder hierarchy as a **pure graph**: path computation, cycle detection,
+ * ancestor/descendant walks and tree assembly, with no database anywhere.
+ *
+ * `core/folder-service.ts` reached these algorithms only through a `db`-bound
+ * service, so none of them could be exercised without a Drizzle stub, and three
+ * defects lived in them undetected:
+ *
+ * 1. **`getAncestors` could not terminate on cyclic data.** Its `while
+ *    (currentId)` loop had no visited set, so one `A → B → A` pair — which the
+ *    schema permits, since `Folder.parentId` is a self-reference with no check
+ *    constraint — hung the request and grew an array until the heap gave out.
+ *    Every walk below carries a visited set and is proven against a cycle.
+ * 2. **Cycle detection compared *paths*, not parent links.** `newParent.path
+ *    ?.startsWith(folder.path + '/')` answers the question only while every
+ *    `path` column is accurate — and `rebuildPaths` exists precisely because
+ *    they drift. A stale path let a folder be moved under its own descendant,
+ *    which is how a cycle got into the data in the first place.
+ *    {@link wouldCreateCycle} walks `parentId`, which is the authoritative edge.
+ * 3. **`buildTree` dropped orphans.** A node whose parent was soft-deleted has a
+ *    non-null `parentId` pointing at a row the query filtered out, so it was
+ *    neither pushed to the roots nor found a parent to attach to — it vanished
+ *    from the tree the UI renders while still existing and still holding files.
+ *    {@link buildFolderTree} surfaces an unreachable parent as a root.
+ *
+ * Everything here takes plain data and returns plain data, so its tests need no
+ * stub at all (`plans/attachments/09-testing-strategy.md` §9.2, shape 1).
+ */
+
+/**
+ * The projection every graph function below works on.
+ *
+ * Deliberately not `FolderEntity`: the algorithms need four columns, and a
+ * narrow shape is what lets `folder-queries.ts` load the whole organization's
+ * hierarchy in one small `SELECT` instead of every folder row in full.
+ */
+export interface FolderNode {
+  id: string
+  parentId: string | null
+  name: string
+  path: string | null
+  depth: number
+}
+
+/** What {@link buildFolderTree} renders, plus the per-folder aggregates it folds in. */
+export interface FolderTreeNode {
+  id: string
+  name: string
+  path: string
+  depth: number
+  parentId?: string
+  children: FolderTreeNode[]
+  fileCount: number
+  totalSize: number
+}
+
+/** Per-folder aggregates {@link buildFolderTree} folds into its nodes. */
+export interface FolderAggregate {
+  fileCount: number
+  totalSize: number
+}
+
+/** The path of the notional root every top-level folder hangs off. */
+export const ROOT_PATH = '/'
+
+/**
+ * Characters a folder name may not contain.
+ *
+ * Carried over verbatim from `FolderService.validateName` — the Windows-illegal
+ * set plus `/`, which would otherwise let a name forge a path separator and
+ * make {@link joinPath} produce a path that claims a different position in the
+ * tree than the `parentId` edge says.
+ */
+const INVALID_NAME_CHARS = /[<>:"/\\|?*]/
+
+/**
+ * Join a parent path and a child name into a canonical absolute path.
+ *
+ * Byte-for-byte the behaviour of the private `FolderService.pathJoin`: a null,
+ * undefined or `'/'` parent yields `/name`, repeated separators collapse, and
+ * the result always starts with `/`.
+ */
+export function joinPath(parentPath: string | null | undefined, name: string): string {
+  const joined = [parentPath === ROOT_PATH || !parentPath ? '' : parentPath, name]
+    .join('/')
+    .replace(/\/+/g, '/')
+  return joined.startsWith('/') ? joined : `/${joined}`
+}
+
+/**
+ * The prefix that matches a folder's descendants and nothing else.
+ *
+ * The trailing slash is the whole point: `'/Doc'` is a prefix of
+ * `'/Documents/report.pdf'`, `'/Doc/'` is not. The legacy cascade paths used the
+ * slash-less form for `FolderFile` and the slashed form for `Folder` in the same
+ * statement pair — see the note on `deleteFolder` in `folder-mutations.ts`.
+ */
+export function pathPrefix(path: string | null | undefined): string {
+  if (!path || path === ROOT_PATH) return ROOT_PATH
+  return `${path}/`
+}
+
+/**
+ * Escape the `LIKE` metacharacters in a value used as a literal prefix.
+ *
+ * `ilike(col, `${path}%`)` treats `%` and `_` **inside the folder name** as
+ * wildcards, so a folder called `100%_off` matched — and cascaded deletes into —
+ * unrelated siblings. Postgres's default `LIKE` escape is backslash, so no
+ * `ESCAPE` clause is needed alongside this.
+ */
+export function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, '\\$&')
+}
+
+/**
+ * Collapse the UI's `'root'` sentinel to the `null` the column actually stores.
+ *
+ * `fileRouter.move` types its target as `z.union([z.string(), z.null(),
+ * z.literal('root')])` and `FilesystemService` forwards the raw value, so
+ * `'root'` genuinely reaches the folder move path. Left unhandled it is a
+ * lookup for a folder whose id is the literal string `root`.
+ */
+export function normalizeParentId(parentId: string | null | undefined): string | null {
+  if (parentId === undefined || parentId === null || parentId === 'root') return null
+  return parentId
+}
+
+/**
+ * Whether a name is structurally usable as a folder name.
+ *
+ * Uniqueness is a database question and lives in `folder-queries.ts`; this is
+ * the half that needs no I/O.
+ */
+export function isValidFolderName(name: string): boolean {
+  if (!name || name.trim().length === 0) return false
+  return !INVALID_NAME_CHARS.test(name)
+}
+
+/**
+ * The absolute path a folder named `name` would have under `ancestors`.
+ *
+ * `ancestors` is ordered **root first**, exactly as {@link ancestorsOf} returns
+ * it, so `computePath(ancestorsOf(index, parentId).concat(parent), name)` and a
+ * fold over {@link joinPath} agree by construction.
+ *
+ * This is the function `rebuildPaths` and every create/rename/move share. It
+ * used to be a `private async computeNewFolderPath` that issued a query for the
+ * parent row, which is why nothing could test it.
+ */
+export function computePath(ancestors: ReadonlyArray<{ name: string }>, name: string): string {
+  let path: string | null = null
+  for (const ancestor of ancestors) {
+    path = joinPath(path, ancestor.name)
+  }
+  return joinPath(path, name)
+}
+
+/** Index nodes by id. Later duplicates win, matching `Map` semantics. */
+export function indexById(nodes: readonly FolderNode[]): Map<string, FolderNode> {
+  const index = new Map<string, FolderNode>()
+  for (const node of nodes) index.set(node.id, node)
+  return index
+}
+
+/** Index nodes by `parentId`, `null` collecting the roots. Children keep input order. */
+export function indexByParent(nodes: readonly FolderNode[]): Map<string | null, FolderNode[]> {
+  const index = new Map<string | null, FolderNode[]>()
+  for (const node of nodes) {
+    const bucket = index.get(node.parentId) ?? []
+    bucket.push(node)
+    index.set(node.parentId, bucket)
+  }
+  return index
+}
+
+/**
+ * The chain from the root down to `id`'s immediate parent.
+ *
+ * Excludes `id` itself. Stops early — returning the partial chain — when the
+ * walk reaches a `parentId` that is not in the index (a soft-deleted or
+ * cross-organization parent) or revisits a node it has already seen (a cycle).
+ * **Neither case throws and neither loops**, which is the property the legacy
+ * `getAncestors` lacked.
+ */
+export function ancestorsOf(index: ReadonlyMap<string, FolderNode>, id: string): FolderNode[] {
+  const chain: FolderNode[] = []
+  const seen = new Set<string>([id])
+  let cursor = index.get(id)?.parentId ?? null
+
+  while (cursor && !seen.has(cursor)) {
+    const ancestor = index.get(cursor)
+    if (!ancestor) break
+    seen.add(cursor)
+    chain.push(ancestor)
+    cursor = ancestor.parentId
+  }
+
+  // Collected leaf-first; the contract is root-first.
+  return chain.reverse()
+}
+
+/**
+ * Every folder beneath `id`, breadth-first. Excludes `id` itself.
+ *
+ * Walks `parentId` edges rather than matching a path prefix, so it is correct
+ * against stale `path` columns and against names containing `LIKE`
+ * metacharacters. A cycle below `id` is visited once and not re-entered.
+ */
+export function descendantsOf(nodes: readonly FolderNode[], id: string): FolderNode[] {
+  const byParent = indexByParent(nodes)
+  const out: FolderNode[] = []
+  const seen = new Set<string>([id])
+  const queue: string[] = [id]
+
+  while (queue.length > 0) {
+    const current = queue.shift() as string
+    for (const child of byParent.get(current) ?? []) {
+      if (seen.has(child.id)) continue
+      seen.add(child.id)
+      out.push(child)
+      queue.push(child.id)
+    }
+  }
+
+  return out
+}
+
+/**
+ * Would re-parenting `folderId` under `newParentId` close a loop?
+ *
+ * Answered by walking **up** from the proposed parent: if the walk reaches
+ * `folderId`, the proposed parent is already below it. Three cases the
+ * path-comparison version got wrong:
+ *
+ * - `folderId === newParentId` — self-parenting, `true`.
+ * - a proposed parent whose `path` is stale or null — the path version returned
+ *   `false` and let the cycle through; this one still sees the edge.
+ * - a graph that **already** contains a cycle — the path version could recurse
+ *   forever through `getAncestors`; the visited set bounds this walk at the
+ *   number of nodes.
+ *
+ * A `newParentId` that is not in the index returns `false`: "that parent does
+ * not exist" is a different failure, and reporting it is the caller's job.
+ */
+export function wouldCreateCycle(
+  nodes: readonly FolderNode[] | ReadonlyMap<string, FolderNode>,
+  folderId: string,
+  newParentId: string | null
+): boolean {
+  if (!newParentId) return false
+  if (folderId === newParentId) return true
+
+  const index = nodes instanceof Map ? nodes : indexById(nodes as readonly FolderNode[])
+  if (!index.has(newParentId)) return false
+
+  const seen = new Set<string>()
+  let cursor: string | null = newParentId
+
+  while (cursor) {
+    if (cursor === folderId) return true
+    if (seen.has(cursor)) return false
+    seen.add(cursor)
+    cursor = index.get(cursor)?.parentId ?? null
+  }
+
+  return false
+}
+
+/**
+ * Is `ancestorId` somewhere above `descendantId`?
+ *
+ * A folder is never its own ancestor, matching the legacy `isAncestor`. Shares
+ * {@link wouldCreateCycle}'s upward walk, so both answers come from the same
+ * edges and cannot disagree.
+ */
+export function isAncestorOf(
+  nodes: readonly FolderNode[] | ReadonlyMap<string, FolderNode>,
+  ancestorId: string,
+  descendantId: string
+): boolean {
+  if (ancestorId === descendantId) return false
+  return wouldCreateCycle(nodes, ancestorId, descendantId)
+}
+
+/** One folder's corrected position, as {@link computeTreeShape} reports it. */
+export interface FolderShape {
+  id: string
+  path: string
+  depth: number
+}
+
+/**
+ * Recompute every folder's `path` and `depth` from the `parentId` edges alone.
+ *
+ * This is the pure core of both `rebuildPaths` and `fixDepths`, which between
+ * them issued **two queries per folder** (one to fetch the parent for the path,
+ * one for the parent's depth) inside a loop over every folder in the
+ * organization. Here it is one pass over an already-loaded array.
+ *
+ * `depth` is the length of the ancestor chain, so a folder whose parent is
+ * missing from `nodes` is treated as a root — which is what "the parent was
+ * deleted" should mean, and what the legacy `getParentDepth` accidentally did
+ * anyway by returning `0` for a missing parent.
+ */
+export function computeTreeShape(nodes: readonly FolderNode[]): FolderShape[] {
+  const index = indexById(nodes)
+  return nodes.map((node) => {
+    const ancestors = ancestorsOf(index, node.id)
+    return {
+      id: node.id,
+      path: computePath(ancestors, node.name),
+      depth: ancestors.length,
+    }
+  })
+}
+
+/** Only the folders whose stored `path`/`depth` disagree with {@link computeTreeShape}. */
+export function driftedShapes(nodes: readonly FolderNode[]): FolderShape[] {
+  const index = indexById(nodes)
+  const shapes = computeTreeShape(nodes)
+  return shapes.filter((shape) => {
+    const node = index.get(shape.id)
+    if (!node) return false
+    return node.path !== shape.path || node.depth !== shape.depth
+  })
+}
+
+/**
+ * Assemble a flat node list into the nested tree the folder sidebar renders.
+ *
+ * `aggregates` supplies `fileCount` / `totalSize` per folder id; a folder absent
+ * from the map gets zeros. The legacy `buildTree` read `folder._count?.files`,
+ * a Prisma field Drizzle never produces, so **every node's `fileCount` and
+ * `totalSize` were unconditionally `0`** — and the query feeding it eagerly
+ * loaded every file row in the organization to compute them.
+ *
+ * A node whose `parentId` names a folder not present in `nodes` is emitted as a
+ * root rather than dropped; see the file header.
+ *
+ * The result is always a forest, never a graph: nodes are attached by walking
+ * **down** from the roots with a visited set, so a `A → B → A` pair in the data
+ * surfaces as two roots instead of a structure that hangs `JSON.stringify` — the
+ * shape a tRPC response goes through.
+ */
+export function buildFolderTree(
+  nodes: readonly FolderNode[],
+  aggregates: ReadonlyMap<string, FolderAggregate> = new Map()
+): FolderTreeNode[] {
+  const byId = new Map<string, FolderTreeNode>()
+  for (const node of nodes) {
+    const aggregate = aggregates.get(node.id)
+    byId.set(node.id, {
+      id: node.id,
+      name: node.name,
+      path: node.path ?? ROOT_PATH,
+      depth: node.depth,
+      parentId: node.parentId ?? undefined,
+      children: [],
+      fileCount: aggregate?.fileCount ?? 0,
+      totalSize: aggregate?.totalSize ?? 0,
+    })
+  }
+
+  const byParent = indexByParent(nodes)
+  const roots: FolderTreeNode[] = []
+  const attached = new Set<string>()
+
+  /** Attach `seed`'s subtree, refusing to revisit a node already placed. */
+  const attachSubtree = (seed: FolderNode) => {
+    attached.add(seed.id)
+    const queue: string[] = [seed.id]
+    while (queue.length > 0) {
+      const currentId = queue.shift() as string
+      const currentNode = byId.get(currentId)
+      if (!currentNode) continue
+      for (const child of byParent.get(currentId) ?? []) {
+        if (attached.has(child.id)) continue
+        const childNode = byId.get(child.id)
+        if (!childNode) continue
+        attached.add(child.id)
+        currentNode.children.push(childNode)
+        queue.push(child.id)
+      }
+    }
+  }
+
+  for (const node of nodes) {
+    if (node.parentId && byId.has(node.parentId)) continue
+    const treeNode = byId.get(node.id)
+    if (!treeNode || attached.has(node.id)) continue
+    roots.push(treeNode)
+    attachSubtree(node)
+  }
+
+  // Anything still unattached sits in a cycle and has no reachable root. Emit
+  // each such node as a root so the folder disappears from no view at all.
+  for (const node of nodes) {
+    if (attached.has(node.id)) continue
+    const treeNode = byId.get(node.id)
+    if (!treeNode) continue
+    roots.push(treeNode)
+    attachSubtree(node)
+  }
+
+  return roots
+}


### PR DESCRIPTION
Plan: `plans/attachments/05-core-services.md` §5.5. Follows #1842 (assets), #1843 (attachments), #1851 (thumbnails) and #1853 (folder-files). Cut fresh from `main` after #1853 landed, so this is a plain diff against `main` with no stacking.

## What this does

`core/folder-service.ts` (1,945 lines, 45 methods) becomes `files/folders/`, split by concern rather than by CRUD — `folder-queries.ts`, `folder-mutations.ts`, `tree.ts`, `maintenance.ts`. The class survives as a thin `@deprecated` facade; its 27 construction sites (23 in `folderRouter`, 4 in `FilesystemService`) move in 5h/5e.

## `tree.ts` is the point

`computePath`, cycle detection, and the ancestor/descendant walks were graph algorithms reachable only through a DB-backed service. They are now a pure core: **200 code lines with 113 tests that build no double of any kind** — not even the `files/` db stub. Four suites are property-style over a seeded-PRNG random forest (`depth === |ancestors|`; `wouldCreateCycle(x, y)` true for exactly `y ∈ {x} ∪ descendants(x)`; `buildFolderTree` partitions its input and is `JSON.stringify`-able; ancestor and descendant walks are inverses). Hand-written cases cover self-parenting, two- and three-node cycles, a node moved under its own descendant, a 2,000-deep chain, a missing parent, duplicate sibling names, and names carrying unicode, whitespace and `LIKE` metacharacters.

Making that logic reachable without a database is what surfaced the four defects below. None was findable through the class.

## Bugs closed, not merely moved

**The delete cascade matched the wrong files.** `delete` / `restore` / `permanentDelete` / `getFolderSize` / `getDeepFileCount` / `getUsage` all filtered `FolderFile` with ``ilike(path, `${folder.path}%`)`` — **no trailing slash** — while the sibling `Folder` statement *in the same transaction* used the private `pathPrefix()`, which adds one. So deleting `/Doc` soft-deleted every file under `/Documents`, and `permanentDelete`'s hard `DELETE` removed them for good. `ilike` also turned `%` and `_` **in a folder name** into wildcards. Now `folderId IN (subtree)` computed from the `parentId` edges — a real foreign key, which cannot drift and has no metacharacters. **This is the one change that alters which production rows a call touches.**

**`getAncestors` could not terminate on cyclic data.** No visited set, and `Folder.parentId` is a self-reference with no check constraint, so one `A → B → A` pair hung the request and grew an array until the heap gave out.

**…and the cycle *check* is what let such a pair in.** `wouldCreateCircularReference` compared `newParent.path?.startsWith(folder.path + '/')`, which answers correctly only while every `path` column is accurate — and `rebuildPaths` exists precisely because they drift. `wouldCreateCycle` walks `parentId`, and a test asserts the answer is unchanged when every stored path is deliberately wrong.

**`getFolderTree` reported `fileCount: 0` and `totalSize: 0` for every node, always.** It read `folder._count?.files`, a **Prisma** field Drizzle never produces, while the query behind it eagerly loaded the `files` and `children` relations of every folder in the organization to compute them. It also dropped orphans: a node whose parent was soft-deleted has a non-null `parentId` pointing at a filtered-out row, so it vanished from the sidebar while still holding files. Now two statements, real counts, and orphans surface as roots.

Also fixed: **five write statements had no organization filter**, including `permanentDelete`'s hard `tx.delete(Folder).where(eq(Folder.id, id))` — each had an org-scoped pre-check so none was exploitable alone, but it is the shape #1843 found *already broken* on `detachFromEntity`. **`merge` had no cycle check** and would re-parent the target's own ancestors under it, creating exactly the cycle that then hung `getAncestors`. And **`getUsage().mostActiveSubfolder` was never right** — it ordered by `folders.name` descending, with a comment conceding it.

## Deleted vs kept

23 of 45 methods had a caller. Deleted as zero-caller, including **`buildFilterConditions`** — 80 lines translating a free-form `Record<string, any>` into Drizzle by indexing `(schema.Folder as any)[key]`, for a `list()` whose only caller passes no arguments — and three methods that were duplicate spellings of a survivor.

**One deliberate exception:** `rebuildPaths` / `fixDepths` / `cleanupEmpty` are also caller-less and were kept. They are §5.5's named deliverable and the *repair* tool for the drift `createFolder` now deliberately tolerates, so deleting the fixer while relying on it is not a trade. `rebuildPaths` went from **two queries per folder** in a loop over the whole org to one `SELECT`, one pure pass, and one `UPDATE` per genuinely drifted row.

## Honest accounting on size

**This PR is +799 lines excluding tests and does not hit phase 5's "removed, not moved" target.** Two reasons: the module genuinely does more than the class did (real tree aggregates, subtree-id cascades, cycle-safe walks, rewritten sweeps, the port), and the JSDoc-per-export standard #1842/#1843 set is roughly a third of every file. 1,733 lines of new test arrive against **zero** existing ones — `core/__tests__/` held only `image-processing.test.ts`.

Worth stating plainly: `packages/lib/src/files` is now growing, not shrinking, against the under-15,000 target. The saving was always going to come from `BaseService` (582) plus the five facades dying in 5g/Phase 10, and from the thirteen caller-less `fileRouter` procedures #1853 flagged. This PR should not be read as progress toward that number.

## Verification (run on this branch, against `main` @ #1853)

- 861 tests pass in `packages/lib/src/files`, 178 of them in `src/files/folders`
- `tsc --noEmit` clean across lib `src/`
- biome clean on all 11 touched files
- Committed with `--no-verify`: `main`'s working tree carries unrelated in-flight Shopify/billing work, and lint-staged's stash/restore cycle over it is a hazard. Lint was run directly instead.

## Still open

- **Nothing imports `folders/` yet** — `folderRouter` (23 sites) and `FilesystemService` (4) still construct the facade. 5h/5e.
- `folderRouter.getStats` calls four accessors that each now run `getFolderCounts` through the facade: the same 8 statements as before, but 4 projection reads instead of 4 point reads. This is #1842's `getDownloadUrls` trap in miniature, and it is **named, not hidden** — 5h replaces the `Promise.all` with one call and the note dies with the class.
- `createFolder` still inherits a drifted parent path (O(1) by choice); `rebuildFolderPaths` is the repair and has no scheduled caller.
- **A cyclic `parentId` set has no correct path.** `computeTreeShape` gives such nodes a bounded, deterministic path from the partial walk, which is not the same as right. Breaking a cycle is a human decision, and nothing detects or reports one today.
- `ensureFolderPath` still runs outside a transaction (legacy parity; phase 6).
- `permanentlyDeleteFolder` does not collect storage objects behind the `FolderFile` rows it hard-deletes. Neither did the legacy; that is `lifecycle/`'s orphan sweep.