### PR TITLE
fix(records): stop re-saving references to deleted records

### DIFF
--- a/apps/web/src/components/dynamic-table/hooks/use-cell-clipboard.ts
+++ b/apps/web/src/components/dynamic-table/hooks/use-cell-clipboard.ts
@@ -3,9 +3,11 @@
 
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useEffect, useRef } from 'react'
+import { api } from '~/trpc/react'
 import { useSelectionStore } from '../stores/selection-store'
 import type { CellAddress, CellSelectionConfig, CopyCellPayload, RangeEndpoint } from '../types'
 import { type CoerceReason, coerceForPaste, reasonToLabel } from '../utils/cell-coercion'
+import { collectPastedRecordIds, resolveMissingRecordIds } from '../utils/missing-record-targets'
 import { rangeBounds } from '../utils/range'
 import type { CellIndexer } from './use-cell-indexer'
 
@@ -123,6 +125,8 @@ export function useCellClipboard({
   config,
   indexer,
 }: UseCellClipboardOptions) {
+  const checkMissingTargets = api.useUtils().record.checkMissingTargets
+
   const handleCopy = useCallback(async () => {
     if (!config) return
     const range = useSelectionStore.getState().getRange(tableId)
@@ -245,6 +249,14 @@ export function useCellClipboard({
       const rows = parseClipboardRows(sidecarJson, plainText)
       if (rows.length === 0) return
 
+      // A pasted RecordId was only ever checked for the right def prefix, so
+      // copying a dangling cell cloned the broken reference. Resolve the
+      // confirmed-deleted subset once for the whole paste; fails open.
+      const missingRecordIds = await resolveMissingRecordIds(
+        checkMissingTargets,
+        collectPastedRecordIds(rows.flat())
+      )
+
       const { rowIds, columnIds } = indexer
       const updates: Array<{ rowId: string; columnId: string; value: unknown }> = []
       const reasons = new Map<CoerceReason | 'out-of-bounds' | 'no-field', number>()
@@ -309,6 +321,7 @@ export function useCellClipboard({
             columnId: targetColId,
             resolveRelationshipByDisplay: config.resolveRelationshipByDisplay,
             resolveActorByDisplay: config.resolveActorByDisplay,
+            isMissingRecord: (recordId) => missingRecordIds.has(recordId),
           })
           if (result.ok) {
             updates.push({ rowId: targetRowId, columnId: targetColId, value: result.value })
@@ -371,7 +384,7 @@ export function useCellClipboard({
         })
       }
     },
-    [config, tableId, indexer]
+    [config, tableId, indexer, checkMissingTargets]
   )
 
   // Mount a hidden textarea inside the scroll container. The native `paste`

--- a/apps/web/src/components/dynamic-table/hooks/use-fill-drag.ts
+++ b/apps/web/src/components/dynamic-table/hooks/use-fill-drag.ts
@@ -3,9 +3,11 @@
 
 import { toastError } from '@auxx/ui/components/toast'
 import { useCallback, useRef } from 'react'
+import { api } from '~/trpc/react'
 import { useSelectionStore } from '../stores/selection-store'
 import type { CellRange, CellSelectionConfig, CopyCellPayload, RangeEndpoint } from '../types'
 import { type CoerceReason, coerceForPaste, reasonToLabel } from '../utils/cell-coercion'
+import { collectPastedRecordIds, resolveMissingRecordIds } from '../utils/missing-record-targets'
 import { rangeBounds } from '../utils/range'
 import type { CellIndexer } from './use-cell-indexer'
 import { usePointerDrag } from './use-pointer-drag'
@@ -72,6 +74,8 @@ export function useFillDrag({
   configRef.current = config
 
   const localRef = useRef<LocalDragState | null>(null)
+
+  const checkMissingTargets = api.useUtils().record.checkMissingTargets
 
   const { begin } = usePointerDrag({ enabled, scrollContainerRef })
 
@@ -182,6 +186,14 @@ export function useFillDrag({
         sourcePayloads.push(rowArr)
       }
 
+      // Same guard as paste: a filled RecordId was only checked for its def
+      // prefix, so dragging a dangling cell propagated the broken reference.
+      // Fails open — an unresolvable check never blocks the fill.
+      const missingRecordIds = await resolveMissingRecordIds(
+        checkMissingTargets,
+        collectPastedRecordIds(sourcePayloads.flat())
+      )
+
       const updates: Array<{ rowId: string; columnId: string; value: unknown }> = []
       const aiCells: Array<{ rowId: string; columnId: string }> = []
       const reasons = new Map<CoerceReason, number>()
@@ -223,6 +235,7 @@ export function useFillDrag({
             columnId: targetColId,
             resolveRelationshipByDisplay: cfg.resolveRelationshipByDisplay,
             resolveActorByDisplay: cfg.resolveActorByDisplay,
+            isMissingRecord: (recordId) => missingRecordIds.has(recordId),
           })
           if (result.ok) {
             updates.push({ rowId: targetRowId, columnId: targetColId, value: result.value })
@@ -296,7 +309,7 @@ export function useFillDrag({
         })
       }
     },
-    [tableId]
+    [tableId, checkMissingTargets]
   )
 
   const beginFillDrag = useCallback(

--- a/apps/web/src/components/dynamic-table/utils/cell-coercion.test.ts
+++ b/apps/web/src/components/dynamic-table/utils/cell-coercion.test.ts
@@ -98,3 +98,79 @@ describe('coerceForPaste — select across columns', () => {
     expect(result).toEqual({ ok: false, reason: 'no-matching-option' })
   })
 })
+
+/**
+ * Paste checked only the def PREFIX of a pasted RecordId, never that the target
+ * still existed — so copying a dangling cell cloned the broken reference into
+ * another row. `isMissingRecord` is the verdict from `record.checkMissingTargets`,
+ * which resolves the target's own backing table; it is never "the client could
+ * not resolve it", because a record this member cannot see is alive.
+ */
+describe('coerceForPaste — dangling relationship targets', () => {
+  const DEAD = 'work_order:dead_instance_id'
+  const LIVE = 'work_order:live_instance_id'
+
+  function relationshipField(): ResourceField {
+    return {
+      id: toFieldId('rel'),
+      key: 'rel',
+      label: 'Work Order',
+      type: 'string',
+      fieldType: 'RELATIONSHIP',
+      options: {
+        relationship: { relationshipType: 'has_many', relatedEntityDefinitionId: 'work_order' },
+      },
+      capabilities: { updatable: true },
+    } as unknown as ResourceField
+  }
+
+  const isMissingRecord = (recordId: string) => recordId === DEAD
+
+  it('refuses a lossless RecordId whose target is confirmed deleted', () => {
+    const result = coerceForPaste(
+      { display: 'Dead WO', fieldType: 'RELATIONSHIP', recordId: DEAD },
+      relationshipField(),
+      { columnId: 'rel', isMissingRecord }
+    )
+    expect(result).toEqual({ ok: false, reason: 'no-matching-record' })
+  })
+
+  it('still accepts a live RecordId', () => {
+    const result = coerceForPaste(
+      { display: 'Live WO', fieldType: 'RELATIONSHIP', recordId: LIVE },
+      relationshipField(),
+      { columnId: 'rel', isMissingRecord }
+    )
+    expect(result).toEqual({ ok: true, value: LIVE })
+  })
+
+  it('drops only the dead legs of a has_many RecordId round-trip', () => {
+    const result = coerceForPaste(
+      { display: `${LIVE}, ${DEAD}`, fieldType: 'RELATIONSHIP' },
+      relationshipField(),
+      { columnId: 'rel', isMissingRecord }
+    )
+    expect(result).toEqual({ ok: true, value: [LIVE] })
+  })
+
+  it('skips the cell when every leg of the round-trip is dead', () => {
+    const result = coerceForPaste(
+      { display: DEAD, fieldType: 'RELATIONSHIP' },
+      relationshipField(),
+      { columnId: 'rel', isMissingRecord }
+    )
+    expect(result).toEqual({ ok: false, reason: 'no-matching-record' })
+  })
+
+  it('is unchanged when no verdict is supplied — the check fails OPEN', () => {
+    // No callback (or a failed/timed-out existence call) must never block a
+    // paste: the reference is already broken, and refusing a valid paste is the
+    // worse failure.
+    const result = coerceForPaste(
+      { display: 'Dead WO', fieldType: 'RELATIONSHIP', recordId: DEAD },
+      relationshipField(),
+      { columnId: 'rel' }
+    )
+    expect(result).toEqual({ ok: true, value: DEAD })
+  })
+})

--- a/apps/web/src/components/dynamic-table/utils/cell-coercion.ts
+++ b/apps/web/src/components/dynamic-table/utils/cell-coercion.ts
@@ -31,6 +31,19 @@ export interface CoerceOptions {
   resolveRelationshipByDisplay?: (columnId: string, query: string) => string | null
   /** Resolve an actor target by display name. Returns an ActorId or null. */
   resolveActorByDisplay?: (columnId: string, query: string) => string | null
+  /**
+   * Is this RecordId's target **confirmed hard-deleted**? Pasting a dangling
+   * reference clones it into another row, so the RecordId branches below refuse
+   * one that answers `true`.
+   *
+   * 🛑 **Must be a positive existence verdict, not "the client could not resolve
+   * it".** A record the pasting member cannot see is alive, and dropping it here
+   * would silently discard a valid paste. Callers get this from
+   * `record.checkMissingTargets`, which answers from the target's own backing
+   * table and refuses to judge anything it cannot resolve to `EntityInstance`.
+   * Omitting the callback keeps today's behavior (def-prefix check only).
+   */
+  isMissingRecord?: (recordId: RecordId) => boolean
 }
 
 export type CoerceResult = { ok: true; value: unknown } | { ok: false; reason: CoerceReason }
@@ -225,6 +238,11 @@ export function coerceForPaste(
             return { ok: false, reason: 'wrong-entity-type' }
           }
         }
+        // The def prefix alone never proved the target still exists — copying a
+        // dangling cell cloned the broken reference into another row.
+        if (opts.isMissingRecord?.(source.recordId as RecordId)) {
+          return { ok: false, reason: 'no-matching-record' }
+        }
         return { ok: true, value: source.recordId }
       }
 
@@ -243,7 +261,9 @@ export function coerceForPaste(
           )
           if (!allMatch) return { ok: false, reason: 'wrong-entity-type' }
         }
-        return { ok: true, value: hasMany ? candidates : candidates[0] }
+        const live = candidates.filter((c) => !opts.isMissingRecord?.(c as RecordId))
+        if (live.length === 0) return { ok: false, reason: 'no-matching-record' }
+        return { ok: true, value: hasMany ? live : live[0] }
       }
 
       // Display-name lookup (phase 2d callback).

--- a/apps/web/src/components/dynamic-table/utils/missing-record-targets.ts
+++ b/apps/web/src/components/dynamic-table/utils/missing-record-targets.ts
@@ -1,0 +1,71 @@
+// apps/web/src/components/dynamic-table/utils/missing-record-targets.ts
+
+'use client'
+
+import { isRecordId, type RecordId } from '@auxx/lib/resources/client'
+import type { CopyCellPayload } from '../types'
+
+/** The most ids one existence call will judge — matches the procedure's cap. */
+const MAX_BATCH = 100
+
+/**
+ * Every RecordId a set of clipboard / fill payloads would write into a
+ * relationship cell.
+ *
+ * Mirrors the two RecordId-bearing branches of `coerceForPaste`: the lossless
+ * `source.recordId`, and the ", "-joined RecordId round-trip that copy falls back
+ * to when the display name was not hydrated at copy time.
+ */
+export function collectPastedRecordIds(
+  sources: Iterable<CopyCellPayload | null | undefined>
+): RecordId[] {
+  const found = new Set<RecordId>()
+  for (const source of sources) {
+    if (!source) continue
+    if (typeof source.recordId === 'string' && isRecordId(source.recordId)) {
+      found.add(source.recordId as RecordId)
+    }
+    const display = (source.display ?? '').trim()
+    if (!display) continue
+    const parts = display
+      .split(',')
+      .map((part) => part.trim())
+      .filter(Boolean)
+    if (parts.length > 0 && parts.every(isRecordId)) {
+      for (const part of parts) found.add(part as RecordId)
+    }
+  }
+  return [...found].slice(0, MAX_BATCH)
+}
+
+/** The narrow slice of `api.useUtils()` {@link resolveMissingRecordIds} needs. */
+export interface MissingTargetsFetcher {
+  fetch: (
+    input: { items: string[] },
+    opts?: { staleTime?: number }
+  ) => Promise<{ missing: string[] }>
+}
+
+/**
+ * Resolve which pasted RecordIds point at a hard-deleted record, so paste stops
+ * cloning a dangling reference into another row.
+ *
+ * ⚠️ **Fails OPEN.** An error, a timeout or an unresolvable def yields an empty
+ * set and the paste proceeds — the existence check exists to stop propagation of
+ * a reference that is already broken, and refusing a valid paste because the
+ * check could not run would be the worse failure. The server-side procedure is
+ * likewise conservative: it never reports a target it cannot resolve to
+ * `EntityInstance`, so a `thread:` or `article:` reference is never rejected.
+ */
+export async function resolveMissingRecordIds(
+  fetcher: MissingTargetsFetcher,
+  recordIds: RecordId[]
+): Promise<Set<string>> {
+  if (recordIds.length === 0) return new Set()
+  try {
+    const result = await fetcher.fetch({ items: recordIds }, { staleTime: 0 })
+    return new Set(result.missing)
+  } catch {
+    return new Set()
+  }
+}

--- a/apps/web/src/components/pickers/record-picker/record-picker-content.tsx
+++ b/apps/web/src/components/pickers/record-picker/record-picker-content.tsx
@@ -20,6 +20,7 @@ import { useRelationship, useResourceStore } from '~/components/resources'
 import { useDebouncedValue } from '~/hooks/use-debounced-value'
 import { api } from '~/trpc/react'
 import { RecordItem } from './record-item'
+import { usePruneDeletedSelections } from './use-prune-deleted-selections'
 
 /**
  * Props for the RecordPickerContent component
@@ -208,6 +209,17 @@ export function RecordPickerContent({
 
   // Hydrate items that will appear in the Selected section (snapshot + pinned)
   const { items: hydratedItems, isLoading: isHydrating } = useRelationship(selectedSectionIds)
+
+  // Drop references to hard-deleted records from the selection, so closing the
+  // picker stops re-committing ids the user can neither see nor deselect.
+  // Hydration only NOMINATES (`null`, never `undefined`); the server decides.
+  usePruneDeletedSelections({
+    recordIds: selectedSectionIds,
+    hydratedItems,
+    value,
+    onChange,
+    enabled: !disabled,
+  })
 
   // Build map of hydrated items for quick lookup
   const hydratedMap = useMemo(() => {

--- a/apps/web/src/components/pickers/record-picker/use-prune-deleted-selections.test.ts
+++ b/apps/web/src/components/pickers/record-picker/use-prune-deleted-selections.test.ts
@@ -1,0 +1,96 @@
+// apps/web/src/components/pickers/record-picker/use-prune-deleted-selections.test.ts
+
+import type { RecordId, RecordPickerItem } from '@auxx/lib/resources/client'
+import { describe, expect, it } from 'vitest'
+import { selectNotFoundCandidates } from './use-prune-deleted-selections'
+
+/**
+ * The three-state hydration contract, pinned.
+ *
+ * `resources/store/relationship-store.ts` documents it: an item (found), `null`
+ * (the batch answered and this id was not in it), `undefined` (not loaded yet).
+ * The picker's `hydratedMap` collapses all three by admitting only truthy items,
+ * which is why a dangling id goes invisible and gets re-saved.
+ *
+ * 🛑 The fix must NOT collapse them the other way. `selectNotFoundCandidates`
+ * keys on `=== null`; a naive `!item` would nominate every relation on the first
+ * paint — before any hydration has returned — and the caller would then commit
+ * that empty list. The `naive` implementation below is the negative control:
+ * every test that distinguishes the two is asserted against BOTH, and the naive
+ * one is asserted to fail exactly where it would destroy data.
+ */
+function naiveFalsinessCandidates(
+  recordIds: RecordId[],
+  hydratedItems: (RecordPickerItem | null | undefined)[]
+): RecordId[] {
+  const candidates: RecordId[] = []
+  for (let index = 0; index < recordIds.length; index++) {
+    if (!hydratedItems[index]) {
+      const recordId = recordIds[index]
+      if (recordId) candidates.push(recordId)
+    }
+  }
+  return candidates
+}
+
+const A = 'work_order:aaaaaaaaaaaaaaaaaaaaaaaa' as RecordId
+const B = 'work_order:bbbbbbbbbbbbbbbbbbbbbbbb' as RecordId
+const C = 'thread:cccccccccccccccccccccccc' as RecordId
+
+function item(recordId: RecordId): RecordPickerItem {
+  return {
+    id: recordId.split(':')[1] as string,
+    recordId,
+    displayName: 'Something',
+  } as RecordPickerItem
+}
+
+describe('selectNotFoundCandidates', () => {
+  it('nominates nothing while hydration is still in flight', () => {
+    // First paint: the store has no slot for any id yet, so every read is
+    // `undefined`. This is the single most dangerous frame in the change.
+    const loading = [undefined, undefined, undefined]
+
+    expect(selectNotFoundCandidates([A, B, C], loading)).toEqual([])
+
+    // Negative control: the naive falsiness test nominates ALL THREE here, and
+    // the caller would save the relation field as empty.
+    expect(naiveFalsinessCandidates([A, B, C], loading)).toEqual([A, B, C])
+  })
+
+  it('nominates nothing on a partially hydrated frame', () => {
+    // The batcher resolves in chunks, so a mixed frame is normal, not an error.
+    const partial = [item(A), undefined, undefined]
+
+    expect(selectNotFoundCandidates([A, B, C], partial)).toEqual([])
+    expect(naiveFalsinessCandidates([A, B, C], partial)).toEqual([B, C])
+  })
+
+  it('nominates only the ids the batch explicitly answered as not found', () => {
+    const settled = [item(A), null, undefined]
+
+    expect(selectNotFoundCandidates([A, B, C], settled)).toEqual([B])
+    // The naive form additionally nominates C, which has not loaded at all.
+    expect(naiveFalsinessCandidates([A, B, C], settled)).toEqual([B, C])
+  })
+
+  it('nominates nothing when every id hydrated', () => {
+    const items = [item(A), item(B), item(C)]
+    expect(selectNotFoundCandidates([A, B, C], items)).toEqual([])
+    expect(naiveFalsinessCandidates([A, B, C], items)).toEqual([])
+  })
+
+  it('tolerates a shorter items array than the id list', () => {
+    // A positional misalignment must read as "not loaded", never "not found".
+    expect(selectNotFoundCandidates([A, B, C], [item(A)])).toEqual([])
+  })
+
+  it('nominating is not deleting — a nominated id is only a question', () => {
+    // `null` covers "this viewer cannot see it" as well as "deleted": every
+    // `thread:` id resolves to nothing through `record.getByIds` for EVERY
+    // viewer (mail-lens tables are dropped from the batch), alive or not. So a
+    // nomination must go to `record.checkMissingTargets` for a verdict — which
+    // refuses to judge any def it cannot resolve to `EntityInstance`.
+    expect(selectNotFoundCandidates([C], [null])).toEqual([C])
+  })
+})

--- a/apps/web/src/components/pickers/record-picker/use-prune-deleted-selections.ts
+++ b/apps/web/src/components/pickers/record-picker/use-prune-deleted-selections.ts
@@ -1,0 +1,113 @@
+// apps/web/src/components/pickers/record-picker/use-prune-deleted-selections.ts
+
+'use client'
+
+import type { RecordId, RecordPickerItem } from '@auxx/lib/resources/client'
+import { useEffect, useMemo, useRef } from 'react'
+import { api } from '~/trpc/react'
+
+/**
+ * The ids whose hydration came back **explicitly not-found** — the only ids that
+ * are even worth asking the server about.
+ *
+ * 🛑 **`null` and `undefined` are different answers and must stay different.**
+ * `relationship-store.ts` documents the three states: an item (found), `null`
+ * (the batch returned and this id was not in it), `undefined` (not loaded yet).
+ * The picker's `hydratedMap` collapses all three by admitting only truthy items,
+ * which is the bug this exists to fix — but a candidate test keyed on falsiness
+ * rather than on `null` would nominate **every** relation on first paint, before
+ * hydration returns, and the caller would then save that. The `=== null` is
+ * load-bearing.
+ *
+ * A candidate is not a verdict: `null` also covers "this viewer cannot see it"
+ * (mail-lens ids, a def the viewer's record scope excludes, a row the visibility
+ * predicate hid, an instance-access row). Only `record.checkMissingTargets`,
+ * which resolves the target's own backing table, may decide.
+ */
+export function selectNotFoundCandidates(
+  recordIds: RecordId[],
+  hydratedItems: (RecordPickerItem | null | undefined)[]
+): RecordId[] {
+  const candidates: RecordId[] = []
+  for (let index = 0; index < recordIds.length; index++) {
+    if (hydratedItems[index] === null) {
+      const recordId = recordIds[index]
+      if (recordId) candidates.push(recordId)
+    }
+  }
+  return candidates
+}
+
+/** Options for {@link usePruneDeletedSelections}. */
+export interface PruneDeletedSelectionsOptions {
+  /** The ids rendered in the Selected section, in hydration order. */
+  recordIds: RecordId[]
+  /** Hydration results, positionally aligned with `recordIds`. */
+  hydratedItems: (RecordPickerItem | null | undefined)[]
+  /** The picker's current selection. */
+  value: RecordId[]
+  /** Called with the selection minus every confirmed-deleted id. */
+  onChange: (selected: RecordId[]) => void
+  /** Skip entirely when the picker cannot be edited. */
+  enabled: boolean
+}
+
+/**
+ * Drop references to **hard-deleted** records from the picker's selection.
+ *
+ * Without this, a dangling id is invisible (it has no hydrated item, so the
+ * Selected section never renders it and the user cannot deselect it) yet stays
+ * in `value` — and `relationship-input-field.tsx` commits the whole id list on
+ * close, re-saving the broken reference on every subsequent edit. Pruning makes
+ * ordinary editing self-healing instead.
+ *
+ * The two-step shape is the safety property: hydration nominates, the server
+ * decides. Anything the existence check will not judge — threads, articles, any
+ * def it cannot resolve to `EntityInstance` — is kept.
+ */
+export function usePruneDeletedSelections({
+  recordIds,
+  hydratedItems,
+  value,
+  onChange,
+  enabled,
+}: PruneDeletedSelectionsOptions): void {
+  // Ids already sent to the existence check, so a verdict of "still there" is
+  // not re-asked on every render.
+  const judged = useRef<Set<RecordId>>(new Set())
+
+  const candidates = useMemo(
+    () => selectNotFoundCandidates(recordIds, hydratedItems),
+    [recordIds, hydratedItems]
+  )
+
+  const pending = useMemo(
+    () => candidates.filter((recordId) => !judged.current.has(recordId)),
+    [candidates]
+  )
+
+  // Stable query input: react-query keys on deep equality, but a fresh array
+  // every render still churns the effect below.
+  const pendingKey = pending.join('|')
+  const items = useMemo(() => (pendingKey ? pendingKey.split('|') : []), [pendingKey])
+
+  const { data } = api.record.checkMissingTargets.useQuery(
+    { items },
+    { enabled: enabled && items.length > 0, staleTime: 60_000 }
+  )
+
+  const valueRef = useRef(value)
+  valueRef.current = value
+  const onChangeRef = useRef(onChange)
+  onChangeRef.current = onChange
+
+  useEffect(() => {
+    if (!data) return
+    for (const recordId of items) judged.current.add(recordId as RecordId)
+    if (data.missing.length === 0) return
+
+    const missing = new Set<string>(data.missing)
+    const next = valueRef.current.filter((recordId) => !missing.has(recordId))
+    if (next.length !== valueRef.current.length) onChangeRef.current(next)
+  }, [data, items])
+}

--- a/apps/web/src/server/api/routers/record.ts
+++ b/apps/web/src/server/api/routers/record.ts
@@ -12,6 +12,7 @@ import {
 } from '@auxx/lib/permissions'
 import {
   type CreateEntityResult,
+  findMissingRecordTargets,
   type LookupCandidate,
   RESOURCE_TABLE_REGISTRY,
   UnifiedCrudHandler,
@@ -662,6 +663,32 @@ export const recordRouter = createTRPCRouter({
           message: `Failed to fetch records by IDs: ${message}`,
         })
       }
+    }),
+
+  /**
+   * Which of these RecordIds point at a target that no longer exists?
+   *
+   * 🛑 **Not the inverse of {@link getByIds}.** That procedure answers "can THIS
+   * viewer read it" — it drops mail-lens ids for everyone, drops whole defs the
+   * viewer's record scope excludes, and narrows per row in SQL. A caller that
+   * treated a hydration miss as deletion would let a restricted viewer strip
+   * references they merely could not see, for everyone. `findMissingRecordTargets`
+   * answers from the target's own backing table and refuses to judge anything it
+   * cannot resolve to `EntityInstance`.
+   *
+   * Deliberately NOT scoped by record visibility: the answer is existence, not
+   * content, and the caller already holds the id (it is stored on a record they
+   * are editing). Returning `[]` on any failure keeps the caller's fallback the
+   * safe one — keep the reference.
+   */
+  checkMissingTargets: capabilityProcedure
+    .input(z.object({ items: z.array(recordIdSchema).max(100) }))
+    .query(async ({ ctx, input }) => {
+      const result = await findMissingRecordTargets(ctx.db, {
+        organizationId: ctx.session.organizationId,
+        recordIds: input.items as RecordId[],
+      })
+      return { missing: result.isOk() ? result.value : [] }
     }),
 
   /**

--- a/packages/lib/src/field-values/field-value-validator.ts
+++ b/packages/lib/src/field-values/field-value-validator.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/field-values/field-value-validator.ts
 
+import type { Database, Transaction } from '@auxx/database'
 import {
   isRecordId,
   parseRecordId,
@@ -184,6 +185,33 @@ export const fieldValueSchemas = {
 }
 
 /**
+ * The verdict for a relationship target with no `EntityInstance` row.
+ *
+ * 🔀 **Soft on purpose, and NOT safe to flip on its own (D-R4).** Two things
+ * have to be true before this can hard-fail:
+ *
+ * 1. **`relatedEntityId` addresses four backing tables, not one.** `Thread`,
+ *    `Article` and `DispatchWorker` targets are legitimate and have no
+ *    `EntityInstance` row, so a check that joins only `EntityInstance` reads
+ *    ~1,256 healthy references in the dev database as missing. Hard-failing here
+ *    would refuse every write that touches a thread or article link — `tag_threads`
+ *    alone carries 1,427 live pairs. A hard rule needs per-target-table
+ *    resolution first; `findMissingRecordTargets` in `resources/record-existence.ts`
+ *    is that resolution, and it answers by REFUSING TO JUDGE anything it cannot
+ *    resolve to `EntityInstance`.
+ * 2. **Write-ahead callers must be surveyed.** Importer, connector and sync sinks
+ *    legitimately write a reference before its target lands; whether any of them
+ *    do so today was not established.
+ *
+ * Until both are settled, a missing target is allowed through and the reference
+ * is cleaned up by the read path (the picker's prune) and the backfill instead.
+ */
+const RELATED_ENTITY_NOT_FOUND = {
+  success: true,
+  message: 'Related entity not found (soft validation)',
+} as const
+
+/**
  * Field value validator with Zod schemas and access control checks.
  */
 export class FieldValueValidator {
@@ -250,6 +278,18 @@ export class FieldValueValidator {
    * Returns a map of entityInstanceId → validation result
    *
    * Accepts both new format (RecordId) and legacy format ({ relatedEntityId, relatedEntityDefinitionId })
+   *
+   * 🛑 **This check did not run for the lifetime of the codebase.** It was
+   * written as `ctx.db.entityInstance.findMany({ where: { id: { in: … } } })` —
+   * Prisma syntax on a Drizzle database — behind a `if (!ctx.db?.entityInstance)`
+   * guard that marked every id valid and returned. The accessor is always
+   * `undefined`, so the guard always fired and the query below it was dead code.
+   * `db` was typed `any`, which is why the typechecker never said so. It is typed
+   * {@link Database} now for exactly that reason.
+   *
+   * Turning it on changes ONE verdict: a target that resolves to a row in a
+   * DIFFERENT organization is now rejected, as the code always intended. The
+   * not-found branch stays soft — see {@link RELATED_ENTITY_NOT_FOUND}.
    */
   async batchValidateRelationships(
     relationships: Array<
@@ -258,7 +298,7 @@ export class FieldValueValidator {
       | { recordId: RecordId }
     >,
     ctx: {
-      db: any // Database instance
+      db: Database | Transaction
       organizationId: string // User's organization
     }
   ): Promise<Map<string, { success: boolean; message?: string }>> {
@@ -280,35 +320,21 @@ export class FieldValueValidator {
         entityInstanceIds.push(rel.relatedEntityId)
       }
     }
-
-    // Check if DB is available
-    if (!ctx.db?.entityInstance) {
-      for (const id of entityInstanceIds) {
-        result.set(id, { success: true })
-      }
-      return result
-    }
+    if (entityInstanceIds.length === 0) return result
 
     try {
-      // Single DB query for all entities
-      const entities = await ctx.db.entityInstance.findMany({
-        where: { id: { in: entityInstanceIds } },
-        select: { id: true, organizationId: true },
+      const rows = await ctx.db.query.EntityInstance.findMany({
+        where: (instances, { inArray }) => inArray(instances.id, entityInstanceIds),
+        columns: { id: true, organizationId: true },
       })
 
-      const entitiesByid = new Map<string, { id: string; organizationId: string }>(
-        entities.map((e: { id: string; organizationId: string }) => [e.id, e])
-      )
+      const byId = new Map(rows.map((row) => [row.id, row]))
 
-      // Check each entity instance
       for (const entityId of entityInstanceIds) {
-        const entity = entitiesByid.get(entityId)
+        const entity = byId.get(entityId)
 
         if (!entity) {
-          result.set(entityId, {
-            success: true, // Soft validation: allow even if not found
-            message: 'Related entity not found (soft validation)',
-          })
+          result.set(entityId, RELATED_ENTITY_NOT_FOUND)
           continue
         }
 
@@ -345,7 +371,7 @@ export class FieldValueValidator {
   async validateRelationship(
     value: unknown,
     ctx: {
-      db: any // Database instance
+      db: Database | Transaction
       organizationId: string // User's organization
     }
   ) {
@@ -358,28 +384,15 @@ export class FieldValueValidator {
     const { recordId } = structureResult.data
     const { entityInstanceId } = parseRecordId(recordId)
 
-    // Then validate access - check that related entity exists AND belongs to same org
-    // NOTE: This is a soft validation - if it fails, we still allow the relationship but log a warning
+    // Then validate access - check that related entity exists AND belongs to same org.
+    // The not-found branch is soft on purpose — see RELATED_ENTITY_NOT_FOUND.
     try {
-      if (!ctx.db?.entityInstance) {
-        console.warn(
-          '[FieldValueValidator] Database context not available for relationship validation, skipping access check'
-        )
-        return {
-          success: true as const,
-          data: { recordId },
-        }
-      }
-
-      const relatedEntity = await ctx.db.entityInstance.findUnique({
-        where: { id: entityInstanceId },
-        select: { id: true, organizationId: true },
+      const relatedEntity = await ctx.db.query.EntityInstance.findFirst({
+        where: (instances, { eq }) => eq(instances.id, entityInstanceId),
+        columns: { id: true, organizationId: true },
       })
 
       if (!relatedEntity) {
-        console.warn(
-          `[FieldValueValidator] Related entity not found: ${entityInstanceId}, allowing relationship`
-        )
         return {
           success: true as const,
           data: { recordId },

--- a/packages/lib/src/resources/index.ts
+++ b/packages/lib/src/resources/index.ts
@@ -84,6 +84,9 @@ export {
   systemConditionBuilder,
   type ValidationResult,
 } from './query-builder'
+// Positive existence check for relation targets (NOT the inverse of hydration)
+export type { FindMissingRecordTargetsParams } from './record-existence'
+export { findMissingRecordTargets, MAX_EXISTENCE_BATCH } from './record-existence'
 // Type exports
 export type {
   CustomResource,

--- a/packages/lib/src/resources/record-existence.test.ts
+++ b/packages/lib/src/resources/record-existence.test.ts
@@ -1,0 +1,182 @@
+// packages/lib/src/resources/record-existence.test.ts
+//
+// `findMissingRecordTargets` is the only thing allowed to say a relation target
+// is gone. Everything downstream of it DELETES on its say-so, so the tests that
+// matter are the refusals: which defs it will not judge, and why.
+
+import { describe, expect, it, vi } from 'vitest'
+
+const getCachedResources = vi.hoisted(() => vi.fn(async () => [] as unknown[]))
+
+vi.mock('../cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../cache')>()
+  return { ...actual, getCachedResources }
+})
+
+import type { RecordId } from '@auxx/types/resource'
+import { findMissingRecordTargets } from './record-existence'
+
+const ORG = 'org_1'
+const WORK_ORDER_DEF = 'wodefwodefwodefwodef0001'
+const CONTACT_DEF = 'ctdefctdefctdefctdef0001'
+
+function customResource(overrides: {
+  id: string
+  apiSlug: string
+  entityDefinitionId: string
+  entityType?: string
+}) {
+  return { type: 'custom', ...overrides } as unknown
+}
+
+function resourcesFixture() {
+  return [
+    customResource({
+      id: WORK_ORDER_DEF,
+      apiSlug: 'work-orders',
+      entityDefinitionId: WORK_ORDER_DEF,
+      entityType: 'work_order',
+    }),
+    customResource({
+      id: CONTACT_DEF,
+      apiSlug: 'contacts',
+      entityDefinitionId: CONTACT_DEF,
+      entityType: 'contact',
+    }),
+    // `thread` IS in the resource cache, as a system resource. It must never be
+    // judged even though it resolves.
+    { type: 'system', id: 'thread', apiSlug: 'threads', entityDefinitionId: 'thread' } as unknown,
+  ]
+}
+
+/**
+ * A `db` whose single `select().from().where()` chain answers with the rows it
+ * was seeded with, and records the fact that it ran at all — "did it query?" is
+ * itself an assertion for the refusal cases.
+ */
+function fakeDb(presentIds: string[]) {
+  let queried = false
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: async () => {
+          queried = true
+          return presentIds.map((id) => ({ id }))
+        },
+      }),
+    }),
+  } as never
+  return { db, didQuery: () => queried }
+}
+
+beforeEach(() => {
+  getCachedResources.mockReset().mockResolvedValue(resourcesFixture() as never)
+})
+
+describe('findMissingRecordTargets', () => {
+  it('reports an EntityInstance-backed target with no row', async () => {
+    const alive = `${WORK_ORDER_DEF}:alive` as RecordId
+    const dead = `${WORK_ORDER_DEF}:dead` as RecordId
+    const { db } = fakeDb(['alive'])
+
+    const result = await findMissingRecordTargets(db, {
+      organizationId: ORG,
+      recordIds: [alive, dead],
+    })
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()).toEqual([dead])
+  })
+
+  it('resolves a def named by its entityType slug as well as its id', async () => {
+    const dead = 'contact:gone' as RecordId
+    const { db } = fakeDb([])
+
+    const result = await findMissingRecordTargets(db, { organizationId: ORG, recordIds: [dead] })
+
+    expect(result._unsafeUnwrap()).toEqual([dead])
+  })
+
+  it('NEVER judges a thread — every thread id resolves to nothing in hydration', async () => {
+    // The whole reason the picker cannot drop on a hydration miss:
+    // `getResourcesByIds` drops mail-lens ids from the batch for EVERY viewer,
+    // so a live `tag_threads` link looks exactly like a deleted one. 1,253 such
+    // links are healthy in the dev database.
+    const thread = 'thread:live_thread_id' as RecordId
+    const { db, didQuery } = fakeDb([])
+
+    const result = await findMissingRecordTargets(db, { organizationId: ORG, recordIds: [thread] })
+
+    expect(result._unsafeUnwrap()).toEqual([])
+    expect(didQuery()).toBe(false)
+  })
+
+  it('NEVER judges a def missing from the resource cache', async () => {
+    // `article`'s EntityDefinition row is filtered OUT of the resource cache
+    // because its data lives in a dedicated table. "Not in the cache" is
+    // ambiguity, not absence.
+    const article = 'article:some_article_id' as RecordId
+    const { db, didQuery } = fakeDb([])
+
+    const result = await findMissingRecordTargets(db, { organizationId: ORG, recordIds: [article] })
+
+    expect(result._unsafeUnwrap()).toEqual([])
+    expect(didQuery()).toBe(false)
+  })
+
+  it('judges the judgeable half of a mixed batch and leaves the rest alone', async () => {
+    const deadWorkOrder = `${WORK_ORDER_DEF}:dead_wo` as RecordId
+    const thread = 'thread:live_thread' as RecordId
+    const article = 'article:live_article' as RecordId
+    const { db } = fakeDb([])
+
+    const result = await findMissingRecordTargets(db, {
+      organizationId: ORG,
+      recordIds: [deadWorkOrder, thread, article],
+    })
+
+    expect(result._unsafeUnwrap()).toEqual([deadWorkOrder])
+  })
+
+  it('reports every spelling of a dead instance, not just the one queried', async () => {
+    const bySlug = 'work_order:dead' as RecordId
+    const byDefId = `${WORK_ORDER_DEF}:dead` as RecordId
+    const { db } = fakeDb([])
+
+    const result = await findMissingRecordTargets(db, {
+      organizationId: ORG,
+      recordIds: [bySlug, byDefId],
+    })
+
+    expect(result._unsafeUnwrap().sort()).toEqual([bySlug, byDefId].sort())
+  })
+
+  it('returns an error rather than a verdict when the query fails', async () => {
+    // Fails CLOSED on the delete side: no ids reported missing, so no caller
+    // removes anything.
+    const db = {
+      select: () => ({
+        from: () => ({
+          where: async () => {
+            throw new Error('connection reset')
+          },
+        }),
+      }),
+    } as never
+
+    const result = await findMissingRecordTargets(db, {
+      organizationId: ORG,
+      recordIds: [`${WORK_ORDER_DEF}:x` as RecordId],
+    })
+
+    expect(result.isErr()).toBe(true)
+  })
+
+  it('answers empty for an empty batch without touching the cache', async () => {
+    const { db, didQuery } = fakeDb([])
+    const result = await findMissingRecordTargets(db, { organizationId: ORG, recordIds: [] })
+    expect(result._unsafeUnwrap()).toEqual([])
+    expect(didQuery()).toBe(false)
+    expect(getCachedResources).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/resources/record-existence.ts
+++ b/packages/lib/src/resources/record-existence.ts
@@ -1,0 +1,133 @@
+// packages/lib/src/resources/record-existence.ts
+
+import { type Database, schema, type Transaction } from '@auxx/database'
+import { and, eq, inArray } from 'drizzle-orm'
+import { err, ok, type Result } from 'neverthrow'
+import { getCachedResources } from '../cache'
+import { isMailLensTableId } from './picker/mail-lens-tables'
+import { isCustomResource, isSystemResourceId } from './registry'
+import { parseRecordId, type RecordId } from './resource-id'
+
+/** The largest batch one call will judge. Matches `record.getByIds`. */
+export const MAX_EXISTENCE_BATCH = 100
+
+/** Parameters for {@link findMissingRecordTargets}. */
+export interface FindMissingRecordTargetsParams {
+  organizationId: string
+  /** RecordIds to judge. Ids beyond {@link MAX_EXISTENCE_BATCH} are ignored. */
+  recordIds: RecordId[]
+}
+
+/**
+ * Answer which of these RecordIds point at a target that is **provably absent**
+ * from the organization — the positive existence signal a caller needs before
+ * it may remove a stored reference.
+ *
+ * 🛑 **This is deliberately NOT the inverse of "the picker could hydrate it".**
+ * `record.getByIds` answers "can THIS viewer read it", and a `null` from that
+ * path has at least five causes, only one of which is deletion:
+ *
+ * 1. the def is instance-access and unroutable through the record path
+ *    (`filterHydratableRecordIds` in `record.ts`),
+ * 2. the def is a mail-lens table — **every** `thread:` / `message:` id resolves
+ *    to nothing there, for every viewer, alive or not
+ *    (`RecordPickerService.getResourcesByIds` step 0.1),
+ * 3. the viewer's record scope for the def is `none`,
+ * 4. the per-row visibility predicate excluded the row in SQL,
+ * 5. `admitSystemRows` dropped it on instance access (kb / dataset / article).
+ *
+ * Treating any of those as "deleted" would let a restricted viewer strip
+ * references they merely could not see — for everyone. So this answers from the
+ * row's own backing table instead, and **refuses to judge anything it cannot
+ * resolve to `EntityInstance`**: a system table-backed def (`thread`,
+ * `article`, `message`, `user`, …), a mail-lens def, or a def key that does not
+ * resolve through the org's resource cache at all. Those are omitted from the
+ * answer — never reported missing.
+ *
+ * `relatedEntityId` addresses four different backing tables; a check that joins
+ * only `EntityInstance` and calls every miss "deleted" would condemn ~1,256
+ * healthy `Thread` / `Article` / `DispatchWorker` references.
+ *
+ * ⚠️ **Archived is not absent.** No `archivedAt` predicate is applied, on
+ * purpose — an archived record still exists and its references are live.
+ *
+ * @returns the subset of `recordIds` whose target row is confirmed gone
+ */
+export async function findMissingRecordTargets(
+  db: Database | Transaction,
+  params: FindMissingRecordTargetsParams
+): Promise<Result<RecordId[], Error>> {
+  const { organizationId } = params
+  const recordIds = params.recordIds.slice(0, MAX_EXISTENCE_BATCH)
+  if (recordIds.length === 0) return ok([])
+
+  const isJudgeableDef = await buildJudgeableDefTest(organizationId)
+
+  // instanceId -> the RecordIds that named it. One instance can be named under
+  // several def prefixes (entityType slug vs definition id); all share a verdict.
+  const judgeable = new Map<string, RecordId[]>()
+  for (const recordId of recordIds) {
+    const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+    if (!entityInstanceId || !isJudgeableDef(entityDefinitionId)) continue
+    const named = judgeable.get(entityInstanceId)
+    if (named) named.push(recordId)
+    else judgeable.set(entityInstanceId, [recordId])
+  }
+  if (judgeable.size === 0) return ok([])
+
+  let rows: { id: string }[]
+  try {
+    rows = await db
+      .select({ id: schema.EntityInstance.id })
+      .from(schema.EntityInstance)
+      .where(
+        and(
+          eq(schema.EntityInstance.organizationId, organizationId),
+          inArray(schema.EntityInstance.id, [...judgeable.keys()])
+        )
+      )
+  } catch (error) {
+    return err(error instanceof Error ? error : new Error('Failed to resolve record targets'))
+  }
+
+  const present = new Set(rows.map((row) => row.id))
+  const missing: RecordId[] = []
+  for (const [instanceId, named] of judgeable) {
+    if (!present.has(instanceId)) missing.push(...named)
+  }
+  return ok(missing)
+}
+
+/**
+ * Build the synchronous "is a missing `EntityInstance` row conclusive for this
+ * def?" test, reading the org's resource cache once.
+ *
+ * A def key reaches this in any of four spellings — the resource id, the
+ * `entityDefinitionId`, the `entityType` slug, or the `apiSlug` — so all four
+ * are indexed. Anything that does not resolve to a `type: 'custom'` resource
+ * answers `false`, which is the safe direction: `article`'s EntityDefinition row
+ * is filtered OUT of the resource cache precisely because its data lives in a
+ * dedicated table, so "not in the cache" must never mean "gone".
+ */
+async function buildJudgeableDefTest(
+  organizationId: string
+): Promise<(entityDefinitionId: string) => boolean> {
+  const resources = await getCachedResources(organizationId)
+  const entityInstanceBacked = new Set<string>()
+  for (const resource of resources) {
+    if (!isCustomResource(resource)) continue
+    entityInstanceBacked.add(resource.id)
+    entityInstanceBacked.add(resource.apiSlug)
+    if (resource.entityDefinitionId) entityInstanceBacked.add(resource.entityDefinitionId)
+    if (resource.entityType) entityInstanceBacked.add(resource.entityType)
+  }
+
+  return (entityDefinitionId: string) => {
+    if (!entityDefinitionId) return false
+    // Static refusals stay ahead of the cache so a slug that somehow appears in
+    // both keyspaces can never be judged.
+    if (isMailLensTableId(entityDefinitionId)) return false
+    if (isSystemResourceId(entityDefinitionId)) return false
+    return entityInstanceBacked.has(entityDefinitionId)
+  }
+}


### PR DESCRIPTION
Layer 2 of `plans/field-values/dangling-relation-references.md`. The delete-path fix (layers 1/3) and the backfill are separate.

## The problem

A relation is stored as **two mirror `FieldValue` rows** and `relatedEntityId` is a bare `text()` column with **no foreign key** (`field-value.ts:93`), so deleting a record leaves the mirror dangling. There are **1,619 such references in dev — 15.5% of all relation values**, all hanging off live records.

The relation picker was keeping them alive. `hydratedMap` admits only truthy items, so a dangling id **never renders in the Selected section** — the user can neither see nor deselect it — but it stays in `value`, and `relationship-input-field.tsx` commits the full list on close. **Every subsequent edit re-saved the broken reference.**

## Why the obvious fix would have been data loss

Dropping an id that fails to hydrate is **not** safe. A hydration miss means at least six different things and the client cannot tell them apart:

- `record.getByIds` is scoped at the read floor and drops unauthorized ids silently. Its own docstring: *"a row coming back IS the read verdict… A row that does not come back DENIES."*
- `RecordPickerService` drops **every `thread:`/`message:` id from the batch unconditionally**, for every viewer, alive or dead (`isMailLensTableId(...) continue`).
- Plus kb/dataset/article instance-access drops and unresolvable def prefixes.

There are **1,253 healthy `Thread` references** in dev. A blind drop deletes all of them on the next save.

## What this does instead

**Hydration nominates; the server decides.** New `findMissingRecordTargets` (`packages/lib/src/resources/record-existence.ts`) resolves each target against **its own backing table** and **refuses to judge** anything it cannot resolve to an `EntityInstance`-backed resource — so mail-lens ids, system `TableId`s and `article` are never candidates. Only confirmed-absent ids are pruned from `value`. Archived is explicitly **not** absent.

**`null` and `undefined` stay different answers.** `null` = the batch returned and this id was not in it; `undefined` = not loaded yet. The predicate is `=== null`, never falsiness:

| frame | `=== null` (shipped) | `!item` (naive) |
|---|---|---|
| `[undefined, undefined, undefined]` — first paint | `[]` | **`[A, B, C]`** ← saves the field empty |
| `[item, undefined, undefined]` — partial batch | `[]` | **`[B, C]`** |
| `[item, null, undefined]` — settled | `[B]` | **`[B, C]`** |

The test asserts the naive column explicitly, so the guard fails loudly if anyone rewrites it as a truthiness check.

**Paste fails open, the picker fails closed.** Paste proceeds if the check can't run (refusing a valid paste is worse than propagating an already-broken ref); the picker deletes nothing without an affirmative verdict. `cell-coercion.ts` stays a pure sync function — callers resolve the verdict once and inject a predicate, and omitting it preserves today's behavior exactly.

## Also: relationship writes have never been validated

`batchValidateRelationships` called `ctx.db.entityInstance.findMany({ where: { id: { in: … } } })` — **Prisma syntax on a Drizzle database**. That accessor appears in exactly one file (4 uses) against 29 canonical `db.query.EntityInstance` uses elsewhere, so it was always `undefined`, the guard above it always fired, and the query was dead code. `db` was typed `any`, which is why the typechecker never caught it. Now `Database | Transaction` with a real Drizzle query.

**Not-found deliberately stays soft.** The check is single-table while the column is four-table, so hard-failing would refuse every write touching a thread or article link — `tag_threads`/`thread_tags` alone is 1,427 live pairs. A strict flag would be wrong *even opt-in*; per-target-table resolution is the prerequisite, and `findMissingRecordTargets` is now that resolution.

⚠️ **One previously-dead path goes live:** a target resolving to a row in a **different organization** is now rejected, as the code's own `// CRITICAL` comment always intended. CUID ids make this unreachable outside a caller bug, but it is a real behavior change on a path that has never executed.

## Testing

- `packages/lib/src/field-values` 272 passed · `packages/lib/src/resources` 549 passed (incl. 8 new) · `apps/web` pickers/table/routers 1,548 passed (incl. 11 new).
- `packages/lib` typecheck: 0 errors under `src/`. `apps/web`: 26 lines of pre-existing errors, none in touched files.
- Biome clean at error level.
- **Not browser-verified** — the prune logic is unit-tested, but the React Query wiring inside a live picker has not been exercised.

## Known limit

Both thread-targeting relation fields (`tag_threads`, `message.thread`) are `isInverse` system fields with `updatable: false`, so a *currently rendered* picker holding thread ids could not be demonstrated. The mail-lens hazard is unambiguously live at the hydration/API layer and is fatal to anything treating a hydration miss as deletion, but for `RecordPickerContent` specifically it is latent rather than demonstrated. The kb/dataset/article and unresolvable-def legs are live regardless.