### PR TITLE
fix(connections): shopify admin api needs its own header, not bearer

### DIFF
--- a/packages/lib/src/connections/auth-apply.ts
+++ b/packages/lib/src/connections/auth-apply.ts
@@ -17,6 +17,20 @@ export const BEARER_AUTH: AuthApply = {
 }
 
 /**
+ * Shopify's Admin API does NOT use a bearer token — it reads the access token from its own
+ * `X-Shopify-Access-Token` header, and rejects `Authorization: Bearer <token>` with a 401 that
+ * looks like a bad credential rather than a bad header.
+ *
+ * Only the HTTP node and the generic-REST connector consult `authApply`; the Shopify app builds
+ * its own requests, which is why every Shopify definition carried the wrong bearer spec unnoticed.
+ */
+export const SHOPIFY_ADMIN_AUTH: AuthApply = {
+  in: 'header',
+  name: 'X-Shopify-Access-Token',
+  format: '{value}',
+}
+
+/**
  * The default auth application for a connection type when none is declared on
  * its definition. An `oauth2-code` access token — and a server-minted
  * `client-credentials` token — is always a bearer token, so app authors needn't

--- a/packages/lib/src/connections/providers/defs.ts
+++ b/packages/lib/src/connections/providers/defs.ts
@@ -5,7 +5,7 @@
 // each into a ConnectionDefinition row keyed by providerKey.
 
 import { FieldType } from '@auxx/database/enums'
-import { BEARER_AUTH as BEARER } from '../auth-apply'
+import { BEARER_AUTH as BEARER, SHOPIFY_ADMIN_AUTH } from '../auth-apply'
 import type { PlatformProviderDef } from './types'
 
 /** Per-credential OAuth client variables for bring-your-own-client providers (§9.1). */
@@ -278,7 +278,7 @@ export const PLATFORM_PROVIDER_DEFS: PlatformProviderDef[] = [
         required: true,
       },
     ],
-    authApply: BEARER,
+    authApply: SHOPIFY_ADMIN_AUTH,
     baseUrlTemplate: 'https://{shop}.myshopify.com/admin/api/2024-10',
     uiMetadata: { icon: 'brand:shopify', category: 'ecommerce', brandColor: '#5d8a66' },
   },


### PR DESCRIPTION
## The bug

The `shopifyOAuth2Api` platform provider declared `authApply: BEARER` — `Authorization: Bearer <token>`.

Shopify's Admin API doesn't accept that. It reads the access token from **`X-Shopify-Access-Token`**, and answers a bearer request with a `401` that reads like a **bad credential** rather than a bad header — so the natural next step is to go re-check the token, which is the wrong place to look.

## The fix

Adds `SHOPIFY_ADMIN_AUTH` beside `BEARER_AUTH` in `auth-apply.ts` and points the definition at it:

```ts
export const SHOPIFY_ADMIN_AUTH: AuthApply = {
  in: 'header',
  name: 'X-Shopify-Access-Token',
  format: '{value}',
}
```

## Why nothing has broken yet

`authApply` is consulted by exactly two things — the **workflow HTTP node** (`http.ts:808`) and the **generic-REST data connector**. The Shopify app is neither: it builds its own requests via raw `fetch` and sets the header itself (`shopify-api.ts`).

That's precisely why the wrong spec sat there unnoticed, and why it would have failed confusingly the first time someone pointed an HTTP node or a REST connector at a Shopify connection.

## Scope

Three Shopify definitions exist. This PR fixes the one that is **code-native**:

| Definition | Fixed where |
| --- | --- |
| `shopifyOAuth2Api` (platform provider) | **this PR** — `defs.ts` |
| Shopify app, OAuth method | build portal (DB row) — done |
| Shopify app, API Key method | build portal (DB row) — done, uses `{api_key}` since the token lives in `fields`, not `value` |

The two app definitions are DB rows and were set through the portal. This one **must** be code: `ensurePlatformProviders` upserts `authApply` unconditionally, so a portal or SQL edit would be silently clobbered on the next reseed.

⚠️ **Takes effect on the next boot/seed, not on deploy** — the row is only rewritten when `ensurePlatformProviders` runs.

## Tests

`packages/lib` connections suite: 102 passing. Ratchet at baseline (29/29).

No behaviour change to any current code path, by construction — nothing reads this spec today.
