### PR TITLE
fix(billing): the uninstalled paywall linked to a shopify page that 404s

### DIFF
--- a/apps/web/src/components/subscriptions/subscription-ended.tsx
+++ b/apps/web/src/components/subscriptions/subscription-ended.tsx
@@ -3,7 +3,6 @@
 
 import { Button } from '@auxx/ui/components/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@auxx/ui/components/card'
-import { toastError } from '@auxx/ui/components/toast'
 import { Clock } from 'lucide-react'
 import Link from 'next/link'
 import { api } from '~/trpc/react'
@@ -29,36 +28,38 @@ export function SubscriptionEnded({
 }: SubscriptionEndedProps) {
   const { data: subscription } = api.billing.getCurrentSubscription.useQuery()
   const billingProvider = subscription?.billingProvider
-  const billingCycle = subscription?.billingCycle
   const subPlan = subscription?.plan
   const resolvedPlanName = (typeof subPlan === 'string' ? subPlan : subPlan?.name) ?? planName
-  const normalizedPlanName = resolvedPlanName?.trim() ? resolvedPlanName.trim() : 'Pro'
-  const displayPlanName = normalizedPlanName.charAt(0).toUpperCase() + normalizedPlanName.slice(1)
-
-  const title = isTrialEnded
-    ? `Your ${displayPlanName} trial has ended`
-    : `${displayPlanName} subscription has ended`
-
-  const description = 'Upgrade to maintain access to your organization and premium features'
-
-  const upgradeSubscription = api.billing.upgradeSubscription.useMutation({
-    onSuccess: (result) => {
-      if (result.url) window.location.assign(result.url)
-    },
-    onError: (error) => {
-      toastError({ title: 'Error starting upgrade', description: error.message })
-    },
-  })
+  const normalizedPlanName = resolvedPlanName?.trim() ? resolvedPlanName.trim() : null
+  const displayPlanName = normalizedPlanName
+    ? normalizedPlanName.charAt(0).toUpperCase() + normalizedPlanName.slice(1)
+    : null
 
   const isShopify = billingProvider === 'shopify'
 
+  // Only Shopify orgs get a CTA that leaves the app, and where it leads depends on
+  // whether the shop still has the app installed — the hosted pricing page 404s once it
+  // doesn't. Probes the Admin API, so it stays scoped to this screen.
+  const { data: planAction, isPending: planActionPending } =
+    api.billing.getShopifyPlanAction.useQuery(undefined, { enabled: isShopify })
+  const isUninstalled = planAction?.kind === 'uninstalled'
+
+  const title = isTrialEnded
+    ? displayPlanName
+      ? `Your ${displayPlanName} trial has ended`
+      : 'Your trial has ended'
+    : isUninstalled
+      ? 'Auxx was uninstalled'
+      : displayPlanName
+        ? `${displayPlanName} subscription has ended`
+        : 'Your subscription has ended'
+
+  const description = isUninstalled
+    ? `Auxx was removed from ${planAction.shopDomain}. Reinstall it from your Shopify admin — Settings → Apps → Uninstalled apps — to pick a plan again.`
+    : 'Upgrade to maintain access to your organization and premium features'
+
   const handleApproveInShopify = () => {
-    upgradeSubscription.mutate({
-      planName: normalizedPlanName,
-      billingCycle: billingCycle ?? 'MONTHLY',
-      successUrl: `${window.location.origin}/billing/subscription/activated`,
-      cancelUrl: window.location.href,
-    })
+    if (planAction?.kind === 'plans') window.location.assign(planAction.url)
   }
 
   return (
@@ -76,17 +77,25 @@ export function SubscriptionEnded({
           </CardHeader>
           <CardContent className='space-y-3'>
             {isShopify ? (
-              <Button
-                className='w-full'
-                onClick={handleApproveInShopify}
-                loading={upgradeSubscription.isPending}
-                loadingText='Redirecting to Shopify...'>
-                Approve in Shopify
-              </Button>
+              // Only offer the CTA when we know it leads somewhere. Shopify's pricing page
+              // 404s for an uninstalled app, and reinstalling happens in the Shopify admin,
+              // which has no deep link — so `uninstalled` (and a failed probe, e.g. a member
+              // without billing access) renders nothing and the description says where to go.
+              planActionPending || planAction?.kind === 'plans' ? (
+                <Button
+                  className='w-full'
+                  onClick={handleApproveInShopify}
+                  loading={planActionPending}
+                  loadingText='Checking your Shopify store...'>
+                  Approve in Shopify
+                </Button>
+              ) : null
             ) : (
               <>
                 <Button asChild className='w-full'>
-                  <Link href='/subscription/convert/addons'>Continue with {displayPlanName}</Link>
+                  <Link href='/subscription/convert/addons'>
+                    Continue with {displayPlanName ?? 'your plan'}
+                  </Link>
                 </Button>
                 <Button asChild variant='translucent' className='w-full'>
                   <Link href='/subscription/convert/explore'>Explore plans</Link>

--- a/apps/web/src/server/api/routers/billing.ts
+++ b/apps/web/src/server/api/routers/billing.ts
@@ -167,19 +167,19 @@ export const billingRouter = createTRPCRouter({
   }),
 
   /**
-   * Returns the URL of Shopify's hosted pricing page for the current org. Used by the
-   * Settings → Plans "Manage plan in Shopify Admin" CTA on Shopify-billed orgs — the
-   * merchant picks/changes the plan on Shopify's page, approves, and returns to
-   * /billing/subscription/activated.
+   * What a Shopify-billed org can still do about its plan: `plans` carries the URL of
+   * Shopify's hosted picker (the merchant changes plan there, approves, and returns to
+   * /billing/subscription/activated), `uninstalled` means the app is gone from the shop
+   * and there is no page to send them to. Probes the Admin API, so call it from surfaces
+   * that render a CTA — not on every page load.
    */
-  getShopifyPricingUrl: billingReadProcedure.query(async ({ ctx }) => {
+  getShopifyPlanAction: billingReadProcedure.query(async ({ ctx }) => {
     const organizationId = getUserOrganizationId(ctx.session)
     if (!organizationId) {
       throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Organization ID not found' })
     }
     const provider = getProvider('shopify') as ShopifyBillingProvider
-    const url = await provider.getPlanSelectionUrl(organizationId)
-    return { url }
+    return provider.getPlanAction(organizationId)
   }),
 
   /**

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -20,6 +20,7 @@ export {
   type SeatDayEventStatus,
   type SeatDayReport,
   ShopifyBillingProvider,
+  type ShopifyPlanAction,
 } from './providers/shopify'
 export { StripeBillingProvider } from './providers/stripe'
 export type {

--- a/packages/billing/src/providers/shopify/index.ts
+++ b/packages/billing/src/providers/shopify/index.ts
@@ -14,7 +14,12 @@ export {
 } from './app-events-client'
 export { createShopifyAdminClient } from './client'
 export { ensureBillingWebhooks } from './ensure-webhooks'
-export { extractStoreHandle, ShopifyBillingProvider } from './provider'
+export { isAppInstalled } from './install-state'
+export {
+  extractStoreHandle,
+  ShopifyBillingProvider,
+  type ShopifyPlanAction,
+} from './provider'
 export { reportOrgSeatDay, type SeatDayReport } from './seat-usage'
 export type { LocalStatus } from './status-mapping'
 export { mapActiveSubscriptionToStatus } from './status-mapping'

--- a/packages/billing/src/providers/shopify/install-state.ts
+++ b/packages/billing/src/providers/shopify/install-state.ts
@@ -1,0 +1,59 @@
+// packages/billing/src/providers/shopify/install-state.ts
+
+import { configService } from '@auxx/credentials'
+import { getAppConnection } from '@auxx/credentials/connections'
+import { createScopedLogger } from '@auxx/logger'
+import { credentialLock } from '../../credential-lock'
+import { createShopifyAdminClient } from './client'
+
+const logger = createScopedLogger('billing/shopify/install-state')
+
+/** The cheapest authenticated Admin API call there is — we only care whether it answers. */
+const PROBE_QUERY = `#graphql
+  query ShopInstallProbe { shop { id } }
+`
+
+/**
+ * Answers whether the app is still installed on a shop, using the org's stored access
+ * token. Shopify revokes that token at uninstall, so a 401/403 is a definitive "no".
+ *
+ * Any other outcome — network failure, schema error, missing credential — returns `true`.
+ * The caller uses this to choose between the hosted pricing page and a reinstall link,
+ * and sending an installed merchant to reinstall is the worse of the two errors.
+ */
+export async function isAppInstalled(input: {
+  shopDomain: string
+  organizationId: string
+}): Promise<boolean> {
+  const appId = configService.get<string>('SHOPIFY_APP_ID')
+  if (!appId) throw new Error('SHOPIFY_APP_ID must be configured')
+
+  try {
+    // Org-scoped connection (written at install) — an empty userId falls through
+    // getAppConnection's user-scoped lookup, same as active-subscription.ts.
+    const conn = await getAppConnection(appId, input.organizationId, '', { lock: credentialLock })
+    if (conn.isErr()) throw conn.error
+    const accessToken = conn.value.accessToken
+    if (!accessToken) throw new Error('Shopify connection has no access token')
+
+    const client = createShopifyAdminClient({ shopDomain: input.shopDomain, accessToken })
+    const res = (await client.request(PROBE_QUERY)) as {
+      errors?: { networkStatusCode?: number }
+    }
+    const statusCode = res.errors?.networkStatusCode
+    if (statusCode === 401 || statusCode === 403) {
+      logger.info('Shopify app is uninstalled — token rejected', {
+        shopDomain: input.shopDomain,
+        statusCode,
+      })
+      return false
+    }
+    return true
+  } catch (error) {
+    logger.warn('Install probe failed — assuming still installed', {
+      shopDomain: input.shopDomain,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return true
+  }
+}

--- a/packages/billing/src/providers/shopify/provider.ts
+++ b/packages/billing/src/providers/shopify/provider.ts
@@ -20,10 +20,20 @@ import type {
   RestoreSubscriptionInput,
 } from '../types'
 import { type ActiveSubscription, getActiveSubscription } from './active-subscription'
+import { isAppInstalled } from './install-state'
 import { mapActiveSubscriptionToStatus } from './status-mapping'
 import { cancelSubscriptionByShop, resolveOrgIdByShopDomain } from './webhook'
 
 const logger = createScopedLogger('billing/shopify/provider')
+
+/**
+ * What a merchant with no live subscription can still do from inside Auxx. `plans` links
+ * to Shopify's hosted picker; `uninstalled` means there is nothing to link to, because
+ * the picker only exists for a shop that currently has the app installed.
+ */
+export type ShopifyPlanAction =
+  | { kind: 'plans'; url: string }
+  | { kind: 'uninstalled'; shopDomain: string }
 
 /**
  * Shopify App Pricing adapter. Plans live in the Partner Dashboard; Shopify hosts the
@@ -79,6 +89,22 @@ export class ShopifyBillingProvider implements BillingProvider {
   async getPlanSelectionUrl(organizationId: string): Promise<string> {
     const shopDomain = await this.loadShopDomain(organizationId)
     return this.buildPricingPageUrl(shopDomain)
+  }
+
+  /**
+   * What to offer a merchant whose subscription is no longer live. `getPlanSelectionUrl`
+   * alone is not safe here: `charges/<app>/pricing_plans` 404s once the shop uninstalls
+   * the app, and App Store requirement 2.1.1 counts a web error reached from our UI
+   * against us. Probes the install first and reports `uninstalled` instead of handing
+   * back a dead link — the merchant reinstalls from their Shopify admin, which we can't
+   * deep-link (Shopify rewrites `?tab=uninstalled` back to the installed tab).
+   */
+  async getPlanAction(organizationId: string): Promise<ShopifyPlanAction> {
+    const shopDomain = await this.loadShopDomain(organizationId)
+    const installed = await isAppInstalled({ shopDomain, organizationId })
+    return installed
+      ? { kind: 'plans', url: this.buildPricingPageUrl(shopDomain) }
+      : { kind: 'uninstalled', shopDomain }
   }
 
   async cancelSubscription(_input: CancelSubscriptionInput): Promise<void> {


### PR DESCRIPTION
## The bug

Uninstalling the app from a Shopify store fires `app/uninstalled` → `cancelSubscriptionByShop` → `status: 'canceled'`, which makes `app-layout-wrapper.tsx` swap the entire `/app/**` shell for `SubscriptionEnded`. That screen's only action was **Approve in Shopify** → `admin.shopify.com/store/<shop>/charges/<app>/pricing_plans`.

That page only exists for a shop that currently has the app installed. Verified against the live dev store: it renders Shopify's **"There's no page at this address"** 404. So the single way out of the paywall was a dead end, and App Store requirement 2.1.1 counts a web error reached from our UI against us:

> "Your app must be free from user interface bugs, display issues, or error pages that fully prevent completion of the review. Web errors such as 404's, 500's, 300's, and etc are not acceptable."

## Why it couldn't just be fixed in the component

Cancelling a plan while the app is still installed and uninstalling the app produce the **identical local row** — `activeSubscriptions` comes back empty either way, both land on `status: 'canceled'` with a stale `planId`. The first case wants the pricing page (it works, and requirement 1.2.3 wants an in-app path to change plans); the second has nowhere to point.

## What this does

- **`install-state.ts`** (new) — `isAppInstalled()` runs one `query { shop { id } }` with the org's stored token. Shopify revokes it at uninstall, so a 401/403 is definitive. Every other failure returns `true`, because telling an installed merchant they're uninstalled is the worse error.
- **`provider.getPlanAction()`** — `{ kind: 'plans', url }` or `{ kind: 'uninstalled', shopDomain }`.
- **`billing.getShopifyPlanAction`** — repurposes `getShopifyPricingUrl`, which had zero callers (noted as dead in `plans/billing/v3/05-plan-change-sync-fix.md`).
- **`subscription-ended.tsx`** — the CTA renders only while the probe is in flight or when it resolves to `plans`. Uninstalled shows **no button** and names the real reinstall path: Settings → Apps → Uninstalled apps. There's nothing to deep-link — Shopify rewrites `?tab=uninstalled` straight back to `tab=installed`.

A failed probe also renders no button, which fixes a smaller bug: this screen shows to every member of a walled org, but the procedure needs `billingView`, so members without it used to get a button that silently did nothing.

Two cleanups in the same file: the screen no longer calls `upgradeSubscription` (for Shopify it only ever returned the same pricing URL), and the `?? 'Pro'` fallback is gone — there is no Pro plan, so that path threw `PLAN_NOT_FOUND`.

## Testing

- `packages/billing` tsc exits 0; IDE diagnostics clean on both `apps/web` files; biome clean.
- `apps/web`'s full tsc still exits via SIGABRT — pre-existing, documented in CLAUDE.md.
- **No unit test.** `providers/shopify/` has no test files at all, and covering `isAppInstalled` means mocking `getAppConnection` plus the Admin client — a pattern this package doesn't have yet. Worth adding, deliberately not bolted on here.
- **Not verified end to end:** the 401 branch was never exercised against a genuinely uninstalled shop — the store had already been reinstalled by the time this was written. `networkStatusCode` is real (`@shopify/graphql-client@1.4.1`), but the next uninstall is worth one look at the `billing/shopify/install-state` log line.

## Not in scope

The Free-plan case produces the same `canceled` + stale `planId` row and therefore the same lockout. That's an accepted product decision for now, not an oversight.