### PR TITLE
fix(chat): gate the shopify storefront card behind SHOPIFY_STOREFRONT_CHAT_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -177,6 +177,10 @@ GOOGLE_PUBSUB_VERIFICATION_TOKEN=
 # ------------------------------------
 SHOPIFY_API_KEY=
 SHOPIFY_API_SECRET=
+# Set true only while the `auxx-chat` theme app extension is deployed on the Shopify app.
+# Gates the Shopify card in the chat-widget Setup tab — with the extension pulled there is
+# nothing on a storefront to render a bound channel.
+SHOPIFY_STOREFRONT_CHAT_ENABLED=false
 
 # Shopify App Pricing (billing v2). See plans/billing/v2/04-partner-api-client.md §1.
 # Hot path — Admin API subscription read:

--- a/apps/web/src/components/chat-widget/ui/settings/sections/setup-section.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/setup-section.tsx
@@ -172,12 +172,9 @@ export function SetupSection({ widget, channelId }: SetupSectionProps) {
         </div>
 
         {/* Platforms axis — the frameworks above are "paste this snippet"; Shopify installs
-            the widget through the Auxx app instead, so it gets its own control rather than
-            a snippet. */}
-        <div className='mt-6'>
-          <p className='mb-2 text-xs font-medium text-muted-foreground'>Or install on a platform</p>
-          <ShopifyCard channelId={channelId} />
-        </div>
+            the widget through the Auxx app instead, so it gets its own control rather than a
+            snippet. Renders nothing when storefront chat is off, heading included. */}
+        <ShopifyCard channelId={channelId} />
 
         <div className='mt-4 flex items-center gap-4'>
           <a

--- a/apps/web/src/components/chat-widget/ui/settings/sections/shopify-card.tsx
+++ b/apps/web/src/components/chat-widget/ui/settings/sections/shopify-card.tsx
@@ -50,7 +50,11 @@ export function ShopifyCard({ channelId }: ShopifyCardProps) {
     },
   })
 
-  if (isLoading || !data) return null
+  // `enabled: false` means the theme app extension isn't deployed, so there is nothing on a
+  // storefront that could render a bound channel. Render nothing at all rather than an
+  // explanation — a merchant who never had this cannot miss it, and a "coming soon" card is
+  // just noise on the one tab people go to when they want to install.
+  if (isLoading || !data || !data.enabled) return null
 
   // Not installed, or installed with no store connected — point at the right next step
   // rather than showing a bind control that cannot work.
@@ -149,7 +153,12 @@ export function ShopifyCard({ channelId }: ShopifyCardProps) {
  * are the only bespoke cards in the chat-widget settings and they sit one tab apart.
  */
 function Card({ children }: { children: React.ReactNode }) {
-  return <div className='relative rounded-2xl border border-border bg-muted/30 p-4'>{children}</div>
+  return (
+    <div className='mt-6'>
+      <p className='mb-2 text-xs font-medium text-muted-foreground'>Or install on a platform</p>
+      <div className='relative rounded-2xl border border-border bg-muted/30 p-4'>{children}</div>
+    </div>
+  )
 }
 
 function Header() {

--- a/apps/web/src/server/api/routers/shopify.ts
+++ b/apps/web/src/server/api/routers/shopify.ts
@@ -4,6 +4,7 @@ import {
   type ShopifyBillingProvider,
   stripeClient,
 } from '@auxx/billing'
+import { configService } from '@auxx/credentials'
 import { listCredentials, setDefaultCredential } from '@auxx/credentials/store'
 import { database as db, schema } from '@auxx/database'
 import { getAppWithInstallationStatus, installApp, saveAppConnection } from '@auxx/lib/apps'
@@ -412,6 +413,21 @@ export const shopifyRouter = createTRPCRouter({
   getChatBinding: protectedProcedure.query(async ({ ctx }) => {
     const { organizationId } = ctx.session
 
+    // Storefront chat only exists if the `auxx-chat` theme app extension is deployed on the
+    // Shopify app. It is currently pulled while the App Store submission is in flight (chat
+    // was flagged in earlier review rounds), so binding a channel would write a metafield
+    // that nothing on the storefront reads — the merchant would get a success toast and no
+    // widget, which is worse than not offering it. Restoring the extension and flipping this
+    // to `true` is the whole of turning it back on; no code change.
+    if (!configService.get<boolean>('SHOPIFY_STOREFRONT_CHAT_ENABLED')) {
+      return {
+        enabled: false,
+        installed: false,
+        boundChannelId: null,
+        shops: [] as { domain: string; themeEditorUrl: string | null }[],
+      }
+    }
+
     const appResult = await getAppWithInstallationStatus({
       appSlug: 'shopify',
       organizationId,
@@ -419,6 +435,7 @@ export const shopifyRouter = createTRPCRouter({
     })
     if (!appResult.ok) {
       return {
+        enabled: true,
         installed: false,
         boundChannelId: null,
         shops: [] as { domain: string; themeEditorUrl: string | null }[],
@@ -427,6 +444,7 @@ export const shopifyRouter = createTRPCRouter({
     const { app, installation } = appResult.value
     if (!installation.isInstalled || !installation.id) {
       return {
+        enabled: true,
         installed: false,
         boundChannelId: null,
         shops: [] as { domain: string; themeEditorUrl: string | null }[],
@@ -478,7 +496,7 @@ export const shopifyRouter = createTRPCRouter({
         : null,
     }))
 
-    return { installed: true, boundChannelId, shops }
+    return { enabled: true, installed: true, boundChannelId, shops }
   }),
 
   /**
@@ -506,6 +524,16 @@ export const shopifyRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const { organizationId } = ctx.session
       const { channelId } = input
+
+      // Hiding the card is not the guard — this is. Binding while the theme extension is
+      // pulled writes a metafield nothing reads, so the merchant gets a success state and no
+      // widget.
+      if (!configService.get<boolean>('SHOPIFY_STOREFRONT_CHAT_ENABLED')) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'Storefront chat is not available on Shopify yet.',
+        })
+      }
 
       const appResult = await getAppWithInstallationStatus({
         appSlug: 'shopify',

--- a/packages/credentials/src/config/config-registry.ts
+++ b/packages/credentials/src/config/config-registry.ts
@@ -800,6 +800,18 @@ export const CONFIG_VARIABLES = {
     isSensitive: true,
     isEnvOnly: false,
   },
+  SHOPIFY_STOREFRONT_CHAT_ENABLED: {
+    key: 'SHOPIFY_STOREFRONT_CHAT_ENABLED',
+    description:
+      'Whether the `auxx-chat` theme app extension is deployed on the Shopify app. Gates the ' +
+      'Shopify card in the chat-widget Setup tab — with the extension pulled there is nothing ' +
+      'on the storefront to render a bound channel, so the card must not offer the bind.',
+    type: ConfigVariableType.BOOLEAN,
+    group: ConfigVariableGroup.SHOPIFY,
+    defaultValue: false,
+    isSensitive: false,
+    isEnvOnly: false,
+  },
 
   // ── BILLING ──────────────────────────────────────────────
   STRIPE_SECRET_KEY: {


### PR DESCRIPTION
Companion to Auxx-Ai/auxxai-apps#58, which pulls the `auxx-chat` theme app extension from the Shopify app while the App Store submission is in flight.

## Why

With the extension gone there is nothing on a storefront that could render a bound channel. The Setup tab's Shopify card would still offer "use this channel on my store" — a merchant clicks it, the logs report a successful metafield write, and no widget ever appears.

That's strictly worse than not offering it, because now we've promised it in our own UI rather than just having a dead block in a theme customizer.

## What

- `SHOPIFY_STOREFRONT_CHAT_ENABLED` config variable, **default false**.
- `getChatBinding` returns `enabled: false`; the card renders nothing — including its "Or install on a platform" heading, which moved into the card so the two hide together rather than leaving an orphaned label.
- `bindChatChannel` throws `PRECONDITION_FAILED` on the same flag. Hiding the card is not the guard; this is.

## Turning it back on

Set the flag and redeploy the extension. No code change.

The test that has to pass before that happens is in `plans/chat/shopify/phase-5-admin-ui.md` §1 — the writer uses `$app:chat` and `embed.liquid` reads `shop.metafields.app.*`, and whether that shorthand resolves a *suffixed* reserved namespace has never been verified against a live theme render. If it doesn't, binding succeeds and the storefront still shows nothing.

## Context

Storefront chat was raised in earlier review rounds. It is **not** in the current open feedback — that's a single billing item (1.2.2, plan changes not reflected in the app UI) — but the extension has been live and enabled on the dev store since June 24 while rendering nothing, so a reviewer poking at it finds a dead feature. Removing the surface until the path is proven.