### PR TITLE
fix(import): match composite identifiers whose legs are relations

### DIFF
--- a/packages/lib/src/import/__tests__/analyze-row.test.ts
+++ b/packages/lib/src/import/__tests__/analyze-row.test.ts
@@ -440,3 +440,142 @@ describe('analyzeRow, update mode never creates', () => {
     expect(result.strategy).toBe('unmatched')
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * A relation identifier leg must be matched on its RESOLVED record id, never on
+ * the raw cell.
+ *
+ * `(part, supplier)` on `vendor_part` is two relation legs, so this is the whole
+ * natural key, not an edge of it. The raw cell says `Acme Corp`; the resolver
+ * turns it into a record id; the stored value is a `relatedEntityId`. Passing
+ * the cell text compares a company NAME against an id column, which can never
+ * match — and the miss is silent, classifying the row `create` and writing the
+ * duplicate the key exists to prevent.
+ */
+describe('analyzeRow, relation identifier legs use the resolved id', () => {
+  const relationMappings = [
+    mapping({
+      id: 'p-part',
+      sourceColumnIndex: 0,
+      sourceColumnName: 'Part',
+      targetFieldKey: 'part',
+      resolutionType: 'relation:match',
+    }),
+    mapping({
+      id: 'p-supplier',
+      sourceColumnIndex: 1,
+      sourceColumnName: 'Supplier',
+      targetFieldKey: 'supplier',
+      resolutionType: 'relation:match',
+    }),
+  ]
+
+  const resolutionsFor = (
+    partCell: string,
+    partId: string | null,
+    supplierCell: string,
+    supplierId: string | null
+  ) =>
+    new Map([
+      [hashValue(partCell), resolution(partCell, { type: 'value', value: partId })],
+      [hashValue(supplierCell), resolution(supplierCell, { type: 'value', value: supplierId })],
+    ])
+
+  it('passes resolved record ids, not the raw cells', async () => {
+    const seen: Array<Record<string, string>> = []
+    const result = await analyzeRow(
+      0,
+      { 0: 'M400L', 1: 'Acme Corp' },
+      {
+        mappings: relationMappings,
+        resolutions: resolutionsFor('M400L', 'part-1', 'Acme Corp', 'company-1'),
+        identifierFieldKeys: ['part', 'supplier'],
+        findExistingRecord: async (v) => {
+          seen.push(v)
+          return { kind: 'one', recordId: 'vp-1' }
+        },
+      }
+    )
+
+    expect(seen).toEqual([{ part: 'part-1', supplier: 'company-1' }])
+    expect(result.strategy).toBe('update')
+    expect(result.existingRecordId).toBe('vp-1')
+  })
+
+  // `onNoMatch: 'blank'` and `relation:create` both resolve to null. The leg is
+  // genuinely absent, so the tuple is incomplete and no lookup is issued — the
+  // raw cell must NOT be substituted back in to make it look complete.
+  it('treats a leg that resolved to null as absent, not as the raw cell', async () => {
+    const findExistingRecord = vi.fn(
+      (_values: Record<string, string>): FindExistingRecordResult => ({
+        kind: 'one',
+        recordId: 'vp-1',
+      })
+    )
+    const result = await analyzeRow(
+      0,
+      { 0: 'M400L', 1: 'Unknown Supplier' },
+      {
+        mappings: relationMappings,
+        resolutions: resolutionsFor('M400L', 'part-1', 'Unknown Supplier', null),
+        identifierFieldKeys: ['part', 'supplier'],
+        findExistingRecord: async (v) => findExistingRecord(v),
+      }
+    )
+
+    expect(findExistingRecord).not.toHaveBeenCalled()
+    expect(result.strategy).toBe('create')
+  })
+
+  // The in-file duplicate guard has to key on the resolved ids too, or two
+  // spellings of one supplier read as two different suppliers.
+  it('keys the in-file duplicate guard on the resolved ids', async () => {
+    const shared = {
+      mappings: relationMappings,
+      resolutions: new Map([
+        ...resolutionsFor('M400L', 'part-1', 'Acme Corp', 'company-1'),
+        ...resolutionsFor('M400L', 'part-1', 'ACME CORP.', 'company-1'),
+      ]),
+      identifierFieldKeys: ['part', 'supplier'],
+      findExistingRecord: async (): Promise<FindExistingRecordResult> => ({ kind: 'none' }),
+      seenIdentifiers: new Map<string, number>(),
+    }
+
+    const first = await analyzeRow(0, { 0: 'M400L', 1: 'Acme Corp' }, shared)
+    const second = await analyzeRow(1, { 0: 'M400L', 1: 'ACME CORP.' }, shared)
+
+    expect(first.errors).toEqual([])
+    expect(second.errors.join(' ')).toContain('repeats row 1')
+  })
+
+  // A scalar leg keeps reading the raw cell. Pinned so the relation branch can
+  // never quietly capture the path `part_sku` has always taken.
+  it('leaves a non-relation leg on the raw cell', async () => {
+    const seen: Array<Record<string, string>> = []
+    await analyzeRow(
+      0,
+      { 0: '  M400L  ' },
+      {
+        mappings: [
+          mapping({
+            id: 'p-sku',
+            sourceColumnIndex: 0,
+            sourceColumnName: 'SKU',
+            targetFieldKey: 'part_sku',
+            resolutionType: 'text:value',
+          }),
+        ],
+        resolutions: new Map(),
+        identifierFieldKeys: ['part_sku'],
+        findExistingRecord: async (v) => {
+          seen.push(v)
+          return { kind: 'none' }
+        },
+      }
+    )
+
+    expect(seen).toEqual([{ part_sku: 'M400L' }])
+  })
+})

--- a/packages/lib/src/import/planning/__tests__/find-existing-record.int.test.ts
+++ b/packages/lib/src/import/planning/__tests__/find-existing-record.int.test.ts
@@ -326,3 +326,214 @@ describe('createFindExistingRecord, Record ID on an entity-backed resource', () 
     await expect(findById(id)).resolves.toEqual({ kind: 'none' })
   })
 })
+
+/**
+ * The composite key that `vendor_part` actually has: `(part, contact)`, TWO
+ * RELATION legs and not one scalar among them.
+ *
+ * This is the shape the declared natural key rests on, and it is the one the
+ * composite tests above never covered — they run on a system table where every
+ * leg is a plain column. A relation leg is stored in `FieldValue.relatedEntityId`
+ * and reaches the lookup core through `createTypedValueInput`, which accepts a
+ * relationship value ONLY as a prefixed `defId:instanceId` RecordId. A bare
+ * instance id parses to `entityInstanceId: ''`, the candidate is refused, and
+ * AND-mode returns an empty result — a silent "no match" that classifies the row
+ * `create` and writes the duplicate the natural key exists to prevent.
+ *
+ * Both accepted spellings are pinned, so the normalization can never quietly
+ * regress to accepting only one of them.
+ */
+describe('createFindExistingRecord, composite RELATION key on an entity-backed resource', () => {
+  let organizationId: string
+  let vendorPartDefId: string
+  let partDefId: string
+  let companyDefId: string
+  let partFieldId: string
+  let contactFieldId: string
+  let db: ReturnType<typeof getTestDb>
+
+  const seedDef = async (slug: string): Promise<string> => {
+    const id = generateId()
+    await db.insert(schema.EntityDefinition).values({
+      id,
+      organizationId,
+      apiSlug: slug,
+      singular: slug,
+      plural: `${slug}s`,
+      updatedAt: new Date(),
+    } as typeof schema.EntityDefinition.$inferInsert)
+    return id
+  }
+
+  const seedRelationField = async (name: string, targetDefId: string): Promise<string> => {
+    const id = generateId()
+    await db.insert(schema.CustomField).values({
+      id,
+      organizationId,
+      entityDefinitionId: vendorPartDefId,
+      name,
+      type: 'RELATIONSHIP',
+      modelType: 'vendor_part',
+      relatedEntityDefinitionId: targetDefId,
+      updatedAt: new Date(),
+    } as typeof schema.CustomField.$inferInsert)
+    return id
+  }
+
+  const seedInstance = async (defId: string): Promise<string> => {
+    const id = generateId()
+    await db.insert(schema.EntityInstance).values({
+      id,
+      organizationId,
+      entityDefinitionId: defId,
+      updatedAt: new Date(),
+    } as typeof schema.EntityInstance.$inferInsert)
+    return id
+  }
+
+  /** One vendor_part linked to `partId` and `companyId`. */
+  const seedVendorPart = async (partId: string, companyId: string): Promise<string> => {
+    const instanceId = await seedInstance(vendorPartDefId)
+    for (const [fieldId, relatedId, relatedDefId] of [
+      [partFieldId, partId, partDefId],
+      [contactFieldId, companyId, companyDefId],
+    ] as const) {
+      await db.insert(schema.FieldValue).values({
+        id: generateId(),
+        organizationId,
+        fieldId,
+        entityId: instanceId,
+        entityDefinitionId: vendorPartDefId,
+        relatedEntityId: relatedId,
+        relatedEntityDefinitionId: relatedDefId,
+        updatedAt: new Date(),
+      } as typeof schema.FieldValue.$inferInsert)
+    }
+    return instanceId
+  }
+
+  /**
+   * `relationship.inverseResourceFieldId` is `targetDefId:inverseFieldId`, and its
+   * FIRST half is the only way the identifier lane can learn what a relation leg
+   * points at. Omit it and `toLookupValue` throws rather than quietly no-matching.
+   */
+  const relationField = (id: string, key: string, targetDefId: string): ResourceField =>
+    ({
+      id,
+      key,
+      type: BaseType.RELATION,
+      relationship: {
+        inverseResourceFieldId: `${targetDefId}:${generateId()}`,
+        relationshipType: 'has_many',
+        isInverse: false,
+      },
+    }) as unknown as ResourceField
+
+  const findPair = (partValue: string, contactValue: string) =>
+    createFindExistingRecord({
+      db: db as never,
+      organizationId,
+      resource: {
+        id: 'vendor_part',
+        type: 'custom',
+        entityDefinitionId: vendorPartDefId,
+      } as unknown as Resource,
+      identifierFields: [
+        relationField(partFieldId, 'part', partDefId),
+        relationField(contactFieldId, 'contact', companyDefId),
+      ],
+    })({ part: partValue, contact: contactValue })
+
+  beforeEach(async () => {
+    db = getTestDb()
+    const org = await createTestOrganization()
+    organizationId = org.id
+    vendorPartDefId = await seedDef('vendor-part')
+    partDefId = await seedDef('part')
+    companyDefId = await seedDef('company')
+    partFieldId = await seedRelationField('Part', partDefId)
+    contactFieldId = await seedRelationField('Supplier', companyDefId)
+  })
+
+  // THE REGRESSION. `resolve-relation-lookups` resolves a supplier cell to a BARE
+  // instance id, and that is what the identifier tuple carries. Before the fix
+  // this returned `{ kind: 'none' }` for a pair that plainly exists.
+  it('matches a (part, supplier) pair given BARE instance ids', async () => {
+    const partId = await seedInstance(partDefId)
+    const companyId = await seedInstance(companyDefId)
+    const vendorPartId = await seedVendorPart(partId, companyId)
+
+    await expect(findPair(partId, companyId)).resolves.toEqual({
+      kind: 'one',
+      recordId: vendorPartId,
+    })
+  })
+
+  it('matches the same pair given PREFIXED record ids', async () => {
+    const partId = await seedInstance(partDefId)
+    const companyId = await seedInstance(companyDefId)
+    const vendorPartId = await seedVendorPart(partId, companyId)
+
+    await expect(
+      findPair(`${partDefId}:${partId}`, `${companyDefId}:${companyId}`)
+    ).resolves.toEqual({ kind: 'one', recordId: vendorPartId })
+  })
+
+  // The property that makes it a composite key rather than a widened one. A
+  // supplier's whole price list shares one `contact` leg, so matching on that
+  // alone would update an arbitrary line of it.
+  it('does NOT match a vendor_part that satisfies only one leg', async () => {
+    const partId = await seedInstance(partDefId)
+    const otherPartId = await seedInstance(partDefId)
+    const companyId = await seedInstance(companyDefId)
+    const otherCompanyId = await seedInstance(companyDefId)
+    await seedVendorPart(partId, companyId)
+
+    await expect(findPair(partId, otherCompanyId)).resolves.toEqual({ kind: 'none' })
+    await expect(findPair(otherPartId, companyId)).resolves.toEqual({ kind: 'none' })
+  })
+
+  // Two price-list lines for the same part from the same supplier is the state a
+  // natural key is supposed to make impossible; if it already exists, the import
+  // must say so rather than pick one.
+  it('reports ambiguity when two rows share the pair', async () => {
+    const partId = await seedInstance(partDefId)
+    const companyId = await seedInstance(companyDefId)
+    await seedVendorPart(partId, companyId)
+    await seedVendorPart(partId, companyId)
+
+    await expect(findPair(partId, companyId)).resolves.toEqual({ kind: 'ambiguous', count: 2 })
+  })
+
+  it('never partially matches when a leg is blank', async () => {
+    const partId = await seedInstance(partDefId)
+    const companyId = await seedInstance(companyDefId)
+    await seedVendorPart(partId, companyId)
+
+    await expect(findPair(partId, '')).resolves.toEqual({ kind: 'none' })
+  })
+
+  // A relation leg whose target cannot be resolved is a STRUCTURAL failure, and
+  // `analyzeRow` turns a throw into a row error. Answering `none` would classify
+  // the row `create` and write the duplicate silently — the same fail-open the
+  // lookup-core rethrow above exists to prevent.
+  it('throws rather than answering "no match" when a leg has no resolvable target', async () => {
+    const partId = await seedInstance(partDefId)
+    const companyId = await seedInstance(companyDefId)
+    await seedVendorPart(partId, companyId)
+
+    const brokenLeg = { id: partFieldId, key: 'part', type: BaseType.RELATION } as ResourceField
+    const find = createFindExistingRecord({
+      db: db as never,
+      organizationId,
+      resource: {
+        id: 'vendor_part',
+        type: 'custom',
+        entityDefinitionId: vendorPartDefId,
+      } as unknown as Resource,
+      identifierFields: [brokenLeg],
+    })
+
+    await expect(find({ part: partId })).rejects.toThrow(/no resolvable target/)
+  })
+})

--- a/packages/lib/src/import/planning/analyze-row.ts
+++ b/packages/lib/src/import/planning/analyze-row.ts
@@ -76,6 +76,7 @@ export async function analyzeRow(
   const mode: ImportStrategyMode = ctx.mode ?? 'create-or-update'
   const identifierKeys = ctx.identifierFieldKeys ?? []
   const identifierRawByKey = new Map<string, string>()
+  const substitutedIdentifierKeys = new Set<string>()
 
   // Process each mapped column
   for (const mapping of ctx.mappings) {
@@ -91,6 +92,9 @@ export async function analyzeRow(
     // Check if this column carries (part of) the identifier
     if (identifierKeys.includes(mapping.targetFieldKey)) {
       identifierRawByKey.set(mapping.targetFieldKey, rawValue.trim())
+      if (isSubstitutingResolution(mapping.resolutionType)) {
+        substitutedIdentifierKeys.add(mapping.targetFieldKey)
+      }
     }
 
     // Look up resolution for this value
@@ -148,7 +152,12 @@ export async function analyzeRow(
   const consultIdentifier = mode !== 'create' && identifierKeys.length > 0
 
   if (consultIdentifier) {
-    const valueSets = collectIdentifierValues(identifierKeys, identifierRawByKey, resolvedData)
+    const valueSets = collectIdentifierValues(
+      identifierKeys,
+      identifierRawByKey,
+      resolvedData,
+      substitutedIdentifierKeys
+    )
     const complete = identifierKeys.every((key) => (valueSets.get(key)?.length ?? 0) > 0)
 
     // In-file duplicates are a row error on the LATER row, regardless of
@@ -243,13 +252,40 @@ export async function analyzeRow(
 }
 
 /**
+ * Resolution types that REPLACE the cell with a different token rather than
+ * merely normalizing it.
+ *
+ * For every other type the raw cell and the resolved value are the same string
+ * modulo normalization, and the lookup re-normalizes anyway (`normalizeForLookup`
+ * mirrors the write path), so the raw cell matches. A relation column is the
+ * exception: the cell says `Acme Corp` and the resolver turns it into a record
+ * id. Matching on the raw cell there compares a company NAME against a
+ * `relatedEntityId` column and can never hit — silently, as a `create`.
+ *
+ * `select:*` transforms the same way (label → optionId) but is not eligible to
+ * be an identifier at all (`ELIGIBLE_IDENTIFIER_TYPES`), so it cannot arrive
+ * here; listing it would imply a path that does not exist.
+ */
+function isSubstitutingResolution(resolutionType: string | null | undefined): boolean {
+  return typeof resolutionType === 'string' && resolutionType.startsWith('relation:')
+}
+
+/**
  * Identifier values to match, per identifier field: a split resolution yields
- * an array (match-ANY); a scalar identifier keeps the raw trimmed cell.
+ * an array (match-ANY); a scalar identifier keeps the raw trimmed cell, EXCEPT
+ * where the resolver substituted a different token for it.
+ *
+ * @param identifierKeys - Ordered match-key field keys
+ * @param rawByKey - Trimmed raw cell per identifier key
+ * @param resolvedData - The row's resolved values, keyed by target field key
+ * @param substitutedKeys - Keys whose resolver replaced the cell (relations),
+ *   for which the raw cell is not a candidate value at all
  */
 function collectIdentifierValues(
   identifierKeys: string[],
   rawByKey: Map<string, string>,
-  resolvedData: Record<string, unknown>
+  resolvedData: Record<string, unknown>,
+  substitutedKeys: ReadonlySet<string>
 ): IdentifierValueSets {
   const sets: IdentifierValueSets = new Map()
   for (const key of identifierKeys) {
@@ -259,6 +295,14 @@ function collectIdentifierValues(
         key,
         resolved.filter((v): v is string => typeof v === 'string' && v.length > 0)
       )
+    } else if (substitutedKeys.has(key)) {
+      // No raw fallback, deliberately. A relation that resolved to null is a
+      // deliberate absence (`onNoMatch: 'blank'`, or a `relation:create` whose
+      // record is not minted until execution), and putting the cell text back
+      // would hand the lookup a value that cannot match while making the tuple
+      // look COMPLETE — which is worse than an incomplete tuple, because a
+      // complete-looking tuple suppresses nothing and just answers `none`.
+      sets.set(key, typeof resolved === 'string' && resolved.length > 0 ? [resolved] : [])
     } else {
       const raw = rawByKey.get(key)
       sets.set(key, raw ? [raw] : [])

--- a/packages/lib/src/import/planning/find-existing-record.ts
+++ b/packages/lib/src/import/planning/find-existing-record.ts
@@ -3,6 +3,7 @@
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
+import { getRelatedEntityDefinitionId, type RelationshipConfig } from '@auxx/types/custom-field'
 import { and, eq, isNull, sql } from 'drizzle-orm'
 import type { PgTableWithColumns } from 'drizzle-orm/pg-core'
 import type { Resource, ResourceField } from '../../resources'
@@ -12,8 +13,12 @@ import {
   lookupEntitiesByFieldValue,
 } from '../../resources/lookup/lookup-entities-by-field-value'
 import { getFieldOutputKey } from '../../resources/registry/field-types'
-import { parseRecordId } from '../../resources/resource-id'
-import type { BaseType } from '../../workflow-engine/core/types'
+import { isRecordId, parseRecordId, toRecordId } from '../../resources/resource-id'
+// Value import (the enum, not just its type) — `toLookupValue` compares against
+// `BaseType.RELATION`. Taken from `resources/types`, which is where the rest of
+// `import/` reaches for it (`fields/identifier-eligibility.ts`), rather than
+// reaching into `workflow-engine/core` directly.
+import { BaseType } from '../../resources/types'
 import { RELATION_MATCH_TEXT_TYPES } from '../resolution/relation-match-types'
 
 const logger = createScopedLogger('find-existing-record')
@@ -260,6 +265,50 @@ export function stripRecordIdPrefix(value: string): string {
 }
 
 /**
+ * Shape one identifier value the way the lookup core insists on receiving it.
+ *
+ * Only RELATION legs need this, and they need it absolutely.
+ * `createTypedValueInput` accepts a relationship value ONLY as a prefixed
+ * `defId:instanceId` RecordId (`isRecordId` is a bare `includes(':')` check); a
+ * plain instance id is refused, `buildLookupCondition` returns null, and AND-mode
+ * answers with an EMPTY result. That is a silent "no match" on a pair that
+ * exists, so the row is classified `create` and the importer writes the very
+ * duplicate a `(part, supplier)` natural key exists to prevent.
+ *
+ * The importer always arrives with the bare form: `resolve-relation-lookups`
+ * resolves a supplier cell through `queryRecordsByField`, which projects
+ * `id: FieldValue.entityId` — an instance id with no prefix.
+ *
+ * The prefix is not decoration even though `typedColumnMatch` currently discards
+ * it (it compares `relatedEntityId` alone). Deriving the real target definition
+ * keeps the value honest if that comparison ever widens to include
+ * `relatedEntityDefinitionId`, and costs one field read.
+ *
+ * @param field - The identifier leg's merged registry field
+ * @param value - The resolved cell value for this leg
+ * @returns The value in the form the lookup core can coerce
+ * @throws When a RELATION leg's target definition cannot be resolved — a
+ *   structural failure, never a "no match", for the same reason the lookup
+ *   core's errors are rethrown below.
+ */
+function toLookupValue(field: ResourceField, value: string): string {
+  if (field.type !== BaseType.RELATION) return value
+  if (isRecordId(value)) return value
+
+  const targetEntityDefinitionId = field.relationship
+    ? getRelatedEntityDefinitionId(field.relationship as RelationshipConfig)
+    : null
+
+  if (!targetEntityDefinitionId) {
+    throw new Error(
+      `Identifier field "${getFieldOutputKey(field)}" is a relation with no resolvable target entity definition, so it cannot be matched`
+    )
+  }
+
+  return toRecordId(targetEntityDefinitionId, value)
+}
+
+/**
  * Find a record in a custom entity by identifier field value(s).
  *
  * Routes through the shared lookup core so the comparison mirrors write-path
@@ -336,7 +385,7 @@ async function findInCustomEntity(
     // Without a resolvable field id there is no candidate; for a composite key
     // that means the tuple cannot match at all.
     if (!field.id) return { kind: 'none' }
-    candidates.push({ fieldId: field.id, value })
+    candidates.push({ fieldId: field.id, value: toLookupValue(field, value) })
   }
   if (candidates.length === 0) return { kind: 'none' }
 

--- a/packages/lib/src/seed/entity-seeder/create-fields.ts
+++ b/packages/lib/src/seed/entity-seeder/create-fields.ts
@@ -35,9 +35,14 @@ import { buildFieldOptions, mapCapabilities, shouldCreateField } from './utils'
 const logger = createScopedLogger('entity-seeder:create-fields')
 
 /**
- * Field registry mapping entity types to their field definitions
+ * Field registry mapping entity types to their field definitions.
+ *
+ * Exported for `seeded-unique-drift.int.test.ts`, which asserts that a freshly seeded
+ * org's `CustomField` capability columns match what these registries declare. Restating
+ * the map in the test is how the two would come to disagree about which entity types are
+ * even seeded.
  */
-const FIELD_REGISTRY: Record<string, Record<string, ResourceField>> = {
+export const FIELD_REGISTRY: Record<string, Record<string, ResourceField>> = {
   contact: CONTACT_FIELDS,
   ticket: TICKET_FIELDS,
   part: PART_FIELDS,

--- a/packages/lib/src/seed/entity-seeder/seeded-unique-drift.int.test.ts
+++ b/packages/lib/src/seed/entity-seeder/seeded-unique-drift.int.test.ts
@@ -1,0 +1,118 @@
+// packages/lib/src/seed/entity-seeder/seeded-unique-drift.int.test.ts
+//
+// DB-backed drift guard (vitest.integration.config.ts -> auxx_test database) for the half of
+// the uniqueness contract that lives in the SEEDER rather than in the registry.
+//
+// `resources/registry/identifier-fields.test.ts` pins the registry-internal invariants
+// (unique => isIdentifier, identifier => filterable). It cannot see whether a freshly seeded
+// organization actually carries those declarations, and that gap is exactly what went wrong:
+// `PART_FIELDS.sku` declared `capabilities.unique: true` from the start, the seeder dropped it
+// on the floor until 2026-04-08, and because `create-fields.ts` inserts and never updates, the
+// 14 orgs created before that date sat at `isUnique = false` for four months with no test red
+// anywhere. Data migration 097 backfilled them; this test is what stops the next one.
+//
+// Runs Pass 1 + Pass 2 of `EntitySeeder` for a real organization -- the same two functions
+// `seedSystemEntities` calls -- and compares every resulting `CustomField.isUnique` against the
+// registry declaration it came from. The later passes (relationships, views, dashboards) never
+// touch `isUnique`, so they are not needed here.
+
+import { type Database, schema } from '@auxx/database'
+import { createTestOrganization, getTestDb } from '@auxx/test-utils'
+import { and, eq } from 'drizzle-orm'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ENTITY_INSTANCE_COLUMNS } from './constants'
+import { createEntityDefinitions } from './create-entity-defs'
+import { createAllFields, FIELD_REGISTRY } from './create-fields'
+import { shouldCreateField } from './utils'
+
+const db = () => getTestDb() as unknown as Database
+
+/** `entityType:systemAttribute` -> the registry's `capabilities.unique` answer. */
+function expectedUniqueByAttribute(): Map<string, boolean> {
+  const expected = new Map<string, boolean>()
+  for (const [entityType, fields] of Object.entries(FIELD_REGISTRY)) {
+    for (const field of Object.values(fields)) {
+      if (!shouldCreateField(field, ENTITY_INSTANCE_COLUMNS)) continue
+      expected.set(`${entityType}:${field.systemAttribute}`, field.capabilities.unique === true)
+    }
+  }
+  return expected
+}
+
+describe('a freshly seeded org matches the registry on uniqueness', () => {
+  let organizationId: string
+
+  beforeEach(async () => {
+    const org = await createTestOrganization()
+    organizationId = org.id
+    const entityDefMap = await createEntityDefinitions(db(), organizationId)
+    await createAllFields(db(), organizationId, entityDefMap)
+  })
+
+  it('seeds at least one field declared unique, so the assertions below can fail', () => {
+    // Without this the parity test passes vacuously the day someone drops the last
+    // `capabilities.unique` from the registry -- or the day `FIELD_REGISTRY` stops being
+    // exported and this file quietly compares two empty maps.
+    const uniqueDeclarations = [...expectedUniqueByAttribute().values()].filter(Boolean)
+    expect(uniqueDeclarations.length).toBeGreaterThan(0)
+  })
+
+  it('every field declaring capabilities.unique is seeded with isUnique = true', async () => {
+    const expected = expectedUniqueByAttribute()
+
+    const rows = await db()
+      .select({
+        modelType: schema.CustomField.modelType,
+        systemAttribute: schema.CustomField.systemAttribute,
+        isUnique: schema.CustomField.isUnique,
+      })
+      .from(schema.CustomField)
+      .where(eq(schema.CustomField.organizationId, organizationId))
+
+    const offenders = rows
+      .filter((row) => expected.get(`${row.modelType}:${row.systemAttribute}`) === true)
+      .filter((row) => row.isUnique !== true)
+      .map((row) => `${row.modelType}.${row.systemAttribute}`)
+
+    expect(offenders).toEqual([])
+  })
+
+  it('no field is seeded unique that the registry does not declare unique', async () => {
+    // The other direction of the same drift. A stray `isUnique = true` is not cosmetic:
+    // `checkUniqueValueTyped` carries no entity or relationship scope, so an over-eager flag
+    // makes one supplier's part number block another's -- the exact reason
+    // `vendor_part.vendorSku` is deliberately NOT unique.
+    const expected = expectedUniqueByAttribute()
+
+    const rows = await db()
+      .select({
+        modelType: schema.CustomField.modelType,
+        systemAttribute: schema.CustomField.systemAttribute,
+        isUnique: schema.CustomField.isUnique,
+      })
+      .from(schema.CustomField)
+      .where(eq(schema.CustomField.organizationId, organizationId))
+
+    const offenders = rows
+      .filter((row) => row.isUnique === true)
+      .filter((row) => expected.get(`${row.modelType}:${row.systemAttribute}`) !== true)
+      .map((row) => `${row.modelType}.${row.systemAttribute}`)
+
+    expect(offenders).toEqual([])
+  })
+
+  it('part.part_sku is seeded unique', async () => {
+    // The named case. Migration 097 exists because this row was `false` in half the fleet.
+    const [row] = await db()
+      .select({ isUnique: schema.CustomField.isUnique })
+      .from(schema.CustomField)
+      .where(
+        and(
+          eq(schema.CustomField.organizationId, organizationId),
+          eq(schema.CustomField.systemAttribute, 'part_sku')
+        )
+      )
+
+    expect(row?.isUnique).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

Composite identifier matching was **built but broken for relation legs**. Both breaks were silent and both ended in `create`, so a re-import duplicated while the wizard reported it was matching. This is wrong on `main` today, independent of any new declaration.

**Break A — the bare instance id is refused.** `isRecordId` is a bare `value.includes(':')` (`packages/types/resource/utils.ts:41`) and gates the relation arm of the typed-value path (`packages/types/field-value/index.ts:467`). But `resolve-relation-lookups` resolves a supplier cell via `queryRecordsByField`, which projects `id: FieldValue.entityId` — a **bare** instance id with no `defId:` prefix. Refused ⇒ `buildLookupCondition` returns null ⇒ AND-mode returns an empty result.

**Break B — the tuple carried the raw cell.** `collectIdentifierValues` ended `sets.set(key, raw ? [raw] : [])`, so the raw cell won for any non-array resolution. A relation leg's tuple carried `Acme Corp` and compared it against `relatedEntityId`.

## The fix

- `find-existing-record.ts` gains `toLookupValue(field, value)`, building a real `RecordId` for `BaseType.RELATION` legs via `getRelatedEntityDefinitionId`. When the target def cannot be resolved it **throws** rather than answering "no match", matching the existing precedent three lines down (*"A structural failure is NOT a 'no match'"*); `analyzeRow` turns that into a row error.
- `analyze-row.ts` gains `isSubstitutingResolution(resolutionType)` (`relation:*`) — legs whose resolver *replaced* the cell rather than normalizing it read the resolved value with **no raw fallback**. A leg resolving to `null` (`onNoMatch: 'blank'`, or a not-yet-minted `relation:create`) is a genuine absence, so the tuple stays incomplete. Scalar legs are untouched, pinned by a test.

Both breaks were **reproduced by test before fixing**. On the pre-fix code the bare-id and ambiguity cases returned `{ kind: 'none' }` while the prefixed-id case passed — the signature of break A.

## Also: the seeded-org drift guard

`05-identity.md` calls this the half that would have caught the original April drift, and it did not exist — only the registry half (#1788) did. It seeds a real org through both seeder passes and asserts `CustomField.isUnique` matches `capabilities.unique` in **both** directions across the whole `FIELD_REGISTRY`, plus a non-vacuity guard.

**Validated by negative control:** forcing `mapCapabilities` to return `isUnique: false` fails it, naming `contact.primary_email` and `part.part_sku`. Without that check it would be a passing no-op. `FIELD_REGISTRY` is exported (previously module-private) so the test compares against the seeder's own map rather than restating it.

## Testing

- 393 unit tests and 93 integration tests pass, including 6 new relation-composite cases.
- Negative controls run on both fixes; both files restored and verified afterwards.
- `packages/lib` typecheck: 0 errors in `src/` (29 pre-existing, all in `scripts/` and `vitest.integration.config.ts`).
- No web edits. No migration.

## Sequencing

This PR is deliberately **separate from and must merge before** the `naturalKey` declaration for `vendor_part` / `subpart`, which is held pending a design ruling. Declaring a natural key on top of these breaks would produce a key that never matches — worse than no key, since the wizard would say "update" and duplicate anyway.