### PR TITLE
fix(field-values): name edits wrote the composite, leaving first/last stale

### DIFF
--- a/apps/web/src/components/custom-fields/ui/entity-instance/entity-instance-form.tsx
+++ b/apps/web/src/components/custom-fields/ui/entity-instance/entity-instance-form.tsx
@@ -588,35 +588,6 @@ export function EntityInstanceForm({
     createExtension?.onReset?.()
   }, [editableFields, presetValues, setInitial, createExtension])
 
-  /**
-   * Expand NAME field values into their source fields (firstName, lastName).
-   * Returns a new values object with NAME fields replaced by their source TEXT fields.
-   */
-  const expandNameFields = useCallback(
-    (vals: Record<string, unknown>): Record<string, unknown> => {
-      const expanded: Record<string, unknown> = {}
-
-      for (const [fieldId, value] of Object.entries(vals)) {
-        const field = editableFields.find((f) => f.id === fieldId)
-        if (field?.fieldType === 'NAME' && field.options?.name) {
-          // Split NAME into source fields
-          const { firstNameFieldId, lastNameFieldId } = field.options.name
-          const nameVal = value as { firstName?: string; lastName?: string } | null
-          if (nameVal) {
-            if (nameVal.firstName !== undefined) expanded[firstNameFieldId] = nameVal.firstName
-            if (nameVal.lastName !== undefined) expanded[lastNameFieldId] = nameVal.lastName
-          }
-          // Don't include the NAME field itself
-        } else {
-          expanded[fieldId] = value
-        }
-      }
-
-      return expanded
-    },
-    [editableFields]
-  )
-
   const handleSubmit = async () => {
     if (!validate()) return
 
@@ -628,11 +599,9 @@ export function EntityInstanceForm({
         instanceId = editingInstanceId
         const instanceRecordId = toRecordId(entityDefinitionId, instanceId)
 
-        // Expand NAME fields into source fields before saving
-        const expandedValues = expandNameFields(values)
-
-        // Save all field values
-        const valuesToSave = Object.entries(expandedValues)
+        // NAME composites are split into their two part fields inside the save
+        // funnel (`useSaveFieldValue`), so every commit path gets it.
+        const valuesToSave = Object.entries(values)
           .filter(([_, value]) => value !== undefined && value !== null && value !== '')
           .map(([fieldId, value]) => {
             const field = editableFields.find((f) => f.id === fieldId)
@@ -644,10 +613,15 @@ export function EntityInstanceForm({
           if (!success) return
         }
       } else {
-        // Create mode: single create call with values
-        // Expand NAME fields and build values object from form state
+        // Create mode: single create call with values. `record.create` does
+        // NOT go through the save funnel (`useSaveFieldValue`), so the NAME
+        // composite is left intact here and decomposed server-side, at the
+        // `setValueWithBuiltIn` chokepoint in
+        // `packages/lib/src/field-values/field-value-mutations.ts` — reached
+        // from create/update via `resources/crud/unified-handler.ts` ->
+        // `setValuesForEntity`.
         const formValues = Object.fromEntries(
-          Object.entries(expandNameFields(values)).filter(
+          Object.entries(values).filter(
             ([_, value]) => value !== undefined && value !== null && value !== ''
           )
         )

--- a/apps/web/src/components/fields/property-provider.name-commit.test.tsx
+++ b/apps/web/src/components/fields/property-provider.name-commit.test.tsx
@@ -1,0 +1,201 @@
+// apps/web/src/components/fields/property-provider.name-commit.test.tsx
+//
+// The property row has TWO commit paths and they used to disagree about NAME.
+// `commitValue` (reached by clicking away to dismiss the popover) split the
+// composite into its two TEXT part fields; `commitValueAndClose` (reached by
+// pressing Enter or arrowing to the next row) had no NAME branch at all and
+// wrote the composite raw, leaving the parts stale. Same field, same value,
+// different key pressed.
+//
+// The split now lives below both of them, in the save funnel, so this file
+// drives BOTH paths and asserts the same thing of each: two part-field writes,
+// no NAME-field write. It is the guard on the deletion — if a NAME branch ever
+// grows back into one commit path and not the other, these two cases stop
+// agreeing.
+//
+// Everything below the funnel runs for real (the funnel, both stores, the
+// resource registry); only the wire and the value read are stubbed.
+
+import type { CustomResource, RecordId, ResourceField } from '@auxx/lib/resources/client'
+import { act, render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getResourceStoreState } from '~/components/resources/store/resource-store'
+
+const DEF = 'def_contact00000000000000000'
+const RECORD_ID = `${DEF}:ein_anita0000000000000000000` as RecordId
+
+const NAME_ID = 'fld_full_name000000000000000'
+const FIRST_ID = 'fld_first_name00000000000000'
+const LAST_ID = 'fld_last_name0000000000000000'
+
+interface BulkInput {
+  recordIds: string[]
+  values: Array<{ fieldId: string; value: unknown }>
+}
+
+const h = vi.hoisted(() => ({
+  set: [] as unknown[],
+  bulk: [] as unknown[],
+}))
+
+vi.mock('~/trpc/react', () => {
+  const record = (sink: unknown[]) => ({
+    useMutation: () => ({
+      mutate: (input: unknown, opts?: { onSuccess?: (result: unknown) => void }) => {
+        sink.push(input)
+        opts?.onSuccess?.({ values: [] })
+      },
+      mutateAsync: async (input: unknown) => {
+        sink.push(input)
+        return { values: [] }
+      },
+      isPending: false,
+    }),
+  })
+  return { api: { fieldValue: { set: record(h.set), setBulk: record(h.bulk) } } }
+})
+
+// The row opens over an empty value — what it reads back is not what is under
+// test, and the real hook auto-fetches through tRPC.
+vi.mock('~/components/resources/hooks/use-field-values', () => ({
+  useFieldValue: () => ({ value: undefined, isLoading: false }),
+}))
+
+const { PropertyProvider, usePropertyContext } = await import('./property-provider')
+
+type Ctx = ReturnType<typeof usePropertyContext>
+
+/** The NAME composite exactly as the record drawer hands it down. */
+const nameField = {
+  id: NAME_ID,
+  key: 'fullName',
+  label: 'Full Name',
+  type: 'string',
+  fieldType: 'NAME',
+  systemAttribute: 'full_name',
+  capabilities: { updatable: true },
+  options: { name: { firstNameFieldId: FIRST_ID, lastNameFieldId: LAST_ID } },
+} as unknown as ResourceField
+
+function partField(id: string, key: string): ResourceField {
+  return {
+    id,
+    key,
+    label: key,
+    type: 'string',
+    fieldType: 'TEXT',
+    capabilities: { updatable: true },
+  } as unknown as ResourceField
+}
+
+/** Mount the row and hand back its context. */
+function mountRow(): Ctx {
+  let ctx: Ctx | undefined
+  function Probe() {
+    ctx = usePropertyContext()
+    return null
+  }
+  render(
+    <PropertyProvider field={nameField} providerId='p1' recordId={RECORD_ID}>
+      <Probe />
+    </PropertyProvider>
+  )
+  if (!ctx) throw new Error('PropertyProvider rendered no context')
+  return ctx
+}
+
+/** Every `{ fieldId, value }` the row put on the wire, across both mutations. */
+function wireEntries(): Array<{ fieldId: string; value: unknown }> {
+  return [
+    ...(h.set as Array<{ fieldId: string; value: unknown }>).map((i) => ({
+      fieldId: i.fieldId,
+      value: i.value,
+    })),
+    ...(h.bulk as BulkInput[]).flatMap((i) => i.values),
+  ]
+}
+
+beforeEach(() => {
+  h.set.length = 0
+  h.bulk.length = 0
+  getResourceStoreState().reset()
+  getResourceStoreState().setResources([
+    {
+      id: DEF,
+      type: 'custom',
+      apiSlug: 'contacts',
+      entityType: 'contact',
+      entityDefinitionId: DEF,
+      organizationId: 'org_1',
+      label: 'Contact',
+      plural: 'Contacts',
+      icon: 'user',
+      color: 'blue',
+      isVisible: true,
+      fields: [nameField, partField(FIRST_ID, 'firstName'), partField(LAST_ID, 'lastName')],
+      display: {
+        primaryDisplayField: null,
+        secondaryDisplayField: null,
+        avatarField: null,
+        defaultSortField: 'updatedAt',
+        defaultSortDirection: 'desc',
+        orgScopingStrategy: 'direct',
+      },
+    } as unknown as CustomResource,
+  ])
+})
+
+describe('PropertyProvider — a NAME row writes its parts from EITHER commit path', () => {
+  // The click-away path. This one always worked.
+  it('commitValue writes both part fields and never the composite', () => {
+    const ctx = mountRow()
+
+    act(() => ctx.commitValue({ firstName: 'Anita', lastName: 'Bicknell' }))
+
+    expect(wireEntries()).toEqual([
+      { fieldId: FIRST_ID, value: 'Anita' },
+      { fieldId: LAST_ID, value: 'Bicknell' },
+    ])
+  })
+
+  // THE regression. Enter / ArrowDown lands here, and this path wrote
+  // `{ recordId, fieldId: <NAME>, value: { firstName, lastName } }` raw.
+  it('commitValueAndClose writes both part fields and never the composite', () => {
+    const ctx = mountRow()
+
+    act(() => ctx.commitValueAndClose({ firstName: 'Anita', lastName: 'Bicknell' }))
+
+    expect(wireEntries()).toEqual([
+      { fieldId: FIRST_ID, value: 'Anita' },
+      { fieldId: LAST_ID, value: 'Bicknell' },
+    ])
+    expect(h.set).toHaveLength(0)
+  })
+
+  // The two paths are only safe while they agree, so compare them directly
+  // rather than trusting two separate expectations to stay in sync.
+  it('both paths put the same thing on the wire', () => {
+    const clickAway = mountRow()
+    act(() => clickAway.commitValue({ firstName: 'Anita', lastName: 'Bicknell' }))
+    const fromCommitValue = wireEntries()
+
+    h.set.length = 0
+    h.bulk.length = 0
+    const enterKey = mountRow()
+    act(() => enterKey.commitValueAndClose({ firstName: 'Anita', lastName: 'Bicknell' }))
+
+    expect(wireEntries()).toEqual(fromCommitValue)
+  })
+
+  // Both parts in ONE request: each part write recomposes `displayName` by
+  // reading its sibling from the DB, so two concurrent single-field writes can
+  // persist an outdated composed name.
+  it('sends one request per commit, carrying both parts', () => {
+    const ctx = mountRow()
+
+    act(() => ctx.commitValueAndClose({ firstName: 'Anita', lastName: 'Bicknell' }))
+
+    expect(h.bulk).toHaveLength(1)
+    expect((h.bulk[0] as BulkInput).recordIds).toEqual([RECORD_ID])
+  })
+})

--- a/apps/web/src/components/fields/property-provider.tsx
+++ b/apps/web/src/components/fields/property-provider.tsx
@@ -3,7 +3,7 @@
 import { FieldType as FieldTypeEnum } from '@auxx/database/enums'
 import type { FieldType } from '@auxx/database/types'
 import { formatToRawValue, readCurrency } from '@auxx/lib/field-values/client'
-import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
+import type { RecordId } from '@auxx/lib/resources/client'
 import { toActorId } from '@auxx/types/actor'
 import {
   createContext,
@@ -18,8 +18,6 @@ import {
 import { useFieldValue } from '~/components/resources/hooks/use-field-values'
 import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
 import type { StoredFieldValue } from '~/components/resources/store/field-value-store'
-import { useRecordStore } from '~/components/resources/store/record-store'
-import { useResourceStore } from '~/components/resources/store/resource-store'
 
 /**
  * property-provider.tsx
@@ -308,7 +306,6 @@ export function PropertyProvider({
   const {
     saveFieldValue: storeSave,
     saveFieldValueAsync: storeSaveAsync,
-    saveMultipleAsync: storeSaveMultiple,
     isPending: isSaving,
   } = useSaveFieldValue({
     getFieldMetadata,
@@ -355,53 +352,6 @@ export function PropertyProvider({
         return
       }
 
-      // Handle NAME field writes - split to source fields
-      if (field.fieldType === FieldTypeEnum.NAME && field.options?.name) {
-        const { firstNameFieldId, lastNameFieldId } = field.options.name
-        const nameValue = newValue as { firstName: string; lastName: string }
-
-        // Update local state SYNCHRONOUSLY
-        setCurrentValue(newValue)
-        setIsDirty(false)
-        setServerValue(newValue)
-
-        // Write BOTH source fields in a single batch mutation. Two separate
-        // single-field writes race on the server-side displayName recompute:
-        // each NAME source write recomputes the composed displayName by reading
-        // its sibling from the DB, so concurrent first/last writes can read a
-        // stale sibling and persist an outdated displayName. Batching writes
-        // them sequentially in one request, so the final recompute always sees
-        // the freshly-written sibling. The computed NAME value updates itself.
-        void storeSaveMultiple(recordId, [
-          {
-            fieldId: firstNameFieldId,
-            value: nameValue.firstName ?? '',
-            fieldType: FieldTypeEnum.TEXT,
-          },
-          {
-            fieldId: lastNameFieldId,
-            value: nameValue.lastName ?? '',
-            fieldType: FieldTypeEnum.TEXT,
-          },
-        ])
-
-        // Optimistically mirror the server-side displayName recompute into the
-        // record store so surfaces reading `record.displayName` (e.g. the drawer
-        // header) update instantly. The editing tab is excluded from the
-        // `record:updated` realtime echo, so without this it would stay stale
-        // until a refetch. Only when this NAME field actually drives the
-        // entity's primary displayName — mirrors the backend gate.
-        const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
-        const resource = useResourceStore.getState().getResourceById(entityDefinitionId)
-        if (resource?.display.primaryDisplayField?.id === field.id) {
-          const composed = `${nameValue.firstName ?? ''} ${nameValue.lastName ?? ''}`.trim()
-          useRecordStore
-            .getState()
-            .updateRecord(entityDefinitionId, entityInstanceId, { displayName: composed })
-        }
-        return
-      }
-
       // 1. Update local state SYNCHRONOUSLY (instant UI update)
       setCurrentValue(newValue)
       setIsDirty(false)
@@ -413,16 +363,7 @@ export function PropertyProvider({
       // Store handles the optimistic update, so also update local serverValue
       setServerValue(newValue)
     },
-    [
-      recordId,
-      serverValue,
-      storeSave,
-      storeSaveMultiple,
-      field.id,
-      field.fieldType,
-      field.options,
-      orderSensitive,
-    ]
+    [recordId, serverValue, storeSave, field.id, field.fieldType, field.options, orderSensitive]
   )
 
   /**

--- a/apps/web/src/components/resources/hooks/use-save-field-value.name-split.test.ts
+++ b/apps/web/src/components/resources/hooks/use-save-field-value.name-split.test.ts
@@ -1,0 +1,420 @@
+// apps/web/src/components/resources/hooks/use-save-field-value.name-split.test.ts
+//
+// A NAME field is a COMPOSITE over two TEXT part fields
+// (`options.name.firstNameFieldId` / `.lastNameFieldId`). It stores NOTHING of
+// its own — the value the UI shows is derived from the parts — so a write that
+// lands on the NAME field itself leaves the parts stale and is silently undone
+// by the next refetch.
+//
+// The split used to live ABOVE this funnel, in `PropertyProvider.commitValue`
+// and in the create form. `commitValue`'s sibling `commitValueAndClose` never
+// got a copy, so committing a name with Enter wrote the composite raw for the
+// ~7 months the linking existed, while clicking away wrote the parts. Grid
+// paste (`saveBulkMultipleFields`) never split at all.
+//
+// These tests pin the split at the funnel, where no commit path can skip it:
+// what goes on the wire is TWO part-field entries and ZERO NAME entries, and
+// the optimistic store writes land on the PART keys.
+
+import type { CustomResource, RecordId, ResourceField } from '@auxx/lib/resources/client'
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildFieldValueKey, useFieldValueStore } from '../store/field-value-store'
+import { useRecordStore } from '../store/record-store'
+import { getResourceStoreState } from '../store/resource-store'
+import { useSaveFieldValue } from './use-save-field-value'
+
+const DEF = 'def_contact00000000000000000'
+const ROW = 'ein_anita0000000000000000000'
+const RECORD_ID = `${DEF}:${ROW}` as RecordId
+
+const OTHER_DEF = 'def_lead00000000000000000000'
+const OTHER_RECORD_ID = `${OTHER_DEF}:ein_lead0000000000000000000` as RecordId
+
+const NAME_ID = 'fld_full_name000000000000000'
+const FIRST_ID = 'fld_first_name00000000000000'
+const LAST_ID = 'fld_last_name0000000000000000'
+const NOTES_ID = 'fld_notes00000000000000000000'
+
+/** One tRPC payload as the funnel put it on the wire. */
+interface SetInput {
+  recordId: string
+  fieldId: string
+  value: unknown
+}
+interface BulkInput {
+  recordIds: string[]
+  values: Array<{ fieldId: string; value: unknown }>
+}
+
+const h = vi.hoisted(() => ({
+  set: [] as unknown[],
+  bulk: [] as unknown[],
+}))
+
+// The wire. Both mutations resolve successfully with an empty value list —
+// what is asserted is the REQUEST, not what the server would answer.
+vi.mock('~/trpc/react', () => {
+  const record = (sink: unknown[]) => ({
+    useMutation: () => ({
+      mutate: (input: unknown, opts?: { onSuccess?: (result: unknown) => void }) => {
+        sink.push(input)
+        opts?.onSuccess?.({ values: [] })
+      },
+      mutateAsync: async (input: unknown) => {
+        sink.push(input)
+        return { values: [] }
+      },
+      isPending: false,
+    }),
+  })
+  return { api: { fieldValue: { set: record(h.set), setBulk: record(h.bulk) } } }
+})
+
+function makeField(overrides: Partial<ResourceField> = {}): ResourceField {
+  return {
+    id: FIRST_ID,
+    key: 'firstName',
+    label: 'First Name',
+    type: 'string',
+    fieldType: 'TEXT',
+    capabilities: { updatable: true },
+    ...overrides,
+  } as unknown as ResourceField
+}
+
+/** The NAME composite, linked to both parts and addressable as `full_name`. */
+function nameField(name: unknown = { firstNameFieldId: FIRST_ID, lastNameFieldId: LAST_ID }) {
+  return makeField({
+    id: NAME_ID,
+    key: 'fullName',
+    label: 'Full Name',
+    fieldType: 'NAME',
+    systemAttribute: 'full_name',
+    options: name ? { name } : {},
+  } as Partial<ResourceField>)
+}
+
+function contactsResource(fields: ResourceField[], primaryDisplayFieldId?: string): CustomResource {
+  return {
+    id: DEF,
+    type: 'custom',
+    apiSlug: 'contacts',
+    entityType: 'contact',
+    entityDefinitionId: DEF,
+    organizationId: 'org_1',
+    label: 'Contact',
+    plural: 'Contacts',
+    icon: 'user',
+    color: 'blue',
+    isVisible: true,
+    fields,
+    display: {
+      primaryDisplayField: primaryDisplayFieldId ? { id: primaryDisplayFieldId } : null,
+      secondaryDisplayField: null,
+      avatarField: null,
+      defaultSortField: 'updatedAt',
+      defaultSortDirection: 'desc',
+      orgScopingStrategy: 'direct',
+    },
+  } as unknown as CustomResource
+}
+
+/** The default registry: a linked NAME composite, both parts, and a plain TEXT. */
+function givenLinkedNameField(primaryDisplayFieldId?: string) {
+  getResourceStoreState().setResources([
+    contactsResource(
+      [
+        nameField(),
+        makeField(),
+        makeField({ id: LAST_ID, key: 'lastName', label: 'Last Name' }),
+        makeField({ id: NOTES_ID, key: 'notes', label: 'Notes' }),
+      ],
+      primaryDisplayFieldId
+    ),
+  ])
+}
+
+function save() {
+  return renderHook(() => useSaveFieldValue()).result.current
+}
+
+/** Every `{ fieldId, value }` the funnel sent, across both mutations. */
+function wireEntries(): Array<{ fieldId: string; value: unknown }> {
+  return [
+    ...(h.set as SetInput[]).map((i) => ({ fieldId: i.fieldId, value: i.value })),
+    ...(h.bulk as BulkInput[]).flatMap((i) => i.values),
+  ]
+}
+
+beforeEach(() => {
+  h.set.length = 0
+  h.bulk.length = 0
+  useFieldValueStore.getState().clearAll()
+  useRecordStore.getState().clearAll()
+  getResourceStoreState().reset()
+  givenLinkedNameField()
+})
+
+describe('NAME writes split into their part fields — saveFieldValue', () => {
+  // THE regression. This is the exact payload the record drawer sent when the
+  // name was committed with Enter: one write, on the NAME field itself.
+  it('sends two part-field writes and never the NAME field', () => {
+    save().saveFieldValue(RECORD_ID, NAME_ID, { firstName: 'Anita', lastName: 'Bicknell' }, 'NAME')
+
+    expect(wireEntries()).toEqual([
+      { fieldId: FIRST_ID, value: 'Anita' },
+      { fieldId: LAST_ID, value: 'Bicknell' },
+    ])
+    expect(wireEntries().some((e) => e.fieldId === NAME_ID)).toBe(false)
+  })
+
+  // Both parts must travel in ONE request: each part write recomposes
+  // `displayName` by reading its SIBLING from the DB, so two concurrent
+  // single-field writes can each read a stale sibling and persist an outdated
+  // composed name.
+  it('batches both parts into a single request', () => {
+    save().saveFieldValue(RECORD_ID, NAME_ID, { firstName: 'Anita', lastName: 'Bicknell' }, 'NAME')
+
+    expect(h.set).toHaveLength(0)
+    expect(h.bulk).toHaveLength(1)
+    expect((h.bulk[0] as BulkInput).recordIds).toEqual([RECORD_ID])
+  })
+
+  // The funnel receives whatever spelling the caller had. This field is
+  // `systemAttribute: 'full_name'`, `isCustom: false` — the alias form has to
+  // resolve or the guard is decorative.
+  it('resolves a systemAttribute-shaped fieldId and still splits', () => {
+    save().saveFieldValue(
+      RECORD_ID,
+      'full_name',
+      { firstName: 'Anita', lastName: 'Bicknell' },
+      'NAME'
+    )
+
+    expect(wireEntries()).toEqual([
+      { fieldId: FIRST_ID, value: 'Anita' },
+      { fieldId: LAST_ID, value: 'Bicknell' },
+    ])
+  })
+
+  it('resolves the static key form and still splits', () => {
+    save().saveFieldValue(
+      RECORD_ID,
+      'fullName',
+      { firstName: 'Anita', lastName: 'Bicknell' },
+      'NAME'
+    )
+
+    expect(wireEntries().map((e) => e.fieldId)).toEqual([FIRST_ID, LAST_ID])
+  })
+
+  // The instant part-row refresh in an open drawer is the whole reason the
+  // split stayed on the client: the optimistic write has to land on the keys
+  // the part rows subscribe to, not on the composite's.
+  it('applies the optimistic store update to the PART keys', () => {
+    save().saveFieldValue(RECORD_ID, NAME_ID, { firstName: 'Anita', lastName: 'Bicknell' }, 'NAME')
+
+    const values = useFieldValueStore.getState().values
+    expect(values[buildFieldValueKey(RECORD_ID, FIRST_ID)]).toEqual({
+      type: 'text',
+      value: 'Anita',
+    })
+    expect(values[buildFieldValueKey(RECORD_ID, LAST_ID)]).toEqual({
+      type: 'text',
+      value: 'Bicknell',
+    })
+    expect(values[buildFieldValueKey(RECORD_ID, NAME_ID)]).toBeUndefined()
+  })
+
+  // The composed `displayName` is recomputed server-side on every part write,
+  // but the editing tab is excluded from the `record:updated` realtime echo —
+  // without the mirror the drawer header stays stale until a refetch.
+  it('mirrors the composed displayName into the record store', () => {
+    getResourceStoreState().reset()
+    givenLinkedNameField(NAME_ID)
+    useRecordStore.getState().setRecords(DEF, [
+      {
+        id: ROW,
+        displayName: 'Anita Old',
+        createdAt: '2026-08-25T00:00:00.000Z',
+        updatedAt: '2026-08-25T00:00:00.000Z',
+      },
+    ])
+
+    save().saveFieldValue(RECORD_ID, NAME_ID, { firstName: 'Anita', lastName: 'Bicknell' }, 'NAME')
+
+    expect(useRecordStore.getState().records[DEF]?.get(ROW)?.displayName).toBe('Anita Bicknell')
+  })
+
+  it('leaves displayName alone when the NAME field is not the primary display field', () => {
+    useRecordStore.getState().setRecords(DEF, [
+      {
+        id: ROW,
+        displayName: 'Anita Old',
+        createdAt: '2026-08-25T00:00:00.000Z',
+        updatedAt: '2026-08-25T00:00:00.000Z',
+      },
+    ])
+
+    save().saveFieldValue(RECORD_ID, NAME_ID, { firstName: 'Anita', lastName: 'Bicknell' }, 'NAME')
+
+    expect(useRecordStore.getState().records[DEF]?.get(ROW)?.displayName).toBe('Anita Old')
+  })
+
+  it('leaves a non-NAME write completely untouched', () => {
+    save().saveFieldValue(RECORD_ID, NOTES_ID, 'hello', 'TEXT')
+
+    expect(h.bulk).toHaveLength(0)
+    expect(h.set).toEqual([{ recordId: RECORD_ID, fieldId: NOTES_ID, value: 'hello' }])
+    expect(useFieldValueStore.getState().values[buildFieldValueKey(RECORD_ID, NOTES_ID)]).toEqual({
+      type: 'text',
+      value: 'hello',
+    })
+  })
+
+  // An unlinked composite has no parts to write through. Falling back to the
+  // raw write is the only behavior that does not lose the edit outright, and
+  // it must not throw on the way.
+  it('falls through unsplit when options.name is missing a part id', () => {
+    getResourceStoreState().reset()
+    getResourceStoreState().setResources([
+      contactsResource([nameField({ firstNameFieldId: FIRST_ID }), makeField()]),
+    ])
+
+    expect(() =>
+      save().saveFieldValue(
+        RECORD_ID,
+        NAME_ID,
+        { firstName: 'Anita', lastName: 'Bicknell' },
+        'NAME'
+      )
+    ).not.toThrow()
+
+    expect(h.bulk).toHaveLength(0)
+    expect((h.set[0] as SetInput).fieldId).toBe(NAME_ID)
+  })
+
+  // Both part ids pointing at the SAME field is a misconfigured composite, not
+  // a linked one. The shared predicate (`readNameParts`, which the server
+  // decomposes with) rejects it, and the client must give the same answer —
+  // splitting here would write a value the server would have stored raw.
+  it('falls through unsplit when both part ids are the same field', () => {
+    getResourceStoreState().reset()
+    getResourceStoreState().setResources([
+      contactsResource([
+        nameField({ firstNameFieldId: FIRST_ID, lastNameFieldId: FIRST_ID }),
+        makeField(),
+      ]),
+    ])
+
+    save().saveFieldValue(RECORD_ID, NAME_ID, { firstName: 'Anita', lastName: 'Bicknell' }, 'NAME')
+
+    expect(h.bulk).toHaveLength(0)
+    expect(h.set).toEqual([
+      {
+        recordId: RECORD_ID,
+        fieldId: NAME_ID,
+        value: { firstName: 'Anita', lastName: 'Bicknell' },
+      },
+    ])
+  })
+
+  it('falls through unsplit when options.name is absent entirely', () => {
+    getResourceStoreState().reset()
+    getResourceStoreState().setResources([contactsResource([nameField(null), makeField()])])
+
+    save().saveFieldValue(RECORD_ID, NAME_ID, { firstName: 'Anita', lastName: 'Bicknell' }, 'NAME')
+
+    expect((h.set[0] as SetInput).fieldId).toBe(NAME_ID)
+  })
+})
+
+describe('NAME writes split into their part fields — the other funnel doors', () => {
+  it('splits in saveFieldValueAsync', async () => {
+    await save().saveFieldValueAsync(
+      RECORD_ID,
+      NAME_ID,
+      { firstName: 'Anita', lastName: 'Bicknell' },
+      'NAME'
+    )
+
+    expect(wireEntries()).toEqual([
+      { fieldId: FIRST_ID, value: 'Anita' },
+      { fieldId: LAST_ID, value: 'Bicknell' },
+    ])
+  })
+
+  // The create/edit form door. The NAME entry is expanded in place, and the
+  // other entries in the same submit ride along untouched.
+  it('splits in saveMultipleAsync and leaves sibling entries in place', async () => {
+    await save().saveMultipleAsync(RECORD_ID, [
+      { fieldId: NOTES_ID, value: 'hello', fieldType: 'TEXT' },
+      { fieldId: NAME_ID, value: { firstName: 'Anita', lastName: 'Bicknell' }, fieldType: 'NAME' },
+    ])
+
+    expect(h.bulk).toHaveLength(1)
+    expect((h.bulk[0] as BulkInput).values).toEqual([
+      { fieldId: NOTES_ID, value: 'hello' },
+      { fieldId: FIRST_ID, value: 'Anita' },
+      { fieldId: LAST_ID, value: 'Bicknell' },
+    ])
+  })
+
+  // Grid paste/fill. This door never had a split copy at all.
+  it('splits in saveBulkMultipleFields, and coerces a pasted full-name string', () => {
+    save().saveBulkMultipleFields(
+      [RECORD_ID],
+      [{ fieldId: NAME_ID, value: 'Anita Bicknell', fieldType: 'NAME' }]
+    )
+
+    expect((h.bulk[0] as BulkInput).values).toEqual([
+      { fieldId: FIRST_ID, value: 'Anita' },
+      { fieldId: LAST_ID, value: 'Bicknell' },
+    ])
+  })
+
+  it('splits in saveBulkValues across every record', () => {
+    const second = `${DEF}:ein_second000000000000000000` as RecordId
+    save().saveBulkValues(
+      [RECORD_ID, second],
+      NAME_ID,
+      { firstName: 'Anita', lastName: '' },
+      'NAME'
+    )
+
+    expect((h.bulk[0] as BulkInput).recordIds).toEqual([RECORD_ID, second])
+    expect((h.bulk[0] as BulkInput).values).toEqual([
+      { fieldId: FIRST_ID, value: 'Anita' },
+      { fieldId: LAST_ID, value: '' },
+    ])
+  })
+
+  // One payload serves every record in a bulk set, so a split is only safe
+  // when every record's definition resolves the same composite. Otherwise the
+  // part ids would be written against a definition that does not own them.
+  it('leaves a bulk write unsplit when the records span definitions that disagree', () => {
+    getResourceStoreState().reset()
+    getResourceStoreState().setResources([
+      contactsResource([nameField(), makeField(), makeField({ id: LAST_ID, key: 'lastName' })]),
+      {
+        ...contactsResource([makeField({ id: NAME_ID, key: 'fullName', fieldType: 'TEXT' })]),
+        id: OTHER_DEF,
+        entityDefinitionId: OTHER_DEF,
+        apiSlug: 'leads',
+        entityType: 'lead',
+      } as CustomResource,
+    ])
+
+    save().saveBulkValues(
+      [RECORD_ID, OTHER_RECORD_ID],
+      NAME_ID,
+      { firstName: 'Anita', lastName: 'Bicknell' },
+      'NAME'
+    )
+
+    expect((h.bulk[0] as BulkInput).values).toEqual([
+      { fieldId: NAME_ID, value: { firstName: 'Anita', lastName: 'Bicknell' } },
+    ])
+  })
+})

--- a/apps/web/src/components/resources/hooks/use-save-field-value.ts
+++ b/apps/web/src/components/resources/hooks/use-save-field-value.ts
@@ -1,12 +1,16 @@
 // apps/web/src/components/resources/hooks/use-save-field-value.ts
 
+import { FieldType as FieldTypeEnum } from '@auxx/database/enums'
 import type { FieldType } from '@auxx/database/types'
 import {
+  coerceNameInput,
   type FieldOptions,
   formatToTypedInput,
   isArrayReturnFieldType,
+  type NameParts,
+  readNameParts,
 } from '@auxx/lib/field-values/client'
-import { parseRecordId, type RecordId } from '@auxx/lib/resources/client'
+import { parseRecordId, type RecordId, type ResourceField } from '@auxx/lib/resources/client'
 import {
   getInverseFieldId,
   getRelatedEntityDefinitionId,
@@ -22,6 +26,7 @@ import {
   type StoredFieldValue,
   useFieldValueStore,
 } from '~/components/resources/store/field-value-store'
+import { useRecordStore } from '~/components/resources/store/record-store'
 import { useResourceStore } from '~/components/resources/store/resource-store'
 import { getNormalizedRecordId } from '~/components/resources/utils/normalize-record-id'
 import { resolveSystemAttributeForRecord } from '~/components/resources/utils/resolve-system-attribute'
@@ -276,6 +281,158 @@ function handleMutationError(
   })
 }
 
+// ─── NAME composites ─────────────────────────────────────────────────────────
+
+/** One field write, in the shape every funnel function accepts it. */
+interface FieldWrite {
+  fieldId: string
+  value: unknown
+  fieldType?: FieldType
+}
+
+/**
+ * Read the part-field ids off a registry field, through the SHARED linkage
+ * predicate the server decomposes with (`readNameParts`).
+ *
+ * One predicate, one answer: an unlinked composite — not a NAME field, a
+ * missing part id, or both parts pointing at the SAME field — has no parts to
+ * write through, and client and server must agree on that or the client splits
+ * a write the server would have stored raw. The adapter is only the shape:
+ * a registry field carries `FieldType` on `fieldType` (`type` is the workflow
+ * BaseType), while the shared predicate is structural over `{ type, options }`.
+ */
+function readFieldNameParts(field: ResourceField | undefined): NameParts | null {
+  if (!field) return null
+  return readNameParts({ type: field.fieldType, options: field.options })
+}
+
+/**
+ * Resolve a bare fieldId to its field definition through the resource store.
+ *
+ * The funnel receives whatever spelling the caller had — a canonical field id,
+ * a static key, or a systemAttribute (`full_name`) — so resolution goes through
+ * `getFieldByRef`, which applies the store's alias resolution. Deliberately NOT
+ * read off a caller-supplied `field` prop: several of those are typed `any`
+ * (`PropertyProvider`'s among them), and a reshaped or sparser object fails a
+ * NAME guard silently.
+ */
+function resolveStoreField(recordId: RecordId, fieldId: string): ResourceField | undefined {
+  const { entityDefinitionId } = parseRecordId(recordId)
+  return useResourceStore
+    .getState()
+    .getFieldByRef(toResourceFieldId(entityDefinitionId, fieldId as FieldId))
+}
+
+/**
+ * The NAME parts every one of `recordIds` agrees on for `fieldId`, or null.
+ *
+ * One payload serves every record in a bulk set, and a bulk set may span entity
+ * definitions where the same spelling resolves to a different field. A split is
+ * therefore only safe when every record resolves the SAME composite; any
+ * disagreement leaves the write untouched for the server to decompose.
+ */
+function resolveNameParts(recordIds: RecordId[], fieldId: string): NameParts | null {
+  let parts: NameParts | null = null
+  for (const recordId of recordIds) {
+    const next = readFieldNameParts(resolveStoreField(recordId, fieldId))
+    if (!next) return null
+    if (
+      parts &&
+      (parts.firstNameFieldId !== next.firstNameFieldId ||
+        parts.lastNameFieldId !== next.lastNameFieldId)
+    ) {
+      return null
+    }
+    parts = next
+  }
+  return parts
+}
+
+/**
+ * Coerce any accepted NAME input into its two part strings.
+ *
+ * `coerceNameInput` is the shared coercion the server decomposes with, so every
+ * shape a NAME write has ever accepted keeps working identically on both sides:
+ * an object, an already-typed `json` value, and a bare full-name string
+ * (`'Anita Bicknell'`, what a grid paste delivers). Its `null` — blank input,
+ * i.e. a clear — is widened here to two empty strings, because the funnel's
+ * callers want a write against each part rather than an absent entry.
+ */
+function coerceNameValue(value: unknown): { firstName: string; lastName: string } {
+  return coerceNameInput(value) ?? { firstName: '', lastName: '' }
+}
+
+/**
+ * Optimistically mirror the server-side `displayName` recompute into the record
+ * store, so surfaces reading `record.displayName` (the drawer header) update
+ * instantly. The editing tab is excluded from the `record:updated` realtime
+ * echo, so without this it stays stale until a refetch. Only when this NAME
+ * field actually drives the entity's primary displayName — mirrors the backend
+ * gate.
+ */
+function mirrorNameDisplayName(
+  recordId: RecordId,
+  field: ResourceField,
+  name: { firstName: string; lastName: string }
+): void {
+  const { entityDefinitionId, entityInstanceId } = parseRecordId(recordId)
+  const resource = useResourceStore.getState().getResourceById(entityDefinitionId)
+  if (resource?.display.primaryDisplayField?.id !== field.id) return
+  useRecordStore.getState().updateRecord(entityDefinitionId, entityInstanceId, {
+    displayName: `${name.firstName} ${name.lastName}`.trim(),
+  })
+}
+
+/**
+ * Rewrite NAME composite writes into writes against their two TEXT part fields.
+ *
+ * A NAME field is a COMPOSITE over `options.name.firstNameFieldId` /
+ * `.lastNameFieldId` and stores nothing of its own — the value the UI shows is
+ * derived from the parts, so a write that lands on the NAME field itself leaves
+ * the parts stale and is undone by the next refetch.
+ *
+ * The split lives HERE, below every commit path, rather than in the editors:
+ * `PropertyProvider` used to carry a copy in `commitValue` only, so committing
+ * a name with Enter (`commitValueAndClose`) wrote the composite raw for as long
+ * as the linking existed, and grid paste never split at all. Below the funnel
+ * that divergence is not expressible.
+ *
+ * Both parts must travel in ONE request. Two separate single-field writes race
+ * on the server-side `displayName` recompute: each part write recomposes by
+ * reading its SIBLING from the DB, so concurrent first/last writes can read a
+ * stale sibling and persist an outdated `displayName`. Callers holding a single
+ * NAME write therefore hand it to the batched door.
+ *
+ * Idempotent: a list that resolves no NAME field is returned unchanged, so an
+ * already-split write passes straight through.
+ */
+function expandNameWrites(recordIds: RecordId[], writes: FieldWrite[]): FieldWrite[] {
+  let expanded: FieldWrite[] | null = null
+
+  for (let index = 0; index < writes.length; index++) {
+    const write = writes[index]
+    if (!write) continue
+    const parts = resolveNameParts(recordIds, write.fieldId)
+    if (!parts) {
+      expanded?.push(write)
+      continue
+    }
+    if (!expanded) expanded = writes.slice(0, index)
+
+    const name = coerceNameValue(write.value)
+    expanded.push(
+      { fieldId: parts.firstNameFieldId, value: name.firstName, fieldType: FieldTypeEnum.TEXT },
+      { fieldId: parts.lastNameFieldId, value: name.lastName, fieldType: FieldTypeEnum.TEXT }
+    )
+    for (const recordId of recordIds) {
+      const field = resolveStoreField(recordId, write.fieldId)
+      if (field) mirrorNameDisplayName(recordId, field, name)
+    }
+  }
+
+  return expanded ?? writes
+}
+
 /**
  * Hook for saving field values with optimistic updates to the shared store.
  * Updates store immediately, then syncs to DB in background.
@@ -303,6 +460,175 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
   const { mutate: bulkMutate, mutateAsync: bulkMutateAsync } = bulkMutation
 
   /**
+   * Save multiple field values to a single resource (async version).
+   * @param recordId - Full RecordId
+   * @param fieldValues - Array of { fieldId, value, fieldType }
+   */
+  const saveMultipleAsync = useCallback(
+    async (
+      recordId: RecordId,
+      fieldValues: Array<{ fieldId: string; value: unknown; fieldType: FieldType }>,
+      saveOpts?: SaveOptions
+    ): Promise<boolean> => {
+      const normalizedRecordId = getNormalizedRecordId(recordId)
+      const store = useFieldValueStore.getState()
+      const ai = saveOpts?.ai === true
+      const requestedAt = ai ? new Date().toISOString() : undefined
+
+      // NAME composites are written through their two TEXT part fields — the
+      // optimistic keys and the payload below are the part fields', never the
+      // composite's. See {@link expandNameWrites}.
+      const writes = expandNameWrites([normalizedRecordId], fieldValues)
+
+      // Build keys, capture versions, and apply optimistic updates
+      const keyVersions: Array<{ key: FieldValueKey; version: number }> = []
+      for (const { fieldId, value, fieldType } of writes) {
+        const key = buildFieldValueKey(
+          normalizedRecordId,
+          resolveFieldRef(fieldId, normalizedRecordId)
+        )
+        const version = store.incrementMutationVersion(key)
+        keyVersions.push({ key, version })
+        if (ai) {
+          store.setAiStateOptimistic(key, 'generating', { requestedAt })
+          store.setValueOptimistic(key, null)
+        } else {
+          const typedValue = fieldType ? formatToTypedInput(value, fieldType) : value
+          store.setValueOptimistic(key, typedValue)
+        }
+      }
+
+      // Build API payload (keep original fieldIds — server resolves systemAttributes)
+      const apiValues = writes.map(({ fieldId, value }) => ({ fieldId, value }))
+
+      try {
+        await bulkMutateAsync({
+          recordIds: [normalizedRecordId],
+          values: apiValues,
+          ...(ai ? { ai: true } : {}),
+        })
+
+        const currentStore = useFieldValueStore.getState()
+        for (const { key, version } of keyVersions) {
+          if (version >= currentStore.getMutationVersion(key)) {
+            if (ai) {
+              currentStore.confirmOptimistic(key)
+              currentStore.confirmAiStateOptimistic(key)
+            } else {
+              currentStore.confirmOptimistic(key)
+            }
+          }
+        }
+        onSuccess?.()
+        return true
+      } catch (error: unknown) {
+        const currentStore = useFieldValueStore.getState()
+        for (const { key, version } of keyVersions) {
+          if (version >= currentStore.getMutationVersion(key)) {
+            if (ai) {
+              // Keep the optimistic null value — see handleMutationError.
+              currentStore.rollbackAiState(key)
+              currentStore.confirmOptimistic(key)
+            } else {
+              currentStore.rollbackOptimistic(key)
+            }
+          }
+        }
+        const errorMessage = error instanceof Error ? error.message : 'Could not save field values'
+        toastError({ title: 'Error saving fields', description: errorMessage })
+        return false
+      }
+    },
+    [bulkMutateAsync, onSuccess]
+  )
+
+  /**
+   * Save multiple field values to multiple resources in one API call.
+   * @param recordIds - Array of RecordIds to update
+   * @param fieldValues - Array of { fieldId, value, fieldType }
+   */
+  const saveBulkMultipleFields = useCallback(
+    (
+      recordIds: RecordId[],
+      fieldValues: Array<{ fieldId: string; value: unknown; fieldType?: FieldType }>,
+      saveOpts?: SaveOptions
+    ): void => {
+      const normalizedRecordIds = recordIds.map(getNormalizedRecordId)
+      const store = useFieldValueStore.getState()
+      const ai = saveOpts?.ai === true
+      const requestedAt = ai ? new Date().toISOString() : undefined
+
+      // NAME composites are written through their two TEXT part fields — the
+      // optimistic keys and the payload below are the part fields', never the
+      // composite's. See {@link expandNameWrites}.
+      const writes = expandNameWrites(normalizedRecordIds, fieldValues)
+
+      // Build all keys, capture versions, and apply optimistic updates
+      const keyVersions: Array<{ key: FieldValueKey; version: number }> = []
+
+      for (const recordId of normalizedRecordIds) {
+        for (const { fieldId, value, fieldType } of writes) {
+          const key = buildFieldValueKey(recordId, resolveFieldRef(fieldId, recordId))
+          const version = store.incrementMutationVersion(key)
+          keyVersions.push({ key, version })
+          if (ai) {
+            store.setAiStateOptimistic(key, 'generating', { requestedAt })
+            store.setValueOptimistic(key, null)
+          } else {
+            const typedValue = fieldType ? formatToTypedInput(value, fieldType) : value
+            store.setValueOptimistic(key, typedValue)
+          }
+        }
+      }
+
+      // Build API payload (keep original fieldIds — server resolves systemAttributes)
+      const apiValues = writes.map(({ fieldId, value }) => ({ fieldId, value }))
+
+      bulkMutate(
+        {
+          recordIds: normalizedRecordIds,
+          values: apiValues,
+          ...(ai ? { ai: true } : {}),
+        },
+        {
+          onSuccess: () => {
+            const currentStore = useFieldValueStore.getState()
+            for (const { key, version } of keyVersions) {
+              if (version >= currentStore.getMutationVersion(key)) {
+                if (ai) {
+                  currentStore.confirmOptimistic(key)
+                  currentStore.confirmAiStateOptimistic(key)
+                } else {
+                  currentStore.confirmOptimistic(key)
+                }
+              }
+            }
+            onSuccess?.()
+          },
+          onError: (error) => {
+            const currentStore = useFieldValueStore.getState()
+            for (const { key, version } of keyVersions) {
+              if (version >= currentStore.getMutationVersion(key)) {
+                if (ai) {
+                  // Keep the optimistic null value — see handleMutationError.
+                  currentStore.rollbackAiState(key)
+                  currentStore.confirmOptimistic(key)
+                } else {
+                  currentStore.rollbackOptimistic(key)
+                }
+              }
+            }
+            toastError({
+              title: 'Error saving fields',
+              description: error.message || 'Could not save field values',
+            })
+          },
+        }
+      )
+    },
+    [bulkMutate, onSuccess]
+  )
+  /**
    * Save a field value with optimistic update.
    * @param recordId - Full RecordId (entityDefinitionId:entityInstanceId)
    * @param fieldId - The custom field ID
@@ -318,6 +644,14 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
       saveOpts?: SaveOptions
     ): void => {
       const normalizedRecordId = getNormalizedRecordId(recordId)
+
+      // A NAME composite fans out into two part-field writes that must travel
+      // in ONE request — hand it to the batched door, which splits it.
+      if (resolveNameParts([normalizedRecordId], fieldId)) {
+        saveBulkMultipleFields([normalizedRecordId], [{ fieldId, value, fieldType }], saveOpts)
+        return
+      }
+
       const ai = saveOpts?.ai === true
       const prep = prepareOptimisticUpdate(
         normalizedRecordId,
@@ -371,7 +705,7 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
         }
       )
     },
-    [setMutate, onSuccess, getFieldMetadata, syncInverseCache]
+    [setMutate, onSuccess, getFieldMetadata, syncInverseCache, saveBulkMultipleFields]
   )
 
   /**
@@ -391,6 +725,18 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
       saveOpts?: SaveOptions
     ): Promise<{ success: boolean; id?: string } | undefined> => {
       const normalizedRecordId = getNormalizedRecordId(recordId)
+
+      // A NAME composite fans out into two part-field writes that must travel
+      // in ONE request — hand it to the batched door, which splits it.
+      if (resolveNameParts([normalizedRecordId], fieldId)) {
+        const success = await saveMultipleAsync(
+          normalizedRecordId,
+          [{ fieldId, value, fieldType }],
+          saveOpts
+        )
+        return { success }
+      }
+
       const ai = saveOpts?.ai === true
       const prep = prepareOptimisticUpdate(
         normalizedRecordId,
@@ -459,85 +805,7 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
         return { success: false }
       }
     },
-    [setMutateAsync, onSuccess, getFieldMetadata, syncInverseCache]
-  )
-
-  /**
-   * Save multiple field values to a single resource (async version).
-   * @param recordId - Full RecordId
-   * @param fieldValues - Array of { fieldId, value, fieldType }
-   */
-  const saveMultipleAsync = useCallback(
-    async (
-      recordId: RecordId,
-      fieldValues: Array<{ fieldId: string; value: unknown; fieldType: FieldType }>,
-      saveOpts?: SaveOptions
-    ): Promise<boolean> => {
-      const normalizedRecordId = getNormalizedRecordId(recordId)
-      const store = useFieldValueStore.getState()
-      const ai = saveOpts?.ai === true
-      const requestedAt = ai ? new Date().toISOString() : undefined
-
-      // Build keys, capture versions, and apply optimistic updates
-      const keyVersions: Array<{ key: FieldValueKey; version: number }> = []
-      for (const { fieldId, value, fieldType } of fieldValues) {
-        const key = buildFieldValueKey(
-          normalizedRecordId,
-          resolveFieldRef(fieldId, normalizedRecordId)
-        )
-        const version = store.incrementMutationVersion(key)
-        keyVersions.push({ key, version })
-        if (ai) {
-          store.setAiStateOptimistic(key, 'generating', { requestedAt })
-          store.setValueOptimistic(key, null)
-        } else {
-          const typedValue = fieldType ? formatToTypedInput(value, fieldType) : value
-          store.setValueOptimistic(key, typedValue)
-        }
-      }
-
-      // Build API payload (keep original fieldIds — server resolves systemAttributes)
-      const apiValues = fieldValues.map(({ fieldId, value }) => ({ fieldId, value }))
-
-      try {
-        await bulkMutateAsync({
-          recordIds: [normalizedRecordId],
-          values: apiValues,
-          ...(ai ? { ai: true } : {}),
-        })
-
-        const currentStore = useFieldValueStore.getState()
-        for (const { key, version } of keyVersions) {
-          if (version >= currentStore.getMutationVersion(key)) {
-            if (ai) {
-              currentStore.confirmOptimistic(key)
-              currentStore.confirmAiStateOptimistic(key)
-            } else {
-              currentStore.confirmOptimistic(key)
-            }
-          }
-        }
-        onSuccess?.()
-        return true
-      } catch (error: unknown) {
-        const currentStore = useFieldValueStore.getState()
-        for (const { key, version } of keyVersions) {
-          if (version >= currentStore.getMutationVersion(key)) {
-            if (ai) {
-              // Keep the optimistic null value — see handleMutationError.
-              currentStore.rollbackAiState(key)
-              currentStore.confirmOptimistic(key)
-            } else {
-              currentStore.rollbackOptimistic(key)
-            }
-          }
-        }
-        const errorMessage = error instanceof Error ? error.message : 'Could not save field values'
-        toastError({ title: 'Error saving fields', description: errorMessage })
-        return false
-      }
-    },
-    [bulkMutateAsync, onSuccess]
+    [setMutateAsync, onSuccess, getFieldMetadata, syncInverseCache, saveMultipleAsync]
   )
 
   /**
@@ -556,6 +824,14 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
       saveOpts?: SaveOptions
     ): void => {
       const normalizedRecordIds = recordIds.map(getNormalizedRecordId)
+
+      // A NAME composite fans out into two part-field writes that must travel
+      // in ONE request — hand it to the batched door, which splits it.
+      if (resolveNameParts(normalizedRecordIds, fieldId)) {
+        saveBulkMultipleFields(normalizedRecordIds, [{ fieldId, value, fieldType }], saveOpts)
+        return
+      }
+
       const store = useFieldValueStore.getState()
       const ai = saveOpts?.ai === true
 
@@ -621,89 +897,7 @@ export function useSaveFieldValue(options: UseSaveFieldValueOptions = {}) {
         }
       )
     },
-    [bulkMutate, onSuccess]
-  )
-
-  /**
-   * Save multiple field values to multiple resources in one API call.
-   * @param recordIds - Array of RecordIds to update
-   * @param fieldValues - Array of { fieldId, value, fieldType }
-   */
-  const saveBulkMultipleFields = useCallback(
-    (
-      recordIds: RecordId[],
-      fieldValues: Array<{ fieldId: string; value: unknown; fieldType?: FieldType }>,
-      saveOpts?: SaveOptions
-    ): void => {
-      const normalizedRecordIds = recordIds.map(getNormalizedRecordId)
-      const store = useFieldValueStore.getState()
-      const ai = saveOpts?.ai === true
-      const requestedAt = ai ? new Date().toISOString() : undefined
-
-      // Build all keys, capture versions, and apply optimistic updates
-      const keyVersions: Array<{ key: FieldValueKey; version: number }> = []
-
-      for (const recordId of normalizedRecordIds) {
-        for (const { fieldId, value, fieldType } of fieldValues) {
-          const key = buildFieldValueKey(recordId, resolveFieldRef(fieldId, recordId))
-          const version = store.incrementMutationVersion(key)
-          keyVersions.push({ key, version })
-          if (ai) {
-            store.setAiStateOptimistic(key, 'generating', { requestedAt })
-            store.setValueOptimistic(key, null)
-          } else {
-            const typedValue = fieldType ? formatToTypedInput(value, fieldType) : value
-            store.setValueOptimistic(key, typedValue)
-          }
-        }
-      }
-
-      // Build API payload (keep original fieldIds — server resolves systemAttributes)
-      const apiValues = fieldValues.map(({ fieldId, value }) => ({ fieldId, value }))
-
-      bulkMutate(
-        {
-          recordIds: normalizedRecordIds,
-          values: apiValues,
-          ...(ai ? { ai: true } : {}),
-        },
-        {
-          onSuccess: () => {
-            const currentStore = useFieldValueStore.getState()
-            for (const { key, version } of keyVersions) {
-              if (version >= currentStore.getMutationVersion(key)) {
-                if (ai) {
-                  currentStore.confirmOptimistic(key)
-                  currentStore.confirmAiStateOptimistic(key)
-                } else {
-                  currentStore.confirmOptimistic(key)
-                }
-              }
-            }
-            onSuccess?.()
-          },
-          onError: (error) => {
-            const currentStore = useFieldValueStore.getState()
-            for (const { key, version } of keyVersions) {
-              if (version >= currentStore.getMutationVersion(key)) {
-                if (ai) {
-                  // Keep the optimistic null value — see handleMutationError.
-                  currentStore.rollbackAiState(key)
-                  currentStore.confirmOptimistic(key)
-                } else {
-                  currentStore.rollbackOptimistic(key)
-                }
-              }
-            }
-            toastError({
-              title: 'Error saving fields',
-              description: error.message || 'Could not save field values',
-            })
-          },
-        }
-      )
-    },
-    [bulkMutate, onSuccess]
+    [bulkMutate, onSuccess, saveBulkMultipleFields]
   )
 
   return {

--- a/docs/entity-architecture-guide.md
+++ b/docs/entity-architecture-guide.md
@@ -146,11 +146,11 @@ app fields dedup on `(appInstallationId, connectionId, appFieldKey, modelType, e
 - `entityId` — the record id (EntityInstance / contact / ticket / …)
 - `entityDefinitionId` — the entity type (UUID or system string)
 - **Typed value columns** (exactly one used per row):
-  - `valueText` — TEXT, RICH_TEXT, NAME, EMAIL, URL, PHONE_INTL, ADDRESS
+  - `valueText` — TEXT, RICH_TEXT, EMAIL, URL, PHONE_INTL, ADDRESS
   - `valueNumber` — NUMBER, CURRENCY (amount)
   - `valueBoolean` — CHECKBOX
   - `valueDate` — DATE, DATETIME, TIME
-  - `valueJson` — FILE, ADDRESS_STRUCT, CURRENCY (`{amount, code}`), CALC, JSON, AI metadata
+  - `valueJson` — FILE, ADDRESS_STRUCT, CURRENCY (`{amount, code}`), JSON, AI metadata
   - `optionId` — SINGLE_SELECT / MULTI_SELECT / TAGS (refs `CustomField.options[].id`)
   - `relatedEntityId` + `relatedEntityDefinitionId` — RELATIONSHIP
   - `actorId` (FK → User) — ACTOR
@@ -391,7 +391,7 @@ column in parentheses:
 | --- | --- | --- |
 | `TEXT` | valueText | |
 | `RICH_TEXT` | valueText | HTML |
-| `NAME` | valueText | |
+| `NAME` | **none** | composite over two TEXT parts — stores nothing of its own (see below) |
 | `EMAIL` | valueText | normalized lowercase |
 | `URL` | valueText | |
 | `PHONE_INTL` | valueText | E.164 normalized |
@@ -409,13 +409,53 @@ column in parentheses:
 | `FILE` | valueJson | `{url, name, size, mimeType}` |
 | `RELATIONSHIP` | relatedEntityId + relatedEntityDefinitionId | |
 | `ACTOR` | actorId | FK → User |
-| `CALC` | valueNumber / valueJson | computed; read-only |
+| `CALC` | **none** | computed at read time; its converter refuses to store |
 | `JSON` | valueJson | arbitrary |
 
 (`PHONE` exists in the pgEnum for legacy rows but is not in the active `FieldType` union; use `PHONE_INTL`.)
 
 Converters: one per type in `field-values/converters/`. Each handles input coercion and row→typed-value
 conversion.
+
+### The two field types that store nothing
+
+`NAME` and `CALC` are derived: neither owns a `FieldValue` row, and a row found under one was written by a
+caller that went around this layer. They are derived by DIFFERENT mechanisms, which matters — only `CALC`
+carries the `computed` value type (`getValueType`), while `NAME` is nominally `json`. The read paths treat
+them separately.
+
+**`NAME` — a composite over two TEXT parts.** A NAME field (e.g. contact `full_name`) links to a first-name
+and a last-name field through `options.name.firstNameFieldId` / `.lastNameFieldId`. The invariant, both
+directions, is:
+
+- **Writes DECOMPOSE.** `setValueWithBuiltIn` — the chokepoint every set-shaped write from every door funnels
+  through (tRPC `set`/`setBulk`, the API set-values route + SDK, importer, workflows, Kopilot, AI commits,
+  record create/update) — fans a NAME write out into two writes against the part fields and never writes the
+  NAME field itself. Every input shape the NAME converter has ever accepted still works, including a bare
+  full-name string (`"Anita Bicknell"` → `Anita` / `Bicknell`); a `null` clears both parts.
+- **Reads COMPOSE.** `getValue` / `getValues` / `batchGetValues` build the value back out of the two part
+  rows and return it in the converter's own shape (`{ type: 'json', value: { firstName, lastName } }`), so
+  an SDK/API reader sees no difference. The NAME field's own row is never read. Both parts blank ⇒ the
+  field's normal "no value" result.
+- **An UNLINKED NAME field** (`options.name` missing or half-configured) has no parts to work with, so both
+  directions fall back to the pre-decomposition behavior — the composite is stored on, and read from, the
+  NAME field's own row. This warns; it never throws.
+
+The linkage predicate is `field-values/name-parts.ts` (`readNameParts`), and both directions read it — a
+second copy of "is this NAME field linked?" would let write and read disagree about the same field.
+
+Stray NAME rows from before decomposition landed were deliberately left in place rather than migrated, so
+compose-on-read is what makes them invisible. One place still reads them: the `searchText` NAME arm
+(`field-values/search-text.ts`) indexes `valueJson` off the NAME field's own row, so a stale stray row keeps
+feeding outdated name text into search until something deletes it.
+
+**`CALC`** is simpler: its converter's `toTypedInput` returns `null` ("do not store"), so a raw CALC write
+degrades into a clear-of-absent and no row is ever created. Reads resolve it through `resolveCalcForRecord`.
+A stored row under a computed type is skipped with a warning on every read path — it used to throw, which
+turned one invented row into a permanent hard failure of every read of that field.
+
+Background and the decision record: `plans/field-values/name-field-writes.md` §4 (write decomposition and
+read semantics), §6/§8 (why the stray rows stay), §7 (the computed-type read).
 
 ---
 

--- a/packages/lib/src/field-values/__tests__/computed-row-skip.test.ts
+++ b/packages/lib/src/field-values/__tests__/computed-row-skip.test.ts
@@ -1,0 +1,110 @@
+// packages/lib/src/field-values/__tests__/computed-row-skip.test.ts
+
+/**
+ * A stored `FieldValue` row on a COMPUTED field type warns and skips — it does
+ * not throw (`plans/field-values/name-field-writes.md` §7).
+ *
+ * CALC is the only computed type and it is never persisted (its converter's
+ * `toTypedInput` returns `null`), so a row under one was invented by a caller
+ * that went around the converters — a raw insert in a migration, a connector
+ * sink, a seeder. `rowToTypedValue` used to answer that with a `throw`, which
+ * turns ONE bad row into a hard failure of every read of that field, for every
+ * caller, forever. That is the poison pill §7 asked to be defused before the
+ * NAME work could rely on it.
+ */
+
+import type { FieldType } from '@auxx/database/types'
+
+// Intercept ONLY this module's logger, leaving every other scope real — the
+// import graph builds a lot of loggers at module load and none of them should
+// change shape for this file.
+const { logWarn } = vi.hoisted(() => ({ logWarn: vi.fn() }))
+vi.mock('@auxx/logger', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  const real = actual.createScopedLogger as (scope: string, options?: unknown) => object
+  return {
+    ...actual,
+    createScopedLogger: (scope: string, options?: unknown) =>
+      scope === 'field-value-helpers' ? { ...real(scope), warn: logWarn } : real(scope, options),
+  }
+})
+
+import {
+  isComputedStoredFieldType,
+  rowsToTypedValues,
+  rowToTypedValue,
+} from '../field-value-helpers'
+import type { FieldValueRow } from '../types'
+
+const CALC = 'CALC' as FieldType
+const TEXT = 'TEXT' as FieldType
+
+const WARNING = 'Stored FieldValue row on a computed field type; skipping it'
+
+/** The row a bypassing caller would have written. */
+const calcRow = {
+  id: 'fv_calc',
+  entityId: 'con_1',
+  fieldId: 'fld_margin',
+  sortKey: 'a0',
+  valueText: '42',
+  createdAt: '2026-08-25T00:00:00.000Z',
+  updatedAt: '2026-08-25T00:00:00.000Z',
+} as unknown as FieldValueRow
+
+beforeEach(() => {
+  logWarn.mockReset()
+})
+
+describe('isComputedStoredFieldType', () => {
+  it('names CALC and nothing in the stored families', () => {
+    expect(isComputedStoredFieldType(CALC)).toBe(true)
+    for (const type of ['TEXT', 'NAME', 'NUMBER', 'DATE', 'JSON', 'RELATIONSHIP', 'ACTOR']) {
+      expect(isComputedStoredFieldType(type as FieldType)).toBe(false)
+    }
+  })
+
+  it('does NOT name NAME — a NAME field is `json`, not `computed`', () => {
+    // NAME is composed on read (§4) but its VALUE TYPE is `json`, so the stray
+    // rows §6 leaves in place were never on the throwing path. The §7 defusal
+    // and the §4 composition are independent fixes.
+    expect(isComputedStoredFieldType('NAME' as FieldType)).toBe(false)
+  })
+})
+
+describe('rowToTypedValue — computed rows warn instead of throwing', () => {
+  it('no longer throws on an invented CALC row', () => {
+    expect(() => rowToTypedValue(calcRow, CALC)).not.toThrow()
+  })
+
+  it('warns with the row identity so the invented row can be found', () => {
+    rowToTypedValue(calcRow, CALC)
+    expect(logWarn).toHaveBeenCalledWith(WARNING, {
+      fieldId: 'fld_margin',
+      entityId: 'con_1',
+      fieldType: 'CALC',
+    })
+  })
+})
+
+describe('rowsToTypedValues — the read seam skips the row', () => {
+  it('reads as unset for a single-value field', () => {
+    expect(rowsToTypedValues([calcRow], CALC, false)).toBeNull()
+    expect(logWarn).toHaveBeenCalledWith(WARNING, expect.objectContaining({ fieldType: 'CALC' }))
+  })
+
+  it('reads as empty for an array-return field', () => {
+    expect(rowsToTypedValues([calcRow], CALC, true)).toEqual([])
+  })
+
+  it('says nothing when there is no invented row to skip', () => {
+    expect(rowsToTypedValues([], CALC, false)).toBeNull()
+    expect(rowsToTypedValues([], CALC, true)).toEqual([])
+    expect(logWarn).not.toHaveBeenCalled()
+  })
+
+  it('still converts non-computed types normally and silently', () => {
+    expect(rowsToTypedValues([calcRow], TEXT, false)).toMatchObject({ type: 'text', value: '42' })
+    expect(logWarn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/lib/src/field-values/__tests__/name-compose-on-read.test.ts
+++ b/packages/lib/src/field-values/__tests__/name-compose-on-read.test.ts
@@ -1,0 +1,391 @@
+// packages/lib/src/field-values/__tests__/name-compose-on-read.test.ts
+
+/**
+ * NAME reads COMPOSE from the two TEXT part fields
+ * (`plans/field-values/name-field-writes.md` §4, "server READ semantics").
+ *
+ * A NAME field is a COMPOSITE and owns no storage: the write side decomposes
+ * every set into its parts, so the read side has to compose back out of them.
+ * The sharp edge is that stray pre-decomposition rows ON the NAME field are
+ * deliberately NOT migrated and NOT deleted (§6/§8) — 84 of them across 5
+ * fields in the dev DB when this landed — so "compose" is not just symmetry,
+ * it is what makes those rows invisible. Every test below that names a stray
+ * row gives it DIFFERENT content from the parts, so a regression that reads the
+ * stored composite cannot pass.
+ *
+ * NOTE on imports: `field-value-helpers` must not be imported for its VALUES
+ * here. Pulling it in ahead of `field-value-queries` re-evaluates the cache
+ * barrel out from under `vi.mock('../../cache')` and the real, DB-backed
+ * `findCachedResource` runs instead of the double. The §7 computed-row tests
+ * live in `computed-row-skip.test.ts` for that reason.
+ */
+
+import { toRecordId } from '@auxx/types/resource'
+
+const { findCachedResource, getCachedUserInstanceGrants } = vi.hoisted(() => ({
+  findCachedResource: vi.fn(),
+  getCachedUserInstanceGrants: vi.fn(),
+}))
+
+// Partial-mock the cache barrel: it is DB/Redis-backed, and a wholesale
+// replacement would drop the entries `field-value-helpers` reaches.
+vi.mock('../../cache', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  findCachedResource,
+  getCachedUserInstanceGrants,
+}))
+
+import type { CachedField, FieldValueContext } from '../field-value-helpers'
+import { getValue, getValues } from '../field-value-queries'
+
+const ORG = 'org_1'
+const CONTACT_ID = 'con_1'
+const CONTACT = toRecordId('contact', CONTACT_ID)
+
+const NAME = 'fld_fullName'
+const FIRST = 'fld_firstName'
+const LAST = 'fld_lastName'
+const EMAIL = 'fld_email'
+
+/** A SECOND NAME field on the same definition, over its own two parts. */
+const NAME2 = 'fld_billingName'
+const FIRST2 = 'fld_billingFirst'
+const LAST2 = 'fld_billingLast'
+
+/** A contact `full_name` NAME field linked to both part fields. */
+const NAME_FIELD = {
+  id: NAME,
+  type: 'NAME',
+  options: { name: { firstNameFieldId: FIRST, lastNameFieldId: LAST } },
+} as unknown as CachedField
+
+/** The same field with `options.name` never configured — nothing to compose. */
+const UNLINKED_NAME_FIELD = {
+  id: NAME,
+  type: 'NAME',
+  options: {},
+} as unknown as CachedField
+
+const CONTACT_RESOURCE = {
+  id: 'contact',
+  fields: [
+    {
+      id: NAME,
+      key: 'full_name',
+      fieldType: 'NAME',
+      options: { name: { firstNameFieldId: FIRST, lastNameFieldId: LAST } },
+    },
+    { id: FIRST, key: 'first_name', fieldType: 'TEXT', options: {} },
+    { id: LAST, key: 'last_name', fieldType: 'TEXT', options: {} },
+    { id: EMAIL, key: 'email', fieldType: 'TEXT', options: {} },
+  ],
+}
+
+/** The same definition with a second, independently linked NAME field. */
+const TWO_NAME_RESOURCE = {
+  id: 'contact',
+  fields: [
+    ...CONTACT_RESOURCE.fields,
+    {
+      id: NAME2,
+      key: 'billing_name',
+      fieldType: 'NAME',
+      options: { name: { firstNameFieldId: FIRST2, lastNameFieldId: LAST2 } },
+    },
+    { id: FIRST2, key: 'billing_first', fieldType: 'TEXT', options: {} },
+    { id: LAST2, key: 'billing_last', fieldType: 'TEXT', options: {} },
+  ],
+}
+
+/**
+ * Each awaited query resolves the next queued result set — the compose read is
+ * a SECOND query behind `getValues`' join, and the two have different shapes.
+ * The last set repeats, so a single-query path can be given one array.
+ */
+function fakeDb(...resultSets: unknown[][]) {
+  let issued = 0
+  const chain: Record<string, unknown> = {}
+  for (const method of ['select', 'from', 'innerJoin', 'where']) {
+    chain[method] = () => chain
+  }
+  chain.orderBy = () => {
+    const rows = resultSets[Math.min(issued, resultSets.length - 1)] ?? []
+    issued++
+    return Promise.resolve(rows)
+  }
+  return {
+    db: chain as unknown as FieldValueContext['db'],
+    queriesIssued: () => issued,
+  }
+}
+
+function context(db: FieldValueContext['db']): FieldValueContext {
+  return {
+    db,
+    organizationId: ORG,
+    fieldCache: new Map(),
+    batchRelationshipValidationCache: new Map(),
+    validator: {} as FieldValueContext['validator'],
+    bypassFieldGuards: new Set(),
+  }
+}
+
+/** A stored TEXT part row, as the compose query projects it. */
+function partRow(fieldId: string, value: string) {
+  return { fieldId, valueText: value }
+}
+
+/**
+ * A stray row ON the NAME field — what the pre-decomposition doors wrote and
+ * what §6 leaves in place. Shaped as a full `FieldValue` row so the legacy read
+ * path would happily turn it into a `json` value if it were ever reached.
+ */
+function strayNameRow(firstName: string, lastName: string) {
+  return {
+    id: 'fv_stray',
+    entityId: CONTACT_ID,
+    fieldId: NAME,
+    sortKey: 'a0',
+    valueText: null,
+    valueJson: { v: { firstName, lastName } },
+    createdAt: '2026-08-25T18:40:17.000Z',
+    updatedAt: '2026-08-25T18:40:17.000Z',
+  }
+}
+
+/** A stored TEXT row, as the `getValues` join returns it (unprojected). */
+function textRow(fieldId: string, value: string) {
+  return {
+    id: `fv_${fieldId}`,
+    entityId: CONTACT_ID,
+    fieldId,
+    sortKey: 'a0',
+    valueText: value,
+    createdAt: '2026-08-25T00:00:00.000Z',
+    updatedAt: '2026-08-25T00:00:00.000Z',
+  }
+}
+
+/** `getValues` joins CustomField, so its rows are `{ FieldValue, CustomField }`. */
+function joined(row: Record<string, unknown>, type: string) {
+  return { FieldValue: row, CustomField: { id: row.fieldId, type, options: {} } }
+}
+
+/** A part field's row on the `getValues` path. */
+function joinedPart(fieldId: string, value: string) {
+  return joined(textRow(fieldId, value), 'TEXT')
+}
+
+beforeEach(() => {
+  findCachedResource.mockReset().mockImplementation(async (_org: string, key: string) => {
+    return key === 'contact' ? CONTACT_RESOURCE : null
+  })
+  getCachedUserInstanceGrants.mockReset().mockResolvedValue({ userId: 'user_1' })
+})
+
+describe('getValue — NAME composes from its parts', () => {
+  it('returns the composed { firstName, lastName }', async () => {
+    const { db } = fakeDb([partRow(FIRST, 'Anita'), partRow(LAST, 'Bicknell')])
+
+    const result = await getValue(context(db), { recordId: CONTACT, fieldId: NAME }, NAME_FIELD)
+
+    // The converter's own output shape (`nameConverter.toTypedInput`), so an
+    // SDK/API reader sees no change now that the stored row is gone.
+    expect(result).toEqual({
+      id: '',
+      entityId: CONTACT_ID,
+      fieldId: NAME,
+      sortKey: '',
+      createdAt: '',
+      updatedAt: '',
+      type: 'json',
+      value: { firstName: 'Anita', lastName: 'Bicknell' },
+    })
+  })
+
+  it('IGNORES a stray row on the NAME field in favour of the parts', async () => {
+    // The exact §2 defect row: the composite the raw write stored says
+    // "Anita1 Bicknell1" while the part fields still hold "Anita Bicknell".
+    const { db, queriesIssued } = fakeDb([
+      strayNameRow('Anita1', 'Bicknell1'),
+      partRow(FIRST, 'Anita'),
+      partRow(LAST, 'Bicknell'),
+    ])
+
+    const result = await getValue(context(db), { recordId: CONTACT, fieldId: NAME }, NAME_FIELD)
+
+    expect(result).toMatchObject({ value: { firstName: 'Anita', lastName: 'Bicknell' } })
+    // One query — the parts. The NAME field's own row is never even selected.
+    expect(queriesIssued()).toBe(1)
+  })
+
+  it('composes with the other part empty when only one is set', async () => {
+    const { db } = fakeDb([partRow(FIRST, 'Anita')])
+
+    const result = await getValue(context(db), { recordId: CONTACT, fieldId: NAME }, NAME_FIELD)
+
+    expect(result).toMatchObject({ value: { firstName: 'Anita', lastName: '' } })
+  })
+
+  it('answers null when neither part is set — the normal "no value" result', async () => {
+    const { db } = fakeDb([])
+
+    expect(await getValue(context(db), { recordId: CONTACT, fieldId: NAME }, NAME_FIELD)).toBeNull()
+  })
+
+  it('answers null when both parts are set to the empty string', async () => {
+    const { db } = fakeDb([partRow(FIRST, ''), partRow(LAST, '')])
+
+    expect(await getValue(context(db), { recordId: CONTACT, fieldId: NAME }, NAME_FIELD)).toBeNull()
+  })
+
+  it('keeps pre-decomposition behavior for an UNLINKED NAME field, and never throws', async () => {
+    // No part ids to compose from, so the stored composite is all there is.
+    const { db, queriesIssued } = fakeDb([strayNameRow('Chicago', 'Person')])
+
+    const result = await getValue(
+      context(db),
+      { recordId: CONTACT, fieldId: NAME },
+      UNLINKED_NAME_FIELD
+    )
+
+    expect(result).toMatchObject({
+      type: 'json',
+      value: { firstName: 'Chicago', lastName: 'Person' },
+    })
+    // Net zero either way: composing SWAPS the SELECT, it does not add one.
+    expect(queriesIssued()).toBe(1)
+  })
+
+  it('takes the lowest-sortKey row when a part carries more than one', async () => {
+    // A misconfigured multi-value part is not a list to join. Rows arrive
+    // ordered by sortKey, so the first wins.
+    const { db } = fakeDb([partRow(FIRST, 'Anita'), partRow(FIRST, 'Anne'), partRow(LAST, 'B')])
+
+    const result = await getValue(context(db), { recordId: CONTACT, fieldId: NAME }, NAME_FIELD)
+
+    expect(result).toMatchObject({ value: { firstName: 'Anita', lastName: 'B' } })
+  })
+})
+
+describe('getValues — NAME composes from its parts, in ONE query', () => {
+  /**
+   * The point of this block is the QUERY COUNT. `getValues` resolves the part
+   * ids from the org cache BEFORE it queries and widens its own `IN` list with
+   * them, so composition never costs a second SELECT — not when `fieldIds` is
+   * omitted (the parts were already in the result set), and not when it is
+   * given (they ride the query that was being made anyway).
+   */
+
+  it('composes from the rows the join already returned — fieldIds omitted', async () => {
+    const { db, queriesIssued } = fakeDb([
+      joined(strayNameRow('Anita1', 'Bicknell1'), 'NAME'),
+      joinedPart(FIRST, 'Anita'),
+      joinedPart(LAST, 'Bicknell'),
+    ])
+
+    const values = await getValues(context(db), { recordId: CONTACT })
+
+    expect(values.get(NAME)).toMatchObject({
+      type: 'json',
+      value: { firstName: 'Anita', lastName: 'Bicknell' },
+    })
+    expect(queriesIssued()).toBe(1)
+  })
+
+  it('keeps the parts in the result when the caller asked for everything', async () => {
+    // `fieldIds` omitted means "every field", so the parts were requested and
+    // must appear in their own right alongside the composed NAME.
+    const { db } = fakeDb([joinedPart(FIRST, 'Anita'), joinedPart(LAST, 'Bicknell')])
+
+    const values = await getValues(context(db), { recordId: CONTACT })
+
+    expect(values.get(FIRST)).toMatchObject({ type: 'text', value: 'Anita' })
+    expect(values.get(LAST)).toMatchObject({ type: 'text', value: 'Bicknell' })
+  })
+
+  it('widens the query for an explicit NAME request — still one query', async () => {
+    // The caller named only `full_name`; the part rows come back because the
+    // `IN` list was widened, not because a second SELECT was issued.
+    const { db, queriesIssued } = fakeDb([joinedPart(FIRST, 'Anita'), joinedPart(LAST, 'Bicknell')])
+
+    const values = await getValues(context(db), { recordId: CONTACT, fieldIds: [NAME] })
+
+    expect(values.get(NAME)).toMatchObject({ value: { firstName: 'Anita', lastName: 'Bicknell' } })
+    expect(queriesIssued()).toBe(1)
+  })
+
+  it('does NOT leak the widened part ids into the result', async () => {
+    const { db } = fakeDb([joinedPart(FIRST, 'Anita'), joinedPart(LAST, 'Bicknell')])
+
+    const values = await getValues(context(db), { recordId: CONTACT, fieldIds: [NAME] })
+
+    expect([...values.keys()]).toEqual([NAME])
+  })
+
+  it('emits a part normally when the caller asked for it TOO, fetching it once', async () => {
+    const { db, queriesIssued } = fakeDb([joinedPart(FIRST, 'Anita'), joinedPart(LAST, 'Bicknell')])
+
+    const values = await getValues(context(db), { recordId: CONTACT, fieldIds: [NAME, FIRST] })
+
+    expect(values.get(NAME)).toMatchObject({ value: { firstName: 'Anita', lastName: 'Bicknell' } })
+    expect(values.get(FIRST)).toMatchObject({ type: 'text', value: 'Anita' })
+    // `last_name` was pulled in for composition only and stays out.
+    expect([...values.keys()].sort()).toEqual([FIRST, NAME].sort())
+    expect(queriesIssued()).toBe(1)
+  })
+
+  it('composes TWO NAME fields on one record in the same single query', async () => {
+    findCachedResource.mockResolvedValue(TWO_NAME_RESOURCE)
+    const { db, queriesIssued } = fakeDb([
+      joinedPart(FIRST, 'Anita'),
+      joinedPart(LAST, 'Bicknell'),
+      joinedPart(FIRST2, 'Ada'),
+      joinedPart(LAST2, 'Lovelace'),
+    ])
+
+    const values = await getValues(context(db), { recordId: CONTACT, fieldIds: [NAME, NAME2] })
+
+    expect(values.get(NAME)).toMatchObject({ value: { firstName: 'Anita', lastName: 'Bicknell' } })
+    expect(values.get(NAME2)).toMatchObject({ value: { firstName: 'Ada', lastName: 'Lovelace' } })
+    expect([...values.keys()].sort()).toEqual([NAME, NAME2].sort())
+    expect(queriesIssued()).toBe(1)
+  })
+
+  it('drops the stray row entirely when neither part is set', async () => {
+    const { db, queriesIssued } = fakeDb([joined(strayNameRow('Anita1', 'Bicknell1'), 'NAME')])
+
+    const values = await getValues(context(db), { recordId: CONTACT })
+
+    expect(values.has(NAME)).toBe(false)
+    expect(queriesIssued()).toBe(1)
+  })
+
+  it('leaves every other field on the record untouched', async () => {
+    const { db } = fakeDb([joinedPart(EMAIL, 'a@b.c'), joinedPart(FIRST, 'Anita')])
+
+    const values = await getValues(context(db), { recordId: CONTACT })
+
+    expect(values.get(EMAIL)).toMatchObject({ type: 'text', value: 'a@b.c' })
+    expect(values.get(NAME)).toMatchObject({ value: { firstName: 'Anita', lastName: '' } })
+  })
+
+  it('issues one query when the definition has no NAME field', async () => {
+    findCachedResource.mockResolvedValue({ id: 'contact', fields: [CONTACT_RESOURCE.fields[3]] })
+    const { db, queriesIssued } = fakeDb([joinedPart(EMAIL, 'a@b.c')])
+
+    await getValues(context(db), { recordId: CONTACT })
+
+    expect(queriesIssued()).toBe(1)
+  })
+
+  it('does not widen for a NAME field the caller did not ask for', async () => {
+    const { db, queriesIssued } = fakeDb([joinedPart(EMAIL, 'a@b.c')])
+
+    const values = await getValues(context(db), { recordId: CONTACT, fieldIds: [EMAIL] })
+
+    expect(values.has(NAME)).toBe(false)
+    expect([...values.keys()]).toEqual([EMAIL])
+    expect(queriesIssued()).toBe(1)
+  })
+})

--- a/packages/lib/src/field-values/__tests__/name-decomposition.test.ts
+++ b/packages/lib/src/field-values/__tests__/name-decomposition.test.ts
@@ -1,0 +1,905 @@
+// packages/lib/src/field-values/__tests__/name-decomposition.test.ts
+//
+// NAME composite decomposition at the server chokepoint
+// (plans/field-values/name-field-writes.md Phase 1 / §4a–§4d).
+//
+// A NAME field is a COMPOSITE over two TEXT part fields and owns no storage of
+// its own: `setValueWithBuiltIn` fans every set-shaped write out to the two
+// parts, so no door — tRPC set/setBulk, the API set-values route, the SDK, the
+// importer, `record.create`, workflows, Kopilot, AI commits — can leave a stray
+// row on the NAME field again. These tests pin one write per door plus the
+// coercion breadth (§4d), the unlinked-field fallback (§4), the NAME-plus-part
+// collision rule (§4b) and the return contract (§4c).
+
+import { toRecordId } from '@auxx/types/resource'
+
+// Mock '../../realtime/publish-helpers' directly — NOT the '../../realtime'
+// barrel (see batched-realtime-publish.test.ts for the import-cycle rationale).
+vi.mock('../../realtime/publish-helpers', () => ({
+  publishFieldValueUpdates: vi.fn(),
+}))
+
+// '../../cache' is a large barrel with real DB/Redis-backed providers. Mock it
+// wholesale; the entry points this suite's code path touches are
+// `getCachedFieldMap`/`getCachedResource` (field-value-mutations) and
+// `getOrgCache` (resolveFieldIds / getField).
+vi.mock('../../cache', () => ({
+  getCachedFieldMap: vi.fn(),
+  getCachedResource: vi.fn(),
+  getOrgCache: vi.fn(),
+  getAllCachedCustomFields: vi.fn(async () => []),
+  getCachedRecordRules: vi.fn(async () => []),
+  // Reached only on the display-recompute path, via `getDisplayFieldDeps`.
+  // Empty = this org has no dependent entities, so no cascade.
+  getCachedResources: vi.fn(async () => []),
+}))
+
+// No post-hooks/pre-hooks: this suite is about WHERE the rows land, not about
+// the hook chain (set-idempotency.test.ts owns that).
+vi.mock('../../field-hooks/registry', () => ({
+  hasEntityFieldChangeHooks: vi.fn(() => false),
+  hasFieldTypeChangeHooks: vi.fn(() => false),
+  hasFieldPreHooks: vi.fn(() => false),
+  getEntityFieldChangeHooks: vi.fn(() => []),
+  getFieldTypeChangeHooks: vi.fn(() => []),
+  getFieldPreHooks: vi.fn(() => []),
+}))
+
+vi.mock('../../field-hooks/collect-triggers', () => ({
+  collectTriggeredFields: vi.fn(async () => []),
+  deduplicateBySystemAttribute: vi.fn((fields: unknown[]) => fields),
+}))
+vi.mock('../../field-hooks/publish', () => ({
+  publishFieldTriggerEvents: vi.fn(async () => {}),
+  publishBatchFieldTriggerEvents: vi.fn(async () => {}),
+}))
+
+// The unlinked-NAME fallback must WARN, never throw. Intercept only the
+// `field-value-mutations` scope and leave every other scoped logger real (a
+// full-replacement mock of a shared module is a footgun here).
+const { loggerWarn } = vi.hoisted(() => ({ loggerWarn: vi.fn() }))
+vi.mock('@auxx/logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@auxx/logger')>()
+  return {
+    ...actual,
+    createScopedLogger: (scope: string) =>
+      scope === 'field-value-mutations'
+        ? { ...actual.createScopedLogger(scope), warn: loggerWarn }
+        : actual.createScopedLogger(scope),
+  }
+})
+
+// Post-write ownership (one stamp + one searchText rebuild per composite
+// write) is counted, not inspected. Both modules are PARTIALLY mocked via
+// `importOriginal` — a full replacement of either would strand the rest of the
+// write path. `updateSearchText` is spied here rather than at its call sites
+// because `field-value-helpers` imports the same module, so this counts EVERY
+// rebuild a write triggers, from whichever frame.
+const { searchTextSpy, stampSpy } = vi.hoisted(() => ({
+  searchTextSpy: vi.fn(async () => {}),
+  stampSpy: vi.fn(async () => {}),
+}))
+vi.mock('../search-text', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../search-text')>()),
+  updateSearchText: searchTextSpy,
+}))
+vi.mock('../field-value-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../field-value-helpers')>()),
+  stampEntityInstanceUpdatedAt: stampSpy,
+}))
+
+vi.mock('../timeline-snapshot', () => ({
+  preloadSnapshotCache: vi.fn(),
+  resolveFieldChangeSnapshotPair: vi.fn(async () => ({ oldDisplay: null, newDisplay: null })),
+  resolveFieldChangeSnapshotsBulk: vi.fn(async () => new Map()),
+}))
+
+import { getCachedFieldMap, getCachedResource, getOrgCache } from '../../cache'
+import { publishFieldValueUpdates } from '../../realtime/publish-helpers'
+import { createFieldValueContext, type FieldValueContext } from '../field-value-helpers'
+import {
+  applyBulk,
+  setBulkValues,
+  setValuesForEntity,
+  setValueWithBuiltIn,
+} from '../field-value-mutations'
+
+const mockedGetCachedResource = getCachedResource as unknown as ReturnType<typeof vi.fn>
+const mockedGetCachedFieldMap = getCachedFieldMap as unknown as ReturnType<typeof vi.fn>
+const mockedGetOrgCache = getOrgCache as unknown as ReturnType<typeof vi.fn>
+const mockedPublish = vi.mocked(publishFieldValueUpdates)
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const recordId = toRecordId('widget', 'inst-1')
+
+/** Minimal CustomField-shaped fixture (same shape as the sibling suites). */
+function fieldFixture(id: string, type: string, options: Record<string, unknown> = {}) {
+  return {
+    id,
+    type,
+    options,
+    entityDefinitionId: null,
+    entityDefinition: null,
+    entityType: null,
+    isUnique: false,
+    systemAttribute: null,
+  }
+}
+
+// Part ids are deliberately ordered so the last-name part sorts BEFORE the
+// first-name part by fieldId — that is what makes the deterministic
+// lock-ordering sort in the decomposition observable.
+const FIELD_FIRST = fieldFixture('field-a-first', 'TEXT')
+const FIELD_LAST = fieldFixture('field-b-last', 'TEXT')
+const FIELD_NAME = fieldFixture('field-z-name', 'NAME', {
+  name: { firstNameFieldId: FIELD_FIRST.id, lastNameFieldId: FIELD_LAST.id },
+})
+const FIELD_NAME_UNLINKED = fieldFixture('field-z-name-unlinked', 'NAME')
+const ALL_FIELDS = [FIELD_FIRST, FIELD_LAST, FIELD_NAME, FIELD_NAME_UNLINKED]
+
+/**
+ * Chainable `ctx.db` fake. Drizzle's `schema.*` column refs are `{}` under this
+ * repo's vitest setup (see project memory), so the fake ignores every `where()`
+ * argument: reads always resolve to `existingRows` and writes are recorded in
+ * order. Every test here starts from an EMPTY store, so each part write is an
+ * INSERT and `insertedRows` is the ordered ledger of what landed where.
+ */
+function makeFakeDb(existingRows: any[] = []) {
+  let idSeq = 0
+  let pendingValues: any[] = []
+  const state = {
+    deleteCalls: 0,
+    insertCalls: 0,
+    updateCalls: 0,
+    insertedRows: [] as any[],
+    updatedPayloads: [] as any[],
+    /**
+     * `select({ valueText })` — the single-column sibling read inside
+     * `resolveNameFieldDisplayValue`, and the only projection of that shape
+     * anywhere in the package. Counting it is what pins "a decomposed write
+     * reads neither part back".
+     */
+    siblingSelects: 0,
+  }
+  const chain: any = {}
+  Object.assign(chain, {
+    delete: () => {
+      state.deleteCalls++
+      return chain
+    },
+    where: () => chain,
+    insert: () => {
+      state.insertCalls++
+      return chain
+    },
+    values: (rows: any) => {
+      pendingValues = Array.isArray(rows) ? rows : [rows]
+      state.insertedRows.push(...pendingValues)
+      return chain
+    },
+    onConflictDoUpdate: () => chain,
+    returning: () =>
+      Promise.resolve(
+        pendingValues.map((row) => ({
+          id: `fv-new-${idSeq++}`,
+          createdAt: '2026-02-01T00:00:00.000Z',
+          updatedAt: '2026-02-01T00:00:00.000Z',
+          ...row,
+        }))
+      ),
+    select: (projection?: any) => {
+      if (projection && Object.keys(projection).length === 1 && 'valueText' in projection) {
+        state.siblingSelects++
+      }
+      return chain
+    },
+    from: () => chain,
+    orderBy: () => Promise.resolve(existingRows),
+    // Terminal for the sibling read; never reached once the decomposition
+    // owns the recompute.
+    limit: () => Promise.resolve([]),
+    update: () => {
+      state.updateCalls++
+      return chain
+    },
+    set: (payload: any) => {
+      state.updatedPayloads.push(payload)
+      return chain
+    },
+    transaction: async (fn: (tx: any) => Promise<any>) => fn(chain),
+    execute: () => Promise.resolve([]),
+  })
+  return { db: chain, state }
+}
+
+/** Context with a REAL userId so the post-hook / field-trigger gates are open. */
+function makeCtx(db: any, fields: Array<{ id: string }>): FieldValueContext {
+  const ctx = createFieldValueContext('org-1', 'user-1', db, 'socket-abc')
+  for (const f of fields) ctx.fieldCache.set(f.id, f as any)
+  return ctx
+}
+
+/** The (fieldId, valueText) pairs the fake recorded, in write order. */
+function writes(state: { insertedRows: any[] }): Array<{ fieldId: string; value: unknown }> {
+  return state.insertedRows.map((r) => ({ fieldId: r.fieldId, value: r.valueText }))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockedGetCachedResource.mockResolvedValue(undefined)
+  mockedPublish.mockResolvedValue(undefined)
+  mockedGetCachedFieldMap.mockResolvedValue(new Map(ALL_FIELDS.map((f) => [f.id, f])))
+  // resolveFieldIds needs `.from(orgId, 'customFields').all()`; getField's
+  // cache-miss fallback needs `.byId()` (never hit — fieldCache is pre-warmed).
+  mockedGetOrgCache.mockReturnValue({
+    from: () => ({ all: async () => ({}), byId: async () => undefined }),
+  })
+})
+
+// =============================================================================
+// Door 1 — direct `setValueWithBuiltIn` (tRPC `fieldValue.set`, API set-values,
+// SDK, workflows, Kopilot)
+// =============================================================================
+
+describe('NAME decomposition — direct setValueWithBuiltIn', () => {
+  it('writes both parts and ZERO rows on the NAME field', async () => {
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, ALL_FIELDS)
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: FIELD_NAME.id,
+      value: { firstName: 'Anita', lastName: 'Bicknell' },
+    })
+
+    expect(writes(state)).toEqual([
+      { fieldId: FIELD_FIRST.id, value: 'Anita' },
+      { fieldId: FIELD_LAST.id, value: 'Bicknell' },
+    ])
+    expect(state.insertedRows.some((r) => r.fieldId === FIELD_NAME.id)).toBe(false)
+  })
+
+  it('orders the two part writes by fieldId ascending (deadlock-free lock order)', async () => {
+    // The fixture links firstName → 'field-a-first' and lastName →
+    // 'field-b-last', so ascending fieldId happens to be first-then-last; flip
+    // the link and the write order must flip with it, proving the order comes
+    // from the sort and not from the literal order of the two part writes.
+    const flipped = fieldFixture('field-z-name-flipped', 'NAME', {
+      name: { firstNameFieldId: FIELD_LAST.id, lastNameFieldId: FIELD_FIRST.id },
+    })
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, [...ALL_FIELDS, flipped])
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: flipped.id,
+      value: { firstName: 'Anita', lastName: 'Bicknell' },
+    })
+
+    expect(writes(state)).toEqual([
+      // 'field-a-first' now holds the LAST name, and still sorts first.
+      { fieldId: FIELD_FIRST.id, value: 'Bicknell' },
+      { fieldId: FIELD_LAST.id, value: 'Anita' },
+    ])
+  })
+
+  it('§4c: returns no values under the NAME fieldId, with an honest `changed`', async () => {
+    const { db } = makeFakeDb()
+    const ctx = makeCtx(db, ALL_FIELDS)
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: FIELD_NAME.id,
+      value: { firstName: 'Anita', lastName: 'Bicknell' },
+    })
+
+    expect(result.state).toBe('complete')
+    expect(result.values).toEqual([])
+    expect(result.changed).toBe(true)
+  })
+
+  it('§4c: reports `changed: false` when neither part moved', async () => {
+    // B-14: clearing a field with no stored rows is a no-op on BOTH parts, so
+    // the composite reports no change and the D-7 stamp upstream stays silent.
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, ALL_FIELDS)
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: FIELD_NAME.id,
+      value: null,
+    })
+
+    expect(result.values).toEqual([])
+    expect(result.changed).toBe(false)
+    expect(state.insertCalls).toBe(0)
+    expect(state.deleteCalls).toBe(0)
+  })
+})
+
+// =============================================================================
+// §4d — coercion breadth: every shape `nameConverter` accepts today
+// =============================================================================
+
+describe('NAME decomposition — input coercion (§4d)', () => {
+  it('a bare full-name STRING splits into the two parts', async () => {
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, ALL_FIELDS)
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: FIELD_NAME.id,
+      value: 'Anita Bicknell',
+    })
+
+    expect(writes(state)).toEqual([
+      { fieldId: FIELD_FIRST.id, value: 'Anita' },
+      { fieldId: FIELD_LAST.id, value: 'Bicknell' },
+    ])
+  })
+
+  it('an already-typed `json` value decomposes too', async () => {
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, ALL_FIELDS)
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: FIELD_NAME.id,
+      value: { type: 'json', value: { firstName: 'Anita', lastName: 'Bicknell' } },
+    })
+
+    expect(writes(state)).toEqual([
+      { fieldId: FIELD_FIRST.id, value: 'Anita' },
+      { fieldId: FIELD_LAST.id, value: 'Bicknell' },
+    ])
+  })
+
+  it('null clears BOTH parts', async () => {
+    const rows = [
+      {
+        id: 'fv-first',
+        entityId: 'inst-1',
+        entityDefinitionId: 'widget',
+        fieldId: FIELD_FIRST.id,
+        organizationId: 'org-1',
+        valueText: 'Anita',
+        valueNumber: null,
+        valueBoolean: null,
+        valueDate: null,
+        valueJson: null,
+        optionId: null,
+        relatedEntityId: null,
+        relatedEntityDefinitionId: null,
+        actorId: null,
+        aiStatus: null,
+        sortKey: 'a0',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]
+    // The fake ignores `where`, so BOTH part reads see this row — which is
+    // exactly what "there is something to clear on each part" needs here.
+    const { db, state } = makeFakeDb(rows)
+    const ctx = makeCtx(db, ALL_FIELDS)
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: FIELD_NAME.id,
+      value: null,
+    })
+
+    // One DELETE per part, nothing inserted, and no row on the NAME field.
+    expect(state.deleteCalls).toBe(2)
+    expect(state.insertCalls).toBe(0)
+    expect(result.changed).toBe(true)
+  })
+
+  it('a blank string clears both parts (converter maps blank to null)', async () => {
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, ALL_FIELDS)
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: FIELD_NAME.id,
+      value: '   ',
+    })
+
+    expect(state.insertCalls).toBe(0)
+    expect(result.changed).toBe(false)
+  })
+})
+
+// =============================================================================
+// §4 — an unlinked NAME field must never throw
+// =============================================================================
+
+describe('NAME decomposition — unlinked NAME field (§4)', () => {
+  it('falls back to the raw store, warns, and does not throw', async () => {
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, ALL_FIELDS)
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: FIELD_NAME_UNLINKED.id,
+      value: { firstName: 'Anita', lastName: 'Bicknell' },
+    })
+
+    // Pre-decomposition behavior: the composite lands on the NAME field's own
+    // row as `valueJson`.
+    expect(state.insertedRows).toHaveLength(1)
+    expect(state.insertedRows[0]!.fieldId).toBe(FIELD_NAME_UNLINKED.id)
+    expect(state.insertedRows[0]!.valueJson).toMatchObject({
+      v: { firstName: 'Anita', lastName: 'Bicknell' },
+    })
+    expect(result.values).toHaveLength(1)
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'NAME field has no linked part fields; storing the composite raw',
+      expect.objectContaining({ fieldId: FIELD_NAME_UNLINKED.id })
+    )
+  })
+
+  it('a half-linked NAME field (one part id only) also falls back', async () => {
+    const half = fieldFixture('field-z-name-half', 'NAME', {
+      name: { firstNameFieldId: FIELD_FIRST.id },
+    })
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, [...ALL_FIELDS, half])
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: half.id,
+      value: { firstName: 'Anita', lastName: 'Bicknell' },
+    })
+
+    expect(state.insertedRows).toHaveLength(1)
+    expect(state.insertedRows[0]!.fieldId).toBe(half.id)
+  })
+})
+
+// =============================================================================
+// Door 2 — `setValuesForEntity` (record create/update via
+// `resources/crud/unified-handler.ts`, the importer, multi-field saves)
+// =============================================================================
+
+describe('NAME decomposition — setValuesForEntity door', () => {
+  it('decomposes and reports the result under the NAME fieldId with no values', async () => {
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, ALL_FIELDS)
+
+    const results = await setValuesForEntity(ctx, {
+      recordId,
+      values: [{ fieldId: FIELD_NAME.id, value: { firstName: 'Anita', lastName: 'Bicknell' } }],
+    })
+
+    expect(writes(state)).toEqual([
+      { fieldId: FIELD_FIRST.id, value: 'Anita' },
+      { fieldId: FIELD_LAST.id, value: 'Bicknell' },
+    ])
+    expect(results).toHaveLength(1)
+    expect(results[0]!.fieldId).toBe(FIELD_NAME.id)
+    expect(results[0]!.values).toEqual([])
+    expect(results[0]!.changed).toBe(true)
+  })
+
+  it('§4b: an explicit part write in the same op WINS over the composite', async () => {
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, ALL_FIELDS)
+
+    // Input order deliberately puts the part FIRST; the two-level sort key
+    // (`isNameField ? 0 : 1`, then fieldId) must still run the composite first
+    // so the explicit part write lands last.
+    await setValuesForEntity(ctx, {
+      recordId,
+      values: [
+        { fieldId: FIELD_FIRST.id, value: 'Explicit' },
+        { fieldId: FIELD_NAME.id, value: { firstName: 'Anita', lastName: 'Bicknell' } },
+      ],
+    })
+
+    expect(writes(state)).toEqual([
+      { fieldId: FIELD_FIRST.id, value: 'Anita' },
+      { fieldId: FIELD_LAST.id, value: 'Bicknell' },
+      { fieldId: FIELD_FIRST.id, value: 'Explicit' },
+    ])
+  })
+
+  it('§4b: the part keys are invalidated in the batched pre-read, not the NAME key', async () => {
+    const { db } = makeFakeDb()
+    const ctx = makeCtx(db, ALL_FIELDS)
+
+    const preloadedSetRows = new Map<string, any[]>([
+      [`inst-1:${FIELD_NAME.id}`, []],
+      [`inst-1:${FIELD_FIRST.id}`, []],
+      [`inst-1:${FIELD_LAST.id}`, []],
+    ])
+
+    await setValuesForEntity(ctx, {
+      recordId,
+      values: [{ fieldId: FIELD_NAME.id, value: { firstName: 'Anita', lastName: 'Bicknell' } }],
+      preloadedSetRows,
+    })
+
+    // Both part snapshots were written through, so both must be gone; the NAME
+    // key is cleared too (harmless — nothing ever writes it).
+    expect(preloadedSetRows.has(`inst-1:${FIELD_FIRST.id}`)).toBe(false)
+    expect(preloadedSetRows.has(`inst-1:${FIELD_LAST.id}`)).toBe(false)
+    expect(preloadedSetRows.has(`inst-1:${FIELD_NAME.id}`)).toBe(false)
+  })
+})
+
+// =============================================================================
+// Door 3 — `setBulkValues` / `applyBulk` (grid paste, bulk-update dialog)
+// =============================================================================
+
+describe('NAME decomposition — bulk door', () => {
+  it('setBulkValues decomposes for every record', async () => {
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, ALL_FIELDS)
+
+    await setBulkValues(ctx, {
+      recordIds: [toRecordId('widget', 'inst-1'), toRecordId('widget', 'inst-2')],
+      values: [{ fieldId: FIELD_NAME.id, value: 'Anita Bicknell' }],
+    })
+
+    expect(state.insertedRows.some((r) => r.fieldId === FIELD_NAME.id)).toBe(false)
+    const byEntity = new Map<string, string[]>()
+    for (const row of state.insertedRows) {
+      byEntity.set(row.entityId, [...(byEntity.get(row.entityId) ?? []), row.fieldId])
+    }
+    expect(byEntity.get('inst-1')).toEqual([FIELD_FIRST.id, FIELD_LAST.id])
+    expect(byEntity.get('inst-2')).toEqual([FIELD_FIRST.id, FIELD_LAST.id])
+  })
+
+  it('applyBulk with the default `set` mode decomposes', async () => {
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, ALL_FIELDS)
+
+    await applyBulk(ctx, {
+      recordIds: [recordId],
+      values: [{ fieldId: FIELD_NAME.id, value: { firstName: 'Anita', lastName: 'Bicknell' } }],
+    })
+
+    expect(writes(state)).toEqual([
+      { fieldId: FIELD_FIRST.id, value: 'Anita' },
+      { fieldId: FIELD_LAST.id, value: 'Bicknell' },
+    ])
+  })
+
+  it("applyBulk `mode: 'add'` on a NAME field still 400s, like every other single-valued type", async () => {
+    // NAME is not in `MULTI_VALUE_FIELD_TYPES`, so `addValuesBulk`'s guard
+    // rejects it — deliberately left alone. The "decompose silently, never
+    // reject" decision is scoped to SET-shaped writes; `add` on a
+    // single-valued field is a semantically wrong request and gets honest
+    // feedback (plans/field-values/name-field-writes.md §3).
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, ALL_FIELDS)
+
+    await expect(
+      applyBulk(ctx, {
+        recordIds: [recordId],
+        values: [{ fieldId: FIELD_NAME.id, mode: 'add', value: 'Anita Bicknell' }],
+      })
+    ).rejects.toThrow(/not multi-value/)
+
+    expect(state.insertedRows).toHaveLength(0)
+  })
+})
+
+// =============================================================================
+// Post-write ownership: ONE stamp + ONE searchText rebuild per composite write
+// =============================================================================
+
+/**
+ * Part fields with a real `entityDefinition`, so `maybeUpdateDisplayValue`
+ * runs past its `if (!entityDef) return` guard and reaches the searchText
+ * refresh a TEXT (indexed-type) write would otherwise trigger per part. The
+ * shared fixtures above carry `entityDefinition: null` and would make these
+ * assertions pass vacuously.
+ */
+const ENTITY_DEF = {
+  id: 'widget',
+  primaryDisplayFieldId: null,
+  secondaryDisplayFieldId: null,
+  avatarFieldId: null,
+}
+const PART_FIRST = { ...fieldFixture('field-c-first', 'TEXT'), entityDefinition: ENTITY_DEF }
+const PART_LAST = { ...fieldFixture('field-d-last', 'TEXT'), entityDefinition: ENTITY_DEF }
+const NAME_OVER_PARTS = fieldFixture('field-z-name-owned', 'NAME', {
+  name: { firstNameFieldId: PART_FIRST.id, lastNameFieldId: PART_LAST.id },
+})
+// Link reversed: `field-c-first` now holds the LAST name, so the part that
+// sorts FIRST by fieldId is the one a single-word name leaves untouched.
+const NAME_FLIPPED = fieldFixture('field-z-name-owned-flipped', 'NAME', {
+  name: { firstNameFieldId: PART_LAST.id, lastNameFieldId: PART_FIRST.id },
+})
+const OWNED_FIELDS = [PART_FIRST, PART_LAST, NAME_OVER_PARTS, NAME_FLIPPED]
+
+describe('NAME decomposition — post-write ownership', () => {
+  it('the single-set door stamps ONCE and rebuilds searchText ONCE, not twice', async () => {
+    const { db } = makeFakeDb()
+    const ctx = makeCtx(db, OWNED_FIELDS)
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: NAME_OVER_PARTS.id,
+      value: { firstName: 'Anita', lastName: 'Bicknell' },
+    })
+
+    // Two part writes landed, but the post-write work ran exactly once — the
+    // parts were handed `skipInstanceStamp` / `skipSearchTextRefresh`.
+    expect(stampSpy).toHaveBeenCalledTimes(1)
+    expect(searchTextSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('nested under a caller that owns both, the NAME frame stamps and flushes nothing', async () => {
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, OWNED_FIELDS)
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: NAME_OVER_PARTS.id,
+      value: { firstName: 'Anita', lastName: 'Bicknell' },
+      skipInstanceStamp: true,
+      skipSearchTextRefresh: true,
+    })
+
+    // The write itself still happened; only the derived work is the caller's.
+    expect(state.insertedRows).toHaveLength(2)
+    expect(stampSpy).not.toHaveBeenCalled()
+    expect(searchTextSpy).not.toHaveBeenCalled()
+  })
+
+  it('EITHER part changing is enough — when only the FIRST-written part moves', async () => {
+    // A single-word name coerces to `{firstName: 'Anita', lastName: ''}`; the
+    // blank part is a B-14 clear-of-absent no-op against the empty store. By
+    // fieldId order `field-c-first` (the first name here) is written FIRST, so
+    // the LAST part write reports `changed: false`.
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, OWNED_FIELDS)
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: NAME_OVER_PARTS.id,
+      value: 'Anita',
+    })
+
+    expect(writes(state)).toEqual([{ fieldId: PART_FIRST.id, value: 'Anita' }])
+    expect(result.changed).toBe(true)
+    expect(stampSpy).toHaveBeenCalledTimes(1)
+    expect(searchTextSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('EITHER part changing is enough — when only the LAST-written part moves', async () => {
+    // Same input over the reversed link: `field-c-first` now receives the
+    // blank last name and no-ops, and the change lands on the part written
+    // second. `partChanged` must survive the earlier `false`.
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, OWNED_FIELDS)
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: NAME_FLIPPED.id,
+      value: 'Anita',
+    })
+
+    expect(writes(state)).toEqual([{ fieldId: PART_LAST.id, value: 'Anita' }])
+    expect(result.changed).toBe(true)
+    expect(stampSpy).toHaveBeenCalledTimes(1)
+    expect(searchTextSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('a pure no-op composite write stamps nothing and rebuilds nothing', async () => {
+    const { db } = makeFakeDb()
+    const ctx = makeCtx(db, OWNED_FIELDS)
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: NAME_OVER_PARTS.id,
+      value: null,
+    })
+
+    expect(result.changed).toBe(false)
+    expect(stampSpy).not.toHaveBeenCalled()
+    expect(searchTextSpy).not.toHaveBeenCalled()
+  })
+})
+
+// =============================================================================
+// The NAME-composed `displayName`: ONE recompute, ZERO sibling reads
+// =============================================================================
+
+/**
+ * `displayName` writes the fake recorded, in order. The display UPDATE carries
+ * `{ displayName, updatedAt }`; the bare D-7 stamp carries `{ updatedAt }`
+ * alone, and a FieldValue reconcile carries value columns — so filtering on
+ * the key counts display-column writes exactly.
+ */
+function displayWrites(state: { updatedPayloads: any[] }): Array<string | null> {
+  return state.updatedPayloads.filter((p) => 'displayName' in p).map((p) => p.displayName)
+}
+
+const DISPLAY_NAME_ID = 'field-z-name-display'
+const DISPLAY_DEF = {
+  id: 'widget',
+  primaryDisplayFieldId: DISPLAY_NAME_ID,
+  secondaryDisplayFieldId: null,
+  avatarFieldId: null,
+}
+const DISP_FIRST = { ...fieldFixture('field-e-first', 'TEXT'), entityDefinition: DISPLAY_DEF }
+const DISP_LAST = { ...fieldFixture('field-f-last', 'TEXT'), entityDefinition: DISPLAY_DEF }
+const DISPLAY_NAME_FIELD = {
+  ...fieldFixture(DISPLAY_NAME_ID, 'NAME', {
+    name: { firstNameFieldId: DISP_FIRST.id, lastNameFieldId: DISP_LAST.id },
+  }),
+  entityDefinition: DISPLAY_DEF,
+}
+
+// Reversed link, and the primary display field of its own definition — so the
+// part that sorts FIRST by fieldId receives the LAST name.
+const FLIPPED_DISPLAY_ID = 'field-z-name-display-flipped'
+const FLIPPED_DEF = { ...DISPLAY_DEF, primaryDisplayFieldId: FLIPPED_DISPLAY_ID }
+const FLIPPED_DISPLAY_FIELD = {
+  ...fieldFixture(FLIPPED_DISPLAY_ID, 'NAME', {
+    name: { firstNameFieldId: DISP_LAST.id, lastNameFieldId: DISP_FIRST.id },
+  }),
+  entityDefinition: FLIPPED_DEF,
+}
+
+// A linked NAME field that is NOT its definition's primary display field —
+// the record is titled by a plain TEXT field instead.
+const TITLE_FIELD = fieldFixture('field-g-title', 'TEXT')
+const NON_PRIMARY_DEF = { ...DISPLAY_DEF, primaryDisplayFieldId: TITLE_FIELD.id }
+const NON_PRIMARY_NAME_FIELD = {
+  ...fieldFixture('field-z-name-non-primary', 'NAME', {
+    name: { firstNameFieldId: DISP_FIRST.id, lastNameFieldId: DISP_LAST.id },
+  }),
+  entityDefinition: NON_PRIMARY_DEF,
+}
+
+const DISPLAY_FIELDS = [
+  DISP_FIRST,
+  DISP_LAST,
+  TITLE_FIELD,
+  DISPLAY_NAME_FIELD,
+  FLIPPED_DISPLAY_FIELD,
+  NON_PRIMARY_NAME_FIELD,
+]
+
+describe('NAME decomposition — composed displayName', () => {
+  it('both parts change: ONE displayName write, ZERO sibling SELECTs', async () => {
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, DISPLAY_FIELDS)
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: DISPLAY_NAME_ID,
+      value: { firstName: 'Anita', lastName: 'Bicknell' },
+    })
+
+    // Before this change each part write recomposed for itself: two sibling
+    // reads and two display UPDATEs, the second read re-reading the row the
+    // first write had just committed.
+    expect(state.siblingSelects).toBe(0)
+    expect(displayWrites(state)).toEqual(['Anita Bicknell'])
+  })
+
+  it('the display write carries the stamp, so no second bare UPDATE is issued', async () => {
+    const { db } = makeFakeDb()
+    const ctx = makeCtx(db, DISPLAY_FIELDS)
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: DISPLAY_NAME_ID,
+      value: { firstName: 'Anita', lastName: 'Bicknell' },
+    })
+
+    // `displayName` and `updatedAt` go in one statement; a separate D-7 stamp
+    // would be a second UPDATE on the same row for the same reason.
+    expect(stampSpy).not.toHaveBeenCalled()
+    // The searchText flush is still this frame's, and still fires once.
+    expect(searchTextSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('only the FIRST-written part changes: displayName still recomputes', async () => {
+    // The reported shape: `Anita Smith` → `Bob Smith` leaves `last_name`
+    // byte-identical, so the second part write is a D-6 no-op. A single-word
+    // name reproduces it against an empty store — `lastName` coerces to `''`
+    // and B-14 no-ops. Hanging the recompute off the last write would strand
+    // `displayName` here.
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, DISPLAY_FIELDS)
+
+    await setValueWithBuiltIn(ctx, { recordId, fieldId: DISPLAY_NAME_ID, value: 'Anita' })
+
+    expect(writes(state)).toEqual([{ fieldId: DISP_FIRST.id, value: 'Anita' }])
+    expect(displayWrites(state)).toEqual(['Anita'])
+    expect(state.siblingSelects).toBe(0)
+  })
+
+  it('only the LAST-written part changes: displayName still recomputes', async () => {
+    // Same input over the reversed link — the change now lands on the part
+    // written second, so `partChanged` has to survive the earlier `false`.
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, DISPLAY_FIELDS)
+
+    await setValueWithBuiltIn(ctx, { recordId, fieldId: FLIPPED_DISPLAY_ID, value: 'Anita' })
+
+    expect(writes(state)).toEqual([{ fieldId: DISP_LAST.id, value: 'Anita' }])
+    expect(displayWrites(state)).toEqual(['Anita'])
+    expect(state.siblingSelects).toBe(0)
+  })
+
+  it('both parts no-op: no recompute, no display write, no stamp', async () => {
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, DISPLAY_FIELDS)
+
+    const result = await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: DISPLAY_NAME_ID,
+      value: null,
+    })
+
+    expect(result.changed).toBe(false)
+    expect(displayWrites(state)).toEqual([])
+    expect(state.siblingSelects).toBe(0)
+    expect(stampSpy).not.toHaveBeenCalled()
+    expect(searchTextSpy).not.toHaveBeenCalled()
+  })
+
+  it('clearing a composed name writes displayName = null exactly once', async () => {
+    const rows = [
+      {
+        id: 'fv-first',
+        entityId: 'inst-1',
+        entityDefinitionId: 'widget',
+        fieldId: DISP_FIRST.id,
+        organizationId: 'org-1',
+        valueText: 'Anita',
+        valueNumber: null,
+        valueBoolean: null,
+        valueDate: null,
+        valueJson: null,
+        optionId: null,
+        relatedEntityId: null,
+        relatedEntityDefinitionId: null,
+        actorId: null,
+        aiStatus: null,
+        sortKey: 'a0',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]
+    const { db, state } = makeFakeDb(rows)
+    const ctx = makeCtx(db, DISPLAY_FIELDS)
+
+    await setValueWithBuiltIn(ctx, { recordId, fieldId: DISPLAY_NAME_ID, value: null })
+
+    expect(displayWrites(state)).toEqual([null])
+    expect(state.siblingSelects).toBe(0)
+  })
+
+  it('a NAME field that is NOT the primary display field recomputes nothing', async () => {
+    const { db, state } = makeFakeDb()
+    const ctx = makeCtx(db, DISPLAY_FIELDS)
+
+    await setValueWithBuiltIn(ctx, {
+      recordId,
+      fieldId: NON_PRIMARY_NAME_FIELD.id,
+      value: { firstName: 'Anita', lastName: 'Bicknell' },
+    })
+
+    // The parts still land; only the display column stays untouched — the same
+    // answer a direct part write gives today.
+    expect(writes(state)).toEqual([
+      { fieldId: DISP_FIRST.id, value: 'Anita' },
+      { fieldId: DISP_LAST.id, value: 'Bicknell' },
+    ])
+    expect(displayWrites(state)).toEqual([])
+    expect(state.siblingSelects).toBe(0)
+    // Nothing wrote `updatedAt` for us, so the D-7 stamp is this frame's again.
+    expect(stampSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/lib/src/field-values/client.ts
+++ b/packages/lib/src/field-values/client.ts
@@ -17,10 +17,8 @@ export {
 } from '@auxx/utils/calc-expression'
 // Converters (for direct access if needed)
 export { converters, type FileValue } from './converters'
-
 // Currency value narrowing — shared by every render/edit surface
 export { normalizeCurrencyCode, readCurrency, resolveCurrencyCode } from './converters/currency'
-
 // Re-export relationship type guards from converter (centralized location)
 export {
   isRelationshipFieldValue,
@@ -49,6 +47,13 @@ export {
   type SelectFieldOptions,
   type TextFieldOptions,
 } from './formatter'
+// NAME composite linkage — the ONE predicate both directions decompose on.
+// The client funnel splits a NAME write into its two part writes and the
+// server chokepoint (`setValueWithBuiltIn`) does the same for every other
+// door; if the two sides disagreed about which fields count as "linked", a
+// misconfigured composite would split on one side and store raw on the other.
+// See plans/field-values/name-field-writes.md §4.
+export { coerceNameInput, type NameParts, readNameParts } from './name-parts'
 // Multi-value scalar helpers (first-is-primary convention)
 export { MAX_MULTI_VALUES, primaryValue } from './primary-value'
 // Relationship utilities

--- a/packages/lib/src/field-values/field-value-helpers.ts
+++ b/packages/lib/src/field-values/field-value-helpers.ts
@@ -3,6 +3,7 @@
 import { type Database, database, schema, type Transaction } from '@auxx/database'
 import { FieldType as FieldTypeEnum } from '@auxx/database/enums'
 import type { FieldType } from '@auxx/database/types'
+import { createScopedLogger } from '@auxx/logger'
 import {
   getValueType,
   isMultiValueFieldType,
@@ -49,6 +50,7 @@ import { isRecordId, parseRecordId, toRecordId } from '../resources/resource-id'
 import { cascadeDependentDisplayNames, getDisplayFieldDeps } from './display-field-deps'
 import { FieldValueValidator, fieldValueSchemas } from './field-value-validator'
 import { formatToDisplayValue } from './formatter'
+import { type NameParts, readNameParts } from './name-parts'
 import { getOrgCurrencyCode, withOrgCurrency } from './org-currency'
 import { MAX_MULTI_VALUES, primaryValue } from './primary-value'
 import type { InverseFieldInfo } from './relationship-sync'
@@ -58,6 +60,8 @@ import type { CachedField, FieldReference, FieldValueRow } from './types'
 
 // Re-export for convenience
 export type { InverseFieldInfo, CachedField }
+
+const logger = createScopedLogger('field-value-helpers')
 
 // =============================================================================
 // CONTEXT INTERFACE
@@ -449,10 +453,40 @@ export function rowToTypedValue(row: FieldValueRow, fieldType: FieldType): Typed
       // CALC is the only `computed` field type and it is never persisted, so a
       // FieldValue row can't carry one — and `TypedFieldValue` has no arm for it.
       // Reaching here means a caller invented a row for a computed field.
-      throw new Error(
-        `[rowToTypedValue] Field type ${fieldType} is computed and has no stored value.`
-      )
+      //
+      // This USED to throw (plans/field-values/name-field-writes.md §7): a
+      // poison pill that turns ONE invented row into a hard failure of every
+      // read of that field, for every caller. Warn instead. Every read seam
+      // drops such a row before it gets here — {@link isComputedStoredFieldType}
+      // guards `rowsToTypedValues` and the two per-row conversions in
+      // `field-value-queries` — so the callers that still reach this arm are
+      // the mutation seams, which map rows they just wrote and have no way to
+      // express a skip. `valueText` is the column `getValueColumn` maps an
+      // unmapped type to, so it is the only place an invented row's payload
+      // could be.
+      warnInventedComputedRow(row, fieldType)
+      return { ...base, type: 'text', value: row.valueText ?? '' }
   }
+}
+
+/**
+ * Whether a FieldValue row can legitimately exist for this field type at all.
+ *
+ * `computed` types (CALC today) are derived at read time and own no storage, so
+ * a stored row for one was invented by a caller that bypassed the converters.
+ * Read paths SKIP such rows rather than throw — see the `computed` arm of
+ * {@link rowToTypedValue} and `plans/field-values/name-field-writes.md` §7.
+ */
+export function isComputedStoredFieldType(fieldType: FieldType): boolean {
+  return getValueType(fieldType) === 'computed'
+}
+
+function warnInventedComputedRow(row: FieldValueRow, fieldType: FieldType): void {
+  logger.warn('Stored FieldValue row on a computed field type; skipping it', {
+    fieldId: row.fieldId,
+    entityId: row.entityId,
+    fieldType,
+  })
 }
 
 /**
@@ -464,6 +498,14 @@ export function rowsToTypedValues(
   fieldType: FieldType,
   isMultiValue: boolean
 ): TypedFieldValue | TypedFieldValue[] | null {
+  // §7 — a computed field type has no stored value, so an invented row reads as
+  // "unset" rather than as an error. This is THE shaping seam `getValue` /
+  // `shapeStoredRowsAsValue` go through, so the skip covers them both.
+  if (isComputedStoredFieldType(fieldType)) {
+    if (rows[0]) warnInventedComputedRow(rows[0], fieldType)
+    return isMultiValue ? [] : null
+  }
+
   const typedValues = rows.map((row) => rowToTypedValue(row, fieldType))
 
   // Return single value for single-value fields, array for multi-value
@@ -1046,9 +1088,89 @@ export async function batchGetRelatedDisplayNames(
 }
 
 /**
+ * THE applicability gate for the NAME-composed `displayName`: the entity's
+ * primary display field is a NAME field linked to two distinct part fields.
+ *
+ * Shared by both routes into that recompute — the per-part-write route
+ * ({@link resolveNameFieldDisplayValue}) and the composite route
+ * ({@link recomposeNameDisplayFromParts}). Keeping one gate is the point: two
+ * copies of these conditions drifting apart is the exact failure mode
+ * `plans/field-values/name-field-writes.md` exists to close.
+ *
+ * Returns `null` when the record's display simply isn't NAME-composed — a
+ * NAME field that is not the primary display field lands here and every
+ * caller no-ops, which is the behavior that predates decomposition.
+ */
+async function resolvePrimaryNameDisplayField(
+  ctx: FieldValueContext,
+  entityDef: { primaryDisplayFieldId: string | null }
+): Promise<{ field: CachedField; parts: NameParts } | null> {
+  if (!entityDef.primaryDisplayFieldId) return null
+
+  const primaryField = await getField(ctx, entityDef.primaryDisplayFieldId)
+  const parts = readNameParts(primaryField)
+  if (!parts) return null
+
+  return { field: primaryField, parts }
+}
+
+/** The one definition of how two name parts read as a `displayName`. */
+function composeNameDisplayValue(firstName: string, lastName: string): string | null {
+  return [firstName, lastName].filter(Boolean).join(' ').trim() || null
+}
+
+/**
+ * Persist a NAME-composed `displayName` and everything derived from it —
+ * the denormalized column, the searchText corpus, the dependent-entity
+ * cascade and the realtime column frame, in that order.
+ *
+ * Extracted so the per-part-write route and the composite route cannot drift:
+ * a decomposed NAME write reaches this exactly once, a direct part write
+ * exactly once.
+ */
+async function writeComposedDisplayName(
+  ctx: FieldValueContext,
+  entityDef: { id: string },
+  entityInstanceId: string,
+  displayName: string | null,
+  skipSearchTextRefresh: boolean
+): Promise<void> {
+  // D-7: a display-source field changed, so this is record content — stamp
+  // `updatedAt` in the same statement as the denormalized column.
+  await ctx.db
+    .update(schema.EntityInstance)
+    .set({ displayName, updatedAt: new Date() })
+    .where(
+      and(
+        eq(schema.EntityInstance.id, entityInstanceId),
+        eq(schema.EntityInstance.organizationId, ctx.organizationId)
+      )
+    )
+
+  if (!skipSearchTextRefresh) {
+    await updateSearchText(ctx.db, entityInstanceId, ctx.organizationId)
+  }
+
+  // Cascade to dependent entities
+  const resource = await getCachedResource(ctx.organizationId, entityDef.id)
+  const entityType = resource?.entityType ?? entityDef.id
+  const deps = await getDisplayFieldDeps(ctx.organizationId, entityType)
+  if (deps.length > 0) {
+    await cascadeDependentDisplayNames(ctx, entityInstanceId, displayName, deps)
+  }
+
+  await publishRecordColumnUpdate(ctx, entityDef.id, entityInstanceId, { displayName })
+}
+
+/**
  * Check if a field is a source field for a NAME-type primary display field.
  * If so, compose "firstName lastName" from the current value and the other source field.
  * Returns the composed display string, null to clear, or undefined if not applicable.
+ *
+ * Costs ONE sibling SELECT, because a part write only ever knows its own half.
+ * A decomposed NAME write knows both halves already and must take
+ * {@link recomposeNameDisplayFromParts} instead — see
+ * `plans/field-values/name-field-writes.md` §4a.
  */
 async function resolveNameFieldDisplayValue(
   ctx: FieldValueContext,
@@ -1057,18 +1179,11 @@ async function resolveNameFieldDisplayValue(
   field: CachedField,
   value: TypedFieldValueInput | TypedFieldValueInput[] | null
 ): Promise<string | null | undefined> {
-  if (!entityDef.primaryDisplayFieldId) return undefined
+  const primary = await resolvePrimaryNameDisplayField(ctx, entityDef)
+  if (!primary) return undefined
 
-  const primaryField = await getField(ctx, entityDef.primaryDisplayFieldId)
-  if (primaryField.type !== 'NAME') return undefined
-
-  const nameOpts = (primaryField.options as Record<string, any>)?.name as
-    | { firstNameFieldId?: string; lastNameFieldId?: string }
-    | undefined
-  if (!nameOpts?.firstNameFieldId || !nameOpts?.lastNameFieldId) return undefined
-
-  const isFirstName = nameOpts.firstNameFieldId === field.id
-  const isLastName = nameOpts.lastNameFieldId === field.id
+  const isFirstName = primary.parts.firstNameFieldId === field.id
+  const isLastName = primary.parts.lastNameFieldId === field.id
   if (!isFirstName && !isLastName) return undefined
 
   // Extract the text value being set
@@ -1077,7 +1192,7 @@ async function resolveNameFieldDisplayValue(
 
   // Fetch the other source field's current value
   const { entityInstanceId } = parseRecordId(recordId)
-  const otherFieldId = isFirstName ? nameOpts.lastNameFieldId : nameOpts.firstNameFieldId
+  const otherFieldId = isFirstName ? primary.parts.lastNameFieldId : primary.parts.firstNameFieldId
   const [otherRow] = await ctx.db
     .select({ valueText: schema.FieldValue.valueText })
     .from(schema.FieldValue)
@@ -1094,7 +1209,55 @@ async function resolveNameFieldDisplayValue(
   const firstName = isFirstName ? currentText : otherText
   const lastName = isLastName ? currentText : otherText
 
-  return [firstName, lastName].filter(Boolean).join(' ').trim() || null
+  return composeNameDisplayValue(firstName, lastName)
+}
+
+/**
+ * Recompute `displayName` for a decomposed NAME write, from the two part
+ * strings the caller already holds — ZERO sibling SELECTs and ONE column
+ * write, where letting the two part writes each recompute would cost two of
+ * each (and the second SELECT would re-read what the first write just
+ * committed).
+ *
+ * The caller MUST have suppressed the per-part recompute
+ * (`skipNameCompose`) and MUST gate this on "either part actually changed":
+ * renaming `Anita Smith` to `Bob Smith` leaves `last_name` byte-identical, so
+ * the second part write is a D-6 no-op — hanging the recompute off the last
+ * write instead would silently strand `displayName`. See
+ * `plans/field-values/name-field-writes.md` §4a.
+ *
+ * A no-op (and no query at all) when the record's display is not composed
+ * from this very NAME field — a non-primary NAME field included, exactly as
+ * a part write behaves today.
+ *
+ * @returns `true` when the `displayName` column was written. That statement
+ * carries `updatedAt` (the display write doubles as a content stamp, as it
+ * always has), so a caller owning the D-7 stamp can skip its own UPDATE.
+ */
+export async function recomposeNameDisplayFromParts(
+  ctx: FieldValueContext,
+  recordId: RecordId,
+  nameField: CachedField,
+  parts: { firstName: string; lastName: string },
+  opts?: { skipSearchTextRefresh?: boolean }
+): Promise<boolean> {
+  const entityDef = nameField.entityDefinition
+  if (!entityDef) return false
+
+  const primary = await resolvePrimaryNameDisplayField(ctx, entityDef)
+  // Same gate as the part-write route, plus: the field being written must BE
+  // the display field. A secondary NAME field composes nothing.
+  if (!primary || primary.field.id !== nameField.id) return false
+
+  const { entityInstanceId } = parseRecordId(recordId)
+  await writeComposedDisplayName(
+    ctx,
+    entityDef,
+    entityInstanceId,
+    composeNameDisplayValue(parts.firstName, parts.lastName),
+    opts?.skipSearchTextRefresh === true
+  )
+  return true
 }
 
 /**
@@ -1196,9 +1359,19 @@ export async function maybeUpdateDisplayValue(
      * last field write (query-reduction plan §3A).
      */
     skipSearchTextRefresh?: boolean
+    /**
+     * Suppresses ONLY the NAME-composed `displayName` recompute this write
+     * would trigger as a *part* of a NAME display field. Set by a decomposed
+     * NAME write, which owns the recompute for both parts at once and runs it
+     * through {@link recomposeNameDisplayFromParts} with no sibling SELECT
+     * (`plans/field-values/name-field-writes.md` §4a). A field that is itself
+     * a display field still writes its own column as always.
+     */
+    skipNameCompose?: boolean
   }
 ): Promise<void> {
   const skipSearchTextRefresh = opts?.skipSearchTextRefresh === true
+  const skipNameCompose = opts?.skipNameCompose === true
   const { entityInstanceId } = parseRecordId(recordId)
   const entityDef = field.entityDefinition
   if (!entityDef) return
@@ -1215,35 +1388,20 @@ export async function maybeUpdateDisplayValue(
     column = 'avatarUrl'
   }
 
-  // If no direct match, check if this field is a source for a NAME-type display field
-  if (!column && entityDef.primaryDisplayFieldId) {
+  // If no direct match, check if this field is a source for a NAME-type display
+  // field. `skipNameCompose` hands that recompute UP to a decomposed NAME
+  // write, which holds both part strings and does it once with no sibling
+  // SELECT (see `recomposeNameDisplayFromParts`).
+  if (!column && !skipNameCompose && entityDef.primaryDisplayFieldId) {
     const result = await resolveNameFieldDisplayValue(ctx, recordId, entityDef, field, value)
     if (result !== undefined) {
-      // D-7: a display-source field changed, so this is record content — stamp
-      // `updatedAt` in the same statement as the denormalized column.
-      await ctx.db
-        .update(schema.EntityInstance)
-        .set({ displayName: result, updatedAt: new Date() })
-        .where(
-          and(
-            eq(schema.EntityInstance.id, entityInstanceId),
-            eq(schema.EntityInstance.organizationId, ctx.organizationId)
-          )
-        )
-      if (!skipSearchTextRefresh) {
-        await updateSearchText(ctx.db, entityInstanceId, ctx.organizationId)
-      }
-
-      // Cascade to dependent entities
-      const resource = await getCachedResource(ctx.organizationId, entityDef.id)
-      const entityType = resource?.entityType ?? entityDef.id
-      const deps = await getDisplayFieldDeps(ctx.organizationId, entityType)
-      if (deps.length > 0) {
-        await cascadeDependentDisplayNames(ctx, entityInstanceId, result, deps)
-      }
-      await publishRecordColumnUpdate(ctx, entityDef.id, entityInstanceId, {
-        displayName: result,
-      })
+      await writeComposedDisplayName(
+        ctx,
+        entityDef,
+        entityInstanceId,
+        result,
+        skipSearchTextRefresh
+      )
       return
     }
   }

--- a/packages/lib/src/field-values/field-value-mutations.ts
+++ b/packages/lib/src/field-values/field-value-mutations.ts
@@ -93,6 +93,7 @@ import {
   type InverseFieldInfo,
   maybeUpdateDisplayValue,
   preBatchValidateRelationships,
+  recomposeNameDisplayFromParts,
   resolveFieldIds,
   rowToTypedValue,
   stampEntityInstancesUpdatedAt,
@@ -103,6 +104,7 @@ import { getValue, getValueFromStoredRows } from './field-value-queries'
 import { formatToTypedInput } from './formatter'
 import { getExistingFieldValue } from './get-existing-value'
 import { insertFieldValue } from './insert-value'
+import { coerceNameInput, type NameParts, readNameParts } from './name-parts'
 import { MAX_MULTI_VALUES } from './primary-value'
 import {
   type BulkRelationshipUpdate,
@@ -761,7 +763,14 @@ export async function setValueWithType(
   ctx: FieldValueContext,
   params: SetValueWithTypeInput
 ): Promise<TypedFieldValue[]> {
-  const { recordId, fieldId, fieldType, skipInverseSync = false, skipSearchTextRefresh } = params
+  const {
+    recordId,
+    fieldId,
+    fieldType,
+    skipInverseSync = false,
+    skipSearchTextRefresh,
+    skipNameCompose,
+  } = params
   let value = params.value
 
   // Parse RecordId to get both parts for DB queries
@@ -884,7 +893,10 @@ export async function setValueWithType(
 
   // Clear (null or empty list): rows are gone, derived state follows.
   if (values.length === 0) {
-    await maybeUpdateDisplayValue(ctx, recordId, field, null, { skipSearchTextRefresh })
+    await maybeUpdateDisplayValue(ctx, recordId, field, null, {
+      skipSearchTextRefresh,
+      skipNameCompose,
+    })
 
     // Sync inverse if we had old relationships
     if (inverseInfo && oldRelatedIds.length > 0) {
@@ -900,7 +912,10 @@ export async function setValueWithType(
   const result = inserted.map((row) => rowToTypedValue(row as unknown as FieldValueRow, fieldType))
 
   // Update display value if this is a display field
-  await maybeUpdateDisplayValue(ctx, recordId, field, value, { skipSearchTextRefresh })
+  await maybeUpdateDisplayValue(ctx, recordId, field, value, {
+    skipSearchTextRefresh,
+    skipNameCompose,
+  })
 
   // Sync inverse relationships
   if (inverseInfo) {
@@ -2636,6 +2651,7 @@ export async function setValueWithBuiltIn(
     collectRealtime,
     skipSearchTextRefresh,
     skipInstanceStamp,
+    skipNameCompose,
   } = params
 
   // Plan 04 §6.2. An explicit `publishEvents: false` is the C3 escape hatch —
@@ -2711,6 +2727,164 @@ export async function setValueWithBuiltIn(
 
   // Get field definition (cached)
   const field = await getField(ctx, fieldId)
+
+  // 2.5. NAME decomposition (plans/field-values/name-field-writes.md §4).
+  // A NAME field is a COMPOSITE over two TEXT part fields and owns no storage
+  // of its own. Every set-shaped write from every door (tRPC set/setBulk, the
+  // API set-values route + SDK, importer, workflows, Kopilot, AI commits,
+  // record create/update) funnels through this function, so this is THE place
+  // the composite is fanned out — the client's split copies become an
+  // optimization, not a correctness requirement.
+  const nameParts = readNameParts(field)
+  if (field.type === 'NAME' && !nameParts) {
+    // §4: an unlinked (or half-linked) NAME field has no parts to decompose
+    // into. Never throw on a shape the org's fields don't support — warn and
+    // fall through to the pre-decomposition behavior (the json converter
+    // stores the composite on the NAME field's own row).
+    logger.warn('NAME field has no linked part fields; storing the composite raw', {
+      fieldId,
+      recordId,
+    })
+  }
+  if (nameParts) {
+    // §4d: reuse the converter's coercion rather than narrowing to
+    // `{firstName, lastName}` — SDK / API / importer callers send a bare full
+    // name string today ('Anita Bicknell' → Anita / Bicknell), and an
+    // already-typed `json` value also has to keep working. `null` (an explicit
+    // clear, or blank input) clears BOTH parts.
+    const coerced = coerceNameInput(value)
+
+    // §4a: two DIRECT `setValueWithBuiltIn` calls — never `setValuesForEntity`,
+    // which is this function's CALLER on every bulk / create / import path.
+    // Re-entering it would re-run `resolveFieldIds`, re-acquire the per-field
+    // advisory locks in a nested savepoint, redo the D-7 `EntityInstance`
+    // stamp and the searchText recompute (see the single flush below, which
+    // this frame owns), and publish its own realtime frame instead of
+    // appending to `collectRealtime`. The parts are TEXT, so `readNameParts`
+    // answers `null` for them and the recursion terminates in exactly one
+    // level by construction.
+    const partWrites = [
+      { fieldId: nameParts.firstNameFieldId, value: coerced?.firstName ?? null },
+      { fieldId: nameParts.lastNameFieldId, value: coerced?.lastName ?? null },
+    ]
+    // Same deterministic order `setValuesForEntity` imposes before its
+    // per-field loop: under an ambient transaction each per-field advisory
+    // lock is a nested savepoint that survives to the OUTER commit, so two
+    // callers taking the same record's part locks in opposite orders would
+    // deadlock. Sorting by fieldId gives every caller one order.
+    partWrites.sort((a, b) => (a.fieldId < b.fieldId ? -1 : a.fieldId > b.fieldId ? 1 : 0))
+
+    let partChanged = false
+    for (const part of partWrites) {
+      const partResult = await setValueWithBuiltIn(ctx, {
+        recordId,
+        fieldId: part.fieldId,
+        value: part.value,
+        // The RAW requested flag, not the derived `publishEvents`: the part
+        // frames re-derive `requestedPublish` / `bufferedScope` from the same
+        // ctx, and handing down a derived `false` would also suppress the
+        // buffering a write session is relying on (the C3 escape hatch is
+        // absolute by design).
+        publishEvents: params.publishEvents,
+        skipInverseSync,
+        collectRealtime,
+        preloadedSetRows: params.preloadedSetRows,
+        // Post-write ownership moves UP to THIS frame, the same way
+        // `setValuesForEntity` takes it from its per-field loop: two part
+        // writes would otherwise stamp `EntityInstance.updatedAt` twice and —
+        // far worse — run the full `updateSearchText` rebuild twice for one
+        // name edit, on the most common door in the app. Forced `true` here
+        // unconditionally; the single flush below re-checks the flags THIS
+        // frame received, so a nested NAME write under a bulk/create/import
+        // caller that already owns both still does nothing.
+        skipSearchTextRefresh: true,
+        skipInstanceStamp: true,
+        // Same hand-up for the NAME-composed `displayName`: left alone, EACH
+        // part write would SELECT its sibling's `valueText` to recompose —
+        // two SELECTs and two column writes, the second SELECT re-reading
+        // what the first write just committed. This frame already holds both
+        // strings, so it recomposes once below with no read at all.
+        skipNameCompose: true,
+        // An AI stage-2 commit on a NAME field lands on the parts, so the
+        // marker rides along with the value instead of being dropped.
+        aiGeneration: params.aiGeneration,
+      })
+      partChanged = partChanged || partResult.changed === true
+    }
+
+    // ONE `displayName` recompute for the composite write, from the two
+    // strings this frame already holds — zero sibling SELECTs, one column
+    // write. Gated on `partChanged`, NOT on "the last part changed": renaming
+    // `Anita Smith` to `Bob Smith` leaves `last_name` byte-identical, so the
+    // second part write is a D-6 no-op and hanging the recompute off it would
+    // strand `displayName` on the old name forever. Both parts no-op means the
+    // composed display cannot have changed, so nothing is skipped by gating
+    // here. A no-op when this NAME field is not the record's primary display
+    // field — the same answer a part write gives today.
+    // Runs BEFORE the searchText flush below: the corpus embeds `displayName`,
+    // so the recompute has to have landed first.
+    let displayWritten = false
+    if (partChanged) {
+      displayWritten = await recomposeNameDisplayFromParts(
+        ctx,
+        recordId,
+        field,
+        coerced ?? { firstName: '', lastName: '' },
+        {
+          // The flush below (or the caller's) owns this; the recompute must
+          // not sneak in a third rebuild.
+          skipSearchTextRefresh: true,
+        }
+      )
+    }
+
+    // D-7: ONE `EntityInstance.updatedAt` stamp for the composite write, iff
+    // EITHER part performed a real change — matching `setValuesForEntity`'s
+    // `results.some((r) => r.changed)`. A pure no-op (both parts idempotent,
+    // or a clear against two absent parts) must not re-dirty the dedup
+    // watermark. When this frame did NOT own the stamp, ownership stays with
+    // the outer caller exactly as before.
+    // Skipped when the recompute above already wrote `displayName`: that
+    // statement carries `updatedAt` in the same UPDATE (the display write has
+    // always doubled as a content stamp), so a separate one would be a second
+    // UPDATE on the same row for the same reason.
+    if (!skipInstanceStamp && partChanged && !displayWritten) {
+      await stampEntityInstanceUpdatedAt(ctx, entityInstanceId)
+    }
+
+    // One searchText recompute for the composite write, on the same
+    // either-part-changed condition. The parts are TEXT — an indexed type —
+    // so this is the single flush that replaces the two the part writes would
+    // otherwise each have run (query-reduction plan §3A's pattern, applied one
+    // level down). `skipSearchTextRefresh` hands ownership up to
+    // `setValuesForEntity` / `setBulkValues`, which flush per record / per op.
+    if (!skipSearchTextRefresh && partChanged) {
+      await updateSearchText(ctx.db, entityInstanceId, ctx.organizationId)
+    }
+
+    // §4c: the NAME key is CLIENT-COMPUTED — `computed-field-registry.ts`
+    // derives it from the two part keys — so returning the parts'
+    // `TypedFieldValue`s here would put stored values on a computed key and
+    // shadow the derived display. Return NO values under the NAME fieldId and
+    // let the part writes' own realtime entries drive the cells; `changed`
+    // still reports honestly so the D-7 stamp one frame up fires iff a part
+    // actually moved.
+    // Exactly ONE searchText recompute happens per decomposed write, from
+    // whichever frame owns the flush — deliberate, not accidental. Called
+    // directly (`fieldValue.set`), that is the flush above. Called from
+    // `setValuesForEntity`, `skipSearchTextRefresh` is already `true` here, so
+    // the flush above is skipped and the record-level one covers it: that
+    // function re-labels this result with the NAME fieldId, and
+    // `fieldFeedsSearchText` resolves the NAME field — which IS in
+    // `isSearchTextIndexedFieldType` — so `changed` alone carries it. Both
+    // routes land on one rebuild, which is what we want: the parts changed.
+    return {
+      state: 'complete',
+      performedAt: new Date().toISOString(),
+      values: [],
+      changed: partChanged,
+    }
+  }
 
   // Client store keys are always cuid-form (`<defId>:<inst>:<defId>:<fieldId>`),
   // but server-side callers (money totals hooks, lifecycle paths) pass alias-form
@@ -2896,7 +3070,10 @@ export async function setValueWithBuiltIn(
       }
     }
     await deleteValue(ctx, { recordId, fieldId, skipInstanceStamp })
-    await maybeUpdateDisplayValue(ctx, recordId, field, null, { skipSearchTextRefresh })
+    await maybeUpdateDisplayValue(ctx, recordId, field, null, {
+      skipSearchTextRefresh,
+      skipNameCompose,
+    })
     if (publishEvents || txScope) {
       // Routed through buildPublishEntry like the set branch below — this
       // publishes `[]` (not `null`) for array-return fields, matching
@@ -2966,6 +3143,7 @@ export async function setValueWithBuiltIn(
     aiGeneration: params.aiGeneration,
     skipSearchTextRefresh,
     skipInstanceStamp,
+    skipNameCompose,
   })
 
   // Sync capture (plan 07 §4): the step-3.55 guard already decided this is a
@@ -3209,14 +3387,39 @@ export async function setValuesForEntity(
       )) ??
       undefined
 
+    // NAME decomposition bookkeeping (plans/field-values/name-field-writes.md
+    // §4b). A NAME entry never writes its own key — `setValueWithBuiltIn` fans
+    // it out to the two part fields — so this op needs the part ids twice
+    // over: for the collision order below, and for the stale-snapshot
+    // invalidation in the loop's `finally`. An unlinked NAME field resolves to
+    // `null` here and behaves exactly like any other field.
+    const namePartsByFieldId = new Map<string, NameParts>()
+    for (const v of customs) {
+      const f = ctx.fieldCache.get(v.fieldId) ?? fieldMap.get(v.fieldId)
+      const parts = f ? readNameParts(f) : null
+      if (parts) namePartsByFieldId.set(v.fieldId, parts)
+    }
+
     // Deterministic advisory-lock acquisition order: under an ambient
     // transaction (merge-service, billing) each per-field lock is a nested
     // savepoint and survives to the OUTER commit, so two concurrent callers
     // acquiring the same record's field locks in different orders would
-    // deadlock. Sorting by fieldId gives every caller one order. Results,
-    // realtime frames and events may reorder relative to the input — every
-    // consumer keys by fieldId, none by position.
-    customs.sort((a, b) => (a.fieldId < b.fieldId ? -1 : a.fieldId > b.fieldId ? 1 : 0))
+    // deadlock. The sort key is two-level — `(isNameField ? 0 : 1, fieldId)` —
+    // and total, so it still gives every caller one order. Results, realtime
+    // frames and events may reorder relative to the input — every consumer
+    // keys by fieldId, none by position.
+    //
+    // §4b collision rule: NAME entries sort FIRST so that an op carrying both
+    // a composite and one of its own parts (an importer mapping `full_name`
+    // alongside `first_name`, a bulk dialog offering both) resolves
+    // last-writer-wins in favour of the EXPLICIT part write, rather than by
+    // alphabetical accident of the two cuids.
+    customs.sort((a, b) => {
+      const an = namePartsByFieldId.has(a.fieldId) ? 0 : 1
+      const bn = namePartsByFieldId.has(b.fieldId) ? 0 : 1
+      if (an !== bn) return an - bn
+      return a.fieldId < b.fieldId ? -1 : a.fieldId > b.fieldId ? 1 : 0
+    })
 
     // Now set each value (will use cached field definitions and relationship validations)
     for (const v of customs) {
@@ -3259,6 +3462,15 @@ export async function setValuesForEntity(
         // fieldId in this op (systemAttribute alias + UUID) must re-read
         // fresh rows, not skip as a false D-6/B-14 no-op against pre-op
         // state.
+        // §4b: a NAME entry's writes land on the PART keys, so those are the
+        // snapshots that just went stale — invalidating only the NAME key
+        // would leave a following part write reading pre-op rows. Clearing
+        // the NAME key too is harmless (nothing ever writes it).
+        const parts = namePartsByFieldId.get(v.fieldId)
+        if (parts) {
+          setRows?.delete(setRowsKey(entityInstanceId, parts.firstNameFieldId))
+          setRows?.delete(setRowsKey(entityInstanceId, parts.lastNameFieldId))
+        }
         setRows?.delete(setRowsKey(entityInstanceId, v.fieldId))
       }
     }

--- a/packages/lib/src/field-values/field-value-queries.ts
+++ b/packages/lib/src/field-values/field-value-queries.ts
@@ -14,7 +14,7 @@ import {
 import type { RecordId } from '@auxx/types/resource'
 import { and, asc, eq, inArray, isNotNull, or, type SQL, sql } from 'drizzle-orm'
 import { findCachedResource } from '../cache'
-import type { FieldOptions, NameFieldOptions } from '../custom-fields/field-options'
+import type { FieldOptions } from '../custom-fields/field-options'
 import { rungsAtOrAbove } from '../permissions/capabilities/record-visibility-scope'
 import type { AiStatus } from '../realtime/events'
 import {
@@ -30,12 +30,14 @@ import {
   type FieldValueContext,
   getField,
   getFieldInfoFromRegistry,
+  isComputedStoredFieldType,
   normalizeFieldReference,
   rowsToTypedValues,
   rowToTypedValue,
   validateFieldReferences,
 } from './field-value-helpers'
 import { resolveMailHostGate, resolveMailLensGate } from './mail-lens-gate'
+import { type NameParts, readNameParts } from './name-parts'
 import {
   batchFetchSystemRelationships,
   isVirtualField,
@@ -91,6 +93,21 @@ export async function getValue(
   // Use cached field if provided (avoids redundant CustomField join)
   const field = cachedField ?? (await getField(ctx, params.fieldId))
 
+  // NAME reads COMPOSE from the part fields (plan §4, "server READ semantics").
+  // A NAME field owns no storage — §4 decomposes every write into its two TEXT
+  // parts — so its own row is not the value and is never read here. Stray
+  // pre-decomposition rows are deliberately NOT migrated (§6/§8), which makes
+  // this the code that has to render them invisible. An UNLINKED NAME field has
+  // no parts to compose from, so `readNameParts` answers `null` and the stored
+  // row keeps today's behavior rather than throwing.
+  const nameParts = readNameParts(field)
+  if (nameParts) {
+    const composed = await composeNameValuesForRecord(ctx, entityInstanceId, [
+      { fieldId: params.fieldId, parts: nameParts },
+    ])
+    return composed.get(params.fieldId) ?? null
+  }
+
   const rows = await ctx.db
     .select()
     .from(schema.FieldValue)
@@ -130,6 +147,14 @@ export function shapeStoredRowsAsValue(
  * saves the re-SELECT while preserving BOTH getValue behaviors the raw rows
  * lack: the mail-host gate (a withheld host or field answers `null`, never
  * the stored rows) and the scalar/array result shaping.
+ *
+ * It deliberately does NOT compose NAME from its parts the way `getValue` does
+ * (plan §4): this is the set path's idempotency-guard derivation, and a LINKED
+ * NAME field never reaches it — `setValueWithBuiltIn` decomposes into the two
+ * part writes long before the guard runs. An unlinked NAME field still stores
+ * its composite raw, and reading that row back is exactly what the guard wants.
+ * Composing here would also re-introduce the SELECT this function exists to
+ * avoid.
  */
 export async function getValueFromStoredRows(
   ctx: FieldValueContext,
@@ -173,6 +198,36 @@ export async function getValues(
   const mailGate = await resolveMailHostGate(ctx, params.recordId)
   if (mailGate?.hidden) return new Map()
 
+  // NAME composition (plan §4) is resolved BEFORE the query, not after it. The
+  // part ids come from the org `resources` cache — no roundtrip — and knowing
+  // them up front is what lets the ONE join below fetch the part rows too.
+  // Composing afterwards cost a SECOND select, and when `fieldIds` was omitted
+  // that select re-read rows the join had already put in memory.
+  //
+  // A linked NAME field's own row is a stray pre-decomposition write (§6/§8:
+  // left in place, never migrated). It is dropped below and replaced by the
+  // composed value — the stored composite is not the field's value.
+  const nameFields = await resolveLinkedNameFields(ctx, params.recordId, params.fieldIds)
+  const linkedNameFieldIds = new Set(nameFields.map((n) => n.fieldId))
+
+  // Part ids pulled in ONLY to compose a NAME. They must never reach the
+  // result: a caller that asked for `full_name` did not ask for `first_name`.
+  // A part the caller DID name is deliberately absent from this set, so it is
+  // fetched once by the widened `IN` and emitted through the normal loop.
+  const composeOnlyFieldIds = new Set<string>()
+  let fetchFieldIds = params.fieldIds
+  if (params.fieldIds && nameFields.length > 0) {
+    const requested = new Set(params.fieldIds)
+    for (const { parts } of nameFields) {
+      for (const partId of [parts.firstNameFieldId, parts.lastNameFieldId]) {
+        if (!requested.has(partId)) composeOnlyFieldIds.add(partId)
+      }
+    }
+    fetchFieldIds = [...requested, ...composeOnlyFieldIds]
+  }
+  // `fieldIds` omitted already fetches every row on the record, so the part
+  // rows are in the result set for free and nothing needs widening.
+
   const query = ctx.db
     .select()
     .from(schema.FieldValue)
@@ -181,7 +236,7 @@ export async function getValues(
       and(
         eq(schema.FieldValue.entityId, entityInstanceId),
         eq(schema.FieldValue.organizationId, ctx.organizationId),
-        params.fieldIds ? inArray(schema.FieldValue.fieldId, params.fieldIds) : undefined
+        fetchFieldIds ? inArray(schema.FieldValue.fieldId, fetchFieldIds) : undefined
       )
     )
     .orderBy(asc(schema.FieldValue.sortKey))
@@ -199,8 +254,12 @@ export async function getValues(
 
   // Convert and store results
   for (const [fieldId, fieldRows] of groupedByField) {
+    // Fetched for composition only — never part of the answer. Tested BEFORE
+    // the lens, because this is a fact about the REQUEST, not about the viewer.
+    if (composeOnlyFieldIds.has(fieldId)) continue
     // FIELD visibility: drop values above the viewer's lens on this thread.
     if (mailGate && !mailGate.admitsField(fieldId)) continue
+    if (linkedNameFieldIds.has(fieldId)) continue
     const fieldType = fieldRows[0]!.CustomField.type as FieldType
     const fieldOptions = fieldRows[0]!.CustomField.options as FieldOptions | undefined
     const fieldValueRows = fieldRows.map((r) => r.FieldValue as unknown as FieldValueRow)
@@ -214,7 +273,169 @@ export async function getValues(
     }
   }
 
+  // ZERO extra queries: composed from the rows the join above already returned.
+  // Composition reads the part rows RAW — a part withheld from this viewer is
+  // not a part the caller asked for, so the lens decision that governs is the
+  // NAME field's own, applied here.
+  const composed = composeNameValues(
+    entityInstanceId,
+    nameFields,
+    readPartText(rows.map((r) => r.FieldValue as unknown as FieldValueRow))
+  )
+  for (const [fieldId, value] of composed) {
+    if (mailGate && !mailGate.admitsField(fieldId)) continue
+    result.set(fieldId, value)
+  }
+
   return result
+}
+
+// =============================================================================
+// NAME COMPOSITION (plans/field-values/name-field-writes.md §4)
+// =============================================================================
+
+/** A NAME field paired with the two part-field ids it composes over. */
+type LinkedNameField = { fieldId: string; parts: NameParts }
+
+/**
+ * The linked NAME fields on a record's definition, narrowed to `fieldIds` when
+ * the caller named some.
+ *
+ * Reads the org `resources` cache — no DB roundtrip, and the only place a NAME
+ * field with no stored row of its own can be discovered from a bare recordId.
+ * A definition that is not in the cache (mail infra, an unregistered def) has
+ * no NAME fields as far as this path is concerned.
+ */
+async function resolveLinkedNameFields(
+  ctx: FieldValueContext,
+  recordId: RecordId,
+  fieldIds?: string[]
+): Promise<LinkedNameField[]> {
+  const { entityDefinitionId } = parseRecordId(recordId)
+  const resource = await findCachedResource(ctx.organizationId, entityDefinitionId)
+  if (!resource) return []
+
+  const requested = fieldIds ? new Set<string>(fieldIds) : null
+  const linked: LinkedNameField[] = []
+  for (const field of resource.fields) {
+    if (requested && !requested.has(field.id)) continue
+    const parts = readNameParts({ type: field.fieldType, options: field.options })
+    if (parts) linked.push({ fieldId: field.id, parts })
+  }
+  return linked
+}
+
+/**
+ * The text each part field holds on one record, keyed by field id.
+ *
+ * Parts are TEXT — that is what being linkable as a part means — so the value
+ * is `valueText`, and with rows arriving in `sortKey` order the lowest wins. A
+ * part carrying more than one row is a misconfigured field, not a list to join.
+ *
+ * Takes rows the caller ALREADY has. Rows for other fields are harmless: the
+ * composition step only ever looks up the two ids it is linked to.
+ */
+function readPartText(
+  rows: Array<{ fieldId: string; valueText: string | null }>
+): Map<string, string> {
+  const partText = new Map<string, string>()
+  for (const row of rows) {
+    if (!partText.has(row.fieldId)) partText.set(row.fieldId, row.valueText ?? '')
+  }
+  return partText
+}
+
+/**
+ * Compose the `{firstName, lastName}` value of every given NAME field on ONE
+ * record. PURE — it issues no query, because on every batched path the part
+ * rows are already in hand.
+ *
+ * A NAME field owns no storage (plan §4): writes decompose into the parts, so
+ * reads compose back out of them and the NAME field's own row — where a stray
+ * pre-decomposition one still exists (§6/§8: not migrated, not deleted) — is
+ * never read.
+ *
+ * A NAME field whose parts are BOTH blank/absent is left out of the map: that
+ * is `getValue`'s "no value" answer (`null`) and `getValues`' (key absent), so
+ * an unset name reads exactly as any other unset field does.
+ */
+function composeNameValues(
+  entityInstanceId: string,
+  nameFields: LinkedNameField[],
+  partText: ReadonlyMap<string, string>
+): Map<string, TypedFieldValue> {
+  const composed = new Map<string, TypedFieldValue>()
+  for (const { fieldId, parts } of nameFields) {
+    const firstName = partText.get(parts.firstNameFieldId) ?? ''
+    const lastName = partText.get(parts.lastNameFieldId) ?? ''
+    if (!firstName && !lastName) continue
+    composed.set(fieldId, composedNameValue(entityInstanceId, fieldId, firstName, lastName))
+  }
+  return composed
+}
+
+/**
+ * {@link composeNameValues} for the ONE caller that has no rows in hand:
+ * `getValue`, which is asked for a single field id.
+ *
+ * Net zero on queries — it selects the part rows INSTEAD of the NAME field's
+ * own row, not in addition to it, so the single-field read still costs exactly
+ * one SELECT.
+ */
+async function composeNameValuesForRecord(
+  ctx: FieldValueContext,
+  entityInstanceId: string,
+  nameFields: LinkedNameField[]
+): Promise<Map<string, TypedFieldValue>> {
+  if (nameFields.length === 0) return new Map()
+
+  const partFieldIds = [
+    ...new Set(nameFields.flatMap((n) => [n.parts.firstNameFieldId, n.parts.lastNameFieldId])),
+  ]
+
+  const rows = await ctx.db
+    .select({
+      fieldId: schema.FieldValue.fieldId,
+      valueText: schema.FieldValue.valueText,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.entityId, entityInstanceId),
+        eq(schema.FieldValue.organizationId, ctx.organizationId),
+        inArray(schema.FieldValue.fieldId, partFieldIds)
+      )
+    )
+    .orderBy(asc(schema.FieldValue.sortKey))
+
+  return composeNameValues(entityInstanceId, nameFields, readPartText(rows))
+}
+
+/**
+ * The synthetic `json` TypedFieldValue a composed NAME reads as.
+ *
+ * Shaped exactly like `nameConverter.toTypedInput`'s output
+ * (`{ type: 'json', value: { firstName, lastName } }`), so an SDK / API reader
+ * sees no change now that the stored composite is no longer returned. NAME is
+ * composed rather than stored, so the row identity and timestamps every other
+ * TypedFieldValue carries have nothing behind them and are empty.
+ */
+function composedNameValue(
+  entityInstanceId: string,
+  fieldId: string,
+  firstName: string,
+  lastName: string
+): TypedFieldValue {
+  return {
+    id: '',
+    entityId: entityInstanceId,
+    fieldId,
+    sortKey: '',
+    createdAt: '',
+    updatedAt: '',
+    type: 'json',
+    value: { firstName, lastName },
+  }
 }
 
 /**
@@ -723,6 +944,9 @@ async function fetchFieldValueResults(
     const fieldType = fieldTypeMap.get(fieldId)
 
     if (!recordId || !fieldRef || !fieldType) continue
+    // §7 — a stored row on a computed field type was invented by a caller that
+    // bypassed the converters. Skip it; a read must never fail on one.
+    if (isComputedStoredFieldType(fieldType)) continue
 
     const fieldOptions = fieldOptionsMap.get(fieldId)
     const isMulti = isArrayReturnFieldType(fieldType, fieldOptions)
@@ -1144,6 +1368,11 @@ async function batchFetchFieldValues(
   fieldType: FieldType,
   fieldOptions?: FieldOptions
 ): Promise<Map<RecordId, TypedFieldValue | TypedFieldValue[]>> {
+  // §7 — a computed field type owns no storage, so any row found under one was
+  // invented by a caller that bypassed the converters. Answer "nothing stored"
+  // rather than let a read fail on it.
+  if (isComputedStoredFieldType(fieldType)) return new Map()
+
   const entityInstanceIds = recordIds.map((rid) => parseRecordId(rid).entityInstanceId)
 
   // No AI-metadata read on this path — valueJson only matters for json-typed fields.
@@ -1291,66 +1520,83 @@ async function resolveNameFieldValues(
   recordIds: RecordId[],
   nameFieldId: string
 ): Promise<Map<RecordId, TypedFieldValue | TypedFieldValue[]>> {
-  // Look up the NAME field to get source field IDs
+  // Look up the NAME field to get source field IDs. `readNameParts` is the one
+  // linkage predicate the write side decomposes on (plan §4), so composing here
+  // on anything else would let the two directions disagree about which fields
+  // count as linked.
   const nameField = await getField(ctx, nameFieldId)
-  const nameOptions = (nameField.options as Record<string, any>)?.name as
-    | NameFieldOptions
-    | undefined
+  const nameParts = readNameParts(nameField)
+  if (!nameParts) return new Map()
 
-  if (!nameOptions?.firstNameFieldId || !nameOptions?.lastNameFieldId) {
-    return new Map()
-  }
+  // ONE query for BOTH parts. This used to be two `batchFetchFieldValues` calls
+  // in a `Promise.all` — concurrent, but still two round trips for two ids on
+  // the same table, same org, same record set. `batchFetchFieldValues` is
+  // single-field by contract and has other callers, so the pair is collapsed
+  // here rather than by widening its signature.
+  const partTextByRecord = await batchFetchNamePartText(ctx, recordIds, nameParts)
 
-  // Fetch both source fields in parallel
-  const [firstNameValues, lastNameValues] = await Promise.all([
-    batchFetchFieldValues(
-      ctx,
-      recordIds,
-      nameOptions.firstNameFieldId,
-      FieldTypeEnum.TEXT as FieldType
-    ),
-    batchFetchFieldValues(
-      ctx,
-      recordIds,
-      nameOptions.lastNameFieldId,
-      FieldTypeEnum.TEXT as FieldType
-    ),
-  ])
-
-  // Compose NAME values from source fields
   const result = new Map<RecordId, TypedFieldValue | TypedFieldValue[]>()
-
   for (const recordId of recordIds) {
-    const firstNameTyped = firstNameValues.get(recordId)
-    const lastNameTyped = lastNameValues.get(recordId)
-
-    // Both sources were fetched as TEXT above, so anything else is a misconfigured
-    // NAME field rather than a value to coerce.
-    const firstName =
-      firstNameTyped && !Array.isArray(firstNameTyped) && firstNameTyped.type === 'text'
-        ? firstNameTyped.value
-        : ''
-    const lastName =
-      lastNameTyped && !Array.isArray(lastNameTyped) && lastNameTyped.type === 'text'
-        ? lastNameTyped.value
-        : ''
-
-    if (firstName || lastName) {
-      // NAME is composed, not stored — there is no FieldValue row behind it, so the
-      // row identity/timestamps every other TypedFieldValue carries are synthesised
-      // from the NAME field itself.
-      result.set(recordId, {
-        id: '',
-        entityId: parseRecordId(recordId).entityInstanceId,
-        fieldId: nameFieldId,
-        sortKey: '',
-        createdAt: '',
-        updatedAt: '',
-        type: 'json',
-        value: { firstName, lastName },
-      })
-    }
+    const composed = composeNameValues(
+      parseRecordId(recordId).entityInstanceId,
+      [{ fieldId: nameFieldId, parts: nameParts }],
+      partTextByRecord.get(recordId) ?? EMPTY_PART_TEXT
+    ).get(nameFieldId)
+    if (composed) result.set(recordId, composed)
   }
 
   return result
+}
+
+/** Shared empty map for records with no part rows at all — never mutated. */
+const EMPTY_PART_TEXT: ReadonlyMap<string, string> = new Map()
+
+/**
+ * The two part fields' text for MANY records at once, keyed by RecordId and
+ * then by part field id — {@link readPartText}'s batch shape.
+ *
+ * Reads `valueText` directly instead of going through the typed-value machinery:
+ * parts are TEXT, so the typed round trip only ever produced `{type:'text'}`
+ * values this function would immediately unwrap again.
+ */
+async function batchFetchNamePartText(
+  ctx: FieldValueContext,
+  recordIds: RecordId[],
+  parts: NameParts
+): Promise<Map<RecordId, Map<string, string>>> {
+  const instanceToRecordId = new Map<string, RecordId>()
+  for (const rid of recordIds) {
+    instanceToRecordId.set(parseRecordId(rid).entityInstanceId, rid)
+  }
+
+  const rows = await ctx.db
+    .select({
+      entityId: schema.FieldValue.entityId,
+      fieldId: schema.FieldValue.fieldId,
+      valueText: schema.FieldValue.valueText,
+    })
+    .from(schema.FieldValue)
+    .where(
+      and(
+        eq(schema.FieldValue.organizationId, ctx.organizationId),
+        inArray(schema.FieldValue.entityId, [...instanceToRecordId.keys()]),
+        inArray(schema.FieldValue.fieldId, [parts.firstNameFieldId, parts.lastNameFieldId])
+      )
+    )
+    .orderBy(asc(schema.FieldValue.sortKey))
+
+  const byRecord = new Map<RecordId, Map<string, string>>()
+  for (const row of rows) {
+    const recordId = instanceToRecordId.get(row.entityId)
+    if (!recordId) continue
+    let partText = byRecord.get(recordId)
+    if (!partText) {
+      partText = new Map<string, string>()
+      byRecord.set(recordId, partText)
+    }
+    // Lowest sortKey wins — rows arrive ordered.
+    if (!partText.has(row.fieldId)) partText.set(row.fieldId, row.valueText ?? '')
+  }
+
+  return byRecord
 }

--- a/packages/lib/src/field-values/name-parts.ts
+++ b/packages/lib/src/field-values/name-parts.ts
@@ -1,0 +1,64 @@
+// packages/lib/src/field-values/name-parts.ts
+
+import type { NameValue } from './converters/json'
+import { nameConverter } from './converters/json'
+
+/**
+ * The two TEXT part fields a NAME composite is linked to.
+ *
+ * A NAME field never stores a value of its own: it is a composite over
+ * `options.name.firstNameFieldId` / `.lastNameFieldId`, and every write to it
+ * is decomposed into writes against those two part fields. See
+ * `plans/field-values/name-field-writes.md`.
+ */
+export type NameParts = {
+  firstNameFieldId: string
+  lastNameFieldId: string
+}
+
+/**
+ * Read the part-field ids off a NAME field's options.
+ *
+ * Returns `null` when the field is not a NAME field, or when its options do
+ * not carry BOTH part ids — an unlinked NAME field has no parts to decompose
+ * into, so callers must fall back to their pre-decomposition behavior rather
+ * than throw.
+ */
+export function readNameParts(field: {
+  type?: string | null
+  options?: unknown
+}): NameParts | null {
+  if (field.type !== 'NAME') return null
+
+  const nameOpts = (field.options as Record<string, unknown> | null | undefined)?.name as
+    | { firstNameFieldId?: unknown; lastNameFieldId?: unknown }
+    | undefined
+
+  const first = nameOpts?.firstNameFieldId
+  const last = nameOpts?.lastNameFieldId
+  if (typeof first !== 'string' || !first) return null
+  if (typeof last !== 'string' || !last) return null
+  if (first === last) return null
+
+  return { firstNameFieldId: first, lastNameFieldId: last }
+}
+
+/**
+ * Coerce any accepted NAME input into its two part strings.
+ *
+ * Delegates to `nameConverter.toTypedInput` so every shape the NAME field has
+ * ever accepted keeps working after decomposition — an object
+ * (`{ firstName, lastName }`), an already-typed `json` value, and a bare full
+ * name string (split on the first whitespace run). Blank/empty input and
+ * `null` coerce to `null`, which callers treat as "clear both parts".
+ */
+export function coerceNameInput(value: unknown): { firstName: string; lastName: string } | null {
+  const typed = nameConverter.toTypedInput(value)
+  if (!typed) return null
+
+  const raw = (typed as { value?: unknown }).value as NameValue | undefined
+  return {
+    firstName: raw?.firstName ?? '',
+    lastName: raw?.lastName ?? '',
+  }
+}

--- a/packages/lib/src/field-values/types.ts
+++ b/packages/lib/src/field-values/types.ts
@@ -113,6 +113,16 @@ export interface SetValueWithBuiltInInput {
    * the stamp. See {@link SetValuesForEntityInput.skipInstanceStamp}.
    */
   skipInstanceStamp?: boolean
+  /**
+   * When `true`, the NAME-composed `displayName` recompute this write would
+   * trigger as a PART of a NAME display field is suppressed. Set only by a
+   * decomposed NAME write on its two part writes: that frame holds both part
+   * strings and recomputes once through `recomposeNameDisplayFromParts` with
+   * no sibling SELECT, where two part writes would each pay one SELECT and
+   * one column write — and the second SELECT would re-read what the first
+   * just committed (`plans/field-values/name-field-writes.md` §4a).
+   */
+  skipNameCompose?: boolean
 }
 
 /**
@@ -308,6 +318,8 @@ export interface SetValueWithTypeInput {
   skipSearchTextRefresh?: boolean
   /** See {@link SetValueWithBuiltInInput.skipInstanceStamp}. */
   skipInstanceStamp?: boolean
+  /** See {@link SetValueWithBuiltInInput.skipNameCompose}. */
+  skipNameCompose?: boolean
 }
 
 /** Input for adding a value to a multi-value field */


### PR DESCRIPTION
## The bug

A NAME field is a composite over two TEXT part fields. Editing it must write those parts; writing the NAME field itself leaves them stale, and a refetch recomposes the old name. The UI looked right because the optimistic store updated the NAME key locally.

## Root cause

`PropertyProvider` has **two** commit paths and only one of them split:

| function | NAME branch? |
|---|---|
| `commitValue` | yes |
| `commitValueAndClose` | **none** — raw `storeSave` |

Both name editors (`name-input-field.tsx`, `name-field-input.tsx`) call the unsplit one from `commitCloseAndNavigate`, fired on **Enter / ArrowDown**. `commitValue` is reached only via `onBeforeClose`, i.e. clicking away.

So: click away → correct. Press Enter → raw NAME row, stale parts.

This has been present since the linking was built (`e0c4315e1`, 2026-01-21) — the split only ever lived in `commitValue`. Not a recent regression; a stray row dated three days before the reported "it broke around Aug 20" confirms the date never held up.

## The fix

Both sides, so no single surface can regress it again.

- **Client** — the split moves into the save funnel, *below* the commit fork, resolving the field from the resource store rather than a caller-supplied prop (`PropertyProvider`'s is typed `any`). Fixes the grid paste/fill path and the bulk-update dialog, which never split at all. Scattered copies deleted.
- **Server** — `setValueWithBuiltIn` decomposes every NAME write into its two part writes, covering the SDK, API, importer, workflows, Kopilot and `record.create` regardless of what the client sends. Unlinked composites warn and fall through rather than throwing.
- **Reads** compose from the parts, so a stray stored row is never returned.

`name-parts.ts` holds the one linkage predicate both directions decompose on, re-exported through `field-values/client` so the browser uses the same answer.

## Query cost went down

| Read path | Before | After |
|---|---|---|
| `getValues`, `fieldIds` omitted | 2 (second re-SELECTs rows already in memory) | **1** |
| `getValues`, `fieldIds` given | 2 | **1** — part ids widen the existing `IN` |
| `batchGetValues`, per NAME field | 2 | **1** |

| Per decomposed write | Before | After |
|---|---|---|
| sibling `SELECT valueText` | 2 | **0** |
| `displayName` UPDATE | 2 | **1** |
| `EntityInstance` UPDATEs | 3 | **1** |
| `updateSearchText` rebuilds | 2 | **1** |

Writes go 1 → 2 field writes on the doors that were broken — the irreducible cost of updating two fields. The drawer and create form are unchanged; the client split already sent two part writes.

## Testing

- `packages/lib` `src/field-values/`: **33 files / 339 tests**
- `apps/web` component suites: **30 files / 350 tests**
- `packages/lib` `tsc`: **0 errors under `src/`**; `apps/web` `tsc`: **0 in touched files**

The regression test mounts the real `PropertyProvider` and drives **both** commit paths, asserting each produces two part writes. Read-path tests assert query **counts**, not just values.

## Known, deliberately out of scope

- `search-text.ts:217`'s NAME arm still reads `valueJson` off the NAME field's own row, so ~84 pre-existing stray rows keep feeding stale name text into search. No new ones can be written. Data repair was decided against separately.
- `applyBulk` with `mode: 'add'` on a NAME field still 400s, same as every other single-valued type.