### PR TITLE
refactor(uploader): extract UploadTransport so the orchestration is testable without a network (plan 8a)

### DIFF
--- a/apps/web/src/components/file-upload/stores/__tests__/server-id-kind.test.ts
+++ b/apps/web/src/components/file-upload/stores/__tests__/server-id-kind.test.ts
@@ -1,57 +1,46 @@
 // apps/web/src/components/file-upload/stores/__tests__/server-id-kind.test.ts
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createFakeUploadTransport } from '../../transport/__fixtures__/fake-upload-transport'
 import { useUploadStore } from '../upload-store'
 
 /**
- * `serverFileId` is parked with the UPLOAD SESSION nanoid at session-create time (it is what
- * SSE correlates on) and used to be overwritten only when the completion payload carried an
- * `assetId`. `FileProcessor` returns `{ fileId }` and no `assetId`, so for any entity type
- * served by it — which, before the registry stopped defaulting, included `visit_qc_item` —
- * `serverFileId` stayed the session nanoid and was then reported to callers as
- * `metadata.assetId` (docs/files-upload-architecture-guide.md §11.3).
+ * `serverFileId` is parked with the UPLOAD SESSION nanoid at session-create time and used to be
+ * overwritten only when the completion payload carried an `assetId`. `FileProcessor` returns
+ * `{ fileId }` and no `assetId`, so for any entity type served by it — which, before the registry
+ * stopped defaulting, included `visit_qc_item` — `serverFileId` stayed the session nanoid and was
+ * then reported to callers as `metadata.assetId`
+ * (docs/files-upload-architecture-guide.md §11.3).
  *
  * So: derive `serverFileId` from `assetId ?? fileId`, and record WHICH kind it is.
+ *
+ * Since PR 8a this needs no `fetch` stub and no `vi.mock` of the XHR layer — the completion body
+ * is simply what the substituted transport returns.
  */
-
-vi.mock('../../utils/direct-upload', () => ({
-  directUpload: () => ({
-    abort: () => {},
-    promise: Promise.resolve({ etag: 'etag-1' }),
-  }),
-}))
 
 const SESSION_NANOID = 'ses_nanoid_from_server'
 
-/** Stub the two endpoints `startUpload` hits, with `completion` as the /complete body. */
-function stubFetch(completion: Record<string, unknown>) {
-  const json = (body: unknown) =>
-    Promise.resolve({ ok: true, json: () => Promise.resolve(body) } as Response)
-
-  return vi.fn((input: RequestInfo | URL) => {
-    const url = String(input)
-    if (url.endsWith('/complete')) return json(completion)
-    return json({
-      sessionId: SESSION_NANOID,
-      uploadMethod: 'single',
-      uploadType: 'PUT',
-      presignedUrl: 'https://example.test/put',
-      storageKey: 'org1/visit_qc_item/item1/photo.jpg',
-    })
-  })
-}
-
 async function uploadOne(completion: Record<string, unknown>) {
-  const store = useUploadStore.getState()
-  const sessionId = await store.createSession({
-    entityType: 'visit_qc_item',
-    entityId: 'qci_1',
-  })
+  useUploadStore.getState().setTransport(
+    createFakeUploadTransport({
+      createSession: async (input) => ({
+        sessionId: SESSION_NANOID,
+        storageKey: `org1/visit_qc_item/item1/${input.fileName}`,
+        uploadMethod: 'single',
+        uploadType: 'PUT',
+        presignedUrl: 'https://storage.test/put',
+      }),
+      completeSession: async () => completion,
+    })
+  )
+
+  const sessionId = await useUploadStore
+    .getState()
+    .createSession({ entityType: 'visit_qc_item', entityId: 'qci_1' })
   const file = new File([new Uint8Array(4)], 'photo.jpg', { type: 'image/jpeg' })
   const [fileId] = useUploadStore.getState().addFiles([file], sessionId)
   if (!fileId) throw new Error('file was not added')
 
-  vi.stubGlobal('fetch', stubFetch(completion))
   await useUploadStore.getState().startUpload()
 
   const state = useUploadStore.getState().files[fileId]
@@ -62,10 +51,6 @@ async function uploadOne(completion: Record<string, unknown>) {
 describe('serverFileId derivation on upload completion', () => {
   beforeEach(() => {
     useUploadStore.getState().reset()
-  })
-
-  afterEach(() => {
-    vi.unstubAllGlobals()
   })
 
   it('uses assetId and marks the id as an asset when the processor made a MediaAsset', async () => {

--- a/apps/web/src/components/file-upload/stores/__tests__/upload-transport.test.ts
+++ b/apps/web/src/components/file-upload/stores/__tests__/upload-transport.test.ts
@@ -1,0 +1,178 @@
+// apps/web/src/components/file-upload/stores/__tests__/upload-transport.test.ts
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { httpUploadTransport } from '../../transport'
+import { createFakeUploadTransport } from '../../transport/__fixtures__/fake-upload-transport'
+import { UploadTransportError } from '../../transport/upload-error'
+import { useUploadStore } from '../upload-store'
+
+/**
+ * What the transport seam buys: these assertions are about the *orchestration*
+ * — the concurrency pool, the per-file failure isolation, the status and error
+ * bookkeeping — and none of them stubs `fetch` or matches a URL string.
+ *
+ * `fetch` is stubbed here only to *assert it is never called*.
+ */
+
+function addFiles(sessionId: string, names: string[]): string[] {
+  const files = names.map((name) => new File([new Uint8Array(4)], name, { type: 'image/jpeg' }))
+  return useUploadStore.getState().addFiles(files, sessionId)
+}
+
+async function newSession() {
+  return useUploadStore.getState().createSession({ entityType: 'FILE', entityId: 'fld_1' })
+}
+
+describe('startUpload over a substituted transport', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    useUploadStore.getState().reset()
+    useUploadStore.getState().setTransport(httpUploadTransport)
+    fetchSpy = vi.fn(() => Promise.reject(new Error('the uploader must not call fetch')))
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uploads every file without touching the network', async () => {
+    const transport = createFakeUploadTransport()
+    useUploadStore.getState().setTransport(transport)
+
+    const sessionId = await newSession()
+    const fileIds = addFiles(sessionId, ['a.jpg', 'b.jpg', 'c.jpg'])
+
+    const result = await useUploadStore.getState().startUpload()
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(result.successCount).toBe(3)
+    expect(result.failedCount).toBe(0)
+    expect(transport.createdSessions().map((s) => s.fileName)).toEqual(['a.jpg', 'b.jpg', 'c.jpg'])
+    // Every completion is addressed to the session id its own presign returned.
+    expect(
+      transport
+        .completedSessions()
+        .map((c) => c.sessionId)
+        .sort()
+    ).toEqual(['ses_1', 'ses_2', 'ses_3'])
+
+    const files = useUploadStore.getState().files
+    for (const id of fileIds) {
+      expect(files[id]?.status).toBe('completed')
+      expect(files[id]?.metadata?.serverIdKind).toBe('asset')
+    }
+    expect(useUploadStore.getState().uploading).toBe(false)
+  })
+
+  it('isolates a failure on file 3 of 5 — the other four still complete', async () => {
+    const transport = createFakeUploadTransport({
+      completeSession: async (sessionId, body) => {
+        if (body.storageKey?.endsWith('c.jpg')) {
+          throw new UploadTransportError('Uploaded object is not an image', {
+            status: 422,
+            code: 'VALIDATION_ERROR',
+            errorType: 'validation',
+            retryable: false,
+          })
+        }
+        return { success: true, sessionId, assetId: `ast_${sessionId}` }
+      },
+    })
+    useUploadStore.getState().setTransport(transport)
+    // Two workers over five files: the pool has to keep going past the failure.
+    useUploadStore.getState().updateConfig({ maxConcurrentUploads: 2 })
+
+    const sessionId = await newSession()
+    const fileIds = addFiles(sessionId, ['a.jpg', 'b.jpg', 'c.jpg', 'd.jpg', 'e.jpg'])
+
+    const result = await useUploadStore.getState().startUpload()
+
+    expect(result.successCount).toBe(4)
+    expect(result.failedCount).toBe(1)
+
+    const files = useUploadStore.getState().files
+    const failed = fileIds.map((id) => files[id]).find((f) => f?.status === 'failed')
+    expect(failed?.name).toBe('c.jpg')
+    // The server's own prose, on the file and in the batch result — not a status code.
+    expect(failed?.error).toBe('Uploaded object is not an image')
+    expect(result.results.find((r) => r.filename === 'c.jpg')?.error).toBe(
+      'Uploaded object is not an image'
+    )
+
+    const storeError = useUploadStore.getState().errors.at(-1)
+    expect(storeError?.message).toBe('Uploaded object is not an image')
+    expect(storeError?.code).toBe('VALIDATION_ERROR')
+    expect(useUploadStore.getState().uploading).toBe(false)
+  })
+
+  it('reports the storage-limit prompt when the presign is refused', async () => {
+    const transport = createFakeUploadTransport({
+      createSession: async () => {
+        throw new UploadTransportError(
+          'You have reached your storage limit. Usage: 4.8GB/5GB. Upgrade your plan for more storage.',
+          {
+            status: 403,
+            code: 'USAGE_LIMIT',
+            retryable: false,
+            details: { upgradeRequired: 'true' },
+          }
+        )
+      },
+    })
+    useUploadStore.getState().setTransport(transport)
+
+    const sessionId = await newSession()
+    addFiles(sessionId, ['big.jpg'])
+
+    const result = await useUploadStore.getState().startUpload()
+
+    expect(result.failedCount).toBe(1)
+    const storeError = useUploadStore.getState().errors.at(-1)
+    expect(storeError?.message).toContain('Upgrade your plan for more storage')
+    expect(storeError?.code).toBe('USAGE_LIMIT')
+    expect(storeError?.details?.upgradeRequired).toBe('true')
+    // Nothing was written, so nothing is completed.
+    expect(transport.completedSessions()).toHaveLength(0)
+  })
+
+  it('records the abort handle so cancelUpload can stop an in-flight file', async () => {
+    let settle: (() => void) | undefined
+    const transport = createFakeUploadTransport({
+      uploadObject: (params) => {
+        const promise = new Promise<{ etag: string }>((_resolve, reject) => {
+          settle = () => reject(new Error('Upload aborted'))
+        })
+        return { abort: () => settle?.(), promise }
+      },
+    })
+    useUploadStore.getState().setTransport(transport)
+
+    const sessionId = await newSession()
+    const [fileId] = addFiles(sessionId, ['slow.jpg'])
+    if (!fileId) throw new Error('file was not added')
+
+    const uploading = useUploadStore.getState().startUpload()
+
+    // Wait for the presign to resolve and the handle to be registered.
+    await vi.waitFor(() => {
+      expect(useUploadStore.getState().inFlight[fileId]).toBeDefined()
+    })
+
+    useUploadStore.getState().cancelUpload()
+    await uploading
+
+    expect(useUploadStore.getState().inFlight[fileId]).toBeUndefined()
+    expect(transport.completedSessions()).toHaveLength(0)
+  })
+
+  it('survives a store reset — the transport is wiring, not work', async () => {
+    const transport = createFakeUploadTransport()
+    useUploadStore.getState().setTransport(transport)
+
+    useUploadStore.getState().reset()
+
+    expect(useUploadStore.getState().transport).toBe(transport)
+  })
+})

--- a/apps/web/src/components/file-upload/stores/slices/orchestration-slice.ts
+++ b/apps/web/src/components/file-upload/stores/slices/orchestration-slice.ts
@@ -3,8 +3,9 @@
 import type { BatchUploadResult, EntityType } from '@auxx/lib/files/types'
 import { getEntityConfig } from '@auxx/lib/files/types'
 import type { StateCreator } from 'zustand'
+import type { UploadTransport } from '../../transport'
+import { httpUploadTransport, isUploadTransportError, resolveServerId } from '../../transport'
 import { validateFile } from '../../utils'
-import { directUpload } from '../../utils/direct-upload'
 import { isFileInFlight } from '../file-status'
 import type { CreateSessionOptions, UploadStore } from '../types'
 
@@ -39,6 +40,18 @@ export const cleanupUploader = (uploaderId: string) => {
 export interface OrchestrationSlice {
   // State
   uploading: boolean
+
+  /**
+   * The network seam. Defaults to {@link httpUploadTransport}; tests swap in a fake
+   * with {@link OrchestrationSlice.setTransport} so the orchestration logic can be
+   * exercised without stubbing global `fetch` or matching URL strings.
+   *
+   * It lives on the store rather than in a module-level `let` so it cannot leak
+   * between test files, and it survives `reset()` on purpose — a reset clears the
+   * work, not the wiring.
+   */
+  transport: UploadTransport
+  setTransport: (transport: UploadTransport) => void
 
   // Per-file abort tracking
   inFlight: Record<string, { abort?: () => void }>
@@ -108,6 +121,13 @@ export const createEnhancedOrchestrationSlice: StateCreator<
   // State
   uploading: false,
   inFlight: {} as Record<string, { abort?: () => void }>,
+  transport: httpUploadTransport,
+
+  setTransport: (transport: UploadTransport) => {
+    set((state) => {
+      state.transport = transport
+    })
+  },
 
   /**
    * Session creation with concurrency guard
@@ -607,37 +627,20 @@ export const createEnhancedOrchestrationSlice: StateCreator<
         const file = toUpload[fileIndex++]
         if (!file?.file) return
 
+        const mimeType = file.mimeType || file.file?.type || 'application/octet-stream'
+
         try {
           // 1. Create presigned session (per file)
-          const createResponse = await fetch('/api/files/upload/sessions', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              fileName: file.name,
-              mimeType: file.mimeType || file.file?.type || 'application/octet-stream',
-              expectedSize: file.size,
-              provider: 'S3', // ✅ Use correct credential provider ID
-              entityType: session.entityType, // ✅ Move to root level for API validation
-              entityId: session.entityId, // ✅ Move to root level for API validation
-              // Forward client session metadata to server
-              metadata: session.metadata || {},
-            }),
+          const presignedConfig = await get().transport.createSession({
+            fileName: file.name,
+            mimeType,
+            expectedSize: file.size ?? 0,
+            provider: 'S3',
+            entityType: session.entityType,
+            entityId: session.entityId,
+            // Forward client session metadata to server
+            metadata: session.metadata || {},
           })
-
-          if (!createResponse.ok) {
-            throw new Error(`Session create failed (${createResponse.status})`)
-          }
-
-          const presignedConfig = (await createResponse.json()) as {
-            sessionId: string
-            uploadMethod: 'single' | 'multipart'
-            uploadType?: 'PUT' | 'POST'
-            presignedUrl?: string
-            presignedFields?: Record<string, string>
-            uploadId?: string
-            partPresignEndpoint?: string
-            storageKey: string
-          }
 
           // Store the server-side session ID. This is an UPLOAD SESSION nanoid, not a
           // server record id — `serverIdKind` says so, so a consumer that needs a real
@@ -661,7 +664,7 @@ export const createEnhancedOrchestrationSlice: StateCreator<
             })),
           })
 
-          const { abort, promise } = directUpload({
+          const { abort, promise } = get().transport.uploadObject({
             file: file.file,
             config: presignedConfig,
             onProgress: (progress) => {
@@ -694,47 +697,18 @@ export const createEnhancedOrchestrationSlice: StateCreator<
           })
 
           // 3. Complete the upload
-          const completeResponse = await fetch(
-            `/api/files/upload/${presignedConfig.sessionId}/complete`,
-            {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                storageKey: presignedConfig.storageKey, // Use storage key from session creation
-                size: file.size,
-                mimeType: file.mimeType || file.file?.type || 'application/octet-stream',
-                etag: uploadResult.etag,
-                uploadId: uploadResult.uploadId,
-                parts: uploadResult.parts,
-              }),
-            }
-          )
+          const completionData = await get().transport.completeSession(presignedConfig.sessionId, {
+            storageKey: presignedConfig.storageKey, // Use storage key from session creation
+            size: file.size ?? 0,
+            mimeType,
+            etag: uploadResult.etag,
+            uploadId: uploadResult.uploadId,
+            parts: uploadResult.parts,
+          })
 
-          if (!completeResponse.ok) {
-            throw new Error(`Complete failed (${completeResponse.status})`)
-          }
-
-          // Parse completion data to capture assetId/url for downstream consumers
-          let completionData: any = null
-          try {
-            completionData = await completeResponse.json()
-            console.log('[orchestration] Complete response:', completionData)
-          } catch (e) {
-            console.error('[orchestration] Failed to parse complete response:', e)
-          }
-
-          // Which kind of server record the completion actually produced. An attachment/asset
-          // processor returns `assetId` (a `MediaAsset`); `FileProcessor` returns only
-          // `fileId` (a `FolderFile`). Recording the kind is what stops a `FolderFile` id —
-          // or, worse, the upload-session nanoid we parked in `serverFileId` at session-create
-          // time — from being reported downstream as an asset id (§11.3).
-          const serverIdKind: 'asset' | 'file' | 'session' = completionData?.assetId
-            ? 'asset'
-            : completionData?.fileId
-              ? 'file'
-              : 'session'
-          const serverId: string | undefined =
-            completionData?.assetId ?? completionData?.fileId ?? undefined
+          // Which kind of server record the completion actually produced — see
+          // `transport/server-id.ts` and guide §11.3.
+          const { serverId, kind: serverIdKind } = resolveServerId(completionData)
 
           // Atomic update: set serverFileId, url, and status together
           // This prevents race conditions where onComplete reads state before serverFileId is set
@@ -762,13 +736,23 @@ export const createEnhancedOrchestrationSlice: StateCreator<
           successes.push(file.id)
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Upload failed'
+          // For a transport failure `message` is now the server's own prose — the
+          // storage-quota upgrade prompt, the 422 policy reason — instead of the
+          // `"Session create failed (403)"` placeholder the inline fetch produced.
           get().addError({
             message,
+            code: isUploadTransportError(error) ? error.code : undefined,
+            details: isUploadTransportError(error) ? error.details : undefined,
             fileId: file.id,
             sessionId: sessionId!,
             recoverable: true,
           })
-          get().updateFileStatus(file.id, 'failed')
+          // `setFileError`, not `updateFileStatus('failed')`: the latter leaves
+          // `FileState.error` unset (its own comment says "caller should also set
+          // error ... separately" and no caller ever did), so every failed upload
+          // reached `BatchUploadResult.results[].error` and `toUploadResult` as
+          // `undefined` — a second place the real message died.
+          get().setFileError(file.id, message)
           failures.push({ id: file.id, error: message })
           get().clearInFlight(file.id)
         }

--- a/apps/web/src/components/file-upload/stores/types.ts
+++ b/apps/web/src/components/file-upload/stores/types.ts
@@ -8,6 +8,7 @@ import type {
   SessionStatus,
   UploadProgress,
 } from '@auxx/lib/files/types'
+import type { UploadTransport } from '../transport'
 
 /**
  * Core store state types
@@ -175,6 +176,12 @@ export interface UploadState {
   inFlight: Record<string, { abort?: () => void }>
   // REMOVED: paused (offline pause/resume functionality)
 
+  /**
+   * How the uploader reaches the network. Defaults to the real HTTP transport;
+   * swapped out with `setTransport` in tests. See `../transport`.
+   */
+  transport: UploadTransport
+
   // Error State
   errors: UploadError[]
   /** Dedupe map: error hash -> last-seen epoch ms. Suppresses repeats within 60s. */
@@ -246,6 +253,9 @@ export interface UploadActions {
   // Presigned upload tracking methods
   setInFlight: (fileId: string, abort?: () => void) => void
   clearInFlight: (fileId: string) => void
+
+  /** Replace the network seam. Production never calls this; tests always do. */
+  setTransport: (transport: UploadTransport) => void
 
   // UI Actions
   setDragActive: (active: boolean) => void

--- a/apps/web/src/components/file-upload/transport/__fixtures__/fake-upload-transport.ts
+++ b/apps/web/src/components/file-upload/transport/__fixtures__/fake-upload-transport.ts
@@ -1,0 +1,94 @@
+// apps/web/src/components/file-upload/transport/__fixtures__/fake-upload-transport.ts
+
+import type {
+  CompletionInput,
+  CompletionResult,
+  CreateSessionInput,
+  PresignedConfig,
+  UploadHandle,
+  UploadTransport,
+} from '../types'
+
+/**
+ * A substitute for {@link UploadTransport} that never touches the network.
+ *
+ * Recorded calls are exposed through **methods**, not through a plain-object
+ * `calls` field: the transport is stored on the Zustand store, which runs under
+ * Immer, and Immer deep-freezes any plain object or array assigned into a draft.
+ * A frozen `calls.createSession` array would silently refuse every `push`. Methods
+ * close over their arrays instead, and functions are not draftable, so nothing
+ * here can be frozen.
+ *
+ * Lives in `__fixtures__` rather than `__tests__` because apps/web's Vitest
+ * `include` treats every file under `__tests__` as a suite.
+ */
+export interface FakeUploadTransport extends UploadTransport {
+  /** Every `createSession` input, in call order. */
+  createdSessions(): CreateSessionInput[]
+  /** Every `completeSession` call, in call order. */
+  completedSessions(): Array<{ sessionId: string; body: CompletionInput }>
+  /** Names of files whose upload handle had `abort()` called. */
+  abortedFiles(): string[]
+}
+
+export interface FakeUploadTransportOptions {
+  /** Override session creation — throw from here to fail the presign step. */
+  createSession?: (input: CreateSessionInput) => Promise<PresignedConfig>
+  /** Override the object write — return a never-settling promise to hang a file. */
+  uploadObject?: (params: Parameters<UploadTransport['uploadObject']>[0]) => UploadHandle
+  /** Override completion — throw from here to fail after the bytes landed. */
+  completeSession?: (sessionId: string, body: CompletionInput) => Promise<CompletionResult>
+}
+
+/** Default presigned config: a single-part PUT, one session id per file. */
+function defaultPresignedConfig(input: CreateSessionInput, index: number): PresignedConfig {
+  return {
+    sessionId: `ses_${index}`,
+    storageKey: `org1/${input.entityType}/${input.fileName}`,
+    uploadMethod: 'single',
+    uploadType: 'PUT',
+    presignedUrl: 'https://storage.test/put',
+  }
+}
+
+export function createFakeUploadTransport(
+  options: FakeUploadTransportOptions = {}
+): FakeUploadTransport {
+  const created: CreateSessionInput[] = []
+  const completed: Array<{ sessionId: string; body: CompletionInput }> = []
+  const aborted: string[] = []
+
+  return {
+    async createSession(input) {
+      created.push(input)
+      if (options.createSession) return options.createSession(input)
+      return defaultPresignedConfig(input, created.length)
+    },
+
+    uploadObject(params) {
+      if (options.uploadObject) return options.uploadObject(params)
+      return {
+        abort: () => {
+          aborted.push(params.file.name)
+        },
+        promise: Promise.resolve({ etag: `etag_${params.file.name}` }),
+      }
+    },
+
+    async completeSession(sessionId, body) {
+      completed.push({ sessionId, body })
+      if (options.completeSession) return options.completeSession(sessionId, body)
+      return {
+        success: true,
+        sessionId,
+        storageLocationId: `sl_${sessionId}`,
+        assetId: `ast_${sessionId}`,
+        url: `https://cdn.test/${sessionId}`,
+      }
+    },
+
+    createdSessions: () => [...created],
+    completedSessions: () => [...completed],
+    abortedFiles: () => [...aborted],
+  }
+}

--- a/apps/web/src/components/file-upload/transport/__tests__/http-upload-transport.test.ts
+++ b/apps/web/src/components/file-upload/transport/__tests__/http-upload-transport.test.ts
@@ -1,0 +1,125 @@
+// apps/web/src/components/file-upload/transport/__tests__/http-upload-transport.test.ts
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { httpUploadTransport } from '../http-upload-transport'
+import { isUploadTransportError } from '../upload-error'
+
+/**
+ * The one place a `fetch` stub is still the right tool: this IS the fetch layer.
+ * Everything above it now takes a transport, so no other suite needs one.
+ */
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function stubFetch(response: Response) {
+  const fetchMock = vi.fn(() => Promise.resolve(response))
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+const CREATE_INPUT = {
+  fileName: 'photo.jpg',
+  mimeType: 'image/jpeg',
+  expectedSize: 1024,
+  provider: 'S3' as const,
+  entityType: 'FILE' as const,
+  entityId: 'fld_1',
+}
+
+describe('httpUploadTransport.createSession', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('posts the session request and returns the presigned config', async () => {
+    const fetchMock = stubFetch(
+      jsonResponse(200, {
+        sessionId: 'ses_1',
+        storageKey: 'org1/FILE/photo.jpg',
+        uploadMethod: 'single',
+        uploadType: 'PUT',
+        presignedUrl: 'https://storage.test/put',
+      })
+    )
+
+    const config = await httpUploadTransport.createSession(CREATE_INPUT)
+
+    expect(config.sessionId).toBe('ses_1')
+    expect(config.uploadMethod).toBe('single')
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('/api/files/upload/sessions')
+    expect(JSON.parse(String(init.body))).toMatchObject({ fileName: 'photo.jpg', provider: 'S3' })
+  })
+
+  it('throws the storage-limit message instead of "Session create failed (403)"', async () => {
+    stubFetch(
+      jsonResponse(403, {
+        error: 'USAGE_LIMIT',
+        message:
+          'You have reached your storage limit. Usage: 4.8GB/5GB. Upgrade your plan for more storage.',
+        details: { metric: 'storageGb', upgradeRequired: 'true' },
+      })
+    )
+
+    const error = await httpUploadTransport.createSession(CREATE_INPUT).catch((e) => e)
+
+    expect(isUploadTransportError(error)).toBe(true)
+    expect(error.message).toContain('Upgrade your plan for more storage')
+    expect(error.status).toBe(403)
+    expect(error.code).toBe('USAGE_LIMIT')
+  })
+})
+
+describe('httpUploadTransport.completeSession', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const body = { size: 1024, mimeType: 'image/jpeg', etag: 'etag-1' }
+
+  it('posts to the session-scoped complete route and returns the produced ids', async () => {
+    const fetchMock = stubFetch(
+      jsonResponse(200, {
+        success: true,
+        sessionId: 'ses_1',
+        storageLocationId: 'sl_1',
+        assetId: 'ast_1',
+        url: 'https://cdn.test/1',
+      })
+    )
+
+    const result = await httpUploadTransport.completeSession('ses_1', body)
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('/api/files/upload/ses_1/complete')
+    expect(result.assetId).toBe('ast_1')
+  })
+
+  it('surfaces the real reason for a 422 policy violation (PR 4e)', async () => {
+    stubFetch(
+      jsonResponse(422, {
+        error: 'Uploaded object is not an image',
+        errorType: 'validation',
+        retryable: false,
+        code: 'VALIDATION_ERROR',
+      })
+    )
+
+    const error = await httpUploadTransport.completeSession('ses_1', body).catch((e) => e)
+
+    expect(error.message).toBe('Uploaded object is not an image')
+    expect(error.status).toBe(422)
+    expect(error.retryable).toBe(false)
+  })
+
+  it('treats an unreadable 200 body as an empty result, not a failure', async () => {
+    stubFetch(new Response('not json', { status: 200 }))
+
+    await expect(httpUploadTransport.completeSession('ses_1', body)).resolves.toEqual({})
+  })
+})

--- a/apps/web/src/components/file-upload/transport/__tests__/upload-error.test.ts
+++ b/apps/web/src/components/file-upload/transport/__tests__/upload-error.test.ts
@@ -1,0 +1,119 @@
+// apps/web/src/components/file-upload/transport/__tests__/upload-error.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { parseUploadErrorResponse } from '../upload-error'
+
+/**
+ * The upload routes have always composed a real message and the browser has never
+ * read one — all three call sites threw `` `… (${res.status})` `` and dropped the
+ * body (PR 4c). These cases pin the two envelopes the routes actually return, both
+ * read off `apps/web/src/app/api/files/upload/**` and
+ * `packages/lib/src/files/upload/errors.ts` as they stand after PR 4e.
+ */
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('parseUploadErrorResponse', () => {
+  it('surfaces the storage-limit upgrade prompt that used to render as "Session create failed (403)"', async () => {
+    // Verbatim from `api/files/upload/sessions/route.ts`'s quota gate.
+    const error = await parseUploadErrorResponse(
+      jsonResponse(403, {
+        error: 'USAGE_LIMIT',
+        message:
+          'You have reached your storage limit. Usage: 4.8GB/5GB. Upgrade your plan for more storage.',
+        details: { metric: 'storageGb', current: '4.8', limit: '5', upgradeRequired: 'true' },
+      }),
+      'Session create failed'
+    )
+
+    expect(error.message).toBe(
+      'You have reached your storage limit. Usage: 4.8GB/5GB. Upgrade your plan for more storage.'
+    )
+    // `error` is the CODE in this envelope, not the prose.
+    expect(error.code).toBe('USAGE_LIMIT')
+    expect(error.status).toBe(403)
+    expect(error.retryable).toBe(false)
+    expect(error.details?.upgradeRequired).toBe('true')
+  })
+
+  it('reads the files.manage 403 the isAuxxError branch returns', async () => {
+    const error = await parseUploadErrorResponse(
+      jsonResponse(403, { error: 'FORBIDDEN', message: 'Missing permission: files.manage' }),
+      'Session create failed'
+    )
+
+    expect(error.message).toBe('Missing permission: files.manage')
+    expect(error.code).toBe('FORBIDDEN')
+  })
+
+  it('reads the lib envelope, where `error` is the prose and `code` is separate', async () => {
+    // What `uploadErrorResponse` returns for a post-upload policy violation (422).
+    const error = await parseUploadErrorResponse(
+      jsonResponse(422, {
+        error: 'Uploaded object is 12MB, over the 10MB limit for this entity type',
+        errorType: 'validation',
+        retryable: false,
+        code: 'VALIDATION_ERROR',
+      }),
+      'Complete failed'
+    )
+
+    expect(error.message).toBe('Uploaded object is 12MB, over the 10MB limit for this entity type')
+    expect(error.code).toBe('VALIDATION_ERROR')
+    expect(error.errorType).toBe('validation')
+    expect(error.retryable).toBe(false)
+  })
+
+  it('keeps a malformed-body 400 non-retryable and distinct from a 5xx', async () => {
+    const error = await parseUploadErrorResponse(
+      jsonResponse(400, {
+        error: 'Invalid completion request format',
+        errorType: 'validation',
+        retryable: false,
+        code: 'VALIDATION_ERROR',
+      }),
+      'Complete failed'
+    )
+
+    expect(error.status).toBe(400)
+    expect(error.retryable).toBe(false)
+  })
+
+  it('trusts the body over the status for retryability', async () => {
+    const error = await parseUploadErrorResponse(
+      jsonResponse(500, {
+        error: 'An unexpected error occurred. Please try again.',
+        errorType: 'unknown',
+        retryable: true,
+        code: 'UNKNOWN_ERROR',
+      }),
+      'Complete failed'
+    )
+
+    expect(error.retryable).toBe(true)
+  })
+
+  it('falls back to the old message when the body is not JSON at all', async () => {
+    const error = await parseUploadErrorResponse(
+      new Response('<html>502 Bad Gateway</html>', { status: 502 }),
+      'Session create failed'
+    )
+
+    // Byte-identical to what the inline fetch threw, so nothing regresses to blank.
+    expect(error.message).toBe('Session create failed (502)')
+    expect(error.retryable).toBe(true)
+    expect(error.code).toBeUndefined()
+  })
+
+  it('falls back when the body is JSON but says nothing usable', async () => {
+    const error = await parseUploadErrorResponse(jsonResponse(404, {}), 'Complete failed')
+
+    expect(error.message).toBe('Complete failed (404)')
+    expect(error.retryable).toBe(false)
+  })
+})

--- a/apps/web/src/components/file-upload/transport/direct-upload.ts
+++ b/apps/web/src/components/file-upload/transport/direct-upload.ts
@@ -1,31 +1,22 @@
-// apps/web/src/components/file-upload/utils/direct-upload.ts
+// apps/web/src/components/file-upload/transport/direct-upload.ts
 
-interface DirectUploadConfig {
-  uploadMethod: 'single' | 'multipart'
-  uploadType?: 'PUT' | 'POST'
-  presignedUrl?: string
-  presignedFields?: Record<string, string>
-  uploadId?: string
-  partPresignEndpoint?: string
-  storageKey: string
-}
+import type {
+  DirectUploadResult,
+  PresignedConfig,
+  UploadHandle,
+  UploadProgressEvent,
+} from './types'
+import { parseUploadErrorResponse } from './upload-error'
 
-interface DirectUploadResult {
-  etag?: string
-  uploadId?: string
-  parts?: Array<{ partNumber: number; etag: string }>
-  storageKey?: string
-}
-
-interface ProgressEvent {
-  loaded: number
-  total: number
-  percentage: number
-}
+/** Multipart chunk size. Must stay at or above S3's 5MB minimum for non-final parts. */
+const CHUNK_SIZE = 10 * 1024 * 1024
 
 /**
- * Direct upload to storage using presigned URLs
- * Supports both single and multipart uploads
+ * Write one file's bytes straight to storage with the presigned config the session
+ * route handed back. `XMLHttpRequest` rather than `fetch` for one reason: upload
+ * progress events, which `fetch` still does not expose.
+ *
+ * Returns synchronously so the caller can register `abort` before awaiting.
  */
 export function directUpload({
   file,
@@ -33,9 +24,9 @@ export function directUpload({
   onProgress,
 }: {
   file: File
-  config: DirectUploadConfig
-  onProgress?: (progress: ProgressEvent) => void
-}): { abort: () => void; promise: Promise<DirectUploadResult> } {
+  config: PresignedConfig
+  onProgress?: (progress: UploadProgressEvent) => void
+}): UploadHandle {
   let aborted = false
   let currentAbort: (() => void) | undefined
 
@@ -47,7 +38,6 @@ export function directUpload({
 
       const xhr = new XMLHttpRequest()
 
-      // Progress tracking
       xhr.upload.addEventListener('progress', (event) => {
         if (event.lengthComputable && onProgress) {
           onProgress({
@@ -58,7 +48,6 @@ export function directUpload({
         }
       })
 
-      // Success handling
       xhr.addEventListener('load', () => {
         if (xhr.status >= 200 && xhr.status < 300) {
           const etag = xhr.getResponseHeader('etag')?.replace(/"/g, '')
@@ -74,11 +63,9 @@ export function directUpload({
         }
       })
 
-      // Error handling
       xhr.addEventListener('error', () => reject(new Error('Upload failed')))
       xhr.addEventListener('abort', () => reject(new Error('Upload aborted')))
 
-      // Configure request based on upload type
       if (config.uploadType === 'POST' && config.presignedFields) {
         // POST with form fields (policy-based)
         const formData = new FormData()
@@ -96,11 +83,7 @@ export function directUpload({
         xhr.send(file)
       }
 
-      // Set up abort function
-      currentAbort = () => {
-        aborted = true
-        xhr.abort()
-      }
+      currentAbort = () => xhr.abort()
     })
   }
 
@@ -109,18 +92,18 @@ export function directUpload({
       throw new Error('Missing multipart configuration')
     }
 
-    const chunkSize = 10 * 1024 * 1024 // 10MB chunks
     const totalSize = file.size
     const parts: Array<{ partNumber: number; etag: string }> = []
     let uploadedBytes = 0
 
-    for (let start = 0, partNumber = 1; start < totalSize; start += chunkSize, partNumber++) {
+    for (let start = 0, partNumber = 1; start < totalSize; start += CHUNK_SIZE, partNumber++) {
       if (aborted) throw new Error('Upload aborted')
 
-      const end = Math.min(start + chunkSize, totalSize)
+      const end = Math.min(start + CHUNK_SIZE, totalSize)
       const chunk = file.slice(start, end)
 
-      // Get presigned URL for this part
+      // Presign this part. A failure here leaves the session alive on the server
+      // (PR 4e): part presigning mutates nothing, so it is safe to retry.
       const partResponse = await fetch(config.partPresignEndpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -128,12 +111,19 @@ export function directUpload({
       })
 
       if (!partResponse.ok) {
-        throw new Error(`Failed to get presigned URL for part ${partNumber}`)
+        throw await parseUploadErrorResponse(
+          partResponse,
+          `Failed to get presigned URL for part ${partNumber}`
+        )
       }
 
-      const { presignedUrl } = await partResponse.json()
+      // The part presign happens between chunks, where no XHR is live and
+      // `currentAbort` therefore does nothing. `abort()` sets the flag itself so a
+      // cancel landing in this window is still honoured on the next iteration.
+      if (aborted) throw new Error('Upload aborted')
 
-      // Upload the part
+      const { presignedUrl } = (await partResponse.json()) as { presignedUrl: string }
+
       const etag = await new Promise<string>((resolve, reject) => {
         const xhr = new XMLHttpRequest()
         const partProgressBase = uploadedBytes
@@ -151,8 +141,7 @@ export function directUpload({
 
         xhr.addEventListener('load', () => {
           if (xhr.status >= 200 && xhr.status < 300) {
-            const etag = xhr.getResponseHeader('etag')?.replace(/"/g, '') || ''
-            resolve(etag)
+            resolve(xhr.getResponseHeader('etag')?.replace(/"/g, '') || '')
           } else {
             reject(new Error(`Part upload failed with status ${xhr.status}`))
           }
@@ -164,11 +153,7 @@ export function directUpload({
         xhr.open('PUT', presignedUrl)
         xhr.send(chunk)
 
-        // Update current abort function for this part
-        currentAbort = () => {
-          aborted = true
-          xhr.abort()
-        }
+        currentAbort = () => xhr.abort()
       })
 
       parts.push({ partNumber, etag })
@@ -184,7 +169,14 @@ export function directUpload({
   const promise = config.uploadMethod === 'single' ? uploadSingle() : uploadMultipart()
 
   return {
-    abort: () => currentAbort?.(),
+    abort: () => {
+      // The flag is set here, not inside `currentAbort`. Setting it there meant an
+      // abort arriving while a part was being presigned — when no XHR is live and
+      // `currentAbort` is stale or unset — was silently dropped and the remaining
+      // parts uploaded anyway.
+      aborted = true
+      currentAbort?.()
+    },
     promise,
   }
 }

--- a/apps/web/src/components/file-upload/transport/http-upload-transport.ts
+++ b/apps/web/src/components/file-upload/transport/http-upload-transport.ts
@@ -1,0 +1,65 @@
+// apps/web/src/components/file-upload/transport/http-upload-transport.ts
+
+import { directUpload } from './direct-upload'
+import type {
+  CompletionInput,
+  CompletionResult,
+  CreateSessionInput,
+  PresignedConfig,
+  UploadHandle,
+  UploadTransport,
+} from './types'
+import { parseUploadErrorResponse } from './upload-error'
+
+/**
+ * The real transport: the three `/api/files/upload/*` routes, plus the direct
+ * PUT/multipart write to storage.
+ *
+ * This is the only place in the uploader that knows a URL. Everything above it
+ * talks to {@link UploadTransport}, so the Phase 4 response-shape changes and any
+ * future ones land here and nowhere else.
+ */
+export const httpUploadTransport: UploadTransport = {
+  async createSession(input: CreateSessionInput): Promise<PresignedConfig> {
+    const response = await fetch('/api/files/upload/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+
+    if (!response.ok) {
+      // Reads the body. The storage-quota 403's "upgrade your plan" message and
+      // the `files.manage` 403 both live in there and used to be discarded.
+      throw await parseUploadErrorResponse(response, 'Session create failed')
+    }
+
+    return (await response.json()) as PresignedConfig
+  },
+
+  uploadObject(params): UploadHandle {
+    return directUpload(params)
+  },
+
+  async completeSession(sessionId: string, body: CompletionInput): Promise<CompletionResult> {
+    const response = await fetch(`/api/files/upload/${sessionId}/complete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+    if (!response.ok) {
+      // 400 = malformed body, session still alive and completable (PR 4e).
+      // 422 = the delivered object broke the session's policy, with the real reason.
+      throw await parseUploadErrorResponse(response, 'Complete failed')
+    }
+
+    try {
+      return (await response.json()) as CompletionResult
+    } catch {
+      // The bytes are stored and the server said 200; an unreadable body costs us
+      // the record ids, not the upload. Reported as an empty result, which
+      // `resolveServerId` reads as `'session'`.
+      return {}
+    }
+  },
+}

--- a/apps/web/src/components/file-upload/transport/index.ts
+++ b/apps/web/src/components/file-upload/transport/index.ts
@@ -1,0 +1,21 @@
+// apps/web/src/components/file-upload/transport/index.ts
+
+export { directUpload } from './direct-upload'
+export { httpUploadTransport } from './http-upload-transport'
+export type { ResolvedServerId } from './server-id'
+export { resolveServerId } from './server-id'
+export type {
+  CompletionInput,
+  CompletionResult,
+  CreateSessionInput,
+  DirectUploadResult,
+  PresignedConfig,
+  UploadHandle,
+  UploadProgressEvent,
+  UploadTransport,
+} from './types'
+export {
+  isUploadTransportError,
+  parseUploadErrorResponse,
+  UploadTransportError,
+} from './upload-error'

--- a/apps/web/src/components/file-upload/transport/server-id.ts
+++ b/apps/web/src/components/file-upload/transport/server-id.ts
@@ -1,0 +1,29 @@
+// apps/web/src/components/file-upload/transport/server-id.ts
+
+import type { ServerIdKind } from '@auxx/lib/files/types'
+import type { CompletionResult } from './types'
+
+/** Which server record a completion produced, and its id. */
+export interface ResolvedServerId {
+  /** `undefined` when the completion carried no usable record id. */
+  serverId?: string
+  kind: ServerIdKind
+}
+
+/**
+ * Decide which id a completion response actually produced.
+ *
+ * An attachment/asset processor returns `assetId` (a `MediaAsset`); `FileProcessor`
+ * returns only `fileId` (a `FolderFile`). Recording the kind alongside the id is
+ * what stops a `FolderFile` id — or, worse, the upload-session nanoid parked in
+ * `serverFileId` at session-create time — being reported downstream as an asset id
+ * (`docs/files-upload-architecture-guide.md` §11.3).
+ *
+ * `'session'` means neither id came back, so whatever `serverFileId` already holds
+ * stays there and is labelled as the session nanoid it is.
+ */
+export function resolveServerId(completion: CompletionResult | null | undefined): ResolvedServerId {
+  if (completion?.assetId) return { serverId: completion.assetId, kind: 'asset' }
+  if (completion?.fileId) return { serverId: completion.fileId, kind: 'file' }
+  return { kind: 'session' }
+}

--- a/apps/web/src/components/file-upload/transport/types.ts
+++ b/apps/web/src/components/file-upload/transport/types.ts
@@ -1,0 +1,126 @@
+// apps/web/src/components/file-upload/transport/types.ts
+
+import type { EntityType } from '@auxx/lib/files/types'
+
+/**
+ * The wire contract between the browser uploader and `/api/files/upload/*`.
+ *
+ * Every field here mirrors a route on `apps/web/src/app/api/files/upload/**`, so a
+ * change to the request or response shape lands in this one file rather than being
+ * spread across the orchestration slice's inline `fetch` bodies.
+ */
+
+/** Body of `POST /api/files/upload/sessions`. */
+export interface CreateSessionInput {
+  fileName: string
+  mimeType: string
+  expectedSize: number
+  /**
+   * Credential provider. Must stay a subset of the route's enum — there is no
+   * `Local` adapter, and sending one turns a 400 into a 500.
+   */
+  provider?: 'S3' | 'GOOGLE_DRIVE' | 'DROPBOX' | 'ONEDRIVE' | 'BOX'
+  entityType: EntityType
+  entityId?: string
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Response of `POST /api/files/upload/sessions`, and everything
+ * {@link UploadTransport.uploadObject} needs to put the bytes somewhere.
+ *
+ * `uploadMethod` is the strategy, `uploadType` is the HTTP verb. Both names are
+ * legacy and both are load-bearing.
+ */
+export interface PresignedConfig {
+  sessionId: string
+  storageKey: string
+  expiresAt?: string
+  warnings?: string[]
+  uploadMethod: 'single' | 'multipart'
+  uploadType?: 'PUT' | 'POST'
+  presignedUrl?: string
+  presignedFields?: Record<string, string>
+  uploadId?: string
+  partPresignEndpoint?: string
+}
+
+/** Byte counts reported while the object is being written to storage. */
+export interface UploadProgressEvent {
+  loaded: number
+  total: number
+  percentage: number
+}
+
+/** What the browser learned by writing the object, and must report back to `complete`. */
+export interface DirectUploadResult {
+  etag?: string
+  uploadId?: string
+  parts?: Array<{ partNumber: number; etag: string }>
+  storageKey?: string
+}
+
+/** A running object upload: a promise for the result, and a way to stop it. */
+export interface UploadHandle {
+  abort: () => void
+  promise: Promise<DirectUploadResult>
+}
+
+/** Body of `POST /api/files/upload/{sessionId}/complete`. */
+export interface CompletionInput {
+  /** Advisory. The server knows the key from the session and never reads this. */
+  storageKey?: string
+  size: number
+  mimeType: string
+  etag?: string
+  /** Multipart only, and required for it. */
+  uploadId?: string
+  /** Multipart only, and required for it. */
+  parts?: Array<{ partNumber: number; etag: string }>
+}
+
+/**
+ * Response of a successful completion.
+ *
+ * Every field is optional on purpose: which ids come back is decided by the
+ * processor the entity type dispatched to — an asset processor returns `assetId`,
+ * `FileProcessor` returns only `fileId` — and a success body that cannot be parsed
+ * at all is reported as an empty result rather than as a failure, which is what the
+ * inline code did before the transport existed.
+ */
+export interface CompletionResult {
+  success?: boolean
+  sessionId?: string
+  storageLocationId?: string
+  fileId?: string
+  assetId?: string
+  attachmentId?: string
+  documentId?: string
+  url?: string
+}
+
+/**
+ * The network seam.
+ *
+ * The orchestration slice holds one of these on the store rather than calling
+ * `fetch` itself, so a test can supply a transport that resolves immediately,
+ * fails on the third file, or never settles — none of which is expressible by
+ * stubbing global `fetch` and matching URL strings.
+ */
+export interface UploadTransport {
+  /** Create the server-side presigned upload session for one file. */
+  createSession(input: CreateSessionInput): Promise<PresignedConfig>
+
+  /**
+   * Write the bytes to storage. Returns synchronously with a handle so the caller
+   * can register the abort before awaiting.
+   */
+  uploadObject(params: {
+    file: File
+    config: PresignedConfig
+    onProgress?: (progress: UploadProgressEvent) => void
+  }): UploadHandle
+
+  /** Tell the server the bytes landed, and get back the rows it produced. */
+  completeSession(sessionId: string, body: CompletionInput): Promise<CompletionResult>
+}

--- a/apps/web/src/components/file-upload/transport/upload-error.ts
+++ b/apps/web/src/components/file-upload/transport/upload-error.ts
@@ -1,0 +1,130 @@
+// apps/web/src/components/file-upload/transport/upload-error.ts
+
+/**
+ * Reading an upload route's error body.
+ *
+ * ## Why this file exists
+ *
+ * Before it, all three browser call sites did exactly this:
+ *
+ * ```ts
+ * if (!res.ok) throw new Error(`Session create failed (${res.status})`)
+ * ```
+ *
+ * — the body was never read. The routes have always composed a real message, and
+ * none of it had ever reached a user. The most visible casualty was the storage
+ * quota gate in `api/files/upload/sessions/route.ts`, which answers 403 with
+ * *"You have reached your storage limit. Usage: 4.8GB/5GB. Upgrade your plan for
+ * more storage."* and rendered in the uploader as **"Session create failed
+ * (403)"**. Same for the post-upload policy violation PR 4e made a 422 with the
+ * real reason on it.
+ *
+ * ## Two body shapes, not one
+ *
+ * The upload routes answer with two different envelopes, and both are current:
+ *
+ * 1. **The lib shape**, from `packages/lib/src/files/upload/errors.ts` —
+ *    `{ error: <message>, errorType, retryable, code, details? }`. Used by
+ *    `uploadErrorResponse`, `uploadValidationError` and `uploadUnauthorizedError`,
+ *    so by every failure on `/parts` and `/complete` and most of `/sessions`.
+ * 2. **The route shape** — `{ error: <CODE>, message: <message>, details? }`.
+ *    Used by the `isAuxxError` branch of `/sessions` (which
+ *    `session-error-mapping.test.ts` pins) and by the storage-limit 403, whose
+ *    `error` is the literal string `'USAGE_LIMIT'`.
+ *
+ * They collide on `error`: in one it is the prose, in the other it is the code.
+ * The discriminator used here is the presence of **both** `error` and `message`,
+ * which only the route shape has.
+ */
+
+/** A non-2xx answer from an upload route, with the body actually read. */
+export class UploadTransportError extends Error {
+  /** HTTP status the route answered with. */
+  readonly status: number
+  /** Stable machine-readable code, when the body carried one. */
+  readonly code?: string
+  /** Coarse family from the lib shape (`validation`, `quota`, ...), when present. */
+  readonly errorType?: string
+  /** True when the same request may succeed unchanged on a retry. */
+  readonly retryable: boolean
+  /** Client-facing diagnostic fields the route chose to surface. */
+  readonly details?: Record<string, unknown>
+
+  constructor(
+    message: string,
+    init: {
+      status: number
+      code?: string
+      errorType?: string
+      retryable: boolean
+      details?: Record<string, unknown>
+    }
+  ) {
+    super(message)
+    this.name = 'UploadTransportError'
+    this.status = init.status
+    this.code = init.code
+    this.errorType = init.errorType
+    this.retryable = init.retryable
+    this.details = init.details
+  }
+}
+
+/**
+ * Narrow a caught value to an {@link UploadTransportError}.
+ *
+ * Checks `name` rather than `instanceof` so a value that crossed a module or
+ * bundle boundary still reads as one.
+ */
+export function isUploadTransportError(error: unknown): error is UploadTransportError {
+  return error instanceof Error && error.name === 'UploadTransportError'
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+/**
+ * Build the {@link UploadTransportError} for a failed upload-route response.
+ *
+ * @param response The non-2xx response. Its body is consumed.
+ * @param fallback Prefix for the message when the body says nothing usable —
+ *   rendered as `` `${fallback} (${status})` ``, which is byte-identical to the
+ *   string the inline `fetch` sites used to throw, so nothing regresses to an
+ *   empty message.
+ */
+export async function parseUploadErrorResponse(
+  response: Response,
+  fallback: string
+): Promise<UploadTransportError> {
+  let body: Record<string, unknown> | null = null
+  try {
+    body = asRecord(await response.json())
+  } catch {
+    body = null
+  }
+
+  const errorField = asString(body?.error)
+  const messageField = asString(body?.message)
+
+  // Only the route shape carries both, and there its `error` is the code.
+  const isRouteShape = errorField !== undefined && messageField !== undefined
+
+  const message = isRouteShape ? messageField : (errorField ?? messageField)
+  const code = isRouteShape ? errorField : asString(body?.code)
+
+  return new UploadTransportError(message ?? `${fallback} (${response.status})`, {
+    status: response.status,
+    code,
+    errorType: asString(body?.errorType),
+    retryable:
+      typeof body?.retryable === 'boolean'
+        ? body.retryable
+        : response.status >= 500 || response.status === 429,
+    details: asRecord(body?.details) ?? undefined,
+  })
+}


### PR DESCRIPTION
> **This one needs a human to upload a file before it merges.** It is front-end, and nothing in it proves a byte reached S3. The unverified list is at the bottom — it is short and specific. Everything else in this programme could be signed off by tests; this cannot.

Plan: `plans/attachments/08-frontend-store.md`, PR 8a. Isolated to `apps/web/src/components/file-upload/**` — touches no `packages/lib` file, so it is independent of the in-flight PR X and 4d.

## What it does

Session create, part presign, PUT/multipart and completion move behind an `UploadTransport` seam, so the orchestration becomes testable without a network — the same move `db`-as-a-parameter made on the server side.

```ts
export interface UploadTransport {
  createSession(input: CreateSessionInput): Promise<PresignedConfig>
  uploadObject(params: { file: File; config: PresignedConfig; onProgress?: (p: UploadProgressEvent) => void }): UploadHandle
  completeSession(sessionId: string, body: CompletionInput): Promise<CompletionResult>
}
```

`transport/http-upload-transport.ts` is now the **only** file in the uploader that knows a URL. The five wire shapes were read off the routes as they stand after #1857, not from memory.

**One deliberate divergence from the plan.** It says the store takes a transport at creation; that does not work here, because `useUploadStore` is a module singleton the hooks resolve by import, so a factory would only be substitutable for tests that build their own store. Instead `transport` is a field on `UploadState`, defaulted at slice construction and swapped with `setTransport`. Store state gives the same isolation between test files that a module-level `let` would not, and it covers the React-level tests too.

## Now covered without a network

`fetch` is stubbed **only to assert it is never called**:

- all files complete — one presign and one completion each, addressed to their own session id
- **a failure on file 3 of 5 with a 2-worker pool** — the other four complete, one error recorded
- a refused presign reports the upgrade prompt and completes nothing
- the abort handle is registered *before* the write is awaited, so cancel reaches an in-flight file
- the transport survives `reset()`

`server-id-kind.test.ts` is rewritten onto the fake and no longer needs a `vi.mock` of the XHR layer or a URL-matching `fetch` stub.

## Three swallowed failures fixed

**The storage-limit 403's upgrade prompt never reached the user.** Every fetch site did `if (!res.ok) throw new Error(\`… (${res.status})\`)` and never read the body, so the message the route carefully composes rendered as *"Session create failed (403)"*. #1856 found this and left it; it is fixed here. `parseUploadErrorResponse` reads **both** envelopes the routes return — the lib shape `{error: <prose>, errorType, retryable, code}` and the route shape `{error: <CODE>, message: <prose>}` used by the `isAuxxError` branch — discriminating on the presence of both `error` and `message`. An unusable body falls back to the old string byte-for-byte, so nothing regresses to blank. `code` and `details` are carried onto `UploadError`, so a future UI can key off `code === 'USAGE_LIMIT'` instead of string-matching prose.

**`FileState.error` was `undefined` for every failed upload.** The failure path called `updateFileStatus(fileId, 'failed')`, whose own switch carries the comment *"Caller should also set error in progress or separately"* — and no caller ever did. So `BatchUploadResult.results[].error` and `toUploadResult().error` were undefined too: a consumer's `onComplete` saw a failure and never the reason.

**`direct-upload`'s `abort()` did nothing between parts.** It was `currentAbort?.()`, and the `aborted` flag was set *inside* the XHR-abort closure. During multipart there are windows with no live XHR — while a part is presigning — where that set nothing, so the remaining parts uploaded anyway after a cancel. `abort()` now sets the flag itself and the loop re-checks after each presign.

## A trap worth knowing for 8b

The fake transport lives in `__fixtures__/`, not `__tests__/support/`: apps/web's Vitest `include` is `src/**/__tests__/**/*`, so a support file there is **collected as a suite** and fails. It also records calls through methods closing over arrays rather than a plain object — **Immer deep-freezes anything plain assigned into a draft, and a frozen array swallows every `push` silently.**

## Out of scope

The three module-level `Map`s and the `activeSessionId` reassignment are **untouched** — the transport extraction needed nothing from them. They are 8b, along with `handleAPIResponse` / `coordinateSSEEvents` / `entity-slice` in 8c.

§8.5 not started: the new files import `EntityType`/`ServerIdKind` from `@auxx/lib/files/types` as `import type`, like every sibling, so nothing enters the bundle. `@auxx/lib/files/client` currently exports only the file-type constants — `EntityType`, `ServerIdKind` and `ENTITY_CONFIGS`/`getEntityConfig` are all missing from it, and adding them means editing `packages/lib`.

## Verified

- **44 tests across 8 files** in `src/components/file-upload`, no Errors section, no unhandled rejections
- `tsc --noEmit` — zero errors matching `components/file-upload` (11 pre-existing elsewhere, all in `components/workflow/**`)
- biome clean on all changed files

## NOT verified — please click through these before merging

1. A real single-part PUT end to end: create → XHR PUT → complete → preview appears
2. A real multipart upload (>10MB) — the part-presign loop is covered by no test
3. **Cancel mid-multipart** — the exact case the `abort()` fix targets
4. The storage-limit 403 as a user actually sees it — the parser is unit-tested against the exact route body, but nobody has watched the toast
5. A 422 completion failure in the UI, same reason
6. Redux DevTools with a function-bearing `transport` in state (the store already carries functions in `sessions[].callbacks` and `inFlight[].abort`, so not a new class of thing — but it is new state)
7. The avatar uploader (`ui/avatar-upload.tsx`) and the record-field uploader (`fields/inputs/hooks/use-field-file-upload.ts`) reach `startUpload` by different paths; neither was changed, both worth one click