### PR TITLE
feat(products): add, link and detach variants from a product

### DIFF
--- a/apps/web/src/components/drawers/cards/part-family-card.tsx
+++ b/apps/web/src/components/drawers/cards/part-family-card.tsx
@@ -1,6 +1,7 @@
 // apps/web/src/components/drawers/cards/part-family-card.tsx
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
 import {
   getInstanceId,
@@ -8,14 +9,17 @@ import {
   PartKind,
   ProductStatus,
   parseRecordId,
+  type RecordId,
 } from '@auxx/lib/resources/client'
-import type { ResourceFieldId } from '@auxx/types/field'
+import type { RelationshipConfig } from '@auxx/types/custom-field'
+import { type ResourceFieldId, toResourceFieldId } from '@auxx/types/field'
 import { Badge, type Variant } from '@auxx/ui/components/badge'
 import { Button } from '@auxx/ui/components/button'
 import { pluralize } from '@auxx/utils'
-import { Sparkles } from 'lucide-react'
+import { Package, Sparkles } from 'lucide-react'
 import Link from 'next/link'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
 import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
 import {
   toRecordId,
@@ -26,7 +30,11 @@ import {
 import { useSaveSystemValues } from '~/components/resources/hooks/use-save-system-values'
 import { useSystemValues } from '~/components/resources/hooks/use-system-values'
 import type { DrawerTabProps } from '../drawer-tab-registry'
-import { isPartKindUnset, shouldSuggestFinishedGood } from './part-family-suggestion'
+import {
+  isPartKindUnset,
+  shouldSuggestFamily,
+  shouldSuggestFinishedGood,
+} from './part-family-suggestion'
 
 /** The part's own family-relevant fields. */
 const PART_FAMILY_ATTRIBUTES = ['part_product', 'part_kind'] as const
@@ -35,6 +43,22 @@ const PRODUCT_ATTRIBUTES = ['product_title', 'product_status'] as const
 
 /** `ProductStatus.values` keyed by option value, for badge label + color. */
 const PRODUCT_STATUS_BY_VALUE = Object.fromEntries(ProductStatus.values.map((v) => [v.value, v]))
+
+/**
+ * How many siblings render before the list collapses behind "Show all".
+ *
+ * A Shopify family can carry dozens of variants, and an overview card is not a
+ * list surface — the product's own Variants tab is. Five is enough to see what
+ * kind of family this is.
+ */
+const SIBLING_LIMIT = 5
+
+/** Synthetic relationship config for the ad-hoc product picker (not a real field). */
+const PRODUCT_RELATIONSHIP: RelationshipConfig = {
+  inverseResourceFieldId: toResourceFieldId('product', 'id'),
+  relationshipType: 'belongs_to',
+  isInverse: false,
+}
 
 /** Unwrap a RELATIONSHIP value into the related instance id. */
 function relatedInstanceId(raw: unknown): string | undefined {
@@ -52,12 +76,21 @@ function relatedInstanceId(raw: unknown): string | undefined {
  * section for them. When it has one: the product (click-through to its record),
  * its status, and the sibling variants with the current part marked.
  *
- * Also hosts the `finished_good` suggestion (§4): a part that has a product
- * and is nobody's subpart is almost certainly a finished good. One click
- * writes `part_kind = 'finished_good'` through the SAME write path the
- * Details panel's select uses (`useSaveSystemValues` → the field-value store
- * mutation) — a suggestion the user confirms, never an auto-write, and never
- * offered over an explicit human choice (`part_kind` set).
+ * The card hosts BOTH halves of the classification loop, and they are mutually
+ * exclusive by construction:
+ *
+ * - the `finished_good` suggestion (01 §4) — a part that has a product and is
+ *   nobody's subpart is almost certainly a finished good. Never offered over an
+ *   explicit human choice of `part_kind`.
+ * - the **family** suggestion (09 §6) — a part already classified
+ *   `finished_good` that sits in no family. Without it a part with no family
+ *   rendered nothing at all, so there was no route into a family from this side
+ *   either: the user had to know products existed and find the Product field in
+ *   the Details panel.
+ *
+ * Both write through the SAME path the Details panel's inputs use
+ * (`useSaveSystemValues` → the field-value store mutation) — a suggestion the
+ * user confirms, never an auto-write.
  *
  * Reads are the standard drawer paths: the relation via `useSystemValues`,
  * siblings via `useRecordList` filtered on `part:product` (the same filter the
@@ -75,6 +108,9 @@ export function PartFamilyCard({ recordId }: DrawerTabProps) {
   const productDefId = useResourceProperty('product', 'id')
   const partDefId = useResourceProperty('part', 'id')
   const subpartDefId = useResourceProperty('subpart', 'id')
+
+  const [showAllSiblings, setShowAllSiblings] = useState(false)
+  const [isPickingProduct, setIsPickingProduct] = useState(false)
 
   const productRecordId =
     productDefId && productId ? toRecordId(productDefId, productId) : undefined
@@ -146,11 +182,55 @@ export function PartFamilyCard({ recordId }: DrawerTabProps) {
     isSubpartOfAssembly: usedInRecords.length > 0,
   })
 
-  // No family → no card; TabCardSection hides the whole section.
-  if (!productId) return null
+  const suggestFamily = shouldSuggestFamily({ hasProduct: !!productId, partKind })
+
+  // No family. A finished good still gets the one row that offers it one —
+  // everything else renders nothing and TabCardSection hides the section.
+  if (!productId) {
+    if (!suggestFamily) return null
+    return (
+      <div className='flex flex-wrap items-center gap-2 rounded-md border border-blue-500/40 bg-blue-500/10 p-2.5'>
+        <Package className='size-4 shrink-0 text-blue-600' />
+        <p className='min-w-40 flex-1 text-xs text-muted-foreground'>
+          <span className='font-medium text-foreground'>Not in a product family.</span> Finished
+          goods usually belong to one.
+        </p>
+        {isPickingProduct ? (
+          <div className='w-48'>
+            <FieldInputAdapter
+              fieldType={FieldType.RELATIONSHIP}
+              value={[]}
+              onChange={(value) => {
+                const recordIds = value as RecordId[]
+                const first = recordIds[0]
+                if (!first) return
+                void save({ part_product: first })
+                setIsPickingProduct(false)
+              }}
+              triggerProps={{ className: 'ps-0 pe-1 w-full' }}
+              placeholder='Select a product...'
+              disabled={isPending}
+              fieldOptions={{ relationship: PRODUCT_RELATIONSHIP, showDefinitionIcon: true }}
+            />
+          </div>
+        ) : (
+          <Button
+            variant='outline'
+            size='xs'
+            loading={isPending}
+            loadingText='Saving...'
+            onClick={() => setIsPickingProduct(true)}>
+            Choose Product
+          </Button>
+        )}
+      </div>
+    )
+  }
 
   const statusMeta = productStatus ? PRODUCT_STATUS_BY_VALUE[productStatus] : undefined
   const variantIndex = siblings.findIndex((record) => record.id === partId)
+  const hiddenSiblingCount = Math.max(0, siblings.length - SIBLING_LIMIT)
+  const visibleSiblings = showAllSiblings ? siblings : siblings.slice(0, SIBLING_LIMIT)
 
   return (
     <div className='space-y-2'>
@@ -183,7 +263,7 @@ export function PartFamilyCard({ recordId }: DrawerTabProps) {
                     : `${siblings.length} ${pluralize(siblings.length, 'variant')}`}
                   {productTitle ? ` in ${productTitle}` : ''}
                 </span>
-                {siblings.map((sibling) =>
+                {visibleSiblings.map((sibling) =>
                   sibling.id === partId ? (
                     <span key={sibling.id} className='truncate font-medium'>
                       {sibling.displayName ?? 'Untitled'}
@@ -192,13 +272,20 @@ export function PartFamilyCard({ recordId }: DrawerTabProps) {
                       </span>
                     </span>
                   ) : (
-                    <Link
+                    <SiblingLink
                       key={sibling.id}
-                      href={`/app/parts?id=${sibling.id}`}
-                      className='truncate hover:underline'>
-                      {sibling.displayName ?? 'Untitled'}
-                    </Link>
+                      recordId={toRecordId(partDefId ?? 'part', sibling.id)}
+                      label={sibling.displayName ?? 'Untitled'}
+                    />
                   )
+                )}
+                {hiddenSiblingCount > 0 && !showAllSiblings && (
+                  <button
+                    type='button'
+                    className='self-start text-xs text-muted-foreground hover:text-foreground hover:underline'
+                    onClick={() => setShowAllSiblings(true)}>
+                    Show all {siblings.length}
+                  </button>
                 )}
               </>
             )}
@@ -224,5 +311,23 @@ export function PartFamilyCard({ recordId }: DrawerTabProps) {
         </div>
       )}
     </div>
+  )
+}
+
+/**
+ * One sibling variant's link.
+ *
+ * A component rather than an inline `<Link>` because `useRecordLink` is a hook
+ * and this renders in a loop. The href it builds resolves through
+ * `resourceHasDetailPage`; the hand-written `/app/parts?id=` it replaced was a
+ * path nothing would have flagged if part routing ever moved.
+ */
+function SiblingLink({ recordId, label }: { recordId: RecordId; label: string }) {
+  const href = useRecordLink(recordId)
+  if (!href) return <span className='truncate'>{label}</span>
+  return (
+    <Link href={href} className='truncate hover:underline'>
+      {label}
+    </Link>
   )
 }

--- a/apps/web/src/components/drawers/cards/part-family-suggestion.test.ts
+++ b/apps/web/src/components/drawers/cards/part-family-suggestion.test.ts
@@ -6,7 +6,11 @@
 // a suggestion the human confirms, never a derivation.
 
 import { describe, expect, it } from 'vitest'
-import { isPartKindUnset, shouldSuggestFinishedGood } from './part-family-suggestion'
+import {
+  isPartKindUnset,
+  shouldSuggestFamily,
+  shouldSuggestFinishedGood,
+} from './part-family-suggestion'
 
 /** The all-conditions-met baseline each test perturbs one axis of. */
 const ELIGIBLE = {
@@ -67,5 +71,55 @@ describe('isPartKindUnset', () => {
   it('treats any concrete value as set, scalar or array-wrapped', () => {
     expect(isPartKindUnset('component')).toBe(false)
     expect(isPartKindUnset(['finished_good'])).toBe(false)
+  })
+})
+
+describe('shouldSuggestFamily', () => {
+  it('suggests a family for an explicit finished good with no product', () => {
+    expect(shouldSuggestFamily({ hasProduct: false, partKind: 'finished_good' })).toBe(true)
+  })
+
+  it('handles the array-shaped SINGLE_SELECT read the same way', () => {
+    expect(shouldSuggestFamily({ hasProduct: false, partKind: ['finished_good'] })).toBe(true)
+  })
+
+  it('never suggests when the part already has a family', () => {
+    expect(shouldSuggestFamily({ hasProduct: true, partKind: 'finished_good' })).toBe(false)
+  })
+
+  it('never suggests for other explicit kinds', () => {
+    expect(shouldSuggestFamily({ hasProduct: false, partKind: 'component' })).toBe(false)
+    expect(shouldSuggestFamily({ hasProduct: false, partKind: 'subassembly' })).toBe(false)
+  })
+
+  it('never suggests on an UNSET kind — finished_good is required explicitly, never inferred', () => {
+    // Every shape `isPartKindUnset` treats as unset must also be silent here.
+    for (const partKind of [undefined, null, '', [], ['']]) {
+      expect(isPartKindUnset(partKind)).toBe(true)
+      expect(shouldSuggestFamily({ hasProduct: false, partKind })).toBe(false)
+    }
+  })
+
+  it('is mutually exclusive with the finished-good suggestion', () => {
+    // The two gate on opposite sides of the same fact: one refuses to speak
+    // OVER a human choice of part_kind, the other refuses to speak WITHOUT one.
+    const cases: Array<{ hasProduct: boolean; partKind: unknown }> = [
+      { hasProduct: false, partKind: undefined },
+      { hasProduct: false, partKind: 'finished_good' },
+      { hasProduct: false, partKind: 'component' },
+      { hasProduct: true, partKind: undefined },
+      { hasProduct: true, partKind: 'finished_good' },
+      { hasProduct: true, partKind: 'component' },
+    ]
+    for (const input of cases) {
+      const both =
+        shouldSuggestFamily(input) &&
+        shouldSuggestFinishedGood({
+          ...input,
+          subpartCheckLoaded: true,
+          isSubpartOfAssembly: false,
+        })
+      expect(both).toBe(false)
+    }
   })
 })

--- a/apps/web/src/components/drawers/cards/part-family-suggestion.ts
+++ b/apps/web/src/components/drawers/cards/part-family-suggestion.ts
@@ -51,3 +51,31 @@ export function shouldSuggestFinishedGood(input: SuggestFinishedGoodInput): bool
   if (!input.subpartCheckLoaded) return false
   return !input.isSubpartOfAssembly
 }
+
+interface SuggestFamilyInput {
+  /** Whether the part has a `product` relation. */
+  hasProduct: boolean
+  /** Raw `part_kind` value. */
+  partKind: unknown
+}
+
+/**
+ * The inverse suggestion (plans/products/09-variant-ui.md §6): a part the human
+ * has ALREADY classified as a finished good, sitting in no product family.
+ *
+ * The card renders nothing at all for a part with no family, which is right for
+ * a 2x4 stud and wrong for a finished good — a finished good is, by definition,
+ * the thing a family is a family of. Without this there is no route into a
+ * family from the part side either; the user has to know products exist and go
+ * find the Product field in the Details panel.
+ *
+ * Note the symmetry with {@link shouldSuggestFinishedGood}, which is why the two
+ * can never fire together: that one refuses to speak OVER a human choice of
+ * `part_kind`, this one refuses to speak WITHOUT one. `finished_good` is
+ * required explicitly and is never inferred — the same Gap C §3.2 rule.
+ */
+export function shouldSuggestFamily(input: SuggestFamilyInput): boolean {
+  if (input.hasProduct) return false
+  const first = Array.isArray(input.partKind) ? input.partKind[0] : input.partKind
+  return first === 'finished_good'
+}

--- a/apps/web/src/components/drawers/cards/product-summary-card.tsx
+++ b/apps/web/src/components/drawers/cards/product-summary-card.tsx
@@ -1,0 +1,199 @@
+// apps/web/src/components/drawers/cards/product-summary-card.tsx
+'use client'
+
+import type { ConditionGroup } from '@auxx/lib/conditions/client'
+import { ProductStatus, type RecordId } from '@auxx/lib/resources/client'
+import type { ResourceFieldId } from '@auxx/types/field'
+import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { pluralize } from '@auxx/utils'
+import { formatCurrency } from '@auxx/utils/currency'
+import { useMemo } from 'react'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
+import type { DrawerTabProps } from '../drawer-tab-registry'
+import { summarizeVariants, type VariantRow } from '../tabs/summarize-variants'
+
+/** The product's own status. */
+const PRODUCT_ATTRIBUTES = ['product_status'] as const
+/** Hop 1 — each variant's own values. Title/SKU/image ride the list payload. */
+const VARIANT_ATTRIBUTES = ['part_quantity_on_hand', 'part_catalog_items'] as const
+/** Hop 2 — the catalog items behind them. */
+const CATALOG_ITEM_ATTRIBUTES = ['catalog_item_default_unit_price', 'catalog_item_active'] as const
+
+/** `ProductStatus.values` keyed by option value, for badge label + colour. */
+const PRODUCT_STATUS_BY_VALUE = Object.fromEntries(ProductStatus.values.map((v) => [v.value, v]))
+
+/**
+ * Family summary for the product drawer's overview and the detail page sidebar
+ * (plans/products/09-variant-ui.md §7).
+ *
+ * The one place the family answers "is this ready to sell?" — how many variants
+ * it has, how much stock stands behind them, what they cost, and how many carry
+ * a price at all. The Variants tab shows the rows; this shows the shape.
+ *
+ * Renders NOTHING for a family with no variants, so `TabCardSection` hides the
+ * whole section — the documented contract for every card in that registry.
+ *
+ * Reads are the same two batched ALL-DIRECT hops the Variants tab uses (§4.1),
+ * for the same reason: one `FieldPath` drill ref would flip `batchGetValues`
+ * off its single-query fast path and resolve every ref sequentially.
+ */
+export function ProductSummaryCard({ entityInstanceId, recordId }: DrawerTabProps) {
+  const partDefId = useResourceProperty('part', 'id')
+
+  const { values } = useSystemValues(recordId, PRODUCT_ATTRIBUTES, { autoFetch: true })
+  const status = values.product_status as string | undefined
+
+  const filters: ConditionGroup[] = useMemo(
+    () => [
+      {
+        id: 'product-filter',
+        logicalOperator: 'AND' as const,
+        conditions: [
+          {
+            id: 'product-match',
+            fieldId: 'part:product' as ResourceFieldId,
+            operator: 'is' as const,
+            value: entityInstanceId,
+          },
+        ],
+      },
+    ],
+    [entityInstanceId]
+  )
+
+  const { records, total, hasNextPage, isLoading } = useRecordList({
+    entityDefinitionId: partDefId ?? '',
+    filters,
+    enabled: !!entityInstanceId && !!partDefId,
+  })
+
+  const rowRecordIds = useMemo(
+    () => (partDefId ? records.map((record) => toRecordId(partDefId, record.id)) : []),
+    [partDefId, records]
+  )
+
+  const { valuesById } = useSystemValuesForRecords(rowRecordIds, VARIANT_ATTRIBUTES, {
+    autoFetch: true,
+    enabled: rowRecordIds.length > 0,
+  })
+
+  const itemRecordIds = useMemo(() => {
+    const ids = new Set<RecordId>()
+    for (const id of rowRecordIds) {
+      const items = valuesById[id]?.part_catalog_items as RecordId[] | undefined
+      for (const item of items ?? []) ids.add(item)
+    }
+    return [...ids]
+  }, [rowRecordIds, valuesById])
+
+  const { valuesById: itemValues, loadedById: itemLoaded } = useSystemValuesForRecords(
+    itemRecordIds,
+    CATALOG_ITEM_ATTRIBUTES,
+    { autoFetch: true, enabled: itemRecordIds.length > 0 }
+  )
+
+  /**
+   * Whether hop 2 has actually answered for every catalog item in play.
+   *
+   * Until it has, every variant looks unpriced — and "0 of 4 priced" is a
+   * wrong number, not a loading state. `undefined` in `valuesById` means
+   * not-yet-fetched; `loadedById` is the distinction, surfaced.
+   */
+  const pricesLoaded = itemRecordIds.every((id) => itemLoaded[id]?.catalog_item_active === true)
+
+  const rows: VariantRow[] = useMemo(
+    () =>
+      records.map((record, index) => {
+        const own = valuesById[rowRecordIds[index] as RecordId]
+        const items = (own?.part_catalog_items as RecordId[] | undefined) ?? []
+        // Only a SINGLE backing item supplies a price — price tiers are not a
+        // price, and picking one arbitrarily would put a wrong number in the
+        // range. Same call `part-pricing-card` makes for the has_many case.
+        const soleItem = items.length === 1 ? (items[0] as RecordId) : undefined
+        const soleValues = soleItem ? itemValues[soleItem] : undefined
+        const active = (soleValues?.catalog_item_active as boolean | null | undefined) ?? true
+        const price =
+          (soleValues?.catalog_item_default_unit_price as number | null | undefined) ?? null
+        return {
+          id: record.id,
+          quantityOnHand: (own?.part_quantity_on_hand as number | null | undefined) ?? null,
+          priceCents: soleItem && active ? price : null,
+          catalogItemCount: items.length,
+        }
+      }),
+    [records, rowRecordIds, valuesById, itemValues]
+  )
+
+  const summary = useMemo(
+    () => summarizeVariants(rows, { total, hasNextPage }),
+    [rows, total, hasNextPage]
+  )
+
+  // Nothing to summarize → no card, and TabCardSection drops the header too.
+  if (isLoading || records.length === 0) return null
+
+  const statusMeta = status ? PRODUCT_STATUS_BY_VALUE[status] : undefined
+  const { priceRange } = summary
+
+  return (
+    <FieldPanel resizeId='product-summary' defaultLabelWidth={130}>
+      <FieldPanelRow title='Variants'>
+        <div className='flex min-h-8 flex-wrap items-center gap-2 text-sm'>
+          <span className='font-medium'>
+            {summary.variantCount} {pluralize(summary.variantCount, 'variant')}
+          </span>
+          {statusMeta && (
+            <Badge variant={(statusMeta.color ?? 'gray') as Variant} size='xs'>
+              {statusMeta.label}
+            </Badge>
+          )}
+        </div>
+      </FieldPanelRow>
+
+      {/* Omitted entirely when no variant has ever been counted — a family with
+          unknown stock must not read as a family holding none. */}
+      {summary.totalOnHand != null && (
+        <FieldPanelRow title='On hand'>
+          <div className='flex min-h-8 items-center text-sm tabular-nums'>
+            {summary.totalOnHand}
+            <span className='ms-1.5 text-xs text-muted-foreground'>
+              across {summary.measuredCount} {pluralize(summary.measuredCount, 'variant')}
+            </span>
+          </div>
+        </FieldPanelRow>
+      )}
+
+      {priceRange && (
+        <FieldPanelRow title='Price'>
+          <div className='flex min-h-8 items-center text-sm tabular-nums'>
+            {priceRange.min === priceRange.max
+              ? formatCurrency(priceRange.min)
+              : `${formatCurrency(priceRange.min)}–${formatCurrency(priceRange.max)}`}
+          </div>
+        </FieldPanelRow>
+      )}
+
+      {/* Withheld until hop 2 answers: an unfetched price is not an absent one,
+          and "0 of 4 priced" would be a wrong number rather than a spinner. */}
+      {pricesLoaded && (
+        <FieldPanelRow title='Priced'>
+          <div className='flex min-h-8 items-center text-sm'>
+            <span className={summary.pricedCount === 0 ? 'text-muted-foreground' : undefined}>
+              {summary.pricedCount} of {summary.measuredCount}
+            </span>
+            {summary.pricedCount < summary.measuredCount && (
+              <span className='ms-1.5 text-xs text-muted-foreground'>
+                {/* "Sellable" is derived from an active catalog item, never
+                    stored — the same rule the part's Pricing card applies. */}
+                variants have a sell price
+              </span>
+            )}
+          </div>
+        </FieldPanelRow>
+      )}
+    </FieldPanel>
+  )
+}

--- a/apps/web/src/components/drawers/cards/product-vendor-card.tsx
+++ b/apps/web/src/components/drawers/cards/product-vendor-card.tsx
@@ -1,0 +1,51 @@
+// apps/web/src/components/drawers/cards/product-vendor-card.tsx
+'use client'
+
+import { getInstanceId, isRecordId, type RecordId } from '@auxx/lib/resources/client'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { toRecordId, useResourceProperty } from '~/components/resources'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { RecordBadge } from '~/components/resources/ui/record-badge'
+import type { DrawerTabProps } from '../drawer-tab-registry'
+
+/** The product's vendor relation. */
+const PRODUCT_VENDOR_ATTRIBUTES = ['product_vendor'] as const
+
+/** Unwrap a RELATIONSHIP value into the related instance id. */
+function relatedInstanceId(raw: unknown): string | undefined {
+  const first = Array.isArray(raw) ? raw[0] : raw
+  if (typeof first !== 'string') return undefined
+  return isRecordId(first) ? getInstanceId(first) : first
+}
+
+/**
+ * The company behind this product family, as a click-through
+ * (plans/products/09-variant-ui.md §7).
+ *
+ * `product.vendor` is a relation to `company`, not a free-text brand string
+ * (01 §2, D9) — a supplier is already a company, which `vendor_part.contact`
+ * established. Shopify's free-text `vendor` lands in an app field instead and a
+ * human links this relation, so it is null on most synced products.
+ *
+ * Renders NOTHING when there is no vendor, so `TabCardSection` hides the
+ * section — which is the common case, and the reason this card is cheap.
+ */
+export function ProductVendorCard({ recordId }: DrawerTabProps) {
+  const companyDefId = useResourceProperty('company', 'id')
+  const { values } = useSystemValues(recordId, PRODUCT_VENDOR_ATTRIBUTES, { autoFetch: true })
+
+  const vendorId = relatedInstanceId(values.product_vendor)
+  if (!vendorId || !companyDefId) return null
+
+  const vendorRecordId: RecordId = toRecordId(companyDefId, vendorId)
+
+  return (
+    <FieldPanel resizeId='product-vendor' defaultLabelWidth={130}>
+      <FieldPanelRow title='Vendor'>
+        <div className='flex min-h-8 flex-wrap items-center gap-2 text-sm'>
+          <RecordBadge recordId={vendorRecordId} variant='link' link={{ tab: 'overview' }} />
+        </div>
+      </FieldPanelRow>
+    </FieldPanel>
+  )
+}

--- a/apps/web/src/components/drawers/drawer-tab-registry.tsx
+++ b/apps/web/src/components/drawers/drawer-tab-registry.tsx
@@ -132,6 +132,20 @@ export const DRAWER_TAB_CARD_COMPONENTS: Record<
     import('./cards/part-family-card').then((m) => ({ default: m.PartFamilyCard })),
 
   // ─────────────────────────────────────────────────────────────────
+  // PRODUCT OVERVIEW CARDS (shared with the product detail-view sidebar —
+  // DetailViewSidebar reads from this same registry)
+  // ─────────────────────────────────────────────────────────────────
+  // Family shape: variant count, stock, price range, how many are priced.
+  // Renders nothing for a family with no variants, hiding its whole section.
+  'product:summary': () =>
+    import('./cards/product-summary-card').then((m) => ({ default: m.ProductSummaryCard })),
+  // The company behind the family (`product.vendor` → `company`, D9). Null on
+  // most synced products — Shopify's brand string lands in an app field, and a
+  // human links this relation — so the section is usually hidden.
+  'product:vendor': () =>
+    import('./cards/product-vendor-card').then((m) => ({ default: m.ProductVendorCard })),
+
+  // ─────────────────────────────────────────────────────────────────
   // QUOTE OVERVIEW CARDS (shared with the quote detail-view sidebar —
   // DetailViewSidebar reads from this same registry, see detail-view-sidebar.tsx)
   // ─────────────────────────────────────────────────────────────────

--- a/apps/web/src/components/drawers/tabs/product-parts-tab.tsx
+++ b/apps/web/src/components/drawers/tabs/product-parts-tab.tsx
@@ -1,9 +1,18 @@
 // apps/web/src/components/drawers/tabs/product-parts-tab.tsx
 'use client'
 
+import { FieldType } from '@auxx/database/enums'
 import type { ConditionGroup } from '@auxx/lib/conditions/client'
-import type { RecordId } from '@auxx/lib/resources/client'
+import { PartKind, type RecordId } from '@auxx/lib/resources/client'
 import type { ResourceFieldId } from '@auxx/types/field'
+import { Badge, type Variant } from '@auxx/ui/components/badge'
+import { Button } from '@auxx/ui/components/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@auxx/ui/components/dropdown-menu'
 import { ScrollArea } from '@auxx/ui/components/scroll-area'
 import { Section } from '@auxx/ui/components/section'
 import { Skeleton } from '@auxx/ui/components/skeleton'
@@ -15,21 +24,64 @@ import {
   TableHeader,
   TableRow,
 } from '@auxx/ui/components/table'
+import { toastError } from '@auxx/ui/components/toast'
+import { pluralize } from '@auxx/utils'
 import { formatCurrency } from '@auxx/utils/currency'
-import { Package } from 'lucide-react'
+import { Link2, MoreHorizontal, Package, Plus, Unlink } from 'lucide-react'
 import Link from 'next/link'
-import { useMemo } from 'react'
-import { toRecordId, useRecordList, useResourceProperty } from '~/components/resources'
-import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { useCallback, useMemo, useState } from 'react'
+import { PartFormDialog } from '~/components/manufacturing/parts/part-form-dialog'
+import {
+  type RecordMeta,
+  toRecordId,
+  useRecordLink,
+  useRecordList,
+  useResource,
+  useResourceProperty,
+} from '~/components/resources'
+import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
+import { useSystemValuesForRecords } from '~/components/resources/hooks/use-system-values-for-records'
+import { RecordIcon } from '~/components/resources/ui/record-icon'
+import { useConfirm } from '~/hooks/use-confirm'
+import { useAccess } from '~/providers/capabilities-provider'
 import type { DrawerTabProps } from '../drawer-tab-registry'
+import { ProductVariantLinkDialog } from './product-variant-link-dialog'
+import { buildVariantSummaryLabel, summarizeVariants, type VariantRow } from './summarize-variants'
 
-/** What each variant row shows — the company-parts-tab column recipe. */
-const VARIANT_ROW_ATTRIBUTES = [
-  'part_title',
-  'part_sku',
+/**
+ * Hop 1 — the part's OWN values.
+ *
+ * Four attributes, not seven: `part_title`, `part_sku` and `part_image` are
+ * already in the list payload as `displayName` / `secondaryInfo` / `avatarUrl`
+ * (`DISPLAY_FIELD_CONFIG.part` maps exactly those three), so fetching them
+ * again buys nothing (plans/products/09-variant-ui.md §2 V5b).
+ */
+const VARIANT_ATTRIBUTES = [
   'part_cost',
   'part_quantity_on_hand',
+  'part_kind',
+  'part_catalog_items',
 ] as const
+
+/** Hop 2 — the backing catalog items', for the Price column. */
+const CATALOG_ITEM_ATTRIBUTES = ['catalog_item_default_unit_price', 'catalog_item_active'] as const
+
+/** `PartKind.values` keyed by option value, for badge label + colour. */
+const PART_KIND_BY_VALUE = Object.fromEntries(PartKind.values.map((v) => [v.value, v]))
+
+/** What one row renders, resolved by the tab. */
+interface VariantRowValues extends VariantRow {
+  cost: number | null
+  kind: string | undefined
+  /** Whether hop 2 has actually answered — `—` until it has, never a guessed 0. */
+  priceLoaded: boolean
+}
+
+/** Collapse a SINGLE_SELECT read (scalar on some paths, array on others). */
+function selectValue(raw: unknown): string | undefined {
+  const first = Array.isArray(raw) ? raw[0] : raw
+  return typeof first === 'string' && first !== '' ? first : undefined
+}
 
 /**
  * Variants tab for the product drawer AND detail page — the product's parts as
@@ -38,11 +90,36 @@ const VARIANT_ROW_ATTRIBUTES = [
  * filtered on the belongs_to side (`part:product`), the same read the part
  * drawer's Family card uses for siblings.
  *
- * Read-only by design: a part joins a family from its own Details panel
- * (`product` relation field); this list has no create/detach affordance in v1.
+ * Writes (plans/products/09-variant-ui.md §3): create a variant into this
+ * family, link an existing part in, and detach one. Detach clears
+ * `part_product` and never deletes the part — it stays re-linkable from the
+ * same header.
+ *
+ * ⚠️ **Seam for contribute mode.** Once the Shopify product stream contributes
+ * (plans/products/02-shopify-mapping.md), the sink writes `part_product` too,
+ * and detaching a connector-written part would be undone by the next sync. No
+ * ownership guard is built here on purpose — there is no such writer yet, and a
+ * guard designed against a hypothetical one is a guard that will be wrong. 02
+ * owns closing it, together with the disconnect/undo questions it already has
+ * open.
+ *
+ * Reads are two batched, ALL-DIRECT hops (§4.1) — never a drill path. One
+ * `FieldPath` ref in a batch flips `batchGetValues` off its single-query fast
+ * path and resolves every ref in that batch sequentially, so the round trip it
+ * saves on the client is paid for several times over on the server.
  */
 export function ProductPartsTab({ entityInstanceId }: DrawerTabProps) {
   const partDefId = useResourceProperty('part', 'id')
+  const { resource: partResource } = useResource(partDefId)
+
+  const [isCreateOpen, setIsCreateOpen] = useState(false)
+  const [isLinkOpen, setIsLinkOpen] = useState(false)
+  const [confirmDetach, ConfirmDetachDialog] = useConfirm()
+
+  // The tab is gated on READ of part (drawer config `recordResource`); adding,
+  // linking and detaching each additionally need WRITE.
+  const { canEditEntity } = useAccess()
+  const canEdit = !!partDefId && canEditEntity(partDefId)
 
   // Parts belonging to this product family
   const filters: ConditionGroup[] = useMemo(
@@ -63,11 +140,110 @@ export function ProductPartsTab({ entityInstanceId }: DrawerTabProps) {
     [entityInstanceId]
   )
 
-  const { records, isLoading } = useRecordList({
-    entityDefinitionId: partDefId ?? '',
-    filters,
-    enabled: !!entityInstanceId && !!partDefId,
+  const { records, isLoading, total, hasNextPage, fetchNextPage, isFetchingNextPage, refresh } =
+    useRecordList({
+      entityDefinitionId: partDefId ?? '',
+      filters,
+      enabled: !!entityInstanceId && !!partDefId,
+    })
+
+  const rowRecordIds = useMemo(
+    () => (partDefId ? records.map((record) => toRecordId(partDefId, record.id)) : []),
+    [partDefId, records]
+  )
+
+  // ── Hop 1: the parts' own values, one batch ───────────────────────
+  const { valuesById } = useSystemValuesForRecords(rowRecordIds, VARIANT_ATTRIBUTES, {
+    autoFetch: true,
+    enabled: rowRecordIds.length > 0,
   })
+
+  // ── Hop 2: the catalog items behind them, one batch ───────────────
+  // Serial after hop 1 by necessity — these ids only exist inside hop 1's
+  // answer. The guard matters: without it the hook fires with an empty array on
+  // first paint.
+  const itemRecordIds = useMemo(() => {
+    const ids = new Set<RecordId>()
+    for (const recordId of rowRecordIds) {
+      const items = valuesById[recordId]?.part_catalog_items as RecordId[] | undefined
+      for (const item of items ?? []) ids.add(item)
+    }
+    return [...ids]
+  }, [rowRecordIds, valuesById])
+
+  const { valuesById: itemValues, loadedById: itemLoaded } = useSystemValuesForRecords(
+    itemRecordIds,
+    CATALOG_ITEM_ATTRIBUTES,
+    { autoFetch: true, enabled: itemRecordIds.length > 0 }
+  )
+
+  const rows: VariantRowValues[] = useMemo(
+    () =>
+      records.map((record, index) => {
+        const recordId = rowRecordIds[index] as RecordId
+        const own = valuesById[recordId]
+        const items = (own?.part_catalog_items as RecordId[] | undefined) ?? []
+
+        // Exactly one backing item supplies a price. Zero has none; more than
+        // one is price tiers, and picking one arbitrarily would be a lie — §4.2
+        // renders "n items" for that row instead, the same call
+        // `part-pricing-card` makes for the has_many case.
+        const soleItem = items.length === 1 ? (items[0] as RecordId) : undefined
+        const soleValues = soleItem ? itemValues[soleItem] : undefined
+        // A missing `active` reads as the registry default, true — the same
+        // collapse `useCatalogItems` applies.
+        const active = (soleValues?.catalog_item_active as boolean | null | undefined) ?? true
+        const price =
+          (soleValues?.catalog_item_default_unit_price as number | null | undefined) ?? null
+
+        return {
+          id: record.id,
+          quantityOnHand: (own?.part_quantity_on_hand as number | null | undefined) ?? null,
+          cost: (own?.part_cost as number | null | undefined) ?? null,
+          kind: selectValue(own?.part_kind),
+          catalogItemCount: items.length,
+          priceCents: soleItem && active ? price : null,
+          priceLoaded: !soleItem || itemLoaded[soleItem]?.catalog_item_active === true,
+        }
+      }),
+    [records, rowRecordIds, valuesById, itemValues, itemLoaded]
+  )
+
+  const summary = useMemo(
+    () => summarizeVariants(rows, { total, hasNextPage }),
+    [rows, total, hasNextPage]
+  )
+
+  // ── Writes ────────────────────────────────────────────────────────
+  const { saveMultipleAsync } = useSaveFieldValue({})
+
+  /** Detach: clear `part_product`. The part itself is never deleted. */
+  const handleDetach = useCallback(
+    async (partId: string, label: string) => {
+      if (!partDefId) return
+      const confirmed = await confirmDetach({
+        title: 'Remove from product',
+        description: `Remove "${label}" from this product family? The part itself is kept, and you can link it back at any time.`,
+        confirmText: 'Remove',
+        cancelText: 'Cancel',
+        destructive: false,
+      })
+      if (!confirmed) return
+
+      const success = await saveMultipleAsync(toRecordId(partDefId, partId), [
+        { fieldId: 'part_product', value: null, fieldType: FieldType.RELATIONSHIP },
+      ])
+      if (!success) {
+        toastError({
+          title: 'Error removing variant',
+          description: 'The part could not be removed from this product.',
+        })
+        return
+      }
+      refresh()
+    },
+    [partDefId, confirmDetach, saveMultipleAsync, refresh]
+  )
 
   if (isLoading) {
     return (
@@ -78,65 +254,203 @@ export function ProductPartsTab({ entityInstanceId }: DrawerTabProps) {
     )
   }
 
+  const actions = canEdit ? (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant='ghost' size='xs'>
+          <Plus />
+          Add Variant
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align='end'>
+        <DropdownMenuItem onClick={() => setIsCreateOpen(true)}>
+          <Plus />
+          New variant
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setIsLinkOpen(true)}>
+          <Link2 />
+          Link existing part
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ) : undefined
+
   return (
     <ScrollArea className='flex-1'>
       <Section
-        title={`Variants (${records.length})`}
+        title={`Variants (${total})`}
+        actions={actions}
         className='flex flex-col flex-1 min-h-0 w-full [&_[data-slot=section]]:flex-1 [&_[data-slot=section]]:border-b-0 [&_[data-slot=section-content]]:flex-1'
         collapsible={false}
         icon={<Package className='size-4 text-muted-foreground/50' />}>
         {records.length === 0 ? (
-          <div className='flex h-24 flex-col items-center justify-center text-center border rounded-lg bg-muted/30'>
-            <Package className='mb-2 h-6 w-6 text-muted-foreground' />
+          <div className='flex h-28 flex-col items-center justify-center gap-1 text-center border rounded-lg bg-muted/30'>
+            <Package className='mb-1 h-6 w-6 text-muted-foreground' />
             <p className='text-sm text-muted-foreground'>No variants yet</p>
-            <p className='text-xs text-muted-foreground'>
-              Link parts to this product via the part&apos;s Product field
-            </p>
+            {canEdit ? (
+              <div className='flex items-center gap-2 pt-1'>
+                <Button variant='outline' size='xs' onClick={() => setIsCreateOpen(true)}>
+                  <Plus />
+                  New variant
+                </Button>
+                <Button variant='outline' size='xs' onClick={() => setIsLinkOpen(true)}>
+                  <Link2 />
+                  Link existing part
+                </Button>
+              </div>
+            ) : (
+              <p className='text-xs text-muted-foreground'>
+                Parts join a family through their Product field
+              </p>
+            )}
           </div>
         ) : (
-          <div className='rounded-md border'>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Part</TableHead>
-                  <TableHead className='text-right'>Cost</TableHead>
-                  <TableHead className='text-right'>On Hand</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {records.map((record) => (
-                  <ProductPartRow
-                    key={record.id}
-                    partId={record.id}
-                    recordId={toRecordId(partDefId!, record.id)}
-                  />
-                ))}
-              </TableBody>
-            </Table>
+          <div className='space-y-2'>
+            <p className='text-xs text-muted-foreground'>
+              {buildVariantSummaryLabel(summary, formatCurrency)}
+            </p>
+            <div className='rounded-md border'>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Variant</TableHead>
+                    <TableHead>Kind</TableHead>
+                    <TableHead className='text-right'>Price</TableHead>
+                    <TableHead className='text-right'>Cost</TableHead>
+                    <TableHead className='text-right'>On Hand</TableHead>
+                    <TableHead className='w-10' />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {records.map((record, index) => (
+                    <ProductPartRow
+                      key={record.id}
+                      record={record}
+                      recordId={rowRecordIds[index] as RecordId}
+                      values={rows[index] as VariantRowValues}
+                      iconId={partResource?.icon ?? 'package'}
+                      color={partResource?.color ?? 'gray'}
+                      canEdit={canEdit}
+                      onDetach={() =>
+                        void handleDetach(record.id, record.displayName ?? 'this part')
+                      }
+                    />
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+            {hasNextPage && (
+              <div className='flex justify-center pt-1'>
+                <Button
+                  variant='ghost'
+                  size='xs'
+                  loading={isFetchingNextPage}
+                  loadingText='Loading...'
+                  onClick={() => fetchNextPage()}>
+                  Load more
+                </Button>
+              </div>
+            )}
           </div>
         )}
       </Section>
+
+      {/* Create seeds nothing into this list: `PartFormDialog` owns its own
+          `api.record.create` (and chains an optional vendor-part create off the
+          result), so the new row arrives via a refetch rather than the
+          `useCreateRecord` cache seed §3.5 sketched. Same outcome, one extra
+          fetch — converting the shared part editor's write path was out of
+          scope here. */}
+      <PartFormDialog
+        open={isCreateOpen}
+        onOpenChange={setIsCreateOpen}
+        productId={entityInstanceId}
+        onSuccess={refresh}
+      />
+
+      <ProductVariantLinkDialog
+        open={isLinkOpen}
+        onOpenChange={setIsLinkOpen}
+        productId={entityInstanceId}
+        excludeRecordIds={rowRecordIds}
+        onSuccess={refresh}
+      />
+
+      <ConfirmDetachDialog />
     </ScrollArea>
   )
 }
 
-/** One variant row: title + SKU (links to the part), cost, quantity on hand. */
-function ProductPartRow({ partId, recordId }: { partId: string; recordId: RecordId }) {
-  const { values } = useSystemValues(recordId, VARIANT_ROW_ATTRIBUTES, { autoFetch: true })
-  const title = values.part_title as string | undefined
-  const sku = values.part_sku as string | undefined
-  const cost = values.part_cost as number | null | undefined
-  const quantityOnHand = values.part_quantity_on_hand as number | null | undefined
+interface ProductPartRowProps {
+  record: RecordMeta
+  recordId: RecordId
+  values: VariantRowValues
+  iconId: string
+  color: string
+  canEdit: boolean
+  onDetach: () => void
+}
+
+/**
+ * One variant row — presentational.
+ *
+ * It used to own a `useSystemValues` subscription per row, which meant N queued
+ * single fetches for one table and no way for the tab to answer anything about
+ * the list as a whole (the summary line is exactly such a question). The tab
+ * now reads every row's values in two batched subscriptions and hands them down
+ * — the shape `part-vendors-tab-row` already uses.
+ *
+ * Title, SKU and image come off the list payload (`displayName`,
+ * `secondaryInfo`, `avatarUrl`), never a second field-value read.
+ */
+function ProductPartRow({
+  record,
+  recordId,
+  values,
+  iconId,
+  color,
+  canEdit,
+  onDetach,
+}: ProductPartRowProps) {
+  const href = useRecordLink(recordId)
+  const { cost, quantityOnHand, kind, priceCents, catalogItemCount, priceLoaded } = values
+  const kindMeta = kind ? PART_KIND_BY_VALUE[kind] : undefined
+  const title = record.displayName ?? 'Untitled'
 
   return (
     <TableRow>
       <TableCell className='font-medium'>
-        <div className='flex flex-col'>
-          <Link href={`/app/parts?id=${partId}`} className='truncate hover:underline'>
-            {title ?? 'Loading...'}
-          </Link>
-          {sku && <span className='text-xs text-muted-foreground'>{sku}</span>}
+        <div className='flex items-center gap-2'>
+          <RecordIcon avatarUrl={record.avatarUrl} iconId={iconId} color={color} size='sm' />
+          <div className='flex min-w-0 flex-col'>
+            {href ? (
+              <Link href={href} className='truncate hover:underline'>
+                {title}
+              </Link>
+            ) : (
+              <span className='truncate'>{title}</span>
+            )}
+            {record.secondaryInfo && (
+              <span className='truncate text-xs text-muted-foreground'>{record.secondaryInfo}</span>
+            )}
+          </div>
         </div>
+      </TableCell>
+      <TableCell>
+        {kindMeta ? (
+          <Badge variant={(kindMeta.color ?? 'gray') as Variant} size='xs'>
+            {kindMeta.label}
+          </Badge>
+        ) : (
+          <span className='text-muted-foreground'>—</span>
+        )}
+      </TableCell>
+      <TableCell className='text-right tabular-nums'>
+        <VariantPriceCell
+          priceCents={priceCents}
+          catalogItemCount={catalogItemCount}
+          priceLoaded={priceLoaded}
+        />
       </TableCell>
       <TableCell className='text-right tabular-nums'>
         {cost != null ? formatCurrency(cost) : <span className='text-muted-foreground'>—</span>}
@@ -144,6 +458,45 @@ function ProductPartRow({ partId, recordId }: { partId: string; recordId: Record
       <TableCell className='text-right tabular-nums'>
         {quantityOnHand != null ? quantityOnHand : <span className='text-muted-foreground'>—</span>}
       </TableCell>
+      <TableCell>
+        {canEdit && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant='ghost' size='icon-sm'>
+                <MoreHorizontal />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end'>
+              {/* Clears `part_product` only — the part is never deleted. */}
+              <DropdownMenuItem onClick={onDetach}>
+                <Unlink />
+                Remove from product
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </TableCell>
     </TableRow>
   )
+}
+
+/**
+ * The Price cell's three answers: a price, "n items" when the part carries
+ * price tiers, and a dash for everything else — including while hop 2 is still
+ * in flight, which must never render as a zero.
+ */
+function VariantPriceCell({
+  priceCents,
+  catalogItemCount,
+  priceLoaded,
+}: Pick<VariantRowValues, 'priceCents' | 'catalogItemCount' | 'priceLoaded'>) {
+  if (catalogItemCount > 1) {
+    return (
+      <span className='text-xs text-muted-foreground'>
+        {catalogItemCount} {pluralize(catalogItemCount, 'item')}
+      </span>
+    )
+  }
+  if (!priceLoaded || priceCents == null) return <span className='text-muted-foreground'>—</span>
+  return <>{formatCurrency(priceCents)}</>
 }

--- a/apps/web/src/components/drawers/tabs/product-variant-link-dialog.tsx
+++ b/apps/web/src/components/drawers/tabs/product-variant-link-dialog.tsx
@@ -1,0 +1,216 @@
+// apps/web/src/components/drawers/tabs/product-variant-link-dialog.tsx
+'use client'
+
+import { FieldType } from '@auxx/database/enums'
+import { getInstanceId, isRecordId, type RecordId, toRecordId } from '@auxx/lib/resources/client'
+import type { RelationshipConfig } from '@auxx/types/custom-field'
+import { toResourceFieldId } from '@auxx/types/field'
+import { Button } from '@auxx/ui/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@auxx/ui/components/dialog'
+import { Kbd, KbdSubmit } from '@auxx/ui/components/kbd'
+import { toastError } from '@auxx/ui/components/toast'
+import { TriangleAlert } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { FieldInputAdapter } from '~/components/fields/inputs/field-input-adapter'
+import { FieldPanel, FieldPanelRow } from '~/components/global/forms/field-panel'
+import { useResourceProperty } from '~/components/resources'
+import { useSaveFieldValue } from '~/components/resources/hooks/use-save-field-value'
+import { useSystemValues } from '~/components/resources/hooks/use-system-values'
+import { BaseType } from '~/components/workflow/types'
+
+/** Synthetic relationship config for the ad-hoc part picker (not a real field). */
+const PART_RELATIONSHIP: RelationshipConfig = {
+  inverseResourceFieldId: toResourceFieldId('part', 'id'),
+  relationshipType: 'belongs_to',
+  isInverse: false,
+}
+
+/** The candidate's own family, read to decide whether this is an add or a move. */
+const CANDIDATE_ATTRIBUTES = ['part_product'] as const
+/** ...and the family's name, once the relation resolves. */
+const PRODUCT_ATTRIBUTES = ['product_title'] as const
+
+/** Unwrap a RELATIONSHIP value into the related instance id. */
+function relatedInstanceId(raw: unknown): string | undefined {
+  const first = Array.isArray(raw) ? raw[0] : raw
+  if (typeof first !== 'string') return undefined
+  return isRecordId(first) ? getInstanceId(first) : first
+}
+
+interface ProductVariantLinkDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** The family being linked INTO. */
+  productId: string
+  /** Parts already on this family — excluded so the picker cannot be a no-op. */
+  excludeRecordIds: RecordId[]
+  /** Called after a successful link. */
+  onSuccess?: () => void
+}
+
+/**
+ * Link an EXISTING part into a product family
+ * (plans/products/09-variant-ui.md §3.3).
+ *
+ * A create-only "Add variant" would be the wrong tool for the common case: any
+ * org reaching this screen already has parts carrying BOMs, costs and supplier
+ * offers, and creating fresh ones to group them would leave four duplicates and
+ * four orphaned BOMs.
+ *
+ * ⚠️ `part.product` is **belongs_to**, so linking a part that already has a
+ * family MOVES it — silently, if nothing says so. The dialog reads the
+ * candidate's current family and, when it has one, names it and changes the
+ * confirm verb to "Move". This is the whole reason the picker is a dialog and
+ * not an inline combobox.
+ *
+ * The write is a plain relation save on the PART, through the same
+ * `useSaveFieldValue` path the Details panel uses — never a create.
+ */
+export function ProductVariantLinkDialog({
+  open,
+  onOpenChange,
+  productId,
+  excludeRecordIds,
+  onSuccess,
+}: ProductVariantLinkDialogProps) {
+  const partDefId = useResourceProperty('part', 'id')
+  const productDefId = useResourceProperty('product', 'id')
+
+  const [selectedPartId, setSelectedPartId] = useState('')
+
+  useEffect(() => {
+    if (open) setSelectedPartId('')
+  }, [open])
+
+  const selectedRecordId =
+    selectedPartId && partDefId ? toRecordId(partDefId, selectedPartId) : undefined
+
+  // The candidate's CURRENT family — the add-vs-move discriminator.
+  const { values: candidateValues } = useSystemValues(selectedRecordId, CANDIDATE_ATTRIBUTES, {
+    autoFetch: true,
+    enabled: !!selectedRecordId,
+  })
+  const currentProductId = relatedInstanceId(candidateValues.part_product)
+  // A part already on THIS family is excluded from the picker, so any current
+  // family here is a different one.
+  const isMove = !!currentProductId && currentProductId !== productId
+
+  const currentProductRecordId =
+    productDefId && currentProductId ? toRecordId(productDefId, currentProductId) : undefined
+  const { values: currentProductValues } = useSystemValues(
+    currentProductRecordId,
+    PRODUCT_ATTRIBUTES,
+    { autoFetch: true, enabled: !!currentProductRecordId }
+  )
+  const currentProductTitle = currentProductValues.product_title as string | undefined
+
+  const { saveMultipleAsync, isPending } = useSaveFieldValue({})
+
+  const handleSubmit = async () => {
+    if (!selectedRecordId || !productDefId) return
+    const success = await saveMultipleAsync(selectedRecordId, [
+      {
+        fieldId: 'part_product',
+        value: toRecordId(productDefId, productId),
+        fieldType: FieldType.RELATIONSHIP,
+      },
+    ])
+    if (!success) {
+      toastError({
+        title: isMove ? 'Error moving part' : 'Error linking part',
+        description: 'The part could not be linked to this product.',
+      })
+      return
+    }
+    onSuccess?.()
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='sm:max-w-[500px]' position='tc'>
+        <DialogHeader>
+          <DialogTitle>Link Existing Part</DialogTitle>
+          <DialogDescription>
+            Add a part you already have to this product family as a variant
+          </DialogDescription>
+        </DialogHeader>
+
+        <FieldPanel
+          className='p-0'
+          orientation='responsive'
+          breakpoint='md'
+          resizeId='variant-link'
+          defaultLabelWidth={140}>
+          <FieldPanelRow
+            title='Part'
+            description='Parts already in this family are hidden'
+            type={BaseType.RELATION}
+            showIcon
+            isRequired>
+            <FieldInputAdapter
+              fieldType={FieldType.RELATIONSHIP}
+              value={selectedRecordId ? [selectedRecordId] : []}
+              onChange={(value) => {
+                const recordIds = value as RecordId[]
+                const first = recordIds[0]
+                setSelectedPartId(first ? getInstanceId(first) : '')
+              }}
+              triggerProps={{ className: 'ps-0 pe-1 w-full' }}
+              placeholder='Select a part...'
+              disabled={isPending}
+              fieldOptions={{
+                relationship: PART_RELATIONSHIP,
+                excludeIds: excludeRecordIds,
+                showDefinitionIcon: true,
+              }}
+            />
+          </FieldPanelRow>
+        </FieldPanel>
+
+        {isMove && (
+          <div className='flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2.5'>
+            <TriangleAlert className='mt-0.5 size-4 shrink-0 text-amber-600' />
+            <p className='text-xs text-muted-foreground'>
+              <span className='font-medium text-foreground'>Already in a family.</span> This part is
+              currently a variant of{' '}
+              <span className='font-medium text-foreground'>
+                {currentProductTitle ?? 'another product'}
+              </span>
+              . A part belongs to one product, so linking it here moves it.
+            </p>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            type='button'
+            variant='ghost'
+            size='sm'
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}>
+            Cancel <Kbd shortcut='esc' variant='ghost' size='sm' />
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            variant='outline'
+            size='sm'
+            loading={isPending}
+            loadingText={isMove ? 'Moving...' : 'Linking...'}
+            disabled={!selectedPartId || !productDefId}
+            data-dialog-submit>
+            {isMove ? 'Move to This Product' : 'Link Part'}{' '}
+            <KbdSubmit variant='outline' size='sm' />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/drawers/tabs/summarize-variants.test.ts
+++ b/apps/web/src/components/drawers/tabs/summarize-variants.test.ts
@@ -1,0 +1,129 @@
+// apps/web/src/components/drawers/tabs/summarize-variants.test.ts
+//
+// The Variants tab's summary line (plans/products/09-variant-ui.md §4.3, §9).
+// Every case here is a way the line could print a number that is not true:
+// a never-counted family reading as zero stock, a price range built from
+// inactive catalog items, `$199–$199`, or a page total presented as a family
+// total.
+
+import { describe, expect, it } from 'vitest'
+import { buildVariantSummaryLabel, summarizeVariants, type VariantRow } from './summarize-variants'
+
+/** Minor units in, plain dollars out — enough to assert against. */
+const money = (minorUnits: number) => `$${(minorUnits / 100).toFixed(2)}`
+
+const row = (overrides: Partial<VariantRow> = {}): VariantRow => ({
+  id: 'part-1',
+  quantityOnHand: 0,
+  priceCents: null,
+  catalogItemCount: 0,
+  ...overrides,
+})
+
+describe('summarizeVariants', () => {
+  it('returns an empty summary for no rows', () => {
+    const summary = summarizeVariants([])
+    expect(summary).toEqual({
+      variantCount: 0,
+      measuredCount: 0,
+      totalOnHand: null,
+      priceRange: null,
+      pricedCount: 0,
+      isPartial: false,
+    })
+  })
+
+  it('sums only the rows that HAVE an on-hand value', () => {
+    const summary = summarizeVariants([
+      row({ id: 'a', quantityOnHand: 12 }),
+      row({ id: 'b', quantityOnHand: null }),
+      row({ id: 'c', quantityOnHand: 25 }),
+    ])
+    expect(summary.totalOnHand).toBe(37)
+  })
+
+  it('omits the on-hand clause when NO row has a value — never reports 0', () => {
+    const summary = summarizeVariants([
+      row({ id: 'a', quantityOnHand: null }),
+      row({ id: 'b', quantityOnHand: null }),
+    ])
+    expect(summary.totalOnHand).toBeNull()
+    expect(buildVariantSummaryLabel(summary, money)).toBe('2 variants')
+  })
+
+  it('keeps a genuine zero distinct from an absent value', () => {
+    const summary = summarizeVariants([row({ id: 'a', quantityOnHand: 0 })])
+    expect(summary.totalOnHand).toBe(0)
+    expect(buildVariantSummaryLabel(summary, money)).toBe('1 variant · 0 on hand')
+  })
+
+  it('spans the price range over priced variants only', () => {
+    // `priceCents: null` is how the tab reports "no catalog item", "inactive",
+    // and "more than one item" alike — none may reach the range.
+    const summary = summarizeVariants([
+      row({ id: 'a', priceCents: 19900, catalogItemCount: 1 }),
+      row({ id: 'b', priceCents: null, catalogItemCount: 0 }),
+      row({ id: 'c', priceCents: null, catalogItemCount: 2 }),
+      row({ id: 'd', priceCents: 34900, catalogItemCount: 1 }),
+    ])
+    expect(summary.priceRange).toEqual({ min: 19900, max: 34900 })
+    expect(summary.pricedCount).toBe(2)
+  })
+
+  it('reports no range when nothing is priced', () => {
+    const summary = summarizeVariants([row({ id: 'a' }), row({ id: 'b' })])
+    expect(summary.priceRange).toBeNull()
+    expect(summary.pricedCount).toBe(0)
+  })
+
+  it('counts the FAMILY when a total is supplied, not the loaded page', () => {
+    const summary = summarizeVariants([row({ id: 'a' })], { total: 128, hasNextPage: true })
+    expect(summary.variantCount).toBe(128)
+    expect(summary.measuredCount).toBe(1)
+    expect(summary.isPartial).toBe(true)
+  })
+
+  it('falls back to the row count when no total is in scope', () => {
+    const summary = summarizeVariants([row({ id: 'a' }), row({ id: 'b' })])
+    expect(summary.variantCount).toBe(2)
+    expect(summary.isPartial).toBe(false)
+  })
+})
+
+describe('buildVariantSummaryLabel', () => {
+  it('renders the full line', () => {
+    const summary = summarizeVariants([
+      row({ id: 'a', quantityOnHand: 12, priceCents: 19900, catalogItemCount: 1 }),
+      row({ id: 'b', quantityOnHand: 25, priceCents: 34900, catalogItemCount: 1 }),
+    ])
+    expect(buildVariantSummaryLabel(summary, money)).toBe(
+      '2 variants · 37 on hand · $199.00–$349.00'
+    )
+  })
+
+  it('renders a single distinct price as one figure, not a degenerate range', () => {
+    const summary = summarizeVariants([
+      row({ id: 'a', priceCents: 19900, catalogItemCount: 1 }),
+      row({ id: 'b', priceCents: 19900, catalogItemCount: 1 }),
+    ])
+    expect(buildVariantSummaryLabel(summary, money)).toBe('2 variants · 0 on hand · $199.00')
+  })
+
+  it('pluralizes the count', () => {
+    const one = summarizeVariants([row({ id: 'a', quantityOnHand: null })])
+    expect(buildVariantSummaryLabel(one, money)).toBe('1 variant')
+  })
+
+  it('says the aggregates describe a page when more rows exist', () => {
+    const summary = summarizeVariants(
+      [
+        row({ id: 'a', quantityOnHand: 12, priceCents: 19900, catalogItemCount: 1 }),
+        row({ id: 'b', quantityOnHand: 25, priceCents: 34900, catalogItemCount: 1 }),
+      ],
+      { total: 128, hasNextPage: true }
+    )
+    expect(buildVariantSummaryLabel(summary, money)).toBe(
+      '128 variants · 37 on hand · $199.00–$349.00 (first 2)'
+    )
+  })
+})

--- a/apps/web/src/components/drawers/tabs/summarize-variants.ts
+++ b/apps/web/src/components/drawers/tabs/summarize-variants.ts
@@ -1,0 +1,122 @@
+// apps/web/src/components/drawers/tabs/summarize-variants.ts
+
+/**
+ * Aggregates for the product Variants tab's summary line
+ * (plans/products/09-variant-ui.md §4.3).
+ *
+ * Pure on purpose: every clause here is a way to print a wrong number, and
+ * each one is cheaper to pin down in a test than in a browser. The module owns
+ * no reads — the tab resolves each row first (including which catalog item, if
+ * any, supplies a price) and hands the result in.
+ */
+
+import { pluralize } from '@auxx/utils'
+
+/** One variant row, already resolved by the tab. */
+export interface VariantRow {
+  /** EntityInstance id of the part. */
+  id: string
+  /** `part_quantity_on_hand`. `null` means no value, NOT zero. */
+  quantityOnHand: number | null
+  /**
+   * Sell price in minor units, or `null` when this variant has none.
+   *
+   * `null` covers three different situations deliberately — no catalog item,
+   * an inactive one, or more than one (price tiers, where picking one
+   * arbitrarily would be a lie; §4.2 renders "n items" for that row instead).
+   * None of them belong in a price range.
+   */
+  priceCents: number | null
+  /** How many catalog items back this part — drives the row's "n items" case. */
+  catalogItemCount: number
+}
+
+/** What {@link summarizeVariants} answers. */
+export interface VariantSummary {
+  /** The FAMILY size (`useRecordList().total`), not the loaded page length. */
+  variantCount: number
+  /** How many rows the aggregates below were actually computed from. */
+  measuredCount: number
+  /** Sum over rows that HAVE a value. `null` when none did — never `0`. */
+  totalOnHand: number | null
+  /** Spans only variants with a single active catalog item. `null` when none. */
+  priceRange: { min: number; max: number } | null
+  /** Variants carrying a usable price — the "3 of 4 priced" numerator. */
+  pricedCount: number
+  /** The aggregates describe a page, not the whole family. */
+  isPartial: boolean
+}
+
+interface SummarizeVariantsOptions {
+  /** `useRecordList().total` — the family size, which may exceed `rows.length`. */
+  total?: number
+  /** `useRecordList().hasNextPage` — rows exist beyond those loaded. */
+  hasNextPage?: boolean
+}
+
+/**
+ * Fold the loaded variant rows into the summary line's numbers.
+ *
+ * `total` defaults to the row count so a caller with no pagination in scope
+ * (the product summary card) gets the obvious answer.
+ */
+export function summarizeVariants(
+  rows: VariantRow[],
+  options: SummarizeVariantsOptions = {}
+): VariantSummary {
+  const { total, hasNextPage = false } = options
+
+  // An absent quantity is not a zero. Summing `?? 0` would report a family
+  // whose stock has never been counted as holding none of itself.
+  const onHandValues = rows
+    .map((row) => row.quantityOnHand)
+    .filter((value): value is number => value != null)
+  const totalOnHand = onHandValues.length
+    ? onHandValues.reduce((sum, value) => sum + value, 0)
+    : null
+
+  const prices = rows.map((row) => row.priceCents).filter((value): value is number => value != null)
+  const priceRange = prices.length ? { min: Math.min(...prices), max: Math.max(...prices) } : null
+
+  return {
+    variantCount: total ?? rows.length,
+    measuredCount: rows.length,
+    totalOnHand,
+    priceRange,
+    pricedCount: prices.length,
+    isPartial: hasNextPage,
+  }
+}
+
+/**
+ * Render the summary as one line: `4 variants · 37 on hand · $199–$349`.
+ *
+ * `formatMoney` is injected rather than imported so this stays pure and the
+ * currency layer stays the caller's concern — values are minor units, which is
+ * what `formatCurrency` already expects everywhere else in this tab.
+ *
+ * A clause with nothing behind it is omitted rather than rendered as a zero or
+ * a dash, and a partial page says so instead of implying a total it does not
+ * have.
+ */
+export function buildVariantSummaryLabel(
+  summary: VariantSummary,
+  formatMoney: (minorUnits: number) => string
+): string {
+  const clauses: string[] = [
+    `${summary.variantCount} ${pluralize(summary.variantCount, 'variant')}`,
+  ]
+
+  if (summary.totalOnHand != null) clauses.push(`${summary.totalOnHand} on hand`)
+
+  if (summary.priceRange) {
+    const { min, max } = summary.priceRange
+    // One distinct price is one figure. `$199–$199` reads as a bug.
+    clauses.push(min === max ? formatMoney(min) : `${formatMoney(min)}–${formatMoney(max)}`)
+  }
+
+  const line = clauses.join(' · ')
+  // The aggregates came from the loaded page. Saying so is the difference
+  // between a summary and a wrong number.
+  return summary.isPartial ? `${line} (first ${summary.measuredCount})` : line
+}

--- a/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
+++ b/apps/web/src/components/manufacturing/parts/part-form-dialog.tsx
@@ -2,7 +2,15 @@
 'use client'
 
 import { FieldType } from '@auxx/database/enums'
-import { parseRecordId, type RecordId, toRecordId } from '@auxx/lib/resources/client'
+import {
+  getInstanceId,
+  PartKind,
+  parseRecordId,
+  type RecordId,
+  toRecordId,
+} from '@auxx/lib/resources/client'
+import type { RelationshipConfig } from '@auxx/types/custom-field'
+import { toResourceFieldId } from '@auxx/types/field'
 import { Button } from '@auxx/ui/components/button'
 import {
   Dialog,
@@ -39,6 +47,16 @@ const PART_SYSTEM_ATTRIBUTES = [
   'hs_code',
 ] as const
 
+/**
+ * Synthetic relationship config for the ad-hoc Product picker (not backed by a
+ * real field on this form) — the `subpart-dialog` pattern.
+ */
+const PRODUCT_RELATIONSHIP: RelationshipConfig = {
+  inverseResourceFieldId: toResourceFieldId('product', 'id'),
+  relationshipType: 'belongs_to',
+  isInverse: false,
+}
+
 /** Props for PartFormDialog component */
 interface PartFormDialogProps {
   /** Whether the dialog is open */
@@ -49,14 +67,29 @@ interface PartFormDialogProps {
   recordId?: RecordId
   /** Callback on successful save */
   onSuccess?: () => void
+  /**
+   * Product family to create this part into — prefills and LOCKS the Product
+   * row (plans/products/09-variant-ui.md §3.1).
+   *
+   * CREATE mode only. In edit mode the Details panel owns `part.product`, and
+   * two writers for one relation is exactly what D15 rejected for price.
+   */
+  productId?: string
 }
 
 /** Dialog for creating/editing a part */
-export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: PartFormDialogProps) {
+export function PartFormDialog({
+  open,
+  onOpenChange,
+  recordId,
+  onSuccess,
+  productId: lockedProductId,
+}: PartFormDialogProps) {
   const isEditMode = !!recordId
 
   // Resolve entity definition IDs
   const partDefId = useResourceProperty('part', 'id')
+  const productDefId = useResourceProperty('product', 'id')
   const vendorPartDefId = useResourceProperty('vendor_part', 'id')
   const companyDefId = useResourceProperty('company', 'id')
 
@@ -80,6 +113,12 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
     sku: '',
     hsCode: '',
     category: [] as string[],
+    productId: '',
+    // Deliberately never defaulted, not even when created from a product —
+    // Gap C §3.2 requires `part_kind` human-confirmed and auditable, and the
+    // part drawer's Family card is the confirmation surface. A silent default
+    // would defeat the `isPartKindUnset` gate that suggestion is built on.
+    kind: '',
   })
   const [errors, setErrors] = useState<Record<string, string>>({})
   const [showSupplier, setShowSupplier] = useState(false)
@@ -98,6 +137,9 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
           hsCode: (systemValues.hs_code as string) ?? '',
           // TAGS reads back as an array of option ids
           category: Array.isArray(systemValues.category) ? (systemValues.category as string[]) : [],
+          // Edit mode ignores the prop: the Details panel owns this relation.
+          productId: '',
+          kind: '',
         })
       } else if (!isEditMode) {
         setValues({
@@ -106,6 +148,8 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
           sku: '',
           hsCode: '',
           category: [],
+          productId: lockedProductId ?? '',
+          kind: '',
         })
       }
       setErrors({})
@@ -113,7 +157,7 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
       setVendorPartValues(defaultVendorPartValues)
       setVendorPartErrors({})
     }
-  }, [open, isEditMode, systemValues])
+  }, [open, isEditMode, systemValues, lockedProductId])
 
   // Field change handler
   const handleChange = useCallback((field: string, value: any) => {
@@ -192,6 +236,11 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
             part_description: values.description || undefined,
             category: values.category.length ? values.category : undefined,
             hs_code: values.hsCode || undefined,
+            part_product:
+              values.productId && productDefId
+                ? toRecordId(productDefId, values.productId)
+                : undefined,
+            part_kind: values.kind || undefined,
           },
         })
 
@@ -296,6 +345,56 @@ export function PartFormDialog({ open, onOpenChange, recordId, onSuccess }: Part
               disabled={isPending}
             />
           </FieldPanelRow>
+
+          {/* Product family — locked when the dialog was opened from a product.
+              Create mode only: in edit mode the Details panel owns the relation. */}
+          {!isEditMode && (
+            <FieldPanelRow
+              title='Product'
+              description='Optional product family this part is a variant of'
+              type={BaseType.RELATION}
+              showIcon>
+              <FieldInputAdapter
+                fieldType={FieldType.RELATIONSHIP}
+                value={
+                  values.productId && productDefId
+                    ? [toRecordId(productDefId, values.productId)]
+                    : []
+                }
+                onChange={(value) => {
+                  const recordIds = value as RecordId[]
+                  const first = recordIds[0]
+                  handleChange('productId', first ? getInstanceId(first) : '')
+                }}
+                triggerProps={{ className: 'ps-0 pe-1 w-full' }}
+                placeholder='Select a product...'
+                disabled={isPending || !!lockedProductId}
+                fieldOptions={{
+                  relationship: PRODUCT_RELATIONSHIP,
+                  showDefinitionIcon: true,
+                }}
+              />
+            </FieldPanelRow>
+          )}
+
+          {/* Kind — the GL classification. No default, ever (see state above). */}
+          {!isEditMode && (
+            <FieldPanelRow
+              title='Kind'
+              description='Which inventory account this part belongs to'
+              type={BaseType.ENUM}
+              showIcon>
+              <FieldInputAdapter
+                fieldType={FieldType.SINGLE_SELECT}
+                fieldOptions={{ options: PartKind.values }}
+                triggerProps={{ className: 'ps-0 pe-1 w-full' }}
+                value={values.kind}
+                onChange={(val) => handleChange('kind', (Array.isArray(val) ? val[0] : val) ?? '')}
+                placeholder='Select a kind...'
+                disabled={isPending}
+              />
+            </FieldPanelRow>
+          )}
 
           {/* HS Code */}
           <FieldPanelRow

--- a/apps/web/src/components/records/record-editor-dialog.test.ts
+++ b/apps/web/src/components/records/record-editor-dialog.test.ts
@@ -1,0 +1,54 @@
+// apps/web/src/components/records/record-editor-dialog.test.ts
+//
+// `presetValues` on RecordEditorDialog is keyed by FIELD ID — the shape
+// EntityInstanceForm applies (`initValues[fieldId] = value`). The part editor
+// used to drop the map entirely; `presetInstanceId` is the translation that
+// stopped it, isolated so it can be tested without a resource store
+// (plans/products/09-variant-ui.md §2 V2, §9).
+
+import { describe, expect, it } from 'vitest'
+import { presetInstanceId } from './record-editor-dialog'
+
+const PRODUCT_FIELD_ID = 'product'
+const PRODUCT_DEF_ID = 'def_product_123'
+const PRODUCT_INSTANCE_ID = 'inst_abc'
+const PRODUCT_RECORD_ID = `${PRODUCT_DEF_ID}:${PRODUCT_INSTANCE_ID}`
+
+describe('presetInstanceId', () => {
+  it('unwraps an array-shaped RecordId preset to the bare instance id', () => {
+    expect(presetInstanceId({ [PRODUCT_FIELD_ID]: [PRODUCT_RECORD_ID] }, PRODUCT_FIELD_ID)).toBe(
+      PRODUCT_INSTANCE_ID
+    )
+  })
+
+  it('unwraps a scalar RecordId preset — RELATIONSHIP reads are array-shaped on only some paths', () => {
+    expect(presetInstanceId({ [PRODUCT_FIELD_ID]: PRODUCT_RECORD_ID }, PRODUCT_FIELD_ID)).toBe(
+      PRODUCT_INSTANCE_ID
+    )
+  })
+
+  it('passes through a bare instance id that is not RecordId-shaped', () => {
+    expect(presetInstanceId({ [PRODUCT_FIELD_ID]: PRODUCT_INSTANCE_ID }, PRODUCT_FIELD_ID)).toBe(
+      PRODUCT_INSTANCE_ID
+    )
+  })
+
+  it('ignores an unknown key rather than crashing — other presets are not this editor s business', () => {
+    expect(presetInstanceId({ somethingElse: PRODUCT_RECORD_ID }, PRODUCT_FIELD_ID)).toBeUndefined()
+  })
+
+  it('returns undefined when the field id has not resolved yet', () => {
+    expect(presetInstanceId({ [PRODUCT_FIELD_ID]: PRODUCT_RECORD_ID }, undefined)).toBeUndefined()
+  })
+
+  it('returns undefined for no presets at all', () => {
+    expect(presetInstanceId(undefined, PRODUCT_FIELD_ID)).toBeUndefined()
+  })
+
+  it('treats empty, empty-array and non-string values as absent', () => {
+    expect(presetInstanceId({ [PRODUCT_FIELD_ID]: '' }, PRODUCT_FIELD_ID)).toBeUndefined()
+    expect(presetInstanceId({ [PRODUCT_FIELD_ID]: [] }, PRODUCT_FIELD_ID)).toBeUndefined()
+    expect(presetInstanceId({ [PRODUCT_FIELD_ID]: null }, PRODUCT_FIELD_ID)).toBeUndefined()
+    expect(presetInstanceId({ [PRODUCT_FIELD_ID]: 42 }, PRODUCT_FIELD_ID)).toBeUndefined()
+  })
+})

--- a/apps/web/src/components/records/record-editor-dialog.tsx
+++ b/apps/web/src/components/records/record-editor-dialog.tsx
@@ -1,10 +1,11 @@
 // apps/web/src/components/records/record-editor-dialog.tsx
 'use client'
 
-import type { RecordId } from '@auxx/lib/resources/client'
+import { getInstanceId, isRecordId, type RecordId } from '@auxx/lib/resources/client'
 import { EntityInstanceDialog } from '~/components/custom-fields/ui/entity-instance-dialog'
 import { WorkOrderEditorDialog } from '~/components/dispatch/ui/work-order-editor'
 import { PartFormDialog } from '~/components/manufacturing/parts/part-form-dialog'
+import { useSystemField } from '~/components/resources/hooks/use-field'
 import { useResource } from '~/components/resources/hooks/use-resource'
 
 /**
@@ -20,7 +21,12 @@ export interface RecordEditorDialogProps {
   recordId?: RecordId
   /** Called after a successful save. */
   onSaved?: (instanceId?: string) => void
-  /** Preset field values for CREATE mode. Custom editors may ignore this. */
+  /**
+   * Preset field values for CREATE mode, **keyed by field id** — the shape
+   * `EntityInstanceForm` applies (`initValues[fieldId] = value`, keys compared
+   * against `editableFields[].id`), not by systemAttribute. Custom editors
+   * translate the keys they understand and ignore the rest.
+   */
   presetValues?: Record<string, unknown>
 }
 
@@ -40,13 +46,56 @@ function WorkOrderEditorAdapter(props: RecordEditorDialogProps) {
   return <WorkOrderEditorDialog {...props} />
 }
 
-/** Adapts {@link PartFormDialog} (uses `onSuccess`, no def id / presets) to the shared shape. */
-function PartEditorAdapter({ open, onOpenChange, recordId, onSaved }: RecordEditorDialogProps) {
+/**
+ * Read one RELATIONSHIP preset out of the field-id-keyed preset map and unwrap
+ * it to a bare EntityInstance id.
+ *
+ * Pure so the translation is testable without a resource store: the only thing
+ * the component contributes is resolving `fieldId`. Handles both stored shapes
+ * — a RELATIONSHIP value arrives as `RecordId[]` on most read paths and as a
+ * scalar on others, and either half may be a bare instance id rather than a
+ * `RecordId`.
+ */
+export function presetInstanceId(
+  presetValues: Record<string, unknown> | undefined,
+  fieldId: string | undefined
+): string | undefined {
+  if (!presetValues || !fieldId) return undefined
+  const raw = presetValues[fieldId]
+  const first = Array.isArray(raw) ? raw[0] : raw
+  if (typeof first !== 'string' || first === '') return undefined
+  return isRecordId(first) ? getInstanceId(first) : first
+}
+
+/**
+ * Adapts {@link PartFormDialog} (which uses `onSuccess` and an explicit
+ * `productId`) to the shared shape.
+ *
+ * `presetValues` used to be dropped here, which made the generic contract lie:
+ * a caller passed presets, `RecordEditorDialog` accepted them, and for `part`
+ * alone they vanished with no error. The map is keyed by FIELD ID, so the
+ * part's `product` field id is resolved first and used to read it — forward
+ * resolution only, no inverse map. Only `part_product` is translated today;
+ * that is the one preset a caller has a reason to pass (creating a variant into
+ * a family), and an unknown key is ignored rather than crashing.
+ */
+function PartEditorAdapter({
+  open,
+  onOpenChange,
+  entityDefinitionId,
+  recordId,
+  onSaved,
+  presetValues,
+}: RecordEditorDialogProps) {
+  const productField = useSystemField('part_product', entityDefinitionId)
+  const productId = presetInstanceId(presetValues, productField?.id)
+
   return (
     <PartFormDialog
       open={open}
       onOpenChange={onOpenChange}
       recordId={recordId}
+      productId={productId}
       onSuccess={() => onSaved?.()}
     />
   )

--- a/packages/lib/src/resources/registry/drawer-config.ts
+++ b/packages/lib/src/resources/registry/drawer-config.ts
@@ -89,6 +89,22 @@ export const DRAWER_CONFIG_REGISTRY: DrawerConfigRegistry = {
     additionalTabs: [
       { value: 'parts', label: 'Variants', icon: 'package', recordResource: 'part' },
     ],
+    // Overview blocks (plans/products/09-variant-ui.md §7). Both render nothing
+    // when they have nothing — an empty family, or no linked vendor — which
+    // hides their whole section.
+    tabCards: {
+      overview: [
+        // Variant count, stock, price range and how many variants carry a sell
+        // price. Reads `part`, so it is gated on that definition.
+        { value: 'summary', label: 'Family', icon: 'package', recordResource: 'part' },
+        // `product.vendor` → `company` click-through (D9 — a supplier is
+        // already a company, never a free-text brand string). No
+        // `recordResource`: this is the product's OWN relationship value, not a
+        // list of another definition's records, and the server already redacts
+        // an unreadable target — the same call `ticket:customer` makes.
+        { value: 'vendor', label: 'Vendor', icon: 'store' },
+      ],
+    },
   },
 
   service_request: {


### PR DESCRIPTION
Plan: `plans/products/09-variant-ui.md`. Closes the read-only gaps left by [01](https://github.com/Auxx-Ai/auxx-ai/pull/1840) phases 2+3.

## The problem

The product family shipped read-only, and said so in its own doc comment:

> `product-parts-tab.tsx` — *"Read-only by design: a part joins a family from its own Details panel; this list has no create/detach affordance in v1."*

There was also no route in from the **other** side: `part-family-card.tsx` returned `null` for a part with no family. So a user had to already know products existed and go find the Product field in the Details panel.

Three layers were actually in the way, not one:

1. The tab had no create/detach affordance.
2. `RecordEditorDialog` supports `presetValues` — and `part` was **the one entity that threw them away** (`PartEditorAdapter`: *"uses `onSuccess`, no def id / presets"*). Passing presets for a part silently did nothing.
3. `PartFormDialog` had no `product` field to prefill into.

## Writes

- **New variant** / **Link existing part** in the tab header, gated on WRITE of `part` (the tab itself is gated on READ via `recordResource`).
- ⚠️ **Linking a part that already has a family is a MOVE**, because `part.product` is `belongs_to`. The dialog names the current family and switches the button to "Move to This Product" rather than reparenting silently.
- **Remove from product** clears `part_product`. It never deletes the part — it stays re-linkable from the same header.
- `PartFormDialog` gains `productId` (create-mode only, locked when supplied), and `PartEditorAdapter` stops discarding presets.

Link-existing is the item most likely to look optional and isn't: every org reaching this screen already has parts with BOMs and costs, so create-only would mean grouping four existing lifts under one family produces four duplicate parts and four orphaned BOMs.

## Reads

Two batched **all-direct** hops replace the per-row subscription, plus a summary line (`4 variants · 37 on hand · $199–$349`) and Price / Kind / thumbnail columns.

Two decisions worth stating, both load-bearing:

**No drill path.** `['part:catalogItems','catalog_item:defaultUnitPrice']` would fetch the price in one round trip. It is slower. `batchGetValues` computes `allDirect = fieldReferences.every(ref => !isFieldPath(ref))`; all-direct takes one query for every ref × every record, while **a single path ref flips the whole batch** to `for (const ref of ...) await resolveFieldReference(...)`. The penalty lands on the *direct* refs. Two all-direct hops = 2 fast queries; one hop with a drill = ~6 sequential ones. The two hops are serial and Price paints after Cost — accepted, and it renders `—` in that window, never `0`.

**No filtered `catalog_item` list either.** The condition lane fails **open**: an uncompilable condition is dropped, not rejected (`useRecordList` reports it out-of-band via `droppedConditions` — *"Non-empty means this list is WIDER than the filters say it is"*). A dropped `in` on a RELATIONSHIP would return every catalog item in the org and the Price column would show another product's price.

**Title, SKU and image are no longer fetched at all** — they already arrive with the list as `displayName` / `secondaryInfo` / `avatarUrl` (`DISPLAY_FIELD_CONFIG.part` maps exactly those three). Hop 1 went from 7 attributes to 4.

## Fixes found in the same files

- `Variants (n)` counted the **page**, not the family — `useRecordList` caps at 50 and a Shopify family can exceed it. Now uses `total`, with "Load more".
- Two hardcoded `/app/parts?id=` links now resolve through `useRecordLink`. `part-family-card.tsx` was doing it both ways in one file.
- The sibling list rendered unbounded; capped at 5 + "Show all N".

## Also

A part already classified `finished_good` with no family now gets a one-row nudge with a product picker — the exact inverse of the existing finished-good suggestion, and mutually exclusive with it by construction (one requires `part_kind` unset, the other requires it explicitly set). Plus two product overview cards (`product:summary`, `product:vendor`).

`part_kind` is **never defaulted**, including on a variant created from a product — Gap C requires it human-confirmed and auditable, which is what the existing chip is for.

## Deliberately out of scope

- **Option axis** (D7) and **variant-aware `CatalogPicker`** (D6) — both locked decisions whose reasons still hold.
- **No connector-ownership guard on detach.** Once the Shopify product stream contributes ([02](../blob/main/plans/products/02-shopify-mapping.md)), the sink writes `part_product` too and detaching a connector-written part would be undone by the next sync. No guard is built because there is no such writer yet and one designed against a hypothetical writer will be wrong. The seam is documented in the file; 02 owns closing it alongside the disconnect/undo questions it already has open.

## Verification

- `vitest run src/components/drawers src/components/records` → **113 passed / 12 files**, 33 new (`summarize-variants`, `shouldSuggestFamily` incl. a mutual-exclusivity property test, the preset translation).
- `typecheck-ratchet --package web` → clean **on top of #1912**. On its own this branch inherits `main`'s pre-existing `allowNewOptions` error; #1912 fixes that independently and is not stacked under this.