### PR TITLE
fix(workflow): stop the app panel's 1 hz write loop

### DIFF
--- a/apps/web/src/components/workflow/apps/app-workflow-node.tsx
+++ b/apps/web/src/components/workflow/apps/app-workflow-node.tsx
@@ -3,6 +3,7 @@
 'use client'
 
 import { PermissionKey } from '@auxx/lib/permissions/client'
+import { stableStringify } from '@auxx/utils/json'
 import { useUpdateNodeInternals } from '@xyflow/react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAppsContext } from '~/components/apps/providers/apps-context'
@@ -62,6 +63,8 @@ export const AppWorkflowNode = memo<AppWorkflowNodeProps>((props) => {
   const [nodeComponent, setNodeComponent] = useState<any>(null)
   const [error, setError] = useState<string | null>(null)
   const dataRef = useRef(data)
+  /** Last payload actually sent to the iframe, so an unchanged one is not re-sent. */
+  const lastSentNodeDataRef = useRef<string | null>(null)
   const updateNodeInternals = useUpdateNodeInternals()
 
   // Keep ref in sync with latest data
@@ -215,6 +218,13 @@ export const AppWorkflowNode = memo<AppWorkflowNodeProps>((props) => {
   useEffect(() => {
     if (!nodeComponent) return // Wait for initial render
     if (!messageClient) return
+
+    // Guarded on the serialized payload, not on `data`'s identity: the node
+    // iframe `setData`s whatever arrives and re-renders, so re-sending bytes it
+    // already holds buys a render per tick and nothing else (plan 29 §2).
+    const payload = stableStringify(dataRef.current)
+    if (payload === lastSentNodeDataRef.current) return
+    lastSentNodeDataRef.current = payload
 
     // Send updated data to node iframe
     void messageClient.sendRequest(`update-node-data-${id}`, dataRef.current)

--- a/apps/web/src/components/workflow/apps/app-workflow-panel.tsx
+++ b/apps/web/src/components/workflow/apps/app-workflow-panel.tsx
@@ -2,6 +2,8 @@
 
 'use client'
 
+import { stableStringify } from '@auxx/utils/json'
+import { deepEqual } from '@auxx/utils/objects'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAppsContext } from '~/components/apps/providers/apps-context'
 import { suppressConnectionDialog } from '~/components/apps/runtime/connection-dialog-suppression'
@@ -74,6 +76,8 @@ export const AppWorkflowPanel = memo<AppWorkflowPanelProps>(
     // Initialize with actual node data from props instead of empty object
     const { inputs: nodeData, setInputs } = useNodeCrud(nodeId, propData || {})
     const nodeDataRef = useRef(nodeData)
+    /** Last payload actually sent to the iframe, so an unchanged one is not re-sent. */
+    const lastSentPanelDataRef = useRef<string | null>(null)
     const [panelComponent, setPanelComponent] = useState<any>(null)
     const [error, setError] = useState<string | null>(null)
     const [isLoading, setIsLoading] = useState(true)
@@ -267,38 +271,54 @@ export const AppWorkflowPanel = memo<AppWorkflowPanelProps>(
 
           if (!isMounted) return
 
+          // An iframe re-render re-sends the block's data whether or not any of
+          // it moved, so this echoes back values we already hold. Writing them
+          // anyway mints a new `node.data` identity, which pushes data back
+          // INTO the iframe and starts the cycle again — plan 29 §2 link H1.
           unsubscribeData = messageClient.listenForRequest(
             'workflow-node-data-update',
             (data: any) => {
-              if (data.nodeId === nodeId) {
-                setInputs({
-                  ...nodeDataRef.current,
-                  ...data.data,
-                })
-              }
+              if (data.nodeId !== nodeId) return
+              const merged = { ...nodeDataRef.current, ...data.data }
+              if (deepEqual(merged, nodeDataRef.current)) return
+              setInputs(merged)
             }
           )
 
-          // Listen for dynamic output updates from SDK-side computeOutputs
+          // Listen for dynamic output updates from SDK-side computeOutputs.
+          // `evaluateComputeOutputs` re-runs on every panel render and emits
+          // unconditionally, so identical outputs arrive ~1/s forever; the
+          // signature comparison below already existed but only gated the
+          // `inferredSchema` clear, not the write itself.
           unsubscribeOutputs = messageClient.listenForRequest(
             'workflow-block-outputs-updated',
             (data: any) => {
-              if (data.nodeId === nodeId) {
-                const prevSig = computeOutputSignature(nodeDataRef.current._computedOutputs || {})
-                const newSig = computeOutputSignature(data.outputs || {})
+              if (data.nodeId !== nodeId) return
 
-                const updates: any = {
-                  ...nodeDataRef.current,
-                  _computedOutputs: data.outputs,
-                }
+              const prevSig = computeOutputSignature(nodeDataRef.current._computedOutputs || {})
+              const newSig = computeOutputSignature(data.outputs || {})
 
-                // Clear stale inferred schema if computed output shape changed
-                if (prevSig !== newSig && nodeDataRef.current.inferredSchema) {
-                  updates.inferredSchema = undefined
-                }
-
-                setInputs(updates)
+              // Same shape AND same values: nothing to record. The signature
+              // alone is not enough — it captures field types and nesting, not
+              // the values, so two different output sets can share one.
+              if (
+                prevSig === newSig &&
+                deepEqual(data.outputs, nodeDataRef.current._computedOutputs)
+              ) {
+                return
               }
+
+              const updates: any = {
+                ...nodeDataRef.current,
+                _computedOutputs: data.outputs,
+              }
+
+              // Clear stale inferred schema if computed output shape changed
+              if (prevSig !== newSig && nodeDataRef.current.inferredSchema) {
+                updates.inferredSchema = undefined
+              }
+
+              setInputs(updates)
             }
           )
         } catch (error) {
@@ -344,11 +364,21 @@ export const AppWorkflowPanel = memo<AppWorkflowPanelProps>(
       setInputs({ ...nodeDataRef.current, _hiddenFields: hidden })
     }, [panelComponent, setInputs])
 
-    // Send data updates to iframe when React Flow data changes
+    // Send data updates to iframe when React Flow data changes.
+    //
+    // Guarded on the SERIALIZED payload, not on `nodeData`'s identity: the
+    // iframe's own `setData` merges whatever arrives into new state and
+    // re-renders, which re-runs its `computeOutputs` and emits back to us. A
+    // re-push of bytes it already holds is therefore not free — it is the
+    // return leg of plan 29 §2's cycle (link H3 → S3).
     // biome-ignore lint/correctness/useExhaustiveDependencies: panelComponent is intentionally excluded - only send when nodeData changes
     useEffect(() => {
       if (!panelComponent) return // Wait for initial render
       if (!messageClient) return
+
+      const payload = stableStringify(nodeDataRef.current)
+      if (payload === lastSentPanelDataRef.current) return
+      lastSentPanelDataRef.current = payload
 
       void messageClient.sendRequest(`update-panel-data-${nodeId}`, nodeDataRef.current)
     }, [nodeData, nodeId, messageClient])

--- a/apps/web/src/components/workflow/hooks/__tests__/use-node-data-update.test.ts
+++ b/apps/web/src/components/workflow/hooks/__tests__/use-node-data-update.test.ts
@@ -1,0 +1,133 @@
+// apps/web/src/components/workflow/hooks/__tests__/use-node-data-update.test.ts
+//
+// `node.data`'s object identity is load-bearing far beyond the render it
+// triggers: the app panel pushes data INTO its iframe on every identity change,
+// the iframe re-renders and echoes back, and the echo used to be written
+// straight back out again. That cycle ran at ~1 Hz for as long as an app panel
+// was open, queueing an autosave and an undo entry on every turn
+// (plans/kopilot/workflow/29-app-panel-write-loop.md).
+//
+// So a write that changes nothing must do nothing — not "cheaply re-render",
+// nothing. These tests pin that, and pin that a real change still goes through.
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  nodes: [] as any[],
+  setNodes: vi.fn(),
+  debouncedSave: vi.fn(),
+  saveStateToHistory: vi.fn(),
+  isReadOnly: false,
+}))
+
+vi.mock('@xyflow/react', () => ({
+  useStoreApi: () => ({ getState: () => ({ nodes: h.nodes, setNodes: h.setNodes }) }),
+  useStore: (selector: any) => selector({ nodes: h.nodes }),
+}))
+
+vi.mock('../use-read-only', () => ({ useReadOnly: () => ({ isReadOnly: h.isReadOnly }) }))
+
+vi.mock('../use-workflow-save', () => ({
+  useWorkflowSave: () => ({ debouncedSave: h.debouncedSave }),
+}))
+
+vi.mock('../use-save-to-history', () => ({
+  useWorkflowHistory: () => ({ saveStateToHistory: h.saveStateToHistory }),
+  WorkflowHistoryEvent: { NodeChange: 'NodeChange' },
+}))
+
+const { useNodeCrud } = await import('../use-node-data-update')
+
+const NODE_ID = 'n1'
+
+function seed(data: Record<string, unknown>) {
+  h.nodes = [{ id: NODE_ID, data }]
+}
+
+describe('useNodeCrud — no-op writes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    h.isReadOnly = false
+    seed({ operation: 'get', resource: 'order' })
+  })
+
+  it('does not touch the store, the save or the history when nothing changed', () => {
+    const { result } = renderHook(() => useNodeCrud(NODE_ID, h.nodes[0].data))
+
+    result.current.setInputs({ operation: 'get', resource: 'order' })
+
+    expect(h.setNodes).not.toHaveBeenCalled()
+    expect(h.debouncedSave).not.toHaveBeenCalled()
+    expect(h.saveStateToHistory).not.toHaveBeenCalled()
+  })
+
+  it('ignores a patch that only repeats values already present', () => {
+    const { result } = renderHook(() => useNodeCrud(NODE_ID, h.nodes[0].data))
+
+    // The comparison must be on the MERGED result, not on the patch: a partial
+    // patch of existing values merges to exactly what is already stored.
+    result.current.setInputs({ operation: 'get' })
+
+    expect(h.setNodes).not.toHaveBeenCalled()
+    expect(h.debouncedSave).not.toHaveBeenCalled()
+  })
+
+  it('ignores repeated identical writes at the app-panel loop cadence', () => {
+    const { result } = renderHook(() => useNodeCrud(NODE_ID, h.nodes[0].data))
+
+    const echo = { operation: 'get', resource: 'order', _computedOutputs: { total: 'number' } }
+    result.current.setInputs(echo)
+    // First one is a real change; the store now holds it.
+    expect(h.setNodes).toHaveBeenCalledTimes(1)
+    seed(h.setNodes.mock.calls[0][0][0].data)
+
+    for (let tick = 0; tick < 5; tick++) {
+      result.current.setInputs({ ...echo })
+    }
+
+    expect(h.setNodes).toHaveBeenCalledTimes(1)
+    expect(h.debouncedSave).toHaveBeenCalledTimes(1)
+    expect(h.saveStateToHistory).toHaveBeenCalledTimes(1)
+  })
+
+  it('key order does not make a write look like a change', () => {
+    const { result } = renderHook(() => useNodeCrud(NODE_ID, h.nodes[0].data))
+
+    result.current.setInputs({ resource: 'order', operation: 'get' })
+
+    expect(h.setNodes).not.toHaveBeenCalled()
+  })
+
+  it('still writes, saves and records when something genuinely changed', () => {
+    const { result } = renderHook(() => useNodeCrud(NODE_ID, h.nodes[0].data))
+
+    result.current.setInputs({ operation: 'list', resource: 'order' })
+
+    expect(h.setNodes).toHaveBeenCalledTimes(1)
+    expect(h.debouncedSave).toHaveBeenCalledTimes(1)
+    expect(h.saveStateToHistory).toHaveBeenCalledWith('NodeChange', {
+      nodeId: NODE_ID,
+      coalesceKey: `NodeChange:${NODE_ID}`,
+    })
+  })
+
+  it('a nested value change is still a change', () => {
+    seed({ config: { fields: ['a', 'b'] } })
+    const { result } = renderHook(() => useNodeCrud(NODE_ID, h.nodes[0].data))
+
+    result.current.setInputs({ config: { fields: ['a', 'c'] } })
+
+    expect(h.setNodes).toHaveBeenCalledTimes(1)
+  })
+
+  it('read-only writes nothing at all', () => {
+    h.isReadOnly = true
+    const { result } = renderHook(() => useNodeCrud(NODE_ID, h.nodes[0].data))
+
+    result.current.setInputs({ operation: 'list' })
+
+    expect(h.setNodes).not.toHaveBeenCalled()
+    expect(h.debouncedSave).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/components/workflow/hooks/use-node-data-update.ts
+++ b/apps/web/src/components/workflow/hooks/use-node-data-update.ts
@@ -1,6 +1,7 @@
 // apps/web/src/components/workflow/hooks/use-node-data-update.ts
 
 import { getByPath } from '@auxx/utils'
+import { deepEqual } from '@auxx/utils/objects'
 import { useStore as useReactFlowStore, useStoreApi } from '@xyflow/react'
 import { produce } from 'immer'
 import { useCallback } from 'react'
@@ -25,29 +26,56 @@ export const useNodeDataUpdate = () => {
   const { isReadOnly } = useReadOnly()
 
   /**
-   * Updates node data in ReactFlow store without side effects
+   * Update node data in the React Flow store, with no side effects.
+   *
+   * **A write that changes nothing does nothing** and returns `false`. That
+   * guard is load-bearing, not an optimisation: `node.data`'s object identity
+   * is what drives the canvas re-render, the app-panel iframe push
+   * (`apps/.../app-workflow-panel.tsx` sends `update-panel-data-` on every
+   * `nodeData` identity change), the autosave and the undo entry. Minting a new
+   * identity for an identical value therefore starts a cycle rather than
+   * recording an edit — see `plans/kopilot/workflow/29-app-panel-write-loop.md`.
+   *
+   * The comparison is on the MERGED result, never on the patch: a patch that
+   * repeats the values already in `data` is exactly the case being caught.
+   *
+   * @returns whether anything actually changed
    */
   const handleNodeDataUpdate = useCallback(
-    ({ id, data }: NodeDataUpdatePayload) => {
+    ({ id, data }: NodeDataUpdatePayload): boolean => {
       const { nodes, setNodes } = store.getState()
+      const current = nodes.find((node) => node.id === id)
+      if (!current) return false
+
+      const merged = { ...current.data, ...data }
+      if (deepEqual(merged, current.data)) return false
+
       const newNodes = produce(nodes, (draft) => {
         const currentNode = draft.find((node) => node.id === id)
         if (currentNode) {
-          currentNode.data = { ...currentNode.data, ...data }
+          currentNode.data = merged
         }
       })
       setNodes(newNodes)
+      return true
     },
     [store]
   )
 
   /**
-   * Updates node data with automatic save and history tracking
+   * Updates node data with automatic save and history tracking.
+   *
+   * Both side effects hang off {@link handleNodeDataUpdate}'s answer, so a
+   * no-op write queues no save and records no undo entry. The history half
+   * matters more than it looks: `HistoryManager`'s coalesce window is 500 ms,
+   * so a repeating writer slower than that gets a NEW entry every time, wipes
+   * the redo stack on each one, and evicts the user's real edits once the
+   * 50-entry stack overflows.
    */
   const handleNodeDataUpdateWithSync = useCallback(
     (payload: NodeDataUpdatePayload) => {
       if (isReadOnly) return
-      handleNodeDataUpdate(payload)
+      if (!handleNodeDataUpdate(payload)) return
       // Variables are automatically synced by VarStoreSyncProvider
       debouncedSave()
       // Keyed per node: a burst of keystrokes in one panel is one undo step,

--- a/apps/web/src/components/workflow/store/__tests__/history-manager-noop.test.ts
+++ b/apps/web/src/components/workflow/store/__tests__/history-manager-noop.test.ts
@@ -1,0 +1,110 @@
+// apps/web/src/components/workflow/store/__tests__/history-manager-noop.test.ts
+//
+// The app-panel write loop (plans/kopilot/workflow/29-app-panel-write-loop.md)
+// landed a no-op `NodeChange` on the undo stack roughly once a second. The
+// coalesce key looked like it should have absorbed that, and did not: the
+// window is 500 ms and the loop's measured period was 993 ms median / 872 ms
+// minimum, so EVERY tick missed the merge and took the push branch — a fresh
+// entry each time, the redo stack wiped on each one, and the user's real edits
+// evicted off the front once 50 entries overflowed.
+//
+// So these tests are deliberately written at the loop's own cadence. A version
+// spaced under 500 ms passes against the unfixed code and proves nothing.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { HistoryManager } from '../history-manager'
+
+/** A snapshot whose content is a function of `tag` alone. */
+function entry(tag: string) {
+  return {
+    action: 'workflow_event',
+    store: 'workflow',
+    data: { event: 'NodeChange', nodes: [{ id: 'n1', data: { value: tag } }], edges: [] },
+    label: tag,
+  }
+}
+
+/** Longer than the 500 ms coalesce window — the gap the real loop ran at. */
+const OUTSIDE_COALESCE_WINDOW = 1000
+
+describe('HistoryManager — no-op entries', () => {
+  let manager: HistoryManager
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    manager = new HistoryManager()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('ignores a record identical to the top of the stack, at the loop cadence', () => {
+    manager.record(entry('initial'))
+    manager.record(entry('edited'), { coalesceKey: 'NodeChange:n1' })
+    expect(manager.getHistory()).toHaveLength(2)
+
+    for (let tick = 0; tick < 5; tick++) {
+      vi.advanceTimersByTime(OUTSIDE_COALESCE_WINDOW)
+      manager.record(entry('edited'), { coalesceKey: 'NodeChange:n1' })
+    }
+
+    expect(manager.getHistory()).toHaveLength(2)
+    expect(manager.getHistory()[1].data.nodes[0].data.value).toBe('edited')
+  })
+
+  it('leaves the redo stack intact across repeated no-op records', () => {
+    manager.record(entry('one'))
+    manager.record(entry('two'))
+    manager.undo()
+    expect(manager.canRedo()).toBe(true)
+
+    // The loop ticking while the user has something to redo.
+    for (let tick = 0; tick < 3; tick++) {
+      vi.advanceTimersByTime(OUTSIDE_COALESCE_WINDOW)
+      manager.record(entry('one'), { coalesceKey: 'NodeChange:n1' })
+    }
+
+    expect(manager.canRedo()).toBe(true)
+  })
+
+  it('never evicts real edits — a no-op writer cannot overflow the stack', () => {
+    const small = new HistoryManager({ maxHistorySize: 5 })
+    small.record(entry('real-edit'))
+    small.record(entry('current'))
+
+    for (let tick = 0; tick < 40; tick++) {
+      vi.advanceTimersByTime(OUTSIDE_COALESCE_WINDOW)
+      small.record(entry('current'), { coalesceKey: 'NodeChange:n1' })
+    }
+
+    const history = small.getHistory()
+    expect(history).toHaveLength(2)
+    expect(history[0].data.nodes[0].data.value).toBe('real-edit')
+  })
+
+  it('still records a genuinely different snapshot at the same cadence', () => {
+    manager.record(entry('initial'))
+    vi.advanceTimersByTime(OUTSIDE_COALESCE_WINDOW)
+    manager.record(entry('a'), { coalesceKey: 'NodeChange:n1' })
+    vi.advanceTimersByTime(OUTSIDE_COALESCE_WINDOW)
+    manager.record(entry('b'), { coalesceKey: 'NodeChange:n1' })
+
+    const history = manager.getHistory()
+    expect(history).toHaveLength(3)
+    expect(history[2].data.nodes[0].data.value).toBe('b')
+  })
+
+  it('still coalesces a fast burst of real changes into one entry', () => {
+    manager.record(entry('initial'))
+    manager.record(entry('typed-h'), { coalesceKey: 'NodeChange:n1' })
+    vi.advanceTimersByTime(100)
+    manager.record(entry('typed-he'), { coalesceKey: 'NodeChange:n1' })
+    vi.advanceTimersByTime(100)
+    manager.record(entry('typed-hel'), { coalesceKey: 'NodeChange:n1' })
+
+    const history = manager.getHistory()
+    expect(history).toHaveLength(2)
+    expect(history[1].data.nodes[0].data.value).toBe('typed-hel')
+  })
+})

--- a/apps/web/src/components/workflow/store/history-manager.ts
+++ b/apps/web/src/components/workflow/store/history-manager.ts
@@ -1,5 +1,6 @@
 // apps/web/src/components/workflow/store/history-manager.ts
 
+import { stableStringify } from '@auxx/utils/json'
 import { v4 as uuidv4 } from 'uuid'
 import { storeEventBus } from './event-bus'
 import type { HistoryDescription, HistoryEntry } from './types'
@@ -117,6 +118,26 @@ export class HistoryManager {
 
     const willCoalesce =
       !!coalesceKey && top?.coalesceKey === coalesceKey && now - top.timestamp < this.coalesceWindow
+
+    // An entry identical to the one on top of the stack is never worth
+    // recording: undoing onto it is a no-op, and it costs one of the
+    // `maxHistorySize` slots that a real edit needs.
+    //
+    // This is belt-and-braces behind the callers, who should not be recording
+    // no-op edits in the first place — but the failure mode when one does is
+    // severe and silent. `coalesceWindow` is 500 ms, tuned for keystroke
+    // bursts, so a repeating writer even slightly SLOWER than that misses the
+    // merge entirely: it pushes a fresh entry every time, clears the redo stack
+    // on each push, and once 50 entries overflow it evicts the user's real
+    // edits off the front. An app panel's iframe echo did exactly that at
+    // ~1 Hz — see `plans/kopilot/workflow/29-app-panel-write-loop.md` §3.1.
+    //
+    // Do NOT "fix" that class of bug by widening `coalesceWindow`: that would
+    // start merging genuinely separate user edits into one undo step, which is
+    // the failure moving history off a time debounce was meant to end.
+    if (top && !willCoalesce && stableStringify(entry.data) === stableStringify(top.data)) {
+      return
+    }
 
     // The state this entry is recorded on top of. When merging, the entry being
     // overwritten is NOT that state — the one below it is.


### PR DESCRIPTION
## What

An open app-block panel drove a **self-sustaining postMessage cycle at ~1 Hz**. Measured on one Shopify node with the page idle:

| postMessage | count / 20 s |
|---|---|
| `workflow-block-outputs-updated` | 20 |
| `workflow-node-updated` | 20 |
| `workflow-panel-updated` | 21 |

Switching the panel to a non-app node: `0 / 0 / 0`. It ran for as long as the panel was open.

## The cycle

The SDK's `computeOutputs` emits `workflow-block-outputs-updated` → the panel writes it back with **no comparison** → `handleNodeDataUpdate` mints a new `node.data` identity **unconditionally** → that identity change pushes the data straight back into the iframe → it recomputes and emits again.

Five links, and breaking any one stops it. This breaks four, all host-side.

## Why it never showed up in the database — and where it did

`_computedOutputs` is `_`-prefixed, so `dehydrateGraph` strips it, the projection matches the baseline, and the save path's content guard dropped the payload before a request was built. The draft row sat at version 10 from Aug 13 through every minute of the loop running.

**The undo history had no such protection.** `HistoryManager`'s coalesce window is 500 ms; the loop's measured period was **993 ms median, 872 ms minimum** — 19 consecutive gaps, every one over the window. So `willCoalesce` was false on *every* tick and every tick took the `push` branch:

1. a junk `NodeChange` entry per second;
2. `redoStack = []` on every push — while an app panel was open, redo could never survive;
3. `maxHistorySize` is 50, so after ~50 seconds the loop had evicted **every real user edit** off the front of the stack.

Leaving a panel open for a minute silently destroyed Cmd+Z, through entries that looked legitimate.

## The fix

One idea in four places — **a write that changes nothing does nothing**:

- **`use-node-data-update.ts`** — `handleNodeDataUpdate` compares the *merged* result and bails, returning whether anything changed; `handleNodeDataUpdateWithSync` hangs both the autosave and the history record off that answer. This is the chokepoint and it covers every panel, not just app blocks.
- **`history-manager.ts`** — `record()` skips a push whose snapshot equals the top of the stack, coalesce window or not.
- **`app-workflow-panel.tsx`** — both iframe listeners compare before writing.
- **`app-workflow-panel.tsx` / `app-workflow-node.tsx`** — both host→iframe pushes compare the serialized payload, so bytes the iframe already holds are not re-sent.

Two notes on the details:

- The existing output **signature** was not sufficient on its own. `computeOutputSignature` captures field types and nesting, **not values**, so two different output sets can share one. The guard is `prevSig === newSig && deepEqual(...)`.
- `coalesceWindow` is deliberately **not** widened. 500 ms is tuned for keystroke bursts; enlarging it would hide this class of bug and start merging genuinely separate user edits into one undo step.

## Verification

Live, after the fix, same page and node as the measurement above:

| Scenario | Before | After |
|---|---|---|
| Panel open, idle 20 s | 20 / 20 / 21 | **0 / 0 / 0** |
| Panel open, idle 3 × 25 s | — | **0, 0, 0** |
| Edit `operation` Get → Get Many | — | finite burst, **1** `workflow.update`, v10 → 11, persisted |
| Revert Get Many → Get | — | finite burst, **1** `workflow.update`, v11 → 12, persisted |
| Close panel, reopen | — | 1 compute, **0** saves |
| Full page reload | — | **0** saves, version unchanged |

Two `workflow.update` for two edits, none for anything else — no save-on-open, no save-on-panel-open, no save-on-reload.

Tests: `apps/web` workflow suite **297 passed / 37 files** (285 before, +12 new). Both new suites were confirmed to **fail** against the unfixed code — 4/7 and 3/5 — while their "must still work" cases pass in both states. The history suite is deliberately written at the loop's cadence (1000 ms under fake timers); spaced under 500 ms it passes today and proves nothing.

## Known residuals

- **The SDK-side guard is not in this PR.** `WorkflowPanelContainer.setData` still mints a new object identity on every received update, and `evaluateComputeOutputs` still emits without comparing to its last emit. It needs a platform-bundle rebuild and an `@auxx/sdk` release, and it is defence in depth rather than part of the fix — the host no longer pushes redundantly, and an emit that arrives anyway is now dropped on arrival.
- **An impure `computeOutputs`** (timestamp, random) would produce genuinely different outputs each run, so the guards would correctly let it through. The save stays clean, but `cloneNodeForHistory` copies `data` verbatim including `_`-prefixed keys, so the history damage could return for such a block. Closing that properly means projecting history snapshots the same way the save path does — not attempted here.

Unrelated: `apps/web` typecheck reports one error in `use-custom-field-mutations.tsx`, a file this branch does not touch and which imports nothing it changes.