### PR TITLE
perf(test): cut the lib suite 252s to 148s and make turbo cacheable in CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -520,28 +520,73 @@ npx dotenv -- npx tsx path/to/script.ts
 
 ### Type Checking (`tsc`)
 
-Every package/app has a scoped `typecheck` script (`tsc --noEmit` run from that
-package's own directory against its own `tsconfig.json`, via `composite: true`
-project references). Run it **per package**, never as a bare `tsc`/`tsc -b`
-from the repo root — there is no root `tsconfig.json`, and a whole-monorepo
-invocation walks every package's sources in one process.
+**Typechecking is cheap — run it freely, but ONLY via the package script.**
 
 ```bash
-# Scope to one package (fast, low memory — most packages finish in seconds)
-pnpm --filter @auxx/utils typecheck
+pnpm --filter @auxx/lib typecheck      # ~4s   (3,846 files)
+pnpm --filter @auxx/web typecheck      # ~10s  (~3.5k files)
 pnpm --filter @auxx/database typecheck
 
-# apps/web and packages/lib are large enough to hit V8's default ~4GB
-# old-space heap limit even when scoped to just that package. Bump it:
-cd apps/web && NODE_OPTIONS="--max-old-space-size=8192" pnpm exec tsc --noEmit
-cd packages/lib && NODE_OPTIONS="--max-old-space-size=8192" pnpm exec tsc --noEmit
+# Cached + parallel across packages, keyed on upstream results.
+# Repeat runs are ~0.5s; editing an upstream package correctly re-runs dependents.
+pnpm exec turbo run typecheck --filter=@auxx/lib
 ```
 
-The OOM was never about total errors or physical memory — it's Node/V8's
-default heap ceiling, hit while checking apps/web's ~3.5k files (or lib's
-~2.6k) in a single process. Scoping to a package keeps most invocations well
-under the limit; for web/lib, raising `--max-old-space-size` is enough (~6GB
-peak observed for web).
+**Never run a bare `pnpm exec tsc` / `npx tsc`.** This repo has **two**
+TypeScript packages installed — `typescript` and `typescript7`
+(`npm:typescript@7.0.2`, the native Go compiler) — and `pnpm exec tsc` resolves
+to a *different one per package*:
+
+| from | `pnpm exec tsc` gives |
+| --- | --- |
+| `packages/lib` | 7.0.2 (native, fast) |
+| `apps/web` | **5.9.2** (legacy JS) |
+
+So `cd apps/web && pnpm exec tsc --noEmit` runs the old compiler, spends ~50s
+climbing to V8's 4GB heap ceiling and dies with an allocation failure — while
+`pnpm --filter @auxx/web typecheck` (which calls `typescript7` explicitly)
+finishes in ~10s. That OOM is the *only* reason `NODE_OPTIONS=--max-old-space-size`
+ever appeared in this file; with the package script it is unnecessary.
+
+Two more traps:
+
+- **`tsc` exits non-zero for reasons other than type errors** (a bad invocation
+  prints `--help` and exits 1). Never judge a run by a `grep`ped line count, and
+  never pipe it — in a pipeline `$?` is grep's status, so a crash reads as a
+  pass. Check the exit code, then read the `error TS` lines.
+- **16 packages/apps have no `typecheck` script at all**, including
+  `@auxx/worker`, `@auxx/services`, `@auxx/seed`, `@auxx/types` and `@auxx/sdk`,
+  so a green `turbo run typecheck` is not whole-repo coverage.
+
+`packages/lib` and `apps/web` carry pre-existing errors, so "clean" is not the
+bar — `scripts/ci/typecheck-ratchet.js` enforces "adds none" against
+`scripts/ci/typecheck-baseline.json`. Use `node scripts/ci/typecheck-ratchet.js
+--package lib` when you want the same answer CI will give.
+
+### Testing
+
+The suite's cost is almost entirely **per-file boot**, not the tests. In
+`packages/lib` the 960 test files sum to ~66s of actual execution, but a full
+run takes **~150s**: each isolated file re-imports the whole module graph
+(`vitest.alias.ts` points every `@auxx/*` at source), so summed import time is
+~1900s against ~66s of tests — a 29:1 ratio.
+
+**So: scope test runs to the module you touched while iterating, and run the
+full package suite once before opening the PR.**
+
+```bash
+cd packages/lib
+pnpm exec vitest run src/field-values     # ~13s, 339 tests
+pnpm exec vitest run                      # ~150s — pre-PR only
+```
+
+- `vitest related <files>` does **not** help here. Widely-imported modules
+  (e.g. `field-values/client.ts`) reach half the package, so it selects 530 of
+  960 files and saves nothing. Pass a directory instead.
+- `--pool=threads` buys ~11%. Not worth changing.
+- `--no-isolate` would cut the full run to ~77s, but ~232 files currently fail
+  under it from state leaking between files in a shared worker. See
+  `plans/test-speed/` (untracked).
 
 ### Rules
 

--- a/packages/lib/src/test/setup.ts
+++ b/packages/lib/src/test/setup.ts
@@ -100,6 +100,24 @@ vi.mock('openai', () => ({
   })),
 }))
 
+// `pusher` is imported by exactly one module (`realtime/providers/pusher.ts`)
+// and NO test mocks it, so any test that reached `RealtimeService.publish`
+// without mocking the realtime layer above it was opening a real connection to
+// whatever `PUSHER_*` pointed at. That is a live network call from a unit test:
+// slow, order-dependent, and it fails outright (`Invalid socket id`) the moment
+// a fixture uses a synthetic socket id. Stub it here so the suite is hermetic —
+// a test that wants to assert on publishing still mocks `../realtime` itself.
+// NOTE: `class`, not `vi.fn(() => ({...}))`. Production code calls
+// `new Pusher(...)`, and a `vi.fn` whose implementation is an arrow function is
+// not constructible — it fails with "is not a constructor" at the `new` site
+// rather than anywhere near here.
+vi.mock('pusher', () => ({
+  default: class {
+    trigger = vi.fn().mockResolvedValue(undefined)
+    authorizeChannel = vi.fn(() => ({ auth: 'test:signature' }))
+  },
+}))
+
 // Global test setup
 beforeAll(() => {
   // Add any global setup here

--- a/packages/lib/vitest.config.ts
+++ b/packages/lib/vitest.config.ts
@@ -2,7 +2,7 @@
 
 import { readFileSync } from 'node:fs'
 import path from 'path'
-import { loadEnv, type Plugin } from 'vite'
+import type { Plugin } from 'vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 import { auxxSourceAlias } from '../../vitest.alias'
@@ -24,10 +24,16 @@ function markdownAsText(): Plugin {
   }
 }
 
-export default defineConfig(({ mode }) => {
-  const monorepoRoot = path.resolve(__dirname, '../..')
-  const env = { ...loadEnv(mode, monorepoRoot, ''), ...loadEnv(mode, process.cwd(), '') }
-
+// `define: { 'process.env': env }` used to live here. It inlined a 180-key,
+// ~10KB object literal at EVERY `process.env` occurrence in every transformed
+// module — and it was redundant, because `src/test/setup.ts` already does the
+// same `loadEnv` + `Object.assign(process.env, env)` at runtime, before any
+// test module is imported. Removing it took the full suite from 252s to 148s
+// (summed import 3226s -> 1905s) and turned the suite green: two tests that
+// had been failing on main now pass. Likely because the inlined literal is
+// frozen at config-load time, so a runtime mutation of process.env was
+// invisible to the code under test — but that mechanism was not confirmed.
+export default defineConfig(() => {
   return {
     plugins: [markdownAsText(), tsconfigPaths()],
 
@@ -90,10 +96,6 @@ export default defineConfig(({ mode }) => {
         ...auxxSourceAlias,
         '~/': path.resolve(__dirname, './src/'),
       },
-    },
-
-    define: {
-      'process.env': env,
     },
   }
 })

--- a/turbo.json
+++ b/turbo.json
@@ -4,10 +4,26 @@
   "globalDependencies": ["**/.env.*local"],
   "tasks": {
     "build": {
-      "env": ["*"],
+      // `["*"]` alone made this task UNCACHEABLE IN CI. The wildcard puts every
+      // environment variable in the hash, and GitHub Actions gives GITHUB_RUN_ID
+      // / GITHUB_SHA / RUNNER_* a new value on every single run — so the key
+      // never repeated and `build` was a guaranteed cache miss on every CI job.
+      //
+      // The exclusions below are the fix. The wildcard is deliberately KEPT:
+      // 136 first-party env vars are read from source but absent from
+      // `globalEnv`, so narrowing this to an explicit list would under-declare
+      // the hash and serve a STALE build — a much worse failure than a slow one.
+      "env": ["*", "!GITHUB_*", "!RUNNER_*", "!ACTIONS_*", "!INPUT_*"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**", "!.next/dev/**", "dist/**"]
+    },
+    // Cacheable, and keyed on upstream typecheck results so that editing
+    // `packages/utils` correctly invalidates `packages/lib`'s cached pass.
+    // Packages without a `typecheck` script are simply skipped by turbo.
+    "typecheck": {
+      "dependsOn": ["^typecheck"],
+      "outputs": []
     },
     "build:platform-runtime": {
       "dependsOn": ["^build"],
@@ -34,7 +50,12 @@
     "db:seed": { "cache": false },
     "seed": { "cache": false },
     "clean": { "cache": false },
-    "test": { "env": ["*"], "dependsOn": ["^test"] }
+    // `dependsOn: ["^test"]` used to be here. It made
+    // `turbo run test --filter=@auxx/workflow-nodes` run @auxx/database#test
+    // first — and since that suite currently fails, the command exited 1
+    // without ever running the package that was asked for. One package's tests
+    // are not an input to another's, so there is nothing to depend on.
+    "test": { "env": ["*", "!GITHUB_*", "!RUNNER_*", "!ACTIONS_*", "!INPUT_*"] }
   },
   "globalEnv": [
     "ANTHROPIC_API_KEY",


### PR DESCRIPTION
Started from "why does so much time go into typechecks and tests" and measured
rather than guessed. The headline: **the test suite's cost is not the tests.**

In `packages/lib`, all 960 test files sum to **~66s** of execution — on 16 cores
that is ~5s of real work — but a full run took **252s**. Everything else is
re-importing the module graph once per isolated file.

## Changes

### `vitest.config.ts` — remove `define: { 'process.env': env }`  (252s -> 148s)

It inlined a 180-key, ~10KB object literal at **every** `process.env` occurrence
in every transformed module. It was also redundant: `src/test/setup.ts` already
does the same `loadEnv` + `Object.assign(process.env, env)` at runtime, before
any test module is imported.

Summed import time 3226s -> 1905s. It also **turned the suite green** — the two
tests that had been failing on `main` now pass. Likely because an inlined
literal is frozen at config-load time, so a runtime mutation of `process.env`
was invisible to the code under test; that mechanism is not confirmed and the
code comment says so.

### `setup.ts` — stub `pusher`

`pusher` is imported by exactly one module and **no test mocked it**, so any
test reaching `RealtimeService.publish` without mocking the realtime layer was
opening a real connection and failing on `Invalid socket id`.

Honest accounting: this is correct hygiene, **not** a speed win. Under
`--no-isolate` it moved failures 181 -> 191 files, i.e. inside run-to-run noise.
Do not credit it with anything.

Note the trap: this must be a `class`, not `vi.fn(() => ({...}))`. Production
calls `new Pusher(...)`, and a `vi.fn` with an arrow implementation throws
"is not a constructor" at the `new` site, far from the mock.

### `turbo.json` — three fixes

**1. `env: ["*"]` made `build` and `test` uncacheable in CI.** The wildcard puts
every environment variable in the hash, and GitHub Actions rotates
`GITHUB_RUN_ID` / `GITHUB_SHA` / `RUNNER_*` on every run, so the key never
repeated:

```
run 1 (cold)                       0 cached   1.038s
run 2 (identical env)              1 cached   444ms  >>> FULL TURBO
run 3 (GITHUB_RUN_ID=12345 added)  0 cached   1.032s
```

**The wildcard is deliberately kept.** 136 first-party env vars are read from
source but absent from `globalEnv` (`APP_URL`, `CDN_URL`, `BETTER_AUTH_SECRET`,
`READ_DATABASE_URL`, ...), so replacing it with an explicit list would
under-declare the hash and serve a **stale build** — much worse than a slow one.
Turbo 2.5 supports negative patterns, so only the per-run CI noise is excluded.

Verified after: identical env -> hit; `GITHUB_*` changed -> **hit**;
`DATABASE_URL` changed -> **miss**.

**2. `test.dependsOn: ["^test"]` removed.** It made
`turbo run test --filter=@auxx/workflow-nodes` run `@auxx/database#test` first —
which fails — so the command exited 1 without ever running the requested
package. Now `Tasks: 1 successful, 1 total`.

**3. `typecheck` task added**, with `dependsOn: ["^typecheck"]` so upstream edits
invalidate dependents. 3.5s cold -> 460ms cached. Invalidation verified by
editing `packages/utils` and watching `--filter=@auxx/lib` go 7/8 -> 5/8 cached.

`turbo.json` now carries `//` comments. Turbo parses them (JSONC) and nothing
else in the repo reads the file — but strict `JSON.parse` no longer works on it.
Happy to strip them if that trade is unwanted.

### `CLAUDE.md` — the typecheck section was wrong

Two errors, both of which would mislead every future session:

- It claimed **every** package has a `typecheck` script. **16 do not**, including
  `@auxx/worker`, `@auxx/services`, `@auxx/seed`, `@auxx/types`, `@auxx/sdk` — so
  a green `turbo run typecheck` is not whole-repo coverage.
- It recommended a bare `pnpm exec tsc`. The repo has **two** TypeScript
  packages, and that command resolves differently per package:

  | from | `pnpm exec tsc` gives |
  | --- | --- |
  | `packages/lib` | 7.0.2 (native, fast) |
  | `apps/web` | **5.9.2** (legacy JS) |

  So `cd apps/web && pnpm exec tsc --noEmit` runs the old compiler, spends ~50s
  climbing to V8's 4GB ceiling and dies with an allocation failure.
  `pnpm --filter @auxx/web typecheck` calls `typescript7` and finishes in
  **~10.3s**.

Also now documents the scoped-test rule (`vitest run src/<dir>` ~13s vs ~150s
full), why `vitest related` does **not** help here (it selects 530 of 960 files),
that a piped `tsc | grep` reports grep's exit status so a crash reads as a pass,
and points at the existing `scripts/ci/typecheck-ratchet.js` — `lib` carries
baselined errors, so "zero errors" was never the bar.

## Found but not fixed

- `apps/web` has **one** real type error, surfaced only once the correct
  compiler is used:
  `use-custom-field-mutations.tsx(133,9) TS2322` — `allowNewOptions` is
  `boolean | null | undefined` against `boolean | undefined`. Looks related to
  recent field-options work.
- `events/handlers/resolve-resource-trigger-match.test.ts` and
  `workflows/__tests__/workflow-draft-cas.test.ts` each have exactly one test
  taking 4-5.5s (first-import cost billed to the first test) against
  `testTimeout: 10000`. Under contention they cross it, which is why a
  *different* file appears to fail on different runs. Confirmed identical
  against the committed `setup.ts`, so it predates this PR.

## Deliberately abandoned

`isolate: false` would take the full suite 148s -> 60s, but 181 files fail under
it. A codemod to spread `importOriginal` into partial `vi.mock` factories was
built and run on `src/resources` (42 sites, 18 files) — it took the **isolated**
suite from 56/56 green to 4 files / 52 tests failing, and was reverted.

Those factories are not partial by accident: `../../cache` is a barrel fronting
the whole DB-backed cache subsystem, and replacing it wholesale is what stops
that subsystem executing. `importOriginal` puts it back, and the real functions
then run against the global `@auxx/database` chainable mock, which returns
itself rather than arrays. The real blocker is that fake, not mock hygiene.
Full write-up in `plans/test-speed/` (untracked).

## Verification

- `packages/lib` full suite: **956 files / 12,551 tests passing**, 0 failing.
- `packages/lib` typecheck: no `src/` errors.
- Biome clean on all changed files.
- All three turbo fixes verified empirically, including the negative cases.
