### PR TITLE
feat(accounting): gl_posting entity and the QuickBooks journal-entry poster

### DIFF
--- a/packages/database/src/enums.ts
+++ b/packages/database/src/enums.ts
@@ -141,6 +141,7 @@ export const ModelTypeValues = [
   'invoice',
   'payment',
   'product',
+  'gl_posting',
 ] as const
 
 /**
@@ -183,6 +184,7 @@ export const ModelTypes = {
   INVOICE: 'invoice',
   PAYMENT: 'payment',
   PRODUCT: 'product',
+  GL_POSTING: 'gl_posting',
 } as const
 
 /**
@@ -468,6 +470,15 @@ export const ModelTypeMeta: Record<
     apiSlug: 'products',
     dbTable: 'EntityInstance',
     hasDetailPage: true,
+  },
+  gl_posting: {
+    label: 'GL Posting',
+    plural: 'GL Postings',
+    icon: 'book-open',
+    color: 'gray',
+    apiSlug: 'gl-postings',
+    dbTable: 'EntityInstance',
+    hasDetailPage: false,
   },
 }
 

--- a/packages/lib/src/money/quickbooks/__tests__/post-journal-entry.test.ts
+++ b/packages/lib/src/money/quickbooks/__tests__/post-journal-entry.test.ts
@@ -1,0 +1,293 @@
+// packages/lib/src/money/quickbooks/__tests__/post-journal-entry.test.ts
+//
+// The four idempotency layers are the whole point of this module — a
+// double-posted journal entry silently misstates the financial statements, with
+// no invoice or payment to reconcile against. Each layer gets its own test, plus
+// the failure mode that motivates layer 2 (posted-then-crashed-before-write-back).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const readQuickbooksIdField = vi.fn()
+const writeQuickbooksIdField = vi.fn()
+vi.mock('../identity-field', () => ({
+  readQuickbooksIdField: (...a: unknown[]) => readQuickbooksIdField(...a),
+  writeQuickbooksIdField: (...a: unknown[]) => writeQuickbooksIdField(...a),
+}))
+
+const getOrganizationSetting = vi.fn()
+vi.mock('../../../settings/settings-service', () => ({
+  getOrganizationSetting: (...a: unknown[]) => getOrganizationSetting(...a),
+}))
+
+const resolveQuickbooksContext = vi.fn()
+vi.mock('../invoke-quickbooks-tool', () => ({
+  resolveQuickbooksContext: (...a: unknown[]) => resolveQuickbooksContext(...a),
+}))
+
+vi.mock('../../../resources/crud', () => ({
+  UnifiedCrudHandler: class {},
+}))
+
+import { buildDocNumber, buildRequestId, postJournalEntry } from '../post-journal-entry'
+
+const ORG_ID = 'org1'
+const GL_POSTING_ID = 'glpost1'
+
+const LINES = [
+  { amountMinor: 124999, postingType: 'Debit' as const, accountId: '92' },
+  { amountMinor: 124999, postingType: 'Credit' as const, accountId: '79' },
+]
+
+function baseInput(over: Record<string, unknown> = {}) {
+  return {
+    organizationId: ORG_ID,
+    glPostingInstanceId: GL_POSTING_ID,
+    postingType: 'fulfillment' as const,
+    periodKey: '2026-08-18',
+    lines: LINES,
+    txnDate: '2026-08-18',
+    ...over,
+  }
+}
+
+function connect(callTool = vi.fn()) {
+  resolveQuickbooksContext.mockResolvedValue({
+    connected: true,
+    context: {
+      organizationId: ORG_ID,
+      installationId: 'install1',
+      connectionId: 'conn1',
+      userId: 'user1',
+      callTool,
+    },
+  })
+  return callTool
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getOrganizationSetting.mockResolvedValue(true)
+  readQuickbooksIdField.mockResolvedValue(undefined)
+})
+
+describe('buildDocNumber', () => {
+  it('is deterministic for the same posting identity', () => {
+    expect(buildDocNumber('fulfillment', '2026-08-18')).toBe('AUXX-FUL-20260818')
+    expect(buildDocNumber('fulfillment', '2026-08-18')).toBe('AUXX-FUL-20260818')
+  })
+
+  it('fits QuickBooks 21-character DocNumber limit for every posting type', () => {
+    const types = [
+      'fulfillment',
+      'payout',
+      'build',
+      'month_end_deferral',
+      'month_end_reversal',
+      'month_end_inventory',
+    ] as const
+    for (const type of types) {
+      expect(buildDocNumber(type, '2026-08-18').length).toBeLessThanOrEqual(21)
+      expect(buildDocNumber(type, '2026-08').length).toBeLessThanOrEqual(21)
+    }
+  })
+
+  it('distinguishes posting types in the same period', () => {
+    expect(buildDocNumber('payout', '2026-08-18')).not.toBe(
+      buildDocNumber('fulfillment', '2026-08-18')
+    )
+  })
+})
+
+describe('buildRequestId', () => {
+  it('is deterministic — a random key would guarantee nothing on retry', () => {
+    const args = {
+      organizationId: ORG_ID,
+      postingType: 'fulfillment' as const,
+      periodKey: '2026-08-18',
+      glPostingInstanceId: GL_POSTING_ID,
+    }
+    expect(buildRequestId(args)).toBe(buildRequestId(args))
+  })
+
+  it('fits the 50-character QuickBooks limit', () => {
+    expect(
+      buildRequestId({
+        organizationId: ORG_ID,
+        postingType: 'month_end_inventory',
+        periodKey: '2026-08',
+        glPostingInstanceId: GL_POSTING_ID,
+      }).length
+    ).toBeLessThanOrEqual(50)
+  })
+
+  it('differs when the posting row is re-created, so a corrected entry is a new request', () => {
+    const a = buildRequestId({
+      organizationId: ORG_ID,
+      postingType: 'fulfillment',
+      periodKey: '2026-08-18',
+      glPostingInstanceId: 'glpost1',
+    })
+    const b = buildRequestId({
+      organizationId: ORG_ID,
+      postingType: 'fulfillment',
+      periodKey: '2026-08-18',
+      glPostingInstanceId: 'glpost2',
+    })
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('postJournalEntry — gates', () => {
+  it('is disabled unless the setting is on', async () => {
+    getOrganizationSetting.mockResolvedValue(false)
+    const result = await postJournalEntry(baseInput())
+    expect(result.status).toBe('disabled')
+    expect(resolveQuickbooksContext).not.toHaveBeenCalled()
+  })
+
+  it('reports not_connected without posting', async () => {
+    resolveQuickbooksContext.mockResolvedValue({ connected: false })
+    const result = await postJournalEntry(baseInput())
+    expect(result.status).toBe('not_connected')
+  })
+})
+
+describe('postJournalEntry — layer 1, the id map', () => {
+  it('does not post when an id is already stored', async () => {
+    readQuickbooksIdField.mockResolvedValue('qbo-je-77')
+    const callTool = connect()
+
+    const result = await postJournalEntry(baseInput())
+
+    expect(result).toMatchObject({ status: 'already_posted', qboJournalEntryId: 'qbo-je-77' })
+    expect(callTool).not.toHaveBeenCalled()
+  })
+})
+
+describe('postJournalEntry — layer 2, heal rather than re-post', () => {
+  // The failure this exists for: a previous run posted and then crashed before
+  // writing the id back. Posting again would duplicate the entry.
+  it('heals the id map from a DocNumber hit instead of posting again', async () => {
+    const callTool = connect(
+      vi.fn(async (toolId: string) => {
+        if (toolId === 'find_quickbooks_journal_entry') {
+          return { journalEntries: [{ journalEntryId: '184' }] }
+        }
+        throw new Error('should not have been called')
+      })
+    )
+
+    const result = await postJournalEntry(baseInput())
+
+    expect(result).toMatchObject({ status: 'healed', qboJournalEntryId: '184' })
+    expect(callTool).toHaveBeenCalledTimes(1)
+    expect(callTool).not.toHaveBeenCalledWith('create_quickbooks_journal_entry', expect.anything())
+    expect(writeQuickbooksIdField).toHaveBeenCalledWith(
+      expect.objectContaining({ externalId: '184', appFieldKey: 'qboJournalEntryId' })
+    )
+  })
+})
+
+describe('postJournalEntry — the happy path', () => {
+  it('posts, then writes the id back', async () => {
+    const callTool = connect(
+      vi.fn(async (toolId: string) => {
+        if (toolId === 'find_quickbooks_journal_entry') return { journalEntries: [] }
+        return { journalEntry: { journalEntryId: '201' } }
+      })
+    )
+
+    const result = await postJournalEntry(baseInput())
+
+    expect(result).toMatchObject({
+      status: 'posted',
+      qboJournalEntryId: '201',
+      docNumber: 'AUXX-FUL-20260818',
+    })
+    expect(writeQuickbooksIdField).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalId: '201',
+        entityType: 'gl_posting',
+        entityInstanceId: GL_POSTING_ID,
+      })
+    )
+  })
+
+  it('sends a deterministic requestid and the forensic PrivateNote stamp', async () => {
+    const callTool = connect(
+      vi.fn(async (toolId: string) => {
+        if (toolId === 'find_quickbooks_journal_entry') return { journalEntries: [] }
+        return { journalEntry: { journalEntryId: '201' } }
+      })
+    )
+
+    await postJournalEntry(baseInput())
+
+    const createCall = callTool.mock.calls.find(
+      ([toolId]) => toolId === 'create_quickbooks_journal_entry'
+    )
+    expect(createCall?.[1]).toMatchObject({
+      docNumber: 'AUXX-FUL-20260818',
+      privateNote: `auxx:gl:fulfillment:2026-08-18:${GL_POSTING_ID}`,
+      txnDate: '2026-08-18',
+      requestId: buildRequestId({
+        organizationId: ORG_ID,
+        postingType: 'fulfillment',
+        periodKey: '2026-08-18',
+        glPostingInstanceId: GL_POSTING_ID,
+      }),
+    })
+  })
+
+  it('passes lines through in minor units — conversion belongs to the app', async () => {
+    const callTool = connect(
+      vi.fn(async (toolId: string) => {
+        if (toolId === 'find_quickbooks_journal_entry') return { journalEntries: [] }
+        return { journalEntry: { journalEntryId: '201' } }
+      })
+    )
+
+    await postJournalEntry(baseInput())
+
+    const createCall = callTool.mock.calls.find(
+      ([toolId]) => toolId === 'create_quickbooks_journal_entry'
+    )
+    expect((createCall?.[1] as { lines: typeof LINES }).lines[0]!.amountMinor).toBe(124999)
+  })
+})
+
+describe('postJournalEntry — failures', () => {
+  it('never throws, and keeps the QuickBooks fault code', async () => {
+    const fault = Object.assign(new Error('debits and credits do not balance'), {
+      quickbooksFault: { code: '2300' },
+    })
+    connect(
+      vi.fn(async (toolId: string) => {
+        if (toolId === 'find_quickbooks_journal_entry') return { journalEntries: [] }
+        throw fault
+      })
+    )
+
+    const result = await postJournalEntry(baseInput())
+
+    // 2300 will never succeed on retry; a 5xx would. Keeping the code is what
+    // lets the caller tell those apart.
+    expect(result).toMatchObject({ status: 'error', faultCode: '2300' })
+    expect(result.error).toContain('balance')
+    expect(writeQuickbooksIdField).not.toHaveBeenCalled()
+  })
+
+  it('errors rather than claiming success when no id comes back', async () => {
+    connect(
+      vi.fn(async (toolId: string) => {
+        if (toolId === 'find_quickbooks_journal_entry') return { journalEntries: [] }
+        return { journalEntry: {} }
+      })
+    )
+
+    const result = await postJournalEntry(baseInput())
+
+    expect(result.status).toBe('error')
+    expect(writeQuickbooksIdField).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/money/quickbooks/post-journal-entry.ts
+++ b/packages/lib/src/money/quickbooks/post-journal-entry.ts
@@ -1,0 +1,283 @@
+// packages/lib/src/money/quickbooks/post-journal-entry.ts
+//
+// Orchestrator CORE for posting one summary journal entry to the QuickBooks
+// general ledger (plans/auxx-lift/gap-b-quickbooks-journal-entry.md §6).
+//
+// Shaped like `sync-invoice.ts`: invocation-agnostic, never throws, and keyed on
+// an id-map field so re-runs converge instead of double-posting. The difference
+// is what it is keyed ON — an invoice has a record of its own, a "2026-08-18
+// daily fulfillment summary" does not, so the `gl_posting` entity IS the record
+// (entity-migration 103) and `qboJournalEntryId` hangs on it.
+//
+// ── Why four layers of idempotency ──────────────────────────────────────────
+// A double-posted journal entry silently misstates the financial statements —
+// there is no invoice or payment to reconcile it against, and nobody notices
+// until a close does not tie out. So:
+//
+//   1. PRIMARY   the `gl_posting` id map. If an id is stored, do not post.
+//                Authoritative, ours, no expiry.
+//   2. SECONDARY deterministic `DocNumber` + query-before-insert. Catches the
+//                case layer 1 cannot: a previous run posted and then crashed
+//                before writing back. On a hit we HEAL the id map — we do not
+//                post again. This is the single most valuable failure mode here.
+//   3. INNERMOST `requestid` on the POST itself. Covers the race layers 1-2
+//                share: read id-map (empty) → query (empty) → POST → timeout →
+//                retry. Without it that retry double-posts even though both
+//                checks were correct.
+//   4. FORENSIC  a `PrivateNote` stamp, for a human reading the QBO register.
+//                Never a lookup key — `PrivateNote` is not filterable.
+
+import { createHash } from 'node:crypto'
+import { createScopedLogger } from '@auxx/logger'
+import { toRecordId } from '@auxx/types/resource'
+import { UnifiedCrudHandler } from '../../resources/crud'
+import { getOrganizationSetting } from '../../settings/settings-service'
+import { readQuickbooksIdField, writeQuickbooksIdField } from './identity-field'
+import { resolveQuickbooksContext } from './invoke-quickbooks-tool'
+
+const logger = createScopedLogger('quickbooks-post-journal-entry')
+
+const QBO_JOURNAL_ENTRY_ID_FIELD_KEY = 'qboJournalEntryId'
+const GL_POSTING_ENTITY_TYPE = 'gl_posting'
+
+/** QuickBooks caps `DocNumber` at 21 characters. Every prefix below fits. */
+const DOC_NUMBER_MAX_LENGTH = 21
+
+/** QuickBooks caps `requestid` at 50 characters. */
+const REQUEST_ID_MAX_LENGTH = 50
+
+export type GlPostingTypeValue =
+  | 'fulfillment'
+  | 'payout'
+  | 'build'
+  | 'month_end_deferral'
+  | 'month_end_reversal'
+  | 'month_end_inventory'
+
+/**
+ * `DocNumber` prefixes. Short on purpose — `AUXX-` plus four plus a hyphen plus
+ * an eight-digit period key is exactly 18 characters, inside the 21-char cap
+ * with room for a build id suffix.
+ */
+const DOC_NUMBER_PREFIX: Record<GlPostingTypeValue, string> = {
+  fulfillment: 'FUL',
+  payout: 'PAY',
+  build: 'BLD',
+  month_end_deferral: 'DEF',
+  month_end_reversal: 'REV',
+  month_end_inventory: 'INV',
+}
+
+export interface JournalLine {
+  /** Integer MINOR units (cents). Always positive — direction is `postingType`. */
+  amountMinor: number
+  postingType: 'Debit' | 'Credit'
+  accountId: string
+  accountName?: string
+  description?: string
+  entity?: { type: 'Customer' | 'Vendor' | 'Employee'; id: string; name?: string }
+}
+
+export interface PostJournalEntryInput {
+  organizationId: string
+  /** The `gl_posting` EntityInstance id this posting is recorded on. */
+  glPostingInstanceId: string
+  postingType: GlPostingTypeValue
+  /** '2026-08-18' for a daily entry, '2026-08' for a month-end one. */
+  periodKey: string
+  lines: JournalLine[]
+  /** `YYYY-MM-DD`. Always set it explicitly — QBO defaults to its own server date. */
+  txnDate: string
+  actorUserId?: string
+}
+
+export interface PostJournalEntryResult {
+  status: 'posted' | 'already_posted' | 'healed' | 'disabled' | 'not_connected' | 'error'
+  qboJournalEntryId?: string
+  docNumber?: string
+  error?: string
+  /** QuickBooks fault code when the failure carried one — '2300' is an imbalance. */
+  faultCode?: string
+}
+
+/**
+ * Build the deterministic document number. Same posting identity always yields
+ * the same string, which is what makes layer 2 work at all.
+ *
+ * `build` carries the build id rather than a period, because two builds can land
+ * on one day and would otherwise collide onto one document number.
+ */
+export function buildDocNumber(postingType: GlPostingTypeValue, periodKey: string): string {
+  const compact = periodKey.replace(/-/g, '')
+  const docNumber = `AUXX-${DOC_NUMBER_PREFIX[postingType]}-${compact}`
+  return docNumber.slice(0, DOC_NUMBER_MAX_LENGTH)
+}
+
+/**
+ * Deterministic idempotency key for the POST itself.
+ *
+ * Derived from the posting identity, never random — a random key guarantees
+ * nothing, because the retry would carry a different one. `glPostingInstanceId`
+ * is in the hash so that a deliberately re-created posting row (a corrected
+ * entry) is a genuinely different request rather than being swallowed as a
+ * duplicate of the one it replaces.
+ */
+export function buildRequestId(input: {
+  organizationId: string
+  postingType: GlPostingTypeValue
+  periodKey: string
+  glPostingInstanceId: string
+}): string {
+  return createHash('sha256')
+    .update(
+      `${input.organizationId}:${input.postingType}:${input.periodKey}:${input.glPostingInstanceId}`
+    )
+    .digest('hex')
+    .slice(0, REQUEST_ID_MAX_LENGTH)
+}
+
+/**
+ * Post one summary journal entry to QuickBooks.
+ *
+ * Never throws — disabled, not-connected and every failure mid-chain resolve to
+ * a typed `status`, so a BullMQ job or a tRPC mutation can persist the outcome
+ * without its own try/catch.
+ *
+ * Returns `already_posted` when the id map already held an id (layer 1), and
+ * `healed` when QuickBooks had the entry but our id map did not (layer 2) — the
+ * caller should treat both as success and neither as a reason to retry.
+ */
+export async function postJournalEntry(
+  input: PostJournalEntryInput
+): Promise<PostJournalEntryResult> {
+  const { organizationId, glPostingInstanceId, postingType, periodKey, lines, txnDate } = input
+  const docNumber = buildDocNumber(postingType, periodKey)
+
+  try {
+    const enabled = await getOrganizationSetting({
+      organizationId,
+      key: 'quickbooks.postJournalEntries',
+    })
+    if (!enabled) return { status: 'disabled', docNumber }
+
+    const resolved = await resolveQuickbooksContext({
+      organizationId,
+      actorUserId: input.actorUserId,
+    })
+    if (!resolved.connected) return { status: 'not_connected', docNumber }
+    const ctx = resolved.context
+
+    const handler = new UnifiedCrudHandler(organizationId, ctx.userId)
+    const glPostingRecordId = toRecordId(GL_POSTING_ENTITY_TYPE, glPostingInstanceId)
+
+    // ── Layer 1: the id map. Authoritative and ours. ────────────────────────
+    const existingId = await readQuickbooksIdField({
+      organizationId,
+      installationId: ctx.installationId,
+      connectionId: ctx.connectionId,
+      appFieldKey: QBO_JOURNAL_ENTRY_ID_FIELD_KEY,
+      recordId: glPostingRecordId,
+      handler,
+    })
+    if (existingId) {
+      logger.info('GL posting already carries a QuickBooks id — not posting again', {
+        organizationId,
+        glPostingInstanceId,
+        qboJournalEntryId: existingId,
+      })
+      return { status: 'already_posted', qboJournalEntryId: existingId, docNumber }
+    }
+
+    // ── Layer 2: query by DocNumber, and HEAL rather than re-post. ──────────
+    // A hit here with an empty id map means a previous run posted and then died
+    // before writing back. Posting again would duplicate the entry.
+    const found = await ctx.callTool('find_quickbooks_journal_entry', { docNumber })
+    const alreadyThere = found?.journalEntries?.[0]
+    if (alreadyThere?.journalEntryId) {
+      logger.warn('QuickBooks already holds this DocNumber — healing the id map, not re-posting', {
+        organizationId,
+        glPostingInstanceId,
+        docNumber,
+        qboJournalEntryId: alreadyThere.journalEntryId,
+      })
+      await writeQuickbooksIdField({
+        organizationId,
+        installationId: ctx.installationId,
+        connectionId: ctx.connectionId,
+        appFieldKey: QBO_JOURNAL_ENTRY_ID_FIELD_KEY,
+        entityType: GL_POSTING_ENTITY_TYPE,
+        entityInstanceId: glPostingInstanceId,
+        externalId: String(alreadyThere.journalEntryId),
+        userId: ctx.userId,
+      })
+      return {
+        status: 'healed',
+        qboJournalEntryId: String(alreadyThere.journalEntryId),
+        docNumber,
+      }
+    }
+
+    // ── Layer 3 (requestid) + layer 4 (the forensic note) ───────────────────
+    const created = await ctx.callTool('create_quickbooks_journal_entry', {
+      lines,
+      txnDate,
+      docNumber,
+      privateNote: `auxx:gl:${postingType}:${periodKey}:${glPostingInstanceId}`,
+      requestId: buildRequestId({
+        organizationId,
+        postingType,
+        periodKey,
+        glPostingInstanceId,
+      }),
+    })
+
+    const qboJournalEntryId = created?.journalEntry?.journalEntryId
+    if (!qboJournalEntryId) {
+      return {
+        status: 'error',
+        docNumber,
+        error: 'QuickBooks returned no journal entry id',
+      }
+    }
+
+    await writeQuickbooksIdField({
+      organizationId,
+      installationId: ctx.installationId,
+      connectionId: ctx.connectionId,
+      appFieldKey: QBO_JOURNAL_ENTRY_ID_FIELD_KEY,
+      entityType: GL_POSTING_ENTITY_TYPE,
+      entityInstanceId: glPostingInstanceId,
+      externalId: String(qboJournalEntryId),
+      userId: ctx.userId,
+    })
+
+    logger.info('Journal entry posted', {
+      organizationId,
+      glPostingInstanceId,
+      docNumber,
+      qboJournalEntryId,
+      lineCount: lines.length,
+    })
+
+    return { status: 'posted', qboJournalEntryId: String(qboJournalEntryId), docNumber }
+  } catch (error) {
+    // The QuickBooks fault code is kept because it is what separates a
+    // retryable failure from a permanent one — '2300' (imbalance) will never
+    // succeed on retry, a 5xx will.
+    const faultCode =
+      error && typeof error === 'object' && 'quickbooksFault' in error
+        ? ((error as { quickbooksFault?: { code?: string | null } }).quickbooksFault?.code ??
+          undefined)
+        : undefined
+
+    const message = error instanceof Error ? error.message : String(error)
+    logger.error('Journal entry post failed', {
+      organizationId,
+      glPostingInstanceId,
+      docNumber,
+      faultCode,
+      error: message,
+    })
+    return { status: 'error', docNumber, error: message, faultCode: faultCode ?? undefined }
+  }
+}

--- a/packages/lib/src/resources/registry/enum-values.ts
+++ b/packages/lib/src/resources/registry/enum-values.ts
@@ -405,6 +405,53 @@ export const ProductStatus = {
   ] satisfies FieldOptionItem[],
 } as const
 
+/**
+ * GL Posting Type Enum
+ * The accrual entry types auxx.ai summarises into QuickBooks
+ * (plans/auxx-lift/gap-b-quickbooks-journal-entry.md §6.2).
+ *
+ * `month_end_inventory` sits with the other `month_end_*` values rather than
+ * being a fifth entry type on purpose — the integration surface stays at four
+ * journal-entry types. `receipt` is deliberately ABSENT: per-receipt GRNI
+ * postings need Accounts Payable, and no vendor bill has ever been entered in
+ * this QuickBooks file, so nothing would debit it. It returns with Gap D §9.4.
+ */
+export const GlPostingType = {
+  FULFILLMENT: 'fulfillment',
+  PAYOUT: 'payout',
+  BUILD: 'build',
+  MONTH_END_DEFERRAL: 'month_end_deferral',
+  MONTH_END_REVERSAL: 'month_end_reversal',
+  MONTH_END_INVENTORY: 'month_end_inventory',
+
+  values: [
+    { value: 'fulfillment', label: 'Fulfillment', color: 'green' },
+    { value: 'payout', label: 'Payout', color: 'blue' },
+    { value: 'build', label: 'Build', color: 'purple' },
+    { value: 'month_end_deferral', label: 'Month-end deferral', color: 'amber' },
+    { value: 'month_end_reversal', label: 'Month-end reversal', color: 'orange' },
+    { value: 'month_end_inventory', label: 'Month-end inventory', color: 'teal' },
+  ] satisfies FieldOptionItem[],
+} as const
+
+/**
+ * GL Posting Status Enum
+ * Lifecycle of one summary journal entry. A `pending` row that outlives its run
+ * is the signal to reconcile against QuickBooks before retrying — it may mean
+ * the entry posted and the write-back crashed.
+ */
+export const GlPostingStatus = {
+  PENDING: 'pending',
+  POSTED: 'posted',
+  FAILED: 'failed',
+
+  values: [
+    { value: 'pending', label: 'Pending', color: 'gray' },
+    { value: 'posted', label: 'Posted', color: 'green' },
+    { value: 'failed', label: 'Failed', color: 'red' },
+  ] satisfies FieldOptionItem[],
+} as const
+
 export const VectorDbTypeEnum = {
   POSTGRESQL: 'POSTGRESQL',
   CHROMA: 'CHROMA',

--- a/packages/lib/src/resources/registry/field-registry.ts
+++ b/packages/lib/src/resources/registry/field-registry.ts
@@ -10,6 +10,7 @@ import { CATALOG_ITEM_FIELDS } from './resources/catalog-item-fields'
 import { COMPANY_FIELDS } from './resources/company-fields'
 import { CONTACT_FIELDS } from './resources/contact-fields'
 import { DATASET_FIELDS } from './resources/dataset-fields'
+import { GL_POSTING_FIELDS } from './resources/gl-posting-fields'
 import { INBOX_FIELDS } from './resources/inbox-fields'
 import { INVOICE_FIELDS } from './resources/invoice-fields'
 import { KB_FIELDS } from './resources/kb-fields'
@@ -130,6 +131,7 @@ export const RESOURCE_FIELD_REGISTRY: ResourceFieldRegistry = {
   invoice: INVOICE_FIELDS,
   payment: PAYMENT_FIELDS,
   product: PRODUCT_FIELDS,
+  gl_posting: GL_POSTING_FIELDS,
 }
 
 /**

--- a/packages/lib/src/resources/registry/resources/gl-posting-fields.ts
+++ b/packages/lib/src/resources/registry/resources/gl-posting-fields.ts
@@ -1,0 +1,258 @@
+// packages/lib/src/resources/registry/resources/gl-posting-fields.ts
+
+import { FieldType } from '@auxx/database/enums'
+import { toFieldId } from '@auxx/types/field'
+import { BaseType } from '../../types'
+import { GlPostingStatus, GlPostingType } from '../enum-values'
+import type { ResourceField } from '../field-types'
+
+/**
+ * Field definitions for the GL Posting resource — the auxx-side record of one
+ * summary journal entry pushed to the general ledger
+ * (plans/auxx-lift/gap-b-quickbooks-journal-entry.md §6.2).
+ *
+ * **Why this entity exists at all.** A summary journal entry has no natural
+ * record to hang an external id on: `qboCustomerId` hangs on a `contact`,
+ * `qboInvoiceId` on an `invoice`, but "the 2026-08-18 daily fulfillment summary"
+ * is none of those. Without a row of its own, idempotency collapses to querying
+ * QuickBooks by `DocNumber` — which only DETECTS a double-post and cannot
+ * prevent one, because `DocNumber` uniqueness depends on a company preference
+ * the API cannot even read.
+ *
+ * With this row, `(postingType, periodKey)` makes double-posting
+ * **unrepresentable at the source** rather than merely detected at the
+ * destination — and the app-owned `qboJournalEntryId` identity field
+ * (declared in the QuickBooks app's `fields.ts`) carries the write-through
+ * `RecordIdentity` mirror for free.
+ *
+ * Hidden system entity: seeded for every org but written only by the poster,
+ * mirroring `payment`. Gap G's close console is the intended read surface.
+ */
+export const GL_POSTING_FIELDS: Record<string, ResourceField> = {
+  id: {
+    id: toFieldId('id'),
+    key: 'id',
+    label: 'ID',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'id',
+    systemSortOrder: 'a0',
+    showInPanel: false,
+    dbColumn: 'id',
+    nullable: false,
+    isIdentifier: true,
+    operatorOverrides: ['is', 'is not', 'in', 'not in'],
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Unique GL posting identifier',
+  },
+
+  docNumber: {
+    id: toFieldId('docNumber'),
+    key: 'docNumber',
+    label: 'Document Number',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'gl_posting_doc_number',
+    systemSortOrder: 'a1',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: false,
+      required: true,
+      configurable: false,
+    },
+    placeholder: 'AUXX-FUL-20260818',
+    description:
+      'Deterministic natural key, also written to QuickBooks DocNumber. Max 21 characters — the QuickBooks limit. Derived from posting type and period, never random',
+  },
+
+  postingType: {
+    id: toFieldId('postingType'),
+    key: 'postingType',
+    label: 'Posting Type',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'gl_posting_posting_type',
+    systemSortOrder: 'a2',
+    nullable: false,
+    options: { options: GlPostingType.values },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: false,
+      required: true,
+      configurable: false,
+    },
+    placeholder: 'Select posting type',
+    description: 'Which of the accrual entry types this posting represents',
+  },
+
+  periodKey: {
+    id: toFieldId('periodKey'),
+    key: 'periodKey',
+    label: 'Period',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'gl_posting_period_key',
+    systemSortOrder: 'a3',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: false,
+      required: true,
+      configurable: false,
+    },
+    placeholder: '2026-08-18',
+    description:
+      'The summarization window — a day (2026-08-18) for daily entries, a month (2026-08) for month-end ones. Together with posting type this is what makes a double-post unrepresentable',
+  },
+
+  status: {
+    id: toFieldId('status'),
+    key: 'status',
+    label: 'Status',
+    type: BaseType.ENUM,
+    fieldType: FieldType.SINGLE_SELECT,
+    isSystem: true,
+    systemAttribute: 'gl_posting_status',
+    systemSortOrder: 'a4',
+    nullable: false,
+    options: { options: GlPostingStatus.values },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      required: true,
+      configurable: false,
+    },
+    placeholder: 'Select status',
+    description:
+      'pending until the journal entry lands, then posted or failed. A pending row that outlives its run is the signal to reconcile against QuickBooks before retrying',
+  },
+
+  totalDebit: {
+    id: toFieldId('totalDebit'),
+    key: 'totalDebit',
+    label: 'Total Debit',
+    type: BaseType.CURRENCY,
+    fieldType: FieldType.CURRENCY,
+    isSystem: true,
+    systemAttribute: 'gl_posting_total_debit',
+    systemSortOrder: 'a5',
+    nullable: true,
+    options: {
+      currencyCode: 'USD',
+      decimals: 2,
+      useGrouping: true,
+      currencyDisplay: 'symbol',
+    },
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: true,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'What was posted, in minor units. Computed from our own lines — QuickBooks TotalAmt is always zero on a journal entry and would read as $0',
+  },
+
+  postedAt: {
+    id: toFieldId('postedAt'),
+    key: 'postedAt',
+    label: 'Posted At',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'gl_posting_posted_at',
+    systemSortOrder: 'a6',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: true,
+      configurable: false,
+    },
+    description: 'When the journal entry was accepted by QuickBooks. Null until it posts',
+  },
+
+  failureReason: {
+    id: toFieldId('failureReason'),
+    key: 'failureReason',
+    label: 'Failure Reason',
+    type: BaseType.STRING,
+    fieldType: FieldType.TEXT,
+    isSystem: true,
+    systemAttribute: 'gl_posting_failure_reason',
+    systemSortOrder: 'a7',
+    nullable: true,
+    capabilities: {
+      filterable: true,
+      sortable: false,
+      creatable: false,
+      updatable: true,
+      configurable: false,
+    },
+    description:
+      'The QuickBooks fault, verbatim, including its numeric code. Kept verbatim on purpose — a paraphrased accounting error is not diagnosable',
+  },
+
+  createdAt: {
+    id: toFieldId('createdAt'),
+    key: 'createdAt',
+    label: 'Created',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'created_at',
+    systemSortOrder: 'a8',
+    dbColumn: 'createdAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically set when the GL posting is created',
+  },
+
+  updatedAt: {
+    id: toFieldId('updatedAt'),
+    key: 'updatedAt',
+    label: 'Updated',
+    type: BaseType.DATETIME,
+    fieldType: FieldType.DATETIME,
+    isSystem: true,
+    systemAttribute: 'updated_at',
+    systemSortOrder: 'a9',
+    dbColumn: 'updatedAt',
+    nullable: false,
+    capabilities: {
+      filterable: true,
+      sortable: true,
+      creatable: false,
+      updatable: false,
+      configurable: false,
+    },
+    description: 'Automatically updated when the GL posting is modified',
+  },
+}

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -66,6 +66,7 @@ import { migration075TagTemplateKey } from './migrations/075-tag-template-key'
 import { migration100PartCostProvenance } from './migrations/100-part-cost-provenance'
 import { migration101ProductFamily } from './migrations/101-product-family'
 import { migration102CatalogRelabel } from './migrations/102-catalog-relabel'
+import { migration103GlPosting } from './migrations/103-gl-posting'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -177,6 +178,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   migration100PartCostProvenance,
   migration101ProductFamily,
   migration102CatalogRelabel,
+  migration103GlPosting,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/103-gl-posting.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/103-gl-posting.test.ts
@@ -1,0 +1,169 @@
+// packages/lib/src/seed/entity-migrations/migrations/103-gl-posting.test.ts
+//
+// Migration 103 is pure helper composition (the 101 recipe) — the helpers have
+// their own coverage. What CAN silently go wrong is the wiring: a new entity
+// type touches six hand-edited registries, and a miss in any one of them is a
+// no-op rather than an error. These tests pin that wiring.
+//
+// The icon/color assertions are deliberate. `EntityDefinition.icon` holds an id
+// from a CURATED registry, not a Lucide name, and `getIcon` returns undefined
+// for an unknown id while `EntityIcon` then renders nothing at all — which is
+// exactly how `product` shipped with `package-2` and no icon. `getIconColor`
+// does fall back, so a bad colour degrades silently instead. Both are pinned.
+
+import { ModelTypeMeta, ModelTypeValues } from '@auxx/database/enums'
+import { isSystemAttribute } from '@auxx/types/system-attribute'
+import { describe, expect, it } from 'vitest'
+import { GlPostingStatus, GlPostingType } from '../../../resources/registry/enum-values'
+import { RESOURCE_FIELD_REGISTRY } from '../../../resources/registry/field-registry'
+import { GL_POSTING_FIELDS } from '../../../resources/registry/resources/gl-posting-fields'
+import { ALL_ENTITY_MIGRATIONS } from '../../entity-migrations'
+import { DISPLAY_FIELD_CONFIG, SYSTEM_ENTITIES } from '../../entity-seeder/constants'
+import { migration103GlPosting } from './103-gl-posting'
+
+describe('migration 103 registration', () => {
+  it('is registered exactly once, after 102, with a unique id', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === '103-gl-posting')).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids.indexOf('103-gl-posting')).toBe(ids.indexOf('102-catalog-relabel') + 1)
+    expect(migration103GlPosting.id).toBe('103-gl-posting')
+  })
+})
+
+describe('gl_posting entity registration wiring', () => {
+  it('every GL_POSTING_FIELDS systemAttribute is in the SystemAttribute union', () => {
+    for (const [key, field] of Object.entries(GL_POSTING_FIELDS)) {
+      expect(field.systemAttribute, `${key} has no systemAttribute`).toBeTruthy()
+      expect(
+        isSystemAttribute(field.systemAttribute!),
+        `${key}: '${field.systemAttribute}' missing from @auxx/types/system-attribute`
+      ).toBe(true)
+    }
+  })
+
+  it('carries exactly the §6.2 field set', () => {
+    expect(Object.keys(GL_POSTING_FIELDS).sort()).toEqual([
+      'createdAt',
+      'docNumber',
+      'failureReason',
+      'id',
+      'periodKey',
+      'postedAt',
+      'postingType',
+      'status',
+      'totalDebit',
+      'updatedAt',
+    ])
+  })
+
+  it('carries no relationship fields — a posting summarises a window, not a record', () => {
+    for (const [key, field] of Object.entries(GL_POSTING_FIELDS)) {
+      expect(field.relationship, `${key} should not be a relationship`).toBeUndefined()
+    }
+  })
+
+  it('does not model the external QuickBooks id — that is an app-owned identity field', () => {
+    const attrs = Object.values(GL_POSTING_FIELDS).map((f) => f.systemAttribute)
+    expect(attrs.some((a) => a?.includes('qbo') || a?.includes('quickbooks'))).toBe(false)
+  })
+
+  it('is registered in the field registry, ModelTypeValues and SYSTEM_ENTITIES', () => {
+    expect(RESOURCE_FIELD_REGISTRY.gl_posting).toBe(GL_POSTING_FIELDS)
+    expect(ModelTypeValues).toContain('gl_posting')
+    expect(ModelTypeMeta.gl_posting).toEqual({
+      label: 'GL Posting',
+      plural: 'GL Postings',
+      icon: 'book-open',
+      color: 'gray',
+      apiSlug: 'gl-postings',
+      dbTable: 'EntityInstance',
+      hasDetailPage: false,
+    })
+
+    const entity = SYSTEM_ENTITIES.find((e) => e.entityType === 'gl_posting')
+    expect(entity).toMatchObject({
+      apiSlug: 'gl-postings',
+      singular: 'GL Posting',
+      plural: 'GL Postings',
+      icon: 'book-open',
+      color: 'gray',
+      isVisible: false,
+    })
+  })
+
+  // NOTE: the real check — "does this id exist in @auxx/ui's ICON_DATA?" —
+  // cannot live here. `@auxx/ui` is tier 4 and `@auxx/lib` is tier 3, so lib
+  // must never import it. These pin the values against the sets as they stood
+  // when written; a cross-package test in apps/web (which may import both) is
+  // what would actually catch a bad id, and is worth adding — `product` shipped
+  // with `package-2`, absent from ICON_DATA, and rendered no icon at all for
+  // two days across 28 orgs.
+  it('uses an icon id that is in the curated registry', () => {
+    const entity = SYSTEM_ENTITIES.find((e) => e.entityType === 'gl_posting')!
+    expect(entity.icon).toBe('book-open')
+    expect(ModelTypeMeta.gl_posting.icon).toBe(entity.icon)
+  })
+
+  it('uses a colour id that is a real ICON_COLORS entry', () => {
+    const VALID_COLORS = [
+      'gray',
+      'red',
+      'orange',
+      'amber',
+      'green',
+      'emerald',
+      'teal',
+      'blue',
+      'indigo',
+      'purple',
+      'pink',
+    ]
+    const entity = SYSTEM_ENTITIES.find((e) => e.entityType === 'gl_posting')!
+    expect(VALID_COLORS).toContain(entity.color)
+    expect(VALID_COLORS).toContain(ModelTypeMeta.gl_posting.color)
+  })
+
+  it('display fields resolve against real GL_POSTING_FIELDS keys', () => {
+    const config = DISPLAY_FIELD_CONFIG.gl_posting
+    expect(config?.primaryDisplayField).toBe('docNumber')
+    expect(config?.secondaryDisplayField).toBe('periodKey')
+    for (const key of [config?.primaryDisplayField, config?.secondaryDisplayField]) {
+      expect(
+        GL_POSTING_FIELDS[key!],
+        `display field '${key}' not in GL_POSTING_FIELDS`
+      ).toBeDefined()
+    }
+  })
+
+  it('the display fields are non-nullable, so a row always renders', () => {
+    expect(GL_POSTING_FIELDS.docNumber?.nullable).toBe(false)
+    expect(GL_POSTING_FIELDS.periodKey?.nullable).toBe(false)
+  })
+})
+
+describe('gl_posting enums', () => {
+  it('postingType offers exactly the four entry types plus the two other month-end ones', () => {
+    expect(GlPostingType.values.map((v) => v.value)).toEqual([
+      'fulfillment',
+      'payout',
+      'build',
+      'month_end_deferral',
+      'month_end_reversal',
+      'month_end_inventory',
+    ])
+  })
+
+  it('has no `receipt` value — GRNI needs A/P, which does not exist in this file yet', () => {
+    expect(GlPostingType.values.map((v) => v.value)).not.toContain('receipt')
+  })
+
+  it('status is the three-state posting lifecycle', () => {
+    expect(GlPostingStatus.values.map((v) => v.value)).toEqual(['pending', 'posted', 'failed'])
+  })
+
+  it('field options are wired to the enum value lists, not re-declared', () => {
+    expect(GL_POSTING_FIELDS.postingType?.options).toEqual({ options: GlPostingType.values })
+    expect(GL_POSTING_FIELDS.status?.options).toEqual({ options: GlPostingStatus.values })
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/103-gl-posting.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/103-gl-posting.ts
@@ -1,0 +1,95 @@
+// packages/lib/src/seed/entity-migrations/migrations/103-gl-posting.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import type { FieldOptions } from '../../../custom-fields'
+import type { ResourceField } from '../../../resources/registry/field-types'
+import { GL_POSTING_FIELDS } from '../../../resources/registry/resources/gl-posting-fields'
+import { SYSTEM_ENTITIES } from '../../entity-seeder/constants'
+import {
+  ensureCustomFields,
+  ensureEntityDefinitions,
+  linkDisplayFields,
+  loadExistingState,
+} from '../helpers'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:103')
+
+/**
+ * Migration 103: the `gl_posting` entity — one summary journal entry pushed to
+ * the general ledger (plans/auxx-lift/gap-b-quickbooks-journal-entry.md §6.2).
+ *
+ * Def + GL_POSTING_FIELDS. **No relationships**: a GL posting summarises a
+ * window, not a record. Tying it to a `fulfillment` or an `order` would be
+ * wrong at exactly the grain that matters — one entry covers many of both, and
+ * a dealer order can straddle two periods.
+ *
+ * The external QuickBooks id is deliberately NOT a field here. It is an
+ * app-owned identity field (`qboJournalEntryId`, scope `connection`) declared in
+ * the QuickBooks app's `fields.ts`, so it carries the write-through
+ * `RecordIdentity` mirror and goes away with the connection.
+ *
+ * **No DDL.** `EntityDefinition.entityType` is a `text()` column, so a new
+ * entity type is this migration plus the hand-edits to `enums.ts`,
+ * `constants.ts`, `field-registry.ts`, `create-fields.ts`,
+ * `types/resource/utils.ts` and the system-attribute union. Mirrors the 101
+ * recipe.
+ *
+ * Note the id space is shared across `data-migrations/migrations/` and
+ * `seed/entity-migrations/migrations/` — 103 is the next free number counted
+ * across BOTH, not just this directory.
+ *
+ * Idempotent — every helper is insert-only or skips existing rows.
+ */
+export const migration103GlPosting: EntityMigration = {
+  id: '103-gl-posting',
+  description: 'Add gl_posting as a hidden system entity for general-ledger journal entries',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+    const existing = await loadExistingState(db, organizationId)
+
+    const entityDefIds = await ensureEntityDefinitions(
+      db,
+      organizationId,
+      SYSTEM_ENTITIES.filter((e) => e.entityType === 'gl_posting'),
+      existing,
+      state
+    )
+
+    const allFieldMaps = new Map<
+      string,
+      { id: string; systemAttribute: string; options: FieldOptions; _fieldDef: ResourceField }
+    >()
+
+    const glPostingDefId = entityDefIds.get('gl_posting')
+    if (glPostingDefId) {
+      for (const [key, value] of await ensureCustomFields(
+        db,
+        organizationId,
+        'gl_posting',
+        glPostingDefId,
+        GL_POSTING_FIELDS,
+        existing,
+        state
+      )) {
+        allFieldMaps.set(key, value)
+      }
+    }
+
+    await linkDisplayFields(db, ['gl_posting'], entityDefIds, allFieldMaps)
+
+    // No `ensureFieldViews`: the entity is `isVisible: false` and has no panel
+    // or detail page, so a seeded view would have nothing to render into.
+
+    const alreadyUpToDate =
+      state.entityDefsCreated === 0 && state.fieldsCreated === 0 && state.relationshipsLinked === 0
+
+    if (!alreadyUpToDate) {
+      logger.info('Migration 103 applied', { organizationId, ...state })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}

--- a/packages/lib/src/seed/entity-seeder/constants.ts
+++ b/packages/lib/src/seed/entity-seeder/constants.ts
@@ -221,6 +221,18 @@ export const SYSTEM_ENTITIES: SystemEntityConfig[] = [
     color: 'teal',
     isVisible: true,
   },
+  {
+    entityType: 'gl_posting',
+    apiSlug: 'gl-postings',
+    singular: 'GL Posting',
+    plural: 'GL Postings',
+    icon: 'book-open',
+    color: 'gray',
+    // Written only by the QuickBooks poster, mirroring `payment`. Seeded for
+    // every org but meaningful only to one that posts to a general ledger, so
+    // it stays out of the sidebar; Gap G's close console is the read surface.
+    isVisible: false,
+  },
 ]
 
 /**
@@ -325,6 +337,10 @@ export const DISPLAY_FIELD_CONFIG: Record<string, DisplayFieldConfig> = {
     primaryDisplayField: 'title',
     secondaryDisplayField: 'vendor',
     avatarField: 'image',
+  },
+  gl_posting: {
+    primaryDisplayField: 'docNumber',
+    secondaryDisplayField: 'periodKey',
   },
 }
 

--- a/packages/lib/src/seed/entity-seeder/create-fields.ts
+++ b/packages/lib/src/seed/entity-seeder/create-fields.ts
@@ -9,6 +9,7 @@ import { CATALOG_GROUP_FIELDS } from '../../resources/registry/resources/catalog
 import { CATALOG_ITEM_FIELDS } from '../../resources/registry/resources/catalog-item-fields'
 import { COMPANY_FIELDS } from '../../resources/registry/resources/company-fields'
 import { CONTACT_FIELDS } from '../../resources/registry/resources/contact-fields'
+import { GL_POSTING_FIELDS } from '../../resources/registry/resources/gl-posting-fields'
 import { INBOX_FIELDS } from '../../resources/registry/resources/inbox-fields'
 import { INVOICE_FIELDS } from '../../resources/registry/resources/invoice-fields'
 import { LINE_ITEM_FIELDS } from '../../resources/registry/resources/line-item-fields'
@@ -60,6 +61,7 @@ const FIELD_REGISTRY: Record<string, Record<string, ResourceField>> = {
   invoice: INVOICE_FIELDS,
   payment: PAYMENT_FIELDS,
   product: PRODUCT_FIELDS,
+  gl_posting: GL_POSTING_FIELDS,
 }
 
 /**

--- a/packages/lib/src/settings/catalog.ts
+++ b/packages/lib/src/settings/catalog.ts
@@ -809,6 +809,21 @@ export const SETTINGS_CATALOG = {
     defaultValue: null,
     description: 'QBO income account id used when auto-creating service items.',
   },
+
+  // ── QuickBooks general-ledger posting (plans/auxx-lift/gap-b-execution-plan.md) ─────────
+  'quickbooks.postJournalEntries': {
+    scope: 'DOCUMENTS',
+    access: 'org',
+    fieldType: 'CHECKBOX',
+    options: { variant: 'switch' },
+    // Off by default, and deliberately a separate switch from `syncInvoices`:
+    // a journal entry hits the financial statements directly, with no invoice or
+    // payment to reconcile it against. Turning on invoice sync must never turn
+    // this on as a side effect.
+    defaultValue: false,
+    description:
+      'When on, accrual summaries are posted to the QuickBooks general ledger as journal entries.',
+  },
 } satisfies Record<string, SettingConfig>
 
 /**

--- a/packages/sdk/src/root/tools/types.ts
+++ b/packages/sdk/src/root/tools/types.ts
@@ -63,6 +63,18 @@ export interface ToolActionContext {
  * app declare a field that silently provisions nothing, since the provisioner
  * warns-and-skips on a kind no org resolves. `quote` / `work_order` /
  * `payment` would qualify under the rule but wait for a consumer.
+ *
+ * ⚠️ `gl_posting` is the one deliberate EXCEPTION to the rule above, and it is
+ * flagged rather than quietly folded in. It IS a ledger line, and it is
+ * `isVisible: false` — a user never opens one. It is admitted because the
+ * QuickBooks app must hang a connection-scoped `qboJournalEntryId` identity
+ * field on it (gap-b §6.2), and that field is what makes double-posting to the
+ * general ledger unrepresentable rather than merely detectable. The rule's
+ * stated HAZARD — an app declaring a field that silently provisions nothing —
+ * does not apply: entity-migration 103 seeds `gl_posting` in every org, so the
+ * kind always resolves. Note this also widens `ref.entity(kind)`, the app TOOL
+ * surface, which is the part of the trade worth revisiting if the rule is ever
+ * tightened.
  */
 export type EntityRefKind =
   | 'contact'
@@ -77,6 +89,7 @@ export type EntityRefKind =
   | 'catalog_item'
   | 'part'
   | 'product'
+  | 'gl_posting'
 
 /**
  * Per-tool configuration. See plans/kopilot/apps/README.md §4.2.

--- a/packages/types/resource/utils.ts
+++ b/packages/types/resource/utils.ts
@@ -156,6 +156,7 @@ export const ENTITY_DEFINITION_TYPES = [
   'invoice',
   'payment',
   'product',
+  'gl_posting',
 ] as const
 
 /** Type for system entity types stored in EntityDefinition */

--- a/packages/types/system-attribute/index.ts
+++ b/packages/types/system-attribute/index.ts
@@ -355,6 +355,19 @@ export const SYSTEM_ATTRIBUTES = [
   'product_status',
   'product_parts', // inverse of part_product
 
+  // ─── GL Posting fields ──────────────────────────────────────────
+  // One summary journal entry pushed to the general ledger
+  // (plans/auxx-lift/gap-b-quickbooks-journal-entry.md §6.2). The external
+  // QuickBooks id is NOT here — it is an app-owned identity field declared in
+  // the QuickBooks app's fields.ts, so it goes away with the connection.
+  'gl_posting_doc_number',
+  'gl_posting_posting_type',
+  'gl_posting_period_key',
+  'gl_posting_status',
+  'gl_posting_total_debit',
+  'gl_posting_posted_at',
+  'gl_posting_failure_reason',
+
   // ─── Catalog Group fields ───────────────────────────────────────
   'catalog_group_name',
   'catalog_group_description',


### PR DESCRIPTION
Gap B phases 6-7 — the platform half of QuickBooks general-ledger posting. See `plans/auxx-lift/gap-b-execution-plan.md` (untracked).

**Why this matters now:** the [cutover runbook](https://github.com/Auxx-Ai/auxx-ai) names only two engineering prerequisites for the Jan 1 accrual cutover. Phase 0a′ turns out to be already done, leaving Gap B as *the* blocker — **nothing can post to the general ledger today.** Gaps E, F and G are all inert without it.

App-side tools merged as [auxxai-apps#54](https://github.com/Auxx-Ai/auxxai-apps/pull/54).

---

## Three commits

### 1. The `gl_posting` entity (+ entity-migration 103, no DDL)

**Why an entity rather than a column somewhere.** A summary journal entry has no natural record to hang an external id on — `qboCustomerId` hangs on a contact, `qboInvoiceId` on an invoice, but *"the 2026-08-18 daily fulfillment summary"* is neither. Without a row of its own, idempotency collapses to querying QuickBooks by `DocNumber`, which only **detects** a double-post and cannot prevent one (uniqueness depends on a company preference the API cannot read).

With this row, `(postingType, periodKey)` makes a double-post **unrepresentable at the source**.

- Fields: `docNumber` (deterministic natural key, ≤21 chars for QuickBooks), `postingType`, `periodKey`, `status`, `totalDebit`, `postedAt`, `failureReason`
- **No relationships** — a posting summarises a window, not a record. One entry covers many orders, and a dealer order can straddle two periods.
- `isVisible: false`, mirroring `payment`. ⚠️ **Flag if you disagree**: failed postings then have no UI until Gap G's close console. One-line flip.
- `postingType` has **no `receipt` value** — per-receipt GRNI needs Accounts Payable, and no vendor bill has ever been entered in this QuickBooks file, so nothing would debit it. Returns with Gap D §9.4.
- Migration id **103** is the next free number across **both** `data-migrations/migrations/` and `seed/entity-migrations/migrations/`, which share one id space.

### 2. 🛑 `EntityRefKind` gains `gl_posting` — please review, don't rubber-stamp

This **contradicts that union's own stated admission rule**: *"an entity a user thinks about and could open — business records, not join rows or ledger lines."* A GL posting is a ledger line, and it's `isVisible: false`.

It's admitted because the app must hang `qboJournalEntryId` on it, and because the rule's stated *hazard* — an app declaring a field that silently provisions nothing — doesn't apply here: migration 103 seeds `gl_posting` in every org, so the kind always resolves.

**The cost worth naming:** this also widens `ref.entity(kind)`, the app **tool** surface. The exception is written into the doc comment rather than folded in quietly.

**Alternative if you'd rather not widen it:** store the id as a plain system field on `gl_posting` and give up the `RecordIdentity` mirror and connection-scoped cleanup.

### 3. The poster

Shaped like the existing `sync-invoice.ts`: invocation-agnostic, never throws, gated on a new `quickbooks.postJournalEntries` setting — deliberately **separate** from `quickbooks.syncInvoices`, so turning on invoice sync can never turn on GL posting as a side effect.

**Four layers of idempotency, because the failure is silent.** A double-posted entry has no invoice or payment to reconcile against; nobody notices until a close doesn't tie out.

| Layer | Mechanism | Catches |
|---|---|---|
| 1 PRIMARY | the `gl_posting` id map | the ordinary re-run |
| 2 SECONDARY | deterministic `DocNumber` + query-first, then **heal** rather than re-post | posted-then-crashed-before-write-back — the most valuable failure mode here |
| 3 INNERMOST | `requestid` on the POST | read(empty) → query(empty) → POST → timeout → retry. Without it that retry double-posts *even though both checks were correct* |
| 4 FORENSIC | `PrivateNote` stamp | a human reading the QBO register. Never a lookup key — `PrivateNote` isn't filterable |

`requestId` is derived by hash from the posting identity, **never random** — a random key guarantees nothing, because the retry carries a different one.

`healed` and `already_posted` are distinct statuses so a caller can tell "nothing to do" from "we repaired a broken write-back" without parsing a message. The QuickBooks fault code is kept on failure: `2300` (imbalance) will never succeed on retry, a 5xx will.

---

## Tests

**29 new, 48 passing in the touched suites.** 15 on the poster (one per layer, plus the posted-then-crashed mode), 14 on the entity wiring.

The entity tests pin the icon and colour ids. ⚠️ The *real* check — "is this id in `ICON_DATA`?" — **cannot live in `@auxx/lib`**: ui is tier 4, lib is tier 3, so lib must never import it. I wrote that test, hit the import error, and replaced it with value pins plus a comment. **A cross-package test in `apps/web` is what would actually catch a bad id** — and would have caught `product`'s `package-2` (see #1864).

## Ordering

This must merge **before** `@auxx/sdk` can publish 0.0.23, which in turn unblocks [auxxai-apps#55](https://github.com/Auxx-Ai/auxxai-apps/pull/55) (the `qboJournalEntryId` field).

## Not in this PR

- **Phase 5** — the workflow-block resource triple + 12 registration sites. Deferred per the plan's own D4; phase 4 alone unblocks this poster.
- **Sandbox smoke tests** (phases 0-1) — need live credentials. These are the validation gates before anything posts for real, in particular `Entity.Type` (documented output-only, present in every official sample) and the `2300` imbalance code.