### PR TITLE
fix(records): delete both halves of a relation, not just one

### DIFF
--- a/packages/lib/src/data-migrations/migrations/105-prune-dangling-relation-values.int.test.ts
+++ b/packages/lib/src/data-migrations/migrations/105-prune-dangling-relation-values.int.test.ts
@@ -1,0 +1,236 @@
+// packages/lib/src/data-migrations/migrations/105-prune-dangling-relation-values.int.test.ts
+//
+// DB-backed test (vitest.integration.config.ts → auxx_test) for the backfill's
+// two ways of destroying live data:
+//
+//   1. Resolving every target against `EntityInstance` alone. `relatedEntityId`
+//      addresses several backing tables — a join against one of them classifies
+//      1,256 healthy `Thread` / `Article` / `DispatchWorker` references as
+//      dangling and deletes them. `Tag` stands in for that whole family here.
+//   2. Treating `archivedAt` as deleted. Archived is not deleted, and zero
+//      dangling references point at an archived row.
+//
+// Runs against the ephemeral `auxx_test` database only — the migration is NOT
+// registered as applied anywhere and has never been run against dev or prod.
+
+import { type Database, schema } from '@auxx/database'
+import { createTestOrganization, getTestDb } from '@auxx/test-utils'
+import { eq } from 'drizzle-orm'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { migration105PruneDanglingRelationValues } from './105-prune-dangling-relation-values'
+
+const db = () => getTestDb() as never as Database
+
+interface Fixture {
+  orgId: string
+  contactDefId: string
+  workOrderDefId: string
+  relationFieldId: string
+  textFieldId: string
+  workOrderId: string
+  liveContactId: string
+  archivedContactId: string
+  tagId: string
+}
+
+/** An id shaped like a real one that resolves in no table at all. */
+const GHOST_CONTACT = 'ghost0000000000000000000'
+const GHOST_OWNER = 'ghost1111111111111111111'
+
+async function seed(): Promise<Fixture> {
+  const org = await createTestOrganization()
+
+  const definition = async (entityType: string, apiSlug: string) => {
+    const [def] = await db()
+      .insert(schema.EntityDefinition)
+      .values({
+        organizationId: org.id,
+        entityType,
+        apiSlug,
+        singular: entityType,
+        plural: apiSlug,
+        updatedAt: new Date(),
+      })
+      .returning()
+    return def!.id
+  }
+
+  const contactDefId = await definition('contact', 'contacts')
+  const workOrderDefId = await definition('work_order', 'work-orders')
+
+  const field = async (defId: string, modelType: string, name: string, type: string) => {
+    const [row] = await db()
+      .insert(schema.CustomField)
+      .values({
+        organizationId: org.id,
+        entityDefinitionId: defId,
+        modelType,
+        name,
+        type: type as never,
+        sortOrder: 'a1',
+        isCustom: false,
+        updatedAt: new Date(),
+      })
+      .returning()
+    return row!.id
+  }
+
+  const relationFieldId = await field(workOrderDefId, 'work_order', 'Contact', 'RELATIONSHIP')
+  const textFieldId = await field(workOrderDefId, 'work_order', 'Notes', 'TEXT')
+
+  const instance = async (defId: string, displayName: string, archived = false) => {
+    const [row] = await db()
+      .insert(schema.EntityInstance)
+      .values({
+        organizationId: org.id,
+        entityDefinitionId: defId,
+        displayName,
+        archivedAt: archived ? new Date() : null,
+        updatedAt: new Date(),
+      })
+      .returning()
+    return row!.id
+  }
+
+  const workOrderId = await instance(workOrderDefId, 'WO-1')
+  const liveContactId = await instance(contactDefId, 'Live Contact')
+  const archivedContactId = await instance(contactDefId, 'Archived Contact', true)
+
+  // `Tag` is a system table, not `EntityInstance` — the family the naive
+  // single-join query would wrongly classify as dangling.
+  const [tag] = await db()
+    .insert(schema.Tag)
+    .values({ organizationId: org.id, title: 'Urgent', updatedAt: new Date() })
+    .returning()
+
+  return {
+    orgId: org.id,
+    contactDefId,
+    workOrderDefId,
+    relationFieldId,
+    textFieldId,
+    workOrderId,
+    liveContactId,
+    archivedContactId,
+    tagId: tag!.id,
+  }
+}
+
+let f: Fixture
+
+async function relationValue(
+  entityId: string,
+  relatedEntityId: string,
+  sortKey: string,
+  relatedDefId?: string
+): Promise<string> {
+  const [row] = await db()
+    .insert(schema.FieldValue)
+    .values({
+      organizationId: f.orgId,
+      entityId,
+      entityDefinitionId: f.workOrderDefId,
+      fieldId: f.relationFieldId,
+      relatedEntityId,
+      relatedEntityDefinitionId: relatedDefId ?? f.contactDefId,
+      sortKey,
+      updatedAt: new Date(),
+    })
+    .returning()
+  return row!.id
+}
+
+async function exists(fieldValueId: string): Promise<boolean> {
+  const rows = await db()
+    .select({ id: schema.FieldValue.id })
+    .from(schema.FieldValue)
+    .where(eq(schema.FieldValue.id, fieldValueId))
+  return rows.length > 0
+}
+
+beforeEach(async () => {
+  f = await seed()
+})
+
+describe('migration 105 — prune dangling relation values', () => {
+  it('deletes the mirror row pointing at a record that no longer exists', async () => {
+    const dangling = await relationValue(f.workOrderId, GHOST_CONTACT, 'a')
+
+    await migration105PruneDanglingRelationValues.run(db())
+
+    expect(await exists(dangling)).toBe(false)
+  })
+
+  it('keeps a reference to a target in a NON-EntityInstance table', async () => {
+    // The single most damaging mistake available here: resolving only against
+    // `EntityInstance` would read this healthy row as dangling.
+    const healthy = await relationValue(f.workOrderId, f.tagId, 'a', 'tag')
+
+    await migration105PruneDanglingRelationValues.run(db())
+
+    expect(await exists(healthy)).toBe(true)
+  })
+
+  it('keeps a reference whose target is merely ARCHIVED', async () => {
+    const archivedRef = await relationValue(f.workOrderId, f.archivedContactId, 'a')
+
+    await migration105PruneDanglingRelationValues.run(db())
+
+    expect(await exists(archivedRef)).toBe(true)
+  })
+
+  it('keeps an ordinary live relation', async () => {
+    const live = await relationValue(f.workOrderId, f.liveContactId, 'a')
+
+    await migration105PruneDanglingRelationValues.run(db())
+
+    expect(await exists(live)).toBe(true)
+  })
+
+  it('deletes a value whose OWNING record is gone, whatever its type', async () => {
+    const [orphan] = await db()
+      .insert(schema.FieldValue)
+      .values({
+        organizationId: f.orgId,
+        entityId: GHOST_OWNER,
+        entityDefinitionId: f.workOrderDefId,
+        fieldId: f.textFieldId,
+        valueText: 'stranded',
+        updatedAt: new Date(),
+      })
+      .returning()
+
+    await migration105PruneDanglingRelationValues.run(db())
+
+    expect(await exists(orphan!.id)).toBe(false)
+  })
+
+  it('keeps a plain value on a live record', async () => {
+    const [kept] = await db()
+      .insert(schema.FieldValue)
+      .values({
+        organizationId: f.orgId,
+        entityId: f.workOrderId,
+        entityDefinitionId: f.workOrderDefId,
+        fieldId: f.textFieldId,
+        valueText: 'still here',
+        updatedAt: new Date(),
+      })
+      .returning()
+
+    await migration105PruneDanglingRelationValues.run(db())
+
+    expect(await exists(kept!.id)).toBe(true)
+  })
+
+  it('is idempotent — a second pass finds nothing left to delete', async () => {
+    const dangling = await relationValue(f.workOrderId, GHOST_CONTACT, 'a')
+    const live = await relationValue(f.workOrderId, f.liveContactId, 'b')
+
+    await migration105PruneDanglingRelationValues.run(db())
+    await migration105PruneDanglingRelationValues.run(db())
+
+    expect(await exists(dangling)).toBe(false)
+    expect(await exists(live)).toBe(true)
+  })
+})

--- a/packages/lib/src/data-migrations/migrations/105-prune-dangling-relation-values.ts
+++ b/packages/lib/src/data-migrations/migrations/105-prune-dangling-relation-values.ts
@@ -1,0 +1,264 @@
+// packages/lib/src/data-migrations/migrations/105-prune-dangling-relation-values.ts
+
+import type { Database } from '@auxx/database'
+import { createScopedLogger } from '@auxx/logger'
+import { sql } from 'drizzle-orm'
+import { updateSearchTextForInstances } from '../../field-values/search-text'
+import type { DataMigrationDef } from '../types'
+
+const logger = createScopedLogger('migration-105')
+
+/** Rebuild `searchText` in bounded batches — the helper inlines every id into one `IN` list. */
+const SEARCH_TEXT_BATCH = 500
+
+/**
+ * Every table a `FieldValue.entityId` / `relatedEntityId` can legitimately
+ * resolve against.
+ *
+ * 🛑 **Getting this list short is how this migration destroys live data.**
+ * `relatedEntityDefinitionId` spans a dual keyspace and the column addresses
+ * several backing tables, not one. A prune that joins only `EntityInstance`
+ * deletes 1,256 perfectly healthy `Thread` / `Article` / `DispatchWorker`
+ * references — measured, not hypothetical.
+ *
+ * The list is deliberately **generous**: an extra table can only leave a genuine
+ * orphan behind (harmless, the next run catches it), while a missing one deletes
+ * live rows. It is the set of non-junction, id-bearing record tables reachable
+ * from `ModelTypeMeta[*].dbTable` (`packages/database/src/enums.ts`) that
+ * actually exist in `packages/database/src/db/schema/`. Note that `Contact` and
+ * `Ticket` appear in `ModelTypeMeta` but have **no** table — both are
+ * `EntityInstance`-backed, which is why their dangling references are real.
+ *
+ * Hardcoded rather than derived, because a data migration must keep meaning what
+ * it meant on the day it ran: deriving the set from a live registry would let a
+ * later refactor silently change which rows a re-run deletes.
+ */
+const TARGET_TABLES = [
+  'EntityInstance',
+  'Thread',
+  'Article',
+  'DispatchWorker',
+  'Invoice',
+  'Message',
+  'Tag',
+  'Participant',
+  'Dataset',
+  'KnowledgeBase',
+  'WorkOrderVisit',
+  'EndUser',
+  'User',
+] as const
+
+/**
+ * `NOT EXISTS` over every table in {@link TARGET_TABLES} for one column.
+ *
+ * 🛑 **No `archivedAt` predicate, on purpose.** Archived is not deleted. Zero
+ * dangling references point at an archived row today, and treating archived as
+ * dead would prune references to records a user can still restore.
+ *
+ * Nothing here is caller-supplied, so `sql.raw` is safe.
+ */
+function unresolvableSql(column: string): string {
+  return TARGET_TABLES.map(
+    (table) => `NOT EXISTS (SELECT 1 FROM "${table}" t WHERE t.id = fv."${column}")`
+  ).join('\n      AND ')
+}
+
+/**
+ * The mirror half: a relation value on a LIVE record pointing at a record that
+ * was hard-deleted.
+ *
+ * Restricted to `cf."type" = 'RELATIONSHIP'` so `ACTOR` rows — which also
+ * populate `relatedEntityId`, with a different keyspace and a different set of
+ * backing tables — are out of scope entirely.
+ */
+const danglingInboundPredicate = sql`
+  fv."relatedEntityId" IS NOT NULL
+  AND cf."type" = 'RELATIONSHIP'
+  AND ${sql.raw(unresolvableSql('relatedEntityId'))}
+`
+
+/**
+ * The other orphan class: a value whose OWNING record is gone. Produced by the
+ * thread/article permanent-delete path, which never touched `FieldValue` at all
+ * and so leaked both halves.
+ *
+ * No field-type restriction — a value with no owner is unreachable whatever its
+ * type, and this population is mostly `thread_tags` / `article_tags` plus a set
+ * of billing projections written onto invoices that had already been deleted.
+ */
+const orphanOutboundPredicate = sql`${sql.raw(unresolvableSql('entityId'))}`
+
+/**
+ * Type alias, not an interface: `db.execute<T>` constrains `T` to
+ * `Record<string, unknown>`, and only a type literal picks up the implicit index
+ * signature that satisfies it.
+ */
+type ReportRow = {
+  organizationId: string
+  fieldId: string
+  fieldName: string
+  fieldType: string
+  relatedEntityDefinitionId: string | null
+  danglingValues: number
+  affectedRecords: number
+  samples: string[]
+}
+
+type OutboundReportRow = {
+  organizationId: string
+  entityDefinitionId: string
+  fieldType: string
+  orphanedValues: number
+  affectedEntities: number
+}
+
+/**
+ * Delete `FieldValue` rows on both sides of relations whose other end no longer
+ * exists.
+ *
+ * **Why they exist.** A relation is stored as TWO mirror rows, one on each end,
+ * and `FieldValue.relatedEntityId` is a bare `text()` column with no foreign key
+ * (`packages/database/src/db/schema/field-value.ts:93`) — same for `entityId`.
+ * `deleteEntityInstance` removed only the dead record's own values, so the
+ * mirror row stayed on the still-living record; the thread and article
+ * permanent-delete paths removed neither. In the dev database that left 1,619
+ * dangling inbound references (15.5% of all relation values, all of them hanging
+ * off live records — one contact displayed 475 work orders that no longer exist
+ * against 15 that do) plus 275 owner-less outbound rows.
+ *
+ * **Prune, not repoint.** Unlike a merge — where `merge-service.ts` repoints
+ * `relatedEntityId` at the winner — the target here is hard-deleted and
+ * unrecoverable. There is nothing to point at.
+ *
+ * 🛑 **Ordering.** This must run only AFTER the relation picker stops
+ * re-committing dead ids on save. Run it first and ordinary editing puts the
+ * rows straight back, silently, from users who never knew they touched them.
+ *
+ * **searchText.** `EntityInstance.searchText` folds in the related record's
+ * `displayName` and is recomputed only on write, so every holder is currently
+ * carrying a dead record's name in its search corpus. The affected ids come
+ * straight off `DELETE … RETURNING`, so the rebuild costs no extra scan. Stale
+ * `displayName` / `secondaryDisplayValue` projections are NOT repaired here —
+ * that cascade needs the deleted record's entity type, which is exactly the
+ * thing no longer available.
+ *
+ * Raw Drizzle on purpose (project convention for data migrations): the
+ * field-value write path fires realtime, record rules and reconciliation side
+ * effects that a garbage-collection pass has no business entering.
+ *
+ * Idempotent: a re-run after a partial failure finds nothing left to match.
+ */
+export const migration105PruneDanglingRelationValues: DataMigrationDef = {
+  id: '105-prune-dangling-relation-values',
+  description: 'Delete relation field values whose target record, or whose own record, is gone',
+  async run(db: Database): Promise<void> {
+    // Report first — once the rows are gone there is no way to reconstruct what
+    // each field lost.
+    const inboundReport = await db.execute<ReportRow>(sql`
+      SELECT
+        fv."organizationId",
+        cf.id AS "fieldId",
+        cf.name AS "fieldName",
+        cf."type" AS "fieldType",
+        fv."relatedEntityDefinitionId",
+        count(*)::int AS "danglingValues",
+        count(DISTINCT fv."entityId")::int AS "affectedRecords",
+        (array_agg(DISTINCT fv."relatedEntityId"))[1:5] AS samples
+      FROM "FieldValue" fv
+      JOIN "CustomField" cf
+        ON cf.id = fv."fieldId"
+       AND cf."organizationId" = fv."organizationId"
+      WHERE ${danglingInboundPredicate}
+      GROUP BY fv."organizationId", cf.id, cf.name, cf."type", fv."relatedEntityDefinitionId"
+      ORDER BY fv."organizationId", cf.id
+    `)
+
+    for (const row of inboundReport.rows) {
+      logger.info('Dangling relation references found', {
+        organizationId: row.organizationId,
+        fieldId: row.fieldId,
+        fieldName: row.fieldName,
+        relatedEntityDefinitionId: row.relatedEntityDefinitionId,
+        danglingValues: row.danglingValues,
+        affectedRecords: row.affectedRecords,
+        sampleTargetIds: row.samples,
+      })
+    }
+
+    const outboundReport = await db.execute<OutboundReportRow>(sql`
+      SELECT
+        fv."organizationId",
+        fv."entityDefinitionId",
+        cf."type" AS "fieldType",
+        count(*)::int AS "orphanedValues",
+        count(DISTINCT fv."entityId")::int AS "affectedEntities"
+      FROM "FieldValue" fv
+      JOIN "CustomField" cf
+        ON cf.id = fv."fieldId"
+       AND cf."organizationId" = fv."organizationId"
+      WHERE ${orphanOutboundPredicate}
+      GROUP BY fv."organizationId", fv."entityDefinitionId", cf."type"
+      ORDER BY fv."organizationId", fv."entityDefinitionId"
+    `)
+
+    for (const row of outboundReport.rows) {
+      logger.info('Owner-less field values found', {
+        organizationId: row.organizationId,
+        entityDefinitionId: row.entityDefinitionId,
+        fieldType: row.fieldType,
+        orphanedValues: row.orphanedValues,
+        affectedEntities: row.affectedEntities,
+      })
+    }
+
+    // Inbound first: its `RETURNING` names the LIVE records whose search corpus
+    // needs rebuilding. The outbound pass returns nothing worth rebuilding —
+    // those records no longer exist.
+    const inboundDeleted = await db.execute<{ organizationId: string; entityId: string }>(sql`
+      DELETE FROM "FieldValue" fv
+      USING "CustomField" cf
+      WHERE cf.id = fv."fieldId"
+        AND cf."organizationId" = fv."organizationId"
+        AND ${danglingInboundPredicate}
+      RETURNING fv."organizationId", fv."entityId"
+    `)
+
+    const outboundDeleted = await db.execute<{ id: string }>(sql`
+      DELETE FROM "FieldValue" fv
+      WHERE ${orphanOutboundPredicate}
+      RETURNING fv.id
+    `)
+
+    // searchText is rebuilt per org because the helper is org-scoped. Ids that
+    // belong to a non-`EntityInstance` holder (a Thread's `thread_tags`, say)
+    // simply match no row.
+    const byOrganization = new Map<string, Set<string>>()
+    for (const row of inboundDeleted.rows) {
+      const ids = byOrganization.get(row.organizationId) ?? new Set<string>()
+      ids.add(row.entityId)
+      byOrganization.set(row.organizationId, ids)
+    }
+
+    let instancesRebuilt = 0
+    for (const [organizationId, idSet] of byOrganization) {
+      const entityInstanceIds = [...idSet]
+      for (let i = 0; i < entityInstanceIds.length; i += SEARCH_TEXT_BATCH) {
+        await updateSearchTextForInstances(
+          db,
+          organizationId,
+          entityInstanceIds.slice(i, i + SEARCH_TEXT_BATCH)
+        )
+      }
+      instancesRebuilt += entityInstanceIds.length
+    }
+
+    logger.info('Pruned dangling relation values', {
+      inboundDeleted: inboundDeleted.rows.length,
+      outboundDeleted: outboundDeleted.rows.length,
+      fieldsAffected: inboundReport.rows.length,
+      organizationsAffected: byOrganization.size,
+      instancesRebuilt,
+    })
+  },
+}

--- a/packages/lib/src/data-migrations/registry.ts
+++ b/packages/lib/src/data-migrations/registry.ts
@@ -65,6 +65,7 @@ import { migration097PartSkuUnique } from './migrations/097-part-sku-unique'
 import { migration098PruneOrphanedOptionValues } from './migrations/098-prune-orphaned-option-values'
 import { migration099ImapBackfillStamps } from './migrations/099-imap-backfill-stamps'
 import { migration103BackfillEmailStorageLocationOrg } from './migrations/103-backfill-email-storage-location-org'
+import { migration105PruneDanglingRelationValues } from './migrations/105-prune-dangling-relation-values'
 import { assertUniqueMigrationIds } from './plan'
 import type { DataMigrationDef } from './types'
 import { wrapEntityMigration } from './wrap-entity-migration'
@@ -156,6 +157,9 @@ function buildRegistry(): DataMigrationDef[] {
     migration098PruneOrphanedOptionValues,
     migration099ImapBackfillStamps,
     migration103BackfillEmailStorageLocationOrg,
+    // 104 (`vendor_sku_optional`) is an ENTITY migration and arrives via
+    // ALL_ENTITY_MIGRATIONS above; it owns 104 in the shared id sequence.
+    migration105PruneDanglingRelationValues,
   ]
 
   all.sort((a, b) => a.id.localeCompare(b.id))

--- a/packages/lib/src/entity-instances/__tests__/dangling-relation-sweep.int.test.ts
+++ b/packages/lib/src/entity-instances/__tests__/dangling-relation-sweep.int.test.ts
@@ -1,0 +1,313 @@
+// packages/lib/src/entity-instances/__tests__/dangling-relation-sweep.int.test.ts
+//
+// DB-backed regression test (vitest.integration.config.ts → auxx_test) for the
+// inbound half of a relation surviving the delete of the record it points at.
+//
+// A relation is TWO mirror `FieldValue` rows, one on each end, and
+// `FieldValue.relatedEntityId` has no foreign key. `deleteEntityInstance` used to
+// delete only `where entityId = id` — the dead record's own half — leaving the
+// mirror row sitting on the still-living record at the other end, pointing at an
+// id that no longer resolves. 1,619 such rows in the dev database, all of them on
+// live records.
+//
+// WHY INTEGRATION. Every claim here is a claim about stored rows and about
+// `EntityInstance.searchText`, which is a materialized column computed by a raw
+// SQL expression that LEFT JOINs the related instance for its `displayName`. A
+// mocked db can assert "the delete builder was called with this predicate"; only
+// real SQL can assert that the holder's search corpus stopped containing the dead
+// record's name.
+//
+// The org cache is mocked wholesale (same approach as
+// `field-values/__tests__/write-idempotency-stamps.int.test.ts`) because
+// `getCachedResources` is Redis-backed. The stub returns one resource whose
+// PRIMARY display field is the relationship — which is what makes the dependent
+// display-name cascade observable.
+
+import { type Database, schema } from '@auxx/database'
+import { createTestOrganization, getTestDb } from '@auxx/test-utils'
+import { and, eq } from 'drizzle-orm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { updateSearchTextForInstances } from '../../field-values/search-text'
+import { deleteEntityInstance } from '../delete-entity-instance'
+
+const db = () => getTestDb() as never as Database
+
+/**
+ * Mutable so `seed()` can publish the field id the display config has to point
+ * at — `checkDisplayField` matches `resource.display.primaryDisplayField.id`
+ * against `resource.fields[].id`, both of which are real `CustomField` ids here.
+ */
+let resources: unknown[] = []
+
+vi.mock('../../cache', () => ({
+  getCachedResources: async () => resources,
+}))
+
+interface Fixture {
+  orgId: string
+  otherOrgId: string
+  contactDefId: string
+  workOrderDefId: string
+  /** RELATIONSHIP field on work_order pointing at a contact. */
+  woContactFieldId: string
+  /** The mirror RELATIONSHIP field on contact. */
+  contactWorkOrdersFieldId: string
+  contactId: string
+  workOrderId: string
+}
+
+const DEAD_NAME = 'Zebra Dead Contact'
+
+async function definition(orgId: string, entityType: string, apiSlug: string): Promise<string> {
+  const [def] = await db()
+    .insert(schema.EntityDefinition)
+    .values({
+      organizationId: orgId,
+      entityType,
+      apiSlug,
+      singular: entityType,
+      plural: apiSlug,
+      updatedAt: new Date(),
+    })
+    .returning()
+  return def!.id
+}
+
+async function relationshipField(
+  orgId: string,
+  defId: string,
+  modelType: string,
+  name: string,
+  systemAttribute: string
+): Promise<string> {
+  const [field] = await db()
+    .insert(schema.CustomField)
+    .values({
+      organizationId: orgId,
+      entityDefinitionId: defId,
+      modelType,
+      name,
+      type: 'RELATIONSHIP',
+      systemAttribute,
+      sortOrder: 'a1',
+      isCustom: false,
+      updatedAt: new Date(),
+    })
+    .returning()
+  return field!.id
+}
+
+async function instance(
+  orgId: string,
+  defId: string,
+  displayName: string,
+  secondaryDisplayValue?: string
+): Promise<string> {
+  const [row] = await db()
+    .insert(schema.EntityInstance)
+    .values({
+      organizationId: orgId,
+      entityDefinitionId: defId,
+      displayName,
+      secondaryDisplayValue: secondaryDisplayValue ?? null,
+      updatedAt: new Date(),
+    })
+    .returning()
+  return row!.id
+}
+
+async function relationValue(
+  orgId: string,
+  entityId: string,
+  entityDefinitionId: string,
+  fieldId: string,
+  relatedEntityId: string,
+  relatedEntityDefinitionId: string,
+  /** Multi-value fields store one row per value; `(entityId, fieldId, sortKey)` is unique. */
+  sortKey = 'a'
+): Promise<void> {
+  await db().insert(schema.FieldValue).values({
+    organizationId: orgId,
+    entityId,
+    entityDefinitionId,
+    fieldId,
+    relatedEntityId,
+    relatedEntityDefinitionId,
+    sortKey,
+    updatedAt: new Date(),
+  })
+}
+
+async function seed(): Promise<Fixture> {
+  const org = await createTestOrganization()
+  const otherOrg = await createTestOrganization()
+
+  const contactDefId = await definition(org.id, 'contact', 'contacts')
+  const workOrderDefId = await definition(org.id, 'work_order', 'work-orders')
+
+  const woContactFieldId = await relationshipField(
+    org.id,
+    workOrderDefId,
+    'work_order',
+    'Contact',
+    'work_order_contact'
+  )
+  const contactWorkOrdersFieldId = await relationshipField(
+    org.id,
+    contactDefId,
+    'contact',
+    'Work Orders',
+    'contact_work_orders'
+  )
+
+  const contactId = await instance(org.id, contactDefId, DEAD_NAME)
+  // The work order's PRIMARY display value is projected from the contact — the
+  // same denormalization the display cascade maintains on rename.
+  const workOrderId = await instance(org.id, workOrderDefId, DEAD_NAME, 'WO-1')
+
+  // Both halves of the one relation.
+  await relationValue(
+    org.id,
+    workOrderId,
+    workOrderDefId,
+    woContactFieldId,
+    contactId,
+    contactDefId
+  )
+  await relationValue(
+    org.id,
+    contactId,
+    contactDefId,
+    contactWorkOrdersFieldId,
+    workOrderId,
+    workOrderDefId
+  )
+
+  resources = [
+    {
+      id: workOrderDefId,
+      entityType: 'work_order',
+      fields: [
+        {
+          id: woContactFieldId,
+          systemAttribute: 'work_order_contact',
+          relationshipConfig: { relatedEntityType: 'contact' },
+        },
+      ],
+      display: {
+        primaryDisplayField: { id: woContactFieldId, type: 'RELATIONSHIP' },
+        secondaryDisplayField: null,
+      },
+    },
+  ]
+
+  await updateSearchTextForInstances(db(), org.id, [workOrderId, contactId])
+
+  return {
+    orgId: org.id,
+    otherOrgId: otherOrg.id,
+    contactDefId,
+    workOrderDefId,
+    woContactFieldId,
+    contactWorkOrdersFieldId,
+    contactId,
+    workOrderId,
+  }
+}
+
+async function valuesPointingAt(id: string) {
+  return await db()
+    .select()
+    .from(schema.FieldValue)
+    .where(eq(schema.FieldValue.relatedEntityId, id))
+}
+
+async function valuesOwnedBy(id: string) {
+  return await db().select().from(schema.FieldValue).where(eq(schema.FieldValue.entityId, id))
+}
+
+async function instanceRow(id: string) {
+  const [row] = await db()
+    .select()
+    .from(schema.EntityInstance)
+    .where(eq(schema.EntityInstance.id, id))
+  return row ?? null
+}
+
+let f: Fixture
+beforeEach(async () => {
+  vi.clearAllMocks()
+  resources = []
+  f = await seed()
+})
+
+describe('deleteEntityInstance — relation sweep', () => {
+  it('leaves NO row pointing at the deleted record, on either end', async () => {
+    // Precondition: the mirror row exists and the holder carries the dead name.
+    expect(await valuesPointingAt(f.contactId)).toHaveLength(1)
+    expect((await instanceRow(f.workOrderId))!.searchText).toContain('Zebra')
+
+    const result = await deleteEntityInstance({ id: f.contactId, organizationId: f.orgId })
+    expect(result.isOk()).toBe(true)
+
+    // The mirror half on the surviving work order — this is the whole bug.
+    expect(await valuesPointingAt(f.contactId)).toHaveLength(0)
+    // The dead record's own half.
+    expect(await valuesOwnedBy(f.contactId)).toHaveLength(0)
+    expect(await instanceRow(f.contactId)).toBeNull()
+  })
+
+  it('drops the dead name from the holder searchText and its projected displayName', async () => {
+    await deleteEntityInstance({ id: f.contactId, organizationId: f.orgId })
+
+    const workOrder = await instanceRow(f.workOrderId)
+    expect(workOrder).not.toBeNull()
+    // The record itself survives — only its references to the dead one are gone.
+    expect(workOrder!.searchText).not.toContain('Zebra')
+    expect(workOrder!.searchText).toContain('WO-1')
+    // The projected display column no longer advertises a record that is gone.
+    expect(workOrder!.displayName).toBeNull()
+  })
+
+  it('is org-scoped in BOTH directions — a mismatched org strips nothing', async () => {
+    // Defect B: the outbound delete used to run first and unscoped, so a
+    // mismatched organizationId emptied a record it then failed to delete, and
+    // still reported success.
+    const result = await deleteEntityInstance({
+      id: f.contactId,
+      organizationId: f.otherOrgId,
+    })
+    expect(result.isOk()).toBe(true)
+
+    expect(await instanceRow(f.contactId)).not.toBeNull()
+    expect(await valuesOwnedBy(f.contactId)).toHaveLength(1)
+    expect(await valuesPointingAt(f.contactId)).toHaveLength(1)
+  })
+
+  it('does not touch relations between two surviving records', async () => {
+    const otherContactId = await instance(f.orgId, f.contactDefId, 'Untouched Contact')
+    await relationValue(
+      f.orgId,
+      f.workOrderId,
+      f.workOrderDefId,
+      f.woContactFieldId,
+      otherContactId,
+      f.contactDefId,
+      'b'
+    )
+
+    await deleteEntityInstance({ id: f.contactId, organizationId: f.orgId })
+
+    const survivors = await db()
+      .select()
+      .from(schema.FieldValue)
+      .where(
+        and(
+          eq(schema.FieldValue.entityId, f.workOrderId),
+          eq(schema.FieldValue.relatedEntityId, otherContactId)
+        )
+      )
+    expect(survivors).toHaveLength(1)
+    expect(await instanceRow(otherContactId)).not.toBeNull()
+  })
+})

--- a/packages/lib/src/entity-instances/delete-entity-instance.ts
+++ b/packages/lib/src/entity-instances/delete-entity-instance.ts
@@ -4,6 +4,7 @@ import { database, schema } from '@auxx/database'
 import { fromDatabase } from '@auxx/services/shared/utils'
 import { and, eq } from 'drizzle-orm'
 import { err, ok } from 'neverthrow'
+import { sweepEntityFieldValues } from '../field-values/sweep-entity-references'
 
 /** Parameters for deleting an entity instance */
 export interface DeleteEntityInstanceParams {
@@ -12,36 +13,70 @@ export interface DeleteEntityInstanceParams {
 }
 
 /**
- * Permanently delete an entity instance and its field values
- * Prefer archiving over deletion
+ * Permanently delete an entity instance, its field values, and every relation
+ * pointing AT it. Prefer archiving over deletion.
+ *
+ * This is the single delete path behind tRPC `record.delete` **and**
+ * `record.bulkDelete` (`bulkDeleteEntities` is a plain loop over `deleteEntity`,
+ * which calls this) — the sweep belongs here and nowhere else.
+ *
+ * Two defects this function used to carry, both fixed by
+ * {@link sweepEntityFieldValues}:
+ *
+ * 1. It deleted only the record's OWN field values, leaving the mirror row on
+ *    the still-living record at the other end of every relation.
+ * 2. That delete was **not** org-scoped while the `EntityInstance` delete was,
+ *    and it ran first — so a mismatched `organizationId` stripped a surviving
+ *    record of all its values, deleted nothing, and returned `success: true`.
+ *
+ * Everything now runs in one transaction: previously the two statements were
+ * sequential and unwrapped, so a failure between them left a record with no
+ * values.
  */
 export async function deleteEntityInstance(params: DeleteEntityInstanceParams) {
   const { id, organizationId } = params
 
-  // Delete field values first
-  const fvResult = await fromDatabase(
-    database.delete(schema.FieldValue).where(eq(schema.FieldValue.entityId, id)),
-    'delete-entity-instance-field-values'
-  )
-  if (fvResult.isErr()) {
-    return err(fvResult.error)
-  }
-
-  // Delete the instance
-  const dbResult = await fromDatabase(
-    database
-      .delete(schema.EntityInstance)
-      .where(
-        and(
-          eq(schema.EntityInstance.id, id),
-          eq(schema.EntityInstance.organizationId, organizationId)
+  const result = await fromDatabase(
+    database.transaction(async (tx) => {
+      // The dead record's `entityType` drives the dependent display-name
+      // cascade inside the sweep. Read before the delete; absent (wrong org, or
+      // already gone) simply skips the cascade — every statement below is
+      // org-scoped on its own.
+      const [target] = await tx
+        .select({ entityType: schema.EntityDefinition.entityType })
+        .from(schema.EntityInstance)
+        .innerJoin(
+          schema.EntityDefinition,
+          eq(schema.EntityDefinition.id, schema.EntityInstance.entityDefinitionId)
         )
-      ),
+        .where(
+          and(
+            eq(schema.EntityInstance.id, id),
+            eq(schema.EntityInstance.organizationId, organizationId)
+          )
+        )
+        .limit(1)
+
+      await sweepEntityFieldValues(tx, {
+        organizationId,
+        entityIds: [id],
+        entityType: target?.entityType ?? null,
+      })
+
+      await tx
+        .delete(schema.EntityInstance)
+        .where(
+          and(
+            eq(schema.EntityInstance.id, id),
+            eq(schema.EntityInstance.organizationId, organizationId)
+          )
+        )
+    }),
     'delete-entity-instance'
   )
 
-  if (dbResult.isErr()) {
-    return err(dbResult.error)
+  if (result.isErr()) {
+    return err(result.error)
   }
 
   return ok({ success: true })

--- a/packages/lib/src/field-values/display-field-deps.ts
+++ b/packages/lib/src/field-values/display-field-deps.ts
@@ -70,6 +70,10 @@ function buildDepsMap(resources: readonly Resource[]): DisplayFieldDepsMap {
 
 /**
  * Check if a display field is a RELATIONSHIP type and add a dependency entry.
+ *
+ * `display` and `fields` are optional-chained: the dep map is now built on the
+ * record DELETE path too, and a cached resource entry missing either one must
+ * contribute no dependency rather than fail the delete around it.
  */
 function checkDisplayField(
   resource: Resource,
@@ -77,14 +81,14 @@ function checkDisplayField(
   column: 'displayName' | 'secondaryDisplayValue',
   map: DisplayFieldDepsMap
 ): void {
-  const displayFieldConfig = resource.display[displayFieldKey]
+  const displayFieldConfig = resource.display?.[displayFieldKey]
   if (!displayFieldConfig) return
 
   // Check if the display field type is RELATIONSHIP
   if (displayFieldConfig.type !== 'RELATIONSHIP') return
 
   // Find the full field definition to get the relationship target
-  const field = resource.fields.find((f) => f.id === displayFieldConfig.id)
+  const field = resource.fields?.find((f) => f.id === displayFieldConfig.id)
   if (!field) return
 
   // Get the target entity type from the relationship config
@@ -112,9 +116,14 @@ function checkDisplayField(
  *
  * When an entity's displayName changes (e.g., a part's title), find all entities
  * that reference it via a RELATIONSHIP display field and update their display columns.
+ *
+ * Takes only the two fields it reads rather than the whole {@link FieldValueContext}
+ * so the delete path (`field-values/sweep-entity-references.ts`) can reuse it with
+ * `null` as the new value — a hard-deleted record leaves the same stale projection
+ * behind as a rename, and nothing else clears it.
  */
 export async function cascadeDependentDisplayNames(
-  ctx: FieldValueContext,
+  ctx: Pick<FieldValueContext, 'db' | 'organizationId'>,
   sourceInstanceId: string,
   newDisplayValue: string | null,
   deps: DisplayFieldDep[]

--- a/packages/lib/src/field-values/index.ts
+++ b/packages/lib/src/field-values/index.ts
@@ -220,6 +220,11 @@ export type {
   UpdateDisplayNameInput,
   UpdateFieldValueInput,
 } from './service-types'
+export {
+  type SweepEntityFieldValuesParams,
+  type SweepEntityFieldValuesResult,
+  sweepEntityFieldValues,
+} from './sweep-entity-references'
 // Typed column match (shared between write-path dedup and read-path lookup)
 export { type TypedColumnMatch, typedColumnMatch } from './typed-column-match'
 // Service types

--- a/packages/lib/src/field-values/sweep-entity-references.ts
+++ b/packages/lib/src/field-values/sweep-entity-references.ts
@@ -1,0 +1,141 @@
+// packages/lib/src/field-values/sweep-entity-references.ts
+
+import { type Database, schema, type Transaction } from '@auxx/database'
+import { and, eq, inArray } from 'drizzle-orm'
+import { cascadeDependentDisplayNames, getDisplayFieldDeps } from './display-field-deps'
+import { updateSearchTextForInstances } from './search-text'
+
+/**
+ * `updateSearchTextForInstances` inlines every id into one `IN (…)` list, so the
+ * rebuild is chunked rather than handed an unbounded set. A single dead contact
+ * can hold hundreds of mirror rows (`contact_work_orders`: 475 from 5 records).
+ */
+const SEARCH_TEXT_BATCH = 500
+
+/** Input for {@link sweepEntityFieldValues}. */
+export interface SweepEntityFieldValuesParams {
+  organizationId: string
+  /** Ids of the records being hard-deleted. Duplicates are tolerated. */
+  entityIds: readonly string[]
+  /**
+   * `EntityDefinition.entityType` of the records being deleted, when known.
+   *
+   * Only drives the dependent display-name cascade — a record whose
+   * `displayName` is *derived* from a relationship to one of `entityIds` keeps
+   * showing the dead record's name otherwise. Omit to skip the cascade; the
+   * sweep itself never depends on it.
+   */
+  entityType?: string | null
+  /**
+   * Also delete the deleted records' OWN values (`entityId IN entityIds`).
+   * Default `true`. Pass `false` only when the caller has already removed them.
+   */
+  includeOutbound?: boolean
+}
+
+/** What {@link sweepEntityFieldValues} removed. */
+export interface SweepEntityFieldValuesResult {
+  /** Rows removed on the deleted records' own side. */
+  outboundDeleted: number
+  /** Mirror rows removed from still-living records. */
+  inboundDeleted: number
+  /** Distinct surviving records that had held a reference to a deleted record. */
+  holderIds: string[]
+}
+
+/**
+ * Remove BOTH halves of every relation touching a set of records that are being
+ * hard-deleted, and repair the surviving side.
+ *
+ * **Why this exists.** A relation is two mirror `FieldValue` rows, one on each
+ * end, and `FieldValue.relatedEntityId` is a bare `text()` column with no
+ * foreign key (`packages/database/src/db/schema/field-value.ts:93`) — same for
+ * `entityId`. Nothing cascades. Every delete path that removed only the dead
+ * record's own values left the mirror row sitting on a live record, pointing at
+ * an id that no longer resolves: 1,619 such rows in the dev database, 15.5% of
+ * all relation values, every one of them on a page a user can open today.
+ *
+ * **Why a shared function and not a hook.** This exact defect was already
+ * diagnosed and fixed once — for `'tags'` only, via
+ * `registerEntityPreDeleteHooks('tags', …)` — which left ~40 other entity types
+ * leaking. The fix has to be keyed off the mechanism (a record is going away),
+ * not off a registration list, or it drifts the same way again.
+ *
+ * **Sweep, not guard.** The tag fix *refuses* the delete while references
+ * exist. That is right for tags and wrong as a general rule: refusing to delete
+ * a contact because a ticket points at it makes deletion impossible in normal
+ * use. Here the delete succeeds and the references are pruned. Unlike a merge
+ * (`resources/merge/merge-service.ts`, which repoints `relatedEntityId` to the
+ * winner) there is no winner to repoint to.
+ *
+ * Every statement is org-scoped. Run it inside the caller's transaction,
+ * alongside the row deletion it belongs to.
+ *
+ * Order matters: the display cascade runs FIRST because it locates dependents
+ * through the very rows the sweep then deletes.
+ */
+export async function sweepEntityFieldValues(
+  db: Database | Transaction,
+  params: SweepEntityFieldValuesParams
+): Promise<SweepEntityFieldValuesResult> {
+  const { organizationId, entityType, includeOutbound = true } = params
+  const entityIds = [...new Set(params.entityIds)]
+  if (entityIds.length === 0) {
+    return { outboundDeleted: 0, inboundDeleted: 0, holderIds: [] }
+  }
+
+  // 1. Dependent display columns. A record whose displayName is projected from
+  //    a relationship to a deleted record holds a stale copy of that record's
+  //    name in a plain column; nothing else ever clears it.
+  if (entityType) {
+    const deps = await getDisplayFieldDeps(organizationId, entityType)
+    if (deps.length > 0) {
+      for (const entityId of entityIds) {
+        await cascadeDependentDisplayNames({ db, organizationId }, entityId, null, deps)
+      }
+    }
+  }
+
+  // 2. The mirror half — the rows this whole function exists for. Served by
+  //    `FieldValue_relatedEntityId_idx`.
+  const inbound = await db
+    .delete(schema.FieldValue)
+    .where(
+      and(
+        inArray(schema.FieldValue.relatedEntityId, entityIds),
+        eq(schema.FieldValue.organizationId, organizationId)
+      )
+    )
+    .returning({ entityId: schema.FieldValue.entityId })
+
+  // 3. The dead records' own values.
+  let outboundDeleted = 0
+  if (includeOutbound) {
+    const outbound = await db
+      .delete(schema.FieldValue)
+      .where(
+        and(
+          inArray(schema.FieldValue.entityId, entityIds),
+          eq(schema.FieldValue.organizationId, organizationId)
+        )
+      )
+      .returning({ id: schema.FieldValue.id })
+    outboundDeleted = outbound.length
+  }
+
+  // 4. `EntityInstance.searchText` is materialized and recomputed only on
+  //    write, and it folds in the related record's `displayName`. Without this
+  //    the deleted record's name stays in every referencing record's search
+  //    corpus forever.
+  const dead = new Set(entityIds)
+  const holderIds = [...new Set(inbound.map((row) => row.entityId))].filter((id) => !dead.has(id))
+  for (let i = 0; i < holderIds.length; i += SEARCH_TEXT_BATCH) {
+    await updateSearchTextForInstances(
+      db,
+      organizationId,
+      holderIds.slice(i, i + SEARCH_TEXT_BATCH)
+    )
+  }
+
+  return { outboundDeleted, inboundDeleted: inbound.length, holderIds }
+}

--- a/packages/lib/src/groups/group-functions.ts
+++ b/packages/lib/src/groups/group-functions.ts
@@ -20,6 +20,7 @@ import { and, asc, eq, inArray, isNull, or, sql } from 'drizzle-orm'
 import { getCachedEntityDefId, getCachedGroups, getOrgCache, onCacheEvent } from '../cache'
 import { createEntityInstance } from '../entity-instances'
 import { NotFoundError } from '../errors'
+import { sweepEntityFieldValues } from '../field-values/sweep-entity-references'
 import { hasGroupPermission, requireGroupPermission } from './permissions'
 
 // ============================================================================
@@ -158,14 +159,35 @@ export async function updateGroup(
 
 /**
  * Delete a group
+ *
+ * A group is an `EntityInstance`, but this path deletes the row directly rather
+ * than through `deleteEntityInstance`, so it carried the same leak: `FieldValue`
+ * has no foreign key on `entityId` or `relatedEntityId`, and neither half was
+ * ever removed. The sweep and the row delete share one transaction, both
+ * org-scoped.
  */
 export async function deleteGroup(ctx: GroupContext, groupId: string): Promise<void> {
-  const { db } = ctx
+  const { db, organizationId } = ctx
 
   await requireGroupPermission(ctx, groupId, ResourcePermission.admin)
 
-  // Cascade deletes handle members and permissions
-  await db.delete(schema.EntityInstance).where(eq(schema.EntityInstance.id, groupId))
+  await db.transaction(async (tx) => {
+    await sweepEntityFieldValues(tx, {
+      organizationId,
+      entityIds: [groupId],
+      entityType: 'entity_group',
+    })
+
+    // Cascade deletes handle members and permissions
+    await tx
+      .delete(schema.EntityInstance)
+      .where(
+        and(
+          eq(schema.EntityInstance.id, groupId),
+          eq(schema.EntityInstance.organizationId, organizationId)
+        )
+      )
+  })
 
   // Group grants stop resolving for every former member — fan out user keys.
   await onCacheEvent('group.deleted', { orgId: ctx.organizationId, broadcastUserKeys: true })

--- a/packages/lib/src/kb/articles/delete-article.ts
+++ b/packages/lib/src/kb/articles/delete-article.ts
@@ -4,6 +4,7 @@ import { ArticleKind } from '@auxx/database/enums'
 import { generateKeyBetween } from '@auxx/utils'
 import { TRPCError } from '@trpc/server'
 import { and, asc, eq, isNull, ne } from 'drizzle-orm'
+import { sweepEntityFieldValues } from '../../field-values/sweep-entity-references'
 import { resolveDb } from '../internal/context'
 import { createNotFoundError, handleError } from '../internal/errors'
 import { resolvePlacement } from '../internal/placement'
@@ -100,6 +101,16 @@ export async function deleteArticle(
         .update(schema.Article)
         .set({ draftRevisionId: null })
         .where(eq(schema.Article.id, id))
+
+      // An article's tags (and any other relation to it) live in `FieldValue`
+      // on both ends, and neither `entityId` nor `relatedEntityId` has a
+      // foreign key — deleting the Article row alone left both halves dangling.
+      await sweepEntityFieldValues(tx, {
+        organizationId: ctx.organizationId,
+        entityIds: [id],
+        entityType: 'article',
+      })
+
       await tx.delete(schema.Article).where(eq(schema.Article.id, id))
     })
     void enqueueKBSync({

--- a/packages/lib/src/threads/__tests__/thread-comment-cascade.test.ts
+++ b/packages/lib/src/threads/__tests__/thread-comment-cascade.test.ts
@@ -67,8 +67,17 @@ function databaseWithDeletedThreads(
         operations.push('comment')
         return { where: vi.fn().mockResolvedValue(undefined) }
       }
+      // Deletes 3 and 4 are the relation sweep — `FieldValue` rows pointing AT
+      // the deleted threads, then the threads' own values. Both `RETURNING`.
+      if (deleteCount === 3 || deleteCount === 4) {
+        operations.push(deleteCount === 3 ? 'fieldvalue-inbound' : 'fieldvalue-outbound')
+        return {
+          where: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) })),
+        }
+      }
       throw new Error('Unexpected delete table')
     }),
+    execute: vi.fn().mockResolvedValue(undefined),
   }
   const transaction = vi.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
     callback(tx)
@@ -121,7 +130,7 @@ describe('thread permanent-delete comment cascade', () => {
       count: 1,
     })
     expect(transaction).toHaveBeenCalledOnce()
-    expect(operations).toEqual(['thread', 'comment'])
+    expect(operations).toEqual(['thread', 'comment', 'fieldvalue-inbound', 'fieldvalue-outbound'])
     expect(inArrayBatches[0]).toEqual(['thread_1', 'thread_missing'])
     expect(inArrayBatches[1]).toEqual(['thread_1'])
     expect(publishThreadDeleted).toHaveBeenCalledOnce()

--- a/packages/lib/src/threads/thread-mutation.service.ts
+++ b/packages/lib/src/threads/thread-mutation.service.ts
@@ -10,6 +10,7 @@ import { BadRequestError } from '../errors'
 import { publisher } from '../events/publisher'
 import { FieldValueService } from '../field-values'
 import { batchGetThreadTagIds } from '../field-values/relationship-queries'
+import { sweepEntityFieldValues } from '../field-values/sweep-entity-references'
 import { toInboxRecordId } from '../inbox-record-ids'
 import { buildDefIdToSlug } from '../permissions/capabilities/resolve-capability-inputs'
 import type { MailViewer } from '../permissions/visibility/context'
@@ -1418,6 +1419,16 @@ export class ThreadMutationService {
             )
           )
 
+        // A thread's tags are `FieldValue` rows on BOTH ends — `thread_tags`
+        // (entityId = threadId) and `tag_threads` (relatedEntityId = threadId) —
+        // and neither column has a foreign key. Deleting the Thread row alone
+        // left both halves behind.
+        await sweepEntityFieldValues(tx, {
+          organizationId: this.organizationId,
+          entityIds: [deletedThreads[0]!.id],
+          entityType: 'thread',
+        })
+
         return deletedThreads
       })
 
@@ -1488,6 +1499,13 @@ export class ThreadMutationService {
               eq(schema.Comment.organizationId, this.organizationId)
             )
           )
+
+          // Both halves of every thread↔tag relation — see `deletePermanently`.
+          await sweepEntityFieldValues(tx, {
+            organizationId: this.organizationId,
+            entityIds: deletedThreads.map((thread) => thread.id),
+            entityType: 'thread',
+          })
         }
 
         return deletedThreads


### PR DESCRIPTION
Layers 1, 3 and 4 of `plans/field-values/dangling-relation-references.md`. The read-path half shipped in #1882.

🛑 **Migration 105 is registered but MUST NOT be deployed until #1882 is live.** See "The migration" below.

## The bug

A relation is stored as **two mirror `FieldValue` rows**, and neither `relatedEntityId` (`field-value.ts:93`) nor `entityId` (`:61`) carries a foreign key, so nothing cascades. Every delete path removed the dead record's **own** values and left the **mirror** on the still-living record pointing at an id that no longer resolves.

**1,619 dangling references in dev — 15.5% of all relation values**, every one hanging off a live, non-archived record.

## Why the fix is in the shared path, not a hook

This exact bug was **already found, documented, and fixed — for one entity type**. `field-hooks/pre/tag-in-use-guard.ts` states the mechanism verbatim, down to the same schema line, including *"one deleted tag left 532 orphaned rows"*. The fix that shipped was `registerEntityPreDeleteHooks('tags', [...])`, leaving ~40 other entity types leaking.

So this puts the sweep in the shared delete path. A per-type registration would drift exactly the same way.

It also **sweeps rather than guards**. The tag fix *refuses* the delete with a `ConflictError`, which is right for tags but wrong generally — refusing to delete a contact because a ticket points at it makes deletion impossible in normal use. The existing tag guard is untouched.

## `sweepEntityFieldValues`

New shared helper (`packages/lib/src/field-values/sweep-entity-references.ts`), called by all four sites — no copies:

1. **Display-name cascade FIRST** — `cascadeDependentDisplayNames` locates its dependents *through* the very rows the sweep is about to delete, so running it after would find nothing.
2. Org-scoped **inbound** delete (`relatedEntityId IN ids`), `RETURNING entityId` to learn the holders. Rides `FieldValue_relatedEntityId_idx`.
3. Org-scoped **outbound** delete (`entityId IN ids`).
4. `updateSearchTextForInstances` for surviving holders, batched at 500.

## Four sites, not one

| site | was | now |
|---|---|---|
| `deleteEntityInstance` | outbound only | sweep, in one transaction |
| thread `deletePermanently` / `bulkDeletePermanently` | **never touched `FieldValue` at all** | sweep inside the existing tx |
| `delete-article.ts` | same | sweep inside the existing tx |
| `groups/group-functions.ts` `deleteGroup` | same, **and no `organizationId` predicate at all** | sweep + org-scoped delete, in one tx |

`groups` was an open question in the plan. It is a real leak, and a worse one. ✅ `bulkDeleteEntities` is confirmed a plain loop over `deleteEntity` → `deleteEntityInstance`, so bulk needs no second fix.

## A latent second bug, fixed by construction

`deleteEntityInstance`'s outbound delete was **not org-scoped** and ran **before** the org-scoped instance delete. Called with a mismatched org it stripped every field value, matched zero rows on the instance, and returned `ok({ success: true })` — a surviving record stripped of its data, reported as a successful delete. Both deletes now live inside the org-scoped sweep.

**The regression test reproduces this against the pre-fix source**, not just in theory.

## The migration — the dangerous part

`105-prune-dangling-relation-values` is written and registered but **has not been run** against dev or any real database (only the ephemeral `auxx_test`).

- 🛑 **Resolves each target against 13 backing tables, not one.** Joining only `EntityInstance` would delete **1,256 healthy** `Thread` / `Article` / `DispatchWorker` references. The list is deliberately generous: an extra table only leaves an orphan behind, a missing one deletes live rows. All 13 verified to exist in `db/schema/`.
- 🛑 **No `archivedAt` predicate anywhere.** Archived is not deleted.
- Inbound arm scoped to `cf.type = 'RELATIONSHIP'`, so ACTOR rows (the DispatchWorker family) are out of scope. Outbound arm unrestricted, covering the 215 tag rows, the 54 billing-projection rows and 6 unexplained.
- 🛑 **Hold until #1882 is deployed.** The picker re-creates dangling refs on every save until the read-path fix is live, so pruning first is undone by ordinary use.

Migration tests explicitly cover both ways this could destroy data: *"keeps a reference to a target in a NON-EntityInstance table"* (`Tag`) and *"keeps a reference whose target is merely ARCHIVED"*, plus idempotency.

## Testing

- **Negative control run.** Reverted `delete-entity-instance.ts` to the exact pre-fix source: 3 of 4 tests failed in the predicted ways — mirror row survived, `searchText` still contained the dead name, and the org-mismatch case reproduced the latent bug live. Restored, re-ran green.
- Migration: 7/7. Sweep: 4/4. `packages/lib` integration: 27 files / 382 tests green, re-verified on top of #1882.
- `packages/lib` typecheck: 0 errors under `src/`; 29 pre-existing in `scripts/`.
- Biome clean on all touched files.
- ⚠️ **Two unrelated unit failures** in the wide run (`workflow-draft-cas`, `resolve-resource-trigger-match`), both timing out at ~10.0s against a 10s default with sibling tests at 8.4–8.9s — i.e. machine-boundary flakes. Neither file's import graph reaches anything changed here, **but they were not proven against a pristine tree.**

## Known gaps

- No DB-backed end-to-end test for the thread / article / group sweep paths; they rely on hardcoded `entityType` strings checked against `seed/entity-seeder/constants.ts`. A wrong string still sweeps correctly — only the cosmetic display cascade is skipped.
- `deleteEntityInstance` still uses the module-level `database` singleton rather than an injected `db`, so its transaction is on a separate connection from any caller's. Pre-existing, unchanged.
- Side finding, untouched: **id `103` is already double-claimed** — `103-backfill-email-storage-location-org` in data-migrations and `103-gl-posting` in entity-migrations.