### PR TITLE
fix(billing): make the seat stepper read-only on shopify

### DIFF
--- a/apps/web/src/components/subscriptions/plan-change-summary.tsx
+++ b/apps/web/src/components/subscriptions/plan-change-summary.tsx
@@ -520,8 +520,14 @@ function PlanChangeSummaryContent({
             )}
           </div>
 
-          {/* Seats Card */}
-          <div className='group flex items-center justify-between rounded-2xl border py-2 px-3 hover:bg-muted transition-colors duration-200'>
+          {/* Seats Card. Read-only on Shopify: App Pricing has no quantity line, so
+              `createSubscription` ignores `seats` and the hosted pricing page has nothing
+              to pre-set — an editable stepper would move the cost preview and then do
+              nothing on approval. Seats are metered daily instead (seat-usage drip). */}
+          <div
+            className={`group flex items-center justify-between rounded-2xl border py-2 px-3 transition-colors duration-200 ${
+              isShopify ? '' : 'hover:bg-muted'
+            }`}>
             <div className='flex flex-row items-center gap-2'>
               <div className='size-8 border bg-muted rounded-lg flex items-center justify-center group-hover:bg-secondary transition-colors shrink-0'>
                 <Users className='size-4' />
@@ -529,21 +535,27 @@ function PlanChangeSummaryContent({
               <div className='flex flex-col'>
                 <span className='text-sm font-medium'>Seats</span>
                 <span className='text-xs text-muted-foreground'>
-                  Purchase additional seats to add more users
+                  {isShopify
+                    ? 'Billed automatically as you add or remove team members'
+                    : 'Purchase additional seats to add more users'}
                 </span>
               </div>
             </div>
-            <NumberInput
-              value={seats}
-              onValueChange={(v) => setSeats(Math.max(selectedPlan.minSeats ?? 1, v ?? 1))}
-              min={selectedPlan.minSeats}
-              max={selectedPlan.maxSeats}
-              step={1}>
-              <InputGroup className='w-32'>
-                <NumberInputField id='seats' />
-                <NumberInputArrows />
-              </InputGroup>
-            </NumberInput>
+            {isShopify ? (
+              <span className='text-sm font-medium tabular-nums pr-2'>{seats}</span>
+            ) : (
+              <NumberInput
+                value={seats}
+                onValueChange={(v) => setSeats(Math.max(selectedPlan.minSeats ?? 1, v ?? 1))}
+                min={selectedPlan.minSeats}
+                max={selectedPlan.maxSeats}
+                step={1}>
+                <InputGroup className='w-32'>
+                  <NumberInputField id='seats' />
+                  <NumberInputArrows />
+                </InputGroup>
+              </NumberInput>
+            )}
           </div>
 
           {/* Billing Information — hidden for providers that don't manage card-on-file. */}


### PR DESCRIPTION
## What

The Seats card in the plan-change dialog renders a static count instead of an editable stepper for Shopify-billed orgs, with the sublabel swapped from "Purchase additional seats to add more users" to "Billed automatically as you add or remove team members". The hover affordance is dropped on the now-inert row. Stripe orgs are untouched.

## Why

Shopify App Pricing has no quantity line. `ShopifyBillingProvider.createSubscription` (`packages/billing/src/providers/shopify/provider.ts`) ignores the `seats` value `onSubmit` hands it and returns the hosted pricing-page redirect — and that page has no seat quantity to pre-set. So on Shopify the stepper moved the cost preview and then did nothing on approval.

## What stayed

The seat number and the `{seats} seat × {plan}` line are still shown, because on Shopify that total is correct: the base recurring price covers seat 1 and seats 2..N accrue through the daily `seat_days` meter at `price/30` per day, landing on `seats × price` over a cycle (`packages/billing/src/providers/shopify/seat-usage.ts`). Only the editing was fake.

## Not in this PR

Tracing this surfaced a separate issue in the same path, left alone deliberately:

`PlanSubscription.seats` doesn't track team size. The only write that moves it is `accept-invitation.ts` (`seats + 1` on invitation acceptance). `removeMember` deletes the member row and leaves it alone, and nothing recomputes it. On Stripe it self-heals — `subscription-updated.ts` rewrites it from the line-item quantity on every webhook. On Shopify there is no quantity line and `syncFromAdminApi` never writes `seats`, so the drift is permanent in both directions — and it is the number `reportOrgSeatDay` bills off.

Practical consequence: a Shopify org whose members did not arrive by accepting an invite sits at the `seats: 1` written at claim, and the drip short-circuits on `billableSeats === 0` — metering nothing, ever.

Two smaller ones alongside it: `seats` counts a field/worker seat identically to a full seat (only `countSeatsUsed` splits the classes), and `syncFromAdminApi` never advances `periodStart`, which `aiIntegration` uses as the AI-usage window start.

## Testing

- `biome check` clean
- `tsc --noEmit` on `apps/web` — no errors in the changed file
- UI change only; no schema, API, or billing-path changes