### PR TITLE
fix(parts): importer phase 0 — round bom costs, currency integer floor, optional vendor sku

### DIFF
--- a/packages/lib/src/bom/cost-calculator.test.ts
+++ b/packages/lib/src/bom/cost-calculator.test.ts
@@ -508,6 +508,68 @@ describe('calculateAllCosts — the unpriced-components signal', () => {
   })
 })
 
+describe('persistCosts — fractional costs round at the write seam', () => {
+  /** A tariff-rate FieldValue row for an existing vendor_part instance. */
+  function tariffRow(instanceId: string, rate: number) {
+    return {
+      instanceId,
+      fieldId: FIELD.vendor_part_tariff_rate!.id,
+      valueNumber: rate,
+      valueBoolean: null,
+      relatedEntityId: null,
+    }
+  }
+
+  it('stores a tariff-bearing landed cost as an integer', async () => {
+    // $19.99 at 7.5%: landed = 1999 + 149.925 = 2148.925. CURRENCY FieldValues
+    // are integer minor units, so the persisted number must be 2149 — the
+    // unrounded value used to be written verbatim and stored a fraction.
+    queue(
+      [...vendorPartRows('vp_motor', MOTOR, 1999), tariffRow('vp_motor', 7.5)],
+      [],
+      storedRows([])
+    )
+
+    await recalculateAffectedParts(ORG, [MOTOR])
+
+    expect(writesFor(FIELD.part_cost!.id)).toEqual([
+      { recordId: `part_def:${MOTOR}`, value: { type: 'number', value: 2149 } },
+    ])
+    expect(writesFor(FIELD.part_purchase_cost!.id)).toEqual([
+      { recordId: `part_def:${MOTOR}`, value: { type: 'number', value: 2149 } },
+    ])
+  })
+
+  it('stores a fractional-quantity roll-up as an integer', async () => {
+    // 0.5 m of $3.33 wire: rollup = 166.5 → 167.
+    queue(
+      vendorPartRows('vp_motor', MOTOR, 333),
+      subpartRows('sp_1', ASSEMBLY, MOTOR, 0.5),
+      storedRows([])
+    )
+
+    await recalculateAffectedParts(ORG, [ASSEMBLY])
+
+    expect(writesFor(FIELD.part_cost!.id)).toEqual([
+      { recordId: `part_def:${ASSEMBLY}`, value: { type: 'number', value: 167 } },
+    ])
+  })
+
+  it('compares the ROUNDED value against storage, so a confirming recalc writes nothing', async () => {
+    // Stored 2149 already equals round(2148.925). Comparing the unrounded
+    // value would classify this as a change and rewrite it on every recalc.
+    queue(
+      [...vendorPartRows('vp_motor', MOTOR, 1999), tariffRow('vp_motor', 7.5)],
+      [],
+      storedRows([{ partId: MOTOR, cost: 2149, purchaseCost: 2149, source: 'vendor' }])
+    )
+
+    await recalculateAffectedParts(ORG, [MOTOR])
+
+    expect(h.setValueWithType).not.toHaveBeenCalled()
+  })
+})
+
 describe('loadOrgPricingData — the offer id the tiebreak depends on', () => {
   it("carries each vendor part's OWN instance id, not just the part it prices", async () => {
     // `selectWinningVendor` breaks an exact tie on `id`. If the loader stopped

--- a/packages/lib/src/bom/cost-calculator.ts
+++ b/packages/lib/src/bom/cost-calculator.ts
@@ -665,9 +665,15 @@ function diffPart(
 
   for (const [field, next, stored] of numeric) {
     if (!field) continue
+    // Landed and roll-up costs are exact and can carry a sub-minor-unit
+    // fraction (4133 at 7.5% → 4442.975), but the stored FieldValue is integer
+    // minor units. This seam is where the exact value becomes a stored one, so
+    // round here — and compare the ROUNDED value, or an unchanged fractional
+    // cost re-writes on every recalculation.
+    const rounded = next == null ? null : Math.round(next)
     const prev = stored.get(partId) ?? null
-    if (next === prev) continue
-    writes.push({ field, value: next == null ? null : { type: 'number', value: next } })
+    if (rounded === prev) continue
+    writes.push({ field, value: rounded == null ? null : { type: 'number', value: rounded } })
   }
 
   if (fields.costSource) {

--- a/packages/lib/src/data-connectors/sinks/row-level-writes.ts
+++ b/packages/lib/src/data-connectors/sinks/row-level-writes.ts
@@ -24,6 +24,7 @@
 // entity-sink) so the sink's mocked unit tests never load that graph.
 
 import { schema } from '@auxx/database'
+import type { FieldType } from '@auxx/database/types'
 import { createScopedLogger } from '@auxx/logger'
 import type { TypedFieldValueInput } from '@auxx/types'
 import { and, asc, eq, isNull } from 'drizzle-orm'
@@ -171,6 +172,7 @@ export async function planRowLevelWrites(
       entityId: instanceId,
       entityDefinitionId,
       fieldId: w.fieldUuid,
+      fieldType: w.field.type as FieldType,
       value: typed,
       sortKey: 'a0', // placeholder — never inserted; only the value columns are read
     })

--- a/packages/lib/src/field-hooks/post/bom-movement-triggers.ts
+++ b/packages/lib/src/field-hooks/post/bom-movement-triggers.ts
@@ -11,7 +11,7 @@ import { and, eq, inArray, sql } from 'drizzle-orm'
 import { getOrgCache, requireCachedEntityDefId } from '../../cache'
 import { createFieldValueContext } from '../../field-values/field-value-helpers'
 import { buildFieldValueRow, setValueWithType } from '../../field-values/field-value-mutations'
-import { toFieldType } from '../../field-values/stored-field-type'
+import { type StoredFieldType, toFieldType } from '../../field-values/stored-field-type'
 import {
   type FieldValueUpdateEntry,
   getRealtimeService,
@@ -130,42 +130,45 @@ export const explodeBomMovement: EntityTriggerHandler = async (event) => {
     const instanceId = insertedInstances[i]!.id
 
     // Define typed values for this child movement
-    const typedValues: Array<{ fieldId: string; value: TypedFieldValueInput }> = [
+    const typedValues: Array<{
+      field: { id: string; type: StoredFieldType }
+      value: TypedFieldValueInput
+    }> = [
       {
-        fieldId: fields.stock_movement_part!.id,
+        field: fields.stock_movement_part!,
         value: {
           type: 'relationship',
           recordId: toRecordId(partDefId, target.partInstanceId) as RecordId,
         },
       },
       {
-        fieldId: fields.stock_movement_quantity!.id,
+        field: fields.stock_movement_quantity!,
         value: { type: 'number', value: target.quantity },
       },
       {
-        fieldId: fields.stock_movement_type!.id,
+        field: fields.stock_movement_type!,
         value: { type: 'option', optionId: type as string },
       },
       {
-        fieldId: fields.stock_movement_adjust_subparts!.id,
+        field: fields.stock_movement_adjust_subparts!,
         value: { type: 'boolean', value: false },
       },
       {
-        fieldId: fields.stock_movement_parent_movement!.id,
+        field: fields.stock_movement_parent_movement!,
         value: { type: 'relationship', recordId: parentMovementRecordId as RecordId },
       },
     ]
 
     if (fields.stock_movement_reason && reason) {
       typedValues.push({
-        fieldId: fields.stock_movement_reason.id,
+        field: fields.stock_movement_reason,
         value: { type: 'text', value: reason },
       })
     }
 
     if (fields.stock_movement_reference && reference) {
       typedValues.push({
-        fieldId: fields.stock_movement_reference.id,
+        field: fields.stock_movement_reference,
         value: { type: 'text', value: reference },
       })
     }
@@ -173,13 +176,14 @@ export const explodeBomMovement: EntityTriggerHandler = async (event) => {
     // Convert each typed value to a FieldValue insert row.
     // These are single-value fields (one row per (entityId, fieldId)),
     // so the sortKey is purely positional — always the canonical first key.
-    for (const { fieldId, value } of typedValues) {
+    for (const { field, value } of typedValues) {
       fieldValueRows.push(
         buildFieldValueRow({
           organizationId,
           entityId: instanceId,
           entityDefinitionId: stockMovementDefId,
-          fieldId,
+          fieldId: field.id,
+          fieldType: toFieldType(field.type),
           value,
           sortKey: nextKeyAfter(null),
         })
@@ -500,6 +504,7 @@ async function batchRecalculateQoH(
         entityId: partId,
         entityDefinitionId: partDefId,
         fieldId: qohField.id,
+        fieldType: toFieldType(qohField.type),
         value: { type: 'number', value: qoh },
         sortKey: nextKeyAfter(null),
       })
@@ -513,6 +518,7 @@ async function batchRecalculateQoH(
           entityId: partId,
           entityDefinitionId: partDefId,
           fieldId: statusField.id,
+          fieldType: toFieldType(statusField.type),
           value: { type: 'option', optionId: status },
           sortKey: nextKeyAfter(null),
         })

--- a/packages/lib/src/field-values/__tests__/currency-integrality-guard.test.ts
+++ b/packages/lib/src/field-values/__tests__/currency-integrality-guard.test.ts
@@ -1,0 +1,181 @@
+// packages/lib/src/field-values/__tests__/currency-integrality-guard.test.ts
+//
+// The CURRENCY integrality guard on the TYPED write path. The coercion path
+// has always rejected fractional amounts, but typed callers skip coercion
+// entirely — which is how the BOM cost calculator stored fractional minor
+// units (plans/importer/01-current-state.md §4.2). The rule is defined once
+// (`assertCurrencyIntegerMinorUnits`, field-value-helpers.ts) and enforced in
+// two places these tests pin separately: `buildFieldValueRow` — the last stop
+// before a number becomes a `valueNumber` row, covering EVERY writer — and an
+// early check in `setValueWithType`, whose only job is ordering: rejecting
+// BEFORE the destructive DELETE so existing values survive.
+
+import { toRecordId } from '@auxx/types/resource'
+
+// ⚠️ Mock '../../realtime/publish-helpers' directly — NOT the '../../realtime'
+// barrel (see batched-realtime-publish.test.ts for the import-cycle rationale).
+vi.mock('../../realtime/publish-helpers', () => ({
+  publishFieldValueUpdates: vi.fn(),
+}))
+
+// Large barrel with DB/Redis-backed providers; nothing here is reached because
+// the field is pre-seeded into `ctx.fieldCache` and is non-RELATIONSHIP,
+// non-unique.
+vi.mock('../../cache', () => ({
+  getCachedFieldMap: vi.fn(),
+  getCachedResource: vi.fn(),
+  getOrgCache: vi.fn(),
+}))
+
+import { BadRequestError } from '../../errors'
+import { createFieldValueContext } from '../field-value-helpers'
+import { buildFieldValueRow, setValueWithType } from '../field-value-mutations'
+
+/** Chainable fake db that records whether the destructive DELETE ever ran. */
+function makeFakeDb() {
+  const calls = { delete: 0 }
+  const chain: any = {}
+  Object.assign(chain, {
+    delete: () => {
+      calls.delete++
+      return chain
+    },
+    where: () => chain,
+    insert: () => chain,
+    values: (rows: any) => {
+      chain._pending = Array.isArray(rows) ? rows : [rows]
+      return chain
+    },
+    onConflictDoUpdate: () => chain,
+    returning: () =>
+      Promise.resolve((chain._pending ?? []).map((row: any) => ({ id: 'fv-1', ...row }))),
+    select: () => chain,
+    from: () => chain,
+    orderBy: () => Promise.resolve([]),
+    update: () => chain,
+    set: () => chain,
+  })
+  return { db: chain, calls }
+}
+
+const recordId = toRecordId('widget', 'inst-1')
+
+const CURRENCY_FIELD = {
+  id: 'field-price',
+  type: 'CURRENCY',
+  options: {},
+  entityDefinitionId: null,
+  entityDefinition: null,
+  entityType: null,
+  isUnique: false,
+  systemAttribute: null,
+} as any
+
+function makeCtx(db: any) {
+  const ctx = createFieldValueContext('org-1', undefined, db)
+  // Pre-seed so `getField` never reaches the mocked org cache.
+  ctx.fieldCache.set(CURRENCY_FIELD.id, CURRENCY_FIELD)
+  return ctx
+}
+
+describe('buildFieldValueRow — the bottom-most enforcement, every writer passes through it', () => {
+  const rowParams = {
+    organizationId: 'org-1',
+    entityId: 'inst-1',
+    entityDefinitionId: 'widget',
+    fieldId: 'field-price',
+    sortKey: 'a0',
+  }
+
+  it('rejects a fractional minor-unit amount for a CURRENCY field', () => {
+    expect(() =>
+      buildFieldValueRow({
+        ...rowParams,
+        fieldType: 'CURRENCY',
+        value: { type: 'number', value: 2148.925 },
+      })
+    ).toThrow(BadRequestError)
+  })
+
+  it('accepts an integer CURRENCY amount', () => {
+    const row = buildFieldValueRow({
+      ...rowParams,
+      fieldType: 'CURRENCY',
+      value: { type: 'number', value: 2149 },
+    })
+    expect(row.valueNumber).toBe(2149)
+  })
+
+  it('leaves fractional NUMBER values alone (0.5 m of wire is legal)', () => {
+    const row = buildFieldValueRow({
+      ...rowParams,
+      fieldType: 'NUMBER',
+      value: { type: 'number', value: 0.5 },
+    })
+    expect(row.valueNumber).toBe(0.5)
+  })
+})
+
+describe('setValueWithType — CURRENCY integrality guard', () => {
+  it('rejects a fractional minor-unit amount', async () => {
+    const { db } = makeFakeDb()
+    await expect(
+      setValueWithType(makeCtx(db), {
+        recordId,
+        fieldId: CURRENCY_FIELD.id,
+        fieldType: 'CURRENCY',
+        value: { type: 'number', value: 2148.925 },
+      })
+    ).rejects.toThrow(BadRequestError)
+  })
+
+  it('rejects BEFORE the destructive delete, so existing values survive', async () => {
+    const { db, calls } = makeFakeDb()
+    await setValueWithType(makeCtx(db), {
+      recordId,
+      fieldId: CURRENCY_FIELD.id,
+      fieldType: 'CURRENCY',
+      value: { type: 'number', value: 0.5 },
+    }).catch(() => {})
+    expect(calls.delete).toBe(0)
+  })
+
+  it('accepts an integer amount', async () => {
+    const { db, calls } = makeFakeDb()
+    const result = await setValueWithType(makeCtx(db), {
+      recordId,
+      fieldId: CURRENCY_FIELD.id,
+      fieldType: 'CURRENCY',
+      value: { type: 'number', value: 2149 },
+    })
+    expect(calls.delete).toBe(1)
+    expect(result).toHaveLength(1)
+  })
+
+  it('leaves a clear (null) untouched', async () => {
+    const { db } = makeFakeDb()
+    await expect(
+      setValueWithType(makeCtx(db), {
+        recordId,
+        fieldId: CURRENCY_FIELD.id,
+        fieldType: 'CURRENCY',
+        value: null,
+      })
+    ).resolves.toEqual([])
+  })
+
+  it('does not touch non-CURRENCY numbers (a fractional NUMBER is legal)', async () => {
+    const { db } = makeFakeDb()
+    const numberField = { ...CURRENCY_FIELD, id: 'field-qty', type: 'NUMBER' }
+    const ctx = createFieldValueContext('org-1', undefined, db)
+    ctx.fieldCache.set(numberField.id, numberField)
+    await expect(
+      setValueWithType(ctx, {
+        recordId,
+        fieldId: numberField.id,
+        fieldType: 'NUMBER',
+        value: { type: 'number', value: 0.5 },
+      })
+    ).resolves.toHaveLength(1)
+  })
+})

--- a/packages/lib/src/field-values/field-value-helpers.ts
+++ b/packages/lib/src/field-values/field-value-helpers.ts
@@ -585,6 +585,32 @@ export function validateRowReferences(row: FieldValueRow, fieldType: FieldType):
 // =============================================================================
 
 /**
+ * A fractional value in a minor-units field is ALWAYS wrong — cents, yen and
+ * thousandths of a dinar are integers for every ISO currency. This is
+ * decidable, unlike dollars-vs-cents on a whole number, and it is the single
+ * check that would have caught the connector passthrough bug at the first sync
+ * instead of months later.
+ *
+ * The ONE definition of the rule. Called from the coercion path (the CURRENCY
+ * case in {@link validateAndConvertValue}'s validator), from
+ * `buildFieldValueRow` (the last stop before a number becomes a `valueNumber`
+ * row, covering every typed writer), and early in `setValueWithType` (so the
+ * rejection lands before its destructive DELETE).
+ *
+ * 🛑 Never converts units. Given `600` it cannot know whether that is $6.00 or
+ * $600 — the undecidable guess that produced 100×-wrong stored data. A caller
+ * holding decimal major units scales (or rounds) in its own projection.
+ */
+export function assertCurrencyIntegerMinorUnits(num: number): void {
+  if (!Number.isInteger(num)) {
+    throw new BadRequestError(
+      `CURRENCY values are integer minor units (cents for USD), but received ${num}. ` +
+        'A caller holding decimal major units must scale or round before writing.'
+    )
+  }
+}
+
+/**
  * Validate and convert raw value to TypedFieldValueInput using FieldValueValidator.
  * Each field type has dedicated Zod schema validation.
  * Throws descriptive error if validation fails.
@@ -737,17 +763,7 @@ export async function validateSingleValue(
       if (!result.success) throwValidationError(result)
       const num = result.data ?? 0
 
-      // A fractional value in a minor-units field is ALWAYS wrong — cents, yen
-      // and thousandths of a dinar are integers for every ISO currency. This is
-      // decidable, unlike dollars-vs-cents on a whole number, and it is the
-      // single check that would have caught the connector passthrough bug at
-      // the first sync instead of months later.
-      if (!Number.isInteger(num)) {
-        throw new BadRequestError(
-          `CURRENCY values are integer minor units (cents for USD), but received ${num}. ` +
-            'A provider reporting decimal major units must scale in its own projection.'
-        )
-      }
+      assertCurrencyIntegerMinorUnits(num)
 
       return { type: 'number', value: num }
     }

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -76,6 +76,7 @@ import { shortCircuitAiGenerate } from './ai-enqueue'
 import { batchGetExistingFieldValues } from './batch-existing-values'
 import { deleteFieldValues } from './delete-values'
 import {
+  assertCurrencyIntegerMinorUnits,
   type CachedField,
   canonicalizeRelationshipRecordId,
   canonicalizeRelationshipValue,
@@ -621,6 +622,17 @@ export async function setValueWithType(
     }
   }
 
+  // Ordering guard only — the rule itself lives in
+  // `assertCurrencyIntegerMinorUnits` and is enforced for every writer by
+  // `buildFieldValueRow`. But that fires while building INSERT rows, which in
+  // this function is after the destructive delete; asserting up front means a
+  // rejected fractional write leaves the record's existing values intact.
+  if (fieldType === 'CURRENCY') {
+    for (const v of Array.isArray(value) ? value : [value]) {
+      if (v?.type === 'number') assertCurrencyIntegerMinorUnits(v.value)
+    }
+  }
+
   // Uniqueness gate — THE gate for every set-shaped write (panel writes via
   // setValueWithBuiltIn, setValuesForEntity/setBulkValues/applyBulk fan-outs,
   // and direct service calls). Array values are checked per element,
@@ -691,6 +703,7 @@ export async function setValueWithType(
       entityId: entityInstanceId,
       entityDefinitionId,
       fieldId,
+      fieldType,
       value: v,
       sortKey: sortKeys[index]!,
     })
@@ -831,6 +844,7 @@ export async function addValue(
     entityId: addInstId,
     entityDefinitionId: addDefId,
     fieldId,
+    fieldType,
     value,
     sortKey,
   })
@@ -1759,6 +1773,7 @@ export async function addValues(
         entityId: entityInstanceId,
         entityDefinitionId,
         fieldId,
+        fieldType,
         value: v,
         sortKey,
       })
@@ -2113,6 +2128,7 @@ export async function addValuesBulk(
             entityId,
             entityDefinitionId,
             fieldId,
+            fieldType,
             value: typedInputs[i]!,
             sortKey,
           })
@@ -2469,6 +2485,7 @@ async function findUnchangedSetResult(
         entityId: args.entityInstanceId,
         entityDefinitionId: args.entityDefinitionId,
         fieldId: args.fieldId,
+        fieldType: args.fieldType,
         value: values[i]!,
         // Payload-only comparison target; the row's own key keeps
         // `buildFieldValueRow` honest without comparing sortKeys themselves.
@@ -3809,7 +3826,7 @@ async function setSingleValue(
 
   if (existing) {
     // UPDATE existing row
-    const updateData = buildUpdateData(singleValue)
+    const updateData = buildUpdateData(fieldType, singleValue)
     const updatedResult = await updateFieldValue({
       id: existing.id,
       organizationId: ctx.organizationId,
@@ -3894,7 +3911,7 @@ async function setMultiValue(
  * Converts recordId back to two DB columns for relationship type.
  */
 function buildInsertData(
-  _fieldType: FieldType,
+  fieldType: FieldType,
   value: TypedFieldValueInput
 ): {
   valueText?: string | null
@@ -3913,6 +3930,7 @@ function buildInsertData(
     case 'number':
       // CURRENCY stores its amount in valueNumber exactly like NUMBER — the
       // denomination is the field's, so nothing rides the envelope.
+      if (fieldType === 'CURRENCY') assertCurrencyIntegerMinorUnits(value.value)
       return { valueNumber: value.value }
     case 'boolean':
       return { valueBoolean: value.value }
@@ -3956,7 +3974,10 @@ function buildInsertData(
  * Build update data from typed value input (for service layer).
  * Converts recordId back to two DB columns for relationship type.
  */
-function buildUpdateData(value: TypedFieldValueInput): {
+function buildUpdateData(
+  fieldType: FieldType,
+  value: TypedFieldValueInput
+): {
   valueText?: string | null
   valueNumber?: number | null
   valueBoolean?: boolean | null
@@ -3967,13 +3988,14 @@ function buildUpdateData(value: TypedFieldValueInput): {
   relatedEntityDefinitionId?: string | null
   actorId?: string | null
 } {
-  // Same structure as insert data (fieldType not needed for structure)
+  // Same structure as insert data
   switch (value.type) {
     case 'text':
       return { valueText: value.value }
     case 'number':
       // CURRENCY stores its amount in valueNumber exactly like NUMBER — the
       // denomination is the field's, so nothing rides the envelope.
+      if (fieldType === 'CURRENCY') assertCurrencyIntegerMinorUnits(value.value)
       return { valueNumber: value.value }
     case 'boolean':
       return { valueBoolean: value.value }
@@ -4011,16 +4033,25 @@ function buildUpdateData(value: TypedFieldValueInput): {
 /**
  * Build a FieldValue insert row from typed input (for direct DB insert).
  * Exported for use in batch inserts (e.g., BOM explosion trigger).
+ *
+ * `fieldType` exists for one reason: this is the last stop before a number
+ * becomes a `valueNumber` row, so it is where the CURRENCY integer-minor-units
+ * invariant is enforced for EVERY writer — including the ones that never pass
+ * through `setValueWithType` (addValue, the bulk fan-outs, the connector sink,
+ * the BOM explosion trigger). A `{type: 'number'}` input alone cannot carry
+ * the distinction, because a fractional NUMBER is legal.
  */
 export function buildFieldValueRow(params: {
   organizationId: string
   entityId: string
   entityDefinitionId: string
   fieldId: string
+  fieldType: FieldType
   value: TypedFieldValueInput
   sortKey: string
 }): typeof schema.FieldValue.$inferInsert {
-  const { organizationId, entityId, entityDefinitionId, fieldId, value, sortKey } = params
+  const { organizationId, entityId, entityDefinitionId, fieldId, fieldType, value, sortKey } =
+    params
 
   const base = {
     organizationId,
@@ -4043,6 +4074,7 @@ export function buildFieldValueRow(params: {
     case 'text':
       return { ...base, valueText: value.value }
     case 'number':
+      if (fieldType === 'CURRENCY') assertCurrencyIntegerMinorUnits(value.value)
       return { ...base, valueNumber: value.value }
     case 'boolean':
       return { ...base, valueBoolean: value.value }

--- a/packages/lib/src/resources/registry/resources/vendor-part-fields.ts
+++ b/packages/lib/src/resources/registry/resources/vendor-part-fields.ts
@@ -111,13 +111,14 @@ export const VENDOR_PART_FIELDS: Record<string, ResourceField> = {
     isSystem: true,
     systemAttribute: 'vendor_part_vendor_sku',
     systemSortOrder: 'a3',
-    nullable: false,
+    // Optional: under the (part, supplier) natural key the vendor's own SKU is
+    // metadata, not identity, and real price lists routinely omit the column.
+    nullable: true,
     capabilities: {
       filterable: true,
       sortable: true,
       creatable: true,
       updatable: true,
-      required: true,
       configurable: false,
     },
     placeholder: 'Enter vendor SKU',

--- a/packages/lib/src/seed/entity-migrations/index.ts
+++ b/packages/lib/src/seed/entity-migrations/index.ts
@@ -67,6 +67,7 @@ import { migration100PartCostProvenance } from './migrations/100-part-cost-prove
 import { migration101ProductFamily } from './migrations/101-product-family'
 import { migration102CatalogRelabel } from './migrations/102-catalog-relabel'
 import { migration103GlPosting } from './migrations/103-gl-posting'
+import { migration104VendorSkuOptional } from './migrations/104-vendor-sku-optional'
 import type { EntityMigration, MigrationRunResult } from './types'
 
 const logger = createScopedLogger('entity-migrations')
@@ -179,6 +180,7 @@ const ALL_MIGRATIONS: EntityMigration[] = [
   migration101ProductFamily,
   migration102CatalogRelabel,
   migration103GlPosting,
+  migration104VendorSkuOptional,
 ]
 
 /**

--- a/packages/lib/src/seed/entity-migrations/migrations/104-vendor-sku-optional.test.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/104-vendor-sku-optional.test.ts
@@ -1,0 +1,32 @@
+// packages/lib/src/seed/entity-migrations/migrations/104-vendor-sku-optional.test.ts
+//
+// Migration 104 is a single required-flag flip, so what can silently go wrong
+// is the wiring: the registry must carry the same optionality the migration
+// writes (or fresh orgs and migrated orgs diverge), and the migration must be
+// registered exactly once. These tests pin both.
+
+import { describe, expect, it } from 'vitest'
+import { VENDOR_PART_FIELDS } from '../../../resources/registry/resources/vendor-part-fields'
+import { ALL_ENTITY_MIGRATIONS } from '../../entity-migrations'
+import { migration104VendorSkuOptional } from './104-vendor-sku-optional'
+
+describe('migration 104 registration', () => {
+  it('is registered exactly once, after 103, with a unique id', () => {
+    const ids = ALL_ENTITY_MIGRATIONS.map((m) => m.id)
+    expect(ids.filter((id) => id === '104-vendor-sku-optional')).toHaveLength(1)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids.indexOf('104-vendor-sku-optional')).toBe(ids.indexOf('103-gl-posting') + 1)
+    expect(migration104VendorSkuOptional.id).toBe('104-vendor-sku-optional')
+  })
+})
+
+describe('registry agrees with the migration', () => {
+  // Fresh orgs seed CustomField.required from the registry capabilities;
+  // existing orgs get this migration. If the registry still said required,
+  // whether a vendorSku-less price-list row imports would depend on when the
+  // org signed up.
+  it('vendorSku is optional in the registry', () => {
+    expect(VENDOR_PART_FIELDS.vendorSku?.nullable).toBe(true)
+    expect(VENDOR_PART_FIELDS.vendorSku?.capabilities.required).toBeUndefined()
+  })
+})

--- a/packages/lib/src/seed/entity-migrations/migrations/104-vendor-sku-optional.ts
+++ b/packages/lib/src/seed/entity-migrations/migrations/104-vendor-sku-optional.ts
@@ -1,0 +1,50 @@
+// packages/lib/src/seed/entity-migrations/migrations/104-vendor-sku-optional.ts
+
+import { type Database, schema } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { and, eq } from 'drizzle-orm'
+import type { EntityMigration, EntityMigrationResult } from '../types'
+
+const logger = createScopedLogger('entity-migrations:104')
+
+/**
+ * Migration 104: Make vendor_part `vendor_part_vendor_sku` optional.
+ *
+ * Under the (part, supplier) natural key the vendor's own SKU is metadata, not
+ * identity, and supplier price lists routinely omit the column — with the field
+ * required, every row of such a file fails. The registry flipped
+ * `vendorSku.capabilities.required` to false; this brings existing orgs'
+ * CustomField rows in line, mirroring 012-contact-email-optional.
+ */
+export const migration104VendorSkuOptional: EntityMigration = {
+  id: '104-vendor-sku-optional',
+  description: 'Flip vendor_part vendor_part_vendor_sku CustomField.required to false',
+
+  async up(db: Database, organizationId: string): Promise<EntityMigrationResult> {
+    const state = { entityDefsCreated: 0, fieldsCreated: 0, relationshipsLinked: 0 }
+
+    const updated = await db
+      .update(schema.CustomField)
+      .set({ required: false, updatedAt: new Date() })
+      .where(
+        and(
+          eq(schema.CustomField.organizationId, organizationId),
+          eq(schema.CustomField.modelType, 'vendor_part'),
+          eq(schema.CustomField.systemAttribute, 'vendor_part_vendor_sku'),
+          eq(schema.CustomField.required, true)
+        )
+      )
+      .returning({ id: schema.CustomField.id })
+
+    const alreadyUpToDate = updated.length === 0
+
+    if (!alreadyUpToDate) {
+      logger.info('Migration 104 applied', {
+        organizationId,
+        fieldsUpdated: updated.length,
+      })
+    }
+
+    return { ...state, alreadyUpToDate }
+  },
+}


### PR DESCRIPTION
Phase 0 of `plans/importer/04-implementation-steps.md` ("stop the bleeding") — three independent fixes ahead of the supplier-price importer. The fourth phase-0 item (excluding join-entity relation fields from the import picker) was deliberately deferred: the correct exclusion sweeps far wider than parts (`invoice.lineItems`, `company.vendorParts`, …) and phase 4 gives those fields real create-child semantics anyway.

## 1. BOM costs round at the write seam

`computeLandedCost` is exact on purpose (ordering), but the exact value was persisted verbatim: $19.99 at 7.5% tariff → `2148.925` stored in an integer-minor-units CURRENCY field. Display divides and rounds, so it never *looked* wrong. `diffPart` now rounds — and compares the **rounded** value against storage, so a recalculation that confirms existing numbers writes nothing instead of re-writing every run.

## 2. CURRENCY integer-minor-units floor

The rule is defined once — `assertCurrencyIntegerMinorUnits` in `field-value-helpers.ts`, shared with the coercion path — and enforced at the bottom of the write path, where a number becomes a `valueNumber` row:

- `buildFieldValueRow` now requires `fieldType` and asserts in its `number` case. This covers every writer that never passes through `setValueWithType`: `addValue`, the bulk fan-outs, the connector sink, the BOM explosion/stock triggers.
- `buildInsertData`/`buildUpdateData` (the raw-column path behind `insertFieldValue`/`updateFieldValue` — the exact bypass `plans/importer/01-current-state.md` §4.2 cited) assert the same way.
- `setValueWithType` keeps one early call purely for ordering: the rejection must land **before** its destructive DELETE, so a bad write leaves the record's existing values intact.

Audited every remaining direct `FieldValue` writer (ai-commit markers, relationship-sync, merges/moves, one-off migrations): none write numbers.

## 3. `vendor_part.vendorSku` optional

Under the decided `(part, supplier)` natural key the vendor's own SKU is metadata, not identity — and supplier price lists routinely omit the column, which with a required field fails every row. Registry flip + entity migration `104-vendor-sku-optional` (mirrors 012) for existing orgs.

## Tests

- `cost-calculator.test.ts`: tariff-bearing landed cost stores an integer; fractional-qty roll-up rounds; confirming recalc writes nothing
- `currency-integrality-guard.test.ts` (new): `buildFieldValueRow` rejects fractional CURRENCY / accepts integers / leaves fractional NUMBER alone; `setValueWithType` rejects before the delete
- `104-vendor-sku-optional.test.ts` (new): registration order + registry agreement

86 test files / 788 tests across field-values, bom, field-hooks, data-connectors green; `packages/lib` typecheck clean.