### PR TITLE
fix(billing): sync shopify plan changes to the app ui

### DIFF
--- a/apps/web/src/app/(auth)/shopify/claim/page.tsx
+++ b/apps/web/src/app/(auth)/shopify/claim/page.tsx
@@ -64,10 +64,11 @@ export default async function ShopifyClaimPage({ searchParams }: PageProps) {
   const claim = JSON.parse(raw) as { shop: string }
 
   // Shopify returns the merchant here (via install → OAuth → claim) right after they approve a
-  // plan on the hosted Managed Pricing page. The `app_subscriptions/update` webhook that flips the
-  // row `incomplete → active` may not have arrived yet, so the short-circuit below would read a
-  // stale `incomplete` from cache and re-show the picker. Confirm + sync against the Admin API
-  // first (busts the org cache) so the short-circuit sees the live status on the first return.
+  // plan on the hosted Managed Pricing page — including plan CHANGES on an already-active
+  // subscription, whose post-approval redirect lands on the app URL rather than
+  // /billing/subscription/activated. The `app_subscriptions/update` webhook may not have arrived
+  // yet, so confirm + sync any live Shopify row against the Admin API (busts the org cache) so
+  // both the short-circuit and the app UI see the new plan on the first return.
   const [shopSub] = await database
     .select({
       organizationId: schema.PlanSubscription.organizationId,
@@ -81,7 +82,7 @@ export default async function ShopifyClaimPage({ searchParams }: PageProps) {
       )
     )
     .limit(1)
-  if (shopSub?.status === 'incomplete') {
+  if (shopSub && shopSub.status !== 'canceled') {
     // Short poll: right after approval the Admin API already reflects the contract, so a couple
     // of attempts catch it without making a not-yet-approved merchant wait the full window.
     await confirmAndSyncShopifySubscription({

--- a/apps/web/src/app/(protected)/app/settings/plans/_components/shopify-sync-on-mount.tsx
+++ b/apps/web/src/app/(protected)/app/settings/plans/_components/shopify-sync-on-mount.tsx
@@ -1,0 +1,35 @@
+// apps/web/src/app/(protected)/app/settings/plans/_components/shopify-sync-on-mount.tsx
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { useIsShopifyBilling } from '~/providers/dehydrated-state-provider'
+import { api } from '~/trpc/react'
+
+/**
+ * Self-heal for Shopify-billed orgs: plan changes approved on Shopify's hosted pricing
+ * page reach us via webhook/redirect, but if either is delayed the plans page would show
+ * a stale plan (App Store review rejection 1.2.2). On mount, reconcile the subscription
+ * against the Admin API and refresh the cached queries when anything changed. The server
+ * enforces a per-org 30s cooldown, so reloads are cheap no-ops.
+ */
+export function ShopifySyncOnMount() {
+  const isShopifyBilling = useIsShopifyBilling()
+  const firedRef = useRef(false)
+  const utils = api.useUtils()
+  const syncStatus = api.billing.syncShopifyStatus.useMutation({
+    onSuccess: (result) => {
+      if (result.synced) {
+        void utils.billing.getCurrentSubscription.invalidate()
+      }
+    },
+  })
+
+  useEffect(() => {
+    if (isShopifyBilling && !firedRef.current) {
+      firedRef.current = true
+      syncStatus.mutate()
+    }
+  }, [isShopifyBilling, syncStatus])
+
+  return null
+}

--- a/apps/web/src/app/(protected)/app/settings/plans/page.tsx
+++ b/apps/web/src/app/(protected)/app/settings/plans/page.tsx
@@ -18,6 +18,7 @@ import { BillingDetailsSection } from './_components/billing-details-section'
 import { DemoBillingCycleGuard } from './_components/demo-billing-cycle-guard'
 import { PlanViewTracker } from './_components/plan-view-tracker'
 import { ShopifyAdminBillingBannerWrapper } from './_components/shopify-admin-billing-banner-wrapper'
+import { ShopifySyncOnMount } from './_components/shopify-sync-on-mount'
 import { UpgradeConfetti } from './_components/upgrade-confetti'
 
 export default function PlansPage() {
@@ -30,6 +31,7 @@ export default function PlansPage() {
       <div className='p-3 sm:p-6 space-y-6 sm:space-y-10'>
         <CapabilityPageGuard permissionKey='billing.view' />
         <PlanViewTracker />
+        <ShopifySyncOnMount />
         <UpgradeConfetti />
         <DemoBillingCycleGuard>
           <Suspense fallback={<BillingCycleAlertSkeleton />}>

--- a/apps/web/src/server/api/routers/billing.ts
+++ b/apps/web/src/server/api/routers/billing.ts
@@ -13,6 +13,7 @@ import { getUserOrganizationId } from '@auxx/lib/email'
 import { BadRequestError } from '@auxx/lib/errors'
 import { PermissionKey } from '@auxx/lib/permissions'
 import { createScopedLogger } from '@auxx/logger'
+import { getRedisClient } from '@auxx/redis'
 import { TRPCError } from '@trpc/server'
 import { and, desc, eq, isNull, lt } from 'drizzle-orm'
 import { z } from 'zod'
@@ -110,10 +111,10 @@ export const billingRouter = createTRPCRouter({
 
   /**
    * Reconciles the local PlanSubscription row against the Shopify Admin API
-   * (`currentAppInstallation.activeSubscriptions`). App Pricing delivers no billing
-   * webhooks, so this is the read-path for off-redirect changes; the post-approval
-   * landing route also calls the provider's `syncFromAdminApi` directly. No-op for
-   * non-Shopify orgs.
+   * (`currentAppInstallation.activeSubscriptions`). Called on plans-page mount for
+   * Shopify-billed orgs so the UI self-heals even when the `app_subscriptions/update`
+   * webhook or the post-approval redirect is delayed. Per-org 30s Redis cooldown
+   * (shared with the worker poll). No-op for non-Shopify orgs.
    */
   syncShopifyStatus: billingReadProcedure.mutation(async ({ ctx }) => {
     const organizationId = getUserOrganizationId(ctx.session)
@@ -135,10 +136,21 @@ export const billingRouter = createTRPCRouter({
       return { synced: false, status: row?.status ?? null }
     }
 
+    // Shares the worker poll's per-org cooldown key so page-mount syncs and the
+    // 15-min job don't hammer the Admin API for the same org.
+    const redis = await getRedisClient()
+    const cooldownKey = `shopify-billing-sync:cooldown:${organizationId}`
+    if (redis && (await redis.get(cooldownKey))) {
+      return { synced: false, status: row.status }
+    }
+
     try {
       const provider = getProvider('shopify') as ShopifyBillingProvider
       await provider.syncFromAdminApi(organizationId)
       await onCacheEvent('plan.changed', { orgId: organizationId })
+      if (redis) {
+        await redis.setex(cooldownKey, 30, '1')
+      }
       const [updated] = await ctx.db
         .select({ status: schema.PlanSubscription.status })
         .from(schema.PlanSubscription)

--- a/apps/web/src/server/api/routers/shopify.ts
+++ b/apps/web/src/server/api/routers/shopify.ts
@@ -1,4 +1,9 @@
-import { getProvider, type ShopifyBillingProvider, stripeClient } from '@auxx/billing'
+import {
+  ensureBillingWebhooks,
+  getProvider,
+  type ShopifyBillingProvider,
+  stripeClient,
+} from '@auxx/billing'
 import { listCredentials, setDefaultCredential } from '@auxx/credentials/store'
 import { database as db, schema } from '@auxx/database'
 import { installApp, saveAppConnection } from '@auxx/lib/apps'
@@ -309,6 +314,7 @@ export const shopifyRouter = createTRPCRouter({
         // where to send the merchant based on the existing row. An `incomplete` row means
         // the merchant never approved a plan on Shopify's hosted page — resume plan
         // selection. Any live status (active/trialing/past_due/paused) just opens the workspace.
+        await registerBillingWebhooks(organizationId, claim.shop)
         if (existing.status === 'incomplete') {
           const provider = getProvider('shopify') as ShopifyBillingProvider
           const redirectUrl = await provider.getPlanSelectionUrl(organizationId)
@@ -370,6 +376,11 @@ export const shopifyRouter = createTRPCRouter({
         })
       }
 
+      // Shop-scoped billing webhooks (app_subscriptions/update, app/uninstalled) — the
+      // legacy install flow forbids toml-declared subscriptions, so registration happens
+      // here, per shop, with the token just linked.
+      await registerBillingWebhooks(organizationId, claim.shop)
+
       // Hand back the Shopify hosted pricing-page URL. The merchant picks the plan +
       // interval there, approves, and is redirected to /billing/subscription/activated.
       const provider = getProvider('shopify') as ShopifyBillingProvider
@@ -377,3 +388,20 @@ export const shopifyRouter = createTRPCRouter({
       return { redirectUrl, shop: claim.shop }
     }),
 })
+
+/**
+ * Best-effort shop-scoped billing-webhook registration. Never blocks the install flow —
+ * a missed registration is backstopped by the sync job's daily ensure and the 15-minute
+ * poll itself.
+ */
+async function registerBillingWebhooks(organizationId: string, shop: string): Promise<void> {
+  try {
+    await ensureBillingWebhooks({ shopDomain: shop, organizationId })
+  } catch (error) {
+    logger.warn('Failed to ensure Shopify billing webhooks', {
+      organizationId,
+      shop,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -10,6 +10,7 @@ export {
   type AppPricingInterval,
   type AppSubscriptionStatus,
   createShopifyAdminClient,
+  ensureBillingWebhooks,
   getActiveSubscription,
   type LocalStatus as ShopifyLocalStatus,
   mapActiveSubscriptionToStatus,

--- a/packages/billing/src/providers/shopify/ensure-webhooks.ts
+++ b/packages/billing/src/providers/shopify/ensure-webhooks.ts
@@ -1,0 +1,106 @@
+// packages/billing/src/providers/shopify/ensure-webhooks.ts
+
+import { WEBAPP_URL } from '@auxx/config/server'
+import { configService } from '@auxx/credentials'
+import { getAppConnection } from '@auxx/credentials/connections'
+import { createScopedLogger } from '@auxx/logger'
+import { credentialLock } from '../../credential-lock'
+import { createShopifyAdminClient } from './client'
+
+const logger = createScopedLogger('billing/shopify/ensure-webhooks')
+
+/**
+ * The billing topics the app depends on for near-real-time plan sync. Registered per shop
+ * because the app uses `use_legacy_install_flow`, and Shopify rejects app-specific
+ * (toml-declared) webhook subscriptions in that mode — shop-scoped subscriptions via the
+ * Admin API are the supported alternative.
+ */
+const BILLING_TOPICS = ['APP_SUBSCRIPTIONS_UPDATE', 'APP_UNINSTALLED'] as const
+
+const LIST_QUERY = `#graphql
+  query BillingWebhookSubscriptions {
+    webhookSubscriptions(first: 50, topics: [APP_SUBSCRIPTIONS_UPDATE, APP_UNINSTALLED]) {
+      edges { node { id topic uri } }
+    }
+  }
+`
+
+const CREATE_MUTATION = `#graphql
+  mutation BillingWebhookSubscriptionCreate(
+    $topic: WebhookSubscriptionTopic!
+    $webhookSubscription: WebhookSubscriptionInput!
+  ) {
+    webhookSubscriptionCreate(topic: $topic, webhookSubscription: $webhookSubscription) {
+      webhookSubscription { id }
+      userErrors { field message }
+    }
+  }
+`
+
+/** The endpoint Shopify delivers billing webhooks to (HMAC-verified by the route). */
+function billingWebhookUri(): string {
+  const base = process.env.NGROK_URL || WEBAPP_URL
+  return `${base}/api/apps/shopify/billing-webhook`
+}
+
+/**
+ * Idempotently registers the shop-scoped billing webhook subscriptions
+ * (`app_subscriptions/update`, `app/uninstalled`) for one shop, using the org's stored
+ * app access token. Skips topics already subscribed at the current callback URI, so it is
+ * safe to call on every install finalize and sync-job tick. Throws on Admin API failure —
+ * callers log and continue, since the 15-minute poll still backstops a missed
+ * registration.
+ */
+export async function ensureBillingWebhooks(input: {
+  shopDomain: string
+  organizationId: string
+}): Promise<{ created: string[] }> {
+  const appId = configService.get<string>('SHOPIFY_APP_ID')
+  if (!appId) throw new Error('SHOPIFY_APP_ID must be configured')
+
+  const conn = await getAppConnection(appId, input.organizationId, '', { lock: credentialLock })
+  if (conn.isErr()) throw conn.error
+  const accessToken = conn.value.accessToken
+  if (!accessToken) throw new Error('Shopify connection has no access token')
+
+  const client = createShopifyAdminClient({ shopDomain: input.shopDomain, accessToken })
+  const uri = billingWebhookUri()
+
+  const listRes = (await client.request(LIST_QUERY)) as {
+    data?: { webhookSubscriptions?: { edges?: Array<{ node: { topic: string; uri: string } }> } }
+    errors?: unknown
+  }
+  if (listRes.errors) {
+    throw new Error(`webhookSubscriptions query failed: ${JSON.stringify(listRes.errors)}`)
+  }
+  const existing = (listRes.data?.webhookSubscriptions?.edges ?? []).map((e) => e.node)
+
+  const created: string[] = []
+  for (const topic of BILLING_TOPICS) {
+    if (existing.some((n) => n.topic === topic && n.uri === uri)) continue
+
+    const createRes = (await client.request(CREATE_MUTATION, {
+      variables: { topic, webhookSubscription: { uri } },
+    })) as {
+      data?: { webhookSubscriptionCreate?: { userErrors?: Array<{ message: string }> } }
+      errors?: unknown
+    }
+    const userErrors = createRes.data?.webhookSubscriptionCreate?.userErrors ?? []
+    if (createRes.errors || userErrors.length > 0) {
+      throw new Error(
+        `webhookSubscriptionCreate(${topic}) failed: ${JSON.stringify(createRes.errors ?? userErrors)}`
+      )
+    }
+    created.push(topic)
+  }
+
+  if (created.length > 0) {
+    logger.info('Registered shop-scoped billing webhooks', {
+      shopDomain: input.shopDomain,
+      organizationId: input.organizationId,
+      created,
+      uri,
+    })
+  }
+  return { created }
+}

--- a/packages/billing/src/providers/shopify/index.ts
+++ b/packages/billing/src/providers/shopify/index.ts
@@ -13,6 +13,7 @@ export {
   type SeatDayEventStatus,
 } from './app-events-client'
 export { createShopifyAdminClient } from './client'
+export { ensureBillingWebhooks } from './ensure-webhooks'
 export { extractStoreHandle, ShopifyBillingProvider } from './provider'
 export { reportOrgSeatDay, type SeatDayReport } from './seat-usage'
 export type { LocalStatus } from './status-mapping'

--- a/packages/billing/src/providers/shopify/provider.ts
+++ b/packages/billing/src/providers/shopify/provider.ts
@@ -153,18 +153,11 @@ export class ShopifyBillingProvider implements BillingProvider {
     switch (input.topic) {
       // Subscription created/approved/changed/cancelled on Shopify. Re-read the Admin API
       // for the authoritative contract + plan resolution (reuses syncFromAdminApi).
+      // A sync failure propagates so the route answers 500 and Shopify redelivers —
+      // swallowing it here left the row stale until the 15-min poll (review rejection 1.2.2).
       case 'app_subscriptions/update':
         if (organizationId) {
-          // Don't 500 the webhook on a transient Admin API failure (e.g. token mid-
-          // rotation) — Shopify would retry noisily and the 15-min worker poll backstops.
-          try {
-            await this.syncFromAdminApi(organizationId)
-          } catch (err) {
-            logger.error('syncFromAdminApi failed handling app_subscriptions/update', {
-              organizationId,
-              error: err instanceof Error ? err.message : String(err),
-            })
-          }
+          await this.syncFromAdminApi(organizationId)
         } else {
           logger.warn('app_subscriptions/update for unknown shop', { shopDomain })
         }

--- a/packages/lib/src/jobs/billing/shopify-billing-sync-job.ts
+++ b/packages/lib/src/jobs/billing/shopify-billing-sync-job.ts
@@ -1,6 +1,6 @@
 // packages/lib/src/jobs/billing/shopify-billing-sync-job.ts
 
-import { ShopifyBillingProvider } from '@auxx/billing'
+import { ensureBillingWebhooks, ShopifyBillingProvider } from '@auxx/billing'
 import { database as db, schema } from '@auxx/database'
 import { getRedisClient } from '@auxx/redis'
 import { and, eq, isNotNull, ne } from 'drizzle-orm'
@@ -28,6 +28,10 @@ export interface ShopifyBillingSyncResult {
  *  redirect-landing sync for the same org. */
 const COOLDOWN_PREFIX = 'shopify-billing-sync:cooldown:'
 const COOLDOWN_SECONDS = 30
+
+/** Daily per-org guard for the webhook-registration ensure (2 extra Admin API calls). */
+const WEBHOOKS_ENSURED_PREFIX = 'shopify-billing-webhooks:ensured:'
+const WEBHOOKS_ENSURED_SECONDS = 24 * 60 * 60
 
 /**
  * Reconciles every Shopify-billed org against the Admin API
@@ -77,6 +81,27 @@ export async function shopifyBillingSyncJob(
 
       if (redis) {
         await redis.setex(`${COOLDOWN_PREFIX}${row.organizationId}`, COOLDOWN_SECONDS, '1')
+      }
+
+      // Once a day, ensure the shop-scoped billing webhooks exist (registration lives
+      // per shop because the legacy install flow forbids toml-declared subscriptions).
+      // Backfills shops installed before registration existed; never fails the tick.
+      const ensuredKey = `${WEBHOOKS_ENSURED_PREFIX}${row.organizationId}`
+      if (row.shopifyShopDomain && (!redis || !(await redis.get(ensuredKey)))) {
+        try {
+          await ensureBillingWebhooks({
+            shopDomain: row.shopifyShopDomain,
+            organizationId: row.organizationId,
+          })
+          if (redis) {
+            await redis.setex(ensuredKey, WEBHOOKS_ENSURED_SECONDS, '1')
+          }
+        } catch (err) {
+          logger.warn('ensureBillingWebhooks failed for org', {
+            orgId: row.organizationId,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
       }
     } catch (err) {
       result.errors++


### PR DESCRIPTION
## Why

Shopify App Store review rejection (rule 1.2.2, assessment 2404984): *"plan changes are not updated on the app UI."* Reproduced live — a Starter → Growth upgrade approved on Shopify's hosted pricing page left the app showing Starter for ~9 minutes, until the 15-minute worker poll corrected it.

Root causes (full analysis in `plans/billing/v3/05-plan-change-sync-fix.md`):
1. **No billing webhooks were registered** — the deployed app config only subscribes the three privacy-compliance topics, so `/api/apps/shopify/billing-webhook` was unreachable. (And toml-declared subscriptions turn out to be rejected by `shopify app deploy` while `use_legacy_install_flow = true`.)
2. **The post-approval redirect lands on the app URL** (install → oauth → claim), not `/billing/subscription/activated`, and the claim-page confirm only ran for `incomplete` rows — a plan change leaves the row `trialing`/`active`.
3. The 15-minute poll was the only survivor.

## What

- **`ensureBillingWebhooks`** (`packages/billing/src/providers/shopify/ensure-webhooks.ts`): idempotently registers shop-scoped `APP_SUBSCRIPTIONS_UPDATE` + `APP_UNINSTALLED` subscriptions via Admin API `webhookSubscriptionCreate` — the supported path for legacy-install-flow apps. Called best-effort from `finalizeAppStoreInstall` (both link branches) and once per org per day from `shopifyBillingSyncJob` (Redis guard) to backfill existing installs.
- **Webhook failures now propagate** — the billing-webhook route answers 500 on an Admin API sync failure so Shopify redelivers, instead of silently leaving the row stale.
- **Claim page** confirms + syncs any live Shopify row on return from Shopify, not just `incomplete` ones.
- **Plans page self-heal**: new `ShopifySyncOnMount` reconciles against the Admin API on load via `billing.syncShopifyStatus` (which gained a per-org 30s Redis cooldown shared with the worker poll) and refetches the subscription query — worst-case staleness is one page load.

## Testing

- Biome clean on all changed files; `@auxx/billing` typechecks clean; lib/web typechecks show no errors in touched files (remaining reds are the pre-existing baseline).
- End-to-end retest of rapid plan flips on the dev store planned post-deploy — that run doubles as the proof-of-resolution screencast for the resubmission.