### PR TITLE
fix(onboarding): end the /app ⇄ /onboarding redirect loop

### DIFF
--- a/apps/web/src/app/(protected)/onboarding/page.tsx
+++ b/apps/web/src/app/(protected)/onboarding/page.tsx
@@ -1,10 +1,60 @@
 // apps/web/src/app/(protected)/onboarding/page.tsx
 
 import { database, schema } from '@auxx/database'
+import { getOrgCache, getUserCache, onCacheEvent } from '@auxx/lib/cache'
 import { eq } from 'drizzle-orm'
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { getSession } from '~/auth/session'
+
+/**
+ * Reconcile the cached onboarding flags against the row before bouncing back to
+ * `/app`.
+ *
+ * `/app` gates on the CACHED dehydrated state (`components/global/dashboard.tsx`);
+ * this page reads the row. Reaching the `/app` redirect below means the row says
+ * onboarding is finished — so the only thing that could have sent the user here
+ * is a cache that disagrees. Neither page ever consults the other's source, so
+ * that disagreement is an unbounded redirect loop, not a one-time glitch.
+ *
+ * This loop has now recurred four times, with a different stale writer each time:
+ * the better-auth session cookie cache (#317), the demo route's direct Drizzle
+ * writes, `userProfile` after better-auth's hookless `updateUser` (#1381), and an
+ * invalidation that lost a race against an in-flight recompute in the org cache.
+ * Fixing writers one at a time has not ended it, so this is the catch-all: the
+ * one place that holds DB truth repairs whatever lied, instead of trusting that
+ * every future writer will remember to.
+ *
+ * Best-effort and never throws — a failure here must not block onboarding, and
+ * the bounce guard in `dashboard.tsx` still stops the loop either way.
+ */
+async function reconcileStaleOnboardingCache(
+  userId: string,
+  organizationId: string
+): Promise<void> {
+  try {
+    const [{ orgProfile }, { userProfile }] = await Promise.all([
+      getOrgCache().getOrRecompute(organizationId, ['orgProfile']),
+      getUserCache().getOrRecompute(userId, ['userProfile']),
+    ])
+
+    const orgStale = orgProfile?.completedOnboarding === false
+    const userStale = userProfile?.completedOnboarding === false
+    if (!orgStale && !userStale) return
+
+    console.warn('[Onboarding] Cached onboarding flags disagree with the database, busting:', {
+      userId,
+      organizationId,
+      cachedOrgCompletedOnboarding: orgProfile?.completedOnboarding,
+      cachedUserCompletedOnboarding: userProfile?.completedOnboarding,
+    })
+
+    if (orgStale) await onCacheEvent('org.updated', { orgId: organizationId })
+    if (userStale) await onCacheEvent('user.updated', { orgId: organizationId, userId })
+  } catch (error) {
+    console.error('[Onboarding] Failed to reconcile cached onboarding flags:', error)
+  }
+}
 
 /**
  * Onboarding entry point that determines where to redirect the user based on:
@@ -77,6 +127,12 @@ export default async function OnboardingPage() {
     if (claimToken) {
       console.log('[Onboarding] Org onboarding complete, claim cookie set, redirecting to claim')
       redirect('/shopify/claim')
+    }
+    // Repair the cache that sent them here before bouncing back — see
+    // `reconcileStaleOnboardingCache`. Must run BEFORE `redirect()`, which throws.
+    // `organizationId` is non-null here: `org` is only fetched when it is set.
+    if (organizationId) {
+      await reconcileStaleOnboardingCache(session.user.id, organizationId)
     }
     console.log('[Onboarding] Org onboarding complete, redirecting to /app')
     redirect('/app')

--- a/apps/web/src/components/global/dashboard.tsx
+++ b/apps/web/src/components/global/dashboard.tsx
@@ -35,6 +35,21 @@ import {
   useDehydratedUser,
 } from '~/providers/dehydrated-state-provider'
 
+/**
+ * Per-tab timestamp of the last bounce this gate made to `/onboarding`.
+ * `sessionStorage`, not state: the redirect is a full page load, so nothing in
+ * React survives it.
+ */
+const ONBOARDING_BOUNCE_KEY = 'auxx:onboarding-bounce-at'
+
+/**
+ * A return inside this window means `/onboarding` sent the user straight back —
+ * i.e. the two pages disagree and this is a loop, not a normal visit. A loop
+ * turns the round trip around in about a second; someone who abandons onboarding
+ * and later navigates to `/app` by hand is far outside it and still gets gated.
+ */
+const ONBOARDING_BOUNCE_WINDOW_MS = 15_000
+
 type Props = {
   user?: any
   children: React.ReactNode
@@ -82,16 +97,54 @@ export const Dashboard = ({
   // Redirect to onboarding if either gate is open. `/onboarding` is the single
   // place that decides WHICH step is missing.
   // Uses full navigation since onboarding is in a separate route group.
-  React.useEffect(() => {
-    if (needsOnboarding) {
-      window.location.href = '/onboarding'
-    }
-  }, [needsOnboarding])
+  //
+  // AT MOST ONCE per tab, and that bound is the point. This gate reads the CACHED
+  // dehydrated state; `/onboarding` reads the row. Whenever those two disagree
+  // they redirect at each other forever, and neither one ever consults the
+  // other's source, so nothing in the cycle can break it. It has happened with a
+  // different stale writer each time (#317 session cookie cache, the demo route's
+  // direct Drizzle writes, #1381 `userProfile`, and a lost invalidation race in
+  // the org cache) — so the bounce is bounded here rather than waiting to fix the
+  // next writer. Coming back still needing onboarding means the cache is lying;
+  // `/onboarding` only sends anyone here when the row says they are done, so
+  // rendering the app is the correct read. Onboarding is a UX gate, never an
+  // authorization one — `(protected)/layout.tsx` is what enforces access.
+  const [onboardingBounceSpent, setOnboardingBounceSpent] = useState(false)
 
-  // Show nothing while redirecting to onboarding
-  if (needsOnboarding) {
-    return null
-  }
+  React.useEffect(() => {
+    if (!needsOnboarding) {
+      try {
+        sessionStorage.removeItem(ONBOARDING_BOUNCE_KEY)
+      } catch {
+        // Private mode / storage disabled — the in-memory guard still holds.
+      }
+      return
+    }
+
+    let bouncedAt = 0
+    try {
+      bouncedAt = Number(sessionStorage.getItem(ONBOARDING_BOUNCE_KEY) ?? 0)
+    } catch {
+      // Unreadable storage — fall through and bounce.
+    }
+
+    if (bouncedAt && Date.now() - bouncedAt < ONBOARDING_BOUNCE_WINDOW_MS) {
+      console.warn(
+        '[Onboarding] Bounced straight back from /onboarding still needing onboarding — ' +
+          'the cached state disagrees with the database. Rendering the app instead of ' +
+          'redirecting again.'
+      )
+      setOnboardingBounceSpent(true)
+      return
+    }
+
+    try {
+      sessionStorage.setItem(ONBOARDING_BOUNCE_KEY, String(Date.now()))
+    } catch {
+      // Ignore — worst case we bounce once more on the next hard load.
+    }
+    window.location.href = '/onboarding'
+  }, [needsOnboarding])
 
   // Use unified mutation hook for optimistic updates
   const { updateBulk } = useThreadMutation()
@@ -136,6 +189,14 @@ export const Dashboard = ({
     },
     [updateBulk, handleFavoriteDragEnd]
   )
+
+  // Render nothing while the redirect above is in flight. This sits BELOW every
+  // hook on purpose: it used to short-circuit before `useThreadMutation`,
+  // `useFavoriteDragEnd` and `handleDragEnd`, so the hook count changed the
+  // moment the gate flipped and React threw "rendered fewer hooks than expected".
+  if (needsOnboarding && !onboardingBounceSpent) {
+    return null
+  }
 
   return (
     <SidebarProvider resizable defaultOpen={defaultSidebarOpen} defaultWidth={defaultSidebarWidth}>

--- a/packages/lib/src/cache/__tests__/org-cache-invalidation-race.test.ts
+++ b/packages/lib/src/cache/__tests__/org-cache-invalidation-race.test.ts
@@ -1,0 +1,136 @@
+// packages/lib/src/cache/__tests__/org-cache-invalidation-race.test.ts
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * In-memory Redis fake covering exactly what OrganizationCacheService uses.
+ * String keys only — the org cache stores data/hash/lock/gen as plain strings.
+ */
+const store = new Map<string, string>()
+
+const fakeRedis = {
+  get: vi.fn(async (key: string) => store.get(key) ?? null),
+  set: vi.fn(async (key: string, value: string, ...args: unknown[]) => {
+    // `set(key, '1', 'EX', n, 'NX')` — the distributed lock. NX must not clobber.
+    if (args.includes('NX') && store.has(key)) return null
+    store.set(key, value)
+    return 'OK'
+  }),
+  del: vi.fn(async (key: string) => (store.delete(key) ? 1 : 0)),
+  incr: vi.fn(async (key: string) => {
+    const next = Number(store.get(key) ?? 0) + 1
+    store.set(key, String(next))
+    return next
+  }),
+  expire: vi.fn(async () => 1),
+  scan: vi.fn(async () => ['0', [] as string[]]),
+  pipeline: vi.fn(() => {
+    const ops: Array<() => void> = []
+    const pipe: any = {
+      set: (key: string, value: string) => {
+        ops.push(() => store.set(key, value))
+        return pipe
+      },
+      expire: () => pipe,
+      exec: async () => {
+        for (const op of ops) op()
+        return []
+      },
+    }
+    return pipe
+  }),
+}
+
+vi.mock('@auxx/redis', () => ({ getRedisClient: vi.fn(async () => fakeRedis) }))
+vi.mock('@auxx/database', () => ({ database: {} }))
+
+import { OrganizationCacheService } from '../org-cache-service'
+
+const ORG = 'org_race'
+
+/** Deferred promise so the test can hold a provider mid-compute. */
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+describe('org cache — invalidation vs. in-flight recompute', () => {
+  beforeEach(() => {
+    store.clear()
+    vi.clearAllMocks()
+  })
+
+  /**
+   * The production failure, in order (org `mark-shopify`, 2026-08-24 17:34:48):
+   *
+   *  1. A page load misses `orgProfile`, enters `recompute()`, takes the lock and
+   *     reads the row — BEFORE the onboarding UPDATE commits.
+   *  2. The UPDATE commits and `onCacheEvent('org.updated')` deletes data + hash,
+   *     then calls `recompute()`. The lock is held, so it polls `:data`.
+   *  3. The stalled compute resolves and `writeBack`s its pre-commit snapshot —
+   *     with a fresh full-length TTL.
+   *  4. The invalidator's poll finds exactly that snapshot and adopts it.
+   *
+   * Net: the invalidation re-installs the value it was called to remove, and
+   * `/app` reads `completedOnboarding: false` against a row that says `true` for
+   * the next 24 hours. Step 3 has to land while step 2 is still polling, which is
+   * what `setTimeout` below models — resolving the gate after the invalidation
+   * has already returned exercises a different (and harmless) interleaving.
+   */
+  it('does not adopt or re-persist a pre-commit snapshot that lands mid-invalidation', async () => {
+    const cache = new OrganizationCacheService({} as any)
+
+    const gate = deferred<void>()
+    let row = { completedOnboarding: false, handle: null as string | null }
+    let calls = 0
+
+    cache.register('orgProfile', {
+      compute: async () => {
+        calls++
+        if (calls === 1) await gate.promise
+        return { ...row } as any
+      },
+    } as any)
+
+    // 1. Page load stalls inside the provider, holding the lock.
+    const inFlight = cache.getOrRecompute(ORG, ['orgProfile'])
+    await new Promise((r) => setImmediate(r))
+
+    // 3. Let it finish while the invalidation below is mid-flight.
+    const timer = setTimeout(() => gate.resolve(), 250)
+
+    // 2. The UPDATE commits, then fires its invalidation.
+    row = { completedOnboarding: true, handle: 'mark-shopify' }
+    await cache.invalidateAndRecompute(ORG, ['orgProfile'])
+
+    clearTimeout(timer)
+    gate.resolve()
+    await inFlight
+
+    // The invalidation must have read the DB itself rather than adopting the
+    // in-flight snapshot...
+    expect(calls).toBe(2)
+
+    // ...and the stale writeBack must not have been persisted behind it.
+    const cached = JSON.parse(store.get('org:profile:v2:org_race:data') as string)
+    expect(cached.completedOnboarding).toBe(true)
+    expect(cached.handle).toBe('mark-shopify')
+  })
+
+  it('keeps serving the fresh value on the next read', async () => {
+    const cache = new OrganizationCacheService({} as any)
+
+    let row = { completedOnboarding: false }
+    cache.register('orgProfile', { compute: async () => ({ ...row }) as any } as any)
+
+    await cache.getOrRecompute(ORG, ['orgProfile'])
+    row = { completedOnboarding: true }
+    await cache.invalidateAndRecompute(ORG, ['orgProfile'])
+
+    const { orgProfile } = await cache.getOrRecompute(ORG, ['orgProfile'])
+    expect(orgProfile.completedOnboarding).toBe(true)
+  })
+})

--- a/packages/lib/src/cache/org-cache-service.ts
+++ b/packages/lib/src/cache/org-cache-service.ts
@@ -79,9 +79,47 @@ export class OrganizationCacheService {
     return `${ORG_CACHE_KEY_CONFIG[keyName].prefix}:${scopeId}:lock`
   }
 
+  /**
+   * Redis key for the invalidation generation counter.
+   *
+   * Deleting `data`/`hash` does not stop a `recompute()` that is ALREADY running
+   * from writing its pre-invalidation snapshot back afterwards — and `writeBack`
+   * sets a full `ttlSeconds` expiry, so a lost race pins stale data for a day.
+   * Every invalidation bumps this counter; a recompute reads it before calling
+   * the provider and refuses to persist a value computed against an older
+   * generation. See `recompute()` and `invalidateAndRecompute()`.
+   */
+  private genKey(keyName: OrgCacheKeyName, scopeId: string): string {
+    return `${ORG_CACHE_KEY_CONFIG[keyName].prefix}:${scopeId}:gen`
+  }
+
   /** Local cache key */
   private localKey(keyName: OrgCacheKeyName, scopeId: string): string {
     return `${ORG_CACHE_KEY_CONFIG[keyName].prefix}:${scopeId}`
+  }
+
+  /** Current invalidation generation, or null when Redis is unavailable/unset. */
+  private async readGeneration(keyName: OrgCacheKeyName, scopeId: string): Promise<string | null> {
+    const redis = await this.getRedis()
+    if (!redis) return null
+    try {
+      return await redis.get(this.genKey(keyName, scopeId))
+    } catch {
+      return null
+    }
+  }
+
+  /** Bump the generation so any in-flight recompute discards its result. */
+  private async bumpGeneration(keyName: OrgCacheKeyName, scopeId: string): Promise<void> {
+    const redis = await this.getRedis()
+    if (!redis) return
+    try {
+      const key = this.genKey(keyName, scopeId)
+      await redis.incr(key)
+      await redis.expire(key, ORG_CACHE_KEY_CONFIG[keyName].ttlSeconds)
+    } catch {
+      // Best effort — a missed bump only costs us the old (unfenced) behaviour.
+    }
   }
 
   /**
@@ -225,10 +263,16 @@ export class OrganizationCacheService {
   /**
    * Compute value from provider and write back to cache.
    * Uses distributed lock to prevent thundering herd.
+   *
+   * `skipLock` is set by {@link invalidateAndRecompute}: the lock's waiter branch
+   * ADOPTS whatever the current holder writes, and that holder may have read the
+   * row before the caller's transaction committed. An invalidation must always
+   * read the DB itself, never inherit an in-flight snapshot.
    */
   private async recompute<K extends OrgCacheKeyName>(
     orgId: string,
-    keyName: K
+    keyName: K,
+    skipLock = false
   ): Promise<OrgCacheDataMap[K]> {
     const provider = this.providers.get(keyName)
     if (!provider) {
@@ -238,7 +282,7 @@ export class OrganizationCacheService {
     const redis = await this.getRedis()
 
     // Try to acquire distributed lock
-    if (redis) {
+    if (redis && !skipLock) {
       const lock = this.lockKey(keyName, orgId)
       try {
         const acquired = await redis.set(lock, '1', 'EX', LOCK_TTL_SECONDS, 'NX')
@@ -263,13 +307,27 @@ export class OrganizationCacheService {
       }
     }
 
+    // Read the generation BEFORE touching the DB. If an invalidation lands while
+    // `compute()` is in flight, this snapshot is already stale by the time it
+    // resolves and must not be written back — `writeBack` would give it a fresh
+    // full-length TTL and silently undo the invalidation.
+    const generation = await this.readGeneration(keyName, orgId)
+
     try {
       const value = await provider.compute(orgId, this.db)
-      await this.writeBack(orgId, keyName, value)
+      const current = await this.readGeneration(keyName, orgId)
+      if (current === generation) {
+        await this.writeBack(orgId, keyName, value)
+      } else {
+        logger.warn(`Discarding stale recompute for ${keyName}:${orgId}`, {
+          computedAtGeneration: generation,
+          currentGeneration: current,
+        })
+      }
       return value
     } finally {
       // Release lock
-      if (redis) {
+      if (redis && !skipLock) {
         try {
           await redis.del(this.lockKey(keyName, orgId))
         } catch {
@@ -329,6 +387,11 @@ export class OrganizationCacheService {
       keys.map(async (keyName) => {
         const lk = this.localKey(keyName, orgId)
 
+        // Bump the generation FIRST. Any recompute already in flight — including
+        // one that read the row before the caller's transaction committed — is
+        // now fenced out and will discard its result instead of resurrecting it.
+        await this.bumpGeneration(keyName, orgId)
+
         // Clear local cache
         this.localCache.delete(lk)
 
@@ -342,10 +405,12 @@ export class OrganizationCacheService {
           }
         }
 
-        // Recompute if provider is registered
+        // Recompute if provider is registered. `skipLock` because the waiter
+        // branch would adopt an in-flight (pre-commit) snapshot instead of
+        // reading the DB — the exact failure this invalidation exists to undo.
         if (this.providers.has(keyName)) {
           try {
-            await this.recompute(orgId, keyName)
+            await this.recompute(orgId, keyName, true)
           } catch (error) {
             logger.warn(`Recompute failed for ${keyName}:${orgId}`, {
               error: error instanceof Error ? error.message : String(error),
@@ -398,6 +463,9 @@ export class OrganizationCacheService {
     const redis = await this.getRedis()
 
     for (const keyName of keysToFlush) {
+      // Fence in-flight recomputes (see `genKey`) before dropping the entry,
+      // or one can write its pre-flush snapshot straight back afterwards.
+      await this.bumpGeneration(keyName, orgId)
       this.localCache.delete(this.localKey(keyName, orgId))
 
       if (redis) {

--- a/packages/lib/src/cache/user-cache-service.ts
+++ b/packages/lib/src/cache/user-cache-service.ts
@@ -75,6 +75,43 @@ export class UserCacheService {
   }
 
   /**
+   * Redis key for the invalidation generation counter.
+   *
+   * Deleting `data`/`hash` does not stop a `recompute()` that is ALREADY running
+   * from writing its pre-invalidation snapshot back afterwards — and `writeBack`
+   * gives it a fresh full-length TTL, so a lost race pins stale data for a day.
+   * Every delete bumps this counter; a recompute reads it before calling the
+   * provider and refuses to persist a value computed against an older generation.
+   */
+  private genKey(keyName: UserCacheKeyName, scopeId: string): string {
+    return `${USER_CACHE_KEY_CONFIG[keyName].prefix}:${scopeId}:gen`
+  }
+
+  /** Current invalidation generation, or null when Redis is unavailable/unset. */
+  private async readGeneration(keyName: UserCacheKeyName, scopeId: string): Promise<string | null> {
+    const redis = await this.getRedis()
+    if (!redis) return null
+    try {
+      return await redis.get(this.genKey(keyName, scopeId))
+    } catch {
+      return null
+    }
+  }
+
+  /** Bump the generation so any in-flight recompute discards its result. */
+  private async bumpGeneration(keyName: UserCacheKeyName, scopeId: string): Promise<void> {
+    const redis = await this.getRedis()
+    if (!redis) return
+    try {
+      const key = this.genKey(keyName, scopeId)
+      await redis.incr(key)
+      await redis.expire(key, USER_CACHE_KEY_CONFIG[keyName].ttlSeconds)
+    } catch {
+      // Best effort — a missed bump only costs us the old (unfenced) behaviour.
+    }
+  }
+
+  /**
    * Multi-key fetch for a single user.
    * @param orgId Required for org-scoped keys (userSettings, userMailViews)
    */
@@ -160,9 +197,24 @@ export class UserCacheService {
     // here would call providers like userProfile with `userId:orgId`, which has
     // no matching User row and silently poisons the cache with null.
     const sid = this.scopeId(userId, keyName, orgId)
+
+    // Read the generation BEFORE touching the DB. If an invalidation lands while
+    // `compute()` is in flight, this snapshot is already stale by the time it
+    // resolves and must not be written back — `writeBack` would give it a fresh
+    // full-length TTL and silently undo the invalidation.
+    const generation = await this.readGeneration(keyName, sid)
+
     const value = await provider.compute(sid, this.db)
 
-    await this.writeBack(sid, keyName, value)
+    const current = await this.readGeneration(keyName, sid)
+    if (current === generation) {
+      await this.writeBack(sid, keyName, value)
+    } else {
+      logger.warn(`Discarding stale recompute for ${keyName}:${sid}`, {
+        computedAtGeneration: generation,
+        currentGeneration: current,
+      })
+    }
 
     return value
   }
@@ -274,6 +326,9 @@ export class UserCacheService {
     await Promise.all(
       keys.map(async (keyName) => {
         const sid = this.scopeId(userId, keyName, orgId)
+        // Fence in-flight recomputes (see `genKey`) BEFORE dropping the entry,
+        // or one can write its pre-invalidation snapshot straight back after.
+        await this.bumpGeneration(keyName, sid)
         this.localCache.delete(this.localKey(keyName, sid))
 
         if (redis) {
@@ -297,6 +352,7 @@ export class UserCacheService {
       // For non-org-scoped keys, flush directly
       if (!ORG_SCOPED_USER_KEYS.has(keyName)) {
         const sid = userId
+        await this.bumpGeneration(keyName, sid)
         this.localCache.delete(this.localKey(keyName, sid))
         if (redis) {
           try {


### PR DESCRIPTION
## What's broken

`app.auxx.ai/app` bounces between `/app` and `/onboarding` about once a second, forever. Every cycle re-bootstraps the whole app (31 Pusher channel auths + ~15 tRPC calls), enough to hit Railway's 500 logs/sec cap.

Two pages disagree about whether onboarding is done, and each reads a different source:

- `/app` (`dashboard.tsx:64`) gates on the **cached** dehydrated state → `completedOnboarding: false` → `window.location.href = '/onboarding'`
- `/onboarding/page.tsx:74` reads the **row** → `true` → `redirect('/app')`

Neither consults the other's source, so nothing in the cycle can break it.

Confirmed live on prod for org `dhufiacul04zw5uo5xqxkafn`:

| | name | handle | completedOnboarding |
|---|---|---|---|
| DB (`organization.list`) | `Mark Shopify` | `mark-shopify` | `true` |
| injected `AUXX_DEHYDRATED_STATE` | `""` | `null` | `false` |

The cached blob is the creation snapshot from `createdAt` 17:33:15. The org finished onboarding 93 seconds later at 17:34:48. `org:profile:v2` has a `ONE_DAY` TTL, so it self-heals only ~24h later — which is why it looks like it randomly fixes itself.

## Why the invalidation lost

This is the **fourth** recurrence of this loop, and the first where the writer did nothing wrong. Previous ones (#317 the better-auth session cookie cache, the demo route's direct Drizzle writes, #1381 `userProfile` after better-auth's hookless `updateUser`) were all "writer X forgot to invalidate key Y". `plans/onboarding/01-personal-step-for-invited-members.md:160-190` writes the loop out step by step and predicts it correctly.

Here, `organization.update` fired `onCacheEvent('org.updated')` correctly. It still lost:

1. A page load misses `orgProfile`, enters `recompute()`, takes the lock, and reads the row **before** the onboarding UPDATE commits.
2. The UPDATE commits. `invalidateAndRecompute` deletes `:data` + `:hash`, then calls `recompute()` — the lock is held, so it falls into the waiter branch and polls `:data`. **It never re-reads the DB.**
3. The stalled compute resolves and `writeBack`s its pre-commit snapshot, with a fresh full-length TTL.
4. The invalidator's poll finds exactly that snapshot and adopts it.

Net: the invalidation re-installs the value it was called to remove. Deleting `:data`/`:hash` does nothing to a recompute that is already running.

## The fix — three layers

Patching one writer at a time hasn't ended this in four tries, so this goes after the shape rather than the instance.

**1. Fence the caches** (`org-cache-service.ts`, `user-cache-service.ts`)

Each key carries a `:gen` counter. Every invalidation `INCR`s it; a recompute reads the generation before calling the provider and refuses to persist a value computed against an older one. `invalidateAndRecompute` passes `skipLock` so it always reads the DB itself rather than inheriting an in-flight snapshot.

**2. `/onboarding` repairs what lied**

It's the one place holding DB truth. Before bouncing to `/app` it compares the cached flags against the row and busts whichever disagrees. Best-effort, never throws.

**3. `dashboard.tsx` can't loop**

The bounce now happens at most once per 15-second window per tab; coming straight back still needing onboarding means the cache is lying, so it renders the app. `/onboarding` only sends anyone to `/app` when the row says they're done, so that's the correct read — and onboarding is a UX gate, never an authorization one (`(protected)/layout.tsx` enforces access). Time-boxed rather than once-per-tab so abandoning onboarding and returning later still gets gated.

Also moves dashboard's `return null` below every hook. It short-circuited before `useThreadMutation`, `useFavoriteDragEnd` and `handleDragEnd`, so the hook count changed the instant the gate flipped — React would throw "rendered fewer hooks than expected".

## Testing

`org-cache-invalidation-race.test.ts` replays the production interleaving, including the timing that matters (the stale writeBack has to land *while* the invalidation is polling — resolving it afterwards exercises a different, harmless path).

Verified it **fails against the old code**: `AssertionError: expected 1 to be 2` — the provider was called once, i.e. the invalidation adopted the in-flight snapshot instead of reading the DB.

- 142 tests green across `packages/lib/src/cache` + affected migration tests
- `tsc --noEmit` clean on `apps/web` and `packages/lib`
- biome clean on all changed files

## Notes

- Existing prod entries stay stale until their TTL or the next invalidation — for the affected workspace, re-saving the org name in Settings clears it immediately.
- Unrelated and **not** addressed here: `TypeError: Response constructor: Invalid response status code 204 / 304`, ~5 per loop cycle, thrown inside minified Next 16 server chunks (no `304` exists anywhere in `apps/web/src/app/api`). It isn't causing the loop but is turning some responses into 500s.
