### PR TITLE
fix(import): relation imports created records with no links and reported success

### DIFF
--- a/packages/lib/src/import/fields/identifier-eligibility.ts
+++ b/packages/lib/src/import/fields/identifier-eligibility.ts
@@ -66,7 +66,7 @@ export const TIER_2_IDENTIFIER_NOTE = 'Not enforced unique'
 
 /** True when the field is derived from other fields and cannot be set directly. */
 function isComputed(field: ResourceField): boolean {
-  return field.capabilities.computed === true || (field.sourceFields?.length ?? 0) > 0
+  return field.capabilities?.computed === true || (field.sourceFields?.length ?? 0) > 0
 }
 
 /**
@@ -86,11 +86,14 @@ function isComputed(field: ResourceField): boolean {
 export function getIdentifierEligibility(field: ResourceField): IdentifierEligibility | null {
   // Hidden fields are invisible in every other user-facing surface; never offer
   // one here either.
-  if (field.capabilities.hidden) return null
+  // Optional-chained throughout: a partially-built field (a hand-made resource, a
+  // projection that dropped capabilities) must be judged INELIGIBLE, never throw —
+  // this is called from relation policy, which runs on resources it did not build.
+  if (field.capabilities?.hidden) return null
 
   // The lookup filters on the field, so it has to be filterable. This is the one
   // pre-existing rule the tiering keeps unchanged.
-  if (!field.capabilities.filterable) return null
+  if (!field.capabilities?.filterable) return null
 
   // A computed field has no stored value of its own to match against.
   if (isComputed(field)) return null
@@ -105,7 +108,7 @@ export function getIdentifierEligibility(field: ResourceField): IdentifierEligib
 
   const outputKey = getFieldOutputKey(field)
   const isRecommended =
-    field.capabilities.unique === true ||
+    field.capabilities?.unique === true ||
     field.isUnique === true ||
     field.isIdentifier === true ||
     // A declared natural-key leg is RECOMMENDED even though it carries no

--- a/packages/lib/src/import/resolution/__tests__/relation-lookup-policy.test.ts
+++ b/packages/lib/src/import/resolution/__tests__/relation-lookup-policy.test.ts
@@ -91,7 +91,12 @@ describe('Defect E, an auto-mapped relation column resolves', () => {
     // Before the fix the resolver looked for a field keyed `Company Name`,
     // found none, and returned [], "No match found" for every value, and a
     // failed row wherever the relation is required.
-    expect(results[0]!.recordId).toBe('rec-1')
+    // 🛑 A full `defId:instanceId` RecordId, not the bare `rec-1` this asserted
+    // until 2026-08-26. The write path's `relationship` arm takes a string only
+    // when it contains a ':' and silently drops anything else, so a bare id here
+    // meant an import created join records with NO links and still reported
+    // success. Do not "simplify" this back.
+    expect(results[0]!.recordId).toBe('def-company:rec-1')
     expect(results[0]!.error).toBeUndefined()
     expect(results[0]!.outcome).toBe('matched')
   })
@@ -251,7 +256,7 @@ describe('§1.2 relation matching stays case-INSENSITIVE, in both directions', (
       [lookup('m400l', { matchField: 'name' })],
       allow
     )
-    expect(results[0]!.recordId).toBe('rec-1')
+    expect(results[0]!.recordId).toBe('def-company:rec-1')
   })
 
   it('an uppercase cell links to a stored lowercase value', async () => {
@@ -266,7 +271,7 @@ describe('§1.2 relation matching stays case-INSENSITIVE, in both directions', (
     )
     // Contract D-F moves the IDENTIFIER path to case-insensitive to agree with
     // this one; the relation direction is pinned here so it can never drift.
-    expect(results[0]!.recordId).toBe('rec-1')
+    expect(results[0]!.recordId).toBe('def-company:rec-1')
   })
 })
 

--- a/packages/lib/src/import/resolution/__tests__/relation-policy.test.ts
+++ b/packages/lib/src/import/resolution/__tests__/relation-policy.test.ts
@@ -1,6 +1,8 @@
 // packages/lib/src/import/resolution/__tests__/relation-policy.test.ts
 
 import { describe, expect, it } from 'vitest'
+import { RESOURCE_FIELD_REGISTRY } from '../../../resources/registry/field-registry'
+import type { ResourceField } from '../../../resources/registry/field-types'
 import type { Resource } from '../../../resources/registry/types'
 import { BaseType } from '../../../resources/types'
 import {
@@ -13,6 +15,7 @@ import {
   explainCreateUnavailable,
   matchesDisplayField,
   relationFieldWriteMode,
+  resolveDefaultMatchFieldKey,
   resolveDisplayFieldKey,
 } from '../relation-policy'
 
@@ -183,5 +186,76 @@ describe('buildRelationColumnPolicy, the auto-map path', () => {
       linkMode: 'add',
       resolutionType: 'relation:match',
     })
+  })
+})
+
+/**
+ * The DEFAULT match field — a real business key if the target has one, else the
+ * display field.
+ *
+ * Display alone was wrong for `part`: no BOM and no price list carries part
+ * TITLES, they carry SKUs, so every row of a parts-relation file resolved to
+ * nothing until the user changed the dropdown by hand — while the picker sat
+ * there labelling SKU "recommended".
+ */
+describe('resolveDefaultMatchFieldKey', () => {
+  const fieldsOf = (id: string) =>
+    Object.values(RESOURCE_FIELD_REGISTRY[id] ?? {}) as ResourceField[]
+
+  it('defaults a part relation to SKU, not Title', () => {
+    const part = {
+      id: 'part',
+      fields: fieldsOf('part'),
+      display: { primaryDisplayField: { id: 'title' } },
+    } as unknown as Resource
+    expect(resolveDefaultMatchFieldKey(part)).toBe('sku')
+    // …and the display field is still `title`, so this is a real divergence and
+    // not the two happening to agree.
+    expect(resolveDisplayFieldKey(part)).toBe('title')
+  })
+
+  // 🛑 The case that makes "just use the identifier" wrong. `company`'s ONLY
+  // tier-1 identifier is `id`. Defaulting to it would match every supplier cell
+  // against a CUID no CSV carries — every row failing — and `matchField === 'id'`
+  // is additionally a hard stop in `canCreateOnNoMatch`, so supplier auto-create
+  // would go dark too. It must fall through to the display field.
+  it('falls back to the display field when the only identifier is `id`', () => {
+    const company = {
+      id: 'company',
+      fields: fieldsOf('company'),
+      display: { primaryDisplayField: { id: 'companyName' } },
+    } as unknown as Resource
+    expect(resolveDefaultMatchFieldKey(company)).toBe('companyName')
+    expect(resolveDefaultMatchFieldKey(company)).toBe(resolveDisplayFieldKey(company))
+  })
+
+  // `id` is never chosen AS the business key. It can still be the answer when a
+  // resource has no display field either — that is the pre-existing last-resort
+  // fallback, unchanged here — so the invariant is stated against resources that
+  // do have one.
+  it('never picks `id` as the business key when a display field exists', () => {
+    for (const id of Object.keys(RESOURCE_FIELD_REGISTRY)) {
+      const fields = fieldsOf(id)
+      const display = fields.find((f) => f.key !== 'id' && f.type === BaseType.STRING)
+      if (!display) continue
+      const resource = {
+        id,
+        fields,
+        display: { primaryDisplayField: { id: display.key } },
+      } as unknown as Resource
+      expect(resolveDefaultMatchFieldKey(resource), `${id} defaulted to id`).not.toBe('id')
+    }
+  })
+
+  // A partially-built resource must be judged, not throw: this runs on resources
+  // the policy layer did not construct.
+  it('tolerates fields with no capabilities rather than throwing', () => {
+    const bare = {
+      id: 'x',
+      fields: [{ id: 'name', key: 'name', label: 'Name', type: BaseType.STRING }],
+      display: { primaryDisplayField: { id: 'name' } },
+    } as unknown as Resource
+    expect(() => resolveDefaultMatchFieldKey(bare)).not.toThrow()
+    expect(resolveDefaultMatchFieldKey(bare)).toBe('name')
   })
 })

--- a/packages/lib/src/import/resolution/__tests__/resolve-relation-lookups.test.ts
+++ b/packages/lib/src/import/resolution/__tests__/resolve-relation-lookups.test.ts
@@ -77,7 +77,7 @@ describe('resolveRelationLookups', () => {
     ])
     const results = await resolveRelationLookups(db, 'org-1', [lookup('ACME.com', 'website')])
     expect(results).toHaveLength(1)
-    expect(results[0]!.recordId).toBe('rec-1')
+    expect(results[0]!.recordId).toBe('def-company:rec-1')
     expect(results[0]!.error).toBeUndefined()
   })
 
@@ -96,7 +96,7 @@ describe('resolveRelationLookups', () => {
       { entityId: 'rec-1', valueText: 'solo@x.com', valueNumber: null, optionId: null },
     ])
     const results = await resolveRelationLookups(db, 'org-1', [lookup('Solo@X.com', 'email')])
-    expect(results[0]!.recordId).toBe('rec-1')
+    expect(results[0]!.recordId).toBe('def-company:rec-1')
   })
 
   it('reports no-match for unmatched values', async () => {

--- a/packages/lib/src/import/resolution/get-unique-values-with-status.ts
+++ b/packages/lib/src/import/resolution/get-unique-values-with-status.ts
@@ -15,6 +15,7 @@ import {
 } from './effective-status'
 import { isOptionResolutionType, resolveOptionLabel } from './option-labels'
 import { resolveColumnOptions } from './resolve-column-options'
+import { isPendingRelationLookup } from './resolvers/relation'
 
 export type { EffectiveStatus, ResolutionStatus } from './effective-status'
 
@@ -73,6 +74,14 @@ function extractResolvedValue(resolvedValues: unknown): string | null {
   const create = (first as ResolvedValue).relationCreate
   if (create) return create.value
   if ('value' in first) {
+    // A matched RELATION is not resolved yet at this point. `relation:*` resolvers
+    // write a PENDING LOOKUP envelope describing how to find the record — the batch
+    // resolver turns it into a real id later, at plan time — so `value` here is an
+    // object, and `String(...)` on it rendered a literal "[object Object]" in every
+    // relation row of the review step. Show the cell it will be matched on, which
+    // is what the user typed and the only part of the envelope that means anything
+    // to them.
+    if (isPendingRelationLookup(first.value)) return first.value.searchValue
     return typeof first.value === 'string' ? first.value : String(first.value ?? '')
   }
   return null

--- a/packages/lib/src/import/resolution/relation-policy.ts
+++ b/packages/lib/src/import/resolution/relation-policy.ts
@@ -1,5 +1,7 @@
 // packages/lib/src/import/resolution/relation-policy.ts
 
+import { getFieldOutputKey } from '../../resources/registry/field-types'
+import { getDefaultIdentifierField } from '../../resources/registry/field-utils'
 import type { Resource } from '../../resources/registry/types'
 import type {
   RelationLinkMode,
@@ -47,15 +49,44 @@ export function resolveDisplayFieldKey(resource: Resource): string {
 }
 
 /**
+ * The match field a relation column DEFAULTS to when the user has chosen none.
+ *
+ * A real business key if the target has one, else the display field.
+ *
+ * Display was the whole answer, and for `company` it still is — a supplier list
+ * names suppliers. But for `part` it is simply wrong: no BOM and no price list on
+ * earth carries part TITLES, they carry SKUs, so every row of a parts-relation
+ * file failed to resolve until the user changed the dropdown by hand. The picker
+ * was already labelling SKU "recommended" while the default ignored it — the
+ * wizard contradicting itself.
+ *
+ * 🛑 `id` is deliberately NOT accepted as the business key, even though it is a
+ * tier-1 identifier and often the only one. No CSV carries CUIDs, so defaulting a
+ * column to `id` guarantees every row fails; and `matchField === 'id'` is a hard
+ * stop in {@link canCreateOnNoMatch}, so it would also silently disable relation
+ * auto-create. `company`'s only tier-1 identifier IS `id`, which is exactly the
+ * case that must keep falling through to the display field.
+ *
+ * @param resource - The relation TARGET resource
+ * @returns The default match field key
+ */
+export function resolveDefaultMatchFieldKey(resource: Resource): string {
+  const identifier = getDefaultIdentifierField(resource)
+  const key = identifier ? getFieldOutputKey(identifier) : null
+  if (key && key !== 'id' && identifier?.key !== 'id') return identifier?.key ?? key
+  return resolveDisplayFieldKey(resource)
+}
+
+/**
  * The match field a relation column will actually use: the explicitly chosen
- * one, or the target's display field key when the column carries none (the
+ * one, or {@link resolveDefaultMatchFieldKey} when the column carries none (the
  * auto-map path).
  *
  * @param resource - The relation TARGET resource
  * @param matchField - The column's persisted `matchField`, if any
  */
 export function resolveMatchFieldKey(resource: Resource, matchField?: string | null): string {
-  return matchField || resolveDisplayFieldKey(resource)
+  return matchField || resolveDefaultMatchFieldKey(resource)
 }
 
 /**

--- a/packages/lib/src/import/resolution/resolve-relation-lookups.ts
+++ b/packages/lib/src/import/resolution/resolve-relation-lookups.ts
@@ -3,6 +3,7 @@
 import type { Database } from '@auxx/database'
 import { schema } from '@auxx/database'
 import { createScopedLogger } from '@auxx/logger'
+import { toRecordId } from '@auxx/types/resource'
 import { and, eq, inArray, isNull, type SQL, sql } from 'drizzle-orm'
 import { getCachedResource } from '../../cache'
 import { normalizeForLookup } from '../../field-values/normalize-for-lookup'
@@ -21,7 +22,7 @@ import {
   RELATION_MATCH_NUMERIC_TYPES,
   RELATION_MATCH_TEXT_TYPES,
 } from './relation-match-types'
-import { canCreateOnNoMatch, resolveDisplayFieldKey } from './relation-policy'
+import { canCreateOnNoMatch, resolveDefaultMatchFieldKey } from './relation-policy'
 import { updateResolutionsByHash } from './write-resolution-rows'
 
 const logger = createScopedLogger('resolve-relation-lookups')
@@ -187,7 +188,7 @@ async function resolveLookupsForTable(
   // KEY through the resource's own fields, `primaryDisplayField.name` is the
   // human LABEL (`Company Name`, `Title`), and trusting it made every
   // auto-mapped relation column report "No match found" for every value.
-  const defaultMatchField = resolveDisplayFieldKey(resource)
+  const defaultMatchField = resolveDefaultMatchFieldKey(resource)
 
   // Group lookups by match field (most will use the same field)
   const byMatchField = new Map<string, PendingRelationLookup[]>()
@@ -227,6 +228,10 @@ async function resolveLookupsForTable(
       }
     }
 
+    // The def every matched id belongs to — needed to build a RecordId, and the
+    // same value for every row in this group.
+    const targetEntityDefinitionId = resource.entityDefinitionId
+
     // Whether auto-create is even legal for this (resource, matchField)
     // pair is asked ONCE per group, not per value: it is a property of the
     // column, and the authority read behind it is a cache hit either way.
@@ -256,7 +261,14 @@ async function resolveLookupsForTable(
         results.push({
           hash: lookup.hash,
           jobPropertyId: lookup.jobPropertyId,
-          recordId: [...matched][0]!,
+          // 🛑 A full `defId:instanceId` RecordId, NOT the bare `EntityInstance.id`
+          // the lookup returns. The write path's `relationship` arm accepts a string
+          // only when `isRecordId(v)` — literally `v.includes(':')` — and otherwise
+          // falls through every arm and returns null, so a bare id was SILENTLY
+          // dropped: the import reported "8 created" and wrote 8 subparts with a
+          // quantity, a note, and no parent and no child. A bare instance id cannot
+          // say which def it belongs to, so it was never a complete answer.
+          recordId: toRecordId(targetEntityDefinitionId, [...matched][0]!),
           outcome: 'matched',
         })
         continue
@@ -385,6 +397,9 @@ async function querySystemResource(
   matchField: string,
   searchValues: string[]
 ): Promise<Array<{ id: string; [key: string]: unknown }>> {
+  // An empty IN list is invalid SQL, and there is nothing to look up anyway.
+  if (searchValues.length === 0) return []
+
   // Use raw SQL query for flexibility with dynamic table/column names
   // This avoids TypeScript issues with dynamic schema access
   const tableName = resource.dbName
@@ -407,7 +422,7 @@ async function querySystemResource(
   const results = await db.execute<{ id: string; [key: string]: unknown }>(
     sql`SELECT * FROM "${sql.raw(tableName)}"
         WHERE "organizationId" = ${organizationId}
-        AND LOWER("${sql.raw(matchField)}") = ANY(${searchValues})
+        AND ${inArray(sql`LOWER("${sql.raw(matchField)}")`, searchValues)}
         LIMIT ${searchValues.length * 2}`
   )
 
@@ -452,6 +467,14 @@ async function queryCustomEntity(
     return []
   }
 
+  // 🛑 `ANY(${array})` was the shape here, and Drizzle interpolates a JS array as a
+  // PARAMETER LIST — `ANY(($1, $2, $3))` — which is a row constructor, not an
+  // array, and Postgres rejects the statement outright. The whole import failed at
+  // plan time with a raw "Failed query" and no preview, while every unit test
+  // passed: they all use a fake db, so malformed SQL is never executed. `inArray`
+  // emits `IN ($1, $2, …)`, which is what was meant.
+  if (searchValues.length === 0) return []
+
   // Build type-appropriate query condition using FieldValue typed columns
   let matchCondition: SQL<unknown>
   let valueColumn: string
@@ -459,7 +482,7 @@ async function queryCustomEntity(
   if (TEXT_FIELD_TYPES.includes(field.type)) {
     // Text types: case-insensitive match on valueText
     valueColumn = 'valueText'
-    matchCondition = sql`LOWER(${schema.FieldValue.valueText}) = ANY(${searchValues})`
+    matchCondition = inArray(sql`LOWER(${schema.FieldValue.valueText})`, searchValues)
   } else if (NUMERIC_FIELD_TYPES.includes(field.type)) {
     // Numeric types: match on valueNumber
     valueColumn = 'valueNumber'
@@ -469,11 +492,11 @@ async function queryCustomEntity(
   } else if (ENUM_FIELD_TYPES.includes(field.type)) {
     // Enum/select types: match on optionId
     valueColumn = 'optionId'
-    matchCondition = sql`LOWER(${schema.FieldValue.optionId}) = ANY(${searchValues})`
+    matchCondition = inArray(sql`LOWER(${schema.FieldValue.optionId})`, searchValues)
   } else if (ARRAY_FIELD_TYPES.includes(field.type)) {
     // Array/tags types: match on optionId (stored as multiple rows)
     valueColumn = 'optionId'
-    matchCondition = sql`LOWER(${schema.FieldValue.optionId}) = ANY(${searchValues})`
+    matchCondition = inArray(sql`LOWER(${schema.FieldValue.optionId})`, searchValues)
   } else {
     // Unsupported field types (ADDRESS, OBJECT, etc.)
     logger.warn('Unsupported field type for relation matching', {


### PR DESCRIPTION
Four defects on the relation import path. **Found by running a BOM import, not by any test** — two of them are silent data loss that the suite is structurally incapable of seeing.

## 1. 🛑 Relations were written as bare ids, then silently dropped

A matched relation resolved to a **bare `EntityInstance.id`** where the write path requires a full `defId:instanceId` RecordId. `packages/types/field-value/index.ts:466` accepts a relationship string only when `isRecordId(v)` — literally `v.includes(':')` — and otherwise falls through every arm and `return null`.

So an 8-row BOM import produced this, and reported **"8 created"**:

```
subpart korj2vd0fzpj4t04he8uq3jn
   subpart_notes      "Lid ships with each holder"
   subpart_quantity   1
                       ← no parent, no child
```

The field was even **named** `recordId` while holding `EntityInstance.id`, which is how it survived review.

Same root cause as #1876's break A, one layer over: that fixed the **lookup** side with `toLookupValue`; nothing fixed the **write** side. Fixed at the source, so both sides get a complete value — `toLookupValue` already short-circuits on `isRecordId`, so it's unaffected.

> **This also explains the duplicate-on-re-import** that looked like a separate bug. Rows with two empty legs can't match a `(parentPart, childPart)` key, so every re-import created. One root cause, two visible failures.

## 2. 🛑 `ANY(${array})` — invalid SQL killed plan generation

```sql
WHERE LOWER("FieldValue"."valueText") = ANY(($3, $4, … $13))
```

Drizzle interpolates a JS array as a **parameter list**, which is a row constructor, not an array — Postgres rejects the statement outright. The job went to `failed` with the raw error buried in `ingestionFailureReason`, while the wizard showed only *"No preview available"*.

Four sites → `inArray`, plus empty-list guards (Drizzle emits invalid SQL for an empty `IN` too).

The rule was **already written down in this same package** — `batch-identifier-lookup.ts:447`: *"`inArray`, never a raw `= ANY(${array})`"*. The identifier path knew; the relation path never got the memo. Swept the repo: every other `= ANY(…)` uses a real `ARRAY[...]` literal with a `::text[]` cast, so this was importer-only.

## 3. The match-field default ignored the identifier ranking

Defaulted to the target's **display** field. No BOM and no price list carries part *titles* — they carry SKUs — so every row of a parts-relation file resolved to nothing until the user changed the dropdown by hand, while the picker sat there labelling SKU **"recommended"**. The wizard contradicting itself.

Now a real business key when the target has one, else display.

> ⚠️ **`id` is deliberately not accepted as that key**, and this is the subtle part. `company`'s only tier-1 identifier **is** `id`; no CSV carries CUIDs, and `matchField === 'id'` is a hard stop in `canCreateOnNoMatch`. The naive "just use the identifier" version would have failed every supplier row *and* silently disabled the auto-create behind #1793. An existing test asserting company falls through to its display field still passes untouched.

## 4. `[object Object]` in the review step

`extractResolvedValue` knew two shapes — a `relationCreate` marker and a plain string — but not the pending-lookup envelope the `relation:*` resolvers actually write, so it fell through to `String(object)`. Reuses the existing `isPendingRelationLookup` guard.

Also: `getIdentifierEligibility` now optional-chains `capabilities` — relation policy calls it on resources it didn't build, and a partially-built field threw.

## Tests

**Five assertions were pinning defect 1** (`expect(results[0].recordId).toBe('rec-1')`). They now assert `'def-company:rec-1'`, with a 🛑 note not to simplify them back.

New coverage for the match-field default: part → `sku`, company → `companyName`, never `id` as the business key, and no throw on a bare field.

- 2,229 tests passing across `src/import`, `src/resources`, `src/field-values`, `src/permissions`
- `tsc --noEmit` clean, biome clean

## Verified in the browser, against dev

| run | result |
| --- | --- |
| first import of an 8-row BOM | **8 created**, both legs linked — confirmed in SQL by joining back through to part SKUs |
| re-import of the same file | **0 create, 8 update** |

That second row is the `(parentPart, childPart)` natural key from #1884 working end to end for the first time.

## Why the suite missed all of this

Every test on these paths uses a fake db, so malformed SQL is never executed and a dropped write is never observed. Same class of miss as #1892's CUID bug. Worth weighing an integration test that writes a relation through the real stack — none of these four would have survived one.