### PR TITLE
refactor(files): abort abandoned multipart uploads and fix client upload-table drift

### DIFF
--- a/apps/web/src/app/(protected)/app/examples/file-upload/page.tsx
+++ b/apps/web/src/app/(protected)/app/examples/file-upload/page.tsx
@@ -52,8 +52,10 @@ function BasicUploadExample({
         </p>
       </div>
       <FileQueueManager
-        entityType='ARTICLE'
-        // Note: entityId is optional - omitting it will create generic upload session
+        entityType='FILE'
+        // FILE is the only handler with no entity behind it (persist: 'folder-file').
+        // ARTICLE and the other 'asset+attachment' handlers write an Attachment row,
+        // whose entityId is NOT NULL, so they 400 without a real entityId.
         onComplete={onComplete}
         onError={onError}
         onProgress={onProgress}
@@ -78,7 +80,7 @@ function MinimalUploadExample({
 }) {
   return (
     <FileQueueManager
-      entityType='ARTICLE'
+      entityType='FILE'
       onComplete={onComplete}
       onError={onError}
       fileItemComponent={MinimalFileItem}
@@ -137,7 +139,7 @@ function FileSelectExample() {
           maxFiles={5}
           maxFileSize={10 * 1024 * 1024} // 10MB
           fileExtensions={['.jpg', '.jpeg', '.png', '.gif', '.pdf', '.doc', '.docx']}
-          entityType='ARTICLE'
+          entityType='FILE'
           onChange={handleFilesChange}
           onUploadComplete={handleUploadComplete}
           onError={handleError}
@@ -303,7 +305,7 @@ function FileSelectExample() {
             maxFiles={3}
             maxFileSize={5 * 1024 * 1024} // 5MB
             fileTypes={['.jpg', '.png', '.pdf']}
-            entityType='ARTICLE'
+            entityType='FILE'
             onSelect={(files) => {
               console.log('FileSelectPicker selected files:', files)
               setMultipleFiles((prev) => [...prev, ...files])

--- a/apps/web/src/app/api/files/upload/[sessionId]/abort/route.ts
+++ b/apps/web/src/app/api/files/upload/[sessionId]/abort/route.ts
@@ -1,0 +1,63 @@
+// apps/web/src/app/api/files/upload/[sessionId]/abort/route.ts
+
+import {
+  abortMultipartUpload,
+  createS3StoragePort,
+  deleteUploadSession,
+  uploadSessionRedis,
+} from '@auxx/lib/files/server'
+import { type NextRequest, NextResponse } from 'next/server'
+import { authorizeUploadSession } from '../authorize-upload-session'
+
+interface RouteParams {
+  params: Promise<{ sessionId: string }>
+}
+
+/**
+ * Abandon an upload session, releasing any multipart upload it opened.
+ *
+ * Cancel used to be purely client-side: the store aborted its `fetch` handles
+ * and told the server nothing. That is correct for a single-part PUT, which
+ * leaves no trace when abandoned, and wrong for a multipart upload, whose
+ * already-uploaded parts S3 holds and bills for indefinitely — there is no
+ * expiry without an explicit abort or a lifecycle rule.
+ *
+ * Authenticated through the same door as `complete` and `parts`: the session
+ * nanoid is not a credential (#1818, guide §11.4), so a caller who merely holds
+ * one must not be able to destroy another user's in-flight upload.
+ *
+ * Always 200 on an authorized call, including when the abort itself failed. The
+ * client cancelled; surfacing a storage error it cannot act on would turn a
+ * successful cancel into a visible failure. `outcome` carries what actually
+ * happened for logging and tests, and the bucket's
+ * `AbortIncompleteMultipartUpload` lifecycle rule is the backstop for both the
+ * `failed` case and the browser that never called this at all.
+ */
+export async function POST(_request: NextRequest, { params }: RouteParams) {
+  const { sessionId } = await params
+
+  const authorized = await authorizeUploadSession(sessionId)
+  if (authorized instanceof Response) return authorized
+
+  const { session } = authorized
+
+  const outcome = await abortMultipartUpload(
+    { storage: createS3StoragePort() },
+    {
+      provider: session.provider,
+      bucket: session.bucket,
+      key: session.storageKey,
+      credentialId: session.credentialId,
+      uploadId: session.uploadId,
+      reason: 'user-cancelled',
+      sessionId,
+    }
+  )
+
+  // The session is spent either way: its presigned URLs are useless once the
+  // upload is abandoned, and leaving it in Redis lets a retry resume against an
+  // `uploadId` S3 has already released.
+  await deleteUploadSession(await uploadSessionRedis(), sessionId)
+
+  return NextResponse.json({ success: true, outcome })
+}

--- a/apps/web/src/app/api/workflows/shared/[shareToken]/files/[sessionId]/complete/public-upload-compensation.test.ts
+++ b/apps/web/src/app/api/workflows/shared/[shareToken]/files/[sessionId]/complete/public-upload-compensation.test.ts
@@ -1,0 +1,209 @@
+// apps/web/src/app/api/workflows/shared/[shareToken]/files/[sessionId]/complete/public-upload-compensation.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The public workflow-share completion route and the bytes it used to leak.
+ *
+ * The browser PUTs to S3 against a presigned URL, so the object exists before
+ * this route runs. Until this test's subject was fixed, every failure branch
+ * returned a 500 having neither deleted the object nor enqueued a cleanup —
+ * `docs/files-upload-architecture-guide.md` §12, checklist item 3.
+ *
+ * What is asserted here is the *policy*, not the mechanism: which branches call
+ * `compensateUploadObject`, which deliberately do not, and that the call always
+ * names the bucket the session recorded. `compensateUploadObject`'s own
+ * behaviour (delete, then enqueue, never throw) is asserted against the real
+ * implementation in `packages/lib/src/files/upload/__tests__/compensate.test.ts`.
+ */
+
+const {
+  compensateUploadObject,
+  createAssetWithVersion,
+  createStorageLocation,
+  getAssetDownloadRef,
+  getSystemUserForActions,
+  headByKey,
+  getRedisData,
+  deleteRedisData,
+  transaction,
+} = vi.hoisted(() => ({
+  compensateUploadObject: vi.fn(async () => 'deleted'),
+  createAssetWithVersion: vi.fn(),
+  createStorageLocation: vi.fn(),
+  getAssetDownloadRef: vi.fn(),
+  getSystemUserForActions: vi.fn(),
+  headByKey: vi.fn(),
+  getRedisData: vi.fn(),
+  deleteRedisData: vi.fn(async () => 1),
+  transaction: vi.fn(),
+}))
+
+vi.mock('@auxx/database', async () =>
+  (await import('~/test/database-mock')).mockAuxxDatabase({ database: { transaction } })
+)
+vi.mock('@auxx/logger', async () => (await import('~/test/logger-mock')).mockAuxxLogger())
+vi.mock('@auxx/redis', () => ({ getRedisData, deleteRedisData }))
+vi.mock('@auxx/lib/users', () => ({
+  SystemUserService: { getSystemUserForActions: getSystemUserForActions },
+}))
+vi.mock('@auxx/lib/files/server', () => ({
+  compensateUploadObject,
+  createAssetWithVersion,
+  createProductionQueuePort: () => ({ queue: true }),
+  createS3StoragePort: () => ({ storage: true }),
+  createStorageManager: () => ({ headByKey, createStorageLocation }),
+  getAssetDownloadRef,
+}))
+vi.mock('@auxx/services/workflow-share', () => ({
+  verifyWorkflowPassport: async () => ({
+    isErr: () => false,
+    value: { shareToken: SHARE_TOKEN, endUserId: END_USER_ID },
+  }),
+}))
+
+const SHARE_TOKEN = 'shr_token00000000000000'
+const SESSION_ID = 'puf_cuid00000000000000000'
+const END_USER_ID = 'eus_cuid00000000000000000'
+const ORG_ID = 'org_cuid000000000000000000000'
+const BUCKET = 'auxx-private-test'
+const STORAGE_KEY = `public-workflow/${ORG_ID}/${SHARE_TOKEN}/${SESSION_ID}/report.pdf`
+
+const { POST } = await import('./route')
+
+const session = (overrides: Record<string, unknown> = {}) => ({
+  storageKey: STORAGE_KEY,
+  filename: 'report.pdf',
+  mimeType: 'application/pdf',
+  size: 1024,
+  organizationId: ORG_ID,
+  endUserId: END_USER_ID,
+  shareToken: SHARE_TOKEN,
+  nodeId: 'n1',
+  bucket: BUCKET,
+  ...overrides,
+})
+
+/** Cast because only the headers matter here; nothing reads the `NextRequest` surface. */
+const request = () =>
+  new Request(`http://localhost/api/workflows/shared/${SHARE_TOKEN}/files/${SESSION_ID}/complete`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer passport' },
+  }) as never
+
+const params = { params: Promise.resolve({ shareToken: SHARE_TOKEN, sessionId: SESSION_ID }) }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  compensateUploadObject.mockResolvedValue('deleted')
+  getRedisData.mockResolvedValue(session())
+  headByKey.mockResolvedValue({ size: 1024, mimeType: 'application/pdf' })
+  getSystemUserForActions.mockResolvedValue('usr_org_system0000000000')
+  createStorageLocation.mockResolvedValue({ id: 'stl_cuid0000000000000000' })
+  createAssetWithVersion.mockResolvedValue({
+    isErr: () => false,
+    value: {
+      asset: { id: 'mda_cuid0000000000000000' },
+      version: { id: 'mdv_cuid0000000000000000' },
+    },
+  })
+  getAssetDownloadRef.mockResolvedValue({
+    isErr: () => false,
+    value: { type: 'url', url: 'https://example.test/report.pdf' },
+  })
+  // A stand-in transaction: runs the body, and propagates a throw the way a
+  // rollback does.
+  transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => fn({ tx: true }))
+})
+
+describe('failures that orphan the object compensate', () => {
+  it('compensates when the persist transaction rolls back, naming the session bucket', async () => {
+    transaction.mockRejectedValue(new Error('asset insert exploded'))
+
+    const response = await POST(request(), params)
+
+    expect(response.status).toBe(500)
+    expect(compensateUploadObject).toHaveBeenCalledTimes(1)
+    expect(compensateUploadObject.mock.calls[0]?.[1]).toMatchObject({
+      provider: 'S3',
+      bucket: BUCKET,
+      key: STORAGE_KEY,
+      organizationId: ORG_ID,
+      sessionId: SESSION_ID,
+    })
+  })
+
+  it('compensates when the asset write returns err, because that rolls back too', async () => {
+    createAssetWithVersion.mockResolvedValue({
+      isErr: () => true,
+      error: new Error('no system user row'),
+    })
+
+    const response = await POST(request(), params)
+
+    expect(response.status).toBe(500)
+    expect(compensateUploadObject).toHaveBeenCalledTimes(1)
+  })
+
+  it('compensates when the organization has no system user', async () => {
+    getSystemUserForActions.mockRejectedValue(new Error('no system user'))
+
+    const response = await POST(request(), params)
+
+    expect(response.status).toBe(500)
+    expect(compensateUploadObject).toHaveBeenCalledTimes(1)
+    expect(compensateUploadObject.mock.calls[0]?.[1]).toMatchObject({ bucket: BUCKET })
+  })
+
+  it('retires the Redis session it just compensated, so a retry cannot compensate twice', async () => {
+    transaction.mockRejectedValue(new Error('asset insert exploded'))
+
+    await POST(request(), params)
+
+    expect(deleteRedisData).toHaveBeenCalledWith(`public-upload:${SESSION_ID}`, false)
+  })
+})
+
+describe('failures that must NOT compensate', () => {
+  it('leaves the object alone when the HEAD fails, because its existence is unconfirmed', async () => {
+    headByKey.mockRejectedValue(new Error('NotFound'))
+
+    const response = await POST(request(), params)
+
+    expect(response.status).toBe(404)
+    expect(compensateUploadObject).not.toHaveBeenCalled()
+    // The session survives for the retry that can still commit those bytes.
+    expect(deleteRedisData).not.toHaveBeenCalled()
+  })
+
+  it('refuses to act at all when the session recorded no bucket, rather than guessing one', async () => {
+    getRedisData.mockResolvedValue(session({ bucket: '' }))
+
+    const response = await POST(request(), params)
+
+    expect(response.status).toBe(500)
+    expect(compensateUploadObject).not.toHaveBeenCalled()
+    expect(headByKey).not.toHaveBeenCalled()
+  })
+
+  it('does not compensate a committed upload whose download URL could not be signed', async () => {
+    getAssetDownloadRef.mockRejectedValue(new Error('presign failed'))
+
+    const response = await POST(request(), params)
+
+    expect(response.status).toBe(200)
+    expect(compensateUploadObject).not.toHaveBeenCalled()
+    expect(await response.json()).toMatchObject({ assetId: 'mda_cuid0000000000000000' })
+  })
+
+  it('does not compensate the happy path', async () => {
+    const response = await POST(request(), params)
+
+    expect(response.status).toBe(200)
+    expect(compensateUploadObject).not.toHaveBeenCalled()
+    expect(createStorageLocation).toHaveBeenCalledWith(
+      expect.objectContaining({ bucket: BUCKET, externalId: STORAGE_KEY }),
+      { tx: { tx: true } }
+    )
+  })
+})

--- a/apps/web/src/app/api/workflows/shared/[shareToken]/files/[sessionId]/complete/route.ts
+++ b/apps/web/src/app/api/workflows/shared/[shareToken]/files/[sessionId]/complete/route.ts
@@ -3,7 +3,9 @@
 import { database } from '@auxx/database'
 import type { FilesCtx } from '@auxx/lib/files/server'
 import {
+  compensateUploadObject,
   createAssetWithVersion,
+  createProductionQueuePort,
   createS3StoragePort,
   createStorageManager,
   getAssetDownloadRef,
@@ -36,6 +38,18 @@ interface UploadSessionData {
  * Completes the upload and creates a storage location record
  *
  * Requires a valid passport token in Authorization header
+ *
+ * ## Compensation
+ *
+ * The browser PUTs the bytes straight to S3 against a presigned URL, so by the
+ * time this handler runs the object already exists and nothing references it.
+ * Every failure between "the object is confirmed present" and "the rows are
+ * committed" therefore leaks bytes unless it compensates, which is what
+ * `compensateUploadObject` is for — same policy, same module, as the main
+ * completion path in `packages/lib/src/files/upload/complete.ts`.
+ *
+ * Two failures deliberately do **not** compensate; see {@link POST}'s inline
+ * comments at each branch.
  */
 export async function POST(
   request: NextRequest,
@@ -77,9 +91,61 @@ export async function POST(
     return NextResponse.json({ error: 'Invalid session for this user' }, { status: 403 })
   }
 
+  // 3b. The bucket is the one thing compensation cannot guess.
+  //
+  // S3 answers 204 No Content for a delete of a key that is not in the bucket
+  // you named, so a wrong-bucket cleanup reports success and leaks the object
+  // with no error anywhere — bugs #1816/#1817/#1818 were all that one shape.
+  // The session route records the bucket it presigned against; if it is not
+  // there, this request cannot HEAD the object either, and inventing a default
+  // would be exactly the failure mode this guard exists to prevent.
+  if (!sessionData.bucket) {
+    logger.error('Upload session has no bucket; refusing to guess one', {
+      sessionId,
+      organizationId: sessionData.organizationId,
+      storageKey: sessionData.storageKey,
+    })
+    return NextResponse.json({ error: 'Failed to complete upload' }, { status: 500 })
+  }
+
+  /**
+   * Undo an object whose rows never landed, then retire the session.
+   *
+   * Never throws — it is called while the handler is already reporting a
+   * failure, and replacing that failure with a storage error would lose the
+   * only actionable information. The Redis session is dropped afterwards
+   * because the bytes it points at are gone: leaving it would let a retry get
+   * as far as a confusing "File not found in storage" and compensate a second
+   * time.
+   */
+  const compensate = async (reason: string) => {
+    const outcome = await compensateUploadObject(
+      {
+        storage: createS3StoragePort(sessionData.organizationId),
+        queue: createProductionQueuePort(),
+      },
+      {
+        provider: 'S3',
+        bucket: sessionData.bucket,
+        key: sessionData.storageKey,
+        organizationId: sessionData.organizationId,
+        reason,
+        sessionId,
+      }
+    )
+    logger.info('Compensated an orphaned public workflow upload', {
+      sessionId,
+      outcome,
+      reason,
+      storageKey: sessionData.storageKey,
+      bucket: sessionData.bucket,
+    })
+    await deleteRedisData(`public-upload:${sessionId}`, false)
+  }
+
   // 4. Verify file exists in S3
   const storageManager = createStorageManager(sessionData.organizationId)
-  let headResult
+  let headResult: Awaited<ReturnType<typeof storageManager.headByKey>>
   try {
     headResult = await storageManager.headByKey({
       provider: 'S3',
@@ -87,6 +153,11 @@ export async function POST(
       bucket: sessionData.bucket,
     })
   } catch (err) {
+    // NO compensation. This branch is the one place the object's existence is
+    // unconfirmed: the usual cause is that the browser never completed its PUT,
+    // so there is nothing to delete, and if instead the HEAD failed
+    // transiently, deleting would destroy bytes a retry can still commit. The
+    // session is left in Redis for exactly that retry.
     logger.error('File not found in storage', {
       sessionId,
       storageKey: sessionData.storageKey,
@@ -100,50 +171,53 @@ export async function POST(
   try {
     systemUserId = await SystemUserService.getSystemUserForActions(sessionData.organizationId)
   } catch (err) {
+    // Compensates: the HEAD above proved the object is there, and a missing
+    // system user is an organization-configuration fault that a retry inside
+    // the session's TTL will hit again. Nothing will ever reference the bytes.
     logger.error('No system user found for organization', {
       organizationId: sessionData.organizationId,
       error: err instanceof Error ? err.message : String(err),
     })
+    await compensate(`Public workflow upload has no system user: ${String(err)}`)
     return NextResponse.json({ error: 'Organization configuration error' }, { status: 500 })
   }
 
-  // 6. Create StorageLocation record
-  let storageLocation
-  try {
-    storageLocation = await storageManager.createStorageLocation({
-      provider: 'S3',
-      externalId: sessionData.storageKey,
-      size: headResult.size,
-      mimeType: headResult.mimeType || sessionData.mimeType,
-      metadata: {
-        source: 'public-workflow',
-        endUserId: sessionData.endUserId,
-        shareToken: sessionData.shareToken,
-        nodeId: sessionData.nodeId,
-        originalFileName: sessionData.filename,
-      },
-      bucket: sessionData.bucket,
-      visibility: 'PRIVATE',
-    })
-  } catch (err) {
-    logger.error('Failed to create storage location', {
-      sessionId,
-      error: err instanceof Error ? err.message : String(err),
-    })
-    return NextResponse.json({ error: 'Failed to complete upload' }, { status: 500 })
-  }
-
-  // 7. Create MediaAsset with version for version locking support.
+  // 6. Write the StorageLocation, the MediaAsset and its first version in ONE
+  //    transaction, so a failure of any of them rolls back the other two.
   //
-  // The asset row and its first version land in ONE transaction, opened here.
-  // `MediaAssetService.createWithVersion` opened it inside lib through
-  // `BaseService.getTx`, which guessed whether it was already in one.
+  //    `createStorageLocation` used to run on the pool, before the transaction
+  //    below was opened, which meant a failed asset insert left a committed
+  //    `StorageLocation` row pointing at bytes this handler was about to delete.
+  //    It rides the caller's transaction now, matching `completeUpload`'s
+  //    phase 2. The bucket is passed explicitly and is non-empty (guard 3b), so
+  //    the facade's metadata preparation short-circuits and performs no
+  //    credential lookup from inside the open transaction.
   const filesCtx: FilesCtx = { db: database, organizationId: sessionData.organizationId }
+  let storageLocationId: string
   let asset: { id: string }
   let version: { id: string }
   try {
-    const created = await database.transaction(async (tx) =>
-      createAssetWithVersion(
+    const created = await database.transaction(async (tx) => {
+      const location = await storageManager.createStorageLocation(
+        {
+          provider: 'S3',
+          externalId: sessionData.storageKey,
+          size: headResult.size,
+          mimeType: headResult.mimeType || sessionData.mimeType,
+          metadata: {
+            source: 'public-workflow',
+            endUserId: sessionData.endUserId,
+            shareToken: sessionData.shareToken,
+            nodeId: sessionData.nodeId,
+            originalFileName: sessionData.filename,
+          },
+          bucket: sessionData.bucket,
+          visibility: 'PRIVATE',
+        },
+        { tx }
+      )
+
+      const result = await createAssetWithVersion(
         tx,
         { ...filesCtx, db: tx },
         { now: () => new Date() },
@@ -156,23 +230,30 @@ export async function POST(
           createdById: systemUserId,
           expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
           purpose: 'PUBLIC_WORKFLOW_INPUT',
-          storageLocationId: storageLocation.id,
+          storageLocationId: location.id,
         }
       )
-    )
-    if (created.isErr()) throw created.error
-    asset = created.value.asset
-    version = created.value.version
+      // Thrown, not returned: `db.transaction` rolls back on a throw, and an
+      // `err()` is an ordinary resolved value the transaction would commit
+      // around.
+      if (result.isErr()) throw result.error
+
+      return { location, ...result.value }
+    })
+    storageLocationId = created.location.id
+    asset = created.asset
+    version = created.version
   } catch (err) {
-    logger.error('Failed to create MediaAsset', {
+    // The rows rolled back; the bytes did not.
+    logger.error('Failed to persist public workflow upload', {
       sessionId,
-      storageLocationId: storageLocation.id,
       error: err instanceof Error ? err.message : String(err),
     })
+    await compensate(`Public workflow upload transaction failed: ${String(err)}`)
     return NextResponse.json({ error: 'Failed to complete upload' }, { status: 500 })
   }
 
-  // 8. Generate download URL using the new version
+  // 7. Generate download URL using the new version
   let downloadUrl: string | undefined
   try {
     const downloadRef = await getAssetDownloadRef(
@@ -185,7 +266,9 @@ export async function POST(
       downloadUrl = downloadRef.value.url
     }
   } catch (err) {
-    // Non-critical - download URL is optional for form submission
+    // NO compensation, and non-critical besides: the rows are committed and the
+    // object is referenced by them, so it is not orphaned. Deleting it here
+    // would destroy a file the caller is about to be told it owns.
     logger.warn('Failed to generate download URL', {
       assetId: asset.id,
       versionId: version.id,
@@ -193,19 +276,19 @@ export async function POST(
     })
   }
 
-  // 9. Clean up Redis session
+  // 8. Clean up Redis session
   await deleteRedisData(`public-upload:${sessionId}`, false)
 
   logger.info('Completed public file upload with MediaAsset', {
     sessionId,
     assetId: asset.id,
     versionId: version.id,
-    storageLocationId: storageLocation.id,
+    storageLocationId,
     filename: sessionData.filename,
     size: headResult.size,
   })
 
-  // 10. Return file metadata with version locking support
+  // 9. Return file metadata with version locking support
   return NextResponse.json({
     // New fields for FileReference compatibility
     assetId: asset.id,

--- a/apps/web/src/components/fields/inputs/hooks/use-field-file-upload.ts
+++ b/apps/web/src/components/fields/inputs/hooks/use-field-file-upload.ts
@@ -2,9 +2,8 @@
 'use client'
 
 import type { FileValue } from '@auxx/lib/field-values/client'
-import type { FileTypeCategory } from '@auxx/lib/files/client'
+import type { BatchUploadResult, FileTypeCategory } from '@auxx/lib/files/client'
 import { getMimePatternsForCategories } from '@auxx/lib/files/client'
-import type { BatchUploadResult } from '@auxx/lib/files/types'
 import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
 import type { FieldReference } from '@auxx/types/field'
 import type { JsonFieldValue, TypedFieldValue } from '@auxx/types/field-value'

--- a/apps/web/src/components/file-select/types.ts
+++ b/apps/web/src/components/file-select/types.ts
@@ -1,6 +1,6 @@
 // apps/web/src/components/file-select/types.ts
 
-import type { EntityType } from '@auxx/lib/files/types'
+import type { EntityType } from '@auxx/lib/files/client'
 import type { EntityUploadConfig } from '~/components/file-upload/types'
 import type { FileItem } from '~/components/files/files-store'
 

--- a/apps/web/src/components/file-upload/hooks/use-file-upload.ts
+++ b/apps/web/src/components/file-upload/hooks/use-file-upload.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import type { BatchUploadResult, EntityType, UploadResult } from '@auxx/lib/files/types'
+import type { BatchUploadResult, EntityType, UploadResult } from '@auxx/lib/files/client'
 import { generateId } from '@auxx/utils/generateId'
 import * as React from 'react'
 import { useShallow } from 'zustand/react/shallow'

--- a/apps/web/src/components/file-upload/stores/__tests__/uploader-settled.test.ts
+++ b/apps/web/src/components/file-upload/stores/__tests__/uploader-settled.test.ts
@@ -1,6 +1,6 @@
 // apps/web/src/components/file-upload/stores/__tests__/uploader-settled.test.ts
 
-import type { BatchUploadResult } from '@auxx/lib/files/types'
+import type { BatchUploadResult } from '@auxx/lib/files/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createFakeUploadTransport } from '../../transport/__fixtures__/fake-upload-transport'
 import type { DirectUploadResult } from '../../transport/types'

--- a/apps/web/src/components/file-upload/stores/slices/file-slice.ts
+++ b/apps/web/src/components/file-upload/stores/slices/file-slice.ts
@@ -1,7 +1,7 @@
 // apps/web/src/components/file-upload/stores/slices/file-slice.ts
 
-import type { EntityType, UploadProgress } from '@auxx/lib/files/types'
-import { getEntityConfig } from '@auxx/lib/files/types'
+import type { EntityType, UploadProgress } from '@auxx/lib/files/client'
+import { getEntityConfig } from '@auxx/lib/files/client'
 import { generateId } from '@auxx/utils/generateId'
 import type { StateCreator } from 'zustand'
 import { isFileInFlight } from '../file-status'

--- a/apps/web/src/components/file-upload/stores/slices/orchestration-slice.ts
+++ b/apps/web/src/components/file-upload/stores/slices/orchestration-slice.ts
@@ -1,7 +1,7 @@
 // apps/web/src/components/file-upload/stores/slices/orchestration-slice.ts
 
-import type { BatchUploadResult, EntityType } from '@auxx/lib/files/types'
-import { getEntityConfig } from '@auxx/lib/files/types'
+import type { BatchUploadResult, EntityType } from '@auxx/lib/files/client'
+import { getEntityConfig } from '@auxx/lib/files/client'
 import type { StateCreator } from 'zustand'
 import type { UploadTransport } from '../../transport'
 import { httpUploadTransport, isUploadTransportError, resolveServerId } from '../../transport'
@@ -950,6 +950,30 @@ export const createEnhancedOrchestrationSlice: StateCreator<
     // nothing to scope to, so fall back to the old blanket abort.
     const abortIds = session ? session.fileIds : Object.keys(inFlight)
     abortIds.forEach((fileId) => inFlight[fileId]?.abort?.())
+
+    // Aborting the handle stops the browser sending, but a multipart upload has
+    // server-side state the browser cannot reach: S3 holds and bills for every
+    // part already delivered, with no expiry, until the upload is aborted. Tell
+    // the server before the file records are cleared, since `serverFileId` is
+    // where the upload-session nanoid lives.
+    //
+    // `serverIdKind` is checked because that field is overwritten with a real
+    // record id once a file completes (§11.3), and a completed upload must never
+    // be abandoned — its rows are already written.
+    const { files: filesById, transport } = get()
+    abortIds
+      .map((fileId) => filesById[fileId])
+      .filter(
+        (f): f is NonNullable<typeof f> & { serverFileId: string } =>
+          Boolean(f?.serverFileId) && f?.metadata?.serverIdKind === 'session'
+      )
+      .forEach((f) => {
+        // Deliberately not awaited and never rethrown: cancellation is
+        // synchronous from the user's point of view, and a failed abort costs
+        // storage the bucket's lifecycle rule reclaims, not correctness.
+        void transport.abortSession(f.serverFileId).catch(() => {})
+      })
+
     set((state) => {
       abortIds.forEach((fileId) => {
         delete state.inFlight[fileId]

--- a/apps/web/src/components/file-upload/stores/slices/session-slice.ts
+++ b/apps/web/src/components/file-upload/stores/slices/session-slice.ts
@@ -1,6 +1,6 @@
 // apps/web/src/components/file-upload/stores/slices/session-slice.ts
 
-import { ENTITY_TYPES } from '@auxx/lib/files/types'
+import { ENTITY_TYPES } from '@auxx/lib/files/client'
 import { generateId } from '@auxx/utils/generateId'
 import type { StateCreator } from 'zustand'
 import type { CreateSessionOptions, SessionState, UploadStore } from '../types'

--- a/apps/web/src/components/file-upload/stores/types.ts
+++ b/apps/web/src/components/file-upload/stores/types.ts
@@ -7,7 +7,7 @@ import type {
   ServerIdKind,
   SessionStatus,
   UploadProgress,
-} from '@auxx/lib/files/types'
+} from '@auxx/lib/files/client'
 import type { UploadTransport } from '../transport'
 
 /**

--- a/apps/web/src/components/file-upload/transport/__fixtures__/fake-upload-transport.ts
+++ b/apps/web/src/components/file-upload/transport/__fixtures__/fake-upload-transport.ts
@@ -29,6 +29,8 @@ export interface FakeUploadTransport extends UploadTransport {
   completedSessions(): Array<{ sessionId: string; body: CompletionInput }>
   /** Names of files whose upload handle had `abort()` called. */
   abortedFiles(): string[]
+  /** Session ids the store asked the server to abandon, in call order. */
+  abortedSessions(): string[]
 }
 
 export interface FakeUploadTransportOptions {
@@ -38,6 +40,8 @@ export interface FakeUploadTransportOptions {
   uploadObject?: (params: Parameters<UploadTransport['uploadObject']>[0]) => UploadHandle
   /** Override completion — throw from here to fail after the bytes landed. */
   completeSession?: (sessionId: string, body: CompletionInput) => Promise<CompletionResult>
+  /** Override the abort call — throw from here to prove a failed abort is swallowed. */
+  abortSession?: (sessionId: string) => Promise<void>
 }
 
 /** Default presigned config: a single-part PUT, one session id per file. */
@@ -57,6 +61,7 @@ export function createFakeUploadTransport(
   const created: CreateSessionInput[] = []
   const completed: Array<{ sessionId: string; body: CompletionInput }> = []
   const aborted: string[] = []
+  const abortedSessionIds: string[] = []
 
   return {
     async createSession(input) {
@@ -87,8 +92,14 @@ export function createFakeUploadTransport(
       }
     },
 
+    async abortSession(sessionId) {
+      abortedSessionIds.push(sessionId)
+      if (options.abortSession) return options.abortSession(sessionId)
+    },
+
     createdSessions: () => [...created],
     completedSessions: () => [...completed],
     abortedFiles: () => [...aborted],
+    abortedSessions: () => [...abortedSessionIds],
   }
 }

--- a/apps/web/src/components/file-upload/transport/http-upload-transport.ts
+++ b/apps/web/src/components/file-upload/transport/http-upload-transport.ts
@@ -40,6 +40,13 @@ export const httpUploadTransport: UploadTransport = {
     return directUpload(params)
   },
 
+  async abortSession(sessionId: string): Promise<void> {
+    // `keepalive` so the request still goes out when the cancel is the user
+    // closing the popover or the tab: a normal fetch is torn down with the page
+    // and the abort never reaches the server.
+    await fetch(`/api/files/upload/${sessionId}/abort`, { method: 'POST', keepalive: true })
+  },
+
   async completeSession(sessionId: string, body: CompletionInput): Promise<CompletionResult> {
     const response = await fetch(`/api/files/upload/${sessionId}/complete`, {
       method: 'POST',

--- a/apps/web/src/components/file-upload/transport/server-id.ts
+++ b/apps/web/src/components/file-upload/transport/server-id.ts
@@ -1,6 +1,6 @@
 // apps/web/src/components/file-upload/transport/server-id.ts
 
-import type { ServerIdKind } from '@auxx/lib/files/types'
+import type { ServerIdKind } from '@auxx/lib/files/client'
 import type { CompletionResult } from './types'
 
 /** Which server record a completion produced, and its id. */

--- a/apps/web/src/components/file-upload/transport/types.ts
+++ b/apps/web/src/components/file-upload/transport/types.ts
@@ -1,6 +1,6 @@
 // apps/web/src/components/file-upload/transport/types.ts
 
-import type { EntityType } from '@auxx/lib/files/types'
+import type { EntityType } from '@auxx/lib/files/client'
 
 /**
  * The wire contract between the browser uploader and `/api/files/upload/*`.
@@ -123,4 +123,14 @@ export interface UploadTransport {
 
   /** Tell the server the bytes landed, and get back the rows it produced. */
   completeSession(sessionId: string, body: CompletionInput): Promise<CompletionResult>
+
+  /**
+   * Abandon a session so the server releases any multipart upload it opened.
+   *
+   * Best-effort by contract: a rejected promise must never fail the cancel that
+   * called it. S3 holds and bills for the parts of an incomplete multipart
+   * upload indefinitely, so skipping this leaks them until the bucket's
+   * `AbortIncompleteMultipartUpload` lifecycle rule expires them.
+   */
+  abortSession(sessionId: string): Promise<void>
 }

--- a/apps/web/src/components/file-upload/types/upload-progress.ts
+++ b/apps/web/src/components/file-upload/types/upload-progress.ts
@@ -28,7 +28,7 @@ import type {
   UploadSessionOptions,
   // Upload types
   UploadStatus,
-} from '@auxx/lib/files/types'
+} from '@auxx/lib/files/client'
 
 // Re-export all shared types
 export type {

--- a/apps/web/src/components/file-upload/ui/file-queue-manager.tsx
+++ b/apps/web/src/components/file-upload/ui/file-queue-manager.tsx
@@ -2,7 +2,7 @@
 
 'use client'
 
-import type { EntityType } from '@auxx/lib/files/types'
+import type { EntityType } from '@auxx/lib/files/client'
 import { Button } from '@auxx/ui/components/button'
 import { cn } from '@auxx/ui/lib/utils'
 import { FileUp, Play, RotateCcw, Square, Trash2, Upload, UploadIcon } from 'lucide-react'

--- a/apps/web/src/components/file-upload/utils/upload-helpers.ts
+++ b/apps/web/src/components/file-upload/utils/upload-helpers.ts
@@ -1,8 +1,7 @@
 // apps/web/src/components/file-upload/utils/upload-helpers.ts
 
-import type { EntityUploadConfig, QueueStats, UploadFile } from '@auxx/lib/files/types'
-import { ENTITY_CONFIGS, getEntityConfig } from '@auxx/lib/files/types'
-import { formatBytes, getFileExtension } from '@auxx/utils/file'
+import type { EntityUploadConfig, QueueStats, UploadFile } from '@auxx/lib/files/client'
+import { formatBytes } from '@auxx/utils/file'
 
 /**
  * Utility functions for file upload processing and calculations
@@ -11,13 +10,25 @@ import { formatBytes, getFileExtension } from '@auxx/utils/file'
 // Removed: fileToFileInfo - not used
 
 /**
- * Validate file against upload constraints
+ * Pre-flight a file against an entity's upload policy, in the browser.
+ *
+ * Deliberately the same two rules, in the same order, as `enforceUploadPolicy`
+ * on the server (`packages/lib/src/files/storage/presign.ts`): a size ceiling
+ * and a MIME allow-list where `type/subtype`, `type/*` and `*​/*` all match.
+ * The config it judges comes from `ENTITY_CONFIGS`, which projects the same
+ * `UPLOAD_POLICIES` table the server's handlers spread — so a file this
+ * function refuses is a file the server would also have refused.
+ *
+ * There used to be a third rule here, an extension allow-list, with no server
+ * counterpart at all. It could only ever refuse a file the server would take:
+ * an `.mp4` was rejected for `ARTICLE` client-side while the server had already
+ * dropped `video/*`, and a `.heic` iPhone capture typed as `image/heic` had to
+ * be listed twice to survive. It is gone.
  */
 export function validateFile(
   file: File,
   config: EntityUploadConfig['validation']
 ): { valid: boolean; error?: string } {
-  // Check file size
   if (file.size > config.maxFileSize) {
     return {
       valid: false,
@@ -25,62 +36,14 @@ export function validateFile(
     }
   }
 
-  // Check file extension first (more reliable than MIME type detection)
-  let extensionValid = true
-  let extensionError = ''
-  if (config.allowedExtensions && config.allowedExtensions.length > 0) {
-    const extension = getFileExtension(file.name).toLowerCase()
-    const isAllowedExtension = config.allowedExtensions
-      .map((ext) => ext.toLowerCase())
-      .includes(extension)
+  const isAllowedType = config.allowedMimeTypes.some((type) => {
+    if (type === '*/*') return true
+    if (type.endsWith('/*')) return file.type.startsWith(type.slice(0, -2))
+    return file.type === type
+  })
 
-    if (!isAllowedExtension) {
-      extensionValid = false
-      extensionError = `File extension "${extension}" is not allowed`
-    }
-  }
-
-  // Check file type (MIME type)
-  let mimeTypeValid = true
-  let mimeTypeError = ''
-  if (config.allowedMimeTypes && config.allowedMimeTypes.length > 0) {
-    const isAllowedType = config.allowedMimeTypes.some((type) => {
-      // Handle the special case of '*/*' which means allow all types
-      if (type === '*/*') {
-        return true
-      }
-      if (type.endsWith('/*')) {
-        const category = type.slice(0, -2)
-        return file.type.startsWith(category)
-      }
-      return file.type === type
-    })
-
-    if (!isAllowedType) {
-      mimeTypeValid = false
-      mimeTypeError = `File type "${file.type}" is not allowed`
-    }
-  }
-
-  // If both extension and MIME type are configured, allow if either passes
-  // This handles cases where MIME type detection fails but extension is correct
-  if (
-    config.allowedExtensions &&
-    config.allowedExtensions.length > 0 &&
-    config.allowedMimeTypes &&
-    config.allowedMimeTypes.length > 0
-  ) {
-    if (!extensionValid && !mimeTypeValid) {
-      return { valid: false, error: `${extensionError} and ${mimeTypeError}` }
-    }
-  } else {
-    // If only one validation method is configured, it must pass
-    if (!extensionValid) {
-      return { valid: false, error: extensionError }
-    }
-    if (!mimeTypeValid) {
-      return { valid: false, error: mimeTypeError }
-    }
+  if (!isAllowedType) {
+    return { valid: false, error: `File type "${file.type}" is not allowed` }
   }
 
   return { valid: true }
@@ -145,13 +108,3 @@ export function calculateQueueStats(files: UploadFile[]): QueueStats {
 
   return stats
 }
-
-/**
- * Entity-specific stage configurations
- */
-export const ENTITY_STAGE_CONFIGS = ENTITY_CONFIGS
-
-/**
- * Get stage configuration for entity type
- */
-export const getStageConfig = getEntityConfig

--- a/apps/web/src/components/global/comments/comment-composer.tsx
+++ b/apps/web/src/components/global/comments/comment-composer.tsx
@@ -3,7 +3,7 @@
 // apps/web/src/components/global/comments/comment-composer.tsx
 
 import type { RecordId } from '@auxx/lib/field-values/client'
-import { ENTITY_TYPES } from '@auxx/lib/files/types'
+import { ENTITY_TYPES } from '@auxx/lib/files/client'
 import { collectReferenceIds, isNonEmptyDoc, trimTrailingEmptyParagraphs } from '@auxx/lib/tiptap'
 import { Button } from '@auxx/ui/components/button'
 import { EmojiPicker } from '@auxx/ui/components/emoji-picker'

--- a/apps/web/src/components/pickers/file-select-picker.tsx
+++ b/apps/web/src/components/pickers/file-select-picker.tsx
@@ -2,7 +2,7 @@
 
 'use client'
 
-import type { EntityType } from '@auxx/lib/files/types'
+import type { EntityType } from '@auxx/lib/files/client'
 import { type FileRef, getFileRefDownloadUrl, toFileRef } from '@auxx/types/file-ref'
 import { Button } from '@auxx/ui/components/button'
 import {

--- a/infra/storage.ts
+++ b/infra/storage.ts
@@ -41,6 +41,13 @@ export const publicBucket = new sst.aws.Bucket('PublicAssets', {
           // Applies to all thumbnails across all orgs
           transitions: [{ days: 90, storageClass: 'INTELLIGENT_TIERING' }],
         },
+        {
+          // PUBLIC uploads go multipart too (a large ARTICLE cover, a workflow
+          // artifact), so the same backstop is required here.
+          id: 'AbortIncompleteMultipartUploads',
+          enabled: true,
+          abortIncompleteMultipartUploadDays: 7,
+        },
       ],
 
       tags: {
@@ -79,10 +86,14 @@ export const privateBucket = new sst.aws.Bucket('PrivateAssets', {
       // Aggressive cleanup for private files
       lifecycleRules: [
         {
-          id: 'DeleteTempFiles',
+          // S3 matches a lifecycle prefix from the START of the key, and every
+          // key here begins with the org id (`{orgId}/file/temp/...`), so the
+          // old `temp/` prefix matched nothing at all — verified against
+          // auxx-dev-private, zero objects. No prefix means every object is
+          // considered, and only the abort below acts on anything.
+          id: 'AbortIncompleteMultipartUploads',
           enabled: true,
-          prefix: 'temp/',
-          expirations: [{ days: 7 }], // Auto-delete temp files
+          abortIncompleteMultipartUploadDays: 7,
         },
         {
           id: 'DeleteOldVersions',

--- a/packages/lib/src/files/__tests__/support/storage.ts
+++ b/packages/lib/src/files/__tests__/support/storage.ts
@@ -59,6 +59,7 @@ const DEFAULTS: { [K in keyof StoragePort]: () => Awaited<ReturnType<StoragePort
   startMultipart: () => ({ uploadId: 'upload-1', expiresAt: EXPIRES }),
   presignPart: () => ({ url: 'https://s3.test/part', method: 'PUT', expiresAt: EXPIRES }),
   completeMultipart: () => ({ etag: 'etag-complete', size: 1024 }),
+  abortMultipart: () => undefined,
   head: () => ({ name: 'file.bin', size: 1024, mimeType: 'application/octet-stream' }),
   putObject: () => ({ etag: 'etag-put', size: 1024 }),
   getObject: () => Buffer.from('fake-object-body'),
@@ -108,6 +109,10 @@ export function makeStoragePort(options: MakeStoragePortOptions = {}): FakeStora
     completeMultipart: async (p) => {
       record('completeMultipart', p)
       return options.impl?.completeMultipart?.(p) ?? resultFor('completeMultipart')
+    },
+    abortMultipart: async (p) => {
+      record('abortMultipart', p)
+      return options.impl?.abortMultipart?.(p) ?? resultFor('abortMultipart')
     },
     head: async (p) => {
       record('head', p)

--- a/packages/lib/src/files/adapters/s3-adapter.ts
+++ b/packages/lib/src/files/adapters/s3-adapter.ts
@@ -4,6 +4,7 @@ import { Readable } from 'node:stream'
 import { configService } from '@auxx/credentials'
 import { encodeRFC5987ValueChars } from '@auxx/utils'
 import {
+  AbortMultipartUploadCommand,
   CompleteMultipartUploadCommand,
   CreateMultipartUploadCommand,
   DeleteObjectCommand,
@@ -486,7 +487,11 @@ export class S3Adapter extends BaseStorageAdapter {
 
       return {
         uploadId: response.UploadId,
-        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days (S3 default)
+        // How long the presigned PART URLs stay signable — NOT an expiry on the
+        // upload. S3 has no default expiry for an incomplete multipart upload:
+        // its parts are held, and billed, until `abortMultipart` runs or an
+        // `AbortIncompleteMultipartUpload` lifecycle rule expires them.
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
       }
     } catch (error) {
       this.handleS3Error(error, 'startMultipart')
@@ -578,6 +583,49 @@ export class S3Adapter extends BaseStorageAdapter {
       }
     } catch (error) {
       this.handleS3Error(error, 'completeMultipart')
+    }
+  }
+
+  /**
+   * Release an unfinished S3 multipart upload.
+   *
+   * S3 keeps the parts of an incomplete multipart upload, and bills for them,
+   * until something aborts it — there is no expiry. `startMultipart` returning
+   * an `expiresAt` does NOT change that: it describes the presigned part URLs,
+   * not the upload.
+   *
+   * `params.bucket` is required for the same reason as everywhere else in this
+   * adapter, with one extra twist: aborting against the wrong bucket raises
+   * `NoSuchUpload` rather than succeeding silently, so a mistake here is loud
+   * but still leaves the real parts behind.
+   *
+   * Treated as best-effort by callers: an abort that fails must never fail the
+   * cancel it is cleaning up after. The lifecycle rule on the bucket is the
+   * backstop for the case no code can reach — a browser that goes away
+   * mid-upload never calls this at all.
+   */
+  async abortMultipart(params: {
+    key: string
+    uploadId: string
+    bucket?: string
+    auth?: ProviderAuth
+  }): Promise<void> {
+    this.requireCapability('presignUpload')
+
+    try {
+      const bucket = assertBucket(params.bucket, 'S3 abortMultipart')
+
+      const client = this.createS3Client(params.auth)
+
+      await client.send(
+        new AbortMultipartUploadCommand({
+          Bucket: bucket,
+          Key: params.key,
+          UploadId: params.uploadId,
+        })
+      )
+    } catch (error) {
+      this.handleS3Error(error, 'abortMultipart')
     }
   }
 

--- a/packages/lib/src/files/client.ts
+++ b/packages/lib/src/files/client.ts
@@ -1,8 +1,14 @@
 // packages/lib/src/files/client.ts
 
 /**
- * Client-safe exports for file utilities
- * These can be safely imported in frontend code
+ * The only `@auxx/lib/files` entry point front-end code may import.
+ *
+ * Everything re-exported here is provably free of server dependencies — no
+ * `@auxx/database`, no queue, no storage client — so importing it from a
+ * `'use client'` component cannot drag a Node-only module into the browser
+ * bundle. `@auxx/lib/files/types` is the server-side barrel for the same
+ * declarations; front-end code goes through this file instead so that the
+ * boundary is a single reviewable list rather than a per-import judgement call.
  */
 
 export {
@@ -18,3 +24,47 @@ export {
   isExtensionAllowed,
   VIDEO_EXTENSIONS,
 } from './file-type-constants'
+export type {
+  EntityUploadConfig,
+  EntityUploadPolicy,
+  FileStatus,
+  FileVisibility,
+  StageConfig,
+  ValidationConfig,
+} from './types/entities'
+export {
+  ENTITY_CONFIGS,
+  ENTITY_TYPES,
+  type EntityType,
+  getEntityConfig,
+  UPLOAD_POLICIES,
+} from './types/entities'
+export type {
+  CreateSessionOptions,
+  FileInfo,
+  SessionConfig,
+  SessionInfo,
+  SessionProgress,
+  SessionStatus,
+  UploadSessionOptions,
+} from './types/sessions'
+export type {
+  BatchProgressCallback,
+  BatchUploadResult,
+  CompletionCallback,
+  ErrorCallback,
+  MultiFileProgress,
+  ProcessingStage,
+  ProgressCallback,
+  QueueConfig,
+  QueuedFile,
+  QueueStats,
+  ServerIdKind,
+  StageStatus,
+  UploadCallbacks,
+  UploadFile,
+  UploadProgress,
+  UploadResult,
+  UploadResultMetadata,
+  UploadStatus,
+} from './types/uploads'

--- a/packages/lib/src/files/server.ts
+++ b/packages/lib/src/files/server.ts
@@ -261,6 +261,8 @@ export {
 // Upload compensation (PR 6c): delete the object, else enqueue a cleanup.
 // Exported so the public workflow-share completion route can stop leaking bytes
 // on failure -- it currently does no compensation at all.
+export type { AbortDeps, AbortInput, AbortOutcome } from './upload/abort'
+export { abortMultipartUpload } from './upload/abort'
 export type { CompensateDeps, CompensateInput, CompensationOutcome } from './upload/compensate'
 export { compensateUploadObject } from './upload/compensate'
 // The upload orchestration the three API routes used to inline (PR 4e).

--- a/packages/lib/src/files/storage/ports.ts
+++ b/packages/lib/src/files/storage/ports.ts
@@ -81,6 +81,18 @@ export interface CompleteMultipartParams extends ObjectRef {
   parts: Array<{ partNumber: number; etag: string }>
 }
 
+/**
+ * Releases an unfinished multipart upload. `bucket` must be the bucket the
+ * upload was started in.
+ *
+ * S3 holds the parts of an incomplete multipart upload, and bills for them,
+ * indefinitely — nothing expires them without an explicit abort or an
+ * `AbortIncompleteMultipartUpload` lifecycle rule on the bucket.
+ */
+export interface AbortMultipartParams extends ObjectRef {
+  uploadId: string
+}
+
 /** Metadata probe. `versionId` targets a specific object version where the provider has them. */
 export interface HeadParams extends ObjectRef {
   versionId?: string
@@ -171,6 +183,11 @@ export interface StoragePort {
   startMultipart(p: PresignUploadParams): Promise<MultipartUpload>
   presignPart(p: PresignPartParams): Promise<PresignedUpload>
   completeMultipart(p: CompleteMultipartParams): Promise<{ etag: string; size?: number }>
+  /**
+   * Releases a multipart upload that will never be completed. Best-effort:
+   * callers must not let a failed abort fail the cancel that triggered it.
+   */
+  abortMultipart(p: AbortMultipartParams): Promise<void>
   head(p: HeadParams): Promise<HeadResult>
   putObject(p: PutObjectParams): Promise<PutResult>
   getObject(p: GetObjectParams): Promise<Buffer>
@@ -349,6 +366,14 @@ export function createS3StoragePort(organizationId?: string): StoragePort {
         key: p.key,
         uploadId: p.uploadId,
         parts: p.parts,
+        bucket: p.bucket,
+        auth: await resolveAuth(p.bucket, p.credentialId),
+      }),
+
+    abortMultipart: async (p) =>
+      (await s3()).abortMultipart({
+        key: p.key,
+        uploadId: p.uploadId,
         bucket: p.bucket,
         auth: await resolveAuth(p.bucket, p.credentialId),
       }),

--- a/packages/lib/src/files/types/entities.ts
+++ b/packages/lib/src/files/types/entities.ts
@@ -1,13 +1,25 @@
 // packages/lib/src/files/types/entities.ts
 
 /**
- * Shared entity types for file upload configurations
- * Safe for import by both frontend and backend - contains no server dependencies
+ * The per-entity upload facts, and nothing that needs a server to state them.
+ *
+ * This module is imported by BOTH sides and must stay free of server
+ * dependencies: `packages/lib/src/files/upload/handlers/*` spread
+ * {@link UPLOAD_POLICIES} into their handler records, and the browser reads
+ * {@link ENTITY_CONFIGS} to reject a file before a byte is uploaded.
+ *
+ * That sharing is the point. The client table used to restate the limits by
+ * hand and drifted from the handlers it was mirroring — `WORKFLOW_RUN` refused
+ * at 15 MB what the server took to 50 MB, `USER_PROFILE` offered `image/*`
+ * where the server allows four explicit types, `ARTICLE` admitted video and
+ * audio the server rejects. Every one of those was a user being told "no" by a
+ * table with no authority. There is now exactly one table, here, and the
+ * handlers spread it rather than repeating it.
  */
 
 /**
  * Supported entity types for file uploads
- * Simple approach where entity type directly maps to processor
+ * Simple approach where entity type directly maps to handler
  */
 export const ENTITY_TYPES = {
   FILE: 'FILE',
@@ -25,6 +37,214 @@ export const ENTITY_TYPES = {
 } as const
 
 export type EntityType = (typeof ENTITY_TYPES)[keyof typeof ENTITY_TYPES]
+
+const MB = 1024 * 1024
+
+/** Every asset-backed entity signs for at most ten minutes. `FILE` is the exception. */
+const ASSET_MAX_TTL_SEC = 10 * 60
+
+/**
+ * MIME types accepted for dataset documents.
+ *
+ * The empty string and `application/octet-stream` are both here on purpose:
+ * a browser that cannot type a file by extension sends one or the other, and
+ * dataset ingestion sniffs the content itself downstream.
+ */
+const DATASET_MIME_TYPES = [
+  'text/plain',
+  'text/markdown',
+  'text/x-markdown',
+  'application/x-markdown',
+  'text/x-web-markdown',
+  'text/csv',
+  'text/tab-separated-values',
+  'text/tsv',
+  'application/json',
+  'application/x-ndjson',
+  'application/jsonl',
+  'text/json',
+  'application/xml',
+  'text/xml',
+  'application/x-yaml',
+  'text/yaml',
+  'text/x-yaml',
+  'application/yaml',
+  'text/css',
+  'text/javascript',
+  'application/javascript',
+  'text/x-python',
+  'text/x-sql',
+  'text/x-log',
+  'text/log',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'application/vnd.ms-powerpoint',
+  'application/pdf',
+  'text/html',
+  'application/xhtml+xml',
+  'application/zip',
+  'application/x-zip-compressed',
+  'message/rfc822',
+  'application/vnd.ms-outlook',
+  'application/epub+zip',
+  'application/rtf',
+  '',
+  'application/octet-stream',
+] as const
+
+/**
+ * Raster images only, and never an `image/*` wildcard: that would admit
+ * `image/svg+xml`, and an uploaded SVG can carry `<script>` that runs in our
+ * origin when the object is opened directly.
+ */
+const LOGO_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const
+
+/**
+ * The declarative half of an upload handler: what an entity type's uploads are
+ * allowed to be, stated as data with no I/O behind it.
+ *
+ * These five fields are exactly the ones `buildUploadConfig` reads to build the
+ * presigned policy, which is why they are also the only ones the browser can
+ * usefully pre-check. Everything else a handler declares — visibility, persist
+ * strategy, asset kind, hooks — is behaviour the client cannot mirror and must
+ * not try to.
+ */
+export interface EntityUploadPolicy {
+  entityType: EntityType
+  /** Hard ceiling, in bytes. Becomes the policy's `contentLengthRange` upper bound. */
+  maxFileSize: number
+  /** `type/subtype`, `type/*` and `*​/*` are all honoured — see `enforceUploadPolicy`. */
+  allowedMimeTypes: readonly string[]
+  /** Ceiling on the presigned signature's lifetime, in seconds. */
+  maxTtlSec: number
+  /** Size at or above which the upload is planned as multipart. */
+  multipartThresholdBytes?: number
+}
+
+/**
+ * The single source of truth for what each entity type's uploads may be.
+ *
+ * Read on the server by the handler records in `files/upload/handlers/`, which
+ * spread the matching entry, and on the client by {@link ENTITY_CONFIGS}. A
+ * limit stated anywhere else is a limit that can disagree with the one the
+ * server enforces.
+ */
+export const UPLOAD_POLICIES = {
+  [ENTITY_TYPES.FILE]: {
+    entityType: ENTITY_TYPES.FILE,
+    // The file library takes anything; the ceiling that actually binds is the
+    // organization's storage quota, answered as a 403 at session creation.
+    maxFileSize: Number.MAX_SAFE_INTEGER,
+    allowedMimeTypes: ['*/*'],
+    maxTtlSec: 60 * 60,
+    multipartThresholdBytes: 100 * MB,
+  },
+
+  [ENTITY_TYPES.DATASET]: {
+    entityType: ENTITY_TYPES.DATASET,
+    maxFileSize: 50 * MB,
+    allowedMimeTypes: DATASET_MIME_TYPES,
+    maxTtlSec: ASSET_MAX_TTL_SEC,
+  },
+
+  [ENTITY_TYPES.ARTICLE]: {
+    entityType: ENTITY_TYPES.ARTICLE,
+    maxFileSize: 10 * MB,
+    // No `image/*` wildcard — that would match `image/svg+xml`, and SVGs can
+    // carry <script> that runs in our origin when opened directly.
+    allowedMimeTypes: [
+      'image/jpeg',
+      'image/png',
+      'image/webp',
+      'image/gif',
+      'application/pdf',
+      'text/plain',
+      'text/markdown',
+      'text/html',
+    ],
+    maxTtlSec: ASSET_MAX_TTL_SEC,
+  },
+
+  [ENTITY_TYPES.USER_PROFILE]: {
+    entityType: ENTITY_TYPES.USER_PROFILE,
+    maxFileSize: 5 * MB,
+    allowedMimeTypes: ['image/jpeg', 'image/png', 'image/webp', 'image/gif'],
+    maxTtlSec: ASSET_MAX_TTL_SEC,
+  },
+
+  [ENTITY_TYPES.WORKFLOW_RUN]: {
+    entityType: ENTITY_TYPES.WORKFLOW_RUN,
+    maxFileSize: 50 * MB,
+    allowedMimeTypes: ['*/*'],
+    maxTtlSec: ASSET_MAX_TTL_SEC,
+    multipartThresholdBytes: 25 * MB,
+  },
+
+  [ENTITY_TYPES.COMMENT]: {
+    entityType: ENTITY_TYPES.COMMENT,
+    maxFileSize: 25 * MB,
+    allowedMimeTypes: [
+      'image/*',
+      'text/*',
+      'application/pdf',
+      'application/msword',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ],
+    maxTtlSec: ASSET_MAX_TTL_SEC,
+  },
+
+  [ENTITY_TYPES.MESSAGE]: {
+    entityType: ENTITY_TYPES.MESSAGE,
+    // 25 MB is the Gmail ceiling every provider is measured against.
+    maxFileSize: 25 * MB,
+    allowedMimeTypes: ['*/*'],
+    maxTtlSec: ASSET_MAX_TTL_SEC,
+  },
+
+  [ENTITY_TYPES.KNOWLEDGE_BASE]: {
+    entityType: ENTITY_TYPES.KNOWLEDGE_BASE,
+    maxFileSize: 10 * MB,
+    allowedMimeTypes: LOGO_MIME_TYPES,
+    maxTtlSec: ASSET_MAX_TTL_SEC,
+  },
+
+  [ENTITY_TYPES.CHAT_WIDGET]: {
+    entityType: ENTITY_TYPES.CHAT_WIDGET,
+    maxFileSize: 10 * MB,
+    allowedMimeTypes: LOGO_MIME_TYPES,
+    maxTtlSec: ASSET_MAX_TTL_SEC,
+  },
+
+  [ENTITY_TYPES.CUSTOM_FIELD]: {
+    entityType: ENTITY_TYPES.CUSTOM_FIELD,
+    // `*​/*` and 25 MB are the outer bounds only. The field's own `options.file`
+    // narrows both at prepare time, in `narrowPolicyToFieldOptions`.
+    maxFileSize: 25 * MB,
+    allowedMimeTypes: ['*/*'],
+    maxTtlSec: ASSET_MAX_TTL_SEC,
+  },
+
+  [ENTITY_TYPES.VISIT_QC_ITEM]: {
+    entityType: ENTITY_TYPES.VISIT_QC_ITEM,
+    maxFileSize: 25 * MB,
+    // HEIC/HEIF are accepted because the photo strip captures straight off an
+    // iPhone and `convertHeicToJpeg` only decodes in Safari — everywhere else it
+    // hands back the original file, so a `.heic` capture reaches the server
+    // as-is. SVG is excluded: XSS vector when served from our origin.
+    allowedMimeTypes: [
+      'image/jpeg',
+      'image/png',
+      'image/webp',
+      'image/gif',
+      'image/heic',
+      'image/heif',
+    ],
+    maxTtlSec: ASSET_MAX_TTL_SEC,
+  },
+} as const satisfies Record<EntityType, EntityUploadPolicy>
 
 /**
  * File visibility options
@@ -57,15 +277,18 @@ export interface StageConfig {
 }
 
 /**
- * File validation configuration
+ * The client-side pre-flight rules, derived from {@link UPLOAD_POLICIES}.
+ *
+ * Deliberately only the two rules the server actually enforces
+ * (`enforceUploadPolicy` checks size and MIME and nothing else). An extension
+ * allow-list used to live here too; it had no server counterpart, so it could
+ * only ever refuse a file the server would have taken.
  */
 export interface ValidationConfig {
-  maxFileSize: number // Maximum file size in bytes
-  allowedMimeTypes: string[] // Allowed MIME types
-  allowedExtensions: string[] // Allowed file extensions
-  scanForViruses?: boolean // Enable virus scanning
-  requireExtension?: boolean // Require file extension
-  blockExecutables?: boolean // Block executable files
+  /** Maximum file size in bytes */
+  maxFileSize: number
+  /** Allowed MIME types. `type/subtype`, `type/*` and `*​/*` are all honoured. */
+  allowedMimeTypes: readonly string[]
 }
 
 /**
@@ -207,38 +430,24 @@ export type EntityFileMetadata =
   | CustomFieldFileMetadata
   | MessageFileMetadata
 
-/**
- * Entity processing capabilities
- */
-export interface EntityCapabilities {
-  supportsBatchUpload: boolean
-  supportsPreview: boolean
-  supportsVersioning: boolean
-  supportsMetadataEditing: boolean
-  maxFileSize: number
-  recommendedFormats: string[]
-}
+/** The half of an entity's upload config that only the UI cares about. */
+type EntityPresentation = Omit<EntityUploadConfig, 'entityType' | 'validation'>
 
 /**
- * Pre-defined entity configurations
+ * Labels, progress stages and per-surface UI switches.
+ *
+ * None of this has a server counterpart — stages are a progress bar, not a
+ * pipeline — so it is stated by hand here and nowhere else. The limits are NOT
+ * here; they come from {@link UPLOAD_POLICIES}.
  */
-export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
+const ENTITY_PRESENTATION: Record<EntityType, EntityPresentation> = {
   [ENTITY_TYPES.FILE]: {
-    entityType: ENTITY_TYPES.FILE,
     displayName: 'Generic File',
     description: 'Upload files for general use',
     stages: [
       { name: 'validation', displayName: 'Validation', weight: 50, estimatedDuration: 1 },
       { name: 'storage', displayName: 'File Storage', weight: 50, estimatedDuration: 2 },
     ],
-    validation: {
-      maxFileSize: 100 * 1024 * 1024, // 100MB
-      allowedMimeTypes: ['*/*'], // Allow all file types for generic
-      allowedExtensions: [], // No restrictions for generic
-      scanForViruses: true,
-      requireExtension: false,
-      blockExecutables: true,
-    },
     defaultVisibility: 'private',
     maxConcurrentUploads: 3,
     enableBatchUpload: true,
@@ -246,7 +455,6 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
   },
 
   [ENTITY_TYPES.DATASET]: {
-    entityType: ENTITY_TYPES.DATASET,
     displayName: 'Dataset Document',
     description: 'Upload documents to be processed and indexed for AI training',
     stages: [
@@ -272,70 +480,6 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
         estimatedDuration: 30,
       },
     ],
-    validation: {
-      maxFileSize: 50 * 1024 * 1024, // 50MB
-      allowedMimeTypes: [
-        'text/*',
-        // 'text/markdown',
-        // 'text/x-markdown',
-        'application/x-markdown',
-        // 'text/x-web-markdown',
-        // 'text/csv',
-        // 'text/tab-separated-values',
-        // 'text/tsv',
-        'application/json',
-        'application/x-ndjson',
-        'application/jsonl',
-        // 'text/json',
-        'application/xml',
-        // 'text/xml',
-        'application/x-yaml',
-        // 'text/yaml',
-        // 'text/x-yaml',
-        'application/yaml',
-        // 'text/css',
-        // 'text/javascript',
-        'application/javascript',
-        // 'text/x-python',
-        // 'text/x-sql',
-        // 'text/x-log',
-        // 'text/log',
-        'application/pdf',
-        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-        'application/msword',
-        // 'text/html',
-        'application/xhtml+xml',
-        // Add empty MIME type support for files without extension detection
-        '',
-        'application/octet-stream',
-      ],
-      allowedExtensions: [
-        '.txt',
-        '.md',
-        '.markdown',
-        '.csv',
-        '.tsv',
-        '.json',
-        '.jsonl',
-        '.ndjson',
-        '.xml',
-        '.yaml',
-        '.yml',
-        '.css',
-        '.js',
-        '.py',
-        '.sql',
-        '.log',
-        '.pdf',
-        '.docx',
-        '.doc',
-        '.html',
-        '.htm',
-      ],
-      scanForViruses: true,
-      requireExtension: true,
-      blockExecutables: true,
-    },
     defaultVisibility: 'private',
     maxConcurrentUploads: 5,
     enableBatchUpload: true,
@@ -343,7 +487,6 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
   },
 
   [ENTITY_TYPES.ARTICLE]: {
-    entityType: ENTITY_TYPES.ARTICLE,
     displayName: 'Article Asset',
     description: 'Upload images and documents for knowledge base articles',
     stages: [
@@ -355,38 +498,6 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
         estimatedDuration: 5,
       },
     ],
-    validation: {
-      maxFileSize: 10 * 1024 * 1024, // 10MB
-      // Avoid `image/*` wildcard — it would admit `image/svg+xml`, which is
-      // an XSS vector when uploaded files are served from our origin.
-      allowedMimeTypes: [
-        'image/jpeg',
-        'image/png',
-        'image/gif',
-        'image/webp',
-        'text/*',
-        'video/*',
-        'audio/*',
-        'application/pdf',
-      ],
-      allowedExtensions: [
-        '.jpg',
-        '.jpeg',
-        '.png',
-        '.gif',
-        '.webp',
-        '.pdf',
-        '.txt',
-        '.md',
-        '.mp4',
-        '.webm',
-        '.mp3',
-        '.wav',
-      ],
-      scanForViruses: true,
-      requireExtension: true,
-      blockExecutables: true,
-    },
     defaultVisibility: 'public',
     maxConcurrentUploads: 5,
     enableBatchUpload: true,
@@ -394,7 +505,6 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
   },
 
   [ENTITY_TYPES.USER_PROFILE]: {
-    entityType: ENTITY_TYPES.USER_PROFILE,
     displayName: 'User Avatar',
     description: 'Upload profile pictures and user avatars',
     stages: [
@@ -406,19 +516,6 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
         estimatedDuration: 2,
       },
     ],
-    validation: {
-      maxFileSize: 5 * 1024 * 1024, // 5MB
-      allowedMimeTypes: [
-        'image/*',
-        // 'image/png',
-        // 'image/webp',
-        // 'image/gif',
-      ],
-      allowedExtensions: ['.jpg', '.jpeg', '.png', '.webp', '.gif'],
-      scanForViruses: true,
-      requireExtension: true,
-      blockExecutables: true,
-    },
     defaultVisibility: 'public',
     maxConcurrentUploads: 1,
     enableBatchUpload: false,
@@ -426,7 +523,6 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
   },
 
   [ENTITY_TYPES.WORKFLOW_RUN]: {
-    entityType: ENTITY_TYPES.WORKFLOW_RUN,
     displayName: 'Workflow Asset',
     description: 'Upload files for workflow templates and examples',
     stages: [
@@ -438,20 +534,6 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
         estimatedDuration: 2,
       },
     ],
-    validation: {
-      maxFileSize: 15 * 1024 * 1024, // 15MB
-      allowedMimeTypes: [
-        'text/*',
-        'image/*',
-        'application/json',
-        'application/xml',
-        'application/pdf',
-      ],
-      allowedExtensions: ['.txt', '.json', '.xml', '.yaml', '.yml', '.jpg', '.png', '.pdf', '.md'],
-      scanForViruses: true,
-      requireExtension: true,
-      blockExecutables: true,
-    },
     defaultVisibility: 'private',
     maxConcurrentUploads: 2,
     enableBatchUpload: false,
@@ -459,7 +541,6 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
   },
 
   [ENTITY_TYPES.COMMENT]: {
-    entityType: ENTITY_TYPES.COMMENT,
     displayName: 'Comment Attachment',
     description: 'Attach files to comments',
     stages: [
@@ -471,47 +552,6 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
         estimatedDuration: 2,
       },
     ],
-    validation: {
-      maxFileSize: 25 * 1024 * 1024, // 25MB
-      allowedMimeTypes: [
-        'image/*',
-        'text/*',
-        'application/pdf',
-        'application/msword',
-        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      ],
-      allowedExtensions: ['.jpg', '.jpeg', '.png', '.gif', '.pdf', '.txt', '.doc', '.docx'],
-      scanForViruses: true,
-      requireExtension: true,
-      blockExecutables: true,
-    },
-    defaultVisibility: 'private',
-    maxConcurrentUploads: 3,
-    enableBatchUpload: true,
-    supportedFeatures: { progress: true, preview: true, retry: true, pause: false, resume: false },
-  },
-
-  [ENTITY_TYPES.CUSTOM_FIELD]: {
-    entityType: ENTITY_TYPES.CUSTOM_FIELD,
-    displayName: 'Custom Field Attachment',
-    description: 'Attach files to custom field values',
-    stages: [
-      { name: 'validation', displayName: 'Validation', weight: 50, estimatedDuration: 1 },
-      {
-        name: 'attachment-creation',
-        displayName: 'Attachment Creation',
-        weight: 50,
-        estimatedDuration: 2,
-      },
-    ],
-    validation: {
-      maxFileSize: 25 * 1024 * 1024, // 25MB
-      allowedMimeTypes: ['*/*'],
-      allowedExtensions: [],
-      scanForViruses: true,
-      requireExtension: false,
-      blockExecutables: true,
-    },
     defaultVisibility: 'private',
     maxConcurrentUploads: 3,
     enableBatchUpload: true,
@@ -519,7 +559,6 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
   },
 
   [ENTITY_TYPES.MESSAGE]: {
-    entityType: ENTITY_TYPES.MESSAGE,
     displayName: 'Email Attachment',
     description: 'Attach files to email messages',
     stages: [
@@ -532,28 +571,13 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
         estimatedDuration: 2,
       },
     ],
-    validation: {
-      maxFileSize: 25 * 1024 * 1024, // 25MB (Gmail standard)
-      allowedMimeTypes: ['image/*', 'text/*', 'application/*', 'audio/*', 'video/*'],
-      allowedExtensions: [], // Allow all extensions for email
-      scanForViruses: true,
-      requireExtension: false,
-      blockExecutables: true,
-    },
     defaultVisibility: 'private',
     maxConcurrentUploads: 5,
     enableBatchUpload: true,
-    supportedFeatures: {
-      progress: true,
-      preview: true,
-      retry: true,
-      pause: false,
-      resume: false,
-    },
+    supportedFeatures: { progress: true, preview: true, retry: true, pause: false, resume: false },
   },
 
   [ENTITY_TYPES.KNOWLEDGE_BASE]: {
-    entityType: ENTITY_TYPES.KNOWLEDGE_BASE,
     displayName: 'Knowledge Base Branding',
     description: 'Logos and branding assets for Knowledge Base',
     stages: [
@@ -565,15 +589,6 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
         estimatedDuration: 2,
       },
     ],
-    validation: {
-      maxFileSize: 10 * 1024 * 1024, // 10MB
-      // SVG is intentionally excluded — XSS risk (script execution in our origin).
-      allowedMimeTypes: ['image/jpeg', 'image/png', 'image/webp'],
-      allowedExtensions: ['.jpg', '.jpeg', '.png', '.webp'],
-      scanForViruses: true,
-      requireExtension: true,
-      blockExecutables: true,
-    },
     defaultVisibility: 'public',
     maxConcurrentUploads: 1,
     enableBatchUpload: false,
@@ -581,7 +596,6 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
   },
 
   [ENTITY_TYPES.CHAT_WIDGET]: {
-    entityType: ENTITY_TYPES.CHAT_WIDGET,
     displayName: 'Chat Widget Branding',
     description: 'Logos and branding assets for the embedded Chat Widget',
     stages: [
@@ -593,22 +607,31 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
         estimatedDuration: 2,
       },
     ],
-    validation: {
-      maxFileSize: 10 * 1024 * 1024, // 10MB
-      allowedMimeTypes: ['image/jpeg', 'image/png', 'image/webp'],
-      allowedExtensions: ['.jpg', '.jpeg', '.png', '.webp'],
-      scanForViruses: true,
-      requireExtension: true,
-      blockExecutables: true,
-    },
     defaultVisibility: 'public',
     maxConcurrentUploads: 1,
     enableBatchUpload: false,
     supportedFeatures: { progress: true, preview: true, retry: true, pause: false, resume: false },
   },
 
+  [ENTITY_TYPES.CUSTOM_FIELD]: {
+    displayName: 'Custom Field Attachment',
+    description: 'Attach files to custom field values',
+    stages: [
+      { name: 'validation', displayName: 'Validation', weight: 50, estimatedDuration: 1 },
+      {
+        name: 'attachment-creation',
+        displayName: 'Attachment Creation',
+        weight: 50,
+        estimatedDuration: 2,
+      },
+    ],
+    defaultVisibility: 'private',
+    maxConcurrentUploads: 3,
+    enableBatchUpload: true,
+    supportedFeatures: { progress: true, preview: true, retry: true, pause: false, resume: false },
+  },
+
   [ENTITY_TYPES.VISIT_QC_ITEM]: {
-    entityType: ENTITY_TYPES.VISIT_QC_ITEM,
     displayName: 'Quality Check Photo',
     description: 'Attach photos to a visit quality-check item',
     stages: [
@@ -620,33 +643,38 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = {
         estimatedDuration: 2,
       },
     ],
-    // Mirrors `visitQcItemHandler` (upload/handlers/visit-qc-item.ts), which is the
-    // authority — this config is only the client-side pre-flight. HEIC/HEIF are accepted because
-    // the strip captures straight off an iPhone and does not run `convertHeicToJpeg` (which is
-    // Safari-only and hands back the original file everywhere else), so a `.heic` capture reaches
-    // the server as-is and the server takes it.
-    validation: {
-      maxFileSize: 25 * 1024 * 1024, // 25MB — matches VisitQcItemProcessor.maxFileSize
-      // SVG excluded — XSS vector when served from our origin.
-      allowedMimeTypes: [
-        'image/jpeg',
-        'image/png',
-        'image/webp',
-        'image/gif',
-        'image/heic',
-        'image/heif',
-      ],
-      allowedExtensions: ['.jpg', '.jpeg', '.png', '.webp', '.gif', '.heic', '.heif'],
-      scanForViruses: true,
-      requireExtension: true,
-      blockExecutables: true,
-    },
     defaultVisibility: 'private',
     maxConcurrentUploads: 3,
     enableBatchUpload: true,
     supportedFeatures: { progress: true, preview: true, retry: true, pause: false, resume: false },
   },
-} as const
+}
+
+/**
+ * Per-entity upload configuration for the browser.
+ *
+ * Built, not written: the `validation` half is projected straight out of
+ * {@link UPLOAD_POLICIES}, so the client cannot refuse a file the server would
+ * accept. Only {@link ENTITY_PRESENTATION} is hand-maintained, and none of it
+ * decides whether a file is allowed.
+ */
+export const ENTITY_CONFIGS: Record<EntityType, EntityUploadConfig> = (() => {
+  const configs = {} as Record<EntityType, EntityUploadConfig>
+
+  for (const entityType of Object.values(ENTITY_TYPES)) {
+    const policy = UPLOAD_POLICIES[entityType]
+    configs[entityType] = {
+      entityType,
+      ...ENTITY_PRESENTATION[entityType],
+      validation: {
+        maxFileSize: policy.maxFileSize,
+        allowedMimeTypes: policy.allowedMimeTypes,
+      },
+    }
+  }
+
+  return configs
+})()
 
 /**
  * Get configuration for specific entity type
@@ -659,19 +687,4 @@ export function getEntityConfig(entityType: EntityType): EntityUploadConfig {
     )
   }
   return config
-}
-
-/**
- * Get capabilities for specific entity type
- */
-export function getEntityCapabilities(entityType: EntityType): EntityCapabilities {
-  const config = getEntityConfig(entityType)
-  return {
-    supportsBatchUpload: config.enableBatchUpload ?? false,
-    supportsPreview: config.supportedFeatures.preview,
-    supportsVersioning: false, // Not implemented yet
-    supportsMetadataEditing: true,
-    maxFileSize: config.validation.maxFileSize,
-    recommendedFormats: config.validation.allowedExtensions,
-  }
 }

--- a/packages/lib/src/files/types/index.ts
+++ b/packages/lib/src/files/types/index.ts
@@ -12,9 +12,9 @@ export type {
   BaseEntityMetadata,
   CustomFieldFileMetadata,
   DatasetFileMetadata,
-  EntityCapabilities,
   EntityFileMetadata,
   EntityUploadConfig,
+  EntityUploadPolicy,
   FileStatus,
   FileVisibility,
   KnowledgeBaseFileMetadata,
@@ -28,8 +28,8 @@ export {
   ENTITY_CONFIGS,
   ENTITY_TYPES,
   type EntityType,
-  getEntityCapabilities,
   getEntityConfig,
+  UPLOAD_POLICIES,
 } from './entities'
 // Event types
 export type {

--- a/packages/lib/src/files/upload/__tests__/abort.test.ts
+++ b/packages/lib/src/files/upload/__tests__/abort.test.ts
@@ -1,0 +1,91 @@
+// packages/lib/src/files/upload/__tests__/abort.test.ts
+
+/**
+ * Releasing an abandoned multipart upload.
+ *
+ * The gap this closes was found by hand, not by a test: cancelling a 184 MB
+ * multipart upload in the browser left its parts in `auxx-dev-private`, and
+ * nothing in the codebase could ever remove them — there was no abort call
+ * anywhere, and the bucket had no `AbortIncompleteMultipartUpload` rule.
+ *
+ * The three properties worth pinning are all about *not* making a cancel worse:
+ * a single-part session must not call storage at all, a failed abort must not
+ * throw into the caller's cancel path, and the bucket must be the one the upload
+ * was started in.
+ *
+ * `vi.mock` count in this file: **zero**.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { makeJournal, makeStoragePort, TEST_BUCKETS, TEST_IDS } from '../../__tests__/support'
+import { type AbortInput, abortMultipartUpload } from '../abort'
+
+const KEY = `${TEST_IDS.organizationId}/file/temp/1787608775497_Ollama-darwin.zip`
+
+function anAbandonedUpload(overrides: Partial<AbortInput> = {}): AbortInput {
+  return {
+    provider: 'S3',
+    bucket: TEST_BUCKETS.private,
+    key: KEY,
+    credentialId: TEST_IDS.credentialId,
+    uploadId: 'Sk86dPkYGArqgRbYYsG',
+    reason: 'user-cancelled',
+    sessionId: 'sess_nanoid_000000000000',
+    ...overrides,
+  }
+}
+
+describe('abortMultipartUpload', () => {
+  it('releases the upload against the bucket it was started in', async () => {
+    const journal = makeJournal()
+    const storage = makeStoragePort({ journal })
+
+    const outcome = await abortMultipartUpload({ storage: storage.port }, anAbandonedUpload())
+
+    expect(outcome).toBe('aborted')
+
+    const calls = storage.callsTo('abortMultipart')
+    expect(calls).toHaveLength(1)
+    // The bucket is carried from the session, never re-derived: an abort against
+    // the wrong bucket raises NoSuchUpload and the real parts stay behind.
+    expect(calls[0]?.params).toMatchObject({
+      bucket: TEST_BUCKETS.private,
+      key: KEY,
+      uploadId: 'Sk86dPkYGArqgRbYYsG',
+    })
+  })
+
+  it('does not touch storage when the session was single-part', async () => {
+    const journal = makeJournal()
+    const storage = makeStoragePort({ journal })
+
+    // No `uploadId`: an abandoned PUT never becomes an object, so there is
+    // nothing for S3 to hold and nothing to release.
+    const outcome = await abortMultipartUpload(
+      { storage: storage.port },
+      anAbandonedUpload({ uploadId: undefined })
+    )
+
+    expect(outcome).toBe('skipped')
+    expect(storage.callsTo('abortMultipart')).toHaveLength(0)
+  })
+
+  it('swallows a storage failure so a cancel never surfaces as an error', async () => {
+    const journal = makeJournal()
+    const storage = makeStoragePort({
+      journal,
+      impl: {
+        abortMultipart: async () => {
+          throw new Error('S3 unreachable')
+        },
+      },
+    })
+
+    // The caller is already cancelling. Replacing that with a storage error the
+    // user cannot act on is strictly worse than leaking parts the bucket's
+    // lifecycle rule reclaims.
+    const outcome = await abortMultipartUpload({ storage: storage.port }, anAbandonedUpload())
+
+    expect(outcome).toBe('failed')
+  })
+})

--- a/packages/lib/src/files/upload/abort.ts
+++ b/packages/lib/src/files/upload/abort.ts
@@ -1,0 +1,127 @@
+// packages/lib/src/files/upload/abort.ts
+
+/**
+ * Releasing a multipart upload that will never be completed.
+ *
+ * ## Why this exists
+ *
+ * A single-part PUT that the browser abandons leaves nothing behind: S3 only
+ * materialises the object when the request finishes. A **multipart** upload is
+ * the opposite. `CreateMultipartUpload` opens server-side state immediately,
+ * every part that lands is stored, and S3 keeps and bills for those parts
+ * **forever** unless something aborts the upload or a lifecycle rule expires it.
+ *
+ * Until this module there was no abort anywhere in the codebase, so cancelling a
+ * multipart upload leaked every part that had already landed. A 184 MB cancel
+ * during the phase-10 browser test left exactly that behind, and it was still
+ * there — immortal — when it was found by hand.
+ *
+ * The `expiresAt` that {@link startMultipartUpload} returns is not a safety net
+ * and never was. It describes how long the presigned part URLs stay signable;
+ * the upload itself has no expiry. The S3 adapter used to carry a
+ * `// 7 days (S3 default)` comment next to it, which is what made the gap look
+ * closed.
+ *
+ * ## Best-effort, always
+ *
+ * This runs while the caller is already cancelling. A failed abort must never
+ * turn a cancel into an error the user sees: the cancel succeeded, and the cost
+ * of the leak is storage the lifecycle rule will reclaim. So this never throws,
+ * exactly like {@link compensateUploadObject}, and reports what happened instead.
+ *
+ * ## This is not the only defence, and must not be the only one
+ *
+ * A browser that is closed, crashes, or loses the network mid-upload never
+ * reaches this code — no client-side handler can be relied on to run. The
+ * durable backstop is an `AbortIncompleteMultipartUpload` lifecycle rule on the
+ * bucket, which is infrastructure, not application code. Both are required:
+ * this reclaims the bytes in seconds for the common case, the rule catches
+ * everything else.
+ *
+ * ## `bucket` is not optional and is never defaulted
+ *
+ * Same rule as every other storage call. Aborting against the wrong bucket does
+ * at least fail loudly with `NoSuchUpload` rather than 204-ing like a delete
+ * does, but the real parts still leak, so the bucket comes from the session that
+ * started the upload and is never re-derived here.
+ */
+
+import { createScopedLogger } from '@auxx/logger'
+import type { FilesDepsSlice } from '../ctx'
+import type { ObjectRef } from '../storage/ports'
+
+const logger = createScopedLogger('upload-abort')
+
+/** Storage only. There is no durable fallback — see {@link AbortOutcome}. */
+export type AbortDeps = FilesDepsSlice<'storage'>
+
+/** The multipart upload to release. */
+export interface AbortInput extends ObjectRef {
+  /**
+   * The `UploadId` S3 returned from `CreateMultipartUpload`, absent on a
+   * single-part session. Optional because that is exactly what the upload
+   * session carries, and narrowing it here would only move the check to every
+   * caller.
+   */
+  uploadId?: string
+  /** Why it is being abandoned. Log triage only. */
+  reason: string
+  /** Correlation for the log lines only. */
+  sessionId?: string
+}
+
+/** What the abort managed to do, so a caller can log or assert on it. */
+export type AbortOutcome =
+  /** S3 released the parts. */
+  | 'aborted'
+  /** Nothing to abort: the session never opened a multipart upload. */
+  | 'skipped'
+  /**
+   * The abort failed. The parts are leaked until the bucket's
+   * `AbortIncompleteMultipartUpload` lifecycle rule expires them.
+   *
+   * Deliberately no queued fallback: a cleanup job would need the `uploadId`,
+   * which is meaningless once S3 has expired the upload, and the lifecycle rule
+   * already covers the same case more reliably than a job could.
+   */
+  | 'failed'
+
+/**
+ * Release an in-flight multipart upload so S3 stops holding its parts.
+ *
+ * Never throws. See the file header for why, and for why the lifecycle rule is
+ * still required alongside this.
+ *
+ * @param deps Storage port — see {@link AbortDeps}.
+ * @param input The upload, its bucket and key, and why it is being abandoned.
+ * @returns `'skipped'` when there was no multipart upload to release.
+ */
+export async function abortMultipartUpload(
+  deps: AbortDeps,
+  input: AbortInput
+): Promise<AbortOutcome> {
+  // A single-part session has no `uploadId` and needs no cleanup: an abandoned
+  // PUT never becomes an object.
+  if (!input.uploadId) return 'skipped'
+
+  try {
+    await deps.storage.abortMultipart({
+      provider: input.provider,
+      bucket: input.bucket,
+      key: input.key,
+      credentialId: input.credentialId,
+      uploadId: input.uploadId,
+    })
+    return 'aborted'
+  } catch (error) {
+    logger.warn('Multipart abort failed; parts leak until the lifecycle rule expires them', {
+      sessionId: input.sessionId,
+      key: input.key,
+      bucket: input.bucket,
+      uploadId: input.uploadId,
+      reason: input.reason,
+      error,
+    })
+    return 'failed'
+  }
+}

--- a/packages/lib/src/files/upload/handlers/__tests__/handlers.test.ts
+++ b/packages/lib/src/files/upload/handlers/__tests__/handlers.test.ts
@@ -16,7 +16,7 @@
 import { describe, expect, it } from 'vitest'
 import { BadRequestError } from '../../../../errors'
 import { VALID_ASSET_KINDS } from '../../../core/types'
-import { ENTITY_TYPES } from '../../../types/entities'
+import { ENTITY_CONFIGS, ENTITY_TYPES } from '../../../types/entities'
 import type { UploadPreparedConfig } from '../../init-types'
 import { narrowPolicyToFieldOptions } from '../custom-field'
 import { getUploadHandler, requiresEntityId, UPLOAD_HANDLERS } from '../index'
@@ -51,6 +51,21 @@ describe('getUploadHandler', () => {
   it('refuses an unknown entity type by name rather than falling back', () => {
     expect(() => getUploadHandler('TICKET')).toThrow(BadRequestError)
     expect(() => getUploadHandler('TICKET')).toThrow('No upload handler for entity type: TICKET')
+  })
+})
+
+describe('the browser pre-flight table cannot drift from the handlers', () => {
+  // `ENTITY_CONFIGS` is read in the browser (`orchestration-slice.ts`) to refuse
+  // a file before it is uploaded. It used to restate the limits by hand and had
+  // drifted: `WORKFLOW_RUN` refused at 15 MB what the server took to 50 MB,
+  // `USER_PROFILE` offered `image/*` against four explicit server types, and
+  // `ARTICLE` admitted video and audio the server rejects. Both sides now read
+  // `UPLOAD_POLICIES`; this is what keeps them reading it.
+  it.each(HANDLERS)('%s agrees with the client config on size and MIME', (key, handler) => {
+    const config = ENTITY_CONFIGS[key as keyof typeof ENTITY_CONFIGS]
+
+    expect(config.validation.maxFileSize).toBe(handler.maxFileSize)
+    expect(config.validation.allowedMimeTypes).toEqual(handler.allowedMimeTypes)
   })
 })
 

--- a/packages/lib/src/files/upload/handlers/article.ts
+++ b/packages/lib/src/files/upload/handlers/article.ts
@@ -1,30 +1,16 @@
 // packages/lib/src/files/upload/handlers/article.ts
 
 import { schema } from '@auxx/database'
-import { ENTITY_TYPES } from '../../types/entities'
-import { ASSET_MAX_TTL_SEC, assertRowInOrg, MB } from './shared'
+import { UPLOAD_POLICIES } from '../../types/entities'
+import { assertRowInOrg } from './shared'
 import type { UploadHandler } from './types'
 
 /** Knowledge-base article bodies: inline images, covers, attached documents. */
 export const articleHandler: UploadHandler = {
-  entityType: ENTITY_TYPES.ARTICLE,
+  ...UPLOAD_POLICIES.ARTICLE,
   // A cover is forced PUBLIC so its URL is durable: OG image crawlers cache for
   // hours or days, by which point a presigned URL answers 403.
   visibility: (init) => (init.metadata?.role === 'COVER' ? 'PUBLIC' : 'PRIVATE'),
-  maxFileSize: 10 * MB,
-  // No `image/*` wildcard — that would match `image/svg+xml`, and SVGs can carry
-  // <script> that runs in our origin when opened directly.
-  allowedMimeTypes: [
-    'image/jpeg',
-    'image/png',
-    'image/webp',
-    'image/gif',
-    'application/pdf',
-    'text/plain',
-    'text/markdown',
-    'text/html',
-  ],
-  maxTtlSec: ASSET_MAX_TTL_SEC,
   // A cover or an explicit thumbnail is a rendition, not body content.
   assetKind: (session) =>
     session.metadata?.role === 'COVER' || session.metadata?.role === 'THUMBNAIL'

--- a/packages/lib/src/files/upload/handlers/chat-widget.ts
+++ b/packages/lib/src/files/upload/handlers/chat-widget.ts
@@ -3,19 +3,16 @@
 import { schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
 import { eq } from 'drizzle-orm'
-import { ENTITY_TYPES } from '../../types/entities'
-import { ASSET_MAX_TTL_SEC, assertRowInOrg, LOGO_MIME_TYPES, logoColumnUpdate, MB } from './shared'
+import { UPLOAD_POLICIES } from '../../types/entities'
+import { assertRowInOrg, logoColumnUpdate } from './shared'
 import type { UploadHandler } from './types'
 
 const logger = createScopedLogger('upload-handler-chat-widget')
 
 /** Embedded chat-widget branding. Rendered at one fixed size, so no presets. */
 export const chatWidgetHandler: UploadHandler = {
-  entityType: ENTITY_TYPES.CHAT_WIDGET,
+  ...UPLOAD_POLICIES.CHAT_WIDGET,
   visibility: 'PUBLIC',
-  maxFileSize: 10 * MB,
-  allowedMimeTypes: LOGO_MIME_TYPES,
-  maxTtlSec: ASSET_MAX_TTL_SEC,
   assetKind: 'THUMBNAIL',
   persist: 'asset+attachment',
 

--- a/packages/lib/src/files/upload/handlers/comment.ts
+++ b/packages/lib/src/files/upload/handlers/comment.ts
@@ -1,8 +1,8 @@
 // packages/lib/src/files/upload/handlers/comment.ts
 
 import { schema } from '@auxx/database'
-import { ENTITY_TYPES } from '../../types/entities'
-import { ASSET_MAX_TTL_SEC, assertRowInOrg, hasTempPrefix, MB, tempExpiry } from './shared'
+import { UPLOAD_POLICIES } from '../../types/entities'
+import { assertRowInOrg, hasTempPrefix, tempExpiry } from './shared'
 import type { UploadHandler } from './types'
 
 /** Uploads aimed at a comment that does not exist yet carry this entity-id prefix. */
@@ -10,17 +10,8 @@ const TEMP_COMMENT_PREFIX = 'temp-comment-'
 
 /** Attachments on a comment, including ones uploaded before the comment exists. */
 export const commentHandler: UploadHandler = {
-  entityType: ENTITY_TYPES.COMMENT,
+  ...UPLOAD_POLICIES.COMMENT,
   visibility: 'PRIVATE',
-  maxFileSize: 25 * MB,
-  allowedMimeTypes: [
-    'image/*',
-    'text/*',
-    'application/pdf',
-    'application/msword',
-    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  ],
-  maxTtlSec: ASSET_MAX_TTL_SEC,
   assetKind: 'TEMP_UPLOAD',
   persist: 'asset+attachment',
 

--- a/packages/lib/src/files/upload/handlers/custom-field.ts
+++ b/packages/lib/src/files/upload/handlers/custom-field.ts
@@ -3,9 +3,9 @@
 import { createScopedLogger } from '@auxx/logger'
 import { getOrgCache } from '../../../cache'
 import { type FileTypeCategory, getMimePatternsForCategories } from '../../file-type-constants'
-import { ENTITY_TYPES } from '../../types/entities'
+import { UPLOAD_POLICIES } from '../../types/entities'
 import type { UploadPreparedConfig } from '../init-types'
-import { ASSET_MAX_TTL_SEC, hasTempPrefix, MB, tempExpiry } from './shared'
+import { hasTempPrefix, tempExpiry } from './shared'
 import type { UploadHandler } from './types'
 
 const logger = createScopedLogger('upload-handler-custom-field')
@@ -59,11 +59,8 @@ export function narrowPolicyToFieldOptions(
  * giving it teeth would reject uploads that work today.
  */
 export const customFieldHandler: UploadHandler = {
-  entityType: ENTITY_TYPES.CUSTOM_FIELD,
+  ...UPLOAD_POLICIES.CUSTOM_FIELD,
   visibility: 'PRIVATE',
-  maxFileSize: 25 * MB,
-  allowedMimeTypes: ['*/*'],
-  maxTtlSec: ASSET_MAX_TTL_SEC,
   assetKind: 'TEMP_UPLOAD',
   persist: 'asset+attachment',
 

--- a/packages/lib/src/files/upload/handlers/dataset.ts
+++ b/packages/lib/src/files/upload/handlers/dataset.ts
@@ -6,9 +6,9 @@ import { DocumentService } from '../../../datasets/services/document-service'
 import type { DocumentProcessingOptions } from '../../../datasets/types'
 import { DocumentProcessingQueue } from '../../../datasets/workers/document-processing-queue'
 import { BadRequestError } from '../../../errors'
-import { ENTITY_TYPES } from '../../types/entities'
+import { UPLOAD_POLICIES } from '../../types/entities'
 import type { PresignedUploadSession } from '../session-types'
-import { ASSET_MAX_TTL_SEC, assertRowInOrg, DATASET_MIME_TYPES, MB } from './shared'
+import { assertRowInOrg } from './shared'
 import type { UploadHandler } from './types'
 
 /** The slice of `session.metadata` a dataset upload carries. */
@@ -35,7 +35,7 @@ function titleFromFileName(fileName: string): string {
  * for background parsing only once that transaction has committed.
  */
 export const datasetHandler: UploadHandler = {
-  entityType: ENTITY_TYPES.DATASET,
+  ...UPLOAD_POLICIES.DATASET,
   // `entityId` IS the dataset id for this entity type; the document writer reads
   // it out of metadata, so it is copied across before the config is built.
   normalizeInit: (init) => ({
@@ -43,9 +43,6 @@ export const datasetHandler: UploadHandler = {
     metadata: { ...init.metadata, datasetId: init.entityId },
   }),
   visibility: 'PRIVATE',
-  maxFileSize: 50 * MB,
-  allowedMimeTypes: DATASET_MIME_TYPES,
-  maxTtlSec: ASSET_MAX_TTL_SEC,
   assetKind: 'DOCUMENT',
   persist: 'asset',
 

--- a/packages/lib/src/files/upload/handlers/file.ts
+++ b/packages/lib/src/files/upload/handlers/file.ts
@@ -1,7 +1,6 @@
 // packages/lib/src/files/upload/handlers/file.ts
 
-import { ENTITY_TYPES } from '../../types/entities'
-import { MB } from './shared'
+import { UPLOAD_POLICIES } from '../../types/entities'
 import type { UploadHandler } from './types'
 
 /**
@@ -12,14 +11,7 @@ import type { UploadHandler } from './types'
  * whose whole prepare path touches no database at all.
  */
 export const fileHandler: UploadHandler = {
-  entityType: ENTITY_TYPES.FILE,
+  ...UPLOAD_POLICIES.FILE,
   visibility: 'PRIVATE',
-  // `FileProcessor` never clamped the base policy's permissive range, so a user
-  // file has no server-side ceiling here. The org's storage quota is the real
-  // limit and the route checks it before this runs.
-  maxFileSize: Number.MAX_SAFE_INTEGER,
-  allowedMimeTypes: ['*/*'],
-  maxTtlSec: 60 * 60,
-  multipartThresholdBytes: 100 * MB,
   persist: 'folder-file',
 }

--- a/packages/lib/src/files/upload/handlers/knowledge-base.ts
+++ b/packages/lib/src/files/upload/handlers/knowledge-base.ts
@@ -2,17 +2,14 @@
 
 import { schema } from '@auxx/database'
 import { eq } from 'drizzle-orm'
-import { ENTITY_TYPES } from '../../types/entities'
-import { ASSET_MAX_TTL_SEC, assertRowInOrg, LOGO_MIME_TYPES, logoColumnUpdate, MB } from './shared'
+import { UPLOAD_POLICIES } from '../../types/entities'
+import { assertRowInOrg, logoColumnUpdate } from './shared'
 import type { UploadHandler } from './types'
 
 /** Knowledge-base branding: the light and dark logo variants. */
 export const knowledgeBaseHandler: UploadHandler = {
-  entityType: ENTITY_TYPES.KNOWLEDGE_BASE,
+  ...UPLOAD_POLICIES.KNOWLEDGE_BASE,
   visibility: 'PUBLIC',
-  maxFileSize: 10 * MB,
-  allowedMimeTypes: LOGO_MIME_TYPES,
-  maxTtlSec: ASSET_MAX_TTL_SEC,
   assetKind: 'THUMBNAIL',
   persist: 'asset+attachment',
 

--- a/packages/lib/src/files/upload/handlers/message.ts
+++ b/packages/lib/src/files/upload/handlers/message.ts
@@ -1,8 +1,8 @@
 // packages/lib/src/files/upload/handlers/message.ts
 
 import { schema } from '@auxx/database'
-import { ENTITY_TYPES } from '../../types/entities'
-import { ASSET_MAX_TTL_SEC, assertRowInOrg, hasTempPrefix, MB, tempExpiry } from './shared'
+import { UPLOAD_POLICIES } from '../../types/entities'
+import { assertRowInOrg, hasTempPrefix, tempExpiry } from './shared'
 import type { UploadHandler } from './types'
 
 /** Uploads aimed at a draft that does not exist yet carry this entity-id prefix. */
@@ -10,11 +10,8 @@ const TEMP_MESSAGE_PREFIX = 'temp-message-'
 
 /** Email attachments. 25 MB is the Gmail ceiling every provider is measured against. */
 export const messageHandler: UploadHandler = {
-  entityType: ENTITY_TYPES.MESSAGE,
+  ...UPLOAD_POLICIES.MESSAGE,
   visibility: 'PRIVATE',
-  maxFileSize: 25 * MB,
-  allowedMimeTypes: ['*/*'],
-  maxTtlSec: ASSET_MAX_TTL_SEC,
   persist: 'asset+attachment',
 
   /**

--- a/packages/lib/src/files/upload/handlers/shared.ts
+++ b/packages/lib/src/files/upload/handlers/shared.ts
@@ -1,13 +1,17 @@
 // packages/lib/src/files/upload/handlers/shared.ts
 
 /**
- * The constants and two helpers more than one upload handler needs.
+ * The helpers more than one upload handler needs.
  *
  * Kept deliberately small. A handler is meant to read as a statement of facts
  * about one entity type, so anything shared has to earn its place by being the
- * *same* fact in several handlers — a MIME list three logos agree on, the 24-hour
- * window every temporary upload gets, the org-scoped existence check six
- * handlers perform against six different tables.
+ * *same* fact in several handlers — the 24-hour window every temporary upload
+ * gets, the org-scoped existence check six handlers perform against six
+ * different tables.
+ *
+ * The declarative limits are NOT here: they live in `UPLOAD_POLICIES`
+ * (`files/types/entities.ts`), which is server-free precisely so the browser's
+ * pre-flight table can be projected from the same numbers the server enforces.
  */
 
 import type { Database } from '@auxx/database'
@@ -17,11 +21,6 @@ import { NotFoundError } from '../../../errors'
 import type { FilesCtx } from '../../ctx'
 import type { PresignedUploadSession } from '../session-types'
 
-export const MB = 1024 * 1024
-
-/** Every asset-backed entity signs for at most ten minutes. `FILE` is the exception. */
-export const ASSET_MAX_TTL_SEC = 10 * 60
-
 /**
  * How long a temporary upload survives before the cleanup sweep may remove it.
  *
@@ -30,65 +29,6 @@ export const ASSET_MAX_TTL_SEC = 10 * 60
  * `entity-processors.ts` each independently said.
  */
 export const TEMP_ASSET_TTL_MS = 24 * 60 * 60 * 1000
-
-/**
- * MIME types accepted for dataset documents.
- *
- * The empty string and `application/octet-stream` are both here on purpose:
- * a browser that cannot type a file by extension sends one or the other, and
- * dataset ingestion sniffs the content itself downstream.
- */
-export const DATASET_MIME_TYPES = [
-  'text/plain',
-  'text/markdown',
-  'text/x-markdown',
-  'application/x-markdown',
-  'text/x-web-markdown',
-  'text/csv',
-  'text/tab-separated-values',
-  'text/tsv',
-  'application/json',
-  'application/x-ndjson',
-  'application/jsonl',
-  'text/json',
-  'application/xml',
-  'text/xml',
-  'application/x-yaml',
-  'text/yaml',
-  'text/x-yaml',
-  'application/yaml',
-  'text/css',
-  'text/javascript',
-  'application/javascript',
-  'text/x-python',
-  'text/x-sql',
-  'text/x-log',
-  'text/log',
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  'application/msword',
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-  'application/vnd.ms-excel',
-  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-  'application/vnd.ms-powerpoint',
-  'application/pdf',
-  'text/html',
-  'application/xhtml+xml',
-  'application/zip',
-  'application/x-zip-compressed',
-  'message/rfc822',
-  'application/vnd.ms-outlook',
-  'application/epub+zip',
-  'application/rtf',
-  '',
-  'application/octet-stream',
-] as const
-
-/**
- * Raster images only, and never an `image/*` wildcard: that would admit
- * `image/svg+xml`, and an uploaded SVG can carry `<script>` that runs in our
- * origin when the object is opened directly.
- */
-export const LOGO_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const
 
 /** A table this file can existence-check: an id and an owning organization. */
 export type OrgScopedTable = PgTable & {

--- a/packages/lib/src/files/upload/handlers/types.ts
+++ b/packages/lib/src/files/upload/handlers/types.ts
@@ -14,7 +14,13 @@
  *
  * 1. **Declarative** — `visibility`, `maxFileSize`, `allowedMimeTypes`,
  *    `maxTtlSec`, `multipartThresholdBytes`, `assetKind`, `persist`. Read by the
- *    pure {@link buildUploadConfig}. No I/O, ever.
+ *    pure {@link buildUploadConfig}. No I/O, ever. Five of them —
+ *    `entityType`, `maxFileSize`, `allowedMimeTypes`, `maxTtlSec` and
+ *    `multipartThresholdBytes` — are **not written in the handler**: every
+ *    handler spreads its entry from `UPLOAD_POLICIES`
+ *    (`files/types/entities.ts`), which is server-free so the browser's
+ *    pre-flight table can be projected from the same numbers. Restating a limit
+ *    in the handler reintroduces the drift that table exists to prevent.
  * 2. **Prepare-time hooks** — {@link UploadHandler.normalizeInit} (pure),
  *    {@link UploadHandler.validateEntity} and
  *    {@link UploadHandler.refineConfig} (both may read). These run in

--- a/packages/lib/src/files/upload/handlers/user-profile.ts
+++ b/packages/lib/src/files/upload/handlers/user-profile.ts
@@ -6,8 +6,7 @@ import { eq } from 'drizzle-orm'
 import { isAgentUser } from '../../../cache'
 import { BadRequestError, NotFoundError } from '../../../errors'
 import { isMember } from '../../../members'
-import { ENTITY_TYPES } from '../../types/entities'
-import { ASSET_MAX_TTL_SEC, MB } from './shared'
+import { UPLOAD_POLICIES } from '../../types/entities'
 import type { UploadHandler } from './types'
 
 const logger = createScopedLogger('upload-handler-user-profile')
@@ -30,14 +29,11 @@ const logger = createScopedLogger('upload-handler-user-profile')
  * identity half: the target has to be *a* user of this organization.
  */
 export const userProfileHandler: UploadHandler = {
-  entityType: ENTITY_TYPES.USER_PROFILE,
+  ...UPLOAD_POLICIES.USER_PROFILE,
   // The avatar's owner is the entity. A client that omits `entityId` means
   // "mine", and the storage key has to say so before it is derived.
   normalizeInit: (init) => ({ ...init, entityId: init.entityId || init.userId }),
   visibility: 'PUBLIC',
-  maxFileSize: 5 * MB,
-  allowedMimeTypes: ['image/jpeg', 'image/png', 'image/webp', 'image/gif'],
-  maxTtlSec: ASSET_MAX_TTL_SEC,
   assetKind: 'USER_AVATAR',
   persist: 'versioned-asset',
 

--- a/packages/lib/src/files/upload/handlers/visit-qc-item.ts
+++ b/packages/lib/src/files/upload/handlers/visit-qc-item.ts
@@ -1,8 +1,8 @@
 // packages/lib/src/files/upload/handlers/visit-qc-item.ts
 
 import { schema } from '@auxx/database'
-import { ENTITY_TYPES } from '../../types/entities'
-import { ASSET_MAX_TTL_SEC, assertRowInOrg, MB } from './shared'
+import { UPLOAD_POLICIES } from '../../types/entities'
+import { assertRowInOrg } from './shared'
 import type { UploadHandler } from './types'
 
 /**
@@ -19,28 +19,8 @@ import type { UploadHandler } from './types'
  * what makes that unrepresentable now.
  */
 export const visitQcItemHandler: UploadHandler = {
-  entityType: ENTITY_TYPES.VISIT_QC_ITEM,
+  ...UPLOAD_POLICIES.visit_qc_item,
   visibility: 'PRIVATE',
-  maxFileSize: 25 * MB,
-  /**
-   * Images only, and no `image/*` wildcard — that would admit `image/svg+xml`,
-   * an XSS vector when uploaded files are served from our origin.
-   *
-   * HEIC/HEIF are included because the strip's input is `accept='image/*'
-   * capture='environment'` and does **not** run `convertHeicToJpeg`
-   * (`components/files/utils/convert-heic.ts`), which is in any case
-   * best-effort — it only decodes in Safari and otherwise hands back the
-   * original HEIC file. Rejecting HEIC here would drop iPhone captures.
-   */
-  allowedMimeTypes: [
-    'image/jpeg',
-    'image/png',
-    'image/webp',
-    'image/gif',
-    'image/heic',
-    'image/heif',
-  ],
-  maxTtlSec: ASSET_MAX_TTL_SEC,
   assetKind: 'INLINE_IMAGE',
   persist: 'asset+attachment',
 

--- a/packages/lib/src/files/upload/handlers/workflow-run.ts
+++ b/packages/lib/src/files/upload/handlers/workflow-run.ts
@@ -1,7 +1,7 @@
 // packages/lib/src/files/upload/handlers/workflow-run.ts
 
-import { ENTITY_TYPES } from '../../types/entities'
-import { ASSET_MAX_TTL_SEC, MB, tempExpiry } from './shared'
+import { UPLOAD_POLICIES } from '../../types/entities'
+import { tempExpiry } from './shared'
 import type { UploadHandler } from './types'
 
 /**
@@ -12,12 +12,8 @@ import type { UploadHandler } from './types'
  * a behaviour change dressed as a refactor.
  */
 export const workflowRunHandler: UploadHandler = {
-  entityType: ENTITY_TYPES.WORKFLOW_RUN,
+  ...UPLOAD_POLICIES.WORKFLOW_RUN,
   visibility: 'PRIVATE',
-  maxFileSize: 50 * MB,
-  allowedMimeTypes: ['*/*'],
-  maxTtlSec: ASSET_MAX_TTL_SEC,
-  multipartThresholdBytes: 25 * MB,
   assetKind: 'TEMP_UPLOAD',
   persist: 'asset+attachment',
 


### PR DESCRIPTION
Three open items from `plans/attachments/10-rollout-checklist.md` (items 2, 3 and 5), plus a fourth bug found while running the phase-10 browser test that no automated test can reach.

## 1. Cancelling a multipart upload leaked every part that had landed

`AbortMultipartUpload` existed **nowhere in the codebase**. `StoragePort` declared `startMultipart` and `completeMultipart` and nothing else. S3 holds — and bills for — the parts of an incomplete multipart upload until something aborts it or a lifecycle rule expires it. There is no expiry.

Found by hand, not by a test: a 184 MB cancel on `/app/examples/file-upload` left this in `auxx-dev-private`, and nothing in the system could ever have removed it.

```
Key:       abgwpa1l81reht2zmwrcihfu/file/temp/1787608775497_Ollama-darwin.zip
Initiated: 2026-08-24T21:59:36Z
```

The likely reason nobody noticed: `startMultipart` returned `expiresAt` with a `// 7 days (S3 default)` comment. There is no such default — that value is the presigned part-URL lifetime. Corrected.

**Application half**
- `abortMultipart` on `StoragePort`, the S3 adapter and the port wiring. `bucket` required, carried from the session, never re-derived
- `upload/abort.ts`, shaped like `compensate.ts` — never throws, returns `aborted` / `skipped` / `failed`. `skipped` is the single-part case, which must not touch storage at all. Deliberately no queued fallback: a job would carry an `uploadId` that stops meaning anything once S3 expires the upload
- `POST /api/files/upload/[sessionId]/abort`, behind `authorizeUploadSession` — the session nanoid is not a credential (#1818)
- `abortSession` on the `UploadTransport` seam, called from `cancelUpload`. `keepalive: true` so it survives the tab or popover closing, and gated on `serverIdKind: 'session'` so a **completed** upload is never abandoned after its rows are written

**Infrastructure half — this is the one that matters.** A browser that crashes or is closed mid-upload never runs any of the above. Both buckets now carry `abortIncompleteMultipartUploadDays: 7`.

**`DeleteTempFiles` removed rather than repaired.** It filtered on prefix `temp/`, but S3 matches prefixes from the start of the key and every key begins with the org id (`{orgId}/file/temp/...`). Verified against the live bucket: **zero objects match**. It has never done anything. Fixing the prefix would *newly* start deleting real objects on a 7-day timer — a behaviour change disguised as a bugfix, so that call is left to a reviewer.

## 2. The client's pre-flight table refused files the server accepts (checklist item 2)

| Entity | Before (client) | Now (= server) |
|---|---|---|
| `WORKFLOW_RUN` | 15 MB | 50 MB |
| `USER_PROFILE` | `image/*` (admits SVG) | 4 explicit raster types |
| `ARTICLE` | admitted video/audio | server's 8 types |
| `MESSAGE` | 5 wildcards | `*/*` |
| `FILE` | 100 MB cap | no client cap — quota answers 403 at session creation |
| `DATASET` | ~20 MIME types | server's 40 |

Now **derived, not deleted**. `UPLOAD_POLICIES` holds one server-free record per `EntityType`; the eleven handlers spread their entry, and `ENTITY_CONFIGS` projects the same values next to a hand-maintained presentation record. An 11-case test asserts the two agree, so it cannot drift again.

The extension allow-list is gone: it had no server counterpart (`enforceUploadPolicy` checks size and MIME only), so it could only ever refuse a file the server would accept.

## 3. `files/client.ts` split (checklist item 5)

`client.ts` now exports `EntityType`, `ServerIdKind`, `ENTITY_TYPES`, `ENTITY_CONFIGS`, `getEntityConfig`, `UPLOAD_POLICIES`. 15 front-end files repointed off `files/types`; the one remaining importer is a server route, which is correct. Exports regenerated via `generate:exports` — **`package.json` has zero diff**, both subpaths already existed.

## 4. The public workflow-share route leaked bytes on every failure (checklist item 3)

`compensateUploadObject` wired into the two branches that leave a guaranteed orphan. The auth, lookup and failed-HEAD branches deliberately do **not** compensate — a failed HEAD is the one case where the object's existence is unconfirmed, and deleting would destroy bytes a retry can still commit.

Two things found while fixing it, neither in any doc:
- The route wrote `StorageLocation` **on the pool, outside** the transaction that wrote the `MediaAsset`. An asset failure left a committed row pointing at bytes the route was about to delete. Now one transaction.
- A session can carry `bucket: ''` when `S3_PRIVATE_BUCKET` is unset. Guarded before anything can delete against it — that is the #1816/#1817/#1818 shape.

## 5. The examples page was broken

It sent `entityType='ARTICLE'` with no `entityId`, which 400s: ARTICLE persists `asset+attachment` and `Attachment.entityId` is `NOT NULL`. The comment claimed `entityId` was optional — stale, describing pre-refactor `BaseAssetProcessor` behaviour. Switched to `FILE`, the only handler with no entity behind it, and the only demo that can reach multipart at all (ARTICLE caps at 10 MB; the threshold is 50 MB).

## Testing

- lib files suite: **49 files, 1066 tests passing** (+11 new drift cases)
- web uploader: **10 files, 62 tests passing**
- 3 new abort tests, 8 new compensation tests, **zero `vi.mock`** in the new files
- `pnpm --filter @auxx/lib build` clean; `dist/files/client.mjs` imports in bare node with zero `database` references
- Manually verified end to end against `auxx-dev-private`: created a probe multipart upload, aborted it, confirmed the bucket returns to zero incomplete uploads

## Reviewer notes

- **Production IAM is unverified.** The runtime role needs `s3:AbortMultipartUpload`. Confirmed working in dev; the lifecycle rule protects you either way.
- **The lifecycle change is a deploy**, not a console edit — `infra/storage.ts` is SST.
- Three plan/guide statements are wrong and worth correcting separately: the pre-flight read site is `orchestration-slice.ts` `validateAndAddFiles`, not `file-slice.ts:75`; item 3's "both failure branches" is really five `catch` blocks of which three must not compensate; and item 5's "make `files/types` server-only" was unnecessary — it was never server-tainted.
- `packages/lib`'s `test` script is bare `vitest` (watch mode) and hangs in CI-style use. `pnpm exec vitest run` is the working form.
