### PR TITLE
fix(import): clearing a review value skips it, and the picker stops offering manage and clear

### DIFF
--- a/apps/web/src/components/data-import/value-review/editing-input.tsx
+++ b/apps/web/src/components/data-import/value-review/editing-input.tsx
@@ -130,8 +130,12 @@ export function EditingInput({
 
   /**
    * Option selection change — saves immediately with the FULL key array
-   * (single select writes one key, multi writes all). Clearing the selection
-   * or re-picking exactly the resolver's answer reverts to it.
+   * (single select writes one key, multi writes all). Re-picking exactly the
+   * resolver's answer reverts to it; clearing the selection (the trigger's ×,
+   * or unchecking the last option) skips the value — "import nothing for this
+   * cell", the same override the row's skip button writes. The old empty-case
+   * only acted when already overridden, so clearing a resolver-matched value
+   * silently did nothing.
    */
   const handleOptionChange = (next: unknown) => {
     const keys = Array.isArray(next)
@@ -140,7 +144,13 @@ export function EditingInput({
         ? [next]
         : []
 
-    if (keys.length === 0 || sameKeys(keys, autoKeys)) {
+    if (keys.length === 0) {
+      // Nothing was selected and nothing is cleared — a no-op, not a skip.
+      if (autoKeys.length === 0 && !isOverridden) return
+      onSave([{ type: 'skip', value: '' }])
+      return
+    }
+    if (sameKeys(keys, autoKeys)) {
       if (isOverridden) onSave(null)
       return
     }
@@ -159,9 +169,14 @@ export function EditingInput({
           onChange={handleOptionChange}
           placeholder='Select value...'
           // Overrides must reference existing option keys; minting happens via
-          // the import's own select-create path, so the picker never creates.
+          // the import's own select-create path, so the picker never creates —
+          // and never manages (renaming/deleting an option here would edit the
+          // org-wide taxonomy from an import screen).
           canAdd={false}
-          triggerProps={{ className: 'h-7' }}
+          canManage={false}
+          // No trigger ×: skipping a value has its own row control; deselecting
+          // everything in the picker still skips.
+          triggerProps={{ className: 'h-7', showClear: false }}
         />
       </div>
     )

--- a/apps/web/src/components/fields/inputs/field-input-adapter.tsx
+++ b/apps/web/src/components/fields/inputs/field-input-adapter.tsx
@@ -106,6 +106,14 @@ export interface FieldInputAdapterProps {
    */
   canAdd?: boolean
   /**
+   * Override `canManage` on select fields — hides the picker's manage mode
+   * (rename/recolor/delete options). Contexts that only PICK among options
+   * (e.g. the import value-review editor) set `false`: deleting an option
+   * there would cascade-delete its stored values org-wide. Defaults to the
+   * field type's `getSelectConfig`.
+   */
+  canManage?: boolean
+  /**
    * When a created select value should be the typed text rather than a UUID
    * (free-text identifier fields). Forwarded to `SelectFieldInput`.
    */
@@ -152,6 +160,7 @@ export function FieldInputAdapter({
   resourceFieldId,
   allowMultiple,
   canAdd,
+  canManage,
   useValueAsLabel,
   triggerProps,
   open,
@@ -354,6 +363,7 @@ export function FieldInputAdapter({
         ...baseConfig,
         ...(allowMultiple !== undefined ? { multi: allowMultiple } : {}),
         ...(canAdd !== undefined ? { canAdd } : {}),
+        ...(canManage !== undefined ? { canManage } : {}),
       }
 
       const selectedValues = Array.isArray(value) ? value : value ? [value] : []

--- a/apps/web/src/components/kb/ui/settings/general/identity-section.tsx
+++ b/apps/web/src/components/kb/ui/settings/general/identity-section.tsx
@@ -17,9 +17,9 @@ import {
 
 /** Mirrors the publish dialog's three-way access choice. Display only. */
 const ACCESS_LABEL = {
-  public: 'Public — anyone can read it',
-  unlisted: 'Unlisted — direct link only',
-  internal: 'Internal — sign-in required',
+  public: 'Public (anyone can read it)',
+  unlisted: 'Unlisted (direct link only)',
+  internal: 'Internal (sign-in required)',
 } as const
 
 interface IdentitySectionProps {


### PR DESCRIPTION
Follow-ups from live testing #1873 on the review-values step:

- **Deselecting a matched value did nothing.** `handleOptionChange`'s empty case only acted when the value was already overridden, so unchecking a resolver-matched option silently no-opped and the picker snapped back to checked. An empty selection now saves the same `{type: 'skip'}` override the row's skip button writes — "import nothing for this cell", visible in the Skipped group and revertible.
- **The trigger's clear × is hidden** (`triggerProps.showClear: false`) — skip has its own row control, and a one-click × that silently skips 28 rows invited accidents.
- **`FieldInputAdapter` gains a `canManage` override** (symmetric with the existing `canAdd`), and the review editor sets it `false`: TAGS fields default to manage-enabled, which offered renaming/deleting org-wide options — including the cascade-delete of a removed option's stored values — from an import screen.

User-verified live on job `gcm6l0…`.