### PR TITLE
fix(import): auto-map mis-mapped the key columns and repairs never restored the natural key

### DIFF
--- a/apps/web/src/server/api/routers/data-import.ts
+++ b/apps/web/src/server/api/routers/data-import.ts
@@ -11,6 +11,7 @@ import {
   getJobWithMapping,
   getMappablePropertiesWithSamples,
   getMappedColumnsWithStats,
+  getNaturalKeyFieldKeys,
   getPlanErrors,
   getPlanPreviewRows,
   getPlanWarnings,
@@ -350,6 +351,15 @@ export const dataImportRouter = createTRPCRouter({
       // Get job and mapping, gated on import authority for its target def
       const job = await requireImportJob(ctx.db, ctx.capabilities, organizationId, input.jobId)
 
+      // A hand-built or hand-REPAIRED mapping gets the resource's declared
+      // natural key defaulted on, exactly like the one auto-map produces —
+      // otherwise correcting a mis-mapped key column leaves the job with no
+      // match key at all and it silently reverts to create-only.
+      const resource = await findCachedResource(
+        organizationId,
+        job.importMapping.entityDefinitionId
+      )
+
       await saveMappingProperty(ctx.db, {
         mappingId: job.importMappingId,
         columnIndex: input.columnIndex,
@@ -361,6 +371,7 @@ export const dataImportRouter = createTRPCRouter({
         options: input.options,
         identityRole: input.identityRole,
         mergeStrategy: input.mergeStrategy,
+        naturalKeyFieldKeys: resource ? getNaturalKeyFieldKeys(resource) : undefined,
       })
 
       // No mapping row is read back here. The identity toggles and the mode

--- a/packages/lib/src/import/fields/__tests__/auto-map-columns.test.ts
+++ b/packages/lib/src/import/fields/__tests__/auto-map-columns.test.ts
@@ -1,0 +1,164 @@
+// packages/lib/src/import/fields/__tests__/auto-map-columns.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { autoMapColumns, type ColumnHeader } from '../auto-map-columns'
+import type { FieldGroup, ImportableField } from '../get-importable-fields'
+
+/**
+ * These pin the fallback matcher against the field sets it actually gets, in
+ * the ORDER it actually gets them — `getImportableFields` emits the identifier
+ * pass, then scalars, then relations, and both defects below were decided by
+ * that order rather than by any header.
+ *
+ * The supplier-price importer is the case that exposed them: every one of its
+ * keys carries the `vendor_part_` prefix, so a one-word header matched all of
+ * them at once.
+ */
+
+function field(
+  key: string,
+  label: string,
+  overrides: Partial<ImportableField> = {}
+): ImportableField {
+  return {
+    key,
+    label,
+    type: 'text',
+    required: false,
+    isRelation: false,
+    isIdentifier: false,
+    group: 'system' as FieldGroup,
+    ...overrides,
+  }
+}
+
+/** Record ID, as the identifier pass emits it: first, and tier 1. */
+const RECORD_ID = field('id', 'Record ID', {
+  group: 'identifier',
+  isIdentifier: true,
+  identifierTier: 1,
+})
+
+/** `vendor_part`, in `getImportableFields` order. */
+const VENDOR_PART_FIELDS: ImportableField[] = [
+  RECORD_ID,
+  field('vendor_part_vendor_sku', 'Vendor SKU'),
+  field('vendor_part_unit_price', 'Unit Price', { type: 'currency' }),
+  field('vendor_part_shipping_cost', 'Shipping Cost', { type: 'currency' }),
+  field('vendor_part_tariff_rate', 'Tariff Rate (%)', { type: 'number' }),
+  field('vendor_part_other_cost', 'Other Cost', { type: 'currency' }),
+  field('vendor_part_lead_time', 'Lead Time', { type: 'number' }),
+  field('vendor_part_min_order_qty', 'Min Order Qty', { type: 'number' }),
+  field('vendor_part_is_preferred', 'Preferred', { type: 'boolean' }),
+  field('vendor_part_part', 'Part', { type: 'relation', isRelation: true, required: true }),
+  field('vendor_part_contact', 'Supplier', { type: 'relation', isRelation: true, required: true }),
+]
+
+/** `subpart` — two relations onto the SAME def, so it cannot lean on the target. */
+const SUBPART_FIELDS: ImportableField[] = [
+  RECORD_ID,
+  field('subpart_quantity', 'Quantity', { type: 'number' }),
+  field('subpart_notes', 'Notes'),
+  field('subpart_parent_part', 'Parent Part', { type: 'relation', isRelation: true }),
+  field('subpart_child_part', 'Child Part', { type: 'relation', isRelation: true }),
+]
+
+const CONTACT_FIELDS: ImportableField[] = [
+  RECORD_ID,
+  field('email', 'Email', { type: 'email', identifierTier: 1 }),
+  field('firstName', 'First Name'),
+  field('lastName', 'Last Name'),
+  field('phone', 'Phone', { type: 'phone' }),
+  field('company', 'Company'),
+]
+
+const headers = (...names: string[]): ColumnHeader[] =>
+  names.map((name, index) => ({ index, name }))
+
+/** `{ header: matched field key }`, with `null` for a column left unmapped. */
+function mapped(names: string[], fields: ImportableField[]): Record<string, string | null> {
+  const results = autoMapColumns(headers(...names), fields)
+  return Object.fromEntries(results.map((r) => [r.columnName, r.matchedField?.key ?? null]))
+}
+
+describe('autoMapColumns — the supplier-price file', () => {
+  const SUPPLIER_PRICE_HEADERS = [
+    'Part',
+    'Supplier',
+    'Vendor SKU',
+    'Unit Price',
+    'Min Order Qty',
+    'Lead Time',
+    'Shipping Cost',
+    'Tariff Rate (%)',
+    'Preferred',
+  ]
+
+  it('maps every column to the field it names', () => {
+    expect(mapped(SUPPLIER_PRICE_HEADERS, VENDOR_PART_FIELDS)).toEqual({
+      Part: 'vendor_part_part',
+      Supplier: 'vendor_part_contact',
+      'Vendor SKU': 'vendor_part_vendor_sku',
+      'Unit Price': 'vendor_part_unit_price',
+      'Min Order Qty': 'vendor_part_min_order_qty',
+      'Lead Time': 'vendor_part_lead_time',
+      'Shipping Cost': 'vendor_part_shipping_cost',
+      'Tariff Rate (%)': 'vendor_part_tariff_rate',
+      Preferred: 'vendor_part_is_preferred',
+    })
+  })
+
+  it('does not park any column on Record ID', () => {
+    const onRecordId = Object.entries(mapped(SUPPLIER_PRICE_HEADERS, VENDOR_PART_FIELDS))
+      .filter(([, key]) => key === 'id')
+      .map(([header]) => header)
+
+    // `Vendor SKU` used to land here: `normalizeForComparison('id')` was `''`,
+    // and every string contains the empty string, so Record ID scored 0.7
+    // against every header. Being tier 1 it then became the import's match key,
+    // and `text:cuid` rejected all 13 vendor SKUs as "Invalid ID format".
+    expect(onRecordId).toEqual([])
+  })
+
+  it('does not let a required relation lose its column to a name that merely contains it', () => {
+    // Every `vendor_part_*` key contains the word `part`, so `Part` tied at 1.0
+    // with all of them and the winner fell out of field order — scalars first.
+    const result = mapped(['Part'], VENDOR_PART_FIELDS)
+    expect(result.Part).toBe('vendor_part_part')
+  })
+})
+
+describe('autoMapColumns — Record ID is claimed, never defaulted to', () => {
+  it('still matches a header that names it', () => {
+    expect(mapped(['Record ID'], VENDOR_PART_FIELDS)).toEqual({ 'Record ID': 'id' })
+    expect(mapped(['id'], VENDOR_PART_FIELDS)).toEqual({ id: 'id' })
+  })
+
+  it('leaves a column that matches nothing unmapped', () => {
+    expect(mapped(['Warehouse Bin', 'Notes From Buyer'], VENDOR_PART_FIELDS)).toEqual({
+      'Warehouse Bin': null,
+      'Notes From Buyer': null,
+    })
+  })
+})
+
+describe('autoMapColumns — resources that already worked keep working', () => {
+  it('maps a BOM file onto both legs of the subpart key', () => {
+    expect(mapped(['Parent Part', 'Child Part', 'Quantity', 'Notes'], SUBPART_FIELDS)).toEqual({
+      'Parent Part': 'subpart_parent_part',
+      'Child Part': 'subpart_child_part',
+      Quantity: 'subpart_quantity',
+      Notes: 'subpart_notes',
+    })
+  })
+
+  it('maps an ordinary contact file, abbreviations and all', () => {
+    expect(mapped(['Email', 'First', 'Last Name', 'Mobile', 'Company'], CONTACT_FIELDS)).toEqual({
+      Email: 'email',
+      First: 'firstName',
+      'Last Name': 'lastName',
+      Mobile: 'phone',
+      Company: 'company',
+    })
+  })
+})

--- a/packages/lib/src/import/fields/auto-map-columns.ts
+++ b/packages/lib/src/import/fields/auto-map-columns.ts
@@ -41,18 +41,39 @@ function splitIntoWords(str: string): string[] {
  * - lowercase
  * - remove underscores, dashes, spaces
  * - remove common prefixes/suffixes
+ *
+ * 🛑 The affix strips must never consume the WHOLE string. `'id'` is itself a
+ * suffix, so the naive form normalized the Record ID field's key to `''` — and
+ * an empty string is a substring of everything, so the containment rule in
+ * {@link wordSimilarity} scored every unmatched header 0.7 against Record ID.
+ * That is above the match threshold and above most genuine partial matches, so
+ * any column the matcher could not place landed on the record's identity and,
+ * Record ID being a tier-1 identifier, silently became the import's match key.
+ * Stripping is a hint, so it yields to the unstripped form rather than to
+ * nothing.
  */
 function normalizeForComparison(str: string): string {
-  return str
+  const base = str
     .toLowerCase()
     .replace(/[_\-\s]/g, '')
     .replace(/^(col|column|field)/, '')
-    .replace(/(id|field|col|column)$/, '')
+  const stripped = base.replace(/(id|field|col|column)$/, '')
+  return stripped || base
 }
 
 /**
  * Calculate word-based similarity between two strings.
  * Handles camelCase, snake_case, and compound names.
+ *
+ * The score is SYMMETRIC: it asks both "how much of the header did the field
+ * explain" and "how much of the field did the header explain". Only the first
+ * half used to count, which made a one-word header score a perfect 1.0 against
+ * every field whose name merely contained that word. Field KEYS carry the
+ * entity prefix (`vendor_part_vendor_sku`, `vendor_part_part`, …), so on a join
+ * entity the header `Part` tied at 1.0 with all of them at once and the winner
+ * fell out of field ORDER — scalars are emitted before relations, so `Part`
+ * landed on Vendor SKU and the required Part relation was left unmapped behind
+ * a wizard reporting every column mapped.
  */
 function wordSimilarity(a: string, b: string): number {
   const wordsA = splitIntoWords(a)
@@ -68,21 +89,26 @@ function wordSimilarity(a: string, b: string): number {
   // Count matching words
   let matchingWords = 0
   let totalWeight = 0
+  /** Which words of B some word of A accounted for. */
+  const explainedB = new Set<number>()
 
   for (const wordA of wordsA) {
     // First word is often more important (e.g., "first" in "firstName")
     const weight = wordA === wordsA[0] ? 2 : 1
     totalWeight += weight
 
-    for (const wordB of wordsB) {
+    for (let i = 0; i < wordsB.length; i++) {
+      const wordB = wordsB[i]!
       if (wordA === wordB) {
         matchingWords += weight
+        explainedB.add(i)
         break
       }
       // Partial match for similar words
       if (wordA.length > 2 && wordB.length > 2) {
         if (wordA.startsWith(wordB) || wordB.startsWith(wordA)) {
           matchingWords += weight * 0.8
+          explainedB.add(i)
           break
         }
       }
@@ -90,11 +116,18 @@ function wordSimilarity(a: string, b: string): number {
   }
 
   // Also check if normalized strings are contained
-  if (normA.includes(normB) || normB.includes(normA)) {
-    return Math.max(0.7, matchingWords / totalWeight)
-  }
+  const contained = normA.includes(normB) || normB.includes(normA)
+  const headerScore = contained
+    ? Math.max(0.7, matchingWords / totalWeight)
+    : matchingWords / totalWeight
 
-  return matchingWords / totalWeight
+  // Damped rather than multiplied outright: a field name is routinely longer
+  // than the header that means it (`Qty` for "Min Order Qty"), so leaving words
+  // unexplained is a demotion, not a disqualification. Half-weight keeps those
+  // above the caller's 0.5 threshold while still ranking the field the header
+  // actually names above one that merely shares a word with it.
+  const fieldCoverage = explainedB.size / wordsB.length
+  return headerScore * (0.5 + 0.5 * fieldCoverage)
 }
 
 /**

--- a/packages/lib/src/import/index.ts
+++ b/packages/lib/src/import/index.ts
@@ -119,6 +119,7 @@ export {
   getColumnSamples,
   getMappablePropertiesWithSamples,
   getMappedColumnsWithStats,
+  getNaturalKeyFieldKeys,
   IMPORT_STRATEGY_MODES,
   invalidateColumnResolutions,
   isImportStrategyMode,

--- a/packages/lib/src/import/mapping/__tests__/identifier-lifecycle.test.ts
+++ b/packages/lib/src/import/mapping/__tests__/identifier-lifecycle.test.ts
@@ -741,3 +741,162 @@ describe('atomicity, every mapping write is one transaction', () => {
     expect(db.mapping.identifierFieldKeys).toEqual(['part_sku'])
   })
 })
+
+/**
+ * The half auto-map cannot cover.
+ *
+ * `batchUpdateMappingsFromAutoMap` defaults the declared natural key on, and for
+ * a long time only it did — so a mapping the user REPAIRED came out with no
+ * match key at all. That is not an edge case: a mis-mapped key column is the
+ * reason anyone opens the mapping step to repair it, and `vendor_part` has no
+ * lone identifier to fall back to. The supplier-price importer shipped whole
+ * with `identifierFieldKeys: []` and `defaultStrategy: 'create'` this way, which
+ * is a monthly price list appending its rows instead of updating them.
+ *
+ * `batchColumnOrder` is load-bearing here for the reason its own docblock gives:
+ * completing the key writes the flag onto SEVERAL columns in one call, and the
+ * single-`focusColumn` model would land all of them on one row.
+ */
+describe('natural key defaults on after a hand REPAIR', () => {
+  /** `(part, supplier)` — the legs `vendor-part-fields.ts` declares. */
+  const VENDOR_PART_KEY = ['vendor_part_part', 'vendor_part_contact']
+
+  /** Two unmapped columns and a mapping with no identity, as after a bad auto-map. */
+  function freshDb() {
+    return new FakeDb(
+      [
+        column(0, { sourceColumnName: 'Part' }),
+        column(1, { sourceColumnName: 'Supplier' }),
+        column(2, { sourceColumnName: 'Vendor SKU' }),
+      ],
+      { identifierFieldKeys: [], defaultStrategy: 'create' }
+    )
+  }
+
+  it('fires when the LAST leg is mapped, and flips the mode to create-or-update', async () => {
+    const db = freshDb()
+
+    // First leg: the tuple is still incomplete, so nothing is flagged yet.
+    db.batchColumnOrder = [0]
+    await save(db, mapTo(0, 'vendor_part_part', { naturalKeyFieldKeys: VENDOR_PART_KEY }))
+    expect(db.mapping.identifierFieldKeys).toEqual([])
+    expect(db.mapping.defaultStrategy).toBe('create')
+
+    // Second leg completes it: the column write, then one write per leg.
+    db.batchColumnOrder = [1, 0, 1]
+    await save(db, mapTo(1, 'vendor_part_contact', { naturalKeyFieldKeys: VENDOR_PART_KEY }))
+
+    expect(db.mapping.identifierFieldKeys).toEqual(VENDOR_PART_KEY)
+    expect(db.mapping.defaultStrategy).toBe('create-or-update')
+  })
+
+  it('leaves a PARTIAL key alone — half a tuple matches nothing', async () => {
+    const db = freshDb()
+
+    db.batchColumnOrder = [0]
+    await save(db, mapTo(0, 'vendor_part_part', { naturalKeyFieldKeys: VENDOR_PART_KEY }))
+
+    expect(db.mapping.identifierFieldKeys).toEqual([])
+    expect(db.mapping.defaultStrategy).toBe('create')
+  })
+
+  it('never overrides an identity the mapping already has', async () => {
+    const db = freshDb()
+
+    // The user's own pick, on a field that is not a leg.
+    db.batchColumnOrder = [2]
+    await save(
+      db,
+      mapTo(2, 'vendor_part_vendor_sku', {
+        identityRole: { kind: 'match' },
+        naturalKeyFieldKeys: VENDOR_PART_KEY,
+      })
+    )
+    db.batchColumnOrder = [0]
+    await save(db, mapTo(0, 'vendor_part_part', { naturalKeyFieldKeys: VENDOR_PART_KEY }))
+    db.batchColumnOrder = [1]
+    await save(db, mapTo(1, 'vendor_part_contact', { naturalKeyFieldKeys: VENDOR_PART_KEY }))
+
+    expect(db.mapping.identifierFieldKeys).toEqual(['vendor_part_vendor_sku'])
+  })
+
+  it('does not undo an explicit clear of the last flag', async () => {
+    const db = freshDb()
+
+    db.batchColumnOrder = [0]
+    await save(db, mapTo(0, 'vendor_part_part', { naturalKeyFieldKeys: VENDOR_PART_KEY }))
+    db.batchColumnOrder = [1, 0, 1]
+    await save(db, mapTo(1, 'vendor_part_contact', { naturalKeyFieldKeys: VENDOR_PART_KEY }))
+    expect(db.mapping.identifierFieldKeys).toEqual(VENDOR_PART_KEY)
+
+    // Clearing the legs one at a time must end at create-only and STAY there —
+    // the default may not re-stamp the tuple the user just took off.
+    db.batchColumnOrder = [0]
+    await save(
+      db,
+      mapTo(0, 'vendor_part_part', { identityRole: null, naturalKeyFieldKeys: VENDOR_PART_KEY })
+    )
+    db.batchColumnOrder = [1]
+    await save(
+      db,
+      mapTo(1, 'vendor_part_contact', { identityRole: null, naturalKeyFieldKeys: VENDOR_PART_KEY })
+    )
+
+    expect(db.mapping.identifierFieldKeys).toEqual([])
+    expect(db.mapping.defaultStrategy).toBe('create')
+  })
+
+  it('is not resurrected by a save on an unrelated column', async () => {
+    const db = freshDb()
+
+    db.batchColumnOrder = [0]
+    await save(db, mapTo(0, 'vendor_part_part', { naturalKeyFieldKeys: VENDOR_PART_KEY }))
+    db.batchColumnOrder = [1]
+    await save(
+      db,
+      mapTo(1, 'vendor_part_contact', { identityRole: null, naturalKeyFieldKeys: VENDOR_PART_KEY })
+    )
+    expect(db.mapping.identifierFieldKeys).toEqual([])
+
+    // Both legs are mapped and the key is off. Editing a THIRD column is not a
+    // statement about identity, so it may not turn the key back on.
+    db.batchColumnOrder = [2]
+    await save(db, mapTo(2, 'vendor_part_vendor_sku', { naturalKeyFieldKeys: VENDOR_PART_KEY }))
+
+    expect(db.mapping.identifierFieldKeys).toEqual([])
+  })
+
+  it('completes a HALF tuple left behind by unmapping and re-mapping one leg', async () => {
+    const db = freshDb()
+
+    db.batchColumnOrder = [0]
+    await save(db, mapTo(0, 'vendor_part_part', { naturalKeyFieldKeys: VENDOR_PART_KEY }))
+    db.batchColumnOrder = [1, 0, 1]
+    await save(db, mapTo(1, 'vendor_part_contact', { naturalKeyFieldKeys: VENDOR_PART_KEY }))
+    expect(db.mapping.identifierFieldKeys).toEqual(VENDOR_PART_KEY)
+
+    // Unmapping a leg drops its flag and leaves the OTHER leg flagged alone —
+    // a key that can never match, since `analyzeRow` needs every component.
+    db.batchColumnOrder = [0]
+    await save(db, mapTo(0, null, { naturalKeyFieldKeys: VENDOR_PART_KEY }))
+    expect(db.mapping.identifierFieldKeys).toEqual(['vendor_part_contact'])
+
+    // Re-mapping it must restore the whole tuple, not sit next to the orphan.
+    db.batchColumnOrder = [0, 0, 1]
+    await save(db, mapTo(0, 'vendor_part_part', { naturalKeyFieldKeys: VENDOR_PART_KEY }))
+
+    expect(db.mapping.identifierFieldKeys).toEqual(VENDOR_PART_KEY)
+  })
+
+  it('is inert for a resource that declares no natural key', async () => {
+    const db = freshDb()
+
+    db.batchColumnOrder = [0]
+    await save(db, mapTo(0, 'contact_email'))
+    db.batchColumnOrder = [1]
+    await save(db, mapTo(1, 'contact_name'))
+
+    expect(db.mapping.identifierFieldKeys).toEqual([])
+    expect(db.mapping.defaultStrategy).toBe('create')
+  })
+})

--- a/packages/lib/src/import/mapping/index.ts
+++ b/packages/lib/src/import/mapping/index.ts
@@ -16,6 +16,7 @@ export {
   type MappedColumnWithStats,
 } from './get-mapped-columns'
 export { invalidateColumnResolutions } from './invalidate-column-resolutions'
+export { getNaturalKeyFieldKeys } from './natural-key'
 export {
   isMatchRole,
   parseResolutionConfig,

--- a/packages/lib/src/import/mapping/natural-key.ts
+++ b/packages/lib/src/import/mapping/natural-key.ts
@@ -1,0 +1,22 @@
+// packages/lib/src/import/mapping/natural-key.ts
+
+import { getFieldOutputKey } from '../../resources/registry/field-types'
+import { getNaturalKeyFields } from '../../resources/registry/field-utils'
+import type { Resource } from '../../resources/registry/types'
+
+/**
+ * The resource's declared natural key as the field keys an import mapping
+ * stores in `ImportMappingProperty.targetFieldKey`, in leg order.
+ *
+ * One derivation for both writers. Auto-map defaults the key on for the mapping
+ * it produces and `saveMappingProperty` does the same for one repaired by hand;
+ * the two agreeing on which keys the tuple is IS the contract, so neither
+ * re-derives it. `[]` for the resources that declare no natural key, which is
+ * most of them.
+ *
+ * @param resource - Any resource carrying merged registry fields
+ * @returns Ordered natural-key field keys, or `[]` when none is declared
+ */
+export function getNaturalKeyFieldKeys(resource: Resource): string[] {
+  return getNaturalKeyFields(resource).map(getFieldOutputKey)
+}

--- a/packages/lib/src/import/mapping/run-auto-map.ts
+++ b/packages/lib/src/import/mapping/run-auto-map.ts
@@ -2,13 +2,12 @@
 
 import type { Database } from '@auxx/database'
 import { getCachedResource } from '../../cache'
-import { getFieldOutputKey } from '../../resources/registry/field-types'
-import { getNaturalKeyFields } from '../../resources/registry/field-utils'
 import type { Resource } from '../../resources/registry/types'
 import { type ColumnHeaderWithSamples, orchestrateAutoMap } from '../fields/auto-map-orchestrator'
 import { getImportableFields } from '../fields/get-importable-fields'
 import { buildRelationColumnPolicy } from '../resolution/relation-policy'
 import { getMappablePropertiesWithSamples } from './get-mappable-properties'
+import { getNaturalKeyFieldKeys } from './natural-key'
 import { batchUpdateMappingsFromAutoMap, type RelationConfig } from './save-mapping-property'
 
 /** Auto-map strategy type */
@@ -161,7 +160,7 @@ export async function runAutoMap(
   //
   // Read off the resource, never off an entity type: `vendor_part` is the first
   // declarer, not a special case, and any resource that declares one gets this.
-  const naturalKeyFieldKeys = getNaturalKeyFields(resource).map(getFieldOutputKey)
+  const naturalKeyFieldKeys = getNaturalKeyFieldKeys(resource)
 
   await batchUpdateMappingsFromAutoMap(db, {
     mappingId: importMappingId,

--- a/packages/lib/src/import/mapping/save-mapping-property.ts
+++ b/packages/lib/src/import/mapping/save-mapping-property.ts
@@ -15,6 +15,7 @@ import type { ResolutionConfig } from '../types/resolution'
 import { syncMappingIdentity } from './derive-identifier-keys'
 import { invalidateColumnResolutions } from './invalidate-column-resolutions'
 import {
+  isMatchRole,
   parseResolutionConfig,
   sanitizeIdentityRole,
   serializeResolutionConfig,
@@ -61,6 +62,20 @@ export interface SaveMappingInput {
    * policy about a specific TARGET FIELD, not about the source column.
    */
   mergeStrategy?: ImportMergeStrategy | null
+  /**
+   * The resource's declared NATURAL KEY, in leg order, when it declares one.
+   *
+   * Same set auto-map receives, and it is here for the case auto-map cannot
+   * cover: a mapping the user REPAIRS by hand. Auto-map defaults the key on,
+   * but only auto-map did, so every correction after it left the key off — and
+   * a mis-mapped key column is exactly what sends the user to repair it. The
+   * supplier-price importer shipped whole with `identifierFieldKeys: []` and
+   * `defaultStrategy: 'create'` for that reason, which is a monthly price list
+   * appending its 340 rows instead of updating them.
+   *
+   * See {@link applyNaturalKeyDefault} for when it is allowed to fire.
+   */
+  naturalKeyFieldKeys?: string[]
 }
 
 /** Minimal column shape for duplicate-target validation */
@@ -136,6 +151,83 @@ async function lockMapping(tx: Transaction, mappingId: string): Promise<void> {
     .from(schema.ImportMapping)
     .where(eq(schema.ImportMapping.id, mappingId))
     .for('update')
+}
+
+/**
+ * Default the declared NATURAL KEY back on after a per-column save.
+ *
+ * Auto-map already does this for the mapping it produces
+ * ({@link batchUpdateMappingsFromAutoMap}); this is the same rule for the
+ * mapping a user assembles or CORRECTS by hand, which auto-map never sees
+ * again. Without it the two paths disagree: `vendor_part` has no lone
+ * identifier at all, so a mapping repaired column by column ends up with no
+ * match key and silently reverts to create-only.
+ *
+ * Three conditions, all narrow on purpose — a match key that reappears on its
+ * own is worse than one that never showed up:
+ *
+ * 1. **The saved column is itself a leg.** An edit to an unrelated column must
+ *    never resurrect a key, so only a write that could have COMPLETED the
+ *    tuple is allowed to stamp it.
+ * 2. **No identity outside the tuple.** A flag on any other field is the user's
+ *    own answer and is never overridden. A flag on a leg is not — a HALF tuple
+ *    is not an answer, it is the state that matches nothing, and unmapping one
+ *    leg and re-mapping it is how a user lands in it. That case is completed
+ *    rather than blocked.
+ * 3. **Every leg is mapped.** All or nothing, for the reason
+ *    {@link AutoMapUpdateInput.naturalKeyFieldKeys} gives: a partial tuple
+ *    matches nothing, so half a key is strictly worse than none.
+ *
+ * The caller additionally skips this on an explicit `identityRole: null`, so
+ * clearing the last flag stays a way to force create-only rather than a write
+ * this function immediately undoes.
+ */
+async function applyNaturalKeyDefault(
+  tx: Transaction,
+  mappingId: string,
+  naturalKeyFieldKeys: string[]
+): Promise<void> {
+  if (naturalKeyFieldKeys.length === 0) return
+
+  const columns = await tx
+    .select({
+      id: schema.ImportMappingProperty.id,
+      targetType: schema.ImportMappingProperty.targetType,
+      targetFieldKey: schema.ImportMappingProperty.targetFieldKey,
+      resolutionConfig: schema.ImportMappingProperty.resolutionConfig,
+    })
+    .from(schema.ImportMappingProperty)
+    .where(eq(schema.ImportMappingProperty.importMappingId, mappingId))
+
+  const mapped = columns.filter((c) => c.targetFieldKey && c.targetType !== 'skip')
+
+  const flagged = mapped
+    .filter((c) => isMatchRole(parseResolutionConfig(c.resolutionConfig).identityRole))
+    .map((c) => c.targetFieldKey)
+
+  // Condition 2 — an identity of the user's own is never overridden.
+  if (flagged.some((key) => !naturalKeyFieldKeys.includes(key!))) return
+  // …and a tuple that is already whole needs no help.
+  if (naturalKeyFieldKeys.every((key) => flagged.includes(key))) return
+
+  // Condition 3 — every leg mapped, or nothing happens.
+  const legs = naturalKeyFieldKeys.map((key) => mapped.find((c) => c.targetFieldKey === key))
+  if (legs.some((leg) => !leg)) return
+
+  const now = new Date()
+  for (const leg of legs) {
+    const config = parseResolutionConfig(leg!.resolutionConfig)
+    await tx
+      .update(schema.ImportMappingProperty)
+      .set({
+        resolutionConfig: serializeResolutionConfig({
+          ...config,
+          identityRole: { kind: 'match' },
+        }),
+        updatedAt: now,
+      })
+      .where(eq(schema.ImportMappingProperty.id, leg!.id))
+  }
 }
 
 /**
@@ -258,6 +350,17 @@ export async function saveMappingProperty(db: Database, input: SaveMappingInput)
           eq(schema.ImportMappingProperty.sourceColumnIndex, input.columnIndex)
         )
       )
+
+    // Before the recompute, not after: this stamps the per-COLUMN flags that
+    // `syncMappingIdentity` then derives the per-JOB key from. An explicit
+    // clear in this same call is the user saying "no match key", so it is
+    // never the write that triggers the default.
+    if (input.identityRole !== null && input.targetFieldKey) {
+      const naturalKey = input.naturalKeyFieldKeys ?? []
+      if (naturalKey.includes(input.targetFieldKey)) {
+        await applyNaturalKeyDefault(tx, input.mappingId, naturalKey)
+      }
+    }
 
     // The match key is per-JOB while the flag above is per-COLUMN. Recomputing it
     // in the same call as the column write is the only thing keeping them honest.


### PR DESCRIPTION
Found by running the supplier-price importer against dev — `plans/importer/08-named-importers.md` §9's first open item. The mapping was wrong on the first screen, and unfixable on the second.

## What a first run actually produced

| CSV column | auto-mapped to |
| --- | --- |
| `Part` | **Vendor SKU** — the REQUIRED `vendor_part_part` relation left unmapped |
| `Vendor SKU` | **Record ID**, `text:cuid`, flagged as the match key |

…behind a header reading *"9 of 9 columns mapped"*, and erroring all 13 rows with `Invalid ID format: RM-CG-1001` once `text:cuid` saw them.

## 1 — two bugs in the fallback matcher

Both decided by field ORDER rather than by any header.

**`normalizeForComparison` strips a trailing `id`**, so the Record ID field's key normalized to `''`. Every string contains the empty string, so `wordSimilarity`'s containment rule scored **every unmatched header 0.7 against Record ID** — above the 0.5 match threshold and above most genuine partial matches. Any column the matcher could not place landed on the record's identity and, Record ID being tier 1, became the import's match key. System-wide, not a `vendor_part` quirk. The strip now yields to the unstripped form rather than to nothing.

**`wordSimilarity` only measured how much of the HEADER the field explained**, so a one-word header scored a perfect 1.0 against every field whose name merely contained that word. Field keys carry the entity prefix, so `Part` tied at **1.000 against all of `vendor_part_*` at once** and the winner fell out of field order — `getImportableFields` emits scalars before relations. The score now also measures how much of the FIELD the header explained, damped at half weight so an abbreviation (`Qty` for "Min Order Qty") is demoted rather than disqualified.

## 2 — repairing the mapping never restored the natural key

Only `batchUpdateMappingsFromAutoMap` defaulted the declared natural key on, so every correction after auto-map left the key off. `vendor_part` has no lone identifier — `(part, supplier)` is the only identity it has — so the supplier-price importer shipped whole with `identifierFieldKeys: []` and `defaultStrategy: 'create'`. That is the monthly price list appending its 340 rows instead of updating them, which is the entire business outcome §5 of the plan claims. And a mis-mapped key column is exactly what sends a user to repair the mapping in the first place.

`saveMappingProperty` now applies the same default, on three narrow conditions — a match key that reappears on its own is worse than one that never showed up:

1. the saved column is itself a leg;
2. no identity outside the tuple already exists — a flag on a leg is not an answer, a **half tuple** is the state that matches nothing, and unmapping one leg and re-mapping it is how a user lands in it, so that case is completed rather than blocked;
3. every leg is mapped.

An explicit `identityRole: null` never triggers it, so clearing the last flag stays a way to force create-only. Both writers read the key from one derivation, `getNaturalKeyFieldKeys`.

## Verified against dev, not just in tests

- Fresh upload of the sample supplier price list → all 9 columns map to the fields they name, **nothing on Record ID**, and the mapping lands `['vendor_part_part', 'vendor_part_contact']` with `create-or-update`.
- Unmapping the part leg drops the key to the orphan half (`['vendor_part_contact']`); re-mapping it restores the pair.

## Tests

`949 passed` across `src/import` + `src/resources`. New: 7 assertions pinning the matcher against the real `vendor_part` / `subpart` / contact field sets in `getImportableFields` order (4 fail on the old scoring, 3 are non-regression); 7 more on the repair path in `identifier-lifecycle.test.ts` (2 fail without the fix).

## Not in this PR

Also found while investigating, deliberately left out:

- `number:integer` is the default for **every** NUMBER field (BaseType has no decimal/integer split), and `resolveInteger` uses `parseInt` — so `Tariff Rate 1.5` imports as `1`, marked **Valid**. System-wide silent truncation; `FieldValue.valueNumber` is `doublePrecision`, so storage was never the constraint.
- Review Values validates **nothing** for relation columns — `resolveRelationMatch` never touches the DB, so a typo'd SKU reads green and fails at import.
- Once you step past unresolved errors the stepper relabels them **"All values valid"**, directly above a panel saying "13 rows have errors". The `Fix N Errors` button is the Continue button with a conditional label; it advances the wizard rather than going to the errors.
- Currency shows raw minor units in review (`12.40` → `1240`).