### PR TITLE
chore(billing): log successful shopify billing webhook deliveries

### DIFF
--- a/apps/web/src/app/api/apps/shopify/billing-webhook/route.ts
+++ b/apps/web/src/app/api/apps/shopify/billing-webhook/route.ts
@@ -60,6 +60,11 @@ export async function POST(req: NextRequest) {
         })
       }
     }
+    logger.info('Shopify billing webhook processed', {
+      topic,
+      shopDomain,
+      organizationId: result.organizationId ?? null,
+    })
     return new NextResponse('ok', { status: 200 })
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)


### PR DESCRIPTION
Successful `app_subscriptions/update` / `app/uninstalled` deliveries previously produced no log line — only the audit row — so confirming webhook receipt meant checking the org's activity log in the UI. One `logger.info` on the success path (topic, shop domain, org id) makes deliveries visible in Railway/OpenObserve. Follow-up to #1855.