### PR TITLE
fix(uploader): give each upload session its own run state, so two sessions stop trading globals (plan 8b)

### DIFF
--- a/apps/web/src/components/file-upload/hooks/use-file-upload.ts
+++ b/apps/web/src/components/file-upload/hooks/use-file-upload.ts
@@ -5,7 +5,7 @@ import { generateId } from '@auxx/utils/generateId'
 import * as React from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import type { FileState } from '../stores'
-import { cleanupUploader, useUploadStore } from '../stores'
+import { useUploadStore } from '../stores'
 import type { EntityUploadConfig } from '../types'
 
 /**
@@ -390,7 +390,10 @@ export function useFileUpload(options: UseFileUploadOptions): UseFileUploadRetur
       uploadSummary.completedFiles + uploadSummary.failedFiles === uploadSummary.totalFiles
 
     if (!done) return
-    const id = useUploadStore.getState().activeSessionId
+    // THIS uploader's session, never the store-wide `activeSessionId`: a second
+    // uploader mounting or uploading moves that global, and reading it here fired
+    // one uploader's `onComplete` against another uploader's files.
+    const id = activeSessionId
     if (!id) return
 
     const store = useUploadStore.getState()
@@ -421,6 +424,7 @@ export function useFileUpload(options: UseFileUploadOptions): UseFileUploadRetur
     })
   }, [
     onComplete,
+    activeSessionId,
     uploadSummary?.uploading,
     uploadSummary?.totalFiles,
     uploadSummary?.completedFiles,
@@ -542,6 +546,12 @@ export function useFileUpload(options: UseFileUploadOptions): UseFileUploadRetur
     [retryFile, retrySession, activeSessionId]
   )
 
+  const handleCancelUpload = React.useCallback(() => {
+    // Scope the cancel to this uploader's session so it cannot abort a second
+    // uploader's in-flight files.
+    cancelUpload(activeSessionId ?? undefined)
+  }, [cancelUpload, activeSessionId])
+
   const handleCloseSession = React.useCallback(() => {
     if (activeSessionId) closeSession(activeSessionId)
   }, [closeSession, activeSessionId])
@@ -573,8 +583,8 @@ export function useFileUpload(options: UseFileUploadOptions): UseFileUploadRetur
         // No need to return anything with Immer
       })
 
-      // Clean up module-level promises and abort controllers
-      cleanupUploader(uploaderId)
+      // Drop this uploader's in-flight session creation (store state since PR 8b)
+      useUploadStore.getState().cleanupUploader(uploaderId)
 
       // If session was exclusive to this uploader, consider marking it for cleanup
       if (sessionId) {
@@ -598,7 +608,7 @@ export function useFileUpload(options: UseFileUploadOptions): UseFileUploadRetur
     addFiles: handleAddFiles,
     removeFile,
     startUpload: handleStartUpload,
-    cancelUpload,
+    cancelUpload: handleCancelUpload,
     retry: handleRetry,
     clearErrors,
 

--- a/apps/web/src/components/file-upload/stores/__tests__/session-orchestration.test.ts
+++ b/apps/web/src/components/file-upload/stores/__tests__/session-orchestration.test.ts
@@ -1,0 +1,289 @@
+// apps/web/src/components/file-upload/stores/__tests__/session-orchestration.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createFakeUploadTransport } from '../../transport/__fixtures__/fake-upload-transport'
+import type { DirectUploadResult } from '../../transport/types'
+import { useUploadStore } from '../upload-store'
+
+/**
+ * Orchestration state used to live in three module-level `Map`s plus a global
+ * `activeSessionId` that `startUploadForSession` reassigned around every call. Two
+ * uploaders in one tab therefore raced on the same three globals, and none of it was
+ * reachable from a test: the maps outlived `reset()`, so a run left in flight by one
+ * test blocked the next one.
+ *
+ * These tests upload through the substituted transport from PR 8a — no `fetch` stub,
+ * no URL matching — and read the per-session run state directly, which is the point
+ * of moving it onto the store.
+ */
+
+/**
+ * A transport whose object writes hang until released by name.
+ *
+ * The gate map lives in this closure rather than on the transport object: the
+ * transport is assigned into an Immer draft by `setTransport`, and Immer deep-freezes
+ * plain objects and arrays it finds there — a frozen `Map` field would throw, and a
+ * frozen array would swallow every `push` in silence.
+ */
+function gatedTransport() {
+  const gates = new Map<string, { resolve: () => void; reject: (error: Error) => void }>()
+  const aborted: string[] = []
+
+  const transport = createFakeUploadTransport({
+    uploadObject: (params) => {
+      const name = params.file.name
+      let resolveGate: () => void = () => {}
+      let rejectGate: (error: Error) => void = () => {}
+      const promise = new Promise<DirectUploadResult>((resolve, reject) => {
+        resolveGate = () => resolve({ etag: `etag_${name}` })
+        rejectGate = reject
+      })
+      gates.set(name, { resolve: resolveGate, reject: rejectGate })
+      return {
+        abort: () => {
+          aborted.push(name)
+          rejectGate(new Error('Upload aborted'))
+        },
+        promise,
+      }
+    },
+  })
+
+  return {
+    transport,
+    /** Files whose bytes are being written right now. */
+    pending: () => [...gates.keys()],
+    /** Files whose upload handle was aborted, in call order. */
+    aborted: () => [...aborted],
+    release: (name: string) => gates.get(name)?.resolve(),
+    /** Resolve once the named file's write has actually started. */
+    waitForPending: (name: string) => vi.waitFor(() => expect(gates.has(name)).toBe(true)),
+  }
+}
+
+function addFile(sessionId: string, name: string): string {
+  const file = new File([new Uint8Array(4)], name, { type: 'image/jpeg' })
+  const [id] = useUploadStore.getState().addFiles([file], sessionId)
+  if (!id) throw new Error(`file ${name} was not added`)
+  return id
+}
+
+function newSession(entityId: string) {
+  return useUploadStore.getState().createSession({ entityType: 'FILE', entityId })
+}
+
+describe('per-session upload runs', () => {
+  beforeEach(() => {
+    useUploadStore.getState().reset()
+  })
+
+  it('does not trade activeSessionId between two sessions uploading at once', async () => {
+    const gated = gatedTransport()
+    useUploadStore.getState().setTransport(gated.transport)
+
+    const sessionA = await newSession('fld_a')
+    addFile(sessionA, 'a1.jpg')
+    const sessionB = await newSession('fld_b')
+    addFile(sessionB, 'b1.jpg')
+
+    // Creating B selected it. Uploading must not change that, in either direction.
+    expect(useUploadStore.getState().activeSessionId).toBe(sessionB)
+
+    const runA = useUploadStore.getState().startUpload(sessionA)
+    const runB = useUploadStore.getState().startUpload(sessionB)
+    await gated.waitForPending('a1.jpg')
+    await gated.waitForPending('b1.jpg')
+
+    expect(useUploadStore.getState().activeSessionId).toBe(sessionB)
+
+    // B finishes first, while A is still writing bytes. The old implementation
+    // restored the `activeSessionId` it had captured on entry — which was A, because
+    // A's own call had already overwritten the global — leaving the store pointed at a
+    // session the user never selected.
+    gated.release('b1.jpg')
+    const resultB = await runB
+    expect(useUploadStore.getState().activeSessionId).toBe(sessionB)
+
+    gated.release('a1.jpg')
+    const resultA = await runA
+    expect(useUploadStore.getState().activeSessionId).toBe(sessionB)
+
+    // Neither batch saw the other's file.
+    expect(resultA.results.map((r) => r.filename)).toEqual(['a1.jpg'])
+    expect(resultB.results.map((r) => r.filename)).toEqual(['b1.jpg'])
+    expect(resultA.successCount).toBe(1)
+    expect(resultB.successCount).toBe(1)
+
+    const sessions = useUploadStore.getState().sessions
+    expect(sessions[sessionA]?.uploadResult?.results.map((r) => r.filename)).toEqual(['a1.jpg'])
+    expect(sessions[sessionB]?.uploadResult?.results.map((r) => r.filename)).toEqual(['b1.jpg'])
+  })
+
+  it('keeps the global uploading flag set while another session is still running', async () => {
+    const gated = gatedTransport()
+    useUploadStore.getState().setTransport(gated.transport)
+
+    const sessionA = await newSession('fld_a')
+    addFile(sessionA, 'a1.jpg')
+    const sessionB = await newSession('fld_b')
+    addFile(sessionB, 'b1.jpg')
+
+    const runA = useUploadStore.getState().startUpload(sessionA)
+    const runB = useUploadStore.getState().startUpload(sessionB)
+    await gated.waitForPending('a1.jpg')
+    await gated.waitForPending('b1.jpg')
+
+    expect(Object.keys(useUploadStore.getState().sessionRuns).sort()).toEqual(
+      [sessionA, sessionB].sort()
+    )
+    expect(useUploadStore.getState().uploading).toBe(true)
+
+    gated.release('b1.jpg')
+    await runB
+
+    // A is still uploading, so the flag its spinner reads must stay true.
+    expect(useUploadStore.getState().uploading).toBe(true)
+    expect(useUploadStore.getState().sessions[sessionB]?.uploading).toBe(false)
+    expect(useUploadStore.getState().sessions[sessionA]?.uploading).toBe(true)
+
+    gated.release('a1.jpg')
+    await runA
+
+    expect(useUploadStore.getState().uploading).toBe(false)
+    expect(useUploadStore.getState().sessionRuns).toEqual({})
+  })
+
+  it('joins the run already in flight instead of uploading the same files twice', async () => {
+    const gated = gatedTransport()
+    useUploadStore.getState().setTransport(gated.transport)
+
+    const sessionId = await newSession('fld_a')
+    addFile(sessionId, 'a1.jpg')
+
+    const first = useUploadStore.getState().startUpload(sessionId)
+    const second = useUploadStore.getState().startUpload(sessionId)
+    // The deprecated alias is the same run, not a third one.
+    const third = useUploadStore.getState().startUploadForSession(sessionId)
+    await gated.waitForPending('a1.jpg')
+
+    gated.release('a1.jpg')
+    const [a, b, c] = await Promise.all([first, second, third])
+
+    expect(b).toBe(a)
+    expect(c).toBe(a)
+    expect(gated.transport.createdSessions()).toHaveLength(1)
+    expect(gated.transport.completedSessions()).toHaveLength(1)
+  })
+
+  it('reset() clears the in-flight run map that the module-level Map used to survive', async () => {
+    const gated = gatedTransport()
+    useUploadStore.getState().setTransport(gated.transport)
+
+    const sessionId = await newSession('fld_a')
+    addFile(sessionId, 'a1.jpg')
+
+    const run = useUploadStore.getState().startUpload(sessionId)
+    await gated.waitForPending('a1.jpg')
+    expect(Object.keys(useUploadStore.getState().sessionRuns)).toEqual([sessionId])
+
+    useUploadStore.getState().reset()
+    expect(useUploadStore.getState().sessionRuns).toEqual({})
+    expect(useUploadStore.getState().uploaderRuns).toEqual({})
+
+    // Let the abandoned run settle so it cannot leak into the next test.
+    gated.release('a1.jpg')
+    await run
+  })
+
+  it('cancels only the named session, leaving a second session uploading', async () => {
+    const gated = gatedTransport()
+    useUploadStore.getState().setTransport(gated.transport)
+
+    const sessionA = await newSession('fld_a')
+    addFile(sessionA, 'a1.jpg')
+    const sessionB = await newSession('fld_b')
+    addFile(sessionB, 'b1.jpg')
+
+    const runA = useUploadStore.getState().startUpload(sessionA)
+    const runB = useUploadStore.getState().startUpload(sessionB)
+    await gated.waitForPending('a1.jpg')
+    await gated.waitForPending('b1.jpg')
+
+    useUploadStore.getState().cancelUpload(sessionA)
+    const resultA = await runA
+
+    // The blanket `Object.values(inFlight).forEach(abort)` aborted every uploader on
+    // the page, not just this session's files.
+    expect(gated.aborted()).toEqual(['a1.jpg'])
+    expect(resultA.successCount).toBe(0)
+    expect(useUploadStore.getState().sessions[sessionA]?.status).toBe('cancelled')
+
+    gated.release('b1.jpg')
+    const resultB = await runB
+
+    expect(resultB.successCount).toBe(1)
+    expect(useUploadStore.getState().sessions[sessionB]?.status).not.toBe('cancelled')
+  })
+
+  it('retries a session that is not the selected one', async () => {
+    useUploadStore.getState().setTransport(createFakeUploadTransport())
+
+    const sessionA = await newSession('fld_a')
+    const fileId = addFile(sessionA, 'a1.jpg')
+    useUploadStore.getState().setFileError(fileId, 'Upload failed')
+
+    // Selecting another session must not decide whether A's retry does anything.
+    const sessionB = await newSession('fld_b')
+    expect(useUploadStore.getState().activeSessionId).toBe(sessionB)
+
+    await useUploadStore.getState().retrySession(sessionA)
+
+    expect(useUploadStore.getState().files[fileId]?.status).toBe('completed')
+  })
+
+  it('leaves a session with nothing pending marked idle', async () => {
+    useUploadStore.getState().setTransport(createFakeUploadTransport())
+
+    const sessionId = await newSession('fld_a')
+    const result = await useUploadStore.getState().startUpload(sessionId)
+
+    expect(result.totalFiles).toBe(0)
+    // The early return used to skip the flag reset, so the session read as uploading
+    // forever — which is the flag consumers check before dropping a completion handler.
+    expect(useUploadStore.getState().sessions[sessionId]?.uploading).toBe(false)
+    expect(useUploadStore.getState().sessionRuns).toEqual({})
+  })
+})
+
+describe('per-uploader session creation', () => {
+  beforeEach(() => {
+    useUploadStore.getState().reset()
+  })
+
+  it('registers one creation guard per uploader and clears it when it settles', async () => {
+    const uploaderId = 'uploader_guard_1'
+    const store = useUploadStore.getState()
+
+    const first = store.createSessionWithGuard(uploaderId, { entityType: 'FILE', entityId: 'f_1' })
+    // Registered synchronously, so a second caller in the same tick joins it.
+    expect(Object.keys(useUploadStore.getState().uploaderRuns)).toEqual([uploaderId])
+    const second = store.createSessionWithGuard(uploaderId, { entityType: 'FILE', entityId: 'f_1' })
+
+    expect(await second).toBe(await first)
+    expect(Object.keys(useUploadStore.getState().sessions)).toHaveLength(1)
+    expect(useUploadStore.getState().uploaderRuns).toEqual({})
+  })
+
+  it('cleanupUploader aborts the creation still in flight', async () => {
+    const uploaderId = 'uploader_guard_2'
+    const creating = useUploadStore
+      .getState()
+      .createSessionWithGuard(uploaderId, { entityType: 'FILE', entityId: 'f_1' })
+
+    useUploadStore.getState().cleanupUploader(uploaderId)
+
+    await expect(creating).rejects.toThrow('Session creation cancelled')
+    expect(useUploadStore.getState().uploaderRuns).toEqual({})
+    expect(useUploadStore.getState().uploaderSessions[uploaderId]).toBeUndefined()
+  })
+})

--- a/apps/web/src/components/file-upload/stores/index.ts
+++ b/apps/web/src/components/file-upload/stores/index.ts
@@ -23,12 +23,14 @@ export type { UISlice } from './slices/ui-slice'
 export type {
   CreateSessionOptions,
   FileState,
+  SessionRun,
   SessionState,
   UploadActions,
   UploadConfig,
   UploadError,
+  UploaderRun,
   UploadState,
   UploadStore,
 } from './types'
 // Main store
-export { cleanupUploader, cleanupUploadStore, useUploadStore } from './upload-store'
+export { cleanupUploadStore, useUploadStore } from './upload-store'

--- a/apps/web/src/components/file-upload/stores/slices/orchestration-slice.ts
+++ b/apps/web/src/components/file-upload/stores/slices/orchestration-slice.ts
@@ -7,31 +7,20 @@ import type { UploadTransport } from '../../transport'
 import { httpUploadTransport, isUploadTransportError, resolveServerId } from '../../transport'
 import { validateFile } from '../../utils'
 import { isFileInFlight } from '../file-status'
-import type { CreateSessionOptions, UploadStore } from '../types'
+import type { CreateSessionOptions, SessionRun, UploaderRun, UploadStore } from '../types'
 
 /**
- * Module-level promise maps for concurrency control (outside component lifecycle)
+ * A fresh empty batch result. A function, not a shared constant: the value is handed
+ * to callers and can be assigned into a session (`uploadResult`), where Immer would
+ * freeze it — a shared frozen object would then leak that freeze to every later caller.
  */
-const sessionCreatePromises = new Map<string, Promise<string>>()
-const uploadPromises = new Map<string, Promise<BatchUploadResult>>()
-const activeRequests = new Map<string, AbortController>()
-
-/**
- * Clean up helper for uploader-specific resources
- */
-export const cleanupUploader = (uploaderId: string) => {
-  // Cancel any in-flight requests
-  const controller = activeRequests.get(uploaderId)
-  if (controller) {
-    controller.abort()
-    activeRequests.delete(uploaderId)
-  }
-
-  // Clear promises
-  sessionCreatePromises.delete(uploaderId)
-
-  // Note: uploadPromises are keyed by sessionId, need different cleanup
-}
+const emptyBatchResult = (): BatchUploadResult => ({
+  totalFiles: 0,
+  successCount: 0,
+  failedCount: 0,
+  results: [],
+  overallProgress: 0,
+})
 
 /**
  * Orchestration slice - the system's "brain"
@@ -55,6 +44,27 @@ export interface OrchestrationSlice {
 
   // Per-file abort tracking
   inFlight: Record<string, { abort?: () => void }>
+
+  /**
+   * One entry per session with an upload run in flight, keyed by session id.
+   *
+   * This used to be a module-level `Map`, which outlived every `reset()` — so a test
+   * that started an upload poisoned the next one, and `cleanupUploader` carried a
+   * comment admitting it could not clear the half keyed by session. As store state it
+   * is cleared by `reset()`, inspectable from a test, and impossible to leak across
+   * store instances.
+   */
+  sessionRuns: Record<string, SessionRun>
+
+  /**
+   * One entry per uploader with a session creation in flight, keyed by uploader id
+   * (the session does not exist yet, so it cannot be keyed by session). Replaces the
+   * module-level `sessionCreatePromises` and `activeRequests` maps.
+   */
+  uploaderRuns: Record<string, UploaderRun>
+
+  /** Drop an uploader's in-flight session creation and abort its controller. */
+  cleanupUploader: (uploaderId: string) => void
 
   // Core Orchestration Actions
   initializeUpload: (options: InitializeUploadOptions) => Promise<string>
@@ -80,9 +90,17 @@ export interface OrchestrationSlice {
      */
     skippedDuplicates: string[]
   }>
-  startUpload: () => Promise<BatchUploadResult>
+  /**
+   * Upload the pending files of one session. `sessionId` defaults to
+   * {@link SessionSlice.activeSessionId} for the callers that have only ever had one
+   * session; dispatch never mutates it. Concurrent calls for the same session join the
+   * run already in flight instead of uploading its files twice.
+   */
+  startUpload: (sessionId?: string) => Promise<BatchUploadResult>
+  /** @deprecated Alias for `startUpload(sessionId)`; kept for callers outside this module. */
   startUploadForSession: (sessionId: string) => Promise<BatchUploadResult>
-  cancelUpload: () => void
+  /** Cancel one session's upload. Defaults to the active session. */
+  cancelUpload: (sessionId?: string) => void
 
   // Session creation with concurrency guard
   createSessionWithGuard: (uploaderId: string, options: CreateSessionOptions) => Promise<string>
@@ -121,11 +139,20 @@ export const createEnhancedOrchestrationSlice: StateCreator<
   // State
   uploading: false,
   inFlight: {} as Record<string, { abort?: () => void }>,
+  sessionRuns: {} as Record<string, SessionRun>,
+  uploaderRuns: {} as Record<string, UploaderRun>,
   transport: httpUploadTransport,
 
   setTransport: (transport: UploadTransport) => {
     set((state) => {
       state.transport = transport
+    })
+  },
+
+  cleanupUploader: (uploaderId: string) => {
+    get().uploaderRuns[uploaderId]?.abortController.abort()
+    set((state) => {
+      delete state.uploaderRuns[uploaderId]
     })
   },
 
@@ -139,7 +166,7 @@ export const createEnhancedOrchestrationSlice: StateCreator<
     const state = get()
 
     // Check if session creation is already in progress for this uploader
-    const existingPromise = sessionCreatePromises.get(uploaderId)
+    const existingPromise = state.uploaderRuns[uploaderId]?.createPromise
     if (existingPromise) {
       return existingPromise
     }
@@ -152,7 +179,6 @@ export const createEnhancedOrchestrationSlice: StateCreator<
 
     // Create abort controller for this operation
     const abortController = new AbortController()
-    activeRequests.set(uploaderId, abortController)
 
     // Create new session with guard
     const createPromise = (async () => {
@@ -217,13 +243,18 @@ export const createEnhancedOrchestrationSlice: StateCreator<
         throw error
       } finally {
         // Always clear the promise and controller
-        sessionCreatePromises.delete(uploaderId)
-        activeRequests.delete(uploaderId)
+        set((state) => {
+          delete state.uploaderRuns[uploaderId]
+        })
       }
     })()
 
-    // Store the promise
-    sessionCreatePromises.set(uploaderId, createPromise)
+    // Register the guard. Safe in this order: the IIFE above suspends on its first
+    // `await` before reaching the `finally` that clears the entry, and this `set` runs
+    // in the same synchronous turn.
+    set((state) => {
+      state.uploaderRuns[uploaderId] = { createPromise, abortController }
+    })
 
     return createPromise
   },
@@ -570,21 +601,17 @@ export const createEnhancedOrchestrationSlice: StateCreator<
    * Presigned upload flow - uploads files directly to storage
    * Uses per-file presigned sessions and direct storage uploads
    */
-  startUpload: async (): Promise<BatchUploadResult> => {
-    const { activeSessionId, sessions, files, addError, entityConfig, config } = get()
+  startUpload: async (sessionId?: string): Promise<BatchUploadResult> => {
+    const { activeSessionId, sessions, addError, config } = get()
     const maxConcurrency = Math.max(1, config?.maxConcurrentUploads ?? 3)
 
-    // Get session or lazily create one
-    const sessionId = activeSessionId
-    const session = sessionId ? sessions[sessionId] : null
+    // Dispatch is by argument. `activeSessionId` is only a default for the callers that
+    // have one session, and is never reassigned to route an upload — two uploaders in
+    // one tab used to fight over it, and whichever finished last restored a stale value.
+    const targetSessionId = sessionId ?? activeSessionId
+    const session = targetSessionId ? sessions[targetSessionId] : undefined
 
-    // Gather files eligible to upload (pending or failed) from the store
-    const allFiles = Object.values(files)
-    const fileIdsToAttach = allFiles
-      .filter((f) => f && (f.status === 'pending' || f.status === 'failed'))
-      .map((f) => f.id)
-
-    if (!session) {
+    if (!targetSessionId || !session) {
       // No fallback to global config - require explicit session creation
       addError({
         message:
@@ -593,323 +620,286 @@ export const createEnhancedOrchestrationSlice: StateCreator<
         recoverable: true,
         details: {
           activeSessionId,
-          fileCount: fileIdsToAttach.length,
+          requestedSessionId: sessionId,
           hint: 'This usually happens when session creation failed. Check console for errors.',
         },
       })
       console.error(
-        'startUpload called without active session. Sessions must be created explicitly via createSession().'
+        'startUpload called without a session. Sessions must be created explicitly via createSession().'
       )
-      return { totalFiles: 0, successCount: 0, failedCount: 0, results: [], overallProgress: 0 }
+      return emptyBatchResult()
     }
 
-    // Get files to upload from session
-    const toUpload = session.fileIds
-      .map((id) => get().files[id])
-      .filter((f) => f && (f.status === 'pending' || f.status === 'failed'))
+    // One run per session: a second start joins the run already in flight rather than
+    // uploading the same files twice.
+    const running = get().sessionRuns[targetSessionId]?.promise
+    if (running) return running
 
-    if (toUpload.length === 0) {
-      addError({ message: 'No files to upload', code: 'NO_FILES', recoverable: true })
-      return { totalFiles: 0, successCount: 0, failedCount: 0, results: [], overallProgress: 0 }
-    }
+    const run = async (): Promise<BatchUploadResult> => {
+      // Get files to upload from session
+      const toUpload = session.fileIds
+        .map((id) => get().files[id])
+        .filter((f) => f && (f.status === 'pending' || f.status === 'failed'))
 
-    set((state) => {
-      state.uploading = true
-    })
+      if (toUpload.length === 0) {
+        addError({ message: 'No files to upload', code: 'NO_FILES', recoverable: true })
+        return emptyBatchResult()
+      }
 
-    // Simple concurrency pool
-    let fileIndex = 0
-    const successes: string[] = []
-    const failures: Array<{ id: string; error: string }> = []
+      // The pool's cursor stays a closure local: it is created per run, and there is at
+      // most one run per session, so two sessions cannot interleave through it.
+      let fileIndex = 0
+      const successes: string[] = []
+      const failures: Array<{ id: string; error: string }> = []
 
-    const processNextFile = async (): Promise<void> => {
-      while (true) {
-        const file = toUpload[fileIndex++]
-        if (!file?.file) return
+      const processNextFile = async (): Promise<void> => {
+        while (true) {
+          const file = toUpload[fileIndex++]
+          if (!file?.file) return
 
-        const mimeType = file.mimeType || file.file?.type || 'application/octet-stream'
+          const mimeType = file.mimeType || file.file?.type || 'application/octet-stream'
 
-        try {
-          // 1. Create presigned session (per file)
-          const presignedConfig = await get().transport.createSession({
-            fileName: file.name,
-            mimeType,
-            expectedSize: file.size ?? 0,
-            provider: 'S3',
-            entityType: session.entityType,
-            entityId: session.entityId,
-            // Forward client session metadata to server
-            metadata: session.metadata || {},
-          })
+          try {
+            // 1. Create presigned session (per file)
+            const presignedConfig = await get().transport.createSession({
+              fileName: file.name,
+              mimeType,
+              expectedSize: file.size ?? 0,
+              provider: 'S3',
+              entityType: session.entityType,
+              entityId: session.entityId,
+              // Forward client session metadata to server
+              metadata: session.metadata || {},
+            })
 
-          // Store the server-side session ID. This is an UPLOAD SESSION nanoid, not a
-          // server record id — `serverIdKind` says so, so a consumer that needs a real
-          // `MediaAsset` id can tell it apart (see §11.3).
-          set((state) => {
-            const fs = state.files[file.id]
-            if (fs) {
-              fs.serverFileId = presignedConfig.sessionId
-              fs.metadata = { ...fs.metadata, serverIdKind: 'session' }
-            }
-          })
-
-          // 2. Upload file directly to storage
-          get().updateFileStatus(file.id, 'uploading')
-
-          // Mark first stage as active when upload starts
-          get().updateFileProgress(file.id, {
-            stages: file.stages?.map((s, idx) => ({
-              ...s,
-              status: idx === 0 ? 'active' : 'pending',
-            })),
-          })
-
-          const { abort, promise } = get().transport.uploadObject({
-            file: file.file,
-            config: presignedConfig,
-            onProgress: (progress) => {
-              get().updateFileProgress(file.id, {
-                fileId: file.id,
-                filename: file.name,
-                overallProgress: progress.percentage,
-                uploadProgress: progress.percentage,
-                bytesUploaded: progress.loaded,
-                totalBytes: progress.total,
-                // Don't pass stages: [] to avoid clearing stages
-              })
-            },
-          })
-
-          // Track for cancellation
-          get().setInFlight(file.id, abort)
-
-          const uploadResult = await promise
-          get().clearInFlight(file.id)
-          get().updateFileStatus(file.id, 'processing')
-
-          // Mark first stage as completed and second as active when switching to processing
-          get().updateFileProgress(file.id, {
-            stages: file.stages?.map((s, idx) => ({
-              ...s,
-              status: idx === 0 ? 'completed' : idx === 1 ? 'active' : 'pending',
-              progress: idx === 0 ? 100 : 0,
-            })),
-          })
-
-          // 3. Complete the upload
-          const completionData = await get().transport.completeSession(presignedConfig.sessionId, {
-            storageKey: presignedConfig.storageKey, // Use storage key from session creation
-            size: file.size ?? 0,
-            mimeType,
-            etag: uploadResult.etag,
-            uploadId: uploadResult.uploadId,
-            parts: uploadResult.parts,
-          })
-
-          // Which kind of server record the completion actually produced — see
-          // `transport/server-id.ts` and guide §11.3.
-          const { serverId, kind: serverIdKind } = resolveServerId(completionData)
-
-          // Atomic update: set serverFileId, url, and status together
-          // This prevents race conditions where onComplete reads state before serverFileId is set
-          set((state) => {
-            const f = state.files[file.id]
-            if (f) {
-              // Store the server record id (asset first, file second) as serverFileId
-              if (serverId) {
-                f.serverFileId = serverId
+            // Store the server-side session ID. This is an UPLOAD SESSION nanoid, not a
+            // server record id — `serverIdKind` says so, so a consumer that needs a real
+            // `MediaAsset` id can tell it apart (see §11.3).
+            set((state) => {
+              const fs = state.files[file.id]
+              if (fs) {
+                fs.serverFileId = presignedConfig.sessionId
+                fs.metadata = { ...fs.metadata, serverIdKind: 'session' }
               }
-              f.metadata = { ...f.metadata, serverIdKind }
-              // Store URL for previews
-              if (completionData?.url) {
-                f.url = completionData.url
+            })
+
+            // 2. Upload file directly to storage
+            get().updateFileStatus(file.id, 'uploading')
+
+            // Mark first stage as active when upload starts
+            get().updateFileProgress(file.id, {
+              stages: file.stages?.map((s, idx) => ({
+                ...s,
+                status: idx === 0 ? 'active' : 'pending',
+              })),
+            })
+
+            const { abort, promise } = get().transport.uploadObject({
+              file: file.file,
+              config: presignedConfig,
+              onProgress: (progress) => {
+                get().updateFileProgress(file.id, {
+                  fileId: file.id,
+                  filename: file.name,
+                  overallProgress: progress.percentage,
+                  uploadProgress: progress.percentage,
+                  bytesUploaded: progress.loaded,
+                  totalBytes: progress.total,
+                  // Don't pass stages: [] to avoid clearing stages
+                })
+              },
+            })
+
+            // Track for cancellation
+            get().setInFlight(file.id, abort)
+
+            const uploadResult = await promise
+            get().clearInFlight(file.id)
+            get().updateFileStatus(file.id, 'processing')
+
+            // Mark first stage as completed and second as active when switching to processing
+            get().updateFileProgress(file.id, {
+              stages: file.stages?.map((s, idx) => ({
+                ...s,
+                status: idx === 0 ? 'completed' : idx === 1 ? 'active' : 'pending',
+                progress: idx === 0 ? 100 : 0,
+              })),
+            })
+
+            // 3. Complete the upload
+            const completionData = await get().transport.completeSession(
+              presignedConfig.sessionId,
+              {
+                storageKey: presignedConfig.storageKey, // Use storage key from session creation
+                size: file.size ?? 0,
+                mimeType,
+                etag: uploadResult.etag,
+                uploadId: uploadResult.uploadId,
+                parts: uploadResult.parts,
               }
-              // Set status to completed
-              f.status = 'completed'
-              f.progress = 100
-              // Update stages
-              if (f.stages) {
-                f.stages = f.stages.map((s) => ({ ...s, status: 'completed', progress: 100 }))
+            )
+
+            // Which kind of server record the completion actually produced — see
+            // `transport/server-id.ts` and guide §11.3.
+            const { serverId, kind: serverIdKind } = resolveServerId(completionData)
+
+            // Atomic update: set serverFileId, url, and status together
+            // This prevents race conditions where onComplete reads state before serverFileId is set
+            set((state) => {
+              const f = state.files[file.id]
+              if (f) {
+                // Store the server record id (asset first, file second) as serverFileId
+                if (serverId) {
+                  f.serverFileId = serverId
+                }
+                f.metadata = { ...f.metadata, serverIdKind }
+                // Store URL for previews
+                if (completionData?.url) {
+                  f.url = completionData.url
+                }
+                // Set status to completed
+                f.status = 'completed'
+                f.progress = 100
+                // Update stages
+                if (f.stages) {
+                  f.stages = f.stages.map((s) => ({ ...s, status: 'completed', progress: 100 }))
+                }
               }
-            }
-          })
-          successes.push(file.id)
-        } catch (error) {
-          const message = error instanceof Error ? error.message : 'Upload failed'
-          // For a transport failure `message` is now the server's own prose — the
-          // storage-quota upgrade prompt, the 422 policy reason — instead of the
-          // `"Session create failed (403)"` placeholder the inline fetch produced.
-          get().addError({
-            message,
-            code: isUploadTransportError(error) ? error.code : undefined,
-            details: isUploadTransportError(error) ? error.details : undefined,
-            fileId: file.id,
-            sessionId: sessionId!,
-            recoverable: true,
-          })
-          // `setFileError`, not `updateFileStatus('failed')`: the latter leaves
-          // `FileState.error` unset (its own comment says "caller should also set
-          // error ... separately" and no caller ever did), so every failed upload
-          // reached `BatchUploadResult.results[].error` and `toUploadResult` as
-          // `undefined` — a second place the real message died.
-          get().setFileError(file.id, message)
-          failures.push({ id: file.id, error: message })
-          get().clearInFlight(file.id)
+            })
+            successes.push(file.id)
+          } catch (error) {
+            const message = error instanceof Error ? error.message : 'Upload failed'
+            // For a transport failure `message` is now the server's own prose — the
+            // storage-quota upgrade prompt, the 422 policy reason — instead of the
+            // `"Session create failed (403)"` placeholder the inline fetch produced.
+            get().addError({
+              message,
+              code: isUploadTransportError(error) ? error.code : undefined,
+              details: isUploadTransportError(error) ? error.details : undefined,
+              fileId: file.id,
+              sessionId: targetSessionId,
+              recoverable: true,
+            })
+            // `setFileError`, not `updateFileStatus('failed')`: the latter leaves
+            // `FileState.error` unset (its own comment says "caller should also set
+            // error ... separately" and no caller ever did), so every failed upload
+            // reached `BatchUploadResult.results[].error` and `toUploadResult` as
+            // `undefined` — a second place the real message died.
+            get().setFileError(file.id, message)
+            failures.push({ id: file.id, error: message })
+            get().clearInFlight(file.id)
+          }
         }
+      }
+
+      // Start concurrent processing pool
+      const poolSize = Math.min(maxConcurrency, toUpload.length)
+      await Promise.all(new Array(poolSize).fill(0).map(() => processNextFile()))
+
+      const finalFiles = session.fileIds.map((id) => get().files[id]).filter((f) => f !== undefined)
+      return {
+        totalFiles: finalFiles.length,
+        successCount: successes.length,
+        failedCount: failures.length,
+        results: finalFiles.map((f) => ({
+          fileId: f.id,
+          filename: f.name,
+          success: f.status === 'completed',
+          error: f.error,
+          url: f.url,
+          checksum: f.checksum,
+        })),
+        overallProgress: get().calculateOverallProgress(targetSessionId),
       }
     }
 
-    // Start concurrent processing pool
-    const poolSize = Math.min(maxConcurrency, toUpload.length)
-    await Promise.all(new Array(poolSize).fill(0).map(() => processNextFile()))
-
-    // Finalize
+    // Start the run, then publish it. `run()` cannot reach its own bookkeeping before
+    // this `set` — its cleanup lives out here, not inside the promise.
+    const promise = run()
     set((state) => {
-      state.uploading = false
+      state.sessionRuns[targetSessionId] = { promise }
+      state.uploading = true
+      const target = state.sessions[targetSessionId]
+      if (target) {
+        target.uploading = true
+        target.uploadStartTime = Date.now()
+      }
     })
 
-    const finalFiles = session.fileIds.map((id) => get().files[id]).filter((f) => f !== undefined)
-    return {
-      totalFiles: finalFiles.length,
-      successCount: successes.length,
-      failedCount: failures.length,
-      results: finalFiles.map((f) => ({
-        fileId: f.id,
-        filename: f.name,
-        success: f.status === 'completed',
-        error: f.error,
-        url: f.url,
-        checksum: f.checksum,
-      })),
-      overallProgress: get().calculateOverallProgress(sessionId!),
+    let result: BatchUploadResult | undefined
+    let failure: string | undefined
+    try {
+      result = await promise
+      return result
+    } catch (error) {
+      failure = error instanceof Error ? error.message : 'Upload failed'
+      throw error
+    } finally {
+      set((state) => {
+        delete state.sessionRuns[targetSessionId]
+        // The global flag is derived from the runs, not stamped: another session may
+        // still be uploading, and clearing it unconditionally stopped its spinner.
+        state.uploading = Object.keys(state.sessionRuns).length > 0
+        const target = state.sessions[targetSessionId]
+        if (target) {
+          // Always cleared, including on the "nothing pending" early return, which used
+          // to leave the session stuck reading `uploading: true` forever.
+          target.uploading = false
+          if (result) target.uploadResult = result
+          if (failure) target.uploadError = failure
+        }
+      })
     }
   },
 
   /**
-   * Upload with concurrency guard - uploads files for a specific session
+   * @deprecated Use `startUpload(sessionId)`.
+   *
+   * Kept only so callers outside this module keep working. It no longer reassigns
+   * `activeSessionId` around the call: the per-session guard, the session bookkeeping
+   * and the run record all live in `startUpload` now.
    */
-  startUploadForSession: async (sessionId: string): Promise<BatchUploadResult> => {
-    // Check if upload is already in progress for this session
-    const existingPromise = uploadPromises.get(sessionId)
-    if (existingPromise) {
-      console.log('[startUploadForSession] Upload already in progress, returning existing promise')
-      return existingPromise
-    }
-
-    const uploadPromise = (async () => {
-      try {
-        // Mark session as uploading (per-session state)
-        set((state) => {
-          const session = state.sessions[sessionId]
-          if (session) {
-            session.uploading = true
-            session.uploadStartTime = Date.now()
-          }
-        })
-
-        // Get files for this session
-        const freshState = get()
-        const session = freshState.sessions[sessionId]
-        if (!session) {
-          throw new Error('Session not found')
-        }
-
-        const filesToUpload = session.fileIds
-          .map((id) => freshState.files[id])
-          .filter((f) => f && (f.status === 'pending' || f.status === 'failed'))
-
-        if (filesToUpload.length === 0) {
-          return {
-            totalFiles: 0,
-            successCount: 0,
-            failedCount: 0,
-            results: [],
-            overallProgress: 0,
-          }
-        }
-
-        // Use the existing startUpload logic but scoped to this session
-        const currentActiveSession = freshState.activeSessionId
-
-        // Temporarily set this session as active for startUpload
-        set((state) => {
-          state.activeSessionId = sessionId
-        })
-
-        try {
-          const result = await get().startUpload()
-
-          // Store result in session for future reference
-          set((state) => {
-            const session = state.sessions[sessionId]
-            if (session) {
-              session.uploading = false
-              session.uploadResult = result
-            }
-          })
-
-          return result
-        } finally {
-          // Restore previous active session if different
-          if (currentActiveSession !== sessionId) {
-            set((state) => {
-              state.activeSessionId = currentActiveSession
-            })
-          }
-        }
-      } catch (error) {
-        // Handle error
-        set((state) => {
-          const session = state.sessions[sessionId]
-          if (session) {
-            session.uploading = false
-            session.uploadError = error instanceof Error ? error.message : 'Upload failed'
-          }
-        })
-
-        throw error
-      } finally {
-        // Clear the promise
-        uploadPromises.delete(sessionId)
-      }
-    })()
-
-    // Store the promise
-    uploadPromises.set(sessionId, uploadPromise)
-
-    return uploadPromise
-  },
+  startUploadForSession: (sessionId: string): Promise<BatchUploadResult> =>
+    get().startUpload(sessionId),
 
   /**
    * Enhanced upload cancellation with per-file abort tracking
    */
-  cancelUpload: () => {
+  cancelUpload: (sessionId?: string) => {
     const { activeSessionId, sessions, inFlight } = get()
+    const targetSessionId = sessionId ?? activeSessionId
+    const session = targetSessionId ? sessions[targetSessionId] : undefined
 
-    // Abort all in-flight uploads (per-file)
-    Object.values(inFlight).forEach((handle) => handle.abort?.())
+    // Abort only this session's files. Aborting every handle on the page cancelled a
+    // second uploader's in-flight files as collateral. With no session at all there is
+    // nothing to scope to, so fall back to the old blanket abort.
+    const abortIds = session ? session.fileIds : Object.keys(inFlight)
+    abortIds.forEach((fileId) => inFlight[fileId]?.abort?.())
     set((state) => {
-      state.inFlight = {}
+      abortIds.forEach((fileId) => {
+        delete state.inFlight[fileId]
+      })
     })
 
-    if (activeSessionId && sessions[activeSessionId]) {
+    if (session && targetSessionId) {
       // Cancel all files in session
-      sessions[activeSessionId].fileIds.forEach((fileId) => {
+      session.fileIds.forEach((fileId) => {
         get().cancelFile(fileId)
       })
 
       // Update session status
       set((state) => {
-        const session = state.sessions[activeSessionId]
-        if (session) {
-          session.status = 'cancelled'
-          session.updatedAt = new Date()
+        const target = state.sessions[targetSessionId]
+        if (target) {
+          target.status = 'cancelled'
+          target.updatedAt = new Date()
         }
       })
     }
 
     set((state) => {
-      state.uploading = false
+      // Derived, not stamped: a different session may still have a run in flight.
+      state.uploading = Object.keys(state.sessionRuns).length > 0
     })
   },
 
@@ -937,10 +927,9 @@ export const createEnhancedOrchestrationSlice: StateCreator<
       }
     })
 
-    // Restart upload if this is the active session
-    if (sessionId === get().activeSessionId) {
-      await get().startUpload()
-    }
+    // Restart this session's upload. It used to run only when the session happened to
+    // be the active one, so retrying any other session reset the statuses and stopped.
+    await get().startUpload(sessionId)
   },
 
   /**

--- a/apps/web/src/components/file-upload/stores/slices/ui-slice.ts
+++ b/apps/web/src/components/file-upload/stores/slices/ui-slice.ts
@@ -131,6 +131,11 @@ export const createUISlice: StateCreator<
       state.uploading = false
       state.errors = []
 
+      // Orchestration bookkeeping. These were module-level `Map`s that outlived every
+      // reset, so an in-flight guard from one test blocked the next one's upload.
+      state.sessionRuns = {}
+      state.uploaderRuns = {}
+
       // Keep config but reset error deduplication
       state.recentErrorHashes = {}
     })

--- a/apps/web/src/components/file-upload/stores/types.ts
+++ b/apps/web/src/components/file-upload/stores/types.ts
@@ -124,6 +124,29 @@ export interface SessionState {
   // REMOVED: organizationId, userId (auth handled server-side)
 }
 
+/**
+ * One session's in-flight upload run.
+ *
+ * Per-session orchestration state used to live in module-level `Map`s that survived
+ * every `reset()`; keeping it here means a reset really resets it and a test can read
+ * it instead of inferring it.
+ */
+export interface SessionRun {
+  /** The run in flight. A second `startUpload` for the same session joins this. */
+  promise: Promise<BatchUploadResult>
+}
+
+/**
+ * One uploader's in-flight session creation. Keyed by uploader rather than session
+ * because the session id is what the promise is still producing.
+ */
+export interface UploaderRun {
+  /** The `createSessionWithGuard` call in flight; concurrent callers join it. */
+  createPromise: Promise<string>
+  /** Aborts that creation when the uploader unmounts. */
+  abortController: AbortController
+}
+
 export interface UploadError {
   id: string
   message: string
@@ -175,6 +198,11 @@ export interface UploadState {
   // Per-file abort tracking for presigned uploads
   inFlight: Record<string, { abort?: () => void }>
   // REMOVED: paused (offline pause/resume functionality)
+
+  /** In-flight upload runs, keyed by session id. */
+  sessionRuns: Record<string, SessionRun>
+  /** In-flight session creations, keyed by uploader id. */
+  uploaderRuns: Record<string, UploaderRun>
 
   /**
    * How the uploader reaches the network. Defaults to the real HTTP transport;
@@ -235,10 +263,15 @@ export interface UploadActions {
      *  not failures; see the orchestration slice. */
     skippedDuplicates: string[]
   }>
-  startUpload: () => Promise<BatchUploadResult>
+  /** Upload one session's pending files; defaults to the active session. */
+  startUpload: (sessionId?: string) => Promise<BatchUploadResult>
+  /** @deprecated Alias for `startUpload(sessionId)`. */
   startUploadForSession: (sessionId: string) => Promise<BatchUploadResult>
   createSessionWithGuard: (uploaderId: string, options: CreateSessionOptions) => Promise<string>
-  cancelUpload: () => void
+  /** Drop an uploader's in-flight session creation and abort its controller. */
+  cleanupUploader: (uploaderId: string) => void
+  /** Cancel one session's upload; defaults to the active session. */
+  cancelUpload: (sessionId?: string) => void
   validateAndAddFiles: (
     files: File[],
     sessionId?: string

--- a/apps/web/src/components/file-upload/stores/upload-store.ts
+++ b/apps/web/src/components/file-upload/stores/upload-store.ts
@@ -5,13 +5,10 @@ import { devtools } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
 import { createEntitySlice } from './slices/entity-slice'
 import { createFileSlice } from './slices/file-slice'
-import { cleanupUploader, createEnhancedOrchestrationSlice } from './slices/orchestration-slice'
+import { createEnhancedOrchestrationSlice } from './slices/orchestration-slice'
 import { createUnifiedSessionSlice } from './slices/session-slice'
 import { createUISlice } from './slices/ui-slice'
 import type { UploadStore } from './types'
-
-// Export cleanupUploader for use in hooks
-export { cleanupUploader }
 
 /**
  * Main upload store combining all slices


### PR DESCRIPTION
> **Front end — needs a human to upload a file before merging.** The browser list is at the bottom and is unchanged from #1858; this change sits on the same paths and adds two behaviour changes of its own.

Plan: `plans/attachments/08-frontend-store.md`, PR 8b. Isolated to `apps/web/src/components/file-upload/**`, so it is independent of PR Y which is in flight elsewhere.

## What moved

The three module-level `Map`s in `orchestration-slice.ts` — and the module-level `cleanupUploader` that existed to service them — become store state. They survived `reset()`, were invisible in devtools, and were why concurrent sessions interfered.

| was (module-level, survived `reset()`) | now (store state) |
| --- | --- |
| `uploadPromises: Map<sessionId, Promise<BatchUploadResult>>` | `sessionRuns[sessionId]` |
| `sessionCreatePromises: Map<uploaderId, Promise<string>>` | `uploaderRuns[id].createPromise` |
| `activeRequests: Map<uploaderId, AbortController>` | `uploaderRuns[id].abortController` |
| `export const cleanupUploader` | a store action |

## The `activeSessionId` reassignment was a live bug — proven, not argued

`startUploadForSession` captured `prev = activeSessionId`, set the global to its own session, and restored `prev` on finish. With two sessions that is a lost update: **A** starts and captures B; **B** starts and captures A, because A has already moved the global; **B finishes first and restores A.**

Rather than assert this, the agent restored the six affected files from `HEAD` read-only, wrote a probe test using only APIs both versions share, and ran it. **Both assertions failed on `main`:**

- the store ends up pointing at a session the user never selected — and `addFiles`' fallback, `cancelUpload`, `retrySession` and `useFileUpload`'s `onComplete` all route off that global;
- **B's finalize stamped `uploading = false` while A was still writing bytes**, killing A's spinner.

The probe was then deleted and the working files restored, md5-verified against a backup.

## Two extras beyond the plan's letter, because they read the same global

- **`cancelUpload` takes an optional session.** It used to abort **every** in-flight handle on the page.
- **`uploading` is derived** from `sessionRuns` rather than stamped, so one session finishing cannot clear another's flag.
- **`useFileUpload`'s `onComplete` keys off the uploader's own session** rather than `getState().activeSessionId`. This one was *required*, not optional: dispatch no longer pins the global for the duration of an upload.

`startUploadForSession` survives as a one-line `@deprecated` alias, so the single caller outside this directory (`components/fields/inputs/hooks/use-field-file-upload.ts`) needed no edit.

## One plan item deliberately not done

The pool cursor `fileIndex` stays a closure local. It's created per run, and with one run per session enforced by the join guard it is *already* per-session; storing it would mean a `set()` and a re-render per file, and would let `reset()` corrupt a running pool. The thing that actually interleaved was `activeSessionId`. There's a code comment saying so.

## Now testable that was not

Two sessions uploading concurrently without trading `activeSessionId` or the global `uploading` flag; a second start joining the in-flight run rather than double-uploading; `reset()` actually clearing the run records; `cancelUpload(sessionId)` aborting only that session's files; `retrySession` on a non-selected session; the creation guard registering and clearing per uploader; `cleanupUploader` aborting a creation still in flight.

**9 new tests, zero `vi.mock`, zero `fetch` stubs** — built on the `UploadTransport` seam from #1858. That seam is what makes any of this reachable.

## Verified

- 53 tests across 9 files in `src/components/file-upload`, no Errors line
- 203 tests across 14 files including `file-select` / `fields` / `files`
- `tsc --noEmit` clean for `components/file-upload`
- biome errors-clean; the 4 `noUnusedVariables` warnings are pre-existing

## NOT verified — please click through before merging

Nothing here proves a byte reached storage.

1. Single-part PUT end to end, and multipart >10MB
2. **Cancel mid-multipart**
3. The 403 storage-limit and 422 policy toasts
4. The avatar uploader, and the record-field uploader (`use-field-file-upload`, which calls the aliased `startUploadForSession`)
5. The file-manager drawer's cancel-on-close path
6. **Specifically the two behaviour changes above** — a cancel now scoped to one uploader's session, and `onComplete` now keyed to the uploader's session

## Deferred to 8c

Files added *while* a run is in flight are still not picked up by that run — the join guard returns the first run's promise. Fixing it changes what the returned `BatchUploadResult` means, which is `onUploaderSettled`'s territory. `handleAPIResponse`, `coordinateSSEEvents`, `entity-slice.ts`, the SSE fields and the `use-field-file-upload` handler registry are untouched. `activeSessionId` remains as UI selection state, per the plan.