### PR TITLE
fix(connections): bring-your-own oauth client was collected but never used

### DIFF
--- a/apps/web/src/app/api/apps/[slug]/oauth2/authorize/app-oauth-authorize-access.test.ts
+++ b/apps/web/src/app/api/apps/[slug]/oauth2/authorize/app-oauth-authorize-access.test.ts
@@ -32,6 +32,7 @@ const {
   resolveAppSlug,
   resolveAppConnection,
   resolveOAuth2Client,
+  resolveOwnClientGateForOrg,
   resolveOwnClientRequirement,
 } = vi.hoisted(() => ({
   getCapabilities: vi.fn(),
@@ -43,9 +44,21 @@ const {
   resolveAppConnection: vi.fn(),
   resolveOAuth2Client: vi.fn(() => ({ clientId: 'client_abc' })),
   resolveOwnClientRequirement: vi.fn(() => ({ requiresOwnClient: false, reason: null })),
+  // Added 2026-08-25: the route swapped to the org-aware gate in #1795 and this file was
+  // never updated, so every case here 500'd on an undefined import from that PR onward.
+  resolveOwnClientGateForOrg: vi.fn(async () => ({
+    requiresOwnClient: false,
+    ownClientOptional: false,
+    reason: null,
+  })),
 }))
 
-vi.mock('@auxx/config/urls', () => ({ WEBAPP_URL: 'http://localhost:3000' }))
+// Partial for the same reason as the connections barrel below — a full replacement drops
+// every other URL export the (now real) connections module reaches for.
+vi.mock('@auxx/config/urls', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/config/urls')>()),
+  WEBAPP_URL: 'http://localhost:3000',
+}))
 
 vi.mock('@auxx/database', async () =>
   (await import('~/test/database-mock')).mockAuxxDatabase({
@@ -60,7 +73,18 @@ vi.mock('@auxx/database', async () =>
 
 vi.mock('@auxx/lib/apps', () => ({ resolveAppConnectionForRuntime: resolveAppConnection }))
 vi.mock('@auxx/lib/cache', () => ({ resolveAppSlug }))
-vi.mock('@auxx/lib/connections', () => ({ resolveOAuth2Client, resolveOwnClientRequirement }))
+/**
+ * Partial, not a full replacement: the route pulls six things off this barrel and only the
+ * two org-aware ones need stubbing. Enumerating the rest is how this file went red — #1795
+ * added `resolveOwnClientGateForOrg` to the route and the mock never grew it, so every case
+ * below 500'd on an undefined import from 2026-08-21 until 2026-08-25.
+ */
+vi.mock('@auxx/lib/connections', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/lib/connections')>()),
+  resolveOAuth2Client,
+  resolveOwnClientGateForOrg,
+  resolveOwnClientRequirement,
+}))
 
 /**
  * The `@auxx/lib/permissions` barrel hangs under vitest, so it can't be partially mocked — but
@@ -80,8 +104,14 @@ vi.mock('@auxx/lib/permissions', async () => {
   }
 })
 
-vi.mock('@auxx/redis', () => ({ getRedisClient: async () => redis }))
-vi.mock('@auxx/services/app-connections', () => ({ interpolateConnectionFields: interpolate }))
+vi.mock('@auxx/redis', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/redis')>()),
+  getRedisClient: async () => redis,
+}))
+vi.mock('@auxx/services/app-connections', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/services/app-connections')>()),
+  interpolateConnectionFields: interpolate,
+}))
 vi.mock('@auxx/logger', async () => (await import('~/test/logger-mock')).mockAuxxLogger())
 vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
 vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))

--- a/apps/web/src/app/api/apps/[slug]/oauth2/authorize/byo-client.test.ts
+++ b/apps/web/src/app/api/apps/[slug]/oauth2/authorize/byo-client.test.ts
@@ -1,0 +1,264 @@
+// apps/web/src/app/api/apps/[slug]/oauth2/authorize/byo-client.test.ts
+//
+// The regression guard for plans/connections/byo-oauth-client-runtime-gap.md F1.
+//
+// What this pins is one thing: **which `client_id` ends up on the authorize URL**. The whole
+// bug was that a bring-your-own client id/secret was collected by the dialog, sent as
+// `var_clientId`/`var_clientSecret`, and then dropped by this route's allowlist — which read
+// the definition's STORED `connectionVariables` (for Shopify: just `shop`) instead of the
+// gated list that injects the BYO descriptors. The merchant was silently sent to consent for
+// the PLATFORM app, believing they were installing their own.
+//
+// Before this file, `var_clientId` appeared in exactly two files repo-wide — the two
+// authorize routes — and neither had a test.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  resolveAppConnectionForRuntime,
+  getSession,
+  resolveAppSlug,
+  findFirstInstallation,
+  findFirstConnDef,
+  resolveOwnClientGateForOrg,
+  requirePermission,
+  redisSetex,
+} = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  resolveAppSlug: vi.fn(),
+  findFirstInstallation: vi.fn(),
+  findFirstConnDef: vi.fn(),
+  resolveOwnClientGateForOrg: vi.fn(),
+  requirePermission: vi.fn(async () => undefined),
+  redisSetex: vi.fn(async () => 'OK'),
+  resolveAppConnectionForRuntime: vi.fn(),
+}))
+
+const PLATFORM_CLIENT = '588ef3496716248f2de2d485e57364ec'
+const BYO_CLIENT = '923366ae8d1cea01903c8ce4bb2de30c'
+const BYO_SECRET = 'shpss_byo_secret_value'
+
+const ORG = 'gax9ejju84qyloup0ctdxc8r'
+const USER = 'PXDf74MTsYWf9vaVUMgLS9kWmozN6Ydz'
+const APP_ID = 'seawyfbhwukgionxzv5o30yb'
+const INSTALLATION = 'jdquls613446zt7qyxum8eqw'
+const CONN_DEF = 'mq1klf9zvjhnfczvuj8s8a0r'
+
+/** The real Shopify app def: declares `shop` only — no BYO descriptors stored. */
+const shopifyDef = {
+  id: CONN_DEF,
+  appId: APP_ID,
+  connectionType: 'oauth2-code',
+  global: true,
+  connectionVariables: [{ key: 'shop', label: 'Shop subdomain' }],
+  oauth2AuthorizeUrl: 'https://{shop}.myshopify.com/admin/oauth/authorize',
+  oauth2AccessTokenUrl: 'https://{shop}.myshopify.com/admin/oauth/access_token',
+  oauth2ClientId: PLATFORM_CLIENT,
+  oauth2ClientSecret: 'shps_platform_secret',
+  oauth2Scopes: ['read_orders', 'write_orders'],
+  oauth2Features: {},
+  oauth2TokenRequestAuthMethod: 'request-body',
+  platformClientApproved: true,
+}
+
+vi.mock('@auxx/database', () => ({
+  database: {
+    query: {
+      AppInstallation: { findFirst: (...a: unknown[]) => findFirstInstallation(...a) },
+      ConnectionDefinition: { findFirst: (...a: unknown[]) => findFirstConnDef(...a) },
+    },
+  },
+}))
+vi.mock('@auxx/lib/cache', () => ({ resolveAppSlug }))
+vi.mock('@auxx/lib/apps', () => ({ resolveAppConnectionForRuntime }))
+vi.mock('@auxx/lib/permissions', () => ({
+  PermissionKey: { integrationsManage: 'integrationsManage' },
+  requirePermission,
+}))
+vi.mock('@auxx/logger', async () => (await import('~/test/logger-mock')).mockAuxxLogger())
+// Partial: `@auxx/lib/connections` is loaded for real below, and it reaches
+// `credential-lock.ts` → `createCredentialLockProvider`. Replacing the module wholesale
+// breaks that import chain.
+vi.mock('@auxx/redis', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/redis')>()),
+  getRedisClient: async () => ({ setex: redisSetex }),
+}))
+vi.mock('next/headers', () => ({ headers: async () => new Headers() }))
+vi.mock('~/auth/server', () => ({ auth: { api: { getSession } } }))
+
+// Everything in `@auxx/lib/connections` is real EXCEPT the org-aware gate, which would need a
+// feature-permission DB read. Keeping the rest real is the point: `effectiveConnectionVariables`
+// and `resolveOAuth2Client` are exactly the collaborators under test.
+vi.mock('@auxx/lib/connections', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@auxx/lib/connections')>()),
+  resolveOwnClientGateForOrg,
+}))
+
+const authorizeUrlFor = async (params: Record<string, string>) => {
+  const { GET } = await import('./route')
+  const url = new URL('https://app.auxx.ai/api/apps/shopify/oauth2/authorize')
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v)
+  const res = await GET({ nextUrl: url, cookies: { get: () => undefined } } as never, {
+    params: Promise.resolve({ slug: 'shopify' }),
+  })
+  return res
+}
+
+const BASE_PARAMS = {
+  installation: INSTALLATION,
+  type: 'organization',
+  connectionDefinitionId: CONN_DEF,
+  var_shop: 'storage-system',
+  mode: 'redirect',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getSession.mockResolvedValue({ user: { id: USER, defaultOrganizationId: ORG } })
+  resolveAppSlug.mockResolvedValue(APP_ID)
+  findFirstInstallation.mockResolvedValue({ id: INSTALLATION, app: { title: 'Shopify' } })
+  findFirstConnDef.mockResolvedValue(shopifyDef)
+  redisSetex.mockResolvedValue('OK')
+})
+
+describe('app authorize route — bring-your-own OAuth client', () => {
+  it('uses the BYO client id when the org is entitled (F1)', async () => {
+    resolveOwnClientGateForOrg.mockResolvedValue({
+      requiresOwnClient: false,
+      ownClientOptional: true,
+      reason: 'byo-entitled',
+    })
+
+    const res = await authorizeUrlFor({
+      ...BASE_PARAMS,
+      var_clientId: BYO_CLIENT,
+      var_clientSecret: BYO_SECRET,
+    })
+
+    const location = res.headers.get('location') ?? ''
+    expect(location).toContain(`client_id=${BYO_CLIENT}`)
+    expect(location).not.toContain(PLATFORM_CLIENT)
+  })
+
+  it('carries the BYO secret into the Redis state so the code exchange can sign with it', async () => {
+    resolveOwnClientGateForOrg.mockResolvedValue({
+      requiresOwnClient: false,
+      ownClientOptional: true,
+      reason: 'byo-entitled',
+    })
+
+    await authorizeUrlFor({
+      ...BASE_PARAMS,
+      var_clientId: BYO_CLIENT,
+      var_clientSecret: BYO_SECRET,
+    })
+
+    const [, , payload] = redisSetex.mock.calls[0] as [string, number, string]
+    expect(JSON.parse(payload).connectionVariables).toMatchObject({
+      shop: 'storage-system',
+      clientId: BYO_CLIENT,
+      clientSecret: BYO_SECRET,
+    })
+  })
+
+  it('falls back to the platform client when no BYO credentials are supplied', async () => {
+    resolveOwnClientGateForOrg.mockResolvedValue({
+      requiresOwnClient: false,
+      ownClientOptional: true,
+      reason: 'byo-entitled',
+    })
+
+    const res = await authorizeUrlFor(BASE_PARAMS)
+    expect(res.headers.get('location') ?? '').toContain(`client_id=${PLATFORM_CLIENT}`)
+  })
+
+  it('ignores query-string BYO credentials when the org is NOT entitled', async () => {
+    resolveOwnClientGateForOrg.mockResolvedValue({
+      requiresOwnClient: false,
+      ownClientOptional: false,
+      reason: null,
+    })
+
+    const res = await authorizeUrlFor({
+      ...BASE_PARAMS,
+      var_clientId: BYO_CLIENT,
+      var_clientSecret: BYO_SECRET,
+    })
+
+    const location = res.headers.get('location') ?? ''
+    expect(location).toContain(`client_id=${PLATFORM_CLIENT}`)
+    expect(location).not.toContain(BYO_CLIENT)
+  })
+
+  it('rejects half a BYO pair rather than mixing clients (F4)', async () => {
+    resolveOwnClientGateForOrg.mockResolvedValue({
+      requiresOwnClient: false,
+      ownClientOptional: true,
+      reason: 'byo-entitled',
+    })
+
+    const res = await authorizeUrlFor({ ...BASE_PARAMS, var_clientId: BYO_CLIENT })
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({
+      error: expect.stringContaining('secret'),
+    })
+  })
+
+  // F1's worse half. The stored-value fallback lives INSIDE the same allowlist loop, so a
+  // reconnect that supplies no credentials used to drop the connection's own stored client
+  // and silently repoint a live BYO connection at the platform app — the exact thing
+  // `stripUnentitledOwnClientVars`' doc comment promises can never happen.
+  it('preserves a stored BYO client across a reconnect that supplies nothing', async () => {
+    resolveOwnClientGateForOrg.mockResolvedValue({
+      requiresOwnClient: false,
+      ownClientOptional: true,
+      reason: 'byo-entitled',
+    })
+    resolveAppConnectionForRuntime.mockResolvedValue({
+      isOk: () => true,
+      value: {
+        organizationConnection: {
+          fields: { shop: 'storage-system', clientId: BYO_CLIENT, clientSecret: BYO_SECRET },
+        },
+      },
+    })
+
+    const res = await authorizeUrlFor({
+      installation: INSTALLATION,
+      type: 'organization',
+      connectionDefinitionId: CONN_DEF,
+      connectionId: 'existing-credential-id',
+      mode: 'redirect',
+    })
+
+    const location = res.headers.get('location') ?? ''
+    expect(location).toContain(`client_id=${BYO_CLIENT}`)
+    expect(location).not.toContain(PLATFORM_CLIENT)
+  })
+
+  it('keeps a stored BYO client even after the org loses the entitlement', async () => {
+    resolveOwnClientGateForOrg.mockResolvedValue({
+      requiresOwnClient: false,
+      ownClientOptional: false,
+      reason: null,
+    })
+    resolveAppConnectionForRuntime.mockResolvedValue({
+      isOk: () => true,
+      value: {
+        organizationConnection: {
+          fields: { shop: 'storage-system', clientId: BYO_CLIENT, clientSecret: BYO_SECRET },
+        },
+      },
+    })
+
+    const res = await authorizeUrlFor({
+      installation: INSTALLATION,
+      type: 'organization',
+      connectionDefinitionId: CONN_DEF,
+      connectionId: 'existing-credential-id',
+      mode: 'redirect',
+    })
+
+    expect(res.headers.get('location') ?? '').toContain(`client_id=${BYO_CLIENT}`)
+  })
+})

--- a/apps/web/src/app/api/apps/[slug]/oauth2/authorize/route.ts
+++ b/apps/web/src/app/api/apps/[slug]/oauth2/authorize/route.ts
@@ -7,6 +7,8 @@ import { resolveAppConnectionForRuntime } from '@auxx/lib/apps'
 import { resolveAppSlug } from '@auxx/lib/cache'
 import {
   appOAuthCallbackUrl,
+  BYO_CLIENT_KEYS,
+  effectiveConnectionVariables,
   resolveOAuth2Client,
   resolveOwnClientGateForOrg,
   stripUnentitledOwnClientVars,
@@ -196,9 +198,13 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     // gating. A verified platform client offers BYO only to orgs holding `byoOAuthClient`.
     const ownClient = await resolveOwnClientGateForOrg(organizationId, connDef)
 
-    // Extract connection variables from query params (allowlisted by definitions)
+    // Extract connection variables from query params (allowlisted by definitions).
+    // The allowlist is the GATED list, not the raw stored column: the BYO client
+    // descriptors are injected at read time and never persisted, so iterating the stored
+    // column alone drops `var_clientId`/`var_clientSecret` and silently falls back to the
+    // platform client. See plans/connections/byo-oauth-client-runtime-gap.md §2.
     const rawVariables: Record<string, string> = {}
-    const connectionVarDefs = connDef.connectionVariables ?? []
+    const connectionVarDefs = effectiveConnectionVariables(connDef, ownClient)
     for (const varDef of connectionVarDefs) {
       const value = searchParams.get(`var_${varDef.key}`) ?? storedVariables[varDef.key]
       if (!value && varDef.required !== false) {
@@ -208,6 +214,15 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         )
       }
       if (value) rawVariables[varDef.key] = value
+    }
+
+    // A revoked entitlement must not repoint a LIVE BYO connection at the platform client.
+    // When the gate closes, `effectiveConnectionVariables` stops listing the client vars, so
+    // the loop above cannot even reach their stored values — carry them forward explicitly.
+    // `stripUnentitledOwnClientVars` below then keeps them precisely because they are stored
+    // (it only drops caller-supplied ones), which is the promise its doc comment makes.
+    for (const key of BYO_CLIENT_KEYS) {
+      if (!rawVariables[key] && storedVariables[key]) rawVariables[key] = storedVariables[key]
     }
 
     // The connect dialog hides the BYO fields when the gate offers no BYO path, but this
@@ -227,6 +242,23 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       return NextResponse.json(
         {
           error: 'This connection requires your own OAuth client id and secret',
+          reason: ownClient.reason,
+        },
+        { status: 400 }
+      )
+    }
+
+    // Half a BYO pair is never valid: the authorize would carry the caller's client id while
+    // the token exchange signed with the platform secret, and the provider answers with an
+    // opaque `invalid_client` the user cannot act on. The connect dialog already enforces
+    // all-or-nothing (`applyOwnClientDisclosure`); this is the same rule server-side, for the
+    // optional gates the guard above does not cover.
+    if (!!connectionVariables.clientId !== !!connectionVariables.clientSecret) {
+      return NextResponse.json(
+        {
+          error: connectionVariables.clientId
+            ? 'Your own OAuth client secret is required when a client id is supplied'
+            : 'Your own OAuth client id is required when a client secret is supplied',
           reason: ownClient.reason,
         },
         { status: 400 }

--- a/apps/web/src/app/api/apps/[slug]/oauth2/callback/route.ts
+++ b/apps/web/src/app/api/apps/[slug]/oauth2/callback/route.ts
@@ -4,7 +4,11 @@ import { WEBAPP_URL } from '@auxx/config/urls'
 import { database as db } from '@auxx/database'
 import { saveAppConnection } from '@auxx/lib/apps'
 import { resolveAppSlug } from '@auxx/lib/cache'
-import { appOAuthCallbackUrl, resolveOAuth2Client } from '@auxx/lib/connections'
+import {
+  appOAuthCallbackUrl,
+  resolveOAuth2Client,
+  splitConnectionVariablesBySecrecy,
+} from '@auxx/lib/connections'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
 import { interpolateConnectionFields } from '@auxx/services/app-connections'
@@ -320,17 +324,15 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
       }
     }
 
-    // Split stored variables by the definition's secret flag: secret-flagged values are
-    // encrypted under `secrets.fields`; only plain ones persist in plaintext metadata.
-    const secretVariableKeys = new Set(
-      (connDef.connectionVariables ?? []).filter((v) => v.secret).map((v) => v.key)
+    // Split stored variables by secrecy: secret values are encrypted under `secrets.fields`;
+    // only plain ones persist in plaintext metadata. Secrecy is a property of the KEY, not of
+    // whether this def declared it — `clientSecret` is flagged only on the injected BYO
+    // descriptors, and plaintext metadata is shipped to the browser by `apps.listConnections`.
+    // See plans/connections/byo-oauth-client-runtime-gap.md §3 F2.
+    const { secretFields, plainVariables } = splitConnectionVariablesBySecrecy(
+      connDef,
+      connectionVariables
     )
-    const secretFields: Record<string, string> = {}
-    const plainVariables: Record<string, string> = {}
-    for (const [key, value] of Object.entries(connectionVariables)) {
-      if (secretVariableKeys.has(key)) secretFields[key] = value
-      else plainVariables[key] = value
-    }
 
     // Save connection to Credential
     const result = await saveAppConnection(

--- a/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/authorize/route.ts
+++ b/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/authorize/route.ts
@@ -5,6 +5,8 @@ import type { OAuth2Features } from '@auxx/database'
 import { database as db } from '@auxx/database'
 import { supportsPersonalChannelConnection } from '@auxx/lib/channels'
 import {
+  BYO_CLIENT_KEYS,
+  effectiveConnectionVariables,
   providerOAuthCallbackUrl,
   resolveConnectionForRuntime,
   resolveOAuth2Client,
@@ -148,9 +150,12 @@ export async function GET(
     // only to orgs holding `byoOAuthClient`.
     const ownClient = await resolveOwnClientGateForOrg(organizationId, connDef)
 
-    // Extract connection variables from query params (allowlisted by the definition)
+    // Extract connection variables from query params (allowlisted by the definition).
+    // GATED list, not the raw stored column — the BYO client descriptors are injected at
+    // read time and never persisted, so the stored column alone cannot see them.
+    // See plans/connections/byo-oauth-client-runtime-gap.md §2.
     const rawVariables: Record<string, string> = {}
-    for (const varDef of connDef.connectionVariables ?? []) {
+    for (const varDef of effectiveConnectionVariables(connDef, ownClient)) {
       const value = searchParams.get(`var_${varDef.key}`) ?? storedVariables[varDef.key]
       if (!value && varDef.required !== false) {
         return NextResponse.json(
@@ -159,6 +164,15 @@ export async function GET(
         )
       }
       if (value) rawVariables[varDef.key] = value
+    }
+
+    // A revoked entitlement must not repoint a LIVE BYO connection at the platform client.
+    // When the gate closes, `effectiveConnectionVariables` stops listing the client vars, so
+    // the loop above cannot even reach their stored values — carry them forward explicitly.
+    // `stripUnentitledOwnClientVars` below then keeps them precisely because they are stored
+    // (it only drops caller-supplied ones), which is the promise its doc comment makes.
+    for (const key of BYO_CLIENT_KEYS) {
+      if (!rawVariables[key] && storedVariables[key]) rawVariables[key] = storedVariables[key]
     }
 
     // The dialog hides the BYO fields when the gate offers no BYO path, but this route
@@ -177,6 +191,23 @@ export async function GET(
       return NextResponse.json(
         {
           error: 'This connection requires your own OAuth client id and secret',
+          reason: ownClient.reason,
+        },
+        { status: 400 }
+      )
+    }
+
+    // Half a BYO pair is never valid: the authorize would carry the caller's client id while
+    // the token exchange signed with the platform secret, and the provider answers with an
+    // opaque `invalid_client` the user cannot act on. The connect dialog already enforces
+    // all-or-nothing (`applyOwnClientDisclosure`); this is the same rule server-side, for the
+    // optional gates the guard above does not cover.
+    if (!!connectionVariables.clientId !== !!connectionVariables.clientSecret) {
+      return NextResponse.json(
+        {
+          error: connectionVariables.clientId
+            ? 'Your own OAuth client secret is required when a client id is supplied'
+            : 'Your own OAuth client id is required when a client secret is supplied',
           reason: ownClient.reason,
         },
         { status: 400 }

--- a/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/callback/route.ts
+++ b/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/callback/route.ts
@@ -7,6 +7,7 @@ import {
   resolveOAuth2Client,
   runPostConnectHook,
   saveConnection,
+  splitConnectionVariablesBySecrecy,
 } from '@auxx/lib/connections'
 import { createScopedLogger } from '@auxx/logger'
 import { getRedisClient } from '@auxx/redis'
@@ -254,17 +255,14 @@ export async function GET(
       }
     }
 
-    // Split stored variables by the definition's secret flag: secret-flagged values are encrypted
-    // under `secrets.fields`; plain ones persist in plaintext metadata.
-    const secretVariableKeys = new Set(
-      (connDef.connectionVariables ?? []).filter((v) => v.secret).map((v) => v.key)
+    // Split stored variables by secrecy: secret values are encrypted under `secrets.fields`;
+    // plain ones persist in plaintext metadata. Secrecy is a property of the KEY, not of
+    // whether this def declared it — `clientSecret` is flagged only on the injected BYO
+    // descriptors. See plans/connections/byo-oauth-client-runtime-gap.md §3 F2.
+    const { secretFields, plainVariables } = splitConnectionVariablesBySecrecy(
+      connDef,
+      connectionVariables
     )
-    const secretFields: Record<string, string> = {}
-    const plainVariables: Record<string, string> = {}
-    for (const [key, value] of Object.entries(connectionVariables)) {
-      if (secretVariableKeys.has(key)) secretFields[key] = value
-      else plainVariables[key] = value
-    }
 
     const result = await saveConnection({
       connectionDefinitionId: connDef.id,

--- a/packages/credentials/src/connections/__tests__/byo-client-variables.test.ts
+++ b/packages/credentials/src/connections/__tests__/byo-client-variables.test.ts
@@ -1,0 +1,136 @@
+// packages/credentials/src/connections/__tests__/byo-client-variables.test.ts
+//
+// Regression guard for plans/connections/byo-oauth-client-runtime-gap.md.
+//
+// The bug these cover: BYO client descriptors are injected at READ time and never stored on
+// a ConnectionDefinition, so any server code that derives an allowlist (or a secret-flag set)
+// from the raw `connectionVariables` column silently drops `clientId`/`clientSecret` and
+// falls back to the platform OAuth client — with no error anywhere.
+
+import { describe, expect, it } from 'vitest'
+import {
+  BYO_CLIENT_VARS,
+  effectiveConnectionVariables,
+  splitConnectionVariablesBySecrecy,
+} from '../resolve-connection-definition'
+
+const OPEN_OPTIONAL = { requiresOwnClient: false, ownClientOptional: true }
+const OPEN_REQUIRED = { requiresOwnClient: true, ownClientOptional: false }
+const CLOSED = { requiresOwnClient: false, ownClientOptional: false }
+
+/** Shopify's real shape: one declared variable, no BYO descriptors. */
+const undeclaredDef = {
+  connectionType: 'oauth2-code',
+  connectionVariables: [{ key: 'shop', label: 'Shop subdomain' }],
+}
+
+/** The Google app rows' shape: BYO descriptors appended by data migration 039. */
+const declaredDef = {
+  connectionType: 'oauth2-code',
+  connectionVariables: [
+    { key: 'clientId', label: 'Client ID', required: false },
+    { key: 'clientSecret', label: 'Client Secret', secret: true, required: false },
+  ],
+}
+
+describe('effectiveConnectionVariables', () => {
+  it('injects the BYO client vars for a def that does not declare them', () => {
+    const keys = effectiveConnectionVariables(undeclaredDef, OPEN_OPTIONAL).map((v) => v.key)
+    expect(keys).toContain('shop')
+    expect(keys).toContain('clientId')
+    expect(keys).toContain('clientSecret')
+  })
+
+  it('does not duplicate them for a def that already declares them', () => {
+    const keys = effectiveConnectionVariables(declaredDef, OPEN_OPTIONAL).map((v) => v.key)
+    expect(keys.filter((k) => k === 'clientId')).toHaveLength(1)
+    expect(keys.filter((k) => k === 'clientSecret')).toHaveLength(1)
+  })
+
+  it('marks them required only when the gate demands an own client', () => {
+    const optional = effectiveConnectionVariables(undeclaredDef, OPEN_OPTIONAL)
+    const required = effectiveConnectionVariables(undeclaredDef, OPEN_REQUIRED)
+    expect(optional.find((v) => v.key === 'clientId')?.required).toBe(false)
+    expect(required.find((v) => v.key === 'clientId')?.required).toBe(true)
+  })
+
+  it('removes them entirely when the gate is closed', () => {
+    const keys = effectiveConnectionVariables(undeclaredDef, CLOSED).map((v) => v.key)
+    expect(keys).toEqual(['shop'])
+  })
+
+  it('leaves non-oauth2-code defs untouched', () => {
+    const secretDef = {
+      connectionType: 'secret',
+      connectionVariables: [{ key: 'apiKey', label: 'API key', secret: true }],
+    }
+    expect(effectiveConnectionVariables(secretDef, OPEN_OPTIONAL).map((v) => v.key)).toEqual([
+      'apiKey',
+    ])
+  })
+
+  it('tolerates a null connectionVariables column', () => {
+    const keys = effectiveConnectionVariables(
+      { connectionType: 'oauth2-code', connectionVariables: null },
+      OPEN_OPTIONAL
+    ).map((v) => v.key)
+    expect(keys).toEqual(['clientId', 'clientSecret'])
+  })
+})
+
+describe('splitConnectionVariablesBySecrecy', () => {
+  it('encrypts clientSecret even when the def never declared it', () => {
+    const { secretFields, plainVariables } = splitConnectionVariablesBySecrecy(undeclaredDef, {
+      shop: 'storage-system',
+      clientId: 'public-client-id',
+      clientSecret: 'shpss_super_secret',
+    })
+    expect(secretFields).toEqual({ clientSecret: 'shpss_super_secret' })
+    expect(plainVariables).toEqual({ shop: 'storage-system', clientId: 'public-client-id' })
+  })
+
+  it('behaves identically for a def that does declare them', () => {
+    const { secretFields, plainVariables } = splitConnectionVariablesBySecrecy(declaredDef, {
+      clientId: 'public-client-id',
+      clientSecret: 'secret',
+    })
+    expect(secretFields).toEqual({ clientSecret: 'secret' })
+    expect(plainVariables).toEqual({ clientId: 'public-client-id' })
+  })
+
+  it('still honours a def-declared secret flag on its own variables', () => {
+    const def = {
+      connectionVariables: [
+        { key: 'account', label: 'Account' },
+        { key: 'token', label: 'Token', secret: true },
+      ],
+    }
+    const { secretFields, plainVariables } = splitConnectionVariablesBySecrecy(def, {
+      account: '123',
+      token: 'tok',
+    })
+    expect(secretFields).toEqual({ token: 'tok' })
+    expect(plainVariables).toEqual({ account: '123' })
+  })
+
+  it('never routes clientSecret into plaintext metadata for any def shape', () => {
+    for (const def of [undeclaredDef, declaredDef, { connectionVariables: null }]) {
+      const { plainVariables } = splitConnectionVariablesBySecrecy(def, { clientSecret: 'x' })
+      expect(plainVariables).not.toHaveProperty('clientSecret')
+    }
+  })
+
+  it('keeps the always-secret set aligned with the canonical descriptors', () => {
+    // If a BYO descriptor is ever added or its `secret` flag flipped, this catches the drift.
+    const declaredSecretKeys = BYO_CLIENT_VARS.filter((v) => v.secret).map((v) => v.key)
+    for (const key of declaredSecretKeys) {
+      const { secretFields } = splitConnectionVariablesBySecrecy(
+        { connectionVariables: [] },
+        {
+          [key]: 'value',
+        }
+      )
+      expect(secretFields).toHaveProperty(key)
+    }
+  })
+})

--- a/packages/credentials/src/connections/index.ts
+++ b/packages/credentials/src/connections/index.ts
@@ -28,10 +28,12 @@ export {
   BYO_CLIENT_VARS,
   type ConnectionDefinitionForRefresh,
   type CredentialOwner,
+  effectiveConnectionVariables,
   gateConnectionVariables,
   loadDefinitionForCredential,
   resolveOAuth2Client,
   resolveOAuth2RefreshConfig,
   resolveOwnClientRequirement,
+  splitConnectionVariablesBySecrecy,
 } from './resolve-connection-definition'
 export type { DecryptedConnectionData } from './types'

--- a/packages/credentials/src/connections/resolve-connection-definition.ts
+++ b/packages/credentials/src/connections/resolve-connection-definition.ts
@@ -176,6 +176,54 @@ export function gateConnectionVariables(
 }
 
 /**
+ * The variables a connect attempt may actually supply: the definition's stored
+ * `connectionVariables` **union** whatever the own-client gate injects.
+ *
+ * The BYO client descriptors are never persisted on a definition — `gateConnectionVariables`
+ * adds them at read time for the connect UI. A server route that builds its allowlist (or
+ * its secret-flag set) from the raw stored column therefore cannot see `clientId` /
+ * `clientSecret` at all, silently drops them off the query string, and falls back to the
+ * platform client. Routing every such read through this helper keeps the UI projection and
+ * the server allowlist the same function by construction.
+ *
+ * See `plans/connections/byo-oauth-client-runtime-gap.md` §2.
+ */
+export function effectiveConnectionVariables(
+  def: { connectionType: string; connectionVariables?: ConnectionVariable[] | null },
+  gate: { requiresOwnClient: boolean; ownClientOptional: boolean }
+): ConnectionVariable[] {
+  return gateConnectionVariables(def.connectionType, def.connectionVariables ?? [], gate)
+}
+
+/** Variable keys that must always be encrypted, whether or not the def declares them. */
+const ALWAYS_SECRET_KEYS = new Set(BYO_CLIENT_VARS.filter((v) => v.secret).map((v) => v.key))
+
+/**
+ * Split a supplied variable map into encrypt-me and plaintext-ok halves.
+ *
+ * Secrecy is a property of the **key**, not of whether this particular definition happened
+ * to declare it. `clientSecret` carries `secret: true` only on the injected
+ * {@link BYO_CLIENT_VARS} descriptors, so a callback deriving its secret set from the stored
+ * column alone would persist a bring-your-own client secret in plaintext metadata — which is
+ * also shipped to the browser by `apps.listConnections`.
+ */
+export function splitConnectionVariablesBySecrecy(
+  def: { connectionVariables?: ConnectionVariable[] | null },
+  variables: Record<string, string>
+): { secretFields: Record<string, string>; plainVariables: Record<string, string> } {
+  const declaredSecret = new Set(
+    (def.connectionVariables ?? []).filter((v) => v.secret).map((v) => v.key)
+  )
+  const secretFields: Record<string, string> = {}
+  const plainVariables: Record<string, string> = {}
+  for (const [key, value] of Object.entries(variables)) {
+    if (declaredSecret.has(key) || ALWAYS_SECRET_KEYS.has(key)) secretFields[key] = value
+    else plainVariables[key] = value
+  }
+  return { secretFields, plainVariables }
+}
+
+/**
  * Resolve which OAuth client id/secret a connection uses (§3.2). Precedence:
  * **per-credential `clientId`/`clientSecret` vars win when present, else the def's
  * platform client** (decrypted + interpolated by `interpolateConnectionFields`). This is

--- a/packages/lib/src/apps/connections/save-app-connection.ts
+++ b/packages/lib/src/apps/connections/save-app-connection.ts
@@ -1,5 +1,6 @@
 // packages/lib/src/apps/connections/save-app-connection.ts
 
+import { BYO_CLIENT_KEYS } from '@auxx/credentials/connections'
 import {
   insertCredential,
   listCredentials,
@@ -132,6 +133,22 @@ function pickSecrets(data: {
  *   }
  * )
  */
+/**
+ * Connection variables an app's own event handlers are allowed to see.
+ *
+ * A bring-your-own OAuth client id/secret is platform-level auth config, not a connector
+ * input — no `connection-identify` or `connection-added` handler has any use for it, and for
+ * a marketplace app those handlers are third-party code. Strip them before they cross that
+ * boundary. See plans/connections/byo-oauth-client-runtime-gap.md §3 F3.
+ */
+function appVisibleFields(fields: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(fields)) {
+    if (!BYO_CLIENT_KEYS.has(key)) out[key] = value
+  }
+  return out
+}
+
 export async function saveAppConnection(
   appId: string,
   appInstallationId: string,
@@ -237,9 +254,11 @@ export async function saveAppConnection(
       : 'secret'
     // Token is already in hand — no persistence yet, so no `id` is sent to identify.
     const identifyValue = connectionData.accessToken || connectionData.secret || ''
-    const identifyFields = mergeConnectionVariables(metadata, {
-      fields: connectionData.secretFields,
-    })
+    const identifyFields = appVisibleFields(
+      mergeConnectionVariables(metadata, {
+        fields: connectionData.secretFields,
+      })
+    )
 
     const identifyResult = await triggerAppEvent({
       appInstallationId,
@@ -384,7 +403,9 @@ export async function saveAppConnection(
   const connectionValue = connectionData.accessToken || connectionData.secret || ''
   // Merged connection variables (plain + secret-flagged) — apps validate credentials
   // in their connection-added handler (e.g. mint a token, return `{ label }`).
-  const fields = mergeConnectionVariables(metadata, { fields: connectionData.secretFields })
+  const fields = appVisibleFields(
+    mergeConnectionVariables(metadata, { fields: connectionData.secretFields })
+  )
 
   const eventResult = await triggerAppEvent({
     appInstallationId,

--- a/packages/lib/src/connections/index.ts
+++ b/packages/lib/src/connections/index.ts
@@ -12,6 +12,7 @@ export {
   type ConnectionDefinitionForRefresh,
   type CredentialLockProvider,
   type CredentialOwner,
+  effectiveConnectionVariables,
   ensureFreshCredentialToken,
   gateConnectionVariables,
   loadDefinitionForCredential,
@@ -22,6 +23,7 @@ export {
   resolveOAuth2Client,
   resolveOAuth2RefreshConfig,
   resolveOwnClientRequirement,
+  splitConnectionVariablesBySecrecy,
 } from '@auxx/credentials/connections'
 export {
   type AuthApply,


### PR DESCRIPTION
## What was broken

The connect dialog offers *"Use your own OAuth client (advanced)"*, accepts a client id and secret, and sends them as `var_clientId` / `var_clientSecret`. Both authorize routes then **discarded them and authorized with the platform client** — no error, no warning.

Found on the first live end-to-end run of the Shopify custom-distribution flow (`plans/shopify/connection-methods.md` §4.2): the grant screen came back for `client_id=588ef34…` (auxxai) instead of the supplied client. A merchant following the setup guide would install *our* app believing they installed *theirs*, and only notice via the app name on their Apps page or the 60-day order-history ceiling they were told they had escaped.

## Root cause

`BYO_CLIENT_VARS` are **never stored** on a `ConnectionDefinition` — `gateConnectionVariables` injects them at *read* time for the connect UI. Both authorize routes built their allowlist from the raw stored `connectionVariables` column, which for Shopify declares only `shop`:

```ts
for (const varDef of connDef.connectionVariables ?? []) {
  const value = searchParams.get(`var_${varDef.key}`) ?? storedVariables[varDef.key]
```

So `var_clientId` was never read and `resolveOAuth2Client` fell through to the platform client.

Invisible until `byoOAuthClient` extended the offer to defs that don't declare the vars. The three Google app rows got them via a data migration and have always worked — which is why this shipped unnoticed.

## Changes

- **Authorize routes** iterate `effectiveConnectionVariables(def, gate)`, so the UI projection and the server allowlist are the same function by construction.
- **Callbacks** use `splitConnectionVariablesBySecrecy`. Secrecy is a property of the *key*, not of whether the def declared it — `clientSecret` carries `secret: true` only on the injected descriptors, so it was headed for plaintext `metadata`, which `apps.listConnections` ships to the browser. **Fixing the allowlist alone would have started writing customer OAuth secrets in the clear**, so these land together.
- **Stored BYO vars are carried forward explicitly.** A closed gate drops them from the gated list *before* `stripUnentitledOwnClientVars` can honour its documented promise not to repoint a live connection. Surfaced by the reconnect test.
- **`BYO_CLIENT_KEYS` stripped** from `connection-identify` / `connection-added` payloads — an OAuth client secret is platform auth config, not a connector input, and for a marketplace app those handlers are third-party code.
- **Pair check**: half a BYO pair is rejected rather than mixing clients and letting the provider answer `invalid_client`.

## Tests

`var_clientId` previously appeared in exactly two files repo-wide — the two authorize routes.

`app-oauth-authorize-access.test.ts` had been **red on main since 2026-08-21**: #1795 added `resolveOwnClientGateForOrg` to the route four days after that file was last touched, and its full-replacement mock never grew the export, so 4 of 16 cases 500'd on an undefined import. Converted to partial mocks (`@auxx/lib/connections`, `@auxx/config/urls`, `@auxx/redis`, `@auxx/services/app-connections`) and green again.

`byo-client.test.ts` is verified as a real guard: **3 of its cases fail against the old allowlist and pass with the fix.**

- 23 passing across both authorize test files, 291 across `apps/web/src/app/api`, 124 in `@auxx/credentials`, 121 in lib connections
- biome clean; lib typecheck ratchet clean
- ⚠️ the web ratchet flags `use-custom-field-mutations.tsx TS2322` — **pre-existing**, not from this branch (baseline recorded 2026-08-14, file last changed 2026-08-20 in #1787). Left alone rather than re-baselining.

## Not covered

This makes the BYO client actually get *used*. It does not make Shopify BYO usable end to end — the callback/refresh paths are right by inspection but untested live, and Protected Customer Data, webhook-registration error swallowing, and the `read_all_orders` opt-in are all still open. Full analysis in `plans/connections/byo-oauth-client-runtime-gap.md` (untracked).