### PR TITLE
chore(build): ship the kb image and adopt next 16.3 build options

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,12 +5,34 @@ packages/*/node_modules
 apps/*/dist
 apps/*/build
 apps/*/.next
+# Env files. `*.env` alone only matches the REPO ROOT — Docker ignore patterns
+# are matched per path, so `apps/<app>/.env` was still copied into the build
+# context. Next loads `.env` during `next build`, so a local `docker build`
+# baked developer values (e.g. HOMEPAGE_URL=http://localhost:3001) and secrets
+# into the image. CI is unaffected (these files are gitignored), but any
+# locally-built image was contaminated.
 *.env
+**/*.env
+**/.env
+**/.env.*
 .DS_Store
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .turbo
+apps/*/.turbo
+packages/*/.turbo
+packages/*/dist
 
 # sst
 .sst
+
+# Local-only working dirs (all gitignored, so none exist in a CI checkout).
+# Locally they were packed into every build context for nothing. Measured on
+# this tree, the entries added above plus these take the context from 2.20 GB
+# to 863 MB — `.pnpm-store` alone is ~1.1 GB of it.
+.pnpm-store
+plans
+.logs
+.playwright-mcp
+.tmp

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -36,6 +36,7 @@ on:
           - lambda-server
           - homepage
           - docs
+          - kb
 
 permissions:
   contents: read
@@ -80,6 +81,9 @@ jobs:
           - name: docs
             file: apps/docs/Dockerfile
             image: ghcr.io/auxx-ai/docs
+          - name: kb
+            file: apps/kb/Dockerfile
+            image: ghcr.io/auxx-ai/kb
 
     steps:
       - name: Skip non-selected image

--- a/apps/build/next.config.ts
+++ b/apps/build/next.config.ts
@@ -14,6 +14,10 @@ const nextConfig: NextConfig = {
     '@auxx/ui',
     '@auxx/utils',
   ],
+  // `next dev` otherwise generates AGENTS.md + CLAUDE.md in this app dir on
+  // every boot, pointing agents at node_modules/next/dist/docs/. We keep agent
+  // instructions in the repo-root CLAUDE.md instead.
+  agentRules: false,
   poweredByHeader: false,
   reactStrictMode: true,
   typescript: {

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -13,6 +13,10 @@ const withMDX = createMDX()
 const config = {
   // Ensure Docker build produces .next/standalone
   output: 'standalone',
+  // `next dev` otherwise generates AGENTS.md + CLAUDE.md in this app dir on
+  // every boot, pointing agents at node_modules/next/dist/docs/. We keep agent
+  // instructions in the repo-root CLAUDE.md instead.
+  agentRules: false,
   reactStrictMode: true,
   transpilePackages: ['@auxx/utils'],
   outputFileTracingRoot: path.join(__dirname, '../../'),

--- a/apps/homepage/next.config.mjs
+++ b/apps/homepage/next.config.mjs
@@ -10,6 +10,10 @@ const nextConfig = {
   output: 'standalone',
   outputFileTracingRoot: path.join(__dirname, '../../'),
   transpilePackages: ['@auxx/config', '@auxx/ui'],
+  // `next dev` otherwise generates AGENTS.md + CLAUDE.md in this app dir on
+  // every boot, pointing agents at node_modules/next/dist/docs/. We keep agent
+  // instructions in the repo-root CLAUDE.md instead.
+  agentRules: false,
   poweredByHeader: false,
   images: {
     // Avoid requiring sharp in the server Lambda; rely on client-side <img> or our optimizer function

--- a/apps/kb/Dockerfile
+++ b/apps/kb/Dockerfile
@@ -27,6 +27,18 @@ FROM base AS builder
 
 ARG PROJECT
 ARG PROJECT_PATH
+ARG GIT_SHA
+ARG APP_VERSION
+ARG BUILD_TIME
+# Baked into the Next build; docker-entrypoint.sh swaps the placeholder for the
+# real domain at container start. Without it, @auxx/config/urls falls through to
+# localhost and the prerendered root redirect points at http://localhost:3001.
+ARG DOMAIN=__RUNTIME_DOMAIN__
+
+ENV GIT_SHA=$GIT_SHA
+ENV APP_VERSION=$APP_VERSION
+ENV BUILD_TIME=$BUILD_TIME
+ENV DOMAIN=$DOMAIN
 
 WORKDIR /app
 
@@ -62,11 +74,19 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store CI=true pnpm prune --prod --no
 FROM slim AS runner
 
 ARG PROJECT_PATH
+ARG DOMAIN
+ARG GIT_SHA
+ARG APP_VERSION
+ARG BUILD_TIME
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=3002
 ENV HOSTNAME=0.0.0.0
+ENV DOMAIN=$DOMAIN
+ENV GIT_SHA=$GIT_SHA
+ENV APP_VERSION=$APP_VERSION
+ENV BUILD_TIME=$BUILD_TIME
 
 WORKDIR /app
 
@@ -89,10 +109,15 @@ COPY --from=builder --chown=nextjs:nodejs /resvg/@resvg ./node_modules/@resvg
 COPY --from=builder --chown=nextjs:nodejs /app/packages ./packages
 COPY --from=builder --chown=nextjs:nodejs /app/${PROJECT_PATH}/node_modules ./${PROJECT_PATH}/node_modules
 
+# Runtime URL substitution — see docker-entrypoint.sh Block 1.
+COPY --chown=nextjs:nodejs docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x ./docker-entrypoint.sh
+
 USER nextjs
 
 WORKDIR /app/${PROJECT_PATH}
 
 EXPOSE 3002
 
+ENTRYPOINT ["../../docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/apps/kb/next.config.ts
+++ b/apps/kb/next.config.ts
@@ -18,6 +18,10 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  // `next dev` otherwise generates AGENTS.md + CLAUDE.md in this app dir on
+  // every boot, pointing agents at node_modules/next/dist/docs/. We keep agent
+  // instructions in the repo-root CLAUDE.md instead.
+  agentRules: false,
   poweredByHeader: false,
 }
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -75,8 +75,20 @@ COPY --from=pruner /app/out/full/ .
 # Build all upstream dependencies (tsdown packages produce dist/*.mjs)
 RUN BUILDING_CONTAINER=true pnpm turbo build --filter="@auxx/web^..."
 
-# Build the web app (Next.js standalone output)
+# Build the web app (Next.js standalone output).
+#
+# Next 16.3 enables Turbopack's persistent build cache by default and writes it
+# to .next/cache. Without the mount below that directory is created and thrown
+# away inside this RUN, so every image build compiles cold. `sharing=locked`
+# because two concurrent builds writing one Turbopack cache is not safe.
+#
+# Caveat, same as plans/docker/web-image-build-speed.md: BuildKit cache mounts
+# do not survive on hosted GitHub runners, which start with an empty mount, so
+# this pays off for local builds and on a persistent-disk builder (e.g. Depot).
+# The runner stage never copies .next/cache, so an empty mount changes nothing
+# about the resulting image.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+  --mount=type=cache,id=next-web,sharing=locked,target=/app/apps/web/.next/cache \
   BUILDING_CONTAINER=true \
   SKIP_ENV_VALIDATION=1 \
   pnpm --filter=web run build:prod

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -36,15 +36,30 @@ const nextConfig = {
     '@auxx/workflow-nodes',
   ],
   experimental: {
-    // Keep Turbopack's incremental dev state across server restarts.
-    turbopackFileSystemCacheForDev: true,
-    // Persists Turbopack's incremental state in .next/cache across production
-    // builds. Only pays off where .next/cache survives between builds (local
-    // builds today; CI needs a persistent-disk builder, e.g. Depot — see
-    // plans/docker/web-image-build-speed.md). Hosted CI runners start empty,
-    // so there it just writes an unused cache.
-    turbopackFileSystemCacheForBuild: true,
+    // `turbopackFileSystemCacheForDev` and `turbopackFileSystemCacheForBuild`
+    // used to be set here. Both default to `true` as of Next 16.3, along with
+    // `turbopackMemoryEviction: 'auto'` (which needs the dev cache and is what
+    // caps dev-server memory growth), so listing them was dead config.
+    //
+    // A fresh git worktree starts with no Turbopack cache and compiles cold.
+    // This seeds it from the main checkout's cache — worth having because most
+    // agent work in this repo happens in throwaway worktrees. Best-effort;
+    // never fails a build.
+    turbopackSeedCacheFromWorktree: true,
+    // Cancel a Server Components HMR refresh's render + validation work once a
+    // newer refresh supersedes it, so saving twice in a row stops paying for
+    // the first save. Off by default upstream.
+    serverComponentsHmrCancellation: true,
+    // Run Node.js evaluation for PostCSS (Tailwind v4, on every CSS change)
+    // in worker threads instead of a pool of child processes talking over
+    // sockets. Upstream says this should use less memory and CPU, and may
+    // become the default in a later release.
+    turbopackPluginRuntimeStrategy: 'workerThreads',
   },
+  // `next dev` otherwise generates AGENTS.md + CLAUDE.md in this app dir on
+  // every boot, pointing agents at node_modules/next/dist/docs/. We keep agent
+  // instructions in the repo-root CLAUDE.md instead.
+  agentRules: false,
   poweredByHeader: false,
   reactStrictMode: true,
   // Override default externalization - exclude Prisma packages from externalization

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
     "check": "tsc --noEmit",
     "build:opennext": "open-next build",
     "check:opennext": "pnpm run build:opennext",
-    "dev": "NODE_OPTIONS='--max-old-space-size=12288' next dev --turbopack",
+    "dev": "NODE_OPTIONS='--max-old-space-size=6144' next dev --turbopack",
     "clean": "rm -rf .next .open-next .turbo node_modules *.tsbuildinfo",
     "preview": "next build --turbopack && next start",
     "start": "PORT=3000 node .next/standalone/apps/web/server.js",

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,7 +5,7 @@
 # independently gated by its own preconditions, so the same script no-ops
 # safely in containers that don't need it.
 #
-# Block 1 — Next.js runtime URL substitution (web, homepage, docs, build):
+# Block 1 — Next.js runtime URL substitution (web, homepage, docs, build, kb):
 #   At build time DOMAIN=__RUNTIME_DOMAIN__ is baked into Next.js bundles.
 #   url.ts produces these patterns:
 #     https://app.__RUNTIME_DOMAIN__    (WEBAPP_URL)
@@ -44,13 +44,24 @@ replace_in_next() {
   pattern_lower=$(echo "${pattern}" | tr '[:upper:]' '[:lower:]')
 
   echo "[entrypoint] Replacing '${label}' → ${replacement}"
-  find "${NEXT_DIR}" \( -name '*.js' -o -name '*.rsc' -o -name '*.html' -o -name '*.body' \) -type f -exec sed -i \
-    -e "s|${pattern}|${replacement}|g" \
-    -e "s|${pattern_lower}|${replacement}|g" \
-    {} + 2>/dev/null || true
+  # Select files by CONTENT, not by extension. This used to be a
+  # `find -name '*.js' -o -name '*.rsc' -o -name '*.html' -o -name '*.body'`
+  # allowlist, which silently missed `.meta` — the sidecar Next writes next to
+  # each prerendered route holding that response's status and headers. The kb
+  # root route is a prerendered 307, so its `Location` lives ONLY in
+  # `.next/server/app/index.meta` and kept pointing at
+  # `https://__RUNTIME_DOMAIN__` in every built image while the entrypoint
+  # reported "Replacement complete." Any allowlist re-breaks the moment Next
+  # adds a file type, so match on the placeholder itself.
+  # `-I` skips binaries; xargs `-r` stops sed reading stdin when nothing matches.
+  grep -rlIZ -e "${pattern}" -e "${pattern_lower}" "${NEXT_DIR}" 2>/dev/null \
+    | xargs -0 -r sed -i \
+        -e "s|${pattern}|${replacement}|g" \
+        -e "s|${pattern_lower}|${replacement}|g" \
+    2>/dev/null || true
 }
 
-# Block 1 only applies to Next.js images (web/homepage/docs/build). Non-Next
+# Block 1 only applies to Next.js images (web/homepage/docs/build/kb). Non-Next
 # images (api, worker) have no .next dir — skip the URL replacements but FALL
 # THROUGH to Block 2 (geo) and the privilege drop below. (This previously
 # `exec`-ed here, which silently skipped the geo download in the api image.)


### PR DESCRIPTION
Publishes the kb image alongside the other apps, adopts the Next 16.3 config surface, and fixes a runtime-substitution bug that shipped a placeholder domain in every prerendered redirect.

## The bug worth reviewing

`docker-entrypoint.sh` Block 1 rewrote only `*.js|*.rsc|*.html|*.body`. Next stores a prerendered route's status and headers in a `.meta` sidecar, so the kb root — a prerendered 307 — kept its `Location` **only** in `.next/server/app/index.meta`, which nothing touched:

```
$ docker run -e DOMAIN=example.com auxx-kb:localtest
[entrypoint] Replacing '__RUNTIME_DOMAIN__' → example.com
[entrypoint] Replacement complete.          # ...and yet:

$ curl -sI localhost:3002/
HTTP/1.1 307 Temporary Redirect
location: https://__RUNTIME_DOMAIN__/
```

Adding `*.meta` to the allowlist would fix today and re-break the next time Next adds a file type, so selection is now driven by the placeholder itself (`grep -rlIZ` → `xargs -0 -r sed -i`). `-I` skips binaries; xargs `-r` stops `sed` reading stdin when nothing matches.

## What else is here

**kb image** — added to the `docker-images` matrix and the `workflow_dispatch` choices; its Dockerfile gains the `GIT_SHA`/`APP_VERSION`/`BUILD_TIME` args, the `DOMAIN=__RUNTIME_DOMAIN__` placeholder, and the shared entrypoint that the other Next images already carry.

**Next 16.3 config** — `turbopackFileSystemCacheForDev`/`ForBuild` both default to `true` in 16.3 (and `turbopackMemoryEviction` to `'auto'`), so listing them was dead config. Replaced with `turbopackSeedCacheFromWorktree` (warm-starts a fresh worktree from the main checkout's cache — most agent work here happens in throwaway worktrees), `serverComponentsHmrCancellation`, and `turbopackPluginRuntimeStrategy: 'workerThreads'`. `agentRules: false` on all five Next apps stops `next dev` writing `AGENTS.md` + `CLAUDE.md` into each app dir on every boot — note this also protects the tracked, hand-written `apps/docs/CLAUDE.md` from being clobbered. Web's dev script drops 12 GB → 6 GB now that memory eviction caps dev-server growth.

**web Dockerfile** — BuildKit cache mount at `.next/cache` so Turbopack's persistent build cache survives local rebuilds. Hosted CI runners start empty and the runner stage never copies `.next/cache`, so the image is byte-identical either way.

**.dockerignore** — `*.env` alone only matches the repo root, so `apps/<app>/.env` was still copied in and baked developer values into locally built images. Also drops gitignored local-only dirs; measured with matching rsync excludes the context goes **2.20 GB → 863 MB** (`.pnpm-store` is ~1.1 GB of it). `static/` and `.bundles/` are deliberately *not* excluded — they're tracked, so CI has them.

## Verification

Local `docker build`, both images run against the dev DB:

- **kb** (`linux/amd64`) — `/health` 200; a published KB renders end to end: `/acme-org/knowledge-base` → 307 → `/acme-org/knowledge-base/main/page-1/overview` → **200, 63 KB, `<title>Overview | Knowledge Base</title>`**, PPR cache headers and S3 preload intact. `search.json` 200, DB-backed 404 renders.
- **web** (native arm64) — builds clean; Next reports the three experiments with no config warning; `/login` **200** with full env. All three ordered substitution passes apply and no placeholder survives in `.next`.
- Post-fix, both images: `grep -rlI __RUNTIME_DOMAIN__ .next` returns nothing, and `/` redirects to the real domain in both `DOMAIN=` and Railway-style `HOMEPAGE_URL`/`APP_URL` modes.

## Not done here

- **The web image was built native arm64, not amd64.** The amd64 attempt died on a qemu flake (`EINTR` on `mkdir /app/packages/logger/.turbo` inside turbo's Rust), not on anything in this diff — kb built fine under the same emulation. CI's amd64 build is the real check.
- **`kb` still needs a Railway service** pointing at `ghcr.io/auxx-ai/kb` with `DOMAIN` set; `docs/ops-reference.md:15` should list it once it exists. Like homepage/docs, kb is not part of the self-hosted compose stack.
- **Pre-existing, untouched:** `turbo prune` drops the `tw-animate-css@1.4.0` entry from kb's pruned lockfile, so kb installs with `--no-frozen-lockfile` and re-resolves on every build. Web uses `--frozen-lockfile` and is unaffected.
- The entrypoint header lists `docs` under Block 1, but `apps/docs/Dockerfile` has no `ENTRYPOINT` and no `DOMAIN` arg. Harmless — docs imports nothing from `@auxx/config` — and deliberately left alone, since its self-host page contains literal `localhost:3000` as documentation.
