### PR TITLE
feat(import): declare natural keys so price lists update instead of duplicating

### DIFF
--- a/packages/lib/src/import/fields/identifier-eligibility.ts
+++ b/packages/lib/src/import/fields/identifier-eligibility.ts
@@ -108,6 +108,14 @@ export function getIdentifierEligibility(field: ResourceField): IdentifierEligib
     field.capabilities.unique === true ||
     field.isUnique === true ||
     field.isIdentifier === true ||
+    // A declared natural-key leg is RECOMMENDED even though it carries no
+    // uniqueness of its own — that is the entire point of declaring one. The
+    // tuple is enforced by nothing and identifies the record anyway, so leaving
+    // `(part, supplier)` at tier 2 behind "Not enforced unique" would bury the
+    // only identity `vendor_part` has under a caveat that reads like a warning.
+    // It stays `compositeOnly` (it is a RELATION), so it can still never be
+    // flagged as a lone key.
+    field.naturalKeyPosition !== undefined ||
     INTRINSIC_IDENTIFIER_KEYS.has(outputKey)
 
   return isRecommended

--- a/packages/lib/src/import/mapping/__tests__/identifier-lifecycle.test.ts
+++ b/packages/lib/src/import/mapping/__tests__/identifier-lifecycle.test.ts
@@ -74,11 +74,30 @@ class FakeDb {
   writesOutsideTransaction = 0
   /** Table the next `update()` should be made to fail on, or null. */
   failUpdatesOn: unknown = null
+  /**
+   * Column indexes the successive `ImportMappingProperty` updates target, in
+   * call order. Opt-in and null by default, so every test written against the
+   * single-{@link focusColumn} model is untouched.
+   *
+   * `batchUpdateMappingsFromAutoMap` writes one statement per mapped column, and
+   * `focusColumn` alone routes all of them onto ONE row — which is fine while
+   * exactly one column can carry the identity flag, and wrong the moment a
+   * COMPOSITE key puts the flag on two. Without this, a natural-key test passes
+   * or fails on which write happened to land last.
+   */
+  batchColumnOrder: number[] | null = null
+  private batchCursor = 0
 
   constructor(properties: FakeProperty[], mapping: FakeMapping, isTransactionHandle = false) {
     this.properties = properties
     this.mapping = mapping
     this.isTransactionHandle = isTransactionHandle
+  }
+
+  /** The column the next property write lands on: the batch order, else the focus. */
+  private nextPropertyColumn(): number {
+    if (this.batchColumnOrder === null) return this.focusColumn
+    return this.batchColumnOrder[this.batchCursor++] ?? this.focusColumn
   }
 
   private rowsFor(table: unknown, limited: boolean): unknown[] {
@@ -120,7 +139,12 @@ class FakeDb {
             }
             if (table === schema.ImportMapping) Object.assign(self.mapping, values)
             if (table === schema.ImportMappingProperty) {
-              const target = self.properties.find((p) => p.sourceColumnIndex === self.focusColumn)
+              // Resolved ONCE per write, deliberately. `nextPropertyColumn` advances
+              // a cursor, and `Array.find` runs its predicate once per element — so
+              // calling it inline would consume several slots per statement and
+              // scatter the writes across the wrong rows.
+              const col = self.nextPropertyColumn()
+              const target = self.properties.find((p) => p.sourceColumnIndex === col)
               if (target) Object.assign(target, values)
             }
             return Promise.resolve()
@@ -144,6 +168,7 @@ class FakeDb {
     const tx = new FakeDb(this.properties, this.mapping, true)
     tx.focusColumn = this.focusColumn
     tx.failUpdatesOn = this.failUpdatesOn
+    tx.batchColumnOrder = this.batchColumnOrder
     try {
       return await fn(tx.asDatabase())
     } catch (error) {
@@ -587,5 +612,132 @@ describe('atomicity, every mapping write is one transaction', () => {
     })
 
     expect(db.writesOutsideTransaction).toBe(0)
+  })
+
+  // ── declared natural key ──────────────────────────────────────────────
+  //
+  // The one composite key that may be DEFAULTED, because the registry states it
+  // rather than the mapper guessing it. `vendor_part` has no lone identifier at
+  // all, so without this a supplier price list can only ever duplicate.
+
+  const vendorPartMappings = [
+    {
+      columnIndex: 0,
+      matchedFieldKey: 'vendor_part_part',
+      customFieldId: null,
+      resolutionType: 'relation:match',
+    },
+    {
+      columnIndex: 1,
+      matchedFieldKey: 'vendor_part_contact',
+      customFieldId: null,
+      resolutionType: 'relation:match',
+    },
+    {
+      columnIndex: 2,
+      matchedFieldKey: 'vendor_part_unit_price',
+      customFieldId: null,
+      resolutionType: 'currency:major',
+    },
+  ]
+
+  it('flags EVERY leg when the whole natural key was mapped', async () => {
+    const db = new FakeDb([column(0), column(1), column(2)], {
+      identifierFieldKeys: [],
+      defaultStrategy: 'create',
+    })
+    db.batchColumnOrder = [0, 1, 2]
+
+    await batchUpdateMappingsFromAutoMap(db.asDatabase(), {
+      mappingId: MAPPING_ID,
+      mappings: vendorPartMappings,
+      preferredIdentifierFieldKeys: ['id'],
+      naturalKeyFieldKeys: ['vendor_part_part', 'vendor_part_contact'],
+    })
+
+    expect(new Set(db.mapping.identifierFieldKeys)).toEqual(
+      new Set(['vendor_part_part', 'vendor_part_contact'])
+    )
+    expect(db.mapping.defaultStrategy).toBe('create-or-update')
+  })
+
+  // Half a tuple ANDs too little. `analyzeRow` requires every component, so a
+  // partial key reports `unmatched` for every row behind a wizard claiming
+  // update — strictly worse than staying create-only.
+  it('flags NOTHING from a partially mapped natural key', async () => {
+    const db = new FakeDb([column(0), column(1)], {
+      identifierFieldKeys: [],
+      defaultStrategy: 'create',
+    })
+    db.batchColumnOrder = [0, 1]
+
+    await batchUpdateMappingsFromAutoMap(db.asDatabase(), {
+      mappingId: MAPPING_ID,
+      mappings: [vendorPartMappings[0]!, vendorPartMappings[2]!],
+      naturalKeyFieldKeys: ['vendor_part_part', 'vendor_part_contact'],
+    })
+
+    expect(db.mapping.identifierFieldKeys).toEqual([])
+    expect(db.mapping.defaultStrategy).toBe('create')
+  })
+
+  // The natural key outranks the single-column pick rather than joining it: a
+  // declared tuple plus a heuristic third leg is a key nobody declared.
+  it('does not mix the natural key with the preferred single identifier', async () => {
+    const db = new FakeDb([column(0), column(1), column(2)], {
+      identifierFieldKeys: [],
+      defaultStrategy: 'create',
+    })
+    db.batchColumnOrder = [0, 1, 2]
+
+    await batchUpdateMappingsFromAutoMap(db.asDatabase(), {
+      mappingId: MAPPING_ID,
+      mappings: [
+        ...vendorPartMappings.slice(0, 2),
+        {
+          columnIndex: 2,
+          matchedFieldKey: 'vendor_part_vendor_sku',
+          customFieldId: null,
+          resolutionType: 'text:value',
+        },
+      ],
+      preferredIdentifierFieldKeys: ['vendor_part_vendor_sku'],
+      naturalKeyFieldKeys: ['vendor_part_part', 'vendor_part_contact'],
+    })
+
+    expect(new Set(db.mapping.identifierFieldKeys)).toEqual(
+      new Set(['vendor_part_part', 'vendor_part_contact'])
+    )
+  })
+
+  // Every other resource is unaffected: no declaration, no behaviour change.
+  it('falls back to the single preferred identifier when no natural key is declared', async () => {
+    const db = new FakeDb([column(0), column(1)], {
+      identifierFieldKeys: [],
+      defaultStrategy: 'create',
+    })
+    db.batchColumnOrder = [0, 1]
+
+    await batchUpdateMappingsFromAutoMap(db.asDatabase(), {
+      mappingId: MAPPING_ID,
+      mappings: [
+        {
+          columnIndex: 0,
+          matchedFieldKey: 'part_sku',
+          customFieldId: null,
+          resolutionType: 'text:value',
+        },
+        {
+          columnIndex: 1,
+          matchedFieldKey: 'part_title',
+          customFieldId: null,
+          resolutionType: 'text:value',
+        },
+      ],
+      preferredIdentifierFieldKeys: ['part_sku', 'id'],
+      naturalKeyFieldKeys: [],
+    })
+
+    expect(db.mapping.identifierFieldKeys).toEqual(['part_sku'])
   })
 })

--- a/packages/lib/src/import/mapping/run-auto-map.ts
+++ b/packages/lib/src/import/mapping/run-auto-map.ts
@@ -2,6 +2,8 @@
 
 import type { Database } from '@auxx/database'
 import { getCachedResource } from '../../cache'
+import { getFieldOutputKey } from '../../resources/registry/field-types'
+import { getNaturalKeyFields } from '../../resources/registry/field-utils'
 import type { Resource } from '../../resources/registry/types'
 import { type ColumnHeaderWithSamples, orchestrateAutoMap } from '../fields/auto-map-orchestrator'
 import { getImportableFields } from '../fields/get-importable-fields'
@@ -151,10 +153,21 @@ export async function runAutoMap(
     .filter((f) => f.identifierTier === 1 && !f.identifierCompositeOnly)
     .map((f) => f.key)
 
+  // A declared NATURAL KEY outranks the single-column pick, when every one of
+  // its legs was mapped. `vendor_part` has no lone identifier at all — a
+  // supplier price list keyed on `(part, supplier)` is the only way it can
+  // update rather than duplicate — and a key the user has to assemble by hand,
+  // two toggles deep in a picker, is a key nobody sets.
+  //
+  // Read off the resource, never off an entity type: `vendor_part` is the first
+  // declarer, not a special case, and any resource that declares one gets this.
+  const naturalKeyFieldKeys = getNaturalKeyFields(resource).map(getFieldOutputKey)
+
   await batchUpdateMappingsFromAutoMap(db, {
     mappingId: importMappingId,
     mappings: mappingsWithFieldData,
     preferredIdentifierFieldKeys,
+    naturalKeyFieldKeys,
   })
 
   // 7. Return result for API response

--- a/packages/lib/src/import/mapping/save-mapping-property.ts
+++ b/packages/lib/src/import/mapping/save-mapping-property.ts
@@ -311,6 +311,21 @@ export interface AutoMapUpdateInput {
    * matches nothing.
    */
   preferredIdentifierFieldKeys?: string[]
+  /**
+   * The resource's declared NATURAL KEY, in leg order — the composite identity of
+   * a join-shaped entity (`(part, supplier)` on `vendor_part`).
+   *
+   * This is the one composite key that is NOT a guess, which is why it may be
+   * defaulted where {@link preferredIdentifierFieldKeys} deliberately picks only
+   * one: the registry states that these fields together identify the record.
+   *
+   * **All or nothing.** It is applied only when EVERY leg was mapped. A partial
+   * tuple can never match anything (`analyzeRow` requires every component), so
+   * flagging half of one produces an import that reports `unmatched` for every
+   * row behind a wizard that says update — strictly worse than flagging nothing
+   * and staying create-only.
+   */
+  naturalKeyFieldKeys?: string[]
 }
 
 /**
@@ -323,10 +338,11 @@ export interface AutoMapUpdateInput {
  * dropped first: a flag left behind on a column that now feeds a different field
  * is exactly the stale-key failure `saveMappingProperty` guards against.
  *
- * Then the flag is **defaulted ON** for the best mapped tier-1 identifier.
- * That is not polish, the entire defect class this code exists to fix comes
- * from the flag being absent, and shipping it unset reproduces the bug with
- * extra clicks.
+ * Then the flag is **defaulted ON**: for every leg of the resource's declared
+ * natural key when all of them were mapped, otherwise for the best mapped
+ * tier-1 identifier. That is not polish, the entire defect class this code
+ * exists to fix comes from the flag being absent, and shipping it unset
+ * reproduces the bug with extra clicks.
  *
  * The per-column writes, the identity recompute and the `allowPlanGeneration`
  * reset are ONE transaction under the mapping's row lock. Auto-map retargets
@@ -346,8 +362,21 @@ export async function batchUpdateMappingsFromAutoMap(
   const mappedKeys = new Set(
     input.mappings.map((m) => m.matchedFieldKey).filter((key): key is string => !!key)
   )
-  const identifierKey =
-    input.preferredIdentifierFieldKeys?.find((key) => mappedKeys.has(key)) ?? null
+
+  // A fully mapped natural key wins outright: it is the resource's DECLARED
+  // identity, not a heuristic pick. Partially mapped, it is dropped entirely
+  // rather than degraded to its mapped legs — a widened key silently updates the
+  // wrong record, which is the failure mode this whole path exists to remove.
+  const naturalKey = input.naturalKeyFieldKeys ?? []
+  const naturalKeyMapped = naturalKey.length > 0 && naturalKey.every((key) => mappedKeys.has(key))
+
+  const identifierKeys = naturalKeyMapped
+    ? new Set(naturalKey)
+    : new Set(
+        [input.preferredIdentifierFieldKeys?.find((key) => mappedKeys.has(key))].filter(
+          (key): key is string => !!key
+        )
+      )
 
   await db.transaction(async (tx) => {
     await lockMapping(tx, input.mappingId)
@@ -383,7 +412,7 @@ export async function batchUpdateMappingsFromAutoMap(
         options: mapping.options,
         relationConfig: mapping.relationConfig,
         identityRole:
-          mapping.matchedFieldKey && mapping.matchedFieldKey === identifierKey
+          mapping.matchedFieldKey && identifierKeys.has(mapping.matchedFieldKey)
             ? { kind: 'match' }
             : undefined,
       })

--- a/packages/lib/src/resources/registry/field-types.ts
+++ b/packages/lib/src/resources/registry/field-types.ts
@@ -195,6 +195,32 @@ export interface ResourceField {
    */
   isIdentifier?: boolean
 
+  /**
+   * This field's 1-based position in the resource's NATURAL KEY — the tuple of
+   * fields that together identify a record when no single field can.
+   *
+   * `vendor_part` is the motivating case: its identity is `(part, supplier)`,
+   * two relations, neither unique on its own and neither ever a sensible lone
+   * match key. Without the declaration a supplier price list can only ever be
+   * re-imported as duplicates, because the picker offers nothing above "Record
+   * ID" and no CSV carries cuids.
+   *
+   * Declared on the FIELD, and promoted through `mergeSystemAndCustomFields`'
+   * allow-list exactly as {@link ResourceField.isIdentifier} is. Whether
+   * `(part, supplier)` identifies a supplier price line is a product fact, so it
+   * belongs to the registry — deriving it from a per-org DB column is the drift
+   * mistake that left `part_sku.isUnique = false` in half the fleet for four
+   * months.
+   *
+   * The position is what makes the key ORDERED and therefore stable: the
+   * importer ANDs the legs in declaration order, and the preview names them in
+   * that order. Positions must be contiguous from 1 within one resource; a test
+   * pins that.
+   *
+   * @optional
+   */
+  naturalKeyPosition?: number
+
   // ─────────────────────────────────────────────────────────────
   // CONVENIENCE PROPERTIES (for unified consumption, avoid transforms)
   // ─────────────────────────────────────────────────────────────

--- a/packages/lib/src/resources/registry/field-utils.ts
+++ b/packages/lib/src/resources/registry/field-utils.ts
@@ -279,6 +279,36 @@ export function getDefaultIdentifierField(resource: {
   })
 }
 
+/**
+ * The resource's declared NATURAL KEY, in declaration order — the tuple of
+ * fields that together identify a record when no single field can.
+ *
+ * Empty for every resource that does not declare one, which is most of them: a
+ * natural key is for join-shaped entities whose identity is the pair they link.
+ * `vendor_part` is `(part, supplier)` and `subpart` is `(parentPart, childPart)`.
+ *
+ * Ordering is the declared `naturalKeyPosition`, never field order, so the key
+ * is stable against someone reordering the registry file. A resource whose
+ * positions are not contiguous from 1 has a broken declaration — the importer
+ * would AND a partial tuple and silently match too much — so this returns
+ * EMPTY rather than a partial key, and a registry test pins the invariant so it
+ * is caught at build time rather than as a mis-import.
+ *
+ * @param resource - Any resource carrying merged registry fields
+ * @returns The ordered key legs, or `[]` when none is declared or the
+ *   declaration is incomplete
+ */
+export function getNaturalKeyFields(resource: { fields: ResourceField[] }): ResourceField[] {
+  const legs = resource.fields
+    .filter((field) => typeof field.naturalKeyPosition === 'number')
+    .sort((a, b) => a.naturalKeyPosition! - b.naturalKeyPosition!)
+
+  if (legs.length === 0) return []
+
+  const contiguous = legs.every((field, index) => field.naturalKeyPosition === index + 1)
+  return contiguous ? legs : []
+}
+
 // ─────────────────────────────────────────────────────────────
 // SYSTEM FIELD HELPERS
 // ─────────────────────────────────────────────────────────────

--- a/packages/lib/src/resources/registry/identifier-fields.test.ts
+++ b/packages/lib/src/resources/registry/identifier-fields.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import { getIdentifiableFields } from '../../import/fields/get-identifiable-fields'
 import { RESOURCE_FIELD_REGISTRY } from './field-registry'
 import { getFieldOutputKey, type ResourceField } from './field-types'
-import { getDefaultIdentifierField } from './field-utils'
+import { getDefaultIdentifierField, getNaturalKeyFields } from './field-utils'
 import type { Resource } from './types'
 
 /**
@@ -126,5 +126,106 @@ describe('picker / auto-select agreement across the registry', () => {
     const part = resources.find((r) => r.id === 'part')
     expect(part).toBeDefined()
     expect(getDefaultIdentifierField(part!)?.key).toBe('sku')
+  })
+})
+
+/**
+ * The declared NATURAL KEY — the composite identity of a join-shaped entity.
+ *
+ * `getNaturalKeyFields` returns EMPTY on a non-contiguous declaration rather
+ * than a partial key, because a partial tuple ANDs too little and updates the
+ * wrong record. That failure is silent at runtime, so it is pinned here instead.
+ */
+describe('registry natural-key declarations', () => {
+  const resources = Object.entries(RESOURCE_FIELD_REGISTRY).map(([id, fields]) => ({
+    id,
+    fields: Object.values(fields ?? {}) as ResourceField[],
+  }))
+
+  it('every declared position is a contiguous run from 1', () => {
+    const offenders: string[] = []
+
+    for (const resource of resources) {
+      const declared = resource.fields
+        .filter((f) => f.naturalKeyPosition !== undefined)
+        .map((f) => f.naturalKeyPosition!)
+        .sort((a, b) => a - b)
+
+      if (declared.length === 0) continue
+      // A lone leg is not a composite key; it is a mistyped `isIdentifier`.
+      if (declared.length === 1) {
+        offenders.push(`${resource.id}: a natural key of ONE field, use isIdentifier instead`)
+        continue
+      }
+      if (declared.some((position, index) => position !== index + 1)) {
+        offenders.push(`${resource.id}: positions [${declared}] are not 1..${declared.length}`)
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+
+  it('every natural-key leg is eligible as an identifier', () => {
+    // A leg the picker refuses (hidden, unfilterable, computed, multi-value, or a
+    // type outside `ELIGIBLE_IDENTIFIER_TYPES`) can never be flagged, so the key
+    // would be undeclarable in the UI while looking declared in the registry.
+    const offenders: string[] = []
+
+    for (const resource of resources) {
+      const eligibleKeys = new Set(
+        getIdentifiableFields(resource as unknown as Resource).map((f) => f.key)
+      )
+      for (const field of getNaturalKeyFields(resource)) {
+        if (!eligibleKeys.has(getFieldOutputKey(field))) {
+          offenders.push(`${resource.id}.${field.key}`)
+        }
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+
+  it('vendor_part is keyed on (part, supplier), in that order', () => {
+    const vendorPart = resources.find((r) => r.id === 'vendor_part')
+    expect(vendorPart).toBeDefined()
+    expect(getNaturalKeyFields(vendorPart!).map((f) => f.key)).toEqual(['part', 'contact'])
+  })
+
+  it('subpart is keyed on (parentPart, childPart), in that order', () => {
+    const subpart = resources.find((r) => r.id === 'subpart')
+    expect(subpart).toBeDefined()
+    expect(getNaturalKeyFields(subpart!).map((f) => f.key)).toEqual(['parentPart', 'childPart'])
+  })
+
+  it('a natural-key leg is offered at tier 1, and only as part of a composite', () => {
+    // Tier 2 would bury the only identity `vendor_part` has behind "Not enforced
+    // unique"; dropping `compositeOnly` would let a whole supplier's price list be
+    // keyed on the supplier alone, updating an arbitrary line of it.
+    const vendorPart = resources.find((r) => r.id === 'vendor_part')!
+    const offered = getIdentifiableFields(vendorPart as unknown as Resource)
+
+    for (const key of ['vendor_part_part', 'vendor_part_contact']) {
+      const entry = offered.find((f) => f.key === key)
+      expect(entry, `${key} is not offered at all`).toBeDefined()
+      expect(entry?.identifierTier).toBe(1)
+      expect(entry?.identifierCompositeOnly).toBe(true)
+    }
+  })
+
+  // The auto-select must not start answering with a relation the moment the legs
+  // become tier 1 — it filters `!compositeOnly`, and this pins that it still does.
+  it('does not let a natural-key leg become the LONE auto-selected identifier', () => {
+    const offenders: string[] = []
+
+    for (const resource of resources) {
+      const legs = new Set(getNaturalKeyFields(resource).map(getFieldOutputKey))
+      if (legs.size === 0) continue
+      const chosen = getDefaultIdentifierField(resource)
+      if (chosen && legs.has(getFieldOutputKey(chosen))) {
+        offenders.push(`${resource.id}: auto-selected ${chosen.key}, a composite leg`)
+      }
+    }
+
+    expect(offenders).toEqual([])
   })
 })

--- a/packages/lib/src/resources/registry/index.ts
+++ b/packages/lib/src/resources/registry/index.ts
@@ -234,6 +234,7 @@ export {
   getDisplayFields,
   getFieldOperators,
   getIdentifierFields,
+  getNaturalKeyFields,
   isComputedField,
   isSystemField,
   isValidOperatorForField,

--- a/packages/lib/src/resources/registry/resource-registry-service.ts
+++ b/packages/lib/src/resources/registry/resource-registry-service.ts
@@ -954,6 +954,13 @@ export class ResourceRegistryService {
           // `getCachedCustomFields`), so promoting here cannot make an existing
           // write start throwing on data that already has duplicates.
           isIdentifier: staticField.isIdentifier ?? dbField.isIdentifier,
+          // The NATURAL KEY is registry-only, by the same argument one rung up, and
+          // with no DB fallback because there is no column that could carry one.
+          // `(part, supplier)` identifies a supplier price line; `(parentPart,
+          // childPart)` identifies a BOM line. Neither leg is unique, so no
+          // per-org boolean could ever express it, and `CustomField.isUnique` is
+          // the wrong shape anyway — a tuple is not a per-field flag.
+          naturalKeyPosition: staticField.naturalKeyPosition,
           // Merge relationship config — DB object exists but inverseResourceFieldId may be null
           // when the seeder linker couldn't resolve it. Fall back to static definition.
           relationship: baseRelationship

--- a/packages/lib/src/resources/registry/resources/subpart-fields.ts
+++ b/packages/lib/src/resources/registry/resources/subpart-fields.ts
@@ -45,6 +45,10 @@ export const SUBPART_FIELDS: Record<string, ResourceField> = {
     systemAttribute: 'subpart_parent_part',
     systemSortOrder: 'a1',
     nullable: false,
+    // Leg 1 of the natural key `(parentPart, childPart)`. A BOM line IS the pair
+    // — one assembly contains one component once, with a quantity — so re-importing
+    // a bill of materials must update the quantity, never append a second line.
+    naturalKeyPosition: 1,
     capabilities: {
       filterable: true,
       sortable: false,
@@ -77,6 +81,8 @@ export const SUBPART_FIELDS: Record<string, ResourceField> = {
     systemAttribute: 'subpart_child_part',
     systemSortOrder: 'a2',
     nullable: false,
+    // Leg 2 of the natural key `(parentPart, childPart)`. See the parent leg above.
+    naturalKeyPosition: 2,
     capabilities: {
       filterable: true,
       sortable: false,

--- a/packages/lib/src/resources/registry/resources/vendor-part-fields.ts
+++ b/packages/lib/src/resources/registry/resources/vendor-part-fields.ts
@@ -46,6 +46,11 @@ export const VENDOR_PART_FIELDS: Record<string, ResourceField> = {
     showInPanel: false, // vendor parts are viewed in the context of their part (drawer tab)
     showInTable: true, // keep the part column in the (internal) vendor-part list
     nullable: false,
+    // Leg 1 of the natural key `(part, supplier)`. A vendor part has no unique
+    // field of its own — `vendorSku` is the SUPPLIER's part number, unique within
+    // that supplier and never org-wide — so this pair is the only identity it has,
+    // and the only way a monthly price list can update rather than duplicate.
+    naturalKeyPosition: 1,
     capabilities: {
       filterable: true,
       sortable: false,
@@ -80,6 +85,8 @@ export const VENDOR_PART_FIELDS: Record<string, ResourceField> = {
     systemAttribute: 'vendor_part_contact',
     systemSortOrder: 'a2',
     nullable: false,
+    // Leg 2 of the natural key `(part, supplier)`. See the `part` leg above.
+    naturalKeyPosition: 2,
     capabilities: {
       filterable: true,
       sortable: false,


### PR DESCRIPTION
## Why

`vendor_part` has **no identifier field in any org**. `vendorSku` is the *supplier's* part number — unique within that supplier, never org-wide — and the identifier picker offers nothing above "Record ID", which no CSV carries. So a monthly supplier price list could only ever be re-imported as **duplicates**.

Its identity is the pair `(part, supplier)`. `subpart` is the same shape: `(parentPart, childPart)` — one assembly contains one component once, with a quantity, so re-importing a BOM must update the quantity rather than append a second line.

The composite-matching machinery already shipped in #1793, and #1876 fixed the two silent breaks in its relation legs. **This is the declaration that turns it on.**

## What

`ResourceField.naturalKeyPosition?: number` — 1-based, ordered — declared on the registry field and promoted through the `mergeSystemAndCustomFields` allow-list exactly as `isIdentifier` is (#1788).

Registry-only, with **no DB fallback**: no per-org column can express a tuple, and `CustomField.isUnique` is the wrong shape for one. Whether `(part, supplier)` identifies a price line is a product fact, so it belongs to the registry — deriving it from a per-org DB column is the drift that left `part_sku.isUnique = false` across half the fleet for four months.

Keyed off the **declaration**, never an entity type — `vendor_part` is the first declarer, not a special case, and any resource that declares a key gets the behaviour.

### Behaviour

- **`getNaturalKeyFields`** returns the legs in declared order, and returns **`[]` on a non-contiguous declaration** rather than a partial key. A partial tuple ANDs too little and updates the *wrong* record; that failure is silent at runtime, so a registry test pins it at build time.
- **Auto-map defaults the identity flag onto every leg, all-or-nothing**, and the natural key **outranks** the single-column pick. Partially mapped, it is dropped entirely rather than degraded to its mapped legs — `analyzeRow` requires every component, so half a tuple reports `unmatched` for every row behind a wizard that says "update", which is strictly worse than staying create-only.
- **A leg is offered at tier 1 but stays `compositeOnly`.** Tier 2 would bury the only identity `vendor_part` has behind a "Not enforced unique" caveat that reads like a warning; dropping `compositeOnly` would let a whole supplier's price list be keyed on the supplier alone, updating an arbitrary line of it.

## Tests

41 new/updated assertions, all green:

- contiguity of every declared position across the whole registry, with a "a natural key of ONE field, use `isIdentifier` instead" guard
- every leg is actually eligible in the picker — otherwise the key looks declared in the registry and is undeclarable in the UI
- `vendor_part` → `(part, contact)` and `subpart` → `(parentPart, childPart)`, **in that order**
- a leg never becomes the lone auto-selected identifier
- every leg flagged when the whole key is mapped; **nothing** flagged when it is partial; the natural key never mixes with the preferred single identifier; resources with no declaration are unchanged

The `identifier-lifecycle` fake db gained an opt-in `batchColumnOrder`, because `focusColumn` alone routes every per-column write onto one row — fine while exactly one column can carry the flag, wrong the moment a composite puts it on two.

## Verification

- `src/import` + `src/resources` — 82 files, **915 passed**, 10 skipped
- `tsc --noEmit` — zero errors in `src/resources/registry` and `src/import`
- biome clean

Rebased onto `e94a249fc` (#1883) — zero file overlap. That merge also closes the dangling-relation hole this phase was carrying: deletes are symmetric now, migration `105` is applied on dev, and all four natural-key legs query **zero** dangling `relatedEntityId`s.