### PR TITLE
fix(import): review-values option labels and selector, broadcast minted options live

### DIFF
--- a/apps/web/src/components/data-import/index.ts
+++ b/apps/web/src/components/data-import/index.ts
@@ -67,7 +67,7 @@ export type {
 export { chunkRows, type RowChunk } from './utils/chunk-rows'
 // Utils
 export { type ParseCSVError, parseCSV } from './utils/parse-csv'
-export { RelationCreateBadge } from './value-review/relation-create-badge'
+export { ValueCreateBadge } from './value-review/relation-create-badge'
 export { ValueRow } from './value-review/value-row'
 // Value review
 export { ValueStatusGroup } from './value-review/value-status-group'

--- a/apps/web/src/components/data-import/types.ts
+++ b/apps/web/src/components/data-import/types.ts
@@ -104,6 +104,12 @@ export interface UniqueValueSummary {
   hash: string
   rawValue: string
   resolvedValue: string | null
+  /**
+   * Display label(s) behind `resolvedValue` for option columns, resolved
+   * server-side against the LIVE option list. Null for non-option columns and
+   * for pending option creates (their `resolvedValue` is a label, not a key).
+   */
+  resolvedLabel: string | null
   resolvedValues: Array<{ type: string; value?: unknown }>
   count: number
   originalStatus: ResolutionStatus // From auto-resolution, used for grouping
@@ -124,6 +130,10 @@ export interface ColumnFieldConfig {
   key: string
   type: string
   resolutionType: string
+  /** `ImportMappingProperty.customFieldId` — null for system fields */
+  customFieldId?: string | null
+  /** `ImportMapping.entityDefinitionId` — the resource this column targets */
+  entityDefinitionId?: string
   options?: SelectOption[]
   relationConfig?: {
     relatedEntityDefinitionId: string

--- a/apps/web/src/components/data-import/value-review/editing-input.tsx
+++ b/apps/web/src/components/data-import/value-review/editing-input.tsx
@@ -2,41 +2,95 @@
 
 'use client'
 
-import { Button } from '@auxx/ui/components/button'
+import { FieldType } from '@auxx/database/enums'
+import { getFieldOutputKey } from '@auxx/lib/resources/client'
 import { Input } from '@auxx/ui/components/input'
-import { useMemo, useState } from 'react'
-import { ComboPicker, type Option } from '~/components/pickers/combo-picker'
-import type { ColumnFieldConfig, OverrideValue } from '../types'
+import { useEffect, useMemo, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { useResourceFields } from '~/components/resources'
+import type { ColumnFieldConfig, OverrideValue, ResolutionStatus } from '../types'
 
 export interface EditingInputProps {
   fieldConfig: ColumnFieldConfig | null
   rawValue: string
   resolvedValue: string | null
+  originalStatus: ResolutionStatus
   isOverridden: boolean
   overrideValues: OverrideValue[] | null
-  hasCustomOverride: boolean
   onSave: (overrideValues: OverrideValue[] | null) => void
+}
+
+/** Compare two option-key sets order-insensitively. */
+function sameKeys(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  const sortedA = [...a].sort()
+  const sortedB = [...b].sort()
+  return sortedA.every((key, i) => key === sortedB[i])
 }
 
 /**
  * Component for editing value overrides.
- * Renders different input types based on field configuration.
- * Saves on blur for text inputs, on selection for enum pickers.
+ *
+ * Option columns (`select:*` / `multiselect:*`) render the real select picker
+ * via `FieldInputAdapter`, showing labels (`TagsView` chips inside the trigger)
+ * instead of raw option keys. Everything else renders a text input that saves
+ * on blur.
  */
 export function EditingInput({
   fieldConfig,
   rawValue,
   resolvedValue,
+  originalStatus,
   isOverridden,
   overrideValues,
-  hasCustomOverride,
   onSave,
 }: EditingInputProps) {
-  // Check if currently skipped
+  // Check if currently skipped (skipped rows don't render this component, but
+  // the derivations below must not read a skip marker as a value)
   const isSkipped = isOverridden && overrideValues?.[0]?.type === 'skip'
 
-  // Initialize value from existing override or resolved value or raw value
-  // If skipped, use resolved/raw value (not the skip value)
+  const resolutionType = fieldConfig?.resolutionType ?? 'text:value'
+  const isOptionColumn =
+    resolutionType.startsWith('select:') || resolutionType.startsWith('multiselect:')
+
+  // The field's REAL type (SINGLE_SELECT vs MULTI_SELECT vs TAGS — they differ
+  // on multi/canAdd). Resolved from the resource store by output key; the
+  // resolution-type prefix is only a fallback for a cold store or a vanished
+  // field. `useFieldByKey` is deliberately not used — its custom-field arm
+  // expects the CustomField UUID, not the output key.
+  const { fields } = useResourceFields(
+    isOptionColumn ? (fieldConfig?.entityDefinitionId ?? null) : null
+  )
+  const storeField = useMemo(() => {
+    if (!isOptionColumn || !fieldConfig) return undefined
+    return fields.find((f) => getFieldOutputKey(f) === fieldConfig.key)
+  }, [fields, fieldConfig, isOptionColumn])
+  const optionFieldType =
+    storeField?.fieldType ??
+    (resolutionType.startsWith('multiselect:') ? FieldType.MULTI_SELECT : FieldType.SINGLE_SELECT)
+
+  // The resolver's answer as option key(s). Multiselect values arrive
+  // comma-joined (option keys never contain commas); a pending option CREATE
+  // resolves to the label to be minted, not a key, so it contributes none.
+  const autoKeys = useMemo(() => {
+    if (!isOptionColumn || originalStatus === 'create' || !resolvedValue) return []
+    return resolvedValue.split(',').filter(Boolean)
+  }, [isOptionColumn, originalStatus, resolvedValue])
+
+  /** Current selection: the override when present, else the resolver's answer. */
+  const selectedKeys = useMemo(() => {
+    if (isOverridden && !isSkipped && overrideValues) {
+      return overrideValues
+        .filter((ov) => ov.type !== 'skip')
+        .map((ov) => ov.value)
+        .filter(Boolean)
+    }
+    return autoKeys
+  }, [isOverridden, isSkipped, overrideValues, autoKeys])
+
+  // ── Text editor state ──────────────────────────────────────────────
+  // Never seeded with `resolvedValue` for option columns: those render the
+  // picker below and a 21-char option key must never appear in a textbox.
   const initialValue = useMemo(() => {
     if (isSkipped) {
       return resolvedValue ?? rawValue
@@ -48,52 +102,13 @@ export function EditingInput({
   }, [isOverridden, isSkipped, overrideValues, resolvedValue, rawValue])
 
   const [editValue, setEditValue] = useState(initialValue)
-  const [pickerOpen, setPickerOpen] = useState(false)
-  const [selectedOptions, setSelectedOptions] = useState<Option[]>(() => {
-    // Initialize selected options for enum fields
-    const fieldOptions = fieldConfig?.options
-    if (fieldConfig?.type === 'enum' && fieldOptions?.length) {
-      // If skipped, use resolved value (not skip value)
-      if (isSkipped) {
-        const matchedOption = fieldOptions.find((opt) => opt.value === resolvedValue)
-        if (matchedOption) {
-          return [{ value: matchedOption.value, label: matchedOption.label }]
-        }
-        return []
-      }
-      // If overridden with values, use those
-      if (isOverridden && overrideValues) {
-        return overrideValues
-          .filter((ov) => ov.type !== 'skip')
-          .map((ov) => {
-            const option = fieldOptions?.find((opt) => opt.value === ov.value)
-            return option ? { value: option.value, label: option.label } : null
-          })
-          .filter((x): x is Option => x !== null)
-      }
-      // Try to match resolved value to option
-      const matchedOption = fieldOptions.find((opt) => opt.value === resolvedValue)
-      if (matchedOption) {
-        return [{ value: matchedOption.value, label: matchedOption.label }]
-      }
-    }
-    return []
-  })
 
-  // Determine editor type based on field config
-  const resolutionType = fieldConfig?.resolutionType ?? 'text:value'
-  const isEnumType =
-    resolutionType.startsWith('select:') || resolutionType.startsWith('multiselect:')
-  const isMultiSelect = resolutionType.startsWith('multiselect:')
-
-  // Build options for enum picker
-  const enumOptions: Option[] = useMemo(() => {
-    if (!fieldConfig?.options?.length) return []
-    return fieldConfig.options.map((opt) => ({
-      value: opt.value,
-      label: opt.label,
-    }))
-  }, [fieldConfig?.options])
+  // Rows are recycled by `hash` in the virtual list and props move under
+  // Revert / re-resolve without a remount — resync the draft when the
+  // incoming value changes.
+  useEffect(() => {
+    setEditValue(initialValue)
+  }, [initialValue])
 
   /** The original (non-overridden) value */
   const originalValue = resolvedValue ?? rawValue
@@ -113,54 +128,42 @@ export function EditingInput({
     onSave([{ type: 'value', value: editValue }])
   }
 
-  /** Handle enum selection - save immediately on single select */
-  const handleEnumChange = (val: Option | Option[] | null) => {
-    if (isMultiSelect) {
-      setSelectedOptions(val as Option[])
-    } else {
-      const newOptions = val ? [val as Option] : []
-      setSelectedOptions(newOptions)
-      // Save immediately for single select
-      if (newOptions.length > 0) {
-        const values: OverrideValue[] = newOptions.map((opt) => ({
-          type: 'value' as const,
-          value: opt.value,
-        }))
-        onSave(values)
-      }
-      setPickerOpen(false)
+  /**
+   * Option selection change — saves immediately with the FULL key array
+   * (single select writes one key, multi writes all). Clearing the selection
+   * or re-picking exactly the resolver's answer reverts to it.
+   */
+  const handleOptionChange = (next: unknown) => {
+    const keys = Array.isArray(next)
+      ? (next as string[]).filter(Boolean)
+      : typeof next === 'string' && next
+        ? [next]
+        : []
+
+    if (keys.length === 0 || sameKeys(keys, autoKeys)) {
+      if (isOverridden) onSave(null)
+      return
     }
+    onSave(keys.map((value) => ({ type: 'value' as const, value })))
   }
 
-  /** Handle enum picker close for multiselect - save on close */
-  const handleEnumClose = () => {
-    setPickerOpen(false)
-    if (isMultiSelect && selectedOptions.length > 0) {
-      const values: OverrideValue[] = selectedOptions.map((opt) => ({
-        type: 'value' as const,
-        value: opt.value,
-      }))
-      onSave(values)
-    }
-  }
-
-  // Render enum picker
-  if (isEnumType && enumOptions.length > 0) {
+  // Option columns always render the picker — even with an empty live list —
+  // so a raw option key never leaks into a text input.
+  if (isOptionColumn && fieldConfig) {
     return (
-      <ComboPicker
-        options={enumOptions}
-        selected={isMultiSelect ? selectedOptions : (selectedOptions[0] ?? null)}
-        multi={isMultiSelect}
-        open={pickerOpen}
-        onOpen={() => setPickerOpen(true)}
-        onClose={handleEnumClose}
-        onChange={handleEnumChange}>
-        <Button variant='outline' size='sm' className='h-7 min-w-[120px] justify-start'>
-          {selectedOptions.length > 0
-            ? selectedOptions.map((o) => o.label).join(', ')
-            : 'Select value...'}
-        </Button>
-      </ComboPicker>
+      <div className='min-w-0 flex-1' title={rawValue}>
+        <FieldInputAdapter
+          fieldType={optionFieldType}
+          fieldOptions={{ options: fieldConfig.options ?? [] }}
+          value={selectedKeys}
+          onChange={handleOptionChange}
+          placeholder='Select value...'
+          // Overrides must reference existing option keys; minting happens via
+          // the import's own select-create path, so the picker never creates.
+          canAdd={false}
+          triggerProps={{ className: 'h-7' }}
+        />
+      </div>
     )
   }
 

--- a/apps/web/src/components/data-import/value-review/index.ts
+++ b/apps/web/src/components/data-import/value-review/index.ts
@@ -1,5 +1,5 @@
 // apps/web/src/components/data-import/value-review/index.ts
 
-export { RelationCreateBadge } from './relation-create-badge'
+export { ValueCreateBadge } from './relation-create-badge'
 export { ValueRow } from './value-row'
 export { ValueStatusGroup } from './value-status-group'

--- a/apps/web/src/components/data-import/value-review/relation-create-badge.tsx
+++ b/apps/web/src/components/data-import/value-review/relation-create-badge.tsx
@@ -9,20 +9,18 @@ import { Plus } from 'lucide-react'
 import { Tooltip } from '~/components/global/tooltip'
 import { useResource } from '~/components/resources'
 
-interface RelationCreateBadgeProps {
-  request: RelationCreateRequest
+/** What the badge announces will be minted when the import runs. */
+export type ValueCreateDescriptor =
+  | { kind: 'relation'; request: RelationCreateRequest }
+  /** A select/tags option; `label` is the trimmed cell text to be minted. */
+  | { kind: 'option'; label: string }
+
+interface ValueCreateBadgeProps {
+  create: ValueCreateDescriptor
 }
 
-/**
- * "Will be created", the render for the `'create'` resolution status.
- *
- * The status has been declared and produced for a long time with nothing
- * rendering it, so a pending relation create looked like an unresolved value.
- * Nothing is minted until execution: this is a statement of intent, and it stays
- * overridable per value (link it to an existing record, or skip it) right up
- * until the import runs.
- */
-export function RelationCreateBadge({ request }: RelationCreateBadgeProps) {
+/** Relation arm split out so `useResource` is only mounted when needed. */
+function RelationCreateContent({ request }: { request: RelationCreateRequest }) {
   const { resource } = useResource(request.entityDefinitionId)
   const label = resource?.label ?? 'record'
 
@@ -41,6 +39,31 @@ export function RelationCreateBadge({ request }: RelationCreateBadgeProps) {
             <Plus />
           )}
           New {label}
+        </Badge>
+      </span>
+    </Tooltip>
+  )
+}
+
+/**
+ * "Will be created", the render for the `'create'` resolution status — for both
+ * pending relation creates and pending select-option creates.
+ *
+ * Nothing is minted until execution: this is a statement of intent, and it stays
+ * overridable per value (pick an existing option/record, or skip it) right up
+ * until the import runs.
+ */
+export function ValueCreateBadge({ create }: ValueCreateBadgeProps) {
+  if (create.kind === 'relation') {
+    return <RelationCreateContent request={create.request} />
+  }
+
+  return (
+    <Tooltip content={`A new option "${create.label}" will be created when the import runs.`}>
+      <span className='inline-flex'>
+        <Badge variant='blue' size='sm' className='shrink-0'>
+          <Plus />
+          New option
         </Badge>
       </span>
     </Tooltip>

--- a/apps/web/src/components/data-import/value-review/value-row.tsx
+++ b/apps/web/src/components/data-import/value-review/value-row.tsx
@@ -15,7 +15,7 @@ import type {
   UniqueValueSummary,
 } from '../types'
 import { EditingInput } from './editing-input'
-import { RelationCreateBadge } from './relation-create-badge'
+import { ValueCreateBadge } from './relation-create-badge'
 
 interface ValueRowProps {
   value: UniqueValueSummary
@@ -70,7 +70,9 @@ export function ValueRow({ value, jobId, columnIndex, fieldConfig }: ValueRowPro
       overrideValues
     )
 
-    // Optimistically update the cache BEFORE the mutation
+    // Optimistically update the cache BEFORE the mutation. `overrideValues` is
+    // what the row DISPLAYS (the picker's chips / the text draft resync from
+    // it), so patching it here updates the shown value, not just the status.
     utils.dataImport.getUniqueValues.setData({ jobId, columnIndex }, (oldData) => {
       if (!oldData) return oldData
       return {
@@ -164,20 +166,31 @@ export function ValueRow({ value, jobId, columnIndex, fieldConfig }: ValueRowPro
               fieldConfig={fieldConfig}
               rawValue={value.rawValue}
               resolvedValue={value.resolvedValue}
+              originalStatus={value.originalStatus}
               isOverridden={value.isOverridden}
               overrideValues={value.overrideValues}
-              hasCustomOverride={hasCustomOverride}
               onSave={handleInputSave}
             />
           )}
         </div>
 
-        {/* Pending relation create, the render the `'create'` status never had */}
+        {/* Pending create — a relation record, or (no `relationCreate` marker)
+            a select option whose to-be-minted label is `resolvedValue`. An
+            override means the user picked an existing target: no badge. */}
         {value.relationCreate && !isSkipped && !hasCustomOverride && (
           <div className='shrink-0 me-2'>
-            <RelationCreateBadge request={value.relationCreate} />
+            <ValueCreateBadge create={{ kind: 'relation', request: value.relationCreate }} />
           </div>
         )}
+        {!value.relationCreate &&
+          value.originalStatus === 'create' &&
+          value.resolvedValue &&
+          !isSkipped &&
+          !hasCustomOverride && (
+            <div className='shrink-0 me-2'>
+              <ValueCreateBadge create={{ kind: 'option', label: value.resolvedValue }} />
+            </div>
+          )}
 
         {/* Action buttons */}
         {/* <div className="flex items-center opacity-0 group-hover:opacity-100 pe-1 transition-opacity overflow-hidden [[data-first]_&]:rounded-tr-2xl [[data-last]_&]:rounded-br-2xl"> */}

--- a/apps/web/src/components/fields/inputs/select-input-field.tsx
+++ b/apps/web/src/components/fields/inputs/select-input-field.tsx
@@ -89,10 +89,15 @@ export function SelectInputField() {
   // Local selected state for debouncing (multi-select only)
   const [localSelected, setLocalSelected] = useState<string[]>(() => {
     const options = field?.options?.options || []
-    const optionValues = new Set(options.map((opt: SelectOption) => opt.value))
+    // A stored value can live in EITHER keyspace (`id` or `value` — see
+    // `buildOptionIndex`). Filtering on `value` alone dropped id-keyed selections
+    // here, so the picker never saw them and the next debounced commit erased them.
+    const optionKeys = new Set(
+      options.flatMap((opt: SelectOption) => [opt.id, opt.value]).filter(Boolean) as string[]
+    )
     // Normalize value to array (SINGLE_SELECT stores string, MULTI_SELECT/TAGS store string[])
     const valueArray = Array.isArray(value) ? value : value ? [value] : []
-    return valueArray.filter((v: string) => optionValues.has(v))
+    return valueArray.filter((v: string) => optionKeys.has(v))
   })
 
   // Ref to track current local value (for onBeforeClose handler)
@@ -124,11 +129,6 @@ export function SelectInputField() {
     if (!config.multi) return // Only needed for multi-select
 
     onBeforeClose.current = () => {
-      console.log(
-        'SelectInputField: onBeforeClose - flushing debounced save',
-        saveTimeoutRef.current,
-        localSelectedRef.current
-      )
       // Flush pending debounced save immediately
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current)

--- a/apps/web/src/components/pickers/multi-select-picker.tsx
+++ b/apps/web/src/components/pickers/multi-select-picker.tsx
@@ -1,7 +1,7 @@
 // apps/web/src/components/pickers/multi-select-picker.tsx
 'use client'
 
-import { getColorSwatch } from '@auxx/lib/custom-fields/client'
+import { buildOptionIndex, getColorSwatch, optionKey } from '@auxx/lib/custom-fields/client'
 import type { SelectOption, SelectOptionColor } from '@auxx/types/custom-field'
 import type { ResourceFieldId } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
@@ -226,6 +226,31 @@ export function MultiSelectPicker({
     setLocalSelected(newSelected)
   }, [value])
 
+  // Both option keyspaces (`id` and `value`) indexed onto their option rows —
+  // the same tolerance TagsView's `resolveOptionIds` applies on the trigger.
+  const optionIndex = useMemo(() => buildOptionIndex(localOptions), [localOptions])
+
+  /**
+   * Map one incoming selected value onto its option's canonical key (`optionKey`,
+   * i.e. `id ?? value`). A stored selection can arrive in EITHER keyspace — rows
+   * written before an option gained an explicit `id` still hold its `value` — so
+   * membership is checked on canonical keys, never on raw stored strings. Values
+   * matching no option pass through unchanged (unknowns are preserved, not dropped).
+   */
+  const canonicalizeSelected = useCallback(
+    (v: string) => {
+      const opt = optionIndex.get(v)
+      return (opt ? optionKey(opt) : undefined) ?? v
+    },
+    [optionIndex]
+  )
+
+  /** The current selection, folded onto canonical keys for membership checks. */
+  const selectedKeys = useMemo(
+    () => new Set(localSelected.map(canonicalizeSelected)),
+    [localSelected, canonicalizeSelected]
+  )
+
   // UI state
   const [searchValue, setSearchValue] = useState('')
   const [isManageMode, setIsManageMode] = useState(false)
@@ -320,23 +345,31 @@ export function MultiSelectPicker({
   )
 
   /**
-   * Handle option selection
+   * Handle option selection.
+   *
+   * Selection identity is the canonical `optionKey` (`id ?? value`) — what
+   * `FieldValue` stores for the option. Membership folds the incoming selection
+   * onto canonical keys first, so a legacy value stored under `value` still reads
+   * as selected; toggling it off removes every entry that resolves to this option,
+   * and toggling on writes only the canonical key. For options with no `id` this
+   * is exactly `value`, so those consumers see zero behavior change.
    */
   const handleSelect = useCallback(
-    (optValue: string) => {
+    (opt: SelectOption) => {
+      const key = optionKey(opt) ?? opt.value
       if (multi) {
         // Toggle in array
-        const newSelected = localSelected.includes(optValue)
-          ? localSelected.filter((v) => v !== optValue)
-          : [...localSelected, optValue]
+        const newSelected = selectedKeys.has(key)
+          ? localSelected.filter((v) => canonicalizeSelected(v) !== key)
+          : [...localSelected, key]
         updateSelected(newSelected)
       } else {
         // Single select - replace and notify
-        updateSelected([optValue])
-        onSelectSingle?.(optValue)
+        updateSelected([key])
+        onSelectSingle?.(key)
       }
     },
-    [multi, localSelected, updateSelected, onSelectSingle]
+    [multi, localSelected, selectedKeys, canonicalizeSelected, updateSelected, onSelectSingle]
   )
 
   /**
@@ -417,15 +450,20 @@ export function MultiSelectPicker({
       const newOptions = localOptions.filter((opt) => opt.value !== optValue)
       updateOptions(newOptions)
 
-      // Also remove from selection if selected. The server cascade covers every other
+      // Also remove from selection if selected — under EITHER keyspace, mirroring the
+      // server cascade's `buildOptionIndex` diff. The cascade covers every other
       // record; this keeps the open record's UI correct before the refetch lands.
-      if (localSelected.includes(optValue)) {
-        updateSelected(localSelected.filter((v) => v !== optValue))
+      // (`canonicalizeSelected` closes over the pre-delete index, so the deleted
+      // option's keys still resolve here.)
+      const deletedKey = (option ? optionKey(option) : undefined) ?? optValue
+      if (localSelected.some((v) => canonicalizeSelected(v) === deletedKey)) {
+        updateSelected(localSelected.filter((v) => canonicalizeSelected(v) !== deletedKey))
       }
     },
     [
       localOptions,
       localSelected,
+      canonicalizeSelected,
       updateOptions,
       updateSelected,
       resourceFieldId,
@@ -524,6 +562,9 @@ export function MultiSelectPicker({
   // item markup — only the surrounding `CommandGroup`(s) differ.
   const renderOption = (opt: SelectOption) => {
     const usage = isManageMode ? sumOptionUsage(usageCounts, opt) : undefined
+    // Canonical-key membership — a value stored under EITHER of the option's
+    // keyspaces reads as checked here, matching the trigger's TagsView.
+    const isSelected = selectedKeys.has(optionKey(opt) ?? opt.value)
     return (
       <CommandItem
         key={opt.value}
@@ -536,7 +577,7 @@ export function MultiSelectPicker({
               startEdit(opt.value)
             }
           } else {
-            handleSelect(opt.value)
+            handleSelect(opt)
           }
         }}
         disabled={disabled}
@@ -614,12 +655,9 @@ export function MultiSelectPicker({
                   Click to edit
                 </span>
               ) : multi ? (
-                <Checkbox
-                  checked={localSelected.includes(opt.value)}
-                  className='pointer-events-none'
-                />
+                <Checkbox checked={isSelected} className='pointer-events-none' />
               ) : (
-                localSelected.includes(opt.value) && (
+                isSelected && (
                   <div className='rounded-full size-4 bg-info flex items-center justify-center border border-blue-800'>
                     <Check className='size-2.5! text-white' strokeWidth={4} />
                   </div>

--- a/apps/web/src/server/api/routers/data-import.ts
+++ b/apps/web/src/server/api/routers/data-import.ts
@@ -471,12 +471,13 @@ export const dataImportRouter = createTRPCRouter({
       // Verify job access and import authority for its target def
       const job = await requireImportJob(ctx.db, ctx.capabilities, organizationId, input.jobId)
 
-      return getUniqueValuesWithResolution(
-        ctx.db,
-        input.jobId,
-        job.importMappingId,
-        input.columnIndex
-      )
+      return getUniqueValuesWithResolution(ctx.db, {
+        jobId: input.jobId,
+        mappingId: job.importMappingId,
+        columnIndex: input.columnIndex,
+        organizationId,
+        entityDefinitionId: job.importMapping.entityDefinitionId,
+      })
     }),
 
   /**

--- a/packages/lib/src/custom-fields/mint-options.ts
+++ b/packages/lib/src/custom-fields/mint-options.ts
@@ -4,13 +4,13 @@ import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { generateId } from '@auxx/utils/generateId'
 import { and, eq } from 'drizzle-orm'
-import { onCacheEvent } from '../cache/invalidate'
 import {
   type FieldOptionItem,
   optionKey,
   optionMatchKey,
 } from '../resources/registry/option-helpers'
 import type { FieldOptions } from './field-options'
+import { notifyCustomFieldChanged } from './notify'
 
 /**
  * Index existing options by folded LABEL, first writer winning on a collision.
@@ -126,7 +126,10 @@ export async function mintOrMatchOptions(
 
   const result = await db.transaction(async (tx) => {
     const [row] = await tx
-      .select({ options: schema.CustomField.options })
+      .select({
+        options: schema.CustomField.options,
+        entityDefinitionId: schema.CustomField.entityDefinitionId,
+      })
       .from(schema.CustomField)
       .where(
         and(
@@ -181,14 +184,31 @@ export async function mintOrMatchOptions(
         )
     }
 
-    return { ids, minted: appended.length, mintedLabels }
+    return {
+      ids,
+      minted: appended.length,
+      mintedLabels,
+      entityDefinitionId: row?.entityDefinitionId ?? null,
+    }
   })
 
   if (result.minted > 0) {
-    // Without this, the next worker in the batch reads a stale option list from
-    // the org cache and re-mints what this one just created.
-    await onCacheEvent('custom-field.updated', { orgId: organizationId })
+    if (result.entityDefinitionId) {
+      // The chokepoint does both halves: the cache bust (without which the next
+      // worker in the batch reads a stale option list and re-mints what this
+      // one just created) AND the `resource:updated` broadcast (without which
+      // every open client keeps the pre-mint vocabulary and renders the new
+      // optionIds as muted unknown chips until an unrelated refetch). One call
+      // per grown field per batch — this function is invoked once with every
+      // label.
+      await notifyCustomFieldChanged(organizationId, result.entityDefinitionId, 'updated')
+    } else {
+      // A def-less row can't be broadcast, but the cache bust must never be
+      // skipped or the next worker re-mints.
+      const { onCacheEvent } = await import('../cache/invalidate')
+      await onCacheEvent('custom-field.updated', { orgId: organizationId })
+    }
   }
 
-  return result
+  return { ids: result.ids, minted: result.minted, mintedLabels: result.mintedLabels }
 }

--- a/packages/lib/src/import/resolution/__tests__/update-value-resolution.test.ts
+++ b/packages/lib/src/import/resolution/__tests__/update-value-resolution.test.ts
@@ -1,0 +1,230 @@
+// packages/lib/src/import/resolution/__tests__/update-value-resolution.test.ts
+
+import type { Database } from '@auxx/database'
+import { schema } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import { buildRecordData } from '../../execution/build-record-data'
+import { hashValue } from '../../hashing/hash-value'
+import type { ImportMappingProperty } from '../../types/mapping'
+import type { ResolvedValue, ValueResolution } from '../../types/resolution'
+import { updateValueResolution } from '../update-value-resolution'
+
+/**
+ * The multi-value override truncation defect, pinned.
+ *
+ * Every executor reads `resolvedValues[0]` ONLY (`buildRecordData`,
+ * `analyzeRow`, `getPlanPreviewRows`, …), and the multiselect RESOLVER's native
+ * output is a single entry whose `value` is a `string[]`
+ * (`resolveMultiselectSplit`). The override writer used to expand N user
+ * choices into N separate entries instead, so a 3-option override imported
+ * exactly one option and silently dropped two. The writer must emit the
+ * resolver's native shape: one array-valued entry for a multi-valued column.
+ *
+ * The fake dispatches on TABLE reference, which is real under the shared
+ * `@auxx/database` mock; COLUMN references are all `undefined` there, so
+ * where-clauses are structurally unreadable and rows are served from the
+ * fake's own state instead. See `invalidate-column-resolutions.test.ts`.
+ */
+
+interface CapturedWrite {
+  values: Record<string, unknown> | null
+  conflictSet: Record<string, unknown> | null
+}
+
+class FakeDb {
+  mappingProp: { id: string; resolutionType: string }
+  jobProp = { id: 'jobprop_0' }
+  existingResolution: Record<string, unknown> | undefined
+  captured: CapturedWrite = { values: null, conflictSet: null }
+
+  query = {
+    ImportMappingProperty: {
+      findFirst: async () => this.mappingProp,
+    },
+    ImportJobProperty: {
+      findFirst: async () => this.jobProp,
+    },
+    ImportValueResolution: {
+      findFirst: async () => this.existingResolution,
+    },
+  }
+
+  constructor(resolutionType: string) {
+    this.mappingProp = { id: 'prop_0', resolutionType }
+  }
+
+  insert(table: unknown) {
+    const self = this
+    return {
+      values(values: Record<string, unknown>) {
+        if (table === schema.ImportValueResolution) self.captured.values = values
+        return {
+          returning: () => Promise.resolve([values]),
+          onConflictDoUpdate: (config: { set: Record<string, unknown> }) => {
+            if (table === schema.ImportValueResolution) self.captured.conflictSet = config.set
+            return Promise.resolve()
+          },
+        }
+      },
+    }
+  }
+
+  update() {
+    return { set: () => ({ where: () => Promise.resolve() }) }
+  }
+
+  asDatabase(): Database {
+    return this as unknown as Database
+  }
+}
+
+function override(
+  db: FakeDb,
+  overrideValues: Array<{ type: 'value' | 'create' | 'skip'; value: string; id?: string }>
+) {
+  return updateValueResolution(db.asDatabase(), {
+    jobId: 'job_1',
+    mappingId: 'mapping_1',
+    columnIndex: 0,
+    hash: hashValue('Red, Green, Blue'),
+    isOverridden: true,
+    overrideValues,
+  })
+}
+
+function mapping(overrides: Partial<ImportMappingProperty>): ImportMappingProperty {
+  return {
+    id: 'prop_0',
+    importMappingId: 'mapping_1',
+    sourceColumnIndex: 0,
+    sourceColumnName: 'Tags',
+    targetType: 'particle',
+    targetFieldKey: 'tags',
+    customFieldId: null,
+    resolutionType: 'multiselect:split',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+describe('updateValueResolution multi-value overrides', () => {
+  it('persists a multiselect override as ONE array-valued entry (resolver-native shape)', async () => {
+    const db = new FakeDb('multiselect:split')
+
+    await override(db, [
+      { type: 'value', value: 'opt_red' },
+      { type: 'value', value: 'opt_green' },
+      { type: 'value', value: 'opt_blue' },
+    ])
+
+    const expected: ResolvedValue[] = [
+      { type: 'value', value: ['opt_red', 'opt_green', 'opt_blue'] },
+    ]
+    expect(db.captured.values?.resolvedValues).toEqual(expected)
+    expect(db.captured.conflictSet?.resolvedValues).toEqual(expected)
+    expect(db.captured.values?.isValid).toBe(true)
+  })
+
+  it('drops skip entries mixed behind a non-skip first entry from the array', async () => {
+    const db = new FakeDb('multiselect:split')
+
+    await override(db, [
+      { type: 'value', value: 'opt_red' },
+      { type: 'skip', value: '' },
+      { type: 'value', value: 'opt_blue' },
+    ])
+
+    expect(db.captured.values?.resolvedValues).toEqual([
+      { type: 'value', value: ['opt_red', 'opt_blue'] },
+    ])
+  })
+
+  it('keeps a whole-cell skip as an empty list, invalid', async () => {
+    const db = new FakeDb('multiselect:split')
+
+    await override(db, [{ type: 'skip', value: '' }])
+
+    expect(db.captured.values?.resolvedValues).toEqual([])
+    expect(db.captured.values?.isValid).toBe(false)
+  })
+
+  it('still persists a single-select override as one scalar entry', async () => {
+    const db = new FakeDb('select:value')
+
+    await override(db, [{ type: 'value', value: 'opt_red' }])
+
+    expect(db.captured.values?.resolvedValues).toEqual([{ type: 'value', value: 'opt_red' }])
+  })
+
+  it('prefers the resolved entity id over the display value, per element', async () => {
+    const db = new FakeDb('multiselect:split')
+
+    await override(db, [
+      { type: 'value', value: 'Red', id: 'opt_red' },
+      { type: 'value', value: 'Blue' },
+    ])
+
+    expect(db.captured.values?.resolvedValues).toEqual([
+      { type: 'value', value: ['opt_red', 'Blue'] },
+    ])
+  })
+
+  it('round-trips all three options into record data via buildRecordData', async () => {
+    const db = new FakeDb('multiselect:split')
+    const raw = 'Red, Green, Blue'
+
+    await override(db, [
+      { type: 'value', value: 'opt_red' },
+      { type: 'value', value: 'opt_green' },
+      { type: 'value', value: 'opt_blue' },
+    ])
+
+    const resolutions = new Map<string, ValueResolution>([
+      [
+        hashValue(raw),
+        {
+          id: 'res_1',
+          importJobPropertyId: 'jobprop_0',
+          hashedValue: hashValue(raw),
+          rawValue: raw,
+          cellCount: 1,
+          resolvedValues: db.captured.values?.resolvedValues as ResolvedValue[],
+          isValid: true,
+        },
+      ],
+    ])
+
+    const { standardFields } = buildRecordData({ 0: raw }, [mapping({})], resolutions)
+    expect(standardFields.tags).toEqual(['opt_red', 'opt_green', 'opt_blue'])
+  })
+
+  it('round-trips a single-select override into one scalar field value', async () => {
+    const db = new FakeDb('select:value')
+    const raw = 'Red, Green, Blue'
+
+    await override(db, [{ type: 'value', value: 'opt_red' }])
+
+    const resolutions = new Map<string, ValueResolution>([
+      [
+        hashValue(raw),
+        {
+          id: 'res_1',
+          importJobPropertyId: 'jobprop_0',
+          hashedValue: hashValue(raw),
+          rawValue: raw,
+          cellCount: 1,
+          resolvedValues: db.captured.values?.resolvedValues as ResolvedValue[],
+          isValid: true,
+        },
+      ],
+    ])
+
+    const { standardFields } = buildRecordData(
+      { 0: raw },
+      [mapping({ resolutionType: 'select:value', targetFieldKey: 'status' })],
+      resolutions
+    )
+    expect(standardFields.status).toBe('opt_red')
+  })
+})

--- a/packages/lib/src/import/resolution/get-relation-create-counts.ts
+++ b/packages/lib/src/import/resolution/get-relation-create-counts.ts
@@ -2,7 +2,7 @@
 
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import type { RelationCreateRequest, ResolvedValue } from '../types/resolution'
 import { relationCreateKey } from './relation-create-key'
 
@@ -68,7 +68,12 @@ async function loadPendingCreates(db: Database, jobId: string): Promise<PendingC
     .where(
       and(
         eq(schema.ImportJobProperty.importJobId, jobId),
-        eq(schema.ImportValueResolution.status, 'create')
+        eq(schema.ImportValueResolution.status, 'create'),
+        // An overridden row is the user's decided value — never materialize a
+        // create for it. Mirrors `loadPendingSelectCreates`; today the erased
+        // `relationCreate` marker already skips these, but that is incidental
+        // to how the override rewrites `resolvedValues`, not a contract.
+        isNull(schema.ImportValueResolution.userOverride)
       )
     )
 

--- a/packages/lib/src/import/resolution/get-select-create-counts.ts
+++ b/packages/lib/src/import/resolution/get-select-create-counts.ts
@@ -2,7 +2,7 @@
 
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import { findCachedResource } from '../../cache'
 import { mintOrMatchOptions } from '../../custom-fields/mint-options'
 import { canGrowFieldOptions, fieldAllowsNewOptions } from '../../custom-fields/ownership'
@@ -171,7 +171,15 @@ export async function loadPendingSelectCreates(
     .where(
       and(
         eq(schema.ImportJobProperty.importJobId, jobId),
-        eq(schema.ImportValueResolution.status, 'create')
+        eq(schema.ImportValueResolution.status, 'create'),
+        // A user override is a decided value, never a label to mint. Without
+        // this, overriding a will-create value to an existing option leaves
+        // `status: 'create'` behind (updateValueResolution never touches
+        // status) and this loader mints a new option literally named the
+        // chosen option's key — and an overridden RELATION create, whose
+        // `relationCreate` marker the override erased, gets claimed by the
+        // select materializer and rejected into a row error.
+        isNull(schema.ImportValueResolution.userOverride)
       )
     )
 

--- a/packages/lib/src/import/resolution/get-unique-values-with-status.ts
+++ b/packages/lib/src/import/resolution/get-unique-values-with-status.ts
@@ -3,8 +3,15 @@
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { and, count, desc, eq } from 'drizzle-orm'
+import {
+  buildOptionIndex,
+  type FieldOptionItem,
+  resolveOptionId,
+} from '../../resources/registry/option-helpers'
+import { parseResolutionConfig } from '../mapping/resolution-config'
 import type { ColumnFieldConfig, OverrideValue, ResolvedValue } from '../types'
 import type { RelationCreateRequest } from '../types/resolution'
+import { resolveColumnOptions } from './resolve-column-options'
 
 /** Resolution status types */
 export type ResolutionStatus = 'pending' | 'valid' | 'error' | 'warning' | 'create'
@@ -20,6 +27,14 @@ export interface UniqueValueWithResolution {
   originalStatus: ResolutionStatus // From DB, used for grouping
   effectiveStatus: EffectiveStatus // Derived from override, used for display
   resolvedValue: string | null
+  /**
+   * The display label(s) behind `resolvedValue` for `select:`/`multiselect:`
+   * columns, resolved against the LIVE option list (multi values joined with
+   * `, `). Null for non-option columns and when no part of the value matches an
+   * option — a pending option create resolves to null on purpose, its
+   * `resolvedValue` is the label to be minted, not a key.
+   */
+  resolvedLabel: string | null
   resolvedValues: ResolvedValue[]
   errorMessage: string | null
   isOverridden: boolean
@@ -68,20 +83,25 @@ function extractRelationCreate(resolvedValues: ResolvedValue[]): RelationCreateR
 /**
  * Build field config from mapping property.
  */
-function buildFieldConfig(mappingProp: {
-  targetFieldKey: string | null
-  resolutionType: string
-  resolutionConfig: unknown
-}): ColumnFieldConfig | null {
+function buildFieldConfig(
+  mappingProp: {
+    targetFieldKey: string | null
+    customFieldId: string | null
+    resolutionType: string
+    resolutionConfig: unknown
+  },
+  entityDefinitionId: string
+): ColumnFieldConfig | null {
   if (!mappingProp.targetFieldKey) return null
 
-  const resolutionConfig = mappingProp.resolutionConfig as {
-    options?: Array<{ value: string; label: string }>
-    relationConfig?: {
-      relatedEntityDefinitionId: string
-      relationshipType: 'belongs_to' | 'has_one' | 'has_many' | 'many_to_many'
-    }
-  } | null
+  // `resolutionConfig` is a JSON STRING column (`text()`), like every other
+  // consumer parses it (resolve-values-job, save-mapping-property,
+  // execute-plan-job). Casting the string made `options`/`relationConfig`
+  // permanently undefined, which left the review step's option picker dead
+  // code and every resolved select value rendering as its raw option key.
+  const resolutionConfig = parseResolutionConfig(
+    mappingProp.resolutionConfig as string | null | undefined
+  )
 
   // Derive base type from resolution type
   const resolutionType = mappingProp.resolutionType
@@ -102,9 +122,36 @@ function buildFieldConfig(mappingProp: {
     key: mappingProp.targetFieldKey,
     type,
     resolutionType,
+    customFieldId: mappingProp.customFieldId,
+    entityDefinitionId,
     options: resolutionConfig?.options,
     relationConfig: resolutionConfig?.relationConfig,
   }
+}
+
+/** Whether a column resolves against a select-ish option list. */
+function isOptionColumn(resolutionType: string): boolean {
+  return resolutionType.startsWith('select:') || resolutionType.startsWith('multiselect:')
+}
+
+/**
+ * Resolve an option column's stored key(s) to display label(s).
+ *
+ * `resolvedValue` is comma-joined for multiselect columns (option keys are
+ * nanoids and never contain commas). Null when nothing matches: a pending
+ * option create's `resolvedValue` is the label to be minted, not a key, and
+ * lands here as null by design.
+ */
+function resolveLabel(
+  resolvedValue: string | null,
+  optionIndex: Map<string, FieldOptionItem> | null
+): string | null {
+  if (!optionIndex || !resolvedValue) return null
+  const parts = resolvedValue.split(',').filter(Boolean)
+  if (parts.length === 0) return null
+  const resolved = parts.map((part) => resolveOptionId(part, optionIndex))
+  if (resolved.every((r) => r.status === 'unknown')) return null
+  return resolved.map((r) => (r.status === 'known' ? r.label : r.raw)).join(', ')
 }
 
 /**
@@ -146,21 +193,34 @@ function deriveEffectiveStatus(
   return 'valid'
 }
 
+/** Parameters for {@link getUniqueValuesWithResolution} */
+export interface GetUniqueValuesParams {
+  jobId: string
+  mappingId: string
+  columnIndex: number
+  /** `ImportMapping.organizationId` — scope for the live option lookup */
+  organizationId: string
+  /** `ImportMapping.entityDefinitionId` — the resource the column targets */
+  entityDefinitionId: string
+}
+
 /**
  * Get unique values for a column with their resolution status.
  *
+ * For select-ish columns the returned `fieldConfig.options` is the LIVE option
+ * list (the stored snapshot is client-asserted and never refreshed — same rule
+ * as `resolve-values-job`), and each value carries a `resolvedLabel` resolved
+ * against that list.
+ *
  * @param db - Database instance
- * @param jobId - Import job ID
- * @param mappingId - Import mapping ID
- * @param columnIndex - Column index
+ * @param params - Job, mapping, column, and org/def scope
  * @returns Unique values with resolution info and field config
  */
 export async function getUniqueValuesWithResolution(
   db: Database,
-  jobId: string,
-  mappingId: string,
-  columnIndex: number
+  params: GetUniqueValuesParams
 ): Promise<UniqueValuesWithFieldConfig> {
+  const { jobId, mappingId, columnIndex, organizationId, entityDefinitionId } = params
   // Get unique values with counts using SQL GROUP BY
   const uniqueValues = await db
     .select({
@@ -197,6 +257,7 @@ export async function getUniqueValuesWithResolution(
         originalStatus: 'pending' as ResolutionStatus,
         effectiveStatus: 'pending' as EffectiveStatus,
         resolvedValue: null,
+        resolvedLabel: null,
         resolvedValues: [],
         errorMessage: null,
         isOverridden: false,
@@ -206,7 +267,22 @@ export async function getUniqueValuesWithResolution(
   }
 
   // Build field config from mapping property
-  const fieldConfig = buildFieldConfig(mappingProp)
+  const fieldConfig = buildFieldConfig(mappingProp, entityDefinitionId)
+
+  // Overlay the LIVE option list for select-ish columns, same rule as
+  // `resolve-values-job`: the live list WINS, the stored snapshot only stands
+  // in for a field that has since vanished.
+  let optionIndex: Map<string, FieldOptionItem> | null = null
+  if (fieldConfig && isOptionColumn(fieldConfig.resolutionType)) {
+    const liveOptions = await resolveColumnOptions({
+      organizationId,
+      entityDefinitionId,
+      targetFieldKeys: [fieldConfig.key],
+    })
+    const live = liveOptions.get(fieldConfig.key)
+    if (live) fieldConfig.options = live
+    optionIndex = buildOptionIndex(fieldConfig.options ?? [])
+  }
 
   // Get job property
   const jobProp = await db.query.ImportJobProperty.findFirst({
@@ -260,6 +336,7 @@ export async function getUniqueValuesWithResolution(
       const originalStatus = (resolution?.status ?? 'pending') as ResolutionStatus
       const isOverridden = resolution?.isOverridden ?? false
       const overrideValues = resolution?.overrideValues ?? null
+      const resolvedValue = resolution?.resolvedValue ?? null
 
       return {
         hash: uv.valueHash,
@@ -267,7 +344,8 @@ export async function getUniqueValuesWithResolution(
         count: Number(uv.count),
         originalStatus,
         effectiveStatus: deriveEffectiveStatus(originalStatus, isOverridden, overrideValues),
-        resolvedValue: resolution?.resolvedValue ?? null,
+        resolvedValue,
+        resolvedLabel: resolveLabel(resolvedValue, optionIndex),
         resolvedValues: resolution?.resolvedValues ?? [],
         errorMessage: resolution?.errorMessage ?? null,
         isOverridden,

--- a/packages/lib/src/import/resolution/update-value-resolution.ts
+++ b/packages/lib/src/import/resolution/update-value-resolution.ts
@@ -119,11 +119,21 @@ export async function updateValueResolution(
   // never reaches the persisted jsonb — the whole-cell skip above already emptied
   // the list, and a `skip` mixed in behind a non-skip first entry is dropped here
   // rather than written out as an unknown `type`.
+  const overrides = input.overrideValues.filter(
+    (ov): ov is OverrideValue & { type: 'value' | 'create' } => ov.type !== 'skip'
+  )
+
+  // A multi-valued column MUST persist the resolver's native shape: ONE entry
+  // whose `value` is the array of option keys (see `resolveMultiselectSplit`).
+  // Every executor reads `resolvedValues[0]` only — N separate entries would
+  // import exactly the first option and silently drop the rest.
+  const isMultiValued = mappingProp.resolutionType.startsWith('multiselect:')
+
   const resolvedValues: ResolvedValue[] = isSkip
     ? [] // Empty for skip
-    : input.overrideValues.flatMap((ov) =>
-        ov.type === 'skip' ? [] : [{ type: ov.type, value: ov.id ?? ov.value }]
-      )
+    : isMultiValued
+      ? [{ type: 'value', value: overrides.map((ov) => ov.id ?? ov.value) }]
+      : overrides.map((ov) => ({ type: ov.type, value: ov.id ?? ov.value }))
 
   // Store original values for revert (only if not already overridden)
   const existingOverride = existingResolution?.userOverride as UserOverrideData | null

--- a/packages/lib/src/import/types/resolution.ts
+++ b/packages/lib/src/import/types/resolution.ts
@@ -197,6 +197,10 @@ export interface ColumnFieldConfig {
   key: string
   type: string // BaseType: 'text', 'number', 'enum', 'relationship', etc.
   resolutionType: string // e.g., 'select:value', 'relation:match'
+  /** `ImportMappingProperty.customFieldId` — null for system fields */
+  customFieldId?: string | null
+  /** `ImportMapping.entityDefinitionId` — the resource this column targets */
+  entityDefinitionId?: string
   options?: SelectOption[]
   relationConfig?: {
     relatedEntityDefinitionId: string


### PR DESCRIPTION
Fixes the two bugs reported while testing today's parts imports, plus four defects found underneath them by the investigation agents. Verified live on import job `gcm6l0…`: the Category column now renders **Steel 28 rows → [Steel]** option chips with a real picker — no more raw `LveU1F6DK8AOiFZe56li3` nanoids.

## 1. Minted options never reached open clients (the "categories are all bad" bug)
`mintOrMatchOptions` busted the org cache but published nothing, so after an import created options every open tab kept the pre-mint vocabulary and rendered the fresh optionIds as muted unknown chips until refresh. It now calls `notifyCustomFieldChanged` — cache bust + `resource:updated` broadcast in the one chokepoint every human option-mutation already uses. **Once per grown field per import** (the importer batches all labels into one call), never per option. Fixes AI autofill tag minting too (same writer, same missing broadcast).

## 2. Review-values rendered raw option keys
`getUniqueValuesWithResolution` cast the JSON-**string** `resolutionConfig` column instead of parsing it, so `fieldConfig.options` was always `undefined` — the enum-picker branch has been dead code since inception, and every select value fell through to a textbox showing `resolvedValue` (post-#1869: a minted nanoid). Now:
- payload overlays the **live** option list via `resolveColumnOptions` (wins over the mapping-time zod-stripped snapshot) + `customFieldId`/`entityDefinitionId`/per-value `resolvedLabel`
- labels render via `TagsView`; editing goes through `FieldInputAdapter` keyed by the field's **real** fieldType (single/multi/tags), with option creation disabled — the import's `select:create` is the only minter, per the #1871 cascade-delete lesson
- create-status values get a generalized `ValueCreateBadge` (`relation` | `option`) instead of looking identical to matched values
- editor state resyncs after Revert/re-resolve (virtual rows recycle by hash)

## 3. Override guards (taxonomy corruption)
The select-create materializer selected on `status='create'` ignoring `userOverride` — overriding a will-create value to an existing option **minted a new option literally named that option's key**; an overridden relation-create (marker erased by the override) got claimed by the select materializer and errored. Both loaders now skip overridden rows.

## 4. Multi-value overrides truncated
`updateValueResolution` expanded N override values into N `resolvedValues` entries but `buildRecordData` reads only `[0]` — a 3-option multiselect override imported one. The writer now emits the multiselect resolver's native shape (one entry, array value), verified against every `resolvedValues` reader in the codebase.

## 5. MultiSelectPicker keyspace
Selection compared on `opt.value` only — an id-keyspace stored value rendered unchecked, and selecting silently switched keyspace. Membership now folds incoming values onto canonical `optionKey` (`id ?? value`) via `buildOptionIndex`, writes canonical keys; all 16 consumers audited — those minting `value`-only options are provably unchanged. `SelectInputField`'s value-only initializer had the same bug and could erase id-keyed selections on the next debounced commit; also removed its stray `console.log`.

## Tests
- 704 packages/lib tests (import, custom-fields, field-values, bom) + 45 picker tests green
- New: `update-value-resolution.test.ts` (7 tests incl. 3-option override → all 3 keys in record data)
- Both scoped typechecks clean in touched files
- Live-verified in the browser: labels, picker, and endpoint payload