### PR TITLE
feat(connections): derive app capabilities from granted oauth scopes

### DIFF
--- a/apps/web/src/app/api/apps/[slug]/oauth2/callback/route.ts
+++ b/apps/web/src/app/api/apps/[slug]/oauth2/callback/route.ts
@@ -6,6 +6,7 @@ import { saveAppConnection } from '@auxx/lib/apps'
 import { resolveAppSlug } from '@auxx/lib/cache'
 import {
   appOAuthCallbackUrl,
+  resolveGrantedScopes,
   resolveOAuth2Client,
   splitConnectionVariablesBySecrecy,
 } from '@auxx/lib/connections'
@@ -350,7 +351,10 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
           ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
           : undefined,
         metadata: {
-          scope: tokens.scope,
+          // RFC 6749 §5.1: an omitted `scope` means the grant matched the request, so fall
+          // back to the definition's list rather than storing nothing. Apps derive their own
+          // capabilities from this — plans/connections/scope-derived-capabilities.md §3.1.
+          scope: resolveGrantedScopes(tokens.scope, connDef.oauth2Scopes),
           tokenType: tokens.token_type,
           ...callbackMetadata,
           ...(Object.keys(plainVariables).length > 0 && {

--- a/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/callback/route.ts
+++ b/apps/web/src/app/api/connections/[connectionDefinitionId]/oauth2/callback/route.ts
@@ -4,6 +4,7 @@ import { WEBAPP_URL } from '@auxx/config/urls'
 import { database as db } from '@auxx/database'
 import {
   providerOAuthCallbackUrl,
+  resolveGrantedScopes,
   resolveOAuth2Client,
   runPostConnectHook,
   saveConnection,
@@ -281,7 +282,9 @@ export async function GET(
           ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
           : undefined,
         metadata: {
-          scope: tokens.scope,
+          // RFC 6749 §5.1: an omitted `scope` means the grant matched the request. See
+          // plans/connections/scope-derived-capabilities.md §3.1.
+          scope: resolveGrantedScopes(tokens.scope, connDef.oauth2Scopes),
           tokenType: tokens.token_type,
           ...callbackMetadata,
           ...(Object.keys(plainVariables).length > 0 && { connectionVariables: plainVariables }),

--- a/packages/credentials/src/connections/__tests__/granted-scopes.test.ts
+++ b/packages/credentials/src/connections/__tests__/granted-scopes.test.ts
@@ -1,0 +1,36 @@
+// packages/credentials/src/connections/__tests__/granted-scopes.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { resolveGrantedScopes } from '../resolve-connection-definition'
+
+describe('resolveGrantedScopes', () => {
+  it('prefers the provider’s token-response scope', () => {
+    expect(resolveGrantedScopes('read_orders write_orders', ['read_orders'])).toBe(
+      'read_orders write_orders'
+    )
+  })
+
+  it('falls back to the requested list when the response omits scope (RFC 6749 §5.1)', () => {
+    expect(resolveGrantedScopes(undefined, ['read_orders', 'write_products'])).toBe(
+      'read_orders write_products'
+    )
+  })
+
+  it('treats a blank response scope as omitted, not as "no scopes"', () => {
+    expect(resolveGrantedScopes('   ', ['read_orders'])).toBe('read_orders')
+  })
+
+  it('preserves the previously stored value when there is nothing better', () => {
+    // The OAuth-mint path replaces `metadata` wholesale, so returning empty here would
+    // destroy the only record of what the connection can do.
+    expect(resolveGrantedScopes(undefined, [], 'read_orders write_orders')).toBe(
+      'read_orders write_orders'
+    )
+    expect(resolveGrantedScopes(null, null, 'read_orders')).toBe('read_orders')
+  })
+
+  it('returns undefined when nothing is known, rather than an empty string', () => {
+    expect(resolveGrantedScopes(undefined, [])).toBeUndefined()
+    expect(resolveGrantedScopes(null, null, '  ')).toBeUndefined()
+  })
+})

--- a/packages/credentials/src/connections/index.ts
+++ b/packages/credentials/src/connections/index.ts
@@ -31,6 +31,7 @@ export {
   effectiveConnectionVariables,
   gateConnectionVariables,
   loadDefinitionForCredential,
+  resolveGrantedScopes,
   resolveOAuth2Client,
   resolveOAuth2RefreshConfig,
   resolveOwnClientRequirement,

--- a/packages/credentials/src/connections/resolve-connection-definition.ts
+++ b/packages/credentials/src/connections/resolve-connection-definition.ts
@@ -224,6 +224,39 @@ export function splitConnectionVariablesBySecrecy(
 }
 
 /**
+ * The scopes a connection was actually granted, as stored on `Credential.metadata.scope`.
+ *
+ * RFC 6749 §5.1 makes `scope` OPTIONAL in the token response — "REQUIRED if the scope of the
+ * access token issued is different from the scope requested by the client, otherwise OPTIONAL".
+ * So an omitted `scope` does not mean "no scopes": it means the grant matched the request.
+ * Defaulting to the requested list is the spec's own reading, not a workaround.
+ *
+ * Populating this at every write site is what lets an app derive its own capabilities from the
+ * connection rather than from a build-time constant — see
+ * `plans/connections/scope-derived-capabilities.md` §3.1.
+ *
+ * @param tokenScope `scope` from the provider's token-exchange response, if any.
+ * @param requestedScopes the definition's `oauth2Scopes` — what the authorize URL asked for.
+ * @param previousScope the value already stored, preserved when there is nothing better.
+ */
+export function resolveGrantedScopes(
+  tokenScope: string | undefined | null,
+  requestedScopes: string[] | null | undefined,
+  previousScope?: string | null
+): string | undefined {
+  const fromToken = tokenScope?.trim()
+  if (fromToken) return fromToken
+
+  const fromRequest = (requestedScopes ?? []).join(' ').trim()
+  if (fromRequest) return fromRequest
+
+  // Nothing to write. Never overwrite a good stored value with an empty one: the OAuth-mint
+  // path in `saveAppConnection` replaces `metadata` wholesale, so returning '' here would
+  // destroy the only record of what this connection can do.
+  return previousScope?.trim() || undefined
+}
+
+/**
  * Resolve which OAuth client id/secret a connection uses (§3.2). Precedence:
  * **per-credential `clientId`/`clientSecret` vars win when present, else the def's
  * platform client** (decrypted + interpolated by `interpolateConnectionFields`). This is

--- a/packages/lib/src/connections/index.ts
+++ b/packages/lib/src/connections/index.ts
@@ -20,6 +20,7 @@ export {
   mintClientCredentialToken,
   type RefreshTokensResult,
   refreshCredentialTokens,
+  resolveGrantedScopes,
   resolveOAuth2Client,
   resolveOAuth2RefreshConfig,
   resolveOwnClientRequirement,

--- a/packages/sdk/src/root/index.ts
+++ b/packages/sdk/src/root/index.ts
@@ -18,6 +18,11 @@ export type {
   WorkflowInput,
   WorkflowOutput,
 } from '../server/workflow/index.js'
+// Scope→capability helpers — `import { resolveCapabilities } from '@auxx/sdk'`.
+// Deliberately on the ROOT surface, not `/server`: `/server` is externalized to the injected
+// `AUXX_SERVER_SDK` global and would need a hand-mirrored copy in the lambda runtime, whereas
+// the root SDK is injected from the real module. See shared/scopes.ts.
+export { parseScopeString, resolveCapabilities } from '../shared/scopes.js'
 export type { App, AppSettings, Permission } from './app.js'
 export type {
   ConnectorConnection,

--- a/packages/sdk/src/shared/__tests__/scopes.test.ts
+++ b/packages/sdk/src/shared/__tests__/scopes.test.ts
@@ -1,0 +1,69 @@
+// packages/sdk/src/shared/__tests__/scopes.test.ts
+
+import { describe, expect, it, vi } from 'vitest'
+import { parseScopeString, resolveCapabilities } from '../scopes'
+
+const GRANTS = {
+  read_orders: ['orders:read'],
+  write_orders: ['orders:read', 'orders:write'],
+  read_all_orders: ['orders:history-full'],
+  read_merchant_managed_fulfillment_orders: ['fulfillment:read'],
+  read_assigned_fulfillment_orders: ['fulfillment:read'],
+} as const
+
+describe('parseScopeString', () => {
+  it('accepts both space and comma delimiters', () => {
+    expect(parseScopeString('a b')).toEqual(['a', 'b'])
+    expect(parseScopeString('a,b')).toEqual(['a', 'b'])
+    expect(parseScopeString('a, b   c')).toEqual(['a', 'b', 'c'])
+  })
+
+  it('yields nothing for empty input', () => {
+    expect(parseScopeString('')).toEqual([])
+    expect(parseScopeString(undefined)).toEqual([])
+    expect(parseScopeString(null)).toEqual([])
+  })
+})
+
+describe('resolveCapabilities', () => {
+  it('unions the capabilities of every granted scope', () => {
+    const caps = resolveCapabilities(GRANTS, 'read_orders read_all_orders')
+    expect([...caps].sort()).toEqual(['orders:history-full', 'orders:read'])
+  })
+
+  it('needs no implication rule: a write scope grants its read capability directly', () => {
+    // The point of the scope->capability direction. `write_orders` alone must satisfy a
+    // read check, with no prefix manipulation anywhere.
+    const caps = resolveCapabilities(GRANTS, 'write_orders')
+    expect(caps.has('orders:read')).toBe(true)
+    expect(caps.has('orders:write')).toBe(true)
+  })
+
+  it('needs no any-of rule: two scopes granting the same capability is the or-condition', () => {
+    for (const scope of [
+      'read_merchant_managed_fulfillment_orders',
+      'read_assigned_fulfillment_orders',
+    ]) {
+      expect(resolveCapabilities(GRANTS, scope).has('fulfillment:read')).toBe(true)
+    }
+  })
+
+  it('accepts an already-split list as well as a raw string', () => {
+    expect([...resolveCapabilities(GRANTS, ['write_orders'])].sort()).toEqual([
+      'orders:read',
+      'orders:write',
+    ])
+  })
+
+  it('reports an unknown scope instead of failing silently', () => {
+    const onUnknownScope = vi.fn()
+    const caps = resolveCapabilities(GRANTS, 'read_orders read_invented', onUnknownScope)
+    expect(onUnknownScope).toHaveBeenCalledExactlyOnceWith('read_invented')
+    expect([...caps]).toEqual(['orders:read'])
+  })
+
+  it('yields nothing for an absent grant', () => {
+    expect(resolveCapabilities(GRANTS, undefined).size).toBe(0)
+    expect(resolveCapabilities(GRANTS, '').size).toBe(0)
+  })
+})

--- a/packages/sdk/src/shared/scopes.ts
+++ b/packages/sdk/src/shared/scopes.ts
@@ -1,0 +1,81 @@
+// packages/sdk/src/shared/scopes.ts
+//
+// Pure helpers for turning a connection's GRANTED OAuth scopes into an app's own
+// capability names. Lives on the root surface (`@auxx/sdk`) rather than
+// `@auxx/sdk/server`: the server surface is externalized to the injected
+// `AUXX_SERVER_SDK` global, so a pure function exported there would have to be
+// mirrored by hand in the lambda runtime. The root SDK is injected from the real
+// module (`g.AUXX_ROOT_SDK = RootSDK`), so one implementation serves every app.
+//
+// See plans/connections/scope-derived-capabilities.md §2.2.
+
+/**
+ * Split a granted-scope string into individual scopes.
+ *
+ * RFC 6749 §3.3 specifies space-delimited, but several providers (Shopify among them) use
+ * commas, so both are accepted rather than assumed.
+ */
+export function parseScopeString(raw: string | undefined | null): string[] {
+  return (raw ?? '').split(/[\s,]+/).filter(Boolean)
+}
+
+/**
+ * The capabilities a connection's granted scopes add up to.
+ *
+ * An app declares a `grants` table mapping **provider scope → the app's own capability
+ * names**, then gates its operations on capabilities rather than on scope strings. Declaring
+ * the relationship in this direction is what removes every special case:
+ *
+ * - **Implication is stated once, where it is true.** Shopify auto-includes `read_x` wherever
+ *   `write_x` was requested, so `write_orders: ['orders:read', 'orders:write']` is a fact
+ *   about that scope — not a prefix rule every caller has to remember to apply.
+ * - **"Any of these will do" needs no mechanism.** Two scopes granting the same capability
+ *   *is* the or-condition (e.g. Shopify's merchant-managed and assigned fulfillment scopes
+ *   both granting `fulfillment:read`).
+ * - **Scopes that are not a read/write level fit anyway** — `read_all_orders` simply grants
+ *   `orders:history-full`, which no level-based model could express.
+ *
+ * The result is a union, so every downstream check is a plain subset test.
+ *
+ * @param grants provider scope → the capability names holding it confers.
+ * @param granted the connection's granted scopes — `connection.metadata.scope`, or an
+ *   already-split list.
+ * @param onUnknownScope called for a granted scope absent from `grants`. Worth logging: an
+ *   unrecognised scope contributes nothing, which presents as operations silently
+ *   disappearing, and is how a provider renaming a scope should be discovered.
+ *
+ * @example
+ * ```typescript
+ * import { resolveCapabilities } from '@auxx/sdk'
+ * import { getConnection, InsufficientPermissionsError } from '@auxx/sdk/server'
+ *
+ * const SCOPE_GRANTS = {
+ *   read_orders: ['orders:read'],
+ *   write_orders: ['orders:read', 'orders:write'],
+ * } as const
+ *
+ * const caps = resolveCapabilities(SCOPE_GRANTS, getConnection().metadata?.scope)
+ * if (!caps.has('orders:write')) {
+ *   throw new InsufficientPermissionsError('organization', ['write_orders'])
+ * }
+ * ```
+ */
+export function resolveCapabilities(
+  grants: Record<string, readonly string[]>,
+  granted: string | Iterable<string> | undefined | null,
+  onUnknownScope?: (scope: string) => void
+): Set<string> {
+  const scopes =
+    typeof granted === 'string' || granted == null ? parseScopeString(granted) : [...granted]
+
+  const capabilities = new Set<string>()
+  for (const scope of scopes) {
+    const grantedBy = grants[scope]
+    if (!grantedBy) {
+      onUnknownScope?.(scope)
+      continue
+    }
+    for (const capability of grantedBy) capabilities.add(capability)
+  }
+  return capabilities
+}


### PR DESCRIPTION
## Why

An app has no way to tell what its connection may actually do. The Shopify connector answers that question with `TEMP_RESTRICTIONS` — a build-time boolean hiding 1 resource and 21 operations from **every org at once**, regardless of what any particular token can perform.

That is a per-connection question answered by a global constant, and it fails in both directions: a merchant whose token carries *more* scopes gains nothing until someone edits the constant and redeploys, and one whose token carries *fewer* gets an opaque 403 instead of a missing option.

## What

Two contracts that share no vocabulary:

| Side | Responsibility |
| --- | --- |
| **Platform** (this PR) | Request scopes for the connection; store what the provider granted. |
| **App** (separate PR) | Derive its own capabilities from that grant; gate its own operations. |

The platform never learns what `write_draft_orders` means; the app never learns what a `ConnectionDefinition` is. Nothing anywhere special-cases a merchant.

### `resolveCapabilities(grants, granted)` — `packages/sdk/src/shared/scopes.ts`

Maps provider scope → the app's own capability names and unions the result, so every downstream check is a plain subset test.

Declaring what a scope **grants** — rather than what a capability **needs** — is what removes the special cases:

- **Implication is stated once, where it is true.** Shopify auto-includes `read_x` wherever `write_x` was requested. `write_orders: ['orders:read', 'orders:write']` is a fact about that scope, not a prefix rule every caller has to remember. No string manipulation anywhere.
- **"Any of these will do" needs no mechanism.** Two scopes granting the same capability *is* the or-condition (Shopify's merchant-managed and assigned fulfillment scopes both grant `fulfillment:read`).
- **Scopes that are not a read/write level still fit.** `read_all_orders` grants `orders:history-full`, which no level-based model could express.

### `resolveGrantedScopes()` — both OAuth callbacks

RFC 6749 §5.1 makes `scope` **OPTIONAL** in the token response — *"REQUIRED if the scope of the access token issued is different from the scope requested, otherwise OPTIONAL"*. Absent therefore means the grant matched the request, so it falls back to the definition's list rather than storing nothing. It also never overwrites a good stored value with an empty one, because the OAuth-mint path in `saveAppConnection` replaces `metadata` wholesale.

Applied to the app door and the provider door, so this benefits every app, not just Shopify.

## Why root SDK, not `/server`

`@auxx/sdk/server` is externalized by esbuild to the injected `AUXX_SERVER_SDK` global. A pure function exported there compiles to a property access on an object that does not carry it — **`undefined` at runtime** — and would need a hand-mirrored copy in the lambda, the way the error classes already do.

The root SDK is injected from the real module (`g.AUXX_ROOT_SDK = RootSDK`), so one implementation serves every app with no mirror. Verified against the build's implementation-stripping step, which leaves `lib/shared/scopes.js` intact and `lib/root/index.js` re-exporting it.

I wrote it the wrong way first and caught it in local testing.

## Risk

**No behaviour change.** Nothing reads the capabilities yet — the consumer is the Shopify connector, in a separate PR in `auxxai-apps`. The only live change is that `metadata.scope` gets populated when a provider omits it, where previously `undefined` was stored.

## Testing

13 unit tests (`granted-scopes.test.ts` ×5, `scopes.test.ts` ×8) covering the RFC fallback, the empty-overwrite guard, both delimiters, write⇒read without an implication rule, two-scopes-one-capability, and unknown-scope reporting.

Verified live against local dev: the derivation runs inside the real app runtime (`AUXX_ROOT_SDK.resolveCapabilities` resolves) and reproduces today's Shopify operation surface exactly from a real credential's stored scope.

Two findings from real stored credentials worth recording:

- Shopify returns scopes **comma-separated**, so the delimiter handling is load-bearing.
- A live credential in dev carries **8 scopes where the app declares 10** — `read_orders` and `read_products` absent while `write_orders`/`write_products` are present. A naive `has('read_orders')` check would hide `order.get` on a connection that can read orders. Two credentials with different scope strings derive identical capabilities, which is the point.

## Notes

- Design doc is `plans/connections/scope-derived-capabilities.md` — `plans/` is gitignored, so it is not in this diff.
- It supersedes Part 3 of `plans/connections/byo-oauth-client-runtime-gap.md` (the per-connection scope opt-in), which is not needed if this lands.
