### PR TITLE
fix(custom-fields): stop the allowNewOptions sentinel leaking into stored options

### DIFF
--- a/apps/web/src/components/custom-fields/hooks/use-custom-field-mutations.tsx
+++ b/apps/web/src/components/custom-fields/hooks/use-custom-field-mutations.tsx
@@ -4,6 +4,7 @@ import type { FieldType, FieldType as FieldTypeEnum } from '@auxx/database/types
 import {
   getEffectiveFieldType,
   PRIMARY_DISPLAY_ELIGIBLE_TYPES,
+  toStoredFieldOptions,
 } from '@auxx/lib/custom-fields/client'
 import type { FieldCapabilities, ResourceField } from '@auxx/lib/resources/client'
 import { mapFieldTypeToBaseType } from '@auxx/lib/workflow-engine/client'
@@ -130,9 +131,11 @@ export function useCustomFieldMutations({ entityDefinitionId }: UseCustomFieldMu
         isSystem: false,
         showInPanel: true,
         capabilities,
-        options: Array.isArray(variables.options)
-          ? { options: variables.options }
-          : (variables.options ?? undefined),
+        // Patch -> stored. `allowNewOptions: null` is a patch-only sentinel
+        // meaning "revert to the type default", and the server CLEARS the key
+        // for it rather than storing it — so the optimistic shape has to do the
+        // same or it predicts a field the server will never write.
+        options: toStoredFieldOptions(variables.options),
       }
 
       store.addOptimisticField(tempKey, optimisticField)

--- a/packages/lib/src/custom-fields/__tests__/to-stored-field-options.test.ts
+++ b/packages/lib/src/custom-fields/__tests__/to-stored-field-options.test.ts
@@ -1,0 +1,67 @@
+// packages/lib/src/custom-fields/__tests__/to-stored-field-options.test.ts
+
+import { describe, expect, it } from 'vitest'
+import { toStoredFieldOptions } from '../field-options'
+
+/**
+ * `toStoredFieldOptions` is the patch -> stored narrowing. Its whole job is the
+ * `allowNewOptions` sentinel: `null` means "revert to the type default" and must
+ * CLEAR the key, because the stored flag is tri-state (absent inherits, true /
+ * false are decisions) and a stored `null` would be a fourth state.
+ *
+ * These mirror `updateCustomField`'s own rule — see
+ * `update-field-allow-new-options.test.ts` for the writer side.
+ */
+describe('toStoredFieldOptions', () => {
+  it('returns undefined for an absent patch', () => {
+    expect(toStoredFieldOptions(undefined)).toBeUndefined()
+    expect(toStoredFieldOptions(null)).toBeUndefined()
+  })
+
+  it('wraps a bare array patch as the option list', () => {
+    const options = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+    ]
+    expect(toStoredFieldOptions(options)).toEqual({ options })
+  })
+
+  it('CLEARS allowNewOptions when the patch sends the null sentinel', () => {
+    const result = toStoredFieldOptions({
+      options: [{ value: 'a', label: 'A' }],
+      allowNewOptions: null,
+    })
+    expect(result).toEqual({ options: [{ value: 'a', label: 'A' }] })
+    expect(result).not.toHaveProperty('allowNewOptions')
+  })
+
+  it('keeps an explicit false — it is a decision, not an absence', () => {
+    const result = toStoredFieldOptions({ allowNewOptions: false })
+    expect(result).toEqual({ allowNewOptions: false })
+  })
+
+  it('keeps an explicit true', () => {
+    expect(toStoredFieldOptions({ allowNewOptions: true })).toEqual({ allowNewOptions: true })
+  })
+
+  it('leaves the key absent when the patch never addressed it', () => {
+    const result = toStoredFieldOptions({ decimals: 2 })
+    expect(result).toEqual({ decimals: 2 })
+    expect(result).not.toHaveProperty('allowNewOptions')
+  })
+
+  it('preserves every sibling block while clearing the sentinel', () => {
+    const result = toStoredFieldOptions({
+      options: [{ value: 'a', label: 'A' }],
+      ai: { enabled: true },
+      allowNewOptions: null,
+    })
+    expect(result).toEqual({ options: [{ value: 'a', label: 'A' }], ai: { enabled: true } })
+  })
+
+  it('does not mutate the caller’s patch', () => {
+    const patch = { options: [{ value: 'a', label: 'A' }], allowNewOptions: null }
+    toStoredFieldOptions({ ...patch })
+    expect(patch.allowNewOptions).toBeNull()
+  })
+})

--- a/packages/lib/src/custom-fields/client.ts
+++ b/packages/lib/src/custom-fields/client.ts
@@ -21,7 +21,15 @@ export {
 export { getAiPrompt, isAiEligible, isAiField } from './ai'
 export { getCalcOptions, getEffectiveFieldType } from './calc'
 
-export type { CalcOptions, CurrencyFieldOptions, NameFieldOptions } from './field-options'
+export type {
+  CalcOptions,
+  CurrencyFieldOptions,
+  FieldOptionsPatch,
+  NameFieldOptions,
+} from './field-options'
+// The patch -> stored narrowing, so an optimistic field shape predicts what the
+// server will persist instead of re-implementing the `allowNewOptions` sentinel.
+export { toStoredFieldOptions } from './field-options'
 export {
   extractFieldIds,
   extractFieldIdsFromString,

--- a/packages/lib/src/custom-fields/field-options.ts
+++ b/packages/lib/src/custom-fields/field-options.ts
@@ -245,6 +245,65 @@ export interface CalcOptions {
 export type CalcFieldOptions = Pick<FieldOptions, 'calc'>
 
 // ─────────────────────────────────────────────────────────────
+// PATCH → STORED
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * The `options` PATCH shape a create/update accepts over the wire — i.e. what
+ * `fieldOptionsUnionSchema` parses to.
+ *
+ * Wider than {@link FieldOptions} in one place that matters: `allowNewOptions`
+ * may be `null`. That is a **patch-only sentinel** meaning "clear the stored
+ * decision back to the type default" — never a stored value.
+ */
+export type FieldOptionsPatch =
+  | NonNullable<FieldOptions['options']>
+  | (Omit<FieldOptions, 'allowNewOptions'> & {
+      allowNewOptions?: boolean | null
+      /**
+       * The AI block rides the same envelope and is PERSISTED
+       * (`update-field.ts` assigns `fieldOptions.ai`), but {@link FieldOptions}
+       * does not declare it — a pre-existing gap, not one this type introduces.
+       * Modelled here as opaque because the narrowing only passes it through;
+       * declaring it properly on `FieldOptions` is a separate change.
+       */
+      ai?: unknown
+    })
+
+/**
+ * Narrow an options PATCH to the shape that is actually STORED.
+ *
+ * Two rules, both mirroring what `updateCustomField` does when it persists:
+ *
+ * 1. A bare array patch IS the option list — it becomes `{ options }`.
+ * 2. 🛑 `allowNewOptions: null` **clears the key** rather than storing `null`.
+ *    The stored flag is tri-state — absent inherits the type default (TAGS
+ *    grow, SELECT sets do not), `true`/`false` is the user's decision — and
+ *    absence has to stay representable or a field can never return to
+ *    inheritance. `null` is how a patch says "go back to inheriting"; storing
+ *    it would put a fourth state into a three-state field.
+ *
+ * Use this anywhere a patch is turned into a `FieldOptions` **without** going
+ * through `updateCustomField` — notably the web layer's optimistic field
+ * shapes, which must predict what the server will persist. Keeping the rule
+ * here rather than at each call site is deliberate: the tri-state has one
+ * writer (`updateCustomField`) and one reader (`fieldAllowsNewOptions`), and a
+ * third copy that drifts open is how a stored `null` reaches a `!== undefined`
+ * check that was written expecting a boolean.
+ *
+ * @param patch - The options payload from a create/update input
+ * @returns The options to store, or undefined when the patch carried none
+ */
+export function toStoredFieldOptions(
+  patch: FieldOptionsPatch | null | undefined
+): FieldOptions | undefined {
+  if (!patch) return undefined
+  if (Array.isArray(patch)) return { options: patch }
+  const { allowNewOptions, ...rest } = patch
+  return allowNewOptions == null ? rest : { ...rest, allowNewOptions }
+}
+
+// ─────────────────────────────────────────────────────────────
 // NARROWED FIELD OPTIONS (Pick from FieldOptions)
 // Use these in components/converters that work with specific field types
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

`allowNewOptions: null` is a **patch-only sentinel** meaning *"revert to the type default"*. `updateCustomField` deletes the key for it rather than storing it — `packages/types/custom-field/index.ts` says so outright (*"patch-only, never stored"*), and `update-field.ts` enforces it:

```ts
if (allowNewOptions === null) {
  delete (fieldOptions as { allowNewOptions?: unknown }).allowNewOptions
} else {
  fieldOptions.allowNewOptions = allowNewOptions
}
```

The stored flag is tri-state — **absent** inherits the type default (TAGS grow, SELECT sets do not), `true`/`false` are decisions — so absence has to stay representable.

`use-custom-field-mutations.tsx` built its optimistic field by dropping the patch straight into the stored slot:

```ts
options: Array.isArray(variables.options)
  ? { options: variables.options }
  : (variables.options ?? undefined),   // sentinel passes through unhandled
```

## Why it matters

Two things, one visible and one not:

1. **It does not typecheck.** `Type 'boolean | null | undefined' is not assignable to type 'boolean | undefined'`. `Typecheck (web)` has been red on `main` since 2026-08-24 (#1869), and because the apps/web baseline is empty (#1612 cleared it) this single error trips the ratchet for anyone touching `apps/web`.
2. **The optimistic overlay predicts a field the server will never write** — it holds `null` where the server deleted the key. Latent rather than live today, because the single reader `fieldAllowsNewOptions` uses `??` and so treats `null` like `undefined`. The `!== undefined` style checks are the ones that would misread it.

## The fix

`toStoredFieldOptions(patch)` in `field-options.ts`, beside the shape it protects, re-exported from `custom-fields/client` (the subpath the hook already imports from):

```ts
export function toStoredFieldOptions(
  patch: FieldOptionsPatch | null | undefined
): FieldOptions | undefined {
  if (!patch) return undefined
  if (Array.isArray(patch)) return { options: patch }
  const { allowNewOptions, ...rest } = patch
  return allowNewOptions == null ? rest : { ...rest, allowNewOptions }
}
```

Keeping the rule in lib rather than inlining a ternary in web is deliberate — `ownership.ts` already warns that *"two copies of this rule drift, and the copy that drifts open is a CSV rewriting a system enum"*. The tri-state has one writer and one reader; this is not a third.

**Not** widening `FieldOptions.allowNewOptions` to `boolean | null`. That was the tempting one-character fix and it is wrong: `FieldOptions` is the *stored* shape, and admitting the sentinel would put a fourth state into a three-state field.

## Noticed while doing it

`FieldOptions` does not declare `ai`, even though `update-field.ts` persists `fieldOptions.ai` and `fieldOptionsUnionSchema` accepts it. Real callers pass a variable so excess-property checking never fires and it stays invisible. Modelled here as `ai?: unknown` on the patch type with a comment; **declaring it properly on `FieldOptions` is a separate change** and probably worth someone's time — a stored key no type knows about is how the next `Omit`/`Pick` silently drops it.

## Verification

- `typecheck-ratchet --package web` → **no new type errors (0 total, baseline 0)**. First time apps/web has been at zero since 08-24.
- `typecheck-ratchet --package lib` → no new type errors (29 total, baseline 29).
- `vitest run src/custom-fields` → 90 passed / 7 files, including 8 new cases: null clears, explicit `false` survives as a decision, absent stays absent, sibling blocks preserved, caller's patch not mutated.