### PR TITLE
fix(fields): inline tag creation resolves, persists, and stays option-safe

### DIFF
--- a/apps/web/src/components/custom-fields/ui/field-input-row.tsx
+++ b/apps/web/src/components/custom-fields/ui/field-input-row.tsx
@@ -168,6 +168,7 @@ export function FieldInputRow({
         placeholder={placeholder ?? `Enter ${field.label.toLowerCase()}...`}
         disabled={disabled}
         triggerProps={{ className: 'ps-0 pe-1 w-full' }}
+        resourceFieldId={field.resourceFieldId}
       />
     </FieldPanelRow>
   )

--- a/apps/web/src/components/fields/inputs/field-input-adapter.tsx
+++ b/apps/web/src/components/fields/inputs/field-input-adapter.tsx
@@ -10,8 +10,8 @@ import {
   type ActorOptions,
   getRelatedEntityDefinitionId,
   type RelationshipConfig,
-  type SelectOption,
 } from '@auxx/types/custom-field'
+import type { ResourceFieldId } from '@auxx/types/field'
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ActorPicker } from '~/components/pickers/actor-picker/actor-picker'
 import { ParticipantPicker } from '~/components/pickers/participant-picker'
@@ -33,7 +33,7 @@ import { useOrgCurrency } from '~/hooks/use-org-currency'
 import { useAccess } from '~/providers/capabilities-provider'
 import { MultiValueFieldInput } from './multi-value-input-field'
 import { NameFieldInput, type NameValue } from './name-field-input'
-import { getSelectConfig, SelectFieldInput } from './select-input-field'
+import { getSelectConfig, SelectFieldInput, StoreSelectFieldInput } from './select-input-field'
 
 /**
  * Wrapper for inline inputs that focuses the input when `open` becomes true.
@@ -88,8 +88,15 @@ export interface FieldInputAdapterProps {
   placeholder?: string
   /** Disabled state */
   disabled?: boolean
-  /** Callback when options change (for TAGS management) */
-  onOptionsChange?: (options: SelectOption[]) => void
+  /**
+   * Identity of the store-backed field being edited. On select types this is
+   * what enables inline option creation/management: the select branch renders
+   * the store-connected variant, which persists option edits itself the way
+   * the RELATIONSHIP branch below owns its inline record-create — no callback
+   * threaded from the form. Omitted (a workflow synthetic, a filter operand),
+   * the select renders read-only options from `fieldOptions`.
+   */
+  resourceFieldId?: ResourceFieldId
   /** Override multi-select behavior (for operators like "in"/"not in") */
   allowMultiple?: boolean
   /**
@@ -142,7 +149,7 @@ export function FieldInputAdapter({
   onChange,
   placeholder = 'Enter value...',
   disabled = false,
-  onOptionsChange,
+  resourceFieldId,
   allowMultiple,
   canAdd,
   useValueAsLabel,
@@ -351,21 +358,27 @@ export function FieldInputAdapter({
 
       const selectedValues = Array.isArray(value) ? value : value ? [value] : []
 
-      return (
-        <SelectFieldInput
-          options={options}
-          value={selectedValues}
-          onChange={onChange}
-          onOptionsChange={onOptionsChange}
-          config={config}
-          placeholder={placeholder}
-          disabled={disabled}
-          triggerProps={triggerProps}
-          open={open}
-          onOpenChange={onOpenChange}
-          shouldPreventDismiss={shouldPreventDismiss}
-          useValueAsLabel={useValueAsLabel}
-        />
+      const selectProps = {
+        options,
+        value: selectedValues,
+        onChange,
+        config,
+        placeholder,
+        disabled,
+        triggerProps,
+        open,
+        onOpenChange,
+        shouldPreventDismiss,
+        useValueAsLabel,
+      }
+
+      // With a field identity, the store-connected variant owns option
+      // freshness and persistence itself (see `StoreSelectFieldInput`); without
+      // one there is nothing to persist to, so options are read-only.
+      return resourceFieldId ? (
+        <StoreSelectFieldInput {...selectProps} resourceFieldId={resourceFieldId} />
+      ) : (
+        <SelectFieldInput {...selectProps} />
       )
     }
 

--- a/apps/web/src/components/fields/inputs/select-input-field.tsx
+++ b/apps/web/src/components/fields/inputs/select-input-field.tsx
@@ -4,12 +4,13 @@
 import { FieldType } from '@auxx/database/enums'
 import { parseRecordId } from '@auxx/lib/resources/client'
 import type { SelectOption } from '@auxx/types/custom-field'
-import { toResourceFieldId } from '@auxx/types/field'
+import { parseResourceFieldId, type ResourceFieldId, toResourceFieldId } from '@auxx/types/field'
 import { Popover, PopoverContent, PopoverTrigger } from '@auxx/ui/components/popover'
 import { cn } from '@auxx/ui/lib/utils'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useCustomFieldMutations } from '~/components/custom-fields/hooks/use-custom-field-mutations'
 import { MultiSelectPicker } from '~/components/pickers/multi-select-picker'
+import { useField } from '~/components/resources/hooks/use-field'
 import { PickerTrigger, type PickerTriggerOptions } from '~/components/ui/picker-trigger'
 import { TagsView } from '~/components/ui/tags-view'
 import { useFieldNavigationOptional } from '../field-navigation-context'
@@ -56,7 +57,7 @@ export function getSelectConfig(fieldType: string): SelectConfig {
         multi: true,
         canManage: true,
         canAdd: true,
-        placeholder: 'Search tags...',
+        placeholder: 'Search or create...',
         manageLabel: 'Manage tags',
         closeOnSelect: false,
       }
@@ -377,5 +378,61 @@ export function SelectFieldInput({
         />
       </PopoverContent>
     </Popover>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────
+// StoreSelectFieldInput - store-connected variant (used by FieldInputAdapter)
+// ─────────────────────────────────────────────────────────────────
+
+/** Props for {@link StoreSelectFieldInput} */
+interface StoreSelectFieldInputProps extends Omit<SelectFieldInputProps, 'onOptionsChange'> {
+  /** Identity of the store-backed field whose taxonomy this input may grow. */
+  resourceFieldId: ResourceFieldId
+}
+
+/**
+ * `SelectFieldInput` wired to the resource store: it sources the option list
+ * from the effective `fieldMap` and persists option edits (a typed tag, a
+ * manage-dialog change) itself.
+ *
+ * Mirrors the RELATIONSHIP branch's inline-create pattern in
+ * `FieldInputAdapter`: the input owns its inline definition-write and hands the
+ * result back through selection, so no form above needs to know that option
+ * creation exists — and no caller can reintroduce the forgot-to-wire hole that
+ * originally shipped a create button writing nowhere.
+ *
+ * The gate mirrors that pattern too: creation/management is offered iff the
+ * field RESOLVES IN THE STORE. The persisted payload is the full option list,
+ * so its base must be the maintained merge — never whatever copy a caller
+ * happened to pass. A field the store doesn't know (a placeholder shim, a
+ * workflow synthetic) falls back to the passed `options` read-only, losing the
+ * affordance instead of arming a write that would replace the real list with a
+ * fragment and cascade-delete the values of every option it dropped.
+ */
+export function StoreSelectFieldInput({
+  resourceFieldId,
+  options,
+  ...rest
+}: StoreSelectFieldInputProps) {
+  const storeField = useField(resourceFieldId)
+  const { entityDefinitionId } = parseResourceFieldId(resourceFieldId)
+  const { update: updateField } = useCustomFieldMutations({ entityDefinitionId })
+
+  const handleOptionsChange = useCallback(
+    (newOptions: SelectOption[]) => {
+      updateField.mutate({ resourceFieldId, options: newOptions })
+    },
+    [updateField, resourceFieldId]
+  )
+
+  const effectiveOptions = (storeField?.options?.options as SelectOption[] | undefined) ?? options
+
+  return (
+    <SelectFieldInput
+      {...rest}
+      options={effectiveOptions}
+      onOptionsChange={storeField ? handleOptionsChange : undefined}
+    />
   )
 }

--- a/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
@@ -60,8 +60,12 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
   const vendorPartDefId = useResourceProperty('vendor_part', 'id')
   const companyDefId = useResourceProperty('company', 'id')
 
-  // Live field def for the Category TAGS input (sources existing option pool)
-  const categoryField = useSystemField('category')
+  // Live field def for the Category TAGS input (sources existing option pool).
+  // Def-scoped on purpose: bare `category` is owned by BOTH `part` and
+  // `product`, and the bare tie-break resolves to whichever def id sorts first
+  // — which is how this dialog once showed (and would have written!) the
+  // products taxonomy's option ids into part records.
+  const categoryField = useSystemField('category', partDefId)
 
   // Load initial values for edit mode
   const { values: systemValues } = useSystemValues(recordId, PART_SYSTEM_ATTRIBUTES, {
@@ -284,6 +288,7 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
             <FieldInputAdapter
               fieldType={FieldType.TAGS}
               fieldOptions={categoryField?.options}
+              resourceFieldId={categoryField?.resourceFieldId}
               triggerProps={{ className: 'ps-0 pe-1 w-full' }}
               value={values.category}
               onChange={(val) => handleChange('category', val)}

--- a/apps/web/src/components/pickers/multi-select-picker.tsx
+++ b/apps/web/src/components/pickers/multi-select-picker.tsx
@@ -189,6 +189,24 @@ export function MultiSelectPicker({
     return () => onCaptureChange?.(false)
   }, [onCaptureChange])
 
+  /**
+   * A created option is only offered when it can still be RESOLVED afterwards,
+   * which is true in exactly two modes:
+   *
+   * - `useValueAsLabel` — the option is label-keyed, so `value === label` and the
+   *   trigger renders it with no lookup and no persistence (the connector source
+   *   panel's custom values work this way).
+   * - `onOptionsChange` — someone upstream persists it and feeds it back through
+   *   `options`.
+   *
+   * With NEITHER, `createOption` mints `value: generateId()` into local state that
+   * nothing saves and nothing can label: the trigger falls back to rendering the
+   * raw cuid, and reopening the popover resets `localOptions` from `options` and
+   * loses it. That combination shipped on the record-create dialog and read as
+   * "creating a tag is broken" — it was a create button wired to nothing.
+   */
+  const canCreateOption = canAdd && (useValueAsLabel || Boolean(onOptionsChange))
+
   // Local options state (for optimistic UI when editing)
   const [localOptions, setLocalOptions] = useState<SelectOption[]>(options)
 
@@ -325,7 +343,7 @@ export function MultiSelectPicker({
    * Create a new option with the current search value
    */
   const createOption = useCallback(() => {
-    if (!canAdd) return
+    if (!canCreateOption) return
     const newLabel = searchValue.trim()
     if (!newLabel) return
 
@@ -356,7 +374,7 @@ export function MultiSelectPicker({
 
     setSearchValue('')
   }, [
-    canAdd,
+    canCreateOption,
     searchValue,
     localOptions,
     localSelected,
@@ -687,7 +705,7 @@ export function MultiSelectPicker({
           ) : (
             <>
               {/* Create option */}
-              {canAdd && searchValue.trim() && !searchMatchesExisting && (
+              {canCreateOption && searchValue.trim() && !searchMatchesExisting && (
                 <>
                   <CommandGroup>
                     <CommandItem

--- a/apps/web/src/components/resources/hooks/use-resource-fields.ts
+++ b/apps/web/src/components/resources/hooks/use-resource-fields.ts
@@ -1,6 +1,6 @@
 // apps/web/src/components/resources/hooks/use-resource-fields.ts
 
-import type { ResourceField } from '@auxx/lib/resources/client'
+import type { Resource, ResourceField } from '@auxx/lib/resources/client'
 import {
   type FieldId,
   parseResourceFieldId,
@@ -12,6 +12,59 @@ import { useResourceStore } from '../store/resource-store'
 
 /** Stable empty array to prevent unnecessary re-renders */
 const EMPTY_FIELDS: ResourceField[] = []
+
+/**
+ * Compose the EFFECTIVE field list for a resource.
+ *
+ * The hydration snapshot (`resource.fields`) decides which fields exist and in
+ * what order; `fieldMap` — the maintained merge of server + pending optimistic
+ * state — supplies each field's current content; the optimistic new/deleted
+ * sets add and remove fields that haven't round-tripped yet.
+ *
+ * This is the single composition point shared by {@link useResourceFields} and
+ * `useResource`. `resourceMap` itself is a hydration snapshot that no field
+ * action ever updates, so any read that must see post-mutation field state
+ * (labels, select options, required, …) has to go through this — reading
+ * `resource.fields` raw is how inline tag creation once sent a stale
+ * full-replace that cascade-deleted other tags' values.
+ */
+export function composeEffectiveFields(
+  resource: Resource,
+  fieldMap: Record<ResourceFieldId, ResourceField>,
+  optimisticDeletedFields: ReadonlySet<ResourceFieldId>,
+  optimisticNewFields: Record<ResourceFieldId, ResourceField>
+): ResourceField[] {
+  const effectiveFields: ResourceField[] = []
+
+  for (const field of resource.fields) {
+    // Mirror setResources' keying exactly: snapshot fields are not guaranteed
+    // to carry `resourceFieldId`, and the fallback key uses `resource.id`.
+    const key = field.resourceFieldId || toResourceFieldId(resource.id, field.id)
+    if (optimisticDeletedFields.has(key)) continue
+
+    const effectiveField = fieldMap[key]
+    if (effectiveField) {
+      effectiveFields.push(effectiveField)
+    }
+  }
+
+  // Add optimistic new fields for this resource. Match on both resource.id and
+  // resource.entityDefinitionId (they should be equal, but handle edge cases).
+  const resourceId = resource.id
+  const resourceEntityDefId = resource.entityDefinitionId
+  for (const [key, field] of Object.entries(optimisticNewFields) as Array<
+    [ResourceFieldId, ResourceField]
+  >) {
+    const { entityDefinitionId: fieldEntityDefId } = parseResourceFieldId(key)
+    const matchesResource =
+      fieldEntityDefId === resourceId || fieldEntityDefId === resourceEntityDefId
+    if (matchesResource && !optimisticDeletedFields.has(key)) {
+      effectiveFields.push(field)
+    }
+  }
+
+  return effectiveFields
+}
 
 interface UseResourceFieldsResult {
   /** All fields for this resource */
@@ -52,36 +105,7 @@ export function useResourceFields(
   // Compute effective fields with useMemo for stable reference
   const fields = useMemo(() => {
     if (!resource || !entityDefinitionIdOrApiSlug) return EMPTY_FIELDS
-
-    const effectiveFields: ResourceField[] = []
-
-    // Add fields from resource with optimistic overlay from fieldMap
-    for (const field of resource.fields) {
-      const key = field.resourceFieldId || toResourceFieldId(resource.id, field.id)
-      if (optimisticDeletedFields.has(key)) continue
-
-      const effectiveField = fieldMap[key]
-      if (effectiveField) {
-        effectiveFields.push(effectiveField)
-      }
-    }
-
-    // Add optimistic new fields for this resource
-    // Use both resource.id and resource.entityDefinitionId for matching (they should be equal but handle edge cases)
-    const resourceId = resource.id
-    const resourceEntityDefId = resource.entityDefinitionId
-    for (const [key, field] of Object.entries(optimisticNewFields) as Array<
-      [ResourceFieldId, ResourceField]
-    >) {
-      const { entityDefinitionId: fieldEntityDefId } = parseResourceFieldId(key)
-      const matchesResource =
-        fieldEntityDefId === resourceId || fieldEntityDefId === resourceEntityDefId
-      if (matchesResource && !optimisticDeletedFields.has(key)) {
-        effectiveFields.push(field)
-      }
-    }
-
-    return effectiveFields
+    return composeEffectiveFields(resource, fieldMap, optimisticDeletedFields, optimisticNewFields)
   }, [
     resource,
     fieldMap,

--- a/apps/web/src/components/resources/hooks/use-resource.test.ts
+++ b/apps/web/src/components/resources/hooks/use-resource.test.ts
@@ -1,0 +1,225 @@
+// apps/web/src/components/resources/hooks/use-resource.test.ts
+// `useResource` must return EFFECTIVE fields, not the hydration snapshot.
+// `resourceMap` is written once by `setResources` and never touched by field
+// actions, so a raw `resource.fields` read shows pre-mutation state — the bug
+// behind inline tag creation on the record-create dialog, where a full
+// option-list replace built on the stale snapshot cascade-deleted other tags'
+// values (plans/custom-fields/inline-option-creation-broken-v2.md).
+
+import type { CustomResource, ResourceField } from '@auxx/lib/resources/client'
+import { toResourceFieldId } from '@auxx/types/field'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { getResourceStoreState } from '../store/resource-store'
+import { useResource } from './use-resource'
+import { useResourceFields } from './use-resource-fields'
+
+const tagsFieldKey = toResourceFieldId('def_orders', 'cf_tags')
+
+const tagsField = {
+  id: 'cf_tags',
+  key: 'tags',
+  label: 'Tags',
+  type: 'multiselect',
+  fieldType: 'TAGS',
+  capabilities: {
+    filterable: true,
+    sortable: true,
+    creatable: true,
+    updatable: true,
+    configurable: true,
+  },
+  resourceFieldId: tagsFieldKey,
+  options: {
+    options: [
+      { value: 'opt_example', label: 'example' },
+      { value: 'opt_qwe', label: 'qwe' },
+    ],
+  },
+} as unknown as ResourceField
+
+const ordersResource = {
+  id: 'def_orders',
+  type: 'custom',
+  apiSlug: 'orders',
+  entityType: 'order',
+  entityDefinitionId: 'def_orders',
+  organizationId: 'org_1',
+  label: 'Order',
+  plural: 'Orders',
+  icon: 'box',
+  color: 'blue',
+  isVisible: true,
+  fields: [tagsField],
+  display: {
+    primaryDisplayField: null,
+    secondaryDisplayField: null,
+    avatarField: null,
+    defaultSortField: 'updatedAt',
+    defaultSortDirection: 'desc',
+    orgScopingStrategy: 'direct',
+  },
+} as unknown as CustomResource
+
+const fieldOptions = (resource: { fields: ResourceField[] } | undefined) =>
+  (resource?.fields.find((f) => f.id === 'cf_tags')?.options?.options ?? []) as Array<{
+    value: string
+    label: string
+  }>
+
+beforeEach(() => {
+  getResourceStoreState().reset()
+  getResourceStoreState().setResources([ordersResource])
+})
+
+describe('useResource effective fields', () => {
+  it('returns the field content from the snapshot after hydration', () => {
+    const { result } = renderHook(() => useResource('def_orders'))
+    expect(fieldOptions(result.current.resource).map((o) => o.label)).toEqual(['example', 'qwe'])
+  })
+
+  it('resolves by apiSlug alias with the same effective fields', () => {
+    const { result } = renderHook(() => useResource('orders'))
+    expect(fieldOptions(result.current.resource).map((o) => o.label)).toEqual(['example', 'qwe'])
+  })
+
+  it('reflects an optimistic option-list update before the server confirms', () => {
+    const { result } = renderHook(() => useResource('def_orders'))
+
+    act(() => {
+      getResourceStoreState().setFieldOptimistic(tagsFieldKey, {
+        options: {
+          options: [
+            ...fieldOptions(result.current.resource),
+            { value: 'opt_new', label: 'urgent' },
+          ],
+        },
+      } as Partial<ResourceField>)
+    })
+
+    expect(fieldOptions(result.current.resource).map((o) => o.label)).toEqual([
+      'example',
+      'qwe',
+      'urgent',
+    ])
+  })
+
+  it('reverts to the snapshot content on rollback', () => {
+    const { result } = renderHook(() => useResource('def_orders'))
+
+    act(() => {
+      getResourceStoreState().setFieldOptimistic(tagsFieldKey, {
+        options: { options: [{ value: 'opt_new', label: 'urgent' }] },
+      } as Partial<ResourceField>)
+    })
+    expect(fieldOptions(result.current.resource).map((o) => o.label)).toEqual(['urgent'])
+
+    act(() => {
+      getResourceStoreState().rollbackFieldUpdate(tagsFieldKey)
+    })
+    expect(fieldOptions(result.current.resource).map((o) => o.label)).toEqual(['example', 'qwe'])
+  })
+
+  it('hides an optimistically deleted field and restores it on rollback', () => {
+    const { result } = renderHook(() => useResource('def_orders'))
+
+    act(() => {
+      getResourceStoreState().markFieldDeleted(tagsFieldKey)
+    })
+    expect(result.current.resource?.fields.find((f) => f.id === 'cf_tags')).toBeUndefined()
+
+    act(() => {
+      getResourceStoreState().rollbackFieldDelete(tagsFieldKey)
+    })
+    expect(result.current.resource?.fields.find((f) => f.id === 'cf_tags')).toBeDefined()
+  })
+
+  it('includes an optimistically created field before the server confirms', () => {
+    const { result } = renderHook(() => useResource('def_orders'))
+
+    const tempKey = toResourceFieldId('def_orders', 'temp_1')
+    act(() => {
+      getResourceStoreState().addOptimisticField(tempKey, {
+        ...tagsField,
+        id: 'temp_1',
+        resourceFieldId: tempKey,
+        label: 'Priority',
+      } as ResourceField)
+    })
+
+    expect(result.current.resource?.fields.map((f) => f.label)).toEqual(['Tags', 'Priority'])
+  })
+
+  it('keeps a stable resource reference across unrelated re-renders', () => {
+    const { result, rerender } = renderHook(() => useResource('def_orders'))
+    const first = result.current.resource
+    rerender()
+    expect(result.current.resource).toBe(first)
+  })
+
+  // The churn guard: an unrelated store write (loading flips on every fetch)
+  // must NOT mint a new resource object, or every useResource consumer
+  // re-renders on every fetch cycle. A field mutation is exactly when a new
+  // identity is wanted.
+  it('changes resource identity on field mutations and ONLY on field mutations', () => {
+    const { result } = renderHook(() => useResource('def_orders'))
+    const initial = result.current.resource
+
+    act(() => {
+      getResourceStoreState().setLoading(true)
+    })
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.resource).toBe(initial)
+
+    act(() => {
+      getResourceStoreState().setFieldOptimistic(tagsFieldKey, {
+        options: { options: [{ value: 'opt_new', label: 'fresh' }] },
+      } as Partial<ResourceField>)
+    })
+    expect(result.current.resource).not.toBe(initial)
+  })
+
+  // The invariant that kills the original bug class: the two field read paths
+  // (`useResource(...).resource.fields` and `useResourceFields(...).fields`)
+  // must never disagree again, through every optimistic phase. If this fails,
+  // a surface reading one path shows different fields than a surface reading
+  // the other — which is exactly how a stale full-list write once
+  // cascade-deleted live tag values.
+  it('always agrees with useResourceFields, through every optimistic phase', () => {
+    const { result } = renderHook(() => ({
+      viaResource: useResource('def_orders').resource?.fields,
+      viaFields: useResourceFields('def_orders').fields,
+    }))
+    const expectParity = () => expect(result.current.viaResource).toEqual(result.current.viaFields)
+
+    expectParity() // after hydration
+
+    act(() => {
+      getResourceStoreState().setFieldOptimistic(tagsFieldKey, {
+        options: { options: [{ value: 'opt_new', label: 'urgent' }] },
+      } as Partial<ResourceField>)
+    })
+    expectParity() // pending optimistic update
+
+    act(() => {
+      getResourceStoreState().addOptimisticField(toResourceFieldId('def_orders', 'temp_1'), {
+        ...tagsField,
+        id: 'temp_1',
+        resourceFieldId: toResourceFieldId('def_orders', 'temp_1'),
+        label: 'Priority',
+      } as ResourceField)
+    })
+    expectParity() // optimistic new field
+
+    act(() => {
+      getResourceStoreState().markFieldDeleted(tagsFieldKey)
+    })
+    expectParity() // optimistic delete
+
+    act(() => {
+      getResourceStoreState().rollbackFieldDelete(tagsFieldKey)
+      getResourceStoreState().rollbackFieldUpdate(tagsFieldKey)
+    })
+    expectParity() // rolled back
+  })
+})

--- a/apps/web/src/components/resources/hooks/use-resource.ts
+++ b/apps/web/src/components/resources/hooks/use-resource.ts
@@ -1,7 +1,9 @@
 // apps/web/src/components/resources/hooks/use-resource.ts
 
 import type { Resource } from '@auxx/lib/resources/client'
+import { useMemo } from 'react'
 import { useResourceStore } from '../store/resource-store'
+import { composeEffectiveFields } from './use-resource-fields'
 
 interface UseResourceResult {
   /** The resource (or undefined if not found) */
@@ -13,12 +15,38 @@ interface UseResourceResult {
 /**
  * Hook for getting a single resource by ID
  * @param resourceId - Can be entityDefinitionId, apiSlug, or systemType (e.g. "contacts")
+ *
+ * The returned resource's `fields` are EFFECTIVE fields (server + optimistic
+ * overlay via `composeEffectiveFields`), not the raw hydration snapshot. The
+ * snapshot in `resourceMap` is written once per `resource.list` fetch and never
+ * touched by field mutations, so any surface rendering `resource.fields` raw
+ * shows pre-mutation state — and a surface that writes a full option list back
+ * from that stale read deletes what it couldn't see. Everything else on the
+ * resource (display config, ordering, flags) still comes from the snapshot.
  */
 export function useResource(resourceId: string | null | undefined): UseResourceResult {
-  // Subscribe directly to the resource data from the map - triggers re-render when resource changes
-  const resource = useResourceStore((s) => (resourceId ? s.resourceMap.get(resourceId) : undefined))
+  // Subscribe to stable store slices and compose in useMemo — a selector that
+  // builds a fresh object every call fails zustand's Object.is check and
+  // re-renders on every store write.
+  const snapshot = useResourceStore((s) => (resourceId ? s.resourceMap.get(resourceId) : undefined))
+  const fieldMap = useResourceStore((s) => s.fieldMap)
+  const optimisticDeletedFields = useResourceStore((s) => s.optimisticDeletedFields)
+  const optimisticNewFields = useResourceStore((s) => s.optimisticNewFields)
   const isQueryLoading = useResourceStore((s) => s.isLoading)
   const hasLoadedOnce = useResourceStore((s) => s.hasLoadedOnce)
+
+  const resource = useMemo(() => {
+    if (!snapshot) return undefined
+    return {
+      ...snapshot,
+      fields: composeEffectiveFields(
+        snapshot,
+        fieldMap,
+        optimisticDeletedFields,
+        optimisticNewFields
+      ),
+    }
+  }, [snapshot, fieldMap, optimisticDeletedFields, optimisticNewFields])
 
   // If we haven't loaded resources yet, we're loading
   // Or if the query is currently loading, we're loading

--- a/docs/files-upload-architecture-guide.md
+++ b/docs/files-upload-architecture-guide.md
@@ -206,14 +206,35 @@ organization". `packages/lib` performs zero access checks (`docs/lib-module-guid
 org-admin gate for uploading an avatar onto someone else's user. `WORKFLOW_RUN` and `CUSTOM_FIELD`
 declare **no** `validateEntity` at all (§12).
 
-### 3.2 The client has a second, disagreeing copy of this table
+### 3.2 The client's copy is projected from the same source (#1866)
 
-`ENTITY_CONFIGS` in the same file (`files/types/entities.ts:225`) is a browser-side pre-flight
-table, read by `file-slice.ts:75` and `orchestration-slice.ts:423` to reject files before upload.
-It duplicates `maxFileSize` and `allowedMimeTypes` and **has drifted from the handlers**:
-`WORKFLOW_RUN` is 15 MB client-side vs 50 MB server-side; `USER_PROFILE` allows `image/*`
-client-side (which admits SVG) vs four explicit types server-side; `ARTICLE` allows `video/*` and
-`audio/*` client-side, which the handler refuses. §12.
+`UPLOAD_POLICIES` in `files/types/entities.ts` is the one server-free record of the five
+declarative fields — `entityType`, `maxFileSize`, `allowedMimeTypes`, `maxTtlSec`,
+`multipartThresholdBytes` — one entry per `EntityType`. The eleven handlers **spread** their entry
+(`...UPLOAD_POLICIES.ARTICLE`) rather than restating limits, and `ENTITY_CONFIGS` — the
+browser-side pre-flight table — projects the same values alongside a hand-maintained
+`ENTITY_PRESENTATION` record (labels, progress stages, per-surface UI switches, none of which has a
+server counterpart).
+
+The pre-flight table is read by **`orchestration-slice.ts`'s `validateAndAddFiles`**
+(`getEntityConfig` ~line 501, `validateFile` ~574) to reject files before upload. It is *not* read
+by `file-slice.ts:75` — that line reads progress-bar stage labels only, which earlier revisions of
+this guide and of `plans/attachments/10-rollout-checklist.md` both got wrong.
+
+Until #1866 the two tables were maintained separately and had drifted: `WORKFLOW_RUN` 15 MB
+client-side vs 50 MB server; `USER_PROFILE` `image/*` (which admits SVG) vs four explicit types;
+`ARTICLE` admitting `video/*` and `audio/*` the handler refuses. Users were refused files the
+server would have accepted. An 11-case test in `handlers/__tests__/handlers.test.ts` now asserts
+`ENTITY_CONFIGS[t].validation` equals each handler's `maxFileSize`/`allowedMimeTypes`, so the two
+cannot silently diverge again.
+
+`ValidationConfig` no longer carries an extension allow-list. It had **no server counterpart** —
+`enforceUploadPolicy` checks size and MIME only — so it could only ever refuse a file the server
+would accept. `validateFile` in `apps/web/.../utils/upload-helpers.ts` is now a two-rule mirror of
+`enforceUploadPolicy` with the same wildcard semantics.
+
+Front-end code imports these from **`@auxx/lib/files/client`**, not `files/types` (#1866). See §12
+for what still is not enforced about that boundary.
 
 ---
 
@@ -293,6 +314,20 @@ Known gap, flagged in the code: the part presign takes no `ttlSec`, so part URLs
 `authorizeUploadSession` → Zod-parse → `completeUpload` → on `err`, `failUploadSession` then
 `uploadErrorResponse`. A malformed body is an **early return**, not a throw: nothing was attempted,
 so it must not mark the session failed and force the client to re-upload the bytes.
+
+### 4.4b `POST /api/files/upload/{sessionId}/abort` (#1866)
+
+The fourth route, and the shortest. Authenticated through the same
+`authorizeUploadSession` door as `parts` and `complete` — the session nanoid is not a credential
+(§11.4), so holding one must not let a caller destroy someone else's in-flight upload.
+
+It calls `abortMultipartUpload`, then deletes the Redis session: the session's presigned URLs are
+useless once the upload is abandoned, and leaving it alive lets a retry resume against an `uploadId`
+S3 has already released.
+
+It answers **200 on any authorized call, including when the abort itself failed.** The client
+cancelled; surfacing a storage error it cannot act on would turn a successful cancel into a visible
+failure. The `outcome` field carries what actually happened, for logs and tests.
 
 ### 4.5 `completeUpload` — `packages/lib/src/files/upload/complete.ts:132`
 
@@ -549,6 +584,19 @@ awaiting. That was one of three swallowed failures the extraction surfaced:
 3. **`abort()` did nothing between multipart parts** — the flag was set inside `currentAbort`, so an
    abort arriving while a part was being presigned (no XHR live) was silently dropped and the
    remaining parts uploaded anyway. `direct-upload.ts:172`.
+
+A fourth method landed in #1866: **`abortSession(sessionId)`**, because stopping the browser from
+sending is only half of a cancel. Aborting an `XMLHttpRequest` cannot touch the multipart upload S3
+has already opened, and S3 holds and bills for every part already delivered — indefinitely, absent
+an abort or a lifecycle rule. `cancelUpload` now calls it for each in-flight file, `keepalive: true`
+so the request survives the tab or popover closing, and gated on `serverIdKind === 'session'` so a
+**completed** upload is never abandoned after its rows are written (`serverFileId` is overwritten
+with a real record id on completion — §11.3). It is best-effort by contract: a rejected promise must
+never fail the cancel that called it, so the store fires it un-awaited with a swallowing `catch`.
+
+The contract's return is deliberately not a bare boolean — `abortMultipartUpload` reports
+`'aborted' | 'skipped' | 'failed'`, where `'skipped'` is the single-part case. An abandoned PUT
+never becomes an object, so a single-part cancel must not call storage at all.
 
 ### 7.2 The transfer itself
 
@@ -858,6 +906,35 @@ export its whole `index.ts` from `server.ts` in the same PR.**
 **Phase 8 — the uploader, 2026-08-24 (#1858).** `UploadTransport` extracted; three swallowed
 failures fixed (§7.1).
 
+**Cancelling a multipart upload leaked every part that had landed — 2026-08-24 (#1866).** Found by
+hand, not by a test: `AbortMultipartUpload` existed **nowhere in the codebase**. `StoragePort`
+declared `startMultipart` and `completeMultipart` and nothing else, so a cancel aborted the
+browser's request and left S3 holding — and billing for — every part already delivered, forever. A
+184 MB cancel during the phase-10 browser test left exactly that in `auxx-dev-private`, and nothing
+in the system could ever have removed it.
+
+Why it survived 33 PRs is worth recording: `startMultipart` returned `expiresAt` under the comment
+`// 7 days (S3 default)`. **There is no such default.** That value is the presigned part-URL
+lifetime; the upload itself has no expiry. One wrong comment made a missing feature look like a
+handled one. It now says what the value is.
+
+Fixed on both halves — `abortMultipart` through the port and adapter, `POST
+/api/files/upload/{sessionId}/abort` behind `authorizeUploadSession`, `abortSession` on the
+transport called from `cancelUpload` (§7.1), **and** `abortIncompleteMultipartUploadDays: 7` on both
+buckets, which is the half that survives a browser that never runs any JS. See §12 for what remains
+unverified.
+
+Two lessons about reading S3 state came out of the same investigation, both instances of rules this
+guide already states in other forms:
+
+- **Check which bucket before believing a clean read.** A `list-multipart-uploads` against
+  `auxxai-files` came back empty and proved nothing — `FILE` is `visibility: 'PRIVATE'`, so its
+  objects live in `auxx-dev-private`. §5.1's never-invent-a-bucket rule applies to reads too.
+- **The shell's AWS identity is not the app's.** A plain shell here resolves a different IAM user,
+  in a different account, from `.env`'s `AWS_PROFILE=auxxai-dev`. An `AccessDenied` may be your
+  credentials rather than a missing permission — and a success may be AdministratorAccess rather
+  than the runtime role.
+
 ---
 
 ## 12. What is still open
@@ -894,10 +971,38 @@ sweep that has not happened yet.
 - **`WORKFLOW_RUN` and `CUSTOM_FIELD` declare no `validateEntity`.** Combined with `*/*` and 50 MB,
   a workflow-run upload can be aimed at any `entityId`. The old `WorkflowRunProcessor` had the same
   hole (an entirely commented-out body); the conversion preserved it rather than inventing a rule.
-- **The client's `ENTITY_CONFIGS` pre-flight table disagrees with the handlers** (§3.2).
+- ~~**The client's `ENTITY_CONFIGS` pre-flight table disagrees with the handlers**~~ — **CLOSED
+  (#1866).** Both tables now project `UPLOAD_POLICIES`, and an 11-case test asserts they agree (§3.2).
 - **`UploadPolicy.allowedExtensions` is recorded and never enforced.** `enforceUploadPolicy` has no
   extension rule, so the narrowing `CUSTOM_FIELD`'s `refineConfig` writes has never been read.
   Typed rather than deleted so the intent stays visible; enforcing it is a decision.
+
+**Multipart, after #1866**
+
+- **Production IAM is unverified.** The runtime role needs `s3:AbortMultipartUpload`. It was proved
+  end-to-end against `auxx-dev-private` (create a probe multipart upload → abort → bucket returns to
+  zero incomplete uploads), but dev resolves credentials through `AWS_PROFILE=auxxai-dev`, which is
+  **SSO AdministratorAccess in a different AWS account** from the IAM user a plain shell here picks
+  up. That proves nothing about production. If the permission is missing, `abortMultipartUpload`
+  returns `'failed'` — silently and by design, because a failed abort must never fail the user's
+  cancel — and every cancelled multipart leaks until the 7-day lifecycle rule reclaims it. Cost, not
+  data loss, but check it.
+- **The lifecycle rule is the half that actually survives.** `abortIncompleteMultipartUploadDays: 7`
+  on both buckets is not belt-and-braces: a browser that is closed, crashes, or loses the network
+  mid-upload never runs `cancelUpload`, so no application code can be relied on to abort. The
+  `POST .../abort` route reclaims bytes in seconds for the common case; the rule catches everything
+  else.
+- **`DeleteTempFiles` was deleted, not repaired, and that is still an open decision.** It filtered on
+  prefix `temp/` while every key begins with the org id (`{orgId}/file/temp/...`), and S3 matches
+  lifecycle prefixes from the **start** of the key — verified against `auxx-dev-private`, zero
+  objects matched. The rule had never done anything. Repairing the prefix would *newly* begin
+  deleting real objects on a 7-day timer, which is a behaviour change, so #1866 removed it and left
+  the decision open.
+- **`sessions/route.ts` can persist `bucket: ''`.** It writes
+  `bucket: configService.get('S3_PRIVATE_BUCKET') || ''`, so an unset config puts an empty-string
+  bucket in the Redis session. #1866 guarded the **read** side in the workflow-share route (it 500s
+  rather than let an empty bucket reach a HEAD or a compensating DELETE), but the write side is
+  unchanged. Same class as the `user-avatar-service.ts` item above, and as §5.1.
 
 **Jobs that do not do what they look like they do**
 
@@ -941,20 +1046,29 @@ sweep that has not happened yet.
   inside the journal the "nothing but database statements between `BEGIN` and `COMMIT`" assertion
   reads. They were previously invisible to it — the assertion held, but not over the two calls that
   had actually broken the rule in production.
-- **The public workflow-share completion route does no compensation at all.**
-  `apps/web/src/app/api/workflows/shared/[shareToken]/files/[sessionId]/complete/route.ts` writes a
-  `StorageLocation`, then a `MediaAsset` in its own transaction, and each failure branch returns a
-  500 having neither deleted the object nor enqueued a cleanup — so every failure there leaks the
-  uploaded bytes. `upload/compensate.ts` is now a standalone
-  `compensateUploadObject(deps, ref)` precisely so the fix is a `catch` that calls it rather than a
-  second copy of the policy. Needs `compensateUploadObject` exported from `files/server.ts`.
+- ~~**The public workflow-share completion route does no compensation at all.**~~ — **CLOSED
+  (#1866).** `compensateUploadObject` is wired into the two branches that leave a guaranteed orphan.
+  Three of the route's five relevant `catch` blocks deliberately do **not** compensate: auth and
+  lookup failures happen before any object is addressed, and a failed `headByKey` is the one case
+  where the object's existence is unconfirmed — deleting there would destroy bytes a retry can still
+  commit, and the Redis session is left intact for exactly that. `completeUpload` makes the same
+  choice on its own failed HEAD. Earlier revisions of this section and of the rollout checklist both
+  said "each failure branch", which would have produced the wrong fix if followed literally.
+  - The same PR fixed an unrecorded bug alongside it: the route wrote `StorageLocation` **on the
+    pool, outside** the transaction that wrote the `MediaAsset`, so an asset failure left a committed
+    row pointing at bytes the route was about to delete. `createStorageLocation` already took
+    `opts.tx` and this route was its only external caller, so it is now one transaction. Passing an
+    explicit non-empty `bucket` makes `resolveS3BucketForLocation` short-circuit, so no credential
+    fetch happens inside the open transaction.
 - **`upload/validators.ts` (201 lines) has zero consumers** outside the `files/index.ts` barrel, and
   its `getMimeTypeFromExtension` duplicates `@auxx/utils/file`.
-- **`files/types` is a second, undeclared client entry point.** `CLAUDE.md` says client code imports
-  from `@auxx/lib/<module>/client`; `files/client.ts` exports only file-type constants, while the
-  whole front end imports `@auxx/lib/files/types`, which ships runtime values (`ENTITY_CONFIGS`,
-  `getEntityConfig`) into the browser bundle. It happens to be server-dependency-free; nothing
-  enforces that.
+- **`files/types` is server-dependency-free by habit, not by enforcement.** The front end no longer
+  imports it (#1866): `files/client.ts` now exports `EntityType`, `ServerIdKind`, `ENTITY_TYPES`,
+  `ENTITY_CONFIGS`, `getEntityConfig` and `UPLOAD_POLICIES`, and 15 front-end files were repointed —
+  the sole remaining importer of `files/types` is the server route `upload/sessions/route.ts`, which
+  is correct. What is **not** fixed is the guarantee: every module under `files/types/` is pure
+  today, and nothing stops the next server import from landing there and silently re-tainting a path
+  the browser used to reach. A `knip`-style or lint guardrail is still absent.
 - ~~**`files/cleanup/` still exists**~~ — **CLOSED (7c), by deletion.** Zero runtime callers; the
   only reference was one lib test, which now exercises `enqueueOrphanedStorageObjectCleanup`
   directly.
@@ -986,6 +1100,7 @@ sweep that has not happened yet.
 apps/web/src/app/api/files/upload/sessions/route.ts               session create + the two gates
 apps/web/src/app/api/files/upload/[sessionId]/parts/route.ts      per-part presign
 apps/web/src/app/api/files/upload/[sessionId]/complete/route.ts   completion
+apps/web/src/app/api/files/upload/[sessionId]/abort/route.ts      cancel: release the multipart upload
 apps/web/src/app/api/files/upload/[sessionId]/authorize-upload-session.ts
 apps/web/src/app/api/files/download/[fileId]/route.ts             buffered download
 apps/web/src/app/api/attachments/[attachmentId]/{content,download,thumbnail}/route.ts
@@ -1006,6 +1121,8 @@ prepare.ts        prepareUpload — handler lookup, config, session, presign
 complete.ts       completeUpload — verify / one transaction / after commit
 persist.ts        persistUpload — the one switch on handler.persist
 post-commit.ts    runUploadPostCommit — afterCommit, thumbnails, preview URL
+compensate.ts     compensateUploadObject — delete the orphan, else enqueue cleanup
+abort.ts          abortMultipartUpload — release an upload that will never complete
 config.ts         buildUploadConfig (pure) + validateCompletedUpload
 handlers/         types.ts (the UploadHandler record) + index.ts + 11 entity handlers
 session.ts        Redis session functions over an injected client, CAS patches


### PR DESCRIPTION
## Symptom

Creating a tag on the record-create dialog showed the raw cuid instead of the label, the tag vanished when the popover reopened, and nothing was persisted. Diagnosed as three independent layers plus a fourth bug found while verifying.

## Fixes

**1. `useResource` returns effective fields** — `resourceMap` is a hydration snapshot no field action ever updates, while `fieldMap` is the maintained merge of server + optimistic state. Every `resource.fields` reader (create dialog, bulk update, records view, merge preview, …) saw pre-mutation state. `composeEffectiveFields` (extracted from `useResourceFields`, which already had the right composition) now overlays `fieldMap` onto the snapshot at read time — snapshot decides membership and order, `fieldMap` supplies content, optimistic new/deleted fields included. This also defuses the destructive edge: a full option-list replace built on the stale snapshot deleted options created since hydration and cascade-deleted their `FieldValue`s org-wide.

**2. Inline option creation lives in the input, not the form** — mirroring the RELATIONSHIP branch's inline-create pattern in `FieldInputAdapter`. New `StoreSelectFieldInput` sources options from the store via `useField` and persists option edits itself; the adapter takes a `resourceFieldId` identity prop (the never-wired `onOptionsChange` callback prop is removed); `FieldInputRow` stays pure value-editing. Creation is offered iff the field resolves in the store, so a placeholder shim or workflow synthetic loses the button instead of arming a full-list replace built on a fragment. Bulk-update gains tag creation for free, and the forgot-to-wire hole that shipped a create button writing nowhere cannot recur.

**3. Picker gate** — `MultiSelectPicker` only offers Create when the created option remains resolvable afterwards (`useValueAsLabel` or a wired persistence handler).

**4. Parts dialog resolved the products taxonomy** — `PartFormDialog` looked up its Category field by bare systemAttribute `category`, which the new products def also claims; the ambiguity tie-break handed it the products options (`la`/`sdf` instead of `Motor`/`fds`). Now def-scoped via `useSystemField('category', partDefId)` and store-connected. `FieldValue` scan confirmed no part record ever received a products option id.

## Tests

`use-resource.test.ts` (9 tests): overlay semantics through every optimistic phase, resource identity stable across unrelated store writes (re-render churn guard), and a parity invariant that `useResource` and `useResourceFields` can never disagree again — the two read paths disagreeing was the bug class. Suites green across resources/custom-fields/fields/pickers (310 tests); verified live on `/app/custom/orders` (create, reopen, reload, cross-surface table→dialog) and `/app/parts`.

Also carries the pending #1866 documentation update to `docs/files-upload-architecture-guide.md` as a separate commit.