### PR TITLE
feat(chat): bind a chat channel to a shopify store from the setup tab

### DIFF
--- a/apps/api/src/routes/chat/shopify-proxy.ts
+++ b/apps/api/src/routes/chat/shopify-proxy.ts
@@ -50,13 +50,23 @@ shopifyProxyRoute.get('/jwt', async (c) => {
   const channelId = params.get('channel_id')
   const customerId = params.get('logged_in_customer_id')
 
-  if (!shop || !channelId) {
-    return c.json({ error: 'missing_params' }, 400)
-  }
-
   // No logged-in customer = visitor path. Tell boot.js to boot anonymous.
+  // Checked BEFORE the param guard: a visitor needs no channel binding to boot
+  // anonymously, and gating the 204 behind `channel_id` would make this branch
+  // unreachable for any caller that omits it.
   if (!customerId) {
     return c.body(null, 204)
+  }
+
+  if (!shop || !channelId) {
+    // Was silent. This is the storefront's contract with us, and `boot.js` omitting
+    // `channel_id` is exactly what made identified chat fail everywhere — if it ever
+    // regresses, this line is how we find out without a merchant reporting it.
+    log.warn('App Proxy JWT request missing params', {
+      shop,
+      hasChannelId: Boolean(channelId),
+    })
+    return c.json({ error: 'missing_params' }, 400)
   }
 
   // Resolve org from the channel (single indexed read).
@@ -148,6 +158,16 @@ shopifyProxyRoute.get('/jwt', async (c) => {
     signingSecret,
     { expiresIn }
   )
+
+  // The success line. A storefront that renders no widget is either not reaching this route
+  // at all (nothing logged → the embed block or the metafield is the problem) or reaching it
+  // and failing above (a warn/error line names which check). Never logs the JWT itself.
+  log.info('Minted Shopify storefront chat JWT', {
+    shop,
+    channelId,
+    organizationId: orgId,
+    expiresIn,
+  })
 
   c.header('Cache-Control', 'no-store')
   return c.json({ userJwt, expiresIn })

--- a/apps/web/src/components/chat-widget/ui/settings/sections/setup-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/setup-section.tsx
@@ -19,6 +19,7 @@ import {
   type SetupFramework,
   type SetupSnippet,
 } from './setup-snippets'
+import { ShopifyCard } from './shopify-card'
 
 interface SetupSectionProps {
   widget: ChatWidgetWithIntegration
@@ -168,6 +169,14 @@ export function SetupSection({ widget, channelId }: SetupSectionProps) {
             )
           })}
           <p className='text-sm text-muted-foreground'>{activeSnippet.note}</p>
+        </div>
+
+        {/* Platforms axis — the frameworks above are "paste this snippet"; Shopify installs
+            the widget through the Auxx app instead, so it gets its own control rather than
+            a snippet. */}
+        <div className='mt-6'>
+          <p className='mb-2 text-xs font-medium text-muted-foreground'>Or install on a platform</p>
+          <ShopifyCard channelId={channelId} />
         </div>
 
         <div className='mt-4 flex items-center gap-4'>

--- a/apps/web/src/components/chat-widget/ui/settings/sections/shopify-card.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/shopify-card.tsx
@@ -1,0 +1,162 @@
+// apps/web/src/components/chat-widget/ui/settings/sections/shopify-card.tsx
+'use client'
+
+import { Alert, AlertDescription } from '@auxx/ui/components/alert'
+import { Badge } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import { toastError } from '@auxx/ui/components/toast'
+import { AlertTriangle, ArrowUpRight, Check, Store } from 'lucide-react'
+import { VisualIcon } from '~/components/icons/ui/visual-icon'
+import { api } from '~/trpc/react'
+
+const SHOPIFY_APP_STORE_URL = 'https://apps.shopify.com/auxxai'
+
+interface ShopifyCardProps {
+  /** The channel this Setup tab is configuring — the one a bind action binds. */
+  channelId: string
+}
+
+/**
+ * "Use this chat channel on your Shopify store" — phase 5 of `plans/chat/shopify`.
+ *
+ * The storefront theme extension reads a shop metafield to learn which channel to boot.
+ * Nothing wrote that metafield before this card existed, which is why storefront chat was
+ * invisible to every merchant (and to the App Store reviewer).
+ *
+ * Scoped to the channel the Setup tab is already on rather than offering a channel picker:
+ * the merchant is standing in one channel's settings, so "use *this* one" is the question
+ * they actually have. Switching from another channel is handled by binding over it.
+ */
+export function ShopifyCard({ channelId }: ShopifyCardProps) {
+  const utils = api.useUtils()
+  const { data, isLoading } = api.shopify.getChatBinding.useQuery()
+
+  const bindChatChannel = api.shopify.bindChatChannel.useMutation({
+    onSuccess: async (result) => {
+      await utils.shopify.getChatBinding.invalidate()
+      // The setting saved but Shopify didn't get the metafield — the admin would otherwise
+      // claim "connected" while the storefront renders nothing. Say so, don't swallow it.
+      if (!result.metafieldWritten) {
+        toastError({
+          title: 'Saved, but your store wasn’t updated',
+          description: result.reason
+            ? `Shopify returned: ${result.reason}. Try again — the widget won’t appear until this succeeds.`
+            : 'The widget won’t appear on your storefront until this succeeds. Try again.',
+        })
+      }
+    },
+    onError: (error) => {
+      toastError({ title: 'Couldn’t update Shopify', description: error.message })
+    },
+  })
+
+  if (isLoading || !data) return null
+
+  // Not installed, or installed with no store connected — point at the right next step
+  // rather than showing a bind control that cannot work.
+  if (!data.installed || data.shops.length === 0) {
+    return (
+      <Card>
+        <Header />
+        <p className='mt-1 text-xs text-muted-foreground'>
+          {data.installed
+            ? 'The Auxx app is installed but no store is connected yet. Connect one to put this chat widget on your storefront.'
+            : 'Install the Auxx app on your Shopify store to put this chat widget on your storefront — no code to paste.'}
+        </p>
+        <a
+          href={data.installed ? '/app/settings/apps/shopify' : SHOPIFY_APP_STORE_URL}
+          target={data.installed ? undefined : '_blank'}
+          rel='noreferrer'
+          className='mt-3 inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline'>
+          {data.installed ? 'Connect your store' : 'Open the Shopify App Store'}
+          <ArrowUpRight className='size-3.5' />
+        </a>
+      </Card>
+    )
+  }
+
+  const boundHere = data.boundChannelId === channelId
+  const boundElsewhere = Boolean(data.boundChannelId) && !boundHere
+
+  return (
+    <Card>
+      <Header />
+
+      <div className='mt-4 mb-3 space-y-2'>
+        {data.shops.map((shop) => (
+          <div
+            key={shop.domain}
+            className='rounded-md border border-border bg-background px-3 py-2 text-xs'>
+            <div className='flex items-center gap-2'>
+              <Store className='size-3.5 shrink-0 text-muted-foreground' />
+              <span className='font-mono text-foreground'>{shop.domain}</span>
+            </div>
+            {boundHere && (
+              <div className='mt-2 flex flex-wrap items-center gap-2'>
+                <Badge variant='outline' className='gap-1 rounded-md'>
+                  <Check className='size-3' />
+                  Using this channel
+                </Badge>
+                {/* Only offered once bound — sending someone to enable an embed that has no
+                    channel behind it produces a widget that renders nothing. */}
+                {shop.themeEditorUrl && (
+                  <a
+                    href={shop.themeEditorUrl}
+                    target='_blank'
+                    rel='noreferrer'
+                    className='inline-flex items-center gap-1 font-medium text-primary hover:underline'>
+                    Enable in theme
+                    <ArrowUpRight className='size-3' />
+                  </a>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {boundElsewhere && (
+        <Alert className='mb-3'>
+          <AlertTriangle className='size-4' />
+          <AlertDescription className='text-xs'>
+            Another chat channel is currently powering your storefront. Connecting this one replaces
+            it.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <p className='mb-3 text-xs text-muted-foreground'>
+        {boundHere
+          ? 'This channel powers your storefront widget. Use “Enable in theme” above if you haven’t switched on the “Auxx Chat” app embed yet — the widget won’t appear until you do.'
+          : 'Connect this channel, then switch on the “Auxx Chat” app embed in your theme and the widget appears on your storefront.'}
+      </p>
+
+      <Button
+        variant='outline'
+        size='sm'
+        loading={bindChatChannel.isPending}
+        loadingText={boundHere ? 'Disconnecting...' : 'Connecting...'}
+        onClick={() => bindChatChannel.mutate({ channelId: boundHere ? null : channelId })}>
+        {boundHere ? 'Disconnect from store' : 'Use this channel on my store'}
+      </Button>
+    </Card>
+  )
+}
+
+/**
+ * Same shell the Identity tab's `EnforcementCard` uses — `rounded-2xl` on `bg-muted/30`,
+ * with `rounded-md` rows on `bg-background` inside it. Kept in sync deliberately: these two
+ * are the only bespoke cards in the chat-widget settings and they sit one tab apart.
+ */
+function Card({ children }: { children: React.ReactNode }) {
+  return <div className='relative rounded-2xl border border-border bg-muted/30 p-4'>{children}</div>
+}
+
+function Header() {
+  return (
+    <div className='mb-1 flex items-center gap-2 text-sm font-medium'>
+      <VisualIcon value='brand:shopify' size='sm' fallbackIconId='shopping-bag' />
+      Shopify
+    </div>
+  )
+}

--- a/apps/web/src/server/api/routers/shopify.ts
+++ b/apps/web/src/server/api/routers/shopify.ts
@@ -6,20 +6,31 @@ import {
 } from '@auxx/billing'
 import { listCredentials, setDefaultCredential } from '@auxx/credentials/store'
 import { database as db, schema } from '@auxx/database'
-import { installApp, saveAppConnection } from '@auxx/lib/apps'
+import { getAppWithInstallationStatus, installApp, saveAppConnection } from '@auxx/lib/apps'
 import { getOrgCache, isOrgMember, onCacheEvent, resolveAppSlug } from '@auxx/lib/cache'
 import { ConflictError } from '@auxx/lib/errors'
 import { OrganizationService } from '@auxx/lib/organizations'
+import { PermissionKey } from '@auxx/lib/permissions'
+import { bindChatChannelToShopifyInstall } from '@auxx/lib/shopify'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
+import { getAppSettings, saveAppSettings } from '@auxx/services/app-settings'
 import { TRPCError } from '@trpc/server'
 import { and, eq, ne, sql } from 'drizzle-orm'
 import { cookies } from 'next/headers'
 import { z } from 'zod'
 import { setUserDefaultOrganization } from '~/server/auth/set-default-organization'
-import { createTRPCRouter, protectedProcedure } from '../trpc'
+import { createTRPCRouter, permissionProcedure, protectedProcedure } from '../trpc'
 
 const CLAIM_COOKIE_NAME = 'shopify_claim_token'
+
+/**
+ * Block handle of the theme app embed, i.e. the filename of
+ * `extensions/auxx-chat/blocks/embed.liquid` in the auxxai-apps repo. Second half of the
+ * theme editor's `activateAppId=<client_id>/<block handle>` pair — rename that file and this
+ * must change with it.
+ */
+const APP_EMBED_BLOCK_HANDLE = 'embed'
 
 const logger = createScopedLogger('shopify-router')
 
@@ -386,6 +397,200 @@ export const shopifyRouter = createTRPCRouter({
       const provider = getProvider('shopify') as ShopifyBillingProvider
       const redirectUrl = await provider.getPlanSelectionUrl(organizationId)
       return { redirectUrl, shop: claim.shop }
+    }),
+
+  /**
+   * Everything the chat-widget Setup tab's Shopify card needs, in one call — phase 5 of
+   * `plans/chat/shopify`.
+   *
+   * The generic app procedures can serve this (`apps.getBySlug` + `apps.getSettings` +
+   * `apps.listConnections`), but awkwardly: `getSettings` demands an `installationType` the
+   * caller has to discover first, and `listConnections` takes no input and returns every
+   * connection in the org. One purpose-built read keeps the card simple and is the
+   * "ergonomic surface" phase 5 was specified to be.
+   */
+  getChatBinding: protectedProcedure.query(async ({ ctx }) => {
+    const { organizationId } = ctx.session
+
+    const appResult = await getAppWithInstallationStatus({
+      appSlug: 'shopify',
+      organizationId,
+      db: ctx.db,
+    })
+    if (!appResult.ok) {
+      return {
+        installed: false,
+        boundChannelId: null,
+        shops: [] as { domain: string; themeEditorUrl: string | null }[],
+      }
+    }
+    const { app, installation } = appResult.value
+    if (!installation.isInstalled || !installation.id) {
+      return {
+        installed: false,
+        boundChannelId: null,
+        shops: [] as { domain: string; themeEditorUrl: string | null }[],
+      }
+    }
+
+    const settingsResult = await getAppSettings({ appInstallationId: installation.id })
+    const raw = settingsResult.isOk()
+      ? (settingsResult.value as Record<string, unknown>).chatChannelId
+      : undefined
+    const boundChannelId = typeof raw === 'string' && raw ? raw : null
+
+    // Shop domains for display. Both metadata shapes are in the wild — see
+    // `resolveShopDomain` in `@auxx/lib/shopify` for why.
+    const credsResult = await listCredentials({
+      organizationId,
+      kind: 'app',
+      appId: app.id,
+      userId: null,
+    })
+    const domains = credsResult.isOk()
+      ? credsResult.value
+          .map((cred) => {
+            const meta = cred.metadata as Record<string, unknown>
+            if (typeof meta.shopDomain === 'string' && meta.shopDomain) return meta.shopDomain
+            const vars = meta.connectionVariables as Record<string, unknown> | undefined
+            const shop = vars?.shop
+            if (typeof shop !== 'string' || !shop) return null
+            return shop.includes('.') ? shop : `${shop}.myshopify.com`
+          })
+          .filter((s): s is string => Boolean(s))
+      : []
+
+    // Binding a channel is only half the merchant's job — the "Auxx Chat" app embed also has
+    // to be switched on in their theme, which is buried under Online Store → Themes →
+    // Customize → App embeds. `activateAppId` opens the theme editor with it already toggled
+    // on, so the remaining step is one click and a Save.
+    //
+    // The id is the **app's client_id**, not the theme extension's uid — verified against a
+    // live theme editor, which puts `?appEmbed=<client_id>/embed` in the URL when the block is
+    // selected. `embed` is the block handle, i.e. `blocks/embed.liquid`. Built server-side
+    // because the client_id differs between the prod and dev Partner apps and must match
+    // whichever one is deployed.
+    const clientId = process.env.SHOPIFY_API_KEY
+    const shops = domains.map((domain) => ({
+      domain,
+      themeEditorUrl: clientId
+        ? `https://${domain}/admin/themes/current/editor?context=apps&activateAppId=${clientId}/${APP_EMBED_BLOCK_HANDLE}`
+        : null,
+    }))
+
+    return { installed: true, boundChannelId, shops }
+  }),
+
+  /**
+   * Bind (or unbind) the chat channel that powers the storefront widget on this org's
+   * Shopify store — phase 5 of `plans/chat/shopify`.
+   *
+   * Two writes, deliberately in this order and NOT in one transaction:
+   *  1. The `chatChannelId` app setting — the durable record, and the thing the audience
+   *     fan-out (`fanOutAuxxChatAudienceToShopify`) later keys off.
+   *  2. The shop metafields on Shopify — what the theme extension's Liquid actually reads.
+   *
+   * A Shopify API failure must not lose the merchant's choice, so step 2 is best-effort and
+   * its outcome is RETURNED rather than thrown: `metafieldWritten: false` means the setting
+   * is saved but the storefront does not know about it yet, and the caller is expected to
+   * offer a retry. Swallowing that silently would leave the admin claiming "bound" while the
+   * storefront renders nothing — the exact divergence that made this area hard to debug.
+   *
+   * Lives here rather than in `apps.saveSettings` because that procedure is the generic,
+   * app-agnostic settings writer with no post-save hook; one app's side effects do not belong
+   * in every app's write path. Mirrors `channel.ts`'s audience fan-out, which is the same
+   * shape for the same reason.
+   */
+  bindChatChannel: permissionProcedure(PermissionKey.integrationsManage)
+    .input(z.object({ channelId: z.string().nullable() }))
+    .mutation(async ({ ctx, input }) => {
+      const { organizationId } = ctx.session
+      const { channelId } = input
+
+      const appResult = await getAppWithInstallationStatus({
+        appSlug: 'shopify',
+        organizationId,
+        db: ctx.db,
+      })
+      if (!appResult.ok) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Shopify app not found' })
+      }
+      const installation = appResult.value.installation
+      if (!installation.isInstalled || !installation.id) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Shopify app is not installed' })
+      }
+
+      // Guard the channel actually belongs to this org — the id comes off a client picker.
+      if (channelId) {
+        const owned = await ctx.db.query.Integration.findFirst({
+          where: and(
+            eq(schema.Integration.id, channelId),
+            eq(schema.Integration.organizationId, organizationId),
+            eq(schema.Integration.provider, 'chat')
+          ),
+          columns: { id: true },
+        })
+        if (!owned) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Chat channel not found' })
+        }
+      }
+
+      const saveResult = await saveAppSettings({
+        appInstallationId: installation.id,
+        appDeploymentId: installation.currentDeploymentId ?? undefined,
+        settings: { chatChannelId: channelId ?? '' },
+      })
+      if (saveResult.isErr()) {
+        logger.error('Failed to save chatChannelId setting', {
+          organizationId,
+          channelId,
+          error: saveResult.error.message,
+        })
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: saveResult.error.message,
+        })
+      }
+
+      let metafieldWritten = false
+      let reason: string | undefined
+      try {
+        const bound = await bindChatChannelToShopifyInstall({
+          organizationId,
+          appInstallationId: installation.id,
+          channelId,
+        })
+        metafieldWritten = bound.ok
+        if (!bound.ok) reason = bound.reason
+      } catch (error) {
+        reason = error instanceof Error ? error.message : String(error)
+        logger.error('bindChatChannelToShopifyInstall threw', {
+          organizationId,
+          channelId,
+          error: reason,
+        })
+      }
+
+      // One line per outcome, same shape, so a prod query on
+      // `scope='shopify-router' AND match_all('chat channel')` shows every bind attempt and
+      // whether Shopify actually received it — see `docs/log-history.md`.
+      if (metafieldWritten) {
+        logger.info('Chat channel bound to Shopify', {
+          organizationId,
+          appInstallationId: installation.id,
+          channelId,
+          action: channelId ? 'bind' : 'unbind',
+        })
+      } else {
+        logger.warn('Chat channel setting saved but shop metafields were not written', {
+          organizationId,
+          appInstallationId: installation.id,
+          channelId,
+          reason,
+        })
+      }
+
+      return { success: true, metafieldWritten, reason }
     }),
 })
 

--- a/packages/lib/src/shopify/chat-metafields.ts
+++ b/packages/lib/src/shopify/chat-metafields.ts
@@ -8,6 +8,16 @@ import { createShopifyAdminClient } from './admin-client'
 
 const logger = createScopedLogger('shopify/chat-metafields')
 
+/**
+ * Outcome of a metafield write. Every failure path is REPORTED, never swallowed.
+ *
+ * This used to return `void` and log-and-continue on all four failure branches, so
+ * `bindChatChannelToShopifyInstall` returned `{ ok: true }` even when Shopify had received
+ * nothing — the admin claimed "connected" while the storefront rendered nothing, with the
+ * only evidence in a log line nobody was reading.
+ */
+export type MetafieldWriteResult = { ok: true } | { ok: false; reason: string }
+
 export const AUXX_CHAT_METAFIELD_NAMESPACE = '$app:chat'
 export const AUXX_CHAT_METAFIELD_KEY_CHANNEL = 'channel_id'
 export const AUXX_CHAT_METAFIELD_KEY_AUDIENCE = 'audience'
@@ -43,9 +53,11 @@ export interface WriteAuxxChatMetafieldsInput {
  * data UI, can't be read/written by other apps, and auto-delete on app
  * uninstall — no definition registration required.
  */
-export async function writeAuxxChatMetafields(input: WriteAuxxChatMetafieldsInput): Promise<void> {
+export async function writeAuxxChatMetafields(
+  input: WriteAuxxChatMetafieldsInput
+): Promise<MetafieldWriteResult> {
   const { shopDomain, accessToken, channelId, audience } = input
-  if (channelId === undefined && audience === undefined) return
+  if (channelId === undefined && audience === undefined) return { ok: true }
 
   const client = createShopifyAdminClient({ shopDomain, accessToken })
 
@@ -54,12 +66,16 @@ export async function writeAuxxChatMetafields(input: WriteAuxxChatMetafieldsInpu
     const response = await client.request(SHOP_GID_QUERY)
     shopGid = response.data?.shop?.id
   } catch (error) {
-    logger.error('Failed to fetch shop GID for metafield write', { shopDomain, error })
-    return
+    const message = error instanceof Error ? error.message : String(error)
+    logger.error('Failed to fetch shop GID for metafield write', { shopDomain, error: message })
+    // An expired or revoked Admin token surfaces here first, as a 401 on the cheapest
+    // possible query — so this branch is the one to look for in prod when a bind "succeeds"
+    // but the storefront never changes.
+    return { ok: false, reason: `shop_gid_request_failed: ${message}` }
   }
   if (!shopGid) {
     logger.error('No shop GID returned from Shopify', { shopDomain })
-    return
+    return { ok: false, reason: 'shop_gid_missing' }
   }
 
   const metafields: Array<{
@@ -95,9 +111,21 @@ export async function writeAuxxChatMetafields(input: WriteAuxxChatMetafieldsInpu
     const errors = response.data?.metafieldsSet?.userErrors ?? []
     if (errors.length > 0) {
       logger.error('Shopify metafieldsSet userErrors', { shopDomain, errors })
+      return { ok: false, reason: `user_errors: ${JSON.stringify(errors)}` }
     }
+    // Success is logged at info with the exact namespace/key/value pairs, because the
+    // storefront reading them back is a different system on a different machine — when the
+    // widget doesn't appear, the first question is always "was anything actually written".
+    logger.info('Wrote Auxx chat metafields', {
+      shopDomain,
+      namespace: AUXX_CHAT_METAFIELD_NAMESPACE,
+      written: metafields.map((m) => ({ key: m.key, value: m.value })),
+    })
+    return { ok: true }
   } catch (error) {
-    logger.error('Failed to write Shopify chat metafields', { shopDomain, error })
+    const message = error instanceof Error ? error.message : String(error)
+    logger.error('Failed to write Shopify chat metafields', { shopDomain, error: message })
+    return { ok: false, reason: `metafields_set_failed: ${message}` }
   }
 }
 
@@ -162,12 +190,19 @@ export async function fanOutAuxxChatAudienceToShopify(params: {
         continue
       }
       const accessToken = revealed.value.secrets.accessToken
-      const shopDomain = revealed.value.record.metadata.shopDomain as string | undefined
+      const shopDomain = resolveShopDomain(revealed.value.record.metadata)
       if (!accessToken || !shopDomain) {
         logger.warn('Shopify credential missing accessToken or shopDomain', { channelId })
         continue
       }
-      await writeAuxxChatMetafields({ shopDomain, accessToken, audience })
+      const written = await writeAuxxChatMetafields({ shopDomain, accessToken, audience })
+      if (!written.ok) {
+        logger.warn('Audience fan-out did not reach Shopify', {
+          channelId,
+          shopDomain,
+          reason: written.reason,
+        })
+      }
     } catch (error) {
       logger.error('Failed to fan out audience metafield to Shopify install', {
         channelId,
@@ -191,6 +226,28 @@ export async function fanOutAuxxChatAudienceToShopify(params: {
  * Pass `channelId = null` to unbind (the embed's Liquid renders nothing
  * when the metafield is blank).
  */
+/**
+ * Resolve a Shopify credential's shop domain, tolerating both shapes the codebase writes.
+ *
+ * `metadata.shopDomain` (full `x.myshopify.com`) is set only by the **App Store** install
+ * path — `shopify.claimShopifyInstall`. A store connected from inside Auxx goes through the
+ * generic `/api/apps/[slug]/oauth2/callback`, which writes the shop as a *subdomain* under
+ * `metadata.connectionVariables.shop` and no `shopDomain` at all. Reading only the former
+ * meant chat binding failed with `credential_missing_shop_or_token` for every in-app
+ * connection — the majority of them.
+ *
+ * Same normalisation the Shopify app's own `getShopDomain` performs.
+ */
+function resolveShopDomain(metadata: Record<string, unknown>): string | undefined {
+  const direct = metadata.shopDomain
+  if (typeof direct === 'string' && direct) return direct
+
+  const vars = metadata.connectionVariables as Record<string, unknown> | undefined
+  const shop = vars?.shop
+  if (typeof shop !== 'string' || !shop) return undefined
+  return shop.includes('.') ? shop : `${shop}.myshopify.com`
+}
+
 export async function bindChatChannelToShopifyInstall(params: {
   organizationId: string
   appInstallationId: string
@@ -236,8 +293,16 @@ export async function bindChatChannelToShopifyInstall(params: {
     return { ok: false, reason: 'decryption_failed' }
   }
   const accessToken = revealed.value.secrets.accessToken
-  const shopDomain = revealed.value.record.metadata.shopDomain as string | undefined
+  const shopDomain = resolveShopDomain(revealed.value.record.metadata)
   if (!accessToken || !shopDomain) {
+    logger.error('Shopify credential unusable for chat binding', {
+      organizationId,
+      appInstallationId,
+      credentialId: credential.id,
+      hasAccessToken: Boolean(accessToken),
+      resolvedShopDomain: shopDomain ?? null,
+      metadataKeys: Object.keys(revealed.value.record.metadata ?? {}),
+    })
     return { ok: false, reason: 'credential_missing_shop_or_token' }
   }
 
@@ -251,12 +316,24 @@ export async function bindChatChannelToShopifyInstall(params: {
     audience = (widget?.chatAudience ?? 'visitors') as 'visitors' | 'both' | 'users'
   }
 
-  await writeAuxxChatMetafields({
+  logger.info('Binding chat channel to Shopify install', {
+    organizationId,
+    appInstallationId,
+    shopDomain,
+    channelId,
+    audience,
+    action: channelId ? 'bind' : 'unbind',
+  })
+
+  const written = await writeAuxxChatMetafields({
     shopDomain,
     accessToken,
     channelId,
     audience,
   })
+  if (!written.ok) {
+    return { ok: false, reason: written.reason }
+  }
 
   return { ok: true }
 }


### PR DESCRIPTION
Closes the App Store reviewer's "Auxx chat not working" report. Phase 5 of `plans/chat/shopify`.

## Why chat was invisible

The theme extension reads a shop metafield to learn which channel to boot. Nothing ever wrote it, because the admin UI that binds a channel was never built — phase 5 was `📝 planned`. Verified live: on `auxxai.myshopify.com` the app embed block is already enabled and the storefront still renders no widget.

## What's here

- **`shopify.bindChatChannel`** — writes the `chatChannelId` app setting, then pushes the shop metafields. On the shopify router rather than `apps.saveSettings`, which is the generic app-agnostic settings writer with no post-save hook; one app's side effects don't belong in every app's write path. Mirrors `channel.ts`'s audience fan-out.
- **`shopify.getChatBinding`** — one read behind the card. The generic procedures can serve this, but `apps.getSettings` demands an `installationType` the caller has to discover first, and `apps.listConnections` takes no input and returns every connection in the org.
- **Shopify card** in the chat-widget Setup tab, styled to match the Identity tab's `EnforcementCard`. Scoped to the channel the tab is already on rather than offering a picker — the merchant is standing in one channel's settings.
- **Theme-customizer deeplink** per shop, so enabling the app embed is one click instead of a hunt through Online Store → Themes → Customize → App embeds. `activateAppId` is `<client_id>/embed` — **the app's client_id, not the theme extension uid**, verified against a live theme editor. Built server-side because prod and dev are different Partner apps.

## Two defects found while wiring it up

**`writeAuxxChatMetafields` swallowed every failure.** It returned `void` and logged-and-continued on all four paths (GID fetch throws, no GID, `metafieldsSet` userErrors, request throws), so `bindChatChannelToShopifyInstall` returned `ok: true` even when Shopify received nothing. It now returns a result, both callers propagate it, and the card surfaces `metafieldWritten: false` with a retry rather than claiming success. Without this the new flag would have lied in exactly the cases it exists to catch.

**The shop domain was read only from `metadata.shopDomain`**, which only the App Store install path writes. A store connected from inside Auxx goes through the generic OAuth callback, which stores a *subdomain* under `metadata.connectionVariables.shop` and no `shopDomain` at all — so binding failed with `credential_missing_shop_or_token` for most connections. `resolveShopDomain` handles both shapes. The audience fan-out had the identical bug.

## Logging

Structured logs across the whole path — bind attempt, metafield write outcome with the exact key/value pairs written, proxy JWT mint, and the previously-silent `missing_params` branch. A storefront that renders nothing is now diagnosable from logs: nothing at the proxy means the embed or metafield is wrong; a warn line names which check failed.

## Needs the companion PR

`boot.js` never sent `channel_id`, so the proxy 400s for logged-in shoppers — Auxx-Ai/auxxai-apps#57. Neither half works alone.

## Still open

The metafield namespace is unverified: the writer uses `$app:chat` (→ `app--{app-id}--chat`) and `embed.liquid` reads `shop.metafields.app.channel_id`. The README documents that shorthand as intentional. If it doesn't resolve a *suffixed* reserved namespace, binding will succeed and the widget still won't appear. It's a five-minute check on a dev store and it's written up in `plans/chat/shopify/phase-5-admin-ui.md` §1.

## Test notes

- `packages/lib` resolves through `dist` in dev — `pnpm --filter @auxx/lib build` after pulling, or the router runs stale code.
- Two Shopify credentials in dev have past `expiresAt` values (the `expiring: '1'` token issue). A bind against those will now fail at the metafield write with a 401 rather than silently — that's the intended behaviour, not a regression.