### PR TITLE
feat(connections): pick optional oauth scopes at connect time

### DIFF
--- a/apps/web/src/components/apps/hooks/use-connect-flow.tsx
+++ b/apps/web/src/components/apps/hooks/use-connect-flow.tsx
@@ -7,6 +7,10 @@ import { toastError, toastSuccess } from '@auxx/ui/components/toast'
 import { type ReactNode, useCallback, useMemo, useState } from 'react'
 import { ConnectionDetailDialog } from '~/components/connections/ui/connection-detail-dialog'
 import type { DetailMethod } from '~/components/connections/ui/connection-detail-page'
+import {
+  optionalScopesHeld,
+  shouldOpenConnectDialog,
+} from '~/components/connections/ui/connection-targets'
 import { useOAuthPopup } from '~/hooks/use-oauth-popup'
 import { api, type RouterOutputs } from '~/trpc/react'
 
@@ -48,6 +52,16 @@ export interface ConnectFlowDefinition {
   ownClientReason?: 'no-platform-client' | 'pending-approval' | 'byo-entitled' | null
   /** Server-built OAuth redirect URI, surfaced for bring-your-own-client users. */
   oauthCallbackUrl?: string | null
+  /**
+   * The definition's scope floor — always requested, never removable. Only read for display
+   * (the dialog's copyable full-scope line); the authorize route reads the row.
+   */
+  oauth2Scopes?: string[] | null
+  /**
+   * Scopes this definition MAY additionally request. Non-empty is what turns the connect
+   * dialog's optional-scope picker on (`plans/connections/optional-oauth-scopes.md` §4.1).
+   */
+  oauth2OptionalScopes?: string[] | null
 }
 
 export interface ConnectTarget {
@@ -108,9 +122,14 @@ export interface ConnectFlowArgs {
    * with that declared list — this is a hint, never the authority
    * (`plans/connections/optional-oauth-scopes.md` §1, §5).
    *
-   * A seam only: nothing in the UI populates it yet. `calendar-sync-toggle.tsx:55-59` documents
-   * wanting exactly this and hand-rolls a bespoke popup because it did not exist; it is left
-   * untouched, and can adopt this when someone gets to it.
+   * Three producers: the connect dialog's picker (via `saveOrOauth`), the Edit dialog's picker
+   * (`connections-section.tsx`, which passes it to `start` outright), and — when nobody set it
+   * — `start`'s own reconnect seed (§4.4). An explicit value ALWAYS wins over the seed, empty
+   * array included: unticking a scope you hold is a deliberate downgrade, not an omission.
+   *
+   * `calendar-sync-toggle.tsx:55-59` documents wanting exactly this and hand-rolls a bespoke
+   * popup because it did not exist; it is left untouched, and can adopt this when someone gets
+   * to it.
    */
   scopeAdd?: string[]
   /**
@@ -216,6 +235,11 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
   // One dialog for every field-entry case (bare secret, multi-field secret, OAuth-with-vars) —
   // `ConnectionDetailDialog` renders the token row or the variable rows from the resolved method.
   const [formOpen, setFormOpen] = useState(false)
+  // The optional scopes ticked in the dialog's picker (§4.2). Deliberately NOT part of the
+  // dialog's `values`: those are persisted as connection variables/secrets, and a picked scope is
+  // a property of one authorize request, never of the stored connection (§5, "never persist what
+  // was picked"). It rides the authorize URL as `scope_add` and nothing else.
+  const [pickedScopes, setPickedScopes] = useState<string[]>([])
   // Pending for the silent refresh-token exchange that precedes the popup on reconnect.
   const [refreshPending, setRefreshPending] = useState(false)
   const [lastConnectedCredId, setLastConnectedCredId] = useState<string | null>(null)
@@ -405,6 +429,7 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
         return
       }
       setArgs(next)
+      setPickedScopes(next.scopeAdd ?? [])
       // `client-credentials` has no browser step — the org enters its id/secret in the same
       // field form as a secret connection; the runtime mints the bearer lazily on first use.
       if (def.connectionType === 'secret' || def.connectionType === 'client-credentials') {
@@ -414,13 +439,29 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
         return
       }
       if (def.connectionType === 'oauth2-code') {
-        const vars = def.connectionVariables ?? []
         // Reconnect reuses the stored variables (e.g. the Shopify shop) server-side,
         // so only prompt for them on a fresh connect — and try a silent token refresh
         // before falling back to the full OAuth flow.
         if (next.connectionId) {
-          void attemptRefreshThenOAuth(next)
-        } else if (vars.length > 0) {
+          // §4.4 — a reconnect must not silently downgrade the grant. It never opens a dialog,
+          // so without a seed a full re-auth of a connection holding an optional scope comes
+          // back with the floor alone and nothing says so. Re-request exactly what the
+          // connection already holds. An explicit `scopeAdd` (the Edit dialog's picker) wins:
+          // it was itself seeded from the grant, and the user's edits to it are deliberate.
+          const seeded =
+            next.scopeAdd !== undefined
+              ? next
+              : {
+                  ...next,
+                  scopeAdd: optionalScopesHeld(grantedScopesFor(utils, next.connectionId), def),
+                }
+          setArgs(seeded)
+          setPickedScopes(seeded.scopeAdd ?? [])
+          // The silent refresh keeps the existing token and never re-authorizes, so the seed is
+          // inert on that leg — it only matters on the fallback to `kickOauth`, which
+          // `attemptRefreshThenOAuth` reaches with this same object.
+          void attemptRefreshThenOAuth(seeded)
+        } else if (shouldOpenConnectDialog(def)) {
           setFormOpen(true)
         } else {
           kickOauth(next)
@@ -433,7 +474,7 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
       }
       setError(new Error('This connection cannot be connected'))
     },
-    [kickOauth, attemptRefreshThenOAuth, kickHostedProvision]
+    [kickOauth, attemptRefreshThenOAuth, kickHostedProvision, utils]
   )
 
   const activeDef = useMemo(() => {
@@ -499,7 +540,10 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
   // dialog open until the save resolves, then `onSecretSaved` closes it); an OAuth def closes the
   // form and hands off to the popup. Mirrors `connectWith`, which the catalog uses to skip the dialog.
   const saveOrOauth = useCallback(
-    (a: ConnectFlowArgs, payload: { values?: Record<string, string>; secret?: string }) => {
+    (
+      a: ConnectFlowArgs,
+      payload: { values?: Record<string, string>; secret?: string; optionalScopes?: string[] }
+    ) => {
       const def = pickDef(a)
       if (def?.connectionType === 'secret' || def?.connectionType === 'client-credentials') {
         saveSecretForOwner(a, payload)
@@ -507,10 +551,13 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
       }
       if (def?.connectionType === 'oauth2-code') {
         setFormOpen(false)
-        kickOauth(a, payload.values ?? {})
+        // The picks ride as `scope_add` on the authorize URL, NEVER as `values` — those are
+        // persisted as connection variables/secrets. The dialog only reports `optionalScopes`
+        // when the picker was actually visible, so fall back to the state it has been driving.
+        kickOauth({ ...a, scopeAdd: payload.optionalScopes ?? pickedScopes }, payload.values ?? {})
       }
     },
-    [kickOauth, saveSecretForOwner]
+    [kickOauth, saveSecretForOwner, pickedScopes]
   )
 
   // The single resolved method backing the dialog — built from the already-resolved activeDef.
@@ -527,6 +574,8 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
       ownClientOptional: activeDef.ownClientOptional,
       ownClientReason: activeDef.ownClientReason,
       oauthCallbackUrl: activeDef.oauthCallbackUrl,
+      oauth2Scopes: activeDef.oauth2Scopes,
+      oauth2OptionalScopes: activeDef.oauth2OptionalScopes,
     }
   }, [args, activeDef])
 
@@ -537,6 +586,7 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
     setRefreshPending(false)
     setFormOpen(false)
     setArgs(null)
+    setPickedScopes([])
   }, [cancelPopup])
 
   const Dialogs =
@@ -557,6 +607,8 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
         // overrides `args.name`/title in `saveSecretForOwner` via the spread `payload.name`.
         showName={showName && !args.connectionId}
         initialName={args.name}
+        selectedOptionalScopes={pickedScopes}
+        onOptionalScopesChange={setPickedScopes}
         onSubmit={(payload) => saveOrOauth(args, payload)}
       />
     ) : null
@@ -575,6 +627,24 @@ export function useConnectFlow(options: UseConnectFlowOptions = {}): UseConnectF
 
 type AppConnectionRow = RouterOutputs['apps']['listConnections'][number]
 type PlatformConnectionRow = RouterOutputs['connections']['list'][number]
+
+/**
+ * The scopes a connection was actually granted (`Credential.metadata.scope`), read off whichever
+ * connection list the caller already has warm — `apps.listConnections` for app owners,
+ * `connections.list` for everything else. Both are projected by the server (§4.6).
+ *
+ * Deliberately a **cache read, not a query**: `start` is synchronous and every surface that can
+ * reconnect a row is by definition already rendering that row from one of these two lists. Both
+ * are consulted rather than just the owner's, because the connections settings page reconnects
+ * app-owned rows out of `connections.list`. A cold cache degrades to `[]` — the connection then
+ * re-requests its floor, which is exactly today's behaviour, never worse.
+ */
+function grantedScopesFor(utils: ReturnType<typeof api.useUtils>, connectionId: string): string[] {
+  const appRow = utils.apps.listConnections.getData()?.find((r) => r.id === connectionId)
+  if (appRow) return appRow.grantedScopes ?? []
+  const platformRow = utils.connections.list.getData()?.find((r) => r.id === connectionId)
+  return platformRow?.grantedScopes ?? []
+}
 
 /**
  * Authoritative success backstop for {@link useOAuthPopup}, baselined against the current

--- a/apps/web/src/components/apps/ui/app-connections.tsx
+++ b/apps/web/src/components/apps/ui/app-connections.tsx
@@ -98,6 +98,14 @@ function AppConnections({ app, returnTo, scope, onConnectionCreated }: Props) {
       ownClientOptional: m.ownClientOptional,
       ownClientReason: m.ownClientReason,
       oauthCallbackUrl: m.oauthCallbackUrl,
+      // Scope floor + additive optional list. This map is a hand-maintained duplicate of
+      // `appTarget()` (connection-targets.ts) — this surface builds its target inline rather
+      // than calling the helper, so every field has to be added in BOTH places. Dropping
+      // these here renders an empty optional-scope picker on the app detail tab while the
+      // connections gallery shows it correctly, which is the same divergence the comment in
+      // `appTarget` records for the BYO gate fields.
+      oauth2Scopes: m.oauth2Scopes,
+      oauth2OptionalScopes: m.oauth2OptionalScopes,
     })),
   }
   const personalMethods = methods.filter((m) => !m.global)

--- a/apps/web/src/components/connections/ui/connection-detail-dialog.tsx
+++ b/apps/web/src/components/connections/ui/connection-detail-dialog.tsx
@@ -22,6 +22,7 @@ import {
   type DetailMethod,
   methodIsBareSecret,
   methodOffersOwnClient,
+  shouldOfferOptionalScopes,
 } from './connection-detail-page'
 import { validateConnectionVariables } from './connection-variable-validation'
 
@@ -59,7 +60,15 @@ interface ConnectionDetailDialogProps {
    */
   onReconnect?: () => void
   reconnectLabel?: string
-  onSubmit: (payload: { values?: Record<string, string>; secret?: string; name?: string }) => void
+  /** Controlled: the optional scopes currently ticked. */
+  selectedOptionalScopes?: string[]
+  onOptionalScopesChange?: (next: string[]) => void
+  onSubmit: (payload: {
+    values?: Record<string, string>
+    secret?: string
+    name?: string
+    optionalScopes?: string[]
+  }) => void
 }
 
 /**
@@ -84,6 +93,8 @@ export function ConnectionDetailDialog({
   initialName,
   onReconnect,
   reconnectLabel = 'Reconnect',
+  selectedOptionalScopes,
+  onOptionalScopesChange,
   onSubmit,
 }: ConnectionDetailDialogProps) {
   const [token, setToken] = useState('')
@@ -91,6 +102,11 @@ export function ConnectionDetailDialog({
   // BYO disclosure (§3.1, ownClientOptional): platform login is primary; the client fields
   // only render — and only become required — once the user opens the advanced section.
   const [byoOpen, setByoOpen] = useState(false)
+  // Optional additive scopes (§4.2). Controlled when the caller passes both props (the connect
+  // flow seeds them from an existing grant on reconnect); otherwise the dialog owns the picks
+  // so it still works standalone. Never default-on — see `OptionalScopePicker`.
+  const [ownOptionalScopes, setOwnOptionalScopes] = useState<string[]>([])
+  const optionalScopes = selectedOptionalScopes ?? ownOptionalScopes
 
   // Stable across renders so the seed effect only fires on open / method change, not every render
   // (a bare method's `?? []` would otherwise re-seed and wipe input on each render). Kept as the
@@ -136,6 +152,9 @@ export function ConnectionDetailDialog({
     setToken(loaded?.tokenSet ? HIDDEN_VALUE : '')
     setName(initialName ?? method.label)
     setByoOpen(!!loaded?.values?.clientId)
+    // Uncontrolled picks only — a controlled caller owns (and seeds) its own array, and
+    // depending on it here would reseed on every render for an inline `[]` literal.
+    setOwnOptionalScopes([])
   }, [open, needsLoad, loaded, initialName, method.label])
 
   const bareSecret = methodIsBareSecret(method)
@@ -144,6 +163,11 @@ export function ConnectionDetailDialog({
   // A bare-OAuth method has neither a token row nor variables — its edit dialog is name-only.
   // Uses the disclosure-shaped set: a closed optional-BYO method is one-click platform login.
   const hasFields = bareSecret || effectiveVariables.length > 0
+
+  function handleOptionalScopesChange(next: string[]) {
+    setOwnOptionalScopes(next)
+    onOptionalScopesChange?.(next)
+  }
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault()
@@ -156,8 +180,15 @@ export function ConnectionDetailDialog({
     })
     setErrors(next)
     if (Object.keys(next).length > 0) return
-    const payload: { values?: Record<string, string>; secret?: string; name?: string } = {}
+    const payload: {
+      values?: Record<string, string>
+      secret?: string
+      name?: string
+      optionalScopes?: string[]
+    } = {}
     if (showName) payload.name = name.trim()
+    // Only report picks the user could actually see and change.
+    if (shouldOfferOptionalScopes(method, byoOpen)) payload.optionalScopes = optionalScopes
     // Only the currently-visible fields ride along; a bare API-key method submits the token.
     if (hasFields) {
       if (bareSecret) payload.secret = token
@@ -198,6 +229,8 @@ export function ConnectionDetailDialog({
             onMethodChange={() => {}}
             byoOpen={byoOpen}
             onByoOpenChange={offersOwnClient ? setByoOpen : undefined}
+            selectedOptionalScopes={optionalScopes}
+            onOptionalScopesChange={handleOptionalScopesChange}
             values={values}
             onValueChange={setValue}
             token={token}

--- a/apps/web/src/components/connections/ui/connection-detail-optional-scopes.test.ts
+++ b/apps/web/src/components/connections/ui/connection-detail-optional-scopes.test.ts
@@ -1,0 +1,61 @@
+// apps/web/src/components/connections/ui/connection-detail-optional-scopes.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { type DetailMethod, shouldOfferOptionalScopes } from './connection-detail-page'
+
+function method(overrides: Partial<DetailMethod> = {}): DetailMethod {
+  return {
+    id: 'm1',
+    label: 'Shopify',
+    description: null,
+    connectionType: 'oauth2-code',
+    global: true,
+    oauth2Scopes: ['read_orders'],
+    oauth2OptionalScopes: ['read_all_orders'],
+    ...overrides,
+  }
+}
+
+describe('shouldOfferOptionalScopes', () => {
+  it('is false for a non-oauth2 method even with optional scopes declared', () => {
+    const secret = method({ connectionType: 'secret', requiresOwnClient: true })
+    expect(shouldOfferOptionalScopes(secret, true)).toBe(false)
+    expect(shouldOfferOptionalScopes(secret, false)).toBe(false)
+  })
+
+  it('is false when the optional list is empty, missing or null', () => {
+    expect(
+      shouldOfferOptionalScopes(method({ oauth2OptionalScopes: [], requiresOwnClient: true }), true)
+    ).toBe(false)
+    expect(
+      shouldOfferOptionalScopes(
+        method({ oauth2OptionalScopes: null, requiresOwnClient: true }),
+        true
+      )
+    ).toBe(false)
+    expect(
+      shouldOfferOptionalScopes(
+        method({ oauth2OptionalScopes: undefined, requiresOwnClient: true }),
+        true
+      )
+    ).toBe(false)
+  })
+
+  it('is true for requiresOwnClient regardless of the disclosure state', () => {
+    const mandatory = method({ requiresOwnClient: true })
+    expect(shouldOfferOptionalScopes(mandatory, false)).toBe(true)
+    expect(shouldOfferOptionalScopes(mandatory, true)).toBe(true)
+  })
+
+  it('follows the disclosure for an ownClientOptional method', () => {
+    const optionalByo = method({ ownClientOptional: true })
+    expect(shouldOfferOptionalScopes(optionalByo, false)).toBe(false)
+    expect(shouldOfferOptionalScopes(optionalByo, true)).toBe(true)
+  })
+
+  it('is false on the platform client when BYO is not offered at all', () => {
+    const platformOnly = method()
+    expect(shouldOfferOptionalScopes(platformOnly, false)).toBe(false)
+    expect(shouldOfferOptionalScopes(platformOnly, true)).toBe(false)
+  })
+})

--- a/apps/web/src/components/connections/ui/connection-detail-page.tsx
+++ b/apps/web/src/components/connections/ui/connection-detail-page.tsx
@@ -3,12 +3,16 @@
 
 import type { ConnectionVariable } from '@auxx/database'
 import { Button } from '@auxx/ui/components/button'
+import { CopyButton } from '@auxx/ui/components/button-copy'
+import { Checkbox } from '@auxx/ui/components/checkbox'
 import { Field, FieldError, FieldLabel } from '@auxx/ui/components/field'
 import { Input } from '@auxx/ui/components/input'
+import { Label } from '@auxx/ui/components/label'
 import { RadioGroup } from '@auxx/ui/components/radio-group'
 import { RadioGroupItemCard } from '@auxx/ui/components/radio-group-item'
 import { cn } from '@auxx/ui/lib/utils'
 import { ChevronDown, ChevronRight, KeyRound, Plug } from 'lucide-react'
+import { useId } from 'react'
 import { ConnectionVariableFields } from '~/components/connections/ui/connection-variable-fields'
 import { FieldPanel } from '~/components/global/forms/field-panel'
 import { OwnClientCallbackNotice } from './own-client-callback-notice'
@@ -32,6 +36,10 @@ export interface DetailMethod {
   ownClientReason?: 'no-platform-client' | 'pending-approval' | 'byo-entitled' | null
   /** Server-built OAuth redirect URI, shown so a BYO user can register it. */
   oauthCallbackUrl?: string | null
+  /** The definition's always-requested scopes (the floor). Used to show the full resulting set. */
+  oauth2Scopes?: string[] | null
+  /** Scopes this connection MAY additionally request. Renders the optional-scope picker. */
+  oauth2OptionalScopes?: string[] | null
 }
 
 /** Copy for the mandatory BYO-client banner (§3.1) — shown only when `requiresOwnClient`. */
@@ -75,6 +83,9 @@ interface ConnectionDetailPageProps {
    */
   byoOpen?: boolean
   onByoOpenChange?: (open: boolean) => void
+  /** Controlled: the optional scopes currently ticked. */
+  selectedOptionalScopes?: string[]
+  onOptionalScopesChange?: (next: string[]) => void
   /** Override the root padding/layout (e.g. the dialog drops the gallery's `px-4 py-5`). */
   className?: string
 }
@@ -126,6 +137,110 @@ export function methodIsBareSecret(method: DetailMethod): boolean {
 }
 
 /**
+ * Should the optional-scope picker be offered for this method
+ * (plans/connections/optional-oauth-scopes.md §4.1)?
+ *
+ * It is BYO-only: a merchant on the platform OAuth client never sees it, because the platform
+ * client generally cannot be granted the extra scope anyway. The gate is **presentation, not
+ * enforcement** — the server re-validates `scope_add` against the definition's optional list
+ * regardless of which client is used.
+ */
+export function shouldOfferOptionalScopes(method: DetailMethod, byoOpen: boolean): boolean {
+  return (
+    method.connectionType === 'oauth2-code' &&
+    (method.oauth2OptionalScopes?.length ?? 0) > 0 &&
+    (!!method.requiresOwnClient || (methodOffersOwnClient(method) && byoOpen))
+  )
+}
+
+/**
+ * Display separator for the full requested-scope line. The definition's real
+ * `oauth2Features.scopeSeparator` is not projected to the client; a comma is correct for
+ * Shopify and for every definition that carries optional scopes today. If a provider that
+ * separates on space ever declares optional scopes, plumb the separator through instead.
+ */
+const SCOPE_DISPLAY_SEPARATOR = ', '
+
+/** Floor + ticked optional scopes, deduped, floor first — what the authorize will request. */
+function buildRequestedScopeLine(method: DetailMethod, selected: string[]): string {
+  const floor = method.oauth2Scopes ?? []
+  const picked = new Set(selected)
+  const extra = (method.oauth2OptionalScopes ?? []).filter(
+    (scope) => picked.has(scope) && !floor.includes(scope)
+  )
+  return [...new Set([...floor, ...extra])].join(SCOPE_DISPLAY_SEPARATOR)
+}
+
+interface OptionalScopePickerProps {
+  method: DetailMethod
+  byoOpen: boolean
+  selected: string[]
+  onChange?: (next: string[]) => void
+  disabled?: boolean
+}
+
+/**
+ * The additive-scope picker (§4.2): unchecked-by-default boxes for the method's optional
+ * scopes, plus the full resulting scope string a BYO user must copy into their own OAuth
+ * app's configuration. Default-off is load-bearing — a silently pre-ticked scope the
+ * provider will not grant makes the authorize fail outright. Self-gates on
+ * {@link shouldOfferOptionalScopes}, so both BYO render sites can call it unconditionally.
+ */
+function OptionalScopePicker({
+  method,
+  byoOpen,
+  selected,
+  onChange,
+  disabled,
+}: OptionalScopePickerProps) {
+  const idPrefix = useId()
+  if (!shouldOfferOptionalScopes(method, byoOpen)) return null
+
+  const optional = method.oauth2OptionalScopes ?? []
+  const picked = new Set(selected)
+  const requested = buildRequestedScopeLine(method, selected)
+
+  return (
+    <div className='flex flex-col gap-2 rounded-2xl border border-border bg-muted/40 p-2'>
+      <p className='text-xs text-muted-foreground'>
+        Extra permissions this connection can request. The provider decides whether to grant them.
+      </p>
+      <div className='flex flex-col gap-1.5'>
+        {optional.map((scope) => (
+          <div key={scope} className='flex items-center gap-2'>
+            <Checkbox
+              id={`${idPrefix}-${scope}`}
+              checked={picked.has(scope)}
+              disabled={disabled}
+              onCheckedChange={(checked) => {
+                const next = new Set(picked)
+                if (checked === true) next.add(scope)
+                else next.delete(scope)
+                onChange?.(optional.filter((s) => next.has(s)))
+              }}
+            />
+            <Label htmlFor={`${idPrefix}-${scope}`} className='font-mono text-xs font-normal'>
+              {scope}
+            </Label>
+          </div>
+        ))}
+      </div>
+      {requested && (
+        <>
+          <p className='text-xs text-muted-foreground'>
+            Set your OAuth app's scopes to match this list before connecting:
+          </p>
+          <div className='flex items-center gap-1'>
+            <code className='min-w-0 flex-1 truncate font-mono text-xs'>{requested}</code>
+            <CopyButton text={requested} />
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+/**
  * The connect form shown on the gallery's detail page. Owns both the method chooser (when an
  * item exposes more than one way to connect — e.g. Stripe: API key OR OAuth2) and the input
  * fields for the chosen method (an API key and/or structured connection variables). A bare
@@ -146,6 +261,8 @@ export function ConnectionDetailPage({
   tokenSaved,
   byoOpen,
   onByoOpenChange,
+  selectedOptionalScopes = [],
+  onOptionalScopesChange,
   className,
   showName,
   name = '',
@@ -203,6 +320,17 @@ export function ConnectionDetailPage({
           <OwnClientCallbackNotice callbackUrl={chosen.oauthCallbackUrl} />
         </div>
       )}
+      {/* Mandatory BYO renders its client fields inline with no disclosure, so the picker sits
+          on its own here; the optional-BYO path renders it inside the disclosure below. */}
+      {chosen?.requiresOwnClient && (
+        <OptionalScopePicker
+          method={chosen}
+          byoOpen={!!byoOpen}
+          selected={selectedOptionalScopes}
+          onChange={onOptionalScopesChange}
+          disabled={disabled}
+        />
+      )}
       {chosen && methodOffersOwnClient(chosen) && (
         <div className='flex flex-col gap-2'>
           <div className='rounded-md border px-3 py-2 text-xs text-muted-foreground'>
@@ -223,6 +351,13 @@ export function ConnectionDetailPage({
             </Button>
           )}
           {byoOpen && <OwnClientCallbackNotice callbackUrl={chosen.oauthCallbackUrl} />}
+          <OptionalScopePicker
+            method={chosen}
+            byoOpen={!!byoOpen}
+            selected={selectedOptionalScopes}
+            onChange={onOptionalScopesChange}
+            disabled={disabled}
+          />
         </div>
       )}
       {chosen && methodNeedsFields(chosen) && (

--- a/apps/web/src/components/connections/ui/connection-targets.test.ts
+++ b/apps/web/src/components/connections/ui/connection-targets.test.ts
@@ -1,0 +1,129 @@
+// apps/web/src/components/connections/ui/connection-targets.test.ts
+import { describe, expect, it } from 'vitest'
+import type { ConnectFlowDefinition } from '~/components/apps/hooks/use-connect-flow'
+import { optionalScopesHeld, shouldOpenConnectDialog } from './connection-targets'
+
+/**
+ * The two pure decisions behind the optional-scope wiring
+ * (`plans/connections/optional-oauth-scopes.md` §4.3, §4.4).
+ */
+
+describe('optionalScopesHeld — the reconnect seed', () => {
+  const vocabulary = {
+    oauth2Scopes: ['read_orders', 'write_orders'],
+    oauth2OptionalScopes: ['read_all_orders', 'read_customers'],
+  }
+
+  it('re-requests exactly the optional scopes the connection was granted', () => {
+    expect(optionalScopesHeld(['read_orders', 'read_all_orders'], vocabulary)).toEqual([
+      'read_all_orders',
+    ])
+  })
+
+  it('returns nothing when the connection has no granted scopes', () => {
+    expect(optionalScopesHeld([], vocabulary)).toEqual([])
+    expect(optionalScopesHeld(undefined, vocabulary)).toEqual([])
+    expect(optionalScopesHeld(null, vocabulary)).toEqual([])
+  })
+
+  it('drops a granted scope the definition no longer declares optional', () => {
+    // `read_customers` was retired from the optional list; the authorize route would intersect
+    // it away, so it must never leave as `scope_add`.
+    const narrowed = { ...vocabulary, oauth2OptionalScopes: ['read_all_orders'] }
+    expect(optionalScopesHeld(['read_all_orders', 'read_customers'], narrowed)).toEqual([
+      'read_all_orders',
+    ])
+  })
+
+  it('never re-sends a floor scope as scope_add', () => {
+    // The two lists are supposed to be disjoint; a row where they are not must still not
+    // duplicate the always-requested floor into the additive list.
+    const overlapping = {
+      oauth2Scopes: ['read_orders'],
+      oauth2OptionalScopes: ['read_orders', 'read_all_orders'],
+    }
+    expect(optionalScopesHeld(['read_orders', 'read_all_orders'], overlapping)).toEqual([
+      'read_all_orders',
+    ])
+  })
+
+  it('returns nothing when the definition declares no optional scopes', () => {
+    expect(optionalScopesHeld(['read_all_orders'], { oauth2Scopes: ['read_orders'] })).toEqual([])
+    expect(optionalScopesHeld(['read_all_orders'], {})).toEqual([])
+  })
+
+  it('follows the declared optional order and dedupes', () => {
+    const duplicated = {
+      oauth2Scopes: [],
+      oauth2OptionalScopes: ['read_customers', 'read_all_orders', 'read_customers'],
+    }
+    expect(optionalScopesHeld(['read_all_orders', 'read_customers'], duplicated)).toEqual([
+      'read_customers',
+      'read_all_orders',
+    ])
+  })
+
+  it('tolerates null columns on both sides', () => {
+    expect(
+      optionalScopesHeld(['read_all_orders'], {
+        oauth2Scopes: null,
+        oauth2OptionalScopes: null,
+      })
+    ).toEqual([])
+  })
+})
+
+describe('shouldOpenConnectDialog — the fresh-connect trigger', () => {
+  const oauth = (extra: Partial<ConnectFlowDefinition> = {}): ConnectFlowDefinition => ({
+    connectionType: 'oauth2-code',
+    ...extra,
+  })
+
+  it('opens for any definition that declares connection variables (unchanged behaviour)', () => {
+    expect(
+      shouldOpenConnectDialog(oauth({ connectionVariables: [{ key: 'shop', label: 'Shop' }] }))
+    ).toBe(true)
+  })
+
+  it('still connects one-click for a bare OAuth definition with no optional scopes', () => {
+    expect(shouldOpenConnectDialog(oauth())).toBe(false)
+    expect(shouldOpenConnectDialog(oauth({ oauth2OptionalScopes: [] }))).toBe(false)
+  })
+
+  it('opens for a variable-less definition whose BYO client is mandatory', () => {
+    // The picker renders immediately — without the dialog it would have nowhere to go (§4.3).
+    expect(
+      shouldOpenConnectDialog(
+        oauth({ oauth2OptionalScopes: ['read_all_orders'], requiresOwnClient: true })
+      )
+    ).toBe(true)
+  })
+
+  it('opens for a variable-less definition that merely OFFERS a BYO client', () => {
+    // `byoOpen` only exists inside the dialog, so the reachable form is used: refusing to open
+    // would make the disclosure — and therefore the picker — unreachable.
+    expect(
+      shouldOpenConnectDialog(
+        oauth({ oauth2OptionalScopes: ['read_all_orders'], ownClientOptional: true })
+      )
+    ).toBe(true)
+  })
+
+  it('stays one-click when optional scopes exist but BYO is neither required nor offered', () => {
+    // `shouldOfferOptionalScopes` could never be true for this method, so the dialog would be
+    // an empty extra click.
+    expect(shouldOpenConnectDialog(oauth({ oauth2OptionalScopes: ['read_all_orders'] }))).toBe(
+      false
+    )
+  })
+
+  it('ignores optional scopes on a non-OAuth definition', () => {
+    expect(
+      shouldOpenConnectDialog({
+        connectionType: 'client-credentials',
+        oauth2OptionalScopes: ['read_all_orders'],
+        ownClientOptional: true,
+      })
+    ).toBe(false)
+  })
+})

--- a/apps/web/src/components/connections/ui/connection-targets.ts
+++ b/apps/web/src/components/connections/ui/connection-targets.ts
@@ -27,6 +27,11 @@ export function platformTarget(provider: ProviderRow): ConnectFlowArgs['target']
     connectionType: provider.connectionType,
     description: provider.description ?? undefined,
     connectionVariables: provider.connectionVariables,
+    // Same reason as `appTarget`'s methods map below: the connect dialog's optional-scope
+    // picker resolves its vocabulary from the def the flow hands it, so dropping these here
+    // renders an empty picker on this surface alone.
+    oauth2Scopes: provider.oauth2Scopes,
+    oauth2OptionalScopes: provider.oauth2OptionalScopes,
   }
   return {
     owner: {
@@ -62,8 +67,73 @@ export function appTarget(inst: AppInstallation): ConnectFlowArgs['target'] {
       ownClientOptional: m.ownClientOptional,
       ownClientReason: m.ownClientReason,
       oauthCallbackUrl: m.oauthCallbackUrl,
+      // Optional-scope vocabulary rides along for the same reason as the gate fields above:
+      // the connect dialog's picker reads `oauth2OptionalScopes` off the method the flow
+      // resolved from here, and the copyable full-scope line needs the `oauth2Scopes` floor
+      // to be right. Drop either and the picker silently renders nothing on this surface.
+      oauth2Scopes: m.oauth2Scopes,
+      oauth2OptionalScopes: m.oauth2OptionalScopes,
     })),
   }
+}
+
+/** The two scope lists a definition/provider row carries (`oauth2Scopes` is the floor). */
+interface ScopeVocabulary {
+  oauth2Scopes?: string[] | null
+  oauth2OptionalScopes?: string[] | null
+}
+
+/**
+ * The **optional** scopes a connection already holds — the intersection of what the provider
+ * actually granted with what the definition still declares as optional.
+ *
+ * This is the seed for both reconnect (§4.4: a full re-auth must re-request what the connection
+ * already had, or the grant silently downgrades to the floor) and the Edit dialog's picker
+ * (§4.5), which is why it lives here rather than inside either caller.
+ *
+ * Three things it deliberately drops:
+ * - a granted scope the definition no longer declares optional — the authorize route would
+ *   intersect it away anyway, so sending it is noise;
+ * - a granted scope that sits in the **floor** — `oauth2Scopes` is always requested, so
+ *   re-sending it as `scope_add` is redundant. The two lists are supposed to be disjoint, but
+ *   this does not assume the authoring guard held for every row already in the database;
+ * - duplicates.
+ *
+ * Order follows the declared optional list, so the result is stable across calls.
+ */
+export function optionalScopesHeld(
+  granted: readonly string[] | null | undefined,
+  vocabulary: ScopeVocabulary
+): string[] {
+  const grantedSet = new Set(granted ?? [])
+  const floor = new Set(vocabulary.oauth2Scopes ?? [])
+  const held = (vocabulary.oauth2OptionalScopes ?? []).filter(
+    (scope) => grantedSet.has(scope) && !floor.has(scope)
+  )
+  return [...new Set(held)]
+}
+
+/**
+ * Does a **fresh** `oauth2-code` connect need the connect dialog?
+ *
+ * Historically the answer was just "does it declare connection variables" — a bare OAuth
+ * definition kicked the popup straight from the card. §4.3: a definition with optional scopes
+ * and no variables then has nowhere to render the picker, so it never gets one.
+ *
+ * `shouldOfferOptionalScopes` (the render-time gate) also takes `byoOpen`, which is state that
+ * lives *inside* the dialog and cannot exist before it opens. So this uses the reachable form:
+ * BYO is either mandatory (`requiresOwnClient` — the picker shows the moment the dialog opens)
+ * or offered (`ownClientOptional` — `byoOpen` can become true once the user expands the
+ * disclosure). Erring open is the only safe direction: refusing to open the dialog for an
+ * `ownClientOptional` method would make the disclosure, and therefore the picker, unreachable.
+ * A method whose BYO is neither required nor offered can never show the picker, so it keeps
+ * the one-click connect.
+ */
+export function shouldOpenConnectDialog(def: ConnectFlowDefinition): boolean {
+  if ((def.connectionVariables?.length ?? 0) > 0) return true
+  if (def.connectionType !== 'oauth2-code') return false
+  if ((def.oauth2OptionalScopes?.length ?? 0) === 0) return false
+  return !!def.requiresOwnClient || !!def.ownClientOptional
 }
 
 /** The definition a target connects under for the given scope. */

--- a/apps/web/src/components/connections/ui/connections-section.tsx
+++ b/apps/web/src/components/connections/ui/connections-section.tsx
@@ -19,7 +19,7 @@ import { ConnectionCard, type ConnectionRow } from './connection-card'
 import { ConnectionDetailDialog } from './connection-detail-dialog'
 import type { DetailMethod } from './connection-detail-page'
 import { ConnectionStackCard } from './connection-stack-card'
-import { appTarget, platformTarget } from './connection-targets'
+import { appTarget, optionalScopesHeld, platformTarget } from './connection-targets'
 import { CredentialTemplateDialog } from './credential-template-dialog'
 import { type ConnectionGroup, groupConnections } from './group-connections'
 import { McpReconnectController } from './mcp-reconnect-controller'
@@ -49,6 +49,10 @@ export function ConnectionsSection() {
 
   const [addOpen, setAddOpen] = useState(false)
   const [editRow, setEditRow] = useState<ConnectionRow | null>(null)
+  // The optional scopes ticked in the edit dialog's picker (§4.5). Seeded from what the row
+  // already holds when the dialog opens, so its Reconnect re-requests the existing grant rather
+  // than dropping to the floor — and unticking one is how a user chooses to give it up.
+  const [editScopes, setEditScopes] = useState<string[]>([])
   // The MCP server being (re)connected from a row's Reconnect — drives the connect controller. The
   // `attempt` nonce keys the controller so re-clicking Reconnect (even on the same server after a
   // cancel) always remounts it and re-fires the connect.
@@ -99,9 +103,30 @@ export function ConnectionsSection() {
     return inst?.app.title ?? row.type
   }
 
+  /**
+   * The definition backing a row — an app's connection method, or the platform provider. Carries
+   * the OAuth scope vocabulary (floor + optional) and the BYO gate the edit dialog's picker reads.
+   * Undefined for MCP rows and definition-less secrets, which have no scopes to offer.
+   */
+  const scopeSourceForRow = (row: ConnectionRow) => {
+    if (row.kind === 'app') {
+      const inst = appInstallations.find((i) => i.app.id === row.appId)
+      // Match the row's own method; single-method apps carry no `connectionDefinitionId` on
+      // older rows, so fall back to the sole method rather than showing nothing.
+      return (
+        inst?.methods?.find((m) => m.id === row.connectionDefinitionId) ??
+        (inst?.methods?.length === 1 ? inst.methods[0] : undefined)
+      )
+    }
+    if (row.kind === 'mcp') return undefined
+    return providerByKey.get(row.type)
+  }
+
   // Reconnect re-authorizes (oauth) or re-enters (secret) the existing credential —
   // the flow opens the right surface based on the definition's connectionType.
-  const handleReconnect = (row: ConnectionRow) => {
+  // `scopeAdd` carries the edit dialog's picks straight through to the authorize URL; when it is
+  // omitted (the card's own Reconnect) the flow seeds it from the existing grant itself (§4.4).
+  const handleReconnect = (row: ConnectionRow, scopeAdd?: string[]) => {
     if (row.kind === 'app') {
       const inst = appInstallations.find((i) => i.app.id === row.appId)
       if (!inst) {
@@ -111,7 +136,12 @@ export function ConnectionsSection() {
         })
         return
       }
-      flow.start({ target: appTarget(inst), scope: row.scope, connectionId: row.id })
+      flow.start({
+        target: appTarget(inst),
+        scope: row.scope,
+        connectionId: row.id,
+        ...(scopeAdd && { scopeAdd }),
+      })
       return
     }
     // MCP rows reconnect through the MCP-native flow (its own OAuth route + connect mutation),
@@ -136,7 +166,12 @@ export function ConnectionsSection() {
       })
       return
     }
-    flow.start({ target: platformTarget(provider), scope: row.scope, connectionId: row.id })
+    flow.start({
+      target: platformTarget(provider),
+      scope: row.scope,
+      connectionId: row.id,
+      ...(scopeAdd && { scopeAdd }),
+    })
   }
 
   // Plain connection secrets with no platform definition edit a single API key inline in the edit
@@ -154,9 +189,14 @@ export function ConnectionsSection() {
     ? isPlainSecret(editRow) || editProvider?.connectionType === 'secret'
     : false
 
+  // The definition backing the row being edited — supplies the OAuth scope vocabulary and the
+  // BYO gate the optional-scope picker hangs off (§4.1).
+  const editSource = editRow ? scopeSourceForRow(editRow) : undefined
+
   // Synthetic method backing the unified edit dialog. Plain secrets expose a bare API-key row;
   // provider secrets expose the provider's fields (apiKey, base URL, …), seeded masked from
-  // `getForEdit`; OAuth/app rows are fieldless (name-only). Cheap to recompute, so no memo.
+  // `getForEdit`; OAuth/app rows are fieldless (name-only) apart from the optional-scope picker.
+  // Cheap to recompute, so no memo.
   const editMethod: DetailMethod | null = editRow
     ? {
         id: editRow.connectionDefinitionId ?? editRow.id,
@@ -166,8 +206,28 @@ export function ConnectionsSection() {
         global: editRow.scope !== 'user',
         connectionVariables:
           editProvider?.connectionType === 'secret' ? (editProvider.connectionVariables ?? []) : [],
+        // The BYO gate rides along because `shouldOfferOptionalScopes` reads it — the picker
+        // lives inside the "use your own OAuth client" disclosure. It adds no credential fields
+        // here: `connectionVariables` above stays empty for OAuth rows, so the dialog keeps its
+        // name-only Save and the disclosure only reveals the callback notice and the picker.
+        ...(editInlineSecret
+          ? {}
+          : {
+              requiresOwnClient: editSource?.requiresOwnClient,
+              ownClientOptional: editSource?.ownClientOptional,
+              ownClientReason: editSource?.ownClientReason,
+              oauthCallbackUrl: editSource?.oauthCallbackUrl,
+              oauth2Scopes: editSource?.oauth2Scopes,
+              oauth2OptionalScopes: editSource?.oauth2OptionalScopes,
+            }),
       }
     : null
+
+  /** Open the edit dialog for a row, seeding the picker with the optional scopes it already holds. */
+  const openEdit = (row: ConnectionRow) => {
+    setEditRow(row)
+    setEditScopes(optionalScopesHeld(row.grantedScopes, scopeSourceForRow(row) ?? {}))
+  }
 
   const onEditSaved = () => {
     setEditRow(null)
@@ -261,7 +321,7 @@ export function ConnectionsSection() {
       iconId={resolveIcon(row)}
       subtitle={resolveSubtitle(row)}
       actionLabel='Edit'
-      onAction={() => setEditRow(row)}
+      onAction={() => openEdit(row)}
       onDelete={() => void handleDelete(row)}
     />
   )
@@ -450,13 +510,19 @@ export function ConnectionsSection() {
               ? 'Rename this connection or update its credentials.'
               : 'Rename this connection, or use Reconnect to re-authorize or update its credentials.'
           }
+          selectedOptionalScopes={editScopes}
+          onOptionalScopesChange={setEditScopes}
+          // The post-connect upgrade path (§4.5): tick the extra scope, then Reconnect. The picks
+          // ride through as `scope_add`; Save stays a rename, since a granted scope only changes
+          // by re-authorizing.
           onReconnect={
             editInlineSecret
               ? undefined
               : () => {
                   const row = editRow
+                  const scopeAdd = editScopes
                   setEditRow(null)
-                  handleReconnect(row)
+                  handleReconnect(row, scopeAdd)
                 }
           }
           onSubmit={handleEditSubmit}

--- a/apps/web/src/components/connections/ui/own-client-callback-notice.tsx
+++ b/apps/web/src/components/connections/ui/own-client-callback-notice.tsx
@@ -23,7 +23,7 @@ export function OwnClientCallbackNotice({ callbackUrl }: OwnClientCallbackNotice
   if (!callbackUrl) return null
 
   return (
-    <div className='flex flex-col gap-1 rounded-md border border-border bg-muted/40 p-2'>
+    <div className='flex flex-col gap-1 rounded-2xl border border-border bg-muted/40 p-2'>
       <p className='text-xs text-muted-foreground'>
         Add this redirect URI to your OAuth app before connecting:
       </p>

--- a/apps/web/src/server/api/routers/apps.ts
+++ b/apps/web/src/server/api/routers/apps.ts
@@ -155,6 +155,14 @@ export const appsRouter = createTRPCRouter({
                   m.connectionVariables,
                   gate
                 ),
+                // Scope floor + additive optional list. This literal is a hard
+                // re-projection, so omitting them here drops them between the cache and the
+                // client exactly as it once dropped the BYO gate fields
+                // (plans/connections/optional-oauth-scopes.md row 19). Ungated on purpose:
+                // the BYO condition on the picker is presentation, resolved in the
+                // component, and `resolveRequestedScopes` re-intersects server-side anyway.
+                oauth2Scopes: m.oauth2Scopes,
+                oauth2OptionalScopes: m.oauth2OptionalScopes,
                 requiresOwnClient: gate.requiresOwnClient,
                 ownClientOptional: gate.ownClientOptional,
                 ownClientReason: gate.reason,

--- a/apps/web/src/server/api/routers/connections.ts
+++ b/apps/web/src/server/api/routers/connections.ts
@@ -24,6 +24,7 @@ import { getAllProviders, getProviderByKey } from '@auxx/lib/connections/provide
 import { isAdminOrOwner } from '@auxx/lib/members'
 import { getChannelProviderIcon } from '@auxx/lib/providers'
 import { CredentialTestingService, isCredentialInUse } from '@auxx/lib/workflow-engine'
+import { parseGrantedScopes } from '@auxx/services/app-connections'
 import { TRPCError } from '@trpc/server'
 import { z } from 'zod'
 import { createTRPCRouter, notDemo, protectedProcedure } from '~/server/api/trpc'
@@ -159,6 +160,12 @@ export const connectionsRouter = createTRPCRouter({
           // a workspace-scoped key (Quo) legitimately backs one channel per phone number, and
           // the delete guard's message counts all of them.
           channelCount: boundChannels?.length ?? 0,
+          // What the provider actually GRANTED, parsed off `metadata.scope`. Always an array
+          // (`[]` when nothing is stored) so the client never branches on absence. Reconnect
+          // seeds `scope_add` from this ∩ the definition's optional list, which is what stops
+          // a full re-auth from silently downgrading the grant — §4.4/§4.6 of
+          // plans/connections/optional-oauth-scopes.md.
+          grantedScopes: parseGrantedScopes(record.metadata?.scope),
         }
       })
     }),
@@ -182,8 +189,17 @@ export const connectionsRouter = createTRPCRouter({
         oauth2ClientId: true,
         oauth2ClientSecret: true,
         platformClientApproved: true,
+        // Scope floor + additive optional list, read from the ROW rather than the code-native
+        // catalog: the authorize route resolves the definition by id and
+        // `resolveRequestedScopes` intersects `scope_add` against THIS row, so a picker built
+        // off the catalog could offer a scope the row does not declare and have it dropped
+        // silently. The row is a faithful mirror of the def (`ensurePlatformProviders` upserts
+        // both columns), but it is the one the server enforces.
+        oauth2Scopes: true,
+        oauth2OptionalScopes: true,
       },
     })
+    const defByKey = new Map(defRows.map((d) => [d.providerKey as string, d]))
     // Org-aware: `byoOAuthClient` can offer BYO on top of a verified platform client.
     // Resolved per row but the feature read behind it is one cached org lookup, not N.
     const gateByKey = new Map(
@@ -210,6 +226,7 @@ export const connectionsRouter = createTRPCRouter({
           ? (gateByKey.get(p.providerKey) ?? NO_OWN_CLIENT_GATE)
           : NO_OWN_CLIENT_GATE
       const { requiresOwnClient, ownClientOptional } = gate
+      const defRow = defByKey.get(p.providerKey)
       return {
         providerKey: p.providerKey,
         label: p.label,
@@ -232,6 +249,10 @@ export const connectionsRouter = createTRPCRouter({
         ),
         icon: p.uiMetadata?.icon ?? null,
         category: p.uiMetadata?.category ?? null,
+        /** Scope floor — always requested. Joined with the picks for the copyable line. */
+        oauth2Scopes: defRow?.oauth2Scopes ?? [],
+        /** Additive scopes this provider MAY be asked for. Empty = no picker. */
+        oauth2OptionalScopes: defRow?.oauth2OptionalScopes ?? [],
         // OAuth-only: whether this connection must bring its own client id/secret, whether
         // BYO is offered as an optional alternative, and why. `false`/`null` for non-OAuth
         // providers (no DB gate) and secret defs.

--- a/packages/lib/src/cache/__tests__/installed-apps-provider-scopes.test.ts
+++ b/packages/lib/src/cache/__tests__/installed-apps-provider-scopes.test.ts
@@ -1,0 +1,98 @@
+// packages/lib/src/cache/__tests__/installed-apps-provider-scopes.test.ts
+
+import type { Database } from '@auxx/database'
+import { describe, expect, it } from 'vitest'
+import { ORG_CACHE_KEY_CONFIG } from '../org-cache-keys'
+import { installedAppsProvider } from '../providers/installed-apps-provider'
+
+/** Minimal db double: the two relational reads plus the batched credential select. */
+function makeFakeDb(installations: unknown[], connectionDefs: unknown[]): Database {
+  const selectChain = (resolved: unknown[]) => {
+    const proxy: unknown = new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          if (prop === 'then') return Promise.resolve(resolved).then.bind(Promise.resolve(resolved))
+          return () => proxy
+        },
+      }
+    )
+    return proxy
+  }
+  return {
+    query: {
+      AppInstallation: { findMany: async () => installations },
+      ConnectionDefinition: { findMany: async () => connectionDefs },
+    },
+    select: () => selectChain([]),
+  } as unknown as Database
+}
+
+const INSTALLATION = {
+  id: 'inst_1',
+  installationType: 'production',
+  installedAt: new Date('2026-01-01'),
+  app: {
+    id: 'app_1',
+    slug: 'shopify',
+    title: 'Shopify',
+    description: null,
+    avatarUrl: null,
+    category: null,
+  },
+  currentDeployment: null,
+}
+
+function connectionDef(overrides: Record<string, unknown>) {
+  return {
+    id: 'cd_1',
+    key: 'oauth',
+    appId: 'app_1',
+    label: 'Shopify store',
+    description: null,
+    global: true,
+    connectionType: 'oauth2-code',
+    oauth2Features: {},
+    connectionVariables: [],
+    oauth2ClientId: null,
+    oauth2ClientSecret: null,
+    platformClientApproved: true,
+    ...overrides,
+  }
+}
+
+/** The third-party row — index 0 is the synthetic built-in `auxx` row. */
+async function methodsFor(def: Record<string, unknown>) {
+  const rows = await installedAppsProvider.compute(
+    'org_1',
+    makeFakeDb([INSTALLATION], [connectionDef(def)])
+  )
+  return rows.find((r) => r.app.id === 'app_1')?.methods ?? []
+}
+
+describe('installedAppsProvider methods[] scope projection', () => {
+  it('carries the scope floor and the additive optional list', async () => {
+    const [method] = await methodsFor({
+      oauth2Scopes: ['read_orders', 'write_orders'],
+      oauth2OptionalScopes: ['read_all_orders'],
+    })
+
+    expect(method?.oauth2Scopes).toEqual(['read_orders', 'write_orders'])
+    expect(method?.oauth2OptionalScopes).toEqual(['read_all_orders'])
+  })
+
+  it('defaults both to [] when the columns are null', async () => {
+    const [method] = await methodsFor({ oauth2Scopes: null, oauth2OptionalScopes: null })
+
+    expect(method?.oauth2Scopes).toEqual([])
+    expect(method?.oauth2OptionalScopes).toEqual([])
+  })
+})
+
+describe('installedApps cache prefix', () => {
+  // The projection above changed shape, so a stale blob under the previous prefix would
+  // make every installed app read as declaring no optional scopes for the full 900 s TTL.
+  it('is bumped to v8', () => {
+    expect(ORG_CACHE_KEY_CONFIG.installedApps.prefix).toBe('org:installed-apps:v8')
+  })
+})

--- a/packages/lib/src/cache/org-cache-keys.ts
+++ b/packages/lib/src/cache/org-cache-keys.ts
@@ -508,6 +508,19 @@ export interface CachedInstalledApp {
      * grant, since `plan.changed` does not invalidate `installedApps`.
      */
     connectionVariables: ConnectionVariable[]
+    /**
+     * The scope FLOOR — always requested, never removable. The optional-scope picker joins
+     * it with the picked optional scopes to show the full scope string a BYO user must
+     * mirror in their own OAuth app.
+     */
+    oauth2Scopes: string[]
+    /**
+     * ADDITIVE scopes a connect attempt may request on top of the floor, disjoint from it.
+     * Rendered as the picker's checkboxes. Presentation only — the authorize route
+     * re-intersects `scope_add` against this same list server-side. See
+     * plans/connections/optional-oauth-scopes.md §4.
+     */
+    oauth2OptionalScopes: string[]
     /** Own-client gate INPUTS (§3.1). The gate itself is resolved per-org at read time. */
     oauth2ClientId: string | null
     oauth2ClientSecret: string | null
@@ -867,7 +880,12 @@ export const ORG_CACHE_KEY_CONFIG: Record<
   // `oauth2ClientId`/`platformClientApproved`, so the read-time gate would read it as
   // "no platform client" and demand BYO credentials for EVERY installed app until the TTL
   // expired. The bump is what makes this deploy safe.
-  installedApps: { prefix: 'org:installed-apps:v7', ttlSeconds: 900 },
+  // v8: `methods[]` gained `oauth2Scopes` + `oauth2OptionalScopes`. A v7 blob carries
+  // neither, so the optional-scope picker would read every installed app as declaring no
+  // optional scopes — it would render nothing at all, and the copyable full-scope line
+  // would come out empty — for the full 900 s TTL. Silent and indistinguishable from
+  // "this app has none", which is exactly the failure the picker exists to prevent.
+  installedApps: { prefix: 'org:installed-apps:v8', ttlSeconds: 900 },
   mcpServers: { prefix: 'org:mcpServers', ttlSeconds: ONE_DAY },
   // Read per CRUD event by trigger dispatch; changes only on admin edits →
   // 5 s local window (dispatch enqueues jobs, so peer staleness is benign).

--- a/packages/lib/src/cache/providers/installed-apps-provider.ts
+++ b/packages/lib/src/cache/providers/installed-apps-provider.ts
@@ -105,6 +105,11 @@ export const installedAppsProvider: CacheProvider<CachedInstalledApp[]> = {
               connectionType: true,
               oauth2Features: true,
               connectionVariables: true,
+              // Scope floor + the additive optional list (disjoint). The picker renders
+              // checkboxes from the optional list and the copyable full-scope string from
+              // both. See plans/connections/optional-oauth-scopes.md §4.2.
+              oauth2Scopes: true,
+              oauth2OptionalScopes: true,
               // Own-client gate (§3.1): a pending-verification platform client lets the app
               // offer platform-login OR bring-your-own client.
               oauth2ClientId: true,
@@ -231,6 +236,8 @@ export const installedAppsProvider: CacheProvider<CachedInstalledApp[]> = {
           connectionType: def.connectionType,
           global: def.global ?? false,
           connectionVariables: def.connectionVariables ?? [],
+          oauth2Scopes: def.oauth2Scopes ?? [],
+          oauth2OptionalScopes: def.oauth2OptionalScopes ?? [],
           oauth2ClientId: def.oauth2ClientId,
           oauth2ClientSecret: def.oauth2ClientSecret,
           platformClientApproved: def.platformClientApproved,

--- a/packages/services/src/app-connections/__tests__/granted-scopes.test.ts
+++ b/packages/services/src/app-connections/__tests__/granted-scopes.test.ts
@@ -1,0 +1,101 @@
+// packages/services/src/app-connections/__tests__/granted-scopes.test.ts
+
+import { describe, expect, it, vi } from 'vitest'
+
+const listCredentials = vi.fn()
+
+vi.mock('@auxx/credentials/store', () => ({
+  listCredentials: (...args: unknown[]) => listCredentials(...args),
+}))
+
+vi.mock('@auxx/database', () => ({
+  database: {},
+  schema: { App: { id: 'id', title: 'title' } },
+}))
+
+import { listAppConnections, parseGrantedScopes } from '../list-app-connections'
+
+/** A credential row shaped like `listCredentials` returns it, with no appId so the App
+ *  title lookup is skipped entirely (`appIds.length === 0`). */
+function credential(metadata: Record<string, unknown>) {
+  return {
+    id: 'cred_1',
+    appId: null,
+    appInstallationId: null,
+    label: null,
+    consecutiveRefreshFailures: 0,
+    expiresAt: null,
+    lastRefreshError: null,
+    lastRefreshFailureAt: null,
+    createdByName: null,
+    createdAt: new Date('2026-01-01'),
+    userId: null,
+    connectionDefinitionId: 'cd_1',
+    isDefault: false,
+    metadata,
+  }
+}
+
+describe('parseGrantedScopes', () => {
+  it('splits a comma-separated Shopify-style scope string', () => {
+    expect(parseGrantedScopes('read_orders,write_orders,read_all_orders')).toEqual([
+      'read_orders',
+      'write_orders',
+      'read_all_orders',
+    ])
+  })
+
+  it('splits a space-separated RFC 6749 scope string', () => {
+    expect(parseGrantedScopes('openid email profile')).toEqual(['openid', 'email', 'profile'])
+  })
+
+  it('tolerates mixed separators and repeated whitespace', () => {
+    expect(parseGrantedScopes('a, b   c,,d')).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('returns [] for empty, absent and non-string values', () => {
+    expect(parseGrantedScopes('')).toEqual([])
+    expect(parseGrantedScopes(undefined)).toEqual([])
+    expect(parseGrantedScopes(null)).toEqual([])
+    expect(parseGrantedScopes(['read_orders'])).toEqual([])
+  })
+})
+
+describe('listAppConnections grantedScopes', () => {
+  it('exposes the granted scope from a comma-separated stored value', async () => {
+    listCredentials.mockResolvedValue({
+      isErr: () => false,
+      value: [credential({ scope: 'read_orders,read_all_orders' })],
+    })
+
+    const result = await listAppConnections('org_1')
+
+    expect(result.isOk()).toBe(true)
+    expect(result._unsafeUnwrap()[0]?.grantedScopes).toEqual(['read_orders', 'read_all_orders'])
+  })
+
+  it('exposes the granted scope from a space-separated stored value', async () => {
+    listCredentials.mockResolvedValue({
+      isErr: () => false,
+      value: [credential({ scope: 'openid https://www.googleapis.com/auth/calendar' })],
+    })
+
+    const result = await listAppConnections('org_1')
+
+    expect(result._unsafeUnwrap()[0]?.grantedScopes).toEqual([
+      'openid',
+      'https://www.googleapis.com/auth/calendar',
+    ])
+  })
+
+  it('returns [] when no scope is stored, never null or undefined', async () => {
+    listCredentials.mockResolvedValue({
+      isErr: () => false,
+      value: [credential({ connectionVariables: { shop: 'auxx-lift' } })],
+    })
+
+    const result = await listAppConnections('org_1')
+
+    expect(result._unsafeUnwrap()[0]?.grantedScopes).toEqual([])
+  })
+})

--- a/packages/services/src/app-connections/index.ts
+++ b/packages/services/src/app-connections/index.ts
@@ -22,7 +22,7 @@ export {
   getConnectionDefinitionById,
   listAppConnectionDefinitions,
 } from './list-app-connection-definitions'
-export { listAppConnections } from './list-app-connections'
+export { listAppConnections, parseGrantedScopes } from './list-app-connections'
 export { renameAppConnection } from './rename-app-connection'
 export type { AppConnection, ConnectionDefinitionSummary } from './types'
 // Export utility functions

--- a/packages/services/src/app-connections/list-app-connection-definitions.ts
+++ b/packages/services/src/app-connections/list-app-connection-definitions.ts
@@ -19,6 +19,18 @@ export interface ConnectionMethod {
   /** true = organization-wide, false = user-specific. A property of the method. */
   global: boolean
   connectionVariables: ConnectionVariable[]
+  /**
+   * The scope FLOOR — always requested, never removable. Carried so the picker can render
+   * the full resulting scope string a BYO user must mirror in their own OAuth app
+   * (`plans/connections/optional-oauth-scopes.md` §4.2).
+   */
+  oauth2Scopes: string[]
+  /**
+   * ADDITIVE scopes a connect attempt may request on top of the floor, disjoint from it.
+   * Never requested unless named via `scope_add`; the server re-intersects against this
+   * same list at authorize, so the picker is a hint, never the authority.
+   */
+  oauth2OptionalScopes: string[]
 }
 
 const METHOD_COLUMNS = {
@@ -29,6 +41,8 @@ const METHOD_COLUMNS = {
   connectionType: true,
   global: true,
   connectionVariables: true,
+  oauth2Scopes: true,
+  oauth2OptionalScopes: true,
 } as const
 
 function toMethod(row: {
@@ -39,6 +53,8 @@ function toMethod(row: {
   connectionType: string
   global: boolean | null
   connectionVariables: ConnectionVariable[] | null
+  oauth2Scopes: string[] | null
+  oauth2OptionalScopes: string[] | null
 }): ConnectionMethod {
   return {
     id: row.id,
@@ -48,6 +64,8 @@ function toMethod(row: {
     connectionType: row.connectionType,
     global: row.global ?? false,
     connectionVariables: row.connectionVariables ?? [],
+    oauth2Scopes: row.oauth2Scopes ?? [],
+    oauth2OptionalScopes: row.oauth2OptionalScopes ?? [],
   }
 }
 

--- a/packages/services/src/app-connections/list-app-connections.ts
+++ b/packages/services/src/app-connections/list-app-connections.ts
@@ -17,6 +17,20 @@ import type { AppConnection } from './types'
 const CONNECTION_CIRCUIT_OPEN_THRESHOLD = 5
 
 /**
+ * Split a stored granted-scope string into individual scopes.
+ *
+ * RFC 6749 §3.3 specifies space-delimited, but several providers (Shopify among them) use
+ * commas, so both are accepted rather than assumed — the same rule as `parseScopeString`
+ * in `@auxx/sdk`, reimplemented here because `@auxx/sdk` is not a dependency of this
+ * package and the granted scope is not an app-runtime concern.
+ *
+ * Always returns an array, never null/undefined, so the client never branches on absence.
+ */
+export function parseGrantedScopes(raw: unknown): string[] {
+  return typeof raw === 'string' ? raw.split(/[\s,]+/).filter(Boolean) : []
+}
+
+/**
  * List active connections for an organization
  *
  * Retrieves all app connections for an organization, with optional filtering by user.
@@ -135,6 +149,11 @@ export async function listAppConnections(organizationId: string, userId?: string
       connectionVariables: (cred.metadata?.connectionVariables ?? undefined) as
         | Record<string, string>
         | undefined,
+      // What the provider actually GRANTED (stamped by `resolveGrantedScopes` at every
+      // callback). Reconnect re-requests this ∩ the definition's optional list so a full
+      // re-auth cannot silently downgrade a connection that holds an optional scope —
+      // plans/connections/optional-oauth-scopes.md §4.4/§4.6.
+      grantedScopes: parseGrantedScopes(cred.metadata?.scope),
     }
   })
 

--- a/packages/services/src/app-connections/types.ts
+++ b/packages/services/src/app-connections/types.ts
@@ -110,4 +110,10 @@ export interface AppConnection {
   /** True when this is the primary org connection record actions resolve to (§4a). */
   isDefault?: boolean
   connectionVariables?: Record<string, string>
+  /**
+   * The scopes the provider actually granted, parsed from `Credential.metadata.scope`.
+   * Always an array — `[]` when nothing is stored — so the client never branches on absence.
+   * Reconnect seeds `scope_add` from this so a re-auth cannot downgrade the grant (§4.4).
+   */
+  grantedScopes: string[]
 }


### PR DESCRIPTION
Phase 2 of `plans/connections/optional-oauth-scopes.md`. Phase 1 (#1908) made a definition able to *declare* optional scopes and the authorize route able to honour `scope_add` — but nothing in the product could request one without hand-building the URL. This adds the picker, the reconnect guarantee, and the post-connect upgrade path.

## The picker is BYO-only

It renders inside the **existing** "Use your own OAuth client (advanced)" disclosure, gated by:

```ts
shouldOfferOptionalScopes(method, byoOpen)
  = connectionType === 'oauth2-code'
    && optionalScopes.length > 0
    && (requiresOwnClient || (methodOffersOwnClient(method) && byoOpen))
```

A merchant on the platform client never sees it — and for the public Shopify app couldn't use it anyway, since Shopify won't grant `read_all_orders` to an unapproved public app.

🛑 **The gate is presentation, not enforcement.** `resolveRequestedScopes` doesn't know about BYO; `scope_add` is still re-intersected server-side against the definition regardless of which client is used.

It lists the **optional scopes alone**, unchecked, plus a **copyable line carrying the full resulting scope string**. That line is the point of the screen — a BYO user must configure their own app's `access_scopes` to match — and its dedupe mirrors `resolveRequestedScopes` exactly, so what they copy is what the server requests. It reuses the `OwnClientCallbackNotice` idiom rather than inventing a second "paste this into your provider's console" pattern.

## Two behaviours that aren't the picker but are load-bearing

**Reconnect no longer silently downgrades a grant.** A connection holding `read_all_orders` that went through a full re-auth came back with only the floor, and nothing said so. Reconnect now seeds `scope_add` from `granted ∩ optional \ floor`. An explicit pick — including unticking everything — still wins, so a deliberate downgrade stays possible.

**The connect dialog opens for optional scopes alone.** It previously rendered only when the method declared connection variables, so a definition with optional scopes and no variables had nowhere to put a picker.

## Post-connect upgrade: Edit → tick → Reconnect

No new menu item. The Edit dialog for OAuth rows was name-only; the picker drops into that space, seeded **default-on** from the held grant (the inverse of fresh connect's default-off). `connectionVariables` stays `[]`, so Save remains name-only.

## `grantedScopes` on both connection lists

Parsed off `metadata.scope` in `listAppConnections` and `connections.list`. Neither projected it before — `listAppConnections` was already reading `connectionVariables` off `metadata` and simply stopped short. **No new DB query anywhere in this PR.** This is what makes the reconnect seed and the upgrade path possible, so it's a prerequisite rather than an add-on.

## The projection problem

Four hand-maintained re-projections sit between the query and the component:

```
installed-apps-provider (cache compute)
  → apps.listInstalled          ← re-projects methods[] as a fresh literal
  → appTarget()                 ← re-projects again
  → app-connections.tsx         ← inline duplicate of appTarget
```

Each names its fields explicitly and silently drops anything missed. **Two of the four were missed on the first pass** — one caught in review, one only in the browser, where the picker rendered nothing despite correct data all the way to the tRPC response. Both fixed, both commented.

`installedApps` cache prefix bumped **v7 → v8**: a v7 blob carries no scope fields, so without it every installed app would render an empty picker until the 900s TTL expired.

## Known limitation (not a bug)

`platformTarget` carries no BYO gate fields, so the picker **cannot render on a fresh platform-provider connect**. App connects and the Edit dialog are unaffected. No platform provider declares optional scopes today, so it's currently unreachable. Threading the gate through would move BYO client fields from inline to behind the disclosure for every platform provider — a separate UX decision, deliberately not made here.

## Tests

250 passing (51 web, 7 services, 192 lib), 28 new — the `shouldOfferOptionalScopes` truth table, the reconnect seed (granted-not-optional dropped, floor scope not re-sent, empty grant), `grantedScopes` parsing (comma / space / mixed / absent), and the cached `methods[]` projection including a `v8` prefix assertion.

`lib` ratchet at baseline. Lint clean.

> ⚠️ The `web` ratchet reports 1 error in `use-custom-field-mutations.tsx` (TS2322, `allowNewOptions`). Byte-identical to main, traces to #1869, unrelated to this PR — same caveat as #1908.

## Verified in the browser

Connect dialog → "Use your own OAuth client" → `read_all_orders` checkbox renders; ticking it appends to the copyable line (10 scopes → 11).
