### PR TITLE
fix(proxy): stop null-body statuses 500ing through the PostHog proxy

### DIFF
--- a/apps/web/src/app/api/extensions/execute-server-function/route.ts
+++ b/apps/web/src/app/api/extensions/execute-server-function/route.ts
@@ -6,6 +6,9 @@ import { headers } from 'next/headers'
 import { z } from 'zod'
 import { auth } from '~/auth/server'
 
+/** Statuses the Fetch spec forbids a body on — see the guard in `POST`. */
+const NULL_BODY_STATUSES = new Set([101, 204, 205, 304])
+
 const bodySchema = z.object({
   appId: z.string().min(1),
   installationId: z.string().min(1),
@@ -111,5 +114,16 @@ export async function POST(request: Request) {
   }
 
   const result = await response.json()
+
+  // `Response.json` always attaches a body, and the Response constructor rejects
+  // a body on a null-body status (101/204/205/304) — it throws rather than
+  // returning, so a 204 upstream would surface as a 500 here. Today the
+  // content-type guard above catches a bare 204, but that is incidental: it only
+  // holds while upstream omits `application/json`. Forward the status with no
+  // body instead.
+  if (NULL_BODY_STATUSES.has(response.status)) {
+    return new Response(null, { status: response.status })
+  }
+
   return Response.json(result, { status: response.status })
 }

--- a/apps/web/src/app/ph/[[...path]]/route.test.ts
+++ b/apps/web/src/app/ph/[[...path]]/route.test.ts
@@ -1,0 +1,61 @@
+// apps/web/src/app/ph/[[...path]]/route.test.ts
+
+import type { NextRequest } from 'next/server'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { GET } from './route'
+
+/**
+ * A null-body status (101/204/205/304) paired with a non-null body makes the
+ * `Response` constructor THROW `Invalid response status code <n>` rather than
+ * return. `response.arrayBuffer()` resolves to a zero-length but non-null
+ * ArrayBuffer, so forwarding it verbatim turned every PostHog 204/304 into a 500
+ * from this proxy — analytics capture and asset revalidation both silently
+ * failing in production.
+ */
+function upstream(status: number, body: string | null = null) {
+  return new Response(body, {
+    status,
+    headers: { etag: 'W/"abc"', 'cache-control': 'max-age=60' },
+  })
+}
+
+function proxyRequest(path = '/ph/static/array.js') {
+  const url = new URL(`https://app.auxx.ai${path}`)
+  return {
+    method: 'GET',
+    nextUrl: url,
+    headers: new Headers({ accept: '*/*' }),
+  } as unknown as NextRequest
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('PostHog proxy — null-body statuses', () => {
+  it.each([204, 205, 304])('forwards %i without throwing', async (status) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => upstream(status))
+    )
+
+    const res = await GET(proxyRequest())
+
+    expect(res.status).toBe(status)
+    expect(res.body).toBeNull()
+    // Conditional-request headers must survive, or the browser re-downloads.
+    expect(res.headers.get('etag')).toBe('W/"abc"')
+  })
+
+  it('still forwards the body on a normal 200', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => upstream(200, 'console.log(1)'))
+    )
+
+    const res = await GET(proxyRequest())
+
+    expect(res.status).toBe(200)
+    await expect(res.text()).resolves.toBe('console.log(1)')
+  })
+})

--- a/apps/web/src/app/ph/[[...path]]/route.ts
+++ b/apps/web/src/app/ph/[[...path]]/route.ts
@@ -5,6 +5,16 @@ import type { NextRequest } from 'next/server'
 const POSTHOG_INGEST = 'https://us.i.posthog.com'
 const POSTHOG_ASSETS = 'https://us-assets.i.posthog.com'
 
+/**
+ * Statuses the Fetch spec forbids a body on. `response.arrayBuffer()` resolves to
+ * a zero-length but NON-null ArrayBuffer for these, and the `Response`
+ * constructor throws `Invalid response status code <n>` when a null-body status
+ * is paired with a non-null body — turning every PostHog 204/304 into a 500 from
+ * this proxy. Pass `null` instead; the headers still carry ETag/Cache-Control, so
+ * conditional requests keep working.
+ */
+const NULL_BODY_STATUSES = new Set([101, 204, 205, 304])
+
 // Cloudflare and proxy-injected headers must be stripped before forwarding to
 // PostHog (also behind Cloudflare). Forwarding cf-connecting-ip from one CF zone
 // to another trips Error 1000 ("DNS points to prohibited IP") on us-assets.
@@ -46,8 +56,9 @@ async function handler(request: NextRequest) {
     body,
   })
 
-  // Fully consume the response to avoid truncation from content-encoding mismatches
-  const data = await response.arrayBuffer()
+  // Fully consume the response to avoid truncation from content-encoding
+  // mismatches — except where a body is not allowed at all (see above).
+  const data = NULL_BODY_STATUSES.has(response.status) ? null : await response.arrayBuffer()
   const responseHeaders = new Headers(response.headers)
   responseHeaders.delete('content-encoding')
   responseHeaders.delete('content-length')


### PR DESCRIPTION
## What's broken

Production logs, still firing on 0.1.215:

```
⨯ TypeError: Response constructor: Invalid response status code 204
    at y (.next/server/chunks/[root-of-the-server]__11zofye._.js:1:6793)
    at async Module._ [as handler] (...)
```

`new Response(body, init)` **throws** when `init.status` is a null-body status (101/204/205/304) and the body is non-null — it doesn't return. `apps/web/src/app/ph/[[...path]]/route.ts` forwarded PostHog's response like this:

```ts
const data = await response.arrayBuffer()   // zero-length but NON-null on 204/304
return new Response(data, { status: response.status, ... })   // throws
```

So every PostHog 204/304 became a **500 from our origin** — analytics capture and static-asset revalidation both failing silently.

Confirmed on Node 22:

```
204 THROWS: Response constructor: Invalid response status code 204
205 THROWS: Response constructor: Invalid response status code 205
304 THROWS: Response constructor: Invalid response status code 304
200 ok (empty ArrayBuffer)
---
204 ok (null body)
304 ok (null body)
```

The stack corroborates: this route does `export const GET = handler` / `export const POST = handler`, so the frame is literally named `handler`, matching `at async Module._ [as handler]`.

## The fix

```ts
const NULL_BODY_STATUSES = new Set([101, 204, 205, 304])
const data = NULL_BODY_STATUSES.has(response.status) ? null : await response.arrayBuffer()
```

Headers are untouched, so a 304 still carries `ETag` / `Cache-Control` and conditional requests keep working.

Also hardens `api/extensions/execute-server-function`, which has the same shape via `Response.json(result, { status: response.status })` — `Response.json` always attaches a body. It isn't firing today only because the `content-type: application/json` guard above it catches a bare 204, and that holds solely while upstream omits the header. Not a fix for a live bug; a fix for one waiting to happen.

## Audited, both fine

| Route | Verdict |
|---|---|
| `api/webhooks/[...path]` | passes `response.body`, which **is** null on 204/304. Dev-only besides. |
| `api/files/download/[fileId]` | `createFileDownloadResponse` only ever returns 200 or 206 |
| `api/attachments/*/thumbnail`, `api/trpc`, `api/extension/*` | all pass `null` |

## Testing

New `route.test.ts` stubs the upstream fetch and asserts 204/205/304 forward without throwing, that the body still comes through on 200, and that `ETag` survives.

Verified it **fails against the old code** with the exact production error:

```
× forwards 204 without throwing
× forwards 205 without throwing
× forwards 304 without throwing
TypeError: Response constructor: Invalid response status code 204
```

4/4 pass with the fix. `tsc --noEmit` clean on `apps/web`; biome clean.

## Note on verification

I could not reproduce this end-to-end through the public URL — a conditional `If-None-Match` request to `app.auxx.ai/ph/static/array.js` returns a clean 304, but Cloudflare fronts that path and had the asset cached, so it almost certainly never reached the origin. The evidence here is the exact error-string match, the `handler` frame name, and the unit test reproducing the throw — not a live round trip.
